### PR TITLE
roachtest: reduce foreground throughput in disk bandwidth test

### DIFF
--- a/pkg/cmd/roachtest/tests/admission_control_disk_bandwidth_overload.go
+++ b/pkg/cmd/roachtest/tests/admission_control_disk_bandwidth_overload.go
@@ -104,7 +104,7 @@ func registerDiskBandwidthOverload(r registry.Registry) {
 				}
 				url := fmt.Sprintf(" {pgurl%s}", c.CRDBNodes())
 				cmd := fmt.Sprintf("./cockroach workload run kv %s --concurrency=2 "+
-					"--splits=1000 --read-percent=50 --min-block-bytes=1024 --max-block-bytes=1024 "+
+					"--splits=1000 --read-percent=50 --min-block-bytes=512 --max-block-bytes=512 "+
 					"--txn-qos='regular' --tolerate-errors %s %s %s",
 					roachtestutil.GetWorkloadHistogramArgs(t, c, labels), foregroundDB, dur, url)
 				c.Run(ctx, option.WithNodes(c.WorkloadNode()), cmd)


### PR DESCRIPTION
In https://github.com/cockroachdb/cockroach/pull/138048, I forgot to change the block size in the actual workload run. It only changed the value for the init.

Fixes #138628.

Release note: None