### PR TITLE
release-24.3: roachtest/mixedversion: upgrade plan should be bounded

### DIFF
--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/mixedversion.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/mixedversion.go
@@ -69,6 +69,7 @@ package mixedversion
 import (
 	"context"
 	"fmt"
+	"math"
 	"math/rand"
 	"os"
 	"path/filepath"
@@ -150,6 +151,9 @@ const (
 	// 	- MVT_UPGRADE_PATH=24.1.5,24.2.0,current
 	// 	- MVT_UPGRADE_PATH=24.1,24.2,current
 	upgradePathOverrideEnv = "MVT_UPGRADE_PATH"
+
+	// Dump the test plan and return, i.e., skipping the actual execution of the test.
+	dryRunEnv = "MVT_DRY_RUN"
 )
 
 var (
@@ -318,6 +322,7 @@ type (
 	testOptions struct {
 		useFixturesProbability         float64
 		upgradeTimeout                 time.Duration
+		maxNumPlanSteps                int
 		minUpgrades                    int
 		maxUpgrades                    int
 		minimumSupportedVersion        *clusterupgrade.Version
@@ -404,6 +409,14 @@ func AlwaysUseFixtures(opts *testOptions) {
 func UpgradeTimeout(timeout time.Duration) CustomOption {
 	return func(opts *testOptions) {
 		opts.upgradeTimeout = timeout
+	}
+}
+
+// MaxNumPlanSteps allows callers to set a maximum number of steps to
+// be performed during a test run.
+func MaxNumPlanSteps(n int) CustomOption {
+	return func(opts *testOptions) {
+		opts.maxNumPlanSteps = n
 	}
 }
 
@@ -512,8 +525,11 @@ func defaultTestOptions() testOptions {
 	return testOptions{
 		// We use fixtures more often than not as they are more likely to
 		// detect bugs, especially in migrations.
-		useFixturesProbability:  0.7,
-		upgradeTimeout:          clusterupgrade.DefaultUpgradeTimeout,
+		useFixturesProbability: 0.7,
+		upgradeTimeout:         clusterupgrade.DefaultUpgradeTimeout,
+		// N.B. The default is unlimited since a priori we don't know anything
+		// about the test plan.
+		maxNumPlanSteps:         math.MaxInt,
 		minUpgrades:             1,
 		maxUpgrades:             4,
 		minimumSupportedVersion: OldestSupportedVersion,
@@ -752,6 +768,11 @@ func (t *Test) Run() {
 
 	t.logger.Printf("mixed-version test:\n%s", plan.PrettyPrint())
 
+	if override := os.Getenv(dryRunEnv); override != "" {
+		t.logger.Printf("skipping test run in dry-run mode")
+		return
+	}
+
 	// Mark the deployment mode and versions, so they show up in the github issue. This makes
 	// it easier to group failures together without having to dig into the test logs.
 	t.rt.AddParam("mvtDeploymentMode", string(plan.deploymentMode))
@@ -777,43 +798,58 @@ func (t *Test) plan() (plan *TestPlan, retErr error) {
 			)
 		}
 	}()
+	var retries int
+	// In case the length of the test plan exceeds `opts.maxNumPlanSteps`, retry up to 100 times.
+	// N.B. Statistically, the expected number of retries is miniscule; see #138014 for more info.
+	for ; retries < 100; retries++ {
 
-	// Pick a random deployment mode to use in this test run among the
-	// list of enabled deployment modes enabled for this test.
-	deploymentMode := t.deploymentMode()
-	t.updateOptionsForDeploymentMode(deploymentMode)
+		// Pick a random deployment mode to use in this test run among the
+		// list of enabled deployment modes enabled for this test.
+		deploymentMode := t.deploymentMode()
+		t.updateOptionsForDeploymentMode(deploymentMode)
 
-	upgradePath, err := t.choosePreviousReleases()
-	if err != nil {
-		return nil, err
-	}
-	upgradePath = append(upgradePath, clusterupgrade.CurrentVersion())
-
-	if override := os.Getenv(upgradePathOverrideEnv); override != "" {
-		upgradePath, err = parseUpgradePathOverride(override)
+		upgradePath, err := t.choosePreviousReleases()
 		if err != nil {
 			return nil, err
 		}
-		t.logger.Printf("%s override set: %s", upgradePathOverrideEnv, upgradePath)
+		upgradePath = append(upgradePath, clusterupgrade.CurrentVersion())
+
+		if override := os.Getenv(upgradePathOverrideEnv); override != "" {
+			upgradePath, err = parseUpgradePathOverride(override)
+			if err != nil {
+				return nil, err
+			}
+			t.logger.Printf("%s override set: %s", upgradePathOverrideEnv, upgradePath)
+		}
+
+		tenantDescriptor := t.tenantDescriptor(deploymentMode)
+		initialRelease := upgradePath[0]
+
+		planner := testPlanner{
+			versions:       upgradePath,
+			deploymentMode: deploymentMode,
+			seed:           t.seed,
+			currentContext: newInitialContext(initialRelease, t.crdbNodes, tenantDescriptor),
+			options:        t.options,
+			rt:             t.rt,
+			isLocal:        t.isLocal(),
+			hooks:          t.hooks,
+			prng:           t.prng,
+			bgChans:        t.bgChans,
+		}
+		// Let's generate a plan.
+		plan = planner.Plan()
+		if plan.length <= t.options.maxNumPlanSteps {
+			break
+		}
 	}
-
-	tenantDescriptor := t.tenantDescriptor(deploymentMode)
-	initialRelease := upgradePath[0]
-
-	planner := testPlanner{
-		versions:       upgradePath,
-		deploymentMode: deploymentMode,
-		seed:           t.seed,
-		currentContext: newInitialContext(initialRelease, t.crdbNodes, tenantDescriptor),
-		options:        t.options,
-		rt:             t.rt,
-		isLocal:        t.isLocal(),
-		hooks:          t.hooks,
-		prng:           t.prng,
-		bgChans:        t.bgChans,
+	if plan.length > t.options.maxNumPlanSteps {
+		return nil, errors.Newf("unable to generate a test plan with at most %d steps", t.options.maxNumPlanSteps)
 	}
-
-	return planner.Plan(), nil
+	if retries > 0 {
+		t.logger.Printf("WARNING: generated a smaller (%d) test plan after %d retries", plan.length, retries)
+	}
+	return plan, nil
 }
 
 func (t *Test) clusterArch() vm.CPUArch {

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/planner_test.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/planner_test.go
@@ -52,6 +52,8 @@ var (
 const seed = 12345 // expectations are based on this seed
 
 func TestTestPlanner(t *testing.T) {
+	// N.B. we must restore default versions since other tests may depend on it.
+	defer setDefaultVersions()
 	// Make some test-only mutators available to the test.
 	mutatorsAvailable := append([]mutator{
 		concurrentUserHooksMutator{},
@@ -294,6 +296,53 @@ func Test_upgradeTimeout(t *testing.T) {
 
 	assertTimeout(10 * time.Minute)                               // using default settings, the default timeout applies
 	assertTimeout(30*time.Minute, UpgradeTimeout(30*time.Minute)) // custom timeout applies.
+}
+
+// Test_maxNumPlanSteps tests the behaviour of plan generation in
+// mixedversion tests. If no custom value is passed, the default
+// should yield a (valid) test plan. Otherwise, the length of a test plan
+// should be <= `maxNumPlanSteps`. If maxNumPlanSteps is too low, an error
+// should be returned.
+func Test_maxNumPlanSteps(t *testing.T) {
+	mvt := newBasicUpgradeTest()
+	plan, err := mvt.plan()
+	require.NoError(t, err)
+	// N.B. the upper bound is very conservative; largest "basic upgrade" plan is well below it.
+	require.LessOrEqual(t, plan.length, 100)
+
+	mvt = newBasicUpgradeTest(MaxNumPlanSteps(15))
+	plan, err = mvt.plan()
+	require.NoError(t, err)
+	require.LessOrEqual(t, plan.length, 15)
+
+	// There is in fact no "basic upgrade" test plan with fewer than 15 steps.
+	// The smallest plan is,
+	//planner_test.go:314: Seed:               12345
+	//Upgrades:           v24.1.1 → <current>
+	//Deployment mode:    system-only
+	//Mutators:           preserve_downgrade_option_randomizer
+	//Plan:
+	//	├── install fixtures for version "v24.1.1" (1)
+	//	├── start cluster at version "v24.1.1" (2)
+	//	├── wait for all nodes (:1-4) to acknowledge cluster version '24.1' on system tenant (3)
+	//	└── upgrade cluster from "v24.1.1" to "<current>"
+	//	├── prevent auto-upgrades on system tenant by setting `preserve_downgrade_option` (4)
+	//	├── upgrade nodes :1-4 from "v24.1.1" to "<current>"
+	//	│   ├── restart node 3 with binary version <current> (5)
+	//	│   ├── run "mixed-version 1" (6)
+	//	│   ├── restart node 2 with binary version <current> (7)
+	//	│   ├── run "on startup 1" (8)
+	//	│   ├── restart node 1 with binary version <current> (9)
+	//	│   ├── allow upgrade to happen on system tenant by resetting `preserve_downgrade_option` (10)
+	//	│   ├── run "mixed-version 2" (11)
+	//	│   └── restart node 4 with binary version <current> (12)
+	//	├── run "mixed-version 2" (13)
+	//	├── wait for all nodes (:1-4) to acknowledge cluster version <current> on system tenant (14)
+	//	└── run "after finalization" (15)
+	mvt = newBasicUpgradeTest(MaxNumPlanSteps(5))
+	plan, err = mvt.plan()
+	require.ErrorContains(t, err, "unable to generate a test plan")
+	require.Nil(t, plan)
 }
 
 // setDefaultVersions overrides the test's view of the current build

--- a/pkg/cmd/roachtest/tests/mixed_version_cdc.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_cdc.go
@@ -501,9 +501,9 @@ func runCDCMixedVersions(ctx context.Context, t test.Test, c cluster.Cluster) {
 		// 23.1. That mistake was then fixed (#110676) but, to simplify
 		// this test, we only create changefeeds in more recent versions.
 		mixedversion.MinimumSupportedVersion("v23.2.0"),
-		// We limit the number of upgrades to be performed in the test run because
-		// the test takes a significant amount of time to complete.
-		mixedversion.MaxUpgrades(3),
+		// We limit the total number of plan steps to 80, which is roughly 60% of all plan lengths.
+		// See https://github.com/cockroachdb/cockroach/pull/137963#discussion_r1906256740 for more details.
+		mixedversion.MaxNumPlanSteps(80),
 	)
 
 	cleanupKafka := tester.StartKafka(t, c)

--- a/pkg/cmd/roachtest/tests/tpcc.go
+++ b/pkg/cmd/roachtest/tests/tpcc.go
@@ -429,7 +429,9 @@ func runTPCCMixedHeadroom(ctx context.Context, t test.Test, c cluster.Cluster) {
 		// the `workload fixtures import` command, which is only supported
 		// reliably multi-tenant mode starting from that version.
 		mixedversion.MinimumSupportedVersion("v23.2.0"),
-		mixedversion.MaxUpgrades(3),
+		// We limit the total number of plan steps to 70, which is roughly 80% of all plan lengths.
+		// See #138014 for more details.
+		mixedversion.MaxNumPlanSteps(70),
 	)
 
 	tenantFeaturesEnabled := make(chan struct{})


### PR DESCRIPTION
Backport 1/1 commits from #137963.

/cc @cockroachdb/release

---

Previously, the mixedversion framework did not bound
the total number of steps in a test plan. Since steps
are generated according to different pseudo-random
distributions, the total number of resulting steps
can vary significantly.
E.g., for `tpcc/mixed-headroom/n5cpu16`, the smallest
test plan has 14 steps, whereas the largest, based
on a sampling of 1_000_000 valid test plans, has
135 steps!

High variability in the size of the test plan
is directly proportional to the running time.
Thus, a very large test plan can cause a test
to time out, due to exceeding its max running time.
That is the case for `tpcc/mixed-headroom/n5cpu16`.

This PR adds an option, namely `MaxNumPlanSteps`,
which enforces an upper bound. If a generated
test plan exceeds the specified value, a new
one is generated until the resulting length
is within the specification.

This PR also adds a primitive `dry-run` mode,
which can be useful for debugging test plans.
If `MVT_DRY_RUN_MODE` env. var. is set, print
the mixedversion test plan and exit.

Resolves: https://github.com/cockroachdb/cockroach/issues/138014
Informs: https://github.com/cockroachdb/cockroach/issues/137332
Epic: none
Release note: None
Release Justification: test-only change
Resolves: https://github.com/cockroachdb/cockroach/issues/140059
