### PR TITLE
ccl/multiregionccl: deflake TestRegionLivenessProberForLeases

### DIFF
--- a/pkg/ccl/multiregionccl/regionliveness_test.go
+++ b/pkg/ccl/multiregionccl/regionliveness_test.go
@@ -281,7 +281,9 @@ func TestRegionLivenessProberForLeases(t *testing.T) {
 				keyToBlockMu.Lock()
 				keyPrefix := keyToBlock
 				keyToBlockMu.Unlock()
-				if keyPrefix == nil || !deleteRequest.Key[:len(keyPrefix)].Equal(keyPrefix) {
+				isPrefixToDelReq := len(deleteRequest.Key) >= len(keyPrefix) &&
+					!deleteRequest.Key[:len(keyPrefix)].Equal(keyPrefix)
+				if keyPrefix == nil || isPrefixToDelReq {
 					return nil
 				}
 				recoveryStart <- struct{}{}


### PR DESCRIPTION
In our `TestingRequestFilter`, we should ensure that the length of our delete request key is at least the same length as the prefix key; otherwise, we risk indexing out of bounds during our prefix key check.

Epic: none
Fixes: #138058

Release note: None