### PR TITLE
sql: Check for concurrent DSC job in legacy schema changer

### DIFF
--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -46,6 +46,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/regionliveness"
 	"github.com/cockroachdb/cockroach/pkg/sql/regions"
+	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scerrors"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/catid"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -797,6 +798,13 @@ func (sc *SchemaChanger) exec(ctx context.Context) (retErr error) {
 	}
 	if err := sc.checkForMVCCCompliantAddIndexMutations(ctx, desc); err != nil {
 		return err
+	}
+	// Check that the DSC is not active for this descriptor.
+	if catalog.HasConcurrentDeclarativeSchemaChange(desc) {
+		log.Infof(ctx,
+			"aborting legacy schema change job execution because DSC was already active for %q (%d)",
+			desc.GetName(), desc.GetID())
+		return scerrors.ConcurrentSchemaChangeError(desc)
 	}
 
 	log.Infof(ctx,
@@ -3162,7 +3170,8 @@ func (sc *SchemaChanger) applyZoneConfigChangeForMutation(
 func DeleteTableDescAndZoneConfig(
 	ctx context.Context, execCfg *ExecutorConfig, tableDesc catalog.TableDescriptor,
 ) error {
-	log.Infof(ctx, "removing table descriptor and zone config for table %d", tableDesc.GetID())
+	log.Infof(ctx, "removing table descriptor and zone config for table %d (has active dsc=%t)",
+		tableDesc.GetID(), catalog.HasConcurrentDeclarativeSchemaChange(tableDesc))
 	const kvTrace = false
 	return DescsTxn(ctx, execCfg, func(ctx context.Context, txn isql.Txn, col *descs.Collection) error {
 		b := txn.KV().NewBatch()


### PR DESCRIPTION
Running the legacy schema changer and the declarative schema changer concurrently can cause issues due to their different approaches to updating descriptors. Normally we have checks to prevent the legacy schema changer from running in such scenarios, timing issues persisted—particularly between `ALTER VIEW .. RENAME` (legacy) and `DROP VIEW` (DSC). In these cases, the view rename could delete the descriptor being processed by the drop view operation.

This change addresses the timing issue by adding a check for an active DSC job at the start of the legacy schema changer job. With this fix, the issue could no longer be reproduced, whereas it was consistently reproducible before.

Epic: none
Closes: #137487
Closes: https://github.com/cockroachdb/cockroach/issues/137828
Release note (bug fix): Fixed a timing issue between `ALTER VIEW .. RENAME` and `DROP VIEW` that caused repeated failures in the `DROP VIEW` job.