### PR TITLE
build: update patch-prepare-repo.sh script

### DIFF
--- a/build/scripts/patch-prepare-repo.sh
+++ b/build/scripts/patch-prepare-repo.sh
@@ -75,7 +75,7 @@ fi
 (
   cd "$CRDB_ROOT"
   set -x
-  bazel run @bazel_gazelle//cmd/gazelle -- update ${@:3} --go_prefix="$IMPORT_PATH" --repo_root=$REPO_DIR $REPO_DIR
+  bazel run @bazel_gazelle//cmd/gazelle -- update ${@:3} --go_naming_convention=import_alias --go_prefix="$IMPORT_PATH" --repo_root=$REPO_DIR $REPO_DIR
 )
 
 git add -A


### PR DESCRIPTION
Add `--go_naming_convention=import_alias` to the gazelle flags. This
makes the `BUILD.bazel` files consistent with those generated during the
crdb build, and the Pebble patch applies cleanly.

Epic: none
Release note: None