### PR TITLE
roachtest: task error groups

### DIFF
--- a/pkg/cmd/roachtest/cluster_test.go
+++ b/pkg/cmd/roachtest/cluster_test.go
@@ -144,7 +144,11 @@ func (t testWrapper) Go(_ task.Func, _ ...task.Option) {
 	panic("implement me")
 }
 
-func (t testWrapper) NewGroup() task.Group {
+func (t testWrapper) NewGroup(_ ...task.Option) task.Group {
+	panic("implement me")
+}
+
+func (t testWrapper) NewErrorGroup(_ ...task.Option) task.ErrorGroup {
 	panic("implement me")
 }
 

--- a/pkg/cmd/roachtest/clusterstats/mock_test_generated_test.go
+++ b/pkg/cmd/roachtest/clusterstats/mock_test_generated_test.go
@@ -343,18 +343,40 @@ func (mr *MockTestMockRecorder) Name() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Name", reflect.TypeOf((*MockTest)(nil).Name))
 }
 
-// NewGroup mocks base method.
-func (m *MockTest) NewGroup() task.Group {
+// NewErrorGroup mocks base method.
+func (m *MockTest) NewErrorGroup(arg0 ...task.Option) task.ErrorGroup {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "NewGroup")
+	varargs := []interface{}{}
+	for _, a := range arg0 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "NewErrorGroup", varargs...)
+	ret0, _ := ret[0].(task.ErrorGroup)
+	return ret0
+}
+
+// NewErrorGroup indicates an expected call of NewErrorGroup.
+func (mr *MockTestMockRecorder) NewErrorGroup(arg0 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewErrorGroup", reflect.TypeOf((*MockTest)(nil).NewErrorGroup), arg0...)
+}
+
+// NewGroup mocks base method.
+func (m *MockTest) NewGroup(arg0 ...task.Option) task.Group {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{}
+	for _, a := range arg0 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "NewGroup", varargs...)
 	ret0, _ := ret[0].(task.Group)
 	return ret0
 }
 
 // NewGroup indicates an expected call of NewGroup.
-func (mr *MockTestMockRecorder) NewGroup() *gomock.Call {
+func (mr *MockTestMockRecorder) NewGroup(arg0 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewGroup", reflect.TypeOf((*MockTest)(nil).NewGroup))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewGroup", reflect.TypeOf((*MockTest)(nil).NewGroup), arg0...)
 }
 
 // PerfArtifactsDir mocks base method.

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/helper.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/helper.go
@@ -263,8 +263,13 @@ func (h *Helper) Go(fn task.Func, opts ...task.Option) {
 }
 
 // NewGroup implements the Group interface.
-func (h *Helper) NewGroup() task.Group {
-	return h.runner.background.NewGroup(h.defaultTaskOptions()...)
+func (h *Helper) NewGroup(opts ...task.Option) task.Group {
+	return h.runner.background.NewGroup(task.OptionList(h.defaultTaskOptions()...), task.OptionList(opts...))
+}
+
+// NewErrorGroup implements the Group interface.
+func (h *Helper) NewErrorGroup(opts ...task.Option) task.ErrorGroup {
+	return h.runner.background.NewErrorGroup(task.OptionList(h.defaultTaskOptions()...), task.OptionList(opts...))
 }
 
 // GoCommand has the same semantics of `GoWithCancel()`; the command passed will

--- a/pkg/cmd/roachtest/roachtestutil/task/BUILD.bazel
+++ b/pkg/cmd/roachtest/roachtestutil/task/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
         "//pkg/roachprod/logger",
         "//pkg/util/ctxgroup",
         "//pkg/util/syncutil",
+        "@com_github_cockroachdb_errors//:errors",
     ],
 )
 

