### PR TITLE
sql: add `sql.defaults.plan_cache_mode` cluster setting

### DIFF
--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -742,6 +742,17 @@ var overrideAlterPrimaryRegionInSuperRegion = settings.RegisterBoolSetting(
 	false,
 	settings.WithPublic)
 
+var planCacheClusterMode = settings.RegisterEnumSetting(
+	settings.ApplicationLevel,
+	"sql.defaults.plan_cache_mode",
+	"default value for plan_cache_mode session setting",
+	"auto",
+	map[sessiondatapb.PlanCacheMode]string{
+		sessiondatapb.PlanCacheModeForceCustom:  "force_custom_plan",
+		sessiondatapb.PlanCacheModeForceGeneric: "force_generic_plan",
+		sessiondatapb.PlanCacheModeAuto:         "auto",
+	})
+
 var errNoTransactionInProgress = pgerror.New(pgcode.NoActiveSQLTransaction, "there is no transaction in progress")
 var errTransactionInProgress = pgerror.New(pgcode.ActiveSQLTransaction, "there is already a transaction in progress")
 

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -3614,7 +3614,7 @@ var varGen = map[string]sessionVar{
 			return evalCtx.SessionData().PlanCacheMode.String(), nil
 		},
 		GlobalDefault: func(sv *settings.Values) string {
-			return sessiondatapb.PlanCacheModeAuto.String()
+			return planCacheClusterMode.String(sv)
 		},
 	},
 


### PR DESCRIPTION
This cluster setting allows changes to the `plan_cache_mode` session
setting to be gradually rolled out across the CockroachCloud fleet.

Epic: None
Release note: None
