### PR TITLE
logictest: skip `alter_primary_key` under race

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/alter_primary_key
+++ b/pkg/sql/logictest/testdata/logic_test/alter_primary_key
@@ -1,4 +1,5 @@
-# LogicTest: !metamorphic-batch-sizes
+# We've seen this test hit a timeout in fakedist configs under race.
+skip under race
 
 statement ok
 CREATE TABLE t (x INT PRIMARY KEY, y INT NOT NULL, z INT NOT NULL, w INT, INDEX i (x), INDEX i2 (z))


### PR DESCRIPTION
We tried to fix this by disabling metamorphic batch sizes, but we just saw another timeout even with that patch applied, so let's just skip this test under race.

Fixes: #139636.

Release note: None