### PR TITLE
drtprod: add dependent target failure check

### DIFF
--- a/pkg/cmd/drtprod/cli/commands/BUILD.bazel
+++ b/pkg/cmd/drtprod/cli/commands/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     deps = [
         "//pkg/build",
         "//pkg/cmd/drtprod/helpers",
+        "//pkg/util/syncutil",
         "@com_github_spf13_cobra//:cobra",
         "@in_gopkg_yaml_v2//:yaml_v2",
         "@org_golang_x_exp//maps",


### PR DESCRIPTION
Currently, if the dependent target defined in the YAML fails, the current target continues its execution. This is wrong as it should fail or the user should be able to ignore as needed. This PR adds the condition to consider parent target failure and also provision to ignore the error as a condition in YAML.

Epic: None
Release: None