### PR TITLE
roachprod: fix remote monitor script

### DIFF
--- a/pkg/roachprod/install/scripts/monitor_remote.sh
+++ b/pkg/roachprod/install/scripts/monitor_remote.sh
@@ -19,7 +19,7 @@ one_shot=#{if .OneShot#}true#{end#}
 prev_frame=""
 while :; do
   # Get all cockroach system units
-  sysctl_output=$(systemctl list-units cockroach\*.service --type=service --no-legend --no-pager | awk '{print $1}')
+  sysctl_output=$(systemctl list-units cockroach\*.service --type=service --no-legend --no-pager --plain | awk '{print $1}')
   frame=""
   while IFS= read -r name; do
     # Query the PID and status of the cockroach system unit


### PR DESCRIPTION
Previously, roachprod Monitor was updated to use new scripts to be able to detect new processes (See: #136879).

But in the event a process dies `systemctl list-units` starts applying formatting to the list entry, for the dead unit. This prevents `awk` from correctly filtering the output.

This change adds `--plain` to the `systemctl list-units call` to prevent `systemctl` from adding formatting to a dead system unit.

Prior to this change, Monitor was still able to detect the process death due to it not being in the list anymore, but lost the cause of death and exit code.

Epic: None
Release note: None