### PR TITLE
release-23.1: cdc/mixed-version: bump timeout to 3h

### DIFF
--- a/pkg/cmd/roachtest/tests/mixed_version_cdc.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_cdc.go
@@ -66,7 +66,7 @@ func registerCDCMixedVersions(r registry.Registry) {
 		Owner: registry.OwnerCDC,
 		// N.B. ARM64 is not yet supported, see https://github.com/cockroachdb/cockroach/issues/103888.
 		Cluster:          r.MakeClusterSpec(5, spec.GCEZones(teamcityAgentZone), spec.Arch(vm.ArchAMD64)),
-		Timeout:          30 * time.Minute,
+		Timeout:          3 * time.Hour,
 		CompatibleClouds: registry.OnlyGCE,
 		Suites:           registry.Suites(registry.Nightly),
 		RequiresLicense:  true,


### PR DESCRIPTION
Backport 1/1 commits from #132488.

/cc @cockroachdb/release

---

This patch fixes cdc/mixed-versions by bumping the timeout and limiting the max
number of upgrades each test runs. This test tends to take a long time.

Fixes: https://github.com/cockroachdb/cockroach/issues/131895
Fixes: https://github.com/cockroachdb/cockroach/issues/137899
Release note: none

---

Release justification: test only changes 
