### PR TITLE
sqlsmith: avoid unparseable SET SESSION CHARACTERISTICS

### DIFF
--- a/pkg/internal/sqlsmith/relational.go
+++ b/pkg/internal/sqlsmith/relational.go
@@ -1471,7 +1471,7 @@ func makeInsert(s *Smither) (tree.Statement, bool) {
 	return stmt, ok
 }
 
-func makeTransactionModes(s *Smither) (tree.TransactionModes, bool) {
+func makeTransactionModes(s *Smither) tree.TransactionModes {
 	levels := []tree.IsolationLevel{
 		tree.UnspecifiedIsolation,
 		tree.ReadUncommittedIsolation,
@@ -1480,12 +1480,11 @@ func makeTransactionModes(s *Smither) (tree.TransactionModes, bool) {
 		tree.SnapshotIsolation,
 		tree.SerializableIsolation,
 	}
-	modes := tree.TransactionModes{Isolation: levels[s.rnd.Intn(len(levels))]}
-	return modes, true
+	return tree.TransactionModes{Isolation: levels[s.rnd.Intn(len(levels))]}
 }
 
 func makeBegin(s *Smither) (tree.Statement, bool) {
-	modes, _ := makeTransactionModes(s)
+	modes := makeTransactionModes(s)
 	return &tree.BeginTransaction{Modes: modes}, true
 }
 
@@ -1531,7 +1530,14 @@ func makeSetSessionCharacteristics(s *Smither) (tree.Statement, bool) {
 	if s.disableIsolationChange {
 		return nil, false
 	}
-	modes, _ := makeTransactionModes(s)
+	modes := makeTransactionModes(s)
+	fmtCtx := tree.NewFmtCtx(tree.FmtSimple)
+	modes.Format(fmtCtx)
+	if fmtCtx.String() == "" {
+		// If no options are specified, then we would get an invalid SET SESSION
+		// CHARACTERISTICS statement.
+		return nil, false
+	}
 	return &tree.SetSessionCharacteristics{Modes: modes}, true
 }
 


### PR DESCRIPTION
After a recent change to modify the txn isolation level, if we happen to pick "unspecified" level, then SET SESSION CHARACTERISTICS stmt would be unparseable.

Fixes: #140406.

Release note: None