### PR TITLE
roachprod: add WAL failover start flag

### DIFF
--- a/pkg/cmd/roachprod/cli/flags.go
+++ b/pkg/cmd/roachprod/cli/flags.go
@@ -248,6 +248,8 @@ func initStartCmdFlags(startCmd *cobra.Command) {
 		"store-count", startOpts.StoreCount, "number of stores to start each node with")
 	startCmd.Flags().IntVar(&startOpts.AdminUIPort,
 		"admin-ui-port", startOpts.AdminUIPort, "port to serve the admin UI on")
+	startCmd.Flags().StringVar(&startOpts.WALFailover,
+		"wal-failover", startOpts.WALFailover, "configures the use and behavior of WAL failover (see cockroach start flags for more details)")
 }
 
 func initStartInstanceCmdFlags(startInstanceCmd *cobra.Command) {


### PR DESCRIPTION
Previously, starting an older version of cockroach (e.g., 23.1) that does not support the WAL failover flag, via the roachprod CLI, would fail and there is no way to exclude the flag.

This change makes the flag configurable, and passing an empty value will cause the flag not to be included in the cockroach start flags.

Epic: None
Release note: None