### PR TITLE
sql/catalog/lease: Skip TestLeaseRenewedPeriodically in race

### DIFF
--- a/pkg/sql/catalog/lease/lease_test.go
+++ b/pkg/sql/catalog/lease/lease_test.go
@@ -1894,6 +1894,8 @@ func TestLeaseRenewedPeriodically(testingT *testing.T) {
 	defer leaktest.AfterTest(testingT)()
 	defer log.Scope(testingT).Close(testingT)
 
+	skip.UnderRace(testingT)
+
 	ctx := context.Background()
 
 	var mu syncutil.Mutex


### PR DESCRIPTION
This test has been flaking more frequently when run in race. Skipping it for now.

Epic: none
Release note: none

Closes #140205
Closes https://github.com/cockroachdb/cockroach/issues/138924