### PR TITLE
workflows: run `update_releases` on `release-25.1`

### DIFF
--- a/.github/workflows/update_releases.yaml
+++ b/.github/workflows/update_releases.yaml
@@ -32,6 +32,7 @@ jobs:
           - "release-24.1"
           - "release-24.2"
           - "release-24.3"
+          - "release-25.1"
     name: Update pkg/testutils/release/cockroach_releases.yaml on ${{ matrix.branch }}
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Release note: None
Epic: None
Release justification: release-infa process only change.