### PR TITLE
jobs,*: cleanup some usages of deprecated desc IDs and started fields

### DIFF
--- a/pkg/cli/debug_job_trace.go
+++ b/pkg/cli/debug_job_trace.go
@@ -46,33 +46,44 @@ func runDebugJobTrace(_ *cobra.Command, args []string) (resErr error) {
 
 func getJobTraceID(sqlConn clisqlclient.Conn, jobID int64) (int64, error) {
 	var traceID int64
-	rows, err := sqlConn.Query(context.Background(),
-		`SELECT trace_id FROM crdb_internal.jobs WHERE job_id=$1`, jobID)
-	if err != nil {
-		return traceID, err
-	}
-	vals := make([]driver.Value, 1)
-	for {
-		var err error
-		if err = rows.Next(vals); err == io.EOF {
-			break
-		}
+	// We normally avoid programatic access to the job's message log, but this is
+	// a debug command so we can allow it here.
+	for attempt, query := range []string{
+		`SELECT message::int FROM system.job_message WHERE job_id=$1 AND kind = 'trace-id' ORDER BY written DESC LIMIT 1`,
+		`SELECT trace_id FROM crdb_internal.jobs WHERE job_id=$1`,
+	} {
+		rows, err := sqlConn.Query(context.Background(), query, jobID)
 		if err != nil {
+			// Cluster might not be on 25.1 yet; just fallback to old query.
+			if attempt == 0 {
+				continue
+			}
 			return traceID, err
 		}
+		vals := make([]driver.Value, 1)
+		for {
+			var err error
+			if err = rows.Next(vals); err == io.EOF {
+				break
+			}
+			if err != nil {
+				return traceID, err
+			}
+		}
+		if err := rows.Close(); err != nil {
+			return traceID, err
+		}
+		if vals[0] == nil {
+			continue
+		}
+		var ok bool
+		traceID, ok = vals[0].(int64)
+		if !ok {
+			return traceID, errors.New("failed to parse traceID")
+		}
+		return traceID, nil
 	}
-	if err := rows.Close(); err != nil {
-		return traceID, err
-	}
-	if vals[0] == nil {
-		return traceID, errors.Newf("no job entry found for %d", jobID)
-	}
-	var ok bool
-	traceID, ok = vals[0].(int64)
-	if !ok {
-		return traceID, errors.New("failed to parse traceID")
-	}
-	return traceID, nil
+	return traceID, errors.Newf("no job entry found for %d", jobID)
 }
 
 func constructJobTraceZipBundle(ctx context.Context, sqlConn clisqlclient.Conn, jobID int64) error {

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -2250,11 +2250,9 @@ SELECT
   description,
   statement,
   user_name,
-  descriptor_ids,
   status,
   running_status,
   created,
-  started,
   finished,
   modified,
   fraction_completed,
@@ -2366,11 +2364,9 @@ func scanRowIntoJob(scanner resultScanner, row tree.Datums, job *serverpb.JobRes
 		&job.Description,
 		&job.Statement,
 		&job.Username,
-		&job.DescriptorIDs,
 		&job.Status,
 		&runningStatusOrNil,
 		&job.Created,
-		&job.Started,
 		&job.Finished,
 		&job.Modified,
 		&fractionCompletedOrNil,
@@ -2427,8 +2423,8 @@ func jobHelper(
 	sqlServer *SQLServer,
 ) (_ *serverpb.JobResponse, retErr error) {
 	const query = `
-	        SELECT job_id, job_type, description, statement, user_name, descriptor_ids, status,
-	  						 running_status, created, started, finished, modified,
+	        SELECT job_id, job_type, description, statement, user_name, status,
+	  						 running_status, created, finished, modified,
 	  						 fraction_completed, high_water_timestamp, error, execution_events::string, coordinator_id
 	          FROM crdb_internal.jobs
 	         WHERE job_id = $1`

--- a/pkg/sql/delegate/show_changefeed_jobs.go
+++ b/pkg/sql/delegate/show_changefeed_jobs.go
@@ -56,7 +56,7 @@ SELECT
     FROM
       crdb_internal.tables
     WHERE
-      table_id = ANY (descriptor_ids)
+      table_id = ANY (SELECT key::INT FROM json_each(changefeed_details->'tables'))
   ) AS full_table_names,
   changefeed_details->'opts'->>'topics' AS topics,
   COALESCE(changefeed_details->'opts'->>'format','json') AS format

--- a/pkg/sql/logictest/testdata/logic_test/schema_change_in_txn
+++ b/pkg/sql/logictest/testdata/logic_test/schema_change_in_txn
@@ -719,10 +719,10 @@ statement ok
 CREATE UNIQUE INDEX n_idx ON customers (n)
 
 # Validate that pending jobs show within a transactions before its committed.
-query TTT
-SELECT status, started, job_type FROM crdb_internal.jobs WHERE status='pending'
+query TT
+SELECT status, job_type FROM crdb_internal.jobs WHERE status='pending'
 ----
-pending    NULL                                    SCHEMA CHANGE
+pending    SCHEMA CHANGE
 
 statement error pgcode XXA00 violates unique constraint
 COMMIT

--- a/pkg/testutils/jobutils/BUILD.bazel
+++ b/pkg/testutils/jobutils/BUILD.bazel
@@ -14,12 +14,10 @@ go_library(
         "//pkg/kv/kvpb",
         "//pkg/kv/kvserver/kvserverbase",
         "//pkg/security/username",
-        "//pkg/sql/catalog/descpb",
         "//pkg/testutils",
         "//pkg/testutils/sqlutils",
         "//pkg/util/protoutil",
         "@com_github_cockroachdb_errors//:errors",
-        "@com_github_lib_pq//:pq",
         "@com_github_stretchr_testify//assert",
     ],
 )


### PR DESCRIPTION
These fields are being deprecated -- the distinction between started and created is not worth loading/updating the payload to track and desc-ids should be determined from feature-specific details by feature specific code. The changes here start removing references to and assertions about the content of these two fields from a variety of tests.