### PR TITLE
sql/schemachanger: Add debug logging to TestExecuteWithDMLInjection

### DIFF
--- a/pkg/sql/schemachanger/sctest/cumulative.go
+++ b/pkg/sql/schemachanger/sctest/cumulative.go
@@ -193,6 +193,7 @@ func ExecuteWithDMLInjection(t *testing.T, relPath string, factory TestServerFac
 					defer jobErrorMutex.Unlock()
 					key := makeStageKey(s.Phase, s.Ordinal, p.InRollback || p.CurrentState.InRollback)
 					if _, ok := usedStages[key.AsInt()]; !ok {
+						t.Logf("Injecting into stage: %s", &key)
 						// Rollbacks don't count towards the successful count
 						if !p.InRollback && !p.CurrentState.InRollback &&
 							p.Stages[stageIdx].Phase != scop.PreCommitPhase {
@@ -243,6 +244,7 @@ func ExecuteWithDMLInjection(t *testing.T, relPath string, factory TestServerFac
 			// commits, this enforces any sanity checks one last time in
 			// the final descriptor state.
 			if lastRollbackStageKey != nil {
+				t.Logf("Job transaction committed. Re-inject statements from rollback: %s", lastRollbackStageKey.String())
 				injectionFunc(*lastRollbackStageKey, tdb, successfulStages)
 			}
 			require.Equal(t, errorDetected, schemaChangeErrorRegex != nil)

--- a/pkg/sql/schemachanger/sctest/framework.go
+++ b/pkg/sql/schemachanger/sctest/framework.go
@@ -443,6 +443,7 @@ func (e *stageExecStmt) Exec(
 		if len(stmt) == 0 {
 			continue
 		}
+		t.Logf("Starting execution of statment: %+v", stmt)
 		// Bind any variables for the statement.
 		boundSQL := os.Expand(stmt, func(s string) string {
 			switch s {


### PR DESCRIPTION
The TestExecuteWithDMLInjection test executes DML at various stages of a schema change. This change adds extra logging to clarify which DML statements have been executed. The additional logging is intended to help track down a failure in issue #138177, where the DML failed but it wasn't clear why or whether all DML injections were executed.

Epic: None
Closes #138177
Release note: None