### PR TITLE
lease: unredact lease struct

### DIFF
--- a/pkg/sql/catalog/lease/lease.go
+++ b/pkg/sql/catalog/lease/lease.go
@@ -1877,7 +1877,7 @@ SELECT COALESCE(l."descID", s."desc_id") as "descID", COALESCE(l.version, s.vers
 			// Early exit?
 			row := rows[i]
 			wg.Add(1)
-			lease := storedLease{
+			lease := &storedLease{
 				id:      descpb.ID(tree.MustBeDInt(row[0])),
 				version: int(tree.MustBeDInt(row[1])),
 			}
@@ -1906,7 +1906,7 @@ SELECT COALESCE(l."descID", s."desc_id") as "descID", COALESCE(l.version, s.vers
 					WaitForSem: true,
 				},
 				func(ctx context.Context) {
-					m.storage.release(ctx, m.stopper, &lease)
+					m.storage.release(ctx, m.stopper, lease)
 					log.Infof(ctx, "released orphaned lease: %+v", lease)
 					wg.Done()
 				}); err != nil {


### PR DESCRIPTION
Previously, ID from lease was getting redacted in logs. This was creating challenge to support team to debug issues. This change makes sure that SafeFormat is getting invoked during logging.

Epic: CRDB-37533
Part of: CRDB-44885
Release note: None