### PR TITLE
release-24.1: codeowners: Add field-engineering team

### DIFF
--- a/TEAMS.yaml
+++ b/TEAMS.yaml
@@ -110,3 +110,6 @@ cockroachdb/release-eng:
     cockroachdb/upgrade-prs: other
   label: T-release
   triage_column_id: 9149730
+cockroachdb/field-engineering:
+  # Field Eng isn't currently using github projects.
+  label: T-field-eng

--- a/pkg/cmd/roachtest/registry/owners.go
+++ b/pkg/cmd/roachtest/registry/owners.go
@@ -31,6 +31,7 @@ const (
 	OwnerStorage          Owner = `storage`
 	OwnerTestEng          Owner = `test-eng`
 	OwnerDevInf           Owner = `dev-inf`
+	OwnerFieldEng         Owner = `field-engineering`
 )
 
 // IsValid returns true if the owner is valid, i.e. it has a corresponding team

--- a/pkg/internal/team/TEAMS.yaml
+++ b/pkg/internal/team/TEAMS.yaml
@@ -110,3 +110,6 @@ cockroachdb/release-eng:
     cockroachdb/upgrade-prs: other
   label: T-release
   triage_column_id: 9149730
+cockroachdb/field-engineering:
+  # Field Eng isn't currently using github projects.
+  label: T-field-eng


### PR DESCRIPTION
Backport 1/1 commits from #138241.

/cc @cockroachdb/release

---

Adding field engineering in preparation of owning the code we are contributing.

Epic: none

Release note: None

Release justification: required for backporting Ceph tests (e.g. #138172). 

