### PR TITLE
server/debug: don't panic on empty goroutine dumps

### DIFF
--- a/pkg/server/debug/goroutineui/BUILD.bazel
+++ b/pkg/server/debug/goroutineui/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/util/allstacks",
+        "@com_github_cockroachdb_errors//:errors",
         "@com_github_maruel_panicparse_v2//stack",
     ],
 )

--- a/pkg/server/debug/goroutineui/dump.go
+++ b/pkg/server/debug/goroutineui/dump.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/util/allstacks"
+	"github.com/cockroachdb/errors"
 	"github.com/maruel/panicparse/v2/stack"
 )
 
@@ -42,6 +43,9 @@ func (d Dump) SortCountDesc() {
 	if d.err != nil {
 		return
 	}
+	if d.agg == nil {
+		return
+	}
 	sort.Slice(d.agg.Buckets, func(i, j int) bool {
 		a, b := d.agg.Buckets[i], d.agg.Buckets[j]
 		return len(a.IDs) > len(b.IDs)
@@ -54,6 +58,9 @@ func (d Dump) SortWaitDesc() {
 	if d.err != nil {
 		return
 	}
+	if d.agg == nil {
+		return
+	}
 	sort.Slice(d.agg.Buckets, func(i, j int) bool {
 		a, b := d.agg.Buckets[i], d.agg.Buckets[j]
 		return a.SleepMax > b.SleepMax
@@ -64,6 +71,9 @@ func (d Dump) SortWaitDesc() {
 func (d Dump) HTML(w io.Writer) error {
 	if d.err != nil {
 		return d.err
+	}
+	if d.agg == nil {
+		return errors.New("goroutineui: empty goroutine dump")
 	}
 	return d.agg.ToHTML(w, "" /* footer */)
 }

--- a/pkg/server/debug/goroutineui/dump_test.go
+++ b/pkg/server/debug/goroutineui/dump_test.go
@@ -22,6 +22,21 @@ func init() {
 	}
 }
 
+func TestDumpEmpty(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	dump := NewDump()
+	dump.agg = nil
+
+	assert.NotPanics(t, func() {
+		dump.SortWaitDesc()
+		dump.SortCountDesc()
+	})
+
+	act := dump.HTMLString()
+	assert.Contains(t, act, "goroutineui: empty goroutine dump")
+}
+
 func TestDumpHTML(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 


### PR DESCRIPTION
Previously, we observed a panic in a running cluster when the goroutine dumper produced a nil result.

We should not panic in this case, but fail gracefully with an error message, even though this situation was not possible to reproduce in a test environment.

Resolves: #139130

Release note: None