### PR TITLE
catalog/externalcatalog: delete namespace entries during clean up

### DIFF
--- a/pkg/sql/catalog/externalcatalog/external_catalog.go
+++ b/pkg/sql/catalog/externalcatalog/external_catalog.go
@@ -256,6 +256,9 @@ func DropIngestedExternalCatalog(
 		if err := descsCol.WriteDescToBatch(ctx, kvTrace, t, b); err != nil {
 			return errors.Wrap(err, "writing dropping table to batch")
 		}
+		if err := descsCol.DeleteNamespaceEntryToBatch(ctx, kvTrace, t, b); err != nil {
+			return errors.Wrap(err, "writing namespace delete to batch")
+		}
 	}
 	return txn.KV().Run(ctx, b)
 }


### PR DESCRIPTION
Previously, the external catalog logic would never clean up namespace entries for descriptors when DropIngestedExternalCatalog was invoked. This would lead to left over junk in the system.namespace table, contrary to the normal object deletion protocol. To address this, this patch also deletes namespace entries.

Fixes: #140551

Release note: None