### PR TITLE
sql/types: preserve tuple labels in `(*T).WithoutTypeModifiers`

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/case
+++ b/pkg/sql/logictest/testdata/logic_test/case
@@ -94,3 +94,36 @@ SELECT CASE WHEN false THEN NULL::DECIMAL(10, 2) ELSE 1.2345::DECIMAL(5, 4) END
 1.2345
 
 subtest end
+
+# Regression test for #136167. Tuple labels should be preserved through CASE
+# expressions.
+subtest regression_136167
+
+query I rowsort
+SELECT (t2.c).foo FROM (
+    SELECT CASE WHEN foo IS NULL THEN NULL ELSE t.* END
+    FROM (VALUES (1, 'a'), (3, 'b')) AS t(foo, bar)
+) AS t2(c)
+----
+1
+3
+
+query T rowsort
+SELECT to_jsonb(CASE WHEN foo IS NULL THEN NULL ELSE t.* END)
+FROM (VALUES (1, 'a'), (3, 'b')) AS t(foo, bar)
+----
+{"bar": "a", "foo": 1}
+{"bar": "b", "foo": 3}
+
+statement ok
+CREATE TABLE t136167 (id UUID PRIMARY KEY, s TEXT)
+
+statement ok
+INSERT INTO t136167 VALUES ('2b740de9-cd33-449a-9c0e-44ea16150f99', 'string')
+
+query T
+SELECT to_jsonb(CASE WHEN t.s IS NULL THEN NULL ELSE t.* END) FROM t136167 AS t
+----
+{"id": "2b740de9-cd33-449a-9c0e-44ea16150f99", "s": "string"}
+
+subtest end

--- a/pkg/sql/types/types.go
+++ b/pkg/sql/types/types.go
@@ -1436,6 +1436,9 @@ func (t *T) WithoutTypeModifiers() *T {
 		if !changed {
 			return t
 		}
+		if l := t.TupleLabels(); l != nil {
+			return MakeLabeledTuple(newContents, l)
+		}
 		return MakeTuple(newContents)
 	case EnumFamily:
 		// Enums have no type modifiers.


### PR DESCRIPTION
Previously, the `WithoutTypeModifiers` method incorrectly removed tuple
labels from the returned type. This has been fixed.

Fixes #136167

Release note (bug fix): A bug has been fixed that disregarded tuple
labels in some cases. This could cause unexpected behavior, such as when
converting a tuple to JSON with `to_jsonb`. See #136167 for more
details. The incorrect removal of tuple labels bug was introduced in
v22.1.0, and changes in v24.3.0 made unexpected behavior due to the bug
more likely.
