### PR TITLE
sql: add schema support for vector indexing in CREATE TABLE

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/refcursor
+++ b/pkg/ccl/logictestccl/testdata/logic_test/refcursor
@@ -573,29 +573,29 @@ statement ok
 CREATE TABLE t112099_no_index (x INT NOT NULL, y TEXT NOT NULL, r REFCURSOR NOT NULL);
 
 # REFCURSOR is not allowed in a primary key.
-statement error pgcode 0A000 pq: unimplemented: column r is of type refcursor and thus is not indexable
+statement error pgcode 0A000 pq: unimplemented: column r has type refcursor, which is not indexable
 CREATE TABLE t112099 (r REFCURSOR PRIMARY KEY);
 
-statement error pgcode 0A000 pq: unimplemented: column r is of type refcursor and thus is not indexable
+statement error pgcode 0A000 pq: unimplemented: column r has type refcursor, which is not indexable
 CREATE TABLE t112099 (x INT, y TEXT, r REFCURSOR, PRIMARY KEY (x, r, y));
 
-statement error pgcode 0A000 pq: unimplemented: column r is of type refcursor and thus is not indexable
+statement error pgcode 0A000 pq: unimplemented: column r has type refcursor, which is not indexable
 ALTER TABLE t112099_no_index ADD PRIMARY KEY (r);
 
-statement error pgcode 0A000 pq: unimplemented: column r is of type refcursor and thus is not indexable
+statement error pgcode 0A000 pq: unimplemented: column r has type refcursor, which is not indexable
 ALTER TABLE t112099_no_index ADD PRIMARY KEY (x, r, y);
 
 # REFCURSOR is not allowed in a secondary index.
-statement error pgcode 0A000 pq: unimplemented: column r is of type refcursor and thus is not indexable
+statement error pgcode 0A000 pq: unimplemented: column r has type refcursor, which is not indexable
 CREATE TABLE t112099 (r REFCURSOR, INDEX (r));
 
-statement error pgcode 0A000 pq: unimplemented: column r is of type refcursor and thus is not indexable
+statement error pgcode 0A000 pq: unimplemented: column r has type refcursor, which is not indexable
 CREATE TABLE t112099 (x INT, y TEXT, r REFCURSOR, INDEX (x, r, y));
 
-statement error pgcode 0A000 pq: unimplemented: column r is of type refcursor and thus is not indexable
+statement error pgcode 0A000 pq: unimplemented: column r has type refcursor, which is not indexable
 CREATE INDEX ON t112099_no_index (r);
 
-statement error pgcode 0A000 pq: unimplemented: column r is of type refcursor and thus is not indexable
+statement error pgcode 0A000 pq: unimplemented: column r has type refcursor, which is not indexable
 CREATE INDEX ON t112099_no_index (x, r, y);
 
 # Regression test for #115701 - REFCURSOR[] is not a valid index column.
@@ -605,40 +605,35 @@ statement ok
 CREATE TABLE t115701_no_index (x INT NOT NULL, y TEXT NOT NULL, r REFCURSOR[] NOT NULL);
 
 # REFCURSOR[] is not allowed in a primary key.
-statement error pgcode 0A000 pq: unimplemented: column r is of type refcursor\[\] and thus is not indexable
+statement error pgcode 0A000 pq: unimplemented: column r has type refcursor\[\], which is not indexable
 CREATE TABLE t115701 (r REFCURSOR[] PRIMARY KEY);
 
-statement error pgcode 0A000 pq: unimplemented: column r is of type refcursor\[\] and thus is not indexable
+statement error pgcode 0A000 pq: unimplemented: column r has type refcursor\[\], which is not indexable
 CREATE TABLE t115701 (x INT, y TEXT, r REFCURSOR[], PRIMARY KEY (x, r, y));
 
-statement error pgcode 0A000 pq: unimplemented: column r is of type refcursor\[\] and thus is not indexable
+statement error pgcode 0A000 pq: unimplemented: column r has type refcursor\[\], which is not indexable
 ALTER TABLE t115701_no_index ADD PRIMARY KEY (r);
 
-statement error pgcode 0A000 pq: unimplemented: column r is of type refcursor\[\] and thus is not indexable
+statement error pgcode 0A000 pq: unimplemented: column r has type refcursor\[\], which is not indexable
 ALTER TABLE t115701_no_index ADD PRIMARY KEY (x, r, y);
 
 # REFCURSOR[] is not allowed in a secondary index.
-statement error pgcode 0A000 pq: unimplemented: column r is of type refcursor\[\] and thus is not indexable
+statement error pgcode 0A000 pq: unimplemented: column r has type refcursor\[\], which is not indexable
 CREATE TABLE t115701 (r REFCURSOR[], INDEX (r));
 
-statement error pgcode 0A000 pq: unimplemented: column r is of type refcursor\[\] and thus is not indexable
+statement error pgcode 0A000 pq: unimplemented: column r has type refcursor\[\], which is not indexable
 CREATE TABLE t115701 (x INT, y TEXT, r REFCURSOR[], INDEX (x, r, y));
 
-statement error pgcode 0A000 pq: unimplemented: column r is of type refcursor\[\] and thus is not indexable
+statement error pgcode 0A000 pq: unimplemented: column r has type refcursor\[\], which is not indexable
 CREATE INDEX ON t115701_no_index (r);
 
-statement error pgcode 0A000 pq: unimplemented: column r is of type refcursor\[\] and thus is not indexable
+statement error pgcode 0A000 pq: unimplemented: column r has type refcursor\[\], which is not indexable
 CREATE INDEX ON t115701_no_index (x, r, y);
 
-statement error pgcode 0A000 pq: column r of type refcursor\[\] is not allowed as the last column in an inverted index
+statement error pgcode 0A000 pq: column r has type refcursor\[\], which is not allowed as the last column in an inverted index
 CREATE INDEX ON t115701_no_index USING GIN (r)
 
-skipif config local-legacy-schema-changer
-statement error pgcode 0A000 pq: unimplemented: column r is of type refcursor\[\] and thus is not indexable
-CREATE INDEX ON t115701_no_index USING GIN (x, r, y gin_trgm_ops)
-
-onlyif config local-legacy-schema-changer
-statement error pgcode 0A000  pq: column r of type refcursor\[\] is only allowed as the last column in an inverted index
+statement error pgcode 0A000 pq: unimplemented: column r has type refcursor\[\], which is not indexable
 CREATE INDEX ON t115701_no_index USING GIN (x, r, y gin_trgm_ops)
 
 # REFCURSOR is allowed as a STORING column.

--- a/pkg/ccl/logictestccl/testdata/logic_test/vector
+++ b/pkg/ccl/logictestccl/testdata/logic_test/vector
@@ -12,7 +12,7 @@ CREATE TABLE v (v vector(0))
 statement error pgcode 42601 dimensions for type vector cannot exceed 16000
 CREATE TABLE v (v vector(16001))
 
