### PR TITLE
cdctest: fix cdc/bank roachtest

### DIFF
--- a/pkg/ccl/changefeedccl/cdctest/nemeses.go
+++ b/pkg/ccl/changefeedccl/cdctest/nemeses.go
@@ -275,14 +275,17 @@ func RunNemesis(
 		return nil, err
 	}
 
-	baV, err := NewBeforeAfterValidator(db, `foo`, cfo)
+	baV, err := NewBeforeAfterValidator(db, `foo`)
 	if err != nil {
 		return nil, err
 	}
 
+	tV := NewTopicValidator(`foo`, cfo.FullTableName)
+
 	validators := Validators{
 		NewOrderValidator(`foo`),
 		baV,
+		tV,
 	}
 
 	if nOp.EnableFpValidator {
@@ -291,6 +294,14 @@ func RunNemesis(
 			return nil, err
 		}
 		validators = append(validators, fprintV)
+	}
+
+	if cfo.KeyInValue {
+		kivV, err := NewKeyInValueValidator(db, `foo`)
+		if err != nil {
+			return nil, err
+		}
+		validators = append(validators, kivV)
 	}
 
 	ns.v = NewCountValidator(validators)

--- a/pkg/ccl/changefeedccl/cdctest/validator_test.go
+++ b/pkg/ccl/changefeedccl/cdctest/validator_test.go
@@ -99,12 +99,6 @@ func TestOrderValidator(t *testing.T) {
 	})
 }
 
