### PR TITLE
kv: skip TestMuxRangeFeedDoesNotStallOnError under duress

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender_rangefeed_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_rangefeed_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/desctestutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util"
@@ -309,6 +310,8 @@ func TestMuxRangeCatchupScanQuotaReleased(t *testing.T) {
 func TestMuxRangeFeedDoesNotStallOnError(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+
+	skip.UnderDuress(t, "slow test")
 
 	ctx := context.Background()
 


### PR DESCRIPTION
Closes #137827.

We tried to deflake this in 7fa456e2 a few weeks ago. That helped, but the test is still slow enough to flake under duress. Even run alone in a race build on my m1 mac, it consumes close 80% cpu and takes ~20s to run. On a loaded CI instance, it could take much longer.

Skip it under those conditions.

Release note: None