### PR TITLE
sqlsmith: use table implicit record types

### DIFF
--- a/pkg/sql/randgen/type.go
+++ b/pkg/sql/randgen/type.go
@@ -128,6 +128,12 @@ func RandTypeFromSlice(rng *rand.Rand, typs []*types.T) *types.T {
 			return types.MakeArray(RandTupleFromSlice(rng, typs))
 		}
 	case types.TupleFamily:
+		// In 50% of cases generate a new tuple type based on the given slice;
+		// in other 50% just use the provided tuple type (if it's not a wildcard
+		// type).
+		if rng.Intn(2) == 0 && !typ.Equal(types.AnyTuple) {
+			return typ
+		}
 		return RandTupleFromSlice(rng, typs)
 	}
 	return typ


### PR DESCRIPTION
This commit attempts to simulate the usage of table implicit record types in the sqlsmith. We do so by including a corresponding type for each user table into set of "seed types". It is an "attempt at simulation" because the type resolution is effectively performed by sqlsmith, not the DB executing the queries generated by sqlsmith, so I'm not sure about utility of this change.

Epic: None
Release note: None