### PR TITLE
vecindex: add SearchForInsert to vector index library

### DIFF
--- a/pkg/sql/vecindex/testdata/search-for-insert.ddt
+++ b/pkg/sql/vecindex/testdata/search-for-insert.ddt
@@ -1,0 +1,107 @@
+# ----------
+# Search tree with only root-level vectors.
+# ----------
+new-index min-partition-size=1 max-partition-size=4 beam-size=2
+vec1: (1, 2)
+vec2: (7, 4)
+vec3: (4, 3)
+----
+• 1 (0, 0)
+│
+├───• vec1 (1, 2)
+├───• vec2 (7, 4)
+└───• vec3 (4, 3)
+
+# Search for insertion into root partition.
+# NOTE: Distance is always set to 0 for the root partition, and the centroid is
+# always the zero vector.
+search-for-insert
+(5, 5)
+----
+partition 1, centroid=(0, 0), sqdist=0
+
+# ----------
+# Search tree with multiple partitions.
+# ----------
+new-index min-partition-size=1 max-partition-size=4 beam-size=2
+vec1: (1, 2)
+vec2: (7, 4)
+vec3: (4, 3)
+vec4: (5, 5)
+vec5: (8, 11)
+vec6: (14, 1)
+vec7: (0, 0)
+vec8: (0, 4)
+vec9: (-2, 8)
+----
+• 1 (7.625, 4.75)
+│
+├───• 2 (11, 6)
+│   │
+│   ├───• vec6 (14, 1)
+│   └───• vec5 (8, 11)
+│
+├───• 4 (5.3333, 4)
+│   │
+│   ├───• vec3 (4, 3)
+│   ├───• vec4 (5, 5)
+│   └───• vec2 (7, 4)
+│
+└───• 5 (0.3333, 2)
+    │
+    ├───• vec1 (1, 2)
+    ├───• vec7 (0, 0)
+    ├───• vec8 (0, 4)
+    └───• vec9 (-2, 8)
+
+# Test exact match.
+search-for-insert
+(5, 5)
+----
+partition 4, centroid=(5.3333, 4), sqdist=1.1111
+
+# Test non-exact match.
+search-for-insert
+(1, 1)
+----
+partition 5, centroid=(0.3333, 2), sqdist=1.4444
+
+# ----------
+# Search tree with one over-sized partition.
+# ----------
+new-index min-partition-size=1 max-partition-size=4 beam-size=2 no-fixups
+vec1: (1, 2)
+vec2: (7, 4)
+vec3: (4, 3)
+vec4: (5, 5)
+vec5: (8, 11)
+----
+• 1 (0, 0)
+│
+├───• vec1 (1, 2)
+├───• vec2 (7, 4)
+├───• vec3 (4, 3)
+├───• vec4 (5, 5)
+└───• vec5 (8, 11)
+
+# Ensure that search for insert triggers a split.
+search-for-insert
+(3, 8)
+----
+partition 1, centroid=(0, 0), sqdist=0
+
+# Root partition should now be split.
+format-tree
+----
+• 1 (4.5833, 4.5833)
+│
+├───• 2 (2.5, 2.5)
+│   │
+│   ├───• vec1 (1, 2)
+│   └───• vec3 (4, 3)
+│
+└───• 3 (6.6667, 6.6667)
+    │
+    ├───• vec2 (7, 4)
+    ├───• vec4 (5, 5)
+    └───• vec5 (8, 11)

--- a/pkg/sql/vecindex/vecstore/partition.go
+++ b/pkg/sql/vecindex/vecstore/partition.go
@@ -81,6 +81,15 @@ func (p *Partition) Clone() *Partition {
 	}
 }
 
