### PR TITLE
drtprod: support for remote execution

### DIFF
--- a/pkg/cmd/drtprod/cli/commands/BUILD.bazel
+++ b/pkg/cmd/drtprod/cli/commands/BUILD.bazel
@@ -11,10 +11,15 @@ go_library(
     deps = [
         "//pkg/build",
         "//pkg/cmd/drtprod/helpers",
+        "//pkg/roachprod",
+        "//pkg/roachprod/config",
+        "//pkg/roachprod/install",
         "//pkg/util/syncutil",
+        "@com_github_cockroachdb_errors//:errors",
         "@com_github_spf13_cobra//:cobra",
         "@in_gopkg_yaml_v2//:yaml_v2",
         "@org_golang_x_exp//maps",
+        "@org_golang_x_sync//errgroup",
     ],
 )
 
@@ -22,5 +27,10 @@ go_test(
     name = "commands_test",
     srcs = ["yamlprocessor_test.go"],
     embed = [":commands"],
-    deps = ["@com_github_stretchr_testify//require"],
+    deps = [
+        "//pkg/roachprod/install",
+        "//pkg/roachprod/logger",
+        "//pkg/util/syncutil",
+        "@com_github_stretchr_testify//require",
+    ],
 )

--- a/pkg/cmd/drtprod/cli/commands/yamlprocessor.go
+++ b/pkg/cmd/drtprod/cli/commands/yamlprocessor.go
@@ -7,16 +7,24 @@ package commands
 
 import (
 	"context"
+	_ "embed"
 	"fmt"
 	"os"
+	"os/exec"
+	"path/filepath"
 	"slices"
 	"strings"
 	"sync"
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/drtprod/helpers"
+	"github.com/cockroachdb/cockroach/pkg/roachprod"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/config"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/errors"
 	"github.com/spf13/cobra"
 	"golang.org/x/exp/maps"
+	"golang.org/x/sync/errgroup"
 	"gopkg.in/yaml.v2"
 )
 
@@ -28,13 +36,24 @@ const (
 	targetResultFailure              // the target has failed
 )
 
-// commandExecutor is responsible for executing the shell commands
-var commandExecutor = helpers.ExecuteCmdWithPrefix
+var (
+	// commandExecutor is responsible for executing the shell commands
+	commandExecutor = helpers.ExecuteCmdWithPrefix
+
+	// roachprodRun executes roachprod.Run. This helps in unit tests
+	roachprodRun = roachprod.Run
+
+	// roachprodPut executes roachprod.Put. This helps in unit tests
+	roachprodPut = roachprod.Put
+
+	drtprodLocation = "artifacts/drtprod"
+)
 
 // GetYamlProcessor creates a new Cobra command for processing a YAML file.
 // The command expects a YAML file as an argument and runs the commands defined in it.
 func GetYamlProcessor(ctx context.Context) *cobra.Command {
 	displayOnly := false
+	remoteConfigYaml := ""
 	userProvidedTargetNames := make([]string, 0)
 	cobraCmd := &cobra.Command{
 		Use:   "execute <yaml file> [flags]",
@@ -45,19 +64,23 @@ You can also specify the rollback commands in case of a step failure.
 		Args: cobra.ExactArgs(1),
 		// Wraps the command execution with additional error handling
 		Run: helpers.Wrap(func(cmd *cobra.Command, args []string) (retErr error) {
-			yamlFileLocation := args[0]
-			// Read the YAML file from the specified location
-			yamlContent, err := os.ReadFile(yamlFileLocation)
+			_, err := exec.LookPath("drtprod")
 			if err != nil {
+				// drtprod is needed in the path to run yaml commands
 				return err
 			}
-			return processYaml(ctx, yamlContent, displayOnly, userProvidedTargetNames)
+			yamlFileLocation := args[0]
+			return processYamlFile(ctx, yamlFileLocation, displayOnly, remoteConfigYaml, userProvidedTargetNames)
 		}),
 	}
 	cobraCmd.Flags().BoolVarP(&displayOnly,
-		"display-only", "d", false, "displays the commands that will be executed without running them")
+		"display-only", "d", false, "displays the commands that will be executed without running them.")
 	cobraCmd.Flags().StringArrayVarP(&userProvidedTargetNames,
 		"targets", "t", nil, "the targets to execute. executes all if not mentioned.")
+	cobraCmd.Flags().StringVarP(&remoteConfigYaml,
+		"remote-config-yaml", "r", "", "runs the deployment remotely in the monitor node. This is "+
+			"useful for long running deployments as the local execution completes after creating a remote cluster. The remote "+
+			"config YAML provides the configuration of the remote monitor cluster.")
 	return cobraCmd
 }
 
