### PR TITLE
sql: enable optimizer_use_merged_partial_statistics by default

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -4023,7 +4023,7 @@ optimizer_use_improved_trigram_similarity_selectivity      on
 optimizer_use_improved_zigzag_join_costing                 on
 optimizer_use_limit_ordering_for_streaming_group_by        on
 optimizer_use_lock_op_for_serializable                     off
-optimizer_use_merged_partial_statistics                    off
+optimizer_use_merged_partial_statistics                    on
 optimizer_use_multicol_stats                               on
 optimizer_use_not_visible_indexes                          off
 optimizer_use_polymorphic_parameter_fix                    on

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -3023,7 +3023,7 @@ optimizer_use_improved_trigram_similarity_selectivity      on                  N
 optimizer_use_improved_zigzag_join_costing                 on                  NULL      NULL        NULL        string
 optimizer_use_limit_ordering_for_streaming_group_by        on                  NULL      NULL        NULL        string
 optimizer_use_lock_op_for_serializable                     off                 NULL      NULL        NULL        string
-optimizer_use_merged_partial_statistics                    off                 NULL      NULL        NULL        string
+optimizer_use_merged_partial_statistics                    on                  NULL      NULL        NULL        string
 optimizer_use_multicol_stats                               on                  NULL      NULL        NULL        string
 optimizer_use_not_visible_indexes                          off                 NULL      NULL        NULL        string
 optimizer_use_polymorphic_parameter_fix                    on                  NULL      NULL        NULL        string
@@ -3228,7 +3228,7 @@ optimizer_use_improved_trigram_similarity_selectivity      on                  N
 optimizer_use_improved_zigzag_join_costing                 on                  NULL  user     NULL      on                  on
 optimizer_use_limit_ordering_for_streaming_group_by        on                  NULL  user     NULL      on                  on
 optimizer_use_lock_op_for_serializable                     off                 NULL  user     NULL      off                 off
-optimizer_use_merged_partial_statistics                    off                 NULL  user     NULL      off                 off
+optimizer_use_merged_partial_statistics                    on                  NULL  user     NULL      on                  on
 optimizer_use_multicol_stats                               on                  NULL  user     NULL      on                  on
 optimizer_use_not_visible_indexes                          off                 NULL  user     NULL      off                 off
 optimizer_use_polymorphic_parameter_fix                    on                  NULL  user     NULL      on                  on

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -154,7 +154,7 @@ optimizer_use_improved_trigram_similarity_selectivity      on
 optimizer_use_improved_zigzag_join_costing                 on
 optimizer_use_limit_ordering_for_streaming_group_by        on
 optimizer_use_lock_op_for_serializable                     off
-optimizer_use_merged_partial_statistics                    off
+optimizer_use_merged_partial_statistics                    on
 optimizer_use_multicol_stats                               on
 optimizer_use_not_visible_indexes                          off
 optimizer_use_polymorphic_parameter_fix                    on

--- a/pkg/sql/opt/exec/execbuilder/testdata/partial_stats
+++ b/pkg/sql/opt/exec/execbuilder/testdata/partial_stats
@@ -1352,7 +1352,7 @@ RESET CLUSTER SETTING sql.stats.histogram_samples.count
 # Verify that optimizer_use_merged_partial_statistics can be used to enable and
 # disable merged stat usage in the optimizer.
 statement ok
-RESET optimizer_use_merged_partial_statistics
+SET optimizer_use_merged_partial_statistics = off
 
 statement ok
 DELETE FROM ka

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -946,7 +946,7 @@ var varGen = map[string]sessionVar{
 		Get: func(evalCtx *extendedEvalContext, _ *kv.Txn) (string, error) {
 			return formatBoolAsPostgresSetting(evalCtx.SessionData().OptimizerUseMergedPartialStatistics), nil
 		},
-		GlobalDefault: globalFalse,
+		GlobalDefault: globalTrue,
 	},
 
 	// CockroachDB extension.


### PR DESCRIPTION
Fixes #134461

Release note (sql change): `optimizer_use_merged_partial_statistics` is now enabled by default, meaning the optimizer will use partial stats if available to estimate more up-to-date statistics.