### PR TITLE
concurrency: save IgnoredSeqNums for unreplicated locks

### DIFF
--- a/pkg/kv/kvserver/concurrency/lock_table_test.go
+++ b/pkg/kv/kvserver/concurrency/lock_table_test.go
@@ -837,7 +837,8 @@ func ScanIgnoredSeqNumbers(t *testing.T, d *datadriven.TestData) []enginepb.Igno
 			}
 			ignoredRange.End = enginepb.TxnSeq(endNum)
 		}
-		ignored = append(ignored, ignoredRange)
+
+		ignored = enginepb.TxnSeqListAppend(ignored, ignoredRange)
 	}
 	return ignored
 }
@@ -2081,8 +2082,8 @@ func TestKeyLocksSafeFormat(t *testing.T) {
 	holder.txn = &enginepb.TxnMeta{ID: uuid.NamespaceDNS}
 	holder.unreplicatedInfo.init()
 	holder.unreplicatedInfo.ts = hlc.Timestamp{WallTime: 123, Logical: 7}
-	require.NoError(t, holder.unreplicatedInfo.acquire(lock.Exclusive, 1))
-	require.NoError(t, holder.unreplicatedInfo.acquire(lock.Shared, 3))
+	require.NoError(t, holder.unreplicatedInfo.acquire(lock.Exclusive, 1, nil))
+	require.NoError(t, holder.unreplicatedInfo.acquire(lock.Shared, 3, nil))
 	replTS := hlc.Timestamp{WallTime: 125, Logical: 1}
 	holder.replicatedInfo.acquire(lock.Intent, replTS)
 	holder.replicatedInfo.acquire(lock.Shared, replTS)
@@ -2109,11 +2110,11 @@ func TestKeyLocksSafeFormatMultipleLockHolders(t *testing.T) {
 	holder1.txn = &enginepb.TxnMeta{ID: uuid.NamespaceDNS}
 	holder1.unreplicatedInfo.init()
 	holder1.unreplicatedInfo.ts = hlc.Timestamp{WallTime: 123, Logical: 7}
-	require.NoError(t, holder1.unreplicatedInfo.acquire(lock.Shared, 3))
+	require.NoError(t, holder1.unreplicatedInfo.acquire(lock.Shared, 3, nil))
 	holder2.txn = &enginepb.TxnMeta{ID: uuid.NamespaceURL}
 	holder2.unreplicatedInfo.init()
 	holder2.unreplicatedInfo.ts = hlc.Timestamp{WallTime: 125, Logical: 1}
-	require.NoError(t, holder2.unreplicatedInfo.acquire(lock.Shared, 6))
+	require.NoError(t, holder2.unreplicatedInfo.acquire(lock.Shared, 6, nil))
 	require.EqualValues(t,
 		" lock: ‹\"KEY\"›\n"+
 			"  holders: txn: 6ba7b810-9dad-11d1-80b4-00c04fd430c8 epoch: 0, iso: Serializable, info: unrepl [(str: Shared seq: 3)]\n"+
@@ -2139,7 +2140,7 @@ func TestKeyLocksSafeFormatWaitQueue(t *testing.T) {
 	holder.txn = &enginepb.TxnMeta{ID: uuid.NamespaceDNS}
 	holder.unreplicatedInfo.init()
 	holder.unreplicatedInfo.ts = hlc.Timestamp{WallTime: 123, Logical: 7}
-	require.NoError(t, holder.unreplicatedInfo.acquire(lock.Shared, 3))
+	require.NoError(t, holder.unreplicatedInfo.acquire(lock.Shared, 3, nil))
 	waiter := queuedGuard{
 		guard:  newLockTableGuardImpl(),
 		active: true,

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/acquire_ignored_seqs
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/acquire_ignored_seqs
@@ -65,7 +65,7 @@ acquire r=req4 k=a durability=u ignored-seqs=2,3 strength=exclusive
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 1)]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 1)] ign seq: [{2 2} {3 3}]
 
 # ------------------------------------------------------------------------------
 # Re-acquire the (unreplicated) lock at a higher sequence number. This time,
@@ -78,11 +78,11 @@ new-txn txn=txn1 ts=10,1 epoch=0 seq=8
 new-request r=req5 txn=txn1 ts=10,1 spans=exclusive@a
 ----
 
-acquire r=req5 k=a durability=u ignored-seqs=4 strength=exclusive
+acquire r=req5 k=a durability=u ignored-seqs=2,3,4 strength=exclusive
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 1)]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: unrepl [(str: Exclusive seq: 1)] ign seq: [{2 2} {3 3} {4 4}]
 
 # ------------------------------------------------------------------------------
 # Ensure sequence numbers get pruned when acquiring replicated locks, and the
