### PR TITLE
opt/optbuilder: only re-type-check values rows for wildcard types

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/udf
+++ b/pkg/sql/logictest/testdata/logic_test/udf
@@ -956,3 +956,26 @@ FROM
 );
 
 subtest end
+
+# Regression test for #137968 - do not incorrectly modify the resolved type of
+# an expression that already found a non-wildcard type.
+subtest regression_137968
+
+statement ok
+SELECT
+	tab_18298.col_30903
+FROM
+	(
+		VALUES
+			(
+				('-26 years -422 days -21:13:57.660026':::INTERVAL::INTERVAL + now():::TIMESTAMP::TIMESTAMP::TIMESTAMP)::TIMESTAMP
+			),
+			(NULL)
+	)
+		AS tab_18298 (col_30903)
+ORDER BY
+	tab_18298.col_30903 ASC
+LIMIT
+	3:::INT8;
+
+subtest end


### PR DESCRIPTION
After #129706 we began type-checking expressions in `Values` operators again after building them. This is needed to update the resolved type if there was a RECORD-returning UDF, which cannot resolve its type until after it is built. However, this fix broke some other cases because the initial type-check can discard casts, causing the second time to result in a slightly different type (e.g. `TIMESTAMP` vs `TIMESTAMPTZ`). This commit fixes the oversight by only type-checking the second time if the previously resolved type was a wildcard type like `AnyTuple`, indicating that a concrete type could not be found on the first pass.

Fixes #137968

Release note (sql change): Fixed a bug existing only in pre-release versions of v25.1 which could cause unexpected errors during planning for `VALUES` expressions containing function calls with multiple overloads.