### PR TITLE
release-24.2: codeowners: Add field-engineering team

### DIFF
--- a/TEAMS.yaml
+++ b/TEAMS.yaml
@@ -114,3 +114,6 @@ cockroachdb/release-eng:
     cockroachdb/upgrade-prs: other
   label: T-release
   triage_column_id: 9149730
+cockroachdb/field-engineering:
+  # Field Eng isn't currently using github projects.
+  label: T-field-eng

--- a/pkg/cmd/roachtest/registry/owners.go
+++ b/pkg/cmd/roachtest/registry/owners.go
@@ -33,6 +33,7 @@ const (
 	OwnerStorage          Owner = `storage`
 	OwnerTestEng          Owner = `test-eng`
 	OwnerDevInf           Owner = `dev-inf`
+	OwnerFieldEng         Owner = `field-engineering`
 )
 
 // IsValid returns true if the owner is valid, i.e. it has a corresponding team

--- a/pkg/internal/team/TEAMS.yaml
+++ b/pkg/internal/team/TEAMS.yaml
@@ -114,3 +114,6 @@ cockroachdb/release-eng:
     cockroachdb/upgrade-prs: other
   label: T-release
   triage_column_id: 9149730
+cockroachdb/field-engineering:
+  # Field Eng isn't currently using github projects.
+  label: T-field-eng


### PR DESCRIPTION
Backport 1/1 commits from #138241.

/cc @cockroachdb/release

---

Adding field engineering in preparation of owning the code we are contributing.

Epic: none

Release note: None

Release justification: required for backporting https://github.com/cockroachdb/cockroach/pull/138172
