### PR TITLE
logictest: separate out some queries in `read_committed`

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/read_committed
+++ b/pkg/ccl/logictestccl/testdata/logic_test/read_committed
@@ -483,10 +483,20 @@ SET SESSION CHARACTERISTICS AS TRANSACTION ISOLATION LEVEL SERIALIZABLE
 
 statement ok
 CREATE USER testuser2 WITH VIEWACTIVITY;
+
+statement ok
 DROP TABLE IF EXISTS t;
+
+statement ok
 CREATE TABLE t(a INT PRIMARY KEY);
+
+statement ok
 INSERT INTO t VALUES(1), (2);
+
+statement ok
 GRANT ALL ON t TO testuser;
+
+statement ok
 GRANT ALL ON t TO testuser2;
 
 user testuser


### PR DESCRIPTION
We just saw a txn retry failure on COMMIT in `read_committed` test on the connection that sent many stmts within a single directive, including some DDL. In an attempt to deflake the test this commit separates those out.

Fixes: #138751.

Release note: None