### PR TITLE
sql/row: use Put instead of CPut when updating value of secondary index

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning_implicit_read_committed
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning_implicit_read_committed
@@ -446,7 +446,7 @@ CPut /Table/110/1/"@"/1/0 -> nil (tombstone)
 CPut /Table/110/1/"\x80"/1/0 -> nil (tombstone)
 CPut /Table/110/1/"\xc0"/1/0 -> nil (tombstone)
 CPut /Table/110/2/"\xa0"/6/0 -> /BYTES/0x89
-CPut /Table/110/2/"\xa0"/4/0 -> /BYTES/0x8a (expecting does not exist)
+CPut /Table/110/2/"\xa0"/4/0 -> /BYTES/0x8a
 CPut /Table/110/2/" "/4/0 -> nil (tombstone)
 CPut /Table/110/2/"@"/4/0 -> nil (tombstone)
 CPut /Table/110/2/"\x80"/4/0 -> nil (tombstone)

--- a/pkg/sql/catalog/bootstrap/kv_writer.go
+++ b/pkg/sql/catalog/bootstrap/kv_writer.go
@@ -97,7 +97,7 @@ func (w KVWriter) Insert(
 		if kvTrace {
 			log.VEventf(ctx, 2, "CPut %s -> %s", kv.Key, kv.Value)
 		}
-		b.CPutAllowingIfNotExists(kv.Key, &kv.Value, nil /* expValue */)
+		b.CPut(kv.Key, &kv.Value, nil /* expValue */)
 	}
 	return nil
 }

--- a/pkg/sql/opt/exec/execbuilder/testdata/cascade
+++ b/pkg/sql/opt/exec/execbuilder/testdata/cascade
@@ -175,10 +175,10 @@ Del /Table/112/1/"updated"/0
 CPut /Table/112/1/"updated2"/0 -> /TUPLE/
 executing cascade for constraint b1_update_cascade_fkey
 Del /Table/113/2/"updated"/0
-CPut /Table/113/2/"updated2"/0 -> /BYTES/0x1262312d706b310001 (expecting does not exist)
+CPut /Table/113/2/"updated2"/0 -> /BYTES/0x1262312d706b310001
 executing cascade for constraint b2_update_cascade_fkey
 Del /Table/114/2/"updated"/0
-CPut /Table/114/2/"updated2"/0 -> /BYTES/0x1262322d706b310001 (expecting does not exist)
+CPut /Table/114/2/"updated2"/0 -> /BYTES/0x1262322d706b310001
 executing cascade for constraint c1_update_cascade_fkey
 executing cascade for constraint c2_update_cascade_fkey
 executing cascade for constraint c3_id_fkey
@@ -463,10 +463,10 @@ Del /Table/134/1/"original"/0
 CPut /Table/134/1/"updated"/0 -> /TUPLE/
 executing cascade for constraint b1_update_cascade_fkey
 Del /Table/135/2/"original"/0
-CPut /Table/135/2/"updated"/0 -> /BYTES/0x1262312d706b310001 (expecting does not exist)
+CPut /Table/135/2/"updated"/0 -> /BYTES/0x1262312d706b310001
 executing cascade for constraint b2_update_cascade_fkey
 Del /Table/136/2/"original"/0
-CPut /Table/136/2/"updated"/0 -> /BYTES/0x1262322d706b310001 (expecting does not exist)
+CPut /Table/136/2/"updated"/0 -> /BYTES/0x1262322d706b310001
 executing cascade for constraint c1_update_set_null_fkey
 executing cascade for constraint c2_update_set_null_fkey
 executing cascade for constraint c3_update_set_null_fkey
@@ -751,10 +751,10 @@ Del /Table/156/1/"original"/0
 CPut /Table/156/1/"updated"/0 -> /TUPLE/
 executing cascade for constraint b1_update_cascade_fkey
 Del /Table/157/2/"original"/0
