### PR TITLE
changefeedccl/kvfeed: pass consumer id correctly

### DIFF
--- a/pkg/ccl/changefeedccl/kvfeed/physical_kv_feed.go
+++ b/pkg/ccl/changefeedccl/kvfeed/physical_kv_feed.go
@@ -97,6 +97,7 @@ func (p rangefeedFactory) Run(ctx context.Context, sink kvevent.Writer, cfg rang
 	if cfg.RangeObserver != nil {
 		rfOpts = append(rfOpts, kvcoord.WithRangeObserver(cfg.RangeObserver))
 	}
+	rfOpts = append(rfOpts, kvcoord.WithConsumerID(cfg.ConsumerID))
 	if len(cfg.Knobs.RangefeedOptions) != 0 {
 		rfOpts = append(rfOpts, cfg.Knobs.RangefeedOptions...)
 	}


### PR DESCRIPTION
Previously, we introduced the concept of a consumer ID to prevent a single
changefeed job from over-consuming the catch-up scan quota and blocking other
consumers from making progress on the server side. However, the changefeed
client-side code requires the consumer ID to be passed again in the rangefeed
options during rangefeedFactory.Run. This was missing in the previous
PR, causing the changefeed job ID to default to zero. This patch fixes
the issue by ensuring the consumer ID is correctly passed in the
rangefeed options.

Related: https://github.com/cockroachdb/cockroach/pull/133789
Release note: none
Epic: none