### PR TITLE
sql/schema: guard DROP INDEX behind sql_safe_updates

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/drop_index
+++ b/pkg/sql/logictest/testdata/logic_test/drop_index
@@ -505,3 +505,16 @@ SELECT constraint_name from [SHOW CONSTRAINTS FROM fk_ref_dst];
 fk_ref_dst_pkey
 j_fk
 m_fk
+
+subtest safe_updates_rejects_drop_index
+
+statement ok
+set sql_safe_updates = true;
+set autocommit_before_ddl = true;
+CREATE TABLE roaches(id INT PRIMARY KEY, value STRING);
+CREATE INDEX roaches_value_idx ON roaches(value);
+
+statement error pq: rejected \(sql_safe_updates = true\): DROP INDEX
+DROP INDEX IF EXISTS roaches@roaches_value_idx;
+
+subtest end

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_alter_column_type.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_alter_column_type.go
@@ -267,7 +267,7 @@ func handleGeneralColumnConversion(
 ) {
 	failIfExplicitTransaction(b)
 	failIfExperimentalSettingNotSet(b, oldColType, newColType)
-	failIfSafeUpdates(b)
+	failIfSafeUpdates(b, t)
 
 	// TODO(#47137): Only support alter statements that only have a single command.
 	switch s := stmt.(type) {
@@ -455,24 +455,6 @@ func failIfExperimentalSettingNotSet(b BuildCtx, oldColType, newColType *scpb.Co
 				"you can enable alter column type general support by running "+
 					"`SET enable_experimental_alter_column_type_general = true`"),
 			pgcode.ExperimentalFeature))
-	}
-}
-
-// failIfSafeUpdates checks if the sql_safe_updates is present, and if so, it
-// will fail the operation.
-func failIfSafeUpdates(b BuildCtx) {
-	if b.SessionData().SafeUpdates {
-		panic(
-			pgerror.WithCandidateCode(
-				errors.WithMessage(
-					errors.New(
-						"ALTER COLUMN TYPE requiring data rewrite may result in data loss "+
-							"for certain type conversions or when applying a USING clause"),
-					"rejected (sql_safe_updates = true)",
-				),
-				pgcode.Warning,
-			),
-		)
 	}
 }
 

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/drop_index.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/drop_index.go
@@ -36,6 +36,8 @@ import (
 // to search all tables in current db and in schemas in the search path till
 // we first find a table with an index of name `idx`).
 func DropIndex(b BuildCtx, n *tree.DropIndex) {
+	failIfSafeUpdates(b, n)
+
 	if n.Concurrently {
 		b.EvalCtx().ClientNoticeSender.BufferClientNotice(b,
 			pgnotice.Newf("CONCURRENTLY is not required as all indexes are dropped concurrently"))


### PR DESCRIPTION
This PR makes it so that DROP INDEX is now guarded behind `sql_safe_updates`.

Fixes: #136830
Release note: DROP INDEX can now only be run when `sql_safe_updates` are set to false.