### PR TITLE
roachprod: respect logger's config specified io.writers

### DIFF
--- a/pkg/roachprod/logger/log.go
+++ b/pkg/roachprod/logger/log.go
@@ -126,8 +126,8 @@ func (cfg *Config) NewLogger(path string) (*Logger, error) {
 		return &Logger{
 			Stdout:  newSafeWriter(stdout),
 			Stderr:  newSafeWriter(stderr),
-			stdoutL: log.New(os.Stdout, cfg.Prefix, logFlags),
-			stderrL: log.New(os.Stderr, cfg.Prefix, logFlags),
+			stdoutL: log.New(stdout, cfg.Prefix, logFlags),
+			stderrL: log.New(stderr, cfg.Prefix, logFlags),
 		}, nil
 	}
 


### PR DESCRIPTION
Previously, when NewLogger() was called with an empty path on a Config{} that specifies customs Stdout and Stderr, the logger was still logging to os.Stdout and os.Stderr unless the caller was directly using the exposed Stdout and Stderr writers.

This change uniformizes makes the logger's internal functions `Printf`, and `Errorf` respect the specified configuration, similarly to when a file path is provided.

Epic: none
Release note: None