### PR TITLE
sql/opt: Invalidate memo for queries using RLS when user changes

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/row_level_security
+++ b/pkg/sql/logictest/testdata/logic_test/row_level_security
@@ -567,16 +567,15 @@ nationals NL
 statement ok
 set role buck
 
-# TODO(136717): Reusing the statement cache prevents recompiling a new plan,
-# which leads to incorrect results in this case.
+# Retry the same query issue before to ensure memo is properly invalidated.
 query TT
 select team, league from bbteams where team != 'cardinals' order by league, team;
 ----
 jays AL
 orioles AL
 tigers AL
-nationals NL
 
+# Try another query we know isn't in the statement cache.
 query TT
 select team, league from bbteams where team != 'astros' order by league, team;
 ----
@@ -595,14 +594,14 @@ statement ok
 set role buck;
 
 # This is the same query as before, but since admin changed, we will see all of the rows.
-# TODO(136717): We are mistakenly reusing the statement plan here. So we see the rows as if
-# the policies were applied.
 query TT
 select team, league from bbteams where team != 'astros' order by league, team;
 ----
 jays AL
 orioles AL
 tigers AL
+cardinals NL
+nationals NL
 
 # Retry with a query never tried before so we avoid the statement cache.
 query TT
@@ -619,6 +618,20 @@ set role root
 
 statement ok
 REVOKE admin FROM buck;
+
+statement ok
+set role buck
+
+# Retry same query we ran before to ensure it's properly invalidated in the statement cache.
+query TT
+select team, league from bbteams where team != 'mariners' order by league, team;
+----
+jays AL
+orioles AL
+tigers AL
+
+statement ok
+set role root
 
 # Add policies that apply to other commands. Only SELECT will return rows.
 statement ok
@@ -766,5 +779,180 @@ use defaultdb;
 
 statement ok
 drop database db2 cascade;
+
+# Ensure that functions defined with security behave as expected
+subtest function_security_definer
+
+statement ok
+CREATE USER sensitive_user;
+
+statement ok
+CREATE TABLE sensitive_data_table (C1 INT);
+
+statement ok
+INSERT INTO sensitive_data_table VALUES (0),(1),(2);
+
+statement ok
+ALTER TABLE sensitive_data_table ENABLE ROW LEVEL SECURITY;
+
+statement ok
+GRANT ALL ON sensitive_data_table TO sensitive_user;
+
+statement ok
+CREATE FUNCTION my_sec_definer_function() RETURNS TABLE(ID INT)
+LANGUAGE SQL AS
+$$
+ SELECT * FROM sensitive_data_table
+$$ SECURITY DEFINER;
+
+statement ok
+CREATE FUNCTION my_non_sec_definer_function() RETURNS TABLE(ID INT)
+LANGUAGE SQL AS
+$$
+ SELECT * FROM sensitive_data_table
+$$;
+
+statement ok
+SET ROLE sensitive_user;
+
+query I rowsort
+SELECT * FROM sensitive_data_table;
+----
+
+query I rowsort
+SELECT my_sec_definer_function();
+----
+0
+1
+2
+
+query I rowsort
+SELECT my_non_sec_definer_function();
+-----
+
+statement ok
+SET ROLE root
+
+statement ok
+CREATE POLICY p1 ON sensitive_data_table FOR SELECT TO sensitive_user USING (C1 != 0);
+
+statement ok
+SET ROLE sensitive_user;
+
+query I rowsort
+SELECT my_sec_definer_function();
+----
+0
+1
+2
+
+query I rowsort
+SELECT my_non_sec_definer_function()
+----
+1
+2
+
+statement ok
+SET ROLE root
+
+statement ok
+DROP FUNCTION my_sec_definer_function;
+
+statement ok
+DROP FUNCTION my_non_sec_definer_function;
+
+statement ok
+DROP TABLE sensitive_data_table;
+
+subtest validate_statement_cache_after_rls_changes
+
+statement ok
+CREATE TABLE rls_cache_test (c1 TEXT);
+
+statement ok
+INSERT INTO rls_cache_test VALUES ('a'), ('b'), ('c');
+
+statement ok
+CREATE USER rls_cache_user;
+
+statement ok
+GRANT ALL ON rls_cache_test TO rls_cache_user;
+
+statement ok
+SET ROLE rls_cache_user;
+
+# Prime the cache
+query T
+SELECT * FROM rls_cache_test ORDER BY c1;
+----
+a
+b
+c
+
+statement ok
+SET ROLE root
+
+statement ok
+ALTER TABLE rls_cache_test ENABLE ROW LEVEL SECURITY;
+
+statement ok
+SET ROLE rls_cache_user;
+
+# The cache should be invalidated
+query T
+SELECT * FROM rls_cache_test ORDER BY c1;
+----
+
+statement ok
+SET ROLE root
+
+statement ok
+CREATE POLICY rls_cache_policy ON rls_cache_test FOR SELECT TO rls_cache_user USING (c1 != 'a');
+
+statement ok
+SET ROLE rls_cache_user;
+
+# The cache should be invalidated (again)
+query T
+SELECT * FROM rls_cache_test ORDER BY c1;
+----
+b
+c
+
+statement ok
+SET ROLE root
+
+statement ok
+ALTER TABLE rls_cache_test DISABLE ROW LEVEL SECURITY;
+
+statement ok
+SET ROLE rls_cache_user;
+
+# The cache should be invalidated (again)
+query T
+SELECT * FROM rls_cache_test ORDER BY c1;
+----
+a
+b
+c
+
+statement ok
+SET ROLE root
+
+# Ensure that the cache is invalidated when table is dropped
+statement ok
+DROP TABLE rls_cache_test;
+
+statement ok
+SET ROLE rls_cache_user;
+
+statement error pq: relation "rls_cache_test" does not exist
+SELECT * FROM rls_cache_test ORDER BY c1;
+
+statement ok
+SET ROLE root
+
+statement ok
+DROP ROLE rls_cache_user;
 
 subtest end

