### PR TITLE
importer: skip TestExportImportBank under race

### DIFF
--- a/pkg/sql/importer/exportcsv_test.go
+++ b/pkg/sql/importer/exportcsv_test.go
@@ -98,7 +98,10 @@ func TestExportImportBank(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	db, _, cleanup := setupExportableBank(t, 3, 100)
+	skip.UnderRace(t, "times out")
+
+	const nodes = 3
+	db, _, cleanup := setupExportableBank(t, nodes, 100)
 	defer cleanup()
 
 	// Add some unicode to prove FmtExport works as advertised.


### PR DESCRIPTION
I think this is the last multi-node test that isn't skipped under race in `importer` package.

Fixes: #139212.

Release note: None