### PR TITLE
catalog/lease: purge old leases after getting the initial version

### DIFF
--- a/pkg/sql/catalog/lease/lease.go
+++ b/pkg/sql/catalog/lease/lease.go
@@ -1345,7 +1345,7 @@ func (m *Manager) AcquireByName(
 			if durationUntilExpiry < m.storage.leaseRenewalTimeout() {
 				if t := m.findDescriptorState(descVersion.GetID(), false /* create */); t != nil {
 					if err := t.maybeQueueLeaseRenewal(
-						ctx, m, descVersion.GetID(), name); err != nil {
+						ctx, m, descVersion); err != nil {
 						return nil, err
 					}
 				}
@@ -1512,7 +1512,7 @@ func (m *Manager) Acquire(
 			if latest {
 				durationUntilExpiry := time.Duration(desc.getExpiration(ctx).WallTime - timestamp.WallTime)
 				if durationUntilExpiry < m.storage.leaseRenewalTimeout() {
-					if err := t.maybeQueueLeaseRenewal(ctx, m, id, desc.GetName()); err != nil {
+					if err := t.maybeQueueLeaseRenewal(ctx, m, desc); err != nil {
 						return nil, err
 					}
 				}
@@ -1694,11 +1694,14 @@ func (m *Manager) RefreshLeases(ctx context.Context, s *stop.Stopper, db *kv.DB)
 						if err != nil {
 							log.Warningf(ctx, "error fetching lease for descriptor %s", err)
 						}
-					} else {
-						if err := purgeOldVersions(ctx, db, desc.GetID(), dropped, desc.GetVersion(), m); err != nil {
-							log.Warningf(ctx, "error purging leases for descriptor %d(%s): %s",
-								desc.GetID(), desc.GetName(), err)
-						}
+					}
+					// Even if an initial acquisition happens above, we need to purge old
+					// descriptor versions, which could have been acquired concurrently.
+					// For example the range feed sees version 2 and a query concurrently
+					// acquires version 1.
+					if err := purgeOldVersions(ctx, db, desc.GetID(), dropped, desc.GetVersion(), m); err != nil {
+						log.Warningf(ctx, "error purging leases for descriptor %d(%s): %s",
+							desc.GetID(), desc.GetName(), err)
 					}
 				}
 				// New descriptors may appear in the future if the descriptor table is


### PR DESCRIPTION
Previously, when the initial version of a descriptor was being acquired by the range feed, that an executing query could fetch an older version. The initial version fetched will normally be the latest observed version by the range feed as a minimum. When this occurred the queries previous version could linger, since the initial version acquisition never purges old versions. This could cause WaitForOneVersion checks to be stuck forever, since the old version could only be purged on access. To address this, this patch modifies the initial version logic to always issue a purge after, which will guarantee that any previous version is released. This patch also fixes a few other minor cases where leases could leak, but these should eventually clean up based on the lease expiry when a new version arrives.

Fixes: #139168
Release note: None