### PR TITLE
sql: avoid sql.exec.latency.detail observation if setting is disabled

### DIFF
--- a/pkg/sql/executor_statement_metrics.go
+++ b/pkg/sql/executor_statement_metrics.go
@@ -306,12 +306,6 @@ func (ex *connExecutor) recordStatementLatencyMetrics(
 
 		m.StatementFingerprintCount.Add([]byte(stmt.StmtNoConstants))
 
-		labels := map[string]string{}
-		if detailedLatencyMetrics.Get(&ex.server.cfg.Settings.SV) {
-			labels = map[string]string{
-				detailedLatencyMetricLabel: stmt.StmtNoConstants,
-			}
-		}
 		if flags.IsDistributed() {
 			if _, ok := stmt.AST.(*tree.Select); ok {
 				m.DistSQLSelectCount.Inc(1)
@@ -325,7 +319,12 @@ func (ex *connExecutor) recordStatementLatencyMetrics(
 			}
 		}
 		if shouldIncludeInLatencyMetrics {
-			m.SQLExecLatencyDetail.Observe(labels, float64(runLatRaw.Nanoseconds()))
+			if detailedLatencyMetrics.Get(&ex.server.cfg.Settings.SV) {
+				labels := map[string]string{
+					detailedLatencyMetricLabel: stmt.StmtNoConstants,
+				}
+				m.SQLExecLatencyDetail.Observe(labels, float64(runLatRaw.Nanoseconds()))
+			}
 			m.SQLExecLatency.RecordValue(runLatRaw.Nanoseconds())
 			m.SQLServiceLatency.RecordValue(svcLatRaw.Nanoseconds())
 		}

--- a/pkg/sql/executor_statement_metrics_test.go
+++ b/pkg/sql/executor_statement_metrics_test.go
@@ -60,11 +60,7 @@ func Test_connExecutor_recordStatementLatencyMetrics(t *testing.T) {
 				flags:               0,
 				automaticRetryCount: 0,
 			},
-			exp: []expected{
-				{
-					duration: 2 * testDuration,
-				},
-			},
+			exp: []expected{},
 		},
 		{
 			name: "With detail",
@@ -115,7 +111,6 @@ func Test_connExecutor_recordStatementLatencyMetrics(t *testing.T) {
 			tt.ex.recordStatementLatencyMetrics(query1, tt.args.flags, tt.args.automaticRetryCount, testDuration, testDuration)
 			tt.ex.recordStatementLatencyMetrics(query2, tt.args.flags, tt.args.automaticRetryCount, testDuration, testDuration)
 			m := tt.ex.metrics.EngineMetrics
-
 			expectedFingerprints := int64(2)
 			if tt.args.automaticRetryCount > 0 {
 				expectedFingerprints = int64(0)


### PR DESCRIPTION
Previously, `sql.exec.latency.detail` metrics were always updated, even when the `sql.stats.detailed_latency_metrics.enabled` cluster setting was disabled. In this case, no labels would be provided to this metric, resulting in a single histogram for all exec latencies. In this situation, `sql.exec.latency.detail` would be equivalent to `sql.exec.latency`.

Instead of having two metrics it reporting the same values, we will now avoid recording to `sql.exec.latency.detail` if the `sql.stats.detailed_latency_metrics.enabled` setting is disabled.

Epic: None
Release note: None