### PR TITLE
crosscluster/logical: allow external conn uris only

### DIFF
--- a/pkg/crosscluster/logical/create_logical_replication_stmt.go
+++ b/pkg/crosscluster/logical/create_logical_replication_stmt.go
@@ -223,9 +223,9 @@ func createLogicalReplicationStreamPlanHook(
 			srcTableNames[i] = tb.String()
 		}
 		spec, err := client.CreateForTables(ctx, &streampb.ReplicationProducerRequest{
-			TableNames:   srcTableNames,
-			AllowOffline: options.ParentID != 0,
-			// TODO(msbutler): pass reverse stream URI for validation.
+			TableNames:                  srcTableNames,
+			AllowOffline:                options.ParentID != 0,
+			UnvalidatedReverseStreamURI: options.BidirectionalURI(),
 		})
 		if err != nil {
 			return err

--- a/pkg/crosscluster/logical/dead_letter_queue_test.go
+++ b/pkg/crosscluster/logical/dead_letter_queue_test.go
@@ -506,7 +506,7 @@ func testEndToEndDLQ(t *testing.T, mode string) {
 
 	dbA.Exec(t, "SET CLUSTER SETTING logical_replication.consumer.retry_queue_duration = '100ms'")
 	dbA.Exec(t, "SET CLUSTER SETTING logical_replication.consumer.retry_queue_backoff  = '1ms'")
-	dbBURL := replicationtestutils.GetReplicationUri(t, s, s, serverutils.DBName("b"))
+	dbBURL := replicationtestutils.GetExternalConnectionURI(t, s, s, serverutils.DBName("b"))
 
 	type testCase struct {
 		tableName         string
@@ -568,9 +568,6 @@ func testEndToEndDLQ(t *testing.T, mode string) {
 		}
 		tests = append(tests, test)
 	}
-
-	dbBURL, cleanup := s.PGUrl(t, serverutils.DBName("b"))
-	defer cleanup()
 
 	for _, tc := range tests {
 		if tc.sql != "" {

--- a/pkg/crosscluster/logical/logical_replication_job_test.go
+++ b/pkg/crosscluster/logical/logical_replication_job_test.go
@@ -162,7 +162,7 @@ func TestLogicalStreamIngestionJobNameResolution(t *testing.T) {
 	server, s, dbA, dbB := setupLogicalTestServer(t, ctx, testClusterBaseClusterArgs, 1)
 	defer server.Stopper().Stop(ctx)
 
-	dbBURL := replicationtestutils.GetReplicationUri(t, s, s, serverutils.DBName("b"))
+	dbBURL := replicationtestutils.GetExternalConnectionURI(t, s, s, serverutils.DBName("b"))
 
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
@@ -271,8 +271,8 @@ func testLogicalStreamIngestionJobBasic(t *testing.T, mode string) {
 	dbA.Exec(t, "INSERT INTO tab VALUES (1, 'hello')")
 	dbB.Exec(t, "INSERT INTO tab VALUES (1, 'goodbye')")
 
-	dbAURL := replicationtestutils.GetReplicationUri(t, s, s, serverutils.DBName("a"))
-	dbBURL := replicationtestutils.GetReplicationUri(t, s, s, serverutils.DBName("b"))
+	dbAURL := replicationtestutils.GetExternalConnectionURI(t, s, s, serverutils.DBName("a"))
+	dbBURL := replicationtestutils.GetExternalConnectionURI(t, s, s, serverutils.DBName("b"))
 
 	var (
 		jobAID jobspb.JobID
@@ -315,8 +315,8 @@ func TestLogicalStreamIngestionJobWithCursor(t *testing.T) {
 	dbA.Exec(t, "INSERT INTO tab VALUES (1, 'hello')")
 	dbB.Exec(t, "INSERT INTO tab VALUES (1, 'goodbye')")
 
-	dbAURL := replicationtestutils.GetReplicationUri(t, s, s, serverutils.DBName("a"))
-	dbBURL := replicationtestutils.GetReplicationUri(t, s, s, serverutils.DBName("b"))
+	dbAURL := replicationtestutils.GetExternalConnectionURI(t, s, s, serverutils.DBName("a"))
+	dbBURL := replicationtestutils.GetExternalConnectionURI(t, s, s, serverutils.DBName("b"))
 
 	var (
 		jobAID jobspb.JobID
@@ -371,7 +371,7 @@ func TestCreateTables(t *testing.T) {
 	defer tc.Stopper().Stop(ctx)
 
 	sqlA := sqlDBs[0]
-	aURL := replicationtestutils.GetReplicationUri(t, srv, srv, serverutils.DBName("a"))
+	aURL := replicationtestutils.GetExternalConnectionURI(t, srv, srv, serverutils.DBName("a"))
 
 	t.Run("basic", func(t *testing.T) {
 		// Ensure the offline scan replicates index spans.
@@ -447,9 +447,8 @@ func TestCreateTables(t *testing.T) {
 		sqlA.Exec(t, "INSERT INTO tab3 VALUES (1, 'hello')")
 
 		sqlA.Exec(t, "CREATE DATABASE d")
+		dURL := replicationtestutils.GetExternalConnectionURI(t, srv, srv, serverutils.DBName("d"))
 		sqlD := sqlutils.MakeSQLRunner(srv.SQLConn(t, serverutils.DBName("d")))
-		dURL, cleanup := srv.PGUrl(t, serverutils.DBName("d"))
-		defer cleanup()
 
 		var jobID jobspb.JobID
 		sqlD.QueryRow(t, "CREATE LOGICALLY REPLICATED TABLE tab3 FROM TABLE tab3 ON $1 WITH BIDIRECTIONAL ON $2", aURL.String(), dURL.String()).Scan(&jobID)
@@ -469,16 +468,14 @@ func TestCreateTables(t *testing.T) {
 
 		sqlA.Exec(t, "CREATE DATABASE e")
 		sqlE := sqlutils.MakeSQLRunner(srv.SQLConn(t, serverutils.DBName("e")))
-		eURL, cleanup := srv.PGUrl(t, serverutils.DBName("e"))
-		defer cleanup()
+		eURL := replicationtestutils.GetExternalConnectionURI(t, srv, srv, serverutils.DBName("e"))
 		sqlE.ExpectErr(t, "either BIDIRECTIONAL or UNIDRECTIONAL must be specified", "CREATE LOGICALLY REPLICATED TABLE b.tab4 FROM TABLE tab4 ON $1", eURL.String())
 		sqlE.ExpectErr(t, "UNIDIRECTIONAL and BIDIRECTIONAL cannot be specified together", "CREATE LOGICALLY REPLICATED TABLE tab4 FROM TABLE tab4 ON $1 WITH BIDIRECTIONAL ON $2, UNIDIRECTIONAL", aURL.String(), eURL.String())
 	})
 	t.Run("parent id check", func(t *testing.T) {
 		sqlA.Exec(t, "CREATE DATABASE f")
 		sqlF := sqlutils.MakeSQLRunner(srv.SQLConn(t, serverutils.DBName("f")))
-		fURL, cleanup := srv.PGUrl(t, serverutils.DBName("f"))
-		defer cleanup()
+		fURL := replicationtestutils.GetExternalConnectionURI(t, srv, srv, serverutils.DBName("f"))
 
 		sqlF.Exec(t, "CREATE TABLE tab (pk int primary key, payload string)")
 
@@ -515,8 +512,8 @@ func TestLogicalStreamIngestionAdvancePTS(t *testing.T) {
 	dbA.Exec(t, "INSERT INTO tab VALUES (1, 'hello')")
 	dbB.Exec(t, "INSERT INTO tab VALUES (1, 'goodbye')")
 
-	dbAURL := replicationtestutils.GetReplicationUri(t, s, s, serverutils.DBName("a"))
-	dbBURL := replicationtestutils.GetReplicationUri(t, s, s, serverutils.DBName("b"))
+	dbAURL := replicationtestutils.GetExternalConnectionURI(t, s, s, serverutils.DBName("a"))
+	dbBURL := replicationtestutils.GetExternalConnectionURI(t, s, s, serverutils.DBName("b"))
 
 	var (
 		jobAID jobspb.JobID
@@ -551,7 +548,7 @@ func TestLogicalStreamIngestionCancelUpdatesProducerJob(t *testing.T) {
 
 	dbA.Exec(t, "SET CLUSTER SETTING physical_replication.producer.stream_liveness_track_frequency='50ms'")
 
-	dbAURL := replicationtestutils.GetReplicationUri(t, s, s, serverutils.DBName("a"))
+	dbAURL := replicationtestutils.GetExternalConnectionURI(t, s, s, serverutils.DBName("a"))
 
 	var jobBID jobspb.JobID
 	dbB.QueryRow(t, "CREATE LOGICAL REPLICATION STREAM FROM TABLE tab ON $1 INTO TABLE tab", dbAURL.String()).Scan(&jobBID)
@@ -580,7 +577,7 @@ func TestRestoreFromLDR(t *testing.T) {
 	server, s, dbA, dbB := setupLogicalTestServer(t, ctx, args, 1)
 	defer server.Stopper().Stop(ctx)
 
-	dbAURL := replicationtestutils.GetReplicationUri(t, s, s, serverutils.DBName("a"))
+	dbAURL := replicationtestutils.GetExternalConnectionURI(t, s, s, serverutils.DBName("a"))
 
 	var jobBID jobspb.JobID
 	dbA.Exec(t, "INSERT INTO tab VALUES (1, 'hello')")
@@ -610,7 +607,7 @@ func TestImportIntoLDR(t *testing.T) {
 	server, s, dbA, dbB := setupLogicalTestServer(t, ctx, args, 1)
 	defer server.Stopper().Stop(ctx)
 
-	dbAURL := replicationtestutils.GetReplicationUri(t, s, s, serverutils.DBName("a"))
+	dbAURL := replicationtestutils.GetExternalConnectionURI(t, s, s, serverutils.DBName("a"))
 
 	var jobBID jobspb.JobID
 	dbA.Exec(t, "INSERT INTO tab VALUES (1, 'hello')")
@@ -634,7 +631,7 @@ func TestLogicalStreamIngestionErrors(t *testing.T) {
 	server := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{})
 	defer server.Stopper().Stop(ctx)
 	s := server.Server(0).ApplicationLayer()
-	url := replicationtestutils.GetReplicationUri(t, s, s, serverutils.DBName("a"))
+	url := replicationtestutils.GetExternalConnectionURI(t, s, s, serverutils.DBName("a"))
 	urlA := url.String()
 
 	_, err := server.Conns[0].Exec("CREATE DATABASE a")
@@ -669,6 +666,12 @@ func TestLogicalStreamIngestionErrors(t *testing.T) {
 			"cannot CREATE LOGICAL REPLICATION STREAM in a multi-statement transaction"))
 	})
 
+	t.Run("not external conn", func(t *testing.T) {
+		sourceURI, cleanup := s.PGUrl(t, serverutils.DBName("a"))
+		defer cleanup()
+		dbB.ExpectErr(t, "uri must be an external connection", "CREATE LOGICAL REPLICATION STREAM FROM TABLE tab ON $1 INTO TABLE tab", sourceURI.String())
+	})
+
 }
 
 func TestLogicalStreamIngestionJobWithColumnFamilies(t *testing.T) {
@@ -697,7 +700,7 @@ family f2(other_payload, v2))
 
 	serverASQL.Exec(t, "INSERT INTO tab_with_cf(pk, payload, other_payload) VALUES (1, 'hello', 'ruroh1')")
 
-	serverAURL := replicationtestutils.GetReplicationUri(t, s, s)
+	serverAURL := replicationtestutils.GetExternalConnectionURI(t, s, s)
 	serverAURL.Path = "a"
 
 	var jobBID jobspb.JobID
@@ -729,7 +732,7 @@ func TestLogicalReplicationWithPhantomDelete(t *testing.T) {
 	tc, s, serverASQL, serverBSQL := setupLogicalTestServer(t, ctx, testClusterBaseClusterArgs, 1)
 	defer tc.Stopper().Stop(ctx)
 
-	serverAURL := replicationtestutils.GetReplicationUri(t, s, s, serverutils.DBName("a"))
+	serverAURL := replicationtestutils.GetExternalConnectionURI(t, s, s, serverutils.DBName("a"))
 
 	for _, mode := range []string{"validated", "immediate"} {
 		t.Run(mode, func(t *testing.T) {
@@ -768,8 +771,8 @@ func TestFilterRangefeedInReplicationStream(t *testing.T) {
 
 	dbA, dbB, dbC := dbs[0], dbs[1], dbs[2]
 
-	dbAURL := replicationtestutils.GetReplicationUri(t, s, s, serverutils.DBName("a"))
-	dbBURL := replicationtestutils.GetReplicationUri(t, s, s, serverutils.DBName("b"))
+	dbAURL := replicationtestutils.GetExternalConnectionURI(t, s, s, serverutils.DBName("a"))
+	dbBURL := replicationtestutils.GetExternalConnectionURI(t, s, s, serverutils.DBName("b"))
 
 	var jobAID, jobBID, jobCID jobspb.JobID
 
@@ -834,7 +837,7 @@ func TestRandomTables(t *testing.T) {
 	var tableName, streamStartStmt string
 	rng, _ := randutil.NewPseudoRand()
 
-	dbAURL := replicationtestutils.GetReplicationUri(t, s, s, serverutils.DBName("a"))
+	dbAURL := replicationtestutils.GetExternalConnectionURI(t, s, s, serverutils.DBName("a"))
 
 	// Keep retrying until the random table satisfies all the static checks
 	// we make when creating the replication stream.
@@ -989,7 +992,7 @@ func TestPreviouslyInterestingTables(t *testing.T) {
 	baseTableName := "rand_table"
 	rng, _ := randutil.NewPseudoRand()
 	numInserts := 20
-	dbAURL := replicationtestutils.GetReplicationUri(t, s, s, serverutils.DBName("a"))
+	dbAURL := replicationtestutils.GetExternalConnectionURI(t, s, s, serverutils.DBName("a"))
 	for i, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			tableName := fmt.Sprintf("%s%d", baseTableName, i)
@@ -1079,8 +1082,8 @@ func TestLogicalAutoReplan(t *testing.T) {
 	serverutils.SetClusterSetting(t, server, "logical_replication.replan_flow_threshold", 0)
 	serverutils.SetClusterSetting(t, server, "logical_replication.replan_flow_frequency", time.Millisecond*500)
 
-	dbAURL := replicationtestutils.GetReplicationUri(t, s, s, serverutils.DBName("a"))
-	dbBURL := replicationtestutils.GetReplicationUri(t, s, s, serverutils.DBName("b"))
+	dbAURL := replicationtestutils.GetExternalConnectionURI(t, s, s, serverutils.DBName("a"))
+	dbBURL := replicationtestutils.GetExternalConnectionURI(t, s, s, serverutils.DBName("b"))
 
 	var (
 		jobAID jobspb.JobID
@@ -1143,7 +1146,7 @@ func TestLogicalJobResiliency(t *testing.T) {
 	server, s, dbA, dbB := setupLogicalTestServer(t, ctx, clusterArgs, 3)
 	defer server.Stopper().Stop(ctx)
 
-	dbBURL := replicationtestutils.GetReplicationUri(t, s, s, serverutils.DBName("b"))
+	dbBURL := replicationtestutils.GetExternalConnectionURI(t, s, s, serverutils.DBName("b"))
 
 	CreateScatteredTable(t, dbB, 2, "B")
 
@@ -1194,8 +1197,8 @@ func TestHeartbeatCancel(t *testing.T) {
 
 	serverutils.SetClusterSetting(t, server, "logical_replication.consumer.heartbeat_frequency", time.Second*1)
 
-	dbAURL := replicationtestutils.GetReplicationUri(t, s, s, serverutils.DBName("a"))
-	dbBURL := replicationtestutils.GetReplicationUri(t, s, s, serverutils.DBName("b"))
+	dbAURL := replicationtestutils.GetExternalConnectionURI(t, s, s, serverutils.DBName("a"))
+	dbBURL := replicationtestutils.GetExternalConnectionURI(t, s, s, serverutils.DBName("b"))
 
 	var (
 		jobAID jobspb.JobID
@@ -1383,7 +1386,7 @@ func TestForeignKeyConstraints(t *testing.T) {
 	server, s, dbA, _ := setupLogicalTestServer(t, ctx, clusterArgs, 1)
 	defer server.Stopper().Stop(ctx)
 
-	dbBURL := replicationtestutils.GetReplicationUri(t, s, s, serverutils.DBName("b"))
+	dbBURL := replicationtestutils.GetExternalConnectionURI(t, s, s, serverutils.DBName("b"))
 
 	dbA.Exec(t, "CREATE TABLE test(a int primary key, b int)")
 
@@ -1533,7 +1536,7 @@ func CreateScatteredTable(t *testing.T, db *sqlutils.SQLRunner, numNodes int, db
 func GetPGURLs(t *testing.T, s serverutils.ApplicationLayerInterface, dbNames []string) []url.URL {
 	result := []url.URL{}
 	for _, name := range dbNames {
-		resultURL := replicationtestutils.GetReplicationUri(t, s, s, serverutils.DBName(name))
+		resultURL := replicationtestutils.GetExternalConnectionURI(t, s, s, serverutils.DBName(name))
 		result = append(result, resultURL)
 	}
 	return result
@@ -1686,8 +1689,8 @@ func TestLogicalStreamIngestionJobWithFallbackUDF(t *testing.T) {
 	dbB.Exec(t, lwwFunc)
 	dbA.Exec(t, lwwFunc)
 
-	dbAURL := replicationtestutils.GetReplicationUri(t, s, s, serverutils.DBName("a"))
-	dbBURL := replicationtestutils.GetReplicationUri(t, s, s, serverutils.DBName("b"))
+	dbAURL := replicationtestutils.GetExternalConnectionURI(t, s, s, serverutils.DBName("a"))
+	dbBURL := replicationtestutils.GetExternalConnectionURI(t, s, s, serverutils.DBName("b"))
 
 	var (
 		jobAID jobspb.JobID
@@ -1805,8 +1808,8 @@ func TestShowLogicalReplicationJobs(t *testing.T) {
 	server, s, dbA, dbB := setupLogicalTestServer(t, ctx, testClusterBaseClusterArgs, 1)
 	defer server.Stopper().Stop(ctx)
 
-	dbAURL := replicationtestutils.GetReplicationUri(t, s, s, serverutils.DBName("a"), serverutils.UserPassword(username.RootUser, "password"))
-	dbBURL := replicationtestutils.GetReplicationUri(t, s, s, serverutils.DBName("b"), serverutils.UserPassword(username.RootUser, "password"))
+	dbAURL := replicationtestutils.GetExternalConnectionURI(t, s, s, serverutils.DBName("a"), serverutils.UserPassword(username.RootUser, "password"))
+	dbBURL := replicationtestutils.GetExternalConnectionURI(t, s, s, serverutils.DBName("b"), serverutils.UserPassword(username.RootUser, "password"))
 
 	var (
 		jobAID jobspb.JobID
@@ -1946,7 +1949,7 @@ func TestUserPrivileges(t *testing.T) {
 	server, s, dbA, _ := setupLogicalTestServer(t, ctx, clusterArgs, 1)
 	defer server.Stopper().Stop(ctx)
 
-	dbBURL := replicationtestutils.GetReplicationUri(t, s, s, serverutils.DBName("b"))
+	dbBURL := replicationtestutils.GetExternalConnectionURI(t, s, s, serverutils.DBName("b"))
 
 	// Create user with no privileges
 	dbA.Exec(t, fmt.Sprintf("CREATE USER %s", username.TestUser))
@@ -2024,7 +2027,7 @@ func TestLogicalReplicationSchemaChanges(t *testing.T) {
 	server, s, dbA, dbB := setupLogicalTestServer(t, ctx, clusterArgs, 1)
 	defer server.Stopper().Stop(ctx)
 
-	dbBURL := replicationtestutils.GetReplicationUri(t, s, s, serverutils.DBName("b"))
+	dbBURL := replicationtestutils.GetExternalConnectionURI(t, s, s, serverutils.DBName("b"))
 
 	var jobAID jobspb.JobID
 	dbA.QueryRow(t, "CREATE LOGICAL REPLICATION STREAM FROM TABLE tab ON $1 INTO TABLE tab", dbBURL.String()).Scan(&jobAID)
@@ -2065,7 +2068,7 @@ func TestUserDefinedTypes(t *testing.T) {
 	server, s, dbA, dbB := setupLogicalTestServer(t, ctx, clusterArgs, 1)
 	defer server.Stopper().Stop(ctx)
 
-	dbBURL := replicationtestutils.GetReplicationUri(t, s, s, serverutils.DBName("b"))
+	dbBURL := replicationtestutils.GetExternalConnectionURI(t, s, s, serverutils.DBName("b"))
 
 	// Create the same user-defined type both tables.
 	dbA.Exec(t, "CREATE TYPE my_enum AS ENUM ('one', 'two', 'three')")
@@ -2138,15 +2141,18 @@ func TestLogicalReplicationGatewayRoute(t *testing.T) {
 	ts, s, runners, dbs := setupServerWithNumDBs(t, context.Background(), args, 1, 2)
 	defer ts.Stopper().Stop(context.Background())
 
-	url, cleanup := s.PGUrl(t, serverutils.DBName(dbs[1]))
+	sourceUrl, cleanup := s.PGUrl(t, serverutils.DBName(dbs[1]))
 	defer cleanup()
 
-	q := url.Query()
+	q := sourceUrl.Query()
 	q.Set(streamclient.RoutingModeKey, string(streamclient.RoutingModeGateway))
-	url.RawQuery = q.Encode()
+	sourceUrl.RawQuery = q.Encode()
+
+	externalUri := url.URL{Scheme: "external", Host: "replication-uri"}
+	runners[1].Exec(t, fmt.Sprintf("CREATE EXTERNAL CONNECTION '%s' AS '%s'", externalUri.Host, sourceUrl.String()))
 
 	var jobID jobspb.JobID
-	runners[0].QueryRow(t, "CREATE LOGICAL REPLICATION STREAM FROM TABLE tab ON $1 INTO TABLE tab", url.String()).Scan(&jobID)
+	runners[0].QueryRow(t, "CREATE LOGICAL REPLICATION STREAM FROM TABLE tab ON $1 INTO TABLE tab", externalUri.String()).Scan(&jobID)
 	runners[1].Exec(t, "INSERT INTO tab VALUES (1, 'hello')")
 
 	now := s.Clock().Now()
@@ -2176,7 +2182,7 @@ func TestLogicalReplicationCreationChecks(t *testing.T) {
 	server, s, dbA, dbB := setupLogicalTestServer(t, ctx, clusterArgs, 1)
 	defer server.Stopper().Stop(ctx)
 
-	dbBURL := replicationtestutils.GetReplicationUri(t, s, s, serverutils.DBName("b"))
+	dbBURL := replicationtestutils.GetExternalConnectionURI(t, s, s, serverutils.DBName("b"))
 
 	// Column families are not allowed.
 	dbA.Exec(t, "ALTER TABLE tab ADD COLUMN new_col INT NOT NULL CREATE FAMILY f1")

--- a/pkg/crosscluster/logical/logical_replication_job_test.go
+++ b/pkg/crosscluster/logical/logical_replication_job_test.go
@@ -471,6 +471,12 @@ func TestCreateTables(t *testing.T) {
 		eURL := replicationtestutils.GetExternalConnectionURI(t, srv, srv, serverutils.DBName("e"))
 		sqlE.ExpectErr(t, "either BIDIRECTIONAL or UNIDRECTIONAL must be specified", "CREATE LOGICALLY REPLICATED TABLE b.tab4 FROM TABLE tab4 ON $1", eURL.String())
 		sqlE.ExpectErr(t, "UNIDIRECTIONAL and BIDIRECTIONAL cannot be specified together", "CREATE LOGICALLY REPLICATED TABLE tab4 FROM TABLE tab4 ON $1 WITH BIDIRECTIONAL ON $2, UNIDIRECTIONAL", aURL.String(), eURL.String())
+
+		// Reverse stream uri not an external connection
+		eURLRaw, cleanup := srv.PGUrl(t, serverutils.DBName("e"))
+		defer cleanup()
+		sqlE.ExpectErr(t, "reverse stream uri failed validation", "CREATE LOGICALLY REPLICATED TABLE tab4 FROM TABLE tab4 ON $1 WITH BIDIRECTIONAL ON $2", aURL.String(), eURLRaw.String())
+
 	})
 	t.Run("parent id check", func(t *testing.T) {
 		sqlA.Exec(t, "CREATE DATABASE f")

--- a/pkg/crosscluster/logical/udf_row_processor_test.go
+++ b/pkg/crosscluster/logical/udf_row_processor_test.go
@@ -85,7 +85,7 @@ func TestUDFWithRandomTables(t *testing.T) {
 		sqlA, tableName, numInserts, nil)
 	require.NoError(t, err)
 
-	dbAURL := replicationtestutils.GetReplicationUri(t, s, s, serverutils.DBName("a"))
+	dbAURL := replicationtestutils.GetExternalConnectionURI(t, s, s, serverutils.DBName("a"))
 
 	streamStartStmt := fmt.Sprintf("CREATE LOGICAL REPLICATION STREAM FROM TABLE %[1]s ON $1 INTO TABLE %[1]s WITH FUNCTION repl_apply FOR TABLE %[1]s", tableName)
 	var jobBID jobspb.JobID
@@ -126,7 +126,7 @@ func TestUDFInsertOnly(t *testing.T) {
 		$$ LANGUAGE plpgsql
 		`)
 
-	dbAURL := replicationtestutils.GetReplicationUri(t, s, s, serverutils.DBName("a"))
+	dbAURL := replicationtestutils.GetExternalConnectionURI(t, s, s, serverutils.DBName("a"))
 
 	streamStartStmt := fmt.Sprintf("CREATE LOGICAL REPLICATION STREAM FROM TABLE %[1]s ON $1 INTO TABLE %[1]s WITH DEFAULT FUNCTION = 'funcs.repl_apply'", tableName)
 	var jobBID jobspb.JobID
@@ -175,7 +175,7 @@ func TestUDFPreviousValue(t *testing.T) {
 		$$ LANGUAGE plpgsql
 		`)
 
-	dbAURL := replicationtestutils.GetReplicationUri(t, s, s, serverutils.DBName("a"))
+	dbAURL := replicationtestutils.GetExternalConnectionURI(t, s, s, serverutils.DBName("a"))
 
 	streamStartStmt := fmt.Sprintf("CREATE LOGICAL REPLICATION STREAM FROM TABLE %[1]s ON $1 INTO TABLE %[1]s WITH FUNCTION repl_apply FOR TABLE %[1]s", tableName)
 	var jobBID jobspb.JobID

--- a/pkg/crosscluster/physical/alter_replication_job_test.go
+++ b/pkg/crosscluster/physical/alter_replication_job_test.go
@@ -585,7 +585,7 @@ func TestAlterTenantStartReplicationAfterRestore(t *testing.T) {
 	enforcedGC.ts = afterBackup
 	enforcedGC.Unlock()
 
-	u := replicationtestutils.GetReplicationUri(t, srv, srv, serverutils.User(username.RootUser))
+	u := replicationtestutils.GetReplicationURI(t, srv, srv, serverutils.User(username.RootUser))
 
 	db.Exec(t, "RESTORE TENANT 3 FROM LATEST IN 'nodelocal://1/t' WITH TENANT = '5', TENANT_NAME = 't2'")
 	db.Exec(t, "ALTER TENANT t2 START REPLICATION OF t1 ON $1", u.String())

--- a/pkg/crosscluster/physical/stream_ingestion_job_test.go
+++ b/pkg/crosscluster/physical/stream_ingestion_job_test.go
@@ -132,8 +132,8 @@ func TestTenantStreamingFailback(t *testing.T) {
 	sqlA := sqlutils.MakeSQLRunner(aDB)
 	sqlB := sqlutils.MakeSQLRunner(bDB)
 
-	serverAURL := replicationtestutils.GetReplicationUri(t, serverA, serverB, serverutils.User(username.RootUser))
-	serverBURL := replicationtestutils.GetReplicationUri(t, serverB, serverA, serverutils.User(username.RootUser))
+	serverAURL := replicationtestutils.GetReplicationURI(t, serverA, serverB, serverutils.User(username.RootUser))
+	serverBURL := replicationtestutils.GetReplicationURI(t, serverB, serverA, serverutils.User(username.RootUser))
 
 	replicationtestutils.ConfigureDefaultSettings(t, sqlA)
 	replicationtestutils.ConfigureDefaultSettings(t, sqlB)

--- a/pkg/crosscluster/physical/stream_ingestion_planning_test.go
+++ b/pkg/crosscluster/physical/stream_ingestion_planning_test.go
@@ -43,7 +43,7 @@ func TestCreateTenantFromReplicationUsingID(t *testing.T) {
 	sqlA := sqlutils.MakeSQLRunner(aDB)
 	sqlB := sqlutils.MakeSQLRunner(bDB)
 
-	serverAURL := replicationtestutils.GetReplicationUri(t, serverA, serverB, serverutils.User(username.RootUser))
+	serverAURL := replicationtestutils.GetReplicationURI(t, serverA, serverB, serverutils.User(username.RootUser))
 
 	verifyCreatedTenant := func(t *testing.T, db *sqlutils.SQLRunner, id int64, fn func()) {
 		const query = "SELECT count(*), count(CASE WHEN id = $1 THEN 1 END) FROM system.tenants"

--- a/pkg/crosscluster/producer/BUILD.bazel
+++ b/pkg/crosscluster/producer/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "//pkg/ccl/utilccl",
         "//pkg/crosscluster",
         "//pkg/crosscluster/replicationutils",
+        "//pkg/crosscluster/streamclient",
         "//pkg/jobs",
         "//pkg/jobs/jobspb",
         "//pkg/jobs/jobsprotectedts",

--- a/pkg/crosscluster/streamclient/BUILD.bazel
+++ b/pkg/crosscluster/streamclient/BUILD.bazel
@@ -27,6 +27,7 @@ go_library(
         "//pkg/sql/isql",
         "//pkg/sql/pgwire/pgcode",
         "//pkg/util",
+        "//pkg/util/buildutil",
         "//pkg/util/ctxgroup",
         "//pkg/util/hlc",
         "//pkg/util/log",

--- a/pkg/crosscluster/streamclient/uri.go
+++ b/pkg/crosscluster/streamclient/uri.go
@@ -13,6 +13,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cloud/externalconn"
 	"github.com/cockroachdb/cockroach/pkg/sql/isql"
 	"github.com/cockroachdb/cockroach/pkg/util"
+	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
 	"github.com/cockroachdb/errors"
 )
 
@@ -71,6 +72,10 @@ func (c *ConfigUri) AsClusterUri(ctx context.Context, db isql.DB) (ClusterUri, e
 		return ClusterUri{}, errors.Wrap(err, "converting external connection into crdb cluster connection")
 	}
 	return ParseClusterUri(ec.ConnectionProto().UnredactedURI())
+}
+
+func (c *ConfigUri) IsExternalOrTestScheme() bool {
+	return c.uri.Scheme == "external" || c.uri.Scheme == "randomgen" && buildutil.CrdbTestBuild
 }
 
 // ClusterUri is a connection uri for a crdb cluster.

--- a/pkg/repstream/streampb/stream.proto
+++ b/pkg/repstream/streampb/stream.proto
@@ -85,6 +85,9 @@ message ReplicationProducerRequest {
   repeated string table_names = 4;
 
   bool allow_offline = 5;
+  
+  // Sent during bidirectional LDR setup to validate the reverse stream URI.
+  string unvalidated_reverse_stream_uri = 6 [(gogoproto.customname) = "UnvalidatedReverseStreamURI"];
 }
 
 enum ReplicationType {


### PR DESCRIPTION
Epic: none

Release note (ops change): customers must pass URIs as external connections to
create LDR statments.