### PR TITLE
roachtest: prepare sysbench through haproxy

### DIFF
--- a/pkg/cmd/roachtest/tests/sysbench.go
+++ b/pkg/cmd/roachtest/tests/sysbench.go
@@ -185,7 +185,7 @@ func runSysbench(ctx context.Context, t test.Test, c cluster.Cluster, opts sysbe
 	var start time.Time
 	runWorkload := func(ctx context.Context) error {
 		t.Status("preparing workload")
-		c.Run(ctx, option.WithNodes(c.WorkloadNode()), opts.cmd(false /* haproxy */)+" prepare")
+		c.Run(ctx, option.WithNodes(c.WorkloadNode()), opts.cmd(true /* haproxy */)+" prepare")
 
 		t.Status("running workload")
 		cmd := opts.cmd(useHAProxy /* haproxy */) + " run"


### PR DESCRIPTION
Pointing `sysbench prepare` at n1 reliably overloads n1. At time of writing, it will reliably spend the first few minutes of `sysbench run` receiving snapshots. In other words, the benchmark results don't represent actual performance.

I did some archaeology to determine why we were bypassing haproxy in the first place, and it turns out that it's because in 2018[^1] the index creations triggered by `prepare` would reliably overwhelm at least one of the nodes, which in turn would prompt `haproxy` to tear down the connections. `sysbench` would react to this by segfaulting; talking directly to n1 was a work-around.

Now that seven years have passed and we have introduced various defenses via admission control, let's try to use haproxy again during bulk loading. Ideally, we end up with much more stable benchmark results that represent CockroachDB's actual performance under this workload.

[^1]: https://github.com/cockroachdb/cockroach/issues/32738

Epic: CRDB-42584

Release note: None