### PR TITLE
pkg/cmd/roachtest: Disable autocommit_before_ddl

### DIFF
--- a/pkg/cmd/roachtest/tests/large_schema_backup_restore.go
+++ b/pkg/cmd/roachtest/tests/large_schema_backup_restore.go
@@ -56,7 +56,12 @@ func largeSchemaBackupRestore(r registry.Registry, numTables int) {
 			conn := c.Conn(ctx, t.L(), 1)
 			defer conn.Close()
 
+			_, err := conn.ExecContext(ctx, "SET autocommit_before_ddl = false")
+			require.NoError(t, err)
+
 			t.L().Printf("Creating tables")
+			// Normally it's a bit risky to do schema changes in a transaction, but it is much faster.
+			// Since this is a very contrived test, it's a fine optimization.
 			tx, err := conn.BeginTx(ctx, nil)
 			require.NoError(t, err)
 			for i := range numDbs {


### PR DESCRIPTION
Tested locally, test consistently fails without this change and passes with it.

Fixes: #140315
Release note: None