### PR TITLE
roachtest: increase the verbosity around tests that kills nodes with traffic

### DIFF
--- a/pkg/cmd/roachtest/tests/restart.go
+++ b/pkg/cmd/roachtest/tests/restart.go
@@ -25,7 +25,9 @@ func runRestart(ctx context.Context, t test.Test, c cluster.Cluster, downDuratio
 
 	t.Status("installing cockroach")
 	startOpts := option.DefaultStartOpts()
-	startOpts.RoachprodOpts.ExtraArgs = append(startOpts.RoachprodOpts.ExtraArgs, "--vmodule=raft_log_queue=3")
+	// Increase the log verbosity to help debug future failures.
+	startOpts.RoachprodOpts.ExtraArgs = append(startOpts.RoachprodOpts.ExtraArgs,
+		"--vmodule=store=2,store_rebalancer=2,liveness=2,raft_log_queue=3,replica_range_lease=3,raft=3")
 	c.Start(ctx, t.L(), startOpts, install.MakeClusterSettings(), crdbNodes)
 
 	// We don't really need tpcc, we just need a good amount of traffic and a good

--- a/pkg/cmd/roachtest/tests/tpcc.go
+++ b/pkg/cmd/roachtest/tests/tpcc.go
@@ -929,6 +929,9 @@ func registerTPCC(r registry.Registry) {
 						},
 						SetupType:         usingInit,
 						WorkloadInstances: tc.workloadInstances,
+						// Increase the log verbosity to help debug future failures.
+						ExtraStartArgs: []string{
+							"--vmodule=store=2,store_rebalancer=2,liveness=2,raft_log_queue=3,replica_range_lease=3,raft=3"},
 					})
 				},
 			})
@@ -963,7 +966,9 @@ func registerTPCC(r registry.Registry) {
 					}
 				},
 				SetupType: usingImport,
-			})
+				// Increase the log verbosity to help debug future failures.
+				ExtraStartArgs: []string{
+					"--vmodule=store=2,store_rebalancer=2,liveness=2,raft_log_queue=3,replica_range_lease=3,raft=3"}})
 		},
 	})
 


### PR DESCRIPTION
The PR increases the verbosity around some roachtests that kills nodes while sending traffic. The roachtests affected by this PR:

1. restart/down-for-2m
2. tpcc/multiregion/survive=region/chaos=true
3. tpcc/multiregion/survive=zone/chaos=true
4. tpcc/w=100/nodes=3/chaos=true

References: #138028

Release note: None