### PR TITLE
ccl/multiregionccl: TestRegionLivenessProber add debugging to deflake

### DIFF
--- a/pkg/sql/regionliveness/BUILD.bazel
+++ b/pkg/sql/regionliveness/BUILD.bazel
@@ -27,6 +27,7 @@ go_library(
         "//pkg/sql/sqlliveness/slbase",
         "//pkg/sql/types",
         "//pkg/util/encoding",
+        "//pkg/util/log",
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",
     ],


### PR DESCRIPTION
Currently, the test TestRegionLivenessProber has flakes which are not easily reproducible. This patch adds debug code to help determine the root cause of the flakes.

Fixes: #138231

Release note: None