### PR TITLE
roachtest: Add tpcc test to match published numbers

### DIFF
--- a/pkg/cmd/roachtest/tests/tpcc.go
+++ b/pkg/cmd/roachtest/tests/tpcc.go
@@ -16,6 +16,7 @@ import (
 	"math/rand"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -51,6 +52,13 @@ const (
 	usingImport tpccSetupType = iota
 	usingInit
 	usingExistingData // skips import
+)
+
+const (
+	AWSMachineTypeC5d4xLarge = "c5d.4xlarge"
+	AWSMachineTypeC5d9xLarge = "c5d.9xlarge"
+	GCEMachineTypeN2std16    = "n2-standard-16"
+	GCEMAchineTypeN2std32    = "n2-standard-32"
 )
 
 // rampDuration returns the default durations passed to the `ramp`
@@ -968,6 +976,221 @@ func registerTPCC(r registry.Registry) {
 				// Increase the log verbosity to help debug future failures.
 				ExtraStartArgs: []string{
 					"--vmodule=store=2,store_rebalancer=2,liveness=2,raft_log_queue=3,replica_range_lease=3,raft=3"}})
+		},
+	})
+	// These are published benchmarks so we want to be able to recreate them easily on each release.
+	r.Add(registry.TestSpec{
+		Name:      "tpcc/published/local",
+		Owner:     registry.OwnerKV,
+		Benchmark: true,
+		Cluster: spec.MakeClusterSpec(
+			4,
+			spec.WorkloadNodeCount(1),
+			spec.AWSMachineType(AWSMachineTypeC5d4xLarge),
+			spec.GCEMachineType(GCEMachineTypeN2std16),
+			spec.PreferLocalSSD(),
+			spec.ReuseNone(),
+		),
+		CompatibleClouds:  registry.AllClouds,
+		Suites:            registry.ManualOnly,
+		EncryptionSupport: registry.EncryptionAlwaysDisabled,
+		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+			runTPCCPublished(ctx, t, c, tpccPublishedOptions{
+				warehouses:        12,
+				duration:          10 * time.Minute,
+				optimized:         true,
+				LoadWarehousesGCE: 10,
+				LoadWarehousesAWS: 10,
+			})
+		},
+	})
+	r.Add(registry.TestSpec{
+		Name:      "tpcc/published/small",
+		Owner:     registry.OwnerKV,
+		Benchmark: true,
+		Cluster: spec.MakeClusterSpec(
+			4,
+			spec.WorkloadNodeCount(1),
+			spec.AWSMachineType(AWSMachineTypeC5d4xLarge),
+			spec.GCEMachineType(GCEMachineTypeN2std16),
+			spec.PreferLocalSSD(),
+			spec.ReuseNone(),
+		),
+		CompatibleClouds:  registry.AllClouds,
+		Suites:            registry.ManualOnly,
+		EncryptionSupport: registry.EncryptionAlwaysDisabled,
+		Timeout:           6 * time.Hour,
+		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+			runTPCCPublished(ctx, t, c, tpccPublishedOptions{
+				warehouses:        6000,
+				duration:          30 * time.Minute,
+				optimized:         true,
+				LoadWarehousesGCE: 4000,
+				LoadWarehousesAWS: 4000,
+			})
+		},
+	})
+	r.Add(registry.TestSpec{
+		Name:      "tpcc/published/multiple-workloadnodes-medium-optimized",
+		Owner:     registry.OwnerKV,
+		Benchmark: true,
+		Cluster: spec.MakeClusterSpec(
+			18,
+			spec.WorkloadNodeCPU(16),
+			spec.WorkloadNodeCount(3),
+			spec.AWSMachineType(AWSMachineTypeC5d4xLarge),
+			spec.GCEMachineType(GCEMachineTypeN2std16),
+			spec.PreferLocalSSD(),
+			spec.ReuseNone(),
+		),
+		CompatibleClouds:  registry.AllClouds,
+		Suites:            registry.ManualOnly,
+		EncryptionSupport: registry.EncryptionAlwaysDisabled,
+		Timeout:           6 * time.Hour,
+		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+			runTPCCPublished(ctx, t, c, tpccPublishedOptions{
+				warehouses:        25000,
+				duration:          30 * time.Minute,
+				optimized:         true,
+				LoadWarehousesGCE: 20000,
+				LoadWarehousesAWS: 20000,
+			})
+		},
+	})
+	r.Add(registry.TestSpec{
+		Name:      "tpcc/published/medium-optimized",
+		Owner:     registry.OwnerKV,
+		Benchmark: true,
+		Cluster: spec.MakeClusterSpec(
+			16,
+			spec.WorkloadNodeCount(1),
+			spec.WorkloadNodeCPU(16),
+			spec.AWSMachineType(AWSMachineTypeC5d4xLarge),
+			spec.GCEMachineType(GCEMachineTypeN2std16),
+			spec.PreferLocalSSD(),
+			spec.ReuseNone(),
+		),
+		CompatibleClouds:  registry.AllClouds,
+		Suites:            registry.ManualOnly,
+		EncryptionSupport: registry.EncryptionAlwaysDisabled,
+		Timeout:           6 * time.Hour,
+		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+			runTPCCPublished(ctx, t, c, tpccPublishedOptions{
+				warehouses:        25000,
+				duration:          30 * time.Minute,
+				optimized:         true,
+				LoadWarehousesGCE: 20000,
+				LoadWarehousesAWS: 20000,
+			})
+		},
+	})
+	r.Add(registry.TestSpec{
+		Name:      "tpcc/published/medium-vanilla",
+		Owner:     registry.OwnerKV,
+		Benchmark: true,
+		Cluster: spec.MakeClusterSpec(
+			16,
+			spec.WorkloadNodeCount(1),
+			spec.WorkloadNodeCPU(16),
+			spec.AWSMachineType(AWSMachineTypeC5d4xLarge),
+			spec.GCEMachineType(GCEMachineTypeN2std16),
+			spec.PreferLocalSSD(),
+			spec.ReuseNone(),
+		),
+		CompatibleClouds:  registry.AllClouds,
+		Suites:            registry.ManualOnly,
+		EncryptionSupport: registry.EncryptionAlwaysDisabled,
+		Timeout:           6 * time.Hour,
+		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+			runTPCCPublished(ctx, t, c, tpccPublishedOptions{
+				warehouses:        17000,
+				duration:          30 * time.Minute,
+				LoadWarehousesGCE: 15000,
+				LoadWarehousesAWS: 15000,
+			})
+		},
+	})
+	r.Add(registry.TestSpec{
+		Name:      "tpcc/published/multiple-workloadnodes-large-optimized",
+		Owner:     registry.OwnerKV,
+		Benchmark: true,
+		Cluster: spec.MakeClusterSpec(
+			84,
+			spec.WorkloadNodeCount(3),
+			spec.WorkloadNodeCPU(32),
+			spec.AWSMachineType(AWSMachineTypeC5d9xLarge),
+			spec.GCEMachineType(GCEMAchineTypeN2std32),
+			spec.Mem(spec.Standard),
+			spec.PreferLocalSSD(),
+			spec.ReuseNone(),
+		),
+		CompatibleClouds:  registry.AllClouds,
+		Suites:            registry.ManualOnly,
+		EncryptionSupport: registry.EncryptionAlwaysDisabled,
+		Timeout:           12 * time.Hour,
+		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+			runTPCCPublished(ctx, t, c, tpccPublishedOptions{
+				warehouses:        160000,
+				duration:          30 * time.Minute,
+				optimized:         true,
+				LoadWarehousesGCE: 140000,
+				LoadWarehousesAWS: 140000,
+			})
+		},
+	})
+	r.Add(registry.TestSpec{
+		Name:      "tpcc/published/large-optimized",
+		Owner:     registry.OwnerKV,
+		Benchmark: true,
+		Cluster: spec.MakeClusterSpec(
+			82,
+			spec.WorkloadNodeCount(1),
+			spec.WorkloadNodeCPU(32),
+			spec.AWSMachineType(AWSMachineTypeC5d9xLarge),
+			spec.GCEMachineType(GCEMAchineTypeN2std32),
+			spec.Mem(spec.Standard),
+			spec.PreferLocalSSD(),
+			spec.ReuseNone(),
+		),
+		CompatibleClouds:  registry.AllClouds,
+		Suites:            registry.ManualOnly,
+		EncryptionSupport: registry.EncryptionAlwaysDisabled,
+		Timeout:           12 * time.Hour,
+		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+			runTPCCPublished(ctx, t, c, tpccPublishedOptions{
+				warehouses:        145000,
+				duration:          30 * time.Minute,
+				optimized:         true,
+				LoadWarehousesGCE: 140000,
+				LoadWarehousesAWS: 140000,
+			})
+		},
+	})
+	r.Add(registry.TestSpec{
+		Name:      "tpcc/published/large-vanilla",
+		Owner:     registry.OwnerKV,
+		Benchmark: true,
+		Cluster: spec.MakeClusterSpec(
+			84,
+			spec.WorkloadNodeCount(3),
+			spec.WorkloadNodeCPU(32),
+			spec.AWSMachineType(AWSMachineTypeC5d9xLarge),
+			spec.GCEMachineType(GCEMAchineTypeN2std32),
+			spec.Mem(spec.Standard),
+			spec.PreferLocalSSD(),
+			spec.ReuseNone(),
+		),
+		CompatibleClouds:  registry.AllClouds,
+		Suites:            registry.ManualOnly,
+		EncryptionSupport: registry.EncryptionAlwaysDisabled,
+		Timeout:           12 * time.Hour,
+		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+			runTPCCPublished(ctx, t, c, tpccPublishedOptions{
+				warehouses:        120000,
+				duration:          30 * time.Minute,
+				LoadWarehousesGCE: 100000,
+				LoadWarehousesAWS: 100000,
+			})
 		},
 	})
 
