### PR TITLE
release-24.2: logictest: give more resources to cockroach-go-testserver tests

### DIFF
--- a/pkg/ccl/logictestccl/tests/cockroach-go-testserver-23.2/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/cockroach-go-testserver-23.2/BUILD.bazel
@@ -10,9 +10,12 @@ go_test(
         "//pkg/cmd/cockroach-short",  # keep
         "//pkg/sql/logictest:cockroach_predecessor_version",  # keep
     ],
-    exec_properties = {"test.Pool": "large"},
+    exec_properties = select({
+        "//build/toolchains:is_heavy": {"test.Pool": "heavy"},
+        "//conditions:default": {"test.Pool": "large"},
+    }),
     shard_count = 1,
-    tags = ["cpu:2"],
+    tags = ["cpu:3"],
     deps = [
         "//pkg/base",
         "//pkg/build/bazel",

--- a/pkg/ccl/logictestccl/tests/cockroach-go-testserver-23.2/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/cockroach-go-testserver-23.2/BUILD.bazel
@@ -10,10 +10,7 @@ go_test(
         "//pkg/cmd/cockroach-short",  # keep
         "//pkg/sql/logictest:cockroach_predecessor_version",  # keep
     ],
-    exec_properties = select({
-        "//build/toolchains:is_heavy": {"test.Pool": "heavy"},
-        "//conditions:default": {"test.Pool": "large"},
-    }),
+    exec_properties = {"test.Pool": "heavy"},
     shard_count = 1,
     tags = ["cpu:3"],
     deps = [

--- a/pkg/cmd/generate-logictest/main.go
+++ b/pkg/cmd/generate-logictest/main.go
@@ -175,11 +175,15 @@ func (t *testdir) dump() error {
 		// allocate the tests which use 3-node clusters 2 vCPUs, and
 		// the ones which use more a bit more.
 		tplCfg.NumCPU = (cfg.NumNodes / 2) + 1
+		if strings.Contains(cfg.Name, "cockroach-go-testserver") {
+			tplCfg.NumCPU = 3
+		}
 		if cfg.Name == "3node-tenant" || strings.HasPrefix(cfg.Name, "multiregion-") {
 			tplCfg.SkipCclUnderRace = true
 		}
 		if strings.Contains(cfg.Name, "5node") ||
 			strings.Contains(cfg.Name, "fakedist") ||
+			strings.Contains(cfg.Name, "cockroach-go-testserver") ||
 			(strings.HasPrefix(cfg.Name, "local-") && !tplCfg.Ccl) ||
 			(cfg.Name == "local" && !tplCfg.Ccl) {
 			tplCfg.UseHeavyPool = true

--- a/pkg/cmd/generate-logictest/templates.go
+++ b/pkg/cmd/generate-logictest/templates.go
@@ -259,7 +259,7 @@ go_test(
         "//pkg/sql/logictest:testdata",  # keep{{ end }}{{ if .ExecBuildLogicTest }}
         "//pkg/sql/opt/exec/execbuilder:testdata",  # keep{{ end }}
     ],
-    exec_properties = {{ if .SqliteLogicTest }}{"test.Pool": "default"},{{ else if .UseHeavyPool }}select({
+    exec_properties = {{ if .SqliteLogicTest }}{"test.Pool": "default"},{{ else if eq .UseHeavyPool 2 }}{"test.Pool": "heavy"},{{ else if eq .UseHeavyPool 1 }}select({
         "//build/toolchains:is_heavy": {"test.Pool": "heavy"},
         "//conditions:default": {"test.Pool": "large"},
     }),{{ else }}{"test.Pool": "large"},{{ end }}

--- a/pkg/sql/logictest/tests/cockroach-go-testserver-23.2/BUILD.bazel
+++ b/pkg/sql/logictest/tests/cockroach-go-testserver-23.2/BUILD.bazel
@@ -10,10 +10,7 @@ go_test(
         "//pkg/sql/logictest:cockroach_predecessor_version",  # keep
         "//pkg/sql/logictest:testdata",  # keep
     ],
-    exec_properties = select({
-        "//build/toolchains:is_heavy": {"test.Pool": "heavy"},
-        "//conditions:default": {"test.Pool": "large"},
-    }),
+    exec_properties = {"test.Pool": "heavy"},
     shard_count = 7,
     tags = ["cpu:3"],
     deps = [

--- a/pkg/sql/logictest/tests/cockroach-go-testserver-23.2/BUILD.bazel
+++ b/pkg/sql/logictest/tests/cockroach-go-testserver-23.2/BUILD.bazel
@@ -10,9 +10,12 @@ go_test(
         "//pkg/sql/logictest:cockroach_predecessor_version",  # keep
         "//pkg/sql/logictest:testdata",  # keep
     ],
-    exec_properties = {"test.Pool": "large"},
+    exec_properties = select({
+        "//build/toolchains:is_heavy": {"test.Pool": "heavy"},
+        "//conditions:default": {"test.Pool": "large"},
+    }),
     shard_count = 7,
-    tags = ["cpu:2"],
+    tags = ["cpu:3"],
     deps = [
         "//pkg/base",
         "//pkg/build/bazel",


### PR DESCRIPTION
Backport:
  * 1/1 commits from "logictest: give more resources to cockroach-go-testserver tests" (#138642)
  * 1/1 commits from "logictest: fix heavy pool allocation for cockroach-go tests" (#138681)

Please see individual PRs for details.

Release justification: test only change

/cc @cockroachdb/release
