### PR TITLE
roachprod-microbench: only report infra failures

### DIFF
--- a/pkg/cmd/roachprod-microbench/executor.go
+++ b/pkg/cmd/roachprod-microbench/executor.go
@@ -438,9 +438,6 @@ func (e *executor) executeBenchmarks() error {
 	}
 
 	e.log.Printf("Completed benchmarks, results located at %s", e.outputDir)
-	if errorCount != 0 {
-		return errors.Newf("Found %d errors during remote execution", errorCount)
-	}
 	return nil
 }
 


### PR DESCRIPTION
Previously, if there were failed benchmarks (due to panic or some other benchmark related error) the microbenchmark job would fail on CI.

This change removes that as a failure condition. Ultimately the benchmark failures should post GitHub issues instead. This will be done in a follow-up PR.

Epic: None
Release note: None