### PR TITLE
util: remove deprecated +build directives

### DIFF
--- a/pkg/util/buildutil/crdb_test_off.go
+++ b/pkg/util/buildutil/crdb_test_off.go
@@ -4,7 +4,6 @@
 // included in the /LICENSE file.
 
 //go:build !crdb_test || crdb_test_off
-// +build !crdb_test crdb_test_off
 
 // Package buildutil provides a constant CrdbTestBuild.
 package buildutil

--- a/pkg/util/buildutil/crdb_test_on.go
+++ b/pkg/util/buildutil/crdb_test_on.go
@@ -4,7 +4,6 @@
 // included in the /LICENSE file.
 
 //go:build crdb_test && !crdb_test_off
-// +build crdb_test,!crdb_test_off
 
 // Package buildutil provides a constant CrdbTestBuild.
 package buildutil

--- a/pkg/util/encoding/complement_fast.go
+++ b/pkg/util/encoding/complement_fast.go
@@ -4,7 +4,6 @@
 // included in the /LICENSE file.
 
 //go:build 386 || amd64
-// +build 386 amd64
 
 package encoding
 

--- a/pkg/util/encoding/complement_safe.go
+++ b/pkg/util/encoding/complement_safe.go
@@ -4,7 +4,6 @@
 // included in the /LICENSE file.
 
 //go:build !386 && !amd64
-// +build !386,!amd64
 
 package encoding
 

--- a/pkg/util/grunning/disabled.go
+++ b/pkg/util/grunning/disabled.go
@@ -6,7 +6,6 @@
 // See grunning.Supported() for an explanation behind this build tag.
 //
 //go:build !bazel
-// +build !bazel
 
 package grunning
 

--- a/pkg/util/grunning/disabled_test.go
+++ b/pkg/util/grunning/disabled_test.go
@@ -6,7 +6,6 @@
 // See grunning.Supported() for an explanation behind this build tag.
 //
 //go:build !bazel
-// +build !bazel
 
 package grunning_test
 

--- a/pkg/util/grunning/enabled.go
+++ b/pkg/util/grunning/enabled.go
@@ -6,7 +6,6 @@
 // See grunning.Supported() for an explanation behind this build tag.
 //
 //go:build bazel
-// +build bazel
 
 package grunning
 

--- a/pkg/util/grunning/enabled_test.go
+++ b/pkg/util/grunning/enabled_test.go
@@ -6,7 +6,6 @@
 // See grunning.Supported() for an explanation behind this build tag.
 //
 //go:build bazel
-// +build bazel
 
 package grunning_test
 

--- a/pkg/util/interval/bu23.go
+++ b/pkg/util/interval/bu23.go
@@ -10,7 +10,6 @@
 // This code originated in the github.com/biogo/store/interval package.
 
 //go:build !td234
-// +build !td234
 
 package interval
 

--- a/pkg/util/interval/generic/internal/interval_btree_tmpl.go
+++ b/pkg/util/interval/generic/internal/interval_btree_tmpl.go
@@ -4,7 +4,6 @@
 // included in the /LICENSE file.
 
 //go:build ignore
-// +build ignore
 
 package internal
 

--- a/pkg/util/interval/generic/internal/interval_btree_tmpl_test.go
+++ b/pkg/util/interval/generic/internal/interval_btree_tmpl_test.go
@@ -4,7 +4,6 @@
 // included in the /LICENSE file.
 
 //go:build ignore
-// +build ignore
 
 package internal
 

--- a/pkg/util/interval/td234.go
+++ b/pkg/util/interval/td234.go
@@ -10,7 +10,6 @@
 // This code originated in the github.com/biogo/store/interval package.
 
 //go:build td234
-// +build td234
 
 package interval
 

--- a/pkg/util/intsets/fast.go
+++ b/pkg/util/intsets/fast.go
@@ -4,7 +4,6 @@
 // included in the /LICENSE file.
 
 //go:build !fast_int_set_small && !fast_int_set_large
-// +build !fast_int_set_small,!fast_int_set_large
 
 package intsets
 

--- a/pkg/util/intsets/fast_large.go
+++ b/pkg/util/intsets/fast_large.go
@@ -4,7 +4,6 @@
 // included in the /LICENSE file.
 
 //go:build fast_int_set_large
-// +build fast_int_set_large
 
 package intsets
 

--- a/pkg/util/intsets/fast_small.go
+++ b/pkg/util/intsets/fast_small.go
@@ -4,7 +4,6 @@
 // included in the /LICENSE file.
 
 //go:build fast_int_set_small
