### PR TITLE
[POC][DNM] sqlstats: use the job subsystem to flush sql stats to disk

### DIFF
--- a/docs/generated/http/full.md
+++ b/docs/generated/http/full.md
@@ -4969,6 +4969,105 @@ Response object returned by ResetSQLStats.
 
 
 
+## PopAllSqlStats
+
+`GET /_status/popallstats`
+
+
+
+Support status: [reserved](#support-status)
+
+#### Request Parameters
+
+
+
+
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| node_id | [string](#cockroach.server.serverpb.PopAllSqlStatsRequest-string) |  |  | [reserved](#support-status) |
+| aggregated_ts | [google.protobuf.Timestamp](#cockroach.server.serverpb.PopAllSqlStatsRequest-google.protobuf.Timestamp) |  |  | [reserved](#support-status) |
+
+
+
+
+
+
+
+#### Response Parameters
+
+
+
+
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| statements | [StatementsResponse.CollectedStatementStatistics](#cockroach.server.serverpb.StatementsResponse-cockroach.server.serverpb.StatementsResponse.CollectedStatementStatistics) | repeated |  | [reserved](#support-status) |
+| last_reset | [google.protobuf.Timestamp](#cockroach.server.serverpb.StatementsResponse-google.protobuf.Timestamp) |  | Timestamp of the last stats reset. | [reserved](#support-status) |
+| internal_app_name_prefix | [string](#cockroach.server.serverpb.StatementsResponse-string) |  | If set and non-empty, indicates the prefix to application_name used for statements/queries issued internally by CockroachDB. | [reserved](#support-status) |
+| transactions | [StatementsResponse.ExtendedCollectedTransactionStatistics](#cockroach.server.serverpb.StatementsResponse-cockroach.server.serverpb.StatementsResponse.ExtendedCollectedTransactionStatistics) | repeated | Transactions is transaction-level statistics for the collection of statements in this response. | [reserved](#support-status) |
+| stmts_total_runtime_secs | [float](#cockroach.server.serverpb.StatementsResponse-float) |  |  | [reserved](#support-status) |
+| txns_total_runtime_secs | [float](#cockroach.server.serverpb.StatementsResponse-float) |  |  | [reserved](#support-status) |
+| oldest_aggregated_ts_returned | [google.protobuf.Timestamp](#cockroach.server.serverpb.StatementsResponse-google.protobuf.Timestamp) |  | OldestAggregatedTsReturned is the timestamp of the oldest entry returned, or null if there is no data returned. | [reserved](#support-status) |
+| stmts_source_table | [string](#cockroach.server.serverpb.StatementsResponse-string) |  | StmtsSourceTable returns the table used to return the statements data. | [reserved](#support-status) |
+| txns_source_table | [string](#cockroach.server.serverpb.StatementsResponse-string) |  | TxnsSourceTable returns the table used to return the transactions data. | [reserved](#support-status) |
+
+
+
+
+
+
+<a name="cockroach.server.serverpb.StatementsResponse-cockroach.server.serverpb.StatementsResponse.CollectedStatementStatistics"></a>
+#### StatementsResponse.CollectedStatementStatistics
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| key | [StatementsResponse.ExtendedStatementStatisticsKey](#cockroach.server.serverpb.StatementsResponse-cockroach.server.serverpb.StatementsResponse.ExtendedStatementStatisticsKey) |  |  | [reserved](#support-status) |
+| id | [uint64](#cockroach.server.serverpb.StatementsResponse-uint64) |  |  | [reserved](#support-status) |
+| stats | [cockroach.sql.StatementStatistics](#cockroach.server.serverpb.StatementsResponse-cockroach.sql.StatementStatistics) |  |  | [reserved](#support-status) |
+| txn_fingerprint_ids | [uint64](#cockroach.server.serverpb.StatementsResponse-uint64) | repeated | In 23.1 we expect the response to only group on fingerprint_id and app_name in the overview page. We now return the aggregated list of unique txn fingerprint ids, leaving the txn_fingerprint_id field in the key empty. | [reserved](#support-status) |
+
+
+
+
+
+<a name="cockroach.server.serverpb.StatementsResponse-cockroach.server.serverpb.StatementsResponse.ExtendedStatementStatisticsKey"></a>
+#### StatementsResponse.ExtendedStatementStatisticsKey
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| key_data | [cockroach.sql.StatementStatisticsKey](#cockroach.server.serverpb.StatementsResponse-cockroach.sql.StatementStatisticsKey) |  |  | [reserved](#support-status) |
+| node_id | [int32](#cockroach.server.serverpb.StatementsResponse-int32) |  |  | [reserved](#support-status) |
+| aggregated_ts | [google.protobuf.Timestamp](#cockroach.server.serverpb.StatementsResponse-google.protobuf.Timestamp) |  |  | [reserved](#support-status) |
+| aggregation_interval | [google.protobuf.Duration](#cockroach.server.serverpb.StatementsResponse-google.protobuf.Duration) |  | The aggregation duration. | [reserved](#support-status) |
+
+
+
+
+
+<a name="cockroach.server.serverpb.StatementsResponse-cockroach.server.serverpb.StatementsResponse.ExtendedCollectedTransactionStatistics"></a>
+#### StatementsResponse.ExtendedCollectedTransactionStatistics
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| stats_data | [cockroach.sql.CollectedTransactionStatistics](#cockroach.server.serverpb.StatementsResponse-cockroach.sql.CollectedTransactionStatistics) |  |  | [reserved](#support-status) |
+| node_id | [int32](#cockroach.server.serverpb.StatementsResponse-int32) |  |  | [reserved](#support-status) |
+
+
+
+
+
+
 ## IndexUsageStatistics
 
 `GET /_status/indexusagestatistics`

--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -2275,6 +2275,7 @@ GO_TARGETS = [
     "//pkg/sql/sqlstats/sslocal:sslocal_test",
     "//pkg/sql/sqlstats/ssmemstorage:ssmemstorage",
     "//pkg/sql/sqlstats/ssmemstorage:ssmemstorage_test",
+    "//pkg/sql/sqlstats/ssremote:ssremote",
     "//pkg/sql/sqlstats:sqlstats",
     "//pkg/sql/sqltelemetry:sqltelemetry",
     "//pkg/sql/sqltestutils:sqltestutils",

--- a/pkg/server/serverpb/status.go
+++ b/pkg/server/serverpb/status.go
@@ -45,6 +45,7 @@ type SQLStatusServer interface {
 	TenantServiceStatus(context.Context, *TenantServiceStatusRequest) (*TenantServiceStatusResponse, error)
 	UpdateTableMetadataCache(context.Context, *UpdateTableMetadataCacheRequest) (*UpdateTableMetadataCacheResponse, error)
 	GetUpdateTableMetadataCacheSignal() chan struct{}
+	PopAllSqlStats(ctx context.Context, request *PopAllSqlStatsRequest) (*StatementsResponse, error)
 }
 
 // OptionalNodesStatusServer is a StatusServer that is only optionally present

--- a/pkg/server/serverpb/status.proto
+++ b/pkg/server/serverpb/status.proto
@@ -1699,6 +1699,11 @@ message StatementsRequest {
   FetchMode fetch_mode = 5;
 }
 
+message PopAllSqlStatsRequest {
+  string node_id = 1 [(gogoproto.customname) = "NodeID"];
+  google.protobuf.Timestamp aggregated_ts = 2 [(gogoproto.nullable) = false,  (gogoproto.stdtime) = true];
+}
+
 message StatementsResponse {
   message ExtendedStatementStatisticsKey {
     cockroach.sql.StatementStatisticsKey key_data = 1 [(gogoproto.nullable) = false];
@@ -2671,6 +2676,11 @@ service Status {
     option (google.api.http) = {
       post: "/_status/resetsqlstats"
       body: "*"
+    };
+  }
+  rpc PopAllSqlStats(PopAllSqlStatsRequest) returns (StatementsResponse) {
+    option (google.api.http) = {
+      get: "/_status/popallstats"
     };
   }
 

--- a/pkg/server/sql_stats.go
+++ b/pkg/server/sql_stats.go
@@ -11,6 +11,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server/authserver"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/appstatspb"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/catconstants"
 	"github.com/cockroachdb/errors"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -66,7 +68,6 @@ func (s *statusServer) ResetSQLStats(
 	}
 
 	var fanoutError error
-
 	if err := iterateNodes(ctx, s.serverIterator, s.stopper, "reset SQL statistics",
 		noTimeout,
 		s.dialNode,
@@ -84,4 +85,137 @@ func (s *statusServer) ResetSQLStats(
 	}
 
 	return response, fanoutError
+}
+
+func (s *statusServer) PopAllSqlStats(
+	ctx context.Context, req *serverpb.PopAllSqlStatsRequest,
+) (*serverpb.StatementsResponse, error) {
+	ctx = authserver.ForwardSQLIdentityThroughRPCCalls(ctx)
+	ctx = s.AnnotateCtx(ctx)
+
+	localReq := &serverpb.PopAllSqlStatsRequest{
+		NodeID: "local",
+	}
+
+	if len(req.NodeID) > 0 {
+		requestedNodeID, local, err := s.parseNodeID(req.NodeID)
+		if err != nil {
+			return nil, status.Error(codes.InvalidArgument, err.Error())
+		}
+		if local {
+			return s.popAllSqlStatsLocal(ctx, requestedNodeID)
+		}
+		statusCli, err := s.dialNode(ctx, requestedNodeID)
+		if err != nil {
+			return nil, err
+		}
+		return statusCli.PopAllSqlStats(ctx, localReq)
+	}
+
+	consumeStats := func(ctx context.Context, status serverpb.StatusClient, _ roachpb.NodeID) (interface{}, error) {
+		return status.PopAllSqlStats(ctx, localReq)
+	}
+
+	var fanoutError error
+	var fanoutResonses = make([]*serverpb.StatementsResponse, 0)
+	if err := iterateNodes(ctx, s.serverIterator, s.stopper, "reset SQL statistics",
+		noTimeout,
+		s.dialNode,
+		consumeStats,
+		func(nodeID roachpb.NodeID, resp interface{}) {
+			fanoutResonses = append(fanoutResonses, resp.(*serverpb.StatementsResponse))
+		},
+		func(nodeID roachpb.NodeID, nodeFnError error) {
+			if nodeFnError != nil {
+				fanoutError = errors.CombineErrors(fanoutError, nodeFnError)
+			}
+		},
+	); err != nil {
+		return nil, err
+	}
+	return combineAllStats(fanoutResonses), fanoutError
+}
+
+func (s *statusServer) popAllSqlStatsLocal(
+	ctx context.Context, nodeID roachpb.NodeID,
+) (*serverpb.StatementsResponse, error) {
+	ctx = authserver.ForwardSQLIdentityThroughRPCCalls(ctx)
+	ctx = s.AnnotateCtx(ctx)
+	statsProvider := s.sqlServer.pgServer.SQLServer.GetSQLStatsProvider()
+	stmtStats, txnstats := statsProvider.PopAllStats(ctx)
+
+	resp := &serverpb.StatementsResponse{
+		Statements:            make([]serverpb.StatementsResponse_CollectedStatementStatistics, len(stmtStats)),
+		LastReset:             statsProvider.GetLastReset(),
+		InternalAppNamePrefix: catconstants.InternalAppNamePrefix,
+		Transactions:          make([]serverpb.StatementsResponse_ExtendedCollectedTransactionStatistics, len(txnstats)),
+	}
+
+	for i, txnstat := range txnstats {
+		resp.Transactions[i] = serverpb.StatementsResponse_ExtendedCollectedTransactionStatistics{
+			StatsData: *txnstat,
+			NodeID:    nodeID,
+		}
+	}
+
+	for i, stmt := range stmtStats {
+		resp.Statements[i] = serverpb.StatementsResponse_CollectedStatementStatistics{
+			Key: serverpb.StatementsResponse_ExtendedStatementStatisticsKey{
+				KeyData: stmt.Key,
+				NodeID:  nodeID,
+			},
+			ID:    stmt.ID,
+			Stats: stmt.Stats,
+		}
+	}
+
+	return resp, nil
+}
+
+func combineAllStats(resps []*serverpb.StatementsResponse) *serverpb.StatementsResponse {
+	stmtMap := make(map[appstatspb.StatementStatisticsKey]serverpb.StatementsResponse_CollectedStatementStatistics)
+	txnMap := make(map[appstatspb.TransactionFingerprintID]serverpb.StatementsResponse_ExtendedCollectedTransactionStatistics)
+	response := serverpb.StatementsResponse{
+		Statements:   make([]serverpb.StatementsResponse_CollectedStatementStatistics, 0),
+		Transactions: make([]serverpb.StatementsResponse_ExtendedCollectedTransactionStatistics, 0),
+	}
+	for _, resp := range resps {
+		for _, stmt := range resp.Statements {
+			if existingStmt, ok := stmtMap[stmt.Key.KeyData]; !ok {
+				stmtMap[stmt.Key.KeyData] = stmt
+			} else {
+				existingStmt.Stats.Add(&stmt.Stats)
+			}
+		}
+		for _, txn := range resp.Transactions {
+			if existingTx, ok := txnMap[txn.StatsData.TransactionFingerprintID]; !ok {
+				txnMap[txn.StatsData.TransactionFingerprintID] = txn
+			} else {
+				existingTx.StatsData.Stats.Add(&txn.StatsData.Stats)
+			}
+		}
+	}
+
+	for k, v := range stmtMap {
+		response.Statements = append(response.Statements,
+			serverpb.StatementsResponse_CollectedStatementStatistics{
+				Key: serverpb.StatementsResponse_ExtendedStatementStatisticsKey{
+					KeyData: k,
+				},
+				ID:    v.ID,
+				Stats: v.Stats,
+			})
+	}
+
+	for _, v := range txnMap {
+		response.Transactions = append(response.Transactions,
+			serverpb.StatementsResponse_ExtendedCollectedTransactionStatistics{
+				StatsData: appstatspb.CollectedTransactionStatistics{
+					StatementFingerprintIDs:  v.StatsData.StatementFingerprintIDs,
+					TransactionFingerprintID: v.StatsData.TransactionFingerprintID,
+					Stats:                    v.StatsData.Stats,
+				},
+			})
+	}
+	return &response
 }

--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -1747,6 +1747,10 @@ type InternalDB struct {
 	monitor    *mon.BytesMonitor
 }
 
+func (ief *InternalDB) GetServer() *Server {
+	return ief.server
+}
+
 // NewShimInternalDB is used to bootstrap the server which needs access to
 // components which will ultimately have a handle to an InternalDB. Some of
 // those components may attempt to access the *kv.DB before the InternalDB

--- a/pkg/sql/sqlstats/persistedsqlstats/BUILD.bazel
+++ b/pkg/sql/sqlstats/persistedsqlstats/BUILD.bazel
@@ -101,6 +101,7 @@ go_test(
         "//pkg/sql/sqlstats",
         "//pkg/sql/sqlstats/persistedsqlstats/sqlstatstestutil",
         "//pkg/sql/sqlstats/ssmemstorage",
+        "//pkg/sql/tablemetadatacache/util",
         "//pkg/testutils",
         "//pkg/testutils/datapathutils",
         "//pkg/testutils/serverutils",
@@ -119,6 +120,7 @@ go_test(
         "@com_github_cockroachdb_datadriven//:datadriven",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_stretchr_testify//require",
+        "@org_golang_x_exp//rand",
     ],
 )
 

--- a/pkg/sql/sqlstats/persistedsqlstats/cluster_settings.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/cluster_settings.go
@@ -59,6 +59,16 @@ var SQLStatsFlushEnabled = settings.RegisterBoolSetting(
 	true, /* defaultValue */
 	settings.WithPublic)
 
+// SQLStatsFlushJobEnabled is the cluster setting that controls if the sqlstats
+// subsystem persists the statistics into system table.
+var SQLStatsFlushJobEnabled = settings.RegisterBoolSetting(
+	settings.ApplicationLevel,
+	"sql.stats.flush.job.enabled",
+	"if set, SQL execution statistics are periodically flushed to disk via job. "+
+		"If this is enabled, the per node flush will be disable",
+	true, /* defaultValue */
+	settings.WithPublic)
+
 // SQLStatsFlushJitter specifies the jitter fraction on the interval between
 // attempts to flush SQL Stats.
 //

--- a/pkg/sql/sqlstats/sslocal/sslocal_provider.go
+++ b/pkg/sql/sqlstats/sslocal/sslocal_provider.go
@@ -8,12 +8,12 @@ package sslocal
 import (
 	"context"
 	"sort"
-	"sync"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/appstatspb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats/insights"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats/ssmemstorage"
@@ -127,78 +127,24 @@ func (s *SQLStats) IterateStatementStats(
 	return nil
 }
 
-// ConsumeStats leverages the process of atomic pulling stats from in-memory storage, clearing in-memory stats, and
-// then iterating over them pulled stats calling stmtVisitor and txnVisitor on statement and transaction stats
-// respectively. ConsumeStats allows to process pulled statements while new sql stats can be added to in-memory statistics.
-func (s *SQLStats) ConsumeStats(
+var _ sqlstats.SSProvider = &SQLStats{}
+
+func (s *SQLStats) PopAllStats(
 	ctx context.Context,
-	stopper *stop.Stopper,
-	stmtVisitor sqlstats.StatementVisitor,
-	txnVisitor sqlstats.TransactionVisitor,
-) {
-	if s.knobs != nil {
-		if s.knobs != nil && s.knobs.ConsumeStmtStatsInterceptor != nil {
-			stmtVisitor = s.knobs.ConsumeStmtStatsInterceptor
-		}
-		if s.knobs != nil && s.knobs.ConsumeTxnStatsInterceptor != nil {
-			txnVisitor = s.knobs.ConsumeTxnStatsInterceptor
-		}
-	}
+) ([]*appstatspb.CollectedStatementStatistics, []*appstatspb.CollectedTransactionStatistics) {
+	stmtStats := make([]*appstatspb.CollectedStatementStatistics, 0)
+	txnStats := make([]*appstatspb.CollectedTransactionStatistics, 0)
 	apps := s.getAppNames(false)
 	for _, app := range apps {
 		container := s.GetApplicationStats(app)
 		if err := s.MaybeDumpStatsToLog(ctx, app, container, s.flushTarget); err != nil {
 			log.Warningf(ctx, "failed to dump stats to log, %s", err.Error())
 		}
-		stmtStats, txnStats := container.PopAllStats(ctx)
-
-		// Iterate over collected stats that have been already cleared from in-memory stats and persist them
-		// the system statement|transaction_statistics tables.
-		// In-memory stats storage is not locked here and it is safe to call stmtVisitor or txnVisitor functions
-		// that might be time consuming operations.
-		var wg sync.WaitGroup
-		wg.Add(2)
-
-		err := stopper.RunAsyncTask(ctx, "sql-stmt-stats-flush", func(ctx context.Context) {
-			defer wg.Done()
-
-			ctx, cancel := stopper.WithCancelOnQuiesce(ctx)
-			defer cancel()
-
-			for _, stat := range stmtStats {
-				stat := stat
-				if err := stmtVisitor(ctx, stat); err != nil {
-					log.Warningf(ctx, "failed to consume statement statistics, %s", err.Error())
-				}
-			}
-		})
-		if err != nil {
-			log.Warningf(ctx, "failed to execute sql-stmt-stats-flush task, %s", err.Error())
-			wg.Done()
-			return
-		}
-
-		err = stopper.RunAsyncTask(ctx, "sql-txn-stats-flush", func(ctx context.Context) {
-			defer wg.Done()
-
-			ctx, cancel := stopper.WithCancelOnQuiesce(ctx)
-			defer cancel()
-
-			for _, stat := range txnStats {
-				stat := stat
-				if err := txnVisitor(ctx, stat); err != nil {
-					log.Warningf(ctx, "failed to consume transaction statistics, %s", err.Error())
-				}
-			}
-		})
-		if err != nil {
-			log.Warningf(ctx, "failed to execute sql-txn-stats-flush task, %s", err.Error())
-			wg.Done()
-			return
-		}
-
-		wg.Wait()
+		containerStmtStats, containerTxnStats := container.PopAllStats(ctx)
+		stmtStats = append(stmtStats, containerStmtStats...)
+		txnStats = append(txnStats, containerTxnStats...)
 	}
+	return stmtStats, txnStats
 }
 
 // StmtStatsIterator returns an instance of sslocal.StmtStatsIterator for

--- a/pkg/sql/sqlstats/ssprovider.go
+++ b/pkg/sql/sqlstats/ssprovider.go
@@ -113,3 +113,10 @@ type RecordedTxnStats struct {
 	SessionData             *sessiondata.SessionData
 	TxnErr                  error
 }
+
+// Interface for getting SQL stats
+type SSProvider interface {
+	// GetStats Stats that are consumed will permanently be removed from their source.
+	// Once the stats are fetched, they cannot be processed again
+	PopAllStats(ctx context.Context) ([]*appstatspb.CollectedStatementStatistics, []*appstatspb.CollectedTransactionStatistics)
+}

--- a/pkg/sql/sqlstats/ssremote/BUILD.bazel
+++ b/pkg/sql/sqlstats/ssremote/BUILD.bazel
@@ -1,0 +1,15 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "ssremote",
+    srcs = ["ssremote_provider.go"],
+    importpath = "github.com/cockroachdb/cockroach/pkg/sql/sqlstats/ssremote",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/server/serverpb",
+        "//pkg/sql",
+        "//pkg/sql/appstatspb",
+        "//pkg/sql/sqlstats",
+        "//pkg/util/log",
+    ],
+)

--- a/pkg/sql/sqlstats/ssremote/ssremote_provider.go
+++ b/pkg/sql/sqlstats/ssremote/ssremote_provider.go
@@ -1,0 +1,55 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package ssremote
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
+	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/appstatspb"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+)
+
+type SQLStats struct {
+	execConfig *sql.ExecutorConfig
+}
+
+func New(execCfg *sql.ExecutorConfig) *SQLStats {
+	return &SQLStats{execConfig: execCfg}
+}
+
+func (ss *SQLStats) PopAllStats(
+	ctx context.Context,
+) ([]*appstatspb.CollectedStatementStatistics, []*appstatspb.CollectedTransactionStatistics) {
+	resp, err := ss.execConfig.SQLStatusServer.PopAllSqlStats(ctx, &serverpb.PopAllSqlStatsRequest{})
+	if err != nil {
+		log.Warning(ctx, "Something went wrong")
+		return nil, nil
+	}
+	stmtStats := make([]*appstatspb.CollectedStatementStatistics, 0, len(resp.Statements))
+	txnStats := make([]*appstatspb.CollectedTransactionStatistics, 0, len(resp.Transactions))
+	for _, stmt := range resp.Statements {
+		stmtStats = append(stmtStats, &appstatspb.CollectedStatementStatistics{
+			ID:    stmt.ID,
+			Key:   stmt.Key.KeyData,
+			Stats: stmt.Stats,
+		})
+	}
+
+	for _, txnstmt := range resp.Transactions {
+		txnStats = append(txnStats, &appstatspb.CollectedTransactionStatistics{
+			StatementFingerprintIDs:  txnstmt.StatsData.StatementFingerprintIDs,
+			App:                      "",
+			Stats:                    txnstmt.StatsData.Stats,
+			TransactionFingerprintID: txnstmt.StatsData.TransactionFingerprintID,
+		})
+	}
+	return stmtStats, txnStats
+}
+
+var _ sqlstats.SSProvider = &SQLStats{}

--- a/pkg/sql/tablemetadatacache/BUILD.bazel
+++ b/pkg/sql/tablemetadatacache/BUILD.bazel
@@ -21,6 +21,8 @@ go_library(
         "//pkg/sql/isql",
         "//pkg/sql/sem/tree",
         "//pkg/sql/sessiondata",
+        "//pkg/sql/sqlstats/persistedsqlstats",
+        "//pkg/sql/sqlstats/ssremote",
         "//pkg/sql/tablemetadatacache/util",
         "//pkg/util/log",
         "//pkg/util/metric",


### PR DESCRIPTION
Repurposes the table metadata cache job  to instead flush sql stats. This is done by using a new gRPC method that collects sql stats from every node and merges any duplicate statement stats. The job uses the persistsqlstats package to persist these stats into the database.