### PR TITLE
logictest: fix heavy pool allocation for cockroach-go tests

### DIFF
--- a/pkg/cmd/generate-logictest/templates.go
+++ b/pkg/cmd/generate-logictest/templates.go
@@ -259,7 +259,7 @@ go_test(
         "//pkg/sql/logictest:testdata",  # keep{{ end }}{{ if .ExecBuildLogicTest }}
         "//pkg/sql/opt/exec/execbuilder:testdata",  # keep{{ end }}
     ],
-    exec_properties = {{ if .SqliteLogicTest }}{"test.Pool": "default"},{{ else if .UseHeavyPool }}select({
+    exec_properties = {{ if .SqliteLogicTest }}{"test.Pool": "default"},{{ else if eq .UseHeavyPool 2 }}{"test.Pool": "heavy"},{{ else if eq .UseHeavyPool 1 }}select({
         "//build/toolchains:is_heavy": {"test.Pool": "heavy"},
         "//conditions:default": {"test.Pool": "large"},
     }),{{ else }}{"test.Pool": "large"},{{ end }}

--- a/pkg/sql/logictest/tests/cockroach-go-testserver-24.3/BUILD.bazel
+++ b/pkg/sql/logictest/tests/cockroach-go-testserver-24.3/BUILD.bazel
@@ -10,10 +10,7 @@ go_test(
         "//pkg/sql/logictest:cockroach_predecessor_version",  # keep
         "//pkg/sql/logictest:testdata",  # keep
     ],
-    exec_properties = select({
-        "//build/toolchains:is_heavy": {"test.Pool": "heavy"},
-        "//conditions:default": {"test.Pool": "large"},
-    }),
+    exec_properties = {"test.Pool": "heavy"},
     shard_count = 6,
     tags = ["cpu:3"],
     deps = [


### PR DESCRIPTION
Previously, the heavy pool would only be used for tests running under deadlock or race. However, since we saw the flakes happening under normal configurations, this commit fixes it so the heavy pool is always used for cockroach-go tests.

informs https://github.com/cockroachdb/cockroach/issues/138270
follow up to https://github.com/cockroachdb/cockroach/pull/138642
Release note: None