### PR TITLE
Vecstore quantize

### DIFF
--- a/pkg/sql/vecindex/quantize/BUILD.bazel
+++ b/pkg/sql/vecindex/quantize/BUILD.bazel
@@ -39,6 +39,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/sql/vecindex/internal",
+        "//pkg/util/buildutil",
         "//pkg/util/num32",
         "//pkg/util/vector",
         "@com_github_cockroachdb_errors//:errors",

--- a/pkg/sql/vecindex/quantize/quantizer.go
+++ b/pkg/sql/vecindex/quantize/quantizer.go
@@ -114,4 +114,8 @@ type QuantizedVectorSet interface {
 	// Clone makes a deep copy of this quantized vector set. Changes to either
 	// the original or clone will not affect the other.
 	Clone() QuantizedVectorSet
+
+	// Clear removes all the elements of the vector set so that it may be reused. The
+	// new centroid is copied over the existing centroid.
+	Clear(centroid vector.T)
 }

--- a/pkg/sql/vecindex/quantize/quantizer.go
+++ b/pkg/sql/vecindex/quantize/quantizer.go
@@ -64,6 +64,10 @@ type Quantizer interface {
 	// NOTE: The caller must ensure that a Workspace is attached to the context.
 	QuantizeInSet(ctx context.Context, quantizedSet QuantizedVectorSet, vectors *vector.Set)
 
+	// NewQuantizedVectorSet returns a new empty vector set preallocated to the
+	// number of vectors specified.
+	NewQuantizedVectorSet(capacity int, centroid vector.T) QuantizedVectorSet
+
 	// EstimateSquaredDistances returns the estimated squared distances of the
 	// query vector from each data vector represented in the given quantized
 	// vector set, as well as the error bounds for those distances.

--- a/pkg/sql/vecindex/quantize/rabitq.go
+++ b/pkg/sql/vecindex/quantize/rabitq.go
@@ -17,7 +17,7 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
-// raBitQuantizer quantizes vectors according to the algorithm described in this
+// RaBitQuantizer quantizes vectors according to the algorithm described in this
 // paper:
 //
 //	"RaBitQ: Quantizing High-Dimensional Vectors with a Theoretical Error Bound
@@ -29,11 +29,11 @@ import (
 // accelerated with fast SIMD instructions. RaBitQ quantization codes use only
 // 1 bit per dimension in the original vector.
 //
-// All methods in raBitQuantizer are thread-safe. It is intended to be cached
+// All methods in RaBitQuantizer are thread-safe. It is intended to be cached
 // on a per-process basis and reused across all threads that query the same
 // vector index. This is important, because the ROT matrix is expensive to
 // generate and can use quite a bit of memory.
-type raBitQuantizer struct {
+type RaBitQuantizer struct {
 	// dims is the dimensionality of vectors that can be quantized.
 	dims int
 	// sqrtDims is the precomputed square root of the "dims" field.
@@ -48,7 +48,7 @@ type raBitQuantizer struct {
 	unbias []float32
 }
 
-var _ Quantizer = (*raBitQuantizer)(nil)
+var _ Quantizer = (*RaBitQuantizer)(nil)
 
 // NewRaBitQuantizer returns a new RaBitQ quantizer that quantizes vectors with
 // the given number of dimensions. The provided seed is used to generate the
@@ -94,7 +94,7 @@ func NewRaBitQuantizer(dims int, seed int64) Quantizer {
 	}
 
 	sqrtDims := num32.Sqrt(float32(dims))
-	return &raBitQuantizer{
+	return &RaBitQuantizer{
 		dims:        dims,
 		sqrtDims:    sqrtDims,
 		sqrtDimsInv: 1.0 / sqrtDims,
@@ -104,17 +104,17 @@ func NewRaBitQuantizer(dims int, seed int64) Quantizer {
 }
 
 // GetOriginalDims implements the Quantizer interface.
-func (q *raBitQuantizer) GetOriginalDims() int {
+func (q *RaBitQuantizer) GetOriginalDims() int {
 	return q.dims
 }
 
 // GetRandomDims implements the Quantizer interface.
-func (q *raBitQuantizer) GetRandomDims() int {
+func (q *RaBitQuantizer) GetRandomDims() int {
 	return q.dims
 }
 
 // RandomizeVector implements the Quantizer interface.
-func (q *raBitQuantizer) RandomizeVector(
+func (q *RaBitQuantizer) RandomizeVector(
 	ctx context.Context, input vector.T, output vector.T, invert bool,
 ) {
 	if !invert {
@@ -125,7 +125,7 @@ func (q *raBitQuantizer) RandomizeVector(
 }
 
 // Quantize implements the Quantizer interface.
-func (q *raBitQuantizer) Quantize(ctx context.Context, vectors *vector.Set) QuantizedVectorSet {
+func (q *RaBitQuantizer) Quantize(ctx context.Context, vectors *vector.Set) QuantizedVectorSet {
 	// Allocate slice for the centroid.
 	quantizedSet := &RaBitQuantizedVectorSet{
 		Centroid: vectors.Centroid(make(vector.T, vectors.Dims)),
@@ -136,14 +136,14 @@ func (q *raBitQuantizer) Quantize(ctx context.Context, vectors *vector.Set) Quan
 }
 
 // QuantizeInSet implements the Quantizer interface.
-func (q *raBitQuantizer) QuantizeInSet(
+func (q *RaBitQuantizer) QuantizeInSet(
 	ctx context.Context, quantizedSet QuantizedVectorSet, vectors *vector.Set,
 ) {
 	q.quantizeHelper(ctx, quantizedSet.(*RaBitQuantizedVectorSet), vectors)
 }
 
 // NewQuantizedVectorSet implements the Quantizer interface
-func (q *raBitQuantizer) NewQuantizedVectorSet(capacity int, centroid vector.T) QuantizedVectorSet {
+func (q *RaBitQuantizer) NewQuantizedVectorSet(capacity int, centroid vector.T) QuantizedVectorSet {
 	dataBuffer := make([]uint64, 0, capacity*RaBitQCodeSetWidth(q.GetRandomDims()))
 	raBitQuantizedVectorSet := &RaBitQuantizedVectorSet{
 		Centroid:          centroid,
@@ -156,7 +156,7 @@ func (q *raBitQuantizer) NewQuantizedVectorSet(capacity int, centroid vector.T) 
 }
 
 // EstimateSquaredDistances implements the Quantizer interface.
-func (q *raBitQuantizer) EstimateSquaredDistances(
+func (q *RaBitQuantizer) EstimateSquaredDistances(
 	ctx context.Context,
 	quantizedSet QuantizedVectorSet,
 	queryVector vector.T,
@@ -298,7 +298,7 @@ func (q *raBitQuantizer) EstimateSquaredDistances(
 
 // quantizeHelper quantizes the given set of vectors and adds the quantization
 // information to the provided quantized vector set.
-func (q *raBitQuantizer) quantizeHelper(
+func (q *RaBitQuantizer) quantizeHelper(
 	ctx context.Context, qs *RaBitQuantizedVectorSet, vectors *vector.Set,
 ) {
 	// Extend any existing slices in the vector set.

--- a/pkg/sql/vecindex/quantize/rabitq.go
+++ b/pkg/sql/vecindex/quantize/rabitq.go
@@ -142,6 +142,19 @@ func (q *raBitQuantizer) QuantizeInSet(
 	q.quantizeHelper(ctx, quantizedSet.(*RaBitQuantizedVectorSet), vectors)
 }
 
+// NewQuantizedVectorSet implements the Quantizer interface
+func (q *raBitQuantizer) NewQuantizedVectorSet(capacity int, centroid vector.T) QuantizedVectorSet {
+	dataBuffer := make([]uint64, 0, capacity*RaBitQCodeSetWidth(q.GetRandomDims()))
+	raBitQuantizedVectorSet := &RaBitQuantizedVectorSet{
+		Centroid:          centroid,
+		Codes:             MakeRaBitQCodeSetFromRawData(dataBuffer, q.GetRandomDims()),
+		CodeCounts:        make([]uint32, 0, capacity),
+		CentroidDistances: make([]float32, 0, capacity),
+		DotProducts:       make([]float32, 0, capacity),
+	}
+	return raBitQuantizedVectorSet
+}
+
 // EstimateSquaredDistances implements the Quantizer interface.
 func (q *raBitQuantizer) EstimateSquaredDistances(
 	ctx context.Context,

--- a/pkg/sql/vecindex/quantize/unquantizedpb.go
+++ b/pkg/sql/vecindex/quantize/unquantizedpb.go
@@ -36,6 +36,13 @@ func (vs *UnQuantizedVectorSet) Clone() QuantizedVectorSet {
 	}
 }
 
+// Clear implements the QuantizedVectorSet interface.
+func (vs *UnQuantizedVectorSet) Clear(centroid vector.T) {
+	copy(vs.Centroid, centroid)
+	vs.CentroidDistances = vs.CentroidDistances[:0]
+	vs.Vectors.Clear()
+}
+
 // ComputeSquaredDistances computes the exact squared distances between the
 // given query vector and the vectors in the set, and writes the distances to
 // the "squaredDistances" slice.

--- a/pkg/sql/vecindex/quantize/unquantizer.go
+++ b/pkg/sql/vecindex/quantize/unquantizer.go
@@ -13,34 +13,34 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
-// unQuantizer trivially implements the Quantizer interface, storing the
+// UnQuantizer trivially implements the Quantizer interface, storing the
 // original full-size vectors in unmodified form.
 //
-// All methods in unQuantizer are thread-safe.
-type unQuantizer struct {
+// All methods in UnQuantizer are thread-safe.
+type UnQuantizer struct {
 	dims int
 }
 
-var _ Quantizer = (*unQuantizer)(nil)
+var _ Quantizer = (*UnQuantizer)(nil)
 
 // NewUnQuantizer returns a new instance of the UnQuantizer that stores vectors
 // with the given number of dimensions.
 func NewUnQuantizer(dims int) Quantizer {
-	return &unQuantizer{dims: dims}
+	return &UnQuantizer{dims: dims}
 }
 
 // GetOriginalDims implements the Quantizer interface.
-func (q *unQuantizer) GetOriginalDims() int {
+func (q *UnQuantizer) GetOriginalDims() int {
 	return q.dims
 }
 
 // GetRandomDims implements the Quantizer interface.
-func (q *unQuantizer) GetRandomDims() int {
+func (q *UnQuantizer) GetRandomDims() int {
 	return q.dims
 }
 
 // RandomizeVector implements the Quantizer interface.
-func (q *unQuantizer) RandomizeVector(
+func (q *UnQuantizer) RandomizeVector(
 	ctx context.Context, input vector.T, output vector.T, invert bool,
 ) {
 	if len(input) != q.dims {
@@ -55,7 +55,7 @@ func (q *unQuantizer) RandomizeVector(
 }
 
 // Quantize implements the Quantizer interface.
-func (q *unQuantizer) Quantize(ctx context.Context, vectors *vector.Set) QuantizedVectorSet {
+func (q *UnQuantizer) Quantize(ctx context.Context, vectors *vector.Set) QuantizedVectorSet {
 	unquantizedSet := &UnQuantizedVectorSet{
 		Centroid: make(vector.T, q.dims),
 		Vectors:  vector.MakeSet(q.dims),
@@ -68,7 +68,7 @@ func (q *unQuantizer) Quantize(ctx context.Context, vectors *vector.Set) Quantiz
 }
 
 // QuantizeInSet implements the Quantizer interface.
-func (q *unQuantizer) QuantizeInSet(
+func (q *UnQuantizer) QuantizeInSet(
 	ctx context.Context, quantizedSet QuantizedVectorSet, vectors *vector.Set,
 ) {
 	unquantizedSet := quantizedSet.(*UnQuantizedVectorSet)
@@ -76,7 +76,7 @@ func (q *unQuantizer) QuantizeInSet(
 }
 
 // NewQuantizedVectorSet implements the Quantizer interface
-func (q *unQuantizer) NewQuantizedVectorSet(capacity int, centroid vector.T) QuantizedVectorSet {
+func (q *UnQuantizer) NewQuantizedVectorSet(capacity int, centroid vector.T) QuantizedVectorSet {
 	dataBuffer := make([]float32, 0, capacity*q.GetRandomDims())
 	unquantizedSet := &UnQuantizedVectorSet{
 		Centroid: centroid,
@@ -86,7 +86,7 @@ func (q *unQuantizer) NewQuantizedVectorSet(capacity int, centroid vector.T) Qua
 }
 
 // EstimateSquaredDistances implements the Quantizer interface.
-func (q *unQuantizer) EstimateSquaredDistances(
+func (q *UnQuantizer) EstimateSquaredDistances(
 	ctx context.Context,
 	quantizedSet QuantizedVectorSet,
 	queryVector vector.T,

--- a/pkg/sql/vecindex/quantize/unquantizer.go
+++ b/pkg/sql/vecindex/quantize/unquantizer.go
@@ -75,6 +75,16 @@ func (q *unQuantizer) QuantizeInSet(
 	unquantizedSet.AddSet(vectors)
 }
 
+// NewQuantizedVectorSet implements the Quantizer interface
+func (q *unQuantizer) NewQuantizedVectorSet(capacity int, centroid vector.T) QuantizedVectorSet {
+	dataBuffer := make([]float32, 0, capacity*q.GetRandomDims())
+	unquantizedSet := &UnQuantizedVectorSet{
+		Centroid: centroid,
+		Vectors:  vector.MakeSetFromRawData(dataBuffer, q.GetRandomDims()),
+	}
+	return unquantizedSet
+}
+
 // EstimateSquaredDistances implements the Quantizer interface.
 func (q *unQuantizer) EstimateSquaredDistances(
 	ctx context.Context,


### PR DESCRIPTION
**quantize: add the NewQuantizedVectorSet() method**
    
Add a method for creating a pre-allocated but empty vector set for use in deserializing quantized vectors from the kv.


**quantize: export Quantizer implementations**
    
Previously, the Quantizer implementations were private because the in-memory store didn't need take action specific to the quantizer in use. However, to properly serialize and deserialize quantized vectors, we need to know the type of quantizer in use. A type method was considered, but just using type assertions seemed more natural.

   
**quantize: add a Clear method to quantized vector sets**

Previously, quantized vector sets were single use. By adding a Clear method, the vector store can reset and reuse short lived vector sets rather than repeatedly allocating new ones.


Epic: CRDB-42943
