### PR TITLE
add source provider for enriched envelope

### DIFF
--- a/pkg/ccl/changefeedccl/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
         "encoder_avro.go",
         "encoder_csv.go",
         "encoder_json.go",
+        "enriched_source_provider.go",
         "event_processing.go",
         "fetch_table_bytes.go",
         "metrics.go",

--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -1241,9 +1241,11 @@ func newChangeFrontierProcessor(
 		return nil, err
 	}
 
+	sourceProvider := newEnrichedSourceProvider(encodingOpts, enrichedSourceData{jobId: cf.spec.JobID.String()})
 	if cf.encoder, err = getEncoder(
 		ctx, encodingOpts, AllTargets(spec.Feed), spec.Feed.Select != "",
 		makeExternalConnectionProvider(ctx, flowCtx.Cfg.DB), sliMetrics,
+		sourceProvider,
 	); err != nil {
 		return nil, err
 	}

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -603,8 +603,9 @@ func createChangefeedJobRecord(
 	if err != nil {
 		return nil, err
 	}
+	sourceProvider := newEnrichedSourceProvider(encodingOpts, enrichedSourceData{jobId: jobID.String()})
 	if _, err := getEncoder(ctx, encodingOpts, AllTargets(details), details.Select != "",
-		makeExternalConnectionProvider(ctx, p.ExecCfg().InternalDB), nil); err != nil {
+		makeExternalConnectionProvider(ctx, p.ExecCfg().InternalDB), nil, sourceProvider); err != nil {
 		return nil, err
 	}
 

--- a/pkg/ccl/changefeedccl/encoder.go
+++ b/pkg/ccl/changefeedccl/encoder.go
@@ -45,10 +45,11 @@ func getEncoder(
 	encodeForQuery bool,
 	p externalConnectionProvider,
 	sliMetrics *sliMetrics,
+	sourceProvider *enrichedSourceProvider,
 ) (Encoder, error) {
 	switch opts.Format {
 	case changefeedbase.OptFormatJSON:
-		return makeJSONEncoder(ctx, jsonEncoderOptions{EncodingOptions: opts, encodeForQuery: encodeForQuery})
+		return makeJSONEncoder(ctx, jsonEncoderOptions{EncodingOptions: opts, encodeForQuery: encodeForQuery}, sourceProvider)
 	case changefeedbase.OptFormatAvro, changefeedbase.DeprecatedOptFormatAvro:
 		return newConfluentAvroEncoder(opts, targets, p, sliMetrics)
 	case changefeedbase.OptFormatCSV:

--- a/pkg/ccl/changefeedccl/encoder_json_test.go
+++ b/pkg/ccl/changefeedccl/encoder_json_test.go
@@ -156,7 +156,7 @@ func TestJSONEncoderJSONNullAsObject(t *testing.T) {
 		// NOTE: This is no longer required in go 1.22+, but bazel still requires it. See https://github.com/bazelbuild/rules_go/issues/3924
 		c := c
 		t.Run(c.name, func(t *testing.T) {
-			e, err := getEncoder(ctx, opts, targets, false, nil, nil)
+			e, err := getEncoder(ctx, opts, targets, false, nil, nil, getTestingEnrichedSourceProvider(opts))
 			require.NoError(t, err)
 
 			row := cdcevent.TestingMakeEventRow(tableDesc, 0, c.row, false)
@@ -200,7 +200,8 @@ func TestJSONEncoderJSONNullAsObjectEdgeCases(t *testing.T) {
 			rowenc.EncDatum{Datum: tree.DBoolTrue},
 			rowenc.EncDatum{Datum: tree.NewDJSON(json.NullJSONValue)},
 		}
-		e, err := getEncoder(ctx, opts, targets, false, nil, nil)
+		e, err := getEncoder(ctx, opts, targets, false, nil, nil,
+			getTestingEnrichedSourceProvider(opts))
 		require.NoError(t, err)
 
 		row := cdcevent.TestingMakeEventRow(tableDesc, 0, eRow, false)
@@ -223,7 +224,8 @@ func TestJSONEncoderJSONNullAsObjectEdgeCases(t *testing.T) {
 			rowenc.EncDatum{Datum: tree.NewDJSON(json.NullJSONValue)},
 			rowenc.EncDatum{Datum: tree.DNull},
 		}
-		e, err := getEncoder(ctx, opts, twoJSONsTargets, false, nil, nil)
+		e, err := getEncoder(ctx, opts, twoJSONsTargets, false, nil, nil,
+			getTestingEnrichedSourceProvider(opts))
 		require.NoError(t, err)
 
 		row := cdcevent.TestingMakeEventRow(twoJSONsTableDesc, 0, eRow, false)
@@ -240,7 +242,8 @@ func TestJSONEncoderJSONNullAsObjectEdgeCases(t *testing.T) {
 			rowenc.EncDatum{Datum: tree.NewDJSON(json.NullJSONValue)},
 			rowenc.EncDatum{Datum: tree.NewDJSON(json.NullJSONValue)},
 		}
-		e, err := getEncoder(ctx, opts, twoJSONsTargets, false, nil, nil)
+		e, err := getEncoder(ctx, opts, twoJSONsTargets, false, nil, nil,
+			getTestingEnrichedSourceProvider(opts))
 		require.NoError(t, err)
 
 		row := cdcevent.TestingMakeEventRow(twoJSONsTableDesc, 0, eRow, false)
@@ -261,7 +264,8 @@ func TestJSONEncoderJSONNullAsObjectEdgeCases(t *testing.T) {
 			rowenc.EncDatum{Datum: tree.NewDJSON(json.NullJSONValue)},
 			rowenc.EncDatum{Datum: tree.DNull},
 		}
-		e, err := getEncoder(ctx, disabledOpts, twoJSONsTargets, false, nil, nil)
+		e, err := getEncoder(ctx, disabledOpts, twoJSONsTargets, false, nil, nil,
+			getTestingEnrichedSourceProvider(disabledOpts))
 		require.NoError(t, err)
 
 		row := cdcevent.TestingMakeEventRow(twoJSONsTableDesc, 0, eRow, false)
@@ -282,7 +286,8 @@ func TestJSONEncoderJSONNullAsObjectEdgeCases(t *testing.T) {
 			rowenc.EncDatum{Datum: tree.NewDJSON(json.NullJSONValue)},
 			rowenc.EncDatum{Datum: tree.NewDJSON(obj)},
 		}
-		e, err := getEncoder(ctx, opts, twoJSONsTargets, false, nil, nil)
+		e, err := getEncoder(ctx, opts, twoJSONsTargets, false, nil, nil,
+			getTestingEnrichedSourceProvider(opts))
 		require.NoError(t, err)
 
 		row := cdcevent.TestingMakeEventRow(twoJSONsTableDesc, 0, eRow, false)

--- a/pkg/ccl/changefeedccl/encoder_test.go
+++ b/pkg/ccl/changefeedccl/encoder_test.go
@@ -241,7 +241,7 @@ func TestEncoders(t *testing.T) {
 				return
 			}
 			require.NoError(t, o.Validate())
-			e, err := getEncoder(context.Background(), o, targets, false, nil, nil)
+			e, err := getEncoder(context.Background(), o, targets, false, nil, nil, getTestingEnrichedSourceProvider(o))
 			require.NoError(t, err)
 
 			rowInsert := cdcevent.TestingMakeEventRow(tableDesc, 0, row, false)
@@ -387,7 +387,7 @@ func TestAvroEncoderWithTLS(t *testing.T) {
 				StatementTimeName: changefeedbase.StatementTimeName(tableDesc.GetName()),
 			})
 
-			e, err := getEncoder(context.Background(), opts, targets, false, nil, nil)
+			e, err := getEncoder(context.Background(), opts, targets, false, nil, nil, getTestingEnrichedSourceProvider(opts))
 			require.NoError(t, err)
 
 			rowInsert := cdcevent.TestingMakeEventRow(tableDesc, 0, row, false)
@@ -419,7 +419,7 @@ func TestAvroEncoderWithTLS(t *testing.T) {
 			defer noCertReg.Close()
 			opts.SchemaRegistryURI = noCertReg.URL()
 
-			enc, err := getEncoder(context.Background(), opts, targets, false, nil, nil)
+			enc, err := getEncoder(context.Background(), opts, targets, false, nil, nil, getTestingEnrichedSourceProvider(opts))
 			require.NoError(t, err)
 			_, err = enc.EncodeKey(context.Background(), rowInsert)
 			require.Regexp(t, "x509", err)
@@ -432,7 +432,7 @@ func TestAvroEncoderWithTLS(t *testing.T) {
 			defer wrongCertReg.Close()
 			opts.SchemaRegistryURI = wrongCertReg.URL()
 
-			enc, err = getEncoder(context.Background(), opts, targets, false, nil, nil)
+			enc, err = getEncoder(context.Background(), opts, targets, false, nil, nil, getTestingEnrichedSourceProvider(opts))
 			require.NoError(t, err)
 			_, err = enc.EncodeKey(context.Background(), rowInsert)
 			require.Regexp(t, `contacting confluent schema registry.*: x509`, err)
@@ -973,7 +973,8 @@ func BenchmarkEncoders(b *testing.B) {
 		b.ReportAllocs()
 		b.StopTimer()
 
-		encoder, err := getEncoder(context.Background(), opts, targets, false, nil, nil)
+		encoder, err := getEncoder(context.Background(), opts, targets, false, nil, nil,
+			getTestingEnrichedSourceProvider(opts))
 		if err != nil {
 			b.Fatal(err)
 		}
@@ -1247,7 +1248,7 @@ func TestJsonRountrip(t *testing.T) {
 
 			// TODO(#139660): test this with other envelopes.
 			opts := jsonEncoderOptions{EncodingOptions: changefeedbase.EncodingOptions{Envelope: changefeedbase.OptEnvelopeBare}}
-			encoder, err := makeJSONEncoder(context.Background(), opts)
+			encoder, err := makeJSONEncoder(context.Background(), opts, getTestingEnrichedSourceProvider(opts.EncodingOptions))
 			require.NoError(t, err)
 
 			// Encode the value to a string and parse it. Assert that the parsed json matches the

--- a/pkg/ccl/changefeedccl/enriched_source_provider.go
+++ b/pkg/ccl/changefeedccl/enriched_source_provider.go
@@ -1,0 +1,62 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package changefeedccl
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/avro"
+	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/cdcevent"
+	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeedbase"
+	"github.com/cockroachdb/cockroach/pkg/util/json"
+)
+
+type enrichedSourceProviderOpts struct {
+	updated, mvccTimestamp bool
+}
+type enrichedSourceData struct {
+	jobId string
+	// TODO(#139692): Add schema info support.
+	// TODO(#139691): Add job info support.
+	// TODO(#139690): Add node/cluster info support.
+}
+type enrichedSourceProvider struct {
+	opts       enrichedSourceProviderOpts
+	sourceData enrichedSourceData
+}
+
+func newEnrichedSourceProvider(
+	opts changefeedbase.EncodingOptions, sourceData enrichedSourceData,
+) *enrichedSourceProvider {
+	return &enrichedSourceProvider{sourceData: sourceData, opts: enrichedSourceProviderOpts{
+		mvccTimestamp: opts.MVCCTimestamps,
+		updated:       opts.UpdatedTimestamps,
+	}}
+}
+
+func (p *enrichedSourceProvider) Schema() *avro.DataRecord {
+	// TODO(#139655): Implement this.
+	return nil
+}
+
+func (p *enrichedSourceProvider) GetJSON(row cdcevent.Row) (json.JSON, error) {
+	// TODO(various): Add fields here.
+	keys := []string{"job_id"}
+	b, err := json.NewFixedKeysObjectBuilder(keys)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := b.Set("job_id", json.FromString(p.sourceData.jobId)); err != nil {
+		return nil, err
+	}
+
+	return b.Build()
+}
+
+func (p *enrichedSourceProvider) GetAvro(row cdcevent.Row) ([]byte, error) {
+	// TODO(#139655): Implement this.
+
+	return nil, nil
+}

--- a/pkg/ccl/changefeedccl/event_processing.go
+++ b/pkg/ccl/changefeedccl/event_processing.go
@@ -101,7 +101,11 @@ func newEventConsumer(
 	makeConsumer := func(s EventSink, frontier frontier) (eventConsumer, error) {
 		var err error
 		encoder, err := getEncoder(ctx, encodingOpts, feed.Targets, spec.Select.Expr != "",
-			makeExternalConnectionProvider(ctx, cfg.DB), sliMetrics)
+			makeExternalConnectionProvider(ctx, cfg.DB), sliMetrics, newEnrichedSourceProvider(
+				encodingOpts, enrichedSourceData{
+					jobId: spec.JobID.String(),
+				}),
+		)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/ccl/changefeedccl/helpers_test.go
+++ b/pkg/ccl/changefeedccl/helpers_test.go
@@ -1436,3 +1436,15 @@ func ChangefeedJobPermissionsTestSetup(t *testing.T, s TestServer) {
 		`CREATE USER regularUser`,
 	)
 }
+
+// getTestingEnrichedSourceData creates an enrichedSourceData
+// for use in tests.
+func getTestingEnrichedSourceData() enrichedSourceData {
+	return enrichedSourceData{jobId: "test_id"}
+}
+
+// getTestingEnrichedSourceProvider creates an enrichedSourceProvider
+// for use in tests.
+func getTestingEnrichedSourceProvider(opts changefeedbase.EncodingOptions) *enrichedSourceProvider {
+	return newEnrichedSourceProvider(opts, getTestingEnrichedSourceData())
+}

--- a/pkg/ccl/changefeedccl/sink_cloudstorage_test.go
+++ b/pkg/ccl/changefeedccl/sink_cloudstorage_test.go
@@ -166,7 +166,7 @@ func TestCloudStorageSink(t *testing.T) {
 		// NB: compression added in single-node subtest.
 	}
 	ts := func(i int64) hlc.Timestamp { return hlc.Timestamp{WallTime: i} }
-	e, err := makeJSONEncoder(ctx, jsonEncoderOptions{EncodingOptions: opts})
+	e, err := makeJSONEncoder(ctx, jsonEncoderOptions{EncodingOptions: opts}, getTestingEnrichedSourceProvider(opts))
 	require.NoError(t, err)
 
 	clientFactory := blobs.TestBlobServiceClient(externalIODir)

--- a/pkg/ccl/changefeedccl/sink_webhook_test.go
+++ b/pkg/ccl/changefeedccl/sink_webhook_test.go
@@ -128,7 +128,7 @@ func testSendAndReceiveRows(t *testing.T, sinkSrc Sink, sinkDest *cdctest.MockWe
 
 	opts, err := getGenericWebhookSinkOptions().GetEncodingOptions()
 	require.NoError(t, err)
-	enc, err := makeJSONEncoder(ctx, jsonEncoderOptions{EncodingOptions: opts})
+	enc, err := makeJSONEncoder(ctx, jsonEncoderOptions{EncodingOptions: opts}, getTestingEnrichedSourceProvider(opts))
 	require.NoError(t, err)
 
 	// test a resolved timestamp entry


### PR DESCRIPTION
    changefeedccl: add source provider for enriched envelope
    
    This adds a source provider for the enriched envelope which will contain
    the data used in the source field of events for the new envelope type.
    This includes an example field usage (jobId).
    
    Fixes: #139689
    
    Epic: CRDB-8665
    
    Release note: None