### PR TITLE
codeowners: add obs-prs to pkg/sql/contention

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -79,6 +79,7 @@
 /pkg/ccl/importerccl/        @cockroachdb/sql-queries-prs
 
 /pkg/sql/appstatspb           @cockroachdb/obs-prs
+/pkg/sql/contention/          @cockroachdb/obs-prs
 /pkg/sql/execstats/           @cockroachdb/obs-prs
 /pkg/sql/scheduledlogging/    @cockroachdb/obs-prs
 /pkg/sql/sqlstats/            @cockroachdb/obs-prs


### PR DESCRIPTION
Epic: none
Release note: none