### PR TITLE
pkg/cli: table dump upload fixes

### DIFF
--- a/pkg/cli/testdata/upload/logs
+++ b/pkg/cli/testdata/upload/logs
@@ -16,6 +16,7 @@ upload-logs
   }
 }
 ----
+=== uploading logs
 Create DD Archive: https://api.us5.datadoghq.com/api/v2/logs/config/archives
 Create DD Archive: {"data":{"type":"archives","attributes":{"name":"abc-20241114000000","query":"-*","destination":{"type":"gcs","path":"ABC/abc-20241114000000","bucket":"debugzip-archives","integration":{"project_id":"arjun-sandbox-424904","client_email":"datadog-archive@arjun-sandbox-424904.iam.gserviceaccount.com"}}}}}
 GCS Upload: ABC/abc-20241114000000/dt=20240716/hour=17/1/cockroach.hostname.username.2024-07-16T17_51_43Z.048498.log:
@@ -43,6 +44,7 @@ upload-logs log-format=crdb-v2
   }
 }
 ----
+=== uploading logs
 Failed to upload logs: decoding on line 2: malformed log entry
 Upload ID: abc-20241114000000
 debug zip upload debugDir --dd-api-key=dd-api-key --dd-app-key=dd-app-key --cluster=ABC --include=logs --log-format=crdb-v2
@@ -77,6 +79,7 @@ upload-logs log-format=crdb-v1
   }
 }
 ----
+=== uploading logs
 Create DD Archive: https://api.us5.datadoghq.com/api/v2/logs/config/archives
 Create DD Archive: {"data":{"type":"archives","attributes":{"name":"abc-20241114000000","query":"-*","destination":{"type":"gcs","path":"ABC/abc-20241114000000","bucket":"debugzip-archives","integration":{"project_id":"arjun-sandbox-424904","client_email":"datadog-archive@arjun-sandbox-424904.iam.gserviceaccount.com"}}}}}
 GCS Upload: ABC/abc-20241114000000/dt=20240716/hour=17/1/cockroach.node1.username.2024-07-16T17_51_43Z.048498.log:
@@ -107,6 +110,7 @@ upload-logs
   }
 }
 ----
+=== uploading logs
 Logs API Hook: https://http-intake.logs.us5.datadoghq.com/api/v2/logs
 Logs API Hook: {"goroutine":100,"file":"server/env_sampler.go","line":125,"message":"failed to start query profiler worker: failed to detect cgroup memory limit: failed to read memory cgroup from cgroups file: /proc/self/cgroup: open /proc/self/cgroup: no such file or directory","counter":33,"tenant_id":"1","timestamp":0,"severity":"WARNING","channel":"DEV","ddtags":"cluster:ABC,env:debug,node_id:1,service:CRDB-SH,source:cockroachdb,upload_id:abc-20241114000000"}
 Logs API Hook: {"goroutine":100,"file":"server/node.go","line":533,"message":"initialized store s1","counter":24,"tenant_id":"1","timestamp":0,"severity":"INFO","channel":"DEV","ddtags":"cluster:ABC,env:debug,node_id:1,service:CRDB-SH,source:cockroachdb,upload_id:abc-20241114000000"}
@@ -134,6 +138,7 @@ upload-logs
   }
 }
 ----
+=== uploading logs
 Create DD Archive: https://api.us5.datadoghq.com/api/v2/logs/config/archives
 Create DD Archive: {"data":{"type":"archives","attributes":{"name":"abc-20241114000000","query":"-*","destination":{"type":"gcs","path":"ABC/abc-20241114000000","bucket":"debugzip-archives","integration":{"project_id":"arjun-sandbox-424904","client_email":"datadog-archive@arjun-sandbox-424904.iam.gserviceaccount.com"}}}}}
 GCS Upload: ABC/abc-20241114000000/dt=20240716/hour=17/1/cockroach.hostname.username.2024-07-16T17_51_43Z.048498.log:

--- a/pkg/cli/testdata/upload/profiles
+++ b/pkg/cli/testdata/upload/profiles
@@ -11,6 +11,7 @@ upload-profiles
   }
 }
 ----
+=== uploading profiles
 Upload ID: abc-20241114000000
 debug zip upload debugDir --dd-api-key=dd-api-key --dd-app-key=dd-app-key --cluster=ABC --include=profiles
 {"start":"","end":"","attachments":["cpu.pprof","heap.pprof"],"tags_profiler":"cluster:ABC,env:debug,node_id:1,service:CRDB-SH,source:cockroachdb,upload_id:abc-20241114000000","family":"go","version":"4"}
@@ -35,6 +36,7 @@ upload-profiles tags=foo:bar
   }
 }
 ----
