### PR TITLE
changefeedccl: support envelope=enriched for avro

### DIFF
--- a/pkg/ccl/changefeedccl/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/BUILD.bazel
@@ -170,6 +170,7 @@ go_library(
         "@com_github_klauspost_compress//zstd",
         "@com_github_klauspost_pgzip//:pgzip",
         "@com_github_lib_pq//:pq",
+        "@com_github_linkedin_goavro_v2//:goavro",
         "@com_github_rcrowley_go_metrics//:go-metrics",
         "@com_github_twmb_franz_go//pkg/kerr",
         "@com_github_twmb_franz_go//pkg/kgo",

--- a/pkg/ccl/changefeedccl/avro/avro_test.go
+++ b/pkg/ccl/changefeedccl/avro/avro_test.go
@@ -760,15 +760,15 @@ func TestAvroSchema(t *testing.T) {
 	})
 }
 
-func (f *schemaField) defaultValueNative() (interface{}, bool) {
+func (f *SchemaField) defaultValueNative() (interface{}, bool) {
 	schType := f.SchemaType
-	if union, ok := schType.([]schemaType); ok {
+	if union, ok := schType.([]SchemaType); ok {
 		// "Default values for union fields correspond to the first schema in
 		// the union."
 		schType = union[0]
 	}
 	switch schType {
-	case schemaTypeNull:
+	case SchemaTypeNull:
 		return nil, true
 	}
 	panic(errors.Errorf(`unimplemented %T: %v`, schType, schType))

--- a/pkg/ccl/changefeedccl/cdctest/schema_registry.go
+++ b/pkg/ccl/changefeedccl/cdctest/schema_registry.go
@@ -168,7 +168,6 @@ func (r *SchemaRegistry) register(hw http.ResponseWriter, hr *http.Request) (err
 	if err := json.NewDecoder(hr.Body).Decode(&req); err != nil {
 		return err
 	}
-
 	subject := strings.Split(hr.URL.Path, "/")[2]
 	id := r.registerSchema(subject, req.Schema)
 	res, err := json.Marshal(confluentSchemaVersionResponse{ID: id})

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -3885,9 +3885,11 @@ func TestChangefeedEnrichedAvro(t *testing.T) {
 		sqlDB.Exec(t, `CREATE TABLE foo (a INT PRIMARY KEY, b STRING)`)
 		sqlDB.Exec(t, `INSERT INTO foo values (0, 'dog')`)
 		foo := feed(t, f, `CREATE CHANGEFEED FOR foo WITH envelope=enriched, format=avro, confluent_schema_registry='localhost:90909'`)
-		// The feed should allow this configuration.
 		defer closeFeed(t, foo)
-		// TODO(#139660): assert messages once this envelope type is integrated into the test suite.
+
+		assertPayloadsEnvelopeStripTs(t, foo, changefeedbase.OptEnvelopeEnriched, []string{
+			`foo: {"a":{"long":0}}->{"after": {"foo": {"a": {"long": 0}, "b": {"string": "dog"}}}, "op": {"string": "c"}, "source": {"source": {"changefeed_sink": {"string": "kafka"}}}}`,
+		})
 	}
 	cdcTest(t, testFn, feedTestForceSink("kafka"))
 }

--- a/pkg/ccl/changefeedccl/helpers_test.go
+++ b/pkg/ccl/changefeedccl/helpers_test.go
@@ -143,7 +143,12 @@ func stripTsFromPayloads(
 
 		switch envelopeType {
 		case changefeedbase.OptEnvelopeEnriched:
-			delete(message["payload"].(map[string]any), "ts_ns")
+			// This message may have a `payload` wrapper if format=json and `enriched_properties` includes `schema`
+			if message["payload"] == nil {
+				delete(message, "ts_ns")
+			} else {
+				delete(message["payload"].(map[string]any), "ts_ns")
+			}
 		case changefeedbase.OptEnvelopeWrapped:
 			delete(message, "updated")
 		default:


### PR DESCRIPTION
Add support for the enriched envelope type to avro.

Epic: CRDB-8665
Fixes: #139657

Release note (enterprise change): Add support for
the enriched envelope type to avro.