### PR TITLE
diagnostics: honor stopper quiescence when reporting diagnostics

### DIFF
--- a/pkg/server/diagnostics/reporter.go
+++ b/pkg/server/diagnostics/reporter.go
@@ -192,7 +192,11 @@ func (r *Reporter) PeriodicallyReportDiagnostics(ctx context.Context, stopper *s
 			// Consider something like rand.Float() > resetFreq/reportFreq here to sample
 			// stat reset periods for reporting.
 			if shouldReportDiagnostics(ctx, r.Settings) {
-				r.ReportDiagnostics(ctx)
+				func() {
+					ctx, cancel := stopper.WithCancelOnQuiesce(ctx)
+					defer cancel()
+					r.ReportDiagnostics(ctx)
+				}()
 			}
 
 			nextReport = nextReport.Add(reportFrequency.Get(&r.Settings.SV))


### PR DESCRIPTION
Previously, we would block on the HTTP diagnostics request until the preset timeout regardless of stopper quiescence. This change ensures that the `ctx` passed to the diagnostics reporter and the HTTP client is cancelled if the stopper is quiescing.

Resolves: #136739

Release note: None