### PR TITLE
release-25.1: scripts: update bump-pebble.sh to use release-25.1

### DIFF
--- a/scripts/bump-pebble.sh
+++ b/scripts/bump-pebble.sh
@@ -11,7 +11,7 @@
 # branch name (e.g. crl-release-23.2, etc.). Also update pebble nightly scripts
 # in build/teamcity/cockroach/nightlies to use `@crl-release-xy.z` instead of
 # `@master`.
-BRANCH=master
+BRANCH=release-25.1
 PEBBLE_BRANCH=master
 
 # This script may be used to produce a branch bumping the Pebble version. The


### PR DESCRIPTION
Update the bump-pebble.sh script to work with the Cockroach repository release-25.1 branch. The corresponding Pebble branch is left as master for now, and we can update it once we cut a Pebble branch for 25.1.

Epic: none
Release note: none
Release justification: non-production code changes to a development script