### PR TITLE
settings: increase number of cores test can use

### DIFF
--- a/pkg/settings/integration_tests/BUILD.bazel
+++ b/pkg/settings/integration_tests/BUILD.bazel
@@ -7,6 +7,7 @@ go_test(
         "propagation_test.go",
         "settings_test.go",
     ],
+    exec_properties = {"test.Pool": "large"},
     shard_count = 6,
     deps = [
         "//pkg/base",


### PR DESCRIPTION
Clutser setting updates on one node occasionally take over 45 seconds to propagate to other nodes. This test has failed a few times recently. The issue is not reproducible, even under stress testing with 10000 repetitions. Increasing the number of cores the test can use to determine if it resolves the problem.

Epic: None
Fixes: https://github.com/cockroachdb/cockroach/issues/133732
Release note: None