### PR TITLE
sql: fix quoting of session settings in stmt bundle env.sql

### DIFF
--- a/pkg/sql/explain_bundle.go
+++ b/pkg/sql/explain_bundle.go
@@ -822,6 +822,8 @@ func init() {
 	binarySVForBundle = &st.SV
 }
 
+var anyWhitespace = regexp.MustCompile(`\s+`)
+
 // PrintSessionSettings appends information about all session variables that
 // differ from their defaults.
 //
@@ -900,7 +902,7 @@ func (c *stmtEnvCollector) PrintSessionSettings(w io.Writer, sv *settings.Values
 		if skip && !all {
 			continue
 		}
-		if _, ok := sessionVarNeedsEscaping[varName]; ok {
+		if _, ok := sessionVarNeedsEscaping[varName]; ok || anyWhitespace.MatchString(value) {
 			value = lexbase.EscapeSQLString(value)
 		}
 		if value == "" {


### PR DESCRIPTION
The values of session setting in the `env.sql` file of a statement
bundle are now wrapped in single quotes if they contain whitespace. The
statement bundle session setting tests have been updated to ensure that
`env.sql` is parsable.

Epic: None

Release note: None