-CPut /Table/157/2/"updated"/0 -> /BYTES/0x1262312d706b310001 (expecting does not exist)
+CPut /Table/157/2/"updated"/0 -> /BYTES/0x1262312d706b310001
 executing cascade for constraint b2_update_cascade_fkey
 Del /Table/158/2/"original"/0
-CPut /Table/158/2/"updated"/0 -> /BYTES/0x1262322d706b310001 (expecting does not exist)
+CPut /Table/158/2/"updated"/0 -> /BYTES/0x1262322d706b310001
 executing cascade for constraint c1_update_set_null_fkey
 executing cascade for constraint c2_update_set_null_fkey
 executing cascade for constraint c3_update_set_null_fkey

--- a/pkg/sql/opt/exec/execbuilder/testdata/partial_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/partial_index
@@ -343,8 +343,8 @@ UPDATE t SET b = 11 WHERE a = 5
 Scan /Table/112/1/5/0 lock Exclusive (Block, Unreplicated)
 Put /Table/112/1/5/0 -> /TUPLE/2:2:Int/11/1:3:Bytes/baz
 Del /Table/112/2/4/5/0
-CPut /Table/112/2/11/5/0 -> /BYTES/ (expecting does not exist)
-CPut /Table/112/3/11/5/0 -> /BYTES/ (expecting does not exist)
+CPut /Table/112/2/11/5/0 -> /BYTES/
+CPut /Table/112/3/11/5/0 -> /BYTES/
 
 # Update a row that matches the first partial index before and after the update
 # and the index entry does not change.
@@ -362,9 +362,9 @@ UPDATE t SET b = 12 WHERE a = 6
 Scan /Table/112/1/6/0 lock Exclusive (Block, Unreplicated)
 Put /Table/112/1/6/0 -> /TUPLE/2:2:Int/12/1:3:Bytes/baz
 Del /Table/112/2/11/6/0
-CPut /Table/112/2/12/6/0 -> /BYTES/ (expecting does not exist)
+CPut /Table/112/2/12/6/0 -> /BYTES/
 Del /Table/112/3/11/6/0
-CPut /Table/112/3/12/6/0 -> /BYTES/ (expecting does not exist)
+CPut /Table/112/3/12/6/0 -> /BYTES/
 
 # Update a row that matches the first partial index before the update, but does
 # not match after the update.
@@ -374,7 +374,7 @@ UPDATE t SET b = 9 WHERE a = 6
 Scan /Table/112/1/6/0 lock Exclusive (Block, Unreplicated)
 Put /Table/112/1/6/0 -> /TUPLE/2:2:Int/9/1:3:Bytes/baz
 Del /Table/112/2/12/6/0
-CPut /Table/112/2/9/6/0 -> /BYTES/ (expecting does not exist)
+CPut /Table/112/2/9/6/0 -> /BYTES/
 Del /Table/112/3/12/6/0
 
 # Update a row that matches both partial indexes before the update, the first
@@ -385,9 +385,9 @@ UPDATE t SET c = 'baz', b = 12 WHERE a = 13
 Scan /Table/112/1/13/0 lock Exclusive (Block, Unreplicated)
 Put /Table/112/1/13/0 -> /TUPLE/2:2:Int/12/1:3:Bytes/baz
 Del /Table/112/2/11/13/0
-CPut /Table/112/2/12/13/0 -> /BYTES/ (expecting does not exist)
+CPut /Table/112/2/12/13/0 -> /BYTES/
 Del /Table/112/3/11/13/0
-CPut /Table/112/3/12/13/0 -> /BYTES/ (expecting does not exist)
+CPut /Table/112/3/12/13/0 -> /BYTES/
 Del /Table/112/4/"foo"/13/0
 
 # Reversing the previous update should reverse the partial index changes.
