### PR TITLE
cdctest: add mvcc_timestamp, diff, sink_config options to nemesis testing

### DIFF
--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -926,7 +926,7 @@ func runCDCBank(ctx context.Context, t test.Test, c cluster.Cluster) {
 		if err != nil {
 			return errors.Wrap(err, "error creating validator")
 		}
-		baV, err := cdctest.NewBeforeAfterValidator(db, `bank.bank`)
+		baV, err := cdctest.NewBeforeAfterValidator(db, `bank.bank`, true)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
This work adds to random changefeed settings we pass into changefeeds
in nemesis testing. This commit adds support for: changefeeds without
the diff option specified, the mvcc_timestamp option and the kafka and
pubsub sink configs.

See also: https://github.com/cockroachdb/cockroach/issues/134119

Epic: [CRDB-42866](https://cockroachlabs.atlassian.net/browse/CRDB-42866)

Release note: None