### PR TITLE
cluster-ui: Show the commit latency in transactions table and details pages

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/statsTableUtil/statsTableUtil.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statsTableUtil/statsTableUtil.tsx
@@ -54,6 +54,7 @@ export const statisticsColumnLabels = {
   statementsCount: "Statements",
   status: "Status",
   time: "Time",
+  commitLatency: "Commit Latency",
   transactionFingerprintId: "Transaction Fingerprint ID",
   transactions: "Transactions",
   txnDuration: "Transaction Duration",
@@ -548,6 +549,23 @@ export const statisticsTableTitles: StatisticTableTitleType = {
         }
       >
         {getLabel("bytesRead")}
+      </Tooltip>
+    );
+  },
+  commitLatency: (_statType: StatisticType) => {
+    return (
+      <Tooltip
+        placement="bottom"
+        style="tableTitle"
+        content={
+          <p>
+            Average commit latency of this transaction. The gray bar indicates
+            the mean latency. The blue bar indicates one standard deviation from
+            the mean.
+          </p>
+        }
+      >
+        {getLabel("commitLatency")}
       </Tooltip>
     );
   },

--- a/pkg/ui/workspaces/cluster-ui/src/transactionDetails/transactionDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionDetails/transactionDetails.tsx
@@ -394,15 +394,21 @@ export class TransactionDetails extends React.Component<
                 <span className={cx("tooltip-info")}>unavailable</span>
               </Tooltip>
             );
-            const meanIdleLatency = transactionSampled ? (
+            const meanIdleLatency = (
               <Text>
                 {formatNumberForDisplay(
                   get(transactionStats, "idle_lat.mean", 0),
                   duration,
                 )}
               </Text>
-            ) : (
-              unavailableTooltip
+            );
+            const meanCommitLatency = (
+              <Text>
+                {formatNumberForDisplay(
+                  get(transactionStats, "commit_lat.mean", 0),
+                  duration,
+                )}
+              </Text>
             );
             const meansRows = `${formatNumberForDisplay(
               transactionStats.rows_read.mean,
@@ -513,6 +519,10 @@ export class TransactionDetails extends React.Component<
                         <SummaryCardItem
                           label="Idle latency"
                           value={meanIdleLatency}
+                        />
+                        <SummaryCardItem
+                          label="Commit latency"
+                          value={meanCommitLatency}
                         />
                         <SummaryCardItem
                           label="Mean rows/bytes read"

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsTable/transactionsBarCharts.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsTable/transactionsBarCharts.ts
@@ -31,14 +31,25 @@ const bytesReadBar = [
 const bytesReadStdDev = bar(cx("bytes-read-dev"), (d: Transaction) =>
   stdDevLong(d.stats_data.stats.bytes_read, d.stats_data.stats.count),
 );
-const latencyBar = [
+const serviceLatencyBar = [
   bar(
     "bar-chart__service-lat",
     (d: Transaction) => d.stats_data.stats.service_lat.mean,
   ),
 ];
-const latencyStdDev = bar(cx("bar-chart__overall-dev"), (d: Transaction) =>
-  stdDevLong(d.stats_data.stats.service_lat, d.stats_data.stats.count),
+const serviceLatencyStdDev = bar(
+  cx("bar-chart__overall-dev"),
+  (d: Transaction) =>
+    stdDevLong(d.stats_data.stats.service_lat, d.stats_data.stats.count),
+);
+const commitLatencyBar = [
+  bar(
+    "bar-chart__commit-lat",
+    (d: Transaction) => d.stats_data.stats.commit_lat.mean,
+  ),
+];
+const commitLatencyStdDev = bar("bar-chart__commit-dev", (d: Transaction) =>
+  stdDevLong(d.stats_data.stats.commit_lat, d.stats_data.stats.count),
 );
 const contentionBar = [
   bar(
@@ -103,11 +114,17 @@ export const transactionsBytesReadBarChart = barChartFactory(
   Bytes,
   bytesReadStdDev,
 );
-export const transactionsLatencyBarChart = barChartFactory(
+export const transactionsServiceLatencyBarChart = barChartFactory(
   "grey",
-  latencyBar,
+  serviceLatencyBar,
   v => Duration(v * 1e9),
-  latencyStdDev,
+  serviceLatencyStdDev,
+);
+export const transactionsCommitLatencyBarChart = barChartFactory(
+  "grey",
+  commitLatencyBar,
+  v => Duration(v * 1e9),
+  commitLatencyStdDev,
 );
 export const transactionsContentionBarChart = barChartFactory(
   "grey",

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsTable/transactionsTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsTable/transactionsTable.tsx
@@ -37,12 +37,13 @@ import {
 import {
   transactionsCountBarChart,
   transactionsBytesReadBarChart,
-  transactionsLatencyBarChart,
+  transactionsServiceLatencyBarChart,
   transactionsContentionBarChart,
   transactionsCPUBarChart,
   transactionsMaxMemUsageBarChart,
   transactionsNetworkBytesBarChart,
   transactionsRetryBarChart,
+  transactionsCommitLatencyBarChart,
 } from "./transactionsBarCharts";
 import { transactionLink } from "./transactionsCells";
 import { tableClasses } from "./transactionsTableClasses";
@@ -114,7 +115,11 @@ export function makeTransactionsColumns(
     transactions,
     defaultBarChartOptions,
   );
-  const latencyBar = transactionsLatencyBarChart(
+  const serviceLatencyBar = transactionsServiceLatencyBarChart(
+    transactions,
+    latencyClasses.barChart,
+  );
+  const commitLatencyBar = transactionsCommitLatencyBarChart(
     transactions,
     latencyClasses.barChart,
   );
@@ -207,9 +212,16 @@ export function makeTransactionsColumns(
     {
       name: "time",
       title: statisticsTableTitles.time(statType),
-      cell: latencyBar,
+      cell: serviceLatencyBar,
       className: latencyClasses.column,
       sort: (item: TransactionInfo) => item.stats_data.stats.service_lat.mean,
+    },
+    {
+      name: "commitLatency",
+      title: statisticsTableTitles.commitLatency(statType),
+      cell: commitLatencyBar,
+      className: latencyClasses.column,
+      sort: (item: TransactionInfo) => item.stats_data.stats.commit_lat.mean,
     },
     {
       name: "contention",


### PR DESCRIPTION
The commit latency is available on the TransactionsStatistics protobuf, however it is not shown in the transactions table and details page in the DB Console.

This commit surfaces that metric to the user.

Part of: #133989

Release note (ui change): Surface commit latency in the transactions pages