+// Metadata returns metadata for the partition.
+func (p *Partition) Metadata() PartitionMetadata {
+	return PartitionMetadata{
+		Level:    p.Level(),
+		Centroid: p.quantizedSet.GetCentroid(),
+		Count:    p.Count(),
+	}
+}
+
 // Count is the number of quantized vectors in the partition.
 func (p *Partition) Count() int {
 	return len(p.childKeys)

--- a/pkg/sql/vecindex/vecstore/persistent_store_test.go
+++ b/pkg/sql/vecindex/vecstore/persistent_store_test.go
@@ -155,20 +155,20 @@ func TestPersistentStore(t *testing.T) {
 		require.NoError(t, err)
 
 		// Add to root partition.
-		count, err := txn.AddToPartition(ctx, RootKey, vector.T{1, 2}, childKey10)
+		metadata, err := txn.AddToPartition(ctx, RootKey, vector.T{1, 2}, childKey10)
 		require.NoError(t, err)
-		require.Equal(t, 1, count)
-		count, err = txn.AddToPartition(ctx, RootKey, vector.T{7, 4}, childKey20)
+		checkPartitionMetadata(t, metadata, Level(2), vector.T{0, 0}, 1)
+		metadata, err = txn.AddToPartition(ctx, RootKey, vector.T{7, 4}, childKey20)
 		require.NoError(t, err)
-		require.Equal(t, 2, count)
-		count, err = txn.AddToPartition(ctx, RootKey, vector.T{4, 3}, childKey30)
+		checkPartitionMetadata(t, metadata, Level(2), vector.T{0, 0}, 2)
+		metadata, err = txn.AddToPartition(ctx, RootKey, vector.T{4, 3}, childKey30)
 		require.NoError(t, err)
-		require.Equal(t, 3, count)
+		checkPartitionMetadata(t, metadata, Level(2), vector.T{0, 0}, 3)
 
 		// Add duplicate and expect value to be overwritten
-		count, err = txn.AddToPartition(ctx, RootKey, vector.T{5, 5}, childKey30)
+		metadata, err = txn.AddToPartition(ctx, RootKey, vector.T{5, 5}, childKey30)
 		require.NoError(t, err)
-		require.Equal(t, 3, count)
+		checkPartitionMetadata(t, metadata, Level(2), vector.T{0, 0}, 3)
 
 		// Search root partition.
 		searchSet := SearchSet{MaxResults: 2}

--- a/pkg/sql/vecindex/vecstore/search_set.go
+++ b/pkg/sql/vecindex/vecstore/search_set.go
@@ -46,7 +46,8 @@ type SearchResult struct {
 	// partition, or the key of its partition if it's in a root/branch partition.
 	ChildKey ChildKey
 	// Vector is the original, full-size data vector. This is nil by default,
-	// and is only set after an optional reranking step.
+	// and is only set when SearchOptions.SkipRerank is false or
+	// SearchOptions.ReturnVectors is true.
 	Vector vector.T
 }
 
@@ -160,13 +161,16 @@ func (ss *SearchStats) Add(other *SearchStats) {
 // vector. Candidates are repeatedly added via the Add methods and the Pop
 // methods return a sorted list of the best candidates.
 type SearchSet struct {
-	// MaxResults is the maximum number of candidates that will be returned by
-	// PopResults.
+	// MaxResults specifies the max number of search results to return. Although
+	// these are the best results, the search process may retrieve additional
+	// candidates for reranking and statistics (up to MaxExtraResults) that are
+	// within the error threshold of being among the best results.
 	MaxResults int
 
-	// MaxExtraResults is the maximum number of candidates that will be returned
-	// by PopExtraResults. These results are within the error threshold of being
-	// among the best results.
+	// MaxExtraResults is the maximum number of additional candidates (beyond
+	// MaxResults) that will be returned by the search process for reranking and
+	// statistics. These results are within the error threshold of being among the
+	// the best results.
 	MaxExtraResults int
 
 	// MatchKey, if non-nil, filters out all search candidates that do not have

--- a/pkg/sql/vecindex/vecstore/store_test.go
+++ b/pkg/sql/vecindex/vecstore/store_test.go
@@ -81,27 +81,37 @@ func commonStoreTests(
 		require.Equal(t, LeafLevel, level)
 		require.Nil(t, searchSet.PopResults())
 		require.Equal(t, 0, partitionCounts[0])
+
+		// Get partition metadata.
+		metadata, err := txn.GetPartitionMetadata(ctx, RootKey, false /* forUpdate */)
+		require.NoError(t, err)
+		checkPartitionMetadata(t, metadata, Level(1), vector.T{0, 0}, 0)
 	})
 
 	t.Run("add to root partition", func(t *testing.T) {
 		txn := beginTransaction(ctx, t, store)
 		defer commitTransaction(ctx, t, store, txn)
 
+		// Get partition metadata with forUpdate = true before updates.
+		metadata, err := txn.GetPartitionMetadata(ctx, RootKey, true /* forUpdate */)
+		require.NoError(t, err)
+		checkPartitionMetadata(t, metadata, Level(1), vector.T{0, 0}, 0)
+
 		// Add to root partition.
-		count, err := txn.AddToPartition(ctx, RootKey, vector.T{1, 2}, primaryKey100)
+		metadata, err = txn.AddToPartition(ctx, RootKey, vector.T{1, 2}, primaryKey100)
 		require.NoError(t, err)
-		require.Equal(t, 1, count)
-		count, err = txn.AddToPartition(ctx, RootKey, vector.T{7, 4}, primaryKey200)
+		checkPartitionMetadata(t, metadata, LeafLevel, vector.T{0, 0}, 1)
+		metadata, err = txn.AddToPartition(ctx, RootKey, vector.T{7, 4}, primaryKey200)
 		require.NoError(t, err)
-		require.Equal(t, 2, count)
-		count, err = txn.AddToPartition(ctx, RootKey, vector.T{4, 3}, primaryKey300)
+		checkPartitionMetadata(t, metadata, LeafLevel, vector.T{0, 0}, 2)
+		metadata, err = txn.AddToPartition(ctx, RootKey, vector.T{4, 3}, primaryKey300)
 		require.NoError(t, err)
-		require.Equal(t, 3, count)
+		checkPartitionMetadata(t, metadata, LeafLevel, vector.T{0, 0}, 3)
 
 		// Add duplicate and expect value to be overwritten
-		count, err = txn.AddToPartition(ctx, RootKey, vector.T{5, 5}, primaryKey300)
+		metadata, err = txn.AddToPartition(ctx, RootKey, vector.T{5, 5}, primaryKey300)
 		require.NoError(t, err)
-		require.Equal(t, 3, count)
+		checkPartitionMetadata(t, metadata, LeafLevel, vector.T{0, 0}, 3)
 
 		// Search root partition.
 		searchSet := SearchSet{MaxResults: 2}
@@ -116,6 +126,11 @@ func commonStoreTests(
 		roundResults(results, 4)
 		require.Equal(t, SearchResults{result1, result2}, results)
 		require.Equal(t, 3, partitionCounts[0])
+
+		// Ensure partition metadata is updated.
+		metadata, err = txn.GetPartitionMetadata(ctx, RootKey, true /* forUpdate */)
+		require.NoError(t, err)
+		checkPartitionMetadata(t, metadata, Level(1), vector.T{0, 0}, 3)
 	})
 
 	var root *Partition
@@ -142,6 +157,11 @@ func commonStoreTests(
 		require.Equal(t, vector.T{0, 0}, results[0].Vector)
 		require.Equal(t, testVectors[0], results[1].Vector)
 		require.Nil(t, results[2].Vector)
+
+		// Get partition metadata.
+		metadata, err := txn.GetPartitionMetadata(ctx, RootKey, false /* forUpdate */)
+		require.NoError(t, err)
+		checkPartitionMetadata(t, metadata, Level(1), vector.T{0, 0}, 3)
 	})
 
 	t.Run("replace root partition", func(t *testing.T) {
@@ -153,7 +173,7 @@ func commonStoreTests(
 		require.NoError(t, err)
 		vectors := vector.T{4, 3}.AsSet()
 		quantizedSet := quantizer.Quantize(ctx, vectors)
-		newRoot := NewPartition(quantizer, quantizedSet, []ChildKey{childKey2}, 2)
+		newRoot := NewPartition(quantizer, quantizedSet, []ChildKey{childKey2}, Level(2))
 		require.NoError(t, txn.SetRootPartition(ctx, newRoot))
 		newRoot, err = txn.GetPartition(ctx, RootKey)
 		require.NoError(t, err)
@@ -169,6 +189,11 @@ func commonStoreTests(
 		result3 := SearchResult{QuerySquaredDistance: 5, ErrorBound: 0, CentroidDistance: 0, ParentPartitionKey: 1, ChildKey: childKey2}
 		require.Equal(t, SearchResults{result3}, searchSet.PopResults())
 		require.Equal(t, 1, partitionCounts[0])
+
+		// Get partition metadata.
+		metadata, err := txn.GetPartitionMetadata(ctx, RootKey, false /* forUpdate */)
+		require.NoError(t, err)
+		checkPartitionMetadata(t, metadata, Level(2), vector.T{4, 3}, 1)
 	})
 
 	var partitionKey1 PartitionKey
@@ -180,22 +205,22 @@ func commonStoreTests(
 		require.NoError(t, err)
 		partitionKey1, err = txn.InsertPartition(ctx, root)
 		require.NoError(t, err)
-		count, err := txn.RemoveFromPartition(ctx, partitionKey1, primaryKey200)
+		metadata, err := txn.RemoveFromPartition(ctx, partitionKey1, primaryKey200)
 		require.NoError(t, err)
-		require.Equal(t, 2, count)
+		checkPartitionMetadata(t, metadata, LeafLevel, vector.T{0, 0}, 2)
 
 		// Try to remove the same key again.
-		count, err = txn.RemoveFromPartition(ctx, partitionKey1, primaryKey200)
+		metadata, err = txn.RemoveFromPartition(ctx, partitionKey1, primaryKey200)
 		require.NoError(t, err)
-		require.Equal(t, 2, count)
+		checkPartitionMetadata(t, metadata, LeafLevel, vector.T{0, 0}, 2)
 
 		// Add an alternate element and add duplicate, expecting value to be overwritten.
-		count, err = txn.AddToPartition(ctx, partitionKey1, vector.T{-1, 0}, primaryKey400)
+		metadata, err = txn.AddToPartition(ctx, partitionKey1, vector.T{-1, 0}, primaryKey400)
 		require.NoError(t, err)
-		require.Equal(t, 3, count)
-		count, err = txn.AddToPartition(ctx, partitionKey1, vector.T{1, 1}, primaryKey400)
+		checkPartitionMetadata(t, metadata, LeafLevel, vector.T{0, 0}, 3)
+		metadata, err = txn.AddToPartition(ctx, partitionKey1, vector.T{1, 1}, primaryKey400)
 		require.NoError(t, err)
-		require.Equal(t, 3, count)
+		checkPartitionMetadata(t, metadata, LeafLevel, vector.T{0, 0}, 3)
 
 		searchSet := SearchSet{MaxResults: 2}
 		partitionCounts := []int{0}

--- a/pkg/sql/vecindex/vector_index_test.go
+++ b/pkg/sql/vecindex/vector_index_test.go
@@ -62,6 +62,9 @@ func TestVectorIndex(t *testing.T) {
 			case "search":
 				return state.Search(d)
 
+			case "search-for-insert":
+				return state.SearchForInsert(d)
+
 			case "insert":
 				return state.Insert(d)
 
@@ -208,6 +211,51 @@ func (s *testState) Search(d *datadriven.TestData) string {
 	buf.WriteString(fmt.Sprintf("%d vectors, ", searchSet.Stats.QuantizedVectorCount))
 	buf.WriteString(fmt.Sprintf("%d full vectors, ", searchSet.Stats.FullVectorCount))
 	buf.WriteString(fmt.Sprintf("%d partitions", searchSet.Stats.PartitionCount))
+
+	// Handle any fixups triggered by the search.
+	s.Index.ProcessFixups()
+
+	return buf.String()
+}
+
+func (s *testState) SearchForInsert(d *datadriven.TestData) string {
+	var vec vector.T
+
+	var err error
+	for _, arg := range d.CmdArgs {
+		switch arg.Key {
+		case "use-feature":
+			require.Len(s.T, arg.Vals, 1)
+			offset, err := strconv.Atoi(arg.Vals[0])
+			require.NoError(s.T, err)
+			vec = s.Features.At(offset)
+		}
+	}
+
+	if vec == nil {
+		// Parse input as the vector to search for.
+		vec = s.parseVector(d.Input)
+	}
+
+	// Search the index within a transaction.
+	txn := beginTransaction(s.Ctx, s.T, s.InMemStore)
+	result, err := s.Index.SearchForInsert(s.Ctx, txn, vec)
+	require.NoError(s.T, err)
+	commitTransaction(s.Ctx, s.T, s.InMemStore, txn)
+
+	var buf bytes.Buffer
+	fmt.Fprintf(&buf, "partition %d, centroid=", result.ChildKey.PartitionKey)
+
+	// Un-randomize the centroid and write it to buffer.
+	original := make(vector.T, len(result.Vector))
+	s.Index.unRandomizeVector(result.Vector, original)
+	writeVector(&buf, original, 4)
+
+	fmt.Fprintf(&buf, ", sqdist=%s", formatFloat(result.QuerySquaredDistance, 4))
+	if result.ErrorBound != 0 {
+		fmt.Fprintf(&buf, "±%s", formatFloat(result.ErrorBound, 2))
+	}
+	buf.WriteByte('\n')
 
 	// Handle any fixups triggered by the search.
 	s.Index.ProcessFixups()
@@ -563,15 +611,6 @@ func (s *testState) parseVector(str string) vector.T {
 	}
 
 	return vector
-}
-
-func formatFloat(value float32, prec int) string {
-	s := strconv.FormatFloat(float64(value), 'f', prec, 32)
-	if strings.Contains(s, ".") {
-		s = strings.TrimRight(s, "0")
-		s = strings.TrimRight(s, ".")
-	}
-	return s
 }
 
 func beginTransaction(ctx context.Context, t *testing.T, store vecstore.Store) vecstore.Txn {


### PR DESCRIPTION
Add a SearchForInsert method to the VectorIndex class that searches for the best partition in which to insert a query vector. This will be used by the execution engine, which creates its own custom insertion batches rather than using VectorIndex.Insert. Add a GetPartitionMetadata method to the Store class that's used by SearchForInsert to efficiently get the centroid of the insert partition, as well as to check whether the partition is over-sized.

Epic: CRDB-42943

Release note: None