### PR TITLE
release-24.3: roachtest/mixedversion: `WaitForReplication` must ensure SQL is ready

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -2173,12 +2173,30 @@ func (c *clusterImpl) StartE(
 			return err
 		}
 	}
+	nodes := selectedNodesOrDefault(opts, c.CRDBNodes())
+	// N.B. If `SkipInit` is set, we don't wait for SQL since node(s) may not join the cluster in any definite time.
+	if !startOpts.RoachprodOpts.SkipInit {
+		// Wait for SQL to be ready on all nodes, for 'system' tenant, only.
+		for _, n := range nodes {
+			conn, err := c.ConnE(ctx, l, nodes[0], option.VirtualClusterName(install.SystemInterfaceName))
+			if err != nil {
+				return errors.Wrapf(err, "failed to connect to n%d", n)
+			}
+			defer conn.Close()
+
+			// N.B. We must ensure SQL session is fully initialized before attempting to execute any SQL commands.
+			if err := roachtestutil.WaitForSQLReady(ctx, conn); err != nil {
+				return errors.Wrap(err, "failed to wait for SQL to be ready")
+			}
+		}
+	}
 
 	if startOpts.WaitForReplicationFactor > 0 {
 		l.Printf("WaitForReplicationFactor: waiting for replication factor of at least %d", startOpts.WaitForReplicationFactor)
-		nodes := selectedNodesOrDefault(opts, c.All())
-
-		conn, err := c.ConnE(ctx, l, nodes[0])
+		// N.B. We must explicitly pass the virtual cluster name to `ConnE`, otherwise the default may turn out to be a
+		// secondary tenant, in which case we would only check the tenant's key range, not the whole system's.
+		// See "Unhidden Bug" in https://github.com/cockroachdb/cockroach/issues/137988
+		conn, err := c.ConnE(ctx, l, nodes[0], option.VirtualClusterName(install.SystemInterfaceName))
 		if err != nil {
 			return errors.Wrapf(err, "failed to connect to n%d", nodes[0])
 		}

--- a/pkg/cmd/roachtest/roachtestutil/utils.go
+++ b/pkg/cmd/roachtest/roachtestutil/utils.go
@@ -6,12 +6,15 @@
 package roachtestutil
 
 import (
+	"context"
+	gosql "database/sql"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/config"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
 	"github.com/cockroachdb/cockroach/pkg/util"
+	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 )
 
@@ -53,4 +56,18 @@ func Every(n time.Duration) EveryN {
 // ShouldLog returns whether it's been more than N time since the last event.
 func (e *EveryN) ShouldLog() bool {
 	return e.ShouldProcess(timeutil.Now())
+}
+
+// WaitForSQLReady waits until the corresponding node's SQL subsystem is fully initialized and ready
+// to serve SQL clients.
+// N.B. The fact that we have a live db connection doesn't imply that the SQL subsystem is ready to serve. E.g.,
+// a SQL session cannot be authenticated until after `SyntheticPrivilegeCache` is initialized, which is done
+// asynchronously at server startup.
+// (See "Root Cause" in https://github.com/cockroachdb/cockroach/issues/137988)
+func WaitForSQLReady(ctx context.Context, db *gosql.DB) error {
+	retryOpts := retry.Options{MaxRetries: 5}
+	return retryOpts.Do(ctx, func(ctx context.Context) error {
+		_, err := db.ExecContext(ctx, "SELECT 1")
+		return err
+	})
 }

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -36,6 +36,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/tests"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/config"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/vm"
 	"github.com/cockroachdb/cockroach/pkg/util/allstacks"
@@ -1502,7 +1503,8 @@ func (r *testRunner) postTestAssertions(
 		// the replica divergence check below will also fail.
 		if t.spec.SkipPostValidations&registry.PostValidationInvalidDescriptors == 0 {
 			func() {
-				db := c.Conn(ctx, t.L(), validationNode)
+				// NB: the invalid description checks should run at the system tenant level.
+				db := c.Conn(ctx, t.L(), validationNode, option.VirtualClusterName(install.SystemInterfaceName))
 				defer db.Close()
 				if err := roachtestutil.CheckInvalidDescriptors(ctx, db); err != nil {
 					postAssertionErr(errors.WithDetail(err, "invalid descriptors check failed"))
@@ -1514,7 +1516,7 @@ func (r *testRunner) postTestAssertions(
 		if t.spec.SkipPostValidations&registry.PostValidationReplicaDivergence == 0 {
 			func() {
 				// NB: the consistency checks should run at the system tenant level.
-				db := c.Conn(ctx, t.L(), validationNode, option.VirtualClusterName("system"))
+				db := c.Conn(ctx, t.L(), validationNode, option.VirtualClusterName(install.SystemInterfaceName))
 				defer db.Close()
 				if err := c.assertConsistentReplicas(ctx, db, t); err != nil {
 					postAssertionErr(errors.WithDetail(err, "consistency check failed"))


### PR DESCRIPTION
Backport 1/1 commits from #138109.

/cc @cockroachdb/release

---

Previously, mixedversion roachtests would occassionally fail while trying to execute SQL against a freshly started node; specifically, `get-user-session` would time out. The precise root cause is described in [1].

As of [2], `WaitForReplication` is the default used by all mixedversion roachtests. Thus, it suffices
to ensure that "SQL is ready" before
`WaitForReplication` is invoked.

However, a number of roachtests don't opt into
`StartOpts.WaitForReplication`, which makes them
susceptible to the same failure mode, e.g., [3].
Thus, we unconditionally `WaitForSQLReady`, for
the system tenant, on every started DB node.

[1] https://github.com/cockroachdb/cockroach/issues/137988
[2] https://github.com/cockroachdb/cockroach/pull/136607
[3] https://github.com/cockroachdb/cockroach/issues/137382

Fixes: https://github.com/cockroachdb/cockroach/issues/137988
Informs: https://github.com/cockroachdb/cockroach/issues/137332

Epic: none
Release note: None
Release Justification: test-only change
