### PR TITLE
release-24.2: sql: allow creating or dropping roles while membership cache is being used

### DIFF
--- a/pkg/sql/authorization.go
+++ b/pkg/sql/authorization.go
@@ -614,27 +614,57 @@ func MemberOfWithAdminOption(
 	roleMembersCache := execCfg.RoleMemberCache
 
 	// Lookup table version.
-	_, tableDesc, err := descs.PrefixAndTable(
+	_, roleMembersTableDesc, err := descs.PrefixAndTable(
 		ctx, txn.Descriptors().ByNameWithLeased(txn.KV()).Get(), &roleMembersTableName,
 	)
 	if err != nil {
 		return nil, err
 	}
 
-	tableVersion := tableDesc.GetVersion()
-	if tableDesc.IsUncommittedVersion() {
+	tableVersion := roleMembersTableDesc.GetVersion()
+	if roleMembersTableDesc.IsUncommittedVersion() {
 		return resolveMemberOfWithAdminOption(ctx, member, txn)
 	}
 	if txn.SessionData().AllowRoleMembershipsToChangeDuringTransaction {
+		systemUsersTableDesc, err := txn.Descriptors().ByIDWithLeased(txn.KV()).Get().Table(ctx, keys.UsersTableID)
+		if err != nil {
+			return nil, err
+		}
+
+		roleOptionsTableDesc, err := txn.Descriptors().ByIDWithLeased(txn.KV()).Get().Table(ctx, keys.RoleOptionsTableID)
+		if err != nil {
+			return nil, err
+		}
+
+		systemUsersTableVersion := systemUsersTableDesc.GetVersion()
+		if systemUsersTableDesc.IsUncommittedVersion() {
+			return resolveMemberOfWithAdminOption(ctx, member, txn)
+		}
+
+		roleOptionsTableVersion := roleOptionsTableDesc.GetVersion()
+		if roleOptionsTableDesc.IsUncommittedVersion() {
+			return resolveMemberOfWithAdminOption(ctx, member, txn)
+		}
+
 		defer func() {
 			if retErr != nil {
 				return
 			}
 			txn.Descriptors().ReleaseSpecifiedLeases(ctx, []lease.IDVersion{
 				{
-					Name:    tableDesc.GetName(),
-					ID:      tableDesc.GetID(),
+					Name:    roleMembersTableDesc.GetName(),
+					ID:      roleMembersTableDesc.GetID(),
 					Version: tableVersion,
+				},
+				{
+					Name:    systemUsersTableDesc.GetName(),
+					ID:      systemUsersTableDesc.GetID(),
+					Version: systemUsersTableVersion,
+				},
+				{
+					Name:    roleOptionsTableDesc.GetName(),
+					ID:      roleOptionsTableDesc.GetID(),
+					Version: roleOptionsTableVersion,
 				},
 			})
 		}()


### PR DESCRIPTION
Backport 1/1 commits from #137940.

/cc @cockroachdb/release

---

When we set `allow_role_memberships_to_change_during_transaction` we should be able to create and drop users even when there are contending transactions on the `system.users` and `system.role_options`. These code changes release the locks on those system tables when `allow_role_memberships_to_change_during_transaction` is set.

Fixes: #137710
Release note (bug fix): When we set `allow_role_memberships_to_change_during_transaction` are able to create and drop users quickly even when there are contending transactions on the `system.users` and `system.role_options`.

Release justification: Fix a performance issue related to this escalation https://github.com/cockroachlabs/support/issues/3098.
