### PR TITLE
server: cleanup creation of storeids slice for span stats

### DIFF
--- a/pkg/server/span_stats_server.go
+++ b/pkg/server/span_stats_server.go
@@ -330,16 +330,16 @@ func (s *systemStatusServer) statsForSpan(
 				return nil, err
 			}
 		}
-
-		spanStats.StoreIDs = make([]roachpb.StoreID, 0, len(storeIDs))
-		for storeID := range storeIDs {
-			spanStats.StoreIDs = append(spanStats.StoreIDs, storeID)
-		}
-		sort.Slice(spanStats.StoreIDs, func(i, j int) bool {
-			return spanStats.StoreIDs[i] < spanStats.StoreIDs[j]
-		})
-
 	}
+
+	spanStats.StoreIDs = make([]roachpb.StoreID, 0, len(storeIDs))
+	for storeID := range storeIDs {
+		spanStats.StoreIDs = append(spanStats.StoreIDs, storeID)
+	}
+	sort.Slice(spanStats.StoreIDs, func(i, j int) bool {
+		return spanStats.StoreIDs[i] < spanStats.StoreIDs[j]
+	})
+
 	// If we still have some remaining ranges, request range stats for the current batch.
 	if len(fullyContainedKeysBatch) > 0 {
 		// Obtain stats for fully contained ranges via RangeStats.


### PR DESCRIPTION
The creation of the storeIDs slice should be done after iterating through range descriptors, not at the end of each iteration. This commit fixes a misplacement of this code block.

Epic: none

Release note: None