### PR TITLE
release-24.2: roachtest: use same arch for cockroach nodes and workload node

### DIFF
--- a/pkg/cmd/roachtest/spec/cluster_spec.go
+++ b/pkg/cmd/roachtest/spec/cluster_spec.go
@@ -434,11 +434,11 @@ func (s *ClusterSpec) RoachprodOpts(
 	var err error
 	switch cloud {
 	case AWS:
-		workloadMachineType, _, err = SelectAWSMachineType(s.WorkloadNodeCPUs, s.Mem, preferLocalSSD && s.VolumeSize == 0, requestedArch)
+		workloadMachineType, _, err = SelectAWSMachineType(s.WorkloadNodeCPUs, s.Mem, preferLocalSSD && s.VolumeSize == 0, selectedArch)
 	case GCE:
-		workloadMachineType, _ = SelectGCEMachineType(s.WorkloadNodeCPUs, s.Mem, requestedArch)
+		workloadMachineType, _ = SelectGCEMachineType(s.WorkloadNodeCPUs, s.Mem, selectedArch)
 	case Azure:
-		workloadMachineType, _, err = SelectAzureMachineType(s.WorkloadNodeCPUs, s.Mem, requestedArch)
+		workloadMachineType, _, err = SelectAzureMachineType(s.WorkloadNodeCPUs, s.Mem, selectedArch)
 	}
 	if err != nil {
 		return vm.CreateOpts{}, nil, nil, "", err


### PR DESCRIPTION
Backport 1/1 commits from #129904.

/cc @cockroachdb/release

---

Prior to this commit, there was a chance that the machine type selection logic chose an architecture different from the one requested. When the same logic was then called to compute the machine type for the workload node, it could pick a machine type that is only compatible with a different archicture (the requested one).

Since we only create one shared instance of `CreateVMOpts` (which includes the selected arch) for both the cockroach nodes and the workload node, the `ProviderOpts` for both cases also need to be compatible with one another, otherwise it can lead to cluster creation errors.

Epic: none
Release note: None
Release justification: test-only change