### PR TITLE
logictest: skip `partitioning_hash_sharded_index` in 5node under race

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning_hash_sharded_index
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning_hash_sharded_index
@@ -1,5 +1,8 @@
 # LogicTest: 5node
 
+# This test routinely times out under race without clear signs of problems.
+skip under race
+
 statement ok
 SET experimental_enable_implicit_column_partitioning = true;
 


### PR DESCRIPTION
We have been seeing this test time out many times under race. I examined a few of the timeouts and didn't find anything suspicious, so let's just skip it under race.

Fixes: #137918.

Release note: None