### PR TITLE
catalog/ingesting: disallow writing cross database references

### DIFF
--- a/pkg/backup/restore_job.go
+++ b/pkg/backup/restore_job.go
@@ -1325,6 +1325,7 @@ func createImportingDescriptors(
 			if err := ingesting.WriteDescriptors(
 				ctx, txn.KV(), p.User(), descsCol, databases, writtenSchemas, tables, writtenTypes, writtenFunctions,
 				details.DescriptorCoverage, nil /* extra */, restoreTempSystemDB, includePublicSchemaCreatePriv,
+				true, /* deprecatedAllowCrossDatabaseRefs */
 			); err != nil {
 				return errors.Wrapf(err, "restoring %d TableDescriptors from %d databases", len(tables), len(databases))
 			}

--- a/pkg/sql/catalog/externalcatalog/external_catalog.go
+++ b/pkg/sql/catalog/externalcatalog/external_catalog.go
@@ -160,6 +160,7 @@ func IngestExternalCatalog(
 	return ingestedCatalog, ingesting.WriteDescriptors(
 		ctx, txn.KV(), user, descsCol, nil, nil, tablesToWrite, nil, nil,
 		tree.RequestedDescriptors, nil /* extra */, "", true,
+		false, /*allowCrossDatabaseRefs*/
 	)
 }
 

--- a/pkg/sql/catalog/ingesting/BUILD.bazel
+++ b/pkg/sql/catalog/ingesting/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/catalog/descs",
         "//pkg/sql/catalog/funcdesc",
+        "//pkg/sql/catalog/nstree",
         "//pkg/sql/catalog/schemadesc",
         "//pkg/sql/catalog/tabledesc",
         "//pkg/sql/catalog/typedesc",

--- a/pkg/sql/catalog/ingesting/write_descs.go
+++ b/pkg/sql/catalog/ingesting/write_descs.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/funcdesc"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/nstree"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/schemadesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/typedesc"
@@ -51,7 +52,9 @@ func WriteDescriptors(
 	extra []roachpb.KeyValue,
 	inheritParentName string,
 	includePublicSchemaCreatePriv bool,
+	allowCrossDatabaseRefs bool,
 ) (err error) {
+	var writtenDescs nstree.MutableCatalog
 	ctx, span := tracing.ChildSpan(ctx, "WriteDescriptors")
 	defer span.Finish()
 	defer func() {
@@ -104,6 +107,7 @@ func WriteDescriptors(
 				return err
 			}
 		}
+		writtenDescs.UpsertDescriptor(desc)
 	}
 
 	// Write namespace and descriptor entries for each schema.
@@ -133,6 +137,7 @@ func WriteDescriptors(
 		if err := descsCol.InsertNamespaceEntryToBatch(ctx, kvTrace, sc, b); err != nil {
 			return err
 		}
+		writtenDescs.UpsertDescriptor(sc)
 	}
 
 	for i := range tables {
@@ -162,6 +167,7 @@ func WriteDescriptors(
 		if err := descsCol.InsertNamespaceEntryToBatch(ctx, kvTrace, table, b); err != nil {
 			return err
 		}
+		writtenDescs.UpsertDescriptor(table)
 	}
 
 	// Write all type descriptors -- create namespace entries and write to
@@ -189,6 +195,7 @@ func WriteDescriptors(
 		if err := descsCol.InsertNamespaceEntryToBatch(ctx, kvTrace, typ, b); err != nil {
 			return err
 		}
+		writtenDescs.UpsertDescriptor(typ)
 	}
 
 	for _, fn := range functions {
@@ -211,6 +218,15 @@ func WriteDescriptors(
 			return err
 		}
 		// Function does not have namespace entry.
+		writtenDescs.UpsertDescriptor(fn)
+	}
+
+	// allowCrossDatabaseRefs is only used by code paths that need the ability
+	// to write deprecated cross database references (i.e. RESTORE / IMPORT).
+	if !allowCrossDatabaseRefs {
+		if err := checkForCrossDatabaseReferences(ctx, writtenDescs.Catalog, descsCol, txn); err != nil {
+			return err
+		}
 	}
 
 	for _, kv := range extra {
@@ -252,4 +268,42 @@ func processTableForMultiRegion(
 		}
 	}
 	return nil
+}
+
+// checkForCrossDatabaseReferences checks if any descriptors written have
+// cross database references. Once cross database references are fully removed this can be
+// a part of descriptor validation.
+func checkForCrossDatabaseReferences(
+	ctx context.Context, descsToCheck nstree.Catalog, descsCol *descs.Collection, txn *kv.Txn,
+) error {
+	return descsToCheck.ForEachDescriptor(func(desc catalog.Descriptor) error {
+		referencedDescs, err := desc.GetReferencedDescIDs(catalog.ValidationLevelAllPreTxnCommit)
+		if err != nil {
+			return err
+		}
+		// Fetch the parent ID of the descriptor. If the object
+		// is already the database its self-referential.
+		parentID := desc.GetParentID()
+		if desc.DescriptorType() == catalog.Database {
+			parentID = desc.GetID()
+		}
+		for _, refID := range referencedDescs.Ordered() {
+			refDesc, err := descsCol.ByIDWithoutLeased(txn).Get().Desc(ctx, refID)
+			if err != nil {
+				return err
+			}
+			otherParentID := refDesc.GetParentID()
+			if refDesc.DescriptorType() == catalog.Database {
+				otherParentID = refDesc.GetID()
+			}
+			if otherParentID != parentID {
+				return pgerror.Newf(
+					pgcode.FeatureNotSupported,
+					"cross database %s references are not supported: %s",
+					refDesc.GetObjectType(),
+					refDesc.GetName())
+			}
+		}
+		return nil
+	})
 }

--- a/pkg/sql/importer/import_job.go
+++ b/pkg/sql/importer/import_job.go
@@ -638,6 +638,7 @@ func prepareNewTablesForIngestion(
 		ctx, txn, p.User(), descsCol, nil /* databases */, nil /* schemas */, tableDescs,
 		nil /* types */, nil /* functions */, tree.RequestedDescriptors, seqValKVs,
 		"" /* inheritParentName */, includePublicSchemaCreatePriv,
+		true, /* allowCrossDatabaseRefs */
 	); err != nil {
 		return nil, errors.Wrapf(err, "creating importTables")
 	}


### PR DESCRIPTION
Previously, the ingest API supported writing cross database references, which could allow tables to be ingested in a manner that is deprecated. To avoid issues, this patch adds an error when cross database references of any kind are detected.

Fixes: #138230

Release note: None

Note: This functionality is only blocked for LDR, since backup / restore and imports have to work with cross database references until we fully remove them.