### PR TITLE
ui: fix statement diag reports when min exec latency is null

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/api/statementDiagnosticsApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/statementDiagnosticsApi.ts
@@ -9,7 +9,7 @@ import moment from "moment-timezone";
 
 import { fetchData } from "src/api";
 
-import { NumberToDuration } from "../util";
+import { DurationToMomentDuration, NumberToDuration } from "../util";
 
 const STATEMENT_DIAGNOSTICS_PATH = "_status/stmtdiagreports";
 const CANCEL_STATEMENT_DIAGNOSTICS_PATH =
@@ -33,17 +33,17 @@ export async function getStatementDiagnosticsReports(): Promise<StatementDiagnos
     STATEMENT_DIAGNOSTICS_PATH,
   );
   return response.reports.map(report => {
+    const minExecutionLatency = report.min_execution_latency
+      ? DurationToMomentDuration(report.min_execution_latency)
+      : null;
     return {
       id: report.id.toString(),
       statement_fingerprint: report.statement_fingerprint,
       completed: report.completed,
       statement_diagnostics_id: report.statement_diagnostics_id.toString(),
-      requested_at: moment.unix(report.requested_at.seconds.toNumber()),
-      min_execution_latency: moment.duration(
-        report.min_execution_latency.seconds.toNumber(),
-        "seconds",
-      ),
-      expires_at: moment.unix(report.expires_at.seconds.toNumber()),
+      requested_at: moment.unix(report.requested_at?.seconds.toNumber()),
+      min_execution_latency: minExecutionLatency,
+      expires_at: moment.unix(report.expires_at?.seconds.toNumber()),
     };
   });
 }


### PR DESCRIPTION
A bug in db console was resulting in statement diagnostics reports to not work as intended. As a result, activating diagnostics didn't result in the intended state change which showed a user that a diagnostics report is running or downloadble.

This was happening in edge cases where reports "minExecutionLatency" response field was null, but the db console expected it to be populated. Now, db console should handle this edge case.

Fixes: #139340
Epic: none
Release note (bug fix): Fixes a bug where sometimes activating diagnostics for sql activity appears unresponsive, with no state or status update upon activating. Now, the status should always reflect that diagnosticsa are active or that a statement bundle is downloadable.