### PR TITLE
vecindex: fix code width bug in NewQuantizedVectorSet

### DIFF
--- a/pkg/sql/vecindex/quantize/rabitq.go
+++ b/pkg/sql/vecindex/quantize/rabitq.go
@@ -144,10 +144,11 @@ func (q *RaBitQuantizer) QuantizeInSet(
 
 // NewQuantizedVectorSet implements the Quantizer interface
 func (q *RaBitQuantizer) NewQuantizedVectorSet(capacity int, centroid vector.T) QuantizedVectorSet {
-	dataBuffer := make([]uint64, 0, capacity*RaBitQCodeSetWidth(q.GetRandomDims()))
+	width := RaBitQCodeSetWidth(q.GetRandomDims())
+	dataBuffer := make([]uint64, 0, capacity*width)
 	raBitQuantizedVectorSet := &RaBitQuantizedVectorSet{
 		Centroid:          centroid,
-		Codes:             MakeRaBitQCodeSetFromRawData(dataBuffer, q.GetRandomDims()),
+		Codes:             MakeRaBitQCodeSetFromRawData(dataBuffer, width),
 		CodeCounts:        make([]uint32, 0, capacity),
 		CentroidDistances: make([]float32, 0, capacity),
 		DotProducts:       make([]float32, 0, capacity),

--- a/pkg/sql/vecindex/quantize/rabitq_test.go
+++ b/pkg/sql/vecindex/quantize/rabitq_test.go
@@ -76,6 +76,23 @@ func TestRaBitQuantizerSimple(t *testing.T) {
 		require.Equal(t, vector.T{0, 0}, quantizedSet.GetCentroid())
 		require.Nil(t, quantizedSet.GetCentroidDistances())
 	})
+
+	t.Run("empty quantized set with capacity", func(t *testing.T) {
+		quantizer := NewRaBitQuantizer(65, 42)
+		centroid := make([]float32, 65)
+		for i := range centroid {
+			centroid[i] = float32(i)
+		}
+		quantizedSet := quantizer.NewQuantizedVectorSet(
+			5, centroid).(*RaBitQuantizedVectorSet)
+		require.Equal(t, centroid, quantizedSet.Centroid)
+		require.Equal(t, 0, quantizedSet.Codes.Count)
+		require.Equal(t, 2, quantizedSet.Codes.Width)
+		require.Equal(t, 10, cap(quantizedSet.Codes.Data))
+		require.Equal(t, 5, cap(quantizedSet.CodeCounts))
+		require.Equal(t, 5, cap(quantizedSet.CentroidDistances))
+		require.Equal(t, 5, cap(quantizedSet.DotProducts))
+	})
 }
 
 // Edge cases.


### PR DESCRIPTION
NewQuantizedVectorSet was using the wrong width for the RaBitQ quantized code. The width should be CEIL(dims / 64), not dims.

Epic: CRDB-42943

Release note: None