### PR TITLE
changefeedccl: Add more context cdc error message when cursor is older than gc threshold

### DIFF
--- a/pkg/ccl/changefeedccl/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/BUILD.bazel
@@ -85,6 +85,7 @@ go_library(
         "//pkg/kv/kvserver/closedts",
         "//pkg/kv/kvserver/protectedts",
         "//pkg/kv/kvserver/protectedts/ptpb",
+        "//pkg/kv/kvpb",
         "//pkg/multitenant",
         "//pkg/roachpb",
         "//pkg/scheduledjobs",

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -5225,7 +5225,7 @@ func TestChangefeedDataTTL(t *testing.T) {
 		// second should be returning
 		for {
 			msg, err := dataExpiredRows.Next()
-			if testutils.IsError(err, `must be after replica GC threshold`) {
+			if testutils.IsError(err, `could not create changefeed because cursor is older than GC threshold`) {
 				t.Logf("got expected GC error: %s", err)
 				break
 			}
@@ -5325,7 +5325,7 @@ func TestChangefeedSchemaTTL(t *testing.T) {
 		for {
 			_, err := dataExpiredRows.Next()
 			if err != nil {
-				require.Regexp(t, `GC threshold`, err)
+				require.Regexp(t, `could not create changefeed because cursor is older than GC threshold`, err)
 				break
 			}
 		}


### PR DESCRIPTION
Fixes #137317