### PR TITLE
sql: Add ALTER JOB x OWNER TO y

### DIFF
--- a/docs/generated/sql/bnf/BUILD.bazel
+++ b/docs/generated/sql/bnf/BUILD.bazel
@@ -38,6 +38,7 @@ FILES = [
     "alter_index_partition_by",
     "alter_index",
     "alter_index_visible_stmt",
+    "alter_job_stmt",
     "alter_partition_stmt",
     "alter_primary_key",
     "alter_range_relocate_stmt",

--- a/docs/generated/sql/bnf/alter_ddl_stmt.bnf
+++ b/docs/generated/sql/bnf/alter_ddl_stmt.bnf
@@ -14,3 +14,4 @@ alter_ddl_stmt ::=
 	| alter_func_stmt
 	| alter_proc_stmt
 	| alter_backup_schedule
+	| alter_job_stmt

--- a/docs/generated/sql/bnf/alter_job_stmt.bnf
+++ b/docs/generated/sql/bnf/alter_job_stmt.bnf
@@ -1,0 +1,2 @@
+alter_job_stmt ::=
+	'ALTER' 'JOB' a_expr 'OWNER' 'TO' role_spec

--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -540,6 +540,7 @@ alter_ddl_stmt ::=
 	| alter_func_stmt
 	| alter_proc_stmt
 	| alter_backup_schedule
+	| alter_job_stmt
 
 alter_role_stmt ::=
 	'ALTER' role_or_group_or_user role_spec opt_role_options
@@ -1758,6 +1759,9 @@ alter_proc_stmt ::=
 
 alter_backup_schedule ::=
 	'ALTER' 'BACKUP' 'SCHEDULE' iconst64 alter_backup_schedule_cmds
+
+alter_job_stmt ::=
+	'ALTER' 'JOB' a_expr 'OWNER' 'TO' role_spec
 
 role_or_group_or_user ::=
 	'ROLE'

--- a/pkg/gen/bnf.bzl
+++ b/pkg/gen/bnf.bzl
@@ -34,6 +34,7 @@ BNF_SRCS = [
     "//docs/generated/sql/bnf:alter_index.bnf",
     "//docs/generated/sql/bnf:alter_index_partition_by.bnf",
     "//docs/generated/sql/bnf:alter_index_visible_stmt.bnf",
+    "//docs/generated/sql/bnf:alter_job_stmt.bnf",
     "//docs/generated/sql/bnf:alter_partition_stmt.bnf",
     "//docs/generated/sql/bnf:alter_primary_key.bnf",
     "//docs/generated/sql/bnf:alter_proc.bnf",

--- a/pkg/gen/diagrams.bzl
+++ b/pkg/gen/diagrams.bzl
@@ -35,6 +35,7 @@ DIAGRAMS_SRCS = [
     "//docs/generated/sql/bnf:alter_index.html",
     "//docs/generated/sql/bnf:alter_index_partition_by.html",
     "//docs/generated/sql/bnf:alter_index_visible.html",
+    "//docs/generated/sql/bnf:alter_job.html",
     "//docs/generated/sql/bnf:alter_partition.html",
     "//docs/generated/sql/bnf:alter_primary_key.html",
     "//docs/generated/sql/bnf:alter_proc.html",

--- a/pkg/gen/docs.bzl
+++ b/pkg/gen/docs.bzl
@@ -47,6 +47,7 @@ DOCS_SRCS = [
     "//docs/generated/sql/bnf:alter_index.bnf",
     "//docs/generated/sql/bnf:alter_index_partition_by.bnf",
     "//docs/generated/sql/bnf:alter_index_visible_stmt.bnf",
+    "//docs/generated/sql/bnf:alter_job_stmt.bnf",
     "//docs/generated/sql/bnf:alter_partition_stmt.bnf",
     "//docs/generated/sql/bnf:alter_primary_key.bnf",
     "//docs/generated/sql/bnf:alter_proc.bnf",

--- a/pkg/jobs/jobs.go
+++ b/pkg/jobs/jobs.go
@@ -597,6 +597,10 @@ type JobNotFoundError struct {
 	sessionID sqlliveness.SessionID
 }
 
+func NewJobNotFoundError(jobID jobspb.JobID) *JobNotFoundError {
+	return &JobNotFoundError{jobID: jobID}
+}
+
 var _ errors.SafeFormatter = &JobNotFoundError{}
 
 func (e *JobNotFoundError) SafeFormatError(p errors.Printer) (next error) {

--- a/pkg/jobs/jobsauth/authorization_test.go
+++ b/pkg/jobs/jobsauth/authorization_test.go
@@ -52,6 +52,8 @@ type testAuthAccessor struct {
 	// set of all usernames who are admins
 	admins map[string]struct{}
 
+	members map[username.SQLUsername]bool
+
 	rand *rand.Rand
 }
 
@@ -137,6 +139,12 @@ func (a *testAuthAccessor) HasGlobalPrivilegeOrRoleOption(
 	return false, nil
 }
 
+func (a *testAuthAccessor) MemberOfWithAdminOption(
+	ctx context.Context, member username.SQLUsername,
+) (map[username.SQLUsername]bool, error) {
+	return a.members, nil
+}
+
 func (a *testAuthAccessor) User() username.SQLUsername {
 	return a.user
 }
@@ -172,6 +180,7 @@ func TestAuthorization(t *testing.T) {
 
 		user                 username.SQLUsername
 		roleOptions          map[roleoption.Option]struct{}
+		members              map[username.SQLUsername]bool
 		userPrivileges       map[userPrivilege]struct{}
 		changeFeedPrivileges map[descpb.ID]struct{}
 		droppedDescriptors   map[descpb.ID]struct{}
@@ -218,6 +227,17 @@ func TestAuthorization(t *testing.T) {
 			payload:     makeBackupPayload("user1"),
 			accessLevel: jobsauth.ControlAccess,
 			userErr:     pgerror.New(pgcode.InsufficientPrivilege, "foo"),
+		},
+		{
+			name:        "users-can-control-their-roles-jobs",
+			user:        username.MakeSQLUsernameFromPreNormalizedString("user1"),
+			roleOptions: map[roleoption.Option]struct{}{},
+			admins:      map[string]struct{}{},
+			payload:     makeBackupPayload("role1"),
+			accessLevel: jobsauth.ControlAccess,
+			members: map[username.SQLUsername]bool{
+				username.MakeSQLUsernameFromPreNormalizedString("role1"): false,
+			},
 		},
 		{
 			name:        "admins-control-admin-jobs",
@@ -317,6 +337,7 @@ func TestAuthorization(t *testing.T) {
 				changeFeedPrivileges: tc.changeFeedPrivileges,
 				droppedDescriptors:   tc.droppedDescriptors,
 				admins:               tc.admins,
+				members:              tc.members,
 				rand:                 rng,
 			}
 

--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
         "alter_function.go",
         "alter_index.go",
         "alter_index_visible.go",
+        "alter_job_owner.go",
         "alter_primary_key.go",
         "alter_role.go",
         "alter_schema.go",

--- a/pkg/sql/alter_job_owner.go
+++ b/pkg/sql/alter_job_owner.go
@@ -1,0 +1,166 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package sql
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
+	"github.com/cockroachdb/cockroach/pkg/jobs"
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
+	"github.com/cockroachdb/cockroach/pkg/security/username"
+	"github.com/cockroachdb/cockroach/pkg/sql/decodeusername"
+	"github.com/cockroachdb/cockroach/pkg/sql/isql"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
+)
+
+type alterJobOwnerNode struct {
+	zeroInputPlanNode
+	jobID tree.TypedExpr
+	owner username.SQLUsername
+}
+
+// alterJobOwner updates the owner of a job. It requires the user calling it be
+// the current owner, a member of the role that is the current owner, or an
+// admin and a user can only transfer ownership to themself or to a role of
+// which they are a member, unless they are an admin (ownership can never be
+// transferred to or from "node").
+func (p *planner) alterJobOwner(ctx context.Context, n *tree.AlterJobOwner) (planNode, error) {
+	owner, err := decodeusername.FromRoleSpec(
+		p.SessionData(), username.PurposeValidation, n.Owner,
+	)
+	if err != nil {
+		return nil, err
+	}
+	var dummyHelper tree.IndexedVarHelper
+	typedJobID, err := p.analyzeExpr(ctx, n.Job, dummyHelper, types.Int, true, "ALTER JOB OWNER")
+	if err != nil {
+		return nil, err
+	}
+	return &alterJobOwnerNode{
+		jobID: typedJobID,
+		owner: owner,
+	}, nil
+}
+
+func (n *alterJobOwnerNode) startExec(params runParams) error {
+	ctx := params.ctx
+	p := params.p
+	newOwner := n.owner
+
+	// The top-level owner column this updates was added in 25.1.
+	v, err := p.InternalSQLTxn().GetSystemSchemaVersion(ctx)
+	if err != nil {
+		return err
+	}
+	if !v.AtLeast(clusterversion.V25_1.Version()) {
+		return pgerror.Newf(pgcode.FeatureNotSupported, "ALTER JOB OWNER requires version %s", clusterversion.V25_1)
+	}
+
+	exprEval := p.ExprEvaluator("ALTER JOB OWNER")
+	jobIDInt, err := exprEval.Int(ctx, n.jobID)
+	if err != nil {
+		return err
+	}
+	jobID := jobspb.JobID(jobIDInt)
+
+	cur, err := params.ExecCfg().InternalDB.Executor().QueryRowEx(
+		ctx, "get-job-owner", p.txn, sessiondata.NodeUserSessionDataOverride,
+		`SELECT owner FROM system.jobs WHERE id = $1`, jobID,
+	)
+	if err != nil {
+		return err
+	}
+	if cur == nil {
+		return jobs.NewJobNotFoundError(jobID)
+	}
+
+	currentOwner := username.MakeSQLUsernameFromPreNormalizedString(string(tree.MustBeDString(cur[0])))
+
+	if err := n.checkOwnership(ctx, params.p, currentOwner, false); err != nil {
+		return err
+	}
+
+	if err := n.checkOwnership(ctx, params.p, newOwner, true); err != nil {
+		return err
+	}
+
+	if newOwner == currentOwner {
+		return nil
+	}
+
+	if _, err = params.ExecCfg().InternalDB.Executor().ExecEx(
+		ctx, "set-job-owner", p.txn, sessiondata.NodeUserSessionDataOverride,
+		`UPDATE system.jobs SET owner = $2 WHERE id = $1`, jobID, newOwner.Normalized(),
+	); err != nil {
+		return err
+	}
+
+	// Update the legacy payload's copy as well since there are still some paths
+	// which read it.
+	// TODO(dt): remove this when we drop the field from the legacy payload.
+	legacyJob, err := params.ExecCfg().JobRegistry.LoadJobWithTxn(ctx, jobID, p.InternalSQLTxn())
+	if err != nil {
+		return err
+	}
+	return legacyJob.WithTxn(p.InternalSQLTxn()).Update(ctx, func(_ isql.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater) error {
+		md.Payload.UsernameProto = newOwner.EncodeProto()
+		ju.UpdatePayload(md.Payload)
+		return nil
+	})
+}
+
+// checkOwnership checks that the current user is allowed to set the owner of a
+// job that is owned or will be owned by the passed owner. This should be called
+// twice: once for the current owner and once for the new owner, with the param
+// forNewOwner indicating which is being done to provide clearer errors.
+func (n *alterJobOwnerNode) checkOwnership(
+	ctx context.Context, p *planner, owner username.SQLUsername, forNewOwner bool,
+) error {
+	// If the user is owner, this is trivially true.
+	if owner == p.User() {
+		return nil
+	}
+
+	// Nobody is allowed to transfer jobs to "node".
+	if owner == username.NodeUserName() {
+		return pgerror.Newf(pgcode.InsufficientPrivilege, "cannot transfer ownership to or from internal node user")
+	}
+
+	// If the user is an admin, ownership is irrelevant.
+	isAdmin, err := p.UserHasAdminRole(ctx, p.User())
+	if err != nil {
+		return err
+	}
+	if isAdmin {
+		return nil
+	}
+
+	// If the user is a member of a role that is the owner, they are an owner.
+	members, err := p.MemberOfWithAdminOption(ctx, p.User())
+	if err != nil {
+		return err
+	}
+	if _, ok := members[owner]; ok {
+		return nil
+	}
+
+	if forNewOwner {
+		return pgerror.Newf(pgcode.InsufficientPrivilege, "%s cannot transfer ownership to %s", p.User(), owner)
+	}
+	// The user doesn't own the job and isn't an admin; they cannot set the owner.
+	return pgerror.Newf(pgcode.InsufficientPrivilege, "%s does not own job", p.User())
+}
+
+//func (n *alterJobOwnerNode) ReadingOwnWrites() {}
+
+func (n *alterJobOwnerNode) Next(runParams) (bool, error) { return false, nil }
+func (n *alterJobOwnerNode) Values() tree.Datums          { return tree.Datums{} }
+func (n *alterJobOwnerNode) Close(context.Context)        {}

--- a/pkg/sql/logictest/testdata/logic_test/owner
+++ b/pkg/sql/logictest/testdata/logic_test/owner
@@ -90,7 +90,7 @@ CREATE DATABASE d
 
 user testuser
 
-# The user doesn't have admin privilege or CREATE privilege on the db
+# The user does not have admin privilege or CREATE privilege on the db
 # but should be able to create a table due to being the db owner.
 
 statement ok
@@ -142,7 +142,7 @@ REVOKE GRANT OPTION FOR ALL PRIVILEGES ON DATABASE d FROM testuser2
 user testuser2
 
 # testuser2 has ALL privileges, no grant options, and is not a member of a role,
-# so it can't GRANT.
+# so it cannot GRANT.
 statement error user testuser2 missing WITH GRANT OPTION privilege on ALL
 GRANT ALL ON DATABASE d TO new_role WITH GRANT OPTION
 
@@ -255,3 +255,121 @@ user testuser
 
 statement error pq: role testuser cannot be dropped because some objects depend on it\nowner of database d\nowner of schema d.public\nowner of schema d.s\nowner of table d.public.t\nowner of table d.s.t\nowner of table test.public.t\nowner of type d.public._typ\nowner of type d.public.typ
 DROP ROLE testuser
+
+user root
+
+skipif config local-mixed-24.3
+let $testuser_job_id
+SELECT id FROM system.jobs WHERE owner = 'testuser' LIMIT 1
+
+skipif config local-mixed-24.3
+let $testuser2_job_id
+SELECT id FROM system.jobs WHERE owner = 'testuser2' LIMIT 1
+
+skipif config local-mixed-24.3
+let $node_job_id
+SELECT id FROM system.jobs WHERE owner = 'node' LIMIT 1
+
+skipif config local-mixed-24.3
+# Verify a simple transfer by an admin from testuser to testuser2 and back.
+statement ok
+ALTER JOB $testuser_job_id OWNER TO testuser2
+
+skipif config local-mixed-24.3
+query T
+SELECT owner FROM system.jobs WHERE id = $testuser_job_id
+----
+testuser2
+
+skipif config local-mixed-24.3
+statement ok
+ALTER JOB $testuser_job_id OWNER TO testuser
+
+skipif config local-mixed-24.3
+query T
+SELECT owner FROM system.jobs WHERE id = $testuser_job_id
+----
+testuser
+
+# Verify that ownership cannot transfer to or from 'node'.
+
+skipif config local-mixed-24.3
+statement error cannot transfer ownership
+ALTER JOB $node_job_id OWNER TO testuser
+
+skipif config local-mixed-24.3
+statement error cannot transfer ownership
+ALTER JOB $testuser_job_id OWNER TO node
+
+# Verify testuser2 can transfer ownership via role testuser to role testrole.
+user testuser2
+
+statement ok
+CREATE ROLE testrole
+
+statement ok
+CREATE ROLE otherrole
+
+statement ok
+CREATE USER testuser3
+
+statement ok
+GRANT testrole TO testuser3
+
+skipif config local-mixed-24.3
+statement ok
+ALTER JOB $testuser_job_id OWNER TO testrole
+
+skipif config local-mixed-24.3
+query T
+SELECT owner FROM system.jobs WHERE id = $testuser_job_id
+----
+testrole
+
+skipif config local-mixed-24.3
+# Verify testuser2 can transfer ownership to themselves and back to testuser.
+statement ok
+ALTER JOB $testuser_job_id OWNER TO testuser2
+
+skipif config local-mixed-24.3
+query T
+SELECT owner FROM system.jobs WHERE id = $testuser_job_id
+----
+testuser2
+
+skipif config local-mixed-24.3
+statement ok
+ALTER JOB $testuser_job_id OWNER TO testuser
+
+skipif config local-mixed-24.3
+query T
+SELECT owner FROM system.jobs WHERE id = $testuser_job_id
+----
+testuser
+
+user testuser3
+
+skipif config local-mixed-24.3
+# Verify testuser3 cannot transfer since they do not own it, including via role.
+statement error testuser3 does not own job
+ALTER JOB $testuser_job_id OWNER TO testuser3
+
+# Now move ownership to testrole so testuser3 can transfer it.
+user testuser2
+
+skipif config local-mixed-24.3
+statement ok
+ALTER JOB $testuser_job_id OWNER TO testrole
+
+user testuser3
+
+skipif config local-mixed-24.3
+statement ok
+ALTER JOB $testuser_job_id OWNER TO testuser3
+
+skipif config local-mixed-24.3
+# Verify testuser3, who is not an admin, cannot transfer to otherrole which they
+# are not a member of.
+statement error testuser3 cannot transfer ownership to otherrole
+ALTER JOB $testuser_job_id OWNER TO otherrole
+

--- a/pkg/sql/logictest/testdata/logic_test/reassign_owned_by
+++ b/pkg/sql/logictest/testdata/logic_test/reassign_owned_by
@@ -45,7 +45,7 @@ GRANT CREATE ON DATABASE test TO new_role
 
 user testuser
 
-# Ensure the current user is a member of the role we're setting to.
+# Ensure the current user is a member of the role we are setting to.
 statement error pq: permission denied to reassign objects\nHINT: user must be a member of the new role
 REASSIGN OWNED BY old_role TO new_role
 

--- a/pkg/sql/opaque.go
+++ b/pkg/sql/opaque.go
@@ -114,6 +114,8 @@ func planOpaque(ctx context.Context, p *planner, stmt tree.Statement) (planNode,
 		return p.AlterIndex(ctx, n)
 	case *tree.AlterIndexVisible:
 		return p.AlterIndexVisible(ctx, n)
+	case *tree.AlterJobOwner:
+		return p.alterJobOwner(ctx, n)
 	case *tree.AlterPolicy:
 		return p.AlterPolicy(ctx, n)
 	case *tree.AlterSchema:
@@ -338,6 +340,7 @@ func init() {
 		&tree.AlterFunctionDepExtension{},
 		&tree.AlterIndex{},
 		&tree.AlterIndexVisible{},
+		&tree.AlterJobOwner{},
 		&tree.AlterPolicy{},
 		&tree.AlterSchema{},
 		&tree.AlterTable{},

--- a/pkg/sql/parser/help_test.go
+++ b/pkg/sql/parser/help_test.go
@@ -38,6 +38,10 @@ func TestContextualHelp(t *testing.T) {
 
 		{`ALTER BACKUP foo ADD NEW_KMS=bar WITH OLD_KMS=foobar ??`, `ALTER BACKUP`},
 
+		{`ALTER JOB ??`, `ALTER JOB`},
+		{`ALTER JOB 123 OWNER ??`, `ALTER JOB`},
+		{`ALTER JOB 123 OWNER TO ??`, `ALTER JOB`},
+
 		{`ALTER TABLE IF ??`, `ALTER TABLE`},
 		{`ALTER TABLE blah ??`, `ALTER TABLE`},
 		{`ALTER TABLE blah ADD ??`, `ALTER TABLE`},

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -1306,7 +1306,7 @@ func (u *sqlSymUnion) indexType() tree.IndexType {
 %type <tree.Statement> grant_stmt
 %type <tree.Statement> insert_stmt
 %type <tree.Statement> import_stmt
-%type <tree.Statement> pause_stmt pause_jobs_stmt pause_schedules_stmt pause_all_jobs_stmt
+%type <tree.Statement> pause_stmt pause_jobs_stmt pause_schedules_stmt pause_all_jobs_stmt alter_job_stmt
 %type <*tree.Select>   for_schedules_clause
 %type <tree.Statement> reassign_owned_by_stmt
 %type <tree.Statement> drop_owned_by_stmt
@@ -1932,6 +1932,7 @@ alter_ddl_stmt:
 | alter_proc_stmt               // EXTEND WITH HELP: ALTER PROCEDURE
 | alter_backup_schedule  // EXTEND WITH HELP: ALTER BACKUP SCHEDULE
 | alter_policy_stmt             // EXTEND WITH HELP: ALTER POLICY
+| alter_job_stmt                // EXTEND WITH HELP: ALTER JOB
 
 // %Help: ALTER TABLE - change the definition of a table
 // %Category: DDL
@@ -6707,6 +6708,22 @@ explain_option_list:
   {
     $$.val = append($1.strs(), $3)
   }
+
+// %Help: ALTER JOB - alter an existing job
+// %Category: Misc
+// %Text:
+// ALTER JOB <jobid> <cmd>
+// %SeeAlso: SHOW JOBS, CANCEL JOBS, RESUME JOBS
+alter_job_stmt:
+  ALTER JOB a_expr OWNER TO role_spec
+  {
+    $$.val = &tree.AlterJobOwner{
+      Job: $3.expr(),
+      Owner: $6.roleSpec(),
+    }
+  }
+| ALTER JOB error // SHOW HELP: ALTER JOB
+
 
 // %Help: ALTER CHANGEFEED - alter an existing changefeed
 // %Category: CCL

--- a/pkg/sql/parser/testdata/reassign
+++ b/pkg/sql/parser/testdata/reassign
@@ -1,4 +1,3 @@
-
 parse
 REASSIGN OWNED BY foo TO bar
 ----
@@ -54,3 +53,19 @@ DROP OWNED BY foo RESTRICT
 DROP OWNED BY foo RESTRICT -- fully parenthesized
 DROP OWNED BY foo RESTRICT -- literals removed
 DROP OWNED BY _ RESTRICT -- identifiers removed
+
+parse
+ALTER JOB 123 OWNER TO foo
+----
+ALTER JOB 123 OWNER TO foo
+ALTER JOB (123) OWNER TO foo -- fully parenthesized
+ALTER JOB _ OWNER TO foo -- literals removed
+ALTER JOB 123 OWNER TO _ -- identifiers removed
+
+parse
+ALTER JOB $1 OWNER TO foo
+----
+ALTER JOB $1 OWNER TO foo
+ALTER JOB ($1) OWNER TO foo -- fully parenthesized
+ALTER JOB $1 OWNER TO foo -- literals removed
+ALTER JOB $1 OWNER TO _ -- identifiers removed

--- a/pkg/sql/sem/tree/run_control.go
+++ b/pkg/sql/sem/tree/run_control.go
@@ -40,6 +40,20 @@ func (n *ControlJobs) Format(ctx *FmtCtx) {
 	}
 }
 
+// AlterJobOwner represents an ALTER JOB OWNER TO statement.
+type AlterJobOwner struct {
+	Job   Expr
+	Owner RoleSpec
+}
+
+// Format implements the NodeFormatter interface.
+func (n *AlterJobOwner) Format(ctx *FmtCtx) {
+	ctx.WriteString("ALTER JOB ")
+	ctx.FormatNode(n.Job)
+	ctx.WriteString(" OWNER TO ")
+	ctx.FormatNode(&n.Owner)
+}
+
 // CancelQueries represents a CANCEL QUERIES statement.
 type CancelQueries struct {
 	Queries  *Select

--- a/pkg/sql/sem/tree/stmt.go
+++ b/pkg/sql/sem/tree/stmt.go
@@ -705,6 +705,15 @@ func (n *ControlJobs) StatementTag() string {
 }
 
 // StatementReturnType implements the Statement interface.
+func (*AlterJobOwner) StatementReturnType() StatementReturnType { return DDL }
+
+// StatementType implements the Statement interface.
+func (*AlterJobOwner) StatementType() StatementType { return TypeDDL }
+
+// StatementTag returns a short string identifying the type of statement.
+func (*AlterJobOwner) StatementTag() string { return "ALTER JOB OWNER" }
+
+// StatementReturnType implements the Statement interface.
 func (*ControlSchedules) StatementReturnType() StatementReturnType { return RowsAffected }
 
 // StatementType implements the Statement interface.
@@ -2415,6 +2424,7 @@ func (n *AlterBackupSchedule) String() string                 { return AsString(
 func (n *AlterBackupScheduleCmds) String() string             { return AsString(n) }
 func (n *AlterIndex) String() string                          { return AsString(n) }
 func (n *AlterIndexVisible) String() string                   { return AsString(n) }
+func (n *AlterJobOwner) String() string                       { return AsString(n) }
 func (n *AlterDatabaseOwner) String() string                  { return AsString(n) }
 func (n *AlterDatabaseAddRegion) String() string              { return AsString(n) }
 func (n *AlterDatabaseDropRegion) String() string             { return AsString(n) }

--- a/pkg/sql/walk.go
+++ b/pkg/sql/walk.go
@@ -351,6 +351,7 @@ var planNodeNames = map[reflect.Type]string{
 	reflect.TypeOf(&alterFunctionDepExtensionNode{}):           "alter function depends on extension",
 	reflect.TypeOf(&alterIndexNode{}):                          "alter index",
 	reflect.TypeOf(&alterIndexVisibleNode{}):                   "alter index visibility",
+	reflect.TypeOf(&alterJobOwnerNode{}):                       "alter job owner",
 	reflect.TypeOf(&alterSequenceNode{}):                       "alter sequence",
 	reflect.TypeOf(&alterSchemaNode{}):                         "alter schema",
 	reflect.TypeOf(&alterTableNode{}):                          "alter table",


### PR DESCRIPTION
Jobs have the notion of an owner like other objects in the system, but previously did not have a mechanism for altering this owner to transfer ownership, particularly to or from a role. This adds ALTER JOB x OWNER TO y, mirroring the similar syntax for adjusting the owner of tables, views and other objects in the system.

Release note (sql change): ALTER JOB ... OWNER TO can now be used to transfer ownership of a job between users/roles.
Epic: none.