### PR TITLE
roachtest/cdc: skip cdc/bank

### DIFF
--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -2294,6 +2294,7 @@ func registerCDC(r registry.Registry) {
 	r.Add(registry.TestSpec{
 		Name:             "cdc/bank",
 		Owner:            `cdc`,
+		Skip:             "#139109",
 		Cluster:          r.MakeClusterSpec(4, spec.WorkloadNode()),
 		Leases:           registry.MetamorphicLeases,
 		CompatibleClouds: registry.AllExceptAWS,


### PR DESCRIPTION
This patch skips the cdc/bank test, as it has been broken since https://github.com/cockroachdb/cockroach/pull/137947. This
patch disables the test while we work on the fix.

Informs: https://github.com/cockroachdb/cockroach/issues/139109
Release note: none
Epic: none