### PR TITLE
sql: add schema support for vector indexing in CREATE INDEX

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning_index
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning_index
@@ -180,6 +180,49 @@ inverted  CREATE TABLE public.inverted (
 )
 -- Warning: Partitioned table with no zone configurations.
 
+# TODO(andyk): Add more partitioning tests once insertion is supported.
+subtest vector
+
+statement ok
+CREATE TABLE vector (
+    a INT PRIMARY KEY, b INT, v VECTOR(3),
+    VECTOR INDEX (b, v) PARTITION BY LIST (b) (
+        PARTITION p1 VALUES IN (1),
+        PARTITION pu VALUES IN (NULL)
+    ),
+    FAMILY "primary" (a, b, v)
+)
+
+statement ok
+CREATE VECTOR INDEX vector_idx ON vector (a, b, v) PARTITION BY LIST (a, b) (
+    PARTITION p1 VALUES IN ((1, 1), (2, 2))
+)
+
+query TT
+SHOW CREATE TABLE vector
+----
+"vector"  CREATE TABLE public."vector" (
+            a INT8 NOT NULL,
+            b INT8 NULL,
+            v VECTOR(3) NULL,
+            CONSTRAINT vector_pkey PRIMARY KEY (a ASC),
+            VECTOR INDEX vector_b_v_idx (b ASC, v) PARTITION BY LIST (b) (
+              PARTITION p1 VALUES IN ((1)),
+              PARTITION pu VALUES IN ((NULL))
+            ),
+            VECTOR INDEX vector_idx (a ASC, b ASC, v) PARTITION BY LIST (a, b) (
+              PARTITION p1 VALUES IN ((1, 1), (2, 2))
+            )
+          )
+          -- Warning: Partitioned table with no zone configurations.
+
+# Partitioning by vector column is not supported b/c the data type does not have
+# a linear ordering.
+statement error partitioning by vector column \(v\) not supported
+CREATE VECTOR INDEX vector_idx2 ON vector (v) PARTITION BY LIST (v) (
+    PARTITION p1 VALUES IN ('[1,2,3]')
+)
+
 # Regression test for #60019. The index predicate should be formatted after the
 # PARTITION BY clause to match the syntax that is accepted.
 statement ok

--- a/pkg/ccl/logictestccl/testdata/logic_test/vector
+++ b/pkg/ccl/logictestccl/testdata/logic_test/vector
@@ -174,19 +174,3 @@ ORDER BY
 	tab_1270.tableoid
 LIMIT
 	83:::INT8;
-
-subtest vector_index
-
-statement ok
-CREATE TABLE t_vec (k INT PRIMARY KEY, v VECTOR(128));
-
-statement error pgcode 0A000 pq: unimplemented: VECTOR indexes are not yet supported
-CREATE VECTOR INDEX ON t_vec (v);
-
-statement error pgcode 0A000 pq: unimplemented: VECTOR indexes are not yet supported
-CREATE INDEX ON t_vec USING CSPANN (v);
-
-statement ok
-DROP TABLE t_vec;
-
-subtest end

--- a/pkg/ccl/schemachangerccl/testdata/decomp/multiregion
+++ b/pkg/ccl/schemachangerccl/testdata/decomp/multiregion
@@ -458,6 +458,7 @@ ElementState:
     tableId: 110
     temporaryIndexId: 0
     type: FORWARD
+    vecConfig: null
   Status: PUBLIC
 - SchemaChild:
     childObjectId: 110
@@ -854,6 +855,7 @@ ElementState:
     tableId: 109
     temporaryIndexId: 0
     type: FORWARD
+    vecConfig: null
   Status: PUBLIC
 - SchemaChild:
     childObjectId: 109
@@ -1484,6 +1486,7 @@ ElementState:
     tableId: 108
     temporaryIndexId: 0
     type: FORWARD
+    vecConfig: null
   Status: PUBLIC
 - SchemaChild:
     childObjectId: 108

--- a/pkg/ccl/schemachangerccl/testdata/decomp/partitioning
+++ b/pkg/ccl/schemachangerccl/testdata/decomp/partitioning
@@ -507,6 +507,7 @@ ElementState:
     tableId: 104
     temporaryIndexId: 0
     type: FORWARD
+    vecConfig: null
   Status: PUBLIC
 - SchemaChild:
     childObjectId: 104
@@ -529,6 +530,7 @@ ElementState:
     tableId: 104
     temporaryIndexId: 0
     type: INVERTED
+    vecConfig: null
   Status: PUBLIC
 - Table:
     isTemporary: false
@@ -940,6 +942,7 @@ ElementState:
     tableId: 105
     temporaryIndexId: 0
     type: FORWARD
+    vecConfig: null
   Status: PUBLIC
 - SchemaChild:
     childObjectId: 105
@@ -962,6 +965,7 @@ ElementState:
     tableId: 105
     temporaryIndexId: 0
     type: FORWARD
+    vecConfig: null
   Status: PUBLIC
 - Table:
     isTemporary: false

--- a/pkg/ccl/telemetryccl/testdata/telemetry/index
+++ b/pkg/ccl/telemetryccl/testdata/telemetry/index
@@ -2,6 +2,7 @@
 
 feature-list
 sql.schema.partitioned_inverted_index
+sql.schema.partitioned_vector_index
 ----
 
 feature-usage
@@ -9,13 +10,19 @@ CREATE TABLE a (
     a INT PRIMARY KEY,
     b INT,
     j JSON,
+    v VECTOR(3),
     INVERTED INDEX (b, j) PARTITION BY LIST (b) (
+        PARTITION p1 VALUES IN (1),
+        PARTITION pu VALUES IN (NULL)
+    ),
+    VECTOR INDEX (b, v) PARTITION BY LIST (b) (
         PARTITION p1 VALUES IN (1),
         PARTITION pu VALUES IN (NULL)
     )
 )
 ----
 sql.schema.partitioned_inverted_index