+=== uploading profiles
 Upload ID: abc-20241114000000
 debug zip upload debugDir --dd-api-key=dd-api-key --dd-app-key=dd-app-key --tags=foo:bar --cluster=ABC --include=profiles
 {"start":"","end":"","attachments":["cpu.pprof","heap.pprof"],"tags_profiler":"cluster:ABC,env:debug,foo:bar,node_id:1,service:CRDB-SH,source:cockroachdb,upload_id:abc-20241114000000","family":"go","version":"4"}
@@ -53,6 +55,7 @@ upload-profiles tags=customer:user-given-name,cluster:XYZ
   }
 }
 ----
+=== uploading profiles
 Upload ID: abc-20241114000000
 debug zip upload debugDir --dd-api-key=dd-api-key --dd-app-key=dd-app-key --tags=customer:user-given-name,cluster:XYZ --cluster=ABC --include=profiles
 {"start":"","end":"","attachments":["cpu.pprof"],"tags_profiler":"cluster:XYZ,customer:user-given-name,env:debug,foo:bar,node_id:1,service:CRDB-SH,source:cockroachdb,upload_id:abc-20241114000000","family":"go","version":"4"}
@@ -66,6 +69,7 @@ upload-profiles
   }
 }
 ----
+=== uploading profiles
 Upload ID: abc-20241114000000
 debug zip upload debugDir --dd-api-key=dd-api-key --dd-app-key=dd-app-key --cluster=ABC --include=profiles
 
@@ -83,6 +87,7 @@ upload-profiles tags=env:SH
   }
 }
 ----
+=== uploading profiles
 Upload ID: abc-20241114000000
 debug zip upload debugDir --dd-api-key=dd-api-key --dd-app-key=dd-app-key --tags=env:SH --cluster=ABC --include=profiles
 {"start":"","end":"","attachments":["cpu.pprof","heap.pprof"],"tags_profiler":"cluster:ABC,env:SH,node_id:1,service:CRDB-SH,source:cockroachdb,upload_id:abc-20241114000000","family":"go","version":"4"}
@@ -101,6 +106,7 @@ upload-profiles tags=ERR
   }
 }
 ----
+=== uploading profiles
 Failed to upload profiles: failed to upload profiles of node 1: status: 400, body: 'runtime' is a required field
 Upload ID: abc-20241114000000
 debug zip upload debugDir --dd-api-key=dd-api-key --dd-app-key=dd-app-key --tags=ERR --cluster=ABC --include=profiles

--- a/pkg/cli/testdata/upload/tables
+++ b/pkg/cli/testdata/upload/tables
@@ -5,10 +5,11 @@ upload-tables
   }
 }
 ----
