### PR TITLE
dev: remove `--strip=never` configuration from `.bazelrc.user`

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -45,7 +45,6 @@ build --define gotags=bazel,gss
 build --experimental_proto_descriptor_sets_include_source_info
 build --incompatible_strict_action_env --incompatible_enable_cc_toolchain_resolution
 build --symlink_prefix=_bazel/
-build --strip=never
 common --experimental_allow_tags_propagation
 test --config=test --experimental_ui_max_stdouterr_bytes=10485760
 build --ui_event_filters=-DEBUG


### PR DESCRIPTION
Previously we unconditionally disabled stripping; however, this has a negative impact on performance (linking gets much more expensive when you do not strip). This is a cost we paid both locally in the development cycle as well as in CI.

Removing this line from `.bazelrc` restores the default behavior of stripping iff the `compilation_mode` is `fastbuild` (which is the default). This will give developers the desired quick iteration behavior. You now have to opt into disabling stripping.

Going forward we may evaluate if it is worth it to disable stripping for unit tests in CI to enable the use of `side-eye` (#136839). Until that point, there is no reason to disable stripping in this context.

Stripping can be enabled with `--strip=always` or by passing `-c dbg` or `-c opt`. Notably, `dev build --cross`, the release process, and the `roachtest` nightlies all currently use `-c opt` when building, so there is nothing else to be done in these cases: they are all correctly not stripping.

Epic: CRDB-17171
Release note: None