### PR TITLE
vecstore: add struct to store vector index configuration

### DIFF
--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -2304,6 +2304,7 @@ GO_TARGETS = [
     "//pkg/sql/vecindex/quantize:quantize",
     "//pkg/sql/vecindex/quantize:quantize_test",
     "//pkg/sql/vecindex/testutils:testutils",
+    "//pkg/sql/vecindex/vecpb:vecpb",
     "//pkg/sql/vecindex/vecstore:vecstore",
     "//pkg/sql/vecindex/vecstore:vecstore_test",
     "//pkg/sql/vecindex:vecindex",

--- a/pkg/gen/protobuf.bzl
+++ b/pkg/gen/protobuf.bzl
@@ -76,6 +76,7 @@ PROTOBUF_SRCS = [
     "//pkg/sql/stats:stats_go_proto",
     "//pkg/sql/types:types_go_proto",
     "//pkg/sql/vecindex/quantize:quantize_go_proto",
+    "//pkg/sql/vecindex/vecpb:vecpb_go_proto",
     "//pkg/sql/vecindex/vecstore:vecstore_go_proto",
     "//pkg/storage/enginepb:enginepb_go_proto",
     "//pkg/storage/storagepb:storagepb_go_proto",

--- a/pkg/sql/vecindex/vecpb/BUILD.bazel
+++ b/pkg/sql/vecindex/vecpb/BUILD.bazel
@@ -1,0 +1,28 @@
+load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
+
+go_library(
+    name = "vecpb",
+    srcs = ["vecpb.go"],
+    embed = [":vecpb_go_proto"],
+    importpath = "github.com/cockroachdb/cockroach/pkg/sql/vecindex/vecpb",
+    visibility = ["//visibility:public"],
+)
+
+go_proto_library(
+    name = "vecpb_go_proto",
+    compilers = ["//pkg/cmd/protoc-gen-gogoroach:protoc-gen-gogoroach_compiler"],
+    importpath = "github.com/cockroachdb/cockroach/pkg/sql/vecindex/vecpb",
+    proto = ":vecpb_proto",
+    visibility = ["//visibility:public"],
+    deps = ["@com_github_gogo_protobuf//gogoproto"],
+)
+
+proto_library(
+    name = "vecpb_proto",
+    srcs = ["vec.proto"],
+    strip_import_prefix = "/pkg",
+    visibility = ["//visibility:public"],
+    deps = ["@com_github_gogo_protobuf//gogoproto:gogo_proto"],
+)

--- a/pkg/sql/vecindex/vecpb/vec.proto
+++ b/pkg/sql/vecindex/vecpb/vec.proto
@@ -1,0 +1,21 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+syntax = "proto3";
+package cockroach.sql.vecindex.vecpb;
+option go_package = "github.com/cockroachdb/cockroach/pkg/sql/vecindex/vecpb";
+
+import "gogoproto/gogo.proto";
+
+// Config encapsulates the information needed to search and maintain a vector
+// index. It should not change after the index is created.
+message Config {
+  // Dims specifies the number of dimensions for vectors in the index.
+  int64 dims = 1 [(gogoproto.casttype) = "int"];
+  // Seed is used to generate the random orthogonal matrix used by the RaBitQ
+  // quantizer. It's important that the same seed be used to do this everytime,
+  // so that the same matrix is generated each time it needs to be used.
+  int64 seed = 2;
+}

--- a/pkg/sql/vecindex/vecpb/vecpb.go
+++ b/pkg/sql/vecindex/vecpb/vecpb.go
@@ -1,0 +1,11 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package vecpb
+
+// Equal returns true if this config is equal to the given config.
+func (c *Config) Equal(other *Config) bool {
+	return c.Dims == other.Dims && c.Seed == other.Seed
+}

--- a/pkg/sql/vecindex/vecstore/BUILD.bazel
+++ b/pkg/sql/vecindex/vecstore/BUILD.bazel
@@ -9,6 +9,7 @@ proto_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/sql/vecindex/quantize:quantize_proto",
+        "//pkg/sql/vecindex/vecpb:vecpb_proto",
         "@com_github_gogo_protobuf//gogoproto:gogo_proto",
     ],
 )
@@ -21,6 +22,7 @@ go_proto_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/sql/vecindex/quantize",
+        "//pkg/sql/vecindex/vecpb",
         "@com_github_gogo_protobuf//gogoproto",
     ],
 )
