### PR TITLE
drtprod: enhance flags field to support any data type in yaml

### DIFF
--- a/pkg/cmd/drtprod/cli/commands/BUILD.bazel
+++ b/pkg/cmd/drtprod/cli/commands/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
         "//pkg/cmd/drtprod/helpers",
         "@com_github_spf13_cobra//:cobra",
         "@in_gopkg_yaml_v2//:yaml_v2",
+        "@org_golang_x_exp//maps",
     ],
 )
 

--- a/pkg/cmd/drtprod/configs/drt_multi_cloud.yaml
+++ b/pkg/cmd/drtprod/configs/drt_multi_cloud.yaml
@@ -1,25 +1,14 @@
-# Yaml for creating and configuring the drt-large and workload-large clusters. This also configures the datadog.
+# Yaml for creating and configuring the drt-multi-cloud and workload-multi-cloud clusters. This also configures the datadog.
 environment:
   ROACHPROD_GCE_DEFAULT_SERVICE_ACCOUNT: 622274581499-compute@developer.gserviceaccount.com
   ROACHPROD_DNS: drt.crdb.io
   ROACHPROD_GCE_DNS_DOMAIN: drt.crdb.io
   ROACHPROD_GCE_DNS_ZONE: drt
   ROACHPROD_GCE_DEFAULT_PROJECT: cockroach-drt
-  CLUSTER: drt-large
-  WORKLOAD_CLUSTER: workload-large
-  STORE_COUNT: 8
-
-  # variables used by tpcc_run_multiregion.sh
-  NUM_REGIONS: 3
-  NODES_PER_REGION: 5
-  REGIONS: northamerica-northeast2,us-east5,us-east1
-  TPCC_WAREHOUSES: 150000
-  DB_NAME: cct_tpcc
-  SURVIVAL_GOAL: region
-  RUN_DURATION: 12h
-  NUM_CONNECTIONS: 500
-  NUM_WORKERS: 500
-  MAX_RATE: 1000
+  CLUSTER: drt-multi-cloud
+  CLUSTER_NODES: 6
+  WORKLOAD_CLUSTER: workload-multi-cloud
+  WORKLOAD_NODES: 1
 
 targets:
   - target_name: $CLUSTER
@@ -28,30 +17,42 @@ targets:
         args:
           - $CLUSTER
         flags:
-          clouds: gce
-          gce-managed: true
-          gce-use-spot: true
-          gce-enable-multiple-stores: true
-          gce-zones: "northamerica-northeast2-a:2,northamerica-northeast2-b:2,northamerica-northeast2-c:1,us-east5-a:2,us-east5-b:2,us-east5-c:1,us-east1-b:2,us-east1-c:2,us-east1-d:1"
-          nodes: 15
-          gce-machine-type: n2-standard-16
-          local-ssd: true
-          gce-local-ssd-count: $STORE_COUNT
-          os-volume-size: 100
+          clouds: gce,aws
+          nodes: $CLUSTER_NODES
+          local-ssd: false
           username: drt
           lifetime: 8760h
+          # gcp flags
+          gce-enable-multiple-stores: true
+          gce-zones: "us-east4-a,us-east4-b,us-east4-c"
+          gce-machine-type: n2-standard-8
+          gce-pd-volume-size: 375
+          gce-pd-volume-type: pd-ssd
+          gce-pd-volume-count: 4
+          gce-image: "ubuntu-2204-jammy-v20240319"
+          # aws flags
+          aws-machine-type: m6i.2xlarge
+          aws-enable-multiple-stores: true
+          # if this flag is not provided a empty string, a default ebs volume of size 500GB is created
+          aws-ebs-volume-type: ""
+          aws-zones: "us-east-1a,us-east-1b,us-east-1c"
+          aws-ebs-volume:
+            - >-
+              {"VolumeType":"gp3","VolumeSize":375}
+            - >-
+              {"VolumeType":"gp3","VolumeSize":375}
+            - >-
+              {"VolumeType":"gp3","VolumeSize":375}
+            - >-
+              {"VolumeType":"gp3","VolumeSize":375}
         on_rollback:
           - command: destroy
             args:
               - $CLUSTER
-      - command: sync
-        flags:
-          clouds: gce
       - command: stage
         args:
           - $CLUSTER
           - cockroach
-      - script: "pkg/cmd/drtprod/scripts/setup_dmsetup_disk_staller"
       - script: "pkg/cmd/drtprod/scripts/setup_datadog_cluster"
       - command: start
         args:
@@ -60,7 +61,7 @@ targets:
           - "./cockroach"
         flags:
           enable-fluent-sink: true
-          store-count: $STORE_COUNT
+          store-count: 4
           args: --wal-failover=among-stores
           restart: false
           sql-port: 26257
@@ -73,25 +74,6 @@ targets:
           - $CLUSTER
           - --
           - "sudo systemctl unmask cron.service ; sudo systemctl enable cron.service ; echo \"crontab -l ; echo '@reboot sleep 100 && ~/cockroach.sh' | crontab -\" > t.sh ; sh t.sh ; rm t.sh"
