### PR TITLE
Make docker init script respect COCKROACH_DATABASE when processing SQL files

### DIFF
--- a/build/deploy/cockroach.sh
+++ b/build/deploy/cockroach.sh
@@ -194,7 +194,7 @@ process_init_files() {
 
 # run_sql_query is a helper function to run sql queries.
 run_sql_query() {
-  $cockroach_entrypoint sql --url="$(cat server.url)" "$@"
+  $cockroach_entrypoint sql --url="$(cat server.url)" --database="${COCKROACH_DATABASE}" "$@"
 }
 
 # db_already_exists runs a sql query to check if the database already exists.


### PR DESCRIPTION
This PR makes the docker init script run the SQL files in `docker-entrypoint-initdb.d` against the database specified by `COCKROACH_DATABASE`.

The behaviour is aligned to [Postgres's init script](https://github.com/docker-library/postgres/blob/3521b2f75282fe3b3e70884d978eaadf370ca4ab/docker-entrypoint.sh#L198), and I believe it is beneficial for the most of use cases. 

Should close #137735