### PR TITLE
roachtest: disable shared process rebalance/by-load roachtests

### DIFF
--- a/pkg/cmd/roachtest/tests/rebalance_load.go
+++ b/pkg/cmd/roachtest/tests/rebalance_load.go
@@ -96,6 +96,12 @@ func registerRebalanceLoad(r registry.Registry) {
 				),
 				// Only use the latest version of each release to work around #127029.
 				mixedversion.AlwaysUseLatestPredecessors,
+				// TODO(kvoli): Re-enable shared process deployments for mixed version
+				// variant #139037.
+				mixedversion.EnabledDeploymentModes(
+					mixedversion.SystemOnlyDeployment,
+					mixedversion.SeparateProcessDeployment,
+				),
 			)
 			mvt.OnStartup("maybe enable split/scatter on tenant",
 				func(ctx context.Context, l *logger.Logger, r *rand.Rand, h *mixedversion.Helper) error {


### PR DESCRIPTION
In #129117, shared process deployments were added to the `rebalance/by-load/*/mixed-version` roachtests. Despite multiple deflaking attempts (#131787, #133681, #136115, #136116), these continue to fail weekly. The root cause is currently unknown.

Part of: #139037
Release note: None