### PR TITLE
roachtest: disable the impact check for elastic workload

### DIFF
--- a/pkg/cmd/roachtest/tests/perturbation/elastic_workload.go
+++ b/pkg/cmd/roachtest/tests/perturbation/elastic_workload.go
@@ -8,6 +8,7 @@ package perturbation
 import (
 	"context"
 	"fmt"
+	"math"
 	"math/rand"
 	"time"
 
@@ -28,7 +29,9 @@ type elasticWorkload struct{}
 var _ perturbation = elasticWorkload{}
 
 func (e elasticWorkload) setup() variations {
-	return setup(e, 20.0)
+	// TODO(#137835): Determine why the impact is so high and reduce this once
+	// it is addressed.
+	return setup(e, math.Inf(1))
 }
 
 func (e elasticWorkload) setupMetamorphic(rng *rand.Rand) variations {


### PR DESCRIPTION
Recently the elastic workload test has been less stable and even with the change to the default kvadmission.flow_control.mode change to `apply_to_all` it can still overload the disk and cause large impacts.

Fixes: #136991
Informs: #137835

Release note: None