### PR TITLE
codeowners: Add field-engineering team

### DIFF
--- a/TEAMS.yaml
+++ b/TEAMS.yaml
@@ -116,3 +116,6 @@ cockroachdb/release-eng:
     cockroachdb/upgrade-prs: other
   label: T-release
   triage_column_id: 9149730
+cockroachdb/field-engineering:
+  # Field Eng isn't currently using github projects.
+  label: T-field-eng

--- a/pkg/cmd/roachtest/registry/owners.go
+++ b/pkg/cmd/roachtest/registry/owners.go
@@ -34,6 +34,7 @@ const (
 	OwnerStorage            Owner = `storage`
 	OwnerTestEng            Owner = `test-eng`
 	OwnerDevInf             Owner = `dev-inf`
+	OwnerFieldEng           Owner = `field-engineering`
 )
 
 // IsValid returns true if the owner is valid, i.e. it has a corresponding team

--- a/pkg/internal/team/TEAMS.yaml
+++ b/pkg/internal/team/TEAMS.yaml
@@ -116,3 +116,6 @@ cockroachdb/release-eng:
     cockroachdb/upgrade-prs: other
   label: T-release
   triage_column_id: 9149730
+cockroachdb/field-engineering:
+  # Field Eng isn't currently using github projects.
+  label: T-field-eng


### PR DESCRIPTION
This PR adds the Field Engineering team so we can get alerts when our upcoming tests fail and what not.

Also, I alphabetized the TEAMS.yaml files and the owners.go list of teams because it makes it easier to read.  
I can skip the second commit if this is not desired.

Also, why are there two TEAMS.yaml if they are identical?
