### PR TITLE
fix over-redaction of startup logs

### DIFF
--- a/pkg/build/BUILD.bazel
+++ b/pkg/build/BUILD.bazel
@@ -26,6 +26,7 @@ go_library(
         "//pkg/util/buildutil",
         "//pkg/util/envutil",
         "//pkg/util/version",
+        "@com_github_cockroachdb_redact//:redact",
     ],
 )
 

--- a/pkg/build/info.go
+++ b/pkg/build/info.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/version"
+	"github.com/cockroachdb/redact"
 )
 
 // TimeFormat is the reference format for build.Time. Make sure it stays in sync
@@ -135,13 +136,18 @@ func init() {
 }
 
 // Short returns a pretty printed build and version summary.
-func (b Info) Short() string {
+func (b Info) Short() redact.RedactableString {
 	plat := b.Platform
 	if b.CgoTargetTriple != "" {
 		plat = b.CgoTargetTriple
 	}
-	return fmt.Sprintf("CockroachDB %s %s (%s, built %s, %s)",
-		b.Distribution, b.Tag, plat, b.Time, b.GoVersion)
+	return redact.Sprintf("CockroachDB %s %s (%s, built %s, %s)",
+		redact.SafeString(b.Distribution),
+		redact.SafeString(b.Tag),
+		redact.SafeString(plat),
+		redact.SafeString(b.Time),
+		redact.SafeString(b.GoVersion),
+	)
 }
 
 // Long returns a pretty printed build summary

--- a/pkg/cli/interactive_tests/test_secure.tcl
+++ b/pkg/cli/interactive_tests/test_secure.tcl
@@ -39,7 +39,7 @@ system "grep AWS_ACCESS_KEY='\\.\\.\\.' logs/db/logs/cockroach.log"
 system "grep GODEBUG=mycooldebugvar logs/db/logs/cockroach.log"
 # NB: this grep checks the value of the TERM var was enclosed
 # in redaction markers.
-system "grep TERM=..*mycoolterm logs/db/logs/cockroach.log"
+system "grep TERM=mycoolterm logs/db/logs/cockroach.log"
 end_test
 
 

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -1365,7 +1365,7 @@ func maybeWarnMemorySizes(ctx context.Context) {
 		} else {
 			fmt.Fprintf(&buf, "  If you have a dedicated server a reasonable setting is 25%% of physical memory.")
 		}
-		log.Ops.Warningf(ctx, "%s", redact.Safe(buf.String()))
+		log.Ops.Warningf(ctx, "%s", redact.SafeString(buf.String()))
 	}
 
 	// Check that the total suggested "max" memory is well below the available memory.
