### PR TITLE
roachprod: optimize logging configuration file copy

### DIFF
--- a/pkg/roachprod/install/cockroach.go
+++ b/pkg/roachprod/install/cockroach.go
@@ -762,6 +762,7 @@ func (c *SyncedCluster) ExecSQL(
 func (c *SyncedCluster) startNodeWithResult(
 	ctx context.Context, l *logger.Logger, node Node, startOpts StartOpts,
 ) (*RunResultDetails, error) {
+	l.Printf("starting node %d", node)
 	startScriptPath := StartScriptPath(startOpts.VirtualClusterName, startOpts.SQLInstance)
 	var runScriptCmd string
 	if c.IsLocal() {
@@ -983,8 +984,12 @@ func (c *SyncedCluster) generateStartArgs(
 			loggingConfigFile := fmt.Sprintf("cockroachdb-logging%s.yaml",
 				virtualClusterDirSuffix(startOpts.VirtualClusterName, startOpts.SQLInstance))
 
-			if err := c.PutString(ctx, l, Nodes{node}, loggingConfig, loggingConfigFile, 0644); err != nil {
-				return nil, errors.Wrap(err, "failed writing remote logging configuration: %w")
+			// To speed up the startup time of nodes in large cluster, the cockroachdb-logging.yaml file is copied
+			// to all nodes in parallel.
+			if c.Nodes[0] == node {
+				if err := c.PutString(ctx, l, c.Nodes, loggingConfig, loggingConfigFile, 0644); err != nil {
+					return nil, errors.Wrap(err, "failed writing remote logging configuration: %w")
+				}
 			}
 
 			args = append(args, "--log-config-file", loggingConfigFile)


### PR DESCRIPTION
This PR reduces the startup time for large clusters by parallelizing the logging configuration file copy process.

For a cluster with 79 nodes in the asia-south1 (Mumbai) region:
- roachprod start without the `--enable-fluent-sink` flag takes an average of 2 seconds per node, totaling 2m38s.
- roachprod start with the `--enable-fluent-sink` flag takes an average of 3.35 seconds per node, totaling 4m25s.

After this change:
- roachprod start with the `--enable-fluent-sink` flag takes an average of 2 seconds per node, totaling 2m37s, which is equivalent to the case without the flag.

Epic: none

Release note: None