### PR TITLE
schemachanger: deprecate IsInverted in favor of new Type field

### DIFF
--- a/pkg/ccl/schemachangerccl/testdata/decomp/multiregion
+++ b/pkg/ccl/schemachangerccl/testdata/decomp/multiregion
@@ -457,6 +457,7 @@ ElementState:
     sourceIndexId: 0
     tableId: 110
     temporaryIndexId: 0
+    type: FORWARD
   Status: PUBLIC
 - SchemaChild:
     childObjectId: 110
@@ -852,6 +853,7 @@ ElementState:
     sourceIndexId: 0
     tableId: 109
     temporaryIndexId: 0
+    type: FORWARD
   Status: PUBLIC
 - SchemaChild:
     childObjectId: 109
@@ -1481,6 +1483,7 @@ ElementState:
     sourceIndexId: 0
     tableId: 108
     temporaryIndexId: 0
+    type: FORWARD
   Status: PUBLIC
 - SchemaChild:
     childObjectId: 108

--- a/pkg/ccl/schemachangerccl/testdata/decomp/partitioning
+++ b/pkg/ccl/schemachangerccl/testdata/decomp/partitioning
@@ -506,6 +506,7 @@ ElementState:
     sourceIndexId: 0
     tableId: 104
     temporaryIndexId: 0
+    type: FORWARD
   Status: PUBLIC
 - SchemaChild:
     childObjectId: 104
@@ -527,6 +528,7 @@ ElementState:
     sourceIndexId: 0
     tableId: 104
     temporaryIndexId: 0
+    type: INVERTED
   Status: PUBLIC
 - Table:
     isTemporary: false
@@ -937,6 +939,7 @@ ElementState:
     sourceIndexId: 0
     tableId: 105
     temporaryIndexId: 0
+    type: FORWARD
   Status: PUBLIC
 - SchemaChild:
     childObjectId: 105
@@ -958,6 +961,7 @@ ElementState:
     sourceIndexId: 0
     tableId: 105
     temporaryIndexId: 0
+    type: FORWARD
   Status: PUBLIC
 - Table:
     isTemporary: false

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_add_column.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_add_column.go
@@ -682,6 +682,7 @@ func addSecondaryIndexTargetsForAddColumn(
 		IndexID:       desc.ID,
 		IsUnique:      desc.Unique,
 		IsInverted:    desc.Type == idxtype.INVERTED,
+		Type:          desc.Type,
 		SourceIndexID: newPrimaryIdx.IndexID,
 		IsNotVisible:  desc.NotVisible,
 		Invisibility:  desc.Invisibility,

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_alter_primary_key.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_alter_primary_key.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scerrors"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/catid"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/idxtype"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
@@ -694,7 +695,7 @@ func recreateAllSecondaryIndexes(
 						kind:      scpb.IndexColumn_KEY,
 						direction: ic.Direction,
 					})
