### PR TITLE
roachtest: use smaller batch size in schemachange/invertedindex

### DIFF
--- a/pkg/cmd/roachtest/tests/inverted_index.go
+++ b/pkg/cmd/roachtest/tests/inverted_index.go
@@ -55,7 +55,7 @@ func runSchemaChangeInvertedIndex(ctx context.Context, t test.Test, c cluster.Cl
 	m := c.NewMonitor(ctx, c.CRDBNodes())
 
 	cmdWrite := fmt.Sprintf(
-		"./workload run json --read-percent=0 --duration %s {pgurl%s} --batch 1000 --sequential",
+		"./workload run json --read-percent=0 --duration %s {pgurl%s} --batch 200 --sequential",
 		initialDataDuration.String(), c.CRDBNodes(),
 	)
 	m.Go(func(ctx context.Context) error {


### PR DESCRIPTION
We've seen this test flake due to the error
```
workload run error: pq: split failed while applying backpressure to
Put [/Table/106/1/136264000/0], Put [/Table/106/1/136264001/0], Put [/Table/106/1/136264002/0],
Put [/Table/106/1/136264003/0], Put [/Table/106/1/136264004/0], Put [/Table/106/1/136264005/0],
Put [/Table/106/1/136264006/0], Put [/Table/106/1/136264007/0], Put [/Table/106/1/136264008/0],
Put [/Table/106/1/136264009/0], Put [/Table/106/1/136264010/0], Put [/Table/106/1/136264011/0],
Put [/Table/106/1/136264012/0], Put [/Table/106/1/136264013/0], Put [/Table/106/1/136264014/0],
Put [/Table/106/1/136264015/0], Put [/Table/106/1/136264016/0], Put [/Table/106/1/136264017/0],
Put [/Table/106/1/136264018/0], Put [/Table/106/1/136264019/0],... 976 skipped ...,
Put [/Table/106/1/136264996/0], Put [/Table/106/1/136264997/0], Put [/Table/106/1/136264998/0],
Put [/Table/106/1/136264999/0], EndTxn(parallel commit) [/Table/106/1/136264000/0],
[txn: d657bdfb], [can-forward-ts] on range r94:/{Table/106/1/127030358-Max}
[(n3,s3):1, (n2,s2):2, (n4,s4):3, next=4, gen=66]: operation "split queue process replica 94"
timed out after 1m5.577s (given timeout 1m0s): failed to re-compute MVCCStats pre split:
result is ambiguous: after 46.48s of attempting command: context deadline exceeded
```

This error is more likely to happen with large inserts, and when the cluster is under load.

We can reduce the chance of this error occurring by using a smaller batch size. A batch size of 1000 would mean somewhere on the order of 15 MB/s was being inserted, so with a batch size of 200, it should be on the order of 3 MB/s.

fixes https://github.com/cockroachdb/cockroach/issues/138891
fixes https://github.com/cockroachdb/cockroach/issues/139320

Release note: None