### PR TITLE
kvclient: buffer blind writes on the client

### DIFF
--- a/pkg/kv/kvclient/kvcoord/BUILD.bazel
+++ b/pkg/kv/kvclient/kvcoord/BUILD.bazel
@@ -153,6 +153,7 @@ go_test(
         "txn_interceptor_pipeliner_test.go",
         "txn_interceptor_seq_num_allocator_test.go",
         "txn_interceptor_span_refresher_test.go",
+        "txn_interceptor_write_buffer_test.go",
         "txn_test.go",
         ":bufferedwrite_interval_btree_test.go",  # keep
         ":mock_kvcoord",  # keep

--- a/pkg/kv/kvclient/kvcoord/txn_coord_sender.go
+++ b/pkg/kv/kvclient/kvcoord/txn_coord_sender.go
@@ -505,7 +505,8 @@ func (tc *TxnCoordSender) Send(
 		return nil, pErr
 	}
 
-	if ba.IsSingleEndTxnRequest() && !tc.interceptorAlloc.txnPipeliner.hasAcquiredLocks() {
+	if ba.IsSingleEndTxnRequest() && !tc.interceptorAlloc.txnPipeliner.hasAcquiredLocks() &&
+		!tc.interceptorAlloc.txnWriteBuffer.hasBufferedWrites() {
 		return nil, tc.finalizeNonLockingTxnLocked(ctx, ba)
 	}
 

--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_pipeliner_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_pipeliner_test.go
@@ -35,6 +35,8 @@ import (
 // to SendLocked will return the default successful response.
 type mockLockedSender struct {
 	mockFn func(*kvpb.BatchRequest) (*kvpb.BatchResponse, *kvpb.Error)
+	// numCalled is the number of times the mock function has been called.
+	numCalled int
 }
 
 func (m *mockLockedSender) SendLocked(
@@ -45,6 +47,7 @@ func (m *mockLockedSender) SendLocked(
 		br.Txn = ba.Txn
 		return br, nil
 	}
+	m.numCalled++
 	return m.mockFn(ba)
 }
 
@@ -53,6 +56,11 @@ func (m *mockLockedSender) MockSend(
 	fn func(*kvpb.BatchRequest) (*kvpb.BatchResponse, *kvpb.Error),
 ) {
 	m.mockFn = fn
+}
+
+// NumCalled returns the number of times the mock function has been called.
+func (m *mockLockedSender) NumCalled() int {
+	return m.numCalled
 }
 
 // ChainMockSend sets a series of mocking functions on the mockLockedSender.

--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_write_buffer.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_write_buffer.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
 
 // BufferedWritesEnabled is used to enable write buffering.
@@ -23,13 +24,6 @@ var BufferedWritesEnabled = settings.RegisterBoolSetting(
 	settings.WithPublic,
 )
 
-// TODO(arul): calm down staticcheck for now. These should go away shortly.
-var _ = bufferedValue{}
-var _ = bufferedValue{}.val
-var _ = bufferedValue{}.seq
-var _ = bufferedWrite{}.vals
-var _ = txnWriteBuffer{}.buffer
-
 // txnWriteBuffer is a txnInterceptor that buffers transactional writes until
 // commit time. Moreover, it also decomposes read-write KV operations (e.g.
 // CPuts, InitPuts) into separate (locking) read and write operations, buffering
@@ -39,7 +33,7 @@ var _ = txnWriteBuffer{}.buffer
 //
 // 1. It allows for more batching of writes, which can be more efficient.
 // Instead of sending write batches one at a time, we can batch all write
-// batches and send the in a single batch at commit time. This is a win even if
+// batches and send them in a single batch at commit time. This is a win even if
 // writes would otherwise be pipelined through raft.
 //
 // 2. It allows for the elimination of redundant writes. If a client writes to
@@ -107,10 +101,15 @@ var _ = txnWriteBuffer{}.buffer
 // tradeoff. Flushing the entire buffer is simpler and frees up more memory.
 // Flushing the buffer partially preserves some (all but the fourth) of the
 // listed benefits of buffering writes for the unflushed portion of the buffer.
+//
+// TODO(arul): In various places below, there's potential to optimize things by
+// batch allocating misc objects and pre-allocating some slices.
 type txnWriteBuffer struct {
 	enabled bool
 
-	buffer btree // nolint:staticcheck
+	buffer        btree
+	bufferSeek    bufferedWrite // re-use while seeking
+	bufferIDAlloc uint64
 
 	wrapped lockedSender
 }
@@ -121,7 +120,96 @@ func (twb *txnWriteBuffer) SendLocked(
 	if !twb.enabled {
 		return twb.wrapped.SendLocked(ctx, ba)
 	}
-	panic("unimplemented")
+
+	if _, ok := ba.GetArg(kvpb.EndTxn); ok {
+		// TODO(arul): should we only flush if the transaction is being committed?
+		// If the transaction is being rolled back, we shouldn't needlessly flush
+		// writes.
+		return twb.flushWithEndTxn(ctx, ba)
+	}
+
+	transformedBa, ts := twb.applyTransformations(ctx, ba)
+
+	if len(transformedBa.Requests) == 0 {
+		// Lower layers (the DistSender and the KVServer) do not expect/handle empty
+		// batches. If all requests in the batch can be handled locally, and we're
+		// left with an empty batch after applying transformations, eschew sending
+		// anything to KV.
+		br := ba.CreateReply()
+		for i, t := range ts {
+			br.Responses[i] = t.toResp()
+		}
+		return br, nil
+	}
+
+	br, pErr := twb.wrapped.SendLocked(ctx, transformedBa)
+	if pErr != nil {
+		return nil, twb.adjustError(ctx, transformedBa, ts, pErr)
+	}
+
+	return twb.mergeResponseWithTransformations(ctx, ts, br), nil
+}
+
+// adjustError adjusts the provided error based on the transformations made by
+// the txnWriteBuffer to the batch request before sending it to KV.
+func (twb *txnWriteBuffer) adjustError(
+	ctx context.Context, ba *kvpb.BatchRequest, ts transformations, pErr *kvpb.Error,
+) *kvpb.Error {
+	// Fix the error index to hide the impact of any requests that were
+	// transformed.
+	if pErr.Index != nil {
+		// We essentially want to find the number of stripped batch requests that
+		// came before the request that caused the error in the original batch, and
+		// therefore weren't sent to the KV layer. We can then adjust the error
+		// index accordingly.
+		numStripped := int32(0)
+		numOriginalRequests := len(ba.Requests) + len(ts)
+		baIdx := int32(0)
+		for i := range numOriginalRequests {
+			if len(ts) > 0 && ts[0].index == i {
+				if ts[0].stripped {
+					numStripped++
+				} else {
+					// TODO(arul): If the error index points to a request that we've
+					// transformed, returning this back to the client is weird -- the
+					// client doesn't know we're making transformations. We should
+					// probably just log a warning and clear out the error index for such
+					// cases.
+					log.Fatal(ctx, "unhandled")
+				}
+				ts = ts[1:]
+				continue
+			}
+			if baIdx == pErr.Index.Index {
+				break
+			}
+			baIdx++
+		}
+
+		pErr.Index.Index += numStripped
+	}
+
+	return pErr
+}
+
+// adjustErrorUponFlush adjusts the provided error based on the number of
+// pre-fixed writes due to flushing the buffer.
+func (twb *txnWriteBuffer) adjustErrorUponFlush(
+	ctx context.Context, numBuffered int, pErr *kvpb.Error,
+) *kvpb.Error {
+	if pErr.Index != nil {
+		if pErr.Index.Index < int32(numBuffered) {
+			// If the error belongs to a request because part of the buffer flush, nil
+			// out the index.
+			log.Warningf(ctx, "error index %d is part of the buffer flush", pErr.Index.Index)
+			pErr.Index = nil
+		} else {
+			// Otherwise, adjust the error index to hide the impact of any flushed
+			// write requests.
+			pErr.Index.Index -= int32(numBuffered)
+		}
+	}
+	return pErr
 }
 
 // setWrapped implements the txnInterceptor interface.
@@ -151,6 +239,217 @@ func (twb *txnWriteBuffer) rollbackToSavepointLocked(ctx context.Context, s save
 
 // closeLocked implements the txnInterceptor interface.
 func (twb *txnWriteBuffer) closeLocked() {}
+
+// applyTransformations applies any applicable transformations to the supplied
+// batch request. In doing so, a new batch request with transformations applied
+// along with a list of transformations that were applied is returned. The
+// caller must handle these transformations on the response path.
+//
+// Some examples of transformations include:
+//
+// 1. Blind writes (Put/Delete requests) are stripped from the batch and
+// buffered locally.
+//
+// TODO(arul): Augment this comment as these expand.
+func (twb *txnWriteBuffer) applyTransformations(
+	ctx context.Context, ba *kvpb.BatchRequest,
+) (*kvpb.BatchRequest, transformations) {
+	baRemote := ba.ShallowCopy()
+	// TODO(arul): We could improve performance here by pre-allocating
+	// baRemote.Requests to the correct size by counting the number of Puts/Dels
+	// in ba.Requests. The same for the transformations slice. We could also
+	// allocate the right number of ResponseUnion, PutResponse, and DeleteResponse
+	// objects as well.
+	baRemote.Requests = nil
+
+	var ts transformations
+	for i, ru := range ba.Requests {
+		req := ru.GetInner()
+		switch t := req.(type) {
+		case *kvpb.PutRequest:
+			var ru kvpb.ResponseUnion
+			ru.MustSetInner(&kvpb.PutResponse{})
+			ts = append(ts, transformation{
+				stripped: true,
+				index:    i,
+				resp:     ru,
+			})
+			twb.addToBuffer(t.Key, t.Value, t.Sequence)
+
+		case *kvpb.DeleteRequest:
+			var ru kvpb.ResponseUnion
+			ru.MustSetInner(&kvpb.DeleteResponse{
+				// TODO(arul): We need to add a flag to DeleteRequests to indicate
+				// whether we care about the return value or not. If we do, we need to
+				// decompose the Delete into a read-write phase. Otherwise, we can
+				// consider the Delete a blind write, and return false here.
+				FoundKey: false,
+			})
+			ts = append(ts, transformation{
+				stripped: true,
+				index:    i,
+				resp:     ru,
+			})
+			twb.addToBuffer(t.Key, roachpb.Value{}, t.Sequence)
+
+		default:
+			baRemote.Requests = append(baRemote.Requests, ru)
+		}
+	}
+	return baRemote, ts
+}
+
+// mergeResponsesWithTransformations merges responses from the KV layer with the
+// transformations that were applied by the txnWriteBuffer before sending the
+// batch request. As a result, interceptors above the txnWriteBuffer remain
+// oblivious to its decision to buffer any writes.
+func (twb *txnWriteBuffer) mergeResponseWithTransformations(
+	ctx context.Context, ts transformations, br *kvpb.BatchResponse,
+) *kvpb.BatchResponse {
+	if ts.Empty() && br == nil {
+		log.Fatal(ctx, "unexpectedly found no transformations and no batch response")
+	} else if ts.Empty() {
+		return br
+	}
+
+	mergedResps := make([]kvpb.ResponseUnion, len(br.Responses)+len(ts))
+	for i := range mergedResps {
+		if len(ts) > 0 && ts[0].index == i {
+			// The transformation applies at this index.
+			mergedResps[i] = ts[0].toResp()
+			ts = ts[1:]
+
+			// TODO(arul): we'll also need to handle !transformation.stripped case here
+			// as well. In particular, if a transformation didn't strip the request,
+			// but instead modified it, we'll need to trim from br.Responses and trim
+			// the mergedResps slice -- we'd otherwise be overcounting.
+			continue
+		}
+
+		// No transformation applies at this index. Copy over the response as is.
+		mergedResps[i] = br.Responses[0]
+		br.Responses = br.Responses[1:]
+	}
+	br.Responses = mergedResps
+	return br
+}
+
+// transformation is a modification applied by the txnWriteBuffer on a batch
+// request that needs to be accounted for when returning the response.
+type transformation struct {
+	// stripped, if true, indicates that the request was stripped from the batch
+	// and never sent to the KV layer.
+	stripped bool
+	// index of the request in the original batch to which the transformation
+	// applies.
+	index int
+	// resp is locally produced response that needs to be merged with any
+	// responses returned by the KV layer. This is set for requests that can be
+	// evaluated locally (e.g. blind writes, reads that can be served entirely
+	// from the buffer). If non-empty, stripped must also be true.
+	resp kvpb.ResponseUnion
+}
+
+// toResp returns the response that should be added to the batch response as
+// a result of applying the transformation.
+func (t transformation) toResp() kvpb.ResponseUnion {
+	if t.stripped {
+		return t.resp
+	}
+
+	// This is only possible once we start decomposing read-write requests into
+	// separate bits.
+	panic("unimplemented")
+
+	// TODO(arul): in the future, when we'll evaluate CPuts locally, we'll have
+	// this function take in the result of the KVGet, save the CPut function
+	// locally on the transformation, and use these two things to evaluate the
+	// condition here, on the client. We'll then construct and return the
+	// appropriate response.
+}
+
+// transformations is a list of transformations applied by the txnWriteBuffer.
+type transformations []transformation
+
+func (t transformations) Empty() bool {
+	return len(t) == 0
+}
+
+// addToBuffer adds a write to the given key to the buffer.
+func (twb *txnWriteBuffer) addToBuffer(key roachpb.Key, val roachpb.Value, seq enginepb.TxnSeq) {
+	it := twb.buffer.MakeIter()
+	seek := &twb.bufferSeek
+	seek.key = key
+
+	it.FirstOverlap(seek)
+	if it.Valid() {
+		// We've already seen a write for this key.
+		bw := it.Cur()
+		bw.vals = append(bw.vals, bufferedValue{val: val, seq: seq})
+	} else {
+		twb.bufferIDAlloc++
+		twb.buffer.Set(&bufferedWrite{
+			id:   twb.bufferIDAlloc,
+			key:  key,
+			vals: []bufferedValue{{val: val, seq: seq}},
+		})
+	}
+}
+
+// flushWithEndTxn flushes all buffered writes to the KV layer along with the
+// EndTxn request. Responses from the flushing are stripped before returning.
+func (twb *txnWriteBuffer) flushWithEndTxn(
+	ctx context.Context, ba *kvpb.BatchRequest,
+) (*kvpb.BatchResponse, *kvpb.Error) {
+	numBuffered := twb.buffer.Len()
+	if numBuffered == 0 {
+		return twb.wrapped.SendLocked(ctx, ba) // nothing to flush
+	}
+	// Iterate over the buffered writes and flush all buffered writes to the KV
+	// layer by adding them to the batch.
+	//
+	// TODO(arul): If the batch request with the EndTxn request also contains an
+	// overlapping write to a key that's already in the buffer, we could exclude
+	// that write from the buffer.
+	reqs := make([]kvpb.RequestUnion, 0, numBuffered+len(ba.Requests))
+	it := twb.buffer.MakeIter()
+	for it.First(); it.Valid(); it.Next() {
+		reqs = append(reqs, it.Cur().toRequest())
+	}
+
+	ba = ba.ShallowCopy()
+	reqs = append(reqs, ba.Requests...)
+	ba.Requests = reqs
+
+	br, pErr := twb.wrapped.SendLocked(ctx, ba)
+	if pErr != nil {
+		return nil, twb.adjustErrorUponFlush(ctx, numBuffered, pErr)
+	}
+	// Strip out responses for all the flushed buffered writes.
+	br.Responses = br.Responses[numBuffered:]
+	return br, nil
+}
+
+// hasBufferedWrites returns whether the interceptor has buffered any writes
+// locally.
+func (twb *txnWriteBuffer) hasBufferedWrites() bool {
+	return twb.buffer.Len() > 0
+}
+
+// testingBufferedWritesAsSlice returns all buffered writes, in key order, as a
+// slice.
+func (twb *txnWriteBuffer) testingBufferedWritesAsSlice() []bufferedWrite {
+	var writes []bufferedWrite
+	it := twb.buffer.MakeIter()
+	for it.First(); it.Valid(); it.Next() {
+		bw := *it.Cur()
+		// Scrub the id/endKey for the benefit of tests.
+		bw.id = 0
+		bw.endKey = nil
+		writes = append(writes, bw)
+	}
+	return writes
+}
 
 // bufferedWrite is a buffered write operation to a given key. It maps a key to
 // possibly multiple values[1], each with an associated sequence number.
@@ -184,3 +483,40 @@ func (bw *bufferedWrite) New() *bufferedWrite { return new(bufferedWrite) }
 func (bw *bufferedWrite) SetID(v uint64)      { bw.id = v }
 func (bw *bufferedWrite) SetKey(v []byte)     { bw.key = v }
 func (bw *bufferedWrite) SetEndKey(v []byte)  { bw.endKey = v }
+
+func (bw *bufferedWrite) toRequest() kvpb.RequestUnion {
+	var ru kvpb.RequestUnion
+	// A key may be written to multiple times during the course of a transaction.
+	// However, when flushing to KV, we only need to flush the most recent write
+	// (read: the one with the highest sequence number). As we store values in
+	// increasing sequence number order, this should be the last value in the
+	// slice.
+	val := bw.vals[len(bw.vals)-1]
+	if val.val.IsPresent() {
+		// TODO(arul): we could allocate PutRequest objects all at once when we're
+		// about to flush the buffer. We'll probably want to keep track of the
+		// number of each request type in the btree to avoid iterating and counting
+		// each request type.
+		//
+		// TODO(arul): should we use a sync.Pool here?
+		putAlloc := new(struct {
+			put   kvpb.PutRequest
+			union kvpb.RequestUnion_Put
+		})
+		putAlloc.put.Key = bw.key
+		putAlloc.put.Value = val.val
+		putAlloc.put.Sequence = val.seq
+		putAlloc.union.Put = &putAlloc.put
+		ru.Value = &putAlloc.union
+	} else {
+		delAlloc := new(struct {
+			del   kvpb.DeleteRequest
+			union kvpb.RequestUnion_Delete
+		})
+		delAlloc.del.Key = bw.key
+		delAlloc.del.Sequence = val.seq
+		delAlloc.union.Delete = &delAlloc.del
+		ru.Value = &delAlloc.union
+	}
+	return ru
+}

--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_write_buffer_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_write_buffer_test.go
@@ -1,0 +1,467 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package kvcoord
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/require"
+)
+
+func makeMockTxnWriteBuffer() (txnWriteBuffer, *mockLockedSender) {
+	mockSender := &mockLockedSender{}
+	return txnWriteBuffer{
+		enabled: true,
+		wrapped: mockSender,
+	}, mockSender
+}
+
+func putArgs(key roachpb.Key, value string, seq enginepb.TxnSeq) *kvpb.PutRequest {
+	return &kvpb.PutRequest{
+		RequestHeader: kvpb.RequestHeader{Key: key, Sequence: seq},
+		Value:         roachpb.MakeValueFromString(value),
+	}
+}
+
+func delArgs(key roachpb.Key, seq enginepb.TxnSeq) *kvpb.DeleteRequest {
+	return &kvpb.DeleteRequest{
+		RequestHeader: kvpb.RequestHeader{Key: key, Sequence: seq},
+	}
+}
+
+func makeBufferedWrite(key roachpb.Key, vals ...bufferedValue) bufferedWrite {
+	return bufferedWrite{key: key, vals: vals}
+}
+
+func makeBufferedValue(value string, seq enginepb.TxnSeq) bufferedValue {
+	val := roachpb.MakeValueFromString(value)
+	if value == "" {
+		// Special handling to denote Deletes.
+		val = roachpb.Value{}
+	}
+	return bufferedValue{val: val, seq: seq}
+}
+
+// TestTxnWriteBufferBuffersBlindWrites tests that the txnWriteBuffer correctly
+// buffers blind writes (Put/Del requests). Other than the basic case, it tests
+// that multiple writes to the same key are stored correctly.
+func TestTxnWriteBufferBuffersBlindWrites(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+	twb, mockSender := makeMockTxnWriteBuffer()
+
+	txn := makeTxnProto()
+	txn.Sequence = 1
+	keyA, keyB, keyC := roachpb.Key("a"), roachpb.Key("b"), roachpb.Key("c")
+
+	// Blindly write to some keys.
+	ba := &kvpb.BatchRequest{}
+	ba.Header = kvpb.Header{Txn: &txn}
+	putA := putArgs(keyA, "valA", txn.Sequence)
+	putB := putArgs(keyB, "valB", txn.Sequence)
+	delC := delArgs(keyC, txn.Sequence)
+	ba.Add(putA, putB, delC)
+
+	numCalled := mockSender.NumCalled()
+	br, pErr := twb.SendLocked(ctx, ba)
+	require.Nil(t, pErr)
+	require.NotNil(t, br)
+	// All the requests should be buffered and not make it past the
+	// txnWriteBuffer.
+	require.Equal(t, numCalled, mockSender.NumCalled())
+	// Even though the txnWriteBuffer did not send any Put requests to the KV
+	// layer above, the responses should still be populated.
+	require.Len(t, br.Responses, 3)
+	require.Equal(t, br.Responses[0].GetInner(), &kvpb.PutResponse{})
+	require.Equal(t, br.Responses[1].GetInner(), &kvpb.PutResponse{})
+	require.Equal(t, br.Responses[2].GetInner(), &kvpb.DeleteResponse{})
+
+	// Verify the writes were buffered correctly.
+	expBufferedWrites := []bufferedWrite{
+		makeBufferedWrite(keyA, makeBufferedValue("valA", 1)),
+		makeBufferedWrite(keyB, makeBufferedValue("valB", 1)),
+		makeBufferedWrite(keyC, makeBufferedValue("", 1)),
+	}
+	require.Equal(t, expBufferedWrites, twb.testingBufferedWritesAsSlice())
+
+	// Commit the transaction and ensure that the buffer is correctly flushed.
+	ba = &kvpb.BatchRequest{}
+	ba.Header = kvpb.Header{Txn: &txn}
+	ba.Add(&kvpb.EndTxnRequest{Commit: true})
+
+	mockSender.MockSend(func(ba *kvpb.BatchRequest) (*kvpb.BatchResponse, *kvpb.Error) {
+		require.Len(t, ba.Requests, 4)
+
+		// We now expect the buffer to be flushed along with the commit.
+		require.IsType(t, &kvpb.PutRequest{}, ba.Requests[0].GetInner())
+		require.IsType(t, &kvpb.PutRequest{}, ba.Requests[1].GetInner())
+		require.IsType(t, &kvpb.DeleteRequest{}, ba.Requests[2].GetInner())
+		require.IsType(t, &kvpb.EndTxnRequest{}, ba.Requests[3].GetInner())
+
+		br = ba.CreateReply()
+		br.Txn = ba.Txn
+		return br, nil
+	})
+
+	br, pErr = twb.SendLocked(ctx, ba)
+	require.Nil(t, pErr)
+	require.NotNil(t, br)
+
+	// Even though we flushed the buffer, responses from the blind writes should
+	// not be returned.
+	require.Len(t, br.Responses, 1)
+	require.IsType(t, &kvpb.EndTxnResponse{}, br.Responses[0].GetInner())
+}
+
+// TestTxnWriteBufferWritesToSameKey ensures that writes to the same key are
+// all buffered as expected, but at commit time, only the final write (the one
+// with the highest sequence number) is flushed to KV.
+func TestTxnWriteBufferWritesToSameKey(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+	twb, mockSender := makeMockTxnWriteBuffer()
+
+	txn := makeTxnProto()
+	txn.Sequence = 1
+	keyA := roachpb.Key("a")
+
+	// Perform blind writes to keyA multiple times.
+	ba := &kvpb.BatchRequest{}
+	ba.Header = kvpb.Header{Txn: &txn}
+	putA := putArgs(keyA, "val1", txn.Sequence)
+	ba.Add(putA)
+
+	numCalledBefore := mockSender.NumCalled()
+	br, pErr := twb.SendLocked(ctx, ba)
+	require.Nil(t, pErr)
+	require.NotNil(t, br)
+	// The request shouldn't make it past the txnWriteBuffer as there's only one
+	// Put, which should be buffered.
+	require.Equal(t, numCalledBefore, mockSender.NumCalled())
+
+	// Even though the txnWriteBuffer did not send any Put requests to the KV
+	// layer above, the responses should still be populated.
+	require.Len(t, br.Responses, 1)
+	require.Equal(t, br.Responses[0].GetInner(), &kvpb.PutResponse{})
+
+	// Verify the write was buffered correctly.
+	expBufferedWrites := []bufferedWrite{
+		makeBufferedWrite(keyA, makeBufferedValue("val1", 1)),
+	}
+	require.Equal(t, expBufferedWrites, twb.testingBufferedWritesAsSlice())
+
+	// Write to keyA again at a higher sequence number.
+	txn.Sequence++
+	ba = &kvpb.BatchRequest{}
+	ba.Header = kvpb.Header{Txn: &txn}
+	putA = putArgs(keyA, "val2", txn.Sequence)
+	ba.Add(putA)
+
+	numCalledBefore = mockSender.NumCalled()
+	br, pErr = twb.SendLocked(ctx, ba)
+	require.Nil(t, pErr)
+	require.NotNil(t, br)
+	// The Put request shouldn't make it past the txnWriteBuffer.
+	require.Equal(t, numCalledBefore, mockSender.NumCalled())
+
+	// Again, there should be a response, even though we didn't send a KV request.
+	require.Len(t, br.Responses, 1)
+	require.Equal(t, br.Responses[0].GetInner(), &kvpb.PutResponse{})
+
+	// Verify the buffer is correctly updated.
+	expBufferedWrites = []bufferedWrite{
+		makeBufferedWrite(keyA,
+			makeBufferedValue("val1", 1), makeBufferedValue("val2", 2),
+		),
+	}
+	require.Equal(t, expBufferedWrites, twb.testingBufferedWritesAsSlice())
+
+	// Commit the transaction and ensure that only the write at sequence number 2
+	// is flushed.
+	ba = &kvpb.BatchRequest{}
+	ba.Header = kvpb.Header{Txn: &txn}
+	ba.Add(&kvpb.EndTxnRequest{Commit: true})
+
+	mockSender.MockSend(func(ba *kvpb.BatchRequest) (*kvpb.BatchResponse, *kvpb.Error) {
+		require.Len(t, ba.Requests, 2)
+
+		// We now expect the buffer to be flushed along with the commit. Instead of
+		// both the writes to keyA, only the final one should be sent to the KV
+		// layer.
+		require.IsType(t, &kvpb.PutRequest{}, ba.Requests[0].GetInner())
+		require.Equal(t, enginepb.TxnSeq(2), ba.Requests[0].GetInner().(*kvpb.PutRequest).Sequence)
+		require.Equal(t, roachpb.MakeValueFromString("val2"), ba.Requests[0].GetInner().(*kvpb.PutRequest).Value)
+
+		require.IsType(t, &kvpb.EndTxnRequest{}, ba.Requests[1].GetInner())
+
+		br = ba.CreateReply()
+		br.Txn = ba.Txn
+		return br, nil
+	})
+
+	br, pErr = twb.SendLocked(ctx, ba)
+	require.Nil(t, pErr)
+	require.NotNil(t, br)
+
+	// Even though we flushed the buffer, responses from the blind writes should
+	// not be returned.
+	require.Len(t, br.Responses, 1)
+	require.IsType(t, &kvpb.EndTxnResponse{}, br.Responses[0].GetInner())
+}
+
+// TestTxnWriteBufferBlindWritesIncludingOtherRequests tests that the
+// txnWriteBuffer behaves correctly when a batch request contains both blind
+// writes and other requests that will not be transformed. In the future, we may
+// want to extend this test to include read-write requests as well.
+func TestTxnWriteBufferBlindWritesIncludingOtherRequests(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+	twb, mockSender := makeMockTxnWriteBuffer()
+
+	txn := makeTxnProto()
+	txn.Sequence = 1
+	keyA, keyB, keyC, keyD, keyE := roachpb.Key("a"), roachpb.Key("b"), roachpb.Key("c"),
+		roachpb.Key("d"), roachpb.Key("e")
+
+	// Construct a batch that includes both blind writes and other requests.
+	ba := &kvpb.BatchRequest{}
+	ba.Header = kvpb.Header{Txn: &txn}
+	putA := putArgs(keyA, "val1", txn.Sequence)
+	getB := &kvpb.GetRequest{RequestHeader: kvpb.RequestHeader{Key: keyB}}
+	delC := delArgs(keyC, txn.Sequence)
+	scanDE := &kvpb.ScanRequest{RequestHeader: kvpb.RequestHeader{Key: keyD, EndKey: keyE}}
+	ba.Add(putA)
+	ba.Add(getB)
+	ba.Add(delC)
+	ba.Add(scanDE)
+
+	mockSender.MockSend(func(ba *kvpb.BatchRequest) (*kvpb.BatchResponse, *kvpb.Error) {
+		require.Len(t, ba.Requests, 2)
+		require.IsType(t, &kvpb.GetRequest{}, ba.Requests[0].GetInner())
+		require.IsType(t, &kvpb.ScanRequest{}, ba.Requests[1].GetInner())
+
+		br := ba.CreateReply()
+		br.Txn = ba.Txn
+		return br, nil
+	})
+
+	br, pErr := twb.SendLocked(ctx, ba)
+	require.Nil(t, pErr)
+	require.NotNil(t, br)
+
+	// Expect 4 responses, even though only 2 KV requests were sent. Moreover,
+	// ensure that the responses are in the correct order.
+	require.Len(t, br.Responses, 4)
+	require.Equal(t, br.Responses[0].GetInner(), &kvpb.PutResponse{})
+	require.Equal(t, br.Responses[1].GetInner(), &kvpb.GetResponse{})
+	require.Equal(t, br.Responses[2].GetInner(), &kvpb.DeleteResponse{})
+	require.Equal(t, br.Responses[3].GetInner(), &kvpb.ScanResponse{})
+
+	// Verify the writes were buffered correctly.
+	expBufferedWrites := []bufferedWrite{
+		makeBufferedWrite(keyA, makeBufferedValue("val1", 1)),
+		makeBufferedWrite(keyC, makeBufferedValue("", 1)),
+	}
+	require.Equal(t, expBufferedWrites, twb.testingBufferedWritesAsSlice())
+
+	// Commit the transaction and ensure that the buffer is correctly flushed.
+	ba = &kvpb.BatchRequest{}
+	ba.Header = kvpb.Header{Txn: &txn}
+	ba.Add(&kvpb.EndTxnRequest{Commit: true})
+
+	mockSender.MockSend(func(ba *kvpb.BatchRequest) (*kvpb.BatchResponse, *kvpb.Error) {
+		require.Len(t, ba.Requests, 3)
+
+		// We now expect the buffer to be flushed along with the commit.
+		require.IsType(t, &kvpb.PutRequest{}, ba.Requests[0].GetInner())
+		require.IsType(t, &kvpb.DeleteRequest{}, ba.Requests[1].GetInner())
+		require.IsType(t, &kvpb.EndTxnRequest{}, ba.Requests[2].GetInner())
+
+		br = ba.CreateReply()
+		br.Txn = ba.Txn
+		return br, nil
+	})
+
+	br, pErr = twb.SendLocked(ctx, ba)
+	require.Nil(t, pErr)
+	require.NotNil(t, br)
+}
+
+// TestTxnWriteBufferCorrectlyAdjustsFlushErrors ensures that the txnWriteBuffer
+// correctly adjusts the index of the error returned upon flushing the buffer.
+// In particular, if the error belongs to a flushed write, the index is nil-ed
+// out. Otherwise, the index is adjusted to hide the flushed writes.
+func TestTxnWriteBufferCorrectlyAdjustsFlushErrors(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	twb, mockSender := makeMockTxnWriteBuffer()
+
+	txn := makeTxnProto()
+	txn.Sequence = 1
+	keyA, keyB, keyC := roachpb.Key("a"), roachpb.Key("b"), roachpb.Key("c")
+
+	// Perform some blind writes.
+	ba := &kvpb.BatchRequest{}
+	ba.Header = kvpb.Header{Txn: &txn}
+	putA := putArgs(keyA, "val1", txn.Sequence)
+	getB := &kvpb.GetRequest{RequestHeader: kvpb.RequestHeader{Key: keyB}}
+	delC := delArgs(keyC, txn.Sequence)
+	ba.Add(putA)
+	ba.Add(getB)
+	ba.Add(delC)
+
+	mockSender.MockSend(func(ba *kvpb.BatchRequest) (*kvpb.BatchResponse, *kvpb.Error) {
+		require.Len(t, ba.Requests, 1)
+		require.IsType(t, &kvpb.GetRequest{}, ba.Requests[0].GetInner())
+
+		br := ba.CreateReply()
+		br.Txn = ba.Txn
+		return br, nil
+	})
+
+	br, pErr := twb.SendLocked(ctx, ba)
+	require.Nil(t, pErr)
+	require.NotNil(t, br)
+
+	for errIdx, resErrIdx := range map[int32]int32{
+		0: -1, // points to the Put; -1 to denote nil
+		1: -1, // points to the Del; -1 to denote nil
+		2: 0,  // points to the Get
+		3: 1,  // points to the EndTxn
+	} {
+		t.Run(fmt.Sprintf("errIdx=%d", errIdx), func(t *testing.T) {
+			// Commit the transaction. This should flush the buffer as well.
+			ba = &kvpb.BatchRequest{}
+			ba.Header = kvpb.Header{Txn: &txn}
+			ba.Add(getB)
+			ba.Add(&kvpb.EndTxnRequest{Commit: true})
+
+			mockSender.MockSend(func(ba *kvpb.BatchRequest) (*kvpb.BatchResponse, *kvpb.Error) {
+				require.Len(t, ba.Requests, 4)
+				require.IsType(t, &kvpb.PutRequest{}, ba.Requests[0].GetInner())
+				require.IsType(t, &kvpb.DeleteRequest{}, ba.Requests[1].GetInner())
+				require.IsType(t, &kvpb.GetRequest{}, ba.Requests[2].GetInner())
+				require.IsType(t, &kvpb.EndTxnRequest{}, ba.Requests[3].GetInner())
+
+				pErr := kvpb.NewErrorWithTxn(errors.New("boom"), &txn)
+				pErr.SetErrorIndex(errIdx)
+				return nil, pErr
+			})
+
+			br, pErr := twb.SendLocked(ctx, ba)
+			require.Nil(t, br)
+			require.NotNil(t, pErr)
+			require.Equal(t, &txn, pErr.GetTxn())
+
+			if resErrIdx == -1 {
+				require.Nil(t, pErr.Index)
+			} else {
+				require.NotNil(t, pErr.Index)
+				require.Equal(t, resErrIdx, pErr.Index.Index)
+			}
+		})
+	}
+}
+
+// TestTxnWriteBufferCorrectlyAdjustsErrorsAfterBuffering ensures that the
+// txnWriteBuffer correctly adjusts the index of the errors returned when a part
+// of the batch is buffered on the client.
+//
+// TODO(arul): extend this test to transformations as well once we start
+// transforming read-write requests into separate bits.
+func TestTxnWriteBufferCorrectlyAdjustsErrorsAfterBuffering(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	twb, mockSender := makeMockTxnWriteBuffer()
+
+	txn := makeTxnProto()
+	txn.Sequence = 1
+	keyA, keyB, keyC, keyD, keyE, keyF := roachpb.Key("a"), roachpb.Key("b"), roachpb.Key("c"),
+		roachpb.Key("d"), roachpb.Key("e"), roachpb.Key("f")
+
+	for errIdx, resErrIdx := range map[int32]int32{
+		0: 1, // points to the GetB
+		1: 4, // points to the GetE
+		2: 5, // points to the GetF
+	} {
+		t.Run(fmt.Sprintf("errIdx=%d", errIdx), func(t *testing.T) {
+			// Construct a batch request where some of the requests will be buffered.
+			ba := &kvpb.BatchRequest{}
+			ba.Header = kvpb.Header{Txn: &txn}
+			putA := putArgs(keyA, "val1", txn.Sequence)
+			getB := &kvpb.GetRequest{RequestHeader: kvpb.RequestHeader{Key: keyB}}
+			delC := delArgs(keyC, txn.Sequence)
+			putD := putArgs(keyD, "val2", txn.Sequence)
+			getE := &kvpb.GetRequest{RequestHeader: kvpb.RequestHeader{Key: keyE}}
+			getF := &kvpb.GetRequest{RequestHeader: kvpb.RequestHeader{Key: keyF}}
+
+			ba.Add(putA)
+			ba.Add(getB)
+			ba.Add(delC)
+			ba.Add(putD)
+			ba.Add(getE)
+			ba.Add(getF)
+
+			mockSender.MockSend(func(ba *kvpb.BatchRequest) (*kvpb.BatchResponse, *kvpb.Error) {
+				require.Len(t, ba.Requests, 3)
+				require.IsType(t, &kvpb.GetRequest{}, ba.Requests[0].GetInner())
+				require.IsType(t, &kvpb.GetRequest{}, ba.Requests[1].GetInner())
+				require.IsType(t, &kvpb.GetRequest{}, ba.Requests[2].GetInner())
+
+				pErr := kvpb.NewErrorWithTxn(errors.New("boom"), &txn)
+				pErr.SetErrorIndex(errIdx)
+				return nil, pErr
+			})
+
+			br, pErr := twb.SendLocked(ctx, ba)
+			require.Nil(t, br)
+			require.NotNil(t, pErr)
+			require.Equal(t, &txn, pErr.GetTxn())
+
+			require.NotNil(t, pErr.Index)
+			require.Equal(t, resErrIdx, pErr.Index.Index)
+		})
+
+		// Finish off the test by commiting the transaction and sanity checking the
+		// buffer is flushed as expected.
+		ba := &kvpb.BatchRequest{}
+		ba.Header = kvpb.Header{Txn: &txn}
+		ba.Add(&kvpb.EndTxnRequest{Commit: true})
+
+		mockSender.MockSend(func(ba *kvpb.BatchRequest) (*kvpb.BatchResponse, *kvpb.Error) {
+			require.Len(t, ba.Requests, 4)
+
+			// We now expect the buffer to be flushed along with the commit.
+			require.IsType(t, &kvpb.PutRequest{}, ba.Requests[0].GetInner())
+			require.IsType(t, &kvpb.DeleteRequest{}, ba.Requests[1].GetInner())
+			require.IsType(t, &kvpb.PutRequest{}, ba.Requests[2].GetInner())
+			require.IsType(t, &kvpb.EndTxnRequest{}, ba.Requests[3].GetInner())
+
+			br := ba.CreateReply()
+			br.Txn = ba.Txn
+			return br, nil
+		})
+
+		br, pErr := twb.SendLocked(ctx, ba)
+		require.Nil(t, pErr)
+		require.NotNil(t, br)
+	}
+}

--- a/pkg/kv/kvclient/kvcoord/txn_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_test.go
@@ -1526,3 +1526,98 @@ func TestTxnPreparedWriteReadConflict(t *testing.T) {
 		}
 	}
 }
+
+// TestTxnBasicBufferedWrites verifies that a simple buffered writes transaction
+// can be run and committed. Moreover, it verifies that the transaction's writes
+// are only observed iff it commits.
+func TestTxnBasicBufferedWrites(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	s := createTestDB(t)
+	defer s.Stop()
+
+	testutils.RunTrueAndFalse(t, "commit", func(t *testing.T, commit bool) {
+		value1 := []byte("value1")
+		value2 := []byte("value2")
+
+		keyA := []byte("keyA")
+		keyB := []byte("keyB")
+
+		ctx := context.Background()
+		err := s.DB.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+			txn.SetBufferedWritesEnabled(true)
+
+			// Put transactional value.
+			if err := txn.Put(ctx, keyA, value1); err != nil {
+				return err
+			}
+
+			// Attempt to read in another txn.
+			conflictTxn := kv.NewTxn(ctx, s.DB, 0 /* gatewayNodeID */)
+			conflictTxn.TestingSetPriority(enginepb.MinTxnPriority)
+			if gr, err := conflictTxn.Get(ctx, keyA); err != nil {
+				return err
+			} else if gr.Exists() {
+				return errors.Errorf("expected nil value; got %v", gr.Value)
+			}
+
+			// Read within the transaction.
+			if gr, err := txn.Get(ctx, keyA); err != nil {
+				return err
+			} else if gr.Exists() {
+				// TODO(arul): this isn't correct yet because we're not serving
+				// read-your-own-writes from the buffer.
+				return errors.Errorf("expected nil value; got %v", gr.Value)
+			}
+
+			// TODO(arul): we should be able to uncomment this once
+			// https://github.com/cockroachdb/cockroach/issues/139054 is addressed.
+			// else if !gr.Exists() || !bytes.Equal(gr.ValueBytes(), value) {
+			//	return errors.Errorf("expected value %q; got %q", value, gr.Value)
+			//}
+
+			// Write to keyB two times. Only the last write should be visible once the
+			// transaction commits.
+			if err := txn.Put(ctx, keyB, value1); err != nil {
+				return err
+			}
+			if err := txn.Put(ctx, keyB, value2); err != nil {
+				return err
+			}
+
+			if commit {
+				return nil
+			} else {
+				return errors.New("abort")
+			}
+		})
+
+		if commit {
+			require.NoError(t, err)
+		} else {
+			require.Error(t, err)
+			testutils.IsError(err, "abort")
+		}
+
+		// Verify the values are visible only if the transaction committed.
+		gr, err := s.DB.Get(ctx, keyA)
+		require.NoError(t, err)
+
+		if commit {
+			require.True(t, gr.Exists())
+			require.Equal(t, value1, gr.ValueBytes())
+		} else {
+			require.False(t, gr.Exists())
+		}
+
+		gr, err = s.DB.Get(ctx, keyB)
+		require.NoError(t, err)
+
+		if commit {
+			require.True(t, gr.Exists())
+			require.Equal(t, value2, gr.ValueBytes()) // value2 is the final value
+		} else {
+			require.False(t, gr.Exists())
+		}
+	})
+}


### PR DESCRIPTION
This patch adds logic to buffer blind writes (Puts or Deletes) in the
txnWriteBuffer. Interceptors and layers above remain oblivious to the
txnWriteBuffer's decision to buffer any writes.

All buffered writes are flushed at commit time, in the same batch as
the EndTxn request. This flushing at commit time is also hidden from
interceptors above the txnWriteBuffer by stripping responses on the
return path.

The code structure here allows us to split a batch request into
different bits, where some portion is evaluated locally and the rest
is sent to the KV layer. It's written with a future where we split
read-write requests (e.g. CPuts) into separte read/write halves, where
the read portion needs to be evaluated at the leaseholder, but the write
needs to be buffered.

Closes https://github.com/cockroachdb/cockroach/issues/139053

Release note: None