### PR TITLE
jobspb: add timestamp-to-spans map to ChangefeedProgress

### DIFF
--- a/pkg/ccl/changefeedccl/alter_changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/alter_changefeed_stmt.go
@@ -802,6 +802,7 @@ func generateNewProgress(
 			Progress: &jobspb.Progress_HighWater{},
 			Details: &jobspb.Progress_Changefeed{
 				Changefeed: &jobspb.ChangefeedProgress{
+					//lint:ignore SA1019 deprecated usage
 					Checkpoint: &jobspb.ChangefeedProgress_Checkpoint{
 						Spans: existingTargetSpans,
 					},
@@ -832,6 +833,7 @@ func generateNewProgress(
 		Progress: &jobspb.Progress_HighWater{},
 		Details: &jobspb.Progress_Changefeed{
 			Changefeed: &jobspb.ChangefeedProgress{
+				//lint:ignore SA1019 deprecated usage
 				Checkpoint: &jobspb.ChangefeedProgress_Checkpoint{
 					Spans: mergedSpanGroup.Slice(),
 				},

--- a/pkg/ccl/changefeedccl/changefeed_dist.go
+++ b/pkg/ccl/changefeedccl/changefeed_dist.go
@@ -257,6 +257,7 @@ func startDistChangefeed(
 	dsp := execCtx.DistSQLPlanner()
 	evalCtx := execCtx.ExtendedEvalContext()
 
+	//lint:ignore SA1019 deprecated usage
 	var checkpoint *jobspb.ChangefeedProgress_Checkpoint
 	if progress := localState.progress.GetChangefeed(); progress != nil && progress.Checkpoint != nil {
 		checkpoint = progress.Checkpoint
@@ -378,6 +379,7 @@ func makePlan(
 	description string,
 	initialHighWater hlc.Timestamp,
 	trackedSpans []roachpb.Span,
+	//lint:ignore SA1019 deprecated usage
 	checkpoint *jobspb.ChangefeedProgress_Checkpoint,
 	drainingNodes []roachpb.NodeID,
 ) func(context.Context, *sql.DistSQLPlanner) (*sql.PhysicalPlan, *sql.PlanningCtx, error) {

--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -1077,7 +1077,10 @@ func (cs *cachedState) SetHighwater(frontier hlc.Timestamp) {
 }
 
 // SetCheckpoint implements the eval.ChangefeedState interface.
-func (cs *cachedState) SetCheckpoint(checkpoint jobspb.ChangefeedProgress_Checkpoint) {
+func (cs *cachedState) SetCheckpoint(
+	//lint:ignore SA1019 deprecated usage
+	checkpoint jobspb.ChangefeedProgress_Checkpoint,
+) {
 	cs.progress.Details.(*jobspb.Progress_Changefeed).Changefeed.Checkpoint = &checkpoint
 }
 
@@ -1673,6 +1676,7 @@ func (cf *changeFrontier) maybeCheckpointJob(
 	updateCheckpoint := (inBackfill || cf.frontier.HasLaggingSpans(&cf.js.settings.SV)) && cf.js.canCheckpointSpans()
 
 	// If the highwater has moved an empty checkpoint will be saved
+	//lint:ignore SA1019 deprecated usage
 	var checkpoint jobspb.ChangefeedProgress_Checkpoint
 	if updateCheckpoint {
 		maxBytes := changefeedbase.SpanCheckpointMaxBytes.Get(&cf.FlowCtx.Cfg.Settings.SV)
@@ -1698,7 +1702,9 @@ func (cf *changeFrontier) maybeCheckpointJob(
 const changefeedJobProgressTxnName = "changefeed job progress"
 
 func (cf *changeFrontier) checkpointJobProgress(
-	frontier hlc.Timestamp, checkpoint jobspb.ChangefeedProgress_Checkpoint,
+	frontier hlc.Timestamp,
+	//lint:ignore SA1019 deprecated usage
+	checkpoint jobspb.ChangefeedProgress_Checkpoint,
 ) (bool, error) {
 	defer cf.sliMetrics.Timers.CheckpointJobProgress.Start()()
 

--- a/pkg/ccl/changefeedccl/checkpoint/checkpoint.go
+++ b/pkg/ccl/changefeedccl/checkpoint/checkpoint.go
@@ -24,7 +24,8 @@ type SpanIter func(forEachSpan span.Operation)
 // spans above the high-water mark.
 func Make(
 	frontier hlc.Timestamp, forEachSpan SpanIter, maxBytes int64, metrics *Metrics,
-) jobspb.ChangefeedProgress_Checkpoint {
+) jobspb. //lint:ignore SA1019 deprecated usage
+		ChangefeedProgress_Checkpoint {
 	start := timeutil.Now()
 
 	// Collect leading spans into a SpanGroup to merge adjacent spans and store
@@ -41,6 +42,7 @@ func Make(
 		return span.ContinueMatch
 	})
 	if checkpointSpanGroup.Len() == 0 {
+		//lint:ignore SA1019 deprecated usage
 		return jobspb.ChangefeedProgress_Checkpoint{}
 	}
 
@@ -55,6 +57,7 @@ func Make(
 		checkpointSpans = append(checkpointSpans, span)
 	}
 
+	//lint:ignore SA1019 deprecated usage
 	cp := jobspb.ChangefeedProgress_Checkpoint{
 		Spans:     checkpointSpans,
 		Timestamp: checkpointTS,

--- a/pkg/ccl/changefeedccl/checkpoint/checkpoint_test.go
+++ b/pkg/ccl/changefeedccl/checkpoint/checkpoint_test.go
@@ -57,6 +57,7 @@ func TestCheckpointMake(t *testing.T) {
 		frontier hlc.Timestamp
 		spans    checkpointSpans
 		maxBytes int64
+		//lint:ignore SA1019 deprecated usage
 		expected jobspb.ChangefeedProgress_Checkpoint
 	}{
 		"all spans ahead of frontier checkpointed": {
@@ -68,6 +69,7 @@ func TestCheckpointMake(t *testing.T) {
 				{span: roachpb.Span{Key: roachpb.Key("d"), EndKey: roachpb.Key("e")}, ts: ts(4)},
 			},
 			maxBytes: 100,
+			//lint:ignore SA1019 deprecated usage
 			expected: jobspb.ChangefeedProgress_Checkpoint{
 				Timestamp: ts(2),
 				Spans: []roachpb.Span{
@@ -85,6 +87,7 @@ func TestCheckpointMake(t *testing.T) {
 				{span: roachpb.Span{Key: roachpb.Key("d"), EndKey: roachpb.Key("e")}, ts: ts(4)},
 			},
 			maxBytes: 2,
+			//lint:ignore SA1019 deprecated usage
 			expected: jobspb.ChangefeedProgress_Checkpoint{
 				Timestamp: ts(2),
 				Spans:     []roachpb.Span{{Key: roachpb.Key("b"), EndKey: roachpb.Key("c")}},
@@ -99,6 +102,7 @@ func TestCheckpointMake(t *testing.T) {
 				{span: roachpb.Span{Key: roachpb.Key("d"), EndKey: roachpb.Key("e")}, ts: ts(4)},
 			},
 			maxBytes: 0,
+			//lint:ignore SA1019 deprecated usage
 			expected: jobspb.ChangefeedProgress_Checkpoint{
 				Timestamp: ts(2),
 			},
@@ -112,6 +116,7 @@ func TestCheckpointMake(t *testing.T) {
 				{span: roachpb.Span{Key: roachpb.Key("d"), EndKey: roachpb.Key("e")}, ts: ts(1)},
 			},
 			maxBytes: 100,
+			//lint:ignore SA1019 deprecated usage
 			expected: jobspb.ChangefeedProgress_Checkpoint{},
 		},
 		"adjacent spans ahead of frontier merged before being checkpointed": {
@@ -123,6 +128,7 @@ func TestCheckpointMake(t *testing.T) {
 				{span: roachpb.Span{Key: roachpb.Key("d"), EndKey: roachpb.Key("e")}, ts: ts(1)},
 			},
 			maxBytes: 100,
+			//lint:ignore SA1019 deprecated usage
 			expected: jobspb.ChangefeedProgress_Checkpoint{
 				Timestamp: ts(2),
 				Spans:     []roachpb.Span{{Key: roachpb.Key("b"), EndKey: roachpb.Key("d")}},

--- a/pkg/ccl/changefeedccl/resolvedspan/frontier.go
+++ b/pkg/ccl/changefeedccl/resolvedspan/frontier.go
@@ -172,7 +172,8 @@ func (f *CoordinatorFrontier) InBackfill(r jobspb.ResolvedSpan) bool {
 // MakeCheckpoint creates a checkpoint based on the current state of the frontier.
 func (f *CoordinatorFrontier) MakeCheckpoint(
 	maxBytes int64, metrics *checkpoint.Metrics,
-) jobspb.ChangefeedProgress_Checkpoint {
+) jobspb. //lint:ignore SA1019 deprecated usage
+		ChangefeedProgress_Checkpoint {
 	return checkpoint.Make(f.Frontier(), f.Entries, maxBytes, metrics)
 }
 

--- a/pkg/jobs/jobspb/BUILD.bazel
+++ b/pkg/jobs/jobspb/BUILD.bazel
@@ -14,9 +14,11 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/base",
+        "//pkg/roachpb",
         "//pkg/sql/catalog/catpb",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/protoreflect",
+        "//pkg/util/hlc",
         "//pkg/util/tracing/tracingpb",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_gogo_protobuf//jsonpb",
@@ -76,9 +78,15 @@ go_proto_library(
 
 go_test(
     name = "jobspb_test",
-    srcs = ["wrap_test.go"],
+    srcs = [
+        "jobs_test.go",
+        "wrap_test.go",
+    ],
     deps = [
         ":jobspb",
+        "//pkg/roachpb",
+        "//pkg/util/hlc",
         "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/jobs/jobspb/jobs.proto
+++ b/pkg/jobs/jobspb/jobs.proto
@@ -1188,6 +1188,23 @@ message ResolvedSpans {
   Stats stats = 2 [(gogoproto.nullable) = false];
 }
 
+// TimestampSpansMap is a map from timestamps to lists of spans.
+//
+// You should create a go map and call NewTimestampSpansMap on it
+// instead of creating one directly.
+//
+// NB: This can't be a protobuf map because that requires the key
+// to be integral/string, but the language guide notes that this
+// structure is equivalent on the wire to a map:
+// https://protobuf.dev/programming-guides/proto3/#backwards.
+message TimestampSpansMap {
+  message Entry {
+    util.hlc.Timestamp timestamp = 1 [(gogoproto.nullable) = false];
+    repeated roachpb.Span spans = 2 [(gogoproto.nullable) = false];
+  }
+  repeated Entry entries = 1 [(gogoproto.nullable) = false];
+}
+
 message ChangefeedProgress {
   reserved 1;
 
@@ -1196,13 +1213,20 @@ message ChangefeedProgress {
   // some spans are significantly behind the rest, such as during backfills or
   // if specific spans are having issues progressing.  On restart, the
   // changefeed will forward the specified spans to the specified timestamp.
+  // TODO(#139734): Delete this nested message type.
   message Checkpoint {
+    option deprecated = true;
     repeated roachpb.Span spans = 1 [(gogoproto.nullable) = false];
     util.hlc.Timestamp timestamp = 2 [(gogoproto.nullable) = false];
   }
 
   reserved 2;
-  Checkpoint checkpoint = 4;
+  // Checkpoint is the deprecated span-level checkpoint for a
+  // changefeed. It consists of a list of spans and a single timestamp
+  // representing the minimum resolved timestamp of the spans.
+  // It is now deprecated in favor of SpanLevelCheckpoint.
+  // TODO(#139734): Delete this field and mark field number as reserved.
+  Checkpoint checkpoint = 4 [deprecated=true];
 
   // ProtectedTimestampRecord is the ID of the protected timestamp record
   // corresponding to this job. While the job ought to clean up the record
@@ -1218,6 +1242,19 @@ message ChangefeedProgress {
     (gogoproto.customtype) = "github.com/cockroachdb/cockroach/pkg/util/uuid.UUID",
     (gogoproto.nullable) = false
   ];
+
+  // SpanLevelCheckpoint is the span-level checkpoint for a changefeed.
+  // It consists of a map from resolved timestamps to lists of spans
+  // with that resolved timestamp.
+  //
+  // On restart, the changefeed can restore the progress of spans in the
+  // checkpoint to its corresponding resolved timestamp, which will be higher
+  // than the overall resolved timestamp and thus allow us to do less work.
+  // This is especially useful during backfills or if some spans are lagging.
+  // TODO(#137692): Write to this field.
+  // TODO(#137693): Restore this field to change aggregators.
+  // TODO(#131549): Restore this field to the change frontier.
+  TimestampSpansMap span_level_checkpoint = 5;
 }
 
 // CreateStatsDetails are used for the CreateStats job, which is triggered

--- a/pkg/jobs/jobspb/jobs_test.go
+++ b/pkg/jobs/jobspb/jobs_test.go
@@ -1,0 +1,45 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package jobspb_test
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTimestampSpansMapRoundTrip(t *testing.T) {
+	ts := func(wt int64) hlc.Timestamp {
+		return hlc.Timestamp{WallTime: wt}
+	}
+
+	span := func(start, end string) roachpb.Span {
+		return roachpb.Span{
+			Key:    roachpb.Key(start),
+			EndKey: roachpb.Key(end),
+		}
+	}
+
+	for name, input := range map[string]map[hlc.Timestamp]roachpb.Spans{
+		"nil map": nil,
+		"map with one timestamp": {
+			ts(1): {span("a", "b")},
+		},
+		"map with multiple timestamps": {
+			ts(1): {span("a", "b"), span("c", "d")},
+			ts(2): {span("b", "c")},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			tsm := jobspb.NewTimestampSpansMap(input)
+			output := tsm.ToGoMap()
+			require.Equal(t, input, output)
+		})
+	}
+}

--- a/pkg/sql/sem/eval/deps.go
+++ b/pkg/sql/sem/eval/deps.go
@@ -654,7 +654,10 @@ type ChangefeedState interface {
 	SetHighwater(frontier hlc.Timestamp)
 
 	// SetCheckpoint sets the checkpoint for the changefeed.
-	SetCheckpoint(checkpoint jobspb.ChangefeedProgress_Checkpoint)
+	SetCheckpoint(
+		//lint:ignore SA1019 deprecated usage
+		checkpoint jobspb.ChangefeedProgress_Checkpoint,
+	)
 }
 
 // TenantOperator is capable of interacting with tenant state, allowing SQL


### PR DESCRIPTION
This patch introduces a new `TimestampSpansMap` proto that will serve
as the basis for the new and improved changefeed span-level checkpoint.
A new field with that type named `SpanLevelCheckpoint` has been added
to `ChangefeedProgress` and the existing `Checkpoint` field and message
type have been been marked as deprecated.

Upcoming work will ensure that existing clusters continue writing to the
deprecated fields until the cluster version has been finalized on a
version with `SpanLevelCheckpoint`, at which point the cluster should
only write to the new field.

Fixes #137689

Release note: None