### PR TITLE
cli: upload misc. files to datadog from debug.zip

### DIFF
--- a/pkg/cli/testdata/table_dumps/events.json
+++ b/pkg/cli/testdata/table_dumps/events.json
@@ -1,0 +1,11 @@
+{
+  "events": [
+    {
+      "timestamp": "2025-01-21T05:17:42.857695Z",
+      "event_type": "node_restart",
+      "reporting_id": 1,
+      "info": "{\"EventType\":\"node_restart\",\"LastUp\":1737426359068817000,\"NodeID\":1,\"StartedAt\":1737436662756679000,\"Timestamp\":1737436662857695000}",
+      "unique_id": "Kmuncp6KTf+KWiuO3I4aww=="
+    }
+  ]
+}

--- a/pkg/cli/testdata/table_dumps/rangelog.json
+++ b/pkg/cli/testdata/table_dumps/rangelog.json
@@ -1,0 +1,52 @@
+{
+  "events": [
+    {
+      "event": {
+        "timestamp": "2025-01-20T11:52:24.424851Z",
+        "range_id": 51,
+        "store_id": 1,
+        "event_type": 3,
+        "other_range_id": 57,
+        "info": {
+          "UpdatedDesc": {
+            "range_id": 51,
+            "start_key": "uA==",
+            "end_key": "wg==",
+            "internal_replicas": [
+              {
+                "node_id": 1,
+                "store_id": 1,
+                "replica_id": 1,
+                "type": 0
+              }
+            ],
+            "next_replica_id": 2,
+            "generation": 5,
+            "sticky_bit": {}
+          },
+          "RemovedDesc": {
+            "range_id": 57,
+            "start_key": "vw==",
+            "end_key": "wg==",
+            "internal_replicas": [
+              {
+                "node_id": 1,
+                "store_id": 1,
+                "replica_id": 1,
+                "type": 0
+              }
+            ],
+            "next_replica_id": 2,
+            "generation": 2,
+            "sticky_bit": {}
+          }
+        }
+      },
+      "pretty_info": {
+        "updated_desc": "r51:/Table/{48-58} [(n1,s1):1, next=2, gen=5]"
+      }
+    }
+  ]
+}
+
+

--- a/pkg/cli/testdata/table_dumps/reports/problemranges.json
+++ b/pkg/cli/testdata/table_dumps/reports/problemranges.json
@@ -1,0 +1,6 @@
+{
+  "node_id": 1,
+  "problems_by_node_id": {
+    "1": {}
+  }
+}

--- a/pkg/cli/testdata/table_dumps/settings.json
+++ b/pkg/cli/testdata/table_dumps/settings.json
@@ -1,0 +1,11 @@
+{
+  "key_values": {
+    "admission.disk_bandwidth_tokens.elastic.enabled": {
+      "value": "true",
+      "type": "b",
+      "description": "when true, and provisioned bandwidth for the disk corresponding to a store is configured, tokens for elastic work will be limited if disk bandwidth becomes a bottleneck",
+      "public": true,
+      "name": "admission.disk_bandwidth_tokens.elastic.enabled"
+    }
+  }
+}

