### PR TITLE
server/admin: add job messages to job detail resp

### DIFF
--- a/docs/generated/http/full.md
+++ b/docs/generated/http/full.md
@@ -6645,6 +6645,7 @@ JobResponse contains the job record for a job.
 | num_runs | [int64](#cockroach.server.serverpb.JobsResponse-int64) |  |  | [reserved](#support-status) |
 | execution_failures | [JobResponse.ExecutionFailure](#cockroach.server.serverpb.JobsResponse-cockroach.server.serverpb.JobResponse.ExecutionFailure) | repeated | ExecutionFailures is a log of execution failures of the job. It is not guaranteed to contain all execution failures and some execution failures may not contain an error or end. | [reserved](#support-status) |
 | coordinator_id | [int64](#cockroach.server.serverpb.JobsResponse-int64) |  | coordinator_id identifies the node coordinating the job. This value will only be present for jobs that are currently running or recently ran. | [reserved](#support-status) |
+| messages | [JobMessage](#cockroach.server.serverpb.JobsResponse-cockroach.server.serverpb.JobMessage) | repeated |  | [reserved](#support-status) |
 
 
 
@@ -6662,6 +6663,21 @@ attempt starting at start and ending at end.
 | start | [google.protobuf.Timestamp](#cockroach.server.serverpb.JobsResponse-google.protobuf.Timestamp) |  | Start is the time at which the execution started. | [reserved](#support-status) |
 | end | [google.protobuf.Timestamp](#cockroach.server.serverpb.JobsResponse-google.protobuf.Timestamp) |  | End is the time at which the error occurred. | [reserved](#support-status) |
 | error | [string](#cockroach.server.serverpb.JobsResponse-string) |  | Error is the error which occurred. | [reserved](#support-status) |
+
+
+
+
+
+<a name="cockroach.server.serverpb.JobsResponse-cockroach.server.serverpb.JobMessage"></a>
+#### JobMessage
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| kind | [string](#cockroach.server.serverpb.JobsResponse-string) |  |  | [reserved](#support-status) |
+| timestamp | [google.protobuf.Timestamp](#cockroach.server.serverpb.JobsResponse-google.protobuf.Timestamp) |  |  | [reserved](#support-status) |
+| message | [string](#cockroach.server.serverpb.JobsResponse-string) |  |  | [reserved](#support-status) |
 
 
 
@@ -6725,6 +6741,7 @@ JobResponse contains the job record for a job.
 | num_runs | [int64](#cockroach.server.serverpb.JobResponse-int64) |  |  | [reserved](#support-status) |
 | execution_failures | [JobResponse.ExecutionFailure](#cockroach.server.serverpb.JobResponse-cockroach.server.serverpb.JobResponse.ExecutionFailure) | repeated | ExecutionFailures is a log of execution failures of the job. It is not guaranteed to contain all execution failures and some execution failures may not contain an error or end. | [reserved](#support-status) |
 | coordinator_id | [int64](#cockroach.server.serverpb.JobResponse-int64) |  | coordinator_id identifies the node coordinating the job. This value will only be present for jobs that are currently running or recently ran. | [reserved](#support-status) |
+| messages | [JobMessage](#cockroach.server.serverpb.JobResponse-cockroach.server.serverpb.JobMessage) | repeated |  | [reserved](#support-status) |
 
 
 
@@ -6743,6 +6760,21 @@ attempt starting at start and ending at end.
 | start | [google.protobuf.Timestamp](#cockroach.server.serverpb.JobResponse-google.protobuf.Timestamp) |  | Start is the time at which the execution started. | [reserved](#support-status) |
 | end | [google.protobuf.Timestamp](#cockroach.server.serverpb.JobResponse-google.protobuf.Timestamp) |  | End is the time at which the error occurred. | [reserved](#support-status) |
 | error | [string](#cockroach.server.serverpb.JobResponse-string) |  | Error is the error which occurred. | [reserved](#support-status) |
+
+
+
+
+
+<a name="cockroach.server.serverpb.JobResponse-cockroach.server.serverpb.JobMessage"></a>
+#### JobMessage
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| kind | [string](#cockroach.server.serverpb.JobResponse-string) |  |  | [reserved](#support-status) |
+| timestamp | [google.protobuf.Timestamp](#cockroach.server.serverpb.JobResponse-google.protobuf.Timestamp) |  |  | [reserved](#support-status) |
+| message | [string](#cockroach.server.serverpb.JobResponse-string) |  |  | [reserved](#support-status) |
 
 
 

--- a/pkg/ccl/serverccl/admin_test.go
+++ b/pkg/ccl/serverccl/admin_test.go
@@ -151,6 +151,9 @@ func TestAdminAPIJobs(t *testing.T) {
 	err = getAdminJSONProto(s, path, &jobRes)
 	require.NoError(t, err)
 
+	// Messages are not equal, since they only appear in the single job response,
+	// so the deep-equal check would fail; copy it so the overall check passes.
+	jobRes.Messages = backups[0].Messages
 	require.Equal(t, backups[0], jobRes)
 }
 

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -20,6 +20,7 @@ import (
 
 	apd "github.com/cockroachdb/apd/v3"
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/config/zonepb"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
@@ -2473,7 +2474,49 @@ func jobHelper(
 		return nil, err
 	}
 
+	// On 25.1+, add any recorded job messages to the response as well.
+	if sqlServer.cfg.Settings.Version.IsActive(ctx, clusterversion.V25_1) {
+		job.Messages = fetchJobMessages(ctx, job.ID, userName, sqlServer)
+	}
 	return &job, nil
+}
+
+func fetchJobMessages(
+	ctx context.Context, jobID int64, user username.SQLUsername, sqlServer *SQLServer,
+) (messages []serverpb.JobMessage) {
+	const msgQuery = `SELECT kind, written, message FROM system.job_message WHERE job_id = $1 ORDER BY written DESC`
+	it, err := sqlServer.internalExecutor.QueryIteratorEx(ctx, "admin-job-messages", nil,
+		sessiondata.InternalExecutorOverride{User: user},
+		msgQuery,
+		jobID,
+	)
+
+	if err != nil {
+		return []serverpb.JobMessage{{Kind: "error", Timestamp: timeutil.Now(), Message: err.Error()}}
+	}
+
+	defer func() {
+		if err := it.Close(); err != nil {
+			messages = []serverpb.JobMessage{{Kind: "error", Timestamp: timeutil.Now(), Message: err.Error()}}
+		}
+	}()
+
+	for {
+		ok, err := it.Next(ctx)
+		if err != nil {
+			return []serverpb.JobMessage{{Kind: "error", Timestamp: timeutil.Now(), Message: err.Error()}}
+		}
+		if !ok {
+			break
+		}
+		row := it.Cur()
+		messages = append(messages, serverpb.JobMessage{
+			Kind:      string(tree.MustBeDStringOrDNull(row[0])),
+			Timestamp: tree.MustBeDTimestampTZ(row[1]).Time,
+			Message:   string(tree.MustBeDStringOrDNull(row[2])),
+		})
+	}
+	return messages
 }
 
 func (s *adminServer) Locations(

--- a/pkg/server/serverpb/admin.proto
+++ b/pkg/server/serverpb/admin.proto
@@ -687,6 +687,12 @@ message JobRequest {
   int64 job_id = 1;
 }
 
+message JobMessage {
+  string kind = 1;
+  google.protobuf.Timestamp timestamp = 2 [(gogoproto.nullable)=false, (gogoproto.stdtime) = true];
+  string message = 3;
+}
+
 // JobResponse contains the job record for a job.
 message JobResponse {
   int64 id = 1 [(gogoproto.customname) = "ID"];
@@ -737,6 +743,8 @@ message JobResponse {
   // coordinator_id identifies the node coordinating the job. This value will
   // only be present for jobs that are currently running or recently ran.
   int64 coordinator_id = 21 [(gogoproto.customname) = "CoordinatorID"];
+
+  repeated JobMessage messages = 22 [(gogoproto.nullable)=false];
 }
 
 // LocationsRequest requests system locality location information.


### PR DESCRIPTION
This should allow showing them on the job detail page.

Release note: none.
Epic: none.