### PR TITLE
kvserver: start LeaseAppliedIndex from 10

### DIFF
--- a/pkg/kv/kvserver/batcheval/cmd_end_transaction_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_end_transaction_test.go
@@ -2364,6 +2364,7 @@ func TestSplitTriggerWritesInitialReplicaState(t *testing.T) {
 	expAppliedState := kvserverpb.RangeAppliedState{
 		RaftAppliedIndexTerm: stateloader.RaftInitialLogTerm,
 		RaftAppliedIndex:     stateloader.RaftInitialLogIndex,
+		LeaseAppliedIndex:    stateloader.InitialLeaseAppliedIndex,
 	}
 	loadedAppliedState, err := slRight.LoadRangeAppliedState(ctx, batch)
 	require.NoError(t, err)

--- a/pkg/kv/kvserver/replica_proposal_buf_test.go
+++ b/pkg/kv/kvserver/replica_proposal_buf_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/leases"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/raftlog"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/raftutil"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/stateloader"
 	"github.com/cockroachdb/cockroach/pkg/raft"
 	"github.com/cockroachdb/cockroach/pkg/raft/raftpb"
 	rafttracker "github.com/cockroachdb/cockroach/pkg/raft/tracker"
@@ -373,12 +374,12 @@ func TestProposalBuffer(t *testing.T) {
 	require.Equal(t, num, p.registered)
 	// We've flushed num requests, out of which one is a lease request (so that
 	// one did not increment the MLAI).
-	require.Equal(t, kvpb.LeaseAppliedIndex(num-1), b.assignedLAI)
+	require.Equal(t, kvpb.LeaseAppliedIndex(stateloader.InitialLeaseAppliedIndex+num-1), b.assignedLAI)
 	require.Equal(t, 2*propBufArrayMinSize, b.arr.len())
 	require.Equal(t, 1, b.evalTracker.Count())
 	proposals := r.consumeProposals()
 	require.Len(t, proposals, propBufArrayMinSize)
-	var lai kvpb.LeaseAppliedIndex
+	lai := kvpb.LeaseAppliedIndex(stateloader.InitialLeaseAppliedIndex)
 	for i, p := range proposals {
 		if i != leaseReqIdx {
 			lai++

--- a/pkg/kv/kvserver/stateloader/initial.go
+++ b/pkg/kv/kvserver/stateloader/initial.go
@@ -26,6 +26,19 @@ const (
 	RaftInitialLogTerm  = 5
 )
 
+const (
+	// InitialLeaseAppliedIndex is the starting LAI of a Range. All proposals are
+	// assigned higher LAIs.
+	//
+	// The LAIs <= InitialLeaseAppliedIndex are reserved, e.g. for injected
+	// out-of-order proposals in tests. A bunch of tests override LAI to 1, in
+	// order to force re-proposals. We don't want "real" proposals racing with
+	// injected ones, this can cause a closed timestamp regression.
+	//
+	// https://github.com/cockroachdb/cockroach/issues/70894#issuecomment-1881165404
+	InitialLeaseAppliedIndex = 10
+)
+
 // WriteInitialReplicaState sets up a new Range, but without writing an
 // associated Raft state (which must be written separately via
 // SynthesizeRaftState before instantiating a Replica). The main task is to
@@ -50,6 +63,7 @@ func WriteInitialReplicaState(
 	s := kvserverpb.ReplicaState{
 		RaftAppliedIndex:     truncState.Index,
 		RaftAppliedIndexTerm: truncState.Term,
+		LeaseAppliedIndex:    InitialLeaseAppliedIndex,
 		Desc: &roachpb.RangeDescriptor{
 			RangeID: desc.RangeID,
 		},


### PR DESCRIPTION
The LAI=1 is reserved for out-of-order proposals in tests. A bunch of tests override proposal's LAI to 1, in order to force reproposals. If these modified proposals race with a "real" proposal with LAI 1, this can cause a closed timestamp regression.

Fixes #131450