### PR TITLE
pkg/cli: add all the remaining table dumps to debugzip upload

### DIFF
--- a/pkg/cli/BUILD.bazel
+++ b/pkg/cli/BUILD.bazel
@@ -439,7 +439,6 @@ go_test(
         "//pkg/testutils/testcluster",
         "//pkg/ts/tspb",
         "//pkg/util",
-        "//pkg/util/encoding",
         "//pkg/util/ioctx",
         "//pkg/util/leaktest",
         "//pkg/util/log",

--- a/pkg/cli/BUILD.bazel
+++ b/pkg/cli/BUILD.bazel
@@ -66,6 +66,7 @@ go_library(
         "zip_per_node.go",
         "zip_table_registry.go",
         "zip_upload.go",
+        "zip_upload_table_dumps.go",
         ":gen-keytype-stringer",  # keep
     ],
     # keep
@@ -368,6 +369,7 @@ go_test(
         "zip_table_registry_test.go",
         "zip_tenant_test.go",
         "zip_test.go",
+        "zip_upload_table_dumps_test.go",
         "zip_upload_test.go",
     ],
     data = glob(["testdata/**"]),
@@ -437,6 +439,7 @@ go_test(
         "//pkg/testutils/testcluster",
         "//pkg/ts/tspb",
         "//pkg/util",
+        "//pkg/util/encoding",
         "//pkg/util/ioctx",
         "//pkg/util/leaktest",
         "//pkg/util/log",

--- a/pkg/cli/testdata/table_dump_column_parsing
+++ b/pkg/cli/testdata/table_dump_column_parsing
@@ -6,8 +6,6 @@
 # ----
 # <decoded value>
 # ...
-# claim_session_id  NULL
-# claim_session_id  \x010180b3c8d31b42174175aeca685a7b0ac5e5
 
 crdb_internal.system_jobs.txt
 progress  \x10bdb9a5929b9f8a03aa0200
@@ -23,3 +21,108 @@ system.tenants.txt
 info  \x080110001a0020002a004200
 ----
 {"deprecated_id":1,"deprecated_data_state":0,"dropped_name":"","physical_replication_consumer_job_id":0,"capabilities":{},"last_revert_tenant_timestamp":{}}
+
+system.statement_statistics_limit_5000.txt
+fingerprint_id	\x0069f90926c070b5
+transaction_fingerprint_id	\x3b78e4a8d5fbb7ae
+plan_hash \x73761d939a82b2be
+----
+"78303036-3966-3930-3932-366330373062"
+"78336237-3865-3461-3864-356662623761"
+"78373337-3631-6439-3339-613832623262"
+
+
+system.sql_instances.txt
+session_id	\x010180a02ce496977a492f83fe04b7961c126c
+----
+"78303130-3138-3061-3032-636534393639"
+
+
+system.sqlliveness.txt
+session_id	\x0101800fd1b2a2f6004f608256705bbaef3f84
+crdb_region	\x80
+crdb_region	us-east1
+----
+"78303130-3138-3030-6664-316232613266"
+null
+"us-east1"
+
+
+system.eventlog.txt
+uniqueID	\x8c3cfa9c789b40438675af0a91017f7a
+----
+"78386333-6366-6139-6337-383962343034"
+
+
+system.descriptor.txt
+descriptor	\x12450a0673797374656d10011a250a0d0a0561646d696e1080101880100a0c0a04726f6f7410801018801012046e6f646518032200280140004a006a0808181002180020167000
+----
+{"Union":{"database":{"name":"system","id":1,"modification_time":{},"version":1,"privileges":{"users":[{"user_proto":"admin","privileges":2048,"with_grant_option":2048},{"user_proto":"root","privileges":2048,"with_grant_option":2048}],"owner_proto":"node","version":3},"schemas":null,"state":0,"offline_reason":"","system_database_schema_version":{"major":24,"minor":2,"patch":0,"internal":22},"replicated_pcr_version":0}}}
+
+
+crdb_internal.node_txn_execution_insights.txt
+txn_fingerprint_id	\x49b155010237c9b5
+----
+"78343962-3135-3530-3130-323337633962"
+
+
+crdb_internal.node_execution_insights.txt
+txn_fingerprint_id	\x49b155010237c9b5
+stmt_fingerprint_id	\x7a77813da47e05e1
+----
+"78343962-3135-3530-3130-323337633962"
+"78376137-3738-3133-6461-343765303565"
+
+
+crdb_internal.kv_session_based_leases.txt
+session_id	\x01018008f8bcbead5c424c8f22d1000ea851ca
+crdb_region	\x80
+crdb_region	us-east1
+----
+"78303130-3138-3030-3866-386263626561"
+null
+"us-east1"
+
+
+system.scheduled_jobs.txt
+schedule_state	\x
+schedule_state	\x0a09737563636565646564
+schedule_details	\x08021a105fd818f3cead470098747a4e2e368092220a12080818100218002016
+execution_args	\x0a4b0a49747970652e676f6f676c65617069732e636f6d2f636f636b726f6163682e73716c2e5363686564756c656453514c5374617473436f6d706163746f72457865637574696f6e41726773
+----
+{}
+{"status":"succeeded"}
+{"wait":2,"cluster_id":"5fd818f3-cead-4700-9874-7a4e2e368092","creation_cluster_version":{"active_version":{"major":24,"minor":2,"patch":0,"internal":22}}}
+{"args":{"type_url":"type.googleapis.com/cockroach.sql.ScheduledSQLStatsCompactorExecutionArgs"}}
+
+
+system.span_configurations.txt
+start_key	\x88
+start_key	\x04006c6976656e6573732d
+end_key	\x04ff7379732d73636667
+config	\x08808080401080808080021a0308901c2805
+----
+"/Table/0"
+"/System/NodeLiveness"
+"/System/SystemSpanConfigKeys"
+{"range_min_bytes":134217728,"range_max_bytes":536870912,"gc_policy":{"ttl_seconds":3600,"protection_policies":null},"num_replicas":5,"constraints":null,"voter_constraints":null,"lease_preferences":null}
+
+
+crdb_internal.transaction_contention_events.txt
+blocking_txn_fingerprint_id	\xee12d3af7ca02346
+waiting_stmt_fingerprint_id	\x62c29177ea079a33
+waiting_txn_fingerprint_id	\xee12d3af7ca02346
+----
+"78656531-3264-3361-6637-636130323334"
+"78363263-3239-3137-3765-613037396133"
+"78656531-3264-3361-6637-636130323334"
+
+
+crdb_internal.transaction_contention_events.fallback.txt
+blocking_txn_fingerprint_id	\xee12d3af7ca02346
+waiting_stmt_fingerprint_id	\x62c29177ea079a33
+waiting_txn_fingerprint_id	\xee12d3af7ca02346
+----
+"78656531-3264-3361-6637-636130323334"
+"78363263-3239-3137-3765-613037396133"
+"78656531-3264-3361-6637-636130323334"

--- a/pkg/cli/testdata/table_dumps/crdb_internal.cluster_locks.txt
+++ b/pkg/cli/testdata/table_dumps/crdb_internal.cluster_locks.txt
@@ -1,0 +1,3 @@
+range_id	table_id	database_name	schema_name	table_name	index_name	lock_key	lock_key_pretty	txn_id	ts	lock_strength	durability	granted	contended	duration	isolation_level
+240	108	cct_tpcc	public	warehouse		\xf48912800001a388	"/Table/108/1/""\x80""/27/0"	948ef211-1fda-41c7-9393-64c46b3e60b6	2024-11-25 09:11:26.185818	Exclusive	Unreplicated	t	t	00:00:00.01032	SERIALIZABLE
+240	108	cct_tpcc	public	warehouse		\xf48912800001a388	"/Table/108/1/""\x80""/27/0"	948ef211-1fda-41c7-9393-64c46b3e60b6	2024-11-25 09:11:26.185818	Exclusive	Unreplicated	f	t	2562047:47:16.854775	SERIALIZABLE

--- a/pkg/cli/testdata/upload/tables
+++ b/pkg/cli/testdata/upload/tables
@@ -9,17 +9,19 @@ Logs API Hook: claim_instance_id=NULL	claim_session_id=NULL	created=2024-12-11 0
 Logs API Hook: claim_instance_id=NULL	claim_session_id=NULL	created=2024-12-11 07:39:23.366318	created_by_id=3	created_by_type=node	ddtags=env:debug,source:debug-zip,upload_id:abc-20241114000000,cluster:ABC,table:crdb_internal.system_jobs	id=101	last_run=NULL	num_runs=NULL	payload=redacted	progress=map[Details:map[pollJobsStats:map[]] Progress:<nil> modified_micros:1.733902763366318e+15 trace_id:0]	status=running	
 Logs API Hook: claim_instance_id=NULL	claim_session_id=NULL	created=2024-12-11 07:39:23.374069	created_by_id=NULL	created_by_type=NULL	ddtags=env:debug,source:debug-zip,upload_id:abc-20241114000000,cluster:ABC,table:crdb_internal.system_jobs	id=103	last_run=NULL	num_runs=NULL	payload=redacted	progress=map[Details:map[update_sql_activity:map[]] Progress:<nil> modified_micros:1.733902763374069e+15 trace_id:0]	status=running	
 Logs API Hook: claim_instance_id=NULL	claim_session_id=NULL	created=2024-12-11 07:39:23.378479	created_by_id=NULL	created_by_type=NULL	ddtags=env:debug,source:debug-zip,upload_id:abc-20241114000000,cluster:ABC,table:crdb_internal.system_jobs	id=104	last_run=NULL	num_runs=NULL	payload=redacted	progress=map[Details:map[mvcc_statistics_progress:map[]] Progress:<nil> modified_micros:1.733902763378479e+15 trace_id:0]	status=running	
-Logs API Hook: ddtags=env:debug,source:debug-zip,upload_id:abc-20241114000000,cluster:ABC,table:nodes/1/crdb_internal.node_metrics,node_id:1	name=gossip.connections.incoming	store_id=NULL	value=0	
-Logs API Hook: ddtags=env:debug,source:debug-zip,upload_id:abc-20241114000000,cluster:ABC,table:nodes/1/crdb_internal.node_metrics,node_id:1	name=jobs.row_level_ttl.select_duration-p99.9	store_id=NULL	value=0	
-Logs API Hook: ddtags=env:debug,source:debug-zip,upload_id:abc-20241114000000,cluster:ABC,table:nodes/1/crdb_internal.node_metrics,node_id:1	name=leases.transfers.success	store_id=1	value=0	
-Logs API Hook: ddtags=env:debug,source:debug-zip,upload_id:abc-20241114000000,cluster:ABC,table:nodes/1/crdb_internal.node_metrics,node_id:1	name=range.snapshots.upreplication.sent-bytes	store_id=1	value=0	
-Logs API Hook: ddtags=env:debug,source:debug-zip,upload_id:abc-20241114000000,cluster:ABC,table:nodes/1/crdb_internal.node_metrics,node_id:1	name=sql.restart_savepoint.rollback.count.internal	store_id=NULL	value=0	
-Logs API Hook: ddtags=env:debug,source:debug-zip,upload_id:abc-20241114000000,cluster:ABC,table:nodes/1/crdb_internal.node_metrics,node_id:1	name=storage.iterator.category-pebble-ingest.block-load.latency-sum	store_id=1	value=0	
-Logs API Hook: ddtags=env:debug,source:debug-zip,upload_id:abc-20241114000000,cluster:ABC,table:nodes/2/crdb_internal.leases,node_id:2	deleted=f	expiration=2024-12-11 07:44:24.205086	name=statement_diagnostics	node_id=1	parent_id=1	table_id=36	
-Logs API Hook: ddtags=env:debug,source:debug-zip,upload_id:abc-20241114000000,cluster:ABC,table:nodes/2/crdb_internal.leases,node_id:2	deleted=f	expiration=2024-12-11 07:44:27.222137	name=rides	node_id=1	parent_id=104	table_id=108	
-Logs API Hook: ddtags=env:debug,source:debug-zip,upload_id:abc-20241114000000,cluster:ABC,table:nodes/2/crdb_internal.leases,node_id:2	deleted=f	expiration=2024-12-11 07:44:31.289861	name=settings	node_id=1	parent_id=1	table_id=6	
-Logs API Hook: ddtags=env:debug,source:debug-zip,upload_id:abc-20241114000000,cluster:ABC,table:nodes/2/crdb_internal.leases,node_id:2	deleted=f	expiration=2024-12-11 07:44:44.824583	name=descriptor	node_id=1	parent_id=1	table_id=3	
-Logs API Hook: ddtags=env:debug,source:debug-zip,upload_id:abc-20241114000000,cluster:ABC,table:nodes/2/crdb_internal.leases,node_id:2	deleted=f	expiration=2024-12-11 07:44:49.537097	name=external_connections	node_id=1	parent_id=1	table_id=53	
+Logs API Hook: contended=t	database_name=cct_tpcc	ddtags=env:debug,source:debug-zip,upload_id:abc-20241114000000,cluster:ABC,table:crdb_internal.cluster_locks	durability=Unreplicated	duration=00:00:00.01032	granted=t	index_name=	isolation_level=SERIALIZABLE	lock_key_pretty="/Table/108/1/""\x80""/27/0"	lock_strength=Exclusive	range_id=240	schema_name=public	table_id=108	table_name=warehouse	ts=2024-11-25 09:11:26.185818	txn_id=948ef211-1fda-41c7-9393-64c46b3e60b6	
+Logs API Hook: contended=t	database_name=cct_tpcc	ddtags=env:debug,source:debug-zip,upload_id:abc-20241114000000,cluster:ABC,table:crdb_internal.cluster_locks	durability=Unreplicated	duration=2562047:47:16.854775	granted=f	index_name=	isolation_level=SERIALIZABLE	lock_key_pretty="/Table/108/1/""\x80""/27/0"	lock_strength=Exclusive	range_id=240	schema_name=public	table_id=108	table_name=warehouse	ts=2024-11-25 09:11:26.185818	txn_id=948ef211-1fda-41c7-9393-64c46b3e60b6	
+Logs API Hook: ddtags=env:debug,source:debug-zip,upload_id:abc-20241114000000,cluster:ABC,table:crdb_internal.leases,node_id:2	deleted=f	expiration=2024-12-11 07:44:24.205086	name=statement_diagnostics	node_id=1	parent_id=1	table_id=36	
+Logs API Hook: ddtags=env:debug,source:debug-zip,upload_id:abc-20241114000000,cluster:ABC,table:crdb_internal.leases,node_id:2	deleted=f	expiration=2024-12-11 07:44:27.222137	name=rides	node_id=1	parent_id=104	table_id=108	
+Logs API Hook: ddtags=env:debug,source:debug-zip,upload_id:abc-20241114000000,cluster:ABC,table:crdb_internal.leases,node_id:2	deleted=f	expiration=2024-12-11 07:44:31.289861	name=settings	node_id=1	parent_id=1	table_id=6	
+Logs API Hook: ddtags=env:debug,source:debug-zip,upload_id:abc-20241114000000,cluster:ABC,table:crdb_internal.leases,node_id:2	deleted=f	expiration=2024-12-11 07:44:44.824583	name=descriptor	node_id=1	parent_id=1	table_id=3	
+Logs API Hook: ddtags=env:debug,source:debug-zip,upload_id:abc-20241114000000,cluster:ABC,table:crdb_internal.leases,node_id:2	deleted=f	expiration=2024-12-11 07:44:49.537097	name=external_connections	node_id=1	parent_id=1	table_id=53	
+Logs API Hook: ddtags=env:debug,source:debug-zip,upload_id:abc-20241114000000,cluster:ABC,table:crdb_internal.node_metrics,node_id:1	name=gossip.connections.incoming	store_id=NULL	value=0	
+Logs API Hook: ddtags=env:debug,source:debug-zip,upload_id:abc-20241114000000,cluster:ABC,table:crdb_internal.node_metrics,node_id:1	name=jobs.row_level_ttl.select_duration-p99.9	store_id=NULL	value=0	
+Logs API Hook: ddtags=env:debug,source:debug-zip,upload_id:abc-20241114000000,cluster:ABC,table:crdb_internal.node_metrics,node_id:1	name=leases.transfers.success	store_id=1	value=0	
+Logs API Hook: ddtags=env:debug,source:debug-zip,upload_id:abc-20241114000000,cluster:ABC,table:crdb_internal.node_metrics,node_id:1	name=range.snapshots.upreplication.sent-bytes	store_id=1	value=0	
+Logs API Hook: ddtags=env:debug,source:debug-zip,upload_id:abc-20241114000000,cluster:ABC,table:crdb_internal.node_metrics,node_id:1	name=sql.restart_savepoint.rollback.count.internal	store_id=NULL	value=0	
+Logs API Hook: ddtags=env:debug,source:debug-zip,upload_id:abc-20241114000000,cluster:ABC,table:crdb_internal.node_metrics,node_id:1	name=storage.iterator.category-pebble-ingest.block-load.latency-sum	store_id=1	value=0	
 Logs API Hook: ddtags=env:debug,source:debug-zip,upload_id:abc-20241114000000,cluster:ABC,table:system.namespace	id=1	name=system	parentID=0	parentSchemaID=0	
 Logs API Hook: ddtags=env:debug,source:debug-zip,upload_id:abc-20241114000000,cluster:ABC,table:system.namespace	id=100	name=defaultdb	parentID=0	parentSchemaID=0	
 Logs API Hook: ddtags=env:debug,source:debug-zip,upload_id:abc-20241114000000,cluster:ABC,table:system.namespace	id=102	name=postgres	parentID=0	parentSchemaID=0	
@@ -29,8 +31,10 @@ Logs API Hook: https://http-intake.logs.us5.datadoghq.com/api/v2/logs
 Logs API Hook: https://http-intake.logs.us5.datadoghq.com/api/v2/logs
 Logs API Hook: https://http-intake.logs.us5.datadoghq.com/api/v2/logs
 Logs API Hook: https://http-intake.logs.us5.datadoghq.com/api/v2/logs
+Logs API Hook: https://http-intake.logs.us5.datadoghq.com/api/v2/logs
 Upload ID: abc-20241114000000
 debug zip upload debugDir --dd-api-key=dd-api-key --dd-app-key=dd-app-key --cluster=ABC --include=tables
+uploaded crdb_internal.cluster_locks.txt
 uploaded crdb_internal.system_jobs.txt
 uploaded nodes/1/crdb_internal.node_metrics.txt
 uploaded nodes/2/crdb_internal.leases.txt

--- a/pkg/cli/zip_upload.go
+++ b/pkg/cli/zip_upload.go
@@ -6,7 +6,6 @@
 package cli
 
 import (
-	"bufio"
 	"bytes"
 	"compress/gzip"
 	"context"
@@ -20,7 +19,6 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"reflect"
 	"regexp"
 	"sort"
 	"strings"
@@ -29,12 +27,9 @@ import (
 
 	"cloud.google.com/go/storage"
 	"github.com/cockroachdb/cockroach/pkg/base"
-	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
-	"github.com/cockroachdb/cockroach/pkg/multitenant/mtinfopb"
 	"github.com/cockroachdb/cockroach/pkg/util/httputil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/log/logpb"
-	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/system"
@@ -612,108 +607,6 @@ func uploadZipLogs(ctx context.Context, uploadID string, debugDirPath string) er
 	return nil
 }
 
-type tsvColumnParserFn func(string) (any, error)
-
-type columnParserMap map[string]tsvColumnParserFn
-
-// makeProtoColumnParser returns a generic function that can parse a column
-// using the given proto type. This function is implemented this way because it
-// allows us to effortlessly extend support to new tables without having to
-// write a lot of boilerplate code for unmarshalling each column.
-func makeProtoColumnParser[T protoutil.Message]() tsvColumnParserFn {
-	return func(s string) (any, error) {
-		interpretedBytes, ok := interpretString(s)
-		if !ok {
-			return nil, fmt.Errorf("failed to interpret progress column: %s", s)
-		}
-
-		var zeroValue T // dummy var to infer the type of T
-		obj := reflect.New(reflect.TypeOf(zeroValue).Elem()).Interface().(T)
-		if err := protoutil.Unmarshal(interpretedBytes, obj); err != nil {
-			return nil, err
-		}
-
-		return obj, nil
-	}
-}
-
-// clusterWideTableDumps is a map of table dumps and their column parsers.
-// Column parsers are required for columns that require special interpretation.
-// For example, columns that are protobufs. If the parser is not present for a
-// column, it is assumed to be plain text.
-var clusterWideTableDumps = map[string]columnParserMap{
-	// table dumps with only plain text columns
-	"system.namespace.txt":                          {},
-	"crdb_internal.kv_node_liveness.txt":            {},
-	"crdb_internal.cluster_database_privileges.txt": {},
-	"system.rangelog.txt":                           {},
-	"crdb_internal.table_indexes.txt":               {},
-	"crdb_internal.index_usage_statistics.txt":      {},
-	"crdb_internal.create_statements.txt":           {},
-	"system.job_info.txt":                           {},
-	"crdb_internal.create_schema_statements.txt":    {},
-	"crdb_internal.default_privileges.txt":          {},
-	"system.role_members.txt":                       {},
-	"crdb_internal.cluster_settings.txt":            {},
-	"system.role_id_seq.txt":                        {},
-	"crdb_internal.cluster_sessions.txt":            {},
-	"system.migrations.txt":                         {},
-	"crdb_internal.kv_store_status.txt":             {},
-	"system.locations.txt":                          {},
-	"crdb_internal.cluster_transactions.txt":        {},
-	"crdb_internal.kv_node_status.txt":              {},
-	"crdb_internal.cluster_contention_events.txt":   {},
-	"crdb_internal.cluster_queries.txt":             {},
-	"crdb_internal.jobs.txt":                        {},
-	"crdb_internal.regions.txt":                     {},
-	"system.table_statistics.txt":                   {},
-
-	// table dumps with columns that need to be interpreted as protos
-	"crdb_internal.system_jobs.txt": {
-		"progress": makeProtoColumnParser[*jobspb.Progress](),
-	},
-	"system.tenants.txt": {
-		"info": makeProtoColumnParser[*mtinfopb.ProtoInfo](),
-	},
-}
-
-var nodeSpecificTableDumps = map[string]columnParserMap{
-	"crdb_internal.node_metrics.txt":                   {},
-	"crdb_internal.node_txn_stats.txt":                 {},
-	"crdb_internal.node_contention_events.txt":         {},
-	"crdb_internal.gossip_liveness.txt":                {},
-	"crdb_internal.gossip_nodes.txt":                   {},
-	"crdb_internal.node_runtime_info.txt":              {},
-	"crdb_internal.node_transaction_statistics.txt":    {},
-	"crdb_internal.node_tenant_capabilities_cache.txt": {},
-	"crdb_internal.node_sessions.txt":                  {},
-	"crdb_internal.node_statement_statistics.txt":      {},
-	"crdb_internal.leases.txt":                         {},
-	"crdb_internal.node_build_info.txt":                {},
-	"crdb_internal.node_memory_monitors.txt":           {},
-	"crdb_internal.active_range_feeds.txt":             {},
-	"crdb_internal.gossip_alerts.txt":                  {},
-	"crdb_internal.node_transactions.txt":              {},
-	"crdb_internal.feature_usage.txt":                  {},
-	"crdb_internal.node_queries.txt":                   {},
-}
-
-func getNodeSpecificTableDumps(debugDirPath string) ([]string, error) {
-	allTxtFiles, err := expandPatterns([]string{path.Join(debugDirPath, zippedNodeTableDumpsPattern)})
-	if err != nil {
-		return nil, err
-	}
-
-	filteredTxtFiles := []string{}
-	for _, txtFile := range allTxtFiles {
-		if _, ok := nodeSpecificTableDumps[filepath.Base(txtFile)]; ok {
-			filteredTxtFiles = append(filteredTxtFiles, strings.TrimPrefix(txtFile, debugDirPath+"/"))
-		}
-	}
-
-	return filteredTxtFiles, nil
-}
-
 // uploadZipTables uploads the table dumps to datadog. The concurrency model
 // here is much simpler than the logs upload. We just fan-out work to a limited
 // set of workers and fan-in the errors if any. The workers read the file,
@@ -773,98 +666,6 @@ func uploadZipTables(ctx context.Context, uploadID string, debugDirPath string) 
 	close(workChan)
 	close(errChan)
 	return nil
-}
-
-func processTableDump(
-	ctx context.Context, dir, fileName, uploadID string, parsers columnParserMap,
-) error {
-	f, err := os.Open(path.Join(dir, fileName))
-	if err != nil {
-		return err
-	}
-	defer f.Close()
-
-	var (
-		lines     = [][]byte{}
-		tableName = strings.TrimSuffix(fileName, filepath.Ext(fileName))
-		tags      = append(
-			[]string{"env:debug", "source:debug-zip"}, makeDDTag(uploadIDTag, uploadID),
-			makeDDTag(clusterTag, debugZipUploadOpts.clusterName), makeDDTag(tableTag, tableName),
-		)
-	)
-
-	if strings.HasPrefix(fileName, "nodes/") {
-		tags = append(tags, makeDDTag(nodeIDTag, strings.Split(fileName, "/")[1]))
-	}
-
-	header, iter := makeTableIterator(f)
-	if err := iter(func(row string) error {
-		cols := strings.Split(row, "\t")
-		if len(header) != len(cols) {
-			return errors.Newf("the number of headers is not matching the number of columns in the row")
-		}
-
-		headerColumnMapping := map[string]any{
-			ddTagsTag: strings.Join(tags, ","),
-		}
-		for i, h := range header {
-			if parser, ok := parsers[h]; ok {
-				colBytes, err := parser(cols[i])
-				if err != nil {
-					return err
-				}
-
-				headerColumnMapping[h] = colBytes
-				continue
-			}
-
-			headerColumnMapping[h] = cols[i]
-		}
-
-		jsonRow, err := json.Marshal(headerColumnMapping)
-		if err != nil {
-			return err
-		}
-
-		lines = append(lines, jsonRow)
-		return nil
-	}); err != nil {
-		return err
-	}
-
-	if len(lines) == 0 {
-		return nil
-	}
-
-	// datadog's logs API only allows 1000 lines of logs per request. So, split
-	// the lines into batches of 1000.
-	for i := 0; i < len(lines); i += datadogMaxLogLinesPerReq {
-		end := min(i+datadogMaxLogLinesPerReq, len(lines))
-		if _, err := uploadLogsToDatadog(
-			makeDDMultiLineLogPayload(lines[i:end]), debugZipUploadOpts.ddAPIKey, debugZipUploadOpts.ddSite,
-		); err != nil {
-			return err
-		}
-	}
-
-	fmt.Printf("uploaded %s\n", fileName)
-	return nil
-}
-
-// makeTableIterator returns the headers slice and an iterator
-func makeTableIterator(f io.Reader) ([]string, func(func(string) error) error) {
-	scanner := bufio.NewScanner(f)
-	scanner.Scan() // scan the first line to get the headers
-
-	return strings.Split(scanner.Text(), "\t"), func(fn func(string) error) error {
-		for scanner.Scan() {
-			if err := fn(scanner.Text()); err != nil {
-				return err
-			}
-		}
-
-		return scanner.Err()
-	}
 }
 
 type ddArchivePayload struct {

--- a/pkg/cli/zip_upload_table_dumps.go
+++ b/pkg/cli/zip_upload_table_dumps.go
@@ -18,7 +18,11 @@ import (
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/multitenant/mtinfopb"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/errors"
 )
@@ -26,6 +30,13 @@ import (
 type tsvColumnParserFn func(string) (any, error)
 
 type columnParserMap map[string]tsvColumnParserFn
+
+// skipColumn is an empty struct that is used to indicate that a column should
+// be skipped. This indicator has to be a type and not a value like bool
+// because, it could conflict with the actual column value. Parsing functions
+// can return this type conditionally or unconditionally to indicate that the
+// column should be skipped.
+type skipColumn struct{}
 
 // clusterWideTableDumps is a map of table dumps and their column parsers.
 // Column parsers are required for columns that require special interpretation.
@@ -57,35 +68,133 @@ var clusterWideTableDumps = map[string]columnParserMap{
 	"crdb_internal.jobs.txt":                        {},
 	"crdb_internal.regions.txt":                     {},
 	"system.table_statistics.txt":                   {},
+	"system.statement_diagnostics_requests.txt":     {},
+	"system.statement_diagnostics.txt":              {},
+	"system.sql_stats_cardinality.txt":              {},
+	"system.settings.txt":                           {},
+	"system.reports_meta.txt":                       {},
+	"system.replication_stats.txt":                  {},
+	"system.replication_critical_localities.txt":    {},
+	"system.replication_constraint_stats.txt":       {},
+	"crdb_internal.cluster_distsql_flows.txt":       {},
+	"system.tenant_tasks.txt":                       {},
+	"system.tenant_settings.txt":                    {},
+	"system.task_payloads.txt":                      {},
+	"system.role_options.txt":                       {},
+	"system.protected_ts_meta.txt":                  {},
+	"system.privileges.txt":                         {},
+	"system.external_connections.txt":               {},
+	"system.database_role_settings.txt":             {},
+	"crdb_internal.super_regions.txt":               {},
+	"crdb_internal.schema_changes.txt":              {},
+	"crdb_internal.partitions.txt":                  {},
+	"crdb_internal.kv_system_privileges.txt":        {},
+	"crdb_internal.kv_protected_ts_records.txt":     {},
+	"crdb_internal.invalid_objects.txt":             {},
+	"crdb_internal.create_type_statements.txt":      {},
+	"crdb_internal.create_procedure_statements.txt": {},
+	"crdb_internal.create_function_statements.txt":  {},
+	"crdb_internal.logical_replication_spans.txt":   {},
+	"crdb_internal.cluster_replication_spans.txt":   {},
+	"system.protected_ts_records.txt":               {},
 
-	// table dumps with columns that need to be interpreted as protos
+	// table dumps with columns that need to be decoded
 	"crdb_internal.system_jobs.txt": {
 		"progress": makeProtoColumnParser[*jobspb.Progress](),
 	},
 	"system.tenants.txt": {
 		"info": makeProtoColumnParser[*mtinfopb.ProtoInfo](),
 	},
+	"system.statement_statistics_limit_5000.txt": {
+		"fingerprint_id":             decodeUUID,
+		"transaction_fingerprint_id": decodeUUID,
+		"plan_hash":                  decodeUUID,
+	},
+	"system.sql_instances.txt": {
+		"session_id": decodeUUID,
+	},
+	"system.sqlliveness.txt": {
+		"session_id":  decodeUUID,
+		"crdb_region": decodeRegion,
+	},
+	"system.lease.txt": {
+		"session_id":  decodeUUID,
+		"crdb_region": decodeRegion,
+	},
+	"system.eventlog.txt": {
+		"uniqueID": decodeUUID,
+	},
+	"system.descriptor.txt": {
+		"descriptor": makeProtoColumnParser[*descpb.Descriptor](),
+	},
+	"system.scheduled_jobs.txt": {
+		"schedule_state":   makeProtoColumnParser[*jobspb.ScheduleState](),
+		"schedule_details": makeProtoColumnParser[*jobspb.ScheduleDetails](),
+		"execution_args":   makeProtoColumnParser[*jobspb.ExecutionArguments](),
+	},
+	"system.tenant_usage.txt": {
+		"total_consumption": makeProtoColumnParser[*kvpb.TenantConsumption](),
+		"current_rates":     makeProtoColumnParser[*kvpb.TenantConsumptionRates](),
+		"next_rates":        makeProtoColumnParser[*kvpb.TenantConsumptionRates](),
+	},
+	"system.span_configurations.txt": {
+		"start_key": decodeKey,
+		"end_key":   decodeKey,
+		"config":    makeProtoColumnParser[*roachpb.SpanConfig](),
+	},
+	"crdb_internal.cluster_locks.txt": {
+		"lock_key": skipColumnFn, // lock_key can be skipped because there is another column called lock_key_pretty
+	},
+	"crdb_internal.transaction_contention_events.fallback.txt": {
+		"blocking_txn_fingerprint_id": decodeUUID,
+		"waiting_stmt_fingerprint_id": decodeUUID,
+		"waiting_txn_fingerprint_id":  decodeUUID,
+	},
+	"crdb_internal.transaction_contention_events.txt": {
+		"blocking_txn_fingerprint_id": decodeUUID,
+		"waiting_stmt_fingerprint_id": decodeUUID,
+		"waiting_txn_fingerprint_id":  decodeUUID,
+	},
 }
 
 var nodeSpecificTableDumps = map[string]columnParserMap{
-	"crdb_internal.node_metrics.txt":                   {},
-	"crdb_internal.node_txn_stats.txt":                 {},
-	"crdb_internal.node_contention_events.txt":         {},
-	"crdb_internal.gossip_liveness.txt":                {},
-	"crdb_internal.gossip_nodes.txt":                   {},
-	"crdb_internal.node_runtime_info.txt":              {},
-	"crdb_internal.node_transaction_statistics.txt":    {},
-	"crdb_internal.node_tenant_capabilities_cache.txt": {},
-	"crdb_internal.node_sessions.txt":                  {},
-	"crdb_internal.node_statement_statistics.txt":      {},
-	"crdb_internal.leases.txt":                         {},
-	"crdb_internal.node_build_info.txt":                {},
-	"crdb_internal.node_memory_monitors.txt":           {},
-	"crdb_internal.active_range_feeds.txt":             {},
-	"crdb_internal.gossip_alerts.txt":                  {},
-	"crdb_internal.node_transactions.txt":              {},
-	"crdb_internal.feature_usage.txt":                  {},
-	"crdb_internal.node_queries.txt":                   {},
+	"crdb_internal.node_metrics.txt":                                {},
+	"crdb_internal.node_txn_stats.txt":                              {},
+	"crdb_internal.node_contention_events.txt":                      {},
+	"crdb_internal.gossip_liveness.txt":                             {},
+	"crdb_internal.gossip_nodes.txt":                                {},
+	"crdb_internal.node_runtime_info.txt":                           {},
+	"crdb_internal.node_transaction_statistics.txt":                 {},
+	"crdb_internal.node_tenant_capabilities_cache.txt":              {},
+	"crdb_internal.node_sessions.txt":                               {},
+	"crdb_internal.node_statement_statistics.txt":                   {},
+	"crdb_internal.leases.txt":                                      {},
+	"crdb_internal.node_build_info.txt":                             {},
+	"crdb_internal.node_memory_monitors.txt":                        {},
+	"crdb_internal.active_range_feeds.txt":                          {},
+	"crdb_internal.gossip_alerts.txt":                               {},
+	"crdb_internal.node_transactions.txt":                           {},
+	"crdb_internal.feature_usage.txt":                               {},
+	"crdb_internal.node_queries.txt":                                {},
+	"crdb_internal.cluster_replication_node_stream_checkpoints.txt": {},
+	"crdb_internal.logical_replication_node_processors.txt":         {},
+	"crdb_internal.cluster_replication_node_streams.txt":            {},
+	"crdb_internal.node_inflight_trace_spans.txt":                   {},
+	"crdb_internal.node_distsql_flows.txt":                          {},
+	"crdb_internal.cluster_replication_node_stream_spans.txt":       {},
+
+	// table dumps with columns that need to be decoded
+	"crdb_internal.node_txn_execution_insights.txt": {
+		"txn_fingerprint_id": decodeUUID,
+	},
+	"crdb_internal.node_execution_insights.txt": {
+		"txn_fingerprint_id":  decodeUUID,
+		"stmt_fingerprint_id": decodeUUID,
+	},
+	"crdb_internal.kv_session_based_leases.txt": {
+		"session_id":  decodeUUID,
+		"crdb_region": decodeRegion,
+	},
 }
 
 // makeProtoColumnParser returns a generic function that can parse a column
@@ -120,7 +229,7 @@ func processTableDump(
 
 	var (
 		lines     = [][]byte{}
-		tableName = strings.TrimSuffix(fileName, filepath.Ext(fileName))
+		tableName = strings.TrimSuffix(filepath.Base(fileName), filepath.Ext(fileName))
 		tags      = append(
 			[]string{"env:debug", "source:debug-zip"}, makeDDTag(uploadIDTag, uploadID),
 			makeDDTag(clusterTag, debugZipUploadOpts.clusterName), makeDDTag(tableTag, tableName),
@@ -146,6 +255,10 @@ func processTableDump(
 				colBytes, err := parser(cols[i])
 				if err != nil {
 					return err
+				}
+
+				if colBytes == (skipColumn{}) {
+					continue
 				}
 
 				headerColumnMapping[h] = colBytes
@@ -215,4 +328,29 @@ func getNodeSpecificTableDumps(debugDirPath string) ([]string, error) {
 	}
 
 	return filteredTxtFiles, nil
+}
+
+func decodeUUID(inp string) (any, error) {
+	_, u, err := encoding.DecodeUUIDValue([]byte(inp))
+	return u, err
+}
+
+func decodeRegion(s string) (any, error) {
+	if s == `\x80` {
+		return nil, nil
+	}
+	return s, nil
+}
+
+func decodeKey(s string) (any, error) {
+	b, ok := interpretString(s)
+	if !ok {
+		return nil, fmt.Errorf("failed to interpret column value: %s", s)
+	}
+
+	return roachpb.Key(b).String(), nil
+}
+
+func skipColumnFn(s string) (any, error) {
+	return skipColumn{}, nil
 }

--- a/pkg/cli/zip_upload_table_dumps.go
+++ b/pkg/cli/zip_upload_table_dumps.go
@@ -1,0 +1,218 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package cli
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"path/filepath"
+	"reflect"
+	"strings"
+
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
+	"github.com/cockroachdb/cockroach/pkg/multitenant/mtinfopb"
+	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
+	"github.com/cockroachdb/errors"
+)
+
+type tsvColumnParserFn func(string) (any, error)
+
+type columnParserMap map[string]tsvColumnParserFn
+
+// clusterWideTableDumps is a map of table dumps and their column parsers.
+// Column parsers are required for columns that require special interpretation.
+// For example, columns that are protobufs. If the parser is not present for a
+// column, it is assumed to be plain text.
+var clusterWideTableDumps = map[string]columnParserMap{
+	// table dumps with only plain text columns
+	"system.namespace.txt":                          {},
+	"crdb_internal.kv_node_liveness.txt":            {},
+	"crdb_internal.cluster_database_privileges.txt": {},
+	"system.rangelog.txt":                           {},
+	"crdb_internal.table_indexes.txt":               {},
+	"crdb_internal.index_usage_statistics.txt":      {},
+	"crdb_internal.create_statements.txt":           {},
+	"system.job_info.txt":                           {},
+	"crdb_internal.create_schema_statements.txt":    {},
+	"crdb_internal.default_privileges.txt":          {},
+	"system.role_members.txt":                       {},
+	"crdb_internal.cluster_settings.txt":            {},
+	"system.role_id_seq.txt":                        {},
+	"crdb_internal.cluster_sessions.txt":            {},
+	"system.migrations.txt":                         {},
+	"crdb_internal.kv_store_status.txt":             {},
+	"system.locations.txt":                          {},
+	"crdb_internal.cluster_transactions.txt":        {},
+	"crdb_internal.kv_node_status.txt":              {},
+	"crdb_internal.cluster_contention_events.txt":   {},
+	"crdb_internal.cluster_queries.txt":             {},
+	"crdb_internal.jobs.txt":                        {},
+	"crdb_internal.regions.txt":                     {},
+	"system.table_statistics.txt":                   {},
+
+	// table dumps with columns that need to be interpreted as protos
+	"crdb_internal.system_jobs.txt": {
+		"progress": makeProtoColumnParser[*jobspb.Progress](),
+	},
+	"system.tenants.txt": {
+		"info": makeProtoColumnParser[*mtinfopb.ProtoInfo](),
+	},
+}
+
+var nodeSpecificTableDumps = map[string]columnParserMap{
+	"crdb_internal.node_metrics.txt":                   {},
+	"crdb_internal.node_txn_stats.txt":                 {},
+	"crdb_internal.node_contention_events.txt":         {},
+	"crdb_internal.gossip_liveness.txt":                {},
+	"crdb_internal.gossip_nodes.txt":                   {},
+	"crdb_internal.node_runtime_info.txt":              {},
+	"crdb_internal.node_transaction_statistics.txt":    {},
+	"crdb_internal.node_tenant_capabilities_cache.txt": {},
+	"crdb_internal.node_sessions.txt":                  {},
+	"crdb_internal.node_statement_statistics.txt":      {},
+	"crdb_internal.leases.txt":                         {},
+	"crdb_internal.node_build_info.txt":                {},
+	"crdb_internal.node_memory_monitors.txt":           {},
+	"crdb_internal.active_range_feeds.txt":             {},
+	"crdb_internal.gossip_alerts.txt":                  {},
+	"crdb_internal.node_transactions.txt":              {},
+	"crdb_internal.feature_usage.txt":                  {},
+	"crdb_internal.node_queries.txt":                   {},
+}
+
+// makeProtoColumnParser returns a generic function that can parse a column
+// using the given proto type. This function is implemented this way because it
+// allows us to effortlessly extend support to new tables without having to
+// write a lot of boilerplate code for unmarshalling each column.
+func makeProtoColumnParser[T protoutil.Message]() tsvColumnParserFn {
+	return func(s string) (any, error) {
+		interpretedBytes, ok := interpretString(s)
+		if !ok {
+			return nil, fmt.Errorf("failed to interpret progress column: %s", s)
+		}
+
+		var zeroValue T // dummy var to infer the type of T
+		obj := reflect.New(reflect.TypeOf(zeroValue).Elem()).Interface().(T)
+		if err := protoutil.Unmarshal(interpretedBytes, obj); err != nil {
+			return nil, err
+		}
+
+		return obj, nil
+	}
+}
+
+func processTableDump(
+	ctx context.Context, dir, fileName, uploadID string, parsers columnParserMap,
+) error {
+	f, err := os.Open(path.Join(dir, fileName))
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	var (
+		lines     = [][]byte{}
+		tableName = strings.TrimSuffix(fileName, filepath.Ext(fileName))
+		tags      = append(
+			[]string{"env:debug", "source:debug-zip"}, makeDDTag(uploadIDTag, uploadID),
+			makeDDTag(clusterTag, debugZipUploadOpts.clusterName), makeDDTag(tableTag, tableName),
+		)
+	)
+
+	if strings.HasPrefix(fileName, "nodes/") {
+		tags = append(tags, makeDDTag(nodeIDTag, strings.Split(fileName, "/")[1]))
+	}
+
+	header, iter := makeTableIterator(f)
+	if err := iter(func(row string) error {
+		cols := strings.Split(row, "\t")
+		if len(header) != len(cols) {
+			return errors.Newf("the number of headers is not matching the number of columns in the row")
+		}
+
+		headerColumnMapping := map[string]any{
+			ddTagsTag: strings.Join(tags, ","),
+		}
+		for i, h := range header {
+			if parser, ok := parsers[h]; ok {
+				colBytes, err := parser(cols[i])
+				if err != nil {
+					return err
+				}
+
+				headerColumnMapping[h] = colBytes
+				continue
+			}
+
+			headerColumnMapping[h] = cols[i]
+		}
+
+		jsonRow, err := json.Marshal(headerColumnMapping)
+		if err != nil {
+			return err
+		}
+
+		lines = append(lines, jsonRow)
+		return nil
+	}); err != nil {
+		return err
+	}
+
+	if len(lines) == 0 {
+		return nil
+	}
+
+	// datadog's logs API only allows 1000 lines of logs per request. So, split
+	// the lines into batches of 1000.
+	for i := 0; i < len(lines); i += datadogMaxLogLinesPerReq {
+		end := min(i+datadogMaxLogLinesPerReq, len(lines))
+		if _, err := uploadLogsToDatadog(
+			makeDDMultiLineLogPayload(lines[i:end]), debugZipUploadOpts.ddAPIKey, debugZipUploadOpts.ddSite,
+		); err != nil {
+			return err
+		}
+	}
+
+	fmt.Printf("uploaded %s\n", fileName)
+	return nil
+}
+
+// makeTableIterator returns the headers slice and an iterator
+func makeTableIterator(f io.Reader) ([]string, func(func(string) error) error) {
+	scanner := bufio.NewScanner(f)
+	scanner.Scan() // scan the first line to get the headers
+
+	return strings.Split(scanner.Text(), "\t"), func(fn func(string) error) error {
+		for scanner.Scan() {
+			if err := fn(scanner.Text()); err != nil {
+				return err
+			}
+		}
+
+		return scanner.Err()
+	}
+}
+
+func getNodeSpecificTableDumps(debugDirPath string) ([]string, error) {
+	allTxtFiles, err := expandPatterns([]string{path.Join(debugDirPath, zippedNodeTableDumpsPattern)})
+	if err != nil {
+		return nil, err
+	}
+
+	filteredTxtFiles := []string{}
+	for _, txtFile := range allTxtFiles {
+		if _, ok := nodeSpecificTableDumps[filepath.Base(txtFile)]; ok {
+			filteredTxtFiles = append(filteredTxtFiles, strings.TrimPrefix(txtFile, debugDirPath+"/"))
+		}
+	}
+
+	return filteredTxtFiles, nil
+}

--- a/pkg/cli/zip_upload_table_dumps_test.go
+++ b/pkg/cli/zip_upload_table_dumps_test.go
@@ -8,11 +8,13 @@ package cli
 import (
 	"bytes"
 	"encoding/json"
+	"fmt"
 	"strings"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/datadriven"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -21,13 +23,21 @@ func TestTableDumpColumnParsing(t *testing.T) {
 
 	datadriven.RunTest(t, "testdata/table_dump_column_parsing", func(t *testing.T, d *datadriven.TestData) string {
 		table, ok := clusterWideTableDumps[d.Cmd]
+		if !ok {
+			table, ok = nodeSpecificTableDumps[d.Cmd]
+		}
 		require.True(t, ok, "table dump not found: %s", d.Cmd)
+
+		t.Log(table)
 
 		var buf bytes.Buffer
 		for _, line := range strings.Split(strings.TrimSpace(d.Input), "\n") {
 			cols := strings.Fields(strings.TrimSpace(line))
 			fn, ok := table[cols[0]]
-			require.True(t, ok, "column not found: %s", cols[0])
+			if !ok {
+				buf.WriteString(strings.TrimSpace(cols[1]) + "\n")
+				continue
+			}
 
 			decoded, err := fn(strings.TrimSpace(cols[1]))
 			require.NoError(t, err)
@@ -40,4 +50,30 @@ func TestTableDumpColumnParsing(t *testing.T) {
 
 		return buf.String()
 	})
+}
+
+func TestTableDumpConsistency(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	for table := range clusterWideTableDumps {
+		if strings.Contains(table, "fallback") {
+			continue
+		}
+
+		table = strings.TrimSuffix(table, ".txt")
+		_, perCluster := zipInternalTablesPerCluster[table]
+		_, perClusterAcrossDBs := zipInternalTablesPerCluster[fmt.Sprintf(`"".%s`, table)]
+		_, system := zipSystemTables[table]
+		assert.True(t, perCluster || system || perClusterAcrossDBs, "table %s is not in table registry", table)
+	}
+
+	for table := range nodeSpecificTableDumps {
+		if strings.Contains(table, "fallback") {
+			continue
+		}
+
+		table = strings.TrimSuffix(table, ".txt")
+		_, ok := zipInternalTablesPerNode[table]
+		assert.True(t, ok, "table %s is not in table registry", table)
+	}
 }

--- a/pkg/cli/zip_upload_table_dumps_test.go
+++ b/pkg/cli/zip_upload_table_dumps_test.go
@@ -1,0 +1,43 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/datadriven"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTableDumpColumnParsing(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	datadriven.RunTest(t, "testdata/table_dump_column_parsing", func(t *testing.T, d *datadriven.TestData) string {
+		table, ok := clusterWideTableDumps[d.Cmd]
+		require.True(t, ok, "table dump not found: %s", d.Cmd)
+
+		var buf bytes.Buffer
+		for _, line := range strings.Split(strings.TrimSpace(d.Input), "\n") {
+			cols := strings.Fields(strings.TrimSpace(line))
+			fn, ok := table[cols[0]]
+			require.True(t, ok, "column not found: %s", cols[0])
+
+			decoded, err := fn(strings.TrimSpace(cols[1]))
+			require.NoError(t, err)
+
+			raw, err := json.Marshal(decoded)
+			require.NoError(t, err)
+
+			buf.Write(append(raw, '\n'))
+		}
+
+		return buf.String()
+	})
+}

--- a/pkg/cli/zip_upload_test.go
+++ b/pkg/cli/zip_upload_test.go
@@ -134,8 +134,9 @@ func TestUploadZipEndToEnd(t *testing.T) {
 	// those two in this list to avoid unnecessary errors
 	origTableDumps := clusterWideTableDumps
 	clusterWideTableDumps = map[string]columnParserMap{
-		"system.namespace.txt":          {},
-		"crdb_internal.system_jobs.txt": origTableDumps["crdb_internal.system_jobs.txt"],
+		"system.namespace.txt":            {},
+		"crdb_internal.system_jobs.txt":   origTableDumps["crdb_internal.system_jobs.txt"],
+		"crdb_internal.cluster_locks.txt": origTableDumps["crdb_internal.cluster_locks.txt"],
 	}
 	defer func() {
 		clusterWideTableDumps = origTableDumps

--- a/pkg/cli/zip_upload_test.go
+++ b/pkg/cli/zip_upload_test.go
@@ -567,32 +567,6 @@ func TestLogUploadSigSplit(t *testing.T) {
 	}
 }
 
-func TestTableDumpColumnParsing(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-
-	datadriven.RunTest(t, "testdata/table_dump_column_parsing", func(t *testing.T, d *datadriven.TestData) string {
-		table, ok := clusterWideTableDumps[d.Cmd]
-		require.True(t, ok, "table dump not found: %s", d.Cmd)
-
-		var buf bytes.Buffer
-		for _, line := range strings.Split(strings.TrimSpace(d.Input), "\n") {
-			cols := strings.Fields(strings.TrimSpace(line))
-			fn, ok := table[cols[0]]
-			require.True(t, ok, "column not found: %s", cols[0])
-
-			decoded, err := fn(strings.TrimSpace(cols[1]))
-			require.NoError(t, err)
-
-			raw, err := json.Marshal(decoded)
-			require.NoError(t, err)
-
-			buf.Write(append(raw, '\n'))
-		}
-
-		return buf.String()
-	})
-}
-
 func copyZipFiles(t *testing.T, src, dest string) {
 	t.Helper()
 


### PR DESCRIPTION
This PR splits the change into the following two commits to make the diffs more reviewable.

----

pkg/cli: move all table dump upload code to a separate file

The table dump upload code is expected to grow a lot more than other
artifact upload code. Moving this to it's own file will make it easier
to implement/review changes to this part of the code.

Epic: none
Release note: None

----

pkg/cli: add all the remaining table dumps to debugzip upload

This commit adds all the remaining table dumps to the debug zip upload
flow. This concludes the table dump upload work. This commit also
introduces a consistency check to make sure that all the tables
mentioned in this upload flow actually exist (by cross referencing with
the debug zip table registry).

Part of: CC-30998
Epic: CC-28996
Release note: None