### PR TITLE
release-23.2: schemachanger: Fixed bug incorrect InvertedColumnKinds in the inverte…

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/show_create
+++ b/pkg/sql/logictest/testdata/logic_test/show_create
@@ -198,3 +198,26 @@ SHOW CREATE INDEXES FROM nonexistent
 
 statement error relation "nonexistent" does not exist
 SHOW CREATE SECONDARY INDEXES FROM nonexistent
+
+subtest gin-index
+
+statement ok
+CREATE TABLE roaches (id UUID PRIMARY KEY, x STRING, y STRING, FAMILY f1 (id, x, y));
+
+statement ok
+CREATE INDEX ON roaches USING GIN (x, y gin_trgm_ops);
+
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE roaches];
+----
+CREATE TABLE public.roaches (
+  id UUID NOT NULL,
+  x STRING NULL,
+  y STRING NULL,
+  CONSTRAINT roaches_pkey PRIMARY KEY (id ASC),
+  INVERTED INDEX roaches_x_y_idx (x ASC, y gin_trgm_ops),
+  FAMILY f1 (id, x, y)
+)
+
+
+subtest end

--- a/pkg/sql/schemachanger/scexec/scmutationexec/index.go
+++ b/pkg/sql/schemachanger/scexec/scmutationexec/index.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catenumpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
@@ -408,7 +409,7 @@ func (i *immediateVisitor) AddColumnToIndex(ctx context.Context, op scop.AddColu
 	}
 	// If this is an inverted column, note that.
 	if indexDesc.Type == descpb.IndexDescriptor_INVERTED && op.ColumnID == indexDesc.InvertedColumnID() {
-		indexDesc.InvertedColumnKinds = append(indexDesc.InvertedColumnKinds, op.InvertedKind)
+		indexDesc.InvertedColumnKinds = []catpb.InvertedIndexColumnKind{op.InvertedKind}
 	}
 	return nil
 }


### PR DESCRIPTION
Backport 1/1 commits from #138043.

/cc @cockroachdb/release

---

…d index

Previously the `SHOW CREATE TABLE` statement would lose index information. The fix now allows `SHOW CREATE TABLE` to show the correct information that can be repeatedly entered back into crdb to recreate the same table.

Fixes: #136410
Release note (bug fix): Previously `SHOW CREATE TABLE` was showing incorrect data with regards to inverted indexes.  It now shows the correct data that can be repeatedly entered back into crdb to recreate the same table.
