### PR TITLE
server: skip TestLogGC under deadlock

### DIFF
--- a/pkg/server/server_systemlog_gc_test.go
+++ b/pkg/server/server_systemlog_gc_test.go
@@ -28,6 +28,7 @@ func TestLogGC(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	skip.UnderRace(t, "takes >1 min under race")
+	skip.UnderDeadlock(t, "takes >1 min under deadlock")
 
 	ctx := context.Background()
 	a := assert.New(t)


### PR DESCRIPTION
TestLogGC issues many large DELETE statements. The combination of `--deadlock` and metamorphic constant kv-batch-size = 1 causes these deletes to take a long time, pushing test runtime over a minute. Let's skip this test under deadlock to avoid the long runtime.

Epic: None

Release note: None