### PR TITLE
sqlstats: convert sampledPlanCache to stmtsCache storing empty struct

### DIFF
--- a/pkg/sql/executor_statement_metrics.go
+++ b/pkg/sql/executor_statement_metrics.go
@@ -237,7 +237,6 @@ func (ex *connExecutor) recordStatementSummary(
 			ex.planner.DistSQLPlanner().distSQLSrv.Metrics.CumulativeContentionNanos.Inc(queryLevelStats.ContentionTime.Nanoseconds())
 		}
 
-		err = ex.statsCollector.RecordStatementExecStats(recordedStmtStatsKey, *queryLevelStats)
 		if err != nil {
 			if log.V(2 /* level */) {
 				log.Warningf(ctx, "unable to record statement exec stats: %s", err)

--- a/pkg/sql/instrumentation.go
+++ b/pkg/sql/instrumentation.go
@@ -464,31 +464,29 @@ func (ih *instrumentationHelper) Setup(
 		}
 	}
 
-	shouldSampleFirstEncounter := func() bool {
-		if stmt.AST.StatementType() == tree.TypeTCL {
-			// We don't collect stats for  statements so
-			// there's no need to trace them.
-			return false
-		}
+	if collectTxnExecStats {
+		statsCollector.SetStatementSampled(stmt.StmtNoConstants, implicitTxn, p.SessionData().Database)
+	} else {
+		collectTxnExecStats = func() bool {
+			if stmt.AST.StatementType() == tree.TypeTCL {
+				// We don't collect stats for  statements so there's no need
+				//to trace them.
+				return false
+			}
 
-		// If this is the first time we see this statement in the current stats
-		// container, we'll collect its execution stats anyway (unless the user
-		// disabled txn or stmt stats collection entirely).
-		// TODO(117690): Unify StmtStatsEnable and TxnStatsEnable into a single cluster setting.
-		if collectTxnStatsSampleRate.Get(&cfg.Settings.SV) == 0 ||
-			!sqlstats.StmtStatsEnable.Get(&cfg.Settings.SV) {
-			return false
-		}
+			// TODO(117690): Unify StmtStatsEnable and TxnStatsEnable into a single cluster setting.
+			if collectTxnStatsSampleRate.Get(&cfg.Settings.SV) == 0 || !sqlstats.StmtStatsEnable.Get(&cfg.Settings.SV) {
+				return false
+			}
 
-		previouslySampled := statsCollector.ShouldSample(stmt.StmtNoConstants, implicitTxn, p.SessionData().Database)
-
-		// We don't want to collect the stats if the stats container is full,
-		// since previouslySampled will always return false for statements
-		// not already in the container.
-		return !previouslySampled && !statsCollector.StatementsContainerFull()
+			// If this is the first time we see this statement in the current stats
+			// container, we'll collect its execution stats anyway (unless the user
+			// disabled txn or stmt stats collection entirely).
+			return statsCollector.ShouldSampleNewStatement(stmt.StmtNoConstants, implicitTxn, p.SessionData().Database)
+		}()
 	}
 
-	ih.collectExecStats = collectTxnExecStats || shouldSampleFirstEncounter()
+	ih.collectExecStats = collectTxnExecStats
 
 	if !ih.collectBundle && ih.withStatementTrace == nil && ih.outputMode == unmodifiedOutput {
 		if ih.collectExecStats {

--- a/pkg/sql/sqlstats/persistedsqlstats/datadriven_test.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/datadriven_test.go
@@ -144,7 +144,7 @@ func TestSQLStatsDataDriven(t *testing.T) {
 			// them.
 			fingerprint = strings.Replace(fingerprint, "%", " ", -1)
 
-			previouslySampled := appStats.ShouldSample(
+			previouslySampled := appStats.StatementSampled(
 				fingerprint,
 				implicitTxn,
 				dbName,

--- a/pkg/sql/sqlstats/persistedsqlstats/flush_test.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/flush_test.go
@@ -784,7 +784,7 @@ func TestSQLStatsPlanSampling(t *testing.T) {
 
 	validateSample := func(fingerprint string, implicitTxn bool, expectedPreviouslySampledState bool) {
 
-		previouslySampled := appStats.ShouldSample(
+		previouslySampled := appStats.StatementSampled(
 			fingerprint,
 			implicitTxn,
 			dbName,

--- a/pkg/sql/sqlstats/sslocal/BUILD.bazel
+++ b/pkg/sql/sqlstats/sslocal/BUILD.bazel
@@ -20,7 +20,6 @@ go_library(
         "//pkg/settings/cluster",
         "//pkg/sql/appstatspb",
         "//pkg/sql/clusterunique",
-        "//pkg/sql/execstats",
         "//pkg/sql/pgwire/pgerror",
         "//pkg/sql/sessionphase",
         "//pkg/sql/sqlstats",

--- a/pkg/sql/sqlstats/sslocal/sslocal_stats_collector.go
+++ b/pkg/sql/sqlstats/sslocal/sslocal_stats_collector.go
@@ -12,7 +12,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/appstatspb"
 	"github.com/cockroachdb/cockroach/pkg/sql/clusterunique"
-	"github.com/cockroachdb/cockroach/pkg/sql/execstats"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessionphase"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats"
@@ -362,12 +361,6 @@ func (s *StatsCollector) RecordTransaction(
 	ctx context.Context, key appstatspb.TransactionFingerprintID, value sqlstats.RecordedTxnStats,
 ) error {
 	return s.flushTarget.RecordTransaction(ctx, key, value)
-}
-
-func (s *StatsCollector) RecordStatementExecStats(
-	key appstatspb.StatementStatisticsKey, stats execstats.QueryLevelStats,
-) error {
-	return s.currentTransactionStatementStats.RecordStatementExecStats(key, stats)
 }
 
 func (s *StatsCollector) IterateStatementStats(

--- a/pkg/sql/sqlstats/ssmemstorage/ss_mem_storage.go
+++ b/pkg/sql/sqlstats/ssmemstorage/ss_mem_storage.go
@@ -80,12 +80,11 @@ type Container struct {
 		stmts map[stmtKey]*stmtStats
 		txns  map[appstatspb.TransactionFingerprintID]*txnStats
 
-		// sampledPlanMetadataCache records when was the last time the plan was
-		// sampled. This data structure uses a subset of stmtKey as the key into
-		// in-memory dictionary in order to allow lookup for whether a plan has been
-		// sampled for a statement without needing to know the statement's
-		// transaction fingerprintID.
-		sampledPlanMetadataCache map[sampledPlanKey]time.Time
+		// sampledStatementCache records if the statement has been sampled via
+		// tracing. sampledPlanKey is used as the key to the map as it does not
+		// use transactionFingerprintID which is not available at the time of
+		// sampling decision.
+		sampledStatementCache map[sampledPlanKey]struct{}
 	}
 
 	txnCounts transactionCounts
@@ -119,7 +118,7 @@ func New(
 
 	s.mu.stmts = make(map[stmtKey]*stmtStats)
 	s.mu.txns = make(map[appstatspb.TransactionFingerprintID]*txnStats)
-	s.mu.sampledPlanMetadataCache = make(map[sampledPlanKey]time.Time)
+	s.mu.sampledStatementCache = make(map[sampledPlanKey]struct{})
 
 	return s
 }
@@ -501,7 +500,7 @@ func (s *Container) getStatsForStmtWithKeyLocked(
 		stats = &stmtStats{}
 		stats.ID = stmtFingerprintID
 		s.mu.stmts[key] = stats
-		s.mu.sampledPlanMetadataCache[key.sampledPlanKey] = s.getTimeNow()
+		s.mu.sampledStatementCache[key.sampledPlanKey] = struct{}{}
 
 		return stats, true /* created */, false /* throttled */
 	}
@@ -652,7 +651,7 @@ func (s *Container) clearLocked(ctx context.Context) {
 	// large for the likely future workload.
 	s.mu.stmts = make(map[stmtKey]*stmtStats, len(s.mu.stmts)/2)
 	s.mu.txns = make(map[appstatspb.TransactionFingerprintID]*txnStats, len(s.mu.txns)/2)
-	s.mu.sampledPlanMetadataCache = make(map[sampledPlanKey]time.Time, len(s.mu.sampledPlanMetadataCache)/2)
+	s.mu.sampledStatementCache = make(map[sampledPlanKey]struct{}, len(s.mu.sampledStatementCache)/2)
 	if s.knobs != nil && s.knobs.OnAfterClear != nil {
 		s.knobs.OnAfterClear()
 	}
@@ -898,15 +897,6 @@ func (s *transactionCounts) recordTransactionCounts(
 	if implicit {
 		s.mu.ImplicitCount++
 	}
-}
-
-func (s *Container) getLogicalPlanLastSampled(
-	key sampledPlanKey,
-) (lastSampled time.Time, found bool) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	lastSampled, found = s.mu.sampledPlanMetadataCache[key]
-	return lastSampled, found
 }
 
 type transactionCounts struct {

--- a/pkg/sql/sqlstats/ssmemstorage/ss_mem_storage.go
+++ b/pkg/sql/sqlstats/ssmemstorage/ss_mem_storage.go
@@ -384,10 +384,7 @@ func (s *stmtStats) sizeUnsafeLocked() int64 {
 	return stmtStatsShallowSize + databaseNameSize + dataSize
 }
 
-func (s *stmtStats) recordExecStats(stats execstats.QueryLevelStats) {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
+func (s *stmtStats) recordExecStatsLocked(stats execstats.QueryLevelStats) {
 	s.mu.data.ExecStats.Count++
 	count := s.mu.data.ExecStats.Count
 	s.mu.data.ExecStats.NetworkBytes.Record(count, float64(stats.NetworkBytesSent))


### PR DESCRIPTION
Previously, we used `sampledPlanCache` which was a map of sampledPlanKey
to time, on the SQLStats application container to track which statements
we've already sampled for the current aggregation period. Since we are
no longer sampling the plan on any interval, we can convert the map
value to be the more low overhead empty struct. This commit also splits
the get and set of the map into separate functions in order to take the
read/full lock where appropriate.

This change also makes it so that we insert a traced stmt into the
cache at the time we decide to trace it, instead of  at the end of its
execution.  This prevents us from sampling statements with the same key
when we've already decided to trace one.

Epic: [CRDB-45771](https://cockroachlabs.atlassian.net/browse/CRDB-45771)

Release note: None

## Commit 2
sqlstats: consolidate RecordStatement and RecordStatementExecStats
Release note: none
Epic: none