### PR TITLE
release-24.3: backup/crosscluster: skip a few tests

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -1543,6 +1543,7 @@ func TestRestoreRetryProcErr(t *testing.T) {
 func TestRestoreReplanOnLag(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+	skip.WithIssue(t, 137098, "move logic to roachtest")
 
 	skip.UnderRace(t, "slow test under stress race")
 

--- a/pkg/ccl/crosscluster/physical/replication_stream_e2e_test.go
+++ b/pkg/ccl/crosscluster/physical/replication_stream_e2e_test.go
@@ -1310,6 +1310,7 @@ func TestStreamingRegionalConstraint(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	skip.UnderRace(t, "takes too long under race")
+	skip.UnderDeadlock(t, "takes too long under deadlock")
 
 	testutils.RunTrueAndFalse(t, "fromSys", func(t *testing.T, sys bool) {
 		ctx := context.Background()


### PR DESCRIPTION
Backport 2/2 commits from #137831.

/cc @cockroachdb/release

---

See commits.

Epic: none

Release note: none
