### PR TITLE
release-25.1: sql: add `sql.defaults.plan_cache_mode` cluster setting and default to `force_custom_plan`

### DIFF
--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -742,6 +742,17 @@ var overrideAlterPrimaryRegionInSuperRegion = settings.RegisterBoolSetting(
 	false,
 	settings.WithPublic)
 
+var planCacheClusterMode = settings.RegisterEnumSetting(
+	settings.ApplicationLevel,
+	"sql.defaults.plan_cache_mode",
+	"default value for plan_cache_mode session setting",
+	"auto",
+	map[sessiondatapb.PlanCacheMode]string{
+		sessiondatapb.PlanCacheModeForceCustom:  "force_custom_plan",
+		sessiondatapb.PlanCacheModeForceGeneric: "force_generic_plan",
+		sessiondatapb.PlanCacheModeAuto:         "auto",
+	})
+
 var errNoTransactionInProgress = pgerror.New(pgcode.NoActiveSQLTransaction, "there is no transaction in progress")
 var errTransactionInProgress = pgerror.New(pgcode.ActiveSQLTransaction, "there is already a transaction in progress")
 

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -746,7 +746,7 @@ var planCacheClusterMode = settings.RegisterEnumSetting(
 	settings.ApplicationLevel,
 	"sql.defaults.plan_cache_mode",
 	"default value for plan_cache_mode session setting",
-	"auto",
+	"force_custom_plan",
 	map[sessiondatapb.PlanCacheMode]string{
 		sessiondatapb.PlanCacheModeForceCustom:  "force_custom_plan",
 		sessiondatapb.PlanCacheModeForceGeneric: "force_generic_plan",

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -4036,7 +4036,7 @@ override_multi_region_zone_config                          off
 parallelize_multi_key_lookup_joins_enabled                 off
 password_encryption                                        scram-sha-256
 pg_trgm.similarity_threshold                               0.3
-plan_cache_mode                                            auto
+plan_cache_mode                                            force_custom_plan
 plpgsql_use_strict_into                                    off
 prefer_lookup_joins_for_fks                                off
 prepared_statements_cache_size                             0 B

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -3036,7 +3036,7 @@ override_multi_region_zone_config                          off                 N
 parallelize_multi_key_lookup_joins_enabled                 off                 NULL      NULL        NULL        string
 password_encryption                                        scram-sha-256       NULL      NULL        NULL        string
 pg_trgm.similarity_threshold                               0.3                 NULL      NULL        NULL        string
-plan_cache_mode                                            auto                NULL      NULL        NULL        string
+plan_cache_mode                                            force_custom_plan   NULL      NULL        NULL        string
 plpgsql_use_strict_into                                    off                 NULL      NULL        NULL        string
 prefer_lookup_joins_for_fks                                off                 NULL      NULL        NULL        string
 prepared_statements_cache_size                             0 B                 NULL      NULL        NULL        string
@@ -3243,7 +3243,7 @@ override_multi_region_zone_config                          off                 N
 parallelize_multi_key_lookup_joins_enabled                 off                 NULL  user     NULL      off                 off
 password_encryption                                        scram-sha-256       NULL  user     NULL      scram-sha-256       scram-sha-256
 pg_trgm.similarity_threshold                               0.3                 NULL  user     NULL      0.3                 0.3
-plan_cache_mode                                            auto                NULL  user     NULL      auto                auto
+plan_cache_mode                                            force_custom_plan   NULL  user     NULL      force_custom_plan   force_custom_plan
 plpgsql_use_strict_into                                    off                 NULL  user     NULL      off                 off
 prefer_lookup_joins_for_fks                                off                 NULL  user     NULL      off                 off
 prepared_statements_cache_size                             0 B                 NULL  user     NULL      0 B                 0 B

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -167,7 +167,7 @@ override_multi_region_zone_config                          off
 parallelize_multi_key_lookup_joins_enabled                 off
 password_encryption                                        scram-sha-256
 pg_trgm.similarity_threshold                               0.3
-plan_cache_mode                                            auto
+plan_cache_mode                                            force_custom_plan
 plpgsql_use_strict_into                                    off
 prefer_lookup_joins_for_fks                                off
 prepared_statements_cache_size                             0 B

--- a/pkg/sql/opt/testutils/opttester/BUILD.bazel
+++ b/pkg/sql/opt/testutils/opttester/BUILD.bazel
@@ -45,6 +45,7 @@ go_library(
         "//pkg/sql/sem/eval",
         "//pkg/sql/sem/tree",
         "//pkg/sql/sem/volatility",
+        "//pkg/sql/sessiondatapb",
         "//pkg/sql/stats",
         "//pkg/testutils/datapathutils",
         "//pkg/testutils/floatcmp",

--- a/pkg/sql/opt/testutils/opttester/opt_tester.go
+++ b/pkg/sql/opt/testutils/opttester/opt_tester.go
@@ -57,6 +57,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/volatility"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondatapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/stats"
 	"github.com/cockroachdb/cockroach/pkg/testutils/datapathutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/floatcmp"
@@ -300,6 +301,10 @@ func New(catalog cat.Catalog, sqlStr string) *OptTester {
 	ot.evalCtx.SessionData().UserProto = username.MakeSQLUsernameFromPreNormalizedString("opttester").EncodeProto()
 	ot.evalCtx.SessionData().Database = "defaultdb"
 	ot.evalCtx.SessionData().ZigzagJoinEnabled = true
+	// Manually set plan_cache_mode to auto. The default is currently
+	// "force_custom_plan", but will become "auto" soon. Running the optimizer
+	// tests as "auto" will make future backports less painful.
+	ot.evalCtx.SessionData().PlanCacheMode = sessiondatapb.PlanCacheModeAuto
 
 	return ot
 }

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -3614,7 +3614,7 @@ var varGen = map[string]sessionVar{
 			return evalCtx.SessionData().PlanCacheMode.String(), nil
 		},
 		GlobalDefault: func(sv *settings.Values) string {
-			return sessiondatapb.PlanCacheModeAuto.String()
+			return planCacheClusterMode.String(sv)
 		},
 	},
 


### PR DESCRIPTION
#### sql: add `sql.defaults.plan_cache_mode` cluster setting

This cluster setting allows changes to the `plan_cache_mode` session
setting to be gradually rolled out across the CockroachCloud fleet.

Epic: None
Release note: None

#### sql: set default sql.defaults.plan_cache_mode to force_custom_plan

Informs #137018
Informs #136975

Release note (sql change): The default setting for `plan_cache_mode` has
been reverted to `force_custom_plan`. Please disregard the previous
release node about it being set to `auto`.

---

Release justification: Reverting change of default session setting.


