### PR TITLE
sql: enforce unique partition names

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning
@@ -1518,3 +1518,41 @@ FROM subzone_spans;
 /2/2
 
 subtest end
+
+# Regression for #128692 in which partition names could be non-unique.
+subtest non_unique_partition_names
+
+statement error pgcode 42601 pq: duplicate partition name
+CREATE TABLE foo (
+    i INT,
+    j INT,
+    INDEX idx1 (i) PARTITION BY LIST (i) (
+        PARTITION p1 VALUES IN (1, 5)
+    ),
+    INDEX idx2 (j) PARTITION BY LIST (j) (
+        PARTITION p1 VALUES IN (2, 4)
+    )
+);
+
+statement ok
+CREATE TABLE foo(i INT PRIMARY KEY, j INT) PARTITION BY LIST (i) (
+  PARTITION p VALUES IN (1, 5)
+);
+
+statement ok
+SET use_declarative_schema_changer = off
+
+statement error pgcode 42601 pq: duplicate partition name
+CREATE INDEX idx ON foo(j) PARTITION BY LIST (j) (
+  PARTITION p VALUES IN (2, 4)
+);
+
+statement error pgcode 42601 pq: duplicate partition name
+ALTER TABLE foo PARTITION BY LIST (j) (
+  PARTITION p VALUES IN (2, 4)
+);
+
+statement ok
+RESET use_declarative_schema_changer
+
+subtest end

--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning
@@ -1539,9 +1539,6 @@ CREATE TABLE foo(i INT PRIMARY KEY, j INT) PARTITION BY LIST (i) (
   PARTITION p VALUES IN (1, 5)
 );
 
