### PR TITLE
roachtest/perturbation: disable low mem config for restart and partition tests

### DIFF
--- a/pkg/cmd/roachtest/tests/perturbation/network_partition.go
+++ b/pkg/cmd/roachtest/tests/perturbation/network_partition.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -42,7 +43,13 @@ func (p partition) setupMetamorphic(rng *rand.Rand) variations {
 	v := p.setup()
 	p.partitionSite = rng.Intn(2) == 0
 	v.perturbation = p
-	return v.randomize(rng)
+	v = v.randomize(rng)
+	// TODO(#137666): The partition test can cause OOM with low memory
+	// configurations.
+	if v.mem == spec.Low {
+		v.mem = spec.Standard
+	}
+	return v
 }
 
 func (p partition) startTargetNode(ctx context.Context, t test.Test, v variations) {

--- a/pkg/cmd/roachtest/tests/perturbation/restart_node.go
+++ b/pkg/cmd/roachtest/tests/perturbation/restart_node.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 )
@@ -47,6 +48,11 @@ func (r restart) setupMetamorphic(rng *rand.Rand) variations {
 	r.cleanRestart = rng.Intn(2) == 0
 	v.perturbation = r
 	v = v.randomize(rng)
+	// TODO(#137666): The restart test can cause OOM with low memory
+	// configurations.
+	if v.mem == spec.Low {
+		v.mem = spec.Standard
+	}
 	return v
 }
 


### PR DESCRIPTION
Informs #137666.

This commit disables the low memory configuration for the `restart` and `partition` tests in the `perturbation` roaachtest suite. These tests can trigger range snapshots, which can overwhelm the low memory configuration and cause it to OOM.

Release note: None