### PR TITLE
raft: optimize storage access for term when leader tries to commit

### DIFF
--- a/pkg/raft/raft_test.go
+++ b/pkg/raft/raft_test.go
@@ -2596,9 +2596,10 @@ func TestLeaderAppResp(t *testing.T) {
 		// Follower 2 responds to leader, indicating log index 2 is replicated.
 		// Leader tries to commit, but commit index doesn't advance since the index
 		// is from a previous term.
-		// We hit maybeCommit() and do term check by getting the term number from
-		// storage.
-		{2, false, 2, 7, 1, 2, 0, 3},
+		// We hit maybeCommit() and do term check comparison by using the invariant
+		// raft.idxPreLeading.
+		// There is no storage access for term in the maybeCommit() code path
+		{2, false, 2, 7, 1, 2, 0, 2},
 
 		// NB: For the following tests, we are skipping the MsgAppResp for the first
 		// 3 entries, by directly processing MsgAppResp for later entries.


### PR DESCRIPTION
When the raft leader wants to commit an entry(advance commit index), it must check the term of the entry it wants to commit and ensure the term number is the same as the current leader term(term of itself).
Previously, this process may involve a storage access for the term number if the entry has been persisted on stable storage and no longer in the unstable log of the leader node.

In fact this above scenario happens quite often. Which makes an optimization improving leader commit latency fruitful.

This PR introduces an optimization that utilizes an invariant that is logically equivalent to checking whether the want-to-be-committed entry has the same term as the leader doing the commit.
This is done by keeping an entry index in leader node's memory that signifies the point in time where the current leader became leader. When the leader wants to commit an entry, the leader compares the want-to-be-committed entry's index(available in memory) with the newly added index in this PR to determine whether the term matches.
Thus completely eliminating storage access on this code path.

A corresponding unit test is also modified to account for the elimination of storage access when leader tries to commit.

A previous related PR(merged): https://github.com/cockroachdb/cockroach/pull/139907
Jira issue: [CRDB-45763](https://cockroachlabs.atlassian.net/browse/CRDB-45763)
Fixes: https://github.com/cockroachdb/cockroach/issues/137826

Release note (performance improvement): removed a potential storage read from raft commit pipeline. This reduces the worst-case KV write latency.