### PR TITLE
sql: disable buffered writes before DDL

### DIFF
--- a/pkg/kv/kvclient/kvcoord/txn_coord_sender.go
+++ b/pkg/kv/kvclient/kvcoord/txn_coord_sender.go
@@ -1165,6 +1165,8 @@ func (tc *TxnCoordSender) SetBufferedWritesEnabled(enabled bool) {
 		panic("cannot enable buffered writes on a running transaction")
 	}
 	tc.interceptorAlloc.txnWriteBuffer.enabled = enabled
+	// TODO(yuzefovich): flush the buffer when going from "enabled" to
+	// "disabled".
 }
 
 // BufferedWritesEnabled is part of the kv.TxnSender interface.

--- a/pkg/kv/sender.go
+++ b/pkg/kv/sender.go
@@ -129,9 +129,9 @@ type TxnSender interface {
 
 	// SetBufferedWritesEnabled toggles whether the writes are buffered on the
 	// gateway node until the commit time. Only allowed on the RootTxn. Buffered
-	// writes cannot be enabled on a txn that performed any requests.
-	// TODO(yuzefovich): should we flush the buffer when going from "enabled" to
-	// "disabled"?
+	// writes cannot be enabled on a txn that performed any requests. When
+	// disabling buffered writes, if there are any writes in the buffer, they
+	// are flushed.
 	SetBufferedWritesEnabled(bool)
 
 	// BufferedWritesEnabled returns whether the buffered writes are enabled.

--- a/pkg/sql/conn_executor_ddl.go
+++ b/pkg/sql/conn_executor_ddl.go
@@ -58,11 +58,14 @@ func (ex *connExecutor) maybeAutoCommitBeforeDDL(
 	return nil, nil
 }
 
-// maybeUpgradeToSerializable checks if the statement is a schema change, and
-// upgrades the transaction to serializable isolation if it is. If the
-// transaction contains multiple statements, and an upgrade was attempted, an
-// error is returned.
-func (ex *connExecutor) maybeUpgradeToSerializable(ctx context.Context, stmt Statement) error {
+// maybeAdjustTxnForDDL checks if the statement is a schema change and adjusts
+// the txn if it is. The following adjustments will be performed:
+// - upgrading to serializable isolation. If the txn contains multiple
+// statements, and an upgrade was attempted, an error is returned.
+// - disabling buffered writes.
+// TODO(#140695): we disable buffered writes out of caution. We should consider
+// allowing this in the future.
+func (ex *connExecutor) maybeAdjustTxnForDDL(ctx context.Context, stmt Statement) error {
 	p := &ex.planner
 	if tree.CanModifySchema(stmt.AST) {
 		if ex.state.mu.txn.IsoLevel().ToleratesWriteSkew() {
@@ -75,6 +78,10 @@ func (ex *connExecutor) maybeUpgradeToSerializable(ctx context.Context, stmt Sta
 			} else {
 				return txnSchemaChangeErr
 			}
+		}
+		if ex.state.mu.txn.BufferedWritesEnabled() {
+			ex.state.mu.txn.SetBufferedWritesEnabled(false /* enabled */)
+			p.BufferClientNotice(ctx, pgnotice.Newf("disabling buffered writes on the current txn due to schema change"))
 		}
 	}
 	return nil

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -2355,6 +2355,13 @@ func (ex *connExecutor) resetTransactionOnSchemaChangeRetry(ctx context.Context)
 	if omitInRangefeeds {
 		newTxn.SetOmitInRangefeeds()
 	}
+	if buildutil.CrdbTestBuild {
+		// For now, we explicitly disable buffered writes before executing DDLs.
+		// TODO(#140695): we should consider allowing this in the future.
+		if ex.state.mu.txn.BufferedWritesEnabled() {
+			return errors.AssertionFailedf("buffered writes should have been disabled on a DDL")
+		}
+	}
 	ex.state.mu.txn = newTxn
 	return nil
 }
@@ -3174,10 +3181,9 @@ var txnSchemaChangeErr = pgerror.Newf(
 func (ex *connExecutor) makeExecPlan(
 	ctx context.Context, planner *planner,
 ) (context.Context, error) {
-	if err := ex.maybeUpgradeToSerializable(ctx, planner.stmt); err != nil {
+	if err := ex.maybeAdjustTxnForDDL(ctx, planner.stmt); err != nil {
 		return ctx, err
 	}
-	// TODO(yuzefovich): consider disabling buffered writes on a DDL.
 
 	if err := planner.makeOptimizerPlan(ctx); err != nil {
 		log.VEventf(ctx, 1, "optimizer plan failed: %v", err)

--- a/pkg/sql/conn_executor_prepare.go
+++ b/pkg/sql/conn_executor_prepare.go
@@ -225,10 +225,9 @@ func (ex *connExecutor) prepare(
 			ex.resetPlanner(ctx, p, txn, ex.server.cfg.Clock.PhysicalTime())
 		}
 
-		if err := ex.maybeUpgradeToSerializable(ctx, stmt); err != nil {
+		if err := ex.maybeAdjustTxnForDDL(ctx, stmt); err != nil {
 			return err
 		}
-		// TODO(yuzefovich): consider disabling buffered writes on a DDL.
 
 		if placeholderHints == nil {
 			placeholderHints = make(tree.PlaceholderTypes, stmt.NumPlaceholders)

--- a/pkg/sql/pgwire/testdata/pgtest/read_committed
+++ b/pkg/sql/pgwire/testdata/pgtest/read_committed
@@ -29,7 +29,7 @@ Query {"String": "CREATE TABLE t1 (a int)"}
 until
 ReadyForQuery
 ----
-{"Severity":"NOTICE","SeverityUnlocalized":"NOTICE","Code":"00000","Message":"setting transaction isolation level to SERIALIZABLE due to schema change","Detail":"","Hint":"","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"conn_executor_ddl.go","Line":0,"Routine":"maybeUpgradeToSerializable","UnknownFields":null}
+{"Severity":"NOTICE","SeverityUnlocalized":"NOTICE","Code":"00000","Message":"setting transaction isolation level to SERIALIZABLE due to schema change","Detail":"","Hint":"","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"conn_executor_ddl.go","Line":0,"Routine":"maybeAdjustTxnForDDL","UnknownFields":null}
 {"Type":"CommandComplete","CommandTag":"CREATE TABLE"}
 {"Type":"ReadyForQuery","TxStatus":"I"}
 
@@ -43,7 +43,7 @@ Sync
 until
 ReadyForQuery
 ----
-{"Severity":"NOTICE","SeverityUnlocalized":"NOTICE","Code":"00000","Message":"setting transaction isolation level to SERIALIZABLE due to schema change","Detail":"","Hint":"","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"conn_executor_ddl.go","Line":0,"Routine":"maybeUpgradeToSerializable","UnknownFields":null}
+{"Severity":"NOTICE","SeverityUnlocalized":"NOTICE","Code":"00000","Message":"setting transaction isolation level to SERIALIZABLE due to schema change","Detail":"","Hint":"","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"conn_executor_ddl.go","Line":0,"Routine":"maybeAdjustTxnForDDL","UnknownFields":null}
 {"Type":"ParseComplete"}
 {"Type":"BindComplete"}
 {"Type":"CommandComplete","CommandTag":"CREATE TABLE"}
@@ -58,7 +58,7 @@ Query {"String": "CREATE TABLE t3 (a int); CREATE TABLE t4 (a int);"}
 until
 ReadyForQuery
 ----
-{"Severity":"NOTICE","SeverityUnlocalized":"NOTICE","Code":"00000","Message":"setting transaction isolation level to SERIALIZABLE due to schema change","Detail":"","Hint":"","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"conn_executor_ddl.go","Line":0,"Routine":"maybeUpgradeToSerializable","UnknownFields":null}
+{"Severity":"NOTICE","SeverityUnlocalized":"NOTICE","Code":"00000","Message":"setting transaction isolation level to SERIALIZABLE due to schema change","Detail":"","Hint":"","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"conn_executor_ddl.go","Line":0,"Routine":"maybeAdjustTxnForDDL","UnknownFields":null}
 {"Type":"CommandComplete","CommandTag":"CREATE TABLE"}
 {"Type":"CommandComplete","CommandTag":"CREATE TABLE"}
 {"Type":"ReadyForQuery","TxStatus":"I"}
@@ -76,7 +76,7 @@ Sync
 until
 ReadyForQuery
 ----
-{"Severity":"NOTICE","SeverityUnlocalized":"NOTICE","Code":"00000","Message":"setting transaction isolation level to SERIALIZABLE due to schema change","Detail":"","Hint":"","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"conn_executor_ddl.go","Line":0,"Routine":"maybeUpgradeToSerializable","UnknownFields":null}
+{"Severity":"NOTICE","SeverityUnlocalized":"NOTICE","Code":"00000","Message":"setting transaction isolation level to SERIALIZABLE due to schema change","Detail":"","Hint":"","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"conn_executor_ddl.go","Line":0,"Routine":"maybeAdjustTxnForDDL","UnknownFields":null}
 {"Type":"ParseComplete"}
 {"Type":"BindComplete"}
 {"Type":"CommandComplete","CommandTag":"CREATE TABLE"}


### PR DESCRIPTION
We want to do it out of caution during the initial rollout of the feature.

Epic: None
Release note: None