### PR TITLE
insights: attempt to fix TestIngester by lowering the flush interval

### DIFF
--- a/pkg/sql/sqlstats/insights/ingester_test.go
+++ b/pkg/sql/sqlstats/insights/ingester_test.go
@@ -77,7 +77,7 @@ func TestIngester(t *testing.T) {
 				}, store, nil),
 			)
 
-			ingester.Start(ctx, stopper)
+			ingester.Start(ctx, stopper, WithFlushInterval(10))
 			for _, e := range tc.observations {
 				if e.statementID != 0 {
 					ingester.ObserveStatement(e.SessionID(), &Statement{ID: e.StatementID()})
@@ -93,7 +93,7 @@ func TestIngester(t *testing.T) {
 					numInsights++
 				})
 				return numInsights == tc.totalTxnInsights
-			}, 1*time.Second, 50*time.Millisecond)
+			}, 1*time.Second, 10*time.Millisecond)
 
 			// See that the insights we were expecting are the ones that
 			// arrived. We allow the provider to do whatever it needs to, so


### PR DESCRIPTION
TestIngester failed under a nightly stress test due to the insights store attached to the test never properly receiving the insights which should have been observed.

The code itself is a bit complex, the Ingester contains a Guard which it configures with a flush function. Below the Ingester is a Registry which contains a Store, and the Ingester on some interval attempts to flush events from its buffer to the Registry, in hopes that the Registry pushes those events to the downstream Store.

After trying to reproduce this failure under a variety of conditions (increasing the count, adding race in addition to the stress flag, doing the same in a gce worker), I tried to reason about how this failure could come about. It seemed mostly likely that the flush was never triggered, or if it were, not triggered early enough under the stress test.

The solution I landed on was to lower the flush interval, assuming the system had not flushed in time before the test exited. Other options explored included:
 - Attaching a logger to the testing knobs to be used within the Ingester.
 - Forcing a flush (which would defeat the purpose of testing the automated flush).

Epic: none
Fixes: #139423

Release note: None