### PR TITLE
spanconfigkvsubscriberccl: run expensive tests in heavy pool

### DIFF
--- a/pkg/ccl/spanconfigccl/spanconfigkvsubscriberccl/BUILD.bazel
+++ b/pkg/ccl/spanconfigccl/spanconfigkvsubscriberccl/BUILD.bazel
@@ -7,7 +7,7 @@ go_test(
         "main_test.go",
     ],
     exec_properties = select({
-        "//build/toolchains:is_heavy": {"test.Pool": "large"},
+        "//build/toolchains:is_heavy": {"test.Pool": "heavy"},
         "//conditions:default": {"test.Pool": "default"},
     }),
     deps = [


### PR DESCRIPTION
We have seen this timeout under race over the past few weeks, so this patch gives the test more resources under race/deadlock.

informs: https://github.com/cockroachdb/cockroach/issues/138032
Release note: None