### PR TITLE
catalog: schema descriptor validation reads all functions under a schema

### DIFF
--- a/pkg/sql/catalog/dbdesc/database_desc.go
+++ b/pkg/sql/catalog/dbdesc/database_desc.go
@@ -318,7 +318,9 @@ func (desc *immutable) maybeValidateSystemDatabaseSchemaVersion(
 
 // GetReferencedDescIDs returns the IDs of all descriptors referenced by
 // this descriptor, including itself.
-func (desc *immutable) GetReferencedDescIDs() (catalog.DescriptorIDSet, error) {
+func (desc *immutable) GetReferencedDescIDs(
+	catalog.ValidationLevel,
+) (catalog.DescriptorIDSet, error) {
 	ids := catalog.MakeDescriptorIDSet(desc.GetID())
 	if desc.IsMultiRegion() {
 		id, err := desc.MultiRegionEnumID()

--- a/pkg/sql/catalog/descriptor.go
+++ b/pkg/sql/catalog/descriptor.go
@@ -243,7 +243,7 @@ type Descriptor interface {
 
 	// GetReferencedDescIDs returns the IDs of all descriptors directly referenced
 	// by this descriptor, including itself.
-	GetReferencedDescIDs() (DescriptorIDSet, error)
+	GetReferencedDescIDs(level ValidationLevel) (DescriptorIDSet, error)
 
 	// ValidateSelf checks the internal consistency of the descriptor.
 	ValidateSelf(vea ValidationErrorAccumulator)

--- a/pkg/sql/catalog/descs/descriptor.go
+++ b/pkg/sql/catalog/descs/descriptor.go
@@ -633,6 +633,7 @@ func (tc *Collection) finalizeDescriptors(
 	descs []catalog.Descriptor,
 	validationLevels []catalog.ValidationLevel,
 ) error {
+	var requiredLevel catalog.ValidationLevel
 	// Add the descriptors to the uncommitted layer if we want them to be mutable.
 	if flags.isMutable {
 		for i, desc := range descs {
@@ -642,14 +643,13 @@ func (tc *Collection) finalizeDescriptors(
 			}
 			descs[i] = mut
 		}
+		requiredLevel = validate.MutableRead
+	} else {
+		requiredLevel = validate.ImmutableRead
 	}
 	// Ensure that all descriptors are sufficiently validated.
 	if !tc.validationModeProvider.ValidateDescriptorsOnRead() {
 		return nil
-	}
-	requiredLevel := validate.MutableRead
-	if !flags.layerFilters.withoutLeased {
-		requiredLevel = validate.ImmutableRead
 	}
 	var toValidate []catalog.Descriptor
 	for i := range descs {

--- a/pkg/sql/catalog/funcdesc/func_desc.go
+++ b/pkg/sql/catalog/funcdesc/func_desc.go
@@ -161,7 +161,9 @@ func (desc *immutable) NewBuilder() catalog.DescriptorBuilder {
 }
 
 // GetReferencedDescIDs implements the catalog.Descriptor interface.
-func (desc *immutable) GetReferencedDescIDs() (catalog.DescriptorIDSet, error) {
+func (desc *immutable) GetReferencedDescIDs(
+	catalog.ValidationLevel,
+) (catalog.DescriptorIDSet, error) {
 	ret := catalog.MakeDescriptorIDSet(desc.GetID(), desc.GetParentID(), desc.GetParentSchemaID())
 	for _, id := range desc.DependsOn {
 		ret.Add(id)

--- a/pkg/sql/catalog/schemadesc/schema_desc.go
+++ b/pkg/sql/catalog/schemadesc/schema_desc.go
@@ -270,13 +270,20 @@ func (desc *immutable) ValidateSelf(vea catalog.ValidationErrorAccumulator) {
 
 // GetReferencedDescIDs returns the IDs of all descriptors referenced by
 // this descriptor, including itself.
-func (desc *immutable) GetReferencedDescIDs() (catalog.DescriptorIDSet, error) {
+func (desc *immutable) GetReferencedDescIDs(
+	level catalog.ValidationLevel,
+) (catalog.DescriptorIDSet, error) {
 	ret := catalog.MakeDescriptorIDSet(desc.GetID(), desc.GetParentID())
-	for _, f := range desc.Functions {
-		for _, sig := range f.Signatures {
-			ret.Add(sig.ID)
+	// We only need to resolve functions in this schema if we are validating
+	// back references as well.
+	if level&catalog.ValidationLevelBackReferences == catalog.ValidationLevelBackReferences {
+		for _, f := range desc.Functions {
+			for _, sig := range f.Signatures {
+				ret.Add(sig.ID)
+			}
 		}
 	}
+
 	return ret, nil
 }
 

--- a/pkg/sql/catalog/schemadesc/synthetic_schema_desc.go
+++ b/pkg/sql/catalog/schemadesc/synthetic_schema_desc.go
@@ -76,7 +76,7 @@ func (p synthetic) NewBuilder() catalog.DescriptorBuilder {
 		"%s schema cannot create a builder", p.kindName())
 	return nil // unreachable
 }
-func (p synthetic) GetReferencedDescIDs() (catalog.DescriptorIDSet, error) {
+func (p synthetic) GetReferencedDescIDs(catalog.ValidationLevel) (catalog.DescriptorIDSet, error) {
 	return catalog.DescriptorIDSet{}, nil
 }
 func (p synthetic) ValidateSelf(_ catalog.ValidationErrorAccumulator) {

--- a/pkg/sql/catalog/tabledesc/validate.go
+++ b/pkg/sql/catalog/tabledesc/validate.go
@@ -58,7 +58,9 @@ func (desc *wrapper) ValidateTxnCommit(
 
 // GetReferencedDescIDs returns the IDs of all descriptors referenced by
 // this descriptor, including itself.
-func (desc *wrapper) GetReferencedDescIDs() (catalog.DescriptorIDSet, error) {
+func (desc *wrapper) GetReferencedDescIDs(
+	catalog.ValidationLevel,
+) (catalog.DescriptorIDSet, error) {
 	ids := catalog.MakeDescriptorIDSet(desc.GetID(), desc.GetParentID())
 	// TODO(richardjcai): Remove logic for keys.PublicSchemaID in 22.2.
 	if desc.GetParentSchemaID() != keys.PublicSchemaID {

--- a/pkg/sql/catalog/typedesc/table_implicit_record_type.go
+++ b/pkg/sql/catalog/typedesc/table_implicit_record_type.go
@@ -150,7 +150,9 @@ func (v *tableImplicitRecordType) NewBuilder() catalog.DescriptorBuilder {
 }
 
 // GetReferencedDescIDs implements the catalog.Descriptor interface.
-func (v *tableImplicitRecordType) GetReferencedDescIDs() (catalog.DescriptorIDSet, error) {
+func (v *tableImplicitRecordType) GetReferencedDescIDs(
+	catalog.ValidationLevel,
+) (catalog.DescriptorIDSet, error) {
 	return catalog.DescriptorIDSet{}, errors.AssertionFailedf(
 		"GetReferencedDescIDs are unsupported for implicit table record types")
 }

--- a/pkg/sql/catalog/typedesc/type_desc.go
+++ b/pkg/sql/catalog/typedesc/type_desc.go
@@ -551,7 +551,9 @@ func (desc *immutable) validateEnumMembers(vea catalog.ValidationErrorAccumulato
 
 // GetReferencedDescIDs returns the IDs of all descriptors referenced by
 // this descriptor, including itself.
-func (desc *immutable) GetReferencedDescIDs() (catalog.DescriptorIDSet, error) {
+func (desc *immutable) GetReferencedDescIDs(
+	catalog.ValidationLevel,
+) (catalog.DescriptorIDSet, error) {
 	ids := catalog.MakeDescriptorIDSet(desc.GetReferencingDescriptorIDs()...)
 	ids.Add(desc.GetParentID())
 	// TODO(richardjcai): Remove logic for keys.PublicSchemaID in 22.2.

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -91,7 +91,7 @@ func (p *planner) getNonTemporarySchemaForCreate(
 	case catalog.SchemaPublic:
 		return sc, nil
 	case catalog.SchemaUserDefined:
-		sc, err := p.Descriptors().MutableByID(p.txn).Schema(ctx, sc.GetID())
+		sc, err = p.Descriptors().ByIDWithoutLeased(p.Txn()).Get().Schema(ctx, sc.GetID())
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/sql/logictest/testdata/logic_test/schema_repair
+++ b/pkg/sql/logictest/testdata/logic_test/schema_repair
@@ -217,7 +217,7 @@ SELECT * FROM corrupt_backref_fk
 ----
 1 a
 
-statement error invalid foreign key backreference
+statement error (invalid foreign key backreference)*(.*referenced descriptor not found.*)*
 DROP TABLE corrupt_backref_fk
 
 statement ok
@@ -241,7 +241,13 @@ SELECT * FROM corrupt_backref_view
 ----
 1 a
 
+onlyif config local-legacy-schema-changer
+
 statement error pgcode XX000 invalid depended-on-by relation back reference
+DROP TABLE corrupt_backref_view
+
+skipif config local-legacy-schema-changer
+statement error pgcode XXUUU .*descriptor not found.*
 DROP TABLE corrupt_backref_view
 
 statement ok

--- a/pkg/sql/testdata/telemetry/error
+++ b/pkg/sql/testdata/telemetry/error
@@ -43,7 +43,7 @@ SELECT crdb_internal.unsafe_upsert_descriptor(id, crdb_internal.json_to_pb('desc
 feature-usage
 DROP TABLE tbl CASCADE;
 ----
-error: pq: internal error: building declarative schema change targets for DROP TABLE: relation "tbl" (...): missing fk back reference "tbl_customer_fkey" to "tbl" from "fktbl"
+error: pq: internal error: executing declarative schema change StatementPhase stage 1 of 1 with 46 MutationType ops (rollback=false) for DROP TABLE: error executing StatementPhase stage 1 of 1 with 46 MutationType ops: *scop.MakePublicForeignKeyConstraintValidated: &{{{}} 105 2}: relation "tbl" (...): missing fk back reference "tbl_customer_fkey" to "tbl" from "fktbl"
 errorcodes.XX000
 sql.schema.validation_errors.read.backward_references.relation
 

--- a/pkg/sql/tests/repair_test.go
+++ b/pkg/sql/tests/repair_test.go
@@ -906,8 +906,10 @@ func TestCorruptDescriptorRepair(t *testing.T) {
 	tdb.CheckQueryResults(t, `SELECT * FROM testdb.parent`, [][]string{{"1", "a"}})
 
 	// Dropping the table should fail, because the table descriptor will fail
-	// the validation checks when being read from storage.
-	tdb.ExpectErr(t, "invalid foreign key backreference", `DROP TABLE testdb.parent`)
+	// the validation checks. For the declarative schema changer before the
+	// execution phase the sel validation will fail with a generic error because
+	// all reads are immutable.
+	tdb.ExpectErr(t, "referenced descriptor ID 107: looking up ID 107: descriptor not found", `DROP TABLE testdb.parent`)
 
 	const parentVersion = `SELECT
 				crdb_internal.pb_to_json('cockroach.sql.sqlbase.Descriptor', sd.descriptor, false)->'table'->>'version'


### PR DESCRIPTION
Presently, schema descriptor validation read all function descriptors under schema. This is problematic when concurrent CREATE TABLE statements referring to any function under a schema are executed will run into frequent transaction retry errors.  To address this this patch will do the following:

1. Extend the Descriptor.GetReferencedDescIDs interface to support a validation level flag, indicating which references should be returned (i.e. forward references, back references, etc..).
2. Update the schema descriptor to only return back references if they are requested
3. Update the validation logic so that mutable descriptors only get mutable validation (with back references). i.e. Not just KV read descriptors
4. Update CREATE TABLE name resolution logic to avoid mutable descriptors, and only use non-leased ones.
5. Add a new test case that validates that concurrent create statements do not run into retry errors. Note: These tests are currently disabled with multi-tenant because of: #138733


Fixes: #138384