### PR TITLE
sql/schemachanger: Fixed TestBuildDataDriven failed [Desc ID mismatch]

### DIFF
--- a/pkg/sql/schemachanger/scbuild/builder_test.go
+++ b/pkg/sql/schemachanger/scbuild/builder_test.go
@@ -108,7 +108,7 @@ func TestBuildDataDriven(t *testing.T) {
 							// to mimic the ID generator and optimizer (resolve all
 							// dependencies in functions and views). So we need these pieces
 							// to be similar as sql dependencies.
-							sctestdeps.WithIDGenerator(s),
+							sctestdeps.WithTransactionalIDGenerator(s),
 							sctestdeps.WithReferenceProviderFactory(refFactory),
 						),
 					)

--- a/pkg/sql/schemachanger/scdeps/sctestdeps/config.go
+++ b/pkg/sql/schemachanger/scdeps/sctestdeps/config.go
@@ -160,6 +160,12 @@ func WithIDGenerator(s serverutils.ApplicationLayerInterface) Option {
 	})
 }
 
+func WithTransactionalIDGenerator(s serverutils.ApplicationLayerInterface) Option {
+	return optionFunc(func(state *TestState) {
+		state.evalCtx.DescIDGenerator = descidgen.NewTransactionalGenerator(s.ClusterSettings(), s.Codec(), state.evalCtx.Txn)
+	})
+}
+
 func WithReferenceProviderFactory(f scbuild.ReferenceProviderFactory) Option {
 	return optionFunc(func(state *TestState) {
 		state.refProviderFactory = f


### PR DESCRIPTION
Previously we were not using the transactional ID generator, resulting in unstable data.  I made the changes to use a transactional ID generator instead to make this test more predictable and stable.

Fixes: #140064
Release note: None