### PR TITLE
roachtest: add provider specific flags to `roachtest run`

### DIFF
--- a/pkg/cmd/roachprod/cli/commands.go
+++ b/pkg/cmd/roachprod/cli/commands.go
@@ -1117,7 +1117,7 @@ func buildSSHKeysListCmd() *cobra.Command {
 		Use:   "list",
 		Short: "list every SSH public key installed on clusters managed by roachprod",
 		Run: wrap(func(cmd *cobra.Command, args []string) error {
-			authorizedKeys, err := gce.GetUserAuthorizedKeys()
+			authorizedKeys, err := gce.Infrastructure.GetUserAuthorizedKeys()
 			if err != nil {
 				return err
 			}
@@ -1168,7 +1168,7 @@ func buildSSHKeysRemoveCmd() *cobra.Command {
 		Run: wrap(func(cmd *cobra.Command, args []string) error {
 			user := args[0]
 
-			existingKeys, err := gce.GetUserAuthorizedKeys()
+			existingKeys, err := gce.Infrastructure.GetUserAuthorizedKeys()
 			if err != nil {
 				return fmt.Errorf("failed to fetch existing keys: %w", err)
 			}

--- a/pkg/cmd/roachprod/cli/flags.go
+++ b/pkg/cmd/roachprod/cli/flags.go
@@ -157,11 +157,12 @@ func initCreateCmdFlags(createCmd *cobra.Command) {
 
 	// Allow each Provider to inject additional configuration flags
 	for _, providerName := range vm.AllProviderNames() {
-		if vm.Providers[providerName].Active() {
+		provider := vm.Providers[providerName]
+		if provider.Active() {
 			providerOptsContainer[providerName].ConfigureCreateFlags(createCmd.Flags())
 			// createCmd only accepts a single GCE project, as opposed to all the other
 			// commands.
-			providerOptsContainer[providerName].ConfigureClusterFlags(createCmd.Flags(), vm.SingleProject)
+			provider.ConfigureProviderFlags(createCmd.Flags(), vm.SingleProject)
 		}
 	}
 }
@@ -170,7 +171,8 @@ func initClusterFlagsForMultiProjects(
 	rootCmd *cobra.Command, excludeFromClusterFlagsMulti []*cobra.Command,
 ) {
 	for _, providerName := range vm.AllProviderNames() {
-		if vm.Providers[providerName].Active() {
+		provider := vm.Providers[providerName]
+		if provider.Active() {
 			for _, cmd := range rootCmd.Commands() {
 				excludeCmd := false
 				for _, c := range excludeFromClusterFlagsMulti {
@@ -182,7 +184,7 @@ func initClusterFlagsForMultiProjects(
 				if excludeCmd {
 					continue
 				}
-				providerOptsContainer[providerName].ConfigureClusterFlags(cmd.Flags(), vm.AcceptMultipleProjects)
+				provider.ConfigureProviderFlags(cmd.Flags(), vm.AcceptMultipleProjects)
 			}
 		}
 	}
@@ -387,10 +389,9 @@ func initGCCmdFlags(gcCmd *cobra.Command) {
 		"dry-run", "n", dryrun, "dry run (don't perform any actions)")
 	gcCmd.Flags().StringVar(&config.SlackToken, "slack-token", "", "Slack bot token")
 	// Allow each Provider to inject additional configuration flags
-	for _, providerName := range vm.AllProviderNames() {
-		if vm.Providers[providerName].Active() {
-			// set up cluster cleanup flag for gcCmd
-			providerOptsContainer[providerName].ConfigureClusterCleanupFlags(gcCmd.Flags())
+	for _, provider := range vm.Providers {
+		if provider.Active() {
+			provider.ConfigureClusterCleanupFlags(gcCmd.Flags())
 		}
 	}
 }

--- a/pkg/cmd/roachtest/roachtestflags/BUILD.bazel
+++ b/pkg/cmd/roachtest/roachtestflags/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/cmd/roachtest/spec",
+        "//pkg/roachprod/vm",
         "//pkg/util/randutil",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_spf13_pflag//:pflag",

--- a/pkg/cmd/roachtest/roachtestflags/flags.go
+++ b/pkg/cmd/roachtest/roachtestflags/flags.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/vm"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/spf13/pflag"
 )
@@ -584,6 +585,9 @@ func AddListFlags(cmdFlags *pflag.FlagSet) {
 // command flag set.
 func AddRunFlags(cmdFlags *pflag.FlagSet) {
 	globalMan.AddFlagsToCommand(runCmdID, cmdFlags)
+	for _, provider := range vm.Providers {
+		provider.ConfigureProviderFlags(cmdFlags, vm.SingleProject)
+	}
 }
 
 // AddRunOpsFlags adds all flags registered for the run-operations command to

--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -335,7 +335,7 @@ func Sync(l *logger.Logger, options vm.ListOptions) (*cloud.Cloud, error) {
 		if !config.Quiet {
 			l.Printf("Refreshing DNS entries...")
 		}
-		if err := gce.SyncDNS(l, vms); err != nil {
+		if err := gce.Infrastructure.SyncDNS(l, vms); err != nil {
 			l.Errorf("failed to update DNS: %v", err)
 		}
 	} else {
@@ -708,7 +708,7 @@ func SetupSSH(ctx context.Context, l *logger.Logger, clusterName string, sync bo
 	}
 	// Fetch public keys from gcloud to set up ssh access for all users into the
 	// shared ubuntu user.
-	authorizedKeys, err := gce.GetUserAuthorizedKeys()
+	authorizedKeys, err := gce.Infrastructure.GetUserAuthorizedKeys()
 	if err != nil {
 		return errors.Wrap(err, "failed to retrieve authorized keys from gcloud")
 	}
@@ -1132,7 +1132,7 @@ func urlGenerator(
 ) ([]string, error) {
 	var urls []string
 	for i, node := range nodes {
-		host := vm.Name(c.Name, int(node)) + "." + gce.DNSDomain()
+		host := vm.Name(c.Name, int(node)) + "." + gce.Infrastructure.DNSDomain()
 
 		// There are no DNS entries for local clusters.
 		if c.IsLocal() {

--- a/pkg/roachprod/vm/aws/config.go
+++ b/pkg/roachprod/vm/aws/config.go
@@ -174,8 +174,6 @@ func (c *awsConfigValue) Set(path string) (err error) {
 	if err != nil {
 		return err
 	}
-	// Update the provider's config with the user-specified config.
-	providerInstance.Config = &c.awsConfig
 	return nil
 }
 

--- a/pkg/roachprod/vm/azure/flags.go
+++ b/pkg/roachprod/vm/azure/flags.go
@@ -55,6 +55,16 @@ func (p *Provider) CreateProviderOpts() vm.ProviderOpts {
 	return DefaultProviderOpts()
 }
 
+// ConfigureProviderFlags implements vm.ProviderFlags and is a no-op.
+func (p *Provider) ConfigureProviderFlags(*pflag.FlagSet, vm.MultipleProjectsOption) {
+}
+
+// ConfigureClusterCleanupFlags is part of ProviderOpts.
+func (o *Provider) ConfigureClusterCleanupFlags(flags *pflag.FlagSet) {
+	flags.StringSliceVar(&providerInstance.SubscriptionNames, ProviderName+"-subscription-names", []string{},
+		"Azure subscription names as a comma-separated string")
+}
+
 // ConfigureCreateFlags implements vm.ProviderFlags.
 func (o *ProviderOpts) ConfigureCreateFlags(flags *pflag.FlagSet) {
 	flags.DurationVar(&providerInstance.OperationTimeout, ProviderName+"-timeout", providerInstance.OperationTimeout,
@@ -80,14 +90,4 @@ func (o *ProviderOpts) ConfigureCreateFlags(flags *pflag.FlagSet) {
 		"Number of IOPS provisioned for ultra disk, only used if network-disk-type=ultra-disk")
 	flags.StringVar(&o.DiskCaching, ProviderName+"-disk-caching", "none",
 		"Disk caching behavior for attached storage.  Valid values are: none, read-only, read-write.  Not applicable to Ultra disks.")
-}
-
-// ConfigureClusterFlags implements vm.ProviderFlags and is a no-op.
-func (o *ProviderOpts) ConfigureClusterFlags(*pflag.FlagSet, vm.MultipleProjectsOption) {
-}
-
-// ConfigureClusterCleanupFlags is part of ProviderOpts.
-func (o *ProviderOpts) ConfigureClusterCleanupFlags(flags *pflag.FlagSet) {
-	flags.StringSliceVar(&providerInstance.SubscriptionNames, ProviderName+"-subscription-names", []string{},
-		"Azure subscription names as a comma-separated string")
 }

--- a/pkg/roachprod/vm/flagstub/BUILD.bazel
+++ b/pkg/roachprod/vm/flagstub/BUILD.bazel
@@ -9,5 +9,6 @@ go_library(
         "//pkg/roachprod/logger",
         "//pkg/roachprod/vm",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_spf13_pflag//:pflag",
     ],
 )

--- a/pkg/roachprod/vm/flagstub/flagstub.go
+++ b/pkg/roachprod/vm/flagstub/flagstub.go
@@ -11,6 +11,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/vm"
 	"github.com/cockroachdb/errors"
+	"github.com/spf13/pflag"
 )
 
 // New wraps a delegate vm.Provider to only return its name and
@@ -25,6 +26,14 @@ func New(delegate vm.Provider, unimplemented string) vm.Provider {
 type provider struct {
 	delegate      vm.Provider
 	unimplemented string
+}
+
+// ConfigureProviderFlags implements vm.Provider.
+func (p *provider) ConfigureProviderFlags(*pflag.FlagSet, vm.MultipleProjectsOption) {
+}
+
+func (p *provider) ConfigureClusterCleanupFlags(*pflag.FlagSet) {
+
 }
 
 func (p *provider) SupportsSpotVMs() bool {

--- a/pkg/roachprod/vm/gce/BUILD.bazel
+++ b/pkg/roachprod/vm/gce/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
         "dns.go",
         "fast_dns.go",
         "gcloud.go",
+        "infra_provider.go",
         "utils.go",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/roachprod/vm/gce",

--- a/pkg/roachprod/vm/gce/infra_provider.go
+++ b/pkg/roachprod/vm/gce/infra_provider.go
@@ -1,0 +1,27 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package gce
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/vm"
+)
+
+// InfraProvider is the API for GCP resources that are used as shared
+// infrastructure by clusters on other other clouds.
+type InfraProvider interface {
+	// GetUserAuthorizedKeys retrieves reads a list of user public keys from the
+	// gcloud cockroach-ephemeral project and returns them formatted for use in
+	// an authorized_keys file.
+	GetUserAuthorizedKeys() (AuthorizedKeys, error)
+	// SyncDNS replaces the configured DNS zone with the supplied hosts.
+	SyncDNS(l *logger.Logger, vms vm.List) error
+	// DNSDomain returns the configured DNS domain for public DNS A records.
+	DNSDomain() string
+}
+
+// Infrastructure is the process level InfraProvider.
+var Infrastructure InfraProvider

--- a/pkg/roachprod/vm/local/local.go
+++ b/pkg/roachprod/vm/local/local.go
@@ -120,6 +120,9 @@ type Provider struct {
 	vm.DNSProvider
 }
 
+func (p *Provider) ConfigureProviderFlags(*pflag.FlagSet, vm.MultipleProjectsOption) {
+}
+
 func (p *Provider) SupportsSpotVMs() bool {
 	return false
 }
@@ -181,12 +184,8 @@ type providerOpts struct{}
 func (o *providerOpts) ConfigureCreateFlags(flags *pflag.FlagSet) {
 }
 
-// ConfigureClusterFlags is part of ProviderOpts.  This implementation is a no-op.
-func (o *providerOpts) ConfigureClusterFlags(*pflag.FlagSet, vm.MultipleProjectsOption) {
-}
-
-// ConfigureClusterCleanupFlags is part of ProviderOpts. This implementation is a no-op.
-func (o *providerOpts) ConfigureClusterCleanupFlags(flags *pflag.FlagSet) {
+// ConfigureClusterCleanupFlags is part of the vm.Provider interface. This implementation is a no-op.
+func (p *Provider) ConfigureClusterCleanupFlags(flags *pflag.FlagSet) {
 }
 
 // CleanSSH is part of the vm.Provider interface.  This implementation is a no-op.

--- a/pkg/roachprod/vm/vm.go
+++ b/pkg/roachprod/vm/vm.go
@@ -353,13 +353,6 @@ type ProviderOpts interface {
 	// ConfigureCreateFlags configures a FlagSet with any options relevant to the
 	// `create` command.
 	ConfigureCreateFlags(*pflag.FlagSet)
-	// ConfigureClusterFlags configures a FlagSet with any options relevant to
-	// cluster manipulation commands (`create`, `destroy`, `list`, `sync` and
-	// `gc`).
-	ConfigureClusterFlags(*pflag.FlagSet, MultipleProjectsOption)
-	// ConfigureClusterCleanupFlags configures a FlagSet with any options relevant to
-	// commands (`gc`)
-	ConfigureClusterCleanupFlags(*pflag.FlagSet)
 }
 
 // VolumeSnapshot is an abstract representation of a specific volume snapshot.
@@ -468,6 +461,14 @@ type ServiceAddress struct {
 
 // A Provider is a source of virtual machines running on some hosting platform.
 type Provider interface {
+	// ConfigureProviderFlags is used to specify flags that apply to the provider
+	// instance and should be used for all clusters managed by the provider.
+	ConfigureProviderFlags(*pflag.FlagSet, MultipleProjectsOption)
+
+	// ConfigureClusterCleanupFlags configures a FlagSet with any options
+	// relevant to commands (`gc`)
+	ConfigureClusterCleanupFlags(*pflag.FlagSet)
+
 	CreateProviderOpts() ProviderOpts
 	CleanSSH(l *logger.Logger) error
 


### PR DESCRIPTION
Previously, `ConfigureClusterFlags` was a method on the provider options, but it applied settings to the underlying provider. Now, these flags were moved to the `ConfigureProviderFlags` method on the provider instance.

The motivation for this change is the AWS profile configuration. The AWS profile is needed to support running roachtests with AWS credentials provisioned via SSO.

The static AWS and GCP providers were removed and code that mutates them
was moved to methods on the providers themselves. The `InfraProvider`
interface was added to the GCP package in order to provide access to
methods on the provider that are used for clusters on multiple clouds.

Release note: none
Epic: none