### PR TITLE
ccl/changefeedccl: add compression options for webhook sink

### DIFF
--- a/pkg/ccl/changefeedccl/cdctest/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/cdctest/BUILD.bazel
@@ -40,6 +40,7 @@ go_library(
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_klauspost_compress//zstd",
         "@com_github_lib_pq//oid",
         "@com_github_linkedin_goavro_v2//:goavro",
         "@com_github_stretchr_testify//require",

--- a/pkg/ccl/changefeedccl/cdctest/mock_webhook_sink.go
+++ b/pkg/ccl/changefeedccl/cdctest/mock_webhook_sink.go
@@ -6,6 +6,7 @@
 package cdctest
 
 import (
+	"compress/gzip"
 	"crypto/tls"
 	"io"
 	"net/http"
@@ -13,6 +14,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/errors"
+	"github.com/klauspost/compress/zstd"
 )
 
 // MockWebhookSink is the Webhook sink used in tests.
@@ -23,9 +25,11 @@ type MockWebhookSink struct {
 	mu                 struct {
 		syncutil.Mutex
 		numCalls         int
+		responseBodies   map[int][]byte
 		statusCodes      []int
 		statusCodesIndex int
 		rows             []string
+		lastHeaders      http.Header
 		notify           chan struct{}
 	}
 }
@@ -35,6 +39,13 @@ func StartMockWebhookSinkInsecure() (*MockWebhookSink, error) {
 	s := makeMockWebhookSink()
 	s.server.Start()
 	return s, nil
+}
+
+// LastRequestHeaders returns the headers from the most recent request.
+func (s *MockWebhookSink) LastRequestHeaders() http.Header {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.mu.lastHeaders
 }
 
 // StartMockWebhookSink creates and starts a mock webhook sink for tests.
@@ -51,7 +62,7 @@ func StartMockWebhookSink(certificate *tls.Certificate) (*MockWebhookSink, error
 }
 
 // StartMockWebhookSinkSecure creates and starts a mock webhook sink server that
-// requires clients to provide client certificates for authentication
+// requires clients to provide client certificates for authentication.
 func StartMockWebhookSinkSecure(certificate *tls.Certificate) (*MockWebhookSink, error) {
 	s := makeMockWebhookSink()
 	if certificate == nil {
@@ -88,6 +99,7 @@ func StartMockWebhookSinkWithBasicAuth(
 func makeMockWebhookSink() *MockWebhookSink {
 	s := &MockWebhookSink{}
 	s.mu.statusCodes = []int{http.StatusOK}
+	s.mu.responseBodies = make(map[int][]byte)
 	s.server = httptest.NewUnstartedServer(http.HandlerFunc(s.requestHandler))
 	return s
 }
@@ -114,6 +126,26 @@ func (s *MockWebhookSink) SetStatusCodes(statusCodes []int) {
 	s.mu.statusCodesIndex = 0
 }
 
+// SetResponse sets the response body and status code to use when responding to
+// a request. Useful for testing error handling behavior on client side.
+func (s *MockWebhookSink) SetResponse(statusCode int, responseBody []byte) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	numOfStatusCodes := len(s.mu.statusCodes)
+	s.mu.statusCodes = append(s.mu.statusCodes, statusCode)
+	s.mu.responseBodies[numOfStatusCodes] = responseBody
+}
+
+// ClearResponses resets status codes to empty list,
+// removes predefined response bodies and resets the index.
+func (s *MockWebhookSink) ClearResponses() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.mu.statusCodes = []int{}
+	s.mu.responseBodies = map[int][]byte{}
+	s.mu.statusCodesIndex = 0
+}
+
 // Close closes the mock Webhook sink.
 func (s *MockWebhookSink) Close() {
 	s.server.Close()
@@ -131,7 +163,7 @@ func (s *MockWebhookSink) Latest() string {
 	return latest
 }
 
-// Pop deletes and returns the oldest message from MockWebhookSink
+// Pop deletes and returns the oldest message from MockWebhookSink.
 func (s *MockWebhookSink) Pop() string {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -181,22 +213,104 @@ func (s *MockWebhookSink) requestHandler(hw http.ResponseWriter, hr *http.Reques
 
 func (s *MockWebhookSink) publish(hw http.ResponseWriter, hr *http.Request) error {
 	defer hr.Body.Close()
-	row, err := io.ReadAll(hr.Body)
-	if err != nil {
-		return err
-	}
+
 	s.mu.Lock()
-	defer s.mu.Unlock()
+	s.mu.lastHeaders = hr.Header.Clone()
 	s.mu.numCalls++
-	if s.mu.statusCodes[s.mu.statusCodesIndex] >= http.StatusOK && s.mu.statusCodes[s.mu.statusCodesIndex] < http.StatusMultipleChoices {
-		s.mu.rows = append(s.mu.rows, string(row))
-		if s.mu.notify != nil {
-			close(s.mu.notify)
-			s.mu.notify = nil
+	statusCode := s.mu.statusCodes[s.mu.statusCodesIndex]
+	resBody, hasResBody := s.mu.responseBodies[s.mu.statusCodesIndex]
+	s.mu.statusCodesIndex = (s.mu.statusCodesIndex + 1) % len(s.mu.statusCodes)
+	s.mu.Unlock()
+
+	compression := hr.Header.Get("Content-Encoding")
+
+	if statusCode < http.StatusOK || statusCode >= http.StatusMultipleChoices {
+		if !hasResBody {
+			hw.WriteHeader(statusCode)
+			return nil
+		}
+
+		switch compression {
+		case "gzip":
+			hw.Header().Set("Content-Encoding", "gzip")
+			gw := gzip.NewWriter(hw)
+			hw.WriteHeader(statusCode)
+			if _, err := gw.Write(resBody); err != nil {
+				return errors.Wrap(err, "failed to write response body")
+			}
+			if err := gw.Close(); err != nil {
+				return errors.Wrap(err, "failed to flush gzip writer")
+			}
+			return nil
+		case "zstd":
+			hw.Header().Set("Content-Encoding", "zstd")
+			zw, err := zstd.NewWriter(hw)
+			if err != nil {
+				return errors.Wrap(err, "failed to create zstd encoder")
+			}
+			hw.WriteHeader(statusCode)
+			if _, err := zw.Write(resBody); err != nil {
+				return errors.Wrap(err, "failed to write response body")
+			}
+			if err := zw.Close(); err != nil {
+				return errors.Wrap(err, "failed to flush zstd writer")
+			}
+			return nil
+		}
+
+		hw.WriteHeader(statusCode)
+		if _, err := hw.Write(resBody); err != nil {
+			return errors.Wrap(err, "failed to write response body")
+		}
+		return nil
+	}
+
+	var row []byte
+	switch compression {
+	case "gzip":
+		gzReader, err := gzip.NewReader(hr.Body)
+		if err != nil {
+			return errors.Wrap(err, "failed to create gzip reader")
+		}
+		row, err = io.ReadAll(gzReader)
+		if err != nil {
+			return errors.Wrap(err, "failed to read compressed request body")
+		}
+		if err = gzReader.Close(); err != nil {
+			return errors.Wrap(err, "failed to close gzip reader")
+		}
+	case "zstd":
+		zstdReader, err := zstd.NewReader(hr.Body)
+		if err != nil {
+			return errors.Wrap(err, "failed to create zstd reader")
+		}
+		row, err = io.ReadAll(zstdReader)
+		if err != nil {
+			return errors.Wrap(err, "failed to read compressed request body")
+		}
+		zstdReader.Close()
+	default:
+		var err error
+		row, err = io.ReadAll(hr.Body)
+		if err != nil {
+			return errors.Wrap(err, "failed to read plain request body")
 		}
 	}
 
-	hw.WriteHeader(s.mu.statusCodes[s.mu.statusCodesIndex])
-	s.mu.statusCodesIndex = (s.mu.statusCodesIndex + 1) % len(s.mu.statusCodes)
+	s.mu.Lock()
+	s.mu.rows = append(s.mu.rows, string(row))
+	if s.mu.notify != nil {
+		close(s.mu.notify)
+		s.mu.notify = nil
+	}
+	s.mu.Unlock()
+
+	hw.WriteHeader(statusCode)
+	if hasResBody {
+		if _, err := hw.Write(resBody); err != nil {
+			return errors.Wrap(err, "failed to write response body")
+		}
+	}
+
 	return nil
 }

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -5976,8 +5976,8 @@ func TestChangefeedErrors(t *testing.T) {
 		`webhook-https://fake-host`,
 	)
 	sqlDB.ExpectErrWithTimeout(
-		t, `this sink is incompatible with option compression`,
-		`CREATE CHANGEFEED FOR foo INTO $1 WITH compression='gzip'`,
+		t, `unknown compression: invalid, valid values are 'gzip' and 'zstd'`,
+		`CREATE CHANGEFEED FOR foo INTO $1 WITH compression='invalid'`,
 		`webhook-https://fake-host`,
 	)
 	sqlDB.ExpectErrWithTimeout(
@@ -6019,6 +6019,12 @@ func TestChangefeedErrors(t *testing.T) {
 	sqlDB.ExpectErrWithTimeout(
 		t, `unknown on_error: not_valid, valid values are 'pause' and 'fail'`,
 		`CREATE CHANGEFEED FOR foo into $1 WITH on_error='not_valid'`,
+		`kafka://nope`)
+
+	// Sanity check for options compatibility validation.
+	sqlDB.ExpectErrWithTimeout(
+		t, `this sink is incompatible with option compression`,
+		`CREATE CHANGEFEED FOR foo into $1 WITH compression='gzip'`,
 		`kafka://nope`)
 
 	sqlDB.ExpectErrWithTimeout(

--- a/pkg/ccl/changefeedccl/changefeedbase/options.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/options.go
@@ -429,7 +429,7 @@ var KafkaValidOptions = makeStringSet(OptAvroSchemaPrefix, OptConfluentSchemaReg
 var CloudStorageValidOptions = makeStringSet(OptCompression)
 
 // WebhookValidOptions is options exclusive to webhook sink
-var WebhookValidOptions = makeStringSet(OptWebhookAuthHeader, OptWebhookClientTimeout, OptWebhookSinkConfig)
+var WebhookValidOptions = makeStringSet(OptWebhookAuthHeader, OptWebhookClientTimeout, OptWebhookSinkConfig, OptCompression)
 
 // PubsubValidOptions is options exclusive to pubsub sink
 var PubsubValidOptions = makeStringSet(OptPubsubSinkConfig)
@@ -1004,12 +1004,17 @@ type WebhookSinkOptions struct {
 	JSONConfig    SinkSpecificJSONConfig
 	AuthHeader    string
 	ClientTimeout *time.Duration
+	Compression   string
 }
 
 // GetWebhookSinkOptions includes arbitrary json to be interpreted
 // by the webhook sink.
 func (s StatementOptions) GetWebhookSinkOptions() (WebhookSinkOptions, error) {
-	o := WebhookSinkOptions{JSONConfig: s.getJSONValue(OptWebhookSinkConfig), AuthHeader: s.m[OptWebhookAuthHeader]}
+	o := WebhookSinkOptions{
+		JSONConfig:  s.getJSONValue(OptWebhookSinkConfig),
+		AuthHeader:  s.m[OptWebhookAuthHeader],
+		Compression: s.m[OptCompression],
+	}
 	timeout, err := s.getDurationValue(OptWebhookClientTimeout)
 	if err != nil {
 		return o, err

--- a/pkg/ccl/changefeedccl/compression.go
+++ b/pkg/ccl/changefeedccl/compression.go
@@ -9,6 +9,7 @@ import (
 	stdgzip "compress/gzip"
 	"io"
 	"strings"
+	"sync"
 
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/util/metamorphic"
@@ -26,13 +27,115 @@ var useFastGzip = settings.RegisterBoolSetting(
 	),
 	settings.WithPublic)
 
+// These encoder/decoder pools intentionally omit the `New` field initialization
+// for a few reasons:
+//  1. The creation of encoders/decoders can fail and return errors, which cannot
+//     be handled by sync.Pool's New function (as it doesn't support error returns)
+//  2. The first Get() will return nil, allowing the calling code to handle the
+//     initialization with proper error handling and parameter configuration
+var (
+	gzipEncoderPool     = sync.Pool{}
+	fastGzipEncoderPool = sync.Pool{}
+	zstdEncoderPool     = sync.Pool{}
+	gzipDecoderPool     = sync.Pool{}
+	zstdDecoderPool     = sync.Pool{}
+)
+
 type compressionAlgo string
 
-const sinkCompressionGzip compressionAlgo = "gzip"
-const sinkCompressionZstd compressionAlgo = "zstd"
+const (
+	sinkCompressionGzip compressionAlgo = "gzip"
+	sinkCompressionZstd compressionAlgo = "zstd"
+)
 
 func (a compressionAlgo) enabled() bool {
 	return a != ""
+}
+
+type encoder interface {
+	io.WriteCloser
+	Reset(io.Writer)
+}
+
+type decoder interface {
+	io.ReadCloser
+	Reset(io.Reader) error
+}
+
+// encWrapper wraps an encoder and includes a pointer to the pool it's associated with.
+type encWrapper struct {
+	encoder encoder
+	pool    *sync.Pool
+}
+
+// Close flushes and closes the underlying encoder, resets, and returns it to the pool.
+// This differs from the inner encoder's Close by adding pool management - the encoder
+// is recycled after closing rather than being discarded.
+func (e *encWrapper) Close() error {
+	if e.encoder == nil {
+		return nil
+	}
+	if err := e.encoder.Close(); err != nil {
+		return errors.Wrap(err, "failed to close writer")
+	}
+	e.encoder.Reset(nil)
+	e.pool.Put(e.encoder)
+	e.encoder = nil
+	return nil
+}
+
+func (e *encWrapper) Write(p []byte) (int, error) {
+	if e.encoder == nil {
+		return 0, errors.AssertionFailedf("attempt to write on a closed encoder")
+	}
+	return e.encoder.Write(p)
+}
+
+// decWrapper wraps a decoder with decoders pool.
+type decWrapper struct {
+	decoder decoder
+	pool    *sync.Pool
+}
+
+// Close closes the underlying decoder and returns it to the pool.
+// Note: The decoder is not reset due to a gzip/pgzip issue
+// where nil reader reset causes subsequent reads to hang.
+// The gzip/pgzip nil reset issue was confirmed while testing.
+func (d *decWrapper) Close() error {
+	if d.decoder == nil {
+		return nil
+	}
+	if err := d.decoder.Close(); err != nil {
+		return errors.Wrap(err, "failed to close reader")
+	}
+
+	d.pool.Put(d.decoder)
+	d.decoder = nil
+	return nil
+}
+
+func (d *decWrapper) Read(p []byte) (int, error) {
+	if d.decoder == nil {
+		return 0, errors.AssertionFailedf("attempt to read on a closed decoder")
+	}
+	return d.decoder.Read(p)
+}
+
+// zstdDecoder wraps zstd.Decoder to implement io.Closer interface correctly.
+// While zstd.Decoder.Close() returns void, io.Closer requires Close() error.
+type zstdDecoder struct {
+	*zstd.Decoder
+}
+
+// Close implements io.Closer interface. It resets the decoder with a nil reader
+// instead of closing it, allowing the decoder to be reused. This approach preserves
+// the decoder's reusability while satisfying the io.Closer contract.
+func (z *zstdDecoder) Close() error {
+	if err := z.Decoder.Reset(nil); err != nil {
+		return errors.Wrap(err, "failed to close zstd decoder")
+	}
+
+	return nil
 }
 
 // newCompressionCodec returns compression codec for the specified algorithm,
@@ -45,11 +148,79 @@ func newCompressionCodec(
 	switch algo {
 	case sinkCompressionGzip:
 		if useFastGzip.Get(sv) {
-			return pgzip.NewWriterLevel(dest, pgzip.DefaultCompression)
+			pooled := fastGzipEncoderPool.Get()
+			if pooled != nil {
+				encoder := pooled.(*pgzip.Writer)
+				encoder.Reset(dest)
+				return &encWrapper{encoder: encoder, pool: &fastGzipEncoderPool}, nil
+			}
+			encoder, err := pgzip.NewWriterLevel(dest, pgzip.DefaultCompression)
+			if err != nil {
+				return nil, errors.Wrap(err, "failed to create pgzip encoder")
+			}
+			return &encWrapper{encoder: encoder, pool: &fastGzipEncoderPool}, nil
 		}
-		return stdgzip.NewWriterLevel(dest, stdgzip.DefaultCompression)
+
+		pooled := gzipEncoderPool.Get()
+		if pooled != nil {
+			encoder := pooled.(*stdgzip.Writer)
+			encoder.Reset(dest)
+			return &encWrapper{encoder: encoder, pool: &gzipEncoderPool}, nil
+		}
+		encoder, err := stdgzip.NewWriterLevel(dest, stdgzip.DefaultCompression)
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to create gzip encoder")
+		}
+		return &encWrapper{encoder: encoder, pool: &gzipEncoderPool}, nil
 	case sinkCompressionZstd:
-		return zstd.NewWriter(dest, zstd.WithEncoderLevel(zstd.SpeedFastest))
+		pooled := zstdEncoderPool.Get()
+		if pooled != nil {
+			encoder := pooled.(*zstd.Encoder)
+			encoder.Reset(dest)
+			return &encWrapper{encoder: encoder, pool: &zstdEncoderPool}, nil
+		}
+		encoder, err := zstd.NewWriter(dest, zstd.WithEncoderLevel(zstd.SpeedFastest))
+		if err != nil {
+			return nil, errors.Wrap(err, "failed to create zstd encoder")
+		}
+		return &encWrapper{encoder: encoder, pool: &zstdEncoderPool}, nil
+	default:
+		return nil, errors.AssertionFailedf("unsupported compression algorithm %q", algo)
+	}
+}
+
+// newDecompressionReader returns decompression reader for the specified algorithm
+func newDecompressionReader(algo compressionAlgo, src io.Reader) (io.ReadCloser, error) {
+	switch algo {
+	case sinkCompressionGzip:
+		// since we are using decompression only for reading error response body, we can use default reader
+		pooled := gzipDecoderPool.Get()
+		if pooled != nil {
+			reader := pooled.(*pgzip.Reader)
+			if err := reader.Reset(src); err != nil {
+				return nil, errors.Wrap(err, "failed to reset gzip reader")
+			}
+			return &decWrapper{decoder: reader, pool: &gzipDecoderPool}, nil
+		}
+		reader, err := pgzip.NewReader(src)
+		if err != nil {
+			return nil, err
+		}
+		return &decWrapper{decoder: reader, pool: &gzipDecoderPool}, nil
+	case sinkCompressionZstd:
+		pooled := zstdDecoderPool.Get()
+		if pooled != nil {
+			reader := pooled.(*zstdDecoder)
+			if err := reader.Reset(src); err != nil {
+				return nil, errors.Wrap(err, "failed to reset zstd reader")
+			}
+			return &decWrapper{decoder: reader, pool: &zstdDecoderPool}, nil
+		}
+		reader, err := zstd.NewReader(src)
+		if err != nil {
+			return nil, err
+		}
+		return &decWrapper{decoder: &zstdDecoder{reader}, pool: &zstdDecoderPool}, nil
 	default:
 		return nil, errors.AssertionFailedf("unsupported compression algorithm %q", algo)
 	}

--- a/pkg/ccl/changefeedccl/sink_cloudstorage.go
+++ b/pkg/ccl/changefeedccl/sink_cloudstorage.go
@@ -887,6 +887,8 @@ func (f *cloudStorageSinkFile) flushToStorage(
 		if err := f.codec.Close(); err != nil {
 			return err
 		}
+		// Reset reference to underlying codec to prevent accidental reuse.
+		f.codec = nil
 	}
 
 	compressedBytes := f.buf.Len()

--- a/pkg/ccl/changefeedccl/sink_webhook_test.go
+++ b/pkg/ccl/changefeedccl/sink_webhook_test.go
@@ -101,8 +101,8 @@ func testSendAndReceiveRows(t *testing.T, sinkSrc Sink, sinkDest *cdctest.MockWe
 
 	// test an insert row entry
 	var pool testAllocPool
-	require.NoError(t, sinkSrc.EmitRow(ctx, noTopic{}, []byte("[1001]"), []byte("{\"after\":{\"col1\":\"val1\",\"rowid\":1000},\"key\":[1001],\"topic:\":\"foo\"}"), zeroTS, zeroTS, pool.alloc()))
-	require.NoError(t, sinkSrc.EmitRow(ctx, noTopic{}, []byte("[1001]"), []byte("{\"after\":{\"col1\":\"val1\",\"rowid\":1002},\"key\":[1001],\"topic:\":\"foo\"}"), zeroTS, zeroTS, pool.alloc()))
+	require.NoError(t, sinkSrc.EmitRow(ctx, noTopic{}, []byte("[1001]"), []byte(`{"after":{"col1":"val1","rowid":1000},"key":[1001],"topic:":"foo"}`), zeroTS, zeroTS, pool.alloc()))
+	require.NoError(t, sinkSrc.EmitRow(ctx, noTopic{}, []byte("[1001]"), []byte(`{"after":{"col1":"val1","rowid":1002},"key":[1001],"topic:":"foo"}`), zeroTS, zeroTS, pool.alloc()))
 	require.NoError(t, sinkSrc.Flush(ctx))
 	testutils.SucceedsSoon(t, func() error {
 		remaining := pool.used()
@@ -113,18 +113,18 @@ func testSendAndReceiveRows(t *testing.T, sinkSrc Sink, sinkDest *cdctest.MockWe
 	})
 
 	require.Equal(t,
-		"{\"payload\":[{\"after\":{\"col1\":\"val1\",\"rowid\":1002},\"key\":[1001],\"topic:\":\"foo\"}],\"length\":1}", sinkDest.Latest(),
+		`{"payload":[{"after":{"col1":"val1","rowid":1002},"key":[1001],"topic:":"foo"}],"length":1}`, sinkDest.Latest(),
 		"sink %s expected to receive message %s", sinkDest.URL(),
-		"{\"payload\":[{\"after\":{\"col1\":\"val1\",\"rowid\":1002},\"key\":[1001],\"topic:\":\"foo\"}],\"length\":1}")
+		`{"payload":[{"after":{"col1":"val1","rowid":1002},"key":[1001],"topic:":"foo"}],"length":1}`)
 
 	// test a delete row entry
-	require.NoError(t, sinkSrc.EmitRow(ctx, noTopic{}, []byte("[1002]"), []byte("{\"after\":null,\"key\":[1002],\"topic:\":\"foo\"}"), zeroTS, zeroTS, pool.alloc()))
+	require.NoError(t, sinkSrc.EmitRow(ctx, noTopic{}, []byte("[1002]"), []byte(`{"after":null,"key":[1002],"topic:":"foo"}`), zeroTS, zeroTS, pool.alloc()))
 	require.NoError(t, sinkSrc.Flush(ctx))
 
 	require.Equal(t,
-		"{\"payload\":[{\"after\":null,\"key\":[1002],\"topic:\":\"foo\"}],\"length\":1}", sinkDest.Latest(),
+		`{"payload":[{"after":null,"key":[1002],"topic:":"foo"}],"length":1}`, sinkDest.Latest(),
 		"sink %s expected to receive message %s", sinkDest.URL(),
-		"{\"payload\":[{\"after\":null,\"key\":[1002],\"topic:\":\"foo\"}],\"length\":1}")
+		`{"payload":[{"after":null,"key":[1002],"topic:":"foo"}],"length":1}`)
 
 	opts, err := getGenericWebhookSinkOptions().GetEncodingOptions()
 	require.NoError(t, err)
@@ -136,9 +136,9 @@ func testSendAndReceiveRows(t *testing.T, sinkSrc Sink, sinkDest *cdctest.MockWe
 	require.NoError(t, sinkSrc.Flush(ctx))
 
 	require.Equal(t,
-		"{\"resolved\":\"2.0000000000\"}", sinkDest.Latest(),
+		`{"resolved":"2.0000000000"}`, sinkDest.Latest(),
 		"sink %s expected to receive message %s", sinkDest.URL(),
-		"{\"resolved\":\"2.0000000000\"}")
+		`{"resolved":"2.0000000000"}`)
 }
 
 func TestWebhookSink(t *testing.T) {
@@ -175,7 +175,7 @@ func TestWebhookSink(t *testing.T) {
 		require.NoError(t, err)
 
 		// now sink's client accepts no custom certs, should reject the server's cert and fail
-		require.NoError(t, sinkSrcNoCert.EmitRow(context.Background(), noTopic{}, []byte("[1001]"), []byte("{\"after\":{\"col1\":\"val1\",\"rowid\":1000},\"key\":[1001],\"topic:\":\"foo\"}"), zeroTS, zeroTS, zeroAlloc))
+		require.NoError(t, sinkSrcNoCert.EmitRow(context.Background(), noTopic{}, []byte("[1001]"), []byte(`{"after":{"col1":"val1","rowid":1000},"key":[1001],"topic:":"foo"}`), zeroTS, zeroTS, zeroAlloc))
 
 		require.Regexp(t, "x509", sinkSrcNoCert.Flush(context.Background()))
 
@@ -190,7 +190,7 @@ func TestWebhookSink(t *testing.T) {
 
 		// sink should throw an error if server is unreachable
 		sinkDest.Close()
-		require.NoError(t, sinkSrc.EmitRow(context.Background(), noTopic{}, []byte("[1001]"), []byte("{\"after\":{\"col1\":\"val1\",\"rowid\":1000},\"key\":[1001],\"topic:\":\"foo\"}"), zeroTS, zeroTS, zeroAlloc))
+		require.NoError(t, sinkSrc.EmitRow(context.Background(), noTopic{}, []byte("[1001]"), []byte(`{"after":{"col1":"val1","rowid":1000},"key":[1001],"topic:":"foo"}`), zeroTS, zeroTS, zeroAlloc))
 
 		err = sinkSrc.Flush(context.Background())
 		require.Error(t, err)
@@ -204,7 +204,7 @@ func TestWebhookSink(t *testing.T) {
 		require.NoError(t, err)
 
 		// sink's client should not accept the endpoint's use of HTTP (expects HTTPS)
-		require.NoError(t, sinkSrcWrongProtocol.EmitRow(context.Background(), noTopic{}, []byte("[1001]"), []byte("{\"after\":{\"col1\":\"val1\",\"rowid\":1000},\"key\":[1001],\"topic:\":\"foo\"}"), zeroTS, zeroTS, zeroAlloc))
+		require.NoError(t, sinkSrcWrongProtocol.EmitRow(context.Background(), noTopic{}, []byte("[1001]"), []byte(`{"after":{"col1":"val1","rowid":1000},"key":[1001],"topic:":"foo"}`), zeroTS, zeroTS, zeroAlloc))
 
 		require.EqualError(t, sinkSrcWrongProtocol.Flush(context.Background()),
 			fmt.Sprintf(`Post "%s": http: server gave HTTP response to HTTPS client`, fmt.Sprintf("https://%s", strings.TrimPrefix(sinkDestHTTP.URL(),
@@ -303,7 +303,7 @@ func TestWebhookSinkWithAuthOptions(t *testing.T) {
 		delete(details.Opts, changefeedbase.OptWebhookAuthHeader)
 		sinkSrcNoCreds, err := setupWebhookSinkWithDetails(context.Background(), details, parallelism, timeutil.DefaultTimeSource{})
 		require.NoError(t, err)
-		require.NoError(t, sinkSrcNoCreds.EmitRow(context.Background(), noTopic{}, []byte("[1001]"), []byte("{\"after\":{\"col1\":\"val1\",\"rowid\":1000},\"key\":[1001],\"topic:\":\"foo\"}"), zeroTS, zeroTS, zeroAlloc))
+		require.NoError(t, sinkSrcNoCreds.EmitRow(context.Background(), noTopic{}, []byte("[1001]"), []byte(`{"after":{"col1":"val1","rowid":1000},"key":[1001],"topic:":"foo"}`), zeroTS, zeroTS, zeroAlloc))
 
 		require.EqualError(t, sinkSrcNoCreds.Flush(context.Background()), "401 Unauthorized: ")
 
@@ -314,7 +314,7 @@ func TestWebhookSinkWithAuthOptions(t *testing.T) {
 		sinkSrcWrongCreds, err := setupWebhookSinkWithDetails(context.Background(), details, parallelism, timeutil.DefaultTimeSource{})
 		require.NoError(t, err)
 
-		require.NoError(t, sinkSrcWrongCreds.EmitRow(context.Background(), noTopic{}, []byte("[1001]"), []byte("{\"after\":{\"col1\":\"val1\",\"rowid\":1000},\"key\":[1001],\"topic:\":\"foo\"}"), zeroTS, zeroTS, zeroAlloc))
+		require.NoError(t, sinkSrcWrongCreds.EmitRow(context.Background(), noTopic{}, []byte("[1001]"), []byte(`{"after":{"col1":"val1","rowid":1000},"key":[1001],"topic:":"foo"}`), zeroTS, zeroTS, zeroAlloc))
 
 		require.EqualError(t, sinkSrcWrongCreds.Flush(context.Background()), "401 Unauthorized: ")
 
@@ -401,7 +401,7 @@ func TestWebhookSinkConfig(t *testing.T) {
 		sinkSrc, err := setupWebhookSinkWithDetails(context.Background(), details, parallelism, timeutil.DefaultTimeSource{})
 		require.NoError(t, err)
 
-		require.NoError(t, sinkSrc.EmitRow(context.Background(), noTopic{}, []byte("[1001]"), []byte("{\"after\":{\"col1\":\"val1\",\"rowid\":1000},\"key\":[1001],\"topic:\":\"foo\"}"), zeroTS, zeroTS, zeroAlloc))
+		require.NoError(t, sinkSrc.EmitRow(context.Background(), noTopic{}, []byte("[1001]"), []byte(`{"after":{"col1":"val1","rowid":1000},"key":[1001],"topic:":"foo"}`), zeroTS, zeroTS, zeroAlloc))
 
 		require.EqualError(t, sinkSrc.Flush(context.Background()), "500 Internal Server Error: ")
 
@@ -443,7 +443,7 @@ func TestWebhookSinkConfig(t *testing.T) {
 		sinkSrc, err := setupWebhookSinkWithDetails(context.Background(), details, parallelism, timeutil.DefaultTimeSource{})
 		require.NoError(t, err)
 
-		require.NoError(t, sinkSrc.EmitRow(context.Background(), noTopic{}, []byte("[1001]"), []byte("{\"after\":{\"col1\":\"val1\",\"rowid\":1000},\"key\":[1001],\"topic:\":\"foo\"}"), zeroTS, zeroTS, pool.alloc()))
+		require.NoError(t, sinkSrc.EmitRow(context.Background(), noTopic{}, []byte("[1001]"), []byte(`{"after":{"col1":"val1","rowid":1000},"key":[1001],"topic:":"foo"}`), zeroTS, zeroTS, pool.alloc()))
 
 		require.EqualError(t, sinkSrc.Flush(context.Background()), "500 Internal Server Error: ")
 
@@ -485,18 +485,18 @@ func TestWebhookSinkConfig(t *testing.T) {
 		sinkSrc, err := setupWebhookSinkWithDetails(context.Background(), details, parallelism, mt)
 		require.NoError(t, err)
 
-		require.NoError(t, sinkSrc.EmitRow(context.Background(), noTopic{}, []byte("[1001]"), []byte("{\"after\":{\"col1\":\"val1\",\"rowid\":1000},\"key\":[1001],\"topic:\":\"foo\"}"), zeroTS, zeroTS, pool.alloc()))
-		require.NoError(t, sinkSrc.EmitRow(context.Background(), noTopic{}, []byte("[1001]"), []byte("{\"after\":{\"col1\":\"val1\",\"rowid\":1001},\"key\":[1001],\"topic:\":\"foo\"}"), zeroTS, zeroTS, pool.alloc()))
-		require.NoError(t, sinkSrc.EmitRow(context.Background(), noTopic{}, []byte("[1001]"), []byte("{\"after\":{\"col1\":\"val1\",\"rowid\":1002},\"key\":[1001],\"topic:\":\"foo\"}"), zeroTS, zeroTS, pool.alloc()))
-		require.NoError(t, sinkSrc.EmitRow(context.Background(), noTopic{}, []byte("[1001]"), []byte("{\"after\":{\"col1\":\"val1\",\"rowid\":1003},\"key\":[1001],\"topic:\":\"foo\"}"), zeroTS, zeroTS, pool.alloc()))
-		require.NoError(t, sinkSrc.EmitRow(context.Background(), noTopic{}, []byte("[1001]"), []byte("{\"after\":{\"col1\":\"val1\",\"rowid\":1004},\"key\":[1001],\"topic:\":\"foo\"}"), zeroTS, zeroTS, pool.alloc()))
+		require.NoError(t, sinkSrc.EmitRow(context.Background(), noTopic{}, []byte("[1001]"), []byte(`{"after":{"col1":"val1","rowid":1000},"key":[1001],"topic:":"foo"}`), zeroTS, zeroTS, pool.alloc()))
+		require.NoError(t, sinkSrc.EmitRow(context.Background(), noTopic{}, []byte("[1001]"), []byte(`{"after":{"col1":"val1","rowid":1001},"key":[1001],"topic:":"foo"}`), zeroTS, zeroTS, pool.alloc()))
+		require.NoError(t, sinkSrc.EmitRow(context.Background(), noTopic{}, []byte("[1001]"), []byte(`{"after":{"col1":"val1","rowid":1002},"key":[1001],"topic:":"foo"}`), zeroTS, zeroTS, pool.alloc()))
+		require.NoError(t, sinkSrc.EmitRow(context.Background(), noTopic{}, []byte("[1001]"), []byte(`{"after":{"col1":"val1","rowid":1003},"key":[1001],"topic:":"foo"}`), zeroTS, zeroTS, pool.alloc()))
+		require.NoError(t, sinkSrc.EmitRow(context.Background(), noTopic{}, []byte("[1001]"), []byte(`{"after":{"col1":"val1","rowid":1004},"key":[1001],"topic:":"foo"}`), zeroTS, zeroTS, pool.alloc()))
 
 		require.NoError(t, sinkSrc.Flush(context.Background()))
-		require.Equal(t, sinkDest.Pop(), "{\"payload\":[{\"after\":{\"col1\":\"val1\",\"rowid\":1000},\"key\":[1001],\"topic:\":\"foo\"},"+
-			"{\"after\":{\"col1\":\"val1\",\"rowid\":1001},\"key\":[1001],\"topic:\":\"foo\"},"+
-			"{\"after\":{\"col1\":\"val1\",\"rowid\":1002},\"key\":[1001],\"topic:\":\"foo\"},"+
-			"{\"after\":{\"col1\":\"val1\",\"rowid\":1003},\"key\":[1001],\"topic:\":\"foo\"},"+
-			"{\"after\":{\"col1\":\"val1\",\"rowid\":1004},\"key\":[1001],\"topic:\":\"foo\"}],\"length\":5}")
+		require.Equal(t, sinkDest.Pop(), `{"payload":[{"after":{"col1":"val1","rowid":1000},"key":[1001],"topic:":"foo"},`+
+			`{"after":{"col1":"val1","rowid":1001},"key":[1001],"topic:":"foo"},`+
+			`{"after":{"col1":"val1","rowid":1002},"key":[1001],"topic:":"foo"},`+
+			`{"after":{"col1":"val1","rowid":1003},"key":[1001],"topic:":"foo"},`+
+			`{"after":{"col1":"val1","rowid":1004},"key":[1001],"topic:":"foo"}],"length":5}`)
 
 		testutils.SucceedsSoon(t, func() error {
 			// wait for the timer in batch worker to be set (1 hour from now, as specified by config) before advancing time.
@@ -512,8 +512,8 @@ func TestWebhookSinkConfig(t *testing.T) {
 		require.Equal(t, sinkDest.Latest(), "")
 
 		// messages without a full batch should not send
-		require.NoError(t, sinkSrc.EmitRow(context.Background(), noTopic{}, []byte("[1001]"), []byte("{\"after\":{\"col1\":\"val1\",\"rowid\":1000},\"key\":[1001],\"topic:\":\"foo\"}"), zeroTS, zeroTS, pool.alloc()))
-		require.NoError(t, sinkSrc.EmitRow(context.Background(), noTopic{}, []byte("[1001]"), []byte("{\"after\":{\"col1\":\"val1\",\"rowid\":1001},\"key\":[1001],\"topic:\":\"foo\"}"), zeroTS, zeroTS, pool.alloc()))
+		require.NoError(t, sinkSrc.EmitRow(context.Background(), noTopic{}, []byte("[1001]"), []byte(`{"after":{"col1":"val1","rowid":1000},"key":[1001],"topic:":"foo"}`), zeroTS, zeroTS, pool.alloc()))
+		require.NoError(t, sinkSrc.EmitRow(context.Background(), noTopic{}, []byte("[1001]"), []byte(`{"after":{"col1":"val1","rowid":1001},"key":[1001],"topic:":"foo"}`), zeroTS, zeroTS, pool.alloc()))
 		require.Equal(t, sinkDest.Latest(), "")
 
 		require.NoError(t, sinkSrc.Close())
@@ -548,22 +548,22 @@ func TestWebhookSinkConfig(t *testing.T) {
 		sinkSrc, err := setupWebhookSinkWithDetails(context.Background(), details, parallelism, timeutil.DefaultTimeSource{})
 		require.NoError(t, err)
 
-		require.NoError(t, sinkSrc.EmitRow(context.Background(), noTopic{}, []byte("[1001]"), []byte("{\"after\":{\"col1\":\"val1\",\"rowid\":1000},\"key\":[1001],\"topic:\":\"foo\"}"), zeroTS, zeroTS, pool.alloc()))
-		require.NoError(t, sinkSrc.EmitRow(context.Background(), noTopic{}, []byte("[1001]"), []byte("{\"after\":{\"col1\":\"val1\",\"rowid\":1001},\"key\":[1001],\"topic:\":\"foo\"}"), zeroTS, zeroTS, pool.alloc()))
-		require.NoError(t, sinkSrc.EmitRow(context.Background(), noTopic{}, []byte("[1001]"), []byte("{\"after\":{\"col1\":\"val1\",\"rowid\":1002},\"key\":[1001],\"topic:\":\"foo\"}"), zeroTS, zeroTS, pool.alloc()))
-		require.NoError(t, sinkSrc.EmitRow(context.Background(), noTopic{}, []byte("[1001]"), []byte("{\"after\":{\"col1\":\"val1\",\"rowid\":1003},\"key\":[1001],\"topic:\":\"foo\"}"), zeroTS, zeroTS, pool.alloc()))
-		require.NoError(t, sinkSrc.EmitRow(context.Background(), noTopic{}, []byte("[1001]"), []byte("{\"after\":{\"col1\":\"val1\",\"rowid\":1004},\"key\":[1001],\"topic:\":\"foo\"}"), zeroTS, zeroTS, pool.alloc()))
+		require.NoError(t, sinkSrc.EmitRow(context.Background(), noTopic{}, []byte("[1001]"), []byte(`{"after":{"col1":"val1","rowid":1000},"key":[1001],"topic:":"foo"}`), zeroTS, zeroTS, pool.alloc()))
+		require.NoError(t, sinkSrc.EmitRow(context.Background(), noTopic{}, []byte("[1001]"), []byte(`{"after":{"col1":"val1","rowid":1001},"key":[1001],"topic:":"foo"}`), zeroTS, zeroTS, pool.alloc()))
+		require.NoError(t, sinkSrc.EmitRow(context.Background(), noTopic{}, []byte("[1001]"), []byte(`{"after":{"col1":"val1","rowid":1002},"key":[1001],"topic:":"foo"}`), zeroTS, zeroTS, pool.alloc()))
+		require.NoError(t, sinkSrc.EmitRow(context.Background(), noTopic{}, []byte("[1001]"), []byte(`{"after":{"col1":"val1","rowid":1003},"key":[1001],"topic:":"foo"}`), zeroTS, zeroTS, pool.alloc()))
+		require.NoError(t, sinkSrc.EmitRow(context.Background(), noTopic{}, []byte("[1001]"), []byte(`{"after":{"col1":"val1","rowid":1004},"key":[1001],"topic:":"foo"}`), zeroTS, zeroTS, pool.alloc()))
 
 		require.NoError(t, sinkSrc.Flush(context.Background()))
-		require.Equal(t, sinkDest.Pop(), "{\"payload\":[{\"after\":{\"col1\":\"val1\",\"rowid\":1000},\"key\":[1001],\"topic:\":\"foo\"},"+
-			"{\"after\":{\"col1\":\"val1\",\"rowid\":1001},\"key\":[1001],\"topic:\":\"foo\"},"+
-			"{\"after\":{\"col1\":\"val1\",\"rowid\":1002},\"key\":[1001],\"topic:\":\"foo\"},"+
-			"{\"after\":{\"col1\":\"val1\",\"rowid\":1003},\"key\":[1001],\"topic:\":\"foo\"},"+
-			"{\"after\":{\"col1\":\"val1\",\"rowid\":1004},\"key\":[1001],\"topic:\":\"foo\"}],\"length\":5}")
+		require.Equal(t, sinkDest.Pop(), `{"payload":[{"after":{"col1":"val1","rowid":1000},"key":[1001],"topic:":"foo"},`+
+			`{"after":{"col1":"val1","rowid":1001},"key":[1001],"topic:":"foo"},`+
+			`{"after":{"col1":"val1","rowid":1002},"key":[1001],"topic:":"foo"},`+
+			`{"after":{"col1":"val1","rowid":1003},"key":[1001],"topic:":"foo"},`+
+			`{"after":{"col1":"val1","rowid":1004},"key":[1001],"topic:":"foo"}],"length":5}`)
 
 		// messages without a full batch should not send
-		require.NoError(t, sinkSrc.EmitRow(context.Background(), noTopic{}, []byte("[1001]"), []byte("{\"after\":{\"col1\":\"val1\",\"rowid\":1000},\"key\":[1001],\"topic:\":\"foo\"}"), zeroTS, zeroTS, pool.alloc()))
-		require.NoError(t, sinkSrc.EmitRow(context.Background(), noTopic{}, []byte("[1001]"), []byte("{\"after\":{\"col1\":\"val1\",\"rowid\":1001},\"key\":[1001],\"topic:\":\"foo\"}"), zeroTS, zeroTS, pool.alloc()))
+		require.NoError(t, sinkSrc.EmitRow(context.Background(), noTopic{}, []byte("[1001]"), []byte(`{"after":{"col1":"val1","rowid":1000},"key":[1001],"topic:":"foo"}`), zeroTS, zeroTS, pool.alloc()))
+		require.NoError(t, sinkSrc.EmitRow(context.Background(), noTopic{}, []byte("[1001]"), []byte(`{"after":{"col1":"val1","rowid":1001},"key":[1001],"topic:":"foo"}`), zeroTS, zeroTS, pool.alloc()))
 		require.Equal(t, sinkDest.Latest(), "")
 
 		require.NoError(t, sinkSrc.Close())
@@ -608,8 +608,8 @@ func TestWebhookSinkConfig(t *testing.T) {
 		}
 
 		// send incomplete batch
-		require.NoError(t, sinkSrc.EmitRow(context.Background(), noTopic{}, []byte("[1001]"), []byte("{\"after\":{\"col1\":\"val1\",\"rowid\":1000},\"key\":[1001],\"topic:\":\"foo\"}"), zeroTS, zeroTS, pool.alloc()))
-		require.NoError(t, sinkSrc.EmitRow(context.Background(), noTopic{}, []byte("[1001]"), []byte("{\"after\":{\"col1\":\"val1\",\"rowid\":1001},\"key\":[1001],\"topic:\":\"foo\"}"), zeroTS, zeroTS, pool.alloc()))
+		require.NoError(t, sinkSrc.EmitRow(context.Background(), noTopic{}, []byte("[1001]"), []byte(`{"after":{"col1":"val1","rowid":1000},"key":[1001],"topic:":"foo"}`), zeroTS, zeroTS, pool.alloc()))
+		require.NoError(t, sinkSrc.EmitRow(context.Background(), noTopic{}, []byte("[1001]"), []byte(`{"after":{"col1":"val1","rowid":1001},"key":[1001],"topic:":"foo"}`), zeroTS, zeroTS, pool.alloc()))
 
 		// no messages at first
 		require.Equal(t, sinkDest.Latest(), "")
@@ -623,8 +623,8 @@ func TestWebhookSinkConfig(t *testing.T) {
 		mt.Advance(time.Hour)
 		require.NoError(t, sinkSrc.Flush(context.Background()))
 		// batch should send after time expires even if message quota has not been met
-		require.Equal(t, sinkDest.Pop(), "{\"payload\":[{\"after\":{\"col1\":\"val1\",\"rowid\":1000},\"key\":[1001],\"topic:\":\"foo\"},"+
-			"{\"after\":{\"col1\":\"val1\",\"rowid\":1001},\"key\":[1001],\"topic:\":\"foo\"}],\"length\":2}")
+		require.Equal(t, sinkDest.Pop(), `{"payload":[{"after":{"col1":"val1","rowid":1000},"key":[1001],"topic:":"foo"},`+
+			`{"after":{"col1":"val1","rowid":1001},"key":[1001],"topic:":"foo"}],"length":2}`)
 
 		mt.Advance(time.Hour)
 		require.NoError(t, sinkSrc.Flush(context.Background()))
@@ -676,7 +676,7 @@ func TestWebhookSinkShutsDownOnError(t *testing.T) {
 		sinkSrc, err := setupWebhookSinkWithDetails(ctx, details, parallelism, timeutil.DefaultTimeSource{})
 		require.NoError(t, err)
 
-		require.NoError(t, sinkSrc.EmitRow(ctx, noTopic{}, []byte("[1001]"), []byte("{\"after\":{\"col1\":\"val1\",\"rowid\":1000},\"key\":[1001],\"topic:\":\"foo\"}"), zeroTS, zeroTS, zeroAlloc))
+		require.NoError(t, sinkSrc.EmitRow(ctx, noTopic{}, []byte("[1001]"), []byte(`{"after":{"col1":"val1","rowid":1000},"key":[1001],"topic:":"foo"}`), zeroTS, zeroTS, zeroAlloc))
 		// error should be propagated immediately in the next call
 		require.EqualError(t, sinkSrc.Flush(ctx), "500 Internal Server Error: ")
 
@@ -755,11 +755,315 @@ func TestWebhookSinkRetry(t *testing.T) {
 	sinkSrc, err := setupWebhookSinkWithDetails(ctx, details, 1 /* parallelism */, timeutil.DefaultTimeSource{})
 	require.NoError(t, err)
 
-	require.NoError(t, sinkSrc.EmitRow(ctx, noTopic{}, []byte("[1001]"), []byte("{\"after\":{\"col1\":\"val1\",\"rowid\":1000},\"key\":[1001],\"topic:\":\"foo\"}"), zeroTS, zeroTS, zeroAlloc))
+	require.NoError(t, sinkSrc.EmitRow(ctx, noTopic{}, []byte("[1001]"), []byte(`{"after":{"col1":"val1","rowid":1000},"key":[1001],"topic:":"foo"}`), zeroTS, zeroTS, zeroAlloc))
 	require.NoError(t, sinkSrc.Flush(ctx))
 
-	require.Equal(t, "{\"payload\":[{\"after\":{\"col1\":\"val1\",\"rowid\":1000},\"key\":[1001],\"topic:\":\"foo\"}],\"length\":1}", sinkDest.Pop())
+	require.Equal(t, `{"payload":[{"after":{"col1":"val1","rowid":1000},"key":[1001],"topic:":"foo"}],"length":1}`, sinkDest.Pop())
 
 	sinkDest.Close()
 	require.NoError(t, sinkSrc.Close())
+}
+
+func TestInvalidWebhookSinkCompression(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	cert, certEncoded, err := cdctest.NewCACertBase64Encoded()
+	require.NoError(t, err)
+
+	sinkDest, err := cdctest.StartMockWebhookSink(cert)
+	require.NoError(t, err)
+	defer sinkDest.Close()
+
+	sinkDestHost, err := url.Parse(sinkDest.URL())
+	require.NoError(t, err)
+
+	params := sinkDestHost.Query()
+	params.Set(changefeedbase.SinkParamCACert, certEncoded)
+	sinkDestHost.RawQuery = params.Encode()
+
+	invalidOpts := getGenericWebhookSinkOptions(struct {
+		key   string
+		value string
+	}{
+		key:   changefeedbase.OptCompression,
+		value: "invalid",
+	})
+
+	details := jobspb.ChangefeedDetails{
+		SinkURI: fmt.Sprintf("webhook-%s", sinkDestHost.String()),
+		Opts:    invalidOpts.AsMap(),
+	}
+
+	_, err = setupWebhookSinkWithDetails(context.Background(), details, 1, timeutil.DefaultTimeSource{})
+	require.Error(t, err)
+	require.Contains(t, err.Error(), `unsupported compression type "invalid"`)
+}
+
+func TestWebhookSinkCompression(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	testCases := []struct {
+		name        string
+		compression string
+	}{
+		{
+			name:        "gzip compression",
+			compression: "gzip",
+		},
+		{
+			name:        "zstd compression",
+			compression: "zstd",
+		},
+	}
+
+	webhookSinkCompressionTestFn := func(compression string, parallelism int) {
+		// Create a test certificate
+		cert, certEncoded, err := cdctest.NewCACertBase64Encoded()
+		require.NoError(t, err)
+
+		// Start mock webhook sink
+		sinkDest, err := cdctest.StartMockWebhookSink(cert)
+		require.NoError(t, err)
+
+		// Get sink options with compression enabled
+		opts := getGenericWebhookSinkOptions(struct {
+			key   string
+			value string
+		}{
+			key:   changefeedbase.OptCompression,
+			value: compression,
+		})
+
+		sinkDestHost, err := url.Parse(sinkDest.URL())
+		require.NoError(t, err)
+
+		params := sinkDestHost.Query()
+		params.Set(changefeedbase.SinkParamCACert, certEncoded)
+		sinkDestHost.RawQuery = params.Encode()
+
+		details := jobspb.ChangefeedDetails{
+			SinkURI: fmt.Sprintf("webhook-%s", sinkDestHost.String()),
+			Opts:    opts.AsMap(),
+		}
+
+		sinkSrc, err := setupWebhookSinkWithDetails(context.Background(), details, parallelism, timeutil.DefaultTimeSource{})
+		require.NoError(t, err)
+
+		// Test with compression
+		require.NoError(t, sinkSrc.EmitRow(context.Background(), noTopic{},
+			[]byte("[1001]"),
+			[]byte(`{"after":{"col1":"val1","rowid":1000},"key":[1001],"topic:":"foo"}`),
+			zeroTS,
+			zeroTS,
+			zeroAlloc))
+		require.NoError(t, sinkSrc.Flush(context.Background()))
+
+		// Verify compression headers are present
+		require.Equal(t, compression, sinkDest.LastRequestHeaders().Get("Content-Encoding"))
+		require.Equal(t, compression, sinkDest.LastRequestHeaders().Get("Accept-Encoding"))
+
+		// Verify the content can be decompressed and matches expected
+		expected := `{"payload":[{"after":{"col1":"val1","rowid":1000},"key":[1001],"topic:":"foo"}],"length":1}`
+		require.Equal(t, expected, sinkDest.Latest())
+
+		require.NoError(t, sinkSrc.Close())
+		sinkDest.Close()
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			for i := 1; i <= 4; i++ {
+				parallelism := i
+				t.Run(fmt.Sprintf("parallelism-%d", parallelism), func(t *testing.T) {
+					webhookSinkCompressionTestFn(tc.compression, parallelism)
+				})
+			}
+		})
+	}
+}
+
+func TestWebhookSinkCompressionWithBatching(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	testCases := []struct {
+		name        string
+		compression string
+	}{
+		{
+			name:        "gzip compression",
+			compression: "gzip",
+		},
+		{
+			name:        "zstd compression",
+			compression: "zstd",
+		},
+	}
+
+	batchingWithCompressionTestFn := func(compression string, parallelism int) {
+		cert, certEncoded, err := cdctest.NewCACertBase64Encoded()
+		require.NoError(t, err)
+		sinkDest, err := cdctest.StartMockWebhookSink(cert)
+		require.NoError(t, err)
+
+		// Configure both compression and batching
+		opts := getGenericWebhookSinkOptions(
+			[]struct {
+				key   string
+				value string
+			}{{
+				key:   changefeedbase.OptCompression,
+				value: compression,
+			}, {
+				key:   changefeedbase.OptWebhookSinkConfig,
+				value: `{"Flush":{"Messages": 2, "Frequency": "1h"}}`,
+			}}...,
+		)
+
+		sinkDestHost, err := url.Parse(sinkDest.URL())
+		require.NoError(t, err)
+
+		params := sinkDestHost.Query()
+		params.Set(changefeedbase.SinkParamCACert, certEncoded)
+		sinkDestHost.RawQuery = params.Encode()
+
+		details := jobspb.ChangefeedDetails{
+			SinkURI: fmt.Sprintf("webhook-%s", sinkDestHost.String()),
+			Opts:    opts.AsMap(),
+		}
+
+		mt := timeutil.NewManualTime(timeutil.Now())
+		sinkSrc, err := setupWebhookSinkWithDetails(context.Background(), details, parallelism, mt)
+		require.NoError(t, err)
+
+		// Send first message - should not trigger batch
+		require.NoError(t, sinkSrc.EmitRow(context.Background(), noTopic{},
+			[]byte("[1001]"),
+			[]byte(`{"after":{"col1":"val1","rowid":1000},"key":[1001],"topic:":"foo"}`),
+			zeroTS,
+			zeroTS,
+			zeroAlloc))
+		require.Equal(t, "", sinkDest.Latest())
+
+		// Send second message - should trigger batch
+		require.NoError(t, sinkSrc.EmitRow(context.Background(), noTopic{},
+			[]byte("[1002]"),
+			[]byte(`{"after":{"col1":"val2","rowid":1001},"key":[1002],"topic:":"foo"}`),
+			zeroTS,
+			zeroTS,
+			zeroAlloc))
+		require.NoError(t, sinkSrc.Flush(context.Background()))
+
+		// Verify compression headers
+		require.Equal(t, compression, sinkDest.LastRequestHeaders().Get("Content-Encoding"))
+		require.Equal(t, compression, sinkDest.LastRequestHeaders().Get("Accept-Encoding"))
+
+		// Verify batched content
+		expected := `{"payload":[` +
+			`{"after":{"col1":"val1","rowid":1000},"key":[1001],"topic:":"foo"},` +
+			`{"after":{"col1":"val2","rowid":1001},"key":[1002],"topic:":"foo"}` +
+			`],"length":2}`
+		require.Equal(t, expected, sinkDest.Latest())
+
+		require.NoError(t, sinkSrc.Close())
+		sinkDest.Close()
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			for i := 1; i <= 4; i++ {
+				parallelism := i
+				t.Run(fmt.Sprintf("parallelism-%d", parallelism), func(t *testing.T) {
+					batchingWithCompressionTestFn(tc.compression, parallelism)
+				})
+			}
+		})
+	}
+}
+
+func TestWebhookSinkErrorCompressedResponse(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	testCases := []struct {
+		name        string
+		compression string
+	}{
+		{
+			name:        "gzip compression",
+			compression: "gzip",
+		},
+		{
+			name:        "zstd compression",
+			compression: "zstd",
+		},
+	}
+
+	webhookSinkCompressedErrorTestFn := func(compression string, parallelism int) {
+		ctx := context.Background()
+		cert, certEncoded, err := cdctest.NewCACertBase64Encoded()
+		require.NoError(t, err)
+		sinkDest, err := cdctest.StartMockWebhookSink(cert)
+		require.NoError(t, err)
+
+		// Configure sink to use specified compression
+		opts := getGenericWebhookSinkOptions(struct {
+			key   string
+			value string
+		}{
+			key:   changefeedbase.OptCompression,
+			value: compression,
+		})
+
+		// Configure error response
+		responseBody := "Test error response"
+		sinkDest.ClearResponses()
+		sinkDest.SetResponse(http.StatusInternalServerError, []byte(responseBody))
+
+		sinkDestHost, err := url.Parse(sinkDest.URL())
+		require.NoError(t, err)
+
+		params := sinkDestHost.Query()
+		params.Set(changefeedbase.SinkParamCACert, certEncoded)
+		sinkDestHost.RawQuery = params.Encode()
+
+		details := jobspb.ChangefeedDetails{
+			SinkURI: fmt.Sprintf("webhook-%s", sinkDestHost.String()),
+			Opts:    opts.AsMap(),
+		}
+
+		sinkSrc, err := setupWebhookSinkWithDetails(ctx, details, parallelism, timeutil.DefaultTimeSource{})
+		require.NoError(t, err)
+
+		// Send data and expect error with compressed response
+		require.NoError(t, sinkSrc.EmitRow(ctx, noTopic{},
+			[]byte("[1001]"),
+			[]byte(`{"after":{"col1":"val1","rowid":1000},"key":[1001],"topic:":"foo"}`),
+			zeroTS,
+			zeroTS,
+			zeroAlloc))
+
+		err = sinkSrc.Flush(ctx)
+		require.Error(t, err)
+		// Verify error body is decompressed
+		require.Equal(t, fmt.Sprintf(`500 Internal Server Error: %s`, responseBody), err.Error())
+
+		// Verify no messages delivered
+		require.Equal(t, "", sinkDest.Pop())
+
+		require.NoError(t, sinkSrc.Close())
+		sinkDest.Close()
+	}
+
+	for _, tc := range testCases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			for i := 1; i <= 4; i++ {
+				parallelism := i
+				t.Run(fmt.Sprintf("parallelism-%d", parallelism), func(t *testing.T) {
+					webhookSinkCompressedErrorTestFn(tc.compression, parallelism)
+				})
+			}
+		})
+	}
 }


### PR DESCRIPTION
Added gzip compression option to the changefeed webhook sink to reduce both network bytes and storage bytes for the customer, leading to cost savings and potentially better performance. A minimum configuration to support for gzip.

Jira issue: [CRDB-42915](https://cockroachlabs.atlassian.net/browse/CRDB-42915)

Epic [CRDB-39392](https://cockroachlabs.atlassian.net/browse/CRDB-39392)

Issue [#132279](https://github.com/cockroachdb/cockroach/issues/132279)