### PR TITLE
kvcoord: eagerly bail on Leaseholder not found in sendToReplicas

### DIFF
--- a/.cursorignore
+++ b/.cursorignore
@@ -1,0 +1,25 @@
+# ignore everything
+*
+
+# but don't ignore files ending with slash = directories
+!*/
+cockroach-*/
+debug*/
+artifacts/
+_bazel/
+c-deps/
+benchdiff/
+bin/
+
+!*.go
+!*.proto
+!*.tsx
+!*.ts
+!*.js
+!*.jsx
+!*.json
+!*.yaml
+!*.yml
+!*.md
+!*.txt
+!*.sh

--- a/pkg/kv/kvclient/kvcoord/dist_sender.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender.go
@@ -415,6 +415,23 @@ var ProxyBatchRequest = settings.RegisterBoolSetting(
 	true,
 )
 
+var EagerlyBailOnLeaseholderNotFound = settings.RegisterBoolSetting(
+	settings.ApplicationLevel,
+	"kv.dist_sender.eagerly_bail_on_leaseholder_not_found.enabled",
+	"when true, the dist sender will eagerly return an error when it encounters errors that "+
+		"indicate an unavailable range, rather than retrying until the circuit breaker trips",
+	true,
+)
+
+var LeaseholderNotFoundBackoffThreshold = settings.RegisterDurationSetting(
+	settings.ApplicationLevel,
+	"kv.dist_sender.leaseholder_not_found_backoff.threshold",
+	"determines how long we will keep backing off when we can't find the range leaseholder before "+
+		"returning that the range in unavailable. This only works when "+
+		"eagerly_bail_on_leaseholder_not_found is set to true",
+	time.Second*10,
+)
+
 // DistSenderMetrics is the set of metrics for a given distributed sender.
 type DistSenderMetrics struct {
 	BatchCount                         *metric.Counter
@@ -2208,7 +2225,7 @@ func (ds *DistSender) sendPartialBatch(
 		}
 
 		prevTok = routingTok
-		reply, err = ds.sendToReplicas(ctx, ba, routingTok, withCommit)
+		reply, err = ds.sendToReplicas(ctx, ba, routingTok, withCommit, tBegin.Elapsed())
 
 		if dur := tBegin.Elapsed(); dur > slowDistSenderRangeThreshold && tBegin != 0 {
 			{
@@ -2490,6 +2507,42 @@ func selectBestError(ambiguousErr, replicaUnavailableErr, lastAttemptErr error) 
 	return lastAttemptErr
 }
 
+// requestBypassesCircuitBreaker determines whether the batch request bypasses
+// the circuit breaker or not.
+func requestBypassesCircuitBreaker(ba *kvpb.BatchRequest) bool {
+	// If the batch contains any operation that bypasses the circuit breaker,
+	// return true.
+	for _, ru := range ba.Requests {
+		req := ru.GetInner()
+		if kvpb.BypassesReplicaCircuitBreaker(req) {
+			return true
+		}
+	}
+	return false
+}
+
+// isRangeUnavailableBasedOnNLHE determines whether the range is considered
+// unavailable based on the NLHEs seen during the execution of the batch.
+func (ds *DistSender) isRangeUnavailableBasedOnNLHE(
+	transport Transport, seenNLHE, seenOtherThanNLHE bool,
+) bool {
+	// We consider the range as unavailable based on NotLeaseholder errors if all
+	// the following conditions are met:
+	// 1. The cluster setting is turned on.
+	// 2. There are no more replicas to try.
+	// 3. We have only seen RPC and NLHEs.
+	return EagerlyBailOnLeaseholderNotFound.Get(&ds.st.SV) &&
+		transport.IsExhausted() &&
+		!seenOtherThanNLHE &&
+		seenNLHE
+}
+
+// shouldBackoffRangeUnavailableBasedOnNLHE determines whether the DistSender
+// should backoff and retry the replicas
+func (ds *DistSender) shouldBackoffRangeUnavailableBasedOnNLHE(duration time.Duration) bool {
+	return duration < LeaseholderNotFoundBackoffThreshold.Get(&ds.st.SV)
+}
+
 // slowDistSenderRangeThreshold is a latency threshold for logging slow
 // requests to a range, potentially involving RPCs to multiple replicas
 // of the range.
@@ -2510,8 +2563,14 @@ const slowDistSenderReplicaThreshold = 10 * time.Second
 // AmbiguousResultError. Of those two, the latter has to be passed back to the
 // client, while the former should be handled by retrying with an updated range
 // descriptor. This method handles other errors returned from replicas
-// internally by retrying (NotLeaseHolderError, RangeNotFoundError), and falls
-// back to a sendError when it runs out of replicas to try.
+// internally by retrying (NotLeaseHolderError[1], RangeNotFoundError), and
+// falls back to a sendError when it runs out of replicas to try.
+//
+// [1] If all replicas return RPC errors and NotLeaseHolderErrors, it typically
+// indicates that the range is unavailable. In that case, and if the cluster
+// setting eagerly_bail_on_leaseholder_not_found.enabled is set to true,
+// sendToReplicas could return a ReplicaUnavailable error if the request started
+// longer than leaseholder_not_found_backoff.threshold.
 //
 // routing dictates what replicas will be tried (but not necessarily their
 // order).
@@ -2525,8 +2584,16 @@ const slowDistSenderReplicaThreshold = 10 * time.Second
 // latter because aborting is idempotent). If withCommit is true, any errors
 // that do not definitively rule out the possibility that the batch could have
 // succeeded are transformed into AmbiguousResultErrors.
+//
+// durationSinceStart is the duration since the start of the request. Note that,
+// sendToReplicas might return retriable errors, which means that the
+// durationSinceStart on the next call to sendToReplicas will be larger.
 func (ds *DistSender) sendToReplicas(
-	ctx context.Context, ba *kvpb.BatchRequest, routing rangecache.EvictionToken, withCommit bool,
+	ctx context.Context,
+	ba *kvpb.BatchRequest,
+	routing rangecache.EvictionToken,
+	withCommit bool,
+	durationSinceStart time.Duration,
 ) (*kvpb.BatchResponse, error) {
 
 	// If this request can be sent to a follower to perform a consistent follower
@@ -2627,10 +2694,56 @@ func (ds *DistSender) sendToReplicas(
 	var ambiguousError, replicaUnavailableError error
 	var leaseholderUnavailable bool
 	var br *kvpb.BatchResponse
+
+	// seenNLHE is set to true if any of the replicas return NotLeaseholderError.
+	// Note that RPC errors aren't considered.
+	seenNLHE := false
+
+	// seenOtherThanNLHE is set to true if any of the replicas return an error
+	// other than NotLeaseholderError. Note that RPC errors aren't considered.
+	seenOtherThanNLHE := false
+
 	attempts := int64(0)
 	for first := true; ; first, attempts = false, attempts+1 {
 		if !first {
 			ds.metrics.NextReplicaErrCount.Inc(1)
+		}
+
+		// If the last replica returned a non-RPC error, check what it was and set
+		// seenNLHE, seenOtherThanNLHE accordingly.
+		if br != nil {
+			if _, ok := br.Error.GetDetail().(*kvpb.NotLeaseHolderError); ok {
+				seenNLHE = true // not an RPC error
+			} else {
+				seenOtherThanNLHE = true // not an RPC error
+			}
+		}
+
+		rangeConsideredUnavailable :=
+			ds.isRangeUnavailableBasedOnNLHE(transport, seenNLHE, seenOtherThanNLHE)
+		if rangeConsideredUnavailable && ambiguousError == nil && !requestBypassesCircuitBreaker(ba) {
+			// If the range is considered unavailable based on the NLHEs that we saw,
+			// there is no ambiguousError that we need to return, and the request
+			// doesn't bypass the circuit breaker, we might return a
+			// ReplicaUnavailable error to avoid the circuit breaker looping for this
+			// request for a long time. However, we first need to check if we should
+			// backoff before returning the error.
+			//
+			// Note that the backoff actually happens in the caller to sendToReplicas
+			// since we will return a retriable error if we are backing off.
+			if !ds.shouldBackoffRangeUnavailableBasedOnNLHE(durationSinceStart) {
+				if replicaUnavailableError == nil {
+					if routing.Leaseholder() != nil {
+						// If we know the leaseholder, include it in the error.
+						replicaUnavailableError = kvpb.NewReplicaUnavailableError(
+							errors.New("leaseholder is unavailable"), desc, *routing.Leaseholder())
+					} else {
+						replicaUnavailableError = kvpb.NewReplicaUnavailableError(
+							errors.New("could not find leaseholder"), desc, prevReplica)
+					}
+
+				}
+			}
 		}
 
 		// Advance through the transport's replicas until we find one that's still
@@ -3016,6 +3129,11 @@ func (ds *DistSender) sendToReplicas(
 					if updatedLeaseholder {
 						leaseholderUnavailable = false
 						routeToLeaseholder = true
+						// Since we are going to retry all replicas again, reset the
+						// seenNLHE and seenOtherThanNLHE booleans since they will be set as
+						// needed while we are iterating over the replicas again.
+						seenNLHE = false
+						seenOtherThanNLHE = false
 						// If we changed the leaseholder, reset the transport to try all the
 						// replicas in order again. After a leaseholder change, requests to
 						// followers will be marked as potential proxy requests and point to

--- a/pkg/kv/kvclient/kvcoord/dist_sender_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_test.go
@@ -732,6 +732,339 @@ func TestErrorWithCancellationExit(t *testing.T) {
 	}
 }
 
+// TestSendToReplicasEagerlyBailOnLeaseholderNotFound tests that if the cluster
+// setting is enabled, the DistSender will eagerly bail out if sendToReplicas
+// can't find the leaseholder for some time.
+func TestSendToReplicasEagerlyBailOnLeaseholderNotFound(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+	stopper := stop.NewStopper()
+	defer stopper.Stop(ctx)
+
+	// transportSendNextError is used to simulate both RPC errors, and batch
+	// response errors.
+	type transportSendNextError struct {
+		err                error
+		batchResponseError *kvpb.Error
+	}
+
+	// Prepare some errors that the transport will return.
+	notLeaseholderErr := transportSendNextError{
+		err: nil,
+		batchResponseError: kvpb.NewError(
+			&kvpb.NotLeaseHolderError{
+				Replica: testUserRangeDescriptor3Replicas.InternalReplicas[0],
+			}),
+	}
+
+	rangeNotFoundErr := transportSendNextError{
+		err: nil,
+		batchResponseError: kvpb.NewError(
+			&kvpb.RangeNotFoundError{
+				RangeID: testUserRangeDescriptor3Replicas.RangeID,
+				StoreID: testUserRangeDescriptor3Replicas.InternalReplicas[0].StoreID,
+			}),
+	}
+
+	rpcError := transportSendNextError{
+		err:                errors.Errorf("RPC error"),
+		batchResponseError: nil,
+	}
+
+	var initDescriptor = roachpb.RangeDescriptor{
+		Generation: 1,
+		RangeID:    1,
+		StartKey:   roachpb.RKeyMin,
+		EndKey:     roachpb.RKeyMax,
+		InternalReplicas: []roachpb.ReplicaDescriptor{
+			{
+				NodeID:    1,
+				StoreID:   1,
+				ReplicaID: 1,
+			},
+			{
+				NodeID:    2,
+				StoreID:   2,
+				ReplicaID: 2,
+			},
+			{
+				NodeID:    3,
+				StoreID:   3,
+				ReplicaID: 3,
+			},
+		},
+	}
+	var initLease = roachpb.Lease{
+		Sequence: 1,
+		Replica: roachpb.ReplicaDescriptor{
+			NodeID: 1, StoreID: 1, ReplicaID: 1,
+		},
+	}
+
+	tests := []struct {
+		name                    string
+		errors                  []transportSendNextError
+		clusterSettingEnabled   bool
+		exceedBackoffThreshold  bool
+		withCommit              bool
+		bypassCircuitBreakerReq bool
+		expectedErr             string
+	}{
+		{
+			name: "all errors are leaseholder and before backoff threshold",
+			errors: []transportSendNextError{
+				notLeaseholderErr,
+				notLeaseholderErr,
+				notLeaseholderErr,
+			},
+			clusterSettingEnabled:   true,
+			exceedBackoffThreshold:  false,
+			withCommit:              false,
+			bypassCircuitBreakerReq: false,
+			// We expect a send error to be returned since we haven't passed the
+			// backoff threshold.
+			expectedErr: "sending to all replicas failed",
+		},
+		{
+			name: "all errors are leaseholder and after backoff threshold",
+			errors: []transportSendNextError{
+				notLeaseholderErr,
+				notLeaseholderErr,
+				notLeaseholderErr,
+			},
+			clusterSettingEnabled:   true,
+			exceedBackoffThreshold:  true,
+			withCommit:              false,
+			bypassCircuitBreakerReq: false,
+			// Since we only have NLHE errors, and we have passed the backoff
+			// threshold, expect that a RUE is returned.
+			expectedErr: "replica unavailable",
+		},
+		{
+			name: "all errors are leaseholder and before backoff threshold with bypass request",
+			errors: []transportSendNextError{
+				notLeaseholderErr,
+				notLeaseholderErr,
+				notLeaseholderErr,
+			},
+			clusterSettingEnabled:   true,
+			exceedBackoffThreshold:  false,
+			withCommit:              false,
+			bypassCircuitBreakerReq: true,
+			// We expect a send error to be returned since we haven't passed the
+			// backoff threshold.
+			expectedErr: "sending to all replicas failed",
+		},
+		{
+			name: "all errors are leaseholder and after backoff threshold with bypass request",
+			errors: []transportSendNextError{
+				notLeaseholderErr,
+				notLeaseholderErr,
+				notLeaseholderErr,
+			},
+			clusterSettingEnabled:   true,
+			exceedBackoffThreshold:  true,
+			withCommit:              false,
+			bypassCircuitBreakerReq: true,
+			// We expect a send error to be returned since we have a request that
+			// bypasses circuit breaker.
+			expectedErr: "sending to all replicas failed",
+		},
+		{
+			name: "all errors are leaseholder and after backoff threshold with setting off",
+			errors: []transportSendNextError{
+				notLeaseholderErr,
+				notLeaseholderErr,
+				notLeaseholderErr,
+			},
+			clusterSettingEnabled:   false,
+			exceedBackoffThreshold:  true,
+			withCommit:              false,
+			bypassCircuitBreakerReq: false,
+			// We expect a send error to be returned since the setting is off.
+			expectedErr: "sending to all replicas failed",
+		},
+		{
+			name: "all errors are leaseholder & rpc before backoff threshold",
+			errors: []transportSendNextError{
+				notLeaseholderErr,
+				rpcError,
+				notLeaseholderErr,
+			},
+			clusterSettingEnabled:   true,
+			exceedBackoffThreshold:  false,
+			withCommit:              false,
+			bypassCircuitBreakerReq: false,
+			// We expect a send error to be returned since we haven't passed the
+			// backoff threshold.
+			expectedErr: "sending to all replicas failed",
+		},
+		{
+			name: "all errors are leaseholder & rpc after backoff threshold",
+			errors: []transportSendNextError{
+				notLeaseholderErr,
+				rpcError,
+				notLeaseholderErr,
+			},
+			clusterSettingEnabled:   true,
+			exceedBackoffThreshold:  true,
+			withCommit:              false,
+			bypassCircuitBreakerReq: false,
+			// Since we only have NLHE and RPC errors, and we have passed the backoff
+			// threshold, expect that a RUE is returned.
+			expectedErr: "replica unavailable",
+		},
+		{
+			name: "not leaseholder and range not found error before backoff threshold",
+			errors: []transportSendNextError{
+				notLeaseholderErr,
+				notLeaseholderErr,
+				rangeNotFoundErr,
+			},
+			clusterSettingEnabled:   true,
+			exceedBackoffThreshold:  false,
+			withCommit:              false,
+			bypassCircuitBreakerReq: false,
+			// We expect a send error to be returned since we haven't passed the
+			// backoff threshold.
+			expectedErr: "sending to all replicas failed",
+		},
+		{
+			name: "not leaseholder and range not found error after backoff threshold",
+			errors: []transportSendNextError{
+				notLeaseholderErr,
+				notLeaseholderErr,
+				rangeNotFoundErr,
+			},
+			clusterSettingEnabled:   true,
+			exceedBackoffThreshold:  true,
+			withCommit:              false,
+			bypassCircuitBreakerReq: false,
+			// We expect a send error to be returned despite exceeding the backoff
+			// threshold since there is other than NLHE.
+			expectedErr: "sending to all replicas failed",
+		},
+		{
+			name: "ambiguous errors are returned before backoff threshold",
+			errors: []transportSendNextError{
+				rpcError,
+				rpcError,
+				notLeaseholderErr,
+			},
+			clusterSettingEnabled:   true,
+			exceedBackoffThreshold:  false,
+			withCommit:              true,
+			bypassCircuitBreakerReq: false,
+			// If there is an ambiguous error, we expect it to be returned regardless
+			// of the backoff threshold.
+			expectedErr: "result is ambiguous",
+		},
+		{
+			name: "ambiguous errors are returned after backoff threshold",
+			errors: []transportSendNextError{
+				rpcError,
+				rpcError,
+				notLeaseholderErr,
+			},
+			clusterSettingEnabled:   true,
+			exceedBackoffThreshold:  true,
+			withCommit:              true,
+			bypassCircuitBreakerReq: false,
+			// If there is an ambiguous error, we expect it to be returned regardless
+			// of the backoff threshold.
+			expectedErr: "result is ambiguous",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+
+			// Set up the manual clock and the request start time.
+			manual := hlc.NewHybridManualClock()
+			clock := hlc.NewClockForTesting(manual)
+			startTime := manual.Now()
+
+			st := cluster.MakeTestingClusterSettings()
+			EagerlyBailOnLeaseholderNotFound.Override(ctx, &st.SV, tc.clusterSettingEnabled)
+
+			// Gossip the two nodes referred to in testUserRangeDescriptor3Replicas.
+			rpcContext := rpc.NewInsecureTestingContext(ctx, clock, stopper)
+			g := makeGossip(t, stopper, rpcContext)
+			for i := 2; i <= 3; i++ {
+				nd := newNodeDesc(roachpb.NodeID(i))
+				if err :=
+					g.AddInfoProto(gossip.MakeNodeIDKey(roachpb.NodeID(i)), nd, time.Hour); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			// Prepare the range cache.
+			rc := rangecache.NewRangeCache(st, nil /* db */, func() int64 { return 100 }, stopper)
+			rc.Insert(ctx, roachpb.RangeInfo{
+				Desc:  initDescriptor,
+				Lease: initLease,
+			})
+
+			if tc.exceedBackoffThreshold {
+				manual.Increment(LeaseholderNotFoundBackoffThreshold.Get(&st.SV).Nanoseconds())
+			}
+
+			var count int
+			testFn := func(_ context.Context, args *kvpb.BatchRequest) (*kvpb.BatchResponse, error) {
+				// Assert that we don't get more errors than we expect.
+				require.True(t, count < len(tc.errors))
+
+				var reply *kvpb.BatchResponse
+				var err error
+				if tc.errors[count].err != nil {
+					err = tc.errors[count].err
+				}
+				if tc.errors[count].batchResponseError != nil {
+					reply = &kvpb.BatchResponse{}
+					reply.Error = tc.errors[count].batchResponseError
+				}
+				count++
+				return reply, err
+			}
+
+			cfg := DistSenderConfig{
+				AmbientCtx:        log.MakeTestingAmbientCtxWithNewTracer(),
+				Clock:             clock,
+				NodeDescs:         g,
+				Stopper:           stopper,
+				TransportFactory:  adaptSimpleTransport(testFn),
+				RangeDescriptorDB: threeReplicaMockRangeDescriptorDB,
+				Settings:          st,
+			}
+			ds := NewDistSender(cfg)
+
+			// Call sendToReplicas and expect the expected error to be returned.
+			ba := &kvpb.BatchRequest{}
+			ba.Add(kvpb.NewGet(roachpb.Key("a")))
+
+			if tc.bypassCircuitBreakerReq {
+				// Add a request that bypasses the circuit breaker.
+				var addReq kvpb.AddSSTableRequest
+				ba.Add(&addReq)
+			}
+
+			tok, err := rc.LookupWithEvictionToken(
+				ctx,
+				roachpb.RKeyMin,
+				rangecache.EvictionToken{},
+				false,
+			)
+			require.NoError(t, err)
+			_, err = ds.sendToReplicas(ctx, ba, tok, tc.withCommit, manual.Now().Sub(startTime))
+			pErr := kvpb.NewError(err)
+
+			require.NotNil(t, pErr)
+			require.True(t, testutils.IsPError(pErr, tc.expectedErr))
+		})
+	}
+}
+
 // TestRetryOnNotLeaseHolderError verifies that the DistSender correctly updates
 // the leaseholder in the range cache and retries when receiving a
 // NotLeaseHolderError.
@@ -3783,12 +4116,13 @@ func TestReplicaErrorsMerged(t *testing.T) {
 					Settings:         cluster.MakeTestingClusterSettings(),
 				}
 				ds := NewDistSender(cfg)
+				startTime := time.Now()
 
 				ba := &kvpb.BatchRequest{}
 				ba.Add(kvpb.NewGet(roachpb.Key("a")))
 				tok, err := rc.LookupWithEvictionToken(ctx, roachpb.RKeyMin, rangecache.EvictionToken{}, false)
 				require.NoError(t, err)
-				br, err := ds.sendToReplicas(ctx, ba, tok, tc.withCommit)
+				br, err := ds.sendToReplicas(ctx, ba, tok, tc.withCommit, time.Since(startTime))
 				log.Infof(ctx, "Error is %v", err)
 				require.ErrorContains(t, err, tc.expErr)
 				require.Nil(t, br)
@@ -5534,12 +5868,13 @@ func TestSendToReplicasSkipsStaleReplicas(t *testing.T) {
 				}
 
 				ds := NewDistSender(cfg)
+				startTime := time.Now()
 
 				ba := &kvpb.BatchRequest{}
 				get := &kvpb.GetRequest{}
 				get.Key = roachpb.Key("a")
 				ba.Add(get)
-				_, err = ds.sendToReplicas(ctx, ba, tok, false /* withCommit */)
+				_, err = ds.sendToReplicas(ctx, ba, tok, false /* withCommit */, time.Since(startTime))
 				require.IsType(t, &sendError{}, err)
 				require.Regexp(t, "NotLeaseHolderError", err)
 				cached, err := rc.TestingGetCached(ctx, tc.initialDesc.StartKey, false, roachpb.LAG_BY_CLUSTER_SETTING)

--- a/pkg/kv/kvclient/kvcoord/send_test.go
+++ b/pkg/kv/kvclient/kvcoord/send_test.go
@@ -258,6 +258,5 @@ func sendBatch(
 	})
 	routing, err := ds.getRoutingInfo(ctx, desc.StartKey, rangecache.EvictionToken{}, false /* useReverseScan */)
 	require.NoError(t, err)
-
-	return ds.sendToReplicas(ctx, &kvpb.BatchRequest{}, routing, false /* withCommit */)
+	return ds.sendToReplicas(ctx, &kvpb.BatchRequest{}, routing, false /* withCommit */, 0 /* curDuration */)
 }


### PR DESCRIPTION
This commit introduces a couple of cluster settings:
1) eagerly_bail_on_leaseholder_not_found: If enabled, it will return
a replica unavailable error if we couldn't find the leaseholder in
sendToReplicas, and we expect that the range in unavailable.
2) leaseholder_not_found_backoff.threshold: Controls the threshold that
we should backoff when we can't find the leaseholder before returning
a replica unavailable error.

This is useful to prevent the dist sender from spinning for a long time
if the range is unavailable. This is especially important for leader
leases as we reject lease proposals if we don't know who the leader is,
which makes it unlikely that the per-replica circuit breaker would trip.

Fixes: #139638

Release note: None