### PR TITLE
cloudtestutils: refactor CheckExportStore, CheckListFiles, CheckNoPermissions

### DIFF
--- a/pkg/cloud/amazon/s3_storage_test.go
+++ b/pkg/cloud/amazon/s3_storage_test.go
@@ -139,9 +139,7 @@ func TestPutS3(t *testing.T) {
 					User: user,
 				}
 				cloudtestutils.CheckExportStore(t, info)
-				cloudtestutils.CheckListFiles(
-					t, info.URI, info.User, nil /* db */, testSettings,
-				)
+				cloudtestutils.CheckListFiles(t, info)
 			})
 
 			// Tests that we can put an object with server side encryption specified.
@@ -232,9 +230,7 @@ func TestPutS3AssumeRole(t *testing.T) {
 			User: user,
 		}
 		cloudtestutils.CheckExportStore(t, info)
-		cloudtestutils.CheckListFiles(
-			t, info.URI, user, nil /* db */, testSettings,
-		)
+		cloudtestutils.CheckListFiles(t, info)
 	})
 
 	t.Run("auth-specified", func(t *testing.T) {
@@ -245,9 +241,7 @@ func TestPutS3AssumeRole(t *testing.T) {
 			User: user,
 		}
 		cloudtestutils.CheckExportStore(t, info)
-		cloudtestutils.CheckListFiles(
-			t, info.URI, user, nil /* db */, testSettings,
-		)
+		cloudtestutils.CheckListFiles(t, info)
 	})
 
 	t.Run("role-chaining-external-id", func(t *testing.T) {

--- a/pkg/cloud/amazon/s3_storage_test.go
+++ b/pkg/cloud/amazon/s3_storage_test.go
@@ -106,14 +106,10 @@ func TestPutS3(t *testing.T) {
 		}
 		t.Run(testName, func(t *testing.T) {
 			t.Run("auth-empty-no-cred", func(t *testing.T) {
-				_, err := cloud.ExternalStorageFromURI(ctx, fmt.Sprintf("s3://%s/%s-%d", bucket,
-					"backup-test-default", testID), base.ExternalIODirConfig{}, testSettings,
-					blobs.TestEmptyBlobClientFactory, user,
-					nil, /* ie */
-					nil, /* ief */
-					nil, /* kvDB */
-					nil, /* limiters */
-					nil, /* metrics */
+				uri := fmt.Sprintf("s3://%s/%s-%d", bucket, "backup-test-default", testID)
+				_, err := cloud.ExternalStorageFromURI(
+					ctx, uri, base.ExternalIODirConfig{}, testSettings, blobs.TestEmptyBlobClientFactory, user,
+					nil /* ie */, nil /* ief */, nil /* kvDB */, nil /* limiters */, nil, /* metrics */
 				)
 				require.EqualError(t, err, fmt.Sprintf(
 					`%s is set to '%s', but %s is not set`,
@@ -124,55 +120,54 @@ func TestPutS3(t *testing.T) {
 			})
 			t.Run("auth-implicit", func(t *testing.T) {
 				skipIfNoDefaultConfig(t, ctx)
-				cloudtestutils.CheckExportStore(t, fmt.Sprintf(
-					"s3://%s/%s-%d?%s=%s",
-					bucket, "backup-test-default", testID,
-					cloud.AuthParam, cloud.AuthParamImplicit,
-				), false, user,
-					nil, /* db */
-					testSettings)
+				info := cloudtestutils.StoreInfo{
+					URI: fmt.Sprintf(
+						"s3://%s/%s-%d?%s=%s",
+						bucket, "backup-test-default", testID,
+						cloud.AuthParam, cloud.AuthParamImplicit,
+					),
+					User: user,
+				}
+				cloudtestutils.CheckExportStore(t, info)
 			})
 			t.Run("auth-specified", func(t *testing.T) {
-				uri := S3URI(bucket, fmt.Sprintf("backup-test-%d", testID),
-					&cloudpb.ExternalStorage_S3{AccessKey: envCreds.AccessKeyID, Secret: envCreds.SecretAccessKey, Region: "us-east-1"},
-				)
-				cloudtestutils.CheckExportStore(
-					t, uri, false, user, nil /* db */, testSettings,
-				)
+				info := cloudtestutils.StoreInfo{
+					URI: S3URI(
+						bucket, fmt.Sprintf("backup-test-%d", testID),
+						&cloudpb.ExternalStorage_S3{AccessKey: envCreds.AccessKeyID, Secret: envCreds.SecretAccessKey, Region: "us-east-1"},
+					),
+					User: user,
+				}
+				cloudtestutils.CheckExportStore(t, info)
 				cloudtestutils.CheckListFiles(
-					t, uri, user, nil /* db */, testSettings,
+					t, info.URI, info.User, nil /* db */, testSettings,
 				)
 			})
 
 			// Tests that we can put an object with server side encryption specified.
 			t.Run("server-side-encryption", func(t *testing.T) {
 				skipIfNoDefaultConfig(t, ctx)
-				cloudtestutils.CheckExportStore(t, fmt.Sprintf(
-					"s3://%s/%s-%d?%s=%s&%s=%s",
-					bucket, "backup-test-sse-256", testID,
-					cloud.AuthParam, cloud.AuthParamImplicit, AWSServerSideEncryptionMode,
-					"AES256",
-				),
-					false,
-					user,
-					nil, /* db */
-					testSettings,
-				)
-
+				info := cloudtestutils.StoreInfo{
+					URI: fmt.Sprintf(
+						"s3://%s/%s-%d?%s=%s&%s=%s",
+						bucket, "backup-test-sse-256", testID,
+						cloud.AuthParam, cloud.AuthParamImplicit, AWSServerSideEncryptionMode,
+						"AES256",
+					),
+					User: user,
+				}
+				cloudtestutils.CheckExportStore(t, info)
 				v := os.Getenv("AWS_KMS_KEY_ARN")
 				if v == "" {
 					skip.IgnoreLint(t, "AWS_KMS_KEY_ARN env var must be set")
 				}
-				cloudtestutils.CheckExportStore(t, fmt.Sprintf(
+				info.URI = fmt.Sprintf(
 					"s3://%s/%s-%d?%s=%s&%s=%s&%s=%s",
 					bucket, "backup-test-sse-kms", testID,
 					cloud.AuthParam, cloud.AuthParamImplicit, AWSServerSideEncryptionMode,
 					"aws:kms", AWSServerSideEncryptionKMSID, v,
-				),
-					false,
-					user,
-					nil, /* db */
-					testSettings)
+				)
+				cloudtestutils.CheckExportStore(t, info)
 			})
 
 			t.Run("server-side-encryption-invalid-params", func(t *testing.T) {
@@ -197,7 +192,6 @@ func TestPutS3(t *testing.T) {
 				require.True(t, testutils.IsError(err, "AWS_SERVER_KMS_ID param must be set when using aws:kms server side encryption mode."))
 			})
 		})
-
 	}
 }
 
@@ -231,26 +225,28 @@ func TestPutS3AssumeRole(t *testing.T) {
 	ctx := context.Background()
 	t.Run("auth-implicit", func(t *testing.T) {
 		skipIfNoDefaultConfig(t, ctx)
-		uri := S3URI(bucket, testPath,
-			&cloudpb.ExternalStorage_S3{Auth: cloud.AuthParamImplicit, RoleARN: roleArn, Region: "us-east-1"},
-		)
-		cloudtestutils.CheckExportStore(
-			t, uri, false, user, nil /* db */, testSettings,
-		)
+		info := cloudtestutils.StoreInfo{
+			URI: S3URI(bucket, testPath,
+				&cloudpb.ExternalStorage_S3{Auth: cloud.AuthParamImplicit, RoleARN: roleArn, Region: "us-east-1"},
+			),
+			User: user,
+		}
+		cloudtestutils.CheckExportStore(t, info)
 		cloudtestutils.CheckListFiles(
-			t, uri, user, nil /* db */, testSettings,
+			t, info.URI, user, nil /* db */, testSettings,
 		)
 	})
 
 	t.Run("auth-specified", func(t *testing.T) {
-		uri := S3URI(bucket, testPath,
-			&cloudpb.ExternalStorage_S3{Auth: cloud.AuthParamSpecified, RoleARN: roleArn, AccessKey: creds.AccessKeyID, Secret: creds.SecretAccessKey, Region: "us-east-1"},
-		)
-		cloudtestutils.CheckExportStore(
-			t, uri, false, user, nil /* db */, testSettings,
-		)
+		info := cloudtestutils.StoreInfo{
+			URI: S3URI(bucket, testPath,
+				&cloudpb.ExternalStorage_S3{Auth: cloud.AuthParamSpecified, RoleARN: roleArn, AccessKey: creds.AccessKeyID, Secret: creds.SecretAccessKey, Region: "us-east-1"},
+			),
+			User: user,
+		}
+		cloudtestutils.CheckExportStore(t, info)
 		cloudtestutils.CheckListFiles(
-			t, uri, user, nil /* db */, testSettings,
+			t, info.URI, user, nil /* db */, testSettings,
 		)
 	})
 
@@ -295,22 +291,25 @@ func TestPutS3AssumeRole(t *testing.T) {
 					delegatesWithoutID = append(delegatesWithoutID, cloudpb.ExternalStorage_AssumeRoleProvider{Role: p.Role})
 				}
 
-				uri := S3URI(bucket, testPath,
-					&cloudpb.ExternalStorage_S3{
-						Auth:                  tc.auth,
-						AssumeRoleProvider:    roleWithoutID,
-						DelegateRoleProviders: delegatesWithoutID,
-						AccessKey:             tc.accessKey,
-						Secret:                tc.secretKey,
-						Region:                "us-east-1",
-					},
-				)
+				info := cloudtestutils.StoreInfo{
+					URI: S3URI(bucket, testPath,
+						&cloudpb.ExternalStorage_S3{
+							Auth:                  tc.auth,
+							AssumeRoleProvider:    roleWithoutID,
+							DelegateRoleProviders: delegatesWithoutID,
+							AccessKey:             tc.accessKey,
+							Secret:                tc.secretKey,
+							Region:                "us-east-1",
+						},
+					),
+					User: user,
+				}
 				cloudtestutils.CheckNoPermission(
-					t, uri, user, nil /* db */, testSettings,
+					t, info.URI, user, nil /* db */, testSettings,
 				)
 
 				// Finally, check that the chain of roles can be used to access the storage.
-				uri = S3URI(bucket, testPath,
+				info.URI = S3URI(bucket, testPath,
 					&cloudpb.ExternalStorage_S3{
 						Auth:                  tc.auth,
 						AssumeRoleProvider:    providerChain[len(providerChain)-1],
@@ -321,9 +320,7 @@ func TestPutS3AssumeRole(t *testing.T) {
 					},
 				)
 
-				cloudtestutils.CheckExportStore(
-					t, uri, false, user, nil /* db */, testSettings,
-				)
+				cloudtestutils.CheckExportStore(t, info)
 			})
 		}
 	})
@@ -363,11 +360,11 @@ func TestPutS3Endpoint(t *testing.T) {
 			RawQuery: q.Encode(),
 		}
 
-		testSettings := cluster.MakeTestingClusterSettings()
-
-		cloudtestutils.CheckExportStore(
-			t, u.String(), false, user, nil /* db */, testSettings,
-		)
+		info := cloudtestutils.StoreInfo{
+			URI:  u.String(),
+			User: user,
+		}
+		cloudtestutils.CheckExportStore(t, info)
 	})
 	t.Run("use-path-style", func(t *testing.T) {
 		// EngFlow machines have no internet access, and queries even to localhost will time out.

--- a/pkg/cloud/azure/azure_storage_test.go
+++ b/pkg/cloud/azure/azure_storage_test.go
@@ -263,7 +263,6 @@ func TestAzureStorageFileImplicitAuth(t *testing.T) {
 		skip.IgnoreLint(t, "Test not configured for Azure")
 		return
 	}
-	testSettings := cluster.MakeTestingClusterSettings()
 	testID := cloudtestutils.NewTestID()
 
 	cleanup := envutil.TestSetEnv(t, "AZURE_CLIENT_ID", "")
@@ -272,8 +271,11 @@ func TestAzureStorageFileImplicitAuth(t *testing.T) {
 	testPath := fmt.Sprintf("backup-test-%d", testID)
 	testListPath := fmt.Sprintf("listing-test-%d", testID)
 
-	cloudtestutils.CheckNoPermission(t, cfg.filePathImplicitAuth(testPath), username.RootUserName(),
-		nil /*db*/, testSettings)
+	info := cloudtestutils.StoreInfo{
+		URI:  cfg.filePathImplicitAuth(testPath),
+		User: username.RootUserName(),
+	}
+	cloudtestutils.CheckNoPermission(t, info)
 
 	tmpDir, cleanup2 := testutils.TempDir(t)
 	defer cleanup2()
@@ -284,10 +286,6 @@ func TestAzureStorageFileImplicitAuth(t *testing.T) {
 	cleanup3 := envutil.TestSetEnv(t, "COCKROACH_AZURE_APPLICATION_CREDENTIALS_FILE", credFile)
 	defer cleanup3()
 
-	info := cloudtestutils.StoreInfo{
-		URI:  cfg.filePathImplicitAuth(testPath),
-		User: username.RootUserName(),
-	}
 	cloudtestutils.CheckExportStore(t, info)
 	info.URI = cfg.filePathImplicitAuth(testListPath)
 	cloudtestutils.CheckListFiles(t, info)

--- a/pkg/cloud/azure/azure_storage_test.go
+++ b/pkg/cloud/azure/azure_storage_test.go
@@ -104,7 +104,6 @@ func TestAzure(t *testing.T) {
 		skip.IgnoreLint(t, "Test not configured for Azure")
 		return
 	}
-	testSettings := cluster.MakeTestingClusterSettings()
 	testID := cloudtestutils.NewTestID()
 	testPath := fmt.Sprintf("backup-test-%d", testID)
 	testListPath := fmt.Sprintf("listing-test-%d", testID)
@@ -114,29 +113,20 @@ func TestAzure(t *testing.T) {
 		User: username.RootUserName(),
 	}
 	cloudtestutils.CheckExportStore(t, info)
-	cloudtestutils.CheckListFiles(t, cfg.filePath(testListPath),
-		username.RootUserName(),
-		nil, /* db */
-		testSettings,
-	)
+	info.URI = cfg.filePath(testListPath)
+	cloudtestutils.CheckListFiles(t, info)
 
 	// Client Secret auth
 	info.URI = cfg.filePathClientAuth(testPath)
 	cloudtestutils.CheckExportStore(t, info)
-	cloudtestutils.CheckListFiles(t, cfg.filePathClientAuth(testListPath),
-		username.RootUserName(),
-		nil, /* db */
-		testSettings,
-	)
+	info.URI = cfg.filePathClientAuth(testListPath)
+	cloudtestutils.CheckListFiles(t, info)
 
 	// Implicit auth
 	info.URI = cfg.filePathImplicitAuth(testPath)
 	cloudtestutils.CheckExportStore(t, info)
-	cloudtestutils.CheckListFiles(t, cfg.filePathImplicitAuth(testListPath),
-		username.RootUserName(),
-		nil, /* db */
-		testSettings,
-	)
+	info.URI = cfg.filePathImplicitAuth(testListPath)
+	cloudtestutils.CheckListFiles(t, info)
 }
 
 func TestAzureSchemes(t *testing.T) {
@@ -298,11 +288,7 @@ func TestAzureStorageFileImplicitAuth(t *testing.T) {
 		URI:  cfg.filePathImplicitAuth(testPath),
 		User: username.RootUserName(),
 	}
-
 	cloudtestutils.CheckExportStore(t, info)
-	cloudtestutils.CheckListFiles(t, cfg.filePathImplicitAuth(testListPath),
-		username.RootUserName(),
-		nil, /* db */
-		testSettings,
-	)
+	info.URI = cfg.filePathImplicitAuth(testListPath)
+	cloudtestutils.CheckListFiles(t, info)
 }

--- a/pkg/cloud/azure/azure_storage_test.go
+++ b/pkg/cloud/azure/azure_storage_test.go
@@ -109,11 +109,11 @@ func TestAzure(t *testing.T) {
 	testPath := fmt.Sprintf("backup-test-%d", testID)
 	testListPath := fmt.Sprintf("listing-test-%d", testID)
 
-	cloudtestutils.CheckExportStore(t, cfg.filePath(testPath),
-		false, username.RootUserName(),
-		nil, /* db */
-		testSettings,
-	)
+	info := cloudtestutils.StoreInfo{
+		URI:  cfg.filePath(testPath),
+		User: username.RootUserName(),
+	}
+	cloudtestutils.CheckExportStore(t, info)
 	cloudtestutils.CheckListFiles(t, cfg.filePath(testListPath),
 		username.RootUserName(),
 		nil, /* db */
@@ -121,11 +121,8 @@ func TestAzure(t *testing.T) {
 	)
 
 	// Client Secret auth
-	cloudtestutils.CheckExportStore(t, cfg.filePathClientAuth(testPath),
-		false, username.RootUserName(),
-		nil, /* db */
-		testSettings,
-	)
+	info.URI = cfg.filePathClientAuth(testPath)
+	cloudtestutils.CheckExportStore(t, info)
 	cloudtestutils.CheckListFiles(t, cfg.filePathClientAuth(testListPath),
 		username.RootUserName(),
 		nil, /* db */
@@ -133,11 +130,8 @@ func TestAzure(t *testing.T) {
 	)
 
 	// Implicit auth
-	cloudtestutils.CheckExportStore(t, cfg.filePathImplicitAuth(testPath),
-		false, username.RootUserName(),
-		nil, /* db */
-		testSettings,
-	)
+	info.URI = cfg.filePathImplicitAuth(testPath)
+	cloudtestutils.CheckExportStore(t, info)
 	cloudtestutils.CheckListFiles(t, cfg.filePathImplicitAuth(testListPath),
 		username.RootUserName(),
 		nil, /* db */
@@ -300,11 +294,12 @@ func TestAzureStorageFileImplicitAuth(t *testing.T) {
 	cleanup3 := envutil.TestSetEnv(t, "COCKROACH_AZURE_APPLICATION_CREDENTIALS_FILE", credFile)
 	defer cleanup3()
 
-	cloudtestutils.CheckExportStore(t, cfg.filePathImplicitAuth(testPath),
-		false, username.RootUserName(),
-		nil, /* db */
-		testSettings,
-	)
+	info := cloudtestutils.StoreInfo{
+		URI:  cfg.filePathImplicitAuth(testPath),
+		User: username.RootUserName(),
+	}
+
+	cloudtestutils.CheckExportStore(t, info)
 	cloudtestutils.CheckListFiles(t, cfg.filePathImplicitAuth(testListPath),
 		username.RootUserName(),
 		nil, /* db */

--- a/pkg/cloud/gcp/gcs_storage_test.go
+++ b/pkg/cloud/gcp/gcs_storage_test.go
@@ -58,14 +58,11 @@ func TestPutGoogleCloud(t *testing.T) {
 		if specified {
 			uri += fmt.Sprintf("&%s=%s", cloud.AuthParam, cloud.AuthParamSpecified)
 		}
-		cloudtestutils.CheckExportStore(
-			t,
-			uri,
-			false,
-			user,
-			nil, /* db */
-			testSettings,
-		)
+		info := cloudtestutils.StoreInfo{
+			URI:  uri,
+			User: user,
+		}
+		cloudtestutils.CheckExportStore(t, info)
 		cloudtestutils.CheckListFiles(t, fmt.Sprintf("gs://%s/%s-%d/%s?%s=%s&%s=%s",
 			bucket,
 			"backup-test-specified",
@@ -84,15 +81,12 @@ func TestPutGoogleCloud(t *testing.T) {
 		if !cloudtestutils.IsImplicitAuthConfigured() {
 			skip.IgnoreLint(t, "implicit auth is not configured")
 		}
-
-		cloudtestutils.CheckExportStore(
-			t,
-			fmt.Sprintf("gs://%s/%s-%d?%s=%s", bucket, "backup-test-implicit", testID,
+		info := cloudtestutils.StoreInfo{
+			URI: fmt.Sprintf("gs://%s/%s-%d?%s=%s", bucket, "backup-test-implicit", testID,
 				cloud.AuthParam, cloud.AuthParamImplicit),
-			false,
-			user,
-			nil, /* db */
-			testSettings)
+			User: user,
+		}
+		cloudtestutils.CheckExportStore(t, info)
 		cloudtestutils.CheckListFiles(t, fmt.Sprintf("gs://%s/%s-%d/%s?%s=%s",
 			bucket,
 			"backup-test-implicit",
@@ -128,13 +122,11 @@ func TestPutGoogleCloud(t *testing.T) {
 			token.AccessToken,
 		)
 		uri += fmt.Sprintf("&%s=%s", cloud.AuthParam, cloud.AuthParamSpecified)
-		cloudtestutils.CheckExportStore(
-			t,
-			uri,
-			false,
-			user,
-			nil, /* db */
-			testSettings)
+		info := cloudtestutils.StoreInfo{
+			URI:  uri,
+			User: user,
+		}
+		cloudtestutils.CheckExportStore(t, info)
 		cloudtestutils.CheckListFiles(t, fmt.Sprintf("gs://%s/%s-%d/%s?%s=%s&%s=%s",
 			bucket,
 			"backup-test-specified",
@@ -181,9 +173,8 @@ func TestGCSAssumeRole(t *testing.T) {
 			testSettings,
 		)
 
-		cloudtestutils.CheckExportStore(
-			t,
-			fmt.Sprintf("gs://%s/%s-%d?%s=%s&%s=%s&%s=%s",
+		info := cloudtestutils.StoreInfo{
+			URI: fmt.Sprintf("gs://%s/%s-%d?%s=%s&%s=%s&%s=%s",
 				limitedBucket,
 				"backup-test-assume-role",
 				testID,
@@ -192,10 +183,10 @@ func TestGCSAssumeRole(t *testing.T) {
 				AssumeRoleParam,
 				assumedAccount, CredentialsParam,
 				url.QueryEscape(encoded),
-			), false, user,
-			nil, /* db */
-			testSettings,
-		)
+			),
+			User: user,
+		}
+		cloudtestutils.CheckExportStore(t, info)
 		cloudtestutils.CheckListFiles(t, fmt.Sprintf("gs://%s/%s-%d/%s?%s=%s&%s=%s&%s=%s",
 			limitedBucket,
 			"backup-test-assume-role",
@@ -226,11 +217,14 @@ func TestGCSAssumeRole(t *testing.T) {
 			testSettings,
 		)
 
-		cloudtestutils.CheckExportStore(t, fmt.Sprintf("gs://%s/%s-%d?%s=%s&%s=%s", limitedBucket, "backup-test-assume-role", testID,
-			cloud.AuthParam, cloud.AuthParamImplicit, AssumeRoleParam, assumedAccount), false, user,
-			nil, /* db */
-			testSettings,
-		)
+		info := cloudtestutils.StoreInfo{
+			URI: fmt.Sprintf(
+				"gs://%s/%s-%d?%s=%s&%s=%s", limitedBucket, "backup-test-assume-role", testID,
+				cloud.AuthParam, cloud.AuthParamImplicit, AssumeRoleParam, assumedAccount,
+			),
+			User: user,
+		}
+		cloudtestutils.CheckExportStore(t, info)
 		cloudtestutils.CheckListFiles(t, fmt.Sprintf("gs://%s/%s-%d/%s?%s=%s&%s=%s",
 			limitedBucket,
 			"backup-test-assume-role",
@@ -291,18 +285,18 @@ func TestGCSAssumeRole(t *testing.T) {
 
 				// Finally, check that the chain of roles can be used to access the storage.
 				q.Set(AssumeRoleParam, roleChainStr)
-				uri := fmt.Sprintf("gs://%s/%s-%d/%s?%s",
-					limitedBucket,
-					"backup-test-assume-role",
-					testID,
-					"listing-test",
-					q.Encode(),
-				)
-				cloudtestutils.CheckExportStore(t, uri, false, user,
-					nil, /* db */
-					testSettings,
-				)
-				cloudtestutils.CheckListFiles(t, uri, user,
+				info := cloudtestutils.StoreInfo{
+					URI: fmt.Sprintf("gs://%s/%s-%d/%s?%s",
+						limitedBucket,
+						"backup-test-assume-role",
+						testID,
+						"listing-test",
+						q.Encode(),
+					),
+					User: user,
+				}
+				cloudtestutils.CheckExportStore(t, info)
+				cloudtestutils.CheckListFiles(t, info.URI, user,
 					nil, /* db */
 					testSettings,
 				)

--- a/pkg/cloud/gcp/gcs_storage_test.go
+++ b/pkg/cloud/gcp/gcs_storage_test.go
@@ -39,7 +39,6 @@ func TestPutGoogleCloud(t *testing.T) {
 	}
 
 	user := username.RootUserName()
-	testSettings := cluster.MakeTestingClusterSettings()
 	testID := cloudtestutils.NewTestID()
 
 	testutils.RunTrueAndFalse(t, "auth-specified-with-auth-param", func(t *testing.T, specified bool) {
@@ -63,19 +62,20 @@ func TestPutGoogleCloud(t *testing.T) {
 			User: user,
 		}
 		cloudtestutils.CheckExportStore(t, info)
-		cloudtestutils.CheckListFiles(t, fmt.Sprintf("gs://%s/%s-%d/%s?%s=%s&%s=%s",
-			bucket,
-			"backup-test-specified",
-			testID,
-			"listing-test",
-			cloud.AuthParam,
-			cloud.AuthParamSpecified,
-			CredentialsParam,
-			url.QueryEscape(encoded),
-		), username.RootUserName(),
-			nil, /* db */
-			testSettings,
-		)
+		info = cloudtestutils.StoreInfo{
+			URI: fmt.Sprintf("gs://%s/%s-%d/%s?%s=%s&%s=%s",
+				bucket,
+				"backup-test-specified",
+				testID,
+				"listing-test",
+				cloud.AuthParam,
+				cloud.AuthParamSpecified,
+				CredentialsParam,
+				url.QueryEscape(encoded),
+			),
+			User: username.RootUserName(),
+		}
+		cloudtestutils.CheckListFiles(t, info)
 	})
 	t.Run("auth-implicit", func(t *testing.T) {
 		if !cloudtestutils.IsImplicitAuthConfigured() {
@@ -87,17 +87,18 @@ func TestPutGoogleCloud(t *testing.T) {
 			User: user,
 		}
 		cloudtestutils.CheckExportStore(t, info)
-		cloudtestutils.CheckListFiles(t, fmt.Sprintf("gs://%s/%s-%d/%s?%s=%s",
-			bucket,
-			"backup-test-implicit",
-			testID,
-			"listing-test",
-			cloud.AuthParam,
-			cloud.AuthParamImplicit,
-		), username.RootUserName(),
-			nil, /* db */
-			testSettings,
-		)
+		info = cloudtestutils.StoreInfo{
+			URI: fmt.Sprintf("gs://%s/%s-%d/%s?%s=%s",
+				bucket,
+				"backup-test-implicit",
+				testID,
+				"listing-test",
+				cloud.AuthParam,
+				cloud.AuthParamImplicit,
+			),
+			User: username.RootUserName(),
+		}
+		cloudtestutils.CheckListFiles(t, info)
 	})
 
 	t.Run("auth-specified-bearer-token", func(t *testing.T) {
@@ -127,19 +128,20 @@ func TestPutGoogleCloud(t *testing.T) {
 			User: user,
 		}
 		cloudtestutils.CheckExportStore(t, info)
-		cloudtestutils.CheckListFiles(t, fmt.Sprintf("gs://%s/%s-%d/%s?%s=%s&%s=%s",
-			bucket,
-			"backup-test-specified",
-			testID,
-			"listing-test",
-			cloud.AuthParam,
-			cloud.AuthParamSpecified,
-			BearerTokenParam,
-			token.AccessToken,
-		), username.RootUserName(),
-			nil, /* db */
-			testSettings,
-		)
+		info = cloudtestutils.StoreInfo{
+			URI: fmt.Sprintf("gs://%s/%s-%d/%s?%s=%s&%s=%s",
+				bucket,
+				"backup-test-specified",
+				testID,
+				"listing-test",
+				cloud.AuthParam,
+				cloud.AuthParamSpecified,
+				BearerTokenParam,
+				token.AccessToken,
+			),
+			User: username.RootUserName(),
+		}
+		cloudtestutils.CheckListFiles(t, info)
 	})
 }
 
@@ -187,21 +189,22 @@ func TestGCSAssumeRole(t *testing.T) {
 			User: user,
 		}
 		cloudtestutils.CheckExportStore(t, info)
-		cloudtestutils.CheckListFiles(t, fmt.Sprintf("gs://%s/%s-%d/%s?%s=%s&%s=%s&%s=%s",
-			limitedBucket,
-			"backup-test-assume-role",
-			testID,
-			"listing-test",
-			cloud.AuthParam,
-			cloud.AuthParamSpecified,
-			AssumeRoleParam,
-			assumedAccount,
-			CredentialsParam,
-			url.QueryEscape(encoded),
-		), username.RootUserName(),
-			nil, /* db */
-			testSettings,
-		)
+		info = cloudtestutils.StoreInfo{
+			URI: fmt.Sprintf("gs://%s/%s-%d/%s?%s=%s&%s=%s&%s=%s",
+				limitedBucket,
+				"backup-test-assume-role",
+				testID,
+				"listing-test",
+				cloud.AuthParam,
+				cloud.AuthParamSpecified,
+				AssumeRoleParam,
+				assumedAccount,
+				CredentialsParam,
+				url.QueryEscape(encoded),
+			),
+			User: username.RootUserName(),
+		}
+		cloudtestutils.CheckListFiles(t, info)
 	})
 
 	t.Run("implicit", func(t *testing.T) {
@@ -225,7 +228,7 @@ func TestGCSAssumeRole(t *testing.T) {
 			User: user,
 		}
 		cloudtestutils.CheckExportStore(t, info)
-		cloudtestutils.CheckListFiles(t, fmt.Sprintf("gs://%s/%s-%d/%s?%s=%s&%s=%s",
+		info.URI = fmt.Sprintf("gs://%s/%s-%d/%s?%s=%s&%s=%s",
 			limitedBucket,
 			"backup-test-assume-role",
 			testID,
@@ -234,10 +237,8 @@ func TestGCSAssumeRole(t *testing.T) {
 			cloud.AuthParamImplicit,
 			AssumeRoleParam,
 			assumedAccount,
-		), username.RootUserName(),
-			nil, /* db */
-			testSettings,
 		)
+		cloudtestutils.CheckListFiles(t, info)
 	})
 
 	t.Run("role-chaining", func(t *testing.T) {
@@ -296,10 +297,7 @@ func TestGCSAssumeRole(t *testing.T) {
 					User: user,
 				}
 				cloudtestutils.CheckExportStore(t, info)
-				cloudtestutils.CheckListFiles(t, info.URI, user,
-					nil, /* db */
-					testSettings,
-				)
+				cloudtestutils.CheckListFiles(t, info)
 			})
 		}
 	})

--- a/pkg/cloud/httpsink/http_storage_test.go
+++ b/pkg/cloud/httpsink/http_storage_test.go
@@ -116,10 +116,12 @@ func TestPutHttp(t *testing.T) {
 	t.Run("singleHost", func(t *testing.T) {
 		srv, files, cleanup := makeServer()
 		defer cleanup()
-		cloudtestutils.CheckExportStore(t, srv.String(), false, user,
-			nil, /* db */
-			testSettings,
-		)
+		info := cloudtestutils.StoreInfo{
+			URI:          srv.String(),
+			User:         user,
+			TestSettings: testSettings,
+		}
+		cloudtestutils.CheckExportStore(t, info)
 		if expected, actual := 14, files(); expected != actual {
 			t.Fatalf("expected %d files to be written to single http store, got %d", expected, actual)
 		}
@@ -136,10 +138,12 @@ func TestPutHttp(t *testing.T) {
 		combined := *srv1
 		combined.Host = strings.Join([]string{srv1.Host, srv2.Host, srv3.Host}, ",")
 
-		cloudtestutils.CheckExportStore(t, combined.String(), true, user,
-			nil, /* db */
-			testSettings,
-		)
+		info := cloudtestutils.StoreInfo{
+			URI:          combined.String(),
+			User:         user,
+			TestSettings: testSettings,
+		}
+		cloudtestutils.CheckExportStoreSkipSingleFile(t, info)
 		if expected, actual := 3, files1(); expected != actual {
 			t.Fatalf("expected %d files written to http host 1, got %d", expected, actual)
 		}

--- a/pkg/cloud/nodelocal/BUILD.bazel
+++ b/pkg/cloud/nodelocal/BUILD.bazel
@@ -36,7 +36,6 @@ go_test(
     deps = [
         "//pkg/cloud/cloudtestutils",
         "//pkg/security/username",
-        "//pkg/settings/cluster",
         "//pkg/testutils",
         "//pkg/util/leaktest",
     ],

--- a/pkg/cloud/nodelocal/nodelocal_storage_test.go
+++ b/pkg/cloud/nodelocal/nodelocal_storage_test.go
@@ -25,8 +25,12 @@ func TestPutLocal(t *testing.T) {
 	testSettings.ExternalIODir = p
 	dest := MakeLocalStorageURI(p)
 
-	cloudtestutils.CheckExportStore(
-		t, dest, false, username.RootUserName(), nil /* db */, testSettings)
+	info := cloudtestutils.StoreInfo{
+		URI:           dest,
+		User:          username.RootUserName(),
+		ExternalIODir: p,
+	}
+	cloudtestutils.CheckExportStore(t, info)
 	url := "nodelocal://1/listing-test/basepath"
 	cloudtestutils.CheckListFiles(
 		t, url, username.RootUserName(), nil /*db */, testSettings,

--- a/pkg/cloud/nodelocal/nodelocal_storage_test.go
+++ b/pkg/cloud/nodelocal/nodelocal_storage_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/cloud/cloudtestutils"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
-	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 )
@@ -21,8 +20,6 @@ func TestPutLocal(t *testing.T) {
 	p, cleanupFn := testutils.TempDir(t)
 	defer cleanupFn()
 
-	testSettings := cluster.MakeTestingClusterSettings()
-	testSettings.ExternalIODir = p
 	dest := MakeLocalStorageURI(p)
 
 	info := cloudtestutils.StoreInfo{
@@ -31,8 +28,6 @@ func TestPutLocal(t *testing.T) {
 		ExternalIODir: p,
 	}
 	cloudtestutils.CheckExportStore(t, info)
-	url := "nodelocal://1/listing-test/basepath"
-	cloudtestutils.CheckListFiles(
-		t, url, username.RootUserName(), nil /*db */, testSettings,
-	)
+	info.URI = "nodelocal://1/listing-test/basepath"
+	cloudtestutils.CheckListFiles(t, info)
 }

--- a/pkg/cloud/userfile/file_table_storage_test.go
+++ b/pkg/cloud/userfile/file_table_storage_test.go
@@ -44,15 +44,19 @@ func TestPutUserFileTable(t *testing.T) {
 	dest := userfile.MakeUserFileStorageURI(qualifiedTableName, filename)
 
 	db := s.InternalDB().(isql.DB)
-	cloudtestutils.CheckExportStore(t, dest, false, username.RootUserName(), db, testSettings)
+	info := cloudtestutils.StoreInfo{
+		URI:  dest,
+		User: username.RootUserName(),
+		DB:   db,
+	}
+	cloudtestutils.CheckExportStore(t, info)
 
 	cloudtestutils.CheckListFiles(t, "userfile://defaultdb.public.file_list_table/listing-test/basepath",
 		username.RootUserName(), db, testSettings)
 
 	t.Run("empty-qualified-table-name", func(t *testing.T) {
-		dest := userfile.MakeUserFileStorageURI("", filename)
-
-		cloudtestutils.CheckExportStore(t, dest, false, username.RootUserName(), db, testSettings)
+		info.URI = userfile.MakeUserFileStorageURI("", filename)
+		cloudtestutils.CheckExportStore(t, info)
 
 		cloudtestutils.CheckListFilesCanonical(t, "userfile:///listing-test/basepath", "userfile://defaultdb.public.userfiles_root/listing-test/basepath",
 			username.RootUserName(), db, testSettings)

--- a/pkg/cloud/userfile/file_table_storage_test.go
+++ b/pkg/cloud/userfile/file_table_storage_test.go
@@ -39,7 +39,6 @@ func TestPutUserFileTable(t *testing.T) {
 	srv := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer srv.Stopper().Stop(ctx)
 	s := srv.ApplicationLayer()
-	testSettings := s.ClusterSettings()
 
 	dest := userfile.MakeUserFileStorageURI(qualifiedTableName, filename)
 
@@ -51,15 +50,15 @@ func TestPutUserFileTable(t *testing.T) {
 	}
 	cloudtestutils.CheckExportStore(t, info)
 
-	cloudtestutils.CheckListFiles(t, "userfile://defaultdb.public.file_list_table/listing-test/basepath",
-		username.RootUserName(), db, testSettings)
+	info.URI = "userfile://defaultdb.public.file_list_table/listing-test/basepath"
+	cloudtestutils.CheckListFiles(t, info)
 
 	t.Run("empty-qualified-table-name", func(t *testing.T) {
 		info.URI = userfile.MakeUserFileStorageURI("", filename)
 		cloudtestutils.CheckExportStore(t, info)
 
-		cloudtestutils.CheckListFilesCanonical(t, "userfile:///listing-test/basepath", "userfile://defaultdb.public.userfiles_root/listing-test/basepath",
-			username.RootUserName(), db, testSettings)
+		info.URI = "userfile:///listing-test/basepath"
+		cloudtestutils.CheckListFilesCanonical(t, info, "userfile://defaultdb.public.userfiles_root/listing-test/basepath")
 	})
 
 	t.Run("reject-normalized-basename", func(t *testing.T) {


### PR DESCRIPTION
This PR is taking a first step towards removing `ExternalIODir` from `cluster.Settings`.

#### cloudtestutils: refactor CheckExportStore

This change adds a `cloudtestutils.StoreInfo` structure and refactors
`CheckExportStore` to use it, making the call sites simpler and more
readable. We now pass the external IO dir explicitly through
`StoreInfo` instead of getting it from the settings.

Epic: none
Release note: None

#### cloudtestutils: refactor CheckListFiles

Refactor `CheckListFiles` and `CheckListFilesCanonical` to use
`StoreInfo`.

Epic: none
Release note: None

#### cloudtestutils: refactor CheckNoPermissions

Use `StoreInfo` for `CheckNoPermissions.`

Epic: none
Release note: None
