### PR TITLE
opt: refactor vector mutation search operator

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/mutation.go
+++ b/pkg/sql/opt/exec/execbuilder/mutation.go
@@ -102,7 +102,7 @@ func (b *Builder) buildInsert(ins *memo.InsertExpr) (_ execPlan, outputCols colO
 	// inserted (e.g. delete-only mutation columns don't need to be inserted).
 	colList := appendColsWhenPresent(
 		ins.InsertCols, ins.CheckCols, ins.PartialIndexPutCols,
-		ins.VectorIndexPutPartitionCols, ins.VectorIndexPutCentroidCols,
+		ins.VectorIndexPutPartitionCols, ins.VectorIndexPutQuantizedVecCols,
 	)
 	input, _, err := b.buildMutationInput(ins, ins.Input, colList, &ins.MutationPrivate)
 	if err != nil {
@@ -335,7 +335,7 @@ func (b *Builder) tryBuildFastPathInsert(
 
 	colList := appendColsWhenPresent(
 		ins.InsertCols, ins.CheckCols, ins.PartialIndexPutCols,
-		ins.VectorIndexDelPartitionCols, ins.VectorIndexPutCentroidCols,
+		ins.VectorIndexDelPartitionCols, ins.VectorIndexPutQuantizedVecCols,
 	)
 	rows, err := b.buildValuesRows(values)
 	if err != nil {
@@ -415,7 +415,7 @@ func (b *Builder) buildUpdate(upd *memo.UpdateExpr) (_ execPlan, outputCols colO
 	colList := appendColsWhenPresent(
 		upd.FetchCols, upd.UpdateCols, neededPassThroughCols, upd.CheckCols,
 		upd.PartialIndexPutCols, upd.PartialIndexDelCols,
-		upd.VectorIndexPutPartitionCols, upd.VectorIndexPutCentroidCols,
+		upd.VectorIndexPutPartitionCols, upd.VectorIndexPutQuantizedVecCols,
 		upd.VectorIndexDelPartitionCols,
 	)
 
@@ -489,7 +489,7 @@ func (b *Builder) buildUpsert(ups *memo.UpsertExpr) (_ execPlan, outputCols colO
 	colList := appendColsWhenPresent(
 		ups.InsertCols, ups.FetchCols, ups.UpdateCols, opt.OptionalColList{ups.CanaryCol},
 		ups.CheckCols, ups.PartialIndexPutCols, ups.PartialIndexDelCols,
-		ups.VectorIndexPutPartitionCols, ups.VectorIndexPutCentroidCols,
+		ups.VectorIndexPutPartitionCols, ups.VectorIndexPutQuantizedVecCols,
 		ups.VectorIndexDelPartitionCols,
 	)
 

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -268,7 +268,7 @@ func (b *Builder) buildRelational(e memo.RelExpr) (_ execPlan, outputCols colOrd
 	case *memo.LockExpr:
 		ep, outputCols, err = b.buildLock(t)
 
-	case *memo.VectorSearchExpr, *memo.VectorPartitionSearchExpr:
+	case *memo.VectorSearchExpr, *memo.VectorMutationSearchExpr:
 		err = unimplemented.New("vector index search",
 			"execution planning for vector index search is not yet implemented")
 

--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -275,7 +275,7 @@ func (f *ExprFmtCtx) formatRelational(e RelExpr, tp treeprinter.Node) {
 
 	case *ScanExpr, *PlaceholderScanExpr, *IndexJoinExpr, *ShowTraceForSessionExpr,
 		*InsertExpr, *UpdateExpr, *UpsertExpr, *DeleteExpr, *LockExpr, *SequenceSelectExpr,
-		*WindowExpr, *VectorSearchExpr, *VectorPartitionSearchExpr, *OpaqueRelExpr,
+		*WindowExpr, *VectorSearchExpr, *VectorMutationSearchExpr, *OpaqueRelExpr,
 		*OpaqueMutationExpr, *OpaqueDDLExpr, *AlterTableSplitExpr, *AlterTableUnsplitExpr,
 		*AlterTableUnsplitAllExpr, *AlterTableRelocateExpr, *AlterRangeRelocateExpr,
 		*ControlJobsExpr, *CancelQueriesExpr, *CancelSessionsExpr, *CreateViewExpr,
@@ -761,7 +761,7 @@ func (f *ExprFmtCtx) formatRelational(e RelExpr, tp treeprinter.Node) {
 		}
 		tp.Childf("target nearest neighbors: %d", t.TargetNeighborCount)
 
-	case *VectorPartitionSearchExpr:
+	case *VectorMutationSearchExpr:
 		if len(t.PrefixKeyCols) > 0 {
 			tp.Childf("prefix key columns: %v", t.PrefixKeyCols)
 		}
@@ -1926,7 +1926,7 @@ func FormatPrivate(f *ExprFmtCtx, private interface{}, physProps *physical.Requi
 	case *VectorSearchPrivate:
 		f.formatIndex(t.Table, t.Index, false /* reverse */)
 
-	case *VectorPartitionSearchPrivate:
+	case *VectorMutationSearchPrivate:
 		f.formatIndex(t.Table, t.Index, false /* reverse */)
 
 	case *props.OrderingChoice:

--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -651,7 +651,7 @@ func (f *ExprFmtCtx) formatRelational(e RelExpr, tp treeprinter.Node) {
 			f.formatOptionalColList(e, tp, "check columns:", t.CheckCols)
 			f.formatOptionalColList(e, tp, "partial index put columns:", t.PartialIndexPutCols)
 			f.formatOptionalColList(e, tp, "vector index put partition columns:", t.VectorIndexPutPartitionCols)
-			f.formatOptionalColList(e, tp, "vector index put centroid columns:", t.VectorIndexPutCentroidCols)
+			f.formatOptionalColList(e, tp, "vector index put quantized vector columns:", t.VectorIndexPutQuantizedVecCols)
 			f.formatBeforeTriggers(tp, t.Table, tree.TriggerEventInsert)
 			f.formatMutationCommon(tp, &t.MutationPrivate)
 		}
@@ -671,7 +671,7 @@ func (f *ExprFmtCtx) formatRelational(e RelExpr, tp treeprinter.Node) {
 			f.formatOptionalColList(e, tp, "partial index del columns:", t.PartialIndexDelCols)
 			f.formatOptionalColList(e, tp, "vector index del partition columns:", t.VectorIndexDelPartitionCols)
 			f.formatOptionalColList(e, tp, "vector index put partition columns:", t.VectorIndexPutPartitionCols)
-			f.formatOptionalColList(e, tp, "vector index put centroid columns:", t.VectorIndexPutCentroidCols)
+			f.formatOptionalColList(e, tp, "vector index put quantized vector columns:", t.VectorIndexPutQuantizedVecCols)
 			f.formatBeforeTriggers(tp, t.Table, tree.TriggerEventUpdate)
 			f.formatMutationCommon(tp, &t.MutationPrivate)
 		}
@@ -698,7 +698,7 @@ func (f *ExprFmtCtx) formatRelational(e RelExpr, tp treeprinter.Node) {
 			f.formatOptionalColList(e, tp, "partial index del columns:", t.PartialIndexDelCols)
 			f.formatOptionalColList(e, tp, "vector index del partition columns:", t.VectorIndexDelPartitionCols)
 			f.formatOptionalColList(e, tp, "vector index put partition columns:", t.VectorIndexPutPartitionCols)
-			f.formatOptionalColList(e, tp, "vector index put centroid columns:", t.VectorIndexPutCentroidCols)
+			f.formatOptionalColList(e, tp, "vector index put quantized vector columns:", t.VectorIndexPutQuantizedVecCols)
 			f.formatBeforeTriggers(tp, t.Table, tree.TriggerEventInsert, tree.TriggerEventUpdate)
 			f.formatMutationCommon(tp, &t.MutationPrivate)
 		}
@@ -770,8 +770,8 @@ func (f *ExprFmtCtx) formatRelational(e RelExpr, tp treeprinter.Node) {
 			tp.Childf("primary key columns: %v", t.PrimaryKeyCols)
 		}
 		tp.Childf("partition col: %s", f.ColumnString(t.PartitionCol))
-		if t.CentroidCol != 0 {
-			tp.Childf("centroid col: %s", f.ColumnString(t.CentroidCol))
+		if t.QuantizedVectorCol != 0 {
+			tp.Childf("quantized vector col: %s", f.ColumnString(t.QuantizedVectorCol))
 		}
 
 	case *CreateTableExpr:

--- a/pkg/sql/opt/memo/logical_props_builder.go
+++ b/pkg/sql/opt/memo/logical_props_builder.go
@@ -1651,15 +1651,15 @@ func (b *logicalPropsBuilder) buildVectorSearchProps(
 	}
 }
 
-func (b *logicalPropsBuilder) buildVectorPartitionSearchProps(
-	search *VectorPartitionSearchExpr, rel *props.Relational,
+func (b *logicalPropsBuilder) buildVectorMutationSearchProps(
+	search *VectorMutationSearchExpr, rel *props.Relational,
 ) {
 	BuildSharedProps(search, &rel.Shared, b.evalCtx)
 	inputProps := search.Input.Relational()
 
 	// Output Columns
 	// --------------
-	// VectorPartitionSearch passes through all input columns. It also produces
+	// VectorMutationSearch passes through all input columns. It also produces
 	// the partition column, and optionally, the centroid column.
 	rel.OutputCols = inputProps.OutputCols.Copy()
 	rel.OutputCols.Add(search.PartitionCol)
@@ -1691,7 +1691,7 @@ func (b *logicalPropsBuilder) buildVectorPartitionSearchProps(
 	// Statistics
 	// ----------
 	if !b.disableStats {
-		b.sb.buildVectorPartitionSearch(search, rel)
+		b.sb.buildVectorMutationSearch(search, rel)
 	}
 }
 

--- a/pkg/sql/opt/memo/logical_props_builder.go
+++ b/pkg/sql/opt/memo/logical_props_builder.go
@@ -1660,11 +1660,11 @@ func (b *logicalPropsBuilder) buildVectorMutationSearchProps(
 	// Output Columns
 	// --------------
 	// VectorMutationSearch passes through all input columns. It also produces
-	// the partition column, and optionally, the centroid column.
+	// the partition column, and optionally, the quantized vector column.
 	rel.OutputCols = inputProps.OutputCols.Copy()
 	rel.OutputCols.Add(search.PartitionCol)
-	if search.CentroidCol != 0 {
-		rel.OutputCols.Add(search.CentroidCol)
+	if search.QuantizedVectorCol != 0 {
+		rel.OutputCols.Add(search.QuantizedVectorCol)
 	}
 
 	// Not Null Columns

--- a/pkg/sql/opt/memo/statistics_builder.go
+++ b/pkg/sql/opt/memo/statistics_builder.go
@@ -501,8 +501,8 @@ func (sb *statisticsBuilder) colStat(colSet opt.ColSet, e RelExpr) *props.Column
 	case opt.VectorSearchOp:
 		return sb.colStatVectorSearch(colSet, e.(*VectorSearchExpr))
 
-	case opt.VectorPartitionSearchOp:
-		return sb.colStatVectorPartitionSearch(colSet, e.(*VectorPartitionSearchExpr))
+	case opt.VectorMutationSearchOp:
+		return sb.colStatVectorMutationSearch(colSet, e.(*VectorMutationSearchExpr))
 
 	case opt.BarrierOp:
 		return sb.colStatBarrier(colSet, e.(*BarrierExpr))
@@ -2905,11 +2905,11 @@ func (sb *statisticsBuilder) colStatVectorSearch(
 }
 
 // +-----------------------+
-// | VectorPartitionSearch |
+// | VectorMutationSearch |
 // +-----------------------+
 
-func (sb *statisticsBuilder) buildVectorPartitionSearch(
-	search *VectorPartitionSearchExpr, relProps *props.Relational,
+func (sb *statisticsBuilder) buildVectorMutationSearch(
+	search *VectorMutationSearchExpr, relProps *props.Relational,
 ) {
 	s := relProps.Statistics()
 	if zeroCardinality := s.Init(relProps, sb.minRowCount); zeroCardinality {
@@ -2920,14 +2920,14 @@ func (sb *statisticsBuilder) buildVectorPartitionSearch(
 
 	inputStats := search.Input.Relational().Statistics()
 
-	// VectorPartitionSearch operators do not change the cardinality of the input.
+	// VectorMutationSearch operators do not change the cardinality of the input.
 	s.RowCount = inputStats.RowCount
 	s.VirtualCols.UnionWith(inputStats.VirtualCols)
 	sb.finalizeFromCardinality(relProps)
 }
 
-func (sb *statisticsBuilder) colStatVectorPartitionSearch(
-	colSet opt.ColSet, search *VectorPartitionSearchExpr,
+func (sb *statisticsBuilder) colStatVectorMutationSearch(
+	colSet opt.ColSet, search *VectorMutationSearchExpr,
 ) *props.ColumnStatistic {
 	s := search.Relational().Statistics()
 

--- a/pkg/sql/opt/memo/testdata/stats/vector-search
+++ b/pkg/sql/opt/memo/testdata/stats/vector-search
@@ -16,15 +16,15 @@ insert t
  │    ├── column1:5 => x:1
  │    └── v_cast:7 => v:2
  ├── vector index put partition columns: vector_index_put_partition1:8(int)
- ├── vector index put centroid columns: vector_index_put_centroid1:9(vector)
+ ├── vector index put quantized vector columns: vector_index_put_quantized_vec1:9(bytes)
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  ├── stats: [rows=0]
  └── vector-mutation-search t@t_v_idx,vector
-      ├── columns: column1:5(int!null) v_cast:7(vector!null) vector_index_put_partition1:8(int) vector_index_put_centroid1:9(vector)
+      ├── columns: column1:5(int!null) v_cast:7(vector!null) vector_index_put_partition1:8(int) vector_index_put_quantized_vec1:9(bytes)
       ├── query vector column: v_cast:7
       ├── partition col: vector_index_put_partition1:8
-      ├── centroid col: vector_index_put_centroid1:9
+      ├── quantized vector col: vector_index_put_quantized_vec1:9
       ├── cardinality: [1 - 1]
       ├── immutable
       ├── stats: [rows=1]
@@ -57,15 +57,15 @@ insert t
  │    ├── column1:5 => x:1
  │    └── v_cast:7 => v:2
  ├── vector index put partition columns: vector_index_put_partition1:8(int)
- ├── vector index put centroid columns: vector_index_put_centroid1:9(vector)
+ ├── vector index put quantized vector columns: vector_index_put_quantized_vec1:9(bytes)
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  ├── stats: [rows=0]
  └── vector-mutation-search t@t_v_idx,vector
-      ├── columns: column1:5(int!null) v_cast:7(vector!null) vector_index_put_partition1:8(int) vector_index_put_centroid1:9(vector)
+      ├── columns: column1:5(int!null) v_cast:7(vector!null) vector_index_put_partition1:8(int) vector_index_put_quantized_vec1:9(bytes)
       ├── query vector column: v_cast:7
       ├── partition col: vector_index_put_partition1:8
-      ├── centroid col: vector_index_put_centroid1:9
+      ├── quantized vector col: vector_index_put_quantized_vec1:9
       ├── cardinality: [3 - 3]
       ├── immutable
       ├── stats: [rows=3]

--- a/pkg/sql/opt/memo/testdata/stats/vector-search
+++ b/pkg/sql/opt/memo/testdata/stats/vector-search
@@ -6,7 +6,7 @@ exec-ddl
 CREATE VECTOR INDEX ON t (v);
 ----
 
-# VectorPartitionSearch produces one output row for each input row.
+# VectorMutationSearch produces one output row for each input row.
 build
 INSERT INTO t VALUES (1, '[1, 2, 3]');
 ----
@@ -20,7 +20,7 @@ insert t
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  ├── stats: [rows=0]
- └── vector-partition-search t@t_v_idx,vector
+ └── vector-mutation-search t@t_v_idx,vector
       ├── columns: column1:5(int!null) v_cast:7(vector!null) vector_index_put_partition1:8(int) vector_index_put_centroid1:9(vector)
       ├── query vector column: v_cast:7
       ├── partition col: vector_index_put_partition1:8
@@ -61,7 +61,7 @@ insert t
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  ├── stats: [rows=0]
- └── vector-partition-search t@t_v_idx,vector
+ └── vector-mutation-search t@t_v_idx,vector
       ├── columns: column1:5(int!null) v_cast:7(vector!null) vector_index_put_partition1:8(int) vector_index_put_centroid1:9(vector)
       ├── query vector column: v_cast:7
       ├── partition col: vector_index_put_partition1:8

--- a/pkg/sql/opt/norm/prune_cols_funcs.go
+++ b/pkg/sql/opt/norm/prune_cols_funcs.go
@@ -69,7 +69,7 @@ func (c *CustomFuncs) neededMutationCols(
 		addCols(private.PartialIndexDelCols)
 	}
 	addCols(private.VectorIndexPutPartitionCols)
-	addCols(private.VectorIndexPutCentroidCols)
+	addCols(private.VectorIndexPutQuantizedVecCols)
 	addCols(private.VectorIndexDelPartitionCols)
 	addCols(private.ReturnCols)
 	addCols(opt.OptionalColList(private.PassthroughCols))

--- a/pkg/sql/opt/ops/mutation.opt
+++ b/pkg/sql/opt/ops/mutation.opt
@@ -146,11 +146,11 @@ define MutationPrivate {
     # indexes on the table.
     VectorIndexPutPartitionCols OptionalColList
 
-    # VectorIndexPutCentroidCols are columns from the Input expression
-    # containing the centroids of the partitions that the inserted or updated
-    # rows should be added to. The length is always equal to the number of
-    # vector indexes on the table.
-    VectorIndexPutCentroidCols OptionalColList
+    # VectorIndexPutQuantizedVecCols are columns from the Input expression
+    # containing the quantized and encoded vectors that should be inserted into
+    # the index. The length is always equal to the number of vector indexes on
+    # the table.
+    VectorIndexPutQuantizedVecCols OptionalColList
 
     # CanaryCol is used only with the Upsert operator. It identifies the column
     # that the execution engine uses to decide whether to insert or to update.

--- a/pkg/sql/opt/ops/relational.opt
+++ b/pkg/sql/opt/ops/relational.opt
@@ -1466,20 +1466,20 @@ define VectorSearchPrivate {
     TargetNeighborCount int64
 }
 
-# VectorPartitionSearch is used to determine the vector-index partition that
+# VectorMutationSearch is used to determine the vector-index partition that
 # contains (or should contain) each vector from the input. It is used in the
 # input of mutation operators. It always produces exactly one row for each
 # input row, containing the partition key and optionally the centroid of the
 # partition. If the input query vector is NULL, no vector search is performed,
 # and the projected output columns are NULL.
 [Relational]
-define VectorPartitionSearch {
+define VectorMutationSearch {
     Input RelExpr
-    _ VectorPartitionSearchPrivate
+    _ VectorMutationSearchPrivate
 }
 
 [Private]
-define VectorPartitionSearchPrivate {
+define VectorMutationSearchPrivate {
     # Table identifies the table to perform the search in.
     Table TableID
 

--- a/pkg/sql/opt/ops/relational.opt
+++ b/pkg/sql/opt/ops/relational.opt
@@ -1467,11 +1467,18 @@ define VectorSearchPrivate {
 }
 
 # VectorMutationSearch is used to determine the vector-index partition that
-# contains (or should contain) each vector from the input. It is used in the
-# input of mutation operators. It always produces exactly one row for each
-# input row, containing the partition key and optionally the centroid of the
-# partition. If the input query vector is NULL, no vector search is performed,
-# and the projected output columns are NULL.
+# contains (or should contain) each vector from the input. It can also produce
+# the quantized and encoded vector for insertion into the index.
+#
+# VectorMutationSearch is used in the input of mutation operators. It always
+# produces exactly one output row for each input row, containing the partition
+# key and optionally (for INSERT/UPSERT/UPDATE) the quantized and encoded
+# vector. If the input query vector is NULL, no vector search is performed, and
+# the projected output columns are NULL.
+#
+# For DELETE operations, the primary key columns are used to constrain the
+# search to a specific row. In rare cases it is possible not to find the
+# requested row, in which case the output partition key will be NULL.
 [Relational]
 define VectorMutationSearch {
     Input RelExpr
@@ -1493,8 +1500,8 @@ define VectorMutationSearchPrivate {
     PrefixKeyCols ColList
 
     # QueryVectorCol is the input column that contains the query vectors.
-    # When the query vector is NULL, the partition and centroid output columns
-    # will be NULL.
+    # When the query vector is NULL, the partition and quantized vector output
+    # columns will be NULL.
     QueryVectorCol ColumnID
 
     # PrimaryKeyCols is the optional set of input columns used to constrain
@@ -1507,10 +1514,10 @@ define VectorMutationSearchPrivate {
     # vector. It is always set.
     PartitionCol ColumnID
 
-    # CentroidCol is the output column that contains the centroid of the
-    # partition. It is only set for inserts into the index (including those
-    # performed for a SQL UPDATE or UPSERT).
-    CentroidCol ColumnID
+    # QuantizedVectorCol is the output column that contains the quantized and
+    # encoded form of the vector, which will be inserted as a value into the
+    # index. It is only set for inserts into the index.
+    QuantizedVectorCol ColumnID
 }
 
 # Barrier is a relational operator that simply passes through its input columns

--- a/pkg/sql/opt/optbuilder/mutation_builder.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder.go
@@ -1053,19 +1053,19 @@ func (mb *mutationBuilder) projectPartialIndexColsImpl(putScope, delScope *scope
 	}
 }
 
-// projectVectorIndexCols builds VectorPartitionSearch operators for the input
+// projectVectorIndexCols builds VectorMutationSearch operators for the input
 // of a non-DELETE mutation. See projectVectorIndexColsImpl for details.
 func (mb *mutationBuilder) projectVectorIndexCols() {
 	mb.projectVectorIndexColsImpl(false /* delete */)
 }
 
-// projectVectorIndexCols builds VectorPartitionSearch operators for the input
+// projectVectorIndexCols builds VectorMutationSearch operators for the input
 // of a DELETE mutation. See projectVectorIndexColsImpl for details.
 func (mb *mutationBuilder) projectVectorIndexColsForDelete() {
 	mb.projectVectorIndexColsImpl(true /* delete */)
 }
 
-// projectVectorIndexColsImpl builds VectorPartitionSearch operators that
+// projectVectorIndexColsImpl builds VectorMutationSearch operators that
 // project partitions to be the target of index insertions and deletions for
 // each vector index defined on the target table. This is needed because vector
 // indexes must perform a search to determine which partition a given vector
@@ -1129,7 +1129,7 @@ func (mb *mutationBuilder) projectVectorIndexColsImpl(delete bool) {
 				partitionCol := addCol(fmt.Sprintf("vector_index_del_partition%d", idxOrd+1), types.Int)
 				outCols := mb.outScope.colSet()
 				outCols.Add(partitionCol)
-				mb.outScope.expr = mb.buildVectorPartitionSearch(
+				mb.outScope.expr = mb.buildVectorMutationSearch(
 					mb.outScope.expr, index, delCol, partitionCol, 0 /* centroidCol */, getPKCols(),
 				)
 				mb.vectorIndexDelPartitionColIDs[idxOrd] = partitionCol
@@ -1140,7 +1140,7 @@ func (mb *mutationBuilder) projectVectorIndexColsImpl(delete bool) {
 				outCols := mb.outScope.colSet()
 				outCols.Add(partitionCol)
 				outCols.Add(centroidCol)
-				mb.outScope.expr = mb.buildVectorPartitionSearch(
+				mb.outScope.expr = mb.buildVectorMutationSearch(
 					mb.outScope.expr, index, putCol, partitionCol, centroidCol, opt.ColSet{}, /* pkCols */
 				)
 				mb.vectorIndexPutPartitionColIDs[idxOrd] = partitionCol
@@ -1151,19 +1151,19 @@ func (mb *mutationBuilder) projectVectorIndexColsImpl(delete bool) {
 	}
 }
 
-// buildVectorPartitionSearch builds a VectorPartitionSearch operator that will
+// buildVectorMutationSearch builds a VectorMutationSearch operator that will
 // find the partition (and centroid, if requested) for vectors in the given
 // queryVectorCol.
 //
 // pkCols should only be set for an index del operation. It is used to locate
 // the partition for a specific row in the table.
-func (mb *mutationBuilder) buildVectorPartitionSearch(
+func (mb *mutationBuilder) buildVectorMutationSearch(
 	input memo.RelExpr,
 	index cat.Index,
 	queryVectorCol, partitionCol, centroidCol opt.ColumnID,
 	pkCols opt.ColSet,
 ) memo.RelExpr {
-	private := memo.VectorPartitionSearchPrivate{
+	private := memo.VectorMutationSearchPrivate{
 		Table:          mb.tabID,
 		Index:          index.Ordinal(),
 		QueryVectorCol: queryVectorCol,
@@ -1171,7 +1171,7 @@ func (mb *mutationBuilder) buildVectorPartitionSearch(
 		PartitionCol:   partitionCol,
 		CentroidCol:    centroidCol,
 	}
-	return mb.b.factory.ConstructVectorPartitionSearch(input, &private)
+	return mb.b.factory.ConstructVectorMutationSearch(input, &private)
 }
 
 // computedColumnScope returns a new scope that can be used to build computed

--- a/pkg/sql/opt/optbuilder/mutation_builder.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder.go
@@ -149,11 +149,11 @@ type mutationBuilder struct {
 	// The length is always equal to the number of vector indexes on the table.
 	vectorIndexPutPartitionColIDs opt.OptionalColList
 
-	// vectorIndexPutCentroidColIDs lists the input column IDs storing the
-	// centroids for the partitions that the inserted or updated rows should be
-	// added to. Note that centroids are not needed for deletions. The length is
+	// vectorIndexPutQuantizedVecColIDs lists the input column IDs storing the
+	// quantized and encoded vectors that should be inserted into the index. Note
+	// that the quantized vectors are not needed for deletions. The length is
 	// always equal to the number of vector indexes on the table.
-	vectorIndexPutCentroidColIDs opt.OptionalColList
+	vectorIndexPutQuantizedVecColIDs opt.OptionalColList
 
 	// triggerColIDs is the set of column IDs used to project the OLD and NEW rows
 	// for row-level AFTER triggers, and possibly also contains the canary column.
@@ -280,7 +280,7 @@ func (mb *mutationBuilder) init(b *Builder, opName string, tab cat.Table, alias 
 	mb.partialIndexPutColIDs = getSlice(numPartialIndexes)
 	mb.partialIndexDelColIDs = getSlice(numPartialIndexes)
 	mb.vectorIndexPutPartitionColIDs = getSlice(numVectorIndexes)
-	mb.vectorIndexPutCentroidColIDs = getSlice(numVectorIndexes)
+	mb.vectorIndexPutQuantizedVecColIDs = getSlice(numVectorIndexes)
 	mb.vectorIndexDelPartitionColIDs = getSlice(numVectorIndexes)
 
 	// Add the table and its columns (including mutation columns) to metadata.
@@ -1071,7 +1071,7 @@ func (mb *mutationBuilder) projectVectorIndexColsForDelete() {
 // indexes must perform a search to determine which partition a given vector
 // belongs to.
 //
-// See the vectorIndexPutPartitionColIDs, vectorIndexPutCentroidColIDs, and
+// See the vectorIndexPutPartitionColIDs, vectorIndexPutQuantizedVecColIDs, and
 // vectorIndexDelPartitionColIDs fields for more information.
 func (mb *mutationBuilder) projectVectorIndexColsImpl(delete bool) {
 	if vectorIndexCount(mb.tab) > 0 {
@@ -1124,27 +1124,26 @@ func (mb *mutationBuilder) projectVectorIndexColsImpl(delete bool) {
 				continue
 			}
 			vectorColOrd := index.VectorColumn().Ordinal()
-			vectorColTyp := index.VectorColumn().DatumType()
 			if delCol := getDelCol(vectorColOrd); delCol != 0 {
 				partitionCol := addCol(fmt.Sprintf("vector_index_del_partition%d", idxOrd+1), types.Int)
 				outCols := mb.outScope.colSet()
 				outCols.Add(partitionCol)
 				mb.outScope.expr = mb.buildVectorMutationSearch(
-					mb.outScope.expr, index, delCol, partitionCol, 0 /* centroidCol */, getPKCols(),
+					mb.outScope.expr, index, delCol, partitionCol, 0 /* encVectorCol */, getPKCols(),
 				)
 				mb.vectorIndexDelPartitionColIDs[idxOrd] = partitionCol
 			}
 			if putCol := getPutCol(vectorColOrd); putCol != 0 {
 				partitionCol := addCol(fmt.Sprintf("vector_index_put_partition%d", idxOrd+1), types.Int)
-				centroidCol := addCol(fmt.Sprintf("vector_index_put_centroid%d", idxOrd+1), vectorColTyp)
+				quantizedVecCol := addCol(fmt.Sprintf("vector_index_put_quantized_vec%d", idxOrd+1), types.Bytes)
 				outCols := mb.outScope.colSet()
 				outCols.Add(partitionCol)
-				outCols.Add(centroidCol)
+				outCols.Add(quantizedVecCol)
 				mb.outScope.expr = mb.buildVectorMutationSearch(
-					mb.outScope.expr, index, putCol, partitionCol, centroidCol, opt.ColSet{}, /* pkCols */
+					mb.outScope.expr, index, putCol, partitionCol, quantizedVecCol, opt.ColSet{}, /* pkCols */
 				)
 				mb.vectorIndexPutPartitionColIDs[idxOrd] = partitionCol
-				mb.vectorIndexPutCentroidColIDs[idxOrd] = centroidCol
+				mb.vectorIndexPutQuantizedVecColIDs[idxOrd] = quantizedVecCol
 			}
 			idxOrd++
 		}
@@ -1152,24 +1151,24 @@ func (mb *mutationBuilder) projectVectorIndexColsImpl(delete bool) {
 }
 
 // buildVectorMutationSearch builds a VectorMutationSearch operator that will
-// find the partition (and centroid, if requested) for vectors in the given
-// queryVectorCol.
+// find the partition (and quantized vector, if requested) for vectors in the
+// given queryVectorCol.
 //
 // pkCols should only be set for an index del operation. It is used to locate
 // the partition for a specific row in the table.
 func (mb *mutationBuilder) buildVectorMutationSearch(
 	input memo.RelExpr,
 	index cat.Index,
-	queryVectorCol, partitionCol, centroidCol opt.ColumnID,
+	queryVectorCol, partitionCol, quantizedVecCol opt.ColumnID,
 	pkCols opt.ColSet,
 ) memo.RelExpr {
 	private := memo.VectorMutationSearchPrivate{
-		Table:          mb.tabID,
-		Index:          index.Ordinal(),
-		QueryVectorCol: queryVectorCol,
-		PrimaryKeyCols: pkCols,
-		PartitionCol:   partitionCol,
-		CentroidCol:    centroidCol,
+		Table:              mb.tabID,
+		Index:              index.Ordinal(),
+		QueryVectorCol:     queryVectorCol,
+		PrimaryKeyCols:     pkCols,
+		PartitionCol:       partitionCol,
+		QuantizedVectorCol: quantizedVecCol,
 	}
 	return mb.b.factory.ConstructVectorMutationSearch(input, &private)
 }
@@ -1241,23 +1240,23 @@ func (mb *mutationBuilder) makeMutationPrivate(needResults bool) *memo.MutationP
 	}
 
 	private := &memo.MutationPrivate{
-		Table:                       mb.tabID,
-		InsertCols:                  checkEmptyList(mb.insertColIDs),
-		FetchCols:                   checkEmptyList(mb.fetchColIDs),
-		UpdateCols:                  checkEmptyList(mb.updateColIDs),
-		CanaryCol:                   mb.canaryColID,
-		ArbiterIndexes:              mb.arbiters.IndexOrdinals(),
-		ArbiterConstraints:          mb.arbiters.UniqueConstraintOrdinals(),
-		CheckCols:                   checkEmptyList(mb.checkColIDs),
-		PartialIndexPutCols:         checkEmptyList(mb.partialIndexPutColIDs),
-		PartialIndexDelCols:         checkEmptyList(mb.partialIndexDelColIDs),
-		VectorIndexPutPartitionCols: checkEmptyList(mb.vectorIndexPutPartitionColIDs),
-		VectorIndexPutCentroidCols:  checkEmptyList(mb.vectorIndexPutCentroidColIDs),
-		VectorIndexDelPartitionCols: checkEmptyList(mb.vectorIndexDelPartitionColIDs),
-		TriggerCols:                 mb.triggerColIDs,
-		FKCascades:                  mb.cascades,
-		AfterTriggers:               mb.afterTriggers,
-		UniqueWithTombstoneIndexes:  mb.uniqueWithTombstoneIndexes.Ordered(),
+		Table:                          mb.tabID,
+		InsertCols:                     checkEmptyList(mb.insertColIDs),
+		FetchCols:                      checkEmptyList(mb.fetchColIDs),
+		UpdateCols:                     checkEmptyList(mb.updateColIDs),
+		CanaryCol:                      mb.canaryColID,
+		ArbiterIndexes:                 mb.arbiters.IndexOrdinals(),
+		ArbiterConstraints:             mb.arbiters.UniqueConstraintOrdinals(),
+		CheckCols:                      checkEmptyList(mb.checkColIDs),
+		PartialIndexPutCols:            checkEmptyList(mb.partialIndexPutColIDs),
+		PartialIndexDelCols:            checkEmptyList(mb.partialIndexDelColIDs),
+		VectorIndexPutPartitionCols:    checkEmptyList(mb.vectorIndexPutPartitionColIDs),
+		VectorIndexPutQuantizedVecCols: checkEmptyList(mb.vectorIndexPutQuantizedVecColIDs),
+		VectorIndexDelPartitionCols:    checkEmptyList(mb.vectorIndexDelPartitionColIDs),
+		TriggerCols:                    mb.triggerColIDs,
+		FKCascades:                     mb.cascades,
+		AfterTriggers:                  mb.afterTriggers,
+		UniqueWithTombstoneIndexes:     mb.uniqueWithTombstoneIndexes.Ordered(),
 	}
 
 	// If we didn't actually plan any checks, cascades, or triggers, don't buffer

--- a/pkg/sql/opt/optbuilder/testdata/vector_mutation
+++ b/pkg/sql/opt/optbuilder/testdata/vector_mutation
@@ -16,12 +16,12 @@ insert t
  │    ├── v_cast:8 => v:2
  │    └── w_default:9 => w:3
  ├── vector index put partition columns: vector_index_put_partition1:10
- ├── vector index put centroid columns: vector_index_put_centroid1:11
+ ├── vector index put quantized vector columns: vector_index_put_quantized_vec1:11
  └── vector-mutation-search t@t_v_idx,vector
-      ├── columns: column1:6!null v_cast:8!null w_default:9 vector_index_put_partition1:10 vector_index_put_centroid1:11
+      ├── columns: column1:6!null v_cast:8!null w_default:9 vector_index_put_partition1:10 vector_index_put_quantized_vec1:11
       ├── query vector column: v_cast:8
       ├── partition col: vector_index_put_partition1:10
-      ├── centroid col: vector_index_put_centroid1:11
+      ├── quantized vector col: vector_index_put_quantized_vec1:11
       └── project
            ├── columns: w_default:9 column1:6!null v_cast:8!null
            ├── project
@@ -46,12 +46,12 @@ update t
  │    └── v_cast:12 => v:2
  ├── vector index del partition columns: vector_index_del_partition1:13
  ├── vector index put partition columns: vector_index_put_partition1:14
- ├── vector index put centroid columns: vector_index_put_centroid1:15
+ ├── vector index put quantized vector columns: vector_index_put_quantized_vec1:15
  └── vector-mutation-search t@t_v_idx,vector
-      ├── columns: x:6!null v:7 w:8 crdb_internal_mvcc_timestamp:9 tableoid:10 v_cast:12!null vector_index_del_partition1:13 vector_index_put_partition1:14 vector_index_put_centroid1:15
+      ├── columns: x:6!null v:7 w:8 crdb_internal_mvcc_timestamp:9 tableoid:10 v_cast:12!null vector_index_del_partition1:13 vector_index_put_partition1:14 vector_index_put_quantized_vec1:15
       ├── query vector column: v_cast:12
       ├── partition col: vector_index_put_partition1:14
-      ├── centroid col: vector_index_put_centroid1:15
+      ├── quantized vector col: vector_index_put_quantized_vec1:15
       └── vector-mutation-search t@t_v_idx,vector
            ├── columns: x:6!null v:7 w:8 crdb_internal_mvcc_timestamp:9 tableoid:10 v_cast:12!null vector_index_del_partition1:13
            ├── query vector column: v:7
@@ -111,12 +111,12 @@ upsert t
  │    └── w_default:9 => w:3
  ├── vector index del partition columns: vector_index_del_partition1:16
  ├── vector index put partition columns: vector_index_put_partition1:17
- ├── vector index put centroid columns: vector_index_put_centroid1:18
+ ├── vector index put quantized vector columns: vector_index_put_quantized_vec1:18
  └── vector-mutation-search t@t_v_idx,vector
-      ├── columns: column1:6!null v_cast:8!null w_default:9 x:10 v:11 w:12 crdb_internal_mvcc_timestamp:13 tableoid:14 upsert_x:15 vector_index_del_partition1:16 vector_index_put_partition1:17 vector_index_put_centroid1:18
+      ├── columns: column1:6!null v_cast:8!null w_default:9 x:10 v:11 w:12 crdb_internal_mvcc_timestamp:13 tableoid:14 upsert_x:15 vector_index_del_partition1:16 vector_index_put_partition1:17 vector_index_put_quantized_vec1:18
       ├── query vector column: v_cast:8
       ├── partition col: vector_index_put_partition1:17
-      ├── centroid col: vector_index_put_centroid1:18
+      ├── quantized vector col: vector_index_put_quantized_vec1:18
       └── vector-mutation-search t@t_v_idx,vector
            ├── columns: column1:6!null v_cast:8!null w_default:9 x:10 v:11 w:12 crdb_internal_mvcc_timestamp:13 tableoid:14 upsert_x:15 vector_index_del_partition1:16
            ├── query vector column: v:11
@@ -172,12 +172,12 @@ upsert t
  │    └── upsert_v:18 => v:2
  ├── vector index del partition columns: vector_index_del_partition1:20
  ├── vector index put partition columns: vector_index_put_partition1:21
- ├── vector index put centroid columns: vector_index_put_centroid1:22
+ ├── vector index put quantized vector columns: vector_index_put_quantized_vec1:22
  └── vector-mutation-search t@t_v_idx,vector
-      ├── columns: column1:6!null v_cast:8!null w_default:9 x:10 v:11 w:12 crdb_internal_mvcc_timestamp:13 tableoid:14 v_cast:16!null upsert_x:17 upsert_v:18!null upsert_w:19 vector_index_del_partition1:20 vector_index_put_partition1:21 vector_index_put_centroid1:22
+      ├── columns: column1:6!null v_cast:8!null w_default:9 x:10 v:11 w:12 crdb_internal_mvcc_timestamp:13 tableoid:14 v_cast:16!null upsert_x:17 upsert_v:18!null upsert_w:19 vector_index_del_partition1:20 vector_index_put_partition1:21 vector_index_put_quantized_vec1:22
       ├── query vector column: upsert_v:18
       ├── partition col: vector_index_put_partition1:21
-      ├── centroid col: vector_index_put_centroid1:22
+      ├── quantized vector col: vector_index_put_quantized_vec1:22
       └── vector-mutation-search t@t_v_idx,vector
            ├── columns: column1:6!null v_cast:8!null w_default:9 x:10 v:11 w:12 crdb_internal_mvcc_timestamp:13 tableoid:14 v_cast:16!null upsert_x:17 upsert_v:18!null upsert_w:19 vector_index_del_partition1:20
            ├── query vector column: v:11
@@ -243,17 +243,17 @@ insert t
  │    ├── v_cast:9 => v:2
  │    └── w_cast:10 => w:3
  ├── vector index put partition columns: vector_index_put_partition1:11 vector_index_put_partition2:13
- ├── vector index put centroid columns: vector_index_put_centroid1:12 vector_index_put_centroid2:14
+ ├── vector index put quantized vector columns: vector_index_put_quantized_vec1:12 vector_index_put_quantized_vec2:14
  └── vector-mutation-search t@t_w_idx,vector
-      ├── columns: column1:6!null v_cast:9!null w_cast:10!null vector_index_put_partition1:11 vector_index_put_centroid1:12 vector_index_put_partition2:13 vector_index_put_centroid2:14
+      ├── columns: column1:6!null v_cast:9!null w_cast:10!null vector_index_put_partition1:11 vector_index_put_quantized_vec1:12 vector_index_put_partition2:13 vector_index_put_quantized_vec2:14
       ├── query vector column: w_cast:10
       ├── partition col: vector_index_put_partition2:13
-      ├── centroid col: vector_index_put_centroid2:14
+      ├── quantized vector col: vector_index_put_quantized_vec2:14
       └── vector-mutation-search t@t_v_idx,vector
-           ├── columns: column1:6!null v_cast:9!null w_cast:10!null vector_index_put_partition1:11 vector_index_put_centroid1:12
+           ├── columns: column1:6!null v_cast:9!null w_cast:10!null vector_index_put_partition1:11 vector_index_put_quantized_vec1:12
            ├── query vector column: v_cast:9
            ├── partition col: vector_index_put_partition1:11
-           ├── centroid col: vector_index_put_centroid1:12
+           ├── quantized vector col: vector_index_put_quantized_vec1:12
            └── project
                 ├── columns: v_cast:9!null w_cast:10!null column1:6!null
                 ├── values
@@ -277,22 +277,22 @@ update t
  │    └── w_cast:14 => w:3
  ├── vector index del partition columns: vector_index_del_partition1:15 vector_index_del_partition2:18
  ├── vector index put partition columns: vector_index_put_partition1:16 vector_index_put_partition2:19
- ├── vector index put centroid columns: vector_index_put_centroid1:17 vector_index_put_centroid2:20
+ ├── vector index put quantized vector columns: vector_index_put_quantized_vec1:17 vector_index_put_quantized_vec2:20
  └── vector-mutation-search t@t_w_idx,vector
-      ├── columns: x:6!null v:7 w:8 crdb_internal_mvcc_timestamp:9 tableoid:10 v_cast:13!null w_cast:14!null vector_index_del_partition1:15 vector_index_put_partition1:16 vector_index_put_centroid1:17 vector_index_del_partition2:18 vector_index_put_partition2:19 vector_index_put_centroid2:20
+      ├── columns: x:6!null v:7 w:8 crdb_internal_mvcc_timestamp:9 tableoid:10 v_cast:13!null w_cast:14!null vector_index_del_partition1:15 vector_index_put_partition1:16 vector_index_put_quantized_vec1:17 vector_index_del_partition2:18 vector_index_put_partition2:19 vector_index_put_quantized_vec2:20
       ├── query vector column: w_cast:14
       ├── partition col: vector_index_put_partition2:19
-      ├── centroid col: vector_index_put_centroid2:20
+      ├── quantized vector col: vector_index_put_quantized_vec2:20
       └── vector-mutation-search t@t_w_idx,vector
-           ├── columns: x:6!null v:7 w:8 crdb_internal_mvcc_timestamp:9 tableoid:10 v_cast:13!null w_cast:14!null vector_index_del_partition1:15 vector_index_put_partition1:16 vector_index_put_centroid1:17 vector_index_del_partition2:18
+           ├── columns: x:6!null v:7 w:8 crdb_internal_mvcc_timestamp:9 tableoid:10 v_cast:13!null w_cast:14!null vector_index_del_partition1:15 vector_index_put_partition1:16 vector_index_put_quantized_vec1:17 vector_index_del_partition2:18
            ├── query vector column: w:8
            ├── primary key columns: (6)
            ├── partition col: vector_index_del_partition2:18
            └── vector-mutation-search t@t_v_idx,vector
-                ├── columns: x:6!null v:7 w:8 crdb_internal_mvcc_timestamp:9 tableoid:10 v_cast:13!null w_cast:14!null vector_index_del_partition1:15 vector_index_put_partition1:16 vector_index_put_centroid1:17
+                ├── columns: x:6!null v:7 w:8 crdb_internal_mvcc_timestamp:9 tableoid:10 v_cast:13!null w_cast:14!null vector_index_del_partition1:15 vector_index_put_partition1:16 vector_index_put_quantized_vec1:17
                 ├── query vector column: v_cast:13
                 ├── partition col: vector_index_put_partition1:16
-                ├── centroid col: vector_index_put_centroid1:17
+                ├── quantized vector col: vector_index_put_quantized_vec1:17
                 └── vector-mutation-search t@t_v_idx,vector
                      ├── columns: x:6!null v:7 w:8 crdb_internal_mvcc_timestamp:9 tableoid:10 v_cast:13!null w_cast:14!null vector_index_del_partition1:15
                      ├── query vector column: v:7
@@ -360,22 +360,22 @@ upsert t
  │    └── w_cast:10 => w:3
  ├── vector index del partition columns: vector_index_del_partition1:17 vector_index_del_partition2:20
  ├── vector index put partition columns: vector_index_put_partition1:18 vector_index_put_partition2:21
- ├── vector index put centroid columns: vector_index_put_centroid1:19 vector_index_put_centroid2:22
+ ├── vector index put quantized vector columns: vector_index_put_quantized_vec1:19 vector_index_put_quantized_vec2:22
  └── vector-mutation-search t@t_w_idx,vector
-      ├── columns: column1:6!null v_cast:9!null w_cast:10!null x:11 v:12 w:13 crdb_internal_mvcc_timestamp:14 tableoid:15 upsert_x:16 vector_index_del_partition1:17 vector_index_put_partition1:18 vector_index_put_centroid1:19 vector_index_del_partition2:20 vector_index_put_partition2:21 vector_index_put_centroid2:22
+      ├── columns: column1:6!null v_cast:9!null w_cast:10!null x:11 v:12 w:13 crdb_internal_mvcc_timestamp:14 tableoid:15 upsert_x:16 vector_index_del_partition1:17 vector_index_put_partition1:18 vector_index_put_quantized_vec1:19 vector_index_del_partition2:20 vector_index_put_partition2:21 vector_index_put_quantized_vec2:22
       ├── query vector column: w_cast:10
       ├── partition col: vector_index_put_partition2:21
-      ├── centroid col: vector_index_put_centroid2:22
+      ├── quantized vector col: vector_index_put_quantized_vec2:22
       └── vector-mutation-search t@t_w_idx,vector
-           ├── columns: column1:6!null v_cast:9!null w_cast:10!null x:11 v:12 w:13 crdb_internal_mvcc_timestamp:14 tableoid:15 upsert_x:16 vector_index_del_partition1:17 vector_index_put_partition1:18 vector_index_put_centroid1:19 vector_index_del_partition2:20
+           ├── columns: column1:6!null v_cast:9!null w_cast:10!null x:11 v:12 w:13 crdb_internal_mvcc_timestamp:14 tableoid:15 upsert_x:16 vector_index_del_partition1:17 vector_index_put_partition1:18 vector_index_put_quantized_vec1:19 vector_index_del_partition2:20
            ├── query vector column: w:13
            ├── primary key columns: (11)
            ├── partition col: vector_index_del_partition2:20
            └── vector-mutation-search t@t_v_idx,vector
-                ├── columns: column1:6!null v_cast:9!null w_cast:10!null x:11 v:12 w:13 crdb_internal_mvcc_timestamp:14 tableoid:15 upsert_x:16 vector_index_del_partition1:17 vector_index_put_partition1:18 vector_index_put_centroid1:19
+                ├── columns: column1:6!null v_cast:9!null w_cast:10!null x:11 v:12 w:13 crdb_internal_mvcc_timestamp:14 tableoid:15 upsert_x:16 vector_index_del_partition1:17 vector_index_put_partition1:18 vector_index_put_quantized_vec1:19
                 ├── query vector column: v_cast:9
                 ├── partition col: vector_index_put_partition1:18
-                ├── centroid col: vector_index_put_centroid1:19
+                ├── quantized vector col: vector_index_put_quantized_vec1:19
                 └── vector-mutation-search t@t_v_idx,vector
                      ├── columns: column1:6!null v_cast:9!null w_cast:10!null x:11 v:12 w:13 crdb_internal_mvcc_timestamp:14 tableoid:15 upsert_x:16 vector_index_del_partition1:17
                      ├── query vector column: v:12
@@ -430,22 +430,22 @@ upsert t
  │    └── upsert_w:22 => w:3
  ├── vector index del partition columns: vector_index_del_partition1:23 vector_index_del_partition2:26
  ├── vector index put partition columns: vector_index_put_partition1:24 vector_index_put_partition2:27
- ├── vector index put centroid columns: vector_index_put_centroid1:25 vector_index_put_centroid2:28
+ ├── vector index put quantized vector columns: vector_index_put_quantized_vec1:25 vector_index_put_quantized_vec2:28
  └── vector-mutation-search t@t_w_idx,vector
-      ├── columns: column1:6!null v_cast:9!null w_cast:10!null x:11 v:12 w:13 crdb_internal_mvcc_timestamp:14 tableoid:15 v_cast:18!null w_cast:19!null upsert_x:20 upsert_v:21!null upsert_w:22!null vector_index_del_partition1:23 vector_index_put_partition1:24 vector_index_put_centroid1:25 vector_index_del_partition2:26 vector_index_put_partition2:27 vector_index_put_centroid2:28
+      ├── columns: column1:6!null v_cast:9!null w_cast:10!null x:11 v:12 w:13 crdb_internal_mvcc_timestamp:14 tableoid:15 v_cast:18!null w_cast:19!null upsert_x:20 upsert_v:21!null upsert_w:22!null vector_index_del_partition1:23 vector_index_put_partition1:24 vector_index_put_quantized_vec1:25 vector_index_del_partition2:26 vector_index_put_partition2:27 vector_index_put_quantized_vec2:28
       ├── query vector column: upsert_w:22
       ├── partition col: vector_index_put_partition2:27
-      ├── centroid col: vector_index_put_centroid2:28
+      ├── quantized vector col: vector_index_put_quantized_vec2:28
       └── vector-mutation-search t@t_w_idx,vector
-           ├── columns: column1:6!null v_cast:9!null w_cast:10!null x:11 v:12 w:13 crdb_internal_mvcc_timestamp:14 tableoid:15 v_cast:18!null w_cast:19!null upsert_x:20 upsert_v:21!null upsert_w:22!null vector_index_del_partition1:23 vector_index_put_partition1:24 vector_index_put_centroid1:25 vector_index_del_partition2:26
+           ├── columns: column1:6!null v_cast:9!null w_cast:10!null x:11 v:12 w:13 crdb_internal_mvcc_timestamp:14 tableoid:15 v_cast:18!null w_cast:19!null upsert_x:20 upsert_v:21!null upsert_w:22!null vector_index_del_partition1:23 vector_index_put_partition1:24 vector_index_put_quantized_vec1:25 vector_index_del_partition2:26
            ├── query vector column: w:13
            ├── primary key columns: (11)
            ├── partition col: vector_index_del_partition2:26
            └── vector-mutation-search t@t_v_idx,vector
-                ├── columns: column1:6!null v_cast:9!null w_cast:10!null x:11 v:12 w:13 crdb_internal_mvcc_timestamp:14 tableoid:15 v_cast:18!null w_cast:19!null upsert_x:20 upsert_v:21!null upsert_w:22!null vector_index_del_partition1:23 vector_index_put_partition1:24 vector_index_put_centroid1:25
+                ├── columns: column1:6!null v_cast:9!null w_cast:10!null x:11 v:12 w:13 crdb_internal_mvcc_timestamp:14 tableoid:15 v_cast:18!null w_cast:19!null upsert_x:20 upsert_v:21!null upsert_w:22!null vector_index_del_partition1:23 vector_index_put_partition1:24 vector_index_put_quantized_vec1:25
                 ├── query vector column: upsert_v:21
                 ├── partition col: vector_index_put_partition1:24
-                ├── centroid col: vector_index_put_centroid1:25
+                ├── quantized vector col: vector_index_put_quantized_vec1:25
                 └── vector-mutation-search t@t_v_idx,vector
                      ├── columns: column1:6!null v_cast:9!null w_cast:10!null x:11 v:12 w:13 crdb_internal_mvcc_timestamp:14 tableoid:15 v_cast:18!null w_cast:19!null upsert_x:20 upsert_v:21!null upsert_w:22!null vector_index_del_partition1:23
                      ├── query vector column: v:12
@@ -509,12 +509,12 @@ update t
  │    └── v_cast:13 => v:2
  ├── vector index del partition columns: vector_index_del_partition1:14
  ├── vector index put partition columns: vector_index_put_partition1:15
- ├── vector index put centroid columns: vector_index_put_centroid1:16
+ ├── vector index put quantized vector columns: vector_index_put_quantized_vec1:16
  └── vector-mutation-search t@t_v_idx,vector
-      ├── columns: x:6!null v:7 w:8 crdb_internal_mvcc_timestamp:9 tableoid:10 x_new:11!null v_cast:13!null vector_index_del_partition1:14 vector_index_put_partition1:15 vector_index_put_centroid1:16
+      ├── columns: x:6!null v:7 w:8 crdb_internal_mvcc_timestamp:9 tableoid:10 x_new:11!null v_cast:13!null vector_index_del_partition1:14 vector_index_put_partition1:15 vector_index_put_quantized_vec1:16
       ├── query vector column: v_cast:13
       ├── partition col: vector_index_put_partition1:15
-      ├── centroid col: vector_index_put_centroid1:16
+      ├── quantized vector col: vector_index_put_quantized_vec1:16
       └── vector-mutation-search t@t_v_idx,vector
            ├── columns: x:6!null v:7 w:8 crdb_internal_mvcc_timestamp:9 tableoid:10 x_new:11!null v_cast:13!null vector_index_del_partition1:14
            ├── query vector column: v:7

--- a/pkg/sql/opt/optbuilder/testdata/vector_mutation
+++ b/pkg/sql/opt/optbuilder/testdata/vector_mutation
@@ -17,7 +17,7 @@ insert t
  │    └── w_default:9 => w:3
  ├── vector index put partition columns: vector_index_put_partition1:10
  ├── vector index put centroid columns: vector_index_put_centroid1:11
- └── vector-partition-search t@t_v_idx,vector
+ └── vector-mutation-search t@t_v_idx,vector
       ├── columns: column1:6!null v_cast:8!null w_default:9 vector_index_put_partition1:10 vector_index_put_centroid1:11
       ├── query vector column: v_cast:8
       ├── partition col: vector_index_put_partition1:10
@@ -47,12 +47,12 @@ update t
  ├── vector index del partition columns: vector_index_del_partition1:13
  ├── vector index put partition columns: vector_index_put_partition1:14
  ├── vector index put centroid columns: vector_index_put_centroid1:15
- └── vector-partition-search t@t_v_idx,vector
+ └── vector-mutation-search t@t_v_idx,vector
       ├── columns: x:6!null v:7 w:8 crdb_internal_mvcc_timestamp:9 tableoid:10 v_cast:12!null vector_index_del_partition1:13 vector_index_put_partition1:14 vector_index_put_centroid1:15
       ├── query vector column: v_cast:12
       ├── partition col: vector_index_put_partition1:14
       ├── centroid col: vector_index_put_centroid1:15
-      └── vector-partition-search t@t_v_idx,vector
+      └── vector-mutation-search t@t_v_idx,vector
            ├── columns: x:6!null v:7 w:8 crdb_internal_mvcc_timestamp:9 tableoid:10 v_cast:12!null vector_index_del_partition1:13
            ├── query vector column: v:7
            ├── primary key columns: (6)
@@ -81,7 +81,7 @@ delete t
  ├── columns: <none>
  ├── fetch columns: x:6 v:7 w:8
  ├── vector index del partition columns: vector_index_del_partition1:11
- └── vector-partition-search t@t_v_idx,vector
+ └── vector-mutation-search t@t_v_idx,vector
       ├── columns: x:6!null v:7 w:8 crdb_internal_mvcc_timestamp:9 tableoid:10 vector_index_del_partition1:11
       ├── query vector column: v:7
       ├── primary key columns: (6)
@@ -112,12 +112,12 @@ upsert t
  ├── vector index del partition columns: vector_index_del_partition1:16
  ├── vector index put partition columns: vector_index_put_partition1:17
  ├── vector index put centroid columns: vector_index_put_centroid1:18
- └── vector-partition-search t@t_v_idx,vector
+ └── vector-mutation-search t@t_v_idx,vector
       ├── columns: column1:6!null v_cast:8!null w_default:9 x:10 v:11 w:12 crdb_internal_mvcc_timestamp:13 tableoid:14 upsert_x:15 vector_index_del_partition1:16 vector_index_put_partition1:17 vector_index_put_centroid1:18
       ├── query vector column: v_cast:8
       ├── partition col: vector_index_put_partition1:17
       ├── centroid col: vector_index_put_centroid1:18
-      └── vector-partition-search t@t_v_idx,vector
+      └── vector-mutation-search t@t_v_idx,vector
            ├── columns: column1:6!null v_cast:8!null w_default:9 x:10 v:11 w:12 crdb_internal_mvcc_timestamp:13 tableoid:14 upsert_x:15 vector_index_del_partition1:16
            ├── query vector column: v:11
            ├── primary key columns: (10)
@@ -173,12 +173,12 @@ upsert t
  ├── vector index del partition columns: vector_index_del_partition1:20
  ├── vector index put partition columns: vector_index_put_partition1:21
  ├── vector index put centroid columns: vector_index_put_centroid1:22
- └── vector-partition-search t@t_v_idx,vector
+ └── vector-mutation-search t@t_v_idx,vector
       ├── columns: column1:6!null v_cast:8!null w_default:9 x:10 v:11 w:12 crdb_internal_mvcc_timestamp:13 tableoid:14 v_cast:16!null upsert_x:17 upsert_v:18!null upsert_w:19 vector_index_del_partition1:20 vector_index_put_partition1:21 vector_index_put_centroid1:22
       ├── query vector column: upsert_v:18
       ├── partition col: vector_index_put_partition1:21
       ├── centroid col: vector_index_put_centroid1:22
-      └── vector-partition-search t@t_v_idx,vector
+      └── vector-mutation-search t@t_v_idx,vector
            ├── columns: column1:6!null v_cast:8!null w_default:9 x:10 v:11 w:12 crdb_internal_mvcc_timestamp:13 tableoid:14 v_cast:16!null upsert_x:17 upsert_v:18!null upsert_w:19 vector_index_del_partition1:20
            ├── query vector column: v:11
            ├── primary key columns: (10)
@@ -244,12 +244,12 @@ insert t
  │    └── w_cast:10 => w:3
  ├── vector index put partition columns: vector_index_put_partition1:11 vector_index_put_partition2:13
  ├── vector index put centroid columns: vector_index_put_centroid1:12 vector_index_put_centroid2:14
- └── vector-partition-search t@t_w_idx,vector
+ └── vector-mutation-search t@t_w_idx,vector
       ├── columns: column1:6!null v_cast:9!null w_cast:10!null vector_index_put_partition1:11 vector_index_put_centroid1:12 vector_index_put_partition2:13 vector_index_put_centroid2:14
       ├── query vector column: w_cast:10
       ├── partition col: vector_index_put_partition2:13
       ├── centroid col: vector_index_put_centroid2:14
-      └── vector-partition-search t@t_v_idx,vector
+      └── vector-mutation-search t@t_v_idx,vector
            ├── columns: column1:6!null v_cast:9!null w_cast:10!null vector_index_put_partition1:11 vector_index_put_centroid1:12
            ├── query vector column: v_cast:9
            ├── partition col: vector_index_put_partition1:11
@@ -278,22 +278,22 @@ update t
  ├── vector index del partition columns: vector_index_del_partition1:15 vector_index_del_partition2:18
  ├── vector index put partition columns: vector_index_put_partition1:16 vector_index_put_partition2:19
  ├── vector index put centroid columns: vector_index_put_centroid1:17 vector_index_put_centroid2:20
- └── vector-partition-search t@t_w_idx,vector
+ └── vector-mutation-search t@t_w_idx,vector
       ├── columns: x:6!null v:7 w:8 crdb_internal_mvcc_timestamp:9 tableoid:10 v_cast:13!null w_cast:14!null vector_index_del_partition1:15 vector_index_put_partition1:16 vector_index_put_centroid1:17 vector_index_del_partition2:18 vector_index_put_partition2:19 vector_index_put_centroid2:20
       ├── query vector column: w_cast:14
       ├── partition col: vector_index_put_partition2:19
       ├── centroid col: vector_index_put_centroid2:20
-      └── vector-partition-search t@t_w_idx,vector
+      └── vector-mutation-search t@t_w_idx,vector
            ├── columns: x:6!null v:7 w:8 crdb_internal_mvcc_timestamp:9 tableoid:10 v_cast:13!null w_cast:14!null vector_index_del_partition1:15 vector_index_put_partition1:16 vector_index_put_centroid1:17 vector_index_del_partition2:18
            ├── query vector column: w:8
            ├── primary key columns: (6)
            ├── partition col: vector_index_del_partition2:18
-           └── vector-partition-search t@t_v_idx,vector
+           └── vector-mutation-search t@t_v_idx,vector
                 ├── columns: x:6!null v:7 w:8 crdb_internal_mvcc_timestamp:9 tableoid:10 v_cast:13!null w_cast:14!null vector_index_del_partition1:15 vector_index_put_partition1:16 vector_index_put_centroid1:17
                 ├── query vector column: v_cast:13
                 ├── partition col: vector_index_put_partition1:16
                 ├── centroid col: vector_index_put_centroid1:17
-                └── vector-partition-search t@t_v_idx,vector
+                └── vector-mutation-search t@t_v_idx,vector
                      ├── columns: x:6!null v:7 w:8 crdb_internal_mvcc_timestamp:9 tableoid:10 v_cast:13!null w_cast:14!null vector_index_del_partition1:15
                      ├── query vector column: v:7
                      ├── primary key columns: (6)
@@ -325,12 +325,12 @@ delete t
  ├── columns: <none>
  ├── fetch columns: x:6 v:7 w:8
  ├── vector index del partition columns: vector_index_del_partition1:11 vector_index_del_partition2:12
- └── vector-partition-search t@t_w_idx,vector
+ └── vector-mutation-search t@t_w_idx,vector
       ├── columns: x:6!null v:7 w:8 crdb_internal_mvcc_timestamp:9 tableoid:10 vector_index_del_partition1:11 vector_index_del_partition2:12
       ├── query vector column: w:8
       ├── primary key columns: (6)
       ├── partition col: vector_index_del_partition2:12
-      └── vector-partition-search t@t_v_idx,vector
+      └── vector-mutation-search t@t_v_idx,vector
            ├── columns: x:6!null v:7 w:8 crdb_internal_mvcc_timestamp:9 tableoid:10 vector_index_del_partition1:11
            ├── query vector column: v:7
            ├── primary key columns: (6)
@@ -361,22 +361,22 @@ upsert t
  ├── vector index del partition columns: vector_index_del_partition1:17 vector_index_del_partition2:20
  ├── vector index put partition columns: vector_index_put_partition1:18 vector_index_put_partition2:21
  ├── vector index put centroid columns: vector_index_put_centroid1:19 vector_index_put_centroid2:22
- └── vector-partition-search t@t_w_idx,vector
+ └── vector-mutation-search t@t_w_idx,vector
       ├── columns: column1:6!null v_cast:9!null w_cast:10!null x:11 v:12 w:13 crdb_internal_mvcc_timestamp:14 tableoid:15 upsert_x:16 vector_index_del_partition1:17 vector_index_put_partition1:18 vector_index_put_centroid1:19 vector_index_del_partition2:20 vector_index_put_partition2:21 vector_index_put_centroid2:22
       ├── query vector column: w_cast:10
       ├── partition col: vector_index_put_partition2:21
       ├── centroid col: vector_index_put_centroid2:22
-      └── vector-partition-search t@t_w_idx,vector
+      └── vector-mutation-search t@t_w_idx,vector
            ├── columns: column1:6!null v_cast:9!null w_cast:10!null x:11 v:12 w:13 crdb_internal_mvcc_timestamp:14 tableoid:15 upsert_x:16 vector_index_del_partition1:17 vector_index_put_partition1:18 vector_index_put_centroid1:19 vector_index_del_partition2:20
            ├── query vector column: w:13
            ├── primary key columns: (11)
            ├── partition col: vector_index_del_partition2:20
-           └── vector-partition-search t@t_v_idx,vector
+           └── vector-mutation-search t@t_v_idx,vector
                 ├── columns: column1:6!null v_cast:9!null w_cast:10!null x:11 v:12 w:13 crdb_internal_mvcc_timestamp:14 tableoid:15 upsert_x:16 vector_index_del_partition1:17 vector_index_put_partition1:18 vector_index_put_centroid1:19
                 ├── query vector column: v_cast:9
                 ├── partition col: vector_index_put_partition1:18
                 ├── centroid col: vector_index_put_centroid1:19
-                └── vector-partition-search t@t_v_idx,vector
+                └── vector-mutation-search t@t_v_idx,vector
                      ├── columns: column1:6!null v_cast:9!null w_cast:10!null x:11 v:12 w:13 crdb_internal_mvcc_timestamp:14 tableoid:15 upsert_x:16 vector_index_del_partition1:17
                      ├── query vector column: v:12
                      ├── primary key columns: (11)
@@ -431,22 +431,22 @@ upsert t
  ├── vector index del partition columns: vector_index_del_partition1:23 vector_index_del_partition2:26
  ├── vector index put partition columns: vector_index_put_partition1:24 vector_index_put_partition2:27
  ├── vector index put centroid columns: vector_index_put_centroid1:25 vector_index_put_centroid2:28
- └── vector-partition-search t@t_w_idx,vector
+ └── vector-mutation-search t@t_w_idx,vector
       ├── columns: column1:6!null v_cast:9!null w_cast:10!null x:11 v:12 w:13 crdb_internal_mvcc_timestamp:14 tableoid:15 v_cast:18!null w_cast:19!null upsert_x:20 upsert_v:21!null upsert_w:22!null vector_index_del_partition1:23 vector_index_put_partition1:24 vector_index_put_centroid1:25 vector_index_del_partition2:26 vector_index_put_partition2:27 vector_index_put_centroid2:28
       ├── query vector column: upsert_w:22
       ├── partition col: vector_index_put_partition2:27
       ├── centroid col: vector_index_put_centroid2:28
-      └── vector-partition-search t@t_w_idx,vector
+      └── vector-mutation-search t@t_w_idx,vector
            ├── columns: column1:6!null v_cast:9!null w_cast:10!null x:11 v:12 w:13 crdb_internal_mvcc_timestamp:14 tableoid:15 v_cast:18!null w_cast:19!null upsert_x:20 upsert_v:21!null upsert_w:22!null vector_index_del_partition1:23 vector_index_put_partition1:24 vector_index_put_centroid1:25 vector_index_del_partition2:26
            ├── query vector column: w:13
            ├── primary key columns: (11)
            ├── partition col: vector_index_del_partition2:26
-           └── vector-partition-search t@t_v_idx,vector
+           └── vector-mutation-search t@t_v_idx,vector
                 ├── columns: column1:6!null v_cast:9!null w_cast:10!null x:11 v:12 w:13 crdb_internal_mvcc_timestamp:14 tableoid:15 v_cast:18!null w_cast:19!null upsert_x:20 upsert_v:21!null upsert_w:22!null vector_index_del_partition1:23 vector_index_put_partition1:24 vector_index_put_centroid1:25
                 ├── query vector column: upsert_v:21
                 ├── partition col: vector_index_put_partition1:24
                 ├── centroid col: vector_index_put_centroid1:25
-                └── vector-partition-search t@t_v_idx,vector
+                └── vector-mutation-search t@t_v_idx,vector
                      ├── columns: column1:6!null v_cast:9!null w_cast:10!null x:11 v:12 w:13 crdb_internal_mvcc_timestamp:14 tableoid:15 v_cast:18!null w_cast:19!null upsert_x:20 upsert_v:21!null upsert_w:22!null vector_index_del_partition1:23
                      ├── query vector column: v:12
                      ├── primary key columns: (11)
@@ -496,7 +496,7 @@ upsert t
                                ├── CASE WHEN x:11 IS NULL THEN v_cast:9 ELSE v_cast:18 END [as=upsert_v:21]
                                └── CASE WHEN x:11 IS NULL THEN w_cast:10 ELSE w_cast:19 END [as=upsert_w:22]
 
-# If the indexed column is not modified, no VectorPartitionSearch is needed for
+# If the indexed column is not modified, no VectorMutationSearch is needed for
 # that index.
 build
 UPDATE t SET x = 3, v = '[1,2,3]' WHERE x = 3;
@@ -510,12 +510,12 @@ update t
  ├── vector index del partition columns: vector_index_del_partition1:14
  ├── vector index put partition columns: vector_index_put_partition1:15
  ├── vector index put centroid columns: vector_index_put_centroid1:16
- └── vector-partition-search t@t_v_idx,vector
+ └── vector-mutation-search t@t_v_idx,vector
       ├── columns: x:6!null v:7 w:8 crdb_internal_mvcc_timestamp:9 tableoid:10 x_new:11!null v_cast:13!null vector_index_del_partition1:14 vector_index_put_partition1:15 vector_index_put_centroid1:16
       ├── query vector column: v_cast:13
       ├── partition col: vector_index_put_partition1:15
       ├── centroid col: vector_index_put_centroid1:16
-      └── vector-partition-search t@t_v_idx,vector
+      └── vector-mutation-search t@t_v_idx,vector
            ├── columns: x:6!null v:7 w:8 crdb_internal_mvcc_timestamp:9 tableoid:10 x_new:11!null v_cast:13!null vector_index_del_partition1:14
            ├── query vector column: v:7
            ├── primary key columns: (6)

--- a/pkg/sql/opt/optgen/lang/support/textmate/OptGen/Syntaxes/optgen.tmLanguage
+++ b/pkg/sql/opt/optgen/lang/support/textmate/OptGen/Syntaxes/optgen.tmLanguage
@@ -258,7 +258,7 @@
                         Sort |
                         TopK |
                         VectorSearch |
-                        VectorPartitionSearch |
+                        VectorMutationSearch |
                         VectorDistance |
                         VectorCosVectorDistance |
                         VectorNegInnerProduct |

--- a/pkg/sql/opt/optgen/lang/support/vim/cropt.vim
+++ b/pkg/sql/opt/optgen/lang/support/vim/cropt.vim
@@ -57,7 +57,7 @@ syn keyword operator DistinctOn EnsureDistinctOn UpsertDistinctOn EnsureUpsertDi
 syn keyword operator Union SetPrivate Intersect Except UnionAll IntersectAll ExceptAll
 syn keyword operator Let Limit Offset Max1Row Explain ExplainPrivate
 syn keyword operator ShowTraceForSession ShowTracePrivate Root RowNumber RowNumberPrivate ProjectSet
-syn keyword operator Sort TopK VectorSearch VectorPartitionSearch
+syn keyword operator Sort TopK VectorSearch VectorMutationSearch
 syn keyword operator VectorDistance VectorCosDistance VectorNegInnerProduct
 syn keyword operator Insert Update Upsert Delete CreateTable OpName
 

--- a/pkg/sql/opt/optgen/lang/support/vscode/cockroachdb.optgen-1.0.0/syntaxes/optgen.tmLanguage
+++ b/pkg/sql/opt/optgen/lang/support/vscode/cockroachdb.optgen-1.0.0/syntaxes/optgen.tmLanguage
@@ -258,7 +258,7 @@
                         Sort |
                         TopK |
                         VectorSearch |
-                        VectorPartitionSearch |
+                        VectorMutationSearch |
                         VectorDistance |
                         VectorCosVectorDistance |
                         VectorNegInnerProduct |

--- a/pkg/sql/opt/xform/coster.go
+++ b/pkg/sql/opt/xform/coster.go
@@ -596,8 +596,8 @@ func (c *coster) ComputeCost(candidate memo.RelExpr, required *physical.Required
 	case opt.VectorSearchOp:
 		cost = c.computeVectorSearchCost(candidate.(*memo.VectorSearchExpr))
 
-	case opt.VectorPartitionSearchOp:
-		cost = c.computeVectorPartitionSearchCost(candidate.(*memo.VectorPartitionSearchExpr))
+	case opt.VectorMutationSearchOp:
+		cost = c.computeVectorMutationSearchCost(candidate.(*memo.VectorMutationSearchExpr))
 
 	case opt.InsertOp:
 		insertExpr, _ := candidate.(*memo.InsertExpr)
@@ -768,9 +768,7 @@ func (c *coster) computeVectorSearchCost(search *memo.VectorSearchExpr) memo.Cos
 	return memo.Cost{C: cpuCostFactor * search.Relational().Statistics().RowCount}
 }
 
-func (c *coster) computeVectorPartitionSearchCost(
-	search *memo.VectorPartitionSearchExpr,
-) memo.Cost {
+func (c *coster) computeVectorMutationSearchCost(search *memo.VectorMutationSearchExpr) memo.Cost {
 	// TODO(drewk, mw5h): implement a proper cost function.
 	return memo.Cost{C: cpuCostFactor * search.Relational().Statistics().RowCount}
 }


### PR DESCRIPTION
#### opt: rename VectorPartitionSearch

This commit renames the `VectorPartitionSearch` operator to
`VectorMutationSearch`. This reflects the fact that the operator is
used to prepare the information needed for index updates.

Epic: None

Release note: None

#### opt: modify VectorMutationSearch to produce quantized vectors

This commit changes `VectorMutationSearch` so that it produces quantized
and encoded vectors, rather than partition centroids. This shifts the
responsibility of quantizing vectors to the `VectorMutationSearch`
operator rather than the insert/update code paths.

Epic: CRDB-42943

Release note: None