### PR TITLE
sql: surface error for duplicate storage parameters during execution

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -4395,3 +4395,33 @@ statement ok
 SET use_declarative_schema_changer = $use_decl_sc;
 
 subtest end
+
+subtest alter_table_duplicate_storage_params
+
+statement ok
+CREATE TABLE alter_table_duplicate_storage_params_a (
+  a INT PRIMARY KEY,
+  b TEXT NOT NULL
+);
+
+statement error pgcode 22023 pq: parameter "fillfactor" specified more than once
+ALTER TABLE alter_table_duplicate_storage_params_a SET (fillfactor=20, fillfactor=30);
+
+subtest end
+
+subtest alter_table_alter_primary_key_duplicate_storage_params
+
+statement ok
+CREATE TABLE alter_table_alter_primary_key_duplicate_storage_params_a (
+  a INT PRIMARY KEY,
+  b TEXT NOT NULL
+);
+
+statement error pgcode 22023 pq: parameter "bucket_count" specified more than once
+ALTER TABLE alter_table_alter_primary_key_duplicate_storage_params_a
+  ALTER PRIMARY KEY
+  USING COLUMNS (b)
+  USING HASH
+  WITH (bucket_count=30, bucket_count=20);
+
+subtest end

--- a/pkg/sql/logictest/testdata/logic_test/create_index
+++ b/pkg/sql/logictest/testdata/logic_test/create_index
@@ -564,3 +564,38 @@ statement ok
 DROP TABLE t_disable_full_ts
 
 subtest end
+
+subtest create_index_duplicate_storage_params
+
+statement ok
+CREATE TABLE create_index_duplicate_storage_params_a (
+  a INT PRIMARY KEY,
+  b INT
+);
+
+statement error pgcode 22023 pq: parameter "fillfactor" specified more than once
+CREATE INDEX idx_a ON create_index_duplicate_storage_params_a (b) WITH (fillfactor=10, fillfactor=20);
+
+statement error pgcode 22023 pq: parameter "fillfactor" specified more than once
+CREATE INDEX IF NOT EXISTS idx_b ON create_index_duplicate_storage_params_a (b) WITH (fillfactor=10, fillfactor=20);
+
+statement error pgcode 22023 pq: parameter "bucket_count" specified more than once
+CREATE INDEX ON create_index_duplicate_storage_params_a (b) USING HASH WITH (bucket_count=10, bucket_count=12);
+
+subtest end
+
+subtest create_inverted_index_duplicate_storage_params
+
+statement ok
+CREATE TABLE create_inverted_index_duplicate_storage_params_a (
+  a INT PRIMARY KEY,
+  b JSONB
+);
+
+statement error pgcode 22023 pq: parameter "fillfactor" specified more than once
+CREATE INVERTED INDEX idx_a ON create_inverted_index_duplicate_storage_params_a (b) WITH (fillfactor=10, fillfactor=20);
+
+statement error pgcode 22023 pq: parameter "fillfactor" specified more than once
+CREATE INVERTED INDEX IF NOT EXISTS idx_b ON create_inverted_index_duplicate_storage_params_a (b) WITH (fillfactor=10, fillfactor=20);
+
+subtest end

--- a/pkg/sql/logictest/testdata/logic_test/create_table
+++ b/pkg/sql/logictest/testdata/logic_test/create_table
@@ -1130,3 +1130,77 @@ CREATE TABLE t2 AS SELECT * FROM t1;
 NOTICE: CREATE TABLE ... AS does not copy over indexes, default expressions, or constraints; the new table has a hidden rowid primary key column
 
 subtest end