-					if idx.IsInverted && ic.OrdinalInKind >= largestKeyOrdinal {
+					if idx.Type == idxtype.INVERTED && ic.OrdinalInKind >= largestKeyOrdinal {
 						largestKeyOrdinal = ic.OrdinalInKind
 						invertedColumnID = ic.ColumnID
 					}
@@ -706,7 +707,7 @@ func recreateAllSecondaryIndexes(
 				if !idxColIDs.Contains(ics.columnID) {
 					idxColIDs.Add(ics.columnID)
 					inColumns = append(inColumns, ics)
-				} else if idx.IsInverted && invertedColumnID == ics.columnID {
+				} else if idx.Type == idxtype.INVERTED && invertedColumnID == ics.columnID {
 					// In an inverted index, the inverted column's value is not equal to
 					// the actual data in the row for that column. As a result, if the
 					// inverted column happens to also be in the primary key, it's crucial
@@ -792,6 +793,7 @@ func addNewUniqueSecondaryIndexAndTempIndex(
 		IndexID:             nextRelationIndexID(b, tbl),
 		IsUnique:            true,
 		IsInverted:          oldPrimaryIndexElem.IsInverted,
+		Type:                oldPrimaryIndexElem.Type,
 		Sharding:            oldPrimaryIndexElem.Sharding,
 		IsCreatedExplicitly: false,
 		ConstraintID:        b.NextTableConstraintID(tbl.TableID),

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/create_index.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/create_index.go
@@ -53,6 +53,7 @@ func CreateIndex(b BuildCtx, n *tree.CreateIndex) {
 		Index: scpb.Index{
 			IsUnique:       n.Unique,
 			IsInverted:     n.Type == idxtype.INVERTED,
+			Type:           n.Type,
 			IsConcurrently: n.Concurrently,
 			IsNotVisible:   n.Invisibility.Value != 0.0,
 			Invisibility:   n.Invisibility.Value,

--- a/pkg/sql/schemachanger/scbuild/testdata/create_index
+++ b/pkg/sql/schemachanger/scbuild/testdata/create_index
@@ -41,7 +41,7 @@ CREATE INVERTED INDEX CONCURRENTLY id2
 - [[TableData:{DescID: 104, ReferencedDescID: 100}, PUBLIC], PUBLIC]
   {databaseId: 100, tableId: 104}
 - [[SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0, TemporaryIndexID: 3, SourceIndexID: 1, RecreateSourceIndexID: 0}, PUBLIC], ABSENT]
-  {indexId: 2, isConcurrently: true, isInverted: true, sourceIndexId: 1, tableId: 104, temporaryIndexId: 3}
+  {indexId: 2, isConcurrently: true, isInverted: true, sourceIndexId: 1, tableId: 104, temporaryIndexId: 3, type: INVERTED}
 - [[IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}, PUBLIC], ABSENT]
   {columnId: 1, indexId: 2, tableId: 104}
 - [[IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}, PUBLIC], ABSENT]
@@ -51,7 +51,7 @@ CREATE INVERTED INDEX CONCURRENTLY id2
 - [[IndexName:{DescID: 104, Name: id2, IndexID: 2}, PUBLIC], ABSENT]
   {indexId: 2, name: id2, tableId: 104}
 - [[TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 1, SourceIndexID: 1}, TRANSIENT_ABSENT], ABSENT]
-  {constraintId: 1, indexId: 3, isConcurrently: true, isInverted: true, isUsingSecondaryEncoding: true, sourceIndexId: 1, tableId: 104}
+  {constraintId: 1, indexId: 3, isConcurrently: true, isInverted: true, isUsingSecondaryEncoding: true, sourceIndexId: 1, tableId: 104, type: INVERTED}
 - [[IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}, TRANSIENT_ABSENT], ABSENT]
   {columnId: 1, indexId: 3, tableId: 104}
 - [[IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}, TRANSIENT_ABSENT], ABSENT]

