### PR TITLE
backup: skip TestDataDriven tests under deadlock

### DIFF
--- a/pkg/backup/backuptestutils/BUILD.bazel
+++ b/pkg/backup/backuptestutils/BUILD.bazel
@@ -14,7 +14,6 @@ go_library(
         "//pkg/kv/kvserver",
         "//pkg/sql/sqlstats",
         "//pkg/testutils",
-        "//pkg/testutils/skip",
         "//pkg/testutils/sqlutils",
         "//pkg/testutils/testcluster",
         "//pkg/util",

--- a/pkg/backup/backuptestutils/testutils.go
+++ b/pkg/backup/backuptestutils/testutils.go
@@ -19,7 +19,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
-	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util"
@@ -102,11 +101,6 @@ func WithSkipInvalidDescriptorCheck() BackupTestArg {
 func StartBackupRestoreTestCluster(
 	t testing.TB, clusterSize int, args ...BackupTestArg,
 ) (*testcluster.TestCluster, *sqlutils.SQLRunner, string, func()) {
-
-	// Because the deadlock detector can increase the runtime of a test by 10-100x
-	// and has not found anything in recent memory for backup/restore tests.
-	skip.UnderDeadlock(t)
-
 	ctx := logtags.AddTag(context.Background(), "start-backup-restore-test-cluster", nil)
 	opts := backupTestOptions{}
 	for _, a := range args {

--- a/pkg/backup/testgen/templates.go
+++ b/pkg/backup/testgen/templates.go
@@ -28,8 +28,8 @@ import (
 func TestDataDriven_{{.TestName}}(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	skip.UnderRace(t, "takes ~3mins to run"){{if eq .TestName "multiregion"}}
-	skip.UnderDeadlockWithIssue(t, 117927){{end}}
+	skip.UnderRace(t, "takes ~3mins to run")
+	skip.UnderDeadlock(t, "slows down test by 10 to 100x")
 
 	runTestDataDriven(t, "{{.TestFilePath}}")
 }


### PR DESCRIPTION
Fixes #137821
Fixes #137820
Fixes #137819
Fixes #137818
Fixes #137817
Fixes #137816
Fixes #137815

Release note: none