### PR TITLE
builtins: fix to_reg* handling of number arguments

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/pg_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/pg_builtins
@@ -710,6 +710,16 @@ SELECT to_regclass('4294967230')
 NULL
 
 query T
+SELECT to_regclass('0 ')
+----
+NULL
+
+query T
+SELECT to_regclass(' -123 ')
+----
+NULL
+
+query T
 SELECT to_regclass('pg_policy')
 ----
 pg_policy
@@ -736,6 +746,16 @@ NULL
 
 query T
 SELECT to_regnamespace(' 1330834471')
+----
+NULL
+
+query T
+SELECT to_regnamespace('0 ')
+----
+NULL
+
+query T
+SELECT to_regnamespace('-1234 ')
 ----
 NULL
 
@@ -780,6 +800,16 @@ SELECT to_regprocedure('961893967')
 NULL
 
 query T
+SELECT to_regprocedure('0')
+----
+NULL
+
+query T
+SELECT to_regprocedure('-2')
+----
+NULL
+
+query T
 SELECT to_regrole('admin')
 ----
 admin
@@ -796,6 +826,16 @@ NULL
 
 query T
 SELECT to_regrole('1546506610')
+----
+NULL
+
+query T
+SELECT to_regrole('0')
+----
+NULL
+
+query T
+SELECT to_regrole('-2')
 ----
 NULL
 
@@ -821,6 +861,16 @@ text
 
 query T
 SELECT to_regtype('1186')
+----
+NULL
+
+query T
+SELECT to_regtype('0')
+----
+NULL
+
+query T
+SELECT to_regtype('-3')
 ----
 NULL
 

--- a/pkg/sql/sem/builtins/pg_builtins.go
+++ b/pkg/sql/sem/builtins/pg_builtins.go
@@ -573,8 +573,9 @@ func makeToRegOverload(typ *types.T, helpText string) builtinDefinition {
 			ReturnType: tree.FixedReturnType(types.RegType),
 			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				typName := tree.MustBeDString(args[0])
-				int, _ := strconv.Atoi(strings.TrimSpace(string(typName)))
-				if int > 0 {
+				_, err := strconv.Atoi(strings.TrimSpace(string(typName)))
+				if err == nil {
+					// If a number was passed in, return NULL.
 					return tree.DNull, nil
 				}
 				typOid, err := eval.ParseDOid(ctx, evalCtx, string(typName), typ)


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/124908
Release note (bug fix): The to_regclass, to_regtype, to_regrole, and related functions now return NULL for any numerical input argument.