### PR TITLE
admission: fix shutdown logic for store grant coordinator

### DIFF
--- a/pkg/util/admission/io_load_listener.go
+++ b/pkg/util/admission/io_load_listener.go
@@ -472,10 +472,6 @@ func (t *tokenAllocationTicker) adjustmentStart(loaded bool) {
 	t.adjustmentIntervalStartTime = timeutil.Now()
 }
 
-func (t *tokenAllocationTicker) tick() {
-	<-t.ticker.C
-}
-
 // remainingTicks will return the remaining ticks before the next adjustment
 // interval is reached while assuming that all future ticks will have a duration of
 // expectedTickDuration. A return value of 0 indicates that adjustmentStart must

--- a/pkg/util/admission/io_load_listener_test.go
+++ b/pkg/util/admission/io_load_listener_test.go
@@ -544,7 +544,7 @@ func TestTokenAllocationTickerAdjustmentCalculation(t *testing.T) {
 	ticker.adjustmentStart(true /* loaded */)
 	adjustmentChanged := false
 	for {
-		ticker.tick()
+		<-ticker.ticker.C
 		remainingTicks := ticker.remainingTicks()
 		if remainingTicks == 0 {
 			if adjustmentChanged {


### PR DESCRIPTION
We were incorrectly waiting on the ticker outside of the select statement, which would inherently cause a delay in case of the stopping sequence being initiated.

Informs #140454.

Release note: None