### PR TITLE
sql: address correctness issues with the dependency digest

### DIFF
--- a/pkg/sql/catalog/descs/factory.go
+++ b/pkg/sql/catalog/descs/factory.go
@@ -144,12 +144,19 @@ func (cf *CollectionFactory) NewCollection(ctx context.Context, options ...Optio
 		opt(&cfg)
 	}
 	v := cf.settings.Version.ActiveVersion(ctx)
+	// If the leaseMgr  is nil then ensure we have a nil LeaseManager interface,
+	// otherwise comparisons against a nil implementation will fail.
+	var lm LeaseManager
+	lm = cf.leaseMgr
+	if cf.leaseMgr == nil {
+		lm = nil
+	}
 	return &Collection{
 		settings:                cf.settings,
 		version:                 v,
 		hydrated:                cf.hydrated,
 		virtual:                 makeVirtualDescriptors(cf.virtualSchemas),
-		leased:                  makeLeasedDescriptors(cf.leaseMgr),
+		leased:                  makeLeasedDescriptors(lm),
 		uncommitted:             makeUncommittedDescriptors(cfg.monitor),
 		uncommittedComments:     makeUncommittedComments(),
 		uncommittedZoneConfigs:  makeUncommittedZoneConfigs(),

--- a/pkg/sql/catalog/lease/lease.go
+++ b/pkg/sql/catalog/lease/lease.go
@@ -1281,6 +1281,7 @@ func NewLeaseManager(
 		sem:              quotapool.NewIntPool("lease manager", leaseConcurrencyLimit),
 		refreshAllLeases: make(chan struct{}),
 	}
+	lm.leaseGeneration.Swap(1) // Start off with 1 as the initial value.
 	lm.storage.regionPrefix = &atomic.Value{}
 	lm.storage.regionPrefix.Store(enum.One)
 	lm.storage.sessionBasedLeasingMode = lm

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -4010,7 +4010,7 @@ func (ex *connExecutor) txnStateTransitionsApplyWrapper(
 		// Session is considered active when executing a transaction.
 		ex.totalActiveTimeStopWatch.Start()
 
-		if err := ex.maybeSetSQLLivenessSession(); err != nil {
+		if err := ex.maybeSetSQLLivenessSessionAndGeneration(); err != nil {
 			return advanceInfo{}, err
 		}
 	case txnCommit:
@@ -4115,7 +4115,7 @@ func (ex *connExecutor) txnStateTransitionsApplyWrapper(
 		// In addition to resetting the extraTxnState, the restart event may
 		// also need to reset the sqlliveness.Session.
 		ex.resetExtraTxnState(ex.Ctx(), advInfo.txnEvent, payloadErr)
-		if err := ex.maybeSetSQLLivenessSession(); err != nil {
+		if err := ex.maybeSetSQLLivenessSessionAndGeneration(); err != nil {
 			return advanceInfo{}, err
 		}
 	default:
@@ -4186,7 +4186,7 @@ func (ex *connExecutor) waitForTxnJobs() error {
 	return retErr
 }
 
-func (ex *connExecutor) maybeSetSQLLivenessSession() error {
+func (ex *connExecutor) maybeSetSQLLivenessSessionAndGeneration() error {
 	if !ex.server.cfg.Codec.ForSystemTenant() ||
 		ex.server.cfg.TestingKnobs.ForceSQLLivenessSession {
 		// Update the leased descriptor collection with the current sqlliveness.Session.
@@ -4201,6 +4201,8 @@ func (ex *connExecutor) maybeSetSQLLivenessSession() error {
 		}
 		ex.extraTxnState.descCollection.SetSession(session)
 	}
+	// Reset the lease generation at the same time.
+	ex.extraTxnState.descCollection.ResetLeaseGeneration()
 	return nil
 }
 

--- a/pkg/sql/opt/BUILD.bazel
+++ b/pkg/sql/opt/BUILD.bazel
@@ -31,6 +31,7 @@ go_library(
         "//pkg/sql/catalog/colinfo",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/catalog/multiregion",
+        "//pkg/sql/catalog/typedesc",
         "//pkg/sql/opt/cat",
         "//pkg/sql/opt/partition",
         "//pkg/sql/pgwire/pgcode",

--- a/pkg/sql/opt/cat/catalog.go
+++ b/pkg/sql/opt/cat/catalog.go
@@ -256,6 +256,10 @@ type Catalog interface {
 	// exactly the same.
 	GetDependencyDigest() DependencyDigest
 
+	// LeaseByStableID leases out a descriptor by the stable ID, which will block
+	// schema changes. The underlying schema object is not returned.
+	LeaseByStableID(ctx context.Context, id StableID) error
+
 	// GetRoutineOwner returns the username.SQLUsername of the routine's
 	// (specified by routineOid) owner.
 	GetRoutineOwner(ctx context.Context, routineOid oid.Oid) (username.SQLUsername, error)

--- a/pkg/sql/opt/metadata.go
+++ b/pkg/sql/opt/metadata.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/multiregion"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/typedesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
@@ -376,6 +377,33 @@ func (md *Metadata) dependencyDigestEquals(currentDigest *cat.DependencyDigest) 
 	return currentDigest.Equal(&md.digest.depDigest)
 }
 
+// leaseObjectsInMetaData ensures that all references within this metadata
+// are leased to prevent schema changes from modifying the underlying objects
+// excessively.
+func (md *Metadata) leaseObjectsInMetaData(ctx context.Context, optCatalog cat.Catalog) error {
+	for id := range md.dataSourceDeps {
+		if err := optCatalog.LeaseByStableID(ctx, id); err != nil {
+			return err
+		}
+	}
+	for id := range md.routineDeps {
+		if err := optCatalog.LeaseByStableID(ctx, id); err != nil {
+			return err
+		}
+	}
+	for oid := range md.userDefinedTypes {
+		id := typedesc.UserDefinedTypeOIDToID(oid)
+		// Not a user defined type.
+		if id == catid.InvalidDescID {
+			continue
+		}
+		if err := optCatalog.LeaseByStableID(ctx, cat.StableID(id)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // CheckDependencies resolves (again) each database object on which this
 // metadata depends, in order to check the following conditions:
 //  1. The object has not been modified.
@@ -402,7 +430,12 @@ func (md *Metadata) CheckDependencies(
 		evalCtx.AsOfSystemTime == nil &&
 		!evalCtx.Txn.ReadTimestampFixed() &&
 		md.dependencyDigestEquals(&currentDigest) {
-		return true, nil
+		// Lease the underlying descriptors for this metadata. If we fail to lease
+		// any descriptors attempt to resolve them by name through the more expensive
+		// code path below.
+		if err := md.leaseObjectsInMetaData(ctx, optCatalog); err == nil {
+			return true, nil
+		}
 	}
 
 	// Check that no referenced data sources have changed.

--- a/pkg/sql/opt/testutils/testcat/test_catalog.go
+++ b/pkg/sql/opt/testutils/testcat/test_catalog.go
@@ -480,6 +480,11 @@ func (tc *Catalog) GetDependencyDigest() cat.DependencyDigest {
 	}
 }
 
+// LeaseByStableID does not do anything since no leasing is used here.
+func (tc *Catalog) LeaseByStableID(_ context.Context, _ cat.StableID) error {
+	return nil
+}
+
 // ExecuteMultipleDDL parses the given semicolon-separated DDL SQL statements
 // and applies each of them to the test catalog.
 func (tc *Catalog) ExecuteMultipleDDL(sql string) error {

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -510,6 +510,14 @@ func (oc *optCatalog) GetCurrentUser() username.SQLUsername {
 	return oc.planner.User()
 }
 
+// LeaseByStableID is part of the cat.Catalog interface.
+func (oc *optCatalog) LeaseByStableID(ctx context.Context, stableID cat.StableID) error {
+	// Lease the descriptor, so that schema changes cannot move forward
+	// after the current version.
+	_, err := oc.planner.byIDGetterBuilder().WithoutNonPublic().Get().Desc(ctx, descpb.ID(stableID))
+	return err
+}
+
 // GetDependencyDigest is part of the cat.Catalog interface.
 func (oc *optCatalog) GetDependencyDigest() cat.DependencyDigest {
 	// The stats cache may not be setup in some tests like

--- a/pkg/sql/stats/stats_cache.go
+++ b/pkg/sql/stats/stats_cache.go
@@ -337,7 +337,6 @@ func (sc *TableStatisticsCache) getTableStatsFromCache(
 ) ([]*TableStatistic, error) {
 	sc.mu.Lock()
 	defer sc.mu.Unlock()
-	defer sc.generation.Add(1)
 
 	if found, e := sc.lookupStatsLocked(ctx, tableID, false /* stealthy */); found {
 		if e.isStale(forecast, udtCols) {


### PR DESCRIPTION
Previously, an incorrect defer was causing the statistics generation to increment every time table statistics was looked up from the cache. This would cause the staleness optimization to kick in an inconsistent manner and be disabled needlessly. To address this, this patch only increments the generation updating stats.

This patch also contains an additional fix so that lease generations stay stable across long running queries. This was found because the test TestRenameTable started failing. 

Finally this patch also adds logic to start leasing descriptors for CheckDependencies when the dependency digest is used. This prevents schema changes from proceeding forward. The acquisition logic in this case is minimal and only sufficient for the lease manager to bump the descriptor refcount up. Previously, the dependency digest changes could misbehave with schema changes causing stale versions of descriptors to be used, as the schema change moved forward, violating the two version invariant.


Benchmark Results:

```
old:  a41a074 Merge #139352
new:  3898b2e opt: lease descriptors with dependency digest
args: benchdiff "--old" "lastmerge" "./pkg/sql/tests" "-b" "-r" "Sysbench" "-d" "1000x" "-c" "10"

name                                            old time/op    new time/op    delta
Sysbench/SQL/1node_local/oltp_point_select-24      319µs ± 3%     302µs ± 3%  -5.59%  (p=0.000 n=10+10)
Sysbench/SQL/1node_remote/oltp_point_select-24     392µs ± 3%     370µs ± 4%  -5.48%  (p=0.000 n=10+10)
Sysbench/KV/1node_remote/oltp_begin_commit-24     1.33µs ± 8%    1.26µs ± 5%  -5.34%  (p=0.011 n=10+9)
Sysbench/SQL/1node_local/oltp_read_only-24        4.55ms ± 2%    4.31ms ± 2%  -5.28%  (p=0.000 n=10+10)
Sysbench/SQL/1node_remote/oltp_read_write-24      9.26ms ± 3%    8.78ms ± 2%  -5.20%  (p=0.000 n=10+10)
Sysbench/SQL/3node/oltp_read_only-24              5.90ms ± 2%    5.60ms ± 3%  -5.18%  (p=0.000 n=10+9)
Sysbench/SQL/3node/oltp_point_select-24            396µs ± 3%     377µs ± 4%  -4.84%  (p=0.000 n=9+10)
Sysbench/SQL/1node_local/oltp_read_write-24       7.41ms ± 4%    7.06ms ± 2%  -4.65%  (p=0.000 n=10+10)
Sysbench/SQL/3node/oltp_read_write-24             9.33ms ± 3%    8.92ms ± 3%  -4.30%  (p=0.000 n=9+9)
Sysbench/SQL/1node_remote/oltp_read_only-24       5.77ms ± 3%    5.55ms ± 3%  -3.77%  (p=0.000 n=9+10)
Sysbench/SQL/3node/oltp_write_only-24             3.40ms ± 3%    3.28ms ± 2%  -3.47%  (p=0.000 n=10+10)
Sysbench/SQL/1node_local/oltp_write_only-24       2.78ms ± 3%    2.69ms ± 4%  -3.11%  (p=0.001 n=10+10)
Sysbench/SQL/1node_remote/oltp_write_only-24      3.23ms ± 3%    3.14ms ± 3%  -2.89%  (p=0.007 n=10+10)
Sysbench/SQL/1node_local/oltp_begin_commit-24      106µs ± 6%     109µs ± 6%    ~     (p=0.095 n=9+10)
Sysbench/SQL/1node_remote/oltp_begin_commit-24     106µs ± 4%     106µs ± 4%    ~     (p=0.676 n=10+9)
Sysbench/SQL/3node/oltp_begin_commit-24            109µs ± 6%     109µs ± 6%    ~     (p=0.930 n=10+10)
Sysbench/KV/1node_local/oltp_read_only-24          590µs ± 7%     591µs ± 4%    ~     (p=0.912 n=10+10)
Sysbench/KV/1node_local/oltp_write_only-24        1.13ms ± 3%    1.11ms ± 3%    ~     (p=0.133 n=10+9)
Sysbench/KV/1node_local/oltp_read_write-24        1.95ms ± 4%    1.95ms ± 2%    ~     (p=0.684 n=10+10)
Sysbench/KV/1node_local/oltp_point_select-24      27.7µs ± 5%    28.3µs ± 6%    ~     (p=0.218 n=10+10)
Sysbench/KV/1node_local/oltp_begin_commit-24      1.28µs ± 6%    1.25µs ± 5%    ~     (p=0.287 n=9+9)
Sysbench/KV/1node_remote/oltp_read_only-24        1.65ms ± 3%    1.66ms ± 4%    ~     (p=1.000 n=9+10)
Sysbench/KV/1node_remote/oltp_write_only-24       1.58ms ± 3%    1.58ms ± 3%    ~     (p=0.631 n=10+10)
Sysbench/KV/1node_remote/oltp_read_write-24       3.42ms ± 3%    3.43ms ± 0%    ~     (p=1.000 n=10+7)
Sysbench/KV/1node_remote/oltp_point_select-24     62.7µs ± 9%    62.1µs ± 6%    ~     (p=1.000 n=10+10)
Sysbench/KV/3node/oltp_read_only-24               1.74ms ± 5%    1.74ms ± 4%    ~     (p=0.853 n=10+10)
Sysbench/KV/3node/oltp_write_only-24              1.87ms ± 3%    1.85ms ± 2%    ~     (p=0.436 n=10+10)
Sysbench/KV/3node/oltp_read_write-24              3.85ms ± 2%    3.84ms ± 4%    ~     (p=0.579 n=10+10)
Sysbench/KV/3node/oltp_point_select-24            64.7µs ± 6%    64.8µs ±10%    ~     (p=0.853 n=10+10)
Sysbench/KV/3node/oltp_begin_commit-24            1.33µs ±17%    1.33µs ±20%    ~     (p=0.986 n=10+10)

name                                            old alloc/op   new alloc/op   delta
Sysbench/SQL/3node/oltp_point_select-24           34.3kB ± 6%    32.9kB ± 7%  -4.00%  (p=0.035 n=9+10)
Sysbench/SQL/1node_local/oltp_point_select-24     27.6kB ± 1%    27.3kB ± 1%  -0.90%  (p=0.033 n=10+7)
Sysbench/SQL/1node_remote/oltp_point_select-24    30.3kB ± 1%    30.1kB ± 1%  -0.79%  (p=0.004 n=10+10)
Sysbench/SQL/1node_local/oltp_write_only-24        425kB ± 1%     422kB ± 1%  -0.62%  (p=0.002 n=9+10)
Sysbench/SQL/1node_local/oltp_read_write-24       1.25MB ± 0%    1.24MB ± 0%  -0.39%  (p=0.005 n=8+8)
Sysbench/SQL/1node_local/oltp_read_only-24         824kB ± 0%     822kB ± 0%  -0.32%  (p=0.000 n=8+10)
Sysbench/SQL/1node_remote/oltp_read_only-24       1.14MB ± 0%    1.13MB ± 0%  -0.26%  (p=0.005 n=8+8)
Sysbench/SQL/1node_local/oltp_begin_commit-24     11.0kB ± 3%    10.9kB ± 1%    ~     (p=0.184 n=10+10)
Sysbench/SQL/1node_remote/oltp_write_only-24       483kB ± 0%     482kB ± 0%    ~     (p=0.315 n=10+9)
Sysbench/SQL/1node_remote/oltp_read_write-24      1.61MB ± 0%    1.61MB ± 0%    ~     (p=0.083 n=8+8)
Sysbench/SQL/1node_remote/oltp_begin_commit-24    10.8kB ± 0%    10.8kB ± 0%    ~     (p=0.412 n=10+9)
Sysbench/SQL/3node/oltp_read_only-24              1.17MB ± 1%    1.17MB ± 1%    ~     (p=0.382 n=8+8)
Sysbench/SQL/3node/oltp_write_only-24              955kB ± 1%     954kB ± 1%    ~     (p=0.573 n=8+10)
Sysbench/SQL/3node/oltp_read_write-24             2.10MB ± 0%    2.10MB ± 1%    ~     (p=0.815 n=8+9)
Sysbench/SQL/3node/oltp_begin_commit-24           11.2kB ± 2%    11.1kB ± 3%    ~     (p=0.334 n=8+9)
Sysbench/KV/1node_local/oltp_read_only-24          255kB ± 0%     254kB ± 0%    ~     (p=0.436 n=10+10)
Sysbench/KV/1node_local/oltp_write_only-24         241kB ± 0%     240kB ± 0%    ~     (p=0.063 n=10+10)
Sysbench/KV/1node_local/oltp_read_write-24         498kB ± 0%     498kB ± 0%    ~     (p=0.633 n=8+10)
Sysbench/KV/1node_local/oltp_point_select-24      4.56kB ± 0%    4.55kB ± 0%    ~     (p=0.051 n=9+9)
Sysbench/KV/1node_local/oltp_begin_commit-24      2.53kB ± 1%    2.53kB ± 1%    ~     (p=0.591 n=9+10)
Sysbench/KV/1node_remote/oltp_read_only-24         643kB ± 0%     644kB ± 0%    ~     (p=0.315 n=10+9)
Sysbench/KV/1node_remote/oltp_write_only-24        299kB ± 0%     300kB ± 0%    ~     (p=1.000 n=9+9)
Sysbench/KV/1node_remote/oltp_read_write-24        971kB ± 0%     971kB ± 0%    ~     (p=0.387 n=9+9)
Sysbench/KV/1node_remote/oltp_point_select-24     6.31kB ± 0%    6.31kB ± 0%    ~     (p=0.857 n=9+10)
Sysbench/KV/1node_remote/oltp_begin_commit-24     2.53kB ± 0%    2.52kB ± 0%    ~     (p=0.366 n=10+9)
Sysbench/KV/3node/oltp_read_only-24                652kB ± 1%     653kB ± 1%    ~     (p=0.356 n=10+9)
Sysbench/KV/3node/oltp_write_only-24               704kB ± 1%     702kB ± 0%    ~     (p=0.078 n=10+10)
Sysbench/KV/3node/oltp_read_write-24              1.46MB ± 0%    1.45MB ± 0%    ~     (p=0.436 n=10+10)
Sysbench/KV/3node/oltp_point_select-24            7.00kB ± 5%    7.09kB ± 4%    ~     (p=0.393 n=10+10)
Sysbench/KV/3node/oltp_begin_commit-24            2.66kB ± 2%    2.65kB ± 1%    ~     (p=0.968 n=9+10)

name                                            old allocs/op  new allocs/op  delta
Sysbench/SQL/3node/oltp_point_select-24              260 ± 7%       240 ± 1%  -7.63%  (p=0.002 n=9+8)
Sysbench/SQL/1node_local/oltp_point_select-24        203 ± 1%       199 ± 1%  -1.63%  (p=0.000 n=10+10)
Sysbench/SQL/1node_remote/oltp_point_select-24       238 ± 1%       235 ± 1%  -1.25%  (p=0.000 n=10+9)
Sysbench/SQL/1node_local/oltp_read_only-24         3.75k ± 0%     3.71k ± 0%  -1.17%  (p=0.000 n=8+10)
Sysbench/SQL/1node_local/oltp_read_write-24        6.52k ± 0%     6.45k ± 0%  -1.12%  (p=0.000 n=10+8)
Sysbench/SQL/3node/oltp_read_only-24               4.65k ± 0%     4.60k ± 0%  -1.04%  (p=0.000 n=8+8)
Sysbench/SQL/1node_remote/oltp_read_only-24        4.41k ± 0%     4.36k ± 1%  -1.04%  (p=0.000 n=10+10)
Sysbench/SQL/1node_local/oltp_write_only-24        2.76k ± 0%     2.74k ± 0%  -0.82%  (p=0.000 n=10+10)
Sysbench/SQL/1node_remote/oltp_read_write-24       7.89k ± 0%     7.84k ± 0%  -0.70%  (p=0.000 n=10+10)
Sysbench/SQL/3node/oltp_write_only-24              6.07k ± 0%     6.03k ± 0%  -0.66%  (p=0.000 n=9+9)
Sysbench/SQL/1node_remote/oltp_write_only-24       3.60k ± 0%     3.58k ± 0%  -0.55%  (p=0.000 n=10+9)
Sysbench/SQL/3node/oltp_read_write-24              10.4k ± 0%     10.4k ± 0%  -0.46%  (p=0.000 n=10+10)
Sysbench/SQL/1node_local/oltp_begin_commit-24       68.3 ± 1%      68.0 ± 0%    ~     (p=0.173 n=10+9)
Sysbench/SQL/1node_remote/oltp_begin_commit-24      68.0 ± 0%      68.0 ± 0%    ~     (all equal)
Sysbench/SQL/3node/oltp_begin_commit-24             68.8 ± 2%      68.8 ± 2%    ~     (p=1.115 n=8+9)
Sysbench/KV/1node_local/oltp_read_only-24            434 ± 0%       434 ± 0%    ~     (p=0.809 n=10+10)
Sysbench/KV/1node_local/oltp_write_only-24         1.37k ± 0%     1.37k ± 0%    ~     (p=0.354 n=10+10)
Sysbench/KV/1node_local/oltp_read_write-24         1.84k ± 0%     1.84k ± 0%    ~     (p=0.959 n=10+10)
Sysbench/KV/1node_local/oltp_point_select-24        23.0 ± 0%      23.0 ± 0%    ~     (all equal)
Sysbench/KV/1node_local/oltp_begin_commit-24        6.00 ± 0%      6.00 ± 0%    ~     (all equal)
Sysbench/KV/1node_remote/oltp_read_only-24         1.77k ± 0%     1.77k ± 0%    ~     (p=0.137 n=10+8)
Sysbench/KV/1node_remote/oltp_write_only-24        2.19k ± 0%     2.19k ± 0%    ~     (p=0.749 n=10+10)
Sysbench/KV/1node_remote/oltp_read_write-24        4.03k ± 0%     4.03k ± 0%    ~     (p=0.165 n=10+9)
Sysbench/KV/1node_remote/oltp_point_select-24       53.0 ± 0%      53.0 ± 0%    ~     (all equal)
Sysbench/KV/1node_remote/oltp_begin_commit-24       6.00 ± 0%      6.00 ± 0%    ~     (all equal)
Sysbench/KV/3node/oltp_read_only-24                1.79k ± 0%     1.79k ± 0%    ~     (p=0.497 n=10+9)
Sysbench/KV/3node/oltp_write_only-24               4.33k ± 1%     4.33k ± 0%    ~     (p=0.566 n=10+10)
```


Fixes: #139876
Fixes: #137335
Fixes: #139800