### PR TITLE
release-24.1: opt: add new optimizer session settings

### DIFF
--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -1057,6 +1057,7 @@ unreserved_keyword ::=
 	| 'ATTRIBUTE'
 	| 'AUTOMATIC'
 	| 'AVAILABILITY'
+	| 'AVOID_FULL_SCAN'
 	| 'BACKUP'
 	| 'BACKUPS'
 	| 'BACKWARD'
@@ -3625,6 +3626,7 @@ bare_label_keywords ::=
 	| 'AUTHORIZATION'
 	| 'AUTOMATIC'
 	| 'AVAILABILITY'
+	| 'AVOID_FULL_SCAN'
 	| 'BACKUP'
 	| 'BACKUPS'
 	| 'BACKWARD'
@@ -4197,6 +4199,7 @@ index_flags_param ::=
 	| 'NO_INDEX_JOIN'
 	| 'NO_ZIGZAG_JOIN'
 	| 'NO_FULL_SCAN'
+	| 'AVOID_FULL_SCAN'
 	| 'FORCE_ZIGZAG'
 	| 'FORCE_ZIGZAG' '=' index_name
 

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -3841,6 +3841,10 @@ func (m *sessionDataMutator) SetLegacyVarcharTyping(val bool) {
 	m.data.LegacyVarcharTyping = val
 }
 
+func (m *sessionDataMutator) SetOptimizerPreferBoundedCardinality(b bool) {
+	m.data.OptimizerPreferBoundedCardinality = b
+}
+
 // Utility functions related to scrubbing sensitive information on SQL Stats.
 
 // quantizeCounts ensures that the Count field in the

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -3845,6 +3845,10 @@ func (m *sessionDataMutator) SetOptimizerPreferBoundedCardinality(b bool) {
 	m.data.OptimizerPreferBoundedCardinality = b
 }
 
+func (m *sessionDataMutator) SetOptimizerMinRowCount(val float64) {
+	m.data.OptimizerMinRowCount = val
+}
+
 // Utility functions related to scrubbing sensitive information on SQL Stats.
 
 // quantizeCounts ensures that the Count field in the

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -6172,6 +6172,7 @@ optimizer_always_use_histograms                            on
 optimizer_apply_full_scan_penalty_to_virtual_tables        off
 optimizer_hoist_uncorrelated_equality_subqueries           on
 optimizer_merge_joins_enabled                              on
+optimizer_min_row_count                                    0
 optimizer_prefer_bounded_cardinality                       off
 optimizer_prove_implication_with_virtual_computed_columns  off
 optimizer_push_limit_into_project_filtered_scan            off

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -5433,19 +5433,19 @@ statement ok
 CREATE SEQUENCE test_seq_3 AS smallint
 
 statement ok
-CREATE SEQUENCE test_seq_4 AS integer 
+CREATE SEQUENCE test_seq_4 AS integer
 
 statement ok
 CREATE SEQUENCE test_seq_5 AS bigint
 
 statement ok
-CREATE SEQUENCE test_seq_6 AS INT2 
+CREATE SEQUENCE test_seq_6 AS INT2
 
 statement ok
 CREATE SEQUENCE test_seq_7 AS INT4
 
 statement ok
-CREATE SEQUENCE test_seq_8 AS INT8 
+CREATE SEQUENCE test_seq_8 AS INT8
 
 query TTTTIIITTTTT colnames,rowsort
 SELECT * FROM information_schema.sequences
@@ -6172,6 +6172,7 @@ optimizer_always_use_histograms                            on
 optimizer_apply_full_scan_penalty_to_virtual_tables        off
 optimizer_hoist_uncorrelated_equality_subqueries           on
 optimizer_merge_joins_enabled                              on
+optimizer_prefer_bounded_cardinality                       off
 optimizer_prove_implication_with_virtual_computed_columns  off
 optimizer_push_limit_into_project_filtered_scan            off
 optimizer_push_offset_into_index_join                      on

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -2932,6 +2932,7 @@ optimizer_always_use_histograms                            on                  N
 optimizer_apply_full_scan_penalty_to_virtual_tables        off                 NULL      NULL        NULL        string
 optimizer_hoist_uncorrelated_equality_subqueries           on                  NULL      NULL        NULL        string
 optimizer_merge_joins_enabled                              on                  NULL      NULL        NULL        string
+optimizer_prefer_bounded_cardinality                       off                 NULL      NULL        NULL        string
 optimizer_prove_implication_with_virtual_computed_columns  off                 NULL      NULL        NULL        string
 optimizer_push_limit_into_project_filtered_scan            off                 NULL      NULL        NULL        string
 optimizer_push_offset_into_index_join                      on                  NULL      NULL        NULL        string
@@ -3122,6 +3123,7 @@ optimizer_always_use_histograms                            on                  N
 optimizer_apply_full_scan_penalty_to_virtual_tables        off                 NULL  user     NULL      off                 off
 optimizer_hoist_uncorrelated_equality_subqueries           on                  NULL  user     NULL      on                  on
 optimizer_merge_joins_enabled                              on                  NULL  user     NULL      on                  on
+optimizer_prefer_bounded_cardinality                       off                 NULL  user     NULL      off                 off
 optimizer_prove_implication_with_virtual_computed_columns  off                 NULL  user     NULL      off                 off
 optimizer_push_limit_into_project_filtered_scan            off                 NULL  user     NULL      off                 off
 optimizer_push_offset_into_index_join                      on                  NULL  user     NULL      on                  on
@@ -3311,6 +3313,7 @@ optimizer_always_use_histograms                            NULL    NULL     NULL
 optimizer_apply_full_scan_penalty_to_virtual_tables        NULL    NULL     NULL     NULL        NULL
 optimizer_hoist_uncorrelated_equality_subqueries           NULL    NULL     NULL     NULL        NULL
 optimizer_merge_joins_enabled                              NULL    NULL     NULL     NULL        NULL
+optimizer_prefer_bounded_cardinality                       NULL    NULL     NULL     NULL        NULL
 optimizer_prove_implication_with_virtual_computed_columns  NULL    NULL     NULL     NULL        NULL
 optimizer_push_limit_into_project_filtered_scan            NULL    NULL     NULL     NULL        NULL
 optimizer_push_offset_into_index_join                      NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -2932,6 +2932,7 @@ optimizer_always_use_histograms                            on                  N
 optimizer_apply_full_scan_penalty_to_virtual_tables        off                 NULL      NULL        NULL        string
 optimizer_hoist_uncorrelated_equality_subqueries           on                  NULL      NULL        NULL        string
 optimizer_merge_joins_enabled                              on                  NULL      NULL        NULL        string
+optimizer_min_row_count                                    0                   NULL      NULL        NULL        string
 optimizer_prefer_bounded_cardinality                       off                 NULL      NULL        NULL        string
 optimizer_prove_implication_with_virtual_computed_columns  off                 NULL      NULL        NULL        string
 optimizer_push_limit_into_project_filtered_scan            off                 NULL      NULL        NULL        string
@@ -3123,6 +3124,7 @@ optimizer_always_use_histograms                            on                  N
 optimizer_apply_full_scan_penalty_to_virtual_tables        off                 NULL  user     NULL      off                 off
 optimizer_hoist_uncorrelated_equality_subqueries           on                  NULL  user     NULL      on                  on
 optimizer_merge_joins_enabled                              on                  NULL  user     NULL      on                  on
+optimizer_min_row_count                                    0                   NULL  user     NULL      0                   0
 optimizer_prefer_bounded_cardinality                       off                 NULL  user     NULL      off                 off
 optimizer_prove_implication_with_virtual_computed_columns  off                 NULL  user     NULL      off                 off
 optimizer_push_limit_into_project_filtered_scan            off                 NULL  user     NULL      off                 off
@@ -3313,6 +3315,7 @@ optimizer_always_use_histograms                            NULL    NULL     NULL
 optimizer_apply_full_scan_penalty_to_virtual_tables        NULL    NULL     NULL     NULL        NULL
 optimizer_hoist_uncorrelated_equality_subqueries           NULL    NULL     NULL     NULL        NULL
 optimizer_merge_joins_enabled                              NULL    NULL     NULL     NULL        NULL
+optimizer_min_row_count                                    NULL    NULL     NULL     NULL        NULL
 optimizer_prefer_bounded_cardinality                       NULL    NULL     NULL     NULL        NULL
 optimizer_prove_implication_with_virtual_computed_columns  NULL    NULL     NULL     NULL        NULL
 optimizer_push_limit_into_project_filtered_scan            NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/select
+++ b/pkg/sql/logictest/testdata/logic_test/select
@@ -756,6 +756,25 @@ SELECT * FROM t_disallow_scans@{FORCE_INDEX=b_idx,NO_FULL_SCAN} WHERE b > 0
 statement ok
 SELECT * FROM t_disallow_scans@{FORCE_INDEX=b_partial,NO_FULL_SCAN} WHERE a > 0 AND b = 1
 
+# Now avoid full scans with a hint. A full scan should not cause an error.
+statement ok
+SELECT * FROM t_disallow_scans@{AVOID_FULL_SCAN}
+
+statement ok
+SELECT * FROM t_disallow_scans@{FORCE_INDEX=b_idx,AVOID_FULL_SCAN}
+
+statement ok
+SELECT * FROM t_disallow_scans@{FORCE_INDEX=b_partial,AVOID_FULL_SCAN} WHERE a > 0
+
+statement ok
+SELECT * FROM t_disallow_scans@{AVOID_FULL_SCAN} WHERE a > 0
+
+statement ok
+SELECT * FROM t_disallow_scans@{FORCE_INDEX=b_idx,AVOID_FULL_SCAN} WHERE b > 0
+
+statement ok
+SELECT * FROM t_disallow_scans@{FORCE_INDEX=b_partial,AVOID_FULL_SCAN} WHERE a > 0 AND b = 1
+
 # Now disable full scans with the session variable.
 statement ok
 SET disallow_full_table_scans = true;

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -128,6 +128,7 @@ optimizer_always_use_histograms                            on
 optimizer_apply_full_scan_penalty_to_virtual_tables        off
 optimizer_hoist_uncorrelated_equality_subqueries           on
 optimizer_merge_joins_enabled                              on
+optimizer_prefer_bounded_cardinality                       off
 optimizer_prove_implication_with_virtual_computed_columns  off
 optimizer_push_limit_into_project_filtered_scan            off
 optimizer_push_offset_into_index_join                      on

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -128,6 +128,7 @@ optimizer_always_use_histograms                            on
 optimizer_apply_full_scan_penalty_to_virtual_tables        off
 optimizer_hoist_uncorrelated_equality_subqueries           on
 optimizer_merge_joins_enabled                              on
+optimizer_min_row_count                                    0
 optimizer_prefer_bounded_cardinality                       off
 optimizer_prove_implication_with_virtual_computed_columns  off
 optimizer_push_limit_into_project_filtered_scan            off

