### PR TITLE
release-24.1: sql: add session setting for legacy VARCHAR typing behavior

### DIFF
--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -3837,6 +3837,10 @@ func (m *sessionDataMutator) SetOptimizerPushLimitIntoProjectFilteredScan(val bo
 	m.data.OptimizerPushLimitIntoProjectFilteredScan = val
 }
 
+func (m *sessionDataMutator) SetLegacyVarcharTyping(val bool) {
+	m.data.LegacyVarcharTyping = val
+}
+
 // Utility functions related to scrubbing sensitive information on SQL Stats.
 
 // quantizeCounts ensures that the Count field in the

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -6154,6 +6154,7 @@ lc_messages                                                C.UTF-8
 lc_monetary                                                C.UTF-8
 lc_numeric                                                 C.UTF-8
 lc_time                                                    C.UTF-8
+legacy_varchar_typing                                      on
 locality                                                   region=test,dc=dc1
 locality_optimized_partitioned_index_scan                  on
 lock_timeout                                               0

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -2915,6 +2915,7 @@ lc_messages                                                C.UTF-8             N
 lc_monetary                                                C.UTF-8             NULL      NULL        NULL        string
 lc_numeric                                                 C.UTF-8             NULL      NULL        NULL        string
 lc_time                                                    C.UTF-8             NULL      NULL        NULL        string
+legacy_varchar_typing                                      on                  NULL      NULL        NULL        string
 locality                                                   region=test,dc=dc1  NULL      NULL        NULL        string
 locality_optimized_partitioned_index_scan                  on                  NULL      NULL        NULL        string
 lock_timeout                                               0                   NULL      NULL        NULL        string
@@ -3104,6 +3105,7 @@ lc_messages                                                C.UTF-8             N
 lc_monetary                                                C.UTF-8             NULL  user     NULL      C.UTF-8             C.UTF-8
 lc_numeric                                                 C.UTF-8             NULL  user     NULL      C.UTF-8             C.UTF-8
 lc_time                                                    C.UTF-8             NULL  user     NULL      C.UTF-8             C.UTF-8
+legacy_varchar_typing                                      on                  NULL  user     NULL      on                  on
 locality                                                   region=test,dc=dc1  NULL  user     NULL      region=test,dc=dc1  region=test,dc=dc1
 locality_optimized_partitioned_index_scan                  on                  NULL  user     NULL      on                  on
 lock_timeout                                               0                   NULL  user     NULL      0s                  0s
@@ -3290,6 +3292,7 @@ lc_messages                                                NULL    NULL     NULL
 lc_monetary                                                NULL    NULL     NULL     NULL        NULL
 lc_numeric                                                 NULL    NULL     NULL     NULL        NULL
 lc_time                                                    NULL    NULL     NULL     NULL        NULL
+legacy_varchar_typing                                      NULL    NULL     NULL     NULL        NULL
 locality                                                   NULL    NULL     NULL     NULL        NULL
 locality_optimized_partitioned_index_scan                  NULL    NULL     NULL     NULL        NULL
 lock_timeout                                               NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -111,6 +111,7 @@ lc_messages                                                C.UTF-8
 lc_monetary                                                C.UTF-8
 lc_numeric                                                 C.UTF-8
 lc_time                                                    C.UTF-8
+legacy_varchar_typing                                      on
 locality                                                   region=test,dc=dc1
 locality_optimized_partitioned_index_scan                  on
 lock_timeout                                               0

--- a/pkg/sql/logictest/testdata/logic_test/typing
+++ b/pkg/sql/logictest/testdata/logic_test/typing
@@ -144,6 +144,9 @@ SELECT 1::pg_catalog.special_int
 query error pq: type "crdb_internal.mytype" does not exist
 SELECT 1::crdb_internal.mytype
 
+statement ok
+SET legacy_varchar_typing = off
+
 # Untyped string literals in binary operators assume the type of the other
 # argument, if an overload exists with exactly matching parameter types. The
 # values are adjusted as necessary, e.g., trailing spaces are trimmed from
@@ -284,6 +287,9 @@ SELECT bp = c FROM
   (VALUES ('foo  ')) v2(c)
 ----
 false
+
+statement ok
+SET legacy_varchar_typing = on
 
 # Regression tests for #15050
 

