### PR TITLE
pkg/cli: fix datadog profile upload URL

### DIFF
--- a/pkg/cli/zip_upload.go
+++ b/pkg/cli/zip_upload.go
@@ -85,7 +85,7 @@ const (
 	tableTag    = "table"
 
 	// datadog endpoint URLs
-	datadogProfileUploadURLTmpl = "https://intake.profile.%s/v1/input"
+	datadogProfileUploadURLTmpl = "https://intake.profile.%s/api/v2/profile"
 	datadogCreateArchiveURLTmpl = "https://api.%s/api/v2/logs/config/archives"
 	datadogLogIntakeURLTmpl     = "https://http-intake.logs.%s/api/v2/logs"
 
@@ -130,10 +130,7 @@ var debugZipUploadOpts = struct {
 
 // This is the list of all supported artifact types. The "possible values" part
 // in the help text is generated from this list. So, make sure to keep this updated
-// var zipArtifactTypes = []string{"profiles", "logs"}
-// TODO(arjunmahishi): Removing the profiles upload for now. It has started
-// failing for some reason. Will fix this later
-var zipArtifactTypes = []string{"logs", "tables", "misc"}
+var zipArtifactTypes = []string{"logs", "tables", "misc", "profiles"}
 
 // uploadZipArtifactFuncs is a registry of handler functions for each artifact type.
 // While adding/removing functions from here, make sure to update
@@ -335,7 +332,9 @@ func uploadZipProfiles(ctx context.Context, uploadID string, debugDirPath string
 
 		fmt.Fprintf(os.Stderr, "Uploaded profiles of node %s to datadog (%s)\n", nodeID, strings.Join(paths, ", "))
 		fmt.Fprintf(os.Stderr, "Explore the profiles on datadog: "+
-			"https://{{ datadog domain }}/profiling/explorer?query=%s:%s\n", uploadIDTag, uploadID)
+			"https://%s/profiling/explorer?query=%s:%s\n", ddSiteToHostMap[debugZipUploadOpts.ddSite],
+			uploadIDTag, uploadID,
+		)
 	}
 
 	return nil

--- a/pkg/cli/zip_upload_test.go
+++ b/pkg/cli/zip_upload_test.go
@@ -147,7 +147,7 @@ func TestUploadZipEndToEnd(t *testing.T) {
 			defer req.Body.Close()
 
 			switch req.URL.Path {
-			case "/v1/input":
+			case "/api/v2/profile":
 				return uploadProfileHook(t, req)
 			case "/api/v2/logs/config/archives":
 				return setupDDArchiveHook(t, req)


### PR DESCRIPTION
The profile upload flow in the `zip upload` command had stopped working when we moved to the US5 datadog. It turns out that the US5 datadog has a different API URL for profile upload. This commit fixes that URL.

Part of: CC-29713
Epic: None
Release note: None

---

**CLI output**

![image](https://github.com/user-attachments/assets/00935a98-924c-4215-add1-76beb62d5863)

**Datadog**

![image](https://github.com/user-attachments/assets/222fe32f-f4a1-4940-89ab-6d3ae954ded9)