### PR TITLE
server,sql: increase redaction coverage of diagnostics tests

### DIFF
--- a/pkg/server/application_api/stats_test.go
+++ b/pkg/server/application_api/stats_test.go
@@ -217,7 +217,7 @@ func TestSQLStatCollection(t *testing.T) {
 	sqlServer.GetSQLStatsController().ResetLocalSQLStats(ctx)
 
 	// Query the reported statistics.
-	stats, err = sqlServer.GetScrubbedReportingStats(ctx, 1000 /* limit */)
+	stats, err = sqlServer.GetScrubbedReportingStats(ctx, 1000, true)
 	require.NoError(t, err)
 
 	foundStat = false
@@ -275,7 +275,7 @@ func TestSQLStatCollection(t *testing.T) {
 	sqlServer.GetSQLStatsController().ResetLocalSQLStats(ctx)
 
 	// Find our statement stat from the reported stats pool.
-	stats, err = sqlServer.GetScrubbedReportingStats(ctx, 1000 /* limit */)
+	stats, err = sqlServer.GetScrubbedReportingStats(ctx, 1000, true)
 	require.NoError(t, err)
 
 	foundStat = false
@@ -411,13 +411,13 @@ func TestScrubbedReportingStatsLimit(t *testing.T) {
 
 	// verify that with low limit, number of stats is within that limit
 	sqlServer.GetSQLStatsController().ResetLocalSQLStats(ctx)
-	stats, err := sqlServer.GetScrubbedReportingStats(ctx, 5 /* limit */)
+	stats, err := sqlServer.GetScrubbedReportingStats(ctx, 5, true)
 	require.NoError(t, err)
 	require.LessOrEqual(t, len(stats), 5)
 
 	// verify that with high limit, the number of	queries is as much as the above
 	sqlServer.GetSQLStatsController().ResetLocalSQLStats(ctx)
-	stats, err = sqlServer.GetScrubbedReportingStats(ctx, 1000 /* limit */)
+	stats, err = sqlServer.GetScrubbedReportingStats(ctx, 1000, true)
 	require.NoError(t, err)
 	require.GreaterOrEqual(t, len(stats), 7)
 }

--- a/pkg/server/diagnostics/reporter.go
+++ b/pkg/server/diagnostics/reporter.go
@@ -382,7 +382,7 @@ func (r *Reporter) CreateReport(
 		}
 	}
 
-	info.SqlStats, err = r.SQLServer.GetScrubbedReportingStats(ctx, 100 /* limit */)
+	info.SqlStats, err = r.SQLServer.GetScrubbedReportingStats(ctx, 100 /* limit */, false)
 	if err != nil {
 		if log.V(2 /* level */) {
 			log.Warningf(ctx, "unexpected error encountered when getting scrubbed reporting stats: %s", err)


### PR DESCRIPTION
This change adds test coverage to the diagnostic reporter that's meant to catch situations where schema or statement scrubbing is accidentally turned off.

In the course of adding tests for SQL Stats it was discovered that the diagnostics reporter would include statements that were in internal applications (`$ internal` prefix) so a change was made to omit those from the reports.

Resolves: #134450

Release note: None