### PR TITLE
server/storage_api: Deflake TestAdminDecommissionedOperations

### DIFF
--- a/pkg/server/storage_api/decommission_test.go
+++ b/pkg/server/storage_api/decommission_test.go
@@ -964,8 +964,10 @@ func TestAdminDecommissionedOperations(t *testing.T) {
 					// This will cause SuccessWithin to retry.
 					return err
 				}
-				require.Equal(t, tc.expectCode, s.Code(), "%+v", err)
-				return nil
+				if tc.expectCode == s.Code() {
+					return nil
+				}
+				return err
 			})
 		})
 	}


### PR DESCRIPTION
TestAdminDecommissionedOperations incorrectly used the SucceedsSoon helper. A flake in #139522 occurred within a SucceedsSoon block, where an error assertion was added instead of returning an error to trigger a retry. This change corrects the behavior.

Epic: None
Release note: None

Closes #139522