### PR TITLE
sql: tune default batch_size for index backfill

### DIFF
--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -78,7 +78,7 @@ var indexBackfillBatchSize = settings.RegisterIntSetting(
 	settings.ApplicationLevel,
 	"bulkio.index_backfill.batch_size",
 	"the number of rows for which we construct index entries in a single batch",
-	50000,
+	30000,
 	settings.NonNegativeInt, /* validateFn */
 )
 


### PR DESCRIPTION
We have seen improvements for index backfills on larger tables when we have decreased the `bulkio.index_backfill.batch_size` in our roachtest experimentation (using `perturbation/full/backfill`). This setting controls the max amount of rows we encode into `IndexEntry`s for a single batch.

The median time it took for the index backfill process to run with the previous default `batch_size` of 50k is 18m21s (w/avg of 27m31s). The median time it took for the index backfill process to run with the new default of 30 is 5m49s (w/avg of 5m36s).

In the worst case, during the construction of index entries, we can run into OOM while encoding kv pairs and retry with a smaller batch_size using exponential backoff (which is great for avoiding an OOM, but slows down the schema change). This decrease in batch_size also helps us avoid this worst case.

Fixes: #136147

Release note: None