### PR TITLE
tests: get cdc_bench cursor at least 1s after table creation

### DIFF
--- a/pkg/cmd/roachtest/tests/cdc_bench.go
+++ b/pkg/cmd/roachtest/tests/cdc_bench.go
@@ -274,6 +274,7 @@ func runCDCBenchScan(
 		`./cockroach workload init kv --splits %d {pgurl:%d}`, numRanges, nData[0]))
 	require.NoError(t, roachtestutil.WaitFor3XReplication(ctx, t.L(), conn))
 
+	time.Sleep(1 * time.Second)
 	cursor := timeutil.Now() // before data is ingested
 
 	// Ingest data. init allows us to import into the existing table. However,


### PR DESCRIPTION
Previously, we would get changefeed cursors from the current time after creating a table and before populating it. Due to the time being at a second granularity, it was possible that the cursor could be the same second that the table was created, which would lead to the table not appearing to be created yet.

This change adds a 1s sleep before getting the cursor timestamp, to ensure that we don't encounter this scenario.

Epic: None

Fixes: #137758
Fixes: #135795

Release note: None