### PR TITLE
roachprod: user-specified `awsConfigValue` may get overriden by `DefaultConfig`

### DIFF
--- a/pkg/roachprod/vm/aws/aws.go
+++ b/pkg/roachprod/vm/aws/aws.go
@@ -522,7 +522,6 @@ func (o *ProviderOpts) ConfigureClusterFlags(flags *pflag.FlagSet, _ vm.Multiple
 	flags.StringVar(&providerInstance.Profile, ProviderName+"-profile", os.Getenv("AWS_PROFILE"),
 		"Profile to manage cluster in")
 	configFlagVal := awsConfigValue{awsConfig: *DefaultConfig}
-	providerInstance.Config = &configFlagVal.awsConfig
 	flags.Var(&configFlagVal, ProviderName+"-config",
 		"Path to json for aws configuration, defaults to predefined configuration")
 }

--- a/pkg/roachprod/vm/aws/config.go
+++ b/pkg/roachprod/vm/aws/config.go
@@ -170,7 +170,13 @@ func (c *awsConfigValue) Set(path string) (err error) {
 	if err != nil {
 		return err
 	}
-	return json.Unmarshal(data, &c.awsConfig)
+	err = json.Unmarshal(data, &c.awsConfig)
+	if err != nil {
+		return err
+	}
+	// Update the provider's config with the user-specified config.
+	providerInstance.Config = &c.awsConfig
+	return nil
 }
 
 // Type is part of the pflag.Value interface.


### PR DESCRIPTION
A recent refactoring [1] has exposed a latent bug, wherein
user-specified `awsConfigValue`, i.e., `--aws-config`
may get overridden by the default configuration.

This PR fixes the bug.

[1] https://github.com/cockroachdb/cockroach/pull/137394

Epic: none
Fixes: #139102
Release note: None