### PR TITLE
storage: configure pebble key categories

### DIFF
--- a/pkg/storage/temp_engine.go
+++ b/pkg/storage/temp_engine.go
@@ -110,6 +110,7 @@ func newPebbleTempEngine(
 			cfg.opts.KeySchema = ""
 			cfg.opts.DisableWAL = true
 			cfg.opts.Experimental.KeyValidationFunc = nil
+			cfg.opts.Experimental.UserKeyCategories = pebble.UserKeyCategories{}
 			cfg.opts.BlockPropertyCollectors = nil
 			cfg.opts.EnableSQLRowSpillMetrics = true
 			cfg.DiskWriteStatsCollector = statsCollector


### PR DESCRIPTION
Set up the Pebble key categories that result in pprof tags in
compactions, allowing to see the breakdown for each key type.

Epic: none
Release note: None