### PR TITLE
changefeedccl: increase ChangefeedTimelyResolvedTimestampUpdatePostRollingRestart verbosity

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -6841,7 +6841,8 @@ func TestChangefeedTimelyResolvedTimestampUpdatePostRollingRestart(t *testing.T)
 	defer log.Scope(t).Close(t)
 
 	// Add verbose logging to help debug future failures.
-	require.NoError(t, log.SetVModule("changefeed_processors=1"))
+	require.NoError(t, log.SetVModule("changefeed_processors=1,replica_rangefeed=2,"+
+		"replica_range_lease=3,raft=3"))
 
 	// This test requires many range splits, which can be slow under certain test
 	// conditions. Skip potentially slow tests.


### PR DESCRIPTION
This commit increases the verbosity of the test:
TestChangefeedTimelyResolvedTimestampUpdatePostRollingRestart so that we have a better chance understanding what happened if it fails.

References: #140133

Release note: None