### PR TITLE
vecstore: change partition key encoding to uvarint

### DIFF
--- a/pkg/sql/vecindex/vecstore/encoding.go
+++ b/pkg/sql/vecindex/vecstore/encoding.go
@@ -44,6 +44,11 @@ func EncodeUnquantizedVector(
 	return vector.Encode(appendTo, v)
 }
 
+// EncodePartitionKey encodes a partition key into the given byte slice.
+func EncodePartitionKey(appendTo []byte, key PartitionKey) []byte {
+	return encoding.EncodeUvarintAscending(appendTo, uint64(key))
+}
+
 // EncodeChildKey encodes a child key into the given byte slice. The "appendTo"
 // slice is expected to be the prefix shared between all KV entries for a
 // partition.
@@ -52,7 +57,7 @@ func EncodeChildKey(appendTo []byte, key ChildKey) []byte {
 		// The primary key is already in encoded form.
 		return append(appendTo, key.PrimaryKey...)
 	}
-	return encoding.EncodeUint64Ascending(appendTo, uint64(key.PartitionKey))
+	return EncodePartitionKey(appendTo, key.PartitionKey)
 }
 
 // DecodePartitionMetadata decodes the metadata for a partition.
@@ -128,7 +133,7 @@ func DecodeChildKey(encChildKey []byte, level Level) (ChildKey, error) {
 		return ChildKey{PrimaryKey: encChildKey}, nil
 	} else {
 		// Non-leaf vectors point to the partition key.
-		_, childPartitionKey, err := encoding.DecodeUint64Ascending(encChildKey)
+		_, childPartitionKey, err := encoding.DecodeUvarintAscending(encChildKey)
 		if err != nil {
 			return ChildKey{}, err
 		}


### PR DESCRIPTION
Change the encoding of partition keys from fixed width to variable width to be more consistent with other id encodings (e.g. table, key) and for improved legibility while debugging (keys with 0 bytes display as long strings of NULLs).

Epic: CRDB-42943