### PR TITLE
release-24.3: roachtest: deflake follower-reads/mixed-version/survival=region/locality=global/reads=strong

### DIFF
--- a/pkg/cmd/roachtest/tests/follower_reads.go
+++ b/pkg/cmd/roachtest/tests/follower_reads.go
@@ -534,6 +534,38 @@ func initFollowerReadsDB(
 		require.NoError(t, err)
 	}
 
+	ensureUpreplicationAndPlacement(ctx, t, l, topology, db)
+
+	const rows = 100
+	const concurrency = 32
+	sem := make(chan struct{}, concurrency)
+	data = make(map[int]int64)
+	insert := func(ctx context.Context, k int) func() error {
+		v := rng.Int63()
+		data[k] = v
+		return func() error {
+			sem <- struct{}{}
+			defer func() { <-sem }()
+			_, err := db.ExecContext(ctx, "INSERT INTO mr_db.test VALUES ( $1, $2 )", k, v)
+			return err
+		}
+	}
+
+	// Insert the data.
+	g, gCtx := errgroup.WithContext(ctx)
+	for i := 0; i < rows; i++ {
+		g.Go(insert(gCtx, i))
+	}
+	if err := g.Wait(); err != nil {
+		t.Fatalf("failed to insert data: %v", err)
+	}
+
+	return data
+}
+
+func ensureUpreplicationAndPlacement(
+	ctx context.Context, t test.Test, l *logger.Logger, topology topologySpec, db *gosql.DB,
+) {
 	// Wait until the table has completed up-replication.
 	l.Printf("waiting for up-replication...")
 	retryOpts := retry.Options{MaxBackoff: 15 * time.Second}
@@ -656,32 +688,6 @@ func initFollowerReadsDB(
 			}
 		}
 	}
-
-	const rows = 100
-	const concurrency = 32
-	sem := make(chan struct{}, concurrency)
-	data = make(map[int]int64)
-	insert := func(ctx context.Context, k int) func() error {
-		v := rng.Int63()
-		data[k] = v
-		return func() error {
-			sem <- struct{}{}
-			defer func() { <-sem }()
-			_, err := db.ExecContext(ctx, "INSERT INTO mr_db.test VALUES ( $1, $2 )", k, v)
-			return err
-		}
-	}
-
-	// Insert the data.
-	g, gCtx := errgroup.WithContext(ctx)
-	for i := 0; i < rows; i++ {
-		g.Go(insert(gCtx, i))
-	}
-	if err := g.Wait(); err != nil {
-		t.Fatalf("failed to insert data: %v", err)
-	}
-
-	return data
 }
 
 func computeFollowerReadDuration(ctx context.Context, db *gosql.DB) (time.Duration, error) {
@@ -1051,6 +1057,7 @@ func runFollowerReadsMixedVersionTest(
 	}
 
 	runFollowerReads := func(ctx context.Context, l *logger.Logger, r *rand.Rand, h *mixedversion.Helper) error {
+		ensureUpreplicationAndPlacement(ctx, t, l, topology, h.Connect(1))
 		runFollowerReadsTest(ctx, t, l, c, r, topology, rc, data)
 		return nil
 	}


### PR DESCRIPTION
Backport 1/1 commits from #139888.

/cc @cockroachdb/release

---

Previously, this test failed due to replicas from the same region being considered unhealthy and re-ordered after replicas from other regions (in `transport.splitHealthy()`), resulting in elevated latency of the (cross-region) follower read. The issue is not present in non-mixed-version tests. Unlike the regular tests, the mixed-version tests invoke the test initialization, which includes ensuring upreplication and correct replica placement, at node startup but not before each follower-reads run. So, a node may consider a recently-restarted node unhealthy, and only the latter would have run the initialization steps on startup.

This commit factors out the logic that ensures upreplicasion and correct replica placement, and invokes this logic not just on node startup but before each follower-reads run.

Fixes: #139335
Fixes: #138076
Fixes: #136099
Fixes: #133520

Release note: None

---

Release justification: Testing only.