--- a/pkg/sql/opt/memo/memo.go
+++ b/pkg/sql/opt/memo/memo.go
@@ -195,6 +195,7 @@ type Memo struct {
 	proveImplicationWithVirtualComputedCols    bool
 	pushOffsetIntoIndexJoin                    bool
 	pushLimitIntoProjectFilteredScan           bool
+	legacyVarcharTyping                        bool
 
 	// txnIsoLevel is the isolation level under which the plan was created. This
 	// affects the planning of some locking operations, so it must be included in
@@ -281,6 +282,7 @@ func (m *Memo) Init(ctx context.Context, evalCtx *eval.Context) {
 		proveImplicationWithVirtualComputedCols:    evalCtx.SessionData().OptimizerProveImplicationWithVirtualComputedColumns,
 		pushOffsetIntoIndexJoin:                    evalCtx.SessionData().OptimizerPushOffsetIntoIndexJoin,
 		pushLimitIntoProjectFilteredScan:           evalCtx.SessionData().OptimizerPushLimitIntoProjectFilteredScan,
+		legacyVarcharTyping:                        evalCtx.SessionData().LegacyVarcharTyping,
 		txnIsoLevel:                                evalCtx.TxnIsoLevel,
 	}
 	m.metadata.Init()
@@ -445,6 +447,7 @@ func (m *Memo) IsStale(
 		m.proveImplicationWithVirtualComputedCols != evalCtx.SessionData().OptimizerProveImplicationWithVirtualComputedColumns ||
 		m.pushOffsetIntoIndexJoin != evalCtx.SessionData().OptimizerPushOffsetIntoIndexJoin ||
 		m.pushLimitIntoProjectFilteredScan != evalCtx.SessionData().OptimizerPushLimitIntoProjectFilteredScan ||
+		m.legacyVarcharTyping != evalCtx.SessionData().LegacyVarcharTyping ||
 		m.txnIsoLevel != evalCtx.TxnIsoLevel {
 		return true, nil
 	}

--- a/pkg/sql/opt/memo/memo_test.go
+++ b/pkg/sql/opt/memo/memo_test.go
@@ -503,6 +503,11 @@ func TestMemoIsStale(t *testing.T) {
 	evalCtx.SessionData().OptimizerPushLimitIntoProjectFilteredScan = false
 	notStale()
 
+	evalCtx.SessionData().LegacyVarcharTyping = true
+	stale()
+	evalCtx.SessionData().LegacyVarcharTyping = false
+	notStale()
+
 	// User no longer has access to view.
 	catalog.View(tree.NewTableNameWithSchema("t", catconstants.PublicSchemaName, "abcview")).Revoked = true
 	_, err = o.Memo().IsStale(ctx, &evalCtx, catalog)

--- a/pkg/sql/opt/optbuilder/builder.go
+++ b/pkg/sql/opt/optbuilder/builder.go
@@ -191,6 +191,10 @@ func New(
 	factory *norm.Factory,
 	stmt tree.Statement,
 ) *Builder {
+	// NOTE: This is a hack to get a session setting plumbed into the
+	// type-checker without plumbing evalCtx. This pattern should probably not
+	// be repeated.
+	semaCtx.Properties.IgnoreUnpreferredOverloads = evalCtx.SessionData().LegacyVarcharTyping
 	return &Builder{
 		factory:        factory,
 		stmt:           stmt,

--- a/pkg/sql/pgwire/testdata/pgtest/typing
+++ b/pkg/sql/pgwire/testdata/pgtest/typing
@@ -1,0 +1,93 @@
+# Regression tests for #133037.
+
+send
+Query {"String": "CREATE TABLE t (id UUID PRIMARY KEY, v VARCHAR)"}
+----
+
+until ignore=NoticeResponse
+ReadyForQuery
+----
+{"Type":"CommandComplete","CommandTag":"CREATE TABLE"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+send crdb_only
+Query {"String": "SET legacy_varchar_typing = on"}
+----
+
+until crdb_only
+ReadyForQuery
+----
+{"Type":"CommandComplete","CommandTag":"SET"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+# These queries with mixed-type comparison succeed with the legacy type-checking
+# logic.
+send crdb_only
+Parse {"Name": "s1", "Query": "SELECT id FROM t WHERE v = $1", "ParameterOIDs": [2950]}
+Bind {"DestinationPortal": "p1", "PreparedStatement": "s1", "ParameterFormatCodes": [0], "Parameters": [{"text":"9AC39CE2-0623-4632-A965-9A51C95682D4"}]}
+Execute {"Portal": "p1"}
+Sync
+----
+
+until crdb_only
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"BindComplete"}
+{"Type":"CommandComplete","CommandTag":"SELECT 0"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+send crdb_only
+Parse {"Name": "s2", "Query": "SELECT id FROM t WHERE v = $1", "ParameterOIDs": [16]}
+Bind {"DestinationPortal": "p1", "PreparedStatement": "s2", "ParameterFormatCodes": [0], "Parameters": [{"text":"true"}]}
+Execute {"Portal": "p1"}
+Sync
+----
+
+until crdb_only
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"BindComplete"}
+{"Type":"CommandComplete","CommandTag":"SELECT 0"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+send crdb_only
+Query {"String": "SET legacy_varchar_typing = off"}
+----
+
+until crdb_only
+ReadyForQuery
+----
+{"Type":"CommandComplete","CommandTag":"SET"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+# The same queries fail with the correct type-checking logic. This match's PG
+# behavior.
+send
+Parse {"Name": "s3", "Query": "SELECT id FROM t WHERE v = $1", "ParameterOIDs": [2950]}
+Bind {"DestinationPortal": "p1", "PreparedStatement": "s3", "ParameterFormatCodes": [0], "Parameters": [{"text":"9AC39CE2-0623-4632-A965-9A51C95682D4"}]}
+Execute {"Portal": "p1"}
+Sync
+----
+
+until keepErrMessage
+ErrorResponse
+ReadyForQuery
+----
+{"Type":"ErrorResponse","Code":"22023","Message":"unsupported comparison operator: \u003cvarchar\u003e = \u003cuuid\u003e"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+send
+Parse {"Name": "s4", "Query": "SELECT id FROM t WHERE v = $1", "ParameterOIDs": [16]}
+Bind {"DestinationPortal": "p1", "PreparedStatement": "s4", "ParameterFormatCodes": [0], "Parameters": [{"text":"true"}]}
+Execute {"Portal": "p1"}
+Sync
+----
+
+until keepErrMessage
+ErrorResponse
+ReadyForQuery
+----
+{"Type":"ErrorResponse","Code":"22023","Message":"unsupported comparison operator: \u003cvarchar\u003e = \u003cbool\u003e"}
+{"Type":"ReadyForQuery","TxStatus":"I"}

--- a/pkg/sql/sem/tree/overload.go
+++ b/pkg/sql/sem/tree/overload.go
@@ -952,6 +952,13 @@ func (s *overloadTypeChecker) typeCheckOverloadedExprs(
 		}
 	}
 
+	if semaCtx != nil && semaCtx.Properties.IgnoreUnpreferredOverloads {
+		// Filter out unpreferred overloads.
+		s.overloadIdxs = filterOverloads(s.overloadIdxs, s.overloads, func(ov overloadImpl) bool {
+			return ov.preference() != OverloadPreferenceUnpreferred
+		})
+	}
+
 	// Filter out incorrect parameter length overloads.
 	matchLen := func(ov overloadImpl, params TypeList) bool {
 		if !foundOutParams && !foundDefaultExprs {

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -92,6 +92,10 @@ type SemaProperties struct {
 	// Ancestors is mutated during semantic analysis to provide contextual
 	// information for each descendent during traversal of sub-expressions.
 	Ancestors ScalarAncestors
+
+	// IgnoreUnpreferredOverloads is set to true when "unpreferred" overloads
+	// should not be used during type-checking and overload resolution.
+	IgnoreUnpreferredOverloads bool
 }
 
 type semaRequirements struct {

--- a/pkg/sql/sessiondatapb/local_only_session_data.proto
+++ b/pkg/sql/sessiondatapb/local_only_session_data.proto
@@ -528,6 +528,10 @@ message LocalOnlySessionData {
   // performed by the vectorized engine when transitioning into the draining
   // state in some cases.
   bool disable_vec_union_eager_cancellation = 143;
+  // LegacyVarcharTyping controls the legacy behavior of allowing some invalid
+  // mix-typed comparisons with VARCHAR types. See #137837, #133037, and
+  // #132268.
+  bool legacy_varchar_typing = 150;
 
   ///////////////////////////////////////////////////////////////////////////
   // WARNING: consider whether a session parameter you're adding needs to  //

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -3457,6 +3457,23 @@ var varGen = map[string]sessionVar{
 		},
 		GlobalDefault: globalFalse,
 	},
+
+	// CockroachDB extension.
+	`legacy_varchar_typing`: {
+		GetStringVal: makePostgresBoolGetStringValFn(`legacy_varchar_typing`),
+		Set: func(_ context.Context, m sessionDataMutator, s string) error {
+			b, err := paramparse.ParseBoolVar("legacy_varchar_typing", s)
+			if err != nil {
+				return err
+			}
+			m.SetLegacyVarcharTyping(b)
+			return nil
+		},
+		Get: func(evalCtx *extendedEvalContext, _ *kv.Txn) (string, error) {
+			return formatBoolAsPostgresSetting(evalCtx.SessionData().LegacyVarcharTyping), nil
+		},
+		GlobalDefault: globalTrue,
+	},
 }
 
 func ReplicationModeFromString(s string) (sessiondatapb.ReplicationMode, error) {


### PR DESCRIPTION
Backport 1/1 commits from #137844.

/cc @cockroachdb/release

---

Informs #137837

Release note (sql change): The `legacy_varchar_typing` session setting
has been added, which reverts the changes of #133037 that cause the
change in typing behavior described in #137837. Specifically, it makes
type-checking and overload resolution ignore the newly added
"unpreferred" overloads. This setting defaults to `on`.

---

Release justification: Reverts unintended change in type-checking
behavior.

