### PR TITLE
release-23.2: pgwire: synchronize readTimeoutConn's timeout with max drain wait

### DIFF
--- a/pkg/sql/pgwire/conn.go
+++ b/pkg/sql/pgwire/conn.go
@@ -45,6 +45,10 @@ import (
 	"github.com/lib/pq/oid"
 )
 
+// readTimeout is the timeout after which readTimeoutConn checks the
+// connection for cancellation.
+const readTimeout = 1 * time.Second
+
 // conn implements a pgwire network connection (version 3 of the protocol,
 // implemented by Postgres v7.4 and later). conn.serve() reads protocol
 // messages, transforms them into commands that it pushes onto a StmtBuf (where
@@ -1491,7 +1495,6 @@ func (c *readTimeoutConn) Read(b []byte) (int, error) {
 	// read before checking for exit conditions. The tradeoff is between the
 	// time it takes to react to session context cancellation and the overhead
 	// of waking up and checking for exit conditions.
-	const readTimeout = 1 * time.Second
 
 	// Remove the read deadline when returning from this function to avoid
 	// unexpected behavior.

--- a/pkg/sql/pgwire/server.go
+++ b/pkg/sql/pgwire/server.go
@@ -193,8 +193,11 @@ const (
 )
 
 // cancelMaxWait is the amount of time a draining server gives to sessions to
-// react to cancellation and return before a forceful shutdown.
-const cancelMaxWait = 1 * time.Second
+// react to cancellation and return before a forceful shutdown. It is natural to
+// set it to twice the maximum duration that a conn may be oblivious to having
+// had its context canceled. If it takes much longer than that, the connection
+// is not reacting as expected to cancellation.
+const cancelMaxWait = 2 * readTimeout
 
 // baseSQLMemoryBudget is the amount of memory pre-allocated in each connection.
 var baseSQLMemoryBudget = envutil.EnvOrDefaultInt64("COCKROACH_BASE_SQL_MEMORY_BUDGET",


### PR DESCRIPTION
Drain was willing to wait for 1s to see pgwire connections terminate after cancelling their context, but connections may only realize they've been cancelled after 1s. With zero slack in the system, this timeout was occasionally hit, in which case Drain returns with an error.

To avoid this, have Drain wait up to twice the maximum duration of an unacked conn context cancellation.

Fixes https://github.com/cockroachdb/cockroach/issues/131604.

Note: v24.2+ are not affected, since the mechanism was reworked in https://github.com/cockroachdb/cockroach/pull/124373 and conns now react promptly to cancellation. Hence, this PR is not a backport but a direct fix.

Epic: none
Release justification: bug and test fix.
Release note (bug fix): Addressed a bug due to which, under rare circumstances, draining a node could fail with "some sessions did not respond to cancellation within 1s".