### PR TITLE
(wip) raft/rafttest: add message limit to deliver-msgs command

### DIFF
--- a/pkg/raft/rafttest/interaction_env_handler.go
+++ b/pkg/raft/rafttest/interaction_env_handler.go
@@ -62,10 +62,12 @@ func (env *InteractionEnv) Handle(t *testing.T, d datadriven.TestData) string {
 		err = env.handleCompact(t, d)
 	case "deliver-msgs":
 		// Deliver the messages for a given recipient.
+		// Use count to specify total number of msgs to deliver.
+		// Not including count means to deliver all available msgs
 		//
 		// Example:
 		//
-		// deliver-msgs <idx> type=MsgApp drop=(2,3)
+		// deliver-msgs <idx> type=MsgApp count=1 drop=(2,3)
 		err = env.handleDeliverMsgs(t, d)
 	case "process-ready":
 		// Example:

--- a/pkg/raft/testdata/specify_num_msgs_to_deliver.txt
+++ b/pkg/raft/testdata/specify_num_msgs_to_deliver.txt
@@ -52,10 +52,24 @@ stabilize 1
   1->2 MsgApp Term:1 Log:1/13 Commit:11 Entries:[1/14 EntryNormal "prop_1_14"]
   1->3 MsgApp Term:1 Log:1/13 Commit:11 Entries:[1/14 EntryNormal "prop_1_14"]
 
-
-# Delivers all available msgs to node 2 with type MsgApp
-deliver-msgs type=MsgApp 2
+# Delivers "count" number msgs to node 2 with type MsgApp
+deliver-msgs type=MsgApp count=2 2
 ----
 1->2 MsgApp Term:1 Log:1/11 Commit:11 Entries:[1/12 EntryNormal "prop_1_12"]
 1->2 MsgApp Term:1 Log:1/12 Commit:11 Entries:[1/13 EntryNormal "prop_1_13"]
+
+# Delivers the reamining msg to node 2
+deliver-msgs type=MsgApp 2
+----
 1->2 MsgApp Term:1 Log:1/13 Commit:11 Entries:[1/14 EntryNormal "prop_1_14"]
+
+# Deliver 1 msg to node 3
+deliver-msgs type=MsgApp count=1 3
+----
+1->3 MsgApp Term:1 Log:1/11 Commit:11 Entries:[1/12 EntryNormal "prop_1_12"]
+
+# Delivers the reamining msgs to node 3
+deliver-msgs type=MsgApp 3
+----
+1->3 MsgApp Term:1 Log:1/12 Commit:11 Entries:[1/13 EntryNormal "prop_1_13"]
+1->3 MsgApp Term:1 Log:1/13 Commit:11 Entries:[1/14 EntryNormal "prop_1_14"]

--- a/pkg/raft/testdata/specify_num_msgs_to_deliver.txt
+++ b/pkg/raft/testdata/specify_num_msgs_to_deliver.txt
@@ -1,0 +1,61 @@
+# This test demonstrates how to specify the number of messages to deliver
+# when calling deliver-msgs
+
+# Turn off output during the setup of the test.
+log-level none
+----
+ok
+
+# Start with 3 nodes, with a limited in-flight capacity.
+add-nodes 3 voters=(1,2,3) index=10
+----
+ok
+
+campaign 1
+----
+ok
+
+stabilize
+----
+ok
+
+# Propose 3 entries.
+propose 1 prop_1_12
+----
+ok
+
+propose 1 prop_1_13
+----
+ok
+
+propose 1 prop_1_14
+----
+ok
+
+log-level debug
+----
+ok
+
+stabilize 1
+----
+> 1 handling Ready
+  Ready MustSync=true:
+  Entries:
+  1/12 EntryNormal "prop_1_12"
+  1/13 EntryNormal "prop_1_13"
+  1/14 EntryNormal "prop_1_14"
+  Messages:
+  1->2 MsgApp Term:1 Log:1/11 Commit:11 Entries:[1/12 EntryNormal "prop_1_12"]
+  1->3 MsgApp Term:1 Log:1/11 Commit:11 Entries:[1/12 EntryNormal "prop_1_12"]
+  1->2 MsgApp Term:1 Log:1/12 Commit:11 Entries:[1/13 EntryNormal "prop_1_13"]
+  1->3 MsgApp Term:1 Log:1/12 Commit:11 Entries:[1/13 EntryNormal "prop_1_13"]
+  1->2 MsgApp Term:1 Log:1/13 Commit:11 Entries:[1/14 EntryNormal "prop_1_14"]
+  1->3 MsgApp Term:1 Log:1/13 Commit:11 Entries:[1/14 EntryNormal "prop_1_14"]
+
+
+# Delivers all available msgs to node 2 with type MsgApp
+deliver-msgs type=MsgApp 2
+----
+1->2 MsgApp Term:1 Log:1/11 Commit:11 Entries:[1/12 EntryNormal "prop_1_12"]
+1->2 MsgApp Term:1 Log:1/12 Commit:11 Entries:[1/13 EntryNormal "prop_1_13"]
+1->2 MsgApp Term:1 Log:1/13 Commit:11 Entries:[1/14 EntryNormal "prop_1_14"]


### PR DESCRIPTION
raft/rafttest: allow specifying number of msgs to deliver when using deliver-msgs in datadriven interaction tests
Previously, calling deliver-msgs in raft data driven tests means sending out all available messages to receiver node.
This behaviour is a bit coarse grained if we want to mimic specific raft scenarios.# Note: to disable this commit template, run: git config --global --add cockroachdb.disable-commit-template true
To address this, this change allows specifying the total messages to send out when calling deliver-msgs. This together with existing options to the deliver-msgs command will allow more fine grained operations in rafttests.

Epic: none

Release note: None