### PR TITLE
roachtest: skip online restore tests on released versions

### DIFF
--- a/pkg/backup/backuptestutils/BUILD.bazel
+++ b/pkg/backup/backuptestutils/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
     deps = [
         "//pkg/backup/backupbase",
         "//pkg/base",
+        "//pkg/clusterversion",
         "//pkg/jobs",
         "//pkg/keyvisualizer",
         "//pkg/kv/kvserver",

--- a/pkg/backup/backuptestutils/testutils.go
+++ b/pkg/backup/backuptestutils/testutils.go
@@ -14,6 +14,7 @@ import (
 
 	_ "github.com/cockroachdb/cockroach/pkg/backup/backupbase" // imported for cluster settings.
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/keyvisualizer"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
@@ -30,6 +31,11 @@ import (
 	"github.com/kr/pretty"
 	"github.com/stretchr/testify/require"
 )
+
+func IsOnlineRestoreSupported() bool {
+	// TODO(jeffswenson): relax this check once online restore is in preview.
+	return clusterversion.DevelopmentBranch
+}
 
 const (
 	// SingleNode is the size of a single node test cluster.

--- a/pkg/cmd/roachtest/tests/BUILD.bazel
+++ b/pkg/cmd/roachtest/tests/BUILD.bazel
@@ -206,6 +206,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/tests",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/backup/backuptestutils",
         "//pkg/base",
         "//pkg/blobs",
         "//pkg/ccl/changefeedccl",

--- a/pkg/cmd/roachtest/tests/online_restore.go
+++ b/pkg/cmd/roachtest/tests/online_restore.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/backup/backuptestutils"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/clusterstats"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
@@ -131,6 +132,10 @@ func registerOnlineRestorePerf(r registry.Registry) {
 					if !useWorkarounds {
 						sp.skip = "used for ad hoc experiments"
 						sp.namePrefix = sp.namePrefix + fmt.Sprintf("/workarounds=%t", useWorkarounds)
+					}
+
+					if sp.skip == "" && !backuptestutils.IsOnlineRestoreSupported() {
+						sp.skip = "online restore is only tested on development branch"
 					}
 
 					sp.initTestName()


### PR DESCRIPTION
Online restore is currently under development. We will skip online roachtests on released versions in order to minimize test toil.

Release note: none
Fixes: #138931
Fixes: #139124
Fixes: #139507