### PR TITLE
sql: deflake TestDropDatabaseDeleteData

### DIFF
--- a/pkg/spanconfig/spanconfigsqlwatcher/sqlwatcher.go
+++ b/pkg/spanconfig/spanconfigsqlwatcher/sqlwatcher.go
@@ -298,6 +298,11 @@ func (s *SQLWatcher) watchForZoneConfigUpdates(
 	}
 
 	log.Infof(ctx, "established range feed over system.zones starting at time %s", startTS)
+
+	if s.knobs != nil && s.knobs.OnWatchForZoneConfigUpdatesEstablished != nil {
+		s.knobs.OnWatchForZoneConfigUpdatesEstablished()
+	}
+
 	return rf, nil
 }
 

--- a/pkg/spanconfig/testing_knobs.go
+++ b/pkg/spanconfig/testing_knobs.go
@@ -126,6 +126,10 @@ type TestingKnobs struct {
 	// OverrideFallbackConf, if set, allows tests to override fields in the
 	// fallback config that will be applied to the span.
 	OverrideFallbackConf func(roachpb.SpanConfig) roachpb.SpanConfig
+
+	// OnWatchForZoneConfigUpdatesEstablished is invoked when the RangeFeed over
+	// system.zones starts.
+	OnWatchForZoneConfigUpdatesEstablished func()
 }
 
 // ModuleTestingKnobs is part of the base.ModuleTestingKnobs interface.

--- a/pkg/sql/drop_test.go
+++ b/pkg/sql/drop_test.go
@@ -10,6 +10,7 @@ import (
 	gosql "database/sql"
 	"fmt"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -23,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
+	"github.com/cockroachdb/cockroach/pkg/spanconfig"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkeys"
@@ -265,6 +267,22 @@ func TestDropDatabaseDeleteData(t *testing.T) {
 	// Speed up mvcc queue scan.
 	params.ScanMaxIdleTime = time.Millisecond
 
+	// zoneCfgRangeFeedStarted is used to signal that the zone config range feed
+	// started. This is used to avoid a race where we update `system.zones` before
+	// the full reconciliation of zone configs has started. The full
+	// reconciliation ignores dropped databases, and if we write to
+	// `system.zones` before that, our write will not be reconciled. By delaying
+	// the test until the zone config range feed starts, we ensure that the full
+	// reconciliation has finished, and the range feed is ready to stream our
+	// changes.
+	var zoneCfgRangeFeedStarted sync.WaitGroup
+	zoneCfgRangeFeedStarted.Add(1)
+	params.Knobs.SpanConfig = &spanconfig.TestingKnobs{
+		OnWatchForZoneConfigUpdatesEstablished: func() {
+			zoneCfgRangeFeedStarted.Done()
+		},
+	}
+
 	srv, sqlDB, kvDB := serverutils.StartServer(t, params)
 	defer srv.Stopper().Stop(context.Background())
 	ctx := context.Background()
@@ -273,11 +291,23 @@ func TestDropDatabaseDeleteData(t *testing.T) {
 	systemDB := srv.SystemLayer().SQLConn(t)
 	_, err := systemDB.Exec(`SET CLUSTER SETTING sql.gc_job.wait_for_gc.interval = '1s';`)
 	require.NoError(t, err)
-
 	// Refresh protected timestamp cache immediately to make MVCC GC queue to
 	// process GC immediately.
 	_, err = systemDB.Exec(`SET CLUSTER SETTING kv.protectedts.poll_interval = '1s';`)
 	require.NoError(t, err)
+
+	// Turn off storage_coalesce_adjacent to avoid a race between the GC and the
+	// split queues where a range might get GCed before splitting. This is
+	// more likely to happen in this test since increase the GC queue scan rate.
+	// If we don't turn the setting off, setting the TTL to table 1 might cause
+	// table 2 to also get purged.
+	_, err = systemDB.Exec(`SET CLUSTER SETTING spanconfig.storage_coalesce_adjacent.enabled = 'false';`)
+	require.NoError(t, err)
+	_, err = systemDB.Exec(`SET CLUSTER SETTING spanconfig.tenant_coalesce_adjacent.enabled = 'false';`)
+	require.NoError(t, err)
+
+	// Wait for the zone config range feed to start.
+	zoneCfgRangeFeedStarted.Wait()
 
 	// Disable strict GC TTL enforcement because we're going to shove a zero-value
 	// TTL into the system with AddImmediateGCZoneConfig.


### PR DESCRIPTION
This commit deflakes the test by doing two things:

1. Delay the start of the test till after the zone config range feed has started already. This is used to avoid a race where we update `system.zones` before the full reconciliation of zone configs has started. The full reconciliation ignores dropped databases, and if we write to `system.zones` before that, our write might not be reconciled. By delaying the test until the zone config range feed starts, we ensure that the full reconciliation has finished, and the range feed is ready to stream our changes.

2. Relaxes the test expectation that only the first table gets purged first. This is because there there is a race between the splits and GC queue where range might get GCed before splitting. This is more likely to happen in this test since increase the GC queue scan rate.

Release note: None

Fixes: #138185