### PR TITLE
sql/stats: generation count was incorrectly incremented on each look up

### DIFF
--- a/pkg/sql/catalog/descs/factory.go
+++ b/pkg/sql/catalog/descs/factory.go
@@ -144,12 +144,19 @@ func (cf *CollectionFactory) NewCollection(ctx context.Context, options ...Optio
 		opt(&cfg)
 	}
 	v := cf.settings.Version.ActiveVersion(ctx)
+	// If the leaseMgr  is nil then ensure we have a nil LeaseManager interface,
+	// otherwise comparisons against a nil implementation will fail.
+	var lm LeaseManager
+	lm = cf.leaseMgr
+	if cf.leaseMgr == nil {
+		lm = nil
+	}
 	return &Collection{
 		settings:                cf.settings,
 		version:                 v,
 		hydrated:                cf.hydrated,
 		virtual:                 makeVirtualDescriptors(cf.virtualSchemas),
-		leased:                  makeLeasedDescriptors(cf.leaseMgr),
+		leased:                  makeLeasedDescriptors(lm),
 		uncommitted:             makeUncommittedDescriptors(cfg.monitor),
 		uncommittedComments:     makeUncommittedComments(),
 		uncommittedZoneConfigs:  makeUncommittedZoneConfigs(),

--- a/pkg/sql/catalog/lease/lease.go
+++ b/pkg/sql/catalog/lease/lease.go
@@ -1281,6 +1281,7 @@ func NewLeaseManager(
 		sem:              quotapool.NewIntPool("lease manager", leaseConcurrencyLimit),
 		refreshAllLeases: make(chan struct{}),
 	}
+	lm.leaseGeneration.Swap(1) // Start off with 1 as the initial value.
 	lm.storage.regionPrefix = &atomic.Value{}
 	lm.storage.regionPrefix.Store(enum.One)
 	lm.storage.sessionBasedLeasingMode = lm

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -4010,7 +4010,7 @@ func (ex *connExecutor) txnStateTransitionsApplyWrapper(
 		// Session is considered active when executing a transaction.
 		ex.totalActiveTimeStopWatch.Start()
 
-		if err := ex.maybeSetSQLLivenessSession(); err != nil {
+		if err := ex.maybeSetSQLLivenessSessionAndGeneration(); err != nil {
 			return advanceInfo{}, err
 		}
 	case txnCommit:
@@ -4115,7 +4115,7 @@ func (ex *connExecutor) txnStateTransitionsApplyWrapper(
 		// In addition to resetting the extraTxnState, the restart event may
 		// also need to reset the sqlliveness.Session.
 		ex.resetExtraTxnState(ex.Ctx(), advInfo.txnEvent, payloadErr)
-		if err := ex.maybeSetSQLLivenessSession(); err != nil {
+		if err := ex.maybeSetSQLLivenessSessionAndGeneration(); err != nil {
 			return advanceInfo{}, err
 		}
 	default:
@@ -4186,7 +4186,7 @@ func (ex *connExecutor) waitForTxnJobs() error {
 	return retErr
 }
 
-func (ex *connExecutor) maybeSetSQLLivenessSession() error {
+func (ex *connExecutor) maybeSetSQLLivenessSessionAndGeneration() error {
 	if !ex.server.cfg.Codec.ForSystemTenant() ||
 		ex.server.cfg.TestingKnobs.ForceSQLLivenessSession {
 		// Update the leased descriptor collection with the current sqlliveness.Session.
@@ -4201,6 +4201,8 @@ func (ex *connExecutor) maybeSetSQLLivenessSession() error {
 		}
 		ex.extraTxnState.descCollection.SetSession(session)
 	}
+	// Reset the lease generation at the same time.
+	ex.extraTxnState.descCollection.ResetLeaseGeneration()
 	return nil
 }
 

--- a/pkg/sql/stats/stats_cache.go
+++ b/pkg/sql/stats/stats_cache.go
@@ -337,7 +337,6 @@ func (sc *TableStatisticsCache) getTableStatsFromCache(
 ) ([]*TableStatistic, error) {
 	sc.mu.Lock()
 	defer sc.mu.Unlock()
-	defer sc.generation.Add(1)
 
 	if found, e := sc.lookupStatsLocked(ctx, tableID, false /* stealthy */); found {
 		if e.isStale(forecast, udtCols) {


### PR DESCRIPTION
Previously, an incorrect defer was causing the statistics generation to increment every time table statistics was looked up from the cache. This would cause the staleness optimization to kick in an inconsistent manner and be disabled needlessly. To address this, this patch only increments the generation updating stats.

This patch also contains an additional fix so that lease generations stay stable across long running queries. This was found because the test TestRenameTable started failing.

After this patch we see:
```
name                                  old time/op    new time/op    delta
Sysbench/SQL/3node/oltp_read_only-10    2.97ms ±14%    2.69ms ± 7%  -9.43%  (p=0.008 n=9+10)

name                                  old alloc/op   new alloc/op   delta
Sysbench/SQL/3node/oltp_read_only-10    1.14MB ± 1%    1.13MB ± 0%  -1.11%  (p=0.000 n=9+9)

name                                  old allocs/op  new allocs/op  delta
Sysbench/SQL/3node/oltp_read_only-10     4.42k ± 2%     4.31k ± 0%  -2.55%  (p=0.000 n=9+9)
```

Fixes: #139876

Release note: None