### PR TITLE
cdctest: disable isolation change stmts from sqlsmith

### DIFF
--- a/pkg/ccl/changefeedccl/cdctest/nemeses.go
+++ b/pkg/ccl/changefeedccl/cdctest/nemeses.go
@@ -403,6 +403,9 @@ func RunNemesis(
 			// queries that could hang decreases.
 			sqlsmith.DisableCrossJoins(),
 			sqlsmith.SimpleDatums(),
+			// We rely on cluster_logical_timestamp() builtin which is only
+			// supported under the serializable isolation.
+			sqlsmith.DisableIsolationChange(),
 		)
 		defer queryGen.Close()
 		const numInserts = 100

--- a/pkg/internal/sqlsmith/relational.go
+++ b/pkg/internal/sqlsmith/relational.go
@@ -1528,6 +1528,9 @@ func makeRollback(s *Smither) (tree.Statement, bool) {
 }
 
 func makeSetSessionCharacteristics(s *Smither) (tree.Statement, bool) {
+	if s.disableIsolationChange {
+		return nil, false
+	}
 	modes, _ := makeTransactionModes(s)
 	return &tree.SetSessionCharacteristics{Modes: modes}, true
 }

--- a/pkg/internal/sqlsmith/sqlsmith.go
+++ b/pkg/internal/sqlsmith/sqlsmith.go
@@ -118,7 +118,8 @@ type Smither struct {
 	// disableUDFCreation indicates whether we're not allowed to create UDFs.
 	// It follows that if we haven't created any UDFs, we have no UDFs to invoke
 	// too.
-	disableUDFCreation bool
+	disableUDFCreation     bool
+	disableIsolationChange bool
 
 	bulkSrv     *httptest.Server
 	bulkFiles   map[string][]byte
@@ -598,6 +599,12 @@ var DisableOIDs = simpleOption("disable OIDs", func(s *Smither) {
 // DisableUDFs causes the Smither to disable user-defined functions.
 var DisableUDFs = simpleOption("disable udfs", func(s *Smither) {
 	s.disableUDFCreation = true
+})
+
+// DisableIsolationChange causes the Smither to disable stmts that modify the
+// txn isolation level.
+var DisableIsolationChange = simpleOption("disable isolation change", func(s *Smither) {
+	s.disableIsolationChange = true
 })
 
 // CompareMode causes the Smither to generate statements that have


### PR DESCRIPTION
CDC test nemesis relies on `cluster_logical_timestamp()` builtin which is only supported under the serializable isolation, so this commit opts out of the recently added ability of sqlsmith to generate stmts that modify the txn isolation level.

Informs: #140355.
Epic: None
Release note: None