### PR TITLE
server: fix TestLogGC test

### DIFF
--- a/pkg/server/server_systemlog_gc_test.go
+++ b/pkg/server/server_systemlog_gc_test.go
@@ -67,7 +67,7 @@ func TestLogGC(t *testing.T) {
 			a.NoError(err)
 		}
 	}
-	maxTS1 := timeutil.Now()
+	maxTS1 := timeutil.Now().Add(time.Duration(-24*7) * time.Hour)
 	maxTS2 := maxTS1.Add(time.Second)
 	maxTS3 := maxTS2.Add(time.Second)
 	maxTS4 := maxTS3.Add(time.Second)


### PR DESCRIPTION
This test started failing after #137069 was merged into mater. That PR introduced a change that made it so that a lock is acquired when performing the initial scan for a DELETE, over all scanned rows. As a result, a race condition was exposed in TestLogGC (specifically when the deadlock flag is set) where calling `gcSystemLog` resulted in a `TransactionRetryError: retry txn` error.
 
This race condition is happening because thetest data being written is using timestamps in the future as opposed to the past. When attemping to GC the table, its conflict with normal writes that are happening at the same time. To fix, the test data is being written in the past, which avoids these conflicts.

Fixes: #137490
Release note: None