### PR TITLE
roachprod-microbench: influx fails on missing benchmark

### DIFF
--- a/pkg/cmd/roachprod-microbench/compare.go
+++ b/pkg/cmd/roachprod-microbench/compare.go
@@ -466,6 +466,10 @@ func (c *compare) pushToInfluxDB() error {
 		}
 
 		for idx, benchmarkName := range cs.Benchmarks {
+			if len(cs.Summaries) == 0 {
+				log.Printf("WARN: no summaries for %s", benchmarkName)
+				continue
+			}
 			sum := cs.Summaries[0][idx]
 			if !sum.Defined() {
 				continue


### PR DESCRIPTION
Previously, the push to influx operation did not handle the case where it could not compute a summary between two runs due to a missing or renamed benchmark. This change adds a check to skip over the benchmark if no summaries are found.

Epic: None
Release note: None