### PR TITLE
crosscluster/logical: prevent LDR creation in pre 25.1 mixed version …

### DIFF
--- a/pkg/crosscluster/logical/BUILD.bazel
+++ b/pkg/crosscluster/logical/BUILD.bazel
@@ -25,6 +25,7 @@ go_library(
         "//pkg/ccl/changefeedccl/changefeedbase",
         "//pkg/ccl/utilccl",
         "//pkg/cloud",
+        "//pkg/clusterversion",
         "//pkg/crosscluster",
         "//pkg/crosscluster/physical",
         "//pkg/crosscluster/replicationutils",

--- a/pkg/crosscluster/logical/create_logical_replication_stmt.go
+++ b/pkg/crosscluster/logical/create_logical_replication_stmt.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl"
 	"github.com/cockroachdb/cockroach/pkg/cloud"
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/crosscluster"
 	"github.com/cockroachdb/cockroach/pkg/crosscluster/replicationutils"
 	"github.com/cockroachdb/cockroach/pkg/crosscluster/streamclient"
@@ -159,6 +160,10 @@ func createLogicalReplicationStreamPlanHook(
 
 		if !p.ExtendedEvalContext().TxnIsSingleStmt {
 			return errors.New("cannot CREATE LOGICAL REPLICATION STREAM in a multi-statement transaction")
+		}
+
+		if !p.ExecCfg().Settings.Version.ActiveVersion(ctx).AtLeast(clusterversion.V25_1.Version()) {
+			return errors.New("cannot create ldr stream until finalizing on 25.1")
 		}
 
 		// Commit the planner txn because several operations below may take several

--- a/pkg/crosscluster/producer/BUILD.bazel
+++ b/pkg/crosscluster/producer/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
     deps = [
         "//pkg/ccl/kvccl/kvfollowerreadsccl",
         "//pkg/ccl/utilccl",
+        "//pkg/clusterversion",
         "//pkg/crosscluster",
         "//pkg/crosscluster/replicationutils",
         "//pkg/jobs",

--- a/pkg/crosscluster/producer/replication_manager.go
+++ b/pkg/crosscluster/producer/replication_manager.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl"
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/crosscluster/replicationutils"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobsprotectedts"
 	"github.com/cockroachdb/cockroach/pkg/keys"
@@ -65,6 +66,10 @@ func (r *replicationStreamManagerImpl) StartReplicationStreamForTables(
 	}
 
 	execConfig := r.evalCtx.Planner.ExecutorConfig().(*sql.ExecutorConfig)
+
+	if !execConfig.Settings.Version.ActiveVersion(ctx).AtLeast(clusterversion.V25_1.Version()) {
+		return streampb.ReplicationProducerSpec{}, errors.New("source of ldr stream be finalized on 25.1")
+	}
 
 	if execConfig.Codec.IsSystem() && !kvserver.RangefeedEnabled.Get(&execConfig.Settings.SV) {
 		return streampb.ReplicationProducerSpec{}, errors.Errorf("kv.rangefeed.enabled must be enabled on the source cluster for logical replication")


### PR DESCRIPTION
…state

This patch prevents a user from beginning LDR in a 24.3/25.1 mixed version state. They must finalize their 25.1 upgrade before beginning LDR.

Around 25.2 branch cut, we will reevaluate bumping these version gates.

Epic: none

Release note: none