### PR TITLE
backup: cleanup old `SHOW BACKUP` code

### DIFF
--- a/pkg/backup/show.go
+++ b/pkg/backup/show.go
@@ -135,7 +135,7 @@ func showBackupTypeCheck(
 	if !ok {
 		return false, nil, nil
 	}
-	if backup.Path == nil && backup.InCollection != nil {
+	if backup.Path == nil {
 		return showBackupsInCollectionTypeCheck(ctx, backup, p)
 	}
 	if err := exprutil.TypeCheck(
@@ -172,7 +172,7 @@ func showBackupPlanHook(
 	}
 	exprEval := p.ExprEvaluator("SHOW BACKUP")
 
-	if showStmt.Path == nil && showStmt.InCollection != nil {
+	if showStmt.Path == nil {
 		collection, err := exprEval.StringArray(
 			ctx, tree.Exprs(showStmt.InCollection),
 		)
@@ -182,17 +182,14 @@ func showBackupPlanHook(
 		return showBackupsInCollectionPlanHook(ctx, collection, showStmt, p)
 	}
 
-	to, err := exprEval.String(ctx, showStmt.Path)
+	subdir, err := exprEval.String(ctx, showStmt.Path)
 	if err != nil {
 		return nil, nil, false, err
 	}
 
-	var inCol []string
-	if showStmt.InCollection != nil {
-		inCol, err = exprEval.StringArray(ctx, tree.Exprs(showStmt.InCollection))
-		if err != nil {
-			return nil, nil, false, err
-		}
+	dest, err := exprEval.StringArray(ctx, tree.Exprs(showStmt.InCollection))
+	if err != nil {
+		return nil, nil, false, err
 	}
 
 	infoReader := getBackupInfoReader(p, showStmt)
@@ -205,46 +202,21 @@ func showBackupPlanHook(
 		ctx, span := tracing.ChildSpan(ctx, stmt.StatementTag())
 		defer span.Finish()
 
-		var (
-			dest   []string
-			subdir string
-		)
-		// For old style show backup, 'to' is the resolved path to the full backup;
-		// for new SHOW BACKUP, 'to' is the subdirectory.
-		if inCol != nil {
-			subdir = to
-			dest = inCol
-		} else {
-			dest = append(dest, to)
-			// Deprecation notice for old `SHOW BACKUP` syntax. Remove this once the syntax is
-			// deleted in 22.2.
-			p.BufferClientNotice(ctx,
-				pgnotice.Newf("The `SHOW BACKUP` syntax without the `IN` keyword will be removed in a"+
-					" future release. Please switch over to using `SHOW BACKUP FROM <backup> IN"+
-					" <collection>` to view metadata on a backup collection: %s."+
-					" Also note that backups created using the `BACKUP TO` syntax may not be showable or"+
-					" restoreable in the next major version release. Use `BACKUP INTO` instead.",
-					"https://www.cockroachlabs.com/docs/stable/show-backup.html"))
-		}
-
 		if err := sql.CheckDestinationPrivileges(ctx, p, dest); err != nil {
 			return err
 		}
 
-		fullyResolvedDest := dest
-		if subdir != "" {
-			if strings.EqualFold(subdir, backupbase.LatestFileName) {
-				subdir, err = backupdest.ReadLatestFile(ctx, dest[0],
-					p.ExecCfg().DistSQLSrv.ExternalStorageFromURI,
-					p.User())
-				if err != nil {
-					return errors.Wrap(err, "read LATEST path")
-				}
-			}
-			fullyResolvedDest, err = backuputils.AppendPaths(dest, subdir)
+		if strings.EqualFold(subdir, backupbase.LatestFileName) {
+			subdir, err = backupdest.ReadLatestFile(ctx, dest[0],
+				p.ExecCfg().DistSQLSrv.ExternalStorageFromURI,
+				p.User())
 			if err != nil {
-				return err
+				return errors.Wrap(err, "read LATEST path")
 			}
+		}
+		fullyResolvedDest, err := backuputils.AppendPaths(dest, subdir)
+		if err != nil {
+			return err
 		}
 		baseStores := make([]cloud.ExternalStorage, len(fullyResolvedDest))
 		for j := range fullyResolvedDest {
@@ -440,11 +412,7 @@ you must pass the 'encryption_info_dir' parameter that points to the directory o
 		if err := infoReader.showBackup(ctx, &mem, mkStore, info, p.User(), &kmsEnv, resultsCh); err != nil {
 			return err
 		}
-		if showStmt.InCollection == nil {
-			telemetry.Count("show-backup.deprecated-subdir-syntax")
-		} else {
-			telemetry.Count("show-backup.collection")
-		}
+		telemetry.Count("show-backup.collection")
 		return nil
 	}
 
@@ -461,7 +429,7 @@ func getBackupInfoReader(p sql.PlanHookState, showStmt *tree.ShowBackup) backupI
 		case tree.BackupRangeDetails:
 			shower = backupShowerRanges
 		case tree.BackupFileDetails:
-			shower = backupShowerFileSetup(p, showStmt.InCollection)
+			shower = backupShowerFileSetup()
 		case tree.BackupSchemaDetails:
 			shower = backupShowerDefault(p, true, showStmt.Options)
 		case tree.BackupValidateDetails:
@@ -1214,9 +1182,7 @@ var backupShowerDoctor = backupShower{
 	},
 }
 
-func backupShowerFileSetup(
-	p sql.PlanHookState, inCol tree.StringOrPlaceholderOptList,
-) backupShower {
+func backupShowerFileSetup() backupShower {
 	return backupShower{header: colinfo.ResultColumns{
 		{Name: "path", Typ: types.String},
 		{Name: "backup_type", Typ: types.String},
@@ -1232,17 +1198,14 @@ func backupShowerFileSetup(
 
 		fn: func(ctx context.Context, info backupInfo) (rows []tree.Datums, err error) {
 
-			var manifestDirs []string
 			var localityAware bool
-			if len(inCol) > 0 {
-				manifestDirs, err = getManifestDirs(info.subdir, info.defaultURIs)
-				if err != nil {
-					return nil, err
-				}
+			manifestDirs, err := getManifestDirs(info.subdir, info.defaultURIs)
+			if err != nil {
+				return nil, err
+			}
 
-				if len(info.localityInfo[0].URIsByOriginalLocalityKV) > 0 {
-					localityAware = true
-				}
+			if len(info.localityInfo[0].URIsByOriginalLocalityKV) > 0 {
+				localityAware = true
 			}
 			for i, manifest := range info.manifests {
 				backupType := "full"
@@ -1268,10 +1231,7 @@ func backupShowerFileSetup(
 						break
 					}
 					file := it.Value()
-					filePath := file.Path
-					if inCol != nil {
-						filePath = path.Join(manifestDirs[i], filePath)
-					}
+					filePath := path.Join(manifestDirs[i], file.Path)
 					locality := "NULL"
 					if localityAware {
 						locality = "default"

--- a/pkg/sql/sem/tree/show.go
+++ b/pkg/sql/sem/tree/show.go
@@ -104,7 +104,7 @@ type ShowBackup struct {
 
 // Format implements the NodeFormatter interface.
 func (node *ShowBackup) Format(ctx *FmtCtx) {
-	if node.InCollection != nil && node.Path == nil {
+	if node.Path == nil {
 		ctx.WriteString("SHOW BACKUPS IN ")
 		ctx.FormatURIs(node.InCollection)
 		return
@@ -124,13 +124,10 @@ func (node *ShowBackup) Format(ctx *FmtCtx) {
 		ctx.WriteString("FROM ")
 	}
 
-	if node.InCollection != nil {
-		ctx.FormatNode(node.Path)
-		ctx.WriteString(" IN ")
-		ctx.FormatURIs(node.InCollection)
-	} else {
-		ctx.FormatURI(node.Path)
-	}
+	ctx.FormatNode(node.Path)
+	ctx.WriteString(" IN ")
+	ctx.FormatURIs(node.InCollection)
+
 	if !node.Options.IsDefault() {
 		ctx.WriteString(" WITH OPTIONS (")
 		ctx.FormatNode(&node.Options)


### PR DESCRIPTION
The old `SHOW BACKUP` syntax without `IN` was removed in #133610. This removes the old code paths for that syntax.

Epic: none

Release note: None