### PR TITLE
wip: sql: generic range scans

### DIFF
--- a/pkg/sql/opt/memo/extract.go
+++ b/pkg/sql/opt/memo/extract.go
@@ -209,12 +209,13 @@ func ExtractJoinConditionFilterOrds(
 		if !ok {
 			continue
 		}
-		if seenCols.Contains(left) || seenCols.Contains(right) {
-			// Don't allow any column to show up twice.
-			// TODO(radu): need to figure out the right thing to do in cases
-			//  like: left.a = right.a AND left.a = right.b
-			continue
-		}
+		// TODO: Figure out how to allow this for placeholders with equalities.
+		// if seenCols.Contains(left) || seenCols.Contains(right) {
+		// 	// Don't allow any column to show up twice.
+		// 	// TODO(radu): need to figure out the right thing to do in cases
+		// 	//  like: left.a = right.a AND left.a = right.b
+		// 	continue
+		// }
 		seenCols.Add(left)
 		seenCols.Add(right)
 		filterOrds.Add(i)

--- a/pkg/sql/opt/norm/select_funcs.go
+++ b/pkg/sql/opt/norm/select_funcs.go
@@ -207,7 +207,7 @@ func (c *CustomFuncs) ConsolidateFilters(filters memo.FiltersExpr) memo.FiltersE
 	return newFilters
 }
 
-// mergeSortedAnds merges two left-deep trees of nested AndExprs sorted by ID.
+// mergeSortedAnds merges two left-deep trees of nested AndExprs sorted by rank.
 // Returns a single sorted, left-deep tree of nested AndExprs, with any
 // duplicate expressions eliminated.
 func (c *CustomFuncs) mergeSortedAnds(left, right opt.ScalarExpr) opt.ScalarExpr {

--- a/pkg/sql/tests/sysbench_test.go
+++ b/pkg/sql/tests/sysbench_test.go
@@ -282,6 +282,9 @@ func (s *sysbenchSQL) prepSchema(rng *rand.Rand) {
 }
 
 func (s *sysbenchSQL) prepConn() {
+	// Force generic query plans.
+	try(s.conn.Exec(s.ctx, "SET plan_cache_mode = force_generic_plan"))
+
 	s.stmt.begin = try(s.conn.Prepare(s.ctx, "begin", sysbenchStmtBegin)).Name
 	s.stmt.commit = try(s.conn.Prepare(s.ctx, "commit", sysbenchStmtCommit)).Name
 	for i := range sysbenchTables {

--- a/pkg/sql/tests/sysbench_test.go
+++ b/pkg/sql/tests/sysbench_test.go
@@ -286,6 +286,8 @@ func (s *sysbenchSQL) prepConn() {
 	try(s.conn.Exec(s.ctx, "SET plan_cache_mode = force_generic_plan"))
 	// Disable the streamer.
 	try(s.conn.Exec(s.ctx, "SET streamer_enabled = false"))
+	// Disable the vectorized engine.
+	try(s.conn.Exec(s.ctx, "SET vectorize = off"))
 
 	s.stmt.begin = try(s.conn.Prepare(s.ctx, "begin", sysbenchStmtBegin)).Name
 	s.stmt.commit = try(s.conn.Prepare(s.ctx, "commit", sysbenchStmtCommit)).Name

--- a/pkg/sql/tests/sysbench_test.go
+++ b/pkg/sql/tests/sysbench_test.go
@@ -284,6 +284,8 @@ func (s *sysbenchSQL) prepSchema(rng *rand.Rand) {
 func (s *sysbenchSQL) prepConn() {
 	// Force generic query plans.
 	try(s.conn.Exec(s.ctx, "SET plan_cache_mode = force_generic_plan"))
+	// Disable the streamer.
+	try(s.conn.Exec(s.ctx, "SET streamer_enabled = false"))
 
 	s.stmt.begin = try(s.conn.Prepare(s.ctx, "begin", sysbenchStmtBegin)).Name
 	s.stmt.commit = try(s.conn.Prepare(s.ctx, "commit", sysbenchStmtCommit)).Name


### PR DESCRIPTION
I had forgotten that lookup join expression support expression like `a > 0 AND a < 10`. It just took a minor adjustment to the optimizer to get it to plan generic lookup joins with expressions like `a > $1 AND a < $2`. The remaining hurdle to get this working is to figure out how these expressions can be costed so that they are picked over the custom plan.

I tested the performance of this with the sysbench micro benchmarks by forcing generic query plans. The results were not good:

```
name                                         old time/op    new time/op    delta
Sysbench/SQL/1node_local/oltp_read_only-16     2.76ms ± 1%    3.28ms ± 1%  +18.86%  (p=0.000 n=9+10)
Sysbench/SQL/1node_local/oltp_read_write-16    4.67ms ± 1%    5.20ms ± 1%  +11.41%  (p=0.000 n=10+10)
Sysbench/SQL/3node/oltp_read_write-16          5.57ms ± 1%    6.27ms ± 1%  +12.64%  (p=0.000 n=10+10)

name                                         old alloc/op   new alloc/op   delta
Sysbench/SQL/1node_local/oltp_read_only-16      834kB ± 0%    1020kB ± 0%  +22.23%  (p=0.000 n=10+10)
Sysbench/SQL/1node_local/oltp_read_write-16    1.36MB ±11%    1.41MB ± 0%     ~     (p=0.143 n=10+10)
Sysbench/SQL/3node/oltp_read_write-16          2.37MB ±15%    2.58MB ± 7%   +9.13%  (p=0.019 n=10+10)

name                                         old allocs/op  new allocs/op  delta
Sysbench/SQL/1node_local/oltp_read_only-16      3.90k ± 1%     5.38k ± 0%  +37.93%  (p=0.000 n=10+10)
Sysbench/SQL/1node_local/oltp_read_write-16     6.81k ± 0%     8.39k ± 0%  +23.27%  (p=0.000 n=9+10)
Sysbench/SQL/3node/oltp_read_write-16           10.8k ± 3%     12.7k ± 3%  +17.43%  (p=0.000 n=10+10)
```

I think this is slower because the execution of the range-scan lookup joins is greater than the overhead of planning constrained scans for the 4 range queries.