-// +build fast_int_set_small
 
 package intsets
 

--- a/pkg/util/intsets/fast_testonly.go
+++ b/pkg/util/intsets/fast_testonly.go
@@ -4,7 +4,6 @@
 // included in the /LICENSE file.
 
 //go:build fast_int_set_small || fast_int_set_large
-// +build fast_int_set_small fast_int_set_large
 
 // This file implements two variants of Fast used for testing which always
 // behaves like in either the "small" or "large" case (depending on

--- a/pkg/util/json/fuzz.go
+++ b/pkg/util/json/fuzz.go
@@ -4,7 +4,6 @@
 // included in the /LICENSE file.
 
 //go:build gofuzz
-// +build gofuzz
 
 package json
 

--- a/pkg/util/log/logconfig/gen.go
+++ b/pkg/util/log/logconfig/gen.go
@@ -4,7 +4,6 @@
 // included in the /LICENSE file.
 
 //go:build bazel
-// +build bazel
 
 package main
 

--- a/pkg/util/log/logcrash/crash_reporting_unix_test.go
+++ b/pkg/util/log/logcrash/crash_reporting_unix_test.go
@@ -4,7 +4,6 @@
 // included in the /LICENSE file.
 
 //go:build !windows
-// +build !windows
 
 package logcrash
 

--- a/pkg/util/log/stderr_redirect_unix.go
+++ b/pkg/util/log/stderr_redirect_unix.go
@@ -4,7 +4,6 @@
 // included in the /LICENSE file.
 
 //go:build !windows
-// +build !windows
 
 package log
 

--- a/pkg/util/metamorphic/constants_metamorphic_disable.go
+++ b/pkg/util/metamorphic/constants_metamorphic_disable.go
@@ -4,7 +4,6 @@
 // included in the /LICENSE file.
 
 //go:build metamorphic_disable
-// +build metamorphic_disable
 
 package metamorphic
 

--- a/pkg/util/metamorphic/constants_metamorphic_enable.go
+++ b/pkg/util/metamorphic/constants_metamorphic_enable.go
@@ -4,7 +4,6 @@
 // included in the /LICENSE file.
 
 //go:build !metamorphic_disable
-// +build !metamorphic_disable
 
 package metamorphic
 

--- a/pkg/util/race_off.go
+++ b/pkg/util/race_off.go
@@ -4,7 +4,6 @@
 // included in the /LICENSE file.
 
 //go:build !race
-// +build !race
 
 package util
 

--- a/pkg/util/race_on.go
+++ b/pkg/util/race_on.go
@@ -4,7 +4,6 @@
 // included in the /LICENSE file.
 
 //go:build race
-// +build race
 
 package util
 

--- a/pkg/util/sdnotify/sdnotify_unix.go
+++ b/pkg/util/sdnotify/sdnotify_unix.go
@@ -4,7 +4,6 @@
 // included in the /LICENSE file.
 
 //go:build !windows
-// +build !windows
 
 package sdnotify
 

--- a/pkg/util/sdnotify/sdnotify_unix_test.go
+++ b/pkg/util/sdnotify/sdnotify_unix_test.go
@@ -4,7 +4,6 @@
 // included in the /LICENSE file.
 
 //go:build !windows
-// +build !windows
 
 package sdnotify
 

--- a/pkg/util/syncutil/mutex_deadlock.go
+++ b/pkg/util/syncutil/mutex_deadlock.go
@@ -4,7 +4,6 @@
 // included in the /LICENSE file.
 
 //go:build deadlock
-// +build deadlock
 
 package syncutil
 

--- a/pkg/util/syncutil/mutex_sync.go
+++ b/pkg/util/syncutil/mutex_sync.go
@@ -4,7 +4,6 @@
 // included in the /LICENSE file.
 
 //go:build !deadlock && !race
-// +build !deadlock,!race
 
 package syncutil
 

--- a/pkg/util/syncutil/mutex_sync_race.go
+++ b/pkg/util/syncutil/mutex_sync_race.go
@@ -4,7 +4,6 @@
 // included in the /LICENSE file.
 
 //go:build !deadlock && race
-// +build !deadlock,race
 
 package syncutil
 

--- a/pkg/util/syncutil/mutex_sync_race_test.go
+++ b/pkg/util/syncutil/mutex_sync_race_test.go
@@ -4,7 +4,6 @@
 // included in the /LICENSE file.
 
 //go:build !deadlock && race
-// +build !deadlock,race
 
 package syncutil
 

