### PR TITLE
storage: move WAL failover config to protobuf

### DIFF
--- a/pkg/base/BUILD.bazel
+++ b/pkg/base/BUILD.bazel
@@ -64,6 +64,7 @@ go_test(
         "//pkg/roachpb",
         "//pkg/security/securityassets",
         "//pkg/security/securitytest",
+        "//pkg/storage/storagepb",
         "//pkg/testutils",
         "//pkg/testutils/datapathutils",
         "//pkg/testutils/echotest",

--- a/pkg/base/config_test.go
+++ b/pkg/base/config_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/storage/storagepb"
 	"github.com/cockroachdb/cockroach/pkg/testutils/datapathutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/echotest"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -217,7 +218,7 @@ func TestWALFailoverConfigRoundtrip(t *testing.T) {
 	datadriven.RunTest(t, datapathutils.TestDataPath(t, "wal-failover-config"), func(t *testing.T, d *datadriven.TestData) string {
 		var buf bytes.Buffer
 		for _, l := range strings.Split(d.Input, "\n") {
-			var cfg base.WALFailoverConfig
+			var cfg storagepb.WALFailover
 			if err := cfg.Set(l); err != nil {
 				fmt.Fprintf(&buf, "err: %s\n", err)
 				continue

--- a/pkg/base/store_spec.go
+++ b/pkg/base/store_spec.go
@@ -626,7 +626,7 @@ func (jls *JoinListType) Set(value string) error {
 // unmatched EncryptionSpec causes an error.
 func PopulateWithEncryptionOpts(
 	storeSpecs StoreSpecList,
-	walFailoverConfig *WALFailoverConfig,
+	walFailoverConfig *storagepb.WALFailover,
 	encryptionSpecs storagepb.EncryptionSpecList,
 ) error {
 	for _, es := range encryptionSpecs.Specs {
@@ -647,7 +647,7 @@ func PopulateWithEncryptionOpts(
 			break
 		}
 
-		for _, externalPath := range [2]*ExternalPath{&walFailoverConfig.Path, &walFailoverConfig.PrevPath} {
+		for _, externalPath := range [2]storagepb.ExternalPath{walFailoverConfig.Path, walFailoverConfig.PrevPath} {
 			if !externalPath.IsSet() || !es.PathMatches(externalPath.Path) {
 				continue
 			}
@@ -655,11 +655,11 @@ func PopulateWithEncryptionOpts(
 			// WALFailoverConfig.PrevPath are only ever set in single-store
 			// configurations. In multi-store with among-stores failover mode, these
 			// will be empty (so we won't encounter the same path twice).
-			if externalPath.EncryptionOptions != nil {
+			if externalPath.Encryption != nil {
 				return fmt.Errorf("WAL failover path %s already has an encryption setting",
 					externalPath.Path)
 			}
-			externalPath.EncryptionOptions = &es.Options
+			externalPath.Encryption = &es.Options
 			found = true
 		}
 

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/cockroachdb/cockroach/pkg/storage/storagepb"
 	"github.com/cockroachdb/cockroach/pkg/ts"
 	"github.com/cockroachdb/cockroach/pkg/util/log/logconfig"
 	"github.com/cockroachdb/cockroach/pkg/util/log/logcrash"
@@ -750,6 +751,6 @@ func GetServerCfgStores() base.StoreSpecList {
 // WARNING: consider very carefully whether you should be using this.
 // If you are not writing CCL code that performs command-line flag
 // parsing, you probably should not be using this.
-func GetWALFailoverConfig() *base.WALFailoverConfig {
-	return &serverCfg.WALFailover
+func GetWALFailoverConfig() *storagepb.WALFailover {
+	return &serverCfg.StorageConfig.WALFailover
 }

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -525,7 +525,7 @@ func init() {
 		cliflagcfg.StringFlag(f, &deprecatedStorageEngine, cliflags.StorageEngine)
 		_ = pf.MarkHidden(cliflags.StorageEngine.Name)
 
-		cliflagcfg.VarFlag(f, &serverCfg.WALFailover, cliflags.WALFailover)
+		cliflagcfg.VarFlag(f, &serverCfg.StorageConfig.WALFailover, cliflags.WALFailover)
 		cliflagcfg.StringFlag(f, &serverCfg.SharedStorage, cliflags.SharedStorage)
 		cliflagcfg.VarFlag(f, &serverCfg.SecondaryCache, cliflags.SecondaryCache)
 		cliflagcfg.VarFlag(f, &serverCfg.MaxOffset, cliflags.MaxOffset)
@@ -1393,19 +1393,19 @@ func extraStoreFlagInit(cmd *cobra.Command) error {
 		serverCfg.Stores.Specs[i] = ss
 	}
 
-	if serverCfg.WALFailover.Path.IsSet() {
-		absPath, err := base.GetAbsoluteFSPath("wal-failover.path", serverCfg.WALFailover.Path.Path)
+	if serverCfg.StorageConfig.WALFailover.Path.IsSet() {
+		absPath, err := base.GetAbsoluteFSPath("wal-failover.path", serverCfg.StorageConfig.WALFailover.Path.Path)
 		if err != nil {
 			return err
 		}
-		serverCfg.WALFailover.Path.Path = absPath
+		serverCfg.StorageConfig.WALFailover.Path.Path = absPath
 	}
-	if serverCfg.WALFailover.PrevPath.IsSet() {
-		absPath, err := base.GetAbsoluteFSPath("wal-failover.prev_path", serverCfg.WALFailover.PrevPath.Path)
+	if serverCfg.StorageConfig.WALFailover.PrevPath.IsSet() {
+		absPath, err := base.GetAbsoluteFSPath("wal-failover.prev_path", serverCfg.StorageConfig.WALFailover.PrevPath.Path)
 		if err != nil {
 			return err
 		}
-		serverCfg.WALFailover.PrevPath.Path = absPath
+		serverCfg.StorageConfig.WALFailover.PrevPath.Path = absPath
 	}
 
 	// Configure the external I/O directory.

--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -285,6 +285,7 @@ go_library(
         "//pkg/storage/disk",
         "//pkg/storage/enginepb",
         "//pkg/storage/fs",
+        "//pkg/storage/storagepb",
         "//pkg/testutils",
         "//pkg/testutils/serverutils",
         "//pkg/testutils/sqlutils",

--- a/pkg/storage/BUILD.bazel
+++ b/pkg/storage/BUILD.bazel
@@ -67,6 +67,7 @@ go_library(
         "//pkg/storage/enginepb",
         "//pkg/storage/fs",
         "//pkg/storage/pebbleiter",
+        "//pkg/storage/storagepb",
         "//pkg/util",
         "//pkg/util/admission",
         "//pkg/util/bufalloc",

--- a/pkg/storage/open_test.go
+++ b/pkg/storage/open_test.go
@@ -12,7 +12,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
@@ -82,17 +81,17 @@ func TestWALFailover(t *testing.T) {
 				td.ScanArgs(t, "open", &openDir)
 				td.ScanArgs(t, "envs", &envDirs)
 
-				var cfg base.WALFailoverConfig
+				var cfg storagepb.WALFailover
 				if flagStr != "" {
 					if err := cfg.Set(flagStr); err != nil {
 						return fmt.Sprintf("error parsing flag: %q", err)
 					}
 				}
 				if td.HasArg("path-encrypted") {
-					cfg.Path.EncryptionOptions = &storagepb.EncryptionOptions{}
+					cfg.Path.Encryption = &storagepb.EncryptionOptions{}
 				}
 				if td.HasArg("prev-path-encrypted") {
-					cfg.PrevPath.EncryptionOptions = &storagepb.EncryptionOptions{}
+					cfg.PrevPath.Encryption = &storagepb.EncryptionOptions{}
 				}
 				openEnv := getEnv(openDir)
 				if openEnv == nil {

--- a/pkg/storage/storagepb/BUILD.bazel
+++ b/pkg/storage/storagepb/BUILD.bazel
@@ -7,6 +7,10 @@ proto_library(
     srcs = ["storage.proto"],
     strip_import_prefix = "/pkg",
     visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/roachpb:roachpb_proto",
+        "@com_github_gogo_protobuf//gogoproto:gogo_proto",
+    ],
 )
 
 go_proto_library(
@@ -15,17 +19,25 @@ go_proto_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/storage/storagepb",
     proto = ":storagepb_proto",
     visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/roachpb",
+        "@com_github_gogo_protobuf//gogoproto",
+    ],
 )
 
 go_library(
     name = "storagepb",
-    srcs = ["encryption_spec.go"],
+    srcs = [
+        "encryption_spec.go",
+        "wal_failover.go",
+    ],
     embed = [":storagepb_go_proto"],
     importpath = "github.com/cockroachdb/cockroach/pkg/storage/storagepb",
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/cli/cliflags",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_cockroachdb_redact//:redact",
         "@com_github_spf13_pflag//:pflag",
     ],
 )

--- a/pkg/storage/storagepb/storage.proto
+++ b/pkg/storage/storagepb/storage.proto
@@ -7,6 +7,9 @@ syntax = "proto3";
 package cockroach.storage.storagepb;
 option go_package = "github.com/cockroachdb/cockroach/pkg/storage/storagepb";
 
+import "gogoproto/gogo.proto";
+import "roachpb/metadata.proto";
+
 enum EncryptionKeySource {
   // Plain key files.
   KeyFiles = 0;
@@ -28,4 +31,61 @@ message EncryptionOptions {
 
   // Default data key rotation in seconds.
   int64 data_key_rotation_period = 3;
+}
+
+// ExternalPath is a path with encryption options.
+message ExternalPath {
+  // The path to the directory.
+  string path = 1;
+  // The encryption options for the directory. May be nil.
+  EncryptionOptions encryption = 2;
+}
+
+enum WALFailoverMode {
+  // DEFAULT leaves the WAL failover configuration unspecified. Today this is
+  // interpreted as DISABLED but future releases may default to another
+  // mode.
+  DEFAULT = 0;
+  // DISABLED leaves WAL failover disabled. Commits to the storage engine
+  // observe the latency of a store's primary WAL directly.
+  DISABLED = 1;
+  // AMONG_STORES enables WAL failover among multiple stores within a node. This
+  // setting has no effect if the node has a single store. When a storage engine
+  // observes high latency writing to its WAL, it may transparently failover to
+  // an arbitrary, predetermined other store's data directory. If successful in
+  // syncing log entries to the other store's volume, the batch commit latency
+  // is insulated from the effects of momentary disk stalls.
+  AMONG_STORES = 2;
+  // EXPLICIT_PATH enables WAL failover for a single-store node to an explicitly
+  // specified path.
+  EXPLICIT_PATH = 3;
+}
+
+// WALFailoverConfig configures a node's stores behavior under high write
+// latency to their write-ahead logs.
+message WALFailover {
+  option (gogoproto.goproto_stringer) = false;
+  WALFailoverMode mode = 1;
+  // Path is the non-store path to which WALs should be written when failing
+  // over. It must be nonempty if and only if Mode ==
+  // WALFailoverMode_EXPLICIT_PATH.
+  ExternalPath path = 2 [ (gogoproto.nullable) = false ];
+  // PrevPath is the previously used non-store path. It may be set with Mode ==
+  // WALFailoverMode_EXPLICIT_PATH (when changing the secondary path) or
+  // WALFailoverMode_DISABLED (when disabling WAL failover after it was
+  // previously enabled with WALFailoverMode_EXPLICIT_PATH). It must be empty
+  // for other modes. If Mode is WALFailoverMode_DISABLED and previously WAL
+  // failover was enabled using WALFailoverMode_AMONG_STORES, then PrevPath must
+  // not be set.
+  ExternalPath prev_path = 3 [ (gogoproto.nullable) = false ];
+}
+
+// NodeConfig is all the node level storage related configurations for this
+// node. This structure is persisted to all stores and can be used to bootstrap
+// the node.
+message NodeConfig {
+  // WALFailover enables and configures automatic WAL failover when latency to
+  // a store's primary WAL increases.
+  WALFailover wal_failover = 2
+      [ (gogoproto.nullable) = false, (gogoproto.customname) = "WALFailover" ];
 }

--- a/pkg/storage/storagepb/wal_failover.go
+++ b/pkg/storage/storagepb/wal_failover.go
@@ -1,0 +1,99 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package storagepb
+
+import (
+	"strings"
+
+	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
+)
+
+// Type implements the pflag.Value interface.
+func (c *WALFailover) Type() string { return "string" }
+
+// String implements fmt.Stringer.
+func (c *WALFailover) String() string {
+	return redact.StringWithoutMarkers(c)
+}
+
+// SafeFormat implements the redact.SafeFormatter interface.
+func (c *WALFailover) SafeFormat(p redact.SafePrinter, _ rune) {
+	switch c.Mode {
+	case WALFailoverMode_DEFAULT:
+		// Empty
+	case WALFailoverMode_DISABLED:
+		p.SafeString("disabled")
+		if c.PrevPath.IsSet() {
+			p.SafeString(",prev_path=")
+			p.SafeString(redact.SafeString(c.PrevPath.Path))
+		}
+	case WALFailoverMode_AMONG_STORES:
+		p.SafeString("among-stores")
+	case WALFailoverMode_EXPLICIT_PATH:
+		p.SafeString("path=")
+		p.SafeString(redact.SafeString(c.Path.Path))
+		if c.PrevPath.IsSet() {
+			p.SafeString(",prev_path=")
+			p.SafeString(redact.SafeString(c.PrevPath.Path))
+		}
+	default:
+		p.Printf("<unknown WALFailoverMode %d>", int8(c.Mode))
+	}
+}
+
+// Set implements the pflag.Value interface.
+func (c *WALFailover) Set(s string) error {
+	switch {
+	case strings.HasPrefix(s, "disabled"):
+		c.Mode = WALFailoverMode_DISABLED
+		var ok bool
+		c.Path.Path, c.PrevPath.Path, ok = parseWALFailoverPathFields(strings.TrimPrefix(s, "disabled"))
+		if !ok || c.Path.IsSet() {
+			return errors.Newf("invalid disabled --wal-failover setting: %s "+
+				"expect disabled[,prev_path=<prev_path>]", s)
+		}
+	case s == "among-stores":
+		c.Mode = WALFailoverMode_AMONG_STORES
+	case strings.HasPrefix(s, "path="):
+		c.Mode = WALFailoverMode_EXPLICIT_PATH
+		var ok bool
+		c.Path.Path, c.PrevPath.Path, ok = parseWALFailoverPathFields(s)
+		if !ok || !c.Path.IsSet() {
+			return errors.Newf("invalid path --wal-failover setting: %s "+
+				"expect path=<path>[,prev_path=<prev_path>]", s)
+		}
+	default:
+		return errors.Newf("invalid --wal-failover setting: %s "+
+			"(possible values: disabled, among-stores, path=<path>)", s)
+	}
+	return nil
+}
+
+func parseWALFailoverPathFields(s string) (path, prevPath string, ok bool) {
+	if s == "" {
+		return "", "", true
+	}
+	if s2 := strings.TrimPrefix(s, "path="); len(s2) < len(s) {
+		s = s2
+		if i := strings.IndexByte(s, ','); i == -1 {
+			return s, "", true
+		} else {
+			path = s[:i]
+			s = s[i:]
+		}
+	}
+
+	// Any remainder must be a prev_path= field.
+	if !strings.HasPrefix(s, ",prev_path=") {
+		return "", "", false
+	}
+	prevPath = strings.TrimPrefix(s, ",prev_path=")
+	return path, prevPath, true
+}
+
+// IsSet returns whether or not the path was provided.
+func (e ExternalPath) IsSet() bool { return e.Path != "" }


### PR DESCRIPTION
This commit moves the WAL failover config into the storagepb package as a protobuf and converts all related code. There is no functional impact of these changes.

Epic: [CRDB-41111](https://cockroachlabs.atlassian.net/browse/CRDB-41111)

Release note: None