### PR TITLE
tablemetadatacache: convert left joins to inner joins

### DIFF
--- a/pkg/sql/tablemetadatacache/table_metadata_batch_iterator.go
+++ b/pkg/sql/tablemetadatacache/table_metadata_batch_iterator.go
@@ -265,8 +265,8 @@ LEFT JOIN (
     FROM system.table_statistics 
     GROUP BY "tableID"
 ) ts ON ts."tableID" = t.id
-LEFT JOIN system.namespace db_name ON t."parentID" = db_name.id AND db_name."parentID" = 0
-LEFT JOIN system.namespace schema_name ON t."parentSchemaID" = schema_name.id AND schema_name."parentID" = t."parentID",
+JOIN system.namespace db_name ON t."parentID" = db_name.id AND db_name."parentID" = 0
+JOIN system.namespace schema_name ON t."parentSchemaID" = schema_name.id AND schema_name."parentID" = t."parentID",
 crdb_internal.pb_to_json('cockroach.sql.sqlbase.Descriptor', t.descriptor) AS d
 %[1]s
 ORDER BY (t."parentID", t."parentSchemaID", t.name);


### PR DESCRIPTION
When scanning `system.namespace` entries for the table metadata
update job, we were using LEFT JOIN to join parent and schema ids
in system.namespace entries with their `name` column, also in
system.namespace. It's seemingly possible that unknown schema failures
can put us in a state where there may not be name entries for all
schema ids present in `system.namespace`. This leads to `NULL` results for
schemaName and cols, something the  results handler  was not anticipating.
These should really be inner joins since we cannot fetch stats for any
entries unable  provide a fully qualified name.

Epic: none
Fixes: https://github.com/cockroachdb/cockroach/issues/139293