### PR TITLE
roachprod: reduce start-up lag

### DIFF
--- a/pkg/cmd/roachprod/cli/commands.go
+++ b/pkg/cmd/roachprod/cli/commands.go
@@ -1935,6 +1935,11 @@ func buildSnapshotApplyCmd() *cobra.Command {
 	}
 }
 
+func roachprodUpdateSupported(goos, goarch string) bool {
+	// We only have prebuilt binaries for Linux. See #120750.
+	return goos == "linux"
+}
+
 func (cr *commandRegistry) buildUpdateCmd() *cobra.Command {
 	updateCmd := &cobra.Command{
 		Use:   "update",
@@ -1944,8 +1949,8 @@ func (cr *commandRegistry) buildUpdateCmd() *cobra.Command {
 			" and can be restored via `roachprod update --revert`.",
 		Run: wrap(func(cmd *cobra.Command, args []string) error {
 			// We only have prebuilt binaries for Linux. See #120750.
-			if runtime.GOOS != "linux" {
-				return errors.New("this command is only available on Linux at this time")
+			if !roachprodUpdateSupported(runtime.GOOS, runtime.GOARCH) {
+				return errors.Errorf("this command is not available on %s/%s at this time", runtime.GOOS, runtime.GOARCH)
 			}
 
 			currentBinary, err := os.Executable()

--- a/pkg/roachprod/BUILD.bazel
+++ b/pkg/roachprod/BUILD.bazel
@@ -27,6 +27,7 @@ go_library(
         "//pkg/roachprod/vm",
         "//pkg/roachprod/vm/aws",
         "//pkg/roachprod/vm/azure",
+        "//pkg/roachprod/vm/flagstub",
         "//pkg/roachprod/vm/gce",
         "//pkg/roachprod/vm/local",
         "//pkg/server/debug/replay",

--- a/pkg/roachprod/vm/aws/aws.go
+++ b/pkg/roachprod/vm/aws/aws.go
@@ -62,6 +62,10 @@ func Init() error {
 	providerInstance.IAMProfile = "roachprod-testing"
 
 	haveRequiredVersion := func() bool {
+		// `aws --version` takes around 400ms on my machine.
+		if os.Getenv("ROACHPROD_SKIP_AWSCLI_CHECK") == "true" {
+			return true
+		}
 		cmd := exec.Command("aws", "--version")
 		output, err := cmd.Output()
 		if err != nil {


### PR DESCRIPTION
On my machine (which is in Europe), this brings `time roachprod --help` from `1.56s` down to to `0.06s` under the following env vars:

```
ROACHPROD_DISABLE_UPDATE_CHECK=true
ROACHPROD_DISABLED_PROVIDERS=azure
ROACHPROD_SKIP_AWSCLI_CHECK=true
```

Under these env vars, my roachprod

- no longer invokes `aws --version` on each start (python, ~400ms)
- no longer inits azure, which is >1s for me
- doesn't list the gs bucket to check for a newer roachprod binary (~800ms; doesn't exist for OSX anyway).

A better way (but one outside of my purview) for most of these would be to add caching for each of these and so to avoid the cost in the common case.

Azure is an exception, as the (wall-clock) profile below shows we're spending most of our time waiting for `GetTokenFromCLIWithParams` to return. It's not clear how to optimize this. (The AWS portion of the flamegraph is `aws --version`).

![image](https://github.com/user-attachments/assets/b4677da6-c5a5-4552-b0d5-462932f1062e)


Epic: none