@@ -397,10 +397,10 @@ UPDATE t SET c = 'foo', b = 11 WHERE a = 13
 Scan /Table/112/1/13/0 lock Exclusive (Block, Unreplicated)
 Put /Table/112/1/13/0 -> /TUPLE/2:2:Int/11/1:3:Bytes/foo
 Del /Table/112/2/12/13/0
-CPut /Table/112/2/11/13/0 -> /BYTES/ (expecting does not exist)
+CPut /Table/112/2/11/13/0 -> /BYTES/
 Del /Table/112/3/12/13/0
-CPut /Table/112/3/11/13/0 -> /BYTES/ (expecting does not exist)
-CPut /Table/112/4/"foo"/13/0 -> /BYTES/ (expecting does not exist)
+CPut /Table/112/3/11/13/0 -> /BYTES/
+CPut /Table/112/4/"foo"/13/0 -> /BYTES/
 
 # Update a row to match a partial index that does not index the column
 # referenced in predicate.
@@ -412,7 +412,7 @@ UPDATE u SET v = 11 WHERE k = 1
 ----
 Scan /Table/113/1/1/0 lock Exclusive (Block, Unreplicated)
 Put /Table/113/1/1/0 -> /TUPLE/2:2:Int/2/1:3:Int/11
-CPut /Table/113/2/2/1/0 -> /BYTES/ (expecting does not exist)
+CPut /Table/113/2/2/1/0 -> /BYTES/
 
 # Update a row to no longer match a partial index that does not index the column
 # referenced in predicate.
@@ -572,7 +572,7 @@ INSERT INTO t VALUES (5, 3, 'foo') ON CONFLICT (a) DO UPDATE SET b = 3
 Scan /Table/112/1/5/0 lock Exclusive (Block, Unreplicated)
 Put /Table/112/1/5/0 -> /TUPLE/2:2:Int/3/1:3:Bytes/bar
 Del /Table/112/2/4/5/0
-CPut /Table/112/2/3/5/0 -> /BYTES/ (expecting does not exist)
+CPut /Table/112/2/3/5/0 -> /BYTES/
 
 # Insert a conflicting row that does not match the first partial index
 # before the update, but does match after the update.
@@ -582,8 +582,8 @@ INSERT INTO t VALUES (5, 7, 'foo') ON CONFLICT (a) DO UPDATE SET b = 11
 Scan /Table/112/1/5/0 lock Exclusive (Block, Unreplicated)
 Put /Table/112/1/5/0 -> /TUPLE/2:2:Int/11/1:3:Bytes/bar
 Del /Table/112/2/3/5/0
-CPut /Table/112/2/11/5/0 -> /BYTES/ (expecting does not exist)
-CPut /Table/112/3/11/5/0 -> /BYTES/ (expecting does not exist)
+CPut /Table/112/2/11/5/0 -> /BYTES/
+CPut /Table/112/3/11/5/0 -> /BYTES/
 
 # Insert a conflicting row that currently matches the first partial index before
 # the update. Update the row so that the row no longer matches the first partial
@@ -594,9 +594,9 @@ INSERT INTO t VALUES (5, 11, 'bar') ON CONFLICT (a) DO UPDATE SET b = 4, c = 'fo
 Scan /Table/112/1/5/0 lock Exclusive (Block, Unreplicated)
 Put /Table/112/1/5/0 -> /TUPLE/2:2:Int/4/1:3:Bytes/foo
 Del /Table/112/2/11/5/0
-CPut /Table/112/2/4/5/0 -> /BYTES/ (expecting does not exist)
+CPut /Table/112/2/4/5/0 -> /BYTES/
 Del /Table/112/3/11/5/0
-CPut /Table/112/4/"foo"/5/0 -> /BYTES/ (expecting does not exist)
+CPut /Table/112/4/"foo"/5/0 -> /BYTES/
 
 # Insert a conflicting row that that matches the second partial index before and
 # after the update and the index entry does not change.
