### PR TITLE
raft: report Ready on replication flow changes

### DIFF
--- a/pkg/raft/rafttest/interaction_env_handler_stabilize.go
+++ b/pkg/raft/rafttest/interaction_env_handler_stabilize.go
@@ -66,11 +66,14 @@ func (env *InteractionEnv) Stabilize(idxs ...int) error {
 		for _, rn := range nodes {
 			if rn.HasReady() {
 				idx := int(rn.Status().ID - 1)
-				fmt.Fprintf(env.Output, "> %d handling Ready\n", idx+1)
-				var err error
-				env.withIndent(func() { err = env.ProcessReady(idx) })
-				if err != nil {
-					return err
+				n := &env.Nodes[idx]
+				if rd := n.Ready(); !isEmptyReady(rd) {
+					fmt.Fprintf(env.Output, "> %d handling Ready\n", idx+1)
+					var err error
+					env.withIndent(func() { err = env.ProcessReady(n, rd) })
+					if err != nil {
+						return err
+					}
 				}
 				done = false
 			}


### PR DESCRIPTION
RACv2 relies on `Ready` being triggered any time there is a replication flow change such as transitioning to/from `StateReplicate`.

This change extends the `HasReady` signal with the cases when a leader->follower flow state changes, particularly to/from `StateReplicate`.

Unblocks #138357
Epic: none
Release note: none