### PR TITLE
changefeedccl: remove backfill checkpoint handling from v21.2 

### DIFF
--- a/pkg/ccl/changefeedccl/alter_changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/alter_changefeed_stmt.go
@@ -836,6 +836,8 @@ func generateNewProgress(
 				//lint:ignore SA1019 deprecated usage
 				Checkpoint: &jobspb.ChangefeedProgress_Checkpoint{
 					Spans: mergedSpanGroup.Slice(),
+					// TODO(reason through this)
+					Timestamp: changefeedProgress.Checkpoint.Timestamp,
 				},
 				ProtectedTimestampRecord: ptsRecord,
 			},


### PR DESCRIPTION
Previously, changefeed only has span-level checkpoints during backfills, and no
checkpoint timestamp was stored since it could be inferred from the highwater
mark. This code was maintained for compatibility with v21.2, but it is now
obsolete. This patch removes it to improve code clarity.

Release note: none
Epic: none