### PR TITLE
crosscluster: skip ldr and pcr e2e tests under deadlock

### DIFF
--- a/pkg/backup/backup_test.go
+++ b/pkg/backup/backup_test.go
@@ -1529,6 +1529,7 @@ func TestRestoreRetryProcErr(t *testing.T) {
 func TestRestoreReplanOnLag(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+	skip.WithIssue(t, 137098, "move logic to roachtest")
 
 	skip.UnderRace(t, "slow test under stress race")
 

--- a/pkg/crosscluster/logical/logical_replication_job_test.go
+++ b/pkg/crosscluster/logical/logical_replication_job_test.go
@@ -1358,6 +1358,9 @@ func setupServerWithNumDBs(
 	[]*sqlutils.SQLRunner,
 	[]string,
 ) {
+	// Deadlock increases test runtime by 10 to 100x.
+	skip.UnderDeadlock(t)
+
 	server := testcluster.StartTestCluster(t, numNodes, clusterArgs)
 	s := server.Server(0).ApplicationLayer()
 

--- a/pkg/crosscluster/replicationtestutils/testutils.go
+++ b/pkg/crosscluster/replicationtestutils/testutils.go
@@ -447,6 +447,9 @@ func CreateMultiTenantStreamingCluster(
 	ctx context.Context, t *testing.T, args TenantStreamingClustersArgs,
 ) (*TenantStreamingClusters, func()) {
 
+	// Deadlock tool slows these tests down by 10 to 100x.
+	skip.UnderDeadlock(t)
+
 	serverArgs := CreateServerArgs(args)
 	cluster, url, cleanup := startC2CTestCluster(ctx, t, serverArgs,
 		args.MultitenantSingleClusterNumNodes, args.MultiTenantSingleClusterTestRegions)


### PR DESCRIPTION
see individual commits

Epic: none

Release note: none