### PR TITLE
server: fix clock monotonicity setup

### DIFF
--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -577,7 +577,7 @@ func TestPersistHLCUpperBound(t *testing.T) {
 			tickProcessedCh := make(chan struct{})
 			persistHLCUpperBoundIntervalCh := make(chan time.Duration, 1)
 			stopCh := make(chan struct{}, 1)
-			defer close(persistHLCUpperBoundIntervalCh)
+			defer close(stopCh)
 
 			go periodicallyPersistHLCUpperBound(
 				c,


### PR DESCRIPTION
Prior to this PR, the last line in the bash script below would find that the server had crashed with

> wall time X is not allowed to be greater than upper bound of Y.

The reason is that upon the second start, the node would persist a "temporary" `now()+5s` upper bound but then fail to update it.

This PR ensures that the update loop starts unconditionally and maintains (i.e. either updates or erases) the HLC upper bound. This likely fixes other crashes of the same sort when the cluster setting is changed while a node is going down (in which case it's conceivable that a node would boot with a persisted upper bound but without a desire to keep maintaining time timestamp).

```

roachprod wipe local
roachprod start local:1
roachprod sql local:1 -- -e "SET CLUSTER SETTING server.clock.persist_upper_bound_interval = '500ms'"
sleep 5
roachprod stop local:1
roachprod start local:1
sleep 10
roachprod sql local:1 -- -e "SELECT 1"
```

With the fix, after restarting, the server logs

> persisting HLC upper bound is enabled [every 0.50s]

a second time (the first time being when the setting is set). Without the fix, we see this log line only once, not to mention the crash.

Fixes #137331.

Epic: none
Release note (bug fix): a problem was fixed which could cause nodes running under the `server.clock.persist_upper_bound_interval` cluster setting to crash after restarts with error "wall time <timestamp> is not allowed to be greater than upper bound of <timestamp>". This problem would occur frequently in single-node clusters, but can not be ruled out on multi-node clusters. It is now fixed in both.