### PR TITLE
roachtest: refactor openmetrics utils and labels

### DIFF
--- a/build/teamcity/cockroach/nightlies/roachtest_nightly_impl.sh
+++ b/build/teamcity/cockroach/nightlies/roachtest_nightly_impl.sh
@@ -100,5 +100,6 @@ build/teamcity-roachtest-invoke.sh \
   --selective-tests="${selective_tests:-false}" \
   --side-eye-token="${SIDE_EYE_API_TOKEN}" \
   --export-openmetrics="${EXPORT_OPENMETRICS:-false}" \
+  --openmetrics-labels="branch=$(tc_build_branch), cpu-arch=${arch}, suite=nightly" \
   ${EXTRA_ROACHTEST_ARGS:+$EXTRA_ROACHTEST_ARGS} \
   "${TESTS}"

--- a/build/teamcity/cockroach/nightlies/roachtest_weekly_impl.sh
+++ b/build/teamcity/cockroach/nightlies/roachtest_weekly_impl.sh
@@ -49,4 +49,5 @@ timeout -s INT $((7800*60)) build/teamcity-roachtest-invoke.sh \
   --slack-token="${SLACK_TOKEN}" \
   --side-eye-token="${SIDE_EYE_API_TOKEN}" \
   --export-openmetrics="${EXPORT_OPENMETRICS:-false}" \
+  --openmetrics-labels="branch=$(tc_build_branch), cpu-arch=${arch}, suite=weekly" \
   ${TESTS:-}

--- a/pkg/cmd/roachtest/cluster_test.go
+++ b/pkg/cmd/roachtest/cluster_test.go
@@ -77,6 +77,10 @@ func (t testWrapper) GetRunId() string {
 	return "mock-run-id"
 }
 
+func (t testWrapper) Owner() string {
+	return "mock-owner"
+}
+
 func (t testWrapper) ExportOpenmetrics() bool {
 	return false
 }

--- a/pkg/cmd/roachtest/clusterstats/BUILD.bazel
+++ b/pkg/cmd/roachtest/clusterstats/BUILD.bazel
@@ -17,7 +17,6 @@ go_library(
         "//pkg/cmd/roachprod/grafana",  #keep
         "//pkg/cmd/roachtest/cluster",
         "//pkg/cmd/roachtest/option",
-        "//pkg/cmd/roachtest/registry",
         "//pkg/cmd/roachtest/test",
         # Required for generated mocks
         "//pkg/roachprod",  #keep
@@ -35,7 +34,7 @@ go_library(
         "@com_github_prometheus_client_golang//api",
         "@com_github_prometheus_client_golang//api/prometheus/v1:prometheus",
         "@com_github_prometheus_common//model",
-        "@org_golang_x_exp//maps",
+        "//pkg/cmd/roachtest/roachtestutil",
     ],
 )
 

