### PR TITLE
envutil: add MALLOC_CONF to safeVarRegistry

### DIFF
--- a/pkg/util/envutil/env.go
+++ b/pkg/util/envutil/env.go
@@ -187,6 +187,8 @@ var safeVarRegistry = map[redact.SafeString]struct{}{
 	"GOMAXPROCS":  {},
 	"GOTRACEBACK": {},
 	"GOMEMLIMIT":  {},
+	// Jemalloc configuration override.
+	"MALLOC_CONF": {},
 	// gRPC.
 	"GRPC_GO_LOG_SEVERITY_LEVEL":  {},
 	"GRPC_GO_LOG_VERBOSITY_LEVEL": {},


### PR DESCRIPTION
If set, this causes it to be logged on node startup.

Relates to https://github.com/cockroachlabs/support/issues/3153

Epic: none

Release note: None