### PR TITLE
sql: clean up plan hooks

### DIFF
--- a/pkg/backup/alter_backup_planning.go
+++ b/pkg/backup/alter_backup_planning.go
@@ -89,7 +89,7 @@ func alterBackupPlanHook(
 		}
 	}
 
-	fn := func(ctx context.Context, _ []sql.PlanNode, resultsCh chan<- tree.Datums) error {
+	fn := func(ctx context.Context, resultsCh chan<- tree.Datums) error {
 
 		if subdir != "" {
 			if strings.EqualFold(subdir, "LATEST") {

--- a/pkg/backup/alter_backup_planning.go
+++ b/pkg/backup/alter_backup_planning.go
@@ -43,10 +43,10 @@ func alterBackupTypeCheck(
 
 func alterBackupPlanHook(
 	ctx context.Context, stmt tree.Statement, p sql.PlanHookState,
-) (sql.PlanHookRowFn, colinfo.ResultColumns, []sql.PlanNode, bool, error) {
+) (sql.PlanHookRowFn, colinfo.ResultColumns, bool, error) {
 	alterBackupStmt, ok := stmt.(*tree.AlterBackup)
 	if !ok {
-		return nil, nil, nil, false, nil
+		return nil, nil, false, nil
 	}
 
 	if err := featureflag.CheckEnabled(
@@ -55,20 +55,20 @@ func alterBackupPlanHook(
 		featureBackupEnabled,
 		"ALTER BACKUP",
 	); err != nil {
-		return nil, nil, nil, false, err
+		return nil, nil, false, err
 	}
 
 	exprEval := p.ExprEvaluator("ALTER BACKUP")
 	backup, err := exprEval.String(ctx, alterBackupStmt.Backup)
 	if err != nil {
-		return nil, nil, nil, false, err
+		return nil, nil, false, err
 	}
 
 	var subdir string
 	if alterBackupStmt.Subdir != nil {
 		subdir, err = exprEval.String(ctx, alterBackupStmt.Subdir)
 		if err != nil {
-			return nil, nil, nil, false, err
+			return nil, nil, false, err
 		}
 	}
 
@@ -80,11 +80,11 @@ func alterBackupPlanHook(
 		case *tree.AlterBackupKMS:
 			newKms, err = exprEval.StringArray(ctx, tree.Exprs(v.KMSInfo.NewKMSURI))
 			if err != nil {
-				return nil, nil, nil, false, err
+				return nil, nil, false, err
 			}
 			oldKms, err = exprEval.StringArray(ctx, tree.Exprs(v.KMSInfo.OldKMSURI))
 			if err != nil {
-				return nil, nil, nil, false, err
+				return nil, nil, false, err
 			}
 		}
 	}
@@ -119,7 +119,7 @@ func alterBackupPlanHook(
 		return doAlterBackupPlan(ctx, alterBackupStmt, p, backup, newKms, oldKms)
 	}
 
-	return fn, nil, nil, false, nil
+	return fn, nil, false, nil
 }
 
 func doAlterBackupPlan(

--- a/pkg/backup/alter_backup_schedule.go
+++ b/pkg/backup/alter_backup_schedule.go
@@ -778,7 +778,7 @@ func alterBackupScheduleHook(
 		return nil, nil, false, err
 	}
 
-	fn := func(ctx context.Context, _ []sql.PlanNode, resultsCh chan<- tree.Datums) error {
+	fn := func(ctx context.Context, resultsCh chan<- tree.Datums) error {
 		err := doAlterBackupSchedules(ctx, p, spec, resultsCh)
 		if err != nil {
 			telemetry.Count("scheduled-backup.alter.failed")

--- a/pkg/backup/alter_backup_schedule.go
+++ b/pkg/backup/alter_backup_schedule.go
@@ -767,15 +767,15 @@ func alterBackupScheduleTypeCheck(
 
 func alterBackupScheduleHook(
 	ctx context.Context, stmt tree.Statement, p sql.PlanHookState,
-) (sql.PlanHookRowFn, colinfo.ResultColumns, []sql.PlanNode, bool, error) {
+) (sql.PlanHookRowFn, colinfo.ResultColumns, bool, error) {
 	alterScheduleStmt, ok := stmt.(*tree.AlterBackupSchedule)
 	if !ok {
-		return nil, nil, nil, false, nil
+		return nil, nil, false, nil
 	}
 
 	spec, err := makeAlterBackupScheduleSpec(ctx, p, alterScheduleStmt)
 	if err != nil {
-		return nil, nil, nil, false, err
+		return nil, nil, false, err
 	}
 
 	fn := func(ctx context.Context, _ []sql.PlanNode, resultsCh chan<- tree.Datums) error {
@@ -787,7 +787,7 @@ func alterBackupScheduleHook(
 
 		return nil
 	}
-	return fn, scheduledBackupHeader, nil, false, nil
+	return fn, scheduledBackupHeader, false, nil
 }
 
 func init() {

--- a/pkg/backup/backup_planning.go
+++ b/pkg/backup/backup_planning.go
@@ -516,7 +516,7 @@ func backupPlanHook(
 		}
 	}
 
-	fn := func(ctx context.Context, _ []sql.PlanNode, resultsCh chan<- tree.Datums) error {
+	fn := func(ctx context.Context, resultsCh chan<- tree.Datums) error {
 		// TODO(dan): Move this span into sql.
 		ctx, span := tracing.ChildSpan(ctx, stmt.StatementTag())
 		defer span.Finish()

--- a/pkg/backup/backup_planning.go
+++ b/pkg/backup/backup_planning.go
@@ -403,10 +403,10 @@ func backupTypeCheck(
 // backupPlanHook implements PlanHookFn.
 func backupPlanHook(
 	ctx context.Context, stmt tree.Statement, p sql.PlanHookState,
-) (sql.PlanHookRowFn, colinfo.ResultColumns, []sql.PlanNode, bool, error) {
+) (sql.PlanHookRowFn, colinfo.ResultColumns, bool, error) {
 	backupStmt := getBackupStatement(stmt)
 	if backupStmt == nil {
-		return nil, nil, nil, false, nil
+		return nil, nil, false, nil
 	}
 	if err := featureflag.CheckEnabled(
 		ctx,
@@ -414,7 +414,7 @@ func backupPlanHook(
 		featureBackupEnabled,
 		"BACKUP",
 	); err != nil {
-		return nil, nil, nil, false, err
+		return nil, nil, false, err
 	}
 
 	detached := backupStmt.Options.Detached == tree.DBoolTrue
@@ -426,20 +426,20 @@ func backupPlanHook(
 	if backupStmt.Subdir != nil {
 		subdir, err = exprEval.String(ctx, backupStmt.Subdir)
 		if err != nil {
-			return nil, nil, nil, false, err
+			return nil, nil, false, err
 		}
 	}
 
 	to, err := exprEval.StringArray(ctx, tree.Exprs(backupStmt.To))
 	if err != nil {
-		return nil, nil, nil, false, err
+		return nil, nil, false, err
 	}
 
 	incrementalStorage, err := exprEval.StringArray(
 		ctx, tree.Exprs(backupStmt.Options.IncrementalStorage),
 	)
 	if err != nil {
-		return nil, nil, nil, false, err
+		return nil, nil, false, err
 	}
 
 	var revisionHistory bool
@@ -448,7 +448,7 @@ func backupPlanHook(
 			ctx, backupStmt.Options.CaptureRevisionHistory,
 		)
 		if err != nil {
-			return nil, nil, nil, false, err
+			return nil, nil, false, err
 		}
 	}
 
@@ -456,11 +456,11 @@ func backupPlanHook(
 	if backupStmt.Options.ExecutionLocality != nil {
 		s, err := exprEval.String(ctx, backupStmt.Options.ExecutionLocality)
 		if err != nil {
-			return nil, nil, nil, false, err
+			return nil, nil, false, err
 		}
 		if s != "" {
 			if err := executionLocality.Set(s); err != nil {
-				return nil, nil, nil, false, err
+				return nil, nil, false, err
 			}
 		}
 	}
@@ -471,7 +471,7 @@ func backupPlanHook(
 			ctx, backupStmt.Options.IncludeAllSecondaryTenants,
 		)
 		if err != nil {
-			return nil, nil, nil, false, err
+			return nil, nil, false, err
 		}
 	}
 
@@ -483,7 +483,7 @@ func backupPlanHook(
 	if backupStmt.Options.EncryptionPassphrase != nil {
 		pw, err = exprEval.String(ctx, backupStmt.Options.EncryptionPassphrase)
 		if err != nil {
-			return nil, nil, nil, false, err
+			return nil, nil, false, err
 		}
 		encryptionParams.Mode = jobspb.EncryptionMode_Passphrase
 	}
@@ -491,18 +491,18 @@ func backupPlanHook(
 	var kms []string
 	if backupStmt.Options.EncryptionKMSURI != nil {
 		if encryptionParams.Mode != jobspb.EncryptionMode_None {
-			return nil, nil, nil, false,
+			return nil, nil, false,
 				errors.New("cannot have both encryption_passphrase and kms option set")
 		}
 		kms, err = exprEval.StringArray(
 			ctx, tree.Exprs(backupStmt.Options.EncryptionKMSURI),
 		)
 		if err != nil {
-			return nil, nil, nil, false, err
+			return nil, nil, false, err
 		}
 		encryptionParams.Mode = jobspb.EncryptionMode_KMS
 		if err = logAndSanitizeKmsURIs(ctx, kms...); err != nil {
-			return nil, nil, nil, false, err
+			return nil, nil, false, err
 		}
 	}
 
@@ -512,7 +512,7 @@ func backupPlanHook(
 			ctx, backupStmt.Options.UpdatesClusterMonitoringMetrics,
 		)
 		if err != nil {
-			return nil, nil, nil, false, err
+			return nil, nil, false, err
 		}
 	}
 
@@ -738,9 +738,9 @@ func backupPlanHook(
 	}
 
 	if detached {
-		return fn, jobs.DetachedJobExecutionResultHeader, nil, false, nil
+		return fn, jobs.DetachedJobExecutionResultHeader, false, nil
 	}
-	return fn, jobs.BackupRestoreJobResultHeader, nil, false, nil
+	return fn, jobs.BackupRestoreJobResultHeader, false, nil
 }
 
 func logAndSanitizeKmsURIs(ctx context.Context, kmsURIs ...string) error {

--- a/pkg/backup/create_scheduled_backup.go
+++ b/pkg/backup/create_scheduled_backup.go
@@ -802,15 +802,15 @@ func createBackupScheduleTypeCheck(
 
 func createBackupScheduleHook(
 	ctx context.Context, stmt tree.Statement, p sql.PlanHookState,
-) (sql.PlanHookRowFn, colinfo.ResultColumns, []sql.PlanNode, bool, error) {
+) (sql.PlanHookRowFn, colinfo.ResultColumns, bool, error) {
 	schedule, ok := stmt.(*tree.ScheduledBackup)
 	if !ok {
-		return nil, nil, nil, false, nil
+		return nil, nil, false, nil
 	}
 
 	spec, err := makeScheduledBackupSpec(ctx, p, schedule)
 	if err != nil {
-		return nil, nil, nil, false, err
+		return nil, nil, false, err
 	}
 
 	fn := func(ctx context.Context, _ []sql.PlanNode, resultsCh chan<- tree.Datums) error {
@@ -822,7 +822,7 @@ func createBackupScheduleHook(
 
 		return nil
 	}
-	return fn, scheduledBackupHeader, nil, false, nil
+	return fn, scheduledBackupHeader, false, nil
 }
 
 func init() {

--- a/pkg/backup/create_scheduled_backup.go
+++ b/pkg/backup/create_scheduled_backup.go
@@ -813,7 +813,7 @@ func createBackupScheduleHook(
 		return nil, nil, false, err
 	}
 
-	fn := func(ctx context.Context, _ []sql.PlanNode, resultsCh chan<- tree.Datums) error {
+	fn := func(ctx context.Context, resultsCh chan<- tree.Datums) error {
 		err := doCreateBackupSchedules(ctx, p, spec, resultsCh)
 		if err != nil {
 			telemetry.Count("scheduled-backup.create.failed")

--- a/pkg/backup/restore_planning.go
+++ b/pkg/backup/restore_planning.go
@@ -1385,7 +1385,7 @@ func restorePlanHook(
 		}
 	}
 
-	fn := func(ctx context.Context, _ []sql.PlanNode, resultsCh chan<- tree.Datums) error {
+	fn := func(ctx context.Context, resultsCh chan<- tree.Datums) error {
 		// TODO(dan): Move this span into sql.
 		ctx, span := tracing.ChildSpan(ctx, stmt.StatementTag())
 		defer span.Finish()

--- a/pkg/backup/restore_planning.go
+++ b/pkg/backup/restore_planning.go
@@ -1205,10 +1205,10 @@ func logSanitizedRestoreDestination(ctx context.Context, restoreDestinations str
 // restorePlanHook implements sql.PlanHookFn.
 func restorePlanHook(
 	ctx context.Context, stmt tree.Statement, p sql.PlanHookState,
-) (sql.PlanHookRowFn, colinfo.ResultColumns, []sql.PlanNode, bool, error) {
+) (sql.PlanHookRowFn, colinfo.ResultColumns, bool, error) {
 	restoreStmt, ok := stmt.(*tree.Restore)
 	if !ok {
-		return nil, nil, nil, false, nil
+		return nil, nil, false, nil
 	}
 
 	if err := featureflag.CheckEnabled(
@@ -1217,11 +1217,11 @@ func restorePlanHook(
 		featureRestoreEnabled,
 		"RESTORE",
 	); err != nil {
-		return nil, nil, nil, false, err
+		return nil, nil, false, err
 	}
 
 	if !restoreStmt.Options.SchemaOnly && restoreStmt.Options.VerifyData {
-		return nil, nil, nil, false,
+		return nil, nil, false,
 			errors.New("to set the verify_backup_table_data option, the schema_only option must be set")
 	}
 
@@ -1229,7 +1229,7 @@ func restorePlanHook(
 
 	from, err := exprEval.StringArray(ctx, tree.Exprs(restoreStmt.From))
 	if err != nil {
-		return nil, nil, nil, false, err
+		return nil, nil, false, err
 	}
 
 	var pw string
@@ -1237,33 +1237,33 @@ func restorePlanHook(
 		var err error
 		pw, err = exprEval.String(ctx, restoreStmt.Options.EncryptionPassphrase)
 		if err != nil {
-			return nil, nil, nil, false, err
+			return nil, nil, false, err
 		}
 	}
 
 	var kms []string
 	if restoreStmt.Options.DecryptionKMSURI != nil {
 		if restoreStmt.Options.EncryptionPassphrase != nil {
-			return nil, nil, nil, false, errors.New("cannot have both encryption_passphrase and kms option set")
+			return nil, nil, false, errors.New("cannot have both encryption_passphrase and kms option set")
 		}
 		var err error
 		kms, err = exprEval.StringArray(
 			ctx, tree.Exprs(restoreStmt.Options.DecryptionKMSURI),
 		)
 		if err != nil {
-			return nil, nil, nil, false, err
+			return nil, nil, false, err
 		}
 	}
 
 	var intoDB string
 	if restoreStmt.Options.IntoDB != nil {
 		if restoreStmt.DescriptorCoverage == tree.SystemUsers {
-			return nil, nil, nil, false, errors.New("cannot set into_db option when only restoring system users")
+			return nil, nil, false, errors.New("cannot set into_db option when only restoring system users")
 		}
 		var err error
 		intoDB, err = exprEval.String(ctx, restoreStmt.Options.IntoDB)
 		if err != nil {
-			return nil, nil, nil, false, err
+			return nil, nil, false, err
 		}
 	}
 
@@ -1272,7 +1272,7 @@ func restorePlanHook(
 		var err error
 		subdir, err = exprEval.String(ctx, restoreStmt.Subdir)
 		if err != nil {
-			return nil, nil, nil, false, err
+			return nil, nil, false, err
 		}
 	} else {
 		// Deprecation notice for non-collection `RESTORE FROM` syntax. Remove this
@@ -1290,7 +1290,7 @@ func restorePlanHook(
 			ctx, tree.Exprs(restoreStmt.Options.IncrementalStorage),
 		)
 		if err != nil {
-			return nil, nil, nil, false, err
+			return nil, nil, false, err
 		}
 	}
 
@@ -1298,11 +1298,11 @@ func restorePlanHook(
 	if restoreStmt.Options.ExecutionLocality != nil {
 		loc, err := exprEval.String(ctx, restoreStmt.Options.ExecutionLocality)
 		if err != nil {
-			return nil, nil, nil, false, err
+			return nil, nil, false, err
 		}
 		if loc != "" {
 			if err := execLocality.Set(loc); err != nil {
-				return nil, nil, nil, false, err
+				return nil, nil, false, err
 			}
 		}
 	}
@@ -1313,20 +1313,20 @@ func restorePlanHook(
 			len(restoreStmt.Targets.Databases) != 1 {
 			err := errors.New("new_db_name can only be used for RESTORE DATABASE with a single target" +
 				" database")
-			return nil, nil, nil, false, err
+			return nil, nil, false, err
 		}
 		if restoreStmt.DescriptorCoverage == tree.SystemUsers {
-			return nil, nil, nil, false, errors.New("cannot set new_db_name option when only restoring system users")
+			return nil, nil, false, errors.New("cannot set new_db_name option when only restoring system users")
 		}
 		var err error
 		newDBName, err = exprEval.String(ctx, restoreStmt.Options.NewDBName)
 		if err != nil {
-			return nil, nil, nil, false, err
+			return nil, nil, false, err
 		}
 	}
 
 	if restoreStmt.Options.ExperimentalOnline && restoreStmt.Options.VerifyData {
-		return nil, nil, nil, false, errors.New("cannot run online restore with verify_backup_table_data")
+		return nil, nil, false, errors.New("cannot run online restore with verify_backup_table_data")
 	}
 
 	var newTenantID *roachpb.TenantID
@@ -1335,7 +1335,7 @@ func restorePlanHook(
 		if restoreStmt.DescriptorCoverage == tree.AllDescriptors || !restoreStmt.Targets.TenantID.IsSet() {
 			err := errors.Errorf("options %q/%q can only be used when running RESTORE TENANT for a single tenant",
 				restoreOptAsTenant, restoreOptForceTenantID)
-			return nil, nil, nil, false, err
+			return nil, nil, false, err
 		}
 
 		if restoreStmt.Options.ForceTenantID != nil {
@@ -1356,7 +1356,7 @@ func restorePlanHook(
 				return &tid, err
 			}()
 			if err != nil {
-				return nil, nil, nil, false, err
+				return nil, nil, false, err
 			}
 		}
 		if restoreStmt.Options.AsTenant != nil {
@@ -1373,13 +1373,13 @@ func restorePlanHook(
 				return &tn, nil
 			}()
 			if err != nil {
-				return nil, nil, nil, false, err
+				return nil, nil, false, err
 			}
 		}
 		if newTenantID == nil && newTenantName != nil {
 			id, err := p.GetAvailableTenantID(ctx, *newTenantName)
 			if err != nil {
-				return nil, nil, nil, false, err
+				return nil, nil, false, err
 			}
 			newTenantID = &id
 		}
@@ -1428,7 +1428,7 @@ func restorePlanHook(
 	} else {
 		header = jobs.BackupRestoreJobResultHeader
 	}
-	return fn, header, nil, false, nil
+	return fn, header, false, nil
 }
 
 // checkRestoreDestinationPrivileges iterates over the External Storage URIs and

--- a/pkg/backup/schedule_exec.go
+++ b/pkg/backup/schedule_exec.go
@@ -162,7 +162,7 @@ func invokeBackup(
 func planBackup(
 	ctx context.Context, p sql.PlanHookState, backupStmt tree.Statement,
 ) (sql.PlanHookRowFn, error) {
-	fn, cols, _, _, err := backupPlanHook(ctx, backupStmt, p)
+	fn, cols, _, err := backupPlanHook(ctx, backupStmt, p)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to evaluate backup stmt")
 	}

--- a/pkg/backup/schedule_exec.go
+++ b/pkg/backup/schedule_exec.go
@@ -152,7 +152,7 @@ func invokeBackup(
 	})
 
 	g.GoCtx(func(ctx context.Context) error {
-		return backupFn(ctx, nil, resultCh)
+		return backupFn(ctx, resultCh)
 	})
 
 	err := g.Wait()

--- a/pkg/backup/show.go
+++ b/pkg/backup/show.go
@@ -218,10 +218,10 @@ func showBackupTypeCheck(
 // showBackupPlanHook implements PlanHookFn.
 func showBackupPlanHook(
 	ctx context.Context, stmt tree.Statement, p sql.PlanHookState,
-) (sql.PlanHookRowFn, colinfo.ResultColumns, []sql.PlanNode, bool, error) {
+) (sql.PlanHookRowFn, colinfo.ResultColumns, bool, error) {
 	showStmt, ok := stmt.(*tree.ShowBackup)
 	if !ok {
-		return nil, nil, nil, false, nil
+		return nil, nil, false, nil
 	}
 	exprEval := p.ExprEvaluator("SHOW BACKUP")
 
@@ -229,35 +229,35 @@ func showBackupPlanHook(
 	if showStmt.Details == tree.BackupConnectionTest {
 		loc, err := exprEval.String(ctx, showStmt.Path)
 		if err != nil {
-			return nil, nil, nil, false, err
+			return nil, nil, false, err
 		}
 		var params cloudcheck.Params
 		if showStmt.Options.CheckConnectionTransferSize != nil {
 			transferSizeStr, err := exprEval.String(ctx, showStmt.Options.CheckConnectionTransferSize)
 			if err != nil {
-				return nil, nil, nil, false, err
+				return nil, nil, false, err
 			}
 			parsed, err := humanizeutil.ParseBytes(transferSizeStr)
 			if err != nil {
-				return nil, nil, nil, false, err
+				return nil, nil, false, err
 			}
 			params.TransferSize = parsed
 		}
 		if showStmt.Options.CheckConnectionDuration != nil {
 			durationStr, err := exprEval.String(ctx, showStmt.Options.CheckConnectionDuration)
 			if err != nil {
-				return nil, nil, nil, false, err
+				return nil, nil, false, err
 			}
 			parsed, err := time.ParseDuration(durationStr)
 			if err != nil {
-				return nil, nil, nil, false, err
+				return nil, nil, false, err
 			}
 			params.MinDuration = parsed
 		}
 		if showStmt.Options.CheckConnectionConcurrency != nil {
 			concurrency, err := exprEval.Int(ctx, showStmt.Options.CheckConnectionConcurrency)
 			if err != nil {
-				return nil, nil, nil, false, err
+				return nil, nil, false, err
 			}
 			params.Concurrency = concurrency
 		}
@@ -269,28 +269,28 @@ func showBackupPlanHook(
 			ctx, tree.Exprs(showStmt.InCollection),
 		)
 		if err != nil {
-			return nil, nil, nil, false, err
+			return nil, nil, false, err
 		}
 		return showBackupsInCollectionPlanHook(ctx, collection, showStmt, p)
 	}
 
 	to, err := exprEval.String(ctx, showStmt.Path)
 	if err != nil {
-		return nil, nil, nil, false, err
+		return nil, nil, false, err
 	}
 
 	var inCol []string
 	if showStmt.InCollection != nil {
 		inCol, err = exprEval.StringArray(ctx, tree.Exprs(showStmt.InCollection))
 		if err != nil {
-			return nil, nil, nil, false, err
+			return nil, nil, false, err
 		}
 	}
 
 	infoReader := getBackupInfoReader(p, showStmt)
 
 	if err != nil {
-		return nil, nil, nil, false, err
+		return nil, nil, false, err
 	}
 
 	fn := func(ctx context.Context, _ []sql.PlanNode, resultsCh chan<- tree.Datums) error {
@@ -540,7 +540,7 @@ you must pass the 'encryption_info_dir' parameter that points to the directory o
 		return nil
 	}
 
-	return fn, infoReader.header(), nil, false, nil
+	return fn, infoReader.header(), false, nil
 }
 
 func getBackupInfoReader(p sql.PlanHookState, showStmt *tree.ShowBackup) backupInfoReader {
@@ -1515,10 +1515,10 @@ var showBackupsInCollectionHeader = colinfo.ResultColumns{
 // showBackupPlanHook implements PlanHookFn.
 func showBackupsInCollectionPlanHook(
 	ctx context.Context, collection []string, showStmt *tree.ShowBackup, p sql.PlanHookState,
-) (sql.PlanHookRowFn, colinfo.ResultColumns, []sql.PlanNode, bool, error) {
+) (sql.PlanHookRowFn, colinfo.ResultColumns, bool, error) {
 
 	if err := cloudprivilege.CheckDestinationPrivileges(ctx, p, collection); err != nil {
-		return nil, nil, nil, false, err
+		return nil, nil, false, err
 	}
 
 	fn := func(ctx context.Context, _ []sql.PlanNode, resultsCh chan<- tree.Datums) error {
@@ -1539,7 +1539,7 @@ func showBackupsInCollectionPlanHook(
 		}
 		return nil
 	}
-	return fn, showBackupsInCollectionHeader, nil, false, nil
+	return fn, showBackupsInCollectionHeader, false, nil
 }
 
 func init() {

--- a/pkg/backup/show.go
+++ b/pkg/backup/show.go
@@ -293,7 +293,7 @@ func showBackupPlanHook(
 		return nil, nil, false, err
 	}
 
-	fn := func(ctx context.Context, _ []sql.PlanNode, resultsCh chan<- tree.Datums) error {
+	fn := func(ctx context.Context, resultsCh chan<- tree.Datums) error {
 		ctx, span := tracing.ChildSpan(ctx, stmt.StatementTag())
 		defer span.Finish()
 
@@ -1521,7 +1521,7 @@ func showBackupsInCollectionPlanHook(
 		return nil, nil, false, err
 	}
 
-	fn := func(ctx context.Context, _ []sql.PlanNode, resultsCh chan<- tree.Datums) error {
+	fn := func(ctx context.Context, resultsCh chan<- tree.Datums) error {
 		ctx, span := tracing.ChildSpan(ctx, showStmt.StatementTag())
 		defer span.Finish()
 

--- a/pkg/ccl/changefeedccl/alter_changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/alter_changefeed_stmt.go
@@ -82,7 +82,7 @@ func alterChangefeedPlanHook(
 		return nil, nil, false, nil
 	}
 
-	fn := func(ctx context.Context, _ []sql.PlanNode, resultsCh chan<- tree.Datums) error {
+	fn := func(ctx context.Context, resultsCh chan<- tree.Datums) error {
 		jobID, err := func() (jobspb.JobID, error) {
 			origProps := p.SemaCtx().Properties
 			p.SemaCtx().Properties.Require("cdc", tree.RejectSubqueries)

--- a/pkg/ccl/changefeedccl/alter_changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/alter_changefeed_stmt.go
@@ -76,10 +76,10 @@ var alterChangefeedHeader = colinfo.ResultColumns{
 // alterChangefeedPlanHook implements sql.PlanHookFn.
 func alterChangefeedPlanHook(
 	ctx context.Context, stmt tree.Statement, p sql.PlanHookState,
-) (sql.PlanHookRowFn, colinfo.ResultColumns, []sql.PlanNode, bool, error) {
+) (sql.PlanHookRowFn, colinfo.ResultColumns, bool, error) {
 	alterChangefeedStmt, ok := stmt.(*tree.AlterChangefeed)
 	if !ok {
-		return nil, nil, nil, false, nil
+		return nil, nil, false, nil
 	}
 
 	fn := func(ctx context.Context, _ []sql.PlanNode, resultsCh chan<- tree.Datums) error {
@@ -261,7 +261,7 @@ func alterChangefeedPlanHook(
 		}
 	}
 
-	return fn, alterChangefeedHeader, nil, false, nil
+	return fn, alterChangefeedHeader, false, nil
 }
 
 func getTargetDesc(

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -132,10 +132,10 @@ func changefeedTypeCheck(
 // changefeedPlanHook implements sql.planHookFn.
 func changefeedPlanHook(
 	ctx context.Context, stmt tree.Statement, p sql.PlanHookState,
-) (sql.PlanHookRowFn, colinfo.ResultColumns, []sql.PlanNode, bool, error) {
+) (sql.PlanHookRowFn, colinfo.ResultColumns, bool, error) {
 	changefeedStmt := getChangefeedStatement(stmt)
 	if changefeedStmt == nil {
-		return nil, nil, nil, false, nil
+		return nil, nil, false, nil
 	}
 
 	exprEval := p.ExprEvaluator("CREATE CHANGEFEED")
@@ -157,11 +157,11 @@ func changefeedPlanHook(
 		var err error
 		sinkURI, err = exprEval.String(ctx, changefeedStmt.SinkURI)
 		if err != nil {
-			return nil, nil, nil, false, changefeedbase.MarkTaggedError(err, changefeedbase.UserInput)
+			return nil, nil, false, changefeedbase.MarkTaggedError(err, changefeedbase.UserInput)
 		}
 		if sinkURI == `` {
 			// Error if someone specifies an INTO with the empty string.
-			return nil, nil, nil, false, errors.New(`omit the SINK clause for inline results`)
+			return nil, nil, false, errors.New(`omit the SINK clause for inline results`)
 		}
 		header = withSinkHeader
 	}
@@ -170,13 +170,13 @@ func changefeedPlanHook(
 		ctx, changefeedStmt.Options, changefeedvalidators.CreateOptionValidations,
 	)
 	if err != nil {
-		return nil, nil, nil, false, err
+		return nil, nil, false, err
 	}
 	opts := changefeedbase.MakeStatementOptions(rawOpts)
 
 	description, err := makeChangefeedDescription(ctx, changefeedStmt.CreateChangefeed, sinkURI, opts)
 	if err != nil {
-		return nil, nil, nil, false, err
+		return nil, nil, false, err
 	}
 
 	// rowFn implements sql.PlanHookRowFn.
@@ -329,7 +329,7 @@ func changefeedPlanHook(
 		}
 		return err
 	}
-	return rowFnLogErrors, header, nil, avoidBuffering, nil
+	return rowFnLogErrors, header, avoidBuffering, nil
 }
 
 func coreChangefeed(

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -180,7 +180,7 @@ func changefeedPlanHook(
 	}
 
 	// rowFn implements sql.PlanHookRowFn.
-	rowFn := func(ctx context.Context, _ []sql.PlanNode, resultsCh chan<- tree.Datums) error {
+	rowFn := func(ctx context.Context, resultsCh chan<- tree.Datums) error {
 		ctx, span := tracing.ChildSpan(ctx, stmt.StatementTag())
 		defer span.Finish()
 		st, err := opts.GetInitialScanType()
@@ -322,8 +322,8 @@ func changefeedPlanHook(
 		}
 	}
 
-	rowFnLogErrors := func(ctx context.Context, pn []sql.PlanNode, resultsCh chan<- tree.Datums) error {
-		err := rowFn(ctx, pn, resultsCh)
+	rowFnLogErrors := func(ctx context.Context, resultsCh chan<- tree.Datums) error {
+		err := rowFn(ctx, resultsCh)
 		if err != nil {
 			logChangefeedFailedTelemetryDuringStartup(ctx, description, failureTypeForStartupError(err))
 		}

--- a/pkg/ccl/changefeedccl/scheduled_changefeed.go
+++ b/pkg/ccl/changefeedccl/scheduled_changefeed.go
@@ -442,7 +442,7 @@ func dryRunCreateChangefeed(
 func planCreateChangefeed(
 	ctx context.Context, p sql.PlanHookState, createChangefeedStmt tree.Statement,
 ) (sql.PlanHookRowFn, error) {
-	fn, cols, _, _, err := changefeedPlanHook(ctx, createChangefeedStmt, p)
+	fn, cols, _, err := changefeedPlanHook(ctx, createChangefeedStmt, p)
 
 	if err != nil {
 		return nil, errors.Wrapf(err, "changefeed table eval: %q", tree.AsString(createChangefeedStmt))
@@ -669,15 +669,15 @@ func doCreateChangefeedSchedule(
 
 func createChangefeedScheduleHook(
 	ctx context.Context, stmt tree.Statement, p sql.PlanHookState,
-) (sql.PlanHookRowFn, colinfo.ResultColumns, []sql.PlanNode, bool, error) {
+) (sql.PlanHookRowFn, colinfo.ResultColumns, bool, error) {
 	schedule, ok := stmt.(*tree.ScheduledChangefeed)
 	if !ok {
-		return nil, nil, nil, false, nil
+		return nil, nil, false, nil
 	}
 
 	spec, err := makeScheduledChangefeedSpec(ctx, p, schedule)
 	if err != nil {
-		return nil, nil, nil, false, err
+		return nil, nil, false, err
 	}
 
 	fn := func(ctx context.Context, _ []sql.PlanNode, resultsCh chan<- tree.Datums) error {
@@ -689,7 +689,7 @@ func createChangefeedScheduleHook(
 		return nil
 	}
 
-	return fn, headerCols, nil, false, nil
+	return fn, headerCols, false, nil
 }
 
 func createChangefeedScheduleTypeCheck(

--- a/pkg/ccl/changefeedccl/scheduled_changefeed.go
+++ b/pkg/ccl/changefeedccl/scheduled_changefeed.go
@@ -470,7 +470,7 @@ func invokeCreateChangefeed(ctx context.Context, createChangefeedFn sql.PlanHook
 	})
 
 	g.GoCtx(func(ctx context.Context) error {
-		return createChangefeedFn(ctx, nil, resultCh)
+		return createChangefeedFn(ctx, resultCh)
 	})
 
 	return g.Wait()
@@ -680,7 +680,7 @@ func createChangefeedScheduleHook(
 		return nil, nil, false, err
 	}
 
-	fn := func(ctx context.Context, _ []sql.PlanNode, resultsCh chan<- tree.Datums) error {
+	fn := func(ctx context.Context, resultsCh chan<- tree.Datums) error {
 		err := doCreateChangefeedSchedule(ctx, p, spec, resultsCh)
 		if err != nil {
 			telemetry.Count("scheduled-changefeed.create.failed")

--- a/pkg/cloud/cloudcheck/cloudcheck_stmt.go
+++ b/pkg/cloud/cloudcheck/cloudcheck_stmt.go
@@ -39,10 +39,10 @@ type Params = execinfrapb.CloudStorageTestSpec_Params
 // should be extended to be a standalone plan instead.
 func ShowCloudStorageTestPlanHook(
 	ctx context.Context, p sql.PlanHookState, location string, params Params,
-) (sql.PlanHookRowFn, colinfo.ResultColumns, []sql.PlanNode, bool, error) {
+) (sql.PlanHookRowFn, colinfo.ResultColumns, bool, error) {
 
 	if err := cloudprivilege.CheckDestinationPrivileges(ctx, p, []string{location}); err != nil {
-		return nil, nil, nil, false, err
+		return nil, nil, false, err
 	}
 
 	fn := func(ctx context.Context, _ []sql.PlanNode, resultsCh chan<- tree.Datums) error {
@@ -106,5 +106,5 @@ func ShowCloudStorageTestPlanHook(
 		dsp.Run(ctx, planCtx, nil, plan, recv, &evalCtxCopy, nil /* finishedSetupFn */)
 		return rowResultWriter.Err()
 	}
-	return fn, Header, nil, false, nil
+	return fn, Header, false, nil
 }

--- a/pkg/cloud/cloudcheck/cloudcheck_stmt.go
+++ b/pkg/cloud/cloudcheck/cloudcheck_stmt.go
@@ -45,7 +45,7 @@ func ShowCloudStorageTestPlanHook(
 		return nil, nil, false, err
 	}
 
-	fn := func(ctx context.Context, _ []sql.PlanNode, resultsCh chan<- tree.Datums) error {
+	fn := func(ctx context.Context, resultsCh chan<- tree.Datums) error {
 		ctx, span := tracing.ChildSpan(ctx, "ShowCloudStorageTestPlanHook")
 		defer span.Finish()
 

--- a/pkg/crosscluster/logical/create_logical_replication_stmt.go
+++ b/pkg/crosscluster/logical/create_logical_replication_stmt.go
@@ -56,17 +56,17 @@ var streamCreationHeader = colinfo.ResultColumns{
 
 func createLogicalReplicationStreamPlanHook(
 	ctx context.Context, untypedStmt tree.Statement, p sql.PlanHookState,
-) (sql.PlanHookRowFn, colinfo.ResultColumns, []sql.PlanNode, bool, error) {
+) (sql.PlanHookRowFn, colinfo.ResultColumns, bool, error) {
 	stmt, ok := untypedStmt.(*tree.CreateLogicalReplicationStream)
 	if !ok {
-		return nil, nil, nil, false, nil
+		return nil, nil, false, nil
 	}
 
 	exprEval := p.ExprEvaluator("LOGICAL REPLICATION STREAM")
 
 	from, err := exprEval.String(ctx, stmt.PGURL)
 	if err != nil {
-		return nil, nil, nil, false, err
+		return nil, nil, false, err
 	}
 
 	fn := func(ctx context.Context, _ []sql.PlanNode, resultsCh chan<- tree.Datums) (retErr error) {
@@ -279,7 +279,7 @@ func createLogicalReplicationStreamPlanHook(
 		return nil
 	}
 
-	return fn, streamCreationHeader, nil, false, nil
+	return fn, streamCreationHeader, false, nil
 }
 
 type ResolvedDestObjects struct {

--- a/pkg/crosscluster/logical/create_logical_replication_stmt.go
+++ b/pkg/crosscluster/logical/create_logical_replication_stmt.go
@@ -69,7 +69,7 @@ func createLogicalReplicationStreamPlanHook(
 		return nil, nil, false, err
 	}
 
-	fn := func(ctx context.Context, _ []sql.PlanNode, resultsCh chan<- tree.Datums) (retErr error) {
+	fn := func(ctx context.Context, resultsCh chan<- tree.Datums) (retErr error) {
 		defer func() {
 			if retErr == nil {
 				telemetry.Count("logical_replication_stream.started")

--- a/pkg/crosscluster/physical/alter_replication_job.go
+++ b/pkg/crosscluster/physical/alter_replication_job.go
@@ -153,14 +153,14 @@ func alterReplicationJobTypeCheck(
 
 func alterReplicationJobHook(
 	ctx context.Context, stmt tree.Statement, p sql.PlanHookState,
-) (sql.PlanHookRowFn, colinfo.ResultColumns, []sql.PlanNode, bool, error) {
+) (sql.PlanHookRowFn, colinfo.ResultColumns, bool, error) {
 	alterTenantStmt, ok := stmt.(*tree.AlterTenantReplication)
 	if !ok {
-		return nil, nil, nil, false, nil
+		return nil, nil, false, nil
 	}
 
 	if !p.ExecCfg().Codec.ForSystemTenant() {
-		return nil, nil, nil, false, pgerror.Newf(pgcode.InsufficientPrivilege,
+		return nil, nil, false, pgerror.Newf(pgcode.InsufficientPrivilege,
 			"only the system tenant can alter tenant")
 	}
 
@@ -169,13 +169,13 @@ func alterReplicationJobHook(
 	if alterTenantStmt.Cutover != nil {
 		if !alterTenantStmt.Cutover.Latest {
 			if alterTenantStmt.Cutover.Timestamp == nil {
-				return nil, nil, nil, false, errors.AssertionFailedf("unexpected nil cutover expression")
+				return nil, nil, false, errors.AssertionFailedf("unexpected nil cutover expression")
 			}
 
 			ct, err := asof.EvalSystemTimeExpr(ctx, evalCtx, p.SemaCtx(), alterTenantStmt.Cutover.Timestamp,
 				alterReplicationJobOp, asof.ReplicationCutover)
 			if err != nil {
-				return nil, nil, nil, false, err
+				return nil, nil, false, err
 			}
 			cutoverTime = ct
 		}
@@ -184,26 +184,26 @@ func alterReplicationJobHook(
 	exprEval := p.ExprEvaluator(alterReplicationJobOp)
 	options, err := evalTenantReplicationOptions(ctx, alterTenantStmt.Options, exprEval, evalCtx, p.SemaCtx(), alterReplicationJobOp)
 	if err != nil {
-		return nil, nil, nil, false, err
+		return nil, nil, false, err
 	}
 
 	var srcAddr, srcTenant string
 	if alterTenantStmt.ReplicationSourceAddress != nil {
 		srcAddr, err = exprEval.String(ctx, alterTenantStmt.ReplicationSourceAddress)
 		if err != nil {
-			return nil, nil, nil, false, err
+			return nil, nil, false, err
 		}
 
 		_, _, srcTenant, err = exprEval.TenantSpec(ctx, alterTenantStmt.ReplicationSourceTenantName)
 		if err != nil {
-			return nil, nil, nil, false, err
+			return nil, nil, false, err
 		}
 	}
 
 	// Ensure the TenantSpec is type checked, even if we don't use the result.
 	_, _, _, err = exprEval.TenantSpec(ctx, alterTenantStmt.TenantSpec)
 	if err != nil {
-		return nil, nil, nil, false, err
+		return nil, nil, false, err
 	}
 
 	retentionTTLSeconds := defaultRetentionTTLSeconds
@@ -280,9 +280,9 @@ func alterReplicationJobHook(
 		return nil
 	}
 	if alterTenantStmt.Cutover != nil {
-		return fn, alterReplicationCutoverHeader, nil, false, nil
+		return fn, alterReplicationCutoverHeader, false, nil
 	}
-	return fn, nil, nil, false, nil
+	return fn, nil, false, nil
 }
 
 func alterTenantSetReplication(

--- a/pkg/crosscluster/physical/alter_replication_job.go
+++ b/pkg/crosscluster/physical/alter_replication_job.go
@@ -211,7 +211,7 @@ func alterReplicationJobHook(
 		retentionTTLSeconds = ret
 	}
 
-	fn := func(ctx context.Context, _ []sql.PlanNode, resultsCh chan<- tree.Datums) error {
+	fn := func(ctx context.Context, resultsCh chan<- tree.Datums) error {
 		if err := utilccl.CheckEnterpriseEnabled(
 			p.ExecCfg().Settings,
 			alterReplicationJobOp,

--- a/pkg/crosscluster/physical/stream_ingestion_planning.go
+++ b/pkg/crosscluster/physical/stream_ingestion_planning.go
@@ -80,14 +80,14 @@ func ingestionTypeCheck(
 
 func ingestionPlanHook(
 	ctx context.Context, stmt tree.Statement, p sql.PlanHookState,
-) (sql.PlanHookRowFn, colinfo.ResultColumns, []sql.PlanNode, bool, error) {
+) (sql.PlanHookRowFn, colinfo.ResultColumns, bool, error) {
 	ingestionStmt, ok := stmt.(*tree.CreateTenantFromReplication)
 	if !ok {
-		return nil, nil, nil, false, nil
+		return nil, nil, false, nil
 	}
 
 	if !p.ExecCfg().Codec.ForSystemTenant() {
-		return nil, nil, nil, false, pgerror.Newf(pgcode.InsufficientPrivilege,
+		return nil, nil, false, pgerror.Newf(pgcode.InsufficientPrivilege,
 			"only the system tenant can create other tenants")
 	}
 
@@ -95,30 +95,30 @@ func ingestionPlanHook(
 
 	from, err := exprEval.String(ctx, ingestionStmt.ReplicationSourceAddress)
 	if err != nil {
-		return nil, nil, nil, false, err
+		return nil, nil, false, err
 	}
 
 	_, _, sourceTenant, err := exprEval.TenantSpec(ctx, ingestionStmt.ReplicationSourceTenantName)
 	if err != nil {
-		return nil, nil, nil, false, err
+		return nil, nil, false, err
 	}
 
 	_, dstTenantID, dstTenantName, err := exprEval.TenantSpec(ctx, ingestionStmt.TenantSpec)
 	if err != nil {
-		return nil, nil, nil, false, err
+		return nil, nil, false, err
 	}
 
 	evalCtx := &p.ExtendedEvalContext().Context
 	options, err := evalTenantReplicationOptions(ctx, ingestionStmt.Options, exprEval, evalCtx, p.SemaCtx(), createReplicationOp)
 	if err != nil {
-		return nil, nil, nil, false, err
+		return nil, nil, false, err
 	}
 	retentionTTLSeconds := defaultRetentionTTLSeconds
 	if ret, ok := options.GetRetention(); ok {
 		retentionTTLSeconds = ret
 	}
 	if _, ok := options.GetExpirationWindow(); ok {
-		return nil, nil, nil, false, CannotSetExpirationWindowErr
+		return nil, nil, false, CannotSetExpirationWindowErr
 	}
 
 	fn := func(ctx context.Context, _ []sql.PlanNode, _ chan<- tree.Datums) (err error) {
@@ -211,7 +211,7 @@ func ingestionPlanHook(
 		)
 	}
 
-	return fn, nil, nil, false, nil
+	return fn, nil, false, nil
 }
 
 func createReplicationJob(

--- a/pkg/crosscluster/physical/stream_ingestion_planning.go
+++ b/pkg/crosscluster/physical/stream_ingestion_planning.go
@@ -121,7 +121,7 @@ func ingestionPlanHook(
 		return nil, nil, false, CannotSetExpirationWindowErr
 	}
 
-	fn := func(ctx context.Context, _ []sql.PlanNode, _ chan<- tree.Datums) (err error) {
+	fn := func(ctx context.Context, _ chan<- tree.Datums) (err error) {
 		defer func() {
 			if err == nil {
 				telemetry.Count("physical_replication.started")

--- a/pkg/jobs/jobs_test.go
+++ b/pkg/jobs/jobs_test.go
@@ -2300,10 +2300,10 @@ func TestJobInTxn(t *testing.T) {
 	sql.AddPlanHook(
 		"test",
 		func(_ context.Context, stmt tree.Statement, execCtx sql.PlanHookState,
-		) (sql.PlanHookRowFn, colinfo.ResultColumns, []sql.PlanNode, bool, error) {
+		) (sql.PlanHookRowFn, colinfo.ResultColumns, bool, error) {
 			st, ok := stmt.(*tree.Backup)
 			if !ok {
-				return nil, nil, nil, false, nil
+				return nil, nil, false, nil
 			}
 			fn := func(ctx context.Context, _ []sql.PlanNode, _ chan<- tree.Datums) error {
 				var err error
@@ -2315,7 +2315,7 @@ func TestJobInTxn(t *testing.T) {
 				})
 				return err
 			}
-			return fn, nil, nil, false, nil
+			return fn, nil, false, nil
 		},
 		func(_ context.Context, stmt tree.Statement, execCtx sql.PlanHookState,
 		) (matched bool, _ colinfo.ResultColumns, _ error) {
@@ -2342,10 +2342,10 @@ func TestJobInTxn(t *testing.T) {
 	sql.AddPlanHook(
 		"test",
 		func(_ context.Context, stmt tree.Statement, execCtx sql.PlanHookState,
-		) (sql.PlanHookRowFn, colinfo.ResultColumns, []sql.PlanNode, bool, error) {
+		) (sql.PlanHookRowFn, colinfo.ResultColumns, bool, error) {
 			_, ok := stmt.(*tree.Restore)
 			if !ok {
-				return nil, nil, nil, false, nil
+				return nil, nil, false, nil
 			}
 			fn := func(ctx context.Context, _ []sql.PlanNode, _ chan<- tree.Datums) error {
 				var err error
@@ -2357,7 +2357,7 @@ func TestJobInTxn(t *testing.T) {
 				})
 				return err
 			}
-			return fn, nil, nil, false, nil
+			return fn, nil, false, nil
 		},
 		func(_ context.Context, stmt tree.Statement, execCtx sql.PlanHookState,
 		) (matched bool, _ colinfo.ResultColumns, _ error) {

--- a/pkg/jobs/jobs_test.go
+++ b/pkg/jobs/jobs_test.go
@@ -2305,7 +2305,7 @@ func TestJobInTxn(t *testing.T) {
 			if !ok {
 				return nil, nil, false, nil
 			}
-			fn := func(ctx context.Context, _ []sql.PlanNode, _ chan<- tree.Datums) error {
+			fn := func(ctx context.Context, _ chan<- tree.Datums) error {
 				var err error
 				jobID = execCtx.ExtendedEvalContext().QueueJob(&jobs.Record{
 					Description: st.String(),
@@ -2347,7 +2347,7 @@ func TestJobInTxn(t *testing.T) {
 			if !ok {
 				return nil, nil, false, nil
 			}
-			fn := func(ctx context.Context, _ []sql.PlanNode, _ chan<- tree.Datums) error {
+			fn := func(ctx context.Context, _ chan<- tree.Datums) error {
 				var err error
 				jobID = execCtx.ExtendedEvalContext().QueueJob(&jobs.Record{
 					Description: "RESTORE",

--- a/pkg/revert/alter_reset_tenant.go
+++ b/pkg/revert/alter_reset_tenant.go
@@ -38,7 +38,7 @@ func alterTenantResetHook(
 		return nil, nil, false, err
 	}
 
-	fn := func(ctx context.Context, _ []sql.PlanNode, resultsCh chan<- tree.Datums) error {
+	fn := func(ctx context.Context, resultsCh chan<- tree.Datums) error {
 		if err := sql.CanManageTenant(ctx, p); err != nil {
 			return err
 		}

--- a/pkg/revert/alter_reset_tenant.go
+++ b/pkg/revert/alter_reset_tenant.go
@@ -23,19 +23,19 @@ const (
 
 func alterTenantResetHook(
 	ctx context.Context, stmt tree.Statement, p sql.PlanHookState,
-) (sql.PlanHookRowFn, colinfo.ResultColumns, []sql.PlanNode, bool, error) {
+) (sql.PlanHookRowFn, colinfo.ResultColumns, bool, error) {
 	alterTenantStmt, ok := stmt.(*tree.AlterTenantReset)
 	if !ok {
-		return nil, nil, nil, false, nil
+		return nil, nil, false, nil
 	}
 	if !p.ExecCfg().Codec.ForSystemTenant() {
-		return nil, nil, nil, false, pgerror.Newf(pgcode.InsufficientPrivilege, "only the system tenant can alter tenant")
+		return nil, nil, false, pgerror.Newf(pgcode.InsufficientPrivilege, "only the system tenant can alter tenant")
 	}
 
 	timestamp, err := asof.EvalSystemTimeExpr(ctx, &p.ExtendedEvalContext().Context, p.SemaCtx(), alterTenantStmt.Timestamp,
 		alterTenantResetOp, asof.ReplicationCutover)
 	if err != nil {
-		return nil, nil, nil, false, err
+		return nil, nil, false, err
 	}
 
 	fn := func(ctx context.Context, _ []sql.PlanNode, resultsCh chan<- tree.Datums) error {
@@ -49,7 +49,7 @@ func alterTenantResetHook(
 		}
 		return RevertTenantToTimestamp(ctx, &p.ExtendedEvalContext().Context, tenInfo.Name, timestamp, p.ExtendedEvalContext().SessionID)
 	}
-	return fn, nil, nil, false, nil
+	return fn, nil, false, nil
 }
 
 func alterTenantResetHookTypeCheck(

--- a/pkg/sql/importer/import_planning.go
+++ b/pkg/sql/importer/import_planning.go
@@ -417,7 +417,7 @@ func importPlanHook(
 		}
 	}
 
-	fn := func(ctx context.Context, _ []sql.PlanNode, resultsCh chan<- tree.Datums) error {
+	fn := func(ctx context.Context, resultsCh chan<- tree.Datums) error {
 		// TODO(dan): Move this span into sql.
 		ctx, span := tracing.ChildSpan(ctx, importStmt.StatementTag())
 		defer span.Finish()

--- a/pkg/sql/importer/import_planning.go
+++ b/pkg/sql/importer/import_planning.go
@@ -352,10 +352,10 @@ func importTypeCheck(
 // importPlanHook implements sql.PlanHookFn.
 func importPlanHook(
 	ctx context.Context, stmt tree.Statement, p sql.PlanHookState,
-) (sql.PlanHookRowFn, colinfo.ResultColumns, []sql.PlanNode, bool, error) {
+) (sql.PlanHookRowFn, colinfo.ResultColumns, bool, error) {
 	importStmt, ok := stmt.(*tree.Import)
 	if !ok {
-		return nil, nil, nil, false, nil
+		return nil, nil, false, nil
 	}
 
 	if !importStmt.Bundle && !importStmt.Into {
@@ -379,7 +379,7 @@ func importPlanHook(
 		featureImportEnabled,
 		"IMPORT",
 	); err != nil {
-		return nil, nil, nil, false, err
+		return nil, nil, false, err
 	}
 
 	exprEval := p.ExprEvaluator("IMPORT")
@@ -387,7 +387,7 @@ func importPlanHook(
 		ctx, importStmt.Options, importOptionExpectValues,
 	)
 	if err != nil {
-		return nil, nil, nil, false, err
+		return nil, nil, false, err
 	}
 
 	var isDetached bool
@@ -397,7 +397,7 @@ func importPlanHook(
 
 	filenamePatterns, err := exprEval.StringArray(ctx, importStmt.Files)
 	if err != nil {
-		return nil, nil, nil, false, err
+		return nil, nil, false, err
 	}
 
 	// Certain ExternalStorage URIs require super-user access. Check all the
@@ -410,10 +410,10 @@ func importPlanHook(
 			if _, workloadErr := parseWorkloadConfig(file); workloadErr == nil {
 				continue
 			}
-			return nil, nil, nil, false, err
+			return nil, nil, false, err
 		}
 		if err := cloudprivilege.CheckDestinationPrivileges(ctx, p, []string{file}); err != nil {
-			return nil, nil, nil, false, err
+			return nil, nil, false, err
 		}
 	}
 
@@ -1030,9 +1030,9 @@ func importPlanHook(
 	}
 
 	if isDetached {
-		return fn, jobs.DetachedJobExecutionResultHeader, nil, false, nil
+		return fn, jobs.DetachedJobExecutionResultHeader, false, nil
 	}
-	return fn, jobs.BulkJobExecutionResultHeader, nil, false, nil
+	return fn, jobs.BulkJobExecutionResultHeader, false, nil
 }
 
 func parseAvroOptions(

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -584,13 +584,13 @@ func (p *planner) maybePlanHook(ctx context.Context, stmt tree.Statement) (planN
 			}, header, nil /* subplans */, p.execCfg.Stopper), nil
 		}
 
-		if fn, header, subplans, avoidBuffering, err := planHook.fn(ctx, stmt, p); err != nil {
+		if fn, header, avoidBuffering, err := planHook.fn(ctx, stmt, p); err != nil {
 			return nil, err
 		} else if fn != nil {
 			if avoidBuffering {
 				p.curPlan.avoidBuffering = true
 			}
-			return newHookFnNode(planHook.name, fn, header, subplans, p.execCfg.Stopper), nil
+			return newHookFnNode(planHook.name, fn, header, nil /* subplans */, p.execCfg.Stopper), nil
 		}
 	}
 	return nil, nil

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -576,7 +576,7 @@ func (p *planner) maybePlanHook(ctx context.Context, stmt tree.Statement) (planN
 			if !matched {
 				continue
 			}
-			return newHookFnNode(planHook.name, func(ctx context.Context, nodes []planNode, datums chan<- tree.Datums) error {
+			return newHookFnNode(planHook.name, func(ctx context.Context, datums chan<- tree.Datums) error {
 				return errors.AssertionFailedf(
 					"cannot execute prepared %v statement",
 					planHook.name,

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -581,7 +581,7 @@ func (p *planner) maybePlanHook(ctx context.Context, stmt tree.Statement) (planN
 					"cannot execute prepared %v statement",
 					planHook.name,
 				)
-			}, header, nil /* subplans */, p.execCfg.Stopper), nil
+			}, header, p.execCfg.Stopper), nil
 		}
 
 		if fn, header, avoidBuffering, err := planHook.fn(ctx, stmt, p); err != nil {
@@ -590,7 +590,7 @@ func (p *planner) maybePlanHook(ctx context.Context, stmt tree.Statement) (planN
 			if avoidBuffering {
 				p.curPlan.avoidBuffering = true
 			}
-			return newHookFnNode(planHook.name, fn, header, nil /* subplans */, p.execCfg.Stopper), nil
+			return newHookFnNode(planHook.name, fn, header, p.execCfg.Stopper), nil
 		}
 	}
 	return nil, nil

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -138,9 +138,6 @@ type mutationPlanNode interface {
 	rowsWritten() int64
 }
 
-// PlanNode is the exported name for planNode. Useful for CCL hooks.
-type PlanNode = planNode
-
 // planNodeFastPath is implemented by nodes that can perform all their
 // work during startPlan(), possibly affecting even multiple rows. For
 // example, DELETE can do this.

--- a/pkg/sql/planhook.go
+++ b/pkg/sql/planhook.go
@@ -38,13 +38,11 @@ import (
 //
 // To intercept a statement the function should return a non-nil function for
 // `fn` as well as the appropriate sqlbase.ResultColumns describing the results
-// it will return (if any). If the hook plan requires sub-plans to be planned
-// and started by the usual machinery (e.g. to run a subquery), it must return
-// then as well. `fn` will be called in a goroutine during the `Start` phase of
-// plan execution.
+// it will return (if any). `fn` will be called in a goroutine during the
+// `Start` phase of plan execution.
 type planHookFn func(
 	context.Context, tree.Statement, PlanHookState,
-) (fn PlanHookRowFn, header colinfo.ResultColumns, subplans []planNode, avoidBuffering bool, err error)
+) (fn PlanHookRowFn, header colinfo.ResultColumns, avoidBuffering bool, err error)
 
 // PlanHookTypeCheckFn is a function that can intercept a statement being
 // prepared and type check its arguments. It exists in parallel to PlanHookFn.

--- a/pkg/sql/planhook.go
+++ b/pkg/sql/planhook.go
@@ -63,11 +63,10 @@ type PlanHookTypeCheckFn func(
 // PlanHookRowFn describes the row-production for hook-created plans. The
 // channel argument is used to return results to the plan's runner. It's
 // a blocking channel, so implementors should be careful to only use blocking
-// sends on it when necessary. Any subplans returned by the hook when initially
-// called are passed back, planned and started, for the RowFn's use.
+// sends on it when necessary.
 //
 // TODO(dt): should this take runParams like a normal planNode.Next?
-type PlanHookRowFn func(context.Context, []planNode, chan<- tree.Datums) error
+type PlanHookRowFn func(context.Context, chan<- tree.Datums) error
 
 type planHook struct {
 	name      string
@@ -190,7 +189,7 @@ func (f *hookFnNode) startExec(params runParams) error {
 			SpanOpt:  stop.ChildSpan,
 		},
 		func(ctx context.Context) {
-			err := f.f(ctx, f.subplans, f.run.resultsCh)
+			err := f.f(ctx, f.run.resultsCh)
 			select {
 			case <-ctx.Done():
 			case f.run.errCh <- err:


### PR DESCRIPTION
#### sql: remove unused subplans return value of planHookFn

Release note: None

#### sql: remove unused []planNode parameter of PlanHookRowFn

Release note: None

#### sql: remove unused subplans field of hookFnNode

Release note: None

#### sql: remove unused PlanNode type alias

Epic: None

Release note: None
