### PR TITLE
upgrademanager: skip TestPrecondition under stress

### DIFF
--- a/pkg/upgrade/upgrademanager/manager_external_test.go
+++ b/pkg/upgrade/upgrademanager/manager_external_test.go
@@ -679,6 +679,7 @@ SELECT id
 func TestPrecondition(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+	skip.UnderStress(t, "flaky")
 
 	// Start by running v0. We want the precondition of v1 to prevent
 	// us from reaching v1 (or v2). We want the precondition to not be


### PR DESCRIPTION
Fixes: #139562
Epic: none
Release note: None