### PR TITLE
release-24.2: roachtest: deflake splits/load/ycsb/d/obj=cpu

### DIFF
--- a/pkg/cmd/roachtest/tests/split.go
+++ b/pkg/cmd/roachtest/tests/split.go
@@ -382,7 +382,7 @@ func registerLoadSplits(r registry.Registry) {
 				// hashed - this will lead to many hotspots over the keyspace that
 				// move. Expect a few less splits than A and B.
 				minimumRanges:     15,
-				maximumRanges:     25,
+				maximumRanges:     30,
 				initialRangeCount: 2,
 				load: ycsbSplitLoad{
 					workload:     "d",


### PR DESCRIPTION
Backport 1/1 commits from #131790.

/cc @cockroachdb/release

---

The number of splits to assert on is historically flaky, when giving absolute bounds, as unrelated changes such as consuming more/less cpu on replica requests, will cause a different number of splits overall. Nevertheless, bump the number of expected splits from 24 to 29.

Fixes: #128254, #139821
Release note: None
Release justification: roachtest deflake