@@ -1905,4 +2128,337 @@ func exportOpenMetrics(
 	}
 
 	return nil
+}
+
+type tpccPublishedOptions struct {
+	warehouses        int
+	skipRamp          bool
+	duration          time.Duration
+	optimized         bool
+	LoadWarehousesGCE int
+	LoadWarehousesAWS int
+}
+
+type worker struct {
+	node              int
+	partitionAffinity string
+	crdbNodes         option.NodeListOption
+}
+
+// See https://www.cockroachlabs.com/docs/stable/performance-benchmarking-with-tpcc-large.html for the details
+func runTPCCPublished(
+	ctx context.Context, t test.Test, c cluster.Cluster, opts tpccPublishedOptions,
+) {
+	workloadCount := c.Spec().WorkloadNodeCount
+	crdbNodes := c.CRDBNodes()
+	crdbNodeCount := len(crdbNodes)
+
+	t.L().Printf("Step 1 - Set up the environment")
+	c.Put(ctx, t.Cockroach(), "./cockroach", c.All())
+	settings := install.MakeClusterSettings()
+	settings.NumRacks = crdbNodeCount
+	startOpts := option.DefaultStartOpts()
+
+	if opts.optimized {
+		// Disable backups for optimized testing.
+		startOpts.RoachprodOpts.ScheduleBackups = false
+	}
+
+	// Configure prometheus for cluster and workloadnode for system metrics
+	var promCfg *prometheus.Config
+	var cleanupFunc func()
+	workloadInstances := []workloadInstance{
+		{
+			nodes:          crdbNodes,
+			prometheusPort: 2112,
+		},
+	}
+	promCfg, cleanupFunc = setupPrometheusForRoachtest(ctx, t, c, promCfg, workloadInstances)
+	defer cleanupFunc()
+	if promCfg == nil {
+		t.Fatal("Failed to configure prometheus for system metrics")
+	}
+
+	t.L().Printf("Step 2. Start CockroachDB")
+	c.Start(ctx, t.L(), startOpts, settings, crdbNodes)
+
+	if !t.SkipInit() {
+
+		t.L().Printf("Step 3. Configure the cluster")
+		{
+			db := c.Conn(ctx, t.L(), 1)
+			// Temporarily set this high to allow the partitioning to finish fast.
+			_, _ = db.ExecContext(ctx, `SET CLUSTER SETTING kv.snapshot_rebalance.max_rate = '256 MiB'`)
+			// Increase goroutine dump threshold since tpcc workload creates many goroutines under load
+			// and we don't want spurious dumps that could impact performance
+			_, _ = db.ExecContext(ctx, `SET CLUSTER SETTING server.goroutine_dump.num_goroutines_threshold = '10000000'`)
+			// Disable fatal errors from long sync durations since this is a benchmark
+			// We don't want the test to fail due to slow I/O that may occur under load
+			_, _ = db.Exec(`SET CLUSTER SETTING storage.max_sync_duration.fatal.enabled = false;`)
+			// These are too aggressive and impactful for the test to pass. Consider
+			// re-enabling them in the future once they cause a smaller impact.
+			if opts.optimized {
+				_, _ = db.ExecContext(ctx, `SET CLUSTER SETTING server.consistency_check.interval = '0s'`)
+				_, _ = db.ExecContext(ctx, `SET CLUSTER SETTING kv.range_merge.queue_enabled = false`)
+				_, _ = db.ExecContext(ctx, `SET CLUSTER SETTING sql.stats.automatic_collection.enabled = false`)
+				_, _ = db.ExecContext(ctx, `SET CLUSTER SETTING rocksdb.min_wal_sync_interval = '500us'`)
+				_, _ = db.ExecContext(ctx, `SET CLUSTER SETTING admission.kv.enabled = false`)
+				_, _ = db.ExecContext(ctx, `SET CLUSTER SETTING kv.replication_reports.interval = '0s'`)
+				_, _ = db.ExecContext(ctx, `ALTER RANGE default CONFIGURE ZONE USING gc.ttlseconds = 600`)
+				_, _ = db.ExecContext(ctx, `SET CLUSTER SETTING storage.columnar_blocks.enabled = false;`)
+
+			}
+			require.NoError(t, db.Close())
+		}
+
+		// Initialize and do the import.
+		{
+			var cmd string
+			if opts.optimized {
+				cmd = tpccImportCmd("", opts.warehouses, fmt.Sprintf("--partitions=%d", crdbNodeCount), "--replicate-static-columns", "--partition-strategy=leases", "--checks=false", "{pgurl:1}")
+			} else {
+				cmd = tpccImportCmd("", opts.warehouses, "--checks=false", "{pgurl:1}")
+			}
+			t.L().Printf("Step 4. Import the TPC-C dataset\n  (%s)", cmd)
+			c.Run(ctx, option.WithNodes(c.Node(1)), cmd)
+		}
+		// Partitioning is done by the init step, run a short workload to make sure
+		// all ranges are set up correctly. This may not be strictly necessary.
+		t.L().Printf("Step 5 - Partition the database (Done automatically by import)")
+		t.L().Printf("Step 6 - This step intentionally left blank to match public docs")
+		{
+			var cmd string
+			extraArgs := ""
+			if opts.optimized {
+				extraArgs = fmt.Sprintf(" --partitions=%d", crdbNodeCount)
+			}
+			cmd = fmt.Sprintf(
+				"./cockroach workload run tpcc %s --warehouses=%d  --duration=1m --workers=1000 --wait=0.0 {pgurl%s}",
+				extraArgs,
+				opts.warehouses,
+				crdbNodes,
+			)
+			t.L().Printf("Step 7 - Allocate partitions\n (%s)", cmd)
+			c.Run(ctx, option.WithNodes(c.Node(1)), cmd)
+			t.L().Printf("Waiting for stable ranges")
+
+			// TODO(baptist): Replace the next 2 steps with replication reports once
+			// they are available.
+			func() {
+				db := c.Conn(ctx, t.L(), 1)
+				defer db.Close()
+				for {
+					var n int
+					require.NoError(t,
+						db.QueryRowContext(
+							ctx,
+							"SELECT count(1) FROM crdb_internal.ranges WHERE array_length(replicas, 1) < 3",
+						).Scan(&n))
+					if n == 0 {
+						t.L().Printf("All ranges fully upreplicated")
+						break
+					}
+					time.Sleep(10 * time.Second)
+				}
+			}()
+			for {
+				// Run all the queries in parallel to find the total pending count.
+				found := make(chan int)
+				for _, nodeID := range crdbNodes {
+					nodeID := nodeID
+					go func() {
+						db := c.Conn(ctx, t.L(), nodeID)
+						defer db.Close()
+						var n int
+						require.NoError(t,
+							db.QueryRowContext(
+								ctx,
+								"SELECT value FROM crdb_internal.node_metrics WHERE name = 'queue.replicate.pending'",
+							).Scan(&n))
+						found <- n
+					}()
+				}
+				var total int
+				// Wait until they have all completed.
+				for range crdbNodes {
+					total += <-found
+				}
+				if total == 0 {
+					t.L().Printf("All ranges in final locations")
+					break
+				}
+				t.L().Printf("Waiting for ranges to move: %d", total)
+				time.Sleep(60 * time.Second)
+			}
+		}
+		{
+			// Reset settings that aren't needed anymore and could impact performance.
+			db := c.Conn(ctx, t.L(), 1)
+			_, _ = db.ExecContext(ctx, `RESET CLUSTER SETTING kv.snapshot_rebalance.max_rate`)
+			require.NoError(t, db.Close())
+		}
+	}
+
+	t.L().Printf("Step 8 - Run the benchmark")
+	// Create all the workers that are used below.
+	var workers []worker
+	lists := make([]string, crdbNodeCount)
+	for i := 0; i < workloadCount; i++ {
+		start := crdbNodeCount * i / workloadCount
+		end := crdbNodeCount * (i + 1) / workloadCount
+		// Use this to handle rounding well.
+		for j := start; j < end; j++ {
+			lists[j-start] = strconv.Itoa(j)
+		}
+		workers = append(workers, worker{
+			node:              i + crdbNodeCount + 1,
+			partitionAffinity: strings.Join(lists[:end-start], ","),
+			crdbNodes:         c.Range(start+1, end),
+		})
+	}
+
+	// Create a temp directory to store the local copy of results from the
+	// workloads.
+	resultsDir, err := os.MkdirTemp("", "roachtest-published-tpcc")
+	if err != nil {
+		t.Fatal(errors.Wrap(err, "failed to create temp dir"))
+	}
+	defer func() { _ = os.RemoveAll(resultsDir) }()
+
+	restart := func(ctx context.Context) {
+		c.Stop(ctx, t.L(), option.DefaultStopOpts(), crdbNodes)
+		c.Start(ctx, t.L(), startOpts, settings, crdbNodes)
+	}
+
+	precision := int(math.Max(1.0, float64(opts.warehouses/50)))
+	initStepSize := precision
+	s := search.NewLineSearcher(1, opts.warehouses, opts.LoadWarehousesGCE, initStepSize, precision)
+	iteration := 0
+	totalWarehouses := opts.warehouses
+	res, err := s.Search(func(warehouses int) (bool, error) {
+		iteration++
+		t.L().Printf("initializing cluster for %d warehouses (search attempt: %d)", warehouses, iteration)
+
+		restart(ctx)
+		time.Sleep(15 * time.Second)
+
+		rampTime := 8 * time.Minute
+		if opts.skipRamp {
+			rampTime = 1 * time.Second
+		}
+
+		m := c.NewMonitor(ctx, crdbNodes)
+
+		resultChan := make(chan *tpcc.Result, workloadCount)
+		for wIdx, w := range workers {
+			// Create a copy of the worker for each loop iteration.
+			w := w
+			wIdx := wIdx
+			m.Go(func(ctx context.Context) error {
+				histogramsPath := fmt.Sprintf("%s/warehouses=%d/stats.json", t.PerfArtifactsDir(), warehouses)
+				var cmd string
+				cmd = fmt.Sprintf(
+					"./cockroach workload run tpcc --warehouses=%d --active-warehouses=%d --workers=%d"+
+						" --histograms=%s --ramp=%s --duration=%s",
+					totalWarehouses,
+					warehouses,
+					((warehouses * 10) / workloadCount),
+					histogramsPath,
+					rampTime,
+					opts.duration,
+				)
+				var cmdSuffix string
+				if opts.optimized {
+					cmdSuffix = fmt.Sprintf(
+						" --partitions %d --partition-affinity %s {pgurl%s}",
+						crdbNodeCount,
+						w.partitionAffinity,
+						w.crdbNodes.String(),
+					)
+				} else {
+					cmdSuffix = fmt.Sprintf(" {pgurl%s}", w.crdbNodes.String())
+				}
+				cmd += cmdSuffix
+				t.L().Printf("running %s", cmd)
+				err := c.RunE(ctx, option.WithNodes(c.Node(w.node)), cmd)
+				if err != nil {
+					// This will let the line search continue at a lower warehouse
+					// count.
+					return errors.Wrapf(err, "error running tpcc load generator")
+				}
+				roachtestHistogramsPath := filepath.Join(resultsDir, fmt.Sprintf("%d.%d-stats.json", warehouses, wIdx))
+				if err := c.Get(
+					ctx, t.L(), histogramsPath, roachtestHistogramsPath, c.Node(w.node),
+				); err != nil {
+					// This will let the line search continue. The reason we do this
+					// is because it's conceivable that we made it here, but a VM just
+					// froze up on us. The next search iteration will handle this state.
+					return err
+				}
+				snapshots, err := histogram.DecodeSnapshots(roachtestHistogramsPath)
+				if err != nil {
+					// If we got this far, and can't decode data, it's not a case of
+					// overload but something that deserves failing the whole test.
+					t.Fatal(err)
+				}
+				result := tpcc.NewResultWithSnapshots(warehouses, 0, snapshots)
+				resultChan <- result
+				return nil
+			})
+		}
+		failErr := m.WaitE()
+		close(resultChan)
+
+		t.L().Printf("Step 9 - Analyze the results")
+		var res *tpcc.Result
+		if failErr != nil {
+			if t.Failed() {
+				return false, failErr
+			}
+			// A goroutine returned an error, but this means only
+			// that the given warehouse count did not run to completion,
+			// presumably because it overloaded the cluster. We thus
+			// "achieved" zero TpmC, but will continue the search.
+			//
+			// Note that it's also possible that we get here due to an
+			// actual bug in CRDB (for example a node crashing due to
+			// getting into an invalid state); we cannot distinguish
+			// those here and so tpccbench isn't a good test to rely
+			// on to catch crash-causing bugs.
+			res = &tpcc.Result{ActiveWarehouses: warehouses}
+		} else {
+			// We managed to run TPCC, which means that we may or may
+			// not have "passed" TPCC.
+			var results []*tpcc.Result
+			for partial := range resultChan {
+				results = append(results, partial)
+			}
+			res = tpcc.MergeResults(results...)
+			failErr = res.FailureError()
+		}
+
+		// Print result for current iteration
+		if failErr == nil {
+			ttycolor.Stdout(ttycolor.Green)
+			t.L().Printf("--- SEARCH ITER PASS: TPCC %d resulted in %.1f tpmC (%.1f%% of max tpmC)\n\n",
+				warehouses, res.TpmC(), res.Efficiency())
+		} else {
+			ttycolor.Stdout(ttycolor.Red)
+			t.L().Printf("--- SEARCH ITER FAIL: TPCC %d resulted in %.1f tpmC and failed due to %v",
+				warehouses, res.TpmC(), failErr)
+		}
+		ttycolor.Stdout(ttycolor.Reset)
+		return failErr == nil, nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	} else {
+		// The last iteration may have been a failing run that overloaded
+		// nodes to the point of them crashing. Make roachtest happy by
+		// restarting the cluster so that it can run consistency checks.
+		restart(ctx)
+		ttycolor.Stdout(ttycolor.Green)
+		t.L().Printf("------\nRUN PASSED with MAX WAREHOUSES = %d\n------\n\n", res)
+		ttycolor.Stdout(ttycolor.Reset)
+	}
 }

--- a/pkg/workload/debug/tpcc_results.go
+++ b/pkg/workload/debug/tpcc_results.go
@@ -27,6 +27,7 @@ var tpccMergeResultsCmd = &cobra.Command{
 func init() {
 	flags := tpccMergeResultsCmd.Flags()
 	flags.Int("warehouses", 0, "number of aggregate warehouses in all of the histograms")
+	_ = tpccMergeResultsCmd.MarkFlagRequired("warehouses")
 }
 
 func tpccMergeResults(cmd *cobra.Command, args []string) error {

--- a/pkg/workload/tpcc/partition.go
+++ b/pkg/workload/tpcc/partition.go
@@ -387,22 +387,28 @@ func (p *partitioner) randActive(rng *rand.Rand) int {
 // default it adds constraints/preferences in terms of racks, but if the zones
 // flag is passed into tpcc, it will set the constraints/preferences based on
 // the geographic zones provided.
-func configureZone(db *gosql.DB, cfg zoneConfig, table, partition string, partIdx int) error {
-	var kv string
+func configureZone(
+	db *gosql.DB, cfg zoneConfig, table, partition string, partIdx int, totalParts int,
+) error {
+	var constraint string
+	var lease string
 	if len(cfg.zones) > 0 {
-		kv = fmt.Sprintf("zone=%s", cfg.zones[partIdx])
+		constraint = fmt.Sprintf("[+zone=%s]", cfg.zones[partIdx])
 	} else {
-		kv = fmt.Sprintf("rack=%d", partIdx)
+		// Note that this only specifies 3 replica locations. If the number of
+		// replicas is >3 this will only specify the location for 3 of them.
+		constraint = fmt.Sprintf(`{+rack=%d: 1, +rack=%d: 1, +rack=%d: 1}`, partIdx, (partIdx+totalParts/3)%totalParts, (partIdx+2*totalParts/3)%totalParts)
+		lease = fmt.Sprintf("[[+rack=%d]]", partIdx)
 	}
 
 	var opts string
 	switch cfg.strategy {
 	case partitionedReplication:
 		// Place all replicas in the zone.
-		opts = fmt.Sprintf(`constraints = '[+%s]'`, kv)
+		opts = fmt.Sprintf(`constraints = '%s'`, constraint)
 	case partitionedLeases:
 		// Place one replica in the zone and give that replica lease preference.
-		opts = fmt.Sprintf(`num_replicas = COPY FROM PARENT, constraints = '{"+%s":1}', lease_preferences = '[[+%s]]'`, kv, kv)
+		opts = fmt.Sprintf(`num_replicas = COPY FROM PARENT, constraints = '%s', lease_preferences = '%s'`, constraint, lease)
 	default:
 		panic("unexpected")
 	}
@@ -437,7 +443,7 @@ func partitionObject(
 	}
 
 	for i := 0; i < p.parts; i++ {
-		if err := configureZone(db, cfg, table, fmt.Sprintf("p%d_%d", idx, i), i); err != nil {
+		if err := configureZone(db, cfg, table, fmt.Sprintf("p%d_%d", idx, i), i, p.parts); err != nil {
 			return err
 		}
 	}

--- a/pkg/workload/tpcc/tpcc.go
+++ b/pkg/workload/tpcc/tpcc.go
@@ -444,7 +444,14 @@ func (w *tpcc) Hooks() workload.Hooks {
 				if w.waitFraction == 0 {
 					w.numConns = w.workers
 				} else {
-					w.numConns = w.activeWarehouses * numConnsPerWarehouse
+					partitionFactor := 1
+					countAffinity := len(w.affinityPartitions)
+					if countAffinity > 0 && w.partitions > 0 {
+						partitionFactor = w.partitions / countAffinity
+					}
+
+					w.numConns = (w.activeWarehouses * numConnsPerWarehouse)
+					w.numConns = w.numConns / partitionFactor
 				}
 			}
 
@@ -896,6 +903,7 @@ func (w *tpcc) Ops(
 	// Limit the number of connections per pool (otherwise preparing statements at
 	// startup can be slow).
 	cfg.MaxConnsPerPool = w.connFlags.Concurrency
+	fmt.Printf("Max Total connections %d Max connections per pool %d \n", cfg.MaxTotalConnections, cfg.MaxConnsPerPool)
 	fmt.Printf("Initializing %d connections...\n", w.numConns)
 
 	// If queries were specified before each operation, then lets

--- a/pkg/workload/tpcc/worker.go
+++ b/pkg/workload/tpcc/worker.go
@@ -237,10 +237,6 @@ func (w *worker) run(ctx context.Context) error {
 	// but don't account for them in the histogram.
 	start := timeutil.Now()
 	_, onTxnStartDuration, err := tx.run(context.Background(), warehouseID)
-	if err != nil {
-		w.counters[txInfo.name].error.Inc()
-		return errors.Wrapf(err, "error in %s", txInfo.name)
-	}
 	if ctx.Err() == nil {
 		elapsed := timeutil.Since(start)
 		// NB: this histogram *should* be named along the lines of
@@ -248,6 +244,11 @@ func (w *worker) run(ctx context.Context) error {
 		// change them now.
 		w.hists.Get(txInfo.name).Record(elapsed - onTxnStartDuration)
 	}
+	if err != nil {
+		w.counters[txInfo.name].error.Inc()
+		return errors.Wrapf(err, "error printed in %s", txInfo.name)
+	}
+
 	w.counters[txInfo.name].success.Inc()
 
 	// 5.2.5.4: Think time is taken independently from a negative exponential


### PR DESCRIPTION
This PR is continuation of draft PR #98418 by
Andrew Baptist @andrewbaptist.

We publish tpcc numbers here:
https://www.cockroachlabs.com/docs/stable/performance-benchmarking-with-tpcc-large.html

We didn't have an automated test to reproduce these results. This PR adds that test so that we can reproduce this on demand. It also adds the 15 node test to weekly so we can monitor this behavior over time.:

Epic: none
Release note: None