### PR TITLE
explain: don't create missing postquery plans in some cases

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/triggers_explain
+++ b/pkg/ccl/logictestccl/testdata/logic_test/triggers_explain
@@ -380,6 +380,7 @@ quality of service: regular
 │
 └── • after-triggers
       trigger: t
+      short-circuited
       input: buffer 1
 
 # Insert a row so that the trigger fires, and show the trigger plan.
@@ -723,6 +724,7 @@ quality of service: regular
 │
 └── • fk-cascade
       fk: child_fk_fkey
+      short-circuited
       input: buffer 1
 
 # Insert rows so that the cascade fires and the plan is generated.

--- a/pkg/sql/opt/exec/execbuilder/post_queries.go
+++ b/pkg/sql/opt/exec/execbuilder/post_queries.go
@@ -151,9 +151,8 @@ func makePostQueryBuilder(b *Builder, mutationWithID opt.WithID) (*postQueryBuil
 // setupCascade fills in an exec.PostQuery struct for the given cascade.
 func (cb *postQueryBuilder) setupCascade(cascade *memo.FKCascade) exec.PostQuery {
 	return exec.PostQuery{
-		FKConstraint:             cascade.FKConstraint,
-		CascadeHasBeforeTriggers: cascade.HasBeforeTriggers,
-		Buffer:                   cb.mutationBuffer,
+		FKConstraint: cascade.FKConstraint,
+		Buffer:       cb.mutationBuffer,
 		PlanFn: func(
 			ctx context.Context,
 			semaCtx *tree.SemaContext,

--- a/pkg/sql/opt/exec/execbuilder/testdata/cascade
+++ b/pkg/sql/opt/exec/execbuilder/testdata/cascade
@@ -1391,3 +1391,113 @@ vectorized: true
                 └── • scan buffer
                       estimated row count: 100
                       label: buffer 1000000
+
+# Regression test for #138974 where the creation of the short-circuited cascade
+# plan triggered a nil pointer in the gist factory.
+statement ok
+CREATE TABLE p138974 (k INT PRIMARY KEY, v INT);
+
+statement ok
+CREATE TABLE c138974 (k INT PRIMARY KEY, parent_k INT REFERENCES p138974(k) ON DELETE CASCADE);
+
+# "Vanilla" EXPLAIN always gets the full plan.
+query T
+EXPLAIN DELETE FROM p138974 WHERE v = 1;
+----
+distribution: local
+vectorized: true
+·
+• root
+│
+├── • delete
+│   │ from: p138974
+│   │
+│   └── • buffer
+│       │ label: buffer 1
+│       │
+│       └── • filter
+│           │ filter: v = 1
+│           │
+│           └── • scan
+│                 missing stats
+│                 table: p138974@p138974_pkey
+│                 spans: FULL SCAN
+│
+└── • fk-cascade
+    │ fk: c138974_parent_k_fkey
+    │
+    └── • delete
+        │ from: c138974
+        │
+        └── • hash join
+            │ equality: (parent_k) = (k)
+            │ right cols are key
+            │
+            ├── • scan
+            │     missing stats
+            │     table: c138974@c138974_pkey
+            │     spans: FULL SCAN
+            │
+            └── • distinct
+                │ estimated row count: 10
+                │ distinct on: k
+                │
+                └── • scan buffer
+                      estimated row count: 100
+                      label: buffer 1000000
+
+# The main query doesn't modify any rows, so the cascade isn't triggered.
+query T
+EXPLAIN ANALYZE DELETE FROM p138974 WHERE v = 1;
+----
+planning time: 10µs
+execution time: 100µs
+distribution: <hidden>
+vectorized: <hidden>
+plan type: custom
+maximum memory usage: <hidden>
+network usage: <hidden>
+regions: <hidden>
+isolation level: serializable
+priority: normal
+quality of service: regular
+·
+• root
+│
+├── • delete
+│   │ sql nodes: <hidden>
+│   │ regions: <hidden>
+│   │ actual row count: 1
+│   │ from: p138974
+│   │
+│   └── • buffer
+│       │ sql nodes: <hidden>
+│       │ regions: <hidden>
+│       │ actual row count: 0
+│       │ label: buffer 1
+│       │
+│       └── • filter
+│           │ sql nodes: <hidden>
+│           │ regions: <hidden>
+│           │ actual row count: 0
+│           │ filter: v = 1
+│           │
+│           └── • scan
+│                 sql nodes: <hidden>
+│                 kv nodes: <hidden>
+│                 regions: <hidden>
+│                 actual row count: 0
+│                 KV time: 0µs
+│                 KV contention time: 0µs
+│                 KV rows decoded: 0
+│                 KV bytes read: 0 B
+│                 KV gRPC calls: 0
+│                 estimated max memory allocated: 0 B
+│                 missing stats
+│                 table: p138974@p138974_pkey
+│                 spans: FULL SCAN
+│
+└── • fk-cascade
+      fk: c138974_parent_k_fkey
+      short-circuited
+      input: buffer 1

--- a/pkg/sql/opt/exec/explain/plan_gist_factory.go
+++ b/pkg/sql/opt/exec/explain/plan_gist_factory.go
@@ -198,7 +198,7 @@ func DecodePlanGistToRows(
 	if err != nil {
 		return nil, err
 	}
-	err = Emit(ctx, evalCtx, explainPlan, ob, func(table cat.Table, index cat.Index, scanParams exec.ScanParams) string { return "" })
+	err = Emit(ctx, evalCtx, explainPlan, ob, func(table cat.Table, index cat.Index, scanParams exec.ScanParams) string { return "" }, false /* createPostQueryPlanIfMissing */)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/opt/exec/explain/plan_gist_test.go
+++ b/pkg/sql/opt/exec/explain/plan_gist_test.go
@@ -47,7 +47,7 @@ func explainGist(gist string, catalog cat.Catalog) string {
 	if err != nil {
 		panic(err)
 	}
-	err = explain.Emit(context.Background(), &eval.Context{}, explainPlan, ob, func(table cat.Table, index cat.Index, scanParams exec.ScanParams) string { return "" })
+	err = explain.Emit(context.Background(), &eval.Context{}, explainPlan, ob, func(table cat.Table, index cat.Index, scanParams exec.ScanParams) string { return "" }, false /* createPostQueryPlanIfMissing */)
 	if err != nil {
 		panic(err)
 	}
@@ -76,7 +76,7 @@ func plan(ot *opttester.OptTester, t *testing.T) string {
 	}
 	flags := explain.Flags{HideValues: true, Deflake: explain.DeflakeAll, OnlyShape: true}
 	ob := explain.NewOutputBuilder(flags)
-	err = explain.Emit(context.Background(), &eval.Context{}, explainPlan.(*explain.Plan), ob, func(table cat.Table, index cat.Index, scanParams exec.ScanParams) string { return "" })
+	err = explain.Emit(context.Background(), &eval.Context{}, explainPlan.(*explain.Plan), ob, func(table cat.Table, index cat.Index, scanParams exec.ScanParams) string { return "" }, false /* createPostQueryPlanIfMissing */)
 	if err != nil {
 		t.Error(err)
 	}

--- a/pkg/sql/opt/exec/factory.go
+++ b/pkg/sql/opt/exec/factory.go
@@ -283,11 +283,6 @@ type PostQuery struct {
 	// PostQuery describes a set of AFTER triggers.
 	FKConstraint cat.ForeignKeyConstraint
 
-	// CascadeHasBeforeTriggers is set only for cascades. It indicates whether the
-	// mutation planned for the cascade will fire BEFORE triggers. It is used
-	// during EXPLAIN.
-	CascadeHasBeforeTriggers bool
-
 	// Triggers is used for logging and EXPLAIN purposes. It is nil if this
 	// PostQuery describes a foreign-key cascade action.
 	Triggers []cat.Trigger


### PR DESCRIPTION
bc508973a299a35d1d65e76f1ba8b6861f94ead0 where we added the support
for showing plans of cascades in EXPLAIN output we needed to introduce
an ability to "create post-query plan if missing". This was needed since
in "vanilla" EXPLAIN we never actually run the main query, so the
cascades are never actually planned. We also enabled this logic in two
other places - in EXPLAIN ANALYZE as well as when populating "plan for
stats". (The latter is used in exec stats feature, e.g. as `plan` column
in `system.statement_statistics`.) Both of these cases result in
creating post-query plans _after_ the query execution which could lead
to unexpected behavior. One such behavior was observed when we added the
EXPLAIN support for triggers when the txn captured by the trigger plan
function could have been committed. Another case was recently introduced
where we reset the gist factory after the execbuilding the main query,
yet the gist factory was captured by the cascade plan function.

This shows that the mechanism is fragile. Note that the "vanilla"
EXPLAIN code path is unaffected by these cases because
1. we created all separate exec.Factory objects (in
`execFactory.ConstructExplain` and `execbuilder.Builder.buildExplain`),
so there is no concern about factories being reset after the
"main" optimizer plan was created.
2. the txn in which the EXPLAIN statement runs is still open
since we're in the middle of the execution of the
`explainPlanNode`.

Additionally, we want to highlight the cases when cascades and triggers
didn't actually run because the main query didn't modify any rows. We
can address this desire as well as the fragility of the mechanism by
disallowing "creating post-query plans if missing" in EXPLAIN ANALYZE
which is what this commit does. Now, when we try to emit the plan for
a cascade or a trigger and we realize that we didn't cache the plan, we
won't attempt to create it, and we'll instead add `short-circuited`
attribute to the output.

Due to the same fragility we also disallow "creating post-query plans if
missing" in the "plan for stats" case. This means that the "plan for
stats" could change depending on the data that the query ran over.
(For example, in one case the cascade could be triggered and in another
the cascade could be skipped ("short-circuited") depending on whether the
main query modified some rows or not.) This is a bit unfortunate because
we would produce different "plan for stats" even though the query is the
same, but it seems like an edge case that we can accept to avoid the
fragility.

Fixes: #125509.
Fixes: #135157.
Fixes: #138974.

Release note: None