### PR TITLE
roachtest: use separate context to download statement bundles

### DIFF
--- a/pkg/cmd/roachtest/tests/kv.go
+++ b/pkg/cmd/roachtest/tests/kv.go
@@ -605,6 +605,12 @@ func registerKVGracefulDraining(r registry.Registry) {
 			// meet its qps targets.
 			require.NoError(t, roachtestutil.ProfileTopStatements(ctx, c, t.L(), roachtestutil.ProfDbName("kv")))
 			defer func() {
+				// In cases where the test fails, the supplied context will be
+				// cancelled, and we'll be left with squat. Download profiles using a
+				// separate context.
+				ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
+				defer cancel()
+
 				if err := roachtestutil.DownloadProfiles(ctx, c, t.L(), t.ArtifactsDir()); err != nil {
 					t.L().PrintfCtx(ctx, "failed to download stmt bundles: %v", err)
 				}


### PR DESCRIPTION
We saw context cancelled errors while trying to download statement bundles in all recent test failures. This seems to be happening because the supplied context is cancelled when t.Fatal is called. Let's prevent this by using a new context to download statement bundles instead.

References https://github.com/cockroachdb/cockroach/issues/131569

Release note: None