### PR TITLE
raft: remove fmt.printf defortify line

### DIFF
--- a/pkg/raft/raft.go
+++ b/pkg/raft/raft.go
@@ -923,7 +923,6 @@ func (r *raft) bcastDeFortify() {
 	assertTrue(r.fortificationTracker.CanDefortify(), "unsafe to de-fortify")
 
 	r.trk.Visit(func(id pb.PeerID, _ *tracker.Progress) {
-		fmt.Printf("Sending defortify to %v\n", id)
 		r.sendDeFortify(id)
 	})
 }


### PR DESCRIPTION
This commit removes a log line that was added, and it shouldn't be there.

Fixes: #139137

Release Note: None