### PR TITLE
sql/parser: parse CREATE LOGICALLY REPLICATED TABLE options seperately

### DIFF
--- a/docs/generated/sql/bnf/create_logical_replication_stream_stmt.bnf
+++ b/docs/generated/sql/bnf/create_logical_replication_stream_stmt.bnf
@@ -1,2 +1,2 @@
 create_logical_replication_stream_stmt ::=
-	'CREATE' 'LOGICALLY' 'REPLICATED' logical_replication_resources 'FROM' logical_replication_resources 'ON' string_or_placeholder opt_logical_replication_options
+	'CREATE' 'LOGICALLY' 'REPLICATED' logical_replication_resources 'FROM' logical_replication_resources 'ON' string_or_placeholder opt_logical_replication_create_table_options

--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -621,7 +621,7 @@ create_external_connection_stmt ::=
 	'CREATE' 'EXTERNAL' 'CONNECTION' label_spec 'AS' string_or_placeholder
 
 create_logical_replication_stream_stmt ::=
-	'CREATE' 'LOGICALLY' 'REPLICATED' logical_replication_resources 'FROM' logical_replication_resources 'ON' string_or_placeholder opt_logical_replication_options
+	'CREATE' 'LOGICALLY' 'REPLICATED' logical_replication_resources 'FROM' logical_replication_resources 'ON' string_or_placeholder opt_logical_replication_create_table_options
 
 create_schedule_stmt ::=
 	create_schedule_for_changefeed_stmt
@@ -1879,9 +1879,9 @@ logical_replication_resources ::=
 	| 'TABLES' '(' logical_replication_resources_list ')'
 	| 'DATABASE' database_name
 
-opt_logical_replication_options ::=
-	'WITH' logical_replication_options_list
-	| 'WITH' 'OPTIONS' '(' logical_replication_options_list ')'
+opt_logical_replication_create_table_options ::=
+	'WITH' logical_replication_create_table_options_list
+	| 'WITH' 'OPTIONS' '(' logical_replication_create_table_options_list ')'
 	| 
 
 create_schedule_for_changefeed_stmt ::=
@@ -2687,8 +2687,8 @@ target_elem ::=
 logical_replication_resources_list ::=
 	( db_object_name ) ( ( ',' db_object_name ) )*
 
-logical_replication_options_list ::=
-	( logical_replication_options ) ( ( ',' logical_replication_options ) )*
+logical_replication_create_table_options_list ::=
+	( logical_replication_create_table_options ) ( ( ',' logical_replication_create_table_options ) )*
 
 schedule_label_spec ::=
 	label_spec
@@ -3340,13 +3340,9 @@ bare_col_label ::=
 	'identifier'
 	| bare_label_keywords
 
-logical_replication_options ::=
-	'CURSOR' '=' string_or_placeholder
-	| 'MODE' '=' string_or_placeholder
-	| 'DEFAULT' 'FUNCTION' '=' string_or_placeholder
-	| 'FUNCTION' db_object_name 'FOR' 'TABLE' db_object_name
+logical_replication_create_table_options ::=
+	'MODE' '=' string_or_placeholder
 	| 'DISCARD' '=' string_or_placeholder
-	| 'SKIP' 'SCHEMA' 'CHECK'
 	| 'LABEL' '=' string_or_placeholder
 
 common_table_expr ::=

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -1264,7 +1264,7 @@ func (u *sqlSymUnion) indexType() tree.IndexType {
 %type <tree.Statement> create_policy_stmt
 
 %type <tree.LogicalReplicationResources> logical_replication_resources, logical_replication_resources_list
-%type <*tree.LogicalReplicationOptions> opt_logical_replication_options logical_replication_options logical_replication_options_list
+%type <*tree.LogicalReplicationOptions> opt_logical_replication_options logical_replication_options logical_replication_options_list opt_logical_replication_create_table_options logical_replication_create_table_options logical_replication_create_table_options_list
 
 %type <tree.Statement> create_stats_stmt
 %type <*tree.CreateStatsOptions> opt_create_stats_options
@@ -4666,7 +4666,7 @@ create_logical_replication_stream_stmt:
       Options: *$11.logicalReplicationOptions(),
     }
   }
