### PR TITLE
opt/bench: fix benchmark regression

### DIFF
--- a/pkg/sql/opt/bench/bench_test.go
+++ b/pkg/sql/opt/bench/bench_test.go
@@ -813,6 +813,7 @@ type harness struct {
 	prepMemo  *memo.Memo
 	testCat   *testcat.Catalog
 	optimizer xform.Optimizer
+	gf        explain.PlanGistFactory
 }
 
 func newHarness(tb testing.TB, query benchQuery, schemas []string) *harness {
@@ -943,12 +944,11 @@ func (h *harness) runSimple(tb testing.TB, query benchQuery, phase Phase) {
 		tb.Fatalf("invalid phase %s for Simple", phase)
 	}
 
-	var gf explain.PlanGistFactory
-	gf.Init(exec.StubFactory{})
+	h.gf.Init(exec.StubFactory{})
 	root := execMemo.RootExpr()
 	eb := execbuilder.New(
 		context.Background(),
-		&gf,
+		&h.gf,
 		&h.optimizer,
 		execMemo,
 		nil, /* catalog */
@@ -1001,12 +1001,11 @@ func (h *harness) runPrepared(tb testing.TB, phase Phase) {
 		tb.Fatalf("invalid phase %s for Prepared", phase)
 	}
 
-	var gf explain.PlanGistFactory
-	gf.Init(exec.StubFactory{})
+	h.gf.Init(exec.StubFactory{})
 	root := execMemo.RootExpr()
 	eb := execbuilder.New(
 		context.Background(),
-		&gf,
+		&h.gf,
 		&h.optimizer,
 		execMemo,
 		nil, /* catalog */
@@ -1779,9 +1778,9 @@ func BenchmarkExecBuild(b *testing.B) {
 		execMemo := h.optimizer.Memo()
 		root := execMemo.RootExpr()
 
+		var gf explain.PlanGistFactory
 		b.Run(tc.query.name, func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
-				var gf explain.PlanGistFactory
 				gf.Init(exec.StubFactory{})
 				eb := execbuilder.New(
 					context.Background(),

--- a/pkg/util/base64/base64.go
+++ b/pkg/util/base64/base64.go
@@ -6,8 +6,8 @@
 package base64
 
 import (
+	"bytes"
 	"encoding/base64"
-	"strings"
 )
 
 // Encoder is a streaming encoder for base64 strings. It must be initialized
@@ -21,7 +21,7 @@ import (
 // handling has been removed for simplification.
 type Encoder struct {
 	enc  *base64.Encoding
-	sb   strings.Builder
+	sb   bytes.Buffer
 	buf  [3]byte    // buffered data waiting to be encoded
 	nbuf int8       // number of bytes in buf
 	out  [1024]byte // output buffer


### PR DESCRIPTION
#### opt/bench: fix benchmark regression

PR #138641 caused extra allocations for plan gist factories in optimizer
benchmarks. These allocations should not be included in benchmark
results, so they have been eliminated.

Release note: None

#### util/base64: use `bytes.Buffer` instead of `strings.Builder` in `Encoder`

For our purposes in base64-encoding plan gists, using `bytes.Buffer` in
`Encoder` causes fewer allocations, presumably because of a more
aggressive growth algorithm.

Epic: None

Release note: None
