### PR TITLE
sqlsmith: randomly change the transaction isolation level

### DIFF
--- a/pkg/internal/sqlsmith/relational.go
+++ b/pkg/internal/sqlsmith/relational.go
@@ -109,6 +109,7 @@ var (
 		{1, makeExport},
 		{1, makeImport},
 		{1, makeCreateStats},
+		{1, makeSetSessionCharacteristics},
 	}
 	nonMutatingStatements = []statementWeight{
 		{10, makeSelect},
@@ -1470,8 +1471,22 @@ func makeInsert(s *Smither) (tree.Statement, bool) {
 	return stmt, ok
 }
 
+func makeTransactionModes(s *Smither) (tree.TransactionModes, bool) {
+	levels := []tree.IsolationLevel{
+		tree.UnspecifiedIsolation,
+		tree.ReadUncommittedIsolation,
+		tree.ReadCommittedIsolation,
+		tree.RepeatableReadIsolation,
+		tree.SnapshotIsolation,
+		tree.SerializableIsolation,
+	}
+	modes := tree.TransactionModes{Isolation: levels[s.rnd.Intn(len(levels))]}
+	return modes, true
+}
+
 func makeBegin(s *Smither) (tree.Statement, bool) {
-	return &tree.BeginTransaction{}, true
+	modes, _ := makeTransactionModes(s)
+	return &tree.BeginTransaction{Modes: modes}, true
 }
 
 const letters = "abcdefghijklmnopqrstuvwxyz"
@@ -1510,6 +1525,11 @@ func makeCommit(s *Smither) (tree.Statement, bool) {
 
 func makeRollback(s *Smither) (tree.Statement, bool) {
 	return &tree.RollbackTransaction{}, true
+}
+
+func makeSetSessionCharacteristics(s *Smither) (tree.Statement, bool) {
+	modes, _ := makeTransactionModes(s)
+	return &tree.SetSessionCharacteristics{Modes: modes}, true
 }
 
 // makeInsert has only one valid reference: its table source, which can be

--- a/pkg/internal/sqlsmith/sqlsmith.go
+++ b/pkg/internal/sqlsmith/sqlsmith.go
@@ -361,6 +361,7 @@ var DisableDDLs = simpleOption("disable DDLs", func(s *Smither) {
 		{5, makeUpdate},
 		{1, makeDelete},
 		{1, makeCreateStats},
+		{1, makeSetSessionCharacteristics},
 		// If we don't have any DDL's, allow for use of savepoints and transactions.
 		{2, makeBegin},
 		{2, makeSavepoint},
@@ -373,7 +374,8 @@ var DisableDDLs = simpleOption("disable DDLs", func(s *Smither) {
 })
 
 // OnlySingleDMLs causes the Smither to only emit single-statement DML (SELECT,
-// INSERT, UPDATE, DELETE) and CREATE STATISTICS statements.
+// INSERT, UPDATE, DELETE), CREATE STATISTICS, and SET SESSION CHARACTERISTICS
+// statements.
 var OnlySingleDMLs = simpleOption("only single DMLs", func(s *Smither) {
 	s.stmtWeights = []statementWeight{
 		{20, makeSelect},
@@ -381,6 +383,7 @@ var OnlySingleDMLs = simpleOption("only single DMLs", func(s *Smither) {
 		{5, makeUpdate},
 		{1, makeDelete},
 		{1, makeCreateStats},
+		{1, makeSetSessionCharacteristics},
 	}
 })
 
@@ -443,24 +446,26 @@ var SimpleNames = simpleOption("simple names", func(s *Smither) {
 	s.simpleNames = true
 })
 
-// MutationsOnly causes the Smither to emit 70% INSERT, 10% UPDATE, 10% DELETE,
-// and 10% CREATE STATISTICS statements.
+// MutationsOnly causes the Smither to emit 60% INSERT, 10% UPDATE, 10% DELETE,
+// 10% CREATE STATISTICS, and 10% SET SESSION CHARACTERISTICS statements.
 var MutationsOnly = simpleOption("mutations only", func(s *Smither) {
 	s.stmtWeights = []statementWeight{
-		{7, makeInsert},
+		{6, makeInsert},
 		{1, makeUpdate},
 		{1, makeDelete},
 		{1, makeCreateStats},
+		{1, makeSetSessionCharacteristics},
 	}
 })
 
-// InsUpdOnly causes the Smither to emit 80% INSERT, 10% UPDATE, and 10% CREATE
-// STATISTICS statements.
+// InsUpdOnly causes the Smither to emit 70% INSERT, 10% UPDATE, 10% CREATE
+// STATISTICS, and 10% SET SESSION CHARACTERISTICS statements.
 var InsUpdOnly = simpleOption("inserts and updates only", func(s *Smither) {
 	s.stmtWeights = []statementWeight{
-		{8, makeInsert},
+		{7, makeInsert},
 		{1, makeUpdate},
 		{1, makeCreateStats},
+		{1, makeSetSessionCharacteristics},
 	}
 })
 


### PR DESCRIPTION
Periodically change the transaction isolation level of the current session using `SET SESSION CHARACTERISTICS`, or set the isolation level in an explicit transaction as part of `BEGIN`.

Fixes #137414

Release note: None