### PR TITLE
vecindex: pace vector index operations

### DIFF
--- a/pkg/cmd/vecbench/BUILD.bazel
+++ b/pkg/cmd/vecbench/BUILD.bazel
@@ -2,7 +2,11 @@ load("@io_bazel_rules_go//go:def.bzl", "go_binary", "go_library")
 
 go_library(
     name = "vecbench_lib",
-    srcs = ["main.go"],
+    srcs = [
+        "chart_printer.go",
+        "main.go",
+        "percentile_estimator.go",
+    ],
     importpath = "github.com/cockroachdb/cockroach/pkg/cmd/vecbench",
     visibility = ["//visibility:private"],
     deps = [
@@ -10,11 +14,15 @@ go_library(
         "//pkg/sql/vecindex/quantize",
         "//pkg/sql/vecindex/vecstore",
         "//pkg/util/stop",
+        "//pkg/util/syncutil",
         "//pkg/util/timeutil",
         "//pkg/util/vector",
+        "@com_github_cockroachdb_crlib//crtime",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_errors//oserror",
+        "@com_github_guptarohit_asciigraph//:asciigraph",
         "@com_google_cloud_go_storage//:storage",
+        "@org_golang_x_term//:term",
     ],
 )
 

--- a/pkg/cmd/vecbench/chart_printer.go
+++ b/pkg/cmd/vecbench/chart_printer.go
@@ -1,0 +1,208 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package main
+
+import (
+	"fmt"
+	"math"
+	"strings"
+
+	"github.com/guptarohit/asciigraph"
+	"golang.org/x/term"
+)
+
+// chartData contains data for a single time series chart.
+type chartData struct {
+	caption string
+	x       int
+	y       int
+	width   int
+	height  int
+
+	series []float64
+	start  int
+	end    int
+}
+
+// chartPrinter display a grid of ASCII time series charts in the console,
+// similar to this:
+//
+// 1722 ┤    ╭─╮                ╭─────╮╭   2.00 ┼──╮      ╭╮  ╭─╮        ╭╮
+// 1700 ┤╭╮  │ ╰╮   ╭╮         ╭╯     ╰╯   1.60 ┤  │      ││  │ │        ││
+// 1678 ┤││ ╭╯  ╰╮ ╭╯╰╮╭─╮╭╮ ╭─╯           1.20 ┤  ╰───╮╭─╯╰──╯ ╰─╮╭─────╯╰─────
+// 1656 ┼╯│╭╯    │╭╯  ╰╯ ╰╯╰─╯             0.80 ┤      ││         ││
+// 1634 ┤ ││     ╰╯                        0.40 ┤      ││         ││
+// 1612 ┤ ╰╯                               0.00 ┤      ╰╯         ╰╯
+//
+//	ops/sec (1707.98)                   fixup queue size (1.00)
+//
+// 0.68 ┼─╮                                55.10 ┤                ╭╮
+// 0.64 ┤ ╰─╮                              54.40 ┤            ╭╮ ╭╯╰─╮ ╭──╮
+// 0.59 ┤   ╰╮                             53.70 ┤            │╰─╯   ╰─╯  ╰╮
+// 0.54 ┤    ╰╮                            53.00 ┤            │            ╰────
+// 0.50 ┤     ╰╮                           52.30 ┤      ╭╮ ╭──╯
+// 0.45 ┤      ╰──────────╮                51.60 ┼─╮╭───╯╰─╯
+// 0.41 ┤                 ╰─────────────   50.90 ┤ ╰╯
+//
+//	p50 ms latency (0.41)                   p99 ms latency (53.15)
+//
+// Example usage:
+//
+//	var cp chartPrinter
+//	series1 := cp.AddChart("series 1")
+//	series2 := cp.AddChart("series 2")
+//	for {
+//		...
+//		cp.AddSample(series1, sample1)
+//		cp.AddSample(series2, sample2)
+//		cp.Plot()
+//		...
+//	}
+type chartPrinter struct {
+	// Footer is the number of rows to reserve below the charts.
+	Footer int
+	// Don't show the chart. This will be automatically set if the console size
+	// cannot be determined, e.g. because we're running under a debugger.
+	Hide bool
+
+	consoleWidth  int
+	consoleHeight int
+	charts        []chartData
+	cleared       bool
+}
+
+// AddChart adds a new chart with the given caption to the chart printer. It
+// returns the ID of the chart to be used when calling AddSample.
+// NOTE: When a new chart is added, all existing charts have any existing
+// samples cleared.
+func (cp *chartPrinter) AddChart(caption string) int {
+	if len(cp.charts) == 0 {
+		// Get size of console window. File descriptor 0 is stdin.
+		var err error
+		cp.consoleWidth, cp.consoleHeight, err = term.GetSize(0)
+		if err != nil {
+			// Terminal does not support size, e.g. because we're running under a
+			// debugger. In this case, hide the charts.
+			cp.Hide = true
+			cp.consoleWidth = 80
+			cp.consoleHeight = 40
+		}
+		cp.consoleHeight -= cp.Footer
+	}
+
+	// Add new chart, but preserve captions for existing charts.
+	numCharts := len(cp.charts) + 1
+	newCharts := make([]chartData, numCharts)
+	copy(newCharts, cp.charts)
+	newCharts[numCharts-1].caption = caption
+	cp.charts = newCharts
+
+	// Re-initialize all previous charts, taking into account new chart. Divide
+	// the charts into a square grid.
+	grid := math.Ceil(math.Sqrt(float64(numCharts)))
+	xInc := float64(cp.consoleWidth) / grid
+	yInc := float64(cp.consoleHeight) / grid
+
+	x := 0.0
+	y := 0.0
+	for i := range cp.charts {
+		nextX := x + xInc
+		chartWidth := int(nextX) - int(x) - 8
+		nextY := y + yInc
+		chartHeight := int(nextY) - int(y) - 2
+
+		cp.charts[i].x = int(x)
+		cp.charts[i].y = int(y)
+		cp.charts[i].width = chartWidth
+		cp.charts[i].height = chartHeight
+		cp.charts[i].series = make([]float64, chartWidth*2)
+		cp.charts[i].start = 0
+		cp.charts[i].end = 0
+
+		x = nextX
+		if int(x+1) >= cp.consoleWidth {
+			x = 0
+			y = nextY
+		}
+	}
+
+	return numCharts - 1
+}
+
+// AddSample adds a new sample for the given chart. The chart ID should have
+// been obtained via a call to AddChart.
+func (cp *chartPrinter) AddSample(chartID int, sample float64) {
+	chart := &cp.charts[chartID]
+
+	if chart.end-chart.start < chart.width {
+		chart.series[chart.end] = sample
+		chart.end++
+	} else {
+		if chart.start >= chart.width {
+			chart.start = 0
+			chart.end = chart.width
+		}
+		chart.series[chart.start] = sample
+		chart.start++
+		chart.series[chart.end] = sample
+		chart.end++
+	}
+}
+
+// Plot prints the most recent samples for the charts on the console.
+func (cp *chartPrinter) Plot() {
+	if cp.Hide {
+		return
+	}
+
+	// Clear the console once. This "scrolls up" history so that it's not
+	// overwritten. After that, clear the console by writing spaces to it, since
+	// we don't want to keep chart printing history.
+	if !cp.cleared {
+		asciigraph.Clear()
+		cp.cleared = true
+	} else {
+		for y := range cp.consoleHeight {
+			blanks := strings.Repeat(" ", cp.consoleWidth)
+			cp.printAt(0, y, blanks)
+		}
+	}
+
+	// Print charts.
+	for i := range cp.charts {
+		chart := &cp.charts[i]
+
+		plotStr := asciigraph.Plot(chart.series[chart.start:chart.end],
+			asciigraph.Width(min(chart.end-chart.start, chart.width)),
+			asciigraph.Height(chart.height))
+
+		// Print each line at specific location.
+		lines := strings.Split(plotStr, "\n")
+		if len(lines) < chart.height {
+			// Vertically pad the chart.
+			plotStr = strings.Repeat("\n", chart.height-len(lines)) + plotStr
+			lines = strings.Split(plotStr, "\n")
+		}
+		for i, line := range lines {
+			cp.printAt(chart.x, chart.y+i, line)
+		}
+
+		// Print caption.
+		x := chart.x + (chart.width-len(chart.caption))/2
+		y := chart.y + len(lines)
+		cp.printAt(x, y, "%s (%0.2f)", White+chart.caption+Reset, chart.series[chart.end-1])
+	}
+
+	// Move cursor to footer.
+	lastChart := &cp.charts[len(cp.charts)-1]
+	cp.printAt(0, lastChart.y+lastChart.height+3, "")
+}
+
+func (cp *chartPrinter) printAt(x, y int, format string, args ...any) {
+	// Console positions are 1-based.
+	fmt.Printf("\033[%d;%dH", y+1, x+1)
+	fmt.Printf(format, args...)
+}

--- a/pkg/cmd/vecbench/percentile_estimator.go
+++ b/pkg/cmd/vecbench/percentile_estimator.go
@@ -1,0 +1,75 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package main
+
+import (
+	"math/rand"
+	"sort"
+
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+)
+
+// PercentileEstimator stores a uniform random sample of a data stream in order
+// to estimate percentiles (e.g. p50, p90, p99). It is thread-safe.
+type PercentileEstimator struct {
+	mu struct {
+		syncutil.Mutex
+
+		// reservoir records a uniform random sample of incoming data points.
+		reservoir []float64
+		// capacity is the maximum size of the reservoir.
+		capacity int
+		// count records the total number of observations seen.
+		count int
+	}
+}
+
+// NewPercentileEstimator initializes a new estimator with a fixed capacity.
+func NewPercentileEstimator(capacity int) *PercentileEstimator {
+	estimator := &PercentileEstimator{}
+	estimator.mu.reservoir = make([]float64, 0, capacity)
+	estimator.mu.capacity = capacity
+	return estimator
+}
+
+// Add records a new observation in the reservoir (with uniform probability).
+func (rs *PercentileEstimator) Add(value float64) {
+	rs.mu.Lock()
+	defer rs.mu.Unlock()
+
+	rs.mu.count++
+	if len(rs.mu.reservoir) < rs.mu.capacity {
+		// Reservoir not yet full, just append.
+		rs.mu.reservoir = append(rs.mu.reservoir, value)
+	} else {
+		// Reservoir full, replace an element at random.
+		r := rand.Intn(rs.mu.count)
+		if r < rs.mu.capacity {
+			rs.mu.reservoir[r] = value
+		}
+	}
+}
+
+// Estimate returns the given percentile (approximate) from the reservoir.
+// "percentile" must be between 0 and 1, inclusive.
+func (rs *PercentileEstimator) Estimate(percentile float64) float64 {
+	rs.mu.Lock()
+	defer rs.mu.Unlock()
+
+	if len(rs.mu.reservoir) == 0 {
+		return 0
+	}
+
+	// Sort the reservoir and return the requested percentile value.
+	size := min(rs.mu.count, rs.mu.capacity)
+	sort.Float64s(rs.mu.reservoir[:size])
+
+	idx := int(percentile * float64(size))
+	if idx >= size {
+		idx = size - 1
+	}
+	return rs.mu.reservoir[idx]
+}

--- a/pkg/sql/vecindex/BUILD.bazel
+++ b/pkg/sql/vecindex/BUILD.bazel
@@ -37,6 +37,7 @@ go_library(
 go_test(
     name = "vecindex_test",
     srcs = [
+        "fixup_processor_test.go",
         "fixup_worker_test.go",
         "index_stats_test.go",
         "kmeans_test.go",

--- a/pkg/sql/vecindex/fixup_processor_test.go
+++ b/pkg/sql/vecindex/fixup_processor_test.go
@@ -1,0 +1,41 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package vecindex
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDelayInsertOrDelete(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	stopper := stop.NewStopper()
+	defer stopper.Stop(ctx)
+
+	// Set up the fixup processor with a minimum delay and allowed ops/sec = 1.
+	var fp FixupProcessor
+	fp.minDelay = time.Hour
+	fp.Init(ctx, stopper, nil /* index */, 42 /* seed */)
+	fp.mu.pacer.Init(1, 0, fp.mu.pacer.monoNow)
+
+	// Cancel the context and verify that DelayInsertOrDelete immediately
+	// returns with an error rather than waiting out the delay.
+	cancel()
+	require.ErrorIs(t, fp.DelayInsertOrDelete(ctx), context.Canceled)
+
+	// Validate that the pacer token was returned to the bucket, since operation
+	// didn't actually happen.
+	require.GreaterOrEqual(t, fp.mu.pacer.currentTokens, 0.0)
+}

--- a/pkg/sql/vecindex/fixup_worker.go
+++ b/pkg/sql/vecindex/fixup_worker.go
@@ -23,7 +23,7 @@ import (
 // processes fixups until its context is canceled.
 type fixupWorker struct {
 	// fp points back to the processor that spawned this worker.
-	fp *fixupProcessor
+	fp *FixupProcessor
 	// index points back to the vector index to which fixups are applied.
 	index *VectorIndex
 	// rng is a random number generator. If nil, then the global random number
@@ -39,7 +39,7 @@ type fixupWorker struct {
 }
 
 // NewFixupWorker returns a new worker for the given processor.
-func NewFixupWorker(fp *fixupProcessor) *fixupWorker {
+func NewFixupWorker(fp *FixupProcessor) *fixupWorker {
 	worker := &fixupWorker{
 		fp:    fp,
 		index: fp.index,

--- a/pkg/sql/vecindex/vector_index_test.go
+++ b/pkg/sql/vecindex/vector_index_test.go
@@ -606,8 +606,8 @@ func TestVectorIndexConcurrency(t *testing.T) {
 	defer stopper.Stop(ctx)
 
 	// Load features.
-	vectors := testutils.LoadFeatures(t, 10000)
-	vectors.SplitAt(100)
+	vectors := testutils.LoadFeatures(t, 100)
+
 	primaryKeys := make([]vecstore.PrimaryKey, vectors.Count)
 	for i := 0; i < vectors.Count; i++ {
 		primaryKeys[i] = vecstore.PrimaryKey(fmt.Sprintf("vec%d", i))
@@ -666,13 +666,15 @@ func buildIndex(
 			// block of vectors. Run any pending fixups after each block.
 			for j := start; j < end; j += blockSize {
 				insertBlock(j, min(j+blockSize, end))
-				index.ProcessFixups()
 			}
 
 			wait.Done()
 		}(i, end)
 	}
 	wait.Wait()
+
+	// Process any remaining fixups.
+	index.ProcessFixups()
 }
 
 func validateIndex(ctx context.Context, t *testing.T, store *vecstore.InMemoryStore) int {


### PR DESCRIPTION
Incorporate the pacer, which tries to match the pace of foreground insert and delete operations with background fixups. Update vecbench to get observability into the progress of index builds. Show time series charts for metrics like ops/sec, latency, and fixup queue size.

Epic: CRDB-42943

Release note: None