### PR TITLE
logictest: disallow metamorphic-batch-sizes for partial_stats

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/partial_stats
+++ b/pkg/sql/opt/exec/execbuilder/testdata/partial_stats
@@ -1,4 +1,4 @@
-# LogicTest: local
+# LogicTest: local !metamorphic-batch-sizes
 
 # Tests that verify we can create and use partial table statistics
 # USING EXTREMES correctly.


### PR DESCRIPTION
The partial_stats execbuilder logictest performs a 10k-row insert. This insert can take over an hour when run under race with kv-batch-size=1. Let's try disallowing metamorphic batch sizes for this test.

Fixes: #138225

Release note: None