### PR TITLE
release-24.1: security: add ttl metrics for certificate timeout values

### DIFF
--- a/pkg/security/BUILD.bazel
+++ b/pkg/security/BUILD.bazel
@@ -65,6 +65,7 @@ go_test(
         "cert_expiry_cache_test.go",
         "certificate_loader_test.go",
         "certificate_manager_test.go",
+        "certificate_metrics_test.go",
         "certs_rotation_test.go",
         "certs_tenant_test.go",
         "certs_test.go",

--- a/pkg/security/cert_expiry_cache.go
+++ b/pkg/security/cert_expiry_cache.go
@@ -34,6 +34,11 @@ var ClientCertExpirationCacheCapacity = settings.RegisterIntSetting(
 	1000,
 	settings.WithPublic)
 
+type clientCertExpirationMetrics struct {
+	expiration aggmetric.Gauge
+	ttl        aggmetric.Gauge
+}
+
 // ClientCertExpirationCache contains a cache of gauge objects keyed by
 // SQL username strings. It is a FIFO cache that stores gauges valued by
 // minimum expiration of the client certs seen (per user).
@@ -82,12 +87,14 @@ func NewClientCertExpirationCache(
 			return int64(size) > capacity
 		},
 		OnEvictedEntry: func(entry *cache.Entry) {
-			gauge := entry.Value.(*aggmetric.Gauge)
+			metrics := entry.Value.(*clientCertExpirationMetrics)
 			// The child metric will continue to report into the parent metric even
 			// after unlinking, so we also reset it to 0.
-			gauge.Update(0)
-			gauge.Unlink()
-			c.mu.acc.Shrink(ctx, int64(unsafe.Sizeof(*gauge)))
+			metrics.expiration.Update(0)
+			metrics.expiration.Unlink()
+			metrics.ttl.Update(0)
+			metrics.ttl.Unlink()
+			c.mu.acc.Shrink(ctx, int64(unsafe.Sizeof(*metrics)))
 		},
 	})
 	c.mon = mon.NewMonitorInheritWithLimit(
@@ -107,23 +114,56 @@ func NewClientCertExpirationCache(
 	return c
 }
 
-// Get retrieves the cert expiration for the given username, if it exists.
-// An expiration of 0 indicates an entry was not found.
-func (c *ClientCertExpirationCache) Get(key string) (int64, bool) {
+// GetTTL retrieves seconds till cert expiration for the given username, if it exists.
+// A TTL of 0 indicates an entry was not found.
+func (c *ClientCertExpirationCache) GetTTL(key string) (int64, bool) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	value, ok := c.mu.cache.Get(key)
 	if !ok {
 		return 0, ok
 	}
-	// If the expiration has already been reached, remove the entry and indicate
+	// If the metrics has already been reached, remove the entry and indicate
 	// that the entry was not found.
-	gauge := value.(*aggmetric.Gauge)
-	if gauge.Value() < c.timeNow() {
+	metrics := value.(*clientCertExpirationMetrics)
+	if metrics.expiration.Value() < c.timeNow() {
 		c.mu.cache.Del(key)
 		return 0, false
 	}
-	return gauge.Value(), ok
+	return metrics.ttl.Value(), ok
+}
+
+// GetExpiration retrieves the cert expiration for the given username, if it exists.
+// An expiration of 0 indicates an entry was not found.
+func (c *ClientCertExpirationCache) GetExpiration(key string) (int64, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	value, ok := c.mu.cache.Get(key)
+	if !ok {
+		return 0, ok
+	}
+	// If the metrics has already been reached, remove the entry and indicate
+	// that the entry was not found.
+	metrics := value.(*clientCertExpirationMetrics)
+	if metrics.expiration.Value() < c.timeNow() {
+		c.mu.cache.Del(key)
+		return 0, false
+	}
+	return metrics.expiration.Value(), ok
+}
+
+// ttlFunc returns a function function which takes a time,
+// if the time is past returns 0, otherwise returns the number
+// of seconds until that timestamp
+func ttlFunc(now func() int64, exp int64) func() int64 {
+	return func() int64 {
+		ttl := exp - now()
+		if ttl > 0 {
+			return ttl
+		} else {
+			return 0
+		}
+	}
 }
 
 // MaybeUpsert may update or insert a client cert expiration gauge for a
@@ -131,26 +171,32 @@ func (c *ClientCertExpirationCache) Get(key string) (int64, bool) {
 // old expiration is after the new expiration. This ensures that the cache
 // maintains the minimum expiration for each user.
 func (c *ClientCertExpirationCache) MaybeUpsert(
-	ctx context.Context, key string, newExpiry int64, parentGauge *aggmetric.AggGauge,
+	ctx context.Context,
+	key string,
+	newExpiry int64,
+	parentExpirationGauge *aggmetric.AggGauge,
+	parentTTLGauge *aggmetric.AggGauge,
 ) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
 	value, ok := c.mu.cache.Get(key)
 	if !ok {
-		err := c.mu.acc.Grow(ctx, int64(unsafe.Sizeof(aggmetric.Gauge{})))
+		err := c.mu.acc.Grow(ctx, int64(unsafe.Sizeof(clientCertExpirationMetrics{})))
 		if err == nil {
 			// Only create new gauges for expirations in the future.
 			if newExpiry > c.timeNow() {
-				gauge := parentGauge.AddChild(key)
-				gauge.Update(newExpiry)
-				c.mu.cache.Add(key, gauge)
+				expiration := parentExpirationGauge.AddChild(key)
+				expiration.Update(newExpiry)
+				ttl := parentTTLGauge.AddFunctionalChild(ttlFunc(c.timeNow, newExpiry), key)
+				c.mu.cache.Add(key, &clientCertExpirationMetrics{*expiration, *ttl})
 			}
 		} else {
 			log.Ops.Warningf(ctx, "no memory available to cache cert expiry: %v", err)
 		}
-	} else if gauge := value.(*aggmetric.Gauge); newExpiry < gauge.Value() || gauge.Value() == 0 {
-		gauge.Update(newExpiry)
+	} else if metrics := value.(*clientCertExpirationMetrics); newExpiry < metrics.expiration.Value() || metrics.expiration.Value() == 0 {
+		metrics.expiration.Update(newExpiry)
+		metrics.ttl.UpdateFn(ttlFunc(c.timeNow, newExpiry))
 	}
 }
 
@@ -211,8 +257,8 @@ func (c *ClientCertExpirationCache) PurgePastExpirations() {
 	var deleteEntryKeys []interface{}
 	now := c.timeNow()
 	c.mu.cache.Do(func(entry *cache.Entry) {
-		gauge := entry.Value.(*aggmetric.Gauge)
-		if gauge.Value() <= now {
+		metrics := entry.Value.(*clientCertExpirationMetrics)
+		if metrics.expiration.Value() <= now {
 			deleteEntryKeys = append(deleteEntryKeys, entry.Key)
 		}
 	})

--- a/pkg/security/cert_expiry_cache_test.go
+++ b/pkg/security/cert_expiry_cache_test.go
@@ -36,75 +36,88 @@ func TestEntryCache(t *testing.T) {
 
 	ctx := context.Background()
 
+	timesource := timeutil.NewManualTime(timeutil.Unix(0, 123))
 	// Create a cache with a capacity of 3.
-	cache, metric := newCache(
+	cache, expMetric, ttlMetric := newCache(
 		ctx,
 		&cluster.Settings{},
 		3, /* capacity */
-		timeutil.NewManualTime(timeutil.Unix(0, 123)),
+		timesource,
 	)
 	require.Equal(t, 0, cache.Len())
 
 	// Verify insert.
-	cache.MaybeUpsert(ctx, fooUser, laterExpiration, metric)
+	cache.MaybeUpsert(ctx, fooUser, laterExpiration, expMetric, ttlMetric)
 	require.Equal(t, 1, cache.Len())
 
 	// Verify update.
-	cache.MaybeUpsert(ctx, fooUser, closerExpiration, metric)
+	cache.MaybeUpsert(ctx, fooUser, closerExpiration, expMetric, ttlMetric)
 	require.Equal(t, 1, cache.Len())
 
 	// Verify retrieval.
-	expiration, found := cache.Get(fooUser)
+	expiration, found := cache.GetExpiration(fooUser)
 	require.Equal(t, true, found)
 	require.Equal(t, closerExpiration, expiration)
 
 	// Verify the cache retains the minimum expiration for a user, assuming no
 	// eviction.
-	cache.MaybeUpsert(ctx, barUser, closerExpiration, metric)
+	cache.MaybeUpsert(ctx, barUser, closerExpiration, expMetric, ttlMetric)
 	require.Equal(t, 2, cache.Len())
-	cache.MaybeUpsert(ctx, barUser, laterExpiration, metric)
+	cache.MaybeUpsert(ctx, barUser, laterExpiration, expMetric, ttlMetric)
 	require.Equal(t, 2, cache.Len())
-	expiration, found = cache.Get(barUser)
+	expiration, found = cache.GetExpiration(barUser)
 	require.Equal(t, true, found)
 	require.Equal(t, closerExpiration, expiration)
 
 	// Verify indication of absence for non-existent values.
-	expiration, found = cache.Get(fakeUser)
+	expiration, found = cache.GetExpiration(fakeUser)
 	require.Equal(t, false, found)
 	require.Equal(t, int64(0), expiration)
 
 	// Verify eviction when the capacity is exceeded.
-	cache.MaybeUpsert(ctx, blahUser, laterExpiration, metric)
+	cache.MaybeUpsert(ctx, blahUser, laterExpiration, expMetric, ttlMetric)
 	require.Equal(t, 3, cache.Len())
-	cache.MaybeUpsert(ctx, fakeUser, closerExpiration, metric)
+	cache.MaybeUpsert(ctx, fakeUser, closerExpiration, expMetric, ttlMetric)
 	require.Equal(t, 3, cache.Len())
-	_, found = cache.Get(fooUser)
+	_, found = cache.GetExpiration(fooUser)
 	require.Equal(t, false, found)
-	_, found = cache.Get(barUser)
+	_, found = cache.GetExpiration(barUser)
 	require.Equal(t, true, found)
 
 	// Verify previous entries can be inserted after the cache is cleared.
 	cache.Clear()
 	require.Equal(t, 0, cache.Len())
-	_, found = cache.Get(fooUser)
+	_, found = cache.GetExpiration(fooUser)
 	require.Equal(t, false, found)
-	_, found = cache.Get(barUser)
+	_, found = cache.GetExpiration(barUser)
 	require.Equal(t, false, found)
-	cache.MaybeUpsert(ctx, fooUser, laterExpiration, metric)
+	cache.MaybeUpsert(ctx, fooUser, laterExpiration, expMetric, ttlMetric)
 	require.Equal(t, 1, cache.Len())
-	cache.MaybeUpsert(ctx, barUser, laterExpiration, metric)
+	cache.MaybeUpsert(ctx, barUser, laterExpiration, expMetric, ttlMetric)
 	require.Equal(t, 2, cache.Len())
-	expiration, found = cache.Get(fooUser)
+	expiration, found = cache.GetExpiration(fooUser)
 	require.Equal(t, true, found)
 	require.Equal(t, laterExpiration, expiration)
-	expiration, found = cache.Get(barUser)
+	expiration, found = cache.GetExpiration(barUser)
 	require.Equal(t, true, found)
 	require.Equal(t, laterExpiration, expiration)
 
 	// Verify expirations in the past cannot be inserted into the cache.
 	cache.Clear()
-	cache.MaybeUpsert(ctx, fooUser, int64(0), metric)
+	cache.MaybeUpsert(ctx, fooUser, int64(0), expMetric, ttlMetric)
 	require.Equal(t, 0, cache.Len())
+
+	// Verify value of TTL metrics
+	cache.Clear()
+	timesource.AdvanceTo(timeutil.Unix(closerExpiration+20, 0))
+	cache.MaybeUpsert(ctx, fooUser, closerExpiration, expMetric, ttlMetric)
+	cache.MaybeUpsert(ctx, barUser, laterExpiration, expMetric, ttlMetric)
+	ttl, found := cache.GetTTL(fooUser)
+	require.Equal(t, false, found)
+	require.Equal(t, int64(0), ttl)
+	ttl, found = cache.GetTTL(barUser)
+	require.Equal(t, true, found)
+	require.Equal(t, laterExpiration-(closerExpiration+20), ttl)
 }
 
 func TestPurgePastEntries(t *testing.T) {
@@ -125,15 +138,15 @@ func TestPurgePastEntries(t *testing.T) {
 
 	// Create a cache with a capacity of 4.
 	clock := timeutil.NewManualTime(timeutil.Unix(0, 123))
-	cache, metric := newCache(ctx, &cluster.Settings{}, 4 /* capacity */, clock)
+	cache, expMetric, ttlMetric := newCache(ctx, &cluster.Settings{}, 4 /* capacity */, clock)
 
 	// Insert entries that we expect to be cleaned up after advancing in time.
-	cache.MaybeUpsert(ctx, fooUser, pastExpiration1, metric)
-	cache.MaybeUpsert(ctx, barUser, pastExpiration2, metric)
-	cache.MaybeUpsert(ctx, blahUser, pastExpiration2, metric)
+	cache.MaybeUpsert(ctx, fooUser, pastExpiration1, expMetric, ttlMetric)
+	cache.MaybeUpsert(ctx, barUser, pastExpiration2, expMetric, ttlMetric)
+	cache.MaybeUpsert(ctx, blahUser, pastExpiration2, expMetric, ttlMetric)
 	// Insert an entry that should NOT be removed after advancing in time
 	// because it is still in the future.
-	cache.MaybeUpsert(ctx, bazUser, futureExpiration, metric)
+	cache.MaybeUpsert(ctx, bazUser, futureExpiration, expMetric, ttlMetric)
 	require.Equal(t, 4, cache.Len())
 
 	// Advance time so that expirations have been reached already.
@@ -141,7 +154,7 @@ func TestPurgePastEntries(t *testing.T) {
 
 	// Verify an expiration from the past cannot be retrieved. Confirm it has
 	// been removed after the attempt as well.
-	_, found := cache.Get(fooUser)
+	_, found := cache.GetExpiration(fooUser)
 	require.Equal(t, false, found)
 	require.Equal(t, 3, cache.Len())
 
@@ -149,7 +162,7 @@ func TestPurgePastEntries(t *testing.T) {
 	// Confirm that expirations in the future do not get removed.
 	cache.PurgePastExpirations()
 	require.Equal(t, 1, cache.Len())
-	_, found = cache.Get(bazUser)
+	_, found = cache.GetExpiration(bazUser)
 	require.Equal(t, true, found)
 }
 
@@ -162,7 +175,7 @@ func TestConcurrentUpdates(t *testing.T) {
 	st := &cluster.Settings{}
 
 	// Create a cache with a large capacity.
-	cache, metric := newCache(
+	cache, expMetric, ttlMetric := newCache(
 		ctx,
 		st,
 		10000, /* capacity */
@@ -181,7 +194,7 @@ func TestConcurrentUpdates(t *testing.T) {
 	for i := 0; i < N; i++ {
 		go func(i int) {
 			if i%2 == 1 {
-				cache.MaybeUpsert(ctx, user, expiration, metric)
+				cache.MaybeUpsert(ctx, user, expiration, expMetric, ttlMetric)
 			} else {
 				cache.Clear()
 			}
@@ -196,19 +209,19 @@ func BenchmarkCertExpirationCacheInsert(b *testing.B) {
 	ctx := context.Background()
 	st := &cluster.Settings{}
 	clock := timeutil.NewManualTime(timeutil.Unix(0, 123))
-	cache, metric := newCache(ctx, st, 1000 /* capacity */, clock)
+	cache, expMetric, ttlMetric := newCache(ctx, st, 1000 /* capacity */, clock)
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		cache.MaybeUpsert(ctx, "foo", clock.Now().Unix(), metric)
-		cache.MaybeUpsert(ctx, "bar", clock.Now().Unix(), metric)
-		cache.MaybeUpsert(ctx, "blah", clock.Now().Unix(), metric)
+		cache.MaybeUpsert(ctx, "foo", clock.Now().Unix(), expMetric, ttlMetric)
+		cache.MaybeUpsert(ctx, "bar", clock.Now().Unix(), expMetric, ttlMetric)
+		cache.MaybeUpsert(ctx, "blah", clock.Now().Unix(), expMetric, ttlMetric)
 	}
 }
 
 func newCache(
 	ctx context.Context, st *cluster.Settings, capacity int, clock *timeutil.ManualTime,
-) (*security.ClientCertExpirationCache, *aggmetric.AggGauge) {
+) (*security.ClientCertExpirationCache, *aggmetric.AggGauge, *aggmetric.AggGauge) {
 	stopper := stop.NewStopper()
 	defer stopper.Stop(ctx)
 	security.ClientCertExpirationCacheCapacity.Override(ctx, &st.SV, int64(capacity))
@@ -217,5 +230,5 @@ func newCache(
 		Settings: st,
 	})
 	cache := security.NewClientCertExpirationCache(ctx, st, stopper, clock, parentMon)
-	return cache, aggmetric.MakeBuilder(security.SQLUserLabel).Gauge(metric.Metadata{})
+	return cache, aggmetric.MakeBuilder(security.SQLUserLabel).Gauge(metric.Metadata{}), aggmetric.MakeBuilder(security.SQLUserLabel).Gauge(metric.Metadata{})
 }

--- a/pkg/security/certificate_loader.go
+++ b/pkg/security/certificate_loader.go
@@ -95,6 +95,8 @@ func (p PemUsage) String() string {
 		return "Client"
 	case TenantPem:
 		return "Tenant Client"
+	case TenantSigningPem:
+		return "Tenant Signing"
 	default:
 		return "unknown"
 	}

--- a/pkg/security/certificate_loader_test.go
+++ b/pkg/security/certificate_loader_test.go
@@ -122,9 +122,17 @@ func countLoadedCertificates(certsDir string) (int, error) {
 	return len(cl.Certificates()), nil
 }
 
+func defaultExpiration() time.Time {
+	return timeutil.Now().Add(time.Hour)
+}
+
 // Generate a x509 cert with specific fields.
 func makeTestCert(
-	t *testing.T, commonName string, keyUsage x509.KeyUsage, extUsages []x509.ExtKeyUsage,
+	t *testing.T,
+	commonName string,
+	keyUsage x509.KeyUsage,
+	extUsages []x509.ExtKeyUsage,
+	expiration time.Time,
 ) (*x509.Certificate, []byte) {
 	// Make smallest rsa key possible: not saved.
 	key, err := rsa.GenerateKey(rand.Reader, 512)
@@ -139,7 +147,7 @@ func makeTestCert(
 			CommonName: commonName,
 		},
 		NotBefore: timeutil.Now().Add(-time.Hour),
-		NotAfter:  timeutil.Now().Add(time.Hour),
+		NotAfter:  expiration,
 		KeyUsage:  keyUsage,
 	}
 
@@ -182,13 +190,13 @@ func TestNamingScheme(t *testing.T) {
 	fullKeyUsage := x509.KeyUsageKeyEncipherment | x509.KeyUsageDigitalSignature
 	// Build a few certificates. These are barebones since we only need to check our custom validation,
 	// not chain verification.
-	parsedCACert, caCert := makeTestCert(t, "", 0, nil)
+	parsedCACert, caCert := makeTestCert(t, "", 0, nil, defaultExpiration())
 
-	parsedGoodNodeCert, goodNodeCert := makeTestCert(t, "node", fullKeyUsage, []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth})
-	_, badUserNodeCert := makeTestCert(t, "notnode", fullKeyUsage, []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth})
+	parsedGoodNodeCert, goodNodeCert := makeTestCert(t, "node", fullKeyUsage, []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth}, defaultExpiration())
+	_, badUserNodeCert := makeTestCert(t, "notnode", fullKeyUsage, []x509.ExtKeyUsage{x509.ExtKeyUsageServerAuth, x509.ExtKeyUsageClientAuth}, defaultExpiration())
 
-	parsedGoodRootCert, goodRootCert := makeTestCert(t, "root", fullKeyUsage, []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth})
-	_, notRootCert := makeTestCert(t, "notroot", fullKeyUsage, []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth})
+	parsedGoodRootCert, goodRootCert := makeTestCert(t, "root", fullKeyUsage, []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth}, defaultExpiration())
+	_, notRootCert := makeTestCert(t, "notroot", fullKeyUsage, []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth}, defaultExpiration())
 
 	// Do not use embedded certs.
 	securityassets.ResetLoader()

--- a/pkg/security/certificate_metrics.go
+++ b/pkg/security/certificate_metrics.go
@@ -8,6 +8,7 @@ package security
 import (
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/metric/aggmetric"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 )
 
 const SQLUserLabel = "sql_user"
@@ -31,6 +32,19 @@ type Metrics struct {
 	// The top-level aggregated value for this metric is not meaningful
 	// (it sums up all the minimum expirations of all users).
 	ClientExpiration *aggmetric.AggGauge
+
+	// Below are TTL metrics which mirror the above expiration metrics.
+	// Instead of returning the unix time in seconds however, they
+	// return the number of seconds till expiration.
+	CATTL         *metric.Gauge
+	TenantTTL     *metric.Gauge
+	TenantCATTL   *metric.Gauge
+	UITTL         *metric.Gauge
+	UICATTL       *metric.Gauge
+	ClientCATTL   *metric.Gauge
+	NodeTTL       *metric.Gauge
+	NodeClientTTL *metric.Gauge
+	ClientTTL     *aggmetric.AggGauge
 }
 
 var _ metric.Struct = (*Metrics)(nil)
@@ -82,7 +96,6 @@ var (
 		Measurement: "Certificate Expiration",
 		Unit:        metric.Unit_TIMESTAMP_SEC,
 	}
-
 	metaTenantCAExpiration = metric.Metadata{
 		Name:        "security.certificate.expiration.ca-client-tenant",
 		Help:        "Expiration for the Tenant Client CA certificate. 0 means no certificate or error.",
@@ -95,20 +108,118 @@ var (
 		Measurement: "Certificate Expiration",
 		Unit:        metric.Unit_TIMESTAMP_SEC,
 	}
+
+	metaCATTL = metric.Metadata{
+		Name:        "security.certificate.ttl.ca",
+		Help:        "Seconds till expiration for the CA certificate. 0 means expired, no certificate or error.",
+		Measurement: "Certificate TTL",
+		Unit:        metric.Unit_TIMESTAMP_SEC,
+	}
+	metaClientCATTL = metric.Metadata{
+		Name:        "security.certificate.ttl.client-ca",
+		Help:        "Seconds till expiration for the client CA certificate. 0 means expired, no certificate or error.",
+		Measurement: "Certificate TTL",
+		Unit:        metric.Unit_TIMESTAMP_SEC,
+	}
+	metaClientTTL = metric.Metadata{
+		Name:        "security.certificate.ttl.client",
+		Help:        "Seconds till expiration for the client certificates, labeled by SQL user. 0 means expired, no certificate or error.",
+		Measurement: "Certificate TTL",
+		Unit:        metric.Unit_TIMESTAMP_SEC,
+	}
+	metaUICATTL = metric.Metadata{
+		Name:        "security.certificate.ttl.ui-ca",
+		Help:        "Seconds till expiration for the UI CA certificate. 0 means expired, no certificate or error.",
+		Measurement: "Certificate TTL",
+		Unit:        metric.Unit_TIMESTAMP_SEC,
+	}
+	metaNodeTTL = metric.Metadata{
+		Name:        "security.certificate.ttl.node",
+		Help:        "Seconds till expiration for the node certificate. 0 means expired, no certificate or error.",
+		Measurement: "Certificate TTL",
+		Unit:        metric.Unit_TIMESTAMP_SEC,
+	}
+	metaNodeClientTTL = metric.Metadata{
+		Name:        "security.certificate.ttl.node-client",
+		Help:        "Seconds till expiration for the node's client certificate. 0 means expired, no certificate or error.",
+		Measurement: "Certificate TTL",
+		Unit:        metric.Unit_TIMESTAMP_SEC,
+	}
+	metaUITTL = metric.Metadata{
+		Name:        "security.certificate.ttl.ui",
+		Help:        "Seconds till expiration for the UI certificate. 0 means expired, no certificate or error.",
+		Measurement: "Certificate TTL",
+		Unit:        metric.Unit_TIMESTAMP_SEC,
+	}
+	metaTenantCATTL = metric.Metadata{
+		Name:        "security.certificate.ttl.ca-client-tenant",
+		Help:        "Seconds till expiration for the Tenant Client CA certificate. 0 means expired, no certificate or error.",
+		Measurement: "Certificate TTL",
+		Unit:        metric.Unit_TIMESTAMP_SEC,
+	}
+	metaTenantTTL = metric.Metadata{
+		Name:        "security.certificate.ttl.client-tenant",
+		Help:        "Seconds till expiration for the Tenant Client certificate. 0 means expired, no certificate or error.",
+		Measurement: "Certificate TTL",
+		Unit:        metric.Unit_TIMESTAMP_SEC,
+	}
 )
 
-func makeMetrics() Metrics {
-	b := aggmetric.MakeBuilder(SQLUserLabel)
-	m := Metrics{
-		CAExpiration:         metric.NewGauge(metaCAExpiration),
-		ClientCAExpiration:   metric.NewGauge(metaClientCAExpiration),
-		TenantCAExpiration:   metric.NewGauge(metaTenantCAExpiration),
-		UICAExpiration:       metric.NewGauge(metaUICAExpiration),
-		ClientExpiration:     b.Gauge(metaClientExpiration),
-		TenantExpiration:     metric.NewGauge(metaTenantExpiration),
-		NodeExpiration:       metric.NewGauge(metaNodeExpiration),
-		NodeClientExpiration: metric.NewGauge(metaNodeClientExpiration),
-		UIExpiration:         metric.NewGauge(metaUIExpiration),
+func expirationGauge(metadata metric.Metadata, ci *CertInfo) *metric.Gauge {
+	return metric.NewFunctionalGauge(metadata, func() int64 {
+		if ci != nil && ci.Error == nil {
+			return ci.ExpirationTime.Unix()
+		} else {
+			return 0
+		}
+	})
+}
+func ttlGauge(metadata metric.Metadata, ci *CertInfo, ts timeutil.TimeSource) *metric.Gauge {
+	return metric.NewFunctionalGauge(metadata, func() int64 {
+		if ci != nil && ci.Error == nil {
+			expiry := ci.ExpirationTime.Unix()
+			sec := timeutil.Unix(expiry, 0).Sub(ts.Now()).Seconds()
+			if sec < 0 {
+				return 0
+			}
+			return int64(sec)
+		} else {
+			return 0
+		}
+	})
+}
+
+var defaultTimeSource = timeutil.DefaultTimeSource{}
+
+// createMetricsLocked makes metrics using the certificate values on the manager.
+// If the corresponding certificate is missing or invalid (Error != nil), we reset the
+// metric to zero.
+// cm.mu must be held to protect the certificates. Metrics do their own atomicity.
+func (cm *CertificateManager) createMetricsLocked() Metrics {
+	ts := cm.timeSource
+	if ts == nil {
+		ts = defaultTimeSource
 	}
-	return m
+	b := aggmetric.MakeBuilder(SQLUserLabel)
+	return Metrics{
+		CAExpiration:         expirationGauge(metaCAExpiration, cm.caCert),
+		TenantExpiration:     expirationGauge(metaTenantExpiration, cm.tenantCert),
+		TenantCAExpiration:   expirationGauge(metaTenantCAExpiration, cm.tenantCACert),
+		UIExpiration:         expirationGauge(metaUIExpiration, cm.uiCert),
+		UICAExpiration:       expirationGauge(metaUICAExpiration, cm.uiCACert),
+		ClientExpiration:     b.Gauge(metaClientExpiration),
+		ClientCAExpiration:   expirationGauge(metaClientCAExpiration, cm.clientCACert),
+		NodeExpiration:       expirationGauge(metaNodeExpiration, cm.nodeCert),
+		NodeClientExpiration: expirationGauge(metaNodeClientExpiration, cm.nodeClientCert),
+
+		CATTL:         ttlGauge(metaCATTL, cm.caCert, ts),
+		TenantTTL:     ttlGauge(metaTenantTTL, cm.tenantCert, ts),
+		TenantCATTL:   ttlGauge(metaTenantCATTL, cm.tenantCACert, ts),
+		UITTL:         ttlGauge(metaUITTL, cm.uiCert, ts),
+		UICATTL:       ttlGauge(metaUICATTL, cm.uiCACert, ts),
+		ClientTTL:     b.Gauge(metaClientTTL),
+		ClientCATTL:   ttlGauge(metaClientCATTL, cm.clientCACert, ts),
+		NodeTTL:       ttlGauge(metaNodeTTL, cm.nodeCert, ts),
+		NodeClientTTL: ttlGauge(metaNodeClientTTL, cm.nodeClientCert, ts),
+	}
 }

--- a/pkg/security/certificate_metrics_test.go
+++ b/pkg/security/certificate_metrics_test.go
@@ -1,0 +1,104 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the Business Source License
+// included in the file licenses/BSL.txt.
+//
+// As of the Change Date specified in that file, in accordance with
+// the Business Source License, use of this software will be governed
+// by the Apache License, Version 2.0, included in the file
+// licenses/APL.txt.
+
+package security_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/security"
+	"github.com/cockroachdb/cockroach/pkg/security/securityassets"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+)
+
+// TestMetricsValues asserts that with the appropriate certificates on disk,
+// the correct expiration and ttl values are set on the metrics vars that are
+// exposed to our collectors. It uses a single key pair to approximate the
+// behavior across other key pairs.
+func TestMetricsValues(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	// required to read certs from disk in tests
+	securityassets.ResetLoader()
+	defer ResetTest()
+
+	// now is unix 1, each expiration is +1 after that.
+	// this means an expiration is 1 + cert offset, and ttl is expiration - 1.
+	now := timeutil.Unix(1, 0)
+
+	certsDir := t.TempDir()
+	for offset, certName := range []string{
+		"ca",
+		"ca-client",
+		"ca-client-tenant",
+		"ca-ui",
+		"node",
+		"ui",
+		"client-tenant.1",
+		"client.node",
+	} {
+
+		certFile := certName + ".crt"
+		expiration := offset + 2
+		_, certBytes := makeTestCert(t, "", 0, nil, timeutil.Unix(int64(expiration), 0))
+		if err := os.WriteFile(filepath.Join(certsDir, certFile), certBytes, 0700); err != nil {
+			t.Fatalf("#%d: could not write file %s: %v", offset, certFile, err)
+		}
+
+		keyFile := certName + ".key"
+		if err := os.WriteFile(filepath.Join(certsDir, keyFile), []byte(keyFile), 0700); err != nil {
+			t.Fatalf("#%d: could not write file %s: %v", offset, keyFile, err)
+		}
+	}
+
+	cm, err := security.NewCertificateManager(
+		certsDir,
+		security.CommandTLSSettings{},
+		security.WithTimeSource(timeutil.NewManualTime(now)),
+		security.ForTenant(1),
+	)
+	if err != nil {
+		t.Error(err)
+	}
+
+	metrics := cm.Metrics()
+	checks := []struct {
+		name     string
+		expected int64
+		actual   int64
+	}{
+		{"CA Certificate Expiration", 2, metrics.CAExpiration.Value()},
+		{"CA Certificate TTL", 1, metrics.CATTL.Value()},
+		{"Client CA Certificate Expiration", 3, metrics.ClientCAExpiration.Value()},
+		{"Client CA Certificate TTL", 2, metrics.ClientCATTL.Value()},
+		{"Tenant CA Certificate Expiration", 4, metrics.TenantCAExpiration.Value()},
+		{"Tenant CA Certificate TTL", 3, metrics.TenantCATTL.Value()},
+		{"UI CA Certificate Expiration", 5, metrics.UICAExpiration.Value()},
+		{"UI CA Certificate TTL", 4, metrics.UICATTL.Value()},
+		{"Node Certificate Expiration", 6, metrics.NodeExpiration.Value()},
+		{"Node Certificate TTL", 5, metrics.NodeTTL.Value()},
+		{"UI Certificate Expiration", 7, metrics.UIExpiration.Value()},
+		{"UI Certificate TTL", 6, metrics.UITTL.Value()},
+		{"Tenant Certificate Expiration", 8, metrics.TenantExpiration.Value()},
+		{"Tenant Certificate TTL", 7, metrics.TenantTTL.Value()},
+		{"Node Client Certificate Expiration", 9, metrics.NodeClientExpiration.Value()},
+		{"Node Client Certificate TTL", 8, metrics.NodeClientTTL.Value()},
+		// placeholder client aggregate gauge
+	}
+	for _, check := range checks {
+		if check.expected != check.actual {
+			t.Fatalf("Expected %s to be %d, but instead got %d", check.name, check.expected, check.actual)
+		}
+	}
+
+}

--- a/pkg/security/certificate_metrics_test.go
+++ b/pkg/security/certificate_metrics_test.go
@@ -1,12 +1,7 @@
 // Copyright 2024 The Cockroach Authors.
 //
-// Use of this software is governed by the Business Source License
-// included in the file licenses/BSL.txt.
-//
-// As of the Change Date specified in that file, in accordance with
-// the Business Source License, use of this software will be governed
-// by the Apache License, Version 2.0, included in the file
-// licenses/APL.txt.
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
 
 package security_test
 
@@ -19,24 +14,11 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/security/securityassets"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/stretchr/testify/require"
 )
 
-// TestMetricsValues asserts that with the appropriate certificates on disk,
-// the correct expiration and ttl values are set on the metrics vars that are
-// exposed to our collectors. It uses a single key pair to approximate the
-// behavior across other key pairs.
-func TestMetricsValues(t *testing.T) {
-	defer leaktest.AfterTest(t)()
+func writeTestCerts(t *testing.T, certsDir string) {
 
-	// required to read certs from disk in tests
-	securityassets.ResetLoader()
-	defer ResetTest()
-
-	// now is unix 1, each expiration is +1 after that.
-	// this means an expiration is 1 + cert offset, and ttl is expiration - 1.
-	now := timeutil.Unix(1, 0)
-
-	certsDir := t.TempDir()
 	for offset, certName := range []string{
 		"ca",
 		"ca-client",
@@ -60,6 +42,25 @@ func TestMetricsValues(t *testing.T) {
 			t.Fatalf("#%d: could not write file %s: %v", offset, keyFile, err)
 		}
 	}
+}
+
+// TestMetricsValues asserts that with the appropriate certificates on disk,
+// the correct expiration and ttl values are set on the metrics vars that are
+// exposed to our collectors. It uses a single key pair to approximate the
+// behavior across other key pairs.
+func TestMetricsValues(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	// required to read certs from disk in tests
+	securityassets.ResetLoader()
+	defer ResetTest()
+
+	// now is unix 1, each expiration is +1 after that.
+	// this means an expiration is 1 + cert offset, and ttl is expiration - 1.
+	now := timeutil.Unix(1, 0)
+
+	certsDir := t.TempDir()
+	writeTestCerts(t, certsDir)
 
 	cm, err := security.NewCertificateManager(
 		certsDir,
@@ -101,4 +102,58 @@ func TestMetricsValues(t *testing.T) {
 		}
 	}
 
+}
+
+// TestCertificateReload verifies that when the certificate manager's
+// underlying ceritificates change, the original metrics references (which are
+// the ones registered) also reflect the TTLs on the new certificates.
+func TestCertificateReload(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	// required to read certs from disk in tests
+	securityassets.ResetLoader()
+	defer ResetTest()
+
+	// now is unix 1, each expiration is +1 after that.
+	// this means an expiration is 1 + cert offset, and ttl is expiration - 1.
+	now := timeutil.Unix(1, 0)
+
+	certsDir := t.TempDir()
+	// writeTestCerts writes the ca certificate with an expiration of 2.
+	writeTestCerts(t, certsDir)
+
+	cm, err := security.NewCertificateManager(
+		certsDir,
+		security.CommandTLSSettings{},
+		security.WithTimeSource(timeutil.NewManualTime(now)),
+		security.ForTenant(1),
+	)
+	if err != nil {
+		t.Error(err)
+	}
+
+	caCertExpiration := cm.Metrics().CAExpiration
+	caCertTTL := cm.Metrics().CATTL
+
+	// Validate the starting values, with an expiration of 2 and a now of 1,
+	// expiration = 2, ttl = 1.
+	require.Equal(t, 2, int(caCertExpiration.Value()))
+	require.Equal(t, 1, int(caCertTTL.Value()))
+
+	// overwrite the ca certificate with an expiration of 1000.
+	certFile := "ca.crt"
+	expiration := 1000
+	_, certBytes := makeTestCert(t, "", 0, nil, timeutil.Unix(int64(expiration), 0))
+	if err := os.WriteFile(filepath.Join(certsDir, certFile), certBytes, 0700); err != nil {
+		t.Fatalf("could not write file %s: %v", certFile, err)
+	}
+
+	// reload certificates after new one is written.
+	err = cm.LoadCertificates()
+	require.NoError(t, err)
+
+	// Validate the values after reload, with an expiration of 1000 and a now of 1,
+	// expiration = 1000, ttl = 999.
+	require.Equal(t, 1000, int(caCertExpiration.Value()))
+	require.Equal(t, 999, int(caCertTTL.Value()))
 }

--- a/pkg/util/metric/aggmetric/gauge.go
+++ b/pkg/util/metric/aggmetric/gauge.go
@@ -175,6 +175,11 @@ func (g *Gauge) Update(val int64) {
 	g.parent.g.Inc(val - old)
 }
 
+// UpdateFn updates the function on the gauge.
+func (g *Gauge) UpdateFn(fn func() int64) {
+	g.fn = fn
+}
+
 // AggGaugeFloat64 maintains a value as the sum of its children. The gauge will
 // report to crdb-internal time series only the aggregate sum of all of its
 // children, while its children are additionally exported to prometheus via the


### PR DESCRIPTION
The below changes address the fact that certificate expiration is exposed as a timestamp in our metrics exports, which cannot be leveraged well in metrics query languages. The two commits below add certificate expiration as a ttl in seconds, and fix a bug in the change which will update when new certificates are loaded.

Backport:
  * 1/1 commits from "ops: add ttl metrics for certificate expiration" (#130110)
  * 1/1 commits from "security: bugfix, ensure cert expiry metrics reflect reloaded certs" (#135596)

Please see individual PRs for details.

/cc @cockroachdb/release

Epic: CRDB-40209
Release justification: Adds a ttl metric for certificate expiration.
