### PR TITLE
changefeedccl: skip TestChangefeedNemeses under deadlock

### DIFF
--- a/pkg/ccl/changefeedccl/nemeses_test.go
+++ b/pkg/ccl/changefeedccl/nemeses_test.go
@@ -26,6 +26,9 @@ func TestChangefeedNemeses(t *testing.T) {
 
 	testutils.RunValues(t, "nemeses_options=", cdctest.NemesesOptions, func(t *testing.T, nop cdctest.NemesesOption) {
 		testFn := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
+			if nop.EnableSQLSmith {
+				skip.UnderDeadlock(t, "takes too long under deadlock")
+			}
 			rng, seed := randutil.NewPseudoRand()
 			t.Logf("random seed: %d", seed)
 


### PR DESCRIPTION
This patch skips TestChangefeedNemeses under deadlock, as sql smith
initialization can be slow, causing the test to fail before the changefeed even
starts.

Epic: none
Fixes: https://github.com/cockroachdb/cockroach/issues/140101