### PR TITLE
sqlstats: remove unnecessary interfaces

### DIFF
--- a/pkg/ccl/serverccl/tenant_test_utils.go
+++ b/pkg/ccl/serverccl/tenant_test_utils.go
@@ -95,8 +95,7 @@ func newTestTenant(
 	tenant, tenantConn := serverutils.StartTenant(t, server, args)
 	sqlDB := sqlutils.MakeSQLRunner(tenantConn)
 	status := tenant.StatusServer().(serverpb.SQLStatusServer)
-	sqlStats := tenant.SQLServer().(*sql.Server).
-		GetSQLStatsProvider().(*persistedsqlstats.PersistedSQLStats)
+	sqlStats := tenant.SQLServer().(*sql.Server).GetSQLStatsProvider()
 	contentionRegistry := tenant.ExecutorConfig().(sql.ExecutorConfig).ContentionRegistry
 
 	return &testTenant{

--- a/pkg/server/application_api/stats_test.go
+++ b/pkg/server/application_api/stats_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/appstatspb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/catconstants"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats"
-	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats/persistedsqlstats"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/diagutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
@@ -132,7 +131,7 @@ func TestEnsureSQLStatsAreFlushedForTelemetry(t *testing.T) {
 
 	statusServer := s.StatusServer().(serverpb.StatusServer)
 	sqlServer := s.SQLServer().(*sql.Server)
-	sqlServer.GetSQLStatsProvider().(*persistedsqlstats.PersistedSQLStats).MaybeFlush(ctx, srv.AppStopper())
+	sqlServer.GetSQLStatsProvider().MaybeFlush(ctx, srv.AppStopper())
 	testutils.SucceedsSoon(t, func() error {
 		// Get the diagnostic info.
 		res, err := statusServer.Diagnostics(ctx, &serverpb.DiagnosticsRequest{NodeId: "local"})
@@ -341,7 +340,7 @@ func TestClusterResetSQLStats(t *testing.T) {
 			populateStats(t, sqlDB)
 			if flushed {
 				gateway.SQLServer().(*sql.Server).
-					GetSQLStatsProvider().(*persistedsqlstats.PersistedSQLStats).MaybeFlush(ctx, gateway.AppStopper())
+					GetSQLStatsProvider().MaybeFlush(ctx, gateway.AppStopper())
 			}
 
 			statsPreReset, err := status.Statements(ctx, &serverpb.StatementsRequest{

--- a/pkg/server/combined_statement_stats.go
+++ b/pkg/server/combined_statement_stats.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats/persistedsqlstats"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -105,7 +106,7 @@ type statementStatsRunner struct {
 func getCombinedStatementStats(
 	ctx context.Context,
 	req *serverpb.CombinedStatementsStatsRequest,
-	statsProvider sqlstats.Provider,
+	statsProvider *persistedsqlstats.PersistedSQLStats,
 	ie *sql.InternalExecutor,
 	settings *cluster.Settings,
 	testingKnobs *sqlstats.TestingKnobs,

--- a/pkg/server/drain.go
+++ b/pkg/server/drain.go
@@ -18,7 +18,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/server/srverrors"
 	"github.com/cockroachdb/cockroach/pkg/settings"
-	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats/persistedsqlstats"
 	"github.com/cockroachdb/cockroach/pkg/util/grpcutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
@@ -443,7 +442,7 @@ func (s *drainServer) drainClients(
 	s.sqlServer.distSQLServer.Drain(ctx, queryMaxWait, reporter)
 
 	// Flush in-memory SQL stats into the statement stats system table.
-	statsProvider := s.sqlServer.pgServer.SQLServer.GetSQLStatsProvider().(*persistedsqlstats.PersistedSQLStats)
+	statsProvider := s.sqlServer.pgServer.SQLServer.GetSQLStatsProvider()
 	// If the SQL server is disabled there is nothing to drain here.
 	if !s.sqlServer.cfg.DisableSQLServer {
 		statsProvider.MaybeFlush(ctx, s.stopper)

--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -521,6 +521,7 @@ go_library(
         "//pkg/sql/sqlstats/persistedsqlstats",
         "//pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil",
         "//pkg/sql/sqlstats/sslocal",
+        "//pkg/sql/sqlstats/ssmemstorage",
         "//pkg/sql/sqltelemetry",
         "//pkg/sql/stats",
         "//pkg/sql/stats/bounds",

--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -34,7 +34,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondatapb"
-	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats/ssmemstorage"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/fsm"
@@ -384,7 +384,7 @@ func (ie *InternalExecutor) newConnExecutorWithTxn(
 	sdMutIterator *sessionDataMutatorIterator,
 	stmtBuf *StmtBuf,
 	clientComm ClientComm,
-	applicationStats sqlstats.ApplicationStats,
+	applicationStats *ssmemstorage.Container,
 	attributeToUser bool,
 ) (ex *connExecutor, _ error) {
 

--- a/pkg/sql/sql_activity_update_job_test.go
+++ b/pkg/sql/sql_activity_update_job_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/appstatspb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats"
-	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats/persistedsqlstats"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
@@ -103,7 +102,7 @@ func TestSqlActivityUpdateJob(t *testing.T) {
 	db.Exec(t, "SET SESSION application_name=$1", appName)
 	db.Exec(t, "SELECT 1;")
 
-	ts.SQLServer().(*Server).GetSQLStatsProvider().(*persistedsqlstats.PersistedSQLStats).MaybeFlush(ctx, srv.AppStopper())
+	ts.SQLServer().(*Server).GetSQLStatsProvider().MaybeFlush(ctx, srv.AppStopper())
 
 	db.Exec(t, "SET SESSION application_name=$1", "randomIgnore")
 
@@ -149,7 +148,7 @@ func TestMergeFunctionLogic(t *testing.T) {
 	db.Exec(t, "SELECT * FROM system.statement_statistics")
 	db.Exec(t, "SELECT count_rows() FROM system.transaction_statistics")
 
-	srv.SQLServer().(*Server).GetSQLStatsProvider().(*persistedsqlstats.PersistedSQLStats).MaybeFlush(ctx, srv.AppStopper())
+	srv.SQLServer().(*Server).GetSQLStatsProvider().MaybeFlush(ctx, srv.AppStopper())
 
 	db.Exec(t, "SET SESSION application_name=$1", "randomIgnore")
 
@@ -314,7 +313,7 @@ func TestSqlActivityUpdateTopLimitJob(t *testing.T) {
 		db.Exec(t, "SET SESSION application_name=$1", "randomIgnore")
 
 		db.Exec(t, "SET CLUSTER SETTING sql.stats.flush.enabled  = true;")
-		ts.SQLServer().(*Server).GetSQLStatsProvider().(*persistedsqlstats.PersistedSQLStats).MaybeFlush(ctx, srv.AppStopper())
+		ts.SQLServer().(*Server).GetSQLStatsProvider().MaybeFlush(ctx, srv.AppStopper())
 		db.Exec(t, "SET CLUSTER SETTING sql.stats.flush.enabled  = false;")
 
 		// Run the updater to add rows to the activity tables.
@@ -574,7 +573,7 @@ func TestTransactionActivityMetadata(t *testing.T) {
 
 	// Flush and transfer stats.
 	var metadataJSON string
-	ts.SQLServer().(*Server).GetSQLStatsProvider().(*persistedsqlstats.PersistedSQLStats).MaybeFlush(ctx, s.AppStopper())
+	ts.SQLServer().(*Server).GetSQLStatsProvider().MaybeFlush(ctx, s.AppStopper())
 
 	// Ensure that the metadata column contains the populated 'stmtFingerprintIDs' field.
 	var metadata struct {
@@ -591,7 +590,7 @@ func TestTransactionActivityMetadata(t *testing.T) {
 	db.Exec(t, "SELECT 1")
 
 	// Flush and transfer top stats.
-	ts.SQLServer().(*Server).GetSQLStatsProvider().(*persistedsqlstats.PersistedSQLStats).MaybeFlush(ctx, s.AppStopper())
+	ts.SQLServer().(*Server).GetSQLStatsProvider().MaybeFlush(ctx, s.AppStopper())
 	require.NoError(t, updater.transferTopStats(ctx, stubTime, 100, 100, 100))
 
 	// Ensure that the metadata column contains the populated 'stmtFingerprintIDs' field.
@@ -647,7 +646,7 @@ func TestActivityStatusCombineAPI(t *testing.T) {
 
 	// Flush and transfer stats.
 	var metadataJSON string
-	ts.SQLServer().(*Server).GetSQLStatsProvider().(*persistedsqlstats.PersistedSQLStats).MaybeFlush(ctx, s.AppStopper())
+	ts.SQLServer().(*Server).GetSQLStatsProvider().MaybeFlush(ctx, s.AppStopper())
 
 	// Ensure that the metadata column contains the populated 'stmtFingerprintIDs' field.
 	var metadata struct {
@@ -840,7 +839,7 @@ func TestFlushToActivityWithDifferentAggTs(t *testing.T) {
 				fmt.Fprintf(&buf, "%s\n", strings.Join(row, ","))
 			}
 		case "flush-stats":
-			ts.SQLServer().(*Server).GetSQLStatsProvider().(*persistedsqlstats.PersistedSQLStats).MaybeFlush(ctx, srv.AppStopper())
+			ts.SQLServer().(*Server).GetSQLStatsProvider().MaybeFlush(ctx, srv.AppStopper())
 		case "update-top-activity":
 			// Populate the Top Activity. This will use the transfer all scenarios
 			// with there only being a few rows.

--- a/pkg/sql/sqlstats/persistedsqlstats/bench_test.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/bench_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/appstatspb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats"
-	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats/persistedsqlstats"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats/ssmemstorage"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
@@ -97,7 +96,7 @@ func runBenchmarkPersistedSqlStatsFlush(
 			db.Exec(b, "SELECT id FROM bench.t1 LIMIT 5")
 		}
 		b.StartTimer()
-		tc.Server(0).SQLServer().(*sql.Server).GetSQLStatsProvider().(*persistedsqlstats.PersistedSQLStats).MaybeFlush(ctx, tc.ApplicationLayer(0).AppStopper())
+		tc.Server(0).SQLServer().(*sql.Server).GetSQLStatsProvider().MaybeFlush(ctx, tc.ApplicationLayer(0).AppStopper())
 		b.StopTimer()
 	}
 }
@@ -384,7 +383,7 @@ func BenchmarkSqlStatsMaxFlushTime(b *testing.B) {
 	defer s.Stopper().Stop(ctx)
 	sqlConn := sqlutils.MakeSQLRunner(conn)
 
-	sqlStats := s.SQLServer().(*sql.Server).GetSQLStatsProvider().(*persistedsqlstats.PersistedSQLStats)
+	sqlStats := s.SQLServer().(*sql.Server).GetSQLStatsProvider()
 	controller := s.SQLServer().(*sql.Server).GetSQLStatsController()
 	stmtFingerprintLimit := sqlstats.MaxMemSQLStatsStmtFingerprints.Get(&s.ClusterSettings().SV)
 	txnFingerprintLimit := sqlstats.MaxMemSQLStatsTxnFingerprints.Get(&s.ClusterSettings().SV)

--- a/pkg/sql/sqlstats/persistedsqlstats/controller_test.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/controller_test.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/sql"
-	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats/persistedsqlstats"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
@@ -69,7 +68,7 @@ func TestPersistedSQLStatsReset(t *testing.T) {
 	}
 
 	sqlStats := server.SQLServer().(*sql.Server).GetSQLStatsProvider()
-	sqlStats.(*persistedsqlstats.PersistedSQLStats).MaybeFlush(ctx, cluster.ApplicationLayer(0).AppStopper())
+	sqlStats.MaybeFlush(ctx, cluster.ApplicationLayer(0).AppStopper())
 
 	checkInsertedStmtStatsAndUpdateFingerprintIDs(t, appName, observer, expectedStmtFingerprintToFingerprintID)
 	checkInsertedTxnStats(t, appName, observer, expectedStmtFingerprintToFingerprintID)

--- a/pkg/sql/sqlstats/persistedsqlstats/datadriven_test.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/datadriven_test.go
@@ -18,7 +18,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats"
-	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats/persistedsqlstats"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/datapathutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
@@ -84,7 +83,7 @@ func TestSQLStatsDataDriven(t *testing.T) {
 	defer cluster.Stopper().Stop(ctx)
 
 	server := cluster.Server(0 /* idx */).ApplicationLayer()
-	sqlStats := server.SQLServer().(*sql.Server).GetSQLStatsProvider().(*persistedsqlstats.PersistedSQLStats)
+	sqlStats := server.SQLServer().(*sql.Server).GetSQLStatsProvider()
 
 	appStats := sqlStats.GetApplicationStats("app1")
 

--- a/pkg/sql/sqlstats/persistedsqlstats/flush_test.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/flush_test.go
@@ -105,8 +105,8 @@ func TestSQLStatsFlush(t *testing.T) {
 	// pollute the in-memory stats of the other 2 servers.
 	observerConn := sqlutils.MakeSQLRunner(testCluster.Server(2).SQLConn(t))
 
-	firstServerSQLStats := firstServer.SQLServer().(*sql.Server).GetSQLStatsProvider().(*persistedsqlstats.PersistedSQLStats)
-	secondServerSQLStats := secondServer.SQLServer().(*sql.Server).GetSQLStatsProvider().(*persistedsqlstats.PersistedSQLStats)
+	firstServerSQLStats := firstServer.SQLServer().(*sql.Server).GetSQLStatsProvider()
+	secondServerSQLStats := secondServer.SQLServer().(*sql.Server).GetSQLStatsProvider()
 
 	firstSQLConn.Exec(t, "SET application_name = 'flush_unit_test'")
 	secondSQLConn.Exec(t, "SET application_name = 'flush_unit_test'")
@@ -248,7 +248,7 @@ func TestSQLStatsInitialDelay(t *testing.T) {
 	s := srv.ApplicationLayer()
 
 	initialNextFlushAt := s.SQLServer().(*sql.Server).
-		GetSQLStatsProvider().(*persistedsqlstats.PersistedSQLStats).GetNextFlushAt()
+		GetSQLStatsProvider().GetNextFlushAt()
 
 	// Since we introduced jitter in our flush interval, the next flush time
 	// is not entirely deterministic. However, we can still have an upperbound
@@ -347,7 +347,7 @@ func TestSQLStatsMinimumFlushInterval(t *testing.T) {
 	sqlConn.Exec(t, "SELECT 1")
 
 	s.SQLServer().(*sql.Server).
-		GetSQLStatsProvider().(*persistedsqlstats.PersistedSQLStats).MaybeFlush(ctx, s.AppStopper())
+		GetSQLStatsProvider().MaybeFlush(ctx, s.AppStopper())
 
 	sqlConn.CheckQueryResults(t, `
 		SELECT count(*)
@@ -364,7 +364,7 @@ func TestSQLStatsMinimumFlushInterval(t *testing.T) {
 	// Since by default, the minimum flush interval is 10 minutes, a subsequent
 	// flush should be no-op.
 	s.SQLServer().(*sql.Server).
-		GetSQLStatsProvider().(*persistedsqlstats.PersistedSQLStats).MaybeFlush(ctx, s.AppStopper())
+		GetSQLStatsProvider().MaybeFlush(ctx, s.AppStopper())
 
 	sqlConn.CheckQueryResults(t, `
 		SELECT count(*)
@@ -383,7 +383,7 @@ func TestSQLStatsMinimumFlushInterval(t *testing.T) {
 	fakeTime.setTime(fakeTime.Now().Add(time.Hour))
 
 	s.SQLServer().(*sql.Server).
-		GetSQLStatsProvider().(*persistedsqlstats.PersistedSQLStats).MaybeFlush(ctx, s.AppStopper())
+		GetSQLStatsProvider().MaybeFlush(ctx, s.AppStopper())
 
 	sqlConn.CheckQueryResults(t, `
 		SELECT count(*) > 1
@@ -425,7 +425,7 @@ func TestInMemoryStatsDiscard(t *testing.T) {
 		`, [][]string{{"1"}})
 
 		s.SQLServer().(*sql.Server).
-			GetSQLStatsProvider().(*persistedsqlstats.PersistedSQLStats).MaybeFlush(ctx, s.AppStopper())
+			GetSQLStatsProvider().MaybeFlush(ctx, s.AppStopper())
 
 		observerConn.CheckQueryResults(t, `
 		SELECT count(*)
@@ -457,7 +457,7 @@ func TestInMemoryStatsDiscard(t *testing.T) {
 
 		// First flush should flush everything into the system tables.
 		s.SQLServer().(*sql.Server).
-			GetSQLStatsProvider().(*persistedsqlstats.PersistedSQLStats).MaybeFlush(ctx, s.AppStopper())
+			GetSQLStatsProvider().MaybeFlush(ctx, s.AppStopper())
 
 		observerConn.CheckQueryResults(t, `
 		SELECT count(*)
@@ -476,7 +476,7 @@ func TestInMemoryStatsDiscard(t *testing.T) {
 		// Second flush should be aborted due to violating the minimum flush
 		// interval requirement. Though the data should still remain in-memory.
 		s.SQLServer().(*sql.Server).
-			GetSQLStatsProvider().(*persistedsqlstats.PersistedSQLStats).MaybeFlush(ctx, s.AppStopper())
+			GetSQLStatsProvider().MaybeFlush(ctx, s.AppStopper())
 
 		observerConn.CheckQueryResults(t, `
 		SELECT count(*)
@@ -520,7 +520,7 @@ func TestSQLStatsGatewayNodeSetting(t *testing.T) {
 	sqlConn.Exec(t, "SET application_name = 'gateway_enabled'")
 	sqlConn.Exec(t, "SELECT 1")
 	s.SQLServer().(*sql.Server).
-		GetSQLStatsProvider().(*persistedsqlstats.PersistedSQLStats).MaybeFlush(ctx, s.AppStopper())
+		GetSQLStatsProvider().MaybeFlush(ctx, s.AppStopper())
 
 	verifyNodeID(t, sqlConn, "SELECT _", true, "gateway_enabled")
 
@@ -530,7 +530,7 @@ func TestSQLStatsGatewayNodeSetting(t *testing.T) {
 	sqlConn.Exec(t, "SET application_name = 'gateway_disabled'")
 	sqlConn.Exec(t, "SELECT 1")
 	s.SQLServer().(*sql.Server).
-		GetSQLStatsProvider().(*persistedsqlstats.PersistedSQLStats).MaybeFlush(ctx, s.AppStopper())
+		GetSQLStatsProvider().MaybeFlush(ctx, s.AppStopper())
 
 	verifyNodeID(t, sqlConn, "SELECT _", false, "gateway_disabled")
 }
@@ -559,7 +559,7 @@ func TestSQLStatsPersistedLimitReached(t *testing.T) {
 	s := srv.ApplicationLayer()
 
 	sqlConn := sqlutils.MakeSQLRunner(conn)
-	pss := s.SQLServer().(*sql.Server).GetSQLStatsProvider().(*persistedsqlstats.PersistedSQLStats)
+	pss := s.SQLServer().(*sql.Server).GetSQLStatsProvider()
 
 	// 1. Flush then count to get the initial number of rows.
 	pss.MaybeFlush(ctx, s.AppStopper())
@@ -660,7 +660,7 @@ func TestSQLStatsReadLimitSizeOnLockedTable(t *testing.T) {
 	sqlConn := sqlutils.MakeSQLRunner(conn)
 	sqlConn.Exec(t, `INSERT INTO system.users VALUES ('node', NULL, true, 3); GRANT node TO root`)
 	waitForFollowerReadTimestamp(t, sqlConn)
-	pss := s.SQLServer().(*sql.Server).GetSQLStatsProvider().(*persistedsqlstats.PersistedSQLStats)
+	pss := s.SQLServer().(*sql.Server).GetSQLStatsProvider()
 
 	// It should be false since nothing has flushed. The table will be empty.
 	limitReached, err := pss.StmtsLimitSizeReached(ctx)
@@ -777,7 +777,7 @@ func TestSQLStatsPlanSampling(t *testing.T) {
 	appName := fmt.Sprintf("TestSQLStatsPlanSampling_%s", uuid.MakeV4().String())
 	sqlRun.Exec(t, "SET application_name = $1", appName)
 
-	sqlStats := s.SQLServer().(*sql.Server).GetSQLStatsProvider().(*persistedsqlstats.PersistedSQLStats)
+	sqlStats := s.SQLServer().(*sql.Server).GetSQLStatsProvider()
 	appStats := sqlStats.GetApplicationStats(appName)
 
 	sqlRun.Exec(t, `SET CLUSTER SETTING sql.txn_stats.sample_rate = 0;`)
@@ -913,7 +913,7 @@ func TestPersistedSQLStats_Flush(t *testing.T) {
 		sqlConn.Exec(t,
 			"SET CLUSTER SETTING sql.stats.limit_table_size.enabled = 'false'")
 
-		sqlStats := srv.ApplicationLayer().SQLServer().(*sql.Server).GetSQLStatsProvider().(*persistedsqlstats.PersistedSQLStats)
+		sqlStats := srv.ApplicationLayer().SQLServer().(*sql.Server).GetSQLStatsProvider()
 
 		{
 			// Add some stats for the first time. It should add one stmt and one txn stats to in-memory sql stats cache.
@@ -993,7 +993,6 @@ func (s *stubTime) getAggTimeTs() time.Time {
 	return s.t.Truncate(s.aggInterval)
 }
 
-// Now implements the testing knob interface for persistedsqlstats.Provider.
 func (s *stubTime) Now() time.Time {
 	s.RWMutex.RLock()
 	defer s.RWMutex.RUnlock()
@@ -1241,7 +1240,7 @@ func TestSQLStatsFlushDoesntWaitForFlushSigReceiver(t *testing.T) {
 	ctx := context.Background()
 	defer tc.Stopper().Stop(ctx)
 
-	ss := tc.ApplicationLayer(0).SQLServer().(*sql.Server).GetSQLStatsProvider().(*persistedsqlstats.PersistedSQLStats)
+	ss := tc.ApplicationLayer(0).SQLServer().(*sql.Server).GetSQLStatsProvider()
 	flushDoneCh := make(chan struct{})
 	ss.SetFlushDoneSignalCh(flushDoneCh)
 
@@ -1271,7 +1270,7 @@ func TestSQLStatsFlushWorkerDoesntSignalJobOnAbort(t *testing.T) {
 	ctx := context.Background()
 	defer ts.Stopper().Stop(ctx)
 
-	ss := ts.ApplicationLayer().SQLServer().(*sql.Server).GetSQLStatsProvider().(*persistedsqlstats.PersistedSQLStats)
+	ss := ts.ApplicationLayer().SQLServer().(*sql.Server).GetSQLStatsProvider()
 	flushDoneCh := make(chan struct{})
 	ss.SetFlushDoneSignalCh(flushDoneCh)
 
@@ -1304,7 +1303,7 @@ func BenchmarkSQLStatsFlush(b *testing.B) {
 	)
 	defer ts.Stop(context.Background())
 
-	sqlStats := ts.SQLServer().(*sql.Server).GetSQLStatsProvider().(*persistedsqlstats.PersistedSQLStats)
+	sqlStats := ts.SQLServer().(*sql.Server).GetSQLStatsProvider()
 	runner := sqlutils.MakeSQLRunner(conn)
 
 	ctx := context.Background()

--- a/pkg/sql/sqlstats/persistedsqlstats/provider.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/provider.go
@@ -54,11 +54,10 @@ type Config struct {
 	Knobs *sqlstats.TestingKnobs
 }
 
-// PersistedSQLStats is a sqlstats.Provider that wraps a node-local in-memory
-// sslocal.SQLStats. It behaves similar to a sslocal.SQLStats. However, it
-// periodically writes the in-memory SQL stats into system table for
-// persistence. It also performs the flush operation if it detects memory
-// pressure.
+// PersistedSQLStats wraps a node-local in-memory sslocal.SQLStats. It
+// behaves similar to a sslocal.SQLStats. However, it periodically
+// writes the in-memory SQL stats into system table for persistence. It
+// also performs the flush operation if it detects memory pressure.
 type PersistedSQLStats struct {
 	*sslocal.SQLStats
 
@@ -88,8 +87,6 @@ type PersistedSQLStats struct {
 	upsertTxnStatsStmt  statements.Statement[tree.Statement]
 	upsertStmtStatsStmt statements.Statement[tree.Statement]
 }
-
-var _ sqlstats.Provider = &PersistedSQLStats{}
 
 // New returns a new instance of the PersistedSQLStats.
 func New(cfg *Config, memSQLStats *sslocal.SQLStats) *PersistedSQLStats {
@@ -141,7 +138,6 @@ SET
 	return p
 }
 
-// Start implements sqlstats.Provider interface.
 func (s *PersistedSQLStats) Start(ctx context.Context, stopper *stop.Stopper) {
 	s.startSQLStatsFlushLoop(ctx, stopper)
 	s.jobMonitor.start(ctx, stopper, s.drain, &s.tasksDoneWG)
@@ -250,9 +246,9 @@ func (s *PersistedSQLStats) startSQLStatsFlushLoop(ctx context.Context, stopper 
 	}
 }
 
-// GetLocalMemProvider returns a sqlstats.Provider that can only be used to
+// GetLocalMemProvider returns a SQLStats that can only be used to
 // access local in-memory sql statistics.
-func (s *PersistedSQLStats) GetLocalMemProvider() sqlstats.Provider {
+func (s *PersistedSQLStats) GetLocalMemProvider() *sslocal.SQLStats {
 	return s.SQLStats
 }
 

--- a/pkg/sql/sqlstats/persistedsqlstats/reader_test.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/reader_test.go
@@ -141,7 +141,7 @@ func insertData(
 ) (*sqlutils.SQLRunner, *persistedsqlstats.PersistedSQLStats, map[string]int64) {
 	server1 := testCluster.Server(0 /* idx */)
 	sqlConn := sqlutils.MakeSQLRunner(server1.SQLConn(t))
-	sqlStats := server1.SQLServer().(*sql.Server).GetSQLStatsProvider().(*persistedsqlstats.PersistedSQLStats)
+	sqlStats := server1.SQLServer().(*sql.Server).GetSQLStatsProvider()
 
 	sqlConn.Exec(t, `SET application_name = 'TestPersistedSQLStatsRead'`)
 	expectedStmtsNoConst := make(map[string]int64)

--- a/pkg/sql/sqlstats/persistedsqlstats/scheduled_sql_stats_compaction_test.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/scheduled_sql_stats_compaction_test.go
@@ -134,7 +134,7 @@ func TestScheduledSQLStatsCompaction(t *testing.T) {
 	// We run some queries then flush so that we ensure that are some stats in
 	// the system table.
 	helper.sqlDB.Exec(t, "SELECT 1; SELECT 1, 1")
-	helper.server.ApplicationLayer().SQLServer().(*sql.Server).GetSQLStatsProvider().(*persistedsqlstats.PersistedSQLStats).MaybeFlush(ctx, helper.server.AppStopper())
+	helper.server.ApplicationLayer().SQLServer().(*sql.Server).GetSQLStatsProvider().MaybeFlush(ctx, helper.server.AppStopper())
 	helper.sqlDB.Exec(t, "SET CLUSTER SETTING sql.stats.persisted_rows.max = 1")
 
 	stmtStatsCnt, txnStatsCnt := getPersistedStatsEntry(t, helper.sqlDB)

--- a/pkg/sql/sqlstats/persistedsqlstats/stmt_reader.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/stmt_reader.go
@@ -21,7 +21,6 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
-// IterateStatementStats implements sqlstats.Provider interface.
 func (s *PersistedSQLStats) IterateStatementStats(
 	ctx context.Context, options sqlstats.IteratorOptions, visitor sqlstats.StatementVisitor,
 ) (err error) {

--- a/pkg/sql/sqlstats/persistedsqlstats/txn_reader.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/txn_reader.go
@@ -20,7 +20,6 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
-// IterateTransactionStats implements sqlstats.Provider interface.
 func (s *PersistedSQLStats) IterateTransactionStats(
 	ctx context.Context, options sqlstats.IteratorOptions, visitor sqlstats.TransactionVisitor,
 ) (err error) {

--- a/pkg/sql/sqlstats/sslocal/BUILD.bazel
+++ b/pkg/sql/sqlstats/sslocal/BUILD.bazel
@@ -70,7 +70,6 @@ go_test(
         "//pkg/sql/sessionphase",
         "//pkg/sql/sqlstats",
         "//pkg/sql/sqlstats/insights",
-        "//pkg/sql/sqlstats/persistedsqlstats",
         "//pkg/sql/sqlstats/persistedsqlstats/sqlstatstestutil",
         "//pkg/sql/sqlstats/ssmemstorage",
         "//pkg/testutils",

--- a/pkg/sql/sqlstats/sslocal/sql_stats_test.go
+++ b/pkg/sql/sqlstats/sslocal/sql_stats_test.go
@@ -33,7 +33,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sessionphase"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats/insights"
-	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats/persistedsqlstats"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats/persistedsqlstats/sqlstatstestutil"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats/sslocal"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats/ssmemstorage"
@@ -337,7 +336,7 @@ WHERE
 `, [][]string{{"SELECT _ WHERE _", "1"}})
 
 	server.SQLServer().(*sql.Server).
-		GetSQLStatsProvider().(*persistedsqlstats.PersistedSQLStats).MaybeFlush(ctx, cluster.ApplicationLayer(0).AppStopper())
+		GetSQLStatsProvider().MaybeFlush(ctx, cluster.ApplicationLayer(0).AppStopper())
 
 	sqlDB.CheckQueryResults(t, `
 SELECT

--- a/pkg/sql/sqlstats/sslocal/sslocal_stats_collector.go
+++ b/pkg/sql/sqlstats/sslocal/sslocal_stats_collector.go
@@ -31,7 +31,7 @@ type StatsCollector struct {
 	// so that we can include the transaction fingerprint ID as part of the
 	// statement's key. This container is local per stats collector and
 	// is cleared for reuse after every transaction.
-	currentTransactionStatementStats sqlstats.ApplicationStats
+	currentTransactionStatementStats *ssmemstorage.Container
 
 	// stmtFingerprintID is the fingerprint ID of the current statement we are
 	// recording. Note that we don't observe sql stats for all statements (e.g. COMMIT).
@@ -62,7 +62,7 @@ type StatsCollector struct {
 	// This is the target where the statement stats are flushed to upon
 	// transaction completion. Note that these are the global stats for the
 	// application.
-	flushTarget sqlstats.ApplicationStats
+	flushTarget *ssmemstorage.Container
 
 	// uniqueServerCounts is a pointer to the statement and transaction
 	// fingerprint counters tracked per server.
@@ -75,7 +75,7 @@ type StatsCollector struct {
 // NewStatsCollector returns an instance of StatsCollector.
 func NewStatsCollector(
 	st *cluster.Settings,
-	appStats sqlstats.ApplicationStats,
+	appStats *ssmemstorage.Container,
 	insights *insights.ConcurrentBufferIngester,
 	phaseTime *sessionphase.Times,
 	uniqueServerCounts *ssmemstorage.SQLStatsAtomicCounters,
@@ -127,7 +127,7 @@ func (s *StatsCollector) PreviousPhaseTimes() *sessionphase.Times {
 
 // Reset resets the StatsCollector with a new flushTarget and a new copy
 // of the sessionphase.Times.
-func (s *StatsCollector) Reset(appStats sqlstats.ApplicationStats, phaseTime *sessionphase.Times) {
+func (s *StatsCollector) Reset(appStats *ssmemstorage.Container, phaseTime *sessionphase.Times) {
 	previousPhaseTime := s.phaseTimes
 	s.flushTarget = appStats
 

--- a/pkg/sql/sqlstats/ssmemstorage/ss_mem_storage.go
+++ b/pkg/sql/sqlstats/ssmemstorage/ss_mem_storage.go
@@ -95,8 +95,6 @@ type Container struct {
 	anomalies *insights.AnomalyDetector
 }
 
-var _ sqlstats.ApplicationStats = &Container{}
-
 // New returns a new instance of Container.
 func New(
 	st *cluster.Settings,
@@ -126,8 +124,6 @@ func New(
 	return s
 }
 
-// IterateAggregatedTransactionStats implements sqlstats.ApplicationStats
-// interface.
 func (s *Container) IterateAggregatedTransactionStats(
 	_ context.Context, _ sqlstats.IteratorOptions, visitor sqlstats.AggregatedTransactionVisitor,
 ) error {
@@ -155,7 +151,6 @@ func (s *Container) TxnStatsIterator(options sqlstats.IteratorOptions) TxnStatsI
 	return NewTxnStatsIterator(s, options)
 }
 
-// IterateStatementStats implements sqlstats.Provider interface.
 func (s *Container) IterateStatementStats(
 	ctx context.Context, options sqlstats.IteratorOptions, visitor sqlstats.StatementVisitor,
 ) error {
@@ -170,7 +165,6 @@ func (s *Container) IterateStatementStats(
 	return nil
 }
 
-// IterateTransactionStats implements sqlstats.Provider interface.
 func (s *Container) IterateTransactionStats(
 	ctx context.Context, options sqlstats.IteratorOptions, visitor sqlstats.TransactionVisitor,
 ) error {
@@ -309,9 +303,7 @@ func NewTempContainerFromExistingTxnStats(
 	return container, nil /* remaining */, nil /* err */
 }
 
-// NewApplicationStatsWithInheritedOptions implements the
-// sqlstats.ApplicationStats interface.
-func (s *Container) NewApplicationStatsWithInheritedOptions() sqlstats.ApplicationStats {
+func (s *Container) NewApplicationStatsWithInheritedOptions() *Container {
 	return New(
 		s.st,
 		// There is no need to constraint txn fingerprint limit since in temporary
@@ -684,10 +676,9 @@ func (s *Container) freeLocked(ctx context.Context) {
 	s.mu.acc.Clear(ctx)
 }
 
-// MergeApplicationStatementStats implements the sqlstats.ApplicationStats interface.
 func (s *Container) MergeApplicationStatementStats(
 	ctx context.Context,
-	other sqlstats.ApplicationStats,
+	other *Container,
 	transactionFingerprintID appstatspb.TransactionFingerprintID,
 ) (discardedStats uint64) {
 	if err := other.IterateStatementStats(

--- a/pkg/sql/sqlstats/ssmemstorage/ss_mem_writer.go
+++ b/pkg/sql/sqlstats/ssmemstorage/ss_mem_writer.go
@@ -35,9 +35,6 @@ var (
 
 var timestampSize = int64(unsafe.Sizeof(time.Time{}))
 
-var _ sqlstats.Writer = &Container{}
-
-// RecordStatement implements sqlstats.Writer interface.
 // RecordStatement saves per-statement statistics.
 //
 // samplePlanDescription can be nil, as these are only sampled periodically
@@ -176,7 +173,6 @@ func (s *Container) RecordStatement(
 	return stats.ID, nil
 }
 
-// RecordStatementExecStats implements sqlstats.Writer interface.
 func (s *Container) RecordStatementExecStats(
 	key appstatspb.StatementStatisticsKey, stats execstats.QueryLevelStats,
 ) error {
@@ -206,8 +202,7 @@ func (s *Container) ShouldSample(fingerprint string, implicitTxn bool, database 
 	return previouslySampled
 }
 
-// RecordTransaction implements sqlstats.Writer interface and saves
-// per-transaction statistics.
+// RecordTransaction saves per-transaction statistics.
 func (s *Container) RecordTransaction(
 	ctx context.Context, key appstatspb.TransactionFingerprintID, value sqlstats.RecordedTxnStats,
 ) error {

--- a/pkg/sql/sqlstats/ssprovider.go
+++ b/pkg/sql/sqlstats/ssprovider.go
@@ -18,82 +18,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/execstats"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
-	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 )
-
-// Writer is the interface that provides methods to record statement and
-// transaction stats.
-type Writer interface {
-	// RecordStatement records statistics for a statement.
-	RecordStatement(ctx context.Context, key appstatspb.StatementStatisticsKey, value RecordedStmtStats) (appstatspb.StmtFingerprintID, error)
-
-	// RecordStatementExecStats records execution statistics for a statement.
-	// This is sampled and not recorded for every single statement.
-	RecordStatementExecStats(key appstatspb.StatementStatisticsKey, stats execstats.QueryLevelStats) error
-
-	// ShouldSample returns two booleans, the first one indicates whether we
-	// ever sampled (i.e. collected statistics for) the given combination of
-	// statement metadata, and the second one whether we should save the logical
-	// plan description for it.
-	ShouldSample(fingerprint string, implicitTxn bool, database string) (previouslySampled bool)
-
-	// RecordTransaction records statistics for a transaction.
-	RecordTransaction(ctx context.Context, key appstatspb.TransactionFingerprintID, value RecordedTxnStats) error
-}
-
-// Reader provides methods to retrieve transaction/statement statistics from
-// the Storage.
-type Reader interface {
-	// IterateStatementStats iterates through all the collected statement statistics
-	// by using StatementVisitor. Caller can specify iteration behavior, such
-	// as ordering, through IteratorOptions argument. StatementVisitor can return
-	// error, if an error is returned after the execution of the visitor, the
-	// iteration is aborted.
-	IterateStatementStats(context.Context, IteratorOptions, StatementVisitor) error
-
-	// IterateTransactionStats iterates through all the collected transaction
-	// statistics by using TransactionVisitor. It behaves similarly to
-	// IterateStatementStats.
-	IterateTransactionStats(context.Context, IteratorOptions, TransactionVisitor) error
-
-	// IterateAggregatedTransactionStats iterates through all the collected app-level
-	// transactions statistics. It behaves similarly to IterateStatementStats.
-	IterateAggregatedTransactionStats(context.Context, IteratorOptions, AggregatedTransactionVisitor) error
-}
-
-// ApplicationStats is an interface to read from or write to the statistics
-// belongs to an application.
-type ApplicationStats interface {
-	Reader
-	Writer
-
-	// MergeApplicationStatementStats merges the other application's statement
-	// statistics into the current ApplicationStats. It returns how many number
-	// of statistics were being discarded due to memory constraint. The
-	// TransactionFingerprintID of all other's statement statistics keys is
-	// updated to the provided one.
-	MergeApplicationStatementStats(
-		ctx context.Context,
-		other ApplicationStats,
-		transactionFingerprintID appstatspb.TransactionFingerprintID,
-	) uint64
-
-	// MaybeLogDiscardMessage is used to possibly log a message when statistics
-	// are being discarded because of memory limits.
-	MaybeLogDiscardMessage(ctx context.Context)
-
-	// NewApplicationStatsWithInheritedOptions returns a new ApplicationStats
-	// interface that inherits all memory limits of the existing
-	NewApplicationStatsWithInheritedOptions() ApplicationStats
-
-	// Free frees the current ApplicationStats and zeros out the memory counts
-	// and fingerprint counts.
-	Free(context.Context)
-
-	// Clear is like Free but also prepares the container for reuse.
-	Clear(context.Context)
-}
 
 // IteratorOptions provides the ability to the caller to change how it iterates
 // the statements and transactions.
@@ -126,29 +52,6 @@ type TransactionVisitor func(context.Context, *appstatspb.CollectedTransactionSt
 // IterateAggregatedTransactionStats(). If an error is encountered when calling
 // the visitor, the iteration is aborted.
 type AggregatedTransactionVisitor func(appName string, statistics *appstatspb.TxnStats) error
-
-// Storage provides clients with interface to perform read and write operations
-// to sql statistics.
-type Storage interface {
-	Reader
-
-	// GetLastReset returns the last time when the sqlstats is being reset.
-	GetLastReset() time.Time
-
-	// GetApplicationStats returns an ApplicationStats instance for the given
-	// application name.
-	GetApplicationStats(appName string) ApplicationStats
-
-	// Reset resets all the statistics stored in-memory in the current Storage.
-	Reset(context.Context) error
-}
-
-// Provider is a wrapper around sqlstats subsystem for external consumption.
-type Provider interface {
-	Storage
-
-	Start(ctx context.Context, stopper *stop.Stopper)
-}
 
 // RecordedStmtStats stores the statistics of a statement to be recorded.
 type RecordedStmtStats struct {


### PR DESCRIPTION
The `Reader`, `Writer`, `ApplicationStats`, `Storage`, and `Provider` interfaces were overcomplicating the implementation and making the code harder to navigate and understand. In practice, there are generally single implementations of these interfaces so it's much simpler to just use the concrete struct pointers.

Epic: CRDB-45771

Release note: None