@@ -606,7 +606,7 @@ INSERT INTO t VALUES (5, 11, 'bar') ON CONFLICT (a) DO UPDATE SET b = 3
 Scan /Table/112/1/5/0 lock Exclusive (Block, Unreplicated)
 Put /Table/112/1/5/0 -> /TUPLE/2:2:Int/3/1:3:Bytes/foo
 Del /Table/112/2/4/5/0
-CPut /Table/112/2/3/5/0 -> /BYTES/ (expecting does not exist)
+CPut /Table/112/2/3/5/0 -> /BYTES/
 
 # Insert a conflicting row that that matches the second partial index before and
 # after the update and the index entry changes.
@@ -616,7 +616,7 @@ INSERT INTO t VALUES (5, 11, 'bar') ON CONFLICT (a) DO UPDATE SET c = 'foobar'
 Scan /Table/112/1/5/0 lock Exclusive (Block, Unreplicated)
 Put /Table/112/1/5/0 -> /TUPLE/2:2:Int/3/1:3:Bytes/foobar
 Del /Table/112/4/"foo"/5/0
-CPut /Table/112/4/"foobar"/5/0 -> /BYTES/ (expecting does not exist)
+CPut /Table/112/4/"foobar"/5/0 -> /BYTES/
 
 # Insert a non-conflicting row that matches the first partial index.
 query T kvtrace
@@ -660,7 +660,7 @@ INSERT INTO u VALUES (2, 3, 11) ON CONFLICT (k) DO UPDATE SET u = 4, v = 12
 Scan /Table/113/1/2/0 lock Exclusive (Block, Unreplicated)
 Put /Table/113/1/2/0 -> /TUPLE/2:2:Int/4/1:3:Int/12
 Del /Table/113/2/3/2/0
-CPut /Table/113/2/4/2/0 -> /BYTES/ (expecting does not exist)
+CPut /Table/113/2/4/2/0 -> /BYTES/
 
 # ---------------------------------------------------------
 # INSERT ON CONFLICT DO UPDATE primary key
@@ -758,7 +758,7 @@ UPSERT INTO t VALUES (5, 3, 'bar')
 Scan /Table/112/1/5/0 lock Exclusive (Block, Unreplicated)
 Put /Table/112/1/5/0 -> /TUPLE/2:2:Int/3/1:3:Bytes/bar
 Del /Table/112/2/4/5/0
-CPut /Table/112/2/3/5/0 -> /BYTES/ (expecting does not exist)
+CPut /Table/112/2/3/5/0 -> /BYTES/
 
 # Upsert a conflicting row that does not match the first partial index before
 # the update, but does match after the update.
@@ -768,8 +768,8 @@ UPSERT INTO t VALUES (5, 11, 'bar')
 Scan /Table/112/1/5/0 lock Exclusive (Block, Unreplicated)
 Put /Table/112/1/5/0 -> /TUPLE/2:2:Int/11/1:3:Bytes/bar
 Del /Table/112/2/3/5/0
-CPut /Table/112/2/11/5/0 -> /BYTES/ (expecting does not exist)
-CPut /Table/112/3/11/5/0 -> /BYTES/ (expecting does not exist)
+CPut /Table/112/2/11/5/0 -> /BYTES/
+CPut /Table/112/3/11/5/0 -> /BYTES/
 
 # Upsert a conflicting row that currently matches the first partial index before
 # the update. Update the row so that the row no longer matches the first partial
@@ -780,9 +780,9 @@ UPSERT INTO t VALUES (5, 3, 'foo')
 Scan /Table/112/1/5/0 lock Exclusive (Block, Unreplicated)
 Put /Table/112/1/5/0 -> /TUPLE/2:2:Int/3/1:3:Bytes/foo
 Del /Table/112/2/11/5/0
-CPut /Table/112/2/3/5/0 -> /BYTES/ (expecting does not exist)
+CPut /Table/112/2/3/5/0 -> /BYTES/
 Del /Table/112/3/11/5/0