-| CREATE LOGICALLY REPLICATED logical_replication_resources FROM logical_replication_resources ON string_or_placeholder opt_logical_replication_options
+| CREATE LOGICALLY REPLICATED logical_replication_resources FROM logical_replication_resources ON string_or_placeholder opt_logical_replication_create_table_options
   {
     $$.val = &tree.CreateLogicalReplicationStream{
       Into: $4.logicalReplicationResources(),
@@ -4729,6 +4729,20 @@ opt_logical_replication_options:
     $$.val = &tree.LogicalReplicationOptions{}
   }
 
+opt_logical_replication_create_table_options:
+  WITH logical_replication_create_table_options_list
+  {
+    $$.val = $2.logicalReplicationOptions()
+  }
+| WITH OPTIONS '(' logical_replication_create_table_options_list ')'
+  {
+    $$.val = $4.logicalReplicationOptions()
+  }
+| /* EMPTY */
+  {
+    $$.val = &tree.LogicalReplicationOptions{}
+  }
+
 logical_replication_options_list:
   // Require at least one option
   logical_replication_options
@@ -4736,6 +4750,19 @@ logical_replication_options_list:
     $$.val = $1.logicalReplicationOptions()
   }
 | logical_replication_options_list ',' logical_replication_options
+  {
+    if err := $1.logicalReplicationOptions().CombineWith($3.logicalReplicationOptions()); err != nil {
+      return setErr(sqllex, err)
+    }
+  }
+
+logical_replication_create_table_options_list:
+  // Require at least one option
+  logical_replication_create_table_options
+  {
+    $$.val = $1.logicalReplicationOptions()
+  }
+| logical_replication_create_table_options_list ',' logical_replication_create_table_options
   {
     if err := $1.logicalReplicationOptions().CombineWith($3.logicalReplicationOptions()); err != nil {
       return setErr(sqllex, err)
@@ -4768,6 +4795,20 @@ logical_replication_options:
 | SKIP SCHEMA CHECK
   {
     $$.val = &tree.LogicalReplicationOptions{SkipSchemaCheck: tree.MakeDBool(true)} 
+  }
+| LABEL '=' string_or_placeholder
+  {
+    $$.val = &tree.LogicalReplicationOptions{MetricsLabel: $3.expr()}
+  }
+
+logical_replication_create_table_options:
+  MODE '=' string_or_placeholder
+  {
+    $$.val = &tree.LogicalReplicationOptions{Mode: $3.expr()}
+  }
+ | DISCARD '=' string_or_placeholder
+  {
+    $$.val = &tree.LogicalReplicationOptions{Discard: $3.expr()}
   }
 | LABEL '=' string_or_placeholder
   {

--- a/pkg/sql/parser/testdata/create_logical_replication
+++ b/pkg/sql/parser/testdata/create_logical_replication
@@ -22,6 +22,23 @@ CREATE LOGICALLY REPLICATED TABLE (foo) FROM TABLE (foo) ON ('uri') -- fully par
 CREATE LOGICALLY REPLICATED TABLE foo FROM TABLE foo ON '_' -- literals removed
 CREATE LOGICALLY REPLICATED TABLE _ FROM TABLE _ ON 'uri' -- identifiers removed
 
+error
+CREATE LOGICALLY REPLICATED TABLE foo FROM TABLE foo ON 'uri' WITH CURSOR = '1536242855577149065.0000000000';
+----
+at or near "cursor": syntax error
+DETAIL: source SQL:
+CREATE LOGICALLY REPLICATED TABLE foo FROM TABLE foo ON 'uri' WITH CURSOR = '1536242855577149065.0000000000'
+                                                                   ^
+HINT: try \h CREATE
+
+parse
+CREATE LOGICALLY REPLICATED TABLE foo FROM TABLE foo ON 'uri' WITH MODE = 'immediate';
+----
+CREATE LOGICALLY REPLICATED TABLE foo FROM TABLE foo ON 'uri' WITH OPTIONS (MODE = 'immediate') -- normalized!
+CREATE LOGICALLY REPLICATED TABLE (foo) FROM TABLE (foo) ON ('uri') WITH OPTIONS (MODE = ('immediate')) -- fully parenthesized
+CREATE LOGICALLY REPLICATED TABLE foo FROM TABLE foo ON '_' WITH OPTIONS (MODE = '_') -- literals removed
+CREATE LOGICALLY REPLICATED TABLE _ FROM TABLE _ ON 'uri' WITH OPTIONS (MODE = 'immediate') -- identifiers removed
+
 parse
 CREATE LOGICAL REPLICATION STREAM FROM TABLE foo.bar ON 'uri' INTO TABLE foo.bar;
 ----


### PR DESCRIPTION
The two different CREATE LDR incancatations will require different options, so we should validate which options apply to which incantation at parsing time.

Epic: none

Release note: none