### PR TITLE
storage: remove deprecated +build directives

### DIFF
--- a/pkg/storage/array_32bit.go
+++ b/pkg/storage/array_32bit.go
@@ -4,7 +4,6 @@
 // included in the /LICENSE file.
 
 //go:build 386 || amd64p32 || arm || armbe || mips || mipsle || mips64p32 || mips64p32le || ppc || sparc
-// +build 386 amd64p32 arm armbe mips mipsle mips64p32 mips64p32le ppc sparc
 
 package storage
 

--- a/pkg/storage/array_64bit.go
+++ b/pkg/storage/array_64bit.go
@@ -4,7 +4,6 @@
 // included in the /LICENSE file.
 
 //go:build amd64 || arm64 || arm64be || ppc64 || ppc64le || mips64 || mips64le || s390x || sparc64
-// +build amd64 arm64 arm64be ppc64 ppc64le mips64 mips64le s390x sparc64
 
 package storage
 

--- a/pkg/storage/disk/linux_parse.go
+++ b/pkg/storage/disk/linux_parse.go
@@ -4,7 +4,6 @@
 // included in the /LICENSE file.
 
 //go:build linux
-// +build linux
 
 package disk
 

--- a/pkg/storage/disk/linux_parse_test.go
+++ b/pkg/storage/disk/linux_parse_test.go
@@ -4,7 +4,6 @@
 // included in the /LICENSE file.
 
 //go:build linux
-// +build linux
 
 package disk
 

--- a/pkg/storage/disk/platform_darwin.go
+++ b/pkg/storage/disk/platform_darwin.go
@@ -4,7 +4,6 @@
 // included in the /LICENSE file.
 
 //go:build darwin
-// +build darwin
 
 package disk
 

--- a/pkg/storage/disk/platform_default.go
+++ b/pkg/storage/disk/platform_default.go
@@ -4,7 +4,6 @@
 // included in the /LICENSE file.
 
 //go:build !linux && !darwin
-// +build !linux,!darwin
 
 package disk
 

--- a/pkg/storage/disk/platform_linux.go
+++ b/pkg/storage/disk/platform_linux.go
@@ -4,7 +4,6 @@
 // included in the /LICENSE file.
 
 //go:build linux
-// +build linux
 
 package disk
 

--- a/pkg/storage/metamorphic/meta_nightly_test.go
+++ b/pkg/storage/metamorphic/meta_nightly_test.go
@@ -4,7 +4,6 @@
 // included in the /LICENSE file.
 
 //go:build nightly
-// +build nightly
 
 package metamorphic
 

--- a/pkg/storage/pebbleiter/crdb_test_off.go
+++ b/pkg/storage/pebbleiter/crdb_test_off.go
@@ -4,7 +4,6 @@
 // included in the /LICENSE file.
 
 //go:build !crdb_test || crdb_test_off
-// +build !crdb_test crdb_test_off
 
 package pebbleiter
 

--- a/pkg/storage/pebbleiter/crdb_test_on.go
+++ b/pkg/storage/pebbleiter/crdb_test_on.go
@@ -4,7 +4,6 @@
 // included in the /LICENSE file.
 
 //go:build crdb_test && !crdb_test_off
-// +build crdb_test,!crdb_test_off
 
 package pebbleiter
 

--- a/pkg/storage/slice_gccgo.go
+++ b/pkg/storage/slice_gccgo.go
@@ -4,7 +4,6 @@
 // included in the /LICENSE file.
 
 //go:build gccgo
-// +build gccgo
 
 package storage
 

--- a/pkg/storage/slice_go1.9.go
+++ b/pkg/storage/slice_go1.9.go
@@ -4,7 +4,6 @@
 // included in the /LICENSE file.
 
 //go:build gc && go1.9
-// +build gc,go1.9
 
 package storage
 


### PR DESCRIPTION
This directive has been deprecated in favor of `go:build` many Go versions
ago.

Informs: #116290
Release note: None