### PR TITLE
 workload/schemachanger: set session variables on all connections

### DIFF
--- a/pkg/ccl/testccl/workload/schemachange/schema_change_external_test.go
+++ b/pkg/ccl/testccl/workload/schemachange/schema_change_external_test.go
@@ -34,7 +34,6 @@ func TestWorkload(t *testing.T) {
 	defer ccl.TestingEnableEnterprise()()
 	skip.UnderDeadlock(t, "test connections can be too slow under expensive configs")
 	skip.UnderRace(t, "test connections can be too slow under expensive configs")
-	skip.WithIssue(t, 140411)
 
 	scope := log.Scope(t)
 	defer scope.Close(t)

--- a/pkg/ccl/testccl/workload/schemachange/schema_change_external_test.go
+++ b/pkg/ccl/testccl/workload/schemachange/schema_change_external_test.go
@@ -34,6 +34,7 @@ func TestWorkload(t *testing.T) {
 	defer ccl.TestingEnableEnterprise()()
 	skip.UnderDeadlock(t, "test connections can be too slow under expensive configs")
 	skip.UnderRace(t, "test connections can be too slow under expensive configs")
+	skip.WithIssue(t, 140411)
 
 	scope := log.Scope(t)
 	defer scope.Close(t)


### PR DESCRIPTION
Previously, we fetched connections from our connection pool to apply
session variables. When we changed the cluster setting the default only
changes for new connection, so our connection pool could have
connections with the previous value. To address this, this patch opens
an new connection for apply cluster settings, and then creates the
connection pools for the workloads.

Fixes: #140411

Release note: None