--- a/pkg/util/sysutil/acl_unix.go
+++ b/pkg/util/sysutil/acl_unix.go
@@ -4,7 +4,6 @@
 // included in the /LICENSE file.
 
 //go:build !windows && !plan9
-// +build !windows,!plan9
 
 package sysutil
 

--- a/pkg/util/sysutil/acl_unix_test.go
+++ b/pkg/util/sysutil/acl_unix_test.go
@@ -4,7 +4,6 @@
 // included in the /LICENSE file.
 
 //go:build !windows && !plan9
-// +build !windows,!plan9
 
 package sysutil
 

--- a/pkg/util/sysutil/large_file_linux.go
+++ b/pkg/util/sysutil/large_file_linux.go
@@ -4,7 +4,6 @@
 // included in the /LICENSE file.
 
 //go:build linux
-// +build linux
 
 package sysutil
 

--- a/pkg/util/sysutil/large_file_nonlinux.go
+++ b/pkg/util/sysutil/large_file_nonlinux.go
@@ -4,7 +4,6 @@
 // included in the /LICENSE file.
 
 //go:build !linux
-// +build !linux
 
 package sysutil
 

--- a/pkg/util/sysutil/sysutil_unix.go
+++ b/pkg/util/sysutil/sysutil_unix.go
@@ -4,7 +4,6 @@
 // included in the /LICENSE file.
 
 //go:build !windows
-// +build !windows
 
 //lint:file-ignore Unconvert (redundant conversions are necessary for cross-platform compatibility)
 

--- a/pkg/util/sysutil/sysutil_unix_test.go
+++ b/pkg/util/sysutil/sysutil_unix_test.go
@@ -4,7 +4,6 @@
 // included in the /LICENSE file.
 
 //go:build !windows
-// +build !windows
 
 package sysutil
 

--- a/pkg/util/sysutil/sysutil_windows.go
+++ b/pkg/util/sysutil/sysutil_windows.go
@@ -4,7 +4,6 @@
 // included in the /LICENSE file.
 
 //go:build windows
-// +build windows
 
 package sysutil
 

--- a/pkg/util/testaddr_default.go
+++ b/pkg/util/testaddr_default.go
@@ -4,7 +4,6 @@
 // included in the /LICENSE file.
 
 //go:build !linux
-// +build !linux
 
 package util
 

--- a/pkg/util/testaddr_random.go
+++ b/pkg/util/testaddr_random.go
@@ -4,7 +4,6 @@
 // included in the /LICENSE file.
 
 //go:build linux
-// +build linux
 
 package util
 

--- a/pkg/util/timeutil/ptp/ptp_clock_linux.go
+++ b/pkg/util/timeutil/ptp/ptp_clock_linux.go
@@ -4,7 +4,6 @@
 // included in the /LICENSE file.
 
 //go:build linux
-// +build linux
 
 package ptp
 

--- a/pkg/util/timeutil/ptp/ptp_clock_linux_test.go
+++ b/pkg/util/timeutil/ptp/ptp_clock_linux_test.go
@@ -4,7 +4,6 @@
 // included in the /LICENSE file.
 
 //go:build linux
-// +build linux
 
 package ptp
 

--- a/pkg/util/timeutil/ptp/ptp_clock_stub.go
+++ b/pkg/util/timeutil/ptp/ptp_clock_stub.go
@@ -4,7 +4,6 @@
 // included in the /LICENSE file.
 
 //go:build !linux
-// +build !linux
 
 package ptp
 

--- a/pkg/util/tracing/span_finalizer_race_off.go
+++ b/pkg/util/tracing/span_finalizer_race_off.go
@@ -4,7 +4,6 @@
 // included in the /LICENSE file.
 
 //go:build !race
-// +build !race
 
 package tracing
 

--- a/pkg/util/tracing/span_finalizer_race_on.go
+++ b/pkg/util/tracing/span_finalizer_race_on.go
@@ -4,7 +4,6 @@
 // included in the /LICENSE file.
 
 //go:build race
-// +build race
 
 package tracing
 

--- a/pkg/util/uuid/fuzz.go
+++ b/pkg/util/uuid/fuzz.go
@@ -10,7 +10,6 @@
 // This code originated in github.com/gofrs/uuid.
 
 //go:build gofuzz
-// +build gofuzz
 
 package uuid
 


### PR DESCRIPTION
Remove uses of deprecated `+build` directive (in favor of `go:build`)
for packages inside util.

Informs: #116290
Release note: None