### PR TITLE
logictest: use more resources for 3node-tenant config

### DIFF
--- a/pkg/ccl/logictestccl/tests/3node-tenant-multiregion/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/3node-tenant-multiregion/BUILD.bazel
@@ -10,7 +10,7 @@ go_test(
         "//pkg/sql/logictest:testdata",  # keep
         "//pkg/sql/opt/exec/execbuilder:testdata",  # keep
     ],
-    exec_properties = {"test.Pool": "large"},
+    exec_properties = {"test.Pool": "heavy"},
     shard_count = 6,
     tags = ["cpu:2"],
     deps = [

--- a/pkg/ccl/logictestccl/tests/3node-tenant/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/3node-tenant/BUILD.bazel
@@ -10,7 +10,7 @@ go_test(
         "//pkg/sql/logictest:testdata",  # keep
         "//pkg/sql/opt/exec/execbuilder:testdata",  # keep
     ],
-    exec_properties = {"test.Pool": "large"},
+    exec_properties = {"test.Pool": "heavy"},
     shard_count = 48,
     tags = ["cpu:2"],
     deps = [

--- a/pkg/cmd/generate-logictest/main.go
+++ b/pkg/cmd/generate-logictest/main.go
@@ -196,7 +196,8 @@ func (t *testdir) dump() error {
 			(strings.HasPrefix(cfg.Name, "local-") && !tplCfg.Ccl) ||
 			(cfg.Name == "local" && !tplCfg.Ccl) {
 			tplCfg.UseHeavyPool = useHeavyPoolForExpensiveConfig
-		} else if strings.Contains(cfg.Name, "cockroach-go-testserver") {
+		} else if strings.Contains(cfg.Name, "cockroach-go-testserver") ||
+			strings.Contains(cfg.Name, "3node-tenant") {
 			tplCfg.UseHeavyPool = useHeavyPoolAlways
 		}
 		subdir := filepath.Join(t.dir, cfg.Name)


### PR DESCRIPTION
We've seen more transaction retry errors caused by ABORT_REASON_CLIENT_REJECT, which can happen under heavy load. Adding more resources can help reduce the chance of hitting that error.

fixes https://github.com/cockroachdb/cockroach/issues/138045
fixes https://github.com/cockroachdb/cockroach/issues/138851

Release note: None