### PR TITLE
fix: ensure branch synchronization in generate diagrams script

### DIFF
--- a/build/teamcity-diagram-generation.sh
+++ b/build/teamcity-diagram-generation.sh
@@ -41,15 +41,19 @@ tc_start_block "Push Diagrams to Git"
 cd generated-diagrams
 
 changed_diagrams=$(git status --porcelain)
-if [ -z "$changed_diagrams" ]
-then
-	echo "No diagrams changed. Exiting."
-  tc_end_block "Push Diagrams to Git"
-	exit 0
+if [ -z "$changed_diagrams" ]; then
+    if [ "$TC_BUILD_BRANCH" = "master" ]; then
+        echo "No diagrams changed and on master branch. Exiting."
+        tc_end_block "Push Diagrams to Git"
+        exit 0
+    else
+        echo "No diagrams changed, but creating branch $TC_BUILD_BRANCH anyway."
+        git commit --allow-empty -m "Empty commit to create branch $TC_BUILD_BRANCH for reference $cockroach_ref.This empty commit is required to ensure the branch exists in the remote repository even when there are no diagram changes. This helps maintain branch consistency with cockroach repo to ensure clean release note generation process "
+    fi
+else
+    git add .
+    git commit -m "Snapshot $cockroach_ref"
 fi
-
-git add .
-git commit -m "Snapshot $cockroach_ref"
 
 github_ssh_key="${PRIVATE_DEPLOY_KEY_FOR_GENERATED_DIAGRAMS}"
 configure_git_ssh_key


### PR DESCRIPTION
**What changed?**
The generate diagrams script is updated to always create a corresponding branch in the generated-diagrams repository, even when no diagram changes are detected.

**Why?**
Previously, if no changes were found, a branch wouldn’t be created in generated-diagrams, leading to inconsistencies between the cockroach and generated-diagrams repositories. This was causing issues for writers when they were creating release notes using release note scripts 

**How?**
The script has been modified to proactively create branches regardless of changes. This ensures that every branch in cockroach has a corresponding branch in generated-diagrams, maintaining synchronization between the two repositories.

Modified the script to proactively create branches in the generated-diagrams repo, even when no changes are detected. This ensures branch consistency between the cockroach and generated-diagrams repositories. Epic:none
release note: none
Jira issue keys: [DOC-12104](https://cockroachlabs.atlassian.net/browse/DOC-12104) 
Epic: None