### PR TITLE
release-24.2:  workload/schemachanger: set session variables on all connections

### DIFF
--- a/pkg/ccl/testccl/workload/schemachange/schema_change_external_test.go
+++ b/pkg/ccl/testccl/workload/schemachange/schema_change_external_test.go
@@ -34,7 +34,6 @@ func TestWorkload(t *testing.T) {
 	defer ccl.TestingEnableEnterprise()()
 	skip.UnderDeadlock(t, "test connections can be too slow under expensive configs")
 	skip.UnderRace(t, "test connections can be too slow under expensive configs")
-	skip.WithIssue(t, 140411)
 
 	scope := log.Scope(t)
 	defer scope.Close(t)

--- a/pkg/ccl/testccl/workload/schemachange/schema_change_external_test.go
+++ b/pkg/ccl/testccl/workload/schemachange/schema_change_external_test.go
@@ -32,7 +32,9 @@ import (
 func TestWorkload(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer ccl.TestingEnableEnterprise()()
-	skip.UnderRace(t, "test connections can be too slow under race option.")
+	skip.UnderDeadlock(t, "test connections can be too slow under expensive configs")
+	skip.UnderRace(t, "test connections can be too slow under expensive configs")
+	skip.WithIssue(t, 140411)
 
 	scope := log.Scope(t)
 	defer scope.Close(t)

--- a/pkg/workload/schemachange/schemachange.go
+++ b/pkg/workload/schemachange/schemachange.go
@@ -216,6 +216,9 @@ func (s *schemaChange) Ops(
 	cfg.MaxConnLifetime = time.Hour
 	cfg.MaxConnIdleTime = time.Hour
 	cfg.QueryTracer = &PGXTracer{tracer: tracer}
+	if err := s.setClusterSettings(ctx, urls[0]); err != nil {
+		return workload.QueryLoad{}, err
+	}
 	pool, err := workload.NewMultiConnPool(ctx, cfg, urls...)
 	if err != nil {
 		return workload.QueryLoad{}, err
@@ -224,9 +227,7 @@ func (s *schemaChange) Ops(
 	if err != nil {
 		return workload.QueryLoad{}, err
 	}
-	if err := s.setClusterSettings(ctx, pool); err != nil {
-		return workload.QueryLoad{}, err
-	}
+
 	stdoutLog := makeAtomicLog(os.Stdout)
 	// Use NewPseudoRand here because we want to print out the global seed used by
 	// the workload. Using NewTestRand() here would only let us see the per-test
@@ -337,12 +338,20 @@ func (s *schemaChange) Ops(
 
 // setClusterSettings configures any settings required for the workload ahead
 // of starting workers.
-func (s *schemaChange) setClusterSettings(ctx context.Context, pool *workload.MultiConnPool) error {
+func (s *schemaChange) setClusterSettings(ctx context.Context, url string) (err error) {
+	conn, err := pgx.Connect(ctx, url)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		closeErr := conn.Close(ctx)
+		err = errors.WithSecondaryError(err, closeErr)
+	}()
 	for _, stmt := range []string{
 		`SET CLUSTER SETTING sql.defaults.super_regions.enabled = 'on'`,
 		`SET CLUSTER SETTING sql.log.all_statements.enabled = 'on'`,
 	} {
-		_, err := pool.Get().Exec(ctx, stmt)
+		_, err := conn.Exec(ctx, stmt)
 		if err != nil {
 			return errors.WithStack(err)
 		}


### PR DESCRIPTION
Backport 2/2 commits from #140415.

/cc @cockroachdb/release

Release justification: test only change

---

Previously, we fetched connections from our connection pool to apply
session variables. When we changed the cluster setting the default only
changes for new connection, so our connection pool could have
connections with the previous value. To address this, this patch opens
an new connection for apply cluster settings, and then creates the
connection pools for the workloads.

Fixes: #140411

Release note: None
