### PR TITLE
release-24.2: roachprod: fix Prometheus target deletion

### DIFF
--- a/pkg/roachprod/cloud/cluster_cloud.go
+++ b/pkg/roachprod/cloud/cluster_cloud.go
@@ -11,7 +11,6 @@ import (
 	"fmt"
 	"regexp"
 	"sort"
-	"strings"
 	"text/tabwriter"
 	"time"
 
@@ -410,7 +409,7 @@ func DestroyCluster(l *logger.Logger, c *Cluster) error {
 				// TODO(bhaskar): Obtain secure cluster information.
 				// Cluster does not have the information on secure or not. So, we retry as insecure
 				// if delete fails with cluster as secure
-				if strings.Contains(err.Error(), "request failed with status 404") {
+				if promhelperclient.IsNotFoundError(err) {
 					if err = promhelperclient.NewPromClient().DeleteClusterConfig(context.Background(),
 						c.Name, false, true /* insecure */, l); err != nil {
 						l.Errorf("Failed to delete the cluster config with cluster as insecure and secure: %v", err)


### PR DESCRIPTION
Backport 1/1 commits from #138772.

/cc @cockroachdb/release

---

During the cluster deletion step, it is unknown if the cluster was start with  the `--insecure` option, so the deletion of the Prometheus targets is attempted via the prom-helper-service on the secure targets endpoint first and, in case of NotFound error, attempted again on the insecure targets endpoint.

This retry mechanism was previously based on the parsing of a 404 status error message. The error message got updated in a previous patch to add more details, which rendered the error message paring obsolete, and left staled insecure targets in the Prometheus configuraiton.

To address this, this PR moves the logic of identifying a NotFound error to the promhelperclient package, which is also now internally based on constant error messages.

Epic: none
Release note: None
Fixes: #120706

---

Release justification: test-only change