### PR TITLE
kv: add TenantInfo rpc to resolve tenant name to ID (do_not_commit)

### DIFF
--- a/pkg/cli/cliflags/flags_mt.go
+++ b/pkg/cli/cliflags/flags_mt.go
@@ -21,6 +21,24 @@ not exist, or if the tenant id is incomplete, the tenant server will block, and
 wait for the tenant id to be fully written to the file (with a newline character).`,
 	}
 
+	// TenantName will eventually replace TenantID. To start a SQL server bound to
+	// a tenant, use this flag instead of TenantID.
+	TenantName = FlagInfo{
+		Name:        "tenant-name",
+		EnvVar:      "COCKROACH_TENANT_NAME",
+		Description: `The tenant name under which to start the SQL server.`,
+	}
+
+	// TenantNameFile is similar to TenantIDFile but uses tenant name instead of
+	// TenantID. 
+	TenantNameFile = FlagInfo{
+		Name: "tenant-name-file",
+		Description: `Allows sourcing the tenant name from a file. The tenant name 
+will be expected to be by itself on the first line of the file. If the file does
+not exist, or if the tenant name is incomplete, the tenant server will block, and
+wait for the tenant name to be fully written to the file (with a newline character).`,
+	}
+
 	KVAddrs = FlagInfo{
 		Name:        "kv-addrs",
 		EnvVar:      "COCKROACH_KV_ADDRS",

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -675,7 +675,6 @@ func init() {
 		if cmd == createClientCertCmd {
 			cliflagcfg.VarFlag(f, &tenantIDSetter{tenantIDs: &certCtx.tenantScope}, cliflags.TenantScope)
 			cliflagcfg.VarFlag(f, &tenantNameSetter{tenantNames: &certCtx.tenantNameScope}, cliflags.TenantScopeByNames)
-			_ = f.MarkHidden(cliflags.TenantScopeByNames.Name)
 
 			// PKCS8 key format is only available for the client cert command.
 			cliflagcfg.BoolFlag(f, &certCtx.generatePKCS8Key, cliflags.GeneratePKCS8Key)

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -483,10 +483,17 @@ func (kvCfg *KVConfig) SetDefaults() {
 type SQLConfig struct {
 	// The tenant that the SQL server runs on the behalf of.
 	TenantID roachpb.TenantID
+	// The tenant that the SQL server runs on the behalf of. This deprecates
+	// the usage of tenant ID.
+	TenantName roachpb.TenantName
 
 	// If set, will to be called at server startup to obtain the tenant id and
 	// locality.
 	DelayedSetTenantID func(context.Context) (roachpb.TenantID, roachpb.Locality, error)
+	
+	// If set, will to be called at server startup to obtain the tenant name and
+	// locality. This deprecates the usage of DelayedSetTenantID.
+  DelayedSetTenantName func(context.Context) (roachpb.TenantName, roachpb.Locality, error)
 
 	// TempStorageConfig is used to configure temp storage, which stores
 	// ephemeral data when processing large queries.


### PR DESCRIPTION
Add a new TenantInfo rpc to internal server that takes a tenant name and returns
tenant info for that tenant. Besides other information, the response includes
TenantID. TenantInfo rpc is accessible to secondary tenants. When tenant name
is invalid, we throw internal error instead of tenant not found.