### PR TITLE
sql: Fix virtual index scan for crdb_internal.create_type_statements

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -1677,13 +1677,32 @@ DELETE FROM system.role_members WHERE member = 'non_cached_user';
 statement ok
 DROP USER real_user;
 
-subtest end
+subtest cross_db
 
 statement ok
 CREATE TYPE other_db.public.enum1 AS ENUM ('yo');
 
-# Ensure that the cross-DB lookup of UDTs works.
+# Ensure that the cross-DB lookup of UDTs works. This uses the full table scan.
 query ITTITTT
-SELECT * FROM "".crdb_internal.create_type_statements WHERE descriptor_id = (('other_db.public.enum1'::regtype::int) - 100000)::oid
+SELECT * FROM "".crdb_internal.create_type_statements WHERE descriptor_name = 'enum1' and database_name = 'other_db'
 ----
 121  other_db  public  151  enum1  CREATE TYPE other_db.public.enum1 AS ENUM ('yo')  {yo}
+
+# This uses the virtual index. descriptor_id is an int in the vtable.
+query ITTITTT
+SELECT * FROM "".crdb_internal.create_type_statements WHERE descriptor_id = (('other_db.public.enum1'::regtype::int) - 100000)
+----
+121  other_db  public  151  enum1  CREATE TYPE other_db.public.enum1 AS ENUM ('yo')  {yo}
+
+# Repeat above two queries but apply only for the current database. We do this by omitting the "".
+# This one uses the full table scan.
+query ITTITTT
+SELECT * FROM crdb_internal.create_type_statements WHERE descriptor_name = 'enum1'
+----
+
+# This one uses the virtual index
+query ITTITTT
+SELECT * FROM crdb_internal.create_type_statements WHERE descriptor_id = (('other_db.public.enum1'::regtype::int) - 100000)
+----
+
+subtest end


### PR DESCRIPTION
When querying the crdb_internal.create_type_statements virtual table, two access paths are possible: a full table scan or a virtual index scan. We observed inconsistent behavior between these paths. The full table scan returned correct data, but the virtual index scan could return types for the wrong database (if one was specified) or panic with a null pointer dereference when querying across all databases. This change corrects the virtual index access pattern to ensure consistency with the full table scan.

Epic: None
Closes #137579
Release note (bug fix): Fixed issues with the virtual index scan on crdb_internal.create_type_statements, ensuring consistent results when querying user-defined types (UDTs) across databases.