### PR TITLE
roachtest: inc ranges per store in rebalance/by-load test

### DIFF
--- a/pkg/cmd/roachtest/tests/rebalance_load.go
+++ b/pkg/cmd/roachtest/tests/rebalance_load.go
@@ -32,7 +32,7 @@ import (
 const (
 	// storeToRangeFactor is the number of ranges to create per store in the
 	// cluster.
-	storeToRangeFactor = 5
+	storeToRangeFactor = 10
 	// meanCPUTolerance is the tolerance applied when checking normalized (0-100)
 	// CPU percent utilization of stores against the mean. In multi-store tests,
 	// the same CPU utilization will be reported for stores on the same node. The


### PR DESCRIPTION
The `rebalance/by-load/*` roachtests previously targeted 5 (user) ranges per store. Increase this to 10 for a more realistic scenario and likely deflaking.

Informs: #139856
Informs: #139937
Informs: #139119
Informs: #136800
Informs: #138635
Part of: #139037
Release note: None