### PR TITLE
roachtest: and an operation to change fortification fraction setting

### DIFF
--- a/pkg/cmd/roachtest/operations/cluster_settings.go
+++ b/pkg/cmd/roachtest/operations/cluster_settings.go
@@ -82,6 +82,16 @@ func registerClusterSettings(r registry.Registry) {
 			Generator: timeBasedValues(timeutil.Now, []string{"true", "false"}, 24*7*time.Hour),
 			Owner:     registry.OwnerKV,
 		},
+		{
+			// Change the fraction of replicas that run leader leases.
+			Name: "kv.raft.leader_fortification.fraction_enabled",
+			Generator: timeBasedRandomValue(timeutil.Now, 6*time.Hour, func(rng *rand.Rand) string {
+				// Random value in the following set: {0, 0.25, 0.5, 0.75, 1.0}
+				fraction := float32(rng.Intn(5)) / 4.0
+				return fmt.Sprintf("%g", fraction)
+			}),
+			Owner: registry.OwnerKV,
+		},
 		// When running multi-store with `--wal-failover=among-stores`, this configures
 		// the threshold to trigger a fail-over to a secondary store’s WAL.
 		// 20-minute cycle.


### PR DESCRIPTION
This commit adds an operation to registerClusterSettings() where it randomly changes the kv.raft.leader_fortification.fraction_enabled value between: {0, 0.25, 0.5, 0.75, 1}.

References: #133891

Release note: None