-CPut /Table/112/4/"foo"/5/0 -> /BYTES/ (expecting does not exist)
+CPut /Table/112/4/"foo"/5/0 -> /BYTES/
 
 # Upsert a conflicting row that that matches the second partial index before and
 # after the update and the index entry does not change.
@@ -792,7 +792,7 @@ UPSERT INTO t VALUES (5, 4, 'foo')
 Scan /Table/112/1/5/0 lock Exclusive (Block, Unreplicated)
 Put /Table/112/1/5/0 -> /TUPLE/2:2:Int/4/1:3:Bytes/foo
 Del /Table/112/2/3/5/0
-CPut /Table/112/2/4/5/0 -> /BYTES/ (expecting does not exist)
+CPut /Table/112/2/4/5/0 -> /BYTES/
 
 # Upsert a conflicting row that that matches the second partial index before and
 # after the update and the index entry changes.
@@ -802,7 +802,7 @@ UPSERT INTO t VALUES (5, 4, 'foobar')
 Scan /Table/112/1/5/0 lock Exclusive (Block, Unreplicated)
 Put /Table/112/1/5/0 -> /TUPLE/2:2:Int/4/1:3:Bytes/foobar
 Del /Table/112/4/"foo"/5/0
-CPut /Table/112/4/"foobar"/5/0 -> /BYTES/ (expecting does not exist)
+CPut /Table/112/4/"foobar"/5/0 -> /BYTES/
 
 # Upsert a non-conflicting row that matches the first partial index.
 query T kvtrace
@@ -846,7 +846,7 @@ UPSERT INTO u VALUES (2, 4, 12)
 Scan /Table/113/1/2/0 lock Exclusive (Block, Unreplicated)
 Put /Table/113/1/2/0 -> /TUPLE/2:2:Int/4/1:3:Int/12
 Del /Table/113/2/3/2/0
-CPut /Table/113/2/4/2/0 -> /BYTES/ (expecting does not exist)
+CPut /Table/113/2/4/2/0 -> /BYTES/
 
 # Tests for partial inverted indexes.
 

--- a/pkg/sql/opt/exec/execbuilder/testdata/secondary_index_column_families
+++ b/pkg/sql/opt/exec/execbuilder/testdata/secondary_index_column_families
@@ -228,10 +228,10 @@ SELECT y FROM t@i WHERE x IS NULL
 Scan /Table/107/2/{NULL-!NULL}
 
 # Ensure that updates only touch the changed column families.
-query T kvtrace(CPut,prefix=/Table/107/2/)
+query T kvtrace(Put,prefix=/Table/107/2/)
 UPDATE t SET y = 5 WHERE x = 1
 ----
-CPut /Table/107/2/1/1/1 -> /TUPLE/2:2:Int/5 (replacing /TUPLE/2:2:Int/2, if exists)
+Put /Table/107/2/1/1/1 -> /TUPLE/2:2:Int/5
 
 # Test composite datatypes.
 statement ok
@@ -404,7 +404,7 @@ CPut /Table/112/3/2/5/1 -> /TUPLE/8:8:Int/8
 query T kvtrace(Put,Del,CPut,prefix=/Table/112/2/)
 UPDATE t SET b = 4, c = NULL, d = NULL, e = 7, f = NULL WHERE y = 2
 ----
-CPut /Table/112/2/2/1/2/1 -> /TUPLE/3:3:Int/3/1:4:Int/4 (replacing /TUPLE/3:3:Int/3, if exists)
+Put /Table/112/2/2/1/2/1 -> /TUPLE/3:3:Int/3/1:4:Int/4
 Del /Table/112/2/2/1/3/1
 CPut /Table/112/2/2/1/4/1 -> /TUPLE/7:7:Int/7 (expecting does not exist)
 Del /Table/112/2/2/1/5/1
