### PR TITLE
storage: use EncryptionOptions instead of byte[]

### DIFF
--- a/pkg/base/config.go
+++ b/pkg/base/config.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/storage/storagepb"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
@@ -933,10 +934,8 @@ type WALFailoverConfig struct {
 // configuration.
 type ExternalPath struct {
 	Path string
-	// EncryptionOptions is a serialized protobuf set by Go CCL code describing
-	// the encryption-at-rest configuration. If encryption-at-rest has ever been
-	// enabled on the store, this field must be set.
-	EncryptionOptions []byte
+	// EncryptionOptions is set if encryption is enabled.
+	EncryptionOptions *storagepb.EncryptionOptions
 }
 
 // IsSet returns whether or not the external path was provided.

--- a/pkg/ccl/storageccl/engineccl/encrypted_fs.go
+++ b/pkg/ccl/storageccl/engineccl/encrypted_fs.go
@@ -287,17 +287,16 @@ func init() {
 }
 
 // newEncryptedEnv creates an encrypted environment and returns the vfs.FS to use for reading and
-// writing data. The optionBytes is a binary serialized storagepb.EncryptionOptions, so that non-CCL
-// code does not depend on CCL code.
+// writing data.
 //
 // See the comment at the top of this file for the structure of this environment.
 func newEncryptedEnv(
-	unencryptedFS vfs.FS, fr *fs.FileRegistry, dbDir string, readOnly bool, optionBytes []byte,
+	unencryptedFS vfs.FS,
+	fr *fs.FileRegistry,
+	dbDir string,
+	readOnly bool,
+	options *storagepb.EncryptionOptions,
 ) (*fs.EncryptionEnv, error) {
-	options := &storagepb.EncryptionOptions{}
-	if err := protoutil.Unmarshal(optionBytes, options); err != nil {
-		return nil, err
-	}
 	if options.KeySource != storagepb.EncryptionKeySource_KeyFiles {
 		return nil, fmt.Errorf("unknown encryption key source: %d", options.KeySource)
 	}

--- a/pkg/cli/ear_test.go
+++ b/pkg/cli/ear_test.go
@@ -46,8 +46,7 @@ func TestDecrypt(t *testing.T) {
 	encSpecStr := fmt.Sprintf("path=%s,key=%s,old-key=plain", dir, keyPath)
 	encSpec, err := storagepb.NewStoreEncryptionSpec(encSpecStr)
 	require.NoError(t, err)
-	encOpts, err := encSpec.ToEncryptionOptions()
-	require.NoError(t, err)
+	encOpts := &encSpec.Options
 
 	env, err := fs.InitEnv(ctx, vfs.Default, dir, fs.EnvConfig{EncryptionOptions: encOpts}, nil /* statsCollector */)
 	require.NoError(t, err)
@@ -129,8 +128,7 @@ func TestList(t *testing.T) {
 	encSpecStr := fmt.Sprintf("path=%s,key=%s,old-key=plain", dir, keyPath)
 	encSpec, err := storagepb.NewStoreEncryptionSpec(encSpecStr)
 	require.NoError(t, err)
-	encOpts, err := encSpec.ToEncryptionOptions()
-	require.NoError(t, err)
+	encOpts := &encSpec.Options
 	env, err := fs.InitEnv(ctx, vfs.Default, dir, fs.EnvConfig{EncryptionOptions: encOpts}, nil /* statsCollector */)
 	require.NoError(t, err)
 	p, err := storage.Open(ctx, env, cluster.MakeTestingClusterSettings())

--- a/pkg/storage/BUILD.bazel
+++ b/pkg/storage/BUILD.bazel
@@ -178,6 +178,7 @@ go_test(
         "//pkg/storage/disk",
         "//pkg/storage/enginepb",
         "//pkg/storage/fs",
+        "//pkg/storage/storagepb",
         "//pkg/testutils",
         "//pkg/testutils/datapathutils",
         "//pkg/testutils/echotest",

--- a/pkg/storage/fs/BUILD.bazel
+++ b/pkg/storage/fs/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "//pkg/settings",
         "//pkg/storage/disk",
         "//pkg/storage/enginepb",
+        "//pkg/storage/storagepb",
         "//pkg/util/buildutil",
         "//pkg/util/envutil",
         "//pkg/util/log",

--- a/pkg/storage/fs/encryption_at_rest.go
+++ b/pkg/storage/fs/encryption_at_rest.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 
+	"github.com/cockroachdb/cockroach/pkg/storage/storagepb"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/vfs"
 )
@@ -18,16 +19,20 @@ import (
 // and writing data. This should be initialized by calling engineccl.Init() before calling
 // NewPebble(). The optionBytes is a binary serialized storagepb.EncryptionOptions.
 var NewEncryptedEnvFunc func(
-	fs vfs.FS, fr *FileRegistry, dbDir string, readOnly bool, optionBytes []byte,
+	fs vfs.FS, fr *FileRegistry, dbDir string, readOnly bool, encryptionOptions *storagepb.EncryptionOptions,
 ) (*EncryptionEnv, error)
 
 // resolveEncryptedEnvOptions creates the EncryptionEnv and associated file
 // registry if this store has encryption-at-rest enabled; otherwise returns a
 // nil EncryptionEnv.
 func resolveEncryptedEnvOptions(
-	ctx context.Context, unencryptedFS vfs.FS, dir string, encryptionOpts []byte, rw RWMode,
+	ctx context.Context,
+	unencryptedFS vfs.FS,
+	dir string,
+	encryptionOpts *storagepb.EncryptionOptions,
+	rw RWMode,
 ) (*FileRegistry, *EncryptionEnv, error) {
-	if len(encryptionOpts) == 0 {
+	if encryptionOpts == nil {
 		// There's no encryption config. This is valid if the user doesn't
 		// intend to use encryption-at-rest, and the store has never had
 		// encryption-at-rest enabled. Validate that there's no file registry.

--- a/pkg/storage/fs/fs.go
+++ b/pkg/storage/fs/fs.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cli/exit"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/storage/disk"
+	"github.com/cockroachdb/cockroach/pkg/storage/storagepb"
 	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/errors"
@@ -121,7 +122,7 @@ func InitEnvFromStoreSpec(
 // EnvConfig provides additional configuration settings for Envs.
 type EnvConfig struct {
 	RW                RWMode
-	EncryptionOptions []byte
+	EncryptionOptions *storagepb.EncryptionOptions
 }
 
 // InitEnv initializes a new virtual filesystem environment.

--- a/pkg/storage/min_version_test.go
+++ b/pkg/storage/min_version_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage/fs"
+	"github.com/cockroachdb/cockroach/pkg/storage/storagepb"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/pebble/vfs"
@@ -118,7 +119,7 @@ func TestMinVersion_IsNotEncrypted(t *testing.T) {
 	st := cluster.MakeClusterSettings()
 	baseFS := vfs.NewMem()
 	env, err := fs.InitEnv(ctx, baseFS, "", fs.EnvConfig{
-		EncryptionOptions: []byte("foo"),
+		EncryptionOptions: &storagepb.EncryptionOptions{},
 	}, nil /* statsCollector */)
 	require.NoError(t, err)
 
@@ -136,7 +137,11 @@ func TestMinVersion_IsNotEncrypted(t *testing.T) {
 }
 
 func fauxNewEncryptedEnvFunc(
-	unencryptedFS vfs.FS, fr *fs.FileRegistry, dbDir string, readOnly bool, optionBytes []byte,
+	unencryptedFS vfs.FS,
+	fr *fs.FileRegistry,
+	dbDir string,
+	readOnly bool,
+	_ *storagepb.EncryptionOptions,
 ) (*fs.EncryptionEnv, error) {
 	return &fs.EncryptionEnv{
 		Closer: nopCloser{},

--- a/pkg/storage/open.go
+++ b/pkg/storage/open.go
@@ -257,11 +257,11 @@ func makeExternalWALDir(
 	// If the store is encrypted, we require that all the WAL failover dirs also
 	// be encrypted so that the user doesn't accidentally leak data unencrypted
 	// onto the filesystem.
-	if engineCfg.env.Encryption != nil && len(externalDir.EncryptionOptions) == 0 {
+	if engineCfg.env.Encryption != nil && externalDir.EncryptionOptions == nil {
 		return wal.Dir{}, errors.Newf("must provide --enterprise-encryption flag for %q, used as WAL failover path for encrypted store %q",
 			externalDir.Path, engineCfg.env.Dir)
 	}
-	if engineCfg.env.Encryption == nil && len(externalDir.EncryptionOptions) != 0 {
+	if engineCfg.env.Encryption == nil && externalDir.EncryptionOptions != nil {
 		return wal.Dir{}, errors.Newf("must provide --enterprise-encryption flag for store %q, specified WAL failover path %q is encrypted",
 			engineCfg.env.Dir, externalDir.Path)
 	}

--- a/pkg/storage/open_test.go
+++ b/pkg/storage/open_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage/fs"
+	"github.com/cockroachdb/cockroach/pkg/storage/storagepb"
 	"github.com/cockroachdb/cockroach/pkg/testutils/datapathutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -63,7 +64,7 @@ func TestWALFailover(t *testing.T) {
 
 				var envConfig fs.EnvConfig
 				if td.HasArg("encrypted-at-rest") {
-					envConfig.EncryptionOptions = []byte("test-encryption-options")
+					envConfig.EncryptionOptions = &storagepb.EncryptionOptions{}
 				}
 				if td.HasArg("read-only") {
 					envConfig.RW = fs.ReadOnly
@@ -88,10 +89,10 @@ func TestWALFailover(t *testing.T) {
 					}
 				}
 				if td.HasArg("path-encrypted") {
-					cfg.Path.EncryptionOptions = []byte("path-encryption-options")
+					cfg.Path.EncryptionOptions = &storagepb.EncryptionOptions{}
 				}
 				if td.HasArg("prev-path-encrypted") {
-					cfg.PrevPath.EncryptionOptions = []byte("prev-encryption-options")
+					cfg.PrevPath.EncryptionOptions = &storagepb.EncryptionOptions{}
 				}
 				openEnv := getEnv(openDir)
 				if openEnv == nil {

--- a/pkg/storage/storagepb/BUILD.bazel
+++ b/pkg/storage/storagepb/BUILD.bazel
@@ -25,7 +25,6 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/cli/cliflags",
-        "//pkg/util/protoutil",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_spf13_pflag//:pflag",
     ],

--- a/pkg/storage/storagepb/encryption_spec_test.go
+++ b/pkg/storage/storagepb/encryption_spec_test.go
@@ -50,16 +50,64 @@ func TestNewStoreEncryptionSpec(t *testing.T) {
 
 		// Good values. Note that paths get absolutized so we start most of them
 		// with / so we can used fixed expected values.
-		{"path=/data,key=/new.key,old-key=/old.key", "", StoreEncryptionSpec{Path: "/data", KeyPath: "/new.key", OldKeyPath: "/old.key", RotationPeriod: DefaultRotationPeriod}},
-		{"path=/data,key=/new.key,old-key=/old.key,rotation-period=1h", "", StoreEncryptionSpec{Path: "/data", KeyPath: "/new.key", OldKeyPath: "/old.key", RotationPeriod: time.Hour}},
-		{"path=/data,key=plain,old-key=/old.key,rotation-period=1h", "", StoreEncryptionSpec{Path: "/data", KeyPath: "plain", OldKeyPath: "/old.key", RotationPeriod: time.Hour}},
-		{"path=/data,key=/new.key,old-key=plain,rotation-period=1h", "", StoreEncryptionSpec{Path: "/data", KeyPath: "/new.key", OldKeyPath: "plain", RotationPeriod: time.Hour}},
+		{
+			"path=/data,key=/new.key,old-key=/old.key", "",
+			StoreEncryptionSpec{Path: "/data",
+				Options: EncryptionOptions{
+					KeyFiles:              &EncryptionKeyFiles{CurrentKey: "/new.key", OldKey: "/old.key"},
+					DataKeyRotationPeriod: int64(DefaultRotationPeriod / time.Second),
+				},
+			},
+		},
+		{
+			"path=/data,key=/new.key,old-key=/old.key,rotation-period=1h", "",
+			StoreEncryptionSpec{Path: "/data",
+				Options: EncryptionOptions{
+					KeyFiles:              &EncryptionKeyFiles{CurrentKey: "/new.key", OldKey: "/old.key"},
+					DataKeyRotationPeriod: int64(time.Hour / time.Second),
+				},
+			},
+		},
+		{
+			"path=/data,key=plain,old-key=/old.key,rotation-period=1h", "",
+			StoreEncryptionSpec{Path: "/data",
+				Options: EncryptionOptions{
+					KeyFiles:              &EncryptionKeyFiles{CurrentKey: "plain", OldKey: "/old.key"},
+					DataKeyRotationPeriod: int64(time.Hour / time.Second),
+				},
+			},
+		},
+		{
+			"path=/data,key=/new.key,old-key=plain,rotation-period=1h", "",
+			StoreEncryptionSpec{Path: "/data",
+				Options: EncryptionOptions{
+					KeyFiles:              &EncryptionKeyFiles{CurrentKey: "/new.key", OldKey: "plain"},
+					DataKeyRotationPeriod: int64(time.Hour / time.Second),
+				},
+			},
+		},
 
 		// One relative path to test absolutization.
-		{"path=data,key=/new.key,old-key=/old.key", "", StoreEncryptionSpec{Path: absDataPath, KeyPath: "/new.key", OldKeyPath: "/old.key", RotationPeriod: DefaultRotationPeriod}},
+		{
+			"path=data,key=/new.key,old-key=/old.key", "",
+			StoreEncryptionSpec{Path: absDataPath,
+				Options: EncryptionOptions{
+					KeyFiles:              &EncryptionKeyFiles{CurrentKey: "/new.key", OldKey: "/old.key"},
+					DataKeyRotationPeriod: int64(DefaultRotationPeriod / time.Second),
+				},
+			},
+		},
 
 		// Special path * is not absolutized.
-		{"path=*,key=/new.key,old-key=/old.key", "", StoreEncryptionSpec{Path: "*", KeyPath: "/new.key", OldKeyPath: "/old.key", RotationPeriod: DefaultRotationPeriod}},
+		{
+			"path=*,key=/new.key,old-key=/old.key", "",
+			StoreEncryptionSpec{Path: "*",
+				Options: EncryptionOptions{
+					KeyFiles:              &EncryptionKeyFiles{CurrentKey: "/new.key", OldKey: "/old.key"},
+					DataKeyRotationPeriod: int64(DefaultRotationPeriod / time.Second),
+				},
+			},
+		},
 	}
 
 	for i, testCase := range testCases {


### PR DESCRIPTION
Previously the encryption options were passed as a byte[] instead of
actual EncryptionOptions. This made it hard to serialize them to disk
and as they are no longer in the CCL is not necessary anymore.

Epic: [CRDB-41111](https://cockroachlabs.atlassian.net/browse/CRDB-41111)

Release note: None