### PR TITLE
rangefeed: fix test logging

### DIFF
--- a/pkg/kv/kvclient/rangefeed/rangefeed_external_test.go
+++ b/pkg/kv/kvclient/rangefeed/rangefeed_external_test.go
@@ -1585,7 +1585,7 @@ func TestRangeFeedIntentResolutionRace(t *testing.T) {
 			require.False(t, commitTS.LessEq(c.ResolvedTS),
 				"repl %s emitted checkpoint %s beyond write timestamp %s", repl3, c.ResolvedTS, commitTS)
 		case v := <-valueC:
-			require.Fail(t, "repl3 emitted premature value %s", v)
+			require.Failf(t, "repl3 emitted premature value", "value: %#+v", v)
 		case <-waitC:
 			done = true
 		}


### PR DESCRIPTION
The logging didn't actually print the value as it seemed to intend.

Informs #119340

Release note: None