@@ -495,4 +495,4 @@ CPut /Table/113/2/5/1/0 -> /BYTES/0x33061308 (expecting does not exist)
 query T kvtrace(Put,Del,CPut,prefix=/Table/113/2/)
 UPDATE t SET z = 5 where y = 5
 ----
-CPut /Table/113/2/5/1/0 -> /BYTES/0x330a1308 (replacing /BYTES/0x33061308, if exists)
+Put /Table/113/2/5/1/0 -> /BYTES/0x330a1308

--- a/pkg/sql/opt/exec/execbuilder/testdata/secondary_index_column_families
+++ b/pkg/sql/opt/exec/execbuilder/testdata/secondary_index_column_families
@@ -406,7 +406,7 @@ UPDATE t SET b = 4, c = NULL, d = NULL, e = 7, f = NULL WHERE y = 2
 ----
 Put /Table/112/2/2/1/2/1 -> /TUPLE/3:3:Int/3/1:4:Int/4
 Del /Table/112/2/2/1/3/1
-CPut /Table/112/2/2/1/4/1 -> /TUPLE/7:7:Int/7 (expecting does not exist)
+CPut /Table/112/2/2/1/4/1 -> /TUPLE/7:7:Int/7
 Del /Table/112/2/2/1/5/1
 
 query IIIIIIII
@@ -422,10 +422,10 @@ INSERT INTO t VALUES (3, 3, NULL, NULL, NULL, NULL, NULL, NULL)
 query T kvtrace(Put,Del,CPut,prefix=/Table/112/2/)
 UPDATE t SET a = 10, b = 11, c = 12, d = 13, e = 14, f = 15 WHERE y = 3
 ----
-CPut /Table/112/2/3/3/2/1 -> /TUPLE/3:3:Int/10/1:4:Int/11 (expecting does not exist)
-CPut /Table/112/2/3/3/3/1 -> /TUPLE/5:5:Int/12/1:6:Int/13 (expecting does not exist)
-CPut /Table/112/2/3/3/4/1 -> /TUPLE/7:7:Int/14 (expecting does not exist)
-CPut /Table/112/2/3/3/5/1 -> /TUPLE/8:8:Int/15 (expecting does not exist)
+CPut /Table/112/2/3/3/2/1 -> /TUPLE/3:3:Int/10/1:4:Int/11
+CPut /Table/112/2/3/3/3/1 -> /TUPLE/5:5:Int/12/1:6:Int/13
+CPut /Table/112/2/3/3/4/1 -> /TUPLE/7:7:Int/14
+CPut /Table/112/2/3/3/5/1 -> /TUPLE/8:8:Int/15
 
 # Test a case where the update causes all k/v's other than
 # the sentinel k/v to get deleted.
@@ -447,13 +447,13 @@ query T kvtrace(Put,Del,CPut,prefix=/Table/112/2/)
 UPDATE t SET y = 22 WHERE y = 21
 ----
 Del /Table/112/2/21/20/0
-CPut /Table/112/2/22/20/0 -> /BYTES/ (expecting does not exist)
+CPut /Table/112/2/22/20/0 -> /BYTES/
 Del /Table/112/2/21/20/2/1
-CPut /Table/112/2/22/20/2/1 -> /TUPLE/3:3:Int/22 (expecting does not exist)
+CPut /Table/112/2/22/20/2/1 -> /TUPLE/3:3:Int/22
 Del /Table/112/2/21/20/3/1
-CPut /Table/112/2/22/20/3/1 -> /TUPLE/6:6:Int/25 (expecting does not exist)
+CPut /Table/112/2/22/20/3/1 -> /TUPLE/6:6:Int/25
 Del /Table/112/2/21/20/5/1
-CPut /Table/112/2/22/20/5/1 -> /TUPLE/8:8:Int/27 (expecting does not exist)
+CPut /Table/112/2/22/20/5/1 -> /TUPLE/8:8:Int/27
 
 # Ensure that the final results on both indexes make sense.
 query IIIIIIII rowsort
