### PR TITLE
roachprod: set org name when creating license

### DIFF
--- a/pkg/roachprod/install/cockroach.go
+++ b/pkg/roachprod/install/cockroach.go
@@ -1307,7 +1307,9 @@ func (c *SyncedCluster) maybeGenerateLicense(l *logger.Logger) string {
 	}
 	if res == "" {
 		res, _ = (&licenseccl.License{
-			Type:              licenseccl.License_Enterprise,
+			Type: licenseccl.License_Enterprise,
+			// OrganizationName needs to be set to preserve backwards compatibility.
+			OrganizationName:  "Cockroach Labs - Production Testing",
 			Environment:       licenseccl.Development,
 			ValidUntilUnixSec: timeutil.Now().AddDate(0, 1, 0).Unix(),
 		}).Encode()


### PR DESCRIPTION
OrganizationName is no longer used in newer versions, but needs to be set to preserve backwards compatibility on older versions, e.g. mixed version tests that might not use the latest predecessor.

Fixes: https://github.com/cockroachdb/cockroach/issues/138144
Epic: none
Release note: none