### PR TITLE
sql/schemachanger: Add support for storing policy command and type

### DIFF
--- a/pkg/sql/catalog/catpb/BUILD.bazel
+++ b/pkg/sql/catalog/catpb/BUILD.bazel
@@ -40,6 +40,7 @@ go_library(
         "job_id.go",
         "multiregion.go",
         "privilege.go",
+        "redact.go",
         ":gen-privilegedescversion-stringer",  # keep
     ],
     embed = [":catpb_go_proto"],

--- a/pkg/sql/catalog/catpb/enum.proto
+++ b/pkg/sql/catalog/catpb/enum.proto
@@ -11,6 +11,10 @@ syntax = "proto3";
 package cockroach.sql.catalog.catpb;
 option go_package = "github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb";
 
+// NOTE: When adding new enum types to this file, consider implementing the
+// redact.SafeValue interface if the values are safe to display in redacted logs.
+// This implementation can be added to the redact.go file in this package.
+
 // SystemColumnKind is an enum representing the different kind of system
 // columns that can be synthesized by the execution engine.
 enum SystemColumnKind {
@@ -47,4 +51,29 @@ enum InvertedIndexColumnKind {
   // TRIGRAM is the trigram kind of inverted index column. It's only valid on
   // text columns.
   TRIGRAM = 1;
+}
+
+// Type represents the category of policy.
+//
+// NOTE: When adding a new enum value, ensure it is only utilized after
+// verifying that the cluster version has been finalized. Older versions
+// will validate that only recognized enum values are present.
+enum PolicyType {
+  POLICYTYPE_UNUSED = 0;
+  PERMISSIVE = 1;
+  RESTRICTIVE = 2;
+}
+
+// PolicyCommand specifies the SQL commands to which the policy applies.
+//
+// NOTE: When adding a new enum value, ensure it is only utilized after
+// verifying that the cluster version has been finalized. Older versions
+// will validate that only recognized enum values are present.
+enum PolicyCommand {
+  POLICYCOMMAND_UNUSED = 0;
+  ALL = 1;
+  SELECT = 2;
+  INSERT = 3;
+  UPDATE = 4;
+  DELETE = 5;
 }

--- a/pkg/sql/catalog/catpb/redact.go
+++ b/pkg/sql/catalog/catpb/redact.go
@@ -1,0 +1,12 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package catpb
+
+// SafeValue implements the redact.SafeValue interface.
+func (PolicyType) SafeValue() {}
+
+// SafeValue implements the redact.SafeValue interface.
+func (PolicyCommand) SafeValue() {}

--- a/pkg/sql/catalog/descpb/structured.proto
+++ b/pkg/sql/catalog/descpb/structured.proto
@@ -706,6 +706,12 @@ message PolicyDescriptor {
 
   // The name of the policy. Unique within a table, and cannot be qualified.
   optional string name = 2 [(gogoproto.nullable) = false];
+
+  // Type indicates whether the policy is permissive or restrictive.
+  optional cockroach.sql.catalog.catpb.PolicyType type = 3 [(gogoproto.nullable) = false];
+
+  // Command specifies the SQL commands to which the policy applies.
+  optional cockroach.sql.catalog.catpb.PolicyCommand command = 4 [(gogoproto.nullable) = false];
 }
 
 // A DescriptorMutation represents a column or an index that

--- a/pkg/sql/catalog/tabledesc/validate.go
+++ b/pkg/sql/catalog/tabledesc/validate.go
@@ -2081,6 +2081,14 @@ func (desc *wrapper) validatePolicies() error {
 				p.ID, p.Name, other)
 		}
 		idToName[p.ID] = p.Name
+		if _, ok := catpb.PolicyType_name[int32(p.Type)]; !ok || p.Type == catpb.PolicyType_POLICYTYPE_UNUSED {
+			return errors.AssertionFailedf(
+				"policy %q has an unknown policy type %v", p.Name, p.Type)
+		}
+		if _, ok := catpb.PolicyCommand_name[int32(p.Command)]; !ok || p.Command == catpb.PolicyCommand_POLICYCOMMAND_UNUSED {
+			return errors.AssertionFailedf(
+				"policy %q has an unknown policy command %v", p.Name, p.Command)
+		}
 	}
 	return nil
 }

