### PR TITLE
crosscluster/logical: prevent duplicate reverse streams

### DIFF
--- a/pkg/crosscluster/logical/create_logical_replication_stmt.go
+++ b/pkg/crosscluster/logical/create_logical_replication_stmt.go
@@ -55,6 +55,21 @@ var streamCreationHeader = colinfo.ResultColumns{
 	{Name: "job_id", Typ: types.Int},
 }
 
+var checkJobWithSameParent = `
+SELECT
+	t.job_id
+	FROM (
+		SELECT
+			id AS job_id,
+			crdb_internal.pb_to_json(
+				'cockroach.sql.jobs.jobspb.Payload',
+				payload)->'logicalReplicationDetails'->>'parentId' AS parent_id 
+		FROM crdb_internal.system_jobs 
+		WHERE job_type = 'LOGICAL REPLICATION'
+	) AS t
+	WHERE t.parent_id = $1
+`
+
 func createLogicalReplicationStreamPlanHook(
 	ctx context.Context, untypedStmt tree.Statement, p sql.PlanHookState,
 ) (sql.PlanHookRowFn, colinfo.ResultColumns, bool, error) {
@@ -161,6 +176,21 @@ func createLogicalReplicationStreamPlanHook(
 		// machinery for releasing leases assumes that we do not close the planner
 		// txn during statement execution.
 		p.InternalSQLTxn().Descriptors().ReleaseAll(ctx)
+
+		if options.ParentID != 0 {
+			row, err := p.ExecCfg().InternalDB.Executor().QueryRow(ctx, "check-parent-job", nil, checkJobWithSameParent, fmt.Sprintf("%d", options.ParentID))
+			if err != nil {
+				return err
+			}
+			if row != nil {
+				// If a job already exists with the same parent ID, then this CREATE
+				// LOGICAL stmt execution is a retry and the replication stream already
+				// exists.
+				jobID := int(*row[0].(*tree.DInt))
+				resultsCh <- tree.Datums{tree.NewDInt(tree.DInt(jobID))}
+				return nil
+			}
+		}
 
 		configUri, err := streamclient.ParseConfigUri(from)
 		if err != nil {

--- a/pkg/crosscluster/logical/logical_replication_job.go
+++ b/pkg/crosscluster/logical/logical_replication_job.go
@@ -325,11 +325,6 @@ func (r *logicalReplicationResumer) maybeStartReverseStream(
 		return errors.Wrapf(err, "failed to start reverse stream")
 	}
 
-	// TODO(msbutler): if the job exits before we write here but after setting up
-	// the reverse stream, we will accidentally create a second reverse stream. To
-	// prevent this, the PARENT option will passed to the reverse stream, then
-	// during ldr stream creation, the planhook checks if any job is already
-	// running with this parent job id.
 	if err := r.job.NoTxn().Update(ctx, func(txn isql.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater) error {
 		md.Progress.Details.(*jobspb.Progress_LogicalReplication).LogicalReplication.StartedReverseStream = true
 		ju.UpdateProgress(md.Progress)


### PR DESCRIPTION
This patch prevents the original bidi stream from setting up a reverse stream on resume, if the coordinator shuts down between setting up the reverse stream successfully and persisting progress on reverse stream set up.

To understand this patch, note that the reverse stream command always contains the og stream job id passed to the Parent option. On reverse stream set up now, if an ldr job with the parent id already exists, the ldr cmd noops and returns the job id of the already existing job.

Epic: none
Release note: none