### PR TITLE
rac2: log force flush and prevent-send-queue tokens deducted

### DIFF
--- a/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/token_counter/token_adjustment
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/token_counter/token_adjustment
@@ -35,6 +35,8 @@ class=regular delta=+2MiB
 class=elastic delta=+2MiB
 class=regular delta=+6MiB
 ----
+regular: deducted: +16 MiB, returned: +16 MiB, force-flush: +0 B, prevent-send-q: +0 B
+elastic: deducted: +18 MiB, returned: +18 MiB, force-flush: +0 B, prevent-send-q: +0 B
 
 history
 ----
@@ -112,6 +114,8 @@ class=regular delta=-9MiB
 class=regular delta=+17MiB
 class=elastic delta=+1MiB
 ----
+regular: deducted: +23 MiB, returned: +23 MiB, force-flush: +0 B, prevent-send-q: +0 B
+elastic: deducted: +30 MiB, returned: +30 MiB, force-flush: +0 B, prevent-send-q: +0 B
 
 
 history
@@ -151,6 +155,8 @@ metrics
 adjust
 class=regular delta=-16MiB
 ----
+regular: deducted: +16 MiB, returned: +0 B, force-flush: +0 B, prevent-send-q: +0 B
+elastic: deducted: +16 MiB, returned: +0 B, force-flush: +0 B, prevent-send-q: +0 B
 
 metrics
 ----

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/token_counter/token_adjustment_flags
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/token_counter/token_adjustment_flags
@@ -59,6 +59,8 @@ class=regular delta=+6MiB
 class=elastic delta=-9MiB flag=prevention
 class=elastic delta=+9MiB
 ----
+regular: deducted: +16 MiB, returned: +16 MiB, force-flush: +0 B, prevent-send-q: +2.0 MiB
+elastic: deducted: +27 MiB, returned: +27 MiB, force-flush: +2.0 MiB, prevent-send-q: +11 MiB
 
 history
 ----


### PR DESCRIPTION
These are logged when send tokens for a stream are zero for some time interval. If we see a store showing unexpected overload, these logs can be used to ascertain whether the overload was due to token pools not being respected.

Informs #136527

Epic: CRDB-37515

Release note: None