### PR TITLE
release-24.1: sql: retry when reading pg_catalog tables with an old timestamp

### DIFF
--- a/pkg/sql/authorization.go
+++ b/pkg/sql/authorization.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/settings"
@@ -108,12 +109,33 @@ func (m *MembershipCache) RunAtCacheReadTS(
 	}
 
 	// If we found a historical timestamp to use, run in a different transaction.
-	return db.DescsTxn(ctx, func(ctx context.Context, newTxn descs.Txn) error {
+	if err := db.DescsTxn(ctx, func(ctx context.Context, newTxn descs.Txn) error {
 		if err := newTxn.KV().SetFixedTimestamp(ctx, readTS); err != nil {
 			return err
 		}
 		return f(ctx, newTxn)
-	})
+	}); err != nil {
+		if errors.HasType(err, (*kvpb.BatchTimestampBeforeGCError)(nil)) {
+			// If we picked a timestamp that has already been GC'd, then we modify
+			// cache to mark it as stale so it's refreshed on the next access,
+			// release the lease, and retry.
+			func() {
+				m.Lock()
+				defer m.Unlock()
+				m.tableVersion = 0
+			}()
+			txn.Descriptors().ReleaseSpecifiedLeases(ctx, []lease.IDVersion{
+				{
+					Name:    tableDesc.GetName(),
+					ID:      tableDesc.GetID(),
+					Version: tableDesc.GetVersion(),
+				},
+			})
+			return m.RunAtCacheReadTS(ctx, db, txn, f)
+		}
+		return err
+	}
+	return nil
 }
 
 // userRoleMembership is a mapping of "rolename" -> "with admin option".


### PR DESCRIPTION
Backport 1/1 commits from #139532.

/cc @cockroachdb/release

Release justification: high priority bug fix

---

If there is a timestamp error, we will now mark the cache as stale,
kelease the lease, and retry. This will cause a more recent read
timestamp to be used, and will also cause the cache to be refreshed on
the next access.

fixes https://github.com/cockroachdb/cockroach/issues/139512

Release note (bug fix): Fixed a bug that could cause SHOW TABLES and
other introspection operations to encounter a "batch timestamp
must be after replica GC threshold" error.

