### PR TITLE
logictest: disable autocommit_before_ddl under 3node-tenant

### DIFF
--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -1684,6 +1684,16 @@ func (t *logicTest) newCluster(
 		tenantID := serverutils.TestTenantID()
 		conn := t.cluster.SystemLayer(0).SQLConn(t.rootT)
 
+		// TODO(rafi): Remove this setting. We're adding it since the 3node-tenant
+		// config seem to be flaky with autcommit_before_ddl = true. Disable that
+		// setting for multitenant configs while the issue is being investigated.
+		if _, err := conn.Exec(
+			"ALTER TENANT [$1] SET CLUSTER SETTING sql.defaults.autocommit_before_ddl.enabled = false",
+			tenantID.ToUint64(),
+		); err != nil {
+			t.Fatal(err)
+		}
+
 		clusterSettings := toa.clusterSettings
 		if len(clusterSettings) > 0 {
 			// We reduce the closed timestamp duration on the host tenant so that the

--- a/pkg/sql/logictest/testdata/logic_test/drop_index
+++ b/pkg/sql/logictest/testdata/logic_test/drop_index
@@ -339,13 +339,15 @@ fk1  CREATE TABLE public.fk1 (
 # test that notices are generated on index drops
 subtest notice_on_drop_index
 
+statement ok
+CREATE TABLE drop_index_test(a int);
+CREATE INDEX drop_index_test_index ON drop_index_test(a);
+
 # Weak isolation levels emit extra notices, so skip them.
 skipif config weak-iso-level-configs
 query T noticetrace
-CREATE TABLE drop_index_test(a int); CREATE INDEX drop_index_test_index ON drop_index_test(a); DROP INDEX drop_index_test_index
+DROP INDEX drop_index_test_index
 ----
-NOTICE: auto-committing transaction before processing DDL due to autocommit_before_ddl setting
-NOTICE: auto-committing transaction before processing DDL due to autocommit_before_ddl setting
 NOTICE: the data for dropped indexes is reclaimed asynchronously
 HINT: The reclamation delay can be customized in the zone configuration for the table.
 

--- a/pkg/sql/logictest/testdata/logic_test/txn
+++ b/pkg/sql/logictest/testdata/logic_test/txn
@@ -188,7 +188,7 @@ ROLLBACK TRANSACTION
 # COMMIT/ROLLBACK without a transaction are allowed when autocommit_before_ddl=true.
 
 statement ok
-RESET autocommit_before_ddl
+SET autocommit_before_ddl = true
 
 statement ok
 COMMIT TRANSACTION
@@ -207,7 +207,7 @@ SET TRANSACTION ISOLATION LEVEL REPEATABLE READ
 # Set isolation level without a transaction is a warning when autocommit_before_ddl=true.
 
 statement ok
-RESET autocommit_before_ddl
+SET autocommit_before_ddl = true
 
 query T noticetrace
 SET TRANSACTION ISOLATION LEVEL REPEATABLE READ
@@ -544,7 +544,7 @@ statement error pgcode 25P01 there is no transaction in progress
 SET TRANSACTION PRIORITY LOW
 
 statement ok
-RESET autocommit_before_ddl
+SET autocommit_before_ddl = true
 
 query T noticetrace
 SET TRANSACTION PRIORITY LOW


### PR DESCRIPTION
A recent change to the default value of this setting appears to have made many 3node-tenant tests flaky. This patch goes back to the old value for multitenant configs while we investigate.

informs https://github.com/cockroachdb/cockroach/issues/140162, https://github.com/cockroachdb/cockroach/issues/140163, https://github.com/cockroachdb/cockroach/issues/140170, https://github.com/cockroachdb/cockroach/issues/140172, #140183, #140182, #140173, #140171, #140168, #140164, 
Release note: None