### PR TITLE
opt: reduce `opt.ColSet` allocs when exploring partial index scans

### DIFF
--- a/pkg/sql/opt/xform/scan_index_iter.go
+++ b/pkg/sql/opt/xform/scan_index_iter.go
@@ -363,15 +363,14 @@ func (it *scanIndexIter) filtersImplyPredicate(
 // the given filters and of types that do not have composite encodings.
 func (it *scanIndexIter) extractConstNonCompositeColumns(f memo.FiltersExpr) opt.ColSet {
 	constCols := memo.ExtractConstColumns(it.e.ctx, f, it.evalCtx)
-	var constNonCompositeCols opt.ColSet
 	for col, ok := constCols.Next(0); ok; col, ok = constCols.Next(col + 1) {
 		ord := it.tabMeta.MetaID.ColumnOrdinal(col)
 		typ := it.tabMeta.Table.Column(ord).DatumType()
-		if !colinfo.CanHaveCompositeKeyEncoding(typ) {
-			constNonCompositeCols.Add(col)
+		if colinfo.CanHaveCompositeKeyEncoding(typ) {
+			constCols.Remove(col)
 		}
 	}
-	return constNonCompositeCols
+	return constCols
 }
 
 // buildConstProjectionsFromPredicate builds a ProjectionsExpr that projects


### PR DESCRIPTION
When exploring a partial index scan, we previously built a set of
columns held constant by partial index predicate, and then built another
set of those columns that are not composite key encoded. Now, instead of
building the second set, we remove columns from the first. This will
reduce allocations in the case where the constant column IDs are larger
than 128.

Epic: None
Release note: None
