### PR TITLE
metric: remove mutex around windowed histogram update

### DIFF
--- a/pkg/util/metric/metric_test.go
+++ b/pkg/util/metric/metric_test.go
@@ -454,7 +454,7 @@ func TestNewHistogramRotate(t *testing.T) {
 			h.RecordValue(12345)
 			f := float64(12345) + sum
 			_, wSum := h.WindowedSnapshot().Total()
-			require.Equal(t, wSum, f)
+			require.Equal(t, f, wSum)
 		}
 		// Tick. This rotates the histogram.
 		now = now.Add(time.Duration(i+1) * 10 * time.Second)

--- a/pkg/util/metric/tick/tick.go
+++ b/pkg/util/metric/tick/tick.go
@@ -6,6 +6,7 @@
 package tick
 
 import (
+	"sync/atomic"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -55,7 +56,7 @@ func MaybeTick(m Periodic) {
 // maintain a windowed version to work around limitations of our internal
 // timeseries database.
 type Ticker struct {
-	nextT        time.Time
+	nextT        atomic.Value
 	tickInterval time.Duration
 
 	onTick func()
@@ -65,11 +66,12 @@ var _ Periodic = &Ticker{}
 
 // NewTicker returns a new *Ticker instance.
 func NewTicker(nextT time.Time, tickInterval time.Duration, onTick func()) *Ticker {
-	return &Ticker{
-		nextT:        nextT,
+	t := &Ticker{
 		tickInterval: tickInterval,
 		onTick:       onTick,
 	}
+	t.nextT.Store(nextT)
+	return t
 }
 
 // OnTick calls the onTick function provided at construction.
@@ -85,7 +87,7 @@ func (s *Ticker) OnTick() {
 
 // NextTick returns the timestamp of the next scheduled tick for this Ticker.
 func (s *Ticker) NextTick() time.Time {
-	return s.nextT
+	return s.nextT.Load().(time.Time)
 }
 
 // Tick updates the next tick timestamp to the next tickInterval, and invokes
@@ -94,6 +96,6 @@ func (s *Ticker) NextTick() time.Time {
 // NB: Generally, MaybeTick should be used instead to ensure that we don't tick
 // before nextT. This function is only used when we want to tick regardless
 func (s *Ticker) Tick() {
-	s.nextT = s.nextT.Add(s.tickInterval)
+	s.nextT.Store(s.nextT.Load().(time.Time).Add(s.tickInterval))
 	s.OnTick()
 }


### PR DESCRIPTION
Previously, we used an `RWMutex` to serialize access to the windowed histogram. This was done because there's a rotation that needs to happen that moves the currently active histogram into the `prev` variable and creates a fresh one to update in `cur`. This is done to maintain the window.

This change limits the mutex usage to rotation and window snapshotting, removing the need to take a read lock during updates since we can atomically grab the `cur` histogram.

There's a bit of nuance to manage around the fact that `prev` can be nil on the first iteration, since `cur` is the first histogram. After a single rotation, `prev` will not be nil again.

The prometheus histogram itself (what's stored in the `atomic.Value`) is thread-safe.

```
old:  https://github.com/dhartunian/cockroach/commit/507c68f8abb0c9a3f527c66cb42129c2cb096e7d Merge https://github.com/cockroachdb/cockroach/pull/140092
new:  https://github.com/dhartunian/cockroach/commit/ff9dd529682dbc6d485687e5451149c28bd82fd7 metric: remove mutex around windowed histogram upd
args: benchdiff "./pkg/util/metric" "-b" "-r" "BenchmarkHistogramRecordValue" "-c" "10" "--preview"

name                                     old time/op    new time/op    delta
HistogramRecordValue/insert_zero-10        30.7ns ± 8%    24.3ns ± 2%  -20.94%  (p=0.000 n=9+8)
HistogramRecordValue/insert_integers-10    37.4ns ± 6%    33.8ns ± 1%   -9.83%  (p=0.000 n=8+8)
HistogramRecordValue/random_integers-10    44.9ns ± 9%    41.7ns ± 1%   -7.25%  (p=0.000 n=8+8)

name                                     old alloc/op   new alloc/op   delta
HistogramRecordValue/insert_integers-10     0.00B          0.00B          ~     (all equal)
HistogramRecordValue/insert_zero-10         0.00B          0.00B          ~     (all equal)
HistogramRecordValue/random_integers-10     0.00B          0.00B          ~     (all equal)

name                                     old allocs/op  new allocs/op  delta
HistogramRecordValue/insert_integers-10      0.00           0.00          ~     (all equal)
HistogramRecordValue/insert_zero-10          0.00           0.00          ~     (all equal)
HistogramRecordValue/random_integers-10      0.00           0.00          ~     (all equal)
```

Part of #133306

Release note: None