### PR TITLE
CODEOWNERS: tweak /pkg/clusterversion owners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -424,7 +424,7 @@
 #!/pkg/ccl/utilccl/          @cockroachdb/unowned
 /pkg/ccl/workloadccl/        @cockroachdb/test-eng
 /pkg/ccl/benchccl/rttanalysisccl/     @cockroachdb/sql-foundations
-#!/pkg/clusterversion/       @cockroachdb/dev-inf-noreview  @cockroachdb/kv-prs-noreview @cockroachdb/test-eng-prs
+#!/pkg/clusterversion/       @cockroachdb/kv-prs-noreview @cockroachdb/dev-inf-noreview @cockroachdb/test-eng-noreview
 /pkg/clusterversion/cockroach_versions.go @cockroachdb/release-eng-prs @cockroachdb/upgrade-prs
 /pkg/cmd/allocsim/           @cockroachdb/kv-prs
 /pkg/cmd/bazci/              @cockroachdb/dev-inf


### PR DESCRIPTION
The blathers bot uses the CODEOWNERS file to assign a `T-` label based on the order of the owners. Issues, generated by Sentry do not usually come from CI, so it's better to keep the KV team as the first owner.

Additionally, use `test-eng-noreview` instead of `test-eng-prs` for consistency.

Epic: none
Release note: None