### PR TITLE
roachtest: deflake c2c node shutdown tests

### DIFF
--- a/pkg/cmd/roachtest/tests/jobs_util.go
+++ b/pkg/cmd/roachtest/tests/jobs_util.go
@@ -180,7 +180,7 @@ func WaitForStatus(
 	maxWait time.Duration,
 ) error {
 	startTime := timeutil.Now()
-	ticker := time.NewTicker(5 * time.Second)
+	ticker := time.NewTicker(time.Microsecond)
 	defer ticker.Stop()
 	var status string
 	for {
@@ -200,6 +200,7 @@ func WaitForStatus(
 			if timeutil.Since(startTime) > maxWait {
 				return errors.Newf("job %d did not reach status %s after %s", jobID, status, maxWait)
 			}
+			ticker.Reset(5 * time.Second)
 		case <-ctx.Done():
 			return errors.Wrapf(ctx.Err(), "context canceled while waiting for job to reach status %s", status)
 		}


### PR DESCRIPTION
If a node shutdown were planned during cutover, the test could flake because cutover completed before the shutdown was executed. This reduces a 5 second wait on the shutdown path to 1 microsecond.

Informs #140194
Informs #137328

Release note: none