@@ -489,7 +489,7 @@ query T kvtrace(Put,CPut,Del,prefix=/Table/113/2/)
 UPDATE t SET y = 5 where y = 2
 ----
 Del /Table/113/2/2/1/0
-CPut /Table/113/2/5/1/0 -> /BYTES/0x33061308 (expecting does not exist)
+CPut /Table/113/2/5/1/0 -> /BYTES/0x33061308
 
 # Changing the value just results in a cput.
 query T kvtrace(Put,Del,CPut,prefix=/Table/113/2/)

--- a/pkg/sql/opt/exec/execbuilder/testdata/upsert
+++ b/pkg/sql/opt/exec/execbuilder/testdata/upsert
@@ -1099,7 +1099,7 @@ colbatchscan  Scan /Table/120/1/2/0 lock Exclusive (Block, Unreplicated)
 colbatchscan  fetched: /kv/kv_pkey/2/v -> /3
 count         Put /Table/120/1/2/0 -> /TUPLE/2:2:Int/2
 count         Del /Table/120/2/3/0
-count         CPut /Table/120/2/2/0 -> /BYTES/0x8a (expecting does not exist)
+count         CPut /Table/120/2/2/0 -> /BYTES/0x8a
 sql query     execution failed after 0 rows: duplicate key value violates unique constraint "woo"
 
 # Test that implicit SELECT FOR UPDATE doesn't spread to subqueries.

