### PR TITLE
roachprod: Create/Destroy should avoid listing _all_ providers

### DIFF
--- a/pkg/roachprod/cloud/cluster_cloud.go
+++ b/pkg/roachprod/cloud/cluster_cloud.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+	"slices"
 	"sort"
 	"text/tabwriter"
 	"time"
@@ -321,6 +322,17 @@ type ClusterCreateOpts struct {
 	Nodes                 int
 	CreateOpts            vm.CreateOpts
 	ProviderOptsContainer vm.ProviderOptionsContainer
+}
+
+// Extracts o.CreateOpts.VMProviders from the provided opts.
+func Providers(opts ...*ClusterCreateOpts) []string {
+	providers := []string{}
+	for _, o := range opts {
+		providers = append(providers, o.CreateOpts.VMProviders...)
+	}
+	// Remove dupes, if any.
+	slices.Sort(providers)
+	return slices.Compact(providers)
 }
 
 // CreateCluster TODO(peter): document

--- a/pkg/roachprod/vm/aws/support.go
+++ b/pkg/roachprod/vm/aws/support.go
@@ -314,7 +314,7 @@ func (p *Provider) runCommand(l *logger.Logger, args []string) ([]byte, error) {
 	output, err := cmd.Output()
 	if err != nil {
 		if exitErr := (*exec.ExitError)(nil); errors.As(err, &exitErr) {
-			l.Printf("%s", string(exitErr.Stderr))
+			l.Printf("%s", exitErr)
 		}
 		return nil, errors.Wrapf(err, "failed to run: aws %s: stderr: %v",
 			strings.Join(args, " "), stderrBuf.String())

--- a/pkg/roachprod/vm/vm.go
+++ b/pkg/roachprod/vm/vm.go
@@ -621,7 +621,9 @@ func FindActiveAccounts(l *logger.Logger) (map[string]string, error) {
 		err := ProvidersSequential(AllProviderNames(), func(p Provider) error {
 			account, err := p.FindActiveAccount(l)
 			if err != nil {
-				return err
+				l.Printf("WARN: provider=%q has no active account", p.Name())
+				//nolint:returnerrcheck
+				return nil
 			}
 			if len(account) > 0 {
 				source[p.Name()] = account


### PR DESCRIPTION
Previously, both `Create` and `Destroy` would attempt to list VMs across _all_ active cloud providers. Not only is it inefficient, but `Create` may also fail if
the user isn't re-authenticated to an unrelated
provider. E.g., `create --clouds gce` may fail
if AWS SSO token expired.

This change derives the set of required providers
from either the user-specified `--clouds` CLI option or the local cluster cache. The set is then used with `ListCloud` to skip listing unrelated providers.
The use of the local cache is sound at this time;
cluster's providers are immutable.

Epic: none

Release note: None