### PR TITLE
mvcc: use point tombstones when rolling back imports

### DIFF
--- a/pkg/kv/kvpb/api.go
+++ b/pkg/kv/kvpb/api.go
@@ -1903,8 +1903,10 @@ func (*DeleteRequest) flags() flag {
 }
 
 func (drr *DeleteRangeRequest) flags() flag {
-	// DeleteRangeRequest using MVCC range tombstones cannot be transactional.
-	if drr.UseRangeTombstone {
+	// DeleteRangeRequest using MVCC range tombstones or deletion predicates
+	// cannot be transactional.
+	hasPredicate := drr.Predicates != (DeleteRangePredicates{})
+	if drr.UseRangeTombstone || hasPredicate {
 		return isWrite | isRange | isAlone | appliesTSCache
 	}
 	// DeleteRangeRequest has different properties if the "inline" flag is set.

--- a/pkg/sql/importer/import_job.go
+++ b/pkg/sql/importer/import_job.go
@@ -936,7 +936,7 @@ func (r *importResumer) dropTable(
 			ctx,
 			execCfg.DB,
 			execCfg.Codec,
-			&execCfg.Settings.SV,
+			execCfg.Settings,
 			execCfg.DistSender,
 			intoTable.GetID(),
 			predicates, sql.RevertTableDefaultBatchSize); err != nil {

--- a/pkg/sql/importer/rollback_job.go
+++ b/pkg/sql/importer/rollback_job.go
@@ -89,7 +89,7 @@ func (r *importRollbackResumer) rollbackTable(
 			ctx,
 			cfg.DB,
 			cfg.Codec,
-			&cfg.Settings.SV,
+			cfg.Settings,
 			cfg.DistSender,
 			tableID,
 			kvpb.DeleteRangePredicates{

--- a/pkg/sql/revert.go
+++ b/pkg/sql/revert.go
@@ -8,12 +8,14 @@ package sql
 import (
 	"context"
 
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvcoord"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/catid"
 	"github.com/cockroachdb/cockroach/pkg/util/admission/admissionpb"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
@@ -55,13 +57,12 @@ func DeleteTableWithPredicate(
 	ctx context.Context,
 	db *kv.DB,
 	codec keys.SQLCodec,
-	sv *settings.Values,
+	clusterSettings *cluster.Settings,
 	distSender *kvcoord.DistSender,
 	tableID catid.DescID,
 	predicates kvpb.DeleteRangePredicates,
 	batchSize int64,
 ) error {
-
 	log.Dev.Infof(ctx, "deleting data for table %d with predicate %s", tableID, predicates.String())
 	tableKey := roachpb.RKey(codec.TablePrefix(uint32(tableID)))
 	tableSpan := roachpb.RSpan{Key: tableKey, EndKey: tableKey.PrefixEnd()}
@@ -71,8 +72,8 @@ func DeleteTableWithPredicate(
 	// The partitions are sent to the workers via the spansToDo channel.
 	//
 	// TODO (msbutler): tune these
-	rangesPerBatch := rollbackBatchSize.Get(sv)
-	numWorkers := int(predicateDeleteRangeNumWorkers.Get(sv))
+	rangesPerBatch := rollbackBatchSize.Get(&clusterSettings.SV)
+	numWorkers := int(predicateDeleteRangeNumWorkers.Get(&clusterSettings.SV))
 
 	spansToDo := make(chan *roachpb.Span, 1)
 
@@ -108,7 +109,9 @@ func DeleteTableWithPredicate(
 								Key:    span.Key,
 								EndKey: span.EndKey,
 							},
-							UseRangeTombstone: true,
+							// Support for deletion predicates without range tombstones was
+							// added in 26_1.
+							UseRangeTombstone: !clusterSettings.Version.IsActive(ctx, clusterversion.V26_1),
 							Predicates:        predicates,
 						}
 						log.VEventf(ctx, 2, "deleting range %s - %s; attempt %v", span.Key, span.EndKey, resumeCount)

--- a/pkg/sql/revert_test.go
+++ b/pkg/sql/revert_test.go
@@ -65,7 +65,7 @@ func TestTableRollback(t *testing.T) {
 
 	predicates := kvpb.DeleteRangePredicates{StartTime: targetTime}
 	require.NoError(t, sql.DeleteTableWithPredicate(
-		ctx, kv, codec, &tt.ClusterSettings().SV, execCfg.DistSender, desc.GetID(), predicates, 10))
+		ctx, kv, codec, tt.ClusterSettings(), execCfg.DistSender, desc.GetID(), predicates, 10))
 
 	db.CheckQueryResults(t, `SELECT count(*) FROM test`, beforeNumRows)
 }
@@ -112,7 +112,7 @@ func TestRollbackRandomTable(t *testing.T) {
 
 	execCfg := tt.ExecutorConfig().(sql.ExecutorConfig)
 	require.NoError(t, sql.DeleteTableWithPredicate(
-		ctx, kv, codec, &tt.ClusterSettings().SV, execCfg.DistSender, desc.GetID(), predicates, 10))
+		ctx, kv, codec, tt.ClusterSettings(), execCfg.DistSender, desc.GetID(), predicates, 10))
 
 	afterFingerprint := db.QueryStr(t, fmt.Sprintf("SHOW EXPERIMENTAL_FINGERPRINTS FROM TABLE test.%s", tableName))
 	require.Equal(t, fingerprint, afterFingerprint)

--- a/pkg/storage/testdata/mvcc_histories/delete_range_predicate
+++ b/pkg/storage/testdata/mvcc_histories/delete_range_predicate
@@ -49,12 +49,11 @@ data: "i"/7.000000000,0 -> /BYTES/i7
 
 # Writing next to or above point keys and tombstones should work.
 run stats ok log-ops
-del_range_pred k=a end=i ts=5 startTime=3 rangeThreshold=2
+del_range_pred k=a end=i ts=5 startTime=3
 ----
->> del_range_pred k=a end=i ts=5 startTime=3 rangeThreshold=2
-stats: key_bytes=+12 val_count=+1 range_key_count=+1 range_key_bytes=+14 range_val_count=+1 live_count=-3 live_bytes=-63 gc_bytes_age=+8455
+>> del_range_pred k=a end=i ts=5 startTime=3
+stats: key_bytes=+36 val_count=+3 live_count=-3 live_bytes=-63 gc_bytes_age=+9405
 >> at end:
-rangekey: {f-h\x00}/[5.000000000,0=/<empty>]
 rangekey: {k-p}/[4.000000000,0=/<empty>]
 data: "a"/4.000000000,0 -> /<empty>
 data: "a"/2.000000000,0 -> /BYTES/a2
@@ -63,15 +62,18 @@ data: "d"/5.000000000,0 -> /<empty>
 data: "d"/4.000000000,0 -> /BYTES/d4
 data: "d"/1.000000000,0 -> /BYTES/d1
 data: "e"/2.000000000,0 -> /BYTES/e2
+data: "f"/5.000000000,0 -> /<empty>
 data: "f"/4.000000000,0 -> /BYTES/f4
 data: "g"/4.000000000,0 -> /<empty>
 data: "g"/2.000000000,0 -> /BYTES/g2
+data: "h"/5.000000000,0 -> /<empty>
 data: "h"/4.000000000,0 -> /BYTES/h4
 meta: "i"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "i"/7.000000000,0 -> /BYTES/i7
 logical op: write_value: key="d", ts=5.000000000,0
-logical op: delete_range: startKey="f" endKey="h\x00" ts=5.000000000,0
-stats: key_count=8 key_bytes=160 val_count=12 val_bytes=111 range_key_count=2 range_key_bytes=27 range_val_count=2 live_count=3 live_bytes=111 gc_bytes_age=17863 intent_count=1 intent_bytes=19 lock_count=1 lock_age=93
+logical op: write_value: key="f", ts=5.000000000,0
+logical op: write_value: key="h", ts=5.000000000,0
+stats: key_count=8 key_bytes=184 val_count=14 val_bytes=111 range_key_count=1 range_key_bytes=13 range_val_count=1 live_count=3 live_bytes=111 gc_bytes_age=18813 intent_count=1 intent_bytes=19 lock_count=1 lock_age=93
 
 # Error on intent, no tombstones should be written. We try both the
 # point tombstone and range tombstone paths.
@@ -81,7 +83,6 @@ del_range_pred k=a end=p ts=6 startTime=1
 >> del_range_pred k=a end=p ts=6 startTime=1
 stats: no change
 >> at end:
-rangekey: {f-h\x00}/[5.000000000,0=/<empty>]
 rangekey: {k-p}/[4.000000000,0=/<empty>]
 data: "a"/4.000000000,0 -> /<empty>
 data: "a"/2.000000000,0 -> /BYTES/a2
@@ -90,13 +91,15 @@ data: "d"/5.000000000,0 -> /<empty>
 data: "d"/4.000000000,0 -> /BYTES/d4
 data: "d"/1.000000000,0 -> /BYTES/d1
 data: "e"/2.000000000,0 -> /BYTES/e2
+data: "f"/5.000000000,0 -> /<empty>
 data: "f"/4.000000000,0 -> /BYTES/f4
 data: "g"/4.000000000,0 -> /<empty>
 data: "g"/2.000000000,0 -> /BYTES/g2
+data: "h"/5.000000000,0 -> /<empty>
 data: "h"/4.000000000,0 -> /BYTES/h4
 meta: "i"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "i"/7.000000000,0 -> /BYTES/i7
-stats: key_count=8 key_bytes=160 val_count=12 val_bytes=111 range_key_count=2 range_key_bytes=27 range_val_count=2 live_count=3 live_bytes=111 gc_bytes_age=17863 intent_count=1 intent_bytes=19 lock_count=1 lock_age=93
+stats: key_count=8 key_bytes=184 val_count=14 val_bytes=111 range_key_count=1 range_key_bytes=13 range_val_count=1 live_count=3 live_bytes=111 gc_bytes_age=18813 intent_count=1 intent_bytes=19 lock_count=1 lock_age=93
 error: (*kvpb.LockConflictError:) conflicting locks on "i"
 
 run stats error
@@ -105,7 +108,6 @@ del_range_pred k=i end=+i ts=6 startTime=1
 >> del_range_pred k=i end=+i ts=6 startTime=1
 stats: no change
 >> at end:
-rangekey: {f-h\x00}/[5.000000000,0=/<empty>]
 rangekey: {k-p}/[4.000000000,0=/<empty>]
 data: "a"/4.000000000,0 -> /<empty>
 data: "a"/2.000000000,0 -> /BYTES/a2
@@ -114,18 +116,20 @@ data: "d"/5.000000000,0 -> /<empty>
 data: "d"/4.000000000,0 -> /BYTES/d4
 data: "d"/1.000000000,0 -> /BYTES/d1
 data: "e"/2.000000000,0 -> /BYTES/e2
+data: "f"/5.000000000,0 -> /<empty>
 data: "f"/4.000000000,0 -> /BYTES/f4
 data: "g"/4.000000000,0 -> /<empty>
 data: "g"/2.000000000,0 -> /BYTES/g2
+data: "h"/5.000000000,0 -> /<empty>
 data: "h"/4.000000000,0 -> /BYTES/h4
 meta: "i"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "i"/7.000000000,0 -> /BYTES/i7
-stats: key_count=8 key_bytes=160 val_count=12 val_bytes=111 range_key_count=2 range_key_bytes=27 range_val_count=2 live_count=3 live_bytes=111 gc_bytes_age=17863 intent_count=1 intent_bytes=19 lock_count=1 lock_age=93
+stats: key_count=8 key_bytes=184 val_count=14 val_bytes=111 range_key_count=1 range_key_bytes=13 range_val_count=1 live_count=3 live_bytes=111 gc_bytes_age=18813 intent_count=1 intent_bytes=19 lock_count=1 lock_age=93
 error: (*kvpb.LockConflictError:) conflicting locks on "i"
 
 # error encountering point key at d5.
-# a tombstone should not get written at c5 or e5, since
-# DeleteRange didn't flush before reaching d5.
+# a tombstone gets written to c5 before the error at d5 since
+# MVCCPredicateDeleteRangePointTombstones writes point tombstones immediately.
 run stats error
 put k=c ts=2 v=c2
 del_range_pred k=c end=f ts=5 startTime=1
@@ -133,61 +137,66 @@ del_range_pred k=c end=f ts=5 startTime=1
 >> put k=c ts=2 v=c2
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+7 live_count=+1 live_bytes=+21
 >> del_range_pred k=c end=f ts=5 startTime=1
-stats: no change
+stats: key_bytes=+12 val_count=+1 live_count=-1 live_bytes=-21 gc_bytes_age=+3135
 >> at end:
-rangekey: {f-h\x00}/[5.000000000,0=/<empty>]
 rangekey: {k-p}/[4.000000000,0=/<empty>]
 data: "a"/4.000000000,0 -> /<empty>
 data: "a"/2.000000000,0 -> /BYTES/a2
 data: "b"/3.000000000,0 -> /BYTES/b3
+data: "c"/5.000000000,0 -> /<empty>
 data: "c"/2.000000000,0 -> /BYTES/c2
 data: "d"/5.000000000,0 -> /<empty>
 data: "d"/4.000000000,0 -> /BYTES/d4
 data: "d"/1.000000000,0 -> /BYTES/d1
 data: "e"/2.000000000,0 -> /BYTES/e2
+data: "f"/5.000000000,0 -> /<empty>
 data: "f"/4.000000000,0 -> /BYTES/f4
 data: "g"/4.000000000,0 -> /<empty>
 data: "g"/2.000000000,0 -> /BYTES/g2
+data: "h"/5.000000000,0 -> /<empty>
 data: "h"/4.000000000,0 -> /BYTES/h4
 meta: "i"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "i"/7.000000000,0 -> /BYTES/i7
-stats: key_count=9 key_bytes=174 val_count=13 val_bytes=118 range_key_count=2 range_key_bytes=27 range_val_count=2 live_count=4 live_bytes=132 gc_bytes_age=17863 intent_count=1 intent_bytes=19 lock_count=1 lock_age=93
+stats: key_count=9 key_bytes=210 val_count=16 val_bytes=118 range_key_count=1 range_key_bytes=13 range_val_count=1 live_count=3 live_bytes=111 gc_bytes_age=21948 intent_count=1 intent_bytes=19 lock_count=1 lock_age=93
 error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "d" at timestamp 5.000000000,0 too old; must write at or above 5.000000000,1
 
 # error encountering range key at k4.
-# a tombstones should not get written to j4 or q4 since
-# DeleteRange did not flush before reaching rangekey {k-p}4.
+# a tombstone gets written to j4 before the error at k4 since
+# MVCCPredicateDeleteRangePointTombstones writes point tombstones immediately.
 run stats error
 put k=j ts=2 v=j2
 put k=q ts=2 v=q2
-del_range_pred k=j end=r ts=4 startTime=1 rangeThreshold=2
+del_range_pred k=j end=r ts=4 startTime=1
 ----
 >> put k=j ts=2 v=j2
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+7 live_count=+1 live_bytes=+21
 >> put k=q ts=2 v=q2
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+7 live_count=+1 live_bytes=+21
->> del_range_pred k=j end=r ts=4 startTime=1 rangeThreshold=2
-stats: no change
+>> del_range_pred k=j end=r ts=4 startTime=1
+stats: key_bytes=+12 val_count=+1 live_count=-1 live_bytes=-21 gc_bytes_age=+3168
 >> at end:
-rangekey: {f-h\x00}/[5.000000000,0=/<empty>]
 rangekey: {k-p}/[4.000000000,0=/<empty>]
 data: "a"/4.000000000,0 -> /<empty>
 data: "a"/2.000000000,0 -> /BYTES/a2
 data: "b"/3.000000000,0 -> /BYTES/b3
+data: "c"/5.000000000,0 -> /<empty>
 data: "c"/2.000000000,0 -> /BYTES/c2
 data: "d"/5.000000000,0 -> /<empty>
 data: "d"/4.000000000,0 -> /BYTES/d4
 data: "d"/1.000000000,0 -> /BYTES/d1
 data: "e"/2.000000000,0 -> /BYTES/e2
+data: "f"/5.000000000,0 -> /<empty>
 data: "f"/4.000000000,0 -> /BYTES/f4
 data: "g"/4.000000000,0 -> /<empty>
 data: "g"/2.000000000,0 -> /BYTES/g2
+data: "h"/5.000000000,0 -> /<empty>
 data: "h"/4.000000000,0 -> /BYTES/h4
 meta: "i"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "i"/7.000000000,0 -> /BYTES/i7
+data: "j"/4.000000000,0 -> /<empty>
 data: "j"/2.000000000,0 -> /BYTES/j2
 data: "q"/2.000000000,0 -> /BYTES/q2
-stats: key_count=11 key_bytes=202 val_count=15 val_bytes=132 range_key_count=2 range_key_bytes=27 range_val_count=2 live_count=6 live_bytes=174 gc_bytes_age=17863 intent_count=1 intent_bytes=19 lock_count=1 lock_age=93
+stats: key_count=11 key_bytes=250 val_count=19 val_bytes=132 range_key_count=1 range_key_bytes=13 range_val_count=1 live_count=4 live_bytes=132 gc_bytes_age=25116 intent_count=1 intent_bytes=19 lock_count=1 lock_age=93
 error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k" at timestamp 4.000000000,0 too old; must write at or above 4.000000000,1
 
 # At this point the keyspace looks like this:
@@ -202,103 +211,106 @@ error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k" at timestam
 #    a   b   c   d   e   f   g   h   i   j   k   l   m   n   o   p  q
 
 # check that del_range will not write anything if no live keys are in its span
-# and predicate ts. Note that the range keys bounds are [firstMatchingKey,LastMatchingKey.Next()].
+# and predicate ts.
 run stats ok
-del_range_pred k=j end=r ts=5 startTime=2 rangeThreshold=2
+del_range_pred k=j end=r ts=5 startTime=2
 ----
->> del_range_pred k=j end=r ts=5 startTime=2 rangeThreshold=2
+>> del_range_pred k=j end=r ts=5 startTime=2
 stats: no change
 >> at end:
-rangekey: {f-h\x00}/[5.000000000,0=/<empty>]
 rangekey: {k-p}/[4.000000000,0=/<empty>]
 data: "a"/4.000000000,0 -> /<empty>
 data: "a"/2.000000000,0 -> /BYTES/a2
 data: "b"/3.000000000,0 -> /BYTES/b3
+data: "c"/5.000000000,0 -> /<empty>
 data: "c"/2.000000000,0 -> /BYTES/c2
 data: "d"/5.000000000,0 -> /<empty>
 data: "d"/4.000000000,0 -> /BYTES/d4
 data: "d"/1.000000000,0 -> /BYTES/d1
 data: "e"/2.000000000,0 -> /BYTES/e2
+data: "f"/5.000000000,0 -> /<empty>
 data: "f"/4.000000000,0 -> /BYTES/f4
 data: "g"/4.000000000,0 -> /<empty>
 data: "g"/2.000000000,0 -> /BYTES/g2
+data: "h"/5.000000000,0 -> /<empty>
 data: "h"/4.000000000,0 -> /BYTES/h4
 meta: "i"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "i"/7.000000000,0 -> /BYTES/i7
+data: "j"/4.000000000,0 -> /<empty>
 data: "j"/2.000000000,0 -> /BYTES/j2
 data: "q"/2.000000000,0 -> /BYTES/q2
-stats: key_count=11 key_bytes=202 val_count=15 val_bytes=132 range_key_count=2 range_key_bytes=27 range_val_count=2 live_count=6 live_bytes=174 gc_bytes_age=17863 intent_count=1 intent_bytes=19 lock_count=1 lock_age=93
+stats: key_count=11 key_bytes=250 val_count=19 val_bytes=132 range_key_count=1 range_key_bytes=13 range_val_count=1 live_count=4 live_bytes=132 gc_bytes_age=25116 intent_count=1 intent_bytes=19 lock_count=1 lock_age=93
 
 # try the same call as above, except with startTime set to 1
 # check that delrange properly continues the run over a range tombstone
 run stats ok log-ops
-del_range_pred k=j end=r ts=5 startTime=1 rangeThreshold=2
+del_range_pred k=j end=r ts=5 startTime=1
 ----
->> del_range_pred k=j end=r ts=5 startTime=1 rangeThreshold=2
-stats: range_key_count=+2 range_key_bytes=+36 range_val_count=+3 live_count=-2 live_bytes=-42 gc_bytes_age=+7406
+>> del_range_pred k=j end=r ts=5 startTime=1
+stats: key_bytes=+12 val_count=+1 live_count=-1 live_bytes=-21 gc_bytes_age=+3135
 >> at end:
-rangekey: {f-h\x00}/[5.000000000,0=/<empty>]
-rangekey: {j-k}/[5.000000000,0=/<empty>]
-rangekey: {k-p}/[5.000000000,0=/<empty> 4.000000000,0=/<empty>]
-rangekey: {p-q\x00}/[5.000000000,0=/<empty>]
+rangekey: {k-p}/[4.000000000,0=/<empty>]
 data: "a"/4.000000000,0 -> /<empty>
 data: "a"/2.000000000,0 -> /BYTES/a2
 data: "b"/3.000000000,0 -> /BYTES/b3
+data: "c"/5.000000000,0 -> /<empty>
 data: "c"/2.000000000,0 -> /BYTES/c2
 data: "d"/5.000000000,0 -> /<empty>
 data: "d"/4.000000000,0 -> /BYTES/d4
 data: "d"/1.000000000,0 -> /BYTES/d1
 data: "e"/2.000000000,0 -> /BYTES/e2
+data: "f"/5.000000000,0 -> /<empty>
 data: "f"/4.000000000,0 -> /BYTES/f4
 data: "g"/4.000000000,0 -> /<empty>
 data: "g"/2.000000000,0 -> /BYTES/g2
+data: "h"/5.000000000,0 -> /<empty>
 data: "h"/4.000000000,0 -> /BYTES/h4
 meta: "i"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "i"/7.000000000,0 -> /BYTES/i7
+data: "j"/4.000000000,0 -> /<empty>
 data: "j"/2.000000000,0 -> /BYTES/j2
+data: "q"/5.000000000,0 -> /<empty>
 data: "q"/2.000000000,0 -> /BYTES/q2
-logical op: delete_range: startKey="j" endKey="q\x00" ts=5.000000000,0
-stats: key_count=11 key_bytes=202 val_count=15 val_bytes=132 range_key_count=4 range_key_bytes=63 range_val_count=5 live_count=4 live_bytes=132 gc_bytes_age=25269 intent_count=1 intent_bytes=19 lock_count=1 lock_age=93
+logical op: write_value: key="q", ts=5.000000000,0
+stats: key_count=11 key_bytes=262 val_count=20 val_bytes=132 range_key_count=1 range_key_bytes=13 range_val_count=1 live_count=3 live_bytes=111 gc_bytes_age=28251 intent_count=1 intent_bytes=19 lock_count=1 lock_age=93
 
-# check that we flush with a range tombstone, if maxBytes is exceeded
-# even though range tombstone threshold has not been met.
-# Return a resume span. Note that the run extends past key d, since
-# its latest value is a point tombstone, and is therefore not counted
-# in runByteSize.
+# check that we return a resume span if maxBytes is exceeded.
+# Return a resume span without writing any tombstones since the first key
+# already exceeds maxBytes=1.
 run stats ok
 del_range_pred k=c end=i ts=6 startTime=1 maxBytes=1
 ----
 >> del_range_pred k=c end=i ts=6 startTime=1 maxBytes=1
 del_range_pred: resume span ["e","i")
-stats: range_key_count=+1 range_key_bytes=+14 range_val_count=+1 live_count=-1 live_bytes=-21 gc_bytes_age=+3290
+stats: no change
 >> at end:
-rangekey: c{-\x00}/[6.000000000,0=/<empty>]
-rangekey: {f-h\x00}/[5.000000000,0=/<empty>]
-rangekey: {j-k}/[5.000000000,0=/<empty>]
-rangekey: {k-p}/[5.000000000,0=/<empty> 4.000000000,0=/<empty>]
-rangekey: {p-q\x00}/[5.000000000,0=/<empty>]
+rangekey: {k-p}/[4.000000000,0=/<empty>]
 data: "a"/4.000000000,0 -> /<empty>
 data: "a"/2.000000000,0 -> /BYTES/a2
 data: "b"/3.000000000,0 -> /BYTES/b3
+data: "c"/5.000000000,0 -> /<empty>
 data: "c"/2.000000000,0 -> /BYTES/c2
 data: "d"/5.000000000,0 -> /<empty>
 data: "d"/4.000000000,0 -> /BYTES/d4
 data: "d"/1.000000000,0 -> /BYTES/d1
 data: "e"/2.000000000,0 -> /BYTES/e2
+data: "f"/5.000000000,0 -> /<empty>
 data: "f"/4.000000000,0 -> /BYTES/f4
 data: "g"/4.000000000,0 -> /<empty>
 data: "g"/2.000000000,0 -> /BYTES/g2
+data: "h"/5.000000000,0 -> /<empty>
 data: "h"/4.000000000,0 -> /BYTES/h4
 meta: "i"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "i"/7.000000000,0 -> /BYTES/i7
+data: "j"/4.000000000,0 -> /<empty>
 data: "j"/2.000000000,0 -> /BYTES/j2
+data: "q"/5.000000000,0 -> /<empty>
 data: "q"/2.000000000,0 -> /BYTES/q2
-stats: key_count=11 key_bytes=202 val_count=15 val_bytes=132 range_key_count=5 range_key_bytes=77 range_val_count=6 live_count=3 live_bytes=111 gc_bytes_age=28559 intent_count=1 intent_bytes=19 lock_count=1 lock_age=93
+stats: key_count=11 key_bytes=262 val_count=20 val_bytes=132 range_key_count=1 range_key_bytes=13 range_val_count=1 live_count=3 live_bytes=111 gc_bytes_age=28251 intent_count=1 intent_bytes=19 lock_count=1 lock_age=93
 
-# check that we flush properly if maxBatchSize is exceeded.
+# check that we return a resume span if maxBatchSize is exceeded.
 # Since max is 1, write a tombstone to e, and as soon as it sees the
 # next eligible key to delete (f), return a resume span.
-# Note that we dont count shadowed tombstones in the batchSize
 run stats ok
 put k=f ts=6 v=f6
 del_range_pred k=c end=i ts=7 startTime=1 max=1
@@ -309,14 +321,11 @@ stats: key_bytes=+12 val_count=+1 val_bytes=+7 live_count=+1 live_bytes=+21 gc_b
 del_range_pred: resume span ["f","i")
 stats: key_bytes=+12 val_count=+1 live_count=-1 live_bytes=-21 gc_bytes_age=+3069
 >> at end:
-rangekey: c{-\x00}/[6.000000000,0=/<empty>]
-rangekey: {f-h\x00}/[5.000000000,0=/<empty>]
-rangekey: {j-k}/[5.000000000,0=/<empty>]
-rangekey: {k-p}/[5.000000000,0=/<empty> 4.000000000,0=/<empty>]
-rangekey: {p-q\x00}/[5.000000000,0=/<empty>]
+rangekey: {k-p}/[4.000000000,0=/<empty>]
 data: "a"/4.000000000,0 -> /<empty>
 data: "a"/2.000000000,0 -> /BYTES/a2
 data: "b"/3.000000000,0 -> /BYTES/b3
+data: "c"/5.000000000,0 -> /<empty>
 data: "c"/2.000000000,0 -> /BYTES/c2
 data: "d"/5.000000000,0 -> /<empty>
 data: "d"/4.000000000,0 -> /BYTES/d4
@@ -324,33 +333,34 @@ data: "d"/1.000000000,0 -> /BYTES/d1
 data: "e"/7.000000000,0 -> /<empty>
 data: "e"/2.000000000,0 -> /BYTES/e2
 data: "f"/6.000000000,0 -> /BYTES/f6
+data: "f"/5.000000000,0 -> /<empty>
 data: "f"/4.000000000,0 -> /BYTES/f4
 data: "g"/4.000000000,0 -> /<empty>
 data: "g"/2.000000000,0 -> /BYTES/g2
+data: "h"/5.000000000,0 -> /<empty>
 data: "h"/4.000000000,0 -> /BYTES/h4
 meta: "i"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "i"/7.000000000,0 -> /BYTES/i7
+data: "j"/4.000000000,0 -> /<empty>
 data: "j"/2.000000000,0 -> /BYTES/j2
+data: "q"/5.000000000,0 -> /<empty>
 data: "q"/2.000000000,0 -> /BYTES/q2
-stats: key_count=11 key_bytes=226 val_count=17 val_bytes=139 range_key_count=5 range_key_bytes=77 range_val_count=6 live_count=3 live_bytes=111 gc_bytes_age=31438 intent_count=1 intent_bytes=19 lock_count=1 lock_age=93
+stats: key_count=11 key_bytes=286 val_count=22 val_bytes=139 range_key_count=1 range_key_bytes=13 range_val_count=1 live_count=3 live_bytes=111 gc_bytes_age=31130 intent_count=1 intent_bytes=19 lock_count=1 lock_age=93
 
-# Run the same DeleteRange as above at ts 8
+# Run the same DeleteRange as above at ts 8.
 # No resume span should get returned because the iterator goes through
-# the whole span without encountering a second eligible key to delete
+# the whole span without encountering a second eligible key to delete.
 run stats ok
 del_range_pred k=c end=i ts=8 startTime=1 max=1
 ----
 >> del_range_pred k=c end=i ts=8 startTime=1 max=1
 stats: key_bytes=+12 val_count=+1 live_count=-1 live_bytes=-21 gc_bytes_age=+3036
 >> at end:
-rangekey: c{-\x00}/[6.000000000,0=/<empty>]
-rangekey: {f-h\x00}/[5.000000000,0=/<empty>]
-rangekey: {j-k}/[5.000000000,0=/<empty>]
-rangekey: {k-p}/[5.000000000,0=/<empty> 4.000000000,0=/<empty>]
-rangekey: {p-q\x00}/[5.000000000,0=/<empty>]
+rangekey: {k-p}/[4.000000000,0=/<empty>]
 data: "a"/4.000000000,0 -> /<empty>
 data: "a"/2.000000000,0 -> /BYTES/a2
 data: "b"/3.000000000,0 -> /BYTES/b3
+data: "c"/5.000000000,0 -> /<empty>
 data: "c"/2.000000000,0 -> /BYTES/c2
 data: "d"/5.000000000,0 -> /<empty>
 data: "d"/4.000000000,0 -> /BYTES/d4
@@ -359,17 +369,21 @@ data: "e"/7.000000000,0 -> /<empty>
 data: "e"/2.000000000,0 -> /BYTES/e2
 data: "f"/8.000000000,0 -> /<empty>
 data: "f"/6.000000000,0 -> /BYTES/f6
+data: "f"/5.000000000,0 -> /<empty>
 data: "f"/4.000000000,0 -> /BYTES/f4
 data: "g"/4.000000000,0 -> /<empty>
 data: "g"/2.000000000,0 -> /BYTES/g2
+data: "h"/5.000000000,0 -> /<empty>
 data: "h"/4.000000000,0 -> /BYTES/h4
 meta: "i"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "i"/7.000000000,0 -> /BYTES/i7
+data: "j"/4.000000000,0 -> /<empty>
 data: "j"/2.000000000,0 -> /BYTES/j2
+data: "q"/5.000000000,0 -> /<empty>
 data: "q"/2.000000000,0 -> /BYTES/q2
-stats: key_count=11 key_bytes=238 val_count=18 val_bytes=139 range_key_count=5 range_key_bytes=77 range_val_count=6 live_count=2 live_bytes=90 gc_bytes_age=34474 intent_count=1 intent_bytes=19 lock_count=1 lock_age=93
+stats: key_count=11 key_bytes=298 val_count=23 val_bytes=139 range_key_count=1 range_key_bytes=13 range_val_count=1 live_count=2 live_bytes=90 gc_bytes_age=34166 intent_count=1 intent_bytes=19 lock_count=1 lock_age=93
 
-# Write some new keys on a and b and ensure a run of point tombstones gets properly written
+# Write some new keys on a and b and ensure point tombstones get properly written.
 run stats ok
 put k=a ts=5 v=a5
 put k=b ts=5 v=a5
@@ -382,11 +396,7 @@ stats: key_bytes=+12 val_count=+1 val_bytes=+7 gc_bytes_age=+1805
 >> del_range_pred k=a end=c ts=6 startTime=1
 stats: key_bytes=+24 val_count=+2 live_count=-2 live_bytes=-42 gc_bytes_age=+6204
 >> at end:
-rangekey: c{-\x00}/[6.000000000,0=/<empty>]
-rangekey: {f-h\x00}/[5.000000000,0=/<empty>]
-rangekey: {j-k}/[5.000000000,0=/<empty>]
-rangekey: {k-p}/[5.000000000,0=/<empty> 4.000000000,0=/<empty>]
-rangekey: {p-q\x00}/[5.000000000,0=/<empty>]
+rangekey: {k-p}/[4.000000000,0=/<empty>]
 data: "a"/6.000000000,0 -> /<empty>
 data: "a"/5.000000000,0 -> /BYTES/a5
 data: "a"/4.000000000,0 -> /<empty>
@@ -394,6 +404,7 @@ data: "a"/2.000000000,0 -> /BYTES/a2
 data: "b"/6.000000000,0 -> /<empty>
 data: "b"/5.000000000,0 -> /BYTES/a5
 data: "b"/3.000000000,0 -> /BYTES/b3
+data: "c"/5.000000000,0 -> /<empty>
 data: "c"/2.000000000,0 -> /BYTES/c2
 data: "d"/5.000000000,0 -> /<empty>
 data: "d"/4.000000000,0 -> /BYTES/d4
@@ -402,12 +413,16 @@ data: "e"/7.000000000,0 -> /<empty>
 data: "e"/2.000000000,0 -> /BYTES/e2
 data: "f"/8.000000000,0 -> /<empty>
 data: "f"/6.000000000,0 -> /BYTES/f6
+data: "f"/5.000000000,0 -> /<empty>
 data: "f"/4.000000000,0 -> /BYTES/f4
 data: "g"/4.000000000,0 -> /<empty>
 data: "g"/2.000000000,0 -> /BYTES/g2
+data: "h"/5.000000000,0 -> /<empty>
 data: "h"/4.000000000,0 -> /BYTES/h4
 meta: "i"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "i"/7.000000000,0 -> /BYTES/i7
+data: "j"/4.000000000,0 -> /<empty>
 data: "j"/2.000000000,0 -> /BYTES/j2
+data: "q"/5.000000000,0 -> /<empty>
 data: "q"/2.000000000,0 -> /BYTES/q2
-stats: key_count=11 key_bytes=286 val_count=22 val_bytes=153 range_key_count=5 range_key_bytes=77 range_val_count=6 live_count=1 live_bytes=69 gc_bytes_age=42291 intent_count=1 intent_bytes=19 lock_count=1 lock_age=93
+stats: key_count=11 key_bytes=346 val_count=27 val_bytes=153 range_key_count=1 range_key_bytes=13 range_val_count=1 live_count=1 live_bytes=69 gc_bytes_age=41983 intent_count=1 intent_bytes=19 lock_count=1 lock_age=93

--- a/pkg/storage/testdata/mvcc_histories/delete_range_predicate_complex
+++ b/pkg/storage/testdata/mvcc_histories/delete_range_predicate_complex
@@ -116,11 +116,11 @@ data: "k"/2.000000000,0 -> /BYTES/k2
 data: "p"/6.000000000,0 -> /BYTES/p6
 stats: key_count=11 key_bytes=226 val_count=17 val_bytes=98 range_key_count=8 range_key_bytes=158 range_val_count=14 live_count=5 live_bytes=105 gc_bytes_age=36216
 
-# Delete the entire span, using both point and range tombstones.
+# Delete the entire span, using point tombstones.
 run stats ok log-ops
-del_range_pred k=a end=z ts=10 startTime=0 rangeThreshold=10
+del_range_pred k=a end=z ts=10 startTime=0
 ----
->> del_range_pred k=a end=z ts=10 startTime=0 rangeThreshold=10
+>> del_range_pred k=a end=z ts=10 startTime=0
 stats: key_bytes=+60 val_count=+5 live_count=-5 live_bytes=-105 gc_bytes_age=+14850
 >> at end:
 rangekey: {a-b}/[1.000000000,0=/<empty>]
@@ -194,45 +194,48 @@ data: "p"/6.000000000,0 -> /BYTES/p6
 stats: key_count=11 key_bytes=226 val_count=17 val_bytes=98 range_key_count=8 range_key_bytes=158 range_val_count=14 live_count=5 live_bytes=105 gc_bytes_age=36216
 
 run stats ok
-del_range_pred k=a end=z ts=10 startTime=0 rangeThreshold=1
+del_range_pred k=a end=z ts=10 startTime=0
 ----
->> del_range_pred k=a end=z ts=10 startTime=0 rangeThreshold=1
-stats: range_key_count=+2 range_key_bytes=+63 range_val_count=+6 live_count=-5 live_bytes=-105 gc_bytes_age=+15024
+>> del_range_pred k=a end=z ts=10 startTime=0
+stats: key_bytes=+60 val_count=+5 live_count=-5 live_bytes=-105 gc_bytes_age=+14850
 >> at end:
 rangekey: {a-b}/[1.000000000,0=/<empty>]
 rangekey: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
 rangekey: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
 rangekey: {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
-rangekey: {f-h}/[10.000000000,0=/<empty> 5.000000000,0=/<empty> 3.000000000,0=/<empty>]
-rangekey: {h-k}/[10.000000000,0=/<empty> 1.000000000,0=/<empty>]
-rangekey: {k-l}/[10.000000000,0=/<empty>]
-rangekey: {l-n}/[10.000000000,0=/<empty> 5.000000000,0=/<empty>]
-rangekey: {n-o}/[10.000000000,0=/<empty> 5.000000000,0=/<empty> 3.000000000,0=/<empty>]
-rangekey: {o-p\x00}/[10.000000000,0=/<empty>]
+rangekey: {f-h}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
+rangekey: {h-k}/[1.000000000,0=/<empty>]
+rangekey: {l-n}/[5.000000000,0=/<empty>]
+rangekey: {n-o}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
 data: "a"/4.000000000,0 -> /<empty>
 data: "a"/2.000000000,0 -> /BYTES/a2
 data: "b"/4.000000000,0 -> /<empty>
 data: "d"/4.000000000,0 -> /BYTES/d4
 data: "d"/2.000000000,0 -> /BYTES/d2
 data: "e"/3.000000000,0 -> /BYTES/e3
+data: "f"/10.000000000,0 -> /<empty>
 data: "f"/6.000000000,0 -> /BYTES/f6
 data: "f"/4.000000000,0 -> /BYTES/f4
 data: "f"/2.000000000,0 -> /BYTES/f2
 data: "g"/4.000000000,0 -> /BYTES/g4
 data: "g"/2.000000000,0 -> /BYTES/g2
+data: "h"/10.000000000,0 -> /<empty>
 data: "h"/3.000000000,0 -> /BYTES/h3
+data: "i"/10.000000000,0 -> /<empty>
 data: "i"/5.000000000,0 -> /BYTES/i5
 data: "j"/6.000000000,0 -> /<empty>
 data: "j"/2.000000000,0 -> /BYTES/j2
+data: "k"/10.000000000,0 -> /<empty>
 data: "k"/2.000000000,0 -> /BYTES/k2
+data: "p"/10.000000000,0 -> /<empty>
 data: "p"/6.000000000,0 -> /BYTES/p6
-stats: key_count=11 key_bytes=226 val_count=17 val_bytes=98 range_key_count=10 range_key_bytes=221 range_val_count=20 gc_bytes_age=51240
+stats: key_count=11 key_bytes=286 val_count=22 val_bytes=98 range_key_count=8 range_key_bytes=158 range_val_count=14 gc_bytes_age=51066
 
 run stats ok
 clear_time_range k=a end=z ts=10 targetTs=6
 ----
 >> clear_time_range k=a end=z ts=10 targetTs=6
-stats: range_key_count=-2 range_key_bytes=-63 range_val_count=-6 live_count=+5 live_bytes=+105 gc_bytes_age=-15024
+stats: key_bytes=-60 val_count=-5 live_count=+5 live_bytes=+105 gc_bytes_age=-14850
 >> at end:
 rangekey: {a-b}/[1.000000000,0=/<empty>]
 rangekey: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
@@ -262,50 +265,49 @@ data: "p"/6.000000000,0 -> /BYTES/p6
 stats: key_count=11 key_bytes=226 val_count=17 val_bytes=98 range_key_count=8 range_key_bytes=158 range_val_count=14 live_count=5 live_bytes=105 gc_bytes_age=36216
 
 run stats ok log-ops
-del_range_pred k=a end=z ts=7 startTime=3 rangeThreshold=1
+del_range_pred k=a end=z ts=7 startTime=3
 ----
->> del_range_pred k=a end=z ts=7 startTime=3 rangeThreshold=1
-stats: range_key_count=+4 range_key_bytes=+84 range_val_count=+7 live_count=-3 live_bytes=-63 gc_bytes_age=+13865
+>> del_range_pred k=a end=z ts=7 startTime=3
+stats: key_bytes=+36 val_count=+3 live_count=-3 live_bytes=-63 gc_bytes_age=+9207
 >> at end:
 rangekey: {a-b}/[1.000000000,0=/<empty>]
 rangekey: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
 rangekey: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
 rangekey: {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
-rangekey: f{-\x00}/[7.000000000,0=/<empty> 5.000000000,0=/<empty> 3.000000000,0=/<empty>]
-rangekey: {f\x00-h}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
-rangekey: {h-i}/[1.000000000,0=/<empty>]
-rangekey: i{-\x00}/[7.000000000,0=/<empty> 1.000000000,0=/<empty>]
-rangekey: {i\x00-k}/[1.000000000,0=/<empty>]
+rangekey: {f-h}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
+rangekey: {h-k}/[1.000000000,0=/<empty>]
 rangekey: {l-n}/[5.000000000,0=/<empty>]
 rangekey: {n-o}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
-rangekey: p{-\x00}/[7.000000000,0=/<empty>]
 data: "a"/4.000000000,0 -> /<empty>
 data: "a"/2.000000000,0 -> /BYTES/a2
 data: "b"/4.000000000,0 -> /<empty>
 data: "d"/4.000000000,0 -> /BYTES/d4
 data: "d"/2.000000000,0 -> /BYTES/d2
 data: "e"/3.000000000,0 -> /BYTES/e3
+data: "f"/7.000000000,0 -> /<empty>
 data: "f"/6.000000000,0 -> /BYTES/f6
 data: "f"/4.000000000,0 -> /BYTES/f4
 data: "f"/2.000000000,0 -> /BYTES/f2
 data: "g"/4.000000000,0 -> /BYTES/g4
 data: "g"/2.000000000,0 -> /BYTES/g2
 data: "h"/3.000000000,0 -> /BYTES/h3
+data: "i"/7.000000000,0 -> /<empty>
 data: "i"/5.000000000,0 -> /BYTES/i5
 data: "j"/6.000000000,0 -> /<empty>
 data: "j"/2.000000000,0 -> /BYTES/j2
 data: "k"/2.000000000,0 -> /BYTES/k2
+data: "p"/7.000000000,0 -> /<empty>
 data: "p"/6.000000000,0 -> /BYTES/p6
-logical op: delete_range: startKey="f" endKey="f\x00" ts=7.000000000,0
-logical op: delete_range: startKey="i" endKey="i\x00" ts=7.000000000,0
-logical op: delete_range: startKey="p" endKey="p\x00" ts=7.000000000,0
-stats: key_count=11 key_bytes=226 val_count=17 val_bytes=98 range_key_count=12 range_key_bytes=242 range_val_count=21 live_count=2 live_bytes=42 gc_bytes_age=50081
+logical op: write_value: key="f", ts=7.000000000,0
+logical op: write_value: key="i", ts=7.000000000,0
+logical op: write_value: key="p", ts=7.000000000,0
+stats: key_count=11 key_bytes=262 val_count=20 val_bytes=98 range_key_count=8 range_key_bytes=158 range_val_count=14 live_count=2 live_bytes=42 gc_bytes_age=45423
 
 run stats ok
 clear_time_range k=a end=z ts=10 targetTs=6
 ----
 >> clear_time_range k=a end=z ts=10 targetTs=6
-stats: range_key_count=-4 range_key_bytes=-84 range_val_count=-7 live_count=+3 live_bytes=+63 gc_bytes_age=-13865
+stats: key_bytes=-36 val_count=-3 live_count=+3 live_bytes=+63 gc_bytes_age=-9207
 >> at end:
 rangekey: {a-b}/[1.000000000,0=/<empty>]
 rangekey: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
@@ -337,27 +339,26 @@ stats: key_count=11 key_bytes=226 val_count=17 val_bytes=98 range_key_count=8 ra
 
 # Range tombstone deletion of times (5-10].
 run stats ok
-del_range_pred k=a end=z ts=10 startTime=5 rangeThreshold=1
+del_range_pred k=a end=z ts=10 startTime=5
 ----
->> del_range_pred k=a end=z ts=10 startTime=5 rangeThreshold=1
-stats: range_key_count=+2 range_key_bytes=+47 range_val_count=+4 live_count=-2 live_bytes=-42 gc_bytes_age=+8123
+>> del_range_pred k=a end=z ts=10 startTime=5
+stats: key_bytes=+24 val_count=+2 live_count=-2 live_bytes=-42 gc_bytes_age=+5940
 >> at end:
 rangekey: {a-b}/[1.000000000,0=/<empty>]
 rangekey: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
 rangekey: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
 rangekey: {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
-rangekey: f{-\x00}/[10.000000000,0=/<empty> 5.000000000,0=/<empty> 3.000000000,0=/<empty>]
-rangekey: {f\x00-h}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
+rangekey: {f-h}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
 rangekey: {h-k}/[1.000000000,0=/<empty>]
 rangekey: {l-n}/[5.000000000,0=/<empty>]
 rangekey: {n-o}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
-rangekey: p{-\x00}/[10.000000000,0=/<empty>]
 data: "a"/4.000000000,0 -> /<empty>
 data: "a"/2.000000000,0 -> /BYTES/a2
 data: "b"/4.000000000,0 -> /<empty>
 data: "d"/4.000000000,0 -> /BYTES/d4
 data: "d"/2.000000000,0 -> /BYTES/d2
 data: "e"/3.000000000,0 -> /BYTES/e3
+data: "f"/10.000000000,0 -> /<empty>
 data: "f"/6.000000000,0 -> /BYTES/f6
 data: "f"/4.000000000,0 -> /BYTES/f4
 data: "f"/2.000000000,0 -> /BYTES/f2
@@ -368,14 +369,15 @@ data: "i"/5.000000000,0 -> /BYTES/i5
 data: "j"/6.000000000,0 -> /<empty>
 data: "j"/2.000000000,0 -> /BYTES/j2
 data: "k"/2.000000000,0 -> /BYTES/k2
+data: "p"/10.000000000,0 -> /<empty>
 data: "p"/6.000000000,0 -> /BYTES/p6
-stats: key_count=11 key_bytes=226 val_count=17 val_bytes=98 range_key_count=10 range_key_bytes=205 range_val_count=18 live_count=3 live_bytes=63 gc_bytes_age=44339
+stats: key_count=11 key_bytes=250 val_count=19 val_bytes=98 range_key_count=8 range_key_bytes=158 range_val_count=14 live_count=3 live_bytes=63 gc_bytes_age=42156
 
 run stats ok
 clear_time_range k=a end=z ts=10 targetTs=6
 ----
 >> clear_time_range k=a end=z ts=10 targetTs=6
-stats: range_key_count=-2 range_key_bytes=-47 range_val_count=-4 live_count=+2 live_bytes=+42 gc_bytes_age=-8123
+stats: key_bytes=-24 val_count=-2 live_count=+2 live_bytes=+42 gc_bytes_age=-5940
 >> at end:
 rangekey: {a-b}/[1.000000000,0=/<empty>]
 rangekey: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
@@ -406,27 +408,26 @@ stats: key_count=11 key_bytes=226 val_count=17 val_bytes=98 range_key_count=8 ra
 
 # Range tombstone deletion of times (5-10].
 run stats ok
-del_range_pred k=a end=z ts=10 startTime=5 rangeThreshold=1
+del_range_pred k=a end=z ts=10 startTime=5
 ----
->> del_range_pred k=a end=z ts=10 startTime=5 rangeThreshold=1
-stats: range_key_count=+2 range_key_bytes=+47 range_val_count=+4 live_count=-2 live_bytes=-42 gc_bytes_age=+8123
+>> del_range_pred k=a end=z ts=10 startTime=5
+stats: key_bytes=+24 val_count=+2 live_count=-2 live_bytes=-42 gc_bytes_age=+5940
 >> at end:
 rangekey: {a-b}/[1.000000000,0=/<empty>]
 rangekey: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
 rangekey: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
 rangekey: {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
-rangekey: f{-\x00}/[10.000000000,0=/<empty> 5.000000000,0=/<empty> 3.000000000,0=/<empty>]
-rangekey: {f\x00-h}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
+rangekey: {f-h}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
 rangekey: {h-k}/[1.000000000,0=/<empty>]
 rangekey: {l-n}/[5.000000000,0=/<empty>]
 rangekey: {n-o}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
-rangekey: p{-\x00}/[10.000000000,0=/<empty>]
 data: "a"/4.000000000,0 -> /<empty>
 data: "a"/2.000000000,0 -> /BYTES/a2
 data: "b"/4.000000000,0 -> /<empty>
 data: "d"/4.000000000,0 -> /BYTES/d4
 data: "d"/2.000000000,0 -> /BYTES/d2
 data: "e"/3.000000000,0 -> /BYTES/e3
+data: "f"/10.000000000,0 -> /<empty>
 data: "f"/6.000000000,0 -> /BYTES/f6
 data: "f"/4.000000000,0 -> /BYTES/f4
 data: "f"/2.000000000,0 -> /BYTES/f2
@@ -437,14 +438,15 @@ data: "i"/5.000000000,0 -> /BYTES/i5
 data: "j"/6.000000000,0 -> /<empty>
 data: "j"/2.000000000,0 -> /BYTES/j2
 data: "k"/2.000000000,0 -> /BYTES/k2
+data: "p"/10.000000000,0 -> /<empty>
 data: "p"/6.000000000,0 -> /BYTES/p6
-stats: key_count=11 key_bytes=226 val_count=17 val_bytes=98 range_key_count=10 range_key_bytes=205 range_val_count=18 live_count=3 live_bytes=63 gc_bytes_age=44339
+stats: key_count=11 key_bytes=250 val_count=19 val_bytes=98 range_key_count=8 range_key_bytes=158 range_val_count=14 live_count=3 live_bytes=63 gc_bytes_age=42156
 
 run stats ok
 clear_time_range k=a end=z ts=10 targetTs=6
 ----
 >> clear_time_range k=a end=z ts=10 targetTs=6
-stats: range_key_count=-2 range_key_bytes=-47 range_val_count=-4 live_count=+2 live_bytes=+42 gc_bytes_age=-8123
+stats: key_bytes=-24 val_count=-2 live_count=+2 live_bytes=+42 gc_bytes_age=-5940
 >> at end:
 rangekey: {a-b}/[1.000000000,0=/<empty>]
 rangekey: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
@@ -475,47 +477,46 @@ stats: key_count=11 key_bytes=226 val_count=17 val_bytes=98 range_key_count=8 ra
 
 # Range tombstone deletion of times (4-10].
 run stats ok
-del_range_pred k=a end=z ts=10 startTime=4 rangeThreshold=1
+del_range_pred k=a end=z ts=10 startTime=4
 ----
->> del_range_pred k=a end=z ts=10 startTime=4 rangeThreshold=1
-stats: range_key_count=+4 range_key_bytes=+84 range_val_count=+7 live_count=-3 live_bytes=-63 gc_bytes_age=+13550
+>> del_range_pred k=a end=z ts=10 startTime=4
+stats: key_bytes=+36 val_count=+3 live_count=-3 live_bytes=-63 gc_bytes_age=+8910
 >> at end:
 rangekey: {a-b}/[1.000000000,0=/<empty>]
 rangekey: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
 rangekey: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
 rangekey: {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
-rangekey: f{-\x00}/[10.000000000,0=/<empty> 5.000000000,0=/<empty> 3.000000000,0=/<empty>]
-rangekey: {f\x00-h}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
-rangekey: {h-i}/[1.000000000,0=/<empty>]
-rangekey: i{-\x00}/[10.000000000,0=/<empty> 1.000000000,0=/<empty>]
-rangekey: {i\x00-k}/[1.000000000,0=/<empty>]
+rangekey: {f-h}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
+rangekey: {h-k}/[1.000000000,0=/<empty>]
 rangekey: {l-n}/[5.000000000,0=/<empty>]
 rangekey: {n-o}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
-rangekey: p{-\x00}/[10.000000000,0=/<empty>]
 data: "a"/4.000000000,0 -> /<empty>
 data: "a"/2.000000000,0 -> /BYTES/a2
 data: "b"/4.000000000,0 -> /<empty>
 data: "d"/4.000000000,0 -> /BYTES/d4
 data: "d"/2.000000000,0 -> /BYTES/d2
 data: "e"/3.000000000,0 -> /BYTES/e3
+data: "f"/10.000000000,0 -> /<empty>
 data: "f"/6.000000000,0 -> /BYTES/f6
 data: "f"/4.000000000,0 -> /BYTES/f4
 data: "f"/2.000000000,0 -> /BYTES/f2
 data: "g"/4.000000000,0 -> /BYTES/g4
 data: "g"/2.000000000,0 -> /BYTES/g2
 data: "h"/3.000000000,0 -> /BYTES/h3
+data: "i"/10.000000000,0 -> /<empty>
 data: "i"/5.000000000,0 -> /BYTES/i5
 data: "j"/6.000000000,0 -> /<empty>
 data: "j"/2.000000000,0 -> /BYTES/j2
 data: "k"/2.000000000,0 -> /BYTES/k2
+data: "p"/10.000000000,0 -> /<empty>
 data: "p"/6.000000000,0 -> /BYTES/p6
-stats: key_count=11 key_bytes=226 val_count=17 val_bytes=98 range_key_count=12 range_key_bytes=242 range_val_count=21 live_count=2 live_bytes=42 gc_bytes_age=49766
+stats: key_count=11 key_bytes=262 val_count=20 val_bytes=98 range_key_count=8 range_key_bytes=158 range_val_count=14 live_count=2 live_bytes=42 gc_bytes_age=45126
 
 run stats ok
 clear_time_range k=a end=z ts=10 targetTs=6
 ----
 >> clear_time_range k=a end=z ts=10 targetTs=6
-stats: range_key_count=-4 range_key_bytes=-84 range_val_count=-7 live_count=+3 live_bytes=+63 gc_bytes_age=-13550
+stats: key_bytes=-36 val_count=-3 live_count=+3 live_bytes=+63 gc_bytes_age=-8910
 >> at end:
 rangekey: {a-b}/[1.000000000,0=/<empty>]
 rangekey: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
@@ -546,47 +547,46 @@ stats: key_count=11 key_bytes=226 val_count=17 val_bytes=98 range_key_count=8 ra
 
 # Range tombstone deletion of times (3-10].
 run stats ok
-del_range_pred k=a end=z ts=10 startTime=3 rangeThreshold=1
+del_range_pred k=a end=z ts=10 startTime=3
 ----
->> del_range_pred k=a end=z ts=10 startTime=3 rangeThreshold=1
-stats: range_key_count=+4 range_key_bytes=+84 range_val_count=+7 live_count=-3 live_bytes=-63 gc_bytes_age=+13550
+>> del_range_pred k=a end=z ts=10 startTime=3
+stats: key_bytes=+36 val_count=+3 live_count=-3 live_bytes=-63 gc_bytes_age=+8910
 >> at end:
 rangekey: {a-b}/[1.000000000,0=/<empty>]
 rangekey: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
 rangekey: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
 rangekey: {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
-rangekey: f{-\x00}/[10.000000000,0=/<empty> 5.000000000,0=/<empty> 3.000000000,0=/<empty>]
-rangekey: {f\x00-h}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
-rangekey: {h-i}/[1.000000000,0=/<empty>]
-rangekey: i{-\x00}/[10.000000000,0=/<empty> 1.000000000,0=/<empty>]
-rangekey: {i\x00-k}/[1.000000000,0=/<empty>]
+rangekey: {f-h}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
+rangekey: {h-k}/[1.000000000,0=/<empty>]
 rangekey: {l-n}/[5.000000000,0=/<empty>]
 rangekey: {n-o}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
-rangekey: p{-\x00}/[10.000000000,0=/<empty>]
 data: "a"/4.000000000,0 -> /<empty>
 data: "a"/2.000000000,0 -> /BYTES/a2
 data: "b"/4.000000000,0 -> /<empty>
 data: "d"/4.000000000,0 -> /BYTES/d4
 data: "d"/2.000000000,0 -> /BYTES/d2
 data: "e"/3.000000000,0 -> /BYTES/e3
+data: "f"/10.000000000,0 -> /<empty>
 data: "f"/6.000000000,0 -> /BYTES/f6
 data: "f"/4.000000000,0 -> /BYTES/f4
 data: "f"/2.000000000,0 -> /BYTES/f2
 data: "g"/4.000000000,0 -> /BYTES/g4
 data: "g"/2.000000000,0 -> /BYTES/g2
 data: "h"/3.000000000,0 -> /BYTES/h3
+data: "i"/10.000000000,0 -> /<empty>
 data: "i"/5.000000000,0 -> /BYTES/i5
 data: "j"/6.000000000,0 -> /<empty>
 data: "j"/2.000000000,0 -> /BYTES/j2
 data: "k"/2.000000000,0 -> /BYTES/k2
+data: "p"/10.000000000,0 -> /<empty>
 data: "p"/6.000000000,0 -> /BYTES/p6
-stats: key_count=11 key_bytes=226 val_count=17 val_bytes=98 range_key_count=12 range_key_bytes=242 range_val_count=21 live_count=2 live_bytes=42 gc_bytes_age=49766
+stats: key_count=11 key_bytes=262 val_count=20 val_bytes=98 range_key_count=8 range_key_bytes=158 range_val_count=14 live_count=2 live_bytes=42 gc_bytes_age=45126
 
 run stats ok
 clear_time_range k=a end=z ts=10 targetTs=6
 ----
 >> clear_time_range k=a end=z ts=10 targetTs=6
-stats: range_key_count=-4 range_key_bytes=-84 range_val_count=-7 live_count=+3 live_bytes=+63 gc_bytes_age=-13550
+stats: key_bytes=-36 val_count=-3 live_count=+3 live_bytes=+63 gc_bytes_age=-8910
 >> at end:
 rangekey: {a-b}/[1.000000000,0=/<empty>]
 rangekey: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
@@ -617,45 +617,47 @@ stats: key_count=11 key_bytes=226 val_count=17 val_bytes=98 range_key_count=8 ra
 
 # Range tombstone deletion of times (2-10].
 run stats ok
-del_range_pred k=a end=z ts=10 startTime=2 rangeThreshold=1
+del_range_pred k=a end=z ts=10 startTime=2
 ----
->> del_range_pred k=a end=z ts=10 startTime=2 rangeThreshold=1
-stats: range_key_count=+2 range_key_bytes=+47 range_val_count=+4 live_count=-4 live_bytes=-84 gc_bytes_age=+11860
+>> del_range_pred k=a end=z ts=10 startTime=2
+stats: key_bytes=+48 val_count=+4 live_count=-4 live_bytes=-84 gc_bytes_age=+11880
 >> at end:
 rangekey: {a-b}/[1.000000000,0=/<empty>]
 rangekey: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
 rangekey: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
 rangekey: {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
-rangekey: {f-h}/[10.000000000,0=/<empty> 5.000000000,0=/<empty> 3.000000000,0=/<empty>]
-rangekey: {h-i\x00}/[10.000000000,0=/<empty> 1.000000000,0=/<empty>]
-rangekey: {i\x00-k}/[1.000000000,0=/<empty>]
+rangekey: {f-h}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
+rangekey: {h-k}/[1.000000000,0=/<empty>]
 rangekey: {l-n}/[5.000000000,0=/<empty>]
 rangekey: {n-o}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
-rangekey: p{-\x00}/[10.000000000,0=/<empty>]
 data: "a"/4.000000000,0 -> /<empty>
 data: "a"/2.000000000,0 -> /BYTES/a2
 data: "b"/4.000000000,0 -> /<empty>
 data: "d"/4.000000000,0 -> /BYTES/d4
 data: "d"/2.000000000,0 -> /BYTES/d2
 data: "e"/3.000000000,0 -> /BYTES/e3
+data: "f"/10.000000000,0 -> /<empty>
 data: "f"/6.000000000,0 -> /BYTES/f6
 data: "f"/4.000000000,0 -> /BYTES/f4
 data: "f"/2.000000000,0 -> /BYTES/f2
 data: "g"/4.000000000,0 -> /BYTES/g4
 data: "g"/2.000000000,0 -> /BYTES/g2
+data: "h"/10.000000000,0 -> /<empty>
 data: "h"/3.000000000,0 -> /BYTES/h3
+data: "i"/10.000000000,0 -> /<empty>
 data: "i"/5.000000000,0 -> /BYTES/i5
 data: "j"/6.000000000,0 -> /<empty>
 data: "j"/2.000000000,0 -> /BYTES/j2
 data: "k"/2.000000000,0 -> /BYTES/k2
+data: "p"/10.000000000,0 -> /<empty>
 data: "p"/6.000000000,0 -> /BYTES/p6
-stats: key_count=11 key_bytes=226 val_count=17 val_bytes=98 range_key_count=10 range_key_bytes=205 range_val_count=18 live_count=1 live_bytes=21 gc_bytes_age=48076
+stats: key_count=11 key_bytes=274 val_count=21 val_bytes=98 range_key_count=8 range_key_bytes=158 range_val_count=14 live_count=1 live_bytes=21 gc_bytes_age=48096
 
 run stats ok
 clear_time_range k=a end=z ts=10 targetTs=6
 ----
 >> clear_time_range k=a end=z ts=10 targetTs=6
-stats: range_key_count=-2 range_key_bytes=-47 range_val_count=-4 live_count=+4 live_bytes=+84 gc_bytes_age=-11860
+stats: key_bytes=-48 val_count=-4 live_count=+4 live_bytes=+84 gc_bytes_age=-11880
 >> at end:
 rangekey: {a-b}/[1.000000000,0=/<empty>]
 rangekey: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]

--- a/pkg/storage/testdata/mvcc_histories/delete_range_predicate_continue_tombstone
+++ b/pkg/storage/testdata/mvcc_histories/delete_range_predicate_continue_tombstone
@@ -52,21 +52,24 @@ data: "g"/3.000000000,0 -> /BYTES/g3
 stats: key_count=7 key_bytes=122 val_count=9 val_bytes=81 live_count=4 live_bytes=84 gc_bytes_age=11662
 
 # Even though b, c, e do not satisfy the predicate, their latest versions are
-# tombstones, so the run continues and we write [a,g)@4.
+# tombstones, so we continue iterating and write point tombstones for a, d, f, g.
 run stats ok
-del_range_pred k=a end=z ts=4 startTime=2 rangeThreshold=3
+del_range_pred k=a end=z ts=4 startTime=2
 ----
->> del_range_pred k=a end=z ts=4 startTime=2 rangeThreshold=3
-stats: range_key_count=+1 range_key_bytes=+14 range_val_count=+1 live_count=-4 live_bytes=-84 gc_bytes_age=+9408
+>> del_range_pred k=a end=z ts=4 startTime=2
+stats: key_bytes=+48 val_count=+4 live_count=-4 live_bytes=-84 gc_bytes_age=+12672
 >> at end:
-rangekey: {a-g\x00}/[4.000000000,0=/<empty>]
+data: "a"/4.000000000,0 -> /<empty>
 data: "a"/3.000000000,0 -> /BYTES/a3
 data: "b"/2.000000000,0 -> {localTs=1.000000000,0}/<empty>
 data: "b"/1.000000000,0 -> /BYTES/b1
 data: "c"/2.000000000,0 -> {localTs=1.000000000,0}/<empty>
 data: "c"/1.000000000,0 -> /BYTES/c1
+data: "d"/4.000000000,0 -> /<empty>
 data: "d"/3.000000000,0 -> /BYTES/d3
 data: "e"/2.000000000,0 -> {localTs=1.000000000,0}/<empty>
+data: "f"/4.000000000,0 -> /<empty>
 data: "f"/3.000000000,0 -> /BYTES/f3
+data: "g"/4.000000000,0 -> /<empty>
 data: "g"/3.000000000,0 -> /BYTES/g3
-stats: key_count=7 key_bytes=122 val_count=9 val_bytes=81 range_key_count=1 range_key_bytes=14 range_val_count=1 gc_bytes_age=21070
+stats: key_count=7 key_bytes=170 val_count=13 val_bytes=81 gc_bytes_age=24334

--- a/pkg/storage/testdata/mvcc_histories/delete_range_predicate_import_epoch
+++ b/pkg/storage/testdata/mvcc_histories/delete_range_predicate_import_epoch
@@ -74,12 +74,11 @@ stats: key_count=10 key_bytes=176 val_count=13 val_bytes=183 live_count=10 live_
 
 # Now lets del_range_pred on epoch 2
 run stats ok log-ops
-del_range_pred k=a end=z ts=10 import_epoch=2 rangeThreshold=3
+del_range_pred k=a end=z ts=10 import_epoch=2
 ----
->> del_range_pred k=a end=z ts=10 import_epoch=2 rangeThreshold=3
-stats: key_bytes=+12 val_count=+1 range_key_count=+1 range_key_bytes=+14 range_val_count=+1 live_count=-5 live_bytes=-150 gc_bytes_age=+15840
+>> del_range_pred k=a end=z ts=10 import_epoch=2
+stats: key_bytes=+60 val_count=+5 live_count=-5 live_bytes=-150 gc_bytes_age=+18900
 >> at end:
-rangekey: {e-h\x00}/[10.000000000,0=/<empty>]
 data: "a"/1.000000000,0 -> {importEpoch=1}/BYTES/a1
 data: "b"/2.000000000,0 -> {importEpoch=1}/BYTES/b2
 data: "c"/10.000000000,0 -> /<empty>
@@ -88,24 +87,30 @@ data: "c"/3.000000000,0 -> /<empty>
 data: "c"/2.000000000,0 -> {importEpoch=1}/BYTES/c2
 data: "d"/3.000000000,0 -> /BYTES/d3
 data: "d"/1.000000000,0 -> {importEpoch=1}/BYTES/d1
+data: "e"/10.000000000,0 -> /<empty>
 data: "e"/4.000000000,0 -> {importEpoch=2}/BYTES/e4
+data: "f"/10.000000000,0 -> /<empty>
 data: "f"/4.000000000,0 -> {importEpoch=2}/BYTES/f4
+data: "g"/10.000000000,0 -> /<empty>
 data: "g"/4.000000000,0 -> {importEpoch=2}/BYTES/g4
+data: "h"/10.000000000,0 -> /<empty>
 data: "h"/5.000000000,0 -> {importEpoch=2}/BYTES/h4
 data: "i"/1.000000000,0 -> {importEpoch=1}/BYTES/i1
 data: "j"/2.000000000,0 -> {importEpoch=1}/BYTES/j2
 logical op: write_value: key="c", ts=10.000000000,0
-logical op: delete_range: startKey="e" endKey="h\x00" ts=10.000000000,0
-stats: key_count=10 key_bytes=188 val_count=14 val_bytes=183 range_key_count=1 range_key_bytes=14 range_val_count=1 live_count=5 live_bytes=141 gc_bytes_age=22436
+logical op: write_value: key="e", ts=10.000000000,0
+logical op: write_value: key="f", ts=10.000000000,0
+logical op: write_value: key="g", ts=10.000000000,0
+logical op: write_value: key="h", ts=10.000000000,0
+stats: key_count=10 key_bytes=236 val_count=18 val_bytes=183 live_count=5 live_bytes=141 gc_bytes_age=25496
 
 # Let's try it again at t11
 run stats ok log-ops
-del_range_pred k=a end=z ts=11 import_epoch=2 rangeThreshold=3
+del_range_pred k=a end=z ts=11 import_epoch=2
 ----
->> del_range_pred k=a end=z ts=11 import_epoch=2 rangeThreshold=3
+>> del_range_pred k=a end=z ts=11 import_epoch=2
 stats: no change
 >> at end:
-rangekey: {e-h\x00}/[10.000000000,0=/<empty>]
 data: "a"/1.000000000,0 -> {importEpoch=1}/BYTES/a1
 data: "b"/2.000000000,0 -> {importEpoch=1}/BYTES/b2
 data: "c"/10.000000000,0 -> /<empty>
@@ -114,13 +119,17 @@ data: "c"/3.000000000,0 -> /<empty>
 data: "c"/2.000000000,0 -> {importEpoch=1}/BYTES/c2
 data: "d"/3.000000000,0 -> /BYTES/d3
 data: "d"/1.000000000,0 -> {importEpoch=1}/BYTES/d1
+data: "e"/10.000000000,0 -> /<empty>
 data: "e"/4.000000000,0 -> {importEpoch=2}/BYTES/e4
+data: "f"/10.000000000,0 -> /<empty>
 data: "f"/4.000000000,0 -> {importEpoch=2}/BYTES/f4
+data: "g"/10.000000000,0 -> /<empty>
 data: "g"/4.000000000,0 -> {importEpoch=2}/BYTES/g4
+data: "h"/10.000000000,0 -> /<empty>
 data: "h"/5.000000000,0 -> {importEpoch=2}/BYTES/h4
 data: "i"/1.000000000,0 -> {importEpoch=1}/BYTES/i1
 data: "j"/2.000000000,0 -> {importEpoch=1}/BYTES/j2
-stats: key_count=10 key_bytes=188 val_count=14 val_bytes=183 range_key_count=1 range_key_bytes=14 range_val_count=1 live_count=5 live_bytes=141 gc_bytes_age=22436
+stats: key_count=10 key_bytes=236 val_count=18 val_bytes=183 live_count=5 live_bytes=141 gc_bytes_age=25496
 
 run ok
 clear_range k=a end=z
@@ -158,23 +167,29 @@ data: "i"/4.000000000,0 -> {importEpoch=1}/BYTES/i
 data: "j"/1.000000000,0 -> {importEpoch=1}/BYTES/j
 
 run stats ok log-ops
-del_range_pred k=a end=z ts=5 import_epoch=2 rangeThreshold=3
+del_range_pred k=a end=z ts=5 import_epoch=2
 ----
->> del_range_pred k=a end=z ts=5 import_epoch=2 rangeThreshold=3
-stats: key_bytes=+12 val_count=+1 range_key_count=+1 range_key_bytes=+14 range_val_count=+1 live_count=-5 live_bytes=-145 gc_bytes_age=+16245
+>> del_range_pred k=a end=z ts=5 import_epoch=2
+stats: key_bytes=+60 val_count=+5 live_count=-5 live_bytes=-145 gc_bytes_age=+19475
 >> at end:
-rangekey: {e-h\x00}/[5.000000000,0=/<empty>]
 data: "a"/1.000000000,0 -> {importEpoch=1}/BYTES/a
 data: "b"/5.000000000,0 -> /<empty>
 data: "b"/2.000000000,0 -> {importEpoch=2}/BYTES/b
 data: "c"/2.000000000,0 -> {importEpoch=1}/BYTES/c
 data: "d"/1.000000000,0 -> {importEpoch=1}/BYTES/d
+data: "e"/5.000000000,0 -> /<empty>
 data: "e"/3.000000000,0 -> {importEpoch=2}/BYTES/e
+data: "f"/5.000000000,0 -> /<empty>
 data: "f"/1.000000000,0 -> {importEpoch=2}/BYTES/f
+data: "g"/5.000000000,0 -> /<empty>
 data: "g"/2.000000000,0 -> {importEpoch=2}/BYTES/g
+data: "h"/5.000000000,0 -> /<empty>
 data: "h"/3.000000000,0 -> {importEpoch=2}/BYTES/h
 data: "i"/4.000000000,0 -> {importEpoch=1}/BYTES/i
 data: "j"/1.000000000,0 -> {importEpoch=1}/BYTES/j
 logical op: write_value: key="b", ts=5.000000000,0
-logical op: delete_range: startKey="e" endKey="h\x00" ts=5.000000000,0
-stats: key_count=10 key_bytes=152 val_count=11 val_bytes=150 range_key_count=1 range_key_bytes=14 range_val_count=1 live_count=5 live_bytes=145 gc_bytes_age=16245
+logical op: write_value: key="e", ts=5.000000000,0
+logical op: write_value: key="f", ts=5.000000000,0
+logical op: write_value: key="g", ts=5.000000000,0
+logical op: write_value: key="h", ts=5.000000000,0
+stats: key_count=10 key_bytes=200 val_count=15 val_bytes=150 live_count=5 live_bytes=145 gc_bytes_age=19475

--- a/pkg/storage/testdata/mvcc_histories/delete_range_predicate_rt
+++ b/pkg/storage/testdata/mvcc_histories/delete_range_predicate_rt
@@ -1,0 +1,413 @@
+# Tests MVCC Del Range with timestamp predicate.
+#
+# Set up some point keys, point tombstones x, range tombstones o--o,
+# and intents [].
+#
+# 7                                [i7]
+# 6
+# 5
+# 4  x           d4     f4   x  h4          o-------------------o
+# 3      b3
+# 2  a2              e2      g2
+# 1              d1
+# 0
+#    a   b   c   d   e   f   g   h   i   j   k   l   m   n   o   p
+run ok
+put k=a ts=2 v=a2
+del k=a ts=4
+put k=b ts=3 v=b3
+put k=d ts=1 v=d1
+put k=d ts=4 v=d4
+put k=e ts=2 v=e2
+put k=f ts=4 v=f4
+put k=g ts=2 v=g2
+del k=g ts=4
+put k=h ts=4 v=h4
+del_range_ts k=k end=p ts=4 rangeTombstone=true
+with t=A
+  txn_begin ts=7
+  put k=i v=i7
+----
+del: "a": found key true
+del: "g": found key true
+put: lock acquisition = {span=i id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
+>> at end:
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=7.000000000,0 gul=0,0
+rangekey: {k-p}/[4.000000000,0=/<empty>]
+data: "a"/4.000000000,0 -> /<empty>
+data: "a"/2.000000000,0 -> /BYTES/a2
+data: "b"/3.000000000,0 -> /BYTES/b3
+data: "d"/4.000000000,0 -> /BYTES/d4
+data: "d"/1.000000000,0 -> /BYTES/d1
+data: "e"/2.000000000,0 -> /BYTES/e2
+data: "f"/4.000000000,0 -> /BYTES/f4
+data: "g"/4.000000000,0 -> /<empty>
+data: "g"/2.000000000,0 -> /BYTES/g2
+data: "h"/4.000000000,0 -> /BYTES/h4
+meta: "i"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "i"/7.000000000,0 -> /BYTES/i7
+
+# Writing next to or above point keys and tombstones should work.
+run stats ok log-ops
+del_range_pred k=a end=i ts=5 startTime=3 rangeThreshold=2 useRangeTombstone=true
+----
+>> del_range_pred k=a end=i ts=5 startTime=3 rangeThreshold=2 useRangeTombstone=true
+stats: key_bytes=+12 val_count=+1 range_key_count=+1 range_key_bytes=+14 range_val_count=+1 live_count=-3 live_bytes=-63 gc_bytes_age=+8455
+>> at end:
+rangekey: {f-h\x00}/[5.000000000,0=/<empty>]
+rangekey: {k-p}/[4.000000000,0=/<empty>]
+data: "a"/4.000000000,0 -> /<empty>
+data: "a"/2.000000000,0 -> /BYTES/a2
+data: "b"/3.000000000,0 -> /BYTES/b3
+data: "d"/5.000000000,0 -> /<empty>
+data: "d"/4.000000000,0 -> /BYTES/d4
+data: "d"/1.000000000,0 -> /BYTES/d1
+data: "e"/2.000000000,0 -> /BYTES/e2
+data: "f"/4.000000000,0 -> /BYTES/f4
+data: "g"/4.000000000,0 -> /<empty>
+data: "g"/2.000000000,0 -> /BYTES/g2
+data: "h"/4.000000000,0 -> /BYTES/h4
+meta: "i"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "i"/7.000000000,0 -> /BYTES/i7
+logical op: write_value: key="d", ts=5.000000000,0
+logical op: delete_range: startKey="f" endKey="h\x00" ts=5.000000000,0
+stats: key_count=8 key_bytes=160 val_count=12 val_bytes=111 range_key_count=2 range_key_bytes=27 range_val_count=2 live_count=3 live_bytes=111 gc_bytes_age=17863 intent_count=1 intent_bytes=19 lock_count=1 lock_age=93
+
+# Error on intent, no tombstones should be written. We try both the
+# point tombstone and range tombstone paths.
+run stats error
+del_range_pred k=a end=p ts=6 startTime=1 useRangeTombstone=true
+----
+>> del_range_pred k=a end=p ts=6 startTime=1 useRangeTombstone=true
+stats: no change
+>> at end:
+rangekey: {f-h\x00}/[5.000000000,0=/<empty>]
+rangekey: {k-p}/[4.000000000,0=/<empty>]
+data: "a"/4.000000000,0 -> /<empty>
+data: "a"/2.000000000,0 -> /BYTES/a2
+data: "b"/3.000000000,0 -> /BYTES/b3
+data: "d"/5.000000000,0 -> /<empty>
+data: "d"/4.000000000,0 -> /BYTES/d4
+data: "d"/1.000000000,0 -> /BYTES/d1
+data: "e"/2.000000000,0 -> /BYTES/e2
+data: "f"/4.000000000,0 -> /BYTES/f4
+data: "g"/4.000000000,0 -> /<empty>
+data: "g"/2.000000000,0 -> /BYTES/g2
+data: "h"/4.000000000,0 -> /BYTES/h4
+meta: "i"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "i"/7.000000000,0 -> /BYTES/i7
+stats: key_count=8 key_bytes=160 val_count=12 val_bytes=111 range_key_count=2 range_key_bytes=27 range_val_count=2 live_count=3 live_bytes=111 gc_bytes_age=17863 intent_count=1 intent_bytes=19 lock_count=1 lock_age=93
+error: (*kvpb.LockConflictError:) conflicting locks on "i"
+
+run stats error
+del_range_pred k=i end=+i ts=6 startTime=1 useRangeTombstone=true
+----
+>> del_range_pred k=i end=+i ts=6 startTime=1 useRangeTombstone=true
+stats: no change
+>> at end:
+rangekey: {f-h\x00}/[5.000000000,0=/<empty>]
+rangekey: {k-p}/[4.000000000,0=/<empty>]
+data: "a"/4.000000000,0 -> /<empty>
+data: "a"/2.000000000,0 -> /BYTES/a2
+data: "b"/3.000000000,0 -> /BYTES/b3
+data: "d"/5.000000000,0 -> /<empty>
+data: "d"/4.000000000,0 -> /BYTES/d4
+data: "d"/1.000000000,0 -> /BYTES/d1
+data: "e"/2.000000000,0 -> /BYTES/e2
+data: "f"/4.000000000,0 -> /BYTES/f4
+data: "g"/4.000000000,0 -> /<empty>
+data: "g"/2.000000000,0 -> /BYTES/g2
+data: "h"/4.000000000,0 -> /BYTES/h4
+meta: "i"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "i"/7.000000000,0 -> /BYTES/i7
+stats: key_count=8 key_bytes=160 val_count=12 val_bytes=111 range_key_count=2 range_key_bytes=27 range_val_count=2 live_count=3 live_bytes=111 gc_bytes_age=17863 intent_count=1 intent_bytes=19 lock_count=1 lock_age=93
+error: (*kvpb.LockConflictError:) conflicting locks on "i"
+
+# error encountering point key at d5.
+# a tombstone should not get written at c5 or e5, since
+# DeleteRange didn't flush before reaching d5.
+run stats error
+put k=c ts=2 v=c2
+del_range_pred k=c end=f ts=5 startTime=1 useRangeTombstone=true
+----
+>> put k=c ts=2 v=c2
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+7 live_count=+1 live_bytes=+21
+>> del_range_pred k=c end=f ts=5 startTime=1 useRangeTombstone=true
+stats: no change
+>> at end:
+rangekey: {f-h\x00}/[5.000000000,0=/<empty>]
+rangekey: {k-p}/[4.000000000,0=/<empty>]
+data: "a"/4.000000000,0 -> /<empty>
+data: "a"/2.000000000,0 -> /BYTES/a2
+data: "b"/3.000000000,0 -> /BYTES/b3
+data: "c"/2.000000000,0 -> /BYTES/c2
+data: "d"/5.000000000,0 -> /<empty>
+data: "d"/4.000000000,0 -> /BYTES/d4
+data: "d"/1.000000000,0 -> /BYTES/d1
+data: "e"/2.000000000,0 -> /BYTES/e2
+data: "f"/4.000000000,0 -> /BYTES/f4
+data: "g"/4.000000000,0 -> /<empty>
+data: "g"/2.000000000,0 -> /BYTES/g2
+data: "h"/4.000000000,0 -> /BYTES/h4
+meta: "i"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "i"/7.000000000,0 -> /BYTES/i7
+stats: key_count=9 key_bytes=174 val_count=13 val_bytes=118 range_key_count=2 range_key_bytes=27 range_val_count=2 live_count=4 live_bytes=132 gc_bytes_age=17863 intent_count=1 intent_bytes=19 lock_count=1 lock_age=93
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "d" at timestamp 5.000000000,0 too old; must write at or above 5.000000000,1
+
+# error encountering range key at k4.
+# a tombstones should not get written to j4 or q4 since
+# DeleteRange did not flush before reaching rangekey {k-p}4.
+run stats error
+put k=j ts=2 v=j2
+put k=q ts=2 v=q2
+del_range_pred k=j end=r ts=4 startTime=1 rangeThreshold=2 useRangeTombstone=true
+----
+>> put k=j ts=2 v=j2
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+7 live_count=+1 live_bytes=+21
+>> put k=q ts=2 v=q2
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+7 live_count=+1 live_bytes=+21
+>> del_range_pred k=j end=r ts=4 startTime=1 rangeThreshold=2 useRangeTombstone=true
+stats: no change
+>> at end:
+rangekey: {f-h\x00}/[5.000000000,0=/<empty>]
+rangekey: {k-p}/[4.000000000,0=/<empty>]
+data: "a"/4.000000000,0 -> /<empty>
+data: "a"/2.000000000,0 -> /BYTES/a2
+data: "b"/3.000000000,0 -> /BYTES/b3
+data: "c"/2.000000000,0 -> /BYTES/c2
+data: "d"/5.000000000,0 -> /<empty>
+data: "d"/4.000000000,0 -> /BYTES/d4
+data: "d"/1.000000000,0 -> /BYTES/d1
+data: "e"/2.000000000,0 -> /BYTES/e2
+data: "f"/4.000000000,0 -> /BYTES/f4
+data: "g"/4.000000000,0 -> /<empty>
+data: "g"/2.000000000,0 -> /BYTES/g2
+data: "h"/4.000000000,0 -> /BYTES/h4
+meta: "i"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "i"/7.000000000,0 -> /BYTES/i7
+data: "j"/2.000000000,0 -> /BYTES/j2
+data: "q"/2.000000000,0 -> /BYTES/q2
+stats: key_count=11 key_bytes=202 val_count=15 val_bytes=132 range_key_count=2 range_key_bytes=27 range_val_count=2 live_count=6 live_bytes=174 gc_bytes_age=17863 intent_count=1 intent_bytes=19 lock_count=1 lock_age=93
+error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k" at timestamp 4.000000000,0 too old; must write at or above 4.000000000,1
+
+# At this point the keyspace looks like this:
+# 7                                [i7]
+# 6
+# 5              x       o-----------o
+# 4  x           d4      f4  x   h4          o-------------------o
+# 3      b3
+# 2  a2     c2       e2      g2          j2                        q2
+# 1              d1
+# 0
+#    a   b   c   d   e   f   g   h   i   j   k   l   m   n   o   p  q
+
+# check that del_range will not write anything if no live keys are in its span
+# and predicate ts. Note that the range keys bounds are [firstMatchingKey,LastMatchingKey.Next()].
+run stats ok
+del_range_pred k=j end=r ts=5 startTime=2 rangeThreshold=2 useRangeTombstone=true
+----
+>> del_range_pred k=j end=r ts=5 startTime=2 rangeThreshold=2 useRangeTombstone=true
+stats: no change
+>> at end:
+rangekey: {f-h\x00}/[5.000000000,0=/<empty>]
+rangekey: {k-p}/[4.000000000,0=/<empty>]
+data: "a"/4.000000000,0 -> /<empty>
+data: "a"/2.000000000,0 -> /BYTES/a2
+data: "b"/3.000000000,0 -> /BYTES/b3
+data: "c"/2.000000000,0 -> /BYTES/c2
+data: "d"/5.000000000,0 -> /<empty>
+data: "d"/4.000000000,0 -> /BYTES/d4
+data: "d"/1.000000000,0 -> /BYTES/d1
+data: "e"/2.000000000,0 -> /BYTES/e2
+data: "f"/4.000000000,0 -> /BYTES/f4
+data: "g"/4.000000000,0 -> /<empty>
+data: "g"/2.000000000,0 -> /BYTES/g2
+data: "h"/4.000000000,0 -> /BYTES/h4
+meta: "i"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "i"/7.000000000,0 -> /BYTES/i7
+data: "j"/2.000000000,0 -> /BYTES/j2
+data: "q"/2.000000000,0 -> /BYTES/q2
+stats: key_count=11 key_bytes=202 val_count=15 val_bytes=132 range_key_count=2 range_key_bytes=27 range_val_count=2 live_count=6 live_bytes=174 gc_bytes_age=17863 intent_count=1 intent_bytes=19 lock_count=1 lock_age=93
+
+# try the same call as above, except with startTime set to 1
+# check that delrange properly continues the run over a range tombstone
+run stats ok log-ops
+del_range_pred k=j end=r ts=5 startTime=1 rangeThreshold=2 useRangeTombstone=true
+----
+>> del_range_pred k=j end=r ts=5 startTime=1 rangeThreshold=2 useRangeTombstone=true
+stats: range_key_count=+2 range_key_bytes=+36 range_val_count=+3 live_count=-2 live_bytes=-42 gc_bytes_age=+7406
+>> at end:
+rangekey: {f-h\x00}/[5.000000000,0=/<empty>]
+rangekey: {j-k}/[5.000000000,0=/<empty>]
+rangekey: {k-p}/[5.000000000,0=/<empty> 4.000000000,0=/<empty>]
+rangekey: {p-q\x00}/[5.000000000,0=/<empty>]
+data: "a"/4.000000000,0 -> /<empty>
+data: "a"/2.000000000,0 -> /BYTES/a2
+data: "b"/3.000000000,0 -> /BYTES/b3
+data: "c"/2.000000000,0 -> /BYTES/c2
+data: "d"/5.000000000,0 -> /<empty>
+data: "d"/4.000000000,0 -> /BYTES/d4
+data: "d"/1.000000000,0 -> /BYTES/d1
+data: "e"/2.000000000,0 -> /BYTES/e2
+data: "f"/4.000000000,0 -> /BYTES/f4
+data: "g"/4.000000000,0 -> /<empty>
+data: "g"/2.000000000,0 -> /BYTES/g2
+data: "h"/4.000000000,0 -> /BYTES/h4
+meta: "i"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "i"/7.000000000,0 -> /BYTES/i7
+data: "j"/2.000000000,0 -> /BYTES/j2
+data: "q"/2.000000000,0 -> /BYTES/q2
+logical op: delete_range: startKey="j" endKey="q\x00" ts=5.000000000,0
+stats: key_count=11 key_bytes=202 val_count=15 val_bytes=132 range_key_count=4 range_key_bytes=63 range_val_count=5 live_count=4 live_bytes=132 gc_bytes_age=25269 intent_count=1 intent_bytes=19 lock_count=1 lock_age=93
+
+# check that we flush with a range tombstone, if maxBytes is exceeded
+# even though range tombstone threshold has not been met.
+# Return a resume span. Note that the run extends past key d, since
+# its latest value is a point tombstone, and is therefore not counted
+# in runByteSize.
+run stats ok
+del_range_pred k=c end=i ts=6 startTime=1 maxBytes=1 useRangeTombstone=true
+----
+>> del_range_pred k=c end=i ts=6 startTime=1 maxBytes=1 useRangeTombstone=true
+del_range_pred: resume span ["e","i")
+stats: range_key_count=+1 range_key_bytes=+14 range_val_count=+1 live_count=-1 live_bytes=-21 gc_bytes_age=+3290
+>> at end:
+rangekey: c{-\x00}/[6.000000000,0=/<empty>]
+rangekey: {f-h\x00}/[5.000000000,0=/<empty>]
+rangekey: {j-k}/[5.000000000,0=/<empty>]
+rangekey: {k-p}/[5.000000000,0=/<empty> 4.000000000,0=/<empty>]
+rangekey: {p-q\x00}/[5.000000000,0=/<empty>]
+data: "a"/4.000000000,0 -> /<empty>
+data: "a"/2.000000000,0 -> /BYTES/a2
+data: "b"/3.000000000,0 -> /BYTES/b3
+data: "c"/2.000000000,0 -> /BYTES/c2
+data: "d"/5.000000000,0 -> /<empty>
+data: "d"/4.000000000,0 -> /BYTES/d4
+data: "d"/1.000000000,0 -> /BYTES/d1
+data: "e"/2.000000000,0 -> /BYTES/e2
+data: "f"/4.000000000,0 -> /BYTES/f4
+data: "g"/4.000000000,0 -> /<empty>
+data: "g"/2.000000000,0 -> /BYTES/g2
+data: "h"/4.000000000,0 -> /BYTES/h4
+meta: "i"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "i"/7.000000000,0 -> /BYTES/i7
+data: "j"/2.000000000,0 -> /BYTES/j2
+data: "q"/2.000000000,0 -> /BYTES/q2
+stats: key_count=11 key_bytes=202 val_count=15 val_bytes=132 range_key_count=5 range_key_bytes=77 range_val_count=6 live_count=3 live_bytes=111 gc_bytes_age=28559 intent_count=1 intent_bytes=19 lock_count=1 lock_age=93
+
+# check that we flush properly if maxBatchSize is exceeded.
+# Since max is 1, write a tombstone to e, and as soon as it sees the
+# next eligible key to delete (f), return a resume span.
+# Note that we dont count shadowed tombstones in the batchSize
+run stats ok
+put k=f ts=6 v=f6
+del_range_pred k=c end=i ts=7 startTime=1 max=1 useRangeTombstone=true
+----
+>> put k=f ts=6 v=f6
+stats: key_bytes=+12 val_count=+1 val_bytes=+7 live_count=+1 live_bytes=+21 gc_bytes_age=-190
+>> del_range_pred k=c end=i ts=7 startTime=1 max=1 useRangeTombstone=true
+del_range_pred: resume span ["f","i")
+stats: key_bytes=+12 val_count=+1 live_count=-1 live_bytes=-21 gc_bytes_age=+3069
+>> at end:
+rangekey: c{-\x00}/[6.000000000,0=/<empty>]
+rangekey: {f-h\x00}/[5.000000000,0=/<empty>]
+rangekey: {j-k}/[5.000000000,0=/<empty>]
+rangekey: {k-p}/[5.000000000,0=/<empty> 4.000000000,0=/<empty>]
+rangekey: {p-q\x00}/[5.000000000,0=/<empty>]
+data: "a"/4.000000000,0 -> /<empty>
+data: "a"/2.000000000,0 -> /BYTES/a2
+data: "b"/3.000000000,0 -> /BYTES/b3
+data: "c"/2.000000000,0 -> /BYTES/c2
+data: "d"/5.000000000,0 -> /<empty>
+data: "d"/4.000000000,0 -> /BYTES/d4
+data: "d"/1.000000000,0 -> /BYTES/d1
+data: "e"/7.000000000,0 -> /<empty>
+data: "e"/2.000000000,0 -> /BYTES/e2
+data: "f"/6.000000000,0 -> /BYTES/f6
+data: "f"/4.000000000,0 -> /BYTES/f4
+data: "g"/4.000000000,0 -> /<empty>
+data: "g"/2.000000000,0 -> /BYTES/g2
+data: "h"/4.000000000,0 -> /BYTES/h4
+meta: "i"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "i"/7.000000000,0 -> /BYTES/i7
+data: "j"/2.000000000,0 -> /BYTES/j2
+data: "q"/2.000000000,0 -> /BYTES/q2
+stats: key_count=11 key_bytes=226 val_count=17 val_bytes=139 range_key_count=5 range_key_bytes=77 range_val_count=6 live_count=3 live_bytes=111 gc_bytes_age=31438 intent_count=1 intent_bytes=19 lock_count=1 lock_age=93
+
+# Run the same DeleteRange as above at ts 8
+# No resume span should get returned because the iterator goes through
+# the whole span without encountering a second eligible key to delete
+run stats ok
+del_range_pred k=c end=i ts=8 startTime=1 max=1 useRangeTombstone=true
+----
+>> del_range_pred k=c end=i ts=8 startTime=1 max=1 useRangeTombstone=true
+stats: key_bytes=+12 val_count=+1 live_count=-1 live_bytes=-21 gc_bytes_age=+3036
+>> at end:
+rangekey: c{-\x00}/[6.000000000,0=/<empty>]
+rangekey: {f-h\x00}/[5.000000000,0=/<empty>]
+rangekey: {j-k}/[5.000000000,0=/<empty>]
+rangekey: {k-p}/[5.000000000,0=/<empty> 4.000000000,0=/<empty>]
+rangekey: {p-q\x00}/[5.000000000,0=/<empty>]
+data: "a"/4.000000000,0 -> /<empty>
+data: "a"/2.000000000,0 -> /BYTES/a2
+data: "b"/3.000000000,0 -> /BYTES/b3
+data: "c"/2.000000000,0 -> /BYTES/c2
+data: "d"/5.000000000,0 -> /<empty>
+data: "d"/4.000000000,0 -> /BYTES/d4
+data: "d"/1.000000000,0 -> /BYTES/d1
+data: "e"/7.000000000,0 -> /<empty>
+data: "e"/2.000000000,0 -> /BYTES/e2
+data: "f"/8.000000000,0 -> /<empty>
+data: "f"/6.000000000,0 -> /BYTES/f6
+data: "f"/4.000000000,0 -> /BYTES/f4
+data: "g"/4.000000000,0 -> /<empty>
+data: "g"/2.000000000,0 -> /BYTES/g2
+data: "h"/4.000000000,0 -> /BYTES/h4
+meta: "i"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "i"/7.000000000,0 -> /BYTES/i7
+data: "j"/2.000000000,0 -> /BYTES/j2
+data: "q"/2.000000000,0 -> /BYTES/q2
+stats: key_count=11 key_bytes=238 val_count=18 val_bytes=139 range_key_count=5 range_key_bytes=77 range_val_count=6 live_count=2 live_bytes=90 gc_bytes_age=34474 intent_count=1 intent_bytes=19 lock_count=1 lock_age=93
+
+# Write some new keys on a and b and ensure a run of point tombstones gets properly written
+run stats ok
+put k=a ts=5 v=a5
+put k=b ts=5 v=a5
+del_range_pred k=a end=c ts=6 startTime=1 useRangeTombstone=true
+----
+>> put k=a ts=5 v=a5
+stats: key_bytes=+12 val_count=+1 val_bytes=+7 live_count=+1 live_bytes=+21 gc_bytes_age=-192
+>> put k=b ts=5 v=a5
+stats: key_bytes=+12 val_count=+1 val_bytes=+7 gc_bytes_age=+1805
+>> del_range_pred k=a end=c ts=6 startTime=1 useRangeTombstone=true
+stats: key_bytes=+24 val_count=+2 live_count=-2 live_bytes=-42 gc_bytes_age=+6204
+>> at end:
+rangekey: c{-\x00}/[6.000000000,0=/<empty>]
+rangekey: {f-h\x00}/[5.000000000,0=/<empty>]
+rangekey: {j-k}/[5.000000000,0=/<empty>]
+rangekey: {k-p}/[5.000000000,0=/<empty> 4.000000000,0=/<empty>]
+rangekey: {p-q\x00}/[5.000000000,0=/<empty>]
+data: "a"/6.000000000,0 -> /<empty>
+data: "a"/5.000000000,0 -> /BYTES/a5
+data: "a"/4.000000000,0 -> /<empty>
+data: "a"/2.000000000,0 -> /BYTES/a2
+data: "b"/6.000000000,0 -> /<empty>
+data: "b"/5.000000000,0 -> /BYTES/a5
+data: "b"/3.000000000,0 -> /BYTES/b3
+data: "c"/2.000000000,0 -> /BYTES/c2
+data: "d"/5.000000000,0 -> /<empty>
+data: "d"/4.000000000,0 -> /BYTES/d4
+data: "d"/1.000000000,0 -> /BYTES/d1
+data: "e"/7.000000000,0 -> /<empty>
+data: "e"/2.000000000,0 -> /BYTES/e2
+data: "f"/8.000000000,0 -> /<empty>
+data: "f"/6.000000000,0 -> /BYTES/f6
+data: "f"/4.000000000,0 -> /BYTES/f4
+data: "g"/4.000000000,0 -> /<empty>
+data: "g"/2.000000000,0 -> /BYTES/g2
+data: "h"/4.000000000,0 -> /BYTES/h4
+meta: "i"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} ts=7.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "i"/7.000000000,0 -> /BYTES/i7
+data: "j"/2.000000000,0 -> /BYTES/j2
+data: "q"/2.000000000,0 -> /BYTES/q2
+stats: key_count=11 key_bytes=286 val_count=22 val_bytes=153 range_key_count=5 range_key_bytes=77 range_val_count=6 live_count=1 live_bytes=69 gc_bytes_age=42291 intent_count=1 intent_bytes=19 lock_count=1 lock_age=93

--- a/pkg/storage/testdata/mvcc_histories/delete_range_predicate_rt_complex
+++ b/pkg/storage/testdata/mvcc_histories/delete_range_predicate_rt_complex
@@ -1,0 +1,685 @@
+# Tests MVCCPredicateDeleteRange with a more complex dataset.
+#
+# Sets up the following dataset, where x is tombstone, o-o is range tombstone, [] is intent.
+#
+#  T
+#  6                      f6              x                       p6
+#  5          o-------------------o   i5          o-----------o
+#  4  x   x       d4      f4  g4
+#  3      o-------o   e3  o-------oh3                     o---o
+#  2  a2          d2      f2  g2          j2  k2
+#  1  o-------------------o       o-----------o
+#     a   b   c   d   e   f   g   h   i   j   k   l   m   n   o   p
+#
+run stats ok
+del_range_ts k=a end=f ts=1
+del_range_ts k=h end=k ts=1
+del_range_ts k=b end=d ts=3
+del_range_ts k=n end=o ts=3
+del_range_ts k=l end=o ts=5
+put k=a ts=2 v=a2
+del k=a ts=4
+del k=b ts=4
+put k=d ts=2 v=d2
+put k=d ts=4 v=d4
+put k=e ts=3 v=e3
+put k=f ts=2 v=f2
+put k=g ts=2 v=g2
+put k=i ts=5 v=i5
+put k=j ts=2 v=j2
+del k=j ts=6
+put k=k ts=2 v=k2
+del_range_ts k=f end=h ts=3 localTs=4
+put k=f ts=4 v=f4
+put k=g ts=4 v=g4
+del_range_ts k=c end=h ts=5
+put k=f ts=6 v=f6
+put k=h ts=3 v=h3
+put k=p ts=6 v=p6
+----
+>> del_range_ts k=a end=f ts=1
+stats: range_key_count=+1 range_key_bytes=+13 range_val_count=+1 gc_bytes_age=+1287
+>> del_range_ts k=h end=k ts=1
+stats: range_key_count=+1 range_key_bytes=+13 range_val_count=+1 gc_bytes_age=+1287
+>> del_range_ts k=b end=d ts=3
+stats: range_key_count=+2 range_key_bytes=+35 range_val_count=+3 gc_bytes_age=+3439
+>> del_range_ts k=n end=o ts=3
+stats: range_key_count=+1 range_key_bytes=+13 range_val_count=+1 gc_bytes_age=+1261
+>> del_range_ts k=l end=o ts=5
+stats: range_key_count=+1 range_key_bytes=+22 range_val_count=+2 gc_bytes_age=+2082
+>> put k=a ts=2 v=a2
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+7 live_count=+1 live_bytes=+21
+>> del k=a ts=4
+del: "a": found key true
+stats: key_bytes=+12 val_count=+1 live_count=-1 live_bytes=-21 gc_bytes_age=+3168
+>> del k=b ts=4
+del: "b": found key false
+stats: key_count=+1 key_bytes=+14 val_count=+1 gc_bytes_age=+1344
+>> put k=d ts=2 v=d2
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+7 live_count=+1 live_bytes=+21
+>> put k=d ts=4 v=d4
+stats: key_bytes=+12 val_count=+1 val_bytes=+7 gc_bytes_age=+1824
+>> put k=e ts=3 v=e3
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+7 live_count=+1 live_bytes=+21
+>> put k=f ts=2 v=f2
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+7 live_count=+1 live_bytes=+21
+>> put k=g ts=2 v=g2
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+7 live_count=+1 live_bytes=+21
+>> put k=i ts=5 v=i5
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+7 live_count=+1 live_bytes=+21
+>> put k=j ts=2 v=j2
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+7 live_count=+1 live_bytes=+21
+>> del k=j ts=6
+del: "j": found key true
+stats: key_bytes=+12 val_count=+1 live_count=-1 live_bytes=-21 gc_bytes_age=+3102
+>> put k=k ts=2 v=k2
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+7 live_count=+1 live_bytes=+21
+>> del_range_ts k=f end=h ts=3 localTs=4
+stats: range_key_count=+1 range_key_bytes=+13 range_val_count=+1 live_count=-2 live_bytes=-42 gc_bytes_age=+5335
+>> put k=f ts=4 v=f4
+stats: key_bytes=+12 val_count=+1 val_bytes=+7 live_count=+1 live_bytes=+21 gc_bytes_age=-194
+>> put k=g ts=4 v=g4
+stats: key_bytes=+12 val_count=+1 val_bytes=+7 live_count=+1 live_bytes=+21 gc_bytes_age=-194
+>> del_range_ts k=c end=h ts=5
+stats: range_key_count=+1 range_key_bytes=+49 range_val_count=+5 live_count=-4 live_bytes=-84 gc_bytes_age=+12665
+>> put k=f ts=6 v=f6
+stats: key_bytes=+12 val_count=+1 val_bytes=+7 live_count=+1 live_bytes=+21 gc_bytes_age=-190
+>> put k=h ts=3 v=h3
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+7 live_count=+1 live_bytes=+21
+>> put k=p ts=6 v=p6
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+7 live_count=+1 live_bytes=+21
+>> at end:
+rangekey: {a-b}/[1.000000000,0=/<empty>]
+rangekey: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {f-h}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
+rangekey: {h-k}/[1.000000000,0=/<empty>]
+rangekey: {l-n}/[5.000000000,0=/<empty>]
+rangekey: {n-o}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
+data: "a"/4.000000000,0 -> /<empty>
+data: "a"/2.000000000,0 -> /BYTES/a2
+data: "b"/4.000000000,0 -> /<empty>
+data: "d"/4.000000000,0 -> /BYTES/d4
+data: "d"/2.000000000,0 -> /BYTES/d2
+data: "e"/3.000000000,0 -> /BYTES/e3
+data: "f"/6.000000000,0 -> /BYTES/f6
+data: "f"/4.000000000,0 -> /BYTES/f4
+data: "f"/2.000000000,0 -> /BYTES/f2
+data: "g"/4.000000000,0 -> /BYTES/g4
+data: "g"/2.000000000,0 -> /BYTES/g2
+data: "h"/3.000000000,0 -> /BYTES/h3
+data: "i"/5.000000000,0 -> /BYTES/i5
+data: "j"/6.000000000,0 -> /<empty>
+data: "j"/2.000000000,0 -> /BYTES/j2
+data: "k"/2.000000000,0 -> /BYTES/k2
+data: "p"/6.000000000,0 -> /BYTES/p6
+stats: key_count=11 key_bytes=226 val_count=17 val_bytes=98 range_key_count=8 range_key_bytes=158 range_val_count=14 live_count=5 live_bytes=105 gc_bytes_age=36216
+
+# Delete the entire span, using both point and range tombstones.
+run stats ok log-ops
+del_range_pred k=a end=z ts=10 startTime=0 rangeThreshold=10 useRangeTombstone=true
+----
+>> del_range_pred k=a end=z ts=10 startTime=0 rangeThreshold=10 useRangeTombstone=true
+stats: key_bytes=+60 val_count=+5 live_count=-5 live_bytes=-105 gc_bytes_age=+14850
+>> at end:
+rangekey: {a-b}/[1.000000000,0=/<empty>]
+rangekey: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {f-h}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
+rangekey: {h-k}/[1.000000000,0=/<empty>]
+rangekey: {l-n}/[5.000000000,0=/<empty>]
+rangekey: {n-o}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
+data: "a"/4.000000000,0 -> /<empty>
+data: "a"/2.000000000,0 -> /BYTES/a2
+data: "b"/4.000000000,0 -> /<empty>
+data: "d"/4.000000000,0 -> /BYTES/d4
+data: "d"/2.000000000,0 -> /BYTES/d2
+data: "e"/3.000000000,0 -> /BYTES/e3
+data: "f"/10.000000000,0 -> /<empty>
+data: "f"/6.000000000,0 -> /BYTES/f6
+data: "f"/4.000000000,0 -> /BYTES/f4
+data: "f"/2.000000000,0 -> /BYTES/f2
+data: "g"/4.000000000,0 -> /BYTES/g4
+data: "g"/2.000000000,0 -> /BYTES/g2
+data: "h"/10.000000000,0 -> /<empty>
+data: "h"/3.000000000,0 -> /BYTES/h3
+data: "i"/10.000000000,0 -> /<empty>
+data: "i"/5.000000000,0 -> /BYTES/i5
+data: "j"/6.000000000,0 -> /<empty>
+data: "j"/2.000000000,0 -> /BYTES/j2
+data: "k"/10.000000000,0 -> /<empty>
+data: "k"/2.000000000,0 -> /BYTES/k2
+data: "p"/10.000000000,0 -> /<empty>
+data: "p"/6.000000000,0 -> /BYTES/p6
+logical op: write_value: key="f", ts=10.000000000,0
+logical op: write_value: key="h", ts=10.000000000,0
+logical op: write_value: key="i", ts=10.000000000,0
+logical op: write_value: key="k", ts=10.000000000,0
+logical op: write_value: key="p", ts=10.000000000,0
+stats: key_count=11 key_bytes=286 val_count=22 val_bytes=98 range_key_count=8 range_key_bytes=158 range_val_count=14 gc_bytes_age=51066
+
+run stats ok
+clear_time_range k=a end=z ts=10 targetTs=6
+----
+>> clear_time_range k=a end=z ts=10 targetTs=6
+stats: key_bytes=-60 val_count=-5 live_count=+5 live_bytes=+105 gc_bytes_age=-14850
+>> at end:
+rangekey: {a-b}/[1.000000000,0=/<empty>]
+rangekey: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {f-h}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
+rangekey: {h-k}/[1.000000000,0=/<empty>]
+rangekey: {l-n}/[5.000000000,0=/<empty>]
+rangekey: {n-o}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
+data: "a"/4.000000000,0 -> /<empty>
+data: "a"/2.000000000,0 -> /BYTES/a2
+data: "b"/4.000000000,0 -> /<empty>
+data: "d"/4.000000000,0 -> /BYTES/d4
+data: "d"/2.000000000,0 -> /BYTES/d2
+data: "e"/3.000000000,0 -> /BYTES/e3
+data: "f"/6.000000000,0 -> /BYTES/f6
+data: "f"/4.000000000,0 -> /BYTES/f4
+data: "f"/2.000000000,0 -> /BYTES/f2
+data: "g"/4.000000000,0 -> /BYTES/g4
+data: "g"/2.000000000,0 -> /BYTES/g2
+data: "h"/3.000000000,0 -> /BYTES/h3
+data: "i"/5.000000000,0 -> /BYTES/i5
+data: "j"/6.000000000,0 -> /<empty>
+data: "j"/2.000000000,0 -> /BYTES/j2
+data: "k"/2.000000000,0 -> /BYTES/k2
+data: "p"/6.000000000,0 -> /BYTES/p6
+stats: key_count=11 key_bytes=226 val_count=17 val_bytes=98 range_key_count=8 range_key_bytes=158 range_val_count=14 live_count=5 live_bytes=105 gc_bytes_age=36216
+
+run stats ok
+del_range_pred k=a end=z ts=10 startTime=0 rangeThreshold=1 useRangeTombstone=true
+----
+>> del_range_pred k=a end=z ts=10 startTime=0 rangeThreshold=1 useRangeTombstone=true
+stats: range_key_count=+2 range_key_bytes=+63 range_val_count=+6 live_count=-5 live_bytes=-105 gc_bytes_age=+15024
+>> at end:
+rangekey: {a-b}/[1.000000000,0=/<empty>]
+rangekey: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {f-h}/[10.000000000,0=/<empty> 5.000000000,0=/<empty> 3.000000000,0=/<empty>]
+rangekey: {h-k}/[10.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {k-l}/[10.000000000,0=/<empty>]
+rangekey: {l-n}/[10.000000000,0=/<empty> 5.000000000,0=/<empty>]
+rangekey: {n-o}/[10.000000000,0=/<empty> 5.000000000,0=/<empty> 3.000000000,0=/<empty>]
+rangekey: {o-p\x00}/[10.000000000,0=/<empty>]
+data: "a"/4.000000000,0 -> /<empty>
+data: "a"/2.000000000,0 -> /BYTES/a2
+data: "b"/4.000000000,0 -> /<empty>
+data: "d"/4.000000000,0 -> /BYTES/d4
+data: "d"/2.000000000,0 -> /BYTES/d2
+data: "e"/3.000000000,0 -> /BYTES/e3
+data: "f"/6.000000000,0 -> /BYTES/f6
+data: "f"/4.000000000,0 -> /BYTES/f4
+data: "f"/2.000000000,0 -> /BYTES/f2
+data: "g"/4.000000000,0 -> /BYTES/g4
+data: "g"/2.000000000,0 -> /BYTES/g2
+data: "h"/3.000000000,0 -> /BYTES/h3
+data: "i"/5.000000000,0 -> /BYTES/i5
+data: "j"/6.000000000,0 -> /<empty>
+data: "j"/2.000000000,0 -> /BYTES/j2
+data: "k"/2.000000000,0 -> /BYTES/k2
+data: "p"/6.000000000,0 -> /BYTES/p6
+stats: key_count=11 key_bytes=226 val_count=17 val_bytes=98 range_key_count=10 range_key_bytes=221 range_val_count=20 gc_bytes_age=51240
+
+run stats ok
+clear_time_range k=a end=z ts=10 targetTs=6
+----
+>> clear_time_range k=a end=z ts=10 targetTs=6
+stats: range_key_count=-2 range_key_bytes=-63 range_val_count=-6 live_count=+5 live_bytes=+105 gc_bytes_age=-15024
+>> at end:
+rangekey: {a-b}/[1.000000000,0=/<empty>]
+rangekey: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {f-h}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
+rangekey: {h-k}/[1.000000000,0=/<empty>]
+rangekey: {l-n}/[5.000000000,0=/<empty>]
+rangekey: {n-o}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
+data: "a"/4.000000000,0 -> /<empty>
+data: "a"/2.000000000,0 -> /BYTES/a2
+data: "b"/4.000000000,0 -> /<empty>
+data: "d"/4.000000000,0 -> /BYTES/d4
+data: "d"/2.000000000,0 -> /BYTES/d2
+data: "e"/3.000000000,0 -> /BYTES/e3
+data: "f"/6.000000000,0 -> /BYTES/f6
+data: "f"/4.000000000,0 -> /BYTES/f4
+data: "f"/2.000000000,0 -> /BYTES/f2
+data: "g"/4.000000000,0 -> /BYTES/g4
+data: "g"/2.000000000,0 -> /BYTES/g2
+data: "h"/3.000000000,0 -> /BYTES/h3
+data: "i"/5.000000000,0 -> /BYTES/i5
+data: "j"/6.000000000,0 -> /<empty>
+data: "j"/2.000000000,0 -> /BYTES/j2
+data: "k"/2.000000000,0 -> /BYTES/k2
+data: "p"/6.000000000,0 -> /BYTES/p6
+stats: key_count=11 key_bytes=226 val_count=17 val_bytes=98 range_key_count=8 range_key_bytes=158 range_val_count=14 live_count=5 live_bytes=105 gc_bytes_age=36216
+
+run stats ok log-ops
+del_range_pred k=a end=z ts=7 startTime=3 rangeThreshold=1 useRangeTombstone=true
+----
+>> del_range_pred k=a end=z ts=7 startTime=3 rangeThreshold=1 useRangeTombstone=true
+stats: range_key_count=+4 range_key_bytes=+84 range_val_count=+7 live_count=-3 live_bytes=-63 gc_bytes_age=+13865
+>> at end:
+rangekey: {a-b}/[1.000000000,0=/<empty>]
+rangekey: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: f{-\x00}/[7.000000000,0=/<empty> 5.000000000,0=/<empty> 3.000000000,0=/<empty>]
+rangekey: {f\x00-h}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
+rangekey: {h-i}/[1.000000000,0=/<empty>]
+rangekey: i{-\x00}/[7.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {i\x00-k}/[1.000000000,0=/<empty>]
+rangekey: {l-n}/[5.000000000,0=/<empty>]
+rangekey: {n-o}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
+rangekey: p{-\x00}/[7.000000000,0=/<empty>]
+data: "a"/4.000000000,0 -> /<empty>
+data: "a"/2.000000000,0 -> /BYTES/a2
+data: "b"/4.000000000,0 -> /<empty>
+data: "d"/4.000000000,0 -> /BYTES/d4
+data: "d"/2.000000000,0 -> /BYTES/d2
+data: "e"/3.000000000,0 -> /BYTES/e3
+data: "f"/6.000000000,0 -> /BYTES/f6
+data: "f"/4.000000000,0 -> /BYTES/f4
+data: "f"/2.000000000,0 -> /BYTES/f2
+data: "g"/4.000000000,0 -> /BYTES/g4
+data: "g"/2.000000000,0 -> /BYTES/g2
+data: "h"/3.000000000,0 -> /BYTES/h3
+data: "i"/5.000000000,0 -> /BYTES/i5
+data: "j"/6.000000000,0 -> /<empty>
+data: "j"/2.000000000,0 -> /BYTES/j2
+data: "k"/2.000000000,0 -> /BYTES/k2
+data: "p"/6.000000000,0 -> /BYTES/p6
+logical op: delete_range: startKey="f" endKey="f\x00" ts=7.000000000,0
+logical op: delete_range: startKey="i" endKey="i\x00" ts=7.000000000,0
+logical op: delete_range: startKey="p" endKey="p\x00" ts=7.000000000,0
+stats: key_count=11 key_bytes=226 val_count=17 val_bytes=98 range_key_count=12 range_key_bytes=242 range_val_count=21 live_count=2 live_bytes=42 gc_bytes_age=50081
+
+run stats ok
+clear_time_range k=a end=z ts=10 targetTs=6
+----
+>> clear_time_range k=a end=z ts=10 targetTs=6
+stats: range_key_count=-4 range_key_bytes=-84 range_val_count=-7 live_count=+3 live_bytes=+63 gc_bytes_age=-13865
+>> at end:
+rangekey: {a-b}/[1.000000000,0=/<empty>]
+rangekey: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {f-h}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
+rangekey: {h-k}/[1.000000000,0=/<empty>]
+rangekey: {l-n}/[5.000000000,0=/<empty>]
+rangekey: {n-o}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
+data: "a"/4.000000000,0 -> /<empty>
+data: "a"/2.000000000,0 -> /BYTES/a2
+data: "b"/4.000000000,0 -> /<empty>
+data: "d"/4.000000000,0 -> /BYTES/d4
+data: "d"/2.000000000,0 -> /BYTES/d2
+data: "e"/3.000000000,0 -> /BYTES/e3
+data: "f"/6.000000000,0 -> /BYTES/f6
+data: "f"/4.000000000,0 -> /BYTES/f4
+data: "f"/2.000000000,0 -> /BYTES/f2
+data: "g"/4.000000000,0 -> /BYTES/g4
+data: "g"/2.000000000,0 -> /BYTES/g2
+data: "h"/3.000000000,0 -> /BYTES/h3
+data: "i"/5.000000000,0 -> /BYTES/i5
+data: "j"/6.000000000,0 -> /<empty>
+data: "j"/2.000000000,0 -> /BYTES/j2
+data: "k"/2.000000000,0 -> /BYTES/k2
+data: "p"/6.000000000,0 -> /BYTES/p6
+stats: key_count=11 key_bytes=226 val_count=17 val_bytes=98 range_key_count=8 range_key_bytes=158 range_val_count=14 live_count=5 live_bytes=105 gc_bytes_age=36216
+
+
+# Range tombstone deletion of times (5-10].
+run stats ok
+del_range_pred k=a end=z ts=10 startTime=5 rangeThreshold=1 useRangeTombstone=true
+----
+>> del_range_pred k=a end=z ts=10 startTime=5 rangeThreshold=1 useRangeTombstone=true
+stats: range_key_count=+2 range_key_bytes=+47 range_val_count=+4 live_count=-2 live_bytes=-42 gc_bytes_age=+8123
+>> at end:
+rangekey: {a-b}/[1.000000000,0=/<empty>]
+rangekey: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: f{-\x00}/[10.000000000,0=/<empty> 5.000000000,0=/<empty> 3.000000000,0=/<empty>]
+rangekey: {f\x00-h}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
+rangekey: {h-k}/[1.000000000,0=/<empty>]
+rangekey: {l-n}/[5.000000000,0=/<empty>]
+rangekey: {n-o}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
+rangekey: p{-\x00}/[10.000000000,0=/<empty>]
+data: "a"/4.000000000,0 -> /<empty>
+data: "a"/2.000000000,0 -> /BYTES/a2
+data: "b"/4.000000000,0 -> /<empty>
+data: "d"/4.000000000,0 -> /BYTES/d4
+data: "d"/2.000000000,0 -> /BYTES/d2
+data: "e"/3.000000000,0 -> /BYTES/e3
+data: "f"/6.000000000,0 -> /BYTES/f6
+data: "f"/4.000000000,0 -> /BYTES/f4
+data: "f"/2.000000000,0 -> /BYTES/f2
+data: "g"/4.000000000,0 -> /BYTES/g4
+data: "g"/2.000000000,0 -> /BYTES/g2
+data: "h"/3.000000000,0 -> /BYTES/h3
+data: "i"/5.000000000,0 -> /BYTES/i5
+data: "j"/6.000000000,0 -> /<empty>
+data: "j"/2.000000000,0 -> /BYTES/j2
+data: "k"/2.000000000,0 -> /BYTES/k2
+data: "p"/6.000000000,0 -> /BYTES/p6
+stats: key_count=11 key_bytes=226 val_count=17 val_bytes=98 range_key_count=10 range_key_bytes=205 range_val_count=18 live_count=3 live_bytes=63 gc_bytes_age=44339
+
+run stats ok
+clear_time_range k=a end=z ts=10 targetTs=6
+----
+>> clear_time_range k=a end=z ts=10 targetTs=6
+stats: range_key_count=-2 range_key_bytes=-47 range_val_count=-4 live_count=+2 live_bytes=+42 gc_bytes_age=-8123
+>> at end:
+rangekey: {a-b}/[1.000000000,0=/<empty>]
+rangekey: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {f-h}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
+rangekey: {h-k}/[1.000000000,0=/<empty>]
+rangekey: {l-n}/[5.000000000,0=/<empty>]
+rangekey: {n-o}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
+data: "a"/4.000000000,0 -> /<empty>
+data: "a"/2.000000000,0 -> /BYTES/a2
+data: "b"/4.000000000,0 -> /<empty>
+data: "d"/4.000000000,0 -> /BYTES/d4
+data: "d"/2.000000000,0 -> /BYTES/d2
+data: "e"/3.000000000,0 -> /BYTES/e3
+data: "f"/6.000000000,0 -> /BYTES/f6
+data: "f"/4.000000000,0 -> /BYTES/f4
+data: "f"/2.000000000,0 -> /BYTES/f2
+data: "g"/4.000000000,0 -> /BYTES/g4
+data: "g"/2.000000000,0 -> /BYTES/g2
+data: "h"/3.000000000,0 -> /BYTES/h3
+data: "i"/5.000000000,0 -> /BYTES/i5
+data: "j"/6.000000000,0 -> /<empty>
+data: "j"/2.000000000,0 -> /BYTES/j2
+data: "k"/2.000000000,0 -> /BYTES/k2
+data: "p"/6.000000000,0 -> /BYTES/p6
+stats: key_count=11 key_bytes=226 val_count=17 val_bytes=98 range_key_count=8 range_key_bytes=158 range_val_count=14 live_count=5 live_bytes=105 gc_bytes_age=36216
+
+# Range tombstone deletion of times (5-10].
+run stats ok
+del_range_pred k=a end=z ts=10 startTime=5 rangeThreshold=1 useRangeTombstone=true
+----
+>> del_range_pred k=a end=z ts=10 startTime=5 rangeThreshold=1 useRangeTombstone=true
+stats: range_key_count=+2 range_key_bytes=+47 range_val_count=+4 live_count=-2 live_bytes=-42 gc_bytes_age=+8123
+>> at end:
+rangekey: {a-b}/[1.000000000,0=/<empty>]
+rangekey: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: f{-\x00}/[10.000000000,0=/<empty> 5.000000000,0=/<empty> 3.000000000,0=/<empty>]
+rangekey: {f\x00-h}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
+rangekey: {h-k}/[1.000000000,0=/<empty>]
+rangekey: {l-n}/[5.000000000,0=/<empty>]
+rangekey: {n-o}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
+rangekey: p{-\x00}/[10.000000000,0=/<empty>]
+data: "a"/4.000000000,0 -> /<empty>
+data: "a"/2.000000000,0 -> /BYTES/a2
+data: "b"/4.000000000,0 -> /<empty>
+data: "d"/4.000000000,0 -> /BYTES/d4
+data: "d"/2.000000000,0 -> /BYTES/d2
+data: "e"/3.000000000,0 -> /BYTES/e3
+data: "f"/6.000000000,0 -> /BYTES/f6
+data: "f"/4.000000000,0 -> /BYTES/f4
+data: "f"/2.000000000,0 -> /BYTES/f2
+data: "g"/4.000000000,0 -> /BYTES/g4
+data: "g"/2.000000000,0 -> /BYTES/g2
+data: "h"/3.000000000,0 -> /BYTES/h3
+data: "i"/5.000000000,0 -> /BYTES/i5
+data: "j"/6.000000000,0 -> /<empty>
+data: "j"/2.000000000,0 -> /BYTES/j2
+data: "k"/2.000000000,0 -> /BYTES/k2
+data: "p"/6.000000000,0 -> /BYTES/p6
+stats: key_count=11 key_bytes=226 val_count=17 val_bytes=98 range_key_count=10 range_key_bytes=205 range_val_count=18 live_count=3 live_bytes=63 gc_bytes_age=44339
+
+run stats ok
+clear_time_range k=a end=z ts=10 targetTs=6
+----
+>> clear_time_range k=a end=z ts=10 targetTs=6
+stats: range_key_count=-2 range_key_bytes=-47 range_val_count=-4 live_count=+2 live_bytes=+42 gc_bytes_age=-8123
+>> at end:
+rangekey: {a-b}/[1.000000000,0=/<empty>]
+rangekey: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {f-h}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
+rangekey: {h-k}/[1.000000000,0=/<empty>]
+rangekey: {l-n}/[5.000000000,0=/<empty>]
+rangekey: {n-o}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
+data: "a"/4.000000000,0 -> /<empty>
+data: "a"/2.000000000,0 -> /BYTES/a2
+data: "b"/4.000000000,0 -> /<empty>
+data: "d"/4.000000000,0 -> /BYTES/d4
+data: "d"/2.000000000,0 -> /BYTES/d2
+data: "e"/3.000000000,0 -> /BYTES/e3
+data: "f"/6.000000000,0 -> /BYTES/f6
+data: "f"/4.000000000,0 -> /BYTES/f4
+data: "f"/2.000000000,0 -> /BYTES/f2
+data: "g"/4.000000000,0 -> /BYTES/g4
+data: "g"/2.000000000,0 -> /BYTES/g2
+data: "h"/3.000000000,0 -> /BYTES/h3
+data: "i"/5.000000000,0 -> /BYTES/i5
+data: "j"/6.000000000,0 -> /<empty>
+data: "j"/2.000000000,0 -> /BYTES/j2
+data: "k"/2.000000000,0 -> /BYTES/k2
+data: "p"/6.000000000,0 -> /BYTES/p6
+stats: key_count=11 key_bytes=226 val_count=17 val_bytes=98 range_key_count=8 range_key_bytes=158 range_val_count=14 live_count=5 live_bytes=105 gc_bytes_age=36216
+
+# Range tombstone deletion of times (4-10].
+run stats ok
+del_range_pred k=a end=z ts=10 startTime=4 rangeThreshold=1 useRangeTombstone=true
+----
+>> del_range_pred k=a end=z ts=10 startTime=4 rangeThreshold=1 useRangeTombstone=true
+stats: range_key_count=+4 range_key_bytes=+84 range_val_count=+7 live_count=-3 live_bytes=-63 gc_bytes_age=+13550
+>> at end:
+rangekey: {a-b}/[1.000000000,0=/<empty>]
+rangekey: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: f{-\x00}/[10.000000000,0=/<empty> 5.000000000,0=/<empty> 3.000000000,0=/<empty>]
+rangekey: {f\x00-h}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
+rangekey: {h-i}/[1.000000000,0=/<empty>]
+rangekey: i{-\x00}/[10.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {i\x00-k}/[1.000000000,0=/<empty>]
+rangekey: {l-n}/[5.000000000,0=/<empty>]
+rangekey: {n-o}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
+rangekey: p{-\x00}/[10.000000000,0=/<empty>]
+data: "a"/4.000000000,0 -> /<empty>
+data: "a"/2.000000000,0 -> /BYTES/a2
+data: "b"/4.000000000,0 -> /<empty>
+data: "d"/4.000000000,0 -> /BYTES/d4
+data: "d"/2.000000000,0 -> /BYTES/d2
+data: "e"/3.000000000,0 -> /BYTES/e3
+data: "f"/6.000000000,0 -> /BYTES/f6
+data: "f"/4.000000000,0 -> /BYTES/f4
+data: "f"/2.000000000,0 -> /BYTES/f2
+data: "g"/4.000000000,0 -> /BYTES/g4
+data: "g"/2.000000000,0 -> /BYTES/g2
+data: "h"/3.000000000,0 -> /BYTES/h3
+data: "i"/5.000000000,0 -> /BYTES/i5
+data: "j"/6.000000000,0 -> /<empty>
+data: "j"/2.000000000,0 -> /BYTES/j2
+data: "k"/2.000000000,0 -> /BYTES/k2
+data: "p"/6.000000000,0 -> /BYTES/p6
+stats: key_count=11 key_bytes=226 val_count=17 val_bytes=98 range_key_count=12 range_key_bytes=242 range_val_count=21 live_count=2 live_bytes=42 gc_bytes_age=49766
+
+run stats ok
+clear_time_range k=a end=z ts=10 targetTs=6
+----
+>> clear_time_range k=a end=z ts=10 targetTs=6
+stats: range_key_count=-4 range_key_bytes=-84 range_val_count=-7 live_count=+3 live_bytes=+63 gc_bytes_age=-13550
+>> at end:
+rangekey: {a-b}/[1.000000000,0=/<empty>]
+rangekey: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {f-h}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
+rangekey: {h-k}/[1.000000000,0=/<empty>]
+rangekey: {l-n}/[5.000000000,0=/<empty>]
+rangekey: {n-o}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
+data: "a"/4.000000000,0 -> /<empty>
+data: "a"/2.000000000,0 -> /BYTES/a2
+data: "b"/4.000000000,0 -> /<empty>
+data: "d"/4.000000000,0 -> /BYTES/d4
+data: "d"/2.000000000,0 -> /BYTES/d2
+data: "e"/3.000000000,0 -> /BYTES/e3
+data: "f"/6.000000000,0 -> /BYTES/f6
+data: "f"/4.000000000,0 -> /BYTES/f4
+data: "f"/2.000000000,0 -> /BYTES/f2
+data: "g"/4.000000000,0 -> /BYTES/g4
+data: "g"/2.000000000,0 -> /BYTES/g2
+data: "h"/3.000000000,0 -> /BYTES/h3
+data: "i"/5.000000000,0 -> /BYTES/i5
+data: "j"/6.000000000,0 -> /<empty>
+data: "j"/2.000000000,0 -> /BYTES/j2
+data: "k"/2.000000000,0 -> /BYTES/k2
+data: "p"/6.000000000,0 -> /BYTES/p6
+stats: key_count=11 key_bytes=226 val_count=17 val_bytes=98 range_key_count=8 range_key_bytes=158 range_val_count=14 live_count=5 live_bytes=105 gc_bytes_age=36216
+
+# Range tombstone deletion of times (3-10].
+run stats ok
+del_range_pred k=a end=z ts=10 startTime=3 rangeThreshold=1 useRangeTombstone=true
+----
+>> del_range_pred k=a end=z ts=10 startTime=3 rangeThreshold=1 useRangeTombstone=true
+stats: range_key_count=+4 range_key_bytes=+84 range_val_count=+7 live_count=-3 live_bytes=-63 gc_bytes_age=+13550
+>> at end:
+rangekey: {a-b}/[1.000000000,0=/<empty>]
+rangekey: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: f{-\x00}/[10.000000000,0=/<empty> 5.000000000,0=/<empty> 3.000000000,0=/<empty>]
+rangekey: {f\x00-h}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
+rangekey: {h-i}/[1.000000000,0=/<empty>]
+rangekey: i{-\x00}/[10.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {i\x00-k}/[1.000000000,0=/<empty>]
+rangekey: {l-n}/[5.000000000,0=/<empty>]
+rangekey: {n-o}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
+rangekey: p{-\x00}/[10.000000000,0=/<empty>]
+data: "a"/4.000000000,0 -> /<empty>
+data: "a"/2.000000000,0 -> /BYTES/a2
+data: "b"/4.000000000,0 -> /<empty>
+data: "d"/4.000000000,0 -> /BYTES/d4
+data: "d"/2.000000000,0 -> /BYTES/d2
+data: "e"/3.000000000,0 -> /BYTES/e3
+data: "f"/6.000000000,0 -> /BYTES/f6
+data: "f"/4.000000000,0 -> /BYTES/f4
+data: "f"/2.000000000,0 -> /BYTES/f2
+data: "g"/4.000000000,0 -> /BYTES/g4
+data: "g"/2.000000000,0 -> /BYTES/g2
+data: "h"/3.000000000,0 -> /BYTES/h3
+data: "i"/5.000000000,0 -> /BYTES/i5
+data: "j"/6.000000000,0 -> /<empty>
+data: "j"/2.000000000,0 -> /BYTES/j2
+data: "k"/2.000000000,0 -> /BYTES/k2
+data: "p"/6.000000000,0 -> /BYTES/p6
+stats: key_count=11 key_bytes=226 val_count=17 val_bytes=98 range_key_count=12 range_key_bytes=242 range_val_count=21 live_count=2 live_bytes=42 gc_bytes_age=49766
+
+run stats ok
+clear_time_range k=a end=z ts=10 targetTs=6
+----
+>> clear_time_range k=a end=z ts=10 targetTs=6
+stats: range_key_count=-4 range_key_bytes=-84 range_val_count=-7 live_count=+3 live_bytes=+63 gc_bytes_age=-13550
+>> at end:
+rangekey: {a-b}/[1.000000000,0=/<empty>]
+rangekey: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {f-h}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
+rangekey: {h-k}/[1.000000000,0=/<empty>]
+rangekey: {l-n}/[5.000000000,0=/<empty>]
+rangekey: {n-o}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
+data: "a"/4.000000000,0 -> /<empty>
+data: "a"/2.000000000,0 -> /BYTES/a2
+data: "b"/4.000000000,0 -> /<empty>
+data: "d"/4.000000000,0 -> /BYTES/d4
+data: "d"/2.000000000,0 -> /BYTES/d2
+data: "e"/3.000000000,0 -> /BYTES/e3
+data: "f"/6.000000000,0 -> /BYTES/f6
+data: "f"/4.000000000,0 -> /BYTES/f4
+data: "f"/2.000000000,0 -> /BYTES/f2
+data: "g"/4.000000000,0 -> /BYTES/g4
+data: "g"/2.000000000,0 -> /BYTES/g2
+data: "h"/3.000000000,0 -> /BYTES/h3
+data: "i"/5.000000000,0 -> /BYTES/i5
+data: "j"/6.000000000,0 -> /<empty>
+data: "j"/2.000000000,0 -> /BYTES/j2
+data: "k"/2.000000000,0 -> /BYTES/k2
+data: "p"/6.000000000,0 -> /BYTES/p6
+stats: key_count=11 key_bytes=226 val_count=17 val_bytes=98 range_key_count=8 range_key_bytes=158 range_val_count=14 live_count=5 live_bytes=105 gc_bytes_age=36216
+
+# Range tombstone deletion of times (2-10].
+run stats ok
+del_range_pred k=a end=z ts=10 startTime=2 rangeThreshold=1 useRangeTombstone=true
+----
+>> del_range_pred k=a end=z ts=10 startTime=2 rangeThreshold=1 useRangeTombstone=true
+stats: range_key_count=+2 range_key_bytes=+47 range_val_count=+4 live_count=-4 live_bytes=-84 gc_bytes_age=+11860
+>> at end:
+rangekey: {a-b}/[1.000000000,0=/<empty>]
+rangekey: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {f-h}/[10.000000000,0=/<empty> 5.000000000,0=/<empty> 3.000000000,0=/<empty>]
+rangekey: {h-i\x00}/[10.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {i\x00-k}/[1.000000000,0=/<empty>]
+rangekey: {l-n}/[5.000000000,0=/<empty>]
+rangekey: {n-o}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
+rangekey: p{-\x00}/[10.000000000,0=/<empty>]
+data: "a"/4.000000000,0 -> /<empty>
+data: "a"/2.000000000,0 -> /BYTES/a2
+data: "b"/4.000000000,0 -> /<empty>
+data: "d"/4.000000000,0 -> /BYTES/d4
+data: "d"/2.000000000,0 -> /BYTES/d2
+data: "e"/3.000000000,0 -> /BYTES/e3
+data: "f"/6.000000000,0 -> /BYTES/f6
+data: "f"/4.000000000,0 -> /BYTES/f4
+data: "f"/2.000000000,0 -> /BYTES/f2
+data: "g"/4.000000000,0 -> /BYTES/g4
+data: "g"/2.000000000,0 -> /BYTES/g2
+data: "h"/3.000000000,0 -> /BYTES/h3
+data: "i"/5.000000000,0 -> /BYTES/i5
+data: "j"/6.000000000,0 -> /<empty>
+data: "j"/2.000000000,0 -> /BYTES/j2
+data: "k"/2.000000000,0 -> /BYTES/k2
+data: "p"/6.000000000,0 -> /BYTES/p6
+stats: key_count=11 key_bytes=226 val_count=17 val_bytes=98 range_key_count=10 range_key_bytes=205 range_val_count=18 live_count=1 live_bytes=21 gc_bytes_age=48076
+
+run stats ok
+clear_time_range k=a end=z ts=10 targetTs=6
+----
+>> clear_time_range k=a end=z ts=10 targetTs=6
+stats: range_key_count=-2 range_key_bytes=-47 range_val_count=-4 live_count=+4 live_bytes=+84 gc_bytes_age=-11860
+>> at end:
+rangekey: {a-b}/[1.000000000,0=/<empty>]
+rangekey: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {d-f}/[5.000000000,0=/<empty> 1.000000000,0=/<empty>]
+rangekey: {f-h}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
+rangekey: {h-k}/[1.000000000,0=/<empty>]
+rangekey: {l-n}/[5.000000000,0=/<empty>]
+rangekey: {n-o}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
+data: "a"/4.000000000,0 -> /<empty>
+data: "a"/2.000000000,0 -> /BYTES/a2
+data: "b"/4.000000000,0 -> /<empty>
+data: "d"/4.000000000,0 -> /BYTES/d4
+data: "d"/2.000000000,0 -> /BYTES/d2
+data: "e"/3.000000000,0 -> /BYTES/e3
+data: "f"/6.000000000,0 -> /BYTES/f6
+data: "f"/4.000000000,0 -> /BYTES/f4
+data: "f"/2.000000000,0 -> /BYTES/f2
+data: "g"/4.000000000,0 -> /BYTES/g4
+data: "g"/2.000000000,0 -> /BYTES/g2
+data: "h"/3.000000000,0 -> /BYTES/h3
+data: "i"/5.000000000,0 -> /BYTES/i5
+data: "j"/6.000000000,0 -> /<empty>
+data: "j"/2.000000000,0 -> /BYTES/j2
+data: "k"/2.000000000,0 -> /BYTES/k2
+data: "p"/6.000000000,0 -> /BYTES/p6
+stats: key_count=11 key_bytes=226 val_count=17 val_bytes=98 range_key_count=8 range_key_bytes=158 range_val_count=14 live_count=5 live_bytes=105 gc_bytes_age=36216

--- a/pkg/storage/testdata/mvcc_histories/delete_range_predicate_rt_continue_tombstone
+++ b/pkg/storage/testdata/mvcc_histories/delete_range_predicate_rt_continue_tombstone
@@ -1,0 +1,72 @@
+# Tests that MVCCPredicateDeleteRange will continue a run when encountering
+# tombstones that do not satisfy the predicate.
+# Sets up the following dataset, where x is a tombstone.
+#  T
+#  3  a3          d3      f3  g3
+#  2      x   x       x
+#  1      b1  c1
+#     a   b   c   d   e   f   g
+#
+run stats ok
+put k=b ts=1 v=b1
+put k=c ts=1 v=c1
+del k=b ts=2 localTs=1
+del k=c ts=2 localTs=1
+del k=e ts=2 localTs=1
+put k=a ts=3 v=a3
+put k=d ts=3 v=d3
+put k=f ts=3 v=f3
+put k=g ts=3 v=g3
+----
+>> put k=b ts=1 v=b1
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+7 live_count=+1 live_bytes=+21
+>> put k=c ts=1 v=c1
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+7 live_count=+1 live_bytes=+21
+>> del k=b ts=2 localTs=1
+del: "b": found key true
+stats: key_bytes=+12 val_count=+1 val_bytes=+13 live_count=-1 live_bytes=-21 gc_bytes_age=+4508
+>> del k=c ts=2 localTs=1
+del: "c": found key true
+stats: key_bytes=+12 val_count=+1 val_bytes=+13 live_count=-1 live_bytes=-21 gc_bytes_age=+4508
+>> del k=e ts=2 localTs=1
+del: "e": found key false
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+13 gc_bytes_age=+2646
+>> put k=a ts=3 v=a3
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+7 live_count=+1 live_bytes=+21
+>> put k=d ts=3 v=d3
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+7 live_count=+1 live_bytes=+21
+>> put k=f ts=3 v=f3
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+7 live_count=+1 live_bytes=+21
+>> put k=g ts=3 v=g3
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+7 live_count=+1 live_bytes=+21
+>> at end:
+data: "a"/3.000000000,0 -> /BYTES/a3
+data: "b"/2.000000000,0 -> {localTs=1.000000000,0}/<empty>
+data: "b"/1.000000000,0 -> /BYTES/b1
+data: "c"/2.000000000,0 -> {localTs=1.000000000,0}/<empty>
+data: "c"/1.000000000,0 -> /BYTES/c1
+data: "d"/3.000000000,0 -> /BYTES/d3
+data: "e"/2.000000000,0 -> {localTs=1.000000000,0}/<empty>
+data: "f"/3.000000000,0 -> /BYTES/f3
+data: "g"/3.000000000,0 -> /BYTES/g3
+stats: key_count=7 key_bytes=122 val_count=9 val_bytes=81 live_count=4 live_bytes=84 gc_bytes_age=11662
+
+# Even though b, c, e do not satisfy the predicate, their latest versions are
+# tombstones, so the run continues and we write [a,g)@4.
+run stats ok
+del_range_pred k=a end=z ts=4 startTime=2 rangeThreshold=3 useRangeTombstone=true
+----
+>> del_range_pred k=a end=z ts=4 startTime=2 rangeThreshold=3 useRangeTombstone=true
+stats: range_key_count=+1 range_key_bytes=+14 range_val_count=+1 live_count=-4 live_bytes=-84 gc_bytes_age=+9408
+>> at end:
+rangekey: {a-g\x00}/[4.000000000,0=/<empty>]
+data: "a"/3.000000000,0 -> /BYTES/a3
+data: "b"/2.000000000,0 -> {localTs=1.000000000,0}/<empty>
+data: "b"/1.000000000,0 -> /BYTES/b1
+data: "c"/2.000000000,0 -> {localTs=1.000000000,0}/<empty>
+data: "c"/1.000000000,0 -> /BYTES/c1
+data: "d"/3.000000000,0 -> /BYTES/d3
+data: "e"/2.000000000,0 -> {localTs=1.000000000,0}/<empty>
+data: "f"/3.000000000,0 -> /BYTES/f3
+data: "g"/3.000000000,0 -> /BYTES/g3
+stats: key_count=7 key_bytes=122 val_count=9 val_bytes=81 range_key_count=1 range_key_bytes=14 range_val_count=1 gc_bytes_age=21070

--- a/pkg/storage/testdata/mvcc_histories/delete_range_predicate_rt_import_epoch
+++ b/pkg/storage/testdata/mvcc_histories/delete_range_predicate_rt_import_epoch
@@ -1,0 +1,180 @@
+# Tests MVCCPredicateDeleteRange with ImportEpoch predicates
+#
+# We set up data the represents a timeline like.
+#
+# Import 1 from t [1,2]
+# More writes at t3
+# Import 2 from t [4,5]
+#
+#  T  E|
+#  5  2|           c5
+#  4  2|                   e4  f4  g4 h4
+#  3   |           x   d3
+#  2  1|       b2  c2                         j2
+#  1  1|  a1           d1                  i1
+#      |   a   b   c   d   e   f   g   h   i   j
+
+run stats ok
+put k=a ts=1 v=a1 import_epoch=1
+put k=b ts=2 v=b2 import_epoch=1
+put k=c ts=2 v=c2 import_epoch=1
+del k=c ts=3
+put k=c ts=5 v=c5 import_epoch=2
+put k=d ts=1 v=d1 import_epoch=1
+put k=d ts=3 v=d3
+put k=e ts=4 v=e4 import_epoch=2
+put k=f ts=4 v=f4 import_epoch=2
+put k=g ts=4 v=g4 import_epoch=2
+put k=h ts=5 v=h4 import_epoch=2
+put k=i ts=1 v=i1 import_epoch=1
+put k=j ts=2 v=j2 import_epoch=1
+----
+>> put k=a ts=1 v=a1 import_epoch=1
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+16 live_count=+1 live_bytes=+30
+>> put k=b ts=2 v=b2 import_epoch=1
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+16 live_count=+1 live_bytes=+30
+>> put k=c ts=2 v=c2 import_epoch=1
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+16 live_count=+1 live_bytes=+30
+>> del k=c ts=3
+del: "c": found key true
+stats: key_bytes=+12 val_count=+1 live_count=-1 live_bytes=-30 gc_bytes_age=+4074
+>> put k=c ts=5 v=c5 import_epoch=2
+stats: key_bytes=+12 val_count=+1 val_bytes=+16 live_count=+1 live_bytes=+30 gc_bytes_age=-194
+>> put k=d ts=1 v=d1 import_epoch=1
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+16 live_count=+1 live_bytes=+30
+>> put k=d ts=3 v=d3
+stats: key_bytes=+12 val_count=+1 val_bytes=+7 live_bytes=-9 gc_bytes_age=+2716
+>> put k=e ts=4 v=e4 import_epoch=2
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+16 live_count=+1 live_bytes=+30
+>> put k=f ts=4 v=f4 import_epoch=2
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+16 live_count=+1 live_bytes=+30
+>> put k=g ts=4 v=g4 import_epoch=2
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+16 live_count=+1 live_bytes=+30
+>> put k=h ts=5 v=h4 import_epoch=2
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+16 live_count=+1 live_bytes=+30
+>> put k=i ts=1 v=i1 import_epoch=1
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+16 live_count=+1 live_bytes=+30
+>> put k=j ts=2 v=j2 import_epoch=1
+stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+16 live_count=+1 live_bytes=+30
+>> at end:
+data: "a"/1.000000000,0 -> {importEpoch=1}/BYTES/a1
+data: "b"/2.000000000,0 -> {importEpoch=1}/BYTES/b2
+data: "c"/5.000000000,0 -> {importEpoch=2}/BYTES/c5
+data: "c"/3.000000000,0 -> /<empty>
+data: "c"/2.000000000,0 -> {importEpoch=1}/BYTES/c2
+data: "d"/3.000000000,0 -> /BYTES/d3
+data: "d"/1.000000000,0 -> {importEpoch=1}/BYTES/d1
+data: "e"/4.000000000,0 -> {importEpoch=2}/BYTES/e4
+data: "f"/4.000000000,0 -> {importEpoch=2}/BYTES/f4
+data: "g"/4.000000000,0 -> {importEpoch=2}/BYTES/g4
+data: "h"/5.000000000,0 -> {importEpoch=2}/BYTES/h4
+data: "i"/1.000000000,0 -> {importEpoch=1}/BYTES/i1
+data: "j"/2.000000000,0 -> {importEpoch=1}/BYTES/j2
+stats: key_count=10 key_bytes=176 val_count=13 val_bytes=183 live_count=10 live_bytes=291 gc_bytes_age=6596
+
+# Now lets del_range_pred on epoch 2
+run stats ok log-ops
+del_range_pred k=a end=z ts=10 import_epoch=2 rangeThreshold=3 useRangeTombstone=true
+----
+>> del_range_pred k=a end=z ts=10 import_epoch=2 rangeThreshold=3 useRangeTombstone=true
+stats: key_bytes=+12 val_count=+1 range_key_count=+1 range_key_bytes=+14 range_val_count=+1 live_count=-5 live_bytes=-150 gc_bytes_age=+15840
+>> at end:
+rangekey: {e-h\x00}/[10.000000000,0=/<empty>]
+data: "a"/1.000000000,0 -> {importEpoch=1}/BYTES/a1
+data: "b"/2.000000000,0 -> {importEpoch=1}/BYTES/b2
+data: "c"/10.000000000,0 -> /<empty>
+data: "c"/5.000000000,0 -> {importEpoch=2}/BYTES/c5
+data: "c"/3.000000000,0 -> /<empty>
+data: "c"/2.000000000,0 -> {importEpoch=1}/BYTES/c2
+data: "d"/3.000000000,0 -> /BYTES/d3
+data: "d"/1.000000000,0 -> {importEpoch=1}/BYTES/d1
+data: "e"/4.000000000,0 -> {importEpoch=2}/BYTES/e4
+data: "f"/4.000000000,0 -> {importEpoch=2}/BYTES/f4
+data: "g"/4.000000000,0 -> {importEpoch=2}/BYTES/g4
+data: "h"/5.000000000,0 -> {importEpoch=2}/BYTES/h4
+data: "i"/1.000000000,0 -> {importEpoch=1}/BYTES/i1
+data: "j"/2.000000000,0 -> {importEpoch=1}/BYTES/j2
+logical op: write_value: key="c", ts=10.000000000,0
+logical op: delete_range: startKey="e" endKey="h\x00" ts=10.000000000,0
+stats: key_count=10 key_bytes=188 val_count=14 val_bytes=183 range_key_count=1 range_key_bytes=14 range_val_count=1 live_count=5 live_bytes=141 gc_bytes_age=22436
+
+# Let's try it again at t11
+run stats ok log-ops
+del_range_pred k=a end=z ts=11 import_epoch=2 rangeThreshold=3 useRangeTombstone=true
+----
+>> del_range_pred k=a end=z ts=11 import_epoch=2 rangeThreshold=3 useRangeTombstone=true
+stats: no change
+>> at end:
+rangekey: {e-h\x00}/[10.000000000,0=/<empty>]
+data: "a"/1.000000000,0 -> {importEpoch=1}/BYTES/a1
+data: "b"/2.000000000,0 -> {importEpoch=1}/BYTES/b2
+data: "c"/10.000000000,0 -> /<empty>
+data: "c"/5.000000000,0 -> {importEpoch=2}/BYTES/c5
+data: "c"/3.000000000,0 -> /<empty>
+data: "c"/2.000000000,0 -> {importEpoch=1}/BYTES/c2
+data: "d"/3.000000000,0 -> /BYTES/d3
+data: "d"/1.000000000,0 -> {importEpoch=1}/BYTES/d1
+data: "e"/4.000000000,0 -> {importEpoch=2}/BYTES/e4
+data: "f"/4.000000000,0 -> {importEpoch=2}/BYTES/f4
+data: "g"/4.000000000,0 -> {importEpoch=2}/BYTES/g4
+data: "h"/5.000000000,0 -> {importEpoch=2}/BYTES/h4
+data: "i"/1.000000000,0 -> {importEpoch=1}/BYTES/i1
+data: "j"/2.000000000,0 -> {importEpoch=1}/BYTES/j2
+stats: key_count=10 key_bytes=188 val_count=14 val_bytes=183 range_key_count=1 range_key_bytes=14 range_val_count=1 live_count=5 live_bytes=141 gc_bytes_age=22436
+
+run ok
+clear_range k=a end=z
+----
+>> at end:
+<no data>
+
+# Restored Import
+#
+# We set up data that contains 2 imports that have all been restored
+# at ts [1,3]
+#
+run ok
+put k=a ts=1 v=a import_epoch=1
+put k=b ts=2 v=b import_epoch=2
+put k=c ts=2 v=c import_epoch=1
+put k=d ts=1 v=d import_epoch=1
+put k=e ts=3 v=e import_epoch=2
+put k=f ts=1 v=f import_epoch=2
+put k=g ts=2 v=g import_epoch=2
+put k=h ts=3 v=h import_epoch=2
+put k=i ts=4 v=i import_epoch=1
+put k=j ts=1 v=j import_epoch=1
+----
+>> at end:
+data: "a"/1.000000000,0 -> {importEpoch=1}/BYTES/a
+data: "b"/2.000000000,0 -> {importEpoch=2}/BYTES/b
+data: "c"/2.000000000,0 -> {importEpoch=1}/BYTES/c
+data: "d"/1.000000000,0 -> {importEpoch=1}/BYTES/d
+data: "e"/3.000000000,0 -> {importEpoch=2}/BYTES/e
+data: "f"/1.000000000,0 -> {importEpoch=2}/BYTES/f
+data: "g"/2.000000000,0 -> {importEpoch=2}/BYTES/g
+data: "h"/3.000000000,0 -> {importEpoch=2}/BYTES/h
+data: "i"/4.000000000,0 -> {importEpoch=1}/BYTES/i
+data: "j"/1.000000000,0 -> {importEpoch=1}/BYTES/j
+
+run stats ok log-ops
+del_range_pred k=a end=z ts=5 import_epoch=2 rangeThreshold=3 useRangeTombstone=true
+----
+>> del_range_pred k=a end=z ts=5 import_epoch=2 rangeThreshold=3 useRangeTombstone=true
+stats: key_bytes=+12 val_count=+1 range_key_count=+1 range_key_bytes=+14 range_val_count=+1 live_count=-5 live_bytes=-145 gc_bytes_age=+16245
+>> at end:
+rangekey: {e-h\x00}/[5.000000000,0=/<empty>]
+data: "a"/1.000000000,0 -> {importEpoch=1}/BYTES/a
+data: "b"/5.000000000,0 -> /<empty>
+data: "b"/2.000000000,0 -> {importEpoch=2}/BYTES/b
+data: "c"/2.000000000,0 -> {importEpoch=1}/BYTES/c
+data: "d"/1.000000000,0 -> {importEpoch=1}/BYTES/d
+data: "e"/3.000000000,0 -> {importEpoch=2}/BYTES/e
+data: "f"/1.000000000,0 -> {importEpoch=2}/BYTES/f
+data: "g"/2.000000000,0 -> {importEpoch=2}/BYTES/g
+data: "h"/3.000000000,0 -> {importEpoch=2}/BYTES/h
+data: "i"/4.000000000,0 -> {importEpoch=1}/BYTES/i
+data: "j"/1.000000000,0 -> {importEpoch=1}/BYTES/j
+logical op: write_value: key="b", ts=5.000000000,0
+logical op: delete_range: startKey="e" endKey="h\x00" ts=5.000000000,0
+stats: key_count=10 key_bytes=152 val_count=11 val_bytes=150 range_key_count=1 range_key_bytes=14 range_val_count=1 live_count=5 live_bytes=145 gc_bytes_age=16245


### PR DESCRIPTION
Previously, import rollback used range tombstones to delete contiguous
ranges of keys in non-empty tables. This is a relatively niche
optimization. It also allows users to create point keys on top of the
range tombstones by writing to the table after the rollback completes.
Import rollback is the only source of point tombstones over range keys
in CRDB.

Now, import rollbacks in non-empty tables will use point keys.

Context in
https://docs.google.com/document/d/1g7AUN3jUbzpLw2yR9C6k3tSib6XUqxYiNFp6OrCTJ4U.

Release Note: none
Fixes: https://github.com/cockroachdb/cockroach/issues/149697