### PR TITLE
release-24.1: backup: skip TestDataDriven tests under deadlock

### DIFF
--- a/pkg/ccl/backupccl/testgen/templates.go
+++ b/pkg/ccl/backupccl/testgen/templates.go
@@ -28,8 +28,8 @@ import (
 func TestDataDriven_{{.TestName}}(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	skip.UnderRace(t, "takes ~3mins to run"){{if eq .TestName "multiregion"}}
-	skip.UnderDeadlockWithIssue(t, 117927){{end}}
+	skip.UnderRace(t, "takes ~3mins to run")
+	skip.UnderDeadlock(t, "slows down test by 10 to 100x")
 
 	runTestDataDriven(t, "{{.TestFilePath}}")
 }


### PR DESCRIPTION
Backport 1/2 commits from #137829.

/cc @cockroachdb/release

---


Release note: none

Release justification: test only change