### PR TITLE
sql/externalcatalog: allow ExtractInternalCatalog to include offline tables

### DIFF
--- a/pkg/crosscluster/producer/replication_manager.go
+++ b/pkg/crosscluster/producer/replication_manager.go
@@ -83,7 +83,7 @@ func (r *replicationStreamManagerImpl) StartReplicationStreamForTables(
 	mutableTableDescs := make([]*tabledesc.Mutable, 0, len(req.TableNames))
 	tableIDs := make([]uint32, 0, len(req.TableNames))
 
-	externalCatalog, err := externalcatalog.ExtractExternalCatalog(ctx, r.resolver, r.txn, r.txn.Descriptors(), req.TableNames...)
+	externalCatalog, err := externalcatalog.ExtractExternalCatalog(ctx, r.resolver, r.txn, r.txn.Descriptors(), false /* includeOffline */, req.TableNames...)
 	if err != nil {
 		return streampb.ReplicationProducerSpec{}, err
 	}

--- a/pkg/sql/catalog/externalcatalog/external_catalog_test.go
+++ b/pkg/sql/catalog/externalcatalog/external_catalog_test.go
@@ -73,7 +73,7 @@ func TestExtractIngestExternalCatalog(t *testing.T) {
 			)
 			defer close()
 
-			catalog, err = ExtractExternalCatalog(ctx, planner.(resolver.SchemaResolver), txn, col, tableNames...)
+			catalog, err = ExtractExternalCatalog(ctx, planner.(resolver.SchemaResolver), txn, col, false, tableNames...)
 			return err
 		})
 		return catalog, err


### PR DESCRIPTION
This patch is required for #138297, where an LDR stream is created from a source that is offline. The subsequent PR will add test coverage to this.

Epic: none

Release note: none