### PR TITLE
changefeedccl: deprecate initial_resolved from changeaggregator_spec

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_processors_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/span"
 	"github.com/stretchr/testify/require"
 )
 
@@ -127,6 +128,156 @@ func TestSetupSpansAndFrontier(t *testing.T) {
 			_, err := ca.setupSpansAndFrontier()
 			require.NoError(t, err)
 			require.Equal(t, tc.expectedFrontier, ca.frontier.Frontier())
+		})
+	}
+}
+
+type checkpointSpan struct {
+	span roachpb.Span
+	ts   hlc.Timestamp
+}
+
+type checkpointSpans []checkpointSpan
+
+// TestSetupSpansAndFrontierWithNewSpec tests that the setupSpansAndFrontier
+// function correctly sets up frontier for the changefeed aggregator frontier
+// with the new ChangeAggregatorSpec_Watch where initial resolved is not set but
+// initial highwater is passed in.
+func TestSetupSpansAndFrontierWithNewSpec(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	statementTime := hlc.Timestamp{WallTime: 10}
+
+	for _, tc := range []struct {
+		name                 string
+		initialHighWater     hlc.Timestamp
+		watches              []execinfrapb.ChangeAggregatorSpec_Watch
+		checkpoints          execinfrapb.ChangeAggregatorSpec_Checkpoint
+		expectedFrontierTs   hlc.Timestamp
+		expectedFrontierSpan checkpointSpans
+	}{
+		{
+			name:             "new initial scan",
+			initialHighWater: hlc.Timestamp{},
+			watches: []execinfrapb.ChangeAggregatorSpec_Watch{
+				{Span: roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("b")}},
+				{Span: roachpb.Span{Key: roachpb.Key("c"), EndKey: roachpb.Key("e")}},
+				{Span: roachpb.Span{Key: roachpb.Key("g"), EndKey: roachpb.Key("h")}},
+			},
+			expectedFrontierTs: hlc.Timestamp{},
+			expectedFrontierSpan: checkpointSpans{
+				{span: roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("b")}, ts: hlc.Timestamp{}},
+				{span: roachpb.Span{Key: roachpb.Key("c"), EndKey: roachpb.Key("e")}, ts: hlc.Timestamp{}},
+				{span: roachpb.Span{Key: roachpb.Key("g"), EndKey: roachpb.Key("h")}, ts: hlc.Timestamp{}},
+			},
+		},
+		{
+			name:             "complete initial scan with empty span level checkpoints",
+			initialHighWater: hlc.Timestamp{WallTime: 5},
+			watches: []execinfrapb.ChangeAggregatorSpec_Watch{
+				{Span: roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("b")}},
+				{Span: roachpb.Span{Key: roachpb.Key("c"), EndKey: roachpb.Key("e")}},
+				{Span: roachpb.Span{Key: roachpb.Key("g"), EndKey: roachpb.Key("h")}},
+			},
+			expectedFrontierTs: hlc.Timestamp{WallTime: 5},
+			expectedFrontierSpan: checkpointSpans{
+				{span: roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("b")}, ts: hlc.Timestamp{WallTime: 5}},
+				{span: roachpb.Span{Key: roachpb.Key("c"), EndKey: roachpb.Key("e")}, ts: hlc.Timestamp{WallTime: 5}},
+				{span: roachpb.Span{Key: roachpb.Key("g"), EndKey: roachpb.Key("h")}, ts: hlc.Timestamp{WallTime: 5}},
+			},
+		},
+		{
+			name:             "initial scan in progress with span level checkpoints and checkpoint ts",
+			initialHighWater: hlc.Timestamp{},
+			watches: []execinfrapb.ChangeAggregatorSpec_Watch{
+				{Span: roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("b")}},
+				{Span: roachpb.Span{Key: roachpb.Key("b"), EndKey: roachpb.Key("c")}},
+				{Span: roachpb.Span{Key: roachpb.Key("c"), EndKey: roachpb.Key("d")}},
+			},
+			checkpoints: execinfrapb.ChangeAggregatorSpec_Checkpoint{
+				Spans:     []roachpb.Span{{Key: roachpb.Key("a"), EndKey: roachpb.Key("b")}, {Key: roachpb.Key("c"), EndKey: roachpb.Key("d")}},
+				Timestamp: hlc.Timestamp{WallTime: 5},
+			},
+			expectedFrontierTs: hlc.Timestamp{},
+			expectedFrontierSpan: checkpointSpans{
+				{span: roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("b")}, ts: hlc.Timestamp{WallTime: 5}},
+				{span: roachpb.Span{Key: roachpb.Key("b"), EndKey: roachpb.Key("c")}, ts: hlc.Timestamp{}},
+				{span: roachpb.Span{Key: roachpb.Key("c"), EndKey: roachpb.Key("d")}, ts: hlc.Timestamp{WallTime: 5}},
+			},
+		},
+		{
+			name:             "initial scan with span level checkpoints but no checkpoint ts",
+			initialHighWater: hlc.Timestamp{},
+			watches: []execinfrapb.ChangeAggregatorSpec_Watch{
+				{Span: roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("b")}},
+				{Span: roachpb.Span{Key: roachpb.Key("b"), EndKey: roachpb.Key("c")}},
+				{Span: roachpb.Span{Key: roachpb.Key("c"), EndKey: roachpb.Key("d")}},
+			},
+			checkpoints: execinfrapb.ChangeAggregatorSpec_Checkpoint{
+				Spans: []roachpb.Span{{Key: roachpb.Key("a"), EndKey: roachpb.Key("b")}, {Key: roachpb.Key("c"), EndKey: roachpb.Key("d")}},
+			},
+			expectedFrontierTs: hlc.Timestamp{},
+			expectedFrontierSpan: checkpointSpans{
+				{span: roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("b")}, ts: statementTime},
+				{span: roachpb.Span{Key: roachpb.Key("b"), EndKey: roachpb.Key("c")}, ts: hlc.Timestamp{}},
+				{span: roachpb.Span{Key: roachpb.Key("c"), EndKey: roachpb.Key("d")}, ts: statementTime},
+			},
+		},
+		{
+			name:             "schema backfill with span level checkpoints and checkpoint ts",
+			initialHighWater: hlc.Timestamp{WallTime: 5},
+			watches: []execinfrapb.ChangeAggregatorSpec_Watch{
+				{Span: roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("b")}},
+				{Span: roachpb.Span{Key: roachpb.Key("b"), EndKey: roachpb.Key("c")}},
+				{Span: roachpb.Span{Key: roachpb.Key("c"), EndKey: roachpb.Key("d")}},
+			},
+			checkpoints: execinfrapb.ChangeAggregatorSpec_Checkpoint{
+				Spans:     []roachpb.Span{{Key: roachpb.Key("a"), EndKey: roachpb.Key("b")}, {Key: roachpb.Key("c"), EndKey: roachpb.Key("d")}},
+				Timestamp: hlc.Timestamp{WallTime: 7},
+			},
+			expectedFrontierTs: hlc.Timestamp{WallTime: 5},
+			expectedFrontierSpan: checkpointSpans{
+				{span: roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("b")}, ts: hlc.Timestamp{WallTime: 7}},
+				{span: roachpb.Span{Key: roachpb.Key("b"), EndKey: roachpb.Key("c")}, ts: hlc.Timestamp{WallTime: 5}},
+				{span: roachpb.Span{Key: roachpb.Key("c"), EndKey: roachpb.Key("d")}, ts: hlc.Timestamp{WallTime: 7}},
+			},
+		},
+		{
+			name:             "schema backfill with span level checkpoints but no checkpoint ts",
+			initialHighWater: hlc.Timestamp{WallTime: 5},
+			watches: []execinfrapb.ChangeAggregatorSpec_Watch{
+				{Span: roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("b")}},
+				{Span: roachpb.Span{Key: roachpb.Key("b"), EndKey: roachpb.Key("c")}},
+				{Span: roachpb.Span{Key: roachpb.Key("c"), EndKey: roachpb.Key("d")}},
+			},
+			checkpoints: execinfrapb.ChangeAggregatorSpec_Checkpoint{
+				Spans: []roachpb.Span{{Key: roachpb.Key("a"), EndKey: roachpb.Key("b")}, {Key: roachpb.Key("c"), EndKey: roachpb.Key("d")}},
+			},
+			expectedFrontierSpan: checkpointSpans{
+				{span: roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("b")}, ts: hlc.Timestamp{WallTime: 5}.Next()},
+				{span: roachpb.Span{Key: roachpb.Key("b"), EndKey: roachpb.Key("c")}, ts: hlc.Timestamp{WallTime: 5}},
+				{span: roachpb.Span{Key: roachpb.Key("c"), EndKey: roachpb.Key("d")}, ts: hlc.Timestamp{WallTime: 5}.Next()},
+			},
+			expectedFrontierTs: hlc.Timestamp{WallTime: 5},
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			ca := &changeAggregator{}
+			ca.spec.Feed.StatementTime = statementTime
+			ca.spec.Checkpoint = tc.checkpoints
+			ca.spec.Watches = tc.watches
+			ca.spec.InitialHighWater = &tc.initialHighWater
+			_, err := ca.setupSpansAndFrontier()
+			require.NoError(t, err)
+			actualFrontierSpan := checkpointSpans{}
+			ca.frontier.Entries(func(sp roachpb.Span, ts hlc.Timestamp) span.OpResult {
+				actualFrontierSpan = append(actualFrontierSpan, checkpointSpan{span: sp, ts: ts})
+				return span.ContinueMatch
+			})
+
+			require.Equal(t, tc.expectedFrontierSpan, actualFrontierSpan)
+			require.Equal(t, tc.expectedFrontierTs, ca.frontier.Frontier())
 		})
 	}
 }

