### PR TITLE
release-24.3: roachtest: use >=23.2.0 in rebalance/*/mixed-version tests

### DIFF
--- a/pkg/cmd/roachtest/tests/rebalance_load.go
+++ b/pkg/cmd/roachtest/tests/rebalance_load.go
@@ -105,6 +105,12 @@ func registerRebalanceLoad(r registry.Registry) {
 
 				// Only use the latest version of each release to work around #127029.
 				mixedversion.AlwaysUseLatestPredecessors,
+				// TODO(kvoli): Re-enable shared process deployments for mixed version
+				// variant #139037.
+				mixedversion.EnabledDeploymentModes(
+					mixedversion.SystemOnlyDeployment,
+					mixedversion.SeparateProcessDeployment,
+				),
 			)
 			mvt.OnStartup("maybe enable split/scatter on tenant",
 				func(ctx context.Context, l *logger.Logger, r *rand.Rand, h *mixedversion.Helper) error {

--- a/pkg/cmd/roachtest/tests/rebalance_load.go
+++ b/pkg/cmd/roachtest/tests/rebalance_load.go
@@ -105,12 +105,7 @@ func registerRebalanceLoad(r registry.Registry) {
 
 				// Only use the latest version of each release to work around #127029.
 				mixedversion.AlwaysUseLatestPredecessors,
-				// TODO(kvoli): Re-enable shared process deployments for mixed version
-				// variant #139037.
-				mixedversion.EnabledDeploymentModes(
-					mixedversion.SystemOnlyDeployment,
-					mixedversion.SeparateProcessDeployment,
-				),
+				mixedversion.MinimumSupportedVersion("v23.2.0"),
 			)
 			mvt.OnStartup("maybe enable split/scatter on tenant",
 				func(ctx context.Context, l *logger.Logger, r *rand.Rand, h *mixedversion.Helper) error {


### PR DESCRIPTION
Backport 1/1 commits from #139040.
Backport 1/1 commits from #139526.

/cc @cockroachdb/release

----

In #129117, shared process deployments were added to the `rebalance/by-load/*/mixed-version` roachtests. Despite multiple deflaking attempts (#131787, #133681, #136115, #136116), these continue to fail weekly. The root cause is currently unknown.

Part of: #139037
Release note: None

----

The `rebalance/by-load/*/mixed-version` roachtests were skipped under shared process multi-tenancy in #139040 due to test failures which were caused by erroneous (empty) metric timeseries data, which is used to assert on the CPU balance of nodes in the cluster.

An identical failure signature has recently reproduced 1/10 runs, on a v23.1 mixed version cluster (see #139037). To that end, unskip shared-process multi-tenant versions of the test and set the minimum version to `v23.2.0`, to avoid encountering the metrics gathering issue again.

Fixes: #137486
Fixes: #138621
Fixes: #138362
Fixes: #136800
Fixes: #138635
Informs: #139037
Release note: None

----

Release justification: Test only.
