### PR TITLE
server: fix over redacted log line in migration server

### DIFF
--- a/pkg/clusterversion/cockroach_versions_test.go
+++ b/pkg/clusterversion/cockroach_versions_test.go
@@ -147,7 +147,7 @@ func TestClusterVersionPrettyPrint(t *testing.T) {
 		{cv(22, 2, 1, 4), "22.2-upgrading-to-23.1-step-004"},
 	}
 	for _, test := range tests {
-		if actual := test.cv.PrettyPrint(); actual != test.exp {
+		if actual := test.cv.PrettyPrint().StripMarkers(); actual != test.exp {
 			t.Errorf("expected %s, got %q", test.exp, actual)
 		}
 	}

--- a/pkg/roachpb/version.go
+++ b/pkg/roachpb/version.go
@@ -112,11 +112,11 @@ func (v Version) IsFence() bool {
 
 // PrettyPrint returns the value in a format that makes it apparent whether or
 // not it is a fence version.
-func (v Version) PrettyPrint() string {
+func (v Version) PrettyPrint() redact.RedactableString {
 	if !v.IsFence() {
-		return v.String()
+		return redact.Sprintf("%v", v)
 	}
-	return fmt.Sprintf("%v(fence)", v)
+	return redact.Sprintf("%v(fence)", v)
 }
 
 // FenceVersion is the fence version -- the internal immediately prior -- for


### PR DESCRIPTION
Previosuly, few log lines were getting redacted assuming that it contains
sensitive information. Support team was facing challenges during dignostics. To
address this, this patch address the log line in migration server which was
overly redacted.

Epic: CRDB-37533
Part of: CRDB-44885
Release note: None