### PR TITLE
logictest: skip `alter_table` under race

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -1,3 +1,6 @@
+# We've seen this file take more than an hour under race.
+skip under race
+
 statement ok
 CREATE TABLE other (b INT PRIMARY KEY)
 


### PR DESCRIPTION
We just saw a test run where `alter_table` took more than an hour under race. None of the metamorphic variables seem likely to be the cause of the slowdown, so probably just the sheer number of schema changes in this file are to blame.

Fixes: #139739.

Release note: None