### PR TITLE
demo: remove `TODOTestTenantDisabled` usage

### DIFF
--- a/pkg/cli/democluster/demo_cluster.go
+++ b/pkg/cli/democluster/demo_cluster.go
@@ -924,7 +924,7 @@ func (demoCtx *Context) testServerArgsForTransientCluster(
 		EnableDemoLoginEndpoint: true,
 		// Demo clusters by default will create their own tenants, so we
 		// don't need to create them here.
-		DefaultTestTenant: base.TODOTestTenantDisabled,
+		DefaultTestTenant: base.TestControlsTenantsExplicitly,
 		DefaultTenantName: roachpb.TenantName(demoTenantName),
 
 		Knobs: base.TestingKnobs{

--- a/pkg/cli/democluster/demo_cluster_test.go
+++ b/pkg/cli/democluster/demo_cluster_test.go
@@ -67,7 +67,7 @@ func TestTestServerArgsForTransientCluster(t *testing.T) {
 			cacheSize:         1 << 10,
 			expected: base.TestServerArgs{
 				DefaultTenantName:             "demoapp",
-				DefaultTestTenant:             base.TODOTestTenantDisabled,
+				DefaultTestTenant:             base.TestControlsTenantsExplicitly,
 				PartOfCluster:                 true,
 				JoinAddr:                      "127.0.0.1",
 				DisableTLSForHTTP:             true,
@@ -95,7 +95,7 @@ func TestTestServerArgsForTransientCluster(t *testing.T) {
 			cacheSize:         4 << 10,
 			expected: base.TestServerArgs{
 				DefaultTenantName:             "demoapp",
-				DefaultTestTenant:             base.TODOTestTenantDisabled,
+				DefaultTestTenant:             base.TestControlsTenantsExplicitly,
 				PartOfCluster:                 true,
 				JoinAddr:                      "127.0.0.1",
 				Addr:                          "127.0.0.1:1336",


### PR DESCRIPTION
Since the `demo` is controlling the tenants explicitly, `TestControlsTenantsExplicitly` makes more sense here.

Informs: #138912
Epic: CRDB-38970
Release note: None