### PR TITLE
testutils: add scatterplot and warmup benchmark utils

### DIFF
--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -2328,6 +2328,7 @@ GO_TARGETS = [
     "//pkg/storage:storage",
     "//pkg/storage:storage_test",
     "//pkg/testutils/bazelcodecover:bazelcodecover",
+    "//pkg/testutils/benchmark:benchmark",
     "//pkg/testutils/colcontainerutils:colcontainerutils",
     "//pkg/testutils/datapathutils:datapathutils",
     "//pkg/testutils/diagutils:diagutils",

--- a/pkg/sql/tests/BUILD.bazel
+++ b/pkg/sql/tests/BUILD.bazel
@@ -118,6 +118,7 @@ go_test(
         "//pkg/sql/types",
         "//pkg/storage",
         "//pkg/testutils",
+        "//pkg/testutils/benchmark",
         "//pkg/testutils/datapathutils",
         "//pkg/testutils/serverutils",
         "//pkg/testutils/skip",

--- a/pkg/sql/tests/main_test.go
+++ b/pkg/sql/tests/main_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/security/securityassets"
 	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
 	"github.com/cockroachdb/cockroach/pkg/server"
+	"github.com/cockroachdb/cockroach/pkg/testutils/benchmark"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
@@ -20,6 +21,8 @@ import (
 //go:generate ../../util/leaktest/add-leaktest.sh *_test.go
 
 func TestMain(m *testing.M) {
+	benchmark.RegisterScatterPlotFlags()
+	benchmark.RegisterWarmupFlags()
 	securityassets.SetLoader(securitytest.EmbeddedAssets)
 	randutil.SeedForTests()
 	serverutils.InitTestServerFactory(server.TestServerFactory)

--- a/pkg/testutils/benchmark/BUILD.bazel
+++ b/pkg/testutils/benchmark/BUILD.bazel
@@ -1,0 +1,15 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "benchmark",
+    srcs = [
+        "scatterplot.go",
+        "warmup.go",
+    ],
+    importpath = "github.com/cockroachdb/cockroach/pkg/testutils/benchmark",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/util/timeutil",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/pkg/testutils/benchmark/scatterplot.go
+++ b/pkg/testutils/benchmark/scatterplot.go
@@ -1,0 +1,103 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package benchmark
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/stretchr/testify/require"
+)
+
+// ScatterPlot is a helper for generating scatter plots of benchmark iteration
+// durations. It writes the time taken for each bucket of iterations to a file.
+// The file format is: `<iteration> <time in nanoseconds>`. Multiple runs are
+// appended to the same file. The file can be plotted using a tool like gnuplot.
+type ScatterPlot struct {
+	timeOffsets []time.Time
+	bucketSize  int
+	bucketMod   int
+	index       int
+	startTime   time.Time
+	configured  bool
+}
+
+var scatterPlotConfig struct {
+	path       *string
+	bucketSize *int
+}
+
+// RegisterScatterPlotFlags adds flags to the test binary necessary to enable
+// scatter plot output. Add this to the top of the `TestMain` function.
+func RegisterScatterPlotFlags() {
+	scatterPlotConfig.path = flag.String("scatterplot", "", "output scatterplot to a file")
+	scatterPlotConfig.bucketSize = flag.Int("scatterplot-bucket", 10, "number of iterations to bucket per point")
+}
+
+// NewScatterPlot initializes a ScatterPlot instance. If the flags are not set,
+// the methods on the returned instance will be no-ops. This helps simplify the
+// benchmark code.
+func NewScatterPlot(b *testing.B) *ScatterPlot {
+	if b.N <= 1 || *scatterPlotConfig.path == "" {
+		return &ScatterPlot{}
+	}
+	if *scatterPlotConfig.bucketSize <= 0 {
+		b.Fatalf("bucket size must be greater than 0")
+	}
+	return &ScatterPlot{
+		timeOffsets: make([]time.Time, b.N/(*scatterPlotConfig.bucketSize)),
+		bucketSize:  *scatterPlotConfig.bucketSize,
+		bucketMod:   *scatterPlotConfig.bucketSize - 1,
+		configured:  true,
+	}
+}
+
+// Start starts the timer for the scatter plot. This should be called right
+// before the benchmark starts.
+func (sp *ScatterPlot) Start() {
+	if !sp.configured {
+		return
+	}
+	sp.startTime = timeutil.Now()
+}
+
+// Stop appends the time taken for each bucket of iterations to the output file.
+// This function should be deferred so that it executes after the benchmark
+// completes.
+func (sp *ScatterPlot) Stop(b *testing.B) {
+	if !sp.configured || sp.index == 0 {
+		return
+	}
+	// The output is opened in append mode to allow for multiple runs to be appended to the same file.
+	file, err := os.OpenFile(*scatterPlotConfig.path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+	require.NoError(b, err)
+	defer func() {
+		require.NoError(b, file.Close())
+	}()
+	prevTime := sp.startTime
+	for i := 0; i < len(sp.timeOffsets); i++ {
+		_, err = fmt.Fprintf(file, "%d %d\n", i, sp.timeOffsets[i].Sub(prevTime).Nanoseconds())
+		require.NoError(b, err)
+		prevTime = sp.timeOffsets[i]
+	}
+}
+
+// Measure records the time at the given index. The call should be placed at the
+// tail end of the benchmark iteration that is being measured and the index set
+// to the current iteration of the benchmark.
+func (sp *ScatterPlot) Measure(i int) {
+	if !sp.configured {
+		return
+	}
+	if i%sp.bucketSize == sp.bucketMod {
+		sp.timeOffsets[sp.index] = timeutil.Now()
+		sp.index++
+	}
+}

--- a/pkg/testutils/benchmark/warmup.go
+++ b/pkg/testutils/benchmark/warmup.go
@@ -1,0 +1,32 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package benchmark
+
+import "flag"
+
+var warmupConfig struct {
+	iterations *int
+}
+
+// RegisterWarmupFlags adds flags to the test binary necessary to enable running
+// warmup iterations before benchmarking. Add this to the top of the `TestMain`
+// function.
+func RegisterWarmupFlags() {
+	warmupConfig.iterations = flag.Int("warmup-iterations", 0, "number of iterations to run before benchmarking")
+}
+
+// Warmup runs the given function the specified number of times before
+// benchmarking. This is useful for warming up caches before benchmarking. This
+// should be run before the benchmarking loop, and the benchmark timer should be
+// reset after the warmup.
+func Warmup(f func()) {
+	if *warmupConfig.iterations <= 0 {
+		return
+	}
+	for i := 0; i < *warmupConfig.iterations; i++ {
+		f()
+	}
+}


### PR DESCRIPTION
This change adds two new utilities (scatter plot, and warmup) to be used with go
test benchmarks. Both of the utilities register configuration flags that will
enable their use during a benchmark.

Scatter Plot provides the ability to measure the iterations within a benchmark.
Since a singular iteration could vary quite a bit in duration, a bucket size can
be configured to group the duration of multiple iterations. The timings are
written to an output file, which can be plotted.

Warmup provides a simple flag to specify a number of warmup iterations. This
could be beneficial in some benchmarks where caches or other initialisations
need to be warmed up in order to get stable iterations during the actual
benchmark.

Epic: None
Release note: None