### PR TITLE
workload: don't prepare tpcc statments with mix weight of 0

### DIFF
--- a/pkg/cmd/roachtest/tests/cluster_to_cluster.go
+++ b/pkg/cmd/roachtest/tests/cluster_to_cluster.go
@@ -217,6 +217,7 @@ type replicateTPCC struct {
 	duration       time.Duration
 	repairOrderIDs bool
 	tolerateErrors bool
+	readOnly       bool
 }
 
 func (tpcc replicateTPCC) sourceInitCmd(tenantName string, nodes option.NodeListOption) string {
@@ -233,6 +234,7 @@ func (tpcc replicateTPCC) sourceRunCmd(tenantName string, nodes option.NodeListO
 		MaybeFlag(tpcc.duration > 0, "duration", tpcc.duration).
 		MaybeOption(tpcc.tolerateErrors, "tolerate-errors").
 		MaybeOption(tpcc.repairOrderIDs, "repair-order-ids").
+		MaybeFlag(tpcc.readOnly, "mix", "newOrder=0,payment=0,orderStatus=1,delivery=0,stockLevel=1").
 		Arg("{pgurl%s:%s}", nodes, tenantName).
 		WithEqualsSyntax()
 	return cmd.String()
@@ -1170,6 +1172,7 @@ func registerClusterToCluster(r registry.Registry) {
 			pdSize:    1000,
 
 			workload:           replicateTPCC{warehouses: 1000, tolerateErrors: true},
+			withReaderWorkload: replicateTPCC{warehouses: 500, readOnly: true, tolerateErrors: true},
 			timeout:            3 * time.Hour,
 			additionalDuration: 60 * time.Minute,
 			cutover:            30 * time.Minute,

--- a/pkg/workload/tpcc/worker.go
+++ b/pkg/workload/tpcc/worker.go
@@ -191,6 +191,9 @@ func newWorker(
 	}
 	for i := range w.txs {
 		var err error
+		if config.txInfos[i].weight == 0 {
+			continue
+		}
 		w.txs[i], err = config.txInfos[i].constructor(ctx, config, mcp)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
This patch adds a flag to the tpcc workload which prevents the driver from
preparing write statements. This functionality will be used to test PCR's read
from standby functionality in PCR's performance and mixed version roachtests.

Epic: none

Release note: none