### PR TITLE
docgen: add DO statement diagram

### DIFF
--- a/docs/generated/sql/bnf/BUILD.bazel
+++ b/docs/generated/sql/bnf/BUILD.bazel
@@ -122,7 +122,7 @@ FILES = [
     "default_value_column_level",
     "delete_stmt",
     "discard_stmt",
-    "do_stmt",
+    "do",
     "drop_column",
     "drop_constraint",
     "drop_database",

--- a/docs/generated/sql/bnf/do.bnf
+++ b/docs/generated/sql/bnf/do.bnf
@@ -1,0 +1,3 @@
+do_stmt ::=
+	'DO'  ( ( (  | 'LANGUAGE' ( 'PLPGSQL' ) routine_body_str ) ) )*
+	| 'DO' 'LANGUAGE' ( 'PLPGSQL' ) routine_body_str ( ( (  | 'LANGUAGE' ( 'PLPGSQL' ) routine_body_str ) ) )*

--- a/docs/generated/sql/bnf/do_stmt.bnf
+++ b/docs/generated/sql/bnf/do_stmt.bnf
@@ -1,2 +1,0 @@
-do_stmt ::=
-	'DO' do_stmt_opt_list

--- a/pkg/cmd/docgen/diagrams.go
+++ b/pkg/cmd/docgen/diagrams.go
@@ -665,6 +665,16 @@ var specs = []stmtSpec{
 		inline: []string{"col_qual_list"},
 	},
 	{
+		name:   "do",
+		stmt:   "do_stmt",
+		inline: []string{"do_stmt_opt_list", "do_stmt_opt_item"},
+		replace: map[string]string{
+			"'SCONST'":                    "",
+			"non_reserved_word_or_sconst": "( 'PLPGSQL' ) routine_body_str",
+		},
+		unlink: []string{"routine_body_str"},
+	},
+	{
 		name:   "for_locking",
 		stmt:   "for_locking_item",
 		inline: []string{"for_locking_strength", "opt_locked_rels", "opt_nowait_or_skip"},

--- a/pkg/gen/bnf.bzl
+++ b/pkg/gen/bnf.bzl
@@ -122,7 +122,7 @@ BNF_SRCS = [
     "//docs/generated/sql/bnf:default_value_column_level.bnf",
     "//docs/generated/sql/bnf:delete_stmt.bnf",
     "//docs/generated/sql/bnf:discard_stmt.bnf",
-    "//docs/generated/sql/bnf:do_stmt.bnf",
+    "//docs/generated/sql/bnf:do.bnf",
     "//docs/generated/sql/bnf:drop_column.bnf",
     "//docs/generated/sql/bnf:drop_constraint.bnf",
     "//docs/generated/sql/bnf:drop_database.bnf",

--- a/pkg/gen/docs.bzl
+++ b/pkg/gen/docs.bzl
@@ -135,7 +135,7 @@ DOCS_SRCS = [
     "//docs/generated/sql/bnf:default_value_column_level.bnf",
     "//docs/generated/sql/bnf:delete_stmt.bnf",
     "//docs/generated/sql/bnf:discard_stmt.bnf",
-    "//docs/generated/sql/bnf:do_stmt.bnf",
+    "//docs/generated/sql/bnf:do.bnf",
     "//docs/generated/sql/bnf:drop_column.bnf",
     "//docs/generated/sql/bnf:drop_constraint.bnf",
     "//docs/generated/sql/bnf:drop_database.bnf",


### PR DESCRIPTION
Added a SQL statement diagram for `DO`. The diagram looks like this:

<img width="519" alt="image" src="https://github.com/user-attachments/assets/30feb56a-2085-4fa6-800c-d7920ec4fe49" />

This is necessary for the accompanying docs PR: https://github.com/cockroachdb/docs/pull/19356

Epic: none
Release note: none
Release justification: non-production code change