### PR TITLE
builtins: improve TestGetSSTableMetricsMultiNode

### DIFF
--- a/pkg/kv/kvclient/kvcoord/transport_race.go
+++ b/pkg/kv/kvclient/kvcoord/transport_race.go
@@ -74,7 +74,7 @@ func (tr raceTransport) SendNext(
 // GRPCTransportFactory during race builds wraps the implementation and
 // intercepts all BatchRequests, reading them asynchronously in a tight loop.
 // This allows the race detector to catch any mutations of a batch passed to the
-// transport. The dealio is that batches passed to the transport are immutable -
+// transport. The dealio is that batches passed to these transport are immutable -
 // the server is not allowed to mutate anything and this transport makes sure
 // they don't. See client.Sender() for more.
 //

--- a/pkg/sql/sem/builtins/generator_builtins_test.go
+++ b/pkg/sql/sem/builtins/generator_builtins_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
-	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
@@ -63,18 +62,13 @@ func TestGetSSTableMetricsMultiNode(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
-	st := cluster.MakeTestingClusterSettings()
-	tc := serverutils.StartCluster(t, 3, base.TestClusterArgs{
-		ServerArgs: base.TestServerArgs{
-			Settings: st,
-		},
-	})
+	tc := serverutils.StartCluster(t, 3, base.TestClusterArgs{})
 	defer tc.Stopper().Stop(ctx)
 
 	sqlDB := sqlutils.MakeSQLRunner(tc.ServerConn(0))
 
 	sqlDB.Exec(t, `CREATE TABLE t(k INT PRIMARY KEY, v INT)`)
-	sqlDB.Exec(t, `INSERT INTO t SELECT i, i*10 FROM generate_series(1, 10000) AS g(i)`)
+	sqlDB.Exec(t, `INSERT INTO t SELECT i, i*10 FROM generate_series(1, 100) AS g(i)`)
 
 	sqlDB.Exec(t, `CREATE TABLE b(k STRING PRIMARY KEY)`)
 	sqlDB.Exec(t, `INSERT INTO b VALUES('abc')`)
@@ -83,7 +77,6 @@ func TestGetSSTableMetricsMultiNode(t *testing.T) {
 
 	require.NoError(t, tc.WaitForFullReplication())
 
-	count := 0
 	var nodeID int
 	var storeID int
 	var level int
@@ -119,15 +112,19 @@ func TestGetSSTableMetricsMultiNode(t *testing.T) {
 			(SELECT raw_end_key FROM [SHOW RANGES FROM TABLE t WITH KEYS] LIMIT 1))`,
 			nodeIDArg, storeIDArg))
 
+		count := 0
 		for rows.Next() {
 			require.NoError(t, rows.Scan(&nodeID, &storeID, &level, &fileNum, &approximateSpanBytes, &metrics))
+			t.Logf("n%d s%d, table: t, level: %d  fileNum: %d  approximateSpanBytes: %d  metrics: %s",
+				nodeID, storeID, level, fileNum, approximateSpanBytes, string(metrics))
 			require.NoError(t, json.Unmarshal(metrics, &enginepb.SSTableMetricsInfo{}))
 			require.Equal(t, nodeID, nodeIDArg)
 			require.Equal(t, storeID, storeIDArg)
-			require.NotEqual(t, fileNum, 0)
-			require.NotEqual(t, approximateSpanBytes, 0)
+			require.NotZero(t, fileNum)
+			require.NotZero(t, approximateSpanBytes)
 			count++
 		}
+		require.Equal(t, 1, count, "nodeID: %d", nodeIDArg)
 
 		rows = sqlDB.Query(t, fmt.Sprintf(`
 		SELECT * FROM crdb_internal.sstable_metrics(
@@ -136,17 +133,20 @@ func TestGetSSTableMetricsMultiNode(t *testing.T) {
 		(SELECT raw_end_key FROM [SHOW RANGES FROM TABLE b WITH KEYS] LIMIT 1))`,
 			nodeIDArg, storeIDArg))
 
+		count = 0
 		for rows.Next() {
 			require.NoError(t, rows.Scan(&nodeID, &storeID, &level, &fileNum, &approximateSpanBytes, &metrics))
+			t.Logf("n%d s%d, table: b, level: %d  fileNum: %d  approximateSpanBytes: %d  metrics: %s",
+				nodeID, storeID, level, fileNum, approximateSpanBytes, string(metrics))
 			require.NoError(t, json.Unmarshal(metrics, &enginepb.SSTableMetricsInfo{}))
 			require.Equal(t, nodeID, nodeIDArg)
 			require.Equal(t, storeID, storeIDArg)
-			require.NotEqual(t, fileNum, 0)
+			require.NotZero(t, fileNum)
+			require.NotZero(t, approximateSpanBytes)
 			count++
 		}
+		require.Equal(t, 1, count, "nodeID: %d", nodeIDArg)
 	}
-
-	require.Equal(t, 6, count)
 }
 
 func TestGetSSTableMetricsSingleNode(t *testing.T) {


### PR DESCRIPTION
The test fails sometimes in race mode. Logs show that things are very
slow and various things happen in the cluster and not all three nodes
have a replica of each table when the test expects it.

This change reduces the size of a table, improves the count check (to
produce a more specific error) and adds logs.

Informs: #139023
Release note: None