### PR TITLE
release-24.2: roachprod: promhelper fix project and wipe

### DIFF
--- a/pkg/roachprod/cloud/cluster_cloud.go
+++ b/pkg/roachprod/cloud/cluster_cloud.go
@@ -397,35 +397,61 @@ func ShrinkCluster(l *logger.Logger, c *Cluster, numNodes int) error {
 	})
 }
 
+func (c *Cluster) DeletePrometheusConfig(ctx context.Context, l *logger.Logger) error {
+
+	cl := promhelperclient.NewPromClient()
+
+	stopSpinner := ui.NewDefaultSpinner(l, "Destroying Prometheus configs").Start()
+	defer stopSpinner()
+
+	for _, node := range c.VMs {
+
+		// only gce is supported for prometheus
+		if !cl.IsSupportedNodeProvider(node.Provider) {
+			continue
+		}
+		if !cl.IsSupportedPromProject(node.Project) {
+			continue
+		}
+
+		err := cl.DeleteClusterConfig(ctx, c.Name, false, false /* insecure */, l)
+		if err != nil {
+
+			if !promhelperclient.IsNotFoundError(err) {
+				return errors.Wrapf(
+					err,
+					"failed to delete the cluster config with cluster as secure",
+				)
+			}
+
+			// TODO(bhaskar): Obtain secure cluster information.
+			// Cluster does not have the information on secure or not.
+			// So, we retry as insecure  if delete fails with cluster as secure.
+			if err = cl.DeleteClusterConfig(ctx, c.Name, false, true /* insecure */, l); err != nil {
+				return errors.Wrapf(
+					err,
+					"failed to delete the cluster config with cluster as insecure and secure",
+				)
+			}
+
+		}
+		break
+
+	}
+
+	return nil
+}
+
 // DestroyCluster TODO(peter): document
 func DestroyCluster(l *logger.Logger, c *Cluster) error {
-	stopSpinner := ui.NewDefaultSpinner(l, "Destroying Prometheus configs").Start()
-	// check if any node is supported as promhelper cluster
-	for _, node := range c.VMs {
-		if _, ok := promhelperclient.SupportedPromProjects[node.Project]; ok &&
-			node.Provider == gce.ProviderName {
-			if err := promhelperclient.NewPromClient().DeleteClusterConfig(context.Background(),
-				c.Name, false, false /* insecure */, l); err != nil {
-				// TODO(bhaskar): Obtain secure cluster information.
-				// Cluster does not have the information on secure or not. So, we retry as insecure
-				// if delete fails with cluster as secure
-				if promhelperclient.IsNotFoundError(err) {
-					if err = promhelperclient.NewPromClient().DeleteClusterConfig(context.Background(),
-						c.Name, false, true /* insecure */, l); err != nil {
-						l.Errorf("Failed to delete the cluster config with cluster as insecure and secure: %v", err)
-					}
-				} else {
-					l.Errorf("Failed to delete the cluster config with cluster as secure: %v", err)
-				}
-			}
-			break
-		}
+
+	if err := c.DeletePrometheusConfig(context.Background(), l); err != nil {
+		l.Printf("WARNING: failed to delete the prometheus config (already wiped?): %s", err)
 	}
-	stopSpinner()
 
 	// DNS entries are destroyed first to ensure that the GC job will not try
 	// and clean-up entries prematurely.
-	stopSpinner = ui.NewDefaultSpinner(l, "Destroying DNS entries").Start()
+	stopSpinner := ui.NewDefaultSpinner(l, "Destroying DNS entries").Start()
 	dnsErr := vm.FanOutDNS(c.VMs, func(p vm.DNSProvider, vms vm.List) error {
 		return p.DeleteRecordsBySubdomain(context.Background(), c.Name)
 	})

--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -788,32 +788,39 @@ func UpdateTargets(
 
 // updatePrometheusTargets updates the prometheus instance cluster config. Any error is logged and ignored.
 func updatePrometheusTargets(ctx context.Context, l *logger.Logger, c *install.SyncedCluster) {
+	cl := promhelperclient.NewPromClient()
 	nodeIPPorts := make(map[int]*promhelperclient.NodeInfo)
 	nodeIPPortsMutex := syncutil.RWMutex{}
 	var wg sync.WaitGroup
 	for _, node := range c.Nodes {
-		if _, ok := promhelperclient.SupportedPromProjects[c.VMs[node-1].Project]; ok &&
-			c.VMs[node-1].Provider == gce.ProviderName {
-			wg.Add(1)
-			go func(index int, v vm.VM) {
-				defer wg.Done()
-				// only gce is supported for prometheus
-				desc, err := c.DiscoverService(ctx, install.Node(index), "", install.ServiceTypeUI, 0)
-				if err != nil {
-					l.Errorf("error getting the port for node %d: %v", index, err)
-					return
-				}
-				nodeInfo := fmt.Sprintf("%s:%d", v.PrivateIP, desc.Port)
-				nodeIPPortsMutex.Lock()
-				// ensure atomicity in map update
-				nodeIPPorts[index] = &promhelperclient.NodeInfo{Target: nodeInfo, CustomLabels: createLabels(v)}
-				nodeIPPortsMutex.Unlock()
-			}(int(node), c.VMs[node-1])
+
+		// only gce is supported for prometheus
+		if !cl.IsSupportedNodeProvider(c.VMs[node-1].Provider) {
+			continue
 		}
+		if !cl.IsSupportedPromProject(c.VMs[node-1].Project) {
+			continue
+		}
+
+		wg.Add(1)
+		go func(index int, v vm.VM) {
+			defer wg.Done()
+			desc, err := c.DiscoverService(ctx, install.Node(index), "", install.ServiceTypeUI, 0)
+			if err != nil {
+				l.Errorf("error getting the port for node %d: %v", index, err)
+				return
+			}
+			nodeInfo := fmt.Sprintf("%s:%d", v.PrivateIP, desc.Port)
+			nodeIPPortsMutex.Lock()
+			// ensure atomicity in map update
+			nodeIPPorts[index] = &promhelperclient.NodeInfo{Target: nodeInfo, CustomLabels: createLabels(v)}
+			nodeIPPortsMutex.Unlock()
+		}(int(node), c.VMs[node-1])
+
 	}
 	wg.Wait()
 	if len(nodeIPPorts) > 0 {
-		if err := promhelperclient.DefaultPromClient.UpdatePrometheusTargets(ctx,
+		if err := cl.UpdatePrometheusTargets(ctx,
 			c.Name, false, nodeIPPorts, !c.Secure, l); err != nil {
 			l.Errorf("creating cluster config failed for the ip:ports %v: %v", nodeIPPorts, err)
 		}


### PR DESCRIPTION
Backport 1/1 commits from #138960.

/cc @cockroachdb/release

---

This PR fixes a bug introduced in #138711 and also adds deletion of Prometheus targets at cluster wipe.

Before #138711, the GCE provider defaults were defined during init(). This logic was moved to an init function to allow the `drtprod` command to define its own defaults via environment variables. This introduced a state in which where the promhelper client's defaults for `SupportedPromProject` is initialized with `gce.DefaultProject()` before this value is initialized, and no Prometheus targets are ever pushed.

This PR removes the `promhelperclient.DefaultClient` that should not be used anymore, and computing the defaults in `NewPromClient()`. This PR also delegates the checks on whether or not providers and projects are supported to the promhelperclient package to simplify the logic in the callers.

Also, prior to this PR, if an `insecure` cluster was reused as a `secure` cluster during a `roachtest` run, the promhelper client would delete the `secure` configuration during cluster destruction, but would leave the `insecure` configuration (as the promhelper clients tries to delete `secure` first, then `insecure` if not found). This was creating stale Prometheus targets.

This PR introduces the deletion of the Prometheus targets at cluster wipe to fix this.

Epic: none
Release note: None

---

Release justification: test-only change