### PR TITLE
logictest: improve handling of `statement` command

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/crdb_internal_tenant
+++ b/pkg/ccl/logictestccl/testdata/logic_test/crdb_internal_tenant
@@ -406,16 +406,16 @@ SET application_name = 'test_max_retry'
 
 # Make the statement retry, to ensure max_retries increases to
 # become different from 0.
-statement OK
+statement ok
 CREATE SEQUENCE s;
 
-statement OK
+statement ok
 SELECT IF(nextval('s')<3, crdb_internal.force_retry('1h'::INTERVAL), 0);
 
-statement OK
+statement ok
 DROP SEQUENCE s
 
-statement OK
+statement ok
 RESET application_name
 
 # Note: in the following test, three rows of output are expected:

--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_query_behavior
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_query_behavior
@@ -416,9 +416,8 @@ Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJyslN1u2zYUx-_3F
 
 # Regression test for #74890. Code should not panic due to distribution already
 # provided by input.
-statement ok nodeidx=3
-USE multi_region_test_db; CREATE TABLE t74890 AS
-SELECT generate_series(1, 5) AS g
+query empty nodeidx=3
+CREATE TABLE multi_region_test_db.public.t74890 AS SELECT generate_series(1, 5) AS g
 
 query I nodeidx=3
 USE multi_region_test_db; SELECT g FROM t74890 ORDER BY g

--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -2651,16 +2651,10 @@ func (t *logicTest) processSubtest(
 				pos:         fmt.Sprintf("\n%s:%d", path, s.Line+subtest.lineLineIndexIntoFile),
 				expectCount: -1,
 			}
-			// Parse "statement (notice|error) <regexp>"
-			if m := noticeRE.FindStringSubmatch(s.Text()); m != nil {
-				stmt.expectNotice = m[1]
-			} else if m := errorRE.FindStringSubmatch(s.Text()); m != nil {
-				stmt.expectErrCode = m[1]
-				stmt.expectErr = m[2]
-			}
 			if len(fields) >= 3 && fields[1] == "async" {
 				stmt.expectAsync = true
 				stmt.statementName = fields[2]
+				// Consume 'async <name>'.
 				copy(fields[1:], fields[3:])
 				fields = fields[:len(fields)-2]
 			}
@@ -2670,6 +2664,26 @@ func (t *logicTest) processSubtest(
 					return err
 				}
 				stmt.expectCount = n
