### PR TITLE
roachpb: add pretty-printing for three remaining value tags

### DIFF
--- a/pkg/roachpb/BUILD.bazel
+++ b/pkg/roachpb/BUILD.bazel
@@ -76,6 +76,7 @@ go_test(
     embed = [":roachpb"],
     deps = [
         "//pkg/cli/exit",
+        "//pkg/geo",
         "//pkg/keys",
         "//pkg/kv/kvserver/concurrency/isolation",
         "//pkg/kv/kvserver/concurrency/lock",
@@ -95,6 +96,8 @@ go_test(
         "//pkg/util/log",
         "//pkg/util/protoutil",
         "//pkg/util/randutil",
+        "//pkg/util/timeofday",
+        "//pkg/util/timetz",
         "//pkg/util/timeutil",
         "//pkg/util/uuid",
         "@com_github_cockroachdb_apd_v3//:apd",

--- a/pkg/roachpb/data.go
+++ b/pkg/roachpb/data.go
@@ -991,6 +991,18 @@ func (v Value) PrettyPrint() (ret string) {
 		var d duration.Duration
 		d, err = v.GetDuration()
 		buf.WriteString(d.StringNanos())
+	case ValueType_TIMETZ:
+		var tz timetz.TimeTZ
+		tz, err = v.GetTimeTZ()
+		buf.WriteString(tz.String())
+	case ValueType_GEO:
+		var g geopb.SpatialObject
+		g, err = v.GetGeo()
+		buf.WriteString(g.String())
+	case ValueType_BOX2D:
+		var g geopb.BoundingBox
+		g, err = v.GetBox2D()
+		buf.WriteString(g.String())
 	default:
 		err = errors.Errorf("unknown tag: %s", t)
 	}

--- a/pkg/roachpb/data.proto
+++ b/pkg/roachpb/data.proto
@@ -33,22 +33,18 @@ message Span {
 }
 
 // ValueType defines a set of type constants placed in the "tag" field of Value
-// messages. These are defined as a protocol buffer enumeration so that they
-// can be used portably between our Go and C code. The tags are used by the
-// RocksDB Merge Operator to perform specialized merges.
+// messages. These are defined as a protocol buffer enumeration for historical
+// reasons.
 enum ValueType {
   // This is a subset of the SQL column type values, representing the underlying
-  // storage for various types. The DELIMITED_foo entries each represent a foo
-  // variant that self-delimits length.
+  // storage for various types.
   UNKNOWN = 0;
-  reserved 7;
+  reserved 7, 8, 9;
   INT = 1;
   FLOAT = 2;
   BYTES = 3;
-  DELIMITED_BYTES = 8;
   TIME = 4;
   DECIMAL = 5;
-  DELIMITED_DECIMAL = 9;
   DURATION = 6;
   TIMETZ = 12;
   GEO = 13;


### PR DESCRIPTION
TIMETZ, GEO, and BOX2D value tags were missing support for pretty-printing.

Epic: None
Release note: None