### PR TITLE
roachtest: improve artifacts' tsdump-run.sh

### DIFF
--- a/pkg/cmd/roachtest/BUILD.bazel
+++ b/pkg/cmd/roachtest/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "work_pool.go",
         "zip_util.go",
     ],
+    embedsrcs = ["tsdump-run.sh"],
     importpath = "github.com/cockroachdb/cockroach/pkg/cmd/roachtest",
     visibility = ["//visibility:private"],
     deps = [

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -9,6 +9,7 @@ import (
 	"bytes"
 	"context"
 	gosql "database/sql"
+	_ "embed"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -57,6 +58,9 @@ import (
 func init() {
 	_ = roachprod.InitProviders()
 }
+
+//go:embed tsdump-run.sh
+var tsdumpRunSh string
 
 var (
 	// maps cpuArch to the corresponding crdb binary's absolute path
@@ -1358,10 +1362,7 @@ func (c *clusterImpl) FetchTimeseriesData(ctx context.Context, l *logger.Logger)
 		if err := os.WriteFile(tsDumpGob+".yaml", buf.Bytes(), 0644); err != nil {
 			return err
 		}
-		return os.WriteFile(tsDumpGob+"-run.sh", []byte(`#!/usr/bin/env bash
-
-COCKROACH_DEBUG_TS_IMPORT_FILE=tsdump.gob cockroach start-single-node --insecure $*
-`), 0755)
+		return os.WriteFile(tsDumpGob+"-run.sh", []byte(tsdumpRunSh), 0755)
 	})
 }
 

--- a/pkg/cmd/roachtest/tsdump-run.sh
+++ b/pkg/cmd/roachtest/tsdump-run.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+
+# Copyright 2016 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+set -euo pipefail
+
+c=local-tsdump
+
+if [ $# -eq 0 ]; then
+  cat <<EOF
+Host tsdump on local cluster $c.
+Usage:
+
+$0 /path/to/cockroach  # use local cockroach binary
+$0 release vNN.YY.ZZ   # download specified release
+$0 cockroach [SHA]     # download specified master SHA
+EOF
+  exit 1
+fi
+
+roachprod destroy local-tsdump &> /dev/null || true
+roachprod create -n 1 $c
+
+if [ -f "$1" ]; then
+  roachprod put $c "$1" ./cockroach
+else
+  roachprod stage $c "$@"
+fi
+
+roachprod start --insecure --env COCKROACH_DEBUG_TS_IMPORT_FILE="${PWD}/tsdump.gob" $c
+
+roachprod adminurl --insecure $c:1
+
+trap "roachprod destroy $c" EXIT
+echo "Running; hit CTRL-C to destroy the cluster"
+while true; do sleep 86400; done


### PR DESCRIPTION
Use a local cluster and avoid the need for any manual setup, while also allowing user to specify the version to host the tsdump with.

Epic: none
Release note: None