--- a/pkg/sql/execinfrapb/processors_changefeeds.proto
+++ b/pkg/sql/execinfrapb/processors_changefeeds.proto
@@ -24,7 +24,7 @@ import "gogoproto/gogo.proto";
 // changes in a set of spans. Each span may cross multiple ranges.
 message ChangeAggregatorSpec {
   message Watch {
-    optional util.hlc.Timestamp initial_resolved = 1 [(gogoproto.nullable) = false];
+    optional util.hlc.Timestamp initial_resolved = 1 [(gogoproto.nullable) = false, deprecated=true];
     optional roachpb.Span span = 2 [(gogoproto.nullable) = false];
   }
   repeated Watch watches = 1 [(gogoproto.nullable) = false];
@@ -57,6 +57,11 @@ message ChangeAggregatorSpec {
 
   // Description is the description of the changefeed. Used for structured logging.
   optional string description = 7 [(gogoproto.nullable) = false];
+
+  // InitialHighWater represents a point in time where all data is known to have
+  // been seen for this changefeed job. It is safe to initialize frontier spans
+  // at this timestamp upon resuming.
+  optional util.hlc.Timestamp initial_high_water = 8;
 }
 
 // ChangeFrontierSpec is the specification for a processor that receives


### PR DESCRIPTION
Previously, the initial resolved timestamp for every spans were computed during
the planning stage and stored in ChangeAggregatorSpec_Watch. Upon resuming,
aggregators would infer the highwater by looking at the resolved timestamps
again and forward checkpointed timestamps again. To simplify this, this patch
deprecates the initial resolved field of ChangeAggregatorSpec_Watch and just
pass the initial high-water to aggregators. And let the aggregator handle both
frontier initializatio and ensure proper forwarding of the checkpointed spans.

A more detailed explanation below:

Upon resuming,

**This is how it currently works:**

1. During the initial planning stage, changefeed has some information from the
job proto including the initial highwater, span level checkpoint timestamp, and
span level checkpoint spans.

The planning stage would create a struct `ChangeAggregatorSpec` for each
aggregator (which contains information like what spans they are watching). This
struct contains `[]ChangeAggregatorSpec_Watch`, and this is how planning stage
creates this struct:
```
type ChangeAggregatorSpec_Watch struct {
 InitialResolved hlc.Timestamp
 Span            roachpb.Span
}
```

For each span aggregator is watching for, the initial resolved timestamp is set
based on whether it is included in the checkpointed spans:
- If included, its `InitialResolved` is set to the checkpointed timestamp.
- Otherwise, it defaults to the initial highwater.
https://github.com/cockroachdb/cockroach/blob/0396abcee4dfa0bf5af6d8f52d16c4a958518404/pkg/ccl/changefeedccl/changefeed_dist.go#L473-L480

2. Each aggregator then receives the `ChangeAggregatorSpec` for initialization.
```
type ChangeAggregatorSpec struct {
 Watches []ChangeAggregatorSpec_Watch
 Checkpoint ChangeAggregatorSpec_Checkpoint
}

type ChangeAggregatorSpec_Checkpoint struct {
 Spans     []roachpb.Span `protobuf:"bytes,1,rep,name=spans" json:"spans"`
 Timestamp hlc.Timestamp  `protobuf:"bytes,2,opt,name=timestamp" json:"timestamp"`
}
```

Each aggregator initializes its aggregator frontier using the provided
`ChangeAggregatorSpec`.
- It recalculates the initial highwater by finding the minimum initial resolved
timestamp across all spans.
- Once determined, it initializes the frontier with this highwater.
- It then forwards checkpointed spans to the checkpointed timestamps.

**This is what we are changing:**

Note how this process involves redundant work. The initial resolved field for
every `ChangeAggregatorSpec_Watch` is used solely to infer the initial
highwater. But the initial high water was already given to us during planning.
We can just pass this initial highwater information directly to each aggregator
in each `ChangeAggregatorSpec`.

This patch removes `InitialResolved` from `ChangeAggregatorSpec_Watch` and
directly passes the initial highwater via `ChangeAggregatorSpec`. This allows
aggregators to:
- Initialize the frontier with the provided initial highwater
- And then forward checkpointed spans as is.

Part of: https://github.com/cockroachdb/cockroach/issues/137693
Epic: None