-      - command: sql
-        args:
-          - $CLUSTER:1
-          - --
-          - -e
-          - "ALTER RANGE timeseries CONFIGURE ZONE USING num_replicas=5,num_voters=5"
-      - command: sql
-        args:
-          - $CLUSTER:1
-          - --
-          - -e
-          - "ALTER RANGE default CONFIGURE ZONE USING num_replicas=5,num_voters=5"
-      - command: sql
-        args:
-          - $CLUSTER:1
-          - --
-          - -e
-          - "SET CLUSTER SETTING kv.snapshot_rebalance.max_rate='256 MB'"
-      - script: "pkg/cmd/drtprod/scripts/create_decommission_node.sh"
   - target_name: $WORKLOAD_CLUSTER
     steps:
       - command: create
@@ -99,9 +81,9 @@ targets:
           - $WORKLOAD_CLUSTER
         flags:
           clouds: gce
-          gce-zones: "northamerica-northeast2-a,us-east5-a,us-east1-b"
-          nodes: $NUM_REGIONS
-          gce-machine-type: n2d-standard-4
+          gce-zones: "us-east4-a"
+          nodes: $WORKLOAD_NODES
+          gce-machine-type: n2-standard-2
           os-volume-size: 100
           username: workload
           lifetime: 8760h
@@ -109,9 +91,6 @@ targets:
           - command: destroy
             args:
               - $WORKLOAD_CLUSTER
-      - command: sync
-        flags:
-          clouds: gce
       - command: stage
         args:
           - $WORKLOAD_CLUSTER
@@ -123,8 +102,8 @@ targets:
       - script: "pkg/cmd/drtprod/scripts/setup_datadog_workload"
   - target_name: post_tasks
     dependent_targets:
-      - $CLUSTER
       - $WORKLOAD_CLUSTER
+      - $CLUSTER
     steps:
       - script: rm
         args:
@@ -148,6 +127,11 @@ targets:
           - $WORKLOAD_CLUSTER
           - certs-$CLUSTER
           - certs
+      - command: put
+        args:
+          - $WORKLOAD_CLUSTER
+          - artifacts/roachprod
+          - roachprod
       - command: ssh
         args:
           - $WORKLOAD_CLUSTER
@@ -158,11 +142,20 @@ targets:
       - script: "pkg/cmd/drtprod/scripts/tpcc_init.sh"
         args:
           - cct_tpcc # suffix added to script name tpcc_init_cct_tpcc.sh
-          - true # determines whether to execute the script immediately on workload node
+          - false # determines whether to execute the script immediately on workload node
         flags:
-          warehouses: $TPCC_WAREHOUSES
-          partitions: $NUM_REGIONS
-          db: $DB_NAME
-          survival-goal: $SURVIVAL_GOAL
-          regions: $REGIONS
-      - script: "pkg/cmd/drtprod/scripts/tpcc_run_multiregion.sh"
+          warehouses: 12000
+          db: cct_tpcc
+      - script: "pkg/cmd/drtprod/scripts/generate_tpcc_run.sh"
+        args:
+          - cct_tpcc # suffix added to script name tpcc_run.sh
+          - false # determines whether to execute the script immediately on workload node
+        flags:
+          db: cct_tpcc
+          warehouses: 12000
+          max-rate: 500
+          workers: 50
+          conns: 50
+          duration: 12h
+          ramp: 10m
+          wait: 0

--- a/pkg/cmd/drtprod/scripts/setup_datadog_cluster
+++ b/pkg/cmd/drtprod/scripts/setup_datadog_cluster
@@ -36,7 +36,7 @@ pipeline:
    apikey: ${dd_api_key}
    dd_source: audit
    dd_service: drt-cockroachdb
-   dd_tags: env:development,cluster:${cluster%:*},service:drt-cockroachdb,team:drt
+   dd_tags: env:development,cluster:${CLUSTER%:*},service:drt-cockroachdb,team:drt
    alias: audit
    storage.total_limit_size: 25MB
 EOF"

--- a/pkg/cmd/drtprod/scripts/tpcc_init.sh
+++ b/pkg/cmd/drtprod/scripts/tpcc_init.sh
@@ -48,6 +48,11 @@ ${pwd}/cockroach workload fixtures import tpcc $PGURLS $@ --checks=false
 EOF"
 drtprod ssh "${WORKLOAD_CLUSTER}":1 -- "chmod +x tpcc_init_${suffix}.sh"
 
+WARNING="DISABLE VALIDATION CONSTRAINT CHECK BEFORE RUNNING IMPORT. TO DISABLE SET THIS CLUSTER SETTING:
+SET CLUSTER SETTING bulkio.import.constraint_validation.unsafe.enabled=false;"
+# Print the warning message in capital bold letters and highlighted in red
+echo -e "\033[1;31m$WARNING\033[0m"
+
 if [ "$execute_script" = "true" ]; then
   drtprod run "${WORKLOAD_CLUSTER}":1 -- "sudo systemd-run --unit tpcc_init_${suffix} --same-dir --uid \$(id -u) --gid \$(id -g) bash ${pwd}/tpcc_init_${suffix}.sh"
 else


### PR DESCRIPTION
Previously, the `flags` field in the YAML configuration for `drtprod` only supported string values. This commit enhances the `flags` field to support any data type (e.g. string, bool, list), providing greater flexibility in defining cluster configurations.

This PR also adds:
- YAML for multi cloud cluster deployment.
- Changes in drt_large.yaml and tppc_init script.

Epic: none

Release note: None