### PR TITLE
release-24.2: raft: bump proposal timeout for TestNodeProposeWaitDropped

### DIFF
--- a/pkg/raft/node_test.go
+++ b/pkg/raft/node_test.go
@@ -373,11 +373,7 @@ func TestNodeProposeWaitDropped(t *testing.T) {
 		}
 		n.Advance()
 	}
-	proposalTimeout := time.Millisecond * 100
-	ctx, cancel := context.WithTimeout(context.Background(), proposalTimeout)
-	// propose with cancel should be cancelled earyly if dropped
-	assert.Equal(t, ErrProposalDropped, n.Propose(ctx, droppingMsg))
-	cancel()
+	assert.Equal(t, ErrProposalDropped, n.Propose(context.Background(), droppingMsg))
 
 	n.Stop()
 	require.Empty(t, msgs)


### PR DESCRIPTION
Backport 1/1 commits from #129996.
Fixes https://github.com/cockroachdb/cockroach/issues/137526.

/cc @cockroachdb/release

Release justification: testing

---

In some rare cases, we see context cancellation race with the proposal being dropped (#129967, #128878). Up the context cancellation deadline 10x to hopefully prevent this, while still not causing the test to hang indefinitely.

closes https://github.com/cockroachdb/cockroach/issues/129967

Release note: None