--- a/pkg/cmd/roachtest/roachtestutil/task/group.go
+++ b/pkg/cmd/roachtest/roachtestutil/task/group.go
@@ -10,10 +10,23 @@ package task
 // complete.
 type Group interface {
 	Tasker
-	// Wait waits for all tasks in the group to complete. Errors from tasks are reported to the
-	// test framework automatically and will cause the test to fail, which also
-	// cancels the context passed to the group.
+	// Wait waits for all tasks in the group to complete. Errors from tasks are
+	// reported to the test framework automatically and will cause the test to
+	// fail, which also cancels the context passed to the group.
 	Wait()
+}
+
+// ErrorGroup is an interface for managing a group of tasks, similar to Group,
+// however ErrorGroup will not fail the test if a task returns an error
+// (including panics), but will still cancel the context passed to the group.
+// Errors are returned through the WaitE method.
+type ErrorGroup interface {
+	Tasker
+	// WaitE waits for all tasks in the group to complete. Any errors from tasks
+	// are returned and will cancel the context passed to the group. If the group
+	// contains multiple subgroups, the errors from the groups will be combined
+	// into a single error.
+	WaitE() error
 }
 
 // GroupProvider is an interface for creating new Group(s). Generally, the test
@@ -22,4 +35,7 @@ type GroupProvider interface {
 	// NewGroup creates a new Group to manage tasks. Any options passed to this
 	// function will be applied to all tasks started by the group.
 	NewGroup(opts ...Option) Group
+	// NewErrorGroup creates a new ErrorGroup to manage tasks, similar to
+	// NewGroup.
+	NewErrorGroup(opts ...Option) ErrorGroup
 }

