### PR TITLE
release-24.1: colfetcher: include column family ID in tracing

### DIFF
--- a/pkg/sql/colfetcher/cfetcher.go
+++ b/pkg/sql/colfetcher/cfetcher.go
@@ -1013,6 +1013,11 @@ func (cf *cFetcher) processValue(ctx context.Context, familyID descpb.FamilyID) 
 	if cf.traceKV {
 		defer func() {
 			if err == nil {
+				if cf.table.spec.MaxKeysPerRow > 1 {
+					// If the index has more than one column family, then
+					// include the column family ID.
+					prettyKey = fmt.Sprintf("%s:cf=%d", prettyKey, familyID)
+				}
 				log.VEventf(ctx, 2, "fetched: %s -> %s", prettyKey, prettyValue)
 			}
 		}()

--- a/pkg/sql/logictest/testdata/logic_test/column_families
+++ b/pkg/sql/logictest/testdata/logic_test/column_families
@@ -76,9 +76,9 @@ SELECT message FROM [SHOW KV TRACE FOR SESSION] WHERE
 message LIKE 'fetched: /t/t_pkey/%'
 ORDER BY message
 ----
-fetched: /t/t_pkey/1/2.00/x -> /1.00
-fetched: /t/t_pkey/1/2/y -> /2.00
-fetched: /t/t_pkey/1/2/z -> /1
+fetched: /t/t_pkey/1/2.00/x:cf=2 -> /1.00
+fetched: /t/t_pkey/1/2/y:cf=1 -> /2.00
+fetched: /t/t_pkey/1/2/z:cf=0 -> /1
 
 # Regression test for #131860.
 

--- a/pkg/sql/opt/exec/execbuilder/testdata/aggregate
+++ b/pkg/sql/opt/exec/execbuilder/testdata/aggregate
@@ -1073,14 +1073,14 @@ SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
  ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
-fetched: /xyz/xyz_pkey/1 -> <undecoded>
-fetched: /xyz/xyz_pkey/1/y -> 2
-fetched: /xyz/xyz_pkey/1/z -> 3.0
-fetched: /xyz/xyz_pkey/4 -> <undecoded>
-fetched: /xyz/xyz_pkey/4/y -> 5
-fetched: /xyz/xyz_pkey/4/z -> 6.0
-fetched: /xyz/xyz_pkey/7 -> <undecoded>
-fetched: /xyz/xyz_pkey/7/z -> 8.0
+fetched: /xyz/xyz_pkey/1:cf=0 -> <undecoded>
+fetched: /xyz/xyz_pkey/1/y:cf=1 -> 2
+fetched: /xyz/xyz_pkey/1/z:cf=2 -> 3.0
+fetched: /xyz/xyz_pkey/4:cf=0 -> <undecoded>
+fetched: /xyz/xyz_pkey/4/y:cf=1 -> 5
+fetched: /xyz/xyz_pkey/4/z:cf=2 -> 6.0
+fetched: /xyz/xyz_pkey/7:cf=0 -> <undecoded>
+fetched: /xyz/xyz_pkey/7/z:cf=2 -> 8.0
 output row: [9 4.5 6.33333333333333]
 
 query T

--- a/pkg/sql/opt/exec/execbuilder/testdata/ddl
+++ b/pkg/sql/opt/exec/execbuilder/testdata/ddl
@@ -137,8 +137,8 @@ SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
  ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
-fetched: /t/t_pkey/1 -> <undecoded>
-fetched: /t/t_pkey/1/b -> 1
+fetched: /t/t_pkey/1:cf=0 -> <undecoded>
+fetched: /t/t_pkey/1/b:cf=1 -> 1
 output row: [1 1]
 
 user root

--- a/pkg/sql/opt/exec/execbuilder/testdata/insert
+++ b/pkg/sql/opt/exec/execbuilder/testdata/insert
@@ -31,19 +31,19 @@ SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
  ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
-fetched: /kv/kv_pkey/'A' -> <undecoded>
-fetched: /kv/kv_pkey/'a' -> <undecoded>
-fetched: /kv/kv_pkey/'a'/v -> 'b'
-fetched: /kv/kv_pkey/'c' -> <undecoded>
-fetched: /kv/kv_pkey/'c'/v -> 'd'
-fetched: /kv/kv_pkey/'e' -> <undecoded>
-fetched: /kv/kv_pkey/'e'/v -> 'f'
-fetched: /kv/kv_pkey/'g' -> <undecoded>
-fetched: /kv/kv_pkey/'g'/v -> ''
-fetched: /kv/kv_pkey/'nil1' -> <undecoded>
-fetched: /kv/kv_pkey/'nil2' -> <undecoded>
-fetched: /kv/kv_pkey/'nil3' -> <undecoded>
-fetched: /kv/kv_pkey/'nil4' -> <undecoded>
+fetched: /kv/kv_pkey/'A':cf=0 -> <undecoded>
+fetched: /kv/kv_pkey/'a':cf=0 -> <undecoded>
+fetched: /kv/kv_pkey/'a'/v:cf=1 -> 'b'
+fetched: /kv/kv_pkey/'c':cf=0 -> <undecoded>
+fetched: /kv/kv_pkey/'c'/v:cf=1 -> 'd'
+fetched: /kv/kv_pkey/'e':cf=0 -> <undecoded>
+fetched: /kv/kv_pkey/'e'/v:cf=1 -> 'f'
+fetched: /kv/kv_pkey/'g':cf=0 -> <undecoded>
+fetched: /kv/kv_pkey/'g'/v:cf=1 -> ''
+fetched: /kv/kv_pkey/'nil1':cf=0 -> <undecoded>
+fetched: /kv/kv_pkey/'nil2':cf=0 -> <undecoded>
+fetched: /kv/kv_pkey/'nil3':cf=0 -> <undecoded>
+fetched: /kv/kv_pkey/'nil4':cf=0 -> <undecoded>
 output row: ['A' NULL]
 output row: ['a' 'b']
 output row: ['c' 'd']
@@ -92,19 +92,19 @@ SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
  ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
-fetched: /kv/kv_pkey/'A' -> <undecoded>
-fetched: /kv/kv_pkey/'a' -> <undecoded>
-fetched: /kv/kv_pkey/'a'/v -> 'b'
-fetched: /kv/kv_pkey/'c' -> <undecoded>
-fetched: /kv/kv_pkey/'c'/v -> 'd'
-fetched: /kv/kv_pkey/'e' -> <undecoded>
-fetched: /kv/kv_pkey/'e'/v -> 'f'
-fetched: /kv/kv_pkey/'g' -> <undecoded>
-fetched: /kv/kv_pkey/'g'/v -> ''
-fetched: /kv/kv_pkey/'nil1' -> <undecoded>
-fetched: /kv/kv_pkey/'nil2' -> <undecoded>
-fetched: /kv/kv_pkey/'nil3' -> <undecoded>
-fetched: /kv/kv_pkey/'nil4' -> <undecoded>
+fetched: /kv/kv_pkey/'A':cf=0 -> <undecoded>
+fetched: /kv/kv_pkey/'a':cf=0 -> <undecoded>
+fetched: /kv/kv_pkey/'a'/v:cf=1 -> 'b'
+fetched: /kv/kv_pkey/'c':cf=0 -> <undecoded>
+fetched: /kv/kv_pkey/'c'/v:cf=1 -> 'd'
+fetched: /kv/kv_pkey/'e':cf=0 -> <undecoded>
+fetched: /kv/kv_pkey/'e'/v:cf=1 -> 'f'
+fetched: /kv/kv_pkey/'g':cf=0 -> <undecoded>
+fetched: /kv/kv_pkey/'g'/v:cf=1 -> ''
+fetched: /kv/kv_pkey/'nil1':cf=0 -> <undecoded>
+fetched: /kv/kv_pkey/'nil2':cf=0 -> <undecoded>
+fetched: /kv/kv_pkey/'nil3':cf=0 -> <undecoded>
+fetched: /kv/kv_pkey/'nil4':cf=0 -> <undecoded>
 output row: ['A' NULL]
 output row: ['a' 'b']
 output row: ['c' 'd']
@@ -153,21 +153,21 @@ SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
  ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
-fetched: /kv/kv_pkey/'A' -> <undecoded>
-fetched: /kv/kv_pkey/'a' -> <undecoded>
-fetched: /kv/kv_pkey/'a'/v -> 'b'
-fetched: /kv/kv_pkey/'c' -> <undecoded>
-fetched: /kv/kv_pkey/'c'/v -> 'd'
-fetched: /kv/kv_pkey/'e' -> <undecoded>
-fetched: /kv/kv_pkey/'e'/v -> 'f'
-fetched: /kv/kv_pkey/'f' -> <undecoded>
-fetched: /kv/kv_pkey/'f'/v -> 'g'
-fetched: /kv/kv_pkey/'g' -> <undecoded>
-fetched: /kv/kv_pkey/'g'/v -> ''
-fetched: /kv/kv_pkey/'nil1' -> <undecoded>
-fetched: /kv/kv_pkey/'nil2' -> <undecoded>
-fetched: /kv/kv_pkey/'nil3' -> <undecoded>
-fetched: /kv/kv_pkey/'nil4' -> <undecoded>
+fetched: /kv/kv_pkey/'A':cf=0 -> <undecoded>
+fetched: /kv/kv_pkey/'a':cf=0 -> <undecoded>
+fetched: /kv/kv_pkey/'a'/v:cf=1 -> 'b'
+fetched: /kv/kv_pkey/'c':cf=0 -> <undecoded>
+fetched: /kv/kv_pkey/'c'/v:cf=1 -> 'd'
+fetched: /kv/kv_pkey/'e':cf=0 -> <undecoded>
+fetched: /kv/kv_pkey/'e'/v:cf=1 -> 'f'
+fetched: /kv/kv_pkey/'f':cf=0 -> <undecoded>
+fetched: /kv/kv_pkey/'f'/v:cf=1 -> 'g'
+fetched: /kv/kv_pkey/'g':cf=0 -> <undecoded>
+fetched: /kv/kv_pkey/'g'/v:cf=1 -> ''
+fetched: /kv/kv_pkey/'nil1':cf=0 -> <undecoded>
+fetched: /kv/kv_pkey/'nil2':cf=0 -> <undecoded>
+fetched: /kv/kv_pkey/'nil3':cf=0 -> <undecoded>
+fetched: /kv/kv_pkey/'nil4':cf=0 -> <undecoded>
 output row: ['A' NULL]
 output row: ['a' 'b']
 output row: ['c' 'd']
@@ -219,21 +219,21 @@ SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
  ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
-fetched: /kv/kv_pkey/'A' -> <undecoded>
-fetched: /kv/kv_pkey/'a' -> <undecoded>
-fetched: /kv/kv_pkey/'a'/v -> 'b'
-fetched: /kv/kv_pkey/'c' -> <undecoded>
-fetched: /kv/kv_pkey/'c'/v -> 'd'
-fetched: /kv/kv_pkey/'e' -> <undecoded>
-fetched: /kv/kv_pkey/'e'/v -> 'f'
-fetched: /kv/kv_pkey/'f' -> <undecoded>
-fetched: /kv/kv_pkey/'f'/v -> 'g'
-fetched: /kv/kv_pkey/'g' -> <undecoded>
-fetched: /kv/kv_pkey/'g'/v -> ''
-fetched: /kv/kv_pkey/'nil1' -> <undecoded>
-fetched: /kv/kv_pkey/'nil2' -> <undecoded>
-fetched: /kv/kv_pkey/'nil3' -> <undecoded>
-fetched: /kv/kv_pkey/'nil4' -> <undecoded>
+fetched: /kv/kv_pkey/'A':cf=0 -> <undecoded>
+fetched: /kv/kv_pkey/'a':cf=0 -> <undecoded>
+fetched: /kv/kv_pkey/'a'/v:cf=1 -> 'b'
+fetched: /kv/kv_pkey/'c':cf=0 -> <undecoded>
+fetched: /kv/kv_pkey/'c'/v:cf=1 -> 'd'
+fetched: /kv/kv_pkey/'e':cf=0 -> <undecoded>
+fetched: /kv/kv_pkey/'e'/v:cf=1 -> 'f'
+fetched: /kv/kv_pkey/'f':cf=0 -> <undecoded>
+fetched: /kv/kv_pkey/'f'/v:cf=1 -> 'g'
+fetched: /kv/kv_pkey/'g':cf=0 -> <undecoded>
+fetched: /kv/kv_pkey/'g'/v:cf=1 -> ''
+fetched: /kv/kv_pkey/'nil1':cf=0 -> <undecoded>
+fetched: /kv/kv_pkey/'nil2':cf=0 -> <undecoded>
+fetched: /kv/kv_pkey/'nil3':cf=0 -> <undecoded>
+fetched: /kv/kv_pkey/'nil4':cf=0 -> <undecoded>
 output row: ['A' NULL]
 output row: ['a' 'b']
 output row: ['c' 'd']
@@ -278,7 +278,8 @@ statement ok
 CREATE TABLE kv5 (
   k CHAR PRIMARY KEY,
   v CHAR,
-  UNIQUE INDEX a (v, k)
+  UNIQUE INDEX a (v, k),
+  FAMILY (k, v)
 )
 
 statement ok

--- a/pkg/sql/opt/exec/execbuilder/testdata/orderby
+++ b/pkg/sql/opt/exec/execbuilder/testdata/orderby
@@ -293,10 +293,10 @@ SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
  ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
-fetched: /abc/abc_pkey/1/2/3 -> <undecoded>
-fetched: /abc/abc_pkey/1/2/3/d -> 'one'
-fetched: /abc/abc_pkey/4/5/6 -> <undecoded>
-fetched: /abc/abc_pkey/4/5/6/d -> 'Two'
+fetched: /abc/abc_pkey/1/2/3:cf=0 -> <undecoded>
+fetched: /abc/abc_pkey/1/2/3/d:cf=1 -> 'one'
+fetched: /abc/abc_pkey/4/5/6:cf=0 -> <undecoded>
+fetched: /abc/abc_pkey/4/5/6/d:cf=1 -> 'Two'
 output row: [1 2 3 'one']
 output row: [4 5 6 'Two']
 
@@ -480,10 +480,10 @@ SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
  ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
-fetched: /abc/abc_pkey/4/?/? -> <undecoded>
-fetched: /abc/abc_pkey/4/?/? -> <undecoded>
-fetched: /abc/abc_pkey/1/?/? -> <undecoded>
-fetched: /abc/abc_pkey/1/?/? -> <undecoded>
+fetched: /abc/abc_pkey/4/?/?:cf=1 -> <undecoded>
+fetched: /abc/abc_pkey/4/?/?:cf=0 -> <undecoded>
+fetched: /abc/abc_pkey/1/?/?:cf=1 -> <undecoded>
+fetched: /abc/abc_pkey/1/?/?:cf=0 -> <undecoded>
 output row: [4]
 output row: [1]
 

--- a/pkg/sql/opt/exec/execbuilder/testdata/secondary_index_column_families
+++ b/pkg/sql/opt/exec/execbuilder/testdata/secondary_index_column_families
@@ -85,9 +85,9 @@ query T
 SELECT message FROM [SHOW KV TRACE FOR SESSION] WHERE
 message LIKE 'fetched: /t1/nonuniqueidxstoring/%'
 ----
-fetched: /t1/nonuniqueidxstoring/1/1 -> <undecoded>
-fetched: /t1/nonuniqueidxstoring/1/1/z -> /1
-fetched: /t1/nonuniqueidxstoring/1/1/a/b -> /1/1
+fetched: /t1/nonuniqueidxstoring/1/1:cf=0 -> <undecoded>
+fetched: /t1/nonuniqueidxstoring/1/1/z:cf=2 -> /1
+fetched: /t1/nonuniqueidxstoring/1/1/a/b:cf=3 -> /1/1
 
 query IIIII
 SET TRACING=on,kv,results;
@@ -100,9 +100,9 @@ query T
 SELECT message FROM [SHOW KV TRACE FOR SESSION] WHERE
 message LIKE 'fetched: /t1/uniqueidxstoring/%'
 ----
-fetched: /t1/uniqueidxstoring/1 -> /1
-fetched: /t1/uniqueidxstoring/1/z -> /1
-fetched: /t1/uniqueidxstoring/1/a/b -> /1/1
+fetched: /t1/uniqueidxstoring/1:cf=0 -> /1
+fetched: /t1/uniqueidxstoring/1/z:cf=2 -> /1
+fetched: /t1/uniqueidxstoring/1/a/b:cf=3 -> /1/1
 
 
 #Test some specific behavior with nulls on unique indexes.
@@ -123,15 +123,15 @@ SELECT message FROM [SHOW KV TRACE FOR SESSION] WHERE
 message LIKE 'fetched: /t1/uniqueidxstoring/%'
 ORDER BY message
 ----
-fetched: /t1/uniqueidxstoring/1 -> /1
-fetched: /t1/uniqueidxstoring/1/a/b -> /1/1
-fetched: /t1/uniqueidxstoring/1/z -> /1
-fetched: /t1/uniqueidxstoring/NULL -> /3
-fetched: /t1/uniqueidxstoring/NULL -> /4
-fetched: /t1/uniqueidxstoring/NULL/a/b -> /3/3
-fetched: /t1/uniqueidxstoring/NULL/a/b -> /4/4
-fetched: /t1/uniqueidxstoring/NULL/z -> /3
-fetched: /t1/uniqueidxstoring/NULL/z -> /4
+fetched: /t1/uniqueidxstoring/1/a/b:cf=3 -> /1/1
+fetched: /t1/uniqueidxstoring/1/z:cf=2 -> /1
+fetched: /t1/uniqueidxstoring/1:cf=0 -> /1
+fetched: /t1/uniqueidxstoring/NULL/a/b:cf=3 -> /3/3
+fetched: /t1/uniqueidxstoring/NULL/a/b:cf=3 -> /4/4
+fetched: /t1/uniqueidxstoring/NULL/z:cf=2 -> /3
+fetched: /t1/uniqueidxstoring/NULL/z:cf=2 -> /4
+fetched: /t1/uniqueidxstoring/NULL:cf=0 -> /3
+fetched: /t1/uniqueidxstoring/NULL:cf=0 -> /4
 
 # Ensure that updates delete and insert all K/V pairs for each index.
 # Note: we don't use kvtrace query type here because it is clearer to
@@ -325,11 +325,11 @@ SELECT message FROM [SHOW KV TRACE FOR SESSION] WHERE
 message LIKE 'fetched%'
 ORDER BY message
 ----
-fetched: /t/i/2/1 -> <undecoded>
-fetched: /t/i/2/1/w -> /3
-fetched: /t/i/5/4 -> <undecoded>
-fetched: /t/i/5/4/z -> /6
-fetched: /t/i/9/8 -> <undecoded>
+fetched: /t/i/2/1/w:cf=3 -> /3
+fetched: /t/i/2/1:cf=0 -> <undecoded>
+fetched: /t/i/5/4/z:cf=2 -> /6
+fetched: /t/i/5/4:cf=0 -> <undecoded>
+fetched: /t/i/9/8:cf=0 -> <undecoded>
 
 statement ok
 DROP TABLE IF EXISTS t;

--- a/pkg/sql/opt/exec/execbuilder/testdata/select
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select
@@ -843,9 +843,9 @@ SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
  ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
-fetched: /dt/dt_pkey/'2015-08-25 04:45:45.53453' -> <undecoded>
-fetched: /dt/dt_pkey/'2015-08-25 04:45:45.53453'/b -> '2015-08-25'
-fetched: /dt/dt_pkey/'2015-08-25 04:45:45.53453'/c -> '02:45:02.234'
+fetched: /dt/dt_pkey/'2015-08-25 04:45:45.53453':cf=0 -> <undecoded>
+fetched: /dt/dt_pkey/'2015-08-25 04:45:45.53453'/b:cf=1 -> '2015-08-25'
+fetched: /dt/dt_pkey/'2015-08-25 04:45:45.53453'/c:cf=2 -> '02:45:02.234'
 output row: ['2015-08-25 04:45:45.53453' '2015-08-25' '02:45:02.234']
 
 statement ok

--- a/pkg/sql/opt/exec/execbuilder/testdata/select_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select_index
@@ -29,9 +29,9 @@ SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
  ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
-fetched: /t/t_pkey/2/'two' -> <undecoded>
-fetched: /t/t_pkey/2/'two'/c -> 22
-fetched: /t/t_pkey/2/'two'/d -> 'bar'
+fetched: /t/t_pkey/2/'two':cf=0 -> <undecoded>
+fetched: /t/t_pkey/2/'two'/c:cf=1 -> 22
+fetched: /t/t_pkey/2/'two'/d:cf=2 -> 'bar'
 output row: [2 'two' 22 'bar']
 
 statement ok
@@ -42,12 +42,12 @@ SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
  ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
-fetched: /t/t_pkey/1/'one' -> <undecoded>
-fetched: /t/t_pkey/1/'one'/c -> 11
-fetched: /t/t_pkey/1/'one'/d -> 'foo'
-fetched: /t/t_pkey/3/'three' -> <undecoded>
-fetched: /t/t_pkey/3/'three'/c -> 33
-fetched: /t/t_pkey/3/'three'/d -> 'blah'
+fetched: /t/t_pkey/1/'one':cf=0 -> <undecoded>
+fetched: /t/t_pkey/1/'one'/c:cf=1 -> 11
+fetched: /t/t_pkey/1/'one'/d:cf=2 -> 'foo'
+fetched: /t/t_pkey/3/'three':cf=0 -> <undecoded>
+fetched: /t/t_pkey/3/'three'/c:cf=1 -> 33
+fetched: /t/t_pkey/3/'three'/d:cf=2 -> 'blah'
 output row: [1 'one' 11 'foo']
 output row: [3 'three' 33 'blah']
 
@@ -96,9 +96,9 @@ SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
  ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
-fetched: /t/t_pkey/1/'one' -> <undecoded>
-fetched: /t/t_pkey/1/'one'/c -> 11
-fetched: /t/t_pkey/1/'one'/d -> 'foo'
+fetched: /t/t_pkey/1/'one':cf=0 -> <undecoded>
+fetched: /t/t_pkey/1/'one'/c:cf=1 -> 11
+fetched: /t/t_pkey/1/'one'/d:cf=2 -> 'foo'
 output row: [1 'one' 11 'foo']
 
 statement ok
@@ -109,12 +109,12 @@ SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
  ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
-fetched: /t/t_pkey/1/'one' -> <undecoded>
-fetched: /t/t_pkey/1/'one'/c -> 11
-fetched: /t/t_pkey/1/'one'/d -> 'foo'
-fetched: /t/t_pkey/2/'two' -> <undecoded>
-fetched: /t/t_pkey/2/'two'/c -> 22
-fetched: /t/t_pkey/2/'two'/d -> 'bar'
+fetched: /t/t_pkey/1/'one':cf=0 -> <undecoded>
+fetched: /t/t_pkey/1/'one'/c:cf=1 -> 11
+fetched: /t/t_pkey/1/'one'/d:cf=2 -> 'foo'
+fetched: /t/t_pkey/2/'two':cf=0 -> <undecoded>
+fetched: /t/t_pkey/2/'two'/c:cf=1 -> 22
+fetched: /t/t_pkey/2/'two'/d:cf=2 -> 'bar'
 output row: [1 'one' 11 'foo']
 output row: [2 'two' 22 'bar']
 
@@ -150,15 +150,15 @@ SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
  ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
-fetched: /t/t_pkey/1/'one' -> <undecoded>
-fetched: /t/t_pkey/1/'one'/c -> 11
-fetched: /t/t_pkey/1/'one'/d -> 'foo'
-fetched: /t/t_pkey/2/'two' -> <undecoded>
-fetched: /t/t_pkey/2/'two'/c -> 22
-fetched: /t/t_pkey/2/'two'/d -> 'bar'
-fetched: /t/t_pkey/3/'three' -> <undecoded>
-fetched: /t/t_pkey/3/'three'/c -> 33
-fetched: /t/t_pkey/3/'three'/d -> 'blah'
+fetched: /t/t_pkey/1/'one':cf=0 -> <undecoded>
+fetched: /t/t_pkey/1/'one'/c:cf=1 -> 11
+fetched: /t/t_pkey/1/'one'/d:cf=2 -> 'foo'
+fetched: /t/t_pkey/2/'two':cf=0 -> <undecoded>
+fetched: /t/t_pkey/2/'two'/c:cf=1 -> 22
+fetched: /t/t_pkey/2/'two'/d:cf=2 -> 'bar'
+fetched: /t/t_pkey/3/'three':cf=0 -> <undecoded>
+fetched: /t/t_pkey/3/'three'/c:cf=1 -> 33
+fetched: /t/t_pkey/3/'three'/d:cf=2 -> 'blah'
 output row: [2 'two' 22 'bar']
 
 # Use the descending index
@@ -248,7 +248,7 @@ SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
  ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
-fetched: /t/t_pkey/1/'c' -> <undecoded>
+fetched: /t/t_pkey/1/'c':cf=0 -> <undecoded>
 output row: [1 'c' NULL NULL]
 
 statement ok
@@ -259,7 +259,7 @@ SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
  ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
-fetched: /t/t_pkey/1/'c' -> <undecoded>
+fetched: /t/t_pkey/1/'c':cf=0 -> <undecoded>
 output row: [1 'c' NULL NULL]
 
 statement ok
@@ -287,7 +287,7 @@ SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
  ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
-fetched: /t/t_pkey/1/'b' -> <undecoded>
+fetched: /t/t_pkey/1/'b':cf=0 -> <undecoded>
 output row: [1 'b' NULL NULL]
 
 statement ok
@@ -1302,10 +1302,10 @@ SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /noncover/b/2/1 -> <undecoded>
-fetched: /noncover/noncover_pkey/1 -> <undecoded>
-fetched: /noncover/noncover_pkey/1/b -> 2
-fetched: /noncover/noncover_pkey/1/c -> 3
-fetched: /noncover/noncover_pkey/1/d -> 4
+fetched: /noncover/noncover_pkey/1:cf=0 -> <undecoded>
+fetched: /noncover/noncover_pkey/1/b:cf=1 -> 2
+fetched: /noncover/noncover_pkey/1/c:cf=2 -> 3
+fetched: /noncover/noncover_pkey/1/d:cf=3 -> 4
 output row: [1 2 3 4]
 
 # Verify that the index join span created doesn't include any potential child
@@ -1339,10 +1339,10 @@ SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
 fetched: /noncover/c/7 -> /5
-fetched: /noncover/noncover_pkey/5 -> <undecoded>
-fetched: /noncover/noncover_pkey/5/b -> 6
-fetched: /noncover/noncover_pkey/5/c -> 7
-fetched: /noncover/noncover_pkey/5/d -> 8
+fetched: /noncover/noncover_pkey/5:cf=0 -> <undecoded>
+fetched: /noncover/noncover_pkey/5/b:cf=1 -> 6
+fetched: /noncover/noncover_pkey/5/c:cf=2 -> 7
+fetched: /noncover/noncover_pkey/5/d:cf=3 -> 8
 output row: [5 6 7 8]
 
 query T
@@ -1579,10 +1579,10 @@ SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
 fetched: /t2/bc/2/1/4 -> <undecoded>
 fetched: /t2/bc/2/2/5 -> <undecoded>
 fetched: /t2/bc/2/3/6 -> <undecoded>
-fetched: /t2/t2_pkey/5 -> <undecoded>
-fetched: /t2/t2_pkey/5/b -> 2
-fetched: /t2/t2_pkey/5/c -> 2
-fetched: /t2/t2_pkey/5/s -> '22'
+fetched: /t2/t2_pkey/5:cf=0 -> <undecoded>
+fetched: /t2/t2_pkey/5/b:cf=1 -> 2
+fetched: /t2/t2_pkey/5/c:cf=2 -> 2
+fetched: /t2/t2_pkey/5/s:cf=3 -> '22'
 output row: [5 2 2 '22']
 
 query T
@@ -1614,14 +1614,14 @@ SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
 ----
 fetched: /t2/bc/2/1/4 -> <undecoded>
 fetched: /t2/bc/2/3/6 -> <undecoded>
-fetched: /t2/t2_pkey/4 -> <undecoded>
-fetched: /t2/t2_pkey/4/b -> 2
-fetched: /t2/t2_pkey/4/c -> 1
-fetched: /t2/t2_pkey/4/s -> '21'
-fetched: /t2/t2_pkey/6 -> <undecoded>
-fetched: /t2/t2_pkey/6/b -> 2
-fetched: /t2/t2_pkey/6/c -> 3
-fetched: /t2/t2_pkey/6/s -> '23'
+fetched: /t2/t2_pkey/4:cf=0 -> <undecoded>
+fetched: /t2/t2_pkey/4/b:cf=1 -> 2
+fetched: /t2/t2_pkey/4/c:cf=2 -> 1
+fetched: /t2/t2_pkey/4/s:cf=3 -> '21'
+fetched: /t2/t2_pkey/6:cf=0 -> <undecoded>
+fetched: /t2/t2_pkey/6/b:cf=1 -> 2
+fetched: /t2/t2_pkey/6/c:cf=2 -> 3
+fetched: /t2/t2_pkey/6/s:cf=3 -> '23'
 output row: [4 2 1 '21']
 output row: [6 2 3 '23']
 
@@ -1636,14 +1636,14 @@ SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
 ----
 fetched: /t2/bc/2/1/4 -> <undecoded>
 fetched: /t2/bc/2/3/6 -> <undecoded>
-fetched: /t2/t2_pkey/4 -> <undecoded>
-fetched: /t2/t2_pkey/4/b -> 2
-fetched: /t2/t2_pkey/4/c -> 1
-fetched: /t2/t2_pkey/4/s -> '21'
-fetched: /t2/t2_pkey/6 -> <undecoded>
-fetched: /t2/t2_pkey/6/b -> 2
-fetched: /t2/t2_pkey/6/c -> 3
-fetched: /t2/t2_pkey/6/s -> '23'
+fetched: /t2/t2_pkey/4:cf=0 -> <undecoded>
+fetched: /t2/t2_pkey/4/b:cf=1 -> 2
+fetched: /t2/t2_pkey/4/c:cf=2 -> 1
+fetched: /t2/t2_pkey/4/s:cf=3 -> '21'
+fetched: /t2/t2_pkey/6:cf=0 -> <undecoded>
+fetched: /t2/t2_pkey/6/b:cf=1 -> 2
+fetched: /t2/t2_pkey/6/c:cf=2 -> 3
+fetched: /t2/t2_pkey/6/s:cf=3 -> '23'
 output row: [6 2 3 '23']
 
 # We only look up the table rows where c = b+1 or a > b+4: '23', '32', '33'.
@@ -1656,42 +1656,42 @@ SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
  ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
-fetched: /t2/t2_pkey/1 -> <undecoded>
-fetched: /t2/t2_pkey/1/b -> 1
-fetched: /t2/t2_pkey/1/c -> 1
-fetched: /t2/t2_pkey/1/s -> '11'
-fetched: /t2/t2_pkey/2 -> <undecoded>
-fetched: /t2/t2_pkey/2/b -> 1
-fetched: /t2/t2_pkey/2/c -> 2
-fetched: /t2/t2_pkey/2/s -> '12'
-fetched: /t2/t2_pkey/3 -> <undecoded>
-fetched: /t2/t2_pkey/3/b -> 1
-fetched: /t2/t2_pkey/3/c -> 3
-fetched: /t2/t2_pkey/3/s -> '13'
-fetched: /t2/t2_pkey/4 -> <undecoded>
-fetched: /t2/t2_pkey/4/b -> 2
-fetched: /t2/t2_pkey/4/c -> 1
-fetched: /t2/t2_pkey/4/s -> '21'
-fetched: /t2/t2_pkey/5 -> <undecoded>
-fetched: /t2/t2_pkey/5/b -> 2
-fetched: /t2/t2_pkey/5/c -> 2
-fetched: /t2/t2_pkey/5/s -> '22'
-fetched: /t2/t2_pkey/6 -> <undecoded>
-fetched: /t2/t2_pkey/6/b -> 2
-fetched: /t2/t2_pkey/6/c -> 3
-fetched: /t2/t2_pkey/6/s -> '23'
-fetched: /t2/t2_pkey/7 -> <undecoded>
-fetched: /t2/t2_pkey/7/b -> 3
-fetched: /t2/t2_pkey/7/c -> 1
-fetched: /t2/t2_pkey/7/s -> '31'
-fetched: /t2/t2_pkey/8 -> <undecoded>
-fetched: /t2/t2_pkey/8/b -> 3
-fetched: /t2/t2_pkey/8/c -> 2
-fetched: /t2/t2_pkey/8/s -> '32'
-fetched: /t2/t2_pkey/9 -> <undecoded>
-fetched: /t2/t2_pkey/9/b -> 3
-fetched: /t2/t2_pkey/9/c -> 3
-fetched: /t2/t2_pkey/9/s -> '33'
+fetched: /t2/t2_pkey/1:cf=0 -> <undecoded>
+fetched: /t2/t2_pkey/1/b:cf=1 -> 1
+fetched: /t2/t2_pkey/1/c:cf=2 -> 1
+fetched: /t2/t2_pkey/1/s:cf=3 -> '11'
+fetched: /t2/t2_pkey/2:cf=0 -> <undecoded>
+fetched: /t2/t2_pkey/2/b:cf=1 -> 1
+fetched: /t2/t2_pkey/2/c:cf=2 -> 2
+fetched: /t2/t2_pkey/2/s:cf=3 -> '12'
+fetched: /t2/t2_pkey/3:cf=0 -> <undecoded>
+fetched: /t2/t2_pkey/3/b:cf=1 -> 1
+fetched: /t2/t2_pkey/3/c:cf=2 -> 3
+fetched: /t2/t2_pkey/3/s:cf=3 -> '13'
+fetched: /t2/t2_pkey/4:cf=0 -> <undecoded>
+fetched: /t2/t2_pkey/4/b:cf=1 -> 2
+fetched: /t2/t2_pkey/4/c:cf=2 -> 1
+fetched: /t2/t2_pkey/4/s:cf=3 -> '21'
+fetched: /t2/t2_pkey/5:cf=0 -> <undecoded>
+fetched: /t2/t2_pkey/5/b:cf=1 -> 2
+fetched: /t2/t2_pkey/5/c:cf=2 -> 2
+fetched: /t2/t2_pkey/5/s:cf=3 -> '22'
+fetched: /t2/t2_pkey/6:cf=0 -> <undecoded>
+fetched: /t2/t2_pkey/6/b:cf=1 -> 2
+fetched: /t2/t2_pkey/6/c:cf=2 -> 3
+fetched: /t2/t2_pkey/6/s:cf=3 -> '23'
+fetched: /t2/t2_pkey/7:cf=0 -> <undecoded>
+fetched: /t2/t2_pkey/7/b:cf=1 -> 3
+fetched: /t2/t2_pkey/7/c:cf=2 -> 1
+fetched: /t2/t2_pkey/7/s:cf=3 -> '31'
+fetched: /t2/t2_pkey/8:cf=0 -> <undecoded>
+fetched: /t2/t2_pkey/8/b:cf=1 -> 3
+fetched: /t2/t2_pkey/8/c:cf=2 -> 2
+fetched: /t2/t2_pkey/8/s:cf=3 -> '32'
+fetched: /t2/t2_pkey/9:cf=0 -> <undecoded>
+fetched: /t2/t2_pkey/9/b:cf=1 -> 3
+fetched: /t2/t2_pkey/9/c:cf=2 -> 3
+fetched: /t2/t2_pkey/9/s:cf=3 -> '33'
 output row: [9 3 3 '33']
 
 # Check that splitting of the expression filter does not mistakenly
@@ -1782,8 +1782,8 @@ SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
  ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
-fetched: /t4/t4_pkey/10/20 -> <undecoded>
-fetched: /t4/t4_pkey/10/20/c -> 30
+fetched: /t4/t4_pkey/10/20:cf=0 -> <undecoded>
+fetched: /t4/t4_pkey/10/20/c:cf=1 -> 30
 output row: [30]
 
 # Point lookup on d does not touch the c or e families.
@@ -1806,8 +1806,8 @@ SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
  ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
-fetched: /t4/t4_pkey/10/20 -> <undecoded>
-fetched: /t4/t4_pkey/10/20/d -> 40
+fetched: /t4/t4_pkey/10/20:cf=0 -> <undecoded>
+fetched: /t4/t4_pkey/10/20/d:cf=2 -> 40
 output row: [40]
 
 # Point lookup on both d and e uses a single span for the two adjacent column

--- a/pkg/sql/opt/exec/execbuilder/testdata/update
+++ b/pkg/sql/opt/exec/execbuilder/testdata/update
@@ -20,14 +20,14 @@ SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
  ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
-fetched: /kv2/kv2_pkey/'a' -> <undecoded>
-fetched: /kv2/kv2_pkey/'a'/v -> 'b'
-fetched: /kv2/kv2_pkey/'c' -> <undecoded>
-fetched: /kv2/kv2_pkey/'c'/v -> 'd'
-fetched: /kv2/kv2_pkey/'e' -> <undecoded>
-fetched: /kv2/kv2_pkey/'e'/v -> 'f'
-fetched: /kv2/kv2_pkey/'f' -> <undecoded>
-fetched: /kv2/kv2_pkey/'f'/v -> 'g'
+fetched: /kv2/kv2_pkey/'a':cf=0 -> <undecoded>
+fetched: /kv2/kv2_pkey/'a'/v:cf=1 -> 'b'
+fetched: /kv2/kv2_pkey/'c':cf=0 -> <undecoded>
+fetched: /kv2/kv2_pkey/'c'/v:cf=1 -> 'd'
+fetched: /kv2/kv2_pkey/'e':cf=0 -> <undecoded>
+fetched: /kv2/kv2_pkey/'e'/v:cf=1 -> 'f'
+fetched: /kv2/kv2_pkey/'f':cf=0 -> <undecoded>
+fetched: /kv2/kv2_pkey/'f'/v:cf=1 -> 'g'
 output row: ['a' 'b']
 output row: ['c' 'd']
 output row: ['e' 'f']
@@ -61,14 +61,14 @@ SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
  ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
-fetched: /kv2/kv2_pkey/'a' -> <undecoded>
-fetched: /kv2/kv2_pkey/'a'/v -> 'b'
-fetched: /kv2/kv2_pkey/'c' -> <undecoded>
-fetched: /kv2/kv2_pkey/'c'/v -> 'd'
-fetched: /kv2/kv2_pkey/'e' -> <undecoded>
-fetched: /kv2/kv2_pkey/'e'/v -> 'f'
-fetched: /kv2/kv2_pkey/'f' -> <undecoded>
-fetched: /kv2/kv2_pkey/'f'/v -> 'g'
+fetched: /kv2/kv2_pkey/'a':cf=0 -> <undecoded>
+fetched: /kv2/kv2_pkey/'a'/v:cf=1 -> 'b'
+fetched: /kv2/kv2_pkey/'c':cf=0 -> <undecoded>
+fetched: /kv2/kv2_pkey/'c'/v:cf=1 -> 'd'
+fetched: /kv2/kv2_pkey/'e':cf=0 -> <undecoded>
+fetched: /kv2/kv2_pkey/'e'/v:cf=1 -> 'f'
+fetched: /kv2/kv2_pkey/'f':cf=0 -> <undecoded>
+fetched: /kv2/kv2_pkey/'f'/v:cf=1 -> 'g'
 output row: ['a' 'b']
 output row: ['c' 'd']
 output row: ['e' 'f']
@@ -333,8 +333,8 @@ SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
  ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
-fetched: /pks/pks_pkey/2/2 -> <undecoded>
-fetched: /pks/pks_pkey/2/2/v -> 3
+fetched: /pks/pks_pkey/2/2:cf=0 -> <undecoded>
+fetched: /pks/pks_pkey/2/2/v:cf=1 -> 3
 output row: [2 2 3]
 
 # Check that UPDATE properly supports ORDER BY (MySQL extension)
@@ -841,9 +841,9 @@ SELECT message FROM [SHOW KV TRACE FOR SESSION]
  WHERE operation != 'dist sender send'
 ----
 Scan /Table/115/{1-2}
-fetched: /tu/tu_pkey/1 -> <undecoded>
-fetched: /tu/tu_pkey/1 -> <undecoded>
-fetched: /tu/tu_pkey/1/c/d -> /3/4
+fetched: /tu/tu_pkey/1:cf=0 -> <undecoded>
+fetched: /tu/tu_pkey/1:cf=1 -> <undecoded>
+fetched: /tu/tu_pkey/1/c/d:cf=2 -> /3/4
 Put /Table/115/1/1/2/1 -> /TUPLE/3:3:Int/4/1:4:Int/4
 fast path completed
 rows affected: 1
@@ -856,9 +856,9 @@ SELECT message FROM [SHOW KV TRACE FOR SESSION]
  WHERE operation != 'dist sender send'
 ----
 Scan /Table/115/{1-2}
-fetched: /tu/tu_pkey/1 -> <undecoded>
-fetched: /tu/tu_pkey/1/b -> 2
-fetched: /tu/tu_pkey/1/c/d -> /4/4
+fetched: /tu/tu_pkey/1:cf=0 -> <undecoded>
+fetched: /tu/tu_pkey/1/b:cf=1 -> 2
+fetched: /tu/tu_pkey/1/c/d:cf=2 -> /4/4
 Del /Table/115/1/1/1/1
 Del /Table/115/1/1/2/1
 fast path completed

--- a/pkg/sql/opt/exec/execbuilder/testdata/window
+++ b/pkg/sql/opt/exec/execbuilder/testdata/window
@@ -31,23 +31,23 @@ SELECT message FROM [SHOW KV TRACE FOR SESSION] WITH ORDINALITY
  WHERE message LIKE 'fetched:%' OR message LIKE 'output row%'
  ORDER BY message LIKE 'fetched:%' DESC, ordinality ASC
 ----
-fetched: /kv/kv_pkey/1/v -> /2
-fetched: /kv/kv_pkey/1/d -> 1
-fetched: /kv/kv_pkey/1 -> <undecoded>
-fetched: /kv/kv_pkey/3/v -> /4
-fetched: /kv/kv_pkey/3/d -> 8
-fetched: /kv/kv_pkey/3 -> <undecoded>
-fetched: /kv/kv_pkey/5 -> <undecoded>
-fetched: /kv/kv_pkey/5/d -> -321
-fetched: /kv/kv_pkey/6/v -> /2
-fetched: /kv/kv_pkey/6/d -> 4.4
-fetched: /kv/kv_pkey/6 -> <undecoded>
-fetched: /kv/kv_pkey/7/v -> /2
-fetched: /kv/kv_pkey/7/d -> 7.9
-fetched: /kv/kv_pkey/7 -> <undecoded>
-fetched: /kv/kv_pkey/8/v -> /4
-fetched: /kv/kv_pkey/8/d -> 3
-fetched: /kv/kv_pkey/8 -> <undecoded>
+fetched: /kv/kv_pkey/1/v:cf=0 -> /2
+fetched: /kv/kv_pkey/1/d:cf=1 -> 1
+fetched: /kv/kv_pkey/1:cf=2 -> <undecoded>
+fetched: /kv/kv_pkey/3/v:cf=0 -> /4
+fetched: /kv/kv_pkey/3/d:cf=1 -> 8
+fetched: /kv/kv_pkey/3:cf=2 -> <undecoded>
+fetched: /kv/kv_pkey/5:cf=0 -> <undecoded>
+fetched: /kv/kv_pkey/5/d:cf=1 -> -321
+fetched: /kv/kv_pkey/6/v:cf=0 -> /2
+fetched: /kv/kv_pkey/6/d:cf=1 -> 4.4
+fetched: /kv/kv_pkey/6:cf=2 -> <undecoded>
+fetched: /kv/kv_pkey/7/v:cf=0 -> /2
+fetched: /kv/kv_pkey/7/d:cf=1 -> 7.9
+fetched: /kv/kv_pkey/7:cf=2 -> <undecoded>
+fetched: /kv/kv_pkey/8/v:cf=0 -> /4
+fetched: /kv/kv_pkey/8/d:cf=1 -> 3
+fetched: /kv/kv_pkey/8:cf=2 -> <undecoded>
 output row: [5 NULL]
 output row: [1 3.4501207708330056853]
 output row: [6 3.4501207708330056853]


### PR DESCRIPTION
Backport 1/1 commits from #140338.

/cc @cockroachdb/release

---

This commit adjusts the tracing in the cFetcher so that if the index has multiple column families, we always append the column family ID as the suffix to the "pretty key".

Epic: None
Release note: None

Release justification: low-risk observability improvement.