### PR TITLE
roachprod: retry hostname validation on different nodes

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -1387,7 +1387,7 @@ func (c *clusterImpl) FetchDebugZip(
 	nodes := selectedNodesOrDefault(opts, c.All())
 
 	// Don't hang forever if we can't fetch the debug zip.
-	return timeutil.RunWithTimeout(ctx, "debug zip", 5*time.Minute, func(ctx context.Context) error {
+	return timeutil.RunWithTimeout(ctx, "debug zip", 10*time.Minute, func(ctx context.Context) error {
 		const zipName = "debug.zip"
 		path := filepath.Join(c.t.ArtifactsDir(), dest)
 		if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {

--- a/pkg/roachprod/install/cluster_synced.go
+++ b/pkg/roachprod/install/cluster_synced.go
@@ -369,16 +369,38 @@ if ! %s; then
 `, isValidHost, errMsg, elseBranch)
 }
 
-// validateHost will run `validateHostnameCmd` on the node passed to
+// validateHost will run `validateHostnameCmd` on the node(s) passed to
 // make sure it still belongs to the SyncedCluster. Returns an error
 // when the hostnames don't match, indicating that the roachprod cache
 // is stale.
-func (c *SyncedCluster) validateHost(ctx context.Context, l *logger.Logger, node Node) error {
+func (c *SyncedCluster) validateHost(ctx context.Context, l *logger.Logger, nodes Nodes) error {
 	if c.IsLocal() {
 		return nil
 	}
-	cmd := c.validateHostnameCmd("", node)
-	return c.Run(ctx, l, l.Stdout, l.Stderr, WithNodes(Nodes{node}), "validate-ssh-host", cmd)
+
+	// Retry on different nodes, in case some of the VMs are unreachable.
+	// While this does indicate something is likely wrong, we don't want to
+	// fail here as some callers want to tolerate this, e.g. fetching logs
+	// after a test failure shouldn't fail just because one VM is down.
+	var combinedErr error
+	retryOpts := *DefaultRetryOpt
+	retryOpts.MaxRetries = 4
+	r := retry.StartWithCtx(ctx, retryOpts)
+	for nodeIdx := 0; r.Next(); nodeIdx = (nodeIdx + 1) % len(nodes) {
+		node := nodes[nodeIdx]
+		cmd := c.validateHostnameCmd("", node)
+
+		err := c.Run(ctx, l, l.Stdout, l.Stderr, WithNodes(Nodes{node}).WithRetryDisabled(), "validate-ssh-host", cmd)
+		if err != nil {
+			if !rperrors.IsTransient(err) {
+				return err
+			}
+			combinedErr = errors.CombineErrors(combinedErr, err)
+			continue
+		}
+		return nil
+	}
+	return combinedErr
 }
 
 // cmdDebugName is the suffix of the generated ssh debug file
@@ -1641,7 +1663,7 @@ func (c *SyncedCluster) PutString(
 func (c *SyncedCluster) Put(
 	ctx context.Context, l *logger.Logger, nodes Nodes, src string, dest string,
 ) error {
-	if err := c.validateHost(ctx, l, nodes[0]); err != nil {
+	if err := c.validateHost(ctx, l, nodes); err != nil {
 		return err
 	}
 	// Check if source file exists and if it's a symlink.
@@ -1885,7 +1907,7 @@ func (c *SyncedCluster) Logs(
 	from, to time.Time,
 	out io.Writer,
 ) error {
-	if err := c.validateHost(context.TODO(), l, c.Nodes[0]); err != nil {
+	if err := c.validateHost(context.TODO(), l, c.Nodes); err != nil {
 		return err
 	}
 	rsyncNodeLogs := func(ctx context.Context, node Node) error {
@@ -2013,7 +2035,7 @@ func (c *SyncedCluster) Logs(
 func (c *SyncedCluster) Get(
 	ctx context.Context, l *logger.Logger, nodes Nodes, src, dest string,
 ) error {
-	if err := c.validateHost(context.TODO(), l, nodes[0]); err != nil {
+	if err := c.validateHost(ctx, l, nodes); err != nil {
 		return err
 	}
 	// TODO(peter): Only get 10 nodes at a time. When a node completes, output a
@@ -2281,7 +2303,7 @@ func (c *SyncedCluster) loadBalancerURL(
 // exclusively.
 func (c *SyncedCluster) SSH(ctx context.Context, l *logger.Logger, sshArgs, args []string) error {
 	targetNode := c.Nodes[0]
-	if err := c.validateHost(ctx, l, targetNode); err != nil {
+	if err := c.validateHost(ctx, l, Nodes{targetNode}); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Previously hostname validation was only attempted on the first node. If the first node reports a mismatch in names, the entire cluster should mismatch as well.

However, it's possible that the first node fails due to a transient error. In this case, we want to try other nodes as a VM being down does not mean the hostnames are wrong.

This is an important distinction for artifacts collection. If a test failed because the a VM went down, we still want to collect logs from the other nodes.

This change also bumps the timeout for fetching `debug.zip`, as we recently saw it timeout despite the collection making reasonable progress.

Epic: none
Informs: #137880
Release note: none