### PR TITLE
scripts: include newline before appending to bashrc

### DIFF
--- a/build/bootstrap/bootstrap-debian.sh
+++ b/build/bootstrap/bootstrap-debian.sh
@@ -31,11 +31,13 @@ sudo apt-get install -y --no-install-recommends \
 
 # pnpm doesn't provide a Debian repository, and supports either `curl | sh` or `npm install -g` installations.
 curl -fsSL https://get.pnpm.io/install.sh | env PNPM_VERSION=8.6.6 sh -
+echo -e '\n' >> ~/.bashrc
 
 sudo adduser "${USER}" docker
 
 # Configure environment variables.
 echo 'export PATH="${PATH}:$HOME/go/src/github.com/cockroachdb/cockroach/bin:/usr/local/go/bin"' >> ~/.bashrc_bootstrap
+echo -e '\n' >> ~/.bashrc
 echo '. ~/.bashrc_bootstrap' >> ~/.bashrc
 . ~/.bashrc_bootstrap
 


### PR DESCRIPTION
`pnpm` tool is installed in gceworker as a part of bootstraping the gceworker vm. This installation
also writes to `~/.bashrc` file inside the same vm without putting the trailing newline. This resulted
in new appends happening at the wrong line, which effectively rendered any new command append a code comment.
example:
before: `command1` is a new append

`# pnpm ends herecommand1`

after: `command1` is a new append
`#pnpm ends here`
`command1`

This commit adds newline at two different instances.
First after the installation of `pnpm` and before
appending `. ~/.bashrc_bootstrap`.

Part of DEVINF-1371