### PR TITLE
roachtest: don't exclude system table dumps in debug.zip

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -1415,7 +1415,7 @@ func (c *clusterImpl) FetchDebugZip(
 			//
 			// Ignore the files in the log directory; we pull the logs separately anyway
 			// so this would only cause duplication.
-			excludeFiles := "*.log,*.txt,*.pprof"
+			excludeFiles := "*.log,*.pprof"
 
 			cmd := roachtestutil.NewCommand("%s debug zip", test.DefaultCockroachPath).
 				Option("include-range-info").


### PR DESCRIPTION
As of #136098, passing --exclude-files=*.txt ends up excluding all of the system table dumps since they end in .txt.

I'm unsure we really want this behaviour change in the original command. But, until we sort that out, I want system tables back in debug.zip from roachtests so that I have a chance at solving problems.

Release note: None