### PR TITLE
row: miscellaneous minor cleanup

### DIFF
--- a/pkg/crosscluster/logical/lww_kv_processor.go
+++ b/pkg/crosscluster/logical/lww_kv_processor.go
@@ -482,7 +482,7 @@ func (p *kvTableWriter) insertRow(ctx context.Context, b *kv.Batch, after cdceve
 		// and destination clusters.
 		// ShouldWinTie: true,
 	}
-	return p.ri.InsertRow(ctx, &row.KVBatchAdapter{Batch: b}, p.newVals, ph, oth, false, false)
+	return p.ri.InsertRow(ctx, &row.KVBatchAdapter{Batch: b}, p.newVals, ph, oth, false /* overwrite */, false /* traceKV */)
 }
 
 func (p *kvTableWriter) updateRow(

--- a/pkg/sql/row/inserter.go
+++ b/pkg/sql/row/inserter.go
@@ -141,11 +141,6 @@ func (ri *Inserter) InsertRow(
 		return errors.Errorf("got %d values but expected %d", len(values), len(ri.InsertCols))
 	}
 
-	putFn := insertCPutFn
-	if overwrite {
-		putFn = insertPutFn
-	}
-
 	// We don't want to insert any empty k/v's, so set includeEmpty to false.
 	// Consider the following case:
 	// TABLE t (
@@ -170,7 +165,7 @@ func (ri *Inserter) InsertRow(
 		&ri.Helper, primaryIndexKey, ri.InsertCols,
 		values, ri.InsertColIDtoRowIndex,
 		ri.InsertColIDtoRowIndex,
-		&ri.key, &ri.value, ri.valueBuf, putFn, oth, nil, overwrite, traceKV)
+		&ri.key, &ri.value, ri.valueBuf, oth, nil /* oldValues */, overwrite, traceKV)
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/row/inserter.go
+++ b/pkg/sql/row/inserter.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
 )
