### PR TITLE
sql: add `kv_transaction_buffered_writes_enabled` session variable

### DIFF
--- a/pkg/kv/kvclient/kvcoord/txn_coord_sender.go
+++ b/pkg/kv/kvclient/kvcoord/txn_coord_sender.go
@@ -317,9 +317,6 @@ func (tc *TxnCoordSender) initCommonInterceptors(
 	if ds, ok := tcf.wrapped.(*DistSender); ok {
 		riGen.ds = ds
 	}
-	tc.interceptorAlloc.txnWriteBuffer = txnWriteBuffer{
-		enabled: BufferedWritesEnabled.Get(&tcf.st.SV),
-	}
 	tc.interceptorAlloc.txnPipeliner = txnPipeliner{
 		st:                       tcf.st,
 		riGen:                    riGen,
@@ -1156,6 +1153,25 @@ func (tc *TxnCoordSender) SetOmitInRangefeeds() {
 		panic("cannot change OmitInRangefeeds of a running transaction")
 	}
 	tc.mu.txn.OmitInRangefeeds = true
+}
+
+// SetBufferedWritesEnabled is part of the kv.TxnSender interface.
+func (tc *TxnCoordSender) SetBufferedWritesEnabled(enabled bool) {
+	tc.mu.Lock()
+	defer tc.mu.Unlock()
+
+	if tc.mu.active && enabled && !tc.interceptorAlloc.txnWriteBuffer.enabled {
+		panic("cannot enable buffered writes on a running transaction")
+	}
+	tc.interceptorAlloc.txnWriteBuffer.enabled = enabled
+}
+
+// BufferedWritesEnabled is part of the kv.TxnSender interface.
+func (tc *TxnCoordSender) BufferedWritesEnabled() bool {
+	tc.mu.Lock()
+	defer tc.mu.Unlock()
+
+	return tc.interceptorAlloc.txnWriteBuffer.enabled
 }
 
 // String is part of the kv.TxnSender interface.

--- a/pkg/kv/mock_transactional_sender.go
+++ b/pkg/kv/mock_transactional_sender.go
@@ -108,6 +108,14 @@ func (m *MockTransactionalSender) SetOmitInRangefeeds() {
 	m.txn.OmitInRangefeeds = true
 }
 
+// SetBufferedWritesEnabled is part of the TxnSender interface.
+func (m *MockTransactionalSender) SetBufferedWritesEnabled(enabled bool) {}
+
+// BufferedWritesEnabled is part of the TxnSender interface.
+func (m *MockTransactionalSender) BufferedWritesEnabled() bool {
+	return false
+}
+
 // String is part of the TxnSender interface.
 func (m *MockTransactionalSender) String() string {
 	return m.txn.String()

--- a/pkg/kv/sender.go
+++ b/pkg/kv/sender.go
@@ -127,6 +127,16 @@ type TxnSender interface {
 	// Transaction proto.
 	SetOmitInRangefeeds()
 
+	// SetBufferedWritesEnabled toggles whether the writes are buffered on the
+	// gateway node until the commit time. Only allowed on the RootTxn. Buffered
+	// writes cannot be enabled on a txn that performed any requests.
+	// TODO(yuzefovich): should we flush the buffer when going from "enabled" to
+	// "disabled"?
+	SetBufferedWritesEnabled(bool)
+
+	// BufferedWritesEnabled returns whether the buffered writes are enabled.
+	BufferedWritesEnabled() bool
+
 	// String returns a string representation of the txn.
 	String() string
 

--- a/pkg/kv/txn.go
+++ b/pkg/kv/txn.go
@@ -397,6 +397,24 @@ func (txn *Txn) debugNameLocked() string {
 	return fmt.Sprintf("%s (id: %s)", txn.mu.debugName, txn.mu.ID)
 }
 
+func (txn *Txn) SetBufferedWritesEnabled(enabled bool) {
+	if txn.typ != RootTxn {
+		panic(errors.AssertionFailedf("SetBufferedWritesEnabled() called on leaf txn"))
+	}
+
+	txn.mu.Lock()
+	defer txn.mu.Unlock()
+
+	txn.mu.sender.SetBufferedWritesEnabled(enabled)
+}
+
+func (txn *Txn) BufferedWritesEnabled() bool {
+	txn.mu.Lock()
+	defer txn.mu.Unlock()
+
+	return txn.mu.sender.BufferedWritesEnabled()
+}
+
 // String returns a string version of this transaction.
 func (txn *Txn) String() string {
 	txn.mu.Lock()

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -3177,6 +3177,7 @@ func (ex *connExecutor) makeExecPlan(
 	if err := ex.maybeUpgradeToSerializable(ctx, planner.stmt); err != nil {
 		return ctx, err
 	}
+	// TODO(yuzefovich): consider disabling buffered writes on a DDL.
 
 	if err := planner.makeOptimizerPlan(ctx); err != nil {
 		log.VEventf(ctx, 1, "optimizer plan failed: %v", err)
@@ -3464,6 +3465,7 @@ func (ex *connExecutor) execStmtInNoTxnState(
 				ex.QualityOfService(),
 				ex.txnIsolationLevelToKV(ctx, s.Modes.Isolation),
 				ex.omitInRangefeeds(),
+				ex.bufferedWritesEnabled(ctx),
 			)
 	case *tree.ShowCommitTimestamp:
 		return ex.execShowCommitTimestampInNoTxnState(ctx, s, res)
@@ -3502,6 +3504,7 @@ func (ex *connExecutor) execStmtInNoTxnState(
 				ex.QualityOfService(),
 				ex.txnIsolationLevelToKV(ctx, tree.UnspecifiedIsolation),
 				ex.omitInRangefeeds(),
+				ex.bufferedWritesEnabled(ctx),
 			)
 	}
 }
@@ -3535,6 +3538,7 @@ func (ex *connExecutor) beginImplicitTxn(
 			qos,
 			ex.txnIsolationLevelToKV(ctx, tree.UnspecifiedIsolation),
 			ex.omitInRangefeeds(),
+			ex.bufferedWritesEnabled(ctx),
 		)
 }
 

--- a/pkg/sql/conn_executor_prepare.go
+++ b/pkg/sql/conn_executor_prepare.go
@@ -228,6 +228,7 @@ func (ex *connExecutor) prepare(
 		if err := ex.maybeUpgradeToSerializable(ctx, stmt); err != nil {
 			return err
 		}
+		// TODO(yuzefovich): consider disabling buffered writes on a DDL.
 
 		if placeholderHints == nil {
 			placeholderHints = make(tree.PlaceholderTypes, stmt.NumPlaceholders)

--- a/pkg/sql/conn_fsm.go
+++ b/pkg/sql/conn_fsm.go
@@ -117,9 +117,10 @@ type eventTxnStartPayload struct {
 	historicalTimestamp *hlc.Timestamp
 	// qualityOfService denotes the user-level admission queue priority to use for
 	// any new Txn started using this payload.
-	qualityOfService sessiondatapb.QoSLevel
-	isoLevel         isolation.Level
-	omitInRangefeeds bool
+	qualityOfService      sessiondatapb.QoSLevel
+	isoLevel              isolation.Level
+	omitInRangefeeds      bool
+	bufferedWritesEnabled bool
 }
 
 // makeEventTxnStartPayload creates an eventTxnStartPayload.
@@ -132,16 +133,18 @@ func makeEventTxnStartPayload(
 	qualityOfService sessiondatapb.QoSLevel,
 	isoLevel isolation.Level,
 	omitInRangefeeds bool,
+	bufferedWritesEnabled bool,
 ) eventTxnStartPayload {
 	return eventTxnStartPayload{
-		pri:                 pri,
-		readOnly:            readOnly,
-		txnSQLTimestamp:     txnSQLTimestamp,
-		historicalTimestamp: historicalTimestamp,
-		tranCtx:             tranCtx,
-		qualityOfService:    qualityOfService,
-		isoLevel:            isoLevel,
-		omitInRangefeeds:    omitInRangefeeds,
+		pri:                   pri,
+		readOnly:              readOnly,
+		txnSQLTimestamp:       txnSQLTimestamp,
+		historicalTimestamp:   historicalTimestamp,
+		tranCtx:               tranCtx,
+		qualityOfService:      qualityOfService,
+		isoLevel:              isoLevel,
+		omitInRangefeeds:      omitInRangefeeds,
+		bufferedWritesEnabled: bufferedWritesEnabled,
 	}
 }
 
@@ -590,6 +593,7 @@ func noTxnToOpen(args fsm.Args) error {
 		payload.qualityOfService,
 		payload.isoLevel,
 		payload.omitInRangefeeds,
+		payload.bufferedWritesEnabled,
 	)
 	ts.setAdvanceInfo(
 		advCode,

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -3143,6 +3143,10 @@ type sessionDataMutatorCallbacks struct {
 	// setCurTxnReadOnly is called when we execute SET transaction_read_only = ...
 	// It can be nil, in which case nothing triggers on execution.
 	setCurTxnReadOnly func(readOnly bool) error
+	// setBufferedWritesEnabled is called when we execute SET kv_transaction_buffered_writes_enabled = ...
+	// It can be nil, in which case nothing triggers on execution (apart from
+	// modification of the session data).
+	setBufferedWritesEnabled func(enabled bool)
 	// upgradedIsolationLevel is called whenever the transaction isolation
 	// session variable is configured and the isolation level is automatically
 	// upgraded to a stronger one. It's also used when the isolation level is
@@ -4010,6 +4014,13 @@ func (m *sessionDataMutator) SetOptimizerPreferBoundedCardinality(b bool) {
 
 func (m *sessionDataMutator) SetOptimizerMinRowCount(val float64) {
 	m.data.OptimizerMinRowCount = val
+}
+
+func (m *sessionDataMutator) SetBufferedWritesEnabled(b bool) {
+	m.data.BufferedWritesEnabled = b
+	if m.setBufferedWritesEnabled != nil {
+		m.setBufferedWritesEnabled(b)
+	}
 }
 
 // Utility functions related to scrubbing sensitive information on SQL Stats.

--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -477,6 +477,9 @@ func (ie *InternalExecutor) newConnExecutorWithTxn(
 		ex.QualityOfService(),
 		isolation.Serializable,
 		txn.GetOmitInRangefeeds(),
+		// TODO(yuzefovich): re-evaluate whether we want to allow buffered
+		// writes for internal executor.
+		false, /* bufferedWritesEnabled */
 	)
 
 	// Modify the Collection to match the parent executor's Collection.

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -3982,6 +3982,7 @@ is_superuser                                               on
 join_reader_index_join_strategy_batch_size                 4.0 MiB
 join_reader_no_ordering_strategy_batch_size                2.0 MiB
 join_reader_ordering_strategy_batch_size                   100 KiB
+kv_transaction_buffered_writes_enabled                     off
 large_full_scan_rows                                       0
 lc_collate                                                 C.UTF-8
 lc_ctype                                                   C.UTF-8

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -2983,6 +2983,7 @@ is_superuser                                               on                  N
 join_reader_index_join_strategy_batch_size                 4.0 MiB             NULL      NULL        NULL        string
 join_reader_no_ordering_strategy_batch_size                2.0 MiB             NULL      NULL        NULL        string
 join_reader_ordering_strategy_batch_size                   100 KiB             NULL      NULL        NULL        string
+kv_transaction_buffered_writes_enabled                     off                 NULL      NULL        NULL        string
 large_full_scan_rows                                       0                   NULL      NULL        NULL        string
 lc_collate                                                 C.UTF-8             NULL      NULL        NULL        string
 lc_ctype                                                   C.UTF-8             NULL      NULL        NULL        string
@@ -3190,6 +3191,7 @@ is_superuser                                               on                  N
 join_reader_index_join_strategy_batch_size                 4.0 MiB             NULL  user     NULL      4.0 MiB             4.0 MiB
 join_reader_no_ordering_strategy_batch_size                2.0 MiB             NULL  user     NULL      2.0 MiB             2.0 MiB
 join_reader_ordering_strategy_batch_size                   100 KiB             NULL  user     NULL      100 KiB             100 KiB
+kv_transaction_buffered_writes_enabled                     off                 NULL  user     NULL      off                 off
 large_full_scan_rows                                       0                   NULL  user     NULL      0                   0
 lc_collate                                                 C.UTF-8             NULL  user     NULL      C.UTF-8             C.UTF-8
 lc_ctype                                                   C.UTF-8             NULL  user     NULL      C.UTF-8             C.UTF-8
@@ -3394,6 +3396,7 @@ is_superuser                                               NULL    NULL     NULL
 join_reader_index_join_strategy_batch_size                 NULL    NULL     NULL     NULL        NULL
 join_reader_no_ordering_strategy_batch_size                NULL    NULL     NULL     NULL        NULL
 join_reader_ordering_strategy_batch_size                   NULL    NULL     NULL     NULL        NULL
+kv_transaction_buffered_writes_enabled                     NULL    NULL     NULL     NULL        NULL
 large_full_scan_rows                                       NULL    NULL     NULL     NULL        NULL
 lc_collate                                                 NULL    NULL     NULL     NULL        NULL
 lc_ctype                                                   NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -114,6 +114,7 @@ is_superuser                                               on
 join_reader_index_join_strategy_batch_size                 4.0 MiB
 join_reader_no_ordering_strategy_batch_size                2.0 MiB
 join_reader_ordering_strategy_batch_size                   100 KiB
+kv_transaction_buffered_writes_enabled                     off
 large_full_scan_rows                                       0
 lc_collate                                                 C.UTF-8
 lc_ctype                                                   C.UTF-8

--- a/pkg/sql/sessiondatapb/local_only_session_data.proto
+++ b/pkg/sql/sessiondatapb/local_only_session_data.proto
@@ -604,6 +604,11 @@ message LocalOnlySessionData {
   // count of zero can still be estimated for expressions with a cardinality of
   // zero, e.g., for a contradictory filter.
   double optimizer_min_row_count = 155;
+  // BufferedWritesEnabled controls whether the buffered writes KV transaction
+  // protocol is used for user queries on the current session. If this variable
+  // is modified in an explicit txn, then the change will be applied only to
+  // future txns on the session.
+  bool buffered_writes_enabled = 156;
 
   ///////////////////////////////////////////////////////////////////////////
   // WARNING: consider whether a session parameter you're adding needs to  //

--- a/pkg/sql/txn_state_test.go
+++ b/pkg/sql/txn_state_test.go
@@ -282,7 +282,7 @@ func TestTransitions(t *testing.T) {
 			ev: eventTxnStart{ImplicitTxn: fsm.True},
 			evPayload: makeEventTxnStartPayload(pri, tree.ReadWrite, timeutil.Now(),
 				nil /* historicalTimestamp */, tranCtx, sessiondatapb.Normal, isolation.Serializable,
-				false, /* omitInRangefeeds */
+				false /* omitInRangefeeds */, false, /* bufferedWritesEnabled */
 			),
 			expState: stateOpen{ImplicitTxn: fsm.True, WasUpgraded: fsm.False},
 			expAdv: expAdvance{
@@ -309,7 +309,7 @@ func TestTransitions(t *testing.T) {
 			ev: eventTxnStart{ImplicitTxn: fsm.False},
 			evPayload: makeEventTxnStartPayload(pri, tree.ReadWrite, timeutil.Now(),
 				nil /* historicalTimestamp */, tranCtx, sessiondatapb.Normal, isolation.Serializable,
-				false, /* omitInRangefeeds */
+				false /* omitInRangefeeds */, false, /* bufferedWritesEnabled */
 			),
 			expState: stateOpen{ImplicitTxn: fsm.False, WasUpgraded: fsm.False},
 			expAdv: expAdvance{


### PR DESCRIPTION
This commit introduces `kv_transaction_buffered_writes_enabled` session variable that controls whether the buffered writes are enabled for the txn in a given user session. To be conservative, we - at least initially, but maybe in the long run too - won't allow usage of this feature for txns created not on the main query path. We also add a version gate for enabling this feature to 25.2.

Note that the session variable is included into "local only session data" meaning that it won't be propagated to remote nodes performing some DistSQL work. I think that won't be needed since the leaf txns on the remote nodes will know whether to enable the write buffer interceptor based on whether any buffered writes are included into the LeafTxnInputState proto.

Changing the session variable in an explicit txn doesn't modify the current txn and we add a notice for that. In other words, the variable value at the start of a txn controls whether buffered writes are enabled.

At the moment we assert that going from "disabled" to "enabled" is not performed on a txn that performed any requests.

Also, I think that we might want to explicitly disable the write buffering whenever we encounter the first DDL statement out of caution, so I left a couple of TODOs for that. Thus, going from "enabled" to "disabled" isn't prohibited.

Epic: None
Release note: None