### PR TITLE
sql,kv: handle blind UPSERTs and DELETEs with buffered writes

### DIFF
--- a/pkg/crosscluster/logical/lww_kv_processor.go
+++ b/pkg/crosscluster/logical/lww_kv_processor.go
@@ -482,7 +482,7 @@ func (p *kvTableWriter) insertRow(ctx context.Context, b *kv.Batch, after cdceve
 		// and destination clusters.
 		// ShouldWinTie: true,
 	}
-	return p.ri.InsertRow(ctx, &row.KVBatchAdapter{Batch: b}, p.newVals, ph, oth, false /* overwrite */, false /* traceKV */)
+	return p.ri.InsertRow(ctx, &row.KVBatchAdapter{Batch: b}, p.newVals, ph, oth, row.CPutOp, false /* traceKV */)
 }
 
 func (p *kvTableWriter) updateRow(

--- a/pkg/kv/batch.go
+++ b/pkg/kv/batch.go
@@ -430,7 +430,7 @@ func (b *Batch) GetForShare(key interface{}, dur kvpb.KeyLockingDurabilityType) 
 	b.get(key, kvpb.ForShare, dur)
 }
 
-func (b *Batch) put(key, value interface{}, inline bool) {
+func (b *Batch) put(key, value interface{}, inline bool, mustAcquireExclusiveLock bool) {
 	k, err := marshalKey(key)
 	if err != nil {
 		b.initResult(0, 1, notRaw, err)
@@ -443,6 +443,8 @@ func (b *Batch) put(key, value interface{}, inline bool) {
 	}
 	if inline {
 		b.appendReqs(kvpb.NewPutInline(k, v))
+	} else if mustAcquireExclusiveLock {
+		b.appendReqs(kvpb.NewPutMustAcquireExclusiveLock(k, v))
 	} else {
 		b.appendReqs(kvpb.NewPut(k, v))
 	}
@@ -463,7 +465,20 @@ func (b *Batch) Put(key, value interface{}) {
 		// value. If the intention was indeed to delete the key, use Del() instead.
 		panic("can't Put an empty Value; did you mean to Del() instead?")
 	}
-	b.put(key, value, false)
+	b.put(key, value, false /* inline */, false /* mustAcquireExclusiveLock */)
+}
+
+// PutMustAcquireExclusiveLock is the same as Put but guarantees that a lock
+// with the strength no lower than "exclusive" will be acquired on the key, even
+// if it doesn't exist (in order to prevent concurrent requests from writing at
+// this key).
+func (b *Batch) PutMustAcquireExclusiveLock(key, value interface{}) {
+	if value == nil {
+		// Empty values are used as deletion tombstones, so one can't write an empty
+		// value. If the intention was indeed to delete the key, use Del() instead.
+		panic("can't Put an empty Value; did you mean to Del() instead?")
+	}
+	b.put(key, value, false /* inline */, true /* mustAcquireExclusiveLock */)
 }
 
 // PutBytes allows an arbitrary number of PutRequests to be added to the batch.
@@ -525,7 +540,7 @@ func (b *Batch) PutTuples(bs BulkSource[[]byte]) {
 // A nil value can be used to delete the respective key, since there is no
 // DelInline(). This is different from Put().
 func (b *Batch) PutInline(key, value interface{}) {
-	b.put(key, value, true)
+	b.put(key, value, true /* inline */, false /* mustAcquireExclusiveLock */)
 }
 
 // CPut conditionally sets the value for a key if the existing value is equal to

--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_write_buffer.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_write_buffer.go
@@ -284,10 +284,9 @@ func (twb *txnWriteBuffer) applyTransformations(
 		case *kvpb.DeleteRequest:
 			var ru kvpb.ResponseUnion
 			ru.MustSetInner(&kvpb.DeleteResponse{
-				// TODO(arul): We need to add a flag to DeleteRequests to indicate
-				// whether we care about the return value or not. If we do, we need to
-				// decompose the Delete into a read-write phase. Otherwise, we can
-				// consider the Delete a blind write, and return false here.
+				// TODO(yuzefovich): if MustAcquireExclusiveLock flag is set on
+				// the Del, then we need to add a locking Get to the
+				// BatchRequest, including if the key doesn't exist (#139232).
 				FoundKey: false,
 			})
 			ts = append(ts, transformation{

--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_write_buffer.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_write_buffer.go
@@ -269,6 +269,11 @@ func (twb *txnWriteBuffer) applyTransformations(
 		case *kvpb.PutRequest:
 			var ru kvpb.ResponseUnion
 			ru.MustSetInner(&kvpb.PutResponse{})
+			// TODO(yuzefovich): if MustAcquireExclusiveLock flag is set on the
+			// Put, then we need to add a locking Get to the BatchRequest,
+			// including if the key doesn't exist (#139232).
+			// TODO(yuzefovich): ensure that we elide the lock acquisition
+			// whenever possible (e.g. blind UPSERT in an implicit txn).
 			ts = append(ts, transformation{
 				stripped: true,
 				index:    i,

--- a/pkg/kv/kvpb/api.go
+++ b/pkg/kv/kvpb/api.go
@@ -1649,6 +1649,19 @@ func NewPutInline(key roachpb.Key, value roachpb.Value) Request {
 	}
 }
 
+// NewPutMustAcquireExclusiveLock returns a Request initialized to put the value
+// at key. It also sets the MustAcquireExclusiveLock flag.
+func NewPutMustAcquireExclusiveLock(key roachpb.Key, value roachpb.Value) Request {
+	value.InitChecksum(key)
+	return &PutRequest{
+		RequestHeader: RequestHeader{
+			Key: key,
+		},
+		Value:                    value,
+		MustAcquireExclusiveLock: true,
+	}
+}
+
 // NewConditionalPut returns a Request initialized to put value at key if the
 // existing value at key equals expValue.
 //

--- a/pkg/kv/kvpb/api.go
+++ b/pkg/kv/kvpb/api.go
@@ -1704,11 +1704,12 @@ func NewConditionalPutInline(
 }
 
 // NewDelete returns a Request initialized to delete the value at key.
-func NewDelete(key roachpb.Key) Request {
+func NewDelete(key roachpb.Key, mustAcquireExclusiveLock bool) Request {
 	return &DeleteRequest{
 		RequestHeader: RequestHeader{
 			Key: key,
 		},
+		MustAcquireExclusiveLock: mustAcquireExclusiveLock,
 	}
 }
 

--- a/pkg/kv/kvpb/api.proto
+++ b/pkg/kv/kvpb/api.proto
@@ -429,6 +429,10 @@ message IncrementResponse {
 // A DeleteRequest is the argument to the Delete() method.
 message DeleteRequest {
   RequestHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
+  // MustAcquireExclusiveLock, if set, indicates that a lock with the strength
+  // no lower than "exclusive" needs to be acquired on the key, even if it
+  // doesn't exist.
+  bool must_acquire_exclusive_lock = 2;
 }
 
 // A DeleteResponse is the return value from the Delete() method.

--- a/pkg/kv/kvpb/api.proto
+++ b/pkg/kv/kvpb/api.proto
@@ -284,6 +284,10 @@ message PutRequest {
   // writing to virgin keyspace and no reads are necessary to
   // rationalize MVCC.
   bool blind = 4;
+  // MustAcquireExclusiveLock, if set, indicates that a lock with the strength
+  // no lower than "exclusive" needs to be acquired on the key, even if it
+  // doesn't exist.
+  bool must_acquire_exclusive_lock = 5;
 }
 
 // A PutResponse is the return value from the Put() method.

--- a/pkg/sql/colenc/bench_test.go
+++ b/pkg/sql/colenc/bench_test.go
@@ -142,6 +142,7 @@ func (n *noopPutter) CPutWithOriginTimestamp(
 ) {
 }
 func (n *noopPutter) Put(key, value interface{})                                {}
+func (n *noopPutter) PutMustAcquireExclusiveLock(key, value interface{})        {}
 func (n *noopPutter) Del(key ...interface{})                                    {}
 func (n *noopPutter) CPutBytesEmpty(kys []roachpb.Key, values [][]byte)         {}
 func (n *noopPutter) CPutValuesEmpty(kys []roachpb.Key, values []roachpb.Value) {}

--- a/pkg/sql/colenc/encode_test.go
+++ b/pkg/sql/colenc/encode_test.go
@@ -607,7 +607,7 @@ func buildRowKVs(
 	p := &capturePutter{}
 	var pm row.PartialIndexUpdateHelper
 	for _, d := range datums {
-		if err := inserter.InsertRow(context.Background(), p, d, pm, nil, false, true); err != nil {
+		if err := inserter.InsertRow(context.Background(), p, d, pm, nil, row.CPutOp, true /* traceKV */); err != nil {
 			return kvs{}, err
 		}
 	}
@@ -718,6 +718,10 @@ func (c *capturePutter) Put(key, value interface{}) {
 	c.kvs.keys = append(c.kvs.keys, copyBytes(*k))
 	v := value.(*roachpb.Value)
 	c.kvs.values = append(c.kvs.values, copyBytes(v.RawBytes))
+}
+
+func (c *capturePutter) PutMustAcquireExclusiveLock(key, value interface{}) {
+	colexecerror.InternalError(errors.New("unimplemented"))
 }
 
 func (c *capturePutter) Del(key ...interface{}) {

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -3210,6 +3210,10 @@ func (ex *connExecutor) execCopyIn(
 
 	// The connExecutor state machine has already set us up with a txn at this
 	// point.
+	//
+	// Disable the buffered writes for COPY since there is no benefit in this
+	// ability here.
+	ex.state.mu.txn.SetBufferedWritesEnabled(false /* enabled */)
 	txnOpt := copyTxnOpt{
 		txn:           ex.state.mu.txn,
 		txnTimestamp:  ex.state.sqlTimestamp,

--- a/pkg/sql/copy_from.go
+++ b/pkg/sql/copy_from.go
@@ -1206,6 +1206,11 @@ func (c *copyMachine) insertRowsInternal(ctx context.Context, finalBatch bool) (
 	var vc tree.SelectStatement
 	if c.copyFastPath {
 		if c.vectorized {
+			if buildutil.CrdbTestBuild {
+				if c.txnOpt.txn.BufferedWritesEnabled() {
+					return errors.AssertionFailedf("buffered writes should have been disabled for COPY")
+				}
+			}
 			b := tree.VectorRows{Batch: c.batch}
 			vc = &tree.LiteralValuesClause{Rows: &b}
 		} else {

--- a/pkg/sql/opt/exec/execbuilder/testdata/cascade
+++ b/pkg/sql/opt/exec/execbuilder/testdata/cascade
@@ -71,7 +71,7 @@ query T rowsort
 SELECT message FROM [SHOW TRACE FOR SESSION]
 WHERE message LIKE '%executing cascade %' OR message LIKE 'Del%'
 ----
-Del /Table/106/1/"a-pk1"/0
+Del (locking) /Table/106/1/"a-pk1"/0
 executing cascade for constraint b1_delete_cascade_fkey
 Del /Table/107/1/"b1-pk1"/0
 Del /Table/107/1/"b1-pk2"/0
@@ -315,7 +315,7 @@ query T
 SELECT message FROM [SHOW TRACE FOR SESSION]
 WHERE message LIKE '%executing cascade %' OR message LIKE 'Del%'
 ----
-Del /Table/123/1/"a-pk1"/0
+Del (locking) /Table/123/1/"a-pk1"/0
 executing cascade for constraint b1_delete_cascade_fkey
 Del /Table/124/1/"b1-pk1"/0
 Del /Table/124/1/"b1-pk2"/0
@@ -603,7 +603,7 @@ query T
 SELECT message FROM [SHOW TRACE FOR SESSION]
 WHERE message LIKE '%executing cascade %' OR message LIKE 'Del%'
 ----
-Del /Table/145/1/"a-pk1"/0
+Del (locking) /Table/145/1/"a-pk1"/0
 executing cascade for constraint b1_delete_cascade_fkey
 Del /Table/146/1/"b1-pk1"/0
 Del /Table/146/1/"b1-pk2"/0
@@ -865,7 +865,7 @@ vectorized: true
 query T kvtrace(Del,DelRange)
 DELETE FROM delrng1 WHERE p = 1
 ----
-Del /Table/165/1/1/0
+Del (locking) /Table/165/1/1/0
 DelRange /Table/166/1/1 - /Table/166/1/2
 DelRange /Table/167/1/1 - /Table/167/1/2
 DelRange /Table/168/1/1 - /Table/168/1/2

--- a/pkg/sql/opt/exec/execbuilder/testdata/delete
+++ b/pkg/sql/opt/exec/execbuilder/testdata/delete
@@ -256,7 +256,7 @@ query TT nosort
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
 WHERE message LIKE '%Del%' OR message LIKE '%sending batch%'
 ----
-delete range      Del /Table/110/1/5/0
+delete range      Del (locking) /Table/110/1/5/0
 dist sender send  r74: sending batch 1 Del, 1 EndTxn to (n1,s1):1
 
 # Ensure that we send DelRanges when doing a point delete operation on a table

--- a/pkg/sql/opt/exec/execbuilder/testdata/partial_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/partial_index
@@ -1072,7 +1072,7 @@ INSERT INTO t57085_c VALUES (10, 1, true), (20, 1, false), (30, 2, true);
 query T kvtrace
 DELETE FROM t57085_p WHERE p = 1;
 ----
-Del /Table/114/1/1/0
+Del (locking) /Table/114/1/1/0
 Scan /Table/115/{1-2}
 Del /Table/115/2/1/10/0
 Del /Table/115/1/10/0

--- a/pkg/sql/opt/exec/execbuilder/testdata/upsert
+++ b/pkg/sql/opt/exec/execbuilder/testdata/upsert
@@ -1048,7 +1048,7 @@ query T
 SELECT message FROM [SHOW KV TRACE FOR SESSION]
  WHERE operation != 'dist sender send'
 ----
-Put /Table/117/1/1/0 -> /TUPLE/
+Put (locking) /Table/117/1/1/0 -> /TUPLE/
 Del /Table/117/1/1/1/1
 Del /Table/117/1/1/2/1
 fast path completed

--- a/pkg/sql/row/inserter.go
+++ b/pkg/sql/row/inserter.go
@@ -106,6 +106,23 @@ func insertPutFn(
 	b.Put(key, value)
 }
 
+// insertPutMustAcquireExclusiveLockFn is used by insertRow when conflicts
+// should be ignored while ensuring that an exclusive lock is acquired on the
+// key.
+func insertPutMustAcquireExclusiveLockFn(
+	ctx context.Context,
+	b Putter,
+	key *roachpb.Key,
+	value *roachpb.Value,
+	traceKV bool,
+	keyEncodingDirs []encoding.Direction,
+) {
+	if traceKV {
+		log.VEventfDepth(ctx, 1, 2, "Put (locking) %s -> %s", keys.PrettyPrint(keyEncodingDirs, *key), value.PrettyPrint())
+	}
+	b.PutMustAcquireExclusiveLock(key, value)
+}
+
 // insertDelFn is used by insertRow to delete existing rows.
 func insertDelFn(ctx context.Context, b Putter, key *roachpb.Key, traceKV bool) {
 	if traceKV {
@@ -137,6 +154,23 @@ func writeTombstones(
 	return nil
 }
 
+// KVInsertOp prescribes which KV operation should be used when inserting a SQL
+// row.
+type KVInsertOp byte
+
+const (
+	// CPutOp prescribes usage of the CPut operation and also indicates that the
+	// row **should not** be overwritten.
+	CPutOp KVInsertOp = iota
+	// PutOp prescribes usage of the Put operation and also indicates that the
+	// row **should** be overwritten.
+	PutOp
+	// PutMustAcquireExclusiveLockOp prescribes usage of the Put operation while
+	// ensuring that an exclusive lock is acquired and also indicates that the
+	// row **should** be overwritten.
+	PutMustAcquireExclusiveLockOp
+)
+
 // InsertRow adds to the batch the kv operations necessary to insert a table row
 // with the given values.
 func (ri *Inserter) InsertRow(
@@ -145,7 +179,7 @@ func (ri *Inserter) InsertRow(
 	values []tree.Datum,
 	pm PartialIndexUpdateHelper,
 	oth *OriginTimestampCPutHelper,
-	overwrite bool,
+	kvOp KVInsertOp,
 	traceKV bool,
 ) error {
 	if len(values) != len(ri.InsertCols) {
@@ -176,7 +210,7 @@ func (ri *Inserter) InsertRow(
 		&ri.Helper, primaryIndexKey, ri.InsertCols,
 		values, ri.InsertColIDtoRowIndex,
 		ri.InsertColIDtoRowIndex,
-		&ri.key, &ri.value, ri.valueBuf, oth, nil /* oldValues */, overwrite, traceKV)
+		&ri.key, &ri.value, ri.valueBuf, oth, nil /* oldValues */, kvOp, traceKV)
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/row/putter.go
+++ b/pkg/sql/row/putter.go
@@ -22,6 +22,7 @@ type Putter interface {
 	CPut(key, value interface{}, expValue []byte)
 	CPutWithOriginTimestamp(key, value interface{}, expValue []byte, ts hlc.Timestamp, shouldWinTie bool)
 	Put(key, value interface{})
+	PutMustAcquireExclusiveLock(key, value interface{})
 	Del(key ...interface{})
 
 	CPutBytesEmpty(kys []roachpb.Key, values [][]byte)
@@ -54,6 +55,11 @@ func (t *TracePutter) CPutWithOriginTimestamp(
 func (t *TracePutter) Put(key, value interface{}) {
 	log.VEventfDepth(t.Ctx, 1, 2, "Put %v -> %v", key, value)
 	t.Putter.Put(key, value)
+}
+
+func (t *TracePutter) PutMustAcquireExclusiveLock(key, value interface{}) {
+	log.VEventfDepth(t.Ctx, 1, 2, "Put (locking) %v -> %v", key, value)
+	t.Putter.PutMustAcquireExclusiveLock(key, value)
 }
 
 func (t *TracePutter) Del(key ...interface{}) {
@@ -179,6 +185,10 @@ func (s *SortingPutter) Put(key, value interface{}) {
 	s.Putter.Put(key, value)
 }
 
+func (s *SortingPutter) PutMustAcquireExclusiveLock(key, value interface{}) {
+	s.Putter.PutMustAcquireExclusiveLock(key, value)
+}
+
 func (s *SortingPutter) Del(key ...interface{}) {
 	s.Putter.Del(key...)
 }
@@ -270,6 +280,10 @@ func (k *KVBatchAdapter) CPut(key, value interface{}, expValue []byte) {
 
 func (k *KVBatchAdapter) Put(key, value interface{}) {
 	k.Batch.Put(key, value)
+}
+
+func (k *KVBatchAdapter) PutMustAcquireExclusiveLock(key, value interface{}) {
+	k.Batch.PutMustAcquireExclusiveLock(key, value)
 }
 
 func (k *KVBatchAdapter) Del(key ...interface{}) {

--- a/pkg/sql/row/row_converter.go
+++ b/pkg/sql/row/row_converter.go
@@ -67,6 +67,7 @@ func (i KVInserter) Put(key, value interface{}) {
 	})
 }
 
+func (c KVInserter) PutMustAcquireExclusiveLock(key, value interface{}) {}
 func (c KVInserter) CPutWithOriginTimestamp(
 	key, value interface{}, expValue []byte, ts hlc.Timestamp, shouldWinTie bool,
 ) {
@@ -564,8 +565,8 @@ func (c *DatumRowConverter) Row(ctx context.Context, sourceID int32, rowIndex in
 		c.kvInserter,
 		insertRow,
 		pm,
-		nil,   /* OriginTimestampCPutHelper */
-		true,  /* overwrite */
+		nil, /* OriginTimestampCPutHelper */
+		PutOp,
 		false, /* traceKV */
 	); err != nil {
 		return errors.Wrap(err, "insert row")

--- a/pkg/sql/row/updater.go
+++ b/pkg/sql/row/updater.go
@@ -356,7 +356,7 @@ func (ru *Updater) UpdateRow(
 			return nil, err
 		}
 		if err := ru.ri.InsertRow(
-			ctx, putter, ru.newValues, pm, oth, false /* overwrite */, traceKV,
+			ctx, putter, ru.newValues, pm, oth, CPutOp, traceKV,
 		); err != nil {
 			return nil, err
 		}
@@ -369,7 +369,7 @@ func (ru *Updater) UpdateRow(
 		&ru.Helper, primaryIndexKey, ru.FetchCols,
 		ru.newValues, ru.FetchColIDtoRowIndex,
 		ru.UpdateColIDtoRowIndex,
-		&ru.key, &ru.value, ru.valueBuf, oth, oldValues, true /* overwrite */, traceKV)
+		&ru.key, &ru.value, ru.valueBuf, oth, oldValues, PutOp, traceKV)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -362,7 +362,7 @@ func (sc *SchemaChanger) backfillQueryIntoTable(
 				},
 			}
 			tableSpan := table.TableSpan(localPlanner.EvalContext().Codec)
-			request.Add(kvpb.NewDeleteRange(tableSpan.Key, tableSpan.EndKey, false))
+			request.Add(kvpb.NewDeleteRange(tableSpan.Key, tableSpan.EndKey, false /* returnKeys */))
 			if _, err := localPlanner.execCfg.DB.NonTransactionalSender().Send(ctx, &request); err != nil {
 				return err.GoError()
 			}

--- a/pkg/sql/tablewriter_insert.go
+++ b/pkg/sql/tablewriter_insert.go
@@ -42,7 +42,7 @@ func (ti *tableInserter) row(
 	ctx context.Context, values tree.Datums, pm row.PartialIndexUpdateHelper, traceKV bool,
 ) error {
 	ti.currentBatchSize++
-	return ti.ri.InsertRow(ctx, &ti.putter, values, pm, nil, false /* overwrite */, traceKV)
+	return ti.ri.InsertRow(ctx, &ti.putter, values, pm, nil, row.CPutOp, traceKV)
 }
 
 // tableDesc returns the TableDescriptor for the table that the tableInserter

--- a/pkg/sql/tablewriter_upsert.go
+++ b/pkg/sql/tablewriter_upsert.go
@@ -158,7 +158,7 @@ func (tu *tableUpserter) makeResultFromRow(
 // of a Value field on the context because Value access in context.Context
 // is rather expensive.
 func (tu *tableUpserter) row(
-	ctx context.Context, row tree.Datums, pm row.PartialIndexUpdateHelper, traceKV bool,
+	ctx context.Context, datums tree.Datums, pm row.PartialIndexUpdateHelper, traceKV bool,
 ) error {
 	tu.currentBatchSize++
 
@@ -168,12 +168,22 @@ func (tu *tableUpserter) row(
 	insertEnd := len(tu.ri.InsertCols)
 	if tu.canaryOrdinal == -1 {
 		// No canary column means that existing row should be overwritten (i.e.
-		// the insert and update columns are the same, so no need to choose).
-		return tu.insertNonConflictingRow(ctx, row[:insertEnd], pm, true /* overwrite */, traceKV)
+		// the insert and update columns are the same, so no need to choose, or
+		// we're in the UPSERT fast-path).
+		//
+		// We use the locking Put here unconditionally since:
+		// - if buffered writes are enabled, since we haven't performed the
+		// read, we need to tell the KV layer to acquire the lock explicitly.
+		// - if buffered writes are disabled, then the KV layer will write an
+		// intent which acts as a lock.
+		// TODO(yuzefovich): add a tracing test to ensure that the lock is
+		// acquired here once the interceptor is updated.
+		kvOp := row.PutMustAcquireExclusiveLockOp
+		return tu.insertNonConflictingRow(ctx, datums[:insertEnd], pm, kvOp, traceKV)
 	}
-	if row[tu.canaryOrdinal] == tree.DNull {
+	if datums[tu.canaryOrdinal] == tree.DNull {
 		// No conflict, so insert a new row.
-		return tu.insertNonConflictingRow(ctx, row[:insertEnd], pm, false /* overwrite */, traceKV)
+		return tu.insertNonConflictingRow(ctx, datums[:insertEnd], pm, row.CPutOp, traceKV)
 	}
 
 	// If no columns need to be updated, then possibly collect the unchanged row.
@@ -182,7 +192,7 @@ func (tu *tableUpserter) row(
 		if !tu.rowsNeeded {
 			return nil
 		}
-		_, err := tu.rows.AddRow(ctx, row[insertEnd:fetchEnd])
+		_, err := tu.rows.AddRow(ctx, datums[insertEnd:fetchEnd])
 		return err
 	}
 
@@ -191,8 +201,8 @@ func (tu *tableUpserter) row(
 	return tu.updateConflictingRow(
 		ctx,
 		tu.b,
-		row[insertEnd:fetchEnd],
-		row[fetchEnd:updateEnd],
+		datums[insertEnd:fetchEnd],
+		datums[fetchEnd:updateEnd],
 		pm,
 		traceKV,
 	)
@@ -205,10 +215,11 @@ func (tu *tableUpserter) insertNonConflictingRow(
 	ctx context.Context,
 	insertRow tree.Datums,
 	pm row.PartialIndexUpdateHelper,
-	overwrite, traceKV bool,
+	kvOp row.KVInsertOp,
+	traceKV bool,
 ) error {
 	// Perform the insert proper.
-	if err := tu.ri.InsertRow(ctx, &tu.putter, insertRow, pm, nil, overwrite, traceKV); err != nil {
+	if err := tu.ri.InsertRow(ctx, &tu.putter, insertRow, pm, nil /* oth */, kvOp, traceKV); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
**sql: disable buffered writes for COPY**

COPY machinery performs bulk writes without doing any reads, and it already performs batching itself, so there is no benefit from enabling buffered writes for it.

**sql,kv: add MustAcquireExclusiveLock flag to Put and use it for blind UPSERT**

This commit extends `PutRequest` with `MustAcquireExclusiveLock` flag that indicates that a lock with the strength no lower than "exclusive" should be acquired on the key, even if the key doesn't exist yet. This ability is then utilized by the SQL layer when performing blind UPSERTs (which is the case where we can avoid the initial scan, in some special cases). (We do that unconditionally, regardless of buffered writes being enabled, since the write intent is a stronger lock.)

Additionally, this commit does a minor cleanup of `InsertRow` interface to take an explicit value which KV write operation should be performed.

**kv: remove some duplication with DelRange**

**kv: extend Del request for buffered writes**

This commit adds `MustAcquireExclusiveLock` flag to the `DeleteRequest` that the SQL layer will use to communicate to the KV client that locks need to be acquired on the keys when writes are buffered on the KV client. This flag is now utilized in the "blind" fast-path DELETE case where we skip the initial scan. All other usages of Del will be audited separately.

There are two alternatives to this approach that I like less:
- we could reuse existing `ReturnKeys` flag of the `DeleteRange` request (and add a similar flag to the `Delete` request) to mean that locks are needed. I don't like it as it conflates different purposes.
- we could adjust the SQL layer to explicitly issue Gets and Scans. I don't like this since SQL doesn't really need the values stored at the keys being deleted.

For now DeleteRange requests in the blind DELETE fast-path are left as a TODO since we haven't fully committed to buffering them in the interceptor.

Fixes: #139105.
Epic: CRDB-45273
Release note: None