### PR TITLE
sql: Integrate RLS Enabled Field

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/row_level_security
+++ b/pkg/sql/logictest/testdata/logic_test/row_level_security
@@ -495,4 +495,276 @@ ALTER TABLE roaches NO FORCE ROW LEVEL SECURITY;
 statement ok
 DROP TABLE roaches;
 
+subtest using_expression_applied
+
+statement ok
+CREATE TYPE league AS ENUM('AL','NL');
+
+statement ok
+CREATE TABLE bbteams (team text, league league, family (team, league));
+
+statement ok
+ALTER TABLE bbteams ENABLE ROW LEVEL SECURITY;
+
+statement ok
+INSERT INTO bbteams VALUES ('jays', 'AL'), ('tigers', 'AL'), ('cardinals', 'NL'), ('orioles', 'AL'), ('nationals', 'NL');
+
+# Confirm admin user can see all rows
+query TT
+select team, league from bbteams order by league, team;
+----
+jays AL
+orioles AL
+tigers AL
+cardinals NL
+nationals NL
+
+statement ok
+CREATE USER buck;
+
+statement ok
+GRANT ALL ON bbteams TO buck;
+
+statement ok
+set role buck
+
+# user buck can't see anything because they aren't admin, rls is enabled and no policies are defined.
+query TT
+select team, league from bbteams order by league, team;
+----
+
+statement ok
+set role root
+
+# We will create a function and a sequence to include in the expression, as
+# these introduce additional dependencies compared to a plain expression using
+# basic types.
+statement ok
+CREATE FUNCTION is_valid(l league) RETURNS BOOL AS $$
+BEGIN
+  RETURN l = 'AL';
+END;
+$$ LANGUAGE PLpgSQL;
+
+statement ok
+CREATE SEQUENCE seq1;
+
+statement ok
+GRANT USAGE ON seq1 TO buck;
+
+statement ok
+create policy restrict_select on bbteams for select to buck,current_user,session_user using (is_valid(league) and nextval('seq1') < 1000);
+
+# confirm admin can see all
+query TT
+select team, league from bbteams where team != 'cardinals' order by league, team;
+----
+jays AL
+orioles AL
+tigers AL
+nationals NL
+
+statement ok
+set role buck
+
+# TODO(136717): Reusing the statement cache prevents recompiling a new plan,
+# which leads to incorrect results in this case.
+query TT
+select team, league from bbteams where team != 'cardinals' order by league, team;
+----
+jays AL
+orioles AL
+tigers AL
+nationals NL
+
+query TT
+select team, league from bbteams where team != 'astros' order by league, team;
+----
+jays AL
+orioles AL
+tigers AL
+
+# Verify that if admin is granted to user buck, it sees all rows because RLS is exempt.
+statement ok
+set role root
+
+statement ok
+GRANT admin TO buck;
+
+statement ok
+set role buck;
+
+# This is the same query as before, but since admin changed, we will see all of the rows.
+# TODO(136717): We are mistakenly reusing the statement plan here. So we see the rows as if
+# the policies were applied.
+query TT
+select team, league from bbteams where team != 'astros' order by league, team;
+----
+jays AL
+orioles AL
+tigers AL
+
+# Retry with a query never tried before so we avoid the statement cache.
+query TT
+select team, league from bbteams where team != 'mariners' order by league, team;
+----
+jays AL
+orioles AL
+tigers AL
+cardinals NL
+nationals NL
+
+statement ok
+set role root
+
+statement ok
+REVOKE admin FROM buck;
+
+# Add policies that apply to other commands. Only SELECT will return rows.
+statement ok
+CREATE POLICY restrict_insert ON bbteams FOR INSERT TO buck USING (false);
+
+statement ok
+CREATE POLICY restrict_delete ON bbteams FOR DELETE TO buck USING (false);
+
+statement ok
+CREATE POLICY restrict_update ON bbteams FOR UPDATE TO buck USING (false);
+
+statement ok
+set role buck
+
+# Verify SELECT will use the original policy that restricts rows just to AL teams
+query TT
+select team, league from bbteams where team != 'jays' order by league, team;
+----
+orioles AL
+tigers AL
+
+# Try updating a row. The policy for update will prevent us from reading the row.
+statement ok
+UPDATE bbteams SET team = 'blue jays' where team = 'jays';
+
+query TT
+select team, league from bbteams order by league, team;
+----
+jays AL
+orioles AL
+tigers AL
+
+# Switch the policy to allow an update, but only for rows in the AL league.
+statement ok
+set role root
+
+statement ok
+DROP POLICY restrict_update on bbteams;
+
+statement ok
+create policy restrict_update on bbteams for update to buck using (is_valid(league) and nextval('seq1') < 1000);
+
+statement ok
+set role buck
+
+# Allowed
+statement ok
+UPDATE bbteams SET team = 'Jays' where team = 'jays';
+
+# Not allowed
+statement ok
+UPDATE bbteams SET team = 'Nationals' where team = 'nationals';
+
+statement ok
+set role root
+
+query TT
+select team, league from bbteams where team in ('jays', 'Jays', 'nationals', 'Nationals') order by league, team;
+----
+Jays AL
+nationals NL
+
+statement ok
+set role buck
+
+# Try to delete the row. The delete policy will prevent us from reading the row.
+statement ok
+DELETE FROM bbteams;
+
+query TT
+select team, league from bbteams order by league, team;
+----
+Jays     AL
+orioles  AL
+tigers   AL
+
+# Switch the delete policy to allow deletion of only the tigers
+statement ok
+set role root
+
+statement ok
+DROP POLICY restrict_delete on bbteams;
+
+statement ok
+create policy restrict_delete on bbteams for delete to buck using (is_valid(league) and team = 'tigers' and nextval('seq1') < 1000) with check (true);
+
+statement ok
+set role buck
+
+statement ok
+DELETE FROM bbteams WHERE team != 'pirates';
+
+query TT
+select team, league from bbteams where team != 'pirates' order by league, team;
+----
+Jays     AL
+orioles  AL
+
+query TT
+SHOW CREATE TABLE bbteams
+----
+bbteams  CREATE TABLE public.bbteams (
+           team STRING NULL,
+           league public.league NULL,
+           rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+           CONSTRAINT bbteams_pkey PRIMARY KEY (rowid ASC),
+           FAMILY fam_0_team_league_rowid (team, league, rowid)
+         )
+
+statement ok
+set role root
+
+statement ok
+DROP TABLE bbteams;
+
+statement ok
+DROP SEQUENCE seq1;
+
+statement ok
+DROP FUNCTION is_valid;
+
+# This subtest verifies proper cleanup of policy elements when dropping with CASCADE.
+subtest drop_with_cascade
+
+statement ok
+CREATE DATABASE db2;
+
+statement ok
+use db2;
+
+statement ok
+CREATE TYPE classes AS ENUM('mammals','birds', 'fish', 'reptiles', 'amphibians');
+
+statement ok
+CREATE TABLE animals (name text, class classes, family (name, class));
+
+statement ok
+ALTER TABLE animals ENABLE ROW LEVEL SECURITY;
+
+statement ok
+create policy p1 on animals for select to current_user using (class in ('mammals','birds')) with check (class in ('reptiles', 'amphibians'));
+
+statement ok
+use defaultdb;
+
+statement ok
+drop database db2 cascade;
+
 subtest end

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -1152,9 +1152,7 @@ func newOptTable(
 	ot.triggers = getOptTriggers(desc.GetTriggers())
 
 	// Store row-level security information
-	// TODO(136717): Update this to utilize the tableDescriptor's field for
-	// indicating if RLS is enabled once the field is added.
-	ot.rlsEnabled = false
+	ot.rlsEnabled = desc.IsRowLevelSecurityEnabled()
 	ot.policies = getOptPolicies(desc.GetPolicies())
 
 	// Add stats last, now that other metadata is initialized.

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/helpers.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/helpers.go
@@ -234,6 +234,8 @@ func dropCascadeDescriptor(b BuildCtx, id catid.DescID) {
 			dropCascadeDescriptor(next, t.FunctionID)
 		case *scpb.TriggerDeps:
 			dropCascadeDescriptor(next, t.TableID)
+		case *scpb.PolicyDeps:
+			dropCascadeDescriptor(next, t.TableID)
 		case *scpb.Column, *scpb.ColumnType, *scpb.SecondaryIndexPartial:
 			// These only have type references.
 			break
@@ -245,6 +247,8 @@ func dropCascadeDescriptor(b BuildCtx, id catid.DescID) {
 			*scpb.ColumnDefaultExpression,
 			*scpb.ColumnOnUpdateExpression,
 			*scpb.ColumnComputeExpression,
+			*scpb.PolicyUsingExpr,
+			*scpb.PolicyWithCheckExpr,
 			*scpb.CheckConstraint,
 			*scpb.CheckConstraintUnvalidated,
 			*scpb.ForeignKeyConstraint,
@@ -253,7 +257,7 @@ func dropCascadeDescriptor(b BuildCtx, id catid.DescID) {
 			*scpb.DatabaseRegionConfig:
 			b.Drop(e)
 		default:
-			panic(errors.AssertionFailedf("un-dropped backref %T (%v) should be either be"+
+			panic(errors.AssertionFailedf("un-dropped backref %T (%v) should either be "+
 				"dropped or skipped", e, target))
 		}
 	})


### PR DESCRIPTION
Previously, the new row-level security (RLS) logic for reads was only functional within unit tests. This change utilizes the RLS enabled field in the table descriptor to ensure USING expressions in policies are correctly applied outside of unit tests. Additional logic tests have been added to validate this behavior.

Note: There are existing issues with the statement cache that can cause incorrect policy application for users/roles. These will be addressed in a follow-up issue.

While creating the test, I encountered two issues with dependency checking:
- `DROP CASCADE` did not correctly handle the new policy expression elements, which surfaced when dropping a database.
- Sequence back-reference maintenance was incorrect when adding a second reference that only targeted the table (as occurs when a sequence is referenced in a policy expression).

Epic: CRDB-11724
Release note: None
Informs #136717