### PR TITLE
workload: handle new RESTORE results when importing fixtures

### DIFF
--- a/pkg/ccl/workloadccl/cliccl/BUILD.bazel
+++ b/pkg/ccl/workloadccl/cliccl/BUILD.bazel
@@ -7,7 +7,6 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/ccl/workloadccl",
-        "//pkg/util/humanizeutil",
         "//pkg/util/log",
         "//pkg/util/timeutil",
         "//pkg/workload",

--- a/pkg/ccl/workloadccl/cliccl/fixtures.go
+++ b/pkg/ccl/workloadccl/cliccl/fixtures.go
@@ -12,7 +12,6 @@ import (
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/ccl/workloadccl"
-	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/workload"
@@ -268,14 +267,17 @@ func (l restoreDataLoader) InitialDataLoad(
 ) (int64, error) {
 	log.Infof(ctx, "starting restore of %d tables", len(gen.Tables()))
 	start := timeutil.Now()
-	bytes, err := workloadccl.RestoreFixture(ctx, db, l.fixture, l.database, true /* injectStats */)
+	err := workloadccl.RestoreFixture(ctx, db, l.fixture, l.database, true /* injectStats */)
 	if err != nil {
 		return 0, errors.Wrap(err, `restoring fixture`)
 	}
 	elapsed := timeutil.Since(start)
-	log.Infof(ctx, "restored %s bytes in %d tables (took %s, %s)",
-		humanizeutil.IBytes(bytes), len(gen.Tables()), elapsed, humanizeutil.DataRate(bytes, elapsed))
-	return bytes, nil
+	log.Infof(ctx, "restored %d tables (took %s)",
+		len(gen.Tables()), elapsed)
+	// As of #134516, RESTORE no longer returns the number of bytes restored.
+	// We still return 0 here to implement the interface, although as of right
+	// now the value is never used.
+	return 0, nil
 }
 
 func fixturesLoad(gen workload.Generator, urls []string, dbName string) error {

--- a/pkg/ccl/workloadccl/fixture_test.go
+++ b/pkg/ccl/workloadccl/fixture_test.go
@@ -167,7 +167,7 @@ func TestFixture(t *testing.T) {
 	}
 
 	sqlDB.Exec(t, `CREATE DATABASE test`)
-	if _, err := workloadccl.RestoreFixture(ctx, db, fixture, `test`, false); err != nil {
+	if err := workloadccl.RestoreFixture(ctx, db, fixture, `test`, false); err != nil {
 		t.Fatalf(`%+v`, err)
 	}
 	sqlDB.CheckQueryResults(t,


### PR DESCRIPTION
In 03e24093c9b39f6fad45e4e2d972cdab3abe83ab, two columns were removed from the RESTORE results. This change supports handling this. It also removes logging around bytes restored as it is no longer returned.

Fixes: #137671
Release note: none
Epic: none