### PR TITLE
changefeedccl: restore fine grained checkpoint from job proto

### DIFF
--- a/pkg/ccl/changefeedccl/alter_changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/alter_changefeed_stmt.go
@@ -805,6 +805,8 @@ func generateNewProgress(
 					//lint:ignore SA1019 deprecated usage
 					Checkpoint: &jobspb.ChangefeedProgress_Checkpoint{
 						Spans: existingTargetSpans,
+						// TODO(#140509): ALTER CHANGEFED should handle fine grained
+						// progress and checkpointed timestamp properly.
 					},
 					ProtectedTimestampRecord: ptsRecord,
 				},

--- a/pkg/ccl/changefeedccl/changefeed_processors_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors_test.go
@@ -23,6 +23,7 @@ func TestSetupSpansAndFrontier(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
+	statementTime := hlc.Timestamp{WallTime: 10}
 	for _, tc := range []struct {
 		name             string
 		expectedFrontier hlc.Timestamp
@@ -125,6 +126,7 @@ func TestSetupSpansAndFrontier(t *testing.T) {
 					Watches: tc.watches,
 				},
 			}
+			ca.spec.Feed.StatementTime = statementTime
 			_, err := ca.setupSpansAndFrontier()
 			require.NoError(t, err)
 			require.Equal(t, tc.expectedFrontier, ca.frontier.Frontier())

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -1475,6 +1475,7 @@ func reloadDest(ctx context.Context, id jobspb.JobID, execCfg *sql.ExecutorConfi
 
 // reconcileJobStateWithLocalState ensures that the job progress information
 // is consistent with the state present in the local state.
+// TODO(#137692): SetCheckpoint should take in old and new checkpoints proto.
 func reconcileJobStateWithLocalState(
 	ctx context.Context, jobID jobspb.JobID, localState *cachedState, execCfg *sql.ExecutorConfig,
 ) error {

--- a/pkg/ccl/changefeedccl/kvfeed/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/kvfeed/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/ccl/changefeedccl/changefeedbase",
+        "//pkg/ccl/changefeedccl/checkpoint",
         "//pkg/ccl/changefeedccl/kvevent",
         "//pkg/ccl/changefeedccl/schemafeed",
         "//pkg/ccl/changefeedccl/timers",
@@ -74,6 +75,7 @@ go_test(
         "//pkg/sql/catalog/desctestutils",
         "//pkg/sql/rowenc/keyside",
         "//pkg/sql/sem/tree",
+        "//pkg/testutils",
         "//pkg/testutils/serverutils",
         "//pkg/testutils/sqlutils",
         "//pkg/testutils/testcluster",

--- a/pkg/ccl/changefeedccl/kvfeed/kv_feed_test.go
+++ b/pkg/ccl/changefeedccl/kvfeed/kv_feed_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc/keyside"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -107,6 +108,7 @@ func TestKVFeed(t *testing.T) {
 		endTime              hlc.Timestamp
 		spans                []roachpb.Span
 		checkpoint           []roachpb.Span
+		spanLevelCheckpoint  *jobspb.TimestampSpansMap
 		events               []kvpb.RangeFeedEvent
 
 		descs []catalog.TableDescriptor
@@ -145,7 +147,7 @@ func TestKVFeed(t *testing.T) {
 		ref := rawEventFeed(tc.events)
 		tf := newRawTableFeed(tc.descs, tc.initialHighWater)
 		st := timers.New(time.Minute).GetOrCreateScopedTimers("")
-		f := newKVFeed(buf, tc.spans, tc.checkpoint, hlc.Timestamp{},
+		f := newKVFeed(buf, tc.spans, tc.checkpoint, hlc.Timestamp{}, nil,
 			tc.schemaChangeEvents, tc.schemaChangePolicy,
 			tc.needsInitialScan, tc.withDiff, true /* withFiltering */, tc.withFrontierQuantize,
 			0, /* consumerID */
@@ -162,7 +164,7 @@ func TestKVFeed(t *testing.T) {
 
 		// Assert that each scanConfig pushed to the channel `scans` by `f.run()`
 		// is what we expected (as specified in the test case).
-		spansToScan := filterCheckpointSpans(tc.spans, tc.checkpoint)
+		spansToScan := filterCheckpointSpansFromCheckpoint(tc.spans, tc.checkpoint, tc.spanLevelCheckpoint)
 		testG := ctxgroup.WithContext(ctx)
 		testG.GoCtx(func(ctx context.Context) error {
 			for expScans := tc.expScans; len(expScans) > 0; expScans = expScans[1:] {
@@ -250,6 +252,9 @@ func TestKVFeed(t *testing.T) {
 			checkpoint: []roachpb.Span{
 				tableSpan(codec, 42),
 			},
+			spanLevelCheckpoint: jobspb.NewTimestampSpansMap(map[hlc.Timestamp]roachpb.Spans{
+				ts(2).Next(): {tableSpan(codec, 42)},
+			}),
 			events: []kvpb.RangeFeedEvent{
 				kvEvent(codec, 42, "a", "b", ts(3)),
 			},
@@ -268,6 +273,9 @@ func TestKVFeed(t *testing.T) {
 			checkpoint: []roachpb.Span{
 				makeSpan(codec, 42, "a", "q"),
 			},
+			spanLevelCheckpoint: jobspb.NewTimestampSpansMap(map[hlc.Timestamp]roachpb.Spans{
+				ts(2).Next(): {makeSpan(codec, 42, "a", "q")},
+			}),
 			events: []kvpb.RangeFeedEvent{
 				kvEvent(codec, 42, "a", "val", ts(3)),
 				kvEvent(codec, 42, "d", "val", ts(3)),
@@ -402,7 +410,10 @@ func TestKVFeed(t *testing.T) {
 			expEventsCount: 4,
 		},
 	} {
-		t.Run(tc.name, func(t *testing.T) {
+		testutils.RunTrueAndFalse(t, tc.name, func(t *testing.T, useNewCheckpoint bool) {
+			if !useNewCheckpoint {
+				tc.spanLevelCheckpoint = nil
+			}
 			runTest(t, tc)
 		})
 	}

--- a/pkg/jobs/jobspb/jobs.proto
+++ b/pkg/jobs/jobspb/jobs.proto
@@ -1252,7 +1252,6 @@ message ChangefeedProgress {
   // than the overall resolved timestamp and thus allow us to do less work.
   // This is especially useful during backfills or if some spans are lagging.
   // TODO(#137692): Write to this field.
-  // TODO(#137693): Restore this field to change aggregators.
   // TODO(#131549): Restore this field to the change frontier.
   TimestampSpansMap span_level_checkpoint = 5;
 }

--- a/pkg/sql/execinfrapb/processors_changefeeds.proto
+++ b/pkg/sql/execinfrapb/processors_changefeeds.proto
@@ -62,6 +62,11 @@ message ChangeAggregatorSpec {
   // been seen for this changefeed job. It is safe to initialize frontier spans
   // at this timestamp upon resuming.
   optional util.hlc.Timestamp initial_high_water = 8;
+
+  // SpanLevelCheckpoint is a map from timestamps to lists of spans. These spans
+  // have been resolved to the given timestamp, so it is safe to forward these
+  // spans to its corresponding timestamps upon resuming.
+  optional cockroach.sql.jobs.jobspb.TimestampSpansMap span_level_checkpoint = 9;
 }
 
 // ChangeFrontierSpec is the specification for a processor that receives


### PR DESCRIPTION
As part of the fine-grained checkpointing project, changefeed now saves resolved
spans for each span above the high-water mark. This patch finalizes the
restoration process for fine-grained checkpoints. Upon resuming, changefeed
reloads span level checkpoints from the job proto and restores progress during
startup.
Restoration is required in three key areas:
1. When aggregators are initialized, including the initialization of each
aggregator frontier.
2. When `rangeFeedResumeFrontier` is initialized during every kvfeed.run.
3. When kvfeed determines which checkpointed spans to filter out from those
requiring backfill.

Note: This remains unused for now until issue https://github.com/cockroachdb/cockroach/issues/137692 is resolved.
NB: `reconcileJobStateWithLocalState` is intentionally left unchanged. We
decided to update it as part of issue https://github.com/cockroachdb/cockroach/issues/137692, as it depends on
`cachedState.SetCheckpoint`.

Resolves: https://github.com/cockroachdb/cockroach/issues/137693
Release Note: None