### PR TITLE
jobs: users can control jobs they own

### DIFF
--- a/pkg/ccl/changefeedccl/authorization.go
+++ b/pkg/ccl/changefeedccl/authorization.go
@@ -153,6 +153,10 @@ func AuthorizeChangefeedJobAccess(
 		return errors.Newf("could not unwrap details from the payload of job %d", jobID)
 	}
 
+	if len(specs.TargetSpecifications) == 0 {
+		return pgerror.Newf(pgcode.InsufficientPrivilege, "job contains no tables on which the user has %s privilege", privilege.CHANGEFEED)
+	}
+
 	for _, spec := range specs.TargetSpecifications {
 		err := a.CheckPrivilegeForTableID(ctx, spec.TableID, privilege.CHANGEFEED)
 		if err != nil {

--- a/pkg/jobs/jobsauth/authorization_test.go
+++ b/pkg/jobs/jobsauth/authorization_test.go
@@ -220,13 +220,12 @@ func TestAuthorization(t *testing.T) {
 			accessLevel: jobsauth.ViewAccess,
 		},
 		{
-			name:        "users-cannot-control-their-own-jobs",
+			name:        "users-can-control-their-own-jobs",
 			user:        username.MakeSQLUsernameFromPreNormalizedString("user1"),
 			roleOptions: map[roleoption.Option]struct{}{},
 			admins:      map[string]struct{}{},
 			payload:     makeBackupPayload("user1"),
 			accessLevel: jobsauth.ControlAccess,
-			userErr:     pgerror.New(pgcode.InsufficientPrivilege, "foo"),
 		},
 		{
 			name:        "users-can-control-their-roles-jobs",
@@ -327,6 +326,17 @@ func TestAuthorization(t *testing.T) {
 			admins:      map[string]struct{}{"user2": {}},
 			payload:     makeBackupPayload("user2"),
 			accessLevel: jobsauth.ViewAccess,
+		},
+		{
+			name: "controljob-system-privilege-insufficient-to-control-admin-jobs",
+			user: username.MakeSQLUsernameFromPreNormalizedString("user1"),
+			userPrivileges: map[userPrivilege]struct{}{
+				controlJobGlobalPrivilege: {},
+			},
+			admins:      map[string]struct{}{"user2": {}},
+			payload:     makeBackupPayload("user2"),
+			accessLevel: jobsauth.ControlAccess,
+			userErr:     pgerror.New(pgcode.InsufficientPrivilege, "admin"),
 		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {

--- a/pkg/sql/logictest/testdata/logic_test/jobs
+++ b/pkg/sql/logictest/testdata/logic_test/jobs
@@ -270,7 +270,7 @@ SELECT count(*) FROM [SHOW AUTOMATIC JOBS] WHERE job_type = 'POLL JOBS STATS' AN
 
 subtest control_job_priv
 
-user testuser
+user testuser2
 
 statement ok
 CREATE TABLE t_control_job_priv(x INT)
@@ -284,7 +284,9 @@ statement ok
 DROP TABLE t_control_job_priv
 
 let $job_id
-SELECT job_id FROM [SHOW JOBS] WHERE user_name = 'testuser' AND job_type = 'SCHEMA CHANGE GC' AND description LIKE 'GC for DROP TABLE test.public.t_control_job_priv'
+SELECT job_id FROM [SHOW JOBS] WHERE user_name = 'testuser2' AND job_type = 'SCHEMA CHANGE GC' AND description LIKE 'GC for DROP TABLE test.public.t_control_job_priv'
+
+user testuser
 
 statement error user testuser does not have privileges for job
 PAUSE JOB (SELECT $job_id)
@@ -308,7 +310,7 @@ subtest end
 
 subtest control_job_priv_inherited
 
-user testuser
+user testuser2
 
 statement ok
 CREATE TABLE t_control_job_priv_inherited(x INT)
@@ -322,7 +324,9 @@ statement ok
 DROP TABLE t_control_job_priv_inherited
 
 let $job_id
-SELECT job_id FROM [SHOW JOBS] WHERE user_name = 'testuser' AND job_type = 'SCHEMA CHANGE GC' AND description LIKE 'GC for DROP TABLE test.public.t_control_job_priv_inherited'
+SELECT job_id FROM [SHOW JOBS] WHERE user_name = 'testuser2' AND job_type = 'SCHEMA CHANGE GC' AND description LIKE 'GC for DROP TABLE test.public.t_control_job_priv_inherited'
+
+user testuser
 
 statement error user testuser does not have privileges for job
 PAUSE JOB (SELECT $job_id)


### PR DESCRIPTION
Ownership implies full control -- it is theirs, since they made it, to
see, pause, or cancel. Priviliges like VIEWJOB or CONTROLJOB can be used
to grant access to other jobs, but are not required to access ones own jobs.

Combined with an ability to reassign ownership and ownership via role
membership, this allows fine-grained granting of access to specific jobs
to specific sets of users via roles, without the need to grant them
the global VIEWJOB or CONTROLJOB privileges.

Release note (sql change): Users can always see and control (pause/resume/cancel) jobs which they own.
Epic: none.