### PR TITLE
release-24.3: roachtest: when building, don't run `nogo`

### DIFF
--- a/build/teamcity/cockroach/nightlies/roachtest_compile_component.sh
+++ b/build/teamcity/cockroach/nightlies/roachtest_compile_component.sh
@@ -66,17 +66,17 @@ artifacts=()
 case "$component" in
   cockroach)
     # Cockroach binary.
-    bazel_args=(--config force_build_cdeps //pkg/cmd/cockroach $crdb_extra_flags)
+    bazel_args=(--config force_build_cdeps --norun_validations //pkg/cmd/cockroach $crdb_extra_flags)
     artifacts=("pkg/cmd/cockroach/cockroach_/cockroach:bin/cockroach.$os-$arch")
     ;;
   cockroach-ea)
     # Cockroach-short with enabled assertions (EA).
-    bazel_args=(--config force_build_cdeps //pkg/cmd/cockroach-short --crdb_test $crdb_extra_flags)
+    bazel_args=(--config force_build_cdeps --norun_validations //pkg/cmd/cockroach-short --crdb_test $crdb_extra_flags)
     artifacts=("pkg/cmd/cockroach-short/cockroach-short_/cockroach-short:bin/cockroach-ea.$os-$arch")
     ;;
   workload)
     # Workload binary.
-    bazel_args=(--config force_build_cdeps //pkg/cmd/workload)
+    bazel_args=(--config force_build_cdeps --norun_validations //pkg/cmd/workload)
     artifacts=("pkg/cmd/workload/workload_/workload:bin/workload.$os-$arch")
     ;;
   libgeos)


### PR DESCRIPTION
Backport 1/1 commits from #138698.

/cc @cockroachdb/release

Release justification: Non-production code changes

roachtest: when building, don't run `nogo`

Part of: #136626
Epic: None
Release note: None