### PR TITLE
storage: switch to cockroachkvs.Comparer

### DIFF
--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -1453,7 +1453,7 @@ func init() {
 	// to write those files.
 	pebbleTool := tool.New(
 		tool.Mergers(storage.MVCCMerger),
-		tool.DefaultComparer(storage.EngineComparer),
+		tool.DefaultComparer(&storage.EngineComparer),
 		tool.KeySchema(storage.DefaultKeySchema),
 		tool.KeySchemas(storage.KeySchemas...),
 		tool.FS(pebbleToolFS),

--- a/pkg/kv/kvserver/store_snapshot.go
+++ b/pkg/kv/kvserver/store_snapshot.go
@@ -317,7 +317,7 @@ func (msstw *multiSSTWriter) finalizeSST(ctx context.Context, nextKey *storage.E
 		// caller of finalizeSST (even when finalizeSST was not called), which was
 		// costly.
 		nextKeyCopy := *nextKey
-		if meta.HasPointKeys && storage.EngineKeyCompare(meta.LargestPoint.UserKey, encodedNextKey) > 0 {
+		if meta.HasPointKeys && storage.EngineComparer.Compare(meta.LargestPoint.UserKey, encodedNextKey) > 0 {
 			metaEndKey, ok := storage.DecodeEngineKey(meta.LargestPoint.UserKey)
 			if !ok {
 				return errors.Errorf("multiSSTWriter created overlapping ingestion sstables: sstable largest point key %s > next sstable start key %s",
@@ -326,7 +326,7 @@ func (msstw *multiSSTWriter) finalizeSST(ctx context.Context, nextKey *storage.E
 			return errors.Errorf("multiSSTWriter created overlapping ingestion sstables: sstable largest point key %s > next sstable start key %s",
 				metaEndKey, nextKeyCopy)
 		}
-		if meta.HasRangeDelKeys && storage.EngineKeyCompare(meta.LargestRangeDel.UserKey, encodedNextKey) > 0 {
+		if meta.HasRangeDelKeys && storage.EngineComparer.Compare(meta.LargestRangeDel.UserKey, encodedNextKey) > 0 {
 			metaEndKey, ok := storage.DecodeEngineKey(meta.LargestRangeDel.UserKey)
 			if !ok {
 				return errors.Errorf("multiSSTWriter created overlapping ingestion sstables: sstable largest range del %s > next sstable start key %s",
@@ -335,7 +335,7 @@ func (msstw *multiSSTWriter) finalizeSST(ctx context.Context, nextKey *storage.E
 			return errors.Errorf("multiSSTWriter created overlapping ingestion sstables: sstable largest range del %s > next sstable start key %s",
 				metaEndKey, nextKeyCopy)
 		}
-		if meta.HasRangeKeys && storage.EngineKeyCompare(meta.LargestRangeKey.UserKey, encodedNextKey) > 0 {
+		if meta.HasRangeKeys && storage.EngineComparer.Compare(meta.LargestRangeKey.UserKey, encodedNextKey) > 0 {
 			metaEndKey, ok := storage.DecodeEngineKey(meta.LargestRangeKey.UserKey)
 			if !ok {
 				return errors.Errorf("multiSSTWriter created overlapping ingestion sstables: sstable largest range key %s > next sstable start key %s",

--- a/pkg/server/debug/server.go
+++ b/pkg/server/debug/server.go
@@ -200,7 +200,7 @@ func analyzeLSM(dir string, writer io.Writer) error {
 	}
 
 	t := pebbletool.New(
-		pebbletool.Comparers(storage.EngineComparer),
+		pebbletool.Comparers(&storage.EngineComparer),
 		pebbletool.KeySchema(storage.DefaultKeySchema),
 		pebbletool.KeySchemas(storage.KeySchemas...),
 	)

--- a/pkg/storage/BUILD.bazel
+++ b/pkg/storage/BUILD.bazel
@@ -96,6 +96,7 @@ go_library(
         "@com_github_cockroachdb_pebble//:pebble",
         "@com_github_cockroachdb_pebble//batchrepr",
         "@com_github_cockroachdb_pebble//bloom",
+        "@com_github_cockroachdb_pebble//cockroachkvs",
         "@com_github_cockroachdb_pebble//objstorage",
         "@com_github_cockroachdb_pebble//objstorage/objstorageprovider",
         "@com_github_cockroachdb_pebble//objstorage/remote",

--- a/pkg/storage/bench_test.go
+++ b/pkg/storage/bench_test.go
@@ -2476,7 +2476,7 @@ func BenchmarkMVCCScannerWithIntentsAndVersions(b *testing.B) {
 			b.Fatal(err)
 		}
 		sort.Slice(kvPairs, func(i, j int) bool {
-			cmp := EngineKeyCompare(kvPairs[i].key, kvPairs[j].key)
+			cmp := EngineComparer.Compare(kvPairs[i].key, kvPairs[j].key)
 			if cmp == 0 {
 				// Should not happen since we resolve in a different batch from the
 				// one where we wrote the intent.

--- a/pkg/storage/engine_key_fuzz.go
+++ b/pkg/storage/engine_key_fuzz.go
@@ -54,8 +54,8 @@ func FuzzEngineKeysInvariants(f *testing.F) {
 	}
 
 	compareEngineKeys := func(t *testing.T, a, b []byte) int {
-		cmp := EngineKeyCompare(a, b)
-		eq := EngineKeyEqual(a, b)
+		cmp := EngineComparer.Compare(a, b)
+		eq := EngineComparer.Equal(a, b)
 		// Invariant: Iff EngineKeyCompare(a, b) == 0, EngineKeyEqual(a, b)
 		if eq != (cmp == 0) {
 			t.Errorf("EngineKeyEqual(0x%x, 0x%x) = %t; EngineKeyCompare(0x%x, 0x%x) = %d",

--- a/pkg/storage/mvcc_history_test.go
+++ b/pkg/storage/mvcc_history_test.go
@@ -262,7 +262,7 @@ func TestMVCCHistories(t *testing.T) {
 		// SST iterator in order to accurately represent the raw SST data.
 		reportSSTEntries := func(buf *redact.StringBuilder, name string, sst []byte) error {
 			r, err := sstable.NewMemReader(sst, sstable.ReaderOptions{
-				Comparer:   storage.EngineComparer,
+				Comparer:   &storage.EngineComparer,
 				KeySchemas: sstable.MakeKeySchemas(storage.KeySchemas...),
 			})
 			if err != nil {

--- a/pkg/storage/mvcc_key_test.go
+++ b/pkg/storage/mvcc_key_test.go
@@ -94,8 +94,8 @@ func TestMVCCKeyCompare(t *testing.T) {
 
 			// Comparators on encoded keys should be identical.
 			aEnc, bEnc := EncodeMVCCKey(tc.a), EncodeMVCCKey(tc.b)
-			require.Equal(t, tc.expect, EngineKeyCompare(aEnc, bEnc))
-			require.Equal(t, tc.expect == 0, EngineKeyEqual(aEnc, bEnc))
+			require.Equal(t, tc.expect, EngineComparer.Compare(aEnc, bEnc))
+			require.Equal(t, tc.expect == 0, EngineComparer.Equal(aEnc, bEnc))
 		})
 	}
 }
@@ -108,9 +108,9 @@ func TestMVCCKeyCompareRandom(t *testing.T) {
 		aEnc, bEnc := EncodeMVCCKey(a), EncodeMVCCKey(b)
 
 		cmp := a.Compare(b)
-		cmpEnc := EngineKeyCompare(aEnc, bEnc)
+		cmpEnc := EngineComparer.Compare(aEnc, bEnc)
 		eq := a.Equal(b)
-		eqEnc := EngineKeyEqual(aEnc, bEnc)
+		eqEnc := EngineComparer.Equal(aEnc, bEnc)
 		lessAB := a.Less(b)
 		lessBA := b.Less(a)
 
@@ -291,8 +291,8 @@ func TestDecodeUnnormalizedMVCCKey(t *testing.T) {
 			// Re-encode the key into its normal form.
 			reencoded := EncodeMVCCKey(decoded)
 			require.NotEqual(t, encoded, reencoded)
-			require.Equal(t, tc.equalToNormal, EngineKeyEqual(encoded, reencoded))
-			require.Equal(t, tc.equalToNormal, EngineKeyCompare(encoded, reencoded) == 0)
+			require.Equal(t, tc.equalToNormal, EngineComparer.Equal(encoded, reencoded))
+			require.Equal(t, tc.equalToNormal, EngineComparer.Compare(encoded, reencoded) == 0)
 		})
 	}
 }

--- a/pkg/storage/pebble_test.go
+++ b/pkg/storage/pebble_test.go
@@ -88,6 +88,7 @@ func TestEngineComparer(t *testing.T) {
 	ts5 := hlc.Timestamp{WallTime: 1}
 
 	syntheticBit := []byte{1}
+	var zeroLogical [mvccEncodedTimeLogicalLen]byte
 	ts2a := appendBytesToTimestamp(ts2, syntheticBit)
 	ts3a := appendBytesToTimestamp(ts3, zeroLogical[:])
 	ts3b := appendBytesToTimestamp(ts3, slices.Concat(zeroLogical[:], syntheticBit))
@@ -189,7 +190,7 @@ func TestEngineComparer(t *testing.T) {
 	for _, v := range []any{ts1, ts2, ts2a, ts3, ts3a, ts3b, ts4, ts5, lock1, lock2} {
 		suffixes = append(suffixes, encodeVersion(v))
 	}
-	require.NoError(t, pebble.CheckComparer(EngineComparer, prefixes, suffixes))
+	require.NoError(t, pebble.CheckComparer(&EngineComparer, prefixes, suffixes))
 }
 
 func TestPebbleIterReuse(t *testing.T) {
@@ -534,7 +535,7 @@ func BenchmarkMVCCKeyCompare(b *testing.B) {
 	keys := makeRandEncodedKeys()
 	b.ResetTimer()
 	for i, j := 0, 0; i < b.N; i, j = i+1, j+3 {
-		_ = EngineKeyCompare(keys[i%len(keys)], keys[j%len(keys)])
+		_ = EngineComparer.Compare(keys[i%len(keys)], keys[j%len(keys)])
 	}
 }
 
@@ -542,7 +543,7 @@ func BenchmarkMVCCKeyEqual(b *testing.B) {
 	keys := makeRandEncodedKeys()
 	b.ResetTimer()
 	for i, j := 0, 0; i < b.N; i, j = i+1, j+3 {
-		_ = EngineKeyEqual(keys[i%len(keys)], keys[j%len(keys)])
+		_ = EngineComparer.Equal(keys[i%len(keys)], keys[j%len(keys)])
 	}
 }
 


### PR DESCRIPTION
Switch to using the `cockroachkvs.Comparer` implementation (which
is identical).

Informs #139068

Release note: None
Epic: none