### PR TITLE
changefeedccl/avro: remove c and posix collated locales from avro test

### DIFF
--- a/pkg/ccl/changefeedccl/avro/avro_test.go
+++ b/pkg/ccl/changefeedccl/avro/avro_test.go
@@ -342,7 +342,14 @@ func TestAvroSchema(t *testing.T) {
 		switch typ.Family() {
 		case types.StringFamily:
 			collationTags := collatedstring.Supported()
+			// "C" and "POSIX" locales are not allowed for collated string
+			// columns in CRDB (see collatedstring logic tests),
+			// so we don't expect these types to be emitted by changefeeds.
 			randCollationTag := collationTags[rand.Intn(len(collationTags))]
+			for randCollationTag == collatedstring.CCollationTag ||
+				randCollationTag == collatedstring.PosixCollationTag {
+				randCollationTag = collationTags[rand.Intn(len(collationTags))]
+			}
 			collatedType := types.MakeCollatedString(typ, randCollationTag)
 			typesToTest = append(typesToTest, collatedType)
 		}


### PR DESCRIPTION
Previously TestAvroSchema could choose from any valid collated string locale in its randomized testing. However, the C and POSIX locales are not supported for column types, so it does not make sense to test these. In fact, using them leads to errors, since these types can't be parsed.

Epic: None
Fixes: #140485

Release note: None