### PR TITLE
kvclient: Enable leader leases for TestTransactionUnexpectedlyCommitted

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender_ambiguous_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_ambiguous_test.go
@@ -341,7 +341,6 @@ func TestTransactionUnexpectedlyCommitted(t *testing.T) {
 
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettings()
-	kvserver.OverrideLeaderLeaseMetamorphism(ctx, &st.SV)
 
 	// Disable closed timestamps for control over when transaction gets bumped.
 	closedts.TargetDuration.Override(ctx, &st.SV, 1*time.Hour)
@@ -375,7 +374,7 @@ func TestTransactionUnexpectedlyCommitted(t *testing.T) {
 	})
 	defer tc.Stopper().Stop(ctx)
 
-	requireRangeLease := func(t *testing.T, desc roachpb.RangeDescriptor, serverIdx int) {
+	requireLeaseUpgrade := func(t *testing.T, desc roachpb.RangeDescriptor, serverIdx int) {
 		t.Helper()
 		testutils.SucceedsSoon(t, func() error {
 			hint := tc.Target(serverIdx)
@@ -396,10 +395,7 @@ func TestTransactionUnexpectedlyCommitted(t *testing.T) {
 			if curLease.Speculative() {
 				return errors.Errorf("only had speculative lease for %s", desc)
 			}
-			if !kvserver.ExpirationLeasesOnly.Get(&tc.Server(0).ClusterSettings().SV) &&
-				curLease.Type() != roachpb.LeaseEpoch {
-				return errors.Errorf("awaiting upgrade to epoch-based lease for %s", desc)
-			}
+			tc.MaybeWaitForLeaseUpgrade(ctx, t, desc)
 			t.Logf("valid lease info for r%d: %v", desc.RangeID, curLease)
 			return nil
 		})
@@ -440,9 +436,9 @@ func TestTransactionUnexpectedlyCommitted(t *testing.T) {
 		firstRange := tc.LookupRangeOrFatal(t, keyA)
 		secondRange := tc.LookupRangeOrFatal(t, keyB)
 		tc.TransferRangeLeaseOrFatal(t, firstRange, tc.Target(0))
-		requireRangeLease(t, firstRange, 0)
+		requireLeaseUpgrade(t, firstRange, 0)
 		tc.TransferRangeLeaseOrFatal(t, secondRange, tc.Target(1))
-		requireRangeLease(t, secondRange, 1)
+		requireLeaseUpgrade(t, secondRange, 1)
 
 		return func() {
 			defer restoreAfterSubTest()
@@ -1370,7 +1366,7 @@ func TestTransactionUnexpectedlyCommitted(t *testing.T) {
 		// Place second range on n1 (same as first).
 		secondRange := tc.LookupRangeOrFatal(t, keyB)
 		tc.TransferRangeLeaseOrFatal(t, secondRange, tc.Target(0))
-		requireRangeLease(t, secondRange, 0)
+		requireLeaseUpgrade(t, secondRange, 0)
 
 		// Operation functions.
 		execTxn2 := func(t *testing.T, name string) error {
@@ -1488,7 +1484,7 @@ func TestTransactionUnexpectedlyCommitted(t *testing.T) {
 		// Place second range on n1 (same as first).
 		secondRange := tc.LookupRangeOrFatal(t, keyB)
 		tc.TransferRangeLeaseOrFatal(t, secondRange, tc.Target(0))
-		requireRangeLease(t, secondRange, 0)
+		requireLeaseUpgrade(t, secondRange, 0)
 
 		// Operation functions.
 		execTxn2 := func(t *testing.T, name string) error {
@@ -1619,7 +1615,7 @@ func TestTransactionUnexpectedlyCommitted(t *testing.T) {
 		// Place second range on n1 (same as first).
 		secondRange := tc.LookupRangeOrFatal(t, keyB)
 		tc.TransferRangeLeaseOrFatal(t, secondRange, tc.Target(0))
-		requireRangeLease(t, secondRange, 0)
+		requireLeaseUpgrade(t, secondRange, 0)
 
 		// Operation functions.
 		execTxn1 := func(t *testing.T, name string) error {


### PR DESCRIPTION
This commit enables leader leases to run with TestTransactionUnexpectedlyCommitted. The test used to expect leases to either be expiration based, or epoch based. This commit makes sure that the lease upgrade expects the 3 lease types.

References: #136806

Release Note: None