### PR TITLE
kvclient: serve point read-your-own-writes from the buffer

### DIFF
--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_write_buffer_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_write_buffer_test.go
@@ -465,3 +465,195 @@ func TestTxnWriteBufferCorrectlyAdjustsErrorsAfterBuffering(t *testing.T) {
 		require.NotNil(t, br)
 	}
 }
+
+// TestTxnWriteBufferServesPointReadsLocally ensures that point reads hoping to
+// do read-your-own-writes are correctly served from the buffer.
+func TestTxnWriteBufferServesPointReadsLocally(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+	twb, mockSender := makeMockTxnWriteBuffer()
+
+	putAtSeq := func(key roachpb.Key, val string, seq enginepb.TxnSeq) {
+		txn := makeTxnProto()
+		txn.Sequence = seq
+		ba := &kvpb.BatchRequest{}
+		ba.Header = kvpb.Header{Txn: &txn}
+		put := putArgs(key, val, seq)
+		ba.Add(put)
+
+		numCalled := mockSender.NumCalled()
+		br, pErr := twb.SendLocked(ctx, ba)
+		require.Nil(t, pErr)
+		require.NotNil(t, br)
+		require.Equal(t, numCalled, mockSender.NumCalled())
+	}
+
+	txn := makeTxnProto()
+	txn.Sequence = 10
+	keyA, keyB, keyC := roachpb.Key("a"), roachpb.Key("b"), roachpb.Key("c")
+
+	const valA10 = "valA10"
+	const valA12 = "valA12"
+	const valA14 = "valA14"
+
+	// Blindly write to keys A and B. Leave C as is.
+	ba := &kvpb.BatchRequest{}
+	ba.Header = kvpb.Header{Txn: &txn}
+	putA := putArgs(keyA, valA10, txn.Sequence)
+	delB := delArgs(keyB, txn.Sequence)
+	ba.Add(putA, delB)
+
+	numCalled := mockSender.NumCalled()
+	br, pErr := twb.SendLocked(ctx, ba)
+	require.Nil(t, pErr)
+	require.NotNil(t, br)
+	// All the requests should be buffered and not make it past the
+	// txnWriteBuffer.
+	require.Equal(t, numCalled, mockSender.NumCalled())
+	// Even though the txnWriteBuffer did not send any Put requests to the KV
+	// layer above, the responses should still be populated.
+	require.Len(t, br.Responses, 2)
+	require.Equal(t, br.Responses[0].GetInner(), &kvpb.PutResponse{})
+	require.Equal(t, br.Responses[1].GetInner(), &kvpb.DeleteResponse{})
+
+	// Verify the writes were buffered correctly.
+	expBufferedWrites := []bufferedWrite{
+		makeBufferedWrite(keyA, makeBufferedValue("valA10", 10)),
+		makeBufferedWrite(keyB, makeBufferedValue("", 10)),
+	}
+	require.Equal(t, expBufferedWrites, twb.testingBufferedWritesAsSlice())
+
+	// Add a few more blind writes to keyA at different sequence numbers.
+	putAtSeq(keyA, valA12, 12)
+	putAtSeq(keyA, valA14, 14)
+
+	// Verify the buffer is what we expect.
+	expBufferedWrites = []bufferedWrite{
+		makeBufferedWrite(keyA,
+			makeBufferedValue(valA10, 10),
+			makeBufferedValue(valA12, 12),
+			makeBufferedValue(valA14, 14),
+		),
+		makeBufferedWrite(keyB, makeBufferedValue("", 10)),
+	}
+	require.Equal(t, expBufferedWrites, twb.testingBufferedWritesAsSlice())
+
+	// First up, perform reads on key A at various sequence numbers and ensure the
+	// correct value is served from the buffer.
+	for seq, expVal := range map[enginepb.TxnSeq]string{
+		10: valA10, 11: valA10, 12: valA12, 13: valA12, 14: valA14, 15: valA14,
+	} {
+		ba = &kvpb.BatchRequest{}
+		txn.Sequence = seq
+		ba.Header = kvpb.Header{Txn: &txn}
+		getA := &kvpb.GetRequest{RequestHeader: kvpb.RequestHeader{Key: keyA, Sequence: txn.Sequence}}
+		ba.Add(getA)
+
+		numCalled = mockSender.NumCalled()
+		br, pErr = twb.SendLocked(ctx, ba)
+		require.Nil(t, pErr)
+		require.NotNil(t, br)
+		require.Len(t, br.Responses, 1)
+		require.Equal(t, roachpb.MakeValueFromString(expVal), *br.Responses[0].GetInner().(*kvpb.GetResponse).Value)
+		// Should be served entirely from the buffer, and nothing should be sent to
+		// the KV layer.
+		require.Equal(t, numCalled, mockSender.NumCalled())
+	}
+
+	// Next, perform a read on keyB using a sequence number that should see the
+	// delete. Ensure it's served from the buffer.
+	txn.Sequence = 10
+	ba = &kvpb.BatchRequest{}
+	ba.Header = kvpb.Header{Txn: &txn}
+	getB := &kvpb.GetRequest{RequestHeader: kvpb.RequestHeader{Key: keyB, Sequence: txn.Sequence}}
+	ba.Add(getB)
+
+	numCalled = mockSender.NumCalled()
+	br, pErr = twb.SendLocked(ctx, ba)
+	require.Nil(t, pErr)
+	require.NotNil(t, br)
+	require.Len(t, br.Responses, 1)
+	require.False(t, br.Responses[0].GetInner().(*kvpb.GetResponse).Value.IsPresent())
+	// Should be served entirely from the buffer, and nothing should be sent to
+	// the KV layer.
+	require.Equal(t, numCalled, mockSender.NumCalled())
+
+	// Perform a read on keyC. This should be sent to the KV layer, as no write
+	// for this key has been buffered.
+	ba = &kvpb.BatchRequest{}
+	getC := &kvpb.GetRequest{RequestHeader: kvpb.RequestHeader{Key: keyC}}
+	ba.Add(getC)
+
+	numCalled = mockSender.NumCalled()
+	mockSender.MockSend(func(ba *kvpb.BatchRequest) (*kvpb.BatchResponse, *kvpb.Error) {
+		require.Len(t, ba.Requests, 1)
+		require.IsType(t, &kvpb.GetRequest{}, ba.Requests[0].GetInner())
+
+		br = ba.CreateReply()
+		br.Txn = ba.Txn
+		return br, nil
+	})
+
+	br, pErr = twb.SendLocked(ctx, ba)
+	require.Nil(t, pErr)
+	require.NotNil(t, br)
+	require.Len(t, br.Responses, 1)
+	// Sanity check that the request did go to the KV layer.
+	require.Equal(t, mockSender.NumCalled(), numCalled+1)
+
+	// Finally, perform a read on keyA and keyB at a lower sequence number than
+	// the minimum buffered write. This should be served from the KV layer.
+	txn.Sequence = 9
+	ba = &kvpb.BatchRequest{}
+	ba.Header = kvpb.Header{Txn: &txn}
+	getA := &kvpb.GetRequest{RequestHeader: kvpb.RequestHeader{Key: keyA, Sequence: txn.Sequence}}
+	getB = &kvpb.GetRequest{RequestHeader: kvpb.RequestHeader{Key: keyB, Sequence: txn.Sequence}}
+	ba.Add(getA)
+	ba.Add(getB)
+
+	numCalled = mockSender.NumCalled()
+	mockSender.MockSend(func(ba *kvpb.BatchRequest) (*kvpb.BatchResponse, *kvpb.Error) {
+		require.Len(t, ba.Requests, 2)
+		require.IsType(t, &kvpb.GetRequest{}, ba.Requests[0].GetInner())
+		require.IsType(t, &kvpb.GetRequest{}, ba.Requests[1].GetInner())
+
+		br = ba.CreateReply()
+		br.Txn = ba.Txn
+		return br, nil
+	})
+	br, pErr = twb.SendLocked(ctx, ba)
+	require.Nil(t, pErr)
+	require.NotNil(t, br)
+	require.Len(t, br.Responses, 2)
+	// Assert that the request was sent to the KV layer.
+	require.Equal(t, mockSender.NumCalled(), numCalled+1)
+
+	// Lastly, for completeness, commit the transaction and ensure that the buffer
+	// is correctly flushed.
+	ba = &kvpb.BatchRequest{}
+	ba.Header = kvpb.Header{Txn: &txn}
+	ba.Add(&kvpb.EndTxnRequest{Commit: true})
+
+	mockSender.MockSend(func(ba *kvpb.BatchRequest) (*kvpb.BatchResponse, *kvpb.Error) {
+		require.Len(t, ba.Requests, 3)
+
+		// We now expect the buffer to be flushed along with the commit.
+		require.IsType(t, &kvpb.PutRequest{}, ba.Requests[0].GetInner())
+		require.IsType(t, &kvpb.DeleteRequest{}, ba.Requests[1].GetInner())
+		require.IsType(t, &kvpb.EndTxnRequest{}, ba.Requests[2].GetInner())
+
+		br = ba.CreateReply()
+		br.Txn = ba.Txn
+		return br, nil
+	})
+
+	br, pErr = twb.SendLocked(ctx, ba)
+	require.Nil(t, pErr)
+	require.NotNil(t, br)
+
+	// Even though we flushed the buffer, responses from the blind writes should
+	// not be returned.
+	require.Len(t, br.Responses, 1)
+	require.IsType(t, &kvpb.EndTxnResponse{}, br.Responses[0].GetInner())
+}

