### PR TITLE
kvserver: reject leader lease proposals if leader is unknown

### DIFF
--- a/pkg/kv/kvserver/leases/build.go
+++ b/pkg/kv/kvserver/leases/build.go
@@ -132,6 +132,9 @@ type BuildInput struct {
 	// alive and caught up on its log (e.g. they just sent it a snapshot) and also
 	// can't tolerate rejected lease transfers.
 	BypassSafetyChecks bool
+
+	// DesiredLeaseType is the desired lease type for this replica.
+	DesiredLeaseType roachpb.LeaseType
 }
 
 // PrevLocal returns whether the previous lease was held by the local store.
@@ -256,6 +259,7 @@ func (i BuildInput) toVerifyInput() VerifyInput {
 		PrevLeaseExpired:   i.PrevLeaseExpired,
 		NextLeaseHolder:    i.NextLeaseHolder,
 		BypassSafetyChecks: i.BypassSafetyChecks,
+		DesiredLeaseType:   i.DesiredLeaseType,
 	}
 }
 

--- a/pkg/kv/kvserver/leases/build_test.go
+++ b/pkg/kv/kvserver/leases/build_test.go
@@ -1215,6 +1215,7 @@ func TestInputToVerifyInput(t *testing.T) {
 			NodeID: 1, StoreID: 1, ReplicaID: 1, Type: 1,
 		},
 		BypassSafetyChecks: true,
+		DesiredLeaseType:   roachpb.LeaseLeader,
 	}
 	verifyInput := noZeroBuildInput.toVerifyInput()
 	require.NoError(t, zerofields.NoZeroField(verifyInput),

--- a/pkg/kv/kvserver/leases/verify_test.go
+++ b/pkg/kv/kvserver/leases/verify_test.go
@@ -196,6 +196,25 @@ func TestVerify(t *testing.T) {
 				expErr:      `\[NotLeaseHolderError\] refusing to acquire lease on follower`,
 				expRedirect: roachpb.ReplicaDescriptor{},
 			},
+			{
+				name: "follower, unknown leader, reject leader lease on leader unknown",
+				st: func() Settings {
+					st := defaultSettings()
+					return st
+				}(),
+				input: func() VerifyInput {
+					in := defaultFollowerInput()
+					// Unknown leader.
+					in.RaftStatus.Lead = raft.None
+					// Leader lease.
+					in.DesiredLeaseType = roachpb.LeaseLeader
+					return in
+				}(),
+				// Rejection if the leader is unknown. However, we don't know who to
+				// redirect to, so we don't include a hint.
+				expErr:      `\[NotLeaseHolderError\] refusing to acquire lease on follower`,
+				expRedirect: roachpb.ReplicaDescriptor{},
+			},
 		})
 	})
 

--- a/pkg/kv/kvserver/replica_proposal_buf.go
+++ b/pkg/kv/kvserver/replica_proposal_buf.go
@@ -1285,6 +1285,7 @@ func (rp *replicaProposer) verifyLeaseRequestSafetyRLocked(
 		PrevLeaseExpired:   !r.ownsValidLeaseRLocked(ctx, r.Clock().NowAsClockTimestamp()),
 		NextLeaseHolder:    nextLease.Replica,
 		BypassSafetyChecks: bypassSafetyChecks,
+		DesiredLeaseType:   r.desiredLeaseTypeRLocked(),
 	}
 	if err := leases.Verify(ctx, st, in); err != nil {
 		if in.Transfer() {

--- a/pkg/kv/kvserver/replica_range_lease.go
+++ b/pkg/kv/kvserver/replica_range_lease.go
@@ -383,6 +383,7 @@ func (p *pendingLeaseRequest) InitOrJoinRequest(
 		PrevLeaseExpired:      status.IsExpired(),
 		NextLeaseHolder:       nextLeaseHolder,
 		BypassSafetyChecks:    bypassSafetyChecks,
+		DesiredLeaseType:      p.repl.desiredLeaseTypeRLocked(),
 	}
 	out, err := leases.VerifyAndBuild(ctx, st, nl, in)
 	if err != nil {


### PR DESCRIPTION
This commit rejects leader lease acquisition if the leader is unknown. Note that we have a cluster setting that does that regardless of the lease type (kv.lease.reject_on_leader_unknown.enabled). However, that cluster setting is set to default false since it caused performance regressions for epoch-based leases.

Fixes: #139498

Release note: None