### PR TITLE
roachprod: log expanded command

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -2505,6 +2505,7 @@ func (c *clusterImpl) RunE(ctx context.Context, options install.RunOptions, args
 	l.Printf("> %s", cmd)
 	expanderCfg := install.ExpanderConfig{
 		DefaultVirtualCluster: c.defaultVirtualCluster,
+		LogExpandedResult:     true,
 	}
 	if err := roachprod.Run(
 		ctx, l, c.MakeNodes(nodes), "", "", c.IsSecure(),
@@ -2575,6 +2576,7 @@ func (c *clusterImpl) RunWithDetails(
 	l.Printf("> %s", cmd)
 	expanderCfg := install.ExpanderConfig{
 		DefaultVirtualCluster: c.defaultVirtualCluster,
+		LogExpandedResult:     true,
 	}
 	results, err := roachprod.RunWithDetails(
 		ctx, l, c.MakeNodes(nodes), "" /* SSHOptions */, "", /* processTag */

--- a/pkg/roachprod/install/expander.go
+++ b/pkg/roachprod/install/expander.go
@@ -43,6 +43,7 @@ var certsDirRe = regexp.MustCompile(`{certs-dir}`)
 
 type ExpanderConfig struct {
 	DefaultVirtualCluster string
+	LogExpandedResult     bool
 }
 
 // expander expands a string which contains templated parameters for cluster
@@ -92,6 +93,9 @@ func (e *expander) expand(
 	})
 	if err != nil {
 		return "", err
+	}
+	if cfg.LogExpandedResult && s != arg {
+		l.Printf("Node %d expanded > %s", e.node, s)
 	}
 	return s, nil
 }


### PR DESCRIPTION
This change now logs expanded commands if they differ from the original command. This should ease debugging as we can know what command was actually run on the node.

Epic: none
Release note: none
Fixes: none