--- a/pkg/cli/testdata/upload/misc
+++ b/pkg/cli/testdata/upload/misc
@@ -1,0 +1,19 @@
+upload-misc
+{
+  "nodes": {
+    "1": {}
+  }
+}
+----
+=== uploading misc
+Logs API Hook: https://http-intake.logs.us5.datadoghq.com/api/v2/logs
+Logs API Hook: https://http-intake.logs.us5.datadoghq.com/api/v2/logs
+Logs API Hook: https://http-intake.logs.us5.datadoghq.com/api/v2/logs
+Logs API Hook: https://http-intake.logs.us5.datadoghq.com/api/v2/logs
+Upload ID: abc-20241114000000
+body: {"message":{"events":[{"event":{"timestamp":"2025-01-20T11:52:24.424851Z","range_id":51,"store_id":1,"event_type":3,"other_range_id":57,"info":{"UpdatedDesc":{"range_id":51,"start_key":"uA==","end_key":"wg==","internal_replicas":[{"node_id":1,"store_id":1,"replica_id":1,"type":0}],"next_replica_id":2,"generation":5,"sticky_bit":{}},"RemovedDesc":{"range_id":57,"start_key":"vw==","end_key":"wg==","internal_replicas":[{"node_id":1,"store_id":1,"replica_id":1,"type":0}],"next_replica_id":2,"generation":2,"sticky_bit":{}}}},"pretty_info":{"updated_desc":"r51:/Table/{48-58} [(n1,s1):1, next=2, gen=5]"}}]},"ddtags":"cluster:ABC,file_name:rangelog.json,upload_id:abc-20241114000000"}
+body: {"message":{"events":[{"timestamp":"2025-01-21T05:17:42.857695Z","event_type":"node_restart","reporting_id":1,"info":"{\"EventType\":\"node_restart\",\"LastUp\":1737426359068817000,\"NodeID\":1,\"StartedAt\":1737436662756679000,\"Timestamp\":1737436662857695000}","unique_id":"Kmuncp6KTf+KWiuO3I4aww=="}]},"ddtags":"cluster:ABC,file_name:events.json,upload_id:abc-20241114000000"}
+body: {"message":{"key_values":{"admission.disk_bandwidth_tokens.elastic.enabled":{"value":"true","type":"b","description":"when true, and provisioned bandwidth for the disk corresponding to a store is configured, tokens for elastic work will be limited if disk bandwidth becomes a bottleneck","public":true,"name":"admission.disk_bandwidth_tokens.elastic.enabled"}}},"ddtags":"cluster:ABC,file_name:settings.json,upload_id:abc-20241114000000"}
+body: {"message":{"node_id":1,"problems_by_node_id":{"1":{}}},"ddtags":"cluster:ABC,file_name:reports/problemranges.json,upload_id:abc-20241114000000"}
+debug zip upload debugDir --dd-api-key=dd-api-key --dd-app-key=dd-app-key --cluster=ABC --include=misc
+

--- a/pkg/cli/zip_upload_test.go
+++ b/pkg/cli/zip_upload_test.go
@@ -208,6 +208,8 @@ func TestUploadZipEndToEnd(t *testing.T) {
 				}
 			case "upload-tables":
 				includeFlag = "--include=tables"
+			case "upload-misc":
+				includeFlag = "--include=misc"
 			}
 
 			debugDir, cleanup := setupZipDir(t, testInput)
@@ -398,10 +400,8 @@ func setupDDLogsHook(t *testing.T, req *http.Request) ([]byte, error) {
 
 			fmt.Println("Logs API Hook:", string(raw))
 		}
-	}
-
-	// capture the body contents for the table dump upload use case
-	if bytes.Contains(body.Bytes(), []byte("source:debug-zip")) {
+	} else if bytes.Contains(body.Bytes(), []byte("source:debug-zip")) {
+		// capture the body contents for the table dump upload use case
 		var lines []map[string]any
 		require.NoError(t, json.Unmarshal(body.Bytes(), &lines))
 
@@ -419,6 +419,8 @@ func setupDDLogsHook(t *testing.T, req *http.Request) ([]byte, error) {
 			}
 			fmt.Println()
 		}
+	} else {
+		fmt.Printf("body: %s\n", body.String())
 	}
 
 	return []byte("200 OK"), nil
@@ -574,6 +576,8 @@ func copyZipFiles(t *testing.T, src, dest string) {
 	paths, err := expandPatterns([]string{
 		path.Join(src, "*.txt"),
 		path.Join(src, "nodes/*/*.txt"),
+		path.Join(src, "*.json"),
+		path.Join(src, "reports/*.json"),
 	})
 	require.NoError(t, err)
 


### PR DESCRIPTION
This patch extends the existing debug.zip upload functionality to datadog. This patch uploads cluster wide generated misc. files to datadog.

Epic: CC-28996
Part of: CC-28884
Release notes: None