### PR TITLE
roachtest/ci: fix for `SELECT_PROBABILITY`

### DIFF
--- a/build/teamcity/cockroach/nightlies/roachtest_nightly_impl.sh
+++ b/build/teamcity/cockroach/nightlies/roachtest_nightly_impl.sh
@@ -32,6 +32,8 @@ source $root/build/teamcity/util/roachtest_util.sh
 # Standard release branches are in the format `release-24.1` for the
 # 24.1 release, for example.
 release_branch_regex="^release-[0-9][0-9]\.[0-9]"
+# Test selection is enabled only on release branches.
+selective_tests="false"
 
 if [[ "${TC_BUILD_BRANCH}" == "master" ]]; then
   # We default to using test selection on master, unless explicitly


### PR DESCRIPTION
The change in [1] left `selective_tests`
(in `roachtest_nightly_impl.sh`) unbound
on PR branches. This change fixes it.

[1] https://github.com/cockroachdb/cockroach/pull/137653

Epic: none

Release note: None