-statement ok
-SET use_declarative_schema_changer = off
-
 statement error pgcode 42601 pq: duplicate partition name
 CREATE INDEX idx ON foo(j) PARTITION BY LIST (j) (
   PARTITION p VALUES IN (2, 4)
@@ -1551,8 +1548,5 @@ statement error pgcode 42601 pq: duplicate partition name
 ALTER TABLE foo PARTITION BY LIST (j) (
   PARTITION p VALUES IN (2, 4)
 );
-
-statement ok
-RESET use_declarative_schema_changer
 
 subtest end

--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning_implicit
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning_implicit
@@ -469,12 +469,12 @@ CREATE TABLE public.t (
 
 statement error cannot define PARTITION BY on an index if the table has a PARTITION ALL BY definition
 CREATE INDEX created_idx ON t(c) PARTITION BY LIST (d) (
-  PARTITION one VALUES IN ((1))
+  PARTITION once VALUES IN ((1))
 )
 
 statement error cannot change the partitioning of an index if the table has PARTITION ALL BY defined
 ALTER INDEX t@t_a_idx PARTITION BY LIST (a) (
-  PARTITION one VALUES IN (1)
+  PARTITION once VALUES IN (1)
 )
 
 query T noticetrace
@@ -671,7 +671,7 @@ CREATE TABLE public.t (
 
 statement error cannot define PARTITION BY on an index if the table has a PARTITION ALL BY definition
 CREATE INDEX created_idx ON t(c) PARTITION BY LIST (d) (
-  PARTITION one VALUES IN ((1))
+  PARTITION one_d VALUES IN ((1))
 )
 
 statement ok

--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning_index
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning_index
@@ -110,10 +110,10 @@ CREATE UNIQUE INDEX IF NOT EXISTS i4 ON indexes (b) PARTITION BY LIST (b) (
     PARTITION p4 VALUES IN (1)
 )
 
-statement error PARTITION p1: name must be unique \(used twice in index "i5"\)
+statement error PARTITION p5: name must be unique \(used twice in index "i5"\)
 CREATE INDEX i5 ON indexes (b) PARTITION BY LIST (b) (
-    PARTITION p1 VALUES IN (1),
-    PARTITION p1 VALUES IN (2)
+    PARTITION p5 VALUES IN (1),
+    PARTITION p5 VALUES IN (2)
 )
 
 # Partition names can be reused across indexes.

--- a/pkg/ccl/logictestccl/testdata/logic_test/zone
+++ b/pkg/ccl/logictestccl/testdata/logic_test/zone
@@ -711,13 +711,13 @@ CREATE TABLE t2 (x INT PRIMARY KEY) PARTITION BY LIST (x) (
   PARTITION p2 VALUES IN (2)
 );
 CREATE INDEX x1 ON t2 (x) PARTITION BY LIST (x) (
-  PARTITION p1 VALUES IN (1),
-  PARTITION p2 VALUES IN (2)
+  PARTITION p1_x1 VALUES IN (1),
+  PARTITION p2_x1 VALUES IN (2)
 );
 CREATE INDEX x2 ON t2 (x) PARTITION BY LIST (x) (
-  PARTITION p1 VALUES IN (1),
-  PARTITION p2 VALUES IN (2),
-  PARTITION p3 VALUES IN (3)
+  PARTITION p1_x3 VALUES IN (1),
+  PARTITION p2_x3 VALUES IN (2),
+  PARTITION p3_x3 VALUES IN (3)
 )
 
 statement ok
@@ -736,26 +736,8 @@ SELECT * FROM [SHOW ALL ZONE CONFIGURATIONS] WHERE target LIKE '%t2@%' ORDER BY 
 ----
 PARTITION p1 OF INDEX "my database".public.t2@t2_pkey  ALTER PARTITION p1 OF INDEX "my database".public.t2@t2_pkey CONFIGURE ZONE USING
                                                        num_replicas = 1
-PARTITION p1 OF INDEX "my database".public.t2@x1       ALTER PARTITION p1 OF INDEX "my database".public.t2@x1 CONFIGURE ZONE USING
-                                                       num_replicas = 1
-PARTITION p1 OF INDEX "my database".public.t2@x2       ALTER PARTITION p1 OF INDEX "my database".public.t2@x2 CONFIGURE ZONE USING
-                                                       num_replicas = 1
 
-# ALTER PARTITION ... OF TABLE should only succeed if the partition name is
-# unique across all indexes.
-statement error pq: partition "p1" exists on multiple indexes of table "t2"
-ALTER PARTITION p1 OF TABLE t2 CONFIGURE ZONE USING num_replicas = 1
-
-statement ok
-ALTER PARTITION p3 OF TABLE t2 CONFIGURE ZONE USING num_replicas = 1
-
-query TT
-SELECT * FROM [SHOW ALL ZONE CONFIGURATIONS] WHERE target LIKE '%t2@x2%' ORDER BY 1
-----
-PARTITION p1 OF INDEX "my database".public.t2@x2  ALTER PARTITION p1 OF INDEX "my database".public.t2@x2 CONFIGURE ZONE USING
-                                                  num_replicas = 1
-PARTITION p3 OF INDEX "my database".public.t2@x2  ALTER PARTITION p3 OF INDEX "my database".public.t2@x2 CONFIGURE ZONE USING
-                                                  num_replicas = 1
+subtest end
 
 statement error pq: partition "p4" does not exist on table "t2"
 ALTER PARTITION p4 OF TABLE t2 CONFIGURE ZONE USING num_replicas = 1
@@ -794,7 +776,7 @@ CREATE TABLE auth.t (x INT PRIMARY KEY) PARTITION BY LIST (x) (
 
 statement ok
 CREATE INDEX x ON auth.t (x) PARTITION BY LIST (x) (
-  PARTITION p VALUES IN (1)
+  PARTITION p_x VALUES IN (1)
 )
 
 user testuser
@@ -816,7 +798,7 @@ statement error pq: user testuser does not have CREATE or ZONECONFIG privilege o
 ALTER PARTITION p OF TABLE auth.t CONFIGURE ZONE USING num_replicas = 3
 
 statement error pq: user testuser does not have CREATE or ZONECONFIG privilege on relation t
-ALTER PARTITION p OF INDEX auth.t@x CONFIGURE ZONE USING num_replicas = 3
+ALTER PARTITION p_x OF INDEX auth.t@x CONFIGURE ZONE USING num_replicas = 3
 
 # Granting CREATE on databases and tables should allow CONFIGURE ZONE on those
 # objects.
@@ -885,7 +867,7 @@ CREATE TABLE auth.t3 (x INT PRIMARY KEY) PARTITION BY LIST (x) (
   PARTITION p VALUES IN (1)
 );
 CREATE INDEX x ON auth.t3 (x) PARTITION BY LIST (x) (
-  PARTITION p VALUES IN (1)
+  PARTITION p_x VALUES IN (1)
 );
 
 statement ok
@@ -901,7 +883,7 @@ statement ok
 ALTER INDEX auth.t3@x CONFIGURE ZONE USING num_replicas=5;
 
 statement ok
-ALTER PARTITION p OF INDEX auth.t3@x CONFIGURE ZONE USING num_replicas = 3
+ALTER PARTITION p_x OF INDEX auth.t3@x CONFIGURE ZONE USING num_replicas = 3
 
 # Granting the admin role should allow configuring zones on system tables and
 # ranges.

--- a/pkg/ccl/telemetryccl/testdata/telemetry/index
+++ b/pkg/ccl/telemetryccl/testdata/telemetry/index
@@ -19,7 +19,7 @@ sql.schema.partitioned_inverted_index
 
 feature-usage
 CREATE INVERTED INDEX i ON a (b, j) PARTITION BY LIST (b) (
-    PARTITION p1 VALUES IN (1)
+    PARTITION p1_i VALUES IN (1)
 )
 ----
 sql.schema.partitioned_inverted_index

--- a/pkg/sql/create_index.go
+++ b/pkg/sql/create_index.go
@@ -742,6 +742,16 @@ func (n *createIndexNode) startExec(params runParams) error {
 		)
 	}
 
+	if n.n.PartitionByIndex != nil && n.n.PartitionByIndex.PartitionBy != nil {
+		// Check all existing partitions on this table's indexes; ensure the
+		// partition name we might add to this index is unique.
+		indexes := append(n.tableDesc.TableDesc().Indexes, n.tableDesc.TableDesc().PrimaryIndex)
+		if err := checkUniquePartitionByForTableIndexes(indexes, n.n.PartitionByIndex.PartitionBy,
+			false /* allowRepartitioning */); err != nil {
+			return err
+		}
+	}
+
 	// Warn against creating a non-partitioned index on a partitioned table,
 	// which is undesirable in most cases.
 	// Avoid the warning if we have PARTITION ALL BY as all indexes will implicitly


### PR DESCRIPTION
While we enforce the fact that subpartition names must be unique on a
partition, we do not enforce unique partition names across all indexes
on a table. This fact surfaces a bug with replication controls -- the
last non-uniquely-named partition to have its zone config edited is the
only partition that the user can control from then on. This is becuase
we assume uniquely-named partitions during the generation of subzone
spans.

Unless we are repartitioning an index, we now disallow non-unique
partition names.

Epic: CRDB-
Fixes: https://github.com/cockroachdb/cockroach/issues/128692

Release note (sql change):