### PR TITLE
changefeedccl: add more obs to RunNemesis

### DIFF
--- a/pkg/ccl/changefeedccl/cdctest/nemeses.go
+++ b/pkg/ccl/changefeedccl/cdctest/nemeses.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/internal/sqlsmith"
 	"github.com/cockroachdb/cockroach/pkg/util/fsm"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 )
 
@@ -409,9 +410,14 @@ func RunNemesis(
 		)
 		defer queryGen.Close()
 		const numInserts = 100
+		time := timeutil.Now()
 		for i := 0; i < numInserts; i++ {
 			query := queryGen.Generate()
-			if _, err := db.Exec(query); err != nil {
+			log.Infof(ctx, "Executing query: %s", query)
+			_, err := db.Exec(query)
+			log.Infof(ctx, "Time taken to execute last query: %s", timeutil.Since(time))
+			time = timeutil.Now()
+			if err != nil {
 				log.Infof(ctx, "Skipping query %s because error %s", query, err)
 				continue
 			}


### PR DESCRIPTION
Previously, it is hard to track which sql smith generated queries take a long time 
to execute. This patch adds more observability by adding more print stmts.

Informs: https://github.com/cockroachdb/cockroach/issues/140355
Release note: none