### PR TITLE
settings: move ExternalIODir

### DIFF
--- a/pkg/backup/backup_test.go
+++ b/pkg/backup/backup_test.go
@@ -4723,7 +4723,7 @@ func TestRestoreDatabaseVersusTable(t *testing.T) {
 	tc, origDB, _, cleanupFn := backupRestoreTestSetup(t, singleNode, numAccounts, InitManualReplication)
 	defer cleanupFn()
 	s := tc.ApplicationLayer(0)
-	args := base.TestServerArgs{ExternalIODir: s.ClusterSettings().ExternalIODir}
+	args := base.TestServerArgs{ExternalIODir: s.ExternalIODir()}
 
 	for _, q := range []string{
 		`CREATE DATABASE d2`,

--- a/pkg/backup/restore_data_processor_test.go
+++ b/pkg/backup/restore_data_processor_test.go
@@ -261,7 +261,7 @@ func runTestIngest(t *testing.T, init func(*cluster.Settings)) {
 			DB: s.InternalDB().(descs.DB),
 			ExternalStorage: func(ctx context.Context, dest cloudpb.ExternalStorage, opts ...cloud.ExternalStorageOption) (cloud.ExternalStorage, error) {
 				return cloud.MakeExternalStorage(ctx, dest, base.ExternalIODirConfig{},
-					s.ClusterSettings(), blobs.TestBlobServiceClient(s.ClusterSettings().ExternalIODir),
+					s.ClusterSettings(), blobs.TestBlobServiceClient(args.ExternalIODir),
 					nil, /* db */
 					nil, /* limiters */
 					cloud.NilMetrics,

--- a/pkg/base/test_server_args.go
+++ b/pkg/base/test_server_args.go
@@ -89,12 +89,13 @@ type TestServerArgs struct {
 	// If not initialized, will default to DefaultTestTempStorageConfig.
 	TempStorageConfig TempStorageConfig
 
-	// ExternalIODir is used to initialize field in cluster.Settings.
-	ExternalIODir string
-
 	// ExternalIODirConfig is used to initialize the same-named
 	// field on the server.Config struct.
 	ExternalIODirConfig ExternalIODirConfig
+
+	// ExternalIODir is used to initialize the same-named field on
+	// the server.Config struct.
+	ExternalIODir string
 
 	// Fields copied to the server.Config.
 	Insecure                    bool
@@ -578,7 +579,7 @@ type TestTenantArgs struct {
 	ExternalIODirConfig ExternalIODirConfig
 
 	// ExternalIODir is used to initialize the same-named field on
-	// the params.Settings struct.
+	// the server.Config struct.
 	ExternalIODir string
 
 	// If set, this will be appended to the Postgres URL by functions that

--- a/pkg/ccl/changefeedccl/sink_cloudstorage_test.go
+++ b/pkg/ccl/changefeedccl/sink_cloudstorage_test.go
@@ -158,7 +158,6 @@ func TestCloudStorageSink(t *testing.T) {
 
 	var noKey []byte
 	settings := cluster.MakeTestingClusterSettings()
-	settings.ExternalIODir = externalIODir
 	opts := changefeedbase.EncodingOptions{
 		Format:     changefeedbase.OptFormatJSON,
 		Envelope:   changefeedbase.OptEnvelopeWrapped,
@@ -169,7 +168,7 @@ func TestCloudStorageSink(t *testing.T) {
 	e, err := makeJSONEncoder(ctx, jsonEncoderOptions{EncodingOptions: opts})
 	require.NoError(t, err)
 
-	clientFactory := blobs.TestBlobServiceClient(settings.ExternalIODir)
+	clientFactory := blobs.TestBlobServiceClient(externalIODir)
 	externalStorageFromURI := func(ctx context.Context, uri string, user username.SQLUsername, opts ...cloud.ExternalStorageOption) (cloud.ExternalStorage,
 		error) {
 		var options cloud.ExternalStorageOptions

--- a/pkg/cli/nodelocal_test.go
+++ b/pkg/cli/nodelocal_test.go
@@ -110,7 +110,7 @@ func TestNodeLocalFileUpload(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			writtenContent, err := os.ReadFile(filepath.Join(c.Server.ClusterSettings().ExternalIODir, destination))
+			writtenContent, err := os.ReadFile(filepath.Join(c.Server.ExternalIODir(), destination))
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -604,11 +604,10 @@ func runStartInternal(
 		return errors.Wrapf(err, "failed to initialize %s", serverType)
 	}
 
-	st := serverCfg.BaseConfig.Settings
-
 	// Derive temporary/auxiliary directory specifications.
-	st.ExternalIODir = startCtx.externalIODir
+	serverCfg.ExternalIODir = startCtx.externalIODir
 
+	st := serverCfg.BaseConfig.Settings
 	if serverCfg.SQLConfig.TempStorageConfig, err = initTempStorageConfig(
 		ctx, st, stopper, serverCfg.Stores,
 	); err != nil {
@@ -869,7 +868,7 @@ func createAndStartServerAsync(
 			// Now inform the user that the server is running and tell the
 			// user about its run-time derived parameters.
 			return reportServerInfo(ctx, tBegin, serverCfg, s.ClusterSettings(),
-				serverType, s.InitialStart(), s.LogicalClusterID())
+				serverType, s.InitialStart(), s.LogicalClusterID(), startCtx.externalIODir)
 		}(); err != nil {
 			shutdownReqC <- serverctl.MakeShutdownRequest(
 				serverctl.ShutdownReasonServerStartupError, errors.Wrapf(err, "server startup failed"))
@@ -1183,6 +1182,7 @@ func reportServerInfo(
 	serverType redact.SafeString,
 	initialStart bool,
 	tenantClusterID uuid.UUID,
+	externalIODir string,
 ) error {
 	var buf redact.StringBuilder
 	info := build.GetInfo()
@@ -1227,8 +1227,8 @@ func reportServerInfo(
 	if tmpDir := serverCfg.SQLConfig.TempStorageConfig.Path; tmpDir != "" {
 		buf.Printf("temp dir:\t%s\n", log.SafeManaged(tmpDir))
 	}
-	if ext := st.ExternalIODir; ext != "" {
-		buf.Printf("external I/O path: \t%s\n", log.SafeManaged(ext))
+	if externalIODir != "" {
+		buf.Printf("external I/O path: \t%s\n", log.SafeManaged(externalIODir))
 	} else {
 		buf.Printf("external I/O path: \t<disabled>\n")
 	}

--- a/pkg/cloud/amazon/s3_storage_test.go
+++ b/pkg/cloud/amazon/s3_storage_test.go
@@ -45,9 +45,8 @@ func makeS3Storage(
 	testSettings := cluster.MakeTestingClusterSettings()
 
 	// Setup a sink for the given args.
-	clientFactory := blobs.TestBlobServiceClient(testSettings.ExternalIODir)
 	s, err := cloud.MakeExternalStorage(ctx, conf, base.ExternalIODirConfig{}, testSettings,
-		clientFactory,
+		blobs.TestEmptyBlobClientFactory,
 		nil, /* db */
 		nil, /* limiters */
 		cloud.NilMetrics,
@@ -391,7 +390,7 @@ func TestPutS3Endpoint(t *testing.T) {
 
 		// Setup a sink for the given args.
 		testSettings := cluster.MakeTestingClusterSettings()
-		clientFactory := blobs.TestBlobServiceClient(testSettings.ExternalIODir)
+		clientFactory := blobs.TestBlobServiceClient("")
 
 		storage, err := cloud.MakeExternalStorage(ctx, conf, ioConf, testSettings, clientFactory,
 			nil, nil, cloud.NilMetrics)
@@ -584,8 +583,6 @@ func TestInterpretAWSCode(t *testing.T) {
 func TestS3BucketDoesNotExist(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	testSettings := cluster.MakeTestingClusterSettings()
-
 	ctx := context.Background()
 	skipIfNoDefaultConfig(t, ctx)
 
@@ -610,7 +607,8 @@ func TestS3BucketDoesNotExist(t *testing.T) {
 	}
 
 	// Setup a sink for the given args.
-	clientFactory := blobs.TestBlobServiceClient(testSettings.ExternalIODir)
+	clientFactory := blobs.TestBlobServiceClient("")
+	testSettings := cluster.MakeTestingClusterSettings()
 	s, err := cloud.MakeExternalStorage(ctx, conf, base.ExternalIODirConfig{}, testSettings,
 		clientFactory,
 		nil, /* db */

--- a/pkg/cloud/azure/azure_file_credentials_test.go
+++ b/pkg/cloud/azure/azure_file_credentials_test.go
@@ -158,7 +158,6 @@ func TestAzureFileCredential(t *testing.T) {
 	// reload, there should be no error that bubbles up to the rest of the Azure
 	// SDK and storage.
 	t.Run("reload-on-error", func(t *testing.T) {
-		testSettings := cluster.MakeTestingClusterSettings()
 		ioConf := base.ExternalIODirConfig{}
 		storeURI := cfg.filePathImplicitAuth("backup-test")
 
@@ -183,7 +182,8 @@ func TestAzureFileCredential(t *testing.T) {
 			}
 
 			// Setup a sink for the given args.
-			clientFactory := blobs.TestBlobServiceClient(testSettings.ExternalIODir)
+			clientFactory := blobs.TestBlobServiceClient("")
+			testSettings := cluster.MakeTestingClusterSettings()
 			s, err := cloud.MakeExternalStorage(ctx, conf, ioConf, testSettings, clientFactory,
 				nil, nil, cloud.NilMetrics, cloud.WithAzureStorageTestingKnobs(&knobs))
 			if err != nil {

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -127,8 +127,9 @@ func (mo *MaxOffsetType) String() string {
 // BaseConfig holds parameters that are needed to setup either a KV or a SQL
 // server.
 type BaseConfig struct {
-	Settings *cluster.Settings
 	*base.Config
+
+	Settings *cluster.Settings
 
 	Tracer *tracing.Tracer
 
@@ -278,6 +279,11 @@ type BaseConfig struct {
 
 	// CidrLookup is used to look up the tag name for a given IP address.
 	CidrLookup *cidr.Lookup
+
+	// ExternalIODir is the local file path under which remotely-initiated
+	// operations that can specify node-local I/O paths (such as BACKUP, RESTORE
+	// or IMPORT) can access files.
+	ExternalIODir string
 }
 
 // MakeBaseConfig returns a BaseConfig with default values.

--- a/pkg/server/external_storage_builder.go
+++ b/pkg/server/external_storage_builder.go
@@ -49,13 +49,14 @@ func (e *externalStorageBuilder) init(
 	db isql.DB,
 	recorder multitenant.TenantSideExternalIORecorder,
 	registry *metric.Registry,
+	externalIODir string,
 ) {
 	var blobClientFactory blobs.BlobClientFactory
 	if p, ok := testingKnobs.Server.(*TestingKnobs); ok && p.BlobClientFactory != nil {
 		blobClientFactory = p.BlobClientFactory
 	}
 	if blobClientFactory == nil {
-		blobClientFactory = blobs.NewBlobClientFactory(nodeIDContainer, nodeDialer, settings.ExternalIODir, allowLocalFastpath)
+		blobClientFactory = blobs.NewBlobClientFactory(nodeIDContainer, nodeDialer, externalIODir, allowLocalFastpath)
 	}
 	e.conf = conf
 	e.settings = settings

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -965,7 +965,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (serverctl.ServerStartupInterf
 	ctpb.RegisterSideTransportServer(grpcServer.Server, ctReceiver)
 
 	// Create blob service for inter-node file sharing.
-	blobService, err := blobs.NewBlobService(cfg.Settings.ExternalIODir)
+	blobService, err := blobs.NewBlobService(cfg.ExternalIODir)
 	if err != nil {
 		return nil, errors.Wrap(err, "creating blob service")
 	}
@@ -2080,6 +2080,7 @@ func (s *topLevelServer) PreStart(ctx context.Context) error {
 		s.sqlServer.execCfg.InternalDB.CloneWithMemoryMonitor(sql.MemoryMetrics{}, ieMon),
 		nil, /* TenantExternalIORecorder */
 		s.appRegistry,
+		s.cfg.ExternalIODir,
 	)
 
 	if err := s.runIdempontentSQLForInitType(ctx, state.initType); err != nil {

--- a/pkg/server/server_controller_new_server.go
+++ b/pkg/server/server_controller_new_server.go
@@ -326,8 +326,9 @@ func makeSharedProcessTenantServerConfig(
 	}
 
 	sqlCfg = MakeSQLConfig(tenantID, tempStorageCfg)
-	baseCfg.Settings.ExternalIODir = kvServerCfg.BaseConfig.Settings.ExternalIODir
 	baseCfg.ExternalIODirConfig = kvServerCfg.BaseConfig.ExternalIODirConfig
+
+	baseCfg.ExternalIODir = kvServerCfg.BaseConfig.ExternalIODir
 
 	// Use the internal connector instead of the network.
 	// See: https://github.com/cockroachdb/cockroach/issues/84591

--- a/pkg/server/tenant.go
+++ b/pkg/server/tenant.go
@@ -859,6 +859,7 @@ func (s *SQLServerWrapper) PreStart(ctx context.Context) error {
 			CloneWithMemoryMonitor(sql.MemoryMetrics{}, ieMon),
 		s.costController,
 		s.registry,
+		s.cfg.ExternalIODir,
 	)
 
 	// Start the job scheduler now that the SQL Server and

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -145,7 +145,6 @@ func makeTestConfigFromParams(params base.TestServerArgs) Config {
 		st = cluster.MakeClusterSettings()
 	}
 
-	st.ExternalIODir = params.ExternalIODir
 	tr := params.Tracer
 	if params.Tracer == nil {
 		tr = tracing.NewTracerWithOpt(context.TODO(), tracing.WithClusterSettings(&st.SV), tracing.WithTracingMode(params.TracingDefault))
@@ -166,6 +165,7 @@ func makeTestConfigFromParams(params base.TestServerArgs) Config {
 	cfg.Locality = params.Locality
 	cfg.StartDiagnosticsReporting = params.StartDiagnosticsReporting
 	cfg.DisableSQLServer = params.DisableSQLServer
+	cfg.ExternalIODir = params.ExternalIODir
 	if params.TraceDir != "" {
 		if err := initTraceDir(params.TraceDir); err == nil {
 			cfg.InflightTraceDirName = params.TraceDir
@@ -566,6 +566,11 @@ func (ts *testServer) TestingKnobs() *base.TestingKnobs {
 	return nil
 }
 
+// ExternalIODir is part of the serverutils.ApplicationLayerInterface.
+func (ts *testServer) ExternalIODir() string {
+	return ts.cfg.ExternalIODir
+}
+
 // SQLServerInternal is part of the serverutils.ApplicationLayerInterface.
 func (ts *testServer) SQLServerInternal() interface{} {
 	return ts.sqlServer
@@ -936,6 +941,11 @@ func (t *testTenant) HTTPAddr() string {
 // RPCAddr is part of the serverutils.ApplicationLayerInterface.
 func (t *testTenant) RPCAddr() string {
 	return t.Cfg.Addr
+}
+
+// ExternalIODir is part of the serverutils.ApplicationLayerInterface.
+func (t *testTenant) ExternalIODir() string {
+	return t.Cfg.ExternalIODir
 }
 
 // SQLConn is part of the serverutils.ApplicationLayerInterface.
@@ -1634,7 +1644,6 @@ func (ts *testServer) StartTenant(
 		st = cluster.MakeTestingClusterSettings()
 	}
 
-	st.ExternalIODir = params.ExternalIODir
 	sqlCfg := makeTestSQLConfig(st, params.TenantID)
 	sqlCfg.TenantLoopbackAddr = ts.AdvRPCAddr()
 	if params.MemoryPoolSize != 0 {
@@ -1692,6 +1701,7 @@ func (ts *testServer) StartTenant(
 	baseCfg.CPUProfileDirName = ts.Cfg.BaseConfig.CPUProfileDirName
 	baseCfg.GoroutineDumpDirName = ts.Cfg.BaseConfig.GoroutineDumpDirName
 	baseCfg.ExternalIODirConfig = params.ExternalIODirConfig
+	baseCfg.ExternalIODir = params.ExternalIODir
 
 	// Grant the tenant the default capabilities.
 	if err := ts.grantDefaultTenantCapabilities(ctx, params.TenantID, params.SkipTenantCheck); err != nil {

--- a/pkg/settings/cluster/cluster_settings.go
+++ b/pkg/settings/cluster/cluster_settings.go
@@ -32,8 +32,6 @@ type Settings struct {
 	// overwriting the default of a single setting.
 	Manual atomic.Value // bool
 
-	ExternalIODir string
-
 	// Tracks whether a CPU profile is going on and if so, which kind. See
 	// CPUProfileType().
 	// This is used so that we can enable "non-cheap" instrumentation only when it
@@ -174,9 +172,7 @@ func MakeTestingClusterSettingsWithVersions(
 // be used for settings objects that are passed as initial parameters for test
 // clusters; the given Settings object should not be in use by any server.
 func TestingCloneClusterSettings(st *Settings) *Settings {
-	result := &Settings{
-		ExternalIODir: st.ExternalIODir,
-	}
+	result := &Settings{}
 	result.Version = clusterversion.MakeVersionHandle(
 		&result.SV, st.Version.LatestVersion(), st.Version.MinSupportedVersion(),
 	)

--- a/pkg/testutils/serverutils/api.go
+++ b/pkg/testutils/serverutils/api.go
@@ -321,6 +321,9 @@ type ApplicationLayerInterface interface {
 	// TestingKnobs returns the TestingKnobs in use by the test server.
 	TestingKnobs() *base.TestingKnobs
 
+	// ExternalIODir returns ExternalIODir form the server config.
+	ExternalIODir() string
+
 	// SQLServerInternal returns the *server.SQLServer as an interface{}
 	// Note: most tests should use SQLServer() and InternalExecutor() instead.
 	SQLServerInternal() interface{}


### PR DESCRIPTION
Move the `ExternalIODir` field from `cluster.Settings` to the server
config.

Epic: none
Release note: None