### PR TITLE
backup: remove bulkio.backup.elide_common_prefix.enabled setting

### DIFF
--- a/pkg/backup/backup_job.go
+++ b/pkg/backup/backup_job.go
@@ -92,12 +92,6 @@ var useBulkOracle = settings.RegisterBoolSetting(
 	"randomize the selection of which replica backs up each range",
 	true)
 
-var elidePrefixes = settings.RegisterBoolSetting(
-	settings.ApplicationLevel,
-	"bulkio.backup.elide_common_prefix.enabled",
-	"remove common prefixes from backup file",
-	true)
-
 func countRows(raw kvpb.BulkOpSummary, pkIDs map[uint64]bool) roachpb.RowCount {
 	res := roachpb.RowCount{DataSize: raw.DataSize}
 	for id, count := range raw.EntryCounts {
@@ -1672,7 +1666,7 @@ func createBackupManifest(
 	elide := execinfrapb.ElidePrefix_None
 	if len(prevBackups) > 0 {
 		elide = prevBackups[0].ElidedPrefix
-	} else if elidePrefixes.Get(&execCfg.Settings.SV) {
+	} else {
 		if len(tenants) > 0 {
 			elide = execinfrapb.ElidePrefix_Tenant
 		} else {

--- a/pkg/backup/testdata/backup-restore/online-restore-prefix-backups
+++ b/pkg/backup/testdata/backup-restore/online-restore-prefix-backups
@@ -9,10 +9,6 @@ new-cluster name=s1 disable-tenant
 
 
 exec-sql
-SET CLUSTER SETTING bulkio.backup.elide_common_prefix.enabled = false;
-----
-
-exec-sql
 CREATE TABLE data.baz (i INT PRIMARY KEY, s STRING);
 INSERT INTO data.baz VALUES (1, 'x'),(2,'y'),(3,'z');
 ----
@@ -40,7 +36,6 @@ SELECT count(*) FROM data.baz;
 ----
 3
 
-exec-sql expect-error-regex=(experimental online restore: descriptor rewrites not supported but required)
+exec-sql 
 RESTORE DATABASE data FROM LATEST IN 'nodelocal://1/cluster/' with EXPERIMENTAL DEFERRED COPY, new_db_name =d2;
 ----
-regex matches error

--- a/pkg/settings/registry.go
+++ b/pkg/settings/registry.go
@@ -250,6 +250,7 @@ var retiredSettings = map[InternalKey]struct{}{
 	"sql.auth.resolve_membership_single_scan.enabled":            {},
 	"storage.single_delete.crash_on_invariant_violation.enabled": {},
 	"storage.single_delete.crash_on_ineffectual.enabled":         {},
+	"bulkio.backup.elide_common_prefix.enabled":                  {},
 }
 
 // grandfatheredDefaultSettings is the list of "grandfathered" existing sql.defaults


### PR DESCRIPTION
This private setting was introduced in 24.1 and was default true to provide more flexibility around whether backup keys should contain prefixes. After a few releases, we have baked prefixless backups sufficiently, so we can remove the setting.

Epic: none

Release note: none