### PR TITLE
sqlccl: increase test package timeout from 5 min to 15 min

### DIFF
--- a/pkg/ccl/testccl/sqlccl/BUILD.bazel
+++ b/pkg/ccl/testccl/sqlccl/BUILD.bazel
@@ -2,6 +2,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_test")
 
 go_test(
     name = "sqlccl_test",
+    size = "large",
     srcs = [
         "explain_test.go",
         "gc_job_test.go",


### PR DESCRIPTION
We've seen `TestExplainRedactDDL` time out 3 times not under duress, with shared process multi-tenancy, without any clear signs of the problems (other than slowness). Let's bump the timeout for the package, and if that doesn't work, we could consider disabling the test under multi-tenancy.

Fixes: #140253.

Release note: None