### PR TITLE
ci: add TODO comment for nightly docker location changes

### DIFF
--- a/build/teamcity/internal/release/process/make-and-publish-build-tagging.sh
+++ b/build/teamcity/internal/release/process/make-and-publish-build-tagging.sh
@@ -36,6 +36,7 @@ fi
 if [[ -z "${DRY_RUN}" ]]; then
   if [[ -z "${is_customized_build}" ]] ; then
     google_credentials=$GOOGLE_COCKROACH_CLOUD_IMAGES_COCKROACHDB_CREDENTIALS
+    # TODO: please see https://cockroachlabs.atlassian.net/browse/RE-360 in case you change the location of the nightly docker images.
     gcr_repository="us-docker.pkg.dev/cockroach-cloud-images/cockroachdb/cockroach"
     # Used for docker login for gcloud
     gcr_hostname="us-docker.pkg.dev"


### PR DESCRIPTION
Added a comment to trigger a work flow in case we change the location of the nightly docker images.

Epic: none
Release note: None