### PR TITLE
util/tracing: remove noop span

### DIFF
--- a/pkg/jobs/adopt.go
+++ b/pkg/jobs/adopt.go
@@ -69,7 +69,7 @@ func (r *Registry) maybeDumpTrace(resumerCtx context.Context, resumer Resumer, j
 	// could have been canceled at this point.
 	dumpCtx, _ := r.makeCtx()
 	sp := tracing.SpanFromContext(resumerCtx)
-	if sp == nil || sp.IsNoop() {
+	if sp == nil {
 		// Should never be true since TraceableJobs force real tracing spans to be
 		// attached to the context.
 		return

--- a/pkg/jobs/jobs.go
+++ b/pkg/jobs/jobs.go
@@ -127,7 +127,7 @@ type StartableJob struct {
 // recordings.
 type TraceableJob interface {
 	// ForceRealSpan forces the registry to create a real Span instead of a
-	// low-overhead non-recordable noop span.
+	// non-recordable no-op (nil) span.
 	ForceRealSpan() bool
 	// DumpTraceAfterRun determines whether the job's trace is dumped to disk at
 	// the end of every adoption.

--- a/pkg/kv/kvserver/replica_application_decoder.go
+++ b/pkg/kv/kvserver/replica_application_decoder.go
@@ -145,7 +145,7 @@ func (d *replicaDecoder) createTracingSpans(ctx context.Context) {
 			propCtx := ctx // raft scheduler's ctx
 			var propSp *tracing.Span
 			// If the client has a trace, put a child into propCtx.
-			if sp := tracing.SpanFromContext(cmd.proposal.Context()); sp != nil && !sp.IsNoop() {
+			if sp := tracing.SpanFromContext(cmd.proposal.Context()); sp != nil {
 				propCtx, propSp = sp.Tracer().StartSpanCtx(
 					propCtx, "local proposal", tracing.WithParent(sp),
 				)

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -184,7 +184,7 @@ func (r *Replica) evalAndPropose(
 
 		// Fork the proposal's context span so that the proposal's context
 		// can outlive the original proposer's context.
-		if s := tracing.SpanFromContext(ctx); s != nil && !s.IsNoop() {
+		if s := tracing.SpanFromContext(ctx); s != nil {
 			ctx, sp := tracing.ForkSpan(ctx, "async consensus")
 			proposal.ctx.Store(&ctx)
 			proposal.sp = sp

--- a/pkg/rpc/context.go
+++ b/pkg/rpc/context.go
@@ -783,7 +783,7 @@ func makeInternalClientAdapter(
 			// look closer to a remote call from the tracing point of view.
 			if separateTracers {
 				sp := tracing.SpanFromContext(ctx)
-				if sp != nil && !sp.IsNoop() {
+				if sp != nil {
 					// Fill in ba.TraceInfo. For remote RPCs (not done throught the
 					// internalClientAdapter), this is done by the TracingInternalClient
 					ba = ba.ShallowCopy()

--- a/pkg/rpc/nodedialer/nodedialer.go
+++ b/pkg/rpc/nodedialer/nodedialer.go
@@ -397,7 +397,7 @@ func maybeWrapInTracingClient(
 	ctx context.Context, client rpc.RestrictedInternalClient,
 ) rpc.RestrictedInternalClient {
 	sp := tracing.SpanFromContext(ctx)
-	if sp != nil && !sp.IsNoop() {
+	if sp != nil {
 		return &tracingInternalClient{RestrictedInternalClient: client}
 	}
 	return client
@@ -408,7 +408,7 @@ func (c *tracingInternalClient) Batch(
 	ctx context.Context, ba *kvpb.BatchRequest, opts ...grpc.CallOption,
 ) (*kvpb.BatchResponse, error) {
 	sp := tracing.SpanFromContext(ctx)
-	if sp != nil && !sp.IsNoop() {
+	if sp != nil {
 		ba = ba.ShallowCopy()
 		ba.TraceInfo = sp.Meta().ToProto()
 	}

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -1726,7 +1726,7 @@ func (n *Node) batchInternal(
 	// To avoid log spam for now we only log the trace if the request was an
 	// ExportRequest.
 	if pErr != nil && ctx.Err() != nil && args.IsSingleExportRequest() {
-		if sp := tracing.SpanFromContext(ctx); sp != nil && !sp.IsNoop() {
+		if sp := tracing.SpanFromContext(ctx); sp != nil {
 			recording := sp.GetConfiguredRecording()
 			if recording.Len() != 0 {
 				log.Infof(ctx, "batch request %s failed with error: %v\ntrace:\n%s", args.String(),
@@ -2058,7 +2058,7 @@ func setupSpanForIncomingRPC(
 			tracing.WithServerSpanKind)
 	}
 
-	if newSpan != nil && !newSpan.IsNoop() {
+	if newSpan != nil {
 		newSpan.SetLazyTag("request", ba.ShallowCopy())
 	}
 	return ctx, spanForRequest{

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -490,7 +490,7 @@ func (dsp *DistSQLPlanner) setupFlows(
 	// issued (either by the current goroutine directly or delegated to the
 	// DistSQL workers).
 	var numIssuedRequests int
-	if sp := tracing.SpanFromContext(origCtx); sp != nil && !sp.IsNoop() {
+	if sp := tracing.SpanFromContext(origCtx); sp != nil {
 		setupReq.TraceInfo = sp.Meta().ToProto()
 	}
 	resultChan := make(chan runnerResult, len(flows)-1)

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -2679,9 +2679,6 @@ func (st *SessionTracing) StartTracing(
 	if _, ok := st.ex.machine.CurState().(stateNoTxn); !ok {
 		txnCtx := st.ex.state.Ctx
 		sp := tracing.SpanFromContext(txnCtx)
-		if sp == nil {
-			return errors.Errorf("no txn span for SessionTracing")
-		}
 		// We're hijacking this span and we're never going to un-hijack it, so it's
 		// up to us to finish it.
 		sp.Finish()

--- a/pkg/sql/execinfra/processorsbase.go
+++ b/pkg/sql/execinfra/processorsbase.go
@@ -840,7 +840,7 @@ func ProcessorSpan(
 	eventListeners ...tracing.EventListener,
 ) (context.Context, *tracing.Span) {
 	sp := tracing.SpanFromContext(ctx)
-	if sp == nil || sp.IsNoop() {
+	if sp == nil {
 		return ctx, nil
 	}
 	var listenersOpt tracing.SpanOption

--- a/pkg/sql/instrumentation.go
+++ b/pkg/sql/instrumentation.go
@@ -458,10 +458,6 @@ func (ih *instrumentationHelper) Setup(
 			ih.needFinish = true
 			return ctx
 		}
-	} else {
-		if buildutil.CrdbTestBuild {
-			panic(errors.AssertionFailedf("the context doesn't have a tracing span"))
-		}
 	}
 
 	shouldSampleFirstEncounter := func() bool {

--- a/pkg/sql/txn_state.go
+++ b/pkg/sql/txn_state.go
@@ -276,9 +276,6 @@ func (ts *txnState) resetForNewSQLTxn(
 func (ts *txnState) finishSQLTxn() (txnID uuid.UUID, commitTimestamp hlc.Timestamp) {
 	ts.mon.Stop(ts.Ctx)
 	sp := tracing.SpanFromContext(ts.Ctx)
-	if sp == nil {
-		panic(errors.AssertionFailedf("No span in context? Was resetForNewSQLTxn() called previously?"))
-	}
 
 	if ts.recordingThreshold > 0 {
 		if elapsed := timeutil.Since(ts.recordingStart); elapsed >= ts.recordingThreshold {

--- a/pkg/util/tracing/bench_test.go
+++ b/pkg/util/tracing/bench_test.go
@@ -37,7 +37,6 @@ func BenchmarkTracer_StartSpanCtx(b *testing.B) {
 		opts              []SpanOption
 		regexpFilter      string
 	}{
-		{name: "none", defaultMode: TracingModeOnDemand},
 		{name: "real", defaultMode: TracingModeActiveSpansRegistry},
 		{name: "real,logtag", defaultMode: TracingModeActiveSpansRegistry,
 			opts: []SpanOption{WithLogTags(staticLogTags)}},

--- a/pkg/util/tracing/context.go
+++ b/pkg/util/tracing/context.go
@@ -44,18 +44,17 @@ func maybeWrapCtx(ctx context.Context, sp *Span) (context.Context, *Span) {
 	if ctx == noCtx {
 		return noCtx, sp
 	}
-	// NB: we check sp != nil explicitly because some callers want to remove a
-	// Span from a Context, and thus pass nil.
-	if sp != nil && sp.IsNoop() {
-		// If the context originally had the noop span, and we would now be wrapping
-		// the noop span in it again, we don't have to wrap at all and can save an
+	// NB: Some callers want to remove a Span from a Context, and thus pass nil.
+	if sp == nil {
+		// If the context originally had the nil span, and we would now be wrapping
+		// the nil span in it again, we don't have to wrap at all and can save an
 		// allocation.
 		//
 		// Note that applying this optimization for a nontrivial ctxSp would
 		// constitute a bug: A real, non-recording span might later start recording.
 		// Besides, the caller expects to get their own span, and will .Finish() it,
 		// leading to an extra, premature call to Finish().
-		if ctxSp := SpanFromContext(ctx); ctxSp != nil && ctxSp.IsNoop() {
+		if ctxSp := SpanFromContext(ctx); ctxSp == nil {
 			return ctx, sp
 		}
 	}

--- a/pkg/util/tracing/doc.go
+++ b/pkg/util/tracing/doc.go
@@ -66,10 +66,7 @@
 // Since this package is used pervasively, the implementation is very
 // performance-sensitive. It tries to avoid allocations (even
 // trying to avoid allocating Span objects[12] whenever possible), and avoids
-// doing work unless strictly necessary. One example of this is us checking to
-// see if a given Span is a "noop span"[13] (i.e. does not have any sinks
-// configured). This then lets us short-circuit work that would be discarded
-// anyway.
+// doing work unless strictly necessary.
 //
 // The tracing package internally makes use of OpenTelemetry[2]. This gives us
 // the ability to configure external collectors for tracing information,
@@ -96,5 +93,4 @@
 // [10]: `{Client,Server}Interceptor`
 // [11]: `SpanFromContext`
 // [12]: WithForceRealSpan
-// [13]: `Span.isNoop`
 package tracing

--- a/pkg/util/tracing/grpcinterceptor/grpc_interceptor.go
+++ b/pkg/util/tracing/grpcinterceptor/grpc_interceptor.go
@@ -155,7 +155,7 @@ func StreamServerInterceptor(tracer *tracing.Tracer) grpc.StreamServerIntercepto
 		// workaround for the following issue:
 		//
 		// https://github.com/cockroachdb/cockroach/issues/135686
-		if (sp == nil || sp.IsNoop()) && !tracing.SpanInclusionFuncForServer(tracer, spanMeta) {
+		if sp == nil && !tracing.SpanInclusionFuncForServer(tracer, spanMeta) {
 			return handler(srv, ss)
 		}
 

--- a/pkg/util/tracing/span.go
+++ b/pkg/util/tracing/span.go
@@ -31,11 +31,6 @@ import (
 // 2. /debug/requests endpoint (net/trace package); mostly useful for local debugging
 // 3. CRDB-internal trace span (powers SQL session tracing).
 //
-// When there is no need to allocate either of these three destinations,
-// a "noop span", i.e. an immutable *Span wrapping the *Tracer, may be
-// returned, to allow starting additional nontrivial Spans from the return
-// value later, when direct access to the tracer may no longer be available.
-//
 // The CockroachDB-internal Span (crdbSpan) is more complex because
 // rather than reporting to some external sink, the caller's "owner"
 // must propagate the trace data back across process boundaries towards
@@ -136,18 +131,6 @@ type Span struct {
 	finishStack debugutil.SafeStack
 }
 
-// IsNoop returns true if this span is a black hole - it doesn't correspond to a
-// CRDB span and it doesn't output either to an OpenTelemetry tracer, or to
-// net.Trace.
-//
-// As opposed to other spans, a noop span can be used after Finish(). In
-// practice, noop spans are pre-allocated by the Tracer and handed out to
-// everybody (shared) if the Tracer is configured to not always create real
-// spans (i.e. TracingModeOnDemand).
-func (sp *Span) IsNoop() bool {
-	return sp.i.isNoop()
-}
-
 // detectUseAfterFinish() checks whether sp has already been Finish()ed. If it
 // did, the behavior depends on the Tracer's configuration: if it was configured
 // to tolerate use-after-Finish, detectUseAfterFinish returns true. If it has
@@ -156,12 +139,9 @@ func (sp *Span) IsNoop() bool {
 // Exported methods on Span are supposed to call this and short-circuit if true
 // is returrned.
 //
-// Note that a nil or no-op span will return true.
+// Note that a nil span will return true.
 func (sp *Span) detectUseAfterFinish() bool {
 	if sp == nil {
-		return true
-	}
-	if sp.IsNoop() {
 		return true
 	}
 	alreadyFinished := atomic.LoadInt32(&sp.finished) != 0
@@ -217,6 +197,9 @@ func (sp *Span) decRef() bool {
 
 // Tracer exports the tracer this span was created using.
 func (sp *Span) Tracer() *Tracer {
+	if sp == nil {
+		return nil
+	}
 	sp.detectUseAfterFinish()
 	return sp.i.Tracer()
 }
@@ -244,7 +227,7 @@ func (sp *Span) Finish() {
 
 // finishInternal finishes the span.
 func (sp *Span) finishInternal() {
-	if sp == nil || sp.IsNoop() || sp.detectUseAfterFinish() {
+	if sp == nil || sp.detectUseAfterFinish() {
 		return
 	}
 	if sp.Tracer().debugUseAfterFinish {
@@ -466,8 +449,8 @@ func (sp *Span) Recordf(format string, args ...interface{}) {
 
 // RecordStructured adds a Structured payload to the Span. It will be added to
 // the recording even if the Span is not verbose; however it will be discarded
-// if the underlying Span has been optimized out (i.e. is a noop span). Payloads
-// may also be dropped due to sizing constraints.
+// if the underlying Span has been optimized out (i.e. is nil). Payloads may
+// also be dropped due to sizing constraints.
 //
 // RecordStructured does not take ownership of item; it marshals it into an Any
 // proto.
@@ -583,9 +566,6 @@ func (sp *Span) SpanID() tracingpb.SpanID {
 func (sp *Span) OperationName() string {
 	if sp == nil {
 		return "<nil>"
-	}
-	if sp.IsNoop() {
-		return "noop"
 	}
 	sp.detectUseAfterFinish()
 	return sp.i.crdb.operation
@@ -746,7 +726,7 @@ func (sp *Span) reset(
 
 // SetOtelStatus sets the status of the OpenTelemetry span (if any).
 func (sp *Span) SetOtelStatus(code codes.Code, msg string) {
-	if sp.i.otelSpan == nil {
+	if sp == nil || sp.i.otelSpan == nil {
 		return
 	}
 	sp.i.otelSpan.SetStatus(codes.Error, msg)

--- a/pkg/util/tracing/span.go
+++ b/pkg/util/tracing/span.go
@@ -210,7 +210,7 @@ func (sp *Span) String() string {
 
 // Redactable returns true if this Span's tracer is marked redactable.
 func (sp *Span) Redactable() bool {
-	if sp == nil || sp.i.isNoop() {
+	if sp == nil {
 		return false
 	}
 	sp.detectUseAfterFinish()
@@ -656,6 +656,9 @@ func (sp *Span) reset(
 	}
 
 	c := sp.i.crdb
+	if c == nil && otelSpan == nil && netTr == nil {
+		panic(errors.AssertionFailedf("must have at least one of crdbSpan, otelSpan, or netTr"))
+	}
 	sp.i = spanInner{
 		tracer:   sp.i.tracer,
 		crdb:     c,

--- a/pkg/util/tracing/span_inner.go
+++ b/pkg/util/tracing/span_inner.go
@@ -10,13 +10,14 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing/tracingpb"
-	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/redact"
 	"go.opentelemetry.io/otel/attribute"
 	oteltrace "go.opentelemetry.io/otel/trace"
 	"golang.org/x/net/trace"
 )
 
+// spanInner contains all the span types we are recording to.
+// Note that one of crdb, otelSpan or netTr should be non-nil.
 type spanInner struct {
 	tracer *Tracer // never nil
 
@@ -38,21 +39,11 @@ type spanInner struct {
 }
 
 func (s *spanInner) TraceID() tracingpb.TraceID {
-	if s.isNoop() {
-		return 0
-	}
 	return s.crdb.TraceID()
 }
 
 func (s *spanInner) SpanID() tracingpb.SpanID {
-	if s.isNoop() {
-		return 0
-	}
 	return s.crdb.SpanID()
-}
-
-func (s *spanInner) isNoop() bool {
-	return s.crdb == nil && s.netTr == nil && s.otelSpan == nil
 }
 
 func (s *spanInner) isSterile() bool {
@@ -64,9 +55,6 @@ func (s *spanInner) RecordingType() tracingpb.RecordingType {
 }
 
 func (s *spanInner) SetRecordingType(to tracingpb.RecordingType) {
-	if s.isNoop() {
-		panic(errors.AssertionFailedf("SetRecordingType called on NoopSpan; use the WithForceRealSpan option for StartSpan"))
-	}
 	s.crdb.SetRecordingType(to)
 }
 
@@ -74,9 +62,6 @@ func (s *spanInner) SetRecordingType(to tracingpb.RecordingType) {
 //
 // See also GetRecording(), which returns it as a tracingpb.Recording.
 func (s *spanInner) GetTraceRecording(recType tracingpb.RecordingType, finishing bool) Trace {
-	if s.isNoop() {
-		return Trace{}
-	}
 	return s.crdb.GetRecording(recType, finishing)
 }
 
@@ -130,7 +115,7 @@ func treeifyRecordingInner(
 }
 
 func (s *spanInner) Finish() {
-	if s == nil || s.isNoop() {
+	if s == nil {
 		return
 	}
 
@@ -200,16 +185,10 @@ func (s *spanInner) Meta() SpanMeta {
 // OperationName returns the span's name. The name was specified at span
 // creation time.
 func (s *spanInner) OperationName() string {
-	if s.isNoop() {
-		return "noop"
-	}
 	return s.crdb.operation
 }
 
 func (s *spanInner) SetTag(key string, value attribute.Value) *spanInner {
-	if s.isNoop() {
-		return s
-	}
 	if s.otelSpan != nil {
 		s.otelSpan.SetAttributes(attribute.KeyValue{
 			Key:   attribute.Key(key),
@@ -226,9 +205,6 @@ func (s *spanInner) SetTag(key string, value attribute.Value) *spanInner {
 }
 
 func (s *spanInner) SetLazyTag(key string, value interface{}) *spanInner {
-	if s.isNoop() {
-		return s
-	}
 	s.crdb.mu.Lock()
 	defer s.crdb.mu.Unlock()
 	s.crdb.setLazyTagLocked(key, value)
@@ -236,9 +212,6 @@ func (s *spanInner) SetLazyTag(key string, value interface{}) *spanInner {
 }
 
 func (s *spanInner) setLazyTagLocked(key string, value interface{}) *spanInner {
-	if s.isNoop() {
-		return s
-	}
 	s.crdb.setLazyTagLocked(key, value)
 	return s
 }
@@ -246,18 +219,12 @@ func (s *spanInner) setLazyTagLocked(key string, value interface{}) *spanInner {
 // GetLazyTag returns the value of the tag with the given key. If that tag doesn't
 // exist, the bool retval is false.
 func (s *spanInner) GetLazyTag(key string) (interface{}, bool) {
-	if s.isNoop() {
-		return attribute.Value{}, false
-	}
 	s.crdb.mu.Lock()
 	defer s.crdb.mu.Unlock()
 	return s.crdb.getLazyTagLocked(key)
 }
 
 func (s *spanInner) RecordStructured(item Structured) {
-	if s.isNoop() {
-		return
-	}
 	s.crdb.recordStructured(item)
 	if s.hasVerboseSink() {
 		// Do not call .String() on the item, so that non-redactable bits

--- a/pkg/util/tracing/span_options.go
+++ b/pkg/util/tracing/span_options.go
@@ -85,7 +85,7 @@ type spanOptions struct {
 }
 
 func (opts *spanOptions) parentTraceID() tracingpb.TraceID {
-	if !opts.Parent.empty() && !opts.Parent.IsNoop() {
+	if !opts.Parent.empty() {
 		return opts.Parent.i.crdb.traceID
 	} else if !opts.RemoteParent.Empty() {
 		return opts.RemoteParent.traceID
@@ -94,7 +94,7 @@ func (opts *spanOptions) parentTraceID() tracingpb.TraceID {
 }
 
 func (opts *spanOptions) parentSpanID() tracingpb.SpanID {
-	if !opts.Parent.empty() && !opts.Parent.IsNoop() {
+	if !opts.Parent.empty() {
 		return opts.Parent.i.crdb.spanID
 	} else if !opts.RemoteParent.Empty() {
 		return opts.RemoteParent.spanID
@@ -114,7 +114,7 @@ func (opts *spanOptions) recordingType() tracingpb.RecordingType {
 	}
 
 	var recordingType tracingpb.RecordingType
-	if !opts.Parent.empty() && !opts.Parent.IsNoop() {
+	if !opts.Parent.empty() {
 		recordingType = opts.Parent.i.crdb.recordingType()
 	} else if !opts.RemoteParent.Empty() {
 		recordingType = opts.RemoteParent.recordingType
@@ -167,11 +167,8 @@ type parentOption spanRef
 // applying this option will be a root span, just as if this option hadn't been
 // specified) in the following cases:
 //   - if `sp` is nil
-//   - if `sp` is a no-op span
 //   - if `sp` is a sterile span (i.e. a span explicitly marked as not wanting
-//     children). Note that the singleton Tracer.noop span is marked as sterile,
-//     which makes this condition mostly encompass the previous one, however in
-//     theory there could be no-op spans other than the singleton one.
+//     children).
 //
 // The child inherits the parent's log tags. The data collected in the
 // child trace will be retrieved automatically when the parent's data is
@@ -179,10 +176,7 @@ type parentOption spanRef
 // must not) manually propagate the recording to the parent Span.
 //
 // The child will start recording if the parent is recording at the time
-// of child instantiation. If the parent span is not recording, the child
-// could be a "noop span" (depending on whether the Tracer is configured
-// to trace to an external tracing system) which does not support
-// recording, unless the WithForceRealSpan option is passed to StartSpan.
+// of child instantiation.
 //
 // By default, children are derived using a ChildOf relationship,
 // which corresponds to the expectation that the parent span will
@@ -212,16 +206,9 @@ func WithParent(sp *Span) SpanOption {
 	// below.
 	_ = sp.detectUseAfterFinish()
 
-	// Noop spans and sterile spans don't get children; a span constructed with
-	// WithParent(sterile-or-noop-span) will be a root span. We could return a
-	// zero parentOption here, but instead we return a parentOption referencing
-	// the tracer's noopSpan. This is so that, when constructing the "child" span
-	// using the returned option we can assert that the Tracer used to construct
-	// the child is the same as sp's Tracer.
-	if sp.IsNoop() || sp.IsSterile() {
-		return parentOption{
-			Span: sp.Tracer().noopSpan,
-		}
+	// Sterile spans don't get children and its children will be a root span.
+	if sp.IsSterile() {
+		return (parentOption)(spanRef{})
 	}
 
 	ref, _ /* ok */ := tryMakeSpanRef(sp)
@@ -388,9 +375,9 @@ type forceRealSpanOption struct{}
 var forceRealSpanSingleton = SpanOption(forceRealSpanOption{})
 
 // WithForceRealSpan forces StartSpan to create of a real Span regardless of the
-// Tracer's tracing mode (instead of a low-overhead non-recordable noop span).
+// Tracer's tracing mode.
 //
-// When tracing is disabled all spans are noopSpans; these spans aren't
+// When tracing is disabled all spans are nil; these spans aren't
 // capable of recording, so this option should be passed to StartSpan if the
 // caller wants to be able to call SetVerbose(true) on the span later. If the
 // span should be recording from the beginning, use WithRecording() instead.

--- a/pkg/util/tracing/span_test.go
+++ b/pkg/util/tracing/span_test.go
@@ -36,7 +36,7 @@ func TestStartSpan(t *testing.T) {
 	tr := NewTracerWithOpt(context.Background(), WithTracingMode(TracingModeOnDemand))
 	sp := tr.StartSpan("test")
 	defer sp.Finish()
-	require.Equal(t, "noop", sp.OperationName())
+	require.Equal(t, "<nil>", sp.OperationName())
 
 	sp2 := tr.StartSpan("test", WithRecording(tracingpb.RecordingStructured))
 	defer sp2.Finish()

--- a/pkg/util/tracing/tracer_test.go
+++ b/pkg/util/tracing/tracer_test.go
@@ -33,30 +33,34 @@ import (
 func TestStartSpanAlwaysTrace(t *testing.T) {
 	// Regression test: if tracing is on, don't erroneously return a noopSpan
 	// due to optimizations in StartSpan.
+	var nilSpan *Span
 	tr := NewTracer()
 	tr._useNetTrace = 1
 	require.True(t, tr.AlwaysTrace())
-	nilMeta := tr.noopSpan.Meta()
+	nilMeta := nilSpan.Meta()
 	require.True(t, nilMeta.Empty())
 	sp := tr.StartSpan("foo", WithRemoteParentFromSpanMeta(nilMeta))
 	require.False(t, sp.IsVerbose()) // parent was not verbose, so neither is sp
-	require.False(t, sp.IsNoop())
+	require.NotNil(t, sp)
 	sp.Finish()
-	sp = tr.StartSpan("foo", WithParent(tr.noopSpan))
+	sp = tr.StartSpan("foo", WithParent(nil))
 	require.False(t, sp.IsVerbose()) // parent was not verbose
-	require.False(t, sp.IsNoop())
+	require.NotNil(t, sp)
 	sp.Finish()
 }
 
 func TestTracingOffRecording(t *testing.T) {
 	tr := NewTracerWithOpt(context.Background(), WithTracingMode(TracingModeOnDemand))
+	// Noop spans are nil.
 	noop1 := tr.StartSpan("noop")
-	require.True(t, noop1.IsNoop())
+	require.Nil(t, noop1)
 
+	// Recording using a nil span is a no-op.
 	noop1.Record("hello")
 
+	// Starting a child span of a nil span is a no-op.
 	noop2 := tr.StartSpan("noop2", WithParent(noop1), WithDetachedRecording())
-	require.True(t, noop2.IsNoop())
+	require.Nil(t, noop2)
 
 	// Noop span returns Empty recording.
 	require.Nil(t, noop1.GetRecording(tracingpb.RecordingVerbose))
@@ -76,8 +80,8 @@ func TestTracerRecording(t *testing.T) {
 	require.Nil(t, sNonRecording.FinishAndGetConfiguredRecording())
 
 	s1 := tr.StartSpan("a", WithRecording(tracingpb.RecordingStructured))
-	if s1.IsNoop() {
-		t.Error("recording Span should not be noop")
+	if s1 == nil {
+		t.Error("recording Span should not be nil")
 	}
 	if s1.IsVerbose() {
 		t.Error("WithRecording(RecordingStructured) should not be verbose")
@@ -106,7 +110,7 @@ func TestTracerRecording(t *testing.T) {
 
 	// Real parent --> real child.
 	real3 := tr.StartSpan("noop3", WithRemoteParentFromSpanMeta(s1.Meta()))
-	if real3.IsNoop() {
+	if real3 == nil {
 		t.Error("expected real child Span")
 	}
 	real3.Finish()
@@ -304,12 +308,10 @@ func TestTracerInjectExtractNoop(t *testing.T) {
 	tr := NewTracerWithOpt(context.Background(), WithTracingMode(TracingModeOnDemand))
 	tr2 := NewTracerWithOpt(context.Background(), WithTracingMode(TracingModeOnDemand))
 
-	// Verify that noop spans become noop spans on the remote side.
+	// Verify that noop (nil) spans become noop spans on the remote side.
 
 	noop1 := tr.StartSpan("noop")
-	if !noop1.IsNoop() {
-		t.Fatalf("expected noop Span: %+v", noop1)
-	}
+	require.Nilf(t, noop1, "expected nil Span: %+v", noop1)
 	carrier := MetadataCarrier{metadata.MD{}}
 	tr.InjectMetaInto(noop1.Meta(), carrier)
 	if len(carrier.MD) != 0 {
@@ -324,9 +326,7 @@ func TestTracerInjectExtractNoop(t *testing.T) {
 		t.Errorf("expected no-op span meta: %v", wireSpanMeta)
 	}
 	noop2 := tr2.StartSpan("remote op", WithRemoteParentFromSpanMeta(wireSpanMeta))
-	if !noop2.IsNoop() {
-		t.Fatalf("expected noop Span: %+v", noop2)
-	}
+	require.Nilf(t, noop2, "expected nil Span: %+v", noop2)
 	noop1.Finish()
 	noop2.Finish()
 }
@@ -638,24 +638,25 @@ func TestSpanRecordingFinished(t *testing.T) {
 	require.Len(t, spanOpsWithFinished, 0)
 }
 
-// Test that the noop span can be used after finish.
+// Test that the noop (nil) span can be used after finish.
 func TestNoopSpanFinish(t *testing.T) {
 	tr := NewTracerWithOpt(context.Background(), WithTracingMode(TracingModeOnDemand))
+	var sp *Span
 	sp1 := tr.StartSpan("noop")
 	sp2 := tr.StartSpan("noop")
-	require.Equal(t, tr.noopSpan, sp1)
-	require.Equal(t, tr.noopSpan, sp2)
+	require.Equal(t, sp1, sp)
+	require.Equal(t, sp2, sp)
 	sp1.Finish()
 	sp2.Record("dummy")
 	sp2.Finish()
 }
 
-// Test that a span constructed with a no-op span behaves like a root span - it
+// Test that a span constructed with a nil span behaves like a root span - it
 // is present in the active spans registry.
 func TestSpanWithNoopParentIsInActiveSpans(t *testing.T) {
 	tr := NewTracerWithOpt(context.Background(), WithTracingMode(TracingModeOnDemand))
 	noop := tr.StartSpan("noop")
-	require.True(t, noop.IsNoop())
+	require.Nil(t, noop)
 	root := tr.StartSpan("foo", WithParent(noop), WithForceRealSpan())
 	defer root.Finish()
 	require.Len(t, tr.activeSpansRegistry.mu.m, 1)
@@ -774,43 +775,22 @@ span: test
 	require.Equal(t, rec1, rec2)
 }
 
-// Check that it is illegal to create a child with a different Tracer than the
-// parent.
+// Check that it is illegal to create a child with a different Tracer than the parent.
+// Note that if the parent is a sterile span, it'll be replaced with a nil span,
+// meaning its tracer won't be available at the time we are creatiing the span, so
+// this assertion doesn't apply for sterile spans. Note also we intend to remove
+// the concept of a sterile span shortly.
 func TestChildNeedsSameTracerAsParent(t *testing.T) {
-	type testCase struct {
-		sterileParent bool
-		noopParent    bool
-	}
-	for _, tc := range []testCase{
-		{},
-		{sterileParent: true},
-		{noopParent: true},
-	} {
-		t.Run("", func(t *testing.T) {
-			tr1 := NewTracerWithOpt(context.Background(), WithTracingMode(TracingModeOnDemand))
-			tr2 := NewTracer()
+	t.Run("", func(t *testing.T) {
+		tr1 := NewTracerWithOpt(context.Background(), WithTracingMode(TracingModeOnDemand))
+		tr2 := NewTracer()
 
-			var opt []SpanOption
-			if tc.sterileParent {
-				opt = append(opt, WithSterile())
-			}
-			if !tc.noopParent {
-				opt = append(opt, WithForceRealSpan())
-			}
-			parent := tr1.StartSpan("parent", opt...)
-			defer parent.Finish()
-			if tc.noopParent {
-				require.True(t, parent.IsNoop())
-			}
-			if tc.sterileParent {
-				require.True(t, parent.IsSterile())
-			}
-
-			require.Panics(t, func() {
-				tr2.StartSpan("child", WithParent(parent))
-			})
+		parent := tr1.StartSpan("parent", WithForceRealSpan())
+		defer parent.Finish()
+		require.Panics(t, func() {
+			tr2.StartSpan("child", WithParent(parent))
 		})
-	}
+	})
 }
 
 // TestSpanReuse checks that spans are reused through the Tracer's pool, instead
@@ -922,17 +902,17 @@ func TestTracerClusterSettings(t *testing.T) {
 
 	tr := NewTracerWithOpt(ctx, WithClusterSettings(&sv))
 	sp := tr.StartSpan("test")
-	require.False(t, sp.IsNoop())
+	require.NotNil(t, sp)
 	sp.Finish()
 
 	EnableActiveSpansRegistry.Override(ctx, &sv, false)
 	sp = tr.StartSpan("test")
-	require.True(t, sp.IsNoop())
+	require.Nil(t, sp)
 	sp.Finish()
 
 	EnableActiveSpansRegistry.Override(ctx, &sv, true)
 	sp = tr.StartSpan("test")
-	require.False(t, sp.IsNoop())
+	require.NotNil(t, sp)
 	sp.Finish()
 }
 


### PR DESCRIPTION
This commit removes the concept of a low overhead 'noop span' as
this is obsolete. The noop span was primarily used to prevent
unnnecessary allocations and operations when tracing was off,
while enabling access to its wrapped tracer to start spans later on.

Summary:
- Where we were creating noop spans, we are now using `nil`
spans - this includes places where we used sterile noop spans.
- All checks for `span.IsNoop` have been removed where there was
already a `nil` check, or have been replaced with `nil` checks.
- Places where we expected to have at least a noop  span from the
context with a valid tracer have been replaced to retrieve the
tracer from a different source, if necessary, if the span is nil.

Part of: https://github.com/cockroachdb/cockroach/issues/135803

Release note: None