### PR TITLE
ui: update antd classname prefix to `crdb-ant`

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/activeExecutions/refreshControl/refreshControl.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/activeExecutions/refreshControl/refreshControl.module.scss
@@ -21,7 +21,7 @@
   margin-right: 12px;
 }
 
-.crl-ant-switch-checked {
+.crdb-ant-switch-checked {
   background-color: $colors--primary-blue-3;
 }
 

--- a/pkg/ui/workspaces/cluster-ui/src/common/styles.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/common/styles.module.scss
@@ -7,25 +7,25 @@
 
 .cockroach--tabs {
   overflow: visible !important;
-  :global(.crl-ant-tabs-bar) {
+  :global(.crdb-ant-tabs-bar) {
     border-bottom: 1px solid $grey2;
   }
 
-  :global(.crl-ant-tabs-tab) {
+  :global(.crdb-ant-tabs-tab) {
     font-family: $font-family--base;
     letter-spacing: normal;
     color: $colors--neutral-7;
   }
 
-  :global(.crl-ant-tabs-nav .crl-ant-tabs-tab-active) {
+  :global(.crdb-ant-tabs-nav .crdb-ant-tabs-tab-active) {
     color: $colors--link;
   }
 
-  :global(.crl-ant-tabs-nav .crl-ant-tabs-tab:hover) {
+  :global(.crdb-ant-tabs-nav .crdb-ant-tabs-tab:hover) {
     color: $colors--link;
   }
 
-  :global(.crl-ant-tabs-ink-bar) {
+  :global(.crdb-ant-tabs-ink-bar) {
     height: 3px;
     border-radius: 40px;
     background-color: $blue;

--- a/pkg/ui/workspaces/cluster-ui/src/components/regionNodesLabel/components/regionLabel.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/components/regionNodesLabel/components/regionLabel.module.scss
@@ -27,7 +27,7 @@
 }
 
 .badge {
-  :global(.crl-ant-badge-count) {
+  :global(.crdb-ant-badge-count) {
     background-color: $colors--neutral-1;
     font-size: 12px;
     height: 20px;

--- a/pkg/ui/workspaces/cluster-ui/src/dateRangeMenu/dateRangeMenu.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/dateRangeMenu/dateRangeMenu.module.scss
@@ -16,7 +16,7 @@
     padding-bottom: 10px;
 
     a {
-      // Matches the color of .crl-ant-dropdown, needed to override default anchor color. A cleaner way would be to install
+      // Matches the color of .crdb-ant-dropdown, needed to override default anchor color. A cleaner way would be to install
       // and set up antd-scss-theme-plugin, and use the antd text-color variable.
       color: rgba(0, 0, 0, 0.65);
     }
@@ -30,7 +30,7 @@
     height: 12px;
   }
 
-  :global(.crl-ant-picker) {
+  :global(.crdb-ant-picker) {
     margin-right: 14px;
   }
 }

--- a/pkg/ui/workspaces/cluster-ui/src/jobs/jobs.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/jobs/jobs.module.scss
@@ -146,7 +146,7 @@
     font-size: $font-size--medium;
     display: flex;
     align-items: center;
-    .crl-ant-divider {
+    .crdb-ant-divider {
       height: 20px;
     }
   }
@@ -166,7 +166,7 @@
   .job-status__line--percentage {
     display: flex;
     align-items: center;
-    .crl-ant-divider {
+    .crdb-ant-divider {
       height: 20px;
     }
     span {
@@ -178,7 +178,7 @@
       margin: 0;
     }
   }
-  .crl-ant-divider {
+  .crdb-ant-divider {
     margin-left: 15px;
     margin-right: 15px;
   }

--- a/pkg/ui/workspaces/cluster-ui/src/modal/modal.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/modal/modal.module.scss
@@ -8,24 +8,24 @@
 .crl-modal {
   @include base;
   :global {
-    .crl-ant-modal-footer {
+    .crdb-ant-modal-footer {
       border-top: none;
       padding: 0;
       margin-top: $spacing-large;
     }
 
-    .crl-ant-modal-header {
+    .crdb-ant-modal-header {
       margin-bottom: $spacing-medium-small;
     }
 
-    .crl-ant-modal-content {
+    .crdb-ant-modal-content {
       padding: $spacing-large;
       box-shadow: 0px 0px 1px rgba(71, 88, 114, 0.47);
       border-radius: 5px;
       min-width: 560px;
     }
 
-    .crl-ant-modal-close {
+    .crdb-ant-modal-close {
       top: $spacing-large;
     }
   }

--- a/pkg/ui/workspaces/cluster-ui/src/schedules/schedules.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/schedules/schedules.module.scss
@@ -154,7 +154,7 @@
     font-size: $font-size--medium;
     display: flex;
     align-items: center;
-    .crl-ant-divider {
+    .crdb-ant-divider {
       height: 20px;
     }
   }
@@ -174,7 +174,7 @@
   .schedule-status__line--percentage {
     display: flex;
     align-items: center;
-    .crl-ant-divider {
+    .crdb-ant-divider {
       height: 20px;
     }
     span {
@@ -186,7 +186,7 @@
       margin: 0;
     }
   }
-  .crl-ant-divider {
+  .crdb-ant-divider {
     margin-left: 15px;
     margin-right: 15px;
   }

--- a/pkg/ui/workspaces/cluster-ui/src/search/search.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/search/search.module.scss
@@ -14,7 +14,7 @@
   margin: 2px;
 }
 
-:global(.crl-ant-input-affix-wrapper:not(.crl-ant-input-affix-wrapper-disabled):focus-within) {
+:global(.crdb-ant-input-affix-wrapper:not(.crdb-ant-input-affix-wrapper-disabled):focus-within) {
   outline: 2px solid $colors--primary-blue-3;
 }
 

--- a/pkg/ui/workspaces/cluster-ui/src/searchCriteria/searchCriteria.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/searchCriteria/searchCriteria.module.scss
@@ -5,15 +5,15 @@
 
 @import "../core/index.module";
 
-:global(.crl-ant-dropdown-menu-submenu-popup ul) {
+:global(.crdb-ant-dropdown-menu-submenu-popup ul) {
   padding-bottom: 5px;
 }
 
-:global(.crl-ant-dropdown-menu-item:hover) {
+:global(.crdb-ant-dropdown-menu-item:hover) {
   background-color: $colors--primary-blue-8;
 }
 
-:global(.crl-ant-dropdown-menu-submenu-title:hover) {
+:global(.crdb-ant-dropdown-menu-submenu-title:hover) {
   background-color: $colors--primary-blue-8;
 }
 
@@ -39,7 +39,7 @@
     font-size: $font-size--medium;
     font-weight: $font-weight--light;
 
-    :global(.crl-ant-btn) {
+    :global(.crdb-ant-btn) {
       border-color: $colors--neutral-4;
     }
   }

--- a/pkg/ui/workspaces/cluster-ui/src/sharedFromCloud/skeleton.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/sharedFromCloud/skeleton.module.scss
@@ -10,7 +10,7 @@
   overflow: hidden;
   width: fit-content;
 
-  :global(.crl-ant-skeleton-element) {
+  :global(.crdb-ant-skeleton-element) {
     height: 100%;
     width: 100%;
   }

--- a/pkg/ui/workspaces/cluster-ui/src/sharedFromCloud/table.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/sharedFromCloud/table.scss
@@ -79,18 +79,18 @@
     padding-bottom: crl-gutters(1);
   }
 
-  .crl-ant-table-thead {
+  .crdb-ant-table-thead {
     > tr > th {
       border-bottom: crl-borders();
 
       &.crl-table__column--with-sorter-tooltip {
-        .crl-ant-table-column-title {
+        .crdb-ant-table-column-title {
           text-decoration: underline dashed $color-core-neutral-4;
           text-underline-offset: 4px;
         }
       }
 
-      &.crl-ant-table-cell {
+      &.crdb-ant-table-cell {
         padding: crl-gutters(2.5) crl-gutters(2) crl-gutters(1);
         @include crl-type-body--strong;
       }
@@ -99,15 +99,15 @@
         text-align: right;
       }
 
-      .crl-ant-table-column-sorters {
+      .crdb-ant-table-column-sorters {
         padding: 0;
 
-        > span:not(.crl-ant-table-column-sorter-full) {
+        > span:not(.crdb-ant-table-column-sorter-full) {
           @include crl-type-body--strong;
         }
       }
 
-      .crl-ant-table-column-sorter {
+      .crdb-ant-table-column-sorter {
         margin-left: 5px;
 
         &-inner-full {
@@ -117,7 +117,7 @@
     }
   }
 
-  .crl-ant-table-tbody {
+  .crdb-ant-table-tbody {
     > tr {
       &:last-child {
         > td {
@@ -142,17 +142,17 @@
     }
   }
 
-  .crl-ant-table-wrapper {
+  .crdb-ant-table-wrapper {
     height: 100%;
     overflow: auto;
   }
 
-  .crl-ant-table-column-title {
+  .crdb-ant-table-column-title {
     padding: 0;
     @include crl-type-body--strong;
   }
 
-  .crl-ant-table .crl-ant-table-row-indent + .crl-ant-table-row-expand-icon {
+  .crdb-ant-table .crdb-ant-table-row-indent + .crdb-ant-table-row-expand-icon {
     margin-right: crl-gutters(1.5);
   }
 
@@ -162,11 +162,11 @@
   &--darkmode {
     background: $color-core-neutral-8;
 
-    .crl-ant-table {
+    .crdb-ant-table {
       background: $color-core-neutral-8;
     }
 
-    .crl-ant-table-thead {
+    .crdb-ant-table-thead {
       > tr {
         &:hover {
           > th {
@@ -177,11 +177,11 @@
         > th {
           background: $color-core-neutral-8;
 
-          &.crl-ant-table-column-sort {
+          &.crdb-ant-table-column-sort {
             background: $color-core-neutral-8;
           }
 
-          &.crl-ant-table-cell {
+          &.crdb-ant-table-cell {
             color: $color-base-white;
             span {
               color: $color-base-white;
@@ -195,7 +195,7 @@
       }
     }
 
-    .crl-ant-table-tbody {
+    .crdb-ant-table-tbody {
       > tr {
         &:hover {
           > td {
@@ -206,7 +206,7 @@
         > td {
           color: $color-base-white;
 
-          &.crl-ant-table-column-sort {
+          &.crdb-ant-table-column-sort {
             background: $color-core-neutral-8;
           }
 
@@ -217,28 +217,28 @@
       }
     }
 
-    .crl-ant-table-cell-row-hover {
+    .crdb-ant-table-cell-row-hover {
       background: $color-core-neutral-7;
     }
 
-    .crl-ant-pagination {
-      .crl-ant-pagination-item {
+    .crdb-ant-pagination {
+      .crdb-ant-pagination-item {
         a {
           color: $color-base-white;
         }
       }
 
-      .crl-ant-pagination-item-container {
-        .crl-ant-pagination-item-ellipsis {
+      .crdb-ant-pagination-item-container {
+        .crdb-ant-pagination-item-ellipsis {
           color: $color-base-white;
         }
       }
 
-      .crl-ant-pagination-item-link {
+      .crdb-ant-pagination-item-link {
         color: $color-base-white;
       }
 
-      .crl-ant-pagination-item-active {
+      .crdb-ant-pagination-item-active {
         background-color: $color-core-neutral-7;
       }
     }
@@ -250,14 +250,14 @@
     padding: 0; // Remove padding added by cockroach container;
   }
 
-  .crl-ant-table-content {
+  .crdb-ant-table-content {
     padding: 5px; // Allows the box shadow to take effect on Right/Left/Bottom
   }
 
   // Use very specific .crl-table selectors to override selectors in AntD without the use
   // of !important tags.
-  .crl-table .crl-ant-table-thead {
-    & > tr > .crl-ant-table-cell {
+  .crl-table .crdb-ant-table-thead {
+    & > tr > .crdb-ant-table-cell {
       padding-bottom: 0; // Only remove the padding in the header row;
       border-bottom: 0;
     }
@@ -269,7 +269,7 @@
     }
   }
 
-  .crl-table .crl-ant-table-tbody {
+  .crl-table .crdb-ant-table-tbody {
     outline: 1px solid $color-core-neutral-3;
     border-radius: $crl-border-radius;
 
@@ -289,12 +289,12 @@
     }
   }
 
-  .crl-table .crl-ant-table-expanded-row > td {
+  .crl-table .crdb-ant-table-expanded-row > td {
     padding: 0; // Remove default padding of an expanded row. This is the padding for the inner table.
   }
 
   // Note: "!important" is necessary here due to an enormous selector on AntD's side.
-  .crl-ant-table-cell::before {
+  .crdb-ant-table-cell::before {
     width: 0 !important; // Remove a border line between cells without a sorter.
   }
 
@@ -303,7 +303,7 @@
   // an expanded row, when the "+" button is clicked.
   //
   // Note: "!important" is necessary here due to table.scss having one.
-  .crl-table .crl-ant-table-tbody > .expanded-row > td {
+  .crl-table .crdb-ant-table-tbody > .expanded-row > td {
     background-color: $color-core-neutral-2 !important;
   }
 }
@@ -316,23 +316,23 @@
     padding: 0; // Remove padding added by cockroach container;
   }
 
-  .crl-table .crl-ant-table-content {
+  .crl-table .crdb-ant-table-content {
     padding: 0 crl-gutters(2) crl-gutters(2) crl-gutters(2);
     background-color: $color-core-neutral-1;
   }
 
-  .crl-table .crl-ant-table-tbody {
+  .crl-table .crdb-ant-table-tbody {
     outline: 0;
 
-    .crl-ant-table-cell {
+    .crdb-ant-table-cell {
       // Ensure that the inner table remains the same background on hover.
       // Note: "!important" is necessary here due to table.scss having one.
       background: $color-core-neutral-1 !important;
     }
   }
 
-  .crl-table .crl-ant-table-thead {
-    .crl-ant-table-cell {
+  .crl-table .crdb-ant-table-thead {
+    .crdb-ant-table-cell {
       // Ensure that the inner table remains the same background on hover.
       background: $color-core-neutral-1 !important;
       transition: background-color 0.3s; // Copy AntD background transition;

--- a/pkg/ui/workspaces/cluster-ui/src/sql/sqlhighlight.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/sql/sqlhighlight.module.scss
@@ -66,12 +66,12 @@
   margin: 15px 0;
 }
 
-:global(.crl-ant-tooltip) {
+:global(.crdb-ant-tooltip) {
   &:global(.hljs) {
-    &:global(.crl-ant-tooltip-content) {
+    &:global(.crdb-ant-tooltip-content) {
       width: 535px;
     }
-    &:global(.crl-ant-tooltip-inner) {
+    &:global(.crdb-ant-tooltip-inner) {
       background-color: $colors--neutral-8;
       padding: 8px;
     }

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementTypeSelect.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementTypeSelect.module.scss
@@ -53,16 +53,16 @@
   transform: scaleY(0);
 }
 
-:global(.crl-ant-radio) {
+:global(.crdb-ant-radio) {
   top: 0;
 }
 
-:global(.crl-ant-radio-checked .crl-ant-radio-inner) {
+:global(.crdb-ant-radio-checked .crdb-ant-radio-inner) {
   background-color: $colors--link;
   border-color: $colors--link;
 }
 
-:global(.crl-ant-radio-checked .crl-ant-radio-inner::after) {
+:global(.crdb-ant-radio-checked .crdb-ant-radio-inner::after) {
   background-color: white;
   height: 6px;
   width: 6px;

--- a/pkg/ui/workspaces/cluster-ui/src/table/table.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/table/table.module.scss
@@ -7,17 +7,17 @@
 @import "src/sortedtable/tableHead/tableHead.module";
 
 .crl-table-wrapper {
-  :global(.crl-ant-table) {
+  :global(.crdb-ant-table) {
     color: $colors--primary-text;
   }
 
   // Table header
-  :global(.crl-ant-table-thead) {
+  :global(.crdb-ant-table-thead) {
     @include table-header-text;
     background-color: $colors--neutral-0;
   }
 
-  :global(.crl-ant-table-thead) > tr > th {
+  :global(.crdb-ant-table-thead) > tr > th {
     color: $colors--neutral-7;
     background-color: $colors--neutral-0;
     padding: $spacing-smaller $spacing-smaller;
@@ -27,14 +27,14 @@
       @include table-header-text;
     }
     :global {
-      .crl-ant-table-header-column .crl-ant-table-column-sorters:hover::before {
+      .crdb-ant-table-header-column .crdb-ant-table-column-sorters:hover::before {
         background-color: $colors--neutral-0;
       }
     }
   }
 
   // Sorter icons on table's header
-  :global(.crl-ant-table-thead .crl-ant-table-column-sorter-inner .anticon) {
+  :global(.crdb-ant-table-thead .crdb-ant-table-column-sorter-inner .anticon) {
     display: flex;
     color: $colors--neutral-4;
     transform: scale(0.91666667) rotate(0deg);
@@ -53,57 +53,57 @@
   // END: Table Column
 
   // Table row
-  :global(.crl-ant-table-row) {
+  :global(.crdb-ant-table-row) {
     @include text--body;
     height: $line-height--xxx-large;
   }
 
-  :global(.crl-ant-table-row) .cell--show-on-hover {
+  :global(.crdb-ant-table-row) .cell--show-on-hover {
     visibility: hidden;
   }
 
-  :global(.crl-ant-table-row):hover .cell--show-on-hover {
+  :global(.crdb-ant-table-row):hover .cell--show-on-hover {
     visibility: visible;
   }
   // END: Table row
 
   // Table cell
-  :global(.crl-ant-table-tbody) > tr > td {
+  :global(.crdb-ant-table-tbody) > tr > td {
     padding: $spacing-smaller $spacing-smaller;
     border-bottom-color: $colors--neutral-3;
   }
 
   // Increase right padding for columns aligned by right
-  :global(.crl-ant-table-tbody) > tr > td.column--align-right {
+  :global(.crdb-ant-table-tbody) > tr > td.column--align-right {
     padding-right: $spacing-mid-large;
   }
 
   // show column with right border
-  :global(.crl-ant-table-tbody) > tr > td.column--border-right {
+  :global(.crdb-ant-table-tbody) > tr > td.column--border-right {
     border-right: $colors--neutral-3 solid 1px;
   }
   // END: Table cell
 
   // Table cell on hover
   :global {
-    .crl-ant-table-thead
-      > tr.crl-ant-table-row-hover:not(.crl-ant-table-expanded-row):not(.crl-ant-table-row-selected)
+    .crdb-ant-table-thead
+      > tr.crdb-ant-table-row-hover:not(.crdb-ant-table-expanded-row):not(.crdb-ant-table-row-selected)
       > td,
-    .crl-ant-table-tbody
-      > tr.crl-ant-table-row-hover:not(.crl-ant-table-expanded-row):not(.crl-ant-table-row-selected)
+    .crdb-ant-table-tbody
+      > tr.crdb-ant-table-row-hover:not(.crdb-ant-table-expanded-row):not(.crdb-ant-table-row-selected)
       > td,
-    .crl-ant-table-thead
-      > tr:hover:not(.crl-ant-table-expanded-row):not(.crl-ant-table-row-selected)
+    .crdb-ant-table-thead
+      > tr:hover:not(.crdb-ant-table-expanded-row):not(.crdb-ant-table-row-selected)
       > td,
-    .crl-ant-table-tbody
-      > tr:hover:not(.crl-ant-table-expanded-row):not(.crl-ant-table-row-selected)
+    .crdb-ant-table-tbody
+      > tr:hover:not(.crdb-ant-table-expanded-row):not(.crdb-ant-table-row-selected)
       > td {
       background: $colors--neutral-1;
     }
   }
   // END: Table cell on hover
 
-  :global(.crl-ant-table-placeholder) {
+  :global(.crdb-ant-table-placeholder) {
     border: $colors--neutral-1 solid 1px;
   }
 
@@ -113,7 +113,7 @@
   }
 
   &__empty {
-    :global(.crl-ant-table-placeholder) {
+    :global(.crdb-ant-table-placeholder) {
       border: none;
     }
   }

--- a/pkg/ui/workspaces/cluster-ui/src/timeScaleDropdown/rangeSelector.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/timeScaleDropdown/rangeSelector.module.scss
@@ -182,17 +182,17 @@
       align-items: center;
     }
   }
-  .crl-ant-fullcalendar-calendar-body {
+  .crdb-ant-fullcalendar-calendar-body {
     padding: 8px 16px;
-    .crl-ant-fullcalendar-column-header {
+    .crdb-ant-fullcalendar-column-header {
       font-family: $font-family--bold;
       font-size: 12px;
       line-height: 2;
       letter-spacing: 0.1px;
     }
-    .crl-ant-fullcalendar-tbody {
-      .crl-ant-fullcalendar-cell {
-        .crl-ant-fullcalendar-value {
+    .crdb-ant-fullcalendar-tbody {
+      .crdb-ant-fullcalendar-cell {
+        .crdb-ant-fullcalendar-value {
           width: 24px;
           height: 24px;
           display: flex;
@@ -209,8 +209,8 @@
             background: $background-color;
           }
         }
-        &.crl-ant-fullcalendar-selected-day {
-          .crl-ant-fullcalendar-value {
+        &.crdb-ant-fullcalendar-selected-day {
+          .crdb-ant-fullcalendar-value {
             background: $colors--primary-blue-1;
             color: $colors--primary-blue-3;
             &:hover {
@@ -219,10 +219,10 @@
             }
           }
         }
-        &.crl-ant-fullcalendar-disabled-cell {
+        &.crdb-ant-fullcalendar-disabled-cell {
           background: $background-color;
           color: $colors--neutral-5;
-          .crl-ant-fullcalendar-value {
+          .crdb-ant-fullcalendar-value {
             background: $background-color;
             color: $colors--neutral-5;
           }
@@ -231,11 +231,11 @@
             color: $colors--neutral-5;
           }
         }
-        &.crl-ant-fullcalendar-today {
+        &.crdb-ant-fullcalendar-today {
           &:hover {
             background: transparent;
           }
-          .crl-ant-fullcalendar-value {
+          .crdb-ant-fullcalendar-value {
             width: 24px;
             height: 24px;
             box-shadow: none;
@@ -246,19 +246,19 @@
               background: $colors--primary-blue-1;
             }
           }
-          &.crl-ant-fullcalendar-selected-day {
-            .crl-ant-fullcalendar-value {
+          &.crdb-ant-fullcalendar-selected-day {
+            .crdb-ant-fullcalendar-value {
               background: $colors--primary-blue-1;
               &:hover {
                 background: #e0efff;
               }
             }
           }
-          &.crl-ant-fullcalendar-disabled-cell {
+          &.crdb-ant-fullcalendar-disabled-cell {
             &:hover {
               background: $background-color;
             }
-            .crl-ant-fullcalendar-value {
+            .crdb-ant-fullcalendar-value {
               font-family: $font-family--bold;
               color: $colors--neutral-5;
               background: $background-color;

--- a/pkg/ui/workspaces/cluster-ui/src/timeScaleDropdown/timeFrameControls.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/timeScaleDropdown/timeFrameControls.module.scss
@@ -41,7 +41,7 @@
     }
   }
 
-  :global(.crl-ant-btn-group) {
+  :global(.crdb-ant-btn-group) {
     display: flex;
     flex-direction: row;
     ._action,

--- a/pkg/ui/workspaces/db-console/src/app.tsx
+++ b/pkg/ui/workspaces/db-console/src/app.tsx
@@ -119,8 +119,8 @@ export const App: React.FC<AppProps> = (props: AppProps) => {
           <TimezoneProvider>
             {/* Apply CRL theme twice, with ConfigProvider instance from Db Console and
              imported instance from Cluster UI as it applies theme imported components only. */}
-            <ClusterUIConfigProvider theme={crlTheme} prefixCls={"crl-ant"}>
-              <ConfigProvider theme={crlTheme} prefixCls={"crl-ant"}>
+            <ClusterUIConfigProvider theme={crlTheme} prefixCls={"crdb-ant"}>
+              <ConfigProvider theme={crlTheme} prefixCls={"crdb-ant"}>
                 <Switch>
                   {/* login */}
                   {createLoginRoute()}

--- a/pkg/ui/workspaces/db-console/src/components/modal/modal.styl
+++ b/pkg/ui/workspaces/db-console/src/components/modal/modal.styl
@@ -6,16 +6,16 @@
 @require '~src/components/core/index.styl'
 
 .crl-modal
-  .crl-ant-modal-footer
+  .crdb-ant-modal-footer
     border-top none
     padding 0
 
-  .crl-ant-modal-header
+  .crdb-ant-modal-header
     border-bottom none
     padding-top unset
     padding-bottom unset
 
-  .crl-ant-modal-content
+  .crdb-ant-modal-content
     padding $spacing-medium
     box-shadow 0px 0px 1px rgba(71, 88, 114, 0.47)
     border-radius 5px

--- a/pkg/ui/workspaces/db-console/src/components/select/select.styl
+++ b/pkg/ui/workspaces/db-console/src/components/select/select.styl
@@ -13,15 +13,15 @@
     color $colors--link
     font-weight $font-weight--bold
     letter-spacing $letter-spacing--compact
-    & > .crl-ant-select-selection
+    & > .crdb-ant-select-selection
       border none
-      & > .crl-ant-select-arrow
+      & > .crdb-ant-select-arrow
         font-size $spacing-base
         color $colors--link
         top 18px
-      & > .crl-ant-select-selection__rendered
+      & > .crdb-ant-select-selection__rendered
         margin-right $spacing-large
-    & > .crl-ant-select-selection:focus
+    & > .crdb-ant-select-selection:focus
       outline-style none
       box-shadow none
       border-color transparent

--- a/pkg/ui/workspaces/db-console/src/components/tooltip/tooltip.styl
+++ b/pkg/ui/workspaces/db-console/src/components/tooltip/tooltip.styl
@@ -6,21 +6,21 @@
 @require '~src/components/core/index.styl'
 
 .tooltip-overlay
-  .crl-ant-tooltip-content
-    .crl-ant-tooltip-inner
+  .crdb-ant-tooltip-content
+    .crdb-ant-tooltip-inner
       @extend $text--body
       line-height $line-height--small
       padding $spacing-x-small $spacing-small
       color $colors--white
       background $colors--neutral-8
-    .crl-ant-tooltip-arrow
+    .crdb-ant-tooltip-arrow
       color $colors--neutral-8
 
 .tooltip-overlay.crl-tooltip--theme-blue
-  .crl-ant-tooltip-content
-    .crl-ant-tooltip-inner
+  .crdb-ant-tooltip-content
+    .crdb-ant-tooltip-inner
       background $colors--neutral-6
-    .crl-ant-tooltip-arrow
+    .crdb-ant-tooltip-arrow
       color $colors--neutral-6
 
 .tooltip__table--title

--- a/pkg/ui/workspaces/db-console/src/views/app/components/Search/search.module.styl
+++ b/pkg/ui/workspaces/db-console/src/views/app/components/Search/search.module.styl
@@ -9,13 +9,13 @@
 ._search-form
   width 280px
   height 40px
-  :global(.crl-ant-input-affix-wrapper)
+  :global(.crdb-ant-input-affix-wrapper)
     height 40px
     &:hover
-      :global(.crl-ant-input:not(.crl-ant-input-disabled))
+      :global(.crdb-ant-input:not(.crdb-ant-input-disabled))
         border-color $adminui-blue-1-base
         border-right-width 2px !important
-  :global(.crl-ant-btn)
+  :global(.crdb-ant-btn)
     margin 0
     padding 0
     width auto
@@ -40,7 +40,7 @@
     line-height 0px !important
     &:hover
       color $adminui-grey-2
-  :global(.crl-ant-input)
+  :global(.crdb-ant-input)
     font-size 14px
     font-family $font-family--base
     color $adminui-grey-1
@@ -56,6 +56,6 @@
       padding-left 35px
       padding-right 60px
   ._submitted
-    :global(.crl-ant-input)
+    :global(.crdb-ant-input)
       &:not(:first-child)
         padding-right 40px

--- a/pkg/ui/workspaces/db-console/src/views/app/components/modal/styles.styl
+++ b/pkg/ui/workspaces/db-console/src/views/app/components/modal/styles.styl
@@ -11,20 +11,20 @@
   background-color $colors--white
   padding 0
   min-width 905px
-  .crl-ant-modal-close-x
+  .crdb-ant-modal-close-x
     font-size 14px
     color $colors--neutral-8
-  .crl-ant-modal-footer
+  .crdb-ant-modal-footer
     display flex
     justify-content flex-end
     border-top none
     padding 0 24px 24px
-  .crl-ant-modal-header
+  .crdb-ant-modal-header
     border-bottom none
     padding 24px 24px 0
-  .crl-ant-modal-body
+  .crdb-ant-modal-body
     padding 0 24px 11px
-  .crl-ant-modal-title
+  .crdb-ant-modal-title
     font-family SourceSansPro-Regular
     font-size 20px
     line-height 1.6

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodesOverview/nodes.styl
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodesOverview/nodes.styl
@@ -40,5 +40,5 @@
 .nodes-overview__panel .crl-table-wrapper .nodes-table__link
   color $colors--link
 
-.nodes-overview__panel .crl-table-wrapper .crl-ant-table-row:hover .nodes-table__link
+.nodes-overview__panel .crl-table-wrapper .crdb-ant-table-row:hover .nodes-table__link
   text-decoration underline

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/network/filter/filter.styl
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/network/filter/filter.styl
@@ -21,24 +21,24 @@
 
 .select__container
   width 100%
-  .crl-ant-select
+  .crdb-ant-select
     margin-bottom 18px
-  .crl-ant-select-selection--single
+  .crdb-ant-select-selection--single
     height 40px
     display flex
     justify-content flex-start
     align-items center
-  .crl-ant-select-selection--single .crl-ant-select-selection__rendered
+  .crdb-ant-select-selection--single .crdb-ant-select-selection__rendered
     width 100%
-  .crl-ant-select-selection__placeholder
+  .crdb-ant-select-selection__placeholder
     font-family SourceSansPro-Regular
     font-size 14px
     line-height 1.57
     letter-spacing 0.1px
     color $colors--neutral-6
-  .crl-ant-select-arrow
+  .crdb-ant-select-arrow
     color #475872
-  .crl-ant-select-selection
+  .crdb-ant-select-selection
     &:hover
       border-color $colors--primary-blue-3
     &:focus, &:active

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/network/latency/latency.styl
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/network/latency/latency.styl
@@ -79,12 +79,12 @@
   padding: 30px;
 
 
-.crl-ant-tooltip.Chip--tooltip
+.crdb-ant-tooltip.Chip--tooltip
   min-width 384px
-  .crl-ant-tooltip-inner
+  .crdb-ant-tooltip-inner
     background-color black
     padding 12px 18px
-  .crl-ant-tooltip-content
+  .crdb-ant-tooltip-content
     width 100%
   span, p
     font-family $font-family--base
@@ -103,7 +103,7 @@
         margin-right 8px
       &:last-child
         margin-left 8px
-    .crl-ant-divider
+    .crdb-ant-divider
       background #3b4a60
       margin 0
     &--item-title, &--item-description

--- a/pkg/ui/workspaces/db-console/src/views/shared/components/alertMessage/alertMessage.styl
+++ b/pkg/ui/workspaces/db-console/src/views/shared/components/alertMessage/alertMessage.styl
@@ -25,11 +25,11 @@
     margin-inline-start 4px
     margin-inline-end 12px
 
-  .crl-ant-alert-message
+  .crdb-ant-alert-message
     @extends $text--body-strong
     color $colors--neutral-8
 
-  .crl-ant-alert-close-icon
+  .crdb-ant-alert-close-icon
     font-weight $font-weight--extra-bold
     align-self start
     margin-top 8px
@@ -37,5 +37,5 @@
       color $colors--neutral-7
 
 
-.crl-ant-alert-success .alert-massage__icon
+.crdb-ant-alert-success .alert-massage__icon
   color $colors--primary-green-3

--- a/pkg/ui/workspaces/db-console/src/views/shared/components/drawer/drawer.module.styl
+++ b/pkg/ui/workspaces/db-console/src/views/shared/components/drawer/drawer.module.styl
@@ -38,7 +38,7 @@
   ::-webkit-scrollbar-thumb:hover {
     background #5f6c87ad
   }
-  :global(.crl-ant-divider)
+  :global(.crdb-ant-divider)
     width 1px
     background #5f6c87
     margin: 0 15px
@@ -53,21 +53,21 @@
       letter-spacing 0.1px
       &:hover
         color #5f6c87
-  :global(.crl-ant-drawer-content)
+  :global(.crdb-ant-drawer-content)
     overflow auto
-  :global(.crl-ant-drawer-mask)
+  :global(.crdb-ant-drawer-mask)
     background-color transparent
-  :global(.crl-ant-drawer-content-wrapper)
+  :global(.crdb-ant-drawer-content-wrapper)
     padding-left 80px
     box-shadow none !important
-  :global(.crl-ant-drawer-content)
+  :global(.crdb-ant-drawer-content)
     background #242a35
-  :global(.crl-ant-drawer-header)
+  :global(.crdb-ant-drawer-header)
     padding 15px 0
     margin 0 24px
     background transparent
     border-bottom: 1px solid #5f6c87;
-  :global(.crl-ant-drawer-body)
+  :global(.crdb-ant-drawer-body)
     padding 15px 20px
     margin 0 4px
     height 190px

--- a/pkg/ui/workspaces/db-console/src/views/shared/components/sql/sqlhighlight.module.styl
+++ b/pkg/ui/workspaces/db-console/src/views/shared/components/sql/sqlhighlight.module.styl
@@ -37,12 +37,12 @@
   :global(.hljs-built_in)
     color $colors--functional-orange-3
 
-:global(.crl-ant-tooltip):global(.hljs)
-  :global(.crl-ant-tooltip-content)
+:global(.crdb-ant-tooltip):global(.hljs)
+  :global(.crdb-ant-tooltip-content)
     width 535px
-  :global(.crl-ant-tooltip-inner), .sql-highlight:global(.hljs)
+  :global(.crdb-ant-tooltip-inner), .sql-highlight:global(.hljs)
     background-color $colors--neutral-8
-  :global(.crl-ant-tooltip-inner)
+  :global(.crdb-ant-tooltip-inner)
     padding 8px
   .sql-highlight:global(.hljs)
     padding 0

--- a/pkg/ui/workspaces/db-console/src/views/shared/components/toolTip/tooltip.module.styl
+++ b/pkg/ui/workspaces/db-console/src/views/shared/components/toolTip/tooltip.module.styl
@@ -6,7 +6,7 @@
 @require '~src/components/core/index.styl'
 
 .tooltip-wrapper
-  :global(.crl-ant-tooltip-arrow)
+  :global(.crdb-ant-tooltip-arrow)
     width 20px
     height 20px
     &::before
@@ -16,9 +16,9 @@
       border: solid 1px #e7ecf3;
       box-shadow: none;
 
-:global(.crl-ant-tooltip).tooltip__preset--white
+:global(.crdb-ant-tooltip).tooltip__preset--white
   max-width 500px
-  :global(.crl-ant-tooltip-inner)
+  :global(.crdb-ant-tooltip-inner)
     padding 10px
     border-radius 3px
     border solid 1px $colors--neutral-2

--- a/pkg/ui/workspaces/db-console/src/views/statements/statements.styl
+++ b/pkg/ui/workspaces/db-console/src/views/statements/statements.styl
@@ -376,5 +376,5 @@ $plan-node-warning-background-color = rgba(209, 135, 55, 0.06)  // light orange
 
 .cl-table-link__statement-tooltip--fixed-width
   max-width max-content
-  .crl-ant-tooltip-content
+  .crdb-ant-tooltip-content
     max-width 500px

--- a/pkg/ui/workspaces/db-console/src/views/statements/statementsTableContent.module.styl
+++ b/pkg/ui/workspaces/db-console/src/views/statements/statementsTableContent.module.styl
@@ -15,7 +15,7 @@
 
 .cl-table-link__statement-tooltip--fixed-width
   max-width max-content
-  :global(.crl-ant-tooltip-content)
+  :global(.crdb-ant-tooltip-content)
     max-width 500px
 
 .tooltip__table--title

--- a/pkg/ui/workspaces/db-console/styl/shame.styl
+++ b/pkg/ui/workspaces/db-console/styl/shame.styl
@@ -133,15 +133,15 @@
   opacity .6
   font-size 10px
 
-.crl-ant-divider
+.crdb-ant-divider
   background $button-border-color
   margin-left 0
   margin-right 22px
-  &.crl-ant-divider-vertical
+  &.crdb-ant-divider-vertical
     height auto
 
-.crl-ant-tooltip
-  .crl-ant-tooltip-inner
+.crdb-ant-tooltip
+  .crdb-ant-tooltip-inner
     font-size 12px
     border-radius 4px
     background-color $body-color
@@ -152,7 +152,7 @@
     min-width 0
     min-height 0
   &.preset-black
-    .crl-ant-tooltip-inner
+    .crdb-ant-tooltip-inner
       background-color #000
       pre
         font-family RobotoMono-Medium
@@ -164,7 +164,7 @@
           font-family RobotoMono-Bold
           color #0055ff
 
-.crl-ant-time-picker-input
+.crdb-ant-time-picker-input
   height 40px
   padding 0px 11px
   border-radius 3px
@@ -175,72 +175,72 @@
   &:hover
     border-color $link-color
 
-.crl-ant-time-picker-panel-combobox
+.crdb-ant-time-picker-panel-combobox
   display flex
 
-.crl-ant-calendar-picker:hover .crl-ant-calendar-picker-input:not(.crl-ant-input-disabled)
+.crdb-ant-calendar-picker:hover .crdb-ant-calendar-picker-input:not(.crdb-ant-input-disabled)
   border-color $link-color
 
-.crl-ant-fullcalendar-header
+.crdb-ant-fullcalendar-header
   padding: 10px 4px
   text-align: center
 
-.crl-ant-fullcalendar
+.crdb-ant-fullcalendar
   font-size 12px
   font-family Lato-Regular
 
-.crl-ant-fullcalendar-selected-day
-  .crl-ant-fullcalendar-date
+.crdb-ant-fullcalendar-selected-day
+  .crdb-ant-fullcalendar-date
     background #eff5fe
     color #3a7ce1
     &:hover
       background #e0efff
       color $blue-color
 
-.crl-ant-fullcalendar-today 
-  &.crl-ant-fullcalendar-date
+.crdb-ant-fullcalendar-today
+  &.crdb-ant-fullcalendar-date
     color #3a7ce1
     border-color #3a7ce1
     &:hover
       background #eff5fd
-  &.crl-ant-fullcalendar-selected-day
-    .crl-ant-fullcalendar-date
+  &.crdb-ant-fullcalendar-selected-day
+    .crdb-ant-fullcalendar-date
       background #eff5fd
       &:hover
         background $grey4
         font-weight bold
-  &.crl-ant-fullcalendar-disabled-cell
-    .crl-ant-fullcalendar-date
+  &.crdb-ant-fullcalendar-disabled-cell
+    .crdb-ant-fullcalendar-date
       background #E7ECF3
       &:hover
         background #E7ECF3
 
-.crl-ant-fullcalendar-date, .crl-ant-time-picker-panel li
+.crdb-ant-fullcalendar-date, .crdb-ant-time-picker-panel li
   color #5F6C87
   font-family Lato-Regular
   font-size 12px
-  &.crl-ant-time-picker-panel-addon-option-disabled
+  &.crdb-ant-time-picker-panel-addon-option-disabled
     color #a3a5af
   &:hover
     background #f6f6f6
   &:focus
     color $link-color
 
-.crl-ant-time-picker-panel li
+.crdb-ant-time-picker-panel li
   display flex
   align-items center
 
-.crl-ant-fullcalendar-disabled-cell .crl-ant-fullcalendar-date
+.crdb-ant-fullcalendar-disabled-cell .crdb-ant-fullcalendar-date
   background #E7ECF3
 
-.crl-ant-fullcalendar-disabled-cell.crl-ant-fullcalendar-today .crl-ant-fullcalendar-date
+.crdb-ant-fullcalendar-disabled-cell.crdb-ant-fullcalendar-today .crdb-ant-fullcalendar-date
   color #a3a5af
   font-weight bold
   border-color transparent
   &:before
     border 1px solid #a3a5af
 
-.crl-ant-calendar-today-btn
+.crdb-ant-calendar-today-btn
   width 100%
   font-family Lato-Bold
   color $link-color
@@ -254,13 +254,13 @@
     line-height 1.71
     letter-spacing 0.1px
 
-.crl-ant-btn:focus
+.crdb-ant-btn:focus
   color: $link-color
 
-.crl-ant-btn:after
+.crdb-ant-btn:after
   display: none !important;
 
-.crl-ant-btn-background-ghost
+.crdb-ant-btn-background-ghost
   box-shadow: none
   
 .color
@@ -269,20 +269,20 @@
     &:hover
       text-decoration underline
 
-.crl-ant-checkbox-wrapper
+.crdb-ant-checkbox-wrapper
   &:hover
-    .crl-ant-checkbox-inner
+    .crdb-ant-checkbox-inner
       border solid 1px $checkbox-border-hover
       background $popover-border-color
-  .crl-ant-checkbox-inner
+  .crdb-ant-checkbox-inner
     border solid 1px $checkbox-border
     border-radius 3px
-  .crl-ant-checkbox-checked
+  .crdb-ant-checkbox-checked
     &:hover
-      .crl-ant-checkbox-inner
+      .crdb-ant-checkbox-inner
         border solid 1px $link
         background $link
-    .crl-ant-checkbox-inner
+    .crdb-ant-checkbox-inner
       background-color $link
   span
     font-family SourceSansPro-SemiBold
@@ -291,39 +291,39 @@
     letter-spacing 0.1px
     color $popover-color
 
-.crl-ant-pagination
+.crdb-ant-pagination
   display flex
   justify-content center
   align-items flex-end
   margin 40px 0
   &.mini
-    .crl-ant-pagination-item, .crl-ant-pagination-prev, .crl-ant-pagination-next
+    .crdb-ant-pagination-item, .crdb-ant-pagination-prev, .crdb-ant-pagination-next
       margin 0 5px
-  .crl-ant-pagination-item
+  .crdb-ant-pagination-item
     a
       color $body-color
       font-size 14px
       font-family Lato-Medium
       &:hover
         color $link-color
-  .crl-ant-pagination-item-active
+  .crdb-ant-pagination-item-active
     background transparent
     border-radius 2px
     border 1px solid $link-color
     a
       color $link-color
-  .crl-ant-pagination-next, .crl-ant-pagination-prev
-    .crl-ant-pagination-item-link
+  .crdb-ant-pagination-next, .crdb-ant-pagination-prev
+    .crdb-ant-pagination-item-link
       font-size 12px
       color $body-color
     &:hover
-      .crl-ant-pagination-item-link
+      .crdb-ant-pagination-item-link
         color $link-color
-    &.crl-ant-pagination-disabled
-      .crl-ant-pagination-item-link
+    &.crdb-ant-pagination-disabled
+      .crdb-ant-pagination-item-link
         color #b8bbbc
       &:hover
-        .crl-ant-pagination-item-link
+        .crdb-ant-pagination-item-link
           color #b8bbbc
 
 .drawer--preset-black
@@ -350,7 +350,7 @@
   ::-webkit-scrollbar-thumb:hover {
     background #5f6c87ad
   }
-  .crl-ant-divider
+  .crdb-ant-divider
     width 1px
     background #5f6c87
     margin: 0 15px
@@ -365,21 +365,21 @@
       letter-spacing 0.1px
       &:hover
         color #5f6c87
-  .crl-ant-drawer-content
+  .crdb-ant-drawer-content
     overflow auto
-  .crl-ant-drawer-mask
+  .crdb-ant-drawer-mask
     background-color transparent
-  .crl-ant-drawer-content-wrapper
+  .crdb-ant-drawer-content-wrapper
     padding-left 80px
     box-shadow none !important
-  .crl-ant-drawer-content
+  .crdb-ant-drawer-content
     background #242a35
-  .crl-ant-drawer-header
+  .crdb-ant-drawer-header
     padding 15px 0
     margin 0 24px
     background transparent
     border-bottom: 1px solid #5f6c87;
-  .crl-ant-drawer-body
+  .crdb-ant-drawer-body
     padding 15px 20px
     margin 0 4px
     height 190px
@@ -395,9 +395,9 @@
       font-family RobotoMono-Bold
 
 .cockroach--tabs
-  .crl-ant-tabs-bar
+  .crdb-ant-tabs-bar
     border-bottom 1px solid $grey2
-  .crl-ant-tabs-tab
+  .crdb-ant-tabs-tab
     font-family SourceSansPro-Regular
     font-size 16px
     line-height 1.5
@@ -405,9 +405,9 @@
     color $placeholder
     &:hover
       color $adminui-grey-1 
-  .crl-ant-tabs-tab-active
+  .crdb-ant-tabs-tab-active
     color $adminui-grey-1 
-  .crl-ant-tabs-ink-bar
+  .crdb-ant-tabs-ink-bar
     height 3px
     border-radius 40px
     background-color $blue


### PR DESCRIPTION
This commit changes the classname prefix for antd
components in `pkg/ui` to `crdb-ant` instead of
`crl-ant` to avoid collisions with CC.

Epic: none
Part of: CC-30835

Release note: None