### PR TITLE
kvcoord: wait on server-side goroutine in MuxRangeFeed

### DIFF
--- a/pkg/rpc/BUILD.bazel
+++ b/pkg/rpc/BUILD.bazel
@@ -49,6 +49,7 @@ go_library(
         "//pkg/util",
         "//pkg/util/buildutil",
         "//pkg/util/circuit",
+        "//pkg/util/ctxgroup",
         "//pkg/util/envutil",
         "//pkg/util/growstack",
         "//pkg/util/grpcutil",


### PR DESCRIPTION
When using an internal client, we launch a goroutine to run the server-side of the range feed request. Previously, nothing was waiting on this goroutine to exit, causing at lease once race condition because of the shared tracing span.

Now, the internal client implements a close method that can be called before the client returns.

Hopefully,

Fixes #136407

Release note: None