### PR TITLE
roachtest: lower the foreground throughput in disk bandwidth test

### DIFF
--- a/pkg/cmd/roachtest/tests/admission_control_disk_bandwidth_overload.go
+++ b/pkg/cmd/roachtest/tests/admission_control_disk_bandwidth_overload.go
@@ -85,7 +85,7 @@ func registerDiskBandwidthOverload(r registry.Registry) {
 
 			c.Run(ctx, option.WithNodes(c.WorkloadNode()),
 				"./cockroach workload init kv --drop --insert-count=400 "+
-					"--max-block-bytes=1024 --min-block-bytes=1024"+foregroundDB+url)
+					"--max-block-bytes=512 --min-block-bytes=512"+foregroundDB+url)
 
 			c.Run(ctx, option.WithNodes(c.WorkloadNode()),
 				"./cockroach workload init kv --drop --insert-count=400 "+


### PR DESCRIPTION
The test fails due to excessive amount of foreground traffic. This patch lowers the bytes written by the foreground traffic.

Fixes #137881

Release note: None