### PR TITLE
kserver: enable leader leases for TestFlowControlCrashedNodeV2

### DIFF
--- a/pkg/kv/kvserver/testdata/flow_control_integration/crashed_node
+++ b/pkg/kv/kvserver/testdata/flow_control_integration/crashed_node
@@ -1,23 +1,23 @@
 echo
 ----
 ----
--- (Issuing regular 5x1MiB, 2x replicated writes that are not admitted.)
+-- (Issuing regular 5x1MiB, 3x replicated writes that are not admitted.)
 
 
--- Flow token metrics from n1 after issuing 5 regular 1MiB 2x replicated writes
--- that are yet to get admitted. We see 5*1MiB*2=10MiB deductions of
+-- Flow token metrics from n1 after issuing 5 regular 1MiB 3x replicated writes
+-- that are yet to get admitted. We see 5*1MiB*3=15MiB deductions of
 -- {regular,elastic} tokens with no corresponding returns.
 SELECT name, crdb_internal.humanize_bytes(value::INT8)
     FROM crdb_internal.node_metrics
    WHERE name LIKE '%kvadmission%tokens%'
 ORDER BY name ASC;
 
-  kvadmission.flow_controller.elastic_tokens_available   | 6.0 MiB  
-  kvadmission.flow_controller.elastic_tokens_deducted    | 10 MiB   
+  kvadmission.flow_controller.elastic_tokens_available   | 9.0 MiB  
+  kvadmission.flow_controller.elastic_tokens_deducted    | 15 MiB   
   kvadmission.flow_controller.elastic_tokens_returned    | 0 B      
   kvadmission.flow_controller.elastic_tokens_unaccounted | 0 B      
-  kvadmission.flow_controller.regular_tokens_available   | 22 MiB   
-  kvadmission.flow_controller.regular_tokens_deducted    | 10 MiB   
+  kvadmission.flow_controller.regular_tokens_available   | 33 MiB   
+  kvadmission.flow_controller.regular_tokens_deducted    | 15 MiB   
   kvadmission.flow_controller.regular_tokens_returned    | 0 B      
   kvadmission.flow_controller.regular_tokens_unaccounted | 0 B      
 
