### PR TITLE
release-24.1: workload: use information_schema to check constraint existence

### DIFF
--- a/pkg/workload/schemachange/error_screening.go
+++ b/pkg/workload/schemachange/error_screening.go
@@ -1050,11 +1050,13 @@ SELECT COALESCE(
 }
 
 func (og *operationGenerator) constraintExists(
-	ctx context.Context, tx pgx.Tx, constraintName string,
+	ctx context.Context, tx pgx.Tx, tableName, constraintName tree.Name,
 ) (bool, error) {
+	// Note: information_schema.table_constraints contains constraints that are
+	// in the dropping state, but pg_constraint.constraints does not.
 	return og.scanBool(ctx, tx, `SELECT EXISTS(
-		SELECT * FROM pg_catalog.pg_constraint WHERE conname = $1
-	 )`, constraintName)
+		SELECT * FROM information_schema.table_constraints WHERE table_name = $1 AND constraint_name = $2
+	 )`, string(tableName), string(constraintName))
 }
 
 func (og *operationGenerator) rowsSatisfyFkConstraint(

--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -346,13 +346,13 @@ func (og *operationGenerator) addUniqueConstraint(ctx context.Context, tx pgx.Tx
 		return nil, err
 	}
 
-	constaintName := fmt.Sprintf("%s_%s_unique", tableName.Object(), columnForConstraint.name)
+	constraintName := fmt.Sprintf("%s_%s_unique", tableName.Object(), columnForConstraint.name)
 
 	columnExistsOnTable, err := og.columnExistsOnTable(ctx, tx, tableName, columnForConstraint.name)
 	if err != nil {
 		return nil, err
 	}
-	constraintExists, err := og.constraintExists(ctx, tx, constaintName)
+	constraintExists, err := og.constraintExists(ctx, tx, tableName.ObjectName, tree.Name(constraintName))
 	if err != nil {
 		return nil, err
 	}
@@ -391,7 +391,7 @@ func (og *operationGenerator) addUniqueConstraint(ctx context.Context, tx pgx.Tx
 		og.candidateExpectedCommitErrors.add(pgcode.UniqueViolation)
 	}
 
-	stmt.sql = fmt.Sprintf(`ALTER TABLE %s ADD CONSTRAINT %s UNIQUE (%s)`, tableName, constaintName, columnForConstraint.name)
+	stmt.sql = fmt.Sprintf(`ALTER TABLE %s ADD CONSTRAINT %s UNIQUE (%s)`, tableName, constraintName, columnForConstraint.name)
 	return stmt, nil
 }
 
@@ -871,7 +871,7 @@ func (og *operationGenerator) addForeignKeyConstraint(
 	if err != nil {
 		return nil, err
 	}
-	constraintExists, err := og.constraintExists(ctx, tx, string(constraintName))
+	constraintExists, err := og.constraintExists(ctx, tx, childTable.ObjectName, constraintName)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Backport 1/1 commits from #139529.

/cc @cockroachdb/release

Release justification: test only change

---

The information_schema.table_constraints table is a better place to check for table constraint existence, since it will include constraints that are in the dropping state.

fixes https://github.com/cockroachdb/cockroach/issues/139331
fixes https://github.com/cockroachdb/cockroach/issues/139400
fixes https://github.com/cockroachdb/cockroach/issues/139395
fixes https://github.com/cockroachdb/cockroach/issues/139425
fixes https://github.com/cockroachdb/cockroach/issues/138728
fixes https://github.com/cockroachdb/cockroach/issues/138547
fixes https://github.com/cockroachdb/cockroach/issues/139307
fixes https://github.com/cockroachdb/cockroach/issues/138883

Release note: None