-statement error column v is of type vector and thus is not indexable
+statement error column v has type vector, which is not indexable in a non-vector index
 CREATE TABLE v (v vector(2) PRIMARY KEY)
 
 statement ok
@@ -188,8 +188,5 @@ CREATE INDEX ON t_vec USING CSPANN (v);
 
 statement ok
 DROP TABLE t_vec;
-
-statement error pgcode 0A000 pq: unimplemented: VECTOR indexes are not yet supported
-CREATE TABLE t_vec (k INT PRIMARY KEY, v VECTOR(128), VECTOR INDEX (v));
 
 subtest end

--- a/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
@@ -2528,6 +2528,13 @@ func TestTenantLogic_values(
 	runLogicTest(t, "values")
 }
 
+func TestTenantLogic_vector_index(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "vector_index")
+}
+
 func TestTenantLogic_vectorize(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/local-read-committed/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/local-read-committed/generated_test.go
@@ -2505,6 +2505,13 @@ func TestReadCommittedLogic_values(
 	runLogicTest(t, "values")
 }
 
+func TestReadCommittedLogic_vector_index(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "vector_index")
+}
+
 func TestReadCommittedLogic_vectorize_agg(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/local-repeatable-read/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/local-repeatable-read/generated_test.go
@@ -2498,6 +2498,13 @@ func TestRepeatableReadLogic_values(
 	runLogicTest(t, "values")
 }
 
+func TestRepeatableReadLogic_vector_index(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "vector_index")
+}
+
 func TestRepeatableReadLogic_vectorize_agg(
 	t *testing.T,
 ) {

--- a/pkg/sql/catalog/BUILD.bazel
+++ b/pkg/sql/catalog/BUILD.bazel
@@ -46,6 +46,7 @@ go_library(
         "//pkg/sql/sessiondatapb",
         "//pkg/sql/sqlclustersettings",
         "//pkg/sql/types",
+        "//pkg/sql/vecindex/vecpb",
         "//pkg/util",
         "//pkg/util/hlc",
         "//pkg/util/intsets",

--- a/pkg/sql/catalog/catformat/index_test.go
+++ b/pkg/sql/catalog/catformat/index_test.go
@@ -112,6 +112,12 @@ func TestIndexForDisplay(t *testing.T) {
 		ColumnNames:  []string{"a"},
 	}
 
+	// VECTOR INDEX baz (a)
+	vectorIndex := baseIndex
+	vectorIndex.Type = idxtype.VECTOR
+	vectorIndex.KeyColumnNames = []string{"a"}
+	vectorIndex.KeyColumnIDs = descpb.ColumnIDs{1}
+
 	testData := []struct {
 		index       descpb.IndexDescriptor
 		tableName   tree.TableName
@@ -265,6 +271,22 @@ func TestIndexForDisplay(t *testing.T) {
 			displayMode: IndexDisplayShowCreate,
 			expected:    "CREATE INDEX baz ON foo.public.bar (a DESC) USING HASH WITH (bucket_count=8)",
 			pgExpected:  "CREATE INDEX baz ON foo.public.bar USING btree (a DESC) USING HASH WITH (bucket_count=8)",
+		},
+		{
+			index:       vectorIndex,
+			tableName:   descpb.AnonymousTable,
+			partition:   "",
+			displayMode: IndexDisplayDefOnly,
+			expected:    "VECTOR INDEX baz (a)",
+			pgExpected:  "INDEX baz USING cspann (a)",
+		},
+		{
+			index:       vectorIndex,
+			tableName:   tableName,
+			partition:   "",
+			displayMode: IndexDisplayShowCreate,
+			expected:    "CREATE VECTOR INDEX baz ON foo.public.bar (a)",
+			pgExpected:  "CREATE INDEX baz ON foo.public.bar USING cspann (a)",
 		},
 	}
 

--- a/pkg/sql/catalog/colinfo/BUILD.bazel
+++ b/pkg/sql/catalog/colinfo/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/docs",
         "//pkg/settings/cluster",
         "//pkg/sql/catalog",
         "//pkg/sql/catalog/catpb",
@@ -24,7 +25,9 @@ go_library(
         "//pkg/sql/pgwire/pgerror",
         "//pkg/sql/sem/catconstants",
         "//pkg/sql/sem/eval",
+        "//pkg/sql/sem/idxtype",
         "//pkg/sql/sem/tree",
+        "//pkg/sql/sqlerrors",
         "//pkg/sql/types",
         "//pkg/util/encoding",
         "//pkg/util/errorutil/unimplemented",

--- a/pkg/sql/catalog/colinfo/col_type_info.go
+++ b/pkg/sql/catalog/colinfo/col_type_info.go
@@ -9,10 +9,13 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/cockroachdb/cockroach/pkg/docs"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/idxtype"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlerrors"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 	"github.com/cockroachdb/errors"
@@ -172,6 +175,12 @@ func ColumnTypeIsOnlyInvertedIndexable(t *types.T) bool {
 	return true
 }
 
+// ColumnTypeIsVectorIndexable returns true if the type t can be indexed using a
+// vector index.
+func ColumnTypeIsVectorIndexable(t *types.T) bool {
+	return t.Family() == types.PGVectorFamily
+}
+
 // MustBeValueEncoded returns true if columns of the given kind can only be value
 // encoded.
 func MustBeValueEncoded(semanticType *types.T) bool {
@@ -191,4 +200,73 @@ func MustBeValueEncoded(semanticType *types.T) bool {
 		return true
 	}
 	return false
+}
+
+// ValidateColumnForIndex checks that the given column type is allowed in the
+// given index. If "isLastCol" is true, then it is the last column in the index.
+// "colDesc" can either be a column name or an expression in the form (a + b).
+func ValidateColumnForIndex(
+	indexType idxtype.T, colDesc string, colType *types.T, isLastCol bool,
+) error {
+	// Inverted and vector indexes only allow certain types for the last column.
+	if isLastCol {
+		switch indexType {
+		case idxtype.INVERTED:
+			if !ColumnTypeIsInvertedIndexable(colType) {
+				return sqlerrors.NewInvalidLastColumnError(colDesc, colType.Name(), indexType)
+			}
+			return nil
+
+		case idxtype.VECTOR:
+			if !ColumnTypeIsVectorIndexable(colType) {
+				return sqlerrors.NewInvalidLastColumnError(colDesc, colType.Name(), indexType)
+			} else if colType.Width() <= 0 {
+				return errors.WithDetail(
+					pgerror.Newf(
+						pgcode.FeatureNotSupported,
+						"%s column %s does not have a fixed number of dimensions, so it cannot be indexed",
+						colType.Name(), colDesc,
+					),
+					"specify the number of dimensions in the type, like VECTOR(128) for 128 dimensions",
+				)
+			}
+			return nil
+		}
+	}
+
+	if !ColumnTypeIsIndexable(colType) {
+		// If the column is indexable as the last column in the right kind of
+		// index, then use a more descriptive error message.
+		if ColumnTypeIsInvertedIndexable(colType) {
+			if indexType == idxtype.INVERTED {
+				// Column type is allowed, but only as the last column.
+				return sqlerrors.NewColumnOnlyIndexableError(colDesc, colType.Name(), idxtype.INVERTED)
+			}
+
+			// Column type is allowed in an inverted index.
+			return errors.WithHint(pgerror.Newf(
+				pgcode.FeatureNotSupported,
+				"column %s has type %s, which is not indexable in a non-inverted index",
+				colDesc, colType),
+				"you may want to create an inverted index instead. See the documentation for inverted indexes: "+docs.URL("inverted-indexes.html"))
+		}
+
+		if ColumnTypeIsVectorIndexable(colType) {
+			if indexType == idxtype.VECTOR {
+				// Column type is allowed, but only as the last column.
+				return sqlerrors.NewColumnOnlyIndexableError(colDesc, colType.Name(), idxtype.VECTOR)
+			}
+
+			// Column type is allowed in a vector index.
+			return errors.WithHint(pgerror.Newf(
+				pgcode.FeatureNotSupported,
+				"column %s has type %s, which is not indexable in a non-vector index",
+				colDesc, colType),
+				"you may want to create a vector index instead")
+		}
+
+		return sqlerrors.NewColumnNotIndexableError(colDesc, colType.Name(), colType.DebugString())
+	}
+
+	return nil
 }

--- a/pkg/sql/catalog/descpb/index.go
+++ b/pkg/sql/catalog/descpb/index.go
@@ -97,7 +97,7 @@ func (desc *IndexDescriptor) GetName() string {
 }
 
 // InvertedColumnID returns the ColumnID of the inverted column of the inverted
-// index. This is always the last column in ColumnIDs. Panics if the index is
+// index. This is always the last column in KeyColumnIDs. Panics if the index is
 // not inverted.
 func (desc *IndexDescriptor) InvertedColumnID() ColumnID {
 	if desc.Type != idxtype.INVERTED {
@@ -125,4 +125,24 @@ func (desc *IndexDescriptor) InvertedColumnKeyType() *types.T {
 		panic(errors.AssertionFailedf("index is not inverted"))
 	}
 	return types.EncodedKey
+}
+
+// VectorColumnID returns the ColumnID of the vector column of the vector index.
+// This is always the last column in KeyColumnIDs. Panics if the index is not a
+// vector index.
+func (desc *IndexDescriptor) VectorColumnID() ColumnID {
+	if desc.Type != idxtype.VECTOR {
+		panic(errors.AssertionFailedf("index is not a vector index"))
+	}
+	return desc.KeyColumnIDs[len(desc.KeyColumnIDs)-1]
+}
+
+// VectorColumnName returns the name of the vector column of the vector index.
+// This is always the last column in KeyColumnNames. Panics if the index is
+// not a vector index.
+func (desc *IndexDescriptor) VectorColumnName() string {
+	if desc.Type != idxtype.VECTOR {
+		panic(errors.AssertionFailedf("index is not a vector index"))
+	}
+	return desc.KeyColumnNames[len(desc.KeyColumnNames)-1]
 }

--- a/pkg/sql/catalog/table_elements.go
+++ b/pkg/sql/catalog/table_elements.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/semenumpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/sql/vecindex/vecpb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/intsets"
 	"github.com/cockroachdb/cockroach/pkg/util/iterutil"
@@ -174,6 +175,7 @@ type Index interface {
 	GetPredicate() string
 	GetType() idxtype.T
 	GetGeoConfig() geopb.Config
+	GetVecConfig() vecpb.Config
 	GetVersion() descpb.IndexDescriptorVersion
 	GetEncodingType() catenumpb.IndexDescriptorEncodingType
 
@@ -222,6 +224,18 @@ type Index interface {
 	// InvertedColumnKind returns the kind of the inverted column of the inverted
 	// index.
 	InvertedColumnKind() catpb.InvertedIndexColumnKind
+
+	// VectorColumnName returns the name of the vector column of the vector
+	// index.
+	//
+	// Panics if the index is not a vector index.
+	VectorColumnName() string
+
+	// VectorColumnID returns the ColumnID of the vector column of the vector
+	// index.
+	//
+	// Panics if the index is not a vector index.
+	VectorColumnID() descpb.ColumnID
 
 	NumPrimaryStoredColumns() int
 	NumSecondaryStoredColumns() int

--- a/pkg/sql/catalog/tabledesc/BUILD.bazel
+++ b/pkg/sql/catalog/tabledesc/BUILD.bazel
@@ -21,7 +21,6 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/clusterversion",
-        "//pkg/docs",
         "//pkg/geo/geopb",
         "//pkg/jobs/jobspb",
         "//pkg/keys",
@@ -59,6 +58,7 @@ go_library(
         "//pkg/sql/sem/volatility",
         "//pkg/sql/sqlerrors",
         "//pkg/sql/types",
+        "//pkg/sql/vecindex/vecpb",
         "//pkg/util",
         "//pkg/util/errorutil/unimplemented",
         "//pkg/util/hlc",
@@ -122,6 +122,7 @@ go_test(
         "//pkg/sql/sem/idxtype",
         "//pkg/sql/sem/semenumpb",
         "//pkg/sql/types",
+        "//pkg/sql/vecindex/vecpb",
         "//pkg/testutils",
         "//pkg/testutils/serverutils",
         "//pkg/testutils/sqlutils",

--- a/pkg/sql/catalog/tabledesc/index.go
+++ b/pkg/sql/catalog/tabledesc/index.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/idxtype"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/sql/vecindex/vecpb"
 	"github.com/cockroachdb/cockroach/pkg/util/iterutil"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -223,6 +224,20 @@ func (w index) InvertedColumnKind() catpb.InvertedIndexColumnKind {
 	return w.desc.InvertedColumnKinds[0]
 }
 
+// VectorColumnID returns the ColumnID of the vector column of the vector index.
+// This is always the last column in KeyColumnIDs. Panics if the index is not a
+// vector index.
+func (w index) VectorColumnID() descpb.ColumnID {
+	return w.desc.VectorColumnID()
+}
+
+// VectorColumnName returns the name of the vector column of the vector index.
+// This is always the last column in KeyColumnIDs. Panics if the index is not a
+// vector index.
+func (w index) VectorColumnName() string {
+	return w.desc.VectorColumnName()
+}
+
 // CollectKeyColumnIDs creates a new set containing the column IDs in the key
 // of this index.
 func (w index) CollectKeyColumnIDs() catalog.TableColSet {
@@ -263,6 +278,11 @@ func (w index) CollectCompositeColumnIDs() catalog.TableColSet {
 // GetGeoConfig returns the geo config in the index descriptor.
 func (w index) GetGeoConfig() geopb.Config {
 	return w.desc.GeoConfig
+}
+
+// GetVecConfig returns the vec config in the index descriptor.
+func (w index) GetVecConfig() vecpb.Config {
+	return w.desc.VecConfig
 }
 
 // GetSharded returns the ShardedDescriptor in the index descriptor

--- a/pkg/sql/catalog/tabledesc/structured_test.go
+++ b/pkg/sql/catalog/tabledesc/structured_test.go
@@ -196,6 +196,7 @@ func TestColumnTypeSQLString(t *testing.T) {
 		{types.String, "STRING"},
 		{types.MakeString(10), "STRING(10)"},
 		{types.Bytes, "BYTES"},
+		{types.MakePGVector(3), "VECTOR(3)"},
 	}
 	for i, d := range testData {
 		t.Run(d.colType.DebugString(), func(t *testing.T) {

--- a/pkg/sql/catalog/tabledesc/table_desc_builder.go
+++ b/pkg/sql/catalog/tabledesc/table_desc_builder.go
@@ -22,7 +22,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/catconstants"
-	"github.com/cockroachdb/cockroach/pkg/sql/sem/idxtype"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/intsets"
@@ -843,7 +842,10 @@ func maybeUpgradePrimaryIndexFormatVersion(builder *tableDescriptorBuilder) (has
 func maybeUpgradeSecondaryIndexFormatVersion(idx *descpb.IndexDescriptor) (hasChanged bool) {
 	switch idx.Version {
 	case descpb.SecondaryIndexFamilyFormatVersion:
-		if idx.Type == idxtype.INVERTED {
+		// If the index type does not support STORING columns, then it's not
+		// encoded differently based on whether column families are in use, so
+		// nothing to do.
+		if !idx.Type.SupportsStoring() {
 			return false
 		}
 	case descpb.EmptyArraysInInvertedIndexesVersion:

--- a/pkg/sql/create_index.go
+++ b/pkg/sql/create_index.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/idxtype"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlerrors"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/storageparam"
 	"github.com/cockroachdb/cockroach/pkg/sql/storageparam/indexstorageparam"
@@ -424,7 +425,7 @@ func populateInvertedIndexDescriptor(
 			return newUndefinedOpclassError(invCol.OpClass)
 		}
 	default:
-		return tabledesc.NewInvalidInvertedColumnError(column.GetName(), column.GetType().Name())
+		return sqlerrors.NewInvalidLastColumnError(column.GetName(), column.GetType().Name(), idxtype.INVERTED)
 	}
 	return nil
 }

--- a/pkg/sql/create_stats.go
+++ b/pkg/sql/create_stats.go
@@ -578,6 +578,10 @@ func createStatsDefaultColumns(
 
 	// Add column stats for each secondary index.
 	for _, idx := range desc.PublicNonPrimaryIndexes() {
+		if idx.GetType() == idxtype.VECTOR {
+			// Skip vector indexes for now.
+			continue
+		}
 		for j, n := 0, idx.NumKeyColumns(); j < n; j++ {
 			colID := idx.GetKeyColumnID(j)
 			isInverted := idx.GetType() == idxtype.INVERTED && colID == idx.InvertedColumnID()

--- a/pkg/sql/logictest/testdata/logic_test/alter_primary_key
+++ b/pkg/sql/logictest/testdata/logic_test/alter_primary_key
@@ -2006,7 +2006,7 @@ CREATE TABLE tab_122871 (
   PRIMARY KEY (col0_18 DESC)
 );
 
-statement error column col0_4 is of type tsvector and thus is not indexable
+statement error column col0_4 has type tsvector, which is not indexable
 ALTER TABLE tab_122871 ALTER PRIMARY KEY USING COLUMNS (col0_4);
 
 subtest end

--- a/pkg/sql/logictest/testdata/logic_test/array
+++ b/pkg/sql/logictest/testdata/logic_test/array
@@ -1693,7 +1693,7 @@ statement error duplicate key value violates unique constraint
 CREATE UNIQUE INDEX ON unique_array(b)
 
 # Create an indexes on a bad type.
-statement error pq: unimplemented: column x is of type geography\[\] and thus is not indexable
+statement error column x has type geography\[\], which is not indexable in a non-inverted index\nHINT: you may want to create an inverted index instead. See the documentation for inverted indexes: https://www.cockroachlabs.com/docs/dev/inverted-indexes.html
 CREATE TABLE tbad (x GEOGRAPHY[] PRIMARY KEY)
 
 # Test arrays of composite types.

--- a/pkg/sql/logictest/testdata/logic_test/create_table
+++ b/pkg/sql/logictest/testdata/logic_test/create_table
@@ -114,19 +114,23 @@ CREATE TABLE telemetry (
   x INT PRIMARY KEY,
   y INT,
   z JSONB,
+  v VECTOR(3),
   INVERTED INDEX (z),
-  INDEX (y) USING HASH WITH (bucket_count=4)
+  INDEX (y) USING HASH WITH (bucket_count=4),
+  VECTOR INDEX (v)
 )
 
 query T rowsort
 SELECT feature_name FROM crdb_internal.feature_usage
 WHERE feature_name IN (
   'sql.schema.inverted_index',
-  'sql.schema.hash_sharded_index'
+  'sql.schema.hash_sharded_index',
+  'sql.schema.vector_index'
 )
 ----
 sql.schema.inverted_index
 sql.schema.hash_sharded_index
+sql.schema.vector_index
 
 subtest like_table
 
@@ -144,12 +148,14 @@ CREATE TABLE like_table (
   j JSON,
   k INT UNIQUE WITHOUT INDEX,
   t TIMESTAMPTZ DEFAULT current_timestamp() - '5s'::interval ON UPDATE current_timestamp(),
+  v VECTOR(3),
   PRIMARY KEY (a, b),
   UNIQUE INDEX foo (b DESC, c),
   INDEX (c) STORING (j),
   INVERTED INDEX (j),
   UNIQUE WITHOUT INDEX (h),
-  UNIQUE WITHOUT INDEX (h) WHERE h > 0
+  UNIQUE WITHOUT INDEX (h) WHERE h > 0,
+  VECTOR INDEX (v)
 )
 
 statement ok
@@ -166,6 +172,7 @@ like_none  CREATE TABLE public.like_none (
              j JSONB NULL,
              k INT8 NULL,
              t TIMESTAMPTZ NULL,
+             v VECTOR(3) NULL,
              rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
              CONSTRAINT like_none_pkey PRIMARY KEY (rowid ASC)
            )
@@ -184,6 +191,7 @@ like_constraints  CREATE TABLE public.like_constraints (
                     j JSONB NULL,
                     k INT8 NULL,
                     t TIMESTAMPTZ NULL,
+                    v VECTOR(3) NULL,
                     rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
                     CONSTRAINT like_constraints_pkey PRIMARY KEY (rowid ASC),
                     CONSTRAINT check_a CHECK (a > 3:::INT8),
@@ -206,10 +214,12 @@ like_indexes  CREATE TABLE public.like_indexes (
                 j JSONB NULL,
                 k INT8 NULL,
                 t TIMESTAMPTZ NULL,
+                v VECTOR(3) NULL,
                 CONSTRAINT like_table_pkey PRIMARY KEY (a ASC, b ASC),
                 UNIQUE INDEX foo (b DESC, c ASC),
                 INDEX like_table_c_idx (c ASC) STORING (j),
-                INVERTED INDEX like_table_j_idx (j)
+                INVERTED INDEX like_table_j_idx (j),
+                VECTOR INDEX like_table_v_idx (v)
               )
 
 # INCLUDING GENERATED adds "generated columns", aka stored columns.
@@ -227,6 +237,7 @@ like_generated  CREATE TABLE public.like_generated (
                   j JSONB NULL,
                   k INT8 NULL,
                   t TIMESTAMPTZ NULL,
+                  v VECTOR(3) NULL,
                   rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
                   CONSTRAINT like_generated_pkey PRIMARY KEY (rowid ASC)
                 )
@@ -245,6 +256,7 @@ like_defaults  CREATE TABLE public.like_defaults (
                  j JSONB NULL,
                  k INT8 NULL,
                  t TIMESTAMPTZ NULL DEFAULT current_timestamp():::TIMESTAMPTZ - '00:00:05':::INTERVAL ON UPDATE current_timestamp():::TIMESTAMPTZ,
+                 v VECTOR(3) NULL,
                  rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
                  CONSTRAINT like_defaults_pkey PRIMARY KEY (rowid ASC)
                )
@@ -263,10 +275,12 @@ like_all  CREATE TABLE public.like_all (
             j JSONB NULL,
             k INT8 NULL,
             t TIMESTAMPTZ NULL DEFAULT current_timestamp():::TIMESTAMPTZ - '00:00:05':::INTERVAL ON UPDATE current_timestamp():::TIMESTAMPTZ,
+            v VECTOR(3) NULL,
             CONSTRAINT like_table_pkey PRIMARY KEY (a ASC, b ASC),
             UNIQUE INDEX foo (b DESC, c ASC),
             INDEX like_table_c_idx (c ASC) STORING (j),
             INVERTED INDEX like_table_j_idx (j),
+            VECTOR INDEX like_table_v_idx (v),
             CONSTRAINT check_a CHECK (a > 3:::INT8),
             CONSTRAINT unique_k UNIQUE WITHOUT INDEX (k),
             CONSTRAINT unique_h UNIQUE WITHOUT INDEX (h),
@@ -289,10 +303,12 @@ like_mixed  CREATE TABLE public.like_mixed (
               j JSONB NULL,
               k INT8 NULL,
               t TIMESTAMPTZ NULL DEFAULT current_timestamp():::TIMESTAMPTZ - '00:00:05':::INTERVAL ON UPDATE current_timestamp():::TIMESTAMPTZ,
+              v VECTOR(3) NULL,
               CONSTRAINT like_table_pkey PRIMARY KEY (a ASC, b ASC),
               UNIQUE INDEX foo (b DESC, c ASC),
               INDEX like_table_c_idx (c ASC) STORING (j),
-              INVERTED INDEX like_table_j_idx (j)
+              INVERTED INDEX like_table_j_idx (j),
+              VECTOR INDEX like_table_v_idx (v)
             )
 
 statement ok
@@ -335,6 +351,7 @@ like_more_specifiers  CREATE TABLE public.like_more_specifiers (
                         j JSONB NULL,
                         k INT8 NULL,
                         t TIMESTAMPTZ NULL,
+                        v VECTOR(3) NULL,
                         z DECIMAL NULL,
                         blah INT8 NULL,
                         rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
@@ -1210,3 +1227,6 @@ CREATE TABLE create_table_index_elem_duplicate_storage_params_e (
 );
 
 subtest end
+
+statement error pq: unimplemented: column col2 has type refcursor, which is not indexable\nHINT: You have attempted to use a feature that is not yet implemented.\nSee: https://go.crdb.dev/issue-v/35730/dev
+CREATE TABLE not_indexable (COL1 INT PRIMARY KEY, COL2 REFCURSOR, COL3 REFCURSOR, INDEX (COL2, COL3))

--- a/pkg/sql/logictest/testdata/logic_test/geospatial
+++ b/pkg/sql/logictest/testdata/logic_test/geospatial
@@ -117,16 +117,16 @@ geog    GEOGRAPHY(GEOMETRY,4326)  true   NULL  ·  {geo_table_geog_idx,geo_table
 geom    GEOMETRY(POINT)           true   NULL  ·  {geo_table_geom_idx,geo_table_pkey}                     false
 orphan  GEOGRAPHY                 true   NULL  ·  {geo_table_pkey}                                        false
 
-statement error column bad_pk is of type geography and thus is not indexable
+statement error column bad_pk has type geography, which is not indexable in a non-inverted index\nHINT: you may want to create an inverted index instead. See the documentation for inverted indexes: https://www.cockroachlabs.com/docs/dev/inverted-indexes.html
 CREATE TABLE bad_geog_table(bad_pk geography primary key)
 
-statement error column bad_pk is of type geometry and thus is not indexable
+statement error column bad_pk has type geometry, which is not indexable in a non-inverted index\nHINT: you may want to create an inverted index instead. See the documentation for inverted indexes: https://www.cockroachlabs.com/docs/dev/inverted-indexes.html
 CREATE TABLE bad_geom_table(bad_pk geometry primary key)
 
-statement error column geog is of type geography and thus is not indexable
+statement error column geog has type geography, which is not indexable
 CREATE INDEX geog_idx ON geo_table(geog)
 
-statement error column geom is of type geometry and thus is not indexable
+statement error column geom has type geometry, which is not indexable
 CREATE INDEX geom_idx ON geo_table(geom)
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/inverted_index
+++ b/pkg/sql/logictest/testdata/logic_test/inverted_index
@@ -13,10 +13,10 @@ INSERT INTO t VALUES (1,1,1)
 statement ok
 CREATE INDEX foo ON t (b)
 
-statement error column b of type int is not allowed as the last column in an inverted index\nHINT: see the documentation for more information about inverted indexes: https://www.cockroachlabs.com/docs/.*/inverted-indexes.html
+statement error column b has type int, which is not allowed as the last column in an inverted index\nHINT: see the documentation for more information about inverted indexes: https://www.cockroachlabs.com/docs/.*/inverted-indexes.html
 CREATE INVERTED INDEX foo_inv ON t(b)
 
-statement error column b of type int is not allowed as the last column in an inverted index\nHINT: see the documentation for more information about inverted indexes: https://www.cockroachlabs.com/docs/.*/inverted-indexes.html
+statement error column b has type int, which is not allowed as the last column in an inverted index\nHINT: see the documentation for more information about inverted indexes: https://www.cockroachlabs.com/docs/.*/inverted-indexes.html
 CREATE INDEX foo_inv2 ON t USING GIN (b)
 
 statement error pq: inverted indexes can't be unique
@@ -73,7 +73,7 @@ CREATE INVERTED INDEX ON c (foo DESC)
 statement ok
 CREATE INVERTED INDEX ON c("qUuX")
 
-statement error column foo of type int is not allowed as the last column in an inverted index\nHINT: see the documentation for more information about inverted indexes
+statement error column foo has type int, which is not allowed as the last column in an inverted index\nHINT: see the documentation for more information about inverted indexes
 CREATE TABLE d (
   id INT PRIMARY KEY,
   foo INT,

--- a/pkg/sql/logictest/testdata/logic_test/inverted_index_multi_column
+++ b/pkg/sql/logictest/testdata/logic_test/inverted_index_multi_column
@@ -1,11 +1,11 @@
 # Tests for multi-column inverted indexes.
 
 # Err if the last column is not an invertable type.
-statement error column b of type int is not allowed as the last column in an inverted index\nHINT: see the documentation for more information about inverted indexes: https://www.cockroachlabs.com/docs/.*/inverted-indexes.html
+statement error column b has type int, which is not allowed as the last column in an inverted index\nHINT: see the documentation for more information about inverted indexes: https://www.cockroachlabs.com/docs/.*/inverted-indexes.html
 CREATE TABLE m_err (k INT PRIMARY KEY, a INT, b INT, geom GEOMETRY, INVERTED INDEX (a, b))
 
 # Err if a non-last column is not a non-invertable type.
-statement error column geom1 of type geometry is only allowed as the last column in an inverted index\nHINT: see the documentation for more information about inverted indexes: https://www.cockroachlabs.com/docs/.*/inverted-indexes.html
+statement error column geom1 has type geometry, which is only allowed as the last column in an inverted index\nHINT: see the documentation for more information about inverted indexes: https://www.cockroachlabs.com/docs/.*/inverted-indexes.html
 CREATE TABLE m_err (k INT PRIMARY KEY, geom1 GEOMETRY , geom GEOMETRY, INVERTED INDEX (geom1, geom))
 
 

--- a/pkg/sql/logictest/testdata/logic_test/vector_index
+++ b/pkg/sql/logictest/testdata/logic_test/vector_index
@@ -1,0 +1,140 @@
+# ------------------------------------------------------------------------------
+# CREATE TABLE tests.
+# ------------------------------------------------------------------------------
+
+# Simple vector index.
+statement ok
+CREATE TABLE simple (
+  a INT PRIMARY KEY,
+  vec1 VECTOR(3),
+  VECTOR INDEX (vec1),
+  FAMILY (a, vec1)
+)
+
+query TT
+SHOW CREATE TABLE simple
+----
+simple  CREATE TABLE public.simple (
+          a INT8 NOT NULL,
+          vec1 VECTOR(3) NULL,
+          CONSTRAINT simple_pkey PRIMARY KEY (a ASC),
+          VECTOR INDEX simple_vec1_idx (vec1),
+          FAMILY fam_0_a_vec1 (a, vec1)
+        )
+
+statement ok
+SHOW INDEX FROM simple
+
+# Specify name for index.
+statement ok
+CREATE TABLE alt_syntax (
+  a INT PRIMARY KEY,
+  vec1 VECTOR(3),
+  VECTOR INDEX vec_idx (vec1),
+  FAMILY (a, vec1)
+)
+
+query TT
+SHOW CREATE TABLE alt_syntax
+----
+alt_syntax  CREATE TABLE public.alt_syntax (
+              a INT8 NOT NULL,
+              vec1 VECTOR(3) NULL,
+              CONSTRAINT alt_syntax_pkey PRIMARY KEY (a ASC),
+              VECTOR INDEX vec_idx (vec1),
+              FAMILY fam_0_a_vec1 (a, vec1)
+            )
+
+# Multiple vector indexes on same table.
+statement ok
+CREATE TABLE multiple_indexes (
+  a INT PRIMARY KEY,
+  vec1 VECTOR(3),
+  vec2 VECTOR(1000),
+  VECTOR INDEX (vec1),
+  VECTOR INDEX (vec2),
+  FAMILY (a, vec1, vec2)
+)
+
+query TT
+SHOW CREATE TABLE multiple_indexes
+----
+multiple_indexes  CREATE TABLE public.multiple_indexes (
+                    a INT8 NOT NULL,
+                    vec1 VECTOR(3) NULL,
+                    vec2 VECTOR(1000) NULL,
+                    CONSTRAINT multiple_indexes_pkey PRIMARY KEY (a ASC),
+                    VECTOR INDEX multiple_indexes_vec1_idx (vec1),
+                    VECTOR INDEX multiple_indexes_vec2_idx (vec2),
+                    FAMILY fam_0_a_vec1_vec2 (a, vec1, vec2)
+                  )
+
+# Use prefix columns in the vector index.
+statement ok
+CREATE TABLE prefix_cols (
+  a INT PRIMARY KEY,
+  b INT,
+  c INT,
+  vec1 VECTOR(3),
+  VECTOR INDEX (c DESC, b, vec1),
+  FAMILY (a, b, c, vec1)
+)
+
+query TT
+SHOW CREATE TABLE prefix_cols
+----
+prefix_cols  CREATE TABLE public.prefix_cols (
+               a INT8 NOT NULL,
+               b INT8 NULL,
+               c INT8 NULL,
+               vec1 VECTOR(3) NULL,
+               CONSTRAINT prefix_cols_pkey PRIMARY KEY (a ASC),
+               VECTOR INDEX prefix_cols_c_b_vec1_idx (c DESC, b ASC, vec1),
+               FAMILY fam_0_a_b_c_vec1 (a, b, c, vec1)
+             )
+
+# Use mixed-case column for vector index.
+statement ok
+CREATE TABLE mixed_case (
+  a INT PRIMARY KEY,
+  qUuX VECTOR(3),
+  VECTOR INDEX (qUuX)
+)
+
+# Try to use vector in primary key.
+statement error column a has type vector, which is not indexable in a non-vector index\nHINT: you may want to create a vector index instead
+CREATE TABLE t (a VECTOR(3), PRIMARY KEY (a))
+
+statement error column b has type int, which is not allowed as the last column in a vector index
+CREATE TABLE t (a INT PRIMARY KEY, b INT, VECTOR INDEX (b))
+
+statement error column c has type vector, which is only allowed as the last column in a vector index
+CREATE TABLE t (a INT PRIMARY KEY, b INT, c VECTOR(3), VECTOR INDEX (c, b))
+
+# Try to use inverted indexable type in vector index.
+statement error column b has type tsvector, which is not indexable in a non-inverted index\nHINT: you may want to create an inverted index instead. See the documentation for inverted indexes: https://www.cockroachlabs.com/docs/dev/inverted-indexes.html
+CREATE TABLE t (a INT PRIMARY KEY, b TSVECTOR, c VECTOR(3), VECTOR INDEX (b, c))
+
+statement error the last column in a vector index cannot have the DESC option
+CREATE TABLE t (a INT PRIMARY KEY, b INT, c VECTOR(3), VECTOR INDEX (b, c DESC))
+
+statement error vector column b does not have a fixed number of dimensions, so it cannot be indexed\nDETAIL: specify the number of dimensions in the type, like VECTOR\(128\) for 128 dimensions
+CREATE TABLE t (a INT PRIMARY KEY, b VECTOR, VECTOR INDEX (b))
+
+# Try to use vector type in forward index.
+statement error pq: column c has type vector, which is not indexable in a non-vector index\nHINT: you may want to create a vector index instead
+CREATE TABLE t (a INT PRIMARY KEY, b INT, c VECTOR(3), INDEX (b, c))
+
+# ------------------------------------------------------------------------------
+# Execution tests.
+# ------------------------------------------------------------------------------
+
+statement ok
+CREATE TABLE exec_test (
+  a INT PRIMARY KEY,
+  vec1 VECTOR(3),
+  VECTOR INDEX (vec1)
+)
+
+statement error unimplemented: execution planning for vector index search is not yet implemented
+INSERT INTO exec_test (a, vec1) values (1, '[1, 2, 3]');

--- a/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
@@ -2481,6 +2481,13 @@ func TestLogic_values(
 	runLogicTest(t, "values")
 }
 
+func TestLogic_vector_index(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "vector_index")
+}
+
 func TestLogic_vectorize(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
@@ -2488,6 +2488,13 @@ func TestLogic_values(
 	runLogicTest(t, "values")
 }
 
+func TestLogic_vector_index(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "vector_index")
+}
+
 func TestLogic_vectorize_agg(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist/generated_test.go
@@ -2502,6 +2502,13 @@ func TestLogic_values(
 	runLogicTest(t, "values")
 }
 
+func TestLogic_vector_index(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "vector_index")
+}
+
 func TestLogic_vectorize(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-legacy-schema-changer/generated_test.go
+++ b/pkg/sql/logictest/tests/local-legacy-schema-changer/generated_test.go
@@ -2474,6 +2474,13 @@ func TestLogic_values(
 	runLogicTest(t, "values")
 }
 
+func TestLogic_vector_index(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "vector_index")
+}
+
 func TestLogic_vectorize_agg(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-mixed-24.3/generated_test.go
+++ b/pkg/sql/logictest/tests/local-mixed-24.3/generated_test.go
@@ -2488,6 +2488,13 @@ func TestLogic_values(
 	runLogicTest(t, "values")
 }
 
+func TestLogic_vector_index(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "vector_index")
+}
+
 func TestLogic_vectorize_agg(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/local-vec-off/generated_test.go
@@ -2516,6 +2516,13 @@ func TestLogic_values(
 	runLogicTest(t, "values")
 }
 
+func TestLogic_vector_index(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "vector_index")
+}
+
 func TestLogic_vectorize_agg(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local/generated_test.go
+++ b/pkg/sql/logictest/tests/local/generated_test.go
@@ -2740,6 +2740,13 @@ func TestLogic_values(
 	runLogicTest(t, "values")
 }
 
+func TestLogic_vector_index(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "vector_index")
+}
+
 func TestLogic_vectorize(
 	t *testing.T,
 ) {

--- a/pkg/sql/parser/lexer.go
+++ b/pkg/sql/parser/lexer.go
@@ -164,7 +164,10 @@ func (l *lexer) Lex(lval *sqlSymType) int {
 		(afterCommaOrParen && followedByNonPunctThenParen) ||
 			// CREATE ... (INVERTED INDEX abc (
 			// CREATE ... (x INT, y INT, INVERTED INDEX abc (
-			(afterCommaOrParenThenINVERTED && followedByNonPunctThenParen) {
+			(afterCommaOrParenThenINVERTED && followedByNonPunctThenParen) ||
+			// CREATE ... (VECTOR INDEX abc (
+			// CREATE ... (x INT, y INT, VECTOR INDEX abc (
+			(afterCommaOrParenThenVECTOR && followedByNonPunctThenParen) {
 			lval.id = INDEX_BEFORE_NAME_THEN_PAREN
 			break
 		}

--- a/pkg/sql/parser/testdata/create_table
+++ b/pkg/sql/parser/testdata/create_table
@@ -1377,6 +1377,23 @@ CREATE TABLE a (b INT8, VECTOR INDEX (b)) -- fully parenthesized
 CREATE TABLE a (b INT8, VECTOR INDEX (b)) -- literals removed
 CREATE TABLE _ (_ INT8, VECTOR INDEX (_)) -- identifiers removed
 
+# Explicitly name the index.
+parse
+CREATE TABLE a (b INT8, INVERTED INDEX i (b))
+----
+CREATE TABLE a (b INT8, INVERTED INDEX i (b))
+CREATE TABLE a (b INT8, INVERTED INDEX i (b)) -- fully parenthesized
+CREATE TABLE a (b INT8, INVERTED INDEX i (b)) -- literals removed
+CREATE TABLE _ (_ INT8, INVERTED INDEX _ (_)) -- identifiers removed
+
+parse
+CREATE TABLE a (b INT8, VECTOR INDEX i (b))
+----
+CREATE TABLE a (b INT8, VECTOR INDEX i (b))
+CREATE TABLE a (b INT8, VECTOR INDEX i (b)) -- fully parenthesized
+CREATE TABLE a (b INT8, VECTOR INDEX i (b)) -- literals removed
+CREATE TABLE _ (_ INT8, VECTOR INDEX _ (_)) -- identifiers removed
+
 parse
 CREATE TABLE a (b INT8, c INT8 REFERENCES foo)
 ----

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_add_column.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_add_column.go
@@ -36,7 +36,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlerrors"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
-	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/errors"
 	"github.com/lib/pq/oid"
@@ -164,10 +163,7 @@ func alterTableAddColumn(
 		!d.Unique.WithoutIndex &&
 		!colinfo.ColumnTypeIsIndexable(spec.colType.Type) {
 		typInfo := spec.colType.Type.DebugString()
-		panic(unimplemented.NewWithIssueDetailf(35730, typInfo,
-			"column %s is of type %s and thus is not indexable",
-			d.Name,
-			spec.colType.Type.Name()))
+		panic(sqlerrors.NewColumnNotIndexableError(d.Name.String(), spec.colType.Type.Name(), typInfo))
 	}
 	// Block unsupported types.
 	switch spec.colType.Type.Oid() {

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_alter_primary_key.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_alter_primary_key.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/catid"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/idxtype"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlerrors"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
@@ -348,12 +349,8 @@ func checkForEarlyExit(b BuildCtx, tbl *scpb.Table, t alterPrimaryKeySpec) {
 		columnType := mustRetrieveColumnTypeElem(b, tbl.TableID, colElem.ColumnID)
 		// Check if the column type is indexable.
 		if !colinfo.ColumnTypeIsIndexable(columnType.Type) {
-			panic(unimplemented.NewWithIssueDetailf(35730,
-				columnType.Type.DebugString(),
-				"column %s is of type %s and thus is not indexable",
-				col.Column,
-				columnType.Type),
-			)
+			panic(sqlerrors.NewColumnNotIndexableError(
+				col.Column.String(), columnType.Type.Name(), columnType.Type.DebugString()))
 		}
 	}
 }

--- a/pkg/sql/sem/idxtype/BUILD.bazel
+++ b/pkg/sql/sem/idxtype/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
     embed = [":idxtype_go_proto"],
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/sem/idxtype",
     visibility = ["//visibility:public"],
+    deps = ["@com_github_cockroachdb_redact//:redact"],
 )
 
 go_proto_library(
@@ -36,14 +37,15 @@ go_library(
 )
 
 # idxtype is meant to stay a leaf package. Never add a heavy-weight dependency.
-# In fact, avoid any dependency at all, except protobuf-related.
 disallowed_imports_test(
     "idxtype",
-    allowlist = [
-        "//pkg/sql/sem/idxtype:idxtype_go_proto",
-        "@com_github_gogo_protobuf//gogoproto",
-        "@com_github_gogo_protobuf//proto",
-        "@com_github_gogo_protobuf//protoc-gen-gogo/descriptor",
+    disallowed_list = [
+        "//pkg/kv",
+        "//pkg/roachpb",
+        "//pkg/security",
+        "//pkg/server",
+        "//pkg/sql",
+        "//pkg/storage",
+        "//pkg/util/log",
     ],
-    disallow_cdeps = True,
 )

--- a/pkg/sql/sem/idxtype/idxtype.go
+++ b/pkg/sql/sem/idxtype/idxtype.go
@@ -5,6 +5,8 @@
 
 package idxtype
 
+import "github.com/cockroachdb/redact"
+
 // CanBePrimary is true if this index type can be the primary index that always
 // contains unique keys sorted according to the primary ordering of the table.
 // Secondary indexes refer to rows in the primary index by unique key value.
@@ -18,11 +20,12 @@ func (t T) CanBeUnique() bool {
 	return t == FORWARD
 }
 
-// AllowExplicitDirection is true if this index type allows all of its columns
-// to specify an explicit ascending or descending direction. For example,
-// inverted and vector indexes do not allow the last column in the index to
-// specify an explicit direction.
-func (t T) AllowExplicitDirection() bool {
+// HasLinearOrdering is true if this index type does not define a linear
+// ordering on the last key column in the index. For example, a vector index
+// groups nearby vectors, but does not define a linear ordering among them. As
+// another example, an inverted index only defines a linear ordering for tokens,
+// not for the original JSONB or ARRAY data type.
+func (t T) HasLinearOrdering() bool {
 	return t == FORWARD
 }
 
@@ -33,24 +36,39 @@ func (t T) AllowsPrefixColumns() bool {
 	return t == INVERTED || t == VECTOR
 }
 
-// SupportsSharding is true if this index can be hash sharded, meaning that its
-// rows are grouped according to a hash value and spread across the keyspace.
+// SupportsSharding is true if this index type can be hash sharded, meaning that
+// its rows are grouped according to a hash value and spread across the
+// keyspace.
 func (t T) SupportsSharding() bool {
 	return t == FORWARD
 }
 
-// SupportsStoring is true if this index allows STORING values, which are
+// SupportsStoring is true if this index type allows STORING values, which are
 // un-indexed columns from the table that are stored directly in the index for
 // faster retrieval.
 func (t T) SupportsStoring() bool {
 	return t == FORWARD
 }
 
-// SupportsOpClass is true if this index allows columns to specify an operator
-// class, which defines an alternate set of operators used when sorting and
-// querying those columns.
+// SupportsOpClass is true if this index type allows columns to specify an
+// operator class, which defines an alternate set of operators used when sorting
+// and querying those columns.
 // NOTE: Currently, only inverted indexes support operator classes, and only on
 // the last column of the index.
 func (t T) SupportsOpClass() bool {
 	return t == INVERTED
+}
+
+// ErrorText describes the type of the index using the phrase "an inverted
+// index" or "a vector index". This is intended to be included in errors that
+// apply to multiple index types.
+func ErrorText(t T) redact.SafeString {
+	switch t {
+	case INVERTED:
+		return "an inverted index"
+	case VECTOR:
+		return "a vector index"
+	default:
+		return "an index"
+	}
 }

--- a/pkg/sql/sqlerrors/BUILD.bazel
+++ b/pkg/sql/sqlerrors/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/build",
+        "//pkg/docs",
         "//pkg/roachpb",
         "//pkg/security/username",
         "//pkg/sql/catalog/catpb",
@@ -15,6 +16,7 @@ go_library(
         "//pkg/sql/pgwire/pgerror",
         "//pkg/sql/privilege",
         "//pkg/sql/sem/catconstants",
+        "//pkg/sql/sem/idxtype",
         "//pkg/sql/sem/tree",
         "//pkg/sql/types",
         "//pkg/util/errorutil/unimplemented",

--- a/pkg/sql/sqltelemetry/schema.go
+++ b/pkg/sql/sqltelemetry/schema.go
@@ -85,6 +85,15 @@ var (
 	// index is created. This includes both regular and inverted expression
 	// indexes.
 	ExpressionIndexCounter = telemetry.GetCounterOnce("sql.schema.expression_index")
+
+	// VectorIndexCounter is to be incremented every time a vector index is
+	// created. This includes single-column vector indexes, multi-column vector
+	// indexes, and partial vector indexes.
+	VectorIndexCounter = telemetry.GetCounterOnce("sql.schema.vector_index")
+
+	// MultiColumnVectorIndexCounter is to be incremented every time a
+	// multi-column vector index is created.
+	MultiColumnVectorIndexCounter = telemetry.GetCounterOnce("sql.schema.multi_column_vector_index")
 )
 
 // SchemaChangeIndexCounter is to be incremented for certain CREATE

--- a/pkg/sql/vecindex/vector_index.go
+++ b/pkg/sql/vecindex/vector_index.go
@@ -60,7 +60,7 @@ type VectorIndexOptions struct {
 	DisableErrorBounds bool
 	// Seed is used to initialize a deterministic random number generator for
 	// testing purposes. If this is zero, then the global random number generator
-	// is used intead.
+	// is used instead.
 	Seed int64
 	// MaxWorkers specifies the maximum number of background workers that can be
 	// created to process fixups for this vector index instance.


### PR DESCRIPTION
Support usage of VECTOR INDEX in a CREATE TABLE statement, e.g.:

  CREATE TABLE simple (
    a INT PRIMARY KEY,
    vec1 VECTOR(3),
    VECTOR INDEX (vec1)
  )

Create the corresponding table and index schema objects for the vector index. Check various error conditions, e.g. that only a column of type VECTOR can be the last column in the index. Add unit and logic tests. CREATE VECTOR INDEX support will come in a future PR.

Epic: CRDB-42943

Release note: None