### PR TITLE
sqlsmith: better support of RECORD types in UDFs

### DIFF
--- a/pkg/internal/sqlsmith/plpgsql.go
+++ b/pkg/internal/sqlsmith/plpgsql.go
@@ -59,11 +59,11 @@ func (s *Smither) makePLpgSQLDeclarations(
 	decls := make([]ast.Statement, numDecls)
 	for i := 0; i < numDecls; i++ {
 		varName := s.makePLpgSQLVarName("decl", newScope)
-		varTyp := s.randType()
+		varTyp, varTypResolvable := s.randType()
 		for varTyp.Identical(types.AnyTuple) || varTyp.Family() == types.CollatedStringFamily {
 			// TODO(#114874): allow record types here when they are supported.
 			// TODO(#105245): allow collated strings when they are supported.
-			varTyp = s.randType()
+			varTyp, varTypResolvable = s.randType()
 		}
 		constant := s.d6() == 1
 		var expr ast.Expr
@@ -74,7 +74,7 @@ func (s *Smither) makePLpgSQLDeclarations(
 		decls[i] = &ast.Declaration{
 			Var:      varName,
 			Constant: constant,
-			Typ:      varTyp,
+			Typ:      varTypResolvable,
 			Expr:     expr,
 		}
 		newScope.addVariable(string(varName), varTyp, constant)

--- a/pkg/internal/sqlsmith/relational.go
+++ b/pkg/internal/sqlsmith/relational.go
@@ -981,8 +981,11 @@ func (s *Smither) makeCreateFunc() (cf *tree.CreateRoutine, ok bool) {
 
 	// RoutineLanguage
 	lang := tree.RoutineLangSQL
+	// Simulate RETURNS TABLE syntax of SQL UDFs in 10% cases.
+	returnsTable := s.rnd.Float64() < 0.1
 	if s.coin() {
 		lang = tree.RoutineLangPLpgSQL
+		returnsTable = false
 	}
 	opts = append(opts, lang)
 
@@ -1045,20 +1048,24 @@ func (s *Smither) makeCreateFunc() (cf *tree.CreateRoutine, ok bool) {
 	refs := make(colRefs, paramCnt)
 	for i := 0; i < paramCnt; i++ {
 		// Do not allow collated string types. These are not supported in UDFs.
-		// Do not allow RECORD-type parameters for PL/pgSQL routines.
-		// TODO(#105713): lift the RECORD-type restriction.
+		// Do not allow RECORD-type parameters for SQL routines.
+		// TODO(#105713): lift the RECORD-type restriction for PL/pgSQL.
 		ptyp, ptypResolvable := s.randType()
-		for ptyp.Family() == types.CollatedStringFamily ||
-			(lang == tree.RoutineLangPLpgSQL && ptyp.Identical(types.AnyTuple)) {
+		for ptyp.Family() == types.CollatedStringFamily || ptyp.Identical(types.AnyTuple) {
 			ptyp, ptypResolvable = s.randType()
 		}
 		pname := fmt.Sprintf("p%d", i)
 		// TODO(88947): choose VARIADIC once supported too.
-		const numSupportedParamClasses = 4
+		var numAllowedParamClasses = 4
+		if returnsTable {
+			// We cannot use explicit OUT and INOUT parameters when simulating
+			// RETURNS TABLE syntax.
+			numAllowedParamClasses = 2
+		}
 		params[i] = tree.RoutineParam{
 			Name:  tree.Name(pname),
 			Type:  ptypResolvable,
-			Class: tree.RoutineParamClass(s.rnd.Intn(numSupportedParamClasses)),
+			Class: tree.RoutineParamClass(s.rnd.Intn(numAllowedParamClasses)),
 		}
 		if params[i].Class != tree.RoutineParamOut {
 			// OUT parameters aren't allowed to have DEFAULT expressions.
@@ -1094,6 +1101,17 @@ func (s *Smither) makeCreateFunc() (cf *tree.CreateRoutine, ok bool) {
 			rTyp, rTypResolvable = s.randType()
 		}
 	}
+	if returnsTable {
+		// Try to pick an existing tuple type for some time. If that doesn't
+		// happen, create a new one.
+		for i := 0; rTyp.Family() != types.TupleFamily && i < 10; i++ {
+			rTyp, rTypResolvable = s.randType()
+		}
+		if rTyp.Family() != types.TupleFamily {
+			rTyp = s.makeRandTupleType()
+			rTypResolvable = rTyp
+		}
+	}
 
 	// TODO(93049): Allow UDFs to create other UDFs.
 	oldDisableMutations := s.disableMutations
@@ -1112,9 +1130,9 @@ func (s *Smither) makeCreateFunc() (cf *tree.CreateRoutine, ok bool) {
 		if !ok {
 			return nil, false
 		}
-		// If the rType isn't a RECORD, change it to stmtRefs or RECORD depending
-		// how many columns there are to avoid return type mismatch errors.
-		if !rTyp.Identical(types.AnyTuple) {
+		// If the rTyp isn't a RECORD, change it to stmtRefs or RECORD depending
+		// on how many columns there are to avoid return type mismatch errors.
+		if !rTyp.Equivalent(types.AnyTuple) {
 			if len(stmtRefs) == 1 && s.coin() && stmtRefs[0].typ.Family() != types.CollatedStringFamily {
 				rTyp, rTypResolvable = stmtRefs[0].typ, stmtRefs[0].typ
 			} else {
@@ -1126,12 +1144,7 @@ func (s *Smither) makeCreateFunc() (cf *tree.CreateRoutine, ok bool) {
 		if plpgsqlRTyp.Identical(types.AnyTuple) {
 			// If the return type is RECORD, choose a concrete type for generating
 			// RETURN statements.
-			numTyps := s.rnd.Intn(3) + 1
-			typs := make([]*types.T, numTyps)
-			for i := range typs {
-				typs[i], _ = s.randType()
-			}
-			plpgsqlRTyp = types.MakeTuple(typs)
+			plpgsqlRTyp = s.makeRandTupleType()
 		}
 		body = s.makeRoutineBodyPLpgSQL(paramTypes, plpgsqlRTyp, funcVol)
 	}
@@ -1139,7 +1152,7 @@ func (s *Smither) makeCreateFunc() (cf *tree.CreateRoutine, ok bool) {
 
 	// Return multiple rows with the SETOF option about 33% of the time.
 	// PL/pgSQL functions do not currently support SETOF.
-	setof := false
+	setof := returnsTable
 	if lang == tree.RoutineLangSQL && s.d6() < 3 {
 		setof = true
 	}

--- a/pkg/internal/sqlsmith/schema.go
+++ b/pkg/internal/sqlsmith/schema.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree/treebin"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/errors"
 	"github.com/lib/pq/oid"
 )
 
@@ -106,6 +107,10 @@ func (s *Smither) ReloadSchemas() error {
 		return err
 	}
 	s.tables, err = s.extractTables()
+	if err != nil {
+		return err
+	}
+	s.types.tableImplicitRecordTypes, s.types.tableImplicitRecordTypeNames, err = s.extractTableImplicitRecordTypes()
 	if err != nil {
 		return err
 	}
@@ -265,6 +270,7 @@ func (s *Smither) getRandUserDefinedType() (*types.T, *tree.TypeName, bool) {
 	return s.types.udts[idx], &s.types.udtNames[idx], true
 }
 
+// extractTypes should be called before extractTables.
 func (s *Smither) extractTypes() (*typeInfo, error) {
 	rows, err := s.db.Query(`
 SELECT
@@ -329,6 +335,37 @@ FROM
 		scalarTypes: append(udts, types.Scalar...),
 		seedTypes:   append(udts, randgen.SeedTypes...),
 	}, nil
+}
+
+// extractTableImplicitRecordTypes should only be called after extractTables.
+func (s *Smither) extractTableImplicitRecordTypes() (
+	[]*types.T,
+	[]tree.ResolvableTypeReference,
+	error,
+) {
+	var tableImplicitRecordTypes []*types.T
+	var tableImplicitRecordTypeNames []tree.ResolvableTypeReference
+	for _, t := range s.tables {
+		contents := make([]*types.T, 0, len(t.Columns))
+		labels := make([]string, 0, len(t.Columns))
+		for _, col := range t.Columns {
+			if colinfo.IsSystemColumnName(string(col.Name)) {
+				// Ignore system columns since they are inaccessible.
+				continue
+			}
+			typ, ok := col.Type.(*types.T)
+			if !ok {
+				return nil, nil, errors.AssertionFailedf("unexpectedly column type is not *types.T: %T", col.Type)
+			}
+			contents = append(contents, typ)
+			labels = append(labels, string(col.Name))
+		}
+		typ := types.MakeLabeledTuple(contents, labels)
+		tableImplicitRecordTypes = append(tableImplicitRecordTypes, typ)
+		typeName := tree.MakeSchemaQualifiedTypeName(t.TableName.Schema(), t.TableName.Table())
+		tableImplicitRecordTypeNames = append(tableImplicitRecordTypeNames, &typeName)
+	}
+	return tableImplicitRecordTypes, tableImplicitRecordTypeNames, nil
 }
 
 type schemaRef struct {

--- a/pkg/internal/sqlsmith/type.go
+++ b/pkg/internal/sqlsmith/type.go
@@ -124,6 +124,15 @@ func (s *Smither) isScalarType(t *types.T) bool {
 	return false
 }
 
+func (s *Smither) makeRandTupleType() *types.T {
+	numTyps := s.rnd.Intn(3) + 1
+	typs := make([]*types.T, numTyps)
+	for i := range typs {
+		typs[i], _ = s.randType()
+	}
+	return types.MakeTuple(typs)
+}
+
 func (s *Smither) randType() (*types.T, tree.ResolvableTypeReference) {
 	s.lock.RLock()
 	defer s.lock.RUnlock()

--- a/pkg/internal/sqlsmith/type.go
+++ b/pkg/internal/sqlsmith/type.go
@@ -33,18 +33,18 @@ func (s *Smither) typeFromSQLTypeSyntax(typeStr string) (*types.T, error) {
 func (s *Smither) pickAnyType(typ *types.T) *types.T {
 	switch typ.Family() {
 	case types.AnyFamily:
-		typ = s.randType()
+		typ, _ = s.randType()
 	case types.ArrayFamily:
 		if typ.ArrayContents().Family() == types.AnyFamily {
 			typ = randgen.RandArrayContentsType(s.rnd)
 		}
 	case types.DecimalFamily:
 		if s.disableDecimals {
-			typ = s.randType()
+			typ, _ = s.randType()
 		}
 	case types.OidFamily:
 		if s.disableOIDs {
-			typ = s.randType()
+			typ, _ = s.randType()
 		}
 	}
 	return typ
@@ -124,11 +124,24 @@ func (s *Smither) isScalarType(t *types.T) bool {
 	return false
 }
 
-func (s *Smither) randType() *types.T {
+func (s *Smither) randType() (*types.T, tree.ResolvableTypeReference) {
 	s.lock.RLock()
 	defer s.lock.RUnlock()
 	seedTypes := randgen.SeedTypes
 	if s.types != nil {
+		if !s.simpleScalarTypes && len(s.types.tableImplicitRecordTypes) > 0 {
+			// If we have some implicit record type names, then choose them with
+			// some probability, proportional to the number of such types, but
+			// no more than 30%.
+			p := 0.05 * float64(len(s.types.tableImplicitRecordTypes))
+			if p > 0.3 {
+				p = 0.3
+			}
+			if s.rnd.Float64() < p {
+				idx := s.rnd.Intn(len(s.types.tableImplicitRecordTypes))
+				return s.types.tableImplicitRecordTypes[idx], s.types.tableImplicitRecordTypeNames[idx]
+			}
+		}
 		seedTypes = s.types.seedTypes
 	}
 	var typ *types.T
@@ -148,13 +161,14 @@ func (s *Smither) randType() *types.T {
 		}
 		break
 	}
-	return typ
+	return typ, typ
 }
 
 func (s *Smither) makeDesiredTypes() []*types.T {
 	var typs []*types.T
 	for {
-		typs = append(typs, s.randType())
+		typ, _ := s.randType()
+		typs = append(typs, typ)
 		if s.d6() < 2 || !s.canRecurse() {
 			break
 		}
@@ -163,10 +177,12 @@ func (s *Smither) makeDesiredTypes() []*types.T {
 }
 
 type typeInfo struct {
-	udts        []*types.T
-	udtNames    []tree.TypeName
-	seedTypes   []*types.T
-	scalarTypes []*types.T
+	udts                         []*types.T
+	udtNames                     []tree.TypeName
+	seedTypes                    []*types.T
+	scalarTypes                  []*types.T
+	tableImplicitRecordTypes     []*types.T
+	tableImplicitRecordTypeNames []tree.ResolvableTypeReference
 }
 
 // ResolveType implements the tree.TypeReferenceResolver interface.

--- a/pkg/sql/randgen/type.go
+++ b/pkg/sql/randgen/type.go
@@ -128,6 +128,12 @@ func RandTypeFromSlice(rng *rand.Rand, typs []*types.T) *types.T {
 			return types.MakeArray(RandTupleFromSlice(rng, typs))
 		}
 	case types.TupleFamily:
+		// In 50% of cases generate a new tuple type based on the given slice;
+		// in other 50% just use the provided tuple type (if it's not a wildcard
+		// type).
+		if rng.Intn(2) == 0 && !typ.Identical(types.AnyTuple) {
+			return typ
+		}
 		return RandTupleFromSlice(rng, typs)
 	}
 	return typ


### PR DESCRIPTION
**sqlsmith: use table implicit record types**

This commit updates `randType` helper to also occasionally use the table
implicit record types. This required some plumbing to use "resolvable
type references" in addition to the resolved `types.T` object. This
ability is now utilized when creating UDFs.

**sqlsmith: make adjustments to simulate RETURNS TABLE for SQL UDFs**

The following changes are made:
- SQL routines now don't use RECORD parameter type (this is disallowed)
- in special "returns table" mode:
  - only use IN parameters
  - always pick RECORD return type
- update the UDF return type to the last stmt's only if it's not
_equivalent_ to `AnyTuple` (to allow for originally chosen RECORD type
to be preserved).

Epic: None
Release note: None