### PR TITLE
crosscluster/logical: reduce TestFourWayReplication to TestThreeWayReplication

### DIFF
--- a/pkg/crosscluster/logical/logical_replication_job_test.go
+++ b/pkg/crosscluster/logical/logical_replication_job_test.go
@@ -1288,14 +1288,14 @@ func TestMultipleSourcesIntoSingleDest(t *testing.T) {
 	dbC.CheckQueryResults(t, "SELECT * from tab", expectedRowsDest)
 }
 
-// TestFourWayReplication tests 4 tables that are all streaming
-// from each other and how they handle conflicts
-func TestFourWayReplication(t *testing.T) {
+// TestThreeWayReplication ensures LWW works on a fully connected graph of
+// streams across 3 databases.
+func TestThreeWayReplication(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	skip.UnderDeadlock(t)
 	defer log.Scope(t).Close(t)
 
-	skip.UnderDuress(t, "running 12 LDR jobs on one server is too much")
+	skip.UnderDuress(t, "running 6 LDR jobs on one server is too much")
 
 	ctx := context.Background()
 
@@ -1332,7 +1332,7 @@ func TestFourWayReplication(t *testing.T) {
 		}
 	}
 
-	numDBs := 4
+	numDBs := 3
 	server, s, runners, dbNames := setupServerWithNumDBs(t, ctx, clusterArgs, 1, numDBs)
 	defer server.Stopper().Stop(ctx)
 
@@ -1360,6 +1360,7 @@ func TestFourWayReplication(t *testing.T) {
 	}
 	verifyExpectedRowAllServers(t, runners, expectedRows, dbNames)
 
+	// Assert Row 2's update wins LWW.
 	for i := range numDBs {
 		runners[i].Exec(t, fmt.Sprintf("UPSERT INTO tab VALUES (2, 'row%v')", i))
 	}
@@ -1368,7 +1369,7 @@ func TestFourWayReplication(t *testing.T) {
 
 	expectedRows = [][]string{
 		{"1", "celery"},
-		{"2", "row3"},
+		{"2", "row2"},
 	}
 	verifyExpectedRowAllServers(t, runners, expectedRows, dbNames)
 }


### PR DESCRIPTION
This test ensures LWW works on a fully connected graph of streams. This can be done with 3 databases instead of 4.

Epic: none

Release note: none