--- a/pkg/sql/catalog/tabledesc/validate_test.go
+++ b/pkg/sql/catalog/tabledesc/validate_test.go
@@ -3107,12 +3107,16 @@ func TestValidateTableDesc(t *testing.T) {
 				desc.NextPolicyID = 3
 				desc.Policies = []descpb.PolicyDescriptor{
 					{
-						ID:   1,
-						Name: "pol",
+						ID:      1,
+						Name:    "pol",
+						Type:    catpb.PolicyType_PERMISSIVE,
+						Command: catpb.PolicyCommand_ALL,
 					},
 					{
-						ID:   2,
-						Name: "pol",
+						ID:      2,
+						Name:    "pol",
+						Type:    catpb.PolicyType_RESTRICTIVE,
+						Command: catpb.PolicyCommand_INSERT,
 					},
 				}
 			}),
@@ -3122,12 +3126,16 @@ func TestValidateTableDesc(t *testing.T) {
 				desc.NextPolicyID = 11
 				desc.Policies = []descpb.PolicyDescriptor{
 					{
-						ID:   10,
-						Name: "pol_old",
+						ID:      10,
+						Name:    "pol_old",
+						Type:    catpb.PolicyType_RESTRICTIVE,
+						Command: catpb.PolicyCommand_UPDATE,
 					},
 					{
-						ID:   10,
-						Name: "pol_new",
+						ID:      10,
+						Name:    "pol_new",
+						Type:    catpb.PolicyType_PERMISSIVE,
+						Command: catpb.PolicyCommand_DELETE,
 					},
 				}
 			}),
