### PR TITLE
roachtest: terminate gossip roachtest on VM migration

### DIFF
--- a/pkg/cmd/roachtest/tests/gossip.go
+++ b/pkg/cmd/roachtest/tests/gossip.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/gossip"
 	"github.com/cockroachdb/cockroach/pkg/roachprod"
@@ -182,7 +183,7 @@ SELECT node_id
 	r.Add(registry.TestSpec{
 		Name:             "gossip/chaos/nodes=9",
 		Owner:            registry.OwnerKV,
-		Cluster:          r.MakeClusterSpec(9),
+		Cluster:          r.MakeClusterSpec(9, spec.TerminateOnMigration()),
 		CompatibleClouds: registry.AllExceptAWS,
 		Suites:           registry.Suites(registry.Nightly),
 		Leases:           registry.MetamorphicLeases,


### PR DESCRIPTION
We've seen unexpected clock jumps in this test's failures. Live migrations are one explanation for this, so let's disable them for this test.

NB: Not closing out the linked issue as it happened on Azure, and this termination policy only applies to GCE.

Informs https://github.com/cockroachdb/cockroach/issues/130737

Release note: None