### PR TITLE
release-24.3: rangefeed: track testing caughtUp state with an atomic

### DIFF
--- a/pkg/kv/kvserver/rangefeed/buffered_registration.go
+++ b/pkg/kv/kvserver/rangefeed/buffered_registration.go
@@ -8,6 +8,7 @@ package rangefeed
 import (
 	"context"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
@@ -52,9 +53,6 @@ type bufferedRegistration struct {
 		// This will cause the registration to exit with an error once the buffer
 		// has been emptied.
 		overflowed bool
-		// Boolean indicating if all events have been output to stream. Used only
-		// for testing.
-		caughtUp bool
 		// Management of the output loop goroutine, used to ensure proper teardown.
 		outputLoopCancelFn func()
 		disconnected       bool
@@ -65,6 +63,10 @@ type bufferedRegistration struct {
 		// that disconnect is called, it is closed by disconnect.
 		catchUpIter *CatchUpIterator
 	}
+
+	// Number of events that have been written to the buffer but
+	// not sent. Used only for testing.
+	testPendingEventToSend atomic.Int64
 }
 
 var _ registration = &bufferedRegistration{}
@@ -97,7 +99,6 @@ func newBufferedRegistration(
 		blockWhenFull: blockWhenFull,
 	}
 	br.mu.Locker = &syncutil.Mutex{}
-	br.mu.caughtUp = true
 	br.mu.catchUpIter = catchUpIter
 	return br
 }
@@ -121,7 +122,7 @@ func (br *bufferedRegistration) publish(
 	alloc.Use(ctx)
 	select {
 	case br.buf <- e:
-		br.mu.caughtUp = false
+		br.testPendingEventToSend.Add(1)
 	default:
 		// If we're asked to block (in tests), do a blocking send after releasing
 		// the mutex -- otherwise, the output loop won't be able to consume from the
@@ -132,7 +133,7 @@ func (br *bufferedRegistration) publish(
 			select {
 			case br.buf <- e:
 				br.mu.Lock()
-				br.mu.caughtUp = false
+				br.testPendingEventToSend.Add(1)
 			case <-ctx.Done():
 				br.mu.Lock()
 				alloc.Release(ctx)
@@ -192,7 +193,6 @@ func (br *bufferedRegistration) outputLoop(ctx context.Context) error {
 		br.mu.Lock()
 		if len(br.buf) == 0 {
 			overflowed = br.mu.overflowed
-			br.mu.caughtUp = true
 		}
 		br.mu.Unlock()
 		if overflowed {
@@ -205,6 +205,7 @@ func (br *bufferedRegistration) outputLoop(ctx context.Context) error {
 		select {
 		case nextEvent := <-br.buf:
 			err := br.stream.SendUnbuffered(nextEvent.event)
+			br.testPendingEventToSend.Add(-1)
 			nextEvent.alloc.Release(ctx)
 			putPooledSharedEvent(nextEvent)
 			if err != nil {
@@ -269,7 +270,9 @@ func (br *bufferedRegistration) maybeRunCatchUpScan(ctx context.Context) error {
 	return catchUpIter.CatchUpScan(ctx, br.stream.SendUnbuffered, br.withDiff, br.withFiltering, br.withOmitRemote)
 }
 
-// Wait for this registration to completely process its internal buffer.
+// Wait for this registration to completely process its internal
+// buffer. This is only used when a test sends a sync event to the
+// rangefeed processor with testRegCatchupSpan set.
 func (br *bufferedRegistration) waitForCaughtUp(ctx context.Context) error {
 	opts := retry.Options{
 		InitialBackoff: 5 * time.Millisecond,
@@ -278,9 +281,7 @@ func (br *bufferedRegistration) waitForCaughtUp(ctx context.Context) error {
 		MaxRetries:     50,
 	}
 	for re := retry.StartWithCtx(ctx, opts); re.Next(); {
-		br.mu.Lock()
-		caughtUp := len(br.buf) == 0 && br.mu.caughtUp
-		br.mu.Unlock()
+		caughtUp := len(br.buf) == 0 && br.testPendingEventToSend.Load() == 0
 		if caughtUp {
 			return nil
 		}


### PR DESCRIPTION
Backport 1/1 commits from #136797.
Fixes https://github.com/cockroachdb/cockroach/issues/137581.

/cc @cockroachdb/release

Release justification: None

---

The caughtUp variable is used in tests to assure that the rangefeed has sent all of its messages to the sender. However, it was subject to a race condition in which the testing-only blocking write path would set catchUp to false _after_ the event had been handled because this testing variable and other variables shared the same mutex.

We increment the counter on every push into the buffer and decrement it after the stream send has succeeded. In the blocking case that was buggy before, it is possible that the counter is temporarily -1, but this doesn't pose a problem.

Epic: none

Fixes #136544

Release note: None
