### PR TITLE
release: generate cloud-only metadata artifact

### DIFF
--- a/build/teamcity/internal/release/process/build-cockroach-release-cloud-only.sh
+++ b/build/teamcity/internal/release/process/build-cockroach-release-cloud-only.sh
@@ -90,3 +90,21 @@ if [ $error = 1 ]; then
   exit 1
 fi
 tc_end_block "Verify docker images"
+
+tc_start_block "Metadata"
+timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+metadata_file="artifacts/metadata.json"
+mkdir -p artifacts
+cat > "$metadata_file" << EOF
+{
+  "sha": "$BUILD_VCS_NUMBER",
+  "timestamp": "$timestamp",
+  "tag": "$TC_BUILD_BRANCH",
+  "version": "$version",
+  "cloud_release": "$cloud_release",
+  "image": "$manifest"
+}
+EOF
+# Run jq to pretty print and validate JSON
+jq . "$metadata_file"
+tc_end_block "Metadata"


### PR DESCRIPTION
Previously, we needed to crawl the build log in order to find the cloud-only build metadata, such as version and cloud-only release number.

This PR adds a step to generate a metadata file with basic information.

Fixes: RE-783
Release note: None