### PR TITLE
crosscluster/physical: return job id in SHOW TENANT WITH REPLICATION STATUS

### DIFF
--- a/pkg/crosscluster/physical/testdata/simple
+++ b/pkg/crosscluster/physical/testdata/simple
@@ -38,9 +38,9 @@ repstream job id=$_producerJobID
 
 
 query-sql as=source-system
-SHOW TENANT source WITH REPLICATION STATUS
+select id, name, status FROM [SHOW TENANT source WITH REPLICATION STATUS]
 ----
-10 source <nil> <nil> <nil> <nil> <nil> <nil> ready
+10 source ready
 
 exec-sql as=source-tenant
 CREATE TABLE d.x (id INT PRIMARY KEY, n INT);

--- a/pkg/sql/catalog/colinfo/result_columns.go
+++ b/pkg/sql/catalog/colinfo/result_columns.go
@@ -302,6 +302,7 @@ var TenantColumnsNoReplication = ResultColumns{
 // TenantColumnsWithReplication is appended to TenantColumns for SHOW VIRTUAL
 // CLUSTER ... WITH REPLICATION STATUS queries.
 var TenantColumnsWithReplication = ResultColumns{
+	{Name: "ingestion_job_id", Typ: types.Int},
 	{Name: "source_tenant_name", Typ: types.String},
 	{Name: "source_cluster_uri", Typ: types.String},
 	// The protected timestamp on the destination cluster, meaning we cannot

--- a/pkg/sql/show_tenant.go
+++ b/pkg/sql/show_tenant.go
@@ -226,6 +226,7 @@ func (n *showTenantNode) Values() tree.Datums {
 		)
 	} else {
 		// This is a 'SHOW VIRTUAL CLUSTER name WITH REPLICATION STATUS' command.
+		replicationJobID := tree.DNull
 		sourceTenantName := tree.DNull
 		sourceClusterUri := tree.DNull
 		replicatedTimestamp := tree.DNull
@@ -235,6 +236,7 @@ func (n *showTenantNode) Values() tree.Datums {
 
 		replicationInfo := v.replicationInfo
 		if replicationInfo != nil {
+			replicationJobID = tree.NewDInt(tree.DInt(v.tenantInfo.PhysicalReplicationConsumerJobID))
 			sourceTenantName = tree.NewDString(string(replicationInfo.IngestionDetails.SourceTenantName))
 			sourceClusterUri = tree.NewDString(replicationInfo.IngestionDetails.SourceClusterConnUri)
 			if replicationInfo.ReplicationLagInfo != nil {
@@ -265,6 +267,7 @@ func (n *showTenantNode) Values() tree.Datums {
 		}
 
 		result = append(result,
+			replicationJobID,
 			sourceTenantName,
 			sourceClusterUri,
 			retainedTimestamp,


### PR DESCRIPTION
Fixes #138548

Release note (sql change): SHOW TENANT WITH REPLICATION STATUS will now display the `ingestion_job_id` column after the `name` column.