### PR TITLE
workload: add mean and max values for histogram in openmetrics

### DIFF
--- a/pkg/workload/histogram/exporter/openmetrics_exporter.go
+++ b/pkg/workload/histogram/exporter/openmetrics_exporter.go
@@ -2,6 +2,7 @@
 //
 // Use of this software is governed by the CockroachDB Software License
 // included in the /LICENSE file.
+
 package exporter
 
 import (
@@ -57,6 +58,16 @@ func (o *OpenMetricsExporter) SnapshotAndWrite(
 
 	// emit elapsed metric for this run
 	if err := o.emitGaugeMetric(*name+"_elapsed", float64(elapsed.Milliseconds()), now); err != nil {
+		return err
+	}
+
+	// emit max metric for this run
+	if err := o.emitGaugeMetric(*name+"_max", float64(hist.Max()), now); err != nil {
+		return err
+	}
+
+	// emit mean metric for this run
+	if err := o.emitGaugeMetric(*name+"_mean", hist.Mean(), now); err != nil {
 		return err
 	}
 

--- a/pkg/workload/histogram/exporter/testdata/kv
+++ b/pkg/workload/histogram/exporter/testdata/kv
@@ -10,6 +10,10 @@ write_sum 0.0 1.719236333446e+09
 write_count 16379 1.719236333446e+09
 # TYPE write_elapsed gauge
 write_elapsed 5031.0 1.719236333446e+09
+# TYPE write_max gauge
+write_max 4.294967295e+09 1.719236333446e+09
+# TYPE write_mean gauge
+write_mean 1.940055858062153e+07 1.719236333446e+09
 # TYPE write_highest_trackable_value gauge
 write_highest_trackable_value 1e+11 1.719236333446e+09
 # EOF

--- a/pkg/workload/histogram/exporter/testdata/tpcc_delivery
+++ b/pkg/workload/histogram/exporter/testdata/tpcc_delivery
@@ -11,6 +11,10 @@ delivery_sum 0.0 1.71924406379e+09
 delivery_count 24 1.71924406379e+09
 # TYPE delivery_elapsed gauge
 delivery_elapsed 992.0 1.71924406379e+09
+# TYPE delivery_max gauge
+delivery_max 4.6137343e+07 1.71924406379e+09
+# TYPE delivery_mean gauge
+delivery_mean 3.6918613333333336e+07 1.71924406379e+09
 # TYPE delivery_highest_trackable_value gauge
 delivery_highest_trackable_value 1e+11 1.71924406379e+09
 # EOF

--- a/pkg/workload/histogram/exporter/testdata/ycsb
+++ b/pkg/workload/histogram/exporter/testdata/ycsb
@@ -11,6 +11,10 @@ read_sum 0.0 1.719230907083e+09
 read_count 34540 1.719230907083e+09
 # TYPE read_elapsed gauge
 read_elapsed 999.0 1.719230907083e+09
+# TYPE read_max gauge
+read_max 1.3631487e+07 1.719230907083e+09
+# TYPE read_mean gauge
+read_mean 1.0934588627678053e+06 1.719230907083e+09
 # TYPE read_highest_trackable_value gauge
 read_highest_trackable_value 1e+11 1.719230907083e+09
 # EOF


### PR DESCRIPTION
A few benchmark like `failover` and `tpchbench` require the max and mean of the histogram for every snapshot. This change aims to add that into the openmetrics exporter in workload binary

Epic: none

Release note: None