### PR TITLE
roachprod: refactor gcp environment variable initialization

### DIFF
--- a/pkg/cmd/drtprod/cli/BUILD.bazel
+++ b/pkg/cmd/drtprod/cli/BUILD.bazel
@@ -11,7 +11,6 @@ go_library(
     deps = [
         "//pkg/cmd/drtprod/cli/commands",
         "//pkg/cmd/roachprod/cli",
-        "//pkg/roachprod",
         "@com_github_spf13_cobra//:cobra",
     ],
 )

--- a/pkg/cmd/drtprod/cli/handlers.go
+++ b/pkg/cmd/drtprod/cli/handlers.go
@@ -11,20 +11,19 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/drtprod/cli/commands"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachprod/cli"
-	"github.com/cockroachdb/cockroach/pkg/roachprod"
 	"github.com/spf13/cobra"
 )
 
-// Initialize sets up the environment and initializes the command-line interface.
-func Initialize(ctx context.Context) {
+func init() {
 	// Set environment variables for the GCE project and DNS configurations.
 	_ = os.Setenv("ROACHPROD_DNS", "drt.crdb.io")
 	_ = os.Setenv("ROACHPROD_GCE_DNS_DOMAIN", "drt.crdb.io")
 	_ = os.Setenv("ROACHPROD_GCE_DNS_ZONE", "drt")
 	_ = os.Setenv("ROACHPROD_GCE_DEFAULT_PROJECT", "cockroach-drt")
-	// Initialize cloud providers for roachprod.
-	_ = roachprod.InitProviders()
+}
 
+// Initialize sets up the environment and initializes the command-line interface.
+func Initialize(ctx context.Context) {
 	// Disable command sorting in Cobra (command-line parser).
 	cobra.EnableCommandSorting = false
 

--- a/pkg/roachprod/vm/gce/dns.go
+++ b/pkg/roachprod/vm/gce/dns.go
@@ -35,6 +35,10 @@ const (
 )
 
 var (
+	dnsDefaultZone, dnsDefaultDomain, dnsDefaultManagedZone, dnsDefaultManagedDomain string
+)
+
+func initDNSDefault() {
 	dnsDefaultZone = config.EnvOrDefaultString(
 		"ROACHPROD_GCE_DNS_ZONE",
 		"roachprod",
@@ -56,7 +60,7 @@ var (
 		"ROACHPROD_GCE_DNS_MANAGED_DOMAIN",
 		"roachprod-managed.crdb.io",
 	)
-)
+}
 
 var ErrDNSOperation = fmt.Errorf("error during Google Cloud DNS operation")
 


### PR DESCRIPTION
Moved the initialization of default variables related to the GCP Project and DNS into the GCP provider Init function instead of initializing them during package initialization. Setting default variables as global variables caused issues when environment variables are modified before calling Init.

Epic: none

Release note: None