### PR TITLE
drtprod: use roachprod Initialize instead of shell

### DIFF
--- a/pkg/cmd/drtprod/cli/BUILD.bazel
+++ b/pkg/cmd/drtprod/cli/BUILD.bazel
@@ -10,7 +10,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/cmd/drtprod/cli/commands",
-        "//pkg/cmd/drtprod/helpers",
+        "//pkg/cmd/roachprod/cli",
         "//pkg/roachprod",
         "@com_github_spf13_cobra//:cobra",
     ],

--- a/pkg/cmd/drtprod/cli/commands/yamlprocessor.go
+++ b/pkg/cmd/drtprod/cli/commands/yamlprocessor.go
@@ -340,7 +340,7 @@ func generateStepCmd(clusterName string, s step) (*command, error) {
 func generateCmdFromCommand(s step, _ string) (*command, error) {
 	// Prepend the cluster name to the command arguments
 	s.Args = append([]string{s.Command}, s.Args...)
-	return getCommand(s, "roachprod")
+	return getCommand(s, "drtprod")
 }
 
 // generateCmdFromScript creates a command from a step that uses a script.

--- a/pkg/cmd/drtprod/cli/commands/yamlprocessor_test.go
+++ b/pkg/cmd/drtprod/cli/commands/yamlprocessor_test.go
@@ -55,21 +55,21 @@ environment:
 		require.Equal(t, 8, len(name1Commands))
 		require.Equal(t, 1, len(name2Commands))
 		// the flags are maintained as map and can be in any sequence
-		require.True(t, strings.HasPrefix(name1Commands[0], "roachprod dummy1 name_value1 arg11"))
+		require.True(t, strings.HasPrefix(name1Commands[0], "drtprod dummy1 name_value1 arg11"))
 		require.True(t, strings.Contains(name1Commands[0], "--clouds=gce"))
 		require.True(t, strings.Contains(name1Commands[0], "--nodes=1"))
 		require.Equal(t, []string{
-			"dummy_script1", "dummy_script2 arg11", "roachprod dummy2", "script33",
+			"dummy_script1", "dummy_script2 arg11", "drtprod dummy2", "script33",
 		}, name1Commands[1:5])
 		// rollback
-		require.True(t, strings.HasPrefix(name1Commands[5], "roachprod rb_dummy2 arg1 arg2"))
+		require.True(t, strings.HasPrefix(name1Commands[5], "drtprod rb_dummy2 arg1 arg2"))
 		require.True(t, strings.Contains(name1Commands[5], "--flag1=value1"))
 		require.True(t, strings.Contains(name1Commands[5], "--flag2=value2"))
 		require.True(t, strings.HasPrefix(name1Commands[6], "dummy_script22"))
 		require.True(t, strings.Contains(name1Commands[6], "--f1=\\\"v1 v2\\\""))
-		require.Equal(t, "roachprod rb_dummy1", name1Commands[7])
+		require.Equal(t, "drtprod rb_dummy1", name1Commands[7])
 		require.Equal(t, []string{
-			"roachprod dummy2 name_value2 arg12",
+			"drtprod dummy2 name_value2 arg12",
 		}, name2Commands)
 	})
 	t.Run("expect no failure", func(t *testing.T) {
@@ -104,14 +104,14 @@ environment:
 		require.Equal(t, 1, len(depN1N2Commands))
 		require.Equal(t, 1, len(depNotPresentCommands))
 		// the flags are maintained as map and can be in any sequence
-		require.True(t, strings.HasPrefix(name1Commands[0], "roachprod dummy1 name_value1 arg11"))
+		require.True(t, strings.HasPrefix(name1Commands[0], "drtprod dummy1 name_value1 arg11"))
 		require.True(t, strings.Contains(name1Commands[0], "--clouds=gce"))
 		require.True(t, strings.Contains(name1Commands[0], "--nodes=1"))
 		require.Equal(t, []string{
-			"dummy_script1", "dummy_script2 arg11", "roachprod dummy2", "script33", "last_script",
+			"dummy_script1", "dummy_script2 arg11", "drtprod dummy2", "script33", "last_script",
 		}, name1Commands[1:])
 		require.Equal(t, []string{
-			"roachprod dummy2 name_value2 arg12",
+			"drtprod dummy2 name_value2 arg12",
 		}, name2Commands)
 	})
 }