@@ -1458,8 +1458,8 @@ func setupAndInitializeLoggingAndProfiling(
 				"consider --accept-sql-without-tls instead. For other options, see:\n\n"+
 				"- %s\n"+
 				"- %s",
-			redact.Safe(build.MakeIssueURL(53404)),
-			redact.Safe(docs.URL("secure-a-cluster.html")),
+			redact.SafeString(build.MakeIssueURL(53404)),
+			redact.SafeString(docs.URL("secure-a-cluster.html")),
 		)
 	}
 

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -1482,7 +1482,7 @@ func setupAndInitializeLoggingAndProfiling(
 	// We log build information to stdout (for the short summary), but also
 	// to stderr to coincide with the full logs.
 	info := build.GetInfo()
-	log.Ops.Infof(ctx, "%s", log.SafeManaged(info.Short()))
+	log.Ops.Infof(ctx, "%s", info.Short())
 
 	// Disable Stopper task tracking as performing that call site tracking is
 	// moderately expensive (certainly outweighing the infrequent benefit it

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -648,6 +648,10 @@ func makeStorageCfg(
 
 // String implements the fmt.Stringer interface.
 func (cfg *Config) String() string {
+	return redact.StringWithoutMarkers(cfg)
+}
+
+func (cfg *Config) SafeFormat(sp redact.SafePrinter, _ rune) {
 	var buf bytes.Buffer
 
 	w := tabwriter.NewWriter(&buf, 2, 1, 2, ' ', 0)
@@ -663,7 +667,7 @@ func (cfg *Config) String() string {
 	}
 	_ = w.Flush()
 
-	return buf.String()
+	sp.Print(redact.SafeString(buf.String()))
 }
 
 // Report logs an overview of the server configuration parameters via
@@ -674,7 +678,7 @@ func (cfg *Config) Report(ctx context.Context) {
 	} else {
 		log.Infof(ctx, "system total memory: %s", humanizeutil.IBytes(memSize))
 	}
-	log.Infof(ctx, "server configuration:\n%s", log.SafeManaged(cfg))
+	log.Infof(ctx, "server configuration:\n%s", cfg)
 }
 
 // Engines is a container of engines, allowing convenient closing.

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -724,7 +724,7 @@ func TestServeIndexHTML(t *testing.T) {
 			// in `server` and not in `server_test`). However, serverutils
 			// doesn't link ccl, so it says it uses OSS distribution. Reconcile
 			// this mismatch.
-			buildInfo := strings.Replace(build.GetInfo().Short(), "CockroachDB CCL", "CockroachDB OSS", 1)
+			buildInfo := strings.Replace(build.GetInfo().Short().StripMarkers(), "CockroachDB CCL", "CockroachDB OSS", 1)
 			expected := fmt.Sprintf(`<!DOCTYPE html>
 <title>CockroachDB</title>
 Binary built without web UI.

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -272,7 +272,7 @@ CREATE TABLE crdb_internal.node_build_info (
 			"Name":         "CockroachDB",
 			"ClusterID":    execCfg.NodeInfo.LogicalClusterID().String(),
 			"Organization": execCfg.Organization(),
-			"Build":        info.Short(),
+			"Build":        info.Short().StripMarkers(),
 			"Version":      info.Tag,
 			"Channel":      info.Channel,
 

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -4706,7 +4706,7 @@ value if you rely on the HLC for accuracy.`,
 			Types:      tree.ParamTypes{},
 			ReturnType: tree.FixedReturnType(types.String),
 			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
-				return tree.NewDString(build.GetInfo().Short()), nil
+				return tree.NewDString(build.GetInfo().Short().StripMarkers()), nil
 			},
 			Info:       "Returns the node's version of CockroachDB.",
 			Volatility: volatility.Volatile,

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -1582,7 +1582,7 @@ var varGen = map[string]sessionVar{
 
 	// CockroachDB extension.
 	`crdb_version`: makeReadOnlyVarWithFn(func() string {
-		return build.GetInfo().Short()
+		return build.GetInfo().Short().StripMarkers()
 	}),
 
 	// CockroachDB extension

--- a/pkg/util/envutil/env.go
+++ b/pkg/util/envutil/env.go
@@ -164,7 +164,7 @@ func GetEnvVarsUsed() (result []redact.RedactableString) {
 		_, crdbVar := envVarRegistry.cache[string(varName)]
 		_, safeVar := safeVarRegistry[varName]
 		if crdbVar || safeVar {
-			result = append(result, redact.Sprintf("%s=%s", varName, redact.Safe(allVarsValues[varName])))
+			result = append(result, redact.Sprintf("%s=%s", varName, redact.SafeString(allVarsValues[varName])))
 		} else if _, reportable := valueReportableUnsafeVarRegistry[varName]; reportable {
 			result = append(result, redact.Sprintf("%s=%s", varName, allVarsValues[varName]))
 		} else if _, reportable := nameReportableUnsafeVarRegistry[varName]; reportable {
@@ -190,6 +190,9 @@ var safeVarRegistry = map[redact.SafeString]struct{}{
 	// gRPC.
 	"GRPC_GO_LOG_SEVERITY_LEVEL":  {},
 	"GRPC_GO_LOG_VERBOSITY_LEVEL": {},
+	// general
+	"LANG": {},
+	"TERM": {},
 }
 
 // valueReportableUnsafeVarRegistry is the list of variables where we can

--- a/pkg/util/log/log_entry.go
+++ b/pkg/util/log/log_entry.go
@@ -336,7 +336,7 @@ func (l *sinkInfo) getStartLines(now time.Time) []*buffer {
 	messages = append(messages,
 		makeStartLine(f, "file created at: %s", redact.Safe(now.Format("2006/01/02 15:04:05"))),
 		makeStartLine(f, "running on machine: %s", SafeManaged(fullHostName)),
-		makeStartLine(f, "binary: %s", redact.Safe(build.GetInfo().Short())),
+		makeStartLine(f, "binary: %s", build.GetInfo().Short()),
 		makeStartLine(f, "arguments: %s", SafeManaged(os.Args)),
 	)
 

--- a/pkg/util/sysutil/BUILD.bazel
+++ b/pkg/util/sysutil/BUILD.bazel
@@ -23,48 +23,63 @@ go_library(
         "@com_github_cockroachdb_errors//:errors",
     ] + select({
         "@io_bazel_rules_go//go/platform:aix": [
+            "@com_github_cockroachdb_redact//:redact",
             "@org_golang_x_sys//unix",
         ],
         "@io_bazel_rules_go//go/platform:android": [
+            "@com_github_cockroachdb_redact//:redact",
             "@org_golang_x_sys//unix",
         ],
         "@io_bazel_rules_go//go/platform:darwin": [
+            "@com_github_cockroachdb_redact//:redact",
             "@org_golang_x_sys//unix",
         ],
         "@io_bazel_rules_go//go/platform:dragonfly": [
+            "@com_github_cockroachdb_redact//:redact",
             "@org_golang_x_sys//unix",
         ],
         "@io_bazel_rules_go//go/platform:freebsd": [
+            "@com_github_cockroachdb_redact//:redact",
             "@org_golang_x_sys//unix",
         ],
         "@io_bazel_rules_go//go/platform:illumos": [
+            "@com_github_cockroachdb_redact//:redact",
             "@org_golang_x_sys//unix",
         ],
         "@io_bazel_rules_go//go/platform:ios": [
+            "@com_github_cockroachdb_redact//:redact",
             "@org_golang_x_sys//unix",
         ],
         "@io_bazel_rules_go//go/platform:js": [
+            "@com_github_cockroachdb_redact//:redact",
             "@org_golang_x_sys//unix",
         ],
         "@io_bazel_rules_go//go/platform:linux": [
+            "@com_github_cockroachdb_redact//:redact",
             "@org_golang_x_sys//unix",
         ],
         "@io_bazel_rules_go//go/platform:netbsd": [
+            "@com_github_cockroachdb_redact//:redact",
             "@org_golang_x_sys//unix",
         ],
         "@io_bazel_rules_go//go/platform:openbsd": [
+            "@com_github_cockroachdb_redact//:redact",
             "@org_golang_x_sys//unix",
         ],
         "@io_bazel_rules_go//go/platform:osx": [
+            "@com_github_cockroachdb_redact//:redact",
             "@org_golang_x_sys//unix",
         ],
         "@io_bazel_rules_go//go/platform:plan9": [
+            "@com_github_cockroachdb_redact//:redact",
             "@org_golang_x_sys//unix",
         ],
         "@io_bazel_rules_go//go/platform:qnx": [
+            "@com_github_cockroachdb_redact//:redact",
             "@org_golang_x_sys//unix",
         ],
         "@io_bazel_rules_go//go/platform:solaris": [
+            "@com_github_cockroachdb_redact//:redact",
             "@org_golang_x_sys//unix",
         ],
         "//conditions:default": [],

--- a/pkg/util/sysutil/sysutil_unix.go
+++ b/pkg/util/sysutil/sysutil_unix.go
@@ -11,10 +11,10 @@
 package sysutil
 
 import (
-	"fmt"
 	"os"
 	"syscall"
 
+	"github.com/cockroachdb/redact"
 	"golang.org/x/sys/unix"
 )
 
@@ -23,8 +23,8 @@ type StatT = syscall.Stat_t
 
 // ProcessIdentity returns a string describing the user and group that this
 // process is running as.
-func ProcessIdentity() string {
-	return fmt.Sprintf("uid %d euid %d gid %d egid %d",
+func ProcessIdentity() redact.RedactableString {
+	return redact.Sprintf("uid %d euid %d gid %d egid %d",
 		unix.Getuid(), unix.Geteuid(), unix.Getgid(), unix.Getegid())
 }
 


### PR DESCRIPTION
pkg/build: fix redaction of info.Short()

info.Short() returns some information about the crdb build in string
form. Since strings are considered unsafe by default by the redaction
lib, it get's redacted(wrongfully) in logs.

This commit fixes that by return a redact.RedactableString in Short()
instead of a standard string. The Short() function is used in a couple
of places. This commit also handles converting the RedactableString to
string where relevant.

Epic: CRDB-37533
Release note: None

----

pkg/cli: fix over-redaction of startup logs

Some of the logs emitted during the startup are overly redacted. This
commit fixes some of that. It also changes some of the redact.Safe to
redact.SafeString (which is more preferable for strings).

The logs that are fixed:
  * Server config - by implementing the SafeFormatter interface
  * Local env vars - By white listing "LANG" and "TERM"
  * Process Identities - By using redact.RedactableString instead of
    string

Epic: CRDB-37533
Release note: None