### PR TITLE
roachtest: only run 30 node backfill tests in full ac mode

### DIFF
--- a/pkg/cmd/roachtest/tests/perturbation/index_backfill.go
+++ b/pkg/cmd/roachtest/tests/perturbation/index_backfill.go
@@ -42,6 +42,13 @@ func (b backfill) setupMetamorphic(rng *rand.Rand) variations {
 	if v.mem == spec.Low {
 		v.mem = spec.Standard
 	}
+
+	// TODO(#139319): This can be removed once we stop testing the non "full"
+	// mode. Without full AC, these tests can OOM.
+	if v.numNodes >= 30 && (v.acMode == elasticOnlyBoth || v.acMode == fullNormalElasticRepl) {
+		v.acMode = fullBoth
+	}
+
 	// TODO(#136848): The backfill test will cause WAL failover resulting in
 	// OOMs even with high memory configurations. This test passes without WAL
 	// failover enabled or with more vCPUs per node.


### PR DESCRIPTION
In the non-full AC modes, a node can OOM during the fill period and the test will fail. This impacts the perturbation/metamorphic/backfill test.

Fixes: #139302
Informs: #139319

Release note: None