### PR TITLE
backup/crosscluster: skip a few tests

### DIFF
--- a/pkg/backup/backup_test.go
+++ b/pkg/backup/backup_test.go
@@ -1529,6 +1529,7 @@ func TestRestoreRetryProcErr(t *testing.T) {
 func TestRestoreReplanOnLag(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+	skip.WithIssue(t, 137098, "move logic to roachtest")
 
 	skip.UnderRace(t, "slow test under stress race")
 

--- a/pkg/crosscluster/physical/replication_stream_e2e_test.go
+++ b/pkg/crosscluster/physical/replication_stream_e2e_test.go
@@ -1313,6 +1313,7 @@ func TestStreamingRegionalConstraint(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	skip.UnderRace(t, "takes too long under race")
+	skip.UnderDeadlock(t, "takes too long under deadlock")
 
 	testutils.RunTrueAndFalse(t, "fromSys", func(t *testing.T, sys bool) {
 		ctx := context.Background()


### PR DESCRIPTION
See commits.

Epic: none

Release note: none