### PR TITLE
cli: update maybeWarnMemorySizes to use redact.StringBuilder

### DIFF
--- a/pkg/cli/flags_util.go
+++ b/pkg/cli/flags_util.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/keysutil"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/vfs"
+	"github.com/cockroachdb/redact"
 	humanize "github.com/dustin/go-humanize"
 	"github.com/spf13/pflag"
 )
@@ -319,6 +320,9 @@ type bytesOrPercentageValue struct {
 	// memoryPercentResolver() and diskPercentResolverFactory().
 	percentResolver percentResolverFunc
 }
+
+var _ redact.SafeFormatter = (*bytesOrPercentageValue)(nil)
+
 type percentResolverFunc func(percent int) (int64, error)
 
 // memoryPercentResolver turns a percent into the respective fraction of the
@@ -426,7 +430,12 @@ func (b *bytesOrPercentageValue) Type() string {
 
 // String implements the pflag.Value interface.
 func (b *bytesOrPercentageValue) String() string {
-	return b.bval.String()
+	return redact.StringWithoutMarkers(b)
+}
+
+// SafeFormat implements the redact.SafeFormatter interface.
+func (b *bytesOrPercentageValue) SafeFormat(p redact.SafePrinter, _ rune) {
+	p.Print(b.bval)
 }
 
 // IsSet returns true iff Set has successfully been called.

--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -6,7 +6,6 @@
 package cli
 
 import (
-	"bytes"
 	"context"
 	"fmt"
 	"math"
@@ -1356,16 +1355,16 @@ func reportConfiguration(ctx context.Context) {
 func maybeWarnMemorySizes(ctx context.Context) {
 	// Is the cache configuration OK?
 	if !startCtx.cacheSizeValue.IsSet() {
-		var buf bytes.Buffer
-		fmt.Fprintf(&buf, "Using the default setting for --cache (%s).\n", &startCtx.cacheSizeValue)
-		fmt.Fprintf(&buf, "  A significantly larger value is usually needed for good performance.\n")
+		var buf redact.StringBuilder
+		buf.Printf("Using the default setting for --cache (%s).\n", &startCtx.cacheSizeValue)
+		buf.Printf("  A significantly larger value is usually needed for good performance.\n")
 		if size, err := status.GetTotalMemory(ctx); err == nil {
-			fmt.Fprintf(&buf, "  If you have a dedicated server a reasonable setting is --cache=.25 (%s).",
+			buf.Printf("  If you have a dedicated server a reasonable setting is --cache=.25 (%s).",
 				humanizeutil.IBytes(size/4))
 		} else {
-			fmt.Fprintf(&buf, "  If you have a dedicated server a reasonable setting is 25%% of physical memory.")
+			buf.Printf("  If you have a dedicated server a reasonable setting is 25%% of physical memory.")
 		}
-		log.Ops.Warningf(ctx, "%s", redact.SafeString(buf.String()))
+		log.Ops.Warningf(ctx, "%s", buf.RedactableString())
 	}
 
 	// Check that the total suggested "max" memory is well below the available memory.


### PR DESCRIPTION
Using a redact.StringBuilder is a bit safer than using a SafeString cast on the whole message, since if we ever add sensitive values to this message in the future, it will automatically take care of redacting them.

follow up to https://github.com/cockroachdb/cockroach/pull/139117
Epic: CRDB-37533
Release note: None