@@ -30,6 +30,7 @@ SELECT range_id, store_id, crdb_internal.humanize_bytes(total_tracked_tokens::IN
 -----------+----------+-----------------------
   75       | 1        | 5.0 MiB               
   75       | 2        | 5.0 MiB               
+  75       | 3        | 5.0 MiB               
 
 
 -- (Crashing n2 but disabling the raft-transport-break token return mechanism.)
@@ -43,6 +44,7 @@ SELECT range_id, store_id, crdb_internal.humanize_bytes(total_tracked_tokens::IN
   range_id | store_id | total_tracked_tokens  
 -----------+----------+-----------------------
   75       | 1        | 5.0 MiB               
+  75       | 3        | 5.0 MiB               
 
 
 -- Flow token metrics from n1 after n2 crashed. Observe that we've returned the
@@ -52,12 +54,12 @@ SELECT name, crdb_internal.humanize_bytes(value::INT8)
    WHERE name LIKE '%kvadmission%tokens%'
 ORDER BY name ASC;
 
-  kvadmission.flow_controller.elastic_tokens_available   | 11 MiB   
-  kvadmission.flow_controller.elastic_tokens_deducted    | 10 MiB   
+  kvadmission.flow_controller.elastic_tokens_available   | 14 MiB   
+  kvadmission.flow_controller.elastic_tokens_deducted    | 15 MiB   
   kvadmission.flow_controller.elastic_tokens_returned    | 5.0 MiB  
   kvadmission.flow_controller.elastic_tokens_unaccounted | 0 B      
-  kvadmission.flow_controller.regular_tokens_available   | 27 MiB   
-  kvadmission.flow_controller.regular_tokens_deducted    | 10 MiB   
+  kvadmission.flow_controller.regular_tokens_available   | 38 MiB   
+  kvadmission.flow_controller.regular_tokens_deducted    | 15 MiB   
   kvadmission.flow_controller.regular_tokens_returned    | 5.0 MiB  
   kvadmission.flow_controller.regular_tokens_unaccounted | 0 B      
 ----

--- a/pkg/kv/kvserver/testdata/flow_control_integration_v2/crashed_node_v1_encoding_apply_to_all
+++ b/pkg/kv/kvserver/testdata/flow_control_integration_v2/crashed_node_v1_encoding_apply_to_all
@@ -8,35 +8,35 @@
 echo
 ----
 ----
--- (Issuing 5x1MiB, 2x replicated writes that are not admitted.)
+-- (Issuing 5x1MiB, 3x replicated writes that are not admitted.)
 
 
--- Flow token metrics from n1 after issuing 5 1MiB 2x replicated writes
--- that are yet to get admitted. We see 5*1MiB*2=10MiB deductions of
+-- Flow token metrics from n1 after issuing 5 1MiB 3x replicated writes
+-- that are yet to get admitted. We see 5*1MiB*3=15MiB deductions of
 -- {regular,elastic} tokens with no corresponding returns.
 SELECT name, crdb_internal.humanize_bytes(value::INT8)
     FROM crdb_internal.node_metrics
    WHERE name LIKE '%kvflowcontrol%tokens%'
 ORDER BY name ASC;
 
-  kvflowcontrol.tokens.eval.elastic.available                       | 6.0 MiB  
-  kvflowcontrol.tokens.eval.elastic.deducted                        | 10 MiB   
+  kvflowcontrol.tokens.eval.elastic.available                       | 9.0 MiB  
+  kvflowcontrol.tokens.eval.elastic.deducted                        | 15 MiB   
   kvflowcontrol.tokens.eval.elastic.returned                        | 0 B      
   kvflowcontrol.tokens.eval.elastic.returned.disconnect             | 0 B      
   kvflowcontrol.tokens.eval.elastic.unaccounted                     | 0 B      
-  kvflowcontrol.tokens.eval.regular.available                       | 32 MiB   
+  kvflowcontrol.tokens.eval.regular.available                       | 48 MiB   
   kvflowcontrol.tokens.eval.regular.deducted                        | 0 B      
   kvflowcontrol.tokens.eval.regular.returned                        | 0 B      
   kvflowcontrol.tokens.eval.regular.returned.disconnect             | 0 B      
   kvflowcontrol.tokens.eval.regular.unaccounted                     | 0 B      
-  kvflowcontrol.tokens.send.elastic.available                       | 6.0 MiB  
-  kvflowcontrol.tokens.send.elastic.deducted                        | 10 MiB   
+  kvflowcontrol.tokens.send.elastic.available                       | 9.0 MiB  
+  kvflowcontrol.tokens.send.elastic.deducted                        | 15 MiB   
   kvflowcontrol.tokens.send.elastic.deducted.force_flush_send_queue | 0 B      
   kvflowcontrol.tokens.send.elastic.deducted.prevent_send_queue     | 0 B      
   kvflowcontrol.tokens.send.elastic.returned                        | 0 B      
   kvflowcontrol.tokens.send.elastic.returned.disconnect             | 0 B      
   kvflowcontrol.tokens.send.elastic.unaccounted                     | 0 B      
-  kvflowcontrol.tokens.send.regular.available                       | 32 MiB   
+  kvflowcontrol.tokens.send.regular.available                       | 48 MiB   
   kvflowcontrol.tokens.send.regular.deducted                        | 0 B      
   kvflowcontrol.tokens.send.regular.deducted.prevent_send_queue     | 0 B      
   kvflowcontrol.tokens.send.regular.returned                        | 0 B      
@@ -52,6 +52,7 @@ SELECT range_id, store_id, crdb_internal.humanize_bytes(total_tracked_tokens::IN
 -----------+----------+-----------------------
   75       | 1        | 5.0 MiB               
   75       | 2        | 5.0 MiB               
+  75       | 3        | 5.0 MiB               
 
 
 -- (Crashing n2)
@@ -65,6 +66,7 @@ SELECT range_id, store_id, crdb_internal.humanize_bytes(total_tracked_tokens::IN
   range_id | store_id | total_tracked_tokens  
 -----------+----------+-----------------------
   75       | 1        | 5.0 MiB               
+  75       | 3        | 5.0 MiB               
 
 
 -- Flow token metrics from n1 after n2 crashed. Observe that we've returned the
@@ -74,24 +76,24 @@ SELECT name, crdb_internal.humanize_bytes(value::INT8)
    WHERE name LIKE '%kvflowcontrol%tokens%'
 ORDER BY name ASC;
 
-  kvflowcontrol.tokens.eval.elastic.available                       | 11 MiB   
-  kvflowcontrol.tokens.eval.elastic.deducted                        | 10 MiB   
+  kvflowcontrol.tokens.eval.elastic.available                       | 14 MiB   
+  kvflowcontrol.tokens.eval.elastic.deducted                        | 15 MiB   
   kvflowcontrol.tokens.eval.elastic.returned                        | 5.0 MiB  
   kvflowcontrol.tokens.eval.elastic.returned.disconnect             | 5.0 MiB  
   kvflowcontrol.tokens.eval.elastic.unaccounted                     | 0 B      
-  kvflowcontrol.tokens.eval.regular.available                       | 32 MiB   
+  kvflowcontrol.tokens.eval.regular.available                       | 48 MiB   
   kvflowcontrol.tokens.eval.regular.deducted                        | 0 B      
   kvflowcontrol.tokens.eval.regular.returned                        | 0 B      
   kvflowcontrol.tokens.eval.regular.returned.disconnect             | 0 B      
   kvflowcontrol.tokens.eval.regular.unaccounted                     | 0 B      
-  kvflowcontrol.tokens.send.elastic.available                       | 11 MiB   
-  kvflowcontrol.tokens.send.elastic.deducted                        | 10 MiB   
+  kvflowcontrol.tokens.send.elastic.available                       | 14 MiB   
+  kvflowcontrol.tokens.send.elastic.deducted                        | 15 MiB   
   kvflowcontrol.tokens.send.elastic.deducted.force_flush_send_queue | 0 B      
   kvflowcontrol.tokens.send.elastic.deducted.prevent_send_queue     | 0 B      
   kvflowcontrol.tokens.send.elastic.returned                        | 5.0 MiB  
   kvflowcontrol.tokens.send.elastic.returned.disconnect             | 5.0 MiB  
   kvflowcontrol.tokens.send.elastic.unaccounted                     | 0 B      
-  kvflowcontrol.tokens.send.regular.available                       | 32 MiB   
+  kvflowcontrol.tokens.send.regular.available                       | 48 MiB   
   kvflowcontrol.tokens.send.regular.deducted                        | 0 B      
   kvflowcontrol.tokens.send.regular.deducted.prevent_send_queue     | 0 B      
   kvflowcontrol.tokens.send.regular.returned                        | 0 B      

--- a/pkg/kv/kvserver/testdata/flow_control_integration_v2/crashed_node_v1_encoding_apply_to_elastic
+++ b/pkg/kv/kvserver/testdata/flow_control_integration_v2/crashed_node_v1_encoding_apply_to_elastic
@@ -8,35 +8,35 @@
 echo
 ----
 ----
--- (Issuing 5x1MiB, 2x replicated writes that are not admitted.)
+-- (Issuing 5x1MiB, 3x replicated writes that are not admitted.)
 
 
--- Flow token metrics from n1 after issuing 5 1MiB 2x replicated writes
--- that are yet to get admitted. We see 5*1MiB*2=10MiB deductions of
+-- Flow token metrics from n1 after issuing 5 1MiB 3x replicated writes
+-- that are yet to get admitted. We see 5*1MiB*3=15MiB deductions of
 -- {regular,elastic} tokens with no corresponding returns.
 SELECT name, crdb_internal.humanize_bytes(value::INT8)
     FROM crdb_internal.node_metrics
    WHERE name LIKE '%kvflowcontrol%tokens%'
 ORDER BY name ASC;
 
-  kvflowcontrol.tokens.eval.elastic.available                       | 6.0 MiB  
-  kvflowcontrol.tokens.eval.elastic.deducted                        | 10 MiB   
+  kvflowcontrol.tokens.eval.elastic.available                       | 9.0 MiB  
+  kvflowcontrol.tokens.eval.elastic.deducted                        | 15 MiB   
   kvflowcontrol.tokens.eval.elastic.returned                        | 0 B      
   kvflowcontrol.tokens.eval.elastic.returned.disconnect             | 0 B      
   kvflowcontrol.tokens.eval.elastic.unaccounted                     | 0 B      
-  kvflowcontrol.tokens.eval.regular.available                       | 32 MiB   
+  kvflowcontrol.tokens.eval.regular.available                       | 48 MiB   
   kvflowcontrol.tokens.eval.regular.deducted                        | 0 B      
   kvflowcontrol.tokens.eval.regular.returned                        | 0 B      
   kvflowcontrol.tokens.eval.regular.returned.disconnect             | 0 B      
   kvflowcontrol.tokens.eval.regular.unaccounted                     | 0 B      
-  kvflowcontrol.tokens.send.elastic.available                       | 6.0 MiB  
-  kvflowcontrol.tokens.send.elastic.deducted                        | 10 MiB   
+  kvflowcontrol.tokens.send.elastic.available                       | 9.0 MiB  
+  kvflowcontrol.tokens.send.elastic.deducted                        | 15 MiB   
   kvflowcontrol.tokens.send.elastic.deducted.force_flush_send_queue | 0 B      
   kvflowcontrol.tokens.send.elastic.deducted.prevent_send_queue     | 0 B      
   kvflowcontrol.tokens.send.elastic.returned                        | 0 B      
   kvflowcontrol.tokens.send.elastic.returned.disconnect             | 0 B      
   kvflowcontrol.tokens.send.elastic.unaccounted                     | 0 B      
-  kvflowcontrol.tokens.send.regular.available                       | 32 MiB   
+  kvflowcontrol.tokens.send.regular.available                       | 48 MiB   
   kvflowcontrol.tokens.send.regular.deducted                        | 0 B      
   kvflowcontrol.tokens.send.regular.deducted.prevent_send_queue     | 0 B      
   kvflowcontrol.tokens.send.regular.returned                        | 0 B      
@@ -52,6 +52,7 @@ SELECT range_id, store_id, crdb_internal.humanize_bytes(total_tracked_tokens::IN
 -----------+----------+-----------------------
   75       | 1        | 5.0 MiB               
   75       | 2        | 5.0 MiB               
+  75       | 3        | 5.0 MiB               
 
 
 -- (Crashing n2)
@@ -65,6 +66,7 @@ SELECT range_id, store_id, crdb_internal.humanize_bytes(total_tracked_tokens::IN
   range_id | store_id | total_tracked_tokens  
 -----------+----------+-----------------------
   75       | 1        | 5.0 MiB               
+  75       | 3        | 5.0 MiB               
 
 
 -- Flow token metrics from n1 after n2 crashed. Observe that we've returned the
@@ -74,24 +76,24 @@ SELECT name, crdb_internal.humanize_bytes(value::INT8)
    WHERE name LIKE '%kvflowcontrol%tokens%'
 ORDER BY name ASC;
 
-  kvflowcontrol.tokens.eval.elastic.available                       | 11 MiB   
-  kvflowcontrol.tokens.eval.elastic.deducted                        | 10 MiB   
+  kvflowcontrol.tokens.eval.elastic.available                       | 14 MiB   
+  kvflowcontrol.tokens.eval.elastic.deducted                        | 15 MiB   
   kvflowcontrol.tokens.eval.elastic.returned                        | 5.0 MiB  
   kvflowcontrol.tokens.eval.elastic.returned.disconnect             | 5.0 MiB  
   kvflowcontrol.tokens.eval.elastic.unaccounted                     | 0 B      
-  kvflowcontrol.tokens.eval.regular.available                       | 32 MiB   
+  kvflowcontrol.tokens.eval.regular.available                       | 48 MiB   
   kvflowcontrol.tokens.eval.regular.deducted                        | 0 B      
   kvflowcontrol.tokens.eval.regular.returned                        | 0 B      
   kvflowcontrol.tokens.eval.regular.returned.disconnect             | 0 B      
   kvflowcontrol.tokens.eval.regular.unaccounted                     | 0 B      
-  kvflowcontrol.tokens.send.elastic.available                       | 11 MiB   
-  kvflowcontrol.tokens.send.elastic.deducted                        | 10 MiB   
+  kvflowcontrol.tokens.send.elastic.available                       | 14 MiB   
+  kvflowcontrol.tokens.send.elastic.deducted                        | 15 MiB   
   kvflowcontrol.tokens.send.elastic.deducted.force_flush_send_queue | 0 B      
   kvflowcontrol.tokens.send.elastic.deducted.prevent_send_queue     | 0 B      
   kvflowcontrol.tokens.send.elastic.returned                        | 5.0 MiB  
   kvflowcontrol.tokens.send.elastic.returned.disconnect             | 5.0 MiB  
   kvflowcontrol.tokens.send.elastic.unaccounted                     | 0 B      
-  kvflowcontrol.tokens.send.regular.available                       | 32 MiB   
+  kvflowcontrol.tokens.send.regular.available                       | 48 MiB   
   kvflowcontrol.tokens.send.regular.deducted                        | 0 B      
   kvflowcontrol.tokens.send.regular.deducted.prevent_send_queue     | 0 B      
   kvflowcontrol.tokens.send.regular.returned                        | 0 B      

--- a/pkg/kv/kvserver/testdata/flow_control_integration_v2/crashed_node_v2_encoding_apply_to_all
+++ b/pkg/kv/kvserver/testdata/flow_control_integration_v2/crashed_node_v2_encoding_apply_to_all
@@ -1,36 +1,36 @@
 echo
 ----
 ----
--- (Issuing 5x1MiB, 2x replicated writes that are not admitted.)
+-- (Issuing 5x1MiB, 3x replicated writes that are not admitted.)
 
 
--- Flow token metrics from n1 after issuing 5 1MiB 2x replicated writes
--- that are yet to get admitted. We see 5*1MiB*2=10MiB deductions of
+-- Flow token metrics from n1 after issuing 5 1MiB 3x replicated writes
+-- that are yet to get admitted. We see 5*1MiB*3=15MiB deductions of
 -- {regular,elastic} tokens with no corresponding returns.
 SELECT name, crdb_internal.humanize_bytes(value::INT8)
     FROM crdb_internal.node_metrics
    WHERE name LIKE '%kvflowcontrol%tokens%'
 ORDER BY name ASC;
 
-  kvflowcontrol.tokens.eval.elastic.available                       | 6.0 MiB  
-  kvflowcontrol.tokens.eval.elastic.deducted                        | 10 MiB   
+  kvflowcontrol.tokens.eval.elastic.available                       | 9.0 MiB  
+  kvflowcontrol.tokens.eval.elastic.deducted                        | 15 MiB   
   kvflowcontrol.tokens.eval.elastic.returned                        | 0 B      
   kvflowcontrol.tokens.eval.elastic.returned.disconnect             | 0 B      
   kvflowcontrol.tokens.eval.elastic.unaccounted                     | 0 B      
-  kvflowcontrol.tokens.eval.regular.available                       | 22 MiB   
-  kvflowcontrol.tokens.eval.regular.deducted                        | 10 MiB   
+  kvflowcontrol.tokens.eval.regular.available                       | 33 MiB   
+  kvflowcontrol.tokens.eval.regular.deducted                        | 15 MiB   
   kvflowcontrol.tokens.eval.regular.returned                        | 0 B      
   kvflowcontrol.tokens.eval.regular.returned.disconnect             | 0 B      
   kvflowcontrol.tokens.eval.regular.unaccounted                     | 0 B      
-  kvflowcontrol.tokens.send.elastic.available                       | 6.0 MiB  
-  kvflowcontrol.tokens.send.elastic.deducted                        | 10 MiB   
+  kvflowcontrol.tokens.send.elastic.available                       | 9.0 MiB  
+  kvflowcontrol.tokens.send.elastic.deducted                        | 15 MiB   
   kvflowcontrol.tokens.send.elastic.deducted.force_flush_send_queue | 0 B      
   kvflowcontrol.tokens.send.elastic.deducted.prevent_send_queue     | 0 B      
   kvflowcontrol.tokens.send.elastic.returned                        | 0 B      
   kvflowcontrol.tokens.send.elastic.returned.disconnect             | 0 B      
   kvflowcontrol.tokens.send.elastic.unaccounted                     | 0 B      
-  kvflowcontrol.tokens.send.regular.available                       | 22 MiB   
-  kvflowcontrol.tokens.send.regular.deducted                        | 10 MiB   
+  kvflowcontrol.tokens.send.regular.available                       | 33 MiB   
+  kvflowcontrol.tokens.send.regular.deducted                        | 15 MiB   
   kvflowcontrol.tokens.send.regular.deducted.prevent_send_queue     | 0 B      
   kvflowcontrol.tokens.send.regular.returned                        | 0 B      
   kvflowcontrol.tokens.send.regular.returned.disconnect             | 0 B      
@@ -45,6 +45,7 @@ SELECT range_id, store_id, crdb_internal.humanize_bytes(total_tracked_tokens::IN
 -----------+----------+-----------------------
   75       | 1        | 5.0 MiB               
   75       | 2        | 5.0 MiB               
+  75       | 3        | 5.0 MiB               
 
 
 -- (Crashing n2)
@@ -58,6 +59,7 @@ SELECT range_id, store_id, crdb_internal.humanize_bytes(total_tracked_tokens::IN
   range_id | store_id | total_tracked_tokens  
 -----------+----------+-----------------------
   75       | 1        | 5.0 MiB               
+  75       | 3        | 5.0 MiB               
 
 
 -- Flow token metrics from n1 after n2 crashed. Observe that we've returned the
@@ -67,25 +69,25 @@ SELECT name, crdb_internal.humanize_bytes(value::INT8)
    WHERE name LIKE '%kvflowcontrol%tokens%'
 ORDER BY name ASC;
 
-  kvflowcontrol.tokens.eval.elastic.available                       | 11 MiB   
-  kvflowcontrol.tokens.eval.elastic.deducted                        | 10 MiB   
+  kvflowcontrol.tokens.eval.elastic.available                       | 14 MiB   
+  kvflowcontrol.tokens.eval.elastic.deducted                        | 15 MiB   
   kvflowcontrol.tokens.eval.elastic.returned                        | 5.0 MiB  
   kvflowcontrol.tokens.eval.elastic.returned.disconnect             | 5.0 MiB  
   kvflowcontrol.tokens.eval.elastic.unaccounted                     | 0 B      
-  kvflowcontrol.tokens.eval.regular.available                       | 27 MiB   
-  kvflowcontrol.tokens.eval.regular.deducted                        | 10 MiB   
+  kvflowcontrol.tokens.eval.regular.available                       | 38 MiB   
+  kvflowcontrol.tokens.eval.regular.deducted                        | 15 MiB   
   kvflowcontrol.tokens.eval.regular.returned                        | 5.0 MiB  
   kvflowcontrol.tokens.eval.regular.returned.disconnect             | 5.0 MiB  
   kvflowcontrol.tokens.eval.regular.unaccounted                     | 0 B      
-  kvflowcontrol.tokens.send.elastic.available                       | 11 MiB   
-  kvflowcontrol.tokens.send.elastic.deducted                        | 10 MiB   
+  kvflowcontrol.tokens.send.elastic.available                       | 14 MiB   
+  kvflowcontrol.tokens.send.elastic.deducted                        | 15 MiB   
   kvflowcontrol.tokens.send.elastic.deducted.force_flush_send_queue | 0 B      
   kvflowcontrol.tokens.send.elastic.deducted.prevent_send_queue     | 0 B      
   kvflowcontrol.tokens.send.elastic.returned                        | 5.0 MiB  
   kvflowcontrol.tokens.send.elastic.returned.disconnect             | 5.0 MiB  
   kvflowcontrol.tokens.send.elastic.unaccounted                     | 0 B      
-  kvflowcontrol.tokens.send.regular.available                       | 27 MiB   
-  kvflowcontrol.tokens.send.regular.deducted                        | 10 MiB   
+  kvflowcontrol.tokens.send.regular.available                       | 38 MiB   
+  kvflowcontrol.tokens.send.regular.deducted                        | 15 MiB   
   kvflowcontrol.tokens.send.regular.deducted.prevent_send_queue     | 0 B      
   kvflowcontrol.tokens.send.regular.returned                        | 5.0 MiB  
   kvflowcontrol.tokens.send.regular.returned.disconnect             | 5.0 MiB  

--- a/pkg/kv/kvserver/testdata/flow_control_integration_v2/crashed_node_v2_encoding_apply_to_elastic
+++ b/pkg/kv/kvserver/testdata/flow_control_integration_v2/crashed_node_v2_encoding_apply_to_elastic
@@ -1,35 +1,35 @@
 echo
 ----
 ----
--- (Issuing 5x1MiB, 2x replicated writes that are not admitted.)
+-- (Issuing 5x1MiB, 3x replicated writes that are not admitted.)
 
 
--- Flow token metrics from n1 after issuing 5 1MiB 2x replicated writes
--- that are yet to get admitted. We see 5*1MiB*2=10MiB deductions of
+-- Flow token metrics from n1 after issuing 5 1MiB 3x replicated writes
+-- that are yet to get admitted. We see 5*1MiB*3=15MiB deductions of
 -- {regular,elastic} tokens with no corresponding returns.
 SELECT name, crdb_internal.humanize_bytes(value::INT8)
     FROM crdb_internal.node_metrics
    WHERE name LIKE '%kvflowcontrol%tokens%'
 ORDER BY name ASC;
 
-  kvflowcontrol.tokens.eval.elastic.available                       | 6.0 MiB  
-  kvflowcontrol.tokens.eval.elastic.deducted                        | 10 MiB   
+  kvflowcontrol.tokens.eval.elastic.available                       | 9.0 MiB  
+  kvflowcontrol.tokens.eval.elastic.deducted                        | 15 MiB   
   kvflowcontrol.tokens.eval.elastic.returned                        | 0 B      
   kvflowcontrol.tokens.eval.elastic.returned.disconnect             | 0 B      
   kvflowcontrol.tokens.eval.elastic.unaccounted                     | 0 B      
-  kvflowcontrol.tokens.eval.regular.available                       | 32 MiB   
+  kvflowcontrol.tokens.eval.regular.available                       | 48 MiB   
   kvflowcontrol.tokens.eval.regular.deducted                        | 0 B      
   kvflowcontrol.tokens.eval.regular.returned                        | 0 B      
   kvflowcontrol.tokens.eval.regular.returned.disconnect             | 0 B      
   kvflowcontrol.tokens.eval.regular.unaccounted                     | 0 B      
-  kvflowcontrol.tokens.send.elastic.available                       | 6.0 MiB  
-  kvflowcontrol.tokens.send.elastic.deducted                        | 10 MiB   
+  kvflowcontrol.tokens.send.elastic.available                       | 9.0 MiB  
+  kvflowcontrol.tokens.send.elastic.deducted                        | 15 MiB   
   kvflowcontrol.tokens.send.elastic.deducted.force_flush_send_queue | 0 B      
   kvflowcontrol.tokens.send.elastic.deducted.prevent_send_queue     | 0 B      
   kvflowcontrol.tokens.send.elastic.returned                        | 0 B      
   kvflowcontrol.tokens.send.elastic.returned.disconnect             | 0 B      
   kvflowcontrol.tokens.send.elastic.unaccounted                     | 0 B      
-  kvflowcontrol.tokens.send.regular.available                       | 32 MiB   
+  kvflowcontrol.tokens.send.regular.available                       | 48 MiB   
   kvflowcontrol.tokens.send.regular.deducted                        | 0 B      
   kvflowcontrol.tokens.send.regular.deducted.prevent_send_queue     | 0 B      
   kvflowcontrol.tokens.send.regular.returned                        | 0 B      
@@ -45,6 +45,7 @@ SELECT range_id, store_id, crdb_internal.humanize_bytes(total_tracked_tokens::IN
 -----------+----------+-----------------------
   75       | 1        | 5.0 MiB               
   75       | 2        | 5.0 MiB               
+  75       | 3        | 5.0 MiB               
 
 
 -- (Crashing n2)
@@ -58,6 +59,7 @@ SELECT range_id, store_id, crdb_internal.humanize_bytes(total_tracked_tokens::IN
   range_id | store_id | total_tracked_tokens  
 -----------+----------+-----------------------
   75       | 1        | 5.0 MiB               
+  75       | 3        | 5.0 MiB               
 
 
 -- Flow token metrics from n1 after n2 crashed. Observe that we've returned the
@@ -67,24 +69,24 @@ SELECT name, crdb_internal.humanize_bytes(value::INT8)
    WHERE name LIKE '%kvflowcontrol%tokens%'
 ORDER BY name ASC;
 
-  kvflowcontrol.tokens.eval.elastic.available                       | 11 MiB   
-  kvflowcontrol.tokens.eval.elastic.deducted                        | 10 MiB   
+  kvflowcontrol.tokens.eval.elastic.available                       | 14 MiB   
+  kvflowcontrol.tokens.eval.elastic.deducted                        | 15 MiB   
   kvflowcontrol.tokens.eval.elastic.returned                        | 5.0 MiB  
   kvflowcontrol.tokens.eval.elastic.returned.disconnect             | 5.0 MiB  
   kvflowcontrol.tokens.eval.elastic.unaccounted                     | 0 B      
-  kvflowcontrol.tokens.eval.regular.available                       | 32 MiB   
+  kvflowcontrol.tokens.eval.regular.available                       | 48 MiB   
   kvflowcontrol.tokens.eval.regular.deducted                        | 0 B      
   kvflowcontrol.tokens.eval.regular.returned                        | 0 B      
   kvflowcontrol.tokens.eval.regular.returned.disconnect             | 0 B      
   kvflowcontrol.tokens.eval.regular.unaccounted                     | 0 B      
-  kvflowcontrol.tokens.send.elastic.available                       | 11 MiB   
-  kvflowcontrol.tokens.send.elastic.deducted                        | 10 MiB   
+  kvflowcontrol.tokens.send.elastic.available                       | 14 MiB   
+  kvflowcontrol.tokens.send.elastic.deducted                        | 15 MiB   
   kvflowcontrol.tokens.send.elastic.deducted.force_flush_send_queue | 0 B      
   kvflowcontrol.tokens.send.elastic.deducted.prevent_send_queue     | 0 B      
   kvflowcontrol.tokens.send.elastic.returned                        | 5.0 MiB  
   kvflowcontrol.tokens.send.elastic.returned.disconnect             | 5.0 MiB  
   kvflowcontrol.tokens.send.elastic.unaccounted                     | 0 B      
-  kvflowcontrol.tokens.send.regular.available                       | 32 MiB   
+  kvflowcontrol.tokens.send.regular.available                       | 48 MiB   
   kvflowcontrol.tokens.send.regular.deducted                        | 0 B      
   kvflowcontrol.tokens.send.regular.deducted.prevent_send_queue     | 0 B      
   kvflowcontrol.tokens.send.regular.returned                        | 0 B      


### PR DESCRIPTION
In 2c89915, TestFlowControlCrashedNode and TestFlowControlCrashedNodeV2 were set up to run with leader leases. TestFlowControlCrashedNodeV2 soon became flaky (#136292) because after one of the two nodes was stopped, the other node (leader) could step down due to `CheckQuorum`. TestFlowControlCrashedNode flaked similarly under race.

This commit adds a third node to the tests, so the leader can retain leadership in the presence of a single crash. It also enables leader leases back for TestFlowControlCrashedNodeV2.

Part of: #136806

Release note: None