--- a/pkg/cmd/roachtest/clusterstats/exporter_test.go
+++ b/pkg/cmd/roachtest/clusterstats/exporter_test.go
@@ -325,9 +325,9 @@ func TestExport(t *testing.T) {
 		mockTest.EXPECT().Name().Return("mock_name")
 		mockTest.EXPECT().GetRunId().Return("mock_id").AnyTimes()
 		mockCluster.EXPECT().Cloud().Times(1).Return(spec.GCE)
-		mockTest.EXPECT().Spec().Times(1).Return(&registry.TestSpec{
+		mockTest.EXPECT().Spec().Return(&registry.TestSpec{
 			Owner: "roachtest_mock", Suites: registry.Suites(registry.Nightly),
-		})
+		}).AnyTimes()
 		statsWriter = func(ctx context.Context, tt test.Test, c cluster.Cluster, buffer *bytes.Buffer, dest string) error {
 			require.Equal(t, mockTest, tt)
 			require.Equal(t, mockCluster, c)
@@ -425,6 +425,7 @@ func getMockTest(
 	tst.EXPECT().L().Return(l)
 	tst.EXPECT().ExportOpenmetrics().Times(1).Return(exportOpenmetrics)
 	tst.EXPECT().PerfArtifactsDir().Times(1).Return(dest)
+	tst.EXPECT().Owner().Return("roachtest_mock").AnyTimes()
 	return tst
 }
 

--- a/pkg/cmd/roachtest/clusterstats/mock_test_generated_test.go
+++ b/pkg/cmd/roachtest/clusterstats/mock_test_generated_test.go
@@ -379,6 +379,20 @@ func (mr *MockTestMockRecorder) NewGroup(arg0 ...interface{}) *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewGroup", reflect.TypeOf((*MockTest)(nil).NewGroup), arg0...)
 }
 
+// Owner mocks base method.
+func (m *MockTest) Owner() string {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Owner")
+	ret0, _ := ret[0].(string)
+	return ret0
+}
+
+// Owner indicates an expected call of Owner.
+func (mr *MockTestMockRecorder) Owner() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Owner", reflect.TypeOf((*MockTest)(nil).Owner))
+}
+
 // PerfArtifactsDir mocks base method.
 func (m *MockTest) PerfArtifactsDir() string {
 	m.ctrl.T.Helper()

--- a/pkg/cmd/roachtest/roachtestflags/flags.go
+++ b/pkg/cmd/roachtest/roachtestflags/flags.go
@@ -328,6 +328,12 @@ var (
 		Usage: `flag to denote if roachtest should export openmetrics file for performance metrics.`,
 	})
 