--- a/pkg/cmd/drtprod/cli/handlers.go
+++ b/pkg/cmd/drtprod/cli/handlers.go
@@ -8,10 +8,9 @@ package cli
 import (
 	"context"
 	"os"
-	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/drtprod/cli/commands"
-	"github.com/cockroachdb/cockroach/pkg/cmd/drtprod/helpers"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachprod/cli"
 	"github.com/cockroachdb/cockroach/pkg/roachprod"
 	"github.com/spf13/cobra"
 )
@@ -32,18 +31,7 @@ func Initialize(ctx context.Context) {
 	// Create the root command and add subcommands.
 	rootCommand := commands.GetRootCommand(ctx)
 	rootCommand.AddCommand(register(ctx)...)
-
-	// Check if the command is found in drtprod; if not, redirect to roachprod.
-	_, _, err := rootCommand.Find(os.Args[1:])
-	if err != nil {
-		if strings.Contains(err.Error(), "unknown command") {
-			// Command not found, execute it in roachprod instead.
-			_ = helpers.ExecuteCmdInteractive(ctx, "roachprod", os.Args[1:]...)
-			return
-		}
-		// If another error occurs, exit with a failure status.
-		os.Exit(1)
-	}
+	cli.Initialize(rootCommand)
 
 	// Execute the root command, exit if an error occurs.
 	if err := rootCommand.Execute(); err != nil {

--- a/pkg/cmd/drtprod/helpers/utils.go
+++ b/pkg/cmd/drtprod/helpers/utils.go
@@ -79,15 +79,3 @@ func ExecuteCmdWithPrefix(ctx context.Context, logPrefix string, cmd string, arg
 	// Wait for the command to complete and return any errors encountered.
 	return c.Run()
 }
-
-// ExecuteCmdInteractive runs a shell command with the given arguments and creates an interactive shell.
-func ExecuteCmdInteractive(ctx context.Context, cmd string, args ...string) error {
-	// Create a command with the given context and arguments.
-	c := exec.CommandContext(ctx, cmd, args...)
-
-	// redirect stdin, stdout and stderr
-	c.Stdin, c.Stdout, c.Stderr = os.Stdin, os.Stdout, os.Stderr
-
-	// Run the command execution
-	return c.Run()
-}

--- a/pkg/cmd/drtprod/scripts/create_run_operation.sh
+++ b/pkg/cmd/drtprod/scripts/create_run_operation.sh
@@ -35,10 +35,10 @@ fi
 drtprod ssh ${WORKLOAD_CLUSTER} -- "ROACHPROD_GCE_DEFAULT_PROJECT=${ROACHPROD_GCE_DEFAULT_PROJECT} ./roachprod sync"
 
 # the ssh keys of all workload nodes should be setup on the crdb nodes for the operations
-roachprod ssh ${CLUSTER} -- "echo \"$(roachprod run ${WORKLOAD_CLUSTER} -- cat ./.ssh/id_rsa.pub|grep ssh-rsa)\" >> ./.ssh/authorized_keys"
+drtprod ssh ${CLUSTER} -- "echo \"$(drtprod run ${WORKLOAD_CLUSTER} -- cat ./.ssh/id_rsa.pub|grep ssh-rsa)\" >> ./.ssh/authorized_keys"
 
-absolute_path=$(roachprod run "${WORKLOAD_CLUSTER}":1 -- "realpath ./roachtest-operations")
-pwd=$(roachprod run "${WORKLOAD_CLUSTER}":1 -- "dirname ${absolute_path}")
+absolute_path=$(drtprod run "${WORKLOAD_CLUSTER}":1 -- "realpath ./roachtest-operations")
+pwd=$(drtprod run "${WORKLOAD_CLUSTER}":1 -- "dirname ${absolute_path}")
 # Loop over all the passed arguments
 for entry in "$@"; do
   # Split the entry into identifier, cron_config, and operation_regex using IFS and comma
@@ -51,7 +51,7 @@ for entry in "$@"; do
   fi
   filename=run_ops_${identifier}.sh
   # Create a file with the name "run_ops_<identifier>.sh" and add the entry of roachtest run-operation
-  roachprod ssh "${WORKLOAD_CLUSTER}":1 -- "tee ${pwd}/${filename} > /dev/null << EOF
+  drtprod ssh "${WORKLOAD_CLUSTER}":1 -- "tee ${pwd}/${filename} > /dev/null << EOF
 #!/bin/bash
 
 export ROACHPROD_GCE_DEFAULT_PROJECT=${ROACHPROD_GCE_DEFAULT_PROJECT}
@@ -60,12 +60,12 @@ ${pwd}/roachtest-operations run-operation ${CLUSTER} \"${operation_regex}\" --da
 --datadog-tags env:development,cluster:${WORKLOAD_CLUSTER},team:drt,service:drt-cockroachdb \
 --datadog-app-key 1 --certs-dir ./certs  | tee -a roachtest_ops_${identifier}.log
 EOF"
-  roachprod ssh "${WORKLOAD_CLUSTER}":1 -- chmod +x "${pwd}"/"${filename}"
+  drtprod ssh "${WORKLOAD_CLUSTER}":1 -- chmod +x "${pwd}"/"${filename}"
   if [ "$cron_config" ]; then
-    roachprod run "${WORKLOAD_CLUSTER}":1 -- "(crontab -l; echo \"${cron_config} /usr/bin/flock -n /tmp/lock_${identifier} ${pwd}/${filename}\") | crontab -"
+    drtprod run "${WORKLOAD_CLUSTER}":1 -- "(crontab -l; echo \"${cron_config} /usr/bin/flock -n /tmp/lock_${identifier} ${pwd}/${filename}\") | crontab -"
   fi
 done
 
 # unmask and start cron
-roachprod ssh "${WORKLOAD_CLUSTER}":1 -- sudo systemctl unmask cron
-roachprod ssh "${WORKLOAD_CLUSTER}":1 -- sudo systemctl start cron
+drtprod ssh "${WORKLOAD_CLUSTER}":1 -- sudo systemctl unmask cron
+drtprod ssh "${WORKLOAD_CLUSTER}":1 -- sudo systemctl start cron

--- a/pkg/cmd/drtprod/scripts/generate_kv_run.sh
+++ b/pkg/cmd/drtprod/scripts/generate_kv_run.sh
@@ -29,7 +29,7 @@ if [ -z "${WORKLOAD_NODES}" ]; then
   exit 1
 fi
 
-PGURLS=$(roachprod pgurl $CLUSTER --external | sed s/\'//g)
+PGURLS=$(drtprod pgurl $CLUSTER --external | sed s/\'//g)
 
 # Loop through each node
 for NODE in $(seq 1 $WORKLOAD_NODES)
@@ -74,9 +74,9 @@ done
 EOF
 
   # Upload the script to the workload cluster
-  roachprod put $WORKLOAD_CLUSTER:$NODE /tmp/kv_run.sh
-  roachprod ssh $WORKLOAD_CLUSTER:$NODE -- "chmod +x kv_run.sh"
+  drtprod put $WORKLOAD_CLUSTER:$NODE /tmp/kv_run.sh
+  drtprod ssh $WORKLOAD_CLUSTER:$NODE -- "chmod +x kv_run.sh"
   if [ "$execute_script" = "true" ]; then
-    roachprod run "${WORKLOAD_CLUSTER}":1 -- "sudo systemd-run --unit kv_run --same-dir --uid \$(id -u) --gid \$(id -g) bash ${pwd}/kv_run.sh"
+    drtprod run "${WORKLOAD_CLUSTER}":1 -- "sudo systemd-run --unit kv_run --same-dir --uid \$(id -u) --gid \$(id -g) bash ${pwd}/kv_run.sh"
   fi
 done

--- a/pkg/cmd/drtprod/scripts/generate_tpcc_drop.sh
+++ b/pkg/cmd/drtprod/scripts/generate_tpcc_drop.sh
@@ -29,8 +29,8 @@ if [ -z "${WORKLOAD_NODES}" ]; then
   exit 1
 fi
 
-PG_URL_N1=$(roachprod pgurl $CLUSTER:1  --external | sed s/\'//g)
-PGURLS=$(roachprod pgurl $CLUSTER --external  | sed s/\'//g)
+PG_URL_N1=$(drtprod pgurl $CLUSTER:1  --external | sed s/\'//g)
+PGURLS=$(drtprod pgurl $CLUSTER --external  | sed s/\'//g)
 
 # Loop through each node
 for NODE in $(seq 1 $WORKLOAD_NODES)
@@ -90,9 +90,9 @@ done
 EOF
 
   # Upload the script to the workload cluster
-  roachprod put $WORKLOAD_CLUSTER:$NODE /tmp/tpcc_drop.sh
-  roachprod ssh $WORKLOAD_CLUSTER:$NODE -- "chmod +x tpcc_drop.sh"
+  drtprod put $WORKLOAD_CLUSTER:$NODE /tmp/tpcc_drop.sh
+  drtprod ssh $WORKLOAD_CLUSTER:$NODE -- "chmod +x tpcc_drop.sh"
   if [ "$execute_script" = "true" ]; then
-    roachprod run "${WORKLOAD_CLUSTER}":1 -- "sudo systemd-run --unit tpcc_drop --same-dir --uid \$(id -u) --gid \$(id -g) bash ${pwd}/tpcc_drop.sh"
+    drtprod run "${WORKLOAD_CLUSTER}":1 -- "sudo systemd-run --unit tpcc_drop --same-dir --uid \$(id -u) --gid \$(id -g) bash ${pwd}/tpcc_drop.sh"
   fi
 done

--- a/pkg/cmd/drtprod/scripts/generate_tpcc_run.sh
+++ b/pkg/cmd/drtprod/scripts/generate_tpcc_run.sh
@@ -44,8 +44,8 @@ if [ -z "${CLUSTER_NODES}" ]; then
   exit 1
 fi
 
-absolute_path=$(roachprod run "${WORKLOAD_CLUSTER}":1 -- "realpath ./cockroach")
-pwd=$(roachprod run "${WORKLOAD_CLUSTER}":1 -- "dirname ${absolute_path}")
+absolute_path=$(drtprod run "${WORKLOAD_CLUSTER}":1 -- "realpath ./cockroach")
+pwd=$(drtprod run "${WORKLOAD_CLUSTER}":1 -- "dirname ${absolute_path}")
 
 # Calculate the number of PGURLS each workload node should get
 PGURL_PER_NODE=$((CLUSTER_NODES / WORKLOAD_NODES))
@@ -82,11 +82,11 @@ done
 EOF
 
 #   Upload the script to the workload cluster
-  roachprod put $WORKLOAD_CLUSTER:$((NODE + 1)) /tmp/tpcc_run_${suffix}.sh
-  roachprod ssh $WORKLOAD_CLUSTER:$((NODE + 1)) -- "chmod +x tpcc_run_${suffix}.sh"
+  drtprod put $WORKLOAD_CLUSTER:$((NODE + 1)) /tmp/tpcc_run_${suffix}.sh
+  drtprod ssh $WORKLOAD_CLUSTER:$((NODE + 1)) -- "chmod +x tpcc_run_${suffix}.sh"
   if [ "$execute_script" = "true" ]; then
-      roachprod run "${WORKLOAD_CLUSTER}":$((NODE + 1)) -- "sudo systemd-run --unit tpcc_run_${suffix} --same-dir --uid \$(id -u) --gid \$(id -g) bash ${pwd}/tpcc_run_${suffix}.sh"
+      drtprod run "${WORKLOAD_CLUSTER}":$((NODE + 1)) -- "sudo systemd-run --unit tpcc_run_${suffix} --same-dir --uid \$(id -u) --gid \$(id -g) bash ${pwd}/tpcc_run_${suffix}.sh"
   else
-    echo "Run --> roachprod run "${WORKLOAD_CLUSTER}":$((NODE + 1)) -- \"sudo systemd-run --unit tpcc_run_${suffix} --same-dir --uid \\\$(id -u) --gid \\\$(id -g) bash ${pwd}/tpcc_run_${suffix}.sh\""
+    echo "Run --> drtprod run "${WORKLOAD_CLUSTER}":$((NODE + 1)) -- \"sudo systemd-run --unit tpcc_run_${suffix} --same-dir --uid \\\$(id -u) --gid \\\$(id -g) bash ${pwd}/tpcc_run_${suffix}.sh\""
     fi
 done

--- a/pkg/cmd/drtprod/scripts/generate_tpch_run.sh
+++ b/pkg/cmd/drtprod/scripts/generate_tpch_run.sh
@@ -25,13 +25,13 @@ if [ -z "${WORKLOAD_CLUSTER}" ]; then
   exit 1
 fi
 
-absolute_path=$(roachprod run "${WORKLOAD_CLUSTER}":1 -- "realpath ./cockroach")
-pwd=$(roachprod run "${WORKLOAD_CLUSTER}":1 -- "dirname ${absolute_path}")
-PGURLS=$(roachprod pgurl "${CLUSTER}":1)
+absolute_path=$(drtprod run "${WORKLOAD_CLUSTER}":1 -- "realpath ./cockroach")
+pwd=$(drtprod run "${WORKLOAD_CLUSTER}":1 -- "dirname ${absolute_path}")
+PGURLS=$(drtprod pgurl "${CLUSTER}":1)
 
-roachprod ssh "${WORKLOAD_CLUSTER}":1 -- "tee tpch_run_${suffix}.sh > /dev/null << 'EOF'
+drtprod ssh "${WORKLOAD_CLUSTER}":1 -- "tee tpch_run_${suffix}.sh > /dev/null << 'EOF'
 #!/bin/bash
 
 ${pwd}/cockroach workload run tpch $@ --verbose --prometheus-port 2113 $PGURLS
 EOF"
-roachprod ssh "${WORKLOAD_CLUSTER}":1 -- "chmod +x tpch_run_${suffix}.sh"
+drtprod ssh "${WORKLOAD_CLUSTER}":1 -- "chmod +x tpch_run_${suffix}.sh"

--- a/pkg/cmd/drtprod/scripts/setup_datadog_cluster
+++ b/pkg/cmd/drtprod/scripts/setup_datadog_cluster
@@ -17,7 +17,7 @@ fi
 
 dd_site="us5.datadoghq.com"
 
-roachprod ssh $CLUSTER -- "sudo mkdir -p /etc/fluent-bit && sudo tee /etc/fluent-bit/config-override.yaml > /dev/null << EOF
+drtprod ssh $CLUSTER -- "sudo mkdir -p /etc/fluent-bit && sudo tee /etc/fluent-bit/config-override.yaml > /dev/null << EOF
 ---
 pipeline:
  inputs:
@@ -41,17 +41,17 @@ pipeline:
    storage.total_limit_size: 25MB
 EOF"
 
-roachprod ssh $CLUSTER -- "sudo tee /etc/profile.d/99-datadog.sh > /dev/null << EOF
+drtprod ssh $CLUSTER -- "sudo tee /etc/profile.d/99-datadog.sh > /dev/null << EOF
 export DD_SITE=${dd_site}
 export DD_API_KEY=${dd_api_key}
 export DD_TAGS=env:development,cluster${CLUSTER%:*},team:drt,service:drt-cockroachdb
 EOF"
 
-roachprod opentelemetry-start $CLUSTER \
+drtprod opentelemetry-start $CLUSTER \
   --datadog-api-key "${dd_api_key}" \
   --datadog-tags 'service:drt-cockroachdb,team:drt'
 
-roachprod fluent-bit-start $CLUSTER \
+drtprod fluent-bit-start $CLUSTER \
   --datadog-api-key "${dd_api_key}" \
   --datadog-service drt-cockroachdb \
   --datadog-tags 'service:drt-cockroachdb,team:drt'

--- a/pkg/cmd/drtprod/scripts/setup_datadog_workload
+++ b/pkg/cmd/drtprod/scripts/setup_datadog_workload
@@ -17,7 +17,7 @@ fi
 
 dd_site="us5.datadoghq.com"
 
-roachprod ssh $WORKLOAD_CLUSTER -- "sudo mkdir -p /etc/otelcol-contrib && sudo tee /etc/otelcol-contrib/config-override.yaml > /dev/null << EOF
+drtprod ssh $WORKLOAD_CLUSTER -- "sudo mkdir -p /etc/otelcol-contrib && sudo tee /etc/otelcol-contrib/config-override.yaml > /dev/null << EOF
 ---
 receivers:
   prometheus/workload:
@@ -93,17 +93,17 @@ service:
       - datadog
 EOF"
 
-roachprod ssh $WORKLOAD_CLUSTER -- "sudo tee /etc/profile.d/99-datadog.sh > /dev/null << EOF
+drtprod ssh $WORKLOAD_CLUSTER -- "sudo tee /etc/profile.d/99-datadog.sh > /dev/null << EOF
 export DD_SITE=${dd_site}
 export DD_API_KEY=${dd_api_key}
 export DD_TAGS=env:development,cluster${CLUSTER%:*},team:drt,service:drt-cockroachdb
 EOF"
 
-roachprod opentelemetry-start $WORKLOAD_CLUSTER \
+drtprod opentelemetry-start $WORKLOAD_CLUSTER \
   --datadog-api-key "${dd_api_key}" \
   --datadog-tags 'service:drt-cockroachdb,team:drt'
 
-roachprod fluent-bit-start $WORKLOAD_CLUSTER \
+drtprod fluent-bit-start $WORKLOAD_CLUSTER \
   --datadog-api-key "${dd_api_key}" \
   --datadog-service drt-cockroachdb \
   --datadog-tags 'service:drt-cockroachdb,team:drt'

--- a/pkg/cmd/drtprod/scripts/tpcc_init.sh
+++ b/pkg/cmd/drtprod/scripts/tpcc_init.sh
@@ -36,20 +36,20 @@ if [ -z "${WORKLOAD_CLUSTER}" ]; then
   exit 1
 fi
 
-absolute_path=$(roachprod run "${WORKLOAD_CLUSTER}":1 -- "realpath ./cockroach")
-pwd=$(roachprod run "${WORKLOAD_CLUSTER}":1 -- "dirname ${absolute_path}")
-PGURLS=$(roachprod pgurl "${CLUSTER}":1)
+absolute_path=$(drtprod run "${WORKLOAD_CLUSTER}":1 -- "realpath ./cockroach")
+pwd=$(drtprod run "${WORKLOAD_CLUSTER}":1 -- "dirname ${absolute_path}")
+PGURLS=$(drtprod pgurl "${CLUSTER}":1)
 
 # script is responsible for importing the tpcc database for workload
-roachprod ssh "${WORKLOAD_CLUSTER}":1 -- "tee tpcc_init_${suffix}.sh > /dev/null << 'EOF'
+drtprod ssh "${WORKLOAD_CLUSTER}":1 -- "tee tpcc_init_${suffix}.sh > /dev/null << 'EOF'
 #!/bin/bash
 
 ${pwd}/cockroach workload fixtures import tpcc $PGURLS $@ --checks=false
 EOF"
-roachprod ssh "${WORKLOAD_CLUSTER}":1 -- "chmod +x tpcc_init_${suffix}.sh"
+drtprod ssh "${WORKLOAD_CLUSTER}":1 -- "chmod +x tpcc_init_${suffix}.sh"
 
 if [ "$execute_script" = "true" ]; then
-  roachprod run "${WORKLOAD_CLUSTER}":1 -- "sudo systemd-run --unit tpcc_init_${suffix} --same-dir --uid \$(id -u) --gid \$(id -g) bash ${pwd}/tpcc_init_${suffix}.sh"
+  drtprod run "${WORKLOAD_CLUSTER}":1 -- "sudo systemd-run --unit tpcc_init_${suffix} --same-dir --uid \$(id -u) --gid \$(id -g) bash ${pwd}/tpcc_init_${suffix}.sh"
 else
-  echo "Run --> roachprod run "${WORKLOAD_CLUSTER}":1 -- \"sudo systemd-run --unit tpcc_init_${suffix} --same-dir --uid \\\$(id -u) --gid \\\$(id -g) bash ${pwd}/tpcc_init_${suffix}.sh\""
+  echo "Run --> drtprod run "${WORKLOAD_CLUSTER}":1 -- \"sudo systemd-run --unit tpcc_init_${suffix} --same-dir --uid \\\$(id -u) --gid \\\$(id -g) bash ${pwd}/tpcc_init_${suffix}.sh\""
 fi

--- a/pkg/cmd/drtprod/scripts/tpcc_run_multiregion.sh
+++ b/pkg/cmd/drtprod/scripts/tpcc_run_multiregion.sh
@@ -28,7 +28,7 @@ do
   #  us to reach the specified region, and then add the actual number of workers
   #  we want to run.
   EFFECTIVE_NUM_WORKERS=$(($(($TPCC_WAREHOUSES/$NUM_REGIONS))*$(($NODE-1))+$NUM_WORKERS))
-  PGURLS_REGION=$(./bin/roachprod pgurl $CLUSTER:$NODE_OFFSET-$LAST_NODE_IN_REGION | sed "s/'//g; s/^/'/; s/$/'/")
+  PGURLS_REGION=$(./bin/drtprod pgurl $CLUSTER:$NODE_OFFSET-$LAST_NODE_IN_REGION | sed "s/'//g; s/^/'/; s/$/'/")
   cat <<EOF >/tmp/tpcc_run.sh
 #!/usr/bin/env bash
 j=0

--- a/pkg/cmd/drtprod/scripts/tpch_init.sh
+++ b/pkg/cmd/drtprod/scripts/tpch_init.sh
@@ -36,18 +36,18 @@ if [ -z "${WORKLOAD_CLUSTER}" ]; then
   exit 1
 fi
 
-absolute_path=$(roachprod run "${WORKLOAD_CLUSTER}":1 -- "realpath ./cockroach")
-pwd=$(roachprod run "${WORKLOAD_CLUSTER}":1 -- "dirname ${absolute_path}")
-PGURLS=$(roachprod pgurl "${CLUSTER}":1)
+absolute_path=$(drtprod run "${WORKLOAD_CLUSTER}":1 -- "realpath ./cockroach")
+pwd=$(drtprod run "${WORKLOAD_CLUSTER}":1 -- "dirname ${absolute_path}")
+PGURLS=$(drtprod pgurl "${CLUSTER}":1)
 
 # script is responsible for importing the tpch database for workload
-roachprod ssh "${WORKLOAD_CLUSTER}":1 -- "tee tpch_init_${suffix}.sh > /dev/null << 'EOF'
+drtprod ssh "${WORKLOAD_CLUSTER}":1 -- "tee tpch_init_${suffix}.sh > /dev/null << 'EOF'
 #!/bin/bash
 
 ${pwd}/cockroach workload init tpch $@ $PGURLS
 EOF"
-roachprod ssh "${WORKLOAD_CLUSTER}":1 -- "chmod +x tpch_init_${suffix}.sh"
+drtprod ssh "${WORKLOAD_CLUSTER}":1 -- "chmod +x tpch_init_${suffix}.sh"
 
 if [ "$execute_script" = "true" ]; then
-  roachprod run "${WORKLOAD_CLUSTER}":1 -- "sudo systemd-run --unit tpch_init_${suffix} --same-dir --uid \$(id -u) --gid \$(id -g) bash ${pwd}/tpch_init_${suffix}.sh"
+  drtprod run "${WORKLOAD_CLUSTER}":1 -- "sudo systemd-run --unit tpch_init_${suffix} --same-dir --uid \$(id -u) --gid \$(id -g) bash ${pwd}/tpch_init_${suffix}.sh"
 fi


### PR DESCRIPTION
With the recent refactoring of roachprod, it is possible to directly invoke the roachprod go code rather than using the shell command. This PR changes the same. Also, this PR changes all the scripts in drtprod to use "drtprod" binary instead of "roachprod" as this can work without compiling rochprod.

Note that the YAML processor still uses the shell command as the input is not cobra. So, this becomes a bigger change.

Epic: none
Release note: None