### PR TITLE
opt: plan generic index joins

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/delete
+++ b/pkg/sql/opt/exec/execbuilder/testdata/delete
@@ -495,7 +495,7 @@ quality of service: regular
 │ from: t137352
 │ auto commit
 │
-└── • lookup join
+└── • index join
     │ sql nodes: <hidden>
     │ kv nodes: <hidden>
     │ regions: <hidden>
@@ -506,10 +506,8 @@ quality of service: regular
     │ KV bytes read: 0 B
     │ KV gRPC calls: 0
     │ estimated max memory allocated: 0 B
+    │ estimated max sql temp disk usage: 0 B
     │ table: t137352@t137352_pkey
-    │ equality: ($1) = (k)
-    │ equality cols are key
-    │ locking strength: for update
     │
     └── • values
           sql nodes: <hidden>

--- a/pkg/sql/opt/exec/execbuilder/testdata/update
+++ b/pkg/sql/opt/exec/execbuilder/testdata/update
@@ -1019,7 +1019,7 @@ quality of service: regular
 │
 └── • render
     │
-    └── • lookup join
+    └── • index join
         │ sql nodes: <hidden>
         │ kv nodes: <hidden>
         │ regions: <hidden>
@@ -1030,10 +1030,8 @@ quality of service: regular
         │ KV bytes read: 0 B
         │ KV gRPC calls: 0
         │ estimated max memory allocated: 0 B
+        │ estimated max sql temp disk usage: 0 B
         │ table: t137352@t137352_pkey
-        │ equality: ($1) = (k)
-        │ equality cols are key
-        │ locking strength: for update
         │
         └── • values
               sql nodes: <hidden>
@@ -1239,7 +1237,7 @@ quality of service: regular
                 │ equality: (k) = (a)
                 │ pred: a = 1
                 │
-                └── • lookup join
+                └── • index join
                     │ sql nodes: <hidden>
                     │ kv nodes: <hidden>
                     │ regions: <hidden>
@@ -1250,10 +1248,9 @@ quality of service: regular
                     │ KV bytes read: 0 B
                     │ KV gRPC calls: 0
                     │ estimated max memory allocated: 0 B
+                    │ estimated max sql temp disk usage: 0 B
                     │ estimated row count: 1
                     │ table: t137352@t137352_pkey
-                    │ equality: ($1) = (k)
-                    │ equality cols are key
                     │
                     └── • values
                           sql nodes: <hidden>

