### PR TITLE
roachtest: install bzip2 for jepsen tests

### DIFF
--- a/pkg/cmd/roachtest/tests/jepsen.go
+++ b/pkg/cmd/roachtest/tests/jepsen.go
@@ -143,6 +143,13 @@ func initJepsen(ctx context.Context, t test.Test, c cluster.Cluster, j jepsenCon
 	c.Run(ctx, option.WithNodes(c.All()), "sh", "-c", `"sudo apt-get -y update > logs/apt-upgrade.log 2>&1"`)
 	c.Run(ctx, option.WithNodes(c.All()), "sh", "-c", `"sudo DEBIAN_FRONTEND=noninteractive apt-get -y upgrade -o Dpkg::Options::='--force-confold' -o DPkg::options::='--force-confdef' > logs/apt-upgrade.log 2>&1"`)
 
+	// Jepsen artifact collection requires bzip2, which is not installed
+	// on the base image.
+	t.L().Printf("installing bzip2")
+	if err := c.Install(ctx, t.L(), c.All(), "bzip2"); err != nil {
+		t.Fatal(err)
+	}
+
 	// TODO(bdarnell): copying the raw binary and compressing it on the
 	// other side is silly, but this lets us avoid platform-specific
 	// quirks in tar. The --transform option is only available on gnu

--- a/pkg/roachprod/install/install.go
+++ b/pkg/roachprod/install/install.go
@@ -104,6 +104,11 @@ rm /tmp/otelcol-contrib.deb;
 	"side-eye": `
 	curl https://sh.side-eye.io/ | SIDE_EYE_API_TOKEN=%API_KEY% SIDE_EYE_ENVIRONMENT="%ROACHPROD_CLUSTER_NAME%" sh
 	`,
+
+	"bzip2": `
+sudo apt-get update;
+sudo apt-get install -y bzip2;
+`,
 }
 
 // installLocalCmds is a map from software name to a map of strings that


### PR DESCRIPTION
As explained in #121708, jepsen artifact collection requires bzip2, which is not installed on Ubuntu 22.04. This was preventing investigation of tests failures.

This PR introduces bzip2 as a new software that can be installed by roachprod install, and installs it while setting up the cluster to run jepsen.

Fixes: https://github.com/cockroachdb/cockroach/issues/121708

Epic: none
Release note: None