### PR TITLE
workload/schemachanger: limit size of datums during insert

### DIFF
--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -2935,7 +2935,23 @@ func (og *operationGenerator) insertRow(ctx context.Context, tx pgx.Tx) (stmt *o
 	for i := 0; i < numRows; i++ {
 		var row []string
 		for _, col := range nonGeneratedCols {
-			d := randgen.RandDatum(og.params.rng, col.typ, col.nullable)
+			// Limit the size of columns being generated.
+			const maxSize = 1024 * 1024
+			maxAttempts := 32
+			var d tree.Datum
+			for i := 0; i < maxAttempts; i++ {
+				d = randgen.RandDatum(og.params.rng, col.typ, col.nullable)
+				// Retry if we exceed the maximum size.
+				if d.Size() < maxSize {
+					break
+				}
+			}
+			if d.Size() > maxSize {
+				og.LogMessage(fmt.Sprintf("datum of type %s exceeds size limit (%d / %d)",
+					col.typ.SQLString(),
+					d.Size(),
+					maxSize))
+			}
 			// Unfortunately, RandDatum for OIDs only selects random values, which will
 			// always fail validation. So, for OIDs we will select a random known type
 			// instead.


### PR DESCRIPTION
Previously, the insert statement in the randomized schema changer workload could have unbounded sizes for individual datums. This patch adds size limit for datums in the insert operation, where datums will be regenerated a limited number of times until they are below a maximum size.

Fixes: #139494

Release note: None