### PR TITLE
cluster-ui: remove periodic triggering of db metadata job

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/components/tableMetadataLastUpdated/tableMetadataJobControl.spec.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/components/tableMetadataLastUpdated/tableMetadataJobControl.spec.tsx
@@ -104,26 +104,6 @@ describe("TableMetadataJobControl", () => {
     expect(mockRefreshJobStatus).toHaveBeenCalled();
   });
 
-  it("schedules periodic updates", async () => {
-    jest.spyOn(global, "setInterval");
-
-    render(
-      <TimezoneContext.Provider value="UTC">
-        <TableMetadataJobControl onJobComplete={mockOnJobComplete} />
-      </TimezoneContext.Provider>,
-    );
-
-    expect(setInterval).toHaveBeenCalledWith(expect.any(Function), 10000);
-
-    await act(async () => {
-      jest.advanceTimersByTime(10000);
-    });
-
-    expect(api.triggerUpdateTableMetaJobApi).toHaveBeenCalledWith({
-      onlyIfStale: true,
-    });
-  });
-
   it("calls onJobComplete when lastCompletedTime changes", () => {
     const { rerender } = render(
       <TimezoneContext.Provider value="UTC">

--- a/pkg/ui/workspaces/cluster-ui/src/components/tableMetadataLastUpdated/tableMetadataJobControl.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/components/tableMetadataLastUpdated/tableMetadataJobControl.tsx
@@ -56,11 +56,6 @@ export const TableMetadataJobControl: React.FC<
 
   useEffect(() => {
     triggerUpdateTableMetaJob();
-    const nextUpdated = setInterval(() => {
-      triggerUpdateTableMetaJob();
-    }, 10000);
-
-    return () => clearTimeout(nextUpdated);
   }, [triggerUpdateTableMetaJob]);
 
   useEffect(() => {


### PR DESCRIPTION
Previously, the Databases page would periodically attempt to trigger the update job in the background while the page was open. This was implemented in order to generate the freshest data possible given the constraints of the "max staleness" that's permitted via the cluster setting.

However, every check whether the data is stale requires executing a SQL query. Doing this every 10 seconds is unnecessary. Additionally, since this code uses `fetch` directly it did not contain logic to deal with 4xx errors to redirect to login or stop the requests in `setInterval`.

In this commit, I've decided instead of expanding the logic and writing more code to deal with additional scenarios, unregister the periodic call on the frontend, etc. I will favor maintaining less code with simpler logic. The periodic request is removed.

At the time the databases page is loaded, one attempt is made to recompute data if it's stale. Otherwise we do not recompute unless the customer requests.

Fixes: CLOUDOPS-12497

Release note (ui change): The databases metadata page updates data less eagerly while the page is open. If data is older than the staleness encoded in the `obs.tablemetadata.data_valid_duration` cluster setting we will recompute at the time the page is opened but not afterwards. Customers are encouraged to use the refresh button that is available to request that metadata be recomputed if necessary.