### PR TITLE
opt: optimize func dep calculations for tables with many indexes

### DIFF
--- a/pkg/sql/opt/memo/logical_props_builder.go
+++ b/pkg/sql/opt/memo/logical_props_builder.go
@@ -2013,6 +2013,12 @@ func MakeTableFuncDep(md *opt.Metadata, tabID opt.TableID) *props.FuncDepSet {
 		var keyCols opt.ColSet
 		index := tab.Index(i)
 
+		if !index.IsUnique() {
+			// A non-unique index won't add any additional information, since it
+			// relies on the PK columns to form a key.
+			continue
+		}
+
 		if index.IsInverted() {
 			// Skip inverted indexes for now.
 			continue

--- a/pkg/sql/opt/norm/testdata/rules/groupby
+++ b/pkg/sql/opt/norm/testdata/rules/groupby
@@ -1534,14 +1534,14 @@ SELECT min(f) FROM a GROUP BY i, s, k
 project
  ├── columns: min:8
  └── group-by (hash)
-      ├── columns: i:2!null s:4!null min:8
-      ├── grouping columns: i:2!null s:4!null
-      ├── key: (2,4)
-      ├── fd: (2,4)-->(8)
+      ├── columns: k:1!null min:8
+      ├── grouping columns: k:1!null
+      ├── key: (1)
+      ├── fd: (1)-->(8)
       ├── scan a
-      │    ├── columns: i:2!null f:3 s:4!null
-      │    ├── key: (2,4)
-      │    └── fd: (2,4)-->(3), (2,3)~~>(4)
+      │    ├── columns: k:1!null f:3
+      │    ├── key: (1)
+      │    └── fd: (1)-->(3)
       └── aggregations
            └── min [as=min:8, outer=(3)]
                 └── f:3


### PR DESCRIPTION
#### props: add fast path for ReduceCols

This commit adds a fast path to `FuncDepSet.ReduceCols`. If the FD set has
a strict key and the key is a subset of the given columns, the columns are
immediately reduced just to the key columns. From that point the columns may
be further reduced if the set has been updated since the key was originally
calculated. Note that changes had to be made to `MakeProduct` and `MakeApply`
to ensure that the original key was invalidated before new dependencies were
added to the set.

Epic: None

Release note: None

#### opt: optimize table func deps for non-unique indexes

When a table is referenced in a query, we build a func-dep set describing
the relationships between the table columns. Among other things, we use
the index key columns for this purpose. There is no benefit considering
non-unique indexes here, so this commit skips them to avoid the extra work.
This results in a performance improvement for queries against tables with
many non-unique indexes and many columns.

Epic: None

Release note: None