### PR TITLE
crosscluster/logical: use large test pool

### DIFF
--- a/pkg/crosscluster/logical/BUILD.bazel
+++ b/pkg/crosscluster/logical/BUILD.bazel
@@ -118,6 +118,7 @@ go_test(
     ],
     data = ["//c-deps:libgeos"],
     embed = [":logical"],
+    exec_properties = {"test.Pool": "large"},
     deps = [
         "//pkg/base",
         "//pkg/ccl",


### PR DESCRIPTION
This package spins up several TestServers. We've also seen many tests timeout, likely due to resource exhaustion.

Informs #138277
Informs #139673

Release note: none