### PR TITLE
tablemetadatacache: cleanup batch iterator query 

### DIFF
--- a/pkg/sql/tablemetadatacache/table_metadata_batch_iterator.go
+++ b/pkg/sql/tablemetadatacache/table_metadata_batch_iterator.go
@@ -228,47 +228,38 @@ func (batchIter *tableMetadataBatchIterator) fetchNextBatch(ctx context.Context)
 // system.table_metadata.
 func newBatchQueryStatement(aostClause string) string {
 	return fmt.Sprintf(`
-WITH tables AS (
-    SELECT n.id,
-           n.name,
-           n."parentID",
-           n."parentSchemaID",
-           d.descriptor,
-           crdb_internal.table_span(n.id) as span
-    FROM system.namespace n
-    JOIN system.descriptor d ON n.id = d.id
-		%[1]s
-    WHERE (n."parentID", n."parentSchemaID", n.name) > ($1, $2, $3) AND n."parentSchemaID" != 0
-    ORDER BY (n."parentID", n."parentSchemaID", n.name)
-    LIMIT $4
-)
-SELECT t.id,
-       t.name,
-       t."parentID",
-       db_name.name as db_name,
-       t."parentSchemaID",
-       schema_name.name as schema_name,
-       json_array_length(d -> 'table' -> 'columns') as columns,
-       COALESCE(json_array_length(d -> 'table' -> 'indexes'), 0) as indexes,
-       CASE
-           WHEN d->'table'->>'isMaterializedView' = 'true' THEN 'MATERIALIZED_VIEW'
-           WHEN d->'table'->>'viewQuery' IS NOT NULL THEN 'VIEW'
-           WHEN d->'table'->'sequenceOpts' IS NOT NULL THEN 'SEQUENCE'
-           ELSE 'TABLE'
-           END as table_type,
-       (d->'table'->'autoStatsSettings'->>'enabled')::BOOL as auto_stats_enabled,
-       ts.last_updated as stats_last_updated,
-       t.span as span
-FROM tables t
+SELECT 
+    n.id,
+    n.name,
+    n."parentID",
+    db_name.name as db_name,
+    n."parentSchemaID",
+    schema_name.name as schema_name,
+    json_array_length(d->'table' -> 'columns') as columns,
+    COALESCE(json_array_length(d->'table' -> 'indexes'), 0) as indexes,
+    CASE
+        WHEN d->'table'->>'isMaterializedView' = 'true' THEN 'MATERIALIZED_VIEW'
+        WHEN d->'table'->>'viewQuery' IS NOT NULL THEN 'VIEW'
+        WHEN d->'table'->'sequenceOpts' IS NOT NULL THEN 'SEQUENCE'
+        ELSE 'TABLE'
+    END as table_type,
+    (d->'table'->'autoStatsSettings'->>'enabled')::BOOL as auto_stats_enabled,
+    ts.last_updated as stats_last_updated,
+    crdb_internal.table_span(n.id) as span
+FROM system.namespace n
+JOIN system.descriptor enc_desc ON n.id = enc_desc.id
+CROSS JOIN LATERAL crdb_internal.pb_to_json('cockroach.sql.sqlbase.Descriptor', enc_desc.descriptor) AS d
+JOIN system.namespace db_name ON n."parentID" = db_name.id AND db_name."parentID" = 0
+JOIN system.namespace schema_name ON n."parentSchemaID" = schema_name.id AND schema_name."parentID" = n."parentID"
 LEFT JOIN (
     SELECT "tableID", max("createdAt") as last_updated 
     FROM system.table_statistics 
     GROUP BY "tableID"
-) ts ON ts."tableID" = t.id
-JOIN system.namespace db_name ON t."parentID" = db_name.id AND db_name."parentID" = 0
-JOIN system.namespace schema_name ON t."parentSchemaID" = schema_name.id AND schema_name."parentID" = t."parentID",
-crdb_internal.pb_to_json('cockroach.sql.sqlbase.Descriptor', t.descriptor) AS d
+) ts ON ts."tableID" = n.id
 %[1]s
-ORDER BY (t."parentID", t."parentSchemaID", t.name);
+WHERE (n."parentID", n."parentSchemaID", n.name) > ($1, $2, $3) 
+  AND n."parentSchemaID" != 0
+ORDER BY n."parentID", n."parentSchemaID", n.name
+LIMIT $4
 `, aostClause)
 }

--- a/pkg/sql/tablemetadatacache/table_metadata_updater_test.go
+++ b/pkg/sql/tablemetadatacache/table_metadata_updater_test.go
@@ -125,6 +125,20 @@ func TestDataDrivenTableMetadataCacheUpdater(t *testing.T) {
 					return err.Error()
 				}
 				return "success"
