### PR TITLE
release-23.2: scbuild: block adding UNIQUE json col in mixed version state

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -3641,3 +3641,14 @@ statement ok
 SET use_declarative_schema_changer = $use_decl_sc;
 
 subtest end
+
+subtest block_json_unique_in_mixed_version
+
+statement ok
+CREATE TABLE t136790 (a INT PRIMARY KEY)
+
+onlyif config local-mixed-23.1
+statement error column b is of type jsonb and thus is not indexable
+ALTER TABLE t136790 ADD COLUMN b JSONB UNIQUE
+
+subtest end

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_add_column.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_add_column.go
@@ -160,9 +160,11 @@ func alterTableAddColumn(
 		maybeFailOnCrossDBTypeReference(b, typeID, tableNamespace.DatabaseID)
 	}
 	// Block unique indexes on unsupported types.
+	version := b.EvalCtx().Settings.Version.ActiveVersion(b)
 	if d.Unique.IsUnique &&
 		!d.Unique.WithoutIndex &&
-		!colinfo.ColumnTypeIsIndexable(spec.colType.Type) {
+		(!colinfo.ColumnTypeIsIndexable(spec.colType.Type) ||
+			(spec.colType.Type.Family() == types.JsonFamily && !version.IsActive(clusterversion.V23_2))) {
 		typInfo := spec.colType.Type.DebugString()
 		panic(unimplemented.NewWithIssueDetailf(35730, typInfo,
 			"column %s is of type %s and thus is not indexable",


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/136790
Release justification: low risk bug fix
Release note (bug fix): A new column of type JSON or JSONB and that has a UNIQUE constraint will now be blocked from being added to a table if the cluster has not yet finalized the upgrade to v23.2.