### PR TITLE
ccl/changeedccl: Add changefeed options into nemesis tests

### DIFF
--- a/pkg/ccl/changefeedccl/cdctest/validator.go
+++ b/pkg/ccl/changefeedccl/cdctest/validator.go
@@ -23,7 +23,7 @@ import (
 // guarantees in a single table.
 type Validator interface {
 	// NoteRow accepts a changed row entry.
-	NoteRow(partition string, key, value string, updated hlc.Timestamp) error
+	NoteRow(partition, key, value string, updated hlc.Timestamp, topic string) error
 	// NoteResolved accepts a resolved timestamp entry.
 	NoteResolved(partition string, resolved hlc.Timestamp) error
 	// Failures returns any violations seen so far.
@@ -64,7 +64,7 @@ var _ StreamValidator = &orderValidator{}
 type noOpValidator struct{}
 
 // NoteRow accepts a changed row entry.
-func (v *noOpValidator) NoteRow(string, string, string, hlc.Timestamp) error { return nil }
+func (v *noOpValidator) NoteRow(string, string, string, hlc.Timestamp, string) error { return nil }
 
 // NoteResolved accepts a resolved timestamp entry.
 func (v *noOpValidator) NoteResolved(string, hlc.Timestamp) error { return nil }
@@ -125,7 +125,9 @@ func (v *orderValidator) GetValuesForKeyBelowTimestamp(
 }
 
 // NoteRow implements the Validator interface.
-func (v *orderValidator) NoteRow(partition string, key, value string, updated hlc.Timestamp) error {
+func (v *orderValidator) NoteRow(
+	partition, key, value string, updated hlc.Timestamp, topic string,
+) error {
 	if prev, ok := v.partitionForKey[key]; ok && prev != partition {
 		v.failures = append(v.failures, fmt.Sprintf(
 			`key [%s] received on two partitions: %s and %s`, key, prev, partition,
@@ -189,6 +191,8 @@ type beforeAfterValidator struct {
 	table          string
 	primaryKeyCols []string
 	resolved       map[string]hlc.Timestamp
+	fullTableName  bool
+	keyInValue     bool
 
 	failures []string
 }
@@ -196,7 +200,9 @@ type beforeAfterValidator struct {
 // NewBeforeAfterValidator returns a Validator verifies that the "before" and
 // "after" fields in each row agree with the source table when performing AS OF
 // SYSTEM TIME lookups before and at the row's timestamp.
-func NewBeforeAfterValidator(sqlDB *gosql.DB, table string) (Validator, error) {
+func NewBeforeAfterValidator(
+	sqlDB *gosql.DB, table string, option ChangefeedOption,
+) (Validator, error) {
 	primaryKeyCols, err := fetchPrimaryKeyCols(sqlDB, table)
 	if err != nil {
 		return nil, errors.Wrap(err, "fetchPrimaryKeyCols failed")
@@ -205,6 +211,8 @@ func NewBeforeAfterValidator(sqlDB *gosql.DB, table string) (Validator, error) {
 	return &beforeAfterValidator{
 		sqlDB:          sqlDB,
 		table:          table,
+		fullTableName:  option.FullTableName,
+		keyInValue:     option.KeyInValue,
 		primaryKeyCols: primaryKeyCols,
 		resolved:       make(map[string]hlc.Timestamp),
 	}, nil
@@ -212,8 +220,21 @@ func NewBeforeAfterValidator(sqlDB *gosql.DB, table string) (Validator, error) {
 
 // NoteRow implements the Validator interface.
 func (v *beforeAfterValidator) NoteRow(
-	partition string, key, value string, updated hlc.Timestamp,
+	partition, key, value string, updated hlc.Timestamp, topic string,
 ) error {
+	if v.fullTableName {
+		if topic != fmt.Sprintf(`d.public.%s`, v.table) {
+			v.failures = append(v.failures, fmt.Sprintf(
+				"topic %s does not match expected table d.public.%s", topic, v.table,
+			))
+		}
+	} else {
+		if topic != v.table {
+			v.failures = append(v.failures, fmt.Sprintf(
+				"topic %s does not match expected table %s", topic, v.table,
+			))
+		}
+	}
 	keyJSON, err := json.ParseJSON(key)
 	if err != nil {
 		return err
@@ -228,6 +249,26 @@ func (v *beforeAfterValidator) NoteRow(
 	valueJSON, err := json.ParseJSON(value)
 	if err != nil {
 		return err
+	}
+
+	if v.keyInValue {
+		keyString := keyJSON.String()
+		keyInValueJSON, err := valueJSON.FetchValKey("key")
+		if err != nil {
+			return err
+		}
+
+		if keyInValueJSON == nil {
+			v.failures = append(v.failures, fmt.Sprintf(
+				"no key in value, expected key value %s", keyString))
+		} else {
+			keyInValueString := keyInValueJSON.String()
+			if keyInValueString != keyString {
+				v.failures = append(v.failures, fmt.Sprintf(
+					"key in value %s does not match expected key value %s",
+					keyInValueString, keyString))
+			}
+		}
 	}
 
 	afterJSON, err := valueJSON.FetchValKey("after")
@@ -451,7 +492,7 @@ func (v *FingerprintValidator) DBFunc(
 
 // NoteRow implements the Validator interface.
 func (v *FingerprintValidator) NoteRow(
-	ignoredPartition string, key, value string, updated hlc.Timestamp,
+	partition, key, value string, updated hlc.Timestamp, topic string,
 ) error {
 	if v.firstRowTimestamp.IsEmpty() || updated.Less(v.firstRowTimestamp) {
 		v.firstRowTimestamp = updated
@@ -663,9 +704,11 @@ func (v *FingerprintValidator) Failures() []string {
 type Validators []Validator
 
 // NoteRow implements the Validator interface.
-func (vs Validators) NoteRow(partition string, key, value string, updated hlc.Timestamp) error {
+func (vs Validators) NoteRow(
+	partition, key, value string, updated hlc.Timestamp, topic string,
+) error {
 	for _, v := range vs {
-		if err := v.NoteRow(partition, key, value, updated); err != nil {
+		if err := v.NoteRow(partition, key, value, updated, topic); err != nil {
 			return err
 		}
 	}
@@ -707,10 +750,12 @@ func NewCountValidator(v Validator) *CountValidator {
 }
 
 // NoteRow implements the Validator interface.
-func (v *CountValidator) NoteRow(partition string, key, value string, updated hlc.Timestamp) error {
+func (v *CountValidator) NoteRow(
+	partition, key, value string, updated hlc.Timestamp, topic string,
+) error {
 	v.NumRows++
 	v.rowsSinceResolved++
-	return v.v.NoteRow(partition, key, value, updated)
+	return v.v.NoteRow(partition, key, value, updated, topic)
 }
 
 // NoteResolved implements the Validator interface.

--- a/pkg/ccl/changefeedccl/cdctest/validator_test.go
+++ b/pkg/ccl/changefeedccl/cdctest/validator_test.go
@@ -24,9 +24,13 @@ func ts(i int64) hlc.Timestamp {
 	return hlc.Timestamp{WallTime: i}
 }
 
-func noteRow(t *testing.T, v Validator, partition, key, value string, updated hlc.Timestamp) {
+func noteRow(
+	t *testing.T, v Validator, partition, key, value string, updated hlc.Timestamp, topic string,
+) {
 	t.Helper()
-	if err := v.NoteRow(partition, key, value, updated); err != nil {
+	// None of the validators in this file include assertions about the topic
+	// name, so it's ok to pass in an empty string for topic.
+	if err := v.NoteRow(partition, key, value, updated, topic); err != nil {
 		t.Fatal(err)
 	}
 }
@@ -57,23 +61,23 @@ func TestOrderValidator(t *testing.T) {
 	})
 	t.Run(`dupe okay`, func(t *testing.T) {
 		v := NewOrderValidator(`t1`)
-		noteRow(t, v, `p1`, `k1`, ignored, ts(1))
-		noteRow(t, v, `p1`, `k1`, ignored, ts(2))
-		noteRow(t, v, `p1`, `k1`, ignored, ts(1))
+		noteRow(t, v, `p1`, `k1`, ignored, ts(1), `foo`)
+		noteRow(t, v, `p1`, `k1`, ignored, ts(2), `foo`)
+		noteRow(t, v, `p1`, `k1`, ignored, ts(1), `foo`)
 		assertValidatorFailures(t, v)
 	})
 	t.Run(`key on two partitions`, func(t *testing.T) {
 		v := NewOrderValidator(`t1`)
-		noteRow(t, v, `p1`, `k1`, ignored, ts(2))
-		noteRow(t, v, `p2`, `k1`, ignored, ts(1))
+		noteRow(t, v, `p1`, `k1`, ignored, ts(2), `foo`)
+		noteRow(t, v, `p2`, `k1`, ignored, ts(1), `foo`)
 		assertValidatorFailures(t, v,
 			`key [k1] received on two partitions: p1 and p2`,
 		)
 	})
 	t.Run(`new key with lower timestamp`, func(t *testing.T) {
 		v := NewOrderValidator(`t1`)
-		noteRow(t, v, `p1`, `k1`, ignored, ts(2))
-		noteRow(t, v, `p1`, `k1`, ignored, ts(1))
+		noteRow(t, v, `p1`, `k1`, ignored, ts(2), `foo`)
+		noteRow(t, v, `p1`, `k1`, ignored, ts(1), `foo`)
 		assertValidatorFailures(t, v,
 			`topic t1 partition p1: saw new row timestamp 1.0000000000 after 2.0000000000 was seen`,
 		)
@@ -82,17 +86,23 @@ func TestOrderValidator(t *testing.T) {
 		v := NewOrderValidator(`t1`)
 		noteResolved(t, v, `p2`, ts(3))
 		// Okay because p2 saw the resolved timestamp but p1 didn't.
-		noteRow(t, v, `p1`, `k1`, ignored, ts(1))
+		noteRow(t, v, `p1`, `k1`, ignored, ts(1), `foo`)
 		noteResolved(t, v, `p1`, ts(3))
 		// This one is not okay.
-		noteRow(t, v, `p1`, `k1`, ignored, ts(2))
+		noteRow(t, v, `p1`, `k1`, ignored, ts(2), `foo`)
 		// Still okay because we've seen it before.
-		noteRow(t, v, `p1`, `k1`, ignored, ts(1))
+		noteRow(t, v, `p1`, `k1`, ignored, ts(1), `foo`)
 		assertValidatorFailures(t, v,
 			`topic t1 partition p1`+
 				`: saw new row timestamp 2.0000000000 after 3.0000000000 was resolved`,
 		)
 	})
+}
+
+var standardChangefeedOptions = ChangefeedOption{
+	FullTableName: false,
+	KeyInValue:    false,
+	Format:        "json",
 }
 
 func TestBeforeAfterValidator(t *testing.T) {
@@ -130,97 +140,115 @@ func TestBeforeAfterValidator(t *testing.T) {
 	}
 
 	t.Run(`empty`, func(t *testing.T) {
-		v, err := NewBeforeAfterValidator(sqlDBRaw, `foo`)
+		v, err := NewBeforeAfterValidator(sqlDBRaw, `foo`, standardChangefeedOptions)
+		require.NoError(t, err)
+		assertValidatorFailures(t, v)
+	})
+	t.Run(`fullTableName`, func(t *testing.T) {
+		v, err := NewBeforeAfterValidator(sqlDBRaw, `foo`, ChangefeedOption{
+			FullTableName: true,
+			KeyInValue:    false,
+			Format:        "json",
+		})
+		require.NoError(t, err)
+		assertValidatorFailures(t, v)
+	})
+	t.Run(`key_in_value`, func(t *testing.T) {
+		v, err := NewBeforeAfterValidator(sqlDBRaw, `foo`, ChangefeedOption{
+			FullTableName: false,
+			KeyInValue:    true,
+			Format:        "json",
+		})
 		require.NoError(t, err)
 		assertValidatorFailures(t, v)
 	})
 	t.Run(`during initial`, func(t *testing.T) {
-		v, err := NewBeforeAfterValidator(sqlDBRaw, `foo`)
+		v, err := NewBeforeAfterValidator(sqlDBRaw, `foo`, standardChangefeedOptions)
 		require.NoError(t, err)
 		// "before" is ignored if missing.
-		noteRow(t, v, `p`, `[1]`, `{"after": {"k":1,"v":1}}`, ts[1])
-		noteRow(t, v, `p`, `[1]`, `{"after": {"k":1,"v":2}}`, ts[2])
+		noteRow(t, v, `p`, `[1]`, `{"after": {"k":1,"v":1}}`, ts[1], `foo`)
+		noteRow(t, v, `p`, `[1]`, `{"after": {"k":1,"v":2}}`, ts[2], `foo`)
 		// However, if provided, it is validated.
-		noteRow(t, v, `p`, `[1]`, `{"after": {"k":1,"v":2}, "before": {"k":1,"v":1}}`, ts[2])
+		noteRow(t, v, `p`, `[1]`, `{"after": {"k":1,"v":2}, "before": {"k":1,"v":1}}`, ts[2], `foo`)
 		assertValidatorFailures(t, v)
-		noteRow(t, v, `p`, `[1]`, `{"after": {"k":1,"v":3}, "before": {"k":1,"v":3}}`, ts[3])
+		noteRow(t, v, `p`, `[1]`, `{"after": {"k":1,"v":3}, "before": {"k":1,"v":3}}`, ts[3], `foo`)
 		assertValidatorFailures(t, v,
 			`"before" field did not agree with row at `+ts[3].Prev().AsOfSystemTime()+
 				`: SELECT count(*) = 1 FROM foo AS OF SYSTEM TIME '`+ts[3].Prev().AsOfSystemTime()+
 				`' WHERE to_json(k)::TEXT = $1 AND to_json(v)::TEXT = $2 [1 3]`)
 	})
 	t.Run(`missing before`, func(t *testing.T) {
-		v, err := NewBeforeAfterValidator(sqlDBRaw, `foo`)
+		v, err := NewBeforeAfterValidator(sqlDBRaw, `foo`, standardChangefeedOptions)
 		require.NoError(t, err)
 		noteResolved(t, v, `p`, ts[0])
 		// "before" should have been provided.
-		noteRow(t, v, `p`, `[1]`, `{"after": {"k":1,"v":2}}`, ts[2])
+		noteRow(t, v, `p`, `[1]`, `{"after": {"k":1,"v":2}}`, ts[2], `foo`)
 		assertValidatorFailures(t, v,
 			`"before" field did not agree with row at `+ts[2].Prev().AsOfSystemTime()+
 				`: SELECT count(*) = 0 FROM foo AS OF SYSTEM TIME '`+ts[2].Prev().AsOfSystemTime()+
 				`' WHERE to_json(k)::TEXT = $1 [1]`)
 	})
 	t.Run(`incorrect before`, func(t *testing.T) {
-		v, err := NewBeforeAfterValidator(sqlDBRaw, `foo`)
+		v, err := NewBeforeAfterValidator(sqlDBRaw, `foo`, standardChangefeedOptions)
 		require.NoError(t, err)
 		noteResolved(t, v, `p`, ts[0])
 		// "before" provided with wrong value.
-		noteRow(t, v, `p`, `[1]`, `{"after": {"k":1,"v":3}, "before": {"k":5,"v":10}}`, ts[3])
+		noteRow(t, v, `p`, `[1]`, `{"after": {"k":1,"v":3}, "before": {"k":5,"v":10}}`, ts[3], `foo`)
 		assertValidatorFailures(t, v,
 			`"before" field did not agree with row at `+ts[3].Prev().AsOfSystemTime()+
 				`: SELECT count(*) = 1 FROM foo AS OF SYSTEM TIME '`+ts[3].Prev().AsOfSystemTime()+
 				`' WHERE to_json(k)::TEXT = $1 AND to_json(v)::TEXT = $2 [5 10]`)
 	})
 	t.Run(`unnecessary before`, func(t *testing.T) {
-		v, err := NewBeforeAfterValidator(sqlDBRaw, `foo`)
+		v, err := NewBeforeAfterValidator(sqlDBRaw, `foo`, standardChangefeedOptions)
 		require.NoError(t, err)
 		noteResolved(t, v, `p`, ts[0])
 		// "before" provided but should not have been.
-		noteRow(t, v, `p`, `[1]`, `{"after": {"k":1,"v":1}, "before": {"k":1,"v":1}}`, ts[1])
+		noteRow(t, v, `p`, `[1]`, `{"after": {"k":1,"v":1}, "before": {"k":1,"v":1}}`, ts[1], `foo`)
 		assertValidatorFailures(t, v,
 			`"before" field did not agree with row at `+ts[1].Prev().AsOfSystemTime()+
 				`: SELECT count(*) = 1 FROM foo AS OF SYSTEM TIME '`+ts[1].Prev().AsOfSystemTime()+
 				`' WHERE to_json(k)::TEXT = $1 AND to_json(v)::TEXT = $2 [1 1]`)
 	})
 	t.Run(`missing after`, func(t *testing.T) {
-		v, err := NewBeforeAfterValidator(sqlDBRaw, `foo`)
+		v, err := NewBeforeAfterValidator(sqlDBRaw, `foo`, standardChangefeedOptions)
 		require.NoError(t, err)
 		noteResolved(t, v, `p`, ts[0])
 		// "after" should have been provided.
-		noteRow(t, v, `p`, `[1]`, `{"before": {"k":1,"v":1}}`, ts[2])
+		noteRow(t, v, `p`, `[1]`, `{"before": {"k":1,"v":1}}`, ts[2], `foo`)
 		assertValidatorFailures(t, v,
 			`"after" field did not agree with row at `+ts[2].AsOfSystemTime()+
 				`: SELECT count(*) = 0 FROM foo AS OF SYSTEM TIME '`+ts[2].AsOfSystemTime()+
 				`' WHERE to_json(k)::TEXT = $1 [1]`)
 	})
 	t.Run(`incorrect after`, func(t *testing.T) {
-		v, err := NewBeforeAfterValidator(sqlDBRaw, `foo`)
+		v, err := NewBeforeAfterValidator(sqlDBRaw, `foo`, standardChangefeedOptions)
 		require.NoError(t, err)
 		noteResolved(t, v, `p`, ts[0])
 		// "after" provided with wrong value.
-		noteRow(t, v, `p`, `[1]`, `{"after": {"k":1,"v":5}, "before": {"k":1,"v":2}}`, ts[3])
+		noteRow(t, v, `p`, `[1]`, `{"after": {"k":1,"v":5}, "before": {"k":1,"v":2}}`, ts[3], `foo`)
 		assertValidatorFailures(t, v,
 			`"after" field did not agree with row at `+ts[3].AsOfSystemTime()+
 				`: SELECT count(*) = 1 FROM foo AS OF SYSTEM TIME '`+ts[3].AsOfSystemTime()+
 				`' WHERE to_json(k)::TEXT = $1 AND to_json(v)::TEXT = $2 [1 5]`)
 	})
 	t.Run(`unnecessary after`, func(t *testing.T) {
-		v, err := NewBeforeAfterValidator(sqlDBRaw, `foo`)
+		v, err := NewBeforeAfterValidator(sqlDBRaw, `foo`, standardChangefeedOptions)
 		require.NoError(t, err)
 		noteResolved(t, v, `p`, ts[0])
 		// "after" provided but should not have been.
-		noteRow(t, v, `p`, `[1]`, `{"after": {"k":1,"v":3}, "before": {"k":1,"v":3}}`, ts[4])
+		noteRow(t, v, `p`, `[1]`, `{"after": {"k":1,"v":3}, "before": {"k":1,"v":3}}`, ts[4], `foo`)
 		assertValidatorFailures(t, v,
 			`"after" field did not agree with row at `+ts[4].AsOfSystemTime()+
 				`: SELECT count(*) = 1 FROM foo AS OF SYSTEM TIME '`+ts[4].AsOfSystemTime()+
 				`' WHERE to_json(k)::TEXT = $1 AND to_json(v)::TEXT = $2 [1 3]`)
 	})
 	t.Run(`incorrect before and after`, func(t *testing.T) {
-		v, err := NewBeforeAfterValidator(sqlDBRaw, `foo`)
+		v, err := NewBeforeAfterValidator(sqlDBRaw, `foo`, standardChangefeedOptions)
 		require.NoError(t, err)
 		noteResolved(t, v, `p`, ts[0])
 		// "before" and "after" both provided with wrong value.
-		noteRow(t, v, `p`, `[1]`, `{"after": {"k":1,"v":5}, "before": {"k":1,"v":4}}`, ts[3])
+		noteRow(t, v, `p`, `[1]`, `{"after": {"k":1,"v":5}, "before": {"k":1,"v":4}}`, ts[3], `foo`)
 		assertValidatorFailures(t, v,
 			`"after" field did not agree with row at `+ts[3].AsOfSystemTime()+
 				`: SELECT count(*) = 1 FROM foo AS OF SYSTEM TIME '`+ts[3].AsOfSystemTime()+
@@ -230,19 +258,19 @@ func TestBeforeAfterValidator(t *testing.T) {
 				`' WHERE to_json(k)::TEXT = $1 AND to_json(v)::TEXT = $2 [1 4]`)
 	})
 	t.Run(`correct`, func(t *testing.T) {
-		v, err := NewBeforeAfterValidator(sqlDBRaw, `foo`)
+		v, err := NewBeforeAfterValidator(sqlDBRaw, `foo`, standardChangefeedOptions)
 		require.NoError(t, err)
 		noteResolved(t, v, `p`, ts[0])
-		noteRow(t, v, `p`, `[1]`, `{}`, ts[0])
-		noteRow(t, v, `p`, `[1]`, `{"after": {"k":1,"v":1}}`, ts[1])
-		noteRow(t, v, `p`, `[1]`, `{"after": {"k":1,"v":1}, "before": null}`, ts[1])
-		noteRow(t, v, `p`, `[1]`, `{"after": {"k":1,"v":2}, "before": {"k":1,"v":1}}`, ts[2])
-		noteRow(t, v, `p`, `[1]`, `{"after": {"k":1,"v":3}, "before": {"k":1,"v":2}}`, ts[3])
-		noteRow(t, v, `p`, `[1]`, `{                        "before": {"k":1,"v":3}}`, ts[4])
-		noteRow(t, v, `p`, `[1]`, `{"after": null,          "before": {"k":1,"v":3}}`, ts[4])
-		noteRow(t, v, `p`, `[2]`, `{}`, ts[1])
-		noteRow(t, v, `p`, `[2]`, `{"after": {"k":2,"v":2}}`, ts[2])
-		noteRow(t, v, `p`, `[2]`, `{"after": {"k":2,"v":2}, "before": null}`, ts[2])
+		noteRow(t, v, `p`, `[1]`, `{}`, ts[0], `foo`)
+		noteRow(t, v, `p`, `[1]`, `{"after": {"k":1,"v":1}}`, ts[1], `foo`)
+		noteRow(t, v, `p`, `[1]`, `{"after": {"k":1,"v":1}, "before": null}`, ts[1], `foo`)
+		noteRow(t, v, `p`, `[1]`, `{"after": {"k":1,"v":2}, "before": {"k":1,"v":1}}`, ts[2], `foo`)
+		noteRow(t, v, `p`, `[1]`, `{"after": {"k":1,"v":3}, "before": {"k":1,"v":2}}`, ts[3], `foo`)
+		noteRow(t, v, `p`, `[1]`, `{                        "before": {"k":1,"v":3}}`, ts[4], `foo`)
+		noteRow(t, v, `p`, `[1]`, `{"after": null,          "before": {"k":1,"v":3}}`, ts[4], `foo`)
+		noteRow(t, v, `p`, `[2]`, `{}`, ts[1], `foo`)
+		noteRow(t, v, `p`, `[2]`, `{"after": {"k":2,"v":2}}`, ts[2], `foo`)
+		noteRow(t, v, `p`, `[2]`, `{"after": {"k":2,"v":2}, "before": null}`, ts[2], `foo`)
 		assertValidatorFailures(t, v)
 	})
 }
@@ -269,10 +297,10 @@ func TestBeforeAfterValidatorForGeometry(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	v, err := NewBeforeAfterValidator(sqlDBRaw, `foo`)
+	v, err := NewBeforeAfterValidator(sqlDBRaw, `foo`, standardChangefeedOptions)
 	require.NoError(t, err)
 	assertValidatorFailures(t, v)
-	noteRow(t, v, `p`, `[1]`, `{"after": {"k":1, "geom":{"coordinates": [1,2], "type": "Point"}}}`, ts[0])
+	noteRow(t, v, `p`, `[1]`, `{"after": {"k":1, "geom":{"coordinates": [1,2], "type": "Point"}}}`, ts[0], `foo`)
 }
 
 func TestFingerprintValidator(t *testing.T) {
@@ -326,7 +354,7 @@ func TestFingerprintValidator(t *testing.T) {
 		sqlDB.Exec(t, createTableStmt(`wrong_data`))
 		v, err := NewFingerprintValidator(sqlDBRaw, `foo`, `wrong_data`, []string{`p`}, testColumns)
 		require.NoError(t, err)
-		noteRow(t, v, ignored, `[1]`, `{"after": {"k":1,"v":10}}`, ts[1])
+		noteRow(t, v, ignored, `[1]`, `{"after": {"k":1,"v":10}}`, ts[1], `foo`)
 		noteResolved(t, v, `p`, ts[1])
 		assertValidatorFailures(t, v,
 			`fingerprints did not match at `+ts[1].AsOfSystemTime()+
@@ -340,14 +368,14 @@ func TestFingerprintValidator(t *testing.T) {
 		if err := v.NoteResolved(`p`, ts[0]); err != nil {
 			t.Fatal(err)
 		}
-		noteRow(t, v, ignored, `[1]`, `{"after": {"k":1,"v":1}}`, ts[1])
+		noteRow(t, v, ignored, `[1]`, `{"after": {"k":1,"v":1}}`, ts[1], `foo`)
 		noteResolved(t, v, `p`, ts[1])
-		noteRow(t, v, ignored, `[1]`, `{"after": {"k":1,"v":2}}`, ts[2])
-		noteRow(t, v, ignored, `[2]`, `{"after": {"k":2,"v":2}}`, ts[2])
+		noteRow(t, v, ignored, `[1]`, `{"after": {"k":1,"v":2}}`, ts[2], `foo`)
+		noteRow(t, v, ignored, `[2]`, `{"after": {"k":2,"v":2}}`, ts[2], `foo`)
 		noteResolved(t, v, `p`, ts[2])
-		noteRow(t, v, ignored, `[1]`, `{"after": {"k":1,"v":3}}`, ts[3])
+		noteRow(t, v, ignored, `[1]`, `{"after": {"k":1,"v":3}}`, ts[3], `foo`)
 		noteResolved(t, v, `p`, ts[3])
-		noteRow(t, v, ignored, `[1]`, `{"after": null}`, ts[4])
+		noteRow(t, v, ignored, `[1]`, `{"after": null}`, ts[4], `foo`)
 		noteResolved(t, v, `p`, ts[4])
 		noteResolved(t, v, `p`, ts[5])
 		assertValidatorFailures(t, v)
@@ -356,11 +384,11 @@ func TestFingerprintValidator(t *testing.T) {
 		sqlDB.Exec(t, createTableStmt(`rows_unsorted`))
 		v, err := NewFingerprintValidator(sqlDBRaw, `foo`, `rows_unsorted`, []string{`p`}, testColumns)
 		require.NoError(t, err)
-		noteRow(t, v, ignored, `[1]`, `{"after": {"k":1,"v":3}}`, ts[3])
-		noteRow(t, v, ignored, `[1]`, `{"after": {"k":1,"v":2}}`, ts[2])
-		noteRow(t, v, ignored, `[1]`, `{"after": {"k":1,"v":1}}`, ts[1])
-		noteRow(t, v, ignored, `[1]`, `{"after": null}`, ts[4])
-		noteRow(t, v, ignored, `[2]`, `{"after": {"k":2,"v":2}}`, ts[2])
+		noteRow(t, v, ignored, `[1]`, `{"after": {"k":1,"v":3}}`, ts[3], `foo`)
+		noteRow(t, v, ignored, `[1]`, `{"after": {"k":1,"v":2}}`, ts[2], `foo`)
+		noteRow(t, v, ignored, `[1]`, `{"after": {"k":1,"v":1}}`, ts[1], `foo`)
+		noteRow(t, v, ignored, `[1]`, `{"after": null}`, ts[4], `foo`)
+		noteRow(t, v, ignored, `[2]`, `{"after": {"k":2,"v":2}}`, ts[2], `foo`)
 		noteResolved(t, v, `p`, ts[5])
 		assertValidatorFailures(t, v)
 	})
@@ -371,9 +399,9 @@ func TestFingerprintValidator(t *testing.T) {
 		noteResolved(t, v, `p`, ts[0])
 		// Intentionally missing {"k":1,"v":1} at ts[1].
 		// Insert a fake row since we don't fingerprint earlier than the first seen row.
-		noteRow(t, v, ignored, `[2]`, `{"after": {"k":2,"v":2}}`, ts[2].Prev())
-		noteRow(t, v, ignored, `[1]`, `{"after": {"k":1,"v":2}}`, ts[2])
-		noteRow(t, v, ignored, `[2]`, `{"after": {"k":2,"v":2}}`, ts[2])
+		noteRow(t, v, ignored, `[2]`, `{"after": {"k":2,"v":2}}`, ts[2].Prev(), `foo`)
+		noteRow(t, v, ignored, `[1]`, `{"after": {"k":1,"v":2}}`, ts[2], `foo`)
+		noteRow(t, v, ignored, `[2]`, `{"after": {"k":2,"v":2}}`, ts[2], `foo`)
 		noteResolved(t, v, `p`, ts[2].Prev())
 		assertValidatorFailures(t, v,
 			`fingerprints did not match at `+ts[2].Prev().AsOfSystemTime()+
@@ -385,11 +413,11 @@ func TestFingerprintValidator(t *testing.T) {
 		v, err := NewFingerprintValidator(sqlDBRaw, `foo`, `missed_middle`, []string{`p`}, testColumns)
 		require.NoError(t, err)
 		noteResolved(t, v, `p`, ts[0])
-		noteRow(t, v, ignored, `[1]`, `{"after": {"k":1,"v":1}}`, ts[1])
+		noteRow(t, v, ignored, `[1]`, `{"after": {"k":1,"v":1}}`, ts[1], `foo`)
 		// Intentionally missing {"k":1,"v":2} at ts[2].
-		noteRow(t, v, ignored, `[2]`, `{"after": {"k":2,"v":2}}`, ts[2])
+		noteRow(t, v, ignored, `[2]`, `{"after": {"k":2,"v":2}}`, ts[2], `foo`)
 		noteResolved(t, v, `p`, ts[2])
-		noteRow(t, v, ignored, `[1]`, `{"after": {"k":1,"v":3}}`, ts[3])
+		noteRow(t, v, ignored, `[1]`, `{"after": {"k":1,"v":3}}`, ts[3], `foo`)
 		noteResolved(t, v, `p`, ts[3])
 		assertValidatorFailures(t, v,
 			`fingerprints did not match at `+ts[2].AsOfSystemTime()+
@@ -403,9 +431,9 @@ func TestFingerprintValidator(t *testing.T) {
 		v, err := NewFingerprintValidator(sqlDBRaw, `foo`, `missed_end`, []string{`p`}, testColumns)
 		require.NoError(t, err)
 		noteResolved(t, v, `p`, ts[0])
-		noteRow(t, v, ignored, `[1]`, `{"after": {"k":1,"v":1}}`, ts[1])
-		noteRow(t, v, ignored, `[1]`, `{"after": {"k":1,"v":2}}`, ts[2])
-		noteRow(t, v, ignored, `[2]`, `{"after": {"k":2,"v":2}}`, ts[2])
+		noteRow(t, v, ignored, `[1]`, `{"after": {"k":1,"v":1}}`, ts[1], `foo`)
+		noteRow(t, v, ignored, `[1]`, `{"after": {"k":1,"v":2}}`, ts[2], `foo`)
+		noteRow(t, v, ignored, `[2]`, `{"after": {"k":2,"v":2}}`, ts[2], `foo`)
 		// Intentionally missing {"k":1,"v":3} at ts[3].
 		noteResolved(t, v, `p`, ts[3])
 		assertValidatorFailures(t, v,
@@ -417,8 +445,8 @@ func TestFingerprintValidator(t *testing.T) {
 		sqlDB.Exec(t, createTableStmt(`initial_scan`))
 		v, err := NewFingerprintValidator(sqlDBRaw, `foo`, `initial_scan`, []string{`p`}, testColumns)
 		require.NoError(t, err)
-		noteRow(t, v, ignored, `[1]`, `{"after": {"k":1,"v":3}}`, ts[3])
-		noteRow(t, v, ignored, `[2]`, `{"after": {"k":2,"v":2}}`, ts[3])
+		noteRow(t, v, ignored, `[1]`, `{"after": {"k":1,"v":3}}`, ts[3], `foo`)
+		noteRow(t, v, ignored, `[2]`, `{"after": {"k":2,"v":2}}`, ts[3], `foo`)
 		noteResolved(t, v, `p`, ts[3])
 		assertValidatorFailures(t, v)
 	})
@@ -434,7 +462,7 @@ func TestFingerprintValidator(t *testing.T) {
 		sqlDB.Exec(t, createTableStmt(`resolved_unsorted`))
 		v, err := NewFingerprintValidator(sqlDBRaw, `foo`, `resolved_unsorted`, []string{`p`}, testColumns)
 		require.NoError(t, err)
-		noteRow(t, v, ignored, `[1]`, `{"after": {"k":1,"v":1}}`, ts[1])
+		noteRow(t, v, ignored, `[1]`, `{"after": {"k":1,"v":1}}`, ts[1], `foo`)
 		noteResolved(t, v, `p`, ts[1])
 		noteResolved(t, v, `p`, ts[1])
 		noteResolved(t, v, `p`, ts[0])
@@ -444,8 +472,8 @@ func TestFingerprintValidator(t *testing.T) {
 		sqlDB.Exec(t, createTableStmt(`two_partitions`))
 		v, err := NewFingerprintValidator(sqlDBRaw, `foo`, `two_partitions`, []string{`p0`, `p1`}, testColumns)
 		require.NoError(t, err)
-		noteRow(t, v, ignored, `[1]`, `{"after": {"k":1,"v":1}}`, ts[1])
-		noteRow(t, v, ignored, `[1]`, `{"after": {"k":1,"v":2}}`, ts[2])
+		noteRow(t, v, ignored, `[1]`, `{"after": {"k":1,"v":1}}`, ts[1], `foo`)
+		noteRow(t, v, ignored, `[1]`, `{"after": {"k":1,"v":2}}`, ts[2], `foo`)
 		// Intentionally missing {"k":2,"v":2}.
 		noteResolved(t, v, `p0`, ts[2])
 		noteResolved(t, v, `p0`, ts[4])
@@ -478,7 +506,7 @@ func TestValidators(t *testing.T) {
 			NewOrderValidator(`t2`),
 		}
 		noteResolved(t, v, `p1`, ts(2))
-		noteRow(t, v, `p1`, `k1`, ignored, ts(1))
+		noteRow(t, v, `p1`, `k1`, ignored, ts(1), `foo`)
 		assertValidatorFailures(t, v,
 			`topic t1 partition p1`+
 				`: saw new row timestamp 1.0000000000 after 2.0000000000 was resolved`,

--- a/pkg/ccl/changefeedccl/nemeses_test.go
+++ b/pkg/ccl/changefeedccl/nemeses_test.go
@@ -8,7 +8,6 @@ package changefeedccl
 import (
 	"math"
 	"regexp"
-	"strings"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/cdctest"
@@ -35,12 +34,8 @@ func TestChangefeedNemeses(t *testing.T) {
 
 			sqlDB := sqlutils.MakeSQLRunner(s.DB)
 			withLegacySchemaChanger := maybeDisableDeclarativeSchemaChangesForTest(t, sqlDB)
-			// TODO(dan): Ugly hack to disable `eventPause` in sinkless feeds. See comment in
-			// `RunNemesis` for details.
-			isSinkless := strings.Contains(t.Name(), "sinkless")
-			isCloudstorage := strings.Contains(t.Name(), "cloudstorage")
 
-			v, err := cdctest.RunNemesis(f, s.DB, isSinkless, isCloudstorage, withLegacySchemaChanger, rng, nop)
+			v, err := cdctest.RunNemesis(f, s.DB, t.Name(), withLegacySchemaChanger, rng, nop)
 			if err != nil {
 				t.Fatalf("%+v", err)
 			}

--- a/pkg/ccl/changefeedccl/validations_test.go
+++ b/pkg/ccl/changefeedccl/validations_test.go
@@ -75,7 +75,7 @@ func TestCatchupScanOrdering(t *testing.T) {
 					if err != nil {
 						t.Fatal(err)
 					}
-					err = v.NoteRow(m.Partition, string(m.Key), string(m.Value), updated)
+					err = v.NoteRow(m.Partition, string(m.Key), string(m.Value), updated, m.Topic)
 					if err != nil {
 						t.Fatal(err)
 					}

--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -898,7 +898,7 @@ func runCDCBank(ctx context.Context, t test.Test, c cluster.Cluster) {
 
 			partitionStr := strconv.Itoa(int(m.Partition))
 			if len(m.Key) > 0 {
-				if err := v.NoteRow(partitionStr, string(m.Key), string(m.Value), updated); err != nil {
+				if err := v.NoteRow(partitionStr, string(m.Key), string(m.Value), updated, m.Topic); err != nil {
 					return err
 				}
 			} else {
@@ -926,7 +926,11 @@ func runCDCBank(ctx context.Context, t test.Test, c cluster.Cluster) {
 		if err != nil {
 			return errors.Wrap(err, "error creating validator")
 		}
-		baV, err := cdctest.NewBeforeAfterValidator(db, `bank.bank`)
+		baV, err := cdctest.NewBeforeAfterValidator(db, `bank.bank`, cdctest.ChangefeedOption{
+			FullTableName: false,
+			KeyInValue:    false,
+			Format:        "json",
+		})
 		if err != nil {
 			return err
 		}
@@ -953,7 +957,7 @@ func runCDCBank(ctx context.Context, t test.Test, c cluster.Cluster) {
 			partitionStr := strconv.Itoa(int(m.Partition))
 			if len(m.Key) > 0 {
 				startTime := timeutil.Now()
-				if err := v.NoteRow(partitionStr, string(m.Key), string(m.Value), updated); err != nil {
+				if err := v.NoteRow(partitionStr, string(m.Key), string(m.Value), updated, m.Topic); err != nil {
 					return err
 				}
 				timeSpentValidatingRows += timeutil.Since(startTime)
@@ -3890,7 +3894,7 @@ func (c *topicConsumer) validateMessage(partition int32, m *sarama.ConsumerMessa
 			return err
 		}
 	default:
-		err := c.validator.NoteRow(partitionStr, string(m.Key), string(m.Value), updated)
+		err := c.validator.NoteRow(partitionStr, string(m.Key), string(m.Value), updated, m.Topic)
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/roachtest/tests/mixed_version_cdc.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_cdc.go
@@ -301,7 +301,7 @@ func (cmvt *cdcMixedVersionTester) validate(
 
 		partitionStr := strconv.Itoa(int(m.Partition))
 		if len(m.Key) > 0 {
-			if err := cmvt.validator.NoteRow(partitionStr, string(m.Key), string(m.Value), updated); err != nil {
+			if err := cmvt.validator.NoteRow(partitionStr, string(m.Key), string(m.Value), updated, m.Topic); err != nil {
 				return err
 			}
 		} else {

--- a/pkg/crosscluster/physical/replication_random_client_test.go
+++ b/pkg/crosscluster/physical/replication_random_client_test.go
@@ -95,7 +95,7 @@ func (sv *streamClientValidator) noteRow(
 ) error {
 	sv.mu.Lock()
 	defer sv.mu.Unlock()
-	return sv.NoteRow(partition, key, value, updated)
+	return sv.NoteRow(partition, key, value, updated, "" /* topic */)
 }
 
 func (sv *streamClientValidator) noteResolved(partition string, resolved hlc.Timestamp) error {


### PR DESCRIPTION
This work makes sure our nemesis tests for changefeeds randomize
over the options we use upon changefeed creation. This randomly adds
the key_in_value option (see below) and full_table_name option half
of the time and checks that the changefeed messages respect them in
the beforeAfter validator.

Note the following limitations: the full_table_name option, when on,
asserts that the topic in the output will be d.public.{table_name}
instead of checking for the actual name of the database/schema.

This change also does not add the key_in_value option when for the
webhook and cloudstorage sinks. Even before this change, since
key_in_value is on by default for those sinks, we remove the key
from the value in those testfeed messages for ease of testing.
Unfortunately, this makes these cases hard to test, so we leave them
out for now.

See also: https://github.com/cockroachdb/cockroach/issues/134119

Epic: [CRDB-42866](https://cockroachlabs.atlassian.net/browse/CRDB-42866)

Release note: None