### PR TITLE
rowexec: add encoded datums to HLL sketch

### DIFF
--- a/pkg/sql/create_stats_test.go
+++ b/pkg/sql/create_stats_test.go
@@ -7,6 +7,7 @@ package sql_test
 
 import (
 	"context"
+	"strconv"
 	"sync"
 	"testing"
 	"time"
@@ -180,4 +181,53 @@ INSERT INTO system.table_statistics (
 		`SELECT stxrelid::regclass::text, stxname, stxnamespace::regnamespace::text FROM pg_catalog.pg_statistic_ext`,
 		[][]string{{"t", "s", "public"}},
 	)
+}
+
+// BenchmarkAnalyze runs a benchmark for the ANALYZE statement on a
+// sysbench-like table.
+func BenchmarkAnalyze(b *testing.B) {
+	defer log.Scope(b).Close(b)
+	ctx := context.Background()
+
+	s, sqlDB, _ := serverutils.StartServer(b, base.TestServerArgs{})
+	defer s.Stopper().Stop(ctx)
+	stats.AutomaticStatisticsClusterMode.Override(ctx, &s.ClusterSettings().SV, false)
+
+	sqlRunner := sqlutils.MakeSQLRunner(sqlDB)
+	// Ensure that there's always a single range.
+	sqlRunner.Exec(b, `SET CLUSTER SETTING kv.split_queue.enabled = false`)
+	sqlRunner.Exec(b, `
+		CREATE TABLE t (
+			id INT8 PRIMARY KEY,
+			k INT8 NOT NULL DEFAULT 0,
+			c CHAR(120) NOT NULL DEFAULT '',
+			pad CHAR(60) NOT NULL DEFAULT '',
+			INDEX (k)
+		)
+	`)
+
+	const (
+		batchSize = 10_000
+		numRows   = 100_000
+	)
+
+	for i, n := 0, numRows; i < n; i += batchSize {
+		sqlRunner.Exec(b, `
+			INSERT INTO t (id, k, c, pad)
+			SELECT
+				i,
+				(random() * `+strconv.Itoa(numRows)+`)::INT, 
+				substr(md5(random()::TEXT) || md5(random()::TEXT) || md5(random()::TEXT) || md5(random()::TEXT), 0, 120),
+				substr(md5(random()::TEXT) || md5(random()::TEXT), 0, 60)
+			FROM generate_series($1, $2) AS g(i)
+		`, i, i+batchSize-1)
+	}
+
+	// Run a full table scan to resolve intents and reduce variance.
+	sqlRunner.Exec(b, `SELECT count(*) FROM t`)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		sqlRunner.Exec(b, `ANALYZE t`)
+	}
 }

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -407,13 +407,18 @@ func (dsp *DistSQLPlanner) setupFlows(
 	if len(statementSQL) > setupFlowRequestStmtMaxLength {
 		statementSQL = statementSQL[:setupFlowRequestStmtMaxLength]
 	}
-	execVersion := execversion.V24_3
-	if dsp.st.Version.IsActive(ctx, clusterversion.V25_1) {
-		execVersion = execversion.V25_1
+	var v execversion.V
+	switch {
+	case dsp.st.Version.IsActive(ctx, clusterversion.V25_2):
+		v = execversion.V25_2
+	case dsp.st.Version.IsActive(ctx, clusterversion.V25_1):
+		v = execversion.V25_1
+	default:
+		v = execversion.V24_3
 	}
 	setupReq := execinfrapb.SetupFlowRequest{
 		LeafTxnInputState: leafInputState,
-		Version:           execVersion,
+		Version:           v,
 		TraceKV:           evalCtx.Tracing.KVTracingEnabled(),
 		CollectStats:      planCtx.collectExecStats,
 		StatementSQL:      statementSQL,

--- a/pkg/sql/execversion/version.go
+++ b/pkg/sql/execversion/version.go
@@ -25,12 +25,16 @@ const V24_3 = V(71)
 // only be used by the flows once the cluster has upgraded to 25.1.
 const V25_1 = V(72)
 
+// V25_2 is the exec version of all binaries of 25.2 cockroach versions. It can
+// only be used by the flows once the cluster has upgraded to 25.2.
+const V25_2 = V(73)
+
 // MinAccepted is the oldest version that the server is compatible with. A
 // server will not accept flows with older versions.
 const MinAccepted = V24_3
 
 // Latest is the latest exec version supported by this binary.
-const Latest = V25_1
+const Latest = V25_2
 
 var contextVersionKey = ctxutil.RegisterFastValueKey()
 

--- a/pkg/sql/logictest/testdata/logic_test/distsql_stats
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_stats
@@ -3055,23 +3055,33 @@ upper_bound            range_rows  distinct_range_rows  equal_rows
 # Verify that the correct partial predicate is used for partial stats using
 # extremes when outer buckets exist (int column type).
 statement ok
-CREATE TABLE int_outer_buckets (a PRIMARY KEY) AS SELECT generate_series(0, 9999);
+CREATE TABLE int_outer_buckets (a INT PRIMARY KEY)
 
+# Inject a full stats collection with 2 outer buckets with upper bounds of
+# MaxInt64 and MinInt64.
 statement ok
-CREATE STATISTICS int_outer_buckets_full ON a FROM int_outer_buckets;
+ALTER TABLE int_outer_buckets INJECT STATISTICS '[
+  {
+    "name": "int_outer_buckets_full",
+    "columns": ["a"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 10000,
+    "distinct_count": 10000,
+    "null_count": 0,
+    "avg_size": 2,
+    "histo_col_type": "int",
+    "histo_version": 3,
+    "histo_buckets": [
+      {"num_eq": 0, "num_range": 0, "distinct_range": 0, "upper_bound": "-9223372036854775808"},
+      {"num_eq": 1, "num_range": 0, "distinct_range": 0, "upper_bound": "0"},
+      {"num_eq": 1, "num_range": 9998, "distinct_range": 9998, "upper_bound": "9999"},
+      {"num_eq": 0, "num_range": 0, "distinct_range": 0, "upper_bound": "9223372036854775807"}
+    ]
+  }
+]'
 
 statement ok
 SELECT crdb_internal.clear_table_stats_cache();
-
-let $hist_id_int_outer_buckets_full
-SELECT histogram_id FROM [SHOW STATISTICS FOR TABLE int_outer_buckets] WHERE statistics_name = 'int_outer_buckets_full'
-
-# The full stats collection should have added 2 outer buckets for a total of 202
-# with upper bounds of MaxInt64 and MinInt64.
-query I
-SELECT count(*) FROM [SHOW HISTOGRAM $hist_id_int_outer_buckets_full]
-----
-202
 
 statement ok
 INSERT INTO int_outer_buckets SELECT generate_series(-10, -1) UNION ALL SELECT generate_series(10000, 10009);

--- a/pkg/sql/opt/exec/execbuilder/testdata/partial_stats
+++ b/pkg/sql/opt/exec/execbuilder/testdata/partial_stats
@@ -1243,32 +1243,36 @@ SET CLUSTER SETTING sql.stats.forecasts.enabled = $forecastsEnabledPrev
 statement ok
 CREATE TABLE ka (k INT PRIMARY KEY, a INT, INDEX(a))
 
+# Inject a full stats collection with 2 outer buckets with upper bounds of
+# MaxInt64 and MinInt64.
 statement ok
-INSERT INTO ka select x, x from generate_series(0, 9998) as g(x)
-
-statement ok
-INSERT INTO ka VALUES (9999, NULL)
-
-statement ok
-CREATE STATISTICS ka_fullstat ON a FROM ka
+ALTER TABLE ka INJECT STATISTICS '[
+  {
+    "name": "ka_fullstat",
+    "columns": ["a"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 10000,
+    "distinct_count": 10000,
+    "null_count": 1,
+    "avg_size": 2,
+    "histo_version": 3,
+    "histo_col_type": "int",
+    "histo_buckets": [
+      {"num_eq": 0, "num_range": 0, "distinct_range": 0, "upper_bound": "-9223372036854775808"},
+      {"num_eq": 1, "num_range": 0, "distinct_range": 0, "upper_bound": "0"},
+      {"num_eq": 1, "num_range": 9997, "distinct_range": 9997, "upper_bound": "9998"},
+      {"num_eq": 0, "num_range": 0, "distinct_range": 0, "upper_bound": "9223372036854775807"}
+    ]
+  }
+]'
 
 # Clear the stat cache so that creating partial statistics has access to the
 # latest full statistic.
 statement ok
 SELECT crdb_internal.clear_table_stats_cache();
 
-let $hist_id_ka_outer_buckets_full
-SELECT histogram_id FROM [SHOW STATISTICS FOR TABLE ka] WHERE statistics_name = 'ka_fullstat'
-
-# The full stats collection should have added 2 outer buckets for a total of 202
-# with upper bounds of MaxInt64 and MinInt64.
-query I
-SELECT count(*) FROM [SHOW HISTOGRAM $hist_id_ka_outer_buckets_full]
-----
-202
-
 statement ok
-INSERT INTO ka VALUES (10000, 9999), (10001, 10000)
+INSERT INTO ka VALUES (10000, 9999), (10001, 10000), (9999, NULL)
 
 statement ok
 CREATE STATISTICS ka_partialstat ON a FROM ka USING EXTREMES
@@ -1279,8 +1283,8 @@ FROM [SHOW STATISTICS FOR TABLE ka WITH MERGE]
 ORDER BY statistics_name
 ----
 statistics_name  column_names  row_count  distinct_count  null_count
-__merged__       {a}           10002      9922            1
-ka_fullstat      {a}           10000      9920            1
+__merged__       {a}           10002      10002           1
+ka_fullstat      {a}           10000      10000           1
 ka_partialstat   {a}           3          3               1
 
 # Verify that the merged histogram correctly appends the partial stat buckets
@@ -1309,21 +1313,33 @@ LIMIT 3
     "upper_bound": "9999"
 }
 {
-    "distinct_range": 49.591730440470876,
+    "distinct_range": 9997,
     "num_eq": 1,
-    "num_range": 50,
+    "num_range": 9997,
     "upper_bound": "9998"
 }
 
 # Verify that distinct counts and null counts are merged correctly.
 statement ok
-SET CLUSTER SETTING sql.stats.histogram_samples.count = 10005
-
-statement ok
-INSERT INTO ka VALUES (10002, 10001)
-
-statement ok
-CREATE STATISTICS ka_fullstat ON a FROM ka
+ALTER TABLE ka INJECT STATISTICS '[
+  {
+    "name": "ka_fullstat",
+    "columns": ["a"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 10004,
+    "distinct_count": 10004,
+    "null_count": 1,
+    "avg_size": 2,
+    "histo_version": 3,
+    "histo_col_type": "int",
+    "histo_buckets": [
+      {"num_eq": 0, "num_range": 0, "distinct_range": 0, "upper_bound": "-9223372036854775808"},
+      {"num_eq": 1, "num_range": 0, "distinct_range": 0, "upper_bound": "0"},
+      {"num_eq": 1, "num_range": 10001, "distinct_range": 10001, "upper_bound": "10002"},
+      {"num_eq": 0, "num_range": 0, "distinct_range": 0, "upper_bound": "9223372036854775807"}
+    ]
+  }
+]'
 
 # Clear the stat cache so that creating partial statistics has access to the
 # latest full statistic.
@@ -1342,9 +1358,9 @@ FROM [SHOW STATISTICS FOR TABLE ka WITH MERGE]
 ORDER BY statistics_name
 ----
 statistics_name  column_names  row_count  distinct_count  null_count
-__merged__       {a}           10005      9924            2
-ka_fullstat      {a}           10003      9923            1
-ka_partialstat   {a}           3          2               2
+__merged__       {a}           10005      10004           2
+ka_fullstat      {a}           10004      10004           1
+ka_partialstat   {a}           2          1               2
 
 statement ok
 RESET CLUSTER SETTING sql.stats.histogram_samples.count

--- a/pkg/sql/randgen/encdatum.go
+++ b/pkg/sql/randgen/encdatum.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/errors"
 )
 
 // RandDatumEncoding returns a random DatumEncoding value.
@@ -88,17 +89,35 @@ func NullEncDatum() rowenc.EncDatum {
 	return rowenc.EncDatum{Datum: tree.DNull}
 }
 
+// DatumEncoding_NONE is only for tests. It is not a valid encoding. It is used
+// to instruct random datum generators to skip encoding the returned datum(s).
+const DatumEncoding_NONE catenumpb.DatumEncoding = -1
+
+func shouldEncode(enc catenumpb.DatumEncoding) bool {
+	return enc != DatumEncoding_NONE
+}
+
 // GenEncDatumRowsInt converts rows of ints to rows of EncDatum DInts.
 // If an int is negative, the corresponding value is NULL.
-func GenEncDatumRowsInt(inputRows [][]int) rowenc.EncDatumRows {
+func GenEncDatumRowsInt(inputRows [][]int, enc catenumpb.DatumEncoding) rowenc.EncDatumRows {
+	var a tree.DatumAlloc
 	rows := make(rowenc.EncDatumRows, len(inputRows))
 	for i, inputRow := range inputRows {
 		for _, x := range inputRow {
+			var d rowenc.EncDatum
 			if x < 0 {
-				rows[i] = append(rows[i], NullEncDatum())
+				d = NullEncDatum()
 			} else {
-				rows[i] = append(rows[i], IntEncDatum(x))
+				d = IntEncDatum(x)
 			}
+			if shouldEncode(enc) {
+				b, err := d.Encode(types.Int, &a, enc, nil /* appendTo */)
+				if err != nil {
+					panic(err)
+				}
+				d = rowenc.EncDatumFromEncoded(enc, b)
+			}
+			rows[i] = append(rows[i], d)
 		}
 	}
 	return rows
@@ -159,17 +178,80 @@ func MakeRepeatedIntRows(n int, numRows int, numCols int) rowenc.EncDatumRows {
 	return rows
 }
 
-// GenEncDatumRowsString converts rows of strings to rows of EncDatum Strings.
-// If a string is empty, the corresponding value is NULL.
-func GenEncDatumRowsString(inputRows [][]string) rowenc.EncDatumRows {
+// GenEncDatumRowsFloat converts rows of strings to rows of EncDatum DFloats.
+func GenEncDatumRowsFloat(inputRows [][]string, enc catenumpb.DatumEncoding) rowenc.EncDatumRows {
+	var a tree.DatumAlloc
 	rows := make(rowenc.EncDatumRows, len(inputRows))
 	for i, inputRow := range inputRows {
 		for _, x := range inputRow {
-			if x == "" {
-				rows[i] = append(rows[i], NullEncDatum())
-			} else {
-				rows[i] = append(rows[i], stringEncDatum(x))
+			f, err := tree.ParseDFloat(x)
+			if err != nil {
+				panic(errors.AssertionFailedf("could not parse float: %v", x))
 			}
+			d := rowenc.EncDatum{Datum: f}
+			if shouldEncode(enc) {
+				b, err := d.Encode(types.Float, &a, enc, nil /* appendTo */)
+				if err != nil {
+					panic(err)
+				}
+				d = rowenc.EncDatumFromEncoded(enc, b)
+			}
+			rows[i] = append(rows[i], d)
+		}
+	}
+	return rows
+}
+
+// GenEncDatumRowsString converts rows of strings to rows of EncDatum Strings.
+// If a string is empty, the corresponding value is NULL.
+func GenEncDatumRowsString(inputRows [][]string, enc catenumpb.DatumEncoding) rowenc.EncDatumRows {
+	var a tree.DatumAlloc
+	rows := make(rowenc.EncDatumRows, len(inputRows))
+	for i, inputRow := range inputRows {
+		for _, x := range inputRow {
+			var d rowenc.EncDatum
+			if x == "" {
+				d = NullEncDatum()
+			} else {
+				d = stringEncDatum(x)
+			}
+			if shouldEncode(enc) {
+				b, err := d.Encode(types.String, &a, enc, nil /* appendTo */)
+				if err != nil {
+					panic(err)
+				}
+				d = rowenc.EncDatumFromEncoded(enc, b)
+			}
+			rows[i] = append(rows[i], d)
+		}
+	}
+	return rows
+}
+
+// GenEncDatumRowsCollatedString converts rows of strings to rows of EncDatum
+// collated Strings.
+// If a string is empty, the corresponding value is NULL.
+func GenEncDatumRowsCollatedString(
+	inputRows [][]string, typ *types.T, enc catenumpb.DatumEncoding,
+) rowenc.EncDatumRows {
+	var a tree.DatumAlloc
+	rows := make(rowenc.EncDatumRows, len(inputRows))
+	for i, inputRow := range inputRows {
+		for _, x := range inputRow {
+			var d rowenc.EncDatum
+			if x == "" {
+				d = NullEncDatum()
+			} else {
+				d = collatedStringEncDatum(x, typ.Locale())
+			}
+			if shouldEncode(enc) {
+				b, err := d.Encode(typ, &a, enc, nil /* appendTo */)
+				if err != nil {
+					panic(err)
+				}
+				d = rowenc.EncDatumFromEncoded(enc, b)
+			}
+			rows[i] = append(rows[i], d)
 		}
 	}
 	return rows
@@ -180,13 +262,30 @@ func stringEncDatum(s string) rowenc.EncDatum {
 	return rowenc.EncDatum{Datum: tree.NewDString(s)}
 }
 
+// collatedStringEncDatum returns an EncDatum representation of a string.
+func collatedStringEncDatum(s string, locale string) rowenc.EncDatum {
+	d, err := tree.NewDCollatedString(s, locale, &tree.CollationEnvironment{})
+	if err != nil {
+		panic(err)
+	}
+	return rowenc.EncDatum{Datum: d}
+}
+
+func bytesEncDatum(b []byte) rowenc.EncDatum {
+	return rowenc.EncDatum{Datum: tree.NewDBytes(tree.DBytes(b))}
+}
+
 // GenEncDatumRowsBytes converts rows of bytes to rows of EncDatum value encoded
 // bytes.
-func GenEncDatumRowsBytes(inputRows [][][]byte) rowenc.EncDatumRows {
+func GenEncDatumRowsBytes(inputRows [][][]byte, enc catenumpb.DatumEncoding) rowenc.EncDatumRows {
 	rows := make(rowenc.EncDatumRows, len(inputRows))
 	for i, inputRow := range inputRows {
 		for _, x := range inputRow {
-			rows[i] = append(rows[i], rowenc.EncDatumFromEncoded(catenumpb.DatumEncoding_VALUE, x))
+			d := bytesEncDatum(x)
+			if shouldEncode(enc) {
+				d = rowenc.EncDatumFromEncoded(catenumpb.DatumEncoding_VALUE, x)
+			}
+			rows[i] = append(rows[i], d)
 		}
 	}
 	return rows

--- a/pkg/sql/rowexec/BUILD.bazel
+++ b/pkg/sql/rowexec/BUILD.bazel
@@ -93,6 +93,7 @@ go_library(
         "//pkg/util",
         "//pkg/util/admission/admissionpb",
         "//pkg/util/cancelchecker",
+        "//pkg/util/collatedstring",
         "//pkg/util/ctxgroup",
         "//pkg/util/encoding",
         "//pkg/util/hlc",

--- a/pkg/sql/rowexec/sample_aggregator_test.go
+++ b/pkg/sql/rowexec/sample_aggregator_test.go
@@ -122,7 +122,7 @@ func runSampleAggregator(
 			rowPartitions[j] = append(rowPartitions[j], row)
 		}
 		for i := 0; i < numSamplers; i++ {
-			rows := randgen.GenEncDatumRowsInt(rowPartitions[i])
+			rows := randgen.GenEncDatumRowsInt(rowPartitions[i], randgen.DatumEncoding_NONE)
 			in[i] = distsqlutils.NewRowBuffer(types.TwoIntCols, rows, distsqlutils.RowBufferArgs{})
 		}
 
@@ -135,7 +135,7 @@ func runSampleAggregator(
 			rowPartitions[j] = append(rowPartitions[j], row)
 		}
 		for i := 0; i < numSamplers; i++ {
-			rows := randgen.GenEncDatumRowsString(rowPartitions[i])
+			rows := randgen.GenEncDatumRowsString(rowPartitions[i], randgen.DatumEncoding_NONE)
 			in[i] = distsqlutils.NewRowBuffer([]*types.T{types.String, types.String}, rows, distsqlutils.RowBufferArgs{})
 		}
 		// Override original columns in samplerOutTypes.


### PR DESCRIPTION
#### sql: add BenchmarkAnalyze

Release note: None

#### sql/execversion: add V25_2

Release note: None

#### rowexec: add encoded datums to HLL sketch

Previously, the sampler would decode and re-encode all datums except for
integers with EncDatum.Fingerprint before adding them to the hyperloglog
sketch. This ensured that equal bytes were added to the sketch for two
semantically equivalent values, even if their encodings were different.
The overhead of decoding and re-encoding is significant, however.

Now, for all types except for collated strings or container types with
collated strings, the encoded bytes of the datum, if present, are added
directly to the hyperloglog sketch, skipping the overhead of
fingerprinting. See the comments added to `addRow` for more details.

```
name     old time/op    new time/op    delta
Analyze     216ms ± 3%     158ms ± 3%  -27.14%  (p=0.000 n=9+10)

name     old alloc/op   new alloc/op   delta
Analyze    75.6MB ± 4%    63.7MB ± 3%  -15.66%  (p=0.000 n=9+9)

name     old allocs/op  new allocs/op  delta
Analyze      573k ± 5%      355k ± 1%  -37.94%  (p=0.000 n=10+8)
```

Fixes #137362
Fixes #140652

Release note: None
