### PR TITLE
roachprod: fix lock usage in ListLoadBalancers

### DIFF
--- a/pkg/roachprod/install/services.go
+++ b/pkg/roachprod/install/services.go
@@ -261,7 +261,8 @@ func (c *SyncedCluster) ListLoadBalancers(l *logger.Logger) ([]vm.ServiceAddress
 		if listErr != nil {
 			return listErr
 		}
-		defer lock.Lock()
+		lock.Lock()
+		defer lock.Unlock()
 		allAddresses = append(allAddresses, addresses...)
 		return nil
 	})


### PR DESCRIPTION
Updated the lock usage in ListLoadBalancers to prevent the roachprod start command from hanging during certificate generation when cluster VMs are distributed across multiple cloud providers. Replaced `defer lock.Lock()` with `lock.Lock()` and `defer lock.Unlock()`.

Epic: none

Release note: None