--- a/pkg/sql/opt/norm/factory_test.go
+++ b/pkg/sql/opt/norm/factory_test.go
@@ -87,8 +87,8 @@ func TestCopyAndReplace(t *testing.T) {
 
 	if e, err := o.Optimize(); err != nil {
 		t.Fatal(err)
-	} else if e.Op() != opt.ProjectOp || e.Child(0).Op() != opt.LookupJoinOp {
-		t.Errorf("expected optimizer to choose a (project (lookup-join)), not (%v (%v))",
+	} else if e.Op() != opt.IndexJoinOp || e.Child(0).Op() != opt.ValuesOp {
+		t.Errorf("expected optimizer to choose a (index-join (values)), not (%v (%v))",
 			e.Op(), e.Child(0).Op())
 	}
 

--- a/pkg/sql/opt/xform/generic_funcs.go
+++ b/pkg/sql/opt/xform/generic_funcs.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/props/physical"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -33,6 +34,95 @@ func (c *CustomFuncs) HasPlaceholdersOrStableExprs(e memo.RelExpr) bool {
 // with unknown placeholder values. See the GenerateParameterizedJoin
 // exploration rule description for more details.
 func (c *CustomFuncs) GenerateParameterizedJoin(
+	grp memo.RelExpr, required *physical.Required, scan *memo.ScanExpr, filters memo.FiltersExpr,
+) {
+	if ok := c.generateParameterizedIndexJoin(grp, &scan.ScanPrivate, filters); ok {
+		return
+	}
+	c.generateParameterizedInnerJoin(grp, required, scan, filters)
+}
+
+// generateParameterizedIndexJoin tries to generate a parameterized index join.
+// The given filters must constrain all PK columns to placeholder values and
+// must not constrain any other columns. If successful, it adds the index join
+// to grp and returns ok=true.
+//
+// TODO(mgartner): Expand this special case to allow filters that constrain PK
+// columns to stable expressions and filters that constrain more than just the
+// PK columns.
+func (c *CustomFuncs) generateParameterizedIndexJoin(
+	grp memo.RelExpr, sp *memo.ScanPrivate, filters memo.FiltersExpr,
+) (ok bool) {
+	var pkCols opt.ColSet
+	tab := c.e.mem.Metadata().Table(sp.Table)
+	pkIndex := tab.Index(cat.PrimaryIndex)
+	for i, n := 0, pkIndex.KeyColumnCount(); i < n; i++ {
+		col := sp.Table.IndexColumnID(pkIndex, i)
+		pkCols.Add(col)
+	}
+
+	// Every filter must constrain a PK column to a placeholder.
+	var exprs memo.ScalarListExpr
+	var cols opt.ColList
+	var eqCols opt.ColSet
+	for i := range filters {
+		eq, ok := filters[i].Condition.(*memo.EqExpr)
+		if !ok {
+			return false
+		}
+		v, ok := eq.Left.(*memo.VariableExpr)
+		if !ok {
+			return false
+		}
+		if !pkCols.Contains(v.Col) {
+			return false
+		}
+		p, ok := eq.Right.(*memo.PlaceholderExpr)
+		if !ok {
+			return false
+		}
+		if !v.Typ.Identical(p.Typ) {
+			return false
+		}
+		eqCols.Add(v.Col)
+		cols = append(cols, v.Col)
+		exprs = append(exprs, eq.Right)
+	}
+
+	// Every PK column must be constrained.
+	if !eqCols.Equals(pkCols) {
+		return false
+	}
+
+	// Create the Values expression with one row and one column for each PK
+	// column.
+	typs := make([]*types.T, len(exprs))
+	for i, e := range exprs {
+		typs[i] = e.DataType()
+	}
+	tupleTyp := types.MakeTuple(typs)
+	rows := memo.ScalarListExpr{c.e.f.ConstructTuple(exprs, tupleTyp)}
+	values := c.e.f.ConstructValues(rows, &memo.ValuesPrivate{
+		Cols: cols,
+		ID:   c.e.f.Metadata().NextUniqueID(),
+	})
+
+	var indexJoin memo.IndexJoinExpr
+	indexJoin.Input = values
+	indexJoin.IndexJoinPrivate = memo.IndexJoinPrivate{
+		Table:   sp.Table,
+		Cols:    sp.Cols,
+		Locking: sp.Locking,
+	}
+	c.e.mem.AddIndexJoinToGroup(&indexJoin, grp)
+	return true
+}
+
+// generateParameterizedInnerJoin generates an inner join between scan and a
+// Values expression. This join may be further transformed into a lookup join;
+// see the GenerateParameterizedJoin rule for more details. This function only
+// succeeds if the given filters have placeholders or stable expressions.
+func (c *CustomFuncs) generateParameterizedInnerJoin(
 	grp memo.RelExpr, required *physical.Required, scan *memo.ScanExpr, filters memo.FiltersExpr,
 ) {
 	var exprs memo.ScalarListExpr

--- a/pkg/sql/opt/xform/rules/generic.opt
+++ b/pkg/sql/opt/xform/rules/generic.opt
@@ -32,27 +32,7 @@
     $scan:(Scan $scanPrivate:*) &
         (GenericRulesEnabled) &
         (IsCanonicalScan $scanPrivate)
-    $filters:* &
-        (HasPlaceholdersOrStableExprs (Root)) &
-        (Let
-            (
-                $values
-                $newFilters
-                $ok
-            ):(GenerateParameterizedJoinValuesAndFilters
-                $filters
-            )
-            $ok
-        )
+    $filters:* & (HasPlaceholdersOrStableExprs (Root))
 )
 =>
-(Project
-    (InnerJoin
-        $values
-        $scan
-        $newFilters
-        (ParameterizedJoinPrivate)
-    )
-    []
-    (OutputCols (Root))
-)
+(GenerateParameterizedJoin $scan $filters)

--- a/pkg/sql/opt/xform/rules/generic.opt
+++ b/pkg/sql/opt/xform/rules/generic.opt
@@ -2,27 +2,44 @@
 # generic.opt contains exploration rules for optimizing generic query plans.
 # =============================================================================
 
-# GenerateParameterizedJoin is an exploration rule that converts a Select
-# expression with placeholders and stable expression in the filters into an
-# InnerJoin that joins the Select's input with a Values expression that produces
-# the placeholder values and stable expressions.
+# GenerateParameterizedJoin converts a Select expression with placeholders and
+# stable filter expressions into a join. This rule allows generic query plans,
+# in which placeholder values are not known and stable expressions are not
+# folded, to be optimized.
 #
-# This rule allows generic query plans, in which placeholder values are not
-# known and stable expressions are not folded, to be optimized. By converting
-# the Select into an InnerJoin, the optimizer can, in many cases, plan a lookup
-# join which has similar performance characteristics to the constrained Scan
-# that would be planned if the placeholder values were known.
+# This rule can result in either an IndexJoin or a LookupJoin. It only generates
+# an IndexJoin if the Select filters hold all PK columns equal to a placeholder
+# value, and there are no other filters. An IndexJoin is preferred over a
+# LookupJoin because the former is more efficient. IndexJoins are optimized for
+# a narrow set of capabilities and there is a vectorized implementation for
+# them.
 #
-# For example, consider a schema and query like:
+# As an example, consider a schema and query like:
 #
-#   CREATE TABLE t (i INT PRIMARY KEY)
-#   SELECT * FROM t WHERE i = $1
+#   CREATE TABLE t (k INT PRIMARY KEY, i INT)
+#   SELECT * FROM t WHERE k = $1
+#
+# GenerateParameterizedJoin will perform the transformation below, from a
+# Select into a IndexJoin.
+#
+#   Select (i=$1)         IndexJoin (t)
+# 	    |           ->          |
+# 	    |                       |
+# 	  Scan t                 Values ($1)
+#
+#
+# As another example, consider a schema and query like:
+#
+#   CREATE TABLE t (k INT PRIMARY KEY, i INT, INDEX i_idx (i))
+#   SELECT k FROM t WHERE i = $1
 #
 # GenerateParameterizedJoin will perform the first transformation below, from a
 # Select into a Join. GenerateLookupJoins will perform the second transformation
-# from a (hash) Join into a LookupJoin.
+# from a (hash) Join into a LookupJoin. The LookupJoin will have similar
+# performance characteristics to the constrained Scan that would be planned if
+# the placeholder values were known.
 #
-#   Select (i=$1)              Join (i=col_$1)         LookupJoin (t@t_pkey)
+#   Select (i=$1)              Join (i=col_$1)         LookupJoin (t@i_idx)
 # 	    |           ->            /   \           ->          |
 # 	    |                        /     \                      |
 # 	  Scan t             Values ($1)   Scan t              Values ($1)

--- a/pkg/sql/opt/xform/testdata/external/hibernate
+++ b/pkg/sql/opt/xform/testdata/external/hibernate
@@ -991,29 +991,19 @@ project
            ├── has-placeholder
            ├── key: ()
            ├── fd: ()-->(1-6,9,12), (1)==(12), (12)==(1)
-           ├── project
+           ├── index-join phone
            │    ├── columns: phones1_.id:9!null person_id:12
            │    ├── cardinality: [0 - 1]
            │    ├── has-placeholder
            │    ├── key: ()
            │    ├── fd: ()-->(9,12)
-           │    └── inner-join (lookup phone [as=phones1_])
-           │         ├── columns: phones1_.id:9!null person_id:12 "$1":17!null
-           │         ├── flags: disallow merge join
-           │         ├── key columns: [17] = [9]
-           │         ├── lookup columns are key
-           │         ├── cardinality: [0 - 1]
+           │    └── values
+           │         ├── columns: phones1_.id:9
+           │         ├── cardinality: [1 - 1]
            │         ├── has-placeholder
            │         ├── key: ()
-           │         ├── fd: ()-->(9,12,17), (9)==(17), (17)==(9)
-           │         ├── values
-           │         │    ├── columns: "$1":17
-           │         │    ├── cardinality: [1 - 1]
-           │         │    ├── has-placeholder
-           │         │    ├── key: ()
-           │         │    ├── fd: ()-->(17)
-           │         │    └── ($1,)
-           │         └── filters (true)
+           │         ├── fd: ()-->(9)
+           │         └── ($1,)
            └── filters (true)
 
 opt
@@ -1056,29 +1046,19 @@ project
            ├── has-placeholder
            ├── key: ()
            ├── fd: ()-->(1-6,9,12), (1)==(12), (12)==(1)
-           ├── project
+           ├── index-join phone
            │    ├── columns: phones1_.id:9!null person_id:12
            │    ├── cardinality: [0 - 1]
            │    ├── has-placeholder
            │    ├── key: ()
            │    ├── fd: ()-->(9,12)
-           │    └── inner-join (lookup phone [as=phones1_])
-           │         ├── columns: phones1_.id:9!null person_id:12 "$1":17!null
-           │         ├── flags: disallow merge join
-           │         ├── key columns: [17] = [9]
-           │         ├── lookup columns are key
-           │         ├── cardinality: [0 - 1]
+           │    └── values
+           │         ├── columns: phones1_.id:9
+           │         ├── cardinality: [1 - 1]
            │         ├── has-placeholder
            │         ├── key: ()
-           │         ├── fd: ()-->(9,12,17), (9)==(17), (17)==(9)
-           │         ├── values
-           │         │    ├── columns: "$1":17
-           │         │    ├── cardinality: [1 - 1]
-           │         │    ├── has-placeholder
-           │         │    ├── key: ()
-           │         │    ├── fd: ()-->(17)
-           │         │    └── ($1,)
-           │         └── filters (true)
+           │         ├── fd: ()-->(9)
+           │         └── ($1,)
            └── filters (true)
 
 opt

--- a/pkg/sql/opt/xform/testdata/external/nova
+++ b/pkg/sql/opt/xform/testdata/external/nova
@@ -2459,29 +2459,19 @@ project
       │    │    │    │    │    ├── has-placeholder
       │    │    │    │    │    ├── key: ()
       │    │    │    │    │    ├── fd: ()-->(1-12,14,15,19,20)
-      │    │    │    │    │    ├── project
+      │    │    │    │    │    ├── index-join flavors
       │    │    │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15
       │    │    │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    │    │    ├── has-placeholder
       │    │    │    │    │    │    ├── key: ()
       │    │    │    │    │    │    ├── fd: ()-->(1-12,14,15)
-      │    │    │    │    │    │    └── inner-join (lookup flavors)
-      │    │    │    │    │    │         ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 "$2":37!null
-      │    │    │    │    │    │         ├── flags: disallow merge join
-      │    │    │    │    │    │         ├── key columns: [37] = [1]
-      │    │    │    │    │    │         ├── lookup columns are key
-      │    │    │    │    │    │         ├── cardinality: [0 - 1]
+      │    │    │    │    │    │    └── values
+      │    │    │    │    │    │         ├── columns: flavors.id:1
+      │    │    │    │    │    │         ├── cardinality: [1 - 1]
       │    │    │    │    │    │         ├── has-placeholder
       │    │    │    │    │    │         ├── key: ()
-      │    │    │    │    │    │         ├── fd: ()-->(1-12,14,15,37), (1)==(37), (37)==(1)
-      │    │    │    │    │    │         ├── values
-      │    │    │    │    │    │         │    ├── columns: "$2":37
-      │    │    │    │    │    │         │    ├── cardinality: [1 - 1]
-      │    │    │    │    │    │         │    ├── has-placeholder
-      │    │    │    │    │    │         │    ├── key: ()
-      │    │    │    │    │    │         │    ├── fd: ()-->(37)
-      │    │    │    │    │    │         │    └── ($2,)
-      │    │    │    │    │    │         └── filters (true)
+      │    │    │    │    │    │         ├── fd: ()-->(1)
+      │    │    │    │    │    │         └── ($2,)
       │    │    │    │    │    ├── project
       │    │    │    │    │    │    ├── columns: flavor_projects.flavor_id:19!null project_id:20!null
       │    │    │    │    │    │    ├── cardinality: [0 - 1]
@@ -2489,20 +2479,20 @@ project
       │    │    │    │    │    │    ├── key: ()
       │    │    │    │    │    │    ├── fd: ()-->(19,20)
       │    │    │    │    │    │    └── inner-join (lookup flavor_projects@flavor_projects_flavor_id_project_id_key)
-      │    │    │    │    │    │         ├── columns: flavor_projects.flavor_id:19!null project_id:20!null "$1":38!null "$2":39!null
+      │    │    │    │    │    │         ├── columns: flavor_projects.flavor_id:19!null project_id:20!null "$1":37!null "$2":38!null
       │    │    │    │    │    │         ├── flags: disallow merge join
-      │    │    │    │    │    │         ├── key columns: [39 38] = [19 20]
+      │    │    │    │    │    │         ├── key columns: [38 37] = [19 20]
       │    │    │    │    │    │         ├── lookup columns are key
       │    │    │    │    │    │         ├── cardinality: [0 - 1]
       │    │    │    │    │    │         ├── has-placeholder
       │    │    │    │    │    │         ├── key: ()
-      │    │    │    │    │    │         ├── fd: ()-->(19,20,38,39), (20)==(38), (38)==(20), (19)==(39), (39)==(19)
+      │    │    │    │    │    │         ├── fd: ()-->(19,20,37,38), (20)==(37), (37)==(20), (19)==(38), (38)==(19)
       │    │    │    │    │    │         ├── values
-      │    │    │    │    │    │         │    ├── columns: "$1":38 "$2":39
+      │    │    │    │    │    │         │    ├── columns: "$1":37 "$2":38
       │    │    │    │    │    │         │    ├── cardinality: [1 - 1]
       │    │    │    │    │    │         │    ├── has-placeholder
       │    │    │    │    │    │         │    ├── key: ()
-      │    │    │    │    │    │         │    ├── fd: ()-->(38,39)
+      │    │    │    │    │    │         │    ├── fd: ()-->(37,38)
       │    │    │    │    │    │         │    └── ($1, $2)
       │    │    │    │    │    │         └── filters (true)
       │    │    │    │    │    └── filters (true)

--- a/pkg/sql/opt/xform/testdata/rules/generic
+++ b/pkg/sql/opt/xform/testdata/rules/generic
@@ -11,6 +11,15 @@ CREATE TABLE t (
 )
 ----
 
+exec-ddl
+CREATE TABLE abc (
+  a STRING,
+  b STRING,
+  c STRING,
+  PRIMARY KEY (a, b)
+)
+----
+
 # --------------------------------------------------
 # GenerateParameterizedJoin
 # --------------------------------------------------
@@ -18,55 +27,201 @@ CREATE TABLE t (
 opt expect=GenerateParameterizedJoin
 SELECT * FROM t WHERE k = $1
 ----
-project
+index-join t
  ├── columns: k:1!null i:2 s:3 b:4 t:5
  ├── cardinality: [0 - 1]
  ├── has-placeholder
  ├── key: ()
  ├── fd: ()-->(1-5)
- └── inner-join (lookup t)
-      ├── columns: k:1!null i:2 s:3 b:4 t:5 "$1":8!null
-      ├── flags: disallow merge join
-      ├── key columns: [8] = [1]
-      ├── lookup columns are key
-      ├── cardinality: [0 - 1]
+ └── values
+      ├── columns: k:1
+      ├── cardinality: [1 - 1]
       ├── has-placeholder
       ├── key: ()
-      ├── fd: ()-->(1-5,8), (1)==(8), (8)==(1)
-      ├── values
-      │    ├── columns: "$1":8
-      │    ├── cardinality: [1 - 1]
-      │    ├── has-placeholder
-      │    ├── key: ()
-      │    ├── fd: ()-->(8)
-      │    └── ($1,)
-      └── filters (true)
+      ├── fd: ()-->(1)
+      └── ($1,)
 
 opt expect=GenerateParameterizedJoin
 SELECT * FROM t WHERE k = $1::INT
 ----
-project
+index-join t
  ├── columns: k:1!null i:2 s:3 b:4 t:5
  ├── cardinality: [0 - 1]
  ├── has-placeholder
  ├── key: ()
  ├── fd: ()-->(1-5)
- └── inner-join (lookup t)
-      ├── columns: k:1!null i:2 s:3 b:4 t:5 "$1":8!null
+ └── values
+      ├── columns: k:1
+      ├── cardinality: [1 - 1]
+      ├── has-placeholder
+      ├── key: ()
+      ├── fd: ()-->(1)
+      └── ($1,)
+
+opt expect=GenerateParameterizedJoin
+SELECT * FROM abc WHERE a = $1 AND b = $2
+----
+index-join abc
+ ├── columns: a:1!null b:2!null c:3
+ ├── cardinality: [0 - 1]
+ ├── has-placeholder
+ ├── key: ()
+ ├── fd: ()-->(1-3)
+ └── values
+      ├── columns: a:1 b:2
+      ├── cardinality: [1 - 1]
+      ├── has-placeholder
+      ├── key: ()
+      ├── fd: ()-->(1,2)
+      └── ($1, $2)
+
+opt expect=GenerateParameterizedJoin
+SELECT * FROM abc WHERE a = $1 AND b = $1
+----
+index-join abc
+ ├── columns: a:1!null b:2!null c:3
+ ├── cardinality: [0 - 1]
+ ├── has-placeholder
+ ├── key: ()
+ ├── fd: ()-->(1-3)
+ └── values
+      ├── columns: a:1 b:2
+      ├── cardinality: [1 - 1]
+      ├── has-placeholder
+      ├── key: ()
+      ├── fd: ()-->(1,2)
+      └── ($1, $1)
+
+# An index join is not planned if the placeholder type does not match the PK
+# column type. In this case the rule still fires and generates a cross-join, but
+# a lookup join is not planned either so the best plan is a full-table scan.
+opt expect=GenerateParameterizedJoin
+SELECT * FROM t WHERE k = $1::REGCLASS
+----
+select
+ ├── columns: k:1!null i:2 s:3 b:4 t:5
+ ├── cardinality: [0 - 1]
+ ├── has-placeholder
+ ├── key: ()
+ ├── fd: ()-->(1-5)
+ ├── scan t
+ │    ├── columns: k:1!null i:2 s:3 b:4 t:5
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-5)
+ └── filters
+      └── k:1 = $1 [outer=(1), constraints=(/1: (/NULL - ]), fd=()-->(1)]
+
+# An index join is not planned if not all PK columns are constrained.
+opt expect=GenerateParameterizedJoin
+SELECT * FROM abc WHERE a = $1
+----
+project
+ ├── columns: a:1!null b:2!null c:3
+ ├── has-placeholder
+ ├── key: (2)
+ ├── fd: ()-->(1), (2)-->(3)
+ └── inner-join (lookup abc)
+      ├── columns: a:1!null b:2!null c:3 "$1":6!null
       ├── flags: disallow merge join
-      ├── key columns: [8] = [1]
+      ├── key columns: [6] = [1]
+      ├── has-placeholder
+      ├── key: (2)
+      ├── fd: ()-->(1,6), (2)-->(3), (1)==(6), (6)==(1)
+      ├── values
+      │    ├── columns: "$1":6
+      │    ├── cardinality: [1 - 1]
+      │    ├── has-placeholder
+      │    ├── key: ()
+      │    ├── fd: ()-->(6)
+      │    └── ($1,)
+      └── filters (true)
+
+# An index join is not planned if not all PK columns are constrained by equality.
+opt expect=GenerateParameterizedJoin
+SELECT * FROM abc WHERE a = $1 AND b > $2
+----
+project
+ ├── columns: a:1!null b:2!null c:3
+ ├── has-placeholder
+ ├── key: (2)
+ ├── fd: ()-->(1), (2)-->(3)
+ └── inner-join (lookup abc)
+      ├── columns: a:1!null b:2!null c:3 "$1":6!null "$2":7!null
+      ├── flags: disallow merge join
+      ├── lookup expression
+      │    └── filters
+      │         ├── b:2 > "$2":7 [outer=(2,7), constraints=(/2: (/NULL - ]; /7: (/NULL - ])]
+      │         └── "$1":6 = a:1 [outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
+      ├── has-placeholder
+      ├── key: (2)
+      ├── fd: ()-->(1,6,7), (2)-->(3), (1)==(6), (6)==(1)
+      ├── values
+      │    ├── columns: "$1":6 "$2":7
+      │    ├── cardinality: [1 - 1]
+      │    ├── has-placeholder
+      │    ├── key: ()
+      │    ├── fd: ()-->(6,7)
+      │    └── ($1, $2)
+      └── filters (true)
+
+# An index join is not planned if a non-PK column is filtered.
+# TODO(mgartner): Lift this restriction.
+opt expect=GenerateParameterizedJoin
+SELECT * FROM abc WHERE a = $1 AND b = $2 AND c = $3
+----
+project
+ ├── columns: a:1!null b:2!null c:3!null
+ ├── cardinality: [0 - 1]
+ ├── has-placeholder
+ ├── key: ()
+ ├── fd: ()-->(1-3)
+ └── inner-join (lookup abc)
+      ├── columns: a:1!null b:2!null c:3!null "$1":6!null "$2":7!null "$3":8!null
+      ├── flags: disallow merge join
+      ├── key columns: [6 7] = [1 2]
       ├── lookup columns are key
       ├── cardinality: [0 - 1]
       ├── has-placeholder
       ├── key: ()
-      ├── fd: ()-->(1-5,8), (1)==(8), (8)==(1)
+      ├── fd: ()-->(1-3,6-8), (1)==(6), (6)==(1), (2)==(7), (7)==(2), (3)==(8), (8)==(3)
       ├── values
-      │    ├── columns: "$1":8
+      │    ├── columns: "$1":6 "$2":7 "$3":8
       │    ├── cardinality: [1 - 1]
       │    ├── has-placeholder
       │    ├── key: ()
-      │    ├── fd: ()-->(8)
-      │    └── ($1,)
+      │    ├── fd: ()-->(6-8)
+      │    └── ($1, $2, $3)
+      └── filters
+           └── c:3 = "$3":8 [outer=(3,8), constraints=(/3: (/NULL - ]; /8: (/NULL - ]), fd=(3)==(8), (8)==(3)]
+
+# An index join is not planned if a PK column is filtered by a non-placeholder
+# expression.
+# TODO(mgartner): Lift this restriction.
+opt no-stable-folds expect=GenerateParameterizedJoin
+SELECT * FROM abc WHERE a = $1 AND b = current_user()
+----
+project
+ ├── columns: a:1!null b:2!null c:3
+ ├── cardinality: [0 - 1]
+ ├── stable, has-placeholder
+ ├── key: ()
+ ├── fd: ()-->(1-3)
+ └── inner-join (lookup abc)
+      ├── columns: a:1!null b:2!null c:3 "$1":6!null column7:7!null
+      ├── flags: disallow merge join
+      ├── key columns: [6 7] = [1 2]
+      ├── lookup columns are key
+      ├── cardinality: [0 - 1]
+      ├── stable, has-placeholder
+      ├── key: ()
+      ├── fd: ()-->(1-3,6,7), (1)==(6), (6)==(1), (2)==(7), (7)==(2)
+      ├── values
+      │    ├── columns: "$1":6 column7:7
+      │    ├── cardinality: [1 - 1]
+      │    ├── stable, has-placeholder
+      │    ├── key: ()
+      │    ├── fd: ()-->(6,7)
+      │    └── ($1, current_user())
       └── filters (true)
 
 opt expect=GenerateParameterizedJoin
@@ -131,6 +286,55 @@ project
       └── filters
            └── k:1 = i:2 [outer=(1,2), constraints=(/1: (/NULL - ]; /2: (/NULL - ]), fd=(1)==(2), (2)==(1)]
 
+# Locking is preserved.
+opt expect=GenerateParameterizedJoin
+SELECT * FROM t WHERE k = $1 FOR UPDATE
+----
+index-join t
+ ├── columns: k:1!null i:2 s:3 b:4 t:5
+ ├── locking: for-update
+ ├── cardinality: [0 - 1]
+ ├── volatile, has-placeholder
+ ├── key: ()
+ ├── fd: ()-->(1-5)
+ └── values
+      ├── columns: k:1
+      ├── cardinality: [1 - 1]
+      ├── has-placeholder
+      ├── key: ()
+      ├── fd: ()-->(1)
+      └── ($1,)
+
+# Locking is preserved.
+opt expect=GenerateParameterizedJoin
+SELECT * FROM t WHERE k = $1 AND i = $1 FOR UPDATE
+----
+project
+ ├── columns: k:1!null i:2!null s:3 b:4 t:5
+ ├── cardinality: [0 - 1]
+ ├── volatile, has-placeholder
+ ├── key: ()
+ ├── fd: ()-->(1-5)
+ └── inner-join (lookup t)
+      ├── columns: k:1!null i:2!null s:3 b:4 t:5 "$1":8!null
+      ├── flags: disallow merge join
+      ├── key columns: [8] = [1]
+      ├── lookup columns are key
+      ├── locking: for-update
+      ├── cardinality: [0 - 1]
+      ├── volatile, has-placeholder
+      ├── key: ()
+      ├── fd: ()-->(1-5,8), (1)==(2,8), (2)==(1,8), (8)==(1,2)
+      ├── values
+      │    ├── columns: "$1":8
+      │    ├── cardinality: [1 - 1]
+      │    ├── has-placeholder
+      │    ├── key: ()
+      │    ├── fd: ()-->(8)
+      │    └── ($1,)
+      └── filters
+           └── k:1 = i:2 [outer=(1,2), constraints=(/1: (/NULL - ]; /2: (/NULL - ]), fd=(1)==(2), (2)==(1)]
+
 # The generated join should not be reordered and merge joins should not be
 # explored on it.
 opt expect=GenerateParameterizedJoin expect-not=(ReorderJoins,GenerateMergeJoins)
@@ -182,29 +386,19 @@ project
       ├── has-placeholder
       ├── key: ()
       ├── fd: ()-->(1-5,8,9), (1)==(9), (9)==(1)
-      ├── project
+      ├── index-join t
       │    ├── columns: k:8!null i:9
       │    ├── cardinality: [0 - 1]
       │    ├── has-placeholder
       │    ├── key: ()
       │    ├── fd: ()-->(8,9)
-      │    └── inner-join (lookup t)
-      │         ├── columns: k:8!null i:9 "$1":15!null
-      │         ├── flags: disallow merge join
-      │         ├── key columns: [15] = [8]
-      │         ├── lookup columns are key
-      │         ├── cardinality: [0 - 1]
+      │    └── values
+      │         ├── columns: k:8
+      │         ├── cardinality: [1 - 1]
       │         ├── has-placeholder
       │         ├── key: ()
-      │         ├── fd: ()-->(8,9,15), (8)==(15), (15)==(8)
-      │         ├── values
-      │         │    ├── columns: "$1":15
-      │         │    ├── cardinality: [1 - 1]
-      │         │    ├── has-placeholder
-      │         │    ├── key: ()
-      │         │    ├── fd: ()-->(15)
-      │         │    └── ($1,)
-      │         └── filters (true)
+      │         ├── fd: ()-->(8)
+      │         └── ($1,)
       └── filters (true)
 
 # TODO(mgartner): The rule doesn't apply because the filters do not reference
@@ -654,6 +848,23 @@ index-join t
       ├── constraint: /2/3/4/1: [/1/'foo' - /1/'foo']
       ├── key: (1)
       └── fd: ()-->(2,3), (1)-->(4)
+
+# The rule does not match if generic optimizations are disabled.
+opt set=(plan_cache_mode=force_custom_plan) expect-not=GenerateParameterizedJoin
+SELECT * FROM t WHERE k = $1
+----
+select
+ ├── columns: k:1!null i:2 s:3 b:4 t:5
+ ├── cardinality: [0 - 1]
+ ├── has-placeholder
+ ├── key: ()
+ ├── fd: ()-->(1-5)
+ ├── scan t
+ │    ├── columns: k:1!null i:2 s:3 b:4 t:5
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-5)
+ └── filters
+      └── k:1 = $1 [outer=(1), constraints=(/1: (/NULL - ]), fd=()-->(1)]
 
 # The rule does not match if generic optimizations are disabled.
 opt set=(plan_cache_mode=force_custom_plan) expect-not=GenerateParameterizedJoin


### PR DESCRIPTION
#### opt: refactor GenerateParameterizedJoin

GenerateParameterizedJoin has been refactored so that it constructs an
InnerJoin and Project in the custom function, and not in the optgen
replace pattern. This will make some upcoming changes simpler.

Release note: None

#### opt: plan generic index joins

The GenerateParameterizedJoin rule can now plan index joins instead of
inner joins that are later converted to lookup joins. Index joins are
more efficient than lookup joins because they are optimized for a
narrower set of capabilities and there is a vectorized implementation
for them. Index joins are currently only planned when all PK columns are
constrained to placeholders. This covers the most common cases of PK
lookups but this restriction can be loosened in the future (see the
added TODOs).

Epic: None
Release note: None
