### PR TITLE
changefeedccl/checkpoint: add Restore 

### DIFF
--- a/pkg/ccl/changefeedccl/checkpoint/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/checkpoint/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "//pkg/util/metric/aggmetric",
         "//pkg/util/span",
         "//pkg/util/timeutil",
+        "@com_github_cockroachdb_errors//:errors",
     ],
 )
 
@@ -29,6 +30,7 @@ go_test(
         "//pkg/jobs/jobspb",
         "//pkg/kv/kvserver/rangefeed",
         "//pkg/roachpb",
+        "//pkg/testutils",
         "//pkg/util/hlc",
         "//pkg/util/leaktest",
         "//pkg/util/log",
@@ -36,6 +38,7 @@ go_test(
         "//pkg/util/randutil",
         "//pkg/util/shuffle",
         "//pkg/util/span",
+        "@com_github_cockroachdb_errors//:errors",
         "@com_github_stretchr_testify//require",
     ],
 )


### PR DESCRIPTION
This patch adds the Restore to support both old and new fine grained checkpoint
mechanisms for changefeed restore upon resuming. Currently, no functions
use this interface, but future commits will integrate it to restore progress.

Part of: https://github.com/cockroachdb/cockroach/issues/137693
Release Note: None