### PR TITLE
raft: remove atomicTimestamp for fortificationtracker

### DIFF
--- a/pkg/raft/raft.go
+++ b/pkg/raft/raft.go
@@ -923,6 +923,7 @@ func (r *raft) bcastDeFortify() {
 	assertTrue(r.fortificationTracker.CanDefortify(), "unsafe to de-fortify")
 
 	r.trk.Visit(func(id pb.PeerID, _ *tracker.Progress) {
+		fmt.Printf("Sending defortify to %v\n", id)
 		r.sendDeFortify(id)
 	})
 }
@@ -1174,6 +1175,7 @@ func (r *raft) tickElection() {
 	r.heartbeatElapsed++
 	if r.heartbeatElapsed >= r.heartbeatTimeout {
 		r.heartbeatElapsed = 0
+
 		if r.shouldBcastDeFortify() {
 			r.bcastDeFortify()
 		}

--- a/pkg/raft/rawnode_test.go
+++ b/pkg/raft/rawnode_test.go
@@ -68,6 +68,12 @@ func TestRawNodeStep(t *testing.T) {
 // that it applies and that the resulting ConfState matches expectations, and for
 // joint configurations makes sure that they are exited successfully.
 func TestRawNodeProposeAndConfChange(t *testing.T) {
+	testutils.RunTrueAndFalse(t, "store-liveness-enabled",
+		func(t *testing.T, storeLivenessEnabled bool) {
+			testRawNodeProposeAndConfChange(t, storeLivenessEnabled)
+		})
+}
+func testRawNodeProposeAndConfChange(t *testing.T, storeLivenessEnabled bool) {
 	testCases := []struct {
 		cc   pb.ConfChangeI
 		exp  pb.ConfState
@@ -180,10 +186,28 @@ func TestRawNodeProposeAndConfChange(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run("", func(t *testing.T) {
 			s := newTestMemoryStorage(withPeers(1))
-			rawNode, err := NewRawNode(newTestConfig(1, 10, 1, s))
-			require.NoError(t, err)
 
+			var fabric *raftstoreliveness.LivenessFabric
+			var rawNode *RawNode
+			var err error
+			if storeLivenessEnabled {
+				fabric = raftstoreliveness.NewLivenessFabricWithPeers(1, 2, 3)
+				rawNode, err = NewRawNode(newTestConfig(1, 10, 1, s,
+					withStoreLiveness(fabric.GetStoreLiveness(1))))
+			} else {
+				rawNode, err = NewRawNode(newTestConfig(1, 10, 1, s,
+					withStoreLiveness(raftstoreliveness.Disabled{})))
+			}
+			require.NoError(t, err)
 			rawNode.Campaign()
+
+			if storeLivenessEnabled {
+				// This is a bit of a hack: we need to make sure that the leader doesn't
+				// return a leaderMaxSupported to be an infinite time. Since we won't be
+				// able to perform a conf change until the current time is past the
+				// leaderMaxSupported.
+				fabric.WithdrawSupportForPeerFromAllPeers(1)
+			}
 			proposed := false
 			var (
 				lastIndex uint64
@@ -211,6 +235,11 @@ func TestRawNodeProposeAndConfChange(t *testing.T) {
 					}
 				}
 				rawNode.Advance(rd)
+				if storeLivenessEnabled {
+					// Revert the support state to how it was so that the test can run
+					// without having peer 1 not supported.
+					fabric.GrantSupportForPeerFromAllPeers(1)
+				}
 				// Once we are the leader, propose a command and a ConfChange.
 				if !proposed && rd.HardState.Lead == rawNode.raft.id {
 					require.NoError(t, rawNode.Propose([]byte("somedata")))
@@ -353,8 +382,20 @@ func testRawNodeJointAutoLeave(t *testing.T, storeLivenessEnabled bool) {
 			if cc != nil {
 				// Force it to step down.
 				rawNode.Step(pb.Message{Type: pb.MsgHeartbeatResp, From: 1, Term: rawNode.raft.Term + 1})
+
+				if storeLivenessEnabled {
+					// At this point, the leader is attempting to step down, and it will
+					// need to wait until the support has expired.
+					fabric.SetSupportExpired(rawNode.raft.id, true)
+					rawNode.Tick()
+				}
+
 				require.Equal(t, pb.StateFollower, rawNode.raft.state)
 				if storeLivenessEnabled {
+					// We can now restore the support so that the test can proceed as
+					// expected.
+					fabric.SetSupportExpired(rawNode.raft.id, false)
+
 					// And also wait for defortification.
 					for range rawNode.raft.heartbeatTimeout {
 						rawNode.Tick()

--- a/pkg/raft/status.go
+++ b/pkg/raft/status.go
@@ -98,7 +98,7 @@ func getBasicStatus(r *raft) BasicStatus {
 	// NOTE: we assign to LeadSupportUntil even if RaftState is not currently
 	// StateLeader. The replica may have been the leader and stepped down to a
 	// follower before its lead support ran out.
-	s.LeadSupportUntil = r.fortificationTracker.LeadSupportUntil(r.state)
+	s.LeadSupportUntil = r.fortificationTracker.LeadSupportUntil()
 
 	assertTrue((s.RaftState == pb.StateLeader) == (s.Lead == r.id), "inconsistent lead / raft state")
 	return s

--- a/pkg/raft/testdata/confchange_v2_add_double_auto.txt
+++ b/pkg/raft/testdata/confchange_v2_add_double_auto.txt
@@ -63,6 +63,7 @@ CommittedEntries:
 1/3 EntryNormal ""
 1/4 EntryConfChangeV2 v2 v3
 INFO 1 switched to configuration voters=(1 2 3)&&(1) autoleave
+INFO 1 ignoring conf change {ConfChangeTransitionAuto [] []} at config voters=(1 2 3)&&(1) autoleave: lead support has not caught up to previous configuration
 INFO initiating automatic transition out of joint configuration voters=(1 2 3)&&(1) autoleave
 
 # n1 immediately probes n2 and n3.
@@ -71,7 +72,7 @@ stabilize 1
 > 1 handling Ready
   Ready MustSync=true:
   Entries:
-  1/5 EntryConfChangeV2
+  1/5 EntryNormal ""
   Messages:
   1->2 MsgFortifyLeader Term:1 Log:0/0
   1->3 MsgFortifyLeader Term:1 Log:0/0
@@ -110,14 +111,14 @@ stabilize 1 2
   Messages:
   1->2 MsgApp Term:1 Log:1/3 Commit:4 Entries:[
     1/4 EntryConfChangeV2 v2 v3
-    1/5 EntryConfChangeV2
+    1/5 EntryNormal ""
   ]
   1->2 MsgSnap Term:1 Log:0/0
     Snapshot: Index:4 Term:1 ConfState:Voters:[1 2 3] VotersOutgoing:[1] Learners:[] LearnersNext:[] AutoLeave:true
 > 2 receiving messages
   1->2 MsgApp Term:1 Log:1/3 Commit:4 Entries:[
     1/4 EntryConfChangeV2 v2 v3
-    1/5 EntryConfChangeV2
+    1/5 EntryNormal ""
   ]
   DEBUG 2 [logterm: 0, index: 3] rejected MsgApp [logterm: 1, index: 3] from 1
   1->2 MsgSnap Term:1 Log:0/0
@@ -141,13 +142,13 @@ stabilize 1 2
 > 1 handling Ready
   Ready MustSync=false:
   Messages:
-  1->2 MsgApp Term:1 Log:1/4 Commit:4 Entries:[1/5 EntryConfChangeV2]
+  1->2 MsgApp Term:1 Log:1/4 Commit:4 Entries:[1/5 EntryNormal ""]
 > 2 receiving messages
-  1->2 MsgApp Term:1 Log:1/4 Commit:4 Entries:[1/5 EntryConfChangeV2]
+  1->2 MsgApp Term:1 Log:1/4 Commit:4 Entries:[1/5 EntryNormal ""]
 > 2 handling Ready
   Ready MustSync=true:
   Entries:
-  1/5 EntryConfChangeV2
+  1/5 EntryNormal ""
   Messages:
   2->1 MsgAppResp Term:1 Log:0/5 Commit:4
 > 1 receiving messages
@@ -156,26 +157,61 @@ stabilize 1 2
   Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:5 Lead:1 LeadEpoch:1
   CommittedEntries:
-  1/5 EntryConfChangeV2
+  1/5 EntryNormal ""
   Messages:
   1->2 MsgApp Term:1 Log:1/5 Commit:5
-  INFO 1 switched to configuration voters=(1 2 3)
+  INFO initiating automatic transition out of joint configuration voters=(1 2 3)&&(1) autoleave
 > 2 receiving messages
   1->2 MsgApp Term:1 Log:1/5 Commit:5
+> 1 handling Ready
+  Ready MustSync=true:
+  Entries:
+  1/6 EntryConfChangeV2
+  Messages:
+  1->2 MsgApp Term:1 Log:1/5 Commit:5 Entries:[1/6 EntryConfChangeV2]
+> 2 handling Ready
+  Ready MustSync=true:
+  HardState Term:1 Commit:5 Lead:1 LeadEpoch:1
+  CommittedEntries:
+  1/5 EntryNormal ""
+  Messages:
+  2->1 MsgAppResp Term:1 Log:0/5 Commit:5
+> 1 receiving messages
+  2->1 MsgAppResp Term:1 Log:0/5 Commit:5
+> 2 receiving messages
+  1->2 MsgApp Term:1 Log:1/5 Commit:5 Entries:[1/6 EntryConfChangeV2]
+> 2 handling Ready
+  Ready MustSync=true:
+  Entries:
+  1/6 EntryConfChangeV2
+  Messages:
+  2->1 MsgAppResp Term:1 Log:0/6 Commit:5
+> 1 receiving messages
+  2->1 MsgAppResp Term:1 Log:0/6 Commit:5
+> 1 handling Ready
+  Ready MustSync=true:
+  HardState Term:1 Vote:1 Commit:6 Lead:1 LeadEpoch:1
+  CommittedEntries:
+  1/6 EntryConfChangeV2
+  Messages:
+  1->2 MsgApp Term:1 Log:1/6 Commit:6
+  INFO 1 switched to configuration voters=(1 2 3)
+> 2 receiving messages
+  1->2 MsgApp Term:1 Log:1/6 Commit:6
 > 1 handling Ready
   Ready MustSync=false:
   Messages:
   1->3 MsgFortifyLeader Term:1 Log:0/0
 > 2 handling Ready
   Ready MustSync=true:
-  HardState Term:1 Commit:5 Lead:1 LeadEpoch:1
+  HardState Term:1 Commit:6 Lead:1 LeadEpoch:1
   CommittedEntries:
-  1/5 EntryConfChangeV2
+  1/6 EntryConfChangeV2
   Messages:
-  2->1 MsgAppResp Term:1 Log:0/5 Commit:5
+  2->1 MsgAppResp Term:1 Log:0/6 Commit:6
   INFO 2 switched to configuration voters=(1 2 3)
 > 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/5 Commit:5
+  2->1 MsgAppResp Term:1 Log:0/6 Commit:6
 
 # n3 immediately receives a snapshot in the final configuration.
 stabilize 1 3
@@ -200,42 +236,44 @@ stabilize 1 3
   3->1 MsgAppResp Term:1 Log:0/3 Rejected (Hint: 0)
   DEBUG 1 received MsgAppResp(rejected, hint: (index 0, term 0)) from 3 for index 3
   DEBUG 1 decreased progress of 3 to [StateProbe match=0 next=1 sentCommit=0 matchCommit=0]
-  DEBUG 1 [firstindex: 3, commit: 5] sent snapshot[index: 5, term: 1] to 3 [StateProbe match=0 next=1 sentCommit=0 matchCommit=0]
-  DEBUG 1 paused sending replication messages to 3 [StateSnapshot match=0 next=6 sentCommit=5 matchCommit=0 paused pendingSnap=5]
+  DEBUG 1 [firstindex: 3, commit: 6] sent snapshot[index: 6, term: 1] to 3 [StateProbe match=0 next=1 sentCommit=0 matchCommit=0]
+  DEBUG 1 paused sending replication messages to 3 [StateSnapshot match=0 next=7 sentCommit=6 matchCommit=0 paused pendingSnap=6]
   3->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:1
 > 1 handling Ready
   Ready MustSync=false:
   Messages:
-  1->3 MsgApp Term:1 Log:1/3 Commit:5 Entries:[
+  1->3 MsgApp Term:1 Log:1/3 Commit:6 Entries:[
     1/4 EntryConfChangeV2 v2 v3
-    1/5 EntryConfChangeV2
+    1/5 EntryNormal ""
+    1/6 EntryConfChangeV2
   ]
   1->3 MsgSnap Term:1 Log:0/0
-    Snapshot: Index:5 Term:1 ConfState:Voters:[1 2 3] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
+    Snapshot: Index:6 Term:1 ConfState:Voters:[1 2 3] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
 > 3 receiving messages
-  1->3 MsgApp Term:1 Log:1/3 Commit:5 Entries:[
+  1->3 MsgApp Term:1 Log:1/3 Commit:6 Entries:[
     1/4 EntryConfChangeV2 v2 v3
-    1/5 EntryConfChangeV2
+    1/5 EntryNormal ""
+    1/6 EntryConfChangeV2
   ]
   DEBUG 3 [logterm: 0, index: 3] rejected MsgApp [logterm: 1, index: 3] from 1
   1->3 MsgSnap Term:1 Log:0/0
-    Snapshot: Index:5 Term:1 ConfState:Voters:[1 2 3] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
-  INFO log [committed=0, applied=0, applying=0, unstable.offset=1, unstable.offsetInProgress=1, len(unstable.Entries)=0] starts to restore snapshot [index: 5, term: 1]
+    Snapshot: Index:6 Term:1 ConfState:Voters:[1 2 3] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
+  INFO log [committed=0, applied=0, applying=0, unstable.offset=1, unstable.offsetInProgress=1, len(unstable.Entries)=0] starts to restore snapshot [index: 6, term: 1]
   INFO 3 switched to configuration voters=(1 2 3)
-  INFO 3 [commit: 5, lastindex: 5, lastterm: 1] restored snapshot [index: 5, term: 1]
-  INFO 3 [commit: 5] restored snapshot [index: 5, term: 1]
+  INFO 3 [commit: 6, lastindex: 6, lastterm: 1] restored snapshot [index: 6, term: 1]
+  INFO 3 [commit: 6] restored snapshot [index: 6, term: 1]
 > 3 handling Ready
   Ready MustSync=true:
-  HardState Term:1 Commit:5 Lead:1 LeadEpoch:1
-  Snapshot Index:5 Term:1 ConfState:Voters:[1 2 3] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
+  HardState Term:1 Commit:6 Lead:1 LeadEpoch:1
+  Snapshot Index:6 Term:1 ConfState:Voters:[1 2 3] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
   Messages:
   3->1 MsgAppResp Term:1 Log:0/3 Rejected (Hint: 0)
-  3->1 MsgAppResp Term:1 Log:0/5 Commit:5
+  3->1 MsgAppResp Term:1 Log:0/6 Commit:6
 > 1 receiving messages
   3->1 MsgAppResp Term:1 Log:0/3 Rejected (Hint: 0)
   DEBUG 1 received MsgAppResp(rejected, hint: (index 0, term 0)) from 3 for index 3
-  3->1 MsgAppResp Term:1 Log:0/5 Commit:5
-  DEBUG 1 recovered from needing snapshot, resumed sending replication messages to 3 [StateSnapshot match=5 next=6 sentCommit=5 matchCommit=5 paused pendingSnap=5]
+  3->1 MsgAppResp Term:1 Log:0/6 Commit:6
+  DEBUG 1 recovered from needing snapshot, resumed sending replication messages to 3 [StateSnapshot match=6 next=7 sentCommit=6 matchCommit=6 paused pendingSnap=6]
 
 # Nothing else happens.
 stabilize
@@ -256,30 +294,30 @@ stabilize 1
 > 1 handling Ready
   Ready MustSync=true:
   Entries:
-  1/6 EntryConfChangeV2 r2 r3 l2 l3
+  1/7 EntryConfChangeV2 r2 r3 l2 l3
   Messages:
-  1->2 MsgApp Term:1 Log:1/5 Commit:5 Entries:[1/6 EntryConfChangeV2 r2 r3 l2 l3]
-  1->3 MsgApp Term:1 Log:1/5 Commit:5 Entries:[1/6 EntryConfChangeV2 r2 r3 l2 l3]
+  1->2 MsgApp Term:1 Log:1/6 Commit:6 Entries:[1/7 EntryConfChangeV2 r2 r3 l2 l3]
+  1->3 MsgApp Term:1 Log:1/6 Commit:6 Entries:[1/7 EntryConfChangeV2 r2 r3 l2 l3]
 
 # n2, n3 ack them.
 stabilize 2 3
 ----
 > 2 receiving messages
-  1->2 MsgApp Term:1 Log:1/5 Commit:5 Entries:[1/6 EntryConfChangeV2 r2 r3 l2 l3]
+  1->2 MsgApp Term:1 Log:1/6 Commit:6 Entries:[1/7 EntryConfChangeV2 r2 r3 l2 l3]
 > 3 receiving messages
-  1->3 MsgApp Term:1 Log:1/5 Commit:5 Entries:[1/6 EntryConfChangeV2 r2 r3 l2 l3]
+  1->3 MsgApp Term:1 Log:1/6 Commit:6 Entries:[1/7 EntryConfChangeV2 r2 r3 l2 l3]
 > 2 handling Ready
   Ready MustSync=true:
   Entries:
-  1/6 EntryConfChangeV2 r2 r3 l2 l3
+  1/7 EntryConfChangeV2 r2 r3 l2 l3
   Messages:
-  2->1 MsgAppResp Term:1 Log:0/6 Commit:5
+  2->1 MsgAppResp Term:1 Log:0/7 Commit:6
 > 3 handling Ready
   Ready MustSync=true:
   Entries:
-  1/6 EntryConfChangeV2 r2 r3 l2 l3
+  1/7 EntryConfChangeV2 r2 r3 l2 l3
   Messages:
-  3->1 MsgAppResp Term:1 Log:0/6 Commit:5
+  3->1 MsgAppResp Term:1 Log:0/7 Commit:6
 
 # n1 gets some more proposals. This is part of a regression test: There used to
 # be a bug in which these proposals would prompt the leader to transition out of
@@ -299,76 +337,76 @@ stabilize 1
 > 1 handling Ready
   Ready MustSync=true:
   Entries:
-  1/7 EntryNormal "foo"
-  1/8 EntryNormal "bar"
+  1/8 EntryNormal "foo"
+  1/9 EntryNormal "bar"
   Messages:
-  1->2 MsgApp Term:1 Log:1/6 Commit:5 Entries:[1/7 EntryNormal "foo"]
-  1->3 MsgApp Term:1 Log:1/6 Commit:5 Entries:[1/7 EntryNormal "foo"]
-  1->2 MsgApp Term:1 Log:1/7 Commit:5 Entries:[1/8 EntryNormal "bar"]
-  1->3 MsgApp Term:1 Log:1/7 Commit:5 Entries:[1/8 EntryNormal "bar"]
+  1->2 MsgApp Term:1 Log:1/7 Commit:6 Entries:[1/8 EntryNormal "foo"]
+  1->3 MsgApp Term:1 Log:1/7 Commit:6 Entries:[1/8 EntryNormal "foo"]
+  1->2 MsgApp Term:1 Log:1/8 Commit:6 Entries:[1/9 EntryNormal "bar"]
+  1->3 MsgApp Term:1 Log:1/8 Commit:6 Entries:[1/9 EntryNormal "bar"]
 > 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/6 Commit:5
-  3->1 MsgAppResp Term:1 Log:0/6 Commit:5
+  2->1 MsgAppResp Term:1 Log:0/7 Commit:6
+  3->1 MsgAppResp Term:1 Log:0/7 Commit:6
 > 1 handling Ready
   Ready MustSync=true:
-  HardState Term:1 Vote:1 Commit:6 Lead:1 LeadEpoch:1
+  HardState Term:1 Vote:1 Commit:7 Lead:1 LeadEpoch:1
   CommittedEntries:
-  1/6 EntryConfChangeV2 r2 r3 l2 l3
+  1/7 EntryConfChangeV2 r2 r3 l2 l3
   Messages:
-  1->2 MsgApp Term:1 Log:1/8 Commit:6
-  1->3 MsgApp Term:1 Log:1/8 Commit:6
+  1->2 MsgApp Term:1 Log:1/9 Commit:7
+  1->3 MsgApp Term:1 Log:1/9 Commit:7
   INFO 1 switched to configuration voters=(1)&&(1 2 3) learners_next=(2 3) autoleave
   INFO initiating automatic transition out of joint configuration voters=(1)&&(1 2 3) learners_next=(2 3) autoleave
 > 1 handling Ready
   Ready MustSync=true:
   Entries:
-  1/9 EntryConfChangeV2
+  1/10 EntryConfChangeV2
   Messages:
-  1->2 MsgApp Term:1 Log:1/8 Commit:6 Entries:[1/9 EntryConfChangeV2]
-  1->3 MsgApp Term:1 Log:1/8 Commit:6 Entries:[1/9 EntryConfChangeV2]
+  1->2 MsgApp Term:1 Log:1/9 Commit:7 Entries:[1/10 EntryConfChangeV2]
+  1->3 MsgApp Term:1 Log:1/9 Commit:7 Entries:[1/10 EntryConfChangeV2]
 
 # n2 and n3 also switch to the joint config, and ack the transition out of it.
 stabilize 2 3
 ----
 > 2 receiving messages
-  1->2 MsgApp Term:1 Log:1/6 Commit:5 Entries:[1/7 EntryNormal "foo"]
-  1->2 MsgApp Term:1 Log:1/7 Commit:5 Entries:[1/8 EntryNormal "bar"]
-  1->2 MsgApp Term:1 Log:1/8 Commit:6
-  1->2 MsgApp Term:1 Log:1/8 Commit:6 Entries:[1/9 EntryConfChangeV2]
+  1->2 MsgApp Term:1 Log:1/7 Commit:6 Entries:[1/8 EntryNormal "foo"]
+  1->2 MsgApp Term:1 Log:1/8 Commit:6 Entries:[1/9 EntryNormal "bar"]
+  1->2 MsgApp Term:1 Log:1/9 Commit:7
+  1->2 MsgApp Term:1 Log:1/9 Commit:7 Entries:[1/10 EntryConfChangeV2]
 > 3 receiving messages
-  1->3 MsgApp Term:1 Log:1/6 Commit:5 Entries:[1/7 EntryNormal "foo"]
-  1->3 MsgApp Term:1 Log:1/7 Commit:5 Entries:[1/8 EntryNormal "bar"]
-  1->3 MsgApp Term:1 Log:1/8 Commit:6
-  1->3 MsgApp Term:1 Log:1/8 Commit:6 Entries:[1/9 EntryConfChangeV2]
+  1->3 MsgApp Term:1 Log:1/7 Commit:6 Entries:[1/8 EntryNormal "foo"]
+  1->3 MsgApp Term:1 Log:1/8 Commit:6 Entries:[1/9 EntryNormal "bar"]
+  1->3 MsgApp Term:1 Log:1/9 Commit:7
+  1->3 MsgApp Term:1 Log:1/9 Commit:7 Entries:[1/10 EntryConfChangeV2]
 > 2 handling Ready
   Ready MustSync=true:
-  HardState Term:1 Commit:6 Lead:1 LeadEpoch:1
+  HardState Term:1 Commit:7 Lead:1 LeadEpoch:1
   Entries:
-  1/7 EntryNormal "foo"
-  1/8 EntryNormal "bar"
-  1/9 EntryConfChangeV2
+  1/8 EntryNormal "foo"
+  1/9 EntryNormal "bar"
+  1/10 EntryConfChangeV2
   CommittedEntries:
-  1/6 EntryConfChangeV2 r2 r3 l2 l3
+  1/7 EntryConfChangeV2 r2 r3 l2 l3
   Messages:
-  2->1 MsgAppResp Term:1 Log:0/7 Commit:5
-  2->1 MsgAppResp Term:1 Log:0/8 Commit:5
   2->1 MsgAppResp Term:1 Log:0/8 Commit:6
   2->1 MsgAppResp Term:1 Log:0/9 Commit:6
+  2->1 MsgAppResp Term:1 Log:0/9 Commit:7
+  2->1 MsgAppResp Term:1 Log:0/10 Commit:7
   INFO 2 switched to configuration voters=(1)&&(1 2 3) learners_next=(2 3) autoleave
 > 3 handling Ready
   Ready MustSync=true:
-  HardState Term:1 Commit:6 Lead:1 LeadEpoch:1
+  HardState Term:1 Commit:7 Lead:1 LeadEpoch:1
   Entries:
-  1/7 EntryNormal "foo"
-  1/8 EntryNormal "bar"
-  1/9 EntryConfChangeV2
+  1/8 EntryNormal "foo"
+  1/9 EntryNormal "bar"
+  1/10 EntryConfChangeV2
   CommittedEntries:
-  1/6 EntryConfChangeV2 r2 r3 l2 l3
+  1/7 EntryConfChangeV2 r2 r3 l2 l3
   Messages:
-  3->1 MsgAppResp Term:1 Log:0/7 Commit:5
-  3->1 MsgAppResp Term:1 Log:0/8 Commit:5
   3->1 MsgAppResp Term:1 Log:0/8 Commit:6
   3->1 MsgAppResp Term:1 Log:0/9 Commit:6
+  3->1 MsgAppResp Term:1 Log:0/9 Commit:7
+  3->1 MsgAppResp Term:1 Log:0/10 Commit:7
   INFO 3 switched to configuration voters=(1)&&(1 2 3) learners_next=(2 3) autoleave
 
 # n2 and n3 also leave the joint config and the dust settles. We see at the very
@@ -377,65 +415,65 @@ stabilize 2 3
 stabilize
 ----
 > 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/7 Commit:5
-  2->1 MsgAppResp Term:1 Log:0/8 Commit:5
   2->1 MsgAppResp Term:1 Log:0/8 Commit:6
   2->1 MsgAppResp Term:1 Log:0/9 Commit:6
-  3->1 MsgAppResp Term:1 Log:0/7 Commit:5
-  3->1 MsgAppResp Term:1 Log:0/8 Commit:5
+  2->1 MsgAppResp Term:1 Log:0/9 Commit:7
+  2->1 MsgAppResp Term:1 Log:0/10 Commit:7
   3->1 MsgAppResp Term:1 Log:0/8 Commit:6
   3->1 MsgAppResp Term:1 Log:0/9 Commit:6
+  3->1 MsgAppResp Term:1 Log:0/9 Commit:7
+  3->1 MsgAppResp Term:1 Log:0/10 Commit:7
 > 1 handling Ready
   Ready MustSync=true:
-  HardState Term:1 Vote:1 Commit:9 Lead:1 LeadEpoch:1
+  HardState Term:1 Vote:1 Commit:10 Lead:1 LeadEpoch:1
   CommittedEntries:
-  1/7 EntryNormal "foo"
-  1/8 EntryNormal "bar"
-  1/9 EntryConfChangeV2
+  1/8 EntryNormal "foo"
+  1/9 EntryNormal "bar"
+  1/10 EntryConfChangeV2
   Messages:
-  1->2 MsgApp Term:1 Log:1/9 Commit:7
-  1->3 MsgApp Term:1 Log:1/9 Commit:7
-  1->2 MsgApp Term:1 Log:1/9 Commit:8
-  1->3 MsgApp Term:1 Log:1/9 Commit:8
-  1->2 MsgApp Term:1 Log:1/9 Commit:9
-  1->3 MsgApp Term:1 Log:1/9 Commit:9
+  1->2 MsgApp Term:1 Log:1/10 Commit:8
+  1->3 MsgApp Term:1 Log:1/10 Commit:8
+  1->2 MsgApp Term:1 Log:1/10 Commit:9
+  1->3 MsgApp Term:1 Log:1/10 Commit:9
+  1->2 MsgApp Term:1 Log:1/10 Commit:10
+  1->3 MsgApp Term:1 Log:1/10 Commit:10
   INFO 1 switched to configuration voters=(1) learners=(2 3)
 > 2 receiving messages
-  1->2 MsgApp Term:1 Log:1/9 Commit:7
-  1->2 MsgApp Term:1 Log:1/9 Commit:8
-  1->2 MsgApp Term:1 Log:1/9 Commit:9
+  1->2 MsgApp Term:1 Log:1/10 Commit:8
+  1->2 MsgApp Term:1 Log:1/10 Commit:9
+  1->2 MsgApp Term:1 Log:1/10 Commit:10
 > 3 receiving messages
-  1->3 MsgApp Term:1 Log:1/9 Commit:7
-  1->3 MsgApp Term:1 Log:1/9 Commit:8
-  1->3 MsgApp Term:1 Log:1/9 Commit:9
+  1->3 MsgApp Term:1 Log:1/10 Commit:8
+  1->3 MsgApp Term:1 Log:1/10 Commit:9
+  1->3 MsgApp Term:1 Log:1/10 Commit:10
 > 2 handling Ready
   Ready MustSync=true:
-  HardState Term:1 Commit:9 Lead:1 LeadEpoch:1
+  HardState Term:1 Commit:10 Lead:1 LeadEpoch:1
   CommittedEntries:
-  1/7 EntryNormal "foo"
-  1/8 EntryNormal "bar"
-  1/9 EntryConfChangeV2
+  1/8 EntryNormal "foo"
+  1/9 EntryNormal "bar"
+  1/10 EntryConfChangeV2
   Messages:
-  2->1 MsgAppResp Term:1 Log:0/9 Commit:7
-  2->1 MsgAppResp Term:1 Log:0/9 Commit:8
-  2->1 MsgAppResp Term:1 Log:0/9 Commit:9
+  2->1 MsgAppResp Term:1 Log:0/10 Commit:8
+  2->1 MsgAppResp Term:1 Log:0/10 Commit:9
+  2->1 MsgAppResp Term:1 Log:0/10 Commit:10
   INFO 2 switched to configuration voters=(1) learners=(2 3)
 > 3 handling Ready
   Ready MustSync=true:
-  HardState Term:1 Commit:9 Lead:1 LeadEpoch:1
+  HardState Term:1 Commit:10 Lead:1 LeadEpoch:1
   CommittedEntries:
-  1/7 EntryNormal "foo"
-  1/8 EntryNormal "bar"
-  1/9 EntryConfChangeV2
+  1/8 EntryNormal "foo"
+  1/9 EntryNormal "bar"
+  1/10 EntryConfChangeV2
   Messages:
-  3->1 MsgAppResp Term:1 Log:0/9 Commit:7
-  3->1 MsgAppResp Term:1 Log:0/9 Commit:8
-  3->1 MsgAppResp Term:1 Log:0/9 Commit:9
+  3->1 MsgAppResp Term:1 Log:0/10 Commit:8
+  3->1 MsgAppResp Term:1 Log:0/10 Commit:9
+  3->1 MsgAppResp Term:1 Log:0/10 Commit:10
   INFO 3 switched to configuration voters=(1) learners=(2 3)
 > 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/9 Commit:7
-  2->1 MsgAppResp Term:1 Log:0/9 Commit:8
-  2->1 MsgAppResp Term:1 Log:0/9 Commit:9
-  3->1 MsgAppResp Term:1 Log:0/9 Commit:7
-  3->1 MsgAppResp Term:1 Log:0/9 Commit:8
-  3->1 MsgAppResp Term:1 Log:0/9 Commit:9
+  2->1 MsgAppResp Term:1 Log:0/10 Commit:8
+  2->1 MsgAppResp Term:1 Log:0/10 Commit:9
+  2->1 MsgAppResp Term:1 Log:0/10 Commit:10
+  3->1 MsgAppResp Term:1 Log:0/10 Commit:8
+  3->1 MsgAppResp Term:1 Log:0/10 Commit:9
+  3->1 MsgAppResp Term:1 Log:0/10 Commit:10

--- a/pkg/raft/tracker/BUILD.bazel
+++ b/pkg/raft/tracker/BUILD.bazel
@@ -19,7 +19,6 @@ go_library(
         "//pkg/raft/raftstoreliveness",
         "//pkg/util/container/ring",
         "//pkg/util/hlc",
-        "//pkg/util/syncutil",
         "@com_github_cockroachdb_redact//:redact",
         "@org_golang_x_exp//maps",
     ],

--- a/pkg/raft/tracker/fortificationtracker.go
+++ b/pkg/raft/tracker/fortificationtracker.go
@@ -15,7 +15,6 @@ import (
 	pb "github.com/cockroachdb/cockroach/pkg/raft/raftpb"
 	"github.com/cockroachdb/cockroach/pkg/raft/raftstoreliveness"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
-	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 )
 
 // FortificationTracker is used to track fortification from peers. This can
@@ -60,11 +59,6 @@ type FortificationTracker struct {
 	// never regresses for a raft group. Naively, without any tracking, this
 	// can happen around configuration changes[1] and leader step down[2].
 	//
-	// NB: We use an atomicTimestamp here, which allows us to forward
-	// leadMaxSupported on every call to LeadSupportUntil, without requiring
-	// callers to acquire a write lock. Typically, LeadSupportUntil is called into
-	// by get{LeadSupport,}Status
-	//
 	// [1] We must ensure that the current LeadSupportUntil is greater than or
 	// equal to any previously calculated LeadSupportUntil before proposing a new
 	// configuration change.
@@ -73,7 +67,7 @@ type FortificationTracker struct {
 	// de-fortification messages, voting for another peer, or calling an election
 	// at a higher term) that could elect a leader until LeadSupportUntil is in
 	// the past.
-	leaderMaxSupported atomicTimestamp
+	leaderMaxSupported hlc.Timestamp
 
 	logger raftlogger.Logger
 
@@ -94,11 +88,14 @@ type FortificationTracker struct {
 	steppingDownTerm uint64
 
 	// computedLeadSupportUntil is the last computed LeadSupportUntil. We
-	// update this value on (1) Every tick, (2) Every time a new fortification is
-	// recorded, and (3) On config changes. Callers of LeadSupportUntil will get
-	// this cached version of LeadSupportUntil, which is good because
-	// LeadSupportUntil is called by every request trying to evaluate the lease's
-	// status.
+	// update this value on:
+	// 1. Every tick.
+	// 2. Every time a new fortification is recorded.
+	// 3. On config changes.
+	//
+	// Callers of LeadSupportUntil will get this cached version of
+	// LeadSupportUntil, which is useful because LeadSupportUntil is called by
+	// every request trying to evaluate the lease's status.
 	computedLeadSupportUntil hlc.Timestamp
 
 	// supportExpMap is a map that hangs off the fortificationTracker to prevent
@@ -193,29 +190,26 @@ func (ft *FortificationTracker) IsFortifiedBy(id pb.PeerID) (isFortified bool, i
 // LeadSupportUntil returns the timestamp until which the leader is guaranteed
 // fortification until based on the fortification being tracked for it by its
 // peers.
-func (ft *FortificationTracker) LeadSupportUntil(state pb.StateType) hlc.Timestamp {
-	// TODO(ibrahim): Consider removing the state from the function parameters.
-	if state != pb.StateLeader || ft.steppingDown {
-		// If we're not the leader or if we are intending to step down, we shouldn't
-		// advance LeadSupportUntil.
-		return ft.leaderMaxSupported.Load()
-	}
-
-	// Forward the leaderMaxSupported to avoid regressions when the configuration
-	// changes.
-	return ft.leaderMaxSupported.Forward(ft.computedLeadSupportUntil)
+func (ft *FortificationTracker) LeadSupportUntil() hlc.Timestamp {
+	return ft.leaderMaxSupported
 }
 
 // ComputeLeadSupportUntil updates the field
 // computedLeadSupportUntil by computing the LeadSupportExpiration.
-func (ft *FortificationTracker) ComputeLeadSupportUntil(state pb.StateType) hlc.Timestamp {
+func (ft *FortificationTracker) ComputeLeadSupportUntil(state pb.StateType) {
 	if state != pb.StateLeader {
 		panic("ComputeLeadSupportUntil should only be called by the leader")
 	}
 
 	if len(ft.fortification) == 0 {
 		ft.computedLeadSupportUntil = hlc.Timestamp{}
-		return ft.computedLeadSupportUntil // fast-path for no fortification
+		return // fast-path for no fortification
+	}
+
+	if ft.steppingDown {
+		// We're in the process of stepping down, so we don't want to advance the
+		// LeadSupportUntil; early return.
+		return
 	}
 
 	clear(ft.supportExpMap)
@@ -233,7 +227,10 @@ func (ft *FortificationTracker) ComputeLeadSupportUntil(state pb.StateType) hlc.
 		}
 	})
 	ft.computedLeadSupportUntil = ft.config.Voters.LeadSupportExpiration(ft.supportExpMap)
-	return ft.computedLeadSupportUntil
+
+	// Forward the leaderMaxSupported to avoid regressions when the configuration
+	// changes.
+	ft.leaderMaxSupported.Forward(ft.computedLeadSupportUntil)
 }
 
 // CanDefortify returns whether the caller can safely[1] de-fortify the term
@@ -246,14 +243,13 @@ func (ft *FortificationTracker) CanDefortify() bool {
 	if ft.term == 0 {
 		return false // nothing is being tracked
 	}
-	leaderMaxSupported := ft.leaderMaxSupported.Load()
-	if leaderMaxSupported.IsEmpty() {
+	if ft.leaderMaxSupported.IsEmpty() {
 		// If leaderMaxSupported is empty, it means that we've never returned any
 		// timestamps to the layers above in calls to LeadSupportUntil. We should be
 		// able to de-fortify. If a tree falls in a forrest ...
 		ft.logger.Debugf("leaderMaxSupported is empty when computing whether we can de-fortify or not")
 	}
-	return ft.storeLiveness.SupportExpired(leaderMaxSupported)
+	return ft.storeLiveness.SupportExpired(ft.leaderMaxSupported)
 }
 
 // NeedsDefortify returns whether the node should still continue to broadcast
@@ -370,14 +366,14 @@ func (ft *FortificationTracker) ConfigChangeSafe() bool {
 	// previous configuration, which is reflected in leaderMaxSupported.
 	//
 	// NB: Only run by the leader.
-	return ft.leaderMaxSupported.Load().LessEq(ft.computedLeadSupportUntil)
+	return ft.leaderMaxSupported.LessEq(ft.computedLeadSupportUntil)
 }
 
 // QuorumActive returns whether the leader is currently supported by a quorum or
 // not.
 func (ft *FortificationTracker) QuorumActive() bool {
 	// NB: Only run by the leader.
-	return !ft.storeLiveness.SupportExpired(ft.LeadSupportUntil(pb.StateLeader))
+	return !ft.storeLiveness.SupportExpired(ft.LeadSupportUntil())
 }
 
 // RequireQuorumSupportOnCampaign returns true if quorum support before
@@ -424,31 +420,4 @@ func (ft *FortificationTracker) String() string {
 		fmt.Fprintf(&buf, "%d : %d\n", id, ft.fortification[id])
 	}
 	return buf.String()
-}
-
-// atomicTimestamp is a thin wrapper to provide atomic access to a timestamp.
-type atomicTimestamp struct {
-	mu syncutil.Mutex
-
-	ts hlc.Timestamp
-}
-
-func (a *atomicTimestamp) Load() hlc.Timestamp {
-	a.mu.Lock()
-	defer a.mu.Unlock()
-	return a.ts
-}
-
-func (a *atomicTimestamp) Forward(ts hlc.Timestamp) hlc.Timestamp {
-	a.mu.Lock()
-	defer a.mu.Unlock()
-
-	a.ts.Forward(ts)
-	return a.ts
-}
-
-func (a *atomicTimestamp) Reset() {
-	a.mu.Lock()
-	defer a.mu.Unlock()
-	a.ts = hlc.Timestamp{}
 }


### PR DESCRIPTION
This commit removes the struct atomicTimestamp and replaces
it with hlc.Timestamp directly without locks. This is now
possible as we only update LeadSupportUntil every tick, and
it won't change on every status call.

References: https://github.com/cockroachdb/cockroach/issues/137264

Release note: None