### PR TITLE
sql: enable tenant testing for more tests

### DIFF
--- a/pkg/sql/as_of_test.go
+++ b/pkg/sql/as_of_test.go
@@ -31,7 +31,7 @@ func TestAsOfTime(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx, cancel := context.WithCancel(context.Background())
-	params, _ := createTestServerParams()
+	params, _ := createTestServerParamsAllowTenants()
 	params.Knobs.GCJob = &sql.GCJobTestingKnobs{RunBeforeResume: func(_ jobspb.JobID) error {
 		<-ctx.Done()
 		return nil
@@ -263,7 +263,7 @@ func TestAsOfRetry(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	params, cmdFilters := createTestServerParams()
+	params, cmdFilters := createTestServerParamsAllowTenants()
 	s, sqlDB, _ := serverutils.StartServer(t, params)
 	defer s.Stopper().Stop(context.Background())
 

--- a/pkg/sql/comment_on_column_test.go
+++ b/pkg/sql/comment_on_column_test.go
@@ -224,7 +224,7 @@ func runCommentOnTestsDeclarativeOnly(t *testing.T, testFunc func(db *gosql.DB))
 }
 
 func runOneCommentOnTest(t *testing.T, setupQuery string, testFunc func(db *gosql.DB)) {
-	params, _ := createTestServerParams()
+	params, _ := createTestServerParamsAllowTenants()
 	s, db, _ := serverutils.StartServer(t, params)
 	defer s.Stopper().Stop(context.Background())
 	_, err := db.Exec(setupQuery)

--- a/pkg/sql/crdb_internal_test.go
+++ b/pkg/sql/crdb_internal_test.go
@@ -83,14 +83,15 @@ func TestGetAllNamesInternal(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	params, _ := createTestServerParams()
+	params, _ := createTestServerParamsAllowTenants()
+
 	s, _ /* sqlDB */, kvDB := serverutils.StartServer(t, params)
 	defer s.Stopper().Stop(ctx)
 
 	err := kvDB.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
 		batch := txn.NewBatch()
-		batch.Put(catalogkeys.EncodeNameKey(keys.SystemSQLCodec, &descpb.NameInfo{ParentID: 999, ParentSchemaID: 444, Name: "bob"}), 9999)
-		batch.Put(catalogkeys.EncodeNameKey(keys.SystemSQLCodec, &descpb.NameInfo{ParentID: 1000, ParentSchemaID: 29, Name: "alice"}), 10000)
+		batch.Put(catalogkeys.EncodeNameKey(s.Codec(), &descpb.NameInfo{ParentID: 999, ParentSchemaID: 444, Name: "bob"}), 9999)
+		batch.Put(catalogkeys.EncodeNameKey(s.Codec(), &descpb.NameInfo{ParentID: 1000, ParentSchemaID: 29, Name: "alice"}), 10000)
 		return txn.CommitInBatch(ctx, batch)
 	})
 	require.NoError(t, err)
@@ -167,12 +168,12 @@ func TestGossipAlertsTable(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	params, _ := createTestServerParams()
+	params, _ := createTestServerParamsAllowTenants()
 	s := serverutils.StartServerOnly(t, params)
-	defer s.Stopper().Stop(context.Background())
+	defer s.Stop(context.Background())
 	ctx := context.Background()
 
-	if err := s.GossipI().(*gossip.Gossip).AddInfoProto(gossip.MakeNodeHealthAlertKey(456), &statuspb.HealthCheckResult{
+	if err := s.StorageLayer().GossipI().(*gossip.Gossip).AddInfoProto(gossip.MakeNodeHealthAlertKey(456), &statuspb.HealthCheckResult{
 		Alerts: []statuspb.HealthAlert{{
 			StoreID:     123,
 			Category:    statuspb.HealthAlert_METRICS,
@@ -183,7 +184,7 @@ func TestGossipAlertsTable(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	ie := s.InternalExecutor().(*sql.InternalExecutor)
+	ie := s.SystemLayer().InternalExecutor().(*sql.InternalExecutor)
 	row, err := ie.QueryRowEx(ctx, "test", nil, /* txn */
 		sessiondata.NodeUserSessionDataOverride,
 		"SELECT * FROM crdb_internal.gossip_alerts WHERE store_id = 123")
@@ -208,7 +209,7 @@ func TestOldBitColumnMetadata(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	params, _ := createTestServerParams()
+	params, _ := createTestServerParamsAllowTenants()
 	s, sqlDB, kvDB := serverutils.StartServer(t, params)
 	defer s.Stopper().Stop(ctx)
 
@@ -227,7 +228,7 @@ CREATE TABLE t.test (k INT);
 	// old-style bit column. We're going to edit the table descriptor
 	// manually, without going through SQL.
 	tableDesc := desctestutils.TestingGetMutableExistingTableDescriptor(
-		kvDB, keys.SystemSQLCodec, "t", "test")
+		kvDB, s.Codec(), "t", "test")
 	for i := range tableDesc.Columns {
 		if tableDesc.Columns[i].Name == "k" {
 			tableDesc.Columns[i].Type.InternalType.VisibleType = 4 // Pre-2.1 BIT.
@@ -264,7 +265,7 @@ CREATE TABLE t.test (k INT);
 
 	// Write the modified descriptor.
 	if err := kvDB.Txn(context.Background(), func(ctx context.Context, txn *kv.Txn) error {
-		return txn.Put(ctx, catalogkeys.MakeDescMetadataKey(keys.SystemSQLCodec, tableDesc.ID), tableDesc.DescriptorProto())
+		return txn.Put(ctx, catalogkeys.MakeDescMetadataKey(s.Codec(), tableDesc.ID), tableDesc.DescriptorProto())
 	}); err != nil {
 		t.Fatal(err)
 	}
@@ -321,7 +322,7 @@ SELECT column_name, character_maximum_length, numeric_precision, numeric_precisi
 	}
 
 	// And verify that this has re-set the fields.
-	tableDesc = desctestutils.TestingGetMutableExistingTableDescriptor(kvDB, keys.SystemSQLCodec, "t", "test")
+	tableDesc = desctestutils.TestingGetMutableExistingTableDescriptor(kvDB, s.Codec(), "t", "test")
 	found := false
 	for i := range tableDesc.Columns {
 		col := &tableDesc.Columns[i]
@@ -429,7 +430,7 @@ func TestInvalidObjects(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	params, _ := createTestServerParams()
+	params, _ := createTestServerParamsAllowTenants()
 	params.Knobs = base.TestingKnobs{
 		Store: &kvserver.StoreTestingKnobs{
 			DisableMergeQueue: true,

--- a/pkg/sql/create_test.go
+++ b/pkg/sql/create_test.go
@@ -246,7 +246,7 @@ func TestParallelCreateConflictingTables(t *testing.T) {
 func TestTableReadErrorsBeforeTableCreation(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	params, _ := createTestServerParams()
+	params, _ := createTestServerParamsAllowTenants()
 	s, sqlDB, _ := serverutils.StartServer(t, params)
 	defer s.Stopper().Stop(context.Background())
 

--- a/pkg/sql/grant_revoke_test.go
+++ b/pkg/sql/grant_revoke_test.go
@@ -11,7 +11,6 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
-	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/desctestutils"
@@ -29,7 +28,7 @@ import (
 func TestNoOpGrant(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	params, _ := createTestServerParams()
+	params, _ := createTestServerParamsAllowTenants()
 	s, sqlDB, kvDB := serverutils.StartServer(t, params)
 	defer s.Stopper().Stop(context.Background())
 	tdb := sqlutils.MakeSQLRunner(sqlDB)
@@ -41,10 +40,10 @@ func TestNoOpGrant(t *testing.T) {
 	tdb.Exec(t, "CREATE USER roach")
 
 	// Assert that user `roach` should not have any privilege on the database, schema, and table.
-	dbDesc := desctestutils.TestingGetDatabaseDescriptor(kvDB, keys.SystemSQLCodec, "db")
-	scDesc := desctestutils.TestingGetSchemaDescriptor(kvDB, keys.SystemSQLCodec, dbDesc.GetID(), "sc")
-	tblDesc := desctestutils.TestingGetTableDescriptor(kvDB, keys.SystemSQLCodec, "db", "sc", "tbl")
-	typDesc := desctestutils.TestingGetTypeDescriptor(kvDB, keys.SystemSQLCodec, "db", "sc", "typ")
+	dbDesc := desctestutils.TestingGetDatabaseDescriptor(kvDB, s.Codec(), "db")
+	scDesc := desctestutils.TestingGetSchemaDescriptor(kvDB, s.Codec(), dbDesc.GetID(), "sc")
+	tblDesc := desctestutils.TestingGetTableDescriptor(kvDB, s.Codec(), "db", "sc", "tbl")
+	typDesc := desctestutils.TestingGetTypeDescriptor(kvDB, s.Codec(), "db", "sc", "typ")
 	userRoach, err := username.MakeSQLUsernameFromUserInput("roach", username.PurposeValidation)
 	require.NoError(t, err)
 	_, ok := dbDesc.GetPrivileges().FindUser(userRoach)
@@ -60,13 +59,13 @@ func TestNoOpGrant(t *testing.T) {
 		var desc catalog.Descriptor
 		switch objectType {
 		case privilege.Database:
-			desc = desctestutils.TestingGetDatabaseDescriptor(kvDB, keys.SystemSQLCodec, dbDesc.GetName())
+			desc = desctestutils.TestingGetDatabaseDescriptor(kvDB, s.Codec(), dbDesc.GetName())
 		case privilege.Schema:
-			desc = desctestutils.TestingGetSchemaDescriptor(kvDB, keys.SystemSQLCodec, dbDesc.GetID(), scDesc.GetName())
+			desc = desctestutils.TestingGetSchemaDescriptor(kvDB, s.Codec(), dbDesc.GetID(), scDesc.GetName())
 		case privilege.Table:
-			desc = desctestutils.TestingGetTableDescriptor(kvDB, keys.SystemSQLCodec, dbDesc.GetName(), scDesc.GetName(), tblDesc.GetName())
+			desc = desctestutils.TestingGetTableDescriptor(kvDB, s.Codec(), dbDesc.GetName(), scDesc.GetName(), tblDesc.GetName())
 		case privilege.Type:
-			desc = desctestutils.TestingGetTypeDescriptor(kvDB, keys.SystemSQLCodec, dbDesc.GetName(), scDesc.GetName(), typDesc.GetName())
+			desc = desctestutils.TestingGetTypeDescriptor(kvDB, s.Codec(), dbDesc.GetName(), scDesc.GetName(), typDesc.GetName())
 		}
 		return desc
 	}
@@ -150,7 +149,7 @@ func TestNoOpGrant(t *testing.T) {
 func TestNoOpRevoke(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	params, _ := createTestServerParams()
+	params, _ := createTestServerParamsAllowTenants()
 	s, sqlDB, kvDB := serverutils.StartServer(t, params)
 	defer s.Stopper().Stop(context.Background())
 	tdb := sqlutils.MakeSQLRunner(sqlDB)
@@ -162,10 +161,10 @@ func TestNoOpRevoke(t *testing.T) {
 	tdb.Exec(t, "CREATE USER roach")
 
 	// Assert that user `roach` should not have any privilege on the database, schema, and table.
-	dbDesc := desctestutils.TestingGetDatabaseDescriptor(kvDB, keys.SystemSQLCodec, "db")
-	scDesc := desctestutils.TestingGetSchemaDescriptor(kvDB, keys.SystemSQLCodec, dbDesc.GetID(), "sc")
-	tblDesc := desctestutils.TestingGetTableDescriptor(kvDB, keys.SystemSQLCodec, "db", "sc", "tbl")
-	typDesc := desctestutils.TestingGetTypeDescriptor(kvDB, keys.SystemSQLCodec, "db", "sc", "typ")
+	dbDesc := desctestutils.TestingGetDatabaseDescriptor(kvDB, s.Codec(), "db")
+	scDesc := desctestutils.TestingGetSchemaDescriptor(kvDB, s.Codec(), dbDesc.GetID(), "sc")
+	tblDesc := desctestutils.TestingGetTableDescriptor(kvDB, s.Codec(), "db", "sc", "tbl")
+	typDesc := desctestutils.TestingGetTypeDescriptor(kvDB, s.Codec(), "db", "sc", "typ")
 	userRoach, err := username.MakeSQLUsernameFromUserInput("roach", username.PurposeValidation)
 	require.NoError(t, err)
 	_, ok := dbDesc.GetPrivileges().FindUser(userRoach)
@@ -181,13 +180,13 @@ func TestNoOpRevoke(t *testing.T) {
 		var desc catalog.Descriptor
 		switch objectType {
 		case privilege.Database:
-			desc = desctestutils.TestingGetDatabaseDescriptor(kvDB, keys.SystemSQLCodec, dbDesc.GetName())
+			desc = desctestutils.TestingGetDatabaseDescriptor(kvDB, s.Codec(), dbDesc.GetName())
 		case privilege.Schema:
-			desc = desctestutils.TestingGetSchemaDescriptor(kvDB, keys.SystemSQLCodec, dbDesc.GetID(), scDesc.GetName())
+			desc = desctestutils.TestingGetSchemaDescriptor(kvDB, s.Codec(), dbDesc.GetID(), scDesc.GetName())
 		case privilege.Table:
-			desc = desctestutils.TestingGetTableDescriptor(kvDB, keys.SystemSQLCodec, dbDesc.GetName(), scDesc.GetName(), tblDesc.GetName())
+			desc = desctestutils.TestingGetTableDescriptor(kvDB, s.Codec(), dbDesc.GetName(), scDesc.GetName(), tblDesc.GetName())
 		case privilege.Type:
-			desc = desctestutils.TestingGetTypeDescriptor(kvDB, keys.SystemSQLCodec, dbDesc.GetName(), scDesc.GetName(), typDesc.GetName())
+			desc = desctestutils.TestingGetTypeDescriptor(kvDB, s.Codec(), dbDesc.GetName(), scDesc.GetName(), typDesc.GetName())
 		}
 		return desc
 	}

--- a/pkg/sql/grant_role_test.go
+++ b/pkg/sql/grant_role_test.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"testing"
 
-	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/desctestutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
@@ -24,7 +23,7 @@ import (
 func TestNoOpGrantRole(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	params, _ := createTestServerParams()
+	params, _ := createTestServerParamsAllowTenants()
 	s, sqlDB, kvDB := serverutils.StartServer(t, params)
 	defer s.Stopper().Stop(context.Background())
 	tdb := sqlutils.MakeSQLRunner(sqlDB)
@@ -38,7 +37,7 @@ func TestNoOpGrantRole(t *testing.T) {
 	num := 0
 	tdb.QueryRow(t, "SELECT count(1) FROM system.role_members WHERE role = 'developer' AND member = 'roach'").Scan(&num)
 	require.Equal(t, 1, num)
-	roleMembersTableDesc := desctestutils.TestingGetTableDescriptor(kvDB, keys.SystemSQLCodec, "system", "public", "role_members")
+	roleMembersTableDesc := desctestutils.TestingGetTableDescriptor(kvDB, s.Codec(), "system", "public", "role_members")
 	roleMembersTableVersion := roleMembersTableDesc.GetVersion()
 
 	// Repeat the statement and assert that no schema change was performed to table `system.role_members`
@@ -46,6 +45,6 @@ func TestNoOpGrantRole(t *testing.T) {
 	tdb.Exec(t, "GRANT developer TO roach")
 	tdb.QueryRow(t, "SELECT count(1) FROM system.role_members WHERE role = 'developer' AND member = 'roach'").Scan(&num)
 	require.Equal(t, 1, num)
-	roleMembersTableDesc = desctestutils.TestingGetTableDescriptor(kvDB, keys.SystemSQLCodec, "system", "public", "role_members")
+	roleMembersTableDesc = desctestutils.TestingGetTableDescriptor(kvDB, s.Codec(), "system", "public", "role_members")
 	require.Equal(t, roleMembersTableVersion, roleMembersTableDesc.GetVersion())
 }

--- a/pkg/sql/indexbackfiller_test.go
+++ b/pkg/sql/indexbackfiller_test.go
@@ -51,7 +51,7 @@ func TestIndexBackfiller(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	params, _ := createTestServerParams()
+	params, _ := createTestServerParamsAllowTenants()
 
 	moveToTDelete := make(chan bool)
 	moveToTWrite := make(chan bool)

--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -265,7 +265,7 @@ CREATE INDEX foo ON t.test (v)
 	}
 
 	// Ensure that the indexes have been created.
-	mTest := makeMutationTest(t, kvDB, sqlDB, tableDesc)
+	mTest := makeMutationTest(t, kvDB, sqlDB, s.Codec(), tableDesc)
 	indexQuery := `SELECT v FROM t.test@foo`
 	mTest.CheckQueryResults(t, indexQuery, [][]string{{"b"}, {"d"}})
 

--- a/pkg/sql/server_params_test.go
+++ b/pkg/sql/server_params_test.go
@@ -20,8 +20,6 @@ import (
 func createTestServerParamsAllowTenants() (base.TestServerArgs, *tests.CommandFilters) {
 	var cmdFilters tests.CommandFilters
 	params := base.TestServerArgs{}
-	// Disable the default test tenant as limits to the number of spans in a
-	// secondary tenant cause this test to fail. Tracked with #76378.
 	params.Knobs.SQLStatsKnobs = sqlstats.CreateTestingKnobs()
 	params.Knobs.Store = &kvserver.StoreTestingKnobs{
 		EvalKnobs: kvserverbase.BatchEvalTestingKnobs{

--- a/pkg/testutils/serverutils/api.go
+++ b/pkg/testutils/serverutils/api.go
@@ -74,10 +74,10 @@ type TestServerInterface interface {
 	// the .TenantController() method.
 	TenantControlInterface
 
-	// ApplicationLayer returns the interface to the application layer that is
-	// exercised by the test. Depending on how the test server is started
-	// and (optionally) randomization, this can be either the SQL layer
-	// of a virtual cluster or that of the system interface.
+	// ApplicationLayer returns the interface to the application layer used
+	// in testing. If the server starts with tenancy enabled under the default
+	// tenant option, this refers to the SQL layer of the virtual cluster.
+	// Otherwise, in single-tenant mode, it refers to the system layer.
 	ApplicationLayer() ApplicationLayerInterface
 
 	// SystemLayer returns the interface to the application layer


### PR DESCRIPTION
To achieve this, this PR reduces the usage of `createTestServerParams` by replacing it with `createTestServerParamsAllowTenants`. The changes are mostly straightforward, including replacing hardcoded `keys.SystemSQLCodec` with `server.Codec()`, and using `server.StorageLayer()`/`server.SystemLayer()` where the test is specific to the system tenant.

Informs: #140446
Epic: CRDB-38970
Release note: None