@@ -111,11 +111,11 @@ new-request r=req7 txn=txn1 ts=10,1 spans=intent@a
 # Because the lock is being acquired as a replicated lock nothing in the
 # unreplicated sequence number tracking gets pruned.
 
-acquire r=req7 k=a durability=r ignored-seqs=8 strength=intent
+acquire r=req7 k=a durability=r ignored-seqs=2,3,4,8 strength=intent
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent], unrepl [(str: Exclusive seq: 1)]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent], unrepl [(str: Exclusive seq: 1)] ign seq: [{2 2} {3 3} {4 4}]
    queued locking requests:
     active: true req: 3, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
 
@@ -124,11 +124,11 @@ num=1
 new-request r=req8 txn=txn1 ts=10,1 spans=exclusive@a
 ----
 
-acquire r=req8 k=a durability=u ignored-seqs=8 strength=exclusive
+acquire r=req8 k=a durability=u ignored-seqs=2,3,4,8 strength=exclusive
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent], unrepl [(str: Exclusive seq: 1)]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent], unrepl [(str: Exclusive seq: 1)] ign seq: [{2 2} {3 3} {4 4} {8 8}]
    queued locking requests:
     active: true req: 3, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
 
@@ -142,11 +142,11 @@ new-txn txn=txn1 ts=10,1 epoch=0 seq=11
 new-request r=req9 txn=txn1 ts=10,1 spans=exclusive@a
 ----
 
-acquire r=req9 k=a durability=u ignored-seqs=1,5-9 strength=exclusive
+acquire r=req9 k=a durability=u ignored-seqs=1,2-9 strength=exclusive
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent], unrepl [(str: Exclusive seq: 11)]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 0, iso: Serializable, ts: 10.000000000,1, info: repl [Intent], unrepl [(str: Exclusive seq: 11)] ign seq: [{1 1} {2 9}]
    queued locking requests:
     active: true req: 3, strength: Intent, txn: 00000000-0000-0000-0000-000000000002
 

--- a/pkg/kv/kvserver/concurrency/testdata/lock_table/update
+++ b/pkg/kv/kvserver/concurrency/testdata/lock_table/update
@@ -432,27 +432,27 @@ update txn=txn1 ts=10 epoch=1 span=a ignored-seqs=3,8-9
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 1, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 1)]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 1, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 1)] ign seq: [{3 3} {8 9}]
 
 # No change since update is using older epoch.
 
-update txn=txn1 ts=10 epoch=0 span=a ignored-seqs=3,5-7
+update txn=txn1 ts=10 epoch=0 span=a ignored-seqs=3,8-9
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 1, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 1)]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 1, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 1)] ign seq: [{3 3} {8 9}]
 
-update txn=txn1 ts=10 epoch=1 span=a ignored-seqs=3,5-7
+update txn=txn1 ts=10 epoch=1 span=a ignored-seqs=3,8-9
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 1, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 1)]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 1, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 1)] ign seq: [{3 3} {8 9}]
 
-update txn=txn1 ts=10 epoch=1 span=a ignored-seqs=9-11
+update txn=txn1 ts=10 epoch=1 span=a ignored-seqs=3,8-11
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 1, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 1)]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 1, iso: Serializable, ts: 10.000000000,0, info: unrepl [(str: Exclusive seq: 1)] ign seq: [{3 3} {8 11}]
 
 # No seqnum change since update is using older epoch. But since the update is using
 # a higher timestamp, the ts is advanced.
@@ -461,7 +461,7 @@ update txn=txn1 ts=15 epoch=0 span=a ignored-seqs=1
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 1, iso: Serializable, ts: 15.000000000,0, info: unrepl [(str: Exclusive seq: 1)]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 1, iso: Serializable, ts: 15.000000000,0, info: unrepl [(str: Exclusive seq: 1)] ign seq: [{3 3} {8 11}]
 
 # No change, since seqnum 3 is not held. Note that the ts is not updated.
 