@@ -58,6 +60,7 @@ go_library(
         "//pkg/sql/sem/tree",
         "//pkg/sql/vecindex/internal",
         "//pkg/sql/vecindex/quantize",
+        "//pkg/sql/vecindex/vecpb",
         "//pkg/util/container/heap",
         "//pkg/util/container/list",
         "//pkg/util/encoding",

--- a/pkg/sql/vecindex/vecstore/in_memory_store.go
+++ b/pkg/sql/vecindex/vecstore/in_memory_store.go
@@ -10,6 +10,7 @@ import (
 	"slices"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/vecindex/quantize"
+	vecpb "github.com/cockroachdb/cockroach/pkg/sql/vecindex/vecpb"
 	"github.com/cockroachdb/cockroach/pkg/util/container/list"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
@@ -342,8 +343,7 @@ func (s *InMemoryStore) MarshalBinary() (data []byte, err error) {
 	}
 
 	storeProto := StoreProto{
-		Dims:       s.dims,
-		Seed:       s.seed,
+		Config:     vecpb.Config{Dims: s.dims, Seed: s.seed},
 		Partitions: make([]PartitionProto, 0, len(s.mu.partitions)),
 		NextKey:    s.mu.nextKey,
 		Vectors:    make([]VectorProto, 0, len(s.mu.vectors)),
@@ -395,8 +395,8 @@ func LoadInMemoryStore(data []byte) (*InMemoryStore, error) {
 
 	// Construct the InMemoryStore object.
 	inMemStore := &InMemoryStore{
-		dims: storeProto.Dims,
-		seed: storeProto.Seed,
+		dims: storeProto.Config.Dims,
+		seed: storeProto.Config.Seed,
 	}
 	inMemStore.mu.clock = 2
 	inMemStore.mu.partitions = make(map[PartitionKey]*inMemoryPartition, len(storeProto.Partitions))
@@ -405,8 +405,8 @@ func LoadInMemoryStore(data []byte) (*InMemoryStore, error) {
 	inMemStore.mu.stats = storeProto.Stats
 	inMemStore.mu.pending.Init()
 
-	raBitQuantizer := quantize.NewRaBitQuantizer(storeProto.Dims, storeProto.Seed)
-	unquantizer := quantize.NewUnQuantizer(storeProto.Dims)
+	raBitQuantizer := quantize.NewRaBitQuantizer(storeProto.Config.Dims, storeProto.Config.Seed)
+	unquantizer := quantize.NewUnQuantizer(storeProto.Config.Dims)
 
 	// Construct the Partition objects.
 	for i := range storeProto.Partitions {

--- a/pkg/sql/vecindex/vecstore/vecstore.proto
+++ b/pkg/sql/vecindex/vecstore/vecstore.proto
@@ -8,6 +8,7 @@ package cockroach.sql.vecindex.vecstore;
 option go_package = "github.com/cockroachdb/cockroach/pkg/sql/vecindex/vecstore";
 
 import "sql/vecindex/quantize/quantize.proto";
+import "sql/vecindex/vecpb/vec.proto";
 import "gogoproto/gogo.proto";
 
 option (gogoproto.goproto_getters_all) = false;
@@ -52,12 +53,11 @@ message IndexStats {
 
 // StoreProto serializes the fields of the in-memory store.
 message StoreProto {
-  int64 dims = 1 [(gogoproto.casttype) = "int"];
-  int64 seed = 2;
-  repeated PartitionProto partitions = 3 [(gogoproto.nullable) = false];
-  uint64 next_key = 4 [(gogoproto.casttype) = "PartitionKey"];
-  repeated VectorProto vectors = 5 [(gogoproto.nullable) = false];
-  IndexStats stats = 6 [(gogoproto.nullable) = false];
+  vecpb.Config config = 1 [(gogoproto.nullable) = false];
+  repeated PartitionProto partitions = 2 [(gogoproto.nullable) = false];
+  uint64 next_key = 3 [(gogoproto.casttype) = "PartitionKey"];
+  repeated VectorProto vectors = 4 [(gogoproto.nullable) = false];
+  IndexStats stats = 5 [(gogoproto.nullable) = false];
 }
 
 // PartitionProto serializes the fields of a partition.


### PR DESCRIPTION
Add vecstore.Config struct that contains information needed to configure a vector index (dimension count and random seed). This struct is generated by protobuf so that it can later be included in schema index descriptors.

Epic: CRDB-42943

Release note: None