### PR TITLE
roachtest: ignore python warnings asyncpg

### DIFF
--- a/pkg/cmd/roachtest/tests/asyncpg.go
+++ b/pkg/cmd/roachtest/tests/asyncpg.go
@@ -18,11 +18,14 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
 )
 
+var asyncpgWarningArgs = "ignore::ResourceWarning"
+
 var asyncpgRunTestCmd = fmt.Sprintf(`
 source venv/bin/activate &&
 cd /mnt/data1/asyncpg &&
-PGPORT={pgport:1} PGHOST=localhost PGUSER=%s PGPASSWORD=%s PGSSLROOTCERT=$HOME/%s/ca.crt PGSSLMODE=require PGDATABASE=defaultdb python3 setup.py test > asyncpg.stdout
-`, install.DefaultUser, install.DefaultPassword, install.CockroachNodeCertsDir)
+PGPORT={pgport:1} PGHOST=localhost PGUSER=%s PGPASSWORD=%s PGSSLROOTCERT=$HOME/%s/ca.crt PGSSLMODE=require PGDATABASE=defaultdb python3 -W%q setup.py test > asyncpg.stdout
+`, install.DefaultUser, install.DefaultPassword, install.CockroachNodeCertsDir, asyncpgWarningArgs,
+)
 
 var asyncpgReleaseTagRegex = regexp.MustCompile(`^(?P<major>v\d+)\.(?P<minor>\d+)\.(?P<point>\d+)$`)
 


### PR DESCRIPTION
Previously, the asyncpg test was flaking because resource warnings could interfere with parsing the test output. To address this, this patch uses the warning flag to skip resource warnings, allowing the output to be correctly analyzed.

Fixes: #139471
fixes https://github.com/cockroachdb/cockroach/issues/139472
fixes https://github.com/cockroachdb/cockroach/issues/139541
fixes https://github.com/cockroachdb/cockroach/issues/139545
fixes https://github.com/cockroachdb/cockroach/issues/139543

informs https://github.com/cockroachdb/cockroach/issues/139546
informs https://github.com/cockroachdb/cockroach/issues/139544

Release note: None