### PR TITLE
WIP remove the only usage of InitPut with FailOnTombstones

### DIFF
--- a/pkg/sql/sqlliveness/slstorage/slstorage.go
+++ b/pkg/sql/sqlliveness/slstorage/slstorage.go
@@ -529,7 +529,7 @@ func (s *Storage) Insert(
 
 		}
 		v := encodeValue(expiration)
-		batch.InitPut(k, &v, true)
+		batch.InitPut(k, &v, false /* failOnTombstones */)
 
 		return txn.CommitInBatch(ctx, batch)
 	}); err != nil {

--- a/pkg/sql/sqlliveness/slstorage/slstorage_test.go
+++ b/pkg/sql/sqlliveness/slstorage/slstorage_test.go
@@ -269,6 +269,10 @@ func TestStorage(t *testing.T) {
 			require.False(t, exists)
 			require.Equal(t, int64(1), metrics.WriteFailures.Count())
 		}
+		// Ensure it cannot be inserted again.
+		{
+			require.Error(t, storage.Insert(ctx, id, exp))
+		}
 	})
 	t.Run("test-jitter", func(t *testing.T) {
 		// We want to test that the GC runs a number of times but is jitterred.


### PR DESCRIPTION
Epic: None

This was introduced in 686f323b6ce9e7bc24b21fb7e3bbb334b8a2c930.