### PR TITLE
explain: show correct number of mutated rows in EXPLAIN ANALYZE

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/triggers_explain
+++ b/pkg/ccl/logictestccl/testdata/logic_test/triggers_explain
@@ -122,7 +122,7 @@ quality of service: regular
 │ columns: ()
 │ sql nodes: <hidden>
 │ regions: <hidden>
-│ actual row count: 1
+│ actual row count: 0
 │ vectorized batch count: 0
 │ estimated row count: 0 (missing stats)
 │ table: xy
@@ -336,7 +336,7 @@ quality of service: regular
 │   │ columns: ()
 │   │ sql nodes: <hidden>
 │   │ regions: <hidden>
-│   │ actual row count: 1
+│   │ actual row count: 0
 │   │ vectorized batch count: 0
 │   │ estimated row count: 0 (missing stats)
 │   │ from: xy
@@ -682,7 +682,7 @@ quality of service: regular
 │   │ columns: ()
 │   │ sql nodes: <hidden>
 │   │ regions: <hidden>
-│   │ actual row count: 1
+│   │ actual row count: 0
 │   │ vectorized batch count: 0
 │   │ estimated row count: 0 (missing stats)
 │   │ table: parent

--- a/pkg/sql/colexec/columnarizer.go
+++ b/pkg/sql/colexec/columnarizer.go
@@ -211,6 +211,20 @@ func (c *Columnarizer) GetStats() *execinfrapb.ComponentStats {
 	return s
 }
 
+// IsFastPathNode returns true if the provided RowSource is the
+// planNodeToRowSource wrapper with "fast-path" enabled. The logic is injected
+// in the sql package to avoid an import cycle.
+var IsFastPathNode func(source execinfra.RowSource) bool
+
+// IsColumnarizerAroundFastPathNode returns true if the provided Operator is a
+// Columnarizer that has "fast-path" enabled planNodeToRowSource wrapper as the
+// input.
+func IsColumnarizerAroundFastPathNode(o colexecop.Operator) bool {
+	o = MaybeUnwrapInvariantsChecker(o)
+	c, ok := o.(*Columnarizer)
+	return ok && IsFastPathNode(c.input)
+}
+
 // Next is part of the colexecop.Operator interface.
 func (c *Columnarizer) Next() coldata.Batch {
 	if c.removedFromFlow {

--- a/pkg/sql/opt/exec/execbuilder/testdata/cascade
+++ b/pkg/sql/opt/exec/execbuilder/testdata/cascade
@@ -1467,7 +1467,7 @@ quality of service: regular
 ├── • delete
 │   │ sql nodes: <hidden>
 │   │ regions: <hidden>
-│   │ actual row count: 1
+│   │ actual row count: 0
 │   │ from: p138974
 │   │
 │   └── • buffer

--- a/pkg/sql/opt/exec/execbuilder/testdata/delete
+++ b/pkg/sql/opt/exec/execbuilder/testdata/delete
@@ -491,7 +491,7 @@ quality of service: regular
 • delete
 │ sql nodes: <hidden>
 │ regions: <hidden>
-│ actual row count: 1
+│ actual row count: 0
 │ from: t137352
 │ auto commit
 │
@@ -541,7 +541,7 @@ quality of service: regular
 • delete
 │ sql nodes: <hidden>
 │ regions: <hidden>
-│ actual row count: 1
+│ actual row count: 0
 │ from: t137352
 │ auto commit
 │

--- a/pkg/sql/opt/exec/execbuilder/testdata/unique
+++ b/pkg/sql/opt/exec/execbuilder/testdata/unique
@@ -619,7 +619,7 @@ quality of service: regular
 ├── • insert
 │   │ sql nodes: <hidden>
 │   │ regions: <hidden>
-│   │ actual row count: 1
+│   │ actual row count: 2
 │   │ into: uniq_fk_parent(a, b, c, rowid)
 │   │
 │   └── • buffer
@@ -737,7 +737,7 @@ quality of service: regular
 ├── • insert
 │   │ sql nodes: <hidden>
 │   │ regions: <hidden>
-│   │ actual row count: 1
+│   │ actual row count: 2
 │   │ into: uniq_fk_child(a, b, c, rowid)
 │   │
 │   └── • buffer
@@ -2621,7 +2621,7 @@ quality of service: regular
 ├── • update
 │   │ sql nodes: <hidden>
 │   │ regions: <hidden>
-│   │ actual row count: 1
+│   │ actual row count: 2
 │   │ table: uniq_fk_parent
 │   │ set: c
 │   │

--- a/pkg/sql/opt/exec/execbuilder/testdata/update
+++ b/pkg/sql/opt/exec/execbuilder/testdata/update
@@ -1012,7 +1012,7 @@ quality of service: regular
 • update
 │ sql nodes: <hidden>
 │ regions: <hidden>
-│ actual row count: 1
+│ actual row count: 0
 │ table: t137352
 │ set: b
 │ auto commit
@@ -1065,7 +1065,7 @@ quality of service: regular
 • update
 │ sql nodes: <hidden>
 │ regions: <hidden>
-│ actual row count: 1
+│ actual row count: 0
 │ table: t137352
 │ set: b
 │ auto commit
@@ -1133,7 +1133,7 @@ quality of service: regular
 • update
 │ sql nodes: <hidden>
 │ regions: <hidden>
-│ actual row count: 1
+│ actual row count: 0
 │ table: t137352
 │ set: b
 │ auto commit
@@ -1199,7 +1199,7 @@ quality of service: regular
 • update
 │ sql nodes: <hidden>
 │ regions: <hidden>
-│ actual row count: 1
+│ actual row count: 0
 │ table: t137352
 │ set: b
 │ auto commit

--- a/pkg/sql/plan_node_to_row_source.go
+++ b/pkg/sql/plan_node_to_row_source.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"sync"
 
+	"github.com/cockroachdb/cockroach/pkg/sql/colexec"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra/execopnode"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra/execreleasable"
@@ -165,6 +166,13 @@ func (p *planNodeToRowSource) Start(ctx context.Context) {
 	// This starts all of the nodes below this node.
 	if err := startExec(p.params, p.node); err != nil {
 		p.MoveToDraining(err)
+	}
+}
+
+func init() {
+	colexec.IsFastPathNode = func(rs execinfra.RowSource) bool {
+		p, ok := rs.(*planNodeToRowSource)
+		return ok && p.fastPath
 	}
 }
 


### PR DESCRIPTION
This commit fixes an oversight in how we populate the "actual row count"
in the vectorized engine for mutation statements. For context, we wrap
each vectorized operator with `batchInfoCollector` which accumulates the
number of tuples the wrapped operator has seen throughout its lifetime
which is then shown as "actual row count". For mutation statements we
have the following chain of objects involed:
`batchInfoCollector -> Columnarizer -> planNodeToRowSource -> mutation planNode`.
The `planNodeToRowSource` wrapper has a special "fast-path" logic where it
needs to produce only the number of rows modified by its input, and it
emits that row count as a single row with a single int datum.

Previously, we would treat that special single row with single datum as
having been produced by the mutation planNode and would show on EXPLAIN
ANALYZE as 1. However, we want to actually show the value from that row
instead. This commit adds some special logic to the `batchInfoCollector`
for this special case.

Fixes: #138971.

Release note (bug fix): Previously, EXPLAIN ANALYZE of mutations
statements would always get `actual row count: 1` execution statistic
for the corresponding mutation node in the plan, regardless of how many
rows were actually modified. The bug has been present since before 22.2
version and is now fixed.