### PR TITLE
Revert "sql/stats: generation count was incorrectly incremented on each look up"

### DIFF
--- a/pkg/sql/catalog/descs/collection.go
+++ b/pkg/sql/catalog/descs/collection.go
@@ -138,11 +138,6 @@ type Collection struct {
 	// It must be set in the multi-tenant environment for ephemeral
 	// SQL pods. It should not be set otherwise.
 	sqlLivenessSession sqlliveness.Session
-
-	// LeaseGeneration is the first generation value observed by this
-	// txn. This guarantees the generation for long-running transactions
-	// this value stays the same for the life of the transaction.
-	leaseGeneration int64
 }
 
 // FromTxn is a convenience function to extract a descs.Collection which is
@@ -204,7 +199,6 @@ func (tc *Collection) ReleaseLeases(ctx context.Context) {
 	tc.leased.releaseAll(ctx)
 	// Clear the associated sqlliveness.session
 	tc.sqlLivenessSession = nil
-	tc.leaseGeneration = 0
 }
 
 // ReleaseAll releases all state currently held by the Collection.
@@ -216,27 +210,11 @@ func (tc *Collection) ReleaseAll(ctx context.Context) {
 	tc.skipValidationOnWrite = false
 }
 
-// ResetLeaseGeneration selects an initial value at the beginning of a txn
-// for lease generation.
-func (tc *Collection) ResetLeaseGeneration() {
-	// Note: If a collection doesn't have a lease manager assigned, then
-	// no generation will be selected. This can only happen with either
-	// bare-bones collections or test cases.
-	if tc.leased.lm != nil {
-		tc.leaseGeneration = tc.leased.lm.GetLeaseGeneration()
-	}
-}
-
 // GetLeaseGeneration provides an integer which will change whenever new
 // descriptor versions are available. This can be used for fast comparisons
 // to make sure previously looked up information is still valid.
 func (tc *Collection) GetLeaseGeneration() int64 {
-	// Sanity: Pick a lease generation if one hasn't been set.
-	if tc.leaseGeneration == 0 {
-		tc.ResetLeaseGeneration()
-	}
-	// Return the cached lease generation, one should have been set earlier.
-	return tc.leaseGeneration
+	return tc.leased.lm.GetLeaseGeneration()
 }
 
 // HasUncommittedTables returns true if the Collection contains uncommitted

--- a/pkg/sql/catalog/descs/factory.go
+++ b/pkg/sql/catalog/descs/factory.go
@@ -144,19 +144,12 @@ func (cf *CollectionFactory) NewCollection(ctx context.Context, options ...Optio
 		opt(&cfg)
 	}
 	v := cf.settings.Version.ActiveVersion(ctx)
-	// If the leaseMgr  is nil then ensure we have a nil LeaseManager interface,
-	// otherwise comparisons against a nil implementation will fail.
-	var lm LeaseManager
-	lm = cf.leaseMgr
-	if cf.leaseMgr == nil {
-		lm = nil
-	}
 	return &Collection{
 		settings:                cf.settings,
 		version:                 v,
 		hydrated:                cf.hydrated,
 		virtual:                 makeVirtualDescriptors(cf.virtualSchemas),
-		leased:                  makeLeasedDescriptors(lm),
+		leased:                  makeLeasedDescriptors(cf.leaseMgr),
 		uncommitted:             makeUncommittedDescriptors(cfg.monitor),
 		uncommittedComments:     makeUncommittedComments(),
 		uncommittedZoneConfigs:  makeUncommittedZoneConfigs(),

--- a/pkg/sql/catalog/lease/lease.go
+++ b/pkg/sql/catalog/lease/lease.go
@@ -1281,7 +1281,6 @@ func NewLeaseManager(
 		sem:              quotapool.NewIntPool("lease manager", leaseConcurrencyLimit),
 		refreshAllLeases: make(chan struct{}),
 	}
-	lm.leaseGeneration.Swap(1) // Start off with 1 as the initial value.
 	lm.storage.regionPrefix = &atomic.Value{}
 	lm.storage.regionPrefix.Store(enum.One)
 	lm.storage.sessionBasedLeasingMode = lm

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -4010,7 +4010,7 @@ func (ex *connExecutor) txnStateTransitionsApplyWrapper(
 		// Session is considered active when executing a transaction.
 		ex.totalActiveTimeStopWatch.Start()
 
-		if err := ex.maybeSetSQLLivenessSessionAndGeneration(); err != nil {
+		if err := ex.maybeSetSQLLivenessSession(); err != nil {
 			return advanceInfo{}, err
 		}
 	case txnCommit:
@@ -4115,7 +4115,7 @@ func (ex *connExecutor) txnStateTransitionsApplyWrapper(
 		// In addition to resetting the extraTxnState, the restart event may
 		// also need to reset the sqlliveness.Session.
 		ex.resetExtraTxnState(ex.Ctx(), advInfo.txnEvent, payloadErr)
-		if err := ex.maybeSetSQLLivenessSessionAndGeneration(); err != nil {
+		if err := ex.maybeSetSQLLivenessSession(); err != nil {
 			return advanceInfo{}, err
 		}
 	default:
@@ -4186,7 +4186,7 @@ func (ex *connExecutor) waitForTxnJobs() error {
 	return retErr
 }
 
-func (ex *connExecutor) maybeSetSQLLivenessSessionAndGeneration() error {
+func (ex *connExecutor) maybeSetSQLLivenessSession() error {
 	if !ex.server.cfg.Codec.ForSystemTenant() ||
 		ex.server.cfg.TestingKnobs.ForceSQLLivenessSession {
 		// Update the leased descriptor collection with the current sqlliveness.Session.
@@ -4201,8 +4201,6 @@ func (ex *connExecutor) maybeSetSQLLivenessSessionAndGeneration() error {
 		}
 		ex.extraTxnState.descCollection.SetSession(session)
 	}
-	// Reset the lease generation at the same time.
-	ex.extraTxnState.descCollection.ResetLeaseGeneration()
 	return nil
 }
 

--- a/pkg/sql/stats/stats_cache.go
+++ b/pkg/sql/stats/stats_cache.go
@@ -337,6 +337,7 @@ func (sc *TableStatisticsCache) getTableStatsFromCache(
 ) ([]*TableStatistic, error) {
 	sc.mu.Lock()
 	defer sc.mu.Unlock()
+	defer sc.generation.Add(1)
 
 	if found, e := sc.lookupStatsLocked(ctx, tableID, false /* stealthy */); found {
 		if e.isStale(forecast, udtCols) {


### PR DESCRIPTION
This original PR introduced regres TestRaceWithBackfill failed, so we reverting it

Fixes: #140055
Release note: None
