### PR TITLE
vecbench: spruce up vecbench

### DIFF
--- a/pkg/sql/vecindex/vecstore/in_memory_store.go
+++ b/pkg/sql/vecindex/vecstore/in_memory_store.go
@@ -160,7 +160,12 @@ func NewInMemoryStore(dims int, seed int64) *InMemoryStore {
 	return st
 }
 
-// BeginTransaction implements the Store interface.
+// Dims returns the number of dimensions in stored vectors.
+func (s *InMemoryStore) Dims() int {
+	return s.dims
+}
+
+// Begin implements the Store interface.
 func (s *InMemoryStore) Begin(ctx context.Context) (Txn, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -173,7 +178,7 @@ func (s *InMemoryStore) Begin(ctx context.Context) (Txn, error) {
 	return &elem.Value.activeTxn, nil
 }
 
-// CommitTransaction implements the Store interface.
+// Commit implements the Store interface.
 func (s *InMemoryStore) Commit(ctx context.Context, txn Txn) error {
 	// Release any exclusive partition locks held by the transaction.
 	tx := txn.(*inMemoryTxn)
@@ -233,7 +238,7 @@ func (s *InMemoryStore) Commit(ctx context.Context, txn Txn) error {
 	return nil
 }
 
-// AbortTransaction implements the Store interface.
+// Abort implements the Store interface.
 func (s *InMemoryStore) Abort(ctx context.Context, txn Txn) error {
 	tx := txn.(*inMemoryTxn)
 	if tx.updated {

--- a/pkg/sql/vecindex/vector_index.go
+++ b/pkg/sql/vecindex/vector_index.go
@@ -198,6 +198,11 @@ func NewVectorIndex(
 	return vi, nil
 }
 
+// Store returns the underlying vector store for the index.
+func (vi *VectorIndex) Store() vecstore.Store {
+	return vi.store
+}
+
 // Options returns the options that specify how the index should be built and
 // searched.
 func (vi *VectorIndex) Options() VectorIndexOptions {


### PR DESCRIPTION
Make some improvements to vecbench, like adding color output, better progress output, and hiding the cursor. Also add a "build" command that benchmarks building the index. Speed up the "search" command by only loading the test vectors, not the training vectors.

Epic: CRDB-42943

Release note: None