### PR TITLE
release-25.1: rpc: disable batch stream pooling by default

### DIFF
--- a/pkg/rpc/nodedialer/nodedialer.go
+++ b/pkg/rpc/nodedialer/nodedialer.go
@@ -335,8 +335,8 @@ func (c *baseInternalClient) MuxRangeFeed(
 var batchStreamPoolingEnabled = settings.RegisterBoolSetting(
 	settings.ApplicationLevel,
 	"rpc.batch_stream_pool.enabled",
-	"if true, use pooled gRPC streams to execute Batch RPCs",
-	metamorphic.ConstantWithTestBool("rpc.batch_stream_pool.enabled", true),
+	"if true, use pooled gRPC streams to execute Batch RPCs (experimental)",
+	metamorphic.ConstantWithTestBool("rpc.batch_stream_pool.enabled", false),
 )
 
 func shouldUseBatchStreamPoolClient(ctx context.Context, st *cluster.Settings) bool {


### PR DESCRIPTION
We decided to give this a release of bake time. It's on on master and will
be on in v25.2.

Epic: CRDB-42584
Release justification: set a cluster setting back to a more conservative value.
Release note (performance change): rpc.batch_stream_pool.enabled now defaults
to false. This supersedes an earlier release note. The cluster setting is
currently experimental and not listed publicly.
