### PR TITLE
release-24.1: changefeedccl: deflake TestChangefeedPrimaryKeyChangeWorks

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -6709,8 +6709,6 @@ INSERT INTO foo VALUES (1, 'f');
 		assertPayloads(t, foo, []string{
 			`foo: ["a"]->{"after": {"a": 6, "b": "a"}}`,
 			`foo: ["e"]->{"after": {"a": 5, "b": "e"}}`,
-		})
-		assertPayloads(t, foo, []string{
 			`foo: [1]->{"after": {"a": 1, "b": "f"}}`,
 		})
 	}


### PR DESCRIPTION
Backport 1/1 commits from #133128.

/cc @cockroachdb/release

---

This patch deflakes `TestChangefeedPrimaryKeyChangeWorks` by removing an
erroneous assumption regarding the order of messages for different keys.

Fixes #133045

Release note: None

---

Release justification: test-only fix
