### PR TITLE
server: skip TestDRPCSelectQuery

### DIFF
--- a/pkg/server/server_drpc_test.go
+++ b/pkg/server/server_drpc_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/stretchr/testify/require"
@@ -23,6 +24,8 @@ import (
 func TestDRPCSelectQuery(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+
+	skip.UnderRaceWithIssue(t, 139134)
 
 	testutils.RunTrueAndFalse(t, "insecure", func(t *testing.T, insecure bool) {
 		ctx, cancel := context.WithTimeout(context.Background(), testutils.SucceedsSoonDuration())


### PR DESCRIPTION
celia's note:
- I'm okay to leave this test as-is on `master`, if helpful/preferred. 
- I primarily would like to skip this test on `release-25.1` to unblock 25.1 releases: https://github.com/cockroachdb/cockroach/pull/139190

----

`Merged ARM64 Tests` - a dependency for building release candidates
- is failing on `TestDRPCSelectQuery/insecure=false`

Which seems to be failing release-25.1 and master:

https://teamcity.cockroachdb.com/test/8101648167209808852?currentProjectId=Cockroach_Ci_TestsAwsLinuxArm64&expandTestHistoryChartSection=true

Temporarily skipping this test to unblock the release process.

Related to: https://github.com/cockroachdb/cockroach/issues/139134
Release note: None
Epic: None
Release justification: test-only change to unblock release process.