### PR TITLE
roachprod: promhelper fix project and wipe

### DIFF
--- a/pkg/roachprod/install/cluster_synced.go
+++ b/pkg/roachprod/install/cluster_synced.go
@@ -593,7 +593,7 @@ func (c *SyncedCluster) Wipe(ctx context.Context, l *logger.Logger, preserveCert
 	if err := c.Stop(ctx, l, int(unix.SIGKILL), true /* wait */, 0 /* gracePeriod */, ""); err != nil {
 		return err
 	}
-	return c.Parallel(ctx, l, WithNodes(c.Nodes).WithDisplay(display), func(ctx context.Context, node Node) (*RunResultDetails, error) {
+	err := c.Parallel(ctx, l, WithNodes(c.Nodes).WithDisplay(display), func(ctx context.Context, node Node) (*RunResultDetails, error) {
 		var cmd string
 		if c.IsLocal() {
 			// Not all shells like brace expansion, so we'll do it here
@@ -622,6 +622,16 @@ func (c *SyncedCluster) Wipe(ctx context.Context, l *logger.Logger, preserveCert
 		}
 		return c.runCmdOnSingleNode(ctx, l, node, cmd, defaultCmdOpts("wipe"))
 	})
+	if err != nil {
+		return err
+	}
+
+	err = c.Cluster.DeletePrometheusConfig(ctx, l)
+	if err != nil {
+		l.Printf("WARNING: failed to delete the prometheus config (already wiped?): %s", err)
+	}
+
+	return nil
 }
 
 // NodeStatus contains details about the status of a node.

--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -815,32 +815,39 @@ func updatePrometheusTargets(
 		return err
 	}
 
+	cl := promhelperclient.NewPromClient()
 	nodeIPPorts := make(map[int]*promhelperclient.NodeInfo)
 	nodeIPPortsMutex := syncutil.RWMutex{}
 	var wg sync.WaitGroup
 	for _, node := range c.Nodes {
-		if _, ok := promhelperclient.SupportedPromProjects[c.VMs[node-1].Project]; ok &&
-			c.VMs[node-1].Provider == gce.ProviderName {
-			wg.Add(1)
-			go func(index int, v vm.VM) {
-				defer wg.Done()
-				// only gce is supported for prometheus
-				desc, err := c.DiscoverService(ctx, install.Node(index), "", install.ServiceTypeUI, 0)
-				if err != nil {
-					l.Errorf("error getting the port for node %d: %v", index, err)
-					return
-				}
-				nodeInfo := fmt.Sprintf("%s:%d", v.PrivateIP, desc.Port)
-				nodeIPPortsMutex.Lock()
-				// ensure atomicity in map update
-				nodeIPPorts[index] = &promhelperclient.NodeInfo{Target: nodeInfo, CustomLabels: createLabels(v)}
-				nodeIPPortsMutex.Unlock()
-			}(int(node), c.VMs[node-1])
+
+		// only gce is supported for prometheus
+		if !cl.IsSupportedNodeProvider(c.VMs[node-1].Provider) {
+			continue
 		}
+		if !cl.IsSupportedPromProject(c.VMs[node-1].Project) {
+			continue
+		}
+
+		wg.Add(1)
+		go func(index int, v vm.VM) {
+			defer wg.Done()
+			desc, err := c.DiscoverService(ctx, install.Node(index), "", install.ServiceTypeUI, 0)
+			if err != nil {
+				l.Errorf("error getting the port for node %d: %v", index, err)
+				return
+			}
+			nodeInfo := fmt.Sprintf("%s:%d", v.PrivateIP, desc.Port)
+			nodeIPPortsMutex.Lock()
+			// ensure atomicity in map update
+			nodeIPPorts[index] = &promhelperclient.NodeInfo{Target: nodeInfo, CustomLabels: createLabels(v)}
+			nodeIPPortsMutex.Unlock()
+		}(int(node), c.VMs[node-1])
+
 	}
 	wg.Wait()
 	if len(nodeIPPorts) > 0 {
-		if err := promhelperclient.DefaultPromClient.UpdatePrometheusTargets(ctx,
+		if err := cl.UpdatePrometheusTargets(ctx,
 			c.Name, false, nodeIPPorts, !c.Secure, l); err != nil {
 			l.Errorf("creating cluster config failed for the ip:ports %v: %v", nodeIPPorts, err)
 		}


### PR DESCRIPTION
This PR fixes a bug introduced in #138711 and also adds deletion of Prometheus targets at cluster wipe.

Before #138711, the GCE provider defaults were defined during init(). This logic was moved to an init function to allow the `drtprod` command to define its own defaults via environment variables. This introduced a state in which where the promhelper client's defaults for `SupportedPromProject` is initialized with `gce.DefaultProject()` before this value is initialized, and no Prometheus targets are ever pushed.

This PR removes the `promhelperclient.DefaultClient` that should not be used anymore, and computing the defaults in `NewPromClient()`. This PR also delegates the checks on whether or not providers and projects are supported to the promhelperclient package to simplify the logic in the callers.

Also, prior to this PR, if an `insecure` cluster was reused as a `secure` cluster during a `roachtest` run, the promhelper client would delete the `secure` configuration during cluster destruction, but would leave the `insecure` configuration (as the promhelper clients tries to delete `secure` first, then `insecure` if not found). This was creating stale Prometheus targets.

This PR introduces the deletion of the Prometheus targets at cluster wipe to fix this.

Epic: none
Release note: None