### PR TITLE
demo: fix `--global` with `--multitenant=true`

### DIFF
--- a/pkg/base/test_server_args.go
+++ b/pkg/base/test_server_args.go
@@ -157,6 +157,11 @@ type TestServerArgs struct {
 	// below for alternative options that suits your test case.
 	DefaultTestTenant DefaultTestTenantOptions
 
+	// DefaultTenantName is the name of the tenant created implicitly according
+	// to DefaultTestTenant. It is typically `test-tenant` for unit tests and
+	// always `demoapp` for the cockroach demo.
+	DefaultTenantName roachpb.TenantName
+
 	// StartDiagnosticsReporting checks cluster.TelemetryOptOut(), and
 	// if not disabled starts the asynchronous goroutine that checks for
 	// CockroachDB upgrades and periodically reports diagnostics to

--- a/pkg/cli/democluster/demo_cluster.go
+++ b/pkg/cli/democluster/demo_cluster.go
@@ -925,6 +925,7 @@ func (demoCtx *Context) testServerArgsForTransientCluster(
 		// Demo clusters by default will create their own tenants, so we
 		// don't need to create them here.
 		DefaultTestTenant: base.TODOTestTenantDisabled,
+		DefaultTenantName: roachpb.TenantName(demoTenantName),
 
 		Knobs: base.TestingKnobs{
 			Server: &server.TestingKnobs{

--- a/pkg/cli/democluster/demo_cluster_test.go
+++ b/pkg/cli/democluster/demo_cluster_test.go
@@ -66,6 +66,7 @@ func TestTestServerArgsForTransientCluster(t *testing.T) {
 			sqlPoolMemorySize: 2 << 10,
 			cacheSize:         1 << 10,
 			expected: base.TestServerArgs{
+				DefaultTenantName:             "demoapp",
 				DefaultTestTenant:             base.TODOTestTenantDisabled,
 				PartOfCluster:                 true,
 				JoinAddr:                      "127.0.0.1",
@@ -93,6 +94,7 @@ func TestTestServerArgsForTransientCluster(t *testing.T) {
 			sqlPoolMemorySize: 4 << 10,
 			cacheSize:         4 << 10,
 			expected: base.TestServerArgs{
+				DefaultTenantName:             "demoapp",
 				DefaultTestTenant:             base.TODOTestTenantDisabled,
 				PartOfCluster:                 true,
 				JoinAddr:                      "127.0.0.1",

--- a/pkg/server/application_api/metrics_test.go
+++ b/pkg/server/application_api/metrics_test.go
@@ -212,10 +212,7 @@ func TestStatusVarsTxnMetrics(t *testing.T) {
 	})
 	t.Run("tenant", func(t *testing.T) {
 		s := srv.ApplicationLayer()
-		// TODO(knz): why is the tenant label missing here?
-		// TODO(herko): it is present when running in shared process mode. Hence why
-		// the test is now forced to run only in external process mode.
-		testFn(s, `tenant=""`)
+		testFn(s, `tenant="test-tenant"`)
 	})
 }
 

--- a/pkg/testutils/serverutils/test_server_shim.go
+++ b/pkg/testutils/serverutils/test_server_shim.go
@@ -38,6 +38,8 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
+const defaultTestTenantName = roachpb.TenantName("test-tenant")
+
 // defaultTestTenantMessage is a message that is printed when a test is run
 // under cluster virtualization. This is useful for debugging test failures.
 //
@@ -317,6 +319,10 @@ func NewServer(params base.TestServerArgs) (TestServerInterface, error) {
 	tcfg := params.DefaultTestTenant
 	if tcfg.TestTenantNoDecisionMade() {
 		return nil, errors.AssertionFailedf("programming error: DefaultTestTenant does not contain a decision\n(maybe call ShouldStartDefaultTestTenant?)")
+	}
+
+	if params.DefaultTenantName == "" {
+		params.DefaultTenantName = defaultTestTenantName
 	}
 
 	srv, err := srvFactoryImpl.New(params)


### PR DESCRIPTION
After the system tenant is running on all nodes, the initialization gets stuck after the `demoapp` tenant is running on node 1 and during the startup of tenant servers on other nodes. The logs show that node 1 was rejecting connection attempts made by the initializing SQL server for `demoapp` from nodes 2 and 3.

```log
kv/kvclient/kvtenant/connector.go:1019 ⋮ [n3,tenant-connector] 13444  error dialing tenant KV address ‹127.0.0.1:26362›: initial connection heartbeat failed: grpc: ‹connection error: desc = "transport: authentication handshake failed: read tcp 127.0.0.1:49534->127.0.0.1:26362: read: connection reset by peer"› [code 14/Unavailable]
```

This was because those connections didn't set the right header required by `delayingConn` on the listener side. The cause was that the `InjectedLatencyOracle` was passed down as `nil`, and due to this, the right dialer for those connections wasn't set up:
https://github.com/cockroachdb/cockroach/blob/5c0c6d3a29d77ae9d9dc381875eb03ba3c0a76f3/pkg/rpc/context.go#L1590-L1600

Why was it passed down as `nil`?

In the `demo_cluster.go`, the main startup/orchestrator function [`transientCluster.Start`](https://github.com/cockroachdb/cockroach/blob/86cd9acda8ba46ff245ac62e078a18816f3f89da/pkg/cli/democluster/demo_cluster.go#L391-L396) creates a tenant sequentially on all nodes while passing the right parameters, including the needed knob:
https://github.com/cockroachdb/cockroach/blob/86cd9acda8ba46ff245ac62e078a18816f3f89da/pkg/cli/democluster/demo_cluster.go#L565-L580

However, there is a race condition with the [monitor that watches](https://github.com/cockroachdb/cockroach/blob/c68c559859be738efead9971f5e11f62a8c69d06/pkg/server/server_controller.go#L203-L222) for tenant entries in the `system.tenants` table and starts the server on other nodes if they aren't running. This path gets its `testArgs` in [`testServer.PreStart`](https://github.com/cockroachdb/cockroach/blob/7f44c4912b3d8f385dc404571e3b74f72ac05247/pkg/server/testserver.go#L786-L804) using the `testServer.getSharedProcessDefaultTenantArgs` function, which not only misses copying the `InjectedLatencyOracle` but also uses the wrong tenant name, causing the problem of the wrong key name in `ts.topLevelServer.serverController.mu.testArgs[args.TenantName] = args`.

The fix here is simple, but we could also explore using a knob that would disable this monitor.

Fixes: #135043
Epic: none
Release note: none