### PR TITLE
release-24.3: crosscluster/logical: use large test pool

### DIFF
--- a/pkg/ccl/crosscluster/logical/BUILD.bazel
+++ b/pkg/ccl/crosscluster/logical/BUILD.bazel
@@ -109,6 +109,7 @@ go_test(
     ],
     data = ["//c-deps:libgeos"],
     embed = [":logical"],
+    exec_properties = {"test.Pool": "large"},
     deps = [
         "//pkg/base",
         "//pkg/ccl",


### PR DESCRIPTION
Epic: none

Release note: none

Release justification: test only change