@@ -3137,8 +3145,36 @@ func TestValidateTableDesc(t *testing.T) {
 				desc.NextPolicyID = 5
 				desc.Policies = []descpb.PolicyDescriptor{
 					{
-						ID:   20,
-						Name: "pol",
+						ID:      20,
+						Name:    "pol",
+						Type:    catpb.PolicyType_PERMISSIVE,
+						Command: catpb.PolicyCommand_SELECT,
+					},
+				}
+			}),
+		},
+		{err: `policy "pol" has an unknown policy type POLICYTYPE_UNUSED`,
+			desc: ModifyDescriptor(func(desc *descpb.TableDescriptor) {
+				desc.NextPolicyID = 2
+				desc.Policies = []descpb.PolicyDescriptor{
+					{
+						ID:      1,
+						Name:    "pol",
+						Type:    0,
+						Command: catpb.PolicyCommand_ALL,
+					},
+				}
+			}),
+		},
+		{err: `policy "pol" has an unknown policy command POLICYCOMMAND_UNUSED`,
+			desc: ModifyDescriptor(func(desc *descpb.TableDescriptor) {
+				desc.NextPolicyID = 2
+				desc.Policies = []descpb.PolicyDescriptor{
+					{
+						ID:      1,
+						Name:    "pol",
+						Type:    catpb.PolicyType_PERMISSIVE,
+						Command: 0,
 					},
 				}
 			}),

--- a/pkg/sql/logictest/testdata/logic_test/row_level_security
+++ b/pkg/sql/logictest/testdata/logic_test/row_level_security
@@ -107,4 +107,58 @@ DROP TABLE explicit1;
 statement ok
 SET use_declarative_schema_changer = $use_decl_sc;
 
+subtest policy_type_and_command_ddl
+
+statement ok
+CREATE TABLE multi_pol_tab1 (c1 INT NOT NULL PRIMARY KEY)
+
+statement ok
+CREATE POLICY "policy 1" ON multi_pol_tab1 AS PERMISSIVE
+
+statement ok
+CREATE POLICY "policy 2" ON multi_pol_tab1 AS RESTRICTIVE
+
+statement ok
+CREATE POLICY "policy 3" ON multi_pol_tab1 FOR ALL
+
+statement ok
+CREATE POLICY "policy 4" ON multi_pol_tab1 FOR INSERT
+
+statement ok
+CREATE POLICY "policy 5" ON multi_pol_tab1 FOR UPDATE
+
+statement ok
+CREATE POLICY "policy 6" ON multi_pol_tab1 FOR DELETE
+
+statement ok
+CREATE POLICY "policy 7" ON multi_pol_tab1 FOR SELECT
+
+query TT
+SHOW CREATE TABLE multi_pol_tab1
+----
+multi_pol_tab1  CREATE TABLE public.multi_pol_tab1 (
+                  c1 INT8 NOT NULL,
+                  CONSTRAINT multi_pol_tab1_pkey PRIMARY KEY (c1 ASC)
+                )
+
+statement ok
+DROP POLICY "policy 1" ON multi_pol_tab1
+
+statement ok
+DROP POLICY "policy 3" ON multi_pol_tab1
+
+statement ok
+DROP POLICY "policy 5" ON multi_pol_tab1
+
+query TT
+SHOW CREATE TABLE multi_pol_tab1
+----
+multi_pol_tab1  CREATE TABLE public.multi_pol_tab1 (
+                  c1 INT8 NOT NULL,
+                  CONSTRAINT multi_pol_tab1_pkey PRIMARY KEY (c1 ASC)
+                )
+
+statement ok
+DROP TABLE multi_pol_tab1
+
 subtest end

--- a/pkg/sql/schemachanger/scbuild/testdata/create_policy
+++ b/pkg/sql/schemachanger/scbuild/testdata/create_policy
@@ -1,0 +1,52 @@
+setup
+CREATE TABLE defaultdb.foo (i INT PRIMARY KEY);
+CREATE USER fred;
+----
+
+build
+CREATE POLICY "first policy" on defaultdb.foo AS PERMISSIVE FOR SELECT TO fred USING (i > 0) WITH CHECK (i % 2 = 0);
+----
+- [[IndexData:{DescID: 104, IndexID: 1}, PUBLIC], PUBLIC]
+  {indexId: 1, tableId: 104}
+- [[TableData:{DescID: 104, ReferencedDescID: 100}, PUBLIC], PUBLIC]
+  {databaseId: 100, tableId: 104}
+- [[Policy:{DescID: 104, PolicyID: 1}, PUBLIC], ABSENT]
+  {command: 2, policyId: 1, tableId: 104, type: 1}
+- [[PolicyName:{DescID: 104, Name: first policy, PolicyID: 1}, PUBLIC], ABSENT]
+  {name: first policy, policyId: 1, tableId: 104}
+
+build
+CREATE POLICY "second policy" on defaultdb.foo AS RESTRICTIVE FOR INSERT USING (false);
+----
+- [[IndexData:{DescID: 104, IndexID: 1}, PUBLIC], PUBLIC]
+  {indexId: 1, tableId: 104}
+- [[TableData:{DescID: 104, ReferencedDescID: 100}, PUBLIC], PUBLIC]
+  {databaseId: 100, tableId: 104}
+- [[Policy:{DescID: 104, PolicyID: 1}, PUBLIC], ABSENT]
+  {command: 3, policyId: 1, tableId: 104, type: 2}
+- [[PolicyName:{DescID: 104, Name: second policy, PolicyID: 1}, PUBLIC], ABSENT]
+  {name: second policy, policyId: 1, tableId: 104}
+
+build
+CREATE POLICY "third policy" on defaultdb.foo FOR DELETE TO CURRENT_USER,fred WITH CHECK (i < 0);
+----
+- [[IndexData:{DescID: 104, IndexID: 1}, PUBLIC], PUBLIC]
+  {indexId: 1, tableId: 104}
+- [[TableData:{DescID: 104, ReferencedDescID: 100}, PUBLIC], PUBLIC]
+  {databaseId: 100, tableId: 104}
+- [[Policy:{DescID: 104, PolicyID: 1}, PUBLIC], ABSENT]
+  {command: 5, policyId: 1, tableId: 104, type: 1}
+- [[PolicyName:{DescID: 104, Name: third policy, PolicyID: 1}, PUBLIC], ABSENT]
+  {name: third policy, policyId: 1, tableId: 104}
+
+build
+CREATE POLICY "fourth policy" on defaultdb.foo AS PERMISSIVE TO PUBLIC,CURRENT_SESSION;
+----
+- [[IndexData:{DescID: 104, IndexID: 1}, PUBLIC], PUBLIC]
+  {indexId: 1, tableId: 104}
+- [[TableData:{DescID: 104, ReferencedDescID: 100}, PUBLIC], PUBLIC]
+  {databaseId: 100, tableId: 104}
+- [[Policy:{DescID: 104, PolicyID: 1}, PUBLIC], ABSENT]
+  {command: 1, policyId: 1, tableId: 104, type: 1}
+- [[PolicyName:{DescID: 104, Name: fourth policy, PolicyID: 1}, PUBLIC], ABSENT]
+  {name: fourth policy, policyId: 1, tableId: 104}

--- a/pkg/sql/schemachanger/scbuild/testdata/drop_policy
+++ b/pkg/sql/schemachanger/scbuild/testdata/drop_policy
@@ -1,0 +1,57 @@
+setup
+SET enable_row_level_security = true;
+CREATE TABLE defaultdb.foo (i INT PRIMARY KEY);
+CREATE USER fred;
+CREATE POLICY "first policy" on defaultdb.foo AS PERMISSIVE FOR SELECT TO fred USING (i > 0) WITH CHECK (i % 2 = 0);
+CREATE POLICY "second policy" on defaultdb.foo AS RESTRICTIVE FOR INSERT USING (false);
+CREATE POLICY "third policy" on defaultdb.foo FOR DELETE TO CURRENT_USER,fred WITH CHECK (i < 0);
+CREATE POLICY "fourth policy" on defaultdb.foo AS PERMISSIVE TO PUBLIC,CURRENT_SESSION;
+----
+
+build
+DROP POLICY "first policy" on defaultdb.foo;
+----
+- [[IndexData:{DescID: 104, IndexID: 1}, PUBLIC], PUBLIC]
+  {indexId: 1, tableId: 104}
+- [[Policy:{DescID: 104, PolicyID: 1}, ABSENT], PUBLIC]
+  {command: 2, policyId: 1, tableId: 104, type: 1}
+- [[PolicyName:{DescID: 104, Name: first policy, PolicyID: 1}, ABSENT], PUBLIC]
+  {name: first policy, policyId: 1, tableId: 104}
+- [[TableData:{DescID: 104, ReferencedDescID: 100}, PUBLIC], PUBLIC]
+  {databaseId: 100, tableId: 104}
+
+build
+DROP POLICY "second policy" on defaultdb.foo CASCADE;
+----
+- [[IndexData:{DescID: 104, IndexID: 1}, PUBLIC], PUBLIC]
+  {indexId: 1, tableId: 104}
+- [[Policy:{DescID: 104, PolicyID: 2}, ABSENT], PUBLIC]
+  {command: 3, policyId: 2, tableId: 104, type: 2}
+- [[PolicyName:{DescID: 104, Name: second policy, PolicyID: 2}, ABSENT], PUBLIC]
+  {name: second policy, policyId: 2, tableId: 104}
+- [[TableData:{DescID: 104, ReferencedDescID: 100}, PUBLIC], PUBLIC]
+  {databaseId: 100, tableId: 104}
+
+build
+DROP POLICY "third policy" on defaultdb.foo RESTRICT;
+----
+- [[IndexData:{DescID: 104, IndexID: 1}, PUBLIC], PUBLIC]
+  {indexId: 1, tableId: 104}
+- [[Policy:{DescID: 104, PolicyID: 3}, ABSENT], PUBLIC]
+  {command: 5, policyId: 3, tableId: 104, type: 1}
+- [[PolicyName:{DescID: 104, Name: third policy, PolicyID: 3}, ABSENT], PUBLIC]
+  {name: third policy, policyId: 3, tableId: 104}
+- [[TableData:{DescID: 104, ReferencedDescID: 100}, PUBLIC], PUBLIC]
+  {databaseId: 100, tableId: 104}
+
+build
+DROP POLICY "fourth policy" on defaultdb.foo;
+----
+- [[IndexData:{DescID: 104, IndexID: 1}, PUBLIC], PUBLIC]
+  {indexId: 1, tableId: 104}
+- [[Policy:{DescID: 104, PolicyID: 4}, ABSENT], PUBLIC]
+  {command: 1, policyId: 4, tableId: 104, type: 1}
+- [[PolicyName:{DescID: 104, Name: fourth policy, PolicyID: 4}, ABSENT], PUBLIC]
+  {name: fourth policy, policyId: 4, tableId: 104}
+- [[TableData:{DescID: 104, ReferencedDescID: 100}, PUBLIC], PUBLIC]
+  {databaseId: 100, tableId: 104}

--- a/pkg/sql/schemachanger/scdecomp/decomp.go
+++ b/pkg/sql/schemachanger/scdecomp/decomp.go
@@ -878,6 +878,8 @@ func (w *walkCtx) walkPolicy(tbl catalog.TableDescriptor, p *descpb.PolicyDescri
 	w.ev(scpb.Status_PUBLIC, &scpb.Policy{
 		TableID:  tbl.GetID(),
 		PolicyID: p.ID,
+		Type:     p.Type,
+		Command:  p.Command,
 	})
 	w.ev(scpb.Status_PUBLIC, &scpb.PolicyName{
 		TableID:  tbl.GetID(),

--- a/pkg/sql/schemachanger/scexec/scmutationexec/policy.go
+++ b/pkg/sql/schemachanger/scexec/scmutationexec/policy.go
@@ -22,7 +22,9 @@ func (i *immediateVisitor) AddPolicy(ctx context.Context, op scop.AddPolicy) err
 		tbl.NextPolicyID = op.Policy.PolicyID + 1
 	}
 	tbl.Policies = append(tbl.Policies, descpb.PolicyDescriptor{
-		ID: op.Policy.PolicyID,
+		ID:      op.Policy.PolicyID,
+		Type:    op.Policy.Type,
+		Command: op.Policy.Command,
 	})
 	return nil
 }

--- a/pkg/sql/schemachanger/scpb/elements.proto
+++ b/pkg/sql/schemachanger/scpb/elements.proto
@@ -368,6 +368,8 @@ message SchemaChild {
 message Policy {
   uint32 table_id = 1 [(gogoproto.customname) = "TableID", (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/sql/sem/catid.DescID"];
   uint32 policy_id = 2 [(gogoproto.customname) = "PolicyID", (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/sql/sem/catid.PolicyID"];
+  uint32 type = 3 [(gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb.PolicyType"];
+  uint32 command = 4 [(gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb.PolicyCommand"];
 }
 
 // PolicyName is the name assigned to a specific policy, based on its ID.

--- a/pkg/sql/schemachanger/scpb/uml/table.puml
+++ b/pkg/sql/schemachanger/scpb/uml/table.puml
@@ -302,6 +302,8 @@ object Policy
 
 Policy :  TableID
 Policy :  PolicyID
+Policy :  Type
+Policy :  Command
 
 object PolicyName
 

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_policy/create_policy.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_policy/create_policy.explain
@@ -11,7 +11,7 @@ Schema change plan for CREATE POLICY ‹"policy 1"› ON ‹t1› AS PERMISSIVE 
  │         │    ├── ABSENT → PUBLIC Policy:{DescID: 104 (t1), PolicyID: 1}
  │         │    └── ABSENT → PUBLIC PolicyName:{DescID: 104 (t1), Name: "policy 1", PolicyID: 1}
  │         └── 2 Mutation operations
- │              ├── AddPolicy {"Policy":{"PolicyID":1,"TableID":104}}
+ │              ├── AddPolicy {"Policy":{"Command":2,"PolicyID":1,"TableID":104,"Type":1}}
  │              └── SetPolicyName {"Name":"policy 1","PolicyID":1,"TableID":104}
  └── PreCommitPhase
       ├── Stage 1 of 2 in PreCommitPhase
@@ -25,5 +25,5 @@ Schema change plan for CREATE POLICY ‹"policy 1"› ON ‹t1› AS PERMISSIVE 
            │    ├── ABSENT → PUBLIC Policy:{DescID: 104 (t1), PolicyID: 1}
            │    └── ABSENT → PUBLIC PolicyName:{DescID: 104 (t1), Name: "policy 1", PolicyID: 1}
            └── 2 Mutation operations
-                ├── AddPolicy {"Policy":{"PolicyID":1,"TableID":104}}
+                ├── AddPolicy {"Policy":{"Command":2,"PolicyID":1,"TableID":104,"Type":1}}
                 └── SetPolicyName {"Name":"policy 1","PolicyID":1,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_policy/create_policy.side_effects
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_policy/create_policy.side_effects
@@ -19,8 +19,10 @@ upsert descriptor #104
   +  nextPolicyId: 2
      parentId: 100
   +  policies:
-  +  - id: 1
+  +  - command: SELECT
+  +    id: 1
   +    name: policy 1
+  +    type: PERMISSIVE
      primaryIndex:
        constraintId: 1
   ...
@@ -41,8 +43,10 @@ upsert descriptor #104
   +  nextPolicyId: 2
      parentId: 100
   +  policies:
-  +  - id: 1
+  +  - command: SELECT
+  +    id: 1
   +    name: policy 1
+  +    type: PERMISSIVE
      primaryIndex:
        constraintId: 1
   ...

--- a/pkg/sql/schemachanger/testdata/end_to_end/drop_policy/drop_policy.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/drop_policy/drop_policy.explain
@@ -15,7 +15,7 @@ Schema change plan for DROP POLICY ‹"policy 2"› ON ‹t1›;
  │         │    └── PUBLIC → ABSENT PolicyName:{DescID: 104 (t1), Name: "policy 2", PolicyID: 2}
  │         └── 2 Mutation operations
  │              ├── SetPolicyName {"Name":"crdb_internal_po...","PolicyID":2,"TableID":104}
- │              └── RemovePolicy {"Policy":{"PolicyID":2,"TableID":104}}
+ │              └── RemovePolicy {"Policy":{"Command":3,"PolicyID":2,"TableID":104,"Type":1}}
  └── PreCommitPhase
       ├── Stage 1 of 2 in PreCommitPhase
       │    ├── 2 elements transitioning toward ABSENT
@@ -29,4 +29,4 @@ Schema change plan for DROP POLICY ‹"policy 2"› ON ‹t1›;
            │    └── PUBLIC → ABSENT PolicyName:{DescID: 104 (t1), Name: "policy 2", PolicyID: 2}
            └── 2 Mutation operations
                 ├── SetPolicyName {"Name":"crdb_internal_po...","PolicyID":2,"TableID":104}
-                └── RemovePolicy {"Policy":{"PolicyID":2,"TableID":104}}
+                └── RemovePolicy {"Policy":{"Command":3,"PolicyID":2,"TableID":104,"Type":1}}

--- a/pkg/sql/schemachanger/testdata/end_to_end/drop_policy/drop_policy.side_effects
+++ b/pkg/sql/schemachanger/testdata/end_to_end/drop_policy/drop_policy.side_effects
@@ -17,10 +17,12 @@ increment telemetry for sql.schema.drop_policy
 ## StatementPhase stage 1 of 1 with 2 MutationType ops
 upsert descriptor #104
   ...
-     - id: 1
        name: policy 1
-  -  - id: 2
+       type: PERMISSIVE
+  -  - command: INSERT
+  -    id: 2
   -    name: policy 2
+  -    type: PERMISSIVE
      primaryIndex:
        constraintId: 1
   ...
@@ -36,10 +38,12 @@ persist all catalog changes to storage
 ## PreCommitPhase stage 2 of 2 with 2 MutationType ops
 upsert descriptor #104
   ...
-     - id: 1
        name: policy 1
-  -  - id: 2
+       type: PERMISSIVE
+  -  - command: INSERT
+  -    id: 2
   -    name: policy 2
+  -    type: PERMISSIVE
      primaryIndex:
        constraintId: 1
   ...

--- a/pkg/testutils/lint/passes/redactcheck/redactcheck.go
+++ b/pkg/testutils/lint/passes/redactcheck/redactcheck.go
@@ -173,8 +173,10 @@ func runAnalyzer(pass *analysis.Pass) (interface{}, error) {
 						"LicType": {},
 					},
 					"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb": {
-						"JobID":      {},
-						"ScheduleID": {},
+						"JobID":         {},
+						"PolicyCommand": {},
+						"PolicyType":    {},
+						"ScheduleID":    {},
 					},
 					"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb": {
 						"ConstraintValidity":           {},


### PR DESCRIPTION
A previous commit introduced basic support for CREATE/DROP POLICY. This commit expands on that functionality by storing additional details in the policy descriptor. Specifically, it adds support for storing the policy type (restrictive or permissive) and the policy command (ALL, SELECT, INSERT, UPDATE, or DELETE).

Since neither the policy type nor the policy command will be modifiable via ALTER POLICY, these attributes are included in the Policy element within the DSC, rather than as separate elements.

Epic: CRDB-11724
Informs: #136696
Release note: None