### PR TITLE
kvserver: avoid an alloc in the write path

### DIFF
--- a/pkg/kv/kvserver/replica_proposal_buf.go
+++ b/pkg/kv/kvserver/replica_proposal_buf.go
@@ -934,11 +934,13 @@ func maybeDeductFlowTokens(
 			// free up all tracked tokens as a result of this leadership change.
 			return
 		}
-		log.VInfof(ctx, 1, "bound index/log terms for proposal entry: %s",
-			raft.DescribeEntry(ents[i], func(bytes []byte) string {
-				return "<omitted>"
-			}),
-		)
+		if log.ExpensiveLogEnabled(ctx, 1) {
+			log.VInfof(ctx, 1, "bound index/log terms for proposal entry: %s",
+				raft.DescribeEntry(ents[i], func(bytes []byte) string {
+					return "<omitted>"
+				}),
+			)
+		}
 		h.DeductTokensFor(
 			admitHandle.pCtx,
 			admissionpb.WorkPriority(admitHandle.handle.AdmissionPriority),


### PR DESCRIPTION
Randomly saw this in a profile over in https://github.com/cockroachdb/cockroach/pull/139557.

<img width="633" alt="image" src="https://github.com/user-attachments/assets/a1f7c2b8-3d73-4199-a641-8b520b0a202e" />

Epic: CRDB-42584
Release note: none
