### PR TITLE
roachtest: disable the impact check for elastic workload

### DIFF
--- a/pkg/cmd/roachtest/tests/admission_control_latency.go
+++ b/pkg/cmd/roachtest/tests/admission_control_latency.go
@@ -216,7 +216,7 @@ func registerLatencyTests(r registry.Registry) {
 	addMetamorphic(r, &decommission{}, 5.0)
 	addMetamorphic(r, backfill{}, 40.0)
 	addMetamorphic(r, &slowDisk{}, math.Inf(1))
-	addMetamorphic(r, elasticWorkload{}, 20.0)
+	addMetamorphic(r, elasticWorkload{}, math.Inf(1))
 
 	// NB: If these tests fail, it likely signals a regression. Investigate the
 	// history of the test on roachperf to see what changed.
@@ -226,7 +226,7 @@ func registerLatencyTests(r registry.Registry) {
 	addFull(r, &decommission{drain: true}, 5.0)
 	addFull(r, backfill{}, 40.0)
 	addFull(r, &slowDisk{slowLiveness: true, walFailover: true}, math.Inf(1))
-	addFull(r, elasticWorkload{}, 20.0)
+	addFull(r, elasticWorkload{}, math.Inf(1))
 
 	// NB: These tests will never fail and are not enabled, but they are useful
 	// for development.


### PR DESCRIPTION
Backport of #137836 

Recently the elastic workload test has been less stable and even with the change to the default kvadmission.flow_control.mode change to `apply_to_all` it can still overload the disk and cause large impacts.

Fixes: #136991
Informs: #137835

Release note: None

Fixes: #138870