+	OpenmetricsLabels string = ""
+	_                        = registerRunFlag(&OpenmetricsLabels, FlagInfo{
+		Name:  "openmetrics-labels",
+		Usage: `flag to pass custom labels to pass to openmetrics for performance metrics,`,
+	})
+
 	DatadogSite string = "us5.datadoghq.com"
 	_                  = registerRunOpsFlag(&DatadogSite, FlagInfo{
 		Name:  "datadog-site",

--- a/pkg/cmd/roachtest/roachtestutil/BUILD.bazel
+++ b/pkg/cmd/roachtest/roachtestutil/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "httpclient.go",
         "jaeger.go",
         "load_group.go",
+        "metric_utils.go",
         "profile.go",
         "replication.go",
         "utils.go",
@@ -18,9 +19,10 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/cmd/roachprod-microbench/util",
         "//pkg/cmd/roachtest/cluster",
-        "//pkg/cmd/roachtest/clusterstats",
         "//pkg/cmd/roachtest/option",
+        "//pkg/cmd/roachtest/roachtestflags",
         "//pkg/cmd/roachtest/spec",
         "//pkg/cmd/roachtest/test",
         "//pkg/kv/kvpb",
@@ -40,6 +42,7 @@ go_library(
         "//pkg/workload/histogram/exporter",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_stretchr_testify//require",
+        "@org_golang_x_exp//maps",
     ],
 )
 

--- a/pkg/cmd/roachtest/roachtestutil/metric_utils.go
+++ b/pkg/cmd/roachtest/roachtestutil/metric_utils.go
@@ -1,0 +1,166 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package roachtestutil
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachprod-microbench/util"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestflags"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
+	"github.com/cockroachdb/cockroach/pkg/workload/histogram/exporter"
+	"github.com/cockroachdb/errors"
+	"golang.org/x/exp/maps"
+)
+
+// GetWorkloadHistogramArgs creates a histogram flag string based on the roachtest to pass to workload binary
+// This is used to make use of t.ExportOpenmetrics() method and create appropriate exporter
+func GetWorkloadHistogramArgs(t test.Test, c cluster.Cluster, labels map[string]string) string {
+	var histogramArgs string
+	if t.ExportOpenmetrics() {
+		// Add openmetrics related labels and arguments
+		histogramArgs = fmt.Sprintf(" --histogram-export-format='openmetrics' --histograms=%s/%s --openmetrics-labels='%s'",
+			t.PerfArtifactsDir(), GetBenchmarkMetricsFileName(t), GetOpenmetricsLabelString(t, c, labels))
+	} else {
+		// Since default is json, no need to add --histogram-export-format flag in this case and also the labels
+		histogramArgs = fmt.Sprintf(" --histograms=%s/%s", t.PerfArtifactsDir(), GetBenchmarkMetricsFileName(t))
+	}
+
+	return histogramArgs
+}
+
+// GetBenchmarkMetricsFileName returns the file name to store the benchmark output
+func GetBenchmarkMetricsFileName(t test.Test) string {
+	if t.ExportOpenmetrics() {
+		return "stats.om"
+	}
+
+	return "stats.json"
+}
+
+// CreateWorkloadHistogramExporter creates a exporter.Exporter based on the roachtest parameters with no labels
+func CreateWorkloadHistogramExporter(t test.Test, c cluster.Cluster) exporter.Exporter {
+	return CreateWorkloadHistogramExporterWithLabels(t, c, nil)
+}
+
+// CreateWorkloadHistogramExporterWithLabels creates a exporter.Exporter based on the roachtest parameters with additional labels
+func CreateWorkloadHistogramExporterWithLabels(
+	t test.Test, c cluster.Cluster, labelMap map[string]string,
+) exporter.Exporter {
+	var metricsExporter exporter.Exporter
+	if t.ExportOpenmetrics() {
+		labels := GetOpenmetricsLabelMap(t, c, labelMap)
+		openMetricsExporter := &exporter.OpenMetricsExporter{}
+		openMetricsExporter.SetLabels(&labels)
+		metricsExporter = openMetricsExporter
+
+	} else {
+		metricsExporter = &exporter.HdrJsonExporter{}
+	}
+
+	return metricsExporter
+}
+
+// UploadPerfStats creates stats file from buffer in the node
+func UploadPerfStats(
+	ctx context.Context,
+	t test.Test,
+	c cluster.Cluster,
+	perfBuf *bytes.Buffer,
+	node option.NodeListOption,
+	fileNamePrefix string,
+) error {
+
+	if perfBuf == nil {
+		return errors.New("perf buffer is nil")
+	}
+	destinationFileName := fmt.Sprintf("%s%s", fileNamePrefix, GetBenchmarkMetricsFileName(t))
+	// Upload the perf artifacts to any one of the nodes so that the test
+	// runner copies it into an appropriate directory path.
+	dest := filepath.Join(t.PerfArtifactsDir(), destinationFileName)
+	if err := c.RunE(ctx, option.WithNodes(node), "mkdir -p "+filepath.Dir(dest)); err != nil {
+		return err
+	}
+	if err := c.PutString(ctx, perfBuf.String(), dest, 0755, node); err != nil {
+		return err
+	}
+	return nil
+}
+
+// CloseExporter closes the exporter and also upload the metrics artifacts to a stats file in the node
+func CloseExporter(
+	ctx context.Context,
+	exporter exporter.Exporter,
+	t test.Test,
+	c cluster.Cluster,
+	perfBuf *bytes.Buffer,
+	node option.NodeListOption,
+	fileNamePrefix string,
+) {
+	if err := exporter.Close(func() error {
+		if err := UploadPerfStats(ctx, t, c, perfBuf, node, fileNamePrefix); err != nil {
+			return err
+		}
+		return nil
+	}); err != nil {
+		t.Errorf("failed to export perf stats: %v", err)
+	}
+}
+
+// GetOpenmetricsLabelString creates a string that follows the openmetrics labels format
+func GetOpenmetricsLabelString(t test.Test, c cluster.Cluster, labels map[string]string) string {
+	return util.LabelMapToString(GetOpenmetricsLabelMap(t, c, labels))
+}
+
+// GetOpenmetricsLabelMap creates a map of label keys and values
+// It takes roachtest parameters and create relevant labels.
+func GetOpenmetricsLabelMap(
+	t test.Test, c cluster.Cluster, labels map[string]string,
+) map[string]string {
+	defaultMap := map[string]string{
+		"test-run-id": t.GetRunId(),
+		"cloud":       c.Cloud().String(),
+		"owner":       t.Owner(),
+		"test":        t.Name(),
+	}
+
+	if roachtestflags.OpenmetricsLabels != "" {
+		roachtestLabelMap, err := GetOpenmetricsLabelsFromString(roachtestflags.OpenmetricsLabels)
+		if err == nil {
+			maps.Copy(defaultMap, roachtestLabelMap)
+		}
+	}
+
+	// If the tests have passed some custom labels, copy them to the map created above
+	if labels != nil {
+		maps.Copy(defaultMap, labels)
+	}
+	return defaultMap
+}
+
+func GetOpenmetricsGaugeType(metricName string) string {
+	return fmt.Sprintf("# TYPE %s gauge\n", util.SanitizeMetricName(metricName))
+}
+
+func GetOpenmetricsLabelsFromString(labelString string) (map[string]string, error) {
+	labelValues := strings.Split(labelString, ",")
+	labels := make(map[string]string)
+	for _, label := range labelValues {
+		parts := strings.SplitN(label, "=", 2)
+		if len(parts) != 2 {
+			return nil, errors.Errorf("invalid histogram label %q", label)
+		}
+		labels[strings.TrimSpace(parts[0])] = strings.TrimSpace(parts[1])
+	}
+
+	return labels, nil
+}

