### PR TITLE
crosscluster/logical: ensure offline scan procs shut down before next phase

### DIFF
--- a/pkg/crosscluster/logical/BUILD.bazel
+++ b/pkg/crosscluster/logical/BUILD.bazel
@@ -30,6 +30,7 @@ go_library(
         "//pkg/crosscluster/replicationutils",
         "//pkg/crosscluster/streamclient",
         "//pkg/jobs",
+        "//pkg/jobs/ingeststopped",
         "//pkg/jobs/jobspb",
         "//pkg/jobs/jobsprofiler",
         "//pkg/keys",

--- a/pkg/crosscluster/logical/offline_initial_scan_processor.go
+++ b/pkg/crosscluster/logical/offline_initial_scan_processor.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/repstream/streampb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
@@ -197,6 +198,8 @@ func (o *offlineInitialScanProcessor) Start(ctx context.Context) {
 	ctx = logtags.AddTags(ctx, tags)
 
 	ctx = o.StartInternal(ctx, offlineInitialScanProcessorName)
+
+	defer o.FlowCtx.Cfg.JobRegistry.MarkAsIngesting(catpb.JobID(o.spec.JobID))()
 
 	if err := o.setup(ctx); err != nil {
 		o.MoveToDrainingAndLogError(err)


### PR DESCRIPTION
This patch adds a check that attempts to wait for the offline scan processors to spin down before transitioning to steady state ingestion or OnFailOrCancel during an offline scan.

Epic: none

Release note: none