--- a/pkg/kv/kvclient/kvcoord/txn_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_test.go
@@ -1537,13 +1537,21 @@ func TestTxnBasicBufferedWrites(t *testing.T) {
 	defer s.Stop()
 
 	testutils.RunTrueAndFalse(t, "commit", func(t *testing.T, commit bool) {
+		ctx := context.Background()
+
 		value1 := []byte("value1")
 		value2 := []byte("value2")
+		value3 := []byte("value3")
 
 		keyA := []byte("keyA")
 		keyB := []byte("keyB")
+		keyC := []byte("keyC")
 
-		ctx := context.Background()
+		// Before the test begins, write a value to keyC. We'll delete it below.
+		txn := kv.NewTxn(ctx, s.DB, 0 /* gatewayNodeID */)
+		require.NoError(t, txn.Put(ctx, keyC, value3))
+		require.NoError(t, txn.Commit(ctx))
+
 		err := s.DB.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
 			txn.SetBufferedWritesEnabled(true)
 
@@ -1564,17 +1572,9 @@ func TestTxnBasicBufferedWrites(t *testing.T) {
 			// Read within the transaction.
 			if gr, err := txn.Get(ctx, keyA); err != nil {
 				return err
-			} else if gr.Exists() {
-				// TODO(arul): this isn't correct yet because we're not serving
-				// read-your-own-writes from the buffer.
-				return errors.Errorf("expected nil value; got %v", gr.Value)
+			} else if !gr.Exists() || !bytes.Equal(gr.ValueBytes(), value1) {
+				return errors.Errorf("expected value %q; got %q", value1, gr.Value)
 			}
-
-			// TODO(arul): we should be able to uncomment this once
-			// https://github.com/cockroachdb/cockroach/issues/139054 is addressed.
-			// else if !gr.Exists() || !bytes.Equal(gr.ValueBytes(), value) {
-			//	return errors.Errorf("expected value %q; got %q", value, gr.Value)
-			//}
 
 			// Write to keyB two times. Only the last write should be visible once the
 			// transaction commits.
@@ -1583,6 +1583,16 @@ func TestTxnBasicBufferedWrites(t *testing.T) {
 			}
 			if err := txn.Put(ctx, keyB, value2); err != nil {
 				return err
+			}
+
+			// Delete keyC before attempting to read it.
+			if _, err := txn.Del(ctx, keyC); err != nil {
+				return err
+			}
+			if gr, err := txn.Get(ctx, keyC); err != nil {
+				return err
+			} else if gr.Exists() {
+				return errors.Errorf("expected nil value for the deleted key; got %v", gr.Value)
 			}
 
 			if commit {
@@ -1618,6 +1628,16 @@ func TestTxnBasicBufferedWrites(t *testing.T) {
 			require.Equal(t, value2, gr.ValueBytes()) // value2 is the final value
 		} else {
 			require.False(t, gr.Exists())
+		}
+
+		// keyC was deleted.
+		gr, err = s.DB.Get(ctx, keyC)
+		require.NoError(t, err)
+		if commit {
+			require.False(t, gr.Exists())
+		} else {
+			require.True(t, gr.Exists())
+			require.Equal(t, value3, gr.ValueBytes())
 		}
 	})
 }


### PR DESCRIPTION
This patch teaches the txnWriteBuffer to recognize when a point-read (i.e. a Get request) should be served from its local buffer. In such cases, we eschew sending the request to the KV layer, and instead stitch the result back on the response path.

The approach above is fairly straightforward. The only thing we must take care of is ensuring the correct value is returned based on the Get request's sequence number. The logic here mirrors that of `getOne` in `pebble_mvcc_scanner.go`. It's a bit simpler, as we don't have to account for sequence number rollbacks here. Unlike on the server, we'll proactively rollback writes belonging to sequence numbers that have been ignored as part of a savepoint rollback. As a result, we can be sure that any writes in the buffer aren't rolled back.

In a followup patch, we'll add support for Scan/Reverse requests that overlap with a part of the butffer.

Informs https://github.com/cockroachdb/cockroach/issues/139054

Release note: None