### PR TITLE
kverver: deflake TestRangefeedCheckpointsRecoverFromLeaseExpiration

### DIFF
--- a/pkg/kv/kvserver/replica_rangefeed_test.go
+++ b/pkg/kv/kvserver/replica_rangefeed_test.go
@@ -1631,8 +1631,12 @@ func TestRangefeedCheckpointsRecoverFromLeaseExpiration(t *testing.T) {
 	log.Infof(ctx, "test waiting for another checkpoint")
 	ts2 := n1.Clock().Now()
 	waitForCheckpoint(ts2)
-	nudged := atomic.LoadInt64(&nudgeSeen)
-	require.Equal(t, int64(1), nudged)
+	testutils.SucceedsSoon(t, func() error {
+		if atomic.LoadInt64(&nudgeSeen) != int64(1) {
+			return errors.Errorf("nudge not seen yet")
+		}
+		return nil
+	})
 
 	// Check that n2 renewed its lease, like the test intended.
 	// Unfortunately this is flaky and it's not so clear how to fix it.


### PR DESCRIPTION
When running with leader leases, it's possible that the nudge to check the old lease status takes longer if the old leader still has store liveness support and hasn't stepped down yet (and lost the lease).

This commit adds a SucceedsSoon around the expected nudge assertion.

Fixes: #137917

Release note: None