### PR TITLE
roachtest: deflake follower-reads/mixed-version/single-region

### DIFF
--- a/pkg/cmd/roachtest/tests/follower_reads.go
+++ b/pkg/cmd/roachtest/tests/follower_reads.go
@@ -125,7 +125,7 @@ func registerFollowerReads(r registry.Registry) {
 			4, /* nodeCount */
 			spec.CPU(2),
 		),
-		CompatibleClouds: registry.AllExceptAWS,
+		CompatibleClouds: registry.OnlyGCE,
 		Suites:           registry.Suites(registry.MixedVersion, registry.Nightly),
 		Randomized:       true,
 		Run:              runFollowerReadsMixedVersionSingleRegionTest,


### PR DESCRIPTION
This test has been failing occasionally, only on Azure. It's already skipped on AWS, and other follower-reads mixed version tests run on GCE only.

This commit configures the test to run on GCE only as well.

Fixes: #135462

Release note: None