### PR TITLE
builder: disable sve due to crash on m4s running 15.2

### DIFF
--- a/build/bazelutil/empty.bazelrc
+++ b/build/bazelutil/empty.bazelrc
@@ -1,1 +1,7 @@
-# intentionally empty (this file is mounted as .bazelrc.user for cross builds)
+# This file is mounted as .bazelrc.user for cross builds and must exist, so
+# keep it here (even if it becomes empty).
+
+# As of late 2024/early 2025, current versions of java crash when run in a guest
+# VM on a MacOS 15.2 host running on an M4 chip. Disbaling SVE avoids this
+# crash until patched versions of Java become available.
+startup --host_jvm_args="-XX:UseSVE=0"


### PR DESCRIPTION
When trying to run 'build --cross' on a m4 mac running 15.2, I was seeing the jvm crash due to SIGILL. Some reports on the internet suggest disabling SVE which appears to resolve this.

Release note: none.
Epic: none.