### PR TITLE
raft: remove commit index handling leftovers

### DIFF
--- a/pkg/raft/raft.go
+++ b/pkg/raft/raft.go
@@ -2432,34 +2432,6 @@ func (r *raft) checkMatch(match uint64) {
 
 func (r *raft) handleHeartbeat(m pb.Message) {
 	r.checkMatch(m.Match)
-
-	// The m.Term leader is indicating to us through this heartbeat message
-	// that indices <= m.Commit in its log are committed. If our log matches
-	// the leader's up to index M, then we can update our commit index to
-	// min(m.Commit, M).
-	//
-	// If accTerm == m.Term, i.e. the last accepted log append came from this
-	// leader, then we know that our log is a prefix of the leader's log. We can
-	// thus put M = r.raftLog.lastIndex() in the formula above.
-	//
-	// Otherwise (accTerm != m.Term), we haven't accepted a single log append from
-	// the m.Term leader, so we don't know M, and it is unsafe to update the
-	// commit index.
-	//
-	// NB: in the latter case, our log is lagging the leader's. If the leader is
-	// stable, we will eventually accept a MsgApp which sets accTerm == m.Term and
-	// enables advancing the commit index. By this, we have the guarantee that our
-	// commit index converges to the leader's.
-	//
-	// TODO(pav-kv): the condition can be relaxed, it is actually safe to bump the
-	// commit index if accTerm >= m.Term.
-	// TODO(pav-kv): move this logic to raftLog.commitTo, once the accTerm has
-	// migrated to raftLog/unstable.
-	// TODO(pav-kv): heartbeats no longer send the commit index. Remove this code.
-	mark := LogMark{Term: m.Term, Index: min(m.Commit, r.raftLog.lastIndex())}
-	if mark.Term == r.raftLog.accTerm() {
-		r.raftLog.commitTo(mark)
-	}
 	r.send(pb.Message{To: m.From, Type: pb.MsgHeartbeatResp})
 }
 

--- a/pkg/raft/tracker/progress.go
+++ b/pkg/raft/tracker/progress.go
@@ -348,7 +348,7 @@ func (pr *Progress) ShouldSendEntries(last uint64, lazyReplication bool) bool {
 // We must send a message periodically even if all updates are already in flight
 // to this peer, to guarantee that eventually the flow is either accepted or
 // rejected.
-func (pr *Progress) ShouldSendProbe(last, commit uint64, advanceCommit bool) bool {
+func (pr *Progress) ShouldSendProbe(last, commit uint64) bool {
 	switch pr.State {
 	case StateProbe:
 		return !pr.MsgAppProbesPaused
@@ -379,10 +379,7 @@ func (pr *Progress) ShouldSendProbe(last, commit uint64, advanceCommit bool) boo
 		// to the follower.
 		// TODO(iskettaneh): Remove the dependency on MsgAppProbesPaused to send
 		// MsgApps.
-		if advanceCommit {
-			return pr.IsFollowerCommitStale(commit) && !pr.MsgAppProbesPaused
-		}
-		return false
+		return pr.IsFollowerCommitStale(commit) && !pr.MsgAppProbesPaused
 
 	case StateSnapshot:
 		return false


### PR DESCRIPTION
`MsgHeartbeat` no longer carries a commit index. Only `MsgApp` does.

Epic: none
Release note: none