### PR TITLE
server: fix errors returned from TriggerMetadataUpdateJob

### DIFF
--- a/pkg/server/api_v2_databases_metadata.go
+++ b/pkg/server/api_v2_databases_metadata.go
@@ -48,6 +48,7 @@ const (
 	MetadataNotStale JobStatusMessage = "Not enough time has elapsed since last job run"
 	JobRunning       JobStatusMessage = "Job is already running"
 	JobTriggered     JobStatusMessage = "Job triggered successfully"
+	JobUnclaimed     JobStatusMessage = "Job is unclaimed"
 )
 
 const (
@@ -1023,8 +1024,12 @@ func (a *apiV2Server) triggerTableMetadataUpdateJob(
 	if err != nil {
 		st, ok := status.FromError(err)
 		if ok {
-			if st.Code() == codes.Aborted {
+			switch st.Code() {
+			case codes.Aborted:
 				return tmJobTriggeredResponse{JobTriggered: false, Message: JobRunning}, nil
+			case codes.Unavailable:
+				return tmJobTriggeredResponse{JobTriggered: false, Message: JobUnclaimed}, nil
+			default:
 			}
 		}
 		return tmJobTriggeredResponse{}, err

--- a/pkg/ui/workspaces/cluster-ui/src/components/tableMetadataLastUpdated/tableMetadataJobControl.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/components/tableMetadataLastUpdated/tableMetadataJobControl.tsx
@@ -42,9 +42,13 @@ export const TableMetadataJobControl: React.FC<
 
   const triggerUpdateTableMetaJob = useCallback(
     async (onlyIfStale = true) => {
-      const resp = await triggerUpdateTableMetaJobApi({ onlyIfStale });
-      if (resp.jobTriggered) {
-        return refreshJobStatus();
+      try {
+        const resp = await triggerUpdateTableMetaJobApi({ onlyIfStale });
+        if (resp.jobTriggered) {
+          return refreshJobStatus();
+        }
+      } catch {
+        // We don't need to do anything with additional errors right now.
       }
     },
     [refreshJobStatus],


### PR DESCRIPTION
Previously POST on `/api/v2/table_metadata/updatejob` would return error if the table metadata update job was unclaimed, which is an expected failure. In those cases we should return 200 with `JobTriggered: false` and a message describing the failure.

The gPRC handler to trigger the job was already returning `status.Unavailable` if the job was unclaimed. The http api handler has now been adjusted to treat this error code as an expected failure case and will return a 200 response with the message `Job is unclaimed` as the reason for failing to trigger the job.

Fixes: #137777

Release note (bug fix): On the v2 databases page, users should no longer see console errors when visitingn the db page directly after node / sql pod startup.