--- a/pkg/sql/row/updater.go
+++ b/pkg/sql/row/updater.go
@@ -398,18 +398,18 @@ func (ru *Updater) UpdateRow(
 				oldEntry, newEntry := &oldEntries[oldIdx], &newEntries[newIdx]
 				if oldEntry.Family == newEntry.Family {
 					// If the families are equal, then check if the keys have changed. If so, delete the old key.
-					// Then, issue a CPut for the new value of the key if the value has changed.
+					// Then, issue a CPut for the new key or a Put if only the value has changed.
 					// Because the indexes will always have a k/v for family 0, it suffices to only
 					// add foreign key checks in this case, because we are guaranteed to enter here.
 					oldIdx++
 					newIdx++
-					var expValue []byte
+					var sameKey bool
 					if !bytes.Equal(oldEntry.Key, newEntry.Key) {
 						if err := ru.Helper.deleteIndexEntry(ctx, batch, index, ru.Helper.secIndexValDirs[i], oldEntry, traceKV); err != nil {
 							return nil, err
 						}
 					} else if !newEntry.Value.EqualTagAndData(oldEntry.Value) {
-						expValue = oldEntry.Value.TagAndDataBytes()
+						sameKey = true
 					} else if !index.IsTemporaryIndexForBackfill() {
 						// If this is a temporary index for backfill, we want to make sure we write out all
 						// index values even in the case where they should be the same. We do this because the
@@ -428,13 +428,17 @@ func (ru *Updater) UpdateRow(
 						if traceKV {
 							k := keys.PrettyPrint(ru.Helper.secIndexValDirs[i], newEntry.Key)
 							v := newEntry.Value.PrettyPrint()
-							if expValue != nil {
-								log.VEventf(ctx, 2, "CPut %s -> %v (replacing %v, if exists)", k, v, oldEntry.Value.PrettyPrint())
+							if sameKey {
+								log.VEventf(ctx, 2, "Put %s -> %v", k, v)
 							} else {
 								log.VEventf(ctx, 2, "CPut %s -> %v (expecting does not exist)", k, v)
 							}
 						}
-						batch.CPutAllowingIfNotExists(newEntry.Key, &newEntry.Value, expValue)
+						if sameKey {
+							batch.Put(newEntry.Key, &newEntry.Value)
+						} else {
+							batch.CPutAllowingIfNotExists(newEntry.Key, &newEntry.Value, nil /* expValue */)
+						}
 					}
 					writtenIndexes.Add(i)
 				} else if oldEntry.Family < newEntry.Family {

--- a/pkg/sql/row/updater.go
+++ b/pkg/sql/row/updater.go
@@ -431,13 +431,13 @@ func (ru *Updater) UpdateRow(
 							if sameKey {
 								log.VEventf(ctx, 2, "Put %s -> %v", k, v)
 							} else {
-								log.VEventf(ctx, 2, "CPut %s -> %v (expecting does not exist)", k, v)
+								log.VEventf(ctx, 2, "CPut %s -> %v", k, v)
 							}
 						}
 						if sameKey {
 							batch.Put(newEntry.Key, &newEntry.Value)
 						} else {
-							batch.CPutAllowingIfNotExists(newEntry.Key, &newEntry.Value, nil /* expValue */)
+							batch.CPut(newEntry.Key, &newEntry.Value, nil /* expValue */)
 						}
 					}
 					writtenIndexes.Add(i)
@@ -472,7 +472,7 @@ func (ru *Updater) UpdateRow(
 						if traceKV {
 							k := keys.PrettyPrint(ru.Helper.secIndexValDirs[i], newEntry.Key)
 							v := newEntry.Value.PrettyPrint()
-							log.VEventf(ctx, 2, "CPut %s -> %v (expecting does not exist)", k, v)
+							log.VEventf(ctx, 2, "CPut %s -> %v", k, v)
 						}
 						batch.CPut(newEntry.Key, &newEntry.Value, nil)
 					}
@@ -506,7 +506,7 @@ func (ru *Updater) UpdateRow(
 					if traceKV {
 						k := keys.PrettyPrint(ru.Helper.secIndexValDirs[i], newEntry.Key)
 						v := newEntry.Value.PrettyPrint()
-						log.VEventf(ctx, 2, "CPut %s -> %v (expecting does not exist)", k, v)
+						log.VEventf(ctx, 2, "CPut %s -> %v", k, v)
 					}
 					batch.CPut(newEntry.Key, &newEntry.Value, nil)
 				}

--- a/pkg/sql/testdata/index_mutations/merging
+++ b/pkg/sql/testdata/index_mutations/merging
@@ -148,7 +148,7 @@ UPDATE tefp SET a = a + 1, b = b + 100
 Scan /Table/108/{1-2} lock Exclusive (Block, Unreplicated)
 Put /Table/108/1/1/0 -> /TUPLE/2:2:Int/3/1:3:Int/200
 Del /Table/108/2/102/0
-CPut /Table/108/2/203/0 -> /BYTES/0x89 (expecting does not exist)
+CPut /Table/108/2/203/0 -> /BYTES/0x89
 
 # Update a row with different values without changing the index entry.
 kvtrace


### PR DESCRIPTION
**sql/row: use Put instead of CPut when updating value of secondary index**

When an UPDATE statement changes the value but not the key of a secondary index (e.g. an update to the stored columns of a secondary index) we need to write a new version of the secondary index KV with the new value.

We were using a CPutAllowingIfNotExists to do this, which verified that if the KV existed, the expected value was the value before update. But there's no need for this verification. We have other mechanisms to detect a write-write conflict with any other transaction that could have changed the value concurrently. We can simply use a Put to overwrite the previous value.

This also matches what we do for the primary index when the PK doesn't change.

Epic: None

Release note: None

---

**sql: change CPutAllowingIfNotExists with nil expValue to CPut**

CPutAllowingIfNotExists with empty expValue is equivalent to CPut with empty expValue, so change a few spots to use regular CPut. This almost gets rid of CPutAllowingIfNotExists entirely, but there is at least one spot in backfill (introduced in #138707) that needs to allow for both a non-empty expValue and non-existence of the KV.

Also drop "(expecting does not exist)" from CPut tracing, as CPut with empty expValue is now overwhelmingly the most common use of CPut. And this matches the tracing in #138707.

Epic: None

Release note: None