### PR TITLE
rpc,server: investigate regression caused by #138368

### DIFF
--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -1875,9 +1875,34 @@ func (n *Node) Batch(ctx context.Context, args *kvpb.BatchRequest) (*kvpb.BatchR
 
 // BatchStream implements the kvpb.InternalServer interface.
 func (n *Node) BatchStream(stream kvpb.Internal_BatchStreamServer) error {
-	return n.batchStreamImpl(stream, func(ba *kvpb.BatchRequest) error {
-		return stream.RecvMsg(ba)
-	})
+	ctx := stream.Context()
+	for {
+		argsAlloc := new(struct {
+			args kvpb.BatchRequest
+			reqs [1]kvpb.RequestUnion
+		})
+		args := &argsAlloc.args
+		args.Requests = argsAlloc.reqs[:0]
+
+		err := stream.RecvMsg(args)
+		if err != nil {
+			// From grpc.ServerStream.Recv:
+			// > It returns io.EOF when the client has performed a CloseSend.
+			if errors.Is(err, io.EOF) {
+				return nil
+			}
+			return err
+		}
+
+		br, err := n.Batch(ctx, args)
+		if err != nil {
+			return err
+		}
+		err = stream.Send(br)
+		if err != nil {
+			return err
+		}
+	}
 }
 
 func (n *Node) batchStreamImpl(


### PR DESCRIPTION
[Branch here.](https://github.com/tbg/cockroach/tree/tbg-drpc)

We observed that #138368 reliably lowers performance by ~1% as measured by time/op in BenchmarkSysbench/SQL/3node/oltp_read_write.

This commit (`server: give Node.BatchStream its own impl`) not only claws back this 1% regression, it actually achieves another 1% improvement on top (when comparing "pr plus my commit" vs "master before pr"). Remarkably, the code change in this commit is a partial revert of a refactor introduced in the PR, and since nothing in the PR should've made performance _better_ (after all, the PR introduced another setting to check, and the setting is off), it's surprising that the commit actually _gains_ 1.73% vs master:

```
old:  f9df57e Merge #137984
new:  826b922 server: give Node.BatchStream its own impl
args: benchdiff "--old" "lastmerge" "./pkg/sql/tests" "-b" "-r" "Sysbench/SQL/3node/oltp_read_write" "-d" "1000x" "-c" "20"
name                                   old time/op    new time/op    delta
Sysbench/SQL/3node/oltp_read_write-24    11.7ms ± 1%    11.5ms ± 1%  -1.73%  (p=0.000 n=19+20)

name                                   old alloc/op   new alloc/op   delta
Sysbench/SQL/3node/oltp_read_write-24    2.20MB ± 3%    2.19MB ± 3%    ~     (p=0.968 n=20+20)

name                                   old allocs/op  new allocs/op  delta
Sysbench/SQL/3node/oltp_read_write-24     10.9k ± 2%     10.9k ± 2%    ~     (p=0.703 n=20+20)
```

To circle in on this more, I wanted to see if pr+commit vs pr produces a 2% speed-up. I didn't even have to run this for very long, it's pretty clear that it does (p-value is basically zero):

```
old:  b0ea57c server: fix drpc end-to-end test
new:  826b922 server: give Node.BatchStream its own impl
args: benchdiff "--old" "HEAD~" "./pkg/sql/tests" "-b" "-r" "Sysbench/SQL/3node/oltp_read_write" "-d" "1000x" "-c" "20"

running benchmarks:
 name                                   old time/op    new time/op    delta
Sysbench/SQL/3node/oltp_read_write-24    11.9ms ± 1%    11.6ms ± 1%  -2.33%  (p=0.000 n=8+8)

name                                   old alloc/op   new alloc/op   delta
Sysbench/SQL/3node/oltp_read_write-24    2.17MB ± 4%    2.19MB ± 2%    ~     (p=0.959 n=8+8)

name                                   old allocs/op  new allocs/op  delta
Sysbench/SQL/3node/oltp_read_write-24     10.8k ± 2%     10.8k ± 2%    ~     (p=0.627 n=8+8)
```

I don't know what to make of this yet, but am reminded of [this segment](https://youtu.be/r-TLSBdHe1A?t=614) of "Performance Matters" by Emery Berger.

A few days later, I re-ran it (note the "new" SHA has changed, but I only fixed a typo in the commit msg), and the regression is gone (see below). Something I did in the interim was blow my build cache:

```
./dev cache --down --clean; git checkout tbg-drpc && bazel clean --expunge && rm -rf benchdiff && benchdiff --old HEAD~ ./pkg/sql/tests -b -r Sysbench/SQL/3node/oltp_read_write -d 1000x -c 20
```

```
old:  b0ea57c server: fix drpc end-to-end test
new:  1ac52a7 server: give Node.BatchStream its own impl
args: benchdiff "--old" "HEAD~" "./pkg/sql/tests" "-b" "-r" "Sysbench/SQL/3node/oltp_read_write" "-d" "1000x" "-c" "20"

name                                   old time/op    new time/op    delta
Sysbench/SQL/3node/oltp_read_write-24    13.3ms ± 2%    13.2ms ± 2%    ~     (p=0.947 n=20+20)

name                                   old alloc/op   new alloc/op   delta
Sysbench/SQL/3node/oltp_read_write-24    2.15MB ± 1%    2.15MB ± 1%  +0.21%  (p=0.049 n=16+17)

name                                   old allocs/op  new allocs/op  delta
Sysbench/SQL/3node/oltp_read_write-24     10.7k ± 1%     10.7k ± 1%  +0.38%  (p=0.011 n=17+19)
```

so whatever this is, it's not stable at all.

Closes https://github.com/cockroachdb/cockroach/issues/139022.