### PR TITLE
roachtest: metamorphically enable buffered sender

### DIFF
--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -930,6 +930,21 @@ func (r *testRunner) runWorker(
 					t.Fatalf("unknown lease type %s", leases)
 				}
 
+				// 50% chance of enabling the rangefeed buffered sender. Disabled by
+				// default. This is the reason we check for run time assertions rather
+				// than using rand:
+				// 1. The cluster setting RangefeedUseBufferedSender validation will fail
+				// if buildutil.CrdbTestBuild tag is not set.
+				// 2. There is a 50% chance that the cockraoch binary used in roachtests
+				// includes the buildutil.CrdbTestBuild tag. And runtime assertion is
+				// enabled if and only if cockroach binaries used in roachtests include
+				// the buildutil.CrdbTestBuild tag.
+				useBufferedSender := roachtestutil.UsingRuntimeAssertions(t)
+				if useBufferedSender {
+					c.clusterSettings["kv.rangefeed.buffered_sender.enabled"] = "true"
+				}
+				c.status(fmt.Sprintf("metamorphically using buffered sender: %t", useBufferedSender))
+				t.AddParam("metamorphicBufferedSender", fmt.Sprint(useBufferedSender))
 				c.goCoverDir = t.GoCoverArtifactsDir()
 				wStatus.SetTest(t, testToRun)
 				wStatus.SetStatus("running test")


### PR DESCRIPTION
To increase test coverage of rangefeed buffered sender, this patch changes
roachtests to metamorphically enable `kv.rangefeed.buffered_sender.enabled` 
50% of the time.

Epic: none
Release note: none