### PR TITLE
[prototype] kvserver: take approximate on-disk size into account for splits

### DIFF
--- a/pkg/kv/kvserver/merge_queue.go
+++ b/pkg/kv/kvserver/merge_queue.go
@@ -290,7 +290,7 @@ func (mq *mergeQueue) process(
 		}
 	}
 
-	shouldSplit, _ := shouldSplitRange(ctx, mergedDesc, mergedStats,
+	shouldSplit, _ := shouldSplitRange(ctx, mergedDesc, lhsRepl.diskUsageTotal(mergedDesc), mergedStats.Total(),
 		lhsRepl.GetMaxBytes(ctx), lhsRepl.shouldBackpressureWrites(), confReader)
 	if shouldSplit {
 		log.VEventf(ctx, 2,

--- a/pkg/kv/kvserver/split_queue_test.go
+++ b/pkg/kv/kvserver/split_queue_test.go
@@ -114,7 +114,7 @@ func TestSplitQueueShouldQueue(t *testing.T) {
 		// Testing using shouldSplitRange instead of shouldQueue to avoid using the splitFinder
 		// This tests the merge queue behavior too as a result. For splitFinder tests,
 		// see split/split_test.go.
-		shouldQ, priority := shouldSplitRange(ctx, repl.Desc(), repl.GetMVCCStats(),
+		shouldQ, priority := shouldSplitRange(ctx, repl.Desc(), repl.GetMVCCStats().Total(), repl.GetMVCCStats().Total(),
 			repl.GetMaxBytes(ctx), repl.ShouldBackpressureWrites(ctx), cfg)
 		if shouldQ != test.shouldQ {
 			t.Errorf("%d: should queue expected %t; got %t", i, test.shouldQ, shouldQ)


### PR DESCRIPTION
Informs https://github.com/cockroachdb/cockroach/issues/136366.
