### PR TITLE
sql/rowenc: reduce index key prefix calls

### DIFF
--- a/pkg/sql/backfill/BUILD.bazel
+++ b/pkg/sql/backfill/BUILD.bazel
@@ -58,6 +58,7 @@ go_test(
     ],
     embed = [":backfill"],
     deps = [
+        "//pkg/keys",
         "//pkg/kv",
         "//pkg/roachpb",
         "//pkg/sql/catalog",

--- a/pkg/sql/backfill/index_backfiller_cols_test.go
+++ b/pkg/sql/backfill/index_backfiller_cols_test.go
@@ -8,6 +8,7 @@ package backfill
 import (
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catenumpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
@@ -411,7 +412,7 @@ func TestInitIndexesAllowList(t *testing.T) {
 	t.Run("nil allowList", func(t *testing.T) {
 		// A nil allowList means no filtering.
 		ib := &IndexBackfiller{}
-		ib.initIndexes(desc, nil /* allowList */)
+		ib.initIndexes(keys.SystemSQLCodec, desc, nil /* allowList */)
 		require.Equal(t, 2, len(ib.added))
 		require.Equal(t, catid.IndexID(2), ib.added[0].GetID())
 		require.Equal(t, catid.IndexID(3), ib.added[1].GetID())
@@ -419,7 +420,7 @@ func TestInitIndexesAllowList(t *testing.T) {
 
 	t.Run("non-nil allowList", func(t *testing.T) {
 		ib := &IndexBackfiller{}
-		ib.initIndexes(desc, []catid.IndexID{3} /* allowList */)
+		ib.initIndexes(keys.SystemSQLCodec, desc, []catid.IndexID{3} /* allowList */)
 		require.Equal(t, 1, len(ib.added))
 		require.Equal(t, catid.IndexID(3), ib.added[0].GetID())
 	})

--- a/pkg/sql/rowenc/index_encoding.go
+++ b/pkg/sql/rowenc/index_encoding.go
@@ -1125,14 +1125,8 @@ func encodeTrigramInvertedIndexTableKeys(
 	return outKeys, nil
 }
 
-// EncodePrimaryIndex constructs a list of k/v pairs for a
-// row encoded as a primary index. This function mirrors the encoding
-// logic in prepareInsertOrUpdateBatch in pkg/sql/row/writer.go.
-// It is somewhat duplicated here due to the different arguments
-// that prepareOrInsertUpdateBatch needs and uses to generate
-// the k/v's for the row it inserts. includeEmpty controls
-// whether or not k/v's with empty values should be returned.
-// It returns indexEntries in family sorted order.
+// EncodePrimaryIndex constructs the key prefix for the primary index and
+// delegates the rest of the encoding to EncodePrimaryIndexWithKeyPrefix.
 func EncodePrimaryIndex(
 	codec keys.SQLCodec,
 	tableDesc catalog.TableDescriptor,
@@ -1142,6 +1136,25 @@ func EncodePrimaryIndex(
 	includeEmpty bool,
 ) ([]IndexEntry, error) {
 	keyPrefix := MakeIndexKeyPrefix(codec, tableDesc.GetID(), index.GetID())
+	return EncodePrimaryIndexWithKeyPrefix(tableDesc, index, keyPrefix, colMap, values, includeEmpty)
+}
+
+// EncodePrimaryIndexWithKeyPrefix constructs a list of k/v pairs for a
+// row encoded as a primary index, using the provided key prefix specific to
+// that index. This function mirrors the encoding logic in
+// prepareInsertOrUpdateBatch in pkg/sql/row/writer.go. It is somewhat
+// duplicated here due to the different arguments that
+// prepareOrInsertUpdateBatch needs and uses to generate the k/v's for the row
+// it inserts. includeEmpty controls whether or not k/v's with empty values
+// should be returned. It returns indexEntries in family sorted order.
+func EncodePrimaryIndexWithKeyPrefix(
+	tableDesc catalog.TableDescriptor,
+	index catalog.Index,
+	keyPrefix []byte,
+	colMap catalog.TableColMap,
+	values []tree.Datum,
+	includeEmpty bool,
+) ([]IndexEntry, error) {
 	indexKey, containsNull, err := EncodeIndexKey(tableDesc, index, colMap, values, keyPrefix)
 	if err != nil {
 		return nil, err
@@ -1284,9 +1297,8 @@ func MakeNullPKError(
 	return errors.AssertionFailedf("NULL value in unknown key column")
 }
 
-// EncodeSecondaryIndexKey encodes the key for a secondary index. The 'colMap'
-// maps descpb.ColumnIDs to positions in 'values'. This function returns a slice
-// of byte arrays representing the key values.
+// EncodeSecondaryIndexKey constructs the key prefix for the secondary index and
+// delegates the rest of the encoding to EncodeSecondaryIndexWithKeyPrefix.
 func EncodeSecondaryIndexKey(
 	ctx context.Context,
 	codec keys.SQLCodec,
@@ -1295,29 +1307,40 @@ func EncodeSecondaryIndexKey(
 	colMap catalog.TableColMap,
 	values []tree.Datum,
 ) ([][]byte, bool, error) {
-	secondaryIndexKeyPrefix := MakeIndexKeyPrefix(codec, tableDesc.GetID(), secondaryIndex.GetID())
+	keyPrefix := MakeIndexKeyPrefix(codec, tableDesc.GetID(), secondaryIndex.GetID())
+	return EncodeSecondaryIndexKeyWithKeyPrefix(ctx, tableDesc, secondaryIndex, keyPrefix, colMap,
+		values)
+}
 
+// EncodeSecondaryIndexKeyWithKeyPrefix generates a slice of byte arrays
+// representing encoded key values for the given secondary index, using the
+// provided key prefix specific to that index. The colMap maps descpb.ColumnIDs
+// to positions in the values slice.
+func EncodeSecondaryIndexKeyWithKeyPrefix(
+	ctx context.Context,
+	tableDesc catalog.TableDescriptor,
+	secondaryIndex catalog.Index,
+	keyPrefix []byte,
+	colMap catalog.TableColMap,
+	values []tree.Datum,
+) ([][]byte, bool, error) {
 	var containsNull = false
 	var secondaryKeys [][]byte
 	var err error
 	if secondaryIndex.GetType() == idxtype.INVERTED {
-		secondaryKeys, err = EncodeInvertedIndexKeys(ctx, secondaryIndex, colMap, values, secondaryIndexKeyPrefix)
+		secondaryKeys, err = EncodeInvertedIndexKeys(ctx, secondaryIndex, colMap, values, keyPrefix)
 	} else {
 		var secondaryIndexKey []byte
 		secondaryIndexKey, containsNull, err = EncodeIndexKey(
-			tableDesc, secondaryIndex, colMap, values, secondaryIndexKeyPrefix)
+			tableDesc, secondaryIndex, colMap, values, keyPrefix)
 
 		secondaryKeys = [][]byte{secondaryIndexKey}
 	}
 	return secondaryKeys, containsNull, err
 }
 
-// EncodeSecondaryIndex encodes key/values for a secondary
-// index. colMap maps descpb.ColumnIDs to indices in `values`. This returns a
-// slice of IndexEntry. includeEmpty controls whether or not
-// EncodeSecondaryIndex should return k/v's that contain
-// empty values. For forward indexes the returned list of
-// index entries is in family sorted order.
+// EncodeSecondaryIndex constructs the key prefix for the secondary index and
+// delegates the rest of the encoding to EncodeSecondaryIndexWithKeyPrefix.
 func EncodeSecondaryIndex(
 	ctx context.Context,
 	codec keys.SQLCodec,
@@ -1327,12 +1350,35 @@ func EncodeSecondaryIndex(
 	values []tree.Datum,
 	includeEmpty bool,
 ) ([]IndexEntry, error) {
+	keyPrefix := MakeIndexKeyPrefix(codec, tableDesc.GetID(), secondaryIndex.GetID())
+	return EncodeSecondaryIndexWithKeyPrefix(ctx, tableDesc, secondaryIndex, keyPrefix, colMap,
+		values, includeEmpty)
+}
+
+// EncodeSecondaryIndexWithKeyPrefix generates a slice of IndexEntry objects
+// representing encoded key/value pairs for the given secondary index, using the
+// provided key prefix specific to that index. This encoding is performed in
+// EncodeSecondaryIndexKeyWithKeyPrefix for secondary indexes. The colMap maps
+// descpb.ColumnIDs to positions in the values slice. The 'includeEmpty'
+// parameter determines whether entries with empty values should be included.
+// For forward indexes, the resulting entries are sorted by column family order.
+func EncodeSecondaryIndexWithKeyPrefix(
+	ctx context.Context,
+	tableDesc catalog.TableDescriptor,
+	secondaryIndex catalog.Index,
+	keyPrefix []byte,
+	colMap catalog.TableColMap,
+	values []tree.Datum,
+	includeEmpty bool,
+) ([]IndexEntry, error) {
 	// Use the primary key encoding for covering indexes.
 	if secondaryIndex.GetEncodingType() == catenumpb.PrimaryIndexEncoding {
-		return EncodePrimaryIndex(codec, tableDesc, secondaryIndex, colMap, values, includeEmpty)
+		return EncodePrimaryIndexWithKeyPrefix(tableDesc, secondaryIndex, keyPrefix, colMap, values,
+			includeEmpty)
 	}
 
-	secondaryKeys, containsNull, err := EncodeSecondaryIndexKey(ctx, codec, tableDesc, secondaryIndex, colMap, values)
+	secondaryKeys, containsNull, err := EncodeSecondaryIndexKeyWithKeyPrefix(ctx, tableDesc,
+		secondaryIndex, keyPrefix, colMap, values)
 	if err != nil {
 		return []IndexEntry{}, err
 	}
@@ -1593,14 +1639,18 @@ func writeColumnValues(
 }
 
 // EncodeSecondaryIndexes encodes key/values for the secondary indexes. colMap
-// maps descpb.ColumnIDs to indices in `values`. secondaryIndexEntries is the return
-// value (passed as a parameter so the caller can reuse between rows) and is
-// expected to be the same length as indexes.
+// maps descpb.ColumnIDs to indices in `values`. keyPrefixes is a slice that
+// associates indexes to their key prefix; the caller can reuse this between
+// rows to save work from creating key prefixes. the indexes and keyPrefixes
+// slice should have the same ordering. secondaryIndexEntries is the return
+// value (passed as a parameter so the caller can reuse between rows) and
+// is expected to be the same length as indexes.
 func EncodeSecondaryIndexes(
 	ctx context.Context,
 	codec keys.SQLCodec,
 	tableDesc catalog.TableDescriptor,
 	indexes []catalog.Index,
+	keyPrefixes [][]byte,
 	colMap catalog.TableColMap,
 	values []tree.Datum,
 	secondaryIndexEntries []IndexEntry,
@@ -1613,8 +1663,16 @@ func EncodeSecondaryIndexes(
 	}
 	const sizeOfIndexEntry = int64(unsafe.Sizeof(IndexEntry{}))
 
-	for i := range indexes {
-		entries, err := EncodeSecondaryIndex(ctx, codec, tableDesc, indexes[i], colMap, values, includeEmpty)
+	for i, idx := range indexes {
+		keyPrefix := keyPrefixes[i]
+		// TODO(annie): For now, we recompute the key prefix of inverted indexes. This is because index
+		// keys with multiple associated values somehow get encoded into the same kv pair when using
+		// our precomputed key prefix. `inverted_index/arrays` (logictest) illustrates this issue.
+		if idx.GetType() == idxtype.INVERTED {
+			keyPrefix = MakeIndexKeyPrefix(codec, tableDesc.GetID(), idx.GetID())
+		}
+		entries, err := EncodeSecondaryIndexWithKeyPrefix(ctx, tableDesc, idx, keyPrefix, colMap, values,
+			includeEmpty)
 		if err != nil {
 			return secondaryIndexEntries, 0, err
 		}

--- a/pkg/sql/rowexec/indexbackfiller_test.go
+++ b/pkg/sql/rowexec/indexbackfiller_test.go
@@ -7,6 +7,7 @@ package rowexec
 
 import (
 	"context"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -18,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scplan"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlerrors"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -92,6 +94,9 @@ func BenchmarkIndexBackfill(b *testing.B) {
 	stopTimer := func() {}
 	startTimer := func() {}
 
+	dir, dirCleanupFn := testutils.TempDir(b)
+	defer dirCleanupFn()
+
 	srv, sqlDB, _ := serverutils.StartServer(b, base.TestServerArgs{
 		Knobs: base.TestingKnobs{
 			SQLEvalContext: &eval.TestingKnobs{
@@ -120,6 +125,7 @@ func BenchmarkIndexBackfill(b *testing.B) {
 				},
 			},
 		},
+		StoreSpecs: []base.StoreSpec{{InMemory: false, Path: filepath.Join(dir, "testserver")}},
 	})
 	defer srv.Stopper().Stop(ctx)
 


### PR DESCRIPTION
### sql/rowexec: run BenchmarkIndexBackfill on-disk
Epic: none
Release note: None

---


### sql/rowenc: reduce index key prefix calls
This patch removes redundant calls to `MakeIndexKeyPrefix` during
the construction of `IndexEntry`s by saving each first-time call in a
map that we can later lookup. Previously, we would make this call
for each row; however, as the prefix (table id + index id) for a
particular index remains the same, we do not need to do any
recomputation.

Epic: [CRDB-42901](https://cockroachlabs.atlassian.net/browse/CRDB-42901)
Fixes: https://github.com/cockroachdb/cockroach/issues/137798

Release note: None

```
name                             old time/op    new time/op    delta
IndexBackfill/100_rows-10          21.1ms ± 2%    21.4ms ± 4%    ~     (p=0.173 n=8+10)
IndexBackfill/10,000_rows-10       38.1ms ± 3%    38.1ms ± 6%    ~     (p=0.696 n=8+10)
IndexBackfill/1,000,000_rows-10     10.9s ± 5%     10.7s ± 1%    ~     (p=0.278 n=10+9)

name                             old alloc/op   new alloc/op   delta
IndexBackfill/100_rows-10          4.52MB ± 3%    4.81MB ±20%    ~     (p=0.053 n=9+10)
IndexBackfill/10,000_rows-10       25.8MB ± 8%    24.9MB ± 3%    ~     (p=0.156 n=10+9)
IndexBackfill/1,000,000_rows-10    6.25GB ± 3%    6.21GB ± 3%    ~     (p=0.353 n=10+10)

name                             old allocs/op  new allocs/op  delta
IndexBackfill/10,000_rows-10         120k ± 2%      109k ± 2%  -9.40%  (p=0.000 n=10+10)
IndexBackfill/1,000,000_rows-10     26.9M ± 0%     25.8M ± 1%  -3.84%  (p=0.000 n=8+10)
IndexBackfill/100_rows-10           24.0k ± 1%     24.7k ± 8%    ~     (p=0.156 n=9+10)
```