### PR TITLE
make polymorphic variadic builtin functions heterogeneous

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -2882,7 +2882,7 @@ Can be used to define the tile bounds required by ST_AsMVTGeom to convert geomet
 </span></td><td>Immutable</td></tr>
 <tr><td><a name="concat"></a><code>concat(anyelement...) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Concatenates a comma-separated list of strings.</p>
 </span></td><td>Immutable</td></tr>
-<tr><td><a name="concat_ws"></a><code>concat_ws(<a href="string.html">string</a>...) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Uses the first argument as a separator between the concatenation of the subsequent arguments.</p>
+<tr><td><a name="concat_ws"></a><code>concat_ws(<a href="string.html">string</a>, anyelement...) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Uses the first argument as a separator between the concatenation of the subsequent arguments.</p>
 <p>For example <code>concat_ws('!','wow','great')</code> returns <code>wow!great</code>.</p>
 </span></td><td>Immutable</td></tr>
 <tr><td><a name="convert_from"></a><code>convert_from(str: <a href="bytes.html">bytes</a>, enc: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Decode the bytes in <code>str</code> into a string using encoding <code>enc</code>. Supports encodings ‘UTF8’ and ‘LATIN1’.</p>

--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -203,6 +203,14 @@ SELECT concat('foo'::concat_enum, ' ', 64.532, ' ', 'baz'::concat_enum, ' ', 42,
 ----
 foo 64.532 baz 42 f {"foo": "bar"} {1,2,3}
 
+statement ok
+PREPARE concat_stmt AS SELECT concat("foo"."a", $1) FROM foo
+
+query T
+EXECUTE concat_stmt(':')
+----
+1:
+
 query T
 SELECT substr('RoacH', 2, 3)
 ----
@@ -2632,6 +2640,19 @@ SELECT format('|%-*s|', -10, 'foo')
 ----
 |foo       |
 
+statement
+PREPARE format_stmt AS SELECT format('|%*s|', $1, $2)
+
+query T
+EXECUTE format_stmt(10, 'foo')
+----
+|       foo|
+
+query T
+EXECUTE format_stmt(-10, 'foo')
+----
+|foo       |
+
 # Escaping $ into \x24 only needed in testlogic or prepared statements
 query T
 SELECT format(E'Testing %3\x24s, %2\x24s, %1\x24s', 'one', 'two', 'three')
@@ -3014,6 +3035,25 @@ SELECT num_nulls(a, b), num_nonnulls(a, b) FROM nulls_test
 1  1
 1  1
 2  0
+
+statement ok
+PREPARE nn_stmt AS SELECT num_nulls(42, $1, a, b), num_nulls(b, $1, 42, a), num_nulls(a, b, $1, 42), num_nulls($1, a, b, 42), num_nonnulls(42, $1, a, b), num_nonnulls(b, $1, 42, a), num_nonnulls(a, b, $1, 42), num_nonnulls($1, a, b, 42) FROM nulls_test
+
+query IIIIIIII rowsort
+EXECUTE nn_stmt(NULL)
+----
+1  1  1  1  3  3  3  3
+2  2  2  2  2  2  2  2
+2  2  2  2  2  2  2  2
+3  3  3  3  1  1  1  1
+
+query IIIIIIII rowsort
+EXECUTE nn_stmt('foo')
+----
+0  0  0  0  4  4  4  4
+1  1  1  1  3  3  3  3
+1  1  1  1  3  3  3  3
+2  2  2  2  2  2  2  2
 
 subtest pb_to_json
 

--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -428,8 +428,18 @@ SELECT concat_ws(',', 'abcde', '2')
 ----
 abcde,2
 
-statement error unknown signature: concat_ws\(string, string, int, unknown, int\)
+query T
 SELECT concat_ws(',', 'abcde', 2, NULL, 22)
+----
+abcde,2,22
+
+statement ok
+PREPARE concat_ws_stmt AS SELECT concat_ws($1, "foo"."a", concat_ws(', ', 42, $2, $3, "foo"."a")) FROM foo
+
+query T
+EXECUTE concat_ws_stmt(': ', NULL, 'abc')
+----
+1: 42, abc, 1
 
 query T
 SELECT split_part('abc~@~def~@~ghi', '~@~', 2)

--- a/pkg/sql/logictest/testdata/logic_test/json_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/json_builtins
@@ -562,6 +562,20 @@ SELECT json_build_object('a', '0100110'::varbit)
 ----
 {"a": "0100110"}
 
+statement ok
+CREATE TABLE foo (a INT);
+
+statement ok
+INSERT INTO foo VALUES (42);
+
+statement ok
+PREPARE jbo_stmt AS SELECT json_build_object('a', a, 'b', $1) FROM foo;
+
+query T
+EXECUTE jbo_stmt(':');
+----
+{"a": 42, "b": ":"}
+
 # Regression for an internal error when using an enum and void in the key.
 statement ok
 CREATE TYPE e AS ENUM ('e');
@@ -712,6 +726,14 @@ query T
 SELECT json_build_array(1, '1'::JSON, 1.2, NULL, ARRAY['x', 'y'])
 ----
 [1, 1, 1.2, null, ["x", "y"]]
+
+statement ok
+PREPARE jba_stmt AS SELECT json_build_array(a, $1) FROM foo;
+
+query T
+EXECUTE jba_stmt(':');
+----
+[42, ":"]
 
 query T
 SELECT jsonb_build_array()

--- a/pkg/sql/pgwire/pgwirebase/encoding.go
+++ b/pkg/sql/pgwire/pgwirebase/encoding.go
@@ -858,7 +858,7 @@ func DecodeDatum(
 		return da.NewDRefCursor(tree.DString(bs)), nil
 	}
 	switch id {
-	case oid.T_text, oid.T_varchar, oid.T_unknown:
+	case oid.T_text, oid.T_varchar, oid.T_unknown, oid.T_anyelement:
 		if err := validateStringBytes(b); err != nil {
 			return nil, err
 		}

--- a/pkg/sql/sem/builtins/fixed_oids.go
+++ b/pkg/sql/sem/builtins/fixed_oids.go
@@ -822,7 +822,7 @@ var builtinOidsArray = []string{
 	846:  `substring(input: bytes, start_pos: int) -> bytes`,
 	847:  `substring(input: bytes, start_pos: int, length: int) -> bytes`,
 	848:  `concat(anyelement...) -> string`,
-	849:  `concat_ws(string...) -> string`,
+	849:  `concat_ws(string, anyelement...) -> string`,
 	850:  `convert_from(str: bytes, enc: string) -> string`,
 	851:  `convert_to(str: string, enc: string) -> bytes`,
 	852:  `get_bit(bit_string: varbit, index: int) -> int`,


### PR DESCRIPTION
**tree: polymorphic variadic builtin functions are now heterogeneous**

Previously, builtin functions with the parameter type VariadicType{VarType: types.Any} required that all variable arguments have the same type. This is what Postgres documents as its behavior, but the reality is that Postgres polymorphic builtins accept any heterogeneous arguments. This patch changes our overload handling to allow heterogeneous arguments to CRDB builtins.

**Fixes:** https://github.com/cockroachdb/cockroach/issues/136295
**Release notes (bug fix):** PREPARE now accepts heterogeneous arguments to the concat, json_build_object, jsonb_build_object, json_build_array, jsonb_build_array functions.

**builtins: support polymorphic variadic arguments in concat_ws()**

Previously, concat_ws took a variable length argument list of strings. Postgres allows anyelement data types for concat_ws(). Rewrite concat_ws() so that it takes a fixed string first argument followed by a variable list of anyelement arguments.

**Release note (sql change):** The concat_ws builtin function will now accept non-string arguments in the second and later positions.