### PR TITLE
logictest: give more resources to cockroach-go-testserver tests

### DIFF
--- a/pkg/cmd/generate-logictest/main.go
+++ b/pkg/cmd/generate-logictest/main.go
@@ -175,11 +175,15 @@ func (t *testdir) dump() error {
 		// allocate the tests which use 3-node clusters 2 vCPUs, and
 		// the ones which use more a bit more.
 		tplCfg.NumCPU = (cfg.NumNodes / 2) + 1
+		if strings.Contains(cfg.Name, "cockroach-go-testserver") {
+			tplCfg.NumCPU = 3
+		}
 		if cfg.Name == "3node-tenant" || strings.HasPrefix(cfg.Name, "multiregion-") {
 			tplCfg.SkipCclUnderRace = true
 		}
 		if strings.Contains(cfg.Name, "5node") ||
 			strings.Contains(cfg.Name, "fakedist") ||
+			strings.Contains(cfg.Name, "cockroach-go-testserver") ||
 			(strings.HasPrefix(cfg.Name, "local-") && !tplCfg.Ccl) ||
 			(cfg.Name == "local" && !tplCfg.Ccl) {
 			tplCfg.UseHeavyPool = true

--- a/pkg/sql/logictest/tests/cockroach-go-testserver-24.3/BUILD.bazel
+++ b/pkg/sql/logictest/tests/cockroach-go-testserver-24.3/BUILD.bazel
@@ -10,9 +10,12 @@ go_test(
         "//pkg/sql/logictest:cockroach_predecessor_version",  # keep
         "//pkg/sql/logictest:testdata",  # keep
     ],
-    exec_properties = {"test.Pool": "large"},
+    exec_properties = select({
+        "//build/toolchains:is_heavy": {"test.Pool": "heavy"},
+        "//conditions:default": {"test.Pool": "large"},
+    }),
     shard_count = 6,
-    tags = ["cpu:2"],
+    tags = ["cpu:3"],
     deps = [
         "//pkg/base",
         "//pkg/build/bazel",


### PR DESCRIPTION
These tests run 3 CockroachDB processes and have encountered flakes recently due to hardware slowness. Adding more resources should help make it less flaky.

informs https://github.com/cockroachdb/cockroach/issues/138270
See this search for many more flakes that were found to be caused by `slow heartbeat` issues: https://github.com/cockroachdb/cockroach/issues?q=sort%3Aupdated-desc+is%3Aissue+cockroach-go-testserver+is%3Aclosed+label%3AX-infra-flake+slow

Release note: None