### PR TITLE
sql: Add RLS feature gate

### DIFF
--- a/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
@@ -1618,6 +1618,13 @@ func TestTenantLogic_routine_schema_change(
 	runLogicTest(t, "routine_schema_change")
 }
 
+func TestTenantLogic_row_level_security(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "row_level_security")
+}
+
 func TestTenantLogic_row_level_ttl(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/local-read-committed/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/local-read-committed/generated_test.go
@@ -1616,6 +1616,13 @@ func TestReadCommittedLogic_routine_schema_change(
 	runLogicTest(t, "routine_schema_change")
 }
 
+func TestReadCommittedLogic_row_level_security(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "row_level_security")
+}
+
 func TestReadCommittedLogic_row_level_ttl(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/local-repeatable-read/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/local-repeatable-read/generated_test.go
@@ -1609,6 +1609,13 @@ func TestRepeatableReadLogic_routine_schema_change(
 	runLogicTest(t, "routine_schema_change")
 }
 
+func TestRepeatableReadLogic_row_level_security(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "row_level_security")
+}
+
 func TestRepeatableReadLogic_row_level_ttl(
 	t *testing.T,
 ) {

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -3576,6 +3576,10 @@ func (m *sessionDataMutator) SetAlterColumnTypeGeneral(val bool) {
 	m.data.AlterColumnTypeGeneralEnabled = val
 }
 
+func (m *sessionDataMutator) SetRowLevelSecurity(val bool) {
+	m.data.RowLevelSecurityEnabled = val
+}
+
 func (m *sessionDataMutator) SetEnableSuperRegions(val bool) {
 	m.data.EnableSuperRegions = val
 }

--- a/pkg/sql/logictest/testdata/logic_test/row_level_security
+++ b/pkg/sql/logictest/testdata/logic_test/row_level_security
@@ -1,0 +1,7 @@
+statement ok
+SET enable_row_level_security = on;
+
+query T
+show session enable_row_level_security;
+----
+on

--- a/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
@@ -1585,6 +1585,13 @@ func TestLogic_routine_schema_change(
 	runLogicTest(t, "routine_schema_change")
 }
 
+func TestLogic_row_level_security(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "row_level_security")
+}
+
 func TestLogic_row_level_ttl(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
@@ -1585,6 +1585,13 @@ func TestLogic_routine_schema_change(
 	runLogicTest(t, "routine_schema_change")
 }
 
+func TestLogic_row_level_security(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "row_level_security")
+}
+
 func TestLogic_row_level_ttl(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist/generated_test.go
@@ -1599,6 +1599,13 @@ func TestLogic_routine_schema_change(
 	runLogicTest(t, "routine_schema_change")
 }
 
+func TestLogic_row_level_security(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "row_level_security")
+}
+
 func TestLogic_row_level_ttl(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-legacy-schema-changer/generated_test.go
+++ b/pkg/sql/logictest/tests/local-legacy-schema-changer/generated_test.go
@@ -1564,6 +1564,13 @@ func TestLogic_routine_schema_change(
 	runLogicTest(t, "routine_schema_change")
 }
 
+func TestLogic_row_level_security(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "row_level_security")
+}
+
 func TestLogic_row_level_ttl(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-mixed-24.3/generated_test.go
+++ b/pkg/sql/logictest/tests/local-mixed-24.3/generated_test.go
@@ -1585,6 +1585,13 @@ func TestLogic_routine_schema_change(
 	runLogicTest(t, "routine_schema_change")
 }
 
+func TestLogic_row_level_security(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "row_level_security")
+}
+
 func TestLogic_row_level_ttl(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/local-vec-off/generated_test.go
@@ -1599,6 +1599,13 @@ func TestLogic_routine_schema_change(
 	runLogicTest(t, "routine_schema_change")
 }
 
+func TestLogic_row_level_security(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "row_level_security")
+}
+
 func TestLogic_row_level_ttl(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local/generated_test.go
+++ b/pkg/sql/logictest/tests/local/generated_test.go
@@ -1767,6 +1767,13 @@ func TestLogic_routine_schema_change(
 	runLogicTest(t, "routine_schema_change")
 }
 
+func TestLogic_row_level_security(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "row_level_security")
+}
+
 func TestLogic_row_level_ttl(
 	t *testing.T,
 ) {

--- a/pkg/sql/sessiondatapb/local_only_session_data.proto
+++ b/pkg/sql/sessiondatapb/local_only_session_data.proto
@@ -101,9 +101,6 @@ message LocalOnlySessionData {
   // DisallowFullTableScans indicates whether queries that plan full table scans
   // should be rejected.
   bool disallow_full_table_scans = 26;
-  // AvoidFullTableScansInMutations indicates whether mutation queries that plan
-  // full table scans should be avoided.
-  bool avoid_full_table_scans_in_mutations = 151;
   // ImplicitSelectForUpdate is true if FOR UPDATE locking may be used during
   // the row-fetch phase of mutation statements.
   bool implicit_select_for_update = 27;
@@ -589,6 +586,11 @@ message LocalOnlySessionData {
   // mix-typed comparisons with VARCHAR types. See #137837, #133037, and
   // #132268.
   bool legacy_varchar_typing = 150;
+  // AvoidFullTableScansInMutations indicates whether mutation queries that plan
+  // full table scans should be avoided.
+  bool avoid_full_table_scans_in_mutations = 151;
+  // RowLevelSecurityEnabled indicates whether row level security is enabled
+  bool row_level_security_enabled = 152;
 
   ///////////////////////////////////////////////////////////////////////////
   // WARNING: consider whether a session parameter you're adding needs to  //

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -2005,6 +2005,24 @@ var varGen = map[string]sessionVar{
 		},
 	},
 
+	// CockroachDB extension.
+	`enable_row_level_security`: {
+		Hidden:       true,
+		GetStringVal: makePostgresBoolGetStringValFn(`enable_row_level_security`),
+		Set: func(_ context.Context, m sessionDataMutator, s string) error {
+			b, err := paramparse.ParseBoolVar("enable_row_level_security", s)
+			if err != nil {
+				return err
+			}
+			m.SetRowLevelSecurity(b)
+			return nil
+		},
+		Get: func(evalCtx *extendedEvalContext, _ *kv.Txn) (string, error) {
+			return formatBoolAsPostgresSetting(evalCtx.SessionData().RowLevelSecurityEnabled), nil
+		},
+		GlobalDefault: globalFalse,
+	},
+
 	// TODO(rytaft): remove this once unique without index constraints are fully
 	// supported.
 	`experimental_enable_unique_without_index_constraints`: {


### PR DESCRIPTION
The RLS feature is currently incomplete and thus we need to gate it. A session variable named enable_row_level_security has been added. It is marked as Hidden so it doesn't appear in docs or other SHOW interfaces.

Epic: CRDB-11724
Fixes: #136693
Release note: None