+				// Consume 'count <count>'.
+				copy(fields[1:], fields[3:])
+				fields = fields[:len(fields)-2]
+			}
+			fullyConsumed := len(fields) == 1
+			// Parse "statement (notice|error) <regexp>"
+			if m := noticeRE.FindStringSubmatch(s.Text()); m != nil {
+				stmt.expectNotice = m[1]
+				fullyConsumed = true
+			} else if m := errorRE.FindStringSubmatch(s.Text()); m != nil {
+				stmt.expectErrCode = m[1]
+				stmt.expectErr = m[2]
+				fullyConsumed = true
+			} else if len(fields) == 2 && strings.ToLower(fields[1]) == "ok" {
+				// Match 'ok' case-insensitively only if there are no options
+				// after it.
+				fullyConsumed = true
+			}
+			if !fullyConsumed {
+				return errors.Newf("unexpected options for 'statement' command: %s", line)
 			}
 			if _, err := stmt.readSQL(t, s, false /* allowSeparator */); err != nil {
 				return err

--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -2677,9 +2677,8 @@ func (t *logicTest) processSubtest(
 				stmt.expectErrCode = m[1]
 				stmt.expectErr = m[2]
 				fullyConsumed = true
-			} else if len(fields) == 2 && strings.ToLower(fields[1]) == "ok" {
-				// Match 'ok' case-insensitively only if there are no options
-				// after it.
+			} else if len(fields) == 2 && fields[1] == "ok" {
+				// Match 'ok' only if there are no options after it.
 				fullyConsumed = true
 			}
 			if !fullyConsumed {

--- a/pkg/sql/logictest/testdata/logic_test/aggregate
+++ b/pkg/sql/logictest/testdata/logic_test/aggregate
@@ -184,7 +184,7 @@ SELECT (SELECT COALESCE(max(1), 0) FROM generate_series(1,0))
 ----
 0
 
-statement OK
+statement ok
 INSERT INTO kv VALUES
 (1, 2, 3, 'a', '1min', '{1, 2, NULL}'),
 (3, 4, 5, 'a', '2sec', '{3, 4, 5}'),
@@ -1081,7 +1081,7 @@ SELECT bool_and(b), bool_or(b) FROM bools
 ----
 NULL NULL
 
-statement OK
+statement ok
 INSERT INTO bools VALUES (true), (true), (true)
 
 query BB
@@ -1089,7 +1089,7 @@ SELECT bool_and(b), bool_or(b) FROM bools
 ----
 true true
 
-statement OK
+statement ok
 INSERT INTO bools VALUES (false), (false)
 
 query BB
@@ -1097,7 +1097,7 @@ SELECT bool_and(b), bool_or(b) FROM bools
 ----
 false true
 
-statement OK
+statement ok
 DELETE FROM bools WHERE b
 
 query BB
@@ -1129,7 +1129,7 @@ CREATE TABLE filter_test (
   mark BOOL
 )
 
-statement OK
+statement ok
 INSERT INTO filter_test VALUES
 (1, 2, false),
 (3, 4, true),
@@ -1260,7 +1260,7 @@ true
 true
 
 # Grouping and rendering tuples.
-statement OK
+statement ok
 CREATE TABLE ab (
   a INT PRIMARY KEY,
   b INT,
@@ -1435,7 +1435,7 @@ SELECT 123 FROM kv ORDER BY max(v)
 
 subtest statistics
 
-statement OK
+statement ok
 CREATE TABLE statistics_agg_test (
   y float,
   x float,
@@ -1445,7 +1445,7 @@ CREATE TABLE statistics_agg_test (
   dx decimal
 )
 
-statement OK
+statement ok
 INSERT INTO statistics_agg_test (y, x, int_y, int_x, dy, dx) VALUES
   (1.0,   10.0,    1,   10, 1.0,   10.0),
   (2.0,   25.0,    2,   25, 2.0,   25.0),
@@ -1486,7 +1486,7 @@ FROM statistics_agg_test
 query error pq: unknown signature: corr\(string, string\)
 SELECT corr(y::string, x::string) FROM statistics_agg_test
 
-statement OK
+statement ok
 INSERT INTO statistics_agg_test (y, x, int_y, int_x, dy, dx) VALUES
   (1.797693134862315708145274237317043567981e+308, 0, 0, 0, 1.797693134862315708145274237317043567981e+308, 0)
 
@@ -1495,10 +1495,10 @@ SELECT corr(y, x), corr(int_y, int_x) FROM statistics_agg_test
 ----
 -0.443213217542505  0.917580124387801
 
-statement OK
+statement ok
 TRUNCATE statistics_agg_test
 
-statement OK
+statement ok
 INSERT INTO statistics_agg_test (y, x, int_y, int_x, dy, dx) VALUES
   (1.0, 10.0, 1, 10, 1.0, 10.0),
   (2.0, 20.0, 2, 20, 2.0, 20.0)
@@ -1509,10 +1509,10 @@ FROM statistics_agg_test
 ----
 1 1 1
 
-statement OK
+statement ok
 TRUNCATE statistics_agg_test
 
-statement OK
+statement ok
 INSERT INTO statistics_agg_test (y, x, int_y, int_x, dy, dx) VALUES
   (1.0,  10.0, 1,  10, 1.0,  10.0),
   (2.0, -20.0, 2, -20, 2.0, -20.0)
@@ -1523,10 +1523,10 @@ FROM statistics_agg_test
 ----
 -1 -1 -1
 
-statement OK
+statement ok
 TRUNCATE statistics_agg_test
 
-statement OK
+statement ok
 INSERT INTO statistics_agg_test (y, x, int_y, int_x, dy, dx) VALUES
   (1.0, -1.0, 1, -1, 1.0, -1.0),
   (1.0,  1.0, 1,  1, 1.0,  1.0)
@@ -1537,12 +1537,12 @@ FROM statistics_agg_test
 ----
 NULL NULL NULL
 
-statement OK
+statement ok
 TRUNCATE statistics_agg_test
 
 subtest covar_pop
 
-statement OK
+statement ok
 INSERT INTO statistics_agg_test (y, x, int_y, int_x, dy, dx)
 VALUES (0.0,   0.09561,    1,   10,   0.0, 0.09561),
        (42.0,   324.78,    2,   25,  42.0,  324.78),
@@ -1583,17 +1583,17 @@ FROM statistics_agg_test
 query error pq: unknown signature: covar_pop\(string, string\)
 SELECT covar_pop(y::string, x::string) FROM statistics_agg_test
 
-statement OK
+statement ok
 INSERT INTO statistics_agg_test (y, x, int_y, int_x) VALUES
   (1.797693134862315708145274237317043567981e+308, 0, 0, 0)
 
 query error float out of range
 SELECT covar_pop(y, x), covar_pop(int_y, int_x) FROM statistics_agg_test
 
-statement OK
+statement ok
 TRUNCATE statistics_agg_test
 
-statement OK
+statement ok
 INSERT INTO statistics_agg_test (y, x, int_y, int_x, dy, dx) VALUES
   (1.0, 10.0, 1, 10, 1.0, 10.0),
   (2.0, 20.0, 2, 20, 2.0, 20.0)
@@ -1604,10 +1604,10 @@ FROM statistics_agg_test
 ----
 2.5 2.5 2.5
 
-statement OK
+statement ok
 TRUNCATE statistics_agg_test
 
-statement OK
+statement ok
 INSERT INTO statistics_agg_test (y, x, int_y, int_x, dy, dx) VALUES
   (1.0,  10.0, 1,  10, 1.0,  10.0),
   (2.0, -20.0, 2, -20, 2.0, -20.0)
@@ -1618,10 +1618,10 @@ FROM statistics_agg_test
 ----
 -7.5 -7.5 -7.5
 
-statement OK
+statement ok
 TRUNCATE statistics_agg_test
 
-statement OK
+statement ok
 INSERT INTO statistics_agg_test (y, x, int_y, int_x, dy, dx) VALUES
   (1.0, -1.0, 1, -1, 1.0, -1.0),
   (1.0,  1.0, 1,  1, 1.0,  1.0)
@@ -1632,12 +1632,12 @@ FROM statistics_agg_test
 ----
 0 0 0
 
-statement OK
+statement ok
 TRUNCATE statistics_agg_test
 
 subtest covar_samp
 
-statement OK
+statement ok
 INSERT INTO statistics_agg_test (y, x, int_y, int_x, dy, dx)
 VALUES (0.0,   0.09561,    1,   10,   0.0, 0.09561),
        (42.0,   324.78,    2,   25,  42.0,  324.78),
@@ -1678,17 +1678,17 @@ FROM statistics_agg_test
 query error pq: unknown signature: covar_samp\(string, string\)
 SELECT covar_samp(y::string, x::string) FROM statistics_agg_test
 
-statement OK
+statement ok
 INSERT INTO statistics_agg_test (y, x, int_y, int_x) VALUES
   (1.797693134862315708145274237317043567981e+308, 0, 0, 0)
 
 query error float out of range
 SELECT covar_samp(y, x), covar_samp(int_y, int_x) FROM statistics_agg_test
 
-statement OK
+statement ok
 TRUNCATE statistics_agg_test
 
-statement OK
+statement ok
 INSERT INTO statistics_agg_test (y, x, int_y, int_x, dy, dx) VALUES
   (1.0, 10.0, 1, 10, 1.0, 10.0),
   (2.0, 20.0, 2, 20, 2.0, 20.0)
@@ -1699,10 +1699,10 @@ FROM statistics_agg_test
 ----
 5 5 5
 
-statement OK
+statement ok
 TRUNCATE statistics_agg_test
 
-statement OK
+statement ok
 INSERT INTO statistics_agg_test (y, x, int_y, int_x, dy, dx) VALUES
   (1.0,  10.0, 1,  10, 1.0,  10.0),
   (2.0, -20.0, 2, -20, 2.0, -20.0)
@@ -1713,10 +1713,10 @@ FROM statistics_agg_test
 ----
 -15 -15 -15
 
-statement OK
+statement ok
 TRUNCATE statistics_agg_test
 
-statement OK
+statement ok
 INSERT INTO statistics_agg_test (y, x, int_y, int_x, dy, dx) VALUES
   (1.0, -1.0, 1, -1, 1.0, -1.0),
   (1.0,  1.0, 1,  1, 1.0,  1.0)
@@ -1727,12 +1727,12 @@ FROM statistics_agg_test
 ----
 0 0 0
 
-statement OK
+statement ok
 TRUNCATE statistics_agg_test
 
 subtest regr_intercept
 
-statement OK
+statement ok
 INSERT INTO statistics_agg_test (y, x, int_y, int_x, dy, dx)
 VALUES (0.0,   0.09561,    1,   10,   0.0, 0.09561),
        (42.0,   324.78,    2,   25,  42.0,  324.78),
@@ -1773,7 +1773,7 @@ FROM statistics_agg_test
 query error pq: unknown signature: regr_intercept\(string, string\)
 SELECT regr_intercept(y::string, x::string) FROM statistics_agg_test
 
-statement OK
+statement ok
 INSERT INTO statistics_agg_test (y, x, int_y, int_x) VALUES
   (1.797693134862315708145274237317043567981e+308, 0, 0, 0)
 
@@ -1782,10 +1782,10 @@ SELECT regr_intercept(y, x), regr_intercept(int_y, int_x) FROM statistics_agg_te
 ----
 2.79449911391682e+307  1.07386861313869
 
-statement OK
+statement ok
 TRUNCATE statistics_agg_test
 
-statement OK
+statement ok
 INSERT INTO statistics_agg_test (y, x, int_y, int_x, dy, dx) VALUES
   (1.0, 10.0, 1, 10, 1.0, 10.0),
   (2.0, 20.0, 2, 20, 2.0, 20.0)
@@ -1796,10 +1796,10 @@ FROM statistics_agg_test
 ----
 0 0 0
 
-statement OK
+statement ok
 TRUNCATE statistics_agg_test
 
-statement OK
+statement ok
 INSERT INTO statistics_agg_test (y, x, int_y, int_x, dy, dx) VALUES
   (1.0,  10.0, 1,  10, 1.0,  10.0),
   (2.0, -20.0, 2, -20, 2.0, -20.0)
@@ -1810,10 +1810,10 @@ FROM statistics_agg_test
 ----
 1.3333333333333333  1.3333333333333333  1.3333333333333333
 
-statement OK
+statement ok
 TRUNCATE statistics_agg_test
 
-statement OK
+statement ok
 INSERT INTO statistics_agg_test (y, x, int_y, int_x, dy, dx) VALUES
   (1.0, -1.0, 1, -1, 1.0, -1.0),
   (1.0,  1.0, 1,  1, 1.0,  1.0)
@@ -1824,12 +1824,12 @@ FROM statistics_agg_test
 ----
 1 1 1
 
-statement OK
+statement ok
 TRUNCATE statistics_agg_test
 
 subtest regr_r2
 
-statement OK
+statement ok
 INSERT INTO statistics_agg_test (y, x, int_y, int_x, dy, dx)
 VALUES (0.0,   0.09561,    1,   10,   0.0, 0.09561),
        (42.0,   324.78,    2,   25,  42.0,  324.78),
@@ -1870,7 +1870,7 @@ FROM statistics_agg_test
 query error pq: unknown signature: regr_r2\(string, string\)
 SELECT regr_r2(y::string, x::string) FROM statistics_agg_test
 
-statement OK
+statement ok
 INSERT INTO statistics_agg_test (y, x, int_y, int_x) VALUES
   (1.797693134862315708145274237317043567981e+308, 0, 0, 0)
 
@@ -1879,10 +1879,10 @@ SELECT regr_r2(y, x), regr_r2(int_y, int_x) FROM statistics_agg_test
 ----
 0.070994090464941  0.841953284671533
 
-statement OK
+statement ok
 TRUNCATE statistics_agg_test
 
-statement OK
+statement ok
 INSERT INTO statistics_agg_test (y, x, int_y, int_x, dy, dx) VALUES
   (1.0, 10.0, 1, 10, 1.0, 10.0),
   (2.0, 20.0, 2, 20, 2.0, 20.0)
@@ -1893,10 +1893,10 @@ FROM statistics_agg_test
 ----
 1 1 1
 
-statement OK
+statement ok
 TRUNCATE statistics_agg_test
 
-statement OK
+statement ok
 INSERT INTO statistics_agg_test (y, x, int_y, int_x, dy, dx) VALUES
   (1.0,  10.0, 1,  10, 1.0,  10.0),
   (2.0, -20.0, 2, -20, 2.0, -20.0)
@@ -1907,10 +1907,10 @@ FROM statistics_agg_test
 ----
 1 1 1
 
-statement OK
+statement ok
 TRUNCATE statistics_agg_test
 
-statement OK
+statement ok
 INSERT INTO statistics_agg_test (y, x, int_y, int_x, dy, dx) VALUES
   (1.0, -1.0, 1, -1, 1.0, -1.0),
   (1.0,  1.0, 1,  1, 1.0,  1.0)
@@ -1921,12 +1921,12 @@ FROM statistics_agg_test
 ----
 1 1 1
 
-statement OK
+statement ok
 TRUNCATE statistics_agg_test
 
 subtest regr_slope
 
-statement OK
+statement ok
 INSERT INTO statistics_agg_test (y, x, int_y, int_x, dy, dx)
 VALUES (0.0,   0.09561,    1,   10,   0.0, 0.09561),
        (42.0,   324.78,    2,   25,  42.0,  324.78),
@@ -1967,7 +1967,7 @@ FROM statistics_agg_test
 query error pq: unknown signature: regr_slope\(string, string\)
 SELECT regr_slope(y::string, x::string) FROM statistics_agg_test
 
-statement OK
+statement ok
 INSERT INTO statistics_agg_test (y, x, int_y, int_x) VALUES
   (1.797693134862315708145274237317043567981e+308, 0, 0, 0)
 
@@ -1976,10 +1976,10 @@ SELECT regr_slope(y, x), regr_slope(int_y, int_x) FROM statistics_agg_test
 ----
 -1.19338306247506e+305  0.0313576642335766
 
-statement OK
+statement ok
 TRUNCATE statistics_agg_test
 
-statement OK
+statement ok
 INSERT INTO statistics_agg_test (y, x, int_y, int_x, dy, dx) VALUES
   (1.0, 10.0, 1, 10, 1.0, 10.0),
   (2.0, 20.0, 2, 20, 2.0, 20.0)
@@ -1990,10 +1990,10 @@ FROM statistics_agg_test
 ----
 0.1 0.1 0.1
 
-statement OK
+statement ok
 TRUNCATE statistics_agg_test
 
-statement OK
+statement ok
 INSERT INTO statistics_agg_test (y, x, int_y, int_x, dy, dx) VALUES
   (1.0,  10.0, 1,  10, 1.0,  10.0),
   (2.0, -20.0, 2, -20, 2.0, -20.0)
@@ -2004,10 +2004,10 @@ FROM statistics_agg_test
 ----
 -0.03333333333333333  -0.03333333333333333  -0.03333333333333333
 
-statement OK
+statement ok
 TRUNCATE statistics_agg_test
 
-statement OK
+statement ok
 INSERT INTO statistics_agg_test (y, x, int_y, int_x, dy, dx) VALUES
   (1.0, -1.0, 1, -1, 1.0, -1.0),
   (1.0,  1.0, 1,  1, 1.0,  1.0)
@@ -2018,12 +2018,12 @@ FROM statistics_agg_test
 ----
 0 0 0
 
-statement OK
+statement ok
 TRUNCATE statistics_agg_test
 
 subtest regr_sxx
 
-statement OK
+statement ok
 INSERT INTO statistics_agg_test (y, x, int_y, int_x, dy, dx)
 VALUES (0.0,   0.09561,    1,   10,   0.0, 0.09561),
        (42.0,   324.78,    2,   25,  42.0,  324.78),
@@ -2064,17 +2064,17 @@ FROM statistics_agg_test
 query error pq: unknown signature: regr_sxx\(string, string\)
 SELECT regr_sxx(y::string, x::string) FROM statistics_agg_test
 
-statement OK
+statement ok
 INSERT INTO statistics_agg_test (y, x, int_y, int_x) VALUES
   (0, 1.797693134862315708145274237317043567981e+308, 0, 0)
 
 query error float out of range
 SELECT regr_sxx(y, x), regr_sxx(int_y, int_x) FROM statistics_agg_test
 
-statement OK
+statement ok
 TRUNCATE statistics_agg_test
 
-statement OK
+statement ok
 INSERT INTO statistics_agg_test (y, x, int_y, int_x, dy, dx) VALUES
   (1.0, 10.0, 1, 10, 1.0, 10.0),
   (2.0, 20.0, 2, 20, 2.0, 20.0)
@@ -2085,10 +2085,10 @@ FROM statistics_agg_test
 ----
 50 50 50
 
-statement OK
+statement ok
 TRUNCATE statistics_agg_test
 
-statement OK
+statement ok
 INSERT INTO statistics_agg_test (y, x, int_y, int_x, dy, dx) VALUES
   (1.0,  10.0, 1,  10, 1.0,  10.0),
   (2.0, -20.0, 2, -20, 2.0, -20.0)
@@ -2099,10 +2099,10 @@ FROM statistics_agg_test
 ----
 450 450 450
 
-statement OK
+statement ok
 TRUNCATE statistics_agg_test
 
-statement OK
+statement ok
 INSERT INTO statistics_agg_test (y, x, int_y, int_x, dy, dx) VALUES
   (1.0, -1.0, 1, -1, 1.0, -1.0),
   (1.0,  1.0, 1,  1, 1.0,  1.0)
@@ -2113,12 +2113,12 @@ FROM statistics_agg_test
 ----
 2 2 2
 
-statement OK
+statement ok
 TRUNCATE statistics_agg_test
 
 subtest regr_sxy
 
-statement OK
+statement ok
 INSERT INTO statistics_agg_test (y, x, int_y, int_x, dy, dx)
 VALUES (0.0,   0.09561,    1,   10,   0.0, 0.09561),
        (42.0,   324.78,    2,   25,  42.0,  324.78),
@@ -2159,17 +2159,17 @@ FROM statistics_agg_test
 query error pq: unknown signature: regr_sxy\(string, string\)
 SELECT regr_sxy(y::string, x::string) FROM statistics_agg_test
 
-statement OK
+statement ok
 INSERT INTO statistics_agg_test (y, x, int_y, int_x) VALUES
   (1.797693134862315708145274237317043567981e+308, 0, 0, 0)
 
 query error float out of range
 SELECT regr_sxy(y, x), regr_sxy(int_y, int_x) FROM statistics_agg_test
 
-statement OK
+statement ok
 TRUNCATE statistics_agg_test
 
-statement OK
+statement ok
 INSERT INTO statistics_agg_test (y, x, int_y, int_x, dy, dx) VALUES
   (1.0, 10.0, 1, 10, 1.0, 10.0),
   (2.0, 20.0, 2, 20, 2.0, 20.0)
@@ -2180,10 +2180,10 @@ FROM statistics_agg_test
 ----
 5 5 5
 
-statement OK
+statement ok
 TRUNCATE statistics_agg_test
 
-statement OK
+statement ok
 INSERT INTO statistics_agg_test (y, x, int_y, int_x, dy, dx) VALUES
   (1.0,  10.0, 1,  10, 1.0,  10.0),
   (2.0, -20.0, 2, -20, 2.0, -20.0)
@@ -2194,10 +2194,10 @@ FROM statistics_agg_test
 ----
 -15 -15 -15
 
-statement OK
+statement ok
 TRUNCATE statistics_agg_test
 
-statement OK
+statement ok
 INSERT INTO statistics_agg_test (y, x, int_y, int_x, dy, dx) VALUES
   (1.0, -1.0, 1, -1, 1.0, -1.0),
   (1.0,  1.0, 1,  1, 1.0,  1.0)
@@ -2208,12 +2208,12 @@ FROM statistics_agg_test
 ----
 0 0 0
 
-statement OK
+statement ok
 TRUNCATE statistics_agg_test
 
 subtest regr_syy
 
-statement OK
+statement ok
 INSERT INTO statistics_agg_test (y, x, int_y, int_x, dy, dx)
 VALUES (0.0,   0.09561,    1,   10,   0.0, 0.09561),
        (42.0,   324.78,    2,   25,  42.0,  324.78),
@@ -2254,17 +2254,17 @@ FROM statistics_agg_test
 query error pq: unknown signature: regr_syy\(string, string\)
 SELECT regr_syy(y::string, x::string) FROM statistics_agg_test
 
-statement OK
+statement ok
 INSERT INTO statistics_agg_test (y, x, int_y, int_x) VALUES
   (1.797693134862315708145274237317043567981e+308, 0, 0, 0)
 
 query error float out of range
 SELECT regr_syy(y, x), regr_syy(int_y, int_x) FROM statistics_agg_test
 
-statement OK
+statement ok
 TRUNCATE statistics_agg_test
 
-statement OK
+statement ok
 INSERT INTO statistics_agg_test (y, x, int_y, int_x, dy, dx) VALUES
   (1.0, 10.0, 1, 10, 1.0, 10.0),
   (2.0, 20.0, 2, 20, 2.0, 20.0)
@@ -2275,10 +2275,10 @@ FROM statistics_agg_test
 ----
 0.5 0.5 0.5
 
-statement OK
+statement ok
 TRUNCATE statistics_agg_test
 
-statement OK
+statement ok
 INSERT INTO statistics_agg_test (y, x, int_y, int_x, dy, dx) VALUES
   (1.0,  10.0, 1,  10, 1.0,  10.0),
   (2.0, -20.0, 2, -20, 2.0, -20.0)
@@ -2289,10 +2289,10 @@ FROM statistics_agg_test
 ----
 0.5 0.5 0.5
 
-statement OK
+statement ok
 TRUNCATE statistics_agg_test
 
-statement OK
+statement ok
 INSERT INTO statistics_agg_test (y, x, int_y, int_x, dy, dx) VALUES
   (1.0, -1.0, 1, -1, 1.0, -1.0),
   (1.0,  1.0, 1,  1, 1.0,  1.0)
@@ -2303,12 +2303,12 @@ FROM statistics_agg_test
 ----
 0 0 0
 
-statement OK
+statement ok
 TRUNCATE statistics_agg_test
 
 subtest regr_count
 
-statement OK
+statement ok
 INSERT INTO statistics_agg_test (y, x, int_y, int_x, dy, dx)
 VALUES (0.0,   0.09561,    1,   10,   0.0, 0.09561),
        (42.0,   324.78,    2,   25,  42.0,  324.78),
@@ -2349,7 +2349,7 @@ FROM statistics_agg_test
 query error pq: unknown signature: regr_count\(string, string\)
 SELECT regr_count(y::string, x::string) FROM statistics_agg_test
 
-statement OK
+statement ok
 INSERT INTO statistics_agg_test (y, x, int_y, int_x) VALUES
   (1.797693134862315708145274237317043567981e+308, 0, 0, 0)
 
@@ -2358,7 +2358,7 @@ SELECT regr_count(y, x), regr_count(int_y, int_x), regr_count(dy, dx) FROM stati
 ----
 11 11 10
 
-statement OK
+statement ok
 TRUNCATE statistics_agg_test
 
 query I
@@ -2366,7 +2366,7 @@ SELECT regr_count(y, x) FROM statistics_agg_test
 ----
 0
 
-statement OK
+statement ok
 INSERT INTO statistics_agg_test (y, x, int_y, int_x, dy, dx) VALUES
   (NULL, NULL, NULL, NULL, NULL, NULL),
   (NULL, NULL, NULL, NULL, NULL, NULL)
@@ -2377,12 +2377,12 @@ FROM statistics_agg_test
 ----
 0
 
-statement OK
+statement ok
 TRUNCATE statistics_agg_test
 
 subtest regr_avgx
 
-statement OK
+statement ok
 INSERT INTO statistics_agg_test (y, x, int_y, int_x, dy, dx) VALUES
   (1.0,   10.0,    1,   10, 1.0,   10.0),
   (2.0,   25.0,    2,   25, 2.0,   25.0),
@@ -2424,17 +2424,17 @@ FROM statistics_agg_test
 query error pq: unknown signature: regr_avgx\(string, string\)
 SELECT regr_avgx(y::string, x::string) FROM statistics_agg_test
 
-statement OK
+statement ok
 INSERT INTO statistics_agg_test (y, x, int_y, int_x, dy, dx) VALUES
   (0, 1.797693134862315708145274237317043567981e+408, 0, 0, 0, 1.797693134862315708145274237317043567981e+408)
 
 query error float out of range
 SELECT regr_avgx(y, x), regr_avgx(int_y, int_x) FROM statistics_agg_test
 
-statement OK
+statement ok
 TRUNCATE statistics_agg_test
 
-statement OK
+statement ok
 INSERT INTO statistics_agg_test (y, x, int_y, int_x, dy, dx) VALUES
   (1.0, 10.0, 1, 10, 1.0, 10.0),
   (2.0, 20.0, 2, 20, 2.0, 20.0)
@@ -2445,10 +2445,10 @@ FROM statistics_agg_test
 ----
 15 15 15
 
-statement OK
+statement ok
 TRUNCATE statistics_agg_test
 
-statement OK
+statement ok
 INSERT INTO statistics_agg_test (y, x, int_y, int_x, dy, dx) VALUES
   (1.0,  10.0, 1,  10, 1.0,  10.0),
   (2.0, -20.0, 2, -20, 2.0, -20.0)
@@ -2459,10 +2459,10 @@ FROM statistics_agg_test
 ----
 -5 -5 -5
 
-statement OK
+statement ok
 TRUNCATE statistics_agg_test
 
-statement OK
+statement ok
 INSERT INTO statistics_agg_test (y, x, int_y, int_x, dy, dx) VALUES
   (1.0, -1.0, 1, -1, 1.0, -1.0),
   (1.0,  1.0, 1,  1, 1.0,  1.0)
@@ -2473,7 +2473,7 @@ FROM statistics_agg_test
 ----
 0 0 0
 
-statement OK
+statement ok
 TRUNCATE statistics_agg_test
 
 query R
@@ -2483,7 +2483,7 @@ NULL
 
 subtest regr_avgy
 
-statement OK
+statement ok
 INSERT INTO statistics_agg_test (y, x, int_y, int_x, dy, dx)
 VALUES (0.0,   0.09561,    1,   10,   0.0, 0.09561),
        (42.0,   324.78,    2,   25,  42.0,  324.78),
@@ -2524,17 +2524,17 @@ FROM statistics_agg_test
 query error pq: unknown signature: regr_avgy\(string, string\)
 SELECT regr_avgy(y::string, x::string) FROM statistics_agg_test
 
-statement OK
+statement ok
 INSERT INTO statistics_agg_test (y, x, int_y, int_x) VALUES
   (1.797693134862315708145274237317043567981e+408, 0, 0, 0)
 
 query error float out of range
 SELECT regr_avgy(y, x), regr_avgy(int_y, int_x) FROM statistics_agg_test
 
-statement OK
+statement ok
 TRUNCATE statistics_agg_test
 
-statement OK
+statement ok
 INSERT INTO statistics_agg_test (y, x, int_y, int_x, dy, dx) VALUES
   (1.0, 10.0, 1, 10, 1.0, 10.0),
   (2.0, 20.0, 2, 20, 2.0, 20.0)
@@ -2545,10 +2545,10 @@ FROM statistics_agg_test
 ----
 1.5  1.5  1.5
 
-statement OK
+statement ok
 TRUNCATE statistics_agg_test
 
-statement OK
+statement ok
 INSERT INTO statistics_agg_test (y, x, int_y, int_x, dy, dx) VALUES
   (1.0,  10.0, 1,  10, 1.0,  10.0),
   (2.0, -20.0, 2, -20, 2.0, -20.0)
@@ -2559,10 +2559,10 @@ FROM statistics_agg_test
 ----
 1.5  1.5  1.5
 
-statement OK
+statement ok
 TRUNCATE statistics_agg_test
 
-statement OK
+statement ok
 INSERT INTO statistics_agg_test (y, x, int_y, int_x, dy, dx) VALUES
   (1.0, -1.0, 1, -1, 1.0, -1.0),
   (1.0,  1.0, 1,  1, 1.0,  1.0)
@@ -2573,12 +2573,12 @@ FROM statistics_agg_test
 ----
 1  1  1
 
-statement OK
+statement ok
 TRUNCATE statistics_agg_test
 
 subtest string_agg
 
-statement OK
+statement ok
 CREATE TABLE string_agg_test (
   id INT PRIMARY KEY,
   company_id INT,
@@ -2617,7 +2617,7 @@ ORDER BY company_id;
 ----
 company_id  string_agg
 
-statement OK
+statement ok
 INSERT INTO string_agg_test VALUES
   (1, 1, 'A'),
   (2, 2, 'B'),
@@ -2779,10 +2779,10 @@ FROM string_agg_test
 GROUP BY company_id
 ORDER BY company_id;
 
-statement OK
+statement ok
 TRUNCATE string_agg_test
 
-statement OK
+statement ok
 INSERT INTO string_agg_test VALUES
   (1, 1, 'A'),
   (2, 1, 'B'),
@@ -2867,7 +2867,7 @@ ORDER BY e.company_id;
 company_id  string_agg
 1           DCBA
 
-statement OK
+statement ok
 DROP TABLE string_agg_test
 
 # Regression test for #28836.
@@ -3808,13 +3808,13 @@ test
 
 subtest corrupt_combine
 
-statement OK
+statement ok
 CREATE TABLE corrupt_combine (
   y float,
   x float
 )
 
-statement OK
+statement ok
 INSERT INTO corrupt_combine (y, x) VALUES
   (1.0, 10.0),
   (2.0, 25.0),

--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -4271,7 +4271,7 @@ SHOW use_declarative_schema_changer
 statement ok
 set use_declarative_schema_changer = 'unsafe_always';
 
-statement ok;
+statement ok
 BEGIN;
 ALTER TABLE t1_add DROP COLUMN c1;
 ALTER TABLE t1_add ADD COLUMN IF NOT EXISTS c1 date DEFAULT '2024-08-31';

--- a/pkg/sql/logictest/testdata/logic_test/cascade
+++ b/pkg/sql/logictest/testdata/logic_test/cascade
@@ -2223,7 +2223,7 @@ CREATE TABLE c (
  ,b_a_id STRING REFERENCES b(a_id) ON UPDATE CASCADE
 );
 
-statement oK
+statement ok
 INSERT INTO a VALUES ('delete-me'), ('untouched');
 INSERT INTO b VALUES ('b1', 'delete-me'), ('b2', 'untouched');
 INSERT INTO c VALUES
@@ -2280,7 +2280,7 @@ CREATE TABLE c (
  ,b_a_id STRING NOT NULL REFERENCES b(a_id) ON UPDATE CASCADE
 );
 
-statement oK
+statement ok
 INSERT INTO a VALUES ('delete-me'), ('untouched');
 INSERT INTO b VALUES ('b1', 'delete-me'), ('b2', 'untouched');
 INSERT INTO c VALUES
@@ -2474,7 +2474,7 @@ CREATE TABLE c (
  ,b_a_id STRING REFERENCES b(a_id) ON UPDATE CASCADE
 );
 
-statement oK
+statement ok
 INSERT INTO a VALUES ('original'), ('untouched');
 INSERT INTO b VALUES ('b1', 'original'), ('b2', 'untouched');
 INSERT INTO c VALUES
@@ -2525,7 +2525,7 @@ CREATE TABLE c (
  ,b_a_id STRING NOT NULL REFERENCES b(a_id) ON UPDATE CASCADE
 );
 
-statement oK
+statement ok
 INSERT INTO a VALUES ('original'), ('untouched');
 INSERT INTO b VALUES ('b1', 'original'), ('b2', 'untouched');
 INSERT INTO c VALUES
@@ -2837,7 +2837,7 @@ CREATE TABLE c (
  ,b_a_id STRING REFERENCES b(a_id) ON UPDATE CASCADE
 );
 
-statement oK
+statement ok
 INSERT INTO a VALUES ('delete-me'), ('untouched'), ('default');
 INSERT INTO b VALUES ('b1', 'delete-me'), ('b2', 'untouched');
 INSERT INTO c VALUES
@@ -2895,7 +2895,7 @@ CREATE TABLE c (
  ,b_a_id STRING REFERENCES b(a_id) ON UPDATE CASCADE
 );
 
-statement oK
+statement ok
 INSERT INTO a VALUES ('delete-me'), ('untouched');
 INSERT INTO b VALUES ('b1', 'delete-me'), ('b2', 'untouched');
 INSERT INTO c VALUES
@@ -2948,7 +2948,7 @@ CREATE TABLE c (
  ,b_a_id STRING NOT NULL REFERENCES b(a_id) ON UPDATE CASCADE
 );
 
-statement oK
+statement ok
 INSERT INTO a VALUES ('delete-me'), ('untouched');
 INSERT INTO b VALUES ('b1', 'delete-me'), ('b2', 'untouched');
 INSERT INTO c VALUES
@@ -2982,7 +2982,7 @@ CREATE TABLE b (
  ,a_id STRING DEFAULT 'default' UNIQUE REFERENCES a ON DELETE SET DEFAULT
 );
 
-statement oK
+statement ok
 INSERT INTO a VALUES ('original'), ('default');
 INSERT INTO b VALUES ('b1', 'original'), ('b2', 'default');
 
@@ -3281,7 +3281,7 @@ CREATE TABLE c (
  ,b_a_id STRING REFERENCES b(a_id) ON UPDATE CASCADE
 );
 
-statement oK
+statement ok
 INSERT INTO a VALUES ('original'), ('untouched'), ('default');
 INSERT INTO b VALUES ('b1', 'original'), ('b2', 'untouched');
 INSERT INTO c VALUES
@@ -3333,7 +3333,7 @@ CREATE TABLE c (
  ,b_a_id STRING NOT NULL REFERENCES b(a_id) ON UPDATE CASCADE
 );
 
-statement oK
+statement ok
 INSERT INTO a VALUES ('original'), ('untouched'), ('default');
 INSERT INTO b VALUES ('b1', 'original'), ('b2', 'untouched');
 INSERT INTO c VALUES
@@ -3365,7 +3365,7 @@ CREATE TABLE b (
  ,a_id STRING DEFAULT 'default' UNIQUE REFERENCES a ON UPDATE SET DEFAULT
 );
 
-statement oK
+statement ok
 INSERT INTO a VALUES ('original'), ('default');
 INSERT INTO b VALUES ('b1', 'original'), ('b2', 'default');
 

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -724,16 +724,16 @@ SET application_name = 'test_max_retry'
 
 # Make the statement retry, to ensure max_retries increases to
 # become different from 0.
-statement OK
+statement ok
 CREATE SEQUENCE s;
 
-statement OK
+statement ok
 SELECT IF(nextval('s')<3, crdb_internal.force_retry('1h'::INTERVAL), 0);
 
-statement OK
+statement ok
 DROP SEQUENCE s
 
-statement OK
+statement ok
 RESET application_name
 
 # Note: in the following test, five rows of output are expected:

--- a/pkg/sql/logictest/testdata/logic_test/create_as
+++ b/pkg/sql/logictest/testdata/logic_test/create_as
@@ -375,7 +375,7 @@ ROLLBACK
 statement ok
 CREATE SEQUENCE seq;
 
-statement OK
+statement ok
 CREATE TABLE tab_from_seq AS (SELECT nextval('seq'))
 
 query B

--- a/pkg/sql/logictest/testdata/logic_test/database
+++ b/pkg/sql/logictest/testdata/logic_test/database
@@ -262,7 +262,7 @@ subtest missing-db-error-issue-68060
 statement ok
 CREATE DATABASE db1;
 
-statement ok;
+statement ok
 USE db1;
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/distsql_event_log
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_event_log
@@ -18,10 +18,9 @@ CREATE TABLE a (id INT PRIMARY KEY, x INT, y INT, INDEX x_idx (x, y))
 statement ok
 CREATE STATISTICS s1 ON id FROM a
 
-# TODO(msirek): Re-enable this test once autostats collection is made
-#               consistently retryable.
-# statement ok retry
-# CREATE STATISTICS __auto__ FROM a
+retry
+statement ok
+CREATE STATISTICS __auto__ FROM a
 
 # Check explicitly for table id 106. System tables could trigger autostats
 # collections at any time.
@@ -32,6 +31,7 @@ WHERE "eventType" = 'create_statistics' AND ("info"::JSONB ->> 'DescriptorID')::
 ORDER BY "timestamp", info
 ----
 1  {"EventType": "create_statistics", "Statement": "CREATE STATISTICS s1 ON id FROM test.public.a WITH OPTIONS AS OF SYSTEM TIME '-1us'", "TableName": "test.public.a", "Tag": "CREATE STATISTICS", "User": "root"}
+1  {"EventType": "create_statistics", "Statement": "CREATE STATISTICS __auto__ FROM test.public.a WITH OPTIONS AS OF SYSTEM TIME '-1us'", "TableName": "test.public.a", "Tag": "CREATE STATISTICS", "User": "root"}
 
 statement ok
 DROP TABLE a

--- a/pkg/sql/logictest/testdata/logic_test/distsql_tenant_locality
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_tenant_locality
@@ -14,7 +14,8 @@ INSERT INTO t SELECT i, i FROM generate_series(1, 6) AS g(i)
 
 # Upreplicate the table's range. We need a retry to guarantee that the
 # capability has been picked up.
-statement ok retry
+retry
+statement ok
 ALTER TABLE t EXPERIMENTAL_RELOCATE VALUES (ARRAY[1, 2, 3], 0)
 
 # Split the ranges in the table.

--- a/pkg/sql/logictest/testdata/logic_test/drop_database
+++ b/pkg/sql/logictest/testdata/logic_test/drop_database
@@ -80,7 +80,7 @@ CREATE DATABASE d2
 statement ok
 CREATE TABLE d1.t1 (k STRING PRIMARY KEY, v STRING)
 
-statement OK
+statement ok
 CREATE TABLE d2.t1 (k STRING PRIMARY KEY, v STRING)
 
 statement ok
@@ -269,16 +269,16 @@ statement ok
 DROP DATABASE foo
 
 # Check that the default databases can be dropped and re-created like any other.
-statement OK
+statement ok
 DROP DATABASE defaultdb;
 
-statement OK
+statement ok
 DROP DATABASE postgres
 
 statement ok
 CREATE DATABASE defaultdb;
 
-statement OK
+statement ok
 CREATE DATABASE postgres
 
 # Test that an empty database doesn't get a GC job.

--- a/pkg/sql/logictest/testdata/logic_test/drop_function
+++ b/pkg/sql/logictest/testdata/logic_test/drop_function
@@ -178,7 +178,7 @@ CREATE FUNCTION sc1.f_test_drop()
   SELECT 1;
 $$
 
-statement ok;
+statement ok
 BEGIN;
 DROP FUNCTION f_test_drop();
 DROP FUNCTION f_test_drop();
@@ -271,7 +271,7 @@ CREATE FUNCTION f_called_by_b() RETURNS INT LANGUAGE SQL AS $$ SELECT 1 $$;
 statement ok
 CREATE FUNCTION f_called_by_b2() RETURNS INT LANGUAGE SQL AS $$ SELECT 1 + f_called_by_b() $$;
 
-statement ok;
+statement ok
 CREATE FUNCTION f_b()  RETURNS INT LANGUAGE SQL AS $$ SELECT (f_called_by_b2()) /f_called_by_b2() FROM f_called_by_b() $$;
 
 statement error pgcode 2BP01 cannot drop function \"f_called_by_b\" because other objects \(\[test.public.f_called_by_b2, test.public.f_b\]\) still depend on it

--- a/pkg/sql/logictest/testdata/logic_test/drop_table
+++ b/pkg/sql/logictest/testdata/logic_test/drop_table
@@ -150,7 +150,7 @@ CREATE TABLE t_not_valid_dst (i INT PRIMARY KEY, j INT, c CHAR);
 statement ok
 CREATE SEQUENCE t_not_valid_sq;
 
-statement ok;
+statement ok
 ALTER TABLE t_not_valid_dst ADD CONSTRAINT v_fk FOREIGN KEY(j) REFERENCES t_not_valid_src(i) NOT VALID;
 
 statement ok
@@ -159,7 +159,7 @@ ALTER TABLE t_not_valid_dst ADD CHECK (j > currval('t_not_valid_sq')) NOT VALID;
 statement ok
 DROP TABLE t_not_valid_src CASCADE;
 
-statement ok;
+statement ok
 DROP SEQUENCE t_not_valid_sq CASCADE;
 
 # Sequence related check constraint should be cleaned, so inserts should work.

--- a/pkg/sql/logictest/testdata/logic_test/gc_job_mixed
+++ b/pkg/sql/logictest/testdata/logic_test/gc_job_mixed
@@ -14,7 +14,7 @@ INSERT INTO db.other (t) VALUES ('other')
 statement ok
 ALTER TABLE db.kv ALTER PRIMARY KEY USING COLUMNS (k)
 
-statement ok;
+statement ok
 DROP TABLE db.kv
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/grant_in_txn
+++ b/pkg/sql/logictest/testdata/logic_test/grant_in_txn
@@ -179,16 +179,16 @@ COMMIT;
 # Ensure that we can inspect information_schema.applicable_roles inside of a
 # transaction. Prior to the change which introduces this
 
-statement ok;
+statement ok
 CREATE ROLE role_foo;
 
-statement ok;
+statement ok
 CREATE ROLE role_bar;
 
 statement ok
 GRANT role_bar TO role_foo WITH ADMIN OPTION;
 
-statement ok;
+statement ok
 GRANT role_foo TO testuser WITH ADMIN OPTION;
 
 # switch to testuser

--- a/pkg/sql/logictest/testdata/logic_test/grant_revoke_with_grant_option
+++ b/pkg/sql/logictest/testdata/logic_test/grant_revoke_with_grant_option
@@ -675,7 +675,7 @@ test           public       grant_ordering_table  grant_ordering_user  ALL      
 statement ok
 CREATE USER owner_grant_option_child
 
-statement oko
+statement ok
 GRANT testuser to owner_grant_option_child
 
 user testuser

--- a/pkg/sql/logictest/testdata/logic_test/grant_table
+++ b/pkg/sql/logictest/testdata/logic_test/grant_table
@@ -1611,7 +1611,7 @@ a  public  t  test-user  TRIGGER     false
 a  public  t  test-user  UPDATE      false
 a  public  t  test-user  ZONECONFIG  false
 
-statement ok rowsort
+statement ok
 REVOKE SELECT ON t FROM "test-user"
 
 query TTTTTB rowsort

--- a/pkg/sql/logictest/testdata/logic_test/jobs
+++ b/pkg/sql/logictest/testdata/logic_test/jobs
@@ -2,7 +2,7 @@
 statement ok
 SET CLUSTER SETTING sql.defaults.use_declarative_schema_changer = 'off';
 
-statement ok;
+statement ok
 SET use_declarative_schema_changer = 'off';
 
 # These test verify that a user's job are visible via

--- a/pkg/sql/logictest/testdata/logic_test/mixed_version_bootstrap_tenant
+++ b/pkg/sql/logictest/testdata/logic_test/mixed_version_bootstrap_tenant
@@ -7,8 +7,10 @@ SELECT crdb_internal.create_tenant(1000)
 upgrade 0
 
 # Create tenant using new binary.
-statement ok nodeidx=0
+query I nodeidx=0
 SELECT crdb_internal.create_tenant(1001)
+----
+1001
 
 upgrade 1
 

--- a/pkg/sql/logictest/testdata/logic_test/new_schema_changer
+++ b/pkg/sql/logictest/testdata/logic_test/new_schema_changer
@@ -553,7 +553,7 @@ CREATE TABLE defaultdb.ttyp (id INT PRIMARY KEY, name varchar(256), x defaultdb.
 statement ok
 BEGIN TRANSACTION ISOLATION LEVEL SERIALIZABLE;
 
-statement ok;
+statement ok
 DROP TABLE defaultdb.ttyp;
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/numeric_references
+++ b/pkg/sql/logictest/testdata/logic_test/numeric_references
@@ -128,10 +128,10 @@ col1  col2  col3
 2     20    200
 3     30    300
 
-statement OK
+statement ok
 UPSERT INTO [$num_ref_id AS num_ref_alias] VALUES (4, 40, 400)
 
-statement OK
+statement ok
 INSERT INTO [$num_ref_id(1) AS num_ref_alias] VALUES (5)
 
 query III rowsort
@@ -143,7 +143,7 @@ SELECT * FROM [$num_ref_id as num_ref_alias]
 4     40    400
 5     NULL  NULL
 
-statement OK
+statement ok
 DELETE FROM [$num_ref_id AS num_ref_alias]@bc WHERE p=5
 
 query I
@@ -158,7 +158,7 @@ SELECT * FROM [$num_ref_id AS num_ref_alias]
 2     20    200
 3     30    300
 
-statement OK
+statement ok
 INSERT INTO [$num_ref_id AS num_ref_alias] (p, c) VALUES (4, 400)
 
 query I

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -4706,7 +4706,7 @@ testuser2  false        true           true        true         3022-01-01 00:00
 
 # Testing users that have admin role
 
-statement ok;
+statement ok
 CREATE USER super_user;
 GRANT admin TO super_user;
 CREATE USER regular_user;

--- a/pkg/sql/logictest/testdata/logic_test/plpgsql_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/plpgsql_builtins
@@ -42,7 +42,7 @@ SELECT crdb_internal.plpgsql_gen_cursor_name(NULL);
 ----
 <unnamed portal 6>
 
-statement ok;
+statement ok
 ABORT;
 
 # Continue incrementing over transaction boundaries.

--- a/pkg/sql/logictest/testdata/logic_test/rename_sequence
+++ b/pkg/sql/logictest/testdata/logic_test/rename_sequence
@@ -18,7 +18,7 @@ DROP SEQUENCE renamed_again_alter_test
 
 # You can't rename a sequence with ALTER TABLE or ALTER VIEW.
 
-statement OK
+statement ok
 CREATE SEQUENCE foo
 
 statement error pgcode 42809 "foo" is not a table

--- a/pkg/sql/logictest/testdata/logic_test/run_control
+++ b/pkg/sql/logictest/testdata/logic_test/run_control
@@ -13,10 +13,10 @@ CANCEL JOBS VALUES (1,2)
 query error pq: CANCEL JOBS data column 1 \(job_id\) must be of type int, not type oid
 CANCEL JOB 1::OID
 
-statement ok count 0
+statement ok
 PAUSE JOB (SELECT id FROM system.jobs LIMIT 0)
 
-statement ok count 0
+statement ok
 PAUSE JOBS SELECT id FROM system.jobs LIMIT 0
 
 query error could not parse "foo" as type int
@@ -37,10 +37,10 @@ RESUME JOBS SELECT 'foo'
 query error too many columns in RESUME JOBS data
 RESUME JOBS VALUES (1,2)
 
-statement ok count 0
+statement ok
 RESUME JOB (SELECT id FROM system.jobs LIMIT 0)
 
-statement ok count 0
+statement ok
 RESUME JOBS SELECT id FROM system.jobs LIMIT 0
 
 query error job with ID 1 does not exist
@@ -49,10 +49,10 @@ CANCEL JOB 1
 query error could not parse "foo" as type int
 CANCEL JOB 'foo'
 
-statement ok count 0
+statement ok
 CANCEL JOB (SELECT id FROM system.jobs LIMIT 0)
 
-statement ok count 0
+statement ok
 CANCEL JOBS SELECT id FROM system.jobs LIMIT 0
 
 query error CANCEL QUERIES data column 1 \(query_id\) must be of type string, not type int
@@ -85,10 +85,10 @@ CANCEL SESSION '14d2355b9cccbca50000000000000001'
 statement ok
 CANCEL SESSION IF EXISTS '14d2355b9cccbca50000000000000001'
 
-statement ok count 0
+statement ok
 CANCEL SESSION (SELECT 'a' LIMIT 0)
 
-statement ok count 0
+statement ok
 CANCEL SESSIONS SELECT 'a' LIMIT 0
 
 # Regression test for #25842

--- a/pkg/sql/logictest/testdata/logic_test/schema
+++ b/pkg/sql/logictest/testdata/logic_test/schema
@@ -773,16 +773,16 @@ subtest show_tables
 statement ok
 CREATE DATABASE for_show;
 
-statement ok;
+statement ok
 USE for_show;
 
-statement ok;
+statement ok
 CREATE TABLE t1 (i INT PRIMARY KEY);
 
-statement ok;
+statement ok
 CREATE SCHEMA sc1;
 
-statement ok;
+statement ok
 CREATE TABLE sc1.t1 (i INT PRIMARY KEY);
 
 query TT rowsort

--- a/pkg/sql/logictest/testdata/logic_test/serializable_eager_restart
+++ b/pkg/sql/logictest/testdata/logic_test/serializable_eager_restart
@@ -48,7 +48,7 @@ statement error pgcode 40001 retry txn.*
 RELEASE SAVEPOINT cockroach_restart
 
 #ROLLBACK TO SAVEPOINT
-statement OK
+statement ok
 ROLLBACK TO SAVEPOINT cockroach_restart
 
 # Check that the connection is usable after the failed COMMIT.

--- a/pkg/sql/logictest/testdata/logic_test/statement_statistics
+++ b/pkg/sql/logictest/testdata/logic_test/statement_statistics
@@ -285,7 +285,7 @@ SELECT * FROM txn_fingerprint_view
 ----
 7184384531886178123  {10543509969653713419,5745311157220589902,5153809228704478461}  1
 
-statement OK
+statement ok
 COMMIT
 
 # Change the limit for unique fingerprint.

--- a/pkg/sql/logictest/testdata/logic_test/union
+++ b/pkg/sql/logictest/testdata/logic_test/union
@@ -122,7 +122,7 @@ CREATE TABLE uniontest (
   v INT
 )
 
-statement OK
+statement ok
 INSERT INTO uniontest VALUES
 (1, 1),
 (1, 1),

--- a/pkg/sql/logictest/testdata/logic_test/vectorize_agg
+++ b/pkg/sql/logictest/testdata/logic_test/vectorize_agg
@@ -10,7 +10,7 @@ query BB
 SELECT bool_and(b), bool_or(b) FROM bools GROUP BY a
 ----
 
-statement OK
+statement ok
 INSERT INTO bools VALUES
 (0, NULL),
 (1, true),  (1, true),

--- a/pkg/sql/logictest/testdata/logic_test/views
+++ b/pkg/sql/logictest/testdata/logic_test/views
@@ -1181,7 +1181,7 @@ CREATE TABLE tval (val int primary key);
 statement ok
 CREATE VIEW rv as select val from tval;
 
-statement ok;
+statement ok
 USE DB2;
 
 # Cross-database type references are not allowed.

--- a/pkg/sql/logictest/testdata/logic_test/window
+++ b/pkg/sql/logictest/testdata/logic_test/window
@@ -16,7 +16,7 @@ CREATE TABLE kv (
   FAMILY (s)
 )
 
-statement OK
+statement ok
 INSERT INTO kv VALUES
 (1, 2, 3, 1.0, 1, 'a', true, '1min'),
 (3, 4, 5, 2, 8, 'a', true, '2sec'),
@@ -651,7 +651,7 @@ SELECT avg(k) OVER w, avg(k) OVER w + 1 FROM kv WINDOW w AS (PARTITION BY v ORDE
 7.0000000000000000000  8.0000000000000000000
 8.0000000000000000000  9.0000000000000000000
 
-statement OK
+statement ok
 INSERT INTO kv VALUES
 (9, 2, 9, .1, DEFAULT, DEFAULT, DEFAULT),
 (10, 4, 9, .2, DEFAULT, DEFAULT, DEFAULT),
@@ -3647,14 +3647,14 @@ SELECT *, avg(w) OVER (PARTITION BY w, z ORDER BY y) FROM wxyz ORDER BY z, w, y 
 2  10  2  0  2.0000000000000000000
 4  10  2  0  4.0000000000000000000
 
-statement OK
+statement ok
 CREATE TABLE string_agg_test (
   id INT PRIMARY KEY,
   company_id INT,
   employee STRING
 )
 
-statement OK
+statement ok
 INSERT INTO string_agg_test VALUES
   (1, 1, 'A'),
   (2, 2, 'B'),
@@ -3943,7 +3943,7 @@ OVER (PARTITION BY company_id)
 FROM string_agg_test
 ORDER BY company_id, id;
 
-statement OK
+statement ok
 DROP TABLE string_agg_test
 
 # Test that windower respects the memory limit set via the session variable.

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_misc
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_misc
@@ -349,10 +349,10 @@ CREATE TABLE IF NOT EXISTS t98373 AS
         FROM
                 generate_series(1, 5) AS g;
 
-statement OK
+statement ok
 SET vectorize = off
 
-statement OK
+statement ok
 SET distsql = always
 
 # These query plans should be disallowed from executing in a distributed
@@ -392,8 +392,8 @@ vectorized: false
 ·
 Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJyMkF9r2zAUxd_3KcR5akFh9sq2TE8tSTYMaZLZfhgUEzTr1hOVJU-S6Urwdx-20_1jg90HiftH5_6OTghfDQQ2nw7bm2zHLtZZURYft5es2Gw3q5J5ajrv6oujtvGVENmuXF4KkW8-HPL9it0UrHZm-eY1e5_vb1l8t7x6e3V9l1TgsE7RTrYUIO6QouIYhSgE58fSaRrI1DeIhEPbro9jueKonSeIE6KOhiBQys-GcpKK_MsEHIqi1GaSPS-cr2P3QE_gWDnTtzYINjGDo-jkmC7AkZNV5MUPW9fp2ROqgcP18SdGiLIhiPQX7mwNkQz8_9FzCp2zgX6j_tem5I9Ni3SoOEg1NP9XcL2v6eBdPc3O6X4SmgqKQpy76Zxk9rkVoifZzvgVx71xj0etIJCcY_GX4zkwPpBNGI0VX9zjJFs-dSPWvTSBOG7lA60pkm-11SHqGiL6nobhxfcAAAD__wgUvrk=
 
-statement OK
+statement ok
 RESET vectorize
 
-statement OK
+statement ok
 RESET distsql

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_tenant_locality
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_tenant_locality
@@ -14,7 +14,8 @@ CREATE TABLE t (k INT PRIMARY KEY, v INT, FAMILY (k, v))
 
 # Upreplicate the table's range. We need a retry to guarantee that the
 # capability has been picked up.
-statement ok retry
+retry
+statement ok
 ALTER TABLE t EXPERIMENTAL_RELOCATE VALUES (ARRAY[1, 2, 3], 0)
 
 # Split the ranges in the table.

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -706,13 +706,13 @@ vectorized: true
             └── • virtual table
                   table: pg_namespace@primary
 
-statement OK
+statement ok
 ANALYZE system.users
 
-statement OK
+statement ok
 ANALYZE system.role_options
 
-statement OK
+statement ok
 ANALYZE system.role_members
 
 query T retry

--- a/pkg/sql/opt/exec/execbuilder/testdata/window
+++ b/pkg/sql/opt/exec/execbuilder/testdata/window
@@ -14,7 +14,7 @@ CREATE TABLE kv (
   FAMILY (s)
 )
 
-statement OK
+statement ok
 INSERT INTO kv VALUES
 (1, 2, 3, 1.0, 1, 'a', true),
 (3, 4, 5, 2, 8, 'a', true),


### PR DESCRIPTION
This commit improves how we handle the `statement` command in the logic test framework. In particular, unlike `query` command, the `statement` does not support many options, and it would previously silently ignore them. I just spent a while trying to understand why `statement ok nodeidx=...` didn't trigger the error I expected it to, so this commit would prevent someone from hitting this issue. (The resolution is that we need to use `query` command which has many supported options.) Relatedly, `retry` option needs to be on a separate line when applied to the `statement` command. A few cases like that are now fixed.

Additionally, we now adhere to the comment on `statement async` variation which specifies (in the doc comment) that it supports flavors like:
- `statement async <name> notice <regexp>`
- `statement async <name> error <regexp>`.

This is achieved by handling the `async` variant earlier (although this isn't used anywhere in the moment).

Epic: None
Release note: None