### PR TITLE
release-25.1: cli: change jemalloc defaults

### DIFF
--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -1173,6 +1173,10 @@ func startShutdownAsync(
 	}()
 }
 
+// cgoAllocConfStr is populated from start_jemalloc.go if we are using jemalloc.
+// Otherwise, it stays empty.
+var cgoAllocConfStr string
+
 // reportServerInfo prints out the server version and network details
 // in a standardized format.
 func reportServerInfo(
@@ -1189,6 +1193,9 @@ func reportServerInfo(
 	buf.Printf("CockroachDB %s starting at %s (took %0.1fs)\n", serverType, timeutil.Now(), timeutil.Since(startTime).Seconds())
 	buf.Printf("build:\t%s %s @ %s (%s)\n",
 		redact.Safe(info.Distribution), redact.Safe(info.Tag), redact.Safe(info.Time), redact.Safe(info.GoVersion))
+	if cgoAllocConfStr != "" {
+		buf.Printf("malloc_conf:\t%s\n", redact.Safe(cgoAllocConfStr))
+	}
 	buf.Printf("webui:\t%s\n", log.SafeManaged(serverCfg.AdminURL()))
 
 	// (Re-)compute the client connection URL. We cannot do this

--- a/pkg/cli/start_jemalloc.go
+++ b/pkg/cli/start_jemalloc.go
@@ -8,6 +8,13 @@
 
 package cli
 
+import (
+	"fmt"
+	"unsafe"
+
+	"github.com/cockroachdb/cockroach/pkg/server/profiler"
+)
+
 // #cgo CPPFLAGS: -DJEMALLOC_NO_DEMANGLE
 // #cgo LDFLAGS: -ljemalloc
 // #cgo dragonfly freebsd LDFLAGS: -lm
@@ -15,6 +22,24 @@ package cli
 //
 // #include <jemalloc/jemalloc.h>
 // #include <stddef.h>
+// #include <stdio.h>
+//
+// // TODO(radu): if we want to change the defaults, we can set the following
+// // global variable.
+// //
+// // These default options can still be overriden via /etc/malloc.conf and the
+// // MALLOC_CONF env var. From the jemalloc man page:
+// //   The string specified via --with-malloc-conf, the string pointed to by
+// //   the global variable malloc_conf, the “name” of the file referenced by
+// //   the symbolic link named /etc/malloc.conf, and the value of the
+// //   environment variable MALLOC_CONF, will be interpreted, in that order,
+// //   from left to right as options. Note that malloc_conf may be read before
+// //   main() is entered, so the declaration of malloc_conf should specify an
+// //   initializer that contains the final value to be read by jemalloc.
+// //   --with-malloc-conf and malloc_conf are compile-time mechanisms, whereas
+// //   /etc/malloc.conf and MALLOC_CONF can be safely set any time prior to
+// //   program invocation.
+// //const char *je_malloc_conf = "...";
 //
 // // Checks whether jemalloc profiling is enabled and active.
 // // Returns true if profiling is enabled and active.
@@ -38,22 +63,91 @@ package cli
 //   return enabled;
 // }
 //
+// typedef struct {
+//   bool prof;
+//   bool prof_active;
+//   bool background_thread;
+//   const char *thp;
+//   const char *metadata_thp;
+//   unsigned narenas;
+//   size_t dirty_decay_ms;
+//   size_t muzzy_decay_ms;
+// } JemallocOpts;
+//
+// // Prints a string showing the values of some of the jemalloc options into
+// // the given buffer of the given size.
+// int jemalloc_get_opts(JemallocOpts *opts) {
+//   size_t sz;
+//   int err;
+//
+//   sz = sizeof(opts->prof);
+//   err = je_mallctl("opt.prof", &opts->prof, &sz, NULL, 0);
+//   if (err != 0) {
+//     return err;
+//   }
+//   sz = sizeof(opts->prof_active);
+//   err = je_mallctl("opt.prof_active", &opts->prof_active, &sz, NULL, 0);
+//   if (err != 0) {
+//     return err;
+//   }
+//   sz = sizeof(opts->thp);
+//   err = je_mallctl("opt.thp", &opts->thp, &sz, NULL, 0);
+//   if (err != 0) {
+//     return err;
+//   }
+//   sz = sizeof(opts->metadata_thp);
+//   err = je_mallctl("opt.metadata_thp", &opts->metadata_thp, &sz, NULL, 0);
+//   if (err != 0) {
+//     return err;
+//   }
+//   sz = sizeof(opts->background_thread);
+//   err = je_mallctl("opt.background_thread", &opts->background_thread, &sz, NULL, 0);
+//   if (err != 0) {
+//     return err;
+//   }
+//   sz = sizeof(opts->narenas);
+//   err = je_mallctl("opt.narenas", &opts->narenas, &sz, NULL, 0);
+//   if (err != 0) {
+//     return err;
+//   }
+//   sz = sizeof(opts->dirty_decay_ms);
+//   err = je_mallctl("opt.dirty_decay_ms", &opts->dirty_decay_ms, &sz, NULL, 0);
+//   if (err != 0) {
+//     return err;
+//   }
+//   sz = sizeof(opts->muzzy_decay_ms);
+//   err = je_mallctl("opt.muzzy_decay_ms", &opts->muzzy_decay_ms, &sz, NULL, 0);
+//   if (err != 0) {
+//     return err;
+//   }
+//   return 0;
+// }
+//
 // // Write a heap profile to "filename". Returns true on success, false on error.
 // int dump_heap_profile(const char *filename) {
 //   return je_mallctl("prof.dump", NULL, NULL, &filename, sizeof(const char *));
 // }
 import "C"
 
-import (
-	"fmt"
-	"unsafe"
-
-	"github.com/cockroachdb/cockroach/pkg/server/profiler"
-)
-
 func init() {
 	if C.is_profiling_enabled() {
 		profiler.SetJemallocHeapDumpFn(writeJemallocProfile)
+	}
+
+	var opts C.JemallocOpts
+	if res, _ := C.jemalloc_get_opts(&opts); res != 0 {
+		cgoAllocConfStr = fmt.Sprintf("unknown (error %d)", int(res))
+	} else {
+		cgoAllocConfStr = fmt.Sprintf("prof:%t,prof_active:%t,background_thread:%t,thp:%s,metadata_thp:%s,narenas:%d,dirty_decay_ms:%d,muzzy_delay_ms:%d",
+			bool(opts.prof),
+			bool(opts.prof_active),
+			bool(opts.background_thread),
+			C.GoString(opts.thp),
+			C.GoString(opts.metadata_thp),
+			int(opts.narenas),
+			int(opts.dirty_decay_ms),
+			int(opts.muzzy_decay_ms),
+		)
 	}
 }
 

--- a/pkg/cli/start_jemalloc.go
+++ b/pkg/cli/start_jemalloc.go
@@ -24,9 +24,6 @@ import (
 // #include <stddef.h>
 // #include <stdio.h>
 //
-// // TODO(radu): if we want to change the defaults, we can set the following
-// // global variable.
-// //
 // // These default options can still be overriden via /etc/malloc.conf and the
 // // MALLOC_CONF env var. From the jemalloc man page:
 // //   The string specified via --with-malloc-conf, the string pointed to by
@@ -39,7 +36,7 @@ import (
 // //   --with-malloc-conf and malloc_conf are compile-time mechanisms, whereas
 // //   /etc/malloc.conf and MALLOC_CONF can be safely set any time prior to
 // //   program invocation.
-// //const char *je_malloc_conf = "...";
+// const char *je_malloc_conf = "background_thread:true,thp:never,metadata_thp:disabled,dirty_decay_ms:2000,muzzy_decay_ms:0";
 //
 // // Checks whether jemalloc profiling is enabled and active.
 // // Returns true if profiling is enabled and active.
@@ -138,7 +135,7 @@ func init() {
 	if res, _ := C.jemalloc_get_opts(&opts); res != 0 {
 		cgoAllocConfStr = fmt.Sprintf("unknown (error %d)", int(res))
 	} else {
-		cgoAllocConfStr = fmt.Sprintf("prof:%t,prof_active:%t,background_thread:%t,thp:%s,metadata_thp:%s,narenas:%d,dirty_decay_ms:%d,muzzy_delay_ms:%d",
+		cgoAllocConfStr = fmt.Sprintf("prof:%t,prof_active:%t,background_thread:%t,thp:%s,metadata_thp:%s,narenas:%d,dirty_decay_ms:%d,muzzy_decay_ms:%d",
 			bool(opts.prof),
 			bool(opts.prof_active),
 			bool(opts.background_thread),

--- a/pkg/server/status/runtime_jemalloc.go
+++ b/pkg/server/status/runtime_jemalloc.go
@@ -35,37 +35,37 @@ package status
 //
 //   int err;
 //
-//   sz = sizeof(&stats->Allocated);
+//   sz = sizeof(stats->Allocated);
 //   err = je_mallctl("stats.allocated", &stats->Allocated, &sz, NULL, 0);
 //   if (err != 0) {
 //     return err;
 //   }
-//   sz = sizeof(&stats->Active);
+//   sz = sizeof(stats->Active);
 //   err = je_mallctl("stats.active", &stats->Active, &sz, NULL, 0);
 //   if (err != 0) {
 //     return err;
 //   }
-//   sz = sizeof(&stats->Metadata);
+//   sz = sizeof(stats->Metadata);
 //   err = je_mallctl("stats.metadata", &stats->Metadata, &sz, NULL, 0);
 //   if (err != 0) {
 //     return err;
 //   }
-//   sz = sizeof(&stats->Resident);
+//   sz = sizeof(stats->Resident);
 //   err = je_mallctl("stats.resident", &stats->Resident, &sz, NULL, 0);
 //   if (err != 0) {
 //     return err;
 //   }
-//   sz = sizeof(&stats->Mapped);
+//   sz = sizeof(stats->Mapped);
 //   err = je_mallctl("stats.mapped", &stats->Mapped, &sz, NULL, 0);
 //   if (err != 0) {
 //     return err;
 //   }
-//   sz = sizeof(&stats->Retained);
+//   sz = sizeof(stats->Retained);
 //   err = je_mallctl("stats.retained", &stats->Retained, &sz, NULL, 0);
 //   if (err != 0) {
 //     return err;
 //   }
-//   return err;
+//   return 0;
 // }
 import "C"
 
@@ -114,6 +114,18 @@ func getJemallocStats(ctx context.Context) (uint, uint, error) {
 		C.je_malloc_stats_print(nil, nil, nil)
 	}
 
+	// js.Allocated corresponds to stats.allocated, which is effectively the sum
+	// of outstanding allocations times the size class; thus it includes internal
+	// fragmentation.
+	//
+	// js.Resident corresponds to stats.resident, which is documented as follows:
+	//   Maximum number of bytes in physically resident data pages mapped by the
+	//   allocator, comprising all pages dedicated to allocator metadata, pages
+	//   backing active allocations, and unused dirty pages. This is a maximum
+	//   rather than precise because pages may not actually be physically resident
+	//   if they correspond to demand-zeroed virtual memory that has not yet been
+	//   touched. This is a multiple of the page size, and is larger than
+	//   stats.active.
 	return uint(js.Allocated), uint(js.Resident), nil
 }
 


### PR DESCRIPTION
Release justification: reduces spikes in memory usage, reducing the chance of unexpected OOMs.

Backport:
  * 1/1 commits from "cli: report jemalloc settings" (#139515)
  * 1/1 commits from "cli: change jemalloc defaults" (#139743)

Please see individual PRs for details.

/cc @cockroachdb/release
