### PR TITLE
opt: optimize planning for queries with many columns

### DIFF
--- a/pkg/sql/opt/memo/expr.go
+++ b/pkg/sql/opt/memo/expr.go
@@ -999,7 +999,7 @@ func (lj *LookupJoinPrivate) LookupIndexPrefixIsEquatedWithColInColSet(
 	for i := range lj.LookupExpr {
 		props := lj.LookupExpr[i].ScalarProps()
 
-		equivCols := props.FuncDeps.ComputeEquivGroup(idxCol)
+		equivCols := props.FuncDeps.GetImmutableEquivGroup(idxCol)
 		if colSet.Intersects(equivCols) {
 			return true
 		}

--- a/pkg/sql/opt/memo/statistics_builder.go
+++ b/pkg/sql/opt/memo/statistics_builder.go
@@ -3940,19 +3940,23 @@ func (sb *statisticsBuilder) applyEquivalencies(
 	s *props.Statistics,
 ) {
 	equivReps.ForEach(func(i opt.ColumnID) {
-		equivGroup := filterFD.ComputeEquivGroup(i)
-		sb.updateDistinctNullCountsFromEquivalency(equivGroup, e, notNullCols, s)
+		immutableEquivGroup := filterFD.GetImmutableEquivGroup(i)
+		if immutableEquivGroup.Empty() {
+			// Trivial case: the column is equivalent only to itself.
+			immutableEquivGroup = opt.MakeColSet(i)
+		}
+		sb.updateDistinctNullCountsFromEquivalency(immutableEquivGroup, e, notNullCols, s)
 	})
 }
 
 func (sb *statisticsBuilder) updateDistinctNullCountsFromEquivalency(
-	equivGroup opt.ColSet, e RelExpr, notNullCols opt.ColSet, s *props.Statistics,
+	immutableEquivGroup opt.ColSet, e RelExpr, notNullCols opt.ColSet, s *props.Statistics,
 ) {
 	// Find the minimum distinct and null counts for all columns in this equivalency
 	// group.
 	minDistinctCount := s.RowCount
 	minNullCount := s.RowCount
-	equivGroup.ForEach(func(col opt.ColumnID) {
+	immutableEquivGroup.ForEach(func(col opt.ColumnID) {
 		colStat, ok := s.ColStats.LookupSingleton(col)
 		if !ok {
 			colSet := opt.MakeColSet(col)
@@ -3973,7 +3977,7 @@ func (sb *statisticsBuilder) updateDistinctNullCountsFromEquivalency(
 
 	// Set the distinct and null counts to the minimum for all columns in this
 	// equivalency group.
-	equivGroup.ForEach(func(col opt.ColumnID) {
+	immutableEquivGroup.ForEach(func(col opt.ColumnID) {
 		colStat, _ := s.ColStats.LookupSingleton(col)
 		colStat.DistinctCount = minDistinctCount
 		colStat.NullCount = minNullCount
@@ -4519,8 +4523,12 @@ func (sb *statisticsBuilder) selectivityFromEquivalencies(
 ) (selectivity props.Selectivity) {
 	selectivity = props.OneSelectivity
 	equivReps.ForEach(func(i opt.ColumnID) {
-		equivGroup := filterFD.ComputeEquivGroup(i)
-		selectivity.Multiply(sb.selectivityFromEquivalency(equivGroup, e, s))
+		immutableEquivGroup := filterFD.GetImmutableEquivGroup(i)
+		if immutableEquivGroup.Empty() {
+			// Trivial case: the column is equivalent only to itself.
+			immutableEquivGroup = opt.MakeColSet(i)
+		}
+		selectivity.Multiply(sb.selectivityFromEquivalency(immutableEquivGroup, e, s))
 	})
 
 	return selectivity
@@ -4703,7 +4711,7 @@ func addEqExprConjuncts(
 }
 
 func (sb *statisticsBuilder) selectivityFromEquivalency(
-	equivGroup opt.ColSet, e RelExpr, s *props.Statistics,
+	immutableEquivGroup opt.ColSet, e RelExpr, s *props.Statistics,
 ) (selectivity props.Selectivity) {
 	var derivedEquivCols opt.ColSet
 	if lookupJoinExpr, ok := e.(*LookupJoinExpr); ok {
@@ -4712,7 +4720,7 @@ func (sb *statisticsBuilder) selectivityFromEquivalency(
 	// Find the maximum input distinct count for all columns in this equivalency
 	// group.
 	maxDistinctCount := float64(0)
-	equivGroup.ForEach(func(col opt.ColumnID) {
+	immutableEquivGroup.ForEach(func(col opt.ColumnID) {
 		if derivedEquivCols.Contains(col) {
 			// Don't apply selectivity from derived equivalencies internally
 			// manufactured by lookup join solely to facilitate index lookups.
@@ -4747,9 +4755,13 @@ func (sb *statisticsBuilder) selectivityFromEquivalenciesSemiJoin(
 ) (selectivity props.Selectivity) {
 	selectivity = props.OneSelectivity
 	equivReps.ForEach(func(i opt.ColumnID) {
-		equivGroup := filterFD.ComputeEquivGroup(i)
+		immutableEquivGroup := filterFD.GetImmutableEquivGroup(i)
+		if immutableEquivGroup.Empty() {
+			// Trivial case: the column is equivalent only to itself.
+			immutableEquivGroup = opt.MakeColSet(i)
+		}
 		selectivity.Multiply(sb.selectivityFromEquivalencySemiJoin(
-			equivGroup, leftOutputCols, rightOutputCols, e, s,
+			immutableEquivGroup, leftOutputCols, rightOutputCols, e, s,
 		))
 	})
 
@@ -4757,13 +4769,13 @@ func (sb *statisticsBuilder) selectivityFromEquivalenciesSemiJoin(
 }
 
 func (sb *statisticsBuilder) selectivityFromEquivalencySemiJoin(
-	equivGroup, leftOutputCols, rightOutputCols opt.ColSet, e RelExpr, s *props.Statistics,
+	immutableEquivGroup, leftOutputCols, rightOutputCols opt.ColSet, e RelExpr, s *props.Statistics,
 ) (selectivity props.Selectivity) {
 	// Find the minimum (maximum) input distinct count for all columns in this
 	// equivalency group from the right (left).
 	minDistinctCountRight := math.MaxFloat64
 	maxDistinctCountLeft := float64(0)
-	equivGroup.ForEach(func(col opt.ColumnID) {
+	immutableEquivGroup.ForEach(func(col opt.ColumnID) {
 		// If any of the distinct counts were updated by the filter, we want to use
 		// the updated value.
 		colStat, ok := s.ColStats.LookupSingleton(col)

--- a/pkg/sql/opt/norm/decorrelate_funcs.go
+++ b/pkg/sql/opt/norm/decorrelate_funcs.go
@@ -1363,7 +1363,8 @@ func (c *CustomFuncs) TryRemapOuterCols(
 		// substituteCols is the set of input columns for which it may be possible to
 		// push a filter constraining the column to be equal to an outer column.
 		// Doing so would allow the column to be substituted for the outer column.
-		substituteCols := expr.Relational().FuncDeps.ComputeEquivGroup(col)
+		substituteCols := opt.MakeColSet(col)
+		substituteCols = expr.Relational().FuncDeps.ComputeEquivClosureNoCopy(substituteCols)
 		for i := range filters {
 			// ComputeEquivClosureNoCopy is ok here because ComputeEquivGroup builds
 			// a new ColSet.

--- a/pkg/sql/opt/norm/join_funcs.go
+++ b/pkg/sql/opt/norm/join_funcs.go
@@ -419,20 +419,20 @@ func (c *CustomFuncs) MapJoinOpFilter(
 func (c *CustomFuncs) GetEquivColsWithEquivType(
 	col opt.ColumnID, equivFD props.FuncDepSet, allowCompositeEncoding bool,
 ) opt.ColSet {
-	var res opt.ColSet
+	// The column is always equivalent to itself.
+	res := opt.MakeColSet(col)
 	colType := c.f.Metadata().ColumnMeta(col).Type
 
 	// Don't bother looking for equivalent columns if colType has a composite
 	// key encoding.
 	if !allowCompositeEncoding && colinfo.CanHaveCompositeKeyEncoding(colType) {
-		res.Add(col)
 		return res
 	}
 
 	// Compute all equivalent columns.
-	eqCols := equivFD.ComputeEquivGroup(col)
+	immutableEquivCols := equivFD.GetImmutableEquivGroup(col)
 
-	eqCols.ForEach(func(i opt.ColumnID) {
+	immutableEquivCols.ForEach(func(i opt.ColumnID) {
 		// Only include columns that have the same type as col.
 		eqColType := c.f.Metadata().ColumnMeta(i).Type
 		if colType.Equivalent(eqColType) {

--- a/pkg/sql/opt/ordering/ordering.go
+++ b/pkg/sql/opt/ordering/ordering.go
@@ -488,7 +488,7 @@ func checkRequired(expr memo.RelExpr, required *props.OrderingChoice) {
 	// Verify that columns in a column group are equivalent.
 	for i := range required.Columns {
 		c := &required.Columns[i]
-		if !c.Group.SubsetOf(rel.FuncDeps.ComputeEquivGroup(c.AnyID())) && !rel.Cardinality.IsZero() {
+		if !rel.FuncDeps.AreAllColsEquiv(c.Group) && !rel.Cardinality.IsZero() {
 			panic(errors.AssertionFailedf(
 				"ordering column group %s contains non-equivalent columns (op %s)",
 				c.Group, expr.Op(),

--- a/pkg/sql/opt/ordering/select.go
+++ b/pkg/sql/opt/ordering/select.go
@@ -70,13 +70,19 @@ func trimColumnGroups(required *props.OrderingChoice, fds *props.FuncDepSet) pro
 	copied := false
 	for i := range res.Columns {
 		c := &res.Columns[i]
-		eqGroup := fds.ComputeEquivGroup(c.AnyID())
-		if !c.Group.SubsetOf(eqGroup) {
+		if !fds.AreAllColsEquiv(c.Group) {
 			if !copied {
 				res = res.Copy()
 				copied = true
 			}
-			res.Columns[i].Group = c.Group.Intersection(eqGroup)
+			anyCol := c.AnyID()
+			immutableEquivCols := fds.GetImmutableEquivGroup(anyCol)
+			if immutableEquivCols.Empty() {
+				// The column is equal only to itself.
+				res.Columns[i].Group = opt.MakeColSet(anyCol)
+			} else {
+				res.Columns[i].Group = c.Group.Intersection(immutableEquivCols)
+			}
 		}
 	}
 	return res

--- a/pkg/sql/opt/props/equiv_set_test.go
+++ b/pkg/sql/opt/props/equiv_set_test.go
@@ -217,6 +217,44 @@ func TestEquivSet(t *testing.T) {
 		require.False(t, equiv4.ContainsCol(7))
 	})
 
+	t.Run("Intersects", func(t *testing.T) {
+		require.False(t, emptyEquiv.Intersects(c(1)))
+		require.True(t, equiv1.Intersects(c(1)))
+		require.True(t, equiv2.Intersects(c(1)))
+		require.True(t, equiv3.Intersects(c(1)))
+		require.True(t, equiv4.Intersects(c(1)))
+
+		require.False(t, emptyEquiv.Intersects(c(3)))
+		require.False(t, equiv1.Intersects(c(3)))
+		require.True(t, equiv2.Intersects(c(3)))
+		require.True(t, equiv3.Intersects(c(3)))
+		require.True(t, equiv4.Intersects(c(3)))
+
+		require.False(t, emptyEquiv.Intersects(c(5)))
+		require.False(t, equiv1.Intersects(c(5)))
+		require.False(t, equiv2.Intersects(c(5)))
+		require.True(t, equiv3.Intersects(c(5)))
+		require.False(t, equiv4.Intersects(c(5)))
+
+		require.False(t, emptyEquiv.Intersects(c(7)))
+		require.False(t, equiv1.Intersects(c(7)))
+		require.False(t, equiv2.Intersects(c(7)))
+		require.False(t, equiv3.Intersects(c(7)))
+		require.False(t, equiv4.Intersects(c(7)))
+
+		require.False(t, emptyEquiv.Intersects(c(3, 5)))
+		require.False(t, equiv1.Intersects(c(3, 5)))
+		require.True(t, equiv2.Intersects(c(3, 5)))
+		require.True(t, equiv3.Intersects(c(3, 5)))
+		require.True(t, equiv4.Intersects(c(3, 5)))
+
+		require.False(t, emptyEquiv.Intersects(c(5, 7)))
+		require.False(t, equiv1.Intersects(c(5, 7)))
+		require.False(t, equiv2.Intersects(c(5, 7)))
+		require.True(t, equiv3.Intersects(c(5, 7)))
+		require.False(t, equiv4.Intersects(c(5, 7)))
+	})
+
 	t.Run("AreColsEquiv", func(t *testing.T) {
 		require.True(t, emptyEquiv.AreColsEquiv(1, 1))
 		require.True(t, equiv1.AreColsEquiv(1, 1))
@@ -291,6 +329,106 @@ func TestEquivSet(t *testing.T) {
 		require.False(t, equiv2.AreAllColsEquiv(c(7, 8)))
 		require.False(t, equiv3.AreAllColsEquiv(c(7, 8)))
 		require.False(t, equiv4.AreAllColsEquiv(c(7, 8)))
+	})
+
+	t.Run("ColsAreEquivClosure", func(t *testing.T) {
+		require.True(t, emptyEquiv.ColsAreEquivClosure(c(1)))
+		require.False(t, equiv1.ColsAreEquivClosure(c(1)))
+		require.False(t, equiv2.ColsAreEquivClosure(c(1)))
+		require.False(t, equiv3.ColsAreEquivClosure(c(1)))
+		require.False(t, equiv4.ColsAreEquivClosure(c(1)))
+
+		require.True(t, emptyEquiv.ColsAreEquivClosure(c(3)))
+		require.True(t, equiv1.ColsAreEquivClosure(c(3)))
+		require.False(t, equiv2.ColsAreEquivClosure(c(3)))
+		require.False(t, equiv3.ColsAreEquivClosure(c(3)))
+		require.False(t, equiv4.ColsAreEquivClosure(c(3)))
+
+		require.True(t, emptyEquiv.ColsAreEquivClosure(c(7)))
+		require.True(t, equiv1.ColsAreEquivClosure(c(7)))
+		require.True(t, equiv2.ColsAreEquivClosure(c(7)))
+		require.True(t, equiv3.ColsAreEquivClosure(c(7)))
+		require.True(t, equiv4.ColsAreEquivClosure(c(7)))
+
+		require.True(t, emptyEquiv.ColsAreEquivClosure(c(1, 2)))
+		require.True(t, equiv1.ColsAreEquivClosure(c(1, 2)))
+		require.True(t, equiv2.ColsAreEquivClosure(c(1, 2)))
+		require.True(t, equiv3.ColsAreEquivClosure(c(1, 2)))
+		require.False(t, equiv4.ColsAreEquivClosure(c(1, 2)))
+
+		require.True(t, emptyEquiv.ColsAreEquivClosure(c(3, 4)))
+		require.True(t, equiv1.ColsAreEquivClosure(c(3, 4)))
+		require.True(t, equiv2.ColsAreEquivClosure(c(3, 4)))
+		require.True(t, equiv3.ColsAreEquivClosure(c(3, 4)))
+		require.False(t, equiv4.ColsAreEquivClosure(c(3, 4)))
+
+		require.True(t, emptyEquiv.ColsAreEquivClosure(c(5, 6)))
+		require.True(t, equiv1.ColsAreEquivClosure(c(5, 6)))
+		require.True(t, equiv2.ColsAreEquivClosure(c(5, 6)))
+		require.True(t, equiv3.ColsAreEquivClosure(c(5, 6)))
+		require.True(t, equiv4.ColsAreEquivClosure(c(5, 6)))
+
+		require.True(t, emptyEquiv.ColsAreEquivClosure(c(1, 2, 3, 4)))
+		require.True(t, equiv1.ColsAreEquivClosure(c(1, 2, 3, 4)))
+		require.True(t, equiv2.ColsAreEquivClosure(c(1, 2, 3, 4)))
+		require.True(t, equiv3.ColsAreEquivClosure(c(1, 2, 3, 4)))
+		require.True(t, equiv4.ColsAreEquivClosure(c(1, 2, 3, 4)))
+
+		require.True(t, emptyEquiv.ColsAreEquivClosure(c(1, 2, 3)))
+		require.True(t, equiv1.ColsAreEquivClosure(c(1, 2, 3)))
+		require.False(t, equiv2.ColsAreEquivClosure(c(1, 2, 3)))
+		require.False(t, equiv3.ColsAreEquivClosure(c(1, 2, 3)))
+		require.False(t, equiv4.ColsAreEquivClosure(c(1, 2, 3)))
+	})
+
+	t.Run("ColsAreEquivGroup", func(t *testing.T) {
+		require.True(t, emptyEquiv.ColsAreEquivGroup(c(1)))
+		require.False(t, equiv1.ColsAreEquivGroup(c(1)))
+		require.False(t, equiv2.ColsAreEquivGroup(c(1)))
+		require.False(t, equiv3.ColsAreEquivGroup(c(1)))
+		require.False(t, equiv4.ColsAreEquivGroup(c(1)))
+
+		require.True(t, emptyEquiv.ColsAreEquivGroup(c(3)))
+		require.True(t, equiv1.ColsAreEquivGroup(c(3)))
+		require.False(t, equiv2.ColsAreEquivGroup(c(3)))
+		require.False(t, equiv3.ColsAreEquivGroup(c(3)))
+		require.False(t, equiv4.ColsAreEquivGroup(c(3)))
+
+		require.True(t, emptyEquiv.ColsAreEquivGroup(c(7)))
+		require.True(t, equiv1.ColsAreEquivGroup(c(7)))
+		require.True(t, equiv2.ColsAreEquivGroup(c(7)))
+		require.True(t, equiv3.ColsAreEquivGroup(c(7)))
+		require.True(t, equiv4.ColsAreEquivGroup(c(7)))
+
+		require.False(t, emptyEquiv.ColsAreEquivGroup(c(1, 2)))
+		require.True(t, equiv1.ColsAreEquivGroup(c(1, 2)))
+		require.True(t, equiv2.ColsAreEquivGroup(c(1, 2)))
+		require.True(t, equiv3.ColsAreEquivGroup(c(1, 2)))
+		require.False(t, equiv4.ColsAreEquivGroup(c(1, 2)))
+
+		require.False(t, emptyEquiv.ColsAreEquivGroup(c(3, 4)))
+		require.False(t, equiv1.ColsAreEquivGroup(c(3, 4)))
+		require.True(t, equiv2.ColsAreEquivGroup(c(3, 4)))
+		require.True(t, equiv3.ColsAreEquivGroup(c(3, 4)))
+		require.False(t, equiv4.ColsAreEquivGroup(c(3, 4)))
+
+		require.False(t, emptyEquiv.ColsAreEquivGroup(c(5, 6)))
+		require.False(t, equiv1.ColsAreEquivGroup(c(5, 6)))
+		require.False(t, equiv2.ColsAreEquivGroup(c(5, 6)))
+		require.True(t, equiv3.ColsAreEquivGroup(c(5, 6)))
+		require.False(t, equiv4.ColsAreEquivGroup(c(5, 6)))
+
+		require.False(t, emptyEquiv.ColsAreEquivGroup(c(1, 2, 3, 4)))
+		require.False(t, equiv1.ColsAreEquivGroup(c(1, 2, 3, 4)))
+		require.False(t, equiv2.ColsAreEquivGroup(c(1, 2, 3, 4)))
+		require.False(t, equiv3.ColsAreEquivGroup(c(1, 2, 3, 4)))
+		require.True(t, equiv4.ColsAreEquivGroup(c(1, 2, 3, 4)))
+
+		require.False(t, emptyEquiv.ColsAreEquivGroup(c(1, 2, 3)))
+		require.False(t, equiv1.ColsAreEquivGroup(c(1, 2, 3)))
+		require.False(t, equiv2.ColsAreEquivGroup(c(1, 2, 3)))
+		require.False(t, equiv3.ColsAreEquivGroup(c(1, 2, 3)))
+		require.False(t, equiv4.ColsAreEquivGroup(c(1, 2, 3)))
 	})
 
 	t.Run("ComputeEquivClosureNoCopy", func(t *testing.T) {

--- a/pkg/sql/opt/props/func_dep.go
+++ b/pkg/sql/opt/props/func_dep.go
@@ -716,6 +716,18 @@ func (f *FuncDepSet) AreColsEquiv(col1, col2 opt.ColumnID) bool {
 	return f.equiv.AreColsEquiv(col1, col2)
 }
 
+// AreAllColsEquiv returns true if all the given columns are equivalent.
+func (f *FuncDepSet) AreAllColsEquiv(cols opt.ColSet) bool {
+	return f.equiv.AreAllColsEquiv(cols)
+}
+
+// ColsAreEquivGroup returns true if the columns within the given ColSet
+// constitute a single equiv group. In other words, all columns are equivalent
+// to each other, and no column is equivalent to any column outside of the set.
+func (f *FuncDepSet) ColsAreEquivGroup(cols opt.ColSet) bool {
+	return f.equiv.ColsAreEquivGroup(cols)
+}
+
 // ComputeEquivClosure returns the equivalence closure of the given columns. The
 // closure includes the input columns plus all columns that are equivalent to
 // any of these columns, either directly or indirectly. For example:
@@ -1567,10 +1579,13 @@ func (f *FuncDepSet) EquivReps() opt.ColSet {
 	return reps
 }
 
-// ComputeEquivGroup returns the group of columns that are equivalent to the
-// given column. See ComputeEquivClosure for more details.
-func (f *FuncDepSet) ComputeEquivGroup(rep opt.ColumnID) opt.ColSet {
-	return f.ComputeEquivClosureNoCopy(opt.MakeColSet(rep))
+// GetImmutableEquivGroup returns the set of columns that are equivalent to the
+// given column. If the column is not part of any equivalence group, it returns\
+// the empty set.
+//
+// NOTE: The returned ColSet *must* be treated as immutable if non-empty.
+func (f *FuncDepSet) GetImmutableEquivGroup(col opt.ColumnID) opt.ColSet {
+	return f.equiv.GroupForCol(col)
 }
 
 // ensureKeyClosure checks whether the closure for this FD set's key (if there

--- a/pkg/sql/opt/props/ordering_choice.go
+++ b/pkg/sql/opt/props/ordering_choice.go
@@ -654,13 +654,12 @@ func (oc *OrderingChoice) AppendCol(id opt.ColumnID, descending bool) {
 // Copy returns a complete copy of this instance, with a private version of the
 // ordering column slice.
 func (oc *OrderingChoice) Copy() OrderingChoice {
+	// NOTE: since the Optional and Group ColSets are immutable, we can just
+	// shallow-copy them.
 	var other OrderingChoice
-	other.Optional = oc.Optional.Copy()
+	other.Optional = oc.Optional
 	other.Columns = make([]OrderingColumnChoice, len(oc.Columns))
 	copy(other.Columns, oc.Columns)
-	for i := range other.Columns {
-		other.Columns[i].Group = other.Columns[i].Group.Copy()
-	}
 	return other
 }
 

--- a/pkg/sql/opt/xform/join_order_builder.go
+++ b/pkg/sql/opt/xform/join_order_builder.go
@@ -472,7 +472,7 @@ func (jb *JoinOrderBuilder) ensureClosure(join memo.RelExpr) {
 	reps := equivFDs.EquivReps()
 	for col, ok := reps.Next(0); ok; col, ok = reps.Next(col + 1) {
 		// Get all columns which are known to be equal to this column.
-		equivGroup := equivFDs.ComputeEquivGroup(col)
+		equivGroup := equivFDs.GetImmutableEquivGroup(col)
 		if !equivGroup.Intersects(join.Relational().NotNullCols) {
 			// If the equivalent columns are nullable, it would be invalid to add an
 			// equality edge because SQL equality rejects NULL values.


### PR DESCRIPTION
#### optbuilder: optimize for handling many columns

This commit makes two changes to the optbuilder logic to reduce allocations
when a query contains many (e.g. thousands) of columns:
1. `buildJoin` reuses the input `cols` slice.
2. `scope.FindSourceMatchingName` now avoids allocating a map to de-duplicate
   data source names, and now tracks only the last data source name.

Release note: None

#### props: add methods to EquivGroups

This commit adds the following methods to `EquivGroups` to enable the
optimizations in following commits:
* `Intersects` allows callers to determine when any columns from a given
  set are contained in an equiv group.
* `ColsAreEquivClosure` returns true if the given `ColSet` is its own
  equivalence closure. In other words, there are no additional columns
  that are equal to any of the given columns.
* `ColsAreEquivGroup` returns true if the given `ColSet` is equal to a
  single equivalence group. This means that all columns are equivalent
  to one another, and there are no other columns that are equal to any
  of the given columns.

Epic: None

Release note: None

#### opt/props: avoid unnecessary work in FD calculation

This commit adds some fast paths during FD calculation to avoid calling
`tryToReduceKey` when it can be proven that the key will not be reduced.
This has a modest effect for queries with many columns, since it avoids
spilling `ColSets` to the heap during expensive calls to `tryToReduceKey`.

Release note: None

#### opt: avoid copies when computing a column's equiv group

This commit replaces `FuncDepSet.ComputeEquivGroup` with a new method
`GetImmutableEquivGroup`, which directly returns the equiv group (if any)
for the given column. This requires care to be taken to avoid mutating the
returned set, but avoids unnecessary copies in common cases.

Epic: None

Release note: None

#### opt: shallow copy ColSets in OrderingChoice.Copy()

This commit removes the unnecessary deep copies in `OrderingChoice.Copy()`.
They were unnecessary because the `Optional` and `Group` column sets are
considered immutable once the `OrderingChoice` is constructed.

Epic: None

Release note: None

#### opt: optimize Simplify and CanSimplify ordering methods

This commit optimizes `OrderingChoice` methods `Simplify` and `CanSimplify`
to avoid some unnecessary allocations. Some new methods `ColsAreClosure`
and `ComputeClosureNoCopy` are introduced for func deps to enable the
optimization.

Epic: None

Release note: None