### PR TITLE
sql, opt: avoid full scans in mutation queries

### DIFF
--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -1071,6 +1071,7 @@ unreserved_keyword ::=
 	| 'ATTRIBUTE'
 	| 'AUTOMATIC'
 	| 'AVAILABILITY'
+	| 'AVOID_FULL_SCAN'
 	| 'BACKUP'
 	| 'BACKUPS'
 	| 'BACKWARD'
@@ -3751,6 +3752,7 @@ bare_label_keywords ::=
 	| 'AUTHORIZATION'
 	| 'AUTOMATIC'
 	| 'AVAILABILITY'
+	| 'AVOID_FULL_SCAN'
 	| 'BACKUP'
 	| 'BACKUPS'
 	| 'BACKWARD'
@@ -4343,6 +4345,7 @@ index_flags_param ::=
 	| 'NO_INDEX_JOIN'
 	| 'NO_ZIGZAG_JOIN'
 	| 'NO_FULL_SCAN'
+	| 'AVOID_FULL_SCAN'
 	| 'FORCE_ZIGZAG'
 	| 'FORCE_ZIGZAG' '=' index_name
 

--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_remote_access_error
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_remote_access_error
@@ -502,7 +502,7 @@ DELETE FROM messages_rbr WHERE account_id NOT IN (SELECT account_id FROM message
 
 # Delete accessing all regions should fail.
 retry
-statement error pq: Query has no home region\. Try adding a filter on messages_rbr\.crdb_region and/or on key column \(messages_rbr\.account_id\)\. For more information, see https://www.cockroachlabs.com/docs/stable/cost-based-optimizer.html#control-whether-queries-are-limited-to-a-single-region
+statement error pq: Query has no home region\. Try adding a filter on messages_rbr\.crdb_region and/or on key column \(messages_rbr\.message\)\. For more information, see https://www.cockroachlabs.com/docs/stable/cost-based-optimizer.html#control-whether-queries-are-limited-to-a-single-region
 DELETE FROM messages_rbr WHERE message = 'Hello World!'
 
 # Insert should fail accessing all rows in messages_rbr.

--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning_implicit_read_committed
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning_implicit_read_committed
@@ -251,12 +251,13 @@ update t
  ├── unique w/tombstone indexes: t_c_key
  └── project
       ├── scan t
-      │    └── constraint: /12/11
-      │         ├── [/'one'/2 - /'one'/2]
-      │         ├── [/'two'/2 - /'two'/2]
-      │         ├── [/'three'/2 - /'three'/2]
-      │         ├── [/'four'/2 - /'four'/2]
-      │         └── [/'five'/2 - /'five'/2]
+      │    ├── constraint: /12/11
+      │    │    ├── [/'one'/2 - /'one'/2]
+      │    │    ├── [/'two'/2 - /'two'/2]
+      │    │    ├── [/'three'/2 - /'three'/2]
+      │    │    ├── [/'four'/2 - /'four'/2]
+      │    │    └── [/'five'/2 - /'five'/2]
+      │    └── flags: avoid-full-scan
       └── projections
            └── 4
 

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_query_behavior
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_query_behavior
@@ -1976,16 +1976,19 @@ SELECT * FROM [EXPLAIN INSERT INTO regional_by_row_table_virt (pk, a, b) VALUES 
 │           ├── • values
 │           │     size: 1 column, 1 row
 │           │
-│           └── • limit
-│               │ count: 1
+│           └── • index join
+│               │ table: regional_by_row_table_virt@regional_by_row_table_virt_pkey
 │               │
-│               └── • filter
-│                   │ filter: ((a + b) = 2) AND ((pk != 1) OR (crdb_region != 'ap-southeast-2'))
+│               └── • limit
+│                   │ count: 1
 │                   │
-│                   └── • scan
-│                         missing stats
-│                         table: regional_by_row_table_virt@regional_by_row_table_virt_pkey
-│                         spans: FULL SCAN (SOFT LIMIT)
+│                   └── • filter
+│                       │ filter: (pk != 1) OR (crdb_region != 'ap-southeast-2')
+│                       │
+│                       └── • scan
+│                             missing stats
+│                             table: regional_by_row_table_virt@regional_by_row_table_virt_v_key
+│                             spans: [/'ap-southeast-2'/2 - /'ap-southeast-2'/2] [/'ca-central-1'/2 - /'ca-central-1'/2] [/'us-east-1'/2 - /'us-east-1'/2]
 │
 └── • constraint-check
     │
@@ -2155,16 +2158,19 @@ SELECT * FROM [EXPLAIN INSERT INTO regional_by_row_table_virt_partial (pk, a, b)
 │           ├── • values
 │           │     size: 1 column, 1 row
 │           │
-│           └── • limit
-│               │ count: 1
+│           └── • index join
+│               │ table: regional_by_row_table_virt_partial@regional_by_row_table_virt_partial_pkey
 │               │
-│               └── • filter
-│                   │ filter: ((a + b) = 2) AND ((pk != 1) OR (crdb_region != 'ap-southeast-2'))
+│               └── • limit
+│                   │ count: 1
 │                   │
-│                   └── • scan
-│                         missing stats
-│                         table: regional_by_row_table_virt_partial@regional_by_row_table_virt_partial_pkey
-│                         spans: FULL SCAN (SOFT LIMIT)
+│                   └── • filter
+│                       │ filter: (pk != 1) OR (crdb_region != 'ap-southeast-2')
+│                       │
+│                       └── • scan
+│                             missing stats
+│                             table: regional_by_row_table_virt_partial@v_v_gt_0 (partial index)
+│                             spans: [/'ap-southeast-2'/2 - /'ap-southeast-2'/2] [/'ca-central-1'/2 - /'ca-central-1'/2] [/'us-east-1'/2 - /'us-east-1'/2]
 │
 └── • constraint-check
     │
@@ -2179,12 +2185,18 @@ SELECT * FROM [EXPLAIN INSERT INTO regional_by_row_table_virt_partial (pk, a, b)
                 │ count: 1
                 │
                 └── • filter
-                    │ filter: ((a = 1) AND (b > -1)) AND ((pk != 1) OR (crdb_region != 'ap-southeast-2'))
+                    │ filter: (a = 1) AND (b > -1)
                     │
-                    └── • scan
-                          missing stats
-                          table: regional_by_row_table_virt_partial@regional_by_row_table_virt_partial_pkey
-                          spans: FULL SCAN (SOFT LIMIT)
+                    └── • index join
+                        │ table: regional_by_row_table_virt_partial@regional_by_row_table_virt_partial_pkey
+                        │
+                        └── • filter
+                            │ filter: (pk != 1) OR (crdb_region != 'ap-southeast-2')
+                            │
+                            └── • scan
+                                  missing stats
+                                  table: regional_by_row_table_virt_partial@v_a_gt_0 (partial index)
+                                  spans: FULL SCAN (SOFT LIMIT)
 
 query T retry
 SELECT * FROM [EXPLAIN UPSERT INTO regional_by_row_table_virt_partial (pk, a, b) VALUES (1, 1, 1)] OFFSET 2

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -3564,6 +3564,10 @@ func (m *sessionDataMutator) SetDisallowFullTableScans(val bool) {
 	m.data.DisallowFullTableScans = val
 }
 
+func (m *sessionDataMutator) SetAvoidFullTableScansInMutations(val bool) {
+	m.data.AvoidFullTableScansInMutations = val
+}
+
 func (m *sessionDataMutator) SetAlterColumnTypeGeneral(val bool) {
 	m.data.AlterColumnTypeGeneralEnabled = val
 }

--- a/pkg/sql/logictest/testdata/logic_test/delete
+++ b/pkg/sql/logictest/testdata/logic_test/delete
@@ -465,7 +465,7 @@ DELETE FROM u_a AS foo USING u_b AS bar WHERE bar.a > foo.c ORDER BY bar.a DESC 
 
 # Test aliased table names, ORDER BY and LIMIT where ORDER BY references the target
 # table.
-query ITI
+query ITI rowsort
 DELETE FROM u_a AS foo USING u_b AS bar WHERE bar.a > foo.c ORDER BY foo.a DESC LIMIT 3 RETURNING foo.*;
 ----
 7  d  35

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -3905,6 +3905,7 @@ always_distribute_full_scans                               off
 application_name                                           ·
 authentication_method                                      cert-password
 avoid_buffering                                            off
+avoid_full_table_scans_in_mutations                        on
 backslash_quote                                            safe_encoding
 bypass_pcr_reader_catalog_aost                             off
 bytea_output                                               hex

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -2904,6 +2904,7 @@ application_name                                           ·                   
 authentication_method                                      cert-password       NULL      NULL        NULL        string
 autocommit_before_ddl                                      off                 NULL      NULL        NULL        string
 avoid_buffering                                            off                 NULL      NULL        NULL        string
+avoid_full_table_scans_in_mutations                        on                  NULL      NULL        NULL        string
 backslash_quote                                            safe_encoding       NULL      NULL        NULL        string
 bypass_pcr_reader_catalog_aost                             off                 NULL      NULL        NULL        string
 bytea_output                                               hex                 NULL      NULL        NULL        string
@@ -3107,6 +3108,7 @@ application_name                                           ·                   
 authentication_method                                      cert-password       NULL  user     NULL      cert-password       cert-password
 autocommit_before_ddl                                      off                 NULL  user     NULL      off                 off
 avoid_buffering                                            off                 NULL  user     NULL      off                 off
+avoid_full_table_scans_in_mutations                        on                  NULL  user     NULL      on                  on
 backslash_quote                                            safe_encoding       NULL  user     NULL      safe_encoding       safe_encoding
 bypass_pcr_reader_catalog_aost                             off                 NULL  user     NULL      off                 off
 bytea_output                                               hex                 NULL  user     NULL      hex                 hex
@@ -3303,6 +3305,7 @@ application_name                                           NULL    NULL     NULL
 authentication_method                                      NULL    NULL     NULL     NULL        NULL
 autocommit_before_ddl                                      NULL    NULL     NULL     NULL        NULL
 avoid_buffering                                            NULL    NULL     NULL     NULL        NULL
+avoid_full_table_scans_in_mutations                        NULL    NULL     NULL     NULL        NULL
 backslash_quote                                            NULL    NULL     NULL     NULL        NULL
 bypass_pcr_reader_catalog_aost                             NULL    NULL     NULL     NULL        NULL
 bytea_output                                               NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/select
+++ b/pkg/sql/logictest/testdata/logic_test/select
@@ -756,6 +756,25 @@ SELECT * FROM t_disallow_scans@{FORCE_INDEX=b_idx,NO_FULL_SCAN} WHERE b > 0
 statement ok
 SELECT * FROM t_disallow_scans@{FORCE_INDEX=b_partial,NO_FULL_SCAN} WHERE a > 0 AND b = 1
 
+# Now avoid full scans with a hint. A full scan should not cause an error.
+statement ok
+SELECT * FROM t_disallow_scans@{AVOID_FULL_SCAN}
+
+statement ok
+SELECT * FROM t_disallow_scans@{FORCE_INDEX=b_idx,AVOID_FULL_SCAN}
+
+statement ok
+SELECT * FROM t_disallow_scans@{FORCE_INDEX=b_partial,AVOID_FULL_SCAN} WHERE a > 0
+
+statement ok
+SELECT * FROM t_disallow_scans@{AVOID_FULL_SCAN} WHERE a > 0
+
+statement ok
+SELECT * FROM t_disallow_scans@{FORCE_INDEX=b_idx,AVOID_FULL_SCAN} WHERE b > 0
+
+statement ok
+SELECT * FROM t_disallow_scans@{FORCE_INDEX=b_partial,AVOID_FULL_SCAN} WHERE a > 0 AND b = 1
+
 # Now disable full scans with the session variable.
 statement ok
 SET disallow_full_table_scans = true;

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -35,6 +35,7 @@ application_name                                           ·
 authentication_method                                      cert-password
 autocommit_before_ddl                                      off
 avoid_buffering                                            off
+avoid_full_table_scans_in_mutations                        on
 backslash_quote                                            safe_encoding
 bypass_pcr_reader_catalog_aost                             off
 bytea_output                                               hex

--- a/pkg/sql/opt/exec/execbuilder/testdata/autocommit
+++ b/pkg/sql/opt/exec/execbuilder/testdata/autocommit
@@ -734,7 +734,7 @@ WHERE message       LIKE '%r$rangeid: sending batch%'
 ----
 dist sender send  r74: sending batch 1 Scan to (n1,s1):1
 dist sender send  r74: sending batch 1 Put to (n1,s1):1
-dist sender send  r74: sending batch 1 Scan to (n1,s1):1
+dist sender send  r74: sending batch 1 Get to (n1,s1):1
 dist sender send  r74: sending batch 1 EndTxn to (n1,s1):1
 
 query B

--- a/pkg/sql/opt/exec/execbuilder/testdata/cascade
+++ b/pkg/sql/opt/exec/execbuilder/testdata/cascade
@@ -913,22 +913,17 @@ vectorized: true
         │   └── • buffer
         │       │ label: buffer 1
         │       │
-        │       └── • hash join
+        │       └── • hash join (semi)
         │           │ equality: (b) = (a)
-        │           │ right cols are key
         │           │
         │           ├── • scan
         │           │     missing stats
         │           │     table: self@self_pkey
         │           │     spans: FULL SCAN
         │           │
-        │           └── • distinct
-        │               │ estimated row count: 10
-        │               │ distinct on: a
-        │               │
-        │               └── • scan buffer
-        │                     estimated row count: 100
-        │                     label: buffer 1000000
+        │           └── • scan buffer
+        │                 estimated row count: 100
+        │                 label: buffer 1000000
         │
         └── • fk-cascade
               fk: self_b_fkey
@@ -998,22 +993,17 @@ vectorized: true
         │   └── • buffer
         │       │ label: buffer 1
         │       │
-        │       └── • hash join
+        │       └── • hash join (semi)
         │           │ equality: (cascade_delete) = (id)
-        │           │ right cols are key
         │           │
         │           ├── • scan
         │           │     missing stats
         │           │     table: loop_b@loop_b_pkey
         │           │     spans: FULL SCAN
         │           │
-        │           └── • distinct
-        │               │ estimated row count: 10
-        │               │ distinct on: id
-        │               │
-        │               └── • scan buffer
-        │                     estimated row count: 100
-        │                     label: buffer 1000000
+        │           └── • scan buffer
+        │                 estimated row count: 100
+        │                 label: buffer 1000000
         │
         └── • fk-cascade
             │ fk: cascade_delete_constraint
@@ -1251,22 +1241,17 @@ vectorized: true
 │       │   └── • buffer
 │       │       │ label: buffer 1
 │       │       │
-│       │       └── • hash join
+│       │       └── • hash join (semi)
 │       │           │ equality: (t4_id3_1) = (id3)
-│       │           │ right cols are key
 │       │           │
 │       │           ├── • scan
 │       │           │     missing stats
 │       │           │     table: t4@t4_pkey
 │       │           │     spans: FULL SCAN
 │       │           │
-│       │           └── • distinct
-│       │               │ estimated row count: 10
-│       │               │ distinct on: id3
-│       │               │
-│       │               └── • scan buffer
-│       │                     estimated row count: 100
-│       │                     label: buffer 1000000
+│       │           └── • scan buffer
+│       │                 estimated row count: 100
+│       │                 label: buffer 1000000
 │       │
 │       └── • fk-cascade
 │           │ fk: fk3
@@ -1277,22 +1262,17 @@ vectorized: true
 │               │
 │               └── • render
 │                   │
-│                   └── • hash join
+│                   └── • hash join (semi)
 │                       │ equality: (t5_id4) = (id4)
-│                       │ right cols are key
 │                       │
 │                       ├── • scan
 │                       │     missing stats
 │                       │     table: t5@t5_pkey
 │                       │     spans: FULL SCAN
 │                       │
-│                       └── • distinct
-│                           │ estimated row count: 10
-│                           │ distinct on: id4
-│                           │
-│                           └── • scan buffer
-│                                 estimated row count: 100
-│                                 label: buffer 1000000
+│                       └── • scan buffer
+│                             estimated row count: 100
+│                             label: buffer 1000000
 │
 ├── • fk-cascade
 │   │ fk: fk2
@@ -1305,22 +1285,17 @@ vectorized: true
 │       │   └── • buffer
 │       │       │ label: buffer 1
 │       │       │
-│       │       └── • hash join
+│       │       └── • hash join (semi)
 │       │           │ equality: (t4_id3_2) = (id3)
-│       │           │ right cols are key
 │       │           │
 │       │           ├── • scan
 │       │           │     missing stats
 │       │           │     table: t4@t4_pkey
 │       │           │     spans: FULL SCAN
 │       │           │
-│       │           └── • distinct
-│       │               │ estimated row count: 10
-│       │               │ distinct on: id3
-│       │               │
-│       │               └── • scan buffer
-│       │                     estimated row count: 100
-│       │                     label: buffer 1000000
+│       │           └── • scan buffer
+│       │                 estimated row count: 100
+│       │                 label: buffer 1000000
 │       │
 │       └── • fk-cascade
 │           │ fk: fk3
@@ -1331,22 +1306,17 @@ vectorized: true
 │               │
 │               └── • render
 │                   │
-│                   └── • hash join
+│                   └── • hash join (semi)
 │                       │ equality: (t5_id4) = (id4)
-│                       │ right cols are key
 │                       │
 │                       ├── • scan
 │                       │     missing stats
 │                       │     table: t5@t5_pkey
 │                       │     spans: FULL SCAN
 │                       │
-│                       └── • distinct
-│                           │ estimated row count: 10
-│                           │ distinct on: id4
-│                           │
-│                           └── • scan buffer
-│                                 estimated row count: 100
-│                                 label: buffer 1000000
+│                       └── • scan buffer
+│                             estimated row count: 100
+│                             label: buffer 1000000
 │
 ├── • fk-cascade
 │   │ fk: fk1
@@ -1354,22 +1324,17 @@ vectorized: true
 │   └── • delete
 │       │ from: t5
 │       │
-│       └── • hash join
+│       └── • hash join (semi)
 │           │ equality: (t5_id3_1) = (id3)
-│           │ right cols are key
 │           │
 │           ├── • scan
 │           │     missing stats
 │           │     table: t5@t5_pkey
 │           │     spans: FULL SCAN
 │           │
-│           └── • distinct
-│               │ estimated row count: 10
-│               │ distinct on: id3
-│               │
-│               └── • scan buffer
-│                     estimated row count: 100
-│                     label: buffer 1000000
+│           └── • scan buffer
+│                 estimated row count: 100
+│                 label: buffer 1000000
 │
 └── • fk-cascade
     │ fk: fk2
@@ -1377,19 +1342,14 @@ vectorized: true
     └── • delete
         │ from: t5
         │
-        └── • hash join
+        └── • hash join (semi)
             │ equality: (t5_id3_2) = (id3)
-            │ right cols are key
             │
             ├── • scan
             │     missing stats
             │     table: t5@t5_pkey
             │     spans: FULL SCAN
             │
-            └── • distinct
-                │ estimated row count: 10
-                │ distinct on: id3
-                │
-                └── • scan buffer
-                      estimated row count: 100
-                      label: buffer 1000000
+            └── • scan buffer
+                  estimated row count: 100
+                  label: buffer 1000000

--- a/pkg/sql/opt/exec/execbuilder/testdata/delete
+++ b/pkg/sql/opt/exec/execbuilder/testdata/delete
@@ -345,6 +345,36 @@ vectorized: true
               spans: /1-/1000 /2001-/3000
               locking strength: for update
 
+# AVOID_FULL_SCAN also works to ensure a constrained scan.
+query T
+EXPLAIN (VERBOSE) DELETE FROM xyz@{AVOID_FULL_SCAN} WHERE (y > 0 AND y < 1000) OR (y > 2000 AND y < 3000) RETURNING z
+----
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (z)
+│
+└── • delete
+    │ columns: (x, z)
+    │ estimated row count: 990 (missing stats)
+    │ from: xyz
+    │ auto commit
+    │
+    └── • index join
+        │ columns: (x, y, z)
+        │ estimated row count: 990 (missing stats)
+        │ table: xyz@xyz_pkey
+        │ key columns: x
+        │ locking strength: for update
+        │
+        └── • scan
+              columns: (x, y)
+              estimated row count: 990 (missing stats)
+              table: xyz@xyz_y_idx
+              spans: /1-/1000 /2001-/3000
+              locking strength: for update
+
 # Testcase for issue 105803.
 
 statement ok

--- a/pkg/sql/opt/exec/execbuilder/testdata/delete
+++ b/pkg/sql/opt/exec/execbuilder/testdata/delete
@@ -288,6 +288,9 @@ CREATE TABLE xyz (
 
 # Ensure that we can use a hint to avoid a full table scan.
 
+statement ok
+SET avoid_full_table_scans_in_mutations = false
+
 # Without the hint, we plan a full table scan.
 query T
 EXPLAIN (VERBOSE) DELETE FROM xyz WHERE (y > 0 AND y < 1000) OR (y > 2000 AND y < 3000) RETURNING z
@@ -348,6 +351,40 @@ vectorized: true
 # AVOID_FULL_SCAN also works to ensure a constrained scan.
 query T
 EXPLAIN (VERBOSE) DELETE FROM xyz@{AVOID_FULL_SCAN} WHERE (y > 0 AND y < 1000) OR (y > 2000 AND y < 3000) RETURNING z
+----
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (z)
+│
+└── • delete
+    │ columns: (x, z)
+    │ estimated row count: 990 (missing stats)
+    │ from: xyz
+    │ auto commit
+    │
+    └── • index join
+        │ columns: (x, y, z)
+        │ estimated row count: 990 (missing stats)
+        │ table: xyz@xyz_pkey
+        │ key columns: x
+        │ locking strength: for update
+        │
+        └── • scan
+              columns: (x, y)
+              estimated row count: 990 (missing stats)
+              table: xyz@xyz_y_idx
+              spans: /1-/1000 /2001-/3000
+              locking strength: for update
+
+# We also avoid the full scan using the session setting
+# avoid_full_table_scans_in_mutations.
+statement ok
+SET avoid_full_table_scans_in_mutations = true
+
+query T
+EXPLAIN (VERBOSE) DELETE FROM xyz WHERE (y > 0 AND y < 1000) OR (y > 2000 AND y < 3000) RETURNING z
 ----
 distribution: local
 vectorized: true

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain_redact
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain_redact
@@ -321,30 +321,26 @@ vectorized: true
     │
     └── • render
         │
-        └── • hash join (left outer)
-            │ equality: (?column?) = (b)
-            │ right cols are key
+        └── • render
             │
-            ├── • distinct
-            │   │ distinct on: ?column?
-            │   │ nulls are distinct
-            │   │ error on duplicate
-            │   │
-            │   └── • render
-            │       │
-            │       └── • render
-            │           │
-            │           └── • scan
-            │                 missing stats
-            │                 table: a@a_pkey
-            │                 spans: FULL SCAN
-            │
-            └── • render
+            └── • lookup join (left outer)
+                │ table: bc@bc_pkey
+                │ equality: (?column?) = (b)
+                │ equality cols are key
                 │
-                └── • scan
-                      missing stats
-                      table: bc@bc_pkey
-                      spans: FULL SCAN
+                └── • distinct
+                    │ distinct on: ?column?
+                    │ nulls are distinct
+                    │ error on duplicate
+                    │
+                    └── • render
+                        │
+                        └── • render
+                            │
+                            └── • scan
+                                  missing stats
+                                  table: a@a_pkey
+                                  spans: FULL SCAN
 
 query T
 EXPLAIN (VERBOSE, REDACT) INSERT INTO bc SELECT a::float + 1 FROM a ON CONFLICT (b) DO UPDATE SET b = bc.b + 100
@@ -379,44 +375,41 @@ vectorized: true
             │ render b: b
             │ render c: c
             │
-            └── • hash join (left outer)
-                │ columns: (c_comp, "?column?", c, b)
-                │ estimated row count: 1,000 (missing stats)
-                │ equality: (?column?) = (b)
-                │ right cols are key
+            └── • render
+                │ columns: (c, "?column?", c_comp, b)
+                │ render c: CASE b IS NULL WHEN ‹×› THEN CAST(‹×› AS FLOAT8) ELSE b * ‹×› END
+                │ render ?column?: "?column?"
+                │ render c_comp: c_comp
+                │ render b: b
                 │
-                ├── • distinct
-                │   │ columns: (c_comp, "?column?")
-                │   │ estimated row count: 1,000 (missing stats)
-                │   │ distinct on: ?column?
-                │   │ nulls are distinct
-                │   │ error on duplicate
-                │   │
-                │   └── • render
-                │       │ columns: (c_comp, "?column?")
-                │       │ render c_comp: "?column?" * ‹×›
-                │       │ render ?column?: "?column?"
-                │       │
-                │       └── • render
-                │           │ columns: ("?column?")
-                │           │ render ?column?: a::FLOAT8 + ‹×›
-                │           │
-                │           └── • scan
-                │                 columns: (a)
-                │                 estimated row count: 1,000 (missing stats)
-                │                 table: a@a_pkey
-                │                 spans: FULL SCAN
-                │
-                └── • render
-                    │ columns: (c, b)
-                    │ render c: b * ‹×›
-                    │ render b: b
+                └── • lookup join (left outer)
+                    │ columns: (c_comp, "?column?", b)
+                    │ estimated row count: 1,000 (missing stats)
+                    │ table: bc@bc_pkey
+                    │ equality: (?column?) = (b)
+                    │ equality cols are key
                     │
-                    └── • scan
-                          columns: (b)
-                          estimated row count: 1,000 (missing stats)
-                          table: bc@bc_pkey
-                          spans: FULL SCAN
+                    └── • distinct
+                        │ columns: (c_comp, "?column?")
+                        │ estimated row count: 1,000 (missing stats)
+                        │ distinct on: ?column?
+                        │ nulls are distinct
+                        │ error on duplicate
+                        │
+                        └── • render
+                            │ columns: (c_comp, "?column?")
+                            │ render c_comp: "?column?" * ‹×›
+                            │ render ?column?: "?column?"
+                            │
+                            └── • render
+                                │ columns: ("?column?")
+                                │ render ?column?: a::FLOAT8 + ‹×›
+                                │
+                                └── • scan
+                                      columns: (a)
+                                      estimated row count: 1,000 (missing stats)
+                                      table: a@a_pkey
+                                      spans: FULL SCAN
 
 query T
 EXPLAIN (OPT, REDACT) INSERT INTO bc SELECT a::float + 1 FROM a ON CONFLICT (b) DO UPDATE SET b = bc.b + 100
@@ -425,27 +418,23 @@ upsert bc
  ├── arbiter indexes: bc_pkey
  └── project
       ├── project
-      │    ├── left-join (hash)
-      │    │    ├── ensure-upsert-distinct-on
-      │    │    │    ├── project
+      │    ├── project
+      │    │    ├── left-join (lookup bc)
+      │    │    │    ├── lookup columns are key
+      │    │    │    ├── ensure-upsert-distinct-on
       │    │    │    │    ├── project
-      │    │    │    │    │    ├── scan a
+      │    │    │    │    │    ├── project
+      │    │    │    │    │    │    ├── scan a
+      │    │    │    │    │    │    └── projections
+      │    │    │    │    │    │         └── a::FLOAT8 + ‹×›
       │    │    │    │    │    └── projections
-      │    │    │    │    │         └── a::FLOAT8 + ‹×›
-      │    │    │    │    └── projections
-      │    │    │    │         └── "?column?" * ‹×›
-      │    │    │    └── aggregations
-      │    │    │         └── first-agg
-      │    │    │              └── c_comp
-      │    │    ├── project
-      │    │    │    ├── scan bc
-      │    │    │    │    └── computed column expressions
-      │    │    │    │         └── c
-      │    │    │    │              └── b * ‹×›
-      │    │    │    └── projections
-      │    │    │         └── b * ‹×›
-      │    │    └── filters
-      │    │         └── "?column?" = b
+      │    │    │    │    │         └── "?column?" * ‹×›
+      │    │    │    │    └── aggregations
+      │    │    │    │         └── first-agg
+      │    │    │    │              └── c_comp
+      │    │    │    └── filters (true)
+      │    │    └── projections
+      │    │         └── CASE b IS NULL WHEN ‹×› THEN CAST(‹×› AS FLOAT8) ELSE b * ‹×› END
       │    └── projections
       │         └── b + ‹×›
       └── projections
@@ -469,13 +458,13 @@ upsert bc
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  ├── stats: [rows=0]
- ├── cost: 2347.4925
+ ├── cost: 7292.92625
  ├── distribution: test
  └── project
       ├── columns: upsert_b:23 upsert_c:24 "?column?":13 c_comp:14 b:15 c:16
       ├── immutable
       ├── stats: [rows=1000]
-      ├── cost: 2347.4825
+      ├── cost: 7292.91625
       ├── lax-key: (13,15)
       ├── fd: (13)-->(14), (15)-->(16), (13,15)~~>(23,24)
       ├── distribution: test
@@ -484,84 +473,69 @@ upsert bc
       │    ├── columns: b_new:21 "?column?":13 c_comp:14 b:15 c:16
       │    ├── immutable
       │    ├── stats: [rows=1000]
-      │    ├── cost: 2317.4625
+      │    ├── cost: 7262.89625
       │    ├── lax-key: (13,15)
       │    ├── fd: (13)-->(14), (15)-->(16,21)
       │    ├── distribution: test
       │    ├── prune: (13-16,21)
-      │    ├── left-join (hash)
-      │    │    ├── columns: "?column?":13 c_comp:14 b:15 c:16
-      │    │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-one)
+      │    ├── project
+      │    │    ├── columns: c:16 "?column?":13 c_comp:14 b:15
       │    │    ├── immutable
       │    │    ├── stats: [rows=1000, distinct(15)=1000, null(15)=0]
-      │    │    ├── cost: 2297.4425
+      │    │    ├── cost: 7242.87625
       │    │    ├── lax-key: (13,15)
       │    │    ├── fd: (13)-->(14), (15)-->(16)
       │    │    ├── distribution: test
-      │    │    ├── ensure-upsert-distinct-on
-      │    │    │    ├── columns: "?column?":13 c_comp:14
-      │    │    │    ├── grouping columns: "?column?":13
-      │    │    │    ├── error: "UPSERT or INSERT...ON CONFLICT command cannot affect row a second time"
+      │    │    ├── left-join (lookup bc)
+      │    │    │    ├── columns: "?column?":13 c_comp:14 b:15
+      │    │    │    ├── key columns: [13] = [15]
+      │    │    │    ├── lookup columns are key
       │    │    │    ├── immutable
-      │    │    │    ├── stats: [rows=1000, distinct(13)=1000, null(13)=0]
-      │    │    │    ├── cost: 1168.83625
-      │    │    │    ├── lax-key: (13)
+      │    │    │    ├── stats: [rows=1000, distinct(15)=1000, null(15)=0]
+      │    │    │    ├── cost: 7222.85625
+      │    │    │    ├── lax-key: (13,15)
       │    │    │    ├── fd: (13)-->(14)
       │    │    │    ├── distribution: test
-      │    │    │    ├── project
-      │    │    │    │    ├── columns: c_comp:14 "?column?":13
+      │    │    │    ├── ensure-upsert-distinct-on
+      │    │    │    │    ├── columns: "?column?":13 c_comp:14
+      │    │    │    │    ├── grouping columns: "?column?":13
+      │    │    │    │    ├── error: "UPSERT or INSERT...ON CONFLICT command cannot affect row a second time"
       │    │    │    │    ├── immutable
-      │    │    │    │    ├── stats: [rows=1000, distinct(13)=100, null(13)=0]
-      │    │    │    │    ├── cost: 1128.66
+      │    │    │    │    ├── stats: [rows=1000, distinct(13)=1000, null(13)=0]
+      │    │    │    │    ├── cost: 1168.83625
+      │    │    │    │    ├── lax-key: (13)
       │    │    │    │    ├── fd: (13)-->(14)
       │    │    │    │    ├── distribution: test
       │    │    │    │    ├── project
-      │    │    │    │    │    ├── columns: "?column?":13
+      │    │    │    │    │    ├── columns: c_comp:14 "?column?":13
       │    │    │    │    │    ├── immutable
       │    │    │    │    │    ├── stats: [rows=1000, distinct(13)=100, null(13)=0]
-      │    │    │    │    │    ├── cost: 1108.64
+      │    │    │    │    │    ├── cost: 1128.66
+      │    │    │    │    │    ├── fd: (13)-->(14)
       │    │    │    │    │    ├── distribution: test
-      │    │    │    │    │    ├── prune: (13)
-      │    │    │    │    │    ├── scan a
-      │    │    │    │    │    │    ├── columns: a:7
-      │    │    │    │    │    │    ├── stats: [rows=1000, distinct(7)=100, null(7)=10]
-      │    │    │    │    │    │    ├── cost: 1088.62
+      │    │    │    │    │    ├── project
+      │    │    │    │    │    │    ├── columns: "?column?":13
+      │    │    │    │    │    │    ├── immutable
+      │    │    │    │    │    │    ├── stats: [rows=1000, distinct(13)=100, null(13)=0]
+      │    │    │    │    │    │    ├── cost: 1108.64
       │    │    │    │    │    │    ├── distribution: test
-      │    │    │    │    │    │    └── prune: (7)
+      │    │    │    │    │    │    ├── prune: (13)
+      │    │    │    │    │    │    ├── scan a
+      │    │    │    │    │    │    │    ├── columns: a:7
+      │    │    │    │    │    │    │    ├── stats: [rows=1000, distinct(7)=100, null(7)=10]
+      │    │    │    │    │    │    │    ├── cost: 1088.62
+      │    │    │    │    │    │    │    ├── distribution: test
+      │    │    │    │    │    │    │    └── prune: (7)
+      │    │    │    │    │    │    └── projections
+      │    │    │    │    │    │         └── a:7::FLOAT8 + ‹×› [as="?column?":13, outer=(7), immutable]
       │    │    │    │    │    └── projections
-      │    │    │    │    │         └── a:7::FLOAT8 + ‹×› [as="?column?":13, outer=(7), immutable]
-      │    │    │    │    └── projections
-      │    │    │    │         └── "?column?":13 * ‹×› [as=c_comp:14, outer=(13), immutable]
-      │    │    │    └── aggregations
-      │    │    │         └── first-agg [as=c_comp:14, outer=(14)]
-      │    │    │              └── c_comp:14
-      │    │    ├── project
-      │    │    │    ├── columns: c:16 b:15
-      │    │    │    ├── immutable
-      │    │    │    ├── stats: [rows=1000, distinct(15)=1000, null(15)=0]
-      │    │    │    ├── cost: 1088.44
-      │    │    │    ├── key: (15)
-      │    │    │    ├── fd: (15)-->(16)
-      │    │    │    ├── distribution: test
-      │    │    │    ├── prune: (15,16)
-      │    │    │    ├── interesting orderings: (+15)
-      │    │    │    ├── unfiltered-cols: (15-20)
-      │    │    │    ├── scan bc
-      │    │    │    │    ├── columns: b:15
-      │    │    │    │    ├── computed column expressions
-      │    │    │    │    │    └── c:16
-      │    │    │    │    │         └── b:15 * ‹×›
-      │    │    │    │    ├── stats: [rows=1000, distinct(15)=1000, null(15)=0]
-      │    │    │    │    ├── cost: 1068.42
-      │    │    │    │    ├── key: (15)
-      │    │    │    │    ├── distribution: test
-      │    │    │    │    ├── prune: (15)
-      │    │    │    │    ├── interesting orderings: (+15)
-      │    │    │    │    └── unfiltered-cols: (15-20)
-      │    │    │    └── projections
-      │    │    │         └── b:15 * ‹×› [as=c:16, outer=(15), immutable]
-      │    │    └── filters
-      │    │         └── "?column?":13 = b:15 [outer=(13,15), constraints=(‹×›), fd=(13)==(15), (15)==(13)]
+      │    │    │    │    │         └── "?column?":13 * ‹×› [as=c_comp:14, outer=(13), immutable]
+      │    │    │    │    └── aggregations
+      │    │    │    │         └── first-agg [as=c_comp:14, outer=(14)]
+      │    │    │    │              └── c_comp:14
+      │    │    │    └── filters (true)
+      │    │    └── projections
+      │    │         └── CASE b:15 IS NULL WHEN ‹×› THEN CAST(‹×› AS FLOAT8) ELSE b:15 * ‹×› END [as=c:16, outer=(15), immutable]
       │    └── projections
       │         └── b:15 + ‹×› [as=b_new:21, outer=(15), immutable]
       └── projections
@@ -585,13 +559,13 @@ upsert bc
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  ├── stats: [rows=0]
- ├── cost: 2347.4925
+ ├── cost: 7292.92625
  ├── distribution: test
  └── project
       ├── columns: upsert_b:23(float) upsert_c:24(float) "?column?":13(float) c_comp:14(float) b:15(float) c:16(float)
       ├── immutable
       ├── stats: [rows=1000]
-      ├── cost: 2347.4825
+      ├── cost: 7292.91625
       ├── lax-key: (13,15)
       ├── fd: (13)-->(14), (15)-->(16), (13,15)~~>(23,24)
       ├── distribution: test
@@ -600,95 +574,83 @@ upsert bc
       │    ├── columns: b_new:21(float) "?column?":13(float) c_comp:14(float) b:15(float) c:16(float)
       │    ├── immutable
       │    ├── stats: [rows=1000]
-      │    ├── cost: 2317.4625
+      │    ├── cost: 7262.89625
       │    ├── lax-key: (13,15)
       │    ├── fd: (13)-->(14), (15)-->(16,21)
       │    ├── distribution: test
       │    ├── prune: (13-16,21)
-      │    ├── left-join (hash)
-      │    │    ├── columns: "?column?":13(float) c_comp:14(float) b:15(float) c:16(float)
-      │    │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-one)
+      │    ├── project
+      │    │    ├── columns: c:16(float) "?column?":13(float) c_comp:14(float) b:15(float)
       │    │    ├── immutable
       │    │    ├── stats: [rows=1000, distinct(15)=1000, null(15)=0]
-      │    │    ├── cost: 2297.4425
+      │    │    ├── cost: 7242.87625
       │    │    ├── lax-key: (13,15)
       │    │    ├── fd: (13)-->(14), (15)-->(16)
       │    │    ├── distribution: test
-      │    │    ├── ensure-upsert-distinct-on
-      │    │    │    ├── columns: "?column?":13(float) c_comp:14(float)
-      │    │    │    ├── grouping columns: "?column?":13(float)
-      │    │    │    ├── error: "UPSERT or INSERT...ON CONFLICT command cannot affect row a second time"
+      │    │    ├── left-join (lookup bc)
+      │    │    │    ├── columns: "?column?":13(float) c_comp:14(float) b:15(float)
+      │    │    │    ├── key columns: [13] = [15]
+      │    │    │    ├── lookup columns are key
       │    │    │    ├── immutable
-      │    │    │    ├── stats: [rows=1000, distinct(13)=1000, null(13)=0]
-      │    │    │    ├── cost: 1168.83625
-      │    │    │    ├── lax-key: (13)
+      │    │    │    ├── stats: [rows=1000, distinct(15)=1000, null(15)=0]
+      │    │    │    ├── cost: 7222.85625
+      │    │    │    ├── lax-key: (13,15)
       │    │    │    ├── fd: (13)-->(14)
       │    │    │    ├── distribution: test
-      │    │    │    ├── project
-      │    │    │    │    ├── columns: c_comp:14(float) "?column?":13(float)
+      │    │    │    ├── ensure-upsert-distinct-on
+      │    │    │    │    ├── columns: "?column?":13(float) c_comp:14(float)
+      │    │    │    │    ├── grouping columns: "?column?":13(float)
+      │    │    │    │    ├── error: "UPSERT or INSERT...ON CONFLICT command cannot affect row a second time"
       │    │    │    │    ├── immutable
-      │    │    │    │    ├── stats: [rows=1000, distinct(13)=100, null(13)=0]
-      │    │    │    │    ├── cost: 1128.66
+      │    │    │    │    ├── stats: [rows=1000, distinct(13)=1000, null(13)=0]
+      │    │    │    │    ├── cost: 1168.83625
+      │    │    │    │    ├── lax-key: (13)
       │    │    │    │    ├── fd: (13)-->(14)
       │    │    │    │    ├── distribution: test
       │    │    │    │    ├── project
-      │    │    │    │    │    ├── columns: "?column?":13(float)
+      │    │    │    │    │    ├── columns: c_comp:14(float) "?column?":13(float)
       │    │    │    │    │    ├── immutable
       │    │    │    │    │    ├── stats: [rows=1000, distinct(13)=100, null(13)=0]
-      │    │    │    │    │    ├── cost: 1108.64
+      │    │    │    │    │    ├── cost: 1128.66
+      │    │    │    │    │    ├── fd: (13)-->(14)
       │    │    │    │    │    ├── distribution: test
-      │    │    │    │    │    ├── prune: (13)
-      │    │    │    │    │    ├── scan a
-      │    │    │    │    │    │    ├── columns: a:7(int)
-      │    │    │    │    │    │    ├── stats: [rows=1000, distinct(7)=100, null(7)=10]
-      │    │    │    │    │    │    ├── cost: 1088.62
+      │    │    │    │    │    ├── project
+      │    │    │    │    │    │    ├── columns: "?column?":13(float)
+      │    │    │    │    │    │    ├── immutable
+      │    │    │    │    │    │    ├── stats: [rows=1000, distinct(13)=100, null(13)=0]
+      │    │    │    │    │    │    ├── cost: 1108.64
       │    │    │    │    │    │    ├── distribution: test
-      │    │    │    │    │    │    └── prune: (7)
+      │    │    │    │    │    │    ├── prune: (13)
+      │    │    │    │    │    │    ├── scan a
+      │    │    │    │    │    │    │    ├── columns: a:7(int)
+      │    │    │    │    │    │    │    ├── stats: [rows=1000, distinct(7)=100, null(7)=10]
+      │    │    │    │    │    │    │    ├── cost: 1088.62
+      │    │    │    │    │    │    │    ├── distribution: test
+      │    │    │    │    │    │    │    └── prune: (7)
+      │    │    │    │    │    │    └── projections
+      │    │    │    │    │    │         └── plus [as="?column?":13, type=float, outer=(7), immutable]
+      │    │    │    │    │    │              ├── cast: ‹×› [type=float]
+      │    │    │    │    │    │              │    └── variable: a:7 [type=int]
+      │    │    │    │    │    │              └── const: ‹×› [type=float]
       │    │    │    │    │    └── projections
-      │    │    │    │    │         └── plus [as="?column?":13, type=float, outer=(7), immutable]
-      │    │    │    │    │              ├── cast: ‹×› [type=float]
-      │    │    │    │    │              │    └── variable: a:7 [type=int]
+      │    │    │    │    │         └── mult [as=c_comp:14, type=float, outer=(13), immutable]
+      │    │    │    │    │              ├── variable: "?column?":13 [type=float]
       │    │    │    │    │              └── const: ‹×› [type=float]
-      │    │    │    │    └── projections
-      │    │    │    │         └── mult [as=c_comp:14, type=float, outer=(13), immutable]
-      │    │    │    │              ├── variable: "?column?":13 [type=float]
-      │    │    │    │              └── const: ‹×› [type=float]
-      │    │    │    └── aggregations
-      │    │    │         └── first-agg [as=c_comp:14, type=float, outer=(14)]
-      │    │    │              └── variable: c_comp:14 [type=float]
-      │    │    ├── project
-      │    │    │    ├── columns: c:16(float!null) b:15(float!null)
-      │    │    │    ├── immutable
-      │    │    │    ├── stats: [rows=1000, distinct(15)=1000, null(15)=0]
-      │    │    │    ├── cost: 1088.44
-      │    │    │    ├── key: (15)
-      │    │    │    ├── fd: (15)-->(16)
-      │    │    │    ├── distribution: test
-      │    │    │    ├── prune: (15,16)
-      │    │    │    ├── interesting orderings: (+15)
-      │    │    │    ├── unfiltered-cols: (15-20)
-      │    │    │    ├── scan bc
-      │    │    │    │    ├── columns: b:15(float!null)
-      │    │    │    │    ├── computed column expressions
-      │    │    │    │    │    └── c:16
-      │    │    │    │    │         └── mult [type=float]
-      │    │    │    │    │              ├── variable: b:15 [type=float]
-      │    │    │    │    │              └── const: ‹×› [type=float]
-      │    │    │    │    ├── stats: [rows=1000, distinct(15)=1000, null(15)=0]
-      │    │    │    │    ├── cost: 1068.42
-      │    │    │    │    ├── key: (15)
-      │    │    │    │    ├── distribution: test
-      │    │    │    │    ├── prune: (15)
-      │    │    │    │    ├── interesting orderings: (+15)
-      │    │    │    │    └── unfiltered-cols: (15-20)
-      │    │    │    └── projections
-      │    │    │         └── mult [as=c:16, type=float, outer=(15), immutable]
-      │    │    │              ├── variable: b:15 [type=float]
-      │    │    │              └── const: ‹×› [type=float]
-      │    │    └── filters
-      │    │         └── eq [type=bool, outer=(13,15), constraints=(‹×›), fd=(13)==(15), (15)==(13)]
-      │    │              ├── variable: "?column?":13 [type=float]
-      │    │              └── variable: b:15 [type=float]
+      │    │    │    │    └── aggregations
+      │    │    │    │         └── first-agg [as=c_comp:14, type=float, outer=(14)]
+      │    │    │    │              └── variable: c_comp:14 [type=float]
+      │    │    │    └── filters (true)
+      │    │    └── projections
+      │    │         └── case [as=c:16, type=float, outer=(15), immutable]
+      │    │              ├── is [type=bool]
+      │    │              │    ├── variable: b:15 [type=float]
+      │    │              │    └── null [type=unknown]
+      │    │              ├── when [type=float]
+      │    │              │    ├── true [type=bool]
+      │    │              │    └── null [type=float]
+      │    │              └── mult [type=float]
+      │    │                   ├── variable: b:15 [type=float]
+      │    │                   └── const: ‹×› [type=float]
       │    └── projections
       │         └── plus [as=b_new:21, type=float, outer=(15), immutable]
       │              ├── variable: b:15 [type=float]
@@ -720,38 +682,38 @@ memo (optimized, ~34KB, required=[presentation: info:25] [distribution: test])
  ├── G1: (explain G2 [distribution: test])
  │    └── [presentation: info:25] [distribution: test]
  │         ├── best: (explain G2="[distribution: test]" [distribution: test])
- │         └── cost: 2347.51
+ │         └── cost: 7292.95
  ├── G2: (upsert G3 G4 G5 bc)
  │    ├── [distribution: test]
  │    │    ├── best: (upsert G3="[distribution: test]" G4 G5 bc)
- │    │    └── cost: 2347.49
+ │    │    └── cost: 7292.93
  │    └── []
  │         ├── best: (upsert G3 G4 G5 bc)
- │         └── cost: 2347.49
+ │         └── cost: 7292.93
  ├── G3: (project G6 G7 ?column? c_comp b c)
  │    ├── [distribution: test]
  │    │    ├── best: (project G6="[distribution: test]" G7 ?column? c_comp b c)
- │    │    └── cost: 2347.48
+ │    │    └── cost: 7292.92
  │    └── []
  │         ├── best: (project G6 G7 ?column? c_comp b c)
- │         └── cost: 2347.48
+ │         └── cost: 7292.92
  ├── G4: (unique-checks)
  ├── G5: (f-k-checks)
  ├── G6: (project G8 G9 ?column? c_comp b c)
  │    ├── [distribution: test]
  │    │    ├── best: (project G8="[distribution: test]" G9 ?column? c_comp b c)
- │    │    └── cost: 2317.46
+ │    │    └── cost: 7262.90
  │    └── []
  │         ├── best: (project G8 G9 ?column? c_comp b c)
- │         └── cost: 2317.46
+ │         └── cost: 7262.90
  ├── G7: (projections G10 G11)
  ├── G8: (left-join G12 G13 G14) (right-join G13 G12 G14) (project G15 G16 ?column? c_comp b) (merge-join G13 G12 G17 right-join,+15,+13)
  │    ├── [distribution: test]
- │    │    ├── best: (left-join G12="[distribution: test]" G13="[distribution: test]" G14)
- │    │    └── cost: 2297.44
+ │    │    ├── best: (project G15="[distribution: test]" G16 ?column? c_comp b)
+ │    │    └── cost: 7242.88
  │    └── []
- │         ├── best: (left-join G12 G13 G14)
- │         └── cost: 2297.44
+ │         ├── best: (project G15 G16 ?column? c_comp b)
+ │         └── cost: 7242.88
  ├── G9: (projections G18)
  ├── G10: (case G19 G20 G21)
  ├── G11: (case G19 G22 G23)
@@ -770,25 +732,25 @@ memo (optimized, ~34KB, required=[presentation: info:25] [distribution: test])
  │         └── cost: 1168.84
  ├── G13: (project G26 G27 b)
  │    ├── [distribution: test]
- │    │    ├── best: (project G26="[distribution: test]" G27 b)
- │    │    └── cost: 1088.44
+ │    │    ├── best: (distribute G13)
+ │    │    └── cost: 106840000000000023520844799485661854770609709450788864.00
  │    ├── [ordering: +15]
- │    │    ├── best: (project G26="[ordering: +15]" G27 b)
- │    │    └── cost: 1088.44
+ │    │    ├── best: (sort G13)
+ │    │    └── cost: 106840000000000023520844799485661854770609709450788864.00
  │    ├── [ordering: +15] [distribution: test]
- │    │    ├── best: (project G26="[ordering: +15] [distribution: test]" G27 b)
- │    │    └── cost: 1088.44
+ │    │    ├── best: (distribute G13="[ordering: +15]")
+ │    │    └── cost: 106840000000000023520844799485661854770609709450788864.00
  │    └── []
  │         ├── best: (project G26 G27 b)
- │         └── cost: 1088.44
+ │         └── cost: 106840000000000023520844799485661854770609709450788864.00
  ├── G14: (filters G28)
  ├── G15: (left-join G12 G26 G14) (right-join G26 G12 G14) (lookup-join G12 G17 bc,keyCols=[13],outCols=(13-15)) (merge-join G26 G12 G17 right-join,+15,+13)
  │    ├── [distribution: test]
- │    │    ├── best: (left-join G12="[distribution: test]" G26="[distribution: test]" G14)
- │    │    └── cost: 2277.42
+ │    │    ├── best: (lookup-join G12="[distribution: test]" G17 bc,keyCols=[13],outCols=(13-15))
+ │    │    └── cost: 7222.86
  │    └── []
- │         ├── best: (left-join G12 G26 G14)
- │         └── cost: 2277.42
+ │         ├── best: (lookup-join G12 G17 bc,keyCols=[13],outCols=(13-15))
+ │         └── cost: 7222.86
  ├── G16: (projections G29)
  ├── G17: (filters)
  ├── G18: (plus G30 G31)
@@ -813,17 +775,17 @@ memo (optimized, ~34KB, required=[presentation: info:25] [distribution: test])
  ├── G25: (aggregations G37)
  ├── G26: (scan bc,cols=(15))
  │    ├── [distribution: test]
- │    │    ├── best: (scan bc,cols=(15))
- │    │    └── cost: 1068.42
+ │    │    ├── best: (distribute G26)
+ │    │    └── cost: 106840000000000023520844799485661854770609709450788864.00
  │    ├── [ordering: +15]
- │    │    ├── best: (scan bc,cols=(15))
- │    │    └── cost: 1068.42
+ │    │    ├── best: (sort G26)
+ │    │    └── cost: 106840000000000023520844799485661854770609709450788864.00
  │    ├── [ordering: +15] [distribution: test]
- │    │    ├── best: (scan bc,cols=(15))
- │    │    └── cost: 1068.42
+ │    │    ├── best: (distribute G26="[ordering: +15]")
+ │    │    └── cost: 106840000000000023520844799485661854770609709450788864.00
  │    └── []
  │         ├── best: (scan bc,cols=(15))
- │         └── cost: 1068.42
+ │         └── cost: 106840000000000023520844799485661854770609709450788864.00
  ├── G27: (projections G38)
  ├── G28: (eq G39 G30)
  ├── G29: (case G40 G41 G38)
@@ -872,27 +834,23 @@ upsert bc
  ├── arbiter indexes: bc_pkey
  └── project
       ├── project
-      │    ├── left-join (hash)
-      │    │    ├── ensure-upsert-distinct-on
-      │    │    │    ├── project
+      │    ├── project
+      │    │    ├── left-join (lookup bc)
+      │    │    │    ├── lookup columns are key
+      │    │    │    ├── ensure-upsert-distinct-on
       │    │    │    │    ├── project
-      │    │    │    │    │    ├── scan a
+      │    │    │    │    │    ├── project
+      │    │    │    │    │    │    ├── scan a
+      │    │    │    │    │    │    └── projections
+      │    │    │    │    │    │         └── a::FLOAT8 + ‹×›
       │    │    │    │    │    └── projections
-      │    │    │    │    │         └── a::FLOAT8 + ‹×›
-      │    │    │    │    └── projections
-      │    │    │    │         └── "?column?" * ‹×›
-      │    │    │    └── aggregations
-      │    │    │         └── first-agg
-      │    │    │              └── c_comp
-      │    │    ├── project
-      │    │    │    ├── scan bc
-      │    │    │    │    └── computed column expressions
-      │    │    │    │         └── c
-      │    │    │    │              └── b * ‹×›
-      │    │    │    └── projections
-      │    │    │         └── b * ‹×›
-      │    │    └── filters
-      │    │         └── "?column?" = b
+      │    │    │    │    │         └── "?column?" * ‹×›
+      │    │    │    │    └── aggregations
+      │    │    │    │         └── first-agg
+      │    │    │    │              └── c_comp
+      │    │    │    └── filters (true)
+      │    │    └── projections
+      │    │         └── CASE b IS NULL WHEN ‹×› THEN CAST(‹×› AS FLOAT8) ELSE b * ‹×› END
       │    └── projections
       │         └── b + ‹×›
       └── projections
@@ -1076,7 +1034,8 @@ EXPLAIN (OPT, REDACT) UPDATE ab SET a = a || 'ab' WHERE a > 'a'
 update ab
  └── project
       ├── scan ab
-      │    └── constraint: /7: ‹×›
+      │    ├── constraint: /7: ‹×›
+      │    └── flags: avoid-full-scan
       └── projections
            ├── ‹×›
            └── a || ‹×›
@@ -1107,6 +1066,7 @@ update ab
       ├── scan ab
       │    ├── columns: a:7 b:8
       │    ├── constraint: /7: ‹×›
+      │    ├── flags: avoid-full-scan
       │    ├── stats: [rows=333.3333, distinct(7)=333.333, null(7)=0]
       │    ├── cost: 378.02
       │    ├── key: (7)
@@ -1142,6 +1102,7 @@ update ab
       ├── scan ab
       │    ├── columns: a:7(string!null) b:8(bool)
       │    ├── constraint: /7: ‹×›
+      │    ├── flags: avoid-full-scan
       │    ├── stats: [rows=333.3333, distinct(7)=333.333, null(7)=0]
       │    ├── cost: 378.02
       │    ├── key: (7)
@@ -1187,11 +1148,11 @@ memo (optimized, ~14KB, required=[presentation: info:15] [distribution: test])
  ├── G7: (projections G10 G11)
  ├── G8: (scan ab,cols=(7,8))
  │    ├── [distribution: test]
- │    │    ├── best: (scan ab,cols=(7,8))
- │    │    └── cost: 1108.82
+ │    │    ├── best: (distribute G8)
+ │    │    └── cost: 110880000000000030724457729200025180392225419481317376.00
  │    └── []
  │         ├── best: (scan ab,cols=(7,8))
- │         └── cost: 1108.82
+ │         └── cost: 110880000000000030724457729200025180392225419481317376.00
  ├── G9: (filters G12)
  ├── G10: (‹×›)
  ├── G11: (concat G13 G14)
@@ -1202,7 +1163,8 @@ memo (optimized, ~14KB, required=[presentation: info:15] [distribution: test])
 update ab
  └── project
       ├── scan ab
-      │    └── constraint: /7: ‹×›
+      │    ├── constraint: /7: ‹×›
+      │    └── flags: avoid-full-scan
       └── projections
            ├── ‹×›
            └── a || ‹×›
@@ -1263,121 +1225,131 @@ vectorized: true
 query T
 EXPLAIN (OPT, REDACT) UPDATE e SET e = 'eee' WHERE e > 'a'
 ----
-update e
- └── project
-      ├── select
-      │    ├── scan e
-      │    │    └── computed column expressions
-      │    │         └── crdb_internal_idx_expr
-      │    │              └── e || ‹×›
-      │    └── filters
-      │         └── e > ‹×›
-      └── projections
-           ├── ‹×›
-           ├── ‹×›
-           └── e || ‹×›
+distribute
+ └── update e
+      └── project
+           ├── select
+           │    ├── scan e
+           │    │    ├── computed column expressions
+           │    │    │    └── crdb_internal_idx_expr
+           │    │    │         └── e || ‹×›
+           │    │    └── flags: avoid-full-scan
+           │    └── filters
+           │         └── e > ‹×›
+           └── projections
+                ├── ‹×›
+                ├── ‹×›
+                └── e || ‹×›
 
 query T
 EXPLAIN (OPT, VERBOSE, REDACT) UPDATE e SET e = 'eee' WHERE e > 'a'
 ----
-update e
- ├── columns: <none>
- ├── fetch columns: e:8 crdb_internal_idx_expr:9 rowid:10
- ├── update-mapping:
- │    ├── e_new:15 => e:1
- │    └── crdb_internal_idx_expr_comp:16 => crdb_internal_idx_expr:2
+distribute
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  ├── stats: [rows=0]
- ├── cost: 1132.21333
+ ├── cost: 1.1088e+53
  ├── distribution: test
- └── project
-      ├── columns: crdb_internal_idx_expr_comp:16 e_new:15 crdb_internal_idx_expr:9 e:8 rowid:10
-      ├── immutable
-      ├── stats: [rows=333.3333]
-      ├── cost: 1132.20333
-      ├── key: (10)
-      ├── fd: ()-->(15,16), (10)-->(8), (8)-->(9)
-      ├── distribution: test
-      ├── prune: (8-10,15,16)
-      ├── select
-      │    ├── columns: e:8 rowid:10
-      │    ├── stats: [rows=333.3333, distinct(8)=33.3333, null(8)=0]
-      │    ├── cost: 1118.85
-      │    ├── key: (10)
-      │    ├── fd: (10)-->(8)
-      │    ├── distribution: test
-      │    ├── scan e
-      │    │    ├── columns: e:8 rowid:10
-      │    │    ├── computed column expressions
-      │    │    │    └── crdb_internal_idx_expr:9
-      │    │    │         └── e:8 || ‹×›
-      │    │    ├── stats: [rows=1000, distinct(8)=100, null(8)=10, distinct(10)=1000, null(10)=0]
-      │    │    ├── cost: 1108.82
-      │    │    ├── key: (10)
-      │    │    ├── fd: (10)-->(8)
-      │    │    ├── distribution: test
-      │    │    └── prune: (8,10)
-      │    └── filters
-      │         └── e:8 > ‹×› [outer=(8), constraints=(‹×›; tight)]
-      └── projections
-           ├── ‹×› [as=crdb_internal_idx_expr_comp:16]
-           ├── ‹×› [as=e_new:15]
-           └── e:8 || ‹×› [as=crdb_internal_idx_expr:9, outer=(8), immutable]
+ ├── input distribution:
+ └── update e
+      ├── columns: <none>
+      ├── fetch columns: e:8 crdb_internal_idx_expr:9 rowid:10
+      ├── update-mapping:
+      │    ├── e_new:15 => e:1
+      │    └── crdb_internal_idx_expr_comp:16 => crdb_internal_idx_expr:2
+      ├── cardinality: [0 - 0]
+      ├── volatile, mutations
+      ├── stats: [rows=0]
+      ├── cost: 1.1088e+53
+      └── project
+           ├── columns: crdb_internal_idx_expr_comp:16 e_new:15 crdb_internal_idx_expr:9 e:8 rowid:10
+           ├── immutable
+           ├── stats: [rows=333.3333]
+           ├── cost: 1.1088e+53
+           ├── key: (10)
+           ├── fd: ()-->(15,16), (10)-->(8), (8)-->(9)
+           ├── prune: (8-10,15,16)
+           ├── select
+           │    ├── columns: e:8 rowid:10
+           │    ├── stats: [rows=333.3333, distinct(8)=33.3333, null(8)=0]
+           │    ├── cost: 1.1088e+53
+           │    ├── key: (10)
+           │    ├── fd: (10)-->(8)
+           │    ├── scan e
+           │    │    ├── columns: e:8 rowid:10
+           │    │    ├── computed column expressions
+           │    │    │    └── crdb_internal_idx_expr:9
+           │    │    │         └── e:8 || ‹×›
+           │    │    ├── flags: avoid-full-scan
+           │    │    ├── stats: [rows=1000, distinct(8)=100, null(8)=10, distinct(10)=1000, null(10)=0]
+           │    │    ├── cost: 1.1088e+53
+           │    │    ├── key: (10)
+           │    │    ├── fd: (10)-->(8)
+           │    │    └── prune: (8,10)
+           │    └── filters
+           │         └── e:8 > ‹×› [outer=(8), constraints=(‹×›; tight)]
+           └── projections
+                ├── ‹×› [as=crdb_internal_idx_expr_comp:16]
+                ├── ‹×› [as=e_new:15]
+                └── e:8 || ‹×› [as=crdb_internal_idx_expr:9, outer=(8), immutable]
 
 query T
 EXPLAIN (OPT, TYPES, REDACT) UPDATE e SET e = 'eee' WHERE e > 'a'
 ----
-update e
- ├── columns: <none>
- ├── fetch columns: e:8(string) crdb_internal_idx_expr:9(string) rowid:10(int)
- ├── update-mapping:
- │    ├── e_new:15 => e:1
- │    └── crdb_internal_idx_expr_comp:16 => crdb_internal_idx_expr:2
+distribute
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  ├── stats: [rows=0]
- ├── cost: 1132.21333
+ ├── cost: 1.1088e+53
  ├── distribution: test
- └── project
-      ├── columns: crdb_internal_idx_expr_comp:16(string!null) e_new:15(string!null) crdb_internal_idx_expr:9(string!null) e:8(string!null) rowid:10(int!null)
-      ├── immutable
-      ├── stats: [rows=333.3333]
-      ├── cost: 1132.20333
-      ├── key: (10)
-      ├── fd: ()-->(15,16), (10)-->(8), (8)-->(9)
-      ├── distribution: test
-      ├── prune: (8-10,15,16)
-      ├── select
-      │    ├── columns: e:8(string!null) rowid:10(int!null)
-      │    ├── stats: [rows=333.3333, distinct(8)=33.3333, null(8)=0]
-      │    ├── cost: 1118.85
-      │    ├── key: (10)
-      │    ├── fd: (10)-->(8)
-      │    ├── distribution: test
-      │    ├── scan e
-      │    │    ├── columns: e:8(string) rowid:10(int!null)
-      │    │    ├── computed column expressions
-      │    │    │    └── crdb_internal_idx_expr:9
-      │    │    │         └── concat [type=string]
-      │    │    │              ├── variable: e:8 [type=string]
-      │    │    │              └── const: ‹×› [type=string]
-      │    │    ├── stats: [rows=1000, distinct(8)=100, null(8)=10, distinct(10)=1000, null(10)=0]
-      │    │    ├── cost: 1108.82
-      │    │    ├── key: (10)
-      │    │    ├── fd: (10)-->(8)
-      │    │    ├── distribution: test
-      │    │    └── prune: (8,10)
-      │    └── filters
-      │         └── gt [type=bool, outer=(8), constraints=(‹×›; tight)]
-      │              ├── variable: e:8 [type=string]
-      │              └── const: ‹×› [type=string]
-      └── projections
-           ├── const: ‹×› [as=crdb_internal_idx_expr_comp:16, type=string]
-           ├── const: ‹×› [as=e_new:15, type=string]
-           └── concat [as=crdb_internal_idx_expr:9, type=string, outer=(8), immutable]
-                ├── variable: e:8 [type=string]
-                └── const: ‹×› [type=string]
+ ├── input distribution:
+ └── update e
+      ├── columns: <none>
+      ├── fetch columns: e:8(string) crdb_internal_idx_expr:9(string) rowid:10(int)
+      ├── update-mapping:
+      │    ├── e_new:15 => e:1
+      │    └── crdb_internal_idx_expr_comp:16 => crdb_internal_idx_expr:2
+      ├── cardinality: [0 - 0]
+      ├── volatile, mutations
+      ├── stats: [rows=0]
+      ├── cost: 1.1088e+53
+      └── project
+           ├── columns: crdb_internal_idx_expr_comp:16(string!null) e_new:15(string!null) crdb_internal_idx_expr:9(string!null) e:8(string!null) rowid:10(int!null)
+           ├── immutable
+           ├── stats: [rows=333.3333]
+           ├── cost: 1.1088e+53
+           ├── key: (10)
+           ├── fd: ()-->(15,16), (10)-->(8), (8)-->(9)
+           ├── prune: (8-10,15,16)
+           ├── select
+           │    ├── columns: e:8(string!null) rowid:10(int!null)
+           │    ├── stats: [rows=333.3333, distinct(8)=33.3333, null(8)=0]
+           │    ├── cost: 1.1088e+53
+           │    ├── key: (10)
+           │    ├── fd: (10)-->(8)
+           │    ├── scan e
+           │    │    ├── columns: e:8(string) rowid:10(int!null)
+           │    │    ├── computed column expressions
+           │    │    │    └── crdb_internal_idx_expr:9
+           │    │    │         └── concat [type=string]
+           │    │    │              ├── variable: e:8 [type=string]
+           │    │    │              └── const: ‹×› [type=string]
+           │    │    ├── flags: avoid-full-scan
+           │    │    ├── stats: [rows=1000, distinct(8)=100, null(8)=10, distinct(10)=1000, null(10)=0]
+           │    │    ├── cost: 1.1088e+53
+           │    │    ├── key: (10)
+           │    │    ├── fd: (10)-->(8)
+           │    │    └── prune: (8,10)
+           │    └── filters
+           │         └── gt [type=bool, outer=(8), constraints=(‹×›; tight)]
+           │              ├── variable: e:8 [type=string]
+           │              └── const: ‹×› [type=string]
+           └── projections
+                ├── const: ‹×› [as=crdb_internal_idx_expr_comp:16, type=string]
+                ├── const: ‹×› [as=e_new:15, type=string]
+                └── concat [as=crdb_internal_idx_expr:9, type=string, outer=(8), immutable]
+                     ├── variable: e:8 [type=string]
+                     └── const: ‹×› [type=string]
 
 query T
 EXPLAIN (OPT, MEMO, REDACT) UPDATE e SET e = 'eee' WHERE e > 'a'
@@ -1386,38 +1358,38 @@ memo (optimized, ~16KB, required=[presentation: info:17] [distribution: test])
  ├── G1: (explain G2 [distribution: test])
  │    └── [presentation: info:17] [distribution: test]
  │         ├── best: (explain G2="[distribution: test]" [distribution: test])
- │         └── cost: 1132.23
+ │         └── cost: 110880000000000030724457729200025180392225419481317376.00
  ├── G2: (update G3 G4 G5 e)
  │    ├── [distribution: test]
- │    │    ├── best: (update G3="[distribution: test]" G4 G5 e)
- │    │    └── cost: 1132.21
+ │    │    ├── best: (distribute G2)
+ │    │    └── cost: 110880000000000030724457729200025180392225419481317376.00
  │    └── []
  │         ├── best: (update G3 G4 G5 e)
- │         └── cost: 1132.21
+ │         └── cost: 110880000000000030724457729200025180392225419481317376.00
  ├── G3: (project G6 G7 e rowid)
  │    ├── [distribution: test]
- │    │    ├── best: (project G6="[distribution: test]" G7 e rowid)
- │    │    └── cost: 1132.20
+ │    │    ├── best: (distribute G3)
+ │    │    └── cost: 110880000000000030724457729200025180392225419481317376.00
  │    └── []
  │         ├── best: (project G6 G7 e rowid)
- │         └── cost: 1132.20
+ │         └── cost: 110880000000000030724457729200025180392225419481317376.00
  ├── G4: (unique-checks)
  ├── G5: (f-k-checks)
  ├── G6: (select G8 G9)
  │    ├── [distribution: test]
- │    │    ├── best: (select G8="[distribution: test]" G9)
- │    │    └── cost: 1118.85
+ │    │    ├── best: (distribute G6)
+ │    │    └── cost: 110880000000000030724457729200025180392225419481317376.00
  │    └── []
  │         ├── best: (select G8 G9)
- │         └── cost: 1118.85
+ │         └── cost: 110880000000000030724457729200025180392225419481317376.00
  ├── G7: (projections G10 G11 G12)
  ├── G8: (scan e,cols=(8,10))
  │    ├── [distribution: test]
- │    │    ├── best: (scan e,cols=(8,10))
- │    │    └── cost: 1108.82
+ │    │    ├── best: (distribute G8)
+ │    │    └── cost: 110880000000000030724457729200025180392225419481317376.00
  │    └── []
  │         ├── best: (scan e,cols=(8,10))
- │         └── cost: 1108.82
+ │         └── cost: 110880000000000030724457729200025180392225419481317376.00
  ├── G9: (filters G13)
  ├── G10: (const ‹×›)
  ├── G11: (const ‹×›)
@@ -1426,19 +1398,21 @@ memo (optimized, ~16KB, required=[presentation: info:17] [distribution: test])
  ├── G14: (variable e)
  ├── G15: (const ‹×›)
  └── G16: (const ‹×›)
-update e
- └── project
-      ├── select
-      │    ├── scan e
-      │    │    └── computed column expressions
-      │    │         └── crdb_internal_idx_expr
-      │    │              └── e || ‹×›
-      │    └── filters
-      │         └── e > ‹×›
-      └── projections
-           ├── ‹×›
-           ├── ‹×›
-           └── e || ‹×›
+distribute
+ └── update e
+      └── project
+           ├── select
+           │    ├── scan e
+           │    │    ├── computed column expressions
+           │    │    │    └── crdb_internal_idx_expr
+           │    │    │         └── e || ‹×›
+           │    │    └── flags: avoid-full-scan
+           │    └── filters
+           │         └── e > ‹×›
+           └── projections
+                ├── ‹×›
+                ├── ‹×›
+                └── e || ‹×›
 
 # Redaction of constants in deletes.
 
@@ -1491,7 +1465,8 @@ EXPLAIN (OPT, REDACT) DELETE FROM f WHERE f = 8.5
 delete f
  └── project
       ├── scan f@f_f_idx,partial
-      │    └── constraint: /7/8: ‹×›
+      │    ├── constraint: /7/8: ‹×›
+      │    └── flags: avoid-full-scan
       └── projections
            └── f > ‹×›
 
@@ -1518,6 +1493,7 @@ delete f
       ├── scan f@f_f_idx,partial
       │    ├── columns: f:7 rowid:8
       │    ├── constraint: /7/8: ‹×›
+      │    ├── flags: avoid-full-scan
       │    ├── stats: [rows=10, distinct(7)=1, null(7)=0]
       │    ├── cost: 28.8200001
       │    ├── key: (8)
@@ -1549,6 +1525,7 @@ delete f
       ├── scan f@f_f_idx,partial
       │    ├── columns: f:7(float!null) rowid:8(int!null)
       │    ├── constraint: /7/8: ‹×›
+      │    ├── flags: avoid-full-scan
       │    ├── stats: [rows=10, distinct(7)=1, null(7)=0]
       │    ├── cost: 28.8200001
       │    ├── key: (8)
@@ -1593,11 +1570,11 @@ memo (optimized, ~16KB, required=[presentation: info:14] [distribution: test])
  ├── G7: (projections G11)
  ├── G8: (scan f,cols=(7,8))
  │    ├── [distribution: test]
- │    │    ├── best: (scan f,cols=(7,8))
- │    │    └── cost: 1108.82
+ │    │    ├── best: (distribute G8)
+ │    │    └── cost: 110880000000000030724457729200025180392225419481317376.00
  │    └── []
  │         ├── best: (scan f,cols=(7,8))
- │         └── cost: 1108.82
+ │         └── cost: 110880000000000030724457729200025180392225419481317376.00
  ├── G9: (filters G12)
  ├── G10: (scan f@f_f_idx,partial,cols=(7,8))
  │    ├── [distribution: test]
@@ -1614,7 +1591,8 @@ memo (optimized, ~16KB, required=[presentation: info:14] [distribution: test])
 delete f
  └── project
       ├── scan f@f_f_idx,partial
-      │    └── constraint: /7/8: ‹×›
+      │    ├── constraint: /7/8: ‹×›
+      │    └── flags: avoid-full-scan
       └── projections
            └── f > ‹×›
 

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain_redact
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain_redact
@@ -1156,7 +1156,7 @@ update ab
 query T
 EXPLAIN (OPT, MEMO, REDACT) UPDATE ab SET a = a || 'ab' WHERE a > 'a'
 ----
-memo (optimized, ~13KB, required=[presentation: info:15] [distribution: test])
+memo (optimized, ~14KB, required=[presentation: info:15] [distribution: test])
  ├── G1: (explain G2 [distribution: test])
  │    └── [presentation: info:15] [distribution: test]
  │         ├── best: (explain G2="[distribution: test]" [distribution: test])
@@ -3825,7 +3825,7 @@ project
 query T
 EXPLAIN (OPT, MEMO, REDACT) SELECT min(c || 'cccc') OVER (ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING EXCLUDE CURRENT ROW) FROM cd
 ----
-memo (optimized, ~11KB, required=[presentation: info:10] [distribution: test])
+memo (optimized, ~12KB, required=[presentation: info:10] [distribution: test])
  ├── G1: (explain G2 [presentation: min:8] [distribution: test])
  │    └── [presentation: info:10] [distribution: test]
  │         ├── best: (explain G2="[presentation: min:8] [distribution: test]" [presentation: min:8] [distribution: test])

--- a/pkg/sql/opt/exec/execbuilder/testdata/fk
+++ b/pkg/sql/opt/exec/execbuilder/testdata/fk
@@ -135,17 +135,13 @@ vectorized: true
     │
     └── • error if rows
         │
-        └── • hash join (anti)
+        └── • lookup join (anti)
+            │ table: parent@parent_pkey
             │ equality: (y) = (p)
-            │ right cols are key
+            │ equality cols are key
             │
-            ├── • scan buffer
-            │     label: buffer 1
-            │
-            └── • scan
-                  missing stats
-                  table: parent@parent_pkey
-                  spans: FULL SCAN
+            └── • scan buffer
+                  label: buffer 1
 
 # Try again with implicit locking of the parent row.
 statement ok
@@ -174,18 +170,14 @@ vectorized: true
     │
     └── • error if rows
         │
-        └── • hash join (anti)
+        └── • lookup join (anti)
+            │ table: parent@parent_pkey
             │ equality: (y) = (p)
-            │ right cols are key
+            │ equality cols are key
+            │ locking strength: for share
             │
-            ├── • scan buffer
-            │     label: buffer 1
-            │
-            └── • scan
-                  missing stats
-                  table: parent@parent_pkey
-                  spans: FULL SCAN
-                  locking strength: for share
+            └── • scan buffer
+                  label: buffer 1
 
 statement ok
 RESET enable_implicit_fk_locking_for_serializable
@@ -620,17 +612,13 @@ vectorized: true
     │
     └── • error if rows
         │
-        └── • merge join (anti)
+        └── • lookup join (anti)
+            │ table: parent@parent_pkey
             │ equality: (p_new) = (p)
-            │ right cols are key
+            │ equality cols are key
             │
-            ├── • scan buffer
-            │     label: buffer 1
-            │
-            └── • scan
-                  missing stats
-                  table: parent@parent_pkey
-                  spans: FULL SCAN
+            └── • scan buffer
+                  label: buffer 1
 
 # Try again with implicit locking of the parent row.
 statement ok
@@ -663,18 +651,14 @@ vectorized: true
     │
     └── • error if rows
         │
-        └── • merge join (anti)
+        └── • lookup join (anti)
+            │ table: parent@parent_pkey
             │ equality: (p_new) = (p)
-            │ right cols are key
+            │ equality cols are key
+            │ locking strength: for share
             │
-            ├── • scan buffer
-            │     label: buffer 1
-            │
-            └── • scan
-                  missing stats
-                  table: parent@parent_pkey
-                  spans: FULL SCAN
-                  locking strength: for share
+            └── • scan buffer
+                  label: buffer 1
 
 # Try again with durable locking enabled.
 statement ok
@@ -684,18 +668,20 @@ SET enable_durable_locking_for_serializable = true
 query T
 EXPLAIN (OPT) UPDATE child SET p = 4
 ----
-update child
- ├── project
- │    ├── scan child
- │    └── projections
- │         └── 4
- └── f-k-checks
-      └── f-k-checks-item: child(p) -> parent(p)
-           └── anti-join (merge)
-                ├── with-scan &1
-                ├── scan parent
-                │    └── locking: for-share,durability-guaranteed
-                └── filters (true)
+distribute
+ └── update child
+      ├── project
+      │    ├── scan child
+      │    │    └── flags: avoid-full-scan
+      │    └── projections
+      │         └── 4
+      └── f-k-checks
+           └── f-k-checks-item: child(p) -> parent(p)
+                └── anti-join (lookup parent)
+                     ├── lookup columns are key
+                     ├── locking: for-share,durability-guaranteed
+                     ├── with-scan &1
+                     └── filters (true)
 
 statement ok
 RESET enable_durable_locking_for_serializable
@@ -808,53 +794,33 @@ vectorized: true
 │   │
 │   └── • error if rows
 │       │
-│       └── • hash join
+│       └── • lookup join (semi)
+│           │ table: child@child_p_idx
 │           │ equality: (p) = (p)
-│           │ left cols are key
-│           │ right cols are key
 │           │
-│           ├── • except all
-│           │   │
-│           │   ├── • scan buffer
-│           │   │     label: buffer 1
-│           │   │
-│           │   └── • scan buffer
-│           │         label: buffer 1
-│           │
-│           └── • distinct
-│               │ distinct on: p
-│               │ order key: p
+│           └── • except all
 │               │
-│               └── • scan
-│                     missing stats
-│                     table: child@child_p_idx
-│                     spans: FULL SCAN
+│               ├── • scan buffer
+│               │     label: buffer 1
+│               │
+│               └── • scan buffer
+│                     label: buffer 1
 │
 └── • constraint-check
     │
     └── • error if rows
         │
-        └── • hash join
+        └── • lookup join (semi)
+            │ table: child_nullable@child_nullable_p_idx
             │ equality: (p) = (p)
-            │ left cols are key
-            │ right cols are key
             │
-            ├── • except all
-            │   │
-            │   ├── • scan buffer
-            │   │     label: buffer 1
-            │   │
-            │   └── • scan buffer
-            │         label: buffer 1
-            │
-            └── • distinct
-                │ distinct on: p
-                │ order key: p
+            └── • except all
                 │
-                └── • scan
-                      missing stats
-                      table: child_nullable@child_nullable_p_idx
-                      spans: FULL SCAN
+                ├── • scan buffer
+                │     label: buffer 1
+                │
+                └── • scan buffer
+                      label: buffer 1
 
 query T
 EXPLAIN UPDATE parent SET p = p+1 WHERE other = 10
@@ -941,10 +907,9 @@ vectorized: true
     │
     └── • error if rows
         │
-        └── • hash join
+        └── • hash join (semi)
             │ equality: (c) = (c)
             │ left cols are key
-            │ right cols are key
             │
             ├── • except all
             │   │
@@ -954,13 +919,10 @@ vectorized: true
             │   └── • scan buffer
             │         label: buffer 1
             │
-            └── • distinct
-                │ distinct on: c
-                │
-                └── • scan
-                      missing stats
-                      table: grandchild@grandchild_pkey
-                      spans: FULL SCAN
+            └── • scan
+                  missing stats
+                  table: grandchild@grandchild_pkey
+                  spans: FULL SCAN
 
 # Even with implicit locking enabled, we should not acquire any shared locks
 # when checking an update of the parent (in this case the child is parent of the
@@ -995,10 +957,9 @@ vectorized: true
     │
     └── • error if rows
         │
-        └── • hash join
+        └── • hash join (semi)
             │ equality: (c) = (c)
             │ left cols are key
-            │ right cols are key
             │
             ├── • except all
             │   │
@@ -1008,13 +969,10 @@ vectorized: true
             │   └── • scan buffer
             │         label: buffer 1
             │
-            └── • distinct
-                │ distinct on: c
-                │
-                └── • scan
-                      missing stats
-                      table: grandchild@grandchild_pkey
-                      spans: FULL SCAN
+            └── • scan
+                  missing stats
+                  table: grandchild@grandchild_pkey
+                  spans: FULL SCAN
 
 statement ok
 RESET enable_implicit_fk_locking_for_serializable
@@ -1047,17 +1005,13 @@ vectorized: true
     │
     └── • error if rows
         │
-        └── • merge join (anti)
+        └── • lookup join (anti)
+            │ table: parent@parent_pkey
             │ equality: (p_new) = (p)
-            │ right cols are key
+            │ equality cols are key
             │
-            ├── • scan buffer
-            │     label: buffer 1
-            │
-            └── • scan
-                  missing stats
-                  table: parent@parent_pkey
-                  spans: FULL SCAN
+            └── • scan buffer
+                  label: buffer 1
 
 # Try again with implicit locking of the parent row.
 statement ok
@@ -1090,18 +1044,14 @@ vectorized: true
     │
     └── • error if rows
         │
-        └── • merge join (anti)
+        └── • lookup join (anti)
+            │ table: parent@parent_pkey
             │ equality: (p_new) = (p)
-            │ right cols are key
+            │ equality cols are key
+            │ locking strength: for share
             │
-            ├── • scan buffer
-            │     label: buffer 1
-            │
-            └── • scan
-                  missing stats
-                  table: parent@parent_pkey
-                  spans: FULL SCAN
-                  locking strength: for share
+            └── • scan buffer
+                  label: buffer 1
 
 statement ok
 RESET enable_implicit_fk_locking_for_serializable
@@ -1131,17 +1081,13 @@ vectorized: true
     │
     └── • error if rows
         │
-        └── • hash join (anti)
+        └── • lookup join (anti)
+            │ table: parent@parent_pkey
             │ equality: (p) = (p)
-            │ right cols are key
+            │ equality cols are key
             │
-            ├── • scan buffer
-            │     label: buffer 1
-            │
-            └── • scan
-                  missing stats
-                  table: parent@parent_pkey
-                  spans: FULL SCAN
+            └── • scan buffer
+                  label: buffer 1
 
 query T
 EXPLAIN UPDATE child SET p = p+1, c = c+1
@@ -1170,26 +1116,21 @@ vectorized: true
 │   │
 │   └── • error if rows
 │       │
-│       └── • hash join (anti)
+│       └── • lookup join (anti)
+│           │ table: parent@parent_pkey
 │           │ equality: (p_new) = (p)
-│           │ right cols are key
+│           │ equality cols are key
 │           │
-│           ├── • scan buffer
-│           │     label: buffer 1
-│           │
-│           └── • scan
-│                 missing stats
-│                 table: parent@parent_pkey
-│                 spans: FULL SCAN
+│           └── • scan buffer
+│                 label: buffer 1
 │
 └── • constraint-check
     │
     └── • error if rows
         │
-        └── • hash join
+        └── • hash join (semi)
             │ equality: (c) = (c)
             │ left cols are key
-            │ right cols are key
             │
             ├── • except all
             │   │
@@ -1199,13 +1140,10 @@ vectorized: true
             │   └── • scan buffer
             │         label: buffer 1
             │
-            └── • distinct
-                │ distinct on: c
-                │
-                └── • scan
-                      missing stats
-                      table: grandchild@grandchild_pkey
-                      spans: FULL SCAN
+            └── • scan
+                  missing stats
+                  table: grandchild@grandchild_pkey
+                  spans: FULL SCAN
 
 # Try again with implicit locking of the parent row.
 statement ok
@@ -1238,27 +1176,22 @@ vectorized: true
 │   │
 │   └── • error if rows
 │       │
-│       └── • hash join (anti)
+│       └── • lookup join (anti)
+│           │ table: parent@parent_pkey
 │           │ equality: (p_new) = (p)
-│           │ right cols are key
+│           │ equality cols are key
+│           │ locking strength: for share
 │           │
-│           ├── • scan buffer
-│           │     label: buffer 1
-│           │
-│           └── • scan
-│                 missing stats
-│                 table: parent@parent_pkey
-│                 spans: FULL SCAN
-│                 locking strength: for share
+│           └── • scan buffer
+│                 label: buffer 1
 │
 └── • constraint-check
     │
     └── • error if rows
         │
-        └── • hash join
+        └── • hash join (semi)
             │ equality: (c) = (c)
             │ left cols are key
-            │ right cols are key
             │
             ├── • except all
             │   │
@@ -1268,13 +1201,10 @@ vectorized: true
             │   └── • scan buffer
             │         label: buffer 1
             │
-            └── • distinct
-                │ distinct on: c
-                │
-                └── • scan
-                      missing stats
-                      table: grandchild@grandchild_pkey
-                      spans: FULL SCAN
+            └── • scan
+                  missing stats
+                  table: grandchild@grandchild_pkey
+                  spans: FULL SCAN
 
 statement ok
 RESET enable_implicit_fk_locking_for_serializable
@@ -1310,17 +1240,13 @@ vectorized: true
     │
     └── • error if rows
         │
-        └── • merge join (anti)
+        └── • lookup join (anti)
+            │ table: parent@parent_pkey
             │ equality: (p_new) = (p)
-            │ right cols are key
+            │ equality cols are key
             │
-            ├── • scan buffer
-            │     label: buffer 1
-            │
-            └── • scan
-                  missing stats
-                  table: parent@parent_pkey
-                  spans: FULL SCAN
+            └── • scan buffer
+                  label: buffer 1
 
 statement ok
 CREATE TABLE self (x INT PRIMARY KEY, y INT NOT NULL REFERENCES self(x))
@@ -1352,17 +1278,13 @@ vectorized: true
     │
     └── • error if rows
         │
-        └── • merge join (anti)
+        └── • lookup join (anti)
+            │ table: self@self_pkey
             │ equality: (y_new) = (x)
-            │ right cols are key
+            │ equality cols are key
             │
-            ├── • scan buffer
-            │     label: buffer 1
-            │
-            └── • scan
-                  missing stats
-                  table: self@self_pkey
-                  spans: FULL SCAN
+            └── • scan buffer
+                  label: buffer 1
 
 # Try again with implicit locking of the parent row.
 statement ok
@@ -1395,18 +1317,14 @@ vectorized: true
     │
     └── • error if rows
         │
-        └── • merge join (anti)
+        └── • lookup join (anti)
+            │ table: self@self_pkey
             │ equality: (y_new) = (x)
-            │ right cols are key
+            │ equality cols are key
+            │ locking strength: for share
             │
-            ├── • scan buffer
-            │     label: buffer 1
-            │
-            └── • scan
-                  missing stats
-                  table: self@self_pkey
-                  spans: FULL SCAN
-                  locking strength: for share
+            └── • scan buffer
+                  label: buffer 1
 
 statement ok
 RESET enable_implicit_fk_locking_for_serializable
@@ -1438,10 +1356,9 @@ vectorized: true
     │
     └── • error if rows
         │
-        └── • hash join
+        └── • hash join (semi)
             │ equality: (x) = (y)
             │ left cols are key
-            │ right cols are key
             │
             ├── • except all
             │   │
@@ -1451,13 +1368,10 @@ vectorized: true
             │   └── • scan buffer
             │         label: buffer 1
             │
-            └── • distinct
-                │ distinct on: y
-                │
-                └── • scan
-                      missing stats
-                      table: self@self_pkey
-                      spans: FULL SCAN
+            └── • scan
+                  missing stats
+                  table: self@self_pkey
+                  spans: FULL SCAN
 
 # Even with implicit locking enabled, we should not acquire any shared locks
 # when checking an update of the parent.
@@ -1491,10 +1405,9 @@ vectorized: true
     │
     └── • error if rows
         │
-        └── • hash join
+        └── • hash join (semi)
             │ equality: (x) = (y)
             │ left cols are key
-            │ right cols are key
             │
             ├── • except all
             │   │
@@ -1504,13 +1417,10 @@ vectorized: true
             │   └── • scan buffer
             │         label: buffer 1
             │
-            └── • distinct
-                │ distinct on: y
-                │
-                └── • scan
-                      missing stats
-                      table: self@self_pkey
-                      spans: FULL SCAN
+            └── • scan
+                  missing stats
+                  table: self@self_pkey
+                  spans: FULL SCAN
 
 statement ok
 RESET enable_implicit_fk_locking_for_serializable
@@ -1749,33 +1659,24 @@ vectorized: true
         └── • project
             │ columns: (c)
             │
-            └── • project
+            └── • hash join (semi)
                 │ columns: (c, p)
+                │ estimated row count: 100 (missing stats)
+                │ equality: (p) = (p)
                 │
-                └── • hash join (inner)
-                    │ columns: (c, p, p)
-                    │ estimated row count: 90 (missing stats)
-                    │ equality: (p) = (p)
-                    │ right cols are key
+                ├── • scan
+                │     columns: (c, p)
+                │     estimated row count: 1,000 (missing stats)
+                │     table: cascadechild@cascadechild_pkey
+                │     spans: FULL SCAN
+                │
+                └── • project
+                    │ columns: (p)
                     │
-                    ├── • scan
-                    │     columns: (c, p)
-                    │     estimated row count: 1,000 (missing stats)
-                    │     table: cascadechild@cascadechild_pkey
-                    │     spans: FULL SCAN
-                    │
-                    └── • distinct
-                        │ columns: (p)
-                        │ estimated row count: 10
-                        │ distinct on: p
-                        │
-                        └── • project
-                            │ columns: (p)
-                            │
-                            └── • scan buffer
-                                  columns: (p, data)
-                                  estimated row count: 100
-                                  label: buffer 1000000
+                    └── • scan buffer
+                          columns: (p, data)
+                          estimated row count: 100
+                          label: buffer 1000000
 
 statement ok
 CREATE TABLE a (
@@ -1893,34 +1794,11 @@ EXPLAIN INSERT INTO c VALUES (1,1), (2,2), (3,3), (4,4), (5,5), (6,6), (7,7), (8
 distribution: local
 vectorized: true
 ·
-• root
-│
-├── • insert
-│   │ into: c(c, p)
-│   │
-│   └── • buffer
-│       │ label: buffer 1
-│       │
-│       └── • values
-│             size: 2 columns, 10 rows
-│
-└── • constraint-check
-    │
-    └── • error if rows
-        │
-        └── • hash join (anti)
-            │ estimated row count: 9
-            │ equality: (column2) = (p)
-            │ right cols are key
-            │
-            ├── • scan buffer
-            │     estimated row count: 10
-            │     label: buffer 1
-            │
-            └── • scan
-                  estimated row count: 1 (100% of the table; stats collected <hidden> ago)
-                  table: p@p_pkey
-                  spans: FULL SCAN
+• insert fast path
+  into: c(c, p)
+  auto commit
+  FK check: p@p_pkey
+  size: 2 columns, 10 rows
 
 query T
 EXPLAIN UPDATE c SET p=p+c WHERE c > 0
@@ -1949,23 +1827,19 @@ vectorized: true
     │
     └── • error if rows
         │
-        └── • hash join (anti)
+        └── • lookup join (anti)
             │ estimated row count: 32
+            │ table: p@p_pkey
             │ equality: (p_new) = (p)
-            │ right cols are key
+            │ equality cols are key
             │
-            ├── • filter
-            │   │ estimated row count: 33
-            │   │ filter: p_new IS NOT NULL
-            │   │
-            │   └── • scan buffer
-            │         estimated row count: 33
-            │         label: buffer 1
-            │
-            └── • scan
-                  estimated row count: 1 (100% of the table; stats collected <hidden> ago)
-                  table: p@p_pkey
-                  spans: FULL SCAN
+            └── • filter
+                │ estimated row count: 33
+                │ filter: p_new IS NOT NULL
+                │
+                └── • scan buffer
+                      estimated row count: 33
+                      label: buffer 1
 
 
 query T
@@ -2138,19 +2012,15 @@ vectorized: true
     │
     └── • error if rows
         │
-        └── • hash join (anti)
+        └── • lookup join (anti)
             │ estimated row count: 0
+            │ table: small_parent@small_parent_pkey
             │ equality: (?column?) = (p)
-            │ right cols are key
+            │ equality cols are key
             │
-            ├── • scan buffer
-            │     estimated row count: 10
-            │     label: buffer 1
-            │
-            └── • scan
-                  estimated row count: 10 (100% of the table; stats collected <hidden> ago)
-                  table: small_parent@small_parent_pkey
-                  spans: FULL SCAN
+            └── • scan buffer
+                  estimated row count: 10
+                  label: buffer 1
 
 # Test that partial indexes with IS NOT NULL predicates are used for performing
 # FK checks.

--- a/pkg/sql/opt/exec/execbuilder/testdata/fk_read_committed
+++ b/pkg/sql/opt/exec/execbuilder/testdata/fk_read_committed
@@ -122,7 +122,8 @@ EXPLAIN (OPT) UPDATE cookies SET j = 2 WHERE c = 1
 update cookies
  ├── project
  │    ├── scan cookies
- │    │    └── constraint: /7: [/1 - /1]
+ │    │    ├── constraint: /7: [/1 - /1]
+ │    │    └── flags: avoid-full-scan
  │    └── projections
  │         └── 2
  └── f-k-checks
@@ -191,22 +192,24 @@ vectorized: true
 query T
 EXPLAIN (OPT) UPDATE jars SET j = j + 4
 ----
-update jars
- ├── project
- │    ├── scan jars
- │    └── projections
- │         └── jars.j + 4
- └── f-k-checks
-      └── f-k-checks-item: cookies(j) -> jars(j)
-           └── project
-                └── inner-join (hash)
-                     ├── except-all
-                     │    ├── with-scan &1
-                     │    └── with-scan &1
-                     ├── distinct-on
-                     │    └── scan cookies
-                     └── filters
-                          └── j = cookies.j
+distribute
+ └── update jars
+      ├── project
+      │    ├── scan jars
+      │    │    └── flags: avoid-full-scan
+      │    └── projections
+      │         └── jars.j + 4
+      └── f-k-checks
+           └── f-k-checks-item: cookies(j) -> jars(j)
+                └── distribute
+                     └── semi-join (hash)
+                          ├── except-all
+                          │    ├── with-scan &1
+                          │    └── with-scan &1
+                          ├── scan cookies
+                          │    └── flags: avoid-full-scan
+                          └── filters
+                               └── j = cookies.j
 
 query T
 EXPLAIN (VERBOSE) UPDATE jars SET j = j + 4
@@ -244,60 +247,55 @@ vectorized: true
     └── • error if rows
         │ columns: ()
         │
-        └── • project
+        └── • hash join (semi)
             │ columns: (j)
+            │ estimated row count: 100 (missing stats)
+            │ equality: (j) = (j)
+            │ left cols are key
             │
-            └── • hash join (inner)
-                │ columns: (j, j)
-                │ estimated row count: 99 (missing stats)
-                │ equality: (j) = (j)
-                │ left cols are key
-                │ right cols are key
-                │
-                ├── • except all
-                │   │ columns: (j)
-                │   │ estimated row count: 1,000 (missing stats)
-                │   │
-                │   ├── • project
-                │   │   │ columns: (j)
-                │   │   │
-                │   │   └── • scan buffer
-                │   │         columns: (j, j_new)
-                │   │         estimated row count: 1,000 (missing stats)
-                │   │         label: buffer 1
-                │   │
-                │   └── • project
-                │       │ columns: (j_new)
-                │       │
-                │       └── • scan buffer
-                │             columns: (j, j_new)
-                │             estimated row count: 1,000 (missing stats)
-                │             label: buffer 1
-                │
-                └── • distinct
-                    │ columns: (j)
-                    │ estimated row count: 100 (missing stats)
-                    │ distinct on: j
-                    │
-                    └── • scan
-                          columns: (j)
-                          estimated row count: 1,000 (missing stats)
-                          table: cookies@cookies_pkey
-                          spans: FULL SCAN
+            ├── • except all
+            │   │ columns: (j)
+            │   │ estimated row count: 1,000 (missing stats)
+            │   │
+            │   ├── • project
+            │   │   │ columns: (j)
+            │   │   │
+            │   │   └── • scan buffer
+            │   │         columns: (j, j_new)
+            │   │         estimated row count: 1,000 (missing stats)
+            │   │         label: buffer 1
+            │   │
+            │   └── • project
+            │       │ columns: (j_new)
+            │       │
+            │       └── • scan buffer
+            │             columns: (j, j_new)
+            │             estimated row count: 1,000 (missing stats)
+            │             label: buffer 1
+            │
+            └── • scan
+                  columns: (j)
+                  estimated row count: 1,000 (missing stats)
+                  table: cookies@cookies_pkey
+                  spans: FULL SCAN
 
 query T
 EXPLAIN (OPT) DELETE FROM jars WHERE j = 1
 ----
-delete jars
- ├── scan jars
- │    └── constraint: /6: [/1 - /1]
- └── f-k-checks
-      └── f-k-checks-item: cookies(j) -> jars(j)
-           └── semi-join (hash)
-                ├── with-scan &1
-                ├── scan cookies
-                └── filters
-                     └── j = cookies.j
+distribute
+ └── delete jars
+      ├── scan jars
+      │    ├── constraint: /6: [/1 - /1]
+      │    └── flags: avoid-full-scan
+      └── f-k-checks
+           └── f-k-checks-item: cookies(j) -> jars(j)
+                └── distribute
+                     └── semi-join (hash)
+                          ├── with-scan &1
+                          ├── scan cookies
+                          │    └── flags: avoid-full-scan
+                          └── filters
+                               └── j = cookies.j
 
 query T
 EXPLAIN (VERBOSE) DELETE FROM jars WHERE j = 1

--- a/pkg/sql/opt/exec/execbuilder/testdata/not_visible_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/not_visible_index
@@ -895,27 +895,17 @@ vectorized: true
     │
     └── • error if rows
         │
-        └── • hash join
+        └── • lookup join (semi)
+            │ table: child@c_idx_invisible
             │ equality: (p) = (p)
-            │ left cols are key
-            │ right cols are key
             │
-            ├── • except all
-            │   │
-            │   ├── • scan buffer
-            │   │     label: buffer 1
-            │   │
-            │   └── • scan buffer
-            │         label: buffer 1
-            │
-            └── • distinct
-                │ distinct on: p
-                │ order key: p
+            └── • except all
                 │
-                └── • scan
-                      missing stats
-                      table: child@c_idx_invisible
-                      spans: FULL SCAN
+                ├── • scan buffer
+                │     label: buffer 1
+                │
+                └── • scan buffer
+                      label: buffer 1
 
 statement ok
 DROP TABLE child
@@ -1116,22 +1106,12 @@ vectorized: true
     │
     └── • error if rows
         │
-        └── • hash join
+        └── • lookup join (semi)
+            │ table: child_update@c_update_idx_invisible
             │ equality: (p) = (p)
-            │ left cols are key
-            │ right cols are key
             │
-            ├── • scan buffer
-            │     label: buffer 1
-            │
-            └── • distinct
-                │ distinct on: p
-                │ order key: p
-                │
-                └── • scan
-                      missing stats
-                      table: child_update@c_update_idx_invisible
-                      spans: FULL SCAN
+            └── • scan buffer
+                  label: buffer 1
 
 # c_delete_idx_invisible is used for constraint check (update on a parent table
 # requires FK check).
@@ -1170,13 +1150,9 @@ vectorized: true
 │       │   └── • buffer
 │       │       │ label: buffer 1
 │       │       │
-│       │       └── • hash join
+│       │       └── • lookup join
+│       │           │ table: child_update@c_update_idx_invisible
 │       │           │ equality: (p) = (p)
-│       │           │
-│       │           ├── • scan
-│       │           │     missing stats
-│       │           │     table: child_update@child_update_pkey
-│       │           │     spans: FULL SCAN
 │       │           │
 │       │           └── • filter
 │       │               │ estimated row count: 33
@@ -1190,14 +1166,10 @@ vectorized: true
 │           │
 │           └── • error if rows
 │               │
-│               └── • hash join (right anti)
-│                   │ equality: (p) = (p_new)
-│                   │ left cols are key
-│                   │
-│                   ├── • scan
-│                   │     missing stats
-│                   │     table: parent@parent_pkey
-│                   │     spans: FULL SCAN
+│               └── • lookup join (anti)
+│                   │ table: parent@parent_pkey
+│                   │ equality: (p_new) = (p)
+│                   │ equality cols are key
 │                   │
 │                   └── • scan buffer
 │                         label: buffer 1
@@ -1206,27 +1178,17 @@ vectorized: true
     │
     └── • error if rows
         │
-        └── • hash join
+        └── • lookup join (semi)
+            │ table: child_delete@c_delete_idx_invisible
             │ equality: (p) = (p)
-            │ left cols are key
-            │ right cols are key
             │
-            ├── • except all
-            │   │
-            │   ├── • scan buffer
-            │   │     label: buffer 1
-            │   │
-            │   └── • scan buffer
-            │         label: buffer 1
-            │
-            └── • distinct
-                │ distinct on: p
-                │ order key: p
+            └── • except all
                 │
-                └── • scan
-                      missing stats
-                      table: child_delete@c_delete_idx_invisible
-                      spans: FULL SCAN
+                ├── • scan buffer
+                │     label: buffer 1
+                │
+                └── • scan buffer
+                      label: buffer 1
 
 statement ok
 DROP TABLE child_delete

--- a/pkg/sql/opt/exec/execbuilder/testdata/schema_change_in_txn
+++ b/pkg/sql/opt/exec/execbuilder/testdata/schema_change_in_txn
@@ -36,7 +36,7 @@ query T kvtrace(prefix=/Table/106/)
 UPSERT INTO t SELECT a + 1 FROM t
 ----
 Scan /Table/106/{1-2}
-Scan /Table/106/{1-2}
+Scan /Table/106/1/10{1-2}, /Table/106/1/10{2-3}
 Put /Table/106/1/101/0 -> /TUPLE/2:2:Decimal/1000.2/1:3:Bytes/empty
 Put /Table/106/1/101/1/1 -> /TUPLE/4:4:Decimal/0.00/2:6:Decimal/1101.2
 CPut /Table/106/1/102/0 -> /TUPLE/2:2:Decimal/1000.2/1:3:Bytes/empty

--- a/pkg/sql/opt/exec/execbuilder/testdata/select_for_update_read_committed
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select_for_update_read_committed
@@ -54,7 +54,8 @@ UPDATE supermarket
 update supermarket
  └── project
       ├── scan supermarket
-      │    └── constraint: /9: [/'michael' - /'michael']
+      │    ├── constraint: /9: [/'michael' - /'michael']
+      │    └── flags: avoid-full-scan
       └── projections
            └── subquery
                 └── project

--- a/pkg/sql/opt/exec/execbuilder/testdata/unique
+++ b/pkg/sql/opt/exec/execbuilder/testdata/unique
@@ -358,15 +358,17 @@ vectorized: true
 │ arbiter indexes: uniq_pkey, uniq_v_key
 │ arbiter constraints: unique_w, unique_x_y
 │
-└── • cross join (right anti)
+└── • hash join (right anti)
     │ columns: (column1, column2, column3, column4, column5)
     │ estimated row count: 0 (missing stats)
+    │ equality: (x, y) = (column4, column5)
+    │ right cols are key
     │
     ├── • scan
-    │     columns: (k)
-    │     estimated row count: 1 (missing stats)
+    │     columns: (x, y)
+    │     estimated row count: 1,000 (missing stats)
     │     table: uniq@uniq_pkey
-    │     spans: /1/0
+    │     spans: FULL SCAN
     │
     └── • hash join (right anti)
         │ columns: (column1, column2, column3, column4, column5)
@@ -387,26 +389,24 @@ vectorized: true
             │ equality: (column2) = (v)
             │ equality cols are key
             │
-            └── • hash join (right anti)
+            └── • cross join (anti)
                 │ columns: (column1, column2, column3, column4, column5)
                 │ estimated row count: 0 (missing stats)
-                │ equality: (x, y) = (column4, column5)
-                │ right cols are key
                 │
-                ├── • scan
-                │     columns: (x, y)
-                │     estimated row count: 1,000 (missing stats)
-                │     table: uniq@uniq_pkey
-                │     spans: FULL SCAN
+                ├── • values
+                │     columns: (column1, column2, column3, column4, column5)
+                │     size: 5 columns, 1 row
+                │     row 0, expr 0: 1
+                │     row 0, expr 1: 2
+                │     row 0, expr 2: 3
+                │     row 0, expr 3: 4
+                │     row 0, expr 4: 5
                 │
-                └── • values
-                      columns: (column1, column2, column3, column4, column5)
-                      size: 5 columns, 1 row
-                      row 0, expr 0: 1
-                      row 0, expr 1: 2
-                      row 0, expr 2: 3
-                      row 0, expr 3: 4
-                      row 0, expr 4: 5
+                └── • scan
+                      columns: (k)
+                      estimated row count: 1 (missing stats)
+                      table: uniq@uniq_pkey
+                      spans: /1/0
 
 # Insert with non-constant input.
 query T
@@ -3782,25 +3782,27 @@ vectorized: true
 │       │
 │       └── • render
 │           │
-│           └── • hash join (left outer)
-│               │ equality: (v) = (v)
+│           └── • lookup join (left outer)
+│               │ table: uniq@uniq_pkey
+│               │ equality: (k) = (k)
+│               │ equality cols are key
 │               │
-│               ├── • distinct
-│               │   │ distinct on: v
-│               │   │ nulls are distinct
-│               │   │ error on duplicate
-│               │   │
-│               │   └── • render
-│               │       │
-│               │       └── • scan
-│               │             missing stats
-│               │             table: other@other_pkey
-│               │             spans: FULL SCAN
-│               │
-│               └── • scan
-│                     missing stats
-│                     table: uniq@uniq_pkey
-│                     spans: FULL SCAN
+│               └── • lookup join (left outer)
+│                   │ table: uniq@uniq_v_key
+│                   │ equality: (v) = (v)
+│                   │ equality cols are key
+│                   │
+│                   └── • distinct
+│                       │ distinct on: v
+│                       │ nulls are distinct
+│                       │ error on duplicate
+│                       │
+│                       └── • render
+│                           │
+│                           └── • scan
+│                                 missing stats
+│                                 table: other@other_pkey
+│                                 spans: FULL SCAN
 │
 ├── • constraint-check
 │   │
@@ -3853,18 +3855,19 @@ vectorized: true
 │       │
 │       └── • render
 │           │
-│           └── • hash join (right outer)
-│               │ equality: (w) = (column3)
+│           └── • hash join (left outer)
+│               │ equality: (column3) = (w)
 │               │
-│               ├── • scan
-│               │     missing stats
-│               │     table: uniq@uniq_pkey
-│               │     spans: FULL SCAN
+│               ├── • render
+│               │   │
+│               │   └── • values
+│               │         size: 3 columns, 2 rows
 │               │
-│               └── • render
-│                   │
-│                   └── • values
-│                         size: 3 columns, 2 rows
+│               └── • scan
+│                     missing stats
+│                     table: uniq@uniq_pkey
+│                     spans: FULL SCAN
+│                     locking strength: for update
 │
 ├── • constraint-check
 │   │
@@ -3943,17 +3946,13 @@ vectorized: true
     │
     └── • error if rows
         │
-        └── • hash join (semi)
+        └── • lookup join (semi)
+            │ table: uniq_overlaps_pk@uniq_overlaps_pk_pkey
             │ equality: (k) = (a)
             │ pred: v != b
             │
-            ├── • scan buffer
-            │     label: buffer 1
-            │
-            └── • scan
-                  missing stats
-                  table: uniq_overlaps_pk@uniq_overlaps_pk_pkey
-                  spans: FULL SCAN
+            └── • scan buffer
+                  label: buffer 1
 
 # Upsert with non-constant input.
 # Add inequality filters for the hidden primary key column.
@@ -4657,28 +4656,28 @@ vectorized: true
 │       │
 │       └── • render
 │           │
-│           └── • hash join (right outer)
-│               │ equality: (a) = (column2)
+│           └── • hash join (left outer)
+│               │ equality: (column2) = (a)
 │               │ pred: b_default > 0
 │               │
-│               ├── • filter
-│               │   │ filter: b > 0
+│               ├── • distinct
+│               │   │ estimated row count: 2
+│               │   │ distinct on: arbiter_unique_a_distinct, column2
+│               │   │ nulls are distinct
+│               │   │ error on duplicate
 │               │   │
-│               │   └── • scan
-│               │         missing stats
-│               │         table: uniq_partial@uniq_partial_pkey
-│               │         spans: FULL SCAN
+│               │   └── • render
+│               │       │
+│               │       └── • values
+│               │             size: 2 columns, 2 rows
 │               │
-│               └── • distinct
-│                   │ estimated row count: 2
-│                   │ distinct on: arbiter_unique_a_distinct, column2
-│                   │ nulls are distinct
-│                   │ error on duplicate
+│               └── • filter
+│                   │ filter: b > 0
 │                   │
-│                   └── • render
-│                       │
-│                       └── • values
-│                             size: 2 columns, 2 rows
+│                   └── • scan
+│                         missing stats
+│                         table: uniq_partial@uniq_partial_pkey
+│                         spans: FULL SCAN
 │
 ├── • constraint-check
 │   │
@@ -5705,13 +5704,70 @@ VALUES (1,1,1,1)
 distribution: local
 vectorized: true
 ·
-• insert fast path
-  into: multiple_uniq_partial(a, b, c, d, rowid)
-  auto commit
-  uniqueness check: multiple_uniq_partial@multiple_uniq_partial_b_c_idx
-  uniqueness check: multiple_uniq_partial@multiple_uniq_partial_a_b_d_idx
-  uniqueness check: multiple_uniq_partial@multiple_uniq_partial_a_b_d_idx
-  size: 7 columns, 1 row
+• root
+│
+├── • insert
+│   │ into: multiple_uniq_partial(a, b, c, d, rowid)
+│   │
+│   └── • buffer
+│       │ label: buffer 1
+│       │
+│       └── • values
+│             size: 7 columns, 1 row
+│
+├── • constraint-check
+│   │
+│   └── • error if rows
+│       │
+│       └── • hash join (right semi)
+│           │ equality: (b, c) = (column2, column3)
+│           │ right cols are key
+│           │ pred: rowid_default != rowid
+│           │
+│           ├── • scan
+│           │     missing stats
+│           │     table: multiple_uniq_partial@multiple_uniq_partial_pkey
+│           │     spans: FULL SCAN
+│           │
+│           └── • scan buffer
+│                 estimated row count: 1
+│                 label: buffer 1
+│
+├── • constraint-check
+│   │
+│   └── • error if rows
+│       │
+│       └── • hash join (right semi)
+│           │ equality: (a, b, d) = (column1, column2, column4)
+│           │ right cols are key
+│           │ pred: rowid_default != rowid
+│           │
+│           ├── • scan
+│           │     missing stats
+│           │     table: multiple_uniq_partial@multiple_uniq_partial_pkey
+│           │     spans: FULL SCAN
+│           │
+│           └── • scan buffer
+│                 estimated row count: 1
+│                 label: buffer 1
+│
+└── • constraint-check
+    │
+    └── • error if rows
+        │
+        └── • hash join (right semi)
+            │ equality: (a) = (column1)
+            │ right cols are key
+            │ pred: rowid_default != rowid
+            │
+            ├── • scan
+            │     missing stats
+            │     table: multiple_uniq_partial@multiple_uniq_partial_pkey
+            │     spans: FULL SCAN
+            │
+            └── • scan buffer
+                  estimated row count: 1
+                  label: buffer 1
 
 # A table with multiple unique without index checks and only partial indexes
 # to cover them is eligible for insert fast path if it is determined,

--- a/pkg/sql/opt/exec/execbuilder/testdata/update
+++ b/pkg/sql/opt/exec/execbuilder/testdata/update
@@ -201,6 +201,9 @@ CREATE INDEX y_idx ON xyz (y)
 
 # Ensure that we can use a hint to avoid a full table scan.
 
+statement ok
+SET avoid_full_table_scans_in_mutations = false
+
 # Without the hint, we plan a full table scan.
 query T
 EXPLAIN (VERBOSE) UPDATE xyz SET x = 5 WHERE (y > 0 AND y < 1000) OR (y > 2000 AND y < 3000)
@@ -303,6 +306,45 @@ vectorized: true
               spans: /1-/1000 /2001-/3000
               locking strength: for update
 
+# We also avoid the full scan using the session setting
+# avoid_full_table_scans_in_mutations.
+statement ok
+SET avoid_full_table_scans_in_mutations = true
+
+query T
+EXPLAIN (VERBOSE) UPDATE xyz SET x = 5 WHERE (y > 0 AND y < 1000) OR (y > 2000 AND y < 3000)
+----
+distribution: local
+vectorized: true
+·
+• update
+│ columns: ()
+│ estimated row count: 0 (missing stats)
+│ table: xyz
+│ set: x
+│ auto commit
+│
+└── • render
+    │ columns: (x, y, z, x_new)
+    │ render x_new: 5
+    │ render x: x
+    │ render y: y
+    │ render z: z
+    │
+    └── • index join
+        │ columns: (x, y, z)
+        │ estimated row count: 990 (missing stats)
+        │ table: xyz@xyz_pkey
+        │ key columns: x
+        │ locking strength: for update
+        │
+        └── • scan
+              columns: (x, y)
+              estimated row count: 990 (missing stats)
+              table: xyz@y_idx
+              spans: /1-/1000 /2001-/3000
+              locking strength: for update
+
 statement ok
 CREATE TABLE pks (
   k1 INT,
@@ -359,14 +401,16 @@ vectorized: true
 │
 └── • render
     │
-    └── • top-k
-        │ order: -v
-        │ k: 10
+    └── • limit
+        │ count: 10
         │
-        └── • scan
-              missing stats
-              table: kv@kv_pkey
-              spans: FULL SCAN
+        └── • sort
+            │ order: -v
+            │
+            └── • scan
+                  missing stats
+                  table: kv@kv_pkey
+                  spans: FULL SCAN
 
 # Use case for UPDATE ... ORDER BY: renumbering a PK without unique violation.
 query T

--- a/pkg/sql/opt/exec/execbuilder/testdata/update
+++ b/pkg/sql/opt/exec/execbuilder/testdata/update
@@ -268,6 +268,41 @@ vectorized: true
               spans: /1-/1000 /2001-/3000
               locking strength: for update
 
+# AVOID_FULL_SCAN also works to ensure a constrained scan.
+query T
+EXPLAIN (VERBOSE) UPDATE xyz@{AVOID_FULL_SCAN} SET x = 5 WHERE (y > 0 AND y < 1000) OR (y > 2000 AND y < 3000)
+----
+distribution: local
+vectorized: true
+·
+• update
+│ columns: ()
+│ estimated row count: 0 (missing stats)
+│ table: xyz
+│ set: x
+│ auto commit
+│
+└── • render
+    │ columns: (x, y, z, x_new)
+    │ render x_new: 5
+    │ render x: x
+    │ render y: y
+    │ render z: z
+    │
+    └── • index join
+        │ columns: (x, y, z)
+        │ estimated row count: 990 (missing stats)
+        │ table: xyz@xyz_pkey
+        │ key columns: x
+        │ locking strength: for update
+        │
+        └── • scan
+              columns: (x, y)
+              estimated row count: 990 (missing stats)
+              table: xyz@y_idx
+              spans: /1-/1000 /2001-/3000
+              locking strength: for update
+
 statement ok
 CREATE TABLE pks (
   k1 INT,

--- a/pkg/sql/opt/exec/execbuilder/testdata/update_from
+++ b/pkg/sql/opt/exec/execbuilder/testdata/update_from
@@ -43,14 +43,10 @@ vectorized: true
 └── • distinct
     │ distinct on: a
     │
-    └── • hash join
+    └── • lookup join
+        │ table: abc@abc_pkey
         │ equality: (a) = (a)
-        │ left cols are key
-        │
-        ├── • scan
-        │     missing stats
-        │     table: abc@abc_pkey
-        │     spans: FULL SCAN
+        │ equality cols are key
         │
         └── • scan
               missing stats
@@ -180,14 +176,10 @@ vectorized: true
         │     table: ab@ab_pkey
         │     spans: FULL SCAN
         │
-        └── • hash join
+        └── • lookup join
+            │ table: abc@abc_pkey
             │ equality: (a) = (a)
-            │ left cols are key
-            │
-            ├── • scan
-            │     missing stats
-            │     table: abc@abc_pkey
-            │     spans: FULL SCAN
+            │ equality cols are key
             │
             └── • scan
                   missing stats
@@ -226,14 +218,10 @@ vectorized: true
         │     table: ab@ab_pkey
         │     spans: FULL SCAN
         │
-        └── • hash join
+        └── • lookup join
+            │ table: abc@abc_pkey
             │ equality: (a) = (a)
-            │ left cols are key
-            │
-            ├── • scan
-            │     missing stats
-            │     table: abc@abc_pkey
-            │     spans: FULL SCAN
+            │ equality cols are key
             │
             └── • scan
                   missing stats

--- a/pkg/sql/opt/exec/execbuilder/testdata/upsert
+++ b/pkg/sql/opt/exec/execbuilder/testdata/upsert
@@ -410,6 +410,112 @@ vectorized: true
 query error could not produce a query plan conforming to the NO_FULL_SCAN hint
 EXPLAIN (VERBOSE) UPSERT INTO indexed@{FORCE_INDEX=secondary,NO_FULL_SCAN} VALUES (1)
 
+# AVOID_FULL_SCAN also works to ensure a constrained scan, and does not error if
+# one is not possible.
+query T
+EXPLAIN (VERBOSE) UPSERT INTO indexed@{AVOID_FULL_SCAN} VALUES (1)
+----
+distribution: local
+vectorized: true
+·
+• upsert
+│ columns: ()
+│ estimated row count: 0 (missing stats)
+│ into: indexed(a, b, c, d)
+│ auto commit
+│ arbiter indexes: indexed_pkey
+│
+└── • project
+    │ columns: (column1, b_default, c_default, d_comp, a, b, c, d, b_default, c_default, d_comp, a, check1)
+    │
+    └── • render
+        │ columns: (check1, column1, b_default, c_default, d_comp, a, b, c, d)
+        │ render check1: c_default > 0
+        │ render column1: column1
+        │ render b_default: b_default
+        │ render c_default: c_default
+        │ render d_comp: d_comp
+        │ render a: a
+        │ render b: b
+        │ render c: c
+        │ render d: d
+        │
+        └── • cross join (left outer)
+            │ columns: (column1, b_default, c_default, d_comp, a, b, c, d)
+            │ estimated row count: 1 (missing stats)
+            │
+            ├── • values
+            │     columns: (column1, b_default, c_default, d_comp)
+            │     size: 4 columns, 1 row
+            │     row 0, expr 0: 1
+            │     row 0, expr 1: CAST(NULL AS INT8)
+            │     row 0, expr 2: 10
+            │     row 0, expr 3: 11
+            │
+            └── • scan
+                  columns: (a, b, c, d)
+                  estimated row count: 1 (missing stats)
+                  table: indexed@indexed_pkey
+                  spans: /1/0
+                  locking strength: for update
+
+query T
+EXPLAIN (VERBOSE) UPSERT INTO indexed@{FORCE_INDEX=secondary,AVOID_FULL_SCAN} VALUES (1)
+----
+distribution: local
+vectorized: true
+·
+• upsert
+│ columns: ()
+│ estimated row count: 0 (missing stats)
+│ into: indexed(a, b, c, d)
+│ auto commit
+│ arbiter indexes: indexed_pkey
+│
+└── • project
+    │ columns: (column1, b_default, c_default, d_comp, a, b, c, d, b_default, c_default, d_comp, a, check1)
+    │
+    └── • render
+        │ columns: (check1, column1, b_default, c_default, d_comp, a, b, c, d)
+        │ render check1: c_default > 0
+        │ render column1: column1
+        │ render b_default: b_default
+        │ render c_default: c_default
+        │ render d_comp: d_comp
+        │ render a: a
+        │ render b: b
+        │ render c: c
+        │ render d: d
+        │
+        └── • cross join (left outer)
+            │ columns: (column1, b_default, c_default, d_comp, a, b, c, d)
+            │ estimated row count: 1 (missing stats)
+            │
+            ├── • values
+            │     columns: (column1, b_default, c_default, d_comp)
+            │     size: 4 columns, 1 row
+            │     row 0, expr 0: 1
+            │     row 0, expr 1: CAST(NULL AS INT8)
+            │     row 0, expr 2: 10
+            │     row 0, expr 3: 11
+            │
+            └── • filter
+                │ columns: (a, b, c, d)
+                │ estimated row count: 1 (missing stats)
+                │ filter: a = 1
+                │
+                └── • index join
+                    │ columns: (a, b, c, d)
+                    │ estimated row count: 1,000 (missing stats)
+                    │ table: indexed@indexed_pkey
+                    │ key columns: a
+                    │
+                    └── • scan
+                          columns: (a, b, d)
+                          estimated row count: 1,000 (missing stats)
+                          table: indexed@secondary
+                          spans: FULL SCAN
+
 query T
 EXPLAIN (VERBOSE)
 INSERT INTO indexed@indexed_pkey AS indexed_pk

--- a/pkg/sql/opt/exec/execbuilder/testdata/upsert
+++ b/pkg/sql/opt/exec/execbuilder/testdata/upsert
@@ -360,6 +360,9 @@ vectorized: true
                           table: indexed@secondary
                           spans: FULL SCAN
 
+statement ok
+SET avoid_full_table_scans_in_mutations = false
+
 query T
 EXPLAIN (VERBOSE) UPSERT INTO indexed@{NO_FULL_SCAN} VALUES (1)
 ----
@@ -515,6 +518,58 @@ vectorized: true
                           estimated row count: 1,000 (missing stats)
                           table: indexed@secondary
                           spans: FULL SCAN
+
+# We also avoid the full scan using the session setting
+# avoid_full_table_scans_in_mutations.
+statement ok
+SET avoid_full_table_scans_in_mutations = true
+
+query T
+EXPLAIN (VERBOSE) UPSERT INTO indexed VALUES (1)
+----
+distribution: local
+vectorized: true
+·
+• upsert
+│ columns: ()
+│ estimated row count: 0 (missing stats)
+│ into: indexed(a, b, c, d)
+│ auto commit
+│ arbiter indexes: indexed_pkey
+│
+└── • project
+    │ columns: (column1, b_default, c_default, d_comp, a, b, c, d, b_default, c_default, d_comp, a, check1)
+    │
+    └── • render
+        │ columns: (check1, column1, b_default, c_default, d_comp, a, b, c, d)
+        │ render check1: c_default > 0
+        │ render column1: column1
+        │ render b_default: b_default
+        │ render c_default: c_default
+        │ render d_comp: d_comp
+        │ render a: a
+        │ render b: b
+        │ render c: c
+        │ render d: d
+        │
+        └── • cross join (left outer)
+            │ columns: (column1, b_default, c_default, d_comp, a, b, c, d)
+            │ estimated row count: 1 (missing stats)
+            │
+            ├── • values
+            │     columns: (column1, b_default, c_default, d_comp)
+            │     size: 4 columns, 1 row
+            │     row 0, expr 0: 1
+            │     row 0, expr 1: CAST(NULL AS INT8)
+            │     row 0, expr 2: 10
+            │     row 0, expr 3: 11
+            │
+            └── • scan
+                  columns: (a, b, c, d)
+                  estimated row count: 1 (missing stats)
+                  table: indexed@indexed_pkey
+                  spans: /1/0
+                  locking strength: for update
 
 query T
 EXPLAIN (VERBOSE)
@@ -942,22 +997,15 @@ vectorized: true
         │ render b: b
         │ render c: c
         │
-        └── • merge join (right outer)
-            │ columns: (a, b, c, x, y, z)
+        └── • lookup join (left outer)
+            │ columns: (x, y, z, a, b, c)
             │ estimated row count: 311 (missing stats)
-            │ equality: (b, c) = (y, z)
-            │ merge ordering: +"(b=y)",+"(c=z)"
-            │
-            ├── • scan
-            │     columns: (a, b, c)
-            │     ordering: +b,+c
-            │     estimated row count: 1,000 (missing stats)
-            │     table: target@target_b_c_key
-            │     spans: FULL SCAN
+            │ table: target@target_b_c_key
+            │ equality: (y, z) = (b, c)
+            │ equality cols are key
             │
             └── • distinct
                 │ columns: (x, y, z)
-                │ ordering: +y,+z
                 │ estimated row count: 311 (missing stats)
                 │ distinct on: y, z
                 │ nulls are distinct

--- a/pkg/sql/opt/exec/execbuilder/testdata/virtual_columns
+++ b/pkg/sql/opt/exec/execbuilder/testdata/virtual_columns
@@ -1296,50 +1296,50 @@ vectorized: true
         │ render v: v
         │ render w: w
         │
-        └── • hash join (right outer)
-            │ columns: (v, w, a, b, c, v_comp, w_comp, column1, column2, column3)
+        └── • hash join (left outer)
+            │ columns: (v_comp, w_comp, column1, column2, column3, v, w, a, b, c)
             │ estimated row count: 20 (missing stats)
-            │ equality: (w) = (w_comp)
-            │ right cols are key
+            │ equality: (w_comp) = (w)
+            │ left cols are key
             │
-            ├── • render
-            │   │ columns: (v, w, a, b, c)
-            │   │ render v: a + b
-            │   │ render w: c + 1
-            │   │ render a: a
-            │   │ render b: b
-            │   │ render c: c
+            ├── • distinct
+            │   │ columns: (v_comp, w_comp, column1, column2, column3)
+            │   │ estimated row count: 2
+            │   │ distinct on: w_comp
+            │   │ nulls are distinct
+            │   │ error on duplicate
             │   │
-            │   └── • scan
-            │         columns: (a, b, c)
-            │         estimated row count: 1,000 (missing stats)
-            │         table: t_idx@t_idx_pkey
-            │         spans: FULL SCAN
+            │   └── • render
+            │       │ columns: (v_comp, w_comp, column1, column2, column3)
+            │       │ render v_comp: column1 + column2
+            │       │ render w_comp: column3 + 1
+            │       │ render column1: column1
+            │       │ render column2: column2
+            │       │ render column3: column3
+            │       │
+            │       └── • values
+            │             columns: (column1, column2, column3)
+            │             size: 3 columns, 2 rows
+            │             row 0, expr 0: 8
+            │             row 0, expr 1: 80
+            │             row 0, expr 2: 800
+            │             row 1, expr 0: 10
+            │             row 1, expr 1: 100
+            │             row 1, expr 2: 700
             │
-            └── • distinct
-                │ columns: (v_comp, w_comp, column1, column2, column3)
-                │ estimated row count: 2
-                │ distinct on: w_comp
-                │ nulls are distinct
-                │ error on duplicate
+            └── • render
+                │ columns: (v, w, a, b, c)
+                │ render v: a + b
+                │ render w: c + 1
+                │ render a: a
+                │ render b: b
+                │ render c: c
                 │
-                └── • render
-                    │ columns: (v_comp, w_comp, column1, column2, column3)
-                    │ render v_comp: column1 + column2
-                    │ render w_comp: column3 + 1
-                    │ render column1: column1
-                    │ render column2: column2
-                    │ render column3: column3
-                    │
-                    └── • values
-                          columns: (column1, column2, column3)
-                          size: 3 columns, 2 rows
-                          row 0, expr 0: 8
-                          row 0, expr 1: 80
-                          row 0, expr 2: 800
-                          row 1, expr 0: 10
-                          row 1, expr 1: 100
-                          row 1, expr 2: 700
+                └── • scan
+                      columns: (a, b, c)
+                      estimated row count: 1,000 (missing stats)
+                      table: t_idx@t_idx_pkey
+                      spans: FULL SCAN
 
 subtest Checks
 

--- a/pkg/sql/opt/memo/expr.go
+++ b/pkg/sql/opt/memo/expr.go
@@ -409,6 +409,9 @@ type ScanFlags struct {
 	// NoFullScan disallows use of a full scan for scanning this table.
 	NoFullScan bool
 
+	// AvoidFullScan avoids use of a full scan for scanning this table.
+	AvoidFullScan bool
+
 	// ForceIndex forces the use of a specific index (specified in Index).
 	// ForceIndex and NoIndexJoin cannot both be set at the same time.
 	ForceIndex bool

--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -514,6 +514,9 @@ func (f *ExprFmtCtx) formatRelational(e RelExpr, tp treeprinter.Node) {
 			if private.Flags.NoFullScan {
 				b.WriteString(" no-full-scan")
 			}
+			if private.Flags.AvoidFullScan {
+				b.WriteString(" avoid-full-scan")
+			}
 			if private.Flags.ForceZigzag {
 				if private.Flags.ZigzagIndexes.Empty() {
 					b.WriteString(" force-zigzag")

--- a/pkg/sql/opt/memo/interner.go
+++ b/pkg/sql/opt/memo/interner.go
@@ -509,6 +509,7 @@ func (h *hasher) HashScanFlags(val ScanFlags) {
 	h.HashBool(val.NoIndexJoin)
 	h.HashBool(val.NoZigzagJoin)
 	h.HashBool(val.NoFullScan)
+	h.HashBool(val.AvoidFullScan)
 	h.HashBool(val.ForceIndex)
 	h.HashBool(val.ForceInvertedIndex)
 	h.HashBool(val.ForceZigzag)

--- a/pkg/sql/opt/memo/interner_test.go
+++ b/pkg/sql/opt/memo/interner_test.go
@@ -402,7 +402,7 @@ func TestInterner(t *testing.T) {
 		{hashFn: in.hasher.HashScanFlags, eqFn: in.hasher.IsScanFlagsEqual, variations: []testVariation{
 			// Use unnamed fields so that compilation fails if a new field is
 			// added to ScanFlags.
-			{val1: ScanFlags{false, false, false, false, false, false, false, 0, 0, intsets.Fast{}}, val2: ScanFlags{}, equal: true},
+			{val1: ScanFlags{false, false, false, false, false, false, false, false, 0, 0, intsets.Fast{}}, val2: ScanFlags{}, equal: true},
 			{val1: ScanFlags{}, val2: ScanFlags{}, equal: true},
 			{val1: ScanFlags{NoIndexJoin: false}, val2: ScanFlags{NoIndexJoin: true}, equal: false},
 			{val1: ScanFlags{NoIndexJoin: true}, val2: ScanFlags{NoIndexJoin: true}, equal: true},
@@ -417,6 +417,8 @@ func TestInterner(t *testing.T) {
 			{val1: ScanFlags{NoIndexJoin: true, Index: 1}, val2: ScanFlags{NoIndexJoin: false, Index: 1}, equal: false},
 			{val1: ScanFlags{NoFullScan: true}, val2: ScanFlags{NoFullScan: false}, equal: false},
 			{val1: ScanFlags{NoFullScan: true}, val2: ScanFlags{NoFullScan: true}, equal: true},
+			{val1: ScanFlags{AvoidFullScan: true}, val2: ScanFlags{AvoidFullScan: false}, equal: false},
+			{val1: ScanFlags{AvoidFullScan: true}, val2: ScanFlags{AvoidFullScan: true}, equal: true},
 			{val1: ScanFlags{ForceInvertedIndex: true}, val2: ScanFlags{ForceInvertedIndex: false}, equal: false},
 			{val1: ScanFlags{ForceInvertedIndex: true}, val2: ScanFlags{ForceInvertedIndex: true}, equal: true},
 			{

--- a/pkg/sql/opt/memo/memo.go
+++ b/pkg/sql/opt/memo/memo.go
@@ -159,6 +159,7 @@ type Memo struct {
 	intervalStyle                              duration.IntervalStyle
 	propagateInputOrdering                     bool
 	disallowFullTableScans                     bool
+	avoidFullTableScansInMutations             bool
 	largeFullScanRows                          float64
 	txnRowsReadErr                             int64
 	nullOrderedLast                            bool
@@ -248,6 +249,7 @@ func (m *Memo) Init(ctx context.Context, evalCtx *eval.Context) {
 		intervalStyle:                              evalCtx.SessionData().GetIntervalStyle(),
 		propagateInputOrdering:                     evalCtx.SessionData().PropagateInputOrdering,
 		disallowFullTableScans:                     evalCtx.SessionData().DisallowFullTableScans,
+		avoidFullTableScansInMutations:             evalCtx.SessionData().AvoidFullTableScansInMutations,
 		largeFullScanRows:                          evalCtx.SessionData().LargeFullScanRows,
 		txnRowsReadErr:                             evalCtx.SessionData().TxnRowsReadErr,
 		nullOrderedLast:                            evalCtx.SessionData().NullOrderedLast,
@@ -415,6 +417,7 @@ func (m *Memo) IsStale(
 		m.intervalStyle != evalCtx.SessionData().GetIntervalStyle() ||
 		m.propagateInputOrdering != evalCtx.SessionData().PropagateInputOrdering ||
 		m.disallowFullTableScans != evalCtx.SessionData().DisallowFullTableScans ||
+		m.avoidFullTableScansInMutations != evalCtx.SessionData().AvoidFullTableScansInMutations ||
 		m.largeFullScanRows != evalCtx.SessionData().LargeFullScanRows ||
 		m.txnRowsReadErr != evalCtx.SessionData().TxnRowsReadErr ||
 		m.nullOrderedLast != evalCtx.SessionData().NullOrderedLast ||

--- a/pkg/sql/opt/memo/memo_test.go
+++ b/pkg/sql/opt/memo/memo_test.go
@@ -294,6 +294,12 @@ func TestMemoIsStale(t *testing.T) {
 	evalCtx.SessionData().DisallowFullTableScans = false
 	notStale()
 
+	// Stale avoid full table scan.
+	evalCtx.SessionData().AvoidFullTableScansInMutations = true
+	stale()
+	evalCtx.SessionData().AvoidFullTableScansInMutations = false
+	notStale()
+
 	// Stale large full scan rows.
 	evalCtx.SessionData().LargeFullScanRows = 1000
 	stale()

--- a/pkg/sql/opt/memo/testdata/logprops/delete
+++ b/pkg/sql/opt/memo/testdata/logprops/delete
@@ -40,6 +40,7 @@ delete abcde
       │    │              │    ├── variable: b:10 [type=int]
       │    │              │    └── variable: c:11 [type=int]
       │    │              └── const: 1 [type=int]
+      │    ├── flags: avoid-full-scan
       │    ├── key: (13)
       │    ├── fd: (13)-->(9-12,14-16), (10,11)-->(12)
       │    ├── prune: (9-16)
@@ -85,6 +86,7 @@ project
            │    │              │    ├── variable: b:10 [type=int]
            │    │              │    └── variable: c:11 [type=int]
            │    │              └── const: 1 [type=int]
+           │    ├── flags: avoid-full-scan
            │    ├── key: (13)
            │    ├── fd: (13)-->(9-12,14-16), (10,11)-->(12)
            │    ├── prune: (9-16)
@@ -133,6 +135,7 @@ project
            │    │              │    ├── variable: b:10 [type=int]
            │    │              │    └── variable: c:11 [type=int]
            │    │              └── const: 1 [type=int]
+           │    ├── flags: avoid-full-scan
            │    ├── key: (13)
            │    ├── fd: (13)-->(9-12,14-16), (10,11)-->(12)
            │    ├── prune: (9-16)
@@ -178,6 +181,7 @@ project
            │    │              │    ├── variable: b:10 [type=int]
            │    │              │    └── variable: c:11 [type=int]
            │    │              └── const: 1 [type=int]
+           │    ├── flags: avoid-full-scan
            │    ├── key: (13)
            │    ├── fd: (13)-->(9-12,14-16), (10,11)-->(12)
            │    ├── prune: (9-16)

--- a/pkg/sql/opt/memo/testdata/logprops/update
+++ b/pkg/sql/opt/memo/testdata/logprops/update
@@ -63,6 +63,7 @@ update abcde
       │    │    │    │    │              │    ├── variable: b:10 [type=int]
       │    │    │    │    │              │    └── variable: c:11 [type=int]
       │    │    │    │    │              └── const: 1 [type=int]
+      │    │    │    │    ├── flags: avoid-full-scan
       │    │    │    │    ├── key: (13)
       │    │    │    │    ├── fd: (13)-->(9-12,14-16), (10,11)-->(12)
       │    │    │    │    ├── prune: (9-16)
@@ -141,6 +142,7 @@ project
            │    │    │    │    │              │    ├── variable: b:10 [type=int]
            │    │    │    │    │              │    └── variable: c:11 [type=int]
            │    │    │    │    │              └── const: 1 [type=int]
+           │    │    │    │    ├── flags: avoid-full-scan
            │    │    │    │    ├── key: (13)
            │    │    │    │    ├── fd: (13)-->(9-12,14-16), (10,11)-->(12)
            │    │    │    │    ├── prune: (9-16)
@@ -222,6 +224,7 @@ project
            │    │    │    │    │              │    ├── variable: b:10 [type=int]
            │    │    │    │    │              │    └── variable: c:11 [type=int]
            │    │    │    │    │              └── const: 1 [type=int]
+           │    │    │    │    ├── flags: avoid-full-scan
            │    │    │    │    ├── key: (13)
            │    │    │    │    ├── fd: (13)-->(9-12,14-16), (10,11)-->(12)
            │    │    │    │    ├── prune: (9-16)
@@ -299,6 +302,7 @@ project
            │    │    │    │    │              │    ├── variable: b:10 [type=int]
            │    │    │    │    │              │    └── variable: c:11 [type=int]
            │    │    │    │    │              └── const: 1 [type=int]
+           │    │    │    │    ├── flags: avoid-full-scan
            │    │    │    │    ├── key: (13)
            │    │    │    │    ├── fd: (13)-->(9-12,14-16), (10,11)-->(12)
            │    │    │    │    ├── prune: (9-16)

--- a/pkg/sql/opt/memo/testdata/logprops/upsert
+++ b/pkg/sql/opt/memo/testdata/logprops/upsert
@@ -151,6 +151,7 @@ project
            │    │    │    │    │         └── plus [type=int]
            │    │    │    │    │              ├── variable: b:15 [type=int]
            │    │    │    │    │              └── const: 1 [type=int]
+           │    │    │    │    ├── flags: avoid-full-scan
            │    │    │    │    ├── key: (17)
            │    │    │    │    ├── fd: (17)-->(14-16,18,19), (14)-->(15-19), (15,16)~~>(14,17-19), (15)-->(16)
            │    │    │    │    ├── prune: (14-19)
@@ -316,6 +317,7 @@ project
            │    │    │    │    │    │    │         └── plus [type=int]
            │    │    │    │    │    │    │              ├── variable: b:15 [type=int]
            │    │    │    │    │    │    │              └── const: 1 [type=int]
+           │    │    │    │    │    │    ├── flags: avoid-full-scan
            │    │    │    │    │    │    ├── key: (17)
            │    │    │    │    │    │    ├── fd: (17)-->(14-16), (14)-->(15-17), (15,16)~~>(14,17), (15)-->(16)
            │    │    │    │    │    │    ├── prune: (14-17)
@@ -332,6 +334,7 @@ project
            │    │    │    │    │    │         └── plus [type=int]
            │    │    │    │    │    │              ├── variable: b:21 [type=int]
            │    │    │    │    │    │              └── const: 1 [type=int]
+           │    │    │    │    │    ├── flags: avoid-full-scan
            │    │    │    │    │    ├── key: (23)
            │    │    │    │    │    ├── fd: (23)-->(20-22), (20)-->(21-23), (21,22)~~>(20,23), (21)-->(22)
            │    │    │    │    │    ├── prune: (20-23)
@@ -348,6 +351,7 @@ project
            │    │    │    │    │         └── plus [type=int]
            │    │    │    │    │              ├── variable: b:27 [type=int]
            │    │    │    │    │              └── const: 1 [type=int]
+           │    │    │    │    ├── flags: avoid-full-scan
            │    │    │    │    ├── key: (29)
            │    │    │    │    ├── fd: (29)-->(26-28), (26)-->(27-29), (27,28)~~>(26,29), (27)-->(28)
            │    │    │    │    ├── prune: (26-29)
@@ -485,6 +489,7 @@ project
  │         │    │    │    │         └── plus [type=int]
  │         │    │    │    │              ├── variable: b:12 [type=int]
  │         │    │    │    │              └── const: 1 [type=int]
+ │         │    │    │    ├── flags: avoid-full-scan
  │         │    │    │    ├── key: (14)
  │         │    │    │    ├── fd: (14)-->(11-13,15,16), (11)-->(12-16), (12,13)~~>(11,14-16), (12)-->(13)
  │         │    │    │    ├── prune: (11-16)
@@ -644,6 +649,7 @@ upsert abc
       │    │    │    │    │         └── plus [type=int]
       │    │    │    │    │              ├── variable: b:16 [type=int]
       │    │    │    │    │              └── const: 1 [type=int]
+      │    │    │    │    ├── flags: avoid-full-scan
       │    │    │    │    ├── key: (18)
       │    │    │    │    ├── fd: (18)-->(15-17,19,20), (15)-->(16-20), (16,17)~~>(15,18-20), (16)-->(17)
       │    │    │    │    ├── prune: (15-20)

--- a/pkg/sql/opt/memo/testdata/stats/delete
+++ b/pkg/sql/opt/memo/testdata/stats/delete
@@ -62,6 +62,7 @@ with &1
  │         ├── fd: ()-->(8), (6)-->(7,9,10)
  │         ├── scan xyz
  │         │    ├── columns: xyz.x:6(string!null) xyz.y:7(int!null) xyz.z:8(float) crdb_internal_mvcc_timestamp:9(decimal) tableoid:10(oid)
+ │         │    ├── flags: avoid-full-scan
  │         │    ├── stats: [rows=1000, distinct(6)=1000, null(6)=0, distinct(7)=100, null(7)=0, distinct(8)=100, null(8)=10]
  │         │    ├── key: (6)
  │         │    └── fd: (6)-->(7-10)
@@ -108,6 +109,7 @@ delete xyz
       ├── fd: (6)-->(7-10)
       ├── scan xyz
       │    ├── columns: x:6(string!null) y:7(int!null) z:8(float) crdb_internal_mvcc_timestamp:9(decimal) tableoid:10(oid)
+      │    ├── flags: avoid-full-scan
       │    ├── stats: [rows=1000]
       │    ├── key: (6)
       │    └── fd: (6)-->(7-10)

--- a/pkg/sql/opt/memo/testdata/stats/update
+++ b/pkg/sql/opt/memo/testdata/stats/update
@@ -69,6 +69,7 @@ with &1
  │         │    ├── fd: ()-->(8), (6)-->(7,9,10)
  │         │    ├── scan xyz
  │         │    │    ├── columns: xyz.x:6(string!null) xyz.y:7(int!null) xyz.z:8(float) crdb_internal_mvcc_timestamp:9(decimal) tableoid:10(oid)
+ │         │    │    ├── flags: avoid-full-scan
  │         │    │    ├── stats: [rows=1000, distinct(6)=1000, null(6)=0, distinct(7)=100, null(7)=0, distinct(8)=100, null(8)=10]
  │         │    │    ├── key: (6)
  │         │    │    └── fd: (6)-->(7-10)
@@ -124,6 +125,7 @@ update xyz
       │    ├── fd: (6)-->(7-10)
       │    ├── scan xyz
       │    │    ├── columns: x:6(string!null) y:7(int!null) z:8(float) crdb_internal_mvcc_timestamp:9(decimal) tableoid:10(oid)
+      │    │    ├── flags: avoid-full-scan
       │    │    ├── stats: [rows=1000]
       │    │    ├── key: (6)
       │    │    └── fd: (6)-->(7-10)
@@ -189,6 +191,7 @@ with &2 (q)
  │         │    │    │    ├── fd: (8)-->(6,7,9,10), (11)-->(12,13)
  │         │    │    │    ├── scan child
  │         │    │    │    │    ├── columns: x:6(int) child.c:7(int) rowid:8(int!null) child.crdb_internal_mvcc_timestamp:9(decimal) child.tableoid:10(oid)
+ │         │    │    │    │    ├── flags: avoid-full-scan
  │         │    │    │    │    ├── stats: [rows=1000, distinct(8)=1000, null(8)=0]
  │         │    │    │    │    ├── key: (8)
  │         │    │    │    │    └── fd: (8)-->(6,7,9,10)
@@ -229,6 +232,7 @@ with &2 (q)
  │                        │    └── fd: ()-->(14)
  │                        ├── scan parent
  │                        │    ├── columns: parent.p:15(int!null)
+ │                        │    ├── flags: avoid-full-scan
  │                        │    ├── stats: [rows=1000, distinct(15)=1000, null(15)=0]
  │                        │    └── key: (15)
  │                        └── filters

--- a/pkg/sql/opt/memo/testdata/stats/upsert
+++ b/pkg/sql/opt/memo/testdata/stats/upsert
@@ -169,6 +169,7 @@ with &1
  │         │    │    │              └── z_default:12 [type=float]
  │         │    │    ├── scan xyz
  │         │    │    │    ├── columns: xyz.x:13(string!null) xyz.y:14(int!null) xyz.z:15(float) xyz.crdb_internal_mvcc_timestamp:16(decimal) xyz.tableoid:17(oid)
+ │         │    │    │    ├── flags: avoid-full-scan
  │         │    │    │    ├── stats: [rows=1000, distinct(13)=1000, null(13)=0]
  │         │    │    │    ├── key: (13)
  │         │    │    │    └── fd: (13)-->(14-17)
@@ -306,6 +307,7 @@ upsert uv
       │    │    │              └── u_default:11 [type=int]
       │    │    ├── scan uv
       │    │    │    ├── columns: u:12(int!null) v:13(int) uv.crdb_internal_mvcc_timestamp:14(decimal) uv.tableoid:15(oid)
+      │    │    │    ├── flags: avoid-full-scan
       │    │    │    ├── stats: [rows=1000, distinct(13)=991, null(13)=10]
       │    │    │    ├── key: (12)
       │    │    │    └── fd: (12)-->(13-15), (13)~~>(12,14,15)
@@ -380,6 +382,7 @@ upsert mno
       │    │    │              └── m:6 [type=int]
       │    │    ├── scan mno
       │    │    │    ├── columns: m:11(int!null) n:12(int) o:13(int) crdb_internal_mvcc_timestamp:14(decimal) tableoid:15(oid)
+      │    │    │    ├── flags: avoid-full-scan
       │    │    │    ├── stats: [rows=2000, distinct(12)=100, null(12)=10, distinct(13)=1900, null(13)=100]
       │    │    │    ├── key: (11)
       │    │    │    └── fd: (11)-->(12-15), (12,13)~~>(11,14,15)

--- a/pkg/sql/opt/norm/testdata/rules/decorrelate
+++ b/pkg/sql/opt/norm/testdata/rules/decorrelate
@@ -82,6 +82,7 @@ update xy
       ├── fd: (5)-->(6,9,10), (9)-->(10)
       ├── scan xy
       │    ├── columns: x:5!null y:6
+      │    ├── flags: avoid-full-scan
       │    ├── key: (5)
       │    └── fd: (5)-->(6)
       ├── scan uv
@@ -134,6 +135,7 @@ upsert xy
       │    │    │    └── (3, 4)
       │    │    ├── scan xy
       │    │    │    ├── columns: x:7!null y:8
+      │    │    │    ├── flags: avoid-full-scan
       │    │    │    ├── key: (7)
       │    │    │    └── fd: (7)-->(8)
       │    │    └── filters
@@ -162,6 +164,7 @@ delete xy
       ├── key: (5)
       ├── scan xy
       │    ├── columns: x:5!null
+      │    ├── flags: avoid-full-scan
       │    └── key: (5)
       ├── scan uv
       │    ├── columns: u:9!null

--- a/pkg/sql/opt/norm/testdata/rules/groupby
+++ b/pkg/sql/opt/norm/testdata/rules/groupby
@@ -641,6 +641,7 @@ upsert xy
  │    │    │    ├── fd: ()-->(7,8)
  │    │    │    ├── scan xy
  │    │    │    │    ├── columns: xy.x:7!null y:8
+ │    │    │    │    ├── flags: avoid-full-scan
  │    │    │    │    ├── key: (7)
  │    │    │    │    └── fd: (7)-->(8)
  │    │    │    └── filters
@@ -677,7 +678,8 @@ upsert xy
       │         │         ├── key: ()
       │         │         └── fd: ()-->(15)
       │         ├── scan fks
-      │         │    └── columns: r1:18!null
+      │         │    ├── columns: r1:18!null
+      │         │    └── flags: avoid-full-scan
       │         └── filters
       │              └── x:14 = r1:18 [outer=(14,18), constraints=(/14: (/NULL - ]; /18: (/NULL - ]), fd=(14)==(18), (18)==(14)]
       └── f-k-checks-item: fks(r2) -> xy(x)
@@ -708,7 +710,8 @@ upsert xy
                 │         ├── key: ()
                 │         └── fd: ()-->(23)
                 ├── scan fks
-                │    └── columns: r2:27
+                │    ├── columns: r2:27
+                │    └── flags: avoid-full-scan
                 └── filters
                      └── x:22 = r2:27 [outer=(22,27), constraints=(/22: (/NULL - ]; /27: (/NULL - ]), fd=(22)==(27), (27)==(22)]
 
@@ -742,6 +745,7 @@ insert xy
       │    ├── fd: ()-->(7)
       │    ├── scan xy
       │    │    ├── columns: x:7!null
+      │    │    ├── flags: avoid-full-scan
       │    │    └── key: (7)
       │    └── filters
       │         └── x:7 = 1 [outer=(7), constraints=(/7: [/1 - /1]; tight), fd=()-->(7)]
@@ -783,6 +787,7 @@ upsert nullablecols
       │    └── (1, 2, 2, unique_rowid())
       ├── scan nullablecols
       │    ├── columns: c1:11 c2:12 c3:13 rowid:14!null
+      │    ├── flags: avoid-full-scan
       │    ├── key: (14)
       │    └── fd: (14)-->(11-13), (11)~~>(12-14), (12,13)~~>(11,14)
       └── filters
@@ -821,6 +826,7 @@ upsert xy
  │    │    │    └── fd: (5)-->(6)
  │    │    ├── scan xy
  │    │    │    ├── columns: xy.x:12!null y:13
+ │    │    │    ├── flags: avoid-full-scan
  │    │    │    ├── key: (12)
  │    │    │    └── fd: (12)-->(13)
  │    │    └── filters
@@ -846,7 +852,8 @@ upsert xy
       │         │         └── mapping:
       │         │              └──  upsert_x:17 => x:20
       │         ├── scan fks
-      │         │    └── columns: r1:23!null
+      │         │    ├── columns: r1:23!null
+      │         │    └── flags: avoid-full-scan
       │         └── filters
       │              └── x:19 = r1:23 [outer=(19,23), constraints=(/19: (/NULL - ]; /23: (/NULL - ]), fd=(19)==(23), (23)==(19)]
       └── f-k-checks-item: fks(r2) -> xy(x)
@@ -867,7 +874,8 @@ upsert xy
                 │         └── mapping:
                 │              └──  upsert_x:17 => x:28
                 ├── scan fks
-                │    └── columns: r2:32
+                │    ├── columns: r2:32
+                │    └── flags: avoid-full-scan
                 └── filters
                      └── x:27 = r2:32 [outer=(27,32), constraints=(/27: (/NULL - ]; /32: (/NULL - ]), fd=(27)==(32), (32)==(27)]
 
@@ -915,6 +923,7 @@ upsert xy
  │    │    │              └── c2:6
  │    │    ├── scan xy
  │    │    │    ├── columns: xy.x:11!null y:12
+ │    │    │    ├── flags: avoid-full-scan
  │    │    │    ├── key: (11)
  │    │    │    └── fd: (11)-->(12)
  │    │    └── filters
@@ -940,7 +949,8 @@ upsert xy
       │         │         └── mapping:
       │         │              └──  upsert_x:16 => x:19
       │         ├── scan fks
-      │         │    └── columns: r1:22!null
+      │         │    ├── columns: r1:22!null
+      │         │    └── flags: avoid-full-scan
       │         └── filters
       │              └── x:18 = r1:22 [outer=(18,22), constraints=(/18: (/NULL - ]; /22: (/NULL - ]), fd=(18)==(22), (22)==(18)]
       └── f-k-checks-item: fks(r2) -> xy(x)
@@ -961,7 +971,8 @@ upsert xy
                 │         └── mapping:
                 │              └──  upsert_x:16 => x:27
                 ├── scan fks
-                │    └── columns: r2:31
+                │    ├── columns: r2:31
+                │    └── flags: avoid-full-scan
                 └── filters
                      └── x:26 = r2:31 [outer=(26,31), constraints=(/26: (/NULL - ]; /31: (/NULL - ]), fd=(26)==(31), (31)==(26)]
 
@@ -1005,6 +1016,7 @@ upsert xy
  │    │    │              └── b:6
  │    │    ├── scan xy
  │    │    │    ├── columns: xy.x:10!null y:11
+ │    │    │    ├── flags: avoid-full-scan
  │    │    │    ├── key: (10)
  │    │    │    └── fd: (10)-->(11)
  │    │    └── filters
@@ -1030,7 +1042,8 @@ upsert xy
       │         │         └── mapping:
       │         │              └──  upsert_x:15 => x:18
       │         ├── scan fks
-      │         │    └── columns: r1:21!null
+      │         │    ├── columns: r1:21!null
+      │         │    └── flags: avoid-full-scan
       │         └── filters
       │              └── x:17 = r1:21 [outer=(17,21), constraints=(/17: (/NULL - ]; /21: (/NULL - ]), fd=(17)==(21), (21)==(17)]
       └── f-k-checks-item: fks(r2) -> xy(x)
@@ -1051,7 +1064,8 @@ upsert xy
                 │         └── mapping:
                 │              └──  upsert_x:15 => x:26
                 ├── scan fks
-                │    └── columns: r2:30
+                │    ├── columns: r2:30
+                │    └── flags: avoid-full-scan
                 └── filters
                      └── x:25 = r2:30 [outer=(25,30), constraints=(/25: (/NULL - ]; /30: (/NULL - ]), fd=(25)==(30), (30)==(25)]
 
@@ -1431,6 +1445,7 @@ upsert nullablecols
       │    │              └── k:7 > 0 [outer=(7), constraints=(/7: [/1 - ]; tight)]
       │    ├── scan nullablecols
       │    │    ├── columns: c1:23 c2:24 c3:25 rowid:26!null
+      │    │    ├── flags: avoid-full-scan
       │    │    ├── key: (26)
       │    │    └── fd: (26)-->(23-25), (23)~~>(24-26), (24,25)~~>(23,26)
       │    └── filters
@@ -1628,6 +1643,7 @@ insert xy
       │    │         └── CAST(NULL AS INT8) [as=y_default:9]
       │    ├── scan xy
       │    │    ├── columns: x:10!null
+      │    │    ├── flags: avoid-full-scan
       │    │    └── key: (10)
       │    └── filters
       │         └── y:6 = x:10 [outer=(6,10), constraints=(/6: (/NULL - ]; /10: (/NULL - ]), fd=(6)==(10), (10)==(6)]
@@ -1682,6 +1698,7 @@ upsert xy
       │    │              └── CAST(NULL AS INT8) [as=y_default:9]
       │    ├── scan xy
       │    │    ├── columns: x:10!null y:11
+      │    │    ├── flags: avoid-full-scan
       │    │    ├── key: (10)
       │    │    └── fd: (10)-->(11)
       │    └── filters
@@ -1725,6 +1742,7 @@ insert xy
       │    │         └── CAST(NULL AS INT8) [as=y_default:9]
       │    ├── scan xy
       │    │    ├── columns: x:10!null
+      │    │    ├── flags: avoid-full-scan
       │    │    └── key: (10)
       │    └── filters
       │         └── y:6 = x:10 [outer=(6,10), constraints=(/6: (/NULL - ]; /10: (/NULL - ]), fd=(6)==(10), (10)==(6)]
@@ -1782,6 +1800,7 @@ upsert xy
       │    │              └── y_default:9
       │    ├── scan xy
       │    │    ├── columns: x:10!null y:11
+      │    │    ├── flags: avoid-full-scan
       │    │    ├── key: (10)
       │    │    └── fd: (10)-->(11)
       │    └── filters
@@ -1834,6 +1853,7 @@ upsert abc
       │              └── "?column?":12
       ├── scan abc
       │    ├── columns: a:13!null b:14!null c:15!null
+      │    ├── flags: avoid-full-scan
       │    └── key: (13-15)
       └── filters
            ├── "?column?":11 = a:13 [outer=(11,13), constraints=(/11: (/NULL - ]; /13: (/NULL - ]), fd=(11)==(13), (13)==(11)]
@@ -1891,6 +1911,7 @@ upsert abc
       │    │              └── b:7
       │    ├── scan abc
       │    │    ├── columns: a:12!null b:13!null c:14!null
+      │    │    ├── flags: avoid-full-scan
       │    │    └── key: (12-14)
       │    └── filters
       │         ├── "?column?":11 = a:12 [outer=(11,12), constraints=(/11: (/NULL - ]; /12: (/NULL - ]), fd=(11)==(12), (12)==(11)]
@@ -2359,6 +2380,7 @@ insert a
       │    │    ├── fd: ()-->(22)
       │    │    ├── scan a
       │    │    │    ├── columns: i:20!null s:22!null
+      │    │    │    ├── flags: avoid-full-scan
       │    │    │    └── key: (20,22)
       │    │    └── filters
       │    │         └── s:22 = 'foo' [outer=(22), constraints=(/22: [/'foo' - /'foo']; tight), fd=()-->(22)]
@@ -2464,6 +2486,7 @@ upsert a
       │    │              └── 'foo' [as="?column?":16]
       │    ├── scan a
       │    │    ├── columns: k:19!null i:20!null f:21 s:22!null j:23
+      │    │    ├── flags: avoid-full-scan
       │    │    ├── key: (19)
       │    │    └── fd: (19)-->(20-23), (20,22)-->(19,21,23), (20,21)~~>(19,22,23)
       │    └── filters
@@ -2788,6 +2811,7 @@ insert a
       │         └── CAST(NULL AS JSONB) [as=j_default:12]
       ├── scan a
       │    ├── columns: i:14!null s:16!null
+      │    ├── flags: avoid-full-scan
       │    └── key: (14,16)
       └── filters
            ├── column3:10 = i:14 [outer=(10,14), constraints=(/10: (/NULL - ]; /14: (/NULL - ]), fd=(10)==(14), (14)==(10)]
@@ -2836,6 +2860,7 @@ upsert a
       │    │         └── CAST(NULL AS JSONB) [as=j_default:12]
       │    ├── scan a
       │    │    ├── columns: k:13!null i:14!null f:15 s:16!null j:17
+      │    │    ├── flags: avoid-full-scan
       │    │    ├── key: (13)
       │    │    └── fd: (13)-->(14-17), (14,16)-->(13,15,17), (14,15)~~>(13,16,17)
       │    └── filters
@@ -2904,6 +2929,7 @@ upsert a
       │    │              └── j_default:12
       │    ├── scan a
       │    │    ├── columns: k:13!null i:14!null f:15 s:16!null j:17
+      │    │    ├── flags: avoid-full-scan
       │    │    ├── key: (13)
       │    │    └── fd: (13)-->(14-17), (14,16)-->(13,15,17), (14,15)~~>(13,16,17)
       │    └── filters
@@ -2954,17 +2980,20 @@ insert a
       │    │    │         └── CAST(NULL AS JSONB) [as=j_default:12]
       │    │    ├── scan a
       │    │    │    ├── columns: k:13!null
+      │    │    │    ├── flags: avoid-full-scan
       │    │    │    └── key: (13)
       │    │    └── filters
       │    │         └── column1:8 = k:13 [outer=(8,13), constraints=(/8: (/NULL - ]; /13: (/NULL - ]), fd=(8)==(13), (13)==(8)]
       │    ├── scan a
       │    │    ├── columns: i:21!null s:23!null
+      │    │    ├── flags: avoid-full-scan
       │    │    └── key: (21,23)
       │    └── filters
       │         ├── column3:10 = i:21 [outer=(10,21), constraints=(/10: (/NULL - ]; /21: (/NULL - ]), fd=(10)==(21), (21)==(10)]
       │         └── column2:9 = s:23 [outer=(9,23), constraints=(/9: (/NULL - ]; /23: (/NULL - ]), fd=(9)==(23), (23)==(9)]
       ├── scan a
       │    ├── columns: i:28!null f:29
+      │    ├── flags: avoid-full-scan
       │    └── lax-key: (28,29)
       └── filters
            ├── column3:10 = i:28 [outer=(10,28), constraints=(/10: (/NULL - ]; /28: (/NULL - ]), fd=(10)==(28), (28)==(10)]
@@ -3026,17 +3055,20 @@ insert a
       │    │    │    │    │         └── CAST(NULL AS JSONB) [as=j_default:12]
       │    │    │    │    ├── scan a
       │    │    │    │    │    ├── columns: k:13!null
+      │    │    │    │    │    ├── flags: avoid-full-scan
       │    │    │    │    │    └── key: (13)
       │    │    │    │    └── filters
       │    │    │    │         └── column1:8 = k:13 [outer=(8,13), constraints=(/8: (/NULL - ]; /13: (/NULL - ]), fd=(8)==(13), (13)==(8)]
       │    │    │    ├── scan a
       │    │    │    │    ├── columns: i:21!null s:23!null
+      │    │    │    │    ├── flags: avoid-full-scan
       │    │    │    │    └── key: (21,23)
       │    │    │    └── filters
       │    │    │         ├── i_default:11 = i:21 [outer=(11,21), constraints=(/11: (/NULL - ]; /21: (/NULL - ]), fd=(11)==(21), (21)==(11)]
       │    │    │         └── column2:9 = s:23 [outer=(9,23), constraints=(/9: (/NULL - ]; /23: (/NULL - ]), fd=(9)==(23), (23)==(9)]
       │    │    ├── scan a
       │    │    │    ├── columns: i:28!null f:29
+      │    │    │    ├── flags: avoid-full-scan
       │    │    │    └── lax-key: (28,29)
       │    │    └── filters
       │    │         ├── i_default:11 = i:28 [outer=(11,28), constraints=(/11: (/NULL - ]; /28: (/NULL - ]), fd=(11)==(28), (28)==(11)]
@@ -3111,17 +3143,20 @@ insert a
       │    │    │    │         └── CAST(NULL AS JSONB) [as=j_default:12]
       │    │    │    ├── scan a
       │    │    │    │    ├── columns: k:13!null
+      │    │    │    │    ├── flags: avoid-full-scan
       │    │    │    │    └── key: (13)
       │    │    │    └── filters
       │    │    │         └── column1:8 = k:13 [outer=(8,13), constraints=(/8: (/NULL - ]; /13: (/NULL - ]), fd=(8)==(13), (13)==(8)]
       │    │    ├── scan a
       │    │    │    ├── columns: i:21!null s:23!null
+      │    │    │    ├── flags: avoid-full-scan
       │    │    │    └── key: (21,23)
       │    │    └── filters
       │    │         ├── column3:10 = i:21 [outer=(10,21), constraints=(/10: (/NULL - ]; /21: (/NULL - ]), fd=(10)==(21), (21)==(10)]
       │    │         └── column2:9 = s:23 [outer=(9,23), constraints=(/9: (/NULL - ]; /23: (/NULL - ]), fd=(9)==(23), (23)==(9)]
       │    ├── scan a
       │    │    ├── columns: i:28!null f:29
+      │    │    ├── flags: avoid-full-scan
       │    │    └── lax-key: (28,29)
       │    └── filters
       │         ├── column3:10 = i:28 [outer=(10,28), constraints=(/10: (/NULL - ]; /28: (/NULL - ]), fd=(10)==(28), (28)==(10)]
@@ -3176,6 +3211,7 @@ insert a
       │    │    ├── fd: ()-->(21)
       │    │    ├── scan a
       │    │    │    ├── columns: i:19!null s:21!null
+      │    │    │    ├── flags: avoid-full-scan
       │    │    │    └── key: (19,21)
       │    │    └── filters
       │    │         └── s:21 = 'foo' [outer=(21), constraints=(/21: [/'foo' - /'foo']; tight), fd=()-->(21)]

--- a/pkg/sql/opt/norm/testdata/rules/inline
+++ b/pkg/sql/opt/norm/testdata/rules/inline
@@ -203,6 +203,7 @@ update computed
       │    ├── computed column expressions
       │    │    └── c:8
       │    │         └── (a:6 + b:7) + 1
+      │    ├── flags: avoid-full-scan
       │    ├── key: (6)
       │    └── fd: (6)-->(7,8)
       └── projections

--- a/pkg/sql/opt/norm/testdata/rules/mutation
+++ b/pkg/sql/opt/norm/testdata/rules/mutation
@@ -56,6 +56,7 @@ update t
       │    │    │    │    └── g:19 > 1 [outer=(19), constraints=(/19: [/2 - ]; tight)]
       │    │    │    └── t_d_idx: filters
       │    │    │         └── c:15 > 1 [outer=(15), constraints=(/15: [/2 - ]; tight)]
+      │    │    ├── flags: avoid-full-scan
       │    │    ├── key: (12)
       │    │    └── fd: (12)-->(13-20)
       │    └── filters
@@ -101,6 +102,7 @@ update t
       │    │    │    │    └── g:19 > 1 [outer=(19), constraints=(/19: [/2 - ]; tight)]
       │    │    │    └── t_d_idx: filters
       │    │    │         └── c:15 > 1 [outer=(15), constraints=(/15: [/2 - ]; tight)]
+      │    │    ├── flags: avoid-full-scan
       │    │    ├── key: (12)
       │    │    └── fd: (12)-->(13-20)
       │    └── filters
@@ -147,6 +149,7 @@ update t
       │    │    │    │    └── g:19 > 1 [outer=(19), constraints=(/19: [/2 - ]; tight)]
       │    │    │    └── t_d_idx: filters
       │    │    │         └── c:15 > 1 [outer=(15), constraints=(/15: [/2 - ]; tight)]
+      │    │    ├── flags: avoid-full-scan
       │    │    ├── key: (12)
       │    │    └── fd: (12)-->(13-20)
       │    └── filters
@@ -200,6 +203,7 @@ update t
       │    │    │    │    │    └── g:19 > 1 [outer=(19), constraints=(/19: [/2 - ]; tight)]
       │    │    │    │    └── t_d_idx: filters
       │    │    │    │         └── c:15 > 1 [outer=(15), constraints=(/15: [/2 - ]; tight)]
+      │    │    │    ├── flags: avoid-full-scan
       │    │    │    ├── key: (12)
       │    │    │    └── fd: (12)-->(13-20)
       │    │    └── filters
@@ -248,6 +252,7 @@ update t
       │    │    │    │    └── g:19 > 1 [outer=(19), constraints=(/19: [/2 - ]; tight)]
       │    │    │    └── t_d_idx: filters
       │    │    │         └── c:15 > 1 [outer=(15), constraints=(/15: [/2 - ]; tight)]
+      │    │    ├── flags: avoid-full-scan
       │    │    ├── key: (12)
       │    │    └── fd: (12)-->(13-20)
       │    └── filters
@@ -294,6 +299,7 @@ update t74385
       │    │    │    └── c:10 IS NULL [outer=(10), constraints=(/10: [/NULL - /NULL]; tight), fd=()-->(10)]
       │    │    └── a_idx: filters
       │    │         └── c:10 IS NULL [outer=(10), constraints=(/10: [/NULL - /NULL]; tight), fd=()-->(10)]
+      │    ├── flags: avoid-full-scan
       │    ├── key: (7)
       │    └── fd: (7)-->(8-10)
       └── projections
@@ -329,6 +335,7 @@ update t106663
       │    ├── partial index predicates
       │    │    └── t106663_b_idx: filters
       │    │         └── c:9 [outer=(9), constraints=(/9: [/true - /true]; tight), fd=()-->(9)]
+      │    ├── flags: avoid-full-scan
       │    ├── key: (10)
       │    └── fd: (10)-->(7,8)
       └── projections

--- a/pkg/sql/opt/norm/testdata/rules/prune_cols
+++ b/pkg/sql/opt/norm/testdata/rules/prune_cols
@@ -1987,6 +1987,7 @@ delete a
  ├── volatile, mutations
  └── scan a
       ├── columns: k:7!null
+      ├── flags: avoid-full-scan
       └── key: (7)
 
 # Prune when computed ordering column is present.
@@ -2023,6 +2024,7 @@ delete a
       │         │    ├── fd: (7)-->(8)
       │         │    ├── scan a
       │         │    │    ├── columns: k:7!null i:8
+      │         │    │    ├── flags: avoid-full-scan
       │         │    │    ├── key: (7)
       │         │    │    └── fd: (7)-->(8)
       │         │    └── filters
@@ -2046,6 +2048,7 @@ delete abcde
       ├── fd: (8)-->(9,10), (9,10)~~>(8)
       ├── scan abcde
       │    ├── columns: a:8!null b:9 c:10
+      │    ├── flags: avoid-full-scan
       │    ├── key: (8)
       │    └── fd: (8)-->(9,10), (9,10)~~>(8)
       └── filters
@@ -2062,6 +2065,7 @@ delete mutation
  ├── volatile, mutations
  └── scan mutation
       ├── columns: a:8!null b:9 d:11 e:12
+      ├── flags: avoid-full-scan
       ├── key: (8)
       └── fd: (8)-->(9,11,12)
 
@@ -2079,6 +2083,7 @@ delete a
  ├── fd: (1)-->(4)
  └── scan a
       ├── columns: k:7!null s:10
+      ├── flags: avoid-full-scan
       ├── key: (7)
       └── fd: (7)-->(10)
 
@@ -2110,6 +2115,7 @@ update computed
       │    │    ├── computed column expressions
       │    │    │    └── d:11
       │    │    │         └── c:10 + 1
+      │    │    ├── flags: avoid-full-scan
       │    │    ├── key: (8)
       │    │    └── fd: (8)-->(9,10,12)
       │    └── filters
@@ -2150,6 +2156,7 @@ update computed
       │    │    │    ├── computed column expressions
       │    │    │    │    └── d:11
       │    │    │    │         └── c:10 + 1
+      │    │    │    ├── flags: avoid-full-scan
       │    │    │    ├── key: (8)
       │    │    │    └── fd: (8)-->(9-12), (10)-->(11)
       │    │    └── filters
@@ -2191,6 +2198,7 @@ update partial_indexes
       │    │    ├── partial index predicates
       │    │    │    └── partial_indexes_c_idx: filters
       │    │    │         └── b:8 > 1 [outer=(8), constraints=(/8: [/2 - ]; tight)]
+      │    │    ├── flags: avoid-full-scan
       │    │    ├── key: (7)
       │    │    └── fd: (7)-->(10)
       │    └── filters
@@ -2230,6 +2238,7 @@ update partial_indexes
       │    │    ├── partial index predicates
       │    │    │    └── partial_indexes_c_idx: filters
       │    │    │         └── b:8 > 1 [outer=(8), constraints=(/8: [/2 - ]; tight)]
+      │    │    ├── flags: avoid-full-scan
       │    │    ├── key: (7)
       │    │    └── fd: (7)-->(8-10)
       │    └── filters
@@ -2289,6 +2298,7 @@ upsert partial_indexes
       │    │    │    ├── partial index predicates
       │    │    │    │    └── partial_indexes_c_idx: filters
       │    │    │    │         └── b:12 > 1 [outer=(12), constraints=(/12: [/2 - ]; tight)]
+      │    │    │    ├── flags: avoid-full-scan
       │    │    │    ├── key: (11)
       │    │    │    └── fd: (11)-->(12,14)
       │    │    └── filters
@@ -2347,6 +2357,7 @@ upsert partial_indexes
       │    │    │    ├── partial index predicates
       │    │    │    │    └── partial_indexes_c_idx: filters
       │    │    │    │         └── b:12 > 1 [outer=(12), constraints=(/12: [/2 - ]; tight)]
+      │    │    │    ├── flags: avoid-full-scan
       │    │    │    ├── key: (11)
       │    │    │    └── fd: (11)-->(12-14)
       │    │    └── filters
@@ -2405,6 +2416,7 @@ upsert partial_indexes
       │    │    │    ├── partial index predicates
       │    │    │    │    └── partial_indexes_c_idx: filters
       │    │    │    │         └── b:12 > 1 [outer=(12), constraints=(/12: [/2 - ]; tight)]
+      │    │    │    ├── flags: avoid-full-scan
       │    │    │    ├── key: (11)
       │    │    │    └── fd: (11)-->(12,14)
       │    │    └── filters
@@ -2469,6 +2481,7 @@ upsert partial_indexes
       │    │    │    │    ├── partial index predicates
       │    │    │    │    │    └── partial_indexes_c_idx: filters
       │    │    │    │    │         └── b:12 > 1 [outer=(12), constraints=(/12: [/2 - ]; tight)]
+      │    │    │    │    ├── flags: avoid-full-scan
       │    │    │    │    ├── key: (11)
       │    │    │    │    └── fd: (11)-->(12-14)
       │    │    │    └── filters
@@ -2506,6 +2519,7 @@ delete partial_indexes
       │    │    ├── partial index predicates
       │    │    │    └── partial_indexes_c_idx: filters
       │    │    │         └── b:8 > 1 [outer=(8), constraints=(/8: [/2 - ]; tight)]
+      │    │    ├── flags: avoid-full-scan
       │    │    ├── key: (7)
       │    │    └── fd: (7)-->(8,9)
       │    └── filters
@@ -2547,6 +2561,7 @@ update virt_partial_idx
       │    │    ├── partial index predicates
       │    │    │    └── virt_partial_idx_c_idx: filters
       │    │    │         └── b:9 > 0 [outer=(9), constraints=(/9: [/1 - ]; tight)]
+      │    │    ├── flags: avoid-full-scan
       │    │    ├── key: (8)
       │    │    └── fd: (8)-->(12)
       │    └── filters
@@ -2596,6 +2611,7 @@ update virt_partial_idx
       │    │    │    ├── partial index predicates
       │    │    │    │    └── virt_partial_idx_c_idx: filters
       │    │    │    │         └── b:9 > 0 [outer=(9), constraints=(/9: [/1 - ]; tight)]
+      │    │    │    ├── flags: avoid-full-scan
       │    │    │    ├── key: (8)
       │    │    │    └── fd: (8)-->(9,11,12)
       │    │    └── filters
@@ -2670,6 +2686,7 @@ upsert virt_partial_idx
       │    │    │    │    ├── partial index predicates
       │    │    │    │    │    └── virt_partial_idx_c_idx: filters
       │    │    │    │    │         └── b:13 > 0 [outer=(13), constraints=(/13: [/1 - ]; tight)]
+      │    │    │    │    ├── flags: avoid-full-scan
       │    │    │    │    ├── key: (12)
       │    │    │    │    └── fd: (12)-->(13,16)
       │    │    │    └── filters
@@ -2743,6 +2760,7 @@ upsert virt_partial_idx
       │    │    │    │    ├── partial index predicates
       │    │    │    │    │    └── virt_partial_idx_c_idx: filters
       │    │    │    │    │         └── b:14 > 0 [outer=(14), constraints=(/14: [/1 - ]; tight)]
+      │    │    │    │    ├── flags: avoid-full-scan
       │    │    │    │    ├── key: (13)
       │    │    │    │    └── fd: (13)-->(14,16,17)
       │    │    │    └── filters
@@ -2815,6 +2833,7 @@ upsert virt_partial_idx
       │    │    │    │    ├── partial index predicates
       │    │    │    │    │    └── virt_partial_idx_c_idx: filters
       │    │    │    │    │         └── b:13 > 0 [outer=(13), constraints=(/13: [/1 - ]; tight)]
+      │    │    │    │    ├── flags: avoid-full-scan
       │    │    │    │    ├── key: (12)
       │    │    │    │    └── fd: (12)-->(13,16)
       │    │    │    └── filters
@@ -2895,6 +2914,7 @@ upsert virt_partial_idx
       │    │    │    │    │    ├── partial index predicates
       │    │    │    │    │    │    └── virt_partial_idx_c_idx: filters
       │    │    │    │    │    │         └── b:13 > 0 [outer=(13), constraints=(/13: [/1 - ]; tight)]
+      │    │    │    │    │    ├── flags: avoid-full-scan
       │    │    │    │    │    ├── key: (12)
       │    │    │    │    │    └── fd: (12)-->(13,15,16)
       │    │    │    │    └── filters
@@ -2939,6 +2959,7 @@ delete virt_partial_idx
       │    │    ├── partial index predicates
       │    │    │    └── virt_partial_idx_c_idx: filters
       │    │    │         └── b:9 > 0 [outer=(9), constraints=(/9: [/1 - ]; tight)]
+      │    │    ├── flags: avoid-full-scan
       │    │    ├── key: (8)
       │    │    └── fd: (8)-->(9,11)
       │    └── filters
@@ -2982,6 +3003,7 @@ update partial_indexes
       │    │    │    ├── partial index predicates
       │    │    │    │    └── partial_indexes_c_idx: filters
       │    │    │    │         └── b:8 > 1 [outer=(8), constraints=(/8: [/2 - ]; tight)]
+      │    │    │    ├── flags: avoid-full-scan
       │    │    │    ├── key: (7)
       │    │    │    └── fd: (7)-->(8,9)
       │    │    └── filters
@@ -3009,6 +3031,7 @@ update family
       ├── fd: (8)-->(9,10)
       ├── scan family
       │    ├── columns: a:8!null b:9 c:10
+      │    ├── flags: avoid-full-scan
       │    ├── key: (8)
       │    └── fd: (8)-->(9,10)
       └── filters
@@ -3036,6 +3059,7 @@ update family
       │    ├── fd: (8)-->(9-12)
       │    ├── scan family
       │    │    ├── columns: a:8!null b:9 c:10 d:11 e:12
+      │    │    ├── flags: avoid-full-scan
       │    │    ├── key: (8)
       │    │    └── fd: (8)-->(9-12)
       │    └── filters
@@ -3068,6 +3092,7 @@ project
            ├── fd: (8)-->(9-11), (10)-->(15)
            ├── scan family
            │    ├── columns: a:8!null b:9 c:10 d:11
+           │    ├── flags: avoid-full-scan
            │    ├── key: (8)
            │    └── fd: (8)-->(9-11)
            └── projections
@@ -3097,6 +3122,7 @@ update multi_col_inv_idx
       │    ├── fd: ()-->(8-11)
       │    ├── scan multi_col_inv_idx
       │    │    ├── columns: a:8!null b:9 c:10 j:11
+      │    │    ├── flags: avoid-full-scan
       │    │    ├── key: (8)
       │    │    └── fd: (8)-->(9-11)
       │    └── filters
@@ -3147,6 +3173,7 @@ upsert a
       │    │    ├── fd: ()-->(11-14)
       │    │    ├── scan a
       │    │    │    ├── columns: k:11!null i:12 f:13 s:14
+      │    │    │    ├── flags: avoid-full-scan
       │    │    │    ├── key: (11)
       │    │    │    └── fd: (11)-->(12-14)
       │    │    └── filters
@@ -3206,6 +3233,7 @@ upsert a
       │    │    ├── fd: ()-->(11-14)
       │    │    ├── scan a
       │    │    │    ├── columns: k:11!null i:12 f:13 s:14
+      │    │    │    ├── flags: avoid-full-scan
       │    │    │    ├── key: (11)
       │    │    │    └── fd: (11)-->(12-14)
       │    │    └── filters
@@ -3255,6 +3283,7 @@ upsert family
       │    ├── fd: ()-->(11,12)
       │    ├── scan family
       │    │    ├── columns: a:11!null b:12
+      │    │    ├── flags: avoid-full-scan
       │    │    ├── key: (11)
       │    │    └── fd: (11)-->(12)
       │    └── filters
@@ -3314,6 +3343,7 @@ project
            │    │    ├── fd: ()-->(13,15-17)
            │    │    ├── scan family
            │    │    │    ├── columns: a:13!null c:15 d:16 e:17
+           │    │    │    ├── flags: avoid-full-scan
            │    │    │    ├── key: (13)
            │    │    │    └── fd: (13)-->(15-17)
            │    │    └── filters
@@ -3368,6 +3398,7 @@ upsert family
       │    │    ├── fd: ()-->(13,15,16)
       │    │    ├── scan family
       │    │    │    ├── columns: a:13!null c:15 d:16
+      │    │    │    ├── flags: avoid-full-scan
       │    │    │    ├── key: (13)
       │    │    │    └── fd: (13)-->(15,16)
       │    │    └── filters
@@ -3419,6 +3450,7 @@ upsert mutation
       │    │    ├── fd: ()-->(12-16)
       │    │    ├── scan mutation
       │    │    │    ├── columns: a:12!null b:13 c:14 d:15 e:16
+      │    │    │    ├── flags: avoid-full-scan
       │    │    │    ├── key: (12)
       │    │    │    └── fd: (12)-->(13-16)
       │    │    └── filters
@@ -3458,6 +3490,7 @@ update checks
       │    ├── columns: a:7!null b:8 c:9 d:10
       │    ├── check constraint expressions
       │    │    └── a:7 > 0 [outer=(7), constraints=(/7: [/1 - ]; tight)]
+      │    ├── flags: avoid-full-scan
       │    ├── key: (7)
       │    └── fd: (7)-->(8-10)
       └── projections
@@ -3483,6 +3516,7 @@ update checks
       │    ├── columns: a:7!null b:8 c:9 d:10
       │    ├── check constraint expressions
       │    │    └── a:7 > 0 [outer=(7), constraints=(/7: [/1 - ]; tight)]
+      │    ├── flags: avoid-full-scan
       │    ├── key: (7)
       │    └── fd: (7)-->(8-10)
       └── projections
@@ -3584,6 +3618,7 @@ upsert checks
       │    │    │    │    ├── columns: a:11!null b:12 c:13 d:14
       │    │    │    │    ├── check constraint expressions
       │    │    │    │    │    └── a:11 > 0 [outer=(11), constraints=(/11: [/1 - ]; tight)]
+      │    │    │    │    ├── flags: avoid-full-scan
       │    │    │    │    ├── key: (11)
       │    │    │    │    └── fd: (11)-->(12-14)
       │    │    │    └── filters
@@ -3622,6 +3657,7 @@ update uniq
  │    │    ├── fd: ()-->(9,11-13)
  │    │    ├── scan uniq
  │    │    │    ├── columns: uniq.k:9!null uniq.w:11 uniq.x:12 uniq.y:13
+ │    │    │    ├── flags: avoid-full-scan
  │    │    │    ├── key: (9)
  │    │    │    └── fd: (9)-->(11-13), (11)~~>(9,12,13), (12,13)~~>(9,11)
  │    │    └── filters
@@ -3651,6 +3687,7 @@ update uniq
       │              │    └── fd: ()-->(27,29)
       │              ├── scan uniq
       │              │    ├── columns: uniq.k:19!null uniq.w:21
+      │              │    ├── flags: avoid-full-scan
       │              │    ├── key: (19)
       │              │    └── fd: (19)-->(21)
       │              └── filters
@@ -3678,6 +3715,7 @@ update uniq
                      │    └── fd: ()-->(41,44,45)
                      ├── scan uniq
                      │    ├── columns: uniq.k:33!null uniq.x:36 uniq.y:37
+                     │    ├── flags: avoid-full-scan
                      │    ├── key: (33)
                      │    └── fd: (33)-->(36,37)
                      └── filters
@@ -3709,6 +3747,7 @@ update uniq_partial
  │    │    ├── fd: ()-->(7-9)
  │    │    ├── scan uniq_partial
  │    │    │    ├── columns: uniq_partial.k:7!null uniq_partial.v:8 uniq_partial.w:9
+ │    │    │    ├── flags: avoid-full-scan
  │    │    │    ├── key: (7)
  │    │    │    └── fd: (7)-->(8,9)
  │    │    └── filters
@@ -3749,6 +3788,7 @@ update uniq_partial
                      │    ├── fd: (14)-->(15,16)
                      │    ├── scan uniq_partial
                      │    │    ├── columns: uniq_partial.k:14!null uniq_partial.v:15 uniq_partial.w:16
+                     │    │    ├── flags: avoid-full-scan
                      │    │    ├── key: (14)
                      │    │    └── fd: (14)-->(15,16)
                      │    └── filters
@@ -3803,6 +3843,7 @@ upsert uniq_fk_parent
  │    │    │    ├── fd: ()-->(11-14)
  │    │    │    ├── scan uniq_fk_parent
  │    │    │    │    ├── columns: uniq_fk_parent.k:11!null uniq_fk_parent.a:12 uniq_fk_parent.b:13 uniq_fk_parent.c:14
+ │    │    │    │    ├── flags: avoid-full-scan
  │    │    │    │    ├── key: (11)
  │    │    │    │    └── fd: (11)-->(12-14), (12)~~>(11,13,14), (13,14)~~>(11,12)
  │    │    │    └── filters
@@ -3835,6 +3876,7 @@ upsert uniq_fk_parent
       │              │    └── fd: ()-->(31,32)
       │              ├── scan uniq_fk_parent
       │              │    ├── columns: uniq_fk_parent.k:24!null uniq_fk_parent.a:25
+      │              │    ├── flags: avoid-full-scan
       │              │    ├── key: (24)
       │              │    └── fd: (24)-->(25)
       │              └── filters
@@ -3862,6 +3904,7 @@ upsert uniq_fk_parent
                      │    └── fd: ()-->(43,45,46)
                      ├── scan uniq_fk_parent
                      │    ├── columns: uniq_fk_parent.k:36!null uniq_fk_parent.b:38 uniq_fk_parent.c:39
+                     │    ├── flags: avoid-full-scan
                      │    ├── key: (36)
                      │    └── fd: (36)-->(38,39)
                      └── filters
@@ -3913,6 +3956,7 @@ upsert uniq_fk_parent
  │    │    │    ├── fd: ()-->(10-14)
  │    │    │    ├── scan uniq_fk_parent
  │    │    │    │    ├── columns: uniq_fk_parent.k:10!null uniq_fk_parent.a:11 uniq_fk_parent.b:12 uniq_fk_parent.c:13 uniq_fk_parent.d:14
+ │    │    │    │    ├── flags: avoid-full-scan
  │    │    │    │    ├── key: (10)
  │    │    │    │    └── fd: (10)-->(11-14), (11)~~>(10,12-14), (12,13)~~>(10,11,14)
  │    │    │    └── filters
@@ -3946,6 +3990,7 @@ upsert uniq_fk_parent
       │              │    └── fd: ()-->(30,31)
       │              ├── scan uniq_fk_parent
       │              │    ├── columns: uniq_fk_parent.k:23!null uniq_fk_parent.a:24
+      │              │    ├── flags: avoid-full-scan
       │              │    ├── key: (23)
       │              │    └── fd: (23)-->(24)
       │              └── filters
@@ -3973,6 +4018,7 @@ upsert uniq_fk_parent
                      │    └── fd: ()-->(42,44,45)
                      ├── scan uniq_fk_parent
                      │    ├── columns: uniq_fk_parent.k:35!null uniq_fk_parent.b:37 uniq_fk_parent.c:38
+                     │    ├── flags: avoid-full-scan
                      │    ├── key: (35)
                      │    └── fd: (35)-->(37,38)
                      └── filters
@@ -3997,6 +4043,7 @@ delete uniq_fk_parent
  │    ├── fd: ()-->(8-11)
  │    ├── scan uniq_fk_parent
  │    │    ├── columns: k:8!null uniq_fk_parent.a:9 uniq_fk_parent.b:10 uniq_fk_parent.c:11
+ │    │    ├── flags: avoid-full-scan
  │    │    ├── key: (8)
  │    │    └── fd: (8)-->(9-11), (9)~~>(8,10,11), (10,11)~~>(8,9)
  │    └── filters
@@ -4018,6 +4065,7 @@ delete uniq_fk_parent
       │         │    └── fd: ()-->(15,16)
       │         ├── scan uniq_fk_child
       │         │    ├── columns: uniq_fk_child.b:18 uniq_fk_child.c:19
+      │         │    ├── flags: avoid-full-scan
       │         │    ├── lax-key: (18,19)
       │         │    └── fd: (19)~~>(18)
       │         └── filters
@@ -4037,7 +4085,8 @@ delete uniq_fk_parent
                 │    ├── key: ()
                 │    └── fd: ()-->(24)
                 ├── scan uniq_fk_child
-                │    └── columns: uniq_fk_child.a:25
+                │    ├── columns: uniq_fk_child.a:25
+                │    └── flags: avoid-full-scan
                 └── filters
                      └── a:24 = uniq_fk_child.a:25 [outer=(24,25), constraints=(/24: (/NULL - ]; /25: (/NULL - ]), fd=(24)==(25), (25)==(24)]
 
@@ -4058,6 +4107,7 @@ delete virt
       │    ├── computed column expressions
       │    │    └── v:8
       │    │         └── a:6 + b:7
+      │    ├── flags: avoid-full-scan
       │    └── key: (6)
       └── filters
            └── a:6 > 1 [outer=(6), constraints=(/6: [/2 - ]; tight)]
@@ -4092,6 +4142,7 @@ project
            │    │    ├── computed column expressions
            │    │    │    └── v:8
            │    │    │         └── a:6 + b:7
+           │    │    ├── flags: avoid-full-scan
            │    │    ├── key: (6)
            │    │    └── fd: (6)-->(7)
            │    └── filters
@@ -4122,6 +4173,7 @@ delete virt_idx
       │    │    ├── computed column expressions
       │    │    │    └── v:10
       │    │    │         └── a:7 + b:8
+      │    │    ├── flags: avoid-full-scan
       │    │    ├── key: (7)
       │    │    └── fd: (7)-->(8)
       │    └── filters
@@ -4156,6 +4208,7 @@ update virt_idx
       │    │    ├── computed column expressions
       │    │    │    └── v:10
       │    │    │         └── a:7 + b:8
+      │    │    ├── flags: avoid-full-scan
       │    │    ├── key: (7)
       │    │    └── fd: (7)-->(8,9)
       │    └── projections
@@ -4191,6 +4244,7 @@ update virt_idx
       │    │    ├── computed column expressions
       │    │    │    └── v:10
       │    │    │         └── a:7 + b:8
+      │    │    ├── flags: avoid-full-scan
       │    │    ├── key: (7)
       │    │    └── fd: (7)-->(8)
       │    └── projections
@@ -4220,6 +4274,7 @@ update virt_idx
       │    ├── computed column expressions
       │    │    └── v:10
       │    │         └── a:7 + b:8
+      │    ├── flags: avoid-full-scan
       │    ├── key: (7)
       │    └── fd: (7)-->(9)
       └── projections
@@ -4247,6 +4302,7 @@ update virt_idx2
       │    ├── computed column expressions
       │    │    └── v:10
       │    │         └── b:8 + 1
+      │    ├── flags: avoid-full-scan
       │    ├── key: (7)
       │    └── fd: (7)-->(8,9)
       └── projections
@@ -4275,6 +4331,7 @@ update virt_idx3
       │    ├── computed column expressions
       │    │    └── v:10
       │    │         └── b:8 + 1
+      │    ├── flags: avoid-full-scan
       │    ├── key: (7)
       │    └── fd: (7)-->(8,9)
       └── projections
@@ -4482,6 +4539,7 @@ project
            ├── fd: (18)-->(11-17), (11)~~>(12-18), (11)-->(21)
            ├── scan returning_test
            │    ├── columns: a:11 b:12 c:13 d:14 e:15 f:16 g:17 rowid:18!null
+           │    ├── flags: avoid-full-scan
            │    ├── key: (18)
            │    └── fd: (18)-->(11-17), (11)~~>(12-18)
            └── projections
@@ -4516,6 +4574,7 @@ project
            ├── fd: (18)-->(11,14-17), (11)~~>(14-18), (11,14)-->(21)
            ├── scan returning_test
            │    ├── columns: a:11 d:14 e:15 f:16 g:17 rowid:18!null
+           │    ├── flags: avoid-full-scan
            │    ├── key: (18)
            │    └── fd: (18)-->(11,14-17), (11)~~>(14-18)
            └── projections
@@ -4546,6 +4605,7 @@ project
            ├── fd: (18)-->(11,21), (11)~~>(18,21)
            ├── scan returning_test
            │    ├── columns: a:11 d:14 rowid:18!null
+           │    ├── flags: avoid-full-scan
            │    ├── key: (18)
            │    └── fd: (18)-->(11,14), (11)~~>(14,18)
            └── projections
@@ -4581,6 +4641,7 @@ project
            ├── fd: (18)-->(11-13), (11)~~>(12,13,18), (11,12)-->(21)
            ├── scan returning_test
            │    ├── columns: a:11 b:12 c:13 rowid:18!null
+           │    ├── flags: avoid-full-scan
            │    ├── key: (18)
            │    └── fd: (18)-->(11-13), (11)~~>(12,13,18)
            └── projections
@@ -4619,6 +4680,7 @@ with &1
  │              ├── fd: (18)-->(11-13), (11)~~>(12,13,18), (11)-->(21)
  │              ├── scan returning_test
  │              │    ├── columns: returning_test.a:11 returning_test.b:12 returning_test.c:13 rowid:18!null
+ │              │    ├── flags: avoid-full-scan
  │              │    ├── key: (18)
  │              │    └── fd: (18)-->(11-13), (11)~~>(12,13,18)
  │              └── projections
@@ -4665,6 +4727,7 @@ with &1
  │              ├── fd: (18)-->(11-13), (11)~~>(12,13,18), (11)-->(21)
  │              ├── scan returning_test
  │              │    ├── columns: returning_test.a:11 returning_test.b:12 returning_test.c:13 rowid:18!null
+ │              │    ├── flags: avoid-full-scan
  │              │    ├── key: (18)
  │              │    └── fd: (18)-->(11-13), (11)~~>(12,13,18)
  │              └── projections
@@ -4717,6 +4780,7 @@ with &2
  │              ├── fd: (30)-->(23-25), (23)~~>(24,25,30), (23)-->(33)
  │              ├── scan returning_test
  │              │    ├── columns: returning_test.a:23 returning_test.b:24 returning_test.c:25 rowid:30!null
+ │              │    ├── flags: avoid-full-scan
  │              │    ├── key: (30)
  │              │    └── fd: (30)-->(23-25), (23)~~>(24,25,30)
  │              └── projections
@@ -4813,6 +4877,7 @@ project
            │    │    ├── fd: ()-->(16-18,23)
            │    │    ├── scan returning_test
            │    │    │    ├── columns: a:16 b:17 c:18 rowid:23!null
+           │    │    │    ├── flags: avoid-full-scan
            │    │    │    ├── key: (23)
            │    │    │    └── fd: (23)-->(16-18), (16)~~>(17,18,23)
            │    │    └── filters
@@ -4850,6 +4915,7 @@ project
            ├── fd: (18)-->(11,12,14), (11)-->(12,14,18)
            ├── scan returning_test
            │    ├── columns: a:11 b:12 d:14 rowid:18!null
+           │    ├── flags: avoid-full-scan
            │    ├── key: (18)
            │    └── fd: (18)-->(11,12,14), (11)~~>(12,14,18)
            └── filters
@@ -4914,6 +4980,7 @@ project
            │    │    └── (1, 2, 'c', CAST(NULL AS INT8), unique_rowid())
            │    ├── scan returning_test
            │    │    ├── columns: a:16 b:17 c:18 d:19 rowid:23!null
+           │    │    ├── flags: avoid-full-scan
            │    │    ├── key: (23)
            │    │    └── fd: (23)-->(16-19), (16)~~>(17-19,23)
            │    └── filters
@@ -4953,6 +5020,7 @@ update abcde
       ├── fd: (8)-->(9-12), (9,10)~~>(8,11,12), (15)-->(16,17), (8)==(15), (15)==(8)
       ├── scan abcde
       │    ├── columns: abcde.a:8!null abcde.b:9 abcde.c:10 abcde.d:11 abcde.e:12
+      │    ├── flags: avoid-full-scan
       │    ├── key: (8)
       │    └── fd: (8)-->(9-12), (9,10)~~>(8,11,12)
       ├── scan family

--- a/pkg/sql/opt/norm/testdata/rules/with
+++ b/pkg/sql/opt/norm/testdata/rules/with
@@ -639,7 +639,7 @@ with &2 (cte)
  ├── cardinality: [1 - 2]
  ├── volatile, mutations
  ├── stats: [rows=2, distinct(14)=2, null(14)=0]
- ├── cost: 1060.9075
+ ├── cost: 1.0482e+53
  ├── key: (14)
  ├── insert t.public.child
  │    ├── columns: t.public.child.c:1(int!null)
@@ -652,7 +652,7 @@ with &2 (cte)
  │    ├── cardinality: [1 - 1]
  │    ├── volatile, mutations
  │    ├── stats: [rows=1, distinct(1)=1, null(1)=0]
- │    ├── cost: 1060.7975
+ │    ├── cost: 1.0482e+53
  │    ├── key: ()
  │    ├── fd: ()-->(1)
  │    ├── values
@@ -672,7 +672,7 @@ with &2 (cte)
  │                   ├── columns: p:7(int!null)
  │                   ├── cardinality: [0 - 1]
  │                   ├── stats: [rows=1e-10]
- │                   ├── cost: 1060.7675
+ │                   ├── cost: 1.0482e+53
  │                   ├── key: ()
  │                   ├── fd: ()-->(7)
  │                   ├── cte-uses
@@ -691,9 +691,9 @@ with &2 (cte)
  │                   │         └── &1: count=1 used-columns=(6)
  │                   ├── scan t.public.parent
  │                   │    ├── columns: t.public.parent.p:8(int!null)
- │                   │    ├── flags: disabled not visible index feature
+ │                   │    ├── flags: avoid-full-scan disabled not visible index feature
  │                   │    ├── stats: [rows=1000, distinct(8)=1000, null(8)=0]
- │                   │    ├── cost: 1048.22
+ │                   │    ├── cost: 1.0482e+53
  │                   │    ├── key: (8)
  │                   │    ├── prune: (8)
  │                   │    ├── interesting orderings: (+8)

--- a/pkg/sql/opt/optbuilder/fk_cascade.go
+++ b/pkg/sql/opt/optbuilder/fk_cascade.go
@@ -308,6 +308,11 @@ func (cb *onDeleteFastCascadeBuilder) Build(
 			var mb mutationBuilder
 			mb.init(b, "delete", cb.childTable, tree.MakeUnqualifiedTableName(cb.childTable.Name()))
 
+			var indexFlags *tree.IndexFlags
+			if mb.b.evalCtx.SessionData().AvoidFullTableScansInMutations {
+				indexFlags = &tree.IndexFlags{AvoidFullScan: true}
+			}
+
 			// Build the input to the delete mutation, which is simply a Scan with a
 			// Select on top.
 			mb.fetchScope = b.buildScan(
@@ -317,7 +322,7 @@ func (cb *onDeleteFastCascadeBuilder) Build(
 					includeSystem:    false,
 					includeInverted:  false,
 				}),
-				nil, /* indexFlags */
+				indexFlags,
 				noRowLocking,
 				b.allocScope(),
 				true, /* disableNotVisibleIndex */
@@ -559,6 +564,11 @@ func (b *Builder) buildDeleteCascadeMutationInput(
 	bindingProps *props.Relational,
 	oldValues opt.ColList,
 ) (outScope *scope) {
+	var indexFlags *tree.IndexFlags
+	if b.evalCtx.SessionData().AvoidFullTableScansInMutations {
+		indexFlags = &tree.IndexFlags{AvoidFullScan: true}
+	}
+
 	outScope = b.buildScan(
 		b.addTable(childTable, childTableAlias),
 		tableOrdinals(childTable, columnKinds{
@@ -566,7 +576,7 @@ func (b *Builder) buildDeleteCascadeMutationInput(
 			includeSystem:    false,
 			includeInverted:  false,
 		}),
-		nil, /* indexFlags */
+		indexFlags,
 		noRowLocking,
 		b.allocScope(),
 		true, /* disableNotVisibleIndex */
@@ -827,6 +837,11 @@ func (b *Builder) buildUpdateCascadeMutationInput(
 	oldValues opt.ColList,
 	newValues opt.ColList,
 ) (outScope *scope) {
+	var indexFlags *tree.IndexFlags
+	if b.evalCtx.SessionData().AvoidFullTableScansInMutations {
+		indexFlags = &tree.IndexFlags{AvoidFullScan: true}
+	}
+
 	outScope = b.buildScan(
 		b.addTable(childTable, childTableAlias),
 		tableOrdinals(childTable, columnKinds{
@@ -834,7 +849,7 @@ func (b *Builder) buildUpdateCascadeMutationInput(
 			includeSystem:    false,
 			includeInverted:  false,
 		}),
-		nil, /* indexFlags */
+		indexFlags,
 		noRowLocking,
 		b.allocScope(),
 		true, /* disableNotVisibleIndex */

--- a/pkg/sql/opt/optbuilder/mutation_builder.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder.go
@@ -308,6 +308,13 @@ func (mb *mutationBuilder) buildInputForUpdate(
 		telemetry.Inc(sqltelemetry.IndexHintUpdateUseCounter)
 	}
 
+	if mb.b.evalCtx.SessionData().AvoidFullTableScansInMutations {
+		if indexFlags == nil {
+			indexFlags = &tree.IndexFlags{}
+		}
+		indexFlags.AvoidFullScan = true
+	}
+
 	// Fetch columns from different instance of the table metadata, so that it's
 	// possible to remap columns, as in this example:
 	//
@@ -416,6 +423,13 @@ func (mb *mutationBuilder) buildInputForDelete(
 		indexFlags = source.IndexFlags
 		telemetry.Inc(sqltelemetry.IndexHintUseCounter)
 		telemetry.Inc(sqltelemetry.IndexHintDeleteUseCounter)
+	}
+
+	if mb.b.evalCtx.SessionData().AvoidFullTableScansInMutations {
+		if indexFlags == nil {
+			indexFlags = &tree.IndexFlags{}
+		}
+		indexFlags.AvoidFullScan = true
 	}
 
 	// Fetch columns from different instance of the table metadata, so that it's

--- a/pkg/sql/opt/optbuilder/mutation_builder_fk.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder_fk.go
@@ -657,10 +657,15 @@ func (h *fkCheckHelper) buildOtherTableScan(parent bool) (outScope *scope, tabMe
 		}
 	}
 	otherTabMeta := h.mb.b.addTable(h.otherTab, tree.NewUnqualifiedTableName(h.otherTab.Name()))
+	indexFlags := &tree.IndexFlags{IgnoreForeignKeys: true}
+	if h.mb.b.evalCtx.SessionData().AvoidFullTableScansInMutations {
+		indexFlags.AvoidFullScan = true
+	}
+
 	return h.mb.b.buildScan(
 		otherTabMeta,
 		h.otherTabOrdinals,
-		&tree.IndexFlags{IgnoreForeignKeys: true},
+		indexFlags,
 		locking,
 		h.mb.b.allocScope(),
 		true, /* disableNotVisibleIndex */

--- a/pkg/sql/opt/optbuilder/mutation_builder_unique.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder_unique.go
@@ -653,12 +653,16 @@ func (h *uniqueCheckHelper) buildTableScan() (outScope *scope, ordinals []int) {
 			},
 		}
 	}
+	// After the update we can't guarantee that the constraints are unique
+	// (which is why we need the uniqueness checks in the first place).
+	indexFlags := &tree.IndexFlags{IgnoreUniqueWithoutIndexKeys: true}
+	if h.mb.b.evalCtx.SessionData().AvoidFullTableScansInMutations {
+		indexFlags.AvoidFullScan = true
+	}
 	return h.mb.b.buildScan(
 		tabMeta,
 		ordinals,
-		// After the update we can't guarantee that the constraints are unique
-		// (which is why we need the uniqueness checks in the first place).
-		&tree.IndexFlags{IgnoreUniqueWithoutIndexKeys: true},
+		indexFlags,
 		locking,
 		h.mb.b.allocScope(),
 		true, /* disableNotVisibleIndex */

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -648,6 +648,7 @@ func (b *Builder) buildScan(
 		private.Flags.NoIndexJoin = indexFlags.NoIndexJoin
 		private.Flags.NoZigzagJoin = indexFlags.NoZigzagJoin
 		private.Flags.NoFullScan = indexFlags.NoFullScan
+		private.Flags.AvoidFullScan = indexFlags.AvoidFullScan
 		private.Flags.ForceInvertedIndex = indexFlags.ForceInvertedIndex
 		if indexFlags.Index != "" || indexFlags.IndexID != 0 {
 			idx := -1

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -523,18 +523,6 @@ func errorOnInvalidMultiregionDB(
 // be in the list (in practice, this coincides with all "ordinary" table columns
 // being in the list).
 //
-// If scanMutationCols is true, then include columns being added or dropped from
-// the table. These are currently required by the execution engine as "fetch
-// columns", when performing mutation DML statements (INSERT, UPDATE, UPSERT,
-// DELETE).
-//
-// NOTE: Callers must take care that mutation columns (columns that are being
-//
-//	added or dropped from the table) are only used when performing mutation
-//	DML statements (INSERT, UPDATE, UPSERT, DELETE). They cannot be used in
-//	any other way because they may not have been initialized yet by the
-//	backfiller!
-//
 // See Builder.buildStmt for a description of the remaining input and return
 // values.
 func (b *Builder) buildScan(

--- a/pkg/sql/opt/optbuilder/testdata/delete
+++ b/pkg/sql/opt/optbuilder/testdata/delete
@@ -53,11 +53,12 @@ delete abcde
  ├── fetch columns: a:9 b:10 c:11 d:12 e:13 rowid:14
  └── scan abcde
       ├── columns: a:9!null b:10 c:11 d:12 e:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16
-      └── computed column expressions
-           ├── d:12
-           │    └── (b:10 + c:11) + 1
-           └── e:13
-                └── a:9
+      ├── computed column expressions
+      │    ├── d:12
+      │    │    └── (b:10 + c:11) + 1
+      │    └── e:13
+      │         └── a:9
+      └── flags: avoid-full-scan
 
 # Use WHERE, ORDER BY, LIMIT.
 build
@@ -77,11 +78,12 @@ delete abcde
       │         ├── columns: a:9!null b:10 c:11 d:12 e:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16
       │         ├── scan abcde
       │         │    ├── columns: a:9!null b:10 c:11 d:12 e:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16
-      │         │    └── computed column expressions
-      │         │         ├── d:12
-      │         │         │    └── (b:10 + c:11) + 1
-      │         │         └── e:13
-      │         │              └── a:9
+      │         │    ├── computed column expressions
+      │         │    │    ├── d:12
+      │         │    │    │    └── (b:10 + c:11) + 1
+      │         │    │    └── e:13
+      │         │    │         └── a:9
+      │         │    └── flags: avoid-full-scan
       │         └── filters
       │              └── a:9 > 0
       └── 10
@@ -104,11 +106,12 @@ delete abcde [as=foo]
       │         ├── columns: a:9!null b:10 c:11 d:12 e:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16
       │         ├── scan abcde [as=foo]
       │         │    ├── columns: a:9!null b:10 c:11 d:12 e:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16
-      │         │    └── computed column expressions
-      │         │         ├── d:12
-      │         │         │    └── (b:10 + c:11) + 1
-      │         │         └── e:13
-      │         │              └── a:9
+      │         │    ├── computed column expressions
+      │         │    │    ├── d:12
+      │         │    │    │    └── (b:10 + c:11) + 1
+      │         │    │    └── e:13
+      │         │    │         └── a:9
+      │         │    └── flags: avoid-full-scan
       │         └── filters
       │              └── a:9 > 0
       └── 10
@@ -132,7 +135,7 @@ delete xyzw
  ├── fetch columns: x:7 y:8 z:9 w:10
  └── scan xyzw
       ├── columns: x:7!null y:8 z:9 w:10 crdb_internal_mvcc_timestamp:11 tableoid:12
-      └── flags: force-index=xyzw_pkey
+      └── flags: force-index=xyzw_pkey avoid-full-scan
 
 build
 DELETE FROM xyzw@foo
@@ -142,7 +145,7 @@ delete xyzw
  ├── fetch columns: x:7 y:8 z:9 w:10
  └── scan xyzw
       ├── columns: x:7!null y:8 z:9 w:10 crdb_internal_mvcc_timestamp:11 tableoid:12
-      └── flags: force-index=foo
+      └── flags: force-index=foo avoid-full-scan
 
 build
 DELETE FROM xyzw@{FORCE_INDEX=foo,ASC}
@@ -152,7 +155,7 @@ delete xyzw
  ├── fetch columns: x:7 y:8 z:9 w:10
  └── scan xyzw
       ├── columns: x:7!null y:8 z:9 w:10 crdb_internal_mvcc_timestamp:11 tableoid:12
-      └── flags: force-index=foo,fwd
+      └── flags: force-index=foo,fwd avoid-full-scan
 
 build
 DELETE FROM xyzw@{FORCE_INDEX=foo,DESC}
@@ -162,7 +165,7 @@ delete xyzw
  ├── fetch columns: x:7 y:8 z:9 w:10
  └── scan xyzw,rev
       ├── columns: x:7!null y:8 z:9 w:10 crdb_internal_mvcc_timestamp:11 tableoid:12
-      └── flags: force-index=foo,rev
+      └── flags: force-index=foo,rev avoid-full-scan
 
 build
 DELETE FROM xyzw@{NO_INDEX_JOIN}
@@ -172,7 +175,7 @@ delete xyzw
  ├── fetch columns: x:7 y:8 z:9 w:10
  └── scan xyzw
       ├── columns: x:7!null y:8 z:9 w:10 crdb_internal_mvcc_timestamp:11 tableoid:12
-      └── flags: no-index-join
+      └── flags: no-index-join avoid-full-scan
 
 build
 DELETE FROM xyzw@bad_idx
@@ -189,19 +192,21 @@ delete xyz
  └── limit
       ├── columns: x:6!null y:7 z:8 crdb_internal_mvcc_timestamp:9 tableoid:10 column11:11
       ├── internal-ordering: -11
-      ├── project
-      │    ├── columns: column11:11 x:6!null y:7 z:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+      ├── sort
+      │    ├── columns: x:6!null y:7 z:8 crdb_internal_mvcc_timestamp:9 tableoid:10 column11:11
       │    ├── ordering: -11
       │    ├── limit hint: 2.00
-      │    ├── select
-      │    │    ├── columns: x:6!null y:7 z:8 crdb_internal_mvcc_timestamp:9 tableoid:10
-      │    │    ├── limit hint: 2.00
-      │    │    ├── scan xyz
-      │    │    │    └── columns: x:6!null y:7 z:8 crdb_internal_mvcc_timestamp:9 tableoid:10
-      │    │    └── filters
-      │    │         └── x:6 = $1
-      │    └── projections
-      │         └── y:7 + $2 [as=column11:11]
+      │    └── project
+      │         ├── columns: column11:11 x:6!null y:7 z:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+      │         ├── select
+      │         │    ├── columns: x:6!null y:7 z:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+      │         │    ├── scan xyz
+      │         │    │    ├── columns: x:6!null y:7 z:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+      │         │    │    └── flags: avoid-full-scan
+      │         │    └── filters
+      │         │         └── x:6 = $1
+      │         └── projections
+      │              └── y:7 + $2 [as=column11:11]
       └── 2
 
 
@@ -221,11 +226,12 @@ with &1 (cte)
            ├── columns: a:14!null b:15 c:16 d:17 e:18 rowid:19!null abcde.crdb_internal_mvcc_timestamp:20 abcde.tableoid:21
            ├── scan abcde
            │    ├── columns: a:14!null b:15 c:16 d:17 e:18 rowid:19!null abcde.crdb_internal_mvcc_timestamp:20 abcde.tableoid:21
-           │    └── computed column expressions
-           │         ├── d:17
-           │         │    └── (b:15 + c:16) + 1
-           │         └── e:18
-           │              └── a:14
+           │    ├── computed column expressions
+           │    │    ├── d:17
+           │    │    │    └── (b:15 + c:16) + 1
+           │    │    └── e:18
+           │    │         └── a:14
+           │    └── flags: avoid-full-scan
            └── filters
                 └── exists
                      └── with-scan &1 (cte)
@@ -260,7 +266,8 @@ with &1
  │    └── select
  │         ├── columns: xyz.x:6!null xyz.y:7 xyz.z:8!null xyz.crdb_internal_mvcc_timestamp:9 xyz.tableoid:10
  │         ├── scan xyz
- │         │    └── columns: xyz.x:6!null xyz.y:7 xyz.z:8 xyz.crdb_internal_mvcc_timestamp:9 xyz.tableoid:10
+ │         │    ├── columns: xyz.x:6!null xyz.y:7 xyz.z:8 xyz.crdb_internal_mvcc_timestamp:9 xyz.tableoid:10
+ │         │    └── flags: avoid-full-scan
  │         └── filters
  │              └── xyz.z:8 > 0.0
  └── with &2 (cte)
@@ -279,11 +286,12 @@ with &1
                 ├── columns: a:22!null b:23!null c:24 d:25 e:26 rowid:27!null abcde.crdb_internal_mvcc_timestamp:28 abcde.tableoid:29
                 ├── scan abcde
                 │    ├── columns: a:22!null b:23 c:24 d:25 e:26 rowid:27!null abcde.crdb_internal_mvcc_timestamp:28 abcde.tableoid:29
-                │    └── computed column expressions
-                │         ├── d:25
-                │         │    └── (b:23 + c:24) + 1
-                │         └── e:26
-                │              └── a:22
+                │    ├── computed column expressions
+                │    │    ├── d:25
+                │    │    │    └── (b:23 + c:24) + 1
+                │    │    └── e:26
+                │    │         └── a:22
+                │    └── flags: avoid-full-scan
                 └── filters
                      └── a:22 = b:23
 
@@ -329,11 +337,12 @@ project
            ├── columns: a:9!null b:10 c:11 d:12 e:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16
            ├── scan abcde
            │    ├── columns: a:9!null b:10 c:11 d:12 e:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16
-           │    └── computed column expressions
-           │         ├── d:12
-           │         │    └── (b:10 + c:11) + 1
-           │         └── e:13
-           │              └── a:9
+           │    ├── computed column expressions
+           │    │    ├── d:12
+           │    │    │    └── (b:10 + c:11) + 1
+           │    │    └── e:13
+           │    │         └── a:9
+           │    └── flags: avoid-full-scan
            └── filters
                 └── a:9 = 1
 
@@ -357,11 +366,12 @@ project
  │         ├── columns: a:9!null b:10 c:11 d:12 e:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16
  │         ├── scan abcde [as=foo]
  │         │    ├── columns: a:9!null b:10 c:11 d:12 e:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16
- │         │    └── computed column expressions
- │         │         ├── d:12
- │         │         │    └── (b:10 + c:11) + 1
- │         │         └── e:13
- │         │              └── a:9
+ │         │    ├── computed column expressions
+ │         │    │    ├── d:12
+ │         │    │    │    └── (b:10 + c:11) + 1
+ │         │    │    └── e:13
+ │         │    │         └── a:9
+ │         │    └── flags: avoid-full-scan
  │         └── filters
  │              └── a:9 = 1
  └── projections
@@ -397,11 +407,12 @@ with &1
  │              │         ├── columns: abcde.a:9!null abcde.b:10 abcde.c:11 abcde.d:12 abcde.e:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16
  │              │         ├── scan abcde
  │              │         │    ├── columns: abcde.a:9!null abcde.b:10 abcde.c:11 abcde.d:12 abcde.e:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16
- │              │         │    └── computed column expressions
- │              │         │         ├── abcde.d:12
- │              │         │         │    └── (abcde.b:10 + abcde.c:11) + 1
- │              │         │         └── abcde.e:13
- │              │         │              └── abcde.a:9
+ │              │         │    ├── computed column expressions
+ │              │         │    │    ├── abcde.d:12
+ │              │         │    │    │    └── (abcde.b:10 + abcde.c:11) + 1
+ │              │         │    │    └── abcde.e:13
+ │              │         │    │         └── abcde.a:9
+ │              │         │    └── flags: avoid-full-scan
  │              │         └── filters
  │              │              └── abcde.a:9 > 0
  │              └── 10
@@ -430,7 +441,8 @@ delete mutation
  └── select
       ├── columns: m:7!null n:8 o:9 p:10 crdb_internal_mvcc_timestamp:11 tableoid:12
       ├── scan mutation
-      │    └── columns: m:7!null n:8 o:9 p:10 crdb_internal_mvcc_timestamp:11 tableoid:12
+      │    ├── columns: m:7!null n:8 o:9 p:10 crdb_internal_mvcc_timestamp:11 tableoid:12
+      │    └── flags: avoid-full-scan
       └── filters
            └── m:7 = 1
 
@@ -447,7 +459,8 @@ delete mutation
  └── select
       ├── columns: m:7!null n:8 o:9 p:10 crdb_internal_mvcc_timestamp:11 tableoid:12
       ├── scan mutation
-      │    └── columns: m:7!null n:8 o:9 p:10 crdb_internal_mvcc_timestamp:11 tableoid:12
+      │    ├── columns: m:7!null n:8 o:9 p:10 crdb_internal_mvcc_timestamp:11 tableoid:12
+      │    └── flags: avoid-full-scan
       └── filters
            └── m:7 = 1
 
@@ -491,11 +504,12 @@ delete t.public.abcde
       │    │    ├── columns: t.public.abcde.a:9!null t.public.abcde.b:10 t.public.abcde.c:11 t.public.abcde.d:12 t.public.abcde.e:13 t.public.abcde.rowid:14!null t.public.abcde.crdb_internal_mvcc_timestamp:15 t.public.abcde.tableoid:16 t.public.fgh.f:17 t.public.fgh.g:18 t.public.fgh.h:19 t.public.fgh.rowid:20!null t.public.fgh.crdb_internal_mvcc_timestamp:21 t.public.fgh.tableoid:22
       │    │    ├── scan t.public.abcde
       │    │    │    ├── columns: t.public.abcde.a:9!null t.public.abcde.b:10 t.public.abcde.c:11 t.public.abcde.d:12 t.public.abcde.e:13 t.public.abcde.rowid:14!null t.public.abcde.crdb_internal_mvcc_timestamp:15 t.public.abcde.tableoid:16
-      │    │    │    └── computed column expressions
-      │    │    │         ├── t.public.abcde.d:12
-      │    │    │         │    └── (t.public.abcde.b:10 + t.public.abcde.c:11) + 1
-      │    │    │         └── t.public.abcde.e:13
-      │    │    │              └── t.public.abcde.a:9
+      │    │    │    ├── computed column expressions
+      │    │    │    │    ├── t.public.abcde.d:12
+      │    │    │    │    │    └── (t.public.abcde.b:10 + t.public.abcde.c:11) + 1
+      │    │    │    │    └── t.public.abcde.e:13
+      │    │    │    │         └── t.public.abcde.a:9
+      │    │    │    └── flags: avoid-full-scan
       │    │    ├── scan t.public.fgh
       │    │    │    └── columns: t.public.fgh.f:17 t.public.fgh.g:18 t.public.fgh.h:19 t.public.fgh.rowid:20!null t.public.fgh.crdb_internal_mvcc_timestamp:21 t.public.fgh.tableoid:22
       │    │    └── filters (true)
@@ -546,11 +560,12 @@ delete abcde
       │    │    ├── columns: abcde.a:9!null abcde.b:10 abcde.c:11 abcde.d:12 abcde.e:13 abcde.rowid:14!null abcde.crdb_internal_mvcc_timestamp:15 abcde.tableoid:16 abcde2.a:17!null abcde2.b:18 abcde2.c:19 abcde2.d:20 abcde2.e:21 abcde2.rowid:22!null abcde2.crdb_internal_mvcc_timestamp:23 abcde2.tableoid:24
       │    │    ├── scan abcde
       │    │    │    ├── columns: abcde.a:9!null abcde.b:10 abcde.c:11 abcde.d:12 abcde.e:13 abcde.rowid:14!null abcde.crdb_internal_mvcc_timestamp:15 abcde.tableoid:16
-      │    │    │    └── computed column expressions
-      │    │    │         ├── abcde.d:12
-      │    │    │         │    └── (abcde.b:10 + abcde.c:11) + 1
-      │    │    │         └── abcde.e:13
-      │    │    │              └── abcde.a:9
+      │    │    │    ├── computed column expressions
+      │    │    │    │    ├── abcde.d:12
+      │    │    │    │    │    └── (abcde.b:10 + abcde.c:11) + 1
+      │    │    │    │    └── abcde.e:13
+      │    │    │    │         └── abcde.a:9
+      │    │    │    └── flags: avoid-full-scan
       │    │    ├── scan abcde [as=abcde2]
       │    │    │    ├── columns: abcde2.a:17!null abcde2.b:18 abcde2.c:19 abcde2.d:20 abcde2.e:21 abcde2.rowid:22!null abcde2.crdb_internal_mvcc_timestamp:23 abcde2.tableoid:24
       │    │    │    └── computed column expressions
@@ -609,7 +624,8 @@ delete fgh
       │    ├── inner-join (cross)
       │    │    ├── columns: f:7 g:8 h:9 fgh.rowid:10!null fgh.crdb_internal_mvcc_timestamp:11 fgh.tableoid:12 a:13!null b:14 c:15 d:16 e:17 abcde.rowid:18!null abcde.crdb_internal_mvcc_timestamp:19 abcde.tableoid:20 x:21!null y:22 z:23 xyz.crdb_internal_mvcc_timestamp:24 xyz.tableoid:25
       │    │    ├── scan fgh
-      │    │    │    └── columns: f:7 g:8 h:9 fgh.rowid:10!null fgh.crdb_internal_mvcc_timestamp:11 fgh.tableoid:12
+      │    │    │    ├── columns: f:7 g:8 h:9 fgh.rowid:10!null fgh.crdb_internal_mvcc_timestamp:11 fgh.tableoid:12
+      │    │    │    └── flags: avoid-full-scan
       │    │    ├── inner-join (cross)
       │    │    │    ├── columns: a:13!null b:14 c:15 d:16 e:17 abcde.rowid:18!null abcde.crdb_internal_mvcc_timestamp:19 abcde.tableoid:20 x:21!null y:22 z:23 xyz.crdb_internal_mvcc_timestamp:24 xyz.tableoid:25
       │    │    │    ├── scan abcde
@@ -697,11 +713,12 @@ project
            │    │    ├── columns: a:9!null b:10 c:11 d:12 e:13 abcde.rowid:14!null abcde.crdb_internal_mvcc_timestamp:15 abcde.tableoid:16 f:17 g:18 h:19 fgh.rowid:20!null fgh.crdb_internal_mvcc_timestamp:21 fgh.tableoid:22
            │    │    ├── scan abcde
            │    │    │    ├── columns: a:9!null b:10 c:11 d:12 e:13 abcde.rowid:14!null abcde.crdb_internal_mvcc_timestamp:15 abcde.tableoid:16
-           │    │    │    └── computed column expressions
-           │    │    │         ├── d:12
-           │    │    │         │    └── (b:10 + c:11) + 1
-           │    │    │         └── e:13
-           │    │    │              └── a:9
+           │    │    │    ├── computed column expressions
+           │    │    │    │    ├── d:12
+           │    │    │    │    │    └── (b:10 + c:11) + 1
+           │    │    │    │    └── e:13
+           │    │    │    │         └── a:9
+           │    │    │    └── flags: avoid-full-scan
            │    │    ├── scan fgh
            │    │    │    └── columns: f:17 g:18 h:19 fgh.rowid:20!null fgh.crdb_internal_mvcc_timestamp:21 fgh.tableoid:22
            │    │    └── filters (true)
@@ -761,11 +778,12 @@ project
            │    │    ├── columns: a:9!null b:10 c:11 d:12 e:13 abcde.rowid:14!null abcde.crdb_internal_mvcc_timestamp:15 abcde.tableoid:16 f:17 g:18 h:19 fgh.rowid:20!null fgh.crdb_internal_mvcc_timestamp:21 fgh.tableoid:22
            │    │    ├── scan abcde
            │    │    │    ├── columns: a:9!null b:10 c:11 d:12 e:13 abcde.rowid:14!null abcde.crdb_internal_mvcc_timestamp:15 abcde.tableoid:16
-           │    │    │    └── computed column expressions
-           │    │    │         ├── d:12
-           │    │    │         │    └── (b:10 + c:11) + 1
-           │    │    │         └── e:13
-           │    │    │              └── a:9
+           │    │    │    ├── computed column expressions
+           │    │    │    │    ├── d:12
+           │    │    │    │    │    └── (b:10 + c:11) + 1
+           │    │    │    │    └── e:13
+           │    │    │    │         └── a:9
+           │    │    │    └── flags: avoid-full-scan
            │    │    ├── scan fgh
            │    │    │    └── columns: f:17 g:18 h:19 fgh.rowid:20!null fgh.crdb_internal_mvcc_timestamp:21 fgh.tableoid:22
            │    │    └── filters (true)
@@ -822,7 +840,8 @@ delete mutation [as=foo]
       │    │         ├── inner-join (cross)
       │    │         │    ├── columns: m:7!null n:8 o:9 p:10 foo.crdb_internal_mvcc_timestamp:11 foo.tableoid:12 a:13!null b:14 c:15 d:16 e:17 rowid:18!null bar.crdb_internal_mvcc_timestamp:19 bar.tableoid:20
       │    │         │    ├── scan mutation [as=foo]
-      │    │         │    │    └── columns: m:7!null n:8 o:9 p:10 foo.crdb_internal_mvcc_timestamp:11 foo.tableoid:12
+      │    │         │    │    ├── columns: m:7!null n:8 o:9 p:10 foo.crdb_internal_mvcc_timestamp:11 foo.tableoid:12
+      │    │         │    │    └── flags: avoid-full-scan
       │    │         │    ├── scan abcde [as=bar]
       │    │         │    │    ├── columns: a:13!null b:14 c:15 d:16 e:17 rowid:18!null bar.crdb_internal_mvcc_timestamp:19 bar.tableoid:20
       │    │         │    │    └── computed column expressions
@@ -903,11 +922,12 @@ project
            │    │    ├── columns: a:9!null b:10 c:11 d:12 e:13 abcde.rowid:14!null abcde.crdb_internal_mvcc_timestamp:15 abcde.tableoid:16 f:17 g:18 h:19 fgh.rowid:20!null fgh.crdb_internal_mvcc_timestamp:21 fgh.tableoid:22
            │    │    ├── scan abcde
            │    │    │    ├── columns: a:9!null b:10 c:11 d:12 e:13 abcde.rowid:14!null abcde.crdb_internal_mvcc_timestamp:15 abcde.tableoid:16
-           │    │    │    └── computed column expressions
-           │    │    │         ├── d:12
-           │    │    │         │    └── (b:10 + c:11) + 1
-           │    │    │         └── e:13
-           │    │    │              └── a:9
+           │    │    │    ├── computed column expressions
+           │    │    │    │    ├── d:12
+           │    │    │    │    │    └── (b:10 + c:11) + 1
+           │    │    │    │    └── e:13
+           │    │    │    │         └── a:9
+           │    │    │    └── flags: avoid-full-scan
            │    │    ├── scan fgh
            │    │    │    └── columns: f:17 g:18 h:19 fgh.rowid:20!null fgh.crdb_internal_mvcc_timestamp:21 fgh.tableoid:22
            │    │    └── filters (true)
@@ -967,11 +987,12 @@ project
            │    │    ├── columns: a:9!null b:10 c:11 d:12 e:13 abcde.rowid:14!null abcde.crdb_internal_mvcc_timestamp:15 abcde.tableoid:16 f:17 g:18 h:19 fgh.rowid:20!null fgh.crdb_internal_mvcc_timestamp:21 fgh.tableoid:22
            │    │    ├── scan abcde
            │    │    │    ├── columns: a:9!null b:10 c:11 d:12 e:13 abcde.rowid:14!null abcde.crdb_internal_mvcc_timestamp:15 abcde.tableoid:16
-           │    │    │    └── computed column expressions
-           │    │    │         ├── d:12
-           │    │    │         │    └── (b:10 + c:11) + 1
-           │    │    │         └── e:13
-           │    │    │              └── a:9
+           │    │    │    ├── computed column expressions
+           │    │    │    │    ├── d:12
+           │    │    │    │    │    └── (b:10 + c:11) + 1
+           │    │    │    │    └── e:13
+           │    │    │    │         └── a:9
+           │    │    │    └── flags: avoid-full-scan
            │    │    ├── scan fgh
            │    │    │    └── columns: f:17 g:18 h:19 fgh.rowid:20!null fgh.crdb_internal_mvcc_timestamp:21 fgh.tableoid:22
            │    │    └── filters (true)
@@ -1022,11 +1043,12 @@ delete abcde
       │    │    ├── columns: a:9!null b:10 c:11 d:12 e:13 abcde.rowid:14!null abcde.crdb_internal_mvcc_timestamp:15 abcde.tableoid:16 f:17 g:18 h:19 fgh.rowid:20!null fgh.crdb_internal_mvcc_timestamp:21 fgh.tableoid:22 x:23!null
       │    │    ├── scan abcde
       │    │    │    ├── columns: a:9!null b:10 c:11 d:12 e:13 abcde.rowid:14!null abcde.crdb_internal_mvcc_timestamp:15 abcde.tableoid:16
-      │    │    │    └── computed column expressions
-      │    │    │         ├── d:12
-      │    │    │         │    └── (b:10 + c:11) + 1
-      │    │    │         └── e:13
-      │    │    │              └── a:9
+      │    │    │    ├── computed column expressions
+      │    │    │    │    ├── d:12
+      │    │    │    │    │    └── (b:10 + c:11) + 1
+      │    │    │    │    └── e:13
+      │    │    │    │         └── a:9
+      │    │    │    └── flags: avoid-full-scan
       │    │    ├── inner-join-apply
       │    │    │    ├── columns: f:17 g:18 h:19 fgh.rowid:20!null fgh.crdb_internal_mvcc_timestamp:21 fgh.tableoid:22 x:23!null
       │    │    │    ├── scan fgh
@@ -1100,9 +1122,10 @@ delete pindex
       │    │    │    ├── columns: a:5 rowid:6!null crdb_internal_mvcc_timestamp:7 tableoid:8 column1:9!null column2:10!null
       │    │    │    ├── scan pindex
       │    │    │    │    ├── columns: a:5 rowid:6!null crdb_internal_mvcc_timestamp:7 tableoid:8
-      │    │    │    │    └── partial index predicates
-      │    │    │    │         └── pindex_a_idx: filters
-      │    │    │    │              └── a:5 > 3
+      │    │    │    │    ├── partial index predicates
+      │    │    │    │    │    └── pindex_a_idx: filters
+      │    │    │    │    │         └── a:5 > 3
+      │    │    │    │    └── flags: avoid-full-scan
       │    │    │    ├── values
       │    │    │    │    ├── columns: column1:9!null column2:10!null
       │    │    │    │    └── (5.0, 6.0)
@@ -1155,7 +1178,8 @@ delete hij
       │    ├── inner-join (cross)
       │    │    ├── columns: h:6!null i:7!null j:8 hij.crdb_internal_mvcc_timestamp:9 hij.tableoid:10 a:11!null b:12 c:13 d:14 e:15 rowid:16!null abcde.crdb_internal_mvcc_timestamp:17 abcde.tableoid:18
       │    │    ├── scan hij
-      │    │    │    └── columns: h:6!null i:7!null j:8 hij.crdb_internal_mvcc_timestamp:9 hij.tableoid:10
+      │    │    │    ├── columns: h:6!null i:7!null j:8 hij.crdb_internal_mvcc_timestamp:9 hij.tableoid:10
+      │    │    │    └── flags: avoid-full-scan
       │    │    ├── scan abcde
       │    │    │    ├── columns: a:11!null b:12 c:13 d:14 e:15 rowid:16!null abcde.crdb_internal_mvcc_timestamp:17 abcde.tableoid:18
       │    │    │    └── computed column expressions

--- a/pkg/sql/opt/optbuilder/testdata/fk-checks-delete
+++ b/pkg/sql/opt/optbuilder/testdata/fk-checks-delete
@@ -15,7 +15,8 @@ delete child
  └── select
       ├── columns: c:5!null p:6!null crdb_internal_mvcc_timestamp:7 tableoid:8
       ├── scan child
-      │    └── columns: c:5!null p:6!null crdb_internal_mvcc_timestamp:7 tableoid:8
+      │    ├── columns: c:5!null p:6!null crdb_internal_mvcc_timestamp:7 tableoid:8
+      │    └── flags: avoid-full-scan
       └── filters
            └── c:5 = 4
 
@@ -29,7 +30,8 @@ delete parent
  ├── select
  │    ├── columns: x:6 parent.p:7!null other:8 parent.crdb_internal_mvcc_timestamp:9 parent.tableoid:10
  │    ├── scan parent
- │    │    └── columns: x:6 parent.p:7!null other:8 parent.crdb_internal_mvcc_timestamp:9 parent.tableoid:10
+ │    │    ├── columns: x:6 parent.p:7!null other:8 parent.crdb_internal_mvcc_timestamp:9 parent.tableoid:10
+ │    │    └── flags: avoid-full-scan
  │    └── filters
  │         └── parent.p:7 = 3
  └── f-k-checks
@@ -42,7 +44,7 @@ delete parent
                 │         └──  parent.p:7 => p:11
                 ├── scan child
                 │    ├── columns: child.p:13!null
-                │    └── flags: disabled not visible index feature
+                │    └── flags: avoid-full-scan disabled not visible index feature
                 └── filters
                      └── p:11 = child.p:13
 
@@ -60,7 +62,8 @@ delete parent
  ├── select
  │    ├── columns: x:6 parent.p:7!null parent.other:8 parent.crdb_internal_mvcc_timestamp:9 parent.tableoid:10
  │    ├── scan parent
- │    │    └── columns: x:6 parent.p:7!null parent.other:8 parent.crdb_internal_mvcc_timestamp:9 parent.tableoid:10
+ │    │    ├── columns: x:6 parent.p:7!null parent.other:8 parent.crdb_internal_mvcc_timestamp:9 parent.tableoid:10
+ │    │    └── flags: avoid-full-scan
  │    └── filters
  │         └── parent.p:7 = 3
  └── f-k-checks
@@ -73,7 +76,7 @@ delete parent
       │         │         └──  parent.p:7 => p:11
       │         ├── scan child
       │         │    ├── columns: child.p:13!null
-      │         │    └── flags: disabled not visible index feature
+      │         │    └── flags: avoid-full-scan disabled not visible index feature
       │         └── filters
       │              └── p:11 = child.p:13
       └── f-k-checks-item: child2(p) -> parent(other)
@@ -85,7 +88,7 @@ delete parent
                 │         └──  parent.other:8 => other:16
                 ├── scan child2
                 │    ├── columns: child2.p:18!null
-                │    └── flags: disabled not visible index feature
+                │    └── flags: avoid-full-scan disabled not visible index feature
                 └── filters
                      └── other:16 = child2.p:18
 
@@ -107,7 +110,8 @@ delete doubleparent
  ├── select
  │    ├── columns: doubleparent.p1:6!null doubleparent.p2:7!null other:8 doubleparent.crdb_internal_mvcc_timestamp:9 doubleparent.tableoid:10
  │    ├── scan doubleparent
- │    │    └── columns: doubleparent.p1:6!null doubleparent.p2:7!null other:8 doubleparent.crdb_internal_mvcc_timestamp:9 doubleparent.tableoid:10
+ │    │    ├── columns: doubleparent.p1:6!null doubleparent.p2:7!null other:8 doubleparent.crdb_internal_mvcc_timestamp:9 doubleparent.tableoid:10
+ │    │    └── flags: avoid-full-scan
  │    └── filters
  │         └── doubleparent.p1:6 = 10
  └── f-k-checks
@@ -121,7 +125,7 @@ delete doubleparent
                 │         └──  doubleparent.p2:7 => p2:12
                 ├── scan doublechild
                 │    ├── columns: doublechild.p1:14 doublechild.p2:15
-                │    └── flags: disabled not visible index feature
+                │    └── flags: avoid-full-scan disabled not visible index feature
                 └── filters
                      ├── p1:11 = doublechild.p1:14
                      └── p2:12 = doublechild.p2:15
@@ -135,7 +139,8 @@ delete doublechild
  └── select
       ├── columns: c:6!null p1:7!null p2:8 crdb_internal_mvcc_timestamp:9 tableoid:10
       ├── scan doublechild
-      │    └── columns: c:6!null p1:7 p2:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+      │    ├── columns: c:6!null p1:7 p2:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+      │    └── flags: avoid-full-scan
       └── filters
            └── p1:7 = 10
 
@@ -150,7 +155,8 @@ delete parent
  ├── select
  │    ├── columns: x:6 parent.p:7!null parent.other:8 parent.crdb_internal_mvcc_timestamp:9 parent.tableoid:10
  │    ├── scan parent
- │    │    └── columns: x:6 parent.p:7!null parent.other:8 parent.crdb_internal_mvcc_timestamp:9 parent.tableoid:10
+ │    │    ├── columns: x:6 parent.p:7!null parent.other:8 parent.crdb_internal_mvcc_timestamp:9 parent.tableoid:10
+ │    │    └── flags: avoid-full-scan
  │    └── filters
  │         └── parent.p:7 = 3
  └── f-k-checks
@@ -164,7 +170,7 @@ delete parent
       │         │         └──  parent.p:7 => p:11
       │         ├── scan child
       │         │    ├── columns: child.p:13!null
-      │         │    └── flags: disabled not visible index feature
+      │         │    └── flags: avoid-full-scan disabled not visible index feature
       │         └── filters
       │              └── p:11 = child.p:13
       └── f-k-checks-item: child2(p) -> parent(other)
@@ -177,7 +183,7 @@ delete parent
                 │         └──  parent.other:8 => other:16
                 ├── scan child2
                 │    ├── columns: child2.p:18!null
-                │    └── flags: disabled not visible index feature
+                │    └── flags: avoid-full-scan disabled not visible index feature
                 └── filters
                      └── other:16 = child2.p:18
 
@@ -192,7 +198,8 @@ delete parent
  ├── select
  │    ├── columns: x:6 parent.p:7!null parent.other:8 parent.crdb_internal_mvcc_timestamp:9 parent.tableoid:10
  │    ├── scan parent
- │    │    └── columns: x:6 parent.p:7!null parent.other:8 parent.crdb_internal_mvcc_timestamp:9 parent.tableoid:10
+ │    │    ├── columns: x:6 parent.p:7!null parent.other:8 parent.crdb_internal_mvcc_timestamp:9 parent.tableoid:10
+ │    │    └── flags: avoid-full-scan
  │    └── filters
  │         └── parent.p:7 = 3
  └── f-k-checks
@@ -205,7 +212,7 @@ delete parent
       │         │         └──  parent.p:7 => p:11
       │         ├── scan child
       │         │    ├── columns: child.p:13!null
-      │         │    └── flags: disabled not visible index feature
+      │         │    └── flags: avoid-full-scan disabled not visible index feature
       │         └── filters
       │              └── p:11 = child.p:13
       └── f-k-checks-item: child2(p) -> parent(other)
@@ -217,6 +224,6 @@ delete parent
                 │         └──  parent.other:8 => other:16
                 ├── scan child2
                 │    ├── columns: child2.p:18!null
-                │    └── flags: disabled not visible index feature
+                │    └── flags: avoid-full-scan disabled not visible index feature
                 └── filters
                      └── other:16 = child2.p:18

--- a/pkg/sql/opt/optbuilder/testdata/fk-checks-insert
+++ b/pkg/sql/opt/optbuilder/testdata/fk-checks-insert
@@ -29,7 +29,7 @@ insert child
                 │         └──  column2:6 => p:7
                 ├── scan parent
                 │    ├── columns: parent.p:8!null
-                │    └── flags: disabled not visible index feature
+                │    └── flags: avoid-full-scan disabled not visible index feature
                 └── filters
                      └── p:7 = parent.p:8
 
@@ -54,7 +54,7 @@ insert child
  │    │    │    └── (200, 1)
  │    │    ├── scan child
  │    │    │    ├── columns: c:7!null child.p:8!null
- │    │    │    └── flags: disabled not visible index feature
+ │    │    │    └── flags: avoid-full-scan disabled not visible index feature
  │    │    └── filters
  │    │         └── column1:5 = c:7
  │    └── aggregations
@@ -70,7 +70,7 @@ insert child
                 │         └──  column2:6 => p:11
                 ├── scan parent
                 │    ├── columns: parent.p:12!null
-                │    └── flags: disabled not visible index feature
+                │    └── flags: avoid-full-scan disabled not visible index feature
                 └── filters
                      └── p:11 = parent.p:12
 
@@ -102,7 +102,7 @@ insert child
                 │         └──  y:6 => p:10
                 ├── scan parent
                 │    ├── columns: parent.p:11!null
-                │    └── flags: disabled not visible index feature
+                │    └── flags: avoid-full-scan disabled not visible index feature
                 └── filters
                      └── p:10 = parent.p:11
 
@@ -139,7 +139,7 @@ insert child_nullable
                 │         └── p:7 IS NOT NULL
                 ├── scan parent
                 │    ├── columns: parent.p:8!null
-                │    └── flags: disabled not visible index feature
+                │    └── flags: avoid-full-scan disabled not visible index feature
                 └── filters
                      └── p:7 = parent.p:8
 
@@ -168,7 +168,7 @@ insert child_nullable
                 │         └──  column2:6 => p:7
                 ├── scan parent
                 │    ├── columns: parent.p:8!null
-                │    └── flags: disabled not visible index feature
+                │    └── flags: avoid-full-scan disabled not visible index feature
                 └── filters
                      └── p:7 = parent.p:8
 
@@ -240,7 +240,7 @@ insert child_nullable_full
                 │         └── p:7 IS NOT NULL
                 ├── scan parent
                 │    ├── columns: parent.p:8!null
-                │    └── flags: disabled not visible index feature
+                │    └── flags: avoid-full-scan disabled not visible index feature
                 └── filters
                      └── p:7 = parent.p:8
 
@@ -309,7 +309,7 @@ insert multi_col_child
                 │         └── r:13 IS NOT NULL
                 ├── scan multi_col_parent
                 │    ├── columns: multi_col_parent.p:14!null multi_col_parent.q:15!null multi_col_parent.r:16!null
-                │    └── flags: disabled not visible index feature
+                │    └── flags: avoid-full-scan disabled not visible index feature
                 └── filters
                      ├── p:11 = multi_col_parent.p:14
                      ├── q:12 = multi_col_parent.q:15
@@ -348,7 +348,7 @@ insert multi_col_child
                 │         └── q:12 IS NOT NULL
                 ├── scan multi_col_parent
                 │    ├── columns: multi_col_parent.p:14!null multi_col_parent.q:15!null multi_col_parent.r:16!null
-                │    └── flags: disabled not visible index feature
+                │    └── flags: avoid-full-scan disabled not visible index feature
                 └── filters
                      ├── p:11 = multi_col_parent.p:14
                      ├── q:12 = multi_col_parent.q:15
@@ -381,7 +381,7 @@ insert multi_col_child
                 │         └──  column4:10 => r:13
                 ├── scan multi_col_parent
                 │    ├── columns: multi_col_parent.p:14!null multi_col_parent.q:15!null multi_col_parent.r:16!null
-                │    └── flags: disabled not visible index feature
+                │    └── flags: avoid-full-scan disabled not visible index feature
                 └── filters
                      ├── p:11 = multi_col_parent.p:14
                      ├── q:12 = multi_col_parent.q:15
@@ -444,7 +444,7 @@ insert multi_col_child_full
                 │         └── ((p:11 IS NOT NULL) OR (q:12 IS NOT NULL)) OR (r:13 IS NOT NULL)
                 ├── scan multi_col_parent
                 │    ├── columns: multi_col_parent.p:14!null multi_col_parent.q:15!null multi_col_parent.r:16!null
-                │    └── flags: disabled not visible index feature
+                │    └── flags: avoid-full-scan disabled not visible index feature
                 └── filters
                      ├── p:11 = multi_col_parent.p:14
                      ├── q:12 = multi_col_parent.q:15
@@ -478,7 +478,7 @@ insert multi_col_child_full
                 │         └──  column4:10 => r:13
                 ├── scan multi_col_parent
                 │    ├── columns: multi_col_parent.p:14!null multi_col_parent.q:15!null multi_col_parent.r:16!null
-                │    └── flags: disabled not visible index feature
+                │    └── flags: avoid-full-scan disabled not visible index feature
                 └── filters
                      ├── p:11 = multi_col_parent.p:14
                      ├── q:12 = multi_col_parent.q:15
@@ -511,7 +511,7 @@ insert multi_col_child_full
                 │         └──  column4:10 => r:13
                 ├── scan multi_col_parent
                 │    ├── columns: multi_col_parent.p:14!null multi_col_parent.q:15!null multi_col_parent.r:16!null
-                │    └── flags: disabled not visible index feature
+                │    └── flags: avoid-full-scan disabled not visible index feature
                 └── filters
                      ├── p:11 = multi_col_parent.p:14
                      ├── q:12 = multi_col_parent.q:15
@@ -562,7 +562,7 @@ insert multi_col_child_full
                 │         └──  column4:10 => r:13
                 ├── scan multi_col_parent
                 │    ├── columns: multi_col_parent.p:14!null multi_col_parent.q:15!null multi_col_parent.r:16!null
-                │    └── flags: disabled not visible index feature
+                │    └── flags: avoid-full-scan disabled not visible index feature
                 └── filters
                      ├── p:11 = multi_col_parent.p:14
                      ├── q:12 = multi_col_parent.q:15
@@ -617,7 +617,7 @@ insert multi_ref_child
       │         │         └── a:11 IS NOT NULL
       │         ├── scan multi_ref_parent_a
       │         │    ├── columns: multi_ref_parent_a.a:12!null
-      │         │    └── flags: disabled not visible index feature
+      │         │    └── flags: avoid-full-scan disabled not visible index feature
       │         └── filters
       │              └── a:11 = multi_ref_parent_a.a:12
       └── f-k-checks-item: multi_ref_child(b,c) -> multi_ref_parent_bc(b,c)
@@ -635,7 +635,7 @@ insert multi_ref_child
                 │         └── c:17 IS NOT NULL
                 ├── scan multi_ref_parent_bc
                 │    ├── columns: multi_ref_parent_bc.b:18!null multi_ref_parent_bc.c:19!null
-                │    └── flags: disabled not visible index feature
+                │    └── flags: avoid-full-scan disabled not visible index feature
                 └── filters
                      ├── b:16 = multi_ref_parent_bc.b:18
                      └── c:17 = multi_ref_parent_bc.c:19
@@ -681,7 +681,7 @@ insert child
                 │         └──  column2:6 => p:7
                 ├── scan parent
                 │    ├── columns: parent.p:8!null
-                │    └── flags: disabled not visible index feature
+                │    └── flags: avoid-full-scan disabled not visible index feature
                 └── filters
                      └── p:7 = parent.p:8
 
@@ -709,7 +709,7 @@ insert child
                 │         └──  column2:6 => p:7
                 ├── scan parent
                 │    ├── columns: parent.p:8!null
-                │    ├── flags: disabled not visible index feature
+                │    ├── flags: avoid-full-scan disabled not visible index feature
                 │    └── locking: for-share
                 └── filters
                      └── p:7 = parent.p:8

--- a/pkg/sql/opt/optbuilder/testdata/fk-checks-update
+++ b/pkg/sql/opt/optbuilder/testdata/fk-checks-update
@@ -18,7 +18,8 @@ update child
  ├── project
  │    ├── columns: p_new:9!null c:5!null child.p:6!null child.crdb_internal_mvcc_timestamp:7 child.tableoid:8
  │    ├── scan child
- │    │    └── columns: c:5!null child.p:6!null child.crdb_internal_mvcc_timestamp:7 child.tableoid:8
+ │    │    ├── columns: c:5!null child.p:6!null child.crdb_internal_mvcc_timestamp:7 child.tableoid:8
+ │    │    └── flags: avoid-full-scan
  │    └── projections
  │         └── 4 [as=p_new:9]
  └── f-k-checks
@@ -31,7 +32,7 @@ update child
                 │         └──  p_new:9 => p:10
                 ├── scan parent
                 │    ├── columns: parent.p:12!null
-                │    └── flags: disabled not visible index feature
+                │    └── flags: avoid-full-scan disabled not visible index feature
                 └── filters
                      └── p:10 = parent.p:12
 
@@ -47,7 +48,8 @@ update parent
  ├── project
  │    ├── columns: p_new:11!null x:6 parent.p:7!null other:8 parent.crdb_internal_mvcc_timestamp:9 parent.tableoid:10
  │    ├── scan parent
- │    │    └── columns: x:6 parent.p:7!null other:8 parent.crdb_internal_mvcc_timestamp:9 parent.tableoid:10
+ │    │    ├── columns: x:6 parent.p:7!null other:8 parent.crdb_internal_mvcc_timestamp:9 parent.tableoid:10
+ │    │    └── flags: avoid-full-scan
  │    └── projections
  │         └── parent.p:7 + 1 [as=p_new:11]
  └── f-k-checks
@@ -68,7 +70,7 @@ update parent
                 │              └──  p_new:11 => p:13
                 ├── scan child
                 │    ├── columns: child.p:15!null
-                │    └── flags: disabled not visible index feature
+                │    └── flags: avoid-full-scan disabled not visible index feature
                 └── filters
                      └── p:12 = child.p:15
 
@@ -88,7 +90,8 @@ update child
  ├── project
  │    ├── columns: c_new:9!null child.c:5!null p:6!null child.crdb_internal_mvcc_timestamp:7 child.tableoid:8
  │    ├── scan child
- │    │    └── columns: child.c:5!null p:6!null child.crdb_internal_mvcc_timestamp:7 child.tableoid:8
+ │    │    ├── columns: child.c:5!null p:6!null child.crdb_internal_mvcc_timestamp:7 child.tableoid:8
+ │    │    └── flags: avoid-full-scan
  │    └── projections
  │         └── 4 [as=c_new:9]
  └── f-k-checks
@@ -109,7 +112,7 @@ update child
                 │              └──  c_new:9 => c:11
                 ├── scan grandchild
                 │    ├── columns: grandchild.c:13!null
-                │    └── flags: disabled not visible index feature
+                │    └── flags: avoid-full-scan disabled not visible index feature
                 └── filters
                      └── c:10 = grandchild.c:13
 
@@ -126,7 +129,8 @@ update child
  ├── project
  │    ├── columns: p_new:9!null c:5!null child.p:6!null child.crdb_internal_mvcc_timestamp:7 child.tableoid:8
  │    ├── scan child
- │    │    └── columns: c:5!null child.p:6!null child.crdb_internal_mvcc_timestamp:7 child.tableoid:8
+ │    │    ├── columns: c:5!null child.p:6!null child.crdb_internal_mvcc_timestamp:7 child.tableoid:8
+ │    │    └── flags: avoid-full-scan
  │    └── projections
  │         └── 4 [as=p_new:9]
  └── f-k-checks
@@ -139,7 +143,7 @@ update child
                 │         └──  p_new:9 => p:10
                 ├── scan parent
                 │    ├── columns: parent.p:12!null
-                │    └── flags: disabled not visible index feature
+                │    └── flags: avoid-full-scan disabled not visible index feature
                 └── filters
                      └── p:10 = parent.p:12
 
@@ -153,7 +157,8 @@ update child
  │    └── child.p:6 => child.p:2
  ├── input binding: &1
  ├── scan child
- │    └── columns: c:5!null child.p:6!null child.crdb_internal_mvcc_timestamp:7 child.tableoid:8
+ │    ├── columns: c:5!null child.p:6!null child.crdb_internal_mvcc_timestamp:7 child.tableoid:8
+ │    └── flags: avoid-full-scan
  └── f-k-checks
       └── f-k-checks-item: child(p) -> parent(p)
            └── anti-join (hash)
@@ -164,7 +169,7 @@ update child
                 │         └──  child.p:6 => p:9
                 ├── scan parent
                 │    ├── columns: parent.p:11!null
-                │    └── flags: disabled not visible index feature
+                │    └── flags: avoid-full-scan disabled not visible index feature
                 └── filters
                      └── p:9 = parent.p:11
 
@@ -181,7 +186,8 @@ update child
  ├── project
  │    ├── columns: p_new:9!null c_new:10!null child.c:5!null child.p:6!null child.crdb_internal_mvcc_timestamp:7 child.tableoid:8
  │    ├── scan child
- │    │    └── columns: child.c:5!null child.p:6!null child.crdb_internal_mvcc_timestamp:7 child.tableoid:8
+ │    │    ├── columns: child.c:5!null child.p:6!null child.crdb_internal_mvcc_timestamp:7 child.tableoid:8
+ │    │    └── flags: avoid-full-scan
  │    └── projections
  │         ├── child.p:6 + 1 [as=p_new:9]
  │         └── child.c:5 + 1 [as=c_new:10]
@@ -195,7 +201,7 @@ update child
       │         │         └──  p_new:9 => p:11
       │         ├── scan parent
       │         │    ├── columns: parent.p:13!null
-      │         │    └── flags: disabled not visible index feature
+      │         │    └── flags: avoid-full-scan disabled not visible index feature
       │         └── filters
       │              └── p:11 = parent.p:13
       └── f-k-checks-item: grandchild(c) -> child(c)
@@ -215,7 +221,7 @@ update child
                 │              └──  c_new:10 => c:18
                 ├── scan grandchild
                 │    ├── columns: grandchild.c:20!null
-                │    └── flags: disabled not visible index feature
+                │    └── flags: avoid-full-scan disabled not visible index feature
                 └── filters
                      └── c:17 = grandchild.c:20
 
@@ -236,7 +242,8 @@ update child_nullable
  └── project
       ├── columns: p_new:9 c:5!null p:6 crdb_internal_mvcc_timestamp:7 tableoid:8
       ├── scan child_nullable
-      │    └── columns: c:5!null p:6 crdb_internal_mvcc_timestamp:7 tableoid:8
+      │    ├── columns: c:5!null p:6 crdb_internal_mvcc_timestamp:7 tableoid:8
+      │    └── flags: avoid-full-scan
       └── projections
            └── NULL::INT8 [as=p_new:9]
 
@@ -257,7 +264,8 @@ update child
  ├── project
  │    ├── columns: p_new:9!null c:5!null child.p:6!null child.crdb_internal_mvcc_timestamp:7 child.tableoid:8
  │    ├── scan child
- │    │    └── columns: c:5!null child.p:6!null child.crdb_internal_mvcc_timestamp:7 child.tableoid:8
+ │    │    ├── columns: c:5!null child.p:6!null child.crdb_internal_mvcc_timestamp:7 child.tableoid:8
+ │    │    └── flags: avoid-full-scan
  │    └── projections
  │         └── 4 [as=p_new:9]
  └── f-k-checks
@@ -270,7 +278,7 @@ update child
                 │         └──  p_new:9 => p:10
                 ├── scan parent
                 │    ├── columns: parent.p:12!null
-                │    └── flags: disabled not visible index feature
+                │    └── flags: avoid-full-scan disabled not visible index feature
                 └── filters
                      └── p:10 = parent.p:12
 
@@ -290,7 +298,8 @@ update self
  ├── project
  │    ├── columns: y_new:9!null x:5!null self.y:6!null crdb_internal_mvcc_timestamp:7 tableoid:8
  │    ├── scan self
- │    │    └── columns: x:5!null self.y:6!null crdb_internal_mvcc_timestamp:7 tableoid:8
+ │    │    ├── columns: x:5!null self.y:6!null crdb_internal_mvcc_timestamp:7 tableoid:8
+ │    │    └── flags: avoid-full-scan
  │    └── projections
  │         └── 3 [as=y_new:9]
  └── f-k-checks
@@ -303,7 +312,7 @@ update self
                 │         └──  y_new:9 => y:10
                 ├── scan self
                 │    ├── columns: x:11!null
-                │    └── flags: disabled not visible index feature
+                │    └── flags: avoid-full-scan disabled not visible index feature
                 └── filters
                      └── y:10 = x:11
 
@@ -319,7 +328,8 @@ update self
  ├── project
  │    ├── columns: x_new:9!null self.x:5!null y:6!null crdb_internal_mvcc_timestamp:7 tableoid:8
  │    ├── scan self
- │    │    └── columns: self.x:5!null y:6!null crdb_internal_mvcc_timestamp:7 tableoid:8
+ │    │    ├── columns: self.x:5!null y:6!null crdb_internal_mvcc_timestamp:7 tableoid:8
+ │    │    └── flags: avoid-full-scan
  │    └── projections
  │         └── 3 [as=x_new:9]
  └── f-k-checks
@@ -340,7 +350,7 @@ update self
                 │              └──  x_new:9 => x:11
                 ├── scan self
                 │    ├── columns: y:13!null
-                │    └── flags: disabled not visible index feature
+                │    └── flags: avoid-full-scan disabled not visible index feature
                 └── filters
                      └── x:10 = y:13
 
@@ -372,7 +382,8 @@ update child_multicol_simple
       ├── select
       │    ├── columns: k:7!null a:8 b:9 c:10 crdb_internal_mvcc_timestamp:11 tableoid:12
       │    ├── scan child_multicol_simple
-      │    │    └── columns: k:7!null a:8 b:9 c:10 crdb_internal_mvcc_timestamp:11 tableoid:12
+      │    │    ├── columns: k:7!null a:8 b:9 c:10 crdb_internal_mvcc_timestamp:11 tableoid:12
+      │    │    └── flags: avoid-full-scan
       │    └── filters
       │         └── k:7 = 1
       └── projections
@@ -404,7 +415,8 @@ update child_multicol_full
  │    ├── select
  │    │    ├── columns: k:7!null child_multicol_full.a:8 child_multicol_full.b:9 child_multicol_full.c:10 child_multicol_full.crdb_internal_mvcc_timestamp:11 child_multicol_full.tableoid:12
  │    │    ├── scan child_multicol_full
- │    │    │    └── columns: k:7!null child_multicol_full.a:8 child_multicol_full.b:9 child_multicol_full.c:10 child_multicol_full.crdb_internal_mvcc_timestamp:11 child_multicol_full.tableoid:12
+ │    │    │    ├── columns: k:7!null child_multicol_full.a:8 child_multicol_full.b:9 child_multicol_full.c:10 child_multicol_full.crdb_internal_mvcc_timestamp:11 child_multicol_full.tableoid:12
+ │    │    │    └── flags: avoid-full-scan
  │    │    └── filters
  │    │         └── k:7 = 1
  │    └── projections
@@ -422,7 +434,7 @@ update child_multicol_full
                 │         └──  a_new:13 => c:17
                 ├── scan parent_multicol
                 │    ├── columns: parent_multicol.a:18!null parent_multicol.b:19!null parent_multicol.c:20!null
-                │    └── flags: disabled not visible index feature
+                │    └── flags: avoid-full-scan disabled not visible index feature
                 └── filters
                      ├── a:15 = parent_multicol.a:18
                      ├── b:16 = parent_multicol.b:19
@@ -443,7 +455,8 @@ update child_multicol_full
       ├── select
       │    ├── columns: k:7!null a:8 b:9 c:10 crdb_internal_mvcc_timestamp:11 tableoid:12
       │    ├── scan child_multicol_full
-      │    │    └── columns: k:7!null a:8 b:9 c:10 crdb_internal_mvcc_timestamp:11 tableoid:12
+      │    │    ├── columns: k:7!null a:8 b:9 c:10 crdb_internal_mvcc_timestamp:11 tableoid:12
+      │    │    └── flags: avoid-full-scan
       │    └── filters
       │         └── k:7 = 1
       └── projections
@@ -482,7 +495,8 @@ update fam
  ├── project
  │    ├── columns: c_new:17!null fam.a:9 fam.b:10 fam.c:11 fam.d:12 rowid:14!null
  │    ├── scan fam
- │    │    └── columns: fam.a:9 fam.b:10 fam.c:11 fam.d:12 rowid:14!null
+ │    │    ├── columns: fam.a:9 fam.b:10 fam.c:11 fam.d:12 rowid:14!null
+ │    │    └── flags: avoid-full-scan
  │    └── projections
  │         └── 3 [as=c_new:17]
  └── f-k-checks
@@ -500,7 +514,7 @@ update fam
                 │         └── d:19 IS NOT NULL
                 ├── scan two
                 │    ├── columns: two.a:20!null two.b:21!null
-                │    └── flags: disabled not visible index feature
+                │    └── flags: avoid-full-scan disabled not visible index feature
                 └── filters
                      ├── c:18 = two.a:20
                      └── d:19 = two.b:21
@@ -517,7 +531,8 @@ update fam
  ├── project
  │    ├── columns: d_new:17!null fam.c:11 fam.d:12 e:13 rowid:14!null
  │    ├── scan fam
- │    │    └── columns: fam.c:11 fam.d:12 e:13 rowid:14!null
+ │    │    ├── columns: fam.c:11 fam.d:12 e:13 rowid:14!null
+ │    │    └── flags: avoid-full-scan
  │    └── projections
  │         └── 3 [as=d_new:17]
  └── f-k-checks
@@ -535,7 +550,7 @@ update fam
                 │         └── c:18 IS NOT NULL
                 ├── scan two
                 │    ├── columns: two.a:20!null two.b:21!null
-                │    └── flags: disabled not visible index feature
+                │    └── flags: avoid-full-scan disabled not visible index feature
                 └── filters
                      ├── c:18 = two.a:20
                      └── d:19 = two.b:21
@@ -553,7 +568,8 @@ update child
  ├── project
  │    ├── columns: p_new:9!null c:5!null child.p:6!null child.crdb_internal_mvcc_timestamp:7 child.tableoid:8
  │    ├── scan child
- │    │    └── columns: c:5!null child.p:6!null child.crdb_internal_mvcc_timestamp:7 child.tableoid:8
+ │    │    ├── columns: c:5!null child.p:6!null child.crdb_internal_mvcc_timestamp:7 child.tableoid:8
+ │    │    └── flags: avoid-full-scan
  │    └── projections
  │         └── 4 [as=p_new:9]
  └── f-k-checks
@@ -567,7 +583,7 @@ update child
                 │         └──  p_new:9 => p:10
                 ├── scan parent
                 │    ├── columns: parent.p:12!null
-                │    └── flags: disabled not visible index feature
+                │    └── flags: avoid-full-scan disabled not visible index feature
                 └── filters
                      └── p:10 = parent.p:12
 
@@ -585,7 +601,8 @@ update child
  ├── project
  │    ├── columns: p_new:9!null c_new:10!null child.c:5!null child.p:6!null child.crdb_internal_mvcc_timestamp:7 child.tableoid:8
  │    ├── scan child
- │    │    └── columns: child.c:5!null child.p:6!null child.crdb_internal_mvcc_timestamp:7 child.tableoid:8
+ │    │    ├── columns: child.c:5!null child.p:6!null child.crdb_internal_mvcc_timestamp:7 child.tableoid:8
+ │    │    └── flags: avoid-full-scan
  │    └── projections
  │         ├── child.p:6 + 1 [as=p_new:9]
  │         └── child.c:5 + 1 [as=c_new:10]
@@ -599,7 +616,7 @@ update child
       │         │         └──  p_new:9 => p:11
       │         ├── scan parent
       │         │    ├── columns: parent.p:13!null
-      │         │    ├── flags: disabled not visible index feature
+      │         │    ├── flags: avoid-full-scan disabled not visible index feature
       │         │    └── locking: for-share
       │         └── filters
       │              └── p:11 = parent.p:13
@@ -620,7 +637,7 @@ update child
       │         │              └──  c_new:10 => c:18
       │         ├── scan grandchild
       │         │    ├── columns: grandchild.c:20!null
-      │         │    └── flags: disabled not visible index feature
+      │         │    └── flags: avoid-full-scan disabled not visible index feature
       │         └── filters
       │              └── c:17 = grandchild.c:20
       └── f-k-checks-item: grandchild2(c) -> child(c)
@@ -640,7 +657,7 @@ update child
                 │              └──  c_new:10 => c:24
                 ├── scan grandchild2
                 │    ├── columns: grandchild2.c:26!null
-                │    └── flags: disabled not visible index feature
+                │    └── flags: avoid-full-scan disabled not visible index feature
                 └── filters
                      └── c:23 = grandchild2.c:26
 
@@ -656,7 +673,8 @@ update self
  ├── project
  │    ├── columns: y_new:9!null x:5!null self.y:6!null crdb_internal_mvcc_timestamp:7 tableoid:8
  │    ├── scan self
- │    │    └── columns: x:5!null self.y:6!null crdb_internal_mvcc_timestamp:7 tableoid:8
+ │    │    ├── columns: x:5!null self.y:6!null crdb_internal_mvcc_timestamp:7 tableoid:8
+ │    │    └── flags: avoid-full-scan
  │    └── projections
  │         └── 3 [as=y_new:9]
  └── f-k-checks
@@ -669,7 +687,7 @@ update self
                 │         └──  y_new:9 => y:10
                 ├── scan self
                 │    ├── columns: x:11!null
-                │    ├── flags: disabled not visible index feature
+                │    ├── flags: avoid-full-scan disabled not visible index feature
                 │    └── locking: for-share
                 └── filters
                      └── y:10 = x:11
@@ -686,7 +704,8 @@ update self
  ├── project
  │    ├── columns: x_new:9!null self.x:5!null y:6!null crdb_internal_mvcc_timestamp:7 tableoid:8
  │    ├── scan self
- │    │    └── columns: self.x:5!null y:6!null crdb_internal_mvcc_timestamp:7 tableoid:8
+ │    │    ├── columns: self.x:5!null y:6!null crdb_internal_mvcc_timestamp:7 tableoid:8
+ │    │    └── flags: avoid-full-scan
  │    └── projections
  │         └── 3 [as=x_new:9]
  └── f-k-checks
@@ -707,6 +726,6 @@ update self
                 │              └──  x_new:9 => x:11
                 ├── scan self
                 │    ├── columns: y:13!null
-                │    └── flags: disabled not visible index feature
+                │    └── flags: avoid-full-scan disabled not visible index feature
                 └── filters
                      └── x:10 = y:13

--- a/pkg/sql/opt/optbuilder/testdata/fk-checks-upsert
+++ b/pkg/sql/opt/optbuilder/testdata/fk-checks-upsert
@@ -58,7 +58,7 @@ upsert c1
                 │         └──  column2:7 => p:9
                 ├── scan p
                 │    ├── columns: p.p:10!null
-                │    └── flags: disabled not visible index feature
+                │    └── flags: avoid-full-scan disabled not visible index feature
                 └── filters
                      └── p:9 = p.p:10
 
@@ -98,7 +98,7 @@ upsert c1
  │    │    │              └── i_default:8
  │    │    ├── scan c1
  │    │    │    ├── columns: c:9!null c1.p:10!null i:11 c1.crdb_internal_mvcc_timestamp:12 c1.tableoid:13
- │    │    │    └── flags: disabled not visible index feature
+ │    │    │    └── flags: avoid-full-scan disabled not visible index feature
  │    │    └── filters
  │    │         └── column1:6 = c:9
  │    └── projections
@@ -115,7 +115,7 @@ upsert c1
                 │         └──  upsert_p:15 => p:17
                 ├── scan p
                 │    ├── columns: p.p:18!null
-                │    └── flags: disabled not visible index feature
+                │    └── flags: avoid-full-scan disabled not visible index feature
                 └── filters
                      └── p:17 = p.p:18
 
@@ -148,7 +148,7 @@ upsert c1
                 │         └──  y:7 => p:14
                 ├── scan p
                 │    ├── columns: p.p:15!null
-                │    └── flags: disabled not visible index feature
+                │    └── flags: avoid-full-scan disabled not visible index feature
                 └── filters
                      └── p:14 = p.p:15
 
@@ -191,7 +191,7 @@ upsert c1
  │    │    │    │              └── i_default:8
  │    │    │    ├── scan c1
  │    │    │    │    ├── columns: c:9!null c1.p:10!null i:11 c1.crdb_internal_mvcc_timestamp:12 c1.tableoid:13
- │    │    │    │    └── flags: disabled not visible index feature
+ │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
  │    │    │    └── filters
  │    │    │         └── column1:6 = c:9
  │    │    └── projections
@@ -210,7 +210,7 @@ upsert c1
                 │         └──  upsert_p:16 => p:18
                 ├── scan p
                 │    ├── columns: p.p:19!null
-                │    └── flags: disabled not visible index feature
+                │    └── flags: avoid-full-scan disabled not visible index feature
                 └── filters
                      └── p:18 = p.p:19
 
@@ -253,7 +253,7 @@ upsert c1
  │    │    │    │              └── i_default:11
  │    │    │    ├── scan c1
  │    │    │    │    ├── columns: c:12!null c1.p:13!null i:14 c1.crdb_internal_mvcc_timestamp:15 c1.tableoid:16
- │    │    │    │    └── flags: disabled not visible index feature
+ │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
  │    │    │    └── filters
  │    │    │         └── u:6 = c:12
  │    │    └── projections
@@ -272,7 +272,7 @@ upsert c1
                 │         └──  upsert_p:19 => p:21
                 ├── scan p
                 │    ├── columns: p.p:22!null
-                │    └── flags: disabled not visible index feature
+                │    └── flags: avoid-full-scan disabled not visible index feature
                 └── filters
                      └── p:21 = p.p:22
 
@@ -308,7 +308,7 @@ upsert c2
  │    │    │    │         └── (2,)
  │    │    │    ├── scan c2
  │    │    │    │    ├── columns: c2.c:5!null c2.crdb_internal_mvcc_timestamp:6 c2.tableoid:7
- │    │    │    │    └── flags: disabled not visible index feature
+ │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
  │    │    │    └── filters
  │    │    │         └── column1:4 = c2.c:5
  │    │    └── projections
@@ -325,7 +325,7 @@ upsert c2
                 │         └──  upsert_c:9 => c:10
                 ├── scan p
                 │    ├── columns: p:11!null
-                │    └── flags: disabled not visible index feature
+                │    └── flags: avoid-full-scan disabled not visible index feature
                 └── filters
                      └── c:10 = p:11
 
@@ -362,7 +362,7 @@ upsert c3
                 │         └── p:7 IS NOT NULL
                 ├── scan p
                 │    ├── columns: p.p:8!null
-                │    └── flags: disabled not visible index feature
+                │    └── flags: avoid-full-scan disabled not visible index feature
                 └── filters
                      └── p:7 = p.p:8
 
@@ -398,7 +398,7 @@ upsert c3
  │    │    │              └── p_default:6
  │    │    ├── scan c3
  │    │    │    ├── columns: c:7!null c3.p:8 c3.crdb_internal_mvcc_timestamp:9 c3.tableoid:10
- │    │    │    └── flags: disabled not visible index feature
+ │    │    │    └── flags: avoid-full-scan disabled not visible index feature
  │    │    └── filters
  │    │         └── column1:5 = c:7
  │    └── projections
@@ -418,7 +418,7 @@ upsert c3
                 │         └── p:13 IS NOT NULL
                 ├── scan p
                 │    ├── columns: p.p:14!null
-                │    └── flags: disabled not visible index feature
+                │    └── flags: avoid-full-scan disabled not visible index feature
                 └── filters
                      └── p:13 = p.p:14
 
@@ -461,7 +461,7 @@ upsert c4
  │    │    │    │              └── z:8
  │    │    │    ├── scan c4
  │    │    │    │    ├── columns: c:13!null c4.a:14 c4.other:15 c4.crdb_internal_mvcc_timestamp:16 c4.tableoid:17
- │    │    │    │    └── flags: disabled not visible index feature
+ │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
  │    │    │    └── filters
  │    │    │         └── y:7 = c4.a:14
  │    │    └── projections
@@ -484,7 +484,7 @@ upsert c4
                 │         └── a:22 IS NOT NULL
                 ├── scan p
                 │    ├── columns: p:23!null
-                │    └── flags: disabled not visible index feature
+                │    └── flags: avoid-full-scan disabled not visible index feature
                 └── filters
                      └── a:22 = p:23
 
@@ -523,7 +523,7 @@ upsert c4
  │    │    │    │              └── z:8
  │    │    │    ├── scan c4
  │    │    │    │    ├── columns: c:13!null c4.a:14 c4.other:15 c4.crdb_internal_mvcc_timestamp:16 c4.tableoid:17
- │    │    │    │    └── flags: disabled not visible index feature
+ │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
  │    │    │    └── filters
  │    │    │         └── y:7 = c4.a:14
  │    │    └── projections
@@ -546,7 +546,7 @@ upsert c4
                 │         └── a:22 IS NOT NULL
                 ├── scan p
                 │    ├── columns: p:23!null
-                │    └── flags: disabled not visible index feature
+                │    └── flags: avoid-full-scan disabled not visible index feature
                 └── filters
                      └── a:22 = p:23
 
@@ -602,7 +602,7 @@ upsert cpq
                 │         └──  column3:9 => q:12
                 ├── scan pq
                 │    ├── columns: pq.p:14 pq.q:15
-                │    └── flags: disabled not visible index feature
+                │    └── flags: avoid-full-scan disabled not visible index feature
                 └── filters
                      ├── p:11 = pq.p:14
                      └── q:12 = pq.q:15
@@ -639,7 +639,7 @@ upsert cpq
                 │         └── q:15 IS NOT NULL
                 ├── scan pq
                 │    ├── columns: pq.p:17 pq.q:18
-                │    └── flags: disabled not visible index feature
+                │    └── flags: avoid-full-scan disabled not visible index feature
                 └── filters
                      ├── p:14 = pq.p:17
                      └── q:15 = pq.q:18
@@ -685,7 +685,7 @@ upsert cpq
  │    │    │              └── other_default:15
  │    │    ├── scan cpq
  │    │    │    ├── columns: c:16!null cpq.p:17 cpq.q:18 cpq.other:19 cpq.crdb_internal_mvcc_timestamp:20 cpq.tableoid:21
- │    │    │    └── flags: disabled not visible index feature
+ │    │    │    └── flags: avoid-full-scan disabled not visible index feature
  │    │    └── filters
  │    │         └── x:7 = c:16
  │    └── projections
@@ -708,7 +708,7 @@ upsert cpq
                 │         └── q:26 IS NOT NULL
                 ├── scan pq
                 │    ├── columns: pq.p:28 pq.q:29
-                │    └── flags: disabled not visible index feature
+                │    └── flags: avoid-full-scan disabled not visible index feature
                 └── filters
                      ├── p:25 = pq.p:28
                      └── q:26 = pq.q:29
@@ -753,7 +753,7 @@ upsert cpq
  │    │    │              └── other_default:16
  │    │    ├── scan cpq
  │    │    │    ├── columns: c:17!null cpq.p:18 cpq.q:19 cpq.other:20 cpq.crdb_internal_mvcc_timestamp:21 cpq.tableoid:22
- │    │    │    └── flags: disabled not visible index feature
+ │    │    │    └── flags: avoid-full-scan disabled not visible index feature
  │    │    └── filters
  │    │         └── x:7 = c:17
  │    └── projections
@@ -777,7 +777,7 @@ upsert cpq
                 │         └── q:28 IS NOT NULL
                 ├── scan pq
                 │    ├── columns: pq.p:30 pq.q:31
-                │    └── flags: disabled not visible index feature
+                │    └── flags: avoid-full-scan disabled not visible index feature
                 └── filters
                      ├── p:27 = pq.p:30
                      └── q:28 = pq.q:31
@@ -816,7 +816,7 @@ upsert cpq
                 │         └──  q_default:15 => q:18
                 ├── scan pq
                 │    ├── columns: pq.p:20 pq.q:21
-                │    └── flags: disabled not visible index feature
+                │    └── flags: avoid-full-scan disabled not visible index feature
                 └── filters
                      ├── p:17 = pq.p:20
                      └── q:18 = pq.q:21
@@ -865,7 +865,7 @@ upsert cpq
  │    │    │    │              └── other_default:10
  │    │    │    ├── scan cpq
  │    │    │    │    ├── columns: c:11!null cpq.p:12 cpq.q:13 cpq.other:14 cpq.crdb_internal_mvcc_timestamp:15 cpq.tableoid:16
- │    │    │    │    └── flags: disabled not visible index feature
+ │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
  │    │    │    └── filters
  │    │    │         └── column1:7 = c:11
  │    │    └── projections
@@ -890,7 +890,7 @@ upsert cpq
                 │         └── q:23 IS NOT NULL
                 ├── scan pq
                 │    ├── columns: pq.p:25 pq.q:26
-                │    └── flags: disabled not visible index feature
+                │    └── flags: avoid-full-scan disabled not visible index feature
                 └── filters
                      ├── p:22 = pq.p:25
                      └── q:23 = pq.q:26
@@ -936,7 +936,7 @@ upsert cmulti
       │         │         └──  x:7 => a:14
       │         ├── scan p
       │         │    ├── columns: p.p:15!null
-      │         │    └── flags: disabled not visible index feature
+      │         │    └── flags: avoid-full-scan disabled not visible index feature
       │         └── filters
       │              └── a:14 = p.p:15
       └── f-k-checks-item: cmulti(b,c) -> pq(p,q)
@@ -949,7 +949,7 @@ upsert cmulti
                 │         └──  z:9 => c:20
                 ├── scan pq
                 │    ├── columns: pq.p:22 q:23
-                │    └── flags: disabled not visible index feature
+                │    └── flags: avoid-full-scan disabled not visible index feature
                 └── filters
                      ├── b:19 = pq.p:22
                      └── c:20 = q:23
@@ -992,7 +992,7 @@ upsert cmulti
  │    │    │              └── d_default:14
  │    │    ├── scan cmulti
  │    │    │    ├── columns: cmulti.a:15!null cmulti.b:16!null cmulti.c:17 d:18 cmulti.crdb_internal_mvcc_timestamp:19 cmulti.tableoid:20
- │    │    │    └── flags: disabled not visible index feature
+ │    │    │    └── flags: avoid-full-scan disabled not visible index feature
  │    │    └── filters
  │    │         ├── x:7 = cmulti.a:15
  │    │         └── y:8 = cmulti.b:16
@@ -1010,7 +1010,7 @@ upsert cmulti
       │         │         └──  upsert_a:21 => a:24
       │         ├── scan p
       │         │    ├── columns: p.p:25!null
-      │         │    └── flags: disabled not visible index feature
+      │         │    └── flags: avoid-full-scan disabled not visible index feature
       │         └── filters
       │              └── a:24 = p.p:25
       └── f-k-checks-item: cmulti(b,c) -> pq(p,q)
@@ -1023,7 +1023,7 @@ upsert cmulti
                 │         └──  z:9 => c:30
                 ├── scan pq
                 │    ├── columns: pq.p:32 q:33
-                │    └── flags: disabled not visible index feature
+                │    └── flags: avoid-full-scan disabled not visible index feature
                 └── filters
                      ├── b:29 = pq.p:32
                      └── c:30 = q:33
@@ -1084,7 +1084,7 @@ upsert p1
       │    │              └── column2:6
       │    ├── scan p1
       │    │    ├── columns: p:7!null other:8 crdb_internal_mvcc_timestamp:9 tableoid:10
-      │    │    └── flags: disabled not visible index feature
+      │    │    └── flags: avoid-full-scan disabled not visible index feature
       │    └── filters
       │         └── column1:5 = p:7
       └── projections
@@ -1124,7 +1124,7 @@ upsert p1
  │    │    │    │              └── column2:6
  │    │    │    ├── scan p1
  │    │    │    │    ├── columns: p1.p:7!null other:8 p1.crdb_internal_mvcc_timestamp:9 p1.tableoid:10
- │    │    │    │    └── flags: disabled not visible index feature
+ │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
  │    │    │    └── filters
  │    │    │         └── column1:5 = p1.p:7
  │    │    └── projections
@@ -1150,7 +1150,7 @@ upsert p1
                 │              └──  upsert_p:12 => p:15
                 ├── scan p1c
                 │    ├── columns: p1c.p:17!null
-                │    └── flags: disabled not visible index feature
+                │    └── flags: avoid-full-scan disabled not visible index feature
                 └── filters
                      └── p:14 = p1c.p:17
 
@@ -1186,7 +1186,7 @@ upsert p1
       │    │    │              └── column2:6
       │    │    ├── scan p1
       │    │    │    ├── columns: p:7!null other:8 crdb_internal_mvcc_timestamp:9 tableoid:10
-      │    │    │    └── flags: disabled not visible index feature
+      │    │    │    └── flags: avoid-full-scan disabled not visible index feature
       │    │    └── filters
       │    │         └── column1:5 = p:7
       │    └── projections
@@ -1234,7 +1234,7 @@ upsert p2
  │    │    │              └── column2:6
  │    │    ├── scan p2
  │    │    │    ├── columns: p:7!null p2.fk:8 p2.crdb_internal_mvcc_timestamp:9 p2.tableoid:10
- │    │    │    └── flags: disabled not visible index feature
+ │    │    │    └── flags: avoid-full-scan disabled not visible index feature
  │    │    └── filters
  │    │         └── column1:5 = p:7
  │    └── projections
@@ -1257,7 +1257,7 @@ upsert p2
                 │              └──  column2:6 => fk:13
                 ├── scan p2c
                 │    ├── columns: p2c.fk:15
-                │    └── flags: disabled not visible index feature
+                │    └── flags: avoid-full-scan disabled not visible index feature
                 └── filters
                      └── fk:12 = p2c.fk:15
 
@@ -1294,7 +1294,7 @@ upsert p2
       │    │    │              └── column2:6
       │    │    ├── scan p2
       │    │    │    ├── columns: p:7!null fk:8 crdb_internal_mvcc_timestamp:9 tableoid:10
-      │    │    │    └── flags: disabled not visible index feature
+      │    │    │    └── flags: avoid-full-scan disabled not visible index feature
       │    │    └── filters
       │    │         └── column1:5 = p:7
       │    └── projections
@@ -1337,7 +1337,7 @@ upsert p2
  │    │    │    │              └── column2:6
  │    │    │    ├── scan p2
  │    │    │    │    ├── columns: p:7!null p2.fk:8 p2.crdb_internal_mvcc_timestamp:9 p2.tableoid:10
- │    │    │    │    └── flags: disabled not visible index feature
+ │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
  │    │    │    └── filters
  │    │    │         └── column1:5 = p:7
  │    │    └── projections
@@ -1363,7 +1363,7 @@ upsert p2
                 │              └──  upsert_fk:13 => fk:15
                 ├── scan p2c
                 │    ├── columns: p2c.fk:17
-                │    └── flags: disabled not visible index feature
+                │    └── flags: avoid-full-scan disabled not visible index feature
                 └── filters
                      └── fk:14 = p2c.fk:17
 
@@ -1400,7 +1400,7 @@ upsert p2
       │    │    │              └── column1:5
       │    │    ├── scan p2
       │    │    │    ├── columns: p:7!null fk:8 crdb_internal_mvcc_timestamp:9 tableoid:10
-      │    │    │    └── flags: disabled not visible index feature
+      │    │    │    └── flags: avoid-full-scan disabled not visible index feature
       │    │    └── filters
       │    │         └── column2:6 = fk:8
       │    └── projections
@@ -1441,7 +1441,7 @@ upsert p2
  │    │    │    │              └── column1:5
  │    │    │    ├── scan p2
  │    │    │    │    ├── columns: p:7!null p2.fk:8 p2.crdb_internal_mvcc_timestamp:9 p2.tableoid:10
- │    │    │    │    └── flags: disabled not visible index feature
+ │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
  │    │    │    └── filters
  │    │    │         └── column2:6 = p2.fk:8
  │    │    └── projections
@@ -1467,7 +1467,7 @@ upsert p2
                 │              └──  upsert_fk:13 => fk:15
                 ├── scan p2c
                 │    ├── columns: p2c.fk:17
-                │    └── flags: disabled not visible index feature
+                │    └── flags: avoid-full-scan disabled not visible index feature
                 └── filters
                      └── fk:14 = p2c.fk:17
 
@@ -1504,7 +1504,7 @@ upsert p2
       │    │              └── fk_default:6
       │    ├── scan p2
       │    │    ├── columns: p:7!null fk:8 crdb_internal_mvcc_timestamp:9 tableoid:10
-      │    │    └── flags: disabled not visible index feature
+      │    │    └── flags: avoid-full-scan disabled not visible index feature
       │    └── filters
       │         └── column1:5 = p:7
       └── projections
@@ -1553,7 +1553,7 @@ upsert pq
  │    │    │              └── column4:10
  │    │    ├── scan pq
  │    │    │    ├── columns: k:11!null pq.p:12 pq.q:13 pq.other:14 pq.crdb_internal_mvcc_timestamp:15 pq.tableoid:16
- │    │    │    └── flags: disabled not visible index feature
+ │    │    │    └── flags: avoid-full-scan disabled not visible index feature
  │    │    └── filters
  │    │         └── column1:7 = k:11
  │    └── projections
@@ -1578,7 +1578,7 @@ upsert pq
       │         │              └──  column3:9 => q:21
       │         ├── scan cpq
       │         │    ├── columns: cpq.p:23 cpq.q:24
-      │         │    └── flags: disabled not visible index feature
+      │         │    └── flags: avoid-full-scan disabled not visible index feature
       │         └── filters
       │              ├── p:18 = cpq.p:23
       │              └── q:19 = cpq.q:24
@@ -1601,7 +1601,7 @@ upsert pq
                 │              └──  column3:9 => q:31
                 ├── scan cmulti
                 │    ├── columns: b:33!null cmulti.c:34
-                │    └── flags: disabled not visible index feature
+                │    └── flags: avoid-full-scan disabled not visible index feature
                 └── filters
                      ├── p:28 = b:33
                      └── q:29 = cmulti.c:34
@@ -1640,7 +1640,7 @@ upsert pq
       │    │              └── p_default:8
       │    ├── scan pq
       │    │    ├── columns: k:9!null p:10 q:11 other:12 crdb_internal_mvcc_timestamp:13 tableoid:14
-      │    │    └── flags: disabled not visible index feature
+      │    │    └── flags: avoid-full-scan disabled not visible index feature
       │    └── filters
       │         └── column1:7 = k:9
       └── projections
@@ -1687,7 +1687,7 @@ upsert pq
  │    │    │              └── p_default:9
  │    │    ├── scan pq
  │    │    │    ├── columns: k:10!null pq.p:11 pq.q:12 pq.other:13 pq.crdb_internal_mvcc_timestamp:14 pq.tableoid:15
- │    │    │    └── flags: disabled not visible index feature
+ │    │    │    └── flags: avoid-full-scan disabled not visible index feature
  │    │    └── filters
  │    │         └── column1:7 = k:10
  │    └── projections
@@ -1714,7 +1714,7 @@ upsert pq
       │         │              └──  column2:8 => q:22
       │         ├── scan cpq
       │         │    ├── columns: cpq.p:24 cpq.q:25
-      │         │    └── flags: disabled not visible index feature
+      │         │    └── flags: avoid-full-scan disabled not visible index feature
       │         └── filters
       │              ├── p:19 = cpq.p:24
       │              └── q:20 = cpq.q:25
@@ -1737,7 +1737,7 @@ upsert pq
                 │              └──  column2:8 => q:32
                 ├── scan cmulti
                 │    ├── columns: b:34!null cmulti.c:35
-                │    └── flags: disabled not visible index feature
+                │    └── flags: avoid-full-scan disabled not visible index feature
                 └── filters
                      ├── p:29 = b:34
                      └── q:30 = cmulti.c:35
@@ -1778,7 +1778,7 @@ upsert pq
       │    │    │              └── column4:10
       │    │    ├── scan pq
       │    │    │    ├── columns: k:11!null p:12 q:13 other:14 crdb_internal_mvcc_timestamp:15 tableoid:16
-      │    │    │    └── flags: disabled not visible index feature
+      │    │    │    └── flags: avoid-full-scan disabled not visible index feature
       │    │    └── filters
       │    │         ├── column2:8 = p:12
       │    │         └── column3:9 = q:13
@@ -1826,7 +1826,7 @@ upsert pq
  │    │    │    │              └── column4:10
  │    │    │    ├── scan pq
  │    │    │    │    ├── columns: k:11!null pq.p:12 pq.q:13 pq.other:14 pq.crdb_internal_mvcc_timestamp:15 pq.tableoid:16
- │    │    │    │    └── flags: disabled not visible index feature
+ │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
  │    │    │    └── filters
  │    │    │         ├── column2:8 = pq.p:12
  │    │    │         └── column3:9 = pq.q:13
@@ -1857,7 +1857,7 @@ upsert pq
       │         │              └──  upsert_q:20 => q:25
       │         ├── scan cpq
       │         │    ├── columns: cpq.p:27 cpq.q:28
-      │         │    └── flags: disabled not visible index feature
+      │         │    └── flags: avoid-full-scan disabled not visible index feature
       │         └── filters
       │              ├── p:22 = cpq.p:27
       │              └── q:23 = cpq.q:28
@@ -1880,7 +1880,7 @@ upsert pq
                 │              └──  upsert_q:20 => q:35
                 ├── scan cmulti
                 │    ├── columns: b:37!null cmulti.c:38
-                │    └── flags: disabled not visible index feature
+                │    └── flags: avoid-full-scan disabled not visible index feature
                 └── filters
                      ├── p:32 = b:37
                      └── q:33 = cmulti.c:38
@@ -1923,7 +1923,7 @@ upsert pq
       │    │    │              └── column4:10
       │    │    ├── scan pq
       │    │    │    ├── columns: k:11!null p:12 q:13 other:14 crdb_internal_mvcc_timestamp:15 tableoid:16
-      │    │    │    └── flags: disabled not visible index feature
+      │    │    │    └── flags: avoid-full-scan disabled not visible index feature
       │    │    └── filters
       │    │         └── column1:7 = k:11
       │    └── projections
@@ -1972,7 +1972,7 @@ upsert pq
  │    │    │    │              └── column4:10
  │    │    │    ├── scan pq
  │    │    │    │    ├── columns: k:11!null pq.p:12 pq.q:13 pq.other:14 pq.crdb_internal_mvcc_timestamp:15 pq.tableoid:16
- │    │    │    │    └── flags: disabled not visible index feature
+ │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
  │    │    │    └── filters
  │    │    │         └── column1:7 = k:11
  │    │    └── projections
@@ -2002,7 +2002,7 @@ upsert pq
       │         │              └──  upsert_q:20 => q:25
       │         ├── scan cpq
       │         │    ├── columns: cpq.p:27 cpq.q:28
-      │         │    └── flags: disabled not visible index feature
+      │         │    └── flags: avoid-full-scan disabled not visible index feature
       │         └── filters
       │              ├── p:22 = cpq.p:27
       │              └── q:23 = cpq.q:28
@@ -2025,7 +2025,7 @@ upsert pq
                 │              └──  upsert_q:20 => q:35
                 ├── scan cmulti
                 │    ├── columns: b:37!null cmulti.c:38
-                │    └── flags: disabled not visible index feature
+                │    └── flags: avoid-full-scan disabled not visible index feature
                 └── filters
                      ├── p:32 = b:37
                      └── q:33 = cmulti.c:38
@@ -2090,7 +2090,7 @@ upsert tab2
  │    │    │              └── column3:8
  │    │    ├── scan tab2
  │    │    │    ├── columns: c:9!null tab2.d:10 tab2.e:11 tab2.crdb_internal_mvcc_timestamp:12 tab2.tableoid:13
- │    │    │    └── flags: disabled not visible index feature
+ │    │    │    └── flags: avoid-full-scan disabled not visible index feature
  │    │    └── filters
  │    │         └── column1:6 = c:9
  │    └── projections
@@ -2109,7 +2109,7 @@ upsert tab2
       │         │         └── d:15 IS NOT NULL
       │         ├── scan tab1
       │         │    ├── columns: b:17
-      │         │    └── flags: disabled not visible index feature
+      │         │    └── flags: avoid-full-scan disabled not visible index feature
       │         └── filters
       │              └── d:15 = b:17
       └── f-k-checks-item: tab3(g) -> tab2(e)
@@ -2129,7 +2129,7 @@ upsert tab2
                 │              └──  column3:8 => e:21
                 ├── scan tab3
                 │    ├── columns: g:23
-                │    └── flags: disabled not visible index feature
+                │    └── flags: avoid-full-scan disabled not visible index feature
                 └── filters
                      └── e:20 = g:23
 
@@ -2167,7 +2167,7 @@ upsert tab2
  │    │    │    │              └── column3:8
  │    │    │    ├── scan tab2
  │    │    │    │    ├── columns: c:9!null tab2.d:10 tab2.e:11 tab2.crdb_internal_mvcc_timestamp:12 tab2.tableoid:13
- │    │    │    │    └── flags: disabled not visible index feature
+ │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
  │    │    │    └── filters
  │    │    │         └── column1:6 = c:9
  │    │    └── projections
@@ -2190,7 +2190,7 @@ upsert tab2
       │         │         └── d:18 IS NOT NULL
       │         ├── scan tab1
       │         │    ├── columns: b:20
-      │         │    └── flags: disabled not visible index feature
+      │         │    └── flags: avoid-full-scan disabled not visible index feature
       │         └── filters
       │              └── d:18 = b:20
       └── f-k-checks-item: tab3(g) -> tab2(e)
@@ -2210,7 +2210,7 @@ upsert tab2
                 │              └──  upsert_e:17 => e:24
                 ├── scan tab3
                 │    ├── columns: g:26
-                │    └── flags: disabled not visible index feature
+                │    └── flags: avoid-full-scan disabled not visible index feature
                 └── filters
                      └── e:23 = g:26
 
@@ -2249,7 +2249,7 @@ upsert tab2
  │    │    │    │              └── column2:7
  │    │    │    ├── scan tab2
  │    │    │    │    ├── columns: c:9!null tab2.d:10 e:11 tab2.crdb_internal_mvcc_timestamp:12 tab2.tableoid:13
- │    │    │    │    └── flags: disabled not visible index feature
+ │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
  │    │    │    └── filters
  │    │    │         └── column3:8 = e:11
  │    │    └── projections
@@ -2272,7 +2272,7 @@ upsert tab2
                 │         └── d:18 IS NOT NULL
                 ├── scan tab1
                 │    ├── columns: b:20
-                │    └── flags: disabled not visible index feature
+                │    └── flags: avoid-full-scan disabled not visible index feature
                 └── filters
                      └── d:18 = b:20
 
@@ -2325,7 +2325,7 @@ upsert self
  │    │    │              └── w:10
  │    │    ├── scan self
  │    │    │    ├── columns: self.a:14!null self.b:15!null self.c:16 self.d:17 self.crdb_internal_mvcc_timestamp:18 self.tableoid:19
- │    │    │    └── flags: disabled not visible index feature
+ │    │    │    └── flags: avoid-full-scan disabled not visible index feature
  │    │    └── filters
  │    │         ├── x:7 = self.a:14
  │    │         └── y:8 = self.b:15
@@ -2343,7 +2343,7 @@ upsert self
       │         │         └──  upsert_b:21 => b:23
       │         ├── scan self
       │         │    ├── columns: self.b:25!null self.d:27
-      │         │    └── flags: disabled not visible index feature
+      │         │    └── flags: avoid-full-scan disabled not visible index feature
       │         └── filters
       │              ├── a:22 = self.b:25
       │              └── b:23 = self.d:27
@@ -2360,7 +2360,7 @@ upsert self
       │         │         └── d:30 IS NOT NULL
       │         ├── scan self
       │         │    ├── columns: self.c:33
-      │         │    └── flags: disabled not visible index feature
+      │         │    └── flags: avoid-full-scan disabled not visible index feature
       │         └── filters
       │              └── d:30 = self.c:33
       ├── f-k-checks-item: self(a,b) -> self(b,d)
@@ -2382,7 +2382,7 @@ upsert self
       │         │              └──  w:10 => d:40
       │         ├── scan self
       │         │    ├── columns: self.a:41!null self.b:42!null
-      │         │    └── flags: disabled not visible index feature
+      │         │    └── flags: avoid-full-scan disabled not visible index feature
       │         └── filters
       │              ├── b:37 = self.a:41
       │              └── d:38 = self.b:42
@@ -2403,6 +2403,6 @@ upsert self
                 │              └──  z:9 => c:48
                 ├── scan self
                 │    ├── columns: self.d:52
-                │    └── flags: disabled not visible index feature
+                │    └── flags: avoid-full-scan disabled not visible index feature
                 └── filters
                      └── c:47 = self.d:52

--- a/pkg/sql/opt/optbuilder/testdata/fk-on-delete-cascade
+++ b/pkg/sql/opt/optbuilder/testdata/fk-on-delete-cascade
@@ -27,7 +27,8 @@ root
  │    └── select
  │         ├── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
  │         ├── scan parent
- │         │    └── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+ │         │    ├── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+ │         │    └── flags: avoid-full-scan
  │         └── filters
  │              └── p:4 > 1
  └── cascade
@@ -38,7 +39,7 @@ root
                 ├── columns: c:11!null child.p:12!null
                 ├── scan child
                 │    ├── columns: c:11!null child.p:12!null
-                │    └── flags: disabled not visible index feature
+                │    └── flags: avoid-full-scan disabled not visible index feature
                 └── filters
                      └── child.p:12 > 1
 
@@ -56,7 +57,8 @@ root
  │    └── select
  │         ├── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
  │         ├── scan parent
- │         │    └── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+ │         │    ├── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+ │         │    └── flags: avoid-full-scan
  │         └── filters
  │              └── (p:4 > 1) AND (random() < 0.5)
  └── cascade
@@ -67,7 +69,7 @@ root
                 ├── columns: c:11!null child.p:12!null
                 ├── scan child
                 │    ├── columns: c:11!null child.p:12!null
-                │    └── flags: disabled not visible index feature
+                │    └── flags: avoid-full-scan disabled not visible index feature
                 ├── with-scan &1
                 │    ├── columns: p:15!null
                 │    └── mapping:
@@ -89,7 +91,8 @@ root
  │    └── select
  │         ├── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
  │         ├── scan parent
- │         │    └── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+ │         │    ├── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+ │         │    └── flags: avoid-full-scan
  │         └── filters
  │              └── exists
  │                   └── project
@@ -104,7 +107,7 @@ root
                 ├── columns: c:15!null child.p:16!null
                 ├── scan child
                 │    ├── columns: c:15!null child.p:16!null
-                │    └── flags: disabled not visible index feature
+                │    └── flags: avoid-full-scan disabled not visible index feature
                 ├── with-scan &1
                 │    ├── columns: p:19!null
                 │    └── mapping:
@@ -126,7 +129,8 @@ root
  │    └── select
  │         ├── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
  │         ├── scan parent
- │         │    └── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+ │         │    ├── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+ │         │    └── flags: avoid-full-scan
  │         └── filters
  │              └── p:4 > one_volatile()
  └── cascade
@@ -137,7 +141,7 @@ root
                 ├── columns: c:12!null child.p:13!null
                 ├── scan child
                 │    ├── columns: c:12!null child.p:13!null
-                │    └── flags: disabled not visible index feature
+                │    └── flags: avoid-full-scan disabled not visible index feature
                 ├── with-scan &1
                 │    ├── columns: p:16!null
                 │    └── mapping:
@@ -158,7 +162,8 @@ root
  │    └── select
  │         ├── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
  │         ├── scan parent
- │         │    └── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+ │         │    ├── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+ │         │    └── flags: avoid-full-scan
  │         └── filters
  │              └── p:4 > one_immutable()
  └── cascade
@@ -169,7 +174,7 @@ root
                 ├── columns: c:12!null child.p:13!null
                 ├── scan child
                 │    ├── columns: c:12!null child.p:13!null
-                │    └── flags: disabled not visible index feature
+                │    └── flags: avoid-full-scan disabled not visible index feature
                 └── filters
                      └── child.p:13 > one_immutable()
 
@@ -184,14 +189,15 @@ root
  │    ├── cascades
  │    │    └── child_p_fkey
  │    └── scan parent
- │         └── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+ │         ├── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+ │         └── flags: avoid-full-scan
  └── cascade
       └── delete child
            ├── columns: <none>
            ├── fetch columns: c:11 child.p:12
            └── scan child
                 ├── columns: c:11!null child.p:12!null
-                └── flags: disabled not visible index feature
+                └── flags: avoid-full-scan disabled not visible index feature
 
 exec-ddl
 CREATE TABLE grandchild (g INT PRIMARY KEY, c INT REFERENCES child(c) ON DELETE CASCADE)
@@ -210,7 +216,8 @@ root
  │    └── select
  │         ├── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
  │         ├── scan parent
- │         │    └── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+ │         │    ├── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+ │         │    └── flags: avoid-full-scan
  │         └── filters
  │              └── p:4 > 1
  └── cascade
@@ -224,7 +231,7 @@ root
       │         ├── columns: c:11!null child.p:12!null
       │         ├── scan child
       │         │    ├── columns: c:11!null child.p:12!null
-      │         │    └── flags: disabled not visible index feature
+      │         │    └── flags: avoid-full-scan disabled not visible index feature
       │         └── filters
       │              └── child.p:12 > 1
       └── cascade
@@ -235,7 +242,7 @@ root
                      ├── columns: g:19!null grandchild.c:20
                      ├── scan grandchild
                      │    ├── columns: g:19!null grandchild.c:20
-                     │    └── flags: disabled not visible index feature
+                     │    └── flags: avoid-full-scan disabled not visible index feature
                      ├── with-scan &1
                      │    ├── columns: c:23!null
                      │    └── mapping:
@@ -257,7 +264,8 @@ root
  │    └── select
  │         ├── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
  │         ├── scan parent
- │         │    └── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+ │         │    ├── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+ │         │    └── flags: avoid-full-scan
  │         └── filters
  │              └── (p:4 > 1) AND (random() < 0.5)
  └── cascade
@@ -271,7 +279,7 @@ root
       │         ├── columns: c:11!null child.p:12!null
       │         ├── scan child
       │         │    ├── columns: c:11!null child.p:12!null
-      │         │    └── flags: disabled not visible index feature
+      │         │    └── flags: avoid-full-scan disabled not visible index feature
       │         ├── with-scan &1
       │         │    ├── columns: p:15!null
       │         │    └── mapping:
@@ -286,7 +294,7 @@ root
                      ├── columns: g:20!null grandchild.c:21
                      ├── scan grandchild
                      │    ├── columns: g:20!null grandchild.c:21
-                     │    └── flags: disabled not visible index feature
+                     │    └── flags: avoid-full-scan disabled not visible index feature
                      ├── with-scan &2
                      │    ├── columns: c:24!null
                      │    └── mapping:
@@ -305,7 +313,8 @@ root
  │    ├── cascades
  │    │    └── child_p_fkey
  │    └── scan parent
- │         └── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+ │         ├── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+ │         └── flags: avoid-full-scan
  └── cascade
       ├── delete child
       │    ├── columns: <none>
@@ -314,7 +323,7 @@ root
       │    │    └── grandchild_c_fkey
       │    └── scan child
       │         ├── columns: c:11!null child.p:12!null
-      │         └── flags: disabled not visible index feature
+      │         └── flags: avoid-full-scan disabled not visible index feature
       └── cascade
            └── delete grandchild
                 ├── columns: <none>
@@ -323,7 +332,7 @@ root
                      ├── columns: g:19!null grandchild.c:20!null
                      ├── scan grandchild
                      │    ├── columns: g:19!null grandchild.c:20
-                     │    └── flags: disabled not visible index feature
+                     │    └── flags: avoid-full-scan disabled not visible index feature
                      └── filters
                           └── grandchild.c:20 IS DISTINCT FROM CAST(NULL AS INT8)
 
@@ -348,7 +357,8 @@ root
  │    └── select
  │         ├── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
  │         ├── scan parent
- │         │    └── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+ │         │    ├── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+ │         │    └── flags: avoid-full-scan
  │         └── filters
  │              └── p:4 > 1
  └── cascade
@@ -360,7 +370,7 @@ root
            │    ├── columns: child.c:11!null child.p:12!null
            │    ├── scan child
            │    │    ├── columns: child.c:11!null child.p:12!null
-           │    │    └── flags: disabled not visible index feature
+           │    │    └── flags: avoid-full-scan disabled not visible index feature
            │    └── filters
            │         └── child.p:12 > 1
            └── f-k-checks
@@ -373,7 +383,7 @@ root
                           │         └──  child.c:11 => c:15
                           ├── scan grandchild
                           │    ├── columns: grandchild.c:17
-                          │    └── flags: disabled not visible index feature
+                          │    └── flags: avoid-full-scan disabled not visible index feature
                           └── filters
                                └── c:15 = grandchild.c:17
 
@@ -390,7 +400,8 @@ root
  │    └── select
  │         ├── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
  │         ├── scan parent
- │         │    └── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+ │         │    ├── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+ │         │    └── flags: avoid-full-scan
  │         └── filters
  │              └── (p:4 > 1) AND (random() < 0.5)
  └── cascade
@@ -402,7 +413,7 @@ root
            │    ├── columns: child.c:11!null child.p:12!null
            │    ├── scan child
            │    │    ├── columns: child.c:11!null child.p:12!null
-           │    │    └── flags: disabled not visible index feature
+           │    │    └── flags: avoid-full-scan disabled not visible index feature
            │    ├── with-scan &1
            │    │    ├── columns: p:15!null
            │    │    └── mapping:
@@ -419,7 +430,7 @@ root
                           │         └──  child.c:11 => c:16
                           ├── scan grandchild
                           │    ├── columns: grandchild.c:18
-                          │    └── flags: disabled not visible index feature
+                          │    └── flags: avoid-full-scan disabled not visible index feature
                           └── filters
                                └── c:16 = grandchild.c:18
 
@@ -441,7 +452,8 @@ root
  │    └── select
  │         ├── columns: a:5!null b:6 crdb_internal_mvcc_timestamp:7 tableoid:8
  │         ├── scan self
- │         │    └── columns: a:5!null b:6 crdb_internal_mvcc_timestamp:7 tableoid:8
+ │         │    ├── columns: a:5!null b:6 crdb_internal_mvcc_timestamp:7 tableoid:8
+ │         │    └── flags: avoid-full-scan
  │         └── filters
  │              └── a:5 = 1
  └── cascade
@@ -455,7 +467,7 @@ root
       │         ├── columns: self.a:13!null b:14
       │         ├── scan self
       │         │    ├── columns: self.a:13!null b:14
-      │         │    └── flags: disabled not visible index feature
+      │         │    └── flags: avoid-full-scan disabled not visible index feature
       │         ├── with-scan &1
       │         │    ├── columns: a:17!null
       │         │    └── mapping:
@@ -473,7 +485,7 @@ root
            │         ├── columns: self.a:22!null b:23
            │         ├── scan self
            │         │    ├── columns: self.a:22!null b:23
-           │         │    └── flags: disabled not visible index feature
+           │         │    └── flags: avoid-full-scan disabled not visible index feature
            │         ├── with-scan &2
            │         │    ├── columns: a:26!null
            │         │    └── mapping:
@@ -491,7 +503,7 @@ root
                           ├── columns: self.a:31!null b:32
                           ├── scan self
                           │    ├── columns: self.a:31!null b:32
-                          │    └── flags: disabled not visible index feature
+                          │    └── flags: avoid-full-scan disabled not visible index feature
                           ├── with-scan &3
                           │    ├── columns: a:35!null
                           │    └── mapping:
@@ -538,7 +550,8 @@ root
  │    └── select
  │         ├── columns: a:5!null b:6 crdb_internal_mvcc_timestamp:7 tableoid:8
  │         ├── scan ab
- │         │    └── columns: a:5!null b:6 crdb_internal_mvcc_timestamp:7 tableoid:8
+ │         │    ├── columns: a:5!null b:6 crdb_internal_mvcc_timestamp:7 tableoid:8
+ │         │    └── flags: avoid-full-scan
  │         └── filters
  │              └── a:5 = 1
  └── cascade
@@ -552,7 +565,7 @@ root
       │         ├── columns: e:13!null f:14
       │         ├── scan ef
       │         │    ├── columns: e:13!null f:14
-      │         │    └── flags: disabled not visible index feature
+      │         │    └── flags: avoid-full-scan disabled not visible index feature
       │         ├── with-scan &1
       │         │    ├── columns: a:17!null
       │         │    └── mapping:
@@ -570,7 +583,7 @@ root
            │         ├── columns: c:22!null d:23
            │         ├── scan cd
            │         │    ├── columns: c:22!null d:23
-           │         │    └── flags: disabled not visible index feature
+           │         │    └── flags: avoid-full-scan disabled not visible index feature
            │         ├── with-scan &2
            │         │    ├── columns: e:26!null
            │         │    └── mapping:
@@ -588,7 +601,7 @@ root
                           ├── columns: ab.a:31!null b:32
                           ├── scan ab
                           │    ├── columns: ab.a:31!null b:32
-                          │    └── flags: disabled not visible index feature
+                          │    └── flags: avoid-full-scan disabled not visible index feature
                           ├── with-scan &3
                           │    ├── columns: c:35!null
                           │    └── mapping:
@@ -632,7 +645,8 @@ root
  │    └── select
  │         ├── columns: a:5!null data:6 crdb_internal_mvcc_timestamp:7 tableoid:8
  │         ├── scan f1
- │         │    └── columns: a:5!null data:6 crdb_internal_mvcc_timestamp:7 tableoid:8
+ │         │    ├── columns: a:5!null data:6 crdb_internal_mvcc_timestamp:7 tableoid:8
+ │         │    └── flags: avoid-full-scan
  │         └── filters
  │              └── (a:5 >= 1) AND (a:5 <= 4)
  └── cascade
@@ -645,7 +659,7 @@ root
       │         ├── columns: f2.a:14!null b:15!null f2.data:16
       │         ├── scan f2
       │         │    ├── columns: f2.a:14!null b:15!null f2.data:16
-      │         │    └── flags: disabled not visible index feature
+      │         │    └── flags: avoid-full-scan disabled not visible index feature
       │         └── filters
       │              └── (f2.a:14 >= 1) AND (f2.a:14 <= 4)
       └── cascade
@@ -656,7 +670,7 @@ root
                      ├── columns: f3.a:25!null f3.b:26!null c:27!null f3.data:28
                      ├── scan f3
                      │    ├── columns: f3.a:25!null f3.b:26!null c:27!null f3.data:28
-                     │    └── flags: disabled not visible index feature
+                     │    └── flags: avoid-full-scan disabled not visible index feature
                      └── filters
                           └── (f3.a:25 >= 1) AND (f3.a:25 <= 4)
 
@@ -674,7 +688,8 @@ root
  │    └── select
  │         ├── columns: a:5!null data:6!null crdb_internal_mvcc_timestamp:7 tableoid:8
  │         ├── scan f1
- │         │    └── columns: a:5!null data:6 crdb_internal_mvcc_timestamp:7 tableoid:8
+ │         │    ├── columns: a:5!null data:6 crdb_internal_mvcc_timestamp:7 tableoid:8
+ │         │    └── flags: avoid-full-scan
  │         └── filters
  │              └── (a:5 = 1) AND (data:6 = 1)
  └── cascade
@@ -688,7 +703,7 @@ root
       │         ├── columns: f2.a:14!null b:15!null f2.data:16
       │         ├── scan f2
       │         │    ├── columns: f2.a:14!null b:15!null f2.data:16
-      │         │    └── flags: disabled not visible index feature
+      │         │    └── flags: avoid-full-scan disabled not visible index feature
       │         ├── with-scan &1
       │         │    ├── columns: a:19!null
       │         │    └── mapping:
@@ -703,7 +718,7 @@ root
                      ├── columns: f3.a:26!null f3.b:27!null c:28!null f3.data:29
                      ├── scan f3
                      │    ├── columns: f3.a:26!null f3.b:27!null c:28!null f3.data:29
-                     │    └── flags: disabled not visible index feature
+                     │    └── flags: avoid-full-scan disabled not visible index feature
                      ├── with-scan &2
                      │    ├── columns: a:32!null b:33!null
                      │    └── mapping:
@@ -740,7 +755,8 @@ root
  │    └── select
  │         ├── columns: a:6!null b:7 rowid:8!null crdb_internal_mvcc_timestamp:9 tableoid:10
  │         ├── scan g1
- │         │    └── columns: a:6 b:7 rowid:8!null crdb_internal_mvcc_timestamp:9 tableoid:10
+ │         │    ├── columns: a:6 b:7 rowid:8!null crdb_internal_mvcc_timestamp:9 tableoid:10
+ │         │    └── flags: avoid-full-scan
  │         └── filters
  │              └── a:6 = 1
  ├── cascade
@@ -751,7 +767,7 @@ root
  │              ├── columns: g2a.a:16!null data:17 g2a.rowid:18!null
  │              ├── scan g2a
  │              │    ├── columns: g2a.a:16 data:17 g2a.rowid:18!null
- │              │    └── flags: disabled not visible index feature
+ │              │    └── flags: avoid-full-scan disabled not visible index feature
  │              └── filters
  │                   ├── g2a.a:16 = 1
  │                   └── g2a.a:16 IS DISTINCT FROM CAST(NULL AS INT8)
@@ -763,7 +779,7 @@ root
                 ├── columns: g2b.b:26 g2b.data:27 g2b.rowid:28!null
                 ├── scan g2b
                 │    ├── columns: g2b.b:26 g2b.data:27 g2b.rowid:28!null
-                │    └── flags: disabled not visible index feature
+                │    └── flags: avoid-full-scan disabled not visible index feature
                 ├── with-scan &1
                 │    ├── columns: b:31
                 │    └── mapping:
@@ -785,7 +801,8 @@ root
  │    └── select
  │         ├── columns: a:6 b:7!null rowid:8!null crdb_internal_mvcc_timestamp:9 tableoid:10
  │         ├── scan g1
- │         │    └── columns: a:6 b:7 rowid:8!null crdb_internal_mvcc_timestamp:9 tableoid:10
+ │         │    ├── columns: a:6 b:7 rowid:8!null crdb_internal_mvcc_timestamp:9 tableoid:10
+ │         │    └── flags: avoid-full-scan
  │         └── filters
  │              └── b:7 = 1
  ├── cascade
@@ -796,7 +813,7 @@ root
  │              ├── columns: g2a.a:16 data:17 g2a.rowid:18!null
  │              ├── scan g2a
  │              │    ├── columns: g2a.a:16 data:17 g2a.rowid:18!null
- │              │    └── flags: disabled not visible index feature
+ │              │    └── flags: avoid-full-scan disabled not visible index feature
  │              ├── with-scan &1
  │              │    ├── columns: a:21
  │              │    └── mapping:
@@ -811,7 +828,7 @@ root
                 ├── columns: g2b.b:27!null g2b.data:28 g2b.rowid:29!null
                 ├── scan g2b
                 │    ├── columns: g2b.b:27 g2b.data:28 g2b.rowid:29!null
-                │    └── flags: disabled not visible index feature
+                │    └── flags: avoid-full-scan disabled not visible index feature
                 └── filters
                      ├── g2b.b:27 = 1
                      └── g2b.b:27 IS DISTINCT FROM CAST(NULL AS INT8)
@@ -840,7 +857,8 @@ root
  │    └── select
  │         ├── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
  │         ├── scan h1
- │         │    └── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+ │         │    ├── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+ │         │    └── flags: avoid-full-scan
  │         └── filters
  │              └── p:4::STRING = '1.0'
  └── cascade
@@ -851,7 +869,7 @@ root
                 ├── columns: c:11!null h2.p:12
                 ├── scan h2
                 │    ├── columns: c:11!null h2.p:12
-                │    └── flags: disabled not visible index feature
+                │    └── flags: avoid-full-scan disabled not visible index feature
                 ├── with-scan &1
                 │    ├── columns: p:15!null
                 │    └── mapping:
@@ -872,7 +890,8 @@ root
  │    └── select
  │         ├── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
  │         ├── scan h1
- │         │    └── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+ │         │    ├── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+ │         │    └── flags: avoid-full-scan
  │         └── filters
  │              └── p:4 = 1
  └── cascade
@@ -883,7 +902,7 @@ root
                 ├── columns: c:11!null h2.p:12!null
                 ├── scan h2
                 │    ├── columns: c:11!null h2.p:12
-                │    └── flags: disabled not visible index feature
+                │    └── flags: avoid-full-scan disabled not visible index feature
                 └── filters
                      ├── h2.p:12 = 1
                      └── h2.p:12 IS DISTINCT FROM CAST(NULL AS DECIMAL)
@@ -919,7 +938,8 @@ root
  │    └── select
  │         ├── columns: a:7 b:8 c:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
  │         ├── scan m1
- │         │    └── columns: a:7 b:8 c:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
+ │         │    ├── columns: a:7 b:8 c:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
+ │         │    └── flags: avoid-full-scan
  │         └── filters
  │              └── ((a:7 + b:8) + c:9) = 1
  └── cascade
@@ -930,7 +950,7 @@ root
                 ├── columns: m2.a:19!null m2.b:20!null m2.c:21!null m2.rowid:22!null
                 ├── scan m2
                 │    ├── columns: m2.a:19 m2.b:20!null m2.c:21 m2.rowid:22!null
-                │    └── flags: disabled not visible index feature
+                │    └── flags: avoid-full-scan disabled not visible index feature
                 └── filters
                      ├── ((m2.a:19 + m2.b:20) + m2.c:21) = 1
                      ├── m2.a:19 IS DISTINCT FROM CAST(NULL AS INT8)
@@ -949,7 +969,8 @@ root
  │    └── select
  │         ├── columns: a:7 b:8 c:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
  │         ├── scan m1
- │         │    └── columns: a:7 b:8 c:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
+ │         │    ├── columns: a:7 b:8 c:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
+ │         │    └── flags: avoid-full-scan
  │         └── filters
  │              └── a:7 IS NULL
  └── cascade
@@ -960,7 +981,7 @@ root
                 ├── columns: m2.a:19!null m2.b:20!null m2.c:21!null m2.rowid:22!null
                 ├── scan m2
                 │    ├── columns: m2.a:19 m2.b:20!null m2.c:21 m2.rowid:22!null
-                │    └── flags: disabled not visible index feature
+                │    └── flags: avoid-full-scan disabled not visible index feature
                 └── filters
                      ├── m2.a:19 IS NULL
                      ├── m2.a:19 IS DISTINCT FROM CAST(NULL AS INT8)
@@ -994,7 +1015,8 @@ root
  │    └── select
  │         ├── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
  │         ├── scan parent_partial
- │         │    └── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+ │         │    ├── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+ │         │    └── flags: avoid-full-scan
  │         └── filters
  │              └── p:4 > 1
  └── cascade
@@ -1013,7 +1035,7 @@ root
                 │    │    │    │    └── i:14 > 0
                 │    │    │    └── child_partial_i_idx: filters
                 │    │    │         └── child_partial.p:13 > 0
-                │    │    └── flags: disabled not visible index feature
+                │    │    └── flags: avoid-full-scan disabled not visible index feature
                 │    └── filters
                 │         ├── child_partial.p:13 > 1
                 │         └── child_partial.p:13 IS DISTINCT FROM CAST(NULL AS INT8)
@@ -1035,7 +1057,8 @@ root
  │    └── select
  │         ├── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
  │         ├── scan parent_partial
- │         │    └── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+ │         │    ├── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+ │         │    └── flags: avoid-full-scan
  │         └── filters
  │              └── (p:4 > 1) AND (random() < 0.5)
  └── cascade
@@ -1054,7 +1077,7 @@ root
                 │    │    │    │    └── i:14 > 0
                 │    │    │    └── child_partial_i_idx: filters
                 │    │    │         └── child_partial.p:13 > 0
-                │    │    └── flags: disabled not visible index feature
+                │    │    └── flags: avoid-full-scan disabled not visible index feature
                 │    ├── with-scan &1
                 │    │    ├── columns: p:17!null
                 │    │    └── mapping:
@@ -1076,7 +1099,8 @@ root
  │    ├── cascades
  │    │    └── child_partial_p_fkey
  │    └── scan parent_partial
- │         └── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+ │         ├── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+ │         └── flags: avoid-full-scan
  └── cascade
       └── delete child_partial
            ├── columns: <none>
@@ -1093,7 +1117,7 @@ root
                 │    │    │    │    └── i:14 > 0
                 │    │    │    └── child_partial_i_idx: filters
                 │    │    │         └── child_partial.p:13 > 0
-                │    │    └── flags: disabled not visible index feature
+                │    │    └── flags: avoid-full-scan disabled not visible index feature
                 │    └── filters
                 │         └── child_partial.p:13 IS DISTINCT FROM CAST(NULL AS INT8)
                 └── projections
@@ -1127,7 +1151,8 @@ root
  │    └── select
  │         ├── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
  │         ├── scan parent_virt
- │         │    └── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+ │         │    ├── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+ │         │    └── flags: avoid-full-scan
  │         └── filters
  │              └── p:4 > 1
  └── cascade
@@ -1145,7 +1170,7 @@ root
                 │    │    │    │    └── child_virt.p:14
                 │    │    │    └── v2:16
                 │    │    │         └── c:13::STRING
-                │    │    └── flags: disabled not visible index feature
+                │    │    └── flags: avoid-full-scan disabled not visible index feature
                 │    └── projections
                 │         ├── child_virt.p:14 [as=v:15]
                 │         └── c:13::STRING [as=v2:16]
@@ -1167,7 +1192,8 @@ root
  │    └── select
  │         ├── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
  │         ├── scan parent_virt
- │         │    └── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+ │         │    ├── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+ │         │    └── flags: avoid-full-scan
  │         └── filters
  │              └── (p:4 > 1) AND (random() < 0.5)
  └── cascade
@@ -1185,7 +1211,7 @@ root
                 │    │    │    │    └── child_virt.p:14
                 │    │    │    └── v2:16
                 │    │    │         └── c:13::STRING
-                │    │    └── flags: disabled not visible index feature
+                │    │    └── flags: avoid-full-scan disabled not visible index feature
                 │    └── projections
                 │         ├── child_virt.p:14 [as=v:15]
                 │         └── c:13::STRING [as=v2:16]

--- a/pkg/sql/opt/optbuilder/testdata/fk-on-delete-set-default
+++ b/pkg/sql/opt/optbuilder/testdata/fk-on-delete-set-default
@@ -19,7 +19,8 @@ root
  │    └── select
  │         ├── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
  │         ├── scan parent
- │         │    └── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+ │         │    ├── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+ │         │    └── flags: avoid-full-scan
  │         └── filters
  │              └── p:4 > 1
  └── cascade
@@ -35,7 +36,7 @@ root
            │    │    ├── columns: c:11!null child.p:12
            │    │    ├── scan child
            │    │    │    ├── columns: c:11!null child.p:12
-           │    │    │    └── flags: disabled not visible index feature
+           │    │    │    └── flags: avoid-full-scan disabled not visible index feature
            │    │    ├── with-scan &1
            │    │    │    ├── columns: p:15!null
            │    │    │    └── mapping:
@@ -54,7 +55,7 @@ root
                           │         └──  p_new:16 => p:17
                           ├── scan parent
                           │    ├── columns: parent.p:18!null
-                          │    └── flags: disabled not visible index feature
+                          │    └── flags: avoid-full-scan disabled not visible index feature
                           └── filters
                                └── p:17 = parent.p:18
 
@@ -81,7 +82,8 @@ root
  │    └── select
  │         ├── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
  │         ├── scan parent
- │         │    └── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+ │         │    ├── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+ │         │    └── flags: avoid-full-scan
  │         └── filters
  │              └── p:4 > 1
  └── cascade
@@ -96,7 +98,7 @@ root
                 │    ├── columns: c:11!null child_null.p:12
                 │    ├── scan child_null
                 │    │    ├── columns: c:11!null child_null.p:12
-                │    │    └── flags: disabled not visible index feature
+                │    │    └── flags: avoid-full-scan disabled not visible index feature
                 │    ├── with-scan &1
                 │    │    ├── columns: p:15!null
                 │    │    └── mapping:
@@ -138,7 +140,8 @@ root
  │    └── select
  │         ├── columns: p:6!null q:7!null r:8!null crdb_internal_mvcc_timestamp:9 tableoid:10
  │         ├── scan parent_multicol
- │         │    └── columns: p:6!null q:7!null r:8!null crdb_internal_mvcc_timestamp:9 tableoid:10
+ │         │    ├── columns: p:6!null q:7!null r:8!null crdb_internal_mvcc_timestamp:9 tableoid:10
+ │         │    └── flags: avoid-full-scan
  │         └── filters
  │              └── p:6 > 1
  └── cascade
@@ -165,7 +168,7 @@ root
            │    │    │    │    │    ├── computed column expressions
            │    │    │    │    │    │    └── x:22
            │    │    │    │    │    │         └── (child_multicol.p:19 + child_multicol.q:20) + child_multicol.r:21
-           │    │    │    │    │    └── flags: disabled not visible index feature
+           │    │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
            │    │    │    │    ├── with-scan &1
            │    │    │    │    │    ├── columns: p:25!null q:26!null r:27!null
            │    │    │    │    │    └── mapping:
@@ -200,7 +203,7 @@ root
                           │         └── r:34 IS NOT NULL
                           ├── scan parent_multicol
                           │    ├── columns: parent_multicol.p:35!null parent_multicol.q:36!null parent_multicol.r:37!null
-                          │    └── flags: disabled not visible index feature
+                          │    └── flags: avoid-full-scan disabled not visible index feature
                           └── filters
                                ├── p:32 = parent_multicol.p:35
                                ├── q:33 = parent_multicol.q:36
@@ -234,7 +237,8 @@ root
  │    └── select
  │         ├── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
  │         ├── scan parent_partial
- │         │    └── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+ │         │    ├── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+ │         │    └── flags: avoid-full-scan
  │         └── filters
  │              └── p:4 > 1
  └── cascade
@@ -259,7 +263,7 @@ root
            │    │    │    │    │    │    └── i:14 > 0
            │    │    │    │    │    └── child_partial_i_idx: filters
            │    │    │    │    │         └── child_partial.p:13 > 0
-           │    │    │    │    └── flags: disabled not visible index feature
+           │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
            │    │    │    ├── with-scan &1
            │    │    │    │    ├── columns: p:17!null
            │    │    │    │    └── mapping:
@@ -282,7 +286,7 @@ root
                           │         └──  p_new:18 => p:22
                           ├── scan parent_partial
                           │    ├── columns: parent_partial.p:23!null
-                          │    └── flags: disabled not visible index feature
+                          │    └── flags: avoid-full-scan disabled not visible index feature
                           └── filters
                                └── p:22 = parent_partial.p:23
 
@@ -312,7 +316,8 @@ root
  │    └── select
  │         ├── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
  │         ├── scan parent_virt
- │         │    └── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+ │         │    ├── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+ │         │    └── flags: avoid-full-scan
  │         └── filters
  │              └── p:4 > 1
  └── cascade
@@ -334,7 +339,7 @@ root
            │    │    │    │    ├── computed column expressions
            │    │    │    │    │    └── v:14
            │    │    │    │    │         └── child_virt.p:13
-           │    │    │    │    └── flags: disabled not visible index feature
+           │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
            │    │    │    └── projections
            │    │    │         └── child_virt.p:13 [as=v:14]
            │    │    ├── with-scan &1
@@ -355,6 +360,6 @@ root
                           │         └──  p_new:18 => p:19
                           ├── scan parent_virt
                           │    ├── columns: parent_virt.p:20!null
-                          │    └── flags: disabled not visible index feature
+                          │    └── flags: avoid-full-scan disabled not visible index feature
                           └── filters
                                └── p:19 = parent_virt.p:20

--- a/pkg/sql/opt/optbuilder/testdata/fk-on-delete-set-null
+++ b/pkg/sql/opt/optbuilder/testdata/fk-on-delete-set-null
@@ -19,7 +19,8 @@ root
  │    └── select
  │         ├── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
  │         ├── scan parent
- │         │    └── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+ │         │    ├── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+ │         │    └── flags: avoid-full-scan
  │         └── filters
  │              └── p:4 > 1
  └── cascade
@@ -34,7 +35,7 @@ root
                 │    ├── columns: c:11!null child.p:12
                 │    ├── scan child
                 │    │    ├── columns: c:11!null child.p:12
-                │    │    └── flags: disabled not visible index feature
+                │    │    └── flags: avoid-full-scan disabled not visible index feature
                 │    ├── with-scan &1
                 │    │    ├── columns: p:15!null
                 │    │    └── mapping:
@@ -75,7 +76,8 @@ root
  │    └── select
  │         ├── columns: p:6!null q:7!null r:8!null crdb_internal_mvcc_timestamp:9 tableoid:10
  │         ├── scan parent_multicol
- │         │    └── columns: p:6!null q:7!null r:8!null crdb_internal_mvcc_timestamp:9 tableoid:10
+ │         │    ├── columns: p:6!null q:7!null r:8!null crdb_internal_mvcc_timestamp:9 tableoid:10
+ │         │    └── flags: avoid-full-scan
  │         └── filters
  │              └── p:6 > 1
  └── cascade
@@ -103,7 +105,7 @@ root
                 │    │    │    │    ├── computed column expressions
                 │    │    │    │    │    └── x:22
                 │    │    │    │    │         └── (child_multicol.p:19 + child_multicol.q:20) + child_multicol.r:21
-                │    │    │    │    └── flags: disabled not visible index feature
+                │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
                 │    │    │    ├── with-scan &1
                 │    │    │    │    ├── columns: p:25!null q:26!null r:27!null
                 │    │    │    │    └── mapping:
@@ -149,7 +151,8 @@ root
  │    └── select
  │         ├── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
  │         ├── scan parent_partial
- │         │    └── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+ │         │    ├── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+ │         │    └── flags: avoid-full-scan
  │         └── filters
  │              └── p:4 > 1
  └── cascade
@@ -173,7 +176,7 @@ root
                 │    │    │    │    │    └── i:14 > 0
                 │    │    │    │    └── child_partial_i_idx: filters
                 │    │    │    │         └── child_partial.p:13 > 0
-                │    │    │    └── flags: disabled not visible index feature
+                │    │    │    └── flags: avoid-full-scan disabled not visible index feature
                 │    │    ├── with-scan &1
                 │    │    │    ├── columns: p:17!null
                 │    │    │    └── mapping:
@@ -213,7 +216,8 @@ root
  │    └── select
  │         ├── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
  │         ├── scan parent_virt
- │         │    └── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+ │         │    ├── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+ │         │    └── flags: avoid-full-scan
  │         └── filters
  │              └── p:4 > 1
  └── cascade
@@ -234,7 +238,7 @@ root
                 │    │    │    ├── computed column expressions
                 │    │    │    │    └── v:14
                 │    │    │    │         └── child_virt.p:13
-                │    │    │    └── flags: disabled not visible index feature
+                │    │    │    └── flags: avoid-full-scan disabled not visible index feature
                 │    │    └── projections
                 │    │         └── child_virt.p:13 [as=v:14]
                 │    ├── with-scan &1

--- a/pkg/sql/opt/optbuilder/testdata/fk-on-update-cascade
+++ b/pkg/sql/opt/optbuilder/testdata/fk-on-update-cascade
@@ -23,7 +23,8 @@ root
  │         ├── select
  │         │    ├── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
  │         │    ├── scan parent
- │         │    │    └── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+ │         │    │    ├── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+ │         │    │    └── flags: avoid-full-scan
  │         │    └── filters
  │         │         └── p:4 > 1
  │         └── projections
@@ -39,7 +40,7 @@ root
            │    ├── columns: c:12!null child.p:13!null p_old:16!null p_new:17!null
            │    ├── scan child
            │    │    ├── columns: c:12!null child.p:13!null
-           │    │    └── flags: disabled not visible index feature
+           │    │    └── flags: avoid-full-scan disabled not visible index feature
            │    ├── select
            │    │    ├── columns: p_old:16!null p_new:17!null
            │    │    ├── with-scan &1
@@ -61,7 +62,7 @@ root
                           │         └──  p_new:17 => p:18
                           ├── scan parent
                           │    ├── columns: parent.p:19!null
-                          │    └── flags: disabled not visible index feature
+                          │    └── flags: avoid-full-scan disabled not visible index feature
                           └── filters
                                └── p:18 = parent.p:19
 
@@ -103,7 +104,8 @@ root
  │         ├── select
  │         │    ├── columns: pk:6!null p:7 q:8 crdb_internal_mvcc_timestamp:9 tableoid:10
  │         │    ├── scan parent_multi
- │         │    │    └── columns: pk:6!null p:7 q:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+ │         │    │    ├── columns: pk:6!null p:7 q:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+ │         │    │    └── flags: avoid-full-scan
  │         │    └── filters
  │         │         └── pk:6 > 1
  │         └── projections
@@ -121,7 +123,7 @@ root
            │    ├── columns: c:18!null child_multi.p:19!null child_multi.q:20!null p_old:23!null p_new:24 q_old:25!null q_new:26
            │    ├── scan child_multi
            │    │    ├── columns: c:18!null child_multi.p:19 child_multi.q:20
-           │    │    └── flags: disabled not visible index feature
+           │    │    └── flags: avoid-full-scan disabled not visible index feature
            │    ├── select
            │    │    ├── columns: p_old:23 p_new:24 q_old:25 q_new:26
            │    │    ├── with-scan &1
@@ -152,7 +154,7 @@ root
                           │         └── q:28 IS NOT NULL
                           ├── scan parent_multi
                           │    ├── columns: parent_multi.p:30 parent_multi.q:31
-                          │    └── flags: disabled not visible index feature
+                          │    └── flags: avoid-full-scan disabled not visible index feature
                           └── filters
                                ├── p:27 = parent_multi.p:30
                                └── q:28 = parent_multi.q:31
@@ -176,7 +178,8 @@ root
  │         ├── select
  │         │    ├── columns: pk:6!null p:7!null q:8 crdb_internal_mvcc_timestamp:9 tableoid:10
  │         │    ├── scan parent_multi
- │         │    │    └── columns: pk:6!null p:7 q:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+ │         │    │    ├── columns: pk:6!null p:7 q:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+ │         │    │    └── flags: avoid-full-scan
  │         │    └── filters
  │         │         └── p:7 > 1
  │         └── projections
@@ -193,7 +196,7 @@ root
            │    ├── columns: c:17!null child_multi.p:18!null child_multi.q:19!null p_old:22!null p_new:23!null q_old:24!null q_new:25
            │    ├── scan child_multi
            │    │    ├── columns: c:17!null child_multi.p:18 child_multi.q:19
-           │    │    └── flags: disabled not visible index feature
+           │    │    └── flags: avoid-full-scan disabled not visible index feature
            │    ├── select
            │    │    ├── columns: p_old:22!null p_new:23!null q_old:24 q_new:25
            │    │    ├── with-scan &1
@@ -223,7 +226,7 @@ root
                           │         └── q:27 IS NOT NULL
                           ├── scan parent_multi
                           │    ├── columns: parent_multi.p:29 parent_multi.q:30
-                          │    └── flags: disabled not visible index feature
+                          │    └── flags: avoid-full-scan disabled not visible index feature
                           └── filters
                                ├── p:26 = parent_multi.p:29
                                └── q:27 = parent_multi.q:30
@@ -265,7 +268,7 @@ root
  │         │    │              └── column3:8
  │         │    ├── scan parent_multi
  │         │    │    ├── columns: pk:9!null p:10 q:11 crdb_internal_mvcc_timestamp:12 tableoid:13
- │         │    │    └── flags: disabled not visible index feature
+ │         │    │    └── flags: avoid-full-scan disabled not visible index feature
  │         │    └── filters
  │         │         └── column1:6 = pk:9
  │         └── projections
@@ -282,7 +285,7 @@ root
            │    ├── columns: c:20!null child_multi.p:21!null child_multi.q:22!null p_old:25!null p_new:26!null q_old:27!null q_new:28!null
            │    ├── scan child_multi
            │    │    ├── columns: c:20!null child_multi.p:21 child_multi.q:22
-           │    │    └── flags: disabled not visible index feature
+           │    │    └── flags: avoid-full-scan disabled not visible index feature
            │    ├── select
            │    │    ├── columns: p_old:25 p_new:26!null q_old:27 q_new:28!null
            │    │    ├── with-scan &1
@@ -308,7 +311,7 @@ root
                           │         └──  q_new:28 => q:30
                           ├── scan parent_multi
                           │    ├── columns: parent_multi.p:32 parent_multi.q:33
-                          │    └── flags: disabled not visible index feature
+                          │    └── flags: avoid-full-scan disabled not visible index feature
                           └── filters
                                ├── p:29 = parent_multi.p:32
                                └── q:30 = parent_multi.q:33
@@ -354,7 +357,7 @@ root
  │         │    │              └── q_default:8
  │         │    ├── scan parent_multi
  │         │    │    ├── columns: pk:9!null p:10 q:11 crdb_internal_mvcc_timestamp:12 tableoid:13
- │         │    │    └── flags: disabled not visible index feature
+ │         │    │    └── flags: avoid-full-scan disabled not visible index feature
  │         │    └── filters
  │         │         └── column1:6 = pk:9
  │         └── projections
@@ -372,7 +375,7 @@ root
            │    ├── columns: c:21!null child_multi.p:22!null child_multi.q:23!null p_old:26!null p_new:27!null q_old:28!null q_new:29
            │    ├── scan child_multi
            │    │    ├── columns: c:21!null child_multi.p:22 child_multi.q:23
-           │    │    └── flags: disabled not visible index feature
+           │    │    └── flags: avoid-full-scan disabled not visible index feature
            │    ├── select
            │    │    ├── columns: p_old:26 p_new:27!null q_old:28 q_new:29
            │    │    ├── with-scan &1
@@ -402,7 +405,7 @@ root
                           │         └── q:31 IS NOT NULL
                           ├── scan parent_multi
                           │    ├── columns: parent_multi.p:33 parent_multi.q:34
-                          │    └── flags: disabled not visible index feature
+                          │    └── flags: avoid-full-scan disabled not visible index feature
                           └── filters
                                ├── p:30 = parent_multi.p:33
                                └── q:31 = parent_multi.q:34
@@ -443,7 +446,7 @@ root
  │         │    │    │              └── column1:6
  │         │    │    ├── scan parent_multi
  │         │    │    │    ├── columns: pk:9!null p:10 q:11 crdb_internal_mvcc_timestamp:12 tableoid:13
- │         │    │    │    └── flags: disabled not visible index feature
+ │         │    │    │    └── flags: avoid-full-scan disabled not visible index feature
  │         │    │    └── filters
  │         │    │         ├── column2:7 = p:10
  │         │    │         └── column3:8 = q:11
@@ -465,7 +468,7 @@ root
            │    ├── columns: c:23!null child_multi.p:24!null child_multi.q:25!null p_old:28!null p_new:29!null q_old:30!null q_new:31
            │    ├── scan child_multi
            │    │    ├── columns: c:23!null child_multi.p:24 child_multi.q:25
-           │    │    └── flags: disabled not visible index feature
+           │    │    └── flags: avoid-full-scan disabled not visible index feature
            │    ├── select
            │    │    ├── columns: p_old:28 p_new:29!null q_old:30 q_new:31
            │    │    ├── with-scan &1
@@ -495,7 +498,7 @@ root
                           │         └── q:33 IS NOT NULL
                           ├── scan parent_multi
                           │    ├── columns: parent_multi.p:35 parent_multi.q:36
-                          │    └── flags: disabled not visible index feature
+                          │    └── flags: avoid-full-scan disabled not visible index feature
                           └── filters
                                ├── p:32 = parent_multi.p:35
                                └── q:33 = parent_multi.q:36
@@ -526,7 +529,8 @@ root
  │         ├── select
  │         │    ├── columns: pk:6!null p:7!null q:8 crdb_internal_mvcc_timestamp:9 tableoid:10
  │         │    ├── scan parent_multi
- │         │    │    └── columns: pk:6!null p:7 q:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+ │         │    │    ├── columns: pk:6!null p:7 q:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+ │         │    │    └── flags: avoid-full-scan
  │         │    └── filters
  │         │         └── p:7 > 1
  │         └── projections
@@ -545,7 +549,7 @@ root
       │    │    ├── columns: c:17!null child_multi.p:18!null child_multi.q:19!null p_old:22!null p_new:23!null q_old:24!null q_new:25
       │    │    ├── scan child_multi
       │    │    │    ├── columns: c:17!null child_multi.p:18 child_multi.q:19
-      │    │    │    └── flags: disabled not visible index feature
+      │    │    │    └── flags: avoid-full-scan disabled not visible index feature
       │    │    ├── select
       │    │    │    ├── columns: p_old:22!null p_new:23!null q_old:24 q_new:25
       │    │    │    ├── with-scan &1
@@ -575,7 +579,7 @@ root
       │                   │         └── q:27 IS NOT NULL
       │                   ├── scan parent_multi
       │                   │    ├── columns: parent_multi.p:29 parent_multi.q:30
-      │                   │    └── flags: disabled not visible index feature
+      │                   │    └── flags: avoid-full-scan disabled not visible index feature
       │                   └── filters
       │                        ├── p:26 = parent_multi.p:29
       │                        └── q:27 = parent_multi.q:30
@@ -591,7 +595,7 @@ root
                 │    ├── columns: g:38!null grandchild.c:39!null grandchild.q:40!null c_old:43!null c_new:44!null q_old:45!null q_new:46
                 │    ├── scan grandchild
                 │    │    ├── columns: g:38!null grandchild.c:39 grandchild.q:40
-                │    │    └── flags: disabled not visible index feature
+                │    │    └── flags: avoid-full-scan disabled not visible index feature
                 │    ├── select
                 │    │    ├── columns: c_old:43!null c_new:44!null q_old:45!null q_new:46
                 │    │    ├── with-scan &2
@@ -621,7 +625,7 @@ root
                                │         └── q:48 IS NOT NULL
                                ├── scan child_multi
                                │    ├── columns: child_multi.c:49!null child_multi.q:51
-                               │    └── flags: disabled not visible index feature
+                               │    └── flags: avoid-full-scan disabled not visible index feature
                                └── filters
                                     ├── c:47 = child_multi.c:49
                                     └── q:48 = child_multi.q:51
@@ -663,7 +667,7 @@ root
  │         │    │              └── column3:8
  │         │    ├── scan parent_multi
  │         │    │    ├── columns: pk:9!null p:10 q:11 crdb_internal_mvcc_timestamp:12 tableoid:13
- │         │    │    └── flags: disabled not visible index feature
+ │         │    │    └── flags: avoid-full-scan disabled not visible index feature
  │         │    └── filters
  │         │         └── column1:6 = pk:9
  │         └── projections
@@ -682,7 +686,7 @@ root
       │    │    ├── columns: c:20!null child_multi.p:21!null child_multi.q:22!null p_old:25!null p_new:26!null q_old:27!null q_new:28!null
       │    │    ├── scan child_multi
       │    │    │    ├── columns: c:20!null child_multi.p:21 child_multi.q:22
-      │    │    │    └── flags: disabled not visible index feature
+      │    │    │    └── flags: avoid-full-scan disabled not visible index feature
       │    │    ├── select
       │    │    │    ├── columns: p_old:25 p_new:26!null q_old:27 q_new:28!null
       │    │    │    ├── with-scan &1
@@ -708,7 +712,7 @@ root
       │                   │         └──  q_new:28 => q:30
       │                   ├── scan parent_multi
       │                   │    ├── columns: parent_multi.p:32 parent_multi.q:33
-      │                   │    └── flags: disabled not visible index feature
+      │                   │    └── flags: avoid-full-scan disabled not visible index feature
       │                   └── filters
       │                        ├── p:29 = parent_multi.p:32
       │                        └── q:30 = parent_multi.q:33
@@ -724,7 +728,7 @@ root
                 │    ├── columns: g:41!null grandchild.c:42!null grandchild.q:43!null c_old:46!null c_new:47!null q_old:48!null q_new:49!null
                 │    ├── scan grandchild
                 │    │    ├── columns: g:41!null grandchild.c:42 grandchild.q:43
-                │    │    └── flags: disabled not visible index feature
+                │    │    └── flags: avoid-full-scan disabled not visible index feature
                 │    ├── select
                 │    │    ├── columns: c_old:46!null c_new:47!null q_old:48!null q_new:49!null
                 │    │    ├── with-scan &2
@@ -750,7 +754,7 @@ root
                                │         └──  q_new:49 => q:51
                                ├── scan child_multi
                                │    ├── columns: child_multi.c:52!null child_multi.q:54
-                               │    └── flags: disabled not visible index feature
+                               │    └── flags: avoid-full-scan disabled not visible index feature
                                └── filters
                                     ├── c:50 = child_multi.c:52
                                     └── q:51 = child_multi.q:54
@@ -787,7 +791,8 @@ root
  │         │    ├── select
  │         │    │    ├── columns: p:5!null p2:6 crdb_internal_mvcc_timestamp:7 tableoid:8
  │         │    │    ├── scan parent_assn_cast
- │         │    │    │    └── columns: p:5!null p2:6 crdb_internal_mvcc_timestamp:7 tableoid:8
+ │         │    │    │    ├── columns: p:5!null p2:6 crdb_internal_mvcc_timestamp:7 tableoid:8
+ │         │    │    │    └── flags: avoid-full-scan
  │         │    │    └── filters
  │         │    │         └── p:5 > 1
  │         │    └── projections
@@ -808,7 +813,7 @@ root
            │    │    ├── columns: c:15!null child_assn_cast.p:16!null p_old:19!null p_new:20!null
            │    │    ├── scan child_assn_cast
            │    │    │    ├── columns: c:15!null child_assn_cast.p:16
-           │    │    │    └── flags: disabled not visible index feature
+           │    │    │    └── flags: avoid-full-scan disabled not visible index feature
            │    │    ├── select
            │    │    │    ├── columns: p_old:19!null p_new:20!null
            │    │    │    ├── with-scan &1
@@ -833,7 +838,7 @@ root
                           │         └──  p_cast:21 => p:22
                           ├── scan parent_assn_cast
                           │    ├── columns: parent_assn_cast.p:23!null
-                          │    └── flags: disabled not visible index feature
+                          │    └── flags: avoid-full-scan disabled not visible index feature
                           └── filters
                                └── p:22 = parent_assn_cast.p:23
 
@@ -883,7 +888,7 @@ root
  │         │    │              └── p2_cast:8
  │         │    ├── scan parent_assn_cast
  │         │    │    ├── columns: p:9!null p2:10 crdb_internal_mvcc_timestamp:11 tableoid:12
- │         │    │    └── flags: disabled not visible index feature
+ │         │    │    └── flags: avoid-full-scan disabled not visible index feature
  │         │    └── filters
  │         │         └── p_cast:7 = p:9
  │         └── projections
@@ -901,7 +906,7 @@ root
            │    │    ├── columns: c:18!null child_assn_cast_p2.p2:19!null p2_old:22!null p2_new:23!null
            │    │    ├── scan child_assn_cast_p2
            │    │    │    ├── columns: c:18!null child_assn_cast_p2.p2:19
-           │    │    │    └── flags: disabled not visible index feature
+           │    │    │    └── flags: avoid-full-scan disabled not visible index feature
            │    │    ├── select
            │    │    │    ├── columns: p2_old:22 p2_new:23!null
            │    │    │    ├── with-scan &1
@@ -926,7 +931,7 @@ root
                           │         └──  p2_cast:24 => p2:25
                           ├── scan parent_assn_cast
                           │    ├── columns: parent_assn_cast.p2:27
-                          │    └── flags: disabled not visible index feature
+                          │    └── flags: avoid-full-scan disabled not visible index feature
                           └── filters
                                └── p2:25 = parent_assn_cast.p2:27
 
@@ -973,7 +978,7 @@ root
  │         │    │    │    │              └── p2_cast:8
  │         │    │    │    ├── scan parent_assn_cast
  │         │    │    │    │    ├── columns: p:9!null p2:10 crdb_internal_mvcc_timestamp:11 tableoid:12
- │         │    │    │    │    └── flags: disabled not visible index feature
+ │         │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
  │         │    │    │    └── filters
  │         │    │    │         └── p_cast:7 = p:9
  │         │    │    └── projections
@@ -997,7 +1002,7 @@ root
            │    │    ├── columns: c:21!null child_assn_cast_p2.p2:22!null p2_old:25!null p2_new:26!null
            │    │    ├── scan child_assn_cast_p2
            │    │    │    ├── columns: c:21!null child_assn_cast_p2.p2:22
-           │    │    │    └── flags: disabled not visible index feature
+           │    │    │    └── flags: avoid-full-scan disabled not visible index feature
            │    │    ├── select
            │    │    │    ├── columns: p2_old:25 p2_new:26!null
            │    │    │    ├── with-scan &1
@@ -1022,7 +1027,7 @@ root
                           │         └──  p2_cast:27 => p2:28
                           ├── scan parent_assn_cast
                           │    ├── columns: parent_assn_cast.p2:30
-                          │    └── flags: disabled not visible index feature
+                          │    └── flags: avoid-full-scan disabled not visible index feature
                           └── filters
                                └── p2:28 = parent_assn_cast.p2:30
 
@@ -1058,7 +1063,8 @@ root
  │         ├── select
  │         │    ├── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
  │         │    ├── scan parent_partial
- │         │    │    └── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+ │         │    │    ├── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+ │         │    │    └── flags: avoid-full-scan
  │         │    └── filters
  │         │         └── p:4 > 1
  │         └── projections
@@ -1083,7 +1089,7 @@ root
            │    │    │    │    │    └── i:15 > 0
            │    │    │    │    └── child_partial_i_idx: filters
            │    │    │    │         └── child_partial.p:14 > 0
-           │    │    │    └── flags: disabled not visible index feature
+           │    │    │    └── flags: avoid-full-scan disabled not visible index feature
            │    │    ├── select
            │    │    │    ├── columns: p_old:18!null p_new:19!null
            │    │    │    ├── with-scan &1
@@ -1109,7 +1115,7 @@ root
                           │         └──  p_new:19 => p:23
                           ├── scan parent_partial
                           │    ├── columns: parent_partial.p:24!null
-                          │    └── flags: disabled not visible index feature
+                          │    └── flags: avoid-full-scan disabled not visible index feature
                           └── filters
                                └── p:23 = parent_partial.p:24
 
@@ -1144,7 +1150,8 @@ root
  │         ├── select
  │         │    ├── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
  │         │    ├── scan parent_partial_ambig
- │         │    │    └── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+ │         │    │    ├── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+ │         │    │    └── flags: avoid-full-scan
  │         │    └── filters
  │         │         └── p:4 > 1
  │         └── projections
@@ -1167,7 +1174,7 @@ root
            │    │    │    ├── partial index predicates
            │    │    │    │    └── child_partial_ambig_i_idx: filters
            │    │    │    │         └── child_partial_ambig.p_new:14 > 0
-           │    │    │    └── flags: disabled not visible index feature
+           │    │    │    └── flags: avoid-full-scan disabled not visible index feature
            │    │    ├── select
            │    │    │    ├── columns: p_new_old:18!null p_new_new:19!null
            │    │    │    ├── with-scan &1
@@ -1192,7 +1199,7 @@ root
                           │         └──  p_new_new:19 => p_new:22
                           ├── scan parent_partial_ambig
                           │    ├── columns: p:23!null
-                          │    └── flags: disabled not visible index feature
+                          │    └── flags: avoid-full-scan disabled not visible index feature
                           └── filters
                                └── p_new:22 = p:23
 
@@ -1259,7 +1266,7 @@ root
  │         │    │              └── p_default:7
  │         │    ├── scan parent_multi_partial
  │         │    │    ├── columns: pk:8!null p:9 q:10 crdb_internal_mvcc_timestamp:11 tableoid:12
- │         │    │    └── flags: disabled not visible index feature
+ │         │    │    └── flags: avoid-full-scan disabled not visible index feature
  │         │    └── filters
  │         │         └── column1:6 = pk:8
  │         └── projections
@@ -1285,7 +1292,7 @@ root
            │    │    │    │    │    └── i:23 > 0
            │    │    │    │    └── child_multi_partial_i_idx: filters
            │    │    │    │         └── (child_multi_partial.p:21 > 0) AND (child_multi_partial.q:22 > 0)
-           │    │    │    └── flags: disabled not visible index feature
+           │    │    │    └── flags: avoid-full-scan disabled not visible index feature
            │    │    ├── select
            │    │    │    ├── columns: p_old:26 p_new:27 q_old:28 q_new:29
            │    │    │    ├── with-scan &1
@@ -1320,7 +1327,7 @@ root
                           │         └── q:34 IS NOT NULL
                           ├── scan parent_multi_partial
                           │    ├── columns: parent_multi_partial.p:36 parent_multi_partial.q:37
-                          │    └── flags: disabled not visible index feature
+                          │    └── flags: avoid-full-scan disabled not visible index feature
                           └── filters
                                ├── p:33 = parent_multi_partial.p:36
                                └── q:34 = parent_multi_partial.q:37
@@ -1360,7 +1367,8 @@ root
  │         ├── select
  │         │    ├── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
  │         │    ├── scan parent_check_ambig
- │         │    │    └── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+ │         │    │    ├── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+ │         │    │    └── flags: avoid-full-scan
  │         │    └── filters
  │         │         └── p:4 > 1
  │         └── projections
@@ -1385,7 +1393,7 @@ root
            │    │    │    │    ├── computed column expressions
            │    │    │    │    │    └── i:15
            │    │    │    │    │         └── child_check_ambig.p_new:14 * 2
-           │    │    │    │    └── flags: disabled not visible index feature
+           │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
            │    │    │    ├── select
            │    │    │    │    ├── columns: p_new_old:18!null p_new_new:19!null
            │    │    │    │    ├── with-scan &1
@@ -1411,7 +1419,7 @@ root
                           │         └──  p_new_new:19 => p_new:22
                           ├── scan parent_check_ambig
                           │    ├── columns: p:23!null
-                          │    └── flags: disabled not visible index feature
+                          │    └── flags: avoid-full-scan disabled not visible index feature
                           └── filters
                                └── p_new:22 = p:23
 
@@ -1445,7 +1453,8 @@ root
  │         ├── select
  │         │    ├── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
  │         │    ├── scan parent_virt
- │         │    │    └── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+ │         │    │    ├── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+ │         │    │    └── flags: avoid-full-scan
  │         │    └── filters
  │         │         └── p:4 > 1
  │         └── projections
@@ -1467,7 +1476,7 @@ root
            │    │    │    ├── computed column expressions
            │    │    │    │    └── v:15
            │    │    │    │         └── child_virt.p:14
-           │    │    │    └── flags: disabled not visible index feature
+           │    │    │    └── flags: avoid-full-scan disabled not visible index feature
            │    │    └── projections
            │    │         └── child_virt.p:14 [as=v:15]
            │    ├── select
@@ -1491,7 +1500,7 @@ root
                           │         └──  p_new:19 => p:20
                           ├── scan parent_virt
                           │    ├── columns: parent_virt.p:21!null
-                          │    └── flags: disabled not visible index feature
+                          │    └── flags: avoid-full-scan disabled not visible index feature
                           └── filters
                                └── p:20 = parent_virt.p:21
 
@@ -1537,6 +1546,7 @@ root
  │         │    ├── fd: ()-->(4-6)
  │         │    ├── scan t.public.parent_diff_type
  │         │    │    ├── columns: t.public.parent_diff_type.p:4(int!null) t.public.parent_diff_type.crdb_internal_mvcc_timestamp:5(decimal) t.public.parent_diff_type.tableoid:6(oid)
+ │         │    │    ├── flags: avoid-full-scan
  │         │    │    ├── stats: [rows=1000, distinct(4)=1000, null(4)=0]
  │         │    │    ├── key: (4)
  │         │    │    ├── fd: (4)-->(5,6)
@@ -1572,7 +1582,7 @@ root
            │    │    ├── fd: ()-->(13,16,17), (13)==(16), (16)==(13)
            │    │    ├── scan t.public.child_diff_type
            │    │    │    ├── columns: t.public.child_diff_type.c:12(int!null) t.public.child_diff_type.p:13(int2)
-           │    │    │    ├── flags: disabled not visible index feature
+           │    │    │    ├── flags: avoid-full-scan disabled not visible index feature
            │    │    │    ├── stats: [rows=1000, distinct(13)=100, null(13)=10]
            │    │    │    ├── key: (12)
            │    │    │    ├── fd: (12)-->(13)
@@ -1623,7 +1633,7 @@ root
                           │         └── &2: count=1 used-columns=(18)
                           ├── scan t.public.parent_diff_type
                           │    ├── columns: t.public.parent_diff_type.p:20(int!null)
-                          │    ├── flags: disabled not visible index feature
+                          │    ├── flags: avoid-full-scan disabled not visible index feature
                           │    ├── stats: [rows=1000, distinct(20)=1000, null(20)=0]
                           │    ├── key: (20)
                           │    └── prune: (20)
@@ -1674,7 +1684,7 @@ root
  │         │    │    │         └── (0,)
  │         │    │    ├── scan parent_diff_type
  │         │    │    │    ├── columns: p:5!null crdb_internal_mvcc_timestamp:6 tableoid:7
- │         │    │    │    └── flags: disabled not visible index feature
+ │         │    │    │    └── flags: avoid-full-scan disabled not visible index feature
  │         │    │    └── filters
  │         │    │         └── column1:4 = p:5
  │         │    └── projections
@@ -1694,7 +1704,7 @@ root
            │    │    ├── columns: c:14!null child_diff_type.p:15!null p_old:18!null p_new:19!null
            │    │    ├── scan child_diff_type
            │    │    │    ├── columns: c:14!null child_diff_type.p:15
-           │    │    │    └── flags: disabled not visible index feature
+           │    │    │    └── flags: avoid-full-scan disabled not visible index feature
            │    │    ├── select
            │    │    │    ├── columns: p_old:18 p_new:19!null
            │    │    │    ├── with-scan &1
@@ -1719,6 +1729,6 @@ root
                           │         └──  p_cast:20 => p:21
                           ├── scan parent_diff_type
                           │    ├── columns: parent_diff_type.p:22!null
-                          │    └── flags: disabled not visible index feature
+                          │    └── flags: avoid-full-scan disabled not visible index feature
                           └── filters
                                └── p:21 = parent_diff_type.p:22

--- a/pkg/sql/opt/optbuilder/testdata/fk-on-update-set-default
+++ b/pkg/sql/opt/optbuilder/testdata/fk-on-update-set-default
@@ -23,7 +23,8 @@ root
  │         ├── select
  │         │    ├── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
  │         │    ├── scan parent
- │         │    │    └── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+ │         │    │    ├── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+ │         │    │    └── flags: avoid-full-scan
  │         │    └── filters
  │         │         └── p:4 > 1
  │         └── projections
@@ -41,7 +42,7 @@ root
            │    │    ├── columns: c:12!null child.p:13!null p_old:16!null p_new:17!null
            │    │    ├── scan child
            │    │    │    ├── columns: c:12!null child.p:13!null
-           │    │    │    └── flags: disabled not visible index feature
+           │    │    │    └── flags: avoid-full-scan disabled not visible index feature
            │    │    ├── select
            │    │    │    ├── columns: p_old:16!null p_new:17!null
            │    │    │    ├── with-scan &1
@@ -65,7 +66,7 @@ root
                           │         └──  p_new:18 => p:19
                           ├── scan parent
                           │    ├── columns: parent.p:20!null
-                          │    └── flags: disabled not visible index feature
+                          │    └── flags: avoid-full-scan disabled not visible index feature
                           └── filters
                                └── p:19 = parent.p:20
 
@@ -108,7 +109,8 @@ root
  │         ├── select
  │         │    ├── columns: pk:6!null p:7 q:8 crdb_internal_mvcc_timestamp:9 tableoid:10
  │         │    ├── scan parent_multi
- │         │    │    └── columns: pk:6!null p:7 q:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+ │         │    │    ├── columns: pk:6!null p:7 q:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+ │         │    │    └── flags: avoid-full-scan
  │         │    └── filters
  │         │         └── pk:6 > 1
  │         └── projections
@@ -128,7 +130,7 @@ root
            │    │    ├── columns: c:18!null child_multi.p:19!null child_multi.q:20!null p_old:23!null p_new:24 q_old:25!null q_new:26
            │    │    ├── scan child_multi
            │    │    │    ├── columns: c:18!null child_multi.p:19 child_multi.q:20
-           │    │    │    └── flags: disabled not visible index feature
+           │    │    │    └── flags: avoid-full-scan disabled not visible index feature
            │    │    ├── select
            │    │    │    ├── columns: p_old:23 p_new:24 q_old:25 q_new:26
            │    │    │    ├── with-scan &1
@@ -157,7 +159,7 @@ root
                           │         └──  q_new:28 => q:30
                           ├── scan parent_multi
                           │    ├── columns: parent_multi.p:32 parent_multi.q:33
-                          │    └── flags: disabled not visible index feature
+                          │    └── flags: avoid-full-scan disabled not visible index feature
                           └── filters
                                ├── p:29 = parent_multi.p:32
                                └── q:30 = parent_multi.q:33
@@ -181,7 +183,8 @@ root
  │         ├── select
  │         │    ├── columns: pk:6!null p:7!null q:8 crdb_internal_mvcc_timestamp:9 tableoid:10
  │         │    ├── scan parent_multi
- │         │    │    └── columns: pk:6!null p:7 q:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+ │         │    │    ├── columns: pk:6!null p:7 q:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+ │         │    │    └── flags: avoid-full-scan
  │         │    └── filters
  │         │         └── p:7 > 1
  │         └── projections
@@ -200,7 +203,7 @@ root
            │    │    ├── columns: c:17!null child_multi.p:18!null child_multi.q:19!null p_old:22!null p_new:23!null q_old:24!null q_new:25
            │    │    ├── scan child_multi
            │    │    │    ├── columns: c:17!null child_multi.p:18 child_multi.q:19
-           │    │    │    └── flags: disabled not visible index feature
+           │    │    │    └── flags: avoid-full-scan disabled not visible index feature
            │    │    ├── select
            │    │    │    ├── columns: p_old:22!null p_new:23!null q_old:24 q_new:25
            │    │    │    ├── with-scan &1
@@ -229,7 +232,7 @@ root
                           │         └──  q_new:27 => q:29
                           ├── scan parent_multi
                           │    ├── columns: parent_multi.p:31 parent_multi.q:32
-                          │    └── flags: disabled not visible index feature
+                          │    └── flags: avoid-full-scan disabled not visible index feature
                           └── filters
                                ├── p:28 = parent_multi.p:31
                                └── q:29 = parent_multi.q:32
@@ -260,7 +263,8 @@ root
  │         ├── select
  │         │    ├── columns: pk:6!null p:7!null q:8 crdb_internal_mvcc_timestamp:9 tableoid:10
  │         │    ├── scan parent_multi
- │         │    │    └── columns: pk:6!null p:7 q:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+ │         │    │    ├── columns: pk:6!null p:7 q:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+ │         │    │    └── flags: avoid-full-scan
  │         │    └── filters
  │         │         └── p:7 > 1
  │         └── projections
@@ -281,7 +285,7 @@ root
       │    │    │    ├── columns: c:17!null child_multi.p:18!null child_multi.q:19!null p_old:22!null p_new:23!null q_old:24!null q_new:25
       │    │    │    ├── scan child_multi
       │    │    │    │    ├── columns: c:17!null child_multi.p:18 child_multi.q:19
-      │    │    │    │    └── flags: disabled not visible index feature
+      │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
       │    │    │    ├── select
       │    │    │    │    ├── columns: p_old:22!null p_new:23!null q_old:24 q_new:25
       │    │    │    │    ├── with-scan &1
@@ -310,7 +314,7 @@ root
       │                   │         └──  q_new:27 => q:29
       │                   ├── scan parent_multi
       │                   │    ├── columns: parent_multi.p:31 parent_multi.q:32
-      │                   │    └── flags: disabled not visible index feature
+      │                   │    └── flags: avoid-full-scan disabled not visible index feature
       │                   └── filters
       │                        ├── p:28 = parent_multi.p:31
       │                        └── q:29 = parent_multi.q:32
@@ -328,7 +332,7 @@ root
                 │    │    ├── columns: g:40!null grandchild.c:41!null grandchild.q:42!null c_old:45!null c_new:46!null q_old:47!null q_new:48!null
                 │    │    ├── scan grandchild
                 │    │    │    ├── columns: g:40!null grandchild.c:41 grandchild.q:42
-                │    │    │    └── flags: disabled not visible index feature
+                │    │    │    └── flags: avoid-full-scan disabled not visible index feature
                 │    │    ├── select
                 │    │    │    ├── columns: c_old:45!null c_new:46!null q_old:47!null q_new:48!null
                 │    │    │    ├── with-scan &2
@@ -357,7 +361,7 @@ root
                                │         └──  q_new:50 => q:52
                                ├── scan child_multi
                                │    ├── columns: child_multi.c:53!null child_multi.q:55
-                               │    └── flags: disabled not visible index feature
+                               │    └── flags: avoid-full-scan disabled not visible index feature
                                └── filters
                                     ├── c:51 = child_multi.c:53
                                     └── q:52 = child_multi.q:55
@@ -399,7 +403,7 @@ root
  │         │    │              └── column3:8
  │         │    ├── scan parent_multi
  │         │    │    ├── columns: pk:9!null p:10 q:11 crdb_internal_mvcc_timestamp:12 tableoid:13
- │         │    │    └── flags: disabled not visible index feature
+ │         │    │    └── flags: avoid-full-scan disabled not visible index feature
  │         │    └── filters
  │         │         └── column1:6 = pk:9
  │         └── projections
@@ -420,7 +424,7 @@ root
       │    │    │    ├── columns: c:20!null child_multi.p:21!null child_multi.q:22!null p_old:25!null p_new:26!null q_old:27!null q_new:28!null
       │    │    │    ├── scan child_multi
       │    │    │    │    ├── columns: c:20!null child_multi.p:21 child_multi.q:22
-      │    │    │    │    └── flags: disabled not visible index feature
+      │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
       │    │    │    ├── select
       │    │    │    │    ├── columns: p_old:25 p_new:26!null q_old:27 q_new:28!null
       │    │    │    │    ├── with-scan &1
@@ -449,7 +453,7 @@ root
       │                   │         └──  q_new:30 => q:32
       │                   ├── scan parent_multi
       │                   │    ├── columns: parent_multi.p:34 parent_multi.q:35
-      │                   │    └── flags: disabled not visible index feature
+      │                   │    └── flags: avoid-full-scan disabled not visible index feature
       │                   └── filters
       │                        ├── p:31 = parent_multi.p:34
       │                        └── q:32 = parent_multi.q:35
@@ -467,7 +471,7 @@ root
                 │    │    ├── columns: g:43!null grandchild.c:44!null grandchild.q:45!null c_old:48!null c_new:49!null q_old:50!null q_new:51!null
                 │    │    ├── scan grandchild
                 │    │    │    ├── columns: g:43!null grandchild.c:44 grandchild.q:45
-                │    │    │    └── flags: disabled not visible index feature
+                │    │    │    └── flags: avoid-full-scan disabled not visible index feature
                 │    │    ├── select
                 │    │    │    ├── columns: c_old:48!null c_new:49!null q_old:50!null q_new:51!null
                 │    │    │    ├── with-scan &2
@@ -496,7 +500,7 @@ root
                                │         └──  q_new:53 => q:55
                                ├── scan child_multi
                                │    ├── columns: child_multi.c:56!null child_multi.q:58
-                               │    └── flags: disabled not visible index feature
+                               │    └── flags: avoid-full-scan disabled not visible index feature
                                └── filters
                                     ├── c:54 = child_multi.c:56
                                     └── q:55 = child_multi.q:58
@@ -542,7 +546,7 @@ root
  │         │    │              └── q_default:8
  │         │    ├── scan parent_multi
  │         │    │    ├── columns: pk:9!null p:10 q:11 crdb_internal_mvcc_timestamp:12 tableoid:13
- │         │    │    └── flags: disabled not visible index feature
+ │         │    │    └── flags: avoid-full-scan disabled not visible index feature
  │         │    └── filters
  │         │         └── column1:6 = pk:9
  │         └── projections
@@ -564,7 +568,7 @@ root
       │    │    │    ├── columns: c:21!null child_multi.p:22!null child_multi.q:23!null p_old:26!null p_new:27!null q_old:28!null q_new:29
       │    │    │    ├── scan child_multi
       │    │    │    │    ├── columns: c:21!null child_multi.p:22 child_multi.q:23
-      │    │    │    │    └── flags: disabled not visible index feature
+      │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
       │    │    │    ├── select
       │    │    │    │    ├── columns: p_old:26 p_new:27!null q_old:28 q_new:29
       │    │    │    │    ├── with-scan &1
@@ -593,7 +597,7 @@ root
       │                   │         └──  q_new:31 => q:33
       │                   ├── scan parent_multi
       │                   │    ├── columns: parent_multi.p:35 parent_multi.q:36
-      │                   │    └── flags: disabled not visible index feature
+      │                   │    └── flags: avoid-full-scan disabled not visible index feature
       │                   └── filters
       │                        ├── p:32 = parent_multi.p:35
       │                        └── q:33 = parent_multi.q:36
@@ -611,7 +615,7 @@ root
                 │    │    ├── columns: g:44!null grandchild.c:45!null grandchild.q:46!null c_old:49!null c_new:50!null q_old:51!null q_new:52!null
                 │    │    ├── scan grandchild
                 │    │    │    ├── columns: g:44!null grandchild.c:45 grandchild.q:46
-                │    │    │    └── flags: disabled not visible index feature
+                │    │    │    └── flags: avoid-full-scan disabled not visible index feature
                 │    │    ├── select
                 │    │    │    ├── columns: c_old:49!null c_new:50!null q_old:51!null q_new:52!null
                 │    │    │    ├── with-scan &2
@@ -640,7 +644,7 @@ root
                                │         └──  q_new:54 => q:56
                                ├── scan child_multi
                                │    ├── columns: child_multi.c:57!null child_multi.q:59
-                               │    └── flags: disabled not visible index feature
+                               │    └── flags: avoid-full-scan disabled not visible index feature
                                └── filters
                                     ├── c:55 = child_multi.c:57
                                     └── q:56 = child_multi.q:59
@@ -681,7 +685,7 @@ root
  │         │    │    │              └── column1:6
  │         │    │    ├── scan parent_multi
  │         │    │    │    ├── columns: pk:9!null p:10 q:11 crdb_internal_mvcc_timestamp:12 tableoid:13
- │         │    │    │    └── flags: disabled not visible index feature
+ │         │    │    │    └── flags: avoid-full-scan disabled not visible index feature
  │         │    │    └── filters
  │         │    │         ├── column2:7 = p:10
  │         │    │         └── column3:8 = q:11
@@ -707,7 +711,7 @@ root
       │    │    │    ├── columns: c:23!null child_multi.p:24!null child_multi.q:25!null p_old:28!null p_new:29!null q_old:30!null q_new:31
       │    │    │    ├── scan child_multi
       │    │    │    │    ├── columns: c:23!null child_multi.p:24 child_multi.q:25
-      │    │    │    │    └── flags: disabled not visible index feature
+      │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
       │    │    │    ├── select
       │    │    │    │    ├── columns: p_old:28 p_new:29!null q_old:30 q_new:31
       │    │    │    │    ├── with-scan &1
@@ -736,7 +740,7 @@ root
       │                   │         └──  q_new:33 => q:35
       │                   ├── scan parent_multi
       │                   │    ├── columns: parent_multi.p:37 parent_multi.q:38
-      │                   │    └── flags: disabled not visible index feature
+      │                   │    └── flags: avoid-full-scan disabled not visible index feature
       │                   └── filters
       │                        ├── p:34 = parent_multi.p:37
       │                        └── q:35 = parent_multi.q:38
@@ -754,7 +758,7 @@ root
                 │    │    ├── columns: g:46!null grandchild.c:47!null grandchild.q:48!null c_old:51!null c_new:52!null q_old:53!null q_new:54!null
                 │    │    ├── scan grandchild
                 │    │    │    ├── columns: g:46!null grandchild.c:47 grandchild.q:48
-                │    │    │    └── flags: disabled not visible index feature
+                │    │    │    └── flags: avoid-full-scan disabled not visible index feature
                 │    │    ├── select
                 │    │    │    ├── columns: c_old:51!null c_new:52!null q_old:53!null q_new:54!null
                 │    │    │    ├── with-scan &2
@@ -783,7 +787,7 @@ root
                                │         └──  q_new:56 => q:58
                                ├── scan child_multi
                                │    ├── columns: child_multi.c:59!null child_multi.q:61
-                               │    └── flags: disabled not visible index feature
+                               │    └── flags: avoid-full-scan disabled not visible index feature
                                └── filters
                                     ├── c:57 = child_multi.c:59
                                     └── q:58 = child_multi.q:61
@@ -819,7 +823,8 @@ root
  │         ├── select
  │         │    ├── columns: p:5!null p2:6 crdb_internal_mvcc_timestamp:7 tableoid:8
  │         │    ├── scan parent_assn_cast
- │         │    │    └── columns: p:5!null p2:6 crdb_internal_mvcc_timestamp:7 tableoid:8
+ │         │    │    ├── columns: p:5!null p2:6 crdb_internal_mvcc_timestamp:7 tableoid:8
+ │         │    │    └── flags: avoid-full-scan
  │         │    └── filters
  │         │         └── p:5 > 1
  │         └── projections
@@ -839,7 +844,7 @@ root
            │    │    │    ├── columns: c:14!null child_assn_cast.p:15!null p_old:18!null p_new:19!null
            │    │    │    ├── scan child_assn_cast
            │    │    │    │    ├── columns: c:14!null child_assn_cast.p:15
-           │    │    │    │    └── flags: disabled not visible index feature
+           │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
            │    │    │    ├── select
            │    │    │    │    ├── columns: p_old:18!null p_new:19!null
            │    │    │    │    ├── with-scan &1
@@ -866,7 +871,7 @@ root
                           │         └──  p_cast:21 => p:22
                           ├── scan parent_assn_cast
                           │    ├── columns: parent_assn_cast.p:23!null
-                          │    └── flags: disabled not visible index feature
+                          │    └── flags: avoid-full-scan disabled not visible index feature
                           └── filters
                                └── p:22 = parent_assn_cast.p:23
 
@@ -909,7 +914,7 @@ root
  │         │    │              └── column2:6
  │         │    ├── scan parent_assn_cast
  │         │    │    ├── columns: p:7!null p2:8 crdb_internal_mvcc_timestamp:9 tableoid:10
- │         │    │    └── flags: disabled not visible index feature
+ │         │    │    └── flags: avoid-full-scan disabled not visible index feature
  │         │    └── filters
  │         │         └── column1:5 = p:7
  │         └── projections
@@ -929,7 +934,7 @@ root
            │    │    │    ├── columns: c:16!null child_assn_cast_p2.p2:17!null p2_old:20!null p2_new:21!null
            │    │    │    ├── scan child_assn_cast_p2
            │    │    │    │    ├── columns: c:16!null child_assn_cast_p2.p2:17
-           │    │    │    │    └── flags: disabled not visible index feature
+           │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
            │    │    │    ├── select
            │    │    │    │    ├── columns: p2_old:20 p2_new:21!null
            │    │    │    │    ├── with-scan &1
@@ -956,7 +961,7 @@ root
                           │         └──  p2_cast:23 => p2:24
                           ├── scan parent_assn_cast
                           │    ├── columns: parent_assn_cast.p2:26
-                          │    └── flags: disabled not visible index feature
+                          │    └── flags: avoid-full-scan disabled not visible index feature
                           └── filters
                                └── p2:24 = parent_assn_cast.p2:26
 
@@ -994,7 +999,7 @@ root
  │         │    │    │              └── column2:6
  │         │    │    ├── scan parent_assn_cast
  │         │    │    │    ├── columns: p:7!null p2:8 crdb_internal_mvcc_timestamp:9 tableoid:10
- │         │    │    │    └── flags: disabled not visible index feature
+ │         │    │    │    └── flags: avoid-full-scan disabled not visible index feature
  │         │    │    └── filters
  │         │    │         └── column1:5 = p:7
  │         │    └── projections
@@ -1017,7 +1022,7 @@ root
            │    │    │    ├── columns: c:18!null child_assn_cast_p2.p2:19!null p2_old:22!null p2_new:23!null
            │    │    │    ├── scan child_assn_cast_p2
            │    │    │    │    ├── columns: c:18!null child_assn_cast_p2.p2:19
-           │    │    │    │    └── flags: disabled not visible index feature
+           │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
            │    │    │    ├── select
            │    │    │    │    ├── columns: p2_old:22 p2_new:23!null
            │    │    │    │    ├── with-scan &1
@@ -1044,7 +1049,7 @@ root
                           │         └──  p2_cast:25 => p2:26
                           ├── scan parent_assn_cast
                           │    ├── columns: parent_assn_cast.p2:28
-                          │    └── flags: disabled not visible index feature
+                          │    └── flags: avoid-full-scan disabled not visible index feature
                           └── filters
                                └── p2:26 = parent_assn_cast.p2:28
 
@@ -1080,7 +1085,8 @@ root
  │         ├── select
  │         │    ├── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
  │         │    ├── scan parent_partial
- │         │    │    └── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+ │         │    │    ├── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+ │         │    │    └── flags: avoid-full-scan
  │         │    └── filters
  │         │         └── p:4 > 1
  │         └── projections
@@ -1107,7 +1113,7 @@ root
            │    │    │    │    │    │    └── i:15 > 0
            │    │    │    │    │    └── child_partial_i_idx: filters
            │    │    │    │    │         └── child_partial.p:14 > 0
-           │    │    │    │    └── flags: disabled not visible index feature
+           │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
            │    │    │    ├── select
            │    │    │    │    ├── columns: p_old:18!null p_new:19!null
            │    │    │    │    ├── with-scan &1
@@ -1135,7 +1141,7 @@ root
                           │         └──  p_new:20 => p:24
                           ├── scan parent_partial
                           │    ├── columns: parent_partial.p:25!null
-                          │    └── flags: disabled not visible index feature
+                          │    └── flags: avoid-full-scan disabled not visible index feature
                           └── filters
                                └── p:24 = parent_partial.p:25
 
@@ -1169,7 +1175,8 @@ root
  │         ├── select
  │         │    ├── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
  │         │    ├── scan parent_virt
- │         │    │    └── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+ │         │    │    ├── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+ │         │    │    └── flags: avoid-full-scan
  │         │    └── filters
  │         │         └── p:4 > 1
  │         └── projections
@@ -1193,7 +1200,7 @@ root
            │    │    │    │    ├── computed column expressions
            │    │    │    │    │    └── v:15
            │    │    │    │    │         └── child_virt.p:14
-           │    │    │    │    └── flags: disabled not visible index feature
+           │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
            │    │    │    └── projections
            │    │    │         └── child_virt.p:14 [as=v:15]
            │    │    ├── select
@@ -1219,6 +1226,6 @@ root
                           │         └──  p_new:20 => p:21
                           ├── scan parent_virt
                           │    ├── columns: parent_virt.p:22!null
-                          │    └── flags: disabled not visible index feature
+                          │    └── flags: avoid-full-scan disabled not visible index feature
                           └── filters
                                └── p:21 = parent_virt.p:22

--- a/pkg/sql/opt/optbuilder/testdata/fk-on-update-set-null
+++ b/pkg/sql/opt/optbuilder/testdata/fk-on-update-set-null
@@ -23,7 +23,8 @@ root
  │         ├── select
  │         │    ├── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
  │         │    ├── scan parent
- │         │    │    └── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+ │         │    │    ├── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+ │         │    │    └── flags: avoid-full-scan
  │         │    └── filters
  │         │         └── p:4 > 1
  │         └── projections
@@ -40,7 +41,7 @@ root
                 │    ├── columns: c:12!null child.p:13!null p_old:16!null p_new:17!null
                 │    ├── scan child
                 │    │    ├── columns: c:12!null child.p:13!null
-                │    │    └── flags: disabled not visible index feature
+                │    │    └── flags: avoid-full-scan disabled not visible index feature
                 │    ├── select
                 │    │    ├── columns: p_old:16!null p_new:17!null
                 │    │    ├── with-scan &1
@@ -93,7 +94,8 @@ root
  │         ├── select
  │         │    ├── columns: pk:6!null p:7 q:8 crdb_internal_mvcc_timestamp:9 tableoid:10
  │         │    ├── scan parent_multi
- │         │    │    └── columns: pk:6!null p:7 q:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+ │         │    │    ├── columns: pk:6!null p:7 q:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+ │         │    │    └── flags: avoid-full-scan
  │         │    └── filters
  │         │         └── pk:6 > 1
  │         └── projections
@@ -112,7 +114,7 @@ root
                 │    ├── columns: c:18!null child_multi.p:19!null child_multi.q:20!null p_old:23!null p_new:24 q_old:25!null q_new:26
                 │    ├── scan child_multi
                 │    │    ├── columns: c:18!null child_multi.p:19 child_multi.q:20
-                │    │    └── flags: disabled not visible index feature
+                │    │    └── flags: avoid-full-scan disabled not visible index feature
                 │    ├── select
                 │    │    ├── columns: p_old:23 p_new:24 q_old:25 q_new:26
                 │    │    ├── with-scan &1
@@ -148,7 +150,8 @@ root
  │         ├── select
  │         │    ├── columns: pk:6!null p:7!null q:8 crdb_internal_mvcc_timestamp:9 tableoid:10
  │         │    ├── scan parent_multi
- │         │    │    └── columns: pk:6!null p:7 q:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+ │         │    │    ├── columns: pk:6!null p:7 q:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+ │         │    │    └── flags: avoid-full-scan
  │         │    └── filters
  │         │         └── p:7 > 1
  │         └── projections
@@ -166,7 +169,7 @@ root
                 │    ├── columns: c:17!null child_multi.p:18!null child_multi.q:19!null p_old:22!null p_new:23!null q_old:24!null q_new:25
                 │    ├── scan child_multi
                 │    │    ├── columns: c:17!null child_multi.p:18 child_multi.q:19
-                │    │    └── flags: disabled not visible index feature
+                │    │    └── flags: avoid-full-scan disabled not visible index feature
                 │    ├── select
                 │    │    ├── columns: p_old:22!null p_new:23!null q_old:24 q_new:25
                 │    │    ├── with-scan &1
@@ -210,7 +213,8 @@ root
  │         ├── select
  │         │    ├── columns: pk:6!null p:7!null q:8 crdb_internal_mvcc_timestamp:9 tableoid:10
  │         │    ├── scan parent_multi
- │         │    │    └── columns: pk:6!null p:7 q:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+ │         │    │    ├── columns: pk:6!null p:7 q:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+ │         │    │    └── flags: avoid-full-scan
  │         │    └── filters
  │         │         └── p:7 > 1
  │         └── projections
@@ -231,7 +235,7 @@ root
       │         │    ├── columns: c:17!null child_multi.p:18!null child_multi.q:19!null p_old:22!null p_new:23!null q_old:24!null q_new:25
       │         │    ├── scan child_multi
       │         │    │    ├── columns: c:17!null child_multi.p:18 child_multi.q:19
-      │         │    │    └── flags: disabled not visible index feature
+      │         │    │    └── flags: avoid-full-scan disabled not visible index feature
       │         │    ├── select
       │         │    │    ├── columns: p_old:22!null p_new:23!null q_old:24 q_new:25
       │         │    │    ├── with-scan &1
@@ -261,7 +265,7 @@ root
                      │    ├── columns: g:32!null grandchild.c:33!null grandchild.q:34!null c_old:37!null c_new:38!null q_old:39!null q_new:40
                      │    ├── scan grandchild
                      │    │    ├── columns: g:32!null grandchild.c:33 grandchild.q:34
-                     │    │    └── flags: disabled not visible index feature
+                     │    │    └── flags: avoid-full-scan disabled not visible index feature
                      │    ├── select
                      │    │    ├── columns: c_old:37!null c_new:38!null q_old:39!null q_new:40
                      │    │    ├── with-scan &2
@@ -316,7 +320,7 @@ root
  │         │    │              └── column3:8
  │         │    ├── scan parent_multi
  │         │    │    ├── columns: pk:9!null p:10 q:11 crdb_internal_mvcc_timestamp:12 tableoid:13
- │         │    │    └── flags: disabled not visible index feature
+ │         │    │    └── flags: avoid-full-scan disabled not visible index feature
  │         │    └── filters
  │         │         └── column1:6 = pk:9
  │         └── projections
@@ -337,7 +341,7 @@ root
       │         │    ├── columns: c:20!null child_multi.p:21!null child_multi.q:22!null p_old:25!null p_new:26!null q_old:27!null q_new:28!null
       │         │    ├── scan child_multi
       │         │    │    ├── columns: c:20!null child_multi.p:21 child_multi.q:22
-      │         │    │    └── flags: disabled not visible index feature
+      │         │    │    └── flags: avoid-full-scan disabled not visible index feature
       │         │    ├── select
       │         │    │    ├── columns: p_old:25 p_new:26!null q_old:27 q_new:28!null
       │         │    │    ├── with-scan &1
@@ -367,7 +371,7 @@ root
                      │    ├── columns: g:35!null grandchild.c:36!null grandchild.q:37!null c_old:40!null c_new:41!null q_old:42!null q_new:43
                      │    ├── scan grandchild
                      │    │    ├── columns: g:35!null grandchild.c:36 grandchild.q:37
-                     │    │    └── flags: disabled not visible index feature
+                     │    │    └── flags: avoid-full-scan disabled not visible index feature
                      │    ├── select
                      │    │    ├── columns: c_old:40!null c_new:41!null q_old:42!null q_new:43
                      │    │    ├── with-scan &2
@@ -426,7 +430,7 @@ root
  │         │    │              └── q_default:8
  │         │    ├── scan parent_multi
  │         │    │    ├── columns: pk:9!null p:10 q:11 crdb_internal_mvcc_timestamp:12 tableoid:13
- │         │    │    └── flags: disabled not visible index feature
+ │         │    │    └── flags: avoid-full-scan disabled not visible index feature
  │         │    └── filters
  │         │         └── column1:6 = pk:9
  │         └── projections
@@ -448,7 +452,7 @@ root
       │         │    ├── columns: c:21!null child_multi.p:22!null child_multi.q:23!null p_old:26!null p_new:27!null q_old:28!null q_new:29
       │         │    ├── scan child_multi
       │         │    │    ├── columns: c:21!null child_multi.p:22 child_multi.q:23
-      │         │    │    └── flags: disabled not visible index feature
+      │         │    │    └── flags: avoid-full-scan disabled not visible index feature
       │         │    ├── select
       │         │    │    ├── columns: p_old:26 p_new:27!null q_old:28 q_new:29
       │         │    │    ├── with-scan &1
@@ -478,7 +482,7 @@ root
                      │    ├── columns: g:36!null grandchild.c:37!null grandchild.q:38!null c_old:41!null c_new:42!null q_old:43!null q_new:44
                      │    ├── scan grandchild
                      │    │    ├── columns: g:36!null grandchild.c:37 grandchild.q:38
-                     │    │    └── flags: disabled not visible index feature
+                     │    │    └── flags: avoid-full-scan disabled not visible index feature
                      │    ├── select
                      │    │    ├── columns: c_old:41!null c_new:42!null q_old:43!null q_new:44
                      │    │    ├── with-scan &2
@@ -532,7 +536,7 @@ root
  │         │    │    │              └── column1:6
  │         │    │    ├── scan parent_multi
  │         │    │    │    ├── columns: pk:9!null p:10 q:11 crdb_internal_mvcc_timestamp:12 tableoid:13
- │         │    │    │    └── flags: disabled not visible index feature
+ │         │    │    │    └── flags: avoid-full-scan disabled not visible index feature
  │         │    │    └── filters
  │         │    │         ├── column2:7 = p:10
  │         │    │         └── column3:8 = q:11
@@ -558,7 +562,7 @@ root
       │         │    ├── columns: c:23!null child_multi.p:24!null child_multi.q:25!null p_old:28!null p_new:29!null q_old:30!null q_new:31
       │         │    ├── scan child_multi
       │         │    │    ├── columns: c:23!null child_multi.p:24 child_multi.q:25
-      │         │    │    └── flags: disabled not visible index feature
+      │         │    │    └── flags: avoid-full-scan disabled not visible index feature
       │         │    ├── select
       │         │    │    ├── columns: p_old:28 p_new:29!null q_old:30 q_new:31
       │         │    │    ├── with-scan &1
@@ -588,7 +592,7 @@ root
                      │    ├── columns: g:38!null grandchild.c:39!null grandchild.q:40!null c_old:43!null c_new:44!null q_old:45!null q_new:46
                      │    ├── scan grandchild
                      │    │    ├── columns: g:38!null grandchild.c:39 grandchild.q:40
-                     │    │    └── flags: disabled not visible index feature
+                     │    │    └── flags: avoid-full-scan disabled not visible index feature
                      │    ├── select
                      │    │    ├── columns: c_old:43!null c_new:44!null q_old:45!null q_new:46
                      │    │    ├── with-scan &2
@@ -638,7 +642,8 @@ root
  │         ├── select
  │         │    ├── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
  │         │    ├── scan parent_partial
- │         │    │    └── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+ │         │    │    ├── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+ │         │    │    └── flags: avoid-full-scan
  │         │    └── filters
  │         │         └── p:4 > 1
  │         └── projections
@@ -664,7 +669,7 @@ root
                 │    │    │    │    │    └── i:15 > 0
                 │    │    │    │    └── child_partial_i_idx: filters
                 │    │    │    │         └── child_partial.p:14 > 0
-                │    │    │    └── flags: disabled not visible index feature
+                │    │    │    └── flags: avoid-full-scan disabled not visible index feature
                 │    │    ├── select
                 │    │    │    ├── columns: p_old:18!null p_new:19!null
                 │    │    │    ├── with-scan &1
@@ -713,7 +718,8 @@ root
  │         ├── select
  │         │    ├── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
  │         │    ├── scan parent_virt
- │         │    │    └── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+ │         │    │    ├── columns: p:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+ │         │    │    └── flags: avoid-full-scan
  │         │    └── filters
  │         │         └── p:4 > 1
  │         └── projections
@@ -736,7 +742,7 @@ root
                 │    │    │    ├── computed column expressions
                 │    │    │    │    └── v:15
                 │    │    │    │         └── child_virt.p:14
-                │    │    │    └── flags: disabled not visible index feature
+                │    │    │    └── flags: avoid-full-scan disabled not visible index feature
                 │    │    └── projections
                 │    │         └── child_virt.p:14 [as=v:15]
                 │    ├── select

--- a/pkg/sql/opt/optbuilder/testdata/inverted-indexes
+++ b/pkg/sql/opt/optbuilder/testdata/inverted-indexes
@@ -78,7 +78,7 @@ upsert kj
       │    │              └── column2:7
       │    ├── scan kj
       │    │    ├── columns: k:8!null j:9 crdb_internal_mvcc_timestamp:10 tableoid:11
-      │    │    └── flags: disabled not visible index feature
+      │    │    └── flags: avoid-full-scan disabled not visible index feature
       │    └── filters
       │         └── column1:6 = k:8
       └── projections
@@ -103,7 +103,7 @@ insert kj
       │    │    └── (1, '{"a": 2}')
       │    ├── scan kj
       │    │    ├── columns: k:8!null j:9
-      │    │    └── flags: disabled not visible index feature
+      │    │    └── flags: avoid-full-scan disabled not visible index feature
       │    └── filters
       │         └── column1:6 = k:8
       └── aggregations
@@ -140,7 +140,7 @@ upsert kj
       │    │    │              └── column2:7
       │    │    ├── scan kj
       │    │    │    ├── columns: k:8!null j:9 crdb_internal_mvcc_timestamp:10 tableoid:11
-      │    │    │    └── flags: disabled not visible index feature
+      │    │    │    └── flags: avoid-full-scan disabled not visible index feature
       │    │    └── filters
       │    │         └── column1:6 = k:8
       │    └── projections
@@ -162,7 +162,8 @@ update kj
       ├── select
       │    ├── columns: k:6!null j:7 crdb_internal_mvcc_timestamp:8 tableoid:9
       │    ├── scan kj
-      │    │    └── columns: k:6!null j:7 crdb_internal_mvcc_timestamp:8 tableoid:9
+      │    │    ├── columns: k:6!null j:7 crdb_internal_mvcc_timestamp:8 tableoid:9
+      │    │    └── flags: avoid-full-scan
       │    └── filters
       │         └── k:6 > 0
       └── projections
@@ -177,6 +178,7 @@ delete kj
  └── select
       ├── columns: k:6!null j:7!null crdb_internal_mvcc_timestamp:8 tableoid:9
       ├── scan kj
-      │    └── columns: k:6!null j:7 crdb_internal_mvcc_timestamp:8 tableoid:9
+      │    ├── columns: k:6!null j:7 crdb_internal_mvcc_timestamp:8 tableoid:9
+      │    └── flags: avoid-full-scan
       └── filters
            └── j:7 @> '{"a": 2}'

--- a/pkg/sql/opt/optbuilder/testdata/partial-indexes
+++ b/pkg/sql/opt/optbuilder/testdata/partial-indexes
@@ -208,15 +208,16 @@ delete partial_indexes
       ├── columns: partial_index_del1:11 partial_index_del2:12 partial_index_del3:13 partial_index_del4:14 a:6!null b:7 c:8 crdb_internal_mvcc_timestamp:9 tableoid:10
       ├── scan partial_indexes
       │    ├── columns: a:6!null b:7 c:8 crdb_internal_mvcc_timestamp:9 tableoid:10
-      │    └── partial index predicates
-      │         ├── partial_indexes_b_idx1: filters
-      │         │    └── c:8 = 'foo'
-      │         ├── partial_indexes_c_idx: filters
-      │         │    └── (a:6 > b:7) AND (c:8 = 'bar')
-      │         ├── b: filters
-      │         │    └── c:8 = 'delete-only'
-      │         └── b: filters
-      │              └── c:8 = 'write-only'
+      │    ├── partial index predicates
+      │    │    ├── partial_indexes_b_idx1: filters
+      │    │    │    └── c:8 = 'foo'
+      │    │    ├── partial_indexes_c_idx: filters
+      │    │    │    └── (a:6 > b:7) AND (c:8 = 'bar')
+      │    │    ├── b: filters
+      │    │    │    └── c:8 = 'delete-only'
+      │    │    └── b: filters
+      │    │         └── c:8 = 'write-only'
+      │    └── flags: avoid-full-scan
       └── projections
            ├── c:8 = 'foo' [as=partial_index_del1:11]
            ├── (a:6 > b:7) AND (c:8 = 'bar') [as=partial_index_del2:12]
@@ -238,13 +239,14 @@ delete ambig
       │    ├── columns: partial_index_put1:7 ambig.partial_index_del1:8!null check1:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
       │    ├── scan ambig
       │    │    ├── columns: partial_index_put1:7 ambig.partial_index_del1:8 check1:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
-      │    │    └── partial index predicates
-      │    │         ├── ambig_partial_index_put1_key: filters
-      │    │         │    └── partial_index_put1:7 > 0
-      │    │         ├── ambig_partial_index_del1_key: filters
-      │    │         │    └── ambig.partial_index_del1:8 > 0
-      │    │         └── ambig_partial_index_put1_idx: filters
-      │    │              └── check1:9 > 0
+      │    │    ├── partial index predicates
+      │    │    │    ├── ambig_partial_index_put1_key: filters
+      │    │    │    │    └── partial_index_put1:7 > 0
+      │    │    │    ├── ambig_partial_index_del1_key: filters
+      │    │    │    │    └── ambig.partial_index_del1:8 > 0
+      │    │    │    └── ambig_partial_index_put1_idx: filters
+      │    │    │         └── check1:9 > 0
+      │    │    └── flags: avoid-full-scan
       │    └── filters
       │         └── ambig.partial_index_del1:8 = 5
       └── projections
@@ -270,11 +272,12 @@ delete comp
       │    │    │    │    └── lower(c:10)
       │    │    │    └── e:12
       │    │    │         └── upper(c:10)
-      │    │    └── partial index predicates
-      │    │         ├── comp_b_idx: filters
-      │    │         │    └── lower(c:10) = 'foo'
-      │    │         └── comp_b_idx1: filters
-      │    │              └── e:12 = 'FOO'
+      │    │    ├── partial index predicates
+      │    │    │    ├── comp_b_idx: filters
+      │    │    │    │    └── lower(c:10) = 'foo'
+      │    │    │    └── comp_b_idx1: filters
+      │    │    │         └── e:12 = 'FOO'
+      │    │    └── flags: avoid-full-scan
       │    └── projections
       │         └── lower(c:10) [as=d:11]
       └── projections
@@ -299,15 +302,16 @@ update partial_indexes
       │    ├── columns: a_new:11!null a:6!null b:7 c:8 crdb_internal_mvcc_timestamp:9 tableoid:10
       │    ├── scan partial_indexes
       │    │    ├── columns: a:6!null b:7 c:8 crdb_internal_mvcc_timestamp:9 tableoid:10
-      │    │    └── partial index predicates
-      │    │         ├── partial_indexes_b_idx1: filters
-      │    │         │    └── c:8 = 'foo'
-      │    │         ├── partial_indexes_c_idx: filters
-      │    │         │    └── (a:6 > b:7) AND (c:8 = 'bar')
-      │    │         ├── b: filters
-      │    │         │    └── c:8 = 'delete-only'
-      │    │         └── b: filters
-      │    │              └── c:8 = 'write-only'
+      │    │    ├── partial index predicates
+      │    │    │    ├── partial_indexes_b_idx1: filters
+      │    │    │    │    └── c:8 = 'foo'
+      │    │    │    ├── partial_indexes_c_idx: filters
+      │    │    │    │    └── (a:6 > b:7) AND (c:8 = 'bar')
+      │    │    │    ├── b: filters
+      │    │    │    │    └── c:8 = 'delete-only'
+      │    │    │    └── b: filters
+      │    │    │         └── c:8 = 'write-only'
+      │    │    └── flags: avoid-full-scan
       │    └── projections
       │         └── 1 [as=a_new:11]
       └── projections
@@ -337,15 +341,16 @@ update partial_indexes
       │    ├── columns: a_new:11!null a:6!null b:7 c:8 crdb_internal_mvcc_timestamp:9 tableoid:10
       │    ├── scan partial_indexes
       │    │    ├── columns: a:6!null b:7 c:8 crdb_internal_mvcc_timestamp:9 tableoid:10
-      │    │    └── partial index predicates
-      │    │         ├── partial_indexes_b_idx1: filters
-      │    │         │    └── c:8 = 'foo'
-      │    │         ├── partial_indexes_c_idx: filters
-      │    │         │    └── (a:6 > b:7) AND (c:8 = 'bar')
-      │    │         ├── b: filters
-      │    │         │    └── c:8 = 'delete-only'
-      │    │         └── b: filters
-      │    │              └── c:8 = 'write-only'
+      │    │    ├── partial index predicates
+      │    │    │    ├── partial_indexes_b_idx1: filters
+      │    │    │    │    └── c:8 = 'foo'
+      │    │    │    ├── partial_indexes_c_idx: filters
+      │    │    │    │    └── (a:6 > b:7) AND (c:8 = 'bar')
+      │    │    │    ├── b: filters
+      │    │    │    │    └── c:8 = 'delete-only'
+      │    │    │    └── b: filters
+      │    │    │         └── c:8 = 'write-only'
+      │    │    └── flags: avoid-full-scan
       │    └── projections
       │         └── a:6 + 5 [as=a_new:11]
       └── projections
@@ -377,15 +382,16 @@ update partial_indexes
       │    │    │    ├── columns: a:6!null b:7 c:8 crdb_internal_mvcc_timestamp:9 tableoid:10 column1:11!null
       │    │    │    ├── scan partial_indexes
       │    │    │    │    ├── columns: a:6!null b:7 c:8 crdb_internal_mvcc_timestamp:9 tableoid:10
-      │    │    │    │    └── partial index predicates
-      │    │    │    │         ├── partial_indexes_b_idx1: filters
-      │    │    │    │         │    └── c:8 = 'foo'
-      │    │    │    │         ├── partial_indexes_c_idx: filters
-      │    │    │    │         │    └── (a:6 > b:7) AND (c:8 = 'bar')
-      │    │    │    │         ├── b: filters
-      │    │    │    │         │    └── c:8 = 'delete-only'
-      │    │    │    │         └── b: filters
-      │    │    │    │              └── c:8 = 'write-only'
+      │    │    │    │    ├── partial index predicates
+      │    │    │    │    │    ├── partial_indexes_b_idx1: filters
+      │    │    │    │    │    │    └── c:8 = 'foo'
+      │    │    │    │    │    ├── partial_indexes_c_idx: filters
+      │    │    │    │    │    │    └── (a:6 > b:7) AND (c:8 = 'bar')
+      │    │    │    │    │    ├── b: filters
+      │    │    │    │    │    │    └── c:8 = 'delete-only'
+      │    │    │    │    │    └── b: filters
+      │    │    │    │    │         └── c:8 = 'write-only'
+      │    │    │    │    └── flags: avoid-full-scan
       │    │    │    ├── values
       │    │    │    │    ├── columns: column1:11!null
       │    │    │    │    ├── (1,)
@@ -435,13 +441,14 @@ update ambig
       │    │    │    ├── columns: ambig.partial_index_put1:7!null ambig.partial_index_del1:8!null ambig.check1:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
       │    │    │    ├── scan ambig
       │    │    │    │    ├── columns: ambig.partial_index_put1:7 ambig.partial_index_del1:8 ambig.check1:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
-      │    │    │    │    └── partial index predicates
-      │    │    │    │         ├── ambig_partial_index_put1_key: filters
-      │    │    │    │         │    └── ambig.partial_index_put1:7 > 0
-      │    │    │    │         ├── ambig_partial_index_del1_key: filters
-      │    │    │    │         │    └── ambig.partial_index_del1:8 > 0
-      │    │    │    │         └── ambig_partial_index_put1_idx: filters
-      │    │    │    │              └── ambig.check1:9 > 0
+      │    │    │    │    ├── partial index predicates
+      │    │    │    │    │    ├── ambig_partial_index_put1_key: filters
+      │    │    │    │    │    │    └── ambig.partial_index_put1:7 > 0
+      │    │    │    │    │    ├── ambig_partial_index_del1_key: filters
+      │    │    │    │    │    │    └── ambig.partial_index_del1:8 > 0
+      │    │    │    │    │    └── ambig_partial_index_put1_idx: filters
+      │    │    │    │    │         └── ambig.check1:9 > 0
+      │    │    │    │    └── flags: avoid-full-scan
       │    │    │    └── filters
       │    │    │         └── (ambig.partial_index_put1:7 = 10) AND (ambig.partial_index_del1:8 = 20)
       │    │    └── projections
@@ -481,11 +488,12 @@ update comp
       │    │    │    │    │    │    └── lower(c:10)
       │    │    │    │    │    └── e:12
       │    │    │    │    │         └── upper(c:10)
-      │    │    │    │    └── partial index predicates
-      │    │    │    │         ├── comp_b_idx: filters
-      │    │    │    │         │    └── lower(c:10) = 'foo'
-      │    │    │    │         └── comp_b_idx1: filters
-      │    │    │    │              └── e:12 = 'FOO'
+      │    │    │    │    ├── partial index predicates
+      │    │    │    │    │    ├── comp_b_idx: filters
+      │    │    │    │    │    │    └── lower(c:10) = 'foo'
+      │    │    │    │    │    └── comp_b_idx1: filters
+      │    │    │    │    │         └── e:12 = 'FOO'
+      │    │    │    │    └── flags: avoid-full-scan
       │    │    │    └── projections
       │    │    │         └── lower(c:10) [as=d:11]
       │    │    └── projections
@@ -524,11 +532,12 @@ update comp
       │    │    │    │    │    │    └── lower(c:10)
       │    │    │    │    │    └── e:12
       │    │    │    │    │         └── upper(c:10)
-      │    │    │    │    └── partial index predicates
-      │    │    │    │         ├── comp_b_idx: filters
-      │    │    │    │         │    └── lower(c:10) = 'foo'
-      │    │    │    │         └── comp_b_idx1: filters
-      │    │    │    │              └── e:12 = 'FOO'
+      │    │    │    │    ├── partial index predicates
+      │    │    │    │    │    ├── comp_b_idx: filters
+      │    │    │    │    │    │    └── lower(c:10) = 'foo'
+      │    │    │    │    │    └── comp_b_idx1: filters
+      │    │    │    │    │         └── e:12 = 'FOO'
+      │    │    │    │    └── flags: avoid-full-scan
       │    │    │    └── projections
       │    │    │         └── lower(c:10) [as=d:11]
       │    │    └── projections
@@ -582,9 +591,10 @@ project
            │    │    │    │    ├── columns: a:5 rowid:6!null crdb_internal_mvcc_timestamp:7 tableoid:8 column1:9!null
            │    │    │    │    ├── scan t61520 [as=t]
            │    │    │    │    │    ├── columns: a:5 rowid:6!null crdb_internal_mvcc_timestamp:7 tableoid:8
-           │    │    │    │    │    └── partial index predicates
-           │    │    │    │    │         └── t61520_a_idx: filters
-           │    │    │    │    │              └── a:5 > 0
+           │    │    │    │    │    ├── partial index predicates
+           │    │    │    │    │    │    └── t61520_a_idx: filters
+           │    │    │    │    │    │         └── a:5 > 0
+           │    │    │    │    │    └── flags: avoid-full-scan
            │    │    │    │    ├── values
            │    │    │    │    │    ├── columns: column1:9!null
            │    │    │    │    │    └── (1.0,)
@@ -646,7 +656,7 @@ insert partial_indexes
       │    │    │    │    │    │    │    └── c:11 = 'delete-only'
       │    │    │    │    │    │    └── b: filters
       │    │    │    │    │    │         └── c:11 = 'write-only'
-      │    │    │    │    │    └── flags: disabled not visible index feature
+      │    │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
       │    │    │    │    └── filters
       │    │    │    │         └── column1:6 = a:9
       │    │    │    ├── scan partial_indexes
@@ -660,7 +670,7 @@ insert partial_indexes
       │    │    │    │    │    │    └── c:16 = 'delete-only'
       │    │    │    │    │    └── b: filters
       │    │    │    │    │         └── c:16 = 'write-only'
-      │    │    │    │    └── flags: disabled not visible index feature
+      │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
       │    │    │    └── filters
       │    │    │         ├── column2:7 = b:15
       │    │    │         └── column3:8 = c:16
@@ -723,7 +733,7 @@ upsert partial_indexes
       │    │    │    │    │    │    └── c:11 = 'delete-only'
       │    │    │    │    │    └── b: filters
       │    │    │    │    │         └── c:11 = 'write-only'
-      │    │    │    │    └── flags: disabled not visible index feature
+      │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
       │    │    │    └── filters
       │    │    │         ├── column2:7 = b:10
       │    │    │         └── column3:8 = c:11
@@ -789,7 +799,7 @@ upsert partial_indexes
       │    │    │    │    │    └── c:11 = 'delete-only'
       │    │    │    │    └── b: filters
       │    │    │    │         └── c:11 = 'write-only'
-      │    │    │    └── flags: disabled not visible index feature
+      │    │    │    └── flags: avoid-full-scan disabled not visible index feature
       │    │    └── filters
       │    │         └── column1:6 = a:9
       │    └── projections
@@ -854,7 +864,7 @@ insert comp
       │    │    │    │    │    │    └── lower(c:15) = 'foo'
       │    │    │    │    │    └── comp_b_idx1: filters
       │    │    │    │    │         └── e:17 = 'FOO'
-      │    │    │    │    └── flags: disabled not visible index feature
+      │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
       │    │    │    └── projections
       │    │    │         └── lower(c:15) [as=d:16]
       │    │    └── filters
@@ -937,7 +947,7 @@ upsert comp
       │    │    │    │    │    │    │    │    └── lower(c:15) = 'foo'
       │    │    │    │    │    │    │    └── comp_b_idx1: filters
       │    │    │    │    │    │    │         └── e:17 = 'FOO'
-      │    │    │    │    │    │    └── flags: disabled not visible index feature
+      │    │    │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
       │    │    │    │    │    └── projections
       │    │    │    │    │         └── lower(c:15) [as=d:16]
       │    │    │    │    └── filters
@@ -1021,7 +1031,7 @@ upsert comp
       │    │    │    │    │    │    └── lower(c:15) = 'foo'
       │    │    │    │    │    └── comp_b_idx1: filters
       │    │    │    │    │         └── e:17 = 'FOO'
-      │    │    │    │    └── flags: disabled not visible index feature
+      │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
       │    │    │    └── projections
       │    │    │         └── lower(c:15) [as=d:16]
       │    │    └── filters
@@ -1069,7 +1079,7 @@ insert uniq
       │         │    │    │    │    │    ├── partial index predicates
       │         │    │    │    │    │    │    └── uniq_b_key: filters
       │         │    │    │    │    │    │         └── c:11 = 'foo'
-      │         │    │    │    │    │    └── flags: disabled not visible index feature
+      │         │    │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
       │         │    │    │    │    └── filters
       │         │    │    │    │         └── column1:6 = a:9
       │         │    │    │    ├── select
@@ -1079,7 +1089,7 @@ insert uniq
       │         │    │    │    │    │    ├── partial index predicates
       │         │    │    │    │    │    │    └── uniq_b_key: filters
       │         │    │    │    │    │    │         └── c:16 = 'foo'
-      │         │    │    │    │    │    └── flags: disabled not visible index feature
+      │         │    │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
       │         │    │    │    │    └── filters
       │         │    │    │    │         └── c:16 = 'foo'
       │         │    │    │    └── filters
@@ -1148,7 +1158,7 @@ insert uniq
       │         │    │         │    │    │    │    │    │    │    └── c:11 = 'foo'
       │         │    │         │    │    │    │    │    │    └── u2: filters
       │         │    │         │    │    │    │    │    │         └── c:11 = 'bar'
-      │         │    │         │    │    │    │    │    └── flags: disabled not visible index feature
+      │         │    │         │    │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
       │         │    │         │    │    │    │    └── filters
       │         │    │         │    │    │    │         └── c:11 = 'foo'
       │         │    │         │    │    │    └── filters
@@ -1163,7 +1173,7 @@ insert uniq
       │         │    │         │    │    │    │    │    │    └── c:16 = 'foo'
       │         │    │         │    │    │    │    │    └── u2: filters
       │         │    │         │    │    │    │    │         └── c:16 = 'bar'
-      │         │    │         │    │    │    │    └── flags: disabled not visible index feature
+      │         │    │         │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
       │         │    │         │    │    │    └── filters
       │         │    │         │    │    │         └── c:16 = 'bar'
       │         │    │         │    │    └── filters
@@ -1230,7 +1240,7 @@ insert uniq
       │    │    │    │    │    └── c:11 = 'foo'
       │    │    │    │    └── u2: filters
       │    │    │    │         └── c:11 = 'bar'
-      │    │    │    └── flags: disabled not visible index feature
+      │    │    │    └── flags: avoid-full-scan disabled not visible index feature
       │    │    └── filters
       │    │         └── column2:7 = b:10
       │    └── aggregations
@@ -1280,7 +1290,7 @@ insert uniq
       │    ├── scan uniq@u4,partial
       │    │    ├── columns: b:10!null
       │    │    ├── constraint: /10: [/1 - /1]
-      │    │    └── flags: disabled not visible index feature
+      │    │    └── flags: avoid-full-scan disabled not visible index feature
       │    └── filters (true)
       └── projections
            ├── column3:8 = 'foo' [as=partial_index_put1:15]
@@ -1347,7 +1357,7 @@ upsert uniq
       │    │    │    │    │    │    │    └── c:12 = 'foo'
       │    │    │    │    │    │    └── u2: filters
       │    │    │    │    │    │         └── c:12 = 'bar'
-      │    │    │    │    │    └── flags: disabled not visible index feature
+      │    │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
       │    │    │    │    └── filters
       │    │    │    │         └── c:12 = 'foo'
       │    │    │    └── filters
@@ -1433,7 +1443,7 @@ upsert ambig
       │    │    │    │    │    │    │    │    └── ambig.partial_index_del1:13 > 0
       │    │    │    │    │    │    │    └── ambig_partial_index_put1_idx: filters
       │    │    │    │    │    │    │         └── ambig.check1:14 > 0
-      │    │    │    │    │    │    └── flags: disabled not visible index feature
+      │    │    │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
       │    │    │    │    │    └── filters
       │    │    │    │    │         └── ambig.partial_index_put1:12 > 0
       │    │    │    │    └── filters
@@ -1514,7 +1524,7 @@ insert comp
       │         │    │    │    │    │    │    │    │    └── e:17 = 'FOO'
       │         │    │    │    │    │    │    │    └── u1: filters
       │         │    │    │    │    │    │    │         └── lower(c:15) = 'foo'
-      │         │    │    │    │    │    │    └── flags: disabled not visible index feature
+      │         │    │    │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
       │         │    │    │    │    │    └── projections
       │         │    │    │    │    │         └── lower(c:15) [as=d:16]
       │         │    │    │    │    └── filters
@@ -1537,7 +1547,7 @@ insert comp
       │         │    │    │    │    │    │    │    │    └── e:24 = 'FOO'
       │         │    │    │    │    │    │    │    └── u1: filters
       │         │    │    │    │    │    │    │         └── lower(c:22) = 'foo'
-      │         │    │    │    │    │    │    └── flags: disabled not visible index feature
+      │         │    │    │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
       │         │    │    │    │    │    └── projections
       │         │    │    │    │    │         └── lower(c:22) [as=d:23]
       │         │    │    │    │    └── filters
@@ -1636,7 +1646,7 @@ insert comp
       │         │    │         │    │    │    │    │    │    │    │    └── lower(c:15) = 'foo'
       │         │    │         │    │    │    │    │    │    │    └── u2: filters
       │         │    │         │    │    │    │    │    │    │         └── e:17 = 'bar'
-      │         │    │         │    │    │    │    │    │    └── flags: disabled not visible index feature
+      │         │    │         │    │    │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
       │         │    │         │    │    │    │    │    └── projections
       │         │    │         │    │    │    │    │         └── lower(c:15) [as=d:16]
       │         │    │         │    │    │    │    └── filters
@@ -1664,7 +1674,7 @@ insert comp
       │         │    │         │    │    │    │    │    │    │    └── lower(c:22) = 'foo'
       │         │    │         │    │    │    │    │    │    └── u2: filters
       │         │    │         │    │    │    │    │    │         └── e:24 = 'bar'
-      │         │    │         │    │    │    │    │    └── flags: disabled not visible index feature
+      │         │    │         │    │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
       │         │    │         │    │    │    │    └── projections
       │         │    │         │    │    │    │         └── lower(c:22) [as=d:23]
       │         │    │         │    │    │    └── filters
@@ -1760,7 +1770,7 @@ insert comp
       │    │    │    │    │    │    └── lower(c:15) = 'foo'
       │    │    │    │    │    └── u2: filters
       │    │    │    │    │         └── e:17 = 'bar'
-      │    │    │    │    └── flags: disabled not visible index feature
+      │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
       │    │    │    └── projections
       │    │    │         └── lower(c:15) [as=d:16]
       │    │    └── filters
@@ -1869,7 +1879,7 @@ upsert comp
       │    │    │    │    │    │    │    │    │    └── lower(c:16) = 'foo'
       │    │    │    │    │    │    │    │    └── u2: filters
       │    │    │    │    │    │    │    │         └── e:18 = 'bar'
-      │    │    │    │    │    │    │    └── flags: disabled not visible index feature
+      │    │    │    │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
       │    │    │    │    │    │    └── projections
       │    │    │    │    │    │         └── lower(c:16) [as=d:17]
       │    │    │    │    │    └── filters

--- a/pkg/sql/opt/optbuilder/testdata/procedure_plpgsql
+++ b/pkg/sql/opt/optbuilder/testdata/procedure_plpgsql
@@ -131,7 +131,8 @@ call
                 │                                                      │                             │         ├── select
                 │                                                      │                             │         │    ├── columns: k:33!null i:34 s:35 crdb_internal_mvcc_timestamp:36 tableoid:37
                 │                                                      │                             │         │    ├── scan t
-                │                                                      │                             │         │    │    └── columns: k:33!null i:34 s:35 crdb_internal_mvcc_timestamp:36 tableoid:37
+                │                                                      │                             │         │    │    ├── columns: k:33!null i:34 s:35 crdb_internal_mvcc_timestamp:36 tableoid:37
+                │                                                      │                             │         │    │    └── flags: avoid-full-scan
                 │                                                      │                             │         │    └── filters
                 │                                                      │                             │         │         └── eq
                 │                                                      │                             │         │              ├── variable: k:33

--- a/pkg/sql/opt/optbuilder/testdata/projection-reuse
+++ b/pkg/sql/opt/optbuilder/testdata/projection-reuse
@@ -200,7 +200,8 @@ update abcd
       ├── select
       │    ├── columns: a:8!null b:9 c:10 d:11 rowid:12!null crdb_internal_mvcc_timestamp:13 tableoid:14
       │    ├── scan abcd
-      │    │    └── columns: a:8 b:9 c:10 d:11 rowid:12!null crdb_internal_mvcc_timestamp:13 tableoid:14
+      │    │    ├── columns: a:8 b:9 c:10 d:11 rowid:12!null crdb_internal_mvcc_timestamp:13 tableoid:14
+      │    │    └── flags: avoid-full-scan
       │    └── filters
       │         └── a:8 = 1.0
       └── projections

--- a/pkg/sql/opt/optbuilder/testdata/select
+++ b/pkg/sql/opt/optbuilder/testdata/select
@@ -1498,7 +1498,8 @@ update inaccessible
  └── project
       ├── columns: k_new:9!null k:5!null v:6 crdb_internal_mvcc_timestamp:7 tableoid:8
       ├── scan inaccessible
-      │    └── columns: k:5!null v:6 crdb_internal_mvcc_timestamp:7 tableoid:8
+      │    ├── columns: k:5!null v:6 crdb_internal_mvcc_timestamp:7 tableoid:8
+      │    └── flags: avoid-full-scan
       └── projections
            └── k:5 + 1 [as=k_new:9]
 
@@ -1679,7 +1680,7 @@ upsert t127365
       │    │    │    │    ├── computed column expressions
       │    │    │    │    │    └── crdb_internal_idx_expr:11
       │    │    │    │    │         └── a:10 + 1
-      │    │    │    │    └── flags: disabled not visible index feature
+      │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
       │    │    │    └── projections
       │    │    │         └── a:10 + 1 [as=crdb_internal_idx_expr:11]
       │    │    └── filters
@@ -1711,9 +1712,10 @@ update t127365
       │    │    │    │    ├── columns: crdb_internal_idx_expr:8 k:6!null a:7 crdb_internal_mvcc_timestamp:9 tableoid:10
       │    │    │    │    ├── scan t127365
       │    │    │    │    │    ├── columns: k:6!null a:7 crdb_internal_mvcc_timestamp:9 tableoid:10
-      │    │    │    │    │    └── computed column expressions
-      │    │    │    │    │         └── crdb_internal_idx_expr:8
-      │    │    │    │    │              └── a:7 + 1
+      │    │    │    │    │    ├── computed column expressions
+      │    │    │    │    │    │    └── crdb_internal_idx_expr:8
+      │    │    │    │    │    │         └── a:7 + 1
+      │    │    │    │    │    └── flags: avoid-full-scan
       │    │    │    │    └── projections
       │    │    │    │         └── a:7 + 1 [as=crdb_internal_idx_expr:8]
       │    │    │    └── filters
@@ -1735,8 +1737,9 @@ delete t127365
       ├── columns: crdb_internal_idx_expr:8 k:6!null a:7 crdb_internal_mvcc_timestamp:9 tableoid:10
       ├── scan t127365
       │    ├── columns: k:6!null a:7 crdb_internal_mvcc_timestamp:9 tableoid:10
-      │    └── computed column expressions
-      │         └── crdb_internal_idx_expr:8
-      │              └── a:7 + 1
+      │    ├── computed column expressions
+      │    │    └── crdb_internal_idx_expr:8
+      │    │         └── a:7 + 1
+      │    └── flags: avoid-full-scan
       └── projections
            └── a:7 + 1 [as=crdb_internal_idx_expr:8]

--- a/pkg/sql/opt/optbuilder/testdata/trigger
+++ b/pkg/sql/opt/optbuilder/testdata/trigger
@@ -99,7 +99,8 @@ root
  │         │         │    │         │    │    ├── select
  │         │         │    │         │    │    │    ├── columns: x:5 y:6 crdb_internal_mvcc_timestamp:7 tableoid:8
  │         │         │    │         │    │    │    ├── scan xy
- │         │         │    │         │    │    │    │    └── columns: x:5 y:6 crdb_internal_mvcc_timestamp:7 tableoid:8
+ │         │         │    │         │    │    │    │    ├── columns: x:5 y:6 crdb_internal_mvcc_timestamp:7 tableoid:8
+ │         │         │    │         │    │    │    │    └── flags: avoid-full-scan
  │         │         │    │         │    │    │    └── filters
  │         │         │    │         │    │    │         └── x:5 = 1
  │         │         │    │         │    │    └── projections
@@ -143,7 +144,8 @@ root
            │         │         │    │         │    ├── inner-join (hash)
            │         │         │    │         │    │    ├── columns: k:32 child.x:33 x_old:36 x_new:37
            │         │         │    │         │    │    ├── scan child
-           │         │         │    │         │    │    │    └── columns: k:32 child.x:33
+           │         │         │    │         │    │    │    ├── columns: k:32 child.x:33
+           │         │         │    │         │    │    │    └── flags: avoid-full-scan
            │         │         │    │         │    │    ├── select
            │         │         │    │         │    │    │    ├── columns: x_old:36 x_new:37
            │         │         │    │         │    │    │    ├── with-scan &1
@@ -178,7 +180,8 @@ root
                           │    └── filters
                           │         └── x:55 IS NOT NULL
                           ├── scan xy
-                          │    └── columns: xy.x:56
+                          │    ├── columns: xy.x:56
+                          │    └── flags: avoid-full-scan
                           └── filters
                                └── x:55 = xy.x:56
 
@@ -207,7 +210,8 @@ root
  │              │    │         ├── select
  │              │    │         │    ├── columns: x:5 y:6 crdb_internal_mvcc_timestamp:7 tableoid:8
  │              │    │         │    ├── scan xy
- │              │    │         │    │    └── columns: x:5 y:6 crdb_internal_mvcc_timestamp:7 tableoid:8
+ │              │    │         │    │    ├── columns: x:5 y:6 crdb_internal_mvcc_timestamp:7 tableoid:8
+ │              │    │         │    │    └── flags: avoid-full-scan
  │              │    │         │    └── filters
  │              │    │         │         └── x:5 = 1
  │              │    │         └── projections
@@ -239,7 +243,8 @@ root
                      │         │    │         ├── semi-join (hash)
                      │         │    │         │    ├── columns: k:28 child.x:29
                      │         │    │         │    ├── scan child
-                     │         │    │         │    │    └── columns: k:28 child.x:29
+                     │         │    │         │    │    ├── columns: k:28 child.x:29
+                     │         │    │         │    │    └── flags: avoid-full-scan
                      │         │    │         │    ├── with-scan &1
                      │         │    │         │    │    ├── columns: x:32
                      │         │    │         │    │    └── mapping:
@@ -315,7 +320,8 @@ root
  │         │    │         │    │         │    │    │         │    │         │    │         └── first-agg [as=column2:6]
  │         │    │         │    │         │    │    │         │    │         │    │              └── column2:6
  │         │    │         │    │         │    │    │         │    │         │    ├── scan xy
- │         │    │         │    │         │    │    │         │    │         │    │    └── columns: x:7 y:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+ │         │    │         │    │         │    │    │         │    │         │    │    ├── columns: x:7 y:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+ │         │    │         │    │         │    │    │         │    │         │    │    └── flags: avoid-full-scan
  │         │    │         │    │         │    │    │         │    │         │    └── filters
  │         │    │         │    │         │    │    │         │    │         │         └── column1:5 = x:7
  │         │    │         │    │         │    │    │         │    │         └── projections
@@ -369,7 +375,8 @@ root
            │         │         │    │         │    ├── inner-join (hash)
            │         │         │    │         │    │    ├── columns: k:39 child.x:40 x_old:43 x_new:44
            │         │         │    │         │    │    ├── scan child
-           │         │         │    │         │    │    │    └── columns: k:39 child.x:40
+           │         │         │    │         │    │    │    ├── columns: k:39 child.x:40
+           │         │         │    │         │    │    │    └── flags: avoid-full-scan
            │         │         │    │         │    │    ├── select
            │         │         │    │         │    │    │    ├── columns: x_old:43 x_new:44
            │         │         │    │         │    │    │    ├── with-scan &1
@@ -404,7 +411,8 @@ root
                           │    └── filters
                           │         └── x:62 IS NOT NULL
                           ├── scan xy
-                          │    └── columns: xy.x:63
+                          │    ├── columns: xy.x:63
+                          │    └── flags: avoid-full-scan
                           └── filters
                                └── x:62 = xy.x:63
 
@@ -470,7 +478,8 @@ root
  │         │    │         │    │         │    │    │    │         │    │         │    │         └── first-agg [as=column2:6]
  │         │    │         │    │         │    │    │    │         │    │         │    │              └── column2:6
  │         │    │         │    │         │    │    │    │         │    │         │    ├── scan xy
- │         │    │         │    │         │    │    │    │         │    │         │    │    └── columns: x:7 y:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+ │         │    │         │    │         │    │    │    │         │    │         │    │    ├── columns: x:7 y:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+ │         │    │         │    │         │    │    │    │         │    │         │    │    └── flags: avoid-full-scan
  │         │    │         │    │         │    │    │    │         │    │         │    └── filters
  │         │    │         │    │         │    │    │    │         │    │         │         └── column1:5 = x:7
  │         │    │         │    │         │    │    │    │         │    │         └── projections
@@ -526,7 +535,8 @@ root
            │         │         │    │         │    ├── inner-join (hash)
            │         │         │    │         │    │    ├── columns: k:40 child.x:41 x_old:44 x_new:45
            │         │         │    │         │    │    ├── scan child
-           │         │         │    │         │    │    │    └── columns: k:40 child.x:41
+           │         │         │    │         │    │    │    ├── columns: k:40 child.x:41
+           │         │         │    │         │    │    │    └── flags: avoid-full-scan
            │         │         │    │         │    │    ├── select
            │         │         │    │         │    │    │    ├── columns: x_old:44 x_new:45
            │         │         │    │         │    │    │    ├── with-scan &1
@@ -561,7 +571,8 @@ root
                           │    └── filters
                           │         └── x:63 IS NOT NULL
                           ├── scan xy
-                          │    └── columns: xy.x:64
+                          │    ├── columns: xy.x:64
+                          │    └── flags: avoid-full-scan
                           └── filters
                                └── x:63 = xy.x:64
 
@@ -637,11 +648,12 @@ update computed
       │    │         │    │         │    ├── columns: k:6 v:7 crdb_internal_mvcc_timestamp:9 tableoid:10
       │    │         │    │         │    ├── scan computed
       │    │         │    │         │    │    ├── columns: k:6 v:7 crdb_internal_mvcc_timestamp:9 tableoid:10
-      │    │         │    │         │    │    └── computed column expressions
-      │    │         │    │         │    │         ├── v:7
-      │    │         │    │         │    │         │    └── k:6 + 1
-      │    │         │    │         │    │         └── w:8
-      │    │         │    │         │    │              └── k:6 + 2
+      │    │         │    │         │    │    ├── computed column expressions
+      │    │         │    │         │    │    │    ├── v:7
+      │    │         │    │         │    │    │    │    └── k:6 + 1
+      │    │         │    │         │    │    │    └── w:8
+      │    │         │    │         │    │    │         └── k:6 + 2
+      │    │         │    │         │    │    └── flags: avoid-full-scan
       │    │         │    │         │    └── filters
       │    │         │    │         │         └── k:6 = 1
       │    │         │    │         └── projections
@@ -878,7 +890,8 @@ root
  │         ├── select
  │         │    ├── columns: x:5 y:6 crdb_internal_mvcc_timestamp:7 tableoid:8
  │         │    ├── scan xy
- │         │    │    └── columns: x:5 y:6 crdb_internal_mvcc_timestamp:7 tableoid:8
+ │         │    │    ├── columns: x:5 y:6 crdb_internal_mvcc_timestamp:7 tableoid:8
+ │         │    │    └── flags: avoid-full-scan
  │         │    └── filters
  │         │         └── x:5 = 1
  │         └── projections
@@ -921,7 +934,8 @@ root
  │    └── select
  │         ├── columns: x:5 y:6 crdb_internal_mvcc_timestamp:7 tableoid:8
  │         ├── scan xy
- │         │    └── columns: x:5 y:6 crdb_internal_mvcc_timestamp:7 tableoid:8
+ │         │    ├── columns: x:5 y:6 crdb_internal_mvcc_timestamp:7 tableoid:8
+ │         │    └── flags: avoid-full-scan
  │         └── filters
  │              └── x:5 = 1
  ├── cascade
@@ -947,7 +961,8 @@ root
  │                   │         │    │         ├── select
  │                   │         │    │         │    ├── columns: k:13 child.x:14
  │                   │         │    │         │    ├── scan child
- │                   │         │    │         │    │    └── columns: k:13 child.x:14
+ │                   │         │    │         │    │    ├── columns: k:13 child.x:14
+ │                   │         │    │         │    │    └── flags: avoid-full-scan
  │                   │         │    │         │    └── filters
  │                   │         │    │         │         ├── child.x:14 = 1
  │                   │         │    │         │         └── child.x:14 IS DISTINCT FROM CAST(NULL AS INT8)
@@ -1011,7 +1026,8 @@ root
  │         │    │         └── first-agg [as=column2:6]
  │         │    │              └── column2:6
  │         │    ├── scan xy
- │         │    │    └── columns: x:7 y:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+ │         │    │    ├── columns: x:7 y:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+ │         │    │    └── flags: avoid-full-scan
  │         │    └── filters
  │         │         └── column1:5 = x:7
  │         └── projections
@@ -1075,7 +1091,8 @@ root
  │         │    │    │         └── first-agg [as=column2:6]
  │         │    │    │              └── column2:6
  │         │    │    ├── scan xy
- │         │    │    │    └── columns: x:7 y:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+ │         │    │    │    ├── columns: x:7 y:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+ │         │    │    │    └── flags: avoid-full-scan
  │         │    │    └── filters
  │         │    │         └── column1:5 = x:7
  │         │    └── projections
@@ -1181,6 +1198,7 @@ insert t133329
  │                   ├── values
  │                   │    └── (1, 1)
  │                   ├── scan t133329
+ │                   │    └── flags: avoid-full-scan
  │                   └── filters
  │                        ├── a = t133329.a
  │                        └── k != t133329.k
@@ -1188,6 +1206,7 @@ insert t133329
       └── fast-path-unique-checks-item: t133329(a)
            └── select
                 ├── scan t133329
+                │    └── flags: avoid-full-scan
                 └── filters
                      └── t133329.a = 1
 
@@ -1230,6 +1249,7 @@ insert t133329
                 └── semi-join (hash)
                      ├── with-scan &1
                      ├── scan t133329
+                     │    └── flags: avoid-full-scan
                      └── filters
                           ├── a = t133329.a
                           └── k != t133329.k

--- a/pkg/sql/opt/optbuilder/testdata/udf
+++ b/pkg/sql/opt/optbuilder/testdata/udf
@@ -1720,7 +1720,8 @@ update abc
       ├── select
       │    ├── columns: a:6!null b:7 c:8 crdb_internal_mvcc_timestamp:9 tableoid:10
       │    ├── scan abc
-      │    │    └── columns: a:6!null b:7 c:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+      │    │    ├── columns: a:6!null b:7 c:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+      │    │    └── flags: avoid-full-scan
       │    └── filters
       │         └── ups(1, 2, 3)
       └── projections
@@ -1852,7 +1853,7 @@ values
       │              │                   │         └──  column2:8 => p:9
       │              │                   ├── scan parent
       │              │                   │    ├── columns: parent.p:10!null
-      │              │                   │    └── flags: disabled not visible index feature
+      │              │                   │    └── flags: avoid-full-scan disabled not visible index feature
       │              │                   └── filters
       │              │                        └── eq
       │              │                             ├── variable: p:9
@@ -1894,7 +1895,7 @@ values
                      │                   │         └──  column2:23 => p:24
                      │                   ├── scan parent
                      │                   │    ├── columns: parent.p:25!null
-                     │                   │    └── flags: disabled not visible index feature
+                     │                   │    └── flags: avoid-full-scan disabled not visible index feature
                      │                   └── filters
                      │                        └── eq
                      │                             ├── variable: p:24

--- a/pkg/sql/opt/optbuilder/testdata/udf_plpgsql
+++ b/pkg/sql/opt/optbuilder/testdata/udf_plpgsql
@@ -4703,7 +4703,8 @@ project
                      │                                       │    └── select
                      │                                       │         ├── columns: k:11!null v:12 crdb_internal_mvcc_timestamp:13 tableoid:14
                      │                                       │         ├── scan kv
-                     │                                       │         │    └── columns: k:11!null v:12 crdb_internal_mvcc_timestamp:13 tableoid:14
+                     │                                       │         │    ├── columns: k:11!null v:12 crdb_internal_mvcc_timestamp:13 tableoid:14
+                     │                                       │         │    └── flags: avoid-full-scan
                      │                                       │         └── filters
                      │                                       │              └── eq
                      │                                       │                   ├── variable: k:11

--- a/pkg/sql/opt/optbuilder/testdata/unique-checks-insert
+++ b/pkg/sql/opt/optbuilder/testdata/unique-checks-insert
@@ -42,7 +42,7 @@ insert uniq
       │              │         └──  column5:12 => y:24
       │              ├── scan uniq
       │              │    ├── columns: uniq.k:13!null uniq.v:14 uniq.w:15 uniq.x:16 uniq.y:17
-      │              │    └── flags: disabled not visible index feature
+      │              │    └── flags: avoid-full-scan disabled not visible index feature
       │              └── filters
       │                   ├── w:22 = uniq.w:15
       │                   └── k:20 != uniq.k:13
@@ -61,7 +61,7 @@ insert uniq
                      │         └──  column5:12 => y:36
                      ├── scan uniq
                      │    ├── columns: uniq.k:25!null uniq.v:26 uniq.w:27 uniq.x:28 uniq.y:29
-                     │    └── flags: disabled not visible index feature
+                     │    └── flags: avoid-full-scan disabled not visible index feature
                      └── filters
                           ├── x:35 = uniq.x:28
                           ├── y:36 = uniq.y:29
@@ -101,7 +101,7 @@ insert uniq
       │              │         └──  column5:12 => y:24
       │              ├── scan uniq
       │              │    ├── columns: uniq.k:13!null uniq.v:14 uniq.w:15 uniq.x:16 uniq.y:17
-      │              │    └── flags: disabled not visible index feature
+      │              │    └── flags: avoid-full-scan disabled not visible index feature
       │              └── filters
       │                   ├── w:22 = uniq.w:15
       │                   └── k:20 != uniq.k:13
@@ -120,7 +120,7 @@ insert uniq
                      │         └──  column5:12 => y:36
                      ├── scan uniq
                      │    ├── columns: uniq.k:25!null uniq.v:26 uniq.w:27 uniq.x:28 uniq.y:29
-                     │    └── flags: disabled not visible index feature
+                     │    └── flags: avoid-full-scan disabled not visible index feature
                      └── filters
                           ├── x:35 = uniq.x:28
                           ├── y:36 = uniq.y:29
@@ -159,7 +159,7 @@ insert uniq
                      │         └──  column5:12 => y:24
                      ├── scan uniq
                      │    ├── columns: uniq.k:13!null uniq.x:16 uniq.y:17
-                     │    └── flags: disabled not visible index feature
+                     │    └── flags: avoid-full-scan disabled not visible index feature
                      └── filters
                           ├── x:23 = uniq.x:16
                           ├── y:24 = uniq.y:17
@@ -197,7 +197,7 @@ insert uniq
                      │         └──  column3:10 => w:22
                      ├── scan uniq
                      │    ├── columns: uniq.k:13!null uniq.w:15
-                     │    └── flags: disabled not visible index feature
+                     │    └── flags: avoid-full-scan disabled not visible index feature
                      └── filters
                           ├── w:22 = uniq.w:15
                           └── k:20 != uniq.k:13
@@ -234,7 +234,7 @@ insert uniq
                      │         └──  column3:10 => w:22
                      ├── scan uniq
                      │    ├── columns: uniq.k:13!null uniq.w:15
-                     │    └── flags: disabled not visible index feature
+                     │    └── flags: avoid-full-scan disabled not visible index feature
                      └── filters
                           ├── w:22 = uniq.w:15
                           └── k:20 != uniq.k:13
@@ -298,22 +298,22 @@ insert uniq
       │    │    │    │    │    │    │    │    └── (1, 2, 3, 4, 5)
       │    │    │    │    │    │    │    ├── scan uniq
       │    │    │    │    │    │    │    │    ├── columns: k:13!null v:14 w:15 x:16 y:17
-      │    │    │    │    │    │    │    │    └── flags: disabled not visible index feature
+      │    │    │    │    │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
       │    │    │    │    │    │    │    └── filters
       │    │    │    │    │    │    │         └── column1:8 = k:13
       │    │    │    │    │    │    ├── scan uniq
       │    │    │    │    │    │    │    ├── columns: k:20!null v:21 w:22 x:23 y:24
-      │    │    │    │    │    │    │    └── flags: disabled not visible index feature
+      │    │    │    │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
       │    │    │    │    │    │    └── filters
       │    │    │    │    │    │         └── column2:9 = v:21
       │    │    │    │    │    ├── scan uniq
       │    │    │    │    │    │    ├── columns: k:27!null v:28 w:29 x:30 y:31
-      │    │    │    │    │    │    └── flags: disabled not visible index feature
+      │    │    │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
       │    │    │    │    │    └── filters
       │    │    │    │    │         └── column3:10 = w:29
       │    │    │    │    ├── scan uniq
       │    │    │    │    │    ├── columns: k:34!null v:35 w:36 x:37 y:38
-      │    │    │    │    │    └── flags: disabled not visible index feature
+      │    │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
       │    │    │    │    └── filters
       │    │    │    │         ├── column4:11 = x:37
       │    │    │    │         └── column5:12 = y:38
@@ -376,7 +376,7 @@ insert uniq
  │    │    │    └── (1, 2, 3, 4, 5)
  │    │    ├── scan uniq
  │    │    │    ├── columns: uniq.k:13!null uniq.v:14 uniq.w:15 uniq.x:16 uniq.y:17
- │    │    │    └── flags: disabled not visible index feature
+ │    │    │    └── flags: avoid-full-scan disabled not visible index feature
  │    │    └── filters
  │    │         └── column3:10 = uniq.w:15
  │    └── aggregations
@@ -399,7 +399,7 @@ insert uniq
  │                   │    └── (1, 2, 3, 4, 5)
  │                   ├── scan uniq
  │                   │    ├── columns: uniq.k:20!null uniq.v:21 uniq.w:22 uniq.x:23 uniq.y:24
- │                   │    └── flags: disabled not visible index feature
+ │                   │    └── flags: avoid-full-scan disabled not visible index feature
  │                   └── filters
  │                        ├── x:30 = uniq.x:23
  │                        ├── y:31 = uniq.y:24
@@ -410,7 +410,7 @@ insert uniq
                 ├── columns: uniq.k:32!null uniq.v:33 uniq.w:34 uniq.x:35!null uniq.y:36!null
                 ├── scan uniq
                 │    ├── columns: uniq.k:32!null uniq.v:33 uniq.w:34 uniq.x:35 uniq.y:36
-                │    └── flags: disabled not visible index feature
+                │    └── flags: avoid-full-scan disabled not visible index feature
                 └── filters
                      ├── uniq.x:35 = 4
                      └── uniq.y:36 = 5
@@ -441,7 +441,7 @@ insert uniq
  │    │    │    └── (6, 7, 8, 9, 10)
  │    │    ├── scan uniq
  │    │    │    ├── columns: uniq.k:13!null uniq.v:14 uniq.w:15 uniq.x:16 uniq.y:17
- │    │    │    └── flags: disabled not visible index feature
+ │    │    │    └── flags: avoid-full-scan disabled not visible index feature
  │    │    └── filters
  │    │         └── column3:10 = uniq.w:15
  │    └── aggregations
@@ -469,7 +469,7 @@ insert uniq
                      │         └──  column5:12 => y:31
                      ├── scan uniq
                      │    ├── columns: uniq.k:20!null uniq.v:21 uniq.w:22 uniq.x:23 uniq.y:24
-                     │    └── flags: disabled not visible index feature
+                     │    └── flags: avoid-full-scan disabled not visible index feature
                      └── filters
                           ├── x:30 = uniq.x:23
                           ├── y:31 = uniq.y:24
@@ -498,7 +498,7 @@ insert uniq
  │    │    │    └── (1, 2, 3, 4, 5)
  │    │    ├── scan uniq
  │    │    │    ├── columns: uniq.k:13!null uniq.v:14 uniq.w:15 uniq.x:16 uniq.y:17
- │    │    │    └── flags: disabled not visible index feature
+ │    │    │    └── flags: avoid-full-scan disabled not visible index feature
  │    │    └── filters
  │    │         └── column3:10 = uniq.w:15
  │    └── aggregations
@@ -521,7 +521,7 @@ insert uniq
  │                   │    └── (1, 2, 3, 4, 5)
  │                   ├── scan uniq
  │                   │    ├── columns: uniq.k:20!null uniq.v:21 uniq.w:22 uniq.x:23 uniq.y:24
- │                   │    └── flags: disabled not visible index feature
+ │                   │    └── flags: avoid-full-scan disabled not visible index feature
  │                   └── filters
  │                        ├── x:30 = uniq.x:23
  │                        ├── y:31 = uniq.y:24
@@ -532,7 +532,7 @@ insert uniq
                 ├── columns: uniq.k:32!null uniq.v:33 uniq.w:34 uniq.x:35!null uniq.y:36!null
                 ├── scan uniq
                 │    ├── columns: uniq.k:32!null uniq.v:33 uniq.w:34 uniq.x:35 uniq.y:36
-                │    └── flags: disabled not visible index feature
+                │    └── flags: avoid-full-scan disabled not visible index feature
                 └── filters
                      ├── uniq.x:35 = 4
                      └── uniq.y:36 = 5
@@ -574,7 +574,7 @@ insert uniq
       │              │         └──  other.y:12 => y:27
       │              ├── scan uniq
       │              │    ├── columns: uniq.k:16!null uniq.v:17 uniq.w:18 uniq.x:19 uniq.y:20
-      │              │    └── flags: disabled not visible index feature
+      │              │    └── flags: avoid-full-scan disabled not visible index feature
       │              └── filters
       │                   ├── w:25 = uniq.w:18
       │                   └── k:23 != uniq.k:16
@@ -593,7 +593,7 @@ insert uniq
                      │         └──  other.y:12 => y:39
                      ├── scan uniq
                      │    ├── columns: uniq.k:28!null uniq.v:29 uniq.w:30 uniq.x:31 uniq.y:32
-                     │    └── flags: disabled not visible index feature
+                     │    └── flags: avoid-full-scan disabled not visible index feature
                      └── filters
                           ├── x:38 = uniq.x:31
                           ├── y:39 = uniq.y:32
@@ -646,7 +646,7 @@ insert uniq_overlaps_pk
       │              │         └──  column4:10 => d:20
       │              ├── scan uniq_overlaps_pk
       │              │    ├── columns: uniq_overlaps_pk.a:11!null uniq_overlaps_pk.b:12!null uniq_overlaps_pk.c:13 uniq_overlaps_pk.d:14
-      │              │    └── flags: disabled not visible index feature
+      │              │    └── flags: avoid-full-scan disabled not visible index feature
       │              └── filters
       │                   ├── b:18 = uniq_overlaps_pk.b:12
       │                   ├── c:19 = uniq_overlaps_pk.c:13
@@ -665,7 +665,7 @@ insert uniq_overlaps_pk
       │              │         └──  column4:10 => d:30
       │              ├── scan uniq_overlaps_pk
       │              │    ├── columns: uniq_overlaps_pk.a:21!null uniq_overlaps_pk.b:22!null uniq_overlaps_pk.c:23 uniq_overlaps_pk.d:24
-      │              │    └── flags: disabled not visible index feature
+      │              │    └── flags: avoid-full-scan disabled not visible index feature
       │              └── filters
       │                   ├── a:27 = uniq_overlaps_pk.a:21
       │                   └── b:28 != uniq_overlaps_pk.b:22
@@ -683,7 +683,7 @@ insert uniq_overlaps_pk
                      │         └──  column4:10 => d:40
                      ├── scan uniq_overlaps_pk
                      │    ├── columns: uniq_overlaps_pk.a:31!null uniq_overlaps_pk.b:32!null uniq_overlaps_pk.c:33 uniq_overlaps_pk.d:34
-                     │    └── flags: disabled not visible index feature
+                     │    └── flags: avoid-full-scan disabled not visible index feature
                      └── filters
                           ├── c:39 = uniq_overlaps_pk.c:33
                           ├── d:40 = uniq_overlaps_pk.d:34
@@ -722,7 +722,7 @@ insert uniq_overlaps_pk
       │              │         └──  y:11 => d:24
       │              ├── scan uniq_overlaps_pk
       │              │    ├── columns: uniq_overlaps_pk.a:15!null uniq_overlaps_pk.b:16!null uniq_overlaps_pk.c:17 uniq_overlaps_pk.d:18
-      │              │    └── flags: disabled not visible index feature
+      │              │    └── flags: avoid-full-scan disabled not visible index feature
       │              └── filters
       │                   ├── b:22 = uniq_overlaps_pk.b:16
       │                   ├── c:23 = uniq_overlaps_pk.c:17
@@ -741,7 +741,7 @@ insert uniq_overlaps_pk
       │              │         └──  y:11 => d:34
       │              ├── scan uniq_overlaps_pk
       │              │    ├── columns: uniq_overlaps_pk.a:25!null uniq_overlaps_pk.b:26!null uniq_overlaps_pk.c:27 uniq_overlaps_pk.d:28
-      │              │    └── flags: disabled not visible index feature
+      │              │    └── flags: avoid-full-scan disabled not visible index feature
       │              └── filters
       │                   ├── a:31 = uniq_overlaps_pk.a:25
       │                   └── b:32 != uniq_overlaps_pk.b:26
@@ -759,7 +759,7 @@ insert uniq_overlaps_pk
                      │         └──  y:11 => d:44
                      ├── scan uniq_overlaps_pk
                      │    ├── columns: uniq_overlaps_pk.a:35!null uniq_overlaps_pk.b:36!null uniq_overlaps_pk.c:37 uniq_overlaps_pk.d:38
-                     │    └── flags: disabled not visible index feature
+                     │    └── flags: avoid-full-scan disabled not visible index feature
                      └── filters
                           ├── c:43 = uniq_overlaps_pk.c:37
                           ├── d:44 = uniq_overlaps_pk.d:38
@@ -815,7 +815,7 @@ insert uniq_hidden_pk
       │              │         └──  rowid_default:12 => rowid:24
       │              ├── scan uniq_hidden_pk
       │              │    ├── columns: uniq_hidden_pk.a:13 uniq_hidden_pk.b:14 uniq_hidden_pk.c:15 uniq_hidden_pk.d:16 uniq_hidden_pk.rowid:17!null
-      │              │    └── flags: disabled not visible index feature
+      │              │    └── flags: avoid-full-scan disabled not visible index feature
       │              └── filters
       │                   ├── b:21 = uniq_hidden_pk.b:14
       │                   ├── c:22 = uniq_hidden_pk.c:15
@@ -835,7 +835,7 @@ insert uniq_hidden_pk
       │              │         └──  rowid_default:12 => rowid:36
       │              ├── scan uniq_hidden_pk
       │              │    ├── columns: uniq_hidden_pk.a:25 uniq_hidden_pk.b:26 uniq_hidden_pk.c:27 uniq_hidden_pk.d:28 uniq_hidden_pk.rowid:29!null
-      │              │    └── flags: disabled not visible index feature
+      │              │    └── flags: avoid-full-scan disabled not visible index feature
       │              └── filters
       │                   ├── a:32 = uniq_hidden_pk.a:25
       │                   ├── b:33 = uniq_hidden_pk.b:26
@@ -856,7 +856,7 @@ insert uniq_hidden_pk
                      │         └──  rowid_default:12 => rowid:48
                      ├── scan uniq_hidden_pk
                      │    ├── columns: uniq_hidden_pk.a:37 uniq_hidden_pk.b:38 uniq_hidden_pk.c:39 uniq_hidden_pk.d:40 uniq_hidden_pk.rowid:41!null
-                     │    └── flags: disabled not visible index feature
+                     │    └── flags: avoid-full-scan disabled not visible index feature
                      └── filters
                           ├── a:44 = uniq_hidden_pk.a:37
                           └── rowid:48 != uniq_hidden_pk.rowid:41
@@ -899,7 +899,7 @@ insert uniq_hidden_pk
       │              │         └──  rowid_default:16 => rowid:28
       │              ├── scan uniq_hidden_pk
       │              │    ├── columns: uniq_hidden_pk.a:17 uniq_hidden_pk.b:18 uniq_hidden_pk.c:19 uniq_hidden_pk.d:20 uniq_hidden_pk.rowid:21!null
-      │              │    └── flags: disabled not visible index feature
+      │              │    └── flags: avoid-full-scan disabled not visible index feature
       │              └── filters
       │                   ├── b:25 = uniq_hidden_pk.b:18
       │                   ├── c:26 = uniq_hidden_pk.c:19
@@ -919,7 +919,7 @@ insert uniq_hidden_pk
       │              │         └──  rowid_default:16 => rowid:40
       │              ├── scan uniq_hidden_pk
       │              │    ├── columns: uniq_hidden_pk.a:29 uniq_hidden_pk.b:30 uniq_hidden_pk.c:31 uniq_hidden_pk.d:32 uniq_hidden_pk.rowid:33!null
-      │              │    └── flags: disabled not visible index feature
+      │              │    └── flags: avoid-full-scan disabled not visible index feature
       │              └── filters
       │                   ├── a:36 = uniq_hidden_pk.a:29
       │                   ├── b:37 = uniq_hidden_pk.b:30
@@ -940,7 +940,7 @@ insert uniq_hidden_pk
                      │         └──  rowid_default:16 => rowid:52
                      ├── scan uniq_hidden_pk
                      │    ├── columns: uniq_hidden_pk.a:41 uniq_hidden_pk.b:42 uniq_hidden_pk.c:43 uniq_hidden_pk.d:44 uniq_hidden_pk.rowid:45!null
-                     │    └── flags: disabled not visible index feature
+                     │    └── flags: avoid-full-scan disabled not visible index feature
                      └── filters
                           ├── a:48 = uniq_hidden_pk.a:41
                           └── rowid:52 != uniq_hidden_pk.rowid:45
@@ -983,7 +983,7 @@ insert uniq_partial
                      │         └──  column3:8 => b:16
                      ├── scan uniq_partial
                      │    ├── columns: uniq_partial.k:9!null uniq_partial.a:10 uniq_partial.b:11
-                     │    └── flags: disabled not visible index feature
+                     │    └── flags: avoid-full-scan disabled not visible index feature
                      └── filters
                           ├── a:15 = uniq_partial.a:10
                           ├── b:16 > 0
@@ -1020,7 +1020,7 @@ insert uniq_partial
                      │         └──  column3:8 => b:16
                      ├── scan uniq_partial
                      │    ├── columns: uniq_partial.k:9!null uniq_partial.a:10 uniq_partial.b:11
-                     │    └── flags: disabled not visible index feature
+                     │    └── flags: avoid-full-scan disabled not visible index feature
                      └── filters
                           ├── a:15 = uniq_partial.a:10
                           ├── b:16 > 0
@@ -1077,14 +1077,14 @@ insert uniq_partial
            │    │    │    │    │    └── (2, 2, 3)
            │    │    │    │    ├── scan uniq_partial
            │    │    │    │    │    ├── columns: k:9!null a:10 b:11
-           │    │    │    │    │    └── flags: disabled not visible index feature
+           │    │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
            │    │    │    │    └── filters
            │    │    │    │         └── column1:6 = k:9
            │    │    │    ├── select
            │    │    │    │    ├── columns: k:14!null a:15 b:16!null
            │    │    │    │    ├── scan uniq_partial
            │    │    │    │    │    ├── columns: k:14!null a:15 b:16
-           │    │    │    │    │    └── flags: disabled not visible index feature
+           │    │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
            │    │    │    │    └── filters
            │    │    │    │         └── b:16 > 0
            │    │    │    └── filters
@@ -1144,7 +1144,7 @@ insert uniq_partial
            │    │    │    ├── columns: k:9!null a:10 b:11!null
            │    │    │    ├── scan uniq_partial
            │    │    │    │    ├── columns: k:9!null a:10 b:11
-           │    │    │    │    └── flags: disabled not visible index feature
+           │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
            │    │    │    └── filters
            │    │    │         └── b:11 > 0
            │    │    └── filters
@@ -1187,7 +1187,7 @@ insert uniq_partial
                      │         └──  w:8 => b:21
                      ├── scan uniq_partial
                      │    ├── columns: uniq_partial.k:14!null uniq_partial.a:15 uniq_partial.b:16
-                     │    └── flags: disabled not visible index feature
+                     │    └── flags: avoid-full-scan disabled not visible index feature
                      └── filters
                           ├── a:20 = uniq_partial.a:15
                           ├── b:21 > 0
@@ -1242,7 +1242,7 @@ insert uniq_partial_overlaps_pk
       │              │         └──  column4:10 => d:20
       │              ├── scan uniq_partial_overlaps_pk
       │              │    ├── columns: uniq_partial_overlaps_pk.a:11!null uniq_partial_overlaps_pk.b:12!null uniq_partial_overlaps_pk.c:13 uniq_partial_overlaps_pk.d:14
-      │              │    └── flags: disabled not visible index feature
+      │              │    └── flags: avoid-full-scan disabled not visible index feature
       │              └── filters
       │                   ├── c:19 = uniq_partial_overlaps_pk.c:13
       │                   ├── d:20 > 0
@@ -1262,7 +1262,7 @@ insert uniq_partial_overlaps_pk
       │              │         └──  column4:10 => d:30
       │              ├── scan uniq_partial_overlaps_pk
       │              │    ├── columns: uniq_partial_overlaps_pk.a:21!null uniq_partial_overlaps_pk.b:22!null uniq_partial_overlaps_pk.c:23 uniq_partial_overlaps_pk.d:24
-      │              │    └── flags: disabled not visible index feature
+      │              │    └── flags: avoid-full-scan disabled not visible index feature
       │              └── filters
       │                   ├── a:27 = uniq_partial_overlaps_pk.a:21
       │                   ├── d:30 > 0
@@ -1282,7 +1282,7 @@ insert uniq_partial_overlaps_pk
                      │         └──  column4:10 => d:40
                      ├── scan uniq_partial_overlaps_pk
                      │    ├── columns: uniq_partial_overlaps_pk.a:31!null uniq_partial_overlaps_pk.b:32!null uniq_partial_overlaps_pk.c:33 uniq_partial_overlaps_pk.d:34
-                     │    └── flags: disabled not visible index feature
+                     │    └── flags: avoid-full-scan disabled not visible index feature
                      └── filters
                           ├── b:38 = uniq_partial_overlaps_pk.b:32
                           ├── c:39 = uniq_partial_overlaps_pk.c:33
@@ -1323,7 +1323,7 @@ insert uniq_partial_overlaps_pk
       │              │         └──  y:11 => d:24
       │              ├── scan uniq_partial_overlaps_pk
       │              │    ├── columns: uniq_partial_overlaps_pk.a:15!null uniq_partial_overlaps_pk.b:16!null uniq_partial_overlaps_pk.c:17 uniq_partial_overlaps_pk.d:18
-      │              │    └── flags: disabled not visible index feature
+      │              │    └── flags: avoid-full-scan disabled not visible index feature
       │              └── filters
       │                   ├── c:23 = uniq_partial_overlaps_pk.c:17
       │                   ├── d:24 > 0
@@ -1343,7 +1343,7 @@ insert uniq_partial_overlaps_pk
       │              │         └──  y:11 => d:34
       │              ├── scan uniq_partial_overlaps_pk
       │              │    ├── columns: uniq_partial_overlaps_pk.a:25!null uniq_partial_overlaps_pk.b:26!null uniq_partial_overlaps_pk.c:27 uniq_partial_overlaps_pk.d:28
-      │              │    └── flags: disabled not visible index feature
+      │              │    └── flags: avoid-full-scan disabled not visible index feature
       │              └── filters
       │                   ├── a:31 = uniq_partial_overlaps_pk.a:25
       │                   ├── d:34 > 0
@@ -1363,7 +1363,7 @@ insert uniq_partial_overlaps_pk
                      │         └──  y:11 => d:44
                      ├── scan uniq_partial_overlaps_pk
                      │    ├── columns: uniq_partial_overlaps_pk.a:35!null uniq_partial_overlaps_pk.b:36!null uniq_partial_overlaps_pk.c:37 uniq_partial_overlaps_pk.d:38
-                     │    └── flags: disabled not visible index feature
+                     │    └── flags: avoid-full-scan disabled not visible index feature
                      └── filters
                           ├── b:42 = uniq_partial_overlaps_pk.b:36
                           ├── c:43 = uniq_partial_overlaps_pk.c:37
@@ -1417,7 +1417,7 @@ insert uniq_partial_hidden_pk
                      │         └──  rowid_default:10 => rowid:20
                      ├── scan uniq_partial_hidden_pk
                      │    ├── columns: uniq_partial_hidden_pk.a:11 uniq_partial_hidden_pk.b:12 uniq_partial_hidden_pk.c:13 uniq_partial_hidden_pk.rowid:14!null
-                     │    └── flags: disabled not visible index feature
+                     │    └── flags: avoid-full-scan disabled not visible index feature
                      └── filters
                           ├── b:18 = uniq_partial_hidden_pk.b:12
                           ├── c:19 > 0
@@ -1460,7 +1460,7 @@ insert uniq_partial_hidden_pk
                      │         └──  rowid_default:16 => rowid:26
                      ├── scan uniq_partial_hidden_pk
                      │    ├── columns: uniq_partial_hidden_pk.a:17 uniq_partial_hidden_pk.b:18 uniq_partial_hidden_pk.c:19 uniq_partial_hidden_pk.rowid:20!null
-                     │    └── flags: disabled not visible index feature
+                     │    └── flags: avoid-full-scan disabled not visible index feature
                      └── filters
                           ├── b:24 = uniq_partial_hidden_pk.b:18
                           ├── c:25 > 0
@@ -1512,7 +1512,7 @@ insert uniq_partial_constraint_and_index
  │    │    │    │    ├── columns: uniq_partial_constraint_and_index.a:10
  │    │    │    │    ├── partial index predicates
  │    │    │    │    │    └── uniq_partial_constraint_and_index_a_key: filters (true)
- │    │    │    │    └── flags: disabled not visible index feature
+ │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
  │    │    │    └── filters
  │    │    │         └── uniq_partial_constraint_and_index.a:10 = 1
  │    │    └── filters (true)
@@ -1562,7 +1562,7 @@ insert uniq_constraint_and_partial_index
       │    │    │    ├── partial index predicates
       │    │    │    │    └── uniq_constraint_and_partial_index_a_key: filters
       │    │    │    │         └── b:11 > 0
-      │    │    │    └── flags: disabled not visible index feature
+      │    │    │    └── flags: avoid-full-scan disabled not visible index feature
       │    │    └── filters
       │    │         └── a:10 = 1
       │    └── filters (true)
@@ -1624,7 +1624,7 @@ insert uniq_partial_constraint_and_partial_index
       │         │    │         │    │    │    │    │    ├── partial index predicates
       │         │    │         │    │    │    │    │    │    └── uniq_partial_constraint_and_partial_index_a_key: filters
       │         │    │         │    │    │    │    │    │         └── b:11 > 0
-      │         │    │         │    │    │    │    │    └── flags: disabled not visible index feature
+      │         │    │         │    │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
       │         │    │         │    │    │    │    └── filters
       │         │    │         │    │    │    │         └── b:11 > 0
       │         │    │         │    │    │    └── filters
@@ -1637,7 +1637,7 @@ insert uniq_partial_constraint_and_partial_index
       │         │    │         │    │    │    │    ├── partial index predicates
       │         │    │         │    │    │    │    │    └── uniq_partial_constraint_and_partial_index_a_key: filters
       │         │    │         │    │    │    │    │         └── b:16 > 0
-      │         │    │         │    │    │    │    └── flags: disabled not visible index feature
+      │         │    │         │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
       │         │    │         │    │    │    └── filters
       │         │    │         │    │    │         └── b:16 > 10
       │         │    │         │    │    └── filters
@@ -1733,7 +1733,7 @@ insert uniq_computed_pk
                      │    │    │    │    └── uniq_computed_pk.d:35
                      │    │    │    └── uniq_computed_pk.c_d_expr:39
                      │    │    │         └── uniq_computed_pk.d:35::STRING
-                     │    │    └── flags: disabled not visible index feature
+                     │    │    └── flags: avoid-full-scan disabled not visible index feature
                      │    └── projections
                      │         └── uniq_computed_pk.s:34 [as=uniq_computed_pk.c_s:37]
                      └── filters
@@ -1776,7 +1776,7 @@ insert uniq_default
  │              │    ├── columns: uniq_default.k:9!null uniq_default.a:10!null uniq_default.b:11!null
  │              │    ├── scan uniq_default
  │              │    │    ├── columns: uniq_default.k:9!null uniq_default.a:10 uniq_default.b:11
- │              │    │    └── flags: disabled not visible index feature
+ │              │    │    └── flags: avoid-full-scan disabled not visible index feature
  │              │    └── filters
  │              │         ├── uniq_default.a:10 = 10
  │              │         ├── uniq_default.b:11 = 100
@@ -1788,7 +1788,7 @@ insert uniq_default
                 ├── columns: uniq_default.k:17!null uniq_default.a:18!null uniq_default.b:19!null
                 ├── scan uniq_default
                 │    ├── columns: uniq_default.k:17!null uniq_default.a:18 uniq_default.b:19
-                │    └── flags: disabled not visible index feature
+                │    └── flags: avoid-full-scan disabled not visible index feature
                 └── filters
                      ├── uniq_default.a:18 = 10
                      └── uniq_default.b:19 = 100
@@ -1846,7 +1846,7 @@ insert t
                      │    ├── partial index predicates
                      │    │    └── t_r_a_idx: filters
                      │    │         └── t.k:13 != 1
-                     │    └── flags: disabled not visible index feature
+                     │    └── flags: avoid-full-scan disabled not visible index feature
                      └── filters
                           ├── a:21 = t.a:15
                           ├── k:19 != 1
@@ -1914,7 +1914,7 @@ insert t
  │                   │    ├── computed column expressions
  │                   │    │    └── t.b:15
  │                   │    │         └── t.k:12 % 9
- │                   │    └── flags: disabled not visible index feature
+ │                   │    └── flags: avoid-full-scan disabled not visible index feature
  │                   └── filters
  │                        ├── a:20 = t.a:14
  │                        └── k:18 != t.k:12
@@ -1929,7 +1929,7 @@ insert t
                 │    ├── computed column expressions
                 │    │    └── t.b:25
                 │    │         └── t.k:22 % 9
-                │    └── flags: disabled not visible index feature
+                │    └── flags: avoid-full-scan disabled not visible index feature
                 └── filters
                      └── t.a:24 = 10
 
@@ -1997,7 +1997,7 @@ insert t
       │              │    ├── computed column expressions
       │              │    │    └── t.b:15
       │              │    │         └── t.k:12 % 9
-      │              │    └── flags: disabled not visible index feature
+      │              │    └── flags: avoid-full-scan disabled not visible index feature
       │              └── filters
       │                   ├── a:20 = t.a:14
       │                   └── k:18 != t.k:12
@@ -2020,7 +2020,7 @@ insert t
                      │    ├── computed column expressions
                      │    │    └── t.b:31
                      │    │         └── t.k:28 % 9
-                     │    └── flags: disabled not visible index feature
+                     │    └── flags: avoid-full-scan disabled not visible index feature
                      └── filters
                           ├── b:37 = t.b:31
                           └── k:34 != t.k:28
@@ -2079,7 +2079,7 @@ insert t
  │    │              │    ├── columns: t.k:12!null t.r:13!null t.a:14 t.b:15
  │    │              │    ├── check constraint expressions
  │    │              │    │    └── t.r:13 IN ('east', 'west')
- │    │              │    └── flags: disabled not visible index feature
+ │    │              │    └── flags: avoid-full-scan disabled not visible index feature
  │    │              └── filters
  │    │                   ├── a:20 = t.a:14
  │    │                   └── k:18 != t.k:12
@@ -2095,7 +2095,7 @@ insert t
  │    │              │    ├── columns: t.k:28!null t.r:29!null t.a:30 t.b:31
  │    │              │    ├── check constraint expressions
  │    │              │    │    └── t.r:29 IN ('east', 'west')
- │    │              │    └── flags: disabled not visible index feature
+ │    │              │    └── flags: avoid-full-scan disabled not visible index feature
  │    │              └── filters
  │    │                   ├── b:37 = t.b:31
  │    │                   └── k:34 != t.k:28
@@ -2111,7 +2111,7 @@ insert t
  │    │              │    ├── columns: t.k:44!null t.r:45!null t.a:46 t.b:47
  │    │              │    ├── check constraint expressions
  │    │              │    │    └── t.r:45 IN ('east', 'west')
- │    │              │    └── flags: disabled not visible index feature
+ │    │              │    └── flags: avoid-full-scan disabled not visible index feature
  │    │              └── filters
  │    │                   ├── r:51 = t.r:45
  │    │                   ├── a:52 = t.a:46
@@ -2129,7 +2129,7 @@ insert t
  │                   │    ├── columns: t.k:60!null t.r:61!null t.a:62 t.b:63
  │                   │    ├── check constraint expressions
  │                   │    │    └── t.r:61 IN ('east', 'west')
- │                   │    └── flags: disabled not visible index feature
+ │                   │    └── flags: avoid-full-scan disabled not visible index feature
  │                   └── filters
  │                        ├── a:68 = t.a:62
  │                        ├── b:69 = t.b:63
@@ -2142,7 +2142,7 @@ insert t
       │         │    ├── columns: t.k:22!null t.r:23!null t.a:24 t.b:25
       │         │    ├── check constraint expressions
       │         │    │    └── t.r:23 IN ('east', 'west')
-      │         │    └── flags: disabled not visible index feature
+      │         │    └── flags: avoid-full-scan disabled not visible index feature
       │         └── filters
       │              └── t.a:24 = 10
       ├── fast-path-unique-checks-item: t(b)
@@ -2152,7 +2152,7 @@ insert t
       │         │    ├── columns: t.k:38!null t.r:39!null t.a:40 t.b:41
       │         │    ├── check constraint expressions
       │         │    │    └── t.r:39 IN ('east', 'west')
-      │         │    └── flags: disabled not visible index feature
+      │         │    └── flags: avoid-full-scan disabled not visible index feature
       │         └── filters
       │              └── t.b:41 = 100
       ├── fast-path-unique-checks-item: t(r,a,b)
@@ -2162,7 +2162,7 @@ insert t
       │         │    ├── columns: t.k:54!null t.r:55!null t.a:56 t.b:57
       │         │    ├── check constraint expressions
       │         │    │    └── t.r:55 IN ('east', 'west')
-      │         │    └── flags: disabled not visible index feature
+      │         │    └── flags: avoid-full-scan disabled not visible index feature
       │         └── filters
       │              ├── t.r:55 = 'east'
       │              ├── t.a:56 = 10
@@ -2174,7 +2174,7 @@ insert t
                 │    ├── columns: t.k:70!null t.r:71!null t.a:72 t.b:73
                 │    ├── check constraint expressions
                 │    │    └── t.r:71 IN ('east', 'west')
-                │    └── flags: disabled not visible index feature
+                │    └── flags: avoid-full-scan disabled not visible index feature
                 └── filters
                      ├── t.a:72 = 10
                      └── t.b:73 = 100
@@ -2216,7 +2216,7 @@ insert t
  │    │              │    ├── columns: t.k:12!null t.r:13!null t.a:14 t.b:15
  │    │              │    ├── check constraint expressions
  │    │              │    │    └── t.r:13 IN ('east', 'west')
- │    │              │    └── flags: disabled not visible index feature
+ │    │              │    └── flags: avoid-full-scan disabled not visible index feature
  │    │              └── filters
  │    │                   ├── a:20 = t.a:14
  │    │                   └── k:18 != t.k:12
@@ -2236,7 +2236,7 @@ insert t
  │    │              │    ├── columns: t.k:28!null t.r:29!null t.a:30 t.b:31
  │    │              │    ├── check constraint expressions
  │    │              │    │    └── t.r:29 IN ('east', 'west')
- │    │              │    └── flags: disabled not visible index feature
+ │    │              │    └── flags: avoid-full-scan disabled not visible index feature
  │    │              └── filters
  │    │                   ├── b:37 = t.b:31
  │    │                   └── k:34 != t.k:28
@@ -2256,7 +2256,7 @@ insert t
  │    │              │    ├── columns: t.k:44!null t.r:45!null t.a:46 t.b:47
  │    │              │    ├── check constraint expressions
  │    │              │    │    └── t.r:45 IN ('east', 'west')
- │    │              │    └── flags: disabled not visible index feature
+ │    │              │    └── flags: avoid-full-scan disabled not visible index feature
  │    │              └── filters
  │    │                   ├── r:51 = t.r:45
  │    │                   ├── a:52 = t.a:46
@@ -2278,7 +2278,7 @@ insert t
  │                   │    ├── columns: t.k:60!null t.r:61!null t.a:62 t.b:63
  │                   │    ├── check constraint expressions
  │                   │    │    └── t.r:61 IN ('east', 'west')
- │                   │    └── flags: disabled not visible index feature
+ │                   │    └── flags: avoid-full-scan disabled not visible index feature
  │                   └── filters
  │                        ├── a:68 = t.a:62
  │                        ├── b:69 = t.b:63
@@ -2291,7 +2291,7 @@ insert t
       │         │    ├── columns: t.k:22!null t.r:23!null t.a:24 t.b:25
       │         │    ├── check constraint expressions
       │         │    │    └── t.r:23 IN ('east', 'west')
-      │         │    └── flags: disabled not visible index feature
+      │         │    └── flags: avoid-full-scan disabled not visible index feature
       │         └── filters
       │              └── t.a:24 = 10
       ├── fast-path-unique-checks-item: t(b)
@@ -2301,7 +2301,7 @@ insert t
       │         │    ├── columns: t.k:38!null t.r:39!null t.a:40 t.b:41
       │         │    ├── check constraint expressions
       │         │    │    └── t.r:39 IN ('east', 'west')
-      │         │    └── flags: disabled not visible index feature
+      │         │    └── flags: avoid-full-scan disabled not visible index feature
       │         └── filters
       │              └── t.b:41 = 100
       ├── fast-path-unique-checks-item: t(r,a,b)
@@ -2311,7 +2311,7 @@ insert t
       │         │    ├── columns: t.k:54!null t.r:55!null t.a:56 t.b:57
       │         │    ├── check constraint expressions
       │         │    │    └── t.r:55 IN ('east', 'west')
-      │         │    └── flags: disabled not visible index feature
+      │         │    └── flags: avoid-full-scan disabled not visible index feature
       │         └── filters
       │              ├── t.r:55 = 'east'
       │              ├── t.a:56 = 10
@@ -2323,7 +2323,7 @@ insert t
                 │    ├── columns: t.k:70!null t.r:71!null t.a:72 t.b:73
                 │    ├── check constraint expressions
                 │    │    └── t.r:71 IN ('east', 'west')
-                │    └── flags: disabled not visible index feature
+                │    └── flags: avoid-full-scan disabled not visible index feature
                 └── filters
                      ├── t.a:72 = 10
                      └── t.b:73 = 100
@@ -2378,7 +2378,7 @@ insert child
  │    │              │    └── (100, 1, 2, 3, 'east')
  │    │              ├── scan child
  │    │              │    ├── columns: child.c:14!null child.p:15!null child.a:16 child.b:17 child.r:18
- │    │              │    └── flags: disabled not visible index feature
+ │    │              │    └── flags: avoid-full-scan disabled not visible index feature
  │    │              └── filters
  │    │                   ├── a:23 = child.a:16
  │    │                   └── c:21 != child.c:14
@@ -2392,7 +2392,7 @@ insert child
  │    │              │    └── (100, 1, 2, 3, 'east')
  │    │              ├── scan child
  │    │              │    ├── columns: child.c:33!null child.p:34!null child.a:35 child.b:36 child.r:37
- │    │              │    └── flags: disabled not visible index feature
+ │    │              │    └── flags: avoid-full-scan disabled not visible index feature
  │    │              └── filters
  │    │                   ├── b:43 = child.b:36
  │    │                   └── c:40 != child.c:33
@@ -2406,7 +2406,7 @@ insert child
  │    │              │    └── (100, 1, 2, 3, 'east')
  │    │              ├── scan child
  │    │              │    ├── columns: child.c:52!null child.p:53!null child.a:54 child.b:55 child.r:56
- │    │              │    └── flags: disabled not visible index feature
+ │    │              │    └── flags: avoid-full-scan disabled not visible index feature
  │    │              └── filters
  │    │                   ├── a:61 = child.a:54
  │    │                   ├── b:62 = child.b:55
@@ -2422,7 +2422,7 @@ insert child
  │                   │    └── (100, 1, 2, 3, 'east')
  │                   ├── scan child
  │                   │    ├── columns: child.c:71!null child.p:72!null child.a:73 child.b:74 child.r:75
- │                   │    └── flags: disabled not visible index feature
+ │                   │    └── flags: avoid-full-scan disabled not visible index feature
  │                   └── filters
  │                        ├── a:80 = child.a:73
  │                        ├── b:81 = child.b:74
@@ -2433,7 +2433,7 @@ insert child
  │    │         ├── columns: child.c:26!null child.p:27!null child.a:28!null child.b:29 child.r:30
  │    │         ├── scan child
  │    │         │    ├── columns: child.c:26!null child.p:27!null child.a:28 child.b:29 child.r:30
- │    │         │    └── flags: disabled not visible index feature
+ │    │         │    └── flags: avoid-full-scan disabled not visible index feature
  │    │         └── filters
  │    │              └── child.a:28 = 2
  │    ├── fast-path-unique-checks-item: child(b)
@@ -2441,7 +2441,7 @@ insert child
  │    │         ├── columns: child.c:45!null child.p:46!null child.a:47 child.b:48!null child.r:49
  │    │         ├── scan child
  │    │         │    ├── columns: child.c:45!null child.p:46!null child.a:47 child.b:48 child.r:49
- │    │         │    └── flags: disabled not visible index feature
+ │    │         │    └── flags: avoid-full-scan disabled not visible index feature
  │    │         └── filters
  │    │              └── child.b:48 = 3
  │    ├── fast-path-unique-checks-item: child(a,b,r)
@@ -2449,7 +2449,7 @@ insert child
  │    │         ├── columns: child.c:64!null child.p:65!null child.a:66!null child.b:67!null child.r:68!null
  │    │         ├── scan child
  │    │         │    ├── columns: child.c:64!null child.p:65!null child.a:66 child.b:67 child.r:68
- │    │         │    └── flags: disabled not visible index feature
+ │    │         │    └── flags: avoid-full-scan disabled not visible index feature
  │    │         └── filters
  │    │              ├── child.a:66 = 2
  │    │              ├── child.b:67 = 3
@@ -2459,7 +2459,7 @@ insert child
  │              ├── columns: child.c:83!null child.p:84!null child.a:85!null child.b:86!null child.r:87
  │              ├── scan child
  │              │    ├── columns: child.c:83!null child.p:84!null child.a:85 child.b:86 child.r:87
- │              │    └── flags: disabled not visible index feature
+ │              │    └── flags: avoid-full-scan disabled not visible index feature
  │              └── filters
  │                   ├── child.a:85 = 2
  │                   └── child.b:86 = 3
@@ -2473,7 +2473,7 @@ insert child
                 │         └──  column2:9 => p:90
                 ├── scan parent
                 │    ├── columns: parent.p:91!null
-                │    └── flags: disabled not visible index feature
+                │    └── flags: avoid-full-scan disabled not visible index feature
                 └── filters
                      └── p:90 = parent.p:91
 
@@ -2541,7 +2541,7 @@ insert t1
       │              │    ├── computed column expressions
       │              │    │    └── t1.b:17
       │              │    │         └── t1.a:16 % 9
-      │              │    └── flags: disabled not visible index feature
+      │              │    └── flags: avoid-full-scan disabled not visible index feature
       │              └── filters
       │                   ├── a:23 = t1.a:16
       │                   └── k:21 != t1.k:14
@@ -2565,7 +2565,7 @@ insert t1
                      │    ├── computed column expressions
                      │    │    └── t1.b:29
                      │    │         └── t1.a:28 % 9
-                     │    └── flags: disabled not visible index feature
+                     │    └── flags: avoid-full-scan disabled not visible index feature
                      └── filters
                           ├── c:37 = t1.c:30
                           └── k:33 != t1.k:26
@@ -2616,7 +2616,7 @@ insert t1
  │    │              │    ├── computed column expressions
  │    │              │    │    └── t1.b:17
  │    │              │    │         └── t1.a:16 % 9
- │    │              │    └── flags: disabled not visible index feature
+ │    │              │    └── flags: avoid-full-scan disabled not visible index feature
  │    │              └── filters
  │    │                   ├── a:23 = t1.a:16
  │    │                   └── k:21 != t1.k:14
@@ -2640,7 +2640,7 @@ insert t1
  │                   │    ├── computed column expressions
  │                   │    │    └── t1.b:36
  │                   │    │         └── t1.a:35 % 9
- │                   │    └── flags: disabled not visible index feature
+ │                   │    └── flags: avoid-full-scan disabled not visible index feature
  │                   └── filters
  │                        ├── c:44 = t1.c:37
  │                        └── k:40 != t1.k:33
@@ -2655,7 +2655,7 @@ insert t1
       │         │    ├── computed column expressions
       │         │    │    └── t1.b:29
       │         │    │         └── t1.a:28 % 9
-      │         │    └── flags: disabled not visible index feature
+      │         │    └── flags: avoid-full-scan disabled not visible index feature
       │         └── filters
       │              └── t1.a:28 = 10
       └── fast-path-unique-checks-item: t1(c)
@@ -2668,6 +2668,6 @@ insert t1
                 │    ├── computed column expressions
                 │    │    └── t1.b:48
                 │    │         └── t1.a:47 % 9
-                │    └── flags: disabled not visible index feature
+                │    └── flags: avoid-full-scan disabled not visible index feature
                 └── filters
                      └── t1.c:49 = 20

--- a/pkg/sql/opt/optbuilder/testdata/unique-checks-update
+++ b/pkg/sql/opt/optbuilder/testdata/unique-checks-update
@@ -23,7 +23,8 @@ update uniq
  ├── project
  │    ├── columns: w_new:15!null x_new:16!null uniq.k:8!null uniq.v:9 uniq.w:10 uniq.x:11 uniq.y:12 crdb_internal_mvcc_timestamp:13 tableoid:14
  │    ├── scan uniq
- │    │    └── columns: uniq.k:8!null uniq.v:9 uniq.w:10 uniq.x:11 uniq.y:12 crdb_internal_mvcc_timestamp:13 tableoid:14
+ │    │    ├── columns: uniq.k:8!null uniq.v:9 uniq.w:10 uniq.x:11 uniq.y:12 crdb_internal_mvcc_timestamp:13 tableoid:14
+ │    │    └── flags: avoid-full-scan
  │    └── projections
  │         ├── 1 [as=w_new:15]
  │         └── 2 [as=x_new:16]
@@ -43,7 +44,7 @@ update uniq
       │              │         └──  uniq.y:12 => y:28
       │              ├── scan uniq
       │              │    ├── columns: uniq.k:17!null uniq.v:18 uniq.w:19 uniq.x:20 uniq.y:21
-      │              │    └── flags: disabled not visible index feature
+      │              │    └── flags: avoid-full-scan disabled not visible index feature
       │              └── filters
       │                   ├── w:26 = uniq.w:19
       │                   └── k:24 != uniq.k:17
@@ -62,7 +63,7 @@ update uniq
                      │         └──  uniq.y:12 => y:40
                      ├── scan uniq
                      │    ├── columns: uniq.k:29!null uniq.v:30 uniq.w:31 uniq.x:32 uniq.y:33
-                     │    └── flags: disabled not visible index feature
+                     │    └── flags: avoid-full-scan disabled not visible index feature
                      └── filters
                           ├── x:39 = uniq.x:32
                           ├── y:40 = uniq.y:33
@@ -82,7 +83,8 @@ update uniq
  ├── project
  │    ├── columns: w_new:15 x_new:16!null uniq.k:8!null uniq.v:9 uniq.w:10 uniq.x:11 uniq.y:12 crdb_internal_mvcc_timestamp:13 tableoid:14
  │    ├── scan uniq
- │    │    └── columns: uniq.k:8!null uniq.v:9 uniq.w:10 uniq.x:11 uniq.y:12 crdb_internal_mvcc_timestamp:13 tableoid:14
+ │    │    ├── columns: uniq.k:8!null uniq.v:9 uniq.w:10 uniq.x:11 uniq.y:12 crdb_internal_mvcc_timestamp:13 tableoid:14
+ │    │    └── flags: avoid-full-scan
  │    └── projections
  │         ├── NULL::INT8 [as=w_new:15]
  │         └── 1 [as=x_new:16]
@@ -102,7 +104,7 @@ update uniq
                      │         └──  uniq.y:12 => y:28
                      ├── scan uniq
                      │    ├── columns: uniq.k:17!null uniq.v:18 uniq.w:19 uniq.x:20 uniq.y:21
-                     │    └── flags: disabled not visible index feature
+                     │    └── flags: avoid-full-scan disabled not visible index feature
                      └── filters
                           ├── x:27 = uniq.x:20
                           ├── y:28 = uniq.y:21
@@ -124,7 +126,8 @@ update uniq
  ├── project
  │    ├── columns: k_new:15!null w_new:16!null x_new:17 uniq.k:8!null uniq.v:9 uniq.w:10 uniq.x:11 uniq.y:12 crdb_internal_mvcc_timestamp:13 tableoid:14
  │    ├── scan uniq
- │    │    └── columns: uniq.k:8!null uniq.v:9 uniq.w:10 uniq.x:11 uniq.y:12 crdb_internal_mvcc_timestamp:13 tableoid:14
+ │    │    ├── columns: uniq.k:8!null uniq.v:9 uniq.w:10 uniq.x:11 uniq.y:12 crdb_internal_mvcc_timestamp:13 tableoid:14
+ │    │    └── flags: avoid-full-scan
  │    └── projections
  │         ├── 1 [as=k_new:15]
  │         ├── 2 [as=w_new:16]
@@ -145,7 +148,7 @@ update uniq
                      │         └──  uniq.y:12 => y:29
                      ├── scan uniq
                      │    ├── columns: uniq.k:18!null uniq.v:19 uniq.w:20 uniq.x:21 uniq.y:22
-                     │    └── flags: disabled not visible index feature
+                     │    └── flags: avoid-full-scan disabled not visible index feature
                      └── filters
                           ├── w:27 = uniq.w:20
                           └── k:25 != uniq.k:18
@@ -166,7 +169,8 @@ update uniq
  │    ├── select
  │    │    ├── columns: uniq.k:8!null uniq.v:9 uniq.w:10 uniq.x:11 uniq.y:12 crdb_internal_mvcc_timestamp:13 tableoid:14
  │    │    ├── scan uniq
- │    │    │    └── columns: uniq.k:8!null uniq.v:9 uniq.w:10 uniq.x:11 uniq.y:12 crdb_internal_mvcc_timestamp:13 tableoid:14
+ │    │    │    ├── columns: uniq.k:8!null uniq.v:9 uniq.w:10 uniq.x:11 uniq.y:12 crdb_internal_mvcc_timestamp:13 tableoid:14
+ │    │    │    └── flags: avoid-full-scan
  │    │    └── filters
  │    │         └── uniq.k:8 = 1
  │    └── projections
@@ -188,7 +192,7 @@ update uniq
                      │         └──  y_new:16 => y:28
                      ├── scan uniq
                      │    ├── columns: uniq.k:17!null uniq.v:18 uniq.w:19 uniq.x:20 uniq.y:21
-                     │    └── flags: disabled not visible index feature
+                     │    └── flags: avoid-full-scan disabled not visible index feature
                      └── filters
                           ├── w:26 = uniq.w:19
                           └── k:24 != uniq.k:17
@@ -206,7 +210,8 @@ update uniq
  └── project
       ├── columns: k_new:15!null v_new:16!null k:8!null v:9 w:10 x:11 y:12 crdb_internal_mvcc_timestamp:13 tableoid:14
       ├── scan uniq
-      │    └── columns: k:8!null v:9 w:10 x:11 y:12 crdb_internal_mvcc_timestamp:13 tableoid:14
+      │    ├── columns: k:8!null v:9 w:10 x:11 y:12 crdb_internal_mvcc_timestamp:13 tableoid:14
+      │    └── flags: avoid-full-scan
       └── projections
            ├── 1 [as=k_new:15]
            └── 2 [as=v_new:16]
@@ -226,7 +231,7 @@ update uniq
  │    ├── columns: w_new:15!null x_new:16!null uniq.k:8!null uniq.v:9 uniq.w:10 uniq.x:11 uniq.y:12 crdb_internal_mvcc_timestamp:13 tableoid:14
  │    ├── scan uniq
  │    │    ├── columns: uniq.k:8!null uniq.v:9 uniq.w:10 uniq.x:11 uniq.y:12 crdb_internal_mvcc_timestamp:13 tableoid:14
- │    │    └── flags: force-index=uniq_v_key
+ │    │    └── flags: force-index=uniq_v_key avoid-full-scan
  │    └── projections
  │         ├── 1 [as=w_new:15]
  │         └── 2 [as=x_new:16]
@@ -246,7 +251,7 @@ update uniq
       │              │         └──  uniq.y:12 => y:28
       │              ├── scan uniq
       │              │    ├── columns: uniq.k:17!null uniq.v:18 uniq.w:19 uniq.x:20 uniq.y:21
-      │              │    └── flags: disabled not visible index feature
+      │              │    └── flags: avoid-full-scan disabled not visible index feature
       │              └── filters
       │                   ├── w:26 = uniq.w:19
       │                   └── k:24 != uniq.k:17
@@ -265,7 +270,7 @@ update uniq
                      │         └──  uniq.y:12 => y:40
                      ├── scan uniq
                      │    ├── columns: uniq.k:29!null uniq.v:30 uniq.w:31 uniq.x:32 uniq.y:33
-                     │    └── flags: disabled not visible index feature
+                     │    └── flags: avoid-full-scan disabled not visible index feature
                      └── filters
                           ├── x:39 = uniq.x:32
                           ├── y:40 = uniq.y:33
@@ -293,7 +298,8 @@ update uniq
  │    ├── inner-join (cross)
  │    │    ├── columns: uniq.k:8!null uniq.v:9 uniq.w:10 uniq.x:11 uniq.y:12 uniq.crdb_internal_mvcc_timestamp:13 uniq.tableoid:14 other.k:15 other.v:16 other.w:17!null other.x:18 other.y:19 rowid:20!null other.crdb_internal_mvcc_timestamp:21 other.tableoid:22
  │    │    ├── scan uniq
- │    │    │    └── columns: uniq.k:8!null uniq.v:9 uniq.w:10 uniq.x:11 uniq.y:12 uniq.crdb_internal_mvcc_timestamp:13 uniq.tableoid:14
+ │    │    │    ├── columns: uniq.k:8!null uniq.v:9 uniq.w:10 uniq.x:11 uniq.y:12 uniq.crdb_internal_mvcc_timestamp:13 uniq.tableoid:14
+ │    │    │    └── flags: avoid-full-scan
  │    │    ├── scan other
  │    │    │    └── columns: other.k:15 other.v:16 other.w:17!null other.x:18 other.y:19 rowid:20!null other.crdb_internal_mvcc_timestamp:21 other.tableoid:22
  │    │    └── filters (true)
@@ -342,7 +348,7 @@ update uniq
       │              │         └──  uniq.y:12 => y:34
       │              ├── scan uniq
       │              │    ├── columns: uniq.k:23!null uniq.v:24 uniq.w:25 uniq.x:26 uniq.y:27
-      │              │    └── flags: disabled not visible index feature
+      │              │    └── flags: avoid-full-scan disabled not visible index feature
       │              └── filters
       │                   ├── w:32 = uniq.w:25
       │                   └── k:30 != uniq.k:23
@@ -361,7 +367,7 @@ update uniq
                      │         └──  uniq.y:12 => y:46
                      ├── scan uniq
                      │    ├── columns: uniq.k:35!null uniq.v:36 uniq.w:37 uniq.x:38 uniq.y:39
-                     │    └── flags: disabled not visible index feature
+                     │    └── flags: avoid-full-scan disabled not visible index feature
                      └── filters
                           ├── x:45 = uniq.x:38
                           ├── y:46 = uniq.y:39
@@ -401,7 +407,8 @@ update uniq_overlaps_pk
  │    ├── select
  │    │    ├── columns: uniq_overlaps_pk.a:7!null uniq_overlaps_pk.b:8!null uniq_overlaps_pk.c:9 uniq_overlaps_pk.d:10 crdb_internal_mvcc_timestamp:11 tableoid:12
  │    │    ├── scan uniq_overlaps_pk
- │    │    │    └── columns: uniq_overlaps_pk.a:7!null uniq_overlaps_pk.b:8!null uniq_overlaps_pk.c:9 uniq_overlaps_pk.d:10 crdb_internal_mvcc_timestamp:11 tableoid:12
+ │    │    │    ├── columns: uniq_overlaps_pk.a:7!null uniq_overlaps_pk.b:8!null uniq_overlaps_pk.c:9 uniq_overlaps_pk.d:10 crdb_internal_mvcc_timestamp:11 tableoid:12
+ │    │    │    └── flags: avoid-full-scan
  │    │    └── filters
  │    │         └── uniq_overlaps_pk.a:7 = 5
  │    └── projections
@@ -424,7 +431,7 @@ update uniq_overlaps_pk
       │              │         └──  d_new:16 => d:26
       │              ├── scan uniq_overlaps_pk
       │              │    ├── columns: uniq_overlaps_pk.a:17!null uniq_overlaps_pk.b:18!null uniq_overlaps_pk.c:19 uniq_overlaps_pk.d:20
-      │              │    └── flags: disabled not visible index feature
+      │              │    └── flags: avoid-full-scan disabled not visible index feature
       │              └── filters
       │                   ├── b:24 = uniq_overlaps_pk.b:18
       │                   ├── c:25 = uniq_overlaps_pk.c:19
@@ -443,7 +450,7 @@ update uniq_overlaps_pk
       │              │         └──  d_new:16 => d:36
       │              ├── scan uniq_overlaps_pk
       │              │    ├── columns: uniq_overlaps_pk.a:27!null uniq_overlaps_pk.b:28!null uniq_overlaps_pk.c:29 uniq_overlaps_pk.d:30
-      │              │    └── flags: disabled not visible index feature
+      │              │    └── flags: avoid-full-scan disabled not visible index feature
       │              └── filters
       │                   ├── a:33 = uniq_overlaps_pk.a:27
       │                   └── b:34 != uniq_overlaps_pk.b:28
@@ -461,7 +468,7 @@ update uniq_overlaps_pk
                      │         └──  d_new:16 => d:46
                      ├── scan uniq_overlaps_pk
                      │    ├── columns: uniq_overlaps_pk.a:37!null uniq_overlaps_pk.b:38!null uniq_overlaps_pk.c:39 uniq_overlaps_pk.d:40
-                     │    └── flags: disabled not visible index feature
+                     │    └── flags: avoid-full-scan disabled not visible index feature
                      └── filters
                           ├── c:45 = uniq_overlaps_pk.c:39
                           ├── d:46 = uniq_overlaps_pk.d:40
@@ -488,7 +495,8 @@ update uniq_overlaps_pk
  │    ├── inner-join (cross)
  │    │    ├── columns: uniq_overlaps_pk.a:7!null uniq_overlaps_pk.b:8!null uniq_overlaps_pk.c:9 uniq_overlaps_pk.d:10 uniq_overlaps_pk.crdb_internal_mvcc_timestamp:11 uniq_overlaps_pk.tableoid:12 k:13 v:14 w:15!null x:16 y:17 rowid:18!null other.crdb_internal_mvcc_timestamp:19 other.tableoid:20
  │    │    ├── scan uniq_overlaps_pk
- │    │    │    └── columns: uniq_overlaps_pk.a:7!null uniq_overlaps_pk.b:8!null uniq_overlaps_pk.c:9 uniq_overlaps_pk.d:10 uniq_overlaps_pk.crdb_internal_mvcc_timestamp:11 uniq_overlaps_pk.tableoid:12
+ │    │    │    ├── columns: uniq_overlaps_pk.a:7!null uniq_overlaps_pk.b:8!null uniq_overlaps_pk.c:9 uniq_overlaps_pk.d:10 uniq_overlaps_pk.crdb_internal_mvcc_timestamp:11 uniq_overlaps_pk.tableoid:12
+ │    │    │    └── flags: avoid-full-scan
  │    │    ├── scan other
  │    │    │    └── columns: k:13 v:14 w:15!null x:16 y:17 rowid:18!null other.crdb_internal_mvcc_timestamp:19 other.tableoid:20
  │    │    └── filters (true)
@@ -532,7 +540,7 @@ update uniq_overlaps_pk
       │              │         └──  v:14 => d:30
       │              ├── scan uniq_overlaps_pk
       │              │    ├── columns: uniq_overlaps_pk.a:21!null uniq_overlaps_pk.b:22!null uniq_overlaps_pk.c:23 uniq_overlaps_pk.d:24
-      │              │    └── flags: disabled not visible index feature
+      │              │    └── flags: avoid-full-scan disabled not visible index feature
       │              └── filters
       │                   ├── a:27 = uniq_overlaps_pk.a:21
       │                   └── b:28 != uniq_overlaps_pk.b:22
@@ -550,7 +558,7 @@ update uniq_overlaps_pk
                      │         └──  v:14 => d:40
                      ├── scan uniq_overlaps_pk
                      │    ├── columns: uniq_overlaps_pk.a:31!null uniq_overlaps_pk.b:32!null uniq_overlaps_pk.c:33 uniq_overlaps_pk.d:34
-                     │    └── flags: disabled not visible index feature
+                     │    └── flags: avoid-full-scan disabled not visible index feature
                      └── filters
                           ├── c:39 = uniq_overlaps_pk.c:33
                           ├── d:40 = uniq_overlaps_pk.d:34
@@ -583,7 +591,8 @@ update uniq_hidden_pk
  ├── project
  │    ├── columns: a_new:15!null uniq_hidden_pk.a:8 uniq_hidden_pk.b:9 uniq_hidden_pk.c:10 uniq_hidden_pk.d:11 uniq_hidden_pk.rowid:12!null crdb_internal_mvcc_timestamp:13 tableoid:14
  │    ├── scan uniq_hidden_pk
- │    │    └── columns: uniq_hidden_pk.a:8 uniq_hidden_pk.b:9 uniq_hidden_pk.c:10 uniq_hidden_pk.d:11 uniq_hidden_pk.rowid:12!null crdb_internal_mvcc_timestamp:13 tableoid:14
+ │    │    ├── columns: uniq_hidden_pk.a:8 uniq_hidden_pk.b:9 uniq_hidden_pk.c:10 uniq_hidden_pk.d:11 uniq_hidden_pk.rowid:12!null crdb_internal_mvcc_timestamp:13 tableoid:14
+ │    │    └── flags: avoid-full-scan
  │    └── projections
  │         └── 1 [as=a_new:15]
  └── unique-checks
@@ -602,7 +611,7 @@ update uniq_hidden_pk
       │              │         └──  uniq_hidden_pk.rowid:12 => rowid:27
       │              ├── scan uniq_hidden_pk
       │              │    ├── columns: uniq_hidden_pk.a:16 uniq_hidden_pk.b:17 uniq_hidden_pk.c:18 uniq_hidden_pk.d:19 uniq_hidden_pk.rowid:20!null
-      │              │    └── flags: disabled not visible index feature
+      │              │    └── flags: avoid-full-scan disabled not visible index feature
       │              └── filters
       │                   ├── a:23 = uniq_hidden_pk.a:16
       │                   ├── b:24 = uniq_hidden_pk.b:17
@@ -623,7 +632,7 @@ update uniq_hidden_pk
                      │         └──  uniq_hidden_pk.rowid:12 => rowid:39
                      ├── scan uniq_hidden_pk
                      │    ├── columns: uniq_hidden_pk.a:28 uniq_hidden_pk.b:29 uniq_hidden_pk.c:30 uniq_hidden_pk.d:31 uniq_hidden_pk.rowid:32!null
-                     │    └── flags: disabled not visible index feature
+                     │    └── flags: avoid-full-scan disabled not visible index feature
                      └── filters
                           ├── a:35 = uniq_hidden_pk.a:28
                           └── rowid:39 != uniq_hidden_pk.rowid:32
@@ -647,7 +656,8 @@ update uniq_hidden_pk
  │    ├── inner-join (cross)
  │    │    ├── columns: uniq_hidden_pk.a:8 uniq_hidden_pk.b:9 uniq_hidden_pk.c:10 uniq_hidden_pk.d:11 uniq_hidden_pk.rowid:12!null uniq_hidden_pk.crdb_internal_mvcc_timestamp:13 uniq_hidden_pk.tableoid:14 k:15 v:16 w:17!null x:18 y:19 other.rowid:20!null other.crdb_internal_mvcc_timestamp:21 other.tableoid:22
  │    │    ├── scan uniq_hidden_pk
- │    │    │    └── columns: uniq_hidden_pk.a:8 uniq_hidden_pk.b:9 uniq_hidden_pk.c:10 uniq_hidden_pk.d:11 uniq_hidden_pk.rowid:12!null uniq_hidden_pk.crdb_internal_mvcc_timestamp:13 uniq_hidden_pk.tableoid:14
+ │    │    │    ├── columns: uniq_hidden_pk.a:8 uniq_hidden_pk.b:9 uniq_hidden_pk.c:10 uniq_hidden_pk.d:11 uniq_hidden_pk.rowid:12!null uniq_hidden_pk.crdb_internal_mvcc_timestamp:13 uniq_hidden_pk.tableoid:14
+ │    │    │    └── flags: avoid-full-scan
  │    │    ├── scan other
  │    │    │    └── columns: k:15 v:16 w:17!null x:18 y:19 other.rowid:20!null other.crdb_internal_mvcc_timestamp:21 other.tableoid:22
  │    │    └── filters (true)
@@ -696,7 +706,7 @@ update uniq_hidden_pk
       │              │         └──  uniq_hidden_pk.rowid:12 => rowid:34
       │              ├── scan uniq_hidden_pk
       │              │    ├── columns: uniq_hidden_pk.a:23 uniq_hidden_pk.b:24 uniq_hidden_pk.c:25 uniq_hidden_pk.d:26 uniq_hidden_pk.rowid:27!null
-      │              │    └── flags: disabled not visible index feature
+      │              │    └── flags: avoid-full-scan disabled not visible index feature
       │              └── filters
       │                   ├── a:30 = uniq_hidden_pk.a:23
       │                   ├── b:31 = uniq_hidden_pk.b:24
@@ -717,7 +727,7 @@ update uniq_hidden_pk
                      │         └──  uniq_hidden_pk.rowid:12 => rowid:46
                      ├── scan uniq_hidden_pk
                      │    ├── columns: uniq_hidden_pk.a:35 uniq_hidden_pk.b:36 uniq_hidden_pk.c:37 uniq_hidden_pk.d:38 uniq_hidden_pk.rowid:39!null
-                     │    └── flags: disabled not visible index feature
+                     │    └── flags: avoid-full-scan disabled not visible index feature
                      └── filters
                           ├── a:42 = uniq_hidden_pk.a:35
                           └── rowid:46 != uniq_hidden_pk.rowid:39
@@ -745,7 +755,8 @@ update uniq_partial
  ├── project
  │    ├── columns: a_new:13!null uniq_partial.k:7!null uniq_partial.a:8 uniq_partial.b:9 uniq_partial.c:10 crdb_internal_mvcc_timestamp:11 tableoid:12
  │    ├── scan uniq_partial
- │    │    └── columns: uniq_partial.k:7!null uniq_partial.a:8 uniq_partial.b:9 uniq_partial.c:10 crdb_internal_mvcc_timestamp:11 tableoid:12
+ │    │    ├── columns: uniq_partial.k:7!null uniq_partial.a:8 uniq_partial.b:9 uniq_partial.c:10 crdb_internal_mvcc_timestamp:11 tableoid:12
+ │    │    └── flags: avoid-full-scan
  │    └── projections
  │         └── 1 [as=a_new:13]
  └── unique-checks
@@ -763,7 +774,7 @@ update uniq_partial
                      │         └──  uniq_partial.c:10 => c:23
                      ├── scan uniq_partial
                      │    ├── columns: uniq_partial.k:14!null uniq_partial.a:15 uniq_partial.b:16 uniq_partial.c:17
-                     │    └── flags: disabled not visible index feature
+                     │    └── flags: avoid-full-scan disabled not visible index feature
                      └── filters
                           ├── a:21 = uniq_partial.a:15
                           ├── b:22 > 0
@@ -783,7 +794,8 @@ update uniq_partial
  ├── project
  │    ├── columns: b_new:13!null uniq_partial.k:7!null uniq_partial.a:8 uniq_partial.b:9 uniq_partial.c:10 crdb_internal_mvcc_timestamp:11 tableoid:12
  │    ├── scan uniq_partial
- │    │    └── columns: uniq_partial.k:7!null uniq_partial.a:8 uniq_partial.b:9 uniq_partial.c:10 crdb_internal_mvcc_timestamp:11 tableoid:12
+ │    │    ├── columns: uniq_partial.k:7!null uniq_partial.a:8 uniq_partial.b:9 uniq_partial.c:10 crdb_internal_mvcc_timestamp:11 tableoid:12
+ │    │    └── flags: avoid-full-scan
  │    └── projections
  │         └── 1 [as=b_new:13]
  └── unique-checks
@@ -801,7 +813,7 @@ update uniq_partial
                      │         └──  uniq_partial.c:10 => c:23
                      ├── scan uniq_partial
                      │    ├── columns: uniq_partial.k:14!null uniq_partial.a:15 uniq_partial.b:16 uniq_partial.c:17
-                     │    └── flags: disabled not visible index feature
+                     │    └── flags: avoid-full-scan disabled not visible index feature
                      └── filters
                           ├── a:21 = uniq_partial.a:15
                           ├── b:22 > 0
@@ -821,7 +833,8 @@ update uniq_partial
  └── project
       ├── columns: a_new:13 b_new:14!null k:7!null a:8 b:9 c:10 crdb_internal_mvcc_timestamp:11 tableoid:12
       ├── scan uniq_partial
-      │    └── columns: k:7!null a:8 b:9 c:10 crdb_internal_mvcc_timestamp:11 tableoid:12
+      │    ├── columns: k:7!null a:8 b:9 c:10 crdb_internal_mvcc_timestamp:11 tableoid:12
+      │    └── flags: avoid-full-scan
       └── projections
            ├── NULL::INT8 [as=a_new:13]
            └── 1 [as=b_new:14]
@@ -841,7 +854,8 @@ update uniq_partial
  └── project
       ├── columns: k_new:13!null a_new:14 k:7!null a:8 b:9 c:10 crdb_internal_mvcc_timestamp:11 tableoid:12
       ├── scan uniq_partial
-      │    └── columns: k:7!null a:8 b:9 c:10 crdb_internal_mvcc_timestamp:11 tableoid:12
+      │    ├── columns: k:7!null a:8 b:9 c:10 crdb_internal_mvcc_timestamp:11 tableoid:12
+      │    └── flags: avoid-full-scan
       └── projections
            ├── 1 [as=k_new:13]
            └── NULL::INT8 [as=a_new:14]
@@ -859,7 +873,8 @@ update uniq_partial
  └── project
       ├── columns: c_new:13!null k:7!null a:8 b:9 c:10 crdb_internal_mvcc_timestamp:11 tableoid:12
       ├── scan uniq_partial
-      │    └── columns: k:7!null a:8 b:9 c:10 crdb_internal_mvcc_timestamp:11 tableoid:12
+      │    ├── columns: k:7!null a:8 b:9 c:10 crdb_internal_mvcc_timestamp:11 tableoid:12
+      │    └── flags: avoid-full-scan
       └── projections
            └── 2 [as=c_new:13]
 
@@ -881,7 +896,8 @@ update uniq_partial
  │    ├── inner-join (cross)
  │    │    ├── columns: uniq_partial.k:7!null uniq_partial.a:8 uniq_partial.b:9 uniq_partial.c:10 uniq_partial.crdb_internal_mvcc_timestamp:11 uniq_partial.tableoid:12 other.k:13 v:14 w:15!null x:16 y:17 rowid:18!null other.crdb_internal_mvcc_timestamp:19 other.tableoid:20
  │    │    ├── scan uniq_partial
- │    │    │    └── columns: uniq_partial.k:7!null uniq_partial.a:8 uniq_partial.b:9 uniq_partial.c:10 uniq_partial.crdb_internal_mvcc_timestamp:11 uniq_partial.tableoid:12
+ │    │    │    ├── columns: uniq_partial.k:7!null uniq_partial.a:8 uniq_partial.b:9 uniq_partial.c:10 uniq_partial.crdb_internal_mvcc_timestamp:11 uniq_partial.tableoid:12
+ │    │    │    └── flags: avoid-full-scan
  │    │    ├── scan other
  │    │    │    └── columns: other.k:13 v:14 w:15!null x:16 y:17 rowid:18!null other.crdb_internal_mvcc_timestamp:19 other.tableoid:20
  │    │    └── filters (true)
@@ -927,7 +943,7 @@ update uniq_partial
                      │         └──  uniq_partial.c:10 => c:30
                      ├── scan uniq_partial
                      │    ├── columns: uniq_partial.k:21!null uniq_partial.a:22 uniq_partial.b:23 uniq_partial.c:24
-                     │    └── flags: disabled not visible index feature
+                     │    └── flags: avoid-full-scan disabled not visible index feature
                      └── filters
                           ├── a:28 = uniq_partial.a:22
                           ├── b:29 > 0
@@ -971,7 +987,8 @@ update uniq_partial_overlaps_pk
  │    ├── select
  │    │    ├── columns: uniq_partial_overlaps_pk.a:7!null uniq_partial_overlaps_pk.b:8!null uniq_partial_overlaps_pk.c:9 uniq_partial_overlaps_pk.d:10 crdb_internal_mvcc_timestamp:11 tableoid:12
  │    │    ├── scan uniq_partial_overlaps_pk
- │    │    │    └── columns: uniq_partial_overlaps_pk.a:7!null uniq_partial_overlaps_pk.b:8!null uniq_partial_overlaps_pk.c:9 uniq_partial_overlaps_pk.d:10 crdb_internal_mvcc_timestamp:11 tableoid:12
+ │    │    │    ├── columns: uniq_partial_overlaps_pk.a:7!null uniq_partial_overlaps_pk.b:8!null uniq_partial_overlaps_pk.c:9 uniq_partial_overlaps_pk.d:10 crdb_internal_mvcc_timestamp:11 tableoid:12
+ │    │    │    └── flags: avoid-full-scan
  │    │    └── filters
  │    │         └── uniq_partial_overlaps_pk.a:7 = 5
  │    └── projections
@@ -994,7 +1011,7 @@ update uniq_partial_overlaps_pk
       │              │         └──  d_new:16 => d:26
       │              ├── scan uniq_partial_overlaps_pk
       │              │    ├── columns: uniq_partial_overlaps_pk.a:17!null uniq_partial_overlaps_pk.b:18!null uniq_partial_overlaps_pk.c:19 uniq_partial_overlaps_pk.d:20
-      │              │    └── flags: disabled not visible index feature
+      │              │    └── flags: avoid-full-scan disabled not visible index feature
       │              └── filters
       │                   ├── c:25 = uniq_partial_overlaps_pk.c:19
       │                   ├── d:26 > 0
@@ -1014,7 +1031,7 @@ update uniq_partial_overlaps_pk
       │              │         └──  d_new:16 => d:36
       │              ├── scan uniq_partial_overlaps_pk
       │              │    ├── columns: uniq_partial_overlaps_pk.a:27!null uniq_partial_overlaps_pk.b:28!null uniq_partial_overlaps_pk.c:29 uniq_partial_overlaps_pk.d:30
-      │              │    └── flags: disabled not visible index feature
+      │              │    └── flags: avoid-full-scan disabled not visible index feature
       │              └── filters
       │                   ├── a:33 = uniq_partial_overlaps_pk.a:27
       │                   ├── d:36 > 0
@@ -1034,7 +1051,7 @@ update uniq_partial_overlaps_pk
                      │         └──  d_new:16 => d:46
                      ├── scan uniq_partial_overlaps_pk
                      │    ├── columns: uniq_partial_overlaps_pk.a:37!null uniq_partial_overlaps_pk.b:38!null uniq_partial_overlaps_pk.c:39 uniq_partial_overlaps_pk.d:40
-                     │    └── flags: disabled not visible index feature
+                     │    └── flags: avoid-full-scan disabled not visible index feature
                      └── filters
                           ├── b:44 = uniq_partial_overlaps_pk.b:38
                           ├── c:45 = uniq_partial_overlaps_pk.c:39
@@ -1064,7 +1081,8 @@ update uniq_partial_overlaps_pk
  │    ├── inner-join (cross)
  │    │    ├── columns: uniq_partial_overlaps_pk.a:7!null uniq_partial_overlaps_pk.b:8!null uniq_partial_overlaps_pk.c:9 uniq_partial_overlaps_pk.d:10 uniq_partial_overlaps_pk.crdb_internal_mvcc_timestamp:11 uniq_partial_overlaps_pk.tableoid:12 k:13 v:14 w:15!null x:16 y:17 rowid:18!null other.crdb_internal_mvcc_timestamp:19 other.tableoid:20
  │    │    ├── scan uniq_partial_overlaps_pk
- │    │    │    └── columns: uniq_partial_overlaps_pk.a:7!null uniq_partial_overlaps_pk.b:8!null uniq_partial_overlaps_pk.c:9 uniq_partial_overlaps_pk.d:10 uniq_partial_overlaps_pk.crdb_internal_mvcc_timestamp:11 uniq_partial_overlaps_pk.tableoid:12
+ │    │    │    ├── columns: uniq_partial_overlaps_pk.a:7!null uniq_partial_overlaps_pk.b:8!null uniq_partial_overlaps_pk.c:9 uniq_partial_overlaps_pk.d:10 uniq_partial_overlaps_pk.crdb_internal_mvcc_timestamp:11 uniq_partial_overlaps_pk.tableoid:12
+ │    │    │    └── flags: avoid-full-scan
  │    │    ├── scan other
  │    │    │    └── columns: k:13 v:14 w:15!null x:16 y:17 rowid:18!null other.crdb_internal_mvcc_timestamp:19 other.tableoid:20
  │    │    └── filters (true)
@@ -1108,7 +1126,7 @@ update uniq_partial_overlaps_pk
                      │         └──  uniq_partial_overlaps_pk.d:10 => d:30
                      ├── scan uniq_partial_overlaps_pk
                      │    ├── columns: uniq_partial_overlaps_pk.a:21!null uniq_partial_overlaps_pk.b:22!null uniq_partial_overlaps_pk.c:23 uniq_partial_overlaps_pk.d:24
-                     │    └── flags: disabled not visible index feature
+                     │    └── flags: avoid-full-scan disabled not visible index feature
                      └── filters
                           ├── a:27 = uniq_partial_overlaps_pk.a:21
                           ├── d:30 > 0
@@ -1137,7 +1155,8 @@ update uniq_partial_hidden_pk
  ├── project
  │    ├── columns: a_new:11!null uniq_partial_hidden_pk.a:6 uniq_partial_hidden_pk.b:7 uniq_partial_hidden_pk.rowid:8!null crdb_internal_mvcc_timestamp:9 tableoid:10
  │    ├── scan uniq_partial_hidden_pk
- │    │    └── columns: uniq_partial_hidden_pk.a:6 uniq_partial_hidden_pk.b:7 uniq_partial_hidden_pk.rowid:8!null crdb_internal_mvcc_timestamp:9 tableoid:10
+ │    │    ├── columns: uniq_partial_hidden_pk.a:6 uniq_partial_hidden_pk.b:7 uniq_partial_hidden_pk.rowid:8!null crdb_internal_mvcc_timestamp:9 tableoid:10
+ │    │    └── flags: avoid-full-scan
  │    └── projections
  │         └── 1 [as=a_new:11]
  └── unique-checks
@@ -1154,7 +1173,7 @@ update uniq_partial_hidden_pk
                      │         └──  uniq_partial_hidden_pk.rowid:8 => rowid:19
                      ├── scan uniq_partial_hidden_pk
                      │    ├── columns: uniq_partial_hidden_pk.a:12 uniq_partial_hidden_pk.b:13 uniq_partial_hidden_pk.rowid:14!null
-                     │    └── flags: disabled not visible index feature
+                     │    └── flags: avoid-full-scan disabled not visible index feature
                      └── filters
                           ├── a:17 = uniq_partial_hidden_pk.a:12
                           ├── b:18 > 0
@@ -1179,7 +1198,8 @@ update uniq_partial_hidden_pk
  │    ├── inner-join (cross)
  │    │    ├── columns: uniq_partial_hidden_pk.a:6 uniq_partial_hidden_pk.b:7 uniq_partial_hidden_pk.rowid:8!null uniq_partial_hidden_pk.crdb_internal_mvcc_timestamp:9 uniq_partial_hidden_pk.tableoid:10 k:11 v:12 w:13!null x:14 y:15 other.rowid:16!null other.crdb_internal_mvcc_timestamp:17 other.tableoid:18
  │    │    ├── scan uniq_partial_hidden_pk
- │    │    │    └── columns: uniq_partial_hidden_pk.a:6 uniq_partial_hidden_pk.b:7 uniq_partial_hidden_pk.rowid:8!null uniq_partial_hidden_pk.crdb_internal_mvcc_timestamp:9 uniq_partial_hidden_pk.tableoid:10
+ │    │    │    ├── columns: uniq_partial_hidden_pk.a:6 uniq_partial_hidden_pk.b:7 uniq_partial_hidden_pk.rowid:8!null uniq_partial_hidden_pk.crdb_internal_mvcc_timestamp:9 uniq_partial_hidden_pk.tableoid:10
+ │    │    │    └── flags: avoid-full-scan
  │    │    ├── scan other
  │    │    │    └── columns: k:11 v:12 w:13!null x:14 y:15 other.rowid:16!null other.crdb_internal_mvcc_timestamp:17 other.tableoid:18
  │    │    └── filters (true)
@@ -1222,7 +1242,7 @@ update uniq_partial_hidden_pk
                      │         └──  uniq_partial_hidden_pk.rowid:8 => rowid:26
                      ├── scan uniq_partial_hidden_pk
                      │    ├── columns: uniq_partial_hidden_pk.a:19 uniq_partial_hidden_pk.b:20 uniq_partial_hidden_pk.rowid:21!null
-                     │    └── flags: disabled not visible index feature
+                     │    └── flags: avoid-full-scan disabled not visible index feature
                      └── filters
                           ├── a:24 = uniq_partial_hidden_pk.a:19
                           ├── b:25 > 0
@@ -1273,15 +1293,16 @@ update uniq_computed_pk
  │    │    │    ├── columns: uniq_computed_pk.c_s:14 uniq_computed_pk.i:10!null uniq_computed_pk.s:11 uniq_computed_pk.d:12 uniq_computed_pk.c_i_expr:13!null uniq_computed_pk.c_d:15 uniq_computed_pk.c_d_expr:16 crdb_internal_mvcc_timestamp:17 tableoid:18
  │    │    │    ├── scan uniq_computed_pk
  │    │    │    │    ├── columns: uniq_computed_pk.i:10!null uniq_computed_pk.s:11 uniq_computed_pk.d:12 uniq_computed_pk.c_i_expr:13!null uniq_computed_pk.c_d:15 uniq_computed_pk.c_d_expr:16 crdb_internal_mvcc_timestamp:17 tableoid:18
- │    │    │    │    └── computed column expressions
- │    │    │    │         ├── uniq_computed_pk.c_i_expr:13
- │    │    │    │         │    └── CASE WHEN uniq_computed_pk.i:10 < 0 THEN 'foo' ELSE 'bar' END
- │    │    │    │         ├── uniq_computed_pk.c_s:14
- │    │    │    │         │    └── uniq_computed_pk.s:11
- │    │    │    │         ├── uniq_computed_pk.c_d:15
- │    │    │    │         │    └── uniq_computed_pk.d:12
- │    │    │    │         └── uniq_computed_pk.c_d_expr:16
- │    │    │    │              └── uniq_computed_pk.d:12::STRING
+ │    │    │    │    ├── computed column expressions
+ │    │    │    │    │    ├── uniq_computed_pk.c_i_expr:13
+ │    │    │    │    │    │    └── CASE WHEN uniq_computed_pk.i:10 < 0 THEN 'foo' ELSE 'bar' END
+ │    │    │    │    │    ├── uniq_computed_pk.c_s:14
+ │    │    │    │    │    │    └── uniq_computed_pk.s:11
+ │    │    │    │    │    ├── uniq_computed_pk.c_d:15
+ │    │    │    │    │    │    └── uniq_computed_pk.d:12
+ │    │    │    │    │    └── uniq_computed_pk.c_d_expr:16
+ │    │    │    │    │         └── uniq_computed_pk.d:12::STRING
+ │    │    │    │    └── flags: avoid-full-scan
  │    │    │    └── projections
  │    │    │         └── uniq_computed_pk.s:11 [as=uniq_computed_pk.c_s:14]
  │    │    └── projections
@@ -1320,7 +1341,7 @@ update uniq_computed_pk
                      │    │    │    │    └── uniq_computed_pk.d:44
                      │    │    │    └── uniq_computed_pk.c_d_expr:48
                      │    │    │         └── uniq_computed_pk.d:44::STRING
-                     │    │    └── flags: disabled not visible index feature
+                     │    │    └── flags: avoid-full-scan disabled not visible index feature
                      │    └── projections
                      │         └── uniq_computed_pk.s:43 [as=uniq_computed_pk.c_s:46]
                      └── filters

--- a/pkg/sql/opt/optbuilder/testdata/unique-checks-upsert
+++ b/pkg/sql/opt/optbuilder/testdata/unique-checks-upsert
@@ -56,7 +56,7 @@ upsert uniq
  │    │    │              └── column5:12
  │    │    ├── scan uniq
  │    │    │    ├── columns: uniq.k:13!null uniq.v:14 uniq.w:15 uniq.x:16 uniq.y:17 crdb_internal_mvcc_timestamp:18 tableoid:19
- │    │    │    └── flags: disabled not visible index feature
+ │    │    │    └── flags: avoid-full-scan disabled not visible index feature
  │    │    └── filters
  │    │         └── column1:8 = uniq.k:13
  │    └── projections
@@ -77,7 +77,7 @@ upsert uniq
       │              │         └──  column5:12 => y:32
       │              ├── scan uniq
       │              │    ├── columns: uniq.k:21!null uniq.v:22 uniq.w:23 uniq.x:24 uniq.y:25
-      │              │    └── flags: disabled not visible index feature
+      │              │    └── flags: avoid-full-scan disabled not visible index feature
       │              └── filters
       │                   ├── w:30 = uniq.w:23
       │                   └── k:28 != uniq.k:21
@@ -96,7 +96,7 @@ upsert uniq
                      │         └──  column5:12 => y:44
                      ├── scan uniq
                      │    ├── columns: uniq.k:33!null uniq.v:34 uniq.w:35 uniq.x:36 uniq.y:37
-                     │    └── flags: disabled not visible index feature
+                     │    └── flags: avoid-full-scan disabled not visible index feature
                      └── filters
                           ├── x:43 = uniq.x:36
                           ├── y:44 = uniq.y:37
@@ -149,7 +149,7 @@ upsert uniq
  │    │    │              └── y_default:12
  │    │    ├── scan uniq
  │    │    │    ├── columns: uniq.k:13!null uniq.v:14 uniq.w:15 uniq.x:16 uniq.y:17 crdb_internal_mvcc_timestamp:18 tableoid:19
- │    │    │    └── flags: disabled not visible index feature
+ │    │    │    └── flags: avoid-full-scan disabled not visible index feature
  │    │    └── filters
  │    │         └── column1:8 = uniq.k:13
  │    └── projections
@@ -172,7 +172,7 @@ upsert uniq
       │              │         └──  upsert_y:22 => y:34
       │              ├── scan uniq
       │              │    ├── columns: uniq.k:23!null uniq.v:24 uniq.w:25 uniq.x:26 uniq.y:27
-      │              │    └── flags: disabled not visible index feature
+      │              │    └── flags: avoid-full-scan disabled not visible index feature
       │              └── filters
       │                   ├── w:32 = uniq.w:25
       │                   └── k:30 != uniq.k:23
@@ -191,7 +191,7 @@ upsert uniq
                      │         └──  upsert_y:22 => y:46
                      ├── scan uniq
                      │    ├── columns: uniq.k:35!null uniq.v:36 uniq.w:37 uniq.x:38 uniq.y:39
-                     │    └── flags: disabled not visible index feature
+                     │    └── flags: avoid-full-scan disabled not visible index feature
                      └── filters
                           ├── x:45 = uniq.x:38
                           ├── y:46 = uniq.y:39
@@ -245,7 +245,7 @@ upsert uniq
  │    │    │              └── y_default:12
  │    │    ├── scan uniq
  │    │    │    ├── columns: uniq.k:13!null uniq.v:14 uniq.w:15 uniq.x:16 uniq.y:17 crdb_internal_mvcc_timestamp:18 tableoid:19
- │    │    │    └── flags: disabled not visible index feature
+ │    │    │    └── flags: avoid-full-scan disabled not visible index feature
  │    │    └── filters
  │    │         └── column1:8 = uniq.k:13
  │    └── projections
@@ -268,7 +268,7 @@ upsert uniq
       │              │         └──  upsert_y:22 => y:34
       │              ├── scan uniq
       │              │    ├── columns: uniq.k:23!null uniq.v:24 uniq.w:25 uniq.x:26 uniq.y:27
-      │              │    └── flags: disabled not visible index feature
+      │              │    └── flags: avoid-full-scan disabled not visible index feature
       │              └── filters
       │                   ├── w:32 = uniq.w:25
       │                   └── k:30 != uniq.k:23
@@ -287,7 +287,7 @@ upsert uniq
                      │         └──  upsert_y:22 => y:46
                      ├── scan uniq
                      │    ├── columns: uniq.k:35!null uniq.v:36 uniq.w:37 uniq.x:38 uniq.y:39
-                     │    └── flags: disabled not visible index feature
+                     │    └── flags: avoid-full-scan disabled not visible index feature
                      └── filters
                           ├── x:45 = uniq.x:38
                           ├── y:46 = uniq.y:39
@@ -343,7 +343,7 @@ upsert uniq
  │    │    │              └── y_default:17
  │    │    ├── scan uniq
  │    │    │    ├── columns: uniq.k:18!null uniq.v:19 uniq.w:20 uniq.x:21 uniq.y:22 uniq.crdb_internal_mvcc_timestamp:23 uniq.tableoid:24
- │    │    │    └── flags: disabled not visible index feature
+ │    │    │    └── flags: avoid-full-scan disabled not visible index feature
  │    │    └── filters
  │    │         └── other.k:8 = uniq.k:18
  │    └── projections
@@ -364,7 +364,7 @@ upsert uniq
       │              │         └──  y_default:17 => y:37
       │              ├── scan uniq
       │              │    ├── columns: uniq.k:26!null uniq.v:27 uniq.w:28 uniq.x:29 uniq.y:30
-      │              │    └── flags: disabled not visible index feature
+      │              │    └── flags: avoid-full-scan disabled not visible index feature
       │              └── filters
       │                   ├── w:35 = uniq.w:28
       │                   └── k:33 != uniq.k:26
@@ -383,7 +383,7 @@ upsert uniq
                      │         └──  y_default:17 => y:49
                      ├── scan uniq
                      │    ├── columns: uniq.k:38!null uniq.v:39 uniq.w:40 uniq.x:41 uniq.y:42
-                     │    └── flags: disabled not visible index feature
+                     │    └── flags: avoid-full-scan disabled not visible index feature
                      └── filters
                           ├── x:48 = uniq.x:41
                           ├── y:49 = uniq.y:42
@@ -432,7 +432,7 @@ upsert uniq
  │    │    │              └── column5:12
  │    │    ├── scan uniq
  │    │    │    ├── columns: uniq.k:13!null uniq.v:14 uniq.w:15 uniq.x:16 uniq.y:17 crdb_internal_mvcc_timestamp:18 tableoid:19
- │    │    │    └── flags: force-index=uniq_v_key disabled not visible index feature
+ │    │    │    └── flags: force-index=uniq_v_key avoid-full-scan disabled not visible index feature
  │    │    └── filters
  │    │         └── column1:8 = uniq.k:13
  │    └── projections
@@ -453,7 +453,7 @@ upsert uniq
       │              │         └──  column5:12 => y:32
       │              ├── scan uniq
       │              │    ├── columns: uniq.k:21!null uniq.v:22 uniq.w:23 uniq.x:24 uniq.y:25
-      │              │    └── flags: disabled not visible index feature
+      │              │    └── flags: avoid-full-scan disabled not visible index feature
       │              └── filters
       │                   ├── w:30 = uniq.w:23
       │                   └── k:28 != uniq.k:21
@@ -472,7 +472,7 @@ upsert uniq
                      │         └──  column5:12 => y:44
                      ├── scan uniq
                      │    ├── columns: uniq.k:33!null uniq.v:34 uniq.w:35 uniq.x:36 uniq.y:37
-                     │    └── flags: disabled not visible index feature
+                     │    └── flags: avoid-full-scan disabled not visible index feature
                      └── filters
                           ├── x:43 = uniq.x:36
                           ├── y:44 = uniq.y:37
@@ -526,7 +526,7 @@ upsert uniq
  │    │    │    │              └── y_default:11
  │    │    │    ├── scan uniq
  │    │    │    │    ├── columns: uniq.k:12!null uniq.v:13 uniq.w:14 uniq.x:15 uniq.y:16 crdb_internal_mvcc_timestamp:17 tableoid:18
- │    │    │    │    └── flags: disabled not visible index feature
+ │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
  │    │    │    └── filters
  │    │    │         └── column1:8 = uniq.k:12
  │    │    └── projections
@@ -553,7 +553,7 @@ upsert uniq
       │              │         └──  upsert_y:24 => y:36
       │              ├── scan uniq
       │              │    ├── columns: uniq.k:25!null uniq.v:26 uniq.w:27 uniq.x:28 uniq.y:29
-      │              │    └── flags: disabled not visible index feature
+      │              │    └── flags: avoid-full-scan disabled not visible index feature
       │              └── filters
       │                   ├── w:34 = uniq.w:27
       │                   └── k:32 != uniq.k:25
@@ -572,7 +572,7 @@ upsert uniq
                      │         └──  upsert_y:24 => y:48
                      ├── scan uniq
                      │    ├── columns: uniq.k:37!null uniq.v:38 uniq.w:39 uniq.x:40 uniq.y:41
-                     │    └── flags: disabled not visible index feature
+                     │    └── flags: avoid-full-scan disabled not visible index feature
                      └── filters
                           ├── x:47 = uniq.x:40
                           ├── y:48 = uniq.y:41
@@ -625,7 +625,7 @@ upsert uniq
  │    │    │    │              └── y_default:17
  │    │    │    ├── scan uniq
  │    │    │    │    ├── columns: uniq.k:18!null uniq.v:19 uniq.w:20 uniq.x:21 uniq.y:22 uniq.crdb_internal_mvcc_timestamp:23 uniq.tableoid:24
- │    │    │    │    └── flags: disabled not visible index feature
+ │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
  │    │    │    └── filters
  │    │    │         └── other.k:8 = uniq.k:18
  │    │    └── projections
@@ -652,7 +652,7 @@ upsert uniq
       │              │         └──  upsert_y:30 => y:42
       │              ├── scan uniq
       │              │    ├── columns: uniq.k:31!null uniq.v:32 uniq.w:33 uniq.x:34 uniq.y:35
-      │              │    └── flags: disabled not visible index feature
+      │              │    └── flags: avoid-full-scan disabled not visible index feature
       │              └── filters
       │                   ├── w:40 = uniq.w:33
       │                   └── k:38 != uniq.k:31
@@ -671,7 +671,7 @@ upsert uniq
                      │         └──  upsert_y:30 => y:54
                      ├── scan uniq
                      │    ├── columns: uniq.k:43!null uniq.v:44 uniq.w:45 uniq.x:46 uniq.y:47
-                     │    └── flags: disabled not visible index feature
+                     │    └── flags: avoid-full-scan disabled not visible index feature
                      └── filters
                           ├── x:53 = uniq.x:46
                           ├── y:54 = uniq.y:47
@@ -725,7 +725,7 @@ upsert uniq
  │    │    │    │              └── y_default:12
  │    │    │    ├── scan uniq
  │    │    │    │    ├── columns: uniq.k:13!null uniq.v:14 uniq.w:15 uniq.x:16 uniq.y:17 crdb_internal_mvcc_timestamp:18 tableoid:19
- │    │    │    │    └── flags: disabled not visible index feature
+ │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
  │    │    │    └── filters
  │    │    │         └── column3:10 = uniq.w:15
  │    │    └── projections
@@ -752,7 +752,7 @@ upsert uniq
       │              │         └──  upsert_y:25 => y:37
       │              ├── scan uniq
       │              │    ├── columns: uniq.k:26!null uniq.v:27 uniq.w:28 uniq.x:29 uniq.y:30
-      │              │    └── flags: disabled not visible index feature
+      │              │    └── flags: avoid-full-scan disabled not visible index feature
       │              └── filters
       │                   ├── w:35 = uniq.w:28
       │                   └── k:33 != uniq.k:26
@@ -771,7 +771,7 @@ upsert uniq
                      │         └──  upsert_y:25 => y:49
                      ├── scan uniq
                      │    ├── columns: uniq.k:38!null uniq.v:39 uniq.w:40 uniq.x:41 uniq.y:42
-                     │    └── flags: disabled not visible index feature
+                     │    └── flags: avoid-full-scan disabled not visible index feature
                      └── filters
                           ├── x:48 = uniq.x:41
                           ├── y:49 = uniq.y:42
@@ -817,7 +817,7 @@ upsert uniq
  │    │    │    │              └── column3:10
  │    │    │    ├── scan uniq
  │    │    │    │    ├── columns: uniq.k:13!null uniq.v:14 uniq.w:15 uniq.x:16 uniq.y:17 crdb_internal_mvcc_timestamp:18 tableoid:19
- │    │    │    │    └── flags: disabled not visible index feature
+ │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
  │    │    │    └── filters
  │    │    │         ├── column4:11 = uniq.x:16
  │    │    │         └── column5:12 = uniq.y:17
@@ -845,7 +845,7 @@ upsert uniq
                      │         └──  upsert_y:25 => y:37
                      ├── scan uniq
                      │    ├── columns: uniq.k:26!null uniq.v:27 uniq.w:28 uniq.x:29 uniq.y:30
-                     │    └── flags: disabled not visible index feature
+                     │    └── flags: avoid-full-scan disabled not visible index feature
                      └── filters
                           ├── w:35 = uniq.w:28
                           └── k:33 != uniq.k:26
@@ -909,7 +909,7 @@ upsert uniq_overlaps_pk
       │              │         └──  column4:10 => d:20
       │              ├── scan uniq_overlaps_pk
       │              │    ├── columns: uniq_overlaps_pk.a:11!null uniq_overlaps_pk.b:12!null uniq_overlaps_pk.c:13 uniq_overlaps_pk.d:14
-      │              │    └── flags: disabled not visible index feature
+      │              │    └── flags: avoid-full-scan disabled not visible index feature
       │              └── filters
       │                   ├── b:18 = uniq_overlaps_pk.b:12
       │                   ├── c:19 = uniq_overlaps_pk.c:13
@@ -928,7 +928,7 @@ upsert uniq_overlaps_pk
       │              │         └──  column4:10 => d:30
       │              ├── scan uniq_overlaps_pk
       │              │    ├── columns: uniq_overlaps_pk.a:21!null uniq_overlaps_pk.b:22!null uniq_overlaps_pk.c:23 uniq_overlaps_pk.d:24
-      │              │    └── flags: disabled not visible index feature
+      │              │    └── flags: avoid-full-scan disabled not visible index feature
       │              └── filters
       │                   ├── a:27 = uniq_overlaps_pk.a:21
       │                   └── b:28 != uniq_overlaps_pk.b:22
@@ -946,7 +946,7 @@ upsert uniq_overlaps_pk
                      │         └──  column4:10 => d:40
                      ├── scan uniq_overlaps_pk
                      │    ├── columns: uniq_overlaps_pk.a:31!null uniq_overlaps_pk.b:32!null uniq_overlaps_pk.c:33 uniq_overlaps_pk.d:34
-                     │    └── flags: disabled not visible index feature
+                     │    └── flags: avoid-full-scan disabled not visible index feature
                      └── filters
                           ├── c:39 = uniq_overlaps_pk.c:33
                           ├── d:40 = uniq_overlaps_pk.d:34
@@ -990,7 +990,7 @@ upsert uniq_overlaps_pk
       │              │         └──  d_default:15 => d:25
       │              ├── scan uniq_overlaps_pk
       │              │    ├── columns: uniq_overlaps_pk.a:16!null uniq_overlaps_pk.b:17!null uniq_overlaps_pk.c:18 uniq_overlaps_pk.d:19
-      │              │    └── flags: disabled not visible index feature
+      │              │    └── flags: avoid-full-scan disabled not visible index feature
       │              └── filters
       │                   ├── b:23 = uniq_overlaps_pk.b:17
       │                   ├── c:24 = uniq_overlaps_pk.c:18
@@ -1009,7 +1009,7 @@ upsert uniq_overlaps_pk
                      │         └──  d_default:15 => d:35
                      ├── scan uniq_overlaps_pk
                      │    ├── columns: uniq_overlaps_pk.a:26!null uniq_overlaps_pk.b:27!null uniq_overlaps_pk.c:28 uniq_overlaps_pk.d:29
-                     │    └── flags: disabled not visible index feature
+                     │    └── flags: avoid-full-scan disabled not visible index feature
                      └── filters
                           ├── a:32 = uniq_overlaps_pk.a:26
                           └── b:33 != uniq_overlaps_pk.b:27
@@ -1054,7 +1054,7 @@ upsert uniq_overlaps_pk
  │    │    │    │              └── column4:10
  │    │    │    ├── scan uniq_overlaps_pk
  │    │    │    │    ├── columns: uniq_overlaps_pk.a:11!null uniq_overlaps_pk.b:12!null uniq_overlaps_pk.c:13 uniq_overlaps_pk.d:14 crdb_internal_mvcc_timestamp:15 tableoid:16
- │    │    │    │    └── flags: disabled not visible index feature
+ │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
  │    │    │    └── filters
  │    │    │         └── column1:7 = uniq_overlaps_pk.a:11
  │    │    └── projections
@@ -1079,7 +1079,7 @@ upsert uniq_overlaps_pk
       │              │         └──  upsert_d:21 => d:31
       │              ├── scan uniq_overlaps_pk
       │              │    ├── columns: uniq_overlaps_pk.a:22!null uniq_overlaps_pk.b:23!null uniq_overlaps_pk.c:24 uniq_overlaps_pk.d:25
-      │              │    └── flags: disabled not visible index feature
+      │              │    └── flags: avoid-full-scan disabled not visible index feature
       │              └── filters
       │                   ├── b:29 = uniq_overlaps_pk.b:23
       │                   ├── c:30 = uniq_overlaps_pk.c:24
@@ -1098,7 +1098,7 @@ upsert uniq_overlaps_pk
       │              │         └──  upsert_d:21 => d:41
       │              ├── scan uniq_overlaps_pk
       │              │    ├── columns: uniq_overlaps_pk.a:32!null uniq_overlaps_pk.b:33!null uniq_overlaps_pk.c:34 uniq_overlaps_pk.d:35
-      │              │    └── flags: disabled not visible index feature
+      │              │    └── flags: avoid-full-scan disabled not visible index feature
       │              └── filters
       │                   ├── a:38 = uniq_overlaps_pk.a:32
       │                   └── b:39 != uniq_overlaps_pk.b:33
@@ -1116,7 +1116,7 @@ upsert uniq_overlaps_pk
                      │         └──  upsert_d:21 => d:51
                      ├── scan uniq_overlaps_pk
                      │    ├── columns: uniq_overlaps_pk.a:42!null uniq_overlaps_pk.b:43!null uniq_overlaps_pk.c:44 uniq_overlaps_pk.d:45
-                     │    └── flags: disabled not visible index feature
+                     │    └── flags: avoid-full-scan disabled not visible index feature
                      └── filters
                           ├── c:50 = uniq_overlaps_pk.c:44
                           ├── d:51 = uniq_overlaps_pk.d:45
@@ -1159,7 +1159,7 @@ upsert uniq_overlaps_pk
  │    │    │    │              └── column2:8
  │    │    │    ├── scan uniq_overlaps_pk
  │    │    │    │    ├── columns: uniq_overlaps_pk.a:11!null uniq_overlaps_pk.b:12!null uniq_overlaps_pk.c:13 uniq_overlaps_pk.d:14 crdb_internal_mvcc_timestamp:15 tableoid:16
- │    │    │    │    └── flags: disabled not visible index feature
+ │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
  │    │    │    └── filters
  │    │    │         ├── column3:9 = uniq_overlaps_pk.c:13
  │    │    │         └── column4:10 = uniq_overlaps_pk.d:14
@@ -1185,7 +1185,7 @@ upsert uniq_overlaps_pk
       │              │         └──  upsert_d:21 => d:31
       │              ├── scan uniq_overlaps_pk
       │              │    ├── columns: uniq_overlaps_pk.a:22!null uniq_overlaps_pk.b:23!null uniq_overlaps_pk.c:24 uniq_overlaps_pk.d:25
-      │              │    └── flags: disabled not visible index feature
+      │              │    └── flags: avoid-full-scan disabled not visible index feature
       │              └── filters
       │                   ├── b:29 = uniq_overlaps_pk.b:23
       │                   ├── c:30 = uniq_overlaps_pk.c:24
@@ -1204,7 +1204,7 @@ upsert uniq_overlaps_pk
                      │         └──  upsert_d:21 => d:41
                      ├── scan uniq_overlaps_pk
                      │    ├── columns: uniq_overlaps_pk.a:32!null uniq_overlaps_pk.b:33!null uniq_overlaps_pk.c:34 uniq_overlaps_pk.d:35
-                     │    └── flags: disabled not visible index feature
+                     │    └── flags: avoid-full-scan disabled not visible index feature
                      └── filters
                           ├── a:38 = uniq_overlaps_pk.a:32
                           └── b:39 != uniq_overlaps_pk.b:33
@@ -1269,7 +1269,7 @@ upsert uniq_hidden_pk
  │    │    │              └── c_default:11
  │    │    ├── scan uniq_hidden_pk
  │    │    │    ├── columns: uniq_hidden_pk.a:13 uniq_hidden_pk.b:14 uniq_hidden_pk.c:15 uniq_hidden_pk.d:16 uniq_hidden_pk.rowid:17!null crdb_internal_mvcc_timestamp:18 tableoid:19
- │    │    │    └── flags: disabled not visible index feature
+ │    │    │    └── flags: avoid-full-scan disabled not visible index feature
  │    │    └── filters
  │    │         └── rowid_default:12 = uniq_hidden_pk.rowid:17
  │    └── projections
@@ -1291,7 +1291,7 @@ upsert uniq_hidden_pk
       │              │         └──  upsert_rowid:21 => rowid:33
       │              ├── scan uniq_hidden_pk
       │              │    ├── columns: uniq_hidden_pk.a:22 uniq_hidden_pk.b:23 uniq_hidden_pk.c:24 uniq_hidden_pk.d:25 uniq_hidden_pk.rowid:26!null
-      │              │    └── flags: disabled not visible index feature
+      │              │    └── flags: avoid-full-scan disabled not visible index feature
       │              └── filters
       │                   ├── b:30 = uniq_hidden_pk.b:23
       │                   ├── c:31 = uniq_hidden_pk.c:24
@@ -1311,7 +1311,7 @@ upsert uniq_hidden_pk
       │              │         └──  upsert_rowid:21 => rowid:45
       │              ├── scan uniq_hidden_pk
       │              │    ├── columns: uniq_hidden_pk.a:34 uniq_hidden_pk.b:35 uniq_hidden_pk.c:36 uniq_hidden_pk.d:37 uniq_hidden_pk.rowid:38!null
-      │              │    └── flags: disabled not visible index feature
+      │              │    └── flags: avoid-full-scan disabled not visible index feature
       │              └── filters
       │                   ├── a:41 = uniq_hidden_pk.a:34
       │                   ├── b:42 = uniq_hidden_pk.b:35
@@ -1332,7 +1332,7 @@ upsert uniq_hidden_pk
                      │         └──  upsert_rowid:21 => rowid:57
                      ├── scan uniq_hidden_pk
                      │    ├── columns: uniq_hidden_pk.a:46 uniq_hidden_pk.b:47 uniq_hidden_pk.c:48 uniq_hidden_pk.d:49 uniq_hidden_pk.rowid:50!null
-                     │    └── flags: disabled not visible index feature
+                     │    └── flags: avoid-full-scan disabled not visible index feature
                      └── filters
                           ├── a:53 = uniq_hidden_pk.a:46
                           └── rowid:57 != uniq_hidden_pk.rowid:50
@@ -1375,7 +1375,7 @@ upsert uniq_hidden_pk
       │              │         └──  rowid_default:16 => rowid:28
       │              ├── scan uniq_hidden_pk
       │              │    ├── columns: uniq_hidden_pk.a:17 uniq_hidden_pk.b:18 uniq_hidden_pk.c:19 uniq_hidden_pk.d:20 uniq_hidden_pk.rowid:21!null
-      │              │    └── flags: disabled not visible index feature
+      │              │    └── flags: avoid-full-scan disabled not visible index feature
       │              └── filters
       │                   ├── b:25 = uniq_hidden_pk.b:18
       │                   ├── c:26 = uniq_hidden_pk.c:19
@@ -1395,7 +1395,7 @@ upsert uniq_hidden_pk
       │              │         └──  rowid_default:16 => rowid:40
       │              ├── scan uniq_hidden_pk
       │              │    ├── columns: uniq_hidden_pk.a:29 uniq_hidden_pk.b:30 uniq_hidden_pk.c:31 uniq_hidden_pk.d:32 uniq_hidden_pk.rowid:33!null
-      │              │    └── flags: disabled not visible index feature
+      │              │    └── flags: avoid-full-scan disabled not visible index feature
       │              └── filters
       │                   ├── a:36 = uniq_hidden_pk.a:29
       │                   ├── b:37 = uniq_hidden_pk.b:30
@@ -1416,7 +1416,7 @@ upsert uniq_hidden_pk
                      │         └──  rowid_default:16 => rowid:52
                      ├── scan uniq_hidden_pk
                      │    ├── columns: uniq_hidden_pk.a:41 uniq_hidden_pk.b:42 uniq_hidden_pk.c:43 uniq_hidden_pk.d:44 uniq_hidden_pk.rowid:45!null
-                     │    └── flags: disabled not visible index feature
+                     │    └── flags: avoid-full-scan disabled not visible index feature
                      └── filters
                           ├── a:48 = uniq_hidden_pk.a:41
                           └── rowid:52 != uniq_hidden_pk.rowid:45
@@ -1463,7 +1463,7 @@ upsert uniq_hidden_pk
  │    │    │    │              └── rowid_default:12
  │    │    │    ├── scan uniq_hidden_pk
  │    │    │    │    ├── columns: uniq_hidden_pk.a:13 uniq_hidden_pk.b:14 uniq_hidden_pk.c:15 uniq_hidden_pk.d:16 uniq_hidden_pk.rowid:17!null crdb_internal_mvcc_timestamp:18 tableoid:19
- │    │    │    │    └── flags: disabled not visible index feature
+ │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
  │    │    │    └── filters
  │    │    │         ├── column1:8 = uniq_hidden_pk.a:13
  │    │    │         ├── column2:9 = uniq_hidden_pk.b:14
@@ -1492,7 +1492,7 @@ upsert uniq_hidden_pk
       │              │         └──  upsert_rowid:25 => rowid:37
       │              ├── scan uniq_hidden_pk
       │              │    ├── columns: uniq_hidden_pk.a:26 uniq_hidden_pk.b:27 uniq_hidden_pk.c:28 uniq_hidden_pk.d:29 uniq_hidden_pk.rowid:30!null
-      │              │    └── flags: disabled not visible index feature
+      │              │    └── flags: avoid-full-scan disabled not visible index feature
       │              └── filters
       │                   ├── b:34 = uniq_hidden_pk.b:27
       │                   ├── c:35 = uniq_hidden_pk.c:28
@@ -1512,7 +1512,7 @@ upsert uniq_hidden_pk
       │              │         └──  upsert_rowid:25 => rowid:49
       │              ├── scan uniq_hidden_pk
       │              │    ├── columns: uniq_hidden_pk.a:38 uniq_hidden_pk.b:39 uniq_hidden_pk.c:40 uniq_hidden_pk.d:41 uniq_hidden_pk.rowid:42!null
-      │              │    └── flags: disabled not visible index feature
+      │              │    └── flags: avoid-full-scan disabled not visible index feature
       │              └── filters
       │                   ├── a:45 = uniq_hidden_pk.a:38
       │                   ├── b:46 = uniq_hidden_pk.b:39
@@ -1533,7 +1533,7 @@ upsert uniq_hidden_pk
                      │         └──  upsert_rowid:25 => rowid:61
                      ├── scan uniq_hidden_pk
                      │    ├── columns: uniq_hidden_pk.a:50 uniq_hidden_pk.b:51 uniq_hidden_pk.c:52 uniq_hidden_pk.d:53 uniq_hidden_pk.rowid:54!null
-                     │    └── flags: disabled not visible index feature
+                     │    └── flags: avoid-full-scan disabled not visible index feature
                      └── filters
                           ├── a:57 = uniq_hidden_pk.a:50
                           └── rowid:61 != uniq_hidden_pk.rowid:54
@@ -1591,7 +1591,7 @@ upsert uniq_fk_parent
  │    │    │              └── column1:5
  │    │    ├── scan uniq_fk_parent
  │    │    │    ├── columns: uniq_fk_parent.a:7 uniq_fk_parent.rowid:8!null uniq_fk_parent.crdb_internal_mvcc_timestamp:9 uniq_fk_parent.tableoid:10
- │    │    │    └── flags: disabled not visible index feature
+ │    │    │    └── flags: avoid-full-scan disabled not visible index feature
  │    │    └── filters
  │    │         └── rowid_default:6 = uniq_fk_parent.rowid:8
  │    └── projections
@@ -1609,7 +1609,7 @@ upsert uniq_fk_parent
  │                   │         └──  upsert_rowid:11 => rowid:17
  │                   ├── scan uniq_fk_parent
  │                   │    ├── columns: uniq_fk_parent.a:12 uniq_fk_parent.rowid:13!null
- │                   │    └── flags: disabled not visible index feature
+ │                   │    └── flags: avoid-full-scan disabled not visible index feature
  │                   └── filters
  │                        ├── a:16 = uniq_fk_parent.a:12
  │                        └── rowid:17 != uniq_fk_parent.rowid:13
@@ -1631,7 +1631,7 @@ upsert uniq_fk_parent
                 │              └──  column1:5 => a:19
                 ├── scan uniq_fk_child
                 │    ├── columns: uniq_fk_child.a:21
-                │    └── flags: disabled not visible index feature
+                │    └── flags: avoid-full-scan disabled not visible index feature
                 └── filters
                      └── a:18 = uniq_fk_child.a:21
 
@@ -1659,7 +1659,7 @@ upsert uniq_fk_child
                 │         └──  column2:6 => a:7
                 ├── scan uniq_fk_parent
                 │    ├── columns: uniq_fk_parent.a:8
-                │    └── flags: disabled not visible index feature
+                │    └── flags: avoid-full-scan disabled not visible index feature
                 └── filters
                      └── a:7 = uniq_fk_parent.a:8
 
@@ -1714,7 +1714,7 @@ upsert t
  │    │    │    │    │    ├── partial index predicates
  │    │    │    │    │    │    └── i1: filters
  │    │    │    │    │    │         └── t.i:7 > 0
- │    │    │    │    │    └── flags: disabled not visible index feature
+ │    │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
  │    │    │    │    └── filters
  │    │    │    │         └── column1:5 = t.i:7
  │    │    │    └── projections
@@ -1741,7 +1741,7 @@ upsert t
                      │    ├── partial index predicates
                      │    │    └── i1: filters
                      │    │         └── t.i:16 > 0
-                     │    └── flags: disabled not visible index feature
+                     │    └── flags: avoid-full-scan disabled not visible index feature
                      └── filters
                           ├── i:20 = t.i:16
                           └── rowid:21 != t.rowid:17
@@ -1787,7 +1787,7 @@ upsert uniq
  │    │    │    │              └── column5:12
  │    │    │    ├── scan uniq
  │    │    │    │    ├── columns: uniq.k:13!null uniq.v:14 uniq.w:15 uniq.x:16 uniq.y:17 crdb_internal_mvcc_timestamp:18 tableoid:19
- │    │    │    │    └── flags: disabled not visible index feature
+ │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
  │    │    │    └── filters
  │    │    │         └── column3:10 = uniq.w:15
  │    │    └── projections
@@ -1814,7 +1814,7 @@ upsert uniq
                      │         └──  upsert_y:25 => y:37
                      ├── scan uniq
                      │    ├── columns: uniq.k:26!null uniq.v:27 uniq.w:28 uniq.x:29 uniq.y:30
-                     │    └── flags: disabled not visible index feature
+                     │    └── flags: avoid-full-scan disabled not visible index feature
                      └── filters
                           ├── x:36 = uniq.x:29
                           ├── y:37 = uniq.y:30
@@ -1858,7 +1858,7 @@ upsert uniq_partial
                      │         └──  column3:8 => b:16
                      ├── scan uniq_partial
                      │    ├── columns: uniq_partial.k:9!null uniq_partial.a:10 uniq_partial.b:11
-                     │    └── flags: disabled not visible index feature
+                     │    └── flags: avoid-full-scan disabled not visible index feature
                      └── filters
                           ├── a:15 = uniq_partial.a:10
                           ├── b:16 > 0
@@ -1909,7 +1909,7 @@ upsert uniq_partial
                      │         └──  w:8 => b:21
                      ├── scan uniq_partial
                      │    ├── columns: uniq_partial.k:14!null uniq_partial.a:15 uniq_partial.b:16
-                     │    └── flags: disabled not visible index feature
+                     │    └── flags: avoid-full-scan disabled not visible index feature
                      └── filters
                           ├── a:20 = uniq_partial.a:15
                           ├── b:21 > 0
@@ -1961,7 +1961,7 @@ upsert uniq_partial
  │    │    │    │    ├── columns: uniq_partial.k:10!null uniq_partial.a:11 uniq_partial.b:12!null crdb_internal_mvcc_timestamp:13 tableoid:14
  │    │    │    │    ├── scan uniq_partial
  │    │    │    │    │    ├── columns: uniq_partial.k:10!null uniq_partial.a:11 uniq_partial.b:12 crdb_internal_mvcc_timestamp:13 tableoid:14
- │    │    │    │    │    └── flags: disabled not visible index feature
+ │    │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
  │    │    │    │    └── filters
  │    │    │    │         └── uniq_partial.b:12 > 0
  │    │    │    └── filters
@@ -1987,7 +1987,7 @@ upsert uniq_partial
                      │         └──  upsert_b:18 => b:26
                      ├── scan uniq_partial
                      │    ├── columns: uniq_partial.k:19!null uniq_partial.a:20 uniq_partial.b:21
-                     │    └── flags: disabled not visible index feature
+                     │    └── flags: avoid-full-scan disabled not visible index feature
                      └── filters
                           ├── a:25 = uniq_partial.a:20
                           ├── b:26 > 0
@@ -2052,7 +2052,7 @@ upsert uniq_partial_constraint_and_index
  │    │    │    │    ├── columns: uniq_partial_constraint_and_index.k:10!null uniq_partial_constraint_and_index.a:11 uniq_partial_constraint_and_index.b:12
  │    │    │    │    ├── partial index predicates
  │    │    │    │    │    └── uniq_partial_constraint_and_index_a_key: filters (true)
- │    │    │    │    └── flags: disabled not visible index feature
+ │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
  │    │    │    └── filters
  │    │    │         └── uniq_partial_constraint_and_index.a:11 = 1
  │    │    └── filters (true)
@@ -2083,7 +2083,7 @@ upsert uniq_partial_constraint_and_index
                      │    │    ├── columns: uniq_partial_constraint_and_index.k:20!null uniq_partial_constraint_and_index.a:21 uniq_partial_constraint_and_index.b:22
                      │    │    ├── partial index predicates
                      │    │    │    └── uniq_partial_constraint_and_index_a_key: filters (true)
-                     │    │    └── flags: disabled not visible index feature
+                     │    │    └── flags: avoid-full-scan disabled not visible index feature
                      │    └── filters
                      │         └── uniq_partial_constraint_and_index.b:22 > 10
                      └── filters
@@ -2135,7 +2135,7 @@ upsert uniq_constraint_and_partial_index
  │    │    │    │    ├── partial index predicates
  │    │    │    │    │    └── uniq_constraint_and_partial_index_a_key: filters
  │    │    │    │    │         └── uniq_constraint_and_partial_index.b:12 > 0
- │    │    │    │    └── flags: disabled not visible index feature
+ │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
  │    │    │    └── filters
  │    │    │         └── uniq_constraint_and_partial_index.a:11 = 1
  │    │    └── filters (true)
@@ -2160,7 +2160,7 @@ upsert uniq_constraint_and_partial_index
                      │    ├── partial index predicates
                      │    │    └── uniq_constraint_and_partial_index_a_key: filters
                      │    │         └── uniq_constraint_and_partial_index.b:23 > 0
-                     │    └── flags: disabled not visible index feature
+                     │    └── flags: avoid-full-scan disabled not visible index feature
                      └── filters
                           ├── a:27 = uniq_constraint_and_partial_index.a:22
                           └── k:26 != uniq_constraint_and_partial_index.k:21
@@ -2265,7 +2265,7 @@ upsert uniq_computed_pk
  │    │    │    │    │    │    │    └── uniq_computed_pk.d:17
  │    │    │    │    │    │    └── uniq_computed_pk.c_d_expr:21
  │    │    │    │    │    │         └── uniq_computed_pk.d:17::STRING
- │    │    │    │    │    └── flags: disabled not visible index feature
+ │    │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
  │    │    │    │    └── projections
  │    │    │    │         └── uniq_computed_pk.s:16 [as=uniq_computed_pk.c_s:19]
  │    │    │    └── filters
@@ -2305,7 +2305,7 @@ upsert uniq_computed_pk
                      │    │    │    │    └── uniq_computed_pk.d:47
                      │    │    │    └── uniq_computed_pk.c_d_expr:51
                      │    │    │         └── uniq_computed_pk.d:47::STRING
-                     │    │    └── flags: disabled not visible index feature
+                     │    │    └── flags: avoid-full-scan disabled not visible index feature
                      │    └── projections
                      │         └── uniq_computed_pk.s:46 [as=uniq_computed_pk.c_s:49]
                      └── filters

--- a/pkg/sql/opt/optbuilder/testdata/update
+++ b/pkg/sql/opt/optbuilder/testdata/update
@@ -119,11 +119,12 @@ update abcde
       │    │    ├── columns: a:9!null b:10 c:11 d:12 e:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16
       │    │    ├── scan abcde
       │    │    │    ├── columns: a:9!null b:10 c:11 d:12 e:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16
-      │    │    │    └── computed column expressions
-      │    │    │         ├── d:12
-      │    │    │         │    └── (b:10 + c:11) + 1
-      │    │    │         └── e:13
-      │    │    │              └── a:9
+      │    │    │    ├── computed column expressions
+      │    │    │    │    ├── d:12
+      │    │    │    │    │    └── (b:10 + c:11) + 1
+      │    │    │    │    └── e:13
+      │    │    │    │         └── a:9
+      │    │    │    └── flags: avoid-full-scan
       │    │    └── filters
       │    │         └── a:9 = 1
       │    └── projections
@@ -151,11 +152,12 @@ update abcde
       │    ├── columns: a_new:17!null b_new:18!null c_new:19!null rowid_new:20!null a:9!null b:10 c:11 d:12 e:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16
       │    ├── scan abcde
       │    │    ├── columns: a:9!null b:10 c:11 d:12 e:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16
-      │    │    └── computed column expressions
-      │    │         ├── d:12
-      │    │         │    └── (b:10 + c:11) + 1
-      │    │         └── e:13
-      │    │              └── a:9
+      │    │    ├── computed column expressions
+      │    │    │    ├── d:12
+      │    │    │    │    └── (b:10 + c:11) + 1
+      │    │    │    └── e:13
+      │    │    │         └── a:9
+      │    │    └── flags: avoid-full-scan
       │    └── projections
       │         ├── 1 [as=a_new:17]
       │         ├── 2 [as=b_new:18]
@@ -184,11 +186,12 @@ update abcde
       │    ├── columns: rowid_new:17!null c_new:18!null b_new:19!null a_new:20!null a:9!null b:10 c:11 d:12 e:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16
       │    ├── scan abcde
       │    │    ├── columns: a:9!null b:10 c:11 d:12 e:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16
-      │    │    └── computed column expressions
-      │    │         ├── d:12
-      │    │         │    └── (b:10 + c:11) + 1
-      │    │         └── e:13
-      │    │              └── a:9
+      │    │    ├── computed column expressions
+      │    │    │    ├── d:12
+      │    │    │    │    └── (b:10 + c:11) + 1
+      │    │    │    └── e:13
+      │    │    │         └── a:9
+      │    │    └── flags: avoid-full-scan
       │    └── projections
       │         ├── 1 [as=rowid_new:17]
       │         ├── 2 [as=c_new:18]
@@ -217,11 +220,12 @@ update abcde
       │    ├── columns: a_new:17 a:9!null b:10 c:11 d:12 e:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16
       │    ├── scan abcde
       │    │    ├── columns: a:9!null b:10 c:11 d:12 e:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16
-      │    │    └── computed column expressions
-      │    │         ├── d:12
-      │    │         │    └── (b:10 + c:11) + 1
-      │    │         └── e:13
-      │    │              └── a:9
+      │    │    ├── computed column expressions
+      │    │    │    ├── d:12
+      │    │    │    │    └── (b:10 + c:11) + 1
+      │    │    │    └── e:13
+      │    │    │         └── a:9
+      │    │    └── flags: avoid-full-scan
       │    └── projections
       │         └── NULL::INT8 [as=a_new:17]
       └── projections
@@ -247,11 +251,12 @@ update abcde
       │    │    ├── columns: a:9!null b:10!null c:11 d:12 e:13!null rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16
       │    │    ├── scan abcde
       │    │    │    ├── columns: a:9!null b:10 c:11 d:12 e:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16
-      │    │    │    └── computed column expressions
-      │    │    │         ├── d:12
-      │    │    │         │    └── (b:10 + c:11) + 1
-      │    │    │         └── e:13
-      │    │    │              └── a:9
+      │    │    │    ├── computed column expressions
+      │    │    │    │    ├── d:12
+      │    │    │    │    │    └── (b:10 + c:11) + 1
+      │    │    │    │    └── e:13
+      │    │    │    │         └── a:9
+      │    │    │    └── flags: avoid-full-scan
       │    │    └── filters
       │    │         └── b:10 > e:13
       │    └── projections
@@ -276,11 +281,12 @@ update abcde [as=foo]
       ├── columns: d_comp:17 a:9!null b:10 c:11 d:12 e:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16
       ├── scan abcde [as=foo]
       │    ├── columns: a:9!null b:10 c:11 d:12 e:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16
-      │    └── computed column expressions
-      │         ├── d:12
-      │         │    └── (b:10 + c:11) + 1
-      │         └── e:13
-      │              └── a:9
+      │    ├── computed column expressions
+      │    │    ├── d:12
+      │    │    │    └── (b:10 + c:11) + 1
+      │    │    └── e:13
+      │    │         └── a:9
+      │    └── flags: avoid-full-scan
       └── projections
            └── (c:11 + c:11) + 1 [as=d_comp:17]
 
@@ -309,11 +315,12 @@ update abcde
       │    │    │         ├── columns: a:9!null b:10 c:11 d:12 e:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16
       │    │    │         ├── scan abcde
       │    │    │         │    ├── columns: a:9!null b:10 c:11 d:12 e:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16
-      │    │    │         │    └── computed column expressions
-      │    │    │         │         ├── d:12
-      │    │    │         │         │    └── (b:10 + c:11) + 1
-      │    │    │         │         └── e:13
-      │    │    │         │              └── a:9
+      │    │    │         │    ├── computed column expressions
+      │    │    │         │    │    ├── d:12
+      │    │    │         │    │    │    └── (b:10 + c:11) + 1
+      │    │    │         │    │    └── e:13
+      │    │    │         │    │         └── a:9
+      │    │    │         │    └── flags: avoid-full-scan
       │    │    │         └── filters
       │    │    │              └── a:9 > 0
       │    │    └── 10
@@ -347,7 +354,7 @@ update xyzw
       │    ├── columns: x:7!null y:8 z:9!null w:10 crdb_internal_mvcc_timestamp:11 tableoid:12
       │    ├── scan xyzw
       │    │    ├── columns: x:7!null y:8 z:9 w:10 crdb_internal_mvcc_timestamp:11 tableoid:12
-      │    │    └── flags: force-index=xyzw_pkey
+      │    │    └── flags: force-index=xyzw_pkey avoid-full-scan
       │    └── filters
       │         └── z:9 = 1
       └── projections
@@ -367,7 +374,7 @@ update xyzw
       │    ├── columns: x:7!null y:8 z:9!null w:10 crdb_internal_mvcc_timestamp:11 tableoid:12
       │    ├── scan xyzw
       │    │    ├── columns: x:7!null y:8 z:9 w:10 crdb_internal_mvcc_timestamp:11 tableoid:12
-      │    │    └── flags: force-index=foo
+      │    │    └── flags: force-index=foo avoid-full-scan
       │    └── filters
       │         └── z:9 = 1
       └── projections
@@ -387,7 +394,7 @@ update xyzw
       │    ├── columns: x:7!null y:8 z:9!null w:10 crdb_internal_mvcc_timestamp:11 tableoid:12
       │    ├── scan xyzw
       │    │    ├── columns: x:7!null y:8 z:9 w:10 crdb_internal_mvcc_timestamp:11 tableoid:12
-      │    │    └── flags: force-index=foo,fwd
+      │    │    └── flags: force-index=foo,fwd avoid-full-scan
       │    └── filters
       │         └── z:9 = 1
       └── projections
@@ -407,7 +414,7 @@ update xyzw
       │    ├── columns: x:7!null y:8 z:9!null w:10 crdb_internal_mvcc_timestamp:11 tableoid:12
       │    ├── scan xyzw,rev
       │    │    ├── columns: x:7!null y:8 z:9 w:10 crdb_internal_mvcc_timestamp:11 tableoid:12
-      │    │    └── flags: force-index=foo,rev
+      │    │    └── flags: force-index=foo,rev avoid-full-scan
       │    └── filters
       │         └── z:9 = 1
       └── projections
@@ -427,7 +434,7 @@ update xyzw
       │    ├── columns: x:7!null y:8 z:9!null w:10 crdb_internal_mvcc_timestamp:11 tableoid:12
       │    ├── scan xyzw
       │    │    ├── columns: x:7!null y:8 z:9 w:10 crdb_internal_mvcc_timestamp:11 tableoid:12
-      │    │    └── flags: no-index-join
+      │    │    └── flags: no-index-join avoid-full-scan
       │    └── filters
       │         └── z:9 = 1
       └── projections
@@ -452,7 +459,8 @@ update xyz
  └── project
       ├── columns: y_new:11!null z_new:12!null x:6!null y:7 z:8 crdb_internal_mvcc_timestamp:9 tableoid:10
       ├── scan xyz
-      │    └── columns: x:6!null y:7 z:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+      │    ├── columns: x:6!null y:7 z:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+      │    └── flags: avoid-full-scan
       └── projections
            ├── 1 [as=y_new:11]
            └── 1.0 [as=z_new:12]
@@ -471,7 +479,8 @@ update xyz
  └── project
       ├── columns: x_new:11 y_new:12 z_new:13 x:6!null y:7 z:8 crdb_internal_mvcc_timestamp:9 tableoid:10
       ├── scan xyz
-      │    └── columns: x:6!null y:7 z:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+      │    ├── columns: x:6!null y:7 z:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+      │    └── flags: avoid-full-scan
       └── projections
            ├── $1 [as=x_new:11]
            ├── $2 [as=y_new:12]
@@ -497,11 +506,12 @@ update abcde
       │    │    ├── columns: a:9!null b:10 c:11!null d:12 e:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16
       │    │    ├── scan abcde
       │    │    │    ├── columns: a:9!null b:10 c:11 d:12 e:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16
-      │    │    │    └── computed column expressions
-      │    │    │         ├── d:12
-      │    │    │         │    └── (b:10 + c:11) + 1
-      │    │    │         └── e:13
-      │    │    │              └── a:9
+      │    │    │    ├── computed column expressions
+      │    │    │    │    ├── d:12
+      │    │    │    │    │    └── (b:10 + c:11) + 1
+      │    │    │    │    └── e:13
+      │    │    │    │         └── a:9
+      │    │    │    └── flags: avoid-full-scan
       │    │    └── filters
       │    │         └── c:11 = 10
       │    └── projections
@@ -538,7 +548,8 @@ update xyz
       ├── project
       │    ├── columns: x_new:11!null z_new:12!null x:6!null y:7 z:8 crdb_internal_mvcc_timestamp:9 tableoid:10
       │    ├── scan xyz
-      │    │    └── columns: x:6!null y:7 z:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+      │    │    ├── columns: x:6!null y:7 z:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+      │    │    └── flags: avoid-full-scan
       │    └── projections
       │         ├── 1 [as=x_new:11]
       │         └── 1.0 [as=z_new:12]
@@ -574,7 +585,8 @@ with &1
  │    └── project
  │         ├── columns: y_new:11 xyz.x:6!null xyz.y:7 xyz.z:8 xyz.crdb_internal_mvcc_timestamp:9 xyz.tableoid:10
  │         ├── scan xyz
- │         │    └── columns: xyz.x:6!null xyz.y:7 xyz.z:8 xyz.crdb_internal_mvcc_timestamp:9 xyz.tableoid:10
+ │         │    ├── columns: xyz.x:6!null xyz.y:7 xyz.z:8 xyz.crdb_internal_mvcc_timestamp:9 xyz.tableoid:10
+ │         │    └── flags: avoid-full-scan
  │         └── projections
  │              └── xyz.y:7 + 1 [as=y_new:11]
  └── with &2 (cte)
@@ -597,11 +609,12 @@ with &1
                 ├── columns: d_comp:31 a:23!null b:24 c:25 d:26 e:27 rowid:28!null abcde.crdb_internal_mvcc_timestamp:29 abcde.tableoid:30
                 ├── scan abcde
                 │    ├── columns: a:23!null b:24 c:25 d:26 e:27 rowid:28!null abcde.crdb_internal_mvcc_timestamp:29 abcde.tableoid:30
-                │    └── computed column expressions
-                │         ├── d:26
-                │         │    └── (b:24 + c:25) + 1
-                │         └── e:27
-                │              └── a:23
+                │    ├── computed column expressions
+                │    │    ├── d:26
+                │    │    │    └── (b:24 + c:25) + 1
+                │    │    └── e:27
+                │    │         └── a:23
+                │    └── flags: avoid-full-scan
                 └── projections
                      └── (b:24 + c:25) + 1 [as=d_comp:31]
 
@@ -654,11 +667,12 @@ project
            │    │    ├── columns: a:9!null b:10 c:11 d:12 e:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16
            │    │    ├── scan abcde
            │    │    │    ├── columns: a:9!null b:10 c:11 d:12 e:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16
-           │    │    │    └── computed column expressions
-           │    │    │         ├── d:12
-           │    │    │         │    └── (b:10 + c:11) + 1
-           │    │    │         └── e:13
-           │    │    │              └── a:9
+           │    │    │    ├── computed column expressions
+           │    │    │    │    ├── d:12
+           │    │    │    │    │    └── (b:10 + c:11) + 1
+           │    │    │    │    └── e:13
+           │    │    │    │         └── a:9
+           │    │    │    └── flags: avoid-full-scan
            │    │    └── filters
            │    │         └── a:9 = 1
            │    └── projections
@@ -693,11 +707,12 @@ project
  │         │    │    ├── columns: a:9!null b:10 c:11 d:12 e:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16
  │         │    │    ├── scan abcde [as=foo]
  │         │    │    │    ├── columns: a:9!null b:10 c:11 d:12 e:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16
- │         │    │    │    └── computed column expressions
- │         │    │    │         ├── d:12
- │         │    │    │         │    └── (b:10 + c:11) + 1
- │         │    │    │         └── e:13
- │         │    │    │              └── a:9
+ │         │    │    │    ├── computed column expressions
+ │         │    │    │    │    ├── d:12
+ │         │    │    │    │    │    └── (b:10 + c:11) + 1
+ │         │    │    │    │    └── e:13
+ │         │    │    │    │         └── a:9
+ │         │    │    │    └── flags: avoid-full-scan
  │         │    │    └── filters
  │         │    │         └── a:9 = 1
  │         │    └── projections
@@ -744,11 +759,12 @@ with &1
  │              │    │    │         ├── columns: abcde.a:9!null abcde.b:10 abcde.c:11 abcde.d:12 abcde.e:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16
  │              │    │    │         ├── scan abcde
  │              │    │    │         │    ├── columns: abcde.a:9!null abcde.b:10 abcde.c:11 abcde.d:12 abcde.e:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16
- │              │    │    │         │    └── computed column expressions
- │              │    │    │         │         ├── abcde.d:12
- │              │    │    │         │         │    └── (abcde.b:10 + abcde.c:11) + 1
- │              │    │    │         │         └── abcde.e:13
- │              │    │    │         │              └── abcde.a:9
+ │              │    │    │         │    ├── computed column expressions
+ │              │    │    │         │    │    ├── abcde.d:12
+ │              │    │    │         │    │    │    └── (abcde.b:10 + abcde.c:11) + 1
+ │              │    │    │         │    │    └── abcde.e:13
+ │              │    │    │         │    │         └── abcde.a:9
+ │              │    │    │         │    └── flags: avoid-full-scan
  │              │    │    │         └── filters
  │              │    │    │              └── abcde.a:9 > 0
  │              │    │    └── 10
@@ -791,11 +807,12 @@ project
            │    ├── columns: rowid_new:17!null a:9!null b:10 c:11 d:12 e:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16
            │    ├── scan abcde
            │    │    ├── columns: a:9!null b:10 c:11 d:12 e:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16
-           │    │    └── computed column expressions
-           │    │         ├── d:12
-           │    │         │    └── (b:10 + c:11) + 1
-           │    │         └── e:13
-           │    │              └── a:9
+           │    │    ├── computed column expressions
+           │    │    │    ├── d:12
+           │    │    │    │    └── (b:10 + c:11) + 1
+           │    │    │    └── e:13
+           │    │    │         └── a:9
+           │    │    └── flags: avoid-full-scan
            │    └── projections
            │         └── rowid:14 + 1 [as=rowid_new:17]
            └── projections
@@ -834,11 +851,12 @@ update abcde
       │    ├── columns: b_new:17 c_new:18!null a:9!null b:10 c:11 d:12 e:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16
       │    ├── scan abcde
       │    │    ├── columns: a:9!null b:10 c:11 d:12 e:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16
-      │    │    └── computed column expressions
-      │    │         ├── d:12
-      │    │         │    └── (b:10 + c:11) + 1
-      │    │         └── e:13
-      │    │              └── a:9
+      │    │    ├── computed column expressions
+      │    │    │    ├── d:12
+      │    │    │    │    └── (b:10 + c:11) + 1
+      │    │    │    └── e:13
+      │    │    │         └── a:9
+      │    │    └── flags: avoid-full-scan
       │    └── projections
       │         ├── NULL::INT8 [as=b_new:17]
       │         └── 10 [as=c_new:18]
@@ -862,11 +880,12 @@ update abcde
       │    ├── columns: a_new:17 a:9!null b:10 c:11 d:12 e:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16
       │    ├── scan abcde
       │    │    ├── columns: a:9!null b:10 c:11 d:12 e:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16
-      │    │    └── computed column expressions
-      │    │         ├── d:12
-      │    │         │    └── (b:10 + c:11) + 1
-      │    │         └── e:13
-      │    │              └── a:9
+      │    │    ├── computed column expressions
+      │    │    │    ├── d:12
+      │    │    │    │    └── (b:10 + c:11) + 1
+      │    │    │    └── e:13
+      │    │    │         └── a:9
+      │    │    └── flags: avoid-full-scan
       │    └── projections
       │         └── NULL::INT8 [as=a_new:17]
       └── projections
@@ -899,11 +918,12 @@ update abcde
       │    ├── columns: a_new:17!null b_new:18!null c_new:19!null a:9!null b:10 c:11 d:12 e:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16
       │    ├── scan abcde
       │    │    ├── columns: a:9!null b:10 c:11 d:12 e:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16
-      │    │    └── computed column expressions
-      │    │         ├── d:12
-      │    │         │    └── (b:10 + c:11) + 1
-      │    │         └── e:13
-      │    │              └── a:9
+      │    │    ├── computed column expressions
+      │    │    │    ├── d:12
+      │    │    │    │    └── (b:10 + c:11) + 1
+      │    │    │    └── e:13
+      │    │    │         └── a:9
+      │    │    └── flags: avoid-full-scan
       │    └── projections
       │         ├── 1 [as=a_new:17]
       │         ├── 2 [as=b_new:18]
@@ -929,11 +949,12 @@ update abcde
       │    ├── columns: c_new:17 b_new:18!null a_new:19!null a:9!null b:10 c:11 d:12 e:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16
       │    ├── scan abcde
       │    │    ├── columns: a:9!null b:10 c:11 d:12 e:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16
-      │    │    └── computed column expressions
-      │    │         ├── d:12
-      │    │         │    └── (b:10 + c:11) + 1
-      │    │         └── e:13
-      │    │              └── a:9
+      │    │    ├── computed column expressions
+      │    │    │    ├── d:12
+      │    │    │    │    └── (b:10 + c:11) + 1
+      │    │    │    └── e:13
+      │    │    │         └── a:9
+      │    │    └── flags: avoid-full-scan
       │    └── projections
       │         ├── NULL::INT8 [as=c_new:17]
       │         ├── 1 [as=b_new:18]
@@ -958,11 +979,12 @@ update abcde
       │    ├── columns: b_new:17 c_new:18!null a:9!null b:10 c:11 d:12 e:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16
       │    ├── scan abcde
       │    │    ├── columns: a:9!null b:10 c:11 d:12 e:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16
-      │    │    └── computed column expressions
-      │    │         ├── d:12
-      │    │         │    └── (b:10 + c:11) + 1
-      │    │         └── e:13
-      │    │              └── a:9
+      │    │    ├── computed column expressions
+      │    │    │    ├── d:12
+      │    │    │    │    └── (b:10 + c:11) + 1
+      │    │    │    └── e:13
+      │    │    │         └── a:9
+      │    │    └── flags: avoid-full-scan
       │    └── projections
       │         ├── NULL::INT8 [as=b_new:17]
       │         └── 10 [as=c_new:18]
@@ -987,11 +1009,12 @@ update abcde
       │    ├── columns: a_new:17 a:9!null b:10 c:11 d:12 e:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16
       │    ├── scan abcde
       │    │    ├── columns: a:9!null b:10 c:11 d:12 e:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16
-      │    │    └── computed column expressions
-      │    │         ├── d:12
-      │    │         │    └── (b:10 + c:11) + 1
-      │    │         └── e:13
-      │    │              └── a:9
+      │    │    ├── computed column expressions
+      │    │    │    ├── d:12
+      │    │    │    │    └── (b:10 + c:11) + 1
+      │    │    │    └── e:13
+      │    │    │         └── a:9
+      │    │    └── flags: avoid-full-scan
       │    └── projections
       │         └── NULL::INT8 [as=a_new:17]
       └── projections
@@ -1037,11 +1060,12 @@ update abcde
       │    ├── columns: a:9!null b:10 c:11 d:12 e:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16 one:17
       │    ├── scan abcde
       │    │    ├── columns: a:9!null b:10 c:11 d:12 e:13 rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16
-      │    │    └── computed column expressions
-      │    │         ├── d:12
-      │    │         │    └── (b:10 + c:11) + 1
-      │    │         └── e:13
-      │    │              └── a:9
+      │    │    ├── computed column expressions
+      │    │    │    ├── d:12
+      │    │    │    │    └── (b:10 + c:11) + 1
+      │    │    │    └── e:13
+      │    │    │         └── a:9
+      │    │    └── flags: avoid-full-scan
       │    ├── max1-row
       │    │    ├── columns: one:17!null
       │    │    └── project
@@ -1074,11 +1098,12 @@ update abcde
       │    ├── columns: a:9!null b:10 c:11 d:12 e:13 rowid:14!null abcde.crdb_internal_mvcc_timestamp:15 abcde.tableoid:16 y:18 x:22 z:23 y1:24
       │    ├── scan abcde
       │    │    ├── columns: a:9!null b:10 c:11 d:12 e:13 rowid:14!null abcde.crdb_internal_mvcc_timestamp:15 abcde.tableoid:16
-      │    │    └── computed column expressions
-      │    │         ├── d:12
-      │    │         │    └── (b:10 + c:11) + 1
-      │    │         └── e:13
-      │    │              └── a:9
+      │    │    ├── computed column expressions
+      │    │    │    ├── d:12
+      │    │    │    │    └── (b:10 + c:11) + 1
+      │    │    │    └── e:13
+      │    │    │         └── a:9
+      │    │    └── flags: avoid-full-scan
       │    ├── max1-row
       │    │    ├── columns: y:18 x:22!null z:23 y1:24
       │    │    └── project
@@ -1115,11 +1140,12 @@ update abcde
       │    │    ├── columns: a:9!null b:10 c:11 d:12 e:13 rowid:14!null abcde.crdb_internal_mvcc_timestamp:15 abcde.tableoid:16 y:18 y1:22
       │    │    ├── scan abcde
       │    │    │    ├── columns: a:9!null b:10 c:11 d:12 e:13 rowid:14!null abcde.crdb_internal_mvcc_timestamp:15 abcde.tableoid:16
-      │    │    │    └── computed column expressions
-      │    │    │         ├── d:12
-      │    │    │         │    └── (b:10 + c:11) + 1
-      │    │    │         └── e:13
-      │    │    │              └── a:9
+      │    │    │    ├── computed column expressions
+      │    │    │    │    ├── d:12
+      │    │    │    │    │    └── (b:10 + c:11) + 1
+      │    │    │    │    └── e:13
+      │    │    │    │         └── a:9
+      │    │    │    └── flags: avoid-full-scan
       │    │    ├── max1-row
       │    │    │    ├── columns: y:18 y1:22
       │    │    │    └── project
@@ -1157,11 +1183,12 @@ update abcde
       │    │    ├── columns: a:9!null b:10 c:11 d:12 e:13 rowid:14!null abcde.crdb_internal_mvcc_timestamp:15 abcde.tableoid:16 y:18 y1:22
       │    │    ├── scan abcde
       │    │    │    ├── columns: a:9!null b:10 c:11 d:12 e:13 rowid:14!null abcde.crdb_internal_mvcc_timestamp:15 abcde.tableoid:16
-      │    │    │    └── computed column expressions
-      │    │    │         ├── d:12
-      │    │    │         │    └── (b:10 + c:11) + 1
-      │    │    │         └── e:13
-      │    │    │              └── a:9
+      │    │    │    ├── computed column expressions
+      │    │    │    │    ├── d:12
+      │    │    │    │    │    └── (b:10 + c:11) + 1
+      │    │    │    │    └── e:13
+      │    │    │    │         └── a:9
+      │    │    │    └── flags: avoid-full-scan
       │    │    ├── max1-row
       │    │    │    ├── columns: y:18 y1:22
       │    │    │    └── project
@@ -1199,11 +1226,12 @@ update abcde
       │    │    ├── columns: a:9!null b:10 c:11 d:12 e:13 rowid:14!null abcde.crdb_internal_mvcc_timestamp:15 abcde.tableoid:16 y:18 y1:22
       │    │    ├── scan abcde
       │    │    │    ├── columns: a:9!null b:10 c:11 d:12 e:13 rowid:14!null abcde.crdb_internal_mvcc_timestamp:15 abcde.tableoid:16
-      │    │    │    └── computed column expressions
-      │    │    │         ├── d:12
-      │    │    │         │    └── (b:10 + c:11) + 1
-      │    │    │         └── e:13
-      │    │    │              └── a:9
+      │    │    │    ├── computed column expressions
+      │    │    │    │    ├── d:12
+      │    │    │    │    │    └── (b:10 + c:11) + 1
+      │    │    │    │    └── e:13
+      │    │    │    │         └── a:9
+      │    │    │    └── flags: avoid-full-scan
       │    │    ├── max1-row
       │    │    │    ├── columns: y:18 y1:22
       │    │    │    └── project
@@ -1242,7 +1270,8 @@ update xyz
       ├── left-join-apply
       │    ├── columns: x:6!null y:7 z:8 crdb_internal_mvcc_timestamp:9 tableoid:10 two:11 three:12
       │    ├── scan xyz
-      │    │    └── columns: x:6!null y:7 z:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+      │    │    ├── columns: x:6!null y:7 z:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+      │    │    └── flags: avoid-full-scan
       │    ├── max1-row
       │    │    ├── columns: two:11!null three:12!null
       │    │    └── project
@@ -1281,11 +1310,12 @@ project
            │    ├── columns: b_new:25 abcde1.a:9!null abcde1.b:10 abcde1.c:11 abcde1.d:12 abcde1.e:13 abcde1.rowid:14!null abcde1.crdb_internal_mvcc_timestamp:15 abcde1.tableoid:16
            │    ├── scan abcde [as=abcde1]
            │    │    ├── columns: abcde1.a:9!null abcde1.b:10 abcde1.c:11 abcde1.d:12 abcde1.e:13 abcde1.rowid:14!null abcde1.crdb_internal_mvcc_timestamp:15 abcde1.tableoid:16
-           │    │    └── computed column expressions
-           │    │         ├── abcde1.d:12
-           │    │         │    └── (abcde1.b:10 + abcde1.c:11) + 1
-           │    │         └── abcde1.e:13
-           │    │              └── abcde1.a:9
+           │    │    ├── computed column expressions
+           │    │    │    ├── abcde1.d:12
+           │    │    │    │    └── (abcde1.b:10 + abcde1.c:11) + 1
+           │    │    │    └── abcde1.e:13
+           │    │    │         └── abcde1.a:9
+           │    │    └── flags: avoid-full-scan
            │    └── projections
            │         └── subquery [as=b_new:25]
            │              └── max1-row
@@ -1356,11 +1386,12 @@ with &1 (cte)
            │    ├── columns: a:14!null b:15 c:16 d:17 e:18 rowid:19!null abcde.crdb_internal_mvcc_timestamp:20 abcde.tableoid:21
            │    ├── scan abcde
            │    │    ├── columns: a:14!null b:15 c:16 d:17 e:18 rowid:19!null abcde.crdb_internal_mvcc_timestamp:20 abcde.tableoid:21
-           │    │    └── computed column expressions
-           │    │         ├── d:17
-           │    │         │    └── (b:15 + c:16) + 1
-           │    │         └── e:18
-           │    │              └── a:14
+           │    │    ├── computed column expressions
+           │    │    │    ├── d:17
+           │    │    │    │    └── (b:15 + c:16) + 1
+           │    │    │    └── e:18
+           │    │    │         └── a:14
+           │    │    └── flags: avoid-full-scan
            │    └── filters
            │         └── exists
            │              └── with-scan &1 (cte)
@@ -1395,11 +1426,12 @@ with &1 (a)
            │    ├── columns: a:15!null b:16 c:17 d:18 e:19 rowid:20!null abcde.crdb_internal_mvcc_timestamp:21 abcde.tableoid:22 y:23 y1:24
            │    ├── scan abcde
            │    │    ├── columns: a:15!null b:16 c:17 d:18 e:19 rowid:20!null abcde.crdb_internal_mvcc_timestamp:21 abcde.tableoid:22
-           │    │    └── computed column expressions
-           │    │         ├── d:18
-           │    │         │    └── (b:16 + c:17) + 1
-           │    │         └── e:19
-           │    │              └── a:15
+           │    │    ├── computed column expressions
+           │    │    │    ├── d:18
+           │    │    │    │    └── (b:16 + c:17) + 1
+           │    │    │    └── e:19
+           │    │    │         └── a:15
+           │    │    └── flags: avoid-full-scan
            │    ├── max1-row
            │    │    ├── columns: y:23 y1:24
            │    │    └── with-scan &1 (a)
@@ -1437,8 +1469,9 @@ update mutation
       │    │    │    ├── columns: m_new:15!null m:8!null n:9 o:10 p:11 q:12 crdb_internal_mvcc_timestamp:13 tableoid:14
       │    │    │    ├── scan mutation
       │    │    │    │    ├── columns: m:8!null n:9 o:10 p:11 q:12 crdb_internal_mvcc_timestamp:13 tableoid:14
-      │    │    │    │    └── check constraint expressions
-      │    │    │    │         └── m:8 > 0
+      │    │    │    │    ├── check constraint expressions
+      │    │    │    │    │    └── m:8 > 0
+      │    │    │    │    └── flags: avoid-full-scan
       │    │    │    └── projections
       │    │    │         └── 1 [as=m_new:15]
       │    │    └── projections
@@ -1471,8 +1504,9 @@ update mutation
       │    │    │    ├── columns: m_new:15!null n_new:16!null m:8!null n:9 o:10 p:11 q:12 crdb_internal_mvcc_timestamp:13 tableoid:14
       │    │    │    ├── scan mutation
       │    │    │    │    ├── columns: m:8!null n:9 o:10 p:11 q:12 crdb_internal_mvcc_timestamp:13 tableoid:14
-      │    │    │    │    └── check constraint expressions
-      │    │    │    │         └── m:8 > 0
+      │    │    │    │    ├── check constraint expressions
+      │    │    │    │    │    └── m:8 > 0
+      │    │    │    │    └── flags: avoid-full-scan
       │    │    │    └── projections
       │    │    │         ├── 1 [as=m_new:15]
       │    │    │         └── 2 [as=n_new:16]
@@ -1506,7 +1540,7 @@ update mutation
       │    │    │    ├── limit
       │    │    │    │    ├── columns: m:8!null n:9 o:10 p:11 q:12 crdb_internal_mvcc_timestamp:13 tableoid:14
       │    │    │    │    ├── internal-ordering: +8,+9
-      │    │    │    │    ├── sort (segmented)
+      │    │    │    │    ├── sort
       │    │    │    │    │    ├── columns: m:8!null n:9 o:10 p:11 q:12 crdb_internal_mvcc_timestamp:13 tableoid:14
       │    │    │    │    │    ├── ordering: +8,+9
       │    │    │    │    │    ├── limit hint: 10.00
@@ -1514,7 +1548,7 @@ update mutation
       │    │    │    │    │         ├── columns: m:8!null n:9 o:10 p:11 q:12 crdb_internal_mvcc_timestamp:13 tableoid:14
       │    │    │    │    │         ├── check constraint expressions
       │    │    │    │    │         │    └── m:8 > 0
-      │    │    │    │    │         └── ordering: +8
+      │    │    │    │    │         └── flags: avoid-full-scan
       │    │    │    │    └── 10
       │    │    │    └── projections
       │    │    │         └── 1 [as=m_new:15]
@@ -1582,9 +1616,10 @@ update checks
       │    │    │    ├── columns: a:7!null b:8 c:9 d:10 crdb_internal_mvcc_timestamp:11 tableoid:12
       │    │    │    ├── check constraint expressions
       │    │    │    │    └── a:7 > 0
-      │    │    │    └── computed column expressions
-      │    │    │         └── d:10
-      │    │    │              └── c:9 + 1
+      │    │    │    ├── computed column expressions
+      │    │    │    │    └── d:10
+      │    │    │    │         └── c:9 + 1
+      │    │    │    └── flags: avoid-full-scan
       │    │    └── projections
       │    │         ├── 1 [as=a_new:13]
       │    │         ├── 2 [as=b_new:14]
@@ -1615,9 +1650,10 @@ update checks
       │    │    │    ├── columns: a:7!null b:8 c:9 d:10 crdb_internal_mvcc_timestamp:11 tableoid:12
       │    │    │    ├── check constraint expressions
       │    │    │    │    └── a:7 > 0
-      │    │    │    └── computed column expressions
-      │    │    │         └── d:10
-      │    │    │              └── c:9 + 1
+      │    │    │    ├── computed column expressions
+      │    │    │    │    └── d:10
+      │    │    │    │         └── c:9 + 1
+      │    │    │    └── flags: avoid-full-scan
       │    │    └── projections
       │    │         └── 1 [as=a_new:13]
       │    └── projections
@@ -1646,9 +1682,10 @@ update checks
       │    │    │    ├── columns: a:7!null b:8 c:9 d:10 crdb_internal_mvcc_timestamp:11 tableoid:12
       │    │    │    ├── check constraint expressions
       │    │    │    │    └── a:7 > 0
-      │    │    │    └── computed column expressions
-      │    │    │         └── d:10
-      │    │    │              └── c:9 + 1
+      │    │    │    ├── computed column expressions
+      │    │    │    │    └── d:10
+      │    │    │    │         └── c:9 + 1
+      │    │    │    └── flags: avoid-full-scan
       │    │    └── projections
       │    │         └── 2 [as=b_new:13]
       │    └── projections
@@ -1678,9 +1715,10 @@ update checks
       │    │    │    ├── columns: checks.a:7!null checks.b:8 checks.c:9 checks.d:10 checks.crdb_internal_mvcc_timestamp:11 checks.tableoid:12
       │    │    │    ├── check constraint expressions
       │    │    │    │    └── checks.a:7 > 0
-      │    │    │    └── computed column expressions
-      │    │    │         └── checks.d:10
-      │    │    │              └── checks.c:9 + 1
+      │    │    │    ├── computed column expressions
+      │    │    │    │    └── checks.d:10
+      │    │    │    │         └── checks.c:9 + 1
+      │    │    │    └── flags: avoid-full-scan
       │    │    ├── max1-row
       │    │    │    ├── columns: abcde.a:13!null abcde.b:14
       │    │    │    └── project
@@ -1744,7 +1782,8 @@ update multi_col_fam_checks
       ├── project
       │    ├── columns: a_new:15!null a:8!null b:9 c:10 d:11 e:12 crdb_internal_mvcc_timestamp:13 tableoid:14
       │    ├── scan multi_col_fam_checks
-      │    │    └── columns: a:8!null b:9 c:10 d:11 e:12 crdb_internal_mvcc_timestamp:13 tableoid:14
+      │    │    ├── columns: a:8!null b:9 c:10 d:11 e:12 crdb_internal_mvcc_timestamp:13 tableoid:14
+      │    │    └── flags: avoid-full-scan
       │    └── projections
       │         └── 5 [as=a_new:15]
       └── projections
@@ -1774,7 +1813,8 @@ update multi_col_fam_checks
       │    ├── select
       │    │    ├── columns: a:8!null b:9!null c:10!null d:11 e:12 crdb_internal_mvcc_timestamp:13 tableoid:14
       │    │    ├── scan multi_col_fam_checks
-      │    │    │    └── columns: a:8!null b:9 c:10 d:11 e:12 crdb_internal_mvcc_timestamp:13 tableoid:14
+      │    │    │    ├── columns: a:8!null b:9 c:10 d:11 e:12 crdb_internal_mvcc_timestamp:13 tableoid:14
+      │    │    │    └── flags: avoid-full-scan
       │    │    └── filters
       │    │         └── (b:9 = 6) AND (c:10 = 3)
       │    └── projections
@@ -1799,7 +1839,8 @@ update multi_col_fam_checks
       ├── project
       │    ├── columns: a_new:15!null b_new:16!null a:8!null b:9 c:10 d:11 e:12 crdb_internal_mvcc_timestamp:13 tableoid:14
       │    ├── scan multi_col_fam_checks
-      │    │    └── columns: a:8!null b:9 c:10 d:11 e:12 crdb_internal_mvcc_timestamp:13 tableoid:14
+      │    │    ├── columns: a:8!null b:9 c:10 d:11 e:12 crdb_internal_mvcc_timestamp:13 tableoid:14
+      │    │    └── flags: avoid-full-scan
       │    └── projections
       │         ├── 5 [as=a_new:15]
       │         └── 6 [as=b_new:16]
@@ -1824,7 +1865,8 @@ update multi_col_fam_checks
       ├── project
       │    ├── columns: a_new:15!null b_new:16!null e_new:17!null a:8!null b:9 c:10 d:11 e:12 crdb_internal_mvcc_timestamp:13 tableoid:14
       │    ├── scan multi_col_fam_checks
-      │    │    └── columns: a:8!null b:9 c:10 d:11 e:12 crdb_internal_mvcc_timestamp:13 tableoid:14
+      │    │    ├── columns: a:8!null b:9 c:10 d:11 e:12 crdb_internal_mvcc_timestamp:13 tableoid:14
+      │    │    └── flags: avoid-full-scan
       │    └── projections
       │         ├── 5 [as=a_new:15]
       │         ├── 6 [as=b_new:16]
@@ -1849,7 +1891,8 @@ update multi_col_fam_checks
       │    ├── select
       │    │    ├── columns: a:8!null b:9 c:10 d:11 e:12 crdb_internal_mvcc_timestamp:13 tableoid:14
       │    │    ├── scan multi_col_fam_checks
-      │    │    │    └── columns: a:8!null b:9 c:10 d:11 e:12 crdb_internal_mvcc_timestamp:13 tableoid:14
+      │    │    │    ├── columns: a:8!null b:9 c:10 d:11 e:12 crdb_internal_mvcc_timestamp:13 tableoid:14
+      │    │    │    └── flags: avoid-full-scan
       │    │    └── filters
       │    │         └── a:8 = 5
       │    └── projections
@@ -1872,7 +1915,8 @@ update multi_col_fam_checks
       ├── project
       │    ├── columns: e_new:15!null a:8!null b:9 c:10 d:11 e:12 crdb_internal_mvcc_timestamp:13 tableoid:14
       │    ├── scan multi_col_fam_checks
-      │    │    └── columns: a:8!null b:9 c:10 d:11 e:12 crdb_internal_mvcc_timestamp:13 tableoid:14
+      │    │    ├── columns: a:8!null b:9 c:10 d:11 e:12 crdb_internal_mvcc_timestamp:13 tableoid:14
+      │    │    └── flags: avoid-full-scan
       │    └── projections
       │         └── 3 [as=e_new:15]
       └── projections
@@ -1913,10 +1957,11 @@ update decimals
       │    │    │    │    ├── columns: a_new:13!null b_new:14 a:7!null b:8 c:9 d:10 crdb_internal_mvcc_timestamp:11 tableoid:12
       │    │    │    │    ├── scan decimals
       │    │    │    │    │    ├── columns: a:7!null b:8 c:9 d:10 crdb_internal_mvcc_timestamp:11 tableoid:12
-      │    │    │    │    │    └── computed column expressions
-      │    │    │    │    │         └── d:10
-      │    │    │    │    │              └── assignment-cast: DECIMAL(10,1)
-      │    │    │    │    │                   └── a:7 + c:9
+      │    │    │    │    │    ├── computed column expressions
+      │    │    │    │    │    │    └── d:10
+      │    │    │    │    │    │         └── assignment-cast: DECIMAL(10,1)
+      │    │    │    │    │    │              └── a:7 + c:9
+      │    │    │    │    │    └── flags: avoid-full-scan
       │    │    │    │    └── projections
       │    │    │    │         ├── 1.1 [as=a_new:13]
       │    │    │    │         └── ARRAY[0.95, NULL, 15::DECIMAL(10,2)] [as=b_new:14]
@@ -1959,10 +2004,11 @@ update decimals
       │    │    │    │    ├── columns: a_new:13!null b_new:14!null a:7!null b:8 c:9 d:10 crdb_internal_mvcc_timestamp:11 tableoid:12
       │    │    │    │    ├── scan decimals
       │    │    │    │    │    ├── columns: a:7!null b:8 c:9 d:10 crdb_internal_mvcc_timestamp:11 tableoid:12
-      │    │    │    │    │    └── computed column expressions
-      │    │    │    │    │         └── d:10
-      │    │    │    │    │              └── assignment-cast: DECIMAL(10,1)
-      │    │    │    │    │                   └── a:7 + c:9
+      │    │    │    │    │    ├── computed column expressions
+      │    │    │    │    │    │    └── d:10
+      │    │    │    │    │    │         └── assignment-cast: DECIMAL(10,1)
+      │    │    │    │    │    │              └── a:7 + c:9
+      │    │    │    │    │    └── flags: avoid-full-scan
       │    │    │    │    └── projections
       │    │    │    │         ├── 1.1 [as=a_new:13]
       │    │    │    │         └── ARRAY[0.95,NULL,15.00] [as=b_new:14]
@@ -2000,10 +2046,11 @@ update assn_cast
       │    │    ├── columns: c_new:19!null qc_new:20!null i_new:21!null s_new:22!null c:10 qc:11 i:12 s:13 d:14 d_comp:15 rowid:16!null crdb_internal_mvcc_timestamp:17 tableoid:18
       │    │    ├── scan assn_cast
       │    │    │    ├── columns: c:10 qc:11 i:12 s:13 d:14 d_comp:15 rowid:16!null crdb_internal_mvcc_timestamp:17 tableoid:18
-      │    │    │    └── computed column expressions
-      │    │    │         └── d_comp:15
-      │    │    │              └── assignment-cast: DECIMAL(10)
-      │    │    │                   └── d:14 + 10.0
+      │    │    │    ├── computed column expressions
+      │    │    │    │    └── d_comp:15
+      │    │    │    │         └── assignment-cast: DECIMAL(10)
+      │    │    │    │              └── d:14 + 10.0
+      │    │    │    └── flags: avoid-full-scan
       │    │    └── projections
       │    │         ├── '' [as=c_new:19]
       │    │         ├── 'foo' [as=qc_new:20]
@@ -2038,10 +2085,11 @@ update assn_cast
       │    │    ├── columns: c_new:19!null qc_new:20!null i_new:21!null c:10 qc:11 i:12 s:13 d:14 d_comp:15 rowid:16!null crdb_internal_mvcc_timestamp:17 tableoid:18
       │    │    ├── scan assn_cast
       │    │    │    ├── columns: c:10 qc:11 i:12 s:13 d:14 d_comp:15 rowid:16!null crdb_internal_mvcc_timestamp:17 tableoid:18
-      │    │    │    └── computed column expressions
-      │    │    │         └── d_comp:15
-      │    │    │              └── assignment-cast: DECIMAL(10)
-      │    │    │                   └── d:14 + 10.0
+      │    │    │    ├── computed column expressions
+      │    │    │    │    └── d_comp:15
+      │    │    │    │         └── assignment-cast: DECIMAL(10)
+      │    │    │    │              └── d:14 + 10.0
+      │    │    │    └── flags: avoid-full-scan
       │    │    └── projections
       │    │         ├── '' [as=c_new:19]
       │    │         ├── 'foo' [as=qc_new:20]
@@ -2071,10 +2119,11 @@ update assn_cast
       │    │    ├── columns: i_new:19!null c:10 qc:11 i:12 s:13 d:14 d_comp:15 rowid:16!null crdb_internal_mvcc_timestamp:17 tableoid:18
       │    │    ├── scan assn_cast
       │    │    │    ├── columns: c:10 qc:11 i:12 s:13 d:14 d_comp:15 rowid:16!null crdb_internal_mvcc_timestamp:17 tableoid:18
-      │    │    │    └── computed column expressions
-      │    │    │         └── d_comp:15
-      │    │    │              └── assignment-cast: DECIMAL(10)
-      │    │    │                   └── d:14 + 10.0
+      │    │    │    ├── computed column expressions
+      │    │    │    │    └── d_comp:15
+      │    │    │    │         └── assignment-cast: DECIMAL(10)
+      │    │    │    │              └── d:14 + 10.0
+      │    │    │    └── flags: avoid-full-scan
       │    │    └── projections
       │    │         └── 10::INT2 [as=i_new:19]
       │    └── projections
@@ -2104,10 +2153,11 @@ update assn_cast
       │    │    │    ├── columns: d_new:19!null c:10 qc:11 i:12 s:13 d:14 d_comp:15 rowid:16!null crdb_internal_mvcc_timestamp:17 tableoid:18
       │    │    │    ├── scan assn_cast
       │    │    │    │    ├── columns: c:10 qc:11 i:12 s:13 d:14 d_comp:15 rowid:16!null crdb_internal_mvcc_timestamp:17 tableoid:18
-      │    │    │    │    └── computed column expressions
-      │    │    │    │         └── d_comp:15
-      │    │    │    │              └── assignment-cast: DECIMAL(10)
-      │    │    │    │                   └── d:14 + 10.0
+      │    │    │    │    ├── computed column expressions
+      │    │    │    │    │    └── d_comp:15
+      │    │    │    │    │         └── assignment-cast: DECIMAL(10)
+      │    │    │    │    │              └── d:14 + 10.0
+      │    │    │    │    └── flags: avoid-full-scan
       │    │    │    └── projections
       │    │    │         └── 1.45::DECIMAL(10,2) [as=d_new:19]
       │    │    └── projections
@@ -2140,10 +2190,11 @@ update assn_cast
       │    │    │    ├── columns: d_new:19!null c:10 qc:11 i:12 s:13 d:14 d_comp:15 rowid:16!null crdb_internal_mvcc_timestamp:17 tableoid:18
       │    │    │    ├── scan assn_cast
       │    │    │    │    ├── columns: c:10 qc:11 i:12 s:13 d:14 d_comp:15 rowid:16!null crdb_internal_mvcc_timestamp:17 tableoid:18
-      │    │    │    │    └── computed column expressions
-      │    │    │    │         └── d_comp:15
-      │    │    │    │              └── assignment-cast: DECIMAL(10)
-      │    │    │    │                   └── d:14 + 10.0
+      │    │    │    │    ├── computed column expressions
+      │    │    │    │    │    └── d_comp:15
+      │    │    │    │    │         └── assignment-cast: DECIMAL(10)
+      │    │    │    │    │              └── d:14 + 10.0
+      │    │    │    │    └── flags: avoid-full-scan
       │    │    │    └── projections
       │    │    │         └── 1.45 [as=d_new:19]
       │    │    └── projections
@@ -2179,10 +2230,11 @@ update decimals
       │    │    │    │    ├── columns: a_new:13!null b_new:14 a:7!null b:8 c:9 d:10 crdb_internal_mvcc_timestamp:11 tableoid:12
       │    │    │    │    ├── scan decimals
       │    │    │    │    │    ├── columns: a:7!null b:8 c:9 d:10 crdb_internal_mvcc_timestamp:11 tableoid:12
-      │    │    │    │    │    └── computed column expressions
-      │    │    │    │    │         └── d:10
-      │    │    │    │    │              └── assignment-cast: DECIMAL(10,1)
-      │    │    │    │    │                   └── a:7 + c:9
+      │    │    │    │    │    ├── computed column expressions
+      │    │    │    │    │    │    └── d:10
+      │    │    │    │    │    │         └── assignment-cast: DECIMAL(10,1)
+      │    │    │    │    │    │              └── a:7 + c:9
+      │    │    │    │    │    └── flags: avoid-full-scan
       │    │    │    │    └── projections
       │    │    │    │         ├── 1.1 [as=a_new:13]
       │    │    │    │         └── ARRAY[0.95, NULL, 15::DECIMAL(10,2)] [as=b_new:14]
@@ -2224,10 +2276,11 @@ update decimals
       │    │    │    │    ├── columns: a_new:13!null b_new:14!null a:7!null b:8 c:9 d:10 crdb_internal_mvcc_timestamp:11 tableoid:12
       │    │    │    │    ├── scan decimals
       │    │    │    │    │    ├── columns: a:7!null b:8 c:9 d:10 crdb_internal_mvcc_timestamp:11 tableoid:12
-      │    │    │    │    │    └── computed column expressions
-      │    │    │    │    │         └── d:10
-      │    │    │    │    │              └── assignment-cast: DECIMAL(10,1)
-      │    │    │    │    │                   └── a:7 + c:9
+      │    │    │    │    │    ├── computed column expressions
+      │    │    │    │    │    │    └── d:10
+      │    │    │    │    │    │         └── assignment-cast: DECIMAL(10,1)
+      │    │    │    │    │    │              └── a:7 + c:9
+      │    │    │    │    │    └── flags: avoid-full-scan
       │    │    │    │    └── projections
       │    │    │    │         ├── 1.1 [as=a_new:13]
       │    │    │    │         └── ARRAY[0.95,NULL,15.00] [as=b_new:14]
@@ -2263,10 +2316,11 @@ update assn_cast
       │    │    ├── columns: c_new:19!null i_new:20!null c:10 qc:11 i:12 s:13 d:14 d_comp:15 rowid:16!null crdb_internal_mvcc_timestamp:17 tableoid:18
       │    │    ├── scan assn_cast
       │    │    │    ├── columns: c:10 qc:11 i:12 s:13 d:14 d_comp:15 rowid:16!null crdb_internal_mvcc_timestamp:17 tableoid:18
-      │    │    │    └── computed column expressions
-      │    │    │         └── d_comp:15
-      │    │    │              └── assignment-cast: DECIMAL(10)
-      │    │    │                   └── d:14 + 10.0
+      │    │    │    ├── computed column expressions
+      │    │    │    │    └── d_comp:15
+      │    │    │    │         └── assignment-cast: DECIMAL(10)
+      │    │    │    │              └── d:14 + 10.0
+      │    │    │    └── flags: avoid-full-scan
       │    │    └── projections
       │    │         ├── '' [as=c_new:19]
       │    │         └── 10::INT2 [as=i_new:20]
@@ -2296,10 +2350,11 @@ update assn_cast
       │    │    ├── columns: c_new:19!null i_new:20!null c:10 qc:11 i:12 s:13 d:14 d_comp:15 rowid:16!null crdb_internal_mvcc_timestamp:17 tableoid:18
       │    │    ├── scan assn_cast
       │    │    │    ├── columns: c:10 qc:11 i:12 s:13 d:14 d_comp:15 rowid:16!null crdb_internal_mvcc_timestamp:17 tableoid:18
-      │    │    │    └── computed column expressions
-      │    │    │         └── d_comp:15
-      │    │    │              └── assignment-cast: DECIMAL(10)
-      │    │    │                   └── d:14 + 10.0
+      │    │    │    ├── computed column expressions
+      │    │    │    │    └── d_comp:15
+      │    │    │    │         └── assignment-cast: DECIMAL(10)
+      │    │    │    │              └── d:14 + 10.0
+      │    │    │    └── flags: avoid-full-scan
       │    │    └── projections
       │    │         ├── '' [as=c_new:19]
       │    │         └── 10::INT2 [as=i_new:20]
@@ -2334,10 +2389,11 @@ update decimals
       │    │    │    │    ├── columns: a:7!null b:8 c:9 d:10 crdb_internal_mvcc_timestamp:11 tableoid:12 n:13
       │    │    │    │    ├── scan decimals
       │    │    │    │    │    ├── columns: a:7!null b:8 c:9 d:10 crdb_internal_mvcc_timestamp:11 tableoid:12
-      │    │    │    │    │    └── computed column expressions
-      │    │    │    │    │         └── d:10
-      │    │    │    │    │              └── assignment-cast: DECIMAL(10,1)
-      │    │    │    │    │                   └── a:7 + c:9
+      │    │    │    │    │    ├── computed column expressions
+      │    │    │    │    │    │    └── d:10
+      │    │    │    │    │    │         └── assignment-cast: DECIMAL(10,1)
+      │    │    │    │    │    │              └── a:7 + c:9
+      │    │    │    │    │    └── flags: avoid-full-scan
       │    │    │    │    ├── max1-row
       │    │    │    │    │    ├── columns: n:13!null
       │    │    │    │    │    └── project
@@ -2383,10 +2439,11 @@ update decimals
       │    │    │    │    ├── columns: a:7!null b:8 c:9 d:10 decimals.crdb_internal_mvcc_timestamp:11 decimals.tableoid:12 u:13 "?column?":18
       │    │    │    │    ├── scan decimals
       │    │    │    │    │    ├── columns: a:7!null b:8 c:9 d:10 decimals.crdb_internal_mvcc_timestamp:11 decimals.tableoid:12
-      │    │    │    │    │    └── computed column expressions
-      │    │    │    │    │         └── d:10
-      │    │    │    │    │              └── assignment-cast: DECIMAL(10,1)
-      │    │    │    │    │                   └── a:7 + c:9
+      │    │    │    │    │    ├── computed column expressions
+      │    │    │    │    │    │    └── d:10
+      │    │    │    │    │    │         └── assignment-cast: DECIMAL(10,1)
+      │    │    │    │    │    │              └── a:7 + c:9
+      │    │    │    │    │    └── flags: avoid-full-scan
       │    │    │    │    ├── max1-row
       │    │    │    │    │    ├── columns: u:13!null "?column?":18!null
       │    │    │    │    │    └── project
@@ -2435,10 +2492,11 @@ update assn_cast
       │    │    │    ├── columns: c:10 qc:11 i:12 s:13 d:14 d_comp:15 assn_cast.rowid:16!null assn_cast.crdb_internal_mvcc_timestamp:17 assn_cast.tableoid:18 "?column?":24 "?column?":25
       │    │    │    ├── scan assn_cast
       │    │    │    │    ├── columns: c:10 qc:11 i:12 s:13 d:14 d_comp:15 assn_cast.rowid:16!null assn_cast.crdb_internal_mvcc_timestamp:17 assn_cast.tableoid:18
-      │    │    │    │    └── computed column expressions
-      │    │    │    │         └── d_comp:15
-      │    │    │    │              └── assignment-cast: DECIMAL(10)
-      │    │    │    │                   └── d:14 + 10.0
+      │    │    │    │    ├── computed column expressions
+      │    │    │    │    │    └── d_comp:15
+      │    │    │    │    │         └── assignment-cast: DECIMAL(10)
+      │    │    │    │    │              └── d:14 + 10.0
+      │    │    │    │    └── flags: avoid-full-scan
       │    │    │    ├── max1-row
       │    │    │    │    ├── columns: "?column?":24!null "?column?":25!null
       │    │    │    │    └── project
@@ -2483,10 +2541,11 @@ update assn_cast_on_update
       │    │    │    ├── columns: i_new:19!null b_new:20!null i:10 i2:11 d:12 d2:13 d_comp:14 b:15 rowid:16!null crdb_internal_mvcc_timestamp:17 tableoid:18
       │    │    │    ├── scan assn_cast_on_update
       │    │    │    │    ├── columns: i:10 i2:11 d:12 d2:13 d_comp:14 b:15 rowid:16!null crdb_internal_mvcc_timestamp:17 tableoid:18
-      │    │    │    │    └── computed column expressions
-      │    │    │    │         └── d_comp:14
-      │    │    │    │              └── assignment-cast: DECIMAL(10)
-      │    │    │    │                   └── d:12
+      │    │    │    │    ├── computed column expressions
+      │    │    │    │    │    └── d_comp:14
+      │    │    │    │    │         └── assignment-cast: DECIMAL(10)
+      │    │    │    │    │              └── d:12
+      │    │    │    │    └── flags: avoid-full-scan
       │    │    │    └── projections
       │    │    │         ├── 1 [as=i_new:19]
       │    │    │         └── true [as=b_new:20]
@@ -2531,7 +2590,8 @@ update on_update_bare
       │    ├── select
       │    │    ├── columns: a:6!null v:7 rowid:8!null crdb_internal_mvcc_timestamp:9 tableoid:10
       │    │    ├── scan on_update_bare
-      │    │    │    └── columns: a:6!null v:7 rowid:8!null crdb_internal_mvcc_timestamp:9 tableoid:10
+      │    │    │    ├── columns: a:6!null v:7 rowid:8!null crdb_internal_mvcc_timestamp:9 tableoid:10
+      │    │    │    └── flags: avoid-full-scan
       │    │    └── filters
       │    │         └── a:6 = 2
       │    └── projections
@@ -2553,7 +2613,8 @@ update on_update_bare
       ├── select
       │    ├── columns: a:6!null v:7 rowid:8!null crdb_internal_mvcc_timestamp:9 tableoid:10
       │    ├── scan on_update_bare
-      │    │    └── columns: a:6!null v:7 rowid:8!null crdb_internal_mvcc_timestamp:9 tableoid:10
+      │    │    ├── columns: a:6!null v:7 rowid:8!null crdb_internal_mvcc_timestamp:9 tableoid:10
+      │    │    └── flags: avoid-full-scan
       │    └── filters
       │         └── a:6 = 2
       └── projections
@@ -2576,7 +2637,8 @@ update on_update_with_default
       │    ├── select
       │    │    ├── columns: a:6!null v:7 rowid:8!null crdb_internal_mvcc_timestamp:9 tableoid:10
       │    │    ├── scan on_update_with_default
-      │    │    │    └── columns: a:6!null v:7 rowid:8!null crdb_internal_mvcc_timestamp:9 tableoid:10
+      │    │    │    ├── columns: a:6!null v:7 rowid:8!null crdb_internal_mvcc_timestamp:9 tableoid:10
+      │    │    │    └── flags: avoid-full-scan
       │    │    └── filters
       │    │         └── a:6 = 2
       │    └── projections
@@ -2598,7 +2660,8 @@ update on_update_with_default
       ├── select
       │    ├── columns: a:6!null v:7 rowid:8!null crdb_internal_mvcc_timestamp:9 tableoid:10
       │    ├── scan on_update_with_default
-      │    │    └── columns: a:6!null v:7 rowid:8!null crdb_internal_mvcc_timestamp:9 tableoid:10
+      │    │    ├── columns: a:6!null v:7 rowid:8!null crdb_internal_mvcc_timestamp:9 tableoid:10
+      │    │    └── flags: avoid-full-scan
       │    └── filters
       │         └── a:6 = 2
       └── projections
@@ -2627,7 +2690,8 @@ update generated_as_identity
  └── project
       ├── columns: b_new:13 a:7 b:8!null c:9!null rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
       ├── scan generated_as_identity
-      │    └── columns: a:7 b:8!null c:9!null rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
+      │    ├── columns: a:7 b:8!null c:9!null rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
+      │    └── flags: avoid-full-scan
       └── projections
            └── nextval('t.public.generated_as_identity_b_seq') [as=b_new:13]
 
@@ -2643,7 +2707,8 @@ update generated_as_identity
  └── project
       ├── columns: a_new:13!null b_new:14 a:7 b:8!null c:9!null rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
       ├── scan generated_as_identity
-      │    └── columns: a:7 b:8!null c:9!null rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
+      │    ├── columns: a:7 b:8!null c:9!null rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
+      │    └── flags: avoid-full-scan
       └── projections
            ├── 10 [as=a_new:13]
            └── nextval('t.public.generated_as_identity_b_seq') [as=b_new:14]
@@ -2659,7 +2724,8 @@ update generated_as_identity
  └── project
       ├── columns: c_new:13!null a:7 b:8!null c:9!null rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
       ├── scan generated_as_identity
-      │    └── columns: a:7 b:8!null c:9!null rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
+      │    ├── columns: a:7 b:8!null c:9!null rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
+      │    └── flags: avoid-full-scan
       └── projections
            └── 1 + 1 [as=c_new:13]
 
@@ -2675,7 +2741,8 @@ update generated_as_identity
  └── project
       ├── columns: a_new:13!null c_new:14!null a:7 b:8!null c:9!null rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
       ├── scan generated_as_identity
-      │    └── columns: a:7 b:8!null c:9!null rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
+      │    ├── columns: a:7 b:8!null c:9!null rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
+      │    └── flags: avoid-full-scan
       └── projections
            ├── 10 [as=a_new:13]
            └── 1 + 1 [as=c_new:14]
@@ -2691,7 +2758,8 @@ update generated_as_identity
  └── project
       ├── columns: c_new:13 a:7 b:8!null c:9!null rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
       ├── scan generated_as_identity
-      │    └── columns: a:7 b:8!null c:9!null rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
+      │    ├── columns: a:7 b:8!null c:9!null rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
+      │    └── flags: avoid-full-scan
       └── projections
            └── nextval('t.public.generated_as_identity_c_seq') [as=c_new:13]
 
@@ -2707,7 +2775,8 @@ update generated_as_identity
  └── project
       ├── columns: a_new:13!null c_new:14 a:7 b:8!null c:9!null rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
       ├── scan generated_as_identity
-      │    └── columns: a:7 b:8!null c:9!null rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
+      │    ├── columns: a:7 b:8!null c:9!null rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
+      │    └── flags: avoid-full-scan
       └── projections
            ├── 10 [as=a_new:13]
            └── nextval('t.public.generated_as_identity_c_seq') [as=c_new:14]
@@ -2731,7 +2800,8 @@ update serial_t
  └── project
       ├── columns: a_new:11!null a:6 b:7 rowid:8!null crdb_internal_mvcc_timestamp:9 tableoid:10
       ├── scan serial_t
-      │    └── columns: a:6 b:7 rowid:8!null crdb_internal_mvcc_timestamp:9 tableoid:10
+      │    ├── columns: a:6 b:7 rowid:8!null crdb_internal_mvcc_timestamp:9 tableoid:10
+      │    └── flags: avoid-full-scan
       └── projections
            └── 1 + 2 [as=a_new:11]
 
@@ -2746,6 +2816,7 @@ update serial_t
  └── project
       ├── columns: a_new:11 a:6 b:7 rowid:8!null crdb_internal_mvcc_timestamp:9 tableoid:10
       ├── scan serial_t
-      │    └── columns: a:6 b:7 rowid:8!null crdb_internal_mvcc_timestamp:9 tableoid:10
+      │    ├── columns: a:6 b:7 rowid:8!null crdb_internal_mvcc_timestamp:9 tableoid:10
+      │    └── flags: avoid-full-scan
       └── projections
            └── unique_rowid() [as=a_new:11]

--- a/pkg/sql/opt/optbuilder/testdata/update-col-cast-bug
+++ b/pkg/sql/opt/optbuilder/testdata/update-col-cast-bug
@@ -28,10 +28,11 @@ with &1 (cte)
            │    │    │    ├── columns: t.c:9(int2) a:7(int2) b:8(int2) rowid:10(int!null) crdb_internal_mvcc_timestamp:11(decimal) tableoid:12(oid)
            │    │    │    ├── scan t
            │    │    │    │    ├── columns: a:7(int2) b:8(int2) rowid:10(int!null) crdb_internal_mvcc_timestamp:11(decimal) tableoid:12(oid)
-           │    │    │    │    └── computed column expressions
-           │    │    │    │         └── t.c:9
-           │    │    │    │              └── assignment-cast: INT2 [type=int2]
-           │    │    │    │                   └── a:7 + b:8 [type=int]
+           │    │    │    │    ├── computed column expressions
+           │    │    │    │    │    └── t.c:9
+           │    │    │    │    │         └── assignment-cast: INT2 [type=int2]
+           │    │    │    │    │              └── a:7 + b:8 [type=int]
+           │    │    │    │    └── flags: avoid-full-scan
            │    │    │    └── projections
            │    │    │         └── assignment-cast: INT2 [as=t.c:9, type=int2]
            │    │    │              └── a:7 + b:8 [type=int]

--- a/pkg/sql/opt/optbuilder/testdata/update_from
+++ b/pkg/sql/opt/optbuilder/testdata/update_from
@@ -26,7 +26,8 @@ update abc
       ├── project
       │    ├── columns: other.a:11!null other.b:12 other.c:13 other.crdb_internal_mvcc_timestamp:14 other.tableoid:15 abc.a:6!null abc.b:7 abc.c:8
       │    ├── scan abc
-      │    │    └── columns: abc.a:6!null abc.b:7 abc.c:8 abc.crdb_internal_mvcc_timestamp:9 abc.tableoid:10
+      │    │    ├── columns: abc.a:6!null abc.b:7 abc.c:8 abc.crdb_internal_mvcc_timestamp:9 abc.tableoid:10
+      │    │    └── flags: avoid-full-scan
       │    └── projections
       │         ├── abc.a:6 [as=other.a:11]
       │         ├── abc.b:7 [as=other.b:12]
@@ -51,14 +52,13 @@ update abc
  └── distinct-on
       ├── columns: abc.a:6!null abc.b:7 abc.c:8 other.a:11!null other.b:12 other.c:13 rowid:14!null other.crdb_internal_mvcc_timestamp:15 other.tableoid:16
       ├── grouping columns: abc.a:6!null
-      ├── inner-join (hash)
+      ├── inner-join (lookup abc)
       │    ├── columns: abc.a:6!null abc.b:7 abc.c:8 other.a:11!null other.b:12 other.c:13 rowid:14!null other.crdb_internal_mvcc_timestamp:15 other.tableoid:16
-      │    ├── scan abc
-      │    │    └── columns: abc.a:6!null abc.b:7 abc.c:8
+      │    ├── key columns: [11] = [6]
+      │    ├── lookup columns are key
       │    ├── scan new_abc [as=other]
       │    │    └── columns: other.a:11 other.b:12 other.c:13 rowid:14!null other.crdb_internal_mvcc_timestamp:15 other.tableoid:16
-      │    └── filters
-      │         └── abc.a:6 = other.a:11
+      │    └── filters (true)
       └── aggregations
            ├── first-agg [as=abc.b:7]
            │    └── abc.b:7
@@ -105,7 +105,8 @@ update abc
       ├── project
       │    ├── columns: old.b:12 old.c:13 abc.a:6!null abc.b:7 abc.c:8
       │    ├── scan abc
-      │    │    └── columns: abc.a:6!null abc.b:7 abc.c:8
+      │    │    ├── columns: abc.a:6!null abc.b:7 abc.c:8
+      │    │    └── flags: avoid-full-scan
       │    └── projections
       │         ├── abc.b:7 [as=old.b:12]
       │         └── abc.c:8 [as=old.c:13]
@@ -133,7 +134,8 @@ update abc
       ├── project
       │    ├── columns: old.a:11!null old.b:12 old.c:13 abc.a:6!null abc.b:7 abc.c:8
       │    ├── scan abc
-      │    │    └── columns: abc.a:6!null abc.b:7 abc.c:8
+      │    │    ├── columns: abc.a:6!null abc.b:7 abc.c:8
+      │    │    └── flags: avoid-full-scan
       │    └── projections
       │         ├── abc.a:6 [as=old.a:11]
       │         ├── abc.b:7 [as=old.b:12]
@@ -159,7 +161,8 @@ update abc
       │    ├── columns: abc.a:6!null abc.b:7 abc.c:8 old.a:11!null old.b:12 old.c:13 old.crdb_internal_mvcc_timestamp:14 old.tableoid:15
       │    ├── scan abc
       │    │    ├── columns: abc.a:6!null abc.b:7 abc.c:8
-      │    │    └── constraint: /6: [/2 - /2]
+      │    │    ├── constraint: /6: [/2 - /2]
+      │    │    └── flags: avoid-full-scan
       │    ├── scan abc [as=old]
       │    │    ├── columns: old.a:11!null old.b:12 old.c:13 old.crdb_internal_mvcc_timestamp:14 old.tableoid:15
       │    │    └── constraint: /11: [/2 - /2]
@@ -229,14 +232,13 @@ update abc
       │    ├── columns: abc.a:6!null abc.b:7 abc.c:8 ab.a:11!null ab.b:12 ab.rowid:13!null ab.crdb_internal_mvcc_timestamp:14 ab.tableoid:15 ac.a:16!null ac.c:17 ac.rowid:18!null ac.crdb_internal_mvcc_timestamp:19 ac.tableoid:20
       │    ├── scan ab
       │    │    └── columns: ab.a:11 ab.b:12 ab.rowid:13!null ab.crdb_internal_mvcc_timestamp:14 ab.tableoid:15
-      │    ├── inner-join (hash)
+      │    ├── inner-join (lookup abc)
       │    │    ├── columns: abc.a:6!null abc.b:7 abc.c:8 ac.a:16!null ac.c:17 ac.rowid:18!null ac.crdb_internal_mvcc_timestamp:19 ac.tableoid:20
-      │    │    ├── scan abc
-      │    │    │    └── columns: abc.a:6!null abc.b:7 abc.c:8
+      │    │    ├── key columns: [16] = [6]
+      │    │    ├── lookup columns are key
       │    │    ├── scan ac
       │    │    │    └── columns: ac.a:16 ac.c:17 ac.rowid:18!null ac.crdb_internal_mvcc_timestamp:19 ac.tableoid:20
-      │    │    └── filters
-      │    │         └── abc.a:6 = ac.a:16
+      │    │    └── filters (true)
       │    └── filters
       │         └── ab.a:11 = ac.a:16
       └── aggregations
@@ -296,14 +298,13 @@ update abc
       │    ├── columns: abc.a:6!null abc.b:7 abc.c:8 ab.a:11!null ab.b:12 ac.a:16!null ac.c:17
       │    ├── scan ab
       │    │    └── columns: ab.a:11 ab.b:12
-      │    ├── inner-join (hash)
+      │    ├── inner-join (lookup abc)
       │    │    ├── columns: abc.a:6!null abc.b:7 abc.c:8 ac.a:16!null ac.c:17
-      │    │    ├── scan abc
-      │    │    │    └── columns: abc.a:6!null abc.b:7 abc.c:8
+      │    │    ├── key columns: [16] = [6]
+      │    │    ├── lookup columns are key
       │    │    ├── scan ac
       │    │    │    └── columns: ac.a:16 ac.c:17
-      │    │    └── filters
-      │    │         └── abc.a:6 = ac.a:16
+      │    │    └── filters (true)
       │    └── filters
       │         └── ab.a:11 = ac.a:16
       └── aggregations
@@ -350,14 +351,13 @@ update abc
       │    ├── columns: abc.a:6!null abc.b:7 abc.c:8 ab.a:11!null ab.b:12 ab.rowid:13!null ac.a:16!null ac.c:17 ac.rowid:18!null
       │    ├── scan ab
       │    │    └── columns: ab.a:11 ab.b:12 ab.rowid:13!null
-      │    ├── inner-join (hash)
+      │    ├── inner-join (lookup abc)
       │    │    ├── columns: abc.a:6!null abc.b:7 abc.c:8 ac.a:16!null ac.c:17 ac.rowid:18!null
-      │    │    ├── scan abc
-      │    │    │    └── columns: abc.a:6!null abc.b:7 abc.c:8
+      │    │    ├── key columns: [16] = [6]
+      │    │    ├── lookup columns are key
       │    │    ├── scan ac
       │    │    │    └── columns: ac.a:16 ac.c:17 ac.rowid:18!null
-      │    │    └── filters
-      │    │         └── abc.a:6 = ac.a:16
+      │    │    └── filters (true)
       │    └── filters
       │         └── ab.a:11 = ac.a:16
       └── aggregations
@@ -389,16 +389,12 @@ update abc
  │    └── b_cast:15 => b:2
  └── project
       ├── columns: b_cast:15 a:6!null b:7 c:8 k:11!null d:12 other.crdb_internal_mvcc_timestamp:13 other.tableoid:14
-      ├── inner-join (merge)
+      ├── inner-join (lookup abc)
       │    ├── columns: a:6!null b:7 c:8 k:11!null d:12 other.crdb_internal_mvcc_timestamp:13 other.tableoid:14
-      │    ├── left ordering: +6
-      │    ├── right ordering: +11
-      │    ├── scan abc
-      │    │    ├── columns: a:6!null b:7 c:8
-      │    │    └── ordering: +6
+      │    ├── key columns: [11] = [6]
+      │    ├── lookup columns are key
       │    ├── scan dec [as=other]
-      │    │    ├── columns: k:11!null d:12 other.crdb_internal_mvcc_timestamp:13 other.tableoid:14
-      │    │    └── ordering: +11
+      │    │    └── columns: k:11!null d:12 other.crdb_internal_mvcc_timestamp:13 other.tableoid:14
       │    └── filters (true)
       └── projections
            └── assignment-cast: INT8 [as=b_cast:15]
@@ -442,7 +438,8 @@ project
            │    │    │    ├── inner-join (cross)
            │    │    │    │    ├── columns: a:5 rowid:6!null crdb_internal_mvcc_timestamp:7 tableoid:8 column1:9!null
            │    │    │    │    ├── scan t61520 [as=t]
-           │    │    │    │    │    └── columns: a:5 rowid:6!null crdb_internal_mvcc_timestamp:7 tableoid:8
+           │    │    │    │    │    ├── columns: a:5 rowid:6!null crdb_internal_mvcc_timestamp:7 tableoid:8
+           │    │    │    │    │    └── flags: avoid-full-scan
            │    │    │    │    ├── values
            │    │    │    │    │    ├── columns: column1:9!null
            │    │    │    │    │    └── (1.0,)
@@ -494,7 +491,8 @@ project
            │    │    ├── inner-join (cross)
            │    │    │    ├── columns: a:5 rowid:6!null crdb_internal_mvcc_timestamp:7 tableoid:8 column1:9!null
            │    │    │    ├── scan t89779
-           │    │    │    │    └── columns: a:5 rowid:6!null crdb_internal_mvcc_timestamp:7 tableoid:8
+           │    │    │    │    ├── columns: a:5 rowid:6!null crdb_internal_mvcc_timestamp:7 tableoid:8
+           │    │    │    │    └── flags: avoid-full-scan
            │    │    │    ├── values
            │    │    │    │    ├── columns: column1:9!null
            │    │    │    │    └── (1,)

--- a/pkg/sql/opt/optbuilder/testdata/upsert
+++ b/pkg/sql/opt/optbuilder/testdata/upsert
@@ -168,7 +168,7 @@ upsert abc
       │    │    │    │    ├── computed column expressions
       │    │    │    │    │    └── c:16
       │    │    │    │    │         └── b:15 + 1
-      │    │    │    │    └── flags: disabled not visible index feature
+      │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
       │    │    │    └── filters
       │    │    │         └── x:7 = a:14
       │    │    └── projections
@@ -240,7 +240,7 @@ project
            │    │    │    │    ├── computed column expressions
            │    │    │    │    │    └── c:15
            │    │    │    │    │         └── b:14 + 1
-           │    │    │    │    └── flags: disabled not visible index feature
+           │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
            │    │    │    └── filters
            │    │    │         ├── y:8 = b:14
            │    │    │         └── c_comp:12 = c:15
@@ -314,7 +314,7 @@ upsert abc
       │    │    │    │    │    ├── computed column expressions
       │    │    │    │    │    │    └── c:16
       │    │    │    │    │    │         └── b:15 + 1
-      │    │    │    │    │    └── flags: disabled not visible index feature
+      │    │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
       │    │    │    │    └── filters
       │    │    │    │         └── x:7 = a:14
       │    │    │    └── filters
@@ -395,7 +395,7 @@ sort
       │              │    │    │    │    ├── computed column expressions
       │              │    │    │    │    │    └── abc.c:13
       │              │    │    │    │    │         └── abc.b:12 + 1
-      │              │    │    │    │    └── flags: disabled not visible index feature
+      │              │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
       │              │    │    │    └── filters
       │              │    │    │         └── column1:7 = abc.a:11
       │              │    │    └── projections
@@ -467,7 +467,7 @@ upsert abc [as=tab]
       │    │    │    │    ├── computed column expressions
       │    │    │    │    │    └── c:13
       │    │    │    │    │         └── b:12 + 1
-      │    │    │    │    └── flags: disabled not visible index feature
+      │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
       │    │    │    └── filters
       │    │    │         └── column1:7 = a:11
       │    │    └── projections
@@ -531,7 +531,7 @@ upsert abc
       │    │    │    │    ├── computed column expressions
       │    │    │    │    │    └── c:13
       │    │    │    │    │         └── b:12 + 1
-      │    │    │    │    └── flags: disabled not visible index feature
+      │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
       │    │    │    └── filters
       │    │    │         ├── column2:8 = b:12
       │    │    │         └── c_comp:10 = c:13
@@ -632,7 +632,7 @@ upsert t102909
       │    │    │    ├── computed column expressions
       │    │    │    │    └── c:14
       │    │    │    │         └── a:12 + b:13
-      │    │    │    └── flags: disabled not visible index feature
+      │    │    │    └── flags: avoid-full-scan disabled not visible index feature
       │    │    └── filters
       │    │         └── column1:7 = id:11
       │    └── projections
@@ -682,18 +682,18 @@ insert xyz
       │    │    │    │    │    │    └── (4, 5, 6)
       │    │    │    │    │    ├── scan xyz
       │    │    │    │    │    │    ├── columns: x:9!null y:10 z:11
-      │    │    │    │    │    │    └── flags: disabled not visible index feature
+      │    │    │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
       │    │    │    │    │    └── filters
       │    │    │    │    │         └── column1:6 = x:9
       │    │    │    │    ├── scan xyz
       │    │    │    │    │    ├── columns: x:14!null y:15 z:16
-      │    │    │    │    │    └── flags: disabled not visible index feature
+      │    │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
       │    │    │    │    └── filters
       │    │    │    │         ├── column2:7 = y:15
       │    │    │    │         └── column3:8 = z:16
       │    │    │    ├── scan xyz
       │    │    │    │    ├── columns: x:19!null y:20 z:21
-      │    │    │    │    └── flags: disabled not visible index feature
+      │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
       │    │    │    └── filters
       │    │    │         ├── column2:7 = y:20
       │    │    │         └── column3:8 = z:21
@@ -733,7 +733,7 @@ insert xyz
       │    │    └── (4, 5, 6)
       │    ├── scan xyz
       │    │    ├── columns: x:9!null y:10 z:11
-      │    │    └── flags: disabled not visible index feature
+      │    │    └── flags: avoid-full-scan disabled not visible index feature
       │    └── filters
       │         ├── column2:7 = y:10
       │         └── column3:8 = z:11
@@ -774,17 +774,17 @@ insert uniq
       │    │    │    │    │    │    └── ('x2', 'y2', 'z2')
       │    │    │    │    │    ├── scan uniq
       │    │    │    │    │    │    ├── columns: x:9!null y:10 z:11
-      │    │    │    │    │    │    └── flags: disabled not visible index feature
+      │    │    │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
       │    │    │    │    │    └── filters
       │    │    │    │    │         └── column1:6 = x:9
       │    │    │    │    ├── scan uniq
       │    │    │    │    │    ├── columns: x:14!null y:15 z:16
-      │    │    │    │    │    └── flags: disabled not visible index feature
+      │    │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
       │    │    │    │    └── filters
       │    │    │    │         └── column2:7 = y:15
       │    │    │    ├── scan uniq
       │    │    │    │    ├── columns: x:19!null y:20 z:21
-      │    │    │    │    └── flags: disabled not visible index feature
+      │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
       │    │    │    └── filters
       │    │    │         └── column3:8 = z:21
       │    │    └── aggregations
@@ -838,18 +838,18 @@ insert xyz
       │    │    │    │    │    │    └── (4, 5, 6)
       │    │    │    │    │    ├── scan xyz
       │    │    │    │    │    │    ├── columns: x:9!null y:10 z:11
-      │    │    │    │    │    │    └── flags: force-index=xyz_pkey disabled not visible index feature
+      │    │    │    │    │    │    └── flags: force-index=xyz_pkey avoid-full-scan disabled not visible index feature
       │    │    │    │    │    └── filters
       │    │    │    │    │         └── column1:6 = x:9
       │    │    │    │    ├── scan xyz
       │    │    │    │    │    ├── columns: x:14!null y:15 z:16
-      │    │    │    │    │    └── flags: force-index=xyz_pkey disabled not visible index feature
+      │    │    │    │    │    └── flags: force-index=xyz_pkey avoid-full-scan disabled not visible index feature
       │    │    │    │    └── filters
       │    │    │    │         ├── column2:7 = y:15
       │    │    │    │         └── column3:8 = z:16
       │    │    │    ├── scan xyz
       │    │    │    │    ├── columns: x:19!null y:20 z:21
-      │    │    │    │    └── flags: force-index=xyz_pkey disabled not visible index feature
+      │    │    │    │    └── flags: force-index=xyz_pkey avoid-full-scan disabled not visible index feature
       │    │    │    └── filters
       │    │    │         ├── column2:7 = y:20
       │    │    │         └── column3:8 = z:21
@@ -888,7 +888,7 @@ insert xyz
       │    │    └── (4, 5, 6)
       │    ├── scan xyz
       │    │    ├── columns: x:9!null y:10 z:11
-      │    │    └── flags: force-index=xyz_y_z_key disabled not visible index feature
+      │    │    └── flags: force-index=xyz_y_z_key avoid-full-scan disabled not visible index feature
       │    └── filters
       │         ├── column2:7 = y:10
       │         └── column3:8 = z:11
@@ -929,18 +929,18 @@ insert xyz
       │    │    │    │    │    │    └── (4, 5, 6)
       │    │    │    │    │    ├── scan xyz
       │    │    │    │    │    │    ├── columns: x:9!null y:10 z:11
-      │    │    │    │    │    │    └── flags: force-index=xyz_y_idx,fwd disabled not visible index feature
+      │    │    │    │    │    │    └── flags: force-index=xyz_y_idx,fwd avoid-full-scan disabled not visible index feature
       │    │    │    │    │    └── filters
       │    │    │    │    │         └── column1:6 = x:9
       │    │    │    │    ├── scan xyz
       │    │    │    │    │    ├── columns: x:14!null y:15 z:16
-      │    │    │    │    │    └── flags: force-index=xyz_y_idx,fwd disabled not visible index feature
+      │    │    │    │    │    └── flags: force-index=xyz_y_idx,fwd avoid-full-scan disabled not visible index feature
       │    │    │    │    └── filters
       │    │    │    │         ├── column2:7 = y:15
       │    │    │    │         └── column3:8 = z:16
       │    │    │    ├── scan xyz
       │    │    │    │    ├── columns: x:19!null y:20 z:21
-      │    │    │    │    └── flags: force-index=xyz_y_idx,fwd disabled not visible index feature
+      │    │    │    │    └── flags: force-index=xyz_y_idx,fwd avoid-full-scan disabled not visible index feature
       │    │    │    └── filters
       │    │    │         ├── column2:7 = y:20
       │    │    │         └── column3:8 = z:21
@@ -989,18 +989,18 @@ insert xyz
       │    │    │    │    │    │    └── (4, 5, 6)
       │    │    │    │    │    ├── scan xyz
       │    │    │    │    │    │    ├── columns: x:9!null y:10 z:11
-      │    │    │    │    │    │    └── flags: no-full-scan disabled not visible index feature
+      │    │    │    │    │    │    └── flags: no-full-scan avoid-full-scan disabled not visible index feature
       │    │    │    │    │    └── filters
       │    │    │    │    │         └── column1:6 = x:9
       │    │    │    │    ├── scan xyz
       │    │    │    │    │    ├── columns: x:14!null y:15 z:16
-      │    │    │    │    │    └── flags: no-full-scan disabled not visible index feature
+      │    │    │    │    │    └── flags: no-full-scan avoid-full-scan disabled not visible index feature
       │    │    │    │    └── filters
       │    │    │    │         ├── column2:7 = y:15
       │    │    │    │         └── column3:8 = z:16
       │    │    │    ├── scan xyz
       │    │    │    │    ├── columns: x:19!null y:20 z:21
-      │    │    │    │    └── flags: no-full-scan disabled not visible index feature
+      │    │    │    │    └── flags: no-full-scan avoid-full-scan disabled not visible index feature
       │    │    │    └── filters
       │    │    │         ├── column2:7 = y:20
       │    │    │         └── column3:8 = z:21
@@ -1074,7 +1074,7 @@ project
  │         │    │    │    │              └── column1:6
  │         │    │    │    ├── scan xyz
  │         │    │    │    │    ├── columns: x:9!null y:10 z:11 crdb_internal_mvcc_timestamp:12 tableoid:13
- │         │    │    │    │    └── flags: disabled not visible index feature
+ │         │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
  │         │    │    │    └── filters
  │         │    │    │         ├── column2:7 = y:10
  │         │    │    │         └── column3:8 = z:11
@@ -1170,7 +1170,7 @@ upsert abc
       │    │    │    │    ├── computed column expressions
       │    │    │    │    │    └── c:13
       │    │    │    │    │         └── b:12 + 1
-      │    │    │    │    └── flags: disabled not visible index feature
+      │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
       │    │    │    └── filters
       │    │    │         └── column1:7 = a:11
       │    │    ├── max1-row
@@ -1249,7 +1249,7 @@ upsert abc
       │    │    │    │    ├── computed column expressions
       │    │    │    │    │    └── c:13
       │    │    │    │    │         └── b:12 + 1
-      │    │    │    │    └── flags: disabled not visible index feature
+      │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
       │    │    │    └── filters
       │    │    │         └── column1:7 = a:11
       │    │    └── projections
@@ -1301,7 +1301,7 @@ upsert xyz
       │    │    │              └── column3:8
       │    │    ├── scan xyz
       │    │    │    ├── columns: x:9!null y:10 z:11 crdb_internal_mvcc_timestamp:12 tableoid:13
-      │    │    │    └── flags: force-index=xyz_pkey disabled not visible index feature
+      │    │    │    └── flags: force-index=xyz_pkey avoid-full-scan disabled not visible index feature
       │    │    └── filters
       │    │         └── column1:6 = x:9
       │    └── projections
@@ -1345,7 +1345,7 @@ upsert xyz
       │    │    │              └── column1:6
       │    │    ├── scan xyz
       │    │    │    ├── columns: x:9!null y:10 z:11 crdb_internal_mvcc_timestamp:12 tableoid:13
-      │    │    │    └── flags: force-index=xyz_y_idx disabled not visible index feature
+      │    │    │    └── flags: force-index=xyz_y_idx avoid-full-scan disabled not visible index feature
       │    │    └── filters
       │    │         ├── column2:7 = y:10
       │    │         └── column3:8 = z:11
@@ -1390,7 +1390,7 @@ upsert xyz
       │    │              └── column3:8
       │    ├── scan xyz
       │    │    ├── columns: x:9!null y:10 z:11 crdb_internal_mvcc_timestamp:12 tableoid:13
-      │    │    └── flags: force-index=xyz_z_y_key,fwd disabled not visible index feature
+      │    │    └── flags: force-index=xyz_z_y_key,fwd avoid-full-scan disabled not visible index feature
       │    └── filters
       │         └── column1:6 = x:9
       └── projections
@@ -1430,7 +1430,7 @@ upsert xyz
       │    │              └── column1:6
       │    ├── scan xyz
       │    │    ├── columns: x:9!null y:10 z:11 crdb_internal_mvcc_timestamp:12 tableoid:13
-      │    │    └── flags: no-full-scan disabled not visible index feature
+      │    │    └── flags: no-full-scan avoid-full-scan disabled not visible index feature
       │    └── filters
       │         ├── column2:7 = y:10
       │         └── column3:8 = z:11
@@ -1499,7 +1499,7 @@ upsert mutation
       │    │    │    │    │    ├── columns: m:12!null n:13 o:14 p:15 q:16 crdb_internal_mvcc_timestamp:17 tableoid:18
       │    │    │    │    │    ├── check constraint expressions
       │    │    │    │    │    │    └── m:12 > 0
-      │    │    │    │    │    └── flags: disabled not visible index feature
+      │    │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
       │    │    │    │    └── filters
       │    │    │    │         └── column1:8 = m:12
       │    │    │    └── projections
@@ -1552,7 +1552,7 @@ upsert xyz
       │    │              └── y_default:7
       │    ├── scan xyz
       │    │    ├── columns: x:8!null y:9 z:10 crdb_internal_mvcc_timestamp:11 tableoid:12
-      │    │    └── flags: disabled not visible index feature
+      │    │    └── flags: avoid-full-scan disabled not visible index feature
       │    └── filters
       │         └── column1:6 = x:8
       └── projections
@@ -1628,7 +1628,7 @@ with &1
  │              │    │    ├── computed column expressions
  │              │    │    │    └── abc.c:13
  │              │    │    │         └── abc.b:12 + 1
- │              │    │    └── flags: disabled not visible index feature
+ │              │    │    └── flags: avoid-full-scan disabled not visible index feature
  │              │    └── filters
  │              │         └── rowid_default:9 = rowid:14
  │              └── projections
@@ -1674,7 +1674,7 @@ upsert xyz
       │    │              └── column3:8
       │    ├── scan xyz
       │    │    ├── columns: x:9!null y:10 z:11 crdb_internal_mvcc_timestamp:12 tableoid:13
-      │    │    └── flags: disabled not visible index feature
+      │    │    └── flags: avoid-full-scan disabled not visible index feature
       │    └── filters
       │         └── column2:7 = x:9
       └── projections
@@ -1746,7 +1746,7 @@ upsert checks
       │    │    │    ├── computed column expressions
       │    │    │    │    └── d:14
       │    │    │    │         └── c:13 + 1
-      │    │    │    └── flags: disabled not visible index feature
+      │    │    │    └── flags: avoid-full-scan disabled not visible index feature
       │    │    └── filters
       │    │         └── column1:7 = a:11
       │    └── projections
@@ -1806,7 +1806,7 @@ upsert mutation
       │    │    │    ├── columns: m:12!null n:13 o:14 p:15 q:16 crdb_internal_mvcc_timestamp:17 tableoid:18
       │    │    │    ├── check constraint expressions
       │    │    │    │    └── m:12 > 0
-      │    │    │    └── flags: disabled not visible index feature
+      │    │    │    └── flags: avoid-full-scan disabled not visible index feature
       │    │    └── filters
       │    │         └── column1:8 = m:12
       │    └── projections
@@ -1865,7 +1865,7 @@ upsert mutation
       │    │    │    ├── columns: m:12!null n:13 o:14 p:15 q:16 crdb_internal_mvcc_timestamp:17 tableoid:18
       │    │    │    ├── check constraint expressions
       │    │    │    │    └── m:12 > 0
-      │    │    │    └── flags: disabled not visible index feature
+      │    │    │    └── flags: avoid-full-scan disabled not visible index feature
       │    │    └── filters
       │    │         └── column1:8 = m:12
       │    └── projections
@@ -1913,7 +1913,7 @@ upsert xyz
       │    │              └── column3:8
       │    ├── scan xyz
       │    │    ├── columns: x:9!null y:10 z:11 crdb_internal_mvcc_timestamp:12 tableoid:13
-      │    │    └── flags: force-index=xyz_pkey disabled not visible index feature
+      │    │    └── flags: force-index=xyz_pkey avoid-full-scan disabled not visible index feature
       │    └── filters
       │         └── column2:7 = x:9
       └── projections
@@ -1951,7 +1951,7 @@ upsert xyz
       │    │              └── column3:8
       │    ├── scan xyz
       │    │    ├── columns: x:9!null y:10 z:11 crdb_internal_mvcc_timestamp:12 tableoid:13
-      │    │    └── flags: force-index=xyz_y_z_key disabled not visible index feature
+      │    │    └── flags: force-index=xyz_y_z_key avoid-full-scan disabled not visible index feature
       │    └── filters
       │         └── column2:7 = x:9
       └── projections
@@ -1989,7 +1989,7 @@ upsert xyz
       │    │              └── column3:8
       │    ├── scan xyz
       │    │    ├── columns: x:9!null y:10 z:11 crdb_internal_mvcc_timestamp:12 tableoid:13
-      │    │    └── flags: no-full-scan disabled not visible index feature
+      │    │    └── flags: no-full-scan avoid-full-scan disabled not visible index feature
       │    └── filters
       │         └── column2:7 = x:9
       └── projections
@@ -2062,7 +2062,7 @@ upsert checks
       │    │    │    │    │    ├── computed column expressions
       │    │    │    │    │    │    └── d:14
       │    │    │    │    │    │         └── c:13 + 1
-      │    │    │    │    │    └── flags: disabled not visible index feature
+      │    │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
       │    │    │    │    └── filters
       │    │    │    │         └── column1:7 = a:11
       │    │    │    └── projections
@@ -2117,7 +2117,7 @@ insert checks
       │    │    │    ├── computed column expressions
       │    │    │    │    └── d:14
       │    │    │    │         └── c:13 + 1
-      │    │    │    └── flags: disabled not visible index feature
+      │    │    │    └── flags: avoid-full-scan disabled not visible index feature
       │    │    └── filters
       │    │         └── column1:7 = a:11
       │    └── aggregations
@@ -2184,7 +2184,7 @@ upsert checks
       │    │    │    │    ├── computed column expressions
       │    │    │    │    │    └── d:14
       │    │    │    │    │         └── c:13 + 1
-      │    │    │    │    └── flags: disabled not visible index feature
+      │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
       │    │    │    └── filters
       │    │    │         └── column1:7 = a:11
       │    │    └── projections
@@ -2259,7 +2259,7 @@ upsert checks
       │    │    │    │    │    ├── computed column expressions
       │    │    │    │    │    │    └── d:18
       │    │    │    │    │    │         └── checks.c:17 + 1
-      │    │    │    │    │    └── flags: disabled not visible index feature
+      │    │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
       │    │    │    │    └── filters
       │    │    │    │         └── abc.a:7 = checks.a:15
       │    │    │    └── projections
@@ -2322,7 +2322,7 @@ upsert xyz
       │    │    │              └── a:6
       │    │    ├── scan xyz
       │    │    │    ├── columns: x:12!null y:13 z:14 xyz.crdb_internal_mvcc_timestamp:15 xyz.tableoid:16
-      │    │    │    └── flags: disabled not visible index feature
+      │    │    │    └── flags: avoid-full-scan disabled not visible index feature
       │    │    └── filters
       │    │         ├── b:7 = y:13
       │    │         └── c:8 = z:14
@@ -2409,7 +2409,7 @@ upsert multi_col_fam_checks
       │    │    │              └── c_default:9
       │    │    ├── scan multi_col_fam_checks
       │    │    │    ├── columns: a:10!null b:11 c:12 d:13 crdb_internal_mvcc_timestamp:14 tableoid:15
-      │    │    │    └── flags: disabled not visible index feature
+      │    │    │    └── flags: avoid-full-scan disabled not visible index feature
       │    │    └── filters
       │    │         └── column1:7 = a:10
       │    └── projections
@@ -2489,7 +2489,7 @@ upsert multi_col_fam_checks
       │    │    │              └── c_default:9
       │    │    ├── scan multi_col_fam_checks
       │    │    │    ├── columns: a:10!null b:11 c:12 d:13 crdb_internal_mvcc_timestamp:14 tableoid:15
-      │    │    │    └── flags: disabled not visible index feature
+      │    │    │    └── flags: avoid-full-scan disabled not visible index feature
       │    │    └── filters
       │    │         └── column1:7 = a:10
       │    └── projections
@@ -2539,7 +2539,7 @@ upsert multi_col_fam_checks
       │    │    │              └── b_default:9
       │    │    ├── scan multi_col_fam_checks
       │    │    │    ├── columns: a:10!null b:11 c:12 d:13 crdb_internal_mvcc_timestamp:14 tableoid:15
-      │    │    │    └── flags: disabled not visible index feature
+      │    │    │    └── flags: avoid-full-scan disabled not visible index feature
       │    │    └── filters
       │    │         └── column1:7 = a:10
       │    └── projections
@@ -2596,7 +2596,7 @@ upsert multi_col_fam_checks
       │    │    │    │              └── b_default:8
       │    │    │    ├── scan multi_col_fam_checks
       │    │    │    │    ├── columns: a:9!null b:10 c:11 d:12 crdb_internal_mvcc_timestamp:13 tableoid:14
-      │    │    │    │    └── flags: disabled not visible index feature
+      │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
       │    │    │    └── filters
       │    │    │         └── column1:7 = a:9
       │    │    └── projections
@@ -2662,7 +2662,7 @@ upsert multi_col_fam_checks
       │    │    │    │              └── a:7
       │    │    │    ├── scan multi_col_fam_checks
       │    │    │    │    ├── columns: a:14!null b:15 c:16 d:17 crdb_internal_mvcc_timestamp:18 tableoid:19
-      │    │    │    │    └── flags: disabled not visible index feature
+      │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
       │    │    │    └── filters
       │    │    │         └── b_default:13 = d:17
       │    │    └── projections
@@ -2719,7 +2719,7 @@ upsert multi_col_fam_checks
       │    │    │    │              └── d_default:10
       │    │    │    ├── scan multi_col_fam_checks
       │    │    │    │    ├── columns: a:11!null b:12 c:13 d:14 crdb_internal_mvcc_timestamp:15 tableoid:16
-      │    │    │    │    └── flags: disabled not visible index feature
+      │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
       │    │    │    └── filters
       │    │    │         ├── column1:7 = a:11
       │    │    │         └── column2:8 = b:12
@@ -2777,7 +2777,7 @@ upsert multi_col_fam_checks
       │    │    │    │              └── b_default:8
       │    │    │    ├── scan multi_col_fam_checks
       │    │    │    │    ├── columns: a:9!null b:10 c:11 d:12 crdb_internal_mvcc_timestamp:13 tableoid:14
-      │    │    │    │    └── flags: disabled not visible index feature
+      │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
       │    │    │    └── filters
       │    │    │         └── column1:7 = a:9
       │    │    └── projections
@@ -2831,7 +2831,7 @@ upsert multi_col_fam_checks
       │    │    │    │              └── column4:10
       │    │    │    ├── scan multi_col_fam_checks
       │    │    │    │    ├── columns: a:11!null b:12 c:13 d:14 crdb_internal_mvcc_timestamp:15 tableoid:16
-      │    │    │    │    └── flags: disabled not visible index feature
+      │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
       │    │    │    └── filters
       │    │    │         ├── column2:8 = b:12
       │    │    │         └── column3:9 = c:13
@@ -2886,7 +2886,7 @@ upsert multi_col_fam_checks
       │    │    │    │              └── b_default:8
       │    │    │    ├── scan multi_col_fam_checks
       │    │    │    │    ├── columns: a:9!null b:10 c:11 d:12 crdb_internal_mvcc_timestamp:13 tableoid:14
-      │    │    │    │    └── flags: disabled not visible index feature
+      │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
       │    │    │    └── filters
       │    │    │         └── column1:7 = a:9
       │    │    └── projections
@@ -2972,7 +2972,7 @@ upsert decimals
       │    │    │    │    │    └── d:18
       │    │    │    │    │         └── assignment-cast: DECIMAL(10,1)
       │    │    │    │    │              └── a:15 + c:17
-      │    │    │    │    └── flags: disabled not visible index feature
+      │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
       │    │    │    └── filters
       │    │    │         └── a_cast:9 = a:15
       │    │    └── projections
@@ -3051,7 +3051,7 @@ upsert decimals
       │    │    │    │    │    └── d:17
       │    │    │    │    │         └── assignment-cast: DECIMAL(10,1)
       │    │    │    │    │              └── a:14 + c:16
-      │    │    │    │    └── flags: disabled not visible index feature
+      │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
       │    │    │    └── filters
       │    │    │         └── a_cast:8 = a:14
       │    │    └── projections
@@ -3131,7 +3131,7 @@ upsert decimals
       │    │    │    │    │    └── d:17
       │    │    │    │    │         └── assignment-cast: DECIMAL(10,1)
       │    │    │    │    │              └── a:14 + c:16
-      │    │    │    │    └── flags: disabled not visible index feature
+      │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
       │    │    │    └── filters
       │    │    │         └── a_cast:8 = a:14
       │    │    └── projections
@@ -3220,7 +3220,7 @@ upsert decimals
       │    │    │    │    │    │    │    └── d:18
       │    │    │    │    │    │    │         └── assignment-cast: DECIMAL(10,1)
       │    │    │    │    │    │    │              └── a:15 + c:17
-      │    │    │    │    │    │    └── flags: disabled not visible index feature
+      │    │    │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
       │    │    │    │    │    └── filters
       │    │    │    │    │         └── a_cast:9 = a:15
       │    │    │    │    └── projections
@@ -3314,7 +3314,7 @@ upsert decimals
       │    │    │    │    │    │    │    └── d:18
       │    │    │    │    │    │    │         └── assignment-cast: DECIMAL(10,1)
       │    │    │    │    │    │    │              └── a:15 + c:17
-      │    │    │    │    │    │    └── flags: disabled not visible index feature
+      │    │    │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
       │    │    │    │    │    └── filters
       │    │    │    │    │         └── a_cast:9 = a:15
       │    │    │    │    └── projections
@@ -3410,7 +3410,7 @@ upsert assn_cast
       │    │    │    │    └── d_comp:28
       │    │    │    │         └── assignment-cast: DECIMAL(10)
       │    │    │    │              └── d:27 + 10.0
-      │    │    │    └── flags: disabled not visible index feature
+      │    │    │    └── flags: avoid-full-scan disabled not visible index feature
       │    │    └── filters
       │    │         └── k_cast:15 = k:22
       │    └── projections
@@ -3495,7 +3495,7 @@ upsert assn_cast
       │    │    │    │    └── d_comp:27
       │    │    │    │         └── assignment-cast: DECIMAL(10)
       │    │    │    │              └── d:26 + 10.0
-      │    │    │    └── flags: disabled not visible index feature
+      │    │    │    └── flags: avoid-full-scan disabled not visible index feature
       │    │    └── filters
       │    │         └── k_cast:14 = k:21
       │    └── projections
@@ -3559,7 +3559,7 @@ insert assn_cast
       │    │    │    └── d_comp:28
       │    │    │         └── assignment-cast: DECIMAL(10)
       │    │    │              └── d:27 + 10.0
-      │    │    └── flags: disabled not visible index feature
+      │    │    └── flags: avoid-full-scan disabled not visible index feature
       │    └── filters
       │         └── k_cast:15 = k:22
       └── aggregations
@@ -3656,7 +3656,7 @@ upsert assn_cast
       │    │    │    │    │    │    └── d_comp:27
       │    │    │    │    │    │         └── assignment-cast: DECIMAL(10)
       │    │    │    │    │    │              └── d:26 + 10.0
-      │    │    │    │    │    └── flags: disabled not visible index feature
+      │    │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
       │    │    │    │    └── filters
       │    │    │    │         └── k_cast:15 = k:21
       │    │    │    └── projections
@@ -3753,7 +3753,7 @@ upsert assn_cast
       │    │    │    │    └── d_comp:25
       │    │    │    │         └── assignment-cast: DECIMAL(10)
       │    │    │    │              └── d:24 + 10.0
-      │    │    │    └── flags: disabled not visible index feature
+      │    │    │    └── flags: avoid-full-scan disabled not visible index feature
       │    │    └── filters
       │    │         └── column1:10 = k:19
       │    └── projections
@@ -3836,7 +3836,7 @@ upsert assn_cast
       │    │    │    │    │    │    └── d_comp:24
       │    │    │    │    │    │         └── assignment-cast: DECIMAL(10)
       │    │    │    │    │    │              └── d:23 + 10.0
-      │    │    │    │    │    └── flags: disabled not visible index feature
+      │    │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
       │    │    │    │    └── filters
       │    │    │    │         └── column1:10 = k:18
       │    │    │    └── projections
@@ -3931,7 +3931,7 @@ upsert assn_cast
       │    │    │    └── d_comp:26
       │    │    │         └── assignment-cast: DECIMAL(10)
       │    │    │              └── d:25 + 10.0
-      │    │    └── flags: disabled not visible index feature
+      │    │    └── flags: avoid-full-scan disabled not visible index feature
       │    └── filters
       │         └── column1:10 = k:20
       └── projections
@@ -4017,7 +4017,7 @@ upsert assn_cast
       │    │    │    └── d_comp:26
       │    │    │         └── assignment-cast: DECIMAL(10)
       │    │    │              └── d:25 + 10.0
-      │    │    └── flags: disabled not visible index feature
+      │    │    └── flags: avoid-full-scan disabled not visible index feature
       │    └── filters
       │         └── column1:10 = k:20
       └── projections
@@ -4083,7 +4083,7 @@ insert assn_cast
       │    │    │    └── d_comp:26
       │    │    │         └── assignment-cast: DECIMAL(10)
       │    │    │              └── d:25 + 10.0
-      │    │    └── flags: disabled not visible index feature
+      │    │    └── flags: avoid-full-scan disabled not visible index feature
       │    └── filters
       │         └── column1:10 = k:20
       └── aggregations
@@ -4184,7 +4184,7 @@ upsert assn_cast
       │    │    │    │    │    │    │    └── d_comp:26
       │    │    │    │    │    │    │         └── assignment-cast: DECIMAL(10)
       │    │    │    │    │    │    │              └── d:25 + 10.0
-      │    │    │    │    │    │    └── flags: disabled not visible index feature
+      │    │    │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
       │    │    │    │    │    └── filters
       │    │    │    │    │         └── column1:10 = k:20
       │    │    │    │    └── projections
@@ -4266,7 +4266,7 @@ upsert assn_cast_on_update
       │    │    │    │    │    │    │    └── d_comp:16
       │    │    │    │    │    │    │         └── assignment-cast: DECIMAL(10)
       │    │    │    │    │    │    │              └── d:14
-      │    │    │    │    │    │    └── flags: disabled not visible index feature
+      │    │    │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
       │    │    │    │    │    └── filters
       │    │    │    │    │         └── column1:8 = k:12
       │    │    │    │    └── projections
@@ -4389,7 +4389,7 @@ upsert on_update_bare
       │    │    │              └── v_default:6
       │    │    ├── scan on_update_bare
       │    │    │    ├── columns: a:7!null v:8 crdb_internal_mvcc_timestamp:9 tableoid:10
-      │    │    │    └── flags: disabled not visible index feature
+      │    │    │    └── flags: avoid-full-scan disabled not visible index feature
       │    │    └── filters
       │    │         └── column1:5 = a:7
       │    └── projections
@@ -4449,7 +4449,7 @@ upsert on_update_with_default
       │    │    │              └── v_default:8
       │    │    ├── scan on_update_with_default
       │    │    │    ├── columns: a:9!null b:10 v:11 crdb_internal_mvcc_timestamp:12 tableoid:13
-      │    │    │    └── flags: disabled not visible index feature
+      │    │    │    └── flags: avoid-full-scan disabled not visible index feature
       │    │    └── filters
       │    │         └── column1:6 = a:9
       │    └── projections
@@ -4499,7 +4499,7 @@ upsert on_update_with_default
       │    │    │              └── b_default:8
       │    │    ├── scan on_update_with_default
       │    │    │    ├── columns: a:9!null b:10 v:11 crdb_internal_mvcc_timestamp:12 tableoid:13
-      │    │    │    └── flags: disabled not visible index feature
+      │    │    │    └── flags: avoid-full-scan disabled not visible index feature
       │    │    └── filters
       │    │         └── column1:6 = a:9
       │    └── projections
@@ -4554,7 +4554,7 @@ upsert on_update_with_default
       │    │    │    │              └── v_default:8
       │    │    │    ├── scan on_update_with_default
       │    │    │    │    ├── columns: a:9!null b:10 v:11 crdb_internal_mvcc_timestamp:12 tableoid:13
-      │    │    │    │    └── flags: disabled not visible index feature
+      │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
       │    │    │    └── filters
       │    │    │         └── column1:6 = a:9
       │    │    └── projections
@@ -4630,7 +4630,7 @@ upsert generated_as_identity
       │    │              └── c_default:9
       │    ├── scan generated_as_identity
       │    │    ├── columns: a:11 b:12!null c:13!null rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16
-      │    │    └── flags: disabled not visible index feature
+      │    │    └── flags: avoid-full-scan disabled not visible index feature
       │    └── filters
       │         └── rowid_default:10 = rowid:14
       └── projections
@@ -4683,7 +4683,7 @@ upsert generated_as_identity
       │    │              └── b_default:9
       │    ├── scan generated_as_identity
       │    │    ├── columns: a:11 b:12!null c:13!null rowid:14!null crdb_internal_mvcc_timestamp:15 tableoid:16
-      │    │    └── flags: disabled not visible index feature
+      │    │    └── flags: avoid-full-scan disabled not visible index feature
       │    └── filters
       │         └── rowid_default:10 = rowid:14
       └── projections
@@ -4733,7 +4733,7 @@ upsert xyz
       │    │    │              └── z_default:8
       │    │    ├── scan xyz
       │    │    │    ├── columns: x:9!null y:10 z:11 crdb_internal_mvcc_timestamp:12 tableoid:13
-      │    │    │    └── flags: disabled not visible index feature
+      │    │    │    └── flags: avoid-full-scan disabled not visible index feature
       │    │    └── filters
       │    │         └── column1:6 = x:9
       │    └── projections
@@ -4781,7 +4781,7 @@ upsert xyz
       │    │    │              └── column1:6
       │    │    ├── scan xyz
       │    │    │    ├── columns: x:9!null y:10 z:11 crdb_internal_mvcc_timestamp:12 tableoid:13
-      │    │    │    └── flags: disabled not visible index feature
+      │    │    │    └── flags: avoid-full-scan disabled not visible index feature
       │    │    └── filters
       │    │         ├── column2:7 = y:10
       │    │         └── z_default:8 = z:11
@@ -4830,7 +4830,7 @@ upsert xyz
       │    │    │              └── column1:6
       │    │    ├── scan xyz
       │    │    │    ├── columns: x:9!null y:10 z:11 crdb_internal_mvcc_timestamp:12 tableoid:13
-      │    │    │    └── flags: disabled not visible index feature
+      │    │    │    └── flags: avoid-full-scan disabled not visible index feature
       │    │    └── filters
       │    │         ├── column2:7 = y:10
       │    │         └── z_default:8 = z:11
@@ -4884,13 +4884,16 @@ insert min_arbiters
            │    │    │    │    │    │    │         ├── NULL::INT8
            │    │    │    │    │    │    │         └── unique_rowid()
            │    │    │    │    │    │    ├── scan min_arbiters
+           │    │    │    │    │    │    │    └── flags: avoid-full-scan
            │    │    │    │    │    │    └── filters
            │    │    │    │    │    │         └── rowid_default = rowid
            │    │    │    │    │    ├── scan min_arbiters
+           │    │    │    │    │    │    └── flags: avoid-full-scan
            │    │    │    │    │    └── filters
            │    │    │    │    │         └── b_default = b
            │    │    │    │    ├── select
            │    │    │    │    │    ├── scan min_arbiters
+           │    │    │    │    │    │    └── flags: avoid-full-scan
            │    │    │    │    │    └── filters
            │    │    │    │    │         └── a > 0
            │    │    │    │    └── filters
@@ -4943,13 +4946,16 @@ insert min_arbiters
            │    │    │    │    │    │    │         ├── NULL::INT8
            │    │    │    │    │    │    │         └── unique_rowid()
            │    │    │    │    │    │    ├── scan min_arbiters
+           │    │    │    │    │    │    │    └── flags: avoid-full-scan
            │    │    │    │    │    │    └── filters
            │    │    │    │    │    │         └── rowid_default = rowid
            │    │    │    │    │    ├── scan min_arbiters
+           │    │    │    │    │    │    └── flags: avoid-full-scan
            │    │    │    │    │    └── filters
            │    │    │    │    │         └── b_default = b
            │    │    │    │    ├── select
            │    │    │    │    │    ├── scan min_arbiters
+           │    │    │    │    │    │    └── flags: avoid-full-scan
            │    │    │    │    │    └── filters
            │    │    │    │    │         └── a > 0
            │    │    │    │    └── filters
@@ -5003,22 +5009,25 @@ insert min_arbiters
       │         │    │    │    │    │    │    │         ├── NULL::INT8
       │         │    │    │    │    │    │    │         └── unique_rowid()
       │         │    │    │    │    │    │    ├── scan min_arbiters
-      │         │    │    │    │    │    │    │    └── partial index predicates
-      │         │    │    │    │    │    │    │         └── redundant: filters
-      │         │    │    │    │    │    │    │              └── a > 0
+      │         │    │    │    │    │    │    │    ├── partial index predicates
+      │         │    │    │    │    │    │    │    │    └── redundant: filters
+      │         │    │    │    │    │    │    │    │         └── a > 0
+      │         │    │    │    │    │    │    │    └── flags: avoid-full-scan
       │         │    │    │    │    │    │    └── filters
       │         │    │    │    │    │    │         └── rowid_default = rowid
       │         │    │    │    │    │    ├── scan min_arbiters
-      │         │    │    │    │    │    │    └── partial index predicates
-      │         │    │    │    │    │    │         └── redundant: filters
-      │         │    │    │    │    │    │              └── a > 0
+      │         │    │    │    │    │    │    ├── partial index predicates
+      │         │    │    │    │    │    │    │    └── redundant: filters
+      │         │    │    │    │    │    │    │         └── a > 0
+      │         │    │    │    │    │    │    └── flags: avoid-full-scan
       │         │    │    │    │    │    └── filters
       │         │    │    │    │    │         └── b_default = b
       │         │    │    │    │    ├── select
       │         │    │    │    │    │    ├── scan min_arbiters
-      │         │    │    │    │    │    │    └── partial index predicates
-      │         │    │    │    │    │    │         └── redundant: filters
-      │         │    │    │    │    │    │              └── a > 0
+      │         │    │    │    │    │    │    ├── partial index predicates
+      │         │    │    │    │    │    │    │    └── redundant: filters
+      │         │    │    │    │    │    │    │         └── a > 0
+      │         │    │    │    │    │    │    └── flags: avoid-full-scan
       │         │    │    │    │    │    └── filters
       │         │    │    │    │    │         └── a > 0
       │         │    │    │    │    └── filters
@@ -5074,22 +5083,25 @@ insert min_arbiters
       │         │    │    │    │    │    │    │         ├── NULL::INT8
       │         │    │    │    │    │    │    │         └── unique_rowid()
       │         │    │    │    │    │    │    ├── scan min_arbiters
-      │         │    │    │    │    │    │    │    └── partial index predicates
-      │         │    │    │    │    │    │    │         └── redundant: filters
-      │         │    │    │    │    │    │    │              └── a > 0
+      │         │    │    │    │    │    │    │    ├── partial index predicates
+      │         │    │    │    │    │    │    │    │    └── redundant: filters
+      │         │    │    │    │    │    │    │    │         └── a > 0
+      │         │    │    │    │    │    │    │    └── flags: avoid-full-scan
       │         │    │    │    │    │    │    └── filters
       │         │    │    │    │    │    │         └── rowid_default = rowid
       │         │    │    │    │    │    ├── scan min_arbiters
-      │         │    │    │    │    │    │    └── partial index predicates
-      │         │    │    │    │    │    │         └── redundant: filters
-      │         │    │    │    │    │    │              └── a > 0
+      │         │    │    │    │    │    │    ├── partial index predicates
+      │         │    │    │    │    │    │    │    └── redundant: filters
+      │         │    │    │    │    │    │    │         └── a > 0
+      │         │    │    │    │    │    │    └── flags: avoid-full-scan
       │         │    │    │    │    │    └── filters
       │         │    │    │    │    │         └── b_default = b
       │         │    │    │    │    ├── select
       │         │    │    │    │    │    ├── scan min_arbiters
-      │         │    │    │    │    │    │    └── partial index predicates
-      │         │    │    │    │    │    │         └── redundant: filters
-      │         │    │    │    │    │    │              └── a > 0
+      │         │    │    │    │    │    │    ├── partial index predicates
+      │         │    │    │    │    │    │    │    └── redundant: filters
+      │         │    │    │    │    │    │    │         └── a > 0
+      │         │    │    │    │    │    │    └── flags: avoid-full-scan
       │         │    │    │    │    │    └── filters
       │         │    │    │    │    │         └── a > 0
       │         │    │    │    │    └── filters
@@ -5149,16 +5161,18 @@ insert min_arbiters
       │         │    │    │         │    │    │    │    │    │    │         ├── NULL::INT8
       │         │    │    │         │    │    │    │    │    │    │         └── unique_rowid()
       │         │    │    │         │    │    │    │    │    │    ├── scan min_arbiters
-      │         │    │    │         │    │    │    │    │    │    │    └── partial index predicates
-      │         │    │    │         │    │    │    │    │    │    │         └── not_redundant: filters
-      │         │    │    │         │    │    │    │    │    │    │              └── a > 10
+      │         │    │    │         │    │    │    │    │    │    │    ├── partial index predicates
+      │         │    │    │         │    │    │    │    │    │    │    │    └── not_redundant: filters
+      │         │    │    │         │    │    │    │    │    │    │    │         └── a > 10
+      │         │    │    │         │    │    │    │    │    │    │    └── flags: avoid-full-scan
       │         │    │    │         │    │    │    │    │    │    └── filters
       │         │    │    │         │    │    │    │    │    │         └── rowid_default = rowid
       │         │    │    │         │    │    │    │    │    ├── select
       │         │    │    │         │    │    │    │    │    │    ├── scan min_arbiters
-      │         │    │    │         │    │    │    │    │    │    │    └── partial index predicates
-      │         │    │    │         │    │    │    │    │    │    │         └── not_redundant: filters
-      │         │    │    │         │    │    │    │    │    │    │              └── a > 10
+      │         │    │    │         │    │    │    │    │    │    │    ├── partial index predicates
+      │         │    │    │         │    │    │    │    │    │    │    │    └── not_redundant: filters
+      │         │    │    │         │    │    │    │    │    │    │    │         └── a > 10
+      │         │    │    │         │    │    │    │    │    │    │    └── flags: avoid-full-scan
       │         │    │    │         │    │    │    │    │    │    └── filters
       │         │    │    │         │    │    │    │    │    │         └── a > 10
       │         │    │    │         │    │    │    │    │    └── filters
@@ -5166,16 +5180,18 @@ insert min_arbiters
       │         │    │    │         │    │    │    │    │         ├── b_default = c
       │         │    │    │         │    │    │    │    │         └── column1 > 10
       │         │    │    │         │    │    │    │    ├── scan min_arbiters
-      │         │    │    │         │    │    │    │    │    └── partial index predicates
-      │         │    │    │         │    │    │    │    │         └── not_redundant: filters
-      │         │    │    │         │    │    │    │    │              └── a > 10
+      │         │    │    │         │    │    │    │    │    ├── partial index predicates
+      │         │    │    │         │    │    │    │    │    │    └── not_redundant: filters
+      │         │    │    │         │    │    │    │    │    │         └── a > 10
+      │         │    │    │         │    │    │    │    │    └── flags: avoid-full-scan
       │         │    │    │         │    │    │    │    └── filters
       │         │    │    │         │    │    │    │         └── b_default = b
       │         │    │    │         │    │    │    ├── select
       │         │    │    │         │    │    │    │    ├── scan min_arbiters
-      │         │    │    │         │    │    │    │    │    └── partial index predicates
-      │         │    │    │         │    │    │    │    │         └── not_redundant: filters
-      │         │    │    │         │    │    │    │    │              └── a > 10
+      │         │    │    │         │    │    │    │    │    ├── partial index predicates
+      │         │    │    │         │    │    │    │    │    │    └── not_redundant: filters
+      │         │    │    │         │    │    │    │    │    │         └── a > 10
+      │         │    │    │         │    │    │    │    │    └── flags: avoid-full-scan
       │         │    │    │         │    │    │    │    └── filters
       │         │    │    │         │    │    │    │         └── a > 0
       │         │    │    │         │    │    │    └── filters
@@ -5242,16 +5258,18 @@ insert min_arbiters
       │         │    │    │         │    │    │    │    │    │    │         ├── NULL::INT8
       │         │    │    │         │    │    │    │    │    │    │         └── unique_rowid()
       │         │    │    │         │    │    │    │    │    │    ├── scan min_arbiters
-      │         │    │    │         │    │    │    │    │    │    │    └── partial index predicates
-      │         │    │    │         │    │    │    │    │    │    │         └── not_redundant: filters
-      │         │    │    │         │    │    │    │    │    │    │              └── c > 0
+      │         │    │    │         │    │    │    │    │    │    │    ├── partial index predicates
+      │         │    │    │         │    │    │    │    │    │    │    │    └── not_redundant: filters
+      │         │    │    │         │    │    │    │    │    │    │    │         └── c > 0
+      │         │    │    │         │    │    │    │    │    │    │    └── flags: avoid-full-scan
       │         │    │    │         │    │    │    │    │    │    └── filters
       │         │    │    │         │    │    │    │    │    │         └── rowid_default = rowid
       │         │    │    │         │    │    │    │    │    ├── select
       │         │    │    │         │    │    │    │    │    │    ├── scan min_arbiters
-      │         │    │    │         │    │    │    │    │    │    │    └── partial index predicates
-      │         │    │    │         │    │    │    │    │    │    │         └── not_redundant: filters
-      │         │    │    │         │    │    │    │    │    │    │              └── c > 0
+      │         │    │    │         │    │    │    │    │    │    │    ├── partial index predicates
+      │         │    │    │         │    │    │    │    │    │    │    │    └── not_redundant: filters
+      │         │    │    │         │    │    │    │    │    │    │    │         └── c > 0
+      │         │    │    │         │    │    │    │    │    │    │    └── flags: avoid-full-scan
       │         │    │    │         │    │    │    │    │    │    └── filters
       │         │    │    │         │    │    │    │    │    │         └── c > 0
       │         │    │    │         │    │    │    │    │    └── filters
@@ -5259,16 +5277,18 @@ insert min_arbiters
       │         │    │    │         │    │    │    │    │         ├── b_default = b
       │         │    │    │         │    │    │    │    │         └── b_default > 0
       │         │    │    │         │    │    │    │    ├── scan min_arbiters
-      │         │    │    │         │    │    │    │    │    └── partial index predicates
-      │         │    │    │         │    │    │    │    │         └── not_redundant: filters
-      │         │    │    │         │    │    │    │    │              └── c > 0
+      │         │    │    │         │    │    │    │    │    ├── partial index predicates
+      │         │    │    │         │    │    │    │    │    │    └── not_redundant: filters
+      │         │    │    │         │    │    │    │    │    │         └── c > 0
+      │         │    │    │         │    │    │    │    │    └── flags: avoid-full-scan
       │         │    │    │         │    │    │    │    └── filters
       │         │    │    │         │    │    │    │         └── b_default = b
       │         │    │    │         │    │    │    ├── select
       │         │    │    │         │    │    │    │    ├── scan min_arbiters
-      │         │    │    │         │    │    │    │    │    └── partial index predicates
-      │         │    │    │         │    │    │    │    │         └── not_redundant: filters
-      │         │    │    │         │    │    │    │    │              └── c > 0
+      │         │    │    │         │    │    │    │    │    ├── partial index predicates
+      │         │    │    │         │    │    │    │    │    │    └── not_redundant: filters
+      │         │    │    │         │    │    │    │    │    │         └── c > 0
+      │         │    │    │         │    │    │    │    │    └── flags: avoid-full-scan
       │         │    │    │         │    │    │    │    └── filters
       │         │    │    │         │    │    │    │         └── a > 0
       │         │    │    │         │    │    │    └── filters
@@ -5330,17 +5350,21 @@ insert min_arbiters
            │    │    │    │    │    │    │    │    │         ├── NULL::INT8
            │    │    │    │    │    │    │    │    │         └── unique_rowid()
            │    │    │    │    │    │    │    │    ├── scan min_arbiters
+           │    │    │    │    │    │    │    │    │    └── flags: avoid-full-scan
            │    │    │    │    │    │    │    │    └── filters
            │    │    │    │    │    │    │    │         └── rowid_default = rowid
            │    │    │    │    │    │    │    ├── scan min_arbiters
+           │    │    │    │    │    │    │    │    └── flags: avoid-full-scan
            │    │    │    │    │    │    │    └── filters
            │    │    │    │    │    │    │         ├── column1 = a
            │    │    │    │    │    │    │         └── b_default = c
            │    │    │    │    │    │    ├── scan min_arbiters
+           │    │    │    │    │    │    │    └── flags: avoid-full-scan
            │    │    │    │    │    │    └── filters
            │    │    │    │    │    │         └── b_default = b
            │    │    │    │    │    ├── select
            │    │    │    │    │    │    ├── scan min_arbiters
+           │    │    │    │    │    │    │    └── flags: avoid-full-scan
            │    │    │    │    │    │    └── filters
            │    │    │    │    │    │         └── a > 0
            │    │    │    │    │    └── filters

--- a/pkg/sql/opt/optbuilder/testdata/virtual-columns
+++ b/pkg/sql/opt/optbuilder/testdata/virtual-columns
@@ -254,9 +254,10 @@ delete t
       │    ├── columns: v:8 a:6!null b:7 crdb_internal_mvcc_timestamp:9 tableoid:10
       │    ├── scan t
       │    │    ├── columns: a:6!null b:7 crdb_internal_mvcc_timestamp:9 tableoid:10
-      │    │    └── computed column expressions
-      │    │         └── v:8
-      │    │              └── a:6 + b:7
+      │    │    ├── computed column expressions
+      │    │    │    └── v:8
+      │    │    │         └── a:6 + b:7
+      │    │    └── flags: avoid-full-scan
       │    └── projections
       │         └── a:6 + b:7 [as=v:8]
       └── filters
@@ -280,9 +281,10 @@ project
            │    ├── columns: v:8 a:6!null b:7 crdb_internal_mvcc_timestamp:9 tableoid:10
            │    ├── scan t
            │    │    ├── columns: a:6!null b:7 crdb_internal_mvcc_timestamp:9 tableoid:10
-           │    │    └── computed column expressions
-           │    │         └── v:8
-           │    │              └── a:6 + b:7
+           │    │    ├── computed column expressions
+           │    │    │    └── v:8
+           │    │    │         └── a:6 + b:7
+           │    │    └── flags: avoid-full-scan
            │    └── projections
            │         └── a:6 + b:7 [as=v:8]
            └── filters
@@ -300,9 +302,10 @@ delete t
       │    ├── columns: v:8 a:6!null b:7 crdb_internal_mvcc_timestamp:9 tableoid:10
       │    ├── scan t
       │    │    ├── columns: a:6!null b:7 crdb_internal_mvcc_timestamp:9 tableoid:10
-      │    │    └── computed column expressions
-      │    │         └── v:8
-      │    │              └── a:6 + b:7
+      │    │    ├── computed column expressions
+      │    │    │    └── v:8
+      │    │    │         └── a:6 + b:7
+      │    │    └── flags: avoid-full-scan
       │    └── projections
       │         └── a:6 + b:7 [as=v:8]
       └── filters
@@ -320,9 +323,10 @@ delete t
       │    ├── columns: v:8 a:6!null b:7 crdb_internal_mvcc_timestamp:9 tableoid:10
       │    ├── scan t
       │    │    ├── columns: a:6!null b:7 crdb_internal_mvcc_timestamp:9 tableoid:10
-      │    │    └── computed column expressions
-      │    │         └── v:8
-      │    │              └── a:6 + b:7
+      │    │    ├── computed column expressions
+      │    │    │    └── v:8
+      │    │    │         └── a:6 + b:7
+      │    │    └── flags: avoid-full-scan
       │    └── projections
       │         └── a:6 + b:7 [as=v:8]
       └── filters
@@ -346,9 +350,10 @@ project
            │    ├── columns: v:8 a:6!null b:7 crdb_internal_mvcc_timestamp:9 tableoid:10
            │    ├── scan t
            │    │    ├── columns: a:6!null b:7 crdb_internal_mvcc_timestamp:9 tableoid:10
-           │    │    └── computed column expressions
-           │    │         └── v:8
-           │    │              └── a:6 + b:7
+           │    │    ├── computed column expressions
+           │    │    │    └── v:8
+           │    │    │         └── a:6 + b:7
+           │    │    └── flags: avoid-full-scan
            │    └── projections
            │         └── a:6 + b:7 [as=v:8]
            └── filters
@@ -370,10 +375,11 @@ project
            ├── columns: v:6!null a:5!null crdb_internal_mvcc_timestamp:7 tableoid:8
            ├── scan t_cast
            │    ├── columns: a:5!null crdb_internal_mvcc_timestamp:7 tableoid:8
-           │    └── computed column expressions
-           │         └── v:6
-           │              └── assignment-cast: CHAR
-           │                   └── a:5
+           │    ├── computed column expressions
+           │    │    └── v:6
+           │    │         └── assignment-cast: CHAR
+           │    │              └── a:5
+           │    └── flags: avoid-full-scan
            └── projections
                 └── assignment-cast: CHAR [as=v:6]
                      └── a:5
@@ -390,9 +396,10 @@ delete t_idx
       │    ├── columns: v:8 a:6!null b:7 crdb_internal_mvcc_timestamp:9 tableoid:10
       │    ├── scan t_idx
       │    │    ├── columns: a:6!null b:7 crdb_internal_mvcc_timestamp:9 tableoid:10
-      │    │    └── computed column expressions
-      │    │         └── v:8
-      │    │              └── a:6 + b:7
+      │    │    ├── computed column expressions
+      │    │    │    └── v:8
+      │    │    │         └── a:6 + b:7
+      │    │    └── flags: avoid-full-scan
       │    └── projections
       │         └── a:6 + b:7 [as=v:8]
       └── filters
@@ -416,9 +423,10 @@ project
            │    ├── columns: v:8 a:6!null b:7 crdb_internal_mvcc_timestamp:9 tableoid:10
            │    ├── scan t_idx
            │    │    ├── columns: a:6!null b:7 crdb_internal_mvcc_timestamp:9 tableoid:10
-           │    │    └── computed column expressions
-           │    │         └── v:8
-           │    │              └── a:6 + b:7
+           │    │    ├── computed column expressions
+           │    │    │    └── v:8
+           │    │    │         └── a:6 + b:7
+           │    │    └── flags: avoid-full-scan
            │    └── projections
            │         └── a:6 + b:7 [as=v:8]
            └── filters
@@ -436,9 +444,10 @@ delete t_idx
       │    ├── columns: v:8 a:6!null b:7 crdb_internal_mvcc_timestamp:9 tableoid:10
       │    ├── scan t_idx
       │    │    ├── columns: a:6!null b:7 crdb_internal_mvcc_timestamp:9 tableoid:10
-      │    │    └── computed column expressions
-      │    │         └── v:8
-      │    │              └── a:6 + b:7
+      │    │    ├── computed column expressions
+      │    │    │    └── v:8
+      │    │    │         └── a:6 + b:7
+      │    │    └── flags: avoid-full-scan
       │    └── projections
       │         └── a:6 + b:7 [as=v:8]
       └── filters
@@ -456,9 +465,10 @@ delete t_idx
       │    ├── columns: v:8 a:6!null b:7 crdb_internal_mvcc_timestamp:9 tableoid:10
       │    ├── scan t_idx
       │    │    ├── columns: a:6!null b:7 crdb_internal_mvcc_timestamp:9 tableoid:10
-      │    │    └── computed column expressions
-      │    │         └── v:8
-      │    │              └── a:6 + b:7
+      │    │    ├── computed column expressions
+      │    │    │    └── v:8
+      │    │    │         └── a:6 + b:7
+      │    │    └── flags: avoid-full-scan
       │    └── projections
       │         └── a:6 + b:7 [as=v:8]
       └── filters
@@ -482,9 +492,10 @@ project
            │    ├── columns: v:8 a:6!null b:7 crdb_internal_mvcc_timestamp:9 tableoid:10
            │    ├── scan t_idx
            │    │    ├── columns: a:6!null b:7 crdb_internal_mvcc_timestamp:9 tableoid:10
-           │    │    └── computed column expressions
-           │    │         └── v:8
-           │    │              └── a:6 + b:7
+           │    │    ├── computed column expressions
+           │    │    │    └── v:8
+           │    │    │         └── a:6 + b:7
+           │    │    └── flags: avoid-full-scan
            │    └── projections
            │         └── a:6 + b:7 [as=v:8]
            └── filters
@@ -516,9 +527,10 @@ update t
       │    │    ├── columns: v:8 a:6!null b:7 crdb_internal_mvcc_timestamp:9 tableoid:10
       │    │    ├── scan t
       │    │    │    ├── columns: a:6!null b:7 crdb_internal_mvcc_timestamp:9 tableoid:10
-      │    │    │    └── computed column expressions
-      │    │    │         └── v:8
-      │    │    │              └── a:6 + b:7
+      │    │    │    ├── computed column expressions
+      │    │    │    │    └── v:8
+      │    │    │    │         └── a:6 + b:7
+      │    │    │    └── flags: avoid-full-scan
       │    │    └── projections
       │    │         └── a:6 + b:7 [as=v:8]
       │    └── projections
@@ -545,9 +557,10 @@ update t
       │    │    │    ├── columns: v:8 a:6!null b:7 crdb_internal_mvcc_timestamp:9 tableoid:10
       │    │    │    ├── scan t
       │    │    │    │    ├── columns: a:6!null b:7 crdb_internal_mvcc_timestamp:9 tableoid:10
-      │    │    │    │    └── computed column expressions
-      │    │    │    │         └── v:8
-      │    │    │    │              └── a:6 + b:7
+      │    │    │    │    ├── computed column expressions
+      │    │    │    │    │    └── v:8
+      │    │    │    │    │         └── a:6 + b:7
+      │    │    │    │    └── flags: avoid-full-scan
       │    │    │    └── projections
       │    │    │         └── a:6 + b:7 [as=v:8]
       │    │    └── filters
@@ -576,9 +589,10 @@ update t
       │    │    │    ├── columns: v:8 a:6!null b:7 crdb_internal_mvcc_timestamp:9 tableoid:10
       │    │    │    ├── scan t
       │    │    │    │    ├── columns: a:6!null b:7 crdb_internal_mvcc_timestamp:9 tableoid:10
-      │    │    │    │    └── computed column expressions
-      │    │    │    │         └── v:8
-      │    │    │    │              └── a:6 + b:7
+      │    │    │    │    ├── computed column expressions
+      │    │    │    │    │    └── v:8
+      │    │    │    │    │         └── a:6 + b:7
+      │    │    │    │    └── flags: avoid-full-scan
       │    │    │    └── projections
       │    │    │         └── a:6 + b:7 [as=v:8]
       │    │    └── filters
@@ -611,10 +625,11 @@ project
            │    │    ├── columns: v:6!null a:5!null crdb_internal_mvcc_timestamp:7 tableoid:8
            │    │    ├── scan t_cast
            │    │    │    ├── columns: a:5!null crdb_internal_mvcc_timestamp:7 tableoid:8
-           │    │    │    └── computed column expressions
-           │    │    │         └── v:6
-           │    │    │              └── assignment-cast: CHAR
-           │    │    │                   └── a:5
+           │    │    │    ├── computed column expressions
+           │    │    │    │    └── v:6
+           │    │    │    │         └── assignment-cast: CHAR
+           │    │    │    │              └── a:5
+           │    │    │    └── flags: avoid-full-scan
            │    │    └── projections
            │    │         └── assignment-cast: CHAR [as=v:6]
            │    │              └── a:5
@@ -641,9 +656,10 @@ update t_idx
       │    │    ├── columns: v:8 a:6!null b:7 crdb_internal_mvcc_timestamp:9 tableoid:10
       │    │    ├── scan t_idx
       │    │    │    ├── columns: a:6!null b:7 crdb_internal_mvcc_timestamp:9 tableoid:10
-      │    │    │    └── computed column expressions
-      │    │    │         └── v:8
-      │    │    │              └── a:6 + b:7
+      │    │    │    ├── computed column expressions
+      │    │    │    │    └── v:8
+      │    │    │    │         └── a:6 + b:7
+      │    │    │    └── flags: avoid-full-scan
       │    │    └── projections
       │    │         └── a:6 + b:7 [as=v:8]
       │    └── projections
@@ -670,9 +686,10 @@ update t_idx
       │    │    │    ├── columns: v:8 a:6!null b:7 crdb_internal_mvcc_timestamp:9 tableoid:10
       │    │    │    ├── scan t_idx
       │    │    │    │    ├── columns: a:6!null b:7 crdb_internal_mvcc_timestamp:9 tableoid:10
-      │    │    │    │    └── computed column expressions
-      │    │    │    │         └── v:8
-      │    │    │    │              └── a:6 + b:7
+      │    │    │    │    ├── computed column expressions
+      │    │    │    │    │    └── v:8
+      │    │    │    │    │         └── a:6 + b:7
+      │    │    │    │    └── flags: avoid-full-scan
       │    │    │    └── projections
       │    │    │         └── a:6 + b:7 [as=v:8]
       │    │    └── filters
@@ -701,9 +718,10 @@ update t_idx
       │    │    │    ├── columns: v:8 a:6!null b:7 crdb_internal_mvcc_timestamp:9 tableoid:10
       │    │    │    ├── scan t_idx
       │    │    │    │    ├── columns: a:6!null b:7 crdb_internal_mvcc_timestamp:9 tableoid:10
-      │    │    │    │    └── computed column expressions
-      │    │    │    │         └── v:8
-      │    │    │    │              └── a:6 + b:7
+      │    │    │    │    ├── computed column expressions
+      │    │    │    │    │    └── v:8
+      │    │    │    │    │         └── a:6 + b:7
+      │    │    │    │    └── flags: avoid-full-scan
       │    │    │    └── projections
       │    │    │         └── a:6 + b:7 [as=v:8]
       │    │    └── filters
@@ -736,9 +754,10 @@ project
            │    │    ├── columns: v:8 a:6!null b:7 crdb_internal_mvcc_timestamp:9 tableoid:10
            │    │    ├── scan t_idx
            │    │    │    ├── columns: a:6!null b:7 crdb_internal_mvcc_timestamp:9 tableoid:10
-           │    │    │    └── computed column expressions
-           │    │    │         └── v:8
-           │    │    │              └── a:6 + b:7
+           │    │    │    ├── computed column expressions
+           │    │    │    │    └── v:8
+           │    │    │    │         └── a:6 + b:7
+           │    │    │    └── flags: avoid-full-scan
            │    │    └── projections
            │    │         └── a:6 + b:7 [as=v:8]
            │    └── projections
@@ -771,11 +790,12 @@ project
            │    │    ├── columns: v:11 w:12 a:8!null b:9 c:10 crdb_internal_mvcc_timestamp:13 tableoid:14
            │    │    ├── scan t_idx2
            │    │    │    ├── columns: a:8!null b:9 c:10 crdb_internal_mvcc_timestamp:13 tableoid:14
-           │    │    │    └── computed column expressions
-           │    │    │         ├── v:11
-           │    │    │         │    └── a:8 + b:9
-           │    │    │         └── w:12
-           │    │    │              └── c:10 + 1
+           │    │    │    ├── computed column expressions
+           │    │    │    │    ├── v:11
+           │    │    │    │    │    └── a:8 + b:9
+           │    │    │    │    └── w:12
+           │    │    │    │         └── c:10 + 1
+           │    │    │    └── flags: avoid-full-scan
            │    │    └── projections
            │    │         ├── a:8 + b:9 [as=v:11]
            │    │         └── c:10 + 1 [as=w:12]
@@ -806,11 +826,12 @@ update t_check
       │    │    │    ├── columns: v:9 w:10 a:7!null b:8 crdb_internal_mvcc_timestamp:11 tableoid:12
       │    │    │    ├── scan t_check
       │    │    │    │    ├── columns: a:7!null b:8 crdb_internal_mvcc_timestamp:11 tableoid:12
-      │    │    │    │    └── computed column expressions
-      │    │    │    │         ├── v:9
-      │    │    │    │         │    └── a:7 + b:8
-      │    │    │    │         └── w:10
-      │    │    │    │              └── a:7 * b:8
+      │    │    │    │    ├── computed column expressions
+      │    │    │    │    │    ├── v:9
+      │    │    │    │    │    │    └── a:7 + b:8
+      │    │    │    │    │    └── w:10
+      │    │    │    │    │         └── a:7 * b:8
+      │    │    │    │    └── flags: avoid-full-scan
       │    │    │    └── projections
       │    │    │         ├── a:7 + b:8 [as=v:9]
       │    │    │         └── a:7 * b:8 [as=w:10]
@@ -886,7 +907,7 @@ upsert t
       │    │    │    │    ├── computed column expressions
       │    │    │    │    │    └── v:11
       │    │    │    │    │         └── a:9 + b:10
-      │    │    │    │    └── flags: disabled not visible index feature
+      │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
       │    │    │    └── projections
       │    │    │         └── a:9 + b:10 [as=v:11]
       │    │    └── filters
@@ -1002,7 +1023,7 @@ project
            │    │    │    ├── computed column expressions
            │    │    │    │    └── v:11
            │    │    │    │         └── a:9 + b:10
-           │    │    │    └── flags: disabled not visible index feature
+           │    │    │    └── flags: avoid-full-scan disabled not visible index feature
            │    │    └── projections
            │    │         └── a:9 + b:10 [as=v:11]
            │    └── filters
@@ -1049,7 +1070,7 @@ project
            │    │    │    │    └── v:8
            │    │    │    │         └── assignment-cast: CHAR
            │    │    │    │              └── a:7
-           │    │    │    └── flags: disabled not visible index feature
+           │    │    │    └── flags: avoid-full-scan disabled not visible index feature
            │    │    └── projections
            │    │         └── assignment-cast: CHAR [as=v:8]
            │    │              └── a:7
@@ -1093,7 +1114,7 @@ insert t_idx2
       │    │    │    │    │    └── a:13 + b:14
       │    │    │    │    └── w:17
       │    │    │    │         └── c:15 + 1
-      │    │    │    └── flags: disabled not visible index feature
+      │    │    │    └── flags: avoid-full-scan disabled not visible index feature
       │    │    └── projections
       │    │         ├── a:13 + b:14 [as=v:16]
       │    │         └── c:15 + 1 [as=w:17]
@@ -1148,7 +1169,7 @@ insert t_idx2
       │    │    │    │    │    │    │    └── a:13 + b:14
       │    │    │    │    │    │    └── w:17
       │    │    │    │    │    │         └── c:15 + 1
-      │    │    │    │    │    └── flags: disabled not visible index feature
+      │    │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
       │    │    │    │    └── projections
       │    │    │    │         ├── a:13 + b:14 [as=v:16]
       │    │    │    │         └── c:15 + 1 [as=w:17]
@@ -1163,7 +1184,7 @@ insert t_idx2
       │    │    │    │    │    │    └── a:20 + b:21
       │    │    │    │    │    └── w:24
       │    │    │    │    │         └── c:22 + 1
-      │    │    │    │    └── flags: disabled not visible index feature
+      │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
       │    │    │    └── projections
       │    │    │         ├── a:20 + b:21 [as=v:23]
       │    │    │         └── c:22 + 1 [as=w:24]
@@ -1233,7 +1254,7 @@ upsert t
       │    │    │    │    │    ├── computed column expressions
       │    │    │    │    │    │    └── v:11
       │    │    │    │    │    │         └── a:9 + b:10
-      │    │    │    │    │    └── flags: disabled not visible index feature
+      │    │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
       │    │    │    │    └── projections
       │    │    │    │         └── a:9 + b:10 [as=v:11]
       │    │    │    └── filters
@@ -1292,7 +1313,7 @@ upsert t
       │    │    │    │    │    ├── computed column expressions
       │    │    │    │    │    │    └── v:11
       │    │    │    │    │    │         └── a:9 + b:10
-      │    │    │    │    │    └── flags: disabled not visible index feature
+      │    │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
       │    │    │    │    └── projections
       │    │    │    │         └── a:9 + b:10 [as=v:11]
       │    │    │    └── filters
@@ -1360,7 +1381,7 @@ upsert t_idx2
       │    │    │    │    │    │    │    └── a:13 + b:14
       │    │    │    │    │    │    └── w:17
       │    │    │    │    │    │         └── c:15 + 1
-      │    │    │    │    │    └── flags: disabled not visible index feature
+      │    │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
       │    │    │    │    └── projections
       │    │    │    │         ├── a:13 + b:14 [as=v:16]
       │    │    │    │         └── c:15 + 1 [as=w:17]
@@ -1432,7 +1453,7 @@ upsert t_idx2
       │    │    │    │    │    │    │    └── a:13 + b:14
       │    │    │    │    │    │    └── w:17
       │    │    │    │    │    │         └── c:15 + 1
-      │    │    │    │    │    └── flags: disabled not visible index feature
+      │    │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
       │    │    │    │    └── projections
       │    │    │    │         ├── a:13 + b:14 [as=v:16]
       │    │    │    │         └── c:15 + 1 [as=w:17]
@@ -1537,7 +1558,7 @@ upsert t1
       │    │    ├── scan t1
       │    │    │    ├── columns: a:8!null b:9
       │    │    │    ├── constraint: /8: [/1 - /1]
-      │    │    │    └── flags: disabled not visible index feature
+      │    │    │    └── flags: avoid-full-scan disabled not visible index feature
       │    │    └── projections
       │    │         └── b:9 + 1 [as=b_plus_one:10]
       │    └── filters (true)
@@ -1561,7 +1582,8 @@ update t1
       │    ├── columns: a:6!null b:7!null
       │    ├── scan t1
       │    │    ├── columns: a:6!null b:7
-      │    │    └── constraint: /6: [/1 - /1]
+      │    │    ├── constraint: /6: [/1 - /1]
+      │    │    └── flags: avoid-full-scan
       │    └── filters
       │         └── b:7 = 2
       └── projections
@@ -1583,7 +1605,8 @@ delete t1
       │    ├── columns: a:6!null b:7!null
       │    ├── scan t1
       │    │    ├── columns: a:6!null b:7
-      │    │    └── constraint: /6: [/2 - /2]
+      │    │    ├── constraint: /6: [/2 - /2]
+      │    │    └── flags: avoid-full-scan
       │    └── filters
       │         └── b:7 = 2
       └── projections
@@ -1617,7 +1640,7 @@ upsert t1
       │    │    ├── scan t1
       │    │    │    ├── columns: a:8!null b:9
       │    │    │    ├── constraint: /8: [/1 - /1]
-      │    │    │    └── flags: disabled not visible index feature
+      │    │    │    └── flags: avoid-full-scan disabled not visible index feature
       │    │    └── projections
       │    │         └── b:9 + 1 [as=b_plus_one:10]
       │    └── filters (true)
@@ -1664,7 +1687,7 @@ upsert t11
       │    │    ├── scan t11
       │    │    │    ├── columns: a:9!null b:10
       │    │    │    ├── constraint: /9: [/1 - /1]
-      │    │    │    └── flags: disabled not visible index feature
+      │    │    │    └── flags: avoid-full-scan disabled not visible index feature
       │    │    └── projections
       │    │         └── b:10 + 1 [as=b_plus_one:11]
       │    └── filters (true)
@@ -1691,7 +1714,8 @@ update t11
       │    │    ├── columns: a:6!null b:7!null
       │    │    ├── scan t11
       │    │    │    ├── columns: a:6!null b:7
-      │    │    │    └── constraint: /6: [/1 - /1]
+      │    │    │    ├── constraint: /6: [/1 - /1]
+      │    │    │    └── flags: avoid-full-scan
       │    │    └── filters
       │    │         └── b:7 = 2
       │    └── projections
@@ -1715,7 +1739,8 @@ delete t11
       │    ├── columns: a:6!null b:7!null
       │    ├── scan t11
       │    │    ├── columns: a:6!null b:7
-      │    │    └── constraint: /6: [/2 - /2]
+      │    │    ├── constraint: /6: [/2 - /2]
+      │    │    └── flags: avoid-full-scan
       │    └── filters
       │         └── b:7 = 2
       └── projections
@@ -1753,7 +1778,7 @@ upsert t11
       │    │    │    ├── scan t11
       │    │    │    │    ├── columns: a:9!null b:10
       │    │    │    │    ├── constraint: /9: [/1 - /1]
-      │    │    │    │    └── flags: disabled not visible index feature
+      │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
       │    │    │    └── projections
       │    │    │         └── b:10 + 1 [as=b_plus_one:11]
       │    │    └── filters (true)

--- a/pkg/sql/opt/optbuilder/testdata/with
+++ b/pkg/sql/opt/optbuilder/testdata/with
@@ -704,7 +704,8 @@ with &1 (t)
            └── project
                 ├── columns: a_new:17 x.a:11 b:12 rowid:13!null crdb_internal_mvcc_timestamp:14 tableoid:15
                 ├── scan x
-                │    └── columns: x.a:11 b:12 rowid:13!null crdb_internal_mvcc_timestamp:14 tableoid:15
+                │    ├── columns: x.a:11 b:12 rowid:13!null crdb_internal_mvcc_timestamp:14 tableoid:15
+                │    └── flags: avoid-full-scan
                 └── projections
                      └── subquery [as=a_new:17]
                           └── max1-row
@@ -735,7 +736,8 @@ with &1 (t)
            └── select
                 ├── columns: x.a:11!null b:12 rowid:13!null crdb_internal_mvcc_timestamp:14 tableoid:15
                 ├── scan x
-                │    └── columns: x.a:11 b:12 rowid:13!null crdb_internal_mvcc_timestamp:14 tableoid:15
+                │    ├── columns: x.a:11 b:12 rowid:13!null crdb_internal_mvcc_timestamp:14 tableoid:15
+                │    └── flags: avoid-full-scan
                 └── filters
                      └── eq
                           ├── x.a:11
@@ -792,7 +794,8 @@ with &1 (t)
       └── select
            ├── columns: xy.x:18 y:19 z:20 xy.rowid:21!null xy.crdb_internal_mvcc_timestamp:22 xy.tableoid:23
            ├── scan xy
-           │    └── columns: xy.x:18 y:19 z:20 xy.rowid:21!null xy.crdb_internal_mvcc_timestamp:22 xy.tableoid:23
+           │    ├── columns: xy.x:18 y:19 z:20 xy.rowid:21!null xy.crdb_internal_mvcc_timestamp:22 xy.tableoid:23
+           │    └── flags: avoid-full-scan
            └── filters
                 └── any: eq
                      ├── with-scan &1 (t)

--- a/pkg/sql/opt/xform/testdata/coster/scan
+++ b/pkg/sql/opt/xform/testdata/coster/scan
@@ -585,7 +585,8 @@ scan t@abc
  ├── key: (1)
  └── fd: ()-->(2,3), (1)-->(4)
 
-# Test that the NO_FULL_SCAN hint creates a huge cost for full scans.
+# Test that the NO_FULL_SCAN and AVOID_FULL_SCAN hints create a huge cost for
+# full scans.
 opt
 SELECT * FROM t@{NO_FULL_SCAN}
 ----
@@ -594,6 +595,17 @@ scan t
  ├── flags: no-full-scan
  ├── stats: [rows=100000]
  ├── cost: 1e+100
+ ├── key: (1)
+ └── fd: (1)-->(2-4)
+
+opt
+SELECT * FROM t@{AVOID_FULL_SCAN}
+----
+scan t
+ ├── columns: k:1!null a:2 b:3 c:4
+ ├── flags: avoid-full-scan
+ ├── stats: [rows=100000]
+ ├── cost: 1.080288e+55
  ├── key: (1)
  └── fd: (1)-->(2-4)
 
@@ -620,6 +632,23 @@ index-join t
       └── fd: (1)-->(3)
 
 opt
+SELECT * FROM t@{AVOID_FULL_SCAN} WHERE c > 0
+----
+index-join t
+ ├── columns: k:1!null a:2 b:3 c:4!null
+ ├── stats: [rows=33003.3, distinct(4)=3333.33, null(4)=0]
+ ├── cost: 234671.505
+ ├── key: (1)
+ ├── fd: (1)-->(2-4)
+ └── scan t@b_partial,partial
+      ├── columns: k:1!null b:3
+      ├── flags: avoid-full-scan
+      ├── stats: [rows=33003.3, distinct(4)=3333.33, null(4)=0]
+      ├── cost: 34341.4524
+      ├── key: (1)
+      └── fd: (1)-->(3)
+
+opt
 SELECT * FROM t@{FORCE_INDEX=b_partial,NO_FULL_SCAN} WHERE c > 0
 ----
 select
@@ -640,6 +669,23 @@ select
  │    └── fd: (1)-->(2-4)
  └── filters
       └── c:4 > 0 [outer=(4), constraints=(/4: [/1 - ]; tight)]
+
+opt
+SELECT * FROM t@{FORCE_INDEX=b_partial,AVOID_FULL_SCAN} WHERE c > 0
+----
+index-join t
+ ├── columns: k:1!null a:2 b:3 c:4!null
+ ├── stats: [rows=33003.3, distinct(4)=3333.33, null(4)=0]
+ ├── cost: 3.43414324e+54
+ ├── key: (1)
+ ├── fd: (1)-->(2-4)
+ └── scan t@b_partial,partial
+      ├── columns: k:1!null b:3
+      ├── flags: force-index=b_partial avoid-full-scan
+      ├── stats: [rows=33003.3, distinct(4)=3333.33, null(4)=0]
+      ├── cost: 3.43414324e+54
+      ├── key: (1)
+      └── fd: (1)-->(3)
 
 # Test that the FORCE_INVERTED_INDEX hint creates a huge cost for full table
 # scans.

--- a/pkg/sql/opt/xform/testdata/coster/scan
+++ b/pkg/sql/opt/xform/testdata/coster/scan
@@ -504,6 +504,7 @@ upsert t64570
       ├── scan t64570
       │    ├── columns: x:9!null y:10!null v:11
       │    ├── constraint: /9/10: [/10/10 - /10/10]
+      │    ├── flags: avoid-full-scan
       │    ├── cardinality: [0 - 1]
       │    ├── stats: [rows=6e-10, distinct(9)=6e-10, null(9)=0, distinct(10)=6e-10, null(10)=0, distinct(9,10)=6e-10, null(9,10)=0]
       │    │   histogram(9)=

--- a/pkg/sql/opt/xform/testdata/external/tpcc
+++ b/pkg/sql/opt/xform/testdata/external/tpcc
@@ -65,6 +65,7 @@ project
            ├── scan district
            │    ├── columns: d_id:14!null d_w_id:15!null d_name:16 d_street_1:17 d_street_2:18 d_city:19 d_state:20 d_zip:21 d_tax:22 d_ytd:23 d_next_o_id:24
            │    ├── constraint: /15/14: [/10/5 - /10/5]
+           │    ├── flags: avoid-full-scan
            │    ├── cardinality: [0 - 1]
            │    ├── key: ()
            │    └── fd: ()-->(14-24)
@@ -344,6 +345,7 @@ update stock
       │    │    ├── [/0/81680 - /0/81680]
       │    │    ├── [/0/89641 - /0/89641]
       │    │    └── [/0/89905 - /0/89905]
+      │    ├── flags: avoid-full-scan
       │    ├── cardinality: [0 - 13]
       │    ├── key: (20)
       │    └── fd: ()-->(21), (20)-->(22-36)
@@ -469,6 +471,7 @@ project
            ├── scan warehouse
            │    ├── columns: w_id:12!null w_name:13 w_street_1:14 w_street_2:15 w_city:16 w_state:17 w_zip:18 w_tax:19 w_ytd:20
            │    ├── constraint: /12: [/10 - /10]
+           │    ├── flags: avoid-full-scan
            │    ├── cardinality: [0 - 1]
            │    ├── key: ()
            │    └── fd: ()-->(12-20)
@@ -513,6 +516,7 @@ project
            ├── scan district
            │    ├── columns: d_id:14!null d_w_id:15!null d_name:16 d_street_1:17 d_street_2:18 d_city:19 d_state:20 d_zip:21 d_tax:22 d_ytd:23 d_next_o_id:24
            │    ├── constraint: /15/14: [/10/5 - /10/5]
+           │    ├── flags: avoid-full-scan
            │    ├── cardinality: [0 - 1]
            │    ├── key: ()
            │    └── fd: ()-->(14-24)
@@ -625,6 +629,7 @@ project
  │         ├── scan customer
  │         │    ├── columns: c_id:24!null c_d_id:25!null c_w_id:26!null c_first:27 c_middle:28 c_last:29 c_street_1:30 c_street_2:31 c_city:32 c_state:33 c_zip:34 c_phone:35 c_since:36 c_credit:37 c_credit_lim:38 c_discount:39 c_balance:40 c_ytd_payment:41 c_payment_cnt:42 c_delivery_cnt:43 c_data:44
  │         │    ├── constraint: /26/25/24: [/10/5/1343 - /10/5/1343]
+ │         │    ├── flags: avoid-full-scan
  │         │    ├── cardinality: [0 - 1]
  │         │    ├── key: ()
  │         │    └── fd: ()-->(24-44)
@@ -898,6 +903,7 @@ project
            │    │    ├── [/10/8/2167 - /10/8/2167]
            │    │    ├── [/10/9/2167 - /10/9/2167]
            │    │    └── [/10/10/2167 - /10/10/2167]
+           │    ├── flags: avoid-full-scan
            │    ├── cardinality: [0 - 10]
            │    ├── key: (12)
            │    └── fd: ()-->(11,13), (12)-->(14-18)
@@ -959,6 +965,7 @@ update customer
       │    │    ├── [/10/8/2106 - /10/8/2106]
       │    │    ├── [/10/9/1412 - /10/9/1412]
       │    │    └── [/10/10/417 - /10/10/417]
+      │    ├── flags: avoid-full-scan
       │    ├── cardinality: [0 - 10]
       │    ├── key: (24,25)
       │    └── fd: ()-->(26), (24,25)-->(27-44)
@@ -1000,6 +1007,7 @@ delete new_order
       │    ├── [/10/8/2167 - /10/8/2167]
       │    ├── [/10/9/2167 - /10/9/2167]
       │    └── [/10/10/2167 - /10/10/2167]
+      ├── flags: avoid-full-scan
       ├── cardinality: [0 - 10]
       ├── key: (7)
       └── fd: ()-->(6,8)
@@ -1045,6 +1053,7 @@ update order_line
       │    │    ├── [/10/8/2167 - /10/8/2167]
       │    │    ├── [/10/9/2167 - /10/9/2167]
       │    │    └── [/10/10/2167 - /10/10/2167]
+      │    ├── flags: avoid-full-scan
       │    ├── key: (14,16)
       │    └── fd: ()-->(13,15), (14,16)-->(17-22)
       └── projections

--- a/pkg/sql/opt/xform/testdata/external/tpcc-later-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpcc-later-stats
@@ -53,6 +53,7 @@ project
            ├── scan district
            │    ├── columns: d_id:14!null d_w_id:15!null d_name:16 d_street_1:17 d_street_2:18 d_city:19 d_state:20 d_zip:21 d_tax:22 d_ytd:23 d_next_o_id:24
            │    ├── constraint: /15/14: [/10/5 - /10/5]
+           │    ├── flags: avoid-full-scan
            │    ├── cardinality: [0 - 1]
            │    ├── key: ()
            │    └── fd: ()-->(14-24)
@@ -343,6 +344,7 @@ update stock
       │    │    ├── [/0/81680 - /0/81680]
       │    │    ├── [/0/89641 - /0/89641]
       │    │    └── [/0/89905 - /0/89905]
+      │    ├── flags: avoid-full-scan
       │    ├── cardinality: [0 - 13]
       │    ├── key: (20)
       │    └── fd: ()-->(21), (20)-->(22-36)
@@ -468,6 +470,7 @@ project
            ├── scan warehouse
            │    ├── columns: w_id:12!null w_name:13 w_street_1:14 w_street_2:15 w_city:16 w_state:17 w_zip:18 w_tax:19 w_ytd:20
            │    ├── constraint: /12: [/10 - /10]
+           │    ├── flags: avoid-full-scan
            │    ├── cardinality: [0 - 1]
            │    ├── key: ()
            │    └── fd: ()-->(12-20)
@@ -512,6 +515,7 @@ project
            ├── scan district
            │    ├── columns: d_id:14!null d_w_id:15!null d_name:16 d_street_1:17 d_street_2:18 d_city:19 d_state:20 d_zip:21 d_tax:22 d_ytd:23 d_next_o_id:24
            │    ├── constraint: /15/14: [/10/5 - /10/5]
+           │    ├── flags: avoid-full-scan
            │    ├── cardinality: [0 - 1]
            │    ├── key: ()
            │    └── fd: ()-->(14-24)
@@ -624,6 +628,7 @@ project
  │         ├── scan customer
  │         │    ├── columns: c_id:24!null c_d_id:25!null c_w_id:26!null c_first:27 c_middle:28 c_last:29 c_street_1:30 c_street_2:31 c_city:32 c_state:33 c_zip:34 c_phone:35 c_since:36 c_credit:37 c_credit_lim:38 c_discount:39 c_balance:40 c_ytd_payment:41 c_payment_cnt:42 c_delivery_cnt:43 c_data:44
  │         │    ├── constraint: /26/25/24: [/10/5/1343 - /10/5/1343]
+ │         │    ├── flags: avoid-full-scan
  │         │    ├── cardinality: [0 - 1]
  │         │    ├── key: ()
  │         │    └── fd: ()-->(24-44)
@@ -897,6 +902,7 @@ project
            │    │    ├── [/10/8/2167 - /10/8/2167]
            │    │    ├── [/10/9/2167 - /10/9/2167]
            │    │    └── [/10/10/2167 - /10/10/2167]
+           │    ├── flags: avoid-full-scan
            │    ├── cardinality: [0 - 10]
            │    ├── key: (12)
            │    └── fd: ()-->(11,13), (12)-->(14-18)
@@ -958,6 +964,7 @@ update customer
       │    │    ├── [/10/8/2106 - /10/8/2106]
       │    │    ├── [/10/9/1412 - /10/9/1412]
       │    │    └── [/10/10/417 - /10/10/417]
+      │    ├── flags: avoid-full-scan
       │    ├── cardinality: [0 - 10]
       │    ├── key: (24,25)
       │    └── fd: ()-->(26), (24,25)-->(27-44)
@@ -999,6 +1006,7 @@ delete new_order
       │    ├── [/10/8/2167 - /10/8/2167]
       │    ├── [/10/9/2167 - /10/9/2167]
       │    └── [/10/10/2167 - /10/10/2167]
+      ├── flags: avoid-full-scan
       ├── cardinality: [0 - 10]
       ├── key: (7)
       └── fd: ()-->(6,8)
@@ -1043,6 +1051,7 @@ update order_line
       │    │    ├── [/10/8/2167 - /10/8/2167]
       │    │    ├── [/10/9/2167 - /10/9/2167]
       │    │    └── [/10/10/2167 - /10/10/2167]
+      │    ├── flags: avoid-full-scan
       │    ├── key: (14,16)
       │    └── fd: ()-->(13,15), (14,16)-->(17-22)
       └── projections

--- a/pkg/sql/opt/xform/testdata/external/tpcc-no-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpcc-no-stats
@@ -62,6 +62,7 @@ project
            ├── scan district
            │    ├── columns: d_id:14!null d_w_id:15!null d_name:16 d_street_1:17 d_street_2:18 d_city:19 d_state:20 d_zip:21 d_tax:22 d_ytd:23 d_next_o_id:24
            │    ├── constraint: /15/14: [/10/5 - /10/5]
+           │    ├── flags: avoid-full-scan
            │    ├── cardinality: [0 - 1]
            │    ├── key: ()
            │    └── fd: ()-->(14-24)
@@ -341,6 +342,7 @@ update stock
       │    │    ├── [/0/81680 - /0/81680]
       │    │    ├── [/0/89641 - /0/89641]
       │    │    └── [/0/89905 - /0/89905]
+      │    ├── flags: avoid-full-scan
       │    ├── cardinality: [0 - 13]
       │    ├── key: (20)
       │    └── fd: ()-->(21), (20)-->(22-36)
@@ -466,6 +468,7 @@ project
            ├── scan warehouse
            │    ├── columns: w_id:12!null w_name:13 w_street_1:14 w_street_2:15 w_city:16 w_state:17 w_zip:18 w_tax:19 w_ytd:20
            │    ├── constraint: /12: [/10 - /10]
+           │    ├── flags: avoid-full-scan
            │    ├── cardinality: [0 - 1]
            │    ├── key: ()
            │    └── fd: ()-->(12-20)
@@ -510,6 +513,7 @@ project
            ├── scan district
            │    ├── columns: d_id:14!null d_w_id:15!null d_name:16 d_street_1:17 d_street_2:18 d_city:19 d_state:20 d_zip:21 d_tax:22 d_ytd:23 d_next_o_id:24
            │    ├── constraint: /15/14: [/10/5 - /10/5]
+           │    ├── flags: avoid-full-scan
            │    ├── cardinality: [0 - 1]
            │    ├── key: ()
            │    └── fd: ()-->(14-24)
@@ -622,6 +626,7 @@ project
  │         ├── scan customer
  │         │    ├── columns: c_id:24!null c_d_id:25!null c_w_id:26!null c_first:27 c_middle:28 c_last:29 c_street_1:30 c_street_2:31 c_city:32 c_state:33 c_zip:34 c_phone:35 c_since:36 c_credit:37 c_credit_lim:38 c_discount:39 c_balance:40 c_ytd_payment:41 c_payment_cnt:42 c_delivery_cnt:43 c_data:44
  │         │    ├── constraint: /26/25/24: [/10/5/1343 - /10/5/1343]
+ │         │    ├── flags: avoid-full-scan
  │         │    ├── cardinality: [0 - 1]
  │         │    ├── key: ()
  │         │    └── fd: ()-->(24-44)
@@ -899,6 +904,7 @@ project
            │         ├── scan order@order_idx
            │         │    ├── columns: o_id:11!null o_d_id:12!null o_w_id:13!null o_c_id:14 o_entry_d:15 o_carrier_id:16
            │         │    ├── constraint: /13/12/14/-11: [/10/1 - /10/10]
+           │         │    ├── flags: avoid-full-scan
            │         │    ├── key: (11,12)
            │         │    └── fd: ()-->(13), (11,12)-->(14-16)
            │         └── filters
@@ -961,6 +967,7 @@ update customer
       │    │    ├── [/10/8/2106 - /10/8/2106]
       │    │    ├── [/10/9/1412 - /10/9/1412]
       │    │    └── [/10/10/417 - /10/10/417]
+      │    ├── flags: avoid-full-scan
       │    ├── cardinality: [0 - 10]
       │    ├── key: (24,25)
       │    └── fd: ()-->(26), (24,25)-->(27-44)
@@ -1002,6 +1009,7 @@ delete new_order
       │    ├── [/10/8/2167 - /10/8/2167]
       │    ├── [/10/9/2167 - /10/9/2167]
       │    └── [/10/10/2167 - /10/10/2167]
+      ├── flags: avoid-full-scan
       ├── cardinality: [0 - 10]
       ├── key: (7)
       └── fd: ()-->(6,8)
@@ -1046,6 +1054,7 @@ update order_line
       │    │    ├── [/10/8/2167 - /10/8/2167]
       │    │    ├── [/10/9/2167 - /10/9/2167]
       │    │    └── [/10/10/2167 - /10/10/2167]
+      │    ├── flags: avoid-full-scan
       │    ├── key: (14,16)
       │    └── fd: ()-->(13,15), (14,16)-->(17-22)
       └── projections

--- a/pkg/sql/opt/xform/testdata/external/tpcc-read-committed
+++ b/pkg/sql/opt/xform/testdata/external/tpcc-read-committed
@@ -67,6 +67,7 @@ project
            ├── scan district
            │    ├── columns: d_id:14!null d_w_id:15!null d_name:16 d_street_1:17 d_street_2:18 d_city:19 d_state:20 d_zip:21 d_tax:22 d_ytd:23 d_next_o_id:24
            │    ├── constraint: /15/14: [/10/5 - /10/5]
+           │    ├── flags: avoid-full-scan
            │    ├── cardinality: [0 - 1]
            │    ├── key: ()
            │    └── fd: ()-->(14-24)
@@ -351,6 +352,7 @@ update stock
       │    │    ├── [/0/81680 - /0/81680]
       │    │    ├── [/0/89641 - /0/89641]
       │    │    └── [/0/89905 - /0/89905]
+      │    ├── flags: avoid-full-scan
       │    ├── cardinality: [0 - 13]
       │    ├── key: (20)
       │    └── fd: ()-->(21), (20)-->(22-36)
@@ -480,6 +482,7 @@ project
            ├── scan warehouse
            │    ├── columns: w_id:12!null w_name:13 w_street_1:14 w_street_2:15 w_city:16 w_state:17 w_zip:18 w_tax:19 w_ytd:20
            │    ├── constraint: /12: [/10 - /10]
+           │    ├── flags: avoid-full-scan
            │    ├── cardinality: [0 - 1]
            │    ├── key: ()
            │    └── fd: ()-->(12-20)
@@ -524,6 +527,7 @@ project
            ├── scan district
            │    ├── columns: d_id:14!null d_w_id:15!null d_name:16 d_street_1:17 d_street_2:18 d_city:19 d_state:20 d_zip:21 d_tax:22 d_ytd:23 d_next_o_id:24
            │    ├── constraint: /15/14: [/10/5 - /10/5]
+           │    ├── flags: avoid-full-scan
            │    ├── cardinality: [0 - 1]
            │    ├── key: ()
            │    └── fd: ()-->(14-24)
@@ -636,6 +640,7 @@ project
  │         ├── scan customer
  │         │    ├── columns: c_id:24!null c_d_id:25!null c_w_id:26!null c_first:27 c_middle:28 c_last:29 c_street_1:30 c_street_2:31 c_city:32 c_state:33 c_zip:34 c_phone:35 c_since:36 c_credit:37 c_credit_lim:38 c_discount:39 c_balance:40 c_ytd_payment:41 c_payment_cnt:42 c_delivery_cnt:43 c_data:44
  │         │    ├── constraint: /26/25/24: [/10/5/1343 - /10/5/1343]
+ │         │    ├── flags: avoid-full-scan
  │         │    ├── cardinality: [0 - 1]
  │         │    ├── key: ()
  │         │    └── fd: ()-->(24-44)
@@ -914,6 +919,7 @@ project
            │    │    ├── [/10/8/2167 - /10/8/2167]
            │    │    ├── [/10/9/2167 - /10/9/2167]
            │    │    └── [/10/10/2167 - /10/10/2167]
+           │    ├── flags: avoid-full-scan
            │    ├── cardinality: [0 - 10]
            │    ├── key: (12)
            │    └── fd: ()-->(11,13), (12)-->(14-18)
@@ -975,6 +981,7 @@ update customer
       │    │    ├── [/10/8/2106 - /10/8/2106]
       │    │    ├── [/10/9/1412 - /10/9/1412]
       │    │    └── [/10/10/417 - /10/10/417]
+      │    ├── flags: avoid-full-scan
       │    ├── cardinality: [0 - 10]
       │    ├── key: (24,25)
       │    └── fd: ()-->(26), (24,25)-->(27-44)
@@ -1016,6 +1023,7 @@ delete new_order
       │    ├── [/10/8/2167 - /10/8/2167]
       │    ├── [/10/9/2167 - /10/9/2167]
       │    └── [/10/10/2167 - /10/10/2167]
+      ├── flags: avoid-full-scan
       ├── cardinality: [0 - 10]
       ├── key: (7)
       └── fd: ()-->(6,8)
@@ -1061,6 +1069,7 @@ update order_line
       │    │    ├── [/10/8/2167 - /10/8/2167]
       │    │    ├── [/10/9/2167 - /10/9/2167]
       │    │    └── [/10/10/2167 - /10/10/2167]
+      │    ├── flags: avoid-full-scan
       │    ├── key: (14,16)
       │    └── fd: ()-->(13,15), (14,16)-->(17-22)
       └── projections

--- a/pkg/sql/opt/xform/testdata/external/tpce
+++ b/pkg/sql/opt/xform/testdata/external/tpce
@@ -584,6 +584,7 @@ with &1 (update_last_trade)
  │    │         ├── scan last_trade
  │    │         │    ├── columns: lt_s_symb:8!null lt_dts:9!null lt_price:10!null lt_open_price:11!null lt_vol:12!null
  │    │         │    ├── constraint: /8: [/'ROACH' - /'ROACH']
+ │    │         │    ├── flags: avoid-full-scan
  │    │         │    ├── cardinality: [0 - 1]
  │    │         │    ├── key: ()
  │    │         │    └── fd: ()-->(8-12)
@@ -3688,6 +3689,7 @@ update holding_summary
       ├── scan holding_summary
       │    ├── columns: hs_ca_id:6!null hs_s_symb:7!null hs_qty:8!null
       │    ├── constraint: /6/7: [/0/'ROACH' - /0/'ROACH']
+      │    ├── flags: avoid-full-scan
       │    ├── cardinality: [0 - 1]
       │    ├── key: ()
       │    └── fd: ()-->(6-8)
@@ -3819,6 +3821,7 @@ update holding
       ├── scan holding
       │    ├── columns: h_t_id:9!null h_ca_id:10!null h_s_symb:11!null h_dts:12!null h_price:13!null h_qty:14!null
       │    ├── constraint: /9: [/0 - /0]
+      │    ├── flags: avoid-full-scan
       │    ├── cardinality: [0 - 1]
       │    ├── key: ()
       │    └── fd: ()-->(9-14)
@@ -3838,6 +3841,7 @@ delete holding
  └── scan holding
       ├── columns: h_t_id:9!null h_ca_id:10!null h_s_symb:11!null h_dts:12!null
       ├── constraint: /9: [/0 - /5]
+      ├── flags: avoid-full-scan
       ├── cardinality: [0 - 6]
       ├── key: (9)
       └── fd: (9)-->(10-12)
@@ -3923,6 +3927,7 @@ delete holding_summary
  ├── scan holding_summary
  │    ├── columns: holding_summary.hs_ca_id:6!null holding_summary.hs_s_symb:7!null
  │    ├── constraint: /6/7: [/0/'ROACH' - /0/'ROACH']
+ │    ├── flags: avoid-full-scan
  │    ├── cardinality: [0 - 1]
  │    ├── key: ()
  │    └── fd: ()-->(6,7)
@@ -3990,6 +3995,7 @@ project
  │         │    ├── scan trade
  │         │    │    ├── columns: t_id:18!null trade.t_tax:31!null
  │         │    │    ├── constraint: /18: [/0 - /0]
+ │         │    │    ├── flags: avoid-full-scan
  │         │    │    ├── cardinality: [0 - 1]
  │         │    │    ├── key: ()
  │         │    │    └── fd: ()-->(18,31)
@@ -4217,6 +4223,7 @@ with &2 (update_trade_commission)
  │    │    │    ├── scan trade
  │    │    │    │    ├── columns: t_id:18!null t_dts:19!null trade.t_st_id:20!null t_tt_id:21!null t_is_cash:22!null t_s_symb:23!null t_qty:24!null t_bid_price:25!null t_ca_id:26!null t_exec_name:27!null t_trade_price:28 t_chrg:29!null t_comm:30!null t_lifo:32!null
  │    │    │    │    ├── constraint: /18: [/0 - /0]
+ │    │    │    │    ├── flags: avoid-full-scan
  │    │    │    │    ├── cardinality: [0 - 1]
  │    │    │    │    ├── key: ()
  │    │    │    │    └── fd: ()-->(18-30,32)
@@ -4278,6 +4285,7 @@ with &2 (update_trade_commission)
       │    │         ├── scan broker
       │    │         │    ├── columns: b_id:60!null b_num_trades:63!null b_comm_total:64!null
       │    │         │    ├── constraint: /60: [/0 - /0]
+      │    │         │    ├── flags: avoid-full-scan
       │    │         │    ├── cardinality: [0 - 1]
       │    │         │    ├── key: ()
       │    │         │    └── fd: ()-->(60,63,64)
@@ -4516,6 +4524,7 @@ with &2 (insert_settlement)
            │         ├── scan customer_account
            │         │    ├── columns: ca_id:71!null ca_b_id:72!null ca_c_id:73!null ca_name:74 ca_tax_st:75!null customer_account.ca_bal:76!null
            │         │    ├── constraint: /71: [/0 - /0]
+           │         │    ├── flags: avoid-full-scan
            │         │    ├── cardinality: [0 - 1]
            │         │    ├── key: ()
            │         │    └── fd: ()-->(71-76)
@@ -5106,6 +5115,7 @@ update trade
       ├── scan trade
       │    ├── columns: t_id:18!null t_dts:19!null t_st_id:20!null t_tt_id:21!null t_is_cash:22!null t_s_symb:23!null t_qty:24!null t_bid_price:25!null t_ca_id:26!null t_exec_name:27!null t_trade_price:28 t_chrg:29!null t_comm:30!null t_lifo:32!null
       │    ├── constraint: /18: [/0 - /3]
+      │    ├── flags: avoid-full-scan
       │    ├── cardinality: [0 - 4]
       │    ├── key: (18)
       │    └── fd: (18)-->(19-30,32)
@@ -5712,6 +5722,7 @@ update address
       ├── scan address
       │    ├── columns: ad_id:8!null ad_line1:9 ad_line2:10 ad_zc_code:11!null ad_ctry:12
       │    ├── constraint: /8: [/0 - /0]
+      │    ├── flags: avoid-full-scan
       │    ├── cardinality: [0 - 1]
       │    ├── key: ()
       │    └── fd: ()-->(8-12)
@@ -5738,6 +5749,7 @@ update company
       ├── scan company
       │    ├── columns: co_id:12!null co_st_id:13!null co_name:14!null co_in_id:15!null co_sp_rate:16!null co_ceo:17!null co_ad_id:18!null co_desc:19!null co_open_date:20!null
       │    ├── constraint: /12: [/0 - /0]
+      │    ├── flags: avoid-full-scan
       │    ├── cardinality: [0 - 1]
       │    ├── key: ()
       │    └── fd: ()-->(12-20)
@@ -5768,6 +5780,7 @@ update customer
       ├── scan customer
       │    ├── columns: c_id:27!null c_tax_id:28!null c_st_id:29!null c_l_name:30!null c_f_name:31!null c_m_name:32 c_gndr:33 c_tier:34!null c_dob:35!null c_ad_id:36!null c_ctry_1:37 c_area_1:38 c_local_1:39 c_ext_1:40 c_ctry_2:41 c_area_2:42 c_local_2:43 c_ext_2:44 c_ctry_3:45 c_area_3:46 c_local_3:47 c_ext_3:48 c_email_1:49 c_email_2:50
       │    ├── constraint: /27: [/0 - /0]
+      │    ├── flags: avoid-full-scan
       │    ├── cardinality: [0 - 1]
       │    ├── key: ()
       │    └── fd: ()-->(27-50)
@@ -5811,6 +5824,7 @@ update customer_taxrate
  │    │    ├── constraint: /6/5
  │    │    │    ├── [/0/'CN' - /0/'CO')
  │    │    │    └── [/0/'US' - /0/'UT')
+ │    │    ├── flags: avoid-full-scan
  │    │    ├── key: (5)
  │    │    └── fd: ()-->(6)
  │    └── projections
@@ -5854,6 +5868,7 @@ update daily_market
       │    ├── scan daily_market@daily_market_dm_s_symb_dm_date_key
       │    │    ├── columns: dm_date:9!null dm_s_symb:10!null dm_close:11!null dm_high:12!null dm_low:13!null dm_vol:14!null
       │    │    ├── constraint: /10/9: [/'ROACH' - /'ROACH']
+      │    │    ├── flags: avoid-full-scan
       │    │    ├── key: (9)
       │    │    └── fd: ()-->(10), (9)-->(11-14)
       │    └── filters
@@ -5885,6 +5900,7 @@ update exchange
       ├── fd: (10)-->(11-16), (15)-->(20)
       ├── scan exchange
       │    ├── columns: ex_id:10!null ex_name:11!null ex_num_symb:12!null ex_open:13!null ex_close:14!null ex_desc:15 ex_ad_id:16!null
+      │    ├── flags: avoid-full-scan
       │    ├── key: (10)
       │    └── fd: (10)-->(11-16)
       └── projections
@@ -5916,6 +5932,7 @@ update financial
       ├── scan financial
       │    ├── columns: fi_co_id:17!null fi_year:18!null fi_qtr:19!null fi_qtr_start_date:20!null fi_revenue:21!null fi_net_earn:22!null fi_basic_eps:23!null fi_dilut_eps:24!null fi_margin:25!null fi_inventory:26!null fi_assets:27!null fi_liability:28!null fi_out_basic:29!null fi_out_dilut:30!null
       │    ├── constraint: /17/18/19: [/0 - /0]
+      │    ├── flags: avoid-full-scan
       │    ├── key: (18,19)
       │    └── fd: ()-->(17), (18,19)-->(20-30)
       └── projections
@@ -5982,6 +5999,7 @@ update security
       ├── scan security
       │    ├── columns: s_symb:19!null s_issue:20!null s_st_id:21!null s_name:22!null s_ex_id:23!null s_co_id:24!null s_num_out:25!null s_start_date:26!null s_exch_date:27!null s_pe:28!null s_52wk_high:29!null s_52wk_high_date:30!null s_52wk_low:31!null s_52wk_low_date:32!null s_dividend:33!null s_yield:34!null
       │    ├── constraint: /19: [/'ROACH' - /'ROACH']
+      │    ├── flags: avoid-full-scan
       │    ├── cardinality: [0 - 1]
       │    ├── key: ()
       │    └── fd: ()-->(19-34)
@@ -6014,6 +6032,7 @@ update taxrate
       ├── scan taxrate
       │    ├── columns: tx_id:6!null tx_name:7!null tx_rate:8!null
       │    ├── constraint: /6: [/'US1' - /'US1']
+      │    ├── flags: avoid-full-scan
       │    ├── cardinality: [0 - 1]
       │    ├── key: ()
       │    └── fd: ()-->(6-8)
@@ -6283,6 +6302,7 @@ update trade
  │    ├── scan trade
  │    │    ├── columns: t_id:18!null t_dts:19!null trade.t_st_id:20!null t_tt_id:21!null t_is_cash:22!null t_s_symb:23!null t_qty:24!null t_bid_price:25!null t_ca_id:26!null t_exec_name:27!null t_trade_price:28 t_chrg:29!null t_comm:30!null t_lifo:32!null
  │    │    ├── constraint: /18: [/1 - /5]
+ │    │    ├── flags: avoid-full-scan
  │    │    ├── cardinality: [0 - 5]
  │    │    ├── key: (18)
  │    │    └── fd: (18)-->(19-30,32)
@@ -6291,10 +6311,10 @@ update trade
  │         └── '2020-06-15 22:27:42.148484' [as=t_dts_new:36]
  └── f-k-checks
       └── f-k-checks-item: trade(t_st_id) -> status_type(st_id)
-           └── anti-join (merge)
+           └── anti-join (lookup status_type)
                 ├── columns: t_st_id:43!null
-                ├── left ordering: +43
-                ├── right ordering: +44
+                ├── key columns: [43] = [44]
+                ├── lookup columns are key
                 ├── cardinality: [0 - 5]
                 ├── fd: ()-->(43)
                 ├── with-scan &1
@@ -6303,10 +6323,6 @@ update trade
                 │    │    └──  t_st_id_cast:37 => t_st_id:43
                 │    ├── cardinality: [0 - 5]
                 │    └── fd: ()-->(43)
-                ├── scan status_type
-                │    ├── columns: st_id:44!null
-                │    ├── key: (44)
-                │    └── ordering: +44
                 └── filters (true)
 
 # Q4
@@ -6340,6 +6356,7 @@ with &1 (empty_trade_requests)
  │         │    ├── columns: trade_request.tr_t_id:9!null tr_tt_id:10!null tr_s_symb:11!null tr_b_id:14!null
  │         │    ├── constraint: /9: [/1 - ]
  │         │    ├── limit: 20
+ │         │    ├── flags: avoid-full-scan
  │         │    ├── key: (9)
  │         │    └── fd: (9)-->(10,11,14)
  │         └── projections

--- a/pkg/sql/opt/xform/testdata/external/tpce-no-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpce-no-stats
@@ -602,6 +602,7 @@ with &1 (update_last_trade)
  │    │         ├── scan last_trade
  │    │         │    ├── columns: lt_s_symb:8!null lt_dts:9!null lt_price:10!null lt_open_price:11!null lt_vol:12!null
  │    │         │    ├── constraint: /8: [/'ROACH' - /'ROACH']
+ │    │         │    ├── flags: avoid-full-scan
  │    │         │    ├── cardinality: [0 - 1]
  │    │         │    ├── key: ()
  │    │         │    └── fd: ()-->(8-12)
@@ -3718,6 +3719,7 @@ update holding_summary
       ├── scan holding_summary
       │    ├── columns: hs_ca_id:6!null hs_s_symb:7!null hs_qty:8!null
       │    ├── constraint: /6/7: [/0/'ROACH' - /0/'ROACH']
+      │    ├── flags: avoid-full-scan
       │    ├── cardinality: [0 - 1]
       │    ├── key: ()
       │    └── fd: ()-->(6-8)
@@ -3849,6 +3851,7 @@ update holding
       ├── scan holding
       │    ├── columns: h_t_id:9!null h_ca_id:10!null h_s_symb:11!null h_dts:12!null h_price:13!null h_qty:14!null
       │    ├── constraint: /9: [/0 - /0]
+      │    ├── flags: avoid-full-scan
       │    ├── cardinality: [0 - 1]
       │    ├── key: ()
       │    └── fd: ()-->(9-14)
@@ -3868,6 +3871,7 @@ delete holding
  └── scan holding
       ├── columns: h_t_id:9!null h_ca_id:10!null h_s_symb:11!null h_dts:12!null
       ├── constraint: /9: [/0 - /5]
+      ├── flags: avoid-full-scan
       ├── cardinality: [0 - 6]
       ├── key: (9)
       └── fd: (9)-->(10-12)
@@ -3953,6 +3957,7 @@ delete holding_summary
  ├── scan holding_summary
  │    ├── columns: holding_summary.hs_ca_id:6!null holding_summary.hs_s_symb:7!null
  │    ├── constraint: /6/7: [/0/'ROACH' - /0/'ROACH']
+ │    ├── flags: avoid-full-scan
  │    ├── cardinality: [0 - 1]
  │    ├── key: ()
  │    └── fd: ()-->(6,7)
@@ -4020,6 +4025,7 @@ project
  │         │    ├── scan trade
  │         │    │    ├── columns: t_id:18!null trade.t_tax:31!null
  │         │    │    ├── constraint: /18: [/0 - /0]
+ │         │    │    ├── flags: avoid-full-scan
  │         │    │    ├── cardinality: [0 - 1]
  │         │    │    ├── key: ()
  │         │    │    └── fd: ()-->(18,31)
@@ -4247,6 +4253,7 @@ with &2 (update_trade_commission)
  │    │    │    ├── scan trade
  │    │    │    │    ├── columns: t_id:18!null t_dts:19!null trade.t_st_id:20!null t_tt_id:21!null t_is_cash:22!null t_s_symb:23!null t_qty:24!null t_bid_price:25!null t_ca_id:26!null t_exec_name:27!null t_trade_price:28 t_chrg:29!null t_comm:30!null t_lifo:32!null
  │    │    │    │    ├── constraint: /18: [/0 - /0]
+ │    │    │    │    ├── flags: avoid-full-scan
  │    │    │    │    ├── cardinality: [0 - 1]
  │    │    │    │    ├── key: ()
  │    │    │    │    └── fd: ()-->(18-30,32)
@@ -4308,6 +4315,7 @@ with &2 (update_trade_commission)
       │    │         ├── scan broker
       │    │         │    ├── columns: b_id:60!null b_num_trades:63!null b_comm_total:64!null
       │    │         │    ├── constraint: /60: [/0 - /0]
+      │    │         │    ├── flags: avoid-full-scan
       │    │         │    ├── cardinality: [0 - 1]
       │    │         │    ├── key: ()
       │    │         │    └── fd: ()-->(60,63,64)
@@ -4546,6 +4554,7 @@ with &2 (insert_settlement)
            │         ├── scan customer_account
            │         │    ├── columns: ca_id:71!null ca_b_id:72!null ca_c_id:73!null ca_name:74 ca_tax_st:75!null customer_account.ca_bal:76!null
            │         │    ├── constraint: /71: [/0 - /0]
+           │         │    ├── flags: avoid-full-scan
            │         │    ├── cardinality: [0 - 1]
            │         │    ├── key: ()
            │         │    └── fd: ()-->(71-76)
@@ -5124,6 +5133,7 @@ update trade
       ├── scan trade
       │    ├── columns: t_id:18!null t_dts:19!null t_st_id:20!null t_tt_id:21!null t_is_cash:22!null t_s_symb:23!null t_qty:24!null t_bid_price:25!null t_ca_id:26!null t_exec_name:27!null t_trade_price:28 t_chrg:29!null t_comm:30!null t_lifo:32!null
       │    ├── constraint: /18: [/0 - /3]
+      │    ├── flags: avoid-full-scan
       │    ├── cardinality: [0 - 4]
       │    ├── key: (18)
       │    └── fd: (18)-->(19-30,32)
@@ -5729,6 +5739,7 @@ update address
       ├── scan address
       │    ├── columns: ad_id:8!null ad_line1:9 ad_line2:10 ad_zc_code:11!null ad_ctry:12
       │    ├── constraint: /8: [/0 - /0]
+      │    ├── flags: avoid-full-scan
       │    ├── cardinality: [0 - 1]
       │    ├── key: ()
       │    └── fd: ()-->(8-12)
@@ -5755,6 +5766,7 @@ update company
       ├── scan company
       │    ├── columns: co_id:12!null co_st_id:13!null co_name:14!null co_in_id:15!null co_sp_rate:16!null co_ceo:17!null co_ad_id:18!null co_desc:19!null co_open_date:20!null
       │    ├── constraint: /12: [/0 - /0]
+      │    ├── flags: avoid-full-scan
       │    ├── cardinality: [0 - 1]
       │    ├── key: ()
       │    └── fd: ()-->(12-20)
@@ -5785,6 +5797,7 @@ update customer
       ├── scan customer
       │    ├── columns: c_id:27!null c_tax_id:28!null c_st_id:29!null c_l_name:30!null c_f_name:31!null c_m_name:32 c_gndr:33 c_tier:34!null c_dob:35!null c_ad_id:36!null c_ctry_1:37 c_area_1:38 c_local_1:39 c_ext_1:40 c_ctry_2:41 c_area_2:42 c_local_2:43 c_ext_2:44 c_ctry_3:45 c_area_3:46 c_local_3:47 c_ext_3:48 c_email_1:49 c_email_2:50
       │    ├── constraint: /27: [/0 - /0]
+      │    ├── flags: avoid-full-scan
       │    ├── cardinality: [0 - 1]
       │    ├── key: ()
       │    └── fd: ()-->(27-50)
@@ -5828,6 +5841,7 @@ update customer_taxrate
  │    │    ├── constraint: /6/5
  │    │    │    ├── [/0/'CN' - /0/'CO')
  │    │    │    └── [/0/'US' - /0/'UT')
+ │    │    ├── flags: avoid-full-scan
  │    │    ├── key: (5)
  │    │    └── fd: ()-->(6)
  │    └── projections
@@ -5871,6 +5885,7 @@ update daily_market
       │    ├── scan daily_market@daily_market_dm_s_symb_dm_date_key
       │    │    ├── columns: dm_date:9!null dm_s_symb:10!null dm_close:11!null dm_high:12!null dm_low:13!null dm_vol:14!null
       │    │    ├── constraint: /10/9: [/'ROACH' - /'ROACH']
+      │    │    ├── flags: avoid-full-scan
       │    │    ├── key: (9)
       │    │    └── fd: ()-->(10), (9)-->(11-14)
       │    └── filters
@@ -5902,6 +5917,7 @@ update exchange
       ├── fd: (10)-->(11-16), (15)-->(20)
       ├── scan exchange
       │    ├── columns: ex_id:10!null ex_name:11!null ex_num_symb:12!null ex_open:13!null ex_close:14!null ex_desc:15 ex_ad_id:16!null
+      │    ├── flags: avoid-full-scan
       │    ├── key: (10)
       │    └── fd: (10)-->(11-16)
       └── projections
@@ -5933,6 +5949,7 @@ update financial
       ├── scan financial
       │    ├── columns: fi_co_id:17!null fi_year:18!null fi_qtr:19!null fi_qtr_start_date:20!null fi_revenue:21!null fi_net_earn:22!null fi_basic_eps:23!null fi_dilut_eps:24!null fi_margin:25!null fi_inventory:26!null fi_assets:27!null fi_liability:28!null fi_out_basic:29!null fi_out_dilut:30!null
       │    ├── constraint: /17/18/19: [/0 - /0]
+      │    ├── flags: avoid-full-scan
       │    ├── key: (18,19)
       │    └── fd: ()-->(17), (18,19)-->(20-30)
       └── projections
@@ -5999,6 +6016,7 @@ update security
       ├── scan security
       │    ├── columns: s_symb:19!null s_issue:20!null s_st_id:21!null s_name:22!null s_ex_id:23!null s_co_id:24!null s_num_out:25!null s_start_date:26!null s_exch_date:27!null s_pe:28!null s_52wk_high:29!null s_52wk_high_date:30!null s_52wk_low:31!null s_52wk_low_date:32!null s_dividend:33!null s_yield:34!null
       │    ├── constraint: /19: [/'ROACH' - /'ROACH']
+      │    ├── flags: avoid-full-scan
       │    ├── cardinality: [0 - 1]
       │    ├── key: ()
       │    └── fd: ()-->(19-34)
@@ -6031,6 +6049,7 @@ update taxrate
       ├── scan taxrate
       │    ├── columns: tx_id:6!null tx_name:7!null tx_rate:8!null
       │    ├── constraint: /6: [/'US1' - /'US1']
+      │    ├── flags: avoid-full-scan
       │    ├── cardinality: [0 - 1]
       │    ├── key: ()
       │    └── fd: ()-->(6-8)
@@ -6303,6 +6322,7 @@ update trade
  │    ├── scan trade
  │    │    ├── columns: t_id:18!null t_dts:19!null trade.t_st_id:20!null t_tt_id:21!null t_is_cash:22!null t_s_symb:23!null t_qty:24!null t_bid_price:25!null t_ca_id:26!null t_exec_name:27!null t_trade_price:28 t_chrg:29!null t_comm:30!null t_lifo:32!null
  │    │    ├── constraint: /18: [/1 - /5]
+ │    │    ├── flags: avoid-full-scan
  │    │    ├── cardinality: [0 - 5]
  │    │    ├── key: (18)
  │    │    └── fd: (18)-->(19-30,32)
@@ -6356,6 +6376,7 @@ with &1 (empty_trade_requests)
  │         │    ├── columns: trade_request.tr_t_id:9!null tr_tt_id:10!null tr_s_symb:11!null tr_b_id:14!null
  │         │    ├── constraint: /9: [/1 - ]
  │         │    ├── limit: 20
+ │         │    ├── flags: avoid-full-scan
  │         │    ├── key: (9)
  │         │    └── fd: (9)-->(10,11,14)
  │         └── projections

--- a/pkg/sql/opt/xform/testdata/external/trading
+++ b/pkg/sql/opt/xform/testdata/external/trading
@@ -1263,6 +1263,7 @@ upsert transactions
       ├── scan transactions
       │    ├── columns: dealerid:19!null isbuy:20!null date:21!null accountname:22!null customername:23!null operationid:24 version:25!null
       │    ├── constraint: /19/20/21: [/1/false/'2020-03-01 00:00:00+00' - /1/false/'2020-03-01 00:00:00+00']
+      │    ├── flags: avoid-full-scan
       │    ├── cardinality: [0 - 1]
       │    ├── key: ()
       │    └── fd: ()-->(19-25)
@@ -1407,6 +1408,7 @@ delete inventorydetails
       │    ├── [/1/294/'some-account' - /1/294/'some-account']
       │    ├── [/1/1793/'some-account' - /1/1793/'some-account']
       │    └── [/1/29483/'some-account' - /1/29483/'some-account']
+      ├── flags: avoid-full-scan
       ├── cardinality: [0 - 3]
       ├── key: (9)
       └── fd: ()-->(8,10)

--- a/pkg/sql/opt/xform/testdata/external/trading-mutation
+++ b/pkg/sql/opt/xform/testdata/external/trading-mutation
@@ -1270,6 +1270,7 @@ upsert transactions
       ├── scan transactions
       │    ├── columns: dealerid:22!null isbuy:23!null date:24!null accountname:25!null customername:26!null operationid:27 version:28!null olddate:29 extra:30
       │    ├── constraint: /22/23/24: [/1/false/'2020-03-01 00:00:00+00' - /1/false/'2020-03-01 00:00:00+00']
+      │    ├── flags: avoid-full-scan
       │    ├── cardinality: [0 - 1]
       │    ├── key: ()
       │    └── fd: ()-->(22-30)
@@ -1419,6 +1420,7 @@ delete inventorydetails
       │    ├── [/1/294/'some-account' - /1/294/'some-account']
       │    ├── [/1/1793/'some-account' - /1/1793/'some-account']
       │    └── [/1/29483/'some-account' - /1/29483/'some-account']
+      ├── flags: avoid-full-scan
       ├── cardinality: [0 - 3]
       ├── key: (11)
       └── fd: ()-->(10,12)

--- a/pkg/sql/opt/xform/testdata/external/ycsb
+++ b/pkg/sql/opt/xform/testdata/external/ycsb
@@ -38,6 +38,7 @@ update usertable
       ├── scan usertable
       │    ├── columns: ycsb_key:14!null field5:20
       │    ├── constraint: /14: [/'user123' - /'user123']
+      │    ├── flags: avoid-full-scan
       │    ├── cardinality: [0 - 1]
       │    ├── key: ()
       │    └── fd: ()-->(14,20)
@@ -182,6 +183,7 @@ update usertable
       ├── scan usertable
       │    ├── columns: ycsb_key:14!null field5:20
       │    ├── constraint: /14: [/'user123' - /'user123']
+      │    ├── flags: avoid-full-scan
       │    ├── cardinality: [0 - 1]
       │    ├── key: ()
       │    └── fd: ()-->(14,20)

--- a/pkg/sql/opt/xform/testdata/physprops/ordering
+++ b/pkg/sql/opt/xform/testdata/physprops/ordering
@@ -2047,6 +2047,7 @@ sort
       │              ├── fd: ()-->(15,16), (12)-->(8-11)
       │              ├── scan abcd
       │              │    ├── columns: abcd.a:8 abcd.b:9 abcd.c:10 abcd.d:11 rowid:12!null
+      │              │    ├── flags: avoid-full-scan
       │              │    ├── key: (12)
       │              │    └── fd: (12)-->(8-11)
       │              └── projections
@@ -2104,6 +2105,7 @@ sort
       │              ├── scan abcd@cd
       │              │    ├── columns: abcd.a:8 abcd.b:9 abcd.c:10 abcd.d:11 rowid:12!null
       │              │    ├── limit: 10
+      │              │    ├── flags: avoid-full-scan
       │              │    ├── key: (12)
       │              │    └── fd: (12)-->(8-11)
       │              └── projections
@@ -2164,6 +2166,7 @@ sort
       │              ├── scan abcd@cd
       │              │    ├── columns: abcd.a:8 abcd.b:9 abcd.c:10 abcd.d:11 rowid:12!null
       │              │    ├── limit: 10
+      │              │    ├── flags: avoid-full-scan
       │              │    ├── key: (12)
       │              │    └── fd: (12)-->(8-11)
       │              └── projections
@@ -2292,6 +2295,7 @@ sort
       │         ├── fd: (5)-->(1-4)
       │         └── scan abcd
       │              ├── columns: abcd.a:8 abcd.b:9 abcd.c:10 abcd.d:11 rowid:12!null
+      │              ├── flags: avoid-full-scan
       │              ├── key: (12)
       │              └── fd: (12)-->(8-11)
       └── with-scan &1
@@ -2337,6 +2341,7 @@ sort
       │         └── scan abcd@cd
       │              ├── columns: abcd.a:8 abcd.b:9 abcd.c:10 abcd.d:11 rowid:12!null
       │              ├── limit: 10
+      │              ├── flags: avoid-full-scan
       │              ├── key: (12)
       │              └── fd: (12)-->(8-11)
       └── with-scan &1
@@ -2387,6 +2392,7 @@ sort
       │         └── scan abcd@cd
       │              ├── columns: abcd.a:8 abcd.b:9 abcd.c:10 abcd.d:11 rowid:12!null
       │              ├── limit: 10
+      │              ├── flags: avoid-full-scan
       │              ├── key: (12)
       │              └── fd: (12)-->(8-11)
       └── select

--- a/pkg/sql/opt/xform/testdata/rules/groupby
+++ b/pkg/sql/opt/xform/testdata/rules/groupby
@@ -2369,21 +2369,21 @@ memo (optimized, ~27KB, required=[])
  ├── G1: (insert G2 G3 G4 G5 xyz)
  │    └── []
  │         ├── best: (insert G2 G3 G4 G5 xyz)
- │         └── cost: 2196.92
+ │         └── cost: 7132.30
  ├── G2: (upsert-distinct-on G6 G7 cols=(8)) (upsert-distinct-on G6 G7 cols=(8),ordering=+8 opt(12))
  │    └── []
  │         ├── best: (upsert-distinct-on G6 G7 cols=(8))
- │         └── cost: 2196.91
+ │         └── cost: 7132.29
  ├── G3: (unique-checks)
  ├── G4: (fast-path-unique-checks)
  ├── G5: (f-k-checks)
  ├── G6: (anti-join G8 G9 G10) (merge-join G8 G9 G11 anti-join,+8,+13) (lookup-join G8 G11 xyz,keyCols=[8],outCols=(8,9,12,13)) (lookup-join G8 G11 xyz@xy,keyCols=[8],outCols=(8,9,12,13))
  │    ├── [ordering: +8 opt(12)]
- │    │    ├── best: (merge-join G8="[ordering: +8 opt(12)]" G9="[ordering: +13]" G11 anti-join,+8,+13)
- │    │    └── cost: 2196.88
+ │    │    ├── best: (lookup-join G8="[ordering: +8 opt(12)]" G11 xyz@xy,keyCols=[8],outCols=(8,9,12,13))
+ │    │    └── cost: 7132.26
  │    └── []
- │         ├── best: (merge-join G8="[ordering: +8 opt(12)]" G9="[ordering: +13]" G11 anti-join,+8,+13)
- │         └── cost: 2196.88
+ │         ├── best: (lookup-join G8 G11 xyz@xy,keyCols=[8],outCols=(8,9,12,13))
+ │         └── cost: 7132.26
  ├── G7: (aggregations G12 G13)
  ├── G8: (project G14 G15 v w)
  │    ├── [ordering: +8 opt(12)]
@@ -2394,11 +2394,11 @@ memo (optimized, ~27KB, required=[])
  │         └── cost: 1108.64
  ├── G9: (scan xyz,cols=(13)) (scan xyz@xy,cols=(13)) (scan xyz@zyx,cols=(13)) (scan xyz@yy,cols=(13))
  │    ├── [ordering: +13]
- │    │    ├── best: (scan xyz@xy,cols=(13))
- │    │    └── cost: 1058.32
+ │    │    ├── best: (sort G9)
+ │    │    └── cost: 105830000000000011086117600777744040134749299700400128.00
  │    └── []
  │         ├── best: (scan xyz@xy,cols=(13))
- │         └── cost: 1058.32
+ │         └── cost: 105830000000000011086117600777744040134749299700400128.00
  ├── G10: (filters G16)
  ├── G11: (filters)
  ├── G12: (first-agg G17)
@@ -2426,17 +2426,17 @@ memo (optimized, ~28KB, required=[])
  ├── G1: (upsert G2 G3 G4 xyz)
  │    └── []
  │         ├── best: (upsert G2 G3 G4 xyz)
- │         └── cost: 2287.34
+ │         └── cost: 7242.72
  ├── G2: (project G5 G6 v w ?column? x y z)
  │    └── []
  │         ├── best: (project G5 G6 v w ?column? x y z)
- │         └── cost: 2287.33
+ │         └── cost: 7242.71
  ├── G3: (unique-checks)
  ├── G4: (f-k-checks)
  ├── G5: (left-join G7 G8 G9) (right-join G8 G7 G9) (lookup-join G7 G10 xyz,keyCols=[8],outCols=(8,9,12-15)) (lookup-join G11 G10 xyz,keyCols=[13],outCols=(8,9,12-15)) (merge-join G8 G7 G10 right-join,+13,+8)
  │    └── []
- │         ├── best: (merge-join G8="[ordering: +13]" G7="[ordering: +8 opt(12)]" G10 right-join,+13,+8)
- │         └── cost: 2267.31
+ │         ├── best: (lookup-join G7 G10 xyz,keyCols=[8],outCols=(8,9,12-15))
+ │         └── cost: 7222.69
  ├── G6: (projections G12)
  ├── G7: (ensure-upsert-distinct-on G13 G14 cols=(8)) (ensure-upsert-distinct-on G13 G14 cols=(8),ordering=+8 opt(12))
  │    ├── [ordering: +8 opt(12)]
@@ -2447,11 +2447,11 @@ memo (optimized, ~28KB, required=[])
  │         └── cost: 1148.67
  ├── G8: (scan xyz,cols=(13-15)) (scan xyz@zyx,cols=(13-15))
  │    ├── [ordering: +13]
- │    │    ├── best: (scan xyz,cols=(13-15))
- │    │    └── cost: 1088.62
+ │    │    ├── best: (sort G8)
+ │    │    └── cost: 108860000000000027122651264342843517581417564466053120.00
  │    └── []
  │         ├── best: (scan xyz,cols=(13-15))
- │         └── cost: 1088.62
+ │         └── cost: 108860000000000027122651264342843517581417564466053120.00
  ├── G9: (filters G15)
  ├── G10: (filters)
  ├── G11: (lookup-join G7 G10 xyz@xy,keyCols=[8],outCols=(8,9,12-14))
@@ -2867,24 +2867,19 @@ upsert xyz
       ├── columns: upsert_z:23 a:7!null b:8!null c:9 x:15 y:16 z:17
       ├── key: (7)
       ├── fd: (7)-->(8,9,15-17,23), (15)-->(16,17)
-      ├── right-join (merge)
+      ├── left-join (lookup xyz)
       │    ├── columns: a:7!null b:8!null c:9 x:15 y:16 z:17
-      │    ├── left ordering: +15
-      │    ├── right ordering: +7
+      │    ├── key columns: [7] = [15]
+      │    ├── lookup columns are key
       │    ├── key: (7)
       │    ├── fd: (7)-->(8,9,15-17), (15)-->(16,17)
-      │    ├── scan xyz
-      │    │    ├── columns: x:15!null y:16 z:17
-      │    │    ├── key: (15)
-      │    │    ├── fd: (15)-->(16,17)
-      │    │    └── ordering: +15
       │    ├── ensure-upsert-distinct-on
       │    │    ├── columns: a:7!null b:8!null c:9
       │    │    ├── grouping columns: a:7!null
+      │    │    ├── internal-ordering: +7
       │    │    ├── error: "UPSERT or INSERT...ON CONFLICT command cannot affect row a second time"
       │    │    ├── key: (7)
       │    │    ├── fd: (7)-->(8,9)
-      │    │    ├── ordering: +7
       │    │    ├── union-all
       │    │    │    ├── columns: a:7!null b:8!null c:9
       │    │    │    ├── left columns: a:25 b:26 c:27
@@ -2933,24 +2928,19 @@ upsert xyz
       ├── columns: upsert_z:23 a:7!null b:8!null c:9 x:15 y:16 z:17
       ├── key: (7)
       ├── fd: (7)-->(8,9,15-17,23), (15)-->(16,17)
-      ├── right-join (merge)
+      ├── left-join (lookup xyz)
       │    ├── columns: a:7!null b:8!null c:9 x:15 y:16 z:17
-      │    ├── left ordering: +15
-      │    ├── right ordering: +7
+      │    ├── key columns: [7] = [15]
+      │    ├── lookup columns are key
       │    ├── key: (7)
       │    ├── fd: (7)-->(8,9,15-17), (15)-->(16,17)
-      │    ├── scan xyz
-      │    │    ├── columns: x:15!null y:16 z:17
-      │    │    ├── key: (15)
-      │    │    ├── fd: (15)-->(16,17)
-      │    │    └── ordering: +15
       │    ├── ensure-upsert-distinct-on
       │    │    ├── columns: a:7!null b:8!null c:9
       │    │    ├── grouping columns: a:7!null
+      │    │    ├── internal-ordering: +7
       │    │    ├── error: "UPSERT or INSERT...ON CONFLICT command cannot affect row a second time"
       │    │    ├── key: (7)
       │    │    ├── fd: (7)-->(8,9)
-      │    │    ├── ordering: +7
       │    │    ├── union-all
       │    │    │    ├── columns: a:7!null b:8!null c:9
       │    │    │    ├── left columns: a:25 b:26 c:27
@@ -3216,24 +3206,19 @@ upsert xyz
       ├── columns: upsert_z:21 a:6 b:7 x:13 y:14 z:15
       ├── lax-key: (6,13)
       ├── fd: (6)~~>(7), (13)-->(14,15), (6,13)~~>(7,21)
-      ├── right-join (merge)
+      ├── left-join (lookup xyz)
       │    ├── columns: a:6 b:7 x:13 y:14 z:15
-      │    ├── left ordering: +13
-      │    ├── right ordering: +6
+      │    ├── key columns: [6] = [13]
+      │    ├── lookup columns are key
       │    ├── lax-key: (6,13)
       │    ├── fd: (6)~~>(7), (13)-->(14,15)
-      │    ├── scan xyz
-      │    │    ├── columns: x:13!null y:14 z:15
-      │    │    ├── key: (13)
-      │    │    ├── fd: (13)-->(14,15)
-      │    │    └── ordering: +13
       │    ├── ensure-upsert-distinct-on
       │    │    ├── columns: a:6 b:7
       │    │    ├── grouping columns: a:6
+      │    │    ├── internal-ordering: +6
       │    │    ├── error: "UPSERT or INSERT...ON CONFLICT command cannot affect row a second time"
       │    │    ├── lax-key: (6)
       │    │    ├── fd: (6)~~>(7)
-      │    │    ├── ordering: +6
       │    │    ├── scan abcd@partial_ab,partial
       │    │    │    ├── columns: a:6 b:7 rowid:10!null
       │    │    │    ├── key: (10)

--- a/pkg/sql/opt/xform/testdata/rules/groupby
+++ b/pkg/sql/opt/xform/testdata/rules/groupby
@@ -1892,7 +1892,7 @@ memo (optimized, ~15KB, required=[presentation: array_agg:7])
 memo
 SELECT sum(k) FROM (SELECT * FROM kuvw WHERE u=v) GROUP BY u,w
 ----
-memo (optimized, ~15KB, required=[presentation: sum:7])
+memo (optimized, ~16KB, required=[presentation: sum:7])
  ├── G1: (project G2 G3 sum)
  │    └── [presentation: sum:7]
  │         ├── best: (project G2 G3 sum)
@@ -1995,7 +1995,7 @@ memo (optimized, ~9KB, required=[presentation: array_agg:7])
 memo
 SELECT DISTINCT u, v, w FROM kuvw
 ----
-memo (optimized, ~6KB, required=[presentation: u:2,v:3,w:4])
+memo (optimized, ~7KB, required=[presentation: u:2,v:3,w:4])
  ├── G1: (distinct-on G2 G3 cols=(2-4)) (distinct-on G2 G3 cols=(2-4),ordering=+2,+3,+4) (distinct-on G2 G3 cols=(2-4),ordering=+4,+3,+2) (distinct-on G2 G3 cols=(2-4),ordering=+3,+4)
  │    └── [presentation: u:2,v:3,w:4]
  │         ├── best: (distinct-on G2="[ordering: +2,+3,+4]" G3 cols=(2-4),ordering=+2,+3,+4)

--- a/pkg/sql/opt/xform/testdata/rules/insert
+++ b/pkg/sql/opt/xform/testdata/rules/insert
@@ -128,6 +128,7 @@ insert t
  │    │                   │    │    │    ├── constraint: /14
  │    │                   │    │    │    │    ├── [ - /1]
  │    │                   │    │    │    │    └── [/3 - ]
+ │    │                   │    │    │    ├── flags: avoid-full-scan
  │    │                   │    │    │    ├── key: (14)
  │    │                   │    │    │    ├── fd: (14)-->(16)
  │    │                   │    │    │    └── limit hint: 35.71
@@ -166,6 +167,7 @@ insert t
  │                        │    │    ├── [/'west'/20 - /'west'/20/1]
  │                        │    │    └── [/'west'/20/3 - /'west'/20]
  │                        │    ├── limit: 1
+ │                        │    ├── flags: avoid-full-scan
  │                        │    ├── key: ()
  │                        │    └── fd: ()-->(33,37)
  │                        └── filters (true)
@@ -182,6 +184,7 @@ insert t
       │         │    ├── computed column expressions
       │         │    │    └── t.b:29
       │         │    │         └── t.k:26 % 9
+      │         │    ├── flags: avoid-full-scan
       │         │    ├── key: (26)
       │         │    └── fd: (26)-->(27-30)
       │         └── filters
@@ -196,6 +199,7 @@ insert t
                      ├── constraint: /46/49/45
                      │    ├── [/'east'/20 - /'east'/20]
                      │    └── [/'west'/20 - /'west'/20]
+                     ├── flags: avoid-full-scan
                      ├── key: (45)
                      └── fd: ()-->(49), (45)-->(46)
 
@@ -270,6 +274,7 @@ insert t
  │    │                   │    │    ├── [/1/10 - /1/10/1]
  │    │                   │    │    └── [/1/10/3 - /1/10]
  │    │                   │    ├── limit: 1
+ │    │                   │    ├── flags: avoid-full-scan
  │    │                   │    ├── key: ()
  │    │                   │    └── fd: ()-->(14,16)
  │    │                   └── filters (true)
@@ -304,6 +309,7 @@ insert t
  │                        │    │    ├── [/'west'/20 - /'west'/20/1]
  │                        │    │    └── [/'west'/20/3 - /'west'/20]
  │                        │    ├── limit: 1
+ │                        │    ├── flags: avoid-full-scan
  │                        │    ├── key: ()
  │                        │    └── fd: ()-->(33,37)
  │                        └── filters (true)
@@ -316,6 +322,7 @@ insert t
       │         └── scan t@t_b_a_idx
       │              ├── columns: t.k:26!null t.a:28!null t.b:29!null
       │              ├── constraint: /29/28/26: [/1/10 - /1/10]
+      │              ├── flags: avoid-full-scan
       │              ├── key: (26)
       │              └── fd: ()-->(28,29)
       └── fast-path-unique-checks-item: t(c)
@@ -328,6 +335,7 @@ insert t
                      ├── constraint: /46/49/45
                      │    ├── [/'east'/20 - /'east'/20]
                      │    └── [/'west'/20 - /'west'/20]
+                     ├── flags: avoid-full-scan
                      ├── key: (45)
                      └── fd: ()-->(49), (45)-->(46)
 
@@ -403,6 +411,7 @@ insert t
  │    │                   │    │    ├── [/10 - /10/1]
  │    │                   │    │    └── [/10/3 - /10]
  │    │                   │    ├── limit: 1
+ │    │                   │    ├── flags: avoid-full-scan
  │    │                   │    ├── key: ()
  │    │                   │    └── fd: ()-->(12,14)
  │    │                   └── filters (true)
@@ -442,6 +451,7 @@ insert t
  │    │                   │    │    ├── scan t@t_b_a_idx
  │    │                   │    │    │    ├── columns: t.k:28!null t.b:31!null
  │    │                   │    │    │    ├── constraint: /31/30/28: [/2 - /2]
+ │    │                   │    │    │    ├── flags: avoid-full-scan
  │    │                   │    │    │    ├── key: (28)
  │    │                   │    │    │    ├── fd: ()-->(31)
  │    │                   │    │    │    └── limit hint: 1.07
@@ -478,6 +488,7 @@ insert t
  │    │                   │    │    ├── [/'east'/10/2 - /'east'/10/2/1]
  │    │                   │    │    └── [/'east'/10/2/3 - /'east'/10/2]
  │    │                   │    ├── limit: 1
+ │    │                   │    ├── flags: avoid-full-scan
  │    │                   │    ├── key: ()
  │    │                   │    └── fd: ()-->(44-47)
  │    │                   └── filters (true)
@@ -510,6 +521,7 @@ insert t
  │                        │    │    ├── [/2/10 - /2/10/1]
  │                        │    │    └── [/2/10/3 - /2/10]
  │                        │    ├── limit: 1
+ │                        │    ├── flags: avoid-full-scan
  │                        │    ├── key: ()
  │                        │    └── fd: ()-->(60,62,63)
  │                        └── filters (true)
@@ -520,6 +532,7 @@ insert t
       │         ├── constraint: /23/24/25/22
       │         │    ├── [/'east'/10 - /'east'/10]
       │         │    └── [/'west'/10 - /'west'/10]
+      │         ├── flags: avoid-full-scan
       │         ├── key: (22)
       │         └── fd: ()-->(24), (22)-->(23,25)
       ├── fast-path-unique-checks-item: t(b)
@@ -530,12 +543,14 @@ insert t
       │         └── scan t@t_b_a_idx
       │              ├── columns: t.k:38!null t.a:40 t.b:41!null
       │              ├── constraint: /41/40/38: [/2 - /2]
+      │              ├── flags: avoid-full-scan
       │              ├── key: (38)
       │              └── fd: ()-->(41), (38)-->(40)
       ├── fast-path-unique-checks-item: t(r,a,b)
       │    └── scan t@t_r_a_b_idx
       │         ├── columns: t.k:54!null t.r:55!null t.a:56!null t.b:57!null
       │         ├── constraint: /55/56/57/54: [/'east'/10/2 - /'east'/10/2]
+      │         ├── flags: avoid-full-scan
       │         ├── key: (54)
       │         └── fd: ()-->(55-57)
       └── fast-path-unique-checks-item: t(a,b)
@@ -544,5 +559,6 @@ insert t
                 ├── constraint: /71/72/73/70
                 │    ├── [/'east'/10/2 - /'east'/10/2]
                 │    └── [/'west'/10/2 - /'west'/10/2]
+                ├── flags: avoid-full-scan
                 ├── key: (70)
                 └── fd: ()-->(72,73), (70)-->(71)

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -1249,7 +1249,7 @@ New expression 2 of 2:
 memo expect=ReorderJoins
 SELECT * FROM abc JOIN xyz ON a=z
 ----
-memo (optimized, ~13KB, required=[presentation: a:1,b:2,c:3,x:7,y:8,z:9])
+memo (optimized, ~14KB, required=[presentation: a:1,b:2,c:3,x:7,y:8,z:9])
  ├── G1: (inner-join G2 G3 G4) (inner-join G3 G2 G4) (merge-join G2 G3 G5 inner-join,+1,+9) (lookup-join G3 G5 abc@ab,keyCols=[9],outCols=(1-3,7-9))
  │    └── [presentation: a:1,b:2,c:3,x:7,y:8,z:9]
  │         ├── best: (inner-join G2 G3 G4)
@@ -1493,7 +1493,7 @@ right-join (hash)
 memo
 SELECT * FROM abc RIGHT OUTER JOIN xyz ON a=z
 ----
-memo (optimized, ~13KB, required=[presentation: a:1,b:2,c:3,x:7,y:8,z:9])
+memo (optimized, ~14KB, required=[presentation: a:1,b:2,c:3,x:7,y:8,z:9])
  ├── G1: (left-join G2 G3 G4) (right-join G3 G2 G4) (lookup-join G2 G5 abc@ab,keyCols=[9],outCols=(1-3,7-9)) (merge-join G3 G2 G5 right-join,+1,+9)
  │    └── [presentation: a:1,b:2,c:3,x:7,y:8,z:9]
  │         ├── best: (left-join G2 G3 G4)
@@ -1823,7 +1823,7 @@ inner-join (merge)
 memo
 SELECT * FROM abc JOIN xyz ON a=x
 ----
-memo (optimized, ~15KB, required=[presentation: a:1,b:2,c:3,x:7,y:8,z:9])
+memo (optimized, ~16KB, required=[presentation: a:1,b:2,c:3,x:7,y:8,z:9])
  ├── G1: (inner-join G2 G3 G4) (inner-join G3 G2 G4) (merge-join G2 G3 G5 inner-join,+1,+7) (lookup-join G2 G5 xyz@xy,keyCols=[1],outCols=(1-3,7-9)) (merge-join G3 G2 G5 inner-join,+7,+1) (lookup-join G3 G5 abc@ab,keyCols=[7],outCols=(1-3,7-9))
  │    └── [presentation: a:1,b:2,c:3,x:7,y:8,z:9]
  │         ├── best: (merge-join G3="[ordering: +7]" G2="[ordering: +1]" G5 inner-join,+7,+1)
@@ -1874,7 +1874,7 @@ memo (optimized, ~11KB, required=[presentation: a:1,b:2,c:3,x:7,y:8,z:9])
 memo set=(optimizer_merge_joins_enabled=false) expect-not=GenerateMergeJoins
 SELECT * FROM abc JOIN xyz ON a=x
 ----
-memo (optimized, ~14KB, required=[presentation: a:1,b:2,c:3,x:7,y:8,z:9])
+memo (optimized, ~15KB, required=[presentation: a:1,b:2,c:3,x:7,y:8,z:9])
  ├── G1: (inner-join G2 G3 G4) (inner-join G3 G2 G4) (lookup-join G2 G5 xyz@xy,keyCols=[1],outCols=(1-3,7-9)) (lookup-join G3 G5 abc@ab,keyCols=[7],outCols=(1-3,7-9))
  │    └── [presentation: a:1,b:2,c:3,x:7,y:8,z:9]
  │         ├── best: (inner-join G3 G2 G4)

--- a/pkg/sql/opt/xform/testdata/rules/limit
+++ b/pkg/sql/opt/xform/testdata/rules/limit
@@ -2749,23 +2749,34 @@ update t82730a
  │    └── col1_5:10 => col1_5:4
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
- └── top-k
+ └── index-join t82730a
       ├── columns: col1_0:7!null col1_1:8 col1_3:9 col1_5:10
-      ├── internal-ordering: +9
-      ├── k: 84
       ├── cardinality: [0 - 84]
       ├── key: (7)
       ├── fd: (7)-->(8-10), (8,9)~~>(7,10)
-      └── select
-           ├── columns: col1_0:7!null col1_1:8 col1_3:9 col1_5:10
+      └── top-k
+           ├── columns: col1_0:7!null col1_1:8 col1_3:9
+           ├── internal-ordering: +9
+           ├── k: 84
+           ├── cardinality: [0 - 84]
            ├── key: (7)
-           ├── fd: (7)-->(8-10), (8,9)~~>(7,10)
-           ├── scan t82730a
-           │    ├── columns: col1_0:7!null col1_1:8 col1_3:9 col1_5:10
-           │    ├── key: (7)
-           │    └── fd: (7)-->(8-10), (8,9)~~>(7,10)
-           └── filters
-                └── col1_0:7 ILIKE col1_0:7 [outer=(7), constraints=(/7: (/NULL - ])]
+           ├── fd: (7)-->(8,9), (8,9)~~>(7)
+           └── select
+                ├── columns: col1_0:7!null col1_1:8 col1_3:9
+                ├── key: (7)
+                ├── fd: (7)-->(8,9), (8,9)~~>(7)
+                ├── scan t82730a@t82730a_col1_1_col1_3_key
+                │    ├── columns: col1_0:7!null col1_1:8 col1_3:9
+                │    ├── constraint: /8/9
+                │    │    ├── [/NULL - /0]
+                │    │    ├── [/2 - /999999999]
+                │    │    ├── [/1000000001 - /1999999999]
+                │    │    └── [/2000000001 - ]
+                │    ├── flags: avoid-full-scan
+                │    ├── key: (7)
+                │    └── fd: (7)-->(8,9), (8,9)~~>(7)
+                └── filters
+                     └── col1_0:7 ILIKE col1_0:7 [outer=(7), constraints=(/7: (/NULL - ])]
 
 exec-ddl
 CREATE TABLE t82730b (
@@ -2812,23 +2823,34 @@ update t82730b [as=tab_41831]
  │    └── col1_5:10 => col1_5:4
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
- └── top-k
+ └── index-join t82730b
       ├── columns: col1_0:7!null col1_1:8 col1_3:9 col1_5:10
-      ├── internal-ordering: +9
-      ├── k: 84
       ├── cardinality: [0 - 84]
       ├── key: (7)
       ├── fd: (7)-->(8-10), (8,9)~~>(7,10)
-      └── select
-           ├── columns: col1_0:7!null col1_1:8 col1_3:9 col1_5:10
+      └── top-k
+           ├── columns: col1_0:7!null col1_1:8 col1_3:9
+           ├── internal-ordering: +9
+           ├── k: 84
+           ├── cardinality: [0 - 84]
            ├── key: (7)
-           ├── fd: (7)-->(8-10), (8,9)~~>(7,10)
-           ├── scan t82730b [as=tab_41831]
-           │    ├── columns: col1_0:7!null col1_1:8 col1_3:9 col1_5:10
-           │    ├── key: (7)
-           │    └── fd: (7)-->(8-10), (8,9)~~>(7,10)
-           └── filters
-                └── col1_0:7 ILIKE col1_0:7 [outer=(7), constraints=(/7: (/NULL - ])]
+           ├── fd: (7)-->(8,9), (8,9)~~>(7)
+           └── select
+                ├── columns: col1_0:7!null col1_1:8 col1_3:9
+                ├── key: (7)
+                ├── fd: (7)-->(8,9), (8,9)~~>(7)
+                ├── scan t82730b@t82730b_col1_1_col1_3_key [as=tab_41831]
+                │    ├── columns: col1_0:7!null col1_1:8 col1_3:9
+                │    ├── constraint: /8/9
+                │    │    ├── [/NULL - /0]
+                │    │    ├── [/2 - /4]
+                │    │    ├── [/6 - /4999999]
+                │    │    └── [/5000001 - ]
+                │    ├── flags: avoid-full-scan
+                │    ├── key: (7)
+                │    └── fd: (7)-->(8,9), (8,9)~~>(7)
+                └── filters
+                     └── col1_0:7 ILIKE col1_0:7 [outer=(7), constraints=(/7: (/NULL - ])]
 
 # Regression test for #88993. Do not construct an unordered limit below the
 # UnionAll.

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -281,7 +281,7 @@ CREATE INDEX idx2 ON p (s) WHERE i > 0
 memo expect=GeneratePartialIndexScans
 SELECT * FROM p WHERE i > 0 AND s = 'foo'
 ----
-memo (optimized, ~18KB, required=[presentation: k:1,i:2,f:3,s:4,b:5])
+memo (optimized, ~19KB, required=[presentation: k:1,i:2,f:3,s:4,b:5])
  ├── G1: (select G2 G3) (index-join G4 p,cols=(1-5)) (index-join G5 p,cols=(1-5)) (index-join G6 p,cols=(1-5)) (index-join G7 p,cols=(1-5))
  │    └── [presentation: k:1,i:2,f:3,s:4,b:5]
  │         ├── best: (index-join G4 p,cols=(1-5))

--- a/pkg/sql/opt/xform/testdata/rules/set
+++ b/pkg/sql/opt/xform/testdata/rules/set
@@ -21,7 +21,7 @@ CREATE TABLE kuvw (
 memo expect=GenerateStreamingSetOp
 SELECT u,v,w FROM kuvw UNION SELECT w,v,u FROM kuvw
 ----
-memo (optimized, ~11KB, required=[presentation: u:13,v:14,w:15])
+memo (optimized, ~12KB, required=[presentation: u:13,v:14,w:15])
  ├── G1: (union G2 G3) (union G2 G3 ordering=+13,+14,+15) (union G2 G3 ordering=+15,+14,+13) (union G2 G3 ordering=+14,+15,+13) (union G2 G3 ordering=+14,+13,+15)
  │    └── [presentation: u:13,v:14,w:15]
  │         ├── best: (union G2="[ordering: +2,+3,+4]" G3="[ordering: +10,+9,+8]" ordering=+13,+14,+15)

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -958,7 +958,7 @@ func (u *sqlSymUnion) triggerForEach() tree.TriggerForEach {
 // Ordinary key words in alphabetical order.
 %token <str> ABORT ABSOLUTE ACCESS ACTION ADD ADMIN AFTER AGGREGATE
 %token <str> ALL ALTER ALWAYS ANALYSE ANALYZE AND AND_AND ANY ANNOTATE_TYPE ARRAY AS ASC AS_JSON AT_AT
-%token <str> ASENSITIVE ASYMMETRIC AT ATOMIC ATTRIBUTE AUTHORIZATION AUTOMATIC AVAILABILITY
+%token <str> ASENSITIVE ASYMMETRIC AT ATOMIC ATTRIBUTE AUTHORIZATION AUTOMATIC AVAILABILITY AVOID_FULL_SCAN
 
 %token <str> BACKUP BACKUPS BACKWARD BATCH BEFORE BEGIN BETWEEN BIGINT BIGSERIAL BINARY BIT
 %token <str> BUCKET_COUNT
@@ -14248,6 +14248,10 @@ index_flags_param:
   {
     $$.val = &tree.IndexFlags{NoFullScan: true}
   }
+| AVOID_FULL_SCAN
+  {
+    $$.val = &tree.IndexFlags{AvoidFullScan: true}
+  }
 | IGNORE_FOREIGN_KEYS
   {
     /* SKIP DOC */
@@ -14337,6 +14341,7 @@ opt_index_flags:
 //   '{' NO_INDEX_JOIN [, ...] '}'
 //   '{' NO_ZIGZAG_JOIN [, ...] '}'
 //   '{' NO_FULL_SCAN [, ...] '}'
+//   '{' AVOID_FULL_SCAN [, ...] '}'
 //   '{' IGNORE_FOREIGN_KEYS [, ...] '}'
 //   '{' FORCE_ZIGZAG = <idxname> [, ...]  '}'
 //
@@ -17819,6 +17824,7 @@ unreserved_keyword:
 | ATTRIBUTE
 | AUTOMATIC
 | AVAILABILITY
+| AVOID_FULL_SCAN
 | BACKUP
 | BACKUPS
 | BACKWARD
@@ -18320,6 +18326,7 @@ bare_label_keywords:
 | AUTHORIZATION
 | AUTOMATIC
 | AVAILABILITY
+| AVOID_FULL_SCAN
 | BACKUP
 | BACKUPS
 | BACKWARD

--- a/pkg/sql/parser/testdata/hints
+++ b/pkg/sql/parser/testdata/hints
@@ -47,6 +47,14 @@ SELECT '_' FROM t@{NO_FULL_SCAN} -- literals removed
 SELECT 'a' FROM _@{NO_FULL_SCAN} -- identifiers removed
 
 parse
+SELECT 'a' FROM t@{AVOID_FULL_SCAN}
+----
+SELECT 'a' FROM t@{AVOID_FULL_SCAN}
+SELECT ('a') FROM t@{AVOID_FULL_SCAN} -- fully parenthesized
+SELECT '_' FROM t@{AVOID_FULL_SCAN} -- literals removed
+SELECT 'a' FROM _@{AVOID_FULL_SCAN} -- identifiers removed
+
+parse
 SELECT 'a' FROM t@{IGNORE_FOREIGN_KEYS}
 ----
 SELECT 'a' FROM t@{IGNORE_FOREIGN_KEYS}

--- a/pkg/sql/sessiondatapb/local_only_session_data.proto
+++ b/pkg/sql/sessiondatapb/local_only_session_data.proto
@@ -101,6 +101,9 @@ message LocalOnlySessionData {
   // DisallowFullTableScans indicates whether queries that plan full table scans
   // should be rejected.
   bool disallow_full_table_scans = 26;
+  // AvoidFullTableScansInMutations indicates whether mutation queries that plan
+  // full table scans should be avoided.
+  bool avoid_full_table_scans_in_mutations = 150;
   // ImplicitSelectForUpdate is true if FOR UPDATE locking may be used during
   // the row-fetch phase of mutation statements.
   bool implicit_select_for_update = 27;

--- a/pkg/sql/telemetry_logging_test.go
+++ b/pkg/sql/telemetry_logging_test.go
@@ -488,7 +488,7 @@ func TestTelemetryLogging(t *testing.T) {
 
 					logCount++
 
-					costRe := regexp.MustCompile("\"CostEstimate\":[0-9]*\\.[0-9]*")
+					costRe := regexp.MustCompile("\"CostEstimate\":[0-9]*\\.?[0-9]*")
 					if !costRe.MatchString(e.Message) {
 						t.Errorf("expected to find CostEstimate but none was found")
 					}

--- a/pkg/sql/ttl/ttljob/testdata/ttljob_plans
+++ b/pkg/sql/ttl/ttljob/testdata/ttljob_plans
@@ -108,23 +108,14 @@ check-plan builder=delete table=p overrides=ReorderJoinsLimit=0
     └── • delete
         │ from: c
         │
-        └── • merge join
+        └── • hash join (semi)
             │ equality: (p_id) = (id)
-            │ right cols are key
             │
             ├── • scan
             │     missing stats
-            │     table: c@c_p_id_idx
+            │     table: c@c_pkey
             │     spans: FULL SCAN
             │
-            └── • sort
-                │ estimated row count: 10
-                │ order: +id
-                │
-                └── • distinct
-                    │ estimated row count: 10
-                    │ distinct on: id
-                    │
-                    └── • scan buffer
-                          estimated row count: 100
-                          label: buffer 1000000
+            └── • scan buffer
+                  estimated row count: 100
+                  label: buffer 1000000

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -1970,6 +1970,23 @@ var varGen = map[string]sessionVar{
 	},
 
 	// CockroachDB extension.
+	`avoid_full_table_scans_in_mutations`: {
+		GetStringVal: makePostgresBoolGetStringValFn(`avoid_full_table_scans_in_mutations`),
+		Set: func(_ context.Context, m sessionDataMutator, s string) error {
+			b, err := paramparse.ParseBoolVar(`avoid_full_table_scans_in_mutations`, s)
+			if err != nil {
+				return err
+			}
+			m.SetAvoidFullTableScansInMutations(b)
+			return nil
+		},
+		Get: func(evalCtx *extendedEvalContext, _ *kv.Txn) (string, error) {
+			return formatBoolAsPostgresSetting(evalCtx.SessionData().AvoidFullTableScansInMutations), nil
+		},
+		GlobalDefault: globalTrue,
+	},
+
+	// CockroachDB extension.
 	`enable_experimental_alter_column_type_general`: {
 		GetStringVal: makePostgresBoolGetStringValFn(`enable_experimental_alter_column_type_general`),
 		Set: func(_ context.Context, m sessionDataMutator, s string) error {


### PR DESCRIPTION
**opt,sql: support hint to avoid full scan**

Informs https://github.com/cockroachdb/cockroach/issues/79683

Release note (sql change): Added support for a new index hint,
`AVOID_FULL_SCAN`, which will prevent the optimizer from planning a
full scan for the specified table if any other plan is possible. The
hint can be used in the same way as other existing index hints. For
example, `SELECT * FROM table_name@{AVOID_FULL_SCAN};`. Note that a
full scan of a partial index may still be preferred by the optimizer,
unless `AVOID_FULL_SCAN` is used in combination with a specific partial
index via `FORCE_INDEX=index_name`. This hint is similar to `NO_FULL_SCAN`,
but will not error if a full scan cannot be avoided.

**sql,opt: add setting avoid_full_table_scans_in_mutations**

Fixes https://github.com/cockroachdb/cockroach/issues/79683

Release note (sql change): Added a new session setting
`avoid_full_table_scans_in_mutations`, which when set to true, causes
the optimizer to avoid planning full table scans for mutation queries
if any other plan is possible. It now defaults to true.

**opt: remove a stale comment above optbuilder.buildScan**

Removed a comment that references a function parameter that no longer
exists.

Release note: None