@@ -77,20 +78,30 @@ func CheckPrimaryKeyColumns(tableDesc catalog.TableDescriptor, colMap catalog.Ta
 // insertCPutFn is used by insertRow when conflicts (i.e. the key already exists)
 // should generate errors.
 func insertCPutFn(
-	ctx context.Context, b Putter, key *roachpb.Key, value *roachpb.Value, traceKV bool,
+	ctx context.Context,
+	b Putter,
+	key *roachpb.Key,
+	value *roachpb.Value,
+	traceKV bool,
+	keyEncodingDirs []encoding.Direction,
 ) {
 	if traceKV {
-		log.VEventfDepth(ctx, 1, 2, "CPut %s -> %s", *key, value.PrettyPrint())
+		log.VEventfDepth(ctx, 1, 2, "CPut %s -> %s", keys.PrettyPrint(keyEncodingDirs, *key), value.PrettyPrint())
 	}
 	b.CPut(key, value, nil /* expValue */)
 }
 
 // insertPutFn is used by insertRow when conflicts should be ignored.
 func insertPutFn(
-	ctx context.Context, b Putter, key *roachpb.Key, value *roachpb.Value, traceKV bool,
+	ctx context.Context,
+	b Putter,
+	key *roachpb.Key,
+	value *roachpb.Value,
+	traceKV bool,
+	keyEncodingDirs []encoding.Direction,
 ) {
 	if traceKV {
-		log.VEventfDepth(ctx, 1, 2, "Put %s -> %s", *key, value.PrettyPrint())
+		log.VEventfDepth(ctx, 1, 2, "Put %s -> %s", keys.PrettyPrint(keyEncodingDirs, *key), value.PrettyPrint())
 	}
 	b.Put(key, value)
 }
@@ -184,9 +195,9 @@ func (ri *Inserter) InsertRow(
 
 				if ri.Helper.Indexes[idx].ForcePut() {
 					// See the comment on (catalog.Index).ForcePut() for more details.
-					insertPutFn(ctx, b, &e.Key, &e.Value, traceKV)
+					insertPutFn(ctx, b, &e.Key, &e.Value, traceKV, ri.Helper.secIndexValDirs[idx])
 				} else {
-					insertCPutFn(ctx, b, &e.Key, &e.Value, traceKV)
+					insertCPutFn(ctx, b, &e.Key, &e.Value, traceKV, ri.Helper.secIndexValDirs[idx])
 				}
 			}
 

--- a/pkg/sql/row/row_converter.go
+++ b/pkg/sql/row/row_converter.go
@@ -565,7 +565,7 @@ func (c *DatumRowConverter) Row(ctx context.Context, sourceID int32, rowIndex in
 		insertRow,
 		pm,
 		nil,   /* OriginTimestampCPutHelper */
-		true,  /* ignoreConflicts */
+		true,  /* overwrite */
 		false, /* traceKV */
 	); err != nil {
 		return errors.Wrap(err, "insert row")

--- a/pkg/sql/row/updater.go
+++ b/pkg/sql/row/updater.go
@@ -22,7 +22,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/util/deduplicate"
 	"github.com/cockroachdb/cockroach/pkg/util/intsets"
-	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
 )
 
@@ -422,24 +421,11 @@ func (ru *Updater) UpdateRow(
 						continue
 					}
 
-					if index.ForcePut() {
+					if index.ForcePut() || sameKey {
 						// See the comment on (catalog.Index).ForcePut() for more details.
-						insertPutFn(ctx, putter, &newEntry.Key, &newEntry.Value, traceKV)
+						insertPutFn(ctx, putter, &newEntry.Key, &newEntry.Value, traceKV, ru.Helper.secIndexValDirs[i])
 					} else {
-						if traceKV {
-							k := keys.PrettyPrint(ru.Helper.secIndexValDirs[i], newEntry.Key)
-							v := newEntry.Value.PrettyPrint()
-							if sameKey {
-								log.VEventf(ctx, 2, "Put %s -> %v", k, v)
-							} else {
-								log.VEventf(ctx, 2, "CPut %s -> %v", k, v)
-							}
-						}
-						if sameKey {
-							batch.Put(newEntry.Key, &newEntry.Value)
-						} else {
-							batch.CPut(newEntry.Key, &newEntry.Value, nil /* expValue */)
-						}
+						insertCPutFn(ctx, putter, &newEntry.Key, &newEntry.Value, traceKV, ru.Helper.secIndexValDirs[i])
 					}
 					writtenIndexes.Add(i)
 				} else if oldEntry.Family < newEntry.Family {
@@ -465,17 +451,12 @@ func (ru *Updater) UpdateRow(
 
 					if index.ForcePut() {
 						// See the comment on (catalog.Index).ForcePut() for more details.
-						insertPutFn(ctx, putter, &newEntry.Key, &newEntry.Value, traceKV)
+						insertPutFn(ctx, putter, &newEntry.Key, &newEntry.Value, traceKV, ru.Helper.secIndexValDirs[i])
 					} else {
 						// In this case, the index now has a k/v that did not exist in the
 						// old row, so we should expect to not see a value for the new key,
 						// and put the new key in place.
-						if traceKV {
-							k := keys.PrettyPrint(ru.Helper.secIndexValDirs[i], newEntry.Key)
-							v := newEntry.Value.PrettyPrint()
-							log.VEventf(ctx, 2, "CPut %s -> %v", k, v)
-						}
-						batch.CPut(newEntry.Key, &newEntry.Value, nil)
+						insertCPutFn(ctx, putter, &newEntry.Key, &newEntry.Value, traceKV, ru.Helper.secIndexValDirs[i])
 					}
 					writtenIndexes.Add(i)
 					newIdx++
@@ -502,14 +483,9 @@ func (ru *Updater) UpdateRow(
 				newEntry := &newEntries[newIdx]
 				if index.ForcePut() {
 					// See the comment on (catalog.Index).ForcePut() for more details.
-					insertPutFn(ctx, putter, &newEntry.Key, &newEntry.Value, traceKV)
+					insertPutFn(ctx, putter, &newEntry.Key, &newEntry.Value, traceKV, ru.Helper.secIndexValDirs[i])
 				} else {
-					if traceKV {
-						k := keys.PrettyPrint(ru.Helper.secIndexValDirs[i], newEntry.Key)
-						v := newEntry.Value.PrettyPrint()
-						log.VEventf(ctx, 2, "CPut %s -> %v", k, v)
-					}
-					batch.CPut(newEntry.Key, &newEntry.Value, nil)
+					insertCPutFn(ctx, putter, &newEntry.Key, &newEntry.Value, traceKV, ru.Helper.secIndexValDirs[i])
 				}
 				writtenIndexes.Add(i)
 				newIdx++
@@ -525,9 +501,9 @@ func (ru *Updater) UpdateRow(
 			for j := range ru.newIndexEntries[i] {
 				if index.ForcePut() {
 					// See the comment on (catalog.Index).ForcePut() for more details.
-					insertPutFn(ctx, putter, &ru.newIndexEntries[i][j].Key, &ru.newIndexEntries[i][j].Value, traceKV)
+					insertPutFn(ctx, putter, &ru.newIndexEntries[i][j].Key, &ru.newIndexEntries[i][j].Value, traceKV, ru.Helper.secIndexValDirs[i])
 				} else {
-					insertCPutFn(ctx, putter, &ru.newIndexEntries[i][j].Key, &ru.newIndexEntries[i][j].Value, traceKV)
+					insertCPutFn(ctx, putter, &ru.newIndexEntries[i][j].Key, &ru.newIndexEntries[i][j].Value, traceKV, ru.Helper.secIndexValDirs[i])
 				}
 			}
 		}

--- a/pkg/sql/row/updater.go
+++ b/pkg/sql/row/updater.go
@@ -527,7 +527,7 @@ func (ru *Updater) UpdateRow(
 					// See the comment on (catalog.Index).ForcePut() for more details.
 					insertPutFn(ctx, putter, &ru.newIndexEntries[i][j].Key, &ru.newIndexEntries[i][j].Value, traceKV)
 				} else {
-					insertInvertedPutFn(ctx, putter, &ru.newIndexEntries[i][j].Key, &ru.newIndexEntries[i][j].Value, traceKV)
+					insertCPutFn(ctx, putter, &ru.newIndexEntries[i][j].Key, &ru.newIndexEntries[i][j].Value, traceKV)
 				}
 			}
 		}

--- a/pkg/sql/row/updater.go
+++ b/pkg/sql/row/updater.go
@@ -357,7 +357,7 @@ func (ru *Updater) UpdateRow(
 			return nil, err
 		}
 		if err := ru.ri.InsertRow(
-			ctx, putter, ru.newValues, pm, oth, false /* ignoreConflicts */, traceKV,
+			ctx, putter, ru.newValues, pm, oth, false /* overwrite */, traceKV,
 		); err != nil {
 			return nil, err
 		}
@@ -370,7 +370,7 @@ func (ru *Updater) UpdateRow(
 		&ru.Helper, primaryIndexKey, ru.FetchCols,
 		ru.newValues, ru.FetchColIDtoRowIndex,
 		ru.UpdateColIDtoRowIndex,
-		&ru.key, &ru.value, ru.valueBuf, insertPutFn, oth, oldValues, true /* overwrite */, traceKV)
+		&ru.key, &ru.value, ru.valueBuf, oth, oldValues, true /* overwrite */, traceKV)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/row/writer.go
+++ b/pkg/sql/row/writer.go
@@ -60,7 +60,7 @@ func ColMapping(fromCols, toCols []catalog.Column) []int {
 }
 
 // prepareInsertOrUpdateBatch constructs a KV batch that inserts or
-// updates a row in KV.
+// updates a row in KV in the primary index.
 //   - batch is the KV batch where commands should be appended.
 //   - helper is the rowHelper that knows about the table being modified.
 //   - primaryIndexKey is the PK prefix for the current row.
@@ -202,7 +202,7 @@ func prepareInsertOrUpdateBatch(
 				if oth.IsSet() {
 					oth.CPutFn(ctx, batch, kvKey, &marshaled, oldVal, traceKV)
 				} else {
-					putFn(ctx, batch, kvKey, &marshaled, traceKV)
+					putFn(ctx, batch, kvKey, &marshaled, traceKV, helper.primIndexValDirs)
 				}
 			}
 
@@ -263,7 +263,7 @@ func prepareInsertOrUpdateBatch(
 			if oth.IsSet() {
 				oth.CPutFn(ctx, batch, kvKey, kvValue, expBytes, traceKV)
 			} else {
-				putFn(ctx, batch, kvKey, kvValue, traceKV)
+				putFn(ctx, batch, kvKey, kvValue, traceKV, helper.primIndexValDirs)
 			}
 		}
 


### PR DESCRIPTION
**row: remove redundant insertInvertedPutFn**

`insertInvertedPutFn` became exactly the same as `insertCPutFn` after
we changed the usage of InitPuts in favor of CPuts, so this commit
replaces all usages.

**row: don't pass putFn as parameter to prepareInsertOrUpdateBatch**

We can figure out which `putFn` variant to use based on `overwrite`
parameter.

**row: unify handling of tracing a bit**

Previously, we would have some custom tracing code in a few spots where
we added Puts or CPuts to the KV batch. However, we could use
`insertPutFn` and `insertCPutFn` instead which already includes the
desired tracing, to remove some code duplication.

Epic: None
Release note: None