+
+subtest create_table_with_duplicate_storage_params
+
+statement error pgcode 22023 pq: parameter "fillfactor" specified more than once
+CREATE TABLE create_table_with_duplicate_storage_params_a (
+  a INT PRIMARY KEY,
+  b TEXT NOT NULL
+) WITH (fillfactor=10, fillfactor=15);
+
+statement error pgcode 22023 pq: parameter "fillfactor" specified more than once
+CREATE TABLE IF NOT EXISTS create_table_with_duplicate_storage_params_b (
+  a INT
+) WITH (fillfactor=10, fillfactor=20);
+
+subtest end
+
+subtest create_table_with_as_duplicate_storage_params
+
+statement ok
+CREATE TABLE create_table_with_as_duplicate_storage_params_a (a INT);
+
+statement error pgcode 22023 pq: parameter "fillfactor" specified more than once
+CREATE TABLE create_table_with_as_duplicate_storage_params_b (a) WITH (fillfactor=10, fillfactor=20) AS (SELECT * FROM create_table_with_as_duplicate_storage_params_a);
+
+statement error pgcode 22023 pq: parameter "fillfactor" specified more than once
+CREATE TABLE IF NOT EXISTS create_table_with_as_duplicate_storage_params_c (a) WITH (fillfactor=10, fillfactor=20) AS (SELECT * FROM create_table_with_as_duplicate_storage_params_a);
+
+subtest end
+
+subtest create_table_primary_key_with_duplicate_storage_params
+
+# only bucket_count is a valid storage param, so USING HASH must be added
+statement error pgcode 22023 pq: parameter "bucket_count" specified more than once
+CREATE TABLE create_table_primary_key_with_duplicate_storage_params_a (a INT PRIMARY KEY USING HASH WITH (bucket_count=10, bucket_count=20));
+
+subtest end
+
+subtest create_table_index_elem_duplicate_storage_params
+
+statement error pgcode 22023 pq: parameter "fillfactor" specified more than once
+CREATE TABLE create_table_index_elem_duplicate_storage_params_a (
+  a INT PRIMARY KEY,
+  b INT,
+  INDEX (b) WITH (fillfactor=10, fillfactor=20)
+);
+
+statement error pgcode 22023 pq: parameter "fillfactor" specified more than once
+CREATE TABLE create_table_index_elem_duplicate_storage_params_b (
+  a INT PRIMARY KEY,
+  b INT,
+  INDEX b_idx (b) WITH (fillfactor=10, fillfactor=20)
+);
+
+statement error pgcode 22023 pq: parameter "bucket_count" specified more than once
+CREATE TABLE create_table_index_elem_duplicate_storage_params_c (
+  a INT PRIMARY KEY,
+  b INT,
+  UNIQUE INDEX (b) USING HASH WITH (bucket_count=10, bucket_count=20)
+);
+
+statement error pgcode 22023 pq: parameter "fillfactor" specified more than once
+CREATE TABLE create_table_index_elem_duplicate_storage_params_d (
+  a INT PRIMARY KEY,
+  b JSONB,
+  INVERTED INDEX (b) WITH (fillfactor=10, fillfactor=20)
+);
+
+statement error pgcode 22023 pq: parameter "bucket_count" specified more than once
+CREATE TABLE create_table_index_elem_duplicate_storage_params_e (
+  a INT,
+  PRIMARY KEY (a) USING HASH WITH (bucket_count=10, bucket_count=20)
+);
+
+subtest end

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_alter_primary_key.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_alter_primary_key.go
@@ -277,12 +277,13 @@ func alterPKInPrimaryIndexAndItsTemp(
 // checkForEarlyExit asserts several precondition for a
 // `ALTER PRIMARY KEY`, including
 //  1. no expression columns allowed;
-//  2. no columns that are in `DROPPED` state;
-//  3. no inaccessible columns;
-//  4. no nullable columns;
-//  5. no virtual columns (starting from v22.1);
-//  6. No columns that are scheduled to be dropped (target status set to `ABSENT`);
-//  7. add more here
+//  2. no duplicate storage parameters;
+//  3. no columns that are in `DROPPED` state;
+//  4. no inaccessible columns;
+//  5. no nullable columns;
+//  6. no virtual columns (starting from v22.1);
+//  7. No columns that are scheduled to be dropped (target status set to `ABSENT`);
+//  8. add more here
 //
 // Panic if any precondition is found unmet.
 func checkForEarlyExit(b BuildCtx, tbl *scpb.Table, t alterPrimaryKeySpec) {
@@ -295,6 +296,8 @@ func checkForEarlyExit(b BuildCtx, tbl *scpb.Table, t alterPrimaryKeySpec) {
 	); err != nil {
 		panic(err)
 	}
+
+	maybeApplyStorageParameters(b, t.StorageParams, &indexSpec{})
 
 	usedColumns := make(map[tree.Name]bool, len(t.Columns))
 	for _, col := range t.Columns {

--- a/pkg/sql/storageparam/storage_param.go
+++ b/pkg/sql/storageparam/storage_param.go
@@ -129,8 +129,13 @@ func storageParamPreChecks(
 		return errors.AssertionFailedf("only one of setParams and resetParams should be non-nil.")
 	}
 
-	var keys []string
+	keys := make([]string, 0, len(setParams)+len(resetParams))
+	params := make(map[string]struct{}, len(setParams))
 	for _, param := range setParams {
+		if _, exists := params[param.Key]; exists {
+			return pgerror.Newf(pgcode.InvalidParameterValue, "parameter %q specified more than once", param.Key)
+		}
+		params[param.Key] = struct{}{}
 		keys = append(keys, param.Key)
 	}
 	keys = append(keys, resetParams...)


### PR DESCRIPTION
Previously, we would allow duplicate storage parameter keys which could lead to confusion - there is no guarantee to the user which storage parameter value would be selected when the index is created. Additionally, Postgres errors with code `22023` when there are duplicate storage parameters specified.

To address this, this patch adds duplicate checks within the `storageparam` package and ensures the checks are run for the possible query types that have the storage parameter option.

Fixes: #90454

Release note (bug fix): Storage parameters with the same key would lead to ambiguity. This has now been fixed - an error will be surfaced if duplicate storage parameters are specified.