### PR TITLE
roachprod: add node_exporter and collect on AWS and Azure

### DIFF
--- a/pkg/cmd/roachtest/clusterstats/helpers.go
+++ b/pkg/cmd/roachtest/clusterstats/helpers.go
@@ -27,7 +27,7 @@ import (
 func SetupCollectorPromClient(
 	ctx context.Context, c cluster.Cluster, l *logger.Logger, cfg *prometheus.Config,
 ) (prometheus.Client, error) {
-	prometheusNodeIP, err := c.ExternalIP(ctx, l, c.Node(int(cfg.PrometheusNode[0])))
+	prometheusNodeIP, err := c.ExternalIP(ctx, l, c.Node(int(cfg.PrometheusNode)))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cmd/roachtest/tests/tpcc.go
+++ b/pkg/cmd/roachtest/tests/tpcc.go
@@ -260,7 +260,7 @@ func runTPCC(
 			return
 		}
 		cep, err := opts.ChaosEventsProcessor(
-			c.Nodes(int(promCfg.PrometheusNode[0])),
+			c.Nodes(int(promCfg.PrometheusNode)),
 			workloadInstances,
 		)
 		if err != nil {

--- a/pkg/roachprod/cloud/cluster_cloud.go
+++ b/pkg/roachprod/cloud/cluster_cloud.go
@@ -494,11 +494,8 @@ func (c *Cluster) DeletePrometheusConfig(ctx context.Context, l *logger.Logger) 
 
 	for _, node := range c.VMs {
 
-		// only gce is supported for prometheus
-		if !cl.IsSupportedNodeProvider(node.Provider) {
-			continue
-		}
-		if !cl.IsSupportedPromProject(node.Project) {
+		reachability := cl.ProviderReachability(node.Provider)
+		if reachability == promhelperclient.None {
 			continue
 		}
 

--- a/pkg/roachprod/promhelperclient/BUILD.bazel
+++ b/pkg/roachprod/promhelperclient/BUILD.bazel
@@ -9,6 +9,8 @@ go_library(
         "//pkg/roachprod/config",
         "//pkg/roachprod/logger",
         "//pkg/roachprod/roachprodutil",
+        "//pkg/roachprod/vm/aws",
+        "//pkg/roachprod/vm/azure",
         "//pkg/roachprod/vm/gce",
         "//pkg/util/httputil",
         "@com_github_cockroachdb_errors//:errors",

--- a/pkg/roachprod/promhelperclient/client.go
+++ b/pkg/roachprod/promhelperclient/client.go
@@ -20,6 +20,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachprod/config"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/roachprodutil"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/vm/aws"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/vm/azure"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/vm/gce"
 	"github.com/cockroachdb/cockroach/pkg/util/httputil"
 	"github.com/cockroachdb/errors"
@@ -36,6 +38,18 @@ const (
 	// when a requests to the prometheus helper service yields a non 200 status.
 	ErrorMessage       = ErrorMessagePrefix + ` on url %s and error %s`
 	ErrorMessagePrefix = "request failed with status %d"
+)
+
+// Reachability is the reachability of the node provider.
+type Reachability int
+
+const (
+	// None indicates that the node is unreachable with this provider.
+	None Reachability = iota
+	// Private indicates that the node is reachable via private network.
+	Private
+	// Public indicates that the node is only reachable via public network.
+	Public
 )
 
 // The URL for the Prometheus registration service. An empty string means that the
@@ -62,10 +76,7 @@ type PromClient struct {
 		oauth2.TokenSource, error)
 
 	// supportedPromProviders are the providers supported for prometheus target
-	supportedPromProviders map[string]struct{}
-
-	// supportedPromProjects are the projects supported for prometheus target
-	supportedPromProjects map[string]struct{}
+	supportedPromProviders map[string]Reachability
 }
 
 // IsNotFoundError returns true if the error is a 404 error.
@@ -76,13 +87,16 @@ func IsNotFoundError(err error) bool {
 // NewPromClient returns a new instance of PromClient
 func NewPromClient() *PromClient {
 	return &PromClient{
-		promUrl:                promRegistrationUrl,
-		disabled:               promRegistrationUrl == "",
-		httpPut:                httputil.Put,
-		httpDelete:             httputil.Delete,
-		newTokenSource:         idtoken.NewTokenSource,
-		supportedPromProviders: map[string]struct{}{gce.ProviderName: {}},
-		supportedPromProjects:  map[string]struct{}{gce.DefaultProject(): {}},
+		promUrl:        promRegistrationUrl,
+		disabled:       promRegistrationUrl == "",
+		httpPut:        httputil.Put,
+		httpDelete:     httputil.Delete,
+		newTokenSource: idtoken.NewTokenSource,
+		supportedPromProviders: map[string]Reachability{
+			gce.ProviderName:   Private,
+			aws.ProviderName:   Public,
+			azure.ProviderName: Public,
+		},
 	}
 }
 
@@ -103,7 +117,7 @@ func (c *PromClient) UpdatePrometheusTargets(
 	ctx context.Context,
 	clusterName string,
 	forceFetchCreds bool,
-	nodes map[int]*NodeInfo,
+	nodes map[int][]*NodeInfo,
 	insecure bool,
 	l *logger.Logger,
 ) error {
@@ -185,18 +199,12 @@ func getUrl(promUrl, clusterName string) string {
 	return fmt.Sprintf("%s/%s/%s/%s", promUrl, resourceVersion, resourceName, clusterName)
 }
 
-// IsSupportedNodeProvider returns true if the provider is supported
-// for prometheus target.
-func (c *PromClient) IsSupportedNodeProvider(provider string) bool {
-	_, ok := c.supportedPromProviders[provider]
-	return ok
-}
-
-// IsSupportedPromProject returns true if the project is supported
-// for prometheus target.
-func (c *PromClient) IsSupportedPromProject(project string) bool {
-	_, ok := c.supportedPromProjects[project]
-	return ok
+// ProviderReachability returns the reachability of the provider
+func (c *PromClient) ProviderReachability(provider string) Reachability {
+	if reachability, ok := c.supportedPromProviders[provider]; ok {
+		return reachability
+	}
+	return None
 }
 
 // CCParams are the params for the cluster configs
@@ -212,18 +220,20 @@ type NodeInfo struct {
 }
 
 // createClusterConfigFile creates the cluster config file per node
-func buildCreateRequest(nodes map[int]*NodeInfo, insecure bool) (io.Reader, error) {
+func buildCreateRequest(nodes map[int][]*NodeInfo, insecure bool) (io.Reader, error) {
 	configs := make([]*CCParams, 0)
 	for _, n := range nodes {
-		params := &CCParams{
-			Targets: []string{n.Target},
-			Labels:  map[string]string{},
+		for _, node := range n {
+			params := &CCParams{
+				Targets: []string{node.Target},
+				Labels:  map[string]string{},
+			}
+			// custom labels - this can override the default labels if needed
+			for n, v := range node.CustomLabels {
+				params.Labels[n] = v
+			}
+			configs = append(configs, params)
 		}
-		// custom labels - this can override the default labels if needed
-		for n, v := range n.CustomLabels {
-			params.Labels[n] = v
-		}
-		configs = append(configs, params)
 	}
 	cb, err := yaml.Marshal(&configs)
 	if err != nil {

--- a/pkg/roachprod/promhelperclient/client_test.go
+++ b/pkg/roachprod/promhelperclient/client_test.go
@@ -46,15 +46,20 @@ func TestUpdatePrometheusTargets(t *testing.T) {
 			}, nil
 		}
 		err := c.UpdatePrometheusTargets(ctx, "c1", false,
-			map[int]*NodeInfo{1: {Target: "n1"}}, true, l)
+			map[int][]*NodeInfo{1: {{Target: "n1"}}}, true, l)
 		require.NotNil(t, err)
 		require.Equal(t, fmt.Sprintf(ErrorMessage, 400, getUrl(promUrl, "c1"), "failed"), err.Error())
 	})
 	t.Run("UpdatePrometheusTargets succeeds", func(t *testing.T) {
-		nodeInfos := map[int]*NodeInfo{1: {Target: "n1"}, 3: {
-			Target:       "n3",
-			CustomLabels: map[string]string{"custom": "label"},
-		}}
+		nodeInfos := map[int][]*NodeInfo{
+			1: {{
+				Target: "n1",
+			}},
+			3: {{
+				Target:       "n3",
+				CustomLabels: map[string]string{"custom": "label"},
+			}},
+		}
 		c.httpPut = func(ctx context.Context, url string, h *http.Header, body io.Reader) (
 			resp *http.Response, err error) {
 			require.Equal(t, getUrl(promUrl, "c1"), url)
@@ -66,10 +71,10 @@ func TestUpdatePrometheusTargets(t *testing.T) {
 			require.Len(t, configs, 2)
 			for _, c := range configs {
 				if c.Targets[0] == "n1" {
-					require.Empty(t, nodeInfos[1].CustomLabels)
+					require.Empty(t, nodeInfos[1][0].CustomLabels)
 				} else {
 					require.Equal(t, "n3", c.Targets[0])
-					for k, v := range nodeInfos[3].CustomLabels {
+					for k, v := range nodeInfos[3][0].CustomLabels {
 						require.Equal(t, v, c.Labels[k])
 					}
 				}

--- a/pkg/roachprod/vm/BUILD.bazel
+++ b/pkg/roachprod/vm/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "dns.go",
         "startup.go",
+        "startup_args_overrides.go",
         "vm.go",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/roachprod/vm",
@@ -21,7 +22,13 @@ go_library(
 go_test(
     name = "vm_test",
     size = "small",
-    srcs = ["vm_test.go"],
+    srcs = [
+        "startup_test.go",
+        "vm_test.go",
+    ],
     embed = [":vm"],
-    deps = ["@com_github_stretchr_testify//assert"],
+    deps = [
+        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
+    ],
 )

--- a/pkg/roachprod/vm/aws/support.go
+++ b/pkg/roachprod/vm/aws/support.go
@@ -162,6 +162,7 @@ setup_disks
 {{ template "hostname_utils" . }}
 {{ template "fips_utils" . }}
 {{ template "ssh_utils" . }}
+{{ template "node_exporter" . }}
 
 sudo touch {{ .OSInitializedFile }}
 `
@@ -187,17 +188,13 @@ func writeStartupScript(
 	}
 
 	args := tmplParams{
-		StartupArgs: vm.StartupArgs{
-			VMName:               name,
-			SharedUser:           remoteUser,
-			DisksInitializedFile: vm.DisksInitializedFile,
-			OSInitializedFile:    vm.OSInitializedFile,
-			StartupLogs:          vm.StartupLogs,
-			EnableCron:           false,
-			Zfs:                  fileSystem == vm.Zfs,
-			EnableFIPS:           enableFips,
-			ChronyServers:        []string{"169.254.169.123"},
-		},
+		StartupArgs: vm.DefaultStartupArgs(
+			vm.WithVMName(name),
+			vm.WithSharedUser(remoteUser),
+			vm.WithZfs(fileSystem == vm.Zfs),
+			vm.WithEnableFIPS(enableFips),
+			vm.WithChronyServers([]string{"169.254.169.123"}),
+		),
 		ExtraMountOpts:   extraMountOpts,
 		UseMultipleDisks: useMultiple,
 	}

--- a/pkg/roachprod/vm/aws/testdata/startup_script
+++ b/pkg/roachprod/vm/aws/testdata/startup_script
@@ -273,6 +273,27 @@ sudo service sshd restart
 sudo service ssh restart
 
 
+
+# Add and start node_exporter, only authorize scrapping from internal network.
+export ARCH=$(dpkg --print-architecture)
+export DEFAULT_USER_HOME="/home/$(id -nu 1000)"
+mkdir -p ${DEFAULT_USER_HOME}/node_exporter && curl -fsSL \
+	https://storage.googleapis.com/cockroach-test-artifacts/prometheus/node_exporter-1.2.2.linux-${ARCH}.tar.gz |
+	tar zxv --strip-components 1 -C ${DEFAULT_USER_HOME}/node_exporter \
+	&& chown -R 1000:1000 ${DEFAULT_USER_HOME}/node_exporter
+
+sudo iptables -A INPUT -s 127.0.0.1,10.0.0.0/8,prometheus.testeng.crdb.io -p tcp --dport 9100 -j ACCEPT
+sudo iptables -A INPUT -p tcp --dport 9100 -j DROP
+(
+	chown -R 1000:1000 ${DEFAULT_USER_HOME}/node_exporter && \
+	cd ${DEFAULT_USER_HOME}/node_exporter && \
+	sudo systemd-run --unit node_exporter --same-dir \
+		./node_exporter --collector.systemd --collector.interrupts --collector.processes \
+		--web.listen-address=":9100" \
+		--web.telemetry-path="/metrics"
+)
+
+
 sudo touch /.roachprod-initialized
 ----
 ----

--- a/pkg/roachprod/vm/azure/azure.go
+++ b/pkg/roachprod/vm/azure/azure.go
@@ -805,23 +805,12 @@ func (p *Provider) createVM(
 	opts vm.CreateOpts,
 	providerOpts ProviderOpts,
 ) (machine compute.VirtualMachine, err error) {
+
 	startupArgs := azureStartupArgs{
-		StartupArgs: vm.StartupArgs{
-			VMName:               name,
-			SharedUser:           remoteUser,
-			DisksInitializedFile: vm.DisksInitializedFile,
-			OSInitializedFile:    vm.OSInitializedFile,
-			StartupLogs:          vm.StartupLogs,
-			EnableCron:           false,
-			Zfs:                  false,
-			EnableFIPS:           false,
-			ChronyServers: []string{
-				"time1.google.com",
-				"time2.google.com",
-				"time3.google.com",
-				"time4.google.com",
-			},
-		},
+		StartupArgs: vm.DefaultStartupArgs(
+			vm.WithVMName(name),
+			vm.WithSharedUser(remoteUser),
+		),
 		DiskControllerNVMe: false,
 		AttachedDiskLun:    nil,
 	}

--- a/pkg/roachprod/vm/azure/testdata/startup_script
+++ b/pkg/roachprod/vm/azure/testdata/startup_script
@@ -212,6 +212,27 @@ sudo service sshd restart
 sudo service ssh restart
 
 
+
+# Add and start node_exporter, only authorize scrapping from internal network.
+export ARCH=$(dpkg --print-architecture)
+export DEFAULT_USER_HOME="/home/$(id -nu 1000)"
+mkdir -p ${DEFAULT_USER_HOME}/node_exporter && curl -fsSL \
+	https://storage.googleapis.com/cockroach-test-artifacts/prometheus/node_exporter-1.2.2.linux-${ARCH}.tar.gz |
+	tar zxv --strip-components 1 -C ${DEFAULT_USER_HOME}/node_exporter \
+	&& chown -R 1000:1000 ${DEFAULT_USER_HOME}/node_exporter
+
+sudo iptables -A INPUT -s 127.0.0.1,10.0.0.0/8,prometheus.testeng.crdb.io -p tcp --dport 0 -j ACCEPT
+sudo iptables -A INPUT -p tcp --dport 0 -j DROP
+(
+	chown -R 1000:1000 ${DEFAULT_USER_HOME}/node_exporter && \
+	cd ${DEFAULT_USER_HOME}/node_exporter && \
+	sudo systemd-run --unit node_exporter --same-dir \
+		./node_exporter --collector.systemd --collector.interrupts --collector.processes \
+		--web.listen-address=":0" \
+		--web.telemetry-path="/metrics"
+)
+
+
 sudo touch /.roachprod-initialized
 ----
 ----

--- a/pkg/roachprod/vm/azure/utils.go
+++ b/pkg/roachprod/vm/azure/utils.go
@@ -85,6 +85,7 @@ echo $ts_dev_id | sudo tee /sys/bus/vmbus/drivers/hv_utils/unbind
 {{ template "hostname_utils" . }}
 {{ template "fips_utils" . }}
 {{ template "ssh_utils" . }}
+{{ template "node_exporter" . }}
 
 sudo touch {{ .OSInitializedFile }}
 `

--- a/pkg/roachprod/vm/gce/testdata/startup_script
+++ b/pkg/roachprod/vm/gce/testdata/startup_script
@@ -279,6 +279,27 @@ sudo service sshd restart
 sudo service ssh restart
 
 
+
+# Add and start node_exporter, only authorize scrapping from internal network.
+export ARCH=$(dpkg --print-architecture)
+export DEFAULT_USER_HOME="/home/$(id -nu 1000)"
+mkdir -p ${DEFAULT_USER_HOME}/node_exporter && curl -fsSL \
+	https://storage.googleapis.com/cockroach-test-artifacts/prometheus/node_exporter-1.2.2.linux-${ARCH}.tar.gz |
+	tar zxv --strip-components 1 -C ${DEFAULT_USER_HOME}/node_exporter \
+	&& chown -R 1000:1000 ${DEFAULT_USER_HOME}/node_exporter
+
+sudo iptables -A INPUT -s 127.0.0.1,10.0.0.0/8,prometheus.testeng.crdb.io -p tcp --dport 9100 -j ACCEPT
+sudo iptables -A INPUT -p tcp --dport 9100 -j DROP
+(
+	chown -R 1000:1000 ${DEFAULT_USER_HOME}/node_exporter && \
+	cd ${DEFAULT_USER_HOME}/node_exporter && \
+	sudo systemd-run --unit node_exporter --same-dir \
+		./node_exporter --collector.systemd --collector.interrupts --collector.processes \
+		--web.listen-address=":9100" \
+		--web.telemetry-path="/metrics"
+)
+
+
 sudo touch /.roachprod-initialized
 ----
 ----

--- a/pkg/roachprod/vm/gce/utils.go
+++ b/pkg/roachprod/vm/gce/utils.go
@@ -170,6 +170,7 @@ setup_disks true
 {{ template "hostname_utils" . }}
 {{ template "fips_utils" . }}
 {{ template "ssh_utils" . }}
+{{ template "node_exporter" . }}
 
 sudo touch {{ .OSInitializedFile }}
 `
@@ -196,16 +197,13 @@ func writeStartupScript(
 	}
 
 	args := tmplParams{
-		StartupArgs: vm.StartupArgs{
-			SharedUser:           config.SharedUser,
-			DisksInitializedFile: vm.DisksInitializedFile,
-			OSInitializedFile:    vm.OSInitializedFile,
-			StartupLogs:          vm.StartupLogs,
-			EnableCron:           enableCron,
-			Zfs:                  fileSystem == vm.Zfs,
-			EnableFIPS:           enableFIPS,
-			ChronyServers:        []string{"metadata.google.internal"},
-		},
+		StartupArgs: vm.DefaultStartupArgs(
+			vm.WithSharedUser(config.SharedUser),
+			vm.WithEnableCron(enableCron),
+			vm.WithZfs(fileSystem == vm.Zfs),
+			vm.WithEnableFIPS(enableFIPS),
+			vm.WithChronyServers([]string{"metadata.google.internal"}),
+		),
 		ExtraMountOpts:   extraMountOpts,
 		UseMultipleDisks: useMultiple,
 		PublicKey:        publicKey,

--- a/pkg/roachprod/vm/startup_args_overrides.go
+++ b/pkg/roachprod/vm/startup_args_overrides.go
@@ -1,0 +1,161 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package vm
+
+// IArgOverride is an interface for applying overrides to StartupArgs.
+type IArgOverride interface {
+	apply(args *StartupArgs)
+}
+
+// WithVMNameOverride is an override for the VMName field in StartupArgs.
+type WithVMNameOverride struct {
+	VMName string
+}
+
+// apply applies the VMName override to the StartupArgs.
+func (o WithVMNameOverride) apply(args *StartupArgs) {
+	args.VMName = o.VMName
+}
+
+// WithVMName overrides the VMName.
+func WithVMName(vmName string) WithVMNameOverride {
+	return WithVMNameOverride{VMName: vmName}
+}
+
+// WithVMImageOverride is an override for the VMImage field in StartupArgs.
+type WithSharedUserOverride struct {
+	SharedUser string
+}
+
+// apply applies the SharedUser override to the StartupArgs.
+func (o WithSharedUserOverride) apply(args *StartupArgs) {
+	args.SharedUser = o.SharedUser
+}
+
+// WithSharedUser overrides the SharedUser.
+func WithSharedUser(sharedUser string) WithSharedUserOverride {
+	return WithSharedUserOverride{SharedUser: sharedUser}
+}
+
+// WithStartupLogsOverride is an override for the StartupLogs field.
+type WithStartupLogsOverride struct {
+	StartupLogs string
+}
+
+// apply applies the startup logs path override to the StartupArgs.
+func (o WithStartupLogsOverride) apply(args *StartupArgs) {
+	args.StartupLogs = o.StartupLogs
+}
+
+// WithStartupLogs overrides the startup logs path.
+func WithStartupLogs(startupLogs string) WithStartupLogsOverride {
+	return WithStartupLogsOverride{StartupLogs: startupLogs}
+}
+
+// WithOSInitializedFileOverride is an override for the OSInitializedFile field.
+type WithOSInitializedFileOverride struct {
+	OSInitializedFile string
+}
+
+// apply applies the OSInitializedFile override to the StartupArgs.
+func (o WithOSInitializedFileOverride) apply(args *StartupArgs) {
+	args.OSInitializedFile = o.OSInitializedFile
+}
+
+// WithOSInitializedFile overrides the OSInitializedFile.
+func WithOSInitializedFile(osInitializedFile string) WithOSInitializedFileOverride {
+	return WithOSInitializedFileOverride{OSInitializedFile: osInitializedFile}
+}
+
+// WithDisksInitializedFileOverride is an override for the DisksInitializedFile field.
+type WithDisksInitializedFileOverride struct {
+	DisksInitializedFile string
+}
+
+// apply applies the DisksInitializedFile override to the StartupArgs.
+func (o WithDisksInitializedFileOverride) apply(args *StartupArgs) {
+	args.DisksInitializedFile = o.DisksInitializedFile
+}
+
+// WithDisksInitializedFile overrides the DisksInitializedFile.
+func WithDisksInitializedFile(disksInitializedFile string) WithDisksInitializedFileOverride {
+	return WithDisksInitializedFileOverride{DisksInitializedFile: disksInitializedFile}
+}
+
+// WithZfsOverride is an override for the Zfs field.
+type WithZfsOverride struct {
+	Zfs bool
+}
+
+// apply applies the Zfs override to the StartupArgs.
+func (o WithZfsOverride) apply(args *StartupArgs) {
+	args.Zfs = o.Zfs
+}
+
+// WithZfs overrides the Zfs field.
+func WithZfs(zfs bool) WithZfsOverride {
+	return WithZfsOverride{Zfs: zfs}
+}
+
+// WithEnableFIPSOverride is an override for the EnableFIPS field.
+type WithEnableFIPSOverride struct {
+	EnableFIPS bool
+}
+
+// apply applies the EnableFIPS override to the StartupArgs.
+func (o WithEnableFIPSOverride) apply(args *StartupArgs) {
+	args.EnableFIPS = o.EnableFIPS
+}
+
+// WithEnableFIPS overrides the EnableFIPS field.
+func WithEnableFIPS(enableFIPS bool) WithEnableFIPSOverride {
+	return WithEnableFIPSOverride{EnableFIPS: enableFIPS}
+}
+
+// WithEnableCronOverride is an override for the EnableCron field.
+type WithEnableCronOverride struct {
+	EnableCron bool
+}
+
+// apply applies the EnableCron override to the StartupArgs.
+func (o WithEnableCronOverride) apply(args *StartupArgs) {
+	args.EnableCron = o.EnableCron
+}
+
+// WithEnableCron overrides the EnableCron field.
+func WithEnableCron(enableCron bool) WithEnableCronOverride {
+	return WithEnableCronOverride{EnableCron: enableCron}
+}
+
+// WithChronyServersOverride is an override for the ChronyServers field.
+type WithChronyServersOverride struct {
+	ChronyServers []string
+}
+
+// apply applies the ChronyServers override to the StartupArgs.
+func (o WithChronyServersOverride) apply(args *StartupArgs) {
+	args.ChronyServers = o.ChronyServers
+}
+
+// WithChronyServers overrides the ChronyServers field.
+func WithChronyServers(chronyServers []string) WithChronyServersOverride {
+	return WithChronyServersOverride{ChronyServers: chronyServers}
+}
+
+// WithNodeExporterPortOverride is an override for the NodeExporterPort field.
+type WithNodeExporterPortOverride struct {
+	NodeExporterPort int
+}
+
+// apply applies the NodeExporterPort override to the StartupArgs.
+func (o WithNodeExporterPortOverride) apply(args *StartupArgs) {
+	args.NodeExporterPort = o.NodeExporterPort
+}
+
+// WithNodeExporterPort overrides the NodeExporterPort field.
+func WithNodeExporterPort(nodeExporterPort int) WithNodeExporterPortOverride {
+	return WithNodeExporterPortOverride{NodeExporterPort: nodeExporterPort}
+}

--- a/pkg/roachprod/vm/startup_test.go
+++ b/pkg/roachprod/vm/startup_test.go
@@ -1,0 +1,57 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package vm
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenericStartupArgs(t *testing.T) {
+	t.Run("WithVMName", func(t *testing.T) {
+		args := DefaultStartupArgs(WithVMName("test"))
+		require.Equal(t, args.VMName, "test")
+	})
+	t.Run("WithSharedUser", func(t *testing.T) {
+		args := DefaultStartupArgs(WithSharedUser("test"))
+		require.Equal(t, args.SharedUser, "test")
+	})
+	t.Run("WithStartupLogs", func(t *testing.T) {
+		args := DefaultStartupArgs(WithStartupLogs("test"))
+		require.Equal(t, args.StartupLogs, "test")
+	})
+	t.Run("WithOSInitializedFile", func(t *testing.T) {
+		args := DefaultStartupArgs(WithOSInitializedFile("test"))
+		require.Equal(t, args.OSInitializedFile, "test")
+	})
+	t.Run("WithDiskInitializeFile", func(t *testing.T) {
+		args := DefaultStartupArgs(WithDisksInitializedFile("test"))
+		require.Equal(t, args.DisksInitializedFile, "test")
+	})
+	t.Run("WithZfs", func(t *testing.T) {
+		args := DefaultStartupArgs(WithZfs(true))
+		require.Equal(t, args.Zfs, true)
+	})
+	t.Run("WithFIPS", func(t *testing.T) {
+		args := DefaultStartupArgs(WithEnableFIPS(true))
+		require.Equal(t, args.EnableFIPS, true)
+	})
+	t.Run("WithEnableCron", func(t *testing.T) {
+		args := DefaultStartupArgs(WithEnableCron(true))
+		require.Equal(t, args.EnableCron, true)
+	})
+	t.Run("WithChronyServers", func(t *testing.T) {
+		args := DefaultStartupArgs(WithChronyServers([]string{"test"}))
+		require.Equal(t, args.ChronyServers, []string{"test"})
+	})
+	t.Run("WithNodeExporterPort", func(t *testing.T) {
+		args := DefaultStartupArgs(WithNodeExporterPort(1234))
+		if args.NodeExporterPort != 1234 {
+			t.Fatalf("expected NodeExporterPort to be 1234, got %d", args.NodeExporterPort)
+		}
+	})
+}

--- a/pkg/roachprod/vm/vm.go
+++ b/pkg/roachprod/vm/vm.go
@@ -42,22 +42,6 @@ const (
 	ArchAMD64   = CPUArch("amd64")
 	ArchFIPS    = CPUArch("fips")
 	ArchUnknown = CPUArch("unknown")
-
-	// InitializedFile is the base name of the initialization paths defined below.
-	InitializedFile = ".roachprod-initialized"
-	// OSInitializedFile is a marker file that is created on a VM to indicate
-	// that it has been initialized at least once by the VM start-up script. This
-	// is used to avoid re-initializing a VM that has been stopped and restarted.
-	OSInitializedFile = "/" + InitializedFile
-	// DisksInitializedFile is a marker file that is created on a VM to indicate
-	// that the disks have been initialized by the VM start-up script. This is
-	// separate from OSInitializedFile, because the disks may be ephemeral and
-	// need to be re-initialized on every start. The presence of this file
-	// automatically implies the presence of OSInitializedFile.
-	DisksInitializedFile = "/mnt/data1/" + InitializedFile
-	// StartupLogs is a log file that is created on a VM to redirect startup script
-	// output logs.
-	StartupLogs = "/var/log/roachprod_startup.log"
 )
 
 // UnimplementedError is returned when a method is not implemented by a


### PR DESCRIPTION
Previously, Prometheus was only collecting the `cockroachdb` metrics on the GCP roachprod clusters.

This PR introduces the installation and collection of system metrics exposed via `node_exporter` now installed during in the nodes' startup script, and also adds metrics collection for AWS and Azure.

The difference between secure and insecure targets is now managed by Prometheus labels, which allows to scrape both secure and insecure exporters on the same cluster.

Firewall rules are added to prevent node_exporter metrics collection from untrusted sources.
The node_exporter setup inside the `grafana-start` command has been reworked a bit to avoid reinstalling node_exporter if it is already installed on the node, and to adapt the firewall rules so that it can be scrapped by the cluster's Prometheus node.

Epic: none
Release note: None