@@ -469,14 +469,14 @@ update txn=txn1 ts=10 epoch=1 span=a ignored-seqs=3
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 1, iso: Serializable, ts: 15.000000000,0, info: unrepl [(str: Exclusive seq: 1)]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 1, iso: Serializable, ts: 15.000000000,0, info: unrepl [(str: Exclusive seq: 1)] ign seq: [{3 3} {8 11}]
 
 # Timestamp is updated again.
 update txn=txn1 ts=16 epoch=1 span=a
 ----
 num=1
  lock: "a"
-  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 1, iso: Serializable, ts: 16.000000000,0, info: unrepl [(str: Exclusive seq: 1)]
+  holder: txn: 00000000-0000-0000-0000-000000000001 epoch: 1, iso: Serializable, ts: 16.000000000,0, info: unrepl [(str: Exclusive seq: 1)] ign seq: [{3 3} {8 11}]
 
 # Seqnum 1 is also ignored, so the lock is released. Note that it does not
 # matter that the update is using an older timestamp.

--- a/pkg/roachpb/data.go
+++ b/pkg/roachpb/data.go
@@ -1596,48 +1596,9 @@ func (t *Transaction) GetObservedTimestamp(nodeID NodeID) (hlc.ClockTimestamp, b
 // allow interior mutations, the existing list is copied instead of being
 // mutated in place.
 //
-// The following invariants are assumed to hold and are preserved:
-// - the list contains no overlapping ranges
-// - the list contains no contiguous ranges
-// - the list is sorted, with larger seqnums at the end
-//
-// Additionally, the caller must ensure:
-//
-//  1. if the new range overlaps with some range in the list, then it
-//     also overlaps with every subsequent range in the list.
-//
-//  2. the new range's "end" seqnum is larger or equal to the "end"
-//     seqnum of the last element in the list.
-//
-// For example:
-//
-//	current list [3 5] [10 20] [22 24]
-//	new item:    [8 26]
-//	final list:  [3 5] [8 26]
-//
-//	current list [3 5] [10 20] [22 24]
-//	new item:    [28 32]
-//	final list:  [3 5] [10 20] [22 24] [28 32]
-//
-// This corresponds to savepoints semantics:
-//
-//   - Property 1 says that a rollback to an earlier savepoint
-//     rolls back over all writes following that savepoint.
-//   - Property 2 comes from that the new range's 'end' seqnum is the
-//     current write seqnum and thus larger than or equal to every
-//     previously seen value.
+// See enginepb.TxnSeqListAppend for more details.
 func (t *Transaction) AddIgnoredSeqNumRange(newRange enginepb.IgnoredSeqNumRange) {
-	// Truncate the list at the last element not included in the new range.
-
-	list := t.IgnoredSeqNums
-	i := sort.Search(len(list), func(i int) bool {
-		return list[i].End >= newRange.Start
-	})
-
-	cpy := make([]enginepb.IgnoredSeqNumRange, i+1)
-	copy(cpy[:i], list[:i])
-	cpy[i] = newRange
-	t.IgnoredSeqNums = cpy
+	t.IgnoredSeqNums = enginepb.TxnSeqListAppend(t.IgnoredSeqNums, newRange)
 }
 
 // AsRecord returns a TransactionRecord object containing only the subset of

--- a/pkg/storage/enginepb/mvcc.go
+++ b/pkg/storage/enginepb/mvcc.go
@@ -60,6 +60,83 @@ func TxnSeqIsIgnored(seq TxnSeq, ignored []IgnoredSeqNumRange) bool {
 		ignored[i].Start <= seq
 }
 
+// TxnSeqListExtends returns true if every interval in b is fully covered by an
+// interval in a.
+//
+// It assumes that the input intervals are non-overlapping, non-contiguous, and
+// sorted. It returns false if the two lists are disjoint.
+func TxnSeqListExtends(a, b []IgnoredSeqNumRange) bool {
+	idxA, idxB := 0, 0
+	for idxB < len(b) {
+		// No more intervals in a but we stil have intervals in b, b must not be
+		// fully covered.
+		if idxA >= len(a) {
+			return false
+		}
+
+		// If the current a start is greater than b start, then b extends to the left
+		// of a and therefore b must not be fully covered.
+		if a[idxA].Start > b[idxB].Start {
+			return false
+		}
+
+		// From above we know b's start is equal to or after the start of a. If a
+		// end is less than b end, then the current a is completely consumed and we
+		// need to move to the next a interval. Otherwise, the b interval is
+		// completely covered and we need to move to the next b interval.
+		if a[idxA].End < b[idxB].End {
+			idxA++
+		} else {
+			idxB++
+		}
+	}
+	return true
+}
+
+// TxnSeqListAppend returns a new slice with the given range added to the
+// given list of ignored seqnum ranges.
+//
+// The following invariants are assumed to hold and are preserved:
+// - the list contains no overlapping ranges
+// - the list contains no contiguous ranges
+// - the list is sorted, with larger seqnums at the end
+//
+// Additionally, the caller must ensure:
+//
+//  1. if the new range overlaps with some range in the list, then it
+//     also overlaps with every subsequent range in the list.
+//
+//  2. the new range's "end" seqnum is larger or equal to the "end"
+//     seqnum of the last element in the list.
+//
+// For example:
+//
+//	current list [3 5] [10 20] [22 24]
+//	new item:    [8 26]
+//	final list:  [3 5] [8 26]
+//
+//	current list [3 5] [10 20] [22 24]
+//	new item:    [28 32]
+//	final list:  [3 5] [10 20] [22 24] [28 32]
+//
+// This corresponds to savepoints semantics:
+//
+//   - Property 1 says that a rollback to an earlier savepoint
+//     rolls back over all writes following that savepoint.
+//   - Property 2 comes from that the new range's 'end' seqnum is the
+//     current write seqnum and thus larger than or equal to every
+//     previously seen value.
+func TxnSeqListAppend(list []IgnoredSeqNumRange, newRange IgnoredSeqNumRange) []IgnoredSeqNumRange {
+	i := sort.Search(len(list), func(i int) bool {
+		return list[i].End >= newRange.Start
+	})
+
+	cpy := make([]IgnoredSeqNumRange, i+1)
+	copy(cpy[:i], list[:i])
+	cpy[i] = newRange
+	return cpy
+}
+
 // Short returns a prefix of the transaction's ID.
 func (t TxnMeta) Short() redact.SafeString {
 	return redact.SafeString(t.ID.Short().String())

--- a/pkg/storage/enginepb/mvcc_test.go
+++ b/pkg/storage/enginepb/mvcc_test.go
@@ -6,6 +6,7 @@
 package enginepb_test
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/isolation"
@@ -101,6 +102,131 @@ func TestTxnSeqIsIgnored(t *testing.T) {
 		for _, notIgn := range tc.notIgnored {
 			assert.False(t, enginepb.TxnSeqIsIgnored(notIgn, tc.list))
 		}
+	}
+}
+
+func TestTxnSeqListExtends(t *testing.T) {
+	type s = enginepb.TxnSeq
+	type r = enginepb.IgnoredSeqNumRange
+	mr := func(a, b s) r {
+		return r{Start: a, End: b}
+	}
+
+	testData := []struct {
+		a        []r
+		b        []r
+		isEqual  bool
+		expected bool
+	}{
+		{
+			[]r{},
+			[]r{},
+			true,
+			true,
+		},
+		{
+			[]r{mr(1, 5)},
+			[]r{mr(1, 1)},
+			false,
+			true,
+		},
+		{
+			[]r{mr(2, 5)},
+			[]r{mr(1, 5)},
+			false,
+			false,
+		},
+		{
+			[]r{mr(1, 5)},
+			[]r{mr(2, 4)},
+			false,
+			true,
+		},
+		{
+			[]r{mr(2, 4)},
+			[]r{mr(1, 5)},
+			false,
+			false,
+		},
+		{
+			[]r{mr(3, 5), mr(8, 26)},
+			[]r{mr(3, 5), mr(10, 20), mr(22, 24)},
+			false,
+			true,
+		},
+		{
+			[]r{mr(3, 5), mr(10, 20), mr(22, 24), mr(28, 32)},
+			[]r{mr(3, 5), mr(10, 20), mr(22, 24)},
+			false,
+			true,
+		},
+		{
+			[]r{mr(3, 5), mr(10, 20), mr(22, 24)},
+			[]r{mr(3, 5), mr(10, 20), mr(22, 24)},
+			true,
+			true,
+		},
+	}
+
+	for i, tc := range testData {
+		t.Run(fmt.Sprintf("case=%d", i), func(t *testing.T) {
+			require.Equal(t, tc.expected, enginepb.TxnSeqListExtends(tc.a, tc.b))
+			if !tc.isEqual {
+				require.Equal(t, !tc.expected, enginepb.TxnSeqListExtends(tc.b, tc.a))
+			} else {
+				require.Equal(t, true, enginepb.TxnSeqListExtends(tc.b, tc.a))
+			}
+		})
+	}
+	t.Run("disjoint", func(t *testing.T) {
+		a := []r{mr(1, 2)}
+		b := []r{mr(4, 5)}
+		require.Equal(t, false, enginepb.TxnSeqListExtends(a, b))
+		require.Equal(t, false, enginepb.TxnSeqListExtends(b, a))
+	})
+}
+
+func TestTxnSeqListAppend(t *testing.T) {
+	type r = enginepb.IgnoredSeqNumRange
+
+	mr := func(a, b enginepb.TxnSeq) r {
+		return r{Start: a, End: b}
+	}
+
+	testData := []struct {
+		list     []r
+		newRange r
+		exp      []r
+	}{
+		{
+			[]r{},
+			mr(1, 2),
+			[]r{mr(1, 2)},
+		},
+		{
+			[]r{mr(1, 2)},
+			mr(1, 4),
+			[]r{mr(1, 4)},
+		},
+		{
+			[]r{mr(1, 2), mr(3, 6)},
+			mr(8, 10),
+			[]r{mr(1, 2), mr(3, 6), mr(8, 10)},
+		},
+		{
+			[]r{mr(1, 2), mr(5, 6)},
+			mr(3, 8),
+			[]r{mr(1, 2), mr(3, 8)},
+		},
+		{
+			[]r{mr(1, 2), mr(5, 6)},
+			mr(1, 8),
+			[]r{mr(1, 8)},
+		},
+	}
+
+	for _, tc := range testData {
+		require.Equal(t, tc.exp, enginepb.TxnSeqListAppend(tc.list, tc.newRange))
 	}
 }
 


### PR DESCRIPTION
The ignoredSeqNums slice is the last-seen ignoredSeqNums from the acquiring transaction. At a given point in time, the transaction may have a larger set of ignoredSeqNums.

The intent is to use this for potential flushing of unreplicated locks as replicated locks. When doing this flush, we want to avoid clobbering existing replicated locks that may be on disk and should be preserved to ensure correct rollback behaviour.

*Motivating example*

First consider the following state:

    replicated lock @ seq=1 (on disk, not in memory)
    rollback @ seq=1
    unreplicated lock @ seq=2 (seq 1 ignored)

The on-disk replicated lock will be ignored by future scans of the lock table. When we go to flush our unreplicated lock as a replicated lock, we want to overwrite the replicated lock at seq=1 with our new lock at seq=2.

Now consider a slightly different scenario:

    replicated lock @ seq=1 (on disk, not in memory)
    unreplicated lock @ seq=2

In this case, the in-memory lock table will have an unreplicated lock at seq=2. When we go to flush our unreplicated lock as a replicated lock, we DO NOT want to overwrite the replicated lock at seq=1.

Here we can see that in both cases we have an unreplicated lock held at seq=2, but what to do when flushing depends on what sequence numbers have been rolled back. Storing the set of ignored sequence numbers from the point of acquisition allows us to do this.

Note that in the second case if seq=2 has been rolled back since we stored the ignoredSeqNums, that is OK, we have a lock at seq=1 still. If seq=1 has been rolled back since we stored the ingoredSeqNums, that is also OK, because future requests will include it in the ignored seq number list and we also know there is no way to rollback 1 without rolling back 2.

We may ask whether the min sequence number in strengths above is sufficient. But we don't believe it is since in the cases, one cannot tell you whether or not you need to preserve the replicated lock at seq=1 based on the sequence of the held unreplicated lock.

Informs #139141

Release Note: None