### PR TITLE
kvserver: fix nil deref in replica metrics

### DIFF
--- a/pkg/kv/kvserver/replica_metrics.go
+++ b/pkg/kv/kvserver/replica_metrics.go
@@ -346,7 +346,7 @@ func calcBehindCount(
 }
 
 func calcRaftFlowStateCounts(status *raft.SparseStatus) (cnt [tracker.StateCount]int64) {
-	if status.RaftState != raftpb.StateLeader {
+	if status == nil || status.RaftState != raftpb.StateLeader {
 		return cnt
 	}
 	for _, pr := range status.Progress {


### PR DESCRIPTION
The raft status can be nil if `internalRaftGroup` is nil. This is possible in the middle of replica removal, after `disconnectReplicationRaftMuLocked` releases `Replica.mu`.

Fixes #138124
Related to #136531