### PR TITLE
release-24.1: backup: fix alter backup schedule failing on uri with spaces

### DIFF
--- a/pkg/ccl/backupccl/alter_backup_schedule.go
+++ b/pkg/ccl/backupccl/alter_backup_schedule.go
@@ -214,30 +214,35 @@ func doAlterBackupSchedules(
 			return err
 		}
 
-		if err := emitAlteredSchedule(s.incJob, s.incStmt, resultsCh); err != nil {
+		if err := emitAlteredSchedule(ctx, p, s.incJob, s.incStmt, resultsCh); err != nil {
 			return err
 		}
 	}
 
 	// Emit the full backup schedule after the incremental.
 	// This matches behavior in CREATE SCHEDULE FOR BACKUP.
-	return emitAlteredSchedule(s.fullJob, s.fullStmt, resultsCh)
+	return emitAlteredSchedule(ctx, p, s.fullJob, s.fullStmt, resultsCh)
 }
 
 func emitAlteredSchedule(
-	job *jobs.ScheduledJob, stmt *tree.Backup, resultsCh chan<- tree.Datums,
+	ctx context.Context,
+	p sql.PlanHookState,
+	job *jobs.ScheduledJob,
+	stmt *tree.Backup,
+	resultsCh chan<- tree.Datums,
 ) error {
-	to := make([]string, len(stmt.To))
-	for i, dest := range stmt.To {
-		to[i] = tree.AsStringWithFlags(dest, tree.FmtBareStrings|tree.FmtShowFullURIs)
+	exprEval := p.ExprEvaluator("BACKUP")
+	to, err := exprEval.StringArray(ctx, tree.Exprs(stmt.To))
+	if err != nil {
+		return err
 	}
-	kmsURIs := make([]string, len(stmt.Options.EncryptionKMSURI))
-	for i, kmsURI := range stmt.Options.EncryptionKMSURI {
-		kmsURIs[i] = tree.AsStringWithFlags(kmsURI, tree.FmtBareStrings|tree.FmtShowFullURIs)
+	kmsURIs, err := exprEval.StringArray(ctx, tree.Exprs(stmt.Options.EncryptionKMSURI))
+	if err != nil {
+		return err
 	}
-	incDests := make([]string, len(stmt.Options.IncrementalStorage))
-	for i, incDest := range stmt.Options.IncrementalStorage {
-		incDests[i] = tree.AsStringWithFlags(incDest, tree.FmtBareStrings|tree.FmtShowFullURIs)
+	incDests, err := exprEval.StringArray(ctx, tree.Exprs(stmt.Options.IncrementalStorage))
+	if err != nil {
+		return err
 	}
 	if err := emitSchedule(job, stmt, to, nil, /* incrementalFrom */
 		kmsURIs, incDests, resultsCh); err != nil {


### PR DESCRIPTION
Backport 1/1 commits from #137948.

/cc @cockroachdb/release

---

`ALTER BACKUP SCHEDULE` being run on a backup schedule whose URI contains spaces would fail with error `ERROR: parse "'gs://cockroachdb-backup-testing/kevin spacey?AUTH=implicit'": first path segment in URL cannot contain colon`.

This was caused by the fact that despite the `FmtBareStrings` flag being used, the space character is considered one of the "special characters" outlined in its doc that causes the string to remain wrapped with quotes. Passing this quoted string to `url.Parse` fails.

Fixes: #134861

Release note (bug fix): `ALTER BACKUP SCHEDULE` no longer fails on schedules whose collection URI contains a space.

Release justification: bug fix