### PR TITLE
catalog: avoid parsing expressions during descriptor validation in some cases

### DIFF
--- a/pkg/sql/catalog/descs/descriptor.go
+++ b/pkg/sql/catalog/descs/descriptor.go
@@ -646,6 +646,11 @@ func (tc *Collection) finalizeDescriptors(
 		requiredLevel = validate.MutableRead
 	} else {
 		requiredLevel = validate.ImmutableRead
+		// If we're reading a batch of immutable descriptors, we'll do only
+		// basic validations in only reduce overhead.
+		if len(validationLevels) > 10 {
+			requiredLevel = validate.ImmutableReadBatch
+		}
 	}
 	// Ensure that all descriptors are sufficiently validated.
 	if !tc.validationModeProvider.ValidateDescriptorsOnRead() {

--- a/pkg/sql/catalog/internal/validate/validate.go
+++ b/pkg/sql/catalog/internal/validate/validate.go
@@ -18,6 +18,10 @@ import (
 )
 
 const (
+	// ImmutableRead is the default validation level when reading many immutable
+	// descriptors all at once.
+	ImmutableReadBatch = catalog.ValidationLevelSelfOnly
+
 	// ImmutableRead is the default validation level when reading an immutable
 	// descriptor.
 	ImmutableRead = catalog.ValidationLevelForwardReferences


### PR DESCRIPTION
### catalog/descs: avoid validating forward references when reading many descriptors

Validating forward references has some overhead since it requires
parsing many expressions stored in the table descriptor. When reading a
lot of descriptors, we will prioritize performance by only performing
minimal validations.

### catalog/tabledesc: only validate all expressions at higher validation levels

This patch moves the validation step that checks that all expressions in
the descriptor can be parsed so it only happens when validating back-references
rather than during every read. Parsing is relatively expensive, so this
avoids a lot of overhead.

Epic: None
Release note: None