--- a/pkg/cmd/roachtest/roachtestutil/task/options.go
+++ b/pkg/cmd/roachtest/roachtestutil/task/options.go
@@ -15,10 +15,12 @@ type (
 	// Options is a struct that contains the options that can be passed when
 	// starting a task.
 	Options struct {
-		Name         string
-		L            LogSupplierFunc
-		PanicHandler PanicHandlerFunc
-		ErrorHandler ErrorHandlerFunc
+		Name             string
+		L                LogSupplierFunc
+		PanicHandler     PanicHandlerFunc
+		ErrorHandler     ErrorHandlerFunc
+		DisableReporting bool
+		Context          context.Context
 	}
 
 	// LogSupplierFunc is a function that supplies the task with a logger.
@@ -74,6 +76,22 @@ func PanicHandler(handler PanicHandlerFunc) Option {
 func ErrorHandler(handler ErrorHandlerFunc) Option {
 	return func(result *Options) {
 		result.ErrorHandler = handler
+	}
+}
+
+// DisableReporting is an option that disables reporting errors and panics to the
+// test framework.
+func DisableReporting() Option {
+	return func(result *Options) {
+		result.DisableReporting = true
+	}
+}
+
+// WithContext is an option that sets the context that will be used by the task.
+// It will override the context passed to the task manager.
+func WithContext(ctx context.Context) Option {
+	return func(result *Options) {
+		result.Context = ctx
 	}
 }
 

--- a/pkg/cmd/roachtest/test/test_interface.go
+++ b/pkg/cmd/roachtest/test/test_interface.go
@@ -83,7 +83,8 @@ type Test interface {
 
 	Go(task.Func, ...task.Option)
 	GoWithCancel(task.Func, ...task.Option) context.CancelFunc
-	NewGroup() task.Group
+	NewGroup(...task.Option) task.Group
+	NewErrorGroup(...task.Option) task.ErrorGroup
 
 	// DeprecatedWorkload returns the path to the workload binary.
 	// Don't use this, invoke `./cockroach workload` instead.

--- a/pkg/cmd/roachtest/test_impl.go
+++ b/pkg/cmd/roachtest/test_impl.go
@@ -711,8 +711,13 @@ func (t *testImpl) Go(fn task.Func, opts ...task.Option) {
 }
 
 // NewGroup starts a new task group.
-func (t *testImpl) NewGroup() task.Group {
-	return t.taskManager.NewGroup(defaultTaskOptions()...)
+func (t *testImpl) NewGroup(opts ...task.Option) task.Group {
+	return t.taskManager.NewGroup(task.OptionList(defaultTaskOptions()...), task.OptionList(opts...))
+}
+
+// NewErrorGroup starts a new task error group.
+func (t *testImpl) NewErrorGroup(opts ...task.Option) task.ErrorGroup {
+	return t.taskManager.NewErrorGroup(task.OptionList(defaultTaskOptions()...), task.OptionList(opts...))
 }
 
 // TeamCityEscape escapes a string for use as <value> in a key='<value>' attribute

--- a/pkg/cmd/roachtest/tests/BUILD.bazel
+++ b/pkg/cmd/roachtest/tests/BUILD.bazel
@@ -330,7 +330,6 @@ go_library(
         "@org_golang_google_protobuf//proto",
         "@org_golang_x_exp//maps",
         "@org_golang_x_oauth2//clientcredentials",
-        "@org_golang_x_sync//errgroup",
     ],
 )
 

--- a/pkg/cmd/roachtest/tests/decommission.go
+++ b/pkg/cmd/roachtest/tests/decommission.go
@@ -21,8 +21,10 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil/task"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
@@ -30,7 +32,6 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/kr/pretty"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/sync/errgroup"
 )
 
 // shudownGracePeriod is the default grace period (in seconds) that we
@@ -179,10 +180,9 @@ func runDrainAndDecommission(
 		require.NoError(t, err)
 	}
 
-	var m *errgroup.Group
-	m, ctx = errgroup.WithContext(ctx)
+	m := t.NewGroup(task.WithContext(ctx))
 	m.Go(
-		func() error {
+		func(ctx context.Context, l *logger.Logger) error {
 			return c.RunE(ctx, option.WithNodes(c.Node(pinnedNode)),
 				fmt.Sprintf("./cockroach workload run kv --max-rate 500 --tolerate-errors --duration=%s {pgurl:1-%d}",
 					duration.String(), nodes-4,
@@ -197,7 +197,7 @@ func runDrainAndDecommission(
 	// Drain the last 3 nodes from the cluster.
 	for nodeID := nodes - 2; nodeID <= nodes; nodeID++ {
 		id := nodeID
-		m.Go(func() error {
+		m.Go(func(ctx context.Context, l *logger.Logger) error {
 			drain := func(id int) error {
 				t.Status(fmt.Sprintf("draining node %d", id))
 				return c.RunE(ctx, option.WithNodes(c.Node(id)), fmt.Sprintf("./cockroach node drain --certs-dir=%s --port={pgport:%d}", install.CockroachNodeCertsDir, id))
@@ -209,7 +209,7 @@ func runDrainAndDecommission(
 	// the draining status of the two nodes we just drained.
 	time.Sleep(30 * time.Second)
 
-	m.Go(func() error {
+	m.Go(func(ctx context.Context, l *logger.Logger) error {
 		// Decommission the fourth-to-last node from the cluster.
 		id := nodes - 3
 		decom := func(id int) error {
@@ -218,9 +218,7 @@ func runDrainAndDecommission(
 		}
 		return decom(id)
 	})
-	if err := m.Wait(); err != nil {
-		t.Fatal(err)
-	}
+	m.Wait()
 }
 
 // runDecommission decommissions and wipes nodes in a cluster repeatedly,
@@ -275,8 +273,8 @@ func runDecommission(
 		fmt.Sprintf("./cockroach workload run kv --max-rate 500 --tolerate-errors --duration=%s {pgurl:1-%d}", duration.String(), nodes),
 	}
 
-	run := func(stmt string) {
-		db := c.Conn(ctx, t.L(), pinnedNode)
+	run := func(l *logger.Logger, stmt string) {
+		db := c.Conn(ctx, l, pinnedNode)
 		defer db.Close()
 
 		t.Status(stmt)
@@ -284,21 +282,20 @@ func runDecommission(
 		if err != nil {
 			t.Fatal(err)
 		}
-		t.L().Printf("run: %s\n", stmt)
+		l.Printf("run: %s\n", stmt)
 	}
 
-	var m *errgroup.Group // see comment in version.go
-	m, ctx = errgroup.WithContext(ctx)
-	for _, cmd := range workloads {
+	m := t.NewGroup(task.WithContext(ctx)) // see comment in version.go
+	for idx, cmd := range workloads {
 		cmd := cmd // copy is important for goroutine
-		m.Go(func() error {
+		m.Go(func(ctx context.Context, _ *logger.Logger) error {
 			return c.RunE(ctx, option.WithNodes(c.Node(pinnedNode)), cmd)
-		})
+		}, task.Name(fmt.Sprintf("workload-%d", idx)))
 	}
 
 	stopOpts := option.NewStopOpts(option.Graceful(shutdownGracePeriod))
 
-	m.Go(func() error {
+	m.Go(func(ctx context.Context, l *logger.Logger) error {
 		tBegin, whileDown := timeutil.Now(), true
 		node := nodes
 		for timeutil.Since(tBegin) <= duration {
@@ -317,18 +314,18 @@ func runDecommission(
 				return err
 			}
 
-			run(fmt.Sprintf(`ALTER RANGE default CONFIGURE ZONE = 'constraints: {"+node%d"}'`, node))
+			run(l, fmt.Sprintf(`ALTER RANGE default CONFIGURE ZONE = 'constraints: {"+node%d"}'`, node))
 			if err := h.waitUpReplicated(ctx, nodeID, node, "kv"); err != nil {
 				return err
 			}
 
 			if whileDown {
-				if err := c.StopE(ctx, t.L(), stopOpts, c.Node(node)); err != nil {
+				if err := c.StopE(ctx, l, stopOpts, c.Node(node)); err != nil {
 					return err
 				}
 			}
 
-			run(fmt.Sprintf(`ALTER RANGE default CONFIGURE ZONE = 'constraints: {"-node%d"}'`, node))
+			run(l, fmt.Sprintf(`ALTER RANGE default CONFIGURE ZONE = 'constraints: {"-node%d"}'`, node))
 
 			targetNodeList := option.NodeListOption{nodeID}
 
@@ -348,7 +345,7 @@ func runDecommission(
 			}
 
 			if !whileDown {
-				if err := c.StopE(ctx, t.L(), stopOpts, c.Node(node)); err != nil {
+				if err := c.StopE(ctx, l, stopOpts, c.Node(node)); err != nil {
 					return err
 				}
 			}
@@ -358,7 +355,7 @@ func runDecommission(
 				return err
 			}
 
-			db := c.Conn(ctx, t.L(), pinnedNode)
+			db := c.Conn(ctx, l, pinnedNode)
 			defer db.Close()
 
 			startOpts := option.NewStartOpts(option.SkipInit)
@@ -367,7 +364,7 @@ func runDecommission(
 				fmt.Sprintf("--attrs=node%d", node),
 			}
 			startOpts.RoachprodOpts.ExtraArgs = append(startOpts.RoachprodOpts.ExtraArgs, extraArgs...)
-			if err := c.StartE(ctx, t.L(), withDecommissionVMod(startOpts),
+			if err := c.StartE(ctx, l, withDecommissionVMod(startOpts),
 				install.MakeClusterSettings(), c.Node(node)); err != nil {
 				return err
 			}
@@ -376,10 +373,8 @@ func runDecommission(
 		// having disappeared. Verify that the workloads don't dip their qps or
 		// show spikes in latencies.
 		return nil
-	})
-	if err := m.Wait(); err != nil {
-		t.Fatal(err)
-	}
+	}, task.Name("decommission"))
+	m.Wait()
 }
 
 // runDecommissionRandomized tests a bunch of node

--- a/pkg/cmd/roachtest/tests/follower_reads.go
+++ b/pkg/cmd/roachtest/tests/follower_reads.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil/mixedversion"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil/task"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
@@ -38,7 +39,6 @@ import (
 	"github.com/jackc/pgtype"
 	"github.com/lib/pq"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/sync/errgroup"
 )
 
 func registerFollowerReads(r registry.Registry) {
@@ -279,8 +279,8 @@ func runFollowerReadsTest(
 			return nil
 		}
 	}
-	doSelects := func(ctx context.Context, node int) func() error {
-		return func() error {
+	doSelects := func(node int) task.Func {
+		return func(ctx context.Context, _ *logger.Logger) error {
 			for ctx.Err() == nil {
 				k, v := chooseKV()
 				err := verifySelect(ctx, node, k, v)()
@@ -335,25 +335,24 @@ func runFollowerReadsTest(
 	// 15 seconds to give closed timestamps a chance to propagate and caches time
 	// to warm up.
 	l.Printf("warming up reads")
-	g, gCtx := errgroup.WithContext(ctx)
+	g := t.NewGroup(task.WithContext(ctx))
+
 	k, v := chooseKV()
 	until := timeutil.Now().Add(15 * time.Second)
 	for i := 1; i <= c.Spec().NodeCount; i++ {
-		fn := verifySelect(gCtx, i, k, v)
-		g.Go(func() error {
+		g.Go(func(gCtx context.Context, l *logger.Logger) error {
+			fn := verifySelect(gCtx, i, k, v)
 			for {
 				if timeutil.Now().After(until) {
 					return nil
 				}
 				if err := fn(); err != nil {
-					return err
+					return errors.Wrap(err, "error verifying node values")
 				}
 			}
 		})
 	}
-	if err := g.Wait(); err != nil {
-		t.Fatalf("error verifying node values: %v", err)
-	}
+	g.Wait()
 	// Verify that the follower read count increments on at least two nodes -
 	// which we expect to be in the non-primary regions.
 	expNodesToSeeFollowerReads := 2
@@ -393,21 +392,23 @@ func runFollowerReadsTest(
 		l.Printf("stopping load")
 		cancel()
 	})
-	g, gCtx = errgroup.WithContext(timeoutCtx)
+	g = t.NewGroup(task.WithContext(timeoutCtx), task.ErrorHandler(
+		func(_ context.Context, name string, l *logger.Logger, err error) error {
+			return errors.Wrapf(err, "error reading data")
+		},
+	))
 	const concurrency = 32
 	var cur int
 	for i := 0; cur < concurrency; i++ {
 		node := i%c.Spec().NodeCount + 1
 		if _, ok := liveNodes[node]; ok {
-			g.Go(doSelects(gCtx, node))
+			g.Go(doSelects(node))
 			cur++
 		}
 	}
 	start := timeutil.Now()
 
-	if err := g.Wait(); err != nil && timeoutCtx.Err() == nil {
-		t.Fatalf("error reading data: %v", err)
-	}
+	g.Wait()
 	end := timeutil.Now()
 	l.Printf("load stopped")
 
@@ -658,25 +659,23 @@ func initFollowerReadsDB(
 	const concurrency = 32
 	sem := make(chan struct{}, concurrency)
 	data = make(map[int]int64)
-	insert := func(ctx context.Context, k int) func() error {
+	insert := func(k int) task.Func {
 		v := rng.Int63()
 		data[k] = v
-		return func() error {
+		return func(ctx context.Context, _ *logger.Logger) error {
 			sem <- struct{}{}
 			defer func() { <-sem }()
 			_, err := db.ExecContext(ctx, "INSERT INTO mr_db.test VALUES ( $1, $2 )", k, v)
-			return err
+			return errors.Wrap(err, "failed to insert data")
 		}
 	}
 
 	// Insert the data.
-	g, gCtx := errgroup.WithContext(ctx)
+	g := t.NewGroup(task.WithContext(ctx))
 	for i := 0; i < rows; i++ {
-		g.Go(insert(gCtx, i))
+		g.Go(insert(i))
 	}
-	if err := g.Wait(); err != nil {
-		t.Fatalf("failed to insert data: %v", err)
-	}
+	g.Wait()
 
 	return data
 }
@@ -894,10 +893,10 @@ const followerReadsMetric = "follower_reads_success_count"
 // according to the metric.
 func getFollowerReadCounts(ctx context.Context, t test.Test, c cluster.Cluster) ([]int, error) {
 	followerReadCounts := make([]int, c.Spec().NodeCount)
-	getFollowerReadCount := func(ctx context.Context, node int) func() error {
-		return func() error {
+	getFollowerReadCount := func(node int) task.Func {
+		return func(ctx context.Context, l *logger.Logger) error {
 			adminUIAddrs, err := c.ExternalAdminUIAddr(
-				ctx, t.L(), c.Node(node), option.VirtualClusterName(install.SystemInterfaceName),
+				ctx, l, c.Node(node), option.VirtualClusterName(install.SystemInterfaceName),
 			)
 			if err != nil {
 				return err
@@ -906,7 +905,7 @@ func getFollowerReadCounts(ctx context.Context, t test.Test, c cluster.Cluster) 
 			// Make sure to connect to the system tenant in case this test
 			// is running on a multitenant deployment.
 			client := roachtestutil.DefaultHTTPClient(
-				c, t.L(), roachtestutil.VirtualCluster(install.SystemInterfaceName),
+				c, l, roachtestutil.VirtualCluster(install.SystemInterfaceName),
 			)
 			resp, err := client.Get(ctx, url)
 			if err != nil {
@@ -932,11 +931,11 @@ func getFollowerReadCounts(ctx context.Context, t test.Test, c cluster.Cluster) 
 			return nil
 		}
 	}
-	g, gCtx := errgroup.WithContext(ctx)
+	g := t.NewErrorGroup(task.WithContext(ctx))
 	for i := 1; i <= c.Spec().NodeCount; i++ {
-		g.Go(getFollowerReadCount(gCtx, i))
+		g.Go(getFollowerReadCount(i), task.Name(fmt.Sprintf("follower-read-count-%d", i)))
 	}
-	if err := g.Wait(); err != nil {
+	if err := g.WaitE(); err != nil {
 		return nil, err
 	}
 	return followerReadCounts, nil

--- a/pkg/cmd/roachtest/tests/rebalance_load.go
+++ b/pkg/cmd/roachtest/tests/rebalance_load.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil/mixedversion"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil/task"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -26,7 +27,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/sync/errgroup"
 )
 
 const (
@@ -242,15 +242,13 @@ func rebalanceByLoad(
 
 	require.NoError(t, roachtestutil.WaitFor3XReplication(ctx, l, db))
 
-	var m *errgroup.Group
-	m, ctx = errgroup.WithContext(ctx)
-
 	// Enable us to exit out of workload early when we achieve the desired CPU
 	// balance. This drastically shortens the duration of the test in the
 	// common case.
 	ctx, cancel := context.WithCancel(ctx)
+	m := t.NewErrorGroup(task.WithContext(ctx))
 
-	m.Go(func() error {
+	m.Go(func(ctx context.Context, l *logger.Logger) error {
 		l.Printf("starting load generator")
 		err := c.RunE(ctx, option.WithNodes(appNode), fmt.Sprintf(
 			"./cockroach workload run kv --read-percent=95 --tolerate-errors --concurrency=%d "+
@@ -263,9 +261,9 @@ func rebalanceByLoad(
 			return nil
 		}
 		return err
-	})
+	}, task.Name("load-generator"))
 
-	m.Go(func() error {
+	m.Go(func(ctx context.Context, l *logger.Logger) error {
 		l.Printf("checking for CPU balance")
 
 		storeCPUFn, err := makeStoreCPUFn(ctx, t, l, c, numNodes, numStores)
@@ -305,8 +303,8 @@ func rebalanceByLoad(
 			}
 		}
 		return errors.Errorf("CPU not evenly balanced after timeout: %s", reason)
-	})
-	return m.Wait()
+	}, task.Name("cpu-balance"))
+	return m.WaitE()
 }
 
 // makeStoreCPUFn returns a function which can be called to gather the CPU of


### PR DESCRIPTION
Previously, the wait call on a task group would not return anything and any
error, that occurred in a task, would be reported to the test framework and fail
the test.

This change adds functionality to allow test authors more control and create an
error group if it is necessary to wait on errors, and not have the test
framework handle the errors directly.

A context can also now be specified to override the default context passed by
the test framework for the task manager.

Informs: #118214

Epic: None
Release note: None