### PR TITLE
logictest: disallow metamorphic-batch-sizes for alter_primary_key

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/alter_primary_key
+++ b/pkg/sql/logictest/testdata/logic_test/alter_primary_key
@@ -1,3 +1,5 @@
+# LogicTest: !metamorphic-batch-sizes
+
 statement ok
 CREATE TABLE t (x INT PRIMARY KEY, y INT NOT NULL, z INT NOT NULL, w INT, INDEX i (x), INDEX i2 (z))
 


### PR DESCRIPTION
The alter_primary_key logictest took over an hour when run under race with kv-batch-size=1. Let's try disallowing metamorphic batch sizes for this test.

Fixes: #138127

Release note: None