### PR TITLE
metamorphic: use globalSeed from `randutil.NewTestRand`

### DIFF
--- a/pkg/util/randutil/rand.go
+++ b/pkg/util/randutil/rand.go
@@ -99,6 +99,16 @@ func NewLockedPseudoRand() (*rand.Rand, int64) {
 	return rand.New(NewLockedSource(seed)), seed
 }
 
+// NewPseudoRandWithGlobalSeed returns an instance of math/rand.Rand, which is
+// seeded with the global seed.
+// It's _not_ intended to be called directly from a test; use NewTestRand for that.
+// Instead, this function is useful for seeding other random number generators, on which the tests
+// may depend; e.g., metamorphic constants.
+// N.B. unlike NewTestRand, this function _never_ reseeds rng.
+func NewPseudoRandWithGlobalSeed() (*rand.Rand, int64) {
+	return rand.New(rand.NewSource(globalSeed)), globalSeed
+}
+
 // NewTestRand returns an instance of math/rand.Rand seeded from rng, which is
 // seeded with the global seed. If the caller is a test with a different
 // path-qualified name than the previous caller, rng is reseeded from the global


### PR DESCRIPTION
A minor quality of life improvement to ensure
metamorphic constants are derived from the
globalSeed. This makes it possible to reproduce
both the metamoprhic constants and the individual
test's rng values, from `COCKROACH_RANDOM_SEED`.

We also log the seed, when metamoprhic constants
are enabled. As of this change, we get a message
of this form, logged to `stderr`,
```
metamorphic: use COCKROACH_RANDOM_SEED=9076506593373491438 for reproduction
```

Epic: none
Release note: None