### PR TITLE
roachprod/promhelper: remove `node` and `tenant` labels

### DIFF
--- a/pkg/roachprod/promhelperclient/client.go
+++ b/pkg/roachprod/promhelperclient/client.go
@@ -15,7 +15,6 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strconv"
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/roachprod/config"
@@ -192,10 +191,10 @@ type NodeInfo struct {
 // createClusterConfigFile creates the cluster config file per node
 func buildCreateRequest(nodes map[int]*NodeInfo, insecure bool) (io.Reader, error) {
 	configs := make([]*CCParams, 0)
-	for i, n := range nodes {
+	for _, n := range nodes {
 		params := &CCParams{
 			Targets: []string{n.Target},
-			Labels:  map[string]string{"node": strconv.Itoa(i)},
+			Labels:  map[string]string{},
 		}
 		// custom labels - this can override the default labels if needed
 		for n, v := range n.CustomLabels {

--- a/pkg/roachprod/promhelperclient/client_test.go
+++ b/pkg/roachprod/promhelperclient/client_test.go
@@ -13,7 +13,6 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"testing"
 
@@ -66,11 +65,13 @@ func TestUpdatePrometheusTargets(t *testing.T) {
 			require.Nil(t, yaml.UnmarshalStrict([]byte(ir.Config), &configs))
 			require.Len(t, configs, 2)
 			for _, c := range configs {
-				nodeID, err := strconv.Atoi(c.Labels["node"])
-				require.NoError(t, err)
-				require.Equal(t, nodeInfos[nodeID].Target, c.Targets[0])
-				for k, v := range nodeInfos[nodeID].CustomLabels {
-					require.Equal(t, v, c.Labels[k])
+				if c.Targets[0] == "n1" {
+					require.Empty(t, nodeInfos[1].CustomLabels)
+				} else {
+					require.Equal(t, "n3", c.Targets[0])
+					for k, v := range nodeInfos[3].CustomLabels {
+						require.Equal(t, v, c.Labels[k])
+					}
 				}
 			}
 			return &http.Response{

--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -852,7 +852,6 @@ func createLabels(v vm.VM) map[string]string {
 		"host_ip":  v.PrivateIP,
 		"project":  v.Project,
 		"zone":     v.Zone,
-		"tenant":   install.SystemInterfaceName,
 		"job":      "cockroachdb",
 	}
 	match := regionRegEx.FindStringSubmatch(v.Zone)


### PR DESCRIPTION
The `node` label is redundant since `node_id` is always present in crdb metrics. The `tenant` label was hardcoded to `system`. We shall revisit it in conjunction with the scraping of
 separate-process tenants (see linked issue.)

Epic: none
Informs: https://github.com/cockroachdb/cockroach/issues/137625
Informs: https://github.com/cockroachdb/cockroach/issues/136789

Release note: None