### PR TITLE
sql: fix an internal error in EXPLAIN ANALYZE in some cases

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/cascade
+++ b/pkg/sql/opt/exec/execbuilder/testdata/cascade
@@ -1391,3 +1391,84 @@ vectorized: true
                 └── • scan buffer
                       estimated row count: 100
                       label: buffer 1000000
+
+# Regression test for #138974 where the creation of the short-circuited cascade
+# plan triggered a nil pointer in the gist factory.
+statement ok
+CREATE TABLE p138974 (k INT PRIMARY KEY, v INT);
+
+statement ok
+CREATE TABLE c138974 (k INT PRIMARY KEY, parent_k INT REFERENCES p138974(k) ON DELETE CASCADE);
+
+query T
+EXPLAIN ANALYZE DELETE FROM p138974 WHERE v = 1;
+----
+planning time: 10µs
+execution time: 100µs
+distribution: <hidden>
+vectorized: <hidden>
+plan type: custom
+maximum memory usage: <hidden>
+network usage: <hidden>
+regions: <hidden>
+isolation level: serializable
+priority: normal
+quality of service: regular
+·
+• root
+│
+├── • delete
+│   │ sql nodes: <hidden>
+│   │ regions: <hidden>
+│   │ actual row count: 1
+│   │ from: p138974
+│   │
+│   └── • buffer
+│       │ sql nodes: <hidden>
+│       │ regions: <hidden>
+│       │ actual row count: 0
+│       │ label: buffer 1
+│       │
+│       └── • filter
+│           │ sql nodes: <hidden>
+│           │ regions: <hidden>
+│           │ actual row count: 0
+│           │ filter: v = 1
+│           │
+│           └── • scan
+│                 sql nodes: <hidden>
+│                 kv nodes: <hidden>
+│                 regions: <hidden>
+│                 actual row count: 0
+│                 KV time: 0µs
+│                 KV contention time: 0µs
+│                 KV rows decoded: 0
+│                 KV bytes read: 0 B
+│                 KV gRPC calls: 0
+│                 estimated max memory allocated: 0 B
+│                 missing stats
+│                 table: p138974@p138974_pkey
+│                 spans: FULL SCAN
+│
+└── • fk-cascade
+    │ fk: c138974_parent_k_fkey
+    │
+    └── • delete
+        │ from: c138974
+        │
+        └── • hash join
+            │ equality: (parent_k) = (k)
+            │ right cols are key
+            │
+            ├── • scan
+            │     missing stats
+            │     table: c138974@c138974_pkey
+            │     spans: FULL SCAN
+            │
+            └── • distinct
+                │ estimated row count: 10
+                │ distinct on: k
+                │
+                └── • scan buffer
+                      estimated row count: 100
+                      label: buffer 1000000

--- a/pkg/sql/opt/exec/explain/explain_factory.go
+++ b/pkg/sql/opt/exec/explain/explain_factory.go
@@ -139,6 +139,11 @@ func NewFactory(
 	}
 }
 
+// ReplaceWrapped updates the wrapped factory with the given one.
+func (f *Factory) ReplaceWrapped(wrappedFactory exec.Factory) {
+	f.wrappedFactory = wrappedFactory
+}
+
 // AnnotateNode is part of the exec.ExplainFactory interface.
 func (f *Factory) AnnotateNode(execNode exec.Node, id exec.ExplainAnnotationID, value interface{}) {
 	execNode.(*Node).Annotate(id, value)


### PR DESCRIPTION
f2be10825ea1c31e7f76efd8908748373b33c6c7 made it so that we embed the plan gist factory into `optPlanningCtx` that we reuse across queries, which is achieved by initializing it before the execbuild and then resetting right after it. This can be problematic in some EXPLAIN scenarios where we call the captured `GetExplainPlan` function for cascades and triggers with `createIfMissing=true` option. That option means that we might attempt to run the execbuilding for a cascade or a trigger at a different point in time than the execbuilding of the main query. In particular, this can be the case for EXPLAIN ANALYZE if the cascade or trigger was short-circuited. (There is a separate issue to highlight these short-circuited cascades and triggers.) Regular EXPLAIN is unaffected because we create all needed plans eagerly in `startExec` method; also, nested cascades and triggers are unaffected because they didn't capture the gist factory.

This commit fixes the problem by removing the only reference to the reset gist factory from the explain factory.

Fixes: #138974.

Release note: None