### PR TITLE
storage: add a "low disk space" event

### DIFF
--- a/docs/generated/eventlog.md
+++ b/docs/generated/eventlog.md
@@ -169,6 +169,29 @@ events.
 | `Timestamp` | The timestamp of the event. Expressed as nanoseconds since the Unix epoch. | no |
 | `EventType` | The type of the event. | no |
 
+### `low_disk_space`
+
+An event of type `low_disk_space` is emitted when a store is reaching capacity, as we reach
+certain thresholds. It is emitted periodically while we are in a low disk
+state.
+
+
+| Field | Description | Sensitive |
+|--|--|--|
+| `NodeID` | The node ID where the event was originated. | no |
+| `StoreID` |  | no |
+| `PercentThreshold` | The free space percent threshold that we went under. | no |
+| `AvailableBytes` |  | no |
+| `TotalBytes` |  | no |
+
+
+#### Common fields
+
+| Field | Description | Sensitive |
+|--|--|--|
+| `Timestamp` | The timestamp of the event. Expressed as nanoseconds since the Unix epoch. | no |
+| `EventType` | The type of the event. | no |
+
 ### `node_decommissioned`
 
 An event of type `node_decommissioned` is recorded when a node is marked as

--- a/pkg/storage/engine.go
+++ b/pkg/storage/engine.go
@@ -1130,6 +1130,11 @@ type Engine interface {
 	// over a short period of time.
 	RegisterDiskSlowCallback(cb func(info pebble.DiskSlowInfo))
 
+	// RegisterLowDiskSpaceCallback registers a callback that will be run when a
+	// disk is running out of space. This callback needs to be thread-safe as it
+	// could be called repeatedly in multiple threads over a short period of time.
+	RegisterLowDiskSpaceCallback(cb func(info pebble.LowDiskSpaceInfo))
+
 	// GetPebbleOptions returns the options used when creating the engine. The
 	// caller must not modify these.
 	GetPebbleOptions() *pebble.Options

--- a/pkg/ui/workspaces/db-console/src/util/eventTypes.ts
+++ b/pkg/ui/workspaces/db-console/src/util/eventTypes.ts
@@ -137,6 +137,9 @@ export const DISK_SLOWNESS_DETECTED = "disk_slowness_detected";
 // Recorded when a disk slowness event is no longer detected on a store
 // after having been detected and reported previously.
 export const DISK_SLOWNESS_CLEARED = "disk_slowness_cleared";
+// Recorded when a disk is running low on available space (recorded
+// periodically).
+export const LOW_DISK_SPACE = "low_disk_space";
 
 // Node Event Types
 export const nodeEvents = [
@@ -147,6 +150,7 @@ export const nodeEvents = [
   NODE_RECOMMISSIONED,
   DISK_SLOWNESS_DETECTED,
   DISK_SLOWNESS_CLEARED,
+  LOW_DISK_SPACE,
 ];
 export const databaseEvents = [CREATE_DATABASE, DROP_DATABASE];
 export const tableEvents = [

--- a/pkg/ui/workspaces/db-console/src/util/events.ts
+++ b/pkg/ui/workspaces/db-console/src/util/events.ts
@@ -210,6 +210,8 @@ export function getEventDescription(e: clusterUiApi.EventColumns): string {
       return `Disk Slowness Detected: Node ${info.NodeID} Store ${info.StoreID} is experiencing a slow disk`;
     case eventTypes.DISK_SLOWNESS_CLEARED:
       return `Disk Slowness Cleared: Node ${info.NodeID} Store ${info.StoreID} is no longer experiencing a slow disk`;
+    case eventTypes.LOW_DISK_SPACE:
+      return `Available disk space below ${info.PercentThreshold}%: Node ${info.NodeID} Store ${info.StoreID}`;
     default:
       return `Event: ${e.eventType}, content: ${JSON.stringify(info, null, 2)}`;
   }
@@ -273,6 +275,9 @@ export interface EventInfo {
   PreviousDescriptor?: string;
   NewDescriptor?: string;
   StoreID?: string;
+  PercentThreshold?: string;
+  AvailableBytes?: string;
+  TotalBytes?: string;
 }
 
 export function getDroppedObjectsText(eventInfo: EventInfo): string {

--- a/pkg/util/log/eventpb/cluster_events.proto
+++ b/pkg/util/log/eventpb/cluster_events.proto
@@ -134,6 +134,22 @@ message DiskSlownessCleared {
   int32 store_id = 3 [(gogoproto.customname) = "StoreID", (gogoproto.jsontag) = ",omitempty"];
 }
 
+// LowDiskSpace is emitted when a store is reaching capacity, as we reach
+// certain thresholds. It is emitted periodically while we are in a low disk
+// state.
+message LowDiskSpace {
+  CommonEventDetails common = 1 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "", (gogoproto.embed) = true];
+
+  // The node ID where the event was originated.
+  int32 node_id = 2 [(gogoproto.customname) = "NodeID", (gogoproto.jsontag) = ",omitempty"];
+  int32 store_id = 3 [(gogoproto.customname) = "StoreID", (gogoproto.jsontag) = ",omitempty"];
+
+  // The free space percent threshold that we went under.
+  int32 percent_threshold = 4 [(gogoproto.jsontag) = ",omitempty"];
+  uint64 available_bytes = 5 [(gogoproto.jsontag) = ",omitempty"];
+  uint64 total_bytes = 6 [(gogoproto.jsontag) = ",omitempty"];
+}
+
 // CertsReload is recorded when the TLS certificates are
 // reloaded/rotated from disk.
 message CertsReload {

--- a/pkg/util/log/eventpb/eventlog_channels_generated.go
+++ b/pkg/util/log/eventpb/eventlog_channels_generated.go
@@ -23,6 +23,9 @@ func (m *DiskSlownessCleared) LoggingChannel() logpb.Channel { return logpb.Chan
 func (m *DiskSlownessDetected) LoggingChannel() logpb.Channel { return logpb.Channel_OPS }
 
 // LoggingChannel implements the EventPayload interface.
+func (m *LowDiskSpace) LoggingChannel() logpb.Channel { return logpb.Channel_OPS }
+
+// LoggingChannel implements the EventPayload interface.
 func (m *NodeDecommissioned) LoggingChannel() logpb.Channel { return logpb.Channel_OPS }
 
 // LoggingChannel implements the EventPayload interface.

--- a/pkg/util/log/eventpb/json_encode_generated.go
+++ b/pkg/util/log/eventpb/json_encode_generated.go
@@ -3438,6 +3438,59 @@ func (m *LevelStats) AppendJSONFields(printComma bool, b redact.RedactableBytes)
 }
 
 // AppendJSONFields implements the EventPayload interface.
+func (m *LowDiskSpace) AppendJSONFields(printComma bool, b redact.RedactableBytes) (bool, redact.RedactableBytes) {
+
+	printComma, b = m.CommonEventDetails.AppendJSONFields(printComma, b)
+
+	if m.NodeID != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"NodeID\":"...)
+		b = strconv.AppendInt(b, int64(m.NodeID), 10)
+	}
+
+	if m.StoreID != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"StoreID\":"...)
+		b = strconv.AppendInt(b, int64(m.StoreID), 10)
+	}
+
+	if m.PercentThreshold != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"PercentThreshold\":"...)
+		b = strconv.AppendInt(b, int64(m.PercentThreshold), 10)
+	}
+
+	if m.AvailableBytes != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"AvailableBytes\":"...)
+		b = strconv.AppendUint(b, uint64(m.AvailableBytes), 10)
+	}
+
+	if m.TotalBytes != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"TotalBytes\":"...)
+		b = strconv.AppendUint(b, uint64(m.TotalBytes), 10)
+	}
+
+	return printComma, b
+}
+
+// AppendJSONFields implements the EventPayload interface.
 func (m *MVCCIteratorStats) AppendJSONFields(printComma bool, b redact.RedactableBytes) (bool, redact.RedactableBytes) {
 
 	if printComma {


### PR DESCRIPTION
Post an event (visible in the Events page) when a store is running low
on disk space. We post an event the first time when the available
bytes go below 10%, then when they go below 5%, then 3%, 2%, 1%. We
repost the event every half hour until the condition is resolved.

Fixes #129319
Release note (ui change): an event is posted when a store is getting
close to full capacity.

---

Example in the UI:

<img width="921" alt="image" src="https://github.com/user-attachments/assets/1d82a915-0e2e-425f-acb5-36b7d882c096" />

It also shows up in logs:
```
I250116 04:35:29.718164 83 3@pebble/event.go:1017 ⋮ [n?,s?,pebble] 23  available disk space under 10% (36GB of 368GB)
I250116 04:40:21.377270 10391 3@pebble/event.go:1017 ⋮ [n2,s2,pebble] 145  available disk space under 5% (18GB of 368GB)
```