### PR TITLE
workload/schemachanger: deflake TestWorkload on CREATE FUNCTION

### DIFF
--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -4346,6 +4346,8 @@ FROM
 	})
 	opStmt.potentialExecErrors.addAll(codesWithConditions{
 		{pgcode.InvalidFunctionDefinition, hasFuncRefs},
+		// TODO(fqazi): For deflaking test workload, shouldn't be required.
+		{pgcode.UndefinedFunction, true},
 	})
 
 	return opStmt, nil


### PR DESCRIPTION
Currently this workload is failing on CREATE FUNCTION statements with undefined function errors. To address this, we will temporarily deflake this by adding undefined function as a potential error.

Informs: #140407

Release note: None