### PR TITLE
server: fix admin server Settings RPC redaction logic

### DIFF
--- a/docs/generated/http/full.md
+++ b/docs/generated/http/full.md
@@ -6402,7 +6402,6 @@ SettingsRequest inquires what are the current settings in the cluster.
 | Field | Type | Label | Description | Support status |
 | ----- | ---- | ----- | ----------- | -------------- |
 | keys | [string](#cockroach.server.serverpb.SettingsRequest-string) | repeated | The array of setting keys or names to retrieve. An empty keys array means "all". | [reserved](#support-status) |
-| unredacted_values | [bool](#cockroach.server.serverpb.SettingsRequest-bool) |  | Indicate whether to see unredacted setting values. This is opt-in so that a previous version `cockroach zip` does not start reporting values when this becomes active. For good security, the server only obeys this after it checks that the logger-in user has admin privilege. | [reserved](#support-status) |
 
 
 

--- a/pkg/cli/rpc_node_shutdown.go
+++ b/pkg/cli/rpc_node_shutdown.go
@@ -69,7 +69,6 @@ func doDrain(
 				string(server.QueryShutdownTimeout.InternalKey()),
 				string(kvserver.LeaseTransferPerIterationTimeout.InternalKey()),
 			},
-			UnredactedValues: true,
 		})
 		if err != nil {
 			return err

--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -241,6 +241,7 @@ go_library(
         "//pkg/sql/parser",
         "//pkg/sql/parser/statements",
         "//pkg/sql/pgwire",
+        "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",
         "//pkg/sql/pgwire/pgwirecancel",
         "//pkg/sql/physicalplan",

--- a/pkg/server/application_api/BUILD.bazel
+++ b/pkg/server/application_api/BUILD.bazel
@@ -54,6 +54,7 @@ go_test(
         "//pkg/security/username",
         "//pkg/server",
         "//pkg/server/apiconstants",
+        "//pkg/server/authserver",
         "//pkg/server/diagnostics",
         "//pkg/server/diagnostics/diagnosticspb",
         "//pkg/server/license",
@@ -99,6 +100,8 @@ go_test(
         "@com_github_prometheus_client_model//go",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
+        "@org_golang_google_grpc//codes",
+        "@org_golang_google_grpc//status",
         "@org_golang_x_sync//errgroup",
     ],
 )

--- a/pkg/server/application_api/config_test.go
+++ b/pkg/server/application_api/config_test.go
@@ -8,17 +8,15 @@ package application_api_test
 import (
 	"context"
 	"fmt"
-	"net/url"
 	"reflect"
-	"slices"
-	"sort"
 	"testing"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/ccl"
 	// To ensure the streaming replication cluster setting is defined.
 	_ "github.com/cockroachdb/cockroach/pkg/crosscluster"
-	"github.com/cockroachdb/cockroach/pkg/server/apiconstants"
+	"github.com/cockroachdb/cockroach/pkg/server/authserver"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/server/srvtestutils"
 	"github.com/cockroachdb/cockroach/pkg/settings"
@@ -27,227 +25,138 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
-	"github.com/cockroachdb/cockroach/pkg/util/safesql"
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 func TestAdminAPISettings(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+	ctx := context.Background()
 
-	srv, conn, _ := serverutils.StartServer(t, base.TestServerArgs{})
-	defer srv.Stopper().Stop(context.Background())
-	s := srv.ApplicationLayer()
-
-	// Any bool that defaults to true will work here.
-	const settingKey = "sql.metrics.statement_details.enabled"
-	st := s.ClusterSettings()
-	target := settings.ForSystemTenant
-	if srv.TenantController().StartedDefaultTestTenant() {
-		target = settings.ForVirtualCluster
+	// Test setup
+	settingName := "some.sensitive.setting"
+	settings.RegisterStringSetting(
+		settings.SystemVisible,
+		settings.InternalKey(settingName),
+		"sensitiveSetting",
+		"Im sensitive!",
+		settings.WithPublic,
+		settings.WithReportable(false),
+		settings.Sensitive,
+	)
+	testUsers := map[string]struct {
+		userName           string
+		consoleOnly        bool
+		redactableSettings bool
+		grantRole          string
+	}{
+		// Admin users should be able to se all cluster settings without redaction.
+		"admin_user": {userName: "admin_user", redactableSettings: false, grantRole: "ADMIN"},
+		// Users with MODIFYCLUSTERSETTING should be able to see all cluster
+		// settings without redaction
+		"modify_settings_user": {userName: "modify_settings_user", redactableSettings: false, grantRole: "SYSTEM MODIFYCLUSTERSETTING"},
+		// Users with VIEWCLUSTERSETTING should be able to see all cluster
+		// settings, but sensitive settings are redacted
+		"view_settings_user": {userName: "view_settings_user", redactableSettings: true, grantRole: "SYSTEM VIEWCLUSTERSETTING"},
+		// Users with VIEWACTIVITY and VIEWACTIVITYREDACTED should only be able to
+		// see console specific settings.
+		"view_activity_user":          {userName: "view_activity_user", redactableSettings: true, grantRole: "SYSTEM VIEWACTIVITY", consoleOnly: true},
+		"view_activity_redacted_user": {userName: "view_activity_redacted_user", redactableSettings: true, grantRole: "SYSTEM VIEWACTIVITYREDACTED", consoleOnly: true},
 	}
-	allKeys := settings.Keys(target)
+	ts := serverutils.StartServerOnly(t, base.TestServerArgs{})
+	defer ts.Stopper().Stop(ctx)
+	forSystemTenant := ts.ApplicationLayer().Codec().ForSystemTenant()
+	conn := sqlutils.MakeSQLRunner(ts.ApplicationLayer().SQLConn(t))
+	settingsLastUpdated := make(map[string]*time.Time)
+	rows := conn.Query(t, `SELECT name, "lastUpdated" FROM system.settings`)
+	defer rows.Close()
+	for rows.Next() {
+		var name string
+		var lastUpdated *time.Time
 
-	checkSetting := func(t *testing.T, k settings.InternalKey, v serverpb.SettingsResponse_Value) {
-		ref, ok := settings.LookupForReportingByKey(k, target)
-		if !ok {
-			t.Fatalf("%s: not found after initial lookup", k)
+		if err := rows.Scan(&name, &lastUpdated); err != nil {
+			t.Fatal(err)
 		}
-		typ := ref.Typ()
+		settingsLastUpdated[name] = lastUpdated
+	}
 
-		if !settings.TestingIsReportable(ref) {
-			if v.Value != "<redacted>" && v.Value != "" {
-				t.Errorf("%s: expected redacted value for %v, got %s", k, ref, v.Value)
-			}
+	for _, u := range testUsers {
+		conn.Exec(t, fmt.Sprintf("CREATE USER IF NOT EXISTS %s", u.userName))
+		conn.Exec(t, fmt.Sprintf("GRANT %s TO %s", u.grantRole, u.userName))
+	}
+
+	// Runs test cases on each user in testUsers twice, once with redact_sensitive_settings
+	// enabled and once with it disabled.
+	testutils.RunTrueAndFalse(t, "redact sensitive", func(t *testing.T, redactSensitive bool) {
+		if redactSensitive {
+			conn.Exec(t, "SET CLUSTER SETTING server.redact_sensitive_settings.enabled=t")
 		} else {
-			if ref.String(&st.SV) != v.Value {
-				t.Errorf("%s: expected value %v, got %s", k, ref, v.Value)
-			}
+			conn.Exec(t, "SET CLUSTER SETTING server.redact_sensitive_settings.enabled=f")
 		}
-
-		if expectedPublic := ref.Visibility() == settings.Public; expectedPublic != v.Public {
-			t.Errorf("%s: expected public %v, got %v", k, expectedPublic, v.Public)
-		}
-
-		if desc := ref.Description(); desc != v.Description {
-			t.Errorf("%s: expected description %s, got %s", k, desc, v.Description)
-		}
-		if typ != v.Type {
-			t.Errorf("%s: expected type %s, got %s", k, typ, v.Type)
-		}
-		if v.LastUpdated != nil {
-			db := sqlutils.MakeSQLRunner(conn)
-			q := safesql.NewQuery()
-			q.Append(`SELECT name, "lastUpdated" FROM system.settings WHERE name=$`, k)
-			rows := db.Query(
-				t,
-				q.String(),
-				q.QueryArguments()...,
-			)
-			defer rows.Close()
-			if rows.Next() == false {
-				t.Errorf("missing sql row for %s", k)
-			}
-		}
-	}
-
-	t.Run("all", func(t *testing.T) {
-		var resp serverpb.SettingsResponse
-
-		if err := srvtestutils.GetAdminJSONProto(s, "settings", &resp); err != nil {
-			t.Fatal(err)
-		}
-
-		// Check that all expected keys were returned.
-		if len(allKeys) != len(resp.KeyValues) {
-			t.Fatalf("expected %d keys, got %d", len(allKeys), len(resp.KeyValues))
-		}
-		for _, k := range allKeys {
-			if _, ok := resp.KeyValues[string(k)]; !ok {
-				t.Fatalf("expected key %s not found in response", k)
-			}
-		}
-
-		// Check that the test key is listed and the values come indeed
-		// from the settings package unchanged.
-		seenRef := false
-		for k, v := range resp.KeyValues {
-			if k == settingKey {
-				seenRef = true
-				if v.Value != "true" {
-					t.Errorf("%s: expected true, got %s", k, v.Value)
+		for _, u := range testUsers {
+			t.Run(u.userName, func(t *testing.T) {
+				authCtx := authserver.ForwardHTTPAuthInfoToRPCCalls(authserver.ContextWithHTTPAuthInfo(ctx, u.userName, 1), nil)
+				resp, err := ts.GetAdminClient(t).Settings(authCtx, &serverpb.SettingsRequest{})
+				require.NoError(t, err)
+				var keys []settings.InternalKey
+				// users with consoleOnly flag are expected to only be able to see
+				// console specific settings
+				if u.consoleOnly {
+					keys = settings.ConsoleKeys()
+				} else {
+					keys = settings.Keys(forSystemTenant)
+					require.Contains(t, resp.KeyValues, settingName)
 				}
-			}
-
-			checkSetting(t, settings.InternalKey(k), v)
+				for _, internalKey := range keys {
+					keyAsString := string(internalKey)
+					setting, ok := settings.LookupForLocalAccessByKey(internalKey, forSystemTenant)
+					require.True(t, ok)
+					settingResponse := resp.KeyValues[keyAsString]
+					settingVal := settingResponse.Value
+					// If the setting is "sensitive", the setting is not empty, the
+					// redact_sensitive_settings is true, and the user being tested
+					// is not allowed to see sensitive settings, the value should
+					// be redacted
+					if settings.TestingIsSensitive(setting) && settingVal != "" && redactSensitive && u.redactableSettings {
+						require.Equalf(t, "<redacted>", settingVal, "Expected %s to be <redacted>, but got %s", keyAsString, settingVal)
+					} else {
+						require.NotEqualf(t, "<redacted>", settingVal, "Expected %s to be %s, but got <redacted>", keyAsString, settingVal)
+					}
+					require.Equal(t, setting.Description(), settingResponse.Description)
+					require.Equal(t, setting.Typ(), settingResponse.Type)
+					require.Equal(t, string(setting.Name()), settingResponse.Name)
+					if lu, ok := settingsLastUpdated[keyAsString]; ok {
+						require.Equal(t, lu.UTC(), *settingResponse.LastUpdated)
+					}
+				}
+			})
 		}
 
-		if !seenRef {
-			t.Fatalf("failed to observe test setting %s, got %+v", settingKey, resp.KeyValues)
-		}
-	})
+		t.Run("no permission", func(t *testing.T) {
+			userName := "no_permission"
+			conn.Exec(t, fmt.Sprintf("CREATE USER IF NOT EXISTS %s", userName))
+			authCtx := authserver.ForwardHTTPAuthInfoToRPCCalls(authserver.ContextWithHTTPAuthInfo(ctx, userName, 1), nil)
+			_, err := ts.GetAdminClient(t).Settings(authCtx, &serverpb.SettingsRequest{})
+			require.Error(t, err)
+			grpcStatus, ok := status.FromError(err)
+			require.True(t, ok)
+			require.Equal(t, codes.PermissionDenied, grpcStatus.Code())
 
-	t.Run("one-by-one", func(t *testing.T) {
-		var resp serverpb.SettingsResponse
+		})
 
-		// All the settings keys must be retrievable, and their
-		// type and description must match.
-		for _, k := range allKeys {
-			q := make(url.Values)
-			q.Add("keys", string(k))
-			url := "settings?" + q.Encode()
-			if err := srvtestutils.GetAdminJSONProto(s, url, &resp); err != nil {
-				t.Fatalf("%s: %v", k, err)
-			}
-			if len(resp.KeyValues) != 1 {
-				t.Fatalf("%s: expected 1 response, got %d", k, len(resp.KeyValues))
-			}
-			v, ok := resp.KeyValues[string(k)]
-			if !ok {
-				t.Fatalf("%s: response does not contain key", k)
-			}
+		t.Run("filter keys", func(t *testing.T) {
+			resp, err := ts.GetAdminClient(t).Settings(ctx, &serverpb.SettingsRequest{Keys: []string{settingName}})
+			require.NoError(t, err)
+			require.Contains(t, resp.KeyValues, settingName)
+			require.Len(t, resp.KeyValues, 1)
 
-			checkSetting(t, k, v)
-		}
-	})
-
-	t.Run("different-permissions", func(t *testing.T) {
-		var resp serverpb.SettingsResponse
-		nonAdminUser := apiconstants.TestingUserNameNoAdmin().Normalized()
-		var consoleKeys []settings.InternalKey
-		for _, k := range settings.ConsoleKeys() {
-			if _, ok := settings.LookupForLocalAccessByKey(k, target); !ok {
-				continue
-			}
-			consoleKeys = append(consoleKeys, k)
-		}
-		sort.Slice(consoleKeys, func(i, j int) bool { return consoleKeys[i] < consoleKeys[j] })
-
-		// Admin should return all cluster settings.
-		if err := srvtestutils.GetAdminJSONProtoWithAdminOption(s, "settings", &resp, true); err != nil {
-			t.Fatal(err)
-		}
-		require.True(t, len(resp.KeyValues) == len(allKeys))
-
-		// Admin requesting specific cluster setting should return that cluster setting.
-		if err := srvtestutils.GetAdminJSONProtoWithAdminOption(s, "settings?keys=sql.stats.persisted_rows.max",
-			&resp, true); err != nil {
-			t.Fatal(err)
-		}
-		require.NotNil(t, resp.KeyValues["sql.stats.persisted_rows.max"])
-		require.True(t, len(resp.KeyValues) == 1)
-
-		// Non-admin with no permission should return error message.
-		err := srvtestutils.GetAdminJSONProtoWithAdminOption(s, "settings", &resp, false)
-		require.Error(t, err, "this operation requires the VIEWCLUSTERSETTING or MODIFYCLUSTERSETTING system privileges")
-
-		// Non-admin with VIEWCLUSTERSETTING permission should return all cluster settings.
-		_, err = conn.Exec(fmt.Sprintf("ALTER USER %s VIEWCLUSTERSETTING", nonAdminUser))
-		require.NoError(t, err)
-		if err := srvtestutils.GetAdminJSONProtoWithAdminOption(s, "settings", &resp, false); err != nil {
-			t.Fatal(err)
-		}
-		require.True(t, len(resp.KeyValues) == len(allKeys))
-
-		// Non-admin with VIEWCLUSTERSETTING permission requesting specific cluster setting should return that cluster setting.
-		if err := srvtestutils.GetAdminJSONProtoWithAdminOption(s, "settings?keys=sql.stats.persisted_rows.max",
-			&resp, false); err != nil {
-			t.Fatal(err)
-		}
-		require.NotNil(t, resp.KeyValues["sql.stats.persisted_rows.max"])
-		require.True(t, len(resp.KeyValues) == 1)
-
-		// Non-admin with VIEWCLUSTERSETTING and VIEWACTIVITY permission should return all cluster settings.
-		_, err = conn.Exec(fmt.Sprintf("ALTER USER %s VIEWACTIVITY", nonAdminUser))
-		require.NoError(t, err)
-		if err := srvtestutils.GetAdminJSONProtoWithAdminOption(s, "settings", &resp, false); err != nil {
-			t.Fatal(err)
-		}
-		require.True(t, len(resp.KeyValues) == len(allKeys))
-
-		// Non-admin with VIEWCLUSTERSETTING and VIEWACTIVITY permission requesting specific cluster setting
-		// should return that cluster setting
-		if err := srvtestutils.GetAdminJSONProtoWithAdminOption(s, "settings?keys=sql.stats.persisted_rows.max",
-			&resp, false); err != nil {
-			t.Fatal(err)
-		}
-		require.NotNil(t, resp.KeyValues["sql.stats.persisted_rows.max"])
-		require.True(t, len(resp.KeyValues) == 1)
-
-		// Non-admin with VIEWACTIVITY and not VIEWCLUSTERSETTING should only see console cluster settings.
-		_, err = conn.Exec(fmt.Sprintf("ALTER USER %s NOVIEWCLUSTERSETTING", nonAdminUser))
-		require.NoError(t, err)
-		if err := srvtestutils.GetAdminJSONProtoWithAdminOption(s, "settings", &resp, false); err != nil {
-			t.Fatal(err)
-		}
-
-		gotKeys := make([]string, 0, len(resp.KeyValues))
-		for k := range resp.KeyValues {
-			gotKeys = append(gotKeys, k)
-		}
-		sort.Strings(gotKeys)
-		require.Equal(t, len(consoleKeys), len(resp.KeyValues), "found:\n%+v\nexpected:\n%+v", gotKeys, consoleKeys)
-		for k := range resp.KeyValues {
-			require.True(t, slices.Contains(consoleKeys, settings.InternalKey(k)))
-		}
-
-		// Non-admin with VIEWACTIVITY and not VIEWCLUSTERSETTING permission requesting specific cluster setting
-		// from console should return that cluster setting
-		if err := srvtestutils.GetAdminJSONProtoWithAdminOption(s, "settings?keys=ui.display_timezone",
-			&resp, false); err != nil {
-			t.Fatal(err)
-		}
-		require.NotNil(t, resp.KeyValues["ui.display_timezone"])
-		require.True(t, len(resp.KeyValues) == 1)
-
-		// Non-admin with VIEWACTIVITY and not VIEWCLUSTERSETTING permission requesting specific cluster setting
-		// that is not from console should not return that cluster setting
-		if err := srvtestutils.GetAdminJSONProtoWithAdminOption(s, "settings?keys=sql.stats.persisted_rows.max",
-			&resp, false); err != nil {
-			t.Fatal(err)
-		}
-		require.True(t, len(resp.KeyValues) == 0)
+			resp, err = ts.GetAdminClient(t).Settings(ctx, &serverpb.SettingsRequest{Keys: []string{"random.key"}})
+			require.NoError(t, err)
+			require.Empty(t, resp.KeyValues)
+		})
 	})
 }
 

--- a/pkg/server/serverpb/admin.proto
+++ b/pkg/server/serverpb/admin.proto
@@ -596,13 +596,7 @@ message SettingsRequest {
   // The array of setting keys or names to retrieve.
   // An empty keys array means "all".
   repeated string keys = 1;
-
-  // Indicate whether to see unredacted setting values.
-  // This is opt-in so that a previous version `cockroach zip`
-  // does not start reporting values when this becomes active.
-  // For good security, the server only obeys this after it checks
-  // that the logger-in user has admin privilege.
-  bool unredacted_values = 2;
+  reserved 2;
 }
 
 // SettingsResponse is the response to SettingsRequest.

--- a/pkg/settings/common.go
+++ b/pkg/settings/common.go
@@ -172,3 +172,22 @@ type internalSetting interface {
 	// are not run against the decoded value.
 	decodeAndSetDefaultOverride(ctx context.Context, sv *Values, encoded string) error
 }
+
+// TestingIsReportable is used in testing for reportability.
+func TestingIsReportable(s Setting) bool {
+	if _, ok := s.(*MaskedSetting); ok {
+		return false
+	}
+	if e, ok := s.(internalSetting); ok {
+		return e.isReportable()
+	}
+	return true
+}
+
+// TestingIsSensitive is used in testing for sensitivity.
+func TestingIsSensitive(s Setting) bool {
+	if e, ok := s.(internalSetting); ok {
+		return e.isSensitive()
+	}
+	return false
+}

--- a/pkg/settings/masked.go
+++ b/pkg/settings/masked.go
@@ -90,14 +90,3 @@ func (s *MaskedSetting) ValueOrigin(ctx context.Context, sv *Values) ValueOrigin
 func (s *MaskedSetting) IsUnsafe() bool {
 	return s.setting.IsUnsafe()
 }
-
-// TestingIsReportable is used in testing for reportability.
-func TestingIsReportable(s Setting) bool {
-	if _, ok := s.(*MaskedSetting); ok {
-		return false
-	}
-	if e, ok := s.(internalSetting); ok {
-		return e.isReportable()
-	}
-	return true
-}


### PR DESCRIPTION
Previously admin.Settings only allowed admins to view all cluster settings without redaction. If the
requester was not an admin, would use the isReportable field on settings to determine if the setting should be redacted or not. This API also had outdated logic, as users with the MODIFYCLUSTERSETTINGS should also be able to view all cluster settings (See #115356 for more discussions on this).

This patch respects this new role, and no longer uses the `isReportable` setting flag to determine if a setting should be redacted. This is implemented by query `crdb_internal.cluster_settings` directly, allowing the sql layer to permission check.

This commit also removes the `unredacted_values` from the request entity as well, since it is no longer necessary.

Ultimately, this commit updates the Settings RPC to have the same redaction logic as querying `crdb_internal.cluster_settings` or using `SHOW CLUSTER SETTINGS`.

Epic: None
Fixes: #137698
Release note (general change): The /_admin/v1/settings API now returns cluster settings using the same redaction logic as querying `SHOW CLUSTER SETTINGS` and `crdb_internal.cluster_settings`. This means that only settings flagged as "sensitive" will be redacted, all other settings will be visible. The same authorization is required for this endpoint, meaning the user must be an admin or have MODIFYCLUSTERSETTINGS or VIEWCLUSTERSETTINGS roles to hit this API. The exception is that if the user has VIEWACTIVITY or VIEWACTIVITYREDACTED, they will see console only settings.