### PR TITLE
rac2: optimize ranges.json size

### DIFF
--- a/docs/generated/http/full.md
+++ b/docs/generated/http/full.md
@@ -1349,7 +1349,6 @@ of a range.
 | ----- | ---- | ----- | ----------- | -------------- |
 | index_to_send | [uint64](#cockroach.server.serverpb.RaftDebugResponse-uint64) |  |  | [reserved](#support-status) |
 | next_raft_index_initial | [uint64](#cockroach.server.serverpb.RaftDebugResponse-uint64) |  |  | [reserved](#support-status) |
-| next_raft_index | [uint64](#cockroach.server.serverpb.RaftDebugResponse-uint64) |  |  | [reserved](#support-status) |
 | force_flush_stop_index | [uint64](#cockroach.server.serverpb.RaftDebugResponse-uint64) |  |  | [reserved](#support-status) |
 | eval_tokens_held | [int64](#cockroach.server.serverpb.RaftDebugResponse-int64) | repeated |  | [reserved](#support-status) |
 | send_tokens_held | [int64](#cockroach.server.serverpb.RaftDebugResponse-int64) | repeated |  | [reserved](#support-status) |
@@ -1648,7 +1647,6 @@ of a range.
 | ----- | ---- | ----- | ----------- | -------------- |
 | index_to_send | [uint64](#cockroach.server.serverpb.RangesResponse-uint64) |  |  | [reserved](#support-status) |
 | next_raft_index_initial | [uint64](#cockroach.server.serverpb.RangesResponse-uint64) |  |  | [reserved](#support-status) |
-| next_raft_index | [uint64](#cockroach.server.serverpb.RangesResponse-uint64) |  |  | [reserved](#support-status) |
 | force_flush_stop_index | [uint64](#cockroach.server.serverpb.RangesResponse-uint64) |  |  | [reserved](#support-status) |
 | eval_tokens_held | [int64](#cockroach.server.serverpb.RangesResponse-int64) | repeated |  | [reserved](#support-status) |
 | send_tokens_held | [int64](#cockroach.server.serverpb.RangesResponse-int64) | repeated |  | [reserved](#support-status) |
@@ -4082,7 +4080,6 @@ of a range.
 | ----- | ---- | ----- | ----------- | -------------- |
 | index_to_send | [uint64](#cockroach.server.serverpb.RangeResponse-uint64) |  |  | [reserved](#support-status) |
 | next_raft_index_initial | [uint64](#cockroach.server.serverpb.RangeResponse-uint64) |  |  | [reserved](#support-status) |
-| next_raft_index | [uint64](#cockroach.server.serverpb.RangeResponse-uint64) |  |  | [reserved](#support-status) |
 | force_flush_stop_index | [uint64](#cockroach.server.serverpb.RangeResponse-uint64) |  |  | [reserved](#support-status) |
 | eval_tokens_held | [int64](#cockroach.server.serverpb.RangeResponse-int64) | repeated |  | [reserved](#support-status) |
 | send_tokens_held | [int64](#cockroach.server.serverpb.RangeResponse-int64) | repeated |  | [reserved](#support-status) |

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/range_controller.go
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/range_controller.go
@@ -1678,7 +1678,10 @@ func (rc *rangeController) StatusRaftMuLocked() serverpb.RACStatus {
 			s.NextRaftIndexInitial = rs.sendStream.mu.nextRaftIndexInitial
 			s.NextRaftIndex = rs.sendStream.mu.sendQueue.nextRaftIndex
 			s.ForceFlushStopIndex = uint64(rs.sendStream.mu.sendQueue.forceFlushStopIndex)
-			s.EvalTokensHeld = convertTokensSlice(rs.sendStream.mu.eval.tokensDeducted[:])
+			// Don't waste space if there are no tokens held.
+			if tokens := rs.sendStream.mu.eval.tokensDeducted[:]; holdsTokens(tokens) {
+				s.EvalTokensHeld = convertTokensSlice(tokens)
+			}
 		}()
 		if rs.sendStream.holdsTokensRaftMuLocked() {
 			s.SendTokensHeld = convertTokensSlice(rs.sendStream.raftMu.tracker.deducted[:])
@@ -1686,6 +1689,12 @@ func (rc *rangeController) StatusRaftMuLocked() serverpb.RACStatus {
 		status.Streams[uint64(id)] = s
 	}
 	return status
+}
+
+func holdsTokens(tokens []kvflowcontrol.Tokens) bool {
+	return slices.ContainsFunc(tokens, func(tokens kvflowcontrol.Tokens) bool {
+		return tokens != 0
+	})
 }
 
 func convertTokensSlice(tokens []kvflowcontrol.Tokens) []int64 {

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/range_controller.go
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/range_controller.go
@@ -1676,7 +1676,6 @@ func (rc *rangeController) StatusRaftMuLocked() serverpb.RACStatus {
 			defer rs.sendStream.mu.Unlock()
 			s.IndexToSend = rs.sendStream.mu.sendQueue.indexToSend
 			s.NextRaftIndexInitial = rs.sendStream.mu.nextRaftIndexInitial
-			s.NextRaftIndex = rs.sendStream.mu.sendQueue.nextRaftIndex
 			s.ForceFlushStopIndex = uint64(rs.sendStream.mu.sendQueue.forceFlushStopIndex)
 			// Don't waste space if there are no tokens held.
 			if tokens := rs.sendStream.mu.eval.tokensDeducted[:]; holdsTokens(tokens) {

--- a/pkg/server/serverpb/status.proto
+++ b/pkg/server/serverpb/status.proto
@@ -391,11 +391,12 @@ message RACStatus {
   message Stream {
     uint64 index_to_send = 1;
     uint64 next_raft_index_initial = 2;
-    uint64 next_raft_index = 3;
     uint64 force_flush_stop_index = 4;
 
     repeated int64 eval_tokens_held = 5;
     repeated int64 send_tokens_held = 6;
+
+    reserved 3;
   }
   map<uint64, Stream> streams = 6 [ (gogoproto.nullable) = false ];
 }


### PR DESCRIPTION
This PR does a couple of optimizations to minimize the `ranges.json` size:

- Excludes "tokens held" slices if no tokens are held.
- Removes a redundant per-stream `NextRaftIndex`. It matches the range controller's `NextRaftIndex`.

Part of #136014