### PR TITLE
colexec: deflake TestExternalDistinctSpilling

### DIFF
--- a/pkg/sql/catalog/table_col_map_test.go
+++ b/pkg/sql/catalog/table_col_map_test.go
@@ -6,7 +6,6 @@
 package catalog_test
 
 import (
-	"math/rand"
 	"sort"
 	"testing"
 
@@ -30,7 +29,7 @@ func TestTableColMap(t *testing.T) {
 	for _, systemColumnDesc := range colinfo.AllSystemColumnDescs {
 		columnIDs = append(columnIDs, systemColumnDesc.ID)
 	}
-	rand.Shuffle(len(columnIDs), func(i, j int) {
+	rng.Shuffle(len(columnIDs), func(i, j int) {
 		columnIDs[i], columnIDs[j] = columnIDs[j], columnIDs[i]
 	})
 

--- a/pkg/sql/colexec/colexecargs/op_creation.go
+++ b/pkg/sql/colexec/colexecargs/op_creation.go
@@ -74,6 +74,10 @@ type NewColOperatorArgs struct {
 	TestingKnobs       struct {
 		// SpillingCallbackFn will be called when the spilling from an in-memory
 		// to disk-backed operator occurs. It should only be set in tests.
+		// TODO(yuzefovich): this knob is a bit confusing because it is
+		// currently inherited by "child" disk-backed operators. It is also
+		// called every time when the disk-backed operator spills to disk,
+		// including after it has been reset for reuse.
 		SpillingCallbackFn func()
 		// NumForcedRepartitions specifies a number of "repartitions" that a
 		// disk-backed operator should be forced to perform. "Repartition" can

--- a/pkg/sql/colexec/colexecdisk/hash_based_partitioner.go
+++ b/pkg/sql/colexec/colexecdisk/hash_based_partitioner.go
@@ -271,6 +271,10 @@ func newHashBasedPartitioner(
 		inputTypes:         inputTypes,
 		hashCols:           hashCols,
 		inMemMainOp:        inMemMainOpConstructor(partitionedInputs),
+		// TODO(yuzefovich): we could delay creation of the disk-backed fallback
+		// operator until we actually need it. This isn't a big deal though
+		// since we only create the hash-based partitioner once some other
+		// operator spills to disk.
 		diskBackedFallbackOp: diskBackedFallbackOpConstructor(
 			partitionedInputs, maxNumberActivePartitions, partitionedDiskQueueSemaphore,
 		),

--- a/pkg/sql/colexec/external_distinct_test.go
+++ b/pkg/sql/colexec/external_distinct_test.go
@@ -146,7 +146,7 @@ func TestExternalDistinctSpilling(t *testing.T) {
 	newTupleProbability := rng.Float64()
 	nTuples := int(float64(nDistinctBatches*coldata.BatchSize()) / newTupleProbability)
 	const maxNumTuples = 25000
-	spillingMightNotHappen := false
+	spillingMustHappen := true
 	if nTuples > maxNumTuples {
 		// If we happen to set a large value for coldata.BatchSize() and a small
 		// value for newTupleProbability, we might end up with huge number of
@@ -158,11 +158,12 @@ func TestExternalDistinctSpilling(t *testing.T) {
 		// limit to the in-memory distinct. In such (relatively rare) scenario
 		// we cannot check that we spilled every time, yet we might as well run
 		// the correctness check.
-		spillingMightNotHappen = true
+		spillingMustHappen = false
 	}
 	tups, expected := generateRandomDataForUnorderedDistinct(rng, nTuples, nCols, newTupleProbability)
 
-	var numRuns, numSpills int
+	var numRuns int
+	runSpilled := make(map[int]struct{})
 	var semsToCheck []semaphore.Semaphore
 	numForcedRepartitions := rng.Intn(5)
 	colexectestutils.RunTestsWithoutAllNullsInjection(
@@ -183,23 +184,29 @@ func TestExternalDistinctSpilling(t *testing.T) {
 			numRuns++
 			return createExternalDistinct(
 				ctx, flowCtx, input, typs, distinctCols, false /* nullsAreDistinct */, "", /* errorOnDup */
-				execinfrapb.Ordering{}, queueCfg, sem, func() { numSpills++ }, numForcedRepartitions,
+				execinfrapb.Ordering{}, queueCfg, sem, func() { runSpilled[numRuns] = struct{}{} }, numForcedRepartitions,
 				&monitorRegistry, &closerRegistry,
 			)
 		},
 	)
-	// We expect to see the disk spiller for each run, and the external distinct
-	// and the disk-backed sort for every time we spilled.
-	require.Equal(t, numRuns+2*numSpills, closerRegistry.NumClosers())
+	if spillingMustHappen {
+		// We expect that we spilled during each run.
+		for run := 1; run <= numRuns; run++ {
+			_, spilled := runSpilled[run]
+			require.Truef(t, spilled, "run %d didn't spill to disk", run)
+		}
+		// For each run we expect to see the following closers:
+		// - the disk spiller for the unordered distinct
+		// - the disk spiller for the disk-backed sort used in the fallback
+		// strategy of the external distinct
+		// - the hash-based partitioner for the external distinct.
+		//
+		// In some scenarios we might also see the external sort there (if the
+		// disk-backed sort actually spills to disk), but we'll ignore that.
+		require.GreaterOrEqual(t, closerRegistry.NumClosers(), 3*numRuns)
+	}
 	for i, sem := range semsToCheck {
 		require.Equal(t, 0, sem.GetCount(), "sem still reports open FDs at index %d", i)
-	}
-	if !spillingMightNotHappen {
-		// The "randomNullsInjection" subtest might not spill to disk when a
-		// large portion of rows is made NULL, so we allow two cases:
-		// - numSpills == numRuns
-		// - numSpills == numRuns - 1.
-		require.GreaterOrEqual(t, numSpills, numRuns-1, "the spilling didn't occur in all cases")
 	}
 }
 

--- a/pkg/sql/colexec/external_distinct_test.go
+++ b/pkg/sql/colexec/external_distinct_test.go
@@ -236,7 +236,7 @@ func generateRandomDataForUnorderedDistinct(
 		}
 	}
 
-	rand.Shuffle(nTups, func(i, j int) { tups[i], tups[j] = tups[j], tups[i] })
+	rng.Shuffle(nTups, func(i, j int) { tups[i], tups[j] = tups[j], tups[i] })
 	return tups, expected
 }
 

--- a/pkg/sql/distsql/columnar_operators_test.go
+++ b/pkg/sql/distsql/columnar_operators_test.go
@@ -329,7 +329,7 @@ func TestAggregatorAgainstProcessor(t *testing.T) {
 						}
 						if hashAgg {
 							// Let's shuffle the rows for the hash aggregator.
-							rand.Shuffle(nRows, func(i, j int) {
+							rng.Shuffle(nRows, func(i, j int) {
 								rows[i], rows[j] = rows[j], rows[i]
 							})
 						} else {


### PR DESCRIPTION
We recently made some changes so that disk operators are created lazily
whenever spilling to disk occurs. In that change we still attempted to
assert that all necessary operators are included into the closer
registry, but the assertion added to `TestExternalDistinctSpilling`
turned out to be flaky. In particular, it is quite tricky to reason
about the expected number of closers since the testing callback function
is inherited by the whole operator tree and it can actually be called
multiple times by a single operator (when it is reset and reused). This
commit refactors the test a bit to relax the assertions a bit without
sacrificing what we attempt to verify.

Fixes: #139085.

Release note: None