### PR TITLE
roachtest: deflake gopg

### DIFF
--- a/pkg/cmd/roachtest/tests/gopg_blocklist.go
+++ b/pkg/cmd/roachtest/tests/gopg_blocklist.go
@@ -50,4 +50,6 @@ var gopgIgnoreList = blocklist{
 	"pg | DB race | SelectOrInsert with OnConflict is race free":    "unknown",
 	"pg | DB race | SelectOrInsert without OnConflict is race free": "unknown",
 	`pg | ORM | relation with no results does not panic`:            "unknown",
+	// This test flakes sometimes because of connection reuse.
+	`v10.TestColumnReuse`: "unknown",
 }


### PR DESCRIPTION
Previously, the test TestColumnReuse could intermittently fail if the temporary table created gets cleaned up if the connection drops. To address this, this patch adds the test on the ignore list.

Fixes: #139207

Release note: None