### PR TITLE
sql,ttl: skip next scheduled TTL job if job is still running

### DIFF
--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -2521,7 +2521,7 @@ func newRowLevelTTLScheduledJob(
 	sj.SetScheduleLabel(ttlbase.BuildScheduleLabel(tblDesc))
 	sj.SetOwner(owner)
 	sj.SetScheduleDetails(jobspb.ScheduleDetails{
-		Wait: jobspb.ScheduleDetails_WAIT,
+		Wait: jobspb.ScheduleDetails_SKIP,
 		// If a job fails, try again at the allocated cron time.
 		OnError:                jobspb.ScheduleDetails_RETRY_SCHED,
 		ClusterID:              clusterID,


### PR DESCRIPTION
See thread for more context: https://cockroachlabs.slack.com/archives/C028YAH6Y3V/p1734820744521159?thread_ts=1734551863.560679&cid=C028YAH6Y3V
Epic: None
Release note (ops change): If a row level TTL job is scheduled to run and the previous scheduled job for that table is still running, the scheduled run will now be skipped rather than waiting for the previous job to complete.