### PR TITLE
release-24.1: jwtauthccl: add mapper for issuer url to jwks URI

### DIFF
--- a/pkg/ccl/jwtauthccl/BUILD.bazel
+++ b/pkg/ccl/jwtauthccl/BUILD.bazel
@@ -21,8 +21,10 @@ go_library(
         "//pkg/util/syncutil",
         "//pkg/util/uuid",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_cockroachdb_redact//:redact",
         "@com_github_lestrrat_go_jwx//jwk",
         "@com_github_lestrrat_go_jwx//jwt",
+        "@org_golang_x_exp//maps",
     ],
 )
 
@@ -53,6 +55,7 @@ go_test(
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_errors//oserror",
+        "@com_github_cockroachdb_redact//:redact",
         "@com_github_lestrrat_go_jwx//jwa",
         "@com_github_lestrrat_go_jwx//jwk",
         "@com_github_lestrrat_go_jwx//jwt",

--- a/pkg/ccl/testccl/authccl/auth_test.go
+++ b/pkg/ccl/testccl/authccl/auth_test.go
@@ -231,7 +231,7 @@ func jwtRunTest(t *testing.T, insecure bool) {
 							if len(a.Vals) != 1 {
 								t.Fatalf("wrong number of argumenets to jwt_cluster_setting issuers: %d", len(a.Vals))
 							}
-							jwtauthccl.JWTAuthIssuers.Override(ctx, sv, a.Vals[0])
+							jwtauthccl.JWTAuthIssuersConfig.Override(ctx, sv, a.Vals[0])
 						case "jwks":
 							if len(a.Vals) != 1 {
 								t.Fatalf("wrong number of argumenets to jwt_cluster_setting jwks: %d", len(a.Vals))

--- a/pkg/sql/pgwire/auth_methods.go
+++ b/pkg/sql/pgwire/auth_methods.go
@@ -701,7 +701,7 @@ type JWTVerifier interface {
 		_ username.SQLUsername,
 		_ []byte,
 		_ *identmap.Conf,
-	) (detailedErrorMsg string, authError error)
+	) (detailedErrorMsg redact.RedactableString, authError error)
 
 	// RetrieveIdentity retrieves the user identity from the JWT.
 	//
@@ -723,7 +723,7 @@ type noJWTConfigured struct{}
 
 func (c *noJWTConfigured) ValidateJWTLogin(
 	_ context.Context, _ *cluster.Settings, _ username.SQLUsername, _ []byte, _ *identmap.Conf,
-) (detailedErrorMsg string, authError error) {
+) (detailedErrorMsg redact.RedactableString, authError error) {
 	return "", errors.New("JWT token authentication requires CCL features")
 }
 


### PR DESCRIPTION
Backport 1/1 commits from #127508.

/cc @cockroachdb/release

---

For provisioning JWKS auto fetch feature we currently depend on issuer's well-known endpoint. This conflicts for some JWT issuers who either don't have a well-known endpoint or path of the well-known endpoint is non-standard. In such cases, operators require to manually set the JWKS URI mapping for each JWT issuer they are intending to allow JWT login. This is facilitated by this PR by allowing `server.jwt_authentication.issuers.configuration` to now take in json object mapping of issuer URL to JWKS URI.

informs https://github.com/cockroachlabs/support/issues/2956 
fixes https://github.com/cockroachdb/cockroach/issues/124976 
Epic CRDB-39178

Release note(security, ops): The cluster setting
server.jwt_authentication.issuers now takes the issuers configuration value apart from the URI. This can be set to one of the following values:
1. Simple string that Go can parse as a valid issuer URL.
2. String that can be parsed as valid JSON array of issuer URLs list.
3. String that can be parsed as valid JSON and deserialized into a map of issuer URLs to corresponding JWKS URIs.
In the third case we will be overriding the JWKS URI present in the issuer's well-known endpoint.

Example valid values:
- 'https://accounts.google.com'
- ['example.com/adfs','https://accounts.google.com']
- '{ "issuer_jwks_map": { "https://accounts.google.com": "https://www.googleapis.com/oauth2/v3/certs", "example.com/adfs": "https://example.com/adfs/discovery/keys" } }' 

When `issuer_jwks_map` is set, we directly use the JWKS URI to get the key set. In all other cases where JWKSAutoFetchEnabled is set we obtain the JWKS URI first from issuer's well-known endpoint and then use this endpoint.

---
Release justification: this is needed as a fix for the AD FS specific issue
