### PR TITLE
kvserver: keep unreplicated locks on split

### DIFF
--- a/pkg/kv/kvserver/concurrency/BUILD.bazel
+++ b/pkg/kv/kvserver/concurrency/BUILD.bazel
@@ -36,6 +36,7 @@ go_library(
         "//pkg/util/hlc",
         "//pkg/util/humanizeutil",
         "//pkg/util/log",
+        "//pkg/util/metamorphic",
         "//pkg/util/metric",
         "//pkg/util/stop",
         "//pkg/util/syncutil",

--- a/pkg/kv/kvserver/concurrency/concurrency_control.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_control.go
@@ -290,9 +290,14 @@ type RangeStateListener interface {
 	// replica is the leaseholder going forward.
 	OnRangeLeaseUpdated(_ roachpb.LeaseSequence, isLeaseholder bool)
 
-	// OnRangeSplit informs the concurrency manager that its range has split off
-	// a new range to its RHS.
-	OnRangeSplit()
+	// OnRangeSplit informs the concurrency manager that its range
+	// has split off a new range to its RHS. The provided key
+	// should be the new RHS StartKey (LHS EndKey). Note that this
+	// is inclusives so all locks on keys greater or equal to this
+	// key will be cleared. The returned LockAcquistion structs
+	// represent locks that we may want to acquire on the RHS
+	// replica before it is serving requests.
+	OnRangeSplit(roachpb.Key) []roachpb.LockAcquisition
 
 	// OnRangeMerge informs the concurrency manager that its range has merged
 	// into its LHS neighbor. This is not called on the LHS range being merged
@@ -1029,4 +1034,8 @@ type requestQueuer interface {
 	// Clear empties the queue(s) and causes all waiting requests to
 	// return. If disable is true, future requests must not be enqueued.
 	Clear(disable bool)
+
+	// ClearGE empties the queue(s) for any keys greater or equal
+	// to than the given key.
+	ClearGE(roachpb.Key) []roachpb.LockAcquisition
 }

--- a/pkg/kv/kvserver/concurrency/concurrency_manager.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_manager.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/debugutil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/metamorphic"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
@@ -110,6 +111,15 @@ var BatchPushedLockResolution = settings.RegisterBoolSetting(
 		"conflicting locks whose holder is known to be pending and have been pushed above the reader's "+
 		"timestamp",
 	true,
+)
+
+// UnreplicatedLockReliability controls whether the replica will attempt
+// to keep unreplicated locks during node operations such as split.
+var UnreplicatedLockReliability = settings.RegisterBoolSetting(
+	settings.SystemOnly,
+	"kv.lock_table.unreplicated_lock_reliability.enabled",
+	"whether the replica should attempt to keep unreplicated locks during various node operations",
+	metamorphic.ConstantWithTestBool("kv.lock_table.unreplicated_lock_reliability_upgrade.enabled", true),
 )
 
 // managerImpl implements the Manager interface.
@@ -588,14 +598,22 @@ func (m *managerImpl) OnRangeLeaseUpdated(seq roachpb.LeaseSequence, isLeasehold
 	}
 }
 
-// OnRangeSplit implements the RangeStateListener interface.
-func (m *managerImpl) OnRangeSplit() {
-	// TODO(nvanbenschoten): it only essential that we clear the half of the
-	// lockTable which contains locks in the key range that is being split off
-	// from the current range. For now though, we clear it all.
-	const disable = false
-	m.lt.Clear(disable)
-	m.twq.Clear(disable)
+// OnRangeSplit implements the RangeStateListener interface. It is called on the
+// LHS replica of a split and should be passed the new RHS start key (LHS
+// EndKey).
+func (m *managerImpl) OnRangeSplit(rhsStartKey roachpb.Key) []roachpb.LockAcquisition {
+	if UnreplicatedLockReliability.Get(&m.st.SV) {
+		lockToMove := m.lt.ClearGE(rhsStartKey)
+		m.twq.ClearGE(rhsStartKey)
+		return lockToMove
+	} else {
+		// TODO(ssd): We could call ClearGE here but ignore the
+		// response. But for now we leave the old behaviour unchanged.
+		const disable = false
+		m.lt.Clear(disable)
+		m.twq.Clear(disable)
+		return nil
+	}
 }
 
 // OnRangeMerge implements the RangeStateListener interface.

--- a/pkg/kv/kvserver/concurrency/lock_table_test.go
+++ b/pkg/kv/kvserver/concurrency/lock_table_test.go
@@ -618,7 +618,17 @@ func TestLockTableBasic(t *testing.T) {
 			case "clear":
 				lt.Clear(d.HasArg("disable"))
 				return lt.String()
-
+			case "clear-ge":
+				var endKeyStr string
+				d.ScanArgs(t, "key", &endKeyStr)
+				locks := lt.ClearGE(roachpb.Key(endKeyStr))
+				var buf strings.Builder
+				fmt.Fprintf(&buf, "num returned for re-acquisition: %d", len(locks))
+				for _, l := range locks {
+					fmt.Fprintf(&buf, "\n span: %s, txn: %s epo: %d, dur: %s, str: %s",
+						l.Span, l.Txn.ID, l.Txn.Epoch, l.Durability, l.Strength)
+				}
+				return buf.String()
 			case "print":
 				return lt.String()
 

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/range_state_listener
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/range_state_listener
@@ -413,9 +413,11 @@ num=1
    queued locking requests:
     active: true req: 6, strength: Intent, txn: 00000002-0000-0000-0000-000000000000
 
-on-split
+# Split with all keys on the RHS
+on-split key=a
 ----
 [-] split range: complete
+[-] split range: range split returned 1 locks for re-acquistion
 [2] sequence req2: lock wait-queue event: done waiting
 [2] sequence req2: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"k"› for 0.000s
 [2] sequence req2: acquiring latches
@@ -494,6 +496,193 @@ num=1
 finish req=req2
 ----
 [-] finish req2: finishing request
+
+reset namespace
+----
+
+# -------------------------------------------------------------
+# OnRangeSplit2 - A range split should not lose locks on the LHS of
+# the split.
+#
+# Setup: txn1 acquires lock k1
+#        txn2 acquires lock k3
+#
+# Test:  txn3 enters lock k1s wait-queue
+#        txn4 enters lock k3s wait-queue
+#        range is split at k2
+#        txn3 continues to wait
+#        txn4 proceeds
+# -------------------------------------------------------------
+
+new-txn name=txn1 ts=10,1 epoch=0
+----
+
+new-txn name=txn2 ts=10,1 epoch=0
+----
+
+new-txn name=txn3 ts=10,1 epoch=0
+----
+
+new-txn name=txn4 ts=10,1 epoch=0
+----
+
+new-request name=req1 txn=txn1 ts=10,1
+  put key=k1 value=v
+----
+
+new-request name=req2 txn=txn2 ts=10,1
+  put key=k3 value=v
+----
+
+new-request name=req3 txn=txn3 ts=10,1
+  put key=k1 value=v
+----
+
+new-request name=req4 txn=txn4 ts=10,1
+  put key=k3 value=v
+----
+
+sequence req=req1
+----
+[1] sequence req1: sequencing request
+[1] sequence req1: acquiring latches
+[1] sequence req1: scanning lock table for conflicting locks
+[1] sequence req1: sequencing complete, returned guard
+
+sequence req=req2
+----
+[2] sequence req2: sequencing request
+[2] sequence req2: acquiring latches
+[2] sequence req2: scanning lock table for conflicting locks
+[2] sequence req2: sequencing complete, returned guard
+
+on-lock-acquired req=req1 key=k1
+----
+[-] acquire lock: txn 00000001 @ ‹k1›
+
+on-lock-acquired req=req2 key=k3
+----
+[-] acquire lock: txn 00000002 @ ‹k3›
+
+finish req=req1
+----
+[-] finish req1: finishing request
+
+finish req=req2
+----
+[-] finish req2: finishing request
+
+debug-lock-table
+----
+num=2
+ lock: "k1"
+  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
+ lock: "k3"
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
+
+# --------------------------------
+# Setup complete, test starts here
+# --------------------------------
+
+sequence req=req3
+----
+[3] sequence req3: sequencing request
+[3] sequence req3: acquiring latches
+[3] sequence req3: scanning lock table for conflicting locks
+[3] sequence req3: waiting in lock wait-queues
+[3] sequence req3: lock wait-queue event: wait for txn 00000001 holding lock @ key ‹"k1"› (queuedLockingRequests: 1, queuedReaders: 0)
+[3] sequence req3: pushing after 1h0m0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
+[3] sequence req3: blocked on select in concurrency.(*lockTableWaiterImpl).WaitOn
+
+debug-lock-table
+----
+num=2
+ lock: "k1"
+  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
+   queued locking requests:
+    active: true req: 9, strength: Intent, txn: 00000003-0000-0000-0000-000000000000
+ lock: "k3"
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
+
+sequence req=req4
+----
+[4] sequence req4: sequencing request
+[4] sequence req4: acquiring latches
+[4] sequence req4: scanning lock table for conflicting locks
+[4] sequence req4: waiting in lock wait-queues
+[4] sequence req4: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"k3"› (queuedLockingRequests: 1, queuedReaders: 0)
+[4] sequence req4: pushing after 1h0m0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
+[4] sequence req4: blocked on select in concurrency.(*lockTableWaiterImpl).WaitOn
+
+
+debug-lock-table
+----
+num=2
+ lock: "k1"
+  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
+   queued locking requests:
+    active: true req: 9, strength: Intent, txn: 00000003-0000-0000-0000-000000000000
+ lock: "k3"
+  holder: txn: 00000002-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
+   queued locking requests:
+    active: true req: 10, strength: Intent, txn: 00000004-0000-0000-0000-000000000000
+
+# Split with k1 on LHS and k3 on RHS.
+#
+# Request 4 is allowed to proceed. Note that in a real world this
+# request would be be rejected because of the new range bounds.
+on-split key=k2
+----
+[-] split range: complete
+[-] split range: range split returned 1 locks for re-acquistion
+[4] sequence req4: lock wait-queue event: done waiting
+[4] sequence req4: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"k3"› for 0.000s
+[4] sequence req4: acquiring latches
+[4] sequence req4: scanning lock table for conflicting locks
+[4] sequence req4: sequencing complete, returned guard
+
+finish req=req4
+----
+[-] finish req4: finishing request
+
+debug-lock-table
+----
+num=1
+ lock: "k1"
+  holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
+   queued locking requests:
+    active: true req: 9, strength: Intent, txn: 00000003-0000-0000-0000-000000000000
+
+
+new-request name=reqRes1 txn=none ts=10,1
+  resolve-intent txn=txn1 key=k1 status=committed
+----
+
+sequence req=reqRes1
+----
+[5] sequence reqRes1: sequencing request
+[5] sequence reqRes1: acquiring latches
+[5] sequence reqRes1: sequencing complete, returned guard
+
+on-lock-updated req=reqRes1 txn=txn1 key=k1 status=committed
+----
+[-] update lock: committing txn 00000001 @ ‹k1›
+[3] sequence req3: lock wait-queue event: done waiting
+[3] sequence req3: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"k1"› for 0.000s
+[3] sequence req3: acquiring latches
+[3] sequence req3: waiting to acquire write latch ‹k1›@10.000000000,1 for request Put [‹"k1"›], [txn: 00000003], held by write latch ‹k1›@10.000000000,1 for request ResolveIntent [‹"k1"›]
+[3] sequence req3: blocked on select in spanlatch.(*Manager).waitForSignal
+
+
+finish req=reqRes1
+----
+[-] finish reqRes1: finishing request
+[3] sequence req3: scanning lock table for conflicting locks
+[3] sequence req3: sequencing complete, returned guard
+
+finish req=req3
+----
+[-] finish req3: finishing request
 
 reset namespace
 ----
@@ -589,7 +778,7 @@ num=1
  lock: "k"
   holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
    queued locking requests:
-    active: true req: 8, strength: Intent, txn: 00000002-0000-0000-0000-000000000000
+    active: true req: 12, strength: Intent, txn: 00000002-0000-0000-0000-000000000000
 
 on-merge
 ----
@@ -656,7 +845,7 @@ num=1
  lock: "k"
   holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
    queued locking requests:
-    active: false req: 10, strength: Intent, txn: 00000002-0000-0000-0000-000000000000
+    active: false req: 14, strength: Intent, txn: 00000002-0000-0000-0000-000000000000
 
 sequence req=req2
 ----
@@ -698,7 +887,7 @@ debug-lock-table
 num=1
  lock: "k"
    queued locking requests:
-    active: false req: 10, strength: Intent, txn: 00000002-0000-0000-0000-000000000000
+    active: false req: 14, strength: Intent, txn: 00000002-0000-0000-0000-000000000000
 
 on-lock-acquired req=req2 key=k
 ----
@@ -787,7 +976,7 @@ num=1
  lock: "k"
   holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
    queued locking requests:
-    active: true req: 12, strength: Intent, txn: 00000002-0000-0000-0000-000000000000
+    active: true req: 16, strength: Intent, txn: 00000002-0000-0000-0000-000000000000
 
 on-snapshot-applied
 ----
@@ -813,7 +1002,7 @@ num=1
  lock: "k"
   holder: txn: 00000001-0000-0000-0000-000000000000 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent]
    queued locking requests:
-    active: false req: 12, strength: Intent, txn: 00000002-0000-0000-0000-000000000000
+    active: false req: 16, strength: Intent, txn: 00000002-0000-0000-0000-000000000000
 
 sequence req=req2
 ----
@@ -855,7 +1044,7 @@ debug-lock-table
 num=1
  lock: "k"
    queued locking requests:
-    active: false req: 12, strength: Intent, txn: 00000002-0000-0000-0000-000000000000
+    active: false req: 16, strength: Intent, txn: 00000002-0000-0000-0000-000000000000
 
 on-lock-acquired req=req2 key=k
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/clear_rhs
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/clear_rhs
@@ -1,0 +1,173 @@
+# This test setup is the same as clear.
+
+new-lock-table maxlocks=10000
+----
+
+# Define three transaction that we'll use below.
+
+new-txn txn=txn1 ts=10,1 epoch=0
+----
+
+new-txn txn=txn2 ts=8,1 epoch=0
+----
+
+new-txn txn=txn3 ts=12,1 epoch=0
+----
+
+# txn1 acquires unreplicated exclusive locks at a and b.
+
+new-request r=req1 txn=txn1 ts=10,1 spans=exclusive@a+exclusive@b
+----
+
+scan r=req1
+----
+start-waiting: false
+
+guard-state r=req1
+----
+new: state=doneWaiting
+
+acquire r=req1 k=a durability=u strength=exclusive
+----
+num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
+
+acquire r=req1 k=b durability=u strength=exclusive
+----
+num=2
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
+ lock: "b"
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
+
+dequeue r=req1
+----
+num=2
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
+ lock: "b"
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
+
+# In its next request, txn1 discovers a lock at c held by txn2.
+
+new-request r=req2 txn=txn1 ts=10,1 spans=none@c
+----
+
+scan r=req2
+----
+start-waiting: false
+
+guard-state r=req2
+----
+new: state=doneWaiting
+
+add-discovered r=req2 k=c txn=txn2
+----
+num=3
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
+ lock: "b"
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
+ lock: "c"
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 8.000000000,1, info: repl [Intent]
+
+# A non-transactional read comes in at a and blocks on the lock.
+
+new-request r=req3 txn=none ts=10,1 spans=none@a
+----
+
+scan r=req3
+----
+start-waiting: true
+
+guard-state r=req3
+----
+new: state=waitFor txn=txn1 key="a" held=true guard-strength=None
+
+# Similarly, a non-transactional write at a arrives and blocks.
+
+new-request r=req4 txn=none ts=10,1 spans=intent@a
+----
+
+scan r=req4
+----
+start-waiting: true
+
+guard-state r=req4
+----
+new: state=waitFor txn=txn1 key="a" held=true guard-strength=Intent
+
+# txn3 tries to write to b which also has a lock held, so txn3 has to wait.
+
+new-request r=req5 txn=txn3 ts=12,1 spans=intent@b
+----
+
+scan r=req5
+----
+start-waiting: true
+
+guard-state r=req5
+----
+new: state=waitFor txn=txn1 key="b" held=true guard-strength=Intent
+
+print
+----
+num=3
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
+   waiting readers:
+    req: 3, txn: none
+   queued locking requests:
+    active: true req: 4, strength: Intent, txn: none
+ lock: "b"
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
+   queued locking requests:
+    active: true req: 5, strength: Intent, txn: 00000000-0000-0000-0000-000000000003
+ lock: "c"
+  holder: txn: 00000000-0000-0000-0000-000000000002 epoch: 0, iso: Serializable, ts: 8.000000000,1, info: repl [Intent]
+
+# The lock on "c" is not returned because it is replicated.
+clear-ge key=b
+----
+num returned for re-acquisition: 1
+ span: b, txn: 00000000-0000-0000-0000-000000000001 epo: 0, dur: Unreplicated, str: Exclusive
+
+print
+----
+num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
+   waiting readers:
+    req: 3, txn: none
+   queued locking requests:
+    active: true req: 4, strength: Intent, txn: none
+
+
+# req3 and req4 are still waiting on a
+guard-state r=req3
+----
+old: state=waitFor txn=txn1 key="a" held=true guard-strength=None
+
+guard-state r=req4
+----
+old: state=waitFor txn=txn1 key="a" held=true guard-strength=Intent
+
+# req5 is no longer waiting
+guard-state r=req5
+----
+new: state=doneWaiting
+
+dequeue r=req3
+----
+num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]
+   queued locking requests:
+    active: true req: 4, strength: Intent, txn: none
+
+dequeue r=req4
+----
+num=1
+ lock: "a"
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 0)]

--- a/pkg/kv/kvserver/concurrency/verifiable_lock_table.go
+++ b/pkg/kv/kvserver/concurrency/verifiable_lock_table.go
@@ -51,6 +51,12 @@ func (v verifyingLockTable) Clear(disable bool) {
 	v.lt.Clear(disable)
 }
 
+// ClearGE implements the lockTable interface.
+func (v verifyingLockTable) ClearGE(key roachpb.Key) []roachpb.LockAcquisition {
+	defer v.lt.verify()
+	return v.lt.ClearGE(key)
+}
+
 // ScanAndEnqueue implements the lockTable interface.
 func (v verifyingLockTable) ScanAndEnqueue(
 	req Request, guard lockTableGuard,


### PR DESCRIPTION
Previously, a range split would result in the loss of all unreplicated locks in the lock table.

With this commit we:

1) Only clear the RHS locks from the LHS lock table. 
2) Acquire new locks on the RHS

Fixes #139139
Release note: None