-var standardChangefeedOptions = ChangefeedOption{
-	FullTableName: false,
-	KeyInValue:    false,
-	Format:        "json",
-}
-
 func TestBeforeAfterValidator(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
@@ -140,30 +134,22 @@ func TestBeforeAfterValidator(t *testing.T) {
 	}
 
 	t.Run(`empty`, func(t *testing.T) {
-		v, err := NewBeforeAfterValidator(sqlDBRaw, `foo`, standardChangefeedOptions)
+		v, err := NewBeforeAfterValidator(sqlDBRaw, `foo`)
 		require.NoError(t, err)
 		assertValidatorFailures(t, v)
 	})
 	t.Run(`fullTableName`, func(t *testing.T) {
-		v, err := NewBeforeAfterValidator(sqlDBRaw, `foo`, ChangefeedOption{
-			FullTableName: true,
-			KeyInValue:    false,
-			Format:        "json",
-		})
+		v, err := NewBeforeAfterValidator(sqlDBRaw, `foo`)
 		require.NoError(t, err)
 		assertValidatorFailures(t, v)
 	})
 	t.Run(`key_in_value`, func(t *testing.T) {
-		v, err := NewBeforeAfterValidator(sqlDBRaw, `foo`, ChangefeedOption{
-			FullTableName: false,
-			KeyInValue:    true,
-			Format:        "json",
-		})
+		v, err := NewBeforeAfterValidator(sqlDBRaw, `foo`)
 		require.NoError(t, err)
 		assertValidatorFailures(t, v)
 	})
 	t.Run(`during initial`, func(t *testing.T) {
-		v, err := NewBeforeAfterValidator(sqlDBRaw, `foo`, standardChangefeedOptions)
+		v, err := NewBeforeAfterValidator(sqlDBRaw, `foo`)
 		require.NoError(t, err)
 		// "before" is ignored if missing.
 		noteRow(t, v, `p`, `[1]`, `{"after": {"k":1,"v":1}}`, ts[1], `foo`)
@@ -178,7 +164,7 @@ func TestBeforeAfterValidator(t *testing.T) {
 				`' WHERE to_json(k)::TEXT = $1 AND to_json(v)::TEXT = $2 [1 3]`)
 	})
 	t.Run(`missing before`, func(t *testing.T) {
-		v, err := NewBeforeAfterValidator(sqlDBRaw, `foo`, standardChangefeedOptions)
+		v, err := NewBeforeAfterValidator(sqlDBRaw, `foo`)
 		require.NoError(t, err)
 		noteResolved(t, v, `p`, ts[0])
 		// "before" should have been provided.
@@ -189,7 +175,7 @@ func TestBeforeAfterValidator(t *testing.T) {
 				`' WHERE to_json(k)::TEXT = $1 [1]`)
 	})
 	t.Run(`incorrect before`, func(t *testing.T) {
-		v, err := NewBeforeAfterValidator(sqlDBRaw, `foo`, standardChangefeedOptions)
+		v, err := NewBeforeAfterValidator(sqlDBRaw, `foo`)
 		require.NoError(t, err)
 		noteResolved(t, v, `p`, ts[0])
 		// "before" provided with wrong value.
@@ -200,7 +186,7 @@ func TestBeforeAfterValidator(t *testing.T) {
 				`' WHERE to_json(k)::TEXT = $1 AND to_json(v)::TEXT = $2 [5 10]`)
 	})
 	t.Run(`unnecessary before`, func(t *testing.T) {
-		v, err := NewBeforeAfterValidator(sqlDBRaw, `foo`, standardChangefeedOptions)
+		v, err := NewBeforeAfterValidator(sqlDBRaw, `foo`)
 		require.NoError(t, err)
 		noteResolved(t, v, `p`, ts[0])
 		// "before" provided but should not have been.
@@ -211,7 +197,7 @@ func TestBeforeAfterValidator(t *testing.T) {
 				`' WHERE to_json(k)::TEXT = $1 AND to_json(v)::TEXT = $2 [1 1]`)
 	})
 	t.Run(`missing after`, func(t *testing.T) {
-		v, err := NewBeforeAfterValidator(sqlDBRaw, `foo`, standardChangefeedOptions)
+		v, err := NewBeforeAfterValidator(sqlDBRaw, `foo`)
 		require.NoError(t, err)
 		noteResolved(t, v, `p`, ts[0])
 		// "after" should have been provided.
@@ -222,7 +208,7 @@ func TestBeforeAfterValidator(t *testing.T) {
 				`' WHERE to_json(k)::TEXT = $1 [1]`)
 	})
 	t.Run(`incorrect after`, func(t *testing.T) {
-		v, err := NewBeforeAfterValidator(sqlDBRaw, `foo`, standardChangefeedOptions)
+		v, err := NewBeforeAfterValidator(sqlDBRaw, `foo`)
 		require.NoError(t, err)
 		noteResolved(t, v, `p`, ts[0])
 		// "after" provided with wrong value.
@@ -233,7 +219,7 @@ func TestBeforeAfterValidator(t *testing.T) {
 				`' WHERE to_json(k)::TEXT = $1 AND to_json(v)::TEXT = $2 [1 5]`)
 	})
 	t.Run(`unnecessary after`, func(t *testing.T) {
-		v, err := NewBeforeAfterValidator(sqlDBRaw, `foo`, standardChangefeedOptions)
+		v, err := NewBeforeAfterValidator(sqlDBRaw, `foo`)
 		require.NoError(t, err)
 		noteResolved(t, v, `p`, ts[0])
 		// "after" provided but should not have been.
@@ -244,7 +230,7 @@ func TestBeforeAfterValidator(t *testing.T) {
 				`' WHERE to_json(k)::TEXT = $1 AND to_json(v)::TEXT = $2 [1 3]`)
 	})
 	t.Run(`incorrect before and after`, func(t *testing.T) {
-		v, err := NewBeforeAfterValidator(sqlDBRaw, `foo`, standardChangefeedOptions)
+		v, err := NewBeforeAfterValidator(sqlDBRaw, `foo`)
 		require.NoError(t, err)
 		noteResolved(t, v, `p`, ts[0])
 		// "before" and "after" both provided with wrong value.
@@ -258,7 +244,7 @@ func TestBeforeAfterValidator(t *testing.T) {
 				`' WHERE to_json(k)::TEXT = $1 AND to_json(v)::TEXT = $2 [1 4]`)
 	})
 	t.Run(`correct`, func(t *testing.T) {
-		v, err := NewBeforeAfterValidator(sqlDBRaw, `foo`, standardChangefeedOptions)
+		v, err := NewBeforeAfterValidator(sqlDBRaw, `foo`)
 		require.NoError(t, err)
 		noteResolved(t, v, `p`, ts[0])
 		noteRow(t, v, `p`, `[1]`, `{}`, ts[0], `foo`)
@@ -297,7 +283,7 @@ func TestBeforeAfterValidatorForGeometry(t *testing.T) {
 			t.Fatal(err)
 		}
 	}
-	v, err := NewBeforeAfterValidator(sqlDBRaw, `foo`, standardChangefeedOptions)
+	v, err := NewBeforeAfterValidator(sqlDBRaw, `foo`)
 	require.NoError(t, err)
 	assertValidatorFailures(t, v)
 	noteRow(t, v, `p`, `[1]`, `{"after": {"k":1, "geom":{"coordinates": [1,2], "type": "Point"}}}`, ts[0], `foo`)

--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -926,11 +926,7 @@ func runCDCBank(ctx context.Context, t test.Test, c cluster.Cluster) {
 		if err != nil {
 			return errors.Wrap(err, "error creating validator")
 		}
-		baV, err := cdctest.NewBeforeAfterValidator(db, `bank.bank`, cdctest.ChangefeedOption{
-			FullTableName: false,
-			KeyInValue:    false,
-			Format:        "json",
-		})
+		baV, err := cdctest.NewBeforeAfterValidator(db, `bank.bank`)
 		if err != nil {
 			return err
 		}
@@ -2294,7 +2290,6 @@ func registerCDC(r registry.Registry) {
 	r.Add(registry.TestSpec{
 		Name:             "cdc/bank",
 		Owner:            `cdc`,
-		Skip:             "#139109",
 		Cluster:          r.MakeClusterSpec(4, spec.WorkloadNode()),
 		Leases:           registry.MetamorphicLeases,
 		CompatibleClouds: registry.AllExceptAWS,


### PR DESCRIPTION
Before, we were validating the topics of test feed messages inside the beforeAfter validator which was being used in the cdc/bank roachtest. That validation should have been put in its own validator. This commit moves that validation and the key_in_value validation into their own validators.

Fixes: #139109

Release note: None