--- a/pkg/sql/schemachanger/scdecomp/decomp.go
+++ b/pkg/sql/schemachanger/scdecomp/decomp.go
@@ -640,6 +640,7 @@ func (w *walkCtx) walkIndex(tbl catalog.TableDescriptor, idx catalog.Index) {
 			IndexID:             idx.GetID(),
 			IsUnique:            idx.IsUnique(),
 			IsInverted:          idx.GetType() == idxtype.INVERTED,
+			Type:                idx.GetType(),
 			IsCreatedExplicitly: idx.IsCreatedExplicitly(),
 			ConstraintID:        idx.GetConstraintID(),
 			IsNotVisible:        idx.GetInvisibility() != 0.0,
@@ -650,7 +651,7 @@ func (w *walkCtx) walkIndex(tbl catalog.TableDescriptor, idx catalog.Index) {
 		}
 		for i, c := range cpy.KeyColumnIDs {
 			invertedKind := catpb.InvertedIndexColumnKind_DEFAULT
-			if index.IsInverted && c == idx.InvertedColumnID() {
+			if index.Type == idxtype.INVERTED && c == idx.InvertedColumnID() {
 				invertedKind = idx.InvertedColumnKind()
 			}
 			w.ev(scpb.Status_PUBLIC, &scpb.IndexColumn{

--- a/pkg/sql/schemachanger/scdecomp/testdata/sequence
+++ b/pkg/sql/schemachanger/scdecomp/testdata/sequence
@@ -467,6 +467,7 @@ ElementState:
     sourceIndexId: 0
     tableId: 105
     temporaryIndexId: 0
+    type: FORWARD
   Status: PUBLIC
 - SchemaChild:
     childObjectId: 105
@@ -857,6 +858,7 @@ ElementState:
     sourceIndexId: 0
     tableId: 105
     temporaryIndexId: 0
+    type: FORWARD
   Status: PUBLIC
 - SchemaChild:
     childObjectId: 105

--- a/pkg/sql/schemachanger/scdecomp/testdata/table
+++ b/pkg/sql/schemachanger/scdecomp/testdata/table
@@ -307,6 +307,7 @@ ElementState:
     sourceIndexId: 0
     tableId: 104
     temporaryIndexId: 0
+    type: FORWARD
   Status: PUBLIC
 - SchemaChild:
     childObjectId: 104
@@ -892,6 +893,7 @@ ElementState:
     sourceIndexId: 0
     tableId: 105
     temporaryIndexId: 0
+    type: FORWARD
   Status: PUBLIC
 - SchemaChild:
     childObjectId: 105
@@ -915,6 +917,7 @@ ElementState:
     sourceIndexId: 0
     tableId: 105
     temporaryIndexId: 0
+    type: FORWARD
     usesFunctionIds: []
     usesSequenceIds: []
     usesTypeIds: []
@@ -1327,6 +1330,7 @@ ElementState:
     sourceIndexId: 0
     tableId: 104
     temporaryIndexId: 0
+    type: FORWARD
   Status: PUBLIC
 - SchemaChild:
     childObjectId: 104
@@ -1717,6 +1721,7 @@ ElementState:
     sourceIndexId: 0
     tableId: 109
     temporaryIndexId: 0
+    type: FORWARD
   Status: PUBLIC
 - SchemaChild:
     childObjectId: 109

--- a/pkg/sql/schemachanger/scdecomp/testdata/type
+++ b/pkg/sql/schemachanger/scdecomp/testdata/type
@@ -669,6 +669,7 @@ ElementState:
     sourceIndexId: 0
     tableId: 108
     temporaryIndexId: 0
+    type: FORWARD
   Status: PUBLIC
 - SchemaChild:
     childObjectId: 108
@@ -692,6 +693,7 @@ ElementState:
     sourceIndexId: 0
     tableId: 108
     temporaryIndexId: 0
+    type: FORWARD
     usesFunctionIds: []
     usesSequenceIds: []
     usesTypeIds: []
@@ -1668,6 +1670,7 @@ ElementState:
     sourceIndexId: 0
     tableId: 111
     temporaryIndexId: 0
+    type: FORWARD
   Status: PUBLIC
 - SchemaChild:
     childObjectId: 111
@@ -1691,6 +1694,7 @@ ElementState:
     sourceIndexId: 0
     tableId: 111
     temporaryIndexId: 0
+    type: FORWARD
     usesFunctionIds: []
     usesSequenceIds: []
     usesTypeIds: []

--- a/pkg/sql/schemachanger/scexec/scmutationexec/index.go
+++ b/pkg/sql/schemachanger/scexec/scmutationexec/index.go
@@ -61,11 +61,6 @@ func addNewIndexMutation(
 		tbl.NextConstraintID = opIndex.ConstraintID + 1
 	}
 
-	// Set up the index descriptor type.
-	indexType := idxtype.FORWARD
-	if opIndex.IsInverted {
-		indexType = idxtype.INVERTED
-	}
 	// Set up the encoding type.
 	encodingType := catenumpb.PrimaryIndexEncoding
 	indexVersion := descpb.LatestIndexDescriptorVersion
@@ -80,7 +75,7 @@ func addNewIndexMutation(
 		NotVisible:                  opIndex.IsNotVisible,
 		Invisibility:                opIndex.Invisibility,
 		Version:                     indexVersion,
-		Type:                        indexType,
+		Type:                        opIndex.Type,
 		CreatedExplicitly:           true,
 		EncodingType:                encodingType,
 		ConstraintID:                opIndex.ConstraintID,

--- a/pkg/sql/schemachanger/scpb/BUILD.bazel
+++ b/pkg/sql/schemachanger/scpb/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
         "//pkg/sql/catalog/catpb",  # keep
         "//pkg/sql/privilege",  # keep
         "//pkg/sql/sem/catid",  # keep
+        "//pkg/sql/sem/idxtype",
         "//pkg/sql/sem/tree",  # keep
         "//pkg/util/debugutil",
         "//pkg/util/protoutil",
@@ -42,6 +43,7 @@ go_proto_library(
         "//pkg/sql/catalog/catenumpb",
         "//pkg/sql/catalog/catpb",
         "//pkg/sql/sem/catid",  # keep
+        "//pkg/sql/sem/idxtype",
         "//pkg/sql/sem/semenumpb",
         "//pkg/sql/types",
         "@com_github_gogo_protobuf//gogoproto",
@@ -61,6 +63,7 @@ proto_library(
         "//pkg/geo/geopb:geopb_proto",
         "//pkg/sql/catalog/catenumpb:catenumpb_proto",
         "//pkg/sql/catalog/catpb:catpb_proto",
+        "//pkg/sql/sem/idxtype:idxtype_proto",
         "//pkg/sql/sem/semenumpb:semenumpb_proto",
         "//pkg/sql/types:types_proto",
         "@com_github_gogo_protobuf//gogoproto:gogo_proto",
@@ -110,6 +113,7 @@ go_test(
     deps = [
         "//pkg/clusterversion",
         "//pkg/sql/catalog/catpb",
+        "//pkg/sql/sem/idxtype",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/sql/schemachanger/scpb/elements.proto
+++ b/pkg/sql/schemachanger/scpb/elements.proto
@@ -9,6 +9,7 @@ option go_package = "github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scpb
 
 import "sql/catalog/catenumpb/index.proto";
 import "sql/catalog/catpb/catalog.proto";
+import "sql/sem/idxtype/idxtype.proto";
 import "sql/sem/semenumpb/constraint.proto";
 import "sql/sem/semenumpb/trigger.proto";
 import "sql/catalog/catpb/function.proto";
@@ -290,7 +291,9 @@ message Index {
   uint32 index_id = 2 [(gogoproto.customname) = "IndexID", (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/sql/sem/catid.IndexID"];
 
   bool is_unique = 10;
-  bool is_inverted = 11;
+  // IsInverted is replaced by the Type enumeration.
+  bool is_inverted = 11 [deprecated = true];
+  cockroach.sql.sem.idxtype.T type = 26;
   cockroach.sql.catalog.catpb.ShardedDescriptor sharding = 12;
 
   // IsCreatedExplicitly specifies whether this index was created explicitly
@@ -318,6 +321,8 @@ message Index {
 
   // Invisibility specifies index invisibility to the optimizer.
   double invisibility = 25;
+
+  // Next field is 27.
 
   reserved 3, 4, 5, 6, 7;
 }

--- a/pkg/sql/schemachanger/scpb/migration_test.go
+++ b/pkg/sql/schemachanger/scpb/migration_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/idxtype"
 	"github.com/stretchr/testify/require"
 )
 
@@ -90,4 +91,58 @@ func TestDeprecatedColumnComputeFieldMigration(t *testing.T) {
 	require.Equal(t, cce.Expr, catpb.Expression("Hello"))
 	require.Equal(t, state.CurrentStatuses[1], Status_PUBLIC)
 	require.Equal(t, state.TargetRanks[1], uint32(2))
+}
+
+// TestDeprecatedIsInvertedMigration tests that the IsInverted field is migrated
+// to the new Type field.
+func TestDeprecatedIsInvertedMigration(t *testing.T) {
+	state := DescriptorState{
+		Targets: []Target{
+			MakeTarget(ToPublic,
+				&PrimaryIndex{Index: Index{
+					TableID:    1,
+					IndexID:    1,
+					IsInverted: true,
+				}},
+				nil,
+			),
+			MakeTarget(ToPublic,
+				&SecondaryIndex{Index: Index{
+					TableID:    1,
+					IndexID:    1,
+					IsInverted: true,
+				}},
+				nil,
+			),
+			MakeTarget(ToPublic,
+				&TemporaryIndex{Index: Index{
+					TableID:    1,
+					IndexID:    1,
+					IsInverted: true,
+				}},
+				nil,
+			),
+		},
+		CurrentStatuses: []Status{Status_PUBLIC, Status_PUBLIC, Status_PUBLIC},
+		TargetRanks:     []uint32{1, 2, 3},
+	}
+	migrationOccurred := MigrateDescriptorState(
+		clusterversion.ClusterVersion{Version: clusterversion.Latest.Version()},
+		1,
+		&state,
+	)
+	require.True(t, migrationOccurred)
+	require.Len(t, state.Targets, 4)
+
+	primary := state.Targets[0].GetPrimaryIndex()
+	require.True(t, primary.IsInverted)
+	require.Equal(t, idxtype.INVERTED, primary.Type)
+
+	secondary := state.Targets[1].GetSecondaryIndex()
+	require.True(t, secondary.IsInverted)
+	require.Equal(t, idxtype.INVERTED, secondary.Type)
+
+	temp := state.Targets[2].GetTemporaryIndex()
+	require.True(t, temp.IsInverted)
+	require.Equal(t, idxtype.INVERTED, temp.Type)
 }

--- a/pkg/sql/schemachanger/scplan/testdata/create_index
+++ b/pkg/sql/schemachanger/scplan/testdata/create_index
@@ -470,6 +470,7 @@ StatementPhase stage 1 of 1 with 7 MutationType ops
         SourceIndexID: 1
         TableID: 104
         TemporaryIndexID: 3
+        Type: 1
       IsSecondaryIndex: true
     *scop.AddColumnToIndex
       ColumnID: 1
@@ -493,6 +494,7 @@ StatementPhase stage 1 of 1 with 7 MutationType ops
         IsInverted: true
         SourceIndexID: 1
         TableID: 104
+        Type: 1
       IsSecondaryIndex: true
     *scop.AddColumnToIndex
       ColumnID: 1
@@ -536,6 +538,7 @@ PreCommitPhase stage 2 of 2 with 11 MutationType ops
         SourceIndexID: 1
         TableID: 104
         TemporaryIndexID: 3
+        Type: 1
       IsSecondaryIndex: true
     *scop.MaybeAddSplitForIndex
       IndexID: 2
@@ -562,6 +565,7 @@ PreCommitPhase stage 2 of 2 with 11 MutationType ops
         IsInverted: true
         SourceIndexID: 1
         TableID: 104
+        Type: 1
       IsSecondaryIndex: true
     *scop.MaybeAddSplitForIndex
       IndexID: 3


### PR DESCRIPTION
Deprecate the IsInverted field in schema changer Index element. Replace it with a new Type field that specifies the type of the index. Add a migration that sets the Type field if it's not already set.

Epic: CRDB-42943

Release note: None