### PR TITLE
sqlstats: disable sql activity flush by default

### DIFF
--- a/pkg/sql/sql_activity_update_job.go
+++ b/pkg/sql/sql_activity_update_job.go
@@ -33,7 +33,7 @@ var sqlStatsActivityFlushEnabled = settings.RegisterBoolSetting(
 	settings.ApplicationLevel,
 	"sql.stats.activity.flush.enabled",
 	"enable the flush to the system statement and transaction activity tables",
-	true)
+	false)
 
 // sqlStatsActivityTopCount is the cluster setting that controls the number of
 // rows selected to be inserted into the activity tables


### PR DESCRIPTION
Previously, we would automatically enable the SQL Activity job by default which would pre-compute aggregations of top 500 rollups for some sql stats by default. Since the addition of this feature we've made many improvements to the sql stats flush and retrieval queries and will continue to work to make those performant.

Furthermore, we're trying to reduce the weight of background operations on this cluster and this aggregation computation can consume significant resources.

Resolves: #123081

Release note: None