### PR TITLE
jobs: make custom authorizers ask for legacy payload

### DIFF
--- a/pkg/ccl/changefeedccl/alter_changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/alter_changefeed_stmt.go
@@ -110,8 +110,11 @@ func alterChangefeedPlanHook(
 		if err != nil {
 			return err
 		}
+		getLegacyPayload := func(ctx context.Context) (*jobspb.Payload, error) {
+			return &jobPayload, nil
+		}
 		err = jobsauth.Authorize(
-			ctx, p, jobID, &jobPayload, jobsauth.ControlAccess, globalPrivileges,
+			ctx, p, jobID, getLegacyPayload, jobPayload.UsernameProto.Decode(), jobPayload.Type(), jobsauth.ControlAccess, globalPrivileges,
 		)
 		if err != nil {
 			return err

--- a/pkg/ccl/changefeedccl/authorization.go
+++ b/pkg/ccl/changefeedccl/authorization.go
@@ -142,8 +142,12 @@ func AuthorizeChangefeedJobAccess(
 	ctx context.Context,
 	a jobsauth.AuthorizationAccessor,
 	jobID jobspb.JobID,
-	payload *jobspb.Payload,
+	getLegacyPayload func(ctx context.Context) (*jobspb.Payload, error),
 ) error {
+	payload, err := getLegacyPayload(ctx)
+	if err != nil {
+		return err
+	}
 	specs, ok := payload.UnwrapDetails().(jobspb.ChangefeedDetails)
 	if !ok {
 		return errors.Newf("could not unwrap details from the payload of job %d", jobID)

--- a/pkg/jobs/jobsauth/authorization_test.go
+++ b/pkg/jobs/jobsauth/authorization_test.go
@@ -324,7 +324,9 @@ func TestAuthorization(t *testing.T) {
 			globalPrivileges, err := jobsauth.GetGlobalJobPrivileges(ctx, testAuth)
 			assert.NoError(t, err)
 			err = jobsauth.Authorize(
-				ctx, testAuth, 0, tc.payload, tc.accessLevel, globalPrivileges,
+				ctx, testAuth, 0,
+				func(ctx context.Context) (*jobspb.Payload, error) { return tc.payload, nil },
+				tc.payload.UsernameProto.Decode(), tc.payload.Type(), tc.accessLevel, globalPrivileges,
 			)
 			assert.Equal(t, pgerror.GetPGCode(tc.userErr), pgerror.GetPGCode(err))
 		})

--- a/pkg/sql/control_jobs.go
+++ b/pkg/sql/control_jobs.go
@@ -68,8 +68,11 @@ func (n *controlJobsNode) startExec(params runParams) error {
 
 		if err := reg.UpdateJobWithTxn(params.ctx, jobspb.JobID(jobID), params.p.InternalSQLTxn(),
 			func(txn isql.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater) error {
+				getLegacyPayload := func(ctx context.Context) (*jobspb.Payload, error) {
+					return md.Payload, nil
+				}
 				if err := jobsauth.Authorize(params.ctx, params.p,
-					md.ID, md.Payload, jobsauth.ControlAccess, globalPrivileges); err != nil {
+					md.ID, getLegacyPayload, md.Payload.UsernameProto.Decode(), md.Payload.Type(), jobsauth.ControlAccess, globalPrivileges); err != nil {
 					return err
 				}
 				switch n.desiredStatus {

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -1113,9 +1113,11 @@ func populateSystemJobsTableRows(
 		if err != nil {
 			return matched, wrapPayloadUnMarshalError(err, currentRow[jobIdIdx])
 		}
-
+		getLegacyPayload := func(ctx context.Context) (*jobspb.Payload, error) {
+			return payload, nil
+		}
 		err = jobsauth.Authorize(
-			ctx, p, jobspb.JobID(jobID), payload, jobsauth.ViewAccess, globalPrivileges,
+			ctx, p, jobspb.JobID(jobID), getLegacyPayload, payload.UsernameProto.Decode(), payload.Type(), jobsauth.ViewAccess, globalPrivileges,
 		)
 		if err != nil {
 			// Filter out jobs which the user is not allowed to see.


### PR DESCRIPTION
Previously the custom authorizer was always passed the legacy payload. In the near future, we do not expect to have these payloads on hand to pass it so it will need to ask for the payload to be explicitly -- and expensively -- fetched specifically for it. To allow it to do this, we now pass it the payload lazily via a function to fetch it (which for now just closes over the existing one in the legacy paths). This potentially will also allow us to make an option to not fetch it, opting out of payload-based extended auth checks to prioritize performance and stability of jobs system commands over job-specific customized visibility schemes.

Release note: none.
Epic: none.