### PR TITLE
kv: extend Del and DelRange requests for buffered writes

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_test.go
@@ -4000,7 +4000,7 @@ func TestMultipleErrorsMerged(t *testing.T) {
 
 				ba := &kvpb.BatchRequest{}
 				ba.Txn = txn.Clone()
-				ba.Add(kvpb.NewDeleteRange(roachpb.Key("a"), roachpb.Key("c"), false /* returnKeys */))
+				ba.Add(kvpb.NewDeleteRange(roachpb.Key("a"), roachpb.Key("c"), false /* returnKeys */, false /* usingTombstone */, false /* lockExisting */))
 
 				expWriteTimestamp := txn.WriteTimestamp
 				if tc.err1 != nil {

--- a/pkg/kv/kvclient/kvcoord/txn_coord_sender.go
+++ b/pkg/kv/kvclient/kvcoord/txn_coord_sender.go
@@ -317,9 +317,6 @@ func (tc *TxnCoordSender) initCommonInterceptors(
 	if ds, ok := tcf.wrapped.(*DistSender); ok {
 		riGen.ds = ds
 	}
-	tc.interceptorAlloc.txnWriteBuffer = txnWriteBuffer{
-		enabled: BufferedWritesEnabled.Get(&tcf.st.SV),
-	}
 	tc.interceptorAlloc.txnPipeliner = txnPipeliner{
 		st:                       tcf.st,
 		riGen:                    riGen,
@@ -1156,6 +1153,25 @@ func (tc *TxnCoordSender) SetOmitInRangefeeds() {
 		panic("cannot change OmitInRangefeeds of a running transaction")
 	}
 	tc.mu.txn.OmitInRangefeeds = true
+}
+
+// SetBufferedWritesEnabled is part of the kv.TxnSender interface.
+func (tc *TxnCoordSender) SetBufferedWritesEnabled(enabled bool) {
+	tc.mu.Lock()
+	defer tc.mu.Unlock()
+
+	if tc.mu.active && enabled && !tc.interceptorAlloc.txnWriteBuffer.enabled {
+		panic("cannot enable buffered writes on a running transaction")
+	}
+	tc.interceptorAlloc.txnWriteBuffer.enabled = enabled
+}
+
+// BufferedWritesEnabled is part of the kv.TxnSender interface.
+func (tc *TxnCoordSender) BufferedWritesEnabled() bool {
+	tc.mu.Lock()
+	defer tc.mu.Unlock()
+
+	return tc.interceptorAlloc.txnWriteBuffer.enabled
 }
 
 // String is part of the kv.TxnSender interface.

--- a/pkg/kv/kvpb/api.go
+++ b/pkg/kv/kvpb/api.go
@@ -1691,23 +1691,28 @@ func NewConditionalPutInline(
 }
 
 // NewDelete returns a Request initialized to delete the value at key.
-func NewDelete(key roachpb.Key) Request {
+func NewDelete(key roachpb.Key, lockIfExists bool) Request {
 	return &DeleteRequest{
 		RequestHeader: RequestHeader{
 			Key: key,
 		},
+		LockIfExists: lockIfExists,
 	}
 }
 
 // NewDeleteRange returns a Request initialized to delete the values in
 // the given key range (excluding the endpoint).
-func NewDeleteRange(startKey, endKey roachpb.Key, returnKeys bool) Request {
+func NewDeleteRange(
+	startKey, endKey roachpb.Key, returnKeys bool, usingTombstone bool, lockExisting bool,
+) Request {
 	return &DeleteRangeRequest{
 		RequestHeader: RequestHeader{
 			Key:    startKey,
 			EndKey: endKey,
 		},
-		ReturnKeys: returnKeys,
+		ReturnKeys:        returnKeys,
+		UseRangeTombstone: usingTombstone,
+		LockExisting:      lockExisting,
 	}
 }
 

--- a/pkg/kv/kvpb/api.proto
+++ b/pkg/kv/kvpb/api.proto
@@ -425,6 +425,10 @@ message IncrementResponse {
 // A DeleteRequest is the argument to the Delete() method.
 message DeleteRequest {
   RequestHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
+  // LockIfExists instructs the KV client to acquire a lock on the key to be
+  // deleted if it exists when the writes are buffered on the client (if writes
+  // aren't buffered, then this flag has no effect).
+  bool lock_if_exists = 2;
 }
 
 // A DeleteResponse is the return value from the Delete() method.
@@ -477,6 +481,10 @@ message DeleteRangeRequest {
   // queue to delete this data as soon as it can, and helps optimizing GC for
   // bulk deletions.
   bool update_range_delete_gc_hint = 8 [(gogoproto.customname) = "UpdateRangeDeleteGCHint"];
+  // LockExisting instructs the KV client to acquire a lock on all existing keys
+  // to be deleted when the writes are buffered on the client (if writes aren't
+  // buffered, then this flag has no effect).
+  bool lock_existing = 9;
 
   DeleteRangePredicates predicates = 6 [(gogoproto.nullable) = false];
 }

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -2200,7 +2200,7 @@ func TestReplicaUpdateTSCache(t *testing.T) {
 	tc.manualClock.MustAdvanceTo(timeutil.Unix(2, 0))
 	ts2 := tc.Clock().Now()
 	key := roachpb.Key("b")
-	drArgs := kvpb.NewDeleteRange(key, key.Next(), false /* returnKeys */)
+	drArgs := kvpb.NewDeleteRange(key, key.Next(), false /* returnKeys */, false /* usingTombstone */, false /* lockExisting */)
 
 	if _, pErr := tc.SendWrappedWith(kvpb.Header{Timestamp: ts2}, drArgs); pErr != nil {
 		t.Error(pErr)

--- a/pkg/kv/mock_transactional_sender.go
+++ b/pkg/kv/mock_transactional_sender.go
@@ -108,6 +108,14 @@ func (m *MockTransactionalSender) SetOmitInRangefeeds() {
 	m.txn.OmitInRangefeeds = true
 }
 
+// SetBufferedWritesEnabled is part of the TxnSender interface.
+func (m *MockTransactionalSender) SetBufferedWritesEnabled(enabled bool) {}
+
+// BufferedWritesEnabled is part of the TxnSender interface.
+func (m *MockTransactionalSender) BufferedWritesEnabled() bool {
+	return false
+}
+
 // String is part of the TxnSender interface.
 func (m *MockTransactionalSender) String() string {
 	return m.txn.String()

--- a/pkg/kv/sender.go
+++ b/pkg/kv/sender.go
@@ -127,6 +127,16 @@ type TxnSender interface {
 	// Transaction proto.
 	SetOmitInRangefeeds()
 
+	// SetBufferedWritesEnabled toggles whether the writes are buffered on the
+	// gateway node until the commit time. Only allowed on the RootTxn. Buffered
+	// writes cannot be enabled on a txn that performed any requests.
+	// TODO(yuzefovich): should we flush the buffer when going from "enabled" to
+	// "disabled"?
+	SetBufferedWritesEnabled(bool)
+
+	// BufferedWritesEnabled returns whether the buffered writes are enabled.
+	BufferedWritesEnabled() bool
+
 	// String returns a string representation of the txn.
 	String() string
 

--- a/pkg/kv/txn.go
+++ b/pkg/kv/txn.go
@@ -397,6 +397,24 @@ func (txn *Txn) debugNameLocked() string {
 	return fmt.Sprintf("%s (id: %s)", txn.mu.debugName, txn.mu.ID)
 }
 
+func (txn *Txn) SetBufferedWritesEnabled(enabled bool) {
+	if txn.typ != RootTxn {
+		panic(errors.AssertionFailedf("SetBufferedWritesEnabled() called on leaf txn"))
+	}
+
+	txn.mu.Lock()
+	defer txn.mu.Unlock()
+
+	txn.mu.sender.SetBufferedWritesEnabled(enabled)
+}
+
+func (txn *Txn) BufferedWritesEnabled() bool {
+	txn.mu.Lock()
+	defer txn.mu.Unlock()
+
+	return txn.mu.sender.BufferedWritesEnabled()
+}
+
 // String returns a string version of this transaction.
 func (txn *Txn) String() string {
 	txn.mu.Lock()

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -3177,6 +3177,7 @@ func (ex *connExecutor) makeExecPlan(
 	if err := ex.maybeUpgradeToSerializable(ctx, planner.stmt); err != nil {
 		return ctx, err
 	}
+	// TODO(yuzefovich): consider disabling buffered writes on a DDL.
 
 	if err := planner.makeOptimizerPlan(ctx); err != nil {
 		log.VEventf(ctx, 1, "optimizer plan failed: %v", err)
@@ -3464,6 +3465,7 @@ func (ex *connExecutor) execStmtInNoTxnState(
 				ex.QualityOfService(),
 				ex.txnIsolationLevelToKV(ctx, s.Modes.Isolation),
 				ex.omitInRangefeeds(),
+				ex.bufferedWritesEnabled(ctx),
 			)
 	case *tree.ShowCommitTimestamp:
 		return ex.execShowCommitTimestampInNoTxnState(ctx, s, res)
@@ -3502,6 +3504,7 @@ func (ex *connExecutor) execStmtInNoTxnState(
 				ex.QualityOfService(),
 				ex.txnIsolationLevelToKV(ctx, tree.UnspecifiedIsolation),
 				ex.omitInRangefeeds(),
+				ex.bufferedWritesEnabled(ctx),
 			)
 	}
 }
@@ -3535,6 +3538,7 @@ func (ex *connExecutor) beginImplicitTxn(
 			qos,
 			ex.txnIsolationLevelToKV(ctx, tree.UnspecifiedIsolation),
 			ex.omitInRangefeeds(),
+			ex.bufferedWritesEnabled(ctx),
 		)
 }
 

--- a/pkg/sql/conn_executor_prepare.go
+++ b/pkg/sql/conn_executor_prepare.go
@@ -228,6 +228,7 @@ func (ex *connExecutor) prepare(
 		if err := ex.maybeUpgradeToSerializable(ctx, stmt); err != nil {
 			return err
 		}
+		// TODO(yuzefovich): consider disabling buffered writes on a DDL.
 
 		if placeholderHints == nil {
 			placeholderHints = make(tree.PlaceholderTypes, stmt.NumPlaceholders)

--- a/pkg/sql/conn_fsm.go
+++ b/pkg/sql/conn_fsm.go
@@ -117,9 +117,10 @@ type eventTxnStartPayload struct {
 	historicalTimestamp *hlc.Timestamp
 	// qualityOfService denotes the user-level admission queue priority to use for
 	// any new Txn started using this payload.
-	qualityOfService sessiondatapb.QoSLevel
-	isoLevel         isolation.Level
-	omitInRangefeeds bool
+	qualityOfService      sessiondatapb.QoSLevel
+	isoLevel              isolation.Level
+	omitInRangefeeds      bool
+	bufferedWritesEnabled bool
 }
 
 // makeEventTxnStartPayload creates an eventTxnStartPayload.
@@ -132,16 +133,18 @@ func makeEventTxnStartPayload(
 	qualityOfService sessiondatapb.QoSLevel,
 	isoLevel isolation.Level,
 	omitInRangefeeds bool,
+	bufferedWritesEnabled bool,
 ) eventTxnStartPayload {
 	return eventTxnStartPayload{
-		pri:                 pri,
-		readOnly:            readOnly,
-		txnSQLTimestamp:     txnSQLTimestamp,
-		historicalTimestamp: historicalTimestamp,
-		tranCtx:             tranCtx,
-		qualityOfService:    qualityOfService,
-		isoLevel:            isoLevel,
-		omitInRangefeeds:    omitInRangefeeds,
+		pri:                   pri,
+		readOnly:              readOnly,
+		txnSQLTimestamp:       txnSQLTimestamp,
+		historicalTimestamp:   historicalTimestamp,
+		tranCtx:               tranCtx,
+		qualityOfService:      qualityOfService,
+		isoLevel:              isoLevel,
+		omitInRangefeeds:      omitInRangefeeds,
+		bufferedWritesEnabled: bufferedWritesEnabled,
 	}
 }
 
@@ -590,6 +593,7 @@ func noTxnToOpen(args fsm.Args) error {
 		payload.qualityOfService,
 		payload.isoLevel,
 		payload.omitInRangefeeds,
+		payload.bufferedWritesEnabled,
 	)
 	ts.setAdvanceInfo(
 		advCode,

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -3143,6 +3143,10 @@ type sessionDataMutatorCallbacks struct {
 	// setCurTxnReadOnly is called when we execute SET transaction_read_only = ...
 	// It can be nil, in which case nothing triggers on execution.
 	setCurTxnReadOnly func(readOnly bool) error
+	// setBufferedWritesEnabled is called when we execute SET kv_transaction_buffered_writes_enabled = ...
+	// It can be nil, in which case nothing triggers on execution (apart from
+	// modification of the session data).
+	setBufferedWritesEnabled func(enabled bool)
 	// upgradedIsolationLevel is called whenever the transaction isolation
 	// session variable is configured and the isolation level is automatically
 	// upgraded to a stronger one. It's also used when the isolation level is
@@ -4006,6 +4010,13 @@ func (m *sessionDataMutator) SetCatalogDigestStalenessCheckEnabled(b bool) {
 
 func (m *sessionDataMutator) SetOptimizerPreferBoundedCardinality(b bool) {
 	m.data.OptimizerPreferBoundedCardinality = b
+}
+
+func (m *sessionDataMutator) SetBufferedWritesEnabled(b bool) {
+	m.data.BufferedWritesEnabled = b
+	if m.setBufferedWritesEnabled != nil {
+		m.setBufferedWritesEnabled(b)
+	}
 }
 
 // Utility functions related to scrubbing sensitive information on SQL Stats.

--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -477,6 +477,9 @@ func (ie *InternalExecutor) newConnExecutorWithTxn(
 		ex.QualityOfService(),
 		isolation.Serializable,
 		txn.GetOmitInRangefeeds(),
+		// TODO(yuzefovich): re-evaluate whether we want to allow buffered
+		// writes for internal executor.
+		false, /* bufferedWritesEnabled */
 	)
 
 	// Modify the Collection to match the parent executor's Collection.

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -3982,6 +3982,7 @@ is_superuser                                               on
 join_reader_index_join_strategy_batch_size                 4.0 MiB
 join_reader_no_ordering_strategy_batch_size                2.0 MiB
 join_reader_ordering_strategy_batch_size                   100 KiB
+kv_transaction_buffered_writes_enabled                     off
 large_full_scan_rows                                       0
 lc_collate                                                 C.UTF-8
 lc_ctype                                                   C.UTF-8

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -2983,6 +2983,7 @@ is_superuser                                               on                  N
 join_reader_index_join_strategy_batch_size                 4.0 MiB             NULL      NULL        NULL        string
 join_reader_no_ordering_strategy_batch_size                2.0 MiB             NULL      NULL        NULL        string
 join_reader_ordering_strategy_batch_size                   100 KiB             NULL      NULL        NULL        string
+kv_transaction_buffered_writes_enabled                     off                 NULL      NULL        NULL        string
 large_full_scan_rows                                       0                   NULL      NULL        NULL        string
 lc_collate                                                 C.UTF-8             NULL      NULL        NULL        string
 lc_ctype                                                   C.UTF-8             NULL      NULL        NULL        string
@@ -3189,6 +3190,7 @@ is_superuser                                               on                  N
 join_reader_index_join_strategy_batch_size                 4.0 MiB             NULL  user     NULL      4.0 MiB             4.0 MiB
 join_reader_no_ordering_strategy_batch_size                2.0 MiB             NULL  user     NULL      2.0 MiB             2.0 MiB
 join_reader_ordering_strategy_batch_size                   100 KiB             NULL  user     NULL      100 KiB             100 KiB
+kv_transaction_buffered_writes_enabled                     off                 NULL  user     NULL      off                 off
 large_full_scan_rows                                       0                   NULL  user     NULL      0                   0
 lc_collate                                                 C.UTF-8             NULL  user     NULL      C.UTF-8             C.UTF-8
 lc_ctype                                                   C.UTF-8             NULL  user     NULL      C.UTF-8             C.UTF-8
@@ -3392,6 +3394,7 @@ is_superuser                                               NULL    NULL     NULL
 join_reader_index_join_strategy_batch_size                 NULL    NULL     NULL     NULL        NULL
 join_reader_no_ordering_strategy_batch_size                NULL    NULL     NULL     NULL        NULL
 join_reader_ordering_strategy_batch_size                   NULL    NULL     NULL     NULL        NULL
+kv_transaction_buffered_writes_enabled                     NULL    NULL     NULL     NULL        NULL
 large_full_scan_rows                                       NULL    NULL     NULL     NULL        NULL
 lc_collate                                                 NULL    NULL     NULL     NULL        NULL
 lc_ctype                                                   NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -114,6 +114,7 @@ is_superuser                                               on
 join_reader_index_join_strategy_batch_size                 4.0 MiB
 join_reader_no_ordering_strategy_batch_size                2.0 MiB
 join_reader_ordering_strategy_batch_size                   100 KiB
+kv_transaction_buffered_writes_enabled                     off
 large_full_scan_rows                                       0
 lc_collate                                                 C.UTF-8
 lc_ctype                                                   C.UTF-8

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -362,7 +362,7 @@ func (sc *SchemaChanger) backfillQueryIntoTable(
 				},
 			}
 			tableSpan := table.TableSpan(localPlanner.EvalContext().Codec)
-			request.Add(kvpb.NewDeleteRange(tableSpan.Key, tableSpan.EndKey, false))
+			request.Add(kvpb.NewDeleteRange(tableSpan.Key, tableSpan.EndKey, false /* returnKeys */, false /* usingTombstone */, false /* lockExisting */))
 			if _, err := localPlanner.execCfg.DB.NonTransactionalSender().Send(ctx, &request); err != nil {
 				return err.GoError()
 			}

--- a/pkg/sql/sessiondatapb/local_only_session_data.proto
+++ b/pkg/sql/sessiondatapb/local_only_session_data.proto
@@ -598,6 +598,11 @@ message LocalOnlySessionData {
   // plans in which every expression has a bounded cardinality over plans with
   // one or more expressions with unbounded cardinality.
   bool optimizer_prefer_bounded_cardinality = 154;
+  // BufferedWritesEnabled controls whether the buffered writes KV transaction
+  // protocol is used for user queries on the current session. If this variable
+  // is modified in an explicit txn, then the change will be applied only to
+  // future txns on the session.
+  bool buffered_writes_enabled = 155;
 
   ///////////////////////////////////////////////////////////////////////////
   // WARNING: consider whether a session parameter you're adding needs to  //

--- a/pkg/sql/txn_state_test.go
+++ b/pkg/sql/txn_state_test.go
@@ -282,7 +282,7 @@ func TestTransitions(t *testing.T) {
 			ev: eventTxnStart{ImplicitTxn: fsm.True},
 			evPayload: makeEventTxnStartPayload(pri, tree.ReadWrite, timeutil.Now(),
 				nil /* historicalTimestamp */, tranCtx, sessiondatapb.Normal, isolation.Serializable,
-				false, /* omitInRangefeeds */
+				false /* omitInRangefeeds */, false, /* bufferedWritesEnabled */
 			),
 			expState: stateOpen{ImplicitTxn: fsm.True, WasUpgraded: fsm.False},
 			expAdv: expAdvance{
@@ -309,7 +309,7 @@ func TestTransitions(t *testing.T) {
 			ev: eventTxnStart{ImplicitTxn: fsm.False},
 			evPayload: makeEventTxnStartPayload(pri, tree.ReadWrite, timeutil.Now(),
 				nil /* historicalTimestamp */, tranCtx, sessiondatapb.Normal, isolation.Serializable,
-				false, /* omitInRangefeeds */
+				false /* omitInRangefeeds */, false, /* bufferedWritesEnabled */
 			),
 			expState: stateOpen{ImplicitTxn: fsm.False, WasUpgraded: fsm.False},
 			expAdv: expAdvance{

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/build"
 	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvcoord"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
@@ -3758,6 +3759,25 @@ var varGen = map[string]sessionVar{
 			return formatBoolAsPostgresSetting(evalCtx.SessionData().OptimizerPreferBoundedCardinality), nil
 		},
 		GlobalDefault: globalFalse,
+	},
+
+	// CockroachDB extension.
+	`kv_transaction_buffered_writes_enabled`: {
+		Get: func(evalCtx *extendedEvalContext, _ *kv.Txn) (string, error) {
+			return formatBoolAsPostgresSetting(evalCtx.SessionData().BufferedWritesEnabled), nil
+		},
+		GetStringVal: makePostgresBoolGetStringValFn("kv_transaction_buffered_writes_enabled"),
+		Set: func(ctx context.Context, m sessionDataMutator, s string) error {
+			b, err := paramparse.ParseBoolVar(`kv_transaction_buffered_writes_enabled`, s)
+			if err != nil {
+				return err
+			}
+			m.SetBufferedWritesEnabled(b)
+			return nil
+		},
+		GlobalDefault: func(sv *settings.Values) string {
+			return formatBoolAsPostgresSetting(kvcoord.BufferedWritesEnabled.Get(sv))
+		},
 	},
 }
 


### PR DESCRIPTION
This commit adds `LockIfExists` and `LockExisting` boolean flags to
`DeleteRequest` and `DeleteRangeRequest`, respectively. These will be
used by the SQL layer to communicate to the KV client that locks need to
be acquired on the keys-to-be-deleted (if they exist) when writes are
buffered on the KV client. The relevant interceptor will consult these
flags to see whether locks are needed and will acquire them somehow
(probably by issuing Gets and Scan). There are two alternatives to this
approach that I like less:
- we could reuse existing `ReturnKeys` flag of the `DeleteRange` request
(and add a similar flag to the `Delete` request) to mean that locks are
needed. I don't like it as it conflates different purposes.
- we could adjust the SQL layer to explicitly issue Gets and Scans.
I don't like this since SQL doesn't really need the values stored at the
keys being deleted.

The newly added flags would be ignored by the KV server (we could
actually strip them in the write buffer interceptor).

At the moment, only the fast-path `deleteRangeNode` is adjusted as
a proof of concept.

Informs: #139105.
Informs: #139160.

Release note: None