### PR TITLE
sql: use parsed statements for persistedsqlstats

### DIFF
--- a/pkg/sql/sqlstats/persistedsqlstats/BUILD.bazel
+++ b/pkg/sql/sqlstats/persistedsqlstats/BUILD.bazel
@@ -32,6 +32,8 @@ go_library(
         "//pkg/sql/appstatspb",
         "//pkg/sql/catalog/systemschema",
         "//pkg/sql/isql",
+        "//pkg/sql/parser",
+        "//pkg/sql/parser/statements",
         "//pkg/sql/sem/tree",
         "//pkg/sql/sessiondata",
         "//pkg/sql/sqlstats",

--- a/pkg/sql/sqlstats/persistedsqlstats/provider.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/provider.go
@@ -20,6 +20,9 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/isql"
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/cockroachdb/cockroach/pkg/sql/parser/statements"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats/sslocal"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -81,6 +84,9 @@ type PersistedSQLStats struct {
 
 	// The last time the size was checked before doing a flush.
 	lastSizeCheck time.Time
+
+	upsertTxnStatsStmt  statements.Statement[tree.Statement]
+	upsertStmtStatsStmt statements.Statement[tree.Statement]
 }
 
 var _ sqlstats.Provider = &PersistedSQLStats{}
@@ -103,6 +109,34 @@ func New(cfg *Config, memSQLStats *sslocal.SQLStats) *PersistedSQLStats {
 	if cfg.Knobs != nil {
 		p.jobMonitor.testingKnobs.updateCheckInterval = cfg.Knobs.JobMonitorUpdateCheckInterval
 	}
+
+	upsertTxnStatsStmt, err := parser.ParseOne(`
+INSERT INTO system.transaction_statistics as t
+VALUES ($1, $2, $3, $4, $5, $6, $7)
+ON CONFLICT (crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_shard_8, aggregated_ts, fingerprint_id, app_name, node_id)
+DO UPDATE
+SET
+  statistics = crdb_internal.merge_transaction_stats(ARRAY(t.statistics, EXCLUDED.statistics))
+`)
+	if err != nil {
+		panic(err)
+	}
+	p.upsertTxnStatsStmt = upsertTxnStatsStmt
+
+	upsertStmtStatsStmt, err := parser.ParseOne(`
+INSERT INTO system.statement_statistics as s
+VALUES ($1 ,$2, $3, $4, $5, $6, $7, $8, $9, $10, $11)
+ON CONFLICT (crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8,
+             aggregated_ts, fingerprint_id, transaction_fingerprint_id, app_name, plan_hash, node_id)
+DO UPDATE
+SET
+  statistics = crdb_internal.merge_statement_stats(ARRAY(s.statistics, EXCLUDED.statistics)),
+  index_recommendations = EXCLUDED.index_recommendations
+`)
+	if err != nil {
+		panic(err)
+	}
+	p.upsertStmtStatsStmt = upsertStmtStatsStmt
 
 	return p
 }


### PR DESCRIPTION
Previously, we would re-parse SQL statements used to upsert statement and txn stats. To address this patch, this patch will parse these statements once and use ExecParsed to reduce CPU usage. This patch also adds a simple benchmark for this code path as well, which shows a small 1% delta.

Before:
BenchmarkSQLStatsFlush          100        1415926687 ns/op        319339313 B/op   2302002 allocs/op
After:
BenchmarkSQLStatsFlush          100        1396673170 ns/op        319003310 B/op   2298192 allocs/op

Fixes: #134583
Release note: None