### PR TITLE
roachprod: add ip address expander func

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -2508,7 +2508,7 @@ func (c *clusterImpl) RunE(ctx context.Context, options install.RunOptions, args
 	}
 	if err := roachprod.Run(
 		ctx, l, c.MakeNodes(nodes), "", "", c.IsSecure(),
-		l.Stdout, l.Stderr, args, options.WithExpanderConfig(expanderCfg),
+		l.Stdout, l.Stderr, args, options.WithExpanderConfig(expanderCfg).WithLogExpandedCommand(),
 	); err != nil {
 		if err := ctx.Err(); err != nil {
 			l.Printf("(note: incoming context was canceled: %s)", err)
@@ -2578,7 +2578,7 @@ func (c *clusterImpl) RunWithDetails(
 	}
 	results, err := roachprod.RunWithDetails(
 		ctx, l, c.MakeNodes(nodes), "" /* SSHOptions */, "", /* processTag */
-		c.IsSecure(), args, options.WithExpanderConfig(expanderCfg),
+		c.IsSecure(), args, options.WithExpanderConfig(expanderCfg).WithLogExpandedCommand(),
 	)
 
 	var logFileFull string

--- a/pkg/cmd/roachtest/tests/failover.go
+++ b/pkg/cmd/roachtest/tests/failover.go
@@ -1341,11 +1341,9 @@ func (f *blackholeFailer) Fail(ctx context.Context, nodeID int) {
 // FailPartial creates a partial blackhole failure between the given node and
 // peers.
 func (f *blackholeFailer) FailPartial(ctx context.Context, nodeID int, peerIDs []int) {
-	peerIPs, err := f.c.InternalIP(ctx, f.t.L(), peerIDs)
-	require.NoError(f.t, err)
-
-	for _, peerIP := range peerIPs {
+	for _, peerID := range peerIDs {
 		pgport := fmt.Sprintf("{pgport:%d}", nodeID)
+		peerIP := fmt.Sprintf("{ip:%d}", peerID)
 
 		// When dropping both input and output, make sure we drop packets in both
 		// directions for both the inbound and outbound TCP connections, such that

--- a/pkg/roachprod/install/BUILD.bazel
+++ b/pkg/roachprod/install/BUILD.bazel
@@ -59,6 +59,7 @@ go_test(
     srcs = [
         "cluster_synced_test.go",
         "cockroach_test.go",
+        "expander_test.go",
         "monitor_test.go",
         "services_test.go",
         "session_test.go",

--- a/pkg/roachprod/install/cluster_synced.go
+++ b/pkg/roachprod/install/cluster_synced.go
@@ -782,10 +782,12 @@ func (r *RunResultDetails) Output(decorate bool) string {
 type RunCmdOptions struct {
 	combinedOut             bool
 	includeRoachprodEnvVars bool
-	stdin                   io.Reader
-	stdout, stderr          io.Writer
-	remoteOptions           []remoteSessionOption
-	expanderConfig          ExpanderConfig
+	// If true, logs the expanded result if it differs from the original command.
+	logExpandedCmd bool
+	stdin          io.Reader
+	stdout, stderr io.Writer
+	remoteOptions  []remoteSessionOption
+	expanderConfig ExpanderConfig
 }
 
 // Default RunCmdOptions enable combining output (stdout and stderr) and capturing ssh (verbose) debug output.
@@ -825,6 +827,9 @@ func (c *SyncedCluster) runCmdOnSingleNode(
 	expandedCmd, err := e.expand(ctx, l, c, opts.expanderConfig, cmd)
 	if err != nil {
 		return &noResult, errors.WithDetailf(err, "error expanding command: %s", cmd)
+	}
+	if opts.logExpandedCmd && expandedCmd != cmd {
+		l.Printf("Node %d expanded cmd: %s", e.node, expandedCmd)
 	}
 
 	nodeCmd := expandedCmd
@@ -931,6 +936,7 @@ func (c *SyncedCluster) Run(
 			stdout:                  stdout,
 			stderr:                  stderr,
 			expanderConfig:          options.ExpanderConfig,
+			logExpandedCmd:          options.LogExpandedCmd,
 		}
 		result, err := c.runCmdOnSingleNode(ctx, l, node, cmd, opts)
 		return result, err
@@ -1015,6 +1021,7 @@ func (c *SyncedCluster) RunWithDetails(
 			stdout:                  l.Stdout,
 			stderr:                  l.Stderr,
 			expanderConfig:          options.ExpanderConfig,
+			logExpandedCmd:          options.LogExpandedCmd,
 		}
 		result, err := c.runCmdOnSingleNode(ctx, l, node, cmd, opts)
 		return result, err

--- a/pkg/roachprod/install/expander_test.go
+++ b/pkg/roachprod/install/expander_test.go
@@ -1,0 +1,89 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package install
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/roachprod/cloud"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
+	"github.com/cockroachdb/cockroach/pkg/testutils/datapathutils"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestCluster(t *testing.T) *SyncedCluster {
+	testClusterFile := datapathutils.TestDataPath(t, "test_cluster.txt")
+	data, err := os.ReadFile(testClusterFile)
+	if err != nil {
+		t.Fatalf("could not read test cluster file: %s", err)
+	}
+	metadata := &cloud.Cluster{}
+	if err := json.Unmarshal(data, metadata); err != nil {
+		t.Fatalf("could not unmarshal test cluster file: %s", err)
+	}
+	c, err := NewSyncedCluster(metadata, "all", MakeClusterSettings())
+	if err != nil {
+		t.Fatalf("could not create synced cluster: %s", err)
+	}
+	return c
+}
+
+func TestIPExpander(t *testing.T) {
+	ctx := context.Background()
+	l := &logger.Logger{}
+
+	c := newTestCluster(t)
+	e := &expander{
+		node: c.Nodes[0],
+	}
+	cfg := ExpanderConfig{}
+
+	for _, tc := range []struct {
+		name     string
+		command  string
+		expected string
+	}{
+		{
+			name:     "same node",
+			command:  "{ip:1}",
+			expected: "10.142.1.1",
+		},
+		{
+			name:     "different node",
+			command:  "{ip:2}",
+			expected: "10.142.1.2",
+		},
+		{
+			name:     "range of nodes",
+			command:  "{ip:1-3}",
+			expected: "10.142.1.1 10.142.1.2 10.142.1.3",
+		},
+		{
+			name:     "non consecutive nodes",
+			command:  "{ip:2,4}",
+			expected: "10.142.1.2 10.142.1.4",
+		},
+		{
+			name:     "public ip",
+			command:  "{ip:1-4:public}",
+			expected: "35.196.120.1 35.227.25.2 34.75.95.3 34.139.54.4",
+		},
+		{
+			name:     "private ip",
+			command:  "{ip:1-4:private}",
+			expected: "10.142.1.1 10.142.1.2 10.142.1.3 10.142.1.4",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			res, err := e.expand(ctx, l, c, cfg, tc.command)
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, res)
+		})
+	}
+}

--- a/pkg/roachprod/install/run_options.go
+++ b/pkg/roachprod/install/run_options.go
@@ -25,6 +25,8 @@ type RunOptions struct {
 	// ExpanderConfig configures the behaviour of the roachprod expander
 	// during a run.
 	ExpanderConfig ExpanderConfig
+	// LogExpandedCmd will log the expanded command if it differs from the original.
+	LogExpandedCmd bool
 
 	// These are private to roachprod
 	Nodes       Nodes
@@ -104,5 +106,10 @@ func (r RunOptions) WithDisplay(display string) RunOptions {
 
 func (r RunOptions) WithExpanderConfig(cfg ExpanderConfig) RunOptions {
 	r.ExpanderConfig = cfg
+	return r
+}
+
+func (r RunOptions) WithLogExpandedCommand() RunOptions {
+	r.LogExpandedCmd = true
 	return r
 }

--- a/pkg/roachprod/install/testdata/test_cluster.txt
+++ b/pkg/roachprod/install/testdata/test_cluster.txt
@@ -1,0 +1,213 @@
+{
+  "name": "foo-bar",
+  "user": "baz",
+  "created_at": "2025-02-04T16:02:50.788732Z",
+  "lifetime": 43200000000000,
+  "vms": [
+    {
+      "name": "foo-bar-0001",
+      "created_at": "2025-02-04T08:02:52.385-08:00",
+      "errors": null,
+      "lifetime": 43200000000000,
+      "preemptible": false,
+      "labels": {
+        "cluster": "foo-bar",
+        "created": "2025-02-04t16_02_50z",
+        "lifetime": "12h0m0s",
+        "roachprod": "true",
+        "usage": "roachprod"
+      },
+      "dns": "foo-bar-0001.us-east1-d.unit-test",
+      "public_dns": "foo-bar-0001.roachprod.crdb.io",
+      "dns_provider": "gce",
+      "provider": "gce",
+      "provider_id": "foo-bar-0001",
+      "private_ip": "10.142.1.1",
+      "public_ip": "35.196.120.1",
+      "remote_user": "ubuntu",
+      "vpc": "default",
+      "machine_type": "n2-standard-4",
+      "cpu_architecture": "amd64",
+      "cpu_family": "ice lake",
+      "zone": "us-east1-d",
+      "project": "unit-test",
+      "non_bootable_volumes": null,
+      "bootable_volume": {
+        "ProviderResourceID": "foo-bar-0001",
+        "ProviderVolumeType": "pd-ssd",
+        "Zone": "us-east1-d",
+        "Encrypted": false,
+        "Name": "foo-bar-0001",
+        "Labels": null,
+        "Size": 10
+      },
+      "local_disks": [
+        {
+          "ProviderResourceID": "",
+          "ProviderVolumeType": "local-ssd",
+          "Zone": "",
+          "Encrypted": false,
+          "Name": "",
+          "Labels": null,
+          "Size": 375
+        }
+      ],
+      "CostPerHour": 0,
+      "EmptyCluster": false
+    },
+    {
+      "name": "foo-bar-0002",
+      "created_at": "2025-02-04T08:02:52.633-08:00",
+      "errors": null,
+      "lifetime": 43200000000000,
+      "preemptible": false,
+      "labels": {
+        "cluster": "foo-bar",
+        "created": "2025-02-04t16_02_50z",
+        "lifetime": "12h0m0s",
+        "roachprod": "true",
+        "usage": "roachprod"
+      },
+      "dns": "foo-bar-0002.us-east1-d.unit-test",
+      "public_dns": "foo-bar-0002.roachprod.crdb.io",
+      "dns_provider": "gce",
+      "provider": "gce",
+      "provider_id": "foo-bar-0002",
+      "private_ip": "10.142.1.2",
+      "public_ip": "35.227.25.2",
+      "remote_user": "ubuntu",
+      "vpc": "default",
+      "machine_type": "n2-standard-4",
+      "cpu_architecture": "amd64",
+      "cpu_family": "ice lake",
+      "zone": "us-east1-d",
+      "project": "unit-test",
+      "non_bootable_volumes": null,
+      "bootable_volume": {
+        "ProviderResourceID": "foo-bar-0002",
+        "ProviderVolumeType": "pd-ssd",
+        "Zone": "us-east1-d",
+        "Encrypted": false,
+        "Name": "foo-bar-0002",
+        "Labels": null,
+        "Size": 10
+      },
+      "local_disks": [
+        {
+          "ProviderResourceID": "",
+          "ProviderVolumeType": "local-ssd",
+          "Zone": "",
+          "Encrypted": false,
+          "Name": "",
+          "Labels": null,
+          "Size": 375
+        }
+      ],
+      "CostPerHour": 0,
+      "EmptyCluster": false
+    },
+    {
+      "name": "foo-bar-0003",
+      "created_at": "2025-02-04T08:02:52.516-08:00",
+      "errors": null,
+      "lifetime": 43200000000000,
+      "preemptible": false,
+      "labels": {
+        "cluster": "foo-bar",
+        "created": "2025-02-04t16_02_50z",
+        "lifetime": "12h0m0s",
+        "roachprod": "true",
+        "usage": "roachprod"
+      },
+      "dns": "foo-bar-0003.us-east1-d.unit-test",
+      "public_dns": "foo-bar-0003.roachprod.crdb.io",
+      "dns_provider": "gce",
+      "provider": "gce",
+      "provider_id": "foo-bar-0003",
+      "private_ip": "10.142.1.3",
+      "public_ip": "34.75.95.3",
+      "remote_user": "ubuntu",
+      "vpc": "default",
+      "machine_type": "n2-standard-4",
+      "cpu_architecture": "amd64",
+      "cpu_family": "ice lake",
+      "zone": "us-east1-d",
+      "project": "unit-test",
+      "non_bootable_volumes": null,
+      "bootable_volume": {
+        "ProviderResourceID": "foo-bar-0003",
+        "ProviderVolumeType": "pd-ssd",
+        "Zone": "us-east1-d",
+        "Encrypted": false,
+        "Name": "foo-bar-0003",
+        "Labels": null,
+        "Size": 10
+      },
+      "local_disks": [
+        {
+          "ProviderResourceID": "",
+          "ProviderVolumeType": "local-ssd",
+          "Zone": "",
+          "Encrypted": false,
+          "Name": "",
+          "Labels": null,
+          "Size": 375
+        }
+      ],
+      "CostPerHour": 0,
+      "EmptyCluster": false
+    },
+    {
+      "name": "foo-bar-0004",
+      "created_at": "2025-02-04T08:02:52.54-08:00",
+      "errors": null,
+      "lifetime": 43200000000000,
+      "preemptible": false,
+      "labels": {
+        "cluster": "foo-bar",
+        "created": "2025-02-04t16_02_50z",
+        "lifetime": "12h0m0s",
+        "roachprod": "true",
+        "usage": "roachprod"
+      },
+      "dns": "foo-bar-0004.us-east1-d.unit-test",
+      "public_dns": "foo-bar-0004.roachprod.crdb.io",
+      "dns_provider": "gce",
+      "provider": "gce",
+      "provider_id": "foo-bar-0004",
+      "private_ip": "10.142.1.4",
+      "public_ip": "34.139.54.4",
+      "remote_user": "ubuntu",
+      "vpc": "default",
+      "machine_type": "n2-standard-4",
+      "cpu_architecture": "amd64",
+      "cpu_family": "ice lake",
+      "zone": "us-east1-d",
+      "project": "unit-testl",
+      "non_bootable_volumes": null,
+      "bootable_volume": {
+        "ProviderResourceID": "foo-bar-0004",
+        "ProviderVolumeType": "pd-ssd",
+        "Zone": "us-east1-d",
+        "Encrypted": false,
+        "Name": "foo-bar-0004",
+        "Labels": null,
+        "Size": 10
+      },
+      "local_disks": [
+        {
+          "ProviderResourceID": "",
+          "ProviderVolumeType": "local-ssd",
+          "Zone": "",
+          "Encrypted": false,
+          "Name": "",
+          "Labels": null,
+          "Size": 375
+        }
+      ],
+      "CostPerHour": 0,
+      "EmptyCluster": false
+    }
+  ],
+  "CostPerHour": 0
+}


### PR DESCRIPTION
This change adds ip to the list of supported roachprod expander funcs. e.g. `{ip:1-3}` now expands to the private ip addresses of nodes 1 to 3. `:public` can be appended, e.g. `{ip:1-3:public}` to specify the public ip addresses.

Additionally, this change also logs expanded commands for roachtests if they differ from the original command. This should ease debugging as we can know what command was actually run on the node.

Release note: none
Epic: none
Fixes: none

----

Additional context is that this PR is motivated by my playing around with iptables on a roachprod cluster. Found running `roachprod ip` repeatedly and copy pasting tedious.