### PR TITLE
scripts: refactor gceworker for managed-service support

### DIFF
--- a/build/bootstrap/bootstrap-debian.sh
+++ b/build/bootstrap/bootstrap-debian.sh
@@ -6,8 +6,8 @@
 # included in the /LICENSE file.
 
 #
-# On a Debian/Ubuntu system, bootstraps a docker install and the cockroach
-# repo.
+# On a Debian/Ubuntu system, bootstraps all the required dependencies for the
+# cockroach & managed-service repos.
 
 set -euxo pipefail
 
@@ -31,15 +31,9 @@ sudo apt-get install -y --no-install-recommends \
 
 # pnpm doesn't provide a Debian repository, and supports either `curl | sh` or `npm install -g` installations.
 curl -fsSL https://get.pnpm.io/install.sh | env PNPM_VERSION=8.6.6 sh -
-echo -e '\n' >> ~/.bashrc
+echo >> ~/.bashrc
 
 sudo adduser "${USER}" docker
-
-# Configure environment variables.
-echo 'export PATH="${PATH}:$HOME/go/src/github.com/cockroachdb/cockroach/bin:/usr/local/go/bin"' >> ~/.bashrc_bootstrap
-echo -e '\n' >> ~/.bashrc
-echo '. ~/.bashrc_bootstrap' >> ~/.bashrc
-. ~/.bashrc_bootstrap
 
 # Upgrade cmake.
 trap 'rm -f /tmp/cmake.tgz' EXIT
@@ -57,9 +51,15 @@ sha256sum -c - <<EOF
 EOF
 sudo tar -C /usr/local -zxf /tmp/go.tgz && rm /tmp/go.tgz
 
-# Clone CockroachDB.
-git clone https://github.com/cockroachdb/cockroach "$(go env GOPATH)/src/github.com/cockroachdb/cockroach"
-git -C "$(go env GOPATH)/src/github.com/cockroachdb/cockroach" submodule update --init
+# Install Docker compose.
+sudo curl -L "https://github.com/docker/compose/releases/download/v2.32.4/docker-compose-linux-x86_64" -o /usr/local/bin/docker-compose
+sudo chmod +x /usr/local/bin/docker-compose
+docker-compose --version
+
+# Install NVM.
+# Note: you still required to run `nvm install <version>` to install a specific version of Node.js.
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash
+echo >> ~/.bashrc
 
 # Install Bazelisk as Bazel.
 # NOTE: you should keep this in sync with build/packer/teamcity-agent.sh and build/bazelbuilder/Dockerfile -- if
@@ -72,3 +72,13 @@ sudo mv /tmp/bazelisk /usr/bin/bazel
 
 # Install the Unison file-syncer.
 . bootstrap/bootstrap-unison.sh
+
+# Configure environment variables for CockroachDB
+echo 'export PATH="${PATH}:${HOME}/go/src/github.com/cockroachdb/cockroach/bin:/usr/local/go/bin"' >> ~/.bashrc_bootstrap
+echo >> ~/.bashrc
+echo '. ~/.bashrc_bootstrap' >> ~/.bashrc
+. ~/.bashrc_bootstrap
+
+git clone https://github.com/cockroachdb/cockroach "$(go env GOPATH)/src/github.com/cockroachdb/cockroach"
+git -C "$(go env GOPATH)/src/github.com/cockroachdb/cockroach" submodule update --init
+


### PR DESCRIPTION
GCEWorker script has been used widely by devs to spawn a remote gcp vm configured to develop CRDB.
In order to work with managed-service in the same fashion, this script is hacked or modified. This commit adds
the support of managed-service in gceworker script out-of-the-box and eliminates the need to either spin new
vm or change the script.
Changes:
- adds support for two new env var DISABLE_COCKROACHDB & DISABLE_MANAGED_SERVICE
  toggling anyone to true will NOT configure them.
- adds cloning for managed-service in bootstrap-debian.sh script
- adds installation of neccessary deps and env for managed-service

Default behaviour of script is to install and configure enviroment for both the repo, Cockroach & managed-service.

Note: Devs still needs to manually do a git clone of managed-service in go paths

Part of: DEVINF-1371
Release note: None