### PR TITLE
logictest: skip MR configs under race outside ccl

### DIFF
--- a/pkg/cmd/generate-logictest/main.go
+++ b/pkg/cmd/generate-logictest/main.go
@@ -27,7 +27,7 @@ type testFileTemplateConfig struct {
 	CockroachGoTestserverTest     bool
 	Ccl                           bool
 	ForceProductionValues         bool
-	SkipCclUnderRace              bool
+	SkipUnderRace                 bool
 	UseHeavyPool                  useHeavyPoolCondition
 	Package, TestRuleName, RelDir string
 	ConfigIdx                     int
@@ -188,7 +188,7 @@ func (t *testdir) dump() error {
 			tplCfg.NumCPU = 3
 		}
 		if cfg.Name == "3node-tenant" || strings.HasPrefix(cfg.Name, "multiregion-") {
-			tplCfg.SkipCclUnderRace = true
+			tplCfg.SkipUnderRace = true
 		}
 		tplCfg.UseHeavyPool = useHeavyPoolNever
 		if strings.Contains(cfg.Name, "5node") ||

--- a/pkg/cmd/generate-logictest/templates.go
+++ b/pkg/cmd/generate-logictest/templates.go
@@ -38,7 +38,7 @@ const templateText = `
 {{- define "runLogicTest" }}
 {{- if .LogicTest -}}
 func runLogicTest(t *testing.T, file string) {
-	{{if and .SkipCclUnderRace .Ccl}}skip.UnderRace(t, "times out and/or hangs")
+	{{if .SkipUnderRace}}skip.UnderRace(t, "times out and/or hangs")
 	{{end}}skip.UnderDeadlock(t, "times out and/or hangs")
 	logictest.RunLogicTest(t, logictest.TestServerArgs{}, configIdx, filepath.Join(logicTestDir, file))
 }
@@ -48,7 +48,7 @@ func runLogicTest(t *testing.T, file string) {
 {{- define "runCCLLogicTest" }}
 {{- if .CclLogicTest -}}
 func runCCLLogicTest(t *testing.T, file string) {
-	{{if .SkipCclUnderRace}}skip.UnderRace(t, "times out and/or hangs")
+	{{if .SkipUnderRace}}skip.UnderRace(t, "times out and/or hangs")
 	{{end}}skip.UnderDeadlock(t, "times out and/or hangs")
 	logictest.RunLogicTest(t, logictest.TestServerArgs{}, configIdx, filepath.Join(cclLogicTestDir, file))
 }

--- a/pkg/sql/logictest/tests/multiregion-9node-3region-3azs/generated_test.go
+++ b/pkg/sql/logictest/tests/multiregion-9node-3region-3azs/generated_test.go
@@ -55,6 +55,7 @@ func TestMain(m *testing.M) {
 }
 
 func runLogicTest(t *testing.T, file string) {
+	skip.UnderRace(t, "times out and/or hangs")
 	skip.UnderDeadlock(t, "times out and/or hangs")
 	logictest.RunLogicTest(t, logictest.TestServerArgs{}, configIdx, filepath.Join(logicTestDir, file))
 }

--- a/pkg/sql/logictest/tests/multiregion-invalid-locality/generated_test.go
+++ b/pkg/sql/logictest/tests/multiregion-invalid-locality/generated_test.go
@@ -55,6 +55,7 @@ func TestMain(m *testing.M) {
 }
 
 func runLogicTest(t *testing.T, file string) {
+	skip.UnderRace(t, "times out and/or hangs")
 	skip.UnderDeadlock(t, "times out and/or hangs")
 	logictest.RunLogicTest(t, logictest.TestServerArgs{}, configIdx, filepath.Join(logicTestDir, file))
 }


### PR DESCRIPTION
This commit skips under race a couple of MR logic tests that don't live under the ccl folder. We've seen these time out a few times.

Fixes: #138035.

Release note: None