### PR TITLE
kvserver: deflake TestClosedTimestampFrozenAfterSubsumption

### DIFF
--- a/pkg/kv/kvserver/closed_timestamp_test.go
+++ b/pkg/kv/kvserver/closed_timestamp_test.go
@@ -625,6 +625,7 @@ func TestClosedTimestampFrozenAfterSubsumption(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	skip.UnderRace(t)
+	skip.UnderDeadlock(t)
 
 	for _, test := range []struct {
 		name string


### PR DESCRIPTION
In very rare cases under deadlock, it seems that the timing causes the storeliveness support to get withdrawn at times when the test doesn't expect.

Fixes: #140323

Release note: None