### PR TITLE
docgen: update COPY TO STDOUT portions of SQL diagram

### DIFF
--- a/docs/generated/sql/bnf/copy_stmt.bnf
+++ b/docs/generated/sql/bnf/copy_stmt.bnf
@@ -1,16 +1,16 @@
 copy_stmt ::=
 	'COPY' table_name opt_column_list 'FROM' 'STDIN' 'WITH' copy_options ( ( copy_options ) )* 
 	| 'COPY' table_name opt_column_list 'FROM' 'STDIN'  copy_options ( ( copy_options ) )* 
-	| 'COPY' table_name opt_column_list 'FROM' 'STDIN' 'WITH' '(' copy_generic_options_list ')' 
-	| 'COPY' table_name opt_column_list 'FROM' 'STDIN'  '(' copy_generic_options_list ')' 
+	| 'COPY' table_name opt_column_list 'FROM' 'STDIN' 'WITH'  
+	| 'COPY' table_name opt_column_list 'FROM' 'STDIN'   
 	| 'COPY' table_name opt_column_list 'FROM' 'STDIN'  
 	| 'COPY' table_name opt_column_list 'TO' 'STDOUT' 'WITH' copy_options ( ( copy_options ) )*
 	| 'COPY' table_name opt_column_list 'TO' 'STDOUT'  copy_options ( ( copy_options ) )*
-	| 'COPY' table_name opt_column_list 'TO' 'STDOUT' 'WITH' '(' copy_generic_options_list ')'
-	| 'COPY' table_name opt_column_list 'TO' 'STDOUT'  '(' copy_generic_options_list ')'
+	| 'COPY' table_name opt_column_list 'TO' 'STDOUT' 'WITH' 
+	| 'COPY' table_name opt_column_list 'TO' 'STDOUT'  
 	| 'COPY' table_name opt_column_list 'TO' 'STDOUT' 
-	| 'COPY' '(' copy_to_stmt ')' 'TO' 'STDOUT' 'WITH' copy_options ( ( copy_options ) )*
-	| 'COPY' '(' copy_to_stmt ')' 'TO' 'STDOUT'  copy_options ( ( copy_options ) )*
-	| 'COPY' '(' copy_to_stmt ')' 'TO' 'STDOUT' 'WITH' '(' copy_generic_options_list ')'
-	| 'COPY' '(' copy_to_stmt ')' 'TO' 'STDOUT'  '(' copy_generic_options_list ')'
-	| 'COPY' '(' copy_to_stmt ')' 'TO' 'STDOUT' 
+	| 'COPY' '(' query ')' 'TO' 'STDOUT' 'WITH' copy_options ( ( copy_options ) )*
+	| 'COPY' '(' query ')' 'TO' 'STDOUT'  copy_options ( ( copy_options ) )*
+	| 'COPY' '(' query ')' 'TO' 'STDOUT' 'WITH' 
+	| 'COPY' '(' query ')' 'TO' 'STDOUT'  
+	| 'COPY' '(' query ')' 'TO' 'STDOUT' 

--- a/pkg/cmd/docgen/diagrams.go
+++ b/pkg/cmd/docgen/diagrams.go
@@ -690,8 +690,12 @@ var specs = []stmtSpec{
 		match:  []*regexp.Regexp{regexp.MustCompile("'COMMIT'|'END'")},
 	},
 	{
-		name:    "copy_stmt",
-		inline:  []string{"opt_with_copy_options", "copy_options_list", "opt_with", "opt_where_clause", "where_clause"},
+		name:   "copy_stmt",
+		inline: []string{"opt_with_copy_options", "copy_options_list", "opt_with", "opt_where_clause", "where_clause"},
+		replace: map[string]string{
+			"copy_to_stmt":                      "query",
+			"'(' copy_generic_options_list ')'": "",
+		},
 		exclude: []*regexp.Regexp{regexp.MustCompile("'WHERE'")},
 	},
 	{


### PR DESCRIPTION
Updated `COPY` diagram so that it better reflects the `COPY TO` syntax that was added in 23.1 (this PR will be backported to every version up until 23.1). These changes accompany the docs updates in https://github.com/cockroachdb/docs/pull/19310
 
Current diagram:

<img width="647" alt="image" src="https://github.com/user-attachments/assets/eb70b831-3473-40aa-823f-5432a8cf2698" />

New diagram:

<img width="829" alt="image" src="https://github.com/user-attachments/assets/314e1345-cec8-4a72-9be2-fb4b2f2885ee" />

Epic: none
Release note: none
Release justification: non-production code change