### PR TITLE
release-24.1: roachtest: collect qps metrics over longer window in gracefuldrain test

### DIFF
--- a/pkg/cmd/roachtest/tests/kv.go
+++ b/pkg/cmd/roachtest/tests/kv.go
@@ -17,6 +17,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
@@ -560,7 +561,7 @@ func registerKVGracefulDraining(r registry.Registry) {
 			})
 
 			verifyQPS := func(ctx context.Context) error {
-				if qps := measureQPS(ctx, t, time.Second, db1, db2); qps < expectedQPS {
+				if qps := measureQPS(ctx, t, base.DefaultMetricsSampleInterval, db1, db2); qps < expectedQPS {
 					return errors.Newf(
 						"QPS of %.2f at time %v is below minimum allowable QPS of %.2f",
 						qps, timeutil.Now(), expectedQPS)


### PR DESCRIPTION
Backport 1/1 commits from #139273.

/cc @cockroachdb/release

---

The gracefuldrain test was modernized in cf30717653ea2995905a0488271388e443721dce. Prior to that commit, QPS metrics were collected over a 10s interval, whereas the modernization refactor changed this to 1 second intervals. Looking at a few recent test failures, I see QPS metrics above the failure threshold, which makes me think suspect that this 1s interval is causing the sorts of inaccuracies MeasureQPS warns against. Also See https://github.com/cockroachdb/cockroach/issues/133020#issuecomment-2596953226.

One thing that doesn't line up is the timeline of this tests failure and cf30717653ea2995905a0488271388e443721dce. Still, this patch changes the metric's interval back to 10s.

References https://github.com/cockroachdb/cockroach/issues/133020

Release note: None
