### PR TITLE
roachtest: fix WaitForReady bugs

### DIFF
--- a/pkg/cmd/roachtest/roachtestutil/utils.go
+++ b/pkg/cmd/roachtest/roachtestutil/utils.go
@@ -189,7 +189,7 @@ func WaitForReady(
 ) {
 	client := DefaultHTTPClient(c, t.L())
 	checkReady := func(ctx context.Context, url string) error {
-		resp, err := client.Get(ctx, url)
+		resp, err := client.client.Get(ctx, url)
 		if err != nil {
 			return err
 		}
@@ -212,13 +212,13 @@ func WaitForReady(
 			for i, adminAddr := range adminAddrs {
 				url := fmt.Sprintf(`https://%s/health?ready=1`, adminAddr)
 
-				for err := checkReady(ctx, url); err != nil; err = checkReady(ctx, url) {
+				for err := checkReady(ctx, url); err != nil && ctx.Err() == nil; err = checkReady(ctx, url) {
 					t.L().Printf("n%d not ready, retrying: %s", nodes[i], err)
 					time.Sleep(time.Second)
 				}
 				t.L().Printf("n%d is ready", nodes[i])
 			}
-			return nil
+			return ctx.Err()
 		},
 	))
 }


### PR DESCRIPTION
WaitForReady was not properly handling when the deadline of a timeout context was reached while waiting for the cluster to be ready. Previously, hitting the timeout would result in the roachtest running for 10 minutes until the whole test timed out. Now, WaitForReady respects when the timeutil.RunWithTimeout context times out.

Updated WaitForReady's checkReady func to use RoachtestHTTPClient's http client when making the call to GET /health?ready=1 instead of RoachtestHTTPClient's wrapper method. This wrapper method attempts to authenticate the user if no session id exists, but this endpoint doesn't require authentication so it doesnt need to use the wrapper method.

Fixes: #138143
Resolves: #136128
Epic: None
Release note: None