### PR TITLE
kvfollowerreadsccl: deflake TestBoundedStalenessDataDriven

### DIFF
--- a/pkg/ccl/kvccl/kvfollowerreadsccl/BUILD.bazel
+++ b/pkg/ccl/kvccl/kvfollowerreadsccl/BUILD.bazel
@@ -44,8 +44,7 @@ go_test(
     data = glob(["testdata/**"]),
     embed = [":kvfollowerreadsccl"],
     exec_properties = select({
-        "//build/toolchains:is_heavy": {"test.Pool": "large"},
-        "//conditions:default": {"test.Pool": "default"},
+        "//conditions:default": {"test.Pool": "large"},
     }),
     deps = [
         "//pkg/base",

--- a/pkg/ccl/kvccl/kvfollowerreadsccl/boundedstaleness_test.go
+++ b/pkg/ccl/kvccl/kvfollowerreadsccl/boundedstaleness_test.go
@@ -264,6 +264,7 @@ func TestBoundedStalenessDataDriven(t *testing.T) {
 	const msg = "1μs staleness reads may actually succeed due to the slow environment"
 	skip.UnderStress(t, msg)
 	skip.UnderRace(t, msg)
+	skip.UnderDeadlock(t, msg)
 	defer ccl.TestingEnableEnterprise()()
 
 	ctx := context.Background()


### PR DESCRIPTION
This test has had a history of rare flakes where a follower read succeeds, instead of being routed to the leaseholder, due to environment slowness.

This commit skips the test under deadlock and allocates more resources for the default execution.

Fixes: #138121

Release note: None