### PR TITLE
raft: optimize new leader replication flow with follower

### DIFF
--- a/pkg/raft/raft.go
+++ b/pkg/raft/raft.go
@@ -1958,6 +1958,7 @@ func stepLeader(r *raft, m pb.Message) error {
 			r.logger.Debugf("%x received MsgAppResp(rejected, hint: (index %d, term %d)) from %x for index %d",
 				r.id, m.RejectHint, m.LogTerm, m.From, m.Index)
 			nextProbeIdx := m.RejectHint
+			nextTerm := m.LogTerm
 			if m.LogTerm > 0 {
 				// If the follower has an uncommitted log tail, we would end up
 				// probing one by one until we hit the common prefix.
@@ -2053,13 +2054,19 @@ func stepLeader(r *raft, m pb.Message) error {
 				//    7, the rejection points it at the end of the follower's log
 				//    which is at a higher log term than the actually committed
 				//    log.
-				nextProbeIdx, _ = r.raftLog.findConflictByTerm(m.RejectHint, m.LogTerm)
+				nextProbeIdx, nextTerm = r.raftLog.findConflictByTerm(m.RejectHint, m.LogTerm)
 			}
 			if pr.MaybeDecrTo(m.Index, nextProbeIdx) {
-				r.logger.Debugf("%x decreased progress of %x to [%s]", r.id, m.From, pr)
-				if pr.State == tracker.StateReplicate {
+				// match := r.raftLog.matchTerm(entryID{nextTerm, nextProbeIdx})
+				if m.LogTerm != 0 && nextTerm == m.LogTerm && pr.State == tracker.StateProbe {
+					r.becomeReplicate(pr)
+				} else if pr.State == tracker.StateReplicate {
 					r.becomeProbe(pr)
 				}
+
+				pr.Next = max(nextProbeIdx+1, pr.Match+1)
+
+				r.logger.Debugf("%x decreased progress of %x to [%s]", r.id, m.From, pr)
 				r.maybeSendAppend(m.From)
 			}
 		} else {

--- a/pkg/raft/raft_test.go
+++ b/pkg/raft/raft_test.go
@@ -2591,7 +2591,7 @@ func TestLeaderAppResp(t *testing.T) {
 		// denied resp; leader does not commit; decrease next and send probing msg
 		// An additional term storage access is involved for an entry
 		// that's already persisted since we are probing backwards.
-		{3, true, 0, 3, 1, 2, 0, 2},
+		{3, true, 0, 4, 1, 3, 0, 1},
 
 		// Follower 2 responds to leader, indicating log index 2 is replicated.
 		// Leader tries to commit, but commit index doesn't advance since the index
@@ -4935,8 +4935,8 @@ func TestFastLogRejection(t *testing.T) {
 			followerCompact: 5, // entries <= index 5 are compacted
 			rejectHintTerm:  0,
 			rejectHintIndex: 3,
-			nextAppendTerm:  1,
-			nextAppendIndex: 2,
+			nextAppendTerm:  3,
+			nextAppendIndex: 3,
 		},
 	}
 

--- a/pkg/raft/testdata/campaign_learner_must_vote.txt
+++ b/pkg/raft/testdata/campaign_learner_must_vote.txt
@@ -124,7 +124,7 @@ stabilize 2 3
   3->2 MsgFortifyLeaderResp Term:2 Log:0/0 LeadEpoch:1
   3->2 MsgAppResp Term:2 Log:1/4 Rejected (Hint: 3) Commit:3
   DEBUG 2 received MsgAppResp(rejected, hint: (index 3, term 1)) from 3 for index 4
-  DEBUG 2 decreased progress of 3 to [StateProbe match=0 next=4 sentCommit=3 matchCommit=3]
+  DEBUG 2 decreased progress of 3 to [StateReplicate match=0 next=4 sentCommit=3 matchCommit=3]
 > 2 handling Ready
   Ready MustSync=false:
   Messages:
@@ -155,6 +155,7 @@ stabilize 2 3
 > 2 receiving messages
   3->2 MsgAppResp Term:2 Log:1/4 Rejected (Hint: 3) Commit:3
   DEBUG 2 received MsgAppResp(rejected, hint: (index 3, term 1)) from 3 for index 4
+  DEBUG 2 decreased progress of 3 to [StateProbe match=0 next=4 sentCommit=0 matchCommit=3]
   3->2 MsgAppResp Term:2 Log:0/5 Commit:4
 > 2 handling Ready
   Ready MustSync=true:
@@ -162,8 +163,16 @@ stabilize 2 3
   CommittedEntries:
   2/5 EntryNormal ""
   Messages:
+  2->3 MsgApp Term:2 Log:1/3 Commit:4 Entries:[
+    1/4 EntryConfChangeV2 v3
+    2/5 EntryNormal ""
+  ]
   2->3 MsgApp Term:2 Log:2/5 Commit:5
 > 3 receiving messages
+  2->3 MsgApp Term:2 Log:1/3 Commit:4 Entries:[
+    1/4 EntryConfChangeV2 v3
+    2/5 EntryNormal ""
+  ]
   2->3 MsgApp Term:2 Log:2/5 Commit:5
 > 3 handling Ready
   Ready MustSync=true:
@@ -171,6 +180,8 @@ stabilize 2 3
   CommittedEntries:
   2/5 EntryNormal ""
   Messages:
+  3->2 MsgAppResp Term:2 Log:0/4 Commit:4
   3->2 MsgAppResp Term:2 Log:0/5 Commit:5
 > 2 receiving messages
+  3->2 MsgAppResp Term:2 Log:0/4 Commit:4
   3->2 MsgAppResp Term:2 Log:0/5 Commit:5

--- a/pkg/raft/testdata/confchange_fortification_safety.txt
+++ b/pkg/raft/testdata/confchange_fortification_safety.txt
@@ -162,7 +162,7 @@ stabilize 1 4
   4->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:1
   4->1 MsgAppResp Term:1 Log:1/3 Rejected (Hint: 2) Commit:2
   DEBUG 1 received MsgAppResp(rejected, hint: (index 2, term 1)) from 4 for index 3
-  DEBUG 1 decreased progress of 4 to [StateProbe match=0 next=3 sentCommit=2 matchCommit=2]
+  DEBUG 1 decreased progress of 4 to [StateReplicate match=0 next=3 sentCommit=2 matchCommit=2]
 > 1 handling Ready
   Ready MustSync=false:
   Messages:
@@ -203,7 +203,28 @@ stabilize 1 4
 > 1 receiving messages
   4->1 MsgAppResp Term:1 Log:1/3 Rejected (Hint: 2) Commit:2
   DEBUG 1 received MsgAppResp(rejected, hint: (index 2, term 1)) from 4 for index 3
+  DEBUG 1 decreased progress of 4 to [StateProbe match=0 next=3 sentCommit=0 matchCommit=2]
   4->1 MsgAppResp Term:1 Log:0/5 Commit:4
+> 1 handling Ready
+  Ready MustSync=false:
+  Messages:
+  1->4 MsgApp Term:1 Log:1/2 Commit:4 Entries:[
+    1/3 EntryNormal ""
+    1/4 EntryConfChangeV2 v4
+    1/5 EntryNormal ""
+  ]
+> 4 receiving messages
+  1->4 MsgApp Term:1 Log:1/2 Commit:4 Entries:[
+    1/3 EntryNormal ""
+    1/4 EntryConfChangeV2 v4
+    1/5 EntryNormal ""
+  ]
+> 4 handling Ready
+  Ready MustSync=false:
+  Messages:
+  4->1 MsgAppResp Term:1 Log:0/4 Commit:4
+> 1 receiving messages
+  4->1 MsgAppResp Term:1 Log:0/4 Commit:4
 
 store-liveness
 ----

--- a/pkg/raft/testdata/leader_step_down_stranded_peer.txt
+++ b/pkg/raft/testdata/leader_step_down_stranded_peer.txt
@@ -344,7 +344,7 @@ stabilize
   3->1 MsgFortifyLeaderResp Term:4 Log:0/0 LeadEpoch:1
   3->1 MsgAppResp Term:4 Log:1/11 Rejected (Hint: 10) Commit:10
   DEBUG 1 received MsgAppResp(rejected, hint: (index 10, term 1)) from 3 for index 11
-  DEBUG 1 decreased progress of 3 to [StateProbe match=0 next=11 sentCommit=10 matchCommit=10]
+  DEBUG 1 decreased progress of 3 to [StateReplicate match=0 next=11 sentCommit=10 matchCommit=10]
 > 1 handling Ready
   Ready MustSync=true:
   HardState Term:4 Vote:1 Commit:12 Lead:1 LeadEpoch:1
@@ -393,6 +393,25 @@ stabilize
   2->1 MsgAppResp Term:4 Log:0/12 Commit:12
   3->1 MsgAppResp Term:4 Log:1/11 Rejected (Hint: 10) Commit:10
   DEBUG 1 received MsgAppResp(rejected, hint: (index 10, term 1)) from 3 for index 11
+  DEBUG 1 decreased progress of 3 to [StateProbe match=0 next=11 sentCommit=0 matchCommit=10]
+  3->1 MsgAppResp Term:4 Log:0/12 Commit:12
+> 1 handling Ready
+  Ready MustSync=false:
+  Messages:
+  1->3 MsgApp Term:4 Log:1/10 Commit:12 Entries:[
+    1/11 EntryNormal ""
+    4/12 EntryNormal ""
+  ]
+> 3 receiving messages
+  1->3 MsgApp Term:4 Log:1/10 Commit:12 Entries:[
+    1/11 EntryNormal ""
+    4/12 EntryNormal ""
+  ]
+> 3 handling Ready
+  Ready MustSync=false:
+  Messages:
+  3->1 MsgAppResp Term:4 Log:0/12 Commit:12
+> 1 receiving messages
   3->1 MsgAppResp Term:4 Log:0/12 Commit:12
 
 raft-state

--- a/pkg/raft/testdata/leader_step_down_stranded_peer_prevote.txt
+++ b/pkg/raft/testdata/leader_step_down_stranded_peer_prevote.txt
@@ -488,7 +488,7 @@ stabilize
   3->1 MsgFortifyLeaderResp Term:4 Log:0/0 LeadEpoch:1
   3->1 MsgAppResp Term:4 Log:1/11 Rejected (Hint: 10) Commit:10
   DEBUG 1 received MsgAppResp(rejected, hint: (index 10, term 1)) from 3 for index 11
-  DEBUG 1 decreased progress of 3 to [StateProbe match=0 next=11 sentCommit=10 matchCommit=10]
+  DEBUG 1 decreased progress of 3 to [StateReplicate match=0 next=11 sentCommit=10 matchCommit=10]
 > 1 handling Ready
   Ready MustSync=true:
   HardState Term:4 Vote:1 Commit:12 Lead:1 LeadEpoch:1
@@ -537,6 +537,25 @@ stabilize
   2->1 MsgAppResp Term:4 Log:0/12 Commit:12
   3->1 MsgAppResp Term:4 Log:1/11 Rejected (Hint: 10) Commit:10
   DEBUG 1 received MsgAppResp(rejected, hint: (index 10, term 1)) from 3 for index 11
+  DEBUG 1 decreased progress of 3 to [StateProbe match=0 next=11 sentCommit=0 matchCommit=10]
+  3->1 MsgAppResp Term:4 Log:0/12 Commit:12
+> 1 handling Ready
+  Ready MustSync=false:
+  Messages:
+  1->3 MsgApp Term:4 Log:1/10 Commit:12 Entries:[
+    1/11 EntryNormal ""
+    4/12 EntryNormal ""
+  ]
+> 3 receiving messages
+  1->3 MsgApp Term:4 Log:1/10 Commit:12 Entries:[
+    1/11 EntryNormal ""
+    4/12 EntryNormal ""
+  ]
+> 3 handling Ready
+  Ready MustSync=false:
+  Messages:
+  3->1 MsgAppResp Term:4 Log:0/12 Commit:12
+> 1 receiving messages
   3->1 MsgAppResp Term:4 Log:0/12 Commit:12
 
 raft-state

--- a/pkg/raft/testdata/probe_and_replicate.txt
+++ b/pkg/raft/testdata/probe_and_replicate.txt
@@ -562,12 +562,18 @@ stabilize 1
   1->6 MsgApp Term:8 Log:6/20 Commit:18 Entries:[8/21 EntryNormal ""]
   1->7 MsgApp Term:8 Log:6/20 Commit:18 Entries:[8/21 EntryNormal ""]
 
+log-level debug
+----
+ok
+
+
 ## Recover each follower, one by one.
 stabilize 1 2
 ----
 > 2 receiving messages
   1->2 MsgFortifyLeader Term:8 Log:0/0
   1->2 MsgApp Term:8 Log:6/20 Commit:18 Entries:[8/21 EntryNormal ""]
+  DEBUG 2 [logterm: 0, index: 20] rejected MsgApp [logterm: 6, index: 20] from 1
 > 2 handling Ready
   Ready MustSync=true:
   HardState Term:8 Vote:1 Commit:18 Lead:1 LeadEpoch:2
@@ -577,6 +583,8 @@ stabilize 1 2
 > 1 receiving messages
   2->1 MsgFortifyLeaderResp Term:8 Log:0/0 LeadEpoch:2
   2->1 MsgAppResp Term:8 Log:6/20 Rejected (Hint: 19) Commit:18
+  DEBUG 1 received MsgAppResp(rejected, hint: (index 19, term 6)) from 2 for index 20
+  DEBUG 1 decreased progress of 2 to [StateReplicate match=0 next=20 sentCommit=18 matchCommit=18]
 > 1 handling Ready
   Ready MustSync=false:
   Messages:
@@ -587,6 +595,7 @@ stabilize 1 2
   ]
 > 2 receiving messages
   1->2 MsgApp Term:8 Log:6/20 Commit:18 Entries:[8/21 EntryNormal ""]
+  DEBUG 2 [logterm: 0, index: 20] rejected MsgApp [logterm: 6, index: 20] from 1
   1->2 MsgApp Term:8 Log:6/19 Commit:18 Entries:[
     6/20 EntryNormal "prop_6_20"
     8/21 EntryNormal ""
@@ -601,7 +610,31 @@ stabilize 1 2
   2->1 MsgAppResp Term:8 Log:0/21 Commit:18
 > 1 receiving messages
   2->1 MsgAppResp Term:8 Log:6/20 Rejected (Hint: 19) Commit:18
+  DEBUG 1 received MsgAppResp(rejected, hint: (index 19, term 6)) from 2 for index 20
+  DEBUG 1 decreased progress of 2 to [StateProbe match=0 next=20 sentCommit=0 matchCommit=18]
   2->1 MsgAppResp Term:8 Log:0/21 Commit:18
+> 1 handling Ready
+  Ready MustSync=false:
+  Messages:
+  1->2 MsgApp Term:8 Log:6/19 Commit:18 Entries:[
+    6/20 EntryNormal "prop_6_20"
+    8/21 EntryNormal ""
+  ]
+> 2 receiving messages
+  1->2 MsgApp Term:8 Log:6/19 Commit:18 Entries:[
+    6/20 EntryNormal "prop_6_20"
+    8/21 EntryNormal ""
+  ]
+> 2 handling Ready
+  Ready MustSync=false:
+  Messages:
+  2->1 MsgAppResp Term:8 Log:0/21 Commit:18
+> 1 receiving messages
+  2->1 MsgAppResp Term:8 Log:0/21 Commit:18
+
+log-level info
+----
+ok
 
 stabilize 1 3
 ----
@@ -663,6 +696,34 @@ stabilize 1 3
 > 1 receiving messages
   3->1 MsgAppResp Term:8 Log:4/20 Rejected (Hint: 14) Commit:14
   3->1 MsgAppResp Term:8 Log:0/21 Commit:18
+> 1 handling Ready
+  Ready MustSync=false:
+  Messages:
+  1->3 MsgApp Term:8 Log:4/14 Commit:18 Entries:[
+    4/15 EntryNormal "prop_4_15"
+    5/16 EntryNormal ""
+    5/17 EntryNormal "prop_5_17"
+    6/18 EntryNormal ""
+    6/19 EntryNormal "prop_6_19"
+    6/20 EntryNormal "prop_6_20"
+    8/21 EntryNormal ""
+  ]
+> 3 receiving messages
+  1->3 MsgApp Term:8 Log:4/14 Commit:18 Entries:[
+    4/15 EntryNormal "prop_4_15"
+    5/16 EntryNormal ""
+    5/17 EntryNormal "prop_5_17"
+    6/18 EntryNormal ""
+    6/19 EntryNormal "prop_6_19"
+    6/20 EntryNormal "prop_6_20"
+    8/21 EntryNormal ""
+  ]
+> 3 handling Ready
+  Ready MustSync=false:
+  Messages:
+  3->1 MsgAppResp Term:8 Log:0/18 Commit:18
+> 1 receiving messages
+  3->1 MsgAppResp Term:8 Log:0/18 Commit:18
 
 stabilize 1 4
 ----
@@ -760,6 +821,26 @@ stabilize 1 5
 > 1 receiving messages
   5->1 MsgAppResp Term:8 Log:6/20 Rejected (Hint: 18) Commit:18
   5->1 MsgAppResp Term:8 Log:0/21 Commit:21
+> 1 handling Ready
+  Ready MustSync=false:
+  Messages:
+  1->5 MsgApp Term:8 Log:6/18 Commit:21 Entries:[
+    6/19 EntryNormal "prop_6_19"
+    6/20 EntryNormal "prop_6_20"
+    8/21 EntryNormal ""
+  ]
+> 5 receiving messages
+  1->5 MsgApp Term:8 Log:6/18 Commit:21 Entries:[
+    6/19 EntryNormal "prop_6_19"
+    6/20 EntryNormal "prop_6_20"
+    8/21 EntryNormal ""
+  ]
+> 5 handling Ready
+  Ready MustSync=false:
+  Messages:
+  5->1 MsgAppResp Term:8 Log:0/21 Commit:21
+> 1 receiving messages
+  5->1 MsgAppResp Term:8 Log:0/21 Commit:21
 
 stabilize 1 6
 ----
@@ -821,4 +902,30 @@ stabilize 1 6
   6->1 MsgAppResp Term:8 Log:0/21 Commit:21
 > 1 receiving messages
   6->1 MsgAppResp Term:8 Log:4/20 Rejected (Hint: 17) Commit:15
+  6->1 MsgAppResp Term:8 Log:0/21 Commit:21
+> 1 handling Ready
+  Ready MustSync=false:
+  Messages:
+  1->6 MsgApp Term:8 Log:4/15 Commit:21 Entries:[
+    5/16 EntryNormal ""
+    5/17 EntryNormal "prop_5_17"
+    6/18 EntryNormal ""
+    6/19 EntryNormal "prop_6_19"
+    6/20 EntryNormal "prop_6_20"
+    8/21 EntryNormal ""
+  ]
+> 6 receiving messages
+  1->6 MsgApp Term:8 Log:4/15 Commit:21 Entries:[
+    5/16 EntryNormal ""
+    5/17 EntryNormal "prop_5_17"
+    6/18 EntryNormal ""
+    6/19 EntryNormal "prop_6_19"
+    6/20 EntryNormal "prop_6_20"
+    8/21 EntryNormal ""
+  ]
+> 6 handling Ready
+  Ready MustSync=false:
+  Messages:
+  6->1 MsgAppResp Term:8 Log:0/21 Commit:21
+> 1 receiving messages
   6->1 MsgAppResp Term:8 Log:0/21 Commit:21

--- a/pkg/raft/testdata/replicate_pause.txt
+++ b/pkg/raft/testdata/replicate_pause.txt
@@ -152,7 +152,7 @@ stabilize 1
 > 1 receiving messages
   3->1 MsgAppResp Term:1 Log:1/14 Rejected (Hint: 11) Commit:11
   DEBUG 1 received MsgAppResp(rejected, hint: (index 11, term 1)) from 3 for index 14
-  DEBUG 1 decreased progress of 3 to [StateReplicate match=11 next=12 sentCommit=11 matchCommit=11 paused inflight=3[full]]
+  DEBUG 1 decreased progress of 3 to [StateProbe match=11 next=12 sentCommit=11 matchCommit=11]
 > 1 handling Ready
   Ready MustSync=false:
   Messages:

--- a/pkg/raft/tracker/progress.go
+++ b/pkg/raft/tracker/progress.go
@@ -268,7 +268,7 @@ func (pr *Progress) MaybeDecrTo(rejected, matchHint uint64) bool {
 		// Directly decrease next to match + 1.
 		//
 		// TODO(tbg): why not use matchHint if it's larger?
-		pr.Next = pr.Match + 1
+		pr.Next = max(pr.Match, matchHint) + 1
 		// Regress the SentCommit since it unlikely has been applied.
 		pr.SentCommit = min(pr.SentCommit, pr.Next-1)
 		return true

--- a/pkg/raft/tracker/progress_test.go
+++ b/pkg/raft/tracker/progress_test.go
@@ -181,8 +181,8 @@ func TestProgressMaybeDecr(t *testing.T) {
 		},
 		{
 			// state replicate and rejected is greater than match
-			// directly decrease to match+1
-			StateReplicate, 5, 10, 9, 9, true, 6,
+			// directly decrease to max(matchHint, match) + 1
+			StateReplicate, 5, 10, 9, 9, true, 10,
 		},
 		{
 			// next-1 != rejected is always false


### PR DESCRIPTION
This commit is a draft change. An optimization where the leader transitions a follower tracker
 state to stateReplicate from stateProbe, if the leader handles a MsgAppResp with
reject:true and the reject hint index/term is currently in the leader's log

This will allow the leader to catch up followers one hop faster, usually after leadership change.

Note: this change is draft change. It is incorrect and causes unnescessary snapshots to be sent. Needs further work.

References: cockroachdb#140516
Epic: None
Release note: None