### PR TITLE
release-24.3: rolemembershipcache: fix timestamp calculation in RunAtCacheReadTS

### DIFF
--- a/pkg/sql/authorization.go
+++ b/pkg/sql/authorization.go
@@ -88,7 +88,11 @@ func (m *MembershipCache) RunAtCacheReadTS(
 		if tableDesc.IsUncommittedVersion() {
 			return
 		}
-		if tableDesc.GetVersion() != m.tableVersion {
+		if tableDesc.GetVersion() > m.tableVersion {
+			return
+		}
+		if tableDesc.GetVersion() < m.tableVersion {
+			readTS = tableDesc.GetModificationTime()
 			return
 		}
 		// The cached ts could be from long ago, so use the table modification


### PR DESCRIPTION
Backport 1/1 commits from #137852.

/cc @cockroachdb/release

Release justification: low risk bug fix 

---

If the transaction has an older version of the role_members table than the version the cache has, then it should use a historical read rather then reading the latest data.

This fixed an exceedingly rare bug that could happen if pg_roles was scanned at the exact same time as a different transaction ran CREATE ROLE.

fixes https://github.com/cockroachdb/cockroach/issues/137747
fixes https://github.com/cockroachdb/cockroach/issues/137812
fixes https://github.com/cockroachdb/cockroach/issues/136712
fixes https://github.com/cockroachdb/cockroach/issues/137077
fixes https://github.com/cockroachdb/cockroach/issues/137664
fixes https://github.com/cockroachdb/cockroach/issues/136555
fixes https://github.com/cockroachdb/cockroach/issues/136983
fixes https://github.com/cockroachdb/cockroach/issues/136981
fixes https://github.com/cockroachdb/cockroach/issues/136948
Release note: None
