### PR TITLE
storage/disk: don't error in absence of collected states

### DIFF
--- a/pkg/storage/disk/monitor.go
+++ b/pkg/storage/disk/monitor.go
@@ -229,9 +229,7 @@ type Monitor struct {
 
 // CumulativeStats returns the most-recent stats observed.
 func (m *Monitor) CumulativeStats() (Stats, error) {
-	if event, err := m.tracer.Latest(); err != nil {
-		return Stats{}, err
-	} else if event.err != nil {
+	if event := m.tracer.Latest(); event.err != nil {
 		return Stats{}, event.err
 	} else {
 		return event.stats, nil

--- a/pkg/storage/disk/monitor_tracer.go
+++ b/pkg/storage/disk/monitor_tracer.go
@@ -13,7 +13,6 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
-	"github.com/cockroachdb/errors"
 )
 
 type traceEvent struct {
@@ -87,16 +86,16 @@ func (m *monitorTracer) RecordEvent(event traceEvent) {
 	}
 }
 
-// Latest retrieves the last traceEvent that was queued. If the trace is empty
-// we throw an error.
-func (m *monitorTracer) Latest() (traceEvent, error) {
+// Latest retrieves the last traceEvent that was queued. Returns a zero-valued
+// traceEvent if none exists.
+func (m *monitorTracer) Latest() traceEvent {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	if m.sizeLocked() == 0 {
-		return traceEvent{}, errors.Errorf("trace is empty")
+		return traceEvent{}
 	}
 	latestIdx := (m.mu.end - 1) % m.capacity
-	return m.mu.trace[latestIdx], nil
+	return m.mu.trace[latestIdx]
 }
 
 // RollingWindow retrieves all traceEvents that occurred after the specified

--- a/pkg/storage/disk/monitor_tracer_test.go
+++ b/pkg/storage/disk/monitor_tracer_test.go
@@ -90,13 +90,9 @@ func TestMonitorTracer(t *testing.T) {
 			}
 			return ""
 		case "latest":
-			event, err := tracer.Latest()
+			event := tracer.Latest()
 			buf.Reset()
-			if err != nil {
-				fmt.Fprint(&buf, err.Error())
-			} else {
-				fmt.Fprintf(&buf, "%q", event)
-			}
+			fmt.Fprintf(&buf, "%q", event)
 			return buf.String()
 		case "trace":
 			buf.Reset()

--- a/pkg/storage/disk/testdata/tracer
+++ b/pkg/storage/disk/testdata/tracer
@@ -8,7 +8,7 @@ rolling-window time=2024-03-27T12:00:00.5Z
 
 latest
 ----
-trace is empty
+"0001-01-01T00:00:00Z\t\t0\t0\t0\t0s\t0\t0\t0\t0s\t0\t0s\t0s\t0\t0\t0\t0s\t0\t0s\tnil"
 
 trace
 ----


### PR DESCRIPTION
Previously, the absence of disk stats was considered an error by the disk monitor. In non-linux platforms, we don't have disk stats. This error was spamming the cockroach logs.

Epic: none
Release note: none