### PR TITLE
awsdms: Update replication instance

### DIFF
--- a/pkg/cmd/roachtest/tests/awsdms.go
+++ b/pkg/cmd/roachtest/tests/awsdms.go
@@ -583,7 +583,7 @@ func setupDMSReplicationInstance(
 		createReplOut, err := dmsCli.CreateReplicationInstance(
 			ctx,
 			&dms.CreateReplicationInstanceInput{
-				ReplicationInstanceClass:      proto.String("dms.c4.large"),
+				ReplicationInstanceClass:      proto.String("dms.c5.large"),
 				ReplicationInstanceIdentifier: proto.String(awsdmsRoachtestDMSReplicationInstanceName(t.BuildVersion())),
 			},
 		)


### PR DESCRIPTION
Previously, we were using the dms.c4.large instance class. However that was recently silently deprecated and caused the test failure.

This commit upgrades the instances to the new c5 classes.

Fixes: #139394
Release note: None