+sql.schema.partitioned_vector_index
 
 feature-usage
 CREATE INVERTED INDEX i ON a (b, j) PARTITION BY LIST (b) (
@@ -23,6 +30,13 @@ CREATE INVERTED INDEX i ON a (b, j) PARTITION BY LIST (b) (
 )
 ----
 sql.schema.partitioned_inverted_index
+
+feature-usage
+CREATE VECTOR INDEX i2 ON a (b, v) PARTITION BY LIST (b) (
+    PARTITION p1 VALUES IN (1)
+)
+----
+sql.schema.partitioned_vector_index
 
 exec
 CREATE DATABASE multi_region_test_db PRIMARY REGION "ca-central-1" REGIONS "ap-southeast-2", "us-east-1" SURVIVE REGION FAILURE;

--- a/pkg/sql/alter_primary_key.go
+++ b/pkg/sql/alter_primary_key.go
@@ -370,7 +370,8 @@ func (p *planner) AlterPrimaryKey(
 	}
 
 	// We have to rewrite all indexes that either:
-	// * depend on uniqueness from the old primary key (inverted, non-unique, or unique with nulls).
+	// * depend on uniqueness from the old primary key (inverted, vector,
+	//   non-unique, or unique with nulls).
 	// * don't store or index all columns in the new primary key.
 	// * is affected by a locality config swap.
 	shouldRewriteIndex := func(idx catalog.Index) (bool, error) {
@@ -434,7 +435,9 @@ func (p *planner) AlterPrimaryKey(
 			return true, nil
 		}
 
-		return !idx.IsUnique() || idx.GetType() == idxtype.INVERTED, nil
+		return !idx.IsUnique() ||
+			idx.GetType() == idxtype.INVERTED ||
+			idx.GetType() == idxtype.VECTOR, nil
 	}
 	var indexesToRewrite []catalog.Index
 	for _, idx := range tableDesc.PublicNonPrimaryIndexes() {
@@ -811,6 +814,7 @@ func setKeySuffixAndStoredColumnIDsFromPrimary(
 	// which have not already been in the key columns in the secondary index.
 	toAdd.KeySuffixColumnIDs = nil
 	invIdx := toAdd.Type == idxtype.INVERTED
+	vecIdx := toAdd.Type == idxtype.VECTOR
 	for _, colID := range primary.KeyColumnIDs {
 		if !idxColIDs.Contains(colID) {
 			toAdd.KeySuffixColumnIDs = append(toAdd.KeySuffixColumnIDs, colID)
@@ -832,6 +836,10 @@ func setKeySuffixAndStoredColumnIDsFromPrimary(
 				"primary key column %s cannot be present in an inverted index",
 				col.GetName(),
 			)
+		} else if vecIdx && colID == toAdd.VectorColumnID() {
+			// VECTOR columns are not allowed in the primary key.
+			return errors.AssertionFailedf(
+				"indexed vector column cannot be part of the primary key")
 		}
 	}
 	// Finally, add all the stored columns if it is not already a key or key suffix column.

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -1471,6 +1471,11 @@ func (sc *SchemaChanger) validateIndexes(ctx context.Context) error {
 			forwardIndexes = append(forwardIndexes, idx)
 		case idxtype.INVERTED:
 			invertedIndexes = append(invertedIndexes, idx)
+		case idxtype.VECTOR:
+			// TODO(drewk): consider whether we can perform useful validation for
+			// vector indexes.
+		default:
+			return errors.AssertionFailedf("unknown index type %d", idx.GetType())
 		}
 	}
 	if len(forwardIndexes) == 0 && len(invertedIndexes) == 0 {

--- a/pkg/sql/catalog/colinfo/col_type_info.go
+++ b/pkg/sql/catalog/colinfo/col_type_info.go
@@ -125,7 +125,8 @@ func ValidateColumnDefType(ctx context.Context, st *cluster.Settings, t *types.T
 	return nil
 }
 
-// ColumnTypeIsIndexable returns whether the type t is valid as an indexed column.
+// ColumnTypeIsIndexable returns whether the type t is valid as an indexed
+// column in a regular FORWARD index.
 func ColumnTypeIsIndexable(t *types.T) bool {
 	// NB: .IsAmbiguous checks the content type of array types.
 	if t.IsAmbiguous() || t.Family() == types.TupleFamily || t.Family() == types.RefCursorFamily {

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -2400,8 +2400,14 @@ func NewTableDesc(
 		}
 		if idx.GetType() == idxtype.VECTOR {
 			telemetry.Inc(sqltelemetry.VectorIndexCounter)
+			if idx.IsPartial() {
+				telemetry.Inc(sqltelemetry.PartialVectorIndexCounter)
+			}
 			if idx.NumKeyColumns() > 1 {
 				telemetry.Inc(sqltelemetry.MultiColumnVectorIndexCounter)
+			}
+			if idx.PartitioningColumnCount() != 0 {
+				telemetry.Inc(sqltelemetry.PartitionedVectorIndexCounter)
 			}
 		}
 		if idx.IsPartial() {

--- a/pkg/sql/logictest/testdata/logic_test/create_index
+++ b/pkg/sql/logictest/testdata/logic_test/create_index
@@ -137,21 +137,25 @@ statement ok
 CREATE TABLE telemetry (
   x INT PRIMARY KEY,
   y INT,
-  z JSONB
+  z JSONB,
+  v VECTOR(3)
 )
 
 statement ok
 CREATE INVERTED INDEX ON telemetry (z);
+CREATE VECTOR INDEX ON telemetry (v);
 CREATE INDEX ON telemetry (y) USING HASH WITH (bucket_count=4)
 
 query T rowsort
 SELECT feature_name FROM crdb_internal.feature_usage
 WHERE feature_name IN (
   'sql.schema.inverted_index',
+  'sql.schema.vector_index',
   'sql.schema.hash_sharded_index'
 )
 ----
 sql.schema.inverted_index
+sql.schema.vector_index
 sql.schema.hash_sharded_index
 
 subtest create_index_concurrently

--- a/pkg/sql/logictest/testdata/logic_test/expression_index
+++ b/pkg/sql/logictest/testdata/logic_test/expression_index
@@ -5,11 +5,13 @@ CREATE TABLE t (
   b INT,
   c STRING,
   j JSON,
+  v VECTOR,
   comp INT AS (a + 10) VIRTUAL,
   INDEX t_a_plus_b_idx ((a + b)),
   INDEX t_lower_c_a_plus_b_idx (lower(c), (a + b)),
   INVERTED INDEX t_b_j_a_asc (b DESC, (j->'a') ASC),
-  FAMILY (k, a, b, c, j)
+  VECTOR INDEX t_vec (a DESC, (v::VECTOR(3))),
+  FAMILY (k, a, b, c, j, v)
 )
 
 query T
@@ -21,12 +23,14 @@ CREATE TABLE public.t (
   b INT8 NULL,
   c STRING NULL,
   j JSONB NULL,
+  v VECTOR NULL,
   comp INT8 NULL AS (a + 10:::INT8) VIRTUAL,
   CONSTRAINT t_pkey PRIMARY KEY (k ASC),
   INDEX t_a_plus_b_idx ((a + b) ASC),
   INDEX t_lower_c_a_plus_b_idx (lower(c) ASC, (a + b) ASC),
   INVERTED INDEX t_b_j_a_asc (b DESC, (j->'a':::STRING)),
-  FAMILY fam_0_k_a_b_c_j (k, a, b, c, j)
+  VECTOR INDEX t_vec (a DESC, (v::VECTOR(3))),
+  FAMILY fam_0_k_a_b_c_j_v (k, a, b, c, j, v)
 )
 
 query T
@@ -38,24 +42,27 @@ CREATE TABLE public.t (
   b INT8 NULL,
   c STRING NULL,
   j JSONB NULL,
+  v VECTOR NULL,
   comp INT8 NULL AS (a + ‹×›:::INT8) VIRTUAL,
   CONSTRAINT t_pkey PRIMARY KEY (k ASC),
   INDEX t_a_plus_b_idx ((a + b) ASC),
   INDEX t_lower_c_a_plus_b_idx (lower(c) ASC, (a + b) ASC),
   INVERTED INDEX t_b_j_a_asc (b DESC, (j->‹×›:::STRING)),
-  FAMILY fam_0_k_a_b_c_j (k, a, b, c, j)
+  VECTOR INDEX t_vec (a DESC, (v::VECTOR(3))),
+  FAMILY fam_0_k_a_b_c_j_v (k, a, b, c, j, v)
 )
 
 query TTBTTTB colnames
 SELECT * FROM [SHOW COLUMNS FROM t] ORDER BY column_name
 ----
-column_name  data_type  is_nullable  column_default  generation_expression  indices                                                     is_hidden
-a            INT8       true         NULL            ·                      {t_pkey}                                                    false
-b            INT8       true         NULL            ·                      {t_b_j_a_asc,t_pkey}                                        false
-c            STRING     true         NULL            ·                      {t_pkey}                                                    false
-comp         INT8       true         NULL            a + 10                 {}                                                          false
-j            JSONB      true         NULL            ·                      {t_pkey}                                                    false
-k            INT8       false        NULL            ·                      {t_a_plus_b_idx,t_b_j_a_asc,t_lower_c_a_plus_b_idx,t_pkey}  false
+column_name  data_type  is_nullable  column_default  generation_expression  indices                                                           is_hidden
+a            INT8       true         NULL            ·                      {t_pkey,t_vec}                                                    false
+b            INT8       true         NULL            ·                      {t_b_j_a_asc,t_pkey}                                              false
+c            STRING     true         NULL            ·                      {t_pkey}                                                          false
+comp         INT8       true         NULL            a + 10                 {}                                                                false
+j            JSONB      true         NULL            ·                      {t_pkey}                                                          false
+k            INT8       false        NULL            ·                      {t_a_plus_b_idx,t_b_j_a_asc,t_lower_c_a_plus_b_idx,t_pkey,t_vec}  false
+v            VECTOR     true         NULL            ·                      {t_pkey}                                                          false
 
 # Referencing an inaccessible column in a CHECK constraint is not allowed.
 statement error column \"crdb_internal_idx_expr\" is inaccessible and cannot be referenced
@@ -111,17 +118,32 @@ CREATE TABLE err (a INT, INDEX (a, (NULL)))
 statement ok
 CREATE TABLE t_null_cast (a INT, INDEX (a, (NULL::TEXT)))
 
-statement error index element \(a, b\) of type record is not indexable
+statement error column \(\(a, b\)\) has type record, which is not indexable
 CREATE TABLE err (a INT, b INT, INDEX (a, (row(a, b))))
 
-statement error index element a \+ b of type int is not allowed as the last column in an inverted index.*\nHINT: see the documentation for more information about inverted indexes: https://www.cockroachlabs.com/docs/.*/inverted-indexes.html
+statement error column \(a \+ b\) has type int, which is not allowed as the last column in an inverted index.*\nHINT: see the documentation for more information about inverted indexes: https://www.cockroachlabs.com/docs/.*/inverted-indexes.html
 CREATE TABLE err (a INT, b INT, INVERTED INDEX (a, (a + b)))
 
-statement error index element \(a, b\) of type record is not allowed as the last column in an inverted index.*\nHINT: see the documentation for more information about inverted indexes: https://www.cockroachlabs.com/docs/.*/inverted-indexes.html
+statement error column \(\(a, b\)\) has type record, which is not allowed as the last column in an inverted index.*\nHINT: see the documentation for more information about inverted indexes: https://www.cockroachlabs.com/docs/.*/inverted-indexes.html
 CREATE TABLE err (a INT, b INT, INVERTED INDEX (a, (row(a, b))))
 
 statement error the last column in an inverted index cannot have the DESC option
 CREATE TABLE err (a INT, j JSON, INVERTED INDEX (a, (j->'a') DESC))
+
+statement error column \(a \+ b\) has type int, which is not allowed as the last column in a vector index
+CREATE TABLE err (a INT, b INT, VECTOR INDEX (a, (a + b)))
+
+statement error column \(vec1::VECTOR\(3\)\) has type vector, which is only allowed as the last column in a vector index
+CREATE TABLE err (a INT, vec1 VECTOR, VECTOR INDEX ((vec1::VECTOR(3)), a))
+
+statement error the last column in a vector index cannot have the DESC option
+CREATE TABLE err (a INT, vec1 VECTOR, VECTOR INDEX (a, (vec1::VECTOR(3)) DESC))
+
+statement error vector column \(vec1::VECTOR\) does not have a fixed number of dimensions, so it cannot be indexed\nDETAIL: specify the number of dimensions in the type, like VECTOR\(128\) for 128 dimensions
+CREATE TABLE err (a INT, vec1 VECTOR(3), VECTOR INDEX (a, (vec1::VECTOR)))
+
+statement error column \(vec1::VECTOR\(3\)\) has type vector, which is not indexable in a non-vector index\nHINT: you may want to create a vector index instead
+CREATE TABLE err (a INT, vec1 VECTOR, INDEX (a, (vec1::VECTOR(3))))
 
 statement error random\(\): volatile functions are not allowed in EXPRESSION INDEX ELEMENT
 CREATE TABLE err (a INT, INDEX ((a + random()::INT)))
@@ -154,8 +176,9 @@ CREATE TABLE t (
   b INT,
   c STRING,
   j JSON,
+  v VECTOR NULL,
   comp INT AS (a + 10) VIRTUAL,
-  FAMILY (k, a, b, c, j)
+  FAMILY (k, a, b, c, j, v)
 )
 
 statement ok
@@ -182,13 +205,14 @@ CREATE TABLE public.t (
   b INT8 NULL,
   c STRING NULL,
   j JSONB NULL,
+  v VECTOR NULL,
   comp INT8 NULL AS (a + 10:::INT8) VIRTUAL,
   CONSTRAINT t_pkey PRIMARY KEY (k ASC),
   INDEX t_a_plus_b_idx ((a + b) ASC),
   INDEX t_lower_c_idx (lower(c) ASC),
   INDEX t_lower_c_a_plus_b_idx (lower(c) ASC, (a + b) ASC),
   INDEX t_a_plus_ten_idx ((a + 10:::INT8) ASC),
-  FAMILY fam_0_k_a_b_c_j (k, a, b, c, j)
+  FAMILY fam_0_k_a_b_c_j_v (k, a, b, c, j, v)
 )
 
 # Referencing an inaccessible column in a CHECK constraint is not allowed.
@@ -256,7 +280,7 @@ SELECT * FROM (
   ) AS desc FROM system.descriptor WHERE id = 't'::REGCLASS
 ) AS cols WHERE cols.desc->'name' = '"crdb_internal_idx_expr_2"'
 ----
-{"computeExpr": "a + 10:::INT8", "id": 9, "inaccessible": true, "name": "crdb_internal_idx_expr_2", "nullable": true, "type": {"family": "IntFamily", "oid": 20, "width": 64}, "virtual": true}
+{"computeExpr": "a + 10:::INT8", "id": 10, "inaccessible": true, "name": "crdb_internal_idx_expr_2", "nullable": true, "type": {"family": "IntFamily", "oid": 20, "width": 64}, "virtual": true}
 
 skipif config local-legacy-schema-changer
 query T
@@ -266,7 +290,7 @@ SELECT * FROM (
   ) AS desc FROM system.descriptor WHERE id = 't'::REGCLASS
 ) AS cols WHERE cols.desc->'name' = '"crdb_internal_idx_expr_2"'
 ----
-{"computeExpr": "a + 10:::INT8", "id": 9, "inaccessible": true, "name": "crdb_internal_idx_expr_2", "nullable": true, "type": {"family": "IntFamily", "oid": 20, "width": 64}, "virtual": true}
+{"computeExpr": "a + 10:::INT8", "id": 10, "inaccessible": true, "name": "crdb_internal_idx_expr_2", "nullable": true, "type": {"family": "IntFamily", "oid": 20, "width": 64}, "virtual": true}
 
 statement ok
 DROP INDEX t_lower_c_a_plus_b_idx
@@ -283,8 +307,8 @@ SELECT cols.desc FROM (
 ) AS cols WHERE cols.desc->>'name' IN ('crdb_internal_idx_expr', 'crdb_internal_idx_expr_1')
 ORDER BY id
 ----
-{"computeExpr": "a + b", "id": 7, "inaccessible": true, "name": "crdb_internal_idx_expr", "nullable": true, "type": {"family": "IntFamily", "oid": 20, "width": 64}, "virtual": true}
-{"computeExpr": "lower(c)", "id": 8, "inaccessible": true, "name": "crdb_internal_idx_expr_1", "nullable": true, "type": {"family": "StringFamily", "oid": 25}, "virtual": true}
+{"computeExpr": "a + b", "id": 8, "inaccessible": true, "name": "crdb_internal_idx_expr", "nullable": true, "type": {"family": "IntFamily", "oid": 20, "width": 64}, "virtual": true}
+{"computeExpr": "lower(c)", "id": 9, "inaccessible": true, "name": "crdb_internal_idx_expr_1", "nullable": true, "type": {"family": "StringFamily", "oid": 25}, "virtual": true}
 
 onlyif config local-legacy-schema-changer
 query T
@@ -295,8 +319,8 @@ SELECT cols.desc FROM (
 ) AS cols WHERE cols.desc->>'name' IN ('crdb_internal_idx_expr', 'crdb_internal_idx_expr_1')
 ORDER BY id
 ----
-{"computeExpr": "a + b", "id": 7, "inaccessible": true, "name": "crdb_internal_idx_expr", "nullable": true, "type": {"family": "IntFamily", "oid": 20, "width": 64}, "virtual": true}
-{"computeExpr": "lower(c)", "id": 8, "inaccessible": true, "name": "crdb_internal_idx_expr_1", "nullable": true, "type": {"family": "StringFamily", "oid": 25}, "virtual": true}
+{"computeExpr": "a + b", "id": 8, "inaccessible": true, "name": "crdb_internal_idx_expr", "nullable": true, "type": {"family": "IntFamily", "oid": 20, "width": 64}, "virtual": true}
+{"computeExpr": "lower(c)", "id": 9, "inaccessible": true, "name": "crdb_internal_idx_expr_1", "nullable": true, "type": {"family": "StringFamily", "oid": 25}, "virtual": true}
 
 statement ok
 DROP INDEX t_a_plus_b_idx
@@ -340,7 +364,7 @@ CREATE INDEX err ON t (a, (j->'a'));
 statement ok
 DROP INDEX err
 
-statement error index element \(a, b\) of type record is not indexable
+statement error column \(\(a, b\)\) has type record, which is not indexable
 CREATE INDEX err ON t (a, (row(a, b)));
 
 statement ok
@@ -349,10 +373,10 @@ CREATE INVERTED INDEX err ON t ((j->'a'), j);
 statement ok
 DROP INDEX err
 
-statement error index element a \+ b of type int is not allowed as the last column in an inverted index.*\nHINT: see the documentation for more information about inverted indexes: https://www.cockroachlabs.com/docs/.*/inverted-indexes.html
+statement error column \(a \+ b\) has type int, which is not allowed as the last column in an inverted index.*\nHINT: see the documentation for more information about inverted indexes: https://www.cockroachlabs.com/docs/.*/inverted-indexes.html
 CREATE INVERTED INDEX err ON t (a, (a + b));
 
-statement error index element \(a, b\) of type record is not allowed as the last column in an inverted index.*\nHINT: see the documentation for more information about inverted indexes: https://www.cockroachlabs.com/docs/.*/inverted-indexes.html
+statement error column \(\(a, b\)\) has type record, which is not allowed as the last column in an inverted index.*\nHINT: see the documentation for more information about inverted indexes: https://www.cockroachlabs.com/docs/.*/inverted-indexes.html
 CREATE INVERTED INDEX err ON t (a, (row(a, b)));
 
 statement error the last column in an inverted index cannot have the DESC option
@@ -360,6 +384,27 @@ CREATE INVERTED INDEX err ON t (a, (j->'a') DESC);
 
 statement ok
 CREATE INVERTED INDEX ON t (a, (j->'a') ASC);
+
+statement ok
+CREATE VECTOR INDEX err ON t (b, (v::VECTOR(3)));
+
+statement ok
+DROP INDEX err
+
+statement error column \(a \+ b\) has type int, which is not allowed as the last column in a vector index
+CREATE VECTOR INDEX err ON t (a, (a + b))
+
+statement error column \(v::VECTOR\(3\)\) has type vector, which is only allowed as the last column in a vector index
+CREATE VECTOR INDEX err ON t ((v::VECTOR(3)), a)
+
+statement error the last column in a vector index cannot have the DESC option
+CREATE VECTOR INDEX err ON t (a, (v::VECTOR(3)) DESC)
+
+statement error vector column \(v::VECTOR\) does not have a fixed number of dimensions, so it cannot be indexed\nDETAIL: specify the number of dimensions in the type, like VECTOR\(128\) for 128 dimensions
+CREATE VECTOR INDEX err ON t (a, (v::VECTOR))
+
+statement error column \(v::VECTOR\(3\)\) has type vector, which is not indexable in a non-vector index\nHINT: you may want to create a vector index instead
+CREATE INDEX err ON t (a, (v::VECTOR(3)))
 
 statement ok
 CREATE TABLE other (
@@ -405,11 +450,13 @@ CREATE TABLE src (
   a INT,
   b INT,
   j JSON,
+  v VECTOR,
   comp INT8 AS (1 + 10) VIRTUAL,
   INDEX ((a + b)),
   INDEX named_idx ((a + 1)),
   UNIQUE INDEX ((a + 10)),
-  INVERTED INDEX ((a + b), (j->'a'))
+  INVERTED INDEX ((a + b), (j->'a')),
+  VECTOR INDEX (b, (v::VECTOR(3)))
 );
 CREATE TABLE copy (LIKE src);
 CREATE TABLE copy_generated (LIKE src INCLUDING GENERATED);
@@ -424,6 +471,7 @@ CREATE TABLE public.copy (
   a INT8 NULL,
   b INT8 NULL,
   j JSONB NULL,
+  v VECTOR NULL,
   comp INT8 NULL,
   rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
   CONSTRAINT copy_pkey PRIMARY KEY (rowid ASC)
@@ -448,6 +496,7 @@ CREATE TABLE public.copy_generated (
   a INT8 NULL,
   b INT8 NULL,
   j JSONB NULL,
+  v VECTOR NULL,
   comp INT8 NULL AS (1:::INT8 + 10:::INT8) VIRTUAL,
   rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
   CONSTRAINT copy_generated_pkey PRIMARY KEY (rowid ASC)
@@ -472,12 +521,14 @@ CREATE TABLE public.copy_indexes (
   a INT8 NULL,
   b INT8 NULL,
   j JSONB NULL,
+  v VECTOR NULL,
   comp INT8 NULL,
   CONSTRAINT src_pkey PRIMARY KEY (k ASC),
   INDEX src_expr_idx ((a + b) ASC),
   INDEX named_idx ((a + 1:::INT8) ASC),
   UNIQUE INDEX src_expr_key ((a + 10:::INT8) ASC),
-  INVERTED INDEX src_expr_expr1_idx ((a + b) ASC, (j->'a':::STRING))
+  INVERTED INDEX src_expr_expr1_idx ((a + b) ASC, (j->'a':::STRING)),
+  VECTOR INDEX src_b_expr_idx (b ASC, (v::VECTOR(3)))
 )
 
 # Inaccessible expression index columns should be copied if the indexes are
@@ -489,7 +540,7 @@ SELECT count(*) FROM (
   ) AS desc FROM system.descriptor WHERE id = 'copy_indexes'::REGCLASS
 ) AS cols WHERE cols.desc->>'name' LIKE 'crdb_internal_idx_expr%'
 ----
-4
+5
 
 query T
 SELECT create_statement FROM [SHOW CREATE TABLE copy_all]
@@ -499,12 +550,14 @@ CREATE TABLE public.copy_all (
   a INT8 NULL,
   b INT8 NULL,
   j JSONB NULL,
+  v VECTOR NULL,
   comp INT8 NULL AS (1:::INT8 + 10:::INT8) VIRTUAL,
   CONSTRAINT src_pkey PRIMARY KEY (k ASC),
   INDEX src_expr_idx ((a + b) ASC),
   INDEX named_idx ((a + 1:::INT8) ASC),
   UNIQUE INDEX src_expr_key ((a + 10:::INT8) ASC),
-  INVERTED INDEX src_expr_expr1_idx ((a + b) ASC, (j->'a':::STRING))
+  INVERTED INDEX src_expr_expr1_idx ((a + b) ASC, (j->'a':::STRING)),
+  VECTOR INDEX src_b_expr_idx (b ASC, (v::VECTOR(3)))
 )
 
 # Inaccessible expression index columns should be copied if the indexes are
@@ -516,7 +569,7 @@ SELECT count(*) FROM (
   ) AS desc FROM system.descriptor WHERE id = 'copy_all'::REGCLASS
 ) AS cols WHERE cols.desc->>'name' LIKE 'crdb_internal_idx_expr%'
 ----
-4
+5
 
 # Test anonymous index name generation.
 

--- a/pkg/sql/logictest/testdata/logic_test/geospatial
+++ b/pkg/sql/logictest/testdata/logic_test/geospatial
@@ -123,10 +123,10 @@ CREATE TABLE bad_geog_table(bad_pk geography primary key)
 statement error column bad_pk has type geometry, which is not indexable in a non-inverted index\nHINT: you may want to create an inverted index instead. See the documentation for inverted indexes: https://www.cockroachlabs.com/docs/dev/inverted-indexes.html
 CREATE TABLE bad_geom_table(bad_pk geometry primary key)
 
-statement error column geog has type geography, which is not indexable
+statement error column geog has type geography, which is not indexable in a non-inverted index\nHINT: you may want to create an inverted index instead. See the documentation for inverted indexes: https://www.cockroachlabs.com/docs/dev/inverted-indexes.html
 CREATE INDEX geog_idx ON geo_table(geog)
 
-statement error column geom has type geometry, which is not indexable
+statement error column geom has type geometry, which is not indexable in a non-inverted index\nHINT: you may want to create an inverted index instead. See the documentation for inverted indexes: https://www.cockroachlabs.com/docs/dev/inverted-indexes.html
 CREATE INDEX geom_idx ON geo_table(geom)
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/partial_index
+++ b/pkg/sql/logictest/testdata/logic_test/partial_index
@@ -1360,6 +1360,41 @@ SELECT * FROM prune@idx WHERE c > 0
 ----
 1  2  3  7
 
+# Vector partial indexes.
+# TODO(andyk): Need more tests once insertion is possible.
+subtest vector
+
+statement ok
+CREATE TABLE vec (id INT PRIMARY KEY, v VECTOR(3), VECTOR INDEX (id, v) WHERE id > 0);
+DROP TABLE vec;
+
+statement ok
+CREATE TABLE vec (
+  id INT PRIMARY KEY,
+  v VECTOR(3),
+  VECTOR INDEX (id, v) WHERE v <-> '[3,1,2]' < 1,
+  FAMILY (id, v)
+);
+
+query TT
+SHOW CREATE TABLE vec
+----
+vec  CREATE TABLE public.vec (
+       id INT8 NOT NULL,
+       v VECTOR(3) NULL,
+       CONSTRAINT vec_pkey PRIMARY KEY (id ASC),
+       VECTOR INDEX vec_id_v_idx (id ASC, v) WHERE (v <-> '[3,1,2]':::VECTOR) < 1.0:::FLOAT8,
+       FAMILY fam_0_id_v (id, v)
+     )
+
+statement ok
+DROP TABLE vec;
+
+statement ok
+CREATE TABLE vec (id INT PRIMARY KEY, s STRING, v VECTOR(3));
+CREATE VECTOR INDEX ON vec (v) WHERE s IN ('foo', 'bar');
+DROP TABLE vec;
+
 # Tests for partial indexes with predicates that reference virtual computed
 # columns.
 subtest virtual

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -4062,6 +4062,32 @@ geospatial_table_pkey  CREATE UNIQUE INDEX geospatial_table_pkey ON test.public.
 idxa                   CREATE INDEX idxa ON test.public.geospatial_table USING gin (a)
 idxb                   CREATE INDEX idxb ON test.public.geospatial_table USING gin (b)
 
+subtest vector
+
+statement ok
+SET DATABASE = test
+
+statement ok
+CREATE TABLE vector_table (
+  id UUID PRIMARY KEY,
+  a vector(3),
+  VECTOR INDEX idxa (a)
+)
+
+statement ok
+CREATE VECTOR INDEX idxb ON vector_table (a)
+
+query TT colnames
+SELECT indexname, indexdef
+FROM pg_catalog.pg_indexes
+WHERE tablename = 'vector_table'
+ORDER BY indexname
+----
+indexname          indexdef
+idxa               CREATE INDEX idxa ON test.public.vector_table USING cspann (a)
+idxb               CREATE INDEX idxb ON test.public.vector_table USING cspann (a)
+vector_table_pkey  CREATE UNIQUE INDEX vector_table_pkey ON test.public.vector_table USING btree (id ASC)
+
 subtest partial_index
 
 statement ok
@@ -4135,13 +4161,13 @@ CREATE TABLE jt (a INT PRIMARY KEY); INSERT INTO jt VALUES(1); INSERT INTO jt VA
 query ITT
 SELECT a, oid, relname FROM jt INNER LOOKUP JOIN pg_class ON a::oid=oid
 ----
-173  173  jt
+174  174  jt
 
 query ITT rowsort
 SELECT a, oid, relname FROM jt LEFT OUTER LOOKUP JOIN pg_class ON a::oid=oid
 ----
 1    NULL  NULL
-173  173   jt
+174  174   jt
 
 subtest regression_49207
 statement ok
@@ -4800,7 +4826,7 @@ JOIN pg_class ON pg_statistic_ext.stxrelid = pg_class.oid
 ----
 relname  stxname  stxnamespace  stxowner  stxstattarget  stxkeys  stxkind
 stxtbl   stxobj   105           NULL      -1             {2,3}    {d}
-stxtbl2  stxobj2  195           NULL      -1             {1,3}    {d}
+stxtbl2  stxobj2  196           NULL      -1             {1,3}    {d}
 stx      NULL     105           NULL      -1             {2}      {d}
 stx      NULL     105           NULL      -1             {1}      {d}
 
@@ -5316,7 +5342,7 @@ query TO colnames,rowsort
 SELECT typname, typrelid FROM pg_catalog.pg_type WHERE typrelid = 'u'::regtype::oid;
 ----
 typname  typrelid
-u        100207
+u        100208
 
 query TOO colnames,rowsort
 SELECT typname, typrelid, typarray FROM pg_catalog.pg_type WHERE oid = 'u[]'::regtype::oid;

--- a/pkg/sql/logictest/testdata/logic_test/vector_index
+++ b/pkg/sql/logictest/testdata/logic_test/vector_index
@@ -1,5 +1,5 @@
 # ------------------------------------------------------------------------------
-# CREATE TABLE tests.
+# CREATE TABLE/INDEX tests.
 # ------------------------------------------------------------------------------
 
 # Simple vector index.
@@ -11,6 +11,13 @@ CREATE TABLE simple (
   FAMILY (a, vec1)
 )
 
+statement ok
+CREATE VECTOR INDEX ON simple (vec1)
+
+# Alternate syntax.
+statement ok
+CREATE INDEX ON simple USING cspann (vec1 ASC);
+
 query TT
 SHOW CREATE TABLE simple
 ----
@@ -19,20 +26,34 @@ simple  CREATE TABLE public.simple (
           vec1 VECTOR(3) NULL,
           CONSTRAINT simple_pkey PRIMARY KEY (a ASC),
           VECTOR INDEX simple_vec1_idx (vec1),
+          VECTOR INDEX simple_vec1_idx1 (vec1),
+          VECTOR INDEX simple_vec1_idx2 (vec1),
           FAMILY fam_0_a_vec1 (a, vec1)
         )
 
 statement ok
 SHOW INDEX FROM simple
 
+statement ok
+DROP INDEX simple@simple_vec1_idx
+
+statement ok
+DROP INDEX simple_vec1_idx2
+
+statement ok
+DROP TABLE simple
+
 # Specify name for index.
 statement ok
 CREATE TABLE alt_syntax (
   a INT PRIMARY KEY,
   vec1 VECTOR(3),
-  VECTOR INDEX vec_idx (vec1),
+  VECTOR INDEX vec_idx (vec1 ASC),
   FAMILY (a, vec1)
 )
+
+statement ok
+CREATE VECTOR INDEX another_index ON alt_syntax (vec1)
 
 query TT
 SHOW CREATE TABLE alt_syntax
@@ -42,10 +63,14 @@ alt_syntax  CREATE TABLE public.alt_syntax (
               vec1 VECTOR(3) NULL,
               CONSTRAINT alt_syntax_pkey PRIMARY KEY (a ASC),
               VECTOR INDEX vec_idx (vec1),
+              VECTOR INDEX another_index (vec1),
               FAMILY fam_0_a_vec1 (a, vec1)
             )
 
-# Multiple vector indexes on same table.
+statement ok
+DROP TABLE alt_syntax
+
+# Multiple vector indexes declared on same table.
 statement ok
 CREATE TABLE multiple_indexes (
   a INT PRIMARY KEY,
@@ -69,6 +94,15 @@ multiple_indexes  CREATE TABLE public.multiple_indexes (
                     FAMILY fam_0_a_vec1_vec2 (a, vec1, vec2)
                   )
 
+statement ok
+DROP INDEX multiple_indexes_vec1_idx;
+
+statement ok
+DROP INDEX multiple_indexes_vec2_idx;
+
+statement ok
+DROP TABLE multiple_indexes
+
 # Use prefix columns in the vector index.
 statement ok
 CREATE TABLE prefix_cols (
@@ -80,6 +114,9 @@ CREATE TABLE prefix_cols (
   FAMILY (a, b, c, vec1)
 )
 
+statement ok
+CREATE VECTOR INDEX another_index ON prefix_cols (b, c DESC, vec1)
+
 query TT
 SHOW CREATE TABLE prefix_cols
 ----
@@ -90,8 +127,12 @@ prefix_cols  CREATE TABLE public.prefix_cols (
                vec1 VECTOR(3) NULL,
                CONSTRAINT prefix_cols_pkey PRIMARY KEY (a ASC),
                VECTOR INDEX prefix_cols_c_b_vec1_idx (c DESC, b ASC, vec1),
+               VECTOR INDEX another_index (b ASC, c DESC, vec1),
                FAMILY fam_0_a_b_c_vec1 (a, b, c, vec1)
              )
+
+statement ok
+DROP TABLE prefix_cols
 
 # Use mixed-case column for vector index.
 statement ok
@@ -100,6 +141,14 @@ CREATE TABLE mixed_case (
   qUuX VECTOR(3),
   VECTOR INDEX (qUuX)
 )
+
+statement ok
+CREATE VECTOR INDEX ON mixed_case (qUuX)
+
+statement ok
+DROP TABLE mixed_case
+
+# ----- CREATE TABLE errors -----
 
 # Try to use vector in primary key.
 statement error column a has type vector, which is not indexable in a non-vector index\nHINT: you may want to create a vector index instead
@@ -122,8 +171,92 @@ statement error vector column b does not have a fixed number of dimensions, so i
 CREATE TABLE t (a INT PRIMARY KEY, b VECTOR, VECTOR INDEX (b))
 
 # Try to use vector type in forward index.
-statement error pq: column c has type vector, which is not indexable in a non-vector index\nHINT: you may want to create a vector index instead
+statement error column c has type vector, which is not indexable in a non-vector index\nHINT: you may want to create a vector index instead
 CREATE TABLE t (a INT PRIMARY KEY, b INT, c VECTOR(3), INDEX (b, c))
+
+# ----- CREATE INDEX errors -----
+statement ok
+CREATE TABLE vec_errors (
+  a INT PRIMARY KEY,
+  b INT,
+  c TSVECTOR,
+  d VECTOR,
+  vec1 VECTOR(3),
+  FAMILY (a, b, vec1)
+)
+
+statement error column b has type int, which is not allowed as the last column in a vector index
+CREATE VECTOR INDEX ON vec_errors (a, b)
+
+statement error column vec1 has type vector, which is only allowed as the last column in a vector index
+CREATE VECTOR INDEX ON vec_errors (vec1, b)
+
+# Try to use inverted indexable type in vector index.
+statement error column c has type tsvector, which is not indexable in a non-inverted index\nHINT: you may want to create an inverted index instead. See the documentation for inverted indexes: https://www.cockroachlabs.com/docs/dev/inverted-indexes.html
+CREATE VECTOR INDEX ON vec_errors (c, vec1)
+
+statement error the last column in a vector index cannot have the DESC option
+CREATE VECTOR INDEX ON vec_errors (b, vec1 DESC)
+
+statement error vector column d does not have a fixed number of dimensions, so it cannot be indexed\nDETAIL: specify the number of dimensions in the type, like VECTOR\(128\) for 128 dimensions
+CREATE VECTOR INDEX ON vec_errors (d)
+
+# Try to use vector type in forward index.
+statement error pq: column vec1 has type vector, which is not indexable in a non-vector index\nHINT: you may want to create a vector index instead
+CREATE INDEX ON vec_errors (b, vec1)
+
+statement error vector indexes can't be unique
+CREATE UNIQUE VECTOR INDEX ON vec_errors (vec1)
+
+statement error vector indexes don't support stored columns
+CREATE INDEX on vec_errors USING cspann (vec1) STORING (b);
+
+statement error vector indexes don't support stored columns
+CREATE VECTOR INDEX on vec_errors (vec1) STORING (b);
+
+# Try to use unsupported vector index type.
+statement error at or near "hnsw": syntax error: unrecognized access method: hnsw
+CREATE INDEX ON vec_errors USING hnsw (vec1)
+
+# Operator classes are not (yet) supported.
+statement error operator classes are only allowed for the last column of an inverted index
+CREATE INDEX ON vec_errors USING cspann (vec1 vector_l2_ops)
+
+statement ok
+DROP TABLE vec_errors
+
+# ------------------------------------------------------------------------------
+# ALTER TABLE tests.
+# TODO(andyk): Move these tests to alter_primary_key when insertion is possible.
+# ------------------------------------------------------------------------------
+
+statement ok
+CREATE TABLE alter_test (
+  a INT PRIMARY KEY,
+  b INT NOT NULL,
+  vec1 VECTOR(3),
+  VECTOR INDEX (vec1),
+  FAMILY (a, b, vec1)
+)
+
+statement ok
+ALTER TABLE alter_test ALTER PRIMARY KEY USING COLUMNS (b)
+
+query TT
+SHOW CREATE TABLE alter_test
+----
+alter_test  CREATE TABLE public.alter_test (
+              a INT8 NOT NULL,
+              b INT8 NOT NULL,
+              vec1 VECTOR(3) NULL,
+              CONSTRAINT alter_test_pkey PRIMARY KEY (b ASC),
+              VECTOR INDEX alter_test_vec1_idx (vec1),
+              UNIQUE INDEX alter_test_a_key (a ASC),
+              FAMILY fam_0_a_b_vec1 (a, b, vec1)
+            )
+
+statement ok
+DROP TABLE alter_test
 
 # ------------------------------------------------------------------------------
 # Execution tests.
@@ -137,4 +270,7 @@ CREATE TABLE exec_test (
 )
 
 statement error unimplemented: execution planning for vector index search is not yet implemented
-INSERT INTO exec_test (a, vec1) values (1, '[1, 2, 3]');
+INSERT INTO exec_test (a, vec1) values (1, '[1, 2, 3]')
+
+statement ok
+DROP TABLE exec_test

--- a/pkg/sql/opt/exec/execbuilder/testdata/not_visible_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/not_visible_index
@@ -553,6 +553,73 @@ statement ok
 DROP TABLE t2
 
 ##################################################################################
+# Check Invisible Vector Index and Partial Vector Index.
+##################################################################################
+statement ok
+CREATE TABLE t1 (
+  id INT,
+  a INT,
+  v VECTOR(3),
+  VECTOR INDEX idx_vec_visible (v) VISIBLE
+);
+
+# idx_vec_visible is chosen because it is visible.
+statement error execution planning for vector index search is not yet implemented
+EXPLAIN SELECT * FROM t1 ORDER BY v <-> '[3,1,2]' LIMIT 5;
+
+statement ok
+DROP INDEX idx_vec_visible
+
+statement ok
+CREATE INDEX idx_vec_invisible ON t1 USING CSPANN (v) NOT VISIBLE;
+
+# Check invisible vector index: ignored idx_vec_invisible.
+query T
+EXPLAIN SELECT * FROM t1 ORDER BY v <-> '[3,1,2]' LIMIT 5;
+----
+distribution: local
+vectorized: true
+·
+• top-k
+│ order: +column9
+│ k: 5
+│
+└── • render
+    │
+    └── • scan
+          missing stats
+          table: t1@t1_pkey
+          spans: FULL SCAN
+
+# Add partial index.
+statement ok
+CREATE VECTOR INDEX idx_partial_invisible ON t1 (a, v) WHERE a > 10 NOT VISIBLE
+
+# Check invisible vector partial index: ignored idx_partial_invisible.
+query T
+EXPLAIN SELECT * FROM t1 WHERE a > 10 ORDER BY v <-> '[3,1,2]' LIMIT 5;
+----
+distribution: local
+vectorized: true
+·
+• top-k
+│ order: +column9
+│ k: 5
+│
+└── • render
+    │
+    └── • filter
+        │ filter: a > 10
+        │
+        └── • scan
+              missing stats
+              table: t1@t1_pkey
+              spans: FULL SCAN
+
+statement ok
+DROP TABLE t1
+
+##################################################################################
 # Check Invisible Inverted Index and Partial Inverted Index.
 ##################################################################################
 statement ok

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/BUILD.bazel
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/BUILD.bazel
@@ -106,6 +106,7 @@ go_library(
         "//pkg/sql/storageparam",
         "//pkg/sql/storageparam/indexstorageparam",
         "//pkg/sql/types",
+        "//pkg/sql/vecindex/vecpb",
         "//pkg/util/encoding",
         "//pkg/util/envutil",
         "//pkg/util/errorutil/unimplemented",

--- a/pkg/sql/schemachanger/scdecomp/decomp.go
+++ b/pkg/sql/schemachanger/scdecomp/decomp.go
@@ -649,6 +649,10 @@ func (w *walkCtx) walkIndex(tbl catalog.TableDescriptor, idx catalog.Index) {
 		if geoConfig := idx.GetGeoConfig(); !geoConfig.IsEmpty() {
 			index.GeoConfig = protoutil.Clone(&geoConfig).(*geopb.Config)
 		}
+		if index.Type == idxtype.VECTOR {
+			vecConfig := idx.GetVecConfig()
+			index.VecConfig = &vecConfig
+		}
 		for i, c := range cpy.KeyColumnIDs {
 			invertedKind := catpb.InvertedIndexColumnKind_DEFAULT
 			if index.Type == idxtype.INVERTED && c == idx.InvertedColumnID() {

--- a/pkg/sql/schemachanger/scdecomp/testdata/sequence
+++ b/pkg/sql/schemachanger/scdecomp/testdata/sequence
@@ -468,6 +468,7 @@ ElementState:
     tableId: 105
     temporaryIndexId: 0
     type: FORWARD
+    vecConfig: null
   Status: PUBLIC
 - SchemaChild:
     childObjectId: 105
@@ -859,6 +860,7 @@ ElementState:
     tableId: 105
     temporaryIndexId: 0
     type: FORWARD
+    vecConfig: null
   Status: PUBLIC
 - SchemaChild:
     childObjectId: 105

--- a/pkg/sql/schemachanger/scdecomp/testdata/table
+++ b/pkg/sql/schemachanger/scdecomp/testdata/table
@@ -308,6 +308,7 @@ ElementState:
     tableId: 104
     temporaryIndexId: 0
     type: FORWARD
+    vecConfig: null
   Status: PUBLIC
 - SchemaChild:
     childObjectId: 104
@@ -894,6 +895,7 @@ ElementState:
     tableId: 105
     temporaryIndexId: 0
     type: FORWARD
+    vecConfig: null
   Status: PUBLIC
 - SchemaChild:
     childObjectId: 105
@@ -921,6 +923,7 @@ ElementState:
     usesFunctionIds: []
     usesSequenceIds: []
     usesTypeIds: []
+    vecConfig: null
   Status: PUBLIC
 - Table:
     isTemporary: false
@@ -1331,6 +1334,7 @@ ElementState:
     tableId: 104
     temporaryIndexId: 0
     type: FORWARD
+    vecConfig: null
   Status: PUBLIC
 - SchemaChild:
     childObjectId: 104
@@ -1722,6 +1726,7 @@ ElementState:
     tableId: 109
     temporaryIndexId: 0
     type: FORWARD
+    vecConfig: null
   Status: PUBLIC
 - SchemaChild:
     childObjectId: 109

--- a/pkg/sql/schemachanger/scdecomp/testdata/type
+++ b/pkg/sql/schemachanger/scdecomp/testdata/type
@@ -670,6 +670,7 @@ ElementState:
     tableId: 108
     temporaryIndexId: 0
     type: FORWARD
+    vecConfig: null
   Status: PUBLIC
 - SchemaChild:
     childObjectId: 108
@@ -697,6 +698,7 @@ ElementState:
     usesFunctionIds: []
     usesSequenceIds: []
     usesTypeIds: []
+    vecConfig: null
   Status: PUBLIC
 - Table:
     isTemporary: false
@@ -1671,6 +1673,7 @@ ElementState:
     tableId: 111
     temporaryIndexId: 0
     type: FORWARD
+    vecConfig: null
   Status: PUBLIC
 - SchemaChild:
     childObjectId: 111
@@ -1698,6 +1701,7 @@ ElementState:
     usesFunctionIds: []
     usesSequenceIds: []
     usesTypeIds: []
+    vecConfig: null
   Status: PUBLIC
 - Table:
     isTemporary: false

--- a/pkg/sql/schemachanger/scexec/exec_validation.go
+++ b/pkg/sql/schemachanger/scexec/exec_validation.go
@@ -34,10 +34,16 @@ func executeValidateUniqueIndex(
 	}
 	// Execute the validation operation as a node user.
 	execOverride := sessiondata.NodeUserSessionDataOverride
-	if index.GetType() == idxtype.FORWARD {
+	switch index.GetType() {
+	case idxtype.FORWARD:
 		err = deps.Validator().ValidateForwardIndexes(ctx, deps.TransactionalJobRegistry().CurrentJob(), table, []catalog.Index{index}, execOverride)
-	} else {
+	case idxtype.INVERTED:
 		err = deps.Validator().ValidateInvertedIndexes(ctx, deps.TransactionalJobRegistry().CurrentJob(), table, []catalog.Index{index}, execOverride)
+	case idxtype.VECTOR:
+		// TODO(drewk): consider whether we can perform useful validation for
+		// vector indexes.
+	default:
+		return errors.AssertionFailedf("unexpected index type %v", index.GetType())
 	}
 	if err != nil {
 		return scerrors.SchemaChangerUserError(err)

--- a/pkg/sql/schemachanger/scexec/scmutationexec/index.go
+++ b/pkg/sql/schemachanger/scexec/scmutationexec/index.go
@@ -91,6 +91,9 @@ func addNewIndexMutation(
 	if opIndex.GeoConfig != nil {
 		idx.GeoConfig = *opIndex.GeoConfig
 	}
+	if opIndex.VecConfig != nil {
+		idx.VecConfig = *opIndex.VecConfig
+	}
 	return enqueueIndexMutation(tbl, idx, state, descpb.DescriptorMutation_ADD)
 }
 

--- a/pkg/sql/schemachanger/scpb/BUILD.bazel
+++ b/pkg/sql/schemachanger/scpb/BUILD.bazel
@@ -46,6 +46,7 @@ go_proto_library(
         "//pkg/sql/sem/idxtype",
         "//pkg/sql/sem/semenumpb",
         "//pkg/sql/types",
+        "//pkg/sql/vecindex/vecpb",
         "@com_github_gogo_protobuf//gogoproto",
     ],
 )
@@ -66,6 +67,7 @@ proto_library(
         "//pkg/sql/sem/idxtype:idxtype_proto",
         "//pkg/sql/sem/semenumpb:semenumpb_proto",
         "//pkg/sql/types:types_proto",
+        "//pkg/sql/vecindex/vecpb:vecpb_proto",
         "@com_github_gogo_protobuf//gogoproto:gogo_proto",
     ],
 )

--- a/pkg/sql/schemachanger/scpb/elements.proto
+++ b/pkg/sql/schemachanger/scpb/elements.proto
@@ -14,6 +14,7 @@ import "sql/sem/semenumpb/constraint.proto";
 import "sql/sem/semenumpb/trigger.proto";
 import "sql/catalog/catpb/function.proto";
 import "sql/types/types.proto";
+import "sql/vecindex/vecpb/vec.proto";
 import "gogoproto/gogo.proto";
 import "geo/geopb/config.proto";
 import "config/zonepb/zone.proto";
@@ -322,7 +323,9 @@ message Index {
   // Invisibility specifies index invisibility to the optimizer.
   double invisibility = 25;
 
-  // Next field is 27.
+  cockroach.sql.vecindex.vecpb.Config vec_config = 27 [(gogoproto.nullable) = true];
+
+  // Next field is 28.
 
   reserved 3, 4, 5, 6, 7;
 }

--- a/pkg/sql/sqltelemetry/schema.go
+++ b/pkg/sql/sqltelemetry/schema.go
@@ -91,6 +91,14 @@ var (
 	// indexes, and partial vector indexes.
 	VectorIndexCounter = telemetry.GetCounterOnce("sql.schema.vector_index")
 
+	// PartialVectorIndexCounter is to be incremented every time a partial vector
+	// index is created.
+	PartialVectorIndexCounter = telemetry.GetCounterOnce("sql.schema.partial_vector_index")
+
+	// PartitionedVectorIndexCounter is to be incremented every time a partitioned
+	// vector index is created.
+	PartitionedVectorIndexCounter = telemetry.GetCounterOnce("sql.schema.partitioned_vector_index")
+
 	// MultiColumnVectorIndexCounter is to be incremented every time a
 	// multi-column vector index is created.
 	MultiColumnVectorIndexCounter = telemetry.GetCounterOnce("sql.schema.multi_column_vector_index")

--- a/pkg/sql/testdata/telemetry/index
+++ b/pkg/sql/testdata/telemetry/index
@@ -12,6 +12,10 @@ sql.schema.partial_index
 sql.schema.partial_inverted_index
 sql.schema.partitioned_inverted_index
 sql.schema.expression_index
+sql.schema.vector_index
+sql.schema.multi_column_vector_index
+sql.schema.partial_vector_index
+sql.schema.partitioned_vector_index
 ----
 
 #### CREATE TABLE tests.
@@ -78,6 +82,13 @@ CREATE TABLE e2 (i INT, j JSON, INDEX ((i + 10)), INVERTED INDEX ((j->'a')))
 ----
 sql.schema.expression_index  2
 sql.schema.inverted_index    1
+
+feature-usage
+CREATE TABLE f (i INT, v VECTOR(3), VECTOR INDEX (v) WHERE i > 0)
+----
+sql.schema.partial_index
+sql.schema.partial_vector_index
+sql.schema.vector_index
 
 #### CREATE INDEX tests.
 
@@ -150,6 +161,25 @@ CREATE INDEX ON trigrams USING GIN(u gin_trgm_ops)
 ----
 sql.schema.inverted_index
 sql.schema.trigram_inverted_index
+
+#### CREATE VECTOR INDEX tests.
+
+exec
+CREATE TABLE v1 (i INT, v VECTOR(3))
+----
+
+feature-usage
+CREATE VECTOR INDEX i ON v1 (v) WHERE i > 0
+----
+sql.schema.partial_index
+sql.schema.partial_vector_index
+sql.schema.vector_index
+
+feature-usage
+CREATE VECTOR INDEX i2 ON v1 (i, v)
+----
+sql.schema.multi_column_vector_index
+sql.schema.vector_index
 
 #### ALTER TABLE tests.
 


### PR DESCRIPTION
Support usage of VECTOR INDEX in a CREATE INDEX statement, e.g.:

  CREATE VECTOR INDEX ON t (vec1);
  CREATE INDEX t_idx ON t USING cspann (vec1);

Update both the legacy schema changer and the new schema changer. Update expression index error messages to match those for regular columns.

Epic: CRDB-42943

Release note: None