### PR TITLE
logictest: skip a subset of partial_index in 3node-tenant config

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/partial_index
+++ b/pkg/sql/logictest/testdata/logic_test/partial_index
@@ -567,21 +567,29 @@ SELECT * FROM h@a_b_foo_idx WHERE b = 'foo'
 # in the same transaction. Use a high priority to make it less likely for the
 # transaction to be aborted.
 
+# Skip 3node-tenant config since it's prone to hitting a txn retry error
+# (#126763).
+skipif config 3node-tenant
 statement ok
 BEGIN PRIORITY HIGH
 
+skipif config 3node-tenant
 statement ok
 CREATE TABLE i (a INT, b enum)
 
+skipif config 3node-tenant
 statement ok
 INSERT INTO i VALUES (1, 'foo'), (2, 'bar')
 
+skipif config 3node-tenant
 statement ok
 CREATE INDEX a_b_foo_idx ON i (a) WHERE b = 'foo'
 
+skipif config 3node-tenant
 statement ok
 COMMIT
 
+skipif config 3node-tenant
 query IT rowsort
 SELECT * FROM i@a_b_foo_idx WHERE b = 'foo'
 ----


### PR DESCRIPTION
We've seen a subset of `partial_index` test fail occasionally on the 3node-tenant config in CI. We tried improving the situation by splitting up the queries in separate logic test directives and using the high priority txn, yet we just saw another failure. Thus, this commit simply skips the relevant part of the test in 3node-tenant config (since we haven't seen anything suspicious in the logs).

Fixes: #138365.

Release note: None