-Logs API Hook: claim_instance_id=NULL	claim_session_id=NULL	created=2024-12-11 07:39:23.165132	created_by_id=NULL	created_by_type=NULL	ddtags=env:debug,source:debug-zip,upload_id:abc-20241114000000,cluster:ABC,table:crdb_internal.system_jobs	id=100	last_run=NULL	num_runs=NULL	payload=redacted	progress=map[Details:map[keyVisualizerProgress:map[]] Progress:<nil> modified_micros:1.733902763165132e+15 trace_id:0]	status=running	
-Logs API Hook: claim_instance_id=NULL	claim_session_id=NULL	created=2024-12-11 07:39:23.366318	created_by_id=3	created_by_type=node	ddtags=env:debug,source:debug-zip,upload_id:abc-20241114000000,cluster:ABC,table:crdb_internal.system_jobs	id=101	last_run=NULL	num_runs=NULL	payload=redacted	progress=map[Details:map[pollJobsStats:map[]] Progress:<nil> modified_micros:1.733902763366318e+15 trace_id:0]	status=running	
-Logs API Hook: claim_instance_id=NULL	claim_session_id=NULL	created=2024-12-11 07:39:23.374069	created_by_id=NULL	created_by_type=NULL	ddtags=env:debug,source:debug-zip,upload_id:abc-20241114000000,cluster:ABC,table:crdb_internal.system_jobs	id=103	last_run=NULL	num_runs=NULL	payload=redacted	progress=map[Details:map[update_sql_activity:map[]] Progress:<nil> modified_micros:1.733902763374069e+15 trace_id:0]	status=running	
-Logs API Hook: claim_instance_id=NULL	claim_session_id=NULL	created=2024-12-11 07:39:23.378479	created_by_id=NULL	created_by_type=NULL	ddtags=env:debug,source:debug-zip,upload_id:abc-20241114000000,cluster:ABC,table:crdb_internal.system_jobs	id=104	last_run=NULL	num_runs=NULL	payload=redacted	progress=map[Details:map[mvcc_statistics_progress:map[]] Progress:<nil> modified_micros:1.733902763378479e+15 trace_id:0]	status=running	
+=== uploading tables
+Logs API Hook: claim_instance_id=<nil>	claim_session_id=<nil>	created=2024-12-11 07:39:23.165132	created_by_id=<nil>	created_by_type=<nil>	ddtags=env:debug,source:debug-zip,upload_id:abc-20241114000000,cluster:ABC,table:crdb_internal.system_jobs	id=100	last_run=<nil>	num_runs=<nil>	payload=redacted	progress=map[Details:map[keyVisualizerProgress:map[]] Progress:<nil> modified_micros:1.733902763165132e+15 trace_id:0]	status=running	
+Logs API Hook: claim_instance_id=<nil>	claim_session_id=<nil>	created=2024-12-11 07:39:23.366318	created_by_id=3	created_by_type=node	ddtags=env:debug,source:debug-zip,upload_id:abc-20241114000000,cluster:ABC,table:crdb_internal.system_jobs	id=101	last_run=<nil>	num_runs=<nil>	payload=redacted	progress=map[Details:map[pollJobsStats:map[]] Progress:<nil> modified_micros:1.733902763366318e+15 trace_id:0]	status=running	
+Logs API Hook: claim_instance_id=<nil>	claim_session_id=<nil>	created=2024-12-11 07:39:23.374069	created_by_id=<nil>	created_by_type=<nil>	ddtags=env:debug,source:debug-zip,upload_id:abc-20241114000000,cluster:ABC,table:crdb_internal.system_jobs	id=103	last_run=<nil>	num_runs=<nil>	payload=redacted	progress=map[Details:map[update_sql_activity:map[]] Progress:<nil> modified_micros:1.733902763374069e+15 trace_id:0]	status=running	
+Logs API Hook: claim_instance_id=<nil>	claim_session_id=<nil>	created=2024-12-11 07:39:23.378479	created_by_id=<nil>	created_by_type=<nil>	ddtags=env:debug,source:debug-zip,upload_id:abc-20241114000000,cluster:ABC,table:crdb_internal.system_jobs	id=104	last_run=<nil>	num_runs=<nil>	payload=redacted	progress=map[Details:map[mvcc_statistics_progress:map[]] Progress:<nil> modified_micros:1.733902763378479e+15 trace_id:0]	status=running	
 Logs API Hook: contended=t	database_name=cct_tpcc	ddtags=env:debug,source:debug-zip,upload_id:abc-20241114000000,cluster:ABC,table:crdb_internal.cluster_locks	durability=Unreplicated	duration=00:00:00.01032	granted=t	index_name=	isolation_level=SERIALIZABLE	lock_key_pretty="/Table/108/1/""\x80""/27/0"	lock_strength=Exclusive	range_id=240	schema_name=public	table_id=108	table_name=warehouse	ts=2024-11-25 09:11:26.185818	txn_id=948ef211-1fda-41c7-9393-64c46b3e60b6	
 Logs API Hook: contended=t	database_name=cct_tpcc	ddtags=env:debug,source:debug-zip,upload_id:abc-20241114000000,cluster:ABC,table:crdb_internal.cluster_locks	durability=Unreplicated	duration=2562047:47:16.854775	granted=f	index_name=	isolation_level=SERIALIZABLE	lock_key_pretty="/Table/108/1/""\x80""/27/0"	lock_strength=Exclusive	range_id=240	schema_name=public	table_id=108	table_name=warehouse	ts=2024-11-25 09:11:26.185818	txn_id=948ef211-1fda-41c7-9393-64c46b3e60b6	
 Logs API Hook: ddtags=env:debug,source:debug-zip,upload_id:abc-20241114000000,cluster:ABC,table:crdb_internal.leases,node_id:2	deleted=f	expiration=2024-12-11 07:44:24.205086	name=statement_diagnostics	node_id=1	parent_id=1	table_id=36	
@@ -16,11 +17,11 @@ Logs API Hook: ddtags=env:debug,source:debug-zip,upload_id:abc-20241114000000,cl
 Logs API Hook: ddtags=env:debug,source:debug-zip,upload_id:abc-20241114000000,cluster:ABC,table:crdb_internal.leases,node_id:2	deleted=f	expiration=2024-12-11 07:44:31.289861	name=settings	node_id=1	parent_id=1	table_id=6	
 Logs API Hook: ddtags=env:debug,source:debug-zip,upload_id:abc-20241114000000,cluster:ABC,table:crdb_internal.leases,node_id:2	deleted=f	expiration=2024-12-11 07:44:44.824583	name=descriptor	node_id=1	parent_id=1	table_id=3	
 Logs API Hook: ddtags=env:debug,source:debug-zip,upload_id:abc-20241114000000,cluster:ABC,table:crdb_internal.leases,node_id:2	deleted=f	expiration=2024-12-11 07:44:49.537097	name=external_connections	node_id=1	parent_id=1	table_id=53	
