### PR TITLE
roachtest/mixedversion: upgrade plan should be bounded

### DIFF
--- a/pkg/cmd/roachtest/tests/mixed_version_cdc.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_cdc.go
@@ -500,9 +500,9 @@ func runCDCMixedVersions(ctx context.Context, t test.Test, c cluster.Cluster) {
 		// 23.1. That mistake was then fixed (#110676) but, to simplify
 		// this test, we only create changefeeds in more recent versions.
 		mixedversion.MinimumSupportedVersion("v23.2.0"),
-		// We limit the number of upgrades to be performed in the test run because
-		// the test takes a significant amount of time to complete.
-		mixedversion.MaxUpgrades(3),
+		// We limit the total number of plan steps to 80, which is roughly 60% of all plan lengths.
+		// See https://github.com/cockroachdb/cockroach/pull/137963#discussion_r1906256740 for more details.
+		mixedversion.MaxNumPlanSteps(80),
 	)
 
 	cleanupKafka := tester.StartKafka(t, c)

--- a/pkg/cmd/roachtest/tests/tpcc.go
+++ b/pkg/cmd/roachtest/tests/tpcc.go
@@ -442,7 +442,9 @@ func runTPCCMixedHeadroom(ctx context.Context, t test.Test, c cluster.Cluster) {
 		// the `workload fixtures import` command, which is only supported
 		// reliably multi-tenant mode starting from that version.
 		mixedversion.MinimumSupportedVersion("v23.2.0"),
-		mixedversion.MaxUpgrades(3),
+		// We limit the total number of plan steps to 70, which is roughly 80% of all plan lengths.
+		// See #138014 for more details.
+		mixedversion.MaxNumPlanSteps(70),
 	)
 
 	tenantFeaturesEnabled := make(chan struct{})


### PR DESCRIPTION
Previously, the mixedversion framework did not bound
the total number of steps in a test plan. Since steps
are generated according to different pseudo-random
distributions, the total number of resulting steps
can vary significantly.
E.g., for `tpcc/mixed-headroom/n5cpu16`, the smallest
test plan has 14 steps, whereas the largest, based
on a sampling of 1_000_000 valid test plans, has
135 steps!

High variability in the size of the test plan
is directly proportional to the running time.
Thus, a very large test plan can cause a test
to time out, due to exceeding its max running time.
That is the case for `tpcc/mixed-headroom/n5cpu16`.

This PR adds an option, namely `MaxNumPlanSteps`,
which enforces an upper bound. If a generated
test plan exceeds the specified value, a new
one is generated until the resulting length
is within the specification.

This PR also adds a primitive `dry-run` mode,
which can be useful for debugging test plans.
If `MVT_DRY_RUN_MODE` env. var. is set, print
the mixedversion test plan and exit.

Resolves: https://github.com/cockroachdb/cockroach/issues/138014
Informs: https://github.com/cockroachdb/cockroach/issues/137332
Epic: none
Release note: None