### PR TITLE
roachtest/mixedversion: TestTestPlanner should restore default version

### DIFF
--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/planner_test.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/planner_test.go
@@ -52,6 +52,8 @@ var (
 const seed = 12345 // expectations are based on this seed
 
 func TestTestPlanner(t *testing.T) {
+	// N.B. we must restore default versions since other tests may depend on it.
+	defer setDefaultVersions()
 	// Make some test-only mutators available to the test.
 	mutatorsAvailable := append([]mutator{
 		concurrentUserHooksMutator{},


### PR DESCRIPTION
We saw that `Test_maxNumPlanSteps` suddenly failed in an otherwise unrelated backport [1]. The reason turned out to be non-determinisim. That is, a different
unit test, namely `TestTestPlanner` did not
restore the default version (`clusterupgrade.TestBuildVersion`).

This change forwardports the missing restore to
ensure future test executions follow the same
PRNG sequence.

[1] https://github.com/cockroachdb/cockroach/pull/140674

Epic: none

Release note: None