### PR TITLE
sql: setup http router after version initialization

### DIFF
--- a/pkg/cmd/roachtest/tests/registry.go
+++ b/pkg/cmd/roachtest/tests/registry.go
@@ -63,6 +63,7 @@ func RegisterTests(r registry.Registry) {
 	registerHibernate(r, hibernateOpts)
 	registerHibernate(r, hibernateSpatialOpts)
 	registerHotSpotSplits(r)
+	registerHTTPRestart(r)
 	registerImportCancellation(r)
 	registerImportDecommissioned(r)
 	registerImportMixedVersions(r)


### PR DESCRIPTION
Previously the http routes were set up after sql version initialization. As of #127170, the version initialization occurs in the sql server prestart, which occurs just after router setup. It became possible to hit the http routes before the version was set, leading to panics as the http routes rely on the sql version being set.

Epic: none
Fixes: #138342