### PR TITLE
kv: conditionally handleReady after tick

### DIFF
--- a/pkg/kv/kvserver/store_raft.go
+++ b/pkg/kv/kvserver/store_raft.go
@@ -762,12 +762,12 @@ func (s *Store) processTick(_ context.Context, rangeID roachpb.RangeID) bool {
 	start := timeutil.Now()
 	ctx := r.raftCtx
 
-	exists, err := r.tick(ctx, livenessMap, ioThresholds)
+	processReady, err := r.tick(ctx, livenessMap, ioThresholds)
 	if err != nil {
 		log.Errorf(ctx, "%v", err)
 	}
 	s.metrics.RaftTickingDurationNanos.Inc(timeutil.Since(start).Nanoseconds())
-	return exists // ready
+	return processReady
 }
 
 func (s *Store) processRACv2PiggybackedAdmitted(ctx context.Context, rangeID roachpb.RangeID) {


### PR DESCRIPTION
Informs #133885.
Informs #133216.

This commit adjusts `Replica.tick` to check `RawNode.HasReady` when deciding whether a `Ready` struct should be processed (`Replica.handleRaftReady`) from the ticked replica. Previously, we would unconditionally pass through `Replica.handleRaftReady` after a tick, even if doing so was unnecessary and we knew ahead of time that we would hit this early return: https://github.com/cockroachdb/cockroach/blob/57aab736c34ce5dc7988bd53e0604fde48cef441/pkg/kv/kvserver/replica_raft.go#L1025

This was mostly harmless in the past with quiescence and a cheap short-circuit in `handleRaftReady`, but has become more problematic recently for the following three reasons:
1. Leader leases don't permit quiescence. We have some work planned to allow follower replicas to quiesce under a leader lease (see #133885), but even after that work, we likely won't allow quiescence for the leaseholder. This means that
2. `Replica.handleRaftReady` has been getting more expensive, even in the no-op case. This is because of work done in `Replica.updateProposalQuotaRaftMuLocked` and work done for replica admission control v2 (RACv2).
3. At some point in the future, we would like to revert 5e6698 and drop the raft tick interval back down to something like 200ms. This will allow us to address #133576 and further reduce failover times.

Release note: None