### PR TITLE
storage: covert SizeSpec to protobuf

### DIFF
--- a/pkg/acceptance/cluster/BUILD.bazel
+++ b/pkg/acceptance/cluster/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
         "//pkg/security",
         "//pkg/security/certnames",
         "//pkg/security/username",
+        "//pkg/storage/storagepb",
         "//pkg/testutils/datapathutils",
         "//pkg/util/log",
         "//pkg/util/log/logflags",

--- a/pkg/acceptance/cluster/dockercluster.go
+++ b/pkg/acceptance/cluster/dockercluster.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/security/certnames"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
+	"github.com/cockroachdb/cockroach/pkg/storage/storagepb"
 	"github.com/cockroachdb/cockroach/pkg/testutils/datapathutils"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/log/logflags"
@@ -484,7 +485,7 @@ func (l *DockerCluster) startNode(ctx context.Context, node *testNode, singleNod
 	for _, store := range node.stores {
 		storeSpec := base.StoreSpec{
 			Path: store.dir,
-			Size: base.SizeSpec{InBytes: int64(store.config.MaxRanges) * maxRangeBytes},
+			Size: storagepb.SizeSpec{Capacity: int64(store.config.MaxRanges) * maxRangeBytes},
 		}
 		cmd = append(cmd, fmt.Sprintf("--store=%s", storeSpec))
 	}

--- a/pkg/base/BUILD.bazel
+++ b/pkg/base/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "constants.go",
         "license.go",
         "node_id.go",
+        "size_spec.go",
         "store_spec.go",
         "test_cluster_replication_mode.go",
         "test_server_args.go",

--- a/pkg/base/BUILD.bazel
+++ b/pkg/base/BUILD.bazel
@@ -10,7 +10,6 @@ go_library(
         "constants.go",
         "license.go",
         "node_id.go",
-        "size_spec.go",
         "store_spec.go",
         "test_cluster_replication_mode.go",
         "test_server_args.go",

--- a/pkg/base/size_spec.go
+++ b/pkg/base/size_spec.go
@@ -1,0 +1,136 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package base
+
+import (
+	"bytes"
+	"fmt"
+	"regexp"
+	"strconv"
+
+	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
+	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
+	humanize "github.com/dustin/go-humanize"
+	"github.com/spf13/pflag"
+)
+
+// fractionRegex is the regular expression that recognizes whether
+// the specified size is a fraction of the total available space.
+// Proportional sizes can be expressed as fractional numbers, either
+// in absolute value or with a trailing "%" sign. A fractional number
+// without a trailing "%" must be recognized by the presence of a
+// decimal separator; numbers without decimal separators are plain
+// sizes in bytes (separate case in the parsing).
+// The first part of the regexp matches NNN.[MMM]; the second part
+// [NNN].MMM, and the last part matches explicit percentages with or
+// without a decimal separator.
+// Values smaller than 1% and 100% are rejected after parsing using
+// a separate check.
+var fractionRegex = regexp.MustCompile(`^([-]?([0-9]+\.[0-9]*|[0-9]*\.[0-9]+|[0-9]+(\.[0-9]*)?%))$`)
+
+// SizeSpec contains size in different kinds of formats supported by CLI(%age, bytes).
+type SizeSpec struct {
+	// InBytes is used for calculating free space and making rebalancing
+	// decisions. Zero indicates that there is no maximum size. This value is not
+	// actually used by the engine and thus not enforced.
+	InBytes int64
+	Percent float64
+}
+
+type intInterval struct {
+	min *int64
+	max *int64
+}
+
+type floatInterval struct {
+	min *float64
+	max *float64
+}
+
+// NewSizeSpec parses the string passed into a --size flag and returns a
+// SizeSpec if it is correctly parsed.
+func NewSizeSpec(
+	field redact.SafeString, value string, bytesRange *intInterval, percentRange *floatInterval,
+) (SizeSpec, error) {
+	var size SizeSpec
+	if fractionRegex.MatchString(value) {
+		percentFactor := 100.0
+		factorValue := value
+		if value[len(value)-1] == '%' {
+			percentFactor = 1.0
+			factorValue = value[:len(value)-1]
+		}
+		var err error
+		size.Percent, err = strconv.ParseFloat(factorValue, 64)
+		size.Percent *= percentFactor
+		if err != nil {
+			return SizeSpec{}, errors.Wrapf(err, "could not parse %s size (%s)", field, value)
+		}
+		if percentRange != nil {
+			if (percentRange.min != nil && size.Percent < *percentRange.min) ||
+				(percentRange.max != nil && size.Percent > *percentRange.max) {
+				return SizeSpec{}, errors.Newf(
+					"%s size (%s) must be between %f%% and %f%%",
+					field,
+					value,
+					*percentRange.min,
+					*percentRange.max,
+				)
+			}
+		}
+	} else {
+		var err error
+		size.InBytes, err = humanizeutil.ParseBytes(value)
+		if err != nil {
+			return SizeSpec{}, errors.Wrapf(err, "could not parse %s size (%s)", field, value)
+		}
+		if bytesRange != nil {
+			if bytesRange.min != nil && size.InBytes < *bytesRange.min {
+				return SizeSpec{}, errors.Newf("%s size (%s) must be larger than %s",
+					field, value, humanizeutil.IBytes(*bytesRange.min))
+			}
+			if bytesRange.max != nil && size.InBytes > *bytesRange.max {
+				return SizeSpec{}, errors.Newf("%s size (%s) must be smaller than %s",
+					field, value, humanizeutil.IBytes(*bytesRange.max))
+			}
+		}
+	}
+	return size, nil
+}
+
+// String returns a string representation of the SizeSpec. This is part
+// of pflag's value interface.
+func (ss *SizeSpec) String() string {
+	var buffer bytes.Buffer
+	if ss.InBytes != 0 {
+		fmt.Fprintf(&buffer, "--size=%s,", humanizeutil.IBytes(ss.InBytes))
+	}
+	if ss.Percent != 0 {
+		fmt.Fprintf(&buffer, "--size=%s%%,", humanize.Ftoa(ss.Percent))
+	}
+	return buffer.String()
+}
+
+// Type returns the underlying type in string form. This is part of pflag's
+// value interface.
+func (ss *SizeSpec) Type() string {
+	return "SizeSpec"
+}
+
+var _ pflag.Value = &SizeSpec{}
+
+// Set adds a new value to the StoreSpecValue. It is the important part of
+// pflag's value interface.
+func (ss *SizeSpec) Set(value string) error {
+	spec, err := NewSizeSpec("specified", value, nil, nil)
+	if err != nil {
+		return err
+	}
+	ss.InBytes = spec.InBytes
+	ss.Percent = spec.Percent
+	return nil
+}

--- a/pkg/base/store_spec.go
+++ b/pkg/base/store_spec.go
@@ -11,9 +11,7 @@ import (
 	"net"
 	"os"
 	"path/filepath"
-	"regexp"
 	"sort"
-	"strconv"
 	"strings"
 	"unicode"
 
@@ -52,109 +50,6 @@ func GetAbsoluteFSPath(fieldName string, p string) (string, error) {
 		return "", errors.Wrapf(err, "could not find absolute path for %s %s", fieldName, p)
 	}
 	return ret, nil
-}
-
-// SizeSpec contains size in different kinds of formats supported by CLI(%age, bytes).
-type SizeSpec struct {
-	// InBytes is used for calculating free space and making rebalancing
-	// decisions. Zero indicates that there is no maximum size. This value is not
-	// actually used by the engine and thus not enforced.
-	InBytes int64
-	Percent float64
-}
-
-type intInterval struct {
-	min *int64
-	max *int64
-}
-
-type floatInterval struct {
-	min *float64
-	max *float64
-}
-
-// NewSizeSpec parses the string passed into a --size flag and returns a
-// SizeSpec if it is correctly parsed.
-func NewSizeSpec(
-	field redact.SafeString, value string, bytesRange *intInterval, percentRange *floatInterval,
-) (SizeSpec, error) {
-	var size SizeSpec
-	if fractionRegex.MatchString(value) {
-		percentFactor := 100.0
-		factorValue := value
-		if value[len(value)-1] == '%' {
-			percentFactor = 1.0
-			factorValue = value[:len(value)-1]
-		}
-		var err error
-		size.Percent, err = strconv.ParseFloat(factorValue, 64)
-		size.Percent *= percentFactor
-		if err != nil {
-			return SizeSpec{}, errors.Wrapf(err, "could not parse %s size (%s)", field, value)
-		}
-		if percentRange != nil {
-			if (percentRange.min != nil && size.Percent < *percentRange.min) ||
-				(percentRange.max != nil && size.Percent > *percentRange.max) {
-				return SizeSpec{}, errors.Newf(
-					"%s size (%s) must be between %f%% and %f%%",
-					field,
-					value,
-					*percentRange.min,
-					*percentRange.max,
-				)
-			}
-		}
-	} else {
-		var err error
-		size.InBytes, err = humanizeutil.ParseBytes(value)
-		if err != nil {
-			return SizeSpec{}, errors.Wrapf(err, "could not parse %s size (%s)", field, value)
-		}
-		if bytesRange != nil {
-			if bytesRange.min != nil && size.InBytes < *bytesRange.min {
-				return SizeSpec{}, errors.Newf("%s size (%s) must be larger than %s",
-					field, value, humanizeutil.IBytes(*bytesRange.min))
-			}
-			if bytesRange.max != nil && size.InBytes > *bytesRange.max {
-				return SizeSpec{}, errors.Newf("%s size (%s) must be smaller than %s",
-					field, value, humanizeutil.IBytes(*bytesRange.max))
-			}
-		}
-	}
-	return size, nil
-}
-
-// String returns a string representation of the SizeSpec. This is part
-// of pflag's value interface.
-func (ss *SizeSpec) String() string {
-	var buffer bytes.Buffer
-	if ss.InBytes != 0 {
-		fmt.Fprintf(&buffer, "--size=%s,", humanizeutil.IBytes(ss.InBytes))
-	}
-	if ss.Percent != 0 {
-		fmt.Fprintf(&buffer, "--size=%s%%,", humanize.Ftoa(ss.Percent))
-	}
-	return buffer.String()
-}
-
-// Type returns the underlying type in string form. This is part of pflag's
-// value interface.
-func (ss *SizeSpec) Type() string {
-	return "SizeSpec"
-}
-
-var _ pflag.Value = &SizeSpec{}
-
-// Set adds a new value to the StoreSpecValue. It is the important part of
-// pflag's value interface.
-func (ss *SizeSpec) Set(value string) error {
-	spec, err := NewSizeSpec("specified", value, nil, nil)
-	if err != nil {
-		return err
-	}
-	ss.InBytes = spec.InBytes
-	ss.Percent = spec.Percent
-	return nil
 }
 
 // ProvisionedRateSpec is an optional part of the StoreSpec.
@@ -276,20 +171,6 @@ func (ss StoreSpec) String() string {
 func (ss StoreSpec) IsEncrypted() bool {
 	return ss.EncryptionOptions != nil
 }
-
-// fractionRegex is the regular expression that recognizes whether
-// the specified size is a fraction of the total available space.
-// Proportional sizes can be expressed as fractional numbers, either
-// in absolute value or with a trailing "%" sign. A fractional number
-// without a trailing "%" must be recognized by the presence of a
-// decimal separator; numbers without decimal separators are plain
-// sizes in bytes (separate case in the parsing).
-// The first part of the regexp matches NNN.[MMM]; the second part
-// [NNN].MMM, and the last part matches explicit percentages with or
-// without a decimal separator.
-// Values smaller than 1% and 100% are rejected after parsing using
-// a separate check.
-var fractionRegex = regexp.MustCompile(`^([-]?([0-9]+\.[0-9]*|[0-9]*\.[0-9]+|[0-9]+(\.[0-9]*)?%))$`)
 
 // NewStoreSpec parses the string passed into a --store flag and returns a
 // StoreSpec if it is correctly parsed.

--- a/pkg/base/store_spec_test.go
+++ b/pkg/base/store_spec_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/storage/storagepb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/errors"
@@ -92,13 +93,13 @@ target_file_size=2097152`
 		{"path=/mnt/hda1,attrs=hdd,attrs=ssd", "attrs field was used twice in store definition", StoreSpec{}},
 
 		// size
-		{"path=/mnt/hda1,size=671088640", "", StoreSpec{Path: "/mnt/hda1", Size: SizeSpec{InBytes: 671088640}}},
-		{"path=/mnt/hda1,size=20GB", "", StoreSpec{Path: "/mnt/hda1", Size: SizeSpec{InBytes: 20000000000}}},
-		{"size=20GiB,path=/mnt/hda1", "", StoreSpec{Path: "/mnt/hda1", Size: SizeSpec{InBytes: 21474836480}}},
-		{"size=0.1TiB,path=/mnt/hda1", "", StoreSpec{Path: "/mnt/hda1", Size: SizeSpec{InBytes: 109951162777}}},
-		{"path=/mnt/hda1,size=.1TiB", "", StoreSpec{Path: "/mnt/hda1", Size: SizeSpec{InBytes: 109951162777}}},
-		{"path=/mnt/hda1,size=123TB", "", StoreSpec{Path: "/mnt/hda1", Size: SizeSpec{InBytes: 123000000000000}}},
-		{"path=/mnt/hda1,size=123TiB", "", StoreSpec{Path: "/mnt/hda1", Size: SizeSpec{InBytes: 135239930216448}}},
+		{"path=/mnt/hda1,size=671088640", "", StoreSpec{Path: "/mnt/hda1", Size: SizeSpec{Capacity: 671088640}}},
+		{"path=/mnt/hda1,size=20GB", "", StoreSpec{Path: "/mnt/hda1", Size: SizeSpec{Capacity: 20000000000}}},
+		{"size=20GiB,path=/mnt/hda1", "", StoreSpec{Path: "/mnt/hda1", Size: SizeSpec{Capacity: 21474836480}}},
+		{"size=0.1TiB,path=/mnt/hda1", "", StoreSpec{Path: "/mnt/hda1", Size: SizeSpec{Capacity: 109951162777}}},
+		{"path=/mnt/hda1,size=.1TiB", "", StoreSpec{Path: "/mnt/hda1", Size: SizeSpec{Capacity: 109951162777}}},
+		{"path=/mnt/hda1,size=123TB", "", StoreSpec{Path: "/mnt/hda1", Size: SizeSpec{Capacity: 123000000000000}}},
+		{"path=/mnt/hda1,size=123TiB", "", StoreSpec{Path: "/mnt/hda1", Size: SizeSpec{Capacity: 135239930216448}}},
 		// %
 		{"path=/mnt/hda1,size=50.5%", "", StoreSpec{Path: "/mnt/hda1", Size: SizeSpec{Percent: 50.5}}},
 		{"path=/mnt/hda1,size=100%", "", StoreSpec{Path: "/mnt/hda1", Size: SizeSpec{Percent: 100}}},
@@ -123,18 +124,18 @@ target_file_size=2097152`
 		{"size=123TB", "no path specified", StoreSpec{}},
 
 		// ballast size
-		{"path=/mnt/hda1,ballast-size=671088640", "", StoreSpec{Path: "/mnt/hda1", BallastSize: &SizeSpec{InBytes: 671088640}}},
-		{"path=/mnt/hda1,ballast-size=20GB", "", StoreSpec{Path: "/mnt/hda1", BallastSize: &SizeSpec{InBytes: 20000000000}}},
+		{"path=/mnt/hda1,ballast-size=671088640", "", StoreSpec{Path: "/mnt/hda1", BallastSize: &SizeSpec{Capacity: 671088640}}},
+		{"path=/mnt/hda1,ballast-size=20GB", "", StoreSpec{Path: "/mnt/hda1", BallastSize: &SizeSpec{Capacity: 20000000000}}},
 		{"path=/mnt/hda1,ballast-size=1%", "", StoreSpec{Path: "/mnt/hda1", BallastSize: &SizeSpec{Percent: 1}}},
 		{"path=/mnt/hda1,ballast-size=100.000%", "ballast size (100.000%) must be between 0.000000% and 50.000000%", StoreSpec{}},
 		{"ballast-size=20GiB,path=/mnt/hda1,ballast-size=20GiB", "ballast-size field was used twice in store definition", StoreSpec{}},
 
 		// type
-		{"type=mem,size=20GiB", "", StoreSpec{Size: SizeSpec{InBytes: 21474836480}, InMemory: true}},
-		{"size=20GiB,type=mem", "", StoreSpec{Size: SizeSpec{InBytes: 21474836480}, InMemory: true}},
-		{"size=20.5GiB,type=mem", "", StoreSpec{Size: SizeSpec{InBytes: 22011707392}, InMemory: true}},
+		{"type=mem,size=20GiB", "", StoreSpec{Size: SizeSpec{Capacity: 21474836480}, InMemory: true}},
+		{"size=20GiB,type=mem", "", StoreSpec{Size: SizeSpec{Capacity: 21474836480}, InMemory: true}},
+		{"size=20.5GiB,type=mem", "", StoreSpec{Size: SizeSpec{Capacity: 22011707392}, InMemory: true}},
 		{"size=20GiB,type=mem,attrs=mem", "", StoreSpec{
-			Size:       SizeSpec{InBytes: 21474836480},
+			Size:       SizeSpec{Capacity: 21474836480},
 			InMemory:   true,
 			Attributes: roachpb.Attributes{Attrs: []string{"mem"}},
 		}},
@@ -161,11 +162,11 @@ target_file_size=2097152`
 		// all together
 		{"path=/mnt/hda1,attrs=hdd:ssd,size=20GiB", "", StoreSpec{
 			Path:       "/mnt/hda1",
-			Size:       SizeSpec{InBytes: 21474836480},
+			Size:       SizeSpec{Capacity: 21474836480},
 			Attributes: roachpb.Attributes{Attrs: []string{"hdd", "ssd"}},
 		}},
 		{"type=mem,attrs=hdd:ssd,size=20GiB", "", StoreSpec{
-			Size:       SizeSpec{InBytes: 21474836480},
+			Size:       SizeSpec{Capacity: 21474836480},
 			InMemory:   true,
 			Attributes: roachpb.Attributes{Attrs: []string{"hdd", "ssd"}},
 		}},
@@ -218,8 +219,8 @@ target_file_size=2097152`
 // StoreSpec aliases base.StoreSpec for convenience.
 type StoreSpec = base.StoreSpec
 
-// SizeSpec aliases base.SizeSpec for convenience.
-type SizeSpec = base.SizeSpec
+// SizeSpec aliases storagepb.SizeSpec for convenience.
+type SizeSpec = storagepb.SizeSpec
 
 func TestJoinListType(t *testing.T) {
 	defer leaktest.AfterTest(t)()

--- a/pkg/base/test_server_args.go
+++ b/pkg/base/test_server_args.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/storage/storagepb"
 	"github.com/cockroachdb/cockroach/pkg/testutils/listenerutil"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
@@ -490,8 +491,8 @@ var (
 	// with no special attributes.
 	DefaultTestStoreSpec = StoreSpec{
 		InMemory: true,
-		Size: SizeSpec{
-			InBytes: 512 << 20,
+		Size: storagepb.SizeSpec{
+			Capacity: 512 << 20,
 		},
 	}
 )

--- a/pkg/ccl/storageccl/engineccl/encrypted_fs_test.go
+++ b/pkg/ccl/storageccl/engineccl/encrypted_fs_test.go
@@ -252,7 +252,7 @@ func TestPebbleEncryption(t *testing.T) {
 			base.StoreSpec{
 				InMemory:          true,
 				Attributes:        roachpb.Attributes{},
-				Size:              base.SizeSpec{InBytes: 512 << 20},
+				Size:              storagepb.SizeSpec{Capacity: 512 << 20},
 				EncryptionOptions: encOptions,
 				StickyVFSID:       stickyVFSID,
 			},
@@ -301,7 +301,7 @@ func TestPebbleEncryption(t *testing.T) {
 			base.StoreSpec{
 				InMemory:          true,
 				Attributes:        roachpb.Attributes{},
-				Size:              base.SizeSpec{InBytes: 512 << 20},
+				Size:              storagepb.SizeSpec{Capacity: 512 << 20},
 				EncryptionOptions: encOptions,
 				StickyVFSID:       stickyVFSID,
 			},
@@ -389,7 +389,7 @@ func TestPebbleEncryption2(t *testing.T) {
 			base.StoreSpec{
 				InMemory:          true,
 				Attributes:        roachpb.Attributes{},
-				Size:              base.SizeSpec{InBytes: 512 << 20},
+				Size:              storagepb.SizeSpec{Capacity: 512 << 20},
 				EncryptionOptions: encOptions,
 				StickyVFSID:       stickyVFSID,
 			},

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -449,7 +449,7 @@ var debugCtx struct {
 	sizes             bool
 	replicated        bool
 	inputFile         string
-	ballastSize       base.SizeSpec
+	ballastSize       storagepb.SizeSpec
 	printSystemConfig bool
 	maxResults        int
 	decodeAsTableDesc string
@@ -467,7 +467,7 @@ func setDebugContextDefaults() {
 	debugCtx.sizes = false
 	debugCtx.replicated = false
 	debugCtx.inputFile = ""
-	debugCtx.ballastSize = base.SizeSpec{InBytes: 1000000000}
+	debugCtx.ballastSize = storagepb.SizeSpec{Capacity: 1000000000}
 	debugCtx.maxResults = 0
 	debugCtx.printSystemConfig = false
 	debugCtx.decodeAsTableDesc = ""

--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -402,7 +402,7 @@ func runDebugBallast(cmd *cobra.Command, args []string) error {
 	if math.Abs(p) > 100 {
 		return errors.Errorf("absolute percentage value %f greater than 100", p)
 	}
-	b := debugCtx.ballastSize.InBytes
+	b := debugCtx.ballastSize.Capacity
 	if p != 0 && b != 0 {
 		return errors.New("expected exactly one of percentage or bytes non-zero, found both")
 	}
@@ -468,8 +468,8 @@ func runDebugRangeData(cmd *cobra.Command, args []string) error {
 
 	earlyBootAccessor := cloud.NewEarlyBootExternalStorageAccessor(serverCfg.Settings, serverCfg.ExternalIODirConfig, cidr.NewLookup(&serverCfg.Settings.SV))
 	opts := []storage.ConfigOption{storage.MustExist, storage.RemoteStorageFactory(earlyBootAccessor)}
-	if serverCfg.SharedStorage != "" {
-		es, err := cloud.ExternalStorageFromURI(ctx, serverCfg.SharedStorage,
+	if serverCfg.StorageConfig.SharedStorage.URI != "" {
+		es, err := cloud.ExternalStorageFromURI(ctx, serverCfg.StorageConfig.SharedStorage.URI,
 			base.ExternalIODirConfig{}, serverCfg.Settings, nil, username.RootUserName(), nil,
 			nil, cloud.NilMetrics)
 		if err != nil {

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -526,8 +526,11 @@ func init() {
 		_ = pf.MarkHidden(cliflags.StorageEngine.Name)
 
 		cliflagcfg.VarFlag(f, &serverCfg.StorageConfig.WALFailover, cliflags.WALFailover)
-		cliflagcfg.StringFlag(f, &serverCfg.SharedStorage, cliflags.SharedStorage)
-		cliflagcfg.VarFlag(f, &serverCfg.SecondaryCache, cliflags.SecondaryCache)
+		// TODO(storage): Consider combining the uri and cache manual settings.
+		// Alternatively remove the ability to configure shared storage without
+		// passing a bootstrap configuration file.
+		cliflagcfg.StringFlag(f, &serverCfg.StorageConfig.SharedStorage.URI, cliflags.SharedStorage)
+		cliflagcfg.VarFlag(f, &serverCfg.StorageConfig.SharedStorage.Cache, cliflags.SecondaryCache)
 		cliflagcfg.VarFlag(f, &serverCfg.MaxOffset, cliflags.MaxOffset)
 		cliflagcfg.BoolFlag(f, &serverCfg.DisableMaxOffsetCheck, cliflags.DisableMaxOffsetCheck)
 		cliflagcfg.StringFlag(f, &serverCfg.ClockDevicePath, cliflags.ClockDevice)
@@ -981,7 +984,7 @@ func init() {
 		f := debugRangeDataCmd.Flags()
 		cliflagcfg.BoolFlag(f, &debugCtx.replicated, cliflags.Replicated)
 		cliflagcfg.IntFlag(f, &debugCtx.maxResults, cliflags.Limit)
-		cliflagcfg.StringFlag(f, &serverCfg.SharedStorage, cliflags.SharedStorage)
+		cliflagcfg.StringFlag(f, &serverCfg.StorageConfig.SharedStorage.URI, cliflags.SharedStorage)
 	}
 	{
 		f := debugGossipValuesCmd.Flags()
@@ -1488,7 +1491,7 @@ func mtStartSQLFlagsInit(cmd *cobra.Command) error {
 		if spec.BallastSize == nil {
 			// Only override if there was no ballast size specified to start
 			// with.
-			zero := base.SizeSpec{InBytes: 0, Percent: 0}
+			zero := storagepb.SizeSpec{Capacity: 0, Percent: 0}
 			spec.BallastSize = &zero
 		}
 	}

--- a/pkg/cli/flags_test.go
+++ b/pkg/cli/flags_test.go
@@ -1491,7 +1491,7 @@ func TestSQLPodStorageDefaults(t *testing.T) {
 				require.NoError(t, err)
 				assert.Equal(t, td.storePath, serverCfg.Stores.Specs[0].Path)
 				for _, s := range serverCfg.Stores.Specs {
-					assert.Zero(t, s.BallastSize.InBytes)
+					assert.Zero(t, s.BallastSize.Capacity)
 					assert.Zero(t, s.BallastSize.Percent)
 				}
 			} else {

--- a/pkg/kv/kvserver/BUILD.bazel
+++ b/pkg/kv/kvserver/BUILD.bazel
@@ -499,6 +499,7 @@ go_test(
         "//pkg/storage/disk",
         "//pkg/storage/enginepb",
         "//pkg/storage/fs",
+        "//pkg/storage/storagepb",
         "//pkg/testutils",
         "//pkg/testutils/datapathutils",
         "//pkg/testutils/echotest",

--- a/pkg/kv/kvserver/client_metrics_test.go
+++ b/pkg/kv/kvserver/client_metrics_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/fs"
+	"github.com/cockroachdb/cockroach/pkg/storage/storagepb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
@@ -252,8 +253,8 @@ func TestStoreMetrics(t *testing.T) {
 			InMemory:    true,
 			StickyVFSID: strconv.FormatInt(int64(i), 10),
 			// Specify a size to trigger the BlockCache in Pebble.
-			Size: base.SizeSpec{
-				InBytes: 512 << 20, /* 512 MiB */
+			Size: storagepb.SizeSpec{
+				Capacity: 512 << 20, /* 512 MiB */
 			},
 		}
 		stickyServerArgs[i] = base.TestServerArgs{

--- a/pkg/kv/kvserver/metrics_test.go
+++ b/pkg/kv/kvserver/metrics_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/storage/storagepb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -105,7 +106,7 @@ func TestPebbleDiskWriteMetrics(t *testing.T) {
 	ts, _, kvDB := serverutils.StartServer(t, base.TestServerArgs{
 		DefaultTestTenant: base.TestControlsTenantsExplicitly,
 		StoreSpecs: []base.StoreSpec{
-			{Size: base.SizeSpec{InBytes: base.MinimumStoreSize}, Path: tmpDir},
+			{Size: storagepb.SizeSpec{Capacity: base.MinimumStoreSize}, Path: tmpDir},
 		},
 	})
 	defer ts.Stopper().Stop(ctx)

--- a/pkg/kv/kvserver/replicate_queue_test.go
+++ b/pkg/kv/kvserver/replicate_queue_test.go
@@ -204,7 +204,6 @@ func TestReplicateQueueRebalanceMultiStore(t *testing.T) {
 		spec = func(node int, store int) base.StoreSpec {
 			return base.StoreSpec{
 				Path: filepath.Join(td, fmt.Sprintf("n%ds%d", node, store)),
-				Size: base.SizeSpec{},
 			}
 		}
 		t.Cleanup(func() {

--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -553,6 +553,7 @@ go_test(
         "//pkg/storage/disk",
         "//pkg/storage/enginepb",
         "//pkg/storage/fs",
+        "//pkg/storage/storagepb",
         "//pkg/testutils",
         "//pkg/testutils/datapathutils",
         "//pkg/testutils/listenerutil",

--- a/pkg/server/config_test.go
+++ b/pkg/server/config_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage/disk"
+	"github.com/cockroachdb/cockroach/pkg/storage/storagepb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
@@ -37,7 +38,7 @@ func TestParseInitNodeAttributes(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	cfg := MakeConfig(context.Background(), cluster.MakeTestingClusterSettings())
 	cfg.Attrs = "attr1=val1::attr2=val2"
-	cfg.Stores = base.StoreSpecList{Specs: []base.StoreSpec{{InMemory: true, Size: base.SizeSpec{InBytes: base.MinimumStoreSize * 100}}}}
+	cfg.Stores = base.StoreSpecList{Specs: []base.StoreSpec{{InMemory: true, Size: storagepb.SizeSpec{Capacity: base.MinimumStoreSize * 100}}}}
 	engines, err := cfg.CreateEngines(context.Background())
 	if err != nil {
 		t.Fatalf("Failed to initialize stores: %s", err)
@@ -65,9 +66,9 @@ func TestCreateEnginesWithMultipleStores(t *testing.T) {
 	tmpDir2, cleanup2 := testutils.TempDir(t)
 	defer cleanup2()
 	cfg.Stores = base.StoreSpecList{Specs: []base.StoreSpec{
-		{Size: base.SizeSpec{InBytes: base.MinimumStoreSize}, Path: tmpDir1},
-		{Size: base.SizeSpec{InBytes: base.MinimumStoreSize}, Path: tmpDir2},
-		{InMemory: true, Size: base.SizeSpec{InBytes: base.MinimumStoreSize * 100}},
+		{Size: storagepb.SizeSpec{Capacity: base.MinimumStoreSize}, Path: tmpDir1},
+		{Size: storagepb.SizeSpec{Capacity: base.MinimumStoreSize}, Path: tmpDir2},
+		{InMemory: true, Size: storagepb.SizeSpec{Capacity: base.MinimumStoreSize * 100}},
 	}}
 	engines, err := cfg.CreateEngines(context.Background())
 	if err != nil {
@@ -93,7 +94,7 @@ func TestParseJoinUsingAddrs(t *testing.T) {
 
 	cfg := MakeConfig(context.Background(), cluster.MakeTestingClusterSettings())
 	cfg.JoinList = []string{"localhost:12345", "[::1]:23456", "f00f::1234", ":34567", ":0", ":", "", "localhost"}
-	cfg.Stores = base.StoreSpecList{Specs: []base.StoreSpec{{InMemory: true, Size: base.SizeSpec{InBytes: base.MinimumStoreSize * 100}}}}
+	cfg.Stores = base.StoreSpecList{Specs: []base.StoreSpec{{InMemory: true, Size: storagepb.SizeSpec{Capacity: base.MinimumStoreSize * 100}}}}
 	engines, err := cfg.CreateEngines(context.Background())
 	if err != nil {
 		t.Fatalf("Failed to initialize stores: %s", err)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -290,6 +290,9 @@ func NewServer(cfg Config, stopper *stop.Stopper) (serverctl.ServerStartupInterf
 
 	engines, err := cfg.CreateEngines(ctx)
 	if err != nil {
+		if true {
+			panic(err)
+		}
 		return nil, errors.Wrap(err, "failed to create engines")
 	}
 	stopper.AddCloser(&engines)
@@ -880,7 +883,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (serverctl.ServerStartupInterf
 		KVMemoryMonitor:              kvMemoryMonitor,
 		RangefeedBudgetFactory:       rangeFeedBudgetFactory,
 		RaftEntriesMonitor:           raftEntriesMonitor,
-		SharedStorageEnabled:         cfg.SharedStorage != "",
+		SharedStorageEnabled:         cfg.StorageConfig.SharedStorage.URI != "",
 		SystemConfigProvider:         systemConfigWatcher,
 		SpanConfigSubscriber:         spanConfig.subscriber,
 		RangeLogWriter:               rangeLogWriter,

--- a/pkg/storage/ballast.go
+++ b/pkg/storage/ballast.go
@@ -7,6 +7,7 @@ package storage
 
 import (
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/storage/storagepb"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/sysutil"
 	"github.com/cockroachdb/errors"
@@ -83,7 +84,7 @@ func IsDiskFull(fs vfs.FS, spec base.StoreSpec) (bool, error) {
 // smaller.
 func BallastSizeBytes(spec base.StoreSpec, diskUsage vfs.DiskUsage) int64 {
 	if spec.BallastSize != nil {
-		v := spec.BallastSize.InBytes
+		v := spec.BallastSize.Capacity
 		if spec.BallastSize.Percent != 0 {
 			v = int64(float64(diskUsage.TotalBytes) * spec.BallastSize.Percent / 100)
 		}
@@ -103,8 +104,8 @@ func BallastSizeBytes(spec base.StoreSpec, diskUsage vfs.DiskUsage) int64 {
 // explicit ballast size (either in bytes or as a percentage of the disk's total
 // capacity), that size is used. A zero value for cacheSize results in no
 // secondary cache.
-func SecondaryCacheBytes(cacheSize base.SizeSpec, diskUsage vfs.DiskUsage) int64 {
-	v := cacheSize.InBytes
+func SecondaryCacheBytes(cacheSize storagepb.SizeSpec, diskUsage vfs.DiskUsage) int64 {
+	v := cacheSize.Capacity
 	if cacheSize.Percent != 0 {
 		v = int64(float64(diskUsage.TotalBytes) * cacheSize.Percent / 100)
 	}

--- a/pkg/storage/ballast_test.go
+++ b/pkg/storage/ballast_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/storage/storagepb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/sysutil"
@@ -43,17 +44,17 @@ func TestBallastSizeBytes(t *testing.T) {
 			want:       256 << 20, // 256 MiB
 		},
 		{
-			StoreSpec:  base.StoreSpec{BallastSize: &base.SizeSpec{InBytes: 1 << 30 /* 1 GiB */}},
+			StoreSpec:  base.StoreSpec{BallastSize: &storagepb.SizeSpec{Capacity: 1 << 30 /* 1 GiB */}},
 			totalBytes: 25 << 30, // 25 GiB
 			want:       1 << 30,  // 1 GiB
 		},
 		{
-			StoreSpec:  base.StoreSpec{BallastSize: &base.SizeSpec{Percent: 20}},
+			StoreSpec:  base.StoreSpec{BallastSize: &storagepb.SizeSpec{Percent: 20}},
 			totalBytes: 25 << 30, // 25 GiB
 			want:       5 << 30,  // 5 GiB
 		},
 		{
-			StoreSpec:  base.StoreSpec{BallastSize: &base.SizeSpec{Percent: 20}},
+			StoreSpec:  base.StoreSpec{BallastSize: &storagepb.SizeSpec{Percent: 20}},
 			totalBytes: 500 << 30, // 500 GiB
 			want:       100 << 30, // 100 GiB
 		},
@@ -124,7 +125,7 @@ func TestIsDiskFull(t *testing.T) {
 	})
 	t.Run("truncating ballast frees enough space", func(t *testing.T) {
 		spec := base.StoreSpec{
-			BallastSize: &base.SizeSpec{InBytes: 1024},
+			BallastSize: &storagepb.SizeSpec{Capacity: 1024},
 		}
 		// Provide two disk usages. The second one will be returned
 		// post-truncation.
@@ -143,7 +144,7 @@ func TestIsDiskFull(t *testing.T) {
 	})
 	t.Run("configured ballast, plenty of space", func(t *testing.T) {
 		spec := base.StoreSpec{
-			BallastSize: &base.SizeSpec{InBytes: 5 << 30 /* 5 GiB */},
+			BallastSize: &storagepb.SizeSpec{Capacity: 5 << 30 /* 5 GiB */},
 		}
 		fs, cleanup := setup(t, &spec, 0 /* ballastSize */, vfs.DiskUsage{
 			AvailBytes: 25 << 30,  // 25 GiB

--- a/pkg/storage/fs/BUILD.bazel
+++ b/pkg/storage/fs/BUILD.bazel
@@ -55,6 +55,7 @@ go_test(
         "//pkg/settings/cluster",
         "//pkg/storage",
         "//pkg/storage/enginepb",
+        "//pkg/storage/storagepb",
         "//pkg/testutils/datapathutils",
         "//pkg/testutils/skip",
         "//pkg/util/debugutil",

--- a/pkg/storage/fs/sticky_vfs_test.go
+++ b/pkg/storage/fs/sticky_vfs_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/fs"
+	"github.com/cockroachdb/cockroach/pkg/storage/storagepb"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/stretchr/testify/require"
@@ -35,7 +36,7 @@ func TestStickyVFS(t *testing.T) {
 		InMemory:    true,
 		StickyVFSID: "engine1",
 		Attributes:  attrs,
-		Size:        base.SizeSpec{InBytes: storeSize},
+		Size:        storagepb.SizeSpec{Capacity: storeSize},
 	}
 	fs1 := registry.Get(spec1.StickyVFSID)
 	env, err := fs.InitEnvFromStoreSpec(ctx, spec1, fs.ReadWrite, registry, nil /* statsCollector */)

--- a/pkg/storage/storagepb/BUILD.bazel
+++ b/pkg/storage/storagepb/BUILD.bazel
@@ -29,6 +29,7 @@ go_library(
     name = "storagepb",
     srcs = [
         "encryption_spec.go",
+        "size_spec.go",
         "wal_failover.go",
     ],
     embed = [":storagepb_go_proto"],
@@ -36,8 +37,10 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/cli/cliflags",
+        "//pkg/util/humanizeutil",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_redact//:redact",
+        "@com_github_dustin_go_humanize//:go-humanize",
         "@com_github_spf13_pflag//:pflag",
     ],
 )

--- a/pkg/storage/storagepb/storage.proto
+++ b/pkg/storage/storagepb/storage.proto
@@ -80,6 +80,27 @@ message WALFailover {
   ExternalPath prev_path = 3 [ (gogoproto.nullable) = false ];
 }
 
+// SizeSpec are used to specify how much of a file system can be used. It
+// can be specified in either a capacity or a percent.
+message SizeSpec {
+  option (gogoproto.goproto_stringer) = false;
+  // Capacity is how much space on the file system to use. if 0 then use the
+  // entire disk.
+  int64 capacity = 1;
+  // Percent can only be set if capacity is 0. If it is set then capacity is
+  // computed based on the space on this percent of the disk.
+  double percent = 2;
+}
+
+// SharedStorage specifies the properties of the shared storage.
+message SharedStorage {
+  // URI is the base location to read and write shared storage files.
+  string uri = 1 [ (gogoproto.customname) = "URI" ];
+  // Cache is the size of the secondary cache used to store blocks from
+  // disaggregated shared storage.
+  SizeSpec cache = 2 [ (gogoproto.nullable) = false ];
+}
+
 // NodeConfig is all the node level storage related configurations for this
 // node. This structure is persisted to all stores and can be used to bootstrap
 // the node.
@@ -88,4 +109,8 @@ message NodeConfig {
   // a store's primary WAL increases.
   WALFailover wal_failover = 2
       [ (gogoproto.nullable) = false, (gogoproto.customname) = "WALFailover" ];
+
+  // SharedStorage is specified to enable disaggregated shared storage. It is
+  // enabled if the uri is set.
+  SharedStorage shared_storage = 4 [ (gogoproto.nullable) = false ];
 }


### PR DESCRIPTION
This commit moves SizeSpec to the storagepb directory and converts it toa protobuf. Additionally it pulls shared storage into the global StorageConfig file.

Epic: none

Release note: None