### PR TITLE
cli: fix debug zip cluster wide zip requests

### DIFF
--- a/pkg/cli/zip_cluster_wide.go
+++ b/pkg/cli/zip_cluster_wide.go
@@ -58,7 +58,7 @@ func makeClusterWideZipRequests(
 	if zipCtx.files.shouldIncludeFile(rangeLogFile) {
 		zipRequests = append(zipRequests, zipRequest{
 			fn: func(ctx context.Context) (interface{}, error) {
-				return admin.Events(ctx, &serverpb.EventsRequest{})
+				return admin.RangeLog(ctx, &serverpb.RangeLogRequest{})
 			},
 			pathName: prefix + rangelogName,
 		})
@@ -69,7 +69,7 @@ func makeClusterWideZipRequests(
 	if zipCtx.files.shouldIncludeFile(settingsFile) {
 		zipRequests = append(zipRequests, zipRequest{
 			fn: func(ctx context.Context) (interface{}, error) {
-				return admin.Events(ctx, &serverpb.EventsRequest{})
+				return admin.Settings(ctx, &serverpb.SettingsRequest{})
 			},
 			pathName: prefix + settingsName,
 		})


### PR DESCRIPTION
Fixes the settings and range log requests to call the correct RPC

Epic: None
Release note: None