+			case "explain-select-query":
+				q := newBatchQueryStatement("AS OF SYSTEM TIME '-1us'")
+				explainQuery := "EXPLAIN (REDACT) " + q
+				res := ""
+				// Query expects 4 arguments - parentID, parentSchemaID, name, limit.
+				rows, err := queryConn.Query(explainQuery, 1, 1, "", 20)
+				if err != nil {
+					return err.Error()
+				}
+				res, err = sqlutils.RowsToDataDrivenOutput(rows)
+				if err != nil {
+					return err.Error()
+				}
+				return explainQuery + "\n---\n" + res
 			default:
 				return "unknown command"
 			}

--- a/pkg/sql/tablemetadatacache/testdata/explain_tmj_select
+++ b/pkg/sql/tablemetadatacache/testdata/explain_tmj_select
@@ -1,0 +1,97 @@
+explain-select-query
+----
+----
+EXPLAIN (REDACT) 
+SELECT 
+    n.id,
+    n.name,
+    n."parentID",
+    db_name.name as db_name,
+    n."parentSchemaID",
+    schema_name.name as schema_name,
+    json_array_length(d->'table' -> 'columns') as columns,
+    COALESCE(json_array_length(d->'table' -> 'indexes'), 0) as indexes,
+    CASE
+        WHEN d->'table'->>'isMaterializedView' = 'true' THEN 'MATERIALIZED_VIEW'
+        WHEN d->'table'->>'viewQuery' IS NOT NULL THEN 'VIEW'
+        WHEN d->'table'->'sequenceOpts' IS NOT NULL THEN 'SEQUENCE'
+        ELSE 'TABLE'
+    END as table_type,
+    (d->'table'->'autoStatsSettings'->>'enabled')::BOOL as auto_stats_enabled,
+    ts.last_updated as stats_last_updated,
+    crdb_internal.table_span(n.id) as span
+FROM system.namespace n
+JOIN system.descriptor enc_desc ON n.id = enc_desc.id
+CROSS JOIN LATERAL crdb_internal.pb_to_json('cockroach.sql.sqlbase.Descriptor', enc_desc.descriptor) AS d
+JOIN system.namespace db_name ON n."parentID" = db_name.id AND db_name."parentID" = 0
+JOIN system.namespace schema_name ON n."parentSchemaID" = schema_name.id AND schema_name."parentID" = n."parentID"
+LEFT JOIN (
+    SELECT "tableID", max("createdAt") as last_updated 
+    FROM system.table_statistics 
+    GROUP BY "tableID"
+) ts ON ts."tableID" = n.id
+AS OF SYSTEM TIME '-1us'
+WHERE (n."parentID", n."parentSchemaID", n.name) > ($1, $2, $3) 
+  AND n."parentSchemaID" != 0
+ORDER BY n."parentID", n."parentSchemaID", n.name
+LIMIT $4
+
+---
+distribution: local
+vectorized: true
+
+• sort
+│ order: +"parentID",+"parentSchemaID",+name
+│
+└── • render
+    │
+    └── • hash join (right outer)
+        │ equality: (tableID) = (id)
+        │ left cols are key
+        │
+        ├── • group (streaming)
+        │   │ group by: tableID
+        │   │ ordered: +"tableID"
+        │   │
+        │   └── • scan
+        │         missing stats
+        │         table: table_statistics@primary
+        │         spans: FULL SCAN
+        │
+        └── • top-k
+            │ order: +"parentID",+"parentSchemaID",+name
+            │ k: 20
+            │
+            └── • hash join
+                │ equality: (parentID, parentSchemaID) = (id, id)
+                │
+                ├── • project set
+                │   │
+                │   └── • hash join
+                │       │ equality: (id) = (id)
+                │       │ left cols are key
+                │       │
+                │       ├── • scan
+                │       │     missing stats
+                │       │     table: descriptor@primary
+                │       │     spans: FULL SCAN
+                │       │
+                │       └── • filter
+                │           │ filter: "parentSchemaID" != ‹×›
+                │           │
+                │           └── • scan
+                │                 missing stats
+                │                 table: namespace@primary
+                │                 spans: 1 span
+                │
+                └── • lookup join
+                    │ table: namespace@primary
+                    │ equality: (id) = (parentID)
+                    │ pred: id != ‹×›
+                    │
+                    └── • scan
+                          missing stats
+                          table: namespace@primary
+                          spans: 1 span
+----
+----


### PR DESCRIPTION
Please note only the latest commit is for review.
-------------------------
This commit removes the CTE in the table metadata batch iterator
as it does not provide much value.

Epic: none

Release note: None