### PR TITLE
metric: add debug information to panicking goroutines in Snapshot

### DIFF
--- a/pkg/util/metric/metric_test.go
+++ b/pkg/util/metric/metric_test.go
@@ -968,3 +968,14 @@ func BenchmarkHistogramRecordValue(b *testing.B) {
 		}
 	})
 }
+
+func TestCollectHistogramBoundsCountsLengths(t *testing.T) {
+	h := prometheus.NewHistogram(prometheus.HistogramOpts{})
+	assert.Equal(t, collectHistogramBoundsCountsLengths(h), "len(upperBounds): 11, len(counts[0].buckets): 11, len(counts[1].buckets): 11")
+	// If this code has gone a year without recurring, remove this test, and the corresponding code underneath it.
+	cutoff := time.Date(2026, 2, 1, 0, 0, 0, 0, time.UTC)
+	if time.Now().After(cutoff) {
+		// Remove this test and the `collectHistogramBoundsCountsLengths` function.
+		t.Fatalf("This test has expired! It's now %v, which is after %v", time.Now(), cutoff)
+	}
+}


### PR DESCRIPTION
Issue #136186 introduced a seemingly impossible situation in which the internal properties of the prometheus histogram implementation mismatched in a way which caused a panic.

The properties specifically, where `h` is a histogram were `h.upperBounds` and `h.counts[0/1].buckets`. These properties are slices, initialized once, whose references are never modified, lengths never changed, and are never appended to. The length of the `counts` property is set by the length of the `upperBounds` property, which should guarantee that they are always the same length, however given the panic in the above ticket, `upperBounds` somehow became longer than `counts[0/1]`.

While this change cannot tell us how the lengths of each array got to a certain way, it will tell us exactly what the lengths are, which would be the next step if it were to recur. The test in this PR is built in with a time bomb so that if it goes a year without being relevant, the test will start failing, encouraging us to move on and focus on other things.

Epic: none
Fixes: #136186

Release note: None