### PR TITLE
catalog/lease: WaitForInitialVersion should be version gated

### DIFF
--- a/pkg/sql/catalog/lease/BUILD.bazel
+++ b/pkg/sql/catalog/lease/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/base",
+        "//pkg/clusterversion",
         "//pkg/keys",
         "//pkg/kv",
         "//pkg/kv/kvclient/rangefeed",

--- a/pkg/sql/catalog/lease/lease.go
+++ b/pkg/sql/catalog/lease/lease.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/rangefeed"
@@ -313,7 +314,8 @@ func (m *Manager) WaitForInitialVersion(
 	retryOpts retry.Options,
 	regions regionliveness.CachedDatabaseRegions,
 ) error {
-	if !WaitForInitialVersion.Get(&m.settings.SV) {
+	if !WaitForInitialVersion.Get(&m.settings.SV) ||
+		!m.storage.settings.Version.IsActive(ctx, clusterversion.V25_1) {
 		return nil
 	}
 	wsTracker := startWaitStatsTracker(ctx)

--- a/pkg/sql/opt/BUILD.bazel
+++ b/pkg/sql/opt/BUILD.bazel
@@ -24,6 +24,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/opt",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/clusterversion",
         "//pkg/server/telemetry",
         "//pkg/sql/catalog",
         "//pkg/sql/catalog/catpb",

--- a/pkg/sql/opt/metadata.go
+++ b/pkg/sql/opt/metadata.go
@@ -11,6 +11,7 @@ import (
 	"math/bits"
 	"strings"
 
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/multiregion"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
@@ -397,6 +398,7 @@ func (md *Metadata) CheckDependencies(
 	// is sufficient.
 	currentDigest := optCatalog.GetDependencyDigest()
 	if evalCtx.SessionData().CatalogDigestStalenessCheckEnabled &&
+		evalCtx.Settings.Version.IsActive(ctx, clusterversion.V25_1) &&
 		evalCtx.AsOfSystemTime == nil &&
 		!evalCtx.Txn.ReadTimestampFixed() &&
 		md.dependencyDigestEquals(&currentDigest) {


### PR DESCRIPTION
Previously, we could have mixed version configurations hang waiting for initial version of descriptors, when new objects are created. This was because prior releases of CRDB do not have logic to lease new descriptors automatically. This patch adds a version gate to enable the WaitForInitialVersion and the memo staleness optimizations once 25.1 is finalized.

Fixes: #139015

Release note: None