### PR TITLE
drtprod: script to decommission dead nodes

### DIFF
--- a/pkg/cmd/drtprod/configs/drt_large.yaml
+++ b/pkg/cmd/drtprod/configs/drt_large.yaml
@@ -85,6 +85,7 @@ targets:
           - --
           - -e
           - "ALTER RANGE default CONFIGURE ZONE USING num_replicas=5,num_voters=5"
+      - script: "pkg/cmd/drtprod/scripts/create_decommission_node.sh"
   - target_name: $WORKLOAD_CLUSTER
     steps:
       - command: create

--- a/pkg/cmd/drtprod/scripts/create_decommission_node.sh
+++ b/pkg/cmd/drtprod/scripts/create_decommission_node.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+# Copyright 2025 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+# This creates a script that runs decommission for the dead nodes at 5AM everyday
+
+if [ -z "${CLUSTER}" ]; then
+  echo "environment CLUSTER is not set"
+  exit 1
+fi
+
+absolute_path=$(drtprod run "${CLUSTER}":1 -- "realpath ./cockroach")
+pwd=$(drtprod run "${CLUSTER}":1 -- "dirname ${absolute_path}")
+
+drtprod ssh "${CLUSTER}":1 -- "tee decommission.sh > /dev/null << 'EOF'
+#!/bin/bash
+
+# script is responsible for decommissioning preempted nodes
+
+# This runs the cockroach node status command and capture the output
+output=\$(${pwd}/cockroach node status --certs-dir=./certs --all | tr -d ' ' | awk 'NR>1 && \$24==\"active\" && \$8==\"false\" && \$9==\"false\" {print \$1}' | paste -s -d ' ')
+
+# It checks if any nodes were found
+if [ -z \"\$output\" ]; then
+  echo \"No nodes found for decommissioning.\"
+else
+  echo \"Decommissioning nodes: \$output\"
+
+  # Then, it runs the cockroach node decommission command with the nodes from the output
+  ${pwd}/cockroach node decommission \$output --certs-dir=./certs
+fi
+EOF"
+drtprod ssh "${CLUSTER}":1 -- "chmod +x decommission.sh"
+# this step adds the entry cronjob to run everyday at 5 AM
+drtprod run "${CLUSTER}":1 -- "(crontab -l; echo \"0 5 * * * ${pwd}/decommission.sh\") | crontab -"
+# these steps unmasks and starts cron
+drtprod ssh "${CLUSTER}":1 -- sudo systemctl unmask cron
+drtprod ssh "${CLUSTER}":1 -- sudo systemctl start cron
+
+


### PR DESCRIPTION
We have spot VMs on drt large because of which we see VMs getting preempted resulting in dead nodes on the cluster. We have been manually cleaning the same. This PR adds a script that creates a script via YAML to decommission nodes. The script is added to node 1 with a cron that runs it every day at 5 AM.

Fixes: #126554
Epic: None
Release note:None