-Logs API Hook: ddtags=env:debug,source:debug-zip,upload_id:abc-20241114000000,cluster:ABC,table:crdb_internal.node_metrics,node_id:1	name=gossip.connections.incoming	store_id=NULL	value=0	
-Logs API Hook: ddtags=env:debug,source:debug-zip,upload_id:abc-20241114000000,cluster:ABC,table:crdb_internal.node_metrics,node_id:1	name=jobs.row_level_ttl.select_duration-p99.9	store_id=NULL	value=0	
+Logs API Hook: ddtags=env:debug,source:debug-zip,upload_id:abc-20241114000000,cluster:ABC,table:crdb_internal.node_metrics,node_id:1	name=gossip.connections.incoming	store_id=<nil>	value=0	
+Logs API Hook: ddtags=env:debug,source:debug-zip,upload_id:abc-20241114000000,cluster:ABC,table:crdb_internal.node_metrics,node_id:1	name=jobs.row_level_ttl.select_duration-p99.9	store_id=<nil>	value=0	
 Logs API Hook: ddtags=env:debug,source:debug-zip,upload_id:abc-20241114000000,cluster:ABC,table:crdb_internal.node_metrics,node_id:1	name=leases.transfers.success	store_id=1	value=0	
 Logs API Hook: ddtags=env:debug,source:debug-zip,upload_id:abc-20241114000000,cluster:ABC,table:crdb_internal.node_metrics,node_id:1	name=range.snapshots.upreplication.sent-bytes	store_id=1	value=0	
-Logs API Hook: ddtags=env:debug,source:debug-zip,upload_id:abc-20241114000000,cluster:ABC,table:crdb_internal.node_metrics,node_id:1	name=sql.restart_savepoint.rollback.count.internal	store_id=NULL	value=0	
+Logs API Hook: ddtags=env:debug,source:debug-zip,upload_id:abc-20241114000000,cluster:ABC,table:crdb_internal.node_metrics,node_id:1	name=sql.restart_savepoint.rollback.count.internal	store_id=<nil>	value=0	
 Logs API Hook: ddtags=env:debug,source:debug-zip,upload_id:abc-20241114000000,cluster:ABC,table:crdb_internal.node_metrics,node_id:1	name=storage.iterator.category-pebble-ingest.block-load.latency-sum	store_id=1	value=0	
 Logs API Hook: ddtags=env:debug,source:debug-zip,upload_id:abc-20241114000000,cluster:ABC,table:system.namespace	id=1	name=system	parentID=0	parentSchemaID=0	
 Logs API Hook: ddtags=env:debug,source:debug-zip,upload_id:abc-20241114000000,cluster:ABC,table:system.namespace	id=100	name=defaultdb	parentID=0	parentSchemaID=0	
@@ -33,9 +34,6 @@ Logs API Hook: https://http-intake.logs.us5.datadoghq.com/api/v2/logs
 Logs API Hook: https://http-intake.logs.us5.datadoghq.com/api/v2/logs
 Logs API Hook: https://http-intake.logs.us5.datadoghq.com/api/v2/logs
 Upload ID: abc-20241114000000
+View as logs here: https://us5.datadoghq.com/logs?query=source:debug-zip&upload_id:abc-20241114000000
+View as tables here: https://us5.datadoghq.com/dashboard/ipq-44t-ez8/table-dumps-from-debug-zip?tpl_var_upload_id%5B0%5D=abc-20241114000000
 debug zip upload debugDir --dd-api-key=dd-api-key --dd-app-key=dd-app-key --cluster=ABC --include=tables
-uploaded crdb_internal.cluster_locks.txt
-uploaded crdb_internal.system_jobs.txt
-uploaded nodes/1/crdb_internal.node_metrics.txt
-uploaded nodes/2/crdb_internal.leases.txt
-uploaded system.namespace.txt


### PR DESCRIPTION
This PR adds a few fixes to the tsdump upload flow --

----

pkg/cli: handle token too long scenario with table dump upload

This commit makes the following changes:
  * Handle the "token too long" scenario while scanning the table dump
    files. The bufio packages sets a default MaxTokenSize to 64KB. We
    can set a custom buffer to be used while scanning to avoid such
    scenarios.
  * Add print statements for when files are skipped due to being empty
  * Skip files that don't exist in the debug

Epic: none
Release note: None

----

pkg/cli: improve concurrency of tabledump upload

Currently, there the table dumps are read concurrency. One go routine
reads one table dumps at a time and uploads the parsed content in
batches. These batches are uploaded serially. This can get very slow
when the size of the table is large.

So, this commit fixes that by introducing two go routine pools. 1 is
responsible for reading the table dumps and parsing them. The workers
then hand off the parsed content in batches to the 2nd pool that uploads
them to datadog. This way, the upload of batches also happen
concurrently.

Epic: none
Release note: None
