### PR TITLE
roachtest: disable backfill success check

### DIFF
--- a/pkg/cmd/roachtest/tests/perturbation/index_backfill.go
+++ b/pkg/cmd/roachtest/tests/perturbation/index_backfill.go
@@ -8,6 +8,7 @@ package perturbation
 import (
 	"context"
 	"fmt"
+	"math"
 	"math/rand"
 	"time"
 
@@ -27,7 +28,9 @@ type backfill struct{}
 var _ perturbation = backfill{}
 
 func (b backfill) setup() variations {
-	v := setup(b, 40.0)
+	// TODO(#139262): Track down why this test causes stalls and drop the value
+	// to something more reasonable (like 5) once this is done.
+	v := setup(b, math.Inf(1))
 	return v
 }
 


### PR DESCRIPTION
The perturbation/*/backfill tests are flaky and are failing at least once a week with the default configuration. This change temporarily disables the check to allow easier investigation of the other failure modes such as backfill failing to complete and node OOMs. Once those are closed, and the test is running more stably, this threshold can be dropped.

Fixes: #137093
Fixes: #137392

Informs: #133114

Release note: None