### PR TITLE
workload: use information_schema to check constraint existence

### DIFF
--- a/pkg/workload/schemachange/error_screening.go
+++ b/pkg/workload/schemachange/error_screening.go
@@ -1011,11 +1011,13 @@ SELECT COALESCE(
 }
 
 func (og *operationGenerator) constraintExists(
-	ctx context.Context, tx pgx.Tx, constraintName string,
+	ctx context.Context, tx pgx.Tx, tableName, constraintName tree.Name,
 ) (bool, error) {
+	// Note: information_schema.table_constraints contains constraints that are
+	// in the dropping state, but pg_constraint.constraints does not.
 	return og.scanBool(ctx, tx, `SELECT EXISTS(
-		SELECT * FROM pg_catalog.pg_constraint WHERE conname = $1
-	 )`, constraintName)
+		SELECT * FROM information_schema.table_constraints WHERE table_name = $1 AND constraint_name = $2
+	 )`, string(tableName), string(constraintName))
 }
 
 func (og *operationGenerator) rowsSatisfyFkConstraint(

--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -367,7 +367,7 @@ func (og *operationGenerator) addUniqueConstraint(ctx context.Context, tx pgx.Tx
 	if err != nil {
 		return nil, err
 	}
-	constraintExists, err := og.constraintExists(ctx, tx, constraintName)
+	constraintExists, err := og.constraintExists(ctx, tx, tableName.ObjectName, tree.Name(constraintName))
 	if err != nil {
 		return nil, err
 	}
@@ -890,7 +890,7 @@ func (og *operationGenerator) addForeignKeyConstraint(
 	if err != nil {
 		return nil, err
 	}
-	constraintExists, err := og.constraintExists(ctx, tx, string(constraintName))
+	constraintExists, err := og.constraintExists(ctx, tx, childTable.ObjectName, constraintName)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The information_schema.table_constraints table is a better place to check for table constraint existence, since it will include constraints that are in the dropping state.

fixes https://github.com/cockroachdb/cockroach/issues/139331
fixes https://github.com/cockroachdb/cockroach/issues/139400
fixes https://github.com/cockroachdb/cockroach/issues/139395
fixes https://github.com/cockroachdb/cockroach/issues/139425
fixes https://github.com/cockroachdb/cockroach/issues/138728
fixes https://github.com/cockroachdb/cockroach/issues/138547
fixes https://github.com/cockroachdb/cockroach/issues/139307
fixes https://github.com/cockroachdb/cockroach/issues/138883

Release note: None