### PR TITLE
server: delay startup of system log gc

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1992,10 +1992,6 @@ func (s *topLevelServer) PreStart(ctx context.Context) error {
 			return err
 		}
 	}
-	// Start garbage collecting system events.
-	if err := startSystemLogsGC(workersCtx, s.sqlServer); err != nil {
-		return err
-	}
 
 	// Connect the HTTP endpoints. This also wraps the privileged HTTP
 	// endpoints served by gwMux by the HTTP cookie authentication
@@ -2053,6 +2049,11 @@ func (s *topLevelServer) PreStart(ctx context.Context) error {
 		); err != nil {
 			return err
 		}
+	}
+
+	// Start garbage collecting system events.
+	if err := startSystemLogsGC(workersCtx, s.sqlServer); err != nil {
+		return err
 	}
 
 	// Initialize the external storage builders configuration params now that the


### PR DESCRIPTION
The GC routine uses the internal executor, so it seems sensible to wait until the SQL Server is started. Notably this also ensures that we've definitely initialized the cluster version.

Epic: none
Informs #135198