### PR TITLE
sql: make annotations for planner used in backfillQueryIntoTable

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/create_as
+++ b/pkg/sql/logictest/testdata/logic_test/create_as
@@ -451,3 +451,13 @@ query B
 SELECT count(*) > 0 FROM t_105887_2
 ----
 true
+
+# Regression test for not setting the Annotations on the planner (#137631).
+statement ok
+SET experimental_enable_temp_tables = 'on';
+
+statement ok
+CREATE TABLE v00 (c01 INT, c02 STRING);
+
+statement ok
+CREATE TEMP TABLE v300 AS ( ( TABLE [ SHOW EXPERIMENTAL_FINGERPRINTS FROM TABLE v00 ] ) ) ;

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -373,6 +373,7 @@ func (sc *SchemaChanger) backfillQueryIntoTable(
 			return err
 		}
 
+		localPlanner.MaybeReallocateAnnotations(stmt.NumAnnotations)
 		// Construct an optimized logical plan of the AS source stmt.
 		localPlanner.stmt = makeStatement(stmt, clusterunique.ID{}, /* queryID */
 			tree.FmtFlags(queryFormattingForFingerprintsMask.Get(&localPlanner.execCfg.Settings.SV)))


### PR DESCRIPTION
We use an internal planner in `backfillQueryIntoTable`, and previously we forgot to create annotations in that code path, which could lead to an internal error in edge cases. Annotations are needed when performing object resolution, and I'm guessing that other places where we use the planner don't need them.

Fixes: #137631.

Release note: None