### PR TITLE
roachtest: add operation to generate a debug zip

### DIFF
--- a/pkg/cmd/roachtest/operations/BUILD.bazel
+++ b/pkg/cmd/roachtest/operations/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "add_index.go",
         "backup_restore.go",
         "cluster_settings.go",
+        "debug_zip.go",
         "disk_stall.go",
         "grant_revoke_all.go",
         "license_throttle.go",

--- a/pkg/cmd/roachtest/operations/debug_zip.go
+++ b/pkg/cmd/roachtest/operations/debug_zip.go
@@ -1,0 +1,80 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package operations
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/operation"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+)
+
+type cleanupDebugZip struct {
+	nodes option.NodeListOption
+}
+
+func (cl *cleanupDebugZip) Cleanup(ctx context.Context, o operation.Operation, c cluster.Cluster) {
+	// No cleanup necessary
+}
+
+func debugZipRunner() func(ctx context.Context, o operation.Operation, c cluster.Cluster) registry.OperationCleanup {
+	return func(ctx context.Context, o operation.Operation, c cluster.Cluster) registry.OperationCleanup {
+		return runDebugZip(ctx, o, c)
+	}
+}
+
+func runDebugZip(
+	ctx context.Context, o operation.Operation, c cluster.Cluster,
+) registry.OperationCleanup {
+	rng, _ := randutil.NewPseudoRand()
+	node := c.All().SeededRandNode(rng)
+
+	addr, err := c.InternalAddr(ctx, o.L(), node)
+	if err != nil {
+		o.Fatal(err)
+	}
+
+	// NOTE(seanc@): we don't actually want the payload from the debug zip, we
+	// just want to run the debug zip command to observe its impact.
+	debugZipCmd := roachtestutil.NewCommand("./%s debug zip /dev/null", o.ClusterCockroach()).
+		WithEqualsSyntax().
+		Flag("host", addr[0]).
+		Flag("logtostderr", "INFO").
+		MaybeFlag(c.IsSecure(), "certs-dir", "certs").
+		MaybeOption(!c.IsSecure(), "insecure")
+
+	o.Status(fmt.Sprintf("running %q on node %s", debugZipCmd.String(), node.NodeIDsString()))
+	err = c.RunE(ctx, option.WithNodes(node), debugZipCmd.String())
+	//result, err := c.RunWithDetailsSingleNode(ctx, o.L(), option.WithNodes(node), debugZipCmd.String())
+	if err != nil {
+		o.Fatal(err)
+	}
+
+	//_ = result
+	//o.L().Printf("stdout: %s\nstderr: %s\n", result.Stdout, result.Stderr)
+
+	return &cleanupDebugZip{
+		nodes: node,
+	}
+}
+
+func registerDebugZip(r registry.Registry) {
+	r.AddOperation(registry.OperationSpec{
+		Name:               "debug-zip/default",
+		Owner:              registry.OwnerServer,
+		Timeout:            60 * time.Minute,
+		CompatibleClouds:   registry.AllClouds,
+		CanRunConcurrently: registry.OperationCanRunConcurrently,
+		Dependencies:       []registry.OperationDependency{registry.OperationRequiresPopulatedDatabase},
+		Run:                debugZipRunner(),
+	})
+}

--- a/pkg/cmd/roachtest/operations/debug_zip.go
+++ b/pkg/cmd/roachtest/operations/debug_zip.go
@@ -18,14 +18,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 )
 
-type cleanupDebugZip struct {
-	nodes option.NodeListOption
-}
-
-func (cl *cleanupDebugZip) Cleanup(ctx context.Context, o operation.Operation, c cluster.Cluster) {
-	// No cleanup necessary
-}
-
 func debugZipRunner() func(ctx context.Context, o operation.Operation, c cluster.Cluster) registry.OperationCleanup {
 	return func(ctx context.Context, o operation.Operation, c cluster.Cluster) registry.OperationCleanup {
 		return runDebugZip(ctx, o, c)
@@ -54,17 +46,11 @@ func runDebugZip(
 
 	o.Status(fmt.Sprintf("running %q on node %s", debugZipCmd.String(), node.NodeIDsString()))
 	err = c.RunE(ctx, option.WithNodes(node), debugZipCmd.String())
-	//result, err := c.RunWithDetailsSingleNode(ctx, o.L(), option.WithNodes(node), debugZipCmd.String())
 	if err != nil {
 		o.Fatal(err)
 	}
 
-	//_ = result
-	//o.L().Printf("stdout: %s\nstderr: %s\n", result.Stdout, result.Stderr)
-
-	return &cleanupDebugZip{
-		nodes: node,
-	}
+	return nil
 }
 
 func registerDebugZip(r registry.Registry) {

--- a/pkg/cmd/roachtest/operations/register.go
+++ b/pkg/cmd/roachtest/operations/register.go
@@ -23,4 +23,5 @@ func RegisterOperations(r registry.Registry) {
 	registerPauseLDRJob(r)
 	registerLicenseThrottle(r)
 	registerSessionVariables(r)
+	registerDebugZip(r)
 }


### PR DESCRIPTION
This change adds the ability to grab a debug zip.  The
debug zip is sent to `/dev/null` so there should be no
cleanup from this operation, but the performance impact
of debug zip collection will be available for observation.

Fixes: #138608 
Epic: none
Release note: None