### PR TITLE
release-24.3: catalog/lease: disallow leases until range feed starts

### DIFF
--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -1636,7 +1636,7 @@ func (s *SQLServer) preStart(
 	// care about what uses the SQL server before those migrations
 	// run.
 
-	s.leaseMgr.RefreshLeases(ctx, stopper, s.execCfg.DB)
+	s.leaseMgr.StartRefreshLeasesTask(ctx, stopper, s.execCfg.DB)
 	s.leaseMgr.RunBackgroundLeasingTask(ctx)
 
 	if err := s.jobRegistry.Start(ctx, stopper); err != nil {

--- a/pkg/sql/catalog/lease/lease.go
+++ b/pkg/sql/catalog/lease/lease.go
@@ -899,6 +899,9 @@ type Manager struct {
 	descDelCh chan descpb.ID
 	// rangefeedErrCh receives any terminal errors from the rangefeed.
 	rangefeedErrCh chan error
+	// waitForInit used when the lease manager is starting up prevent leases from
+	// being acquired before the range feed.
+	waitForInit chan struct{}
 }
 
 const leaseConcurrencyLimit = 5
@@ -987,7 +990,8 @@ func NewLeaseManager(
 	lm.storage.writer = newKVWriter(codec, db.KV(), keys.LeaseTableID, settingsWatcher, lm)
 	lm.stopper.AddCloser(lm.sem.Closer("stopper"))
 	lm.mu.descriptors = make(map[descpb.ID]*descriptorState)
-	// We are going to start the range feed later when RefreshLeases
+	lm.waitForInit = make(chan struct{})
+	// We are going to start the range feed later when StartRefreshLeasesTask
 	// is invoked inside pre-start. So, that guarantees all range feed events
 	// that will be generated will be after the current time. So, historical
 	// queries with in this tenant (i.e. PCR catalog reader) before this point are
@@ -1330,8 +1334,17 @@ func (m *Manager) SetDraining(
 	}
 }
 
+// maybeWaitForInit waits for the lease manager to startup.
+func (m *Manager) maybeWaitForInit() {
+	select {
+	case <-m.waitForInit:
+	case <-m.stopper.ShouldQuiesce():
+	}
+}
+
 // If create is set, cache and stopper need to be set as well.
 func (m *Manager) findDescriptorState(id descpb.ID, create bool) *descriptorState {
+	m.maybeWaitForInit()
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	t := m.mu.descriptors[id]
@@ -1342,13 +1355,14 @@ func (m *Manager) findDescriptorState(id descpb.ID, create bool) *descriptorStat
 	return t
 }
 
-// RefreshLeases starts a goroutine that refreshes the lease manager
+// StartRefreshLeasesTask starts a goroutine that refreshes the lease manager
 // leases for descriptors received in the latest system configuration via gossip or
 // rangefeeds. This function must be passed a non-nil gossip if
 // RangefeedLeases is not active.
-func (m *Manager) RefreshLeases(ctx context.Context, s *stop.Stopper, db *kv.DB) {
+func (m *Manager) StartRefreshLeasesTask(ctx context.Context, s *stop.Stopper, db *kv.DB) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	defer close(m.waitForInit)
 	m.watchForUpdates(ctx)
 	_ = s.RunAsyncTask(ctx, "refresh-leases", func(ctx context.Context) {
 		for {
@@ -2092,4 +2106,12 @@ func (m *Manager) TestingSetDisableRangeFeedCheckpointFn(disable bool) chan stru
 		m.testingKnobs.RangeFeedResetChannel = nil
 	}
 	return m.testingKnobs.RangeFeedResetChannel
+}
+
+// TestingMarkInit marks the lease manager as initialized without a range feed being started.
+// This is only used for testing.
+func (m *Manager) TestingMarkInit() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	close(m.waitForInit)
 }

--- a/pkg/sql/catalog/lease/lease_test.go
+++ b/pkg/sql/catalog/lease/lease_test.go
@@ -283,6 +283,7 @@ func (t *leaseTest) node(nodeID uint32) *lease.Manager {
 		)
 		ctx := logtags.AddTag(context.Background(), "leasemgr", nodeID)
 		mgr.RunBackgroundLeasingTask(ctx)
+		mgr.TestingMarkInit()
 		t.nodes[nodeID] = mgr
 	}
 	return mgr


### PR DESCRIPTION
Backport 1/1 commits from #140058.

/cc @cockroachdb/release

---

Previusly, the lease manager allowed descriptors to be leased before the range feed was fully initialized. This was problematic because if an descriptor was updated before the range feed is started we would have no way of knowing. For example an early query during startup could fetch the system database descriptor before the range feed starts, and this could kept forever. If an upgrade bumped the descriptor version between the initial fetch and start of range feed then we could end up with a node stuck with the sale version forever. To address this, this patch forces any early lease acqusitions to wait for the range feed to start up.

Fixes: #140403

Release note: None
Release justification: low risk fix that prevents panics during startup