### PR TITLE
roachtest: disable 4K block size intent resolution test

### DIFF
--- a/pkg/cmd/roachtest/tests/perturbation/intents.go
+++ b/pkg/cmd/roachtest/tests/perturbation/intents.go
@@ -33,7 +33,15 @@ func (i intents) setup() variations {
 }
 
 func (i intents) setupMetamorphic(rng *rand.Rand) variations {
-	return i.setup().randomize(rng)
+	v := i.setup()
+	v = v.randomize(rng)
+
+	// TODO(#139187): Large block sizes result in a big slowdown when the intents
+	// are written.
+	// TODO(#139188): Large block sizes result in a big slowdown when the intents
+	// are resolved.
+	v.blockSize = min(v.blockSize, 1024)
+	return v
 }
 
 func (intents) startTargetNode(ctx context.Context, t test.Test, v variations) {

--- a/pkg/cmd/roachtest/tests/perturbation/intents.go
+++ b/pkg/cmd/roachtest/tests/perturbation/intents.go
@@ -41,6 +41,10 @@ func (i intents) setupMetamorphic(rng *rand.Rand) variations {
 	// TODO(#139188): Large block sizes result in a big slowdown when the intents
 	// are resolved.
 	v.blockSize = min(v.blockSize, 1024)
+
+	// TODO(#135934): A large buildup of intents still causes a large slowdown
+	// when the intents are resolved.
+	v.perturbationDuration = max(v.perturbationDuration, 10*time.Minute)
 	return v
 }
 


### PR DESCRIPTION
With a 4K block size, the intent resolution test will cause unacceptable slowdowns. This commit changes the perturbation/*/intents to only test up to 1024 block sizes.

This also reduces the max perturbation duration to 10 minutes.

Informs: #139187
Informs: #139188
Informs: #137590 
Informs: #135934
Fixes: #137590

Epic: none

Release note: None