### PR TITLE
refactor: Use WalkDir to avoid sys call on every traversal

### DIFF
--- a/pkg/acceptance/util_docker.go
+++ b/pkg/acceptance/util_docker.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"crypto/rand"
 	"fmt"
+	"io/fs"
 	"math/big"
 	"os"
 	"path/filepath"
@@ -170,7 +171,7 @@ func testDocker(
 // so the files can be used inside a docker container. The caller function is responsible for cleaning up.
 // This function doesn't copy the original file permissions and uses 755 for directories and files.
 func copyRunfiles(source, destination string) error {
-	return filepath.WalkDir(source, func(path string, dirEntry os.DirEntry, walkErr error) error {
+	return filepath.WalkDir(source, func(path string, dirEntry fs.DirEntry, walkErr error) error {
 		if walkErr != nil {
 			return walkErr
 		}

--- a/pkg/backup/full_cluster_backup_restore_test.go
+++ b/pkg/backup/full_cluster_backup_restore_test.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	gosql "database/sql"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -667,14 +668,14 @@ func TestClusterRestoreFailCleanup(t *testing.T) {
 
 	// Bugger the backup by removing the SST files. (Note this messes up all of
 	// the backups, but there is only one at this point.)
-	if err := filepath.Walk(tempDir, func(path string, info os.FileInfo, err error) error {
+	if err := filepath.WalkDir(tempDir, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if info.Name() == backupbase.BackupManifestName ||
+		if d.Name() == backupbase.BackupManifestName ||
 			!strings.HasSuffix(path, ".sst") ||
-			info.Name() == backupinfo.BackupMetadataDescriptorsListPath ||
-			info.Name() == backupinfo.BackupMetadataFilesListPath {
+			d.Name() == backupinfo.BackupMetadataDescriptorsListPath ||
+			d.Name() == backupinfo.BackupMetadataFilesListPath {
 			return nil
 		}
 		return os.Remove(path)

--- a/pkg/blobs/local_storage.go
+++ b/pkg/blobs/local_storage.go
@@ -8,6 +8,7 @@ package blobs
 import (
 	"context"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -186,11 +187,11 @@ func (l *LocalStorage) List(pattern string) ([]string, error) {
 			}
 		}
 
-		if err := filepath.Walk(walkRoot, func(p string, f os.FileInfo, err error) error {
+		if err := filepath.WalkDir(walkRoot, func(p string, d fs.DirEntry, err error) error {
 			if err != nil {
 				return err
 			}
-			if f.IsDir() {
+			if d.IsDir() {
 				return nil
 			}
 			if listingParent && !strings.HasPrefix(p, fullPath) {

--- a/pkg/ccl/changefeedccl/testfeed_test.go
+++ b/pkg/ccl/changefeedccl/testfeed_test.go
@@ -13,6 +13,7 @@ import (
 	"encoding/base64"
 	gojson "encoding/json"
 	"fmt"
+	"io/fs"
 	"math/rand"
 	"net/url"
 	"os"
@@ -1493,13 +1494,13 @@ func (c *cloudFeed) Next() (*cdctest.TestFeedMessage, error) {
 			return nil, err
 		}
 
-		if err := filepath.Walk(c.dir, c.walkDir); err != nil {
+		if err := filepath.WalkDir(c.dir, c.walkDir); err != nil {
 			return nil, err
 		}
 	}
 }
 
-func (c *cloudFeed) walkDir(path string, info os.FileInfo, err error) error {
+func (c *cloudFeed) walkDir(path string, d fs.DirEntry, err error) error {
 	if strings.HasSuffix(path, `.tmp`) {
 		// File in the process of being written by ExternalStorage. Ignore.
 		return nil
@@ -1520,7 +1521,7 @@ func (c *cloudFeed) walkDir(path string, info os.FileInfo, err error) error {
 		return err
 	}
 
-	if info.IsDir() {
+	if d.IsDir() {
 		// Nothing to do for directories.
 		return nil
 	}

--- a/pkg/cli/debug_merge_logs.go
+++ b/pkg/cli/debug_merge_logs.go
@@ -11,6 +11,7 @@ import (
 	"container/heap"
 	"context"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -349,12 +350,11 @@ func findLogFiles(
 	}
 	var files []fileInfo
 	for _, p := range paths {
-		// NB: come go1.16, we should use WalkDir here as it is more efficient.
-		if err := filepath.Walk(p, func(p string, info os.FileInfo, err error) error {
+		if err := filepath.WalkDir(p, func(p string, d fs.DirEntry, err error) error {
 			if err != nil {
 				return err
 			}
-			if info.IsDir() {
+			if d.IsDir() {
 				// Don't act on the directory itself, Walk will visit it for us.
 				return nil
 			}

--- a/pkg/cli/gen_test.go
+++ b/pkg/cli/gen_test.go
@@ -6,6 +6,7 @@
 package cli
 
 import (
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -28,8 +29,8 @@ func TestGenMan(t *testing.T) {
 
 	// Ensure we have a sane number of man pages.
 	count := 0
-	err := filepath.Walk(manpath, func(path string, info os.FileInfo, err error) error {
-		if strings.HasSuffix(path, ".1") && !info.IsDir() {
+	err := filepath.WalkDir(manpath, func(path string, d fs.DirEntry, err error) error {
+		if strings.HasSuffix(path, ".1") && !d.IsDir() {
 			count++
 		}
 		return nil

--- a/pkg/cli/userfiletable_test.go
+++ b/pkg/cli/userfiletable_test.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"io/fs"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -446,12 +447,12 @@ func TestUserFileUploadRecursive(t *testing.T) {
 					dstDir = tc.destination + "/" + filepath.Base(testDir)
 				}
 
-				err = filepath.Walk(testDir,
-					func(path string, info os.FileInfo, err error) error {
+				err = filepath.WalkDir(testDir,
+					func(path string, d fs.DirEntry, err error) error {
 						if err != nil {
 							return err
 						}
-						if info.IsDir() {
+						if d.IsDir() {
 							return nil
 						}
 						relPath := strings.TrimPrefix(path, testDir+"/")

--- a/pkg/cmd/dev/io/os/os.go
+++ b/pkg/cmd/dev/io/os/os.go
@@ -459,10 +459,10 @@ func (o *OS) ListFilesWithSuffix(root, suffix string) ([]string, error) {
 
 	output, err := o.Next(command, func() (output string, err error) {
 		var ret []string
-		if err := filepath.Walk(root, func(path string, info fs.FileInfo, err error) error {
+		if err := filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
 			// If there's an error walking the tree, throw it away -- there's
 			// nothing interesting we can do with it.
-			if err != nil || info.IsDir() {
+			if err != nil || d.IsDir() {
 				//nolint:returnerrcheck
 				return nil
 			}

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -2333,11 +2333,11 @@ func (c *clusterImpl) RefetchCertsFromNode(ctx context.Context, node int) error 
 		return errors.Wrap(err, "cluster.StartE")
 	}
 	// Need to prevent world readable files or lib/pq will complain.
-	return filepath.Walk(c.localCertsDir, func(path string, info fs.FileInfo, err error) error {
+	return filepath.WalkDir(c.localCertsDir, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
 			return errors.Wrap(err, "walking localCertsDir failed")
 		}
-		if info.IsDir() {
+		if d.IsDir() {
 			return nil
 		}
 		return os.Chmod(path, 0600)

--- a/pkg/cmd/roachtest/tests/network.go
+++ b/pkg/cmd/roachtest/tests/network.go
@@ -8,6 +8,7 @@ package tests
 import (
 	"context"
 	"fmt"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -87,7 +88,7 @@ func runNetworkAuthentication(ctx context.Context, t test.Test, c cluster.Cluste
 	require.NoError(t, err)
 	require.NoError(t, os.RemoveAll(localCertsDir))
 	require.NoError(t, c.Get(ctx, t.L(), certsDir, localCertsDir, c.Node(1)))
-	require.NoError(t, filepath.Walk(localCertsDir, func(path string, info os.FileInfo, err error) error {
+	require.NoError(t, filepath.WalkDir(localCertsDir, func(path string, d fs.DirEntry, err error) error {
 		// Don't change permissions for the certs directory.
 		if path == localCertsDir {
 			return nil

--- a/pkg/cmd/roachtest/zip_util.go
+++ b/pkg/cmd/roachtest/zip_util.go
@@ -8,6 +8,7 @@ package main
 import (
 	"archive/zip"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"sort"
@@ -26,11 +27,11 @@ func moveToZipArchive(archiveName string, rootPath string, relPaths ...string) e
 	z := zip.NewWriter(f)
 	for _, relPath := range relPaths {
 		// Walk the given path.
-		if err := filepath.Walk(filepath.Join(rootPath, relPath), func(path string, info os.FileInfo, err error) error {
+		if err := filepath.WalkDir(filepath.Join(rootPath, relPath), func(path string, d fs.DirEntry, err error) error {
 			if err != nil {
 				return err
 			}
-			if info.IsDir() {
+			if d.IsDir() {
 				// Let Walk recurse inside.
 				return nil
 			}

--- a/pkg/cmd/roachtest/zip_util_test.go
+++ b/pkg/cmd/roachtest/zip_util_test.go
@@ -7,6 +7,7 @@ package main
 
 import (
 	"archive/zip"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"strings"
@@ -31,9 +32,9 @@ func TestMoveToZipArchive(t *testing.T) {
 	expectLs := func(expected ...string) {
 		t.Helper()
 		var actual []string
-		require.NoError(t, filepath.Walk(baseDir, func(path string, info os.FileInfo, err error) error {
+		require.NoError(t, filepath.WalkDir(baseDir, func(path string, d fs.DirEntry, err error) error {
 			require.NoError(t, err)
-			if !info.IsDir() {
+			if !d.IsDir() {
 				rel, err := filepath.Rel(baseDir, path)
 				require.NoError(t, err)
 				actual = append(actual, rel)

--- a/pkg/cmd/whoownsit/whoownsit.go
+++ b/pkg/cmd/whoownsit/whoownsit.go
@@ -12,6 +12,7 @@ package main
 import (
 	"flag"
 	"fmt"
+	"io/fs"
 	"log"
 	"os"
 	"path/filepath"
@@ -41,11 +42,11 @@ func main() {
 				os.Exit(1)
 			}
 		}
-		if err := filepath.Walk(path, func(path string, info os.FileInfo, err error) error {
+		if err := filepath.WalkDir(path, func(path string, d fs.DirEntry, err error) error {
 			if err != nil {
 				return err
 			}
-			if !*dirsOnly || info.IsDir() {
+			if !*dirsOnly || d.IsDir() {
 				matches := codeOwners.Match(path)
 				var aliases []string
 				for _, match := range matches {

--- a/pkg/internal/codeowners/lint.go
+++ b/pkg/internal/codeowners/lint.go
@@ -7,7 +7,7 @@ package codeowners
 
 import (
 	"fmt"
-	"os"
+	"io/fs"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -72,14 +72,14 @@ func LintEverythingIsOwned(
 
 	walkRoot := filepath.Join(repoRoot, walkDir)
 
-	unownedWalkFn := func(path string, info os.FileInfo) error {
+	unownedWalkFn := func(path string, d fs.DirEntry) error {
 		teams := co.Match(path)
 		if len(teams) > 0 {
 			// The file has an owner, so nothing to report.
 			debug("%s <- has team(s) %v", path, teams)
 			return nil
 		}
-		if !info.IsDir() {
+		if !d.IsDir() {
 			// We're looking at a file that has no owner.
 			//
 			// Let's say `path = ./pkg/foo/bar/baz.go`.
@@ -113,7 +113,7 @@ func LintEverythingIsOwned(
 	for len(dirsToWalk) != 0 {
 		// We first visit each directory's files, and then the subdirectories.
 		// See TestLintEverythingIsOwned for details.
-		require.NoError(t, filepath.Walk(dirsToWalk[0], func(path string, info os.FileInfo, err error) error {
+		require.NoError(t, filepath.WalkDir(dirsToWalk[0], func(path string, d fs.DirEntry, err error) error {
 			if err != nil {
 				return err
 			}
@@ -132,7 +132,7 @@ func LintEverythingIsOwned(
 
 				if _, ok := skip[relPath]; ok {
 					debug("skipping %s", relPath)
-					if info.IsDir() {
+					if d.IsDir() {
 						return filepath.SkipDir
 					}
 					return nil
@@ -144,7 +144,7 @@ func LintEverythingIsOwned(
 					}
 					if ok {
 						debug("skipping %s", relPath)
-						if info.IsDir() {
+						if d.IsDir() {
 							return filepath.SkipDir
 						}
 						return nil
@@ -153,21 +153,21 @@ func LintEverythingIsOwned(
 				fname := filepath.Base(relPath)
 				if _, ok := skip[fname]; ok {
 					debug("skipping %s", relPath)
-					if info.IsDir() {
+					if d.IsDir() {
 						return filepath.SkipDir
 					}
 					return nil
 				}
 			}
 
-			if info.IsDir() {
+			if d.IsDir() {
 				if path == dirsToWalk[0] {
 					return nil
 				}
 				dirsToWalk = append(dirsToWalk, path)
 				return filepath.SkipDir
 			}
-			return unownedWalkFn(filepath.Join(walkDir, relPath), info)
+			return unownedWalkFn(filepath.Join(walkDir, relPath), d)
 		}))
 		dirsToWalk = dirsToWalk[1:]
 	}

--- a/pkg/storage/pebble_iterator_test.go
+++ b/pkg/storage/pebble_iterator_test.go
@@ -49,11 +49,11 @@ func TestPebbleIterator_Corruption(t *testing.T) {
 	require.NoError(t, p.Flush())
 
 	// Corrupt the SSTs in the DB.
-	err = filepath.Walk(dataDir, func(path string, info stdfs.FileInfo, err error) error {
+	err = filepath.WalkDir(dataDir, func(path string, d stdfs.DirEntry, err error) error {
 		if err != nil {
 			return err
 		}
-		if !strings.HasSuffix(info.Name(), ".sst") {
+		if !strings.HasSuffix(d.Name(), ".sst") {
 			return nil
 		}
 		file, err := os.OpenFile(path, os.O_WRONLY, 0600)


### PR DESCRIPTION
Avoid calls to os.Lstat for every file or directory to retrieve os.FileInfo. 

fs.DirEntry interface includes file type information without requiring a stat call.
