### PR TITLE
opt: reduce allocations when filtering histogram buckets

### DIFF
--- a/pkg/sql/opt/props/histogram_test.go
+++ b/pkg/sql/opt/props/histogram_test.go
@@ -438,8 +438,8 @@ func TestFilterBucket(t *testing.T) {
 		// the second bucket.
 		iter.setIdx(1)
 		b := getFilteredBucket(&iter, &keyCtx, span, colOffset)
-		roundBucket(b)
-		return b, nil
+		roundBucket(&b)
+		return &b, nil
 	}
 
 	runTest := func(h *Histogram, testData []testCase, colOffset int, typs ...types.Family) {


### PR DESCRIPTION
`cat.HistogramBuckets` are now returned and passed by value in
`getFilteredBucket` and `(*Histogram).addBucket`, respectively,
eliminating some heap allocations.

Also, two allocations when building spans from buckets via the
`spanBuilder` have been combined into one. The new `(*spanBuilder).init`
method simplifies the API by no longer requiring that prefix datums are
passed to every invocation of `makeSpanFromBucket`. This also reduces
redundant copying of the prefix.

Epic: None

Release note: None
