### PR TITLE
kv/storeliveness: deflake TestStoreLivenessDiskStall

### DIFF
--- a/pkg/kv/kvserver/storeliveness/multi_store_test.go
+++ b/pkg/kv/kvserver/storeliveness/multi_store_test.go
@@ -278,7 +278,6 @@ func TestStoreLivenessDiskStall(t *testing.T) {
 	checkSupport(t, tc, checkSupportFn)
 
 	// Stop blocking writes.
-	testEngine.SignalToUnblock()
 	testEngine.SetBlockOnWrite(false)
 
 	// Ensure all-to-all support again.

--- a/pkg/kv/kvserver/storeliveness/store_liveness_test.go
+++ b/pkg/kv/kvserver/storeliveness/store_liveness_test.go
@@ -100,7 +100,7 @@ func TestStoreLiveness(t *testing.T) {
 					case "error-on-write":
 						var errorOnWrite bool
 						d.ScanArgs(t, "on", &errorOnWrite)
-						engine.errorOnWrite = errorOnWrite
+						engine.SetErrorOnWrite(errorOnWrite)
 						return ""
 
 					case "debug-requester-state":

--- a/pkg/kv/kvserver/storeliveness/support_manager_test.go
+++ b/pkg/kv/kvserver/storeliveness/support_manager_test.go
@@ -348,7 +348,6 @@ func TestSupportManagerDiskStall(t *testing.T) {
 	require.True(t, supported)
 
 	// Stop blocking writes.
-	engine.SignalToUnblock()
 	engine.SetBlockOnWrite(false)
 
 	// Ensure the heartbeat is unblocked and sent out.

--- a/pkg/kv/kvserver/storeliveness/testutils.go
+++ b/pkg/kv/kvserver/storeliveness/testutils.go
@@ -7,6 +7,7 @@ package storeliveness
 
 import (
 	"context"
+	"sync"
 
 	slpb "github.com/cockroachdb/cockroach/pkg/kv/kvserver/storeliveness/storelivenesspb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -21,27 +22,24 @@ type TestEngine struct {
 	storage.Engine
 	storeID      slpb.StoreIdent
 	mu           syncutil.Mutex
-	blockingCh   chan struct{}
+	cond         sync.Cond
 	blockOnWrite bool
 	errorOnWrite bool
 }
 
 func NewTestEngine(storeID slpb.StoreIdent) *TestEngine {
-	return &TestEngine{
-		Engine:     storage.NewDefaultInMemForTesting(),
-		storeID:    storeID,
-		blockingCh: make(chan struct{}, 1),
+	te := &TestEngine{
+		Engine:  storage.NewDefaultInMemForTesting(),
+		storeID: storeID,
 	}
+	te.cond.L = &te.mu
+	return te
 }
 
 func (te *TestEngine) NewBatch() storage.Batch {
-	te.mu.Lock()
-	defer te.mu.Unlock()
 	return TestBatch{
-		Batch:        te.Engine.NewBatch(),
-		blockingCh:   te.blockingCh,
-		blockOnWrite: te.blockOnWrite,
-		errorOnWrite: te.errorOnWrite,
+		Batch: te.Engine.NewBatch(),
+		te:    te,
 	}
 }
 
@@ -49,37 +47,36 @@ func (te *TestEngine) SetBlockOnWrite(bow bool) {
 	te.mu.Lock()
 	defer te.mu.Unlock()
 	te.blockOnWrite = bow
+	te.cond.Broadcast()
 }
 
-func (te *TestEngine) SignalToUnblock() {
-	te.blockingCh <- struct{}{}
+func (te *TestEngine) blockOrErrorOnWrite() error {
+	te.mu.Lock()
+	defer te.mu.Unlock()
+	for te.blockOnWrite {
+		te.cond.Wait()
+	}
+	if te.errorOnWrite {
+		return errors.New("error on write")
+	}
+	return nil
 }
 
 func (te *TestEngine) PutUnversioned(key roachpb.Key, value []byte) error {
-	te.mu.Lock()
-	defer te.mu.Unlock()
-	if te.blockOnWrite {
-		<-te.blockingCh
-	}
-	if te.errorOnWrite {
-		return errors.New("error writing")
+	if err := te.blockOrErrorOnWrite(); err != nil {
+		return err
 	}
 	return te.Engine.PutUnversioned(key, value)
 }
 
 type TestBatch struct {
 	storage.Batch
-	blockingCh   chan struct{}
-	blockOnWrite bool
-	errorOnWrite bool
+	te *TestEngine
 }
 
 func (tb TestBatch) Commit(sync bool) error {
-	if tb.blockOnWrite {
-		<-tb.blockingCh
-	}
-	if tb.errorOnWrite {
-		return errors.New("error committing batch")
+	if err := tb.te.blockOrErrorOnWrite(); err != nil {
+		return err
 	}
 	return tb.Batch.Commit(sync)
 }

--- a/pkg/kv/kvserver/storeliveness/testutils.go
+++ b/pkg/kv/kvserver/storeliveness/testutils.go
@@ -37,7 +37,7 @@ func NewTestEngine(storeID slpb.StoreIdent) *TestEngine {
 }
 
 func (te *TestEngine) NewBatch() storage.Batch {
-	return TestBatch{
+	return &TestBatch{
 		Batch: te.Engine.NewBatch(),
 		te:    te,
 	}
@@ -80,7 +80,7 @@ type TestBatch struct {
 	te *TestEngine
 }
 
-func (tb TestBatch) Commit(sync bool) error {
+func (tb *TestBatch) Commit(sync bool) error {
 	if err := tb.te.blockOrErrorOnWrite(); err != nil {
 		return err
 	}

--- a/pkg/kv/kvserver/storeliveness/testutils.go
+++ b/pkg/kv/kvserver/storeliveness/testutils.go
@@ -50,6 +50,12 @@ func (te *TestEngine) SetBlockOnWrite(bow bool) {
 	te.cond.Broadcast()
 }
 
+func (te *TestEngine) SetErrorOnWrite(eow bool) {
+	te.mu.Lock()
+	defer te.mu.Unlock()
+	te.errorOnWrite = eow
+}
+
 func (te *TestEngine) blockOrErrorOnWrite() error {
 	te.mu.Lock()
 	defer te.mu.Unlock()


### PR DESCRIPTION
Fixes #137876.

This commit deflakes `TestStoreLivenessDiskStall` and `TestSupportManagerDiskStall`. The two tests were inducing disk stalls using the `TestEngine`'s `blockOnWrite` functionality. They were then ending the disk stall before the end of this test. However, they were doing so in a racy way, first signalling any already blocked writers and then preventing any new writers from blocking. This left a window open for new writers to block before the disk stall was ended. By adding a 5 second sleep in that window, the test reliably deadlocks.

This commit fixes the race and cleans some of this logic up.

@arulajmani I'm assigning you because Mira is out for the week.

Release note: None