### PR TITLE
release-24.3: roachtest: inc wait to 10m for token return in perturbation tests

### DIFF
--- a/pkg/cmd/roachtest/tests/admission_control_latency.go
+++ b/pkg/cmd/roachtest/tests/admission_control_latency.go
@@ -943,7 +943,7 @@ func validateTokensReturned(
 				}
 			}
 			return nil
-		}, 5*time.Second)
+		}, 10*time.Minute)
 	}
 }
 


### PR DESCRIPTION
Backport 1/1 commits from #135211.

/cc @cockroachdb/release

---

We assert that tokens are returned at the end of the `perturbation/*`
roachtests. However, we only waited 5 seconds before failing the
assertion. As the comment in this patch suggests, draining a send queue
can take longer as the node paces its catchup. In such cases, it is
acceptable that tokens are not returned within the lesser duration.

Bump this duration to 10 minutes.

Fixes: #139809
Release note: None

Release Justification: Test only change.
