### PR TITLE
raft: cache LeadSupportUntil

### DIFF
--- a/pkg/kv/kvserver/leases/status.go
+++ b/pkg/kv/kvserver/leases/status.go
@@ -27,7 +27,7 @@ type StatusInput struct {
 	MinValidObservedTs hlc.ClockTimestamp
 
 	// Information about raft.
-	RaftStatus raft.LeadSupportStatus
+	RaftStatus raft.BasicStatus
 
 	// The current time and the time of the request to evaluate the lease for.
 	Now       hlc.ClockTimestamp

--- a/pkg/kv/kvserver/leases/status_test.go
+++ b/pkg/kv/kvserver/leases/status_test.go
@@ -69,8 +69,8 @@ func TestStatus(t *testing.T) {
 	leaderLeaseRemote := leaderLease
 	leaderLeaseRemote.Replica = repl2
 
-	raftStatus := func(state raftpb.StateType, term uint64, leadSupport hlc.Timestamp) raft.LeadSupportStatus {
-		var s raft.LeadSupportStatus
+	raftStatus := func(state raftpb.StateType, term uint64, leadSupport hlc.Timestamp) raft.BasicStatus {
+		var s raft.BasicStatus
 		s.ID = raftpb.PeerID(repl1.ReplicaID)
 		s.RaftState = state
 		s.Term = term
@@ -98,7 +98,7 @@ func TestStatus(t *testing.T) {
 		now           hlc.ClockTimestamp
 		minProposedTS hlc.ClockTimestamp
 		reqTS         hlc.Timestamp
-		raftStatus    raft.LeadSupportStatus
+		raftStatus    raft.BasicStatus
 		liveness      livenesspb.Liveness
 		want          kvserverpb.LeaseState
 		wantErr       string

--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -1686,13 +1686,6 @@ func (r *Replica) raftBasicStatusRLocked() raft.BasicStatus {
 	return raft.BasicStatus{}
 }
 
-func (r *Replica) raftLeadSupportStatusRLocked() raft.LeadSupportStatus {
-	if rg := r.mu.internalRaftGroup; rg != nil {
-		return rg.LeadSupportStatus()
-	}
-	return raft.LeadSupportStatus{}
-}
-
 // RACv2Status returns the status of the RACv2 range controller of this replica.
 // Returns an empty struct if there is no RACv2 range controller, i.e. this
 // replica is not the leader or is not running RACv2.

--- a/pkg/kv/kvserver/replica_metrics.go
+++ b/pkg/kv/kvserver/replica_metrics.go
@@ -101,7 +101,6 @@ func (r *Replica) Metrics(
 		clusterNodes:             clusterNodes,
 		desc:                     r.shMu.state.Desc,
 		raftStatus:               r.raftSparseStatusRLocked(),
-		leadSupportStatus:        r.raftLeadSupportStatusRLocked(),
 		now:                      now,
 		leaseStatus:              r.leaseStatusAtRLocked(ctx, now),
 		storeID:                  r.store.StoreID(),
@@ -134,7 +133,6 @@ type calcReplicaMetricsInput struct {
 	clusterNodes             int
 	desc                     *roachpb.RangeDescriptor
 	raftStatus               *raft.SparseStatus
-	leadSupportStatus        raft.LeadSupportStatus
 	now                      hlc.ClockTimestamp
 	leaseStatus              kvserverpb.LeaseStatus
 	storeID                  roachpb.StoreID
@@ -190,7 +188,7 @@ func calcReplicaMetrics(d calcReplicaMetricsInput) ReplicaMetrics {
 	if leader {
 		leaderBehindCount = calcBehindCount(d.raftStatus, d.desc, d.vitalityMap)
 		leaderPausedFollowerCount = int64(len(d.paused))
-		leaderNotFortified = d.leadSupportStatus.LeadSupportUntil.Less(d.now.ToTimestamp())
+		leaderNotFortified = d.raftStatus.LeadSupportUntil.Less(d.now.ToTimestamp())
 	}
 
 	return ReplicaMetrics{

--- a/pkg/kv/kvserver/replica_range_lease.go
+++ b/pkg/kv/kvserver/replica_range_lease.go
@@ -758,13 +758,9 @@ func (r *Replica) leaseStatusForRequestRLocked(
 		RequestTs:          reqTS,
 		Lease:              *r.shMu.state.Lease,
 	}
-	// TODO(nvanbenschoten): evaluate whether this is too expensive to compute for
-	// every lease status request. We may need to cache this result. If, at that
-	// time, we determine that it is sufficiently cheap, we should either compute
-	// it unconditionally, regardless of the lease type or let leases.Status
-	// decide when to compute it. See #125255.
+
 	if in.Lease.Type() == roachpb.LeaseLeader {
-		in.RaftStatus = r.raftLeadSupportStatusRLocked()
+		in.RaftStatus = r.raftBasicStatusRLocked()
 	}
 	return leases.Status(ctx, r.store.cfg.NodeLiveness, in)
 }

--- a/pkg/raft/raft.go
+++ b/pkg/raft/raft.go
@@ -1840,7 +1840,7 @@ type stepFunc func(r *raft, m pb.Message) error
 
 func stepLeader(r *raft, m pb.Message) error {
 	// Compute the LeadSupportUntil on every tick.
-	r.fortificationTracker.UpdateComputedLeadSupportUntil(r.state)
+	r.fortificationTracker.ComputeLeadSupportUntil(r.state)
 
 	// These message types do not require any progress for m.From.
 	switch m.Type {
@@ -2760,7 +2760,7 @@ func (r *raft) switchToConfig(cfg quorum.Config, progressMap tracker.ProgressMap
 
 	// Config changes might cause the LeadSupportUntil to change, we need to
 	// recalculate it here.
-	r.fortificationTracker.UpdateComputedLeadSupportUntil(r.state)
+	r.fortificationTracker.ComputeLeadSupportUntil(r.state)
 
 	if r.isLearner {
 		// This node is leader and was demoted, step down.

--- a/pkg/raft/raft.go
+++ b/pkg/raft/raft.go
@@ -1839,6 +1839,9 @@ func (r *raft) logMsgHigherTerm(m pb.Message, suffix redact.SafeString) {
 type stepFunc func(r *raft, m pb.Message) error
 
 func stepLeader(r *raft, m pb.Message) error {
+	// Compute the LeadSupportUntil on every tick.
+	r.fortificationTracker.UpdateComputedLeadSupportUntil(r.state)
+
 	// These message types do not require any progress for m.From.
 	switch m.Type {
 	case pb.MsgBeat:
@@ -2754,6 +2757,10 @@ func (r *raft) switchToConfig(cfg quorum.Config, progressMap tracker.ProgressMap
 		//    leader is gone and stepping up to campaign.
 		r.logger.Panicf("%x leader removed from configuration %s", r.id, r.config)
 	}
+
+	// Config changes might cause the LeadSupportUntil to change, we need to
+	// recalculate it here.
+	r.fortificationTracker.UpdateComputedLeadSupportUntil(r.state)
 
 	if r.isLearner {
 		// This node is leader and was demoted, step down.

--- a/pkg/raft/raft_test.go
+++ b/pkg/raft/raft_test.go
@@ -2177,7 +2177,7 @@ func testFreeStuckCandidateWithCheckQuorum(t *testing.T, storeLivenessEnabled bo
 	nt.send(pb.Message{From: 1, To: 1, Type: pb.MsgHup})
 	assert.Equal(t, pb.StateLeader, a.state)
 	if storeLivenessEnabled {
-		assert.Equal(t, hlc.MaxTimestamp, getLeadSupportStatus(a).LeadSupportUntil)
+		assert.Equal(t, hlc.MaxTimestamp, getBasicStatus(a).LeadSupportUntil)
 	}
 
 	nt.isolate(1)
@@ -4533,7 +4533,7 @@ func testPreVoteMigrationWithFreeStuckPreCandidate(t *testing.T, storeLivenessEn
 
 	assert.Equal(t, pb.StateLeader, n1.state)
 	if storeLivenessEnabled {
-		assert.Equal(t, hlc.MaxTimestamp, getLeadSupportStatus(n1).LeadSupportUntil)
+		assert.Equal(t, hlc.MaxTimestamp, getBasicStatus(n1).LeadSupportUntil)
 	}
 
 	if storeLivenessEnabled {

--- a/pkg/raft/rawnode.go
+++ b/pkg/raft/rawnode.go
@@ -617,12 +617,6 @@ func (rn *RawNode) SparseStatus() SparseStatus {
 	return getSparseStatus(rn.raft)
 }
 
-// LeadSupportStatus returns a LeadSupportStatus. Notably, it only includes
-// leader support information.
-func (rn *RawNode) LeadSupportStatus() LeadSupportStatus {
-	return getLeadSupportStatus(rn.raft)
-}
-
 // ProgressType indicates the type of replica a Progress corresponds to.
 type ProgressType byte
 

--- a/pkg/raft/tracker/fortificationtracker.go
+++ b/pkg/raft/tracker/fortificationtracker.go
@@ -138,7 +138,7 @@ func (ft *FortificationTracker) RecordFortification(id pb.PeerID, epoch pb.Epoch
 	ft.fortification[id] = max(ft.fortification[id], epoch)
 	// Every time a new follower has fortified us, we need to recompute the
 	// LeadSupportUntil since it might have changed.
-	ft.UpdateComputedLeadSupportUntil(pb.StateLeader)
+	ft.ComputeLeadSupportUntil(pb.StateLeader)
 }
 
 // Reset clears out any previously tracked fortification and prepares the
@@ -194,17 +194,16 @@ func (ft *FortificationTracker) LeadSupportUntil(state pb.StateType) hlc.Timesta
 		return ft.leaderMaxSupported.Load()
 	}
 
-	// Compute the lead support using the current configuration and forward the
-	// leaderMaxSupported to avoid regressions when the configuration changes.
-	leadSupportUntil := ft.computeLeadSupportUntil(state)
-	return ft.leaderMaxSupported.Forward(leadSupportUntil)
+	// Forward the leaderMaxSupported to avoid regressions when the configuration
+	// changes.
+	return ft.leaderMaxSupported.Forward(ft.computedLeadSupportUntil)
 }
 
-// UpdateComputedLeadSupportUntil updates the field
+// ComputeLeadSupportUntil updates the field
 // computedLeadSupportUntil by computing the LeadSupportExpiration.
-func (ft *FortificationTracker) UpdateComputedLeadSupportUntil(state pb.StateType) hlc.Timestamp {
+func (ft *FortificationTracker) ComputeLeadSupportUntil(state pb.StateType) hlc.Timestamp {
 	if state != pb.StateLeader {
-		panic("UpdateComputedLeadSupportUntil should only be called by the leader")
+		panic("ComputeLeadSupportUntil should only be called by the leader")
 	}
 
 	if len(ft.fortification) == 0 {
@@ -230,39 +229,6 @@ func (ft *FortificationTracker) UpdateComputedLeadSupportUntil(state pb.StateTyp
 	})
 	ft.computedLeadSupportUntil = ft.config.Voters.LeadSupportExpiration(supportExpMap)
 	return ft.computedLeadSupportUntil
-}
-
-// computeLeadSupportUntil computes the timestamp until which the leader is
-// guaranteed fortification using the current quorum configuration.
-//
-// Unlike LeadSupportUntil, this computation does not provide a guarantee of
-// monotonicity. Specifically, its result may regress after a configuration
-// change.
-func (ft *FortificationTracker) computeLeadSupportUntil(state pb.StateType) hlc.Timestamp {
-	if state != pb.StateLeader {
-		panic("computeLeadSupportUntil should only be called by the leader")
-	}
-	if len(ft.fortification) == 0 {
-		return hlc.Timestamp{} // fast-path for no fortification
-	}
-
-	// TODO(ibrahim): avoid this map allocation as we're calling LeadSupportUntil
-	// from hot paths.
-	supportExpMap := make(map[pb.PeerID]hlc.Timestamp)
-	ft.config.Voters.Visit(func(id pb.PeerID) {
-		if supportEpoch, ok := ft.fortification[id]; ok {
-			curEpoch, curExp := ft.storeLiveness.SupportFrom(id)
-			// NB: We can't assert that supportEpoch <= curEpoch because there may be
-			// a race between a successful MsgFortifyLeaderResp and the store liveness
-			// heartbeat response that lets the leader know the follower's store is
-			// supporting the leader's store at the epoch in the MsgFortifyLeaderResp
-			// message.
-			if curEpoch == supportEpoch {
-				supportExpMap[id] = curExp
-			}
-		}
-	})
-	return ft.config.Voters.LeadSupportExpiration(supportExpMap)
 }
 
 // CanDefortify returns whether the caller can safely[1] de-fortify the term
@@ -399,7 +365,7 @@ func (ft *FortificationTracker) ConfigChangeSafe() bool {
 	// previous configuration, which is reflected in leaderMaxSupported.
 	//
 	// NB: Only run by the leader.
-	return ft.leaderMaxSupported.Load().LessEq(ft.computeLeadSupportUntil(pb.StateLeader))
+	return ft.leaderMaxSupported.Load().LessEq(ft.computedLeadSupportUntil)
 }
 
 // QuorumActive returns whether the leader is currently supported by a quorum or

--- a/pkg/raft/tracker/fortificationtracker_test.go
+++ b/pkg/raft/tracker/fortificationtracker_test.go
@@ -899,6 +899,7 @@ func TestConfigChangeSafe(t *testing.T) {
 
 		tc.afterConfigChange(&mockLiveness, ft)
 
+		ft.ComputeLeadSupportUntil(pb.StateLeader)
 		require.Equal(t, tc.expConfigChangeSafe, ft.ConfigChangeSafe())
 		require.Equal(t, tc.expLeadSupportUntil, ft.LeadSupportUntil(pb.StateLeader))
 	}


### PR DESCRIPTION
This PR introduces lastComputedLeadSupportUntil, which is a cached value of LeadSupportUntil. This makes it cheaper to get LeadSupportUntil. The lastComputedLeadSupportUntil is updated on every tick, and on every fortification/config change.

References: #137264

Release note: None