### PR TITLE
sql: check comparison operators correctly in cmpOpFixups

### DIFF
--- a/pkg/sql/sem/tree/eval.go
+++ b/pkg/sql/sem/tree/eval.go
@@ -1478,7 +1478,7 @@ func cmpOpFixups(
 	cmpOps map[treecmp.ComparisonOperatorSymbol]*CmpOpOverloads,
 ) map[treecmp.ComparisonOperatorSymbol]*CmpOpOverloads {
 	findVolatility := func(op treecmp.ComparisonOperatorSymbol, t *types.T) volatility.V {
-		for _, o := range cmpOps[treecmp.EQ].overloads {
+		for _, o := range cmpOps[op].overloads {
 			if o.LeftType.Equivalent(t) && o.RightType.Equivalent(t) {
 				return o.Volatility
 			}


### PR DESCRIPTION
Previously, we would return incorrect volatilities for different comparison operators as it would only iterate through `treecmp.EQ` overloads. This has now been fixed to properly check the correct comparison operator for its volatility.

Epic: None
Release note: None