### PR TITLE
colexecerror: delete BenchmarkCatchVectorizedRuntimeError

### DIFF
--- a/pkg/sql/colexecerror/BUILD.bazel
+++ b/pkg/sql/colexecerror/BUILD.bazel
@@ -26,8 +26,6 @@ go_test(
         "//pkg/security/securityassets",
         "//pkg/security/securitytest",
         "//pkg/server",
-        "//pkg/sql/pgwire/pgcode",
-        "//pkg/sql/pgwire/pgerror",
         "//pkg/testutils/serverutils",
         "//pkg/testutils/sqlutils",
         "//pkg/util/leaktest",


### PR DESCRIPTION
This benchmark is now way too fast (100ns per op) so that random changes in the binary result in "regressions".

Epic: None
Release note: None