### PR TITLE
sql: remove executorType condition from disallow_full_table_scans check

### DIFF
--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -3184,24 +3184,22 @@ func (ex *connExecutor) makeExecPlan(ctx context.Context, planner *planner) erro
 	flags := planner.curPlan.flags
 
 	if flags.IsSet(planFlagContainsFullIndexScan) || flags.IsSet(planFlagContainsFullTableScan) {
-		if ex.executorType == executorTypeExec && planner.EvalContext().SessionData().DisallowFullTableScans {
-			hasLargeScan := flags.IsSet(planFlagContainsLargeFullIndexScan) || flags.IsSet(planFlagContainsLargeFullTableScan)
-			if hasLargeScan {
-				// We don't execute the statement if:
-				// - plan contains a full table or full index scan.
-				//   TODO(#123783): this currently doesn't apply to full scans
-				//   of virtual tables.
-				// - the session setting disallows full table/index scans.
-				// - the scan is considered large.
-				// - the query is not an internal query.
-				ex.metrics.EngineMetrics.FullTableOrIndexScanRejectedCount.Inc(1)
-				return errors.WithHint(
-					pgerror.Newf(pgcode.TooManyRows,
-						"query `%s` contains a full table/index scan which is explicitly disallowed",
-						planner.stmt.SQL),
-					"try overriding the `disallow_full_table_scans` or increasing the `large_full_scan_rows` cluster/session settings",
-				)
-			}
+		if planner.EvalContext().SessionData().DisallowFullTableScans &&
+			(flags.IsSet(planFlagContainsLargeFullIndexScan) ||
+				flags.IsSet(planFlagContainsLargeFullTableScan)) {
+			// We don't execute the statement if:
+			// - plan contains a full table or full index scan.
+			//   TODO(#123783): this currently doesn't apply to full scans
+			//   of virtual tables.
+			// - the session setting disallows full table/index scans.
+			// - the scan is considered large.
+			ex.metrics.EngineMetrics.FullTableOrIndexScanRejectedCount.Inc(1)
+			return errors.WithHint(
+				pgerror.Newf(pgcode.TooManyRows,
+					"query `%s` contains a full table/index scan which is explicitly disallowed",
+					planner.stmt.SQL),
+				"try overriding the `disallow_full_table_scans` or increasing the `large_full_scan_rows` cluster/session settings",
+			)
 		}
 		ex.metrics.EngineMetrics.FullTableOrIndexScanCount.Inc(1)
 	}


### PR DESCRIPTION
Now that #137681 explicitly turns off `disallow_full_table_scans` for the internal executor, we no longer need to look at executorType in the connExecutor check. This makes the connExecutor check match the execBuilder check added in #71317.

Informs: #137404

Release note: None