### PR TITLE
upgrade_manager: fix ListBetweenOverride for some tests

### DIFF
--- a/pkg/upgrade/upgradebase/testing_knobs.go
+++ b/pkg/upgrade/upgradebase/testing_knobs.go
@@ -27,9 +27,9 @@ const (
 // are useful for testing.
 type TestingKnobs struct {
 
-	// ListBetweenOverride injects an override for `clusterversion.ListBetween()
-	// in order to run upgrades corresponding to versions which do not
-	// actually exist.
+	// ListBetweenOverride injects an override for clusterversion.ListBetween() in
+	// order to run upgrades corresponding to versions which do not actually
+	// exist. This function has to return versions in the range (from, to].
 	ListBetweenOverride func(from, to roachpb.Version) []roachpb.Version
 
 	// RegistryOverride is used to inject upgrades for specific cluster versions.

--- a/pkg/upgrade/upgrades/schema_changes_external_test.go
+++ b/pkg/upgrade/upgrades/schema_changes_external_test.go
@@ -351,9 +351,7 @@ func testMigrationWithFailures(
 						},
 						UpgradeManager: &upgradebase.TestingKnobs{
 							ListBetweenOverride: func(from, to roachpb.Version) []roachpb.Version {
-								return []roachpb.Version{
-									endCV,
-								}
+								return []roachpb.Version{to}
 							},
 							RegistryOverride: func(cv roachpb.Version) (upgradebase.Upgrade, bool) {
 								if cv.Equal(endCV) {
@@ -364,7 +362,7 @@ func testMigrationWithFailures(
 										upgrade.RestoreActionNotRequired("test"),
 									), true
 								}
-								panic("unexpected version")
+								return nil, false
 							}},
 					},
 				},


### PR DESCRIPTION
`ListBetweenOverride` is used by tests to override `clusterversion.ListBetween` when we are not testing with real versions. This function is supposed to return versions that are *after* `from`; some tests return `from` in the result which causes some failures when trying to mint the 25.1 release.

This commit fixes these and adds validation of the `ListBetweenOverride` result.

Epic: none
Release note: None