### PR TITLE
roachtest: cleaning up microceph cluster

### DIFF
--- a/pkg/cmd/roachtest/tests/s3_clone_backup_restore.go
+++ b/pkg/cmd/roachtest/tests/s3_clone_backup_restore.go
@@ -60,6 +60,7 @@ func registerBackupS3Clones(r registry.Registry) {
 					version: cephVersion,
 				}
 				ceph.install(ctx)
+				defer ceph.cleanup(ctx)
 				v.validateBackupRestore(ctx, ceph)
 			},
 		})


### PR DESCRIPTION
The microceph cluster must be removed at the end of test to allow for the node to be reused.