### PR TITLE
roachtest: fix unsortedMatricesDiffWithFloatComp helper

### DIFF
--- a/pkg/cmd/roachtest/tests/query_comparison_util_test.go
+++ b/pkg/cmd/roachtest/tests/query_comparison_util_test.go
@@ -148,6 +148,14 @@ func TestUnsortedMatricesDiff(t *testing.T) {
 			exactMatch:  false,
 			approxMatch: true,
 		},
+		{
+			name:        "multi row 0 in array matches -0 in array, lib/pq type name",
+			colTypes:    []string{"_FLOAT4"}, // this is how []FLOAT4 is named in lib/pq driver
+			t1:          [][]string{{"NULL"}, {"{-1}"}, {"{-0}"}, {"{0}"}, {"{NaN}"}},
+			t2:          [][]string{{"NULL"}, {"{-1}"}, {"{0}"}, {"{0}"}, {"{NaN}"}},
+			exactMatch:  false,
+			approxMatch: true,
+		},
 	}
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
`unsortedMatricesDiffWithFloatComp` has a special logic for handling float and decimal arrays, and it figures out whether that logic is applicable based on the stringified type name. Previously, we would only match strings like `[]FLOAT4` for that, but lib/pq library returns `_FLOAT4` as the name for that array, so we would previously not apply the special logic in some cases, which would lead to spurious failures. This is now fixed.

Fixes: #139727.

Release note: None