### PR TITLE
raft: avoid allocating supportMap for every LeadSupportUntil calculation

### DIFF
--- a/pkg/raft/status.go
+++ b/pkg/raft/status.go
@@ -98,7 +98,6 @@ func getBasicStatus(r *raft) BasicStatus {
 	// NOTE: we assign to LeadSupportUntil even if RaftState is not currently
 	// StateLeader. The replica may have been the leader and stepped down to a
 	// follower before its lead support ran out.
-	//s.LeadSupportUntil = hlc.Timestamp{}
 	s.LeadSupportUntil = r.fortificationTracker.LeadSupportUntil(r.state)
 
 	assertTrue((s.RaftState == pb.StateLeader) == (s.Lead == r.id), "inconsistent lead / raft state")


### PR DESCRIPTION
This adds supportExpMap that hangs off the fortificationTracker. This is                                                                                                                                                                                  
useful to avoid allocating the map for every LeadSupportUntil                                                                                                                                                                                             
calculation. This is now possible since all the calls to                                                                                                                                                                                                  
ComputeLeadSupportUntil are done with a lock held.                                                                                                                                                                                                        
                                                                                                                                                                                                                                                          
Note that this doesn't seem to improve the performance of                                                                                                                                                                                                 
ComputeLeadSupportUntil when the number of voters are low. The reason                                                                                                                                                                                     
is that there is a go compiler optimization that seems to  make an                                                                                                                                                                                        
on-stack map allocation if the size is small.                                                                                                                                                                                                             
                                                                                                                                                                                                                                                          
References: #137264                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                          
Release note: None 