@@ -106,8 +129,9 @@ type target struct {
 
 // yamlConfig represents the structure of the entire YAML configuration file.
 type yamlConfig struct {
-	Environment map[string]string `yaml:"environment"` // Environment variables to set
-	Targets     []target          `yaml:"targets"`     // List of target clusters with their steps
+	DependentFileLocations []string          `yaml:"dependent_file_locations,omitempty"` // location of all the dependent files - scripts/binaries
+	Environment            map[string]string `yaml:"environment"`                        // Environment variables to set
+	Targets                []target          `yaml:"targets"`                            // List of target clusters with their steps
 }
 
 // command is a simplified representation of a shell command that needs to be executed.
@@ -127,16 +151,203 @@ func (c *command) String() string {
 	return cmdStr
 }
 
-// processYaml reads the YAML file, parses it, sets the environment variables, and processes the targets.
-func processYaml(
-	ctx context.Context, yamlContent []byte, displayOnly bool, userProvidedTargetNames []string,
+// processYamlFile is responsible for processing the yaml configuration. The YAML commands can be executed
+// either locally or in a remote VM based on whether "remoteConfigYaml" is provided or not.
+// If the remoteConfigYaml is provided, a new VM is created based on the configuration provided in the remoteConfigYaml
+// is created and the current YAML is copied across along with the required scripts and binaries and execution
+// is run there. This is useful for long-running deployments where the local deployment just delegates
+// the execution of the deployment to the remote machine.
+func processYamlFile(
+	ctx context.Context,
+	yamlFileLocation string,
+	displayOnly bool,
+	remoteConfigYaml string,
+	userProvidedTargetNames []string,
 ) (err error) {
+	if _, err = os.Stat(yamlFileLocation); err != nil {
+		// if YAML config file is not available, we cannot proceed
+		return errors.Wrapf(err, "%s is not present", yamlFileLocation)
+	}
+	// Read the YAML file from the specified location
+	yamlContent, err := os.ReadFile(yamlFileLocation)
+	if err != nil {
+		return errors.Wrapf(err, "error reading %s", yamlFileLocation)
+	}
+	remoteDeployYamlContent := make([]byte, 0)
+	if remoteConfigYaml != "" {
+		if _, err = os.Stat(remoteConfigYaml); err != nil {
+			// if remote YAML config file is not available, we cannot proceed with remote deployment
+			return errors.Wrapf(err, "%s is not present", remoteConfigYaml)
+		}
+		remoteDeployYamlContent, err = os.ReadFile(remoteConfigYaml)
+		if err != nil {
+			return errors.Wrapf(err, "error reading %s", remoteConfigYaml)
+		}
+	}
+	return processYaml(ctx, yamlFileLocation, yamlContent, remoteDeployYamlContent, displayOnly, userProvidedTargetNames)
+}
 
+// processYaml processes the YAML content as explained in processYamlFile. A separate function taking the binary direct
+// helps in writing unit tests.
+func processYaml(
+	ctx context.Context,
+	yamlFileLocation string,
+	yamlContent, remoteDeployYamlContent []byte,
+	displayOnly bool,
+	userProvidedTargetNames []string,
+) error {
 	// Unmarshal the YAML content into the yamlConfig struct
-	var config yamlConfig
-	if err = yaml.UnmarshalStrict(yamlContent, &config); err != nil {
+	var clusterConfig yamlConfig
+	if err := yaml.UnmarshalStrict(yamlContent, &clusterConfig); err != nil {
 		return err
 	}
+	if !displayOnly {
+		if err := checkForDependentFiles(clusterConfig.DependentFileLocations); err != nil {
+			return err
+		}
+	}
+	if len(remoteDeployYamlContent) > 0 {
+		// Unmarshal the YAML content for the remote deployment and the cluster config will be executed in that remote VM.
+		var remoteDeploymentConfig yamlConfig
+		if err := yaml.UnmarshalStrict(remoteDeployYamlContent, &remoteDeploymentConfig); err != nil {
+			return err
+		}
+		return processYamlRemote(ctx, yamlFileLocation, clusterConfig, remoteDeploymentConfig, displayOnly, userProvidedTargetNames)
+	}
+	return processYamlConfig(ctx, clusterConfig, displayOnly, userProvidedTargetNames)
+}
+
+// checkForDependentFiles checks if the dependent files are missing and raises an error if not
+func checkForDependentFiles(dependentFileLocations []string) error {
+	missingFiles := make([]string, 0)
+	for _, f := range dependentFileLocations {
+		_, err := os.Stat(f)
+		if err != nil {
+			missingFiles = append(missingFiles, f)
+		}
+	}
+	if len(missingFiles) == 0 {
+		return nil
+	}
+	return errors.Errorf("dependent files are missing for the YAML: %s", strings.Join(missingFiles, ", "))
+}
+
+// processYamlRemote executes the YAML remotely
+func processYamlRemote(
+	ctx context.Context,
+	yamlFileLocation string,
+	config, remoteDeploymentConfig yamlConfig,
+	displayOnly bool,
+	userProvidedTargetNames []string,
+) (err error) {
+	if _, err = os.Stat(drtprodLocation); err != nil {
+		// if drtprod binary is not available in artifacts, we cannot proceed as this is needed for executing
+		// the YAML remotely
+		return errors.Wrapf(err, "%s must be available for executing remotely", drtprodLocation)
+	}
+	// displayOnly has to be run locally as this is just for displaying the commands
+	if displayOnly {
+		return errors.Errorf("display option is not valid for remote execution")
+	}
+	// the MONITOR_CLUSTER is overwritten with the YAML file name
+	yamlFileName := strings.Split(filepath.Base(yamlFileLocation), ".")[0]
+	monitorClusterName := fmt.Sprintf("%s-monitor", strings.ReplaceAll(yamlFileName, "_", "-"))
+	remoteDeploymentConfig.Environment["MONITOR_CLUSTER"] = monitorClusterName
+	// processing the remoteDeploymentConfig creates the VM for the remote execution.
+	err = processYamlConfig(ctx, remoteDeploymentConfig, false, make([]string, 0))
+	if err != nil {
+		return err
+	}
+	// Once the cluster is ready, the dependent files are uploaded
+	err = uploadAllDependentFiles(ctx, yamlFileLocation, config, monitorClusterName)
+	if err != nil {
+		return err
+	}
+	// The last step is to setup and execute the command on the remote VM
+	return setupAndExecute(ctx, yamlFileLocation, userProvidedTargetNames, monitorClusterName)
+}
+
+// setupAndExecute moves the drtprod binary to /usr/bin on the remote cluster
+// and then starts its execution using systemd, optionally targeting specific user-provided targets.
+func setupAndExecute(
+	ctx context.Context,
+	yamlFileLocation string,
+	userProvidedTargetNames []string,
+	monitorClusterName string,
+) error {
+	logger := config.Logger
+	// Move the drtprod binary to /usr/bin to ensure it is available system-wide on the cluster.
+	err := roachprodRun(ctx, logger, monitorClusterName, "", "", true,
+		os.Stdout, os.Stderr,
+		[]string{fmt.Sprintf("sudo mv %s /usr/bin", drtprodLocation)},
+		install.RunOptions{FailOption: install.FailSlow})
+	if err != nil {
+		return err
+	}
+
+	// Prepare the systemd command to execute the drtprod binary.
+	executeArgs := fmt.Sprintf(
+		"sudo systemd-run --unit %s --same-dir --uid $(id -u) --gid $(id -g) drtprod execute ./%s",
+		monitorClusterName,
+		yamlFileLocation)
+
+	// If the user provided specific target names, add them to the execution command.
+	if len(userProvidedTargetNames) > 0 {
+		executeArgs = fmt.Sprintf("%s -t %s", executeArgs, strings.Join(userProvidedTargetNames, " "))
+	}
+
+	// Run the systemd command on the remote cluster.
+	return roachprodRun(ctx, logger, monitorClusterName, "", "", true,
+		os.Stdout, os.Stderr,
+		[]string{executeArgs},
+		install.RunOptions{FailOption: install.FailSlow})
+}
+
+// uploadAllDependentFiles uploads all dependent files (including the YAML file and others)
+// to the specified remote cluster in parallel using goroutines.
+// If any error occurs during the upload, it is tracked and returned at the end.
+func uploadAllDependentFiles(
+	ctx context.Context, yamlFileLocation string, c yamlConfig, monitorClusterName string,
+) error {
+	logger := config.Logger
+	var g errgroup.Group
+	// Loop through all dependent files and upload them in parallel.
+	for _, fileLocation := range append(c.DependentFileLocations, yamlFileLocation, drtprodLocation) {
+		fl := fileLocation
+		g.Go(func() error {
+			// Create directory on the remote if the file contains a directory path.
+			if strings.Contains(fl, "/") {
+				dirLocation := filepath.Dir(fl)
+				// Use roachprod to create the directory on the remote.
+				err := roachprodRun(ctx, logger, monitorClusterName, "", "", true,
+					os.Stdout, os.Stderr,
+					[]string{fmt.Sprintf("mkdir -p %s", dirLocation)},
+					install.RunOptions{FailOption: install.FailSlow})
+				if err != nil {
+					return errors.Wrapf(err, "Error while creating directory for file %s", fl)
+				}
+			}
+			// Upload the file using roachprod.
+			err := roachprodPut(ctx, logger, monitorClusterName, fl, fl, true)
+			if err != nil {
+				return errors.Wrapf(err, "Error while putting file %s", fl)
+			}
+			return nil
+		})
+	}
+	if err := g.Wait(); err != nil {
+		return err
+	}
+	// Log success if all files were uploaded successfully.
+	fmt.Printf("All the dependencies are uploaded\n")
+	return nil
+}
+
+// processYamlConfig executes the YAML configuration. This execution may happen locally or remotely.
+// This reads the YAML to set the environment variables, and processes the targets.
+func processYamlConfig(
+	ctx context.Context, config yamlConfig, displayOnly bool, userProvidedTargetNames []string,
+) (err error) {
 
 	// Set the environment variables specified in the YAML
 	if err = setEnv(config.Environment, displayOnly); err != nil {
@@ -144,11 +355,7 @@ func processYaml(
 	}
 
 	// Process the targets defined in the YAML
-	if err = processTargets(ctx, config.Targets, displayOnly, userProvidedTargetNames); err != nil {
-		return err
-	}
-
-	return nil
+	return processTargets(ctx, config.Targets, displayOnly, userProvidedTargetNames)
 }
 
 // setEnv sets the environment variables as defined in the YAML configuration.
@@ -197,17 +404,15 @@ func processTargets(
 		}
 		return nil
 	}
-	// Use a WaitGroup to wait for commands executed concurrently
-	wg := sync.WaitGroup{}
-	for _, t := range targets {
+	var g errgroup.Group
+	for _, theTarget := range targets {
+		t := theTarget
 		if shouldSkipTarget(targetNameMap, t, userProvidedTargetNames) {
 			continue
 		}
-		wg.Add(1)
-		go func(t target) {
+		g.Go(func() error {
 			// defer complete the wait group for the dependent targets to proceed
 			defer waitGroupTracker[t.TargetName].Done()
-			defer wg.Done()
 			err := waitForDependentTargets(t, waitGroupTracker, sr)
 			// dependent targets must be success for executing further commands
 			if err == nil {
@@ -216,14 +421,13 @@ func processTargets(
 			if err != nil {
 				fmt.Printf("[%s] Error executing commands: %v\n", t.TargetName, err)
 				sr.setTargetStatus(t.TargetName, targetResultFailure)
-				return
+				return errors.Wrapf(err, "target %s failed", t.TargetName)
 			}
 			sr.setTargetStatus(t.TargetName, targetResultSuccess)
-		}(t)
+			return nil
+		})
 	}
-	// final wait for all targets to complete
-	wg.Wait()
-	return nil
+	return g.Wait()
 }
 
 // waitForDependentTargets waits for the dependent targets and returns an error if ignore_dependent_failure is false
@@ -244,7 +448,7 @@ func waitForDependentTargets(
 			if !t.IgnoreDependentFailure && sr.getTargetStatus(dt) == targetResultFailure {
 				fmt.Printf("[%s] Not proceeding as the dependent target %s was not successful.\n", t.TargetName, dt)
 				// if the dependent target has failed, the current target is marked as failure
-				return fmt.Errorf("[%s] not proceeding as the dependent target %s was not successful", t.TargetName, dt)
+				return errors.Errorf("[%s] not proceeding as the dependent target %s was not successful", t.TargetName, dt)
 			}
 		}
 	}

--- a/pkg/cmd/drtprod/cli/commands/yamlprocessor_test.go
+++ b/pkg/cmd/drtprod/cli/commands/yamlprocessor_test.go
@@ -8,34 +8,86 @@ package commands
 import (
 	"context"
 	"fmt"
+	"io"
+	"os"
 	"strings"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/stretchr/testify/require"
 )
 
+var cleanupFuncs = make([]func(), 0)
+
 func Test_processYaml(t *testing.T) {
+	t.Cleanup(func() {
+		// cleanup all once the tests are complete
+		for _, f := range cleanupFuncs {
+			f()
+		}
+	})
 	ctx := context.Background()
 	// setting to nil as a precaution that the command execution does not invoke an
 	// actual command
 	commandExecutor = nil
+	roachprodRun = nil
+	roachprodPut = nil
+	drtprodLocation = ""
 	t.Run("expect unmarshall to fail", func(t *testing.T) {
-		err := processYaml(ctx, []byte("invalid"), false, nil)
+		err := processYaml(ctx, "", []byte("invalid"), nil, false, nil)
 		require.NotNil(t, err)
 		require.Contains(t, err.Error(), "cannot unmarshal")
 	})
 	t.Run("expect failure due to unwanted field", func(t *testing.T) {
-		err := processYaml(ctx, []byte(`
+		err := processYaml(ctx, "", []byte(`
 unwanted: value
 environment:
   NAME_1: name_value1
   NAME_2: name_value2
-`), false, nil)
+`), nil, false, nil)
 		require.NotNil(t, err)
 		require.Contains(t, err.Error(), "field unwanted not found in type commands.yamlConfig")
 	})
 	t.Run("expect no command execution on display-only=true", func(t *testing.T) {
-		require.Nil(t, processYaml(ctx, getTestYaml(), true, nil))
+		require.Nil(t, processYaml(ctx, "", getTestYaml(), nil, true, nil))
+	})
+	t.Run("expect dependent file check to fail", func(t *testing.T) {
+		existingFile, err := os.CreateTemp("", "drtprod")
+		require.Nil(t, err)
+		yamlContent := []byte(fmt.Sprintf("%s%s",
+			fmt.Sprintf(`dependent_file_locations:
+  - file_not_present
+  - %[1]s
+  - another/missing/file
+`, existingFile.Name()), getTestYaml()))
+		err = processYaml(ctx, "", yamlContent, nil, false, nil)
+		require.NotNil(t, err)
+		require.Equal(t, "dependent files are missing for the YAML: file_not_present, another/missing/file", err.Error())
+	})
+	t.Run("expect dependent file check to pass for display only", func(t *testing.T) {
+		existingFile, err := os.CreateTemp("", "drtprod")
+		require.Nil(t, err)
+		yamlContent := []byte(fmt.Sprintf("%s%s",
+			fmt.Sprintf(`dependent_file_locations:
+  - file_not_present
+  - %[1]s
+  - another/missing/file
+`, existingFile.Name()), getTestYaml()))
+		require.Nil(t, processYaml(ctx, "", yamlContent, nil, true, nil))
+	})
+	t.Run("expect dependent file to pass", func(t *testing.T) {
+		commandExecutor = func(ctx context.Context, logPrefix string, cmd string, args ...string) error {
+			return nil
+		}
+		existingFile, err := os.CreateTemp("", "drtprod")
+		require.Nil(t, err)
+		yamlContent := []byte(fmt.Sprintf("%s%s",
+			fmt.Sprintf(`dependent_file_locations:
+  - %[1]s
+`, existingFile.Name()), getTestYaml()))
+		require.Nil(t, processYaml(ctx, "", yamlContent, nil, false, nil))
 	})
 	t.Run("expect partial failure and rollback", func(t *testing.T) {
 		name1Commands := make([]string, 0)
@@ -61,17 +113,18 @@ environment:
 			} else if strings.HasPrefix(logPrefix, "dependent_target_ignore_failure_n2_n1") {
 				// expect that "name_value1" and "name_value2" is complete by now
 				require.Equal(t, 8, len(name1Commands))
-				require.Equal(t, 1, len(name2Commands))
+				require.Equal(t, 2, len(name2Commands))
 				depN1N2IgnoreFailureCommands = append(depN1N2IgnoreFailureCommands, (&command{name: cmd, args: args}).String())
 			} else if strings.HasPrefix(logPrefix, "dependent_target_not_present") {
 				depNotPresentCommands = append(depNotPresentCommands, (&command{name: cmd, args: args}).String())
 			}
-			if cmd == "dummy_script1" || cmd == "script33" || args[0] == "rb_dummy2" {
+			if cmd == "dummy_script1" || cmd == "path/to/script33" || (len(args) > 0 && args[0] == "rb_dummy2") {
 				return fmt.Errorf("error while processing script %s", cmd)
 			}
 			return nil
 		}
-		require.Nil(t, processYaml(ctx, getTestYaml(), false, nil))
+		err := processYaml(ctx, "", getTestYaml(), nil, false, nil)
+		require.NotNil(t, err)
 		require.Equal(t, 8, len(name1Commands))
 		require.Equal(t, 0, len(depN1Commands))
 		require.Equal(t, 0, len(depN1N2Commands))
@@ -82,7 +135,7 @@ environment:
 		require.True(t, strings.Contains(name1Commands[0], "--clouds=gce"))
 		require.True(t, strings.Contains(name1Commands[0], "--nodes=1"))
 		require.Equal(t, []string{
-			"dummy_script1", "dummy_script2 arg11", "drtprod dummy2", "script33",
+			"dummy_script1", "dummy_script2 arg11", "drtprod dummy2", "path/to/script33",
 		}, name1Commands[1:5])
 		// rollback
 		require.True(t, strings.HasPrefix(name1Commands[5], "drtprod rb_dummy2 arg1 arg2"))
@@ -92,7 +145,7 @@ environment:
 		require.True(t, strings.Contains(name1Commands[6], "--f1=\\\"v1 v2\\\""))
 		require.Equal(t, "drtprod rb_dummy1", name1Commands[7])
 		require.Equal(t, []string{
-			"drtprod dummy2 name_value2 arg12",
+			"drtprod dummy2 name_value2 arg12", "drtprod put name_value2 path/to/file",
 		}, name2Commands)
 	})
 	t.Run("expect no failure", func(t *testing.T) {
@@ -114,21 +167,21 @@ environment:
 			} else if strings.HasPrefix(logPrefix, "dependent_target_n2_n1") {
 				// expect that "name_value1" and "name_value2" is complete by now
 				require.Equal(t, 6, len(name1Commands))
-				require.Equal(t, 1, len(name2Commands))
+				require.Equal(t, 2, len(name2Commands))
 				depN1N2Commands = append(depN1N2Commands, (&command{name: cmd, args: args}).String())
 			} else if strings.HasPrefix(logPrefix, "dependent_target_ignore_failure_n2_n1") {
 				// expect that "name_value1" and "name_value2" is complete by now
 				require.Equal(t, 6, len(name1Commands))
-				require.Equal(t, 1, len(name2Commands))
+				require.Equal(t, 2, len(name2Commands))
 				depN1N2IgnoreFailureCommands = append(depN1N2IgnoreFailureCommands, (&command{name: cmd, args: args}).String())
 			} else if strings.HasPrefix(logPrefix, "dependent_target_not_present") {
 				depNotPresentCommands = append(depNotPresentCommands, (&command{name: cmd, args: args}).String())
 			}
 			return nil
 		}
-		require.Nil(t, processYaml(ctx, getTestYaml(), false, nil))
+		require.Nil(t, processYaml(ctx, "", getTestYaml(), nil, false, nil))
 		require.Equal(t, 6, len(name1Commands))
-		require.Equal(t, 1, len(name2Commands))
+		require.Equal(t, 2, len(name2Commands))
 		require.Equal(t, 1, len(depN1Commands))
 		require.Equal(t, 1, len(depN1N2Commands))
 		require.Equal(t, 1, len(depNotPresentCommands))
@@ -138,12 +191,347 @@ environment:
 		require.True(t, strings.Contains(name1Commands[0], "--clouds=gce"))
 		require.True(t, strings.Contains(name1Commands[0], "--nodes=1"))
 		require.Equal(t, []string{
-			"dummy_script1", "dummy_script2 arg11", "drtprod dummy2", "script33", "last_script",
+			"dummy_script1", "dummy_script2 arg11", "drtprod dummy2", "path/to/script33", "last_script",
 		}, name1Commands[1:])
 		require.Equal(t, []string{
-			"drtprod dummy2 name_value2 arg12",
+			"drtprod dummy2 name_value2 arg12", "drtprod put name_value2 path/to/file",
 		}, name2Commands)
 	})
+	t.Run("run command remotely with missing invalid deployment YAML", func(t *testing.T) {
+		commandExecutor = nil
+		err := processYaml(ctx, "location/to/test.yaml", getTestYaml(), []byte("invalid content"), false, nil)
+		require.NotNil(t, err)
+		require.Contains(t, err.Error(), "cannot unmarshal")
+	})
+	t.Run("run command remotely with drtprod that does not exist", func(t *testing.T) {
+		commandExecutor = nil
+		drtprodLocation = "missing_drtprod"
+		err := processYaml(ctx, "location/to/test.yaml", getTestYaml(), getRemoteConfigYaml(), false, nil)
+		require.NotNil(t, err)
+		require.Equal(t, "missing_drtprod must be available for executing remotely: stat missing_drtprod: no such file or directory",
+			err.Error())
+	})
+	t.Run("run command remotely with display option", func(t *testing.T) {
+		commandExecutor = nil
+		f, err := os.CreateTemp("", "drtprod")
+		require.Nil(t, err)
+		drtprodLocation = f.Name()
+		err = processYaml(ctx, "location/to/test.yaml", getTestYaml(), getRemoteConfigYaml(), true, nil)
+		require.NotNil(t, err)
+		require.Equal(t, "display option is not valid for remote execution",
+			err.Error())
+	})
+	t.Run("run command remotely to fail", func(t *testing.T) {
+		f, err := os.CreateTemp("", "drtprod")
+		require.Nil(t, err)
+		drtprodLocation = f.Name()
+		scriptsDir := os.TempDir()
+		executedCmds := make([]string, 0)
+		commandExecutor = func(ctx context.Context, logPrefix string, cmd string, args ...string) error {
+			require.Equal(t, "test-monitor", logPrefix)
+			executedCmds = append(executedCmds, (&command{name: cmd, args: args}).String())
+			return fmt.Errorf("failure in execution")
+		}
+		err = processYaml(ctx, "location/to/test.yaml", addRemoteConfig(t, getTestYaml(), scriptsDir),
+			getRemoteConfigYaml(), false, nil)
+		require.NotNil(t, err)
+		// for create error is ignored, so, there are 2 commands.
+		require.Equal(t, 1, len(executedCmds))
+		require.Equal(t, "drtprod create test-monitor --clouds=gce --gce-image=ubuntu-2204-jammy-v20240319 --gce-machine-type=n2-standard-2 --gce-zones=us-central1-a --lifetime=8760h --nodes=1 --username=drt",
+			executedCmds[0])
+	})
+	t.Run("run command remotely with failure in upload while mkdir", func(t *testing.T) {
+		f, err := os.CreateTemp("", "drtprod")
+		require.Nil(t, err)
+		drtprodLocation = f.Name()
+		scriptsDir := os.TempDir()
+		executedCmds := make([]string, 0)
+		commandExecutor = func(ctx context.Context, logPrefix string, cmd string, args ...string) error {
+			require.Equal(t, "test-monitor", logPrefix)
+			executedCmds = append(executedCmds, (&command{name: cmd, args: args}).String())
+			return nil
+		}
+		roachprodRun = func(ctx context.Context, l *logger.Logger, clusterName,
+			SSHOptions, processTag string, secure bool, stdout, stderr io.Writer,
+			cmdArray []string, options install.RunOptions) error {
+			require.Equal(t, "test-monitor", clusterName)
+			if strings.HasPrefix(cmdArray[0], "mkdir -p") {
+				return fmt.Errorf("failed in upload")
+			}
+			return nil
+		}
+		roachprodPut = func(ctx context.Context, l *logger.Logger, clusterName, src, dest string, useTreeDist bool) error {
+			require.Equal(t, "test-monitor", clusterName)
+			return nil
+		}
+		err = processYaml(ctx, "location/to/test.yaml", addRemoteConfig(t, getTestYaml(), scriptsDir),
+			getRemoteConfigYaml(), false, nil)
+		require.NotNil(t, err)
+		require.Contains(t, err.Error(), "Error while creating directory for file")
+		require.Equal(t, 2, len(executedCmds))
+	})
+	t.Run("run command remotely with failure in upload while put", func(t *testing.T) {
+		f, err := os.CreateTemp("", "drtprod")
+		require.Nil(t, err)
+		drtprodLocation = f.Name()
+		scriptsDir := os.TempDir()
+		executedCmds := make([]string, 0)
+		commandExecutor = func(ctx context.Context, logPrefix string, cmd string, args ...string) error {
+			require.Equal(t, "test-monitor", logPrefix)
+			executedCmds = append(executedCmds, (&command{name: cmd, args: args}).String())
+			return nil
+		}
+		roachprodRun = func(ctx context.Context, l *logger.Logger, clusterName,
+			SSHOptions, processTag string, secure bool, stdout, stderr io.Writer,
+			cmdArray []string, options install.RunOptions) error {
+			require.Equal(t, "test-monitor", clusterName)
+			return nil
+		}
+		roachprodPut = func(ctx context.Context, l *logger.Logger, clusterName, src, dest string, useTreeDist bool) error {
+			require.Equal(t, "test-monitor", clusterName)
+			return fmt.Errorf("failed to put the file")
+		}
+		err = processYaml(ctx, "location/to/test.yaml", addRemoteConfig(t, getTestYaml(), scriptsDir),
+			getRemoteConfigYaml(), false, nil)
+		require.NotNil(t, err)
+		require.Contains(t, err.Error(), "Error while putting file")
+		require.Equal(t, 2, len(executedCmds))
+	})
+	t.Run("run command remotely with failure in mv of drtprod", func(t *testing.T) {
+		f, err := os.CreateTemp("", "drtprod")
+		require.Nil(t, err)
+		drtprodLocation = f.Name()
+		scriptsDir := os.TempDir()
+		executedCmds := make([]string, 0)
+		commandExecutor = func(ctx context.Context, logPrefix string, cmd string, args ...string) error {
+			require.Equal(t, "test-monitor", logPrefix)
+			executedCmds = append(executedCmds, (&command{name: cmd, args: args}).String())
+			return nil
+		}
+		roachprodRun = func(ctx context.Context, l *logger.Logger, clusterName,
+			SSHOptions, processTag string, secure bool, stdout, stderr io.Writer,
+			cmdArray []string, options install.RunOptions) error {
+			if strings.HasPrefix(cmdArray[0], "sudo mv") {
+				return fmt.Errorf("move command failed")
+			}
+			return nil
+		}
+		roachprodPut = func(ctx context.Context, l *logger.Logger, clusterName, src, dest string, useTreeDist bool) error {
+			require.Equal(t, "test-monitor", clusterName)
+			return nil
+		}
+		err = processYaml(ctx, "location/to/test.yaml", addRemoteConfig(t, getTestYaml(), scriptsDir),
+			getRemoteConfigYaml(), false, nil)
+		require.NotNil(t, err)
+		require.Equal(t, "move command failed", err.Error())
+		require.Equal(t, 2, len(executedCmds))
+	})
+	t.Run("run command remotely with failure in systemd-run", func(t *testing.T) {
+		f, err := os.CreateTemp("", "drtprod")
+		require.Nil(t, err)
+		drtprodLocation = f.Name()
+		scriptsDir := os.TempDir()
+		executedCmds := make([]string, 0)
+		runCmds := make([]string, 0)
+		runCmdsLock := syncutil.Mutex{}
+		commandExecutor = func(ctx context.Context, logPrefix string, cmd string, args ...string) error {
+			require.Equal(t, "test-monitor", logPrefix)
+			executedCmds = append(executedCmds, (&command{name: cmd, args: args}).String())
+			return nil
+		}
+		roachprodRun = func(ctx context.Context, l *logger.Logger, clusterName,
+			SSHOptions, processTag string, secure bool, stdout, stderr io.Writer,
+			cmdArray []string, options install.RunOptions) error {
+			runCmdsLock.Lock()
+			defer runCmdsLock.Unlock()
+			runCmds = append(runCmds, cmdArray[0])
+			if strings.HasPrefix(cmdArray[0], "sudo systemd-run") {
+				return fmt.Errorf("systemd-run command failed")
+			}
+			return nil
+		}
+		roachprodPut = func(ctx context.Context, l *logger.Logger, clusterName, src, dest string, useTreeDist bool) error {
+			require.Equal(t, "test-monitor", clusterName)
+			return nil
+		}
+		err = processYaml(ctx, "location/to/test.yaml", addRemoteConfig(t, getTestYaml(), scriptsDir),
+			getRemoteConfigYaml(), false, nil)
+		require.NotNil(t, err)
+		require.Equal(t, "systemd-run command failed", err.Error())
+		require.Equal(t, 2, len(executedCmds))
+		t.Log(runCmds)
+	})
+	t.Run("run command remotely with failure in systemd-run", func(t *testing.T) {
+		f, err := os.CreateTemp("", "drtprod")
+		require.Nil(t, err)
+		drtprodLocation = f.Name()
+		scriptsDir := os.TempDir()
+		executedCmds := make([]string, 0)
+		commandExecutor = func(ctx context.Context, logPrefix string, cmd string, args ...string) error {
+			require.Equal(t, "test-monitor", logPrefix)
+			executedCmds = append(executedCmds, (&command{name: cmd, args: args}).String())
+			return nil
+		}
+		roachprodRun = func(ctx context.Context, l *logger.Logger, clusterName,
+			SSHOptions, processTag string, secure bool, stdout, stderr io.Writer,
+			cmdArray []string, options install.RunOptions) error {
+			require.Equal(t, "test-monitor", clusterName)
+			if strings.HasPrefix(cmdArray[0], "sudo systemd-run") {
+				return fmt.Errorf("systemd-run command failed")
+			}
+			return nil
+		}
+		roachprodPut = func(ctx context.Context, l *logger.Logger, clusterName, src, dest string, useTreeDist bool) error {
+			require.Equal(t, "test-monitor", clusterName)
+			return nil
+		}
+		err = processYaml(ctx, "location/to/test.yaml", addRemoteConfig(t, getTestYaml(), scriptsDir),
+			getRemoteConfigYaml(), false, nil)
+		require.NotNil(t, err)
+		require.Equal(t, "systemd-run command failed", err.Error())
+		require.Equal(t, 2, len(executedCmds))
+	})
+	t.Run("run command remotely with no failure", func(t *testing.T) {
+		f, err := os.CreateTemp("", "drtprod")
+		require.Nil(t, err)
+		drtprodLocation = f.Name()
+		scriptsDir := os.TempDir()
+		executedCmds := make([]string, 0)
+		runCmds := make(map[string][]string)
+		runCmdsLock := syncutil.Mutex{}
+		putCmds := make(map[string]int)
+		putCmdsLock := syncutil.Mutex{}
+		commandExecutor = func(ctx context.Context, logPrefix string, cmd string, args ...string) error {
+			require.Equal(t, "test-monitor", logPrefix)
+			executedCmds = append(executedCmds, (&command{name: cmd, args: args}).String())
+			return nil
+		}
+		roachprodRun = func(ctx context.Context, l *logger.Logger, clusterName,
+			SSHOptions, processTag string, secure bool, stdout, stderr io.Writer,
+			cmdArray []string, options install.RunOptions) error {
+			require.Equal(t, "test-monitor", clusterName)
+			runCmdsLock.Lock()
+			defer runCmdsLock.Unlock()
+			if strings.HasPrefix(cmdArray[0], "mkdir -p") {
+				if _, ok := runCmds["mkdir"]; !ok {
+					runCmds["mkdir"] = make([]string, 0)
+				}
+				runCmds["mkdir"] = append(runCmds["mkdir"], cmdArray[0])
+			} else if strings.HasPrefix(cmdArray[0], "sudo mv") {
+				if _, ok := runCmds["mv"]; !ok {
+					runCmds["mv"] = make([]string, 0)
+				}
+				runCmds["mv"] = append(runCmds["mv"], cmdArray[0])
+			} else if strings.HasPrefix(cmdArray[0], "sudo systemd-run") {
+				if _, ok := runCmds["systemd"]; !ok {
+					runCmds["systemd"] = make([]string, 0)
+				}
+				runCmds["systemd"] = append(runCmds["systemd"], cmdArray[0])
+			}
+			return nil
+		}
+		roachprodPut = func(ctx context.Context, l *logger.Logger, clusterName, src, dest string, useTreeDist bool) error {
+			require.Equal(t, "test-monitor", clusterName)
+			putCmdsLock.Lock()
+			defer putCmdsLock.Unlock()
+			require.Equal(t, src, dest)
+			if strings.Contains(src, "drtprod") {
+				putCmds["drtprod"] += 1
+			} else if strings.Contains(src, "put") {
+				putCmds["put"] += 1
+			} else if strings.Contains(src, "script") {
+				putCmds["script"] += 1
+			} else if strings.Contains(src, "yaml") {
+				putCmds["yaml"] += 1
+			}
+			return nil
+		}
+		require.Nil(t, processYaml(ctx, "location/to/test.yaml", addRemoteConfig(t, getTestYaml(), scriptsDir),
+			getRemoteConfigYaml(), false, nil))
+		require.Equal(t, 2, len(executedCmds))
+		require.Equal(t, 4, len(putCmds))
+		for _, v := range putCmds {
+			require.Equal(t, 1, v)
+		}
+		t.Log(runCmds)
+		require.Equal(t, 3, len(runCmds))
+		require.Equal(t, 4, len(runCmds["mkdir"]))
+		require.Equal(t, 1, len(runCmds["mv"]))
+		require.Equal(t, 1, len(runCmds["systemd"]))
+		require.Equal(t, "sudo systemd-run --unit test-monitor --same-dir --uid $(id -u) --gid $(id -g) drtprod execute ./location/to/test.yaml",
+			runCmds["systemd"][0])
+	})
+	t.Run("run command remotely with no failure and targets specified", func(t *testing.T) {
+		f, err := os.CreateTemp("", "drtprod")
+		require.Nil(t, err)
+		drtprodLocation = f.Name()
+		scriptsDir := os.TempDir()
+		executedCmds := make([]string, 0)
+		runCmds := make(map[string][]string)
+		runCmdsLock := syncutil.Mutex{}
+		putCmds := make(map[string]int)
+		putCmdsLock := syncutil.Mutex{}
+		commandExecutor = func(ctx context.Context, logPrefix string, cmd string, args ...string) error {
+			require.Equal(t, "test-monitor", logPrefix)
+			executedCmds = append(executedCmds, (&command{name: cmd, args: args}).String())
+			return nil
+		}
+		roachprodRun = func(ctx context.Context, l *logger.Logger, clusterName,
+			SSHOptions, processTag string, secure bool, stdout, stderr io.Writer,
+			cmdArray []string, options install.RunOptions) error {
+			require.Equal(t, "test-monitor", clusterName)
+			runCmdsLock.Lock()
+			defer runCmdsLock.Unlock()
+			if strings.HasPrefix(cmdArray[0], "mkdir -p") {
+				if _, ok := runCmds["mkdir"]; !ok {
+					runCmds["mkdir"] = make([]string, 0)
+				}
+				runCmds["mkdir"] = append(runCmds["mkdir"], cmdArray[0])
+			} else if strings.HasPrefix(cmdArray[0], "sudo mv") {
+				if _, ok := runCmds["mv"]; !ok {
+					runCmds["mv"] = make([]string, 0)
+				}
+				runCmds["mv"] = append(runCmds["mv"], cmdArray[0])
+			} else if strings.HasPrefix(cmdArray[0], "sudo systemd-run") {
+				if _, ok := runCmds["systemd"]; !ok {
+					runCmds["systemd"] = make([]string, 0)
+				}
+				runCmds["systemd"] = append(runCmds["systemd"], cmdArray[0])
+			}
+			return nil
+		}
+		roachprodPut = func(ctx context.Context, l *logger.Logger, clusterName, src, dest string, useTreeDist bool) error {
+			require.Equal(t, "test-monitor", clusterName)
+			putCmdsLock.Lock()
+			defer putCmdsLock.Unlock()
+			require.Equal(t, src, dest)
+			if strings.Contains(src, "drtprod") {
+				putCmds["drtprod"] += 1
+			} else if strings.Contains(src, "put") {
+				putCmds["put"] += 1
+			} else if strings.Contains(src, "script") {
+				putCmds["script"] += 1
+			} else if strings.Contains(src, "yaml") {
+				putCmds["yaml"] += 1
+			}
+			return nil
+		}
+		require.Nil(t, processYaml(ctx, "location/to/test.yaml", addRemoteConfig(t, getTestYaml(), scriptsDir),
+			getRemoteConfigYaml(), false, []string{"target1"}))
+		require.Equal(t, 2, len(executedCmds))
+		require.Equal(t, 4, len(putCmds))
+		for _, v := range putCmds {
+			require.Equal(t, 1, v)
+		}
+		t.Log(runCmds)
+		require.Equal(t, 3, len(runCmds))
+		require.Equal(t, 4, len(runCmds["mkdir"]))
+		require.Equal(t, 1, len(runCmds["mv"]))
+		require.Equal(t, 1, len(runCmds["systemd"]))
+		require.Equal(t, "sudo systemd-run --unit test-monitor --same-dir --uid $(id -u) --gid $(id -g) drtprod execute ./location/to/test.yaml -t target1",
+			runCmds["systemd"][0])
+	})
+
 }
 
 func getTestYaml() []byte {
@@ -181,7 +569,7 @@ targets:
       - script: "dummy_script22"
         flags:
           f1: \"v1 v2\"
-    - script: "script33"
+    - script: "path/to/script33"
       on_rollback:
       - command: script33_rb
     - script: "last_script"
@@ -193,6 +581,10 @@ targets:
       args:
         - $NAME_2
         - arg12
+    - command: put
+      args:
+        - $NAME_2
+        - path/to/file
   - target_name: dependent_target_n1
     dependent_targets:
       - $NAME_1
@@ -229,6 +621,56 @@ targets:
     - command: dummy2
       args:
         - $NAME_2
-        - arg12
+        - arg12`)
+}
+
+func addRemoteConfig(t *testing.T, config []byte, fileDir string) []byte {
+	scriptFile, err := os.CreateTemp(fileDir, "script1")
+	require.Nil(t, err)
+	putFile, err := os.CreateTemp(fileDir, "put1")
+	require.Nil(t, err)
+	_, err = os.Create("script2")
+	require.Nil(t, err)
+	c := []byte(
+		fmt.Sprintf("%s%s",
+			string(config),
+			fmt.Sprintf(`
+dependent_file_locations:
+  - %[1]s
+  - %[2]s
+`, scriptFile.Name(), putFile.Name(),
+			)))
+	cleanupFuncs = append(cleanupFuncs, func() {
+		_ = os.Remove("script2")
+	})
+	return c
+}
+
+func getRemoteConfigYaml() []byte {
+	return []byte(`environment:
+  ROACHPROD_GCE_DEFAULT_SERVICE_ACCOUNT: 622274581499-compute@developer.gserviceaccount.com
+  ROACHPROD_DNS: drt.crdb.io
+  ROACHPROD_GCE_DNS_DOMAIN: drt.crdb.io
+  ROACHPROD_GCE_DNS_ZONE: drt
+  ROACHPROD_GCE_DEFAULT_PROJECT: cockroach-drt
+  MONITOR_CLUSTER: <yaml file name>-monitor # this is overwritten with the yaml file name
+
+targets:
+  - target_name: $MONITOR_CLUSTER
+    steps:
+      - command: create
+        args:
+          - $MONITOR_CLUSTER
+        flags:
+          clouds: gce
+          gce-zones: "us-central1-a"
+          nodes: 1
+          gce-machine-type: n2-standard-2
+          username: drt
+          lifetime: 8760h
+          gce-image: "ubuntu-2204-jammy-v20240319"
+      - command: sync
+        flags:
+          clouds: gce
 `)
 }

--- a/pkg/cmd/drtprod/configs/drt_chaos.yaml
+++ b/pkg/cmd/drtprod/configs/drt_chaos.yaml
@@ -10,6 +10,17 @@ environment:
   WORKLOAD_CLUSTER: workload-chaos
   WORKLOAD_NODES: 1
 
+dependent_file_locations:
+  - artifacts/roachprod
+  - artifacts/roachtest
+  - pkg/cmd/drtprod/scripts/setup_dmsetup_disk_staller
+  - pkg/cmd/drtprod/scripts/setup_datadog_cluster
+  - pkg/cmd/drtprod/scripts/setup_datadog_workload
+  - pkg/cmd/drtprod/scripts/tpcc_init.sh
+  - pkg/cmd/drtprod/scripts/generate_tpcc_run.sh
+  - pkg/cmd/drtprod/scripts/generate_kv_run.sh
+  - pkg/cmd/drtprod/scripts/generate_tpcc_drop.sh
+
 targets:
   - target_name: $CLUSTER
     steps:

--- a/pkg/cmd/drtprod/configs/drt_large.yaml
+++ b/pkg/cmd/drtprod/configs/drt_large.yaml
@@ -21,6 +21,16 @@ environment:
   NUM_WORKERS: 500
   MAX_RATE: 500
 
+dependent_file_locations:
+  - artifacts/roachprod
+  - artifacts/roachtest
+  - pkg/cmd/drtprod/scripts/setup_dmsetup_disk_staller
+  - pkg/cmd/drtprod/scripts/setup_datadog_cluster
+  - pkg/cmd/drtprod/scripts/create_decommission_node.sh
+  - pkg/cmd/drtprod/scripts/setup_datadog_workload
+  - pkg/cmd/drtprod/scripts/tpcc_init.sh
+  - pkg/cmd/drtprod/scripts/tpcc_run_multiregion.sh
+
 targets:
   - target_name: $CLUSTER
     steps:

--- a/pkg/cmd/drtprod/configs/drt_remote.yaml
+++ b/pkg/cmd/drtprod/configs/drt_remote.yaml
@@ -1,0 +1,27 @@
+# YAML for creating and configuring the drt monitor cluster. This is used for remotre deployment
+environment:
+  ROACHPROD_GCE_DEFAULT_SERVICE_ACCOUNT: 622274581499-compute@developer.gserviceaccount.com
+  ROACHPROD_DNS: drt.crdb.io
+  ROACHPROD_GCE_DNS_DOMAIN: drt.crdb.io
+  ROACHPROD_GCE_DNS_ZONE: drt
+  ROACHPROD_GCE_DEFAULT_PROJECT: cockroach-drt
+  MONITOR_CLUSTER: <yaml file name>-monitor # this is overwritten with the yaml file name
+
+targets:
+  - target_name: $MONITOR_CLUSTER
+    steps:
+      - command: create
+        continue_on_failure: true
+        args:
+          - $MONITOR_CLUSTER
+        flags:
+          clouds: gce
+          gce-zones: "us-central1-a"
+          nodes: 1
+          gce-machine-type: n2-standard-2
+          username: drt
+          lifetime: 8760h
+          gce-image: "ubuntu-2204-jammy-v20240319"
+      - command: sync
+        flags:
+          clouds: gce


### PR DESCRIPTION
currently drtprod execute runs the execution of the YAML file locally. This is an issue in cases where we have long running deployments. So, to solve this problem, this change provides a new option to run the execution on a remote machine. This machine is created and all the dependent files are copied across to that machine. All executions are done in the remote machines.
In addition, I have added another feature to define the dependent scripts. This becomes more important as the impact of failure in remote execution is more as compared to running locally. So, we have to ensure that the required files are present.

Epic: None
Release Note: None