### PR TITLE
rttanalysis: avoid tracing during non-validation benchmark

### DIFF
--- a/pkg/bench/rttanalysis/registry.go
+++ b/pkg/bench/rttanalysis/registry.go
@@ -42,7 +42,7 @@ func NewRegistry(numNodes int, cc ClusterConstructor) *Registry {
 func (r *Registry) Run(b *testing.B) {
 	tests, ok := r.r[bName(b)]
 	require.True(b, ok)
-	runRoundTripBenchmark(bShim{b}, tests, r.cc)
+	runCPUMemBenchmark(bShim{b}, tests, r.cc)
 }
 
 // RunExpectations runs all the benchmarks for one iteration


### PR DESCRIPTION
The benchmarks in this package were all capturing statement traces. That is useful for when we want to measure the number of KV roundtrips and compare it to the expected number, but when we run the test cases as normal benchmarks the overhead of capturing a trace distorts all measurements.

Now we only capture traces when we need to, in the TestBenchmarkExpectation test.

Epic: None
Release note: None