### PR TITLE
release-24.2: opt: type check wildcard-typed VALUES rows after building them

### DIFF
--- a/pkg/ccl/testccl/sqlccl/explain_test.go
+++ b/pkg/ccl/testccl/sqlccl/explain_test.go
@@ -140,7 +140,7 @@ func TestExplainGist(t *testing.T) {
 
 	// Use the release-build panic-catching behavior instead of the
 	// crdb_test-build behavior. This is needed so that some known bugs like
-	// #117101 don't result in a test failure.
+	// #119045 and #133129 don't result in a test failure.
 	defer colexecerror.ProductionBehaviorForTests()()
 
 	ctx := context.Background()
@@ -195,7 +195,6 @@ func TestExplainGist(t *testing.T) {
 			if err != nil && strings.Contains(err.Error(), "internal error") {
 				// Ignore all errors except the internal ones.
 				for _, knownErr := range []string{
-					"invalid datum type given: RECORD, expected RECORD", // #117101
 					"expected equivalence dependants to be its closure", // #119045
 					"not in index", // #133129
 				} {

--- a/pkg/sql/logictest/testdata/logic_test/udf
+++ b/pkg/sql/logictest/testdata/logic_test/udf
@@ -925,4 +925,26 @@ SELECT f('0');
 statement ok
 DROP FUNCTION f;
 
+# Regression test for #117101 - update the resolved type of a VALUES row with a
+# UDF after the UDF is built.
+subtest regression_117101
+
+statement ok
+CREATE FUNCTION f117101() RETURNS RECORD CALLED ON NULL INPUT AS $funcbody$
+  SELECT ((42)::INT8, (43)::INT8)
+$funcbody$ LANGUAGE SQL;
+
+statement error pgcode 42804 pq: VALUES types tuple{int, int} and tuple{tuple{string, int}, unknown} cannot be matched
+SELECT
+  *
+FROM
+(
+  VALUES
+    (
+     (('aloha'::TEXT,
+     (44)::INT8), NULL)
+    ),
+    (COALESCE(f117101(), NULL))
+);
+
 subtest end

--- a/pkg/sql/logictest/testdata/logic_test/udf
+++ b/pkg/sql/logictest/testdata/logic_test/udf
@@ -948,3 +948,26 @@ FROM
 );
 
 subtest end
+
+# Regression test for #137968 - do not incorrectly modify the resolved type of
+# an expression that already found a non-wildcard type.
+subtest regression_137968
+
+statement ok
+SELECT
+	tab_18298.col_30903
+FROM
+	(
+		VALUES
+			(
+				('-26 years -422 days -21:13:57.660026':::INTERVAL::INTERVAL + now():::TIMESTAMP::TIMESTAMP::TIMESTAMP)::TIMESTAMP
+			),
+			(NULL)
+	)
+		AS tab_18298 (col_30903)
+ORDER BY
+	tab_18298.col_30903 ASC
+LIMIT
+	3:::INT8;
+
+subtest end

--- a/pkg/sql/opt/optbuilder/values.go
+++ b/pkg/sql/opt/optbuilder/values.go
@@ -75,6 +75,14 @@ func (b *Builder) buildValuesClause(
 			// resolving the column types.
 			elems[elemPos] = b.buildScalar(texpr, inScope, nil, nil, nil)
 			elemPos += numCols
+			// Type-check the expression once again in order to update expressions
+			// that wrap a UDF to reflect the modified type. Make sure to use the
+			// previously resolved type as the desired type, since the AST may have
+			// been modified to remove type annotations.
+			texpr, err = tree.TypeCheck(b.ctx, texpr, b.semaCtx, texpr.ResolvedType())
+			if err != nil {
+				panic(err)
+			}
 			if typ := texpr.ResolvedType(); typ.Family() != types.UnknownFamily {
 				if colTypes[colIdx].Family() == types.UnknownFamily {
 					colTypes[colIdx] = typ

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -1164,6 +1164,12 @@ func (expr *FuncExpr) typeCheckWithFuncAncestor(semaCtx *SemaContext, fn func() 
 func (expr *FuncExpr) TypeCheck(
 	ctx context.Context, semaCtx *SemaContext, desired *types.T,
 ) (TypedExpr, error) {
+	if expr.fn != nil && expr.fn.Type != BuiltinRoutine && expr.typ != nil {
+		// Don't overwrite the resolved properties for a user-defined routine if the
+		// routine has already been resolved.
+		return expr, nil
+	}
+
 	searchPath := EmptySearchPath
 	var resolver FunctionReferenceResolver
 	if semaCtx != nil {


### PR DESCRIPTION
Backport:
  * 1/1 commits from "opt: type check VALUES rows after building them" (#129706)
  * 1/1 commits from "opt/optbuilder: only re-type-check values rows for wildcard types" (#140277)

Please see individual PRs for details.

/cc @cockroachdb/release

Release justification: bug fix for internal error due to failed type-checking