### PR TITLE
multiregionccl: deflake TestColdStartLatency

### DIFF
--- a/pkg/ccl/multiregionccl/cold_start_latency_test.go
+++ b/pkg/ccl/multiregionccl/cold_start_latency_test.go
@@ -171,6 +171,7 @@ func TestColdStartLatency(t *testing.T) {
 		} else {
 			stmts = []string{`
 BEGIN;
+SET LOCAL autocommit_before_ddl = false;
 ALTER DATABASE system PRIMARY REGION "us-east1";
 ALTER DATABASE system ADD REGION "us-west1";
 ALTER DATABASE system ADD REGION "europe-west1";


### PR DESCRIPTION
Similar to what we're seeing in
https://github.com/cockroachdb/cockroach/issues/140172 and the issues linked to https://github.com/cockroachdb/cockroach/pull/140187, this test is flaky due to running with autocommit_before_ddl=true in a multitenant setup.

fixes https://github.com/cockroachdb/cockroach/issues/140174
Release note: None