### PR TITLE
rpc: avoid modifying shared TLS config to prevent data race

### DIFF
--- a/pkg/rpc/drpc.go
+++ b/pkg/rpc/drpc.go
@@ -120,10 +120,12 @@ func dialDRPC(rpcCtx *Context) func(ctx context.Context, target string) (drpcpoo
 				if err != nil {
 					return nil, err
 				}
-				tlsConn := tls.Client(netConn, tlsConfig)
+				// Clone TLS config to avoid modifying a cached TLS config.
+				tlsConfig = tlsConfig.Clone()
 				// TODO(server): remove this hack which is necessary at least in
 				// testing to get TestDRPCSelectQuery to pass.
 				tlsConfig.InsecureSkipVerify = true
+				tlsConn := tls.Client(netConn, tlsConfig)
 				conn = drpcconn.NewWithOptions(tlsConn, opts)
 			}
 

--- a/pkg/server/server_drpc_test.go
+++ b/pkg/server/server_drpc_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
-	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/stretchr/testify/require"
@@ -24,8 +23,6 @@ import (
 func TestDRPCSelectQuery(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-
-	skip.UnderRaceWithIssue(t, 139134)
 
 	testutils.RunTrueAndFalse(t, "insecure", func(t *testing.T, insecure bool) {
 		ctx, cancel := context.WithTimeout(context.Background(), testutils.SucceedsSoonDuration())


### PR DESCRIPTION
The certificate manager initializes a new TLS configuration instance and caches it for reuse. Modifying the cached TLS configuration introduced a data race. Fixed the data race and unskipped the test that was skipped in #139189.

Fixes: #139134
Epic: none
Release note: none