--- a/pkg/sql/opt/distribution/distribution_test.go
+++ b/pkg/sql/opt/distribution/distribution_test.go
@@ -173,8 +173,8 @@ func TestGetDistributions(t *testing.T) {
 			inputRel := childInput
 			distributeExpr := &memo.DistributeExpr{Input: childInput}
 			distributeRel = distributeExpr
-			f.Memo().SetBestProps(distributeRel, &physical.Required{}, parentProvided, 0)
-			f.Memo().SetBestProps(inputRel, &physical.Required{}, childProvided, 0)
+			f.Memo().SetBestProps(distributeRel, &physical.Required{}, parentProvided, memo.Cost{C: 0})
+			f.Memo().SetBestProps(inputRel, &physical.Required{}, childProvided, memo.Cost{C: 0})
 
 			targetDist, sourceDist, ok := distributeExpr.GetDistributions()
 			// Check if we got distributions when expected.

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -396,7 +396,7 @@ func (b *Builder) maybeAnnotateWithEstimates(node exec.Node, e memo.RelExpr) {
 		val := exec.EstimatedStats{
 			TableStatsAvailable: stats.Available,
 			RowCount:            stats.RowCount,
-			Cost:                float64(e.Cost()),
+			Cost:                e.Cost().C,
 		}
 		if scan, ok := e.(*memo.ScanExpr); ok {
 			tab := b.mem.Metadata().Table(scan.Table)

--- a/pkg/sql/opt/exec/execbuilder/testdata/delete
+++ b/pkg/sql/opt/exec/execbuilder/testdata/delete
@@ -338,6 +338,34 @@ vectorized: true
               table: xyz@xyz_y_idx
               spans: /1-/1000 /2001-/3000
 
+# AVOID_FULL_SCAN also works to ensure a constrained scan.
+query T
+EXPLAIN (VERBOSE) DELETE FROM xyz@{AVOID_FULL_SCAN} WHERE (y > 0 AND y < 1000) OR (y > 2000 AND y < 3000) RETURNING z
+----
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (z)
+│
+└── • delete
+    │ columns: (x, z)
+    │ estimated row count: 990 (missing stats)
+    │ from: xyz
+    │ auto commit
+    │
+    └── • index join
+        │ columns: (x, y, z)
+        │ estimated row count: 990 (missing stats)
+        │ table: xyz@xyz_pkey
+        │ key columns: x
+        │
+        └── • scan
+              columns: (x, y)
+              estimated row count: 990 (missing stats)
+              table: xyz@xyz_y_idx
+              spans: /1-/1000 /2001-/3000
+
 # Testcase for issue 105803.
 
 statement ok

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain_redact
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain_redact
@@ -1366,7 +1366,7 @@ update e
 query T
 EXPLAIN (OPT, MEMO, REDACT) UPDATE e SET e = 'eee' WHERE e > 'a'
 ----
-memo (optimized, ~16KB, required=[presentation: info:13] [distribution: test])
+memo (optimized, ~17KB, required=[presentation: info:13] [distribution: test])
  ├── G1: (explain G2 [distribution: test])
  │    └── [presentation: info:13] [distribution: test]
  │         ├── best: (explain G2="[distribution: test]" [distribution: test])
@@ -3103,7 +3103,7 @@ anti-join-apply
 query T
 EXPLAIN (OPT, MEMO, REDACT) SELECT * FROM a WHERE a > ALL (SELECT c::int + 2 FROM bc WHERE b > a::float * 3)
 ----
-memo (optimized, ~22KB, required=[presentation: info:11] [distribution: test])
+memo (optimized, ~23KB, required=[presentation: info:11] [distribution: test])
  ├── G1: (explain G2 [presentation: a:1] [distribution: test])
  │    └── [presentation: info:11] [distribution: test]
  │         ├── best: (explain G2="[presentation: a:1] [distribution: test]" [presentation: a:1] [distribution: test])
@@ -3430,7 +3430,7 @@ top-k
 query T
 EXPLAIN (OPT, MEMO, REDACT) SELECT * FROM cd ORDER BY regexp_replace(c, '[0-9]', 'd') LIMIT 3
 ----
-memo (optimized, ~7KB, required=[presentation: info:7] [distribution: test])
+memo (optimized, ~8KB, required=[presentation: info:7] [distribution: test])
  ├── G1: (explain G2 [presentation: c:1,d:2] [ordering: +6 opt(2)] [distribution: test])
  │    └── [presentation: info:7] [distribution: test]
  │         ├── best: (explain G2="[presentation: c:1,d:2] [ordering: +6 opt(2)] [distribution: test]" [presentation: c:1,d:2] [ordering: +6 opt(2)] [distribution: test])
@@ -3931,7 +3931,7 @@ create-table
 query T
 EXPLAIN (OPT, MEMO, REDACT) CREATE TABLE t (col STRING CHECK (col != 'secret'))
 ----
-memo (optimized, ~3KB, required=[presentation: info:1] [distribution: test])
+memo (optimized, ~4KB, required=[presentation: info:1] [distribution: test])
  ├── G1: (explain G2 [distribution: test])
  │    └── [presentation: info:1] [distribution: test]
  │         ├── best: (explain G2="[distribution: test]" [distribution: test])

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain_redact
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain_redact
@@ -700,7 +700,7 @@ upsert bc
 query T
 EXPLAIN (OPT, MEMO, REDACT) INSERT INTO bc SELECT a::float + 1 FROM a ON CONFLICT (b) DO UPDATE SET b = bc.b + 100
 ----
-memo (optimized, ~34KB, required=[presentation: info:19] [distribution: test])
+memo (optimized, ~35KB, required=[presentation: info:19] [distribution: test])
  ├── G1: (explain G2 [distribution: test])
  │    └── [presentation: info:19] [distribution: test]
  │         ├── best: (explain G2="[distribution: test]" [distribution: test])

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain_redact
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain_redact
@@ -1140,7 +1140,7 @@ update ab
 query T
 EXPLAIN (OPT, MEMO, REDACT) UPDATE ab SET a = a || 'ab' WHERE a > 'a'
 ----
-memo (optimized, ~13KB, required=[presentation: info:11] [distribution: test])
+memo (optimized, ~14KB, required=[presentation: info:11] [distribution: test])
  ├── G1: (explain G2 [distribution: test])
  │    └── [presentation: info:11] [distribution: test]
  │         ├── best: (explain G2="[distribution: test]" [distribution: test])
@@ -3807,7 +3807,7 @@ project
 query T
 EXPLAIN (OPT, MEMO, REDACT) SELECT min(c || 'cccc') OVER (ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING EXCLUDE CURRENT ROW) FROM cd
 ----
-memo (optimized, ~11KB, required=[presentation: info:8] [distribution: test])
+memo (optimized, ~12KB, required=[presentation: info:8] [distribution: test])
  ├── G1: (explain G2 [presentation: min:6] [distribution: test])
  │    └── [presentation: info:8] [distribution: test]
  │         ├── best: (explain G2="[presentation: min:6] [distribution: test]" [presentation: min:6] [distribution: test])

--- a/pkg/sql/opt/exec/execbuilder/testdata/update
+++ b/pkg/sql/opt/exec/execbuilder/testdata/update
@@ -268,6 +268,41 @@ vectorized: true
               spans: /1-/1000 /2001-/3000
               locking strength: for update
 
+# AVOID_FULL_SCAN also works to ensure a constrained scan.
+query T
+EXPLAIN (VERBOSE) UPDATE xyz@{AVOID_FULL_SCAN} SET x = 5 WHERE (y > 0 AND y < 1000) OR (y > 2000 AND y < 3000)
+----
+distribution: local
+vectorized: true
+·
+• update
+│ columns: ()
+│ estimated row count: 0 (missing stats)
+│ table: xyz
+│ set: x
+│ auto commit
+│
+└── • render
+    │ columns: (x, y, z, x_new)
+    │ render x_new: 5
+    │ render x: x
+    │ render y: y
+    │ render z: z
+    │
+    └── • index join
+        │ columns: (x, y, z)
+        │ estimated row count: 990 (missing stats)
+        │ table: xyz@xyz_pkey
+        │ key columns: x
+        │ locking strength: for update
+        │
+        └── • scan
+              columns: (x, y)
+              estimated row count: 990 (missing stats)
+              table: xyz@y_idx
+              spans: /1-/1000 /2001-/3000
+              locking strength: for update
+
 statement ok
 CREATE TABLE pks (
   k1 INT,

--- a/pkg/sql/opt/exec/execbuilder/testdata/upsert
+++ b/pkg/sql/opt/exec/execbuilder/testdata/upsert
@@ -410,6 +410,112 @@ vectorized: true
 query error could not produce a query plan conforming to the NO_FULL_SCAN hint
 EXPLAIN (VERBOSE) UPSERT INTO indexed@{FORCE_INDEX=secondary,NO_FULL_SCAN} VALUES (1)
 
+# AVOID_FULL_SCAN also works to ensure a constrained scan, and does not error if
+# one is not possible.
+query T
+EXPLAIN (VERBOSE) UPSERT INTO indexed@{AVOID_FULL_SCAN} VALUES (1)
+----
+distribution: local
+vectorized: true
+·
+• upsert
+│ columns: ()
+│ estimated row count: 0 (missing stats)
+│ into: indexed(a, b, c, d)
+│ auto commit
+│ arbiter indexes: indexed_pkey
+│
+└── • project
+    │ columns: (column1, b_default, c_default, d_comp, a, b, c, d, b_default, c_default, d_comp, a, check1)
+    │
+    └── • render
+        │ columns: (check1, column1, b_default, c_default, d_comp, a, b, c, d)
+        │ render check1: c_default > 0
+        │ render column1: column1
+        │ render b_default: b_default
+        │ render c_default: c_default
+        │ render d_comp: d_comp
+        │ render a: a
+        │ render b: b
+        │ render c: c
+        │ render d: d
+        │
+        └── • cross join (left outer)
+            │ columns: (column1, b_default, c_default, d_comp, a, b, c, d)
+            │ estimated row count: 1 (missing stats)
+            │
+            ├── • values
+            │     columns: (column1, b_default, c_default, d_comp)
+            │     size: 4 columns, 1 row
+            │     row 0, expr 0: 1
+            │     row 0, expr 1: CAST(NULL AS INT8)
+            │     row 0, expr 2: 10
+            │     row 0, expr 3: 11
+            │
+            └── • scan
+                  columns: (a, b, c, d)
+                  estimated row count: 1 (missing stats)
+                  table: indexed@indexed_pkey
+                  spans: /1/0
+                  locking strength: for update
+
+query T
+EXPLAIN (VERBOSE) UPSERT INTO indexed@{FORCE_INDEX=secondary,AVOID_FULL_SCAN} VALUES (1)
+----
+distribution: local
+vectorized: true
+·
+• upsert
+│ columns: ()
+│ estimated row count: 0 (missing stats)
+│ into: indexed(a, b, c, d)
+│ auto commit
+│ arbiter indexes: indexed_pkey
+│
+└── • project
+    │ columns: (column1, b_default, c_default, d_comp, a, b, c, d, b_default, c_default, d_comp, a, check1)
+    │
+    └── • render
+        │ columns: (check1, column1, b_default, c_default, d_comp, a, b, c, d)
+        │ render check1: c_default > 0
+        │ render column1: column1
+        │ render b_default: b_default
+        │ render c_default: c_default
+        │ render d_comp: d_comp
+        │ render a: a
+        │ render b: b
+        │ render c: c
+        │ render d: d
+        │
+        └── • cross join (left outer)
+            │ columns: (column1, b_default, c_default, d_comp, a, b, c, d)
+            │ estimated row count: 1 (missing stats)
+            │
+            ├── • values
+            │     columns: (column1, b_default, c_default, d_comp)
+            │     size: 4 columns, 1 row
+            │     row 0, expr 0: 1
+            │     row 0, expr 1: CAST(NULL AS INT8)
+            │     row 0, expr 2: 10
+            │     row 0, expr 3: 11
+            │
+            └── • filter
+                │ columns: (a, b, c, d)
+                │ estimated row count: 1 (missing stats)
+                │ filter: a = 1
+                │
+                └── • index join
+                    │ columns: (a, b, c, d)
+                    │ estimated row count: 1,000 (missing stats)
+                    │ table: indexed@indexed_pkey
+                    │ key columns: a
+                    │
+                    └── • scan
+                          columns: (a, b, d)
+                          estimated row count: 1,000 (missing stats)
+                          table: indexed@secondary
+                          spans: FULL SCAN
+
 query T
 EXPLAIN (VERBOSE)
 INSERT INTO indexed@indexed_pkey AS indexed_pk

--- a/pkg/sql/opt/memo/cost.go
+++ b/pkg/sql/opt/memo/cost.go
@@ -10,12 +10,17 @@ import "math"
 // Cost is the best-effort approximation of the actual cost of executing a
 // particular operator tree.
 // TODO: Need more details about what one "unit" of cost means.
-type Cost float64
+type Cost struct {
+	C float64
+	// CostFlags is used as a placeholder for cost flags that will be added in a
+	// future commit.
+	CostFlags int
+}
 
 // MaxCost is the maximum possible estimated cost. It's used to suppress memo
 // group members during testing, by setting their cost so high that any other
 // member will have a lower cost.
-var MaxCost = Cost(math.Inf(+1))
+var MaxCost = Cost{C: math.Inf(+1)}
 
 // Less returns true if this cost is lower than the given cost.
 func (c Cost) Less(other Cost) bool {
@@ -29,10 +34,10 @@ func (c Cost) Less(other Cost) bool {
 	// the magnitude of the numbers. Because the mantissa is in the low bits, we
 	// can just use the bit representations as integers.
 	const ulpTolerance = 1000
-	return math.Float64bits(float64(c))+ulpTolerance <= math.Float64bits(float64(other))
+	return math.Float64bits(c.C)+ulpTolerance <= math.Float64bits(other.C)
 }
 
-// Sub subtracts the other cost from this cost and returns the result.
-func (c Cost) Sub(other Cost) Cost {
-	return c - other
+// Add adds the other cost to this cost.
+func (c *Cost) Add(other Cost) {
+	c.C += other.C
 }

--- a/pkg/sql/opt/memo/cost.go
+++ b/pkg/sql/opt/memo/cost.go
@@ -11,19 +11,23 @@ import "math"
 // particular operator tree.
 // TODO: Need more details about what one "unit" of cost means.
 type Cost struct {
-	C float64
-	// CostFlags is used as a placeholder for cost flags that will be added in a
-	// future commit.
-	CostFlags int
+	C     float64
+	Flags CostFlags
 }
 
 // MaxCost is the maximum possible estimated cost. It's used to suppress memo
 // group members during testing, by setting their cost so high that any other
 // member will have a lower cost.
-var MaxCost = Cost{C: math.Inf(+1)}
+var MaxCost = Cost{
+	C:     math.Inf(+1),
+	Flags: CostFlags{FullScanPenalty: true, HugeCostPenalty: true},
+}
 
 // Less returns true if this cost is lower than the given cost.
 func (c Cost) Less(other Cost) bool {
+	if c.Flags != other.Flags {
+		return c.Flags.Less(other.Flags)
+	}
 	// Two plans with the same cost can have slightly different floating point
 	// results (e.g. same subcosts being added up in a different order). So we
 	// treat plans with very similar cost as equal.
@@ -40,4 +44,43 @@ func (c Cost) Less(other Cost) bool {
 // Add adds the other cost to this cost.
 func (c *Cost) Add(other Cost) {
 	c.C += other.C
+	c.Flags.Add(other.Flags)
+}
+
+// CostFlags contains flags that penalize the cost of an operator.
+type CostFlags struct {
+	// FullScanPenalty is true if the cost of a full table or index scan is
+	// penalized, indicating that a full scan should only be used if no other plan
+	// is possible.
+	FullScanPenalty bool
+	// HugeCostPenalty is true if a plan should be avoided at all costs. This is
+	// used when the optimizer is forced to use a particular plan, and will error
+	// if it cannot be used.
+	HugeCostPenalty bool
+}
+
+// Less returns true if these flags indicate a lower penalty than the other
+// CostFlags.
+func (c CostFlags) Less(other CostFlags) bool {
+	// HugeCostPenalty takes precedence over other penalties, since it indicates
+	// that a plan is being forced with a hint, and will error if we cannot comply
+	// with the hint.
+	if c.HugeCostPenalty != other.HugeCostPenalty {
+		return !c.HugeCostPenalty
+	}
+	if c.FullScanPenalty != other.FullScanPenalty {
+		return !c.FullScanPenalty
+	}
+	return false
+}
+
+// Add adds the other flags to these flags.
+func (c *CostFlags) Add(other CostFlags) {
+	c.FullScanPenalty = c.FullScanPenalty || other.FullScanPenalty
+	c.HugeCostPenalty = c.HugeCostPenalty || other.HugeCostPenalty
+}
+
+// Empty returns true if these flags are empty.
+func (c CostFlags) Empty() bool {
+	return !c.FullScanPenalty && !c.HugeCostPenalty
 }

--- a/pkg/sql/opt/memo/cost_test.go
+++ b/pkg/sql/opt/memo/cost_test.go
@@ -35,6 +35,8 @@ func TestCostLess(t *testing.T) {
 		{memo.MaxCost, memo.MaxCost, false},
 		{memo.MaxCost, memo.Cost{C: 1.0, Flags: memo.CostFlags{FullScanPenalty: true}}, false},
 		{memo.Cost{C: 1.0, Flags: memo.CostFlags{HugeCostPenalty: true}}, memo.MaxCost, true},
+		{memo.Cost{C: 2.0, Flags: memo.CostFlags{}}, memo.Cost{C: 1.0, Flags: memo.CostFlags{UnboundedCardinality: true}}, true},
+		{memo.Cost{C: 1.0, Flags: memo.CostFlags{UnboundedCardinality: true}}, memo.Cost{C: 2.0, Flags: memo.CostFlags{}}, false},
 	}
 	for _, tc := range testCases {
 		if tc.left.Less(tc.right) != tc.expected {
@@ -72,6 +74,8 @@ func TestCostFlagsLess(t *testing.T) {
 		{memo.CostFlags{FullScanPenalty: true, HugeCostPenalty: true}, memo.CostFlags{FullScanPenalty: true, HugeCostPenalty: true}, false},
 		{memo.CostFlags{FullScanPenalty: false}, memo.CostFlags{FullScanPenalty: true}, true},
 		{memo.CostFlags{HugeCostPenalty: false}, memo.CostFlags{HugeCostPenalty: true}, true},
+		{memo.CostFlags{UnboundedCardinality: false}, memo.CostFlags{UnboundedCardinality: true}, true},
+		{memo.CostFlags{UnboundedCardinality: true}, memo.CostFlags{UnboundedCardinality: false}, false},
 	}
 	for _, tc := range testCases {
 		if tc.left.Less(tc.right) != tc.expected {

--- a/pkg/sql/opt/memo/cost_test.go
+++ b/pkg/sql/opt/memo/cost_test.go
@@ -26,6 +26,15 @@ func TestCostLess(t *testing.T) {
 		{memo.Cost{C: 1}, memo.Cost{C: 1.00000001}, true},
 		{memo.Cost{C: 1000}, memo.Cost{C: 1000.00000000001}, false},
 		{memo.Cost{C: 1000}, memo.Cost{C: 1000.00001}, true},
+		{memo.Cost{C: 1.0, Flags: memo.CostFlags{FullScanPenalty: true}}, memo.Cost{C: 1.0}, false},
+		{memo.Cost{C: 1.0}, memo.Cost{C: 1.0, Flags: memo.CostFlags{HugeCostPenalty: true}}, true},
+		{memo.Cost{C: 1.0, Flags: memo.CostFlags{FullScanPenalty: true, HugeCostPenalty: true}}, memo.Cost{C: 1.0}, false},
+		{memo.Cost{C: 1.0, Flags: memo.CostFlags{FullScanPenalty: true}}, memo.Cost{C: 1.0, Flags: memo.CostFlags{HugeCostPenalty: true}}, true},
+		{memo.MaxCost, memo.Cost{C: 1.0}, false},
+		{memo.Cost{C: 0.0}, memo.MaxCost, true},
+		{memo.MaxCost, memo.MaxCost, false},
+		{memo.MaxCost, memo.Cost{C: 1.0, Flags: memo.CostFlags{FullScanPenalty: true}}, false},
+		{memo.Cost{C: 1.0, Flags: memo.CostFlags{HugeCostPenalty: true}}, memo.MaxCost, true},
 	}
 	for _, tc := range testCases {
 		if tc.left.Less(tc.right) != tc.expected {
@@ -42,8 +51,45 @@ func TestCostAdd(t *testing.T) {
 		{memo.Cost{C: 0.0}, memo.Cost{C: 0.0}, memo.Cost{C: 0.0}},
 		{memo.Cost{C: -1.0}, memo.Cost{C: 1.0}, memo.Cost{C: 0.0}},
 		{memo.Cost{C: 1.5}, memo.Cost{C: 2.5}, memo.Cost{C: 4.0}},
+		{memo.Cost{C: 1.0, Flags: memo.CostFlags{FullScanPenalty: true}}, memo.Cost{C: 2.0}, memo.Cost{C: 3.0, Flags: memo.CostFlags{FullScanPenalty: true}}},
+		{memo.Cost{C: 1.0}, memo.Cost{C: 2.0, Flags: memo.CostFlags{HugeCostPenalty: true}}, memo.Cost{C: 3.0, Flags: memo.CostFlags{HugeCostPenalty: true}}},
 	}
+	for _, tc := range testCases {
+		tc.left.Add(tc.right)
+		if tc.left != tc.expected {
+			t.Errorf("expected %v.Add(%v) to be %v, got %v", tc.left, tc.right, tc.expected, tc.left)
+		}
+	}
+}
 
+func TestCostFlagsLess(t *testing.T) {
+	testCases := []struct {
+		left, right memo.CostFlags
+		expected    bool
+	}{
+		{memo.CostFlags{FullScanPenalty: false, HugeCostPenalty: false}, memo.CostFlags{FullScanPenalty: true, HugeCostPenalty: true}, true},
+		{memo.CostFlags{FullScanPenalty: true, HugeCostPenalty: true}, memo.CostFlags{FullScanPenalty: false, HugeCostPenalty: false}, false},
+		{memo.CostFlags{FullScanPenalty: true, HugeCostPenalty: true}, memo.CostFlags{FullScanPenalty: true, HugeCostPenalty: true}, false},
+		{memo.CostFlags{FullScanPenalty: false}, memo.CostFlags{FullScanPenalty: true}, true},
+		{memo.CostFlags{HugeCostPenalty: false}, memo.CostFlags{HugeCostPenalty: true}, true},
+	}
+	for _, tc := range testCases {
+		if tc.left.Less(tc.right) != tc.expected {
+			t.Errorf("expected %v.Less(%v) to be %v", tc.left, tc.right, tc.expected)
+		}
+	}
+}
+
+func TestCostFlagsAdd(t *testing.T) {
+	testCases := []struct {
+		left, right, expected memo.CostFlags
+	}{
+		{memo.CostFlags{FullScanPenalty: false, HugeCostPenalty: false}, memo.CostFlags{FullScanPenalty: true, HugeCostPenalty: true}, memo.CostFlags{FullScanPenalty: true, HugeCostPenalty: true}},
+		{memo.CostFlags{FullScanPenalty: true, HugeCostPenalty: true}, memo.CostFlags{FullScanPenalty: false, HugeCostPenalty: false}, memo.CostFlags{FullScanPenalty: true, HugeCostPenalty: true}},
+		{memo.CostFlags{FullScanPenalty: false}, memo.CostFlags{FullScanPenalty: true}, memo.CostFlags{FullScanPenalty: true}},
+		{memo.CostFlags{HugeCostPenalty: false}, memo.CostFlags{HugeCostPenalty: true}, memo.CostFlags{HugeCostPenalty: true}},
+		{memo.CostFlags{FullScanPenalty: true, HugeCostPenalty: false}, memo.CostFlags{FullScanPenalty: false, HugeCostPenalty: true}, memo.CostFlags{FullScanPenalty: true, HugeCostPenalty: true}},
+	}
 	for _, tc := range testCases {
 		tc.left.Add(tc.right)
 		if tc.left != tc.expected {

--- a/pkg/sql/opt/memo/cost_test.go
+++ b/pkg/sql/opt/memo/cost_test.go
@@ -16,16 +16,16 @@ func TestCostLess(t *testing.T) {
 		left, right memo.Cost
 		expected    bool
 	}{
-		{0.0, 1.0, true},
-		{0.0, 1e-20, true},
-		{0.0, 0.0, false},
-		{1.0, 0.0, false},
-		{1e-20, 1.0000000000001e-20, false},
-		{1e-20, 1.000001e-20, true},
-		{1, 1.00000000000001, false},
-		{1, 1.00000001, true},
-		{1000, 1000.00000000001, false},
-		{1000, 1000.00001, true},
+		{memo.Cost{C: 0.0}, memo.Cost{C: 1.0}, true},
+		{memo.Cost{C: 0.0}, memo.Cost{C: 1e-20}, true},
+		{memo.Cost{C: 0.0}, memo.Cost{C: 0.0}, false},
+		{memo.Cost{C: 1.0}, memo.Cost{C: 0.0}, false},
+		{memo.Cost{C: 1e-20}, memo.Cost{C: 1.0000000000001e-20}, false},
+		{memo.Cost{C: 1e-20}, memo.Cost{C: 1.000001e-20}, true},
+		{memo.Cost{C: 1}, memo.Cost{C: 1.00000000000001}, false},
+		{memo.Cost{C: 1}, memo.Cost{C: 1.00000001}, true},
+		{memo.Cost{C: 1000}, memo.Cost{C: 1000.00000000001}, false},
+		{memo.Cost{C: 1000}, memo.Cost{C: 1000.00001}, true},
 	}
 	for _, tc := range testCases {
 		if tc.left.Less(tc.right) != tc.expected {
@@ -34,15 +34,20 @@ func TestCostLess(t *testing.T) {
 	}
 }
 
-func TestCostSub(t *testing.T) {
-	testSub := func(left, right memo.Cost, expected memo.Cost) {
-		actual := left.Sub(right)
-		if actual != expected {
-			t.Errorf("expected %v.Sub(%v) to be %v, got %v", left, right, expected, actual)
-		}
+func TestCostAdd(t *testing.T) {
+	testCases := []struct {
+		left, right, expected memo.Cost
+	}{
+		{memo.Cost{C: 1.0}, memo.Cost{C: 2.0}, memo.Cost{C: 3.0}},
+		{memo.Cost{C: 0.0}, memo.Cost{C: 0.0}, memo.Cost{C: 0.0}},
+		{memo.Cost{C: -1.0}, memo.Cost{C: 1.0}, memo.Cost{C: 0.0}},
+		{memo.Cost{C: 1.5}, memo.Cost{C: 2.5}, memo.Cost{C: 4.0}},
 	}
 
-	testSub(memo.Cost(10.0), memo.Cost(3.0), memo.Cost(7.0))
-	testSub(memo.Cost(3.0), memo.Cost(10.0), memo.Cost(-7.0))
-	testSub(memo.Cost(10.0), memo.Cost(10.0), memo.Cost(0.0))
+	for _, tc := range testCases {
+		tc.left.Add(tc.right)
+		if tc.left != tc.expected {
+			t.Errorf("expected %v.Add(%v) to be %v, got %v", tc.left, tc.right, tc.expected, tc.left)
+		}
+	}
 }

--- a/pkg/sql/opt/memo/expr.go
+++ b/pkg/sql/opt/memo/expr.go
@@ -409,6 +409,9 @@ type ScanFlags struct {
 	// NoFullScan disallows use of a full scan for scanning this table.
 	NoFullScan bool
 
+	// AvoidFullScan avoids use of a full scan for scanning this table.
+	AvoidFullScan bool
+
 	// ForceIndex forces the use of a specific index (specified in Index).
 	// ForceIndex and NoIndexJoin cannot both be set at the same time.
 	ForceIndex bool

--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -846,8 +846,8 @@ func (f *ExprFmtCtx) formatRelational(e RelExpr, tp treeprinter.Node) {
 
 	if !f.HasFlags(ExprFmtHideCost) {
 		cost := e.Cost()
-		if cost != 0 {
-			tp.Childf("cost: %.9g", cost)
+		if cost.C != 0 {
+			tp.Childf("cost: %.9g", cost.C)
 		}
 	}
 

--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -861,6 +861,9 @@ func (f *ExprFmtCtx) formatRelational(e RelExpr, tp treeprinter.Node) {
 			if cost.Flags.HugeCostPenalty {
 				b.WriteString(" huge-cost-penalty")
 			}
+			if cost.Flags.UnboundedCardinality {
+				b.WriteString(" unbounded-cardinality")
+			}
 			tp.Child(b.String())
 		}
 	}

--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -514,6 +514,9 @@ func (f *ExprFmtCtx) formatRelational(e RelExpr, tp treeprinter.Node) {
 			if private.Flags.NoFullScan {
 				b.WriteString(" no-full-scan")
 			}
+			if private.Flags.AvoidFullScan {
+				b.WriteString(" avoid-full-scan")
+			}
 			if private.Flags.ForceZigzag {
 				if private.Flags.ZigzagIndexes.Empty() {
 					b.WriteString(" force-zigzag")
@@ -848,6 +851,17 @@ func (f *ExprFmtCtx) formatRelational(e RelExpr, tp treeprinter.Node) {
 		cost := e.Cost()
 		if cost.C != 0 {
 			tp.Childf("cost: %.9g", cost.C)
+		}
+		if !cost.Flags.Empty() {
+			var b strings.Builder
+			b.WriteString("cost-flags:")
+			if cost.Flags.FullScanPenalty {
+				b.WriteString(" full-scan-penalty")
+			}
+			if cost.Flags.HugeCostPenalty {
+				b.WriteString(" huge-cost-penalty")
+			}
+			tp.Child(b.String())
 		}
 	}
 

--- a/pkg/sql/opt/memo/interner.go
+++ b/pkg/sql/opt/memo/interner.go
@@ -514,6 +514,7 @@ func (h *hasher) HashScanFlags(val ScanFlags) {
 	h.HashBool(val.NoIndexJoin)
 	h.HashBool(val.NoZigzagJoin)
 	h.HashBool(val.NoFullScan)
+	h.HashBool(val.AvoidFullScan)
 	h.HashBool(val.ForceIndex)
 	h.HashBool(val.ForceInvertedIndex)
 	h.HashBool(val.ForceZigzag)

--- a/pkg/sql/opt/memo/interner_test.go
+++ b/pkg/sql/opt/memo/interner_test.go
@@ -397,7 +397,7 @@ func TestInterner(t *testing.T) {
 		{hashFn: in.hasher.HashScanFlags, eqFn: in.hasher.IsScanFlagsEqual, variations: []testVariation{
 			// Use unnamed fields so that compilation fails if a new field is
 			// added to ScanFlags.
-			{val1: ScanFlags{false, false, false, false, false, false, false, 0, 0, intsets.Fast{}}, val2: ScanFlags{}, equal: true},
+			{val1: ScanFlags{false, false, false, false, false, false, false, false, 0, 0, intsets.Fast{}}, val2: ScanFlags{}, equal: true},
 			{val1: ScanFlags{}, val2: ScanFlags{}, equal: true},
 			{val1: ScanFlags{NoIndexJoin: false}, val2: ScanFlags{NoIndexJoin: true}, equal: false},
 			{val1: ScanFlags{NoIndexJoin: true}, val2: ScanFlags{NoIndexJoin: true}, equal: true},
@@ -412,6 +412,8 @@ func TestInterner(t *testing.T) {
 			{val1: ScanFlags{NoIndexJoin: true, Index: 1}, val2: ScanFlags{NoIndexJoin: false, Index: 1}, equal: false},
 			{val1: ScanFlags{NoFullScan: true}, val2: ScanFlags{NoFullScan: false}, equal: false},
 			{val1: ScanFlags{NoFullScan: true}, val2: ScanFlags{NoFullScan: true}, equal: true},
+			{val1: ScanFlags{AvoidFullScan: true}, val2: ScanFlags{AvoidFullScan: false}, equal: false},
+			{val1: ScanFlags{AvoidFullScan: true}, val2: ScanFlags{AvoidFullScan: true}, equal: true},
 			{val1: ScanFlags{ForceInvertedIndex: true}, val2: ScanFlags{ForceInvertedIndex: false}, equal: false},
 			{val1: ScanFlags{ForceInvertedIndex: true}, val2: ScanFlags{ForceInvertedIndex: true}, equal: true},
 			{

--- a/pkg/sql/opt/memo/memo.go
+++ b/pkg/sql/opt/memo/memo.go
@@ -197,6 +197,7 @@ type Memo struct {
 	pushLimitIntoProjectFilteredScan           bool
 	legacyVarcharTyping                        bool
 	preferBoundedCardinality                   bool
+	minRowCount                                float64
 
 	// txnIsoLevel is the isolation level under which the plan was created. This
 	// affects the planning of some locking operations, so it must be included in
@@ -285,6 +286,7 @@ func (m *Memo) Init(ctx context.Context, evalCtx *eval.Context) {
 		pushLimitIntoProjectFilteredScan:           evalCtx.SessionData().OptimizerPushLimitIntoProjectFilteredScan,
 		legacyVarcharTyping:                        evalCtx.SessionData().LegacyVarcharTyping,
 		preferBoundedCardinality:                   evalCtx.SessionData().OptimizerPreferBoundedCardinality,
+		minRowCount:                                evalCtx.SessionData().OptimizerMinRowCount,
 		txnIsoLevel:                                evalCtx.TxnIsoLevel,
 	}
 	m.metadata.Init()
@@ -451,6 +453,7 @@ func (m *Memo) IsStale(
 		m.pushLimitIntoProjectFilteredScan != evalCtx.SessionData().OptimizerPushLimitIntoProjectFilteredScan ||
 		m.legacyVarcharTyping != evalCtx.SessionData().LegacyVarcharTyping ||
 		m.preferBoundedCardinality != evalCtx.SessionData().OptimizerPreferBoundedCardinality ||
+		m.minRowCount != evalCtx.SessionData().OptimizerMinRowCount ||
 		m.txnIsoLevel != evalCtx.TxnIsoLevel {
 		return true, nil
 	}

--- a/pkg/sql/opt/memo/memo.go
+++ b/pkg/sql/opt/memo/memo.go
@@ -196,6 +196,7 @@ type Memo struct {
 	pushOffsetIntoIndexJoin                    bool
 	pushLimitIntoProjectFilteredScan           bool
 	legacyVarcharTyping                        bool
+	preferBoundedCardinality                   bool
 
 	// txnIsoLevel is the isolation level under which the plan was created. This
 	// affects the planning of some locking operations, so it must be included in
@@ -283,6 +284,7 @@ func (m *Memo) Init(ctx context.Context, evalCtx *eval.Context) {
 		pushOffsetIntoIndexJoin:                    evalCtx.SessionData().OptimizerPushOffsetIntoIndexJoin,
 		pushLimitIntoProjectFilteredScan:           evalCtx.SessionData().OptimizerPushLimitIntoProjectFilteredScan,
 		legacyVarcharTyping:                        evalCtx.SessionData().LegacyVarcharTyping,
+		preferBoundedCardinality:                   evalCtx.SessionData().OptimizerPreferBoundedCardinality,
 		txnIsoLevel:                                evalCtx.TxnIsoLevel,
 	}
 	m.metadata.Init()
@@ -448,6 +450,7 @@ func (m *Memo) IsStale(
 		m.pushOffsetIntoIndexJoin != evalCtx.SessionData().OptimizerPushOffsetIntoIndexJoin ||
 		m.pushLimitIntoProjectFilteredScan != evalCtx.SessionData().OptimizerPushLimitIntoProjectFilteredScan ||
 		m.legacyVarcharTyping != evalCtx.SessionData().LegacyVarcharTyping ||
+		m.preferBoundedCardinality != evalCtx.SessionData().OptimizerPreferBoundedCardinality ||
 		m.txnIsoLevel != evalCtx.TxnIsoLevel {
 		return true, nil
 	}

--- a/pkg/sql/opt/memo/memo.go
+++ b/pkg/sql/opt/memo/memo.go
@@ -493,7 +493,7 @@ func (m *Memo) SetBestProps(
 				redact.Safe(e.Cost()),
 				required.String(),
 				provided.String(), // Call String() so provided doesn't escape.
-				cost,
+				cost.C,
 			))
 		}
 		return
@@ -526,7 +526,7 @@ func (m *Memo) OptimizationCost() Cost {
 	// This cpuCostFactor is the same as cpuCostFactor in the coster.
 	// TODO(mgartner): Package these constants up in a shared location.
 	const cpuCostFactor = 0.01
-	return Cost(m.Metadata().NumTables()) * 1000 * cpuCostFactor
+	return Cost{C: float64(m.Metadata().NumTables()) * 1000 * cpuCostFactor}
 }
 
 // NextRank returns a new rank that can be assigned to a scalar expression.

--- a/pkg/sql/opt/memo/memo_test.go
+++ b/pkg/sql/opt/memo/memo_test.go
@@ -513,6 +513,11 @@ func TestMemoIsStale(t *testing.T) {
 	evalCtx.SessionData().OptimizerPreferBoundedCardinality = false
 	notStale()
 
+	evalCtx.SessionData().OptimizerMinRowCount = 1.0
+	stale()
+	evalCtx.SessionData().OptimizerMinRowCount = 0
+	notStale()
+
 	// User no longer has access to view.
 	catalog.View(tree.NewTableNameWithSchema("t", catconstants.PublicSchemaName, "abcview")).Revoked = true
 	_, err = o.Memo().IsStale(ctx, &evalCtx, catalog)

--- a/pkg/sql/opt/memo/memo_test.go
+++ b/pkg/sql/opt/memo/memo_test.go
@@ -508,6 +508,11 @@ func TestMemoIsStale(t *testing.T) {
 	evalCtx.SessionData().LegacyVarcharTyping = false
 	notStale()
 
+	evalCtx.SessionData().OptimizerPreferBoundedCardinality = true
+	stale()
+	evalCtx.SessionData().OptimizerPreferBoundedCardinality = false
+	notStale()
+
 	// User no longer has access to view.
 	catalog.View(tree.NewTableNameWithSchema("t", catconstants.PublicSchemaName, "abcview")).Revoked = true
 	_, err = o.Memo().IsStale(ctx, &evalCtx, catalog)

--- a/pkg/sql/opt/memo/statistics_builder_test.go
+++ b/pkg/sql/opt/memo/statistics_builder_test.go
@@ -111,7 +111,8 @@ func TestGetStatsFromConstraint(t *testing.T) {
 		relProps := &props.Relational{Cardinality: props.AnyCardinality}
 		relProps.NotNullCols = cs.ExtractNotNullCols(&evalCtx)
 		s := relProps.Statistics()
-		s.Init(relProps)
+		const minRowCount = 0
+		s.Init(relProps, minRowCount)
 
 		// Calculate distinct counts.
 		sb.applyConstraintSet(cs, true /* tight */, sel, relProps, relProps.Statistics())

--- a/pkg/sql/opt/memo/testdata/format
+++ b/pkg/sql/opt/memo/testdata/format
@@ -584,6 +584,7 @@ select
  ├── columns: n:1(int!null) a:2(int!null) b:3(int!null) c:4(string)
  ├── stats: [rows=0.9108108, distinct(2)=0.910811, null(2)=0, distinct(3)=0.910811, null(3)=0, distinct(2,3)=0.910811, null(2,3)=0]
  ├── cost: 1e+100
+ ├── cost-flags: huge-cost-penalty
  ├── key: (1)
  ├── fd: ()-->(2,3), (1)-->(4), (3,4)~~>(1)
  ├── prune: (1,4)
@@ -593,6 +594,7 @@ select
  │    ├── flags: force-zigzag
  │    ├── stats: [rows=1000, distinct(1)=1000, null(1)=0, distinct(2)=100, null(2)=10, distinct(3)=100, null(3)=10, distinct(2,3)=1000, null(2,3)=0.1]
  │    ├── cost: 1e+100
+ │    ├── cost-flags: huge-cost-penalty
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
  │    ├── prune: (1-4)
@@ -614,6 +616,7 @@ select
  ├── columns: n:1(int!null) a:2(int!null) b:3(int!null) c:4(string)
  ├── stats: [rows=0.9108108, distinct(2)=0.910811, null(2)=0, distinct(3)=0.910811, null(3)=0, distinct(2,3)=0.910811, null(2,3)=0]
  ├── cost: 1e+100
+ ├── cost-flags: huge-cost-penalty
  ├── key: (1)
  ├── fd: ()-->(2,3), (1)-->(4), (3,4)~~>(1)
  ├── prune: (1,4)
@@ -623,6 +626,7 @@ select
  │    ├── flags: force-zigzag=a_idx
  │    ├── stats: [rows=1000, distinct(1)=1000, null(1)=0, distinct(2)=100, null(2)=10, distinct(3)=100, null(3)=10, distinct(2,3)=1000, null(2,3)=0.1]
  │    ├── cost: 1e+100
+ │    ├── cost-flags: huge-cost-penalty
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
  │    ├── prune: (1-4)
@@ -644,6 +648,7 @@ select
  ├── columns: n:1(int!null) a:2(int!null) b:3(int!null) c:4(string)
  ├── stats: [rows=0.9108108, distinct(2)=0.910811, null(2)=0, distinct(3)=0.910811, null(3)=0, distinct(2,3)=0.910811, null(2,3)=0]
  ├── cost: 1e+100
+ ├── cost-flags: huge-cost-penalty
  ├── key: (1)
  ├── fd: ()-->(2,3), (1)-->(4), (3,4)~~>(1)
  ├── prune: (1,4)
@@ -653,6 +658,7 @@ select
  │    ├── flags: force-zigzag=b_idx
  │    ├── stats: [rows=1000, distinct(1)=1000, null(1)=0, distinct(2)=100, null(2)=10, distinct(3)=100, null(3)=10, distinct(2,3)=1000, null(2,3)=0.1]
  │    ├── cost: 1e+100
+ │    ├── cost-flags: huge-cost-penalty
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
  │    ├── prune: (1-4)
@@ -674,6 +680,7 @@ select
  ├── columns: n:1(int!null) a:2(int!null) b:3(int!null) c:4(string)
  ├── stats: [rows=0.9108108, distinct(2)=0.910811, null(2)=0, distinct(3)=0.910811, null(3)=0, distinct(2,3)=0.910811, null(2,3)=0]
  ├── cost: 1e+100
+ ├── cost-flags: huge-cost-penalty
  ├── key: (1)
  ├── fd: ()-->(2,3), (1)-->(4), (3,4)~~>(1)
  ├── prune: (1,4)
@@ -683,6 +690,7 @@ select
  │    ├── flags: force-zigzag=a_idx,b_idx
  │    ├── stats: [rows=1000, distinct(1)=1000, null(1)=0, distinct(2)=100, null(2)=10, distinct(3)=100, null(3)=10, distinct(2,3)=1000, null(2,3)=0.1]
  │    ├── cost: 1e+100
+ │    ├── cost-flags: huge-cost-penalty
  │    ├── key: (1)
  │    ├── fd: (1)-->(2-4), (3,4)~~>(1,2)
  │    ├── prune: (1-4)

--- a/pkg/sql/opt/memo/testdata/memo
+++ b/pkg/sql/opt/memo/testdata/memo
@@ -128,7 +128,7 @@ WHERE a.y>1 AND a.x::string=b.x
 ORDER BY y
 LIMIT 10
 ----
-memo (optimized, ~25KB, required=[presentation: y:2,x:6,c:11] [ordering: +2])
+memo (optimized, ~26KB, required=[presentation: y:2,x:6,c:11] [ordering: +2])
  ├── G1: (project G2 G3 y x)
  │    ├── [presentation: y:2,x:6,c:11] [ordering: +2]
  │    │    ├── best: (project G2="[ordering: +2]" G3 y x)

--- a/pkg/sql/opt/memo/testdata/memo
+++ b/pkg/sql/opt/memo/testdata/memo
@@ -413,7 +413,7 @@ memo (optimized, ~6KB, required=[presentation: array_cat_agg:6])
 memo
 SELECT DISTINCT info FROM [EXPLAIN SELECT 123 AS k]
 ----
-memo (optimized, ~9KB, required=[presentation: info:3])
+memo (optimized, ~10KB, required=[presentation: info:3])
  ├── G1: (distinct-on G2 G3 cols=(3))
  │    └── [presentation: info:3]
  │         ├── best: (distinct-on G2 G3 cols=(3))

--- a/pkg/sql/opt/memo/testdata/stats/inverted-geo
+++ b/pkg/sql/opt/memo/testdata/stats/inverted-geo
@@ -303,7 +303,7 @@ select
 memo
 SELECT * FROM t WHERE g IS NULL OR st_intersects('LINESTRING(100 100, 150 150)', g)
 ----
-memo (optimized, ~5KB, required=[presentation: i:1,g:2])
+memo (optimized, ~6KB, required=[presentation: i:1,g:2])
  ├── G1: (select G2 G3)
  │    └── [presentation: i:1,g:2]
  │         ├── best: (select G2 G3)

--- a/pkg/sql/opt/opbench/opbench_test.go
+++ b/pkg/sql/opt/opbench/opbench_test.go
@@ -269,7 +269,7 @@ func runBench(t *testing.T, spec *opbench.Spec, path string, mode runMode) {
 			t.Fatal(err)
 		}
 
-		cost := fmt.Sprintf("%f", e.(memo.RelExpr).Cost())
+		cost := fmt.Sprintf("%f", e.(memo.RelExpr).Cost().C)
 
 		if mode.rewriteEstimated {
 			newRecord[estimatedIdx] = cost

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -653,6 +653,7 @@ func (b *Builder) buildScan(
 		private.Flags.NoIndexJoin = indexFlags.NoIndexJoin
 		private.Flags.NoZigzagJoin = indexFlags.NoZigzagJoin
 		private.Flags.NoFullScan = indexFlags.NoFullScan
+		private.Flags.AvoidFullScan = indexFlags.AvoidFullScan
 		private.Flags.ForceInvertedIndex = indexFlags.ForceInvertedIndex
 		if indexFlags.Index != "" || indexFlags.IndexID != 0 {
 			idx := -1

--- a/pkg/sql/opt/optgen/exprgen/expr_gen.go
+++ b/pkg/sql/opt/optgen/exprgen/expr_gen.go
@@ -402,7 +402,7 @@ func (eg *exprGen) populateBestProps(
 		} else {
 			childProps = xform.BuildChildPhysicalPropsScalar(eg.mem, expr, i)
 		}
-		cost += eg.populateBestProps(ctx, expr.Child(i), childProps)
+		cost.Add(eg.populateBestProps(ctx, expr.Child(i), childProps))
 	}
 
 	if rel != nil {
@@ -412,7 +412,7 @@ func (eg *exprGen) populateBestProps(
 		provided.Ordering = ordering.BuildProvided(eg.f.EvalContext(), rel, &required.Ordering)
 		provided.Distribution = distribution.BuildProvided(ctx, eg.f.EvalContext(), rel, &required.Distribution)
 
-		cost += eg.coster.ComputeCost(rel, required)
+		cost.Add(eg.coster.ComputeCost(rel, required))
 		eg.mem.SetBestProps(rel, required, provided, cost)
 	}
 	return cost

--- a/pkg/sql/opt/testutils/opttester/opt_tester.go
+++ b/pkg/sql/opt/testutils/opttester/opt_tester.go
@@ -1816,7 +1816,7 @@ func (ot *OptTester) optStepsDisplay(before string, after string, os *optSteps) 
 		ot.separator("=")
 		ot.output(format, args...)
 		if rel, ok := e.(memo.RelExpr); ok {
-			ot.output("  Cost: %.2f\n", rel.Cost())
+			ot.output("  Cost: %.2f\n", rel.Cost().C)
 		} else {
 			ot.output("\n")
 		}

--- a/pkg/sql/opt/xform/coster.go
+++ b/pkg/sql/opt/xform/coster.go
@@ -145,12 +145,6 @@ const (
 	// up with better way to incorporate latency into the coster.
 	latencyCostFactor = cpuCostFactor
 
-	// hugeCost is used with expressions we want to avoid; these are expressions
-	// that "violate" a hint like forcing a specific index or join algorithm.
-	// If the final expression has this cost or larger, it means that there was no
-	// plan that could satisfy the hints.
-	hugeCost memo.Cost = 1e100
-
 	// fullScanRowCountPenalty adds a penalty to full table scans. This is especially
 	// useful for empty or very small tables, where we would get plans that are
 	// surprising to users (like full scans instead of point lookups).
@@ -167,32 +161,6 @@ const (
 	// helps prevent surprising plans for very small tables or for when stats are
 	// stale.
 	largeMaxCardinalityScanCostPenalty = unboundedMaxCardinalityScanCostPenalty / 2
-
-	// SmallDistributeCost is the per-operation cost overhead for scans which may
-	// access remote regions, but the scanned table is unpartitioned with no lease
-	// preferences, so locality information is not available. The distribution
-	// cost is unknown, so a small overhead cost is added to give optimizations
-	// like locality-optimized search a chance to get picked.
-	SmallDistributeCost = randIOCostFactor
-
-	// DistributeCost is the per-operation cost overhead for Distribute operations
-	// or scans which access remote regions.
-	// TODO(msirek): Measure actual latencies between regions and produce a table
-	//               for determining the maximum latency between the most remote
-	//               region in a distribution and the gateway region.
-	DistributeCost = 200
-
-	// LargeDistributeCost is the cost to use for Distribute operations when a
-	// session mode is set to error out on access of rows from remote regions.
-	LargeDistributeCost = hugeCost
-
-	// LargeDistributeCostWithHomeRegion is the cost to use for Distribute
-	// operations when a session mode is set to error out on access of rows from
-	// remote regions, and the query plan has a home region.
-	// TODO(msirek): Is there a better way of preferring plans that have a home
-	//               region instead of relying on costing, which may not guarantee
-	//               the correct plan is found?
-	LargeDistributeCostWithHomeRegion = LargeDistributeCost / 2
 
 	// preferLookupJoinFactor is a scale factor for the cost of a lookup join when
 	// we have a hint for preferring a lookup join.
@@ -217,6 +185,40 @@ const (
 	spillCostFactor = seqIOCostFactor
 )
 
+var (
+	// hugeCost is used with expressions we want to avoid; these are expressions
+	// that "violate" a hint like forcing a specific index or join algorithm.
+	// If the final expression has this cost or larger, it means that there was no
+	// plan that could satisfy the hints.
+	hugeCost = memo.Cost{C: 1e100}
+
+	// SmallDistributeCost is the per-operation cost overhead for scans which may
+	// access remote regions, but the scanned table is unpartitioned with no lease
+	// preferences, so locality information is not available. The distribution
+	// cost is unknown, so a small overhead cost is added to give optimizations
+	// like locality-optimized search a chance to get picked.
+	SmallDistributeCost = memo.Cost{C: randIOCostFactor}
+
+	// DistributeCost is the per-operation cost overhead for Distribute operations
+	// or scans which access remote regions.
+	// TODO(msirek): Measure actual latencies between regions and produce a table
+	//               for determining the maximum latency between the most remote
+	//               region in a distribution and the gateway region.
+	DistributeCost = memo.Cost{C: 200}
+
+	// LargeDistributeCost is the cost to use for Distribute operations when a
+	// session mode is set to error out on access of rows from remote regions.
+	LargeDistributeCost = hugeCost
+
+	// LargeDistributeCostWithHomeRegion is the cost to use for Distribute
+	// operations when a session mode is set to error out on access of rows from
+	// remote regions, and the query plan has a home region.
+	// TODO(msirek): Is there a better way of preferring plans that have a home
+	//               region instead of relying on costing, which may not guarantee
+	//               the correct plan is found?
+	LargeDistributeCostWithHomeRegion = memo.Cost{C: LargeDistributeCost.C / 2}
+)
+
 // fnCost maps some functions to an execution cost. Currently this list
 // contains only st_* functions, including some we don't have implemented
 // yet. Although function costs differ based on the overload (due to
@@ -228,258 +230,258 @@ const (
 // TODO(mjibson): Add costs directly to overloads. When that is done, we should
 // also add a test that ensures those costs match postgres.
 var fnCost = map[string]memo.Cost{
-	"st_3dclosestpoint":           1000 * cpuCostFactor,
-	"st_3ddfullywithin":           10000 * cpuCostFactor,
-	"st_3ddistance":               1000 * cpuCostFactor,
-	"st_3ddwithin":                10000 * cpuCostFactor,
-	"st_3dintersects":             10000 * cpuCostFactor,
-	"st_3dlength":                 100 * cpuCostFactor,
-	"st_3dlongestline":            1000 * cpuCostFactor,
-	"st_3dmakebox":                100 * cpuCostFactor,
-	"st_3dmaxdistance":            1000 * cpuCostFactor,
-	"st_3dperimeter":              100 * cpuCostFactor,
-	"st_3dshortestline":           1000 * cpuCostFactor,
-	"st_addmeasure":               1000 * cpuCostFactor,
-	"st_addpoint":                 100 * cpuCostFactor,
-	"st_affine":                   100 * cpuCostFactor,
-	"st_angle":                    100 * cpuCostFactor,
-	"st_area":                     100 * cpuCostFactor,
-	"st_area2d":                   100 * cpuCostFactor,
-	"st_asbinary":                 100 * cpuCostFactor,
-	"st_asencodedpolyline":        100 * cpuCostFactor,
-	"st_asewkb":                   100 * cpuCostFactor,
-	"st_asewkt":                   100 * cpuCostFactor,
-	"st_asgeojson":                100 * cpuCostFactor,
-	"st_asgml":                    100 * cpuCostFactor,
-	"st_ashexewkb":                100 * cpuCostFactor,
-	"st_askml":                    100 * cpuCostFactor,
-	"st_aslatlontext":             100 * cpuCostFactor,
-	"st_assvg":                    100 * cpuCostFactor,
-	"st_asmvtgeom":                100 * cpuCostFactor,
-	"st_astext":                   100 * cpuCostFactor,
-	"st_astwkb":                   1000 * cpuCostFactor,
-	"st_asx3d":                    100 * cpuCostFactor,
-	"st_azimuth":                  100 * cpuCostFactor,
-	"st_bdmpolyfromtext":          100 * cpuCostFactor,
-	"st_bdpolyfromtext":           100 * cpuCostFactor,
-	"st_boundary":                 1000 * cpuCostFactor,
-	"st_boundingdiagonal":         100 * cpuCostFactor,
-	"st_box2dfromgeohash":         1000 * cpuCostFactor,
-	"st_buffer":                   100 * cpuCostFactor,
-	"st_buildarea":                10000 * cpuCostFactor,
-	"st_centroid":                 100 * cpuCostFactor,
-	"st_chaikinsmoothing":         10000 * cpuCostFactor,
-	"st_cleangeometry":            10000 * cpuCostFactor,
-	"st_clipbybox2d":              10000 * cpuCostFactor,
-	"st_closestpoint":             1000 * cpuCostFactor,
-	"st_closestpointofapproach":   10000 * cpuCostFactor,
-	"st_clusterdbscan":            10000 * cpuCostFactor,
-	"st_clusterintersecting":      10000 * cpuCostFactor,
-	"st_clusterkmeans":            10000 * cpuCostFactor,
-	"st_clusterwithin":            10000 * cpuCostFactor,
-	"st_collectionextract":        100 * cpuCostFactor,
-	"st_collectionhomogenize":     100 * cpuCostFactor,
-	"st_concavehull":              10000 * cpuCostFactor,
-	"st_contains":                 10000 * cpuCostFactor,
-	"st_containsproperly":         10000 * cpuCostFactor,
-	"st_convexhull":               10000 * cpuCostFactor,
-	"st_coorddim":                 100 * cpuCostFactor,
-	"st_coveredby":                100 * cpuCostFactor,
-	"st_covers":                   100 * cpuCostFactor,
-	"st_cpawithin":                10000 * cpuCostFactor,
-	"st_createtopogeo":            100 * cpuCostFactor,
-	"st_crosses":                  10000 * cpuCostFactor,
-	"st_curvetoline":              10000 * cpuCostFactor,
-	"st_delaunaytriangles":        10000 * cpuCostFactor,
-	"st_dfullywithin":             10000 * cpuCostFactor,
-	"st_difference":               10000 * cpuCostFactor,
-	"st_dimension":                100 * cpuCostFactor,
-	"st_disjoint":                 10000 * cpuCostFactor,
-	"st_distance":                 100 * cpuCostFactor,
-	"st_distancecpa":              10000 * cpuCostFactor,
-	"st_distancesphere":           100 * cpuCostFactor,
-	"st_distancespheroid":         1000 * cpuCostFactor,
-	"st_dump":                     1000 * cpuCostFactor,
-	"st_dumppoints":               100 * cpuCostFactor,
-	"st_dumprings":                1000 * cpuCostFactor,
-	"st_dwithin":                  100 * cpuCostFactor,
-	"st_endpoint":                 100 * cpuCostFactor,
-	"st_envelope":                 100 * cpuCostFactor,
-	"st_equals":                   10000 * cpuCostFactor,
-	"st_expand":                   100 * cpuCostFactor,
-	"st_exteriorring":             100 * cpuCostFactor,
-	"st_filterbym":                1000 * cpuCostFactor,
-	"st_findextent":               100 * cpuCostFactor,
-	"st_flipcoordinates":          1000 * cpuCostFactor,
-	"st_force2d":                  100 * cpuCostFactor,
-	"st_force3d":                  100 * cpuCostFactor,
-	"st_force3dm":                 100 * cpuCostFactor,
-	"st_force3dz":                 100 * cpuCostFactor,
-	"st_force4d":                  100 * cpuCostFactor,
-	"st_forcecollection":          100 * cpuCostFactor,
-	"st_forcecurve":               1000 * cpuCostFactor,
-	"st_forcepolygonccw":          100 * cpuCostFactor,
-	"st_forcepolygoncw":           1000 * cpuCostFactor,
-	"st_forcerhr":                 1000 * cpuCostFactor,
-	"st_forcesfs":                 1000 * cpuCostFactor,
-	"st_frechetdistance":          10000 * cpuCostFactor,
-	"st_generatepoints":           10000 * cpuCostFactor,
-	"st_geogfromtext":             100 * cpuCostFactor,
-	"st_geogfromwkb":              100 * cpuCostFactor,
-	"st_geographyfromtext":        100 * cpuCostFactor,
-	"st_geohash":                  1000 * cpuCostFactor,
-	"st_geomcollfromtext":         100 * cpuCostFactor,
-	"st_geomcollfromwkb":          100 * cpuCostFactor,
-	"st_geometricmedian":          10000 * cpuCostFactor,
-	"st_geometryfromtext":         1000 * cpuCostFactor,
-	"st_geometryn":                100 * cpuCostFactor,
-	"st_geometrytype":             100 * cpuCostFactor,
-	"st_geomfromewkb":             100 * cpuCostFactor,
-	"st_geomfromewkt":             100 * cpuCostFactor,
-	"st_geomfromgeohash":          1000 * cpuCostFactor,
-	"st_geomfromgeojson":          1000 * cpuCostFactor,
-	"st_geomfromgml":              100 * cpuCostFactor,
-	"st_geomfromkml":              1000 * cpuCostFactor,
-	"st_geomfromtext":             1000 * cpuCostFactor,
-	"st_geomfromtwkb":             100 * cpuCostFactor,
-	"st_geomfromwkb":              100 * cpuCostFactor,
-	"st_gmltosql":                 100 * cpuCostFactor,
-	"st_hasarc":                   100 * cpuCostFactor,
-	"st_hausdorffdistance":        10000 * cpuCostFactor,
-	"st_inittopogeo":              100 * cpuCostFactor,
-	"st_interiorringn":            100 * cpuCostFactor,
-	"st_interpolatepoint":         1000 * cpuCostFactor,
-	"st_intersection":             100 * cpuCostFactor,
-	"st_intersects":               100 * cpuCostFactor,
-	"st_isclosed":                 100 * cpuCostFactor,
-	"st_iscollection":             1000 * cpuCostFactor,
-	"st_isempty":                  100 * cpuCostFactor,
-	"st_ispolygonccw":             100 * cpuCostFactor,
-	"st_ispolygoncw":              100 * cpuCostFactor,
-	"st_isring":                   1000 * cpuCostFactor,
-	"st_issimple":                 1000 * cpuCostFactor,
-	"st_isvalid":                  100 * cpuCostFactor,
-	"st_isvaliddetail":            10000 * cpuCostFactor,
-	"st_isvalidreason":            100 * cpuCostFactor,
-	"st_isvalidtrajectory":        10000 * cpuCostFactor,
-	"st_length":                   100 * cpuCostFactor,
-	"st_length2d":                 100 * cpuCostFactor,
-	"st_length2dspheroid":         1000 * cpuCostFactor,
-	"st_lengthspheroid":           1000 * cpuCostFactor,
-	"st_linecrossingdirection":    10000 * cpuCostFactor,
-	"st_linefromencodedpolyline":  1000 * cpuCostFactor,
-	"st_linefrommultipoint":       100 * cpuCostFactor,
-	"st_linefromtext":             100 * cpuCostFactor,
-	"st_linefromwkb":              100 * cpuCostFactor,
-	"st_lineinterpolatepoint":     1000 * cpuCostFactor,
-	"st_lineinterpolatepoints":    1000 * cpuCostFactor,
-	"st_linelocatepoint":          1000 * cpuCostFactor,
-	"st_linemerge":                10000 * cpuCostFactor,
-	"st_linestringfromwkb":        100 * cpuCostFactor,
-	"st_linesubstring":            1000 * cpuCostFactor,
-	"st_linetocurve":              10000 * cpuCostFactor,
-	"st_locatealong":              1000 * cpuCostFactor,
-	"st_locatebetween":            1000 * cpuCostFactor,
-	"st_locatebetweenelevations":  1000 * cpuCostFactor,
-	"st_longestline":              100 * cpuCostFactor,
-	"st_makeenvelope":             100 * cpuCostFactor,
-	"st_makeline":                 100 * cpuCostFactor,
-	"st_makepoint":                100 * cpuCostFactor,
-	"st_makepointm":               100 * cpuCostFactor,
-	"st_makepolygon":              100 * cpuCostFactor,
-	"st_makevalid":                10000 * cpuCostFactor,
-	"st_maxdistance":              100 * cpuCostFactor,
-	"st_memsize":                  100 * cpuCostFactor,
-	"st_minimumboundingcircle":    10000 * cpuCostFactor,
-	"st_minimumboundingradius":    10000 * cpuCostFactor,
-	"st_minimumclearance":         10000 * cpuCostFactor,
-	"st_minimumclearanceline":     10000 * cpuCostFactor,
-	"st_mlinefromtext":            100 * cpuCostFactor,
-	"st_mlinefromwkb":             100 * cpuCostFactor,
-	"st_mpointfromtext":           100 * cpuCostFactor,
-	"st_mpointfromwkb":            100 * cpuCostFactor,
-	"st_mpolyfromtext":            100 * cpuCostFactor,
-	"st_mpolyfromwkb":             100 * cpuCostFactor,
-	"st_multi":                    100 * cpuCostFactor,
-	"st_multilinefromwkb":         100 * cpuCostFactor,
-	"st_multilinestringfromtext":  100 * cpuCostFactor,
-	"st_multipointfromtext":       100 * cpuCostFactor,
-	"st_multipointfromwkb":        100 * cpuCostFactor,
-	"st_multipolyfromwkb":         100 * cpuCostFactor,
-	"st_multipolygonfromtext":     100 * cpuCostFactor,
-	"st_node":                     10000 * cpuCostFactor,
-	"st_normalize":                100 * cpuCostFactor,
-	"st_npoints":                  100 * cpuCostFactor,
-	"st_nrings":                   100 * cpuCostFactor,
-	"st_numgeometries":            100 * cpuCostFactor,
-	"st_numinteriorring":          100 * cpuCostFactor,
-	"st_numinteriorrings":         100 * cpuCostFactor,
-	"st_numpatches":               100 * cpuCostFactor,
-	"st_numpoints":                100 * cpuCostFactor,
-	"st_offsetcurve":              10000 * cpuCostFactor,
-	"st_orderingequals":           10000 * cpuCostFactor,
-	"st_orientedenvelope":         10000 * cpuCostFactor,
-	"st_overlaps":                 10000 * cpuCostFactor,
-	"st_patchn":                   100 * cpuCostFactor,
-	"st_perimeter":                100 * cpuCostFactor,
-	"st_perimeter2d":              100 * cpuCostFactor,
-	"st_point":                    100 * cpuCostFactor,
-	"st_pointfromgeohash":         1000 * cpuCostFactor,
-	"st_pointfromtext":            100 * cpuCostFactor,
-	"st_pointfromwkb":             100 * cpuCostFactor,
-	"st_pointinsidecircle":        1000 * cpuCostFactor,
-	"st_pointn":                   100 * cpuCostFactor,
-	"st_pointonsurface":           1000 * cpuCostFactor,
-	"st_points":                   1000 * cpuCostFactor,
-	"st_polyfromtext":             100 * cpuCostFactor,
-	"st_polyfromwkb":              100 * cpuCostFactor,
-	"st_polygon":                  100 * cpuCostFactor,
-	"st_polygonfromtext":          100 * cpuCostFactor,
-	"st_polygonfromwkb":           100 * cpuCostFactor,
-	"st_polygonize":               10000 * cpuCostFactor,
-	"st_project":                  1000 * cpuCostFactor,
-	"st_quantizecoordinates":      1000 * cpuCostFactor,
-	"st_relate":                   10000 * cpuCostFactor,
-	"st_relatematch":              1000 * cpuCostFactor,
-	"st_removepoint":              100 * cpuCostFactor,
-	"st_removerepeatedpoints":     1000 * cpuCostFactor,
-	"st_reverse":                  1000 * cpuCostFactor,
-	"st_rotate":                   100 * cpuCostFactor,
-	"st_rotatex":                  100 * cpuCostFactor,
-	"st_rotatey":                  100 * cpuCostFactor,
-	"st_rotatez":                  100 * cpuCostFactor,
-	"st_scale":                    100 * cpuCostFactor,
-	"st_segmentize":               1000 * cpuCostFactor,
-	"st_seteffectivearea":         1000 * cpuCostFactor,
-	"st_setpoint":                 100 * cpuCostFactor,
-	"st_setsrid":                  100 * cpuCostFactor,
-	"st_sharedpaths":              10000 * cpuCostFactor,
-	"st_shortestline":             1000 * cpuCostFactor,
-	"st_simplify":                 100 * cpuCostFactor,
-	"st_simplifypreservetopology": 10000 * cpuCostFactor,
-	"st_simplifyvw":               10000 * cpuCostFactor,
-	"st_snap":                     10000 * cpuCostFactor,
-	"st_snaptogrid":               100 * cpuCostFactor,
-	"st_split":                    10000 * cpuCostFactor,
-	"st_srid":                     100 * cpuCostFactor,
-	"st_startpoint":               100 * cpuCostFactor,
-	"st_subdivide":                10000 * cpuCostFactor,
-	"st_summary":                  100 * cpuCostFactor,
-	"st_swapordinates":            100 * cpuCostFactor,
-	"st_symdifference":            10000 * cpuCostFactor,
-	"st_symmetricdifference":      10000 * cpuCostFactor,
-	"st_tileenvelope":             100 * cpuCostFactor,
-	"st_touches":                  10000 * cpuCostFactor,
-	"st_transform":                100 * cpuCostFactor,
-	"st_translate":                100 * cpuCostFactor,
-	"st_transscale":               100 * cpuCostFactor,
-	"st_unaryunion":               10000 * cpuCostFactor,
-	"st_union":                    10000 * cpuCostFactor,
-	"st_voronoilines":             100 * cpuCostFactor,
-	"st_voronoipolygons":          100 * cpuCostFactor,
-	"st_within":                   10000 * cpuCostFactor,
-	"st_wkbtosql":                 100 * cpuCostFactor,
-	"st_wkttosql":                 1000 * cpuCostFactor,
+	"st_3dclosestpoint":           {C: 1000 * cpuCostFactor},
+	"st_3ddfullywithin":           {C: 10000 * cpuCostFactor},
+	"st_3ddistance":               {C: 1000 * cpuCostFactor},
+	"st_3ddwithin":                {C: 10000 * cpuCostFactor},
+	"st_3dintersects":             {C: 10000 * cpuCostFactor},
+	"st_3dlength":                 {C: 100 * cpuCostFactor},
+	"st_3dlongestline":            {C: 1000 * cpuCostFactor},
+	"st_3dmakebox":                {C: 100 * cpuCostFactor},
+	"st_3dmaxdistance":            {C: 1000 * cpuCostFactor},
+	"st_3dperimeter":              {C: 100 * cpuCostFactor},
+	"st_3dshortestline":           {C: 1000 * cpuCostFactor},
+	"st_addmeasure":               {C: 1000 * cpuCostFactor},
+	"st_addpoint":                 {C: 100 * cpuCostFactor},
+	"st_affine":                   {C: 100 * cpuCostFactor},
+	"st_angle":                    {C: 100 * cpuCostFactor},
+	"st_area":                     {C: 100 * cpuCostFactor},
+	"st_area2d":                   {C: 100 * cpuCostFactor},
+	"st_asbinary":                 {C: 100 * cpuCostFactor},
+	"st_asencodedpolyline":        {C: 100 * cpuCostFactor},
+	"st_asewkb":                   {C: 100 * cpuCostFactor},
+	"st_asewkt":                   {C: 100 * cpuCostFactor},
+	"st_asgeojson":                {C: 100 * cpuCostFactor},
+	"st_asgml":                    {C: 100 * cpuCostFactor},
+	"st_ashexewkb":                {C: 100 * cpuCostFactor},
+	"st_askml":                    {C: 100 * cpuCostFactor},
+	"st_aslatlontext":             {C: 100 * cpuCostFactor},
+	"st_assvg":                    {C: 100 * cpuCostFactor},
+	"st_asmvtgeom":                {C: 100 * cpuCostFactor},
+	"st_astext":                   {C: 100 * cpuCostFactor},
+	"st_astwkb":                   {C: 1000 * cpuCostFactor},
+	"st_asx3d":                    {C: 100 * cpuCostFactor},
+	"st_azimuth":                  {C: 100 * cpuCostFactor},
+	"st_bdmpolyfromtext":          {C: 100 * cpuCostFactor},
+	"st_bdpolyfromtext":           {C: 100 * cpuCostFactor},
+	"st_boundary":                 {C: 1000 * cpuCostFactor},
+	"st_boundingdiagonal":         {C: 100 * cpuCostFactor},
+	"st_box2dfromgeohash":         {C: 1000 * cpuCostFactor},
+	"st_buffer":                   {C: 100 * cpuCostFactor},
+	"st_buildarea":                {C: 10000 * cpuCostFactor},
+	"st_centroid":                 {C: 100 * cpuCostFactor},
+	"st_chaikinsmoothing":         {C: 10000 * cpuCostFactor},
+	"st_cleangeometry":            {C: 10000 * cpuCostFactor},
+	"st_clipbybox2d":              {C: 10000 * cpuCostFactor},
+	"st_closestpoint":             {C: 1000 * cpuCostFactor},
+	"st_closestpointofapproach":   {C: 10000 * cpuCostFactor},
+	"st_clusterdbscan":            {C: 10000 * cpuCostFactor},
+	"st_clusterintersecting":      {C: 10000 * cpuCostFactor},
+	"st_clusterkmeans":            {C: 10000 * cpuCostFactor},
+	"st_clusterwithin":            {C: 10000 * cpuCostFactor},
+	"st_collectionextract":        {C: 100 * cpuCostFactor},
+	"st_collectionhomogenize":     {C: 100 * cpuCostFactor},
+	"st_concavehull":              {C: 10000 * cpuCostFactor},
+	"st_contains":                 {C: 10000 * cpuCostFactor},
+	"st_containsproperly":         {C: 10000 * cpuCostFactor},
+	"st_convexhull":               {C: 10000 * cpuCostFactor},
+	"st_coorddim":                 {C: 100 * cpuCostFactor},
+	"st_coveredby":                {C: 100 * cpuCostFactor},
+	"st_covers":                   {C: 100 * cpuCostFactor},
+	"st_cpawithin":                {C: 10000 * cpuCostFactor},
+	"st_createtopogeo":            {C: 100 * cpuCostFactor},
+	"st_crosses":                  {C: 10000 * cpuCostFactor},
+	"st_curvetoline":              {C: 10000 * cpuCostFactor},
+	"st_delaunaytriangles":        {C: 10000 * cpuCostFactor},
+	"st_dfullywithin":             {C: 10000 * cpuCostFactor},
+	"st_difference":               {C: 10000 * cpuCostFactor},
+	"st_dimension":                {C: 100 * cpuCostFactor},
+	"st_disjoint":                 {C: 10000 * cpuCostFactor},
+	"st_distance":                 {C: 100 * cpuCostFactor},
+	"st_distancecpa":              {C: 10000 * cpuCostFactor},
+	"st_distancesphere":           {C: 100 * cpuCostFactor},
+	"st_distancespheroid":         {C: 1000 * cpuCostFactor},
+	"st_dump":                     {C: 1000 * cpuCostFactor},
+	"st_dumppoints":               {C: 100 * cpuCostFactor},
+	"st_dumprings":                {C: 1000 * cpuCostFactor},
+	"st_dwithin":                  {C: 100 * cpuCostFactor},
+	"st_endpoint":                 {C: 100 * cpuCostFactor},
+	"st_envelope":                 {C: 100 * cpuCostFactor},
+	"st_equals":                   {C: 10000 * cpuCostFactor},
+	"st_expand":                   {C: 100 * cpuCostFactor},
+	"st_exteriorring":             {C: 100 * cpuCostFactor},
+	"st_filterbym":                {C: 1000 * cpuCostFactor},
+	"st_findextent":               {C: 100 * cpuCostFactor},
+	"st_flipcoordinates":          {C: 1000 * cpuCostFactor},
+	"st_force2d":                  {C: 100 * cpuCostFactor},
+	"st_force3d":                  {C: 100 * cpuCostFactor},
+	"st_force3dm":                 {C: 100 * cpuCostFactor},
+	"st_force3dz":                 {C: 100 * cpuCostFactor},
+	"st_force4d":                  {C: 100 * cpuCostFactor},
+	"st_forcecollection":          {C: 100 * cpuCostFactor},
+	"st_forcecurve":               {C: 1000 * cpuCostFactor},
+	"st_forcepolygonccw":          {C: 100 * cpuCostFactor},
+	"st_forcepolygoncw":           {C: 1000 * cpuCostFactor},
+	"st_forcerhr":                 {C: 1000 * cpuCostFactor},
+	"st_forcesfs":                 {C: 1000 * cpuCostFactor},
+	"st_frechetdistance":          {C: 10000 * cpuCostFactor},
+	"st_generatepoints":           {C: 10000 * cpuCostFactor},
+	"st_geogfromtext":             {C: 100 * cpuCostFactor},
+	"st_geogfromwkb":              {C: 100 * cpuCostFactor},
+	"st_geographyfromtext":        {C: 100 * cpuCostFactor},
+	"st_geohash":                  {C: 1000 * cpuCostFactor},
+	"st_geomcollfromtext":         {C: 100 * cpuCostFactor},
+	"st_geomcollfromwkb":          {C: 100 * cpuCostFactor},
+	"st_geometricmedian":          {C: 10000 * cpuCostFactor},
+	"st_geometryfromtext":         {C: 1000 * cpuCostFactor},
+	"st_geometryn":                {C: 100 * cpuCostFactor},
+	"st_geometrytype":             {C: 100 * cpuCostFactor},
+	"st_geomfromewkb":             {C: 100 * cpuCostFactor},
+	"st_geomfromewkt":             {C: 100 * cpuCostFactor},
+	"st_geomfromgeohash":          {C: 1000 * cpuCostFactor},
+	"st_geomfromgeojson":          {C: 1000 * cpuCostFactor},
+	"st_geomfromgml":              {C: 100 * cpuCostFactor},
+	"st_geomfromkml":              {C: 1000 * cpuCostFactor},
+	"st_geomfromtext":             {C: 1000 * cpuCostFactor},
+	"st_geomfromtwkb":             {C: 100 * cpuCostFactor},
+	"st_geomfromwkb":              {C: 100 * cpuCostFactor},
+	"st_gmltosql":                 {C: 100 * cpuCostFactor},
+	"st_hasarc":                   {C: 100 * cpuCostFactor},
+	"st_hausdorffdistance":        {C: 10000 * cpuCostFactor},
+	"st_inittopogeo":              {C: 100 * cpuCostFactor},
+	"st_interiorringn":            {C: 100 * cpuCostFactor},
+	"st_interpolatepoint":         {C: 1000 * cpuCostFactor},
+	"st_intersection":             {C: 100 * cpuCostFactor},
+	"st_intersects":               {C: 100 * cpuCostFactor},
+	"st_isclosed":                 {C: 100 * cpuCostFactor},
+	"st_iscollection":             {C: 1000 * cpuCostFactor},
+	"st_isempty":                  {C: 100 * cpuCostFactor},
+	"st_ispolygonccw":             {C: 100 * cpuCostFactor},
+	"st_ispolygoncw":              {C: 100 * cpuCostFactor},
+	"st_isring":                   {C: 1000 * cpuCostFactor},
+	"st_issimple":                 {C: 1000 * cpuCostFactor},
+	"st_isvalid":                  {C: 100 * cpuCostFactor},
+	"st_isvaliddetail":            {C: 10000 * cpuCostFactor},
+	"st_isvalidreason":            {C: 100 * cpuCostFactor},
+	"st_isvalidtrajectory":        {C: 10000 * cpuCostFactor},
+	"st_length":                   {C: 100 * cpuCostFactor},
+	"st_length2d":                 {C: 100 * cpuCostFactor},
+	"st_length2dspheroid":         {C: 1000 * cpuCostFactor},
+	"st_lengthspheroid":           {C: 1000 * cpuCostFactor},
+	"st_linecrossingdirection":    {C: 10000 * cpuCostFactor},
+	"st_linefromencodedpolyline":  {C: 1000 * cpuCostFactor},
+	"st_linefrommultipoint":       {C: 100 * cpuCostFactor},
+	"st_linefromtext":             {C: 100 * cpuCostFactor},
+	"st_linefromwkb":              {C: 100 * cpuCostFactor},
+	"st_lineinterpolatepoint":     {C: 1000 * cpuCostFactor},
+	"st_lineinterpolatepoints":    {C: 1000 * cpuCostFactor},
+	"st_linelocatepoint":          {C: 1000 * cpuCostFactor},
+	"st_linemerge":                {C: 10000 * cpuCostFactor},
+	"st_linestringfromwkb":        {C: 100 * cpuCostFactor},
+	"st_linesubstring":            {C: 1000 * cpuCostFactor},
+	"st_linetocurve":              {C: 10000 * cpuCostFactor},
+	"st_locatealong":              {C: 1000 * cpuCostFactor},
+	"st_locatebetween":            {C: 1000 * cpuCostFactor},
+	"st_locatebetweenelevations":  {C: 1000 * cpuCostFactor},
+	"st_longestline":              {C: 100 * cpuCostFactor},
+	"st_makeenvelope":             {C: 100 * cpuCostFactor},
+	"st_makeline":                 {C: 100 * cpuCostFactor},
+	"st_makepoint":                {C: 100 * cpuCostFactor},
+	"st_makepointm":               {C: 100 * cpuCostFactor},
+	"st_makepolygon":              {C: 100 * cpuCostFactor},
+	"st_makevalid":                {C: 10000 * cpuCostFactor},
+	"st_maxdistance":              {C: 100 * cpuCostFactor},
+	"st_memsize":                  {C: 100 * cpuCostFactor},
+	"st_minimumboundingcircle":    {C: 10000 * cpuCostFactor},
+	"st_minimumboundingradius":    {C: 10000 * cpuCostFactor},
+	"st_minimumclearance":         {C: 10000 * cpuCostFactor},
+	"st_minimumclearanceline":     {C: 10000 * cpuCostFactor},
+	"st_mlinefromtext":            {C: 100 * cpuCostFactor},
+	"st_mlinefromwkb":             {C: 100 * cpuCostFactor},
+	"st_mpointfromtext":           {C: 100 * cpuCostFactor},
+	"st_mpointfromwkb":            {C: 100 * cpuCostFactor},
+	"st_mpolyfromtext":            {C: 100 * cpuCostFactor},
+	"st_mpolyfromwkb":             {C: 100 * cpuCostFactor},
+	"st_multi":                    {C: 100 * cpuCostFactor},
+	"st_multilinefromwkb":         {C: 100 * cpuCostFactor},
+	"st_multilinestringfromtext":  {C: 100 * cpuCostFactor},
+	"st_multipointfromtext":       {C: 100 * cpuCostFactor},
+	"st_multipointfromwkb":        {C: 100 * cpuCostFactor},
+	"st_multipolyfromwkb":         {C: 100 * cpuCostFactor},
+	"st_multipolygonfromtext":     {C: 100 * cpuCostFactor},
+	"st_node":                     {C: 10000 * cpuCostFactor},
+	"st_normalize":                {C: 100 * cpuCostFactor},
+	"st_npoints":                  {C: 100 * cpuCostFactor},
+	"st_nrings":                   {C: 100 * cpuCostFactor},
+	"st_numgeometries":            {C: 100 * cpuCostFactor},
+	"st_numinteriorring":          {C: 100 * cpuCostFactor},
+	"st_numinteriorrings":         {C: 100 * cpuCostFactor},
+	"st_numpatches":               {C: 100 * cpuCostFactor},
+	"st_numpoints":                {C: 100 * cpuCostFactor},
+	"st_offsetcurve":              {C: 10000 * cpuCostFactor},
+	"st_orderingequals":           {C: 10000 * cpuCostFactor},
+	"st_orientedenvelope":         {C: 10000 * cpuCostFactor},
+	"st_overlaps":                 {C: 10000 * cpuCostFactor},
+	"st_patchn":                   {C: 100 * cpuCostFactor},
+	"st_perimeter":                {C: 100 * cpuCostFactor},
+	"st_perimeter2d":              {C: 100 * cpuCostFactor},
+	"st_point":                    {C: 100 * cpuCostFactor},
+	"st_pointfromgeohash":         {C: 1000 * cpuCostFactor},
+	"st_pointfromtext":            {C: 100 * cpuCostFactor},
+	"st_pointfromwkb":             {C: 100 * cpuCostFactor},
+	"st_pointinsidecircle":        {C: 1000 * cpuCostFactor},
+	"st_pointn":                   {C: 100 * cpuCostFactor},
+	"st_pointonsurface":           {C: 1000 * cpuCostFactor},
+	"st_points":                   {C: 1000 * cpuCostFactor},
+	"st_polyfromtext":             {C: 100 * cpuCostFactor},
+	"st_polyfromwkb":              {C: 100 * cpuCostFactor},
+	"st_polygon":                  {C: 100 * cpuCostFactor},
+	"st_polygonfromtext":          {C: 100 * cpuCostFactor},
+	"st_polygonfromwkb":           {C: 100 * cpuCostFactor},
+	"st_polygonize":               {C: 10000 * cpuCostFactor},
+	"st_project":                  {C: 1000 * cpuCostFactor},
+	"st_quantizecoordinates":      {C: 1000 * cpuCostFactor},
+	"st_relate":                   {C: 10000 * cpuCostFactor},
+	"st_relatematch":              {C: 1000 * cpuCostFactor},
+	"st_removepoint":              {C: 100 * cpuCostFactor},
+	"st_removerepeatedpoints":     {C: 1000 * cpuCostFactor},
+	"st_reverse":                  {C: 1000 * cpuCostFactor},
+	"st_rotate":                   {C: 100 * cpuCostFactor},
+	"st_rotatex":                  {C: 100 * cpuCostFactor},
+	"st_rotatey":                  {C: 100 * cpuCostFactor},
+	"st_rotatez":                  {C: 100 * cpuCostFactor},
+	"st_scale":                    {C: 100 * cpuCostFactor},
+	"st_segmentize":               {C: 1000 * cpuCostFactor},
+	"st_seteffectivearea":         {C: 1000 * cpuCostFactor},
+	"st_setpoint":                 {C: 100 * cpuCostFactor},
+	"st_setsrid":                  {C: 100 * cpuCostFactor},
+	"st_sharedpaths":              {C: 10000 * cpuCostFactor},
+	"st_shortestline":             {C: 1000 * cpuCostFactor},
+	"st_simplify":                 {C: 100 * cpuCostFactor},
+	"st_simplifypreservetopology": {C: 10000 * cpuCostFactor},
+	"st_simplifyvw":               {C: 10000 * cpuCostFactor},
+	"st_snap":                     {C: 10000 * cpuCostFactor},
+	"st_snaptogrid":               {C: 100 * cpuCostFactor},
+	"st_split":                    {C: 10000 * cpuCostFactor},
+	"st_srid":                     {C: 100 * cpuCostFactor},
+	"st_startpoint":               {C: 100 * cpuCostFactor},
+	"st_subdivide":                {C: 10000 * cpuCostFactor},
+	"st_summary":                  {C: 100 * cpuCostFactor},
+	"st_swapordinates":            {C: 100 * cpuCostFactor},
+	"st_symdifference":            {C: 10000 * cpuCostFactor},
+	"st_symmetricdifference":      {C: 10000 * cpuCostFactor},
+	"st_tileenvelope":             {C: 100 * cpuCostFactor},
+	"st_touches":                  {C: 10000 * cpuCostFactor},
+	"st_transform":                {C: 100 * cpuCostFactor},
+	"st_translate":                {C: 100 * cpuCostFactor},
+	"st_transscale":               {C: 100 * cpuCostFactor},
+	"st_unaryunion":               {C: 10000 * cpuCostFactor},
+	"st_union":                    {C: 10000 * cpuCostFactor},
+	"st_voronoilines":             {C: 100 * cpuCostFactor},
+	"st_voronoipolygons":          {C: 100 * cpuCostFactor},
+	"st_within":                   {C: 10000 * cpuCostFactor},
+	"st_wkbtosql":                 {C: 100 * cpuCostFactor},
+	"st_wkttosql":                 {C: 1000 * cpuCostFactor},
 }
 
 // Init initializes a new coster structure with the given memo.
@@ -595,7 +597,7 @@ func (c *coster) ComputeCost(candidate memo.RelExpr, required *physical.Required
 				// Make the cost of insert fast path slightly cheaper than non-fast path
 				// so that the optimizer will pick it. All of the costed operations
 				// should have identical costs between the two inserts.
-				cost -= cpuCostFactor
+				cost.C -= cpuCostFactor
 			}
 		}
 
@@ -609,13 +611,13 @@ func (c *coster) ComputeCost(candidate memo.RelExpr, required *physical.Required
 	// Add a one-time cost for any operator, meant to reflect the cost of setting
 	// up execution for the operator. This makes plans with fewer operators
 	// preferable, all else being equal.
-	cost += cpuCostFactor
+	cost.C += cpuCostFactor
 
 	// Add a one-time cost for any operator with unbounded cardinality. This
 	// ensures we prefer plans that push limits as far down the tree as possible,
 	// all else being equal.
 	if candidate.Relational().Cardinality.IsUnbounded() {
-		cost += cpuCostFactor
+		cost.C += cpuCostFactor
 	}
 
 	if !cost.Less(memo.MaxCost) {
@@ -627,7 +629,7 @@ func (c *coster) ComputeCost(candidate memo.RelExpr, required *physical.Required
 
 	if c.perturbation != 0 {
 		// Don't perturb the cost if we are forcing an index.
-		if cost < hugeCost {
+		if cost.Less(hugeCost) {
 			// Get a random value in the range [-1.0, 1.0)
 			var multiplier float64
 			if c.rng == nil {
@@ -639,11 +641,8 @@ func (c *coster) ComputeCost(candidate memo.RelExpr, required *physical.Required
 			// If perturbation is p, and the estimated cost of an expression is c,
 			// the new cost is in the range [max(0, c - pc), c + pc). For example,
 			// if p=1.5, the new cost is in the range [0, c + 1.5 * c).
-			cost += cost * memo.Cost(c.perturbation*multiplier)
-			// The cost must always be >= 0.
-			if cost < 0 {
-				cost = 0
-			}
+			perturbedCost := cost.C * (1 + c.perturbation*multiplier)
+			cost.C = math.Max(0, perturbedCost)
 		}
 	}
 
@@ -663,15 +662,15 @@ func (c *coster) computeTopKCost(topk *memo.TopKExpr, required *physical.Require
 	// Add the cost of sorting.
 	// Start with a cost of storing each row; TopK sort only stores K rows in a
 	// max heap.
-	cost := memo.Cost(cpuCostFactor * float64(rel.OutputCols.Len()) * outputRowCount)
+	cost := memo.Cost{C: cpuCostFactor * float64(rel.OutputCols.Len()) * outputRowCount}
 
 	// Add buffering cost for the output rows.
-	cost += c.rowBufferCost(outputRowCount)
+	cost.Add(c.rowBufferCost(outputRowCount))
 
 	// In the worst case, there are O(N*log(K)) comparisons to compare each row in
 	// the input to the top of the max heap and sift the max heap if each row
 	// compared is in the top K found so far.
-	cost += c.rowCmpCost(len(topk.Ordering.Columns)) * memo.Cost((1+math.Log2(math.Max(outputRowCount, 1)))*inputRowCount)
+	cost.C += c.rowCmpCost(len(topk.Ordering.Columns)).C * (1 + math.Log2(math.Max(outputRowCount, 1))) * inputRowCount
 
 	// TODO(harding): Add the CPU cost of emitting the K output rows. This should
 	// be done in conjunction with computeSortCost.
@@ -698,14 +697,14 @@ func (c *coster) computeSortCost(sort *memo.SortExpr, required *physical.Require
 	// Start with a cost of storing each row; this takes the total number of
 	// columns into account so that a sort on fewer columns is preferred (e.g.
 	// sort before projecting a new column).
-	cost := memo.Cost(cpuCostFactor * float64(rel.OutputCols.Len()) * stats.RowCount)
+	cost := memo.Cost{C: cpuCostFactor * float64(rel.OutputCols.Len()) * stats.RowCount}
 
 	if !sort.InputOrdering.Any() {
 		// Add the cost for finding the segments: each row is compared to the
 		// previous row on the preordered columns. Most of these comparisons will
 		// yield equality, so we don't use rowCmpCost(): we expect to have to
 		// compare all preordered columns.
-		cost += cpuCostFactor * memo.Cost(numPreorderedCols) * memo.Cost(stats.RowCount)
+		cost.C += cpuCostFactor * float64(numPreorderedCols) * stats.RowCount
 	}
 
 	// Add the cost to sort the segments. On average, each row is involved in
@@ -716,9 +715,9 @@ func (c *coster) computeSortCost(sort *memo.SortExpr, required *physical.Require
 
 		// Add a cost for buffering rows that takes into account increased memory
 		// pressure and the possibility of spilling to disk.
-		cost += memo.Cost(numSegments) * c.rowBufferCost(segmentSize)
+		cost.C += numSegments * c.rowBufferCost(segmentSize).C
 	}
-	cost += c.rowCmpCost(numKeyCols-numPreorderedCols) * memo.Cost(numCmpOpsPerRow*stats.RowCount)
+	cost.C += c.rowCmpCost(numKeyCols-numPreorderedCols).C * numCmpOpsPerRow * stats.RowCount
 	// TODO(harding): Add the CPU cost of emitting the output rows. This should be
 	// done in conjunction with computeTopKCost.
 	return cost
@@ -729,7 +728,7 @@ func (c *coster) computeDistributeCost(
 ) memo.Cost {
 	if distribute.NoOpDistribution() {
 		// If the distribution will be elided, the cost is zero.
-		return memo.Cost(0)
+		return memo.Cost{C: 0}
 	}
 	if target, source, ok := distribute.GetDistributions(); ok {
 		if distributionIsLocal(target, c.evalCtx) {
@@ -801,11 +800,11 @@ func (c *coster) computeScanCost(scan *memo.ScanExpr, required *physical.Require
 	} else if scan.InvertedConstraint != nil {
 		numSpans = len(scan.InvertedConstraint)
 	}
-	baseCost := memo.Cost(numSpans * randIOCostFactor)
+	baseCost := memo.Cost{C: float64(numSpans) * randIOCostFactor}
 
 	// If this is a virtual scan, add the cost of fetching table descriptors.
 	if c.mem.Metadata().Table(scan.Table).IsVirtualTable() {
-		baseCost += virtualScanTableDescriptorFetchCost
+		baseCost.C += virtualScanTableDescriptorFetchCost
 	}
 
 	// Performing a reverse scan is more expensive than a forward scan, but it's
@@ -816,7 +815,7 @@ func (c *coster) computeScanCost(scan *memo.ScanExpr, required *physical.Require
 	if ordering.ScanIsReverse(scan, &required.Ordering) {
 		if rowCount > 1 {
 			// Need to do binary search to seek to the previous row.
-			perRowCost += memo.Cost(math.Log2(rowCount)) * cpuCostFactor
+			perRowCost.C += math.Log2(rowCount) * cpuCostFactor
 		}
 	}
 
@@ -833,7 +832,7 @@ func (c *coster) computeScanCost(scan *memo.ScanExpr, required *physical.Require
 		if partitionCount := index.PartitionCount(); partitionCount > 1 {
 			// Subtract 1 since we already accounted for the first partition when
 			// counting spans.
-			baseCost += memo.Cost(partitionCount-1) * randIOCostFactor
+			baseCost.C += float64(partitionCount-1) * randIOCostFactor
 		}
 	}
 
@@ -844,13 +843,14 @@ func (c *coster) computeScanCost(scan *memo.ScanExpr, required *physical.Require
 	// Note: we add this to the baseCost rather than the rowCount, so that the
 	// number of index columns does not have an outsized effect on the cost of
 	// the scan. See issue #68556.
-	baseCost += c.largeCardinalityCostPenalty(scan.Relational().Cardinality, rowCount)
+	baseCost.Add(c.largeCardinalityCostPenalty(scan.Relational().Cardinality, rowCount))
 
 	if required.LimitHint != 0 {
 		rowCount = math.Min(rowCount, required.LimitHint)
 	}
 
-	cost := baseCost + memo.Cost(rowCount)*(seqIOCostFactor+perRowCost)
+	cost := baseCost
+	cost.C += rowCount * (seqIOCostFactor + perRowCost.C)
 
 	var regionsAccessed physical.Distribution
 	if scan.Distribution.Regions != nil {
@@ -863,7 +863,7 @@ func (c *coster) computeScanCost(scan *memo.ScanExpr, required *physical.Require
 		return cost
 	}
 	extraCost := c.distributionCost(regionsAccessed)
-	cost += extraCost
+	cost.Add(extraCost)
 	return cost
 }
 
@@ -892,14 +892,14 @@ func (c *coster) distributionCost(regionsAccessed physical.Distribution) (cost m
 	// TODO(rytaft,msirek): Compute a real cost here. Currently this is a rough
 	//                      estimate of latency overhead, but actual measurements
 	//                      would be useful.
-	extraCost := memo.Cost(DistributeCost)
+	extraCost := DistributeCost
 	if regionsAccessed.Any() {
 		// Non-multiregion tables may have no regions populated in regionsAccessed.
 		// To avoid potential plan regressions involving non-multiregion tables,
 		// don't add the somewhat large `DistributeCost` when
 		// `regionsAccessed.Any()` is true because query planning can't be done in
 		// that case to try and avoid the distribution anyway.
-		extraCost = memo.Cost(SmallDistributeCost)
+		extraCost = SmallDistributeCost
 	} else if !regionsAccessed.Any() && c.evalCtx != nil &&
 		c.evalCtx.Planner.EnforceHomeRegion() {
 		if len(regionsAccessed.Regions) == 1 {
@@ -924,8 +924,8 @@ func (c *coster) computeSelectCost(sel *memo.SelectExpr, required *physical.Requ
 	}
 
 	filterSetup, filterPerRow := c.computeFiltersCost(sel.Filters, intsets.Fast{})
-	cost := memo.Cost(inputRowCount) * filterPerRow
-	cost += filterSetup
+	cost := memo.Cost{C: inputRowCount * filterPerRow.C}
+	cost.Add(filterSetup)
 	return cost
 }
 
@@ -933,22 +933,22 @@ func (c *coster) computeProjectCost(prj *memo.ProjectExpr) memo.Cost {
 	// Each synthesized column causes an expression to be evaluated on each row.
 	rowCount := prj.Relational().Statistics().RowCount
 	synthesizedColCount := len(prj.Projections)
-	cost := memo.Cost(rowCount) * memo.Cost(synthesizedColCount) * cpuCostFactor
+	cost := memo.Cost{C: rowCount * float64(synthesizedColCount) * cpuCostFactor}
 
 	// Add the CPU cost of emitting the rows.
-	cost += memo.Cost(rowCount) * cpuCostFactor
+	cost.C += rowCount * cpuCostFactor
 	return cost
 }
 
 func (c *coster) computeInvertedFilterCost(invFilter *memo.InvertedFilterExpr) memo.Cost {
 	// The filter has to be evaluated on each input row.
 	inputRowCount := invFilter.Input.Relational().Statistics().RowCount
-	cost := memo.Cost(inputRowCount) * cpuCostFactor
+	cost := memo.Cost{C: inputRowCount * cpuCostFactor}
 	return cost
 }
 
 func (c *coster) computeValuesCost(values *memo.ValuesExpr) memo.Cost {
-	return memo.Cost(values.Relational().Statistics().RowCount) * cpuCostFactor
+	return memo.Cost{C: values.Relational().Statistics().RowCount * cpuCostFactor}
 }
 
 func (c *coster) computeHashJoinCost(join memo.RelExpr) memo.Cost {
@@ -978,11 +978,11 @@ func (c *coster) computeHashJoinCost(join memo.RelExpr) memo.Cost {
 	// right side is the one stored in the hashtable, so we use a larger factor
 	// for that side. This ensures that a join with the smaller right side is
 	// preferred to the symmetric join.
-	cost := memo.Cost(1.25*leftRowCount+1.75*rightRowCount) * cpuCostFactor
+	cost := memo.Cost{C: (1.25*leftRowCount + 1.75*rightRowCount) * cpuCostFactor}
 
 	// Add a cost for buffering rows that takes into account increased memory
 	// pressure and the possibility of spilling to disk.
-	cost += c.rowBufferCost(rightRowCount)
+	cost.Add(c.rowBufferCost(rightRowCount))
 
 	// Compute filter cost. Fetch the indices of the filters that will be used in
 	// the join, since they will not add to the cost and should be skipped.
@@ -991,7 +991,7 @@ func (c *coster) computeHashJoinCost(join memo.RelExpr) memo.Cost {
 	rightCols := join.Child(1).(memo.RelExpr).Relational().OutputCols
 	filtersToSkip := memo.ExtractJoinConditionFilterOrds(leftCols, rightCols, *on, false /* inequality */)
 	filterSetup, filterPerRow := c.computeFiltersCost(*on, filtersToSkip)
-	cost += filterSetup
+	cost.Add(filterSetup)
 
 	// Add the CPU cost of emitting the rows.
 	rowsProcessed, ok := c.mem.RowsProcessed(join)
@@ -1000,7 +1000,7 @@ func (c *coster) computeHashJoinCost(join memo.RelExpr) memo.Cost {
 		// of rows.
 		rowsProcessed = join.Relational().Statistics().RowCount
 	}
-	cost += memo.Cost(rowsProcessed) * filterPerRow
+	cost.C += rowsProcessed * filterPerRow.C
 
 	return cost
 }
@@ -1025,10 +1025,10 @@ func (c *coster) computeMergeJoinCost(join *memo.MergeJoinExpr) memo.Cost {
 	// whereas the left side is processed in a streaming fashion. To account for
 	// this difference, we multiply both row counts so that a join with the
 	// smaller right side is preferred to the symmetric join.
-	cost := memo.Cost(0.9*leftRowCount+1.1*rightRowCount) * cpuCostFactor
+	cost := memo.Cost{C: (0.9*leftRowCount + 1.1*rightRowCount) * cpuCostFactor}
 
 	filterSetup, filterPerRow := c.computeFiltersCost(join.On, intsets.Fast{})
-	cost += filterSetup
+	cost.Add(filterSetup)
 
 	// Add the CPU cost of emitting the rows.
 	rowsProcessed, ok := c.mem.RowsProcessed(join)
@@ -1038,7 +1038,7 @@ func (c *coster) computeMergeJoinCost(join *memo.MergeJoinExpr) memo.Cost {
 		// logPropsBuilder.clear() is called.
 		panic(errors.AssertionFailedf("could not get rows processed for merge join"))
 	}
-	cost += memo.Cost(rowsProcessed) * filterPerRow
+	cost.C += rowsProcessed * filterPerRow.C
 	return cost
 }
 
@@ -1078,7 +1078,7 @@ func (c *coster) computeLookupJoinCost(
 	_, provided := distribution.BuildLookupJoinLookupTableDistribution(
 		c.ctx, c.evalCtx, join, required, c.MaybeGetBestCostRelation)
 	extraCost := c.distributionCost(provided)
-	cost += extraCost
+	cost.Add(extraCost)
 	return cost
 }
 
@@ -1134,17 +1134,17 @@ func (c *coster) computeIndexLookupJoinCost(
 		// 100 ranges showed that a "non-parallel" lookup join is about 5 times
 		// slower.
 		// TODO(drewk): this no longer applies now that the streamer work is used.
-		perLookupCost += 4 * randIOCostFactor
+		perLookupCost.C += 4 * randIOCostFactor
 	}
 	if c.mem.Metadata().Table(table).IsVirtualTable() {
 		// It's expensive to perform a lookup join into a virtual table because
 		// we need to fetch the table descriptors on each lookup.
-		perLookupCost += virtualScanTableDescriptorFetchCost
+		perLookupCost.C += virtualScanTableDescriptorFetchCost
 	}
-	cost := memo.Cost(lookupCount) * perLookupCost
+	cost := memo.Cost{C: lookupCount * perLookupCost.C}
 
 	filterSetup, filterPerRow := c.computeFiltersCost(on, intsets.Fast{})
-	cost += filterSetup
+	cost.Add(filterSetup)
 
 	// Each lookup might retrieve many rows; add the IO cost of retrieving the
 	// rows (relevant when we expect many resulting rows per lookup) and the CPU
@@ -1152,14 +1152,14 @@ func (c *coster) computeIndexLookupJoinCost(
 	// TODO(harding): Add the cost of reading all columns in the lookup table when
 	// we cost rows by column size.
 	lookupCols := cols.Difference(input.Relational().OutputCols)
-	perRowCost := lookupJoinRetrieveRowCost + filterPerRow +
-		c.rowScanCost(table, index, lookupCols)
+	perRowCost := lookupJoinRetrieveRowCost + filterPerRow.C +
+		c.rowScanCost(table, index, lookupCols).C
 
-	cost += memo.Cost(rowsProcessed) * perRowCost
+	cost.C += rowsProcessed * perRowCost
 
 	if flags.Has(memo.PreferLookupJoinIntoRight) {
 		// If we prefer a lookup join, make the cost much smaller.
-		cost *= preferLookupJoinFactor
+		cost.C *= preferLookupJoinFactor
 	}
 
 	// If this lookup join is locality optimized, divide the cost by 2.5 in order to make
@@ -1168,7 +1168,7 @@ func (c *coster) computeIndexLookupJoinCost(
 	// TODO(rytaft): This is hacky. We should really be making this determination
 	// based on the latency between regions.
 	if localityOptimized {
-		cost /= 2.5
+		cost.C /= 2.5
 	}
 	return cost
 }
@@ -1213,45 +1213,45 @@ func (c *coster) computeInvertedJoinCost(
 	// The rows in the (left) input are used to probe into the (right) table.
 	// Since the matching rows in the table may not all be in the same range, this
 	// counts as random I/O.
-	perLookupCost := memo.Cost(randIOCostFactor)
+	perLookupCost := memo.Cost{C: randIOCostFactor}
 	// Since inverted indexes can't form a key, execution will have to
 	// limit KV batches which prevents running requests to multiple nodes
 	// in parallel.  An experiment on a 4 node cluster with a table with
 	// 100k rows split into 100 ranges showed that a "non-parallel" lookup
 	// join is about 5 times slower.
-	perLookupCost *= 5
-	cost := memo.Cost(lookupCount) * perLookupCost
+	perLookupCost.C *= 5
+	cost := memo.Cost{C: lookupCount * perLookupCost.C}
 
 	filterSetup, filterPerRow := c.computeFiltersCost(join.On, intsets.Fast{})
-	cost += filterSetup
+	cost.Add(filterSetup)
 
 	// Each lookup might retrieve many rows; add the IO cost of retrieving the
 	// rows (relevant when we expect many resulting rows per lookup) and the CPU
 	// cost of emitting the rows.
 	lookupCols := join.Cols.Difference(join.Input.Relational().OutputCols)
-	perRowCost := lookupJoinRetrieveRowCost + filterPerRow +
-		c.rowScanCost(join.Table, join.Index, lookupCols)
+	perRowCost := memo.Cost{C: lookupJoinRetrieveRowCost + filterPerRow.C +
+		c.rowScanCost(join.Table, join.Index, lookupCols).C}
 
-	cost += memo.Cost(rowsProcessed) * perRowCost
+	cost.C += rowsProcessed * perRowCost.C
 
 	provided := distribution.BuildInvertedJoinLookupTableDistribution(c.ctx, c.evalCtx, join)
 	extraCost := c.distributionCost(provided)
-	cost += extraCost
+	cost.Add(extraCost)
 	return cost
 }
 
 // computeExprCost calculates per-row cost of the expression.
 // It finds every embedded spatial function and add its cost.
 func (c *coster) computeExprCost(expr opt.Expr) memo.Cost {
-	perRowCost := memo.Cost(0)
+	perRowCost := memo.Cost{C: 0}
 	if expr.Op() == opt.FunctionOp {
 		// We are ok with the zero value here for functions not in the map.
 		function := expr.(*memo.FunctionExpr)
-		perRowCost += fnCost[function.Name]
+		perRowCost.Add(fnCost[function.Name])
 	}
 	// recurse into the children of the current expression
 	for i := 0; i < expr.ChildCount(); i++ {
-		perRowCost += c.computeExprCost(expr.Child(i))
+		perRowCost.Add(c.computeExprCost(expr.Child(i)))
 	}
 	return perRowCost
 }
@@ -1268,17 +1268,17 @@ func (c *coster) computeFiltersCost(
 ) (setupCost, perRowCost memo.Cost) {
 	// Add a base perRowCost so that callers do not need to have their own
 	// base per-row cost.
-	perRowCost += cpuCostFactor
+	perRowCost.C += cpuCostFactor
 	for i := range filters {
 		if filtersToSkip.Contains(i) {
 			continue
 		}
 		f := &filters[i]
-		perRowCost += c.computeExprCost(f.Condition)
+		perRowCost.Add(c.computeExprCost(f.Condition))
 		// Add a constant "setup" cost per ON condition to account for the fact that
 		// the rowsProcessed estimate alone cannot effectively discriminate between
 		// plans when RowCount is too small.
-		setupCost += cpuCostFactor
+		setupCost.C += cpuCostFactor
 	}
 	return setupCost, perRowCost
 }
@@ -1298,7 +1298,7 @@ func (c *coster) computeZigzagJoinCost(join *memo.ZigzagJoinExpr) memo.Cost {
 	rightCols.IntersectionWith(join.Cols)
 	rightCols.DifferenceWith(leftCols)
 	scanCost := c.rowScanCost(join.LeftTable, join.LeftIndex, leftCols)
-	scanCost += c.rowScanCost(join.RightTable, join.RightIndex, rightCols)
+	scanCost.Add(c.rowScanCost(join.RightTable, join.RightIndex, rightCols))
 
 	filterSetup, filterPerRow := c.computeFiltersCost(join.On, intsets.Fast{})
 
@@ -1318,12 +1318,12 @@ func (c *coster) computeZigzagJoinCost(join *memo.ZigzagJoinExpr) memo.Cost {
 	// See `indexLookupJoinPerLookupCost` and `computeIndexLookupJoinCost`.
 	// Increased zigzag join costs mean that accurate selectivity estimation is
 	// needed to ensure this index access path can be picked.
-	seekCost := memo.Cost(randIOCostFactor + lookupJoinRetrieveRowCost)
+	seekCost := memo.Cost{C: randIOCostFactor + lookupJoinRetrieveRowCost}
 
 	// Double the cost of emitting rows as well as the cost of seeking rows,
 	// given two indexes will be accessed.
-	cost := memo.Cost(rowCount) * (2*(cpuCostFactor+seekCost) + scanCost + filterPerRow)
-	cost += filterSetup
+	cost := memo.Cost{C: rowCount * (2*(cpuCostFactor+seekCost.C) + scanCost.C + filterPerRow.C)}
+	cost.Add(filterSetup)
 
 	// Add a penalty if the cardinality exceeds the row count estimate. Adding a
 	// few rows worth of cost helps prevent surprising plans for very small tables
@@ -1333,19 +1333,19 @@ func (c *coster) computeZigzagJoinCost(join *memo.ZigzagJoinExpr) memo.Cost {
 	// Note: we add this directly to the cost rather than the rowCount, so that
 	// the number of index columns does not have an outsized effect on the cost of
 	// the zigzag join. See issue #68556.
-	cost += c.largeCardinalityCostPenalty(join.Relational().Cardinality, rowCount)
+	cost.Add(c.largeCardinalityCostPenalty(join.Relational().Cardinality, rowCount))
 
 	if c.evalCtx != nil && c.evalCtx.SessionData().OptimizerUseImprovedZigzagJoinCosting {
 		// Add one randIOCostFactor of additional seek cost so the cost is at least as
 		// much as a scan if rowCount is less than one.
-		cost += randIOCostFactor
+		cost.C += randIOCostFactor
 
 		// TODO(rytaft): We don't capture distribution info in zigzag joins, so pass
 		// an empty distribution. We need to add some distribution cost to prevent the
 		// coster from always preferring zigzag joins over scans. If we ever want to
 		// make zigzag joins a priority again, we should store a real distribution
 		// value on the zigzag join, similar to scans.
-		cost += c.distributionCost(physical.Distribution{})
+		cost.Add(c.distributionCost(physical.Distribution{}))
 	}
 
 	return cost
@@ -1365,7 +1365,7 @@ func (c *coster) computeSetCost(set memo.RelExpr, required *physical.Required) m
 	if outputRowCount != 0 && required.LimitHint != 0 && outputRowCount > required.LimitHint {
 		outputRowCount = required.LimitHint
 	}
-	cost := memo.Cost(outputRowCount) * cpuCostFactor
+	cost := memo.Cost{C: outputRowCount * cpuCostFactor}
 
 	// A set operation must process every row from both tables once. UnionAll and
 	// LocalityOptimizedSearch can avoid any extra computation, but all other set
@@ -1379,25 +1379,28 @@ func (c *coster) computeSetCost(set memo.RelExpr, required *physical.Required) m
 		!isStreamingSetOperator(set) {
 		leftRowCount := set.Child(0).(memo.RelExpr).Relational().Statistics().RowCount
 		rightRowCount := set.Child(1).(memo.RelExpr).Relational().Statistics().RowCount
-		cost += memo.Cost(leftRowCount+rightRowCount) * cpuCostFactor
+		cost.C += (leftRowCount + rightRowCount) * cpuCostFactor
 
 		// Add a cost for buffering rows that takes into account increased memory
 		// pressure and the possibility of spilling to disk.
 		switch set.Op() {
 		case opt.UnionOp:
 			// Hash Union is implemented as UnionAll followed by Hash Distinct.
-			cost += c.rowBufferCost(outputRowCount)
+			cost.Add(c.rowBufferCost(outputRowCount))
 
 		case opt.IntersectOp, opt.ExceptOp:
 			// Hash Intersect and Except are implemented as Hash Distinct on each
 			// input followed by a Hash Join that builds the hash table from the right
 			// input.
-			cost += c.rowBufferCost(leftRowCount) + 2*c.rowBufferCost(rightRowCount)
+			cost.Add(c.rowBufferCost(leftRowCount))
+			rightCost := c.rowBufferCost(rightRowCount)
+			cost.Add(rightCost)
+			cost.Add(rightCost)
 
 		case opt.IntersectAllOp, opt.ExceptAllOp:
 			// Hash IntersectAll and ExceptAll are implemented as a Hash Join that
 			// builds the hash table from the right input.
-			cost += c.rowBufferCost(rightRowCount)
+			cost.Add(c.rowBufferCost(rightRowCount))
 
 		default:
 			panic(errors.AssertionFailedf("unhandled operator %s", set.Op()))
@@ -1410,11 +1413,11 @@ func (c *coster) computeGroupingCost(grouping memo.RelExpr, required *physical.R
 	// Start with some extra fixed overhead, since the grouping operators have
 	// setup overhead that is greater than other operators like Project. This
 	// can matter for rules like ReplaceMaxWithLimit.
-	cost := memo.Cost(cpuCostFactor)
+	cost := memo.Cost{C: cpuCostFactor}
 
 	// Add the CPU cost of emitting the rows.
 	outputRowCount := grouping.Relational().Statistics().RowCount
-	cost += memo.Cost(outputRowCount) * cpuCostFactor
+	cost.C += outputRowCount * cpuCostFactor
 
 	private := grouping.Private().(*memo.GroupingPrivate)
 	groupingColCount := private.GroupingCols.Len()
@@ -1441,7 +1444,7 @@ func (c *coster) computeGroupingCost(grouping memo.RelExpr, required *physical.R
 
 	// Cost per row depends on the number of grouping columns and the number of
 	// aggregates.
-	cost += memo.Cost(inputRowCount) * memo.Cost(aggsCount+groupingColCount) * cpuCostFactor
+	cost.C += inputRowCount * float64(aggsCount+groupingColCount) * cpuCostFactor
 
 	// Add a cost that reflects the use of a hash table - unless we are doing a
 	// streaming aggregation.
@@ -1450,11 +1453,11 @@ func (c *coster) computeGroupingCost(grouping memo.RelExpr, required *physical.R
 	// input.
 	if groupingColCount > 0 && streamingType != memo.Streaming {
 		// Add the cost to build the hash table.
-		cost += memo.Cost(inputRowCount) * cpuCostFactor
+		cost.C += inputRowCount * cpuCostFactor
 
 		// Add a cost for buffering rows that takes into account increased memory
 		// pressure and the possibility of spilling to disk.
-		cost += c.rowBufferCost(outputRowCount)
+		cost.Add(c.rowBufferCost(outputRowCount))
 	}
 
 	return cost
@@ -1462,25 +1465,25 @@ func (c *coster) computeGroupingCost(grouping memo.RelExpr, required *physical.R
 
 func (c *coster) computeLimitCost(limit *memo.LimitExpr) memo.Cost {
 	// Add the CPU cost of emitting the rows.
-	cost := memo.Cost(limit.Relational().Statistics().RowCount) * cpuCostFactor
+	cost := memo.Cost{C: limit.Relational().Statistics().RowCount * cpuCostFactor}
 	return cost
 }
 
 func (c *coster) computeOffsetCost(offset *memo.OffsetExpr) memo.Cost {
 	// Add the CPU cost of emitting the rows.
-	cost := memo.Cost(offset.Relational().Statistics().RowCount) * cpuCostFactor
+	cost := memo.Cost{C: offset.Relational().Statistics().RowCount * cpuCostFactor}
 	return cost
 }
 
 func (c *coster) computeOrdinalityCost(ord *memo.OrdinalityExpr) memo.Cost {
 	// Add the CPU cost of emitting the rows.
-	cost := memo.Cost(ord.Relational().Statistics().RowCount) * cpuCostFactor
+	cost := memo.Cost{C: ord.Relational().Statistics().RowCount * cpuCostFactor}
 	return cost
 }
 
 func (c *coster) computeProjectSetCost(projectSet *memo.ProjectSetExpr) memo.Cost {
 	// Add the CPU cost of emitting the rows.
-	cost := memo.Cost(projectSet.Relational().Statistics().RowCount) * cpuCostFactor
+	cost := memo.Cost{C: projectSet.Relational().Statistics().RowCount * cpuCostFactor}
 	return cost
 }
 
@@ -1540,7 +1543,7 @@ func (c *coster) rowCmpCost(numKeyCols int) memo.Cost {
 	// There is a fixed "non-comparison" cost and a comparison cost proportional
 	// to the key columns. Note that the cost has to be high enough so that a
 	// sort is almost always more expensive than a reverse scan or an index scan.
-	return memo.Cost(cost)
+	return memo.Cost{C: cost}
 }
 
 // rowScanCost is the CPU cost to scan one row, which depends on the average
@@ -1560,14 +1563,14 @@ func (c *coster) rowScanCost(tabID opt.TableID, idxOrd int, scannedCols opt.ColS
 
 	// Adjust cost based on how well the current locality matches the index's
 	// zone constraints.
-	var costFactor memo.Cost = cpuCostFactor
+	var costFactor float64 = cpuCostFactor
 	if !tab.IsVirtualTable() && len(c.locality.Tiers) != 0 {
 		// If 0% of locality tiers have matching constraints, then add additional
 		// cost. If 100% of locality tiers have matching constraints, then add no
 		// additional cost. Anything in between is proportional to the number of
 		// matches.
 		adjustment := 1.0 - localityMatchScore(idx.Zone(), c.locality)
-		costFactor += latencyCostFactor * memo.Cost(adjustment)
+		costFactor += latencyCostFactor * adjustment
 	}
 
 	// The number of the columns in the index matter because more columns means
@@ -1576,9 +1579,9 @@ func (c *coster) rowScanCost(tabID opt.TableID, idxOrd int, scannedCols opt.ColS
 	// the network.
 	if c.evalCtx != nil && c.evalCtx.SessionData().CostScansWithDefaultColSize {
 		numScannedCols := scannedCols.Len()
-		return memo.Cost(numCols+numScannedCols) * costFactor
+		return memo.Cost{C: float64(numCols+numScannedCols) * costFactor}
 	}
-	var cost memo.Cost
+	var cost float64
 	for i := 0; i < idx.ColumnCount(); i++ {
 		colID := tabID.ColumnID(idx.Column(i).Ordinal())
 		isScannedCol := scannedCols.Contains(colID)
@@ -1589,7 +1592,7 @@ func (c *coster) rowScanCost(tabID opt.TableID, idxOrd int, scannedCols opt.ColS
 		avgSize := c.mem.RequestColAvgSize(tabID, colID)
 		// Scanned columns are double-counted due to the cost of transferring data
 		// over the network.
-		var networkCostFactor memo.Cost = 1
+		var networkCostFactor float64 = 1
 		if isScannedCol && !isSystemCol {
 			networkCostFactor = 2
 		}
@@ -1597,9 +1600,9 @@ func (c *coster) rowScanCost(tabID opt.TableID, idxOrd int, scannedCols opt.ColS
 		// default the cost of plans involving tables that use the default AvgSize
 		// (e.g., if the stat is not available) is the same as if
 		// CostScansWithDefaultColSize were true.
-		cost += memo.Cost(float64(avgSize)/4) * costFactor * networkCostFactor
+		cost += (float64(avgSize) / 4) * costFactor * networkCostFactor
 	}
-	return cost
+	return memo.Cost{C: cost}
 }
 
 // rowBufferCost adds a cost for buffering rows according to a ramp function:
@@ -1624,16 +1627,16 @@ func (c *coster) rowScanCost(tabID opt.TableID, idxOrd int, scannedCols opt.ColS
 // and avoid sudden surprising plan changes due to a small change in stats.
 func (c *coster) rowBufferCost(rowCount float64) memo.Cost {
 	if rowCount <= noSpillRowCount {
-		return 0
+		return memo.Cost{C: 0}
 	}
-	var fraction memo.Cost
+	var fraction float64
 	if rowCount >= spillRowCount {
 		fraction = 1
 	} else {
-		fraction = memo.Cost(rowCount-noSpillRowCount) / (spillRowCount - noSpillRowCount)
+		fraction = (rowCount - noSpillRowCount) / (spillRowCount - noSpillRowCount)
 	}
 
-	return memo.Cost(rowCount) * spillCostFactor * fraction
+	return memo.Cost{C: rowCount * spillCostFactor * fraction}
 }
 
 // largeCardinalityCostPenalty returns a penalty that should be added to the
@@ -1645,16 +1648,16 @@ func (c *coster) largeCardinalityCostPenalty(
 	cardinality props.Cardinality, rowCount float64,
 ) memo.Cost {
 	if cardinality.IsUnbounded() {
-		return unboundedMaxCardinalityScanCostPenalty
+		return memo.Cost{C: unboundedMaxCardinalityScanCostPenalty}
 	}
 	if maxCard := float64(cardinality.Max); maxCard > rowCount {
 		penalty := maxCard - rowCount
 		if penalty > largeMaxCardinalityScanCostPenalty {
 			penalty = largeMaxCardinalityScanCostPenalty
 		}
-		return memo.Cost(penalty)
+		return memo.Cost{C: penalty}
 	}
-	return 0
+	return memo.Cost{C: 0}
 }
 
 // localityMatchScore returns a number from 0.0 to 1.0 that describes how well
@@ -1876,7 +1879,7 @@ func indexLookupJoinPerLookupCost(join memo.RelExpr) memo.Cost {
 	// The rows in the (left) input are used to probe into the (right) table.
 	// Since the matching rows in the table may not all be in the same range,
 	// this counts as random I/O.
-	cost := memo.Cost(randIOCostFactor)
+	cost := memo.Cost{C: randIOCostFactor}
 	lookupJoin, ok := join.(*memo.LookupJoinExpr)
 	if ok && len(lookupJoin.LookupExpr) > 0 {
 		numSpans := 1
@@ -1906,13 +1909,13 @@ func indexLookupJoinPerLookupCost(join memo.RelExpr) memo.Cost {
 		}
 		if numSpans > 1 {
 			// Account for the random IO incurred by looking up the extra spans.
-			cost += memo.Cost(randIOCostFactor * (numSpans - 1))
+			cost.C += randIOCostFactor * float64(numSpans-1)
 		}
 		// 1.1 is a fudge factor that pushes some plans over the edge when choosing
 		// between a partial index vs full index plus lookup expr in the
 		// regional_by_row.
 		// TODO(treilly): do some empirical analysis and model this better
-		cost += cpuCostFactor * memo.Cost(len(lookupJoin.LookupExpr)) * 1.1
+		cost.C += cpuCostFactor * float64(len(lookupJoin.LookupExpr)) * 1.1
 	}
 	return cost
 }

--- a/pkg/sql/opt/xform/coster.go
+++ b/pkg/sql/opt/xform/coster.go
@@ -190,7 +190,7 @@ var (
 	// that "violate" a hint like forcing a specific index or join algorithm.
 	// If the final expression has this cost or larger, it means that there was no
 	// plan that could satisfy the hints.
-	hugeCost = memo.Cost{C: 1e100}
+	hugeCost = memo.Cost{C: 1e100, Flags: memo.CostFlags{HugeCostPenalty: true}}
 
 	// SmallDistributeCost is the per-operation cost overhead for scans which may
 	// access remote regions, but the scanned table is unpartitioned with no lease
@@ -216,7 +216,10 @@ var (
 	// TODO(msirek): Is there a better way of preferring plans that have a home
 	//               region instead of relying on costing, which may not guarantee
 	//               the correct plan is found?
-	LargeDistributeCostWithHomeRegion = memo.Cost{C: LargeDistributeCost.C / 2}
+	LargeDistributeCostWithHomeRegion = memo.Cost{
+		C:     LargeDistributeCost.C / 2,
+		Flags: memo.CostFlags{HugeCostPenalty: true},
+	}
 )
 
 // fnCost maps some functions to an execution cost. Currently this list
@@ -757,14 +760,14 @@ func (c *coster) computeScanCost(scan *memo.ScanExpr, required *physical.Require
 	}
 
 	isUnfiltered := scan.IsUnfiltered(c.mem.Metadata())
-	if scan.Flags.NoFullScan {
-		// Normally a full scan of a partial index would be allowed with the
-		// NO_FULL_SCAN hint (isUnfiltered is false for partial indexes), but if the
-		// user has explicitly forced the partial index *and* used NO_FULL_SCAN, we
-		// disallow the full index scan.
-		if isUnfiltered || (scan.Flags.ForceIndex && scan.IsFullIndexScan(c.mem.Metadata())) {
-			return hugeCost
-		}
+
+	// Normally a full scan of a partial index would not be considered a "full
+	// scan" for the purposes of the NO_FULL_SCAN and AVOID_FULL_SCAN hints
+	// (isUnfiltered is false for partial indexes), but if the user has explicitly
+	// forced the partial index, we do consider it a full scan.
+	isFullScan := isUnfiltered || (scan.Flags.ForceIndex && scan.IsFullIndexScan(c.mem.Metadata()))
+	if scan.Flags.NoFullScan && isFullScan {
+		return hugeCost
 	}
 
 	if scan.Flags.ForceInvertedIndex && !scan.IsInvertedScan(c.mem.Metadata()) {
@@ -864,6 +867,12 @@ func (c *coster) computeScanCost(scan *memo.ScanExpr, required *physical.Require
 	}
 	extraCost := c.distributionCost(regionsAccessed)
 	cost.Add(extraCost)
+
+	// Apply a penalty for a full scan if needed.
+	if scan.Flags.AvoidFullScan && isFullScan {
+		cost.Flags.FullScanPenalty = true
+	}
+
 	return cost
 }
 

--- a/pkg/sql/opt/xform/coster.go
+++ b/pkg/sql/opt/xform/coster.go
@@ -619,8 +619,13 @@ func (c *coster) ComputeCost(candidate memo.RelExpr, required *physical.Required
 	// Add a one-time cost for any operator with unbounded cardinality. This
 	// ensures we prefer plans that push limits as far down the tree as possible,
 	// all else being equal.
+	//
+	// Also add a cost flag for unbounded cardinality.
 	if candidate.Relational().Cardinality.IsUnbounded() {
 		cost.C += cpuCostFactor
+		if c.evalCtx.SessionData().OptimizerPreferBoundedCardinality {
+			cost.Flags.UnboundedCardinality = true
+		}
 	}
 
 	if !cost.Less(memo.MaxCost) {

--- a/pkg/sql/opt/xform/memo_format.go
+++ b/pkg/sql/opt/xform/memo_format.go
@@ -91,7 +91,7 @@ func (mf *memoFormatter) format() string {
 			c := tpChild.Childf("%s", s.required)
 			mf.formatBest(s.best, s.required)
 			c.Childf("best: %s", mf.buf.String())
-			c.Childf("cost: %.2f", s.cost)
+			c.Childf("cost: %.2f", s.cost.C)
 		}
 	}
 

--- a/pkg/sql/opt/xform/optimizer.go
+++ b/pkg/sql/opt/xform/optimizer.go
@@ -299,7 +299,7 @@ func (o *Optimizer) optimizeExpr(
 		// Short-circuit traversal of scalar expressions with no nested subquery,
 		// since there's only one possible tree.
 		if !t.ScalarProps().HasSubquery {
-			return 0, true
+			return memo.Cost{C: 0}, true
 		}
 		return o.optimizeScalarExpr(t)
 
@@ -584,9 +584,10 @@ func (o *Optimizer) optimizeGroupMember(
 				//               remote branch, e.g., compare the size of the limit hint
 				//               with the expected row count of the local branch.
 				//               Is there a better approach?
-				cost += childCost / 10
+				childCost.C /= 10
+				cost.Add(childCost)
 			} else {
-				cost += childCost
+				cost.Add(childCost)
 			}
 
 			// If any child expression is not fully optimized, then the parent
@@ -597,7 +598,7 @@ func (o *Optimizer) optimizeGroupMember(
 		}
 
 		// Check whether this is the new lowest cost expression.
-		cost += o.coster.ComputeCost(member, required)
+		cost.Add(o.coster.ComputeCost(member, required))
 		o.ratchetCost(state, member, cost)
 	}
 
@@ -617,7 +618,7 @@ func (o *Optimizer) optimizeScalarExpr(
 		childCost, childOptimized := o.optimizeExpr(scalar.Child(i), childProps)
 
 		// Accumulate cost of children.
-		cost += childCost
+		cost.Add(childCost)
 
 		// If any child expression is not fully optimized, then the parent
 		// expression is also not fully optimized.
@@ -716,7 +717,8 @@ func (o *Optimizer) optimizeEnforcer(
 
 	// Check whether this is the new lowest cost expression with the enforcer
 	// added.
-	cost := innerState.cost + o.coster.ComputeCost(enforcer, enforcerProps)
+	cost := innerState.cost
+	cost.Add(o.coster.ComputeCost(enforcer, enforcerProps))
 	if o.ratchetCost(state, enforcer, cost) {
 		if _, ok := enforcer.(*memo.SortExpr); ok {
 			// The expression was added to the memo, so lose the reference.
@@ -1130,7 +1132,7 @@ func (o *Optimizer) RecomputeCost() {
 func (o *Optimizer) recomputeCostImpl(
 	parent opt.Expr, parentProps *physical.Required, c Coster,
 ) memo.Cost {
-	cost := memo.Cost(0)
+	cost := memo.Cost{C: 0}
 	for i, n := 0, parent.ChildCount(); i < n; i++ {
 		child := parent.Child(i)
 		childProps := physical.MinRequired
@@ -1138,12 +1140,12 @@ func (o *Optimizer) recomputeCostImpl(
 		case memo.RelExpr:
 			childProps = t.RequiredPhysical()
 		}
-		cost += o.recomputeCostImpl(child, childProps, c)
+		cost.Add(o.recomputeCostImpl(child, childProps, c))
 	}
 
 	switch t := parent.(type) {
 	case memo.RelExpr:
-		cost += c.ComputeCost(t, parentProps)
+		cost.Add(c.ComputeCost(t, parentProps))
 		o.mem.ResetCost(t, cost)
 	}
 

--- a/pkg/sql/opt/xform/placeholder_fast_path.go
+++ b/pkg/sql/opt/xform/placeholder_fast_path.go
@@ -211,7 +211,7 @@ func (o *Optimizer) TryPlaceholderFastPath() (_ opt.Expr, ok bool, err error) {
 		ScanPrivate: newPrivate,
 	}
 	placeholderScan = o.mem.AddPlaceholderScanToGroup(placeholderScan, root)
-	o.mem.SetBestProps(placeholderScan, rootPhysicalProps, &physical.Provided{}, 1.0 /* cost */)
+	o.mem.SetBestProps(placeholderScan, rootPhysicalProps, &physical.Provided{}, memo.Cost{C: 1.0})
 	o.mem.SetRoot(placeholderScan, rootPhysicalProps)
 
 	if buildutil.CrdbTestBuild && !o.mem.IsOptimized() {

--- a/pkg/sql/opt/xform/testdata/coster/join
+++ b/pkg/sql/opt/xform/testdata/coster/join
@@ -108,6 +108,7 @@ inner-join (hash)
  ├── multiplicity: left-rows(zero-or-more), right-rows(zero-or-one)
  ├── stats: [rows=990, distinct(1)=99, null(1)=0, distinct(7)=99, null(7)=0]
  ├── cost: 1e+100
+ ├── cost-flags: huge-cost-penalty
  ├── fd: (1)==(7), (7)==(1)
  ├── scan a
  │    ├── columns: k:1!null
@@ -146,6 +147,7 @@ New expression 1 of 1:
   right-join (hash)
    ├── flags: disallow hash join (store right side) and lookup join (into right side) and inverted join (into right side)
    ├── cost: 1e+100
+   ├── cost-flags: huge-cost-penalty
    ├── scan a
    │    └── cost: 1078.52
    ├── scan b
@@ -170,6 +172,7 @@ Source expression:
   left-join (hash)
    ├── flags: disallow hash join (store right side) and lookup join (into right side) and inverted join (into right side)
    ├── cost: 1e+100
+   ├── cost-flags: huge-cost-penalty
    ├── scan a
    │    └── cost: 1078.52
    ├── scan b
@@ -233,6 +236,7 @@ inner-join (cross)
  ├── immutable
  ├── stats: [rows=333333.3]
  ├── cost: 1e+100
+ ├── cost-flags: huge-cost-penalty
  ├── key: (1,6)
  ├── fd: (1)-->(2), (6)-->(7)
  ├── scan g [as=g1]

--- a/pkg/sql/opt/xform/testdata/coster/outside-histogram
+++ b/pkg/sql/opt/xform/testdata/coster/outside-histogram
@@ -1,0 +1,484 @@
+# This file contains tests for queries that filter columns beyond the max/min
+# values in their histograms. Each query is tested multiple times with different
+# settings to show the effect those settings have on the plan.
+#
+
+exec-ddl
+CREATE TABLE t (
+  k INT PRIMARY KEY,
+  i INT,
+  s STRING,
+  INDEX (i),
+  INDEX (s)
+)
+----
+
+exec-ddl
+ALTER TABLE t INJECT STATISTICS '[
+  {
+    "columns": ["k"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 1000,
+    "distinct_count": 1000,
+    "null_count": 0,
+    "avg_size": 2,
+    "histo_col_type": "int",
+    "histo_buckets": [
+      {"num_eq": 0, "num_range": 0, "distinct_range": 0, "upper_bound": "0"},
+      {"num_eq": 1, "num_range": 99, "distinct_range": 99, "upper_bound": "100"},
+      {"num_eq": 1, "num_range": 199, "distinct_range": 199, "upper_bound": "200"},
+      {"num_eq": 1, "num_range": 299, "distinct_range": 299, "upper_bound": "300"},
+      {"num_eq": 1, "num_range": 399, "distinct_range": 399, "upper_bound": "400"}
+    ]
+  },
+  {
+    "columns": ["i"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 1000,
+    "distinct_count": 44,
+    "null_count": 0,
+    "avg_size": 2,
+    "histo_col_type": "int",
+    "histo_buckets": [
+      {"num_eq": 0, "num_range": 0, "distinct_range": 0, "upper_bound": "0"},
+      {"num_eq": 10, "num_range": 90, "distinct_range": 10, "upper_bound": "100"},
+      {"num_eq": 10, "num_range": 190, "distinct_range": 10, "upper_bound": "200"},
+      {"num_eq": 20, "num_range": 280, "distinct_range": 10, "upper_bound": "300"},
+      {"num_eq": 30, "num_range": 370, "distinct_range": 10, "upper_bound": "400"}
+    ]
+  },
+  {
+    "columns": ["s"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 1000,
+    "distinct_count": 40,
+    "null_count": 0,
+    "avg_size": 3,
+    "histo_col_type": "string",
+    "histo_buckets": [
+      {"num_eq": 0, "num_range": 0, "distinct_range": 0, "upper_bound": "apple"},
+      {"num_eq": 100, "num_range": 100, "distinct_range": 10, "upper_bound": "banana"},
+      {"num_eq": 100, "num_range": 100, "distinct_range": 10, "upper_bound": "cherry"},
+      {"num_eq": 200, "num_range": 100, "distinct_range": 10, "upper_bound": "mango"},
+      {"num_eq": 200, "num_range": 100, "distinct_range": 10, "upper_bound": "pineapple"}
+    ]
+  }
+]'
+----
+
+# --------------------------------------------------
+# Q1
+# --------------------------------------------------
+
+opt set=(optimizer_prefer_bounded_cardinality=false)
+SELECT * FROM t WHERE k IN (110, 120, 130, 140) AND i = 500
+----
+index-join t
+ ├── columns: k:1!null i:2!null s:3
+ ├── cardinality: [0 - 4]
+ ├── stats: [rows=2e-07, distinct(1)=2e-07, null(1)=0, distinct(2)=2e-07, null(2)=0, distinct(1,2)=2e-07, null(1,2)=0]
+ │   histogram(1)=  0 5e-08 0 5e-08 0 5e-08 0 5e-08
+ │                <--- 110 --- 120 --- 130 --- 140
+ │   histogram(2)=
+ ├── cost: 24.0200012
+ ├── key: (1)
+ ├── fd: ()-->(2), (1)-->(3)
+ └── scan t@t_i_idx
+      ├── columns: k:1!null i:2!null
+      ├── constraint: /2/1
+      │    ├── [/500/110 - /500/110]
+      │    ├── [/500/120 - /500/120]
+      │    ├── [/500/130 - /500/130]
+      │    └── [/500/140 - /500/140]
+      ├── cardinality: [0 - 4]
+      ├── stats: [rows=2e-07, distinct(1)=2e-07, null(1)=0, distinct(2)=2e-07, null(2)=0, distinct(1,2)=2e-07, null(1,2)=0]
+      │   histogram(1)=  0 5e-08 0 5e-08 0 5e-08 0 5e-08
+      │                <--- 110 --- 120 --- 130 --- 140
+      │   histogram(2)=
+      ├── cost: 24.01
+      ├── key: (1)
+      └── fd: ()-->(2)
+
+opt set=(optimizer_prefer_bounded_cardinality=true)
+SELECT * FROM t WHERE k IN (110, 120, 130, 140) AND i = 500
+----
+index-join t
+ ├── columns: k:1!null i:2!null s:3
+ ├── cardinality: [0 - 4]
+ ├── stats: [rows=2e-07, distinct(1)=2e-07, null(1)=0, distinct(2)=2e-07, null(2)=0, distinct(1,2)=2e-07, null(1,2)=0]
+ │   histogram(1)=  0 5e-08 0 5e-08 0 5e-08 0 5e-08
+ │                <--- 110 --- 120 --- 130 --- 140
+ │   histogram(2)=
+ ├── cost: 24.0200012
+ ├── key: (1)
+ ├── fd: ()-->(2), (1)-->(3)
+ └── scan t@t_i_idx
+      ├── columns: k:1!null i:2!null
+      ├── constraint: /2/1
+      │    ├── [/500/110 - /500/110]
+      │    ├── [/500/120 - /500/120]
+      │    ├── [/500/130 - /500/130]
+      │    └── [/500/140 - /500/140]
+      ├── cardinality: [0 - 4]
+      ├── stats: [rows=2e-07, distinct(1)=2e-07, null(1)=0, distinct(2)=2e-07, null(2)=0, distinct(1,2)=2e-07, null(1,2)=0]
+      │   histogram(1)=  0 5e-08 0 5e-08 0 5e-08 0 5e-08
+      │                <--- 110 --- 120 --- 130 --- 140
+      │   histogram(2)=
+      ├── cost: 24.01
+      ├── key: (1)
+      └── fd: ()-->(2)
+
+# --------------------------------------------------
+# Q2
+# --------------------------------------------------
+
+opt set=(optimizer_prefer_bounded_cardinality=false)
+SELECT * FROM t WHERE k IN (100, 110, 120, 130) AND i > 500
+----
+index-join t
+ ├── columns: k:1!null i:2!null s:3
+ ├── cardinality: [0 - 4]
+ ├── stats: [rows=2e-07, distinct(1)=2e-07, null(1)=0, distinct(2)=2e-07, null(2)=0, distinct(1,2)=2e-07, null(1,2)=0]
+ │   histogram(1)=  0 5e-08 0 5e-08 0 5e-08 0 5e-08
+ │                <--- 100 --- 110 --- 120 --- 130
+ │   histogram(2)=
+ ├── cost: 18.0500006
+ ├── key: (1)
+ ├── fd: (1)-->(2,3)
+ └── select
+      ├── columns: k:1!null i:2!null
+      ├── cardinality: [0 - 4]
+      ├── stats: [rows=8e-10, distinct(1)=8e-10, null(1)=0]
+      │   histogram(1)=  0 2e-10 0 2e-10 0 2e-10 0 2e-10
+      │                <--- 100 --- 110 --- 120 --- 130
+      ├── cost: 18.0400002
+      ├── key: (1)
+      ├── fd: (1)-->(2)
+      ├── scan t@t_i_idx
+      │    ├── columns: k:1!null i:2!null
+      │    ├── constraint: /2/1: [/501/100 - ]
+      │    ├── stats: [rows=2e-07, distinct(1)=2e-07, null(1)=0, distinct(2)=2e-07, null(2)=0]
+      │    │   histogram(1)=  0  0  1.98e-08 2e-10 3.98e-08 2e-10 5.98e-08 2e-10 7.98e-08 2e-10
+      │    │                <--- 0 ---------- 100 ---------- 200 ---------- 300 ---------- 400
+      │    │   histogram(2)=
+      │    ├── cost: 18.0200002
+      │    ├── key: (1)
+      │    └── fd: (1)-->(2)
+      └── filters
+           └── k:1 IN (100, 110, 120, 130) [outer=(1), constraints=(/1: [/100 - /100] [/110 - /110] [/120 - /120] [/130 - /130]; tight)]
+
+opt set=(optimizer_prefer_bounded_cardinality=true)
+SELECT * FROM t WHERE k IN (100, 110, 120, 130) AND i > 500
+----
+select
+ ├── columns: k:1!null i:2!null s:3
+ ├── cardinality: [0 - 4]
+ ├── stats: [rows=2e-07, distinct(1)=2e-07, null(1)=0, distinct(2)=2e-07, null(2)=0, distinct(1,2)=2e-07, null(1,2)=0]
+ │   histogram(1)=  0 5e-08 0 5e-08 0 5e-08 0 5e-08
+ │                <--- 100 --- 110 --- 120 --- 130
+ │   histogram(2)=
+ ├── cost: 24.21
+ ├── key: (1)
+ ├── fd: (1)-->(2,3)
+ ├── scan t
+ │    ├── columns: k:1!null i:2 s:3
+ │    ├── constraint: /1
+ │    │    ├── [/100 - /100]
+ │    │    ├── [/110 - /110]
+ │    │    ├── [/120 - /120]
+ │    │    └── [/130 - /130]
+ │    ├── cardinality: [0 - 4]
+ │    ├── stats: [rows=4, distinct(1)=4, null(1)=0]
+ │    │   histogram(1)=  0   1   0   1   0   1   0   1
+ │    │                <--- 100 --- 110 --- 120 --- 130
+ │    ├── cost: 24.15
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2,3)
+ └── filters
+      └── i:2 > 500 [outer=(2), constraints=(/2: [/501 - ]; tight)]
+
+# --------------------------------------------------
+# Q3
+# --------------------------------------------------
+
+opt set=(optimizer_prefer_bounded_cardinality=false)
+SELECT * FROM t WHERE k IN (410, 420, 430) AND i > 500
+----
+index-join t
+ ├── columns: k:1!null i:2!null s:3
+ ├── cardinality: [0 - 3]
+ ├── stats: [rows=2e-07, distinct(1)=2e-07, null(1)=0, distinct(2)=2e-07, null(2)=0]
+ │   histogram(1)=
+ │   histogram(2)=
+ ├── cost: 18.0500006
+ ├── key: (1)
+ ├── fd: (1)-->(2,3)
+ └── select
+      ├── columns: k:1!null i:2!null
+      ├── cardinality: [0 - 3]
+      ├── stats: [rows=4e-17, distinct(1)=4e-17, null(1)=0]
+      │   histogram(1)=
+      ├── cost: 18.0400002
+      ├── key: (1)
+      ├── fd: (1)-->(2)
+      ├── scan t@t_i_idx
+      │    ├── columns: k:1!null i:2!null
+      │    ├── constraint: /2/1: [/501/410 - ]
+      │    ├── stats: [rows=2e-07, distinct(1)=2e-07, null(1)=0, distinct(2)=2e-07, null(2)=0]
+      │    │   histogram(1)=  0  0  1.98e-08 2e-10 3.98e-08 2e-10 5.98e-08 2e-10 7.98e-08 2e-10
+      │    │                <--- 0 ---------- 100 ---------- 200 ---------- 300 ---------- 400
+      │    │   histogram(2)=
+      │    ├── cost: 18.0200002
+      │    ├── key: (1)
+      │    └── fd: (1)-->(2)
+      └── filters
+           └── k:1 IN (410, 420, 430) [outer=(1), constraints=(/1: [/410 - /410] [/420 - /420] [/430 - /430]; tight)]
+
+opt set=(optimizer_prefer_bounded_cardinality=true)
+SELECT * FROM t WHERE k IN (410, 420, 430) AND i > 500
+----
+select
+ ├── columns: k:1!null i:2!null s:3
+ ├── cardinality: [0 - 3]
+ ├── stats: [rows=2e-07, distinct(1)=2e-07, null(1)=0, distinct(2)=2e-07, null(2)=0]
+ │   histogram(1)=
+ │   histogram(2)=
+ ├── cost: 19.03
+ ├── key: (1)
+ ├── fd: (1)-->(2,3)
+ ├── scan t
+ │    ├── columns: k:1!null i:2 s:3
+ │    ├── constraint: /1
+ │    │    ├── [/410 - /410]
+ │    │    ├── [/420 - /420]
+ │    │    └── [/430 - /430]
+ │    ├── cardinality: [0 - 3]
+ │    ├── stats: [rows=2e-07, distinct(1)=2e-07, null(1)=0]
+ │    │   histogram(1)=
+ │    ├── cost: 19.01
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2,3)
+ └── filters
+      └── i:2 > 500 [outer=(2), constraints=(/2: [/501 - ]; tight)]
+
+# --------------------------------------------------
+# Q4
+# --------------------------------------------------
+
+opt set=(optimizer_prefer_bounded_cardinality=false)
+SELECT * FROM t WHERE k IN (100, 110, 120, 130) AND i = 400 AND s < 'apple'
+----
+select
+ ├── columns: k:1!null i:2!null s:3!null
+ ├── cardinality: [0 - 4]
+ ├── stats: [rows=2e-07, distinct(1)=2e-07, null(1)=0, distinct(2)=2e-07, null(2)=0, distinct(3)=2e-07, null(3)=0, distinct(2,3)=2e-07, null(2,3)=0, distinct(1-3)=2e-07, null(1-3)=0]
+ │   histogram(1)=  0 5e-08 0 5e-08 0 5e-08 0 5e-08
+ │                <--- 100 --- 110 --- 120 --- 130
+ │   histogram(2)=  0 2e-07
+ │                <--- 400
+ │   histogram(3)=
+ ├── cost: 18.0700002
+ ├── key: (1)
+ ├── fd: ()-->(2), (1)-->(3)
+ ├── index-join t
+ │    ├── columns: k:1!null i:2 s:3
+ │    ├── cardinality: [0 - 4]
+ │    ├── stats: [rows=8e-10]
+ │    ├── cost: 18.0500002
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2,3)
+ │    └── select
+ │         ├── columns: k:1!null s:3!null
+ │         ├── cardinality: [0 - 4]
+ │         ├── stats: [rows=8e-10, distinct(1)=8e-10, null(1)=0]
+ │         │   histogram(1)=  0 2e-10 0 2e-10 0 2e-10 0 2e-10
+ │         │                <--- 100 --- 110 --- 120 --- 130
+ │         ├── cost: 18.0400002
+ │         ├── key: (1)
+ │         ├── fd: (1)-->(3)
+ │         ├── scan t@t_s_idx
+ │         │    ├── columns: k:1!null s:3!null
+ │         │    ├── constraint: /3/1: (/NULL - /'apple')
+ │         │    ├── stats: [rows=2e-07, distinct(1)=2e-07, null(1)=0, distinct(3)=2e-07, null(3)=0]
+ │         │    │   histogram(1)=  0  0  1.98e-08 2e-10 3.98e-08 2e-10 5.98e-08 2e-10 7.98e-08 2e-10
+ │         │    │                <--- 0 ---------- 100 ---------- 200 ---------- 300 ---------- 400
+ │         │    │   histogram(3)=
+ │         │    ├── cost: 18.0200002
+ │         │    ├── key: (1)
+ │         │    └── fd: (1)-->(3)
+ │         └── filters
+ │              └── k:1 IN (100, 110, 120, 130) [outer=(1), constraints=(/1: [/100 - /100] [/110 - /110] [/120 - /120] [/130 - /130]; tight)]
+ └── filters
+      └── i:2 = 400 [outer=(2), constraints=(/2: [/400 - /400]; tight), fd=()-->(2)]
+
+opt set=(optimizer_prefer_bounded_cardinality=true)
+SELECT * FROM t WHERE k IN (100, 110, 120, 130) AND i = 400 AND s < 'apple'
+----
+select
+ ├── columns: k:1!null i:2!null s:3!null
+ ├── cardinality: [0 - 4]
+ ├── stats: [rows=2e-07, distinct(1)=2e-07, null(1)=0, distinct(2)=2e-07, null(2)=0, distinct(3)=2e-07, null(3)=0, distinct(2,3)=2e-07, null(2,3)=0, distinct(1-3)=2e-07, null(1-3)=0]
+ │   histogram(1)=  0 5e-08 0 5e-08 0 5e-08 0 5e-08
+ │                <--- 100 --- 110 --- 120 --- 130
+ │   histogram(2)=  0 2e-07
+ │                <--- 400
+ │   histogram(3)=
+ ├── cost: 24.22
+ ├── key: (1)
+ ├── fd: ()-->(2), (1)-->(3)
+ ├── scan t
+ │    ├── columns: k:1!null i:2 s:3
+ │    ├── constraint: /1
+ │    │    ├── [/100 - /100]
+ │    │    ├── [/110 - /110]
+ │    │    ├── [/120 - /120]
+ │    │    └── [/130 - /130]
+ │    ├── cardinality: [0 - 4]
+ │    ├── stats: [rows=4, distinct(1)=4, null(1)=0]
+ │    │   histogram(1)=  0   1   0   1   0   1   0   1
+ │    │                <--- 100 --- 110 --- 120 --- 130
+ │    ├── cost: 24.15
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2,3)
+ └── filters
+      ├── i:2 = 400 [outer=(2), constraints=(/2: [/400 - /400]; tight), fd=()-->(2)]
+      └── s:3 < 'apple' [outer=(3), constraints=(/3: (/NULL - /'apple'); tight)]
+
+# --------------------------------------------------
+# Q5
+# --------------------------------------------------
+
+opt set=(enable_zigzag_join=false,optimizer_prefer_bounded_cardinality=false)
+SELECT * FROM t WHERE i = 400 AND s > 'z'
+----
+select
+ ├── columns: k:1!null i:2!null s:3!null
+ ├── stats: [rows=2e-07, distinct(2)=2e-07, null(2)=0, distinct(3)=2e-07, null(3)=0, distinct(2,3)=2e-07, null(2,3)=0]
+ │   histogram(2)=  0 2e-07
+ │                <--- 400
+ │   histogram(3)=
+ ├── cost: 18.0700014
+ ├── key: (1)
+ ├── fd: ()-->(2), (1)-->(3)
+ ├── index-join t
+ │    ├── columns: k:1!null i:2 s:3
+ │    ├── stats: [rows=2e-07]
+ │    ├── cost: 18.0400014
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2,3)
+ │    └── scan t@t_s_idx
+ │         ├── columns: k:1!null s:3!null
+ │         ├── constraint: /3/1: [/e'z\x00' - ]
+ │         ├── stats: [rows=2e-07, distinct(3)=2e-07, null(3)=0]
+ │         │   histogram(3)=
+ │         ├── cost: 18.0200002
+ │         ├── key: (1)
+ │         └── fd: (1)-->(3)
+ └── filters
+      └── i:2 = 400 [outer=(2), constraints=(/2: [/400 - /400]; tight), fd=()-->(2)]
+
+opt set=(enable_zigzag_join=false,optimizer_prefer_bounded_cardinality=true)
+SELECT * FROM t WHERE i = 400 AND s > 'z'
+----
+select
+ ├── columns: k:1!null i:2!null s:3!null
+ ├── stats: [rows=2e-07, distinct(2)=2e-07, null(2)=0, distinct(3)=2e-07, null(3)=0, distinct(2,3)=2e-07, null(2,3)=0]
+ │   histogram(2)=  0 2e-07
+ │                <--- 400
+ │   histogram(3)=
+ ├── cost: 18.0700014
+ ├── cost-flags: unbounded-cardinality
+ ├── key: (1)
+ ├── fd: ()-->(2), (1)-->(3)
+ ├── index-join t
+ │    ├── columns: k:1!null i:2 s:3
+ │    ├── stats: [rows=2e-07]
+ │    ├── cost: 18.0400014
+ │    ├── cost-flags: unbounded-cardinality
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2,3)
+ │    └── scan t@t_s_idx
+ │         ├── columns: k:1!null s:3!null
+ │         ├── constraint: /3/1: [/e'z\x00' - ]
+ │         ├── stats: [rows=2e-07, distinct(3)=2e-07, null(3)=0]
+ │         │   histogram(3)=
+ │         ├── cost: 18.0200002
+ │         ├── cost-flags: unbounded-cardinality
+ │         ├── key: (1)
+ │         └── fd: (1)-->(3)
+ └── filters
+      └── i:2 = 400 [outer=(2), constraints=(/2: [/400 - /400]; tight), fd=()-->(2)]
+
+# --------------------------------------------------
+# Q6
+# --------------------------------------------------
+
+opt set=(optimizer_prefer_bounded_cardinality=false)
+SELECT * FROM t WHERE k = 100 AND i = 500 AND s = 'zzz'
+----
+select
+ ├── columns: k:1!null i:2!null s:3!null
+ ├── cardinality: [0 - 1]
+ ├── stats: [rows=2e-07, distinct(1)=2e-07, null(1)=0, distinct(2)=2e-07, null(2)=0, distinct(3)=2e-07, null(3)=0]
+ │   histogram(1)=  0 2e-07
+ │                <--- 100
+ │   histogram(2)=
+ │   histogram(3)=
+ ├── cost: 9.04000121
+ ├── key: ()
+ ├── fd: ()-->(1-3)
+ ├── index-join t
+ │    ├── columns: k:1!null i:2 s:3
+ │    ├── cardinality: [0 - 1]
+ │    ├── stats: [rows=2e-07]
+ │    ├── cost: 9.02000121
+ │    ├── key: ()
+ │    ├── fd: ()-->(1-3)
+ │    └── scan t@t_i_idx
+ │         ├── columns: k:1!null i:2!null
+ │         ├── constraint: /2/1: [/500/100 - /500/100]
+ │         ├── cardinality: [0 - 1]
+ │         ├── stats: [rows=2e-07, distinct(1)=2e-07, null(1)=0, distinct(2)=2e-07, null(2)=0, distinct(1,2)=2e-07, null(1,2)=0]
+ │         │   histogram(1)=  0 2e-07
+ │         │                <--- 100
+ │         │   histogram(2)=
+ │         ├── cost: 9.01
+ │         ├── key: ()
+ │         └── fd: ()-->(1,2)
+ └── filters
+      └── s:3 = 'zzz' [outer=(3), constraints=(/3: [/'zzz' - /'zzz']; tight), fd=()-->(3)]
+
+opt set=(optimizer_prefer_bounded_cardinality=true)
+SELECT * FROM t WHERE k = 100 AND i = 500 AND s = 'zzz'
+----
+select
+ ├── columns: k:1!null i:2!null s:3!null
+ ├── cardinality: [0 - 1]
+ ├── stats: [rows=2e-07, distinct(1)=2e-07, null(1)=0, distinct(2)=2e-07, null(2)=0, distinct(3)=2e-07, null(3)=0]
+ │   histogram(1)=  0 2e-07
+ │                <--- 100
+ │   histogram(2)=
+ │   histogram(3)=
+ ├── cost: 9.04000121
+ ├── key: ()
+ ├── fd: ()-->(1-3)
+ ├── index-join t
+ │    ├── columns: k:1!null i:2 s:3
+ │    ├── cardinality: [0 - 1]
+ │    ├── stats: [rows=2e-07]
+ │    ├── cost: 9.02000121
+ │    ├── key: ()
+ │    ├── fd: ()-->(1-3)
+ │    └── scan t@t_i_idx
+ │         ├── columns: k:1!null i:2!null
+ │         ├── constraint: /2/1: [/500/100 - /500/100]
+ │         ├── cardinality: [0 - 1]
+ │         ├── stats: [rows=2e-07, distinct(1)=2e-07, null(1)=0, distinct(2)=2e-07, null(2)=0, distinct(1,2)=2e-07, null(1,2)=0]
+ │         │   histogram(1)=  0 2e-07
+ │         │                <--- 100
+ │         │   histogram(2)=
+ │         ├── cost: 9.01
+ │         ├── key: ()
+ │         └── fd: ()-->(1,2)
+ └── filters
+      └── s:3 = 'zzz' [outer=(3), constraints=(/3: [/'zzz' - /'zzz']; tight), fd=()-->(3)]

--- a/pkg/sql/opt/xform/testdata/coster/outside-histogram
+++ b/pkg/sql/opt/xform/testdata/coster/outside-histogram
@@ -70,7 +70,7 @@ ALTER TABLE t INJECT STATISTICS '[
 # Q1
 # --------------------------------------------------
 
-opt set=(optimizer_prefer_bounded_cardinality=false)
+opt set=(optimizer_prefer_bounded_cardinality=false,optimizer_min_row_count=0)
 SELECT * FROM t WHERE k IN (110, 120, 130, 140) AND i = 500
 ----
 index-join t
@@ -99,7 +99,7 @@ index-join t
       ├── key: (1)
       └── fd: ()-->(2)
 
-opt set=(optimizer_prefer_bounded_cardinality=true)
+opt set=(optimizer_prefer_bounded_cardinality=true,optimizer_min_row_count=0)
 SELECT * FROM t WHERE k IN (110, 120, 130, 140) AND i = 500
 ----
 index-join t
@@ -127,12 +127,42 @@ index-join t
       ├── cost: 24.01
       ├── key: (1)
       └── fd: ()-->(2)
+
+opt set=(optimizer_prefer_bounded_cardinality=false,optimizer_min_row_count=1)
+SELECT * FROM t WHERE k IN (110, 120, 130, 140) AND i = 500
+----
+select
+ ├── columns: k:1!null i:2!null s:3
+ ├── cardinality: [0 - 4]
+ ├── stats: [rows=1, distinct(1)=1, null(1)=0, distinct(2)=1, null(2)=0, distinct(1,2)=1, null(1,2)=0]
+ │   histogram(1)=  0 0.25  0 0.25  0 0.25  0 0.25
+ │                <--- 110 --- 120 --- 130 --- 140
+ │   histogram(2)=
+ ├── cost: 24.21
+ ├── key: (1)
+ ├── fd: ()-->(2), (1)-->(3)
+ ├── scan t
+ │    ├── columns: k:1!null i:2 s:3
+ │    ├── constraint: /1
+ │    │    ├── [/110 - /110]
+ │    │    ├── [/120 - /120]
+ │    │    ├── [/130 - /130]
+ │    │    └── [/140 - /140]
+ │    ├── cardinality: [0 - 4]
+ │    ├── stats: [rows=4, distinct(1)=4, null(1)=0]
+ │    │   histogram(1)=  0   1   0   1   0   1   0   1
+ │    │                <--- 110 --- 120 --- 130 --- 140
+ │    ├── cost: 24.15
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2,3)
+ └── filters
+      └── i:2 = 500 [outer=(2), constraints=(/2: [/500 - /500]; tight), fd=()-->(2)]
 
 # --------------------------------------------------
 # Q2
 # --------------------------------------------------
 
-opt set=(optimizer_prefer_bounded_cardinality=false)
+opt set=(optimizer_prefer_bounded_cardinality=false,optimizer_min_row_count=0)
 SELECT * FROM t WHERE k IN (100, 110, 120, 130) AND i > 500
 ----
 index-join t
@@ -167,7 +197,7 @@ index-join t
       └── filters
            └── k:1 IN (100, 110, 120, 130) [outer=(1), constraints=(/1: [/100 - /100] [/110 - /110] [/120 - /120] [/130 - /130]; tight)]
 
-opt set=(optimizer_prefer_bounded_cardinality=true)
+opt set=(optimizer_prefer_bounded_cardinality=true,optimizer_min_row_count=0)
 SELECT * FROM t WHERE k IN (100, 110, 120, 130) AND i > 500
 ----
 select
@@ -197,11 +227,41 @@ select
  └── filters
       └── i:2 > 500 [outer=(2), constraints=(/2: [/501 - ]; tight)]
 
+opt set=(optimizer_prefer_bounded_cardinality=false,optimizer_min_row_count=1)
+SELECT * FROM t WHERE k IN (100, 110, 120, 130) AND i > 500
+----
+select
+ ├── columns: k:1!null i:2!null s:3
+ ├── cardinality: [0 - 4]
+ ├── stats: [rows=1, distinct(1)=1, null(1)=0, distinct(2)=1, null(2)=0, distinct(1,2)=1, null(1,2)=0]
+ │   histogram(1)=  0 0.25  0 0.25  0 0.25  0 0.25
+ │                <--- 100 --- 110 --- 120 --- 130
+ │   histogram(2)=
+ ├── cost: 24.21
+ ├── key: (1)
+ ├── fd: (1)-->(2,3)
+ ├── scan t
+ │    ├── columns: k:1!null i:2 s:3
+ │    ├── constraint: /1
+ │    │    ├── [/100 - /100]
+ │    │    ├── [/110 - /110]
+ │    │    ├── [/120 - /120]
+ │    │    └── [/130 - /130]
+ │    ├── cardinality: [0 - 4]
+ │    ├── stats: [rows=4, distinct(1)=4, null(1)=0]
+ │    │   histogram(1)=  0   1   0   1   0   1   0   1
+ │    │                <--- 100 --- 110 --- 120 --- 130
+ │    ├── cost: 24.15
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2,3)
+ └── filters
+      └── i:2 > 500 [outer=(2), constraints=(/2: [/501 - ]; tight)]
+
 # --------------------------------------------------
 # Q3
 # --------------------------------------------------
 
-opt set=(optimizer_prefer_bounded_cardinality=false)
+opt set=(optimizer_prefer_bounded_cardinality=false,optimizer_min_row_count=0)
 SELECT * FROM t WHERE k IN (410, 420, 430) AND i > 500
 ----
 index-join t
@@ -234,7 +294,7 @@ index-join t
       └── filters
            └── k:1 IN (410, 420, 430) [outer=(1), constraints=(/1: [/410 - /410] [/420 - /420] [/430 - /430]; tight)]
 
-opt set=(optimizer_prefer_bounded_cardinality=true)
+opt set=(optimizer_prefer_bounded_cardinality=true,optimizer_min_row_count=0)
 SELECT * FROM t WHERE k IN (410, 420, 430) AND i > 500
 ----
 select
@@ -261,11 +321,38 @@ select
  └── filters
       └── i:2 > 500 [outer=(2), constraints=(/2: [/501 - ]; tight)]
 
+opt set=(optimizer_prefer_bounded_cardinality=false,optimizer_min_row_count=1)
+SELECT * FROM t WHERE k IN (410, 420, 430) AND i > 500
+----
+select
+ ├── columns: k:1!null i:2!null s:3
+ ├── cardinality: [0 - 3]
+ ├── stats: [rows=1, distinct(1)=1, null(1)=0, distinct(2)=1, null(2)=0]
+ │   histogram(1)=
+ │   histogram(2)=
+ ├── cost: 19.03
+ ├── key: (1)
+ ├── fd: (1)-->(2,3)
+ ├── scan t
+ │    ├── columns: k:1!null i:2 s:3
+ │    ├── constraint: /1
+ │    │    ├── [/410 - /410]
+ │    │    ├── [/420 - /420]
+ │    │    └── [/430 - /430]
+ │    ├── cardinality: [0 - 3]
+ │    ├── stats: [rows=6e-07, distinct(1)=6e-07, null(1)=0]
+ │    │   histogram(1)=
+ │    ├── cost: 19.01
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2,3)
+ └── filters
+      └── i:2 > 500 [outer=(2), constraints=(/2: [/501 - ]; tight)]
+
 # --------------------------------------------------
 # Q4
 # --------------------------------------------------
 
-opt set=(optimizer_prefer_bounded_cardinality=false)
+opt set=(optimizer_prefer_bounded_cardinality=false,optimizer_min_row_count=0)
 SELECT * FROM t WHERE k IN (100, 110, 120, 130) AND i = 400 AND s < 'apple'
 ----
 select
@@ -311,7 +398,7 @@ select
  └── filters
       └── i:2 = 400 [outer=(2), constraints=(/2: [/400 - /400]; tight), fd=()-->(2)]
 
-opt set=(optimizer_prefer_bounded_cardinality=true)
+opt set=(optimizer_prefer_bounded_cardinality=true,optimizer_min_row_count=0)
 SELECT * FROM t WHERE k IN (100, 110, 120, 130) AND i = 400 AND s < 'apple'
 ----
 select
@@ -344,11 +431,44 @@ select
       ├── i:2 = 400 [outer=(2), constraints=(/2: [/400 - /400]; tight), fd=()-->(2)]
       └── s:3 < 'apple' [outer=(3), constraints=(/3: (/NULL - /'apple'); tight)]
 
+opt set=(optimizer_prefer_bounded_cardinality=false,optimizer_min_row_count=1)
+SELECT * FROM t WHERE k IN (100, 110, 120, 130) AND i = 400 AND s < 'apple'
+----
+select
+ ├── columns: k:1!null i:2!null s:3!null
+ ├── cardinality: [0 - 4]
+ ├── stats: [rows=1, distinct(1)=1, null(1)=0, distinct(2)=1, null(2)=0, distinct(3)=1, null(3)=0, distinct(2,3)=1, null(2,3)=0, distinct(1-3)=1, null(1-3)=0]
+ │   histogram(1)=  0 0.25  0 0.25  0 0.25  0 0.25
+ │                <--- 100 --- 110 --- 120 --- 130
+ │   histogram(2)=  0   1
+ │                <--- 400
+ │   histogram(3)=
+ ├── cost: 24.22
+ ├── key: (1)
+ ├── fd: ()-->(2), (1)-->(3)
+ ├── scan t
+ │    ├── columns: k:1!null i:2 s:3
+ │    ├── constraint: /1
+ │    │    ├── [/100 - /100]
+ │    │    ├── [/110 - /110]
+ │    │    ├── [/120 - /120]
+ │    │    └── [/130 - /130]
+ │    ├── cardinality: [0 - 4]
+ │    ├── stats: [rows=4, distinct(1)=4, null(1)=0]
+ │    │   histogram(1)=  0   1   0   1   0   1   0   1
+ │    │                <--- 100 --- 110 --- 120 --- 130
+ │    ├── cost: 24.15
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2,3)
+ └── filters
+      ├── i:2 = 400 [outer=(2), constraints=(/2: [/400 - /400]; tight), fd=()-->(2)]
+      └── s:3 < 'apple' [outer=(3), constraints=(/3: (/NULL - /'apple'); tight)]
+
 # --------------------------------------------------
 # Q5
 # --------------------------------------------------
 
-opt set=(enable_zigzag_join=false,optimizer_prefer_bounded_cardinality=false)
+opt set=(enable_zigzag_join=false,optimizer_prefer_bounded_cardinality=false,optimizer_min_row_count=0)
 SELECT * FROM t WHERE i = 400 AND s > 'z'
 ----
 select
@@ -377,7 +497,7 @@ select
  └── filters
       └── i:2 = 400 [outer=(2), constraints=(/2: [/400 - /400]; tight), fd=()-->(2)]
 
-opt set=(enable_zigzag_join=false,optimizer_prefer_bounded_cardinality=true)
+opt set=(enable_zigzag_join=false,optimizer_prefer_bounded_cardinality=true,optimizer_min_row_count=0)
 SELECT * FROM t WHERE i = 400 AND s > 'z'
 ----
 select
@@ -409,11 +529,40 @@ select
  └── filters
       └── i:2 = 400 [outer=(2), constraints=(/2: [/400 - /400]; tight), fd=()-->(2)]
 
+opt set=(enable_zigzag_join=false,optimizer_prefer_bounded_cardinality=false,optimizer_min_row_count=1)
+SELECT * FROM t WHERE i = 400 AND s > 'z'
+----
+select
+ ├── columns: k:1!null i:2!null s:3!null
+ ├── stats: [rows=1, distinct(2)=1, null(2)=0, distinct(3)=1, null(3)=0, distinct(2,3)=1, null(2,3)=0]
+ │   histogram(2)=  0   1
+ │                <--- 400
+ │   histogram(3)=
+ ├── cost: 25.1375
+ ├── key: (1)
+ ├── fd: ()-->(2), (1)-->(3)
+ ├── index-join t
+ │    ├── columns: k:1!null i:2 s:3
+ │    ├── stats: [rows=1]
+ │    ├── cost: 25.0975
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2,3)
+ │    └── scan t@t_s_idx
+ │         ├── columns: k:1!null s:3!null
+ │         ├── constraint: /3/1: [/e'z\x00' - ]
+ │         ├── stats: [rows=1, distinct(3)=1, null(3)=0]
+ │         │   histogram(3)=
+ │         ├── cost: 19.045
+ │         ├── key: (1)
+ │         └── fd: (1)-->(3)
+ └── filters
+      └── i:2 = 400 [outer=(2), constraints=(/2: [/400 - /400]; tight), fd=()-->(2)]
+
 # --------------------------------------------------
 # Q6
 # --------------------------------------------------
 
-opt set=(optimizer_prefer_bounded_cardinality=false)
+opt set=(optimizer_prefer_bounded_cardinality=false,optimizer_min_row_count=0)
 SELECT * FROM t WHERE k = 100 AND i = 500 AND s = 'zzz'
 ----
 select
@@ -448,7 +597,7 @@ select
  └── filters
       └── s:3 = 'zzz' [outer=(3), constraints=(/3: [/'zzz' - /'zzz']; tight), fd=()-->(3)]
 
-opt set=(optimizer_prefer_bounded_cardinality=true)
+opt set=(optimizer_prefer_bounded_cardinality=true,optimizer_min_row_count=0)
 SELECT * FROM t WHERE k = 100 AND i = 500 AND s = 'zzz'
 ----
 select
@@ -481,4 +630,32 @@ select
  │         ├── key: ()
  │         └── fd: ()-->(1,2)
  └── filters
+      └── s:3 = 'zzz' [outer=(3), constraints=(/3: [/'zzz' - /'zzz']; tight), fd=()-->(3)]
+
+opt set=(optimizer_prefer_bounded_cardinality=false,optimizer_min_row_count=1)
+SELECT * FROM t WHERE k = 100 AND i = 500 AND s = 'zzz'
+----
+select
+ ├── columns: k:1!null i:2!null s:3!null
+ ├── cardinality: [0 - 1]
+ ├── stats: [rows=1, distinct(1)=1, null(1)=0, distinct(2)=1, null(2)=0, distinct(3)=1, null(3)=0]
+ │   histogram(1)=  0   1
+ │                <--- 100
+ │   histogram(2)=
+ │   histogram(3)=
+ ├── cost: 9.085
+ ├── key: ()
+ ├── fd: ()-->(1-3)
+ ├── scan t
+ │    ├── columns: k:1!null i:2 s:3
+ │    ├── constraint: /1: [/100 - /100]
+ │    ├── cardinality: [0 - 1]
+ │    ├── stats: [rows=1, distinct(1)=1, null(1)=0]
+ │    │   histogram(1)=  0   1
+ │    │                <--- 100
+ │    ├── cost: 9.045
+ │    ├── key: ()
+ │    └── fd: ()-->(1-3)
+ └── filters
+      ├── i:2 = 500 [outer=(2), constraints=(/2: [/500 - /500]; tight), fd=()-->(2)]
       └── s:3 = 'zzz' [outer=(3), constraints=(/3: [/'zzz' - /'zzz']; tight), fd=()-->(3)]

--- a/pkg/sql/opt/xform/testdata/coster/scan
+++ b/pkg/sql/opt/xform/testdata/coster/scan
@@ -585,7 +585,8 @@ scan t@abc
  ├── key: (1)
  └── fd: ()-->(2,3), (1)-->(4)
 
-# Test that the NO_FULL_SCAN hint creates a huge cost for full scans.
+# Test that the NO_FULL_SCAN and AVOID_FULL_SCAN hints add a huge cost or
+# penalty for full scans.
 opt
 SELECT * FROM t@{NO_FULL_SCAN}
 ----
@@ -594,6 +595,19 @@ scan t
  ├── flags: no-full-scan
  ├── stats: [rows=100000]
  ├── cost: 1e+100
+ ├── cost-flags: huge-cost-penalty
+ ├── key: (1)
+ └── fd: (1)-->(2-4)
+
+opt
+SELECT * FROM t@{AVOID_FULL_SCAN}
+----
+scan t
+ ├── columns: k:1!null a:2 b:3 c:4
+ ├── flags: avoid-full-scan
+ ├── stats: [rows=100000]
+ ├── cost: 108028.82
+ ├── cost-flags: full-scan-penalty
  ├── key: (1)
  └── fd: (1)-->(2-4)
 
@@ -620,12 +634,30 @@ index-join t
       └── fd: (1)-->(3)
 
 opt
+SELECT * FROM t@{AVOID_FULL_SCAN} WHERE c > 0
+----
+index-join t
+ ├── columns: k:1!null a:2 b:3 c:4!null
+ ├── stats: [rows=33003.3, distinct(4)=3333.33, null(4)=0]
+ ├── cost: 234671.505
+ ├── key: (1)
+ ├── fd: (1)-->(2-4)
+ └── scan t@b_partial,partial
+      ├── columns: k:1!null b:3
+      ├── flags: avoid-full-scan
+      ├── stats: [rows=33003.3, distinct(4)=3333.33, null(4)=0]
+      ├── cost: 34341.4524
+      ├── key: (1)
+      └── fd: (1)-->(3)
+
+opt
 SELECT * FROM t@{FORCE_INDEX=b_partial,NO_FULL_SCAN} WHERE c > 0
 ----
 select
  ├── columns: k:1!null a:2 b:3 c:4!null
  ├── stats: [rows=33003.3, distinct(4)=3333.33, null(4)=0]
  ├── cost: 1e+100
+ ├── cost-flags: huge-cost-penalty
  ├── key: (1)
  ├── fd: (1)-->(2-4)
  ├── scan t
@@ -636,10 +668,30 @@ select
  │    ├── flags: force-index=b_partial no-full-scan
  │    ├── stats: [rows=100000, distinct(1)=3, null(1)=0, distinct(4)=10000, null(4)=1000]
  │    ├── cost: 1e+100
+ │    ├── cost-flags: huge-cost-penalty
  │    ├── key: (1)
  │    └── fd: (1)-->(2-4)
  └── filters
       └── c:4 > 0 [outer=(4), constraints=(/4: [/1 - ]; tight)]
+
+opt
+SELECT * FROM t@{FORCE_INDEX=b_partial,AVOID_FULL_SCAN} WHERE c > 0
+----
+index-join t
+ ├── columns: k:1!null a:2 b:3 c:4!null
+ ├── stats: [rows=33003.3, distinct(4)=3333.33, null(4)=0]
+ ├── cost: 234671.505
+ ├── cost-flags: full-scan-penalty
+ ├── key: (1)
+ ├── fd: (1)-->(2-4)
+ └── scan t@b_partial,partial
+      ├── columns: k:1!null b:3
+      ├── flags: force-index=b_partial avoid-full-scan
+      ├── stats: [rows=33003.3, distinct(4)=3333.33, null(4)=0]
+      ├── cost: 34341.4524
+      ├── cost-flags: full-scan-penalty
+      ├── key: (1)
+      └── fd: (1)-->(3)
 
 # Test that the FORCE_INVERTED_INDEX hint creates a huge cost for full table
 # scans.
@@ -654,6 +706,7 @@ scan t
  ├── flags:
  ├── stats: [rows=100000]
  ├── cost: 1e+100
+ ├── cost-flags: huge-cost-penalty
  ├── key: (1)
  └── fd: (1)-->(2-4)
 
@@ -668,6 +721,7 @@ select
  │   histogram(3)=  0  0
  │                <--- 0
  ├── cost: 1e+100
+ ├── cost-flags: huge-cost-penalty
  ├── key: (1)
  ├── fd: ()-->(3), (1)-->(2,4)
  ├── scan t
@@ -680,6 +734,7 @@ select
  │    │   histogram(3)=  0  0  1e+05  0
  │    │                <--- 0 ------- 10
  │    ├── cost: 1e+100
+ │    ├── cost-flags: huge-cost-penalty
  │    ├── key: (1)
  │    └── fd: (1)-->(2-4)
  └── filters

--- a/pkg/sql/opt/xform/testdata/coster/select
+++ b/pkg/sql/opt/xform/testdata/coster/select
@@ -134,6 +134,7 @@ select
  ├── columns: n:1!null a:2!null b:3!null c:4
  ├── stats: [rows=0.9108108, distinct(2)=0.910811, null(2)=0, distinct(3)=0.910811, null(3)=0, distinct(2,3)=0.910811, null(2,3)=0]
  ├── cost: 1e+100
+ ├── cost-flags: huge-cost-penalty
  ├── key: (1)
  ├── fd: ()-->(2,3), (1)-->(4), (3,4)~~>(1)
  ├── scan zigzag
@@ -141,6 +142,7 @@ select
  │    ├── flags: force-zigzag=a_idx,c_idx
  │    ├── stats: [rows=1000, distinct(1)=1000, null(1)=0, distinct(2)=100, null(2)=10, distinct(3)=100, null(3)=10, distinct(2,3)=1000, null(2,3)=0.1]
  │    ├── cost: 1e+100
+ │    ├── cost-flags: huge-cost-penalty
  │    ├── key: (1)
  │    └── fd: (1)-->(2-4), (3,4)~~>(1,2)
  └── filters
@@ -155,6 +157,7 @@ select
  ├── columns: n:1!null a:2!null b:3!null c:4
  ├── stats: [rows=0.9108108, distinct(2)=0.910811, null(2)=0, distinct(3)=0.910811, null(3)=0, distinct(2,3)=0.910811, null(2,3)=0]
  ├── cost: 1e+100
+ ├── cost-flags: huge-cost-penalty
  ├── key: (1)
  ├── fd: ()-->(2,3), (1)-->(4), (3,4)~~>(1)
  ├── scan zigzag
@@ -162,6 +165,7 @@ select
  │    ├── flags: force-zigzag=a_idx,c_idx
  │    ├── stats: [rows=1000, distinct(1)=1000, null(1)=0, distinct(2)=100, null(2)=10, distinct(3)=100, null(3)=10, distinct(2,3)=1000, null(2,3)=0.1]
  │    ├── cost: 1e+100
+ │    ├── cost-flags: huge-cost-penalty
  │    ├── key: (1)
  │    └── fd: (1)-->(2-4), (3,4)~~>(1,2)
  └── filters

--- a/pkg/sql/opt/xform/testdata/rules/groupby
+++ b/pkg/sql/opt/xform/testdata/rules/groupby
@@ -1892,7 +1892,7 @@ memo (optimized, ~15KB, required=[presentation: array_agg:7])
 memo
 SELECT sum(k) FROM (SELECT * FROM kuvw WHERE u=v) GROUP BY u,w
 ----
-memo (optimized, ~15KB, required=[presentation: sum:7])
+memo (optimized, ~16KB, required=[presentation: sum:7])
  ├── G1: (project G2 G3 sum)
  │    └── [presentation: sum:7]
  │         ├── best: (project G2 G3 sum)

--- a/pkg/sql/opt/xform/testdata/rules/groupby
+++ b/pkg/sql/opt/xform/testdata/rules/groupby
@@ -1819,7 +1819,7 @@ memo (optimized, ~9KB, required=[presentation: array_agg:7])
 memo
 SELECT array_agg(k) FROM (SELECT * FROM kuvw WHERE u=v ORDER BY u) GROUP BY w
 ----
-memo (optimized, ~15KB, required=[presentation: array_agg:7])
+memo (optimized, ~16KB, required=[presentation: array_agg:7])
  ├── G1: (project G2 G3 array_agg)
  │    └── [presentation: array_agg:7]
  │         ├── best: (project G2 G3 array_agg)
@@ -2142,7 +2142,7 @@ memo (optimized, ~6KB, required=[presentation: u:2,v:3,w:4] [ordering: +2])
 memo
 SELECT DISTINCT ON (u) u, v, w FROM kuvw ORDER BY u, v, w
 ----
-memo (optimized, ~6KB, required=[presentation: u:2,v:3,w:4] [ordering: +2])
+memo (optimized, ~7KB, required=[presentation: u:2,v:3,w:4] [ordering: +2])
  ├── G1: (distinct-on G2 G3 cols=(2),ordering=+3,+4 opt(2)) (distinct-on G2 G3 cols=(2),ordering=+2,+3,+4) (distinct-on G2 G3 cols=(2),ordering=+3,+4)
  │    ├── [presentation: u:2,v:3,w:4] [ordering: +2]
  │    │    ├── best: (distinct-on G2="[ordering: +2,+3,+4]" G3 cols=(2),ordering=+3,+4 opt(2))
@@ -2298,7 +2298,7 @@ memo (optimized, ~6KB, required=[presentation: u:2,v:3,w:4] [ordering: +4])
 memo
 SELECT (SELECT w FROM kuvw WHERE v=1 AND x=u) FROM xyz ORDER BY x+1, x
 ----
-memo (optimized, ~26KB, required=[presentation: w:12] [ordering: +13,+1])
+memo (optimized, ~27KB, required=[presentation: w:12] [ordering: +13,+1])
  ├── G1: (project G2 G3 x)
  │    ├── [presentation: w:12] [ordering: +13,+1]
  │    │    ├── best: (sort G1)
@@ -2365,7 +2365,7 @@ memo (optimized, ~26KB, required=[presentation: w:12] [ordering: +13,+1])
 memo
 INSERT INTO xyz SELECT v, w, 1.0 FROM kuvw ON CONFLICT (x) DO NOTHING
 ----
-memo (optimized, ~27KB, required=[])
+memo (optimized, ~28KB, required=[])
  ├── G1: (insert G2 G3 G4 G5 xyz)
  │    └── []
  │         ├── best: (insert G2 G3 G4 G5 xyz)
@@ -3432,7 +3432,7 @@ INDEX gg (g)
 memo
 SELECT d, e, count(*) FROM defg GROUP BY d, e LIMIT 10
 ----
-memo (optimized, ~20KB, required=[presentation: d:1,e:2,count:8])
+memo (optimized, ~21KB, required=[presentation: d:1,e:2,count:8])
  ├── G1: (limit G2 G3) (limit G4 G3) (limit G5 G3) (limit G6 G3)
  │    └── [presentation: d:1,e:2,count:8]
  │         ├── best: (limit G4="[limit hint: 10.00]" G3)

--- a/pkg/sql/opt/xform/testdata/rules/groupby
+++ b/pkg/sql/opt/xform/testdata/rules/groupby
@@ -1766,7 +1766,7 @@ memo (optimized, ~8KB, required=[presentation: sum:7])
 memo
 SELECT sum(w) FROM kuvw GROUP BY v
 ----
-memo (optimized, ~7KB, required=[presentation: sum:7])
+memo (optimized, ~8KB, required=[presentation: sum:7])
  ├── G1: (project G2 G3 sum)
  │    └── [presentation: sum:7]
  │         ├── best: (project G2 G3 sum)
@@ -1995,7 +1995,7 @@ memo (optimized, ~9KB, required=[presentation: array_agg:7])
 memo
 SELECT DISTINCT u, v, w FROM kuvw
 ----
-memo (optimized, ~6KB, required=[presentation: u:2,v:3,w:4])
+memo (optimized, ~7KB, required=[presentation: u:2,v:3,w:4])
  ├── G1: (distinct-on G2 G3 cols=(2-4)) (distinct-on G2 G3 cols=(2-4),ordering=+2,+3,+4) (distinct-on G2 G3 cols=(2-4),ordering=+4,+3,+2) (distinct-on G2 G3 cols=(2-4),ordering=+3,+4)
  │    └── [presentation: u:2,v:3,w:4]
  │         ├── best: (distinct-on G2="[ordering: +2,+3,+4]" G3 cols=(2-4),ordering=+2,+3,+4)

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -1823,7 +1823,7 @@ inner-join (merge)
 memo
 SELECT * FROM abc JOIN xyz ON a=x
 ----
-memo (optimized, ~15KB, required=[presentation: a:1,b:2,c:3,x:7,y:8,z:9])
+memo (optimized, ~16KB, required=[presentation: a:1,b:2,c:3,x:7,y:8,z:9])
  ├── G1: (inner-join G2 G3 G4) (inner-join G3 G2 G4) (merge-join G2 G3 G5 inner-join,+1,+7) (lookup-join G2 G5 xyz@xy,keyCols=[1],outCols=(1-3,7-9)) (merge-join G3 G2 G5 inner-join,+7,+1) (lookup-join G3 G5 abc@ab,keyCols=[7],outCols=(1-3,7-9))
  │    └── [presentation: a:1,b:2,c:3,x:7,y:8,z:9]
  │         ├── best: (merge-join G3="[ordering: +7]" G2="[ordering: +1]" G5 inner-join,+7,+1)
@@ -1874,7 +1874,7 @@ memo (optimized, ~11KB, required=[presentation: a:1,b:2,c:3,x:7,y:8,z:9])
 memo set=(optimizer_merge_joins_enabled=false) expect-not=GenerateMergeJoins
 SELECT * FROM abc JOIN xyz ON a=x
 ----
-memo (optimized, ~14KB, required=[presentation: a:1,b:2,c:3,x:7,y:8,z:9])
+memo (optimized, ~15KB, required=[presentation: a:1,b:2,c:3,x:7,y:8,z:9])
  ├── G1: (inner-join G2 G3 G4) (inner-join G3 G2 G4) (lookup-join G2 G5 xyz@xy,keyCols=[1],outCols=(1-3,7-9)) (lookup-join G3 G5 abc@ab,keyCols=[7],outCols=(1-3,7-9))
  │    └── [presentation: a:1,b:2,c:3,x:7,y:8,z:9]
  │         ├── best: (inner-join G3 G2 G4)
@@ -7237,7 +7237,7 @@ WHERE n.name = 'Upper West Side'
 OR n.name = 'Upper East Side'
 GROUP BY n.name, n.geom
 ----
-memo (optimized, ~36KB, required=[presentation: name:16,popn_per_sqkm:22])
+memo (optimized, ~37KB, required=[presentation: name:16,popn_per_sqkm:22])
  ├── G1: (project G2 G3 name)
  │    └── [presentation: name:16,popn_per_sqkm:22]
  │         ├── best: (project G2 G3 name)

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -297,7 +297,7 @@ memo (optimized, ~46KB, required=[presentation: a:1,b:2,c:3,s:7,t:8,u:9,x:12,y:1
 memo
 SELECT * FROM abc, stu, xyz, pqr WHERE a = 1
 ----
-memo (optimized, ~30KB, required=[presentation: a:1,b:2,c:3,s:7,t:8,u:9,x:12,y:13,z:14,p:18,q:19,r:20,s:21,t:22])
+memo (optimized, ~31KB, required=[presentation: a:1,b:2,c:3,s:7,t:8,u:9,x:12,y:13,z:14,p:18,q:19,r:20,s:21,t:22])
  ├── G1: (inner-join G2 G3 G4) (inner-join G3 G2 G4)
  │    └── [presentation: a:1,b:2,c:3,s:7,t:8,u:9,x:12,y:13,z:14,p:18,q:19,r:20,s:21,t:22]
  │         ├── best: (inner-join G3 G2 G4)
@@ -437,7 +437,7 @@ INNER JOIN LATERAL (
 )
 ON a = v
 ----
-memo (optimized, ~16KB, required=[presentation: a:1,b:2,c:3,v:7,s:8,t:9,u:10])
+memo (optimized, ~17KB, required=[presentation: a:1,b:2,c:3,v:7,s:8,t:9,u:10])
  ├── G1: (inner-join-apply G2 G3 G4)
  │    └── [presentation: a:1,b:2,c:3,v:7,s:8,t:9,u:10]
  │         ├── best: (inner-join-apply G2 G3 G4)
@@ -1249,7 +1249,7 @@ New expression 2 of 2:
 memo expect=ReorderJoins
 SELECT * FROM abc JOIN xyz ON a=z
 ----
-memo (optimized, ~13KB, required=[presentation: a:1,b:2,c:3,x:7,y:8,z:9])
+memo (optimized, ~14KB, required=[presentation: a:1,b:2,c:3,x:7,y:8,z:9])
  ├── G1: (inner-join G2 G3 G4) (inner-join G3 G2 G4) (merge-join G2 G3 G5 inner-join,+1,+9) (lookup-join G3 G5 abc@ab,keyCols=[9],outCols=(1-3,7-9))
  │    └── [presentation: a:1,b:2,c:3,x:7,y:8,z:9]
  │         ├── best: (inner-join G2 G3 G4)
@@ -1493,7 +1493,7 @@ right-join (hash)
 memo
 SELECT * FROM abc RIGHT OUTER JOIN xyz ON a=z
 ----
-memo (optimized, ~13KB, required=[presentation: a:1,b:2,c:3,x:7,y:8,z:9])
+memo (optimized, ~14KB, required=[presentation: a:1,b:2,c:3,x:7,y:8,z:9])
  ├── G1: (left-join G2 G3 G4) (right-join G3 G2 G4) (lookup-join G2 G5 abc@ab,keyCols=[9],outCols=(1-3,7-9)) (merge-join G3 G2 G5 right-join,+1,+9)
  │    └── [presentation: a:1,b:2,c:3,x:7,y:8,z:9]
  │         ├── best: (left-join G2 G3 G4)

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -2152,7 +2152,7 @@ left-join (merge)
 memo
 SELECT * FROM abc JOIN xyz ON a=b
 ----
-memo (optimized, ~17KB, required=[presentation: a:1,b:2,c:3,x:7,y:8,z:9])
+memo (optimized, ~18KB, required=[presentation: a:1,b:2,c:3,x:7,y:8,z:9])
  ├── G1: (inner-join G2 G3 G4) (inner-join G3 G2 G4)
  │    └── [presentation: a:1,b:2,c:3,x:7,y:8,z:9]
  │         ├── best: (inner-join G3 G2 G4)
@@ -2190,7 +2190,7 @@ CREATE TABLE kfloat (k FLOAT PRIMARY KEY)
 memo
 SELECT * FROM abc JOIN kfloat ON a=k
 ----
-memo (optimized, ~13KB, required=[presentation: a:1,b:2,c:3,k:7])
+memo (optimized, ~14KB, required=[presentation: a:1,b:2,c:3,k:7])
  ├── G1: (inner-join G2 G3 G4) (inner-join G3 G2 G4)
  │    └── [presentation: a:1,b:2,c:3,k:7]
  │         ├── best: (inner-join G3 G2 G4)

--- a/pkg/sql/opt/xform/testdata/rules/join_order
+++ b/pkg/sql/opt/xform/testdata/rules/join_order
@@ -587,7 +587,7 @@ memo (optimized, ~31KB, required=[presentation: b:1,x:2,c:5,y:6,d:9,z:10,a:13,b:
 memo set=reorder_joins_limit=3
 SELECT * FROM bx, cy, dz, abc WHERE x = y AND y = z AND z = a
 ----
-memo (optimized, ~66KB, required=[presentation: b:1,x:2,c:5,y:6,d:9,z:10,a:13,b:14,c:15,d:16])
+memo (optimized, ~67KB, required=[presentation: b:1,x:2,c:5,y:6,d:9,z:10,a:13,b:14,c:15,d:16])
  ├── G1: (inner-join G2 G3 G4) (inner-join G3 G2 G4) (inner-join G5 G6 G7) (inner-join G6 G5 G7) (inner-join G8 G9 G7) (inner-join G9 G8 G7) (inner-join G10 G11 G12) (inner-join G11 G10 G12) (inner-join G13 G14 G12) (inner-join G14 G13 G12) (inner-join G15 G16 G12) (inner-join G16 G15 G12) (inner-join G17 G18 G12) (inner-join G18 G17 G12) (merge-join G3 G2 G19 inner-join,+6,+2) (merge-join G6 G5 G19 inner-join,+10,+6) (merge-join G9 G8 G19 inner-join,+10,+6) (merge-join G11 G10 G19 inner-join,+13,+10) (merge-join G14 G13 G19 inner-join,+13,+10) (merge-join G16 G15 G19 inner-join,+13,+10) (lookup-join G17 G19 abc,keyCols=[10],outCols=(1,2,5,6,9,10,13-16)) (merge-join G18 G17 G19 inner-join,+13,+10)
  │    └── [presentation: b:1,x:2,c:5,y:6,d:9,z:10,a:13,b:14,c:15,d:16]
  │         ├── best: (inner-join G3 G2 G4)
@@ -2774,7 +2774,7 @@ SELECT (
 )
   FROM table80901_1 AS tab_42921;
 ----
-memo (optimized, ~70KB, required=[presentation: ?column?:50])
+memo (optimized, ~71KB, required=[presentation: ?column?:50])
  ├── G1: (project G2 G3)
  │    └── [presentation: ?column?:50]
  │         ├── best: (project G2 G3)

--- a/pkg/sql/opt/xform/testdata/rules/join_order
+++ b/pkg/sql/opt/xform/testdata/rules/join_order
@@ -360,7 +360,7 @@ memo (optimized, ~24KB, required=[presentation: b:1,x:2,c:5,y:6,a:9,b:10,c:11,d:
 memo set=reorder_joins_limit=2
 SELECT * FROM bx, cy, abc WHERE a = 1 AND abc.b = bx.b AND abc.c = cy.c
 ----
-memo (optimized, ~35KB, required=[presentation: b:1,x:2,c:5,y:6,a:9,b:10,c:11,d:12])
+memo (optimized, ~36KB, required=[presentation: b:1,x:2,c:5,y:6,a:9,b:10,c:11,d:12])
  ├── G1: (inner-join G2 G3 G4) (inner-join G3 G2 G4) (inner-join G5 G6 G7) (inner-join G6 G5 G7) (merge-join G2 G3 G8 inner-join,+1,+10) (merge-join G3 G2 G8 inner-join,+10,+1) (lookup-join G3 G8 bx,keyCols=[10],outCols=(1,2,5,6,9-12)) (merge-join G5 G6 G8 inner-join,+5,+11) (merge-join G6 G5 G8 inner-join,+11,+5) (lookup-join G6 G8 cy,keyCols=[11],outCols=(1,2,5,6,9-12))
  │    └── [presentation: b:1,x:2,c:5,y:6,a:9,b:10,c:11,d:12]
  │         ├── best: (lookup-join G3 G8 bx,keyCols=[10],outCols=(1,2,5,6,9-12))
@@ -521,7 +521,7 @@ inner-join (cross)
 memo set=reorder_joins_limit=0
 SELECT * FROM bx, cy, dz, abc WHERE x = y AND y = z AND z = a
 ----
-memo (optimized, ~31KB, required=[presentation: b:1,x:2,c:5,y:6,d:9,z:10,a:13,b:14,c:15,d:16])
+memo (optimized, ~32KB, required=[presentation: b:1,x:2,c:5,y:6,d:9,z:10,a:13,b:14,c:15,d:16])
  ├── G1: (inner-join G2 G3 G4) (merge-join G2 G3 G5 inner-join,+2,+6)
  │    └── [presentation: b:1,x:2,c:5,y:6,d:9,z:10,a:13,b:14,c:15,d:16]
  │         ├── best: (inner-join G2 G3 G4)
@@ -2774,7 +2774,7 @@ SELECT (
 )
   FROM table80901_1 AS tab_42921;
 ----
-memo (optimized, ~71KB, required=[presentation: ?column?:50])
+memo (optimized, ~72KB, required=[presentation: ?column?:50])
  ├── G1: (project G2 G3)
  │    └── [presentation: ?column?:50]
  │         ├── best: (project G2 G3)
@@ -3547,7 +3547,7 @@ right-join (hash)
 
 # Only 2 joins are considered (instead of 8) when the STRAIGHT hint is present in one join.
 reorderjoins format=hide-all
-SELECT * 
+SELECT *
 FROM straight_join1
 INNER STRAIGHT JOIN straight_join2 ON straight_join1.x = straight_join2.y
 INNER JOIN straight_join3 ON straight_join1.x = straight_join3.z
@@ -3597,7 +3597,7 @@ inner-join (hash)
 
 # No joins are considered when the STRAIGHT hint is present in both joins.
 reorderjoins format=hide-all
-SELECT * 
+SELECT *
 FROM straight_join1
 INNER STRAIGHT JOIN straight_join2 ON straight_join1.x = straight_join2.y
 INNER STRAIGHT JOIN straight_join3 ON straight_join1.x = straight_join3.z

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -892,7 +892,7 @@ index-join b
 memo
 SELECT * FROM b WHERE v >= 1 AND v <= 10 AND k > 5
 ----
-memo (optimized, ~10KB, required=[presentation: k:1,u:2,v:3,j:4])
+memo (optimized, ~11KB, required=[presentation: k:1,u:2,v:3,j:4])
  ├── G1: (select G2 G3) (select G4 G5) (index-join G6 b,cols=(1-4))
  │    └── [presentation: k:1,u:2,v:3,j:4]
  │         ├── best: (index-join G6 b,cols=(1-4))
@@ -9494,7 +9494,7 @@ select
 memo
 SELECT p,q,r,s FROM pqr WHERE q = 1 AND r = 1 AND s = 'foo'
 ----
-memo (optimized, ~40KB, required=[presentation: p:1,q:2,r:3,s:4])
+memo (optimized, ~41KB, required=[presentation: p:1,q:2,r:3,s:4])
  ├── G1: (select G2 G3) (select G4 G5) (select G6 G7) (select G8 G9) (select G10 G9) (lookup-join G11 G12 pqr,keyCols=[1],outCols=(1-4)) (zigzag-join G3 pqr@q pqr@s) (zigzag-join G3 pqr@q pqr@rs) (lookup-join G13 G9 pqr,keyCols=[1],outCols=(1-4))
  │    └── [presentation: p:1,q:2,r:3,s:4]
  │         ├── best: (zigzag-join G3 pqr@q pqr@s)
@@ -9586,7 +9586,7 @@ select
 memo
 SELECT q,t FROM pqr WHERE q = 1 AND t = 'foo'
 ----
-memo (optimized, ~11KB, required=[presentation: q:2,t:5])
+memo (optimized, ~12KB, required=[presentation: q:2,t:5])
  ├── G1: (select G2 G3) (select G4 G5) (select G6 G7)
  │    └── [presentation: q:2,t:5]
  │         ├── best: (select G4 G5)

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -281,7 +281,7 @@ CREATE INDEX idx2 ON p (s) WHERE i > 0
 memo expect=GeneratePartialIndexScans
 SELECT * FROM p WHERE i > 0 AND s = 'foo'
 ----
-memo (optimized, ~18KB, required=[presentation: k:1,i:2,f:3,s:4,b:5])
+memo (optimized, ~19KB, required=[presentation: k:1,i:2,f:3,s:4,b:5])
  ├── G1: (select G2 G3) (index-join G4 p,cols=(1-5)) (index-join G5 p,cols=(1-5)) (index-join G6 p,cols=(1-5)) (index-join G7 p,cols=(1-5))
  │    └── [presentation: k:1,i:2,f:3,s:4,b:5]
  │         ├── best: (index-join G4 p,cols=(1-5))

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -574,7 +574,7 @@ scan a
 memo
 SELECT k FROM a WHERE k = 1
 ----
-memo (optimized, ~6KB, required=[presentation: k:1])
+memo (optimized, ~7KB, required=[presentation: k:1])
  ├── G1: (select G2 G3) (scan a,cols=(1),constrained)
  │    └── [presentation: k:1]
  │         ├── best: (scan a,cols=(1),constrained)
@@ -1753,7 +1753,7 @@ CREATE INDEX idx2 ON p (i) WHERE s = 'foo'
 memo
 SELECT i FROM p WHERE i = 3 AND s = 'foo'
 ----
-memo (optimized, ~23KB, required=[presentation: i:2])
+memo (optimized, ~24KB, required=[presentation: i:2])
  ├── G1: (project G2 G3 i)
  │    └── [presentation: i:2]
  │         ├── best: (project G2 G3 i)
@@ -6940,7 +6940,7 @@ CREATE INVERTED INDEX idx2 ON pi (j) WHERE s = 'bar'
 memo expect=GenerateInvertedIndexScans
 SELECT * FROM pi WHERE j @> '{"a": "b"}' AND s = 'bar'
 ----
-memo (optimized, ~14KB, required=[presentation: k:1,s:2,j:3])
+memo (optimized, ~15KB, required=[presentation: k:1,s:2,j:3])
  ├── G1: (select G2 G3) (select G4 G5) (index-join G6 pi,cols=(1-3))
  │    └── [presentation: k:1,s:2,j:3]
  │         ├── best: (index-join G6 pi,cols=(1-3))
@@ -6988,7 +6988,7 @@ CREATE INVERTED INDEX idx ON pi (j) WHERE s IN ('foo', 'bar')
 memo expect-not=GenerateInvertedIndexScans
 SELECT * FROM pi WHERE j @> '{"a": "b"}' AND s = 'baz'
 ----
-memo (optimized, ~8KB, required=[presentation: k:1,s:2,j:3])
+memo (optimized, ~9KB, required=[presentation: k:1,s:2,j:3])
  ├── G1: (select G2 G3)
  │    └── [presentation: k:1,s:2,j:3]
  │         ├── best: (select G2 G3)
@@ -11571,7 +11571,7 @@ CREATE TABLE t58390 (
 memo
 SELECT * FROM t58390 WHERE a > 1 OR b > 1
 ----
-memo (optimized, ~24KB, required=[presentation: k:1,a:2,b:3,c:4])
+memo (optimized, ~25KB, required=[presentation: k:1,a:2,b:3,c:4])
  ├── G1: (select G2 G3) (index-join G4 t58390,cols=(1-4)) (distinct-on G5 G6 cols=(1)) (distinct-on G5 G6 cols=(1),ordering=+1)
  │    └── [presentation: k:1,a:2,b:3,c:4]
  │         ├── best: (select G2 G3)
@@ -11686,7 +11686,7 @@ JOIN t61795 AS t2 ON t1.c = t1.b AND t1.b = t2.b
 WHERE t1.a = 10 OR t2.b != abs(t2.b)
 ORDER BY t1.b ASC
 ----
-memo (optimized, ~36KB, required=[presentation: a:1] [ordering: +2])
+memo (optimized, ~37KB, required=[presentation: a:1] [ordering: +2])
  ├── G1: (project G2 G3 a b)
  │    ├── [presentation: a:1] [ordering: +2]
  │    │    ├── best: (sort G1)

--- a/pkg/sql/opt/xform/testdata/rules/set
+++ b/pkg/sql/opt/xform/testdata/rules/set
@@ -21,7 +21,7 @@ CREATE TABLE kuvw (
 memo expect=GenerateStreamingSetOp
 SELECT u,v,w FROM kuvw UNION SELECT w,v,u FROM kuvw
 ----
-memo (optimized, ~11KB, required=[presentation: u:13,v:14,w:15])
+memo (optimized, ~12KB, required=[presentation: u:13,v:14,w:15])
  ├── G1: (union G2 G3) (union G2 G3 ordering=+13,+14,+15) (union G2 G3 ordering=+15,+14,+13) (union G2 G3 ordering=+14,+15,+13) (union G2 G3 ordering=+14,+13,+15)
  │    └── [presentation: u:13,v:14,w:15]
  │         ├── best: (union G2="[ordering: +2,+3,+4]" G3="[ordering: +10,+9,+8]" ordering=+13,+14,+15)

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -910,7 +910,7 @@ func (u *sqlSymUnion) showFingerprintOptions() *tree.ShowFingerprintOptions {
 // Ordinary key words in alphabetical order.
 %token <str> ABORT ABSOLUTE ACCESS ACTION ADD ADMIN AFTER AGGREGATE
 %token <str> ALL ALTER ALWAYS ANALYSE ANALYZE AND AND_AND ANY ANNOTATE_TYPE ARRAY AS ASC AS_JSON AT_AT
-%token <str> ASENSITIVE ASYMMETRIC AT ATOMIC ATTRIBUTE AUTHORIZATION AUTOMATIC AVAILABILITY
+%token <str> ASENSITIVE ASYMMETRIC AT ATOMIC ATTRIBUTE AUTHORIZATION AUTOMATIC AVAILABILITY AVOID_FULL_SCAN
 
 %token <str> BACKUP BACKUPS BACKWARD BATCH BEFORE BEGIN BETWEEN BIGINT BIGSERIAL BINARY BIT
 %token <str> BUCKET_COUNT
@@ -13502,6 +13502,10 @@ index_flags_param:
   {
     $$.val = &tree.IndexFlags{NoFullScan: true}
   }
+| AVOID_FULL_SCAN
+  {
+    $$.val = &tree.IndexFlags{AvoidFullScan: true}
+  }
 | IGNORE_FOREIGN_KEYS
   {
     /* SKIP DOC */
@@ -13591,6 +13595,7 @@ opt_index_flags:
 //   '{' NO_INDEX_JOIN [, ...] '}'
 //   '{' NO_ZIGZAG_JOIN [, ...] '}'
 //   '{' NO_FULL_SCAN [, ...] '}'
+//   '{' AVOID_FULL_SCAN [, ...] '}'
 //   '{' IGNORE_FOREIGN_KEYS [, ...] '}'
 //   '{' FORCE_ZIGZAG = <idxname> [, ...]  '}'
 //
@@ -17042,6 +17047,7 @@ unreserved_keyword:
 | ATTRIBUTE
 | AUTOMATIC
 | AVAILABILITY
+| AVOID_FULL_SCAN
 | BACKUP
 | BACKUPS
 | BACKWARD
@@ -17524,6 +17530,7 @@ bare_label_keywords:
 | AUTHORIZATION
 | AUTOMATIC
 | AVAILABILITY
+| AVOID_FULL_SCAN
 | BACKUP
 | BACKUPS
 | BACKWARD

--- a/pkg/sql/parser/testdata/hints
+++ b/pkg/sql/parser/testdata/hints
@@ -47,6 +47,14 @@ SELECT '_' FROM t@{NO_FULL_SCAN} -- literals removed
 SELECT 'a' FROM _@{NO_FULL_SCAN} -- identifiers removed
 
 parse
+SELECT 'a' FROM t@{AVOID_FULL_SCAN}
+----
+SELECT 'a' FROM t@{AVOID_FULL_SCAN}
+SELECT ('a') FROM t@{AVOID_FULL_SCAN} -- fully parenthesized
+SELECT '_' FROM t@{AVOID_FULL_SCAN} -- literals removed
+SELECT 'a' FROM _@{AVOID_FULL_SCAN} -- identifiers removed
+
+parse
 SELECT 'a' FROM t@{IGNORE_FOREIGN_KEYS}
 ----
 SELECT 'a' FROM t@{IGNORE_FOREIGN_KEYS}

--- a/pkg/sql/plan_opt.go
+++ b/pkg/sql/plan_opt.go
@@ -555,7 +555,9 @@ func (opc *optPlanningCtx) reuseMemo(
 	opc.flags.Set(planFlagOptimized)
 	mem := f.Memo()
 	if prep := opc.p.stmt.Prepared; opc.allowMemoReuse && prep != nil {
-		prep.Costs.AddCustom(mem.RootExpr().(memo.RelExpr).Cost() + mem.OptimizationCost())
+		costWithOptimizationCost := mem.RootExpr().(memo.RelExpr).Cost()
+		costWithOptimizationCost.Add(mem.OptimizationCost())
+		prep.Costs.AddCustom(costWithOptimizationCost)
 	}
 	return mem, nil
 }
@@ -596,10 +598,10 @@ func (opc *optPlanningCtx) useGenericPlan() bool {
 		//
 		//   1. The generic cost is unknown because a generic plan has not been
 		//      built.
-		//   2. Or, the cost of the generic plan is less than or equal to the
-		//      average cost of the custom plans.
+		//   2. Or, the cost of the generic plan is less than the average cost of
+		//      the custom plans.
 		//
-		return prep.Costs.Generic() == 0 || prep.Costs.Generic() < prep.Costs.AvgCustom()
+		return prep.Costs.Generic().C == 0 || prep.Costs.Generic().Less(prep.Costs.AvgCustom())
 	default:
 		return false
 	}
@@ -957,7 +959,7 @@ func (opc *optPlanningCtx) runExecBuilder(
 	if gf != nil {
 		planTop.instrumentation.planGist = gf.PlanGist()
 	}
-	planTop.instrumentation.costEstimate = float64(mem.RootExpr().(memo.RelExpr).Cost())
+	planTop.instrumentation.costEstimate = mem.RootExpr().(memo.RelExpr).Cost().C
 	available := mem.RootExpr().(memo.RelExpr).Relational().Statistics().Available
 	planTop.instrumentation.statsAvailable = available
 	if available {

--- a/pkg/sql/prepared_stmt.go
+++ b/pkg/sql/prepared_stmt.go
@@ -169,6 +169,11 @@ func (p *planCosts) NumCustom() int {
 
 // AvgCustom returns the average cost of all the custom plan costs in planCosts.
 // If there are no custom plan costs, it returns 0.
+//
+// TODO(mgartner): Figure out how this should incorporate cost flags. Some of
+// them, like UnboundedCardinality, are only set if session settings are set.
+// When those session settings change, do we need to clear and recompute the
+// average cost of custom plans?
 func (p *planCosts) AvgCustom() memo.Cost {
 	if p.custom.length == 0 {
 		return memo.Cost{C: 0}

--- a/pkg/sql/prepared_stmt.go
+++ b/pkg/sql/prepared_stmt.go
@@ -171,18 +171,19 @@ func (p *planCosts) NumCustom() int {
 // If there are no custom plan costs, it returns 0.
 func (p *planCosts) AvgCustom() memo.Cost {
 	if p.custom.length == 0 {
-		return 0
+		return memo.Cost{C: 0}
 	}
 	var sum memo.Cost
 	for i := 0; i < p.custom.length; i++ {
-		sum += p.custom.costs[i]
+		sum.Add(p.custom.costs[i])
 	}
-	return sum / memo.Cost(p.custom.length)
+	sum.C /= float64(p.custom.length)
+	return sum
 }
 
 // ClearGeneric clears the generic cost.
 func (p *planCosts) ClearGeneric() {
-	p.generic = 0
+	p.generic = memo.Cost{C: 0}
 }
 
 // ClearCustom clears any previously added custom costs.

--- a/pkg/sql/prepared_stmt_test.go
+++ b/pkg/sql/prepared_stmt_test.go
@@ -18,29 +18,30 @@ func TestPlanCosts(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	type testCase struct {
-		input       []memo.Cost
+		input       []float64
 		expectedNum int
-		expectedAvg memo.Cost
+		expectedAvg float64
 	}
 	testCases := []testCase{
-		{input: []memo.Cost{}, expectedNum: 0, expectedAvg: 0},
-		{input: []memo.Cost{0, 0}, expectedNum: 2, expectedAvg: 0},
-		{input: []memo.Cost{1, 1}, expectedNum: 2, expectedAvg: 1},
-		{input: []memo.Cost{1, 2, 3, 4, 5}, expectedNum: 5, expectedAvg: 3},
-		{input: []memo.Cost{1, 2, 3, 4, 5, 6}, expectedNum: 5, expectedAvg: 4},
-		{input: []memo.Cost{9, 9, 9, 9, 9, 1, 2, 3, 4, 5}, expectedNum: 5, expectedAvg: 3},
+		{input: []float64{}, expectedNum: 0, expectedAvg: 0},
+		{input: []float64{0, 0}, expectedNum: 2, expectedAvg: 0},
+		{input: []float64{1, 1}, expectedNum: 2, expectedAvg: 1},
+		{input: []float64{1, 2, 3, 4, 5}, expectedNum: 5, expectedAvg: 3},
+		{input: []float64{1, 2, 3, 4, 5, 6}, expectedNum: 5, expectedAvg: 4},
+		{input: []float64{9, 9, 9, 9, 9, 1, 2, 3, 4, 5}, expectedNum: 5, expectedAvg: 3},
 	}
 	var pc planCosts
 	for _, tc := range testCases {
 		pc.ClearCustom()
 		for _, cost := range tc.input {
-			pc.AddCustom(cost)
+			pc.AddCustom(memo.Cost{C: cost})
 		}
 		if pc.NumCustom() != tc.expectedNum {
 			t.Errorf("expected Len() to be %d, got %d", tc.expectedNum, pc.NumCustom())
 		}
-		if pc.AvgCustom() != tc.expectedAvg {
-			t.Errorf("expected Avg() to be %f, got %f", tc.expectedAvg, pc.AvgCustom())
+		expectedAvgCost := memo.Cost{C: tc.expectedAvg}
+		if pc.AvgCustom() != expectedAvgCost {
+			t.Errorf("expected Avg() to be %f, got %f", tc.expectedAvg, pc.AvgCustom().C)
 		}
 	}
 }

--- a/pkg/sql/sessiondatapb/local_only_session_data.proto
+++ b/pkg/sql/sessiondatapb/local_only_session_data.proto
@@ -536,6 +536,12 @@ message LocalOnlySessionData {
   // plans in which every expression has a bounded cardinality over plans with
   // one or more expressions with unbounded cardinality.
   bool optimizer_prefer_bounded_cardinality = 154;
+  // OptimizerMinRowCount set a lower bound on row count estimates for
+  // relational expressions during query planning. A value of zero indicates no
+  // lower bound. Note that if this is set to a value greater than zero, a row
+  // count of zero can still be estimated for expressions with a cardinality of
+  // zero, e.g., for a contradictory filter.
+  double optimizer_min_row_count = 155;
 
   ///////////////////////////////////////////////////////////////////////////
   // WARNING: consider whether a session parameter you're adding needs to  //

--- a/pkg/sql/sessiondatapb/local_only_session_data.proto
+++ b/pkg/sql/sessiondatapb/local_only_session_data.proto
@@ -532,6 +532,10 @@ message LocalOnlySessionData {
   // mix-typed comparisons with VARCHAR types. See #137837, #133037, and
   // #132268.
   bool legacy_varchar_typing = 150;
+  // OptimizerPreferBoundedCardinality instructs the optimizer to prefer query
+  // plans in which every expression has a bounded cardinality over plans with
+  // one or more expressions with unbounded cardinality.
+  bool optimizer_prefer_bounded_cardinality = 154;
 
   ///////////////////////////////////////////////////////////////////////////
   // WARNING: consider whether a session parameter you're adding needs to  //

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -3491,6 +3491,30 @@ var varGen = map[string]sessionVar{
 		},
 		GlobalDefault: globalFalse,
 	},
+
+	`optimizer_min_row_count`: {
+		GetStringVal: makeFloatGetStringValFn(`optimizer_min_row_count`),
+		Get: func(evalCtx *extendedEvalContext, _ *kv.Txn) (string, error) {
+			return formatFloatAsPostgresSetting(evalCtx.SessionData().OptimizerMinRowCount), nil
+		},
+		GlobalDefault: func(sv *settings.Values) string {
+			return "0"
+		},
+		Set: func(_ context.Context, m sessionDataMutator, s string) error {
+			f, err := strconv.ParseFloat(s, 64)
+			if err != nil {
+				return err
+			}
+			// Note that we permit fractions above 1.0 to allow for giving
+			// head-of-the-line batch more memory that is available - this will
+			// put the budget in debt.
+			if f < 0 {
+				return pgerror.New(pgcode.InvalidParameterValue, "optimizer_min_row_count must be non-negative")
+			}
+			m.SetOptimizerMinRowCount(f)
+			return nil
+		},
+	},
 }
 
 func ReplicationModeFromString(s string) (sessiondatapb.ReplicationMode, error) {

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -3474,6 +3474,23 @@ var varGen = map[string]sessionVar{
 		},
 		GlobalDefault: globalTrue,
 	},
+
+	// CockroachDB extension.
+	`optimizer_prefer_bounded_cardinality`: {
+		GetStringVal: makePostgresBoolGetStringValFn(`optimizer_prefer_bounded_cardinality`),
+		Set: func(_ context.Context, m sessionDataMutator, s string) error {
+			b, err := paramparse.ParseBoolVar("optimizer_prefer_bounded_cardinality", s)
+			if err != nil {
+				return err
+			}
+			m.SetOptimizerPreferBoundedCardinality(b)
+			return nil
+		},
+		Get: func(evalCtx *extendedEvalContext, _ *kv.Txn) (string, error) {
+			return formatBoolAsPostgresSetting(evalCtx.SessionData().OptimizerPreferBoundedCardinality), nil
+		},
+		GlobalDefault: globalFalse,
+	},
 }
 
 func ReplicationModeFromString(s string) (sessiondatapb.ReplicationMode, error) {


### PR DESCRIPTION
Backport:
  * 2/4 commits from "sql, opt: avoid full scans in mutation queries with cost flags" (#137984)
  * 1/1 commits from "opt: add `optimizer_prefer_bounded_cardinality` session setting" (#139985)
  * 1/1 commits from "opt: add `optimizer_min_row_count` session setting" (#140065)

Please see individual PRs for details.

/cc @cockroachdb/release

Release justification: Optimizer changes gated behind session settings.
