### PR TITLE
logictest: deflake alter_table by increasing another timestamp delta

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -602,7 +602,7 @@ statement ok
 ALTER TABLE add_default ADD COLUMN c TIMESTAMP DEFAULT current_timestamp()
 
 query II rowsort
-SELECT a,b FROM add_default WHERE current_timestamp > c AND current_timestamp() - c < interval '10s'
+SELECT a,b FROM add_default WHERE current_timestamp > c AND current_timestamp() - c < interval '20s'
 ----
 2 42
 3 10


### PR DESCRIPTION
See #130052 and #132178.

Fixes: #138077

Release note: None