### PR TITLE
backup: remove support for reading old backup manifest format

### DIFF
--- a/pkg/backup/backup_job.go
+++ b/pkg/backup/backup_job.go
@@ -456,7 +456,7 @@ func backup(
 	// TODO(adityamaru): We can stop writing `BACKUP_MANIFEST` in 23.2
 	// because a mixed-version cluster with 23.1 nodes will read the
 	// `BACKUP_METADATA` instead.
-	if err := backupinfo.WriteBackupManifest(ctx, defaultStore, backupbase.BackupManifestName,
+	if err := backupinfo.WriteBackupManifest(ctx, defaultStore, backupbase.LegacyBackupManifestName,
 		encryption, &kmsEnv, backupManifest); err != nil {
 		return roachpb.RowCount{}, 0, err
 	}

--- a/pkg/backup/backup_test.go
+++ b/pkg/backup/backup_test.go
@@ -142,7 +142,7 @@ func TestBackupRestoreStatementResult(t *testing.T) {
 	// have been stored in the GZip compressed format.
 	t.Run("GZipBackupManifest", func(t *testing.T) {
 		backupDir := fmt.Sprintf("%s/foo", dir)
-		backupManifestFile := backupDir + backupPath + "/" + backupbase.BackupManifestName
+		backupManifestFile := backupDir + backupPath + "/" + backupbase.LegacyBackupManifestName
 		backupManifestBytes, err := os.ReadFile(backupManifestFile)
 		if err != nil {
 			t.Fatal(err)
@@ -665,7 +665,7 @@ func TestBackupRestoreAppend(t *testing.T) {
 	// Find the backup times in the collection and try RESTORE'ing to each, and
 	// within each also check if we can restore to individual times captured with
 	// incremental backups that were appended to that backup.
-	fullBackup1, fullBackup2 := findFullBackupPaths(tmpDir, path.Join(tmpDir, "*/*/*/"+backupbase.BackupManifestName))
+	fullBackup1, fullBackup2 := findFullBackupPaths(tmpDir, path.Join(tmpDir, "*/*/*/"+backupbase.LegacyBackupManifestName))
 
 	sqlDB.Exec(t, "DROP DATABASE data CASCADE")
 	sqlDB.Exec(t, "RESTORE DATABASE data FROM $4 IN ($1, $2, $3) AS OF SYSTEM TIME "+tsBefore,
@@ -730,7 +730,7 @@ func TestBackupAndRestoreJobDescription(t *testing.T) {
 	sqlDB.Exec(t, "BACKUP INTO ($1, $2, $3) AS OF SYSTEM TIME '-1s'", collections...)
 
 	// Find the subdirectory created by the full BACKUP INTO statement.
-	matches, err := filepath.Glob(path.Join(tmpDir, "full/*/*/*/"+backupbase.BackupManifestName))
+	matches, err := filepath.Glob(path.Join(tmpDir, "full/*/*/*/"+backupbase.LegacyBackupManifestName))
 	require.NoError(t, err)
 	require.Equal(t, 2, len(matches))
 	for i := range matches {
@@ -1766,7 +1766,7 @@ func TestBackupRestoreResume(t *testing.T) {
 
 				// If the backup properly took the (incorrect) checkpoint into account, it
 				// won't have tried to re-export any keys within backupCompletedSpan.
-				backupManifestFile := backupDir + "/" + backupbase.BackupManifestName
+				backupManifestFile := backupDir + "/" + backupbase.LegacyBackupManifestName
 				backupManifestBytes, err := os.ReadFile(backupManifestFile)
 				if err != nil {
 					t.Fatal(err)
@@ -3976,7 +3976,7 @@ func TestBackupRestoreChecksum(t *testing.T) {
 
 	var backupManifest backuppb.BackupManifest
 	{
-		backupManifestBytes, err := os.ReadFile(filepath.Join(dir, backupPath, backupbase.BackupManifestName))
+		backupManifestBytes, err := os.ReadFile(filepath.Join(dir, backupPath, backupbase.LegacyBackupManifestName))
 		if err != nil {
 			t.Fatalf("%+v", err)
 		}
@@ -10582,7 +10582,7 @@ func TestBackupDoNotIncludeViewSpans(t *testing.T) {
 	// Read the backup manifest.
 	var backupManifest backuppb.BackupManifest
 	{
-		backupManifestBytes, err := os.ReadFile(filepath.Join(dir, "foo", res[0][0], backupbase.BackupManifestName))
+		backupManifestBytes, err := os.ReadFile(filepath.Join(dir, "foo", res[0][0], backupbase.LegacyBackupManifestName))
 		if err != nil {
 			t.Fatalf("%+v", err)
 		}

--- a/pkg/backup/backupbase/constants.go
+++ b/pkg/backup/backupbase/constants.go
@@ -29,19 +29,12 @@ const (
 	// Also exported for testing backup inspection tooling.
 	DateBasedIntoFolderName = "/2006/01/02-150405.00"
 
-	// BackupOldManifestName is an old name for the serialized BackupManifest
-	// proto. It is used by 20.1 nodes and earlier.
-	//
-	// TODO(adityamaru): Remove this in 22.2 as part of disallowing backups
-	// from >1 major version in the past.
-	BackupOldManifestName = "BACKUP"
-
-	// BackupManifestName is the file name used for serialized BackupManifest
+	// LegacyBackupManifestName is the file name used for serialized BackupManifest
 	// protos.
 	//
 	// TODO(adityamaru): Remove in 23.2 since at that point all nodes will be
 	// writing a SlimBackupManifest instead.
-	BackupManifestName = "BACKUP_MANIFEST"
+	LegacyBackupManifestName = "BACKUP_MANIFEST"
 
 	// BackupMetadataName is the file name used for serialized BackupManifest
 	// protos written by 23.1 nodes and later. This manifest has the alloc heavy

--- a/pkg/backup/backupdest/backup_destination.go
+++ b/pkg/backup/backupdest/backup_destination.go
@@ -50,7 +50,7 @@ const (
 // On some cloud storage platforms (i.e. GS, S3), backups in a base bucket may
 // omit a leading slash. However, backups in a subdirectory of a base bucket
 // will contain one.
-var backupPathRE = regexp.MustCompile("^/?[^\\/]+/[^\\/]+/[^\\/]+/" + backupbase.BackupManifestName + "$")
+var backupPathRE = regexp.MustCompile("^/?[^\\/]+/[^\\/]+/[^\\/]+/" + backupbase.LegacyBackupManifestName + "$")
 
 // featureFullBackupUserSubdir, when true, will create a full backup at a user
 // specified subdirectory if no backup already exists at that subdirectory. As
@@ -65,7 +65,7 @@ var featureFullBackupUserSubdir = settings.RegisterBoolSetting(
 
 // TODO(adityamaru): Move this to the soon to be `backupinfo` package.
 func containsManifest(ctx context.Context, exportStore cloud.ExternalStorage) (bool, error) {
-	r, _, err := exportStore.ReadFile(ctx, backupbase.BackupManifestName, cloud.ReadOptions{NoFileSize: true})
+	r, _, err := exportStore.ReadFile(ctx, backupbase.LegacyBackupManifestName, cloud.ReadOptions{NoFileSize: true})
 	if err != nil {
 		if errors.Is(err, cloud.ErrFileDoesNotExist) {
 			return false, nil
@@ -475,7 +475,7 @@ func ListFullBackupsInCollection(
 		return nil, err
 	}
 	for i, backupPath := range backupPaths {
-		backupPaths[i] = strings.TrimSuffix(backupPath, "/"+backupbase.BackupManifestName)
+		backupPaths[i] = strings.TrimSuffix(backupPath, "/"+backupbase.LegacyBackupManifestName)
 	}
 	return backupPaths, nil
 }

--- a/pkg/backup/backupdest/backup_destination_test.go
+++ b/pkg/backup/backupdest/backup_destination_test.go
@@ -48,7 +48,7 @@ func TestBackupRestoreResolveDestination(t *testing.T) {
 		storage, err := externalStorageFromURI(ctx, uri, username.RootUserName())
 		defer storage.Close()
 		require.NoError(t, err)
-		require.NoError(t, cloud.WriteFile(ctx, storage, backupbase.BackupManifestName, emptyReader))
+		require.NoError(t, cloud.WriteFile(ctx, storage, backupbase.LegacyBackupManifestName, emptyReader))
 	}
 
 	// writeLatest writes latestBackupSuffix to the LATEST file in the given

--- a/pkg/backup/backupdest/incrementals.go
+++ b/pkg/backup/backupdest/incrementals.go
@@ -78,22 +78,14 @@ func FindPriorBackups(
 
 	var prev []string
 	if err := store.List(ctx, "", backupbase.ListingDelimDataSlash, func(p string) error {
-		if ok, err := path.Match(incBackupSubdirGlob+backupbase.BackupManifestName, p); err != nil {
+		if ok, err := path.Match(incBackupSubdirGlob+backupbase.LegacyBackupManifestName, p); err != nil {
 			return err
 		} else if ok {
 			if !includeManifest {
-				p = strings.TrimSuffix(p, "/"+backupbase.BackupManifestName)
+				p = strings.TrimSuffix(p, "/"+backupbase.LegacyBackupManifestName)
 			}
 			prev = append(prev, p)
 			return nil
-		}
-		if ok, err := path.Match(incBackupSubdirGlob+backupbase.BackupOldManifestName, p); err != nil {
-			return err
-		} else if ok {
-			if !includeManifest {
-				p = strings.TrimSuffix(p, "/"+backupbase.BackupOldManifestName)
-			}
-			prev = append(prev, p)
 		}
 		return nil
 	}); err != nil {

--- a/pkg/backup/full_cluster_backup_restore_test.go
+++ b/pkg/backup/full_cluster_backup_restore_test.go
@@ -665,7 +665,7 @@ func TestClusterRestoreFailCleanup(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if info.Name() == backupbase.BackupManifestName ||
+		if info.Name() == backupbase.LegacyBackupManifestName ||
 			!strings.HasSuffix(path, ".sst") ||
 			info.Name() == backupinfo.BackupMetadataDescriptorsListPath ||
 			info.Name() == backupinfo.BackupMetadataFilesListPath {

--- a/pkg/backup/show.go
+++ b/pkg/backup/show.go
@@ -510,7 +510,7 @@ func checkBackupFiles(
 		// Check metadata files. Note: we do not check locality aware backup
 		// metadata files ( prefixed with `backupPartitionDescriptorPrefix`) , as
 		// they're validated in resolveBackupManifests.
-		metaFile := backupbase.BackupManifestName + backupinfo.BackupManifestChecksumSuffix
+		metaFile := backupbase.LegacyBackupManifestName + backupinfo.BackupManifestChecksumSuffix
 		if _, err := defaultStore.Size(ctx, metaFile); err != nil {
 			return nil, errors.Wrapf(err, "Error checking metadata file %s/%s",
 				info.defaultURIs[layer], metaFile)

--- a/pkg/backup/utils_test.go
+++ b/pkg/backup/utils_test.go
@@ -229,7 +229,7 @@ func makeThresholdBlocker(threshold int) thresholdBlocker {
 // getSpansFromManifest returns the spans that describe the data included in a
 // given backup.
 func getSpansFromManifest(ctx context.Context, t *testing.T, backupPath string) roachpb.Spans {
-	backupManifestBytes, err := os.ReadFile(backupPath + "/" + backupbase.BackupManifestName)
+	backupManifestBytes, err := os.ReadFile(backupPath + "/" + backupbase.LegacyBackupManifestName)
 	require.NoError(t, err)
 	var backupManifest backuppb.BackupManifest
 	decompressedBytes, err := backupinfo.DecompressData(ctx, mon.NewStandaloneUnlimitedAccount(), backupManifestBytes)


### PR DESCRIPTION
This removes support for reading the non-compressed "BACKUP" manifest that was deprecate back in 22.1.

This change also renames the manifest to the legacy manifest. The legacy manifest was supposed to be deleted back in 23.2, but there are still some consumers that need to be switched to read the slim manifest. This rename makes it clear that no new code should read the legacy manifest.

Release Note: none
Epic: none