--- a/pkg/cmd/roachtest/test/test_interface.go
+++ b/pkg/cmd/roachtest/test/test_interface.go
@@ -99,4 +99,7 @@ type Test interface {
 	// GetRunId returns the run id of the roachtest run, this is set to build id
 	// when ran from teamcity
 	GetRunId() string
+
+	// Owner returns the owner of the test
+	Owner() string
 }

--- a/pkg/cmd/roachtest/tests/sysbench.go
+++ b/pkg/cmd/roachtest/tests/sysbench.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachprod-microbench/util"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
-	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/clusterstats"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil"
@@ -380,7 +379,7 @@ func exportSysbenchResults(
 		"rows-per-table": fmt.Sprintf("%d", opts.rowsPerTable),
 		"use-postgres":   fmt.Sprintf("%t", opts.usePostgres),
 	}
-	labelString := clusterstats.GetOpenmetricsLabelString(t, c, labels)
+	labelString := roachtestutil.GetOpenmetricsLabelString(t, c, labels)
 	openmetricsMap := make(map[string][]openmetricsValues)
 	tick := func(fields []string, qpsByType []string) error {
 		snapshotTick := sysbenchMetrics{
@@ -478,7 +477,7 @@ func getOpenmetricsBytes(openmetricsMap map[string][]openmetricsValues, labelStr
 	metricsBuf := bytes.NewBuffer([]byte{})
 	for key, values := range openmetricsMap {
 		metricName := util.SanitizeMetricName(key)
-		metricsBuf.WriteString(clusterstats.GetOpenmetricsGaugeType(metricName))
+		metricsBuf.WriteString(roachtestutil.GetOpenmetricsGaugeType(metricName))
 		for _, value := range values {
 			metricsBuf.WriteString(fmt.Sprintf("%s{%s} %s %d\n", metricName, labelString, value.Value, value.Time))
 		}

--- a/pkg/cmd/roachtest/tests/tpcc.go
+++ b/pkg/cmd/roachtest/tests/tpcc.go
@@ -20,7 +20,6 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
-	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/clusterstats"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil"
@@ -305,7 +304,7 @@ func runTPCC(
 				Flag("warehouses", opts.Warehouses).
 				MaybeFlag(!opts.DisableHistogram, "histograms", histogramsPath).
 				MaybeFlag(!opts.DisableHistogram && t.ExportOpenmetrics(), "histogram-export-format", "openmetrics").
-				MaybeFlag(!opts.DisableHistogram && t.ExportOpenmetrics(), "openmetrics-labels", clusterstats.GetOpenmetricsLabelString(t, c, labelsMap)).
+				MaybeFlag(!opts.DisableHistogram && t.ExportOpenmetrics(), "openmetrics-labels", roachtestutil.GetOpenmetricsLabelString(t, c, labelsMap)).
 				Flag("ramp", rampDur).
 				Flag("duration", opts.Duration).
 				Flag("prometheus-port", workloadInstances[i].prometheusPort).
@@ -510,7 +509,7 @@ func runTPCCMixedHeadroom(ctx context.Context, t test.Test, c cluster.Cluster) {
 			Flag("warehouses", headroomWarehouses).
 			Flag("histograms", histogramsPath).
 			MaybeFlag(t.ExportOpenmetrics(), "histogram-export-format", "openmetrics").
-			MaybeFlag(t.ExportOpenmetrics(), "openmetrics-labels", clusterstats.GetOpenmetricsLabelString(t, c, labelsMap)).
+			MaybeFlag(t.ExportOpenmetrics(), "openmetrics-labels", roachtestutil.GetOpenmetricsLabelString(t, c, labelsMap)).
 			Flag("ramp", rampDur).
 			Flag("prometheus-port", 2112).
 			Flag("pprofport", workloadPProfStartPort).

--- a/pkg/cmd/roachtest/tests/tpce.go
+++ b/pkg/cmd/roachtest/tests/tpce.go
@@ -16,7 +16,6 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
-	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/clusterstats"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil"
@@ -368,7 +367,7 @@ func exportTPCEResults(t test.Test, c cluster.Cluster, result string) error {
 			labels := map[string]string{
 				"workload": "tpce",
 			}
-			labelString := clusterstats.GetOpenmetricsLabelString(t, c, labels)
+			labelString := roachtestutil.GetOpenmetricsLabelString(t, c, labels)
 			metricBytes = getOpenMetrics(metrics, fields[5], labelString)
 		} else {
 			metricBytes, err = json.Marshal(metrics)

--- a/pkg/workload/cli/run.go
+++ b/pkg/workload/cli/run.go
@@ -681,13 +681,12 @@ func maybeInitAndCreateExporter(gen workload.Generator) (exporter.Exporter, *os.
 		labelValues := strings.Split(*openmetricsLabels, ",")
 		labels := make(map[string]string)
 		for _, label := range labelValues {
-			parts := strings.Split(label, "=")
+			parts := strings.SplitN(label, "=", 2)
 			if len(parts) != 2 {
 				return nil, nil, errors.Errorf("invalid histogram label %q", label)
 			}
 			labels[strings.TrimSpace(parts[0])] = strings.TrimSpace(parts[1])
 		}
-
 		// Append workload generator name as a tag
 		labels["workload"] = gen.Meta().Name
 		openMetricsExporter := exporter.OpenMetricsExporter{}

--- a/pkg/workload/histogram/exporter/openmetrics_exporter.go
+++ b/pkg/workload/histogram/exporter/openmetrics_exporter.go
@@ -155,7 +155,7 @@ func (o *OpenMetricsExporter) SetLabels(labels *map[string]string) {
 		labelName := util.SanitizeKey(label)
 
 		// In case the label value already has surrounding quotes, we should trim them
-		labelValue := util.SanitizeValue(strings.Trim(value, "\""))
+		labelValue := util.SanitizeValue(strings.Trim(value, `"`))
 		labelPair := &prom.LabelPair{
 			Name:  &labelName,
 			Value: &labelValue,


### PR DESCRIPTION
1. Create new `metrics_utils.go` and refactor all openmetrics related utils into this file
2. Add `Owner()` function in test interface
3. Remove `subtest` labels since they are making the dashboard labels confusing
4. Add new flag `openmetrics-labels` in roachtest which currently adds `branch, arch, suite` labels

Epic: https://cockroachlabs.atlassian.net/browse/CRDB-41852

Release note: None