--- a/pkg/sql/opt/BUILD.bazel
+++ b/pkg/sql/opt/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "operator.go",
         "ordering.go",
         "panic_injection.go",
+        "row_level_security.go",
         "rule_name.go",
         "schema_dependencies.go",
         "table_meta.go",
@@ -25,6 +26,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/clusterversion",
+        "//pkg/security/username",
         "//pkg/server/telemetry",
         "//pkg/sql/catalog",
         "//pkg/sql/catalog/catpb",

--- a/pkg/sql/opt/cat/catalog.go
+++ b/pkg/sql/opt/cat/catalog.go
@@ -224,6 +224,9 @@ type Catalog interface {
 	// returns true. Returns an error if query on the `system.users` table failed
 	HasAdminRole(ctx context.Context) (bool, error)
 
+	// UserHasAdminRole checks if the specified user has admin privileges.
+	UserHasAdminRole(ctx context.Context, user username.SQLUsername) (bool, error)
+
 	// HasRoleOption converts the roleoption to its SQL column name and checks if
 	// the user belongs to a role where the option has value true. Requires a
 	// valid transaction to be open.

--- a/pkg/sql/opt/memo/BUILD.bazel
+++ b/pkg/sql/opt/memo/BUILD.bazel
@@ -83,6 +83,7 @@ go_test(
     embed = [":memo"],
     deps = [
         "//pkg/kv/kvserver/concurrency/isolation",
+        "//pkg/security/username",
         "//pkg/settings/cluster",
         "//pkg/sql/inverted",
         "//pkg/sql/opt",

--- a/pkg/sql/opt/optbuilder/row_level_security.go
+++ b/pkg/sql/opt/optbuilder/row_level_security.go
@@ -27,10 +27,11 @@ func (b *Builder) addRowLevelSecurityFilter(
 	}
 
 	// Admin users are exempt from any RLS filtering.
-	isAdmin, err := b.catalog.HasAdminRole(b.ctx)
+	isAdmin, err := b.catalog.UserHasAdminRole(b.ctx, b.checkPrivilegeUser)
 	if err != nil {
 		panic(err)
 	}
+	b.factory.Metadata().SetRLSEnabled(b.checkPrivilegeUser, isAdmin)
 	if isAdmin {
 		return
 	}

--- a/pkg/sql/opt/row_level_security.go
+++ b/pkg/sql/opt/row_level_security.go
@@ -1,0 +1,39 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package opt
+
+import "github.com/cockroachdb/cockroach/pkg/security/username"
+
+// RowLevelSecurityMeta contains metadata pertaining to row-level security
+// policies that were enforced when building the query plan.
+type RowLevelSecurityMeta struct {
+	// IsInitialized indicates that the struct has been initialized. This gets
+	// lazily initialized, only when the query plan building comes across a table
+	// that is enabled for row-level security.
+	IsInitialized bool
+
+	// User is the user that constructed the metadata. This is important since
+	// RLS policies differ based on the role of the user executing the query.
+	User username.SQLUsername
+
+	// HasAdminRole is true if the current user was part of the admin role when
+	// creating the query plan.
+	HasAdminRole bool
+}
+
+func (r *RowLevelSecurityMeta) MaybeInit(user username.SQLUsername, hasAdminRole bool) {
+	if r.IsInitialized {
+		return
+	}
+	r.User = user
+	r.HasAdminRole = hasAdminRole
+	r.IsInitialized = true
+}
+
+// Clear unsets the initialized property. This is used as a test helper.
+func (r *RowLevelSecurityMeta) Clear() {
+	r = &RowLevelSecurityMeta{}
+}

--- a/pkg/sql/opt/testutils/testcat/test_catalog.go
+++ b/pkg/sql/opt/testutils/testcat/test_catalog.go
@@ -319,9 +319,14 @@ func (tc *Catalog) CheckExecutionPrivilege(
 
 // HasAdminRole is part of the cat.Catalog interface.
 func (tc *Catalog) HasAdminRole(ctx context.Context) (bool, error) {
-	roleMembership, found := tc.users[tc.currentUser]
+	return tc.UserHasAdminRole(ctx, tc.currentUser)
+}
+
+// UserHasAdminRole is part of the cat.Catalog interface.
+func (tc *Catalog) UserHasAdminRole(ctx context.Context, user username.SQLUsername) (bool, error) {
+	roleMembership, found := tc.users[user]
 	if !found {
-		return false, errors.AssertionFailedf("user %q not found", tc.currentUser)
+		return false, errors.AssertionFailedf("user %q not found", user)
 	}
 	return roleMembership.isMemberOfAdminRole, nil
 }
@@ -477,6 +482,7 @@ func (tc *Catalog) GetDependencyDigest() cat.DependencyDigest {
 	tc.dependencyDigest++
 	return cat.DependencyDigest{
 		LeaseGeneration: tc.dependencyDigest,
+		CurrentUser:     tc.currentUser,
 	}
 }
 

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -438,6 +438,13 @@ func (oc *optCatalog) HasAdminRole(ctx context.Context) (bool, error) {
 	return oc.planner.HasAdminRole(ctx)
 }
 
+// UserHasAdminRole is part of the cat.Catalog interface.
+func (oc *optCatalog) UserHasAdminRole(
+	ctx context.Context, user username.SQLUsername,
+) (bool, error) {
+	return oc.planner.UserHasAdminRole(ctx, user)
+}
+
 // HasRoleOption is part of the cat.Catalog interface.
 func (oc *optCatalog) HasRoleOption(
 	ctx context.Context, roleOption roleoption.Option,


### PR DESCRIPTION
When reusing a query from the statement cache, we generally allow reuse if the query is to be executed by a different user. However, this approach is problematic for queries that involve row-level security (RLS), as the executing user directly influences the injected expressions. To ensure correctness, this considers the memo as stale when the user changes if RLS was used in the query.

Epic: CRDB-11724
Release note: None

Closes #136717