### PR TITLE
types: rename types.Any to types.AnyElement

### DIFF
--- a/pkg/bench/bench_test.go
+++ b/pkg/bench/bench_test.go
@@ -1587,7 +1587,7 @@ func BenchmarkFuncExprTypeCheck(b *testing.B) {
 			require.NoError(b, err)
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				_, err := tree.TypeCheck(ctx, expr, semaCtx, types.Any)
+				_, err := tree.TypeCheck(ctx, expr, semaCtx, types.AnyElement)
 				require.NoError(b, err)
 			}
 		})

--- a/pkg/internal/sqlsmith/type.go
+++ b/pkg/internal/sqlsmith/type.go
@@ -28,7 +28,7 @@ func (s *Smither) typeFromSQLTypeSyntax(typeStr string) (*types.T, error) {
 	return typ, nil
 }
 
-// pickAnyType returns a concrete type if typ is types.Any or types.AnyArray,
+// pickAnyType returns a concrete type if typ is types.AnyElement or types.AnyArray,
 // otherwise typ.
 func (s *Smither) pickAnyType(typ *types.T) *types.T {
 	switch typ.Family() {

--- a/pkg/sql/catalog/colinfo/column_type_properties_test.go
+++ b/pkg/sql/catalog/colinfo/column_type_properties_test.go
@@ -19,7 +19,7 @@ func TestCanHaveCompositeKeyEncoding(t *testing.T) {
 		typ *types.T
 		exp bool
 	}{
-		{types.Any, true},
+		{types.AnyElement, true},
 		{types.AnyArray, true},
 		{types.AnyCollatedString, true},
 		{types.AnyEnum, false},

--- a/pkg/sql/catalog/schemaexpr/computed_column.go
+++ b/pkg/sql/catalog/schemaexpr/computed_column.go
@@ -29,8 +29,8 @@ import (
 // ValidateComputedColumnExpression verifies that an expression is a valid
 // computed column expression. It returns the serialized expression and its type
 // if valid, and an error otherwise. The returned type is only useful if d has
-// type Any which indicates the expression's type is unknown and does not have
-// to match a specific type.
+// type AnyElement which indicates the expression's type is unknown and does not
+// have to match a specific type.
 //
 // A computed column expression is valid if all of the following are true:
 //

--- a/pkg/sql/catalog/schemaexpr/expr.go
+++ b/pkg/sql/catalog/schemaexpr/expr.go
@@ -361,7 +361,7 @@ func deserializeExprForFormatting(
 	}
 
 	// Type-check the expression to resolve user defined types.
-	typedExpr, err := replacedExpr.TypeCheck(ctx, semaCtx, types.Any)
+	typedExpr, err := replacedExpr.TypeCheck(ctx, semaCtx, types.AnyElement)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/catalog/schemaexpr/expr_test.go
+++ b/pkg/sql/catalog/schemaexpr/expr_test.go
@@ -57,12 +57,12 @@ func TestValidateExpr(t *testing.T) {
 		{"b + 1", false, "", types.Bool, volatility.Immutable},
 
 		// Validates that the expression has no variable expressions.
-		{"$1", false, "", types.Any, volatility.Immutable},
+		{"$1", false, "", types.AnyElement, volatility.Immutable},
 
 		// Validates the volatility check.
 		{"now()", true, "now():::TIMESTAMPTZ", types.TimestampTZ, volatility.Volatile},
 		{"now()", true, "now():::TIMESTAMPTZ", types.TimestampTZ, volatility.Stable},
-		{"now()", false, "", types.Any, volatility.Immutable},
+		{"now()", false, "", types.AnyElement, volatility.Immutable},
 		{"uuid_v4()::STRING", true, "uuid_v4()::STRING", types.String, volatility.Volatile},
 		{"uuid_v4()::STRING", false, "", types.String, volatility.Stable},
 		{"uuid_v4()::STRING", false, "", types.String, volatility.Immutable},

--- a/pkg/sql/catalog/seqexpr/sequence_test.go
+++ b/pkg/sql/catalog/seqexpr/sequence_test.go
@@ -39,7 +39,7 @@ func TestGetSequenceFromFunc(t *testing.T) {
 				t.Fatal(err)
 			}
 			semaCtx := tree.MakeSemaContext(nil /* resolver */)
-			typedExpr, err := tree.TypeCheck(ctx, parsedExpr, &semaCtx, types.Any)
+			typedExpr, err := tree.TypeCheck(ctx, parsedExpr, &semaCtx, types.AnyElement)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -89,7 +89,7 @@ func TestGetUsedSequences(t *testing.T) {
 				t.Fatal(err)
 			}
 			semaCtx := tree.MakeSemaContext(nil /* resolver */)
-			typedExpr, err := tree.TypeCheck(ctx, parsedExpr, &semaCtx, types.Any)
+			typedExpr, err := tree.TypeCheck(ctx, parsedExpr, &semaCtx, types.AnyElement)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -140,7 +140,7 @@ func TestReplaceSequenceNamesWithIDs(t *testing.T) {
 				t.Fatal(err)
 			}
 			semaCtx := tree.MakeSemaContext(nil /* resolver */)
-			typedExpr, err := tree.TypeCheck(ctx, parsedExpr, &semaCtx, types.Any)
+			typedExpr, err := tree.TypeCheck(ctx, parsedExpr, &semaCtx, types.AnyElement)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/sql/colexec/builtin_funcs_test.go
+++ b/pkg/sql/colexec/builtin_funcs_test.go
@@ -220,7 +220,7 @@ func BenchmarkCompareSpecializedOperators(b *testing.B) {
 	p := &colexectestutils.MockTypeContext{Typs: typs}
 	semaCtx := tree.MakeSemaContext(nil /* resolver */)
 	semaCtx.IVarContainer = p
-	typedExpr, err := tree.TypeCheck(ctx, expr, &semaCtx, types.Any)
+	typedExpr, err := tree.TypeCheck(ctx, expr, &semaCtx, types.AnyElement)
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/pkg/sql/colexec/colexectestutils/proj_utils.go
+++ b/pkg/sql/colexec/colexectestutils/proj_utils.go
@@ -61,7 +61,7 @@ func CreateTestProjectingOperator(
 	p := &MockTypeContext{Typs: inputTypes}
 	semaCtx := tree.MakeSemaContext(nil /* resolver */)
 	semaCtx.IVarContainer = p
-	typedExpr, err := tree.TypeCheck(ctx, expr, &semaCtx, types.Any)
+	typedExpr, err := tree.TypeCheck(ctx, expr, &semaCtx, types.AnyElement)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/colexec/execgen/cmd/execgen/overloads_bin.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/overloads_bin.go
@@ -114,7 +114,7 @@ func registerBinOpOutputTypes() {
 	for _, binOp := range []treebin.BinaryOperatorSymbol{treebin.Bitand, treebin.Bitor, treebin.Bitxor} {
 		binOpOutputTypes[binOp] = make(map[typePair]*types.T)
 		populateBinOpIntOutputTypeOnIntArgs(binOp)
-		binOpOutputTypes[binOp][typePair{typeconv.DatumVecCanonicalTypeFamily, anyWidth, typeconv.DatumVecCanonicalTypeFamily, anyWidth}] = types.Any
+		binOpOutputTypes[binOp][typePair{typeconv.DatumVecCanonicalTypeFamily, anyWidth, typeconv.DatumVecCanonicalTypeFamily, anyWidth}] = types.AnyElement
 	}
 
 	// Simple arithmetic binary operators.
@@ -157,8 +157,8 @@ func registerBinOpOutputTypes() {
 		types.IntervalFamily, // types.Time + types.Interval
 	} {
 		for _, width := range supportedWidthsByCanonicalTypeFamily[compatibleFamily] {
-			binOpOutputTypes[treebin.Plus][typePair{typeconv.DatumVecCanonicalTypeFamily, anyWidth, compatibleFamily, width}] = types.Any
-			binOpOutputTypes[treebin.Plus][typePair{compatibleFamily, width, typeconv.DatumVecCanonicalTypeFamily, anyWidth}] = types.Any
+			binOpOutputTypes[treebin.Plus][typePair{typeconv.DatumVecCanonicalTypeFamily, anyWidth, compatibleFamily, width}] = types.AnyElement
+			binOpOutputTypes[treebin.Plus][typePair{compatibleFamily, width, typeconv.DatumVecCanonicalTypeFamily, anyWidth}] = types.AnyElement
 		}
 	}
 	for _, compatibleFamily := range []types.Family{
@@ -168,8 +168,8 @@ func registerBinOpOutputTypes() {
 		types.BytesFamily,                    // types.Jsonb - types.String
 	} {
 		for _, width := range supportedWidthsByCanonicalTypeFamily[compatibleFamily] {
-			binOpOutputTypes[treebin.Minus][typePair{typeconv.DatumVecCanonicalTypeFamily, anyWidth, compatibleFamily, width}] = types.Any
-			binOpOutputTypes[treebin.Minus][typePair{compatibleFamily, width, typeconv.DatumVecCanonicalTypeFamily, anyWidth}] = types.Any
+			binOpOutputTypes[treebin.Minus][typePair{typeconv.DatumVecCanonicalTypeFamily, anyWidth, compatibleFamily, width}] = types.AnyElement
+			binOpOutputTypes[treebin.Minus][typePair{compatibleFamily, width, typeconv.DatumVecCanonicalTypeFamily, anyWidth}] = types.AnyElement
 		}
 	}
 
@@ -188,14 +188,14 @@ func registerBinOpOutputTypes() {
 	// Other non-arithmetic binary operators.
 	binOpOutputTypes[treebin.Concat] = map[typePair]*types.T{
 		{types.BytesFamily, anyWidth, types.BytesFamily, anyWidth}:                                       types.Bytes,
-		{typeconv.DatumVecCanonicalTypeFamily, anyWidth, typeconv.DatumVecCanonicalTypeFamily, anyWidth}: types.Any,
+		{typeconv.DatumVecCanonicalTypeFamily, anyWidth, typeconv.DatumVecCanonicalTypeFamily, anyWidth}: types.AnyElement,
 	}
 
 	for _, binOp := range []treebin.BinaryOperatorSymbol{treebin.LShift, treebin.RShift} {
 		binOpOutputTypes[binOp] = make(map[typePair]*types.T)
 		populateBinOpIntOutputTypeOnIntArgs(binOp)
 		for _, intWidth := range supportedWidthsByCanonicalTypeFamily[types.IntFamily] {
-			binOpOutputTypes[binOp][typePair{typeconv.DatumVecCanonicalTypeFamily, anyWidth, types.IntFamily, intWidth}] = types.Any
+			binOpOutputTypes[binOp][typePair{typeconv.DatumVecCanonicalTypeFamily, anyWidth, types.IntFamily, intWidth}] = types.AnyElement
 		}
 	}
 

--- a/pkg/sql/create_index.go
+++ b/pkg/sql/create_index.go
@@ -521,10 +521,10 @@ func replaceExpressionElemsWithVirtualCols(
 		elem := &elems[i]
 		if elem.Expr != nil {
 			// Create a dummy ColumnTableDef to use for validating the
-			// expression. The type is Any because it is unknown until
+			// expression. The type is AnyElement because it is unknown until
 			// validation is performed.
 			colDef := &tree.ColumnTableDef{
-				Type: types.Any,
+				Type: types.AnyElement,
 			}
 			colDef.Computed.Computed = true
 			colDef.Computed.Expr = elem.Expr

--- a/pkg/sql/execinfrapb/expr.go
+++ b/pkg/sql/execinfrapb/expr.go
@@ -256,7 +256,7 @@ func (eh *exprHelper) deserializeExpr(ctx context.Context, e Expression) (tree.T
 	defer func() { eh.semaCtx.IVarContainer = originalIVarContainer }()
 
 	// Type-check the expression.
-	typedExpr, err := tree.TypeCheck(ctx, expr, eh.semaCtx, types.Any)
+	typedExpr, err := tree.TypeCheck(ctx, expr, eh.semaCtx, types.AnyElement)
 	if err != nil {
 		// Type checking must succeed.
 		return nil, errors.NewAssertionErrorWithWrappedErrf(err, "%s", expr)

--- a/pkg/sql/opt/norm/general_funcs.go
+++ b/pkg/sql/opt/norm/general_funcs.go
@@ -76,9 +76,9 @@ func (c *CustomFuncs) BoolType() *types.T {
 	return types.Bool
 }
 
-// AnyType returns the wildcard Any type.
+// AnyType returns the wildcard AnyElement type.
 func (c *CustomFuncs) AnyType() *types.T {
-	return types.Any
+	return types.AnyElement
 }
 
 // CanConstructBinary returns true if (op left right) has a valid binary op

--- a/pkg/sql/opt/optbuilder/create_trigger.go
+++ b/pkg/sql/opt/optbuilder/create_trigger.go
@@ -54,7 +54,7 @@ func (b *Builder) buildCreateTrigger(ct *tree.CreateTrigger, inScope *scope) (ou
 
 	// Resolve the trigger function and check its privileges.
 	funcExpr := tree.FuncExpr{Func: tree.ResolvableFunctionReference{FunctionReference: ct.FuncName}}
-	typedExpr := inScope.resolveType(&funcExpr, types.Any)
+	typedExpr := inScope.resolveType(&funcExpr, types.AnyElement)
 	f, ok := typedExpr.(*tree.FuncExpr)
 	if !ok {
 		panic(errors.AssertionFailedf("%s is not a function", funcExpr.Func.String()))

--- a/pkg/sql/opt/optbuilder/groupby.go
+++ b/pkg/sql/opt/optbuilder/groupby.go
@@ -721,7 +721,7 @@ func (b *Builder) buildAggregateFunction(
 	if f.OrderBy != nil {
 		for _, o := range f.OrderBy {
 			// ORDER BY (a, b) => ORDER BY a, b.
-			te := fromScope.resolveType(o.Expr, types.Any)
+			te := fromScope.resolveType(o.Expr, types.AnyElement)
 			cols := flattenTuples([]tree.TypedExpr{te})
 
 			nullsDefaultOrder := b.hasDefaultNullsOrder(o)

--- a/pkg/sql/opt/optbuilder/orderby.go
+++ b/pkg/sql/opt/optbuilder/orderby.go
@@ -152,7 +152,7 @@ func (b *Builder) analyzeOrderByIndex(order *tree.Order, inScope, orderByScope *
 		}
 
 		colItem := tree.NewColumnItem(&tn, col.ColName())
-		expr := inScope.resolveType(colItem, types.Any)
+		expr := inScope.resolveType(colItem, types.AnyElement)
 		outCol := orderByScope.addColumn(scopeColName(""), expr)
 		outCol.descending = desc
 	}

--- a/pkg/sql/opt/optbuilder/plpgsql.go
+++ b/pkg/sql/opt/optbuilder/plpgsql.go
@@ -2615,7 +2615,7 @@ func (r *recordTypeVisitor) Visit(stmt ast.Statement) (newStmt ast.Statement, re
 			return t, false
 		}
 	case *ast.Return:
-		desired := types.Any
+		desired := types.AnyElement
 		if r.typ != nil && r.typ.Family() != types.UnknownFamily {
 			desired = r.typ
 		}

--- a/pkg/sql/opt/optbuilder/project.go
+++ b/pkg/sql/opt/optbuilder/project.go
@@ -166,7 +166,7 @@ func (b *Builder) analyzeSelectList(
 				}
 			}
 
-			desired := types.Any
+			desired := types.AnyElement
 			if i < len(desiredTypes) {
 				desired = desiredTypes[i]
 			}
@@ -219,7 +219,7 @@ func (b *Builder) resolveColRef(e tree.Expr, inScope *scope) tree.TypedExpr {
 			if sqlerrors.IsUndefinedColumnError(resolveErr) {
 				return func() tree.TypedExpr {
 					defer wrapColTupleStarPanic(resolveErr)
-					return inScope.resolveType(columnNameAsTupleStar(colName), types.Any)
+					return inScope.resolveType(columnNameAsTupleStar(colName), types.AnyElement)
 				}()
 			}
 			panic(resolveErr)

--- a/pkg/sql/opt/optbuilder/routine.go
+++ b/pkg/sql/opt/optbuilder/routine.go
@@ -151,7 +151,7 @@ func (b *Builder) resolveProcedureDefinition(
 ) (f *tree.FuncExpr, def *tree.ResolvedFunctionDefinition) {
 	// Type-check the procedure and its arguments. Subqueries are disallowed in
 	// arguments.
-	typedExpr := inScope.resolveTypeAndReject(proc, types.Any,
+	typedExpr := inScope.resolveTypeAndReject(proc, types.AnyElement,
 		"CALL argument", tree.RejectSubqueries)
 	f, ok := typedExpr.(*tree.FuncExpr)
 	if !ok {

--- a/pkg/sql/opt/optbuilder/row_level_security.go
+++ b/pkg/sql/opt/optbuilder/row_level_security.go
@@ -61,7 +61,7 @@ func (b *Builder) buildRowLevelSecurityUsingExpression(
 		if err != nil {
 			panic(err)
 		}
-		typedExpr := tableScope.resolveType(parsedExpr, types.Any)
+		typedExpr := tableScope.resolveType(parsedExpr, types.AnyElement)
 		scalar := b.buildScalar(typedExpr, tableScope, nil, nil, nil)
 		// TODO(136742): Apply multiple RLS policies.
 		return scalar

--- a/pkg/sql/opt/optbuilder/scalar.go
+++ b/pkg/sql/opt/optbuilder/scalar.go
@@ -943,7 +943,7 @@ func (sb *ScalarBuilder) Build(expr tree.Expr) (_ opt.ScalarExpr, err error) {
 		}
 	}()
 
-	typedExpr := sb.scope.resolveType(expr, types.Any)
+	typedExpr := sb.scope.resolveType(expr, types.AnyElement)
 	scalar := sb.buildScalar(typedExpr, &sb.scope, nil, nil, nil)
 	return scalar, nil
 }

--- a/pkg/sql/opt/optbuilder/scope.go
+++ b/pkg/sql/opt/optbuilder/scope.go
@@ -507,7 +507,7 @@ func (s *scope) resolveTypeAndReject(
 
 // ensureNullType tests the type of the given expression. If types.Unknown, then
 // ensureNullType wraps the expression in a CAST to the desired type (assuming
-// it is not types.Any). types.Unknown is a special type used for null values,
+// it is not types.AnyElement). types.Unknown is a special type used for null values,
 // and can be cast to any other type.
 func (s *scope) ensureNullType(texpr tree.TypedExpr, desired *types.T) tree.TypedExpr {
 	if desired.Family() != types.AnyFamily && texpr.ResolvedType().Family() == types.UnknownFamily {
@@ -1206,7 +1206,7 @@ func (s *scope) replaceSRF(f *tree.FuncExpr, def *tree.ResolvedFunctionDefinitio
 		tree.RejectAggregates|tree.RejectWindowApplications|tree.RejectNestedGenerators)
 
 	expr := f.Walk(s)
-	typedFunc, err := tree.TypeCheck(s.builder.ctx, expr, s.builder.semaCtx, types.Any)
+	typedFunc, err := tree.TypeCheck(s.builder.ctx, expr, s.builder.semaCtx, types.AnyElement)
 	if err != nil {
 		panic(err)
 	}
@@ -1307,7 +1307,7 @@ func (s *scope) replaceAggregate(f *tree.FuncExpr, def *tree.ResolvedFunctionDef
 		copy(fCopy.Exprs, oldExprs)
 
 		// Add implicit column to the input expressions.
-		fCopy.Exprs = append(fCopy.Exprs, s.resolveType(fCopy.OrderBy[0].Expr, types.Any))
+		fCopy.Exprs = append(fCopy.Exprs, s.resolveType(fCopy.OrderBy[0].Expr, types.AnyElement))
 	}
 
 	expr := fCopy.Walk(s)
@@ -1326,14 +1326,14 @@ func (s *scope) replaceAggregate(f *tree.FuncExpr, def *tree.ResolvedFunctionDef
 			defer func() { s.builder.semaCtx.Properties.Restore(oldProps) }()
 
 			s.builder.semaCtx.Properties.Require("FILTER", tree.RejectSpecial)
-			_, err := tree.TypeCheck(s.builder.ctx, expr.(*tree.FuncExpr).Filter, s.builder.semaCtx, types.Any)
+			_, err := tree.TypeCheck(s.builder.ctx, expr.(*tree.FuncExpr).Filter, s.builder.semaCtx, types.AnyElement)
 			if err != nil {
 				panic(err)
 			}
 		}()
 	}
 
-	typedFunc, err := tree.TypeCheck(s.builder.ctx, expr, s.builder.semaCtx, types.Any)
+	typedFunc, err := tree.TypeCheck(s.builder.ctx, expr, s.builder.semaCtx, types.AnyElement)
 	if err != nil {
 		panic(err)
 	}
@@ -1405,7 +1405,7 @@ func (s *scope) replaceWindowFn(f *tree.FuncExpr, def *tree.ResolvedFunctionDefi
 
 	expr := fCopy.Walk(s)
 
-	typedFunc, err := tree.TypeCheck(s.builder.ctx, expr, s.builder.semaCtx, types.Any)
+	typedFunc, err := tree.TypeCheck(s.builder.ctx, expr, s.builder.semaCtx, types.AnyElement)
 	if err != nil {
 		panic(err)
 	}
@@ -1426,7 +1426,7 @@ func (s *scope) replaceWindowFn(f *tree.FuncExpr, def *tree.ResolvedFunctionDefi
 	oldPartitions := f.WindowDef.Partitions
 	f.WindowDef.Partitions = make(tree.Exprs, len(oldPartitions))
 	for i, e := range oldPartitions {
-		typedExpr := s.resolveType(e, types.Any)
+		typedExpr := s.resolveType(e, types.AnyElement)
 		f.WindowDef.Partitions[i] = typedExpr
 	}
 
@@ -1437,7 +1437,7 @@ func (s *scope) replaceWindowFn(f *tree.FuncExpr, def *tree.ResolvedFunctionDefi
 		if ord.OrderType != tree.OrderByColumn {
 			panic(errOrderByIndexInWindow)
 		}
-		typedExpr := s.resolveType(ord.Expr, types.Any)
+		typedExpr := s.resolveType(ord.Expr, types.AnyElement)
 		ord.Expr = typedExpr
 		f.WindowDef.OrderBy[i] = &ord
 	}
@@ -1489,7 +1489,7 @@ func (s *scope) replaceSQLFn(f *tree.FuncExpr, def *tree.ResolvedFunctionDefinit
 	s.builder.semaCtx.Properties.Require("SQL function", tree.RejectSpecial)
 
 	expr := f.Walk(s)
-	typedFunc, err := tree.TypeCheck(s.builder.ctx, expr, s.builder.semaCtx, types.Any)
+	typedFunc, err := tree.TypeCheck(s.builder.ctx, expr, s.builder.semaCtx, types.AnyElement)
 	if err != nil {
 		panic(err)
 	}
@@ -1635,7 +1635,7 @@ func (s *scope) replaceCount(
 			// We call TypeCheck to fill in FuncExpr internals. This is a fixed
 			// expression; we should not hit an error here.
 			semaCtx := tree.MakeSemaContext(nil /* resolver */)
-			if _, err := e.TypeCheck(s.builder.ctx, &semaCtx, types.Any); err != nil {
+			if _, err := e.TypeCheck(s.builder.ctx, &semaCtx, types.AnyElement); err != nil {
 				panic(err)
 			}
 			newDef, err := e.Func.Resolve(s.builder.ctx, s.builder.semaCtx.SearchPath, nil /* resolver */)

--- a/pkg/sql/opt/optbuilder/srfs.go
+++ b/pkg/sql/opt/optbuilder/srfs.go
@@ -102,7 +102,7 @@ func (b *Builder) buildZip(exprs tree.Exprs, inScope *scope) (outScope *scope) {
 		if err != nil {
 			panic(err)
 		}
-		texpr := inScope.resolveType(expr, types.Any)
+		texpr := inScope.resolveType(expr, types.AnyElement)
 
 		var def *tree.ResolvedFunctionDefinition
 		funcExpr, ok := texpr.(*tree.FuncExpr)

--- a/pkg/sql/opt/optbuilder/trigger.go
+++ b/pkg/sql/opt/optbuilder/trigger.go
@@ -786,7 +786,7 @@ func (b *Builder) buildTriggerFunction(
 	triggerFuncScope := b.allocScope()
 	funcRef := &tree.FunctionOID{OID: catid.FuncIDToOID(catid.DescID(trigger.FuncID()))}
 	funcExpr := tree.FuncExpr{Func: tree.ResolvableFunctionReference{FunctionReference: funcRef}}
-	triggerFuncScope.resolveType(&funcExpr, types.Any)
+	triggerFuncScope.resolveType(&funcExpr, types.AnyElement)
 	resolvedDef := funcExpr.Func.FunctionReference.(*tree.ResolvedFunctionDefinition)
 	o := funcExpr.ResolvedOverload()
 

--- a/pkg/sql/opt/optbuilder/union_test.go
+++ b/pkg/sql/opt/optbuilder/union_test.go
@@ -62,7 +62,7 @@ func TestUnionType(t *testing.T) {
 			expected: types.Decimal,
 		},
 		{
-			left:     types.MakeArray(types.MakeTuple([]*types.T{types.Any})),
+			left:     types.MakeArray(types.MakeTuple([]*types.T{types.AnyElement})),
 			right:    types.MakeArray(types.MakeTuple([]*types.T{types.Bool})),
 			expected: types.MakeArray(types.MakeTuple([]*types.T{types.Bool})),
 		},

--- a/pkg/sql/opt/optbuilder/util.go
+++ b/pkg/sql/opt/optbuilder/util.go
@@ -59,7 +59,7 @@ func (b *Builder) expandStar(
 ) (aliases []string, exprs []tree.TypedExpr) {
 	switch t := expr.(type) {
 	case *tree.TupleStar:
-		texpr := inScope.resolveType(t.Expr, types.Any)
+		texpr := inScope.resolveType(t.Expr, types.AnyElement)
 		typ := texpr.ResolvedType()
 		if typ.Family() != types.TupleFamily {
 			panic(tree.NewTypeIsNotCompositeError(typ))
@@ -171,7 +171,7 @@ func (b *Builder) expandStarAndResolveType(
 		return b.expandStarAndResolveType(vn, inScope)
 
 	default:
-		texpr := inScope.resolveType(t, types.Any)
+		texpr := inScope.resolveType(t, types.AnyElement)
 		exprs = []tree.TypedExpr{texpr}
 	}
 

--- a/pkg/sql/opt/optbuilder/values.go
+++ b/pkg/sql/opt/optbuilder/values.go
@@ -54,7 +54,7 @@ func (b *Builder) buildValuesClause(
 
 	colTypes := make([]*types.T, numCols)
 	for colIdx := range colTypes {
-		desired := types.Any
+		desired := types.AnyElement
 		if colIdx < len(desiredTypes) {
 			desired = desiredTypes[colIdx]
 		}

--- a/pkg/sql/opt/optbuilder/window.go
+++ b/pkg/sql/opt/optbuilder/window.go
@@ -420,7 +420,7 @@ func (b *Builder) buildWindowOrdering(
 	ord := make(opt.Ordering, 0, len(orderBy))
 	for j, t := range orderBy {
 		// ORDER BY (a, b) => ORDER BY a, b.
-		te := inScope.resolveType(t.Expr, types.Any)
+		te := inScope.resolveType(t.Expr, types.AnyElement)
 		cols := flattenTuples([]tree.TypedExpr{te})
 
 		nullsDefaultOrder := b.hasDefaultNullsOrder(t)

--- a/pkg/sql/opt/optgen/cmd/optgen/exprs_gen.go
+++ b/pkg/sql/opt/optgen/cmd/optgen/exprs_gen.go
@@ -555,7 +555,7 @@ func (g *exprsGen) genListExprFuncs(define *lang.DefineExpr) {
 
 	// Generate the DataType method.
 	fmt.Fprintf(g.w, "func (e *%s) DataType() *types.T {\n", opTyp.name)
-	fmt.Fprintf(g.w, "  return types.Any\n")
+	fmt.Fprintf(g.w, "  return types.AnyElement\n")
 	fmt.Fprintf(g.w, "}\n\n")
 }
 

--- a/pkg/sql/opt/optgen/cmd/optgen/testdata/exprs
+++ b/pkg/sql/opt/optgen/cmd/optgen/testdata/exprs
@@ -230,7 +230,7 @@ func (e *ProjectionsExpr) SetChild(nth int, child opt.Expr) {
 }
 
 func (e *ProjectionsExpr) DataType() *types.T {
-	return types.Any
+	return types.AnyElement
 }
 
 type ProjectionsItem struct {

--- a/pkg/sql/opt/testutils/testcat/create_table.go
+++ b/pkg/sql/opt/testutils/testcat/create_table.go
@@ -1391,7 +1391,7 @@ func (ti *Index) partitionByListExprToDatums(
 	d := make(tree.Datums, len(vals))
 	for i := range vals {
 		c := tree.CastExpr{Expr: vals[i], Type: ti.Columns[i].DatumType()}
-		cTyped, err := c.TypeCheck(ctx, semaCtx, types.Any)
+		cTyped, err := c.TypeCheck(ctx, semaCtx, types.AnyElement)
 		if err != nil {
 			panic(err)
 		}

--- a/pkg/sql/opt/testutils/testcat/table_expr.go
+++ b/pkg/sql/opt/testutils/testcat/table_expr.go
@@ -52,7 +52,7 @@ func typeCheckTableExpr(e tree.Expr, cols []cat.Column) *types.T {
 	}
 	ctx := context.Background()
 	semaCtx := tree.MakeSemaContext(nil /* resolver */)
-	typedExpr, err := resolved.TypeCheck(ctx, &semaCtx, types.Any)
+	typedExpr, err := resolved.TypeCheck(ctx, &semaCtx, types.AnyElement)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -497,7 +497,7 @@ https://www.postgresql.org/docs/12/catalog-pg-attribute.html`,
 		// Add a dropped entry for any attribute numbers in the middle that are
 		// missing, assuming there are any numeric gaps in the number of columns
 		// observed.
-		missingColumnType := types.Any
+		missingColumnType := types.AnyElement
 		if populatedColumns.Len() != maxPGAttributeNum {
 			for colOrdinal := 1; colOrdinal <= maxPGAttributeNum; colOrdinal++ {
 				if populatedColumns.Contains(colOrdinal) {
@@ -2613,7 +2613,7 @@ func addPgProcBuiltinRow(name string, addRow func(...tree.Datum) error) error {
 			variadicType = tree.NewDOid(v.VarType.Oid())
 		case tree.HomogeneousType:
 			argmodes = getVariadicStringArray()
-			variadicType = tree.NewDOid(types.Any.Oid())
+			variadicType = tree.NewDOid(types.AnyElement.Oid())
 		default:
 			argmodes = tree.DNull
 			variadicType = oidZero

--- a/pkg/sql/pgwire/encoding_test.go
+++ b/pkg/sql/pgwire/encoding_test.go
@@ -73,7 +73,7 @@ func readEncodingTests(t testing.TB) []*encodingTest {
 			t.Fatal("expected 1 expr")
 		}
 		expr := selectClause.Exprs[0].Expr
-		te, err := expr.TypeCheck(ctx, &sema, types.Any)
+		te, err := expr.TypeCheck(ctx, &sema, types.AnyElement)
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/sql/physicalplan/aggregator_funcs.go
+++ b/pkg/sql/physicalplan/aggregator_funcs.go
@@ -137,7 +137,7 @@ var DistAggregationTable = map[execinfrapb.AggregatorSpec_Func]DistAggregationIn
 			}
 			semaCtx := tree.MakeSemaContext(nil /* resolver */)
 			semaCtx.IVarContainer = h.Container()
-			return expr.TypeCheck(context.TODO(), &semaCtx, types.Any)
+			return expr.TypeCheck(context.TODO(), &semaCtx, types.AnyElement)
 		},
 	},
 

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/create_index.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/create_index.go
@@ -860,7 +860,7 @@ func maybeCreateVirtualColumnForIndex(
 	// Infer column type from expression.
 	{
 		replacedExpr := b.ComputedColumnExpression(tbl, d)
-		typedExpr, err := tree.TypeCheck(b, replacedExpr, b.SemaCtx(), types.Any)
+		typedExpr, err := tree.TypeCheck(b, replacedExpr, b.SemaCtx(), types.AnyElement)
 		if err != nil {
 			panic(err)
 		}

--- a/pkg/sql/schemachanger/scexec/scmutationexec/column.go
+++ b/pkg/sql/schemachanger/scexec/scmutationexec/column.go
@@ -264,7 +264,7 @@ func (i *immediateVisitor) RemoveDroppedColumnType(
 		return err
 	}
 	col := mut.AsColumn().ColumnDesc()
-	col.Type = types.Any
+	col.Type = types.AnyElement
 	if col.IsComputed() {
 		clearComputedExpr(col)
 	}

--- a/pkg/sql/schemachanger/screl/scalars_test.go
+++ b/pkg/sql/schemachanger/screl/scalars_test.go
@@ -75,7 +75,7 @@ func TestAllDescIDsAndContainsDescID(t *testing.T) {
 				TableID:  1,
 				ColumnID: 10,
 				TypeT: scpb.TypeT{
-					Type:          types.Any,
+					Type:          types.AnyElement,
 					ClosedTypeIDs: []catid.DescID{2, 3},
 				},
 			},
@@ -87,7 +87,7 @@ func TestAllDescIDsAndContainsDescID(t *testing.T) {
 				TableID:  1,
 				ColumnID: 10,
 				TypeT: scpb.TypeT{
-					Type:          types.Any,
+					Type:          types.AnyElement,
 					ClosedTypeIDs: []catid.DescID{2, 3},
 				},
 				ComputeExpr: &scpb.Expression{

--- a/pkg/sql/sem/asof/type_check.go
+++ b/pkg/sql/sem/asof/type_check.go
@@ -28,7 +28,7 @@ import (
 func TypeCheckSystemTimeExpr(
 	ctx context.Context, semaCtx *tree.SemaContext, systemTimeExpr tree.Expr, op string,
 ) (tree.TypedExpr, error) {
-	typedExpr, err := tree.TypeCheckAndRequire(ctx, systemTimeExpr, semaCtx, types.Any, op)
+	typedExpr, err := tree.TypeCheckAndRequire(ctx, systemTimeExpr, semaCtx, types.AnyElement, op)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/sem/builtins/aggregate_builtins.go
+++ b/pkg/sql/sem/builtins/aggregate_builtins.go
@@ -347,7 +347,7 @@ var aggregates = map[string]builtinDefinition{
 	),
 
 	"count": makeBuiltin(tree.FunctionProperties{},
-		makeAggOverload([]*types.T{types.Any}, types.Int, newCountAggregate,
+		makeAggOverload([]*types.T{types.AnyElement}, types.Int, newCountAggregate,
 			"Calculates the number of selected elements.", volatility.Immutable, true /* calledOnNullInput */),
 	),
 
@@ -526,21 +526,21 @@ var aggregates = map[string]builtinDefinition{
 	),
 
 	"json_agg": makeBuiltin(tree.FunctionProperties{},
-		makeAggOverload([]*types.T{types.Any}, types.Jsonb, newJSONAggregate,
+		makeAggOverload([]*types.T{types.AnyElement}, types.Jsonb, newJSONAggregate,
 			"Aggregates values as a JSON or JSONB array.", volatility.Stable, true /* calledOnNullInput */),
 	),
 
 	"jsonb_agg": makeBuiltin(tree.FunctionProperties{},
-		makeAggOverload([]*types.T{types.Any}, types.Jsonb, newJSONAggregate,
+		makeAggOverload([]*types.T{types.AnyElement}, types.Jsonb, newJSONAggregate,
 			"Aggregates values as a JSON or JSONB array.", volatility.Stable, true /* calledOnNullInput */),
 	),
 
 	"json_object_agg": makeBuiltin(tree.FunctionProperties{},
-		makeAggOverload([]*types.T{types.String, types.Any}, types.Jsonb, newJSONObjectAggregate,
+		makeAggOverload([]*types.T{types.String, types.AnyElement}, types.Jsonb, newJSONObjectAggregate,
 			"Aggregates values as a JSON or JSONB object.", volatility.Stable, true /* calledOnNullInput */),
 	),
 	"jsonb_object_agg": makeBuiltin(tree.FunctionProperties{},
-		makeAggOverload([]*types.T{types.String, types.Any}, types.Jsonb, newJSONObjectAggregate,
+		makeAggOverload([]*types.T{types.String, types.AnyElement}, types.Jsonb, newJSONObjectAggregate,
 			"Aggregates values as a JSON or JSONB object.", volatility.Stable, true /* calledOnNullInput */),
 	),
 
@@ -591,7 +591,7 @@ var aggregates = map[string]builtinDefinition{
 
 	AnyNotNull: makePrivate(makeBuiltin(tree.FunctionProperties{},
 		makeImmutableAggOverloadWithReturnType(
-			[]*types.T{types.Any},
+			[]*types.T{types.AnyElement},
 			tree.IdentityReturnType(0),
 			newAnyNotNullAggregate,
 			"Returns an arbitrary not-NULL value, or NULL if none exists.",

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -392,7 +392,7 @@ var regularBuiltins = map[string]builtinDefinition{
 	"concat": makeBuiltin(
 		defProps(),
 		tree.Overload{
-			Types:      tree.VariadicType{VarType: types.Any},
+			Types:      tree.VariadicType{VarType: types.AnyElement},
 			ReturnType: tree.FixedReturnType(types.String),
 			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				ctx := tree.NewFmtCtx(tree.FmtPgwireText)
@@ -1954,7 +1954,7 @@ var regularBuiltins = map[string]builtinDefinition{
 			Volatility: volatility.Immutable,
 		},
 		tree.Overload{
-			Types:      tree.ParamTypes{{Name: "val", Typ: types.Any}},
+			Types:      tree.ParamTypes{{Name: "val", Typ: types.AnyElement}},
 			ReturnType: tree.FixedReturnType(types.String),
 			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				// PostgreSQL specifies that this variant first casts to the SQL string type,
@@ -1992,7 +1992,7 @@ var regularBuiltins = map[string]builtinDefinition{
 			CalledOnNullInput: true,
 		},
 		tree.Overload{
-			Types:      tree.ParamTypes{{Name: "val", Typ: types.Any}},
+			Types:      tree.ParamTypes{{Name: "val", Typ: types.AnyElement}},
 			ReturnType: tree.FixedReturnType(types.String),
 			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				if args[0] == tree.DNull {
@@ -4438,7 +4438,7 @@ value if you rely on the HLC for accuracy.`,
 			// Note that datums_to_bytes(a) == datums_to_bytes(b) iff (a IS NOT DISTINCT FROM b)
 			Info: "Converts datums into key-encoded bytes. " +
 				"Supports NULLs and all data types which may be used in index keys",
-			Types:      tree.VariadicType{VarType: types.Any},
+			Types:      tree.VariadicType{VarType: types.AnyElement},
 			ReturnType: tree.FixedReturnType(types.Bytes),
 			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				var out []byte
@@ -5303,7 +5303,7 @@ DO NOT USE -- USE 'CREATE VIRTUAL CLUSTER' INSTEAD`,
 			Types: tree.ParamTypes{
 				{Name: "table_id", Typ: types.Int},
 				{Name: "index_id", Typ: types.Int},
-				{Name: "row_tuple", Typ: types.Any},
+				{Name: "row_tuple", Typ: types.AnyElement},
 			},
 			ReturnType: tree.FixedReturnType(types.Bytes),
 			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
@@ -6571,8 +6571,8 @@ SELECT
 		},
 		tree.Overload{
 			Types: tree.ParamTypes{
-				{Name: "val", Typ: types.Any},
-				{Name: "type", Typ: types.Any},
+				{Name: "val", Typ: types.AnyElement},
+				{Name: "type", Typ: types.AnyElement},
 			},
 			ReturnType: tree.IdentityReturnType(1),
 			FnWithExprs: eval.FnWithExprsOverload(func(
@@ -7171,7 +7171,7 @@ Parameters:` + randgencfg.ConfigDoc,
 		},
 		tree.Overload{
 			Types: tree.VariadicType{
-				VarType: types.Any,
+				VarType: types.AnyElement,
 			},
 			ReturnType: tree.FixedReturnType(types.Int),
 			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
@@ -7194,7 +7194,7 @@ Parameters:` + randgencfg.ConfigDoc,
 		},
 		tree.Overload{
 			Types: tree.VariadicType{
-				VarType: types.Any,
+				VarType: types.AnyElement,
 			},
 			ReturnType: tree.FixedReturnType(types.Int),
 			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
@@ -8784,7 +8784,7 @@ specified store on the node it's run from. One of 'mvccGC', 'merge', 'split',
 				{Name: "name", Typ: types.RefCursor},
 				{Name: "direction", Typ: types.Int},
 				{Name: "count", Typ: types.Int},
-				{Name: "resultTypes", Typ: types.Any},
+				{Name: "resultTypes", Typ: types.AnyElement},
 			},
 			ReturnType: tree.IdentityReturnType(3),
 			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
@@ -9191,7 +9191,7 @@ func makeSubStringImpls() builtinDefinition {
 
 var formatImpls = makeBuiltin(tree.FunctionProperties{Category: builtinconstants.CategoryString},
 	tree.Overload{
-		Types:      tree.VariadicType{FixedTypes: []*types.T{types.String}, VarType: types.Any},
+		Types:      tree.VariadicType{FixedTypes: []*types.T{types.String}, VarType: types.AnyElement},
 		ReturnType: tree.FixedReturnType(types.String),
 		Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 			if args[0] == tree.DNull {
@@ -9902,7 +9902,7 @@ func jsonProps() tree.FunctionProperties {
 }
 
 var jsonBuildObjectImpl = tree.Overload{
-	Types:      tree.VariadicType{VarType: types.Any},
+	Types:      tree.VariadicType{VarType: types.AnyElement},
 	ReturnType: tree.FixedReturnType(types.Jsonb),
 	Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 		if len(args)%2 != 0 {
@@ -9945,7 +9945,7 @@ var jsonBuildObjectImpl = tree.Overload{
 }
 
 var toJSONImpl = tree.Overload{
-	Types:      tree.ParamTypes{{Name: "val", Typ: types.Any}},
+	Types:      tree.ParamTypes{{Name: "val", Typ: types.AnyElement}},
 	ReturnType: tree.FixedReturnType(types.Jsonb),
 	Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 		return toJSONObject(evalCtx, args[0])
@@ -9980,7 +9980,7 @@ var arrayToJSONImpls = makeBuiltin(jsonProps(),
 )
 
 var jsonBuildArrayImpl = tree.Overload{
-	Types:      tree.VariadicType{VarType: types.Any},
+	Types:      tree.VariadicType{VarType: types.AnyElement},
 	ReturnType: tree.FixedReturnType(types.Jsonb),
 	Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 		builder := json.NewArrayBuilder(len(args))

--- a/pkg/sql/sem/builtins/generator_builtins.go
+++ b/pkg/sql/sem/builtins/generator_builtins.go
@@ -1399,7 +1399,7 @@ func (s *subscriptsValueGenerator) Values() (tree.Datums, error) {
 // EmptyGenerator returns a new, empty generator. Used when a SRF
 // evaluates to NULL.
 func EmptyGenerator() eval.ValueGenerator {
-	return &arrayValueGenerator{array: tree.NewDArray(types.Any)}
+	return &arrayValueGenerator{array: tree.NewDArray(types.AnyElement)}
 }
 
 // NullGenerator returns a new generator that returns a single row of nulls
@@ -1765,7 +1765,7 @@ func makeJSONPopulateImpl(gen eval.GeneratorWithExprsOverload, info string) tree
 		// structure. The first argument is an arbitrary tuple type, which is used
 		// to set the columns of the output when the builtin is used as a FROM
 		// source, or used as-is when it's used as an ordinary projection. To match
-		// PostgreSQL, the argument actually is types.Any, and its tuple-ness is
+		// PostgreSQL, the argument actually is types.AnyElement, and its tuple-ness is
 		// checked at execution time.
 		// The second argument is a JSON object or array of objects. The builtin
 		// transforms the JSON in the second argument into the tuple in the first
@@ -1776,7 +1776,7 @@ func makeJSONPopulateImpl(gen eval.GeneratorWithExprsOverload, info string) tree
 		// the default values of each field will be NULL.
 		// The second argument can also be null, in which case the first argument
 		// is returned as-is.
-		Types:              tree.ParamTypes{{Name: "base", Typ: types.Any}, {Name: "from_json", Typ: types.Jsonb}},
+		Types:              tree.ParamTypes{{Name: "base", Typ: types.AnyElement}, {Name: "from_json", Typ: types.Jsonb}},
 		ReturnType:         tree.IdentityReturnType(0),
 		GeneratorWithExprs: gen,
 		Class:              tree.GeneratorClass,

--- a/pkg/sql/sem/builtins/math_builtins.go
+++ b/pkg/sql/sem/builtins/math_builtins.go
@@ -593,7 +593,7 @@ var mathBuiltins = map[string]builtinDefinition{
 			Volatility: volatility.Immutable,
 		},
 		tree.Overload{
-			Types:      tree.ParamTypes{{Name: "operand", Typ: types.Any}, {Name: "thresholds", Typ: types.AnyArray}},
+			Types:      tree.ParamTypes{{Name: "operand", Typ: types.AnyElement}, {Name: "thresholds", Typ: types.AnyArray}},
 			ReturnType: tree.FixedReturnType(types.Int),
 			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				operand := args[0]

--- a/pkg/sql/sem/builtins/pg_builtins.go
+++ b/pkg/sql/sem/builtins/pg_builtins.go
@@ -65,7 +65,7 @@ func makeNotUsableFalseBuiltin() builtinDefinition {
 // programmatically determine whether or not this underscore is present, hence
 // the existence of this map.
 var typeBuiltinsHaveUnderscore = map[oid.Oid]struct{}{
-	types.Any.Oid():         {},
+	types.AnyElement.Oid():  {},
 	types.AnyArray.Oid():    {},
 	types.Date.Oid():        {},
 	types.Time.Oid():        {},
@@ -297,11 +297,11 @@ func makeTypeIOBuiltins(builtinPrefix string, typ *types.T) map[string]builtinDe
 		// Note: PG takes type 2281 "internal" for these builtins, which we don't
 		// provide. We won't implement these functions anyway, so it shouldn't
 		// matter.
-		builtinPrefix + "recv": makeTypeIOBuiltin(tree.ParamTypes{{Name: "input", Typ: types.Any}}, typ),
+		builtinPrefix + "recv": makeTypeIOBuiltin(tree.ParamTypes{{Name: "input", Typ: types.AnyElement}}, typ),
 		// Note: PG returns 'cstring' for these builtins, but we don't support that.
 		builtinPrefix + "out": makeTypeIOBuiltin(tree.ParamTypes{{Name: typname, Typ: typ}}, types.Bytes),
 		// Note: PG takes 'cstring' for these builtins, but we don't support that.
-		builtinPrefix + "in": makeTypeIOBuiltin(tree.ParamTypes{{Name: "input", Typ: types.Any}}, typ),
+		builtinPrefix + "in": makeTypeIOBuiltin(tree.ParamTypes{{Name: "input", Typ: types.AnyElement}}, typ),
 	}
 }
 
@@ -979,7 +979,7 @@ var pgBuiltins = map[string]builtinDefinition{
 	// TODO(bram): Make sure the reported type is correct for tuples. See #25523.
 	"pg_typeof": makeBuiltin(defProps(),
 		tree.Overload{
-			Types:      tree.ParamTypes{{Name: "val", Typ: types.Any}},
+			Types:      tree.ParamTypes{{Name: "val", Typ: types.AnyElement}},
 			ReturnType: tree.FixedReturnType(types.String),
 			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				return tree.NewDString(args[0].ResolvedType().SQLStandardName()), nil
@@ -994,7 +994,7 @@ var pgBuiltins = map[string]builtinDefinition{
 	"pg_collation_for": makeBuiltin(
 		tree.FunctionProperties{Category: builtinconstants.CategoryString},
 		tree.Overload{
-			Types:      tree.ParamTypes{{Name: "str", Typ: types.Any}},
+			Types:      tree.ParamTypes{{Name: "str", Typ: types.AnyElement}},
 			ReturnType: tree.FixedReturnType(types.String),
 			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
 				var collation string
@@ -2038,7 +2038,7 @@ var pgBuiltins = map[string]builtinDefinition{
 	"pg_column_size": makeBuiltin(defProps(),
 		tree.Overload{
 			Types: tree.VariadicType{
-				VarType: types.Any,
+				VarType: types.AnyElement,
 			},
 			ReturnType: tree.FixedReturnType(types.Int),
 			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {

--- a/pkg/sql/sem/cast/cast_test.go
+++ b/pkg/sql/sem/cast/cast_test.go
@@ -201,7 +201,7 @@ func TestTupleCastVolatility(t *testing.T) {
 		},
 		{
 			from: []*types.T{types.Int, types.Int},
-			to:   []*types.T{types.Any},
+			to:   []*types.T{types.AnyElement},
 			exp:  "stable",
 		},
 		{

--- a/pkg/sql/sem/eval/context.go
+++ b/pkg/sql/sem/eval/context.go
@@ -819,7 +819,7 @@ func (ec *Context) BoundedStaleness() bool {
 }
 
 // ensureExpectedType will return an error if a datum does not match the
-// provided type. If the expected type is Any or if the datum is a Null
+// provided type. If the expected type is AnyElement or if the datum is a Null
 // type, then no error will be returned.
 func ensureExpectedType(exp *types.T, d tree.Datum) error {
 	if !(exp.Family() == types.AnyFamily || d.ResolvedType().Family() == types.UnknownFamily ||

--- a/pkg/sql/sem/eval/eval_test.go
+++ b/pkg/sql/sem/eval/eval_test.go
@@ -80,7 +80,7 @@ func TestEval(t *testing.T) {
 		walkExpr(t, func(e tree.Expr) (tree.TypedExpr, error) {
 			// expr.TypeCheck to avoid constant folding.
 			semaCtx := tree.MakeSemaContext(nil /* resolver */)
-			typedExpr, err := e.TypeCheck(ctx, &semaCtx, types.Any)
+			typedExpr, err := e.TypeCheck(ctx, &semaCtx, types.AnyElement)
 			if err != nil {
 				return nil, err
 			}
@@ -359,7 +359,7 @@ func TestEvalError(t *testing.T) {
 			t.Fatalf("%s: %v", d.expr, err)
 		}
 		semaCtx := tree.MakeSemaContext(nil /* resolver */)
-		typedExpr, err := tree.TypeCheck(ctx, expr, &semaCtx, types.Any)
+		typedExpr, err := tree.TypeCheck(ctx, expr, &semaCtx, types.AnyElement)
 		if err == nil {
 			evalCtx := eval.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
 			defer evalCtx.Stop(ctx)

--- a/pkg/sql/sem/eval/eval_test/eval_test.go
+++ b/pkg/sql/sem/eval/eval_test/eval_test.go
@@ -95,7 +95,7 @@ func TestEval(t *testing.T) {
 			}
 			// expr.TypeCheck to avoid constant folding.
 			semaCtx := tree.MakeSemaContext(nil /* resolver */)
-			typedExpr, err := expr.TypeCheck(ctx, &semaCtx, types.Any)
+			typedExpr, err := expr.TypeCheck(ctx, &semaCtx, types.AnyElement)
 			if err != nil {
 				// An error here should have been found above by QueryRow.
 				t.Fatal(err)
@@ -112,7 +112,7 @@ func TestEval(t *testing.T) {
 						continue
 					}
 					// Figure out the type of the tuple value.
-					expr, err := tuple.Exprs[i].TypeCheck(ctx, &semaCtx, types.Any)
+					expr, err := tuple.Exprs[i].TypeCheck(ctx, &semaCtx, types.AnyElement)
 					if err != nil {
 						t.Fatal(err)
 					}
@@ -156,7 +156,7 @@ func TestEval(t *testing.T) {
 				return strings.TrimSpace(d.Expected)
 			}
 			semaCtx := tree.MakeSemaContext(nil /* resolver */)
-			typedExpr, err := expr.TypeCheck(ctx, &semaCtx, types.Any)
+			typedExpr, err := expr.TypeCheck(ctx, &semaCtx, types.AnyElement)
 			if err != nil {
 				// Skip this test as it's testing an expected error which would be
 				// caught before execution.

--- a/pkg/sql/sem/eval/parse_doid.go
+++ b/pkg/sql/sem/eval/parse_doid.go
@@ -110,16 +110,16 @@ func ParseDOid(ctx context.Context, evalCtx *Context, s string, t *types.T) (*tr
 
 		if len(fd.Overloads) == 1 {
 			// This is a hack to be compatible with some ORMs which depends on some
-			// builtin function not implemented in CRDB. We just use `Any` as the arg
+			// builtin function not implemented in CRDB. We just use `AnyElement` as the arg
 			// type while some ORMs sends more meaningful function signatures whose
-			// arg type list mismatch with `Any` type. For this case we just
+			// arg type list mismatch with `AnyElement` type. For this case we just
 			// short-circuit it to return the oid. For example, `array_in` is defined
-			// to take in a `Any` type, but some ORM sends
+			// to take in a `AnyElement` type, but some ORM sends
 			// `'array_in(cstring,oid,integer)'::REGPROCEDURE` for introspection.
 			ol := fd.Overloads[0]
 			if !catid.IsOIDUserDefined(ol.Oid) &&
 				ol.Types.Length() == 1 &&
-				ol.Types.GetAt(0).Identical(types.Any) {
+				ol.Types.GetAt(0).Identical(types.AnyElement) {
 				return tree.NewDOidWithTypeAndName(ol.Oid, t, fd.Name), nil
 			}
 		}

--- a/pkg/sql/sem/normalize/constant_eval_test.go
+++ b/pkg/sql/sem/normalize/constant_eval_test.go
@@ -32,7 +32,7 @@ func TestConstantEvalArrayComparison(t *testing.T) {
 	}
 
 	semaCtx := tree.MakeSemaContext(nil /* resolver */)
-	typedExpr, err := expr.TypeCheck(context.Background(), &semaCtx, types.Any)
+	typedExpr, err := expr.TypeCheck(context.Background(), &semaCtx, types.AnyElement)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/sql/sem/normalize/normalize_test.go
+++ b/pkg/sql/sem/normalize/normalize_test.go
@@ -224,7 +224,7 @@ func TestNormalizeExpr(t *testing.T) {
 			if err != nil {
 				t.Fatalf("%s: %v", d.expr, err)
 			}
-			typedExpr, err := expr.TypeCheck(ctx, &semaCtx, types.Any)
+			typedExpr, err := expr.TypeCheck(ctx, &semaCtx, types.AnyElement)
 			if err != nil {
 				t.Fatalf("%s: %v", d.expr, err)
 			}

--- a/pkg/sql/sem/tree/collatedstring_test.go
+++ b/pkg/sql/sem/tree/collatedstring_test.go
@@ -39,7 +39,7 @@ func TestCastToCollatedString(t *testing.T) {
 				SyntaxMode: tree.CastShort,
 			}
 			semaCtx := tree.MakeSemaContext(nil /* resolver */)
-			typedexpr, err := expr.TypeCheck(ctx, &semaCtx, types.Any)
+			typedexpr, err := expr.TypeCheck(ctx, &semaCtx, types.AnyElement)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/sql/sem/tree/compare_test.go
+++ b/pkg/sql/sem/tree/compare_test.go
@@ -53,7 +53,7 @@ func TestEvalComparisonExprCaching(t *testing.T) {
 		ctx := eval.NewTestingEvalContext(cluster.MakeTestingClusterSettings())
 		defer ctx.Stop(context.Background())
 		ctx.ReCache = tree.NewRegexpCache(8)
-		typedExpr, err := tree.TypeCheck(context.Background(), expr, nil, types.Any)
+		typedExpr, err := tree.TypeCheck(context.Background(), expr, nil, types.AnyElement)
 		if err != nil {
 			t.Fatalf("%v: %v", d, err)
 		}

--- a/pkg/sql/sem/tree/datum_integration_test.go
+++ b/pkg/sql/sem/tree/datum_integration_test.go
@@ -41,7 +41,7 @@ func prepareExpr(t *testing.T, datumExpr string) tree.Datum {
 	// annotations have come into effect.
 	ctx := context.Background()
 	sema := tree.MakeSemaContext(nil /* resolver */)
-	typedExpr, err := tree.TypeCheck(ctx, expr, &sema, types.Any)
+	typedExpr, err := tree.TypeCheck(ctx, expr, &sema, types.AnyElement)
 	if err != nil {
 		t.Fatalf("%s: %v", datumExpr, err)
 	}

--- a/pkg/sql/sem/tree/expr.go
+++ b/pkg/sql/sem/tree/expr.go
@@ -39,7 +39,7 @@ type Expr interface {
 	// The semaCtx parameter defines the context in which to perform type checking.
 	// The desired parameter hints the desired type that the method's caller wants from
 	// the resulting TypedExpr. It is not valid to call TypeCheck with a nil desired
-	// type. Instead, call it with wildcard type types.Any if no specific type is
+	// type. Instead, call it with wildcard type types.AnyElement if no specific type is
 	// desired. This restriction is also true of most methods and functions related
 	// to type checking.
 	TypeCheck(ctx context.Context, semaCtx *SemaContext, desired *types.T) (TypedExpr, error)
@@ -808,7 +808,7 @@ func (node *Placeholder) Format(ctx *FmtCtx) {
 // ResolvedType implements the TypedExpr interface.
 func (node *Placeholder) ResolvedType() *types.T {
 	if node.typ == nil {
-		return types.Any
+		return types.AnyElement
 	}
 	return node.typ
 }
@@ -966,7 +966,7 @@ type Subquery struct {
 // ResolvedType implements the TypedExpr interface.
 func (node *Subquery) ResolvedType() *types.T {
 	if node.typ == nil {
-		return types.Any
+		return types.AnyElement
 	}
 	return node.typ
 }

--- a/pkg/sql/sem/tree/expr_test.go
+++ b/pkg/sql/sem/tree/expr_test.go
@@ -148,7 +148,7 @@ func TestExprString(t *testing.T) {
 		if err != nil {
 			t.Fatalf("%s: %v", exprStr, err)
 		}
-		typedExpr, err := tree.TypeCheck(ctx, expr, nil, types.Any)
+		typedExpr, err := tree.TypeCheck(ctx, expr, nil, types.AnyElement)
 		if err != nil {
 			t.Fatalf("%s: %v", expr, err)
 		}
@@ -158,7 +158,7 @@ func TestExprString(t *testing.T) {
 		if err != nil {
 			t.Fatalf("%s: %v", exprStr, err)
 		}
-		typedExpr2, err := tree.TypeCheck(ctx, expr2, nil, types.Any)
+		typedExpr2, err := tree.TypeCheck(ctx, expr2, nil, types.AnyElement)
 		if err != nil {
 			t.Fatalf("%s: %v", expr2, err)
 		}

--- a/pkg/sql/sem/tree/format_test.go
+++ b/pkg/sql/sem/tree/format_test.go
@@ -238,7 +238,7 @@ func TestFormatExpr(t *testing.T) {
 				t.Fatal(err)
 			}
 			semaContext := tree.MakeSemaContext(nil /* resolver */)
-			typeChecked, err := tree.TypeCheck(ctx, expr, &semaContext, types.Any)
+			typeChecked, err := tree.TypeCheck(ctx, expr, &semaContext, types.AnyElement)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -424,7 +424,7 @@ func TestFormatExpr2(t *testing.T) {
 	for i, test := range testData {
 		t.Run(fmt.Sprintf("%d %s", i, test.expr), func(t *testing.T) {
 			semaCtx := tree.MakeSemaContext(nil /* resolver */)
-			typeChecked, err := tree.TypeCheck(ctx, test.expr, &semaCtx, types.Any)
+			typeChecked, err := tree.TypeCheck(ctx, test.expr, &semaCtx, types.AnyElement)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -485,7 +485,7 @@ func TestFormatPgwireText(t *testing.T) {
 				t.Fatal(err)
 			}
 			semaCtx := tree.MakeSemaContext(nil /* resolver */)
-			typeChecked, err := tree.TypeCheck(ctx, expr, &semaCtx, types.Any)
+			typeChecked, err := tree.TypeCheck(ctx, expr, &semaCtx, types.AnyElement)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/sql/sem/tree/indexed_vars_test.go
+++ b/pkg/sql/sem/tree/indexed_vars_test.go
@@ -55,7 +55,7 @@ func TestIndexedVars(t *testing.T) {
 	ctx := context.Background()
 	semaContext := tree.MakeSemaContext(nil /* resolver */)
 	semaContext.IVarContainer = c
-	typedExpr, err := expr.TypeCheck(ctx, &semaContext, types.Any)
+	typedExpr, err := expr.TypeCheck(ctx, &semaContext, types.AnyElement)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/sql/sem/tree/overload.go
+++ b/pkg/sql/sem/tree/overload.go
@@ -323,7 +323,7 @@ func (b Overload) defaultExprs() Exprs {
 	return b.DefaultExprs
 }
 
-// FixedReturnType returns a fixed type that the function returns, returning Any
+// FixedReturnType returns a fixed type that the function returns, returning AnyElement
 // if the return type is based on the function's arguments.
 func (b Overload) FixedReturnType() *types.T {
 	if b.ReturnType == nil {
@@ -491,7 +491,7 @@ func (p ParamTypes) MatchAt(typ *types.T, i int) bool {
 	// The parameterized types for Tuples are checked in the type checking
 	// routines before getting here, so we only need to check if the parameter
 	// type is p types.TUPLE below. This allows us to avoid defining overloads
-	// for types.Tuple{}, types.Tuple{types.Any}, types.Tuple{types.Any, types.Any},
+	// for types.Tuple{}, types.Tuple{types.AnyElement}, types.Tuple{types.AnyElement, types.AnyElement},
 	// etc. for Tuple operators.
 	if typ.Family() == types.TupleFamily {
 		typ = types.AnyTuple
@@ -601,7 +601,7 @@ func (HomogeneousType) MatchLen(l int) bool {
 
 // GetAt is part of the TypeList interface.
 func (HomogeneousType) GetAt(i int) *types.T {
-	return types.Any
+	return types.AnyElement
 }
 
 // Length is part of the TypeList interface.
@@ -611,7 +611,7 @@ func (HomogeneousType) Length() int {
 
 // Types is part of the TypeList interface.
 func (HomogeneousType) Types() []*types.T {
-	return []*types.T{types.Any}
+	return []*types.T{types.AnyElement}
 }
 
 func (HomogeneousType) String() string {
@@ -764,7 +764,7 @@ func returnTypeToFixedType(s ReturnTyper, inputTyps []TypedExpr) *types.T {
 	if t := s(inputTyps); t != UnknownReturnType {
 		return t
 	}
-	return types.Any
+	return types.AnyElement
 }
 
 type overloadTypeChecker struct {
@@ -924,7 +924,7 @@ func (s *overloadTypeChecker) typeCheckOverloadedExprs(
 	// If no overloads are provided, just type check parameters and return.
 	if numOverloads == 0 {
 		for i, ok := s.resolvableIdxs.Next(0); ok; i, ok = s.resolvableIdxs.Next(i + 1) {
-			typ, err := s.exprs[i].TypeCheck(ctx, semaCtx, types.Any)
+			typ, err := s.exprs[i].TypeCheck(ctx, semaCtx, types.AnyElement)
 			if err != nil {
 				return pgerror.Wrapf(err, pgcode.InvalidParameterValue,
 					"error type checking resolved expression:")
@@ -1028,7 +1028,7 @@ func (s *overloadTypeChecker) typeCheckOverloadedExprs(
 		}
 	}
 	for i, ok := typeableIdxs.Next(0); ok; i, ok = typeableIdxs.Next(i + 1) {
-		paramDesired := types.Any
+		paramDesired := types.AnyElement
 
 		// If all remaining candidates require the same type for this parameter,
 		// begin desiring that type for the corresponding argument expression.
@@ -1095,7 +1095,7 @@ func (s *overloadTypeChecker) typeCheckOverloadedExprs(
 		argTypes := make([]*types.T, 0, len(params))
 		outArgTypes := make([]*types.T, 0, len(outParams))
 		for i := range s.exprs {
-			typedExpr, err := s.exprs[i].TypeCheck(ctx, semaCtx, types.Any)
+			typedExpr, err := s.exprs[i].TypeCheck(ctx, semaCtx, types.AnyElement)
 			if err != nil {
 				panic(errors.HandleAsAssertionFailure(err))
 			}
@@ -1500,14 +1500,14 @@ func (s *overloadTypeChecker) typeCheckOverloadedExprs(
 			var err error
 			left := s.typedExprs[0]
 			if left == nil {
-				left, err = s.exprs[0].TypeCheck(ctx, semaCtx, types.Any)
+				left, err = s.exprs[0].TypeCheck(ctx, semaCtx, types.AnyElement)
 				if err != nil {
 					return
 				}
 			}
 			right := s.typedExprs[1]
 			if right == nil {
-				right, err = s.exprs[1].TypeCheck(ctx, semaCtx, types.Any)
+				right, err = s.exprs[1].TypeCheck(ctx, semaCtx, types.AnyElement)
 				if err != nil {
 					return
 				}
@@ -1543,14 +1543,14 @@ func (s *overloadTypeChecker) typeCheckOverloadedExprs(
 			var err error
 			left := s.typedExprs[0]
 			if left == nil {
-				left, err = s.exprs[0].TypeCheck(ctx, semaCtx, types.Any)
+				left, err = s.exprs[0].TypeCheck(ctx, semaCtx, types.AnyElement)
 				if err != nil {
 					return
 				}
 			}
 			right := s.typedExprs[1]
 			if right == nil {
-				right, err = s.exprs[1].TypeCheck(ctx, semaCtx, types.Any)
+				right, err = s.exprs[1].TypeCheck(ctx, semaCtx, types.AnyElement)
 				if err != nil {
 					return
 				}
@@ -1639,7 +1639,7 @@ func defaultTypeCheck(
 	ctx context.Context, semaCtx *SemaContext, s *overloadTypeChecker, errorOnPlaceholders bool,
 ) error {
 	for i, ok := s.constIdxs.Next(0); ok; i, ok = s.constIdxs.Next(i + 1) {
-		typ, err := s.exprs[i].TypeCheck(ctx, semaCtx, types.Any)
+		typ, err := s.exprs[i].TypeCheck(ctx, semaCtx, types.AnyElement)
 		if err != nil {
 			return pgerror.Wrapf(err, pgcode.InvalidParameterValue,
 				"error type checking constant value")
@@ -1648,7 +1648,7 @@ func defaultTypeCheck(
 	}
 	for i, ok := s.placeholderIdxs.Next(0); ok; i, ok = s.placeholderIdxs.Next(i + 1) {
 		if errorOnPlaceholders {
-			if _, err := s.exprs[i].TypeCheck(ctx, semaCtx, types.Any); err != nil {
+			if _, err := s.exprs[i].TypeCheck(ctx, semaCtx, types.AnyElement); err != nil {
 				return err
 			}
 		}

--- a/pkg/sql/sem/tree/overload_test.go
+++ b/pkg/sql/sem/tree/overload_test.go
@@ -279,7 +279,7 @@ func TestTypeCheckOverloadedExprs(t *testing.T) {
 		t.Run(fmt.Sprintf("%v/%v", d.exprs, d.overloads), func(t *testing.T) {
 			semaCtx := MakeSemaContext(nil /* resolver */)
 			semaCtx.Placeholders.Init(2 /* numPlaceholders */, nil /* typeHints */)
-			desired := types.Any
+			desired := types.AnyElement
 			if d.desired != nil {
 				desired = d.desired
 			}

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -336,14 +336,14 @@ func decorateTypeCheckError(err error, format string, a ...interface{}) error {
 // their inferred types in the provided context. The optional desired parameter can
 // be used to hint the desired type for the root of the resulting typed expression
 // tree. Like with Expr.TypeCheck, it is not valid to provide a nil desired
-// type. Instead, call it with the wildcard type types.Any if no specific type is
+// type. Instead, call it with the wildcard type types.AnyElement if no specific type is
 // desired.
 func TypeCheck(
 	ctx context.Context, expr Expr, semaCtx *SemaContext, desired *types.T,
 ) (TypedExpr, error) {
 	if desired == nil {
 		return nil, errors.AssertionFailedf(
-			"the desired type for tree.TypeCheck cannot be nil, use types.Any instead: %T", expr)
+			"the desired type for tree.TypeCheck cannot be nil, use types.AnyElement instead: %T", expr)
 	}
 
 	return expr.TypeCheck(ctx, semaCtx, desired)
@@ -470,7 +470,7 @@ func (expr *CaseExpr) TypeCheck(
 			tmpExprs = append(tmpExprs, when.Cond)
 		}
 
-		typedSubExprs, _, err := typeCheckSameTypedExprs(ctx, semaCtx, types.Any, tmpExprs...)
+		typedSubExprs, _, err := typeCheckSameTypedExprs(ctx, semaCtx, types.AnyElement, tmpExprs...)
 		if err != nil {
 			return nil, decorateTypeCheckError(err, "incompatible condition type:")
 		}
@@ -614,10 +614,10 @@ func isArrayExpr(expr Expr) bool {
 func (expr *CastExpr) TypeCheck(
 	ctx context.Context, semaCtx *SemaContext, _ *types.T,
 ) (TypedExpr, error) {
-	// The desired type provided to a CastExpr is ignored. Instead, types.Any is
+	// The desired type provided to a CastExpr is ignored. Instead, types.AnyElement is
 	// passed to the child of the cast. There are a few exceptions, described
 	// below.
-	desired := types.Any
+	desired := types.AnyElement
 	exprType, err := ResolveType(ctx, expr.Type, semaCtx.GetTypeResolver())
 	if err != nil {
 		return nil, err
@@ -739,7 +739,7 @@ func (expr *IndirectionExpr) TypeCheck(
 			if t.Slice {
 				return nil, pgerror.Newf(pgcode.DatatypeMismatch, "jsonb subscript does not support slices")
 			}
-			beginExpr, err := t.Begin.TypeCheck(ctx, semaCtx, types.Any)
+			beginExpr, err := t.Begin.TypeCheck(ctx, semaCtx, types.AnyElement)
 			if err != nil {
 				return nil, err
 			}
@@ -879,7 +879,7 @@ func (expr *ColumnAccessExpr) TypeCheck(
 	// at least this label and the element type T for this label" from
 	// the sub-expression. Of course, our type system does not support
 	// this. So drop the type constraint instead.
-	subExpr, err := expr.Expr.TypeCheck(ctx, semaCtx, types.Any)
+	subExpr, err := expr.Expr.TypeCheck(ctx, semaCtx, types.AnyElement)
 	if err != nil {
 		return nil, err
 	}
@@ -1460,7 +1460,7 @@ func (expr *FuncExpr) TypeCheck(
 	if expr.OrderBy != nil {
 		if err = expr.typeCheckWithFuncAncestor(semaCtx, func() error {
 			for i := range expr.OrderBy {
-				typedExpr, err := expr.OrderBy[i].Expr.TypeCheck(ctx, semaCtx, types.Any)
+				typedExpr, err := expr.OrderBy[i].Expr.TypeCheck(ctx, semaCtx, types.AnyElement)
 				if err != nil {
 					return err
 				}
@@ -1509,7 +1509,7 @@ func (expr *IfErrExpr) TypeCheck(
 	var retType *types.T
 	var err error
 	if expr.Else == nil {
-		typedCond, err = expr.Cond.TypeCheck(ctx, semaCtx, types.Any)
+		typedCond, err = expr.Cond.TypeCheck(ctx, semaCtx, types.AnyElement)
 		if err != nil {
 			return nil, err
 		}
@@ -1570,7 +1570,7 @@ func (expr *IfExpr) TypeCheck(
 func (expr *IsOfTypeExpr) TypeCheck(
 	ctx context.Context, semaCtx *SemaContext, desired *types.T,
 ) (TypedExpr, error) {
-	exprTyped, err := expr.Expr.TypeCheck(ctx, semaCtx, types.Any)
+	exprTyped, err := expr.Expr.TypeCheck(ctx, semaCtx, types.AnyElement)
 	if err != nil {
 		return nil, err
 	}
@@ -1605,7 +1605,7 @@ func (expr *NotExpr) TypeCheck(
 func (expr *IsNullExpr) TypeCheck(
 	ctx context.Context, semaCtx *SemaContext, desired *types.T,
 ) (TypedExpr, error) {
-	exprTyped, err := expr.Expr.TypeCheck(ctx, semaCtx, types.Any)
+	exprTyped, err := expr.Expr.TypeCheck(ctx, semaCtx, types.AnyElement)
 	if err != nil {
 		return nil, err
 	}
@@ -1618,7 +1618,7 @@ func (expr *IsNullExpr) TypeCheck(
 func (expr *IsNotNullExpr) TypeCheck(
 	ctx context.Context, semaCtx *SemaContext, desired *types.T,
 ) (TypedExpr, error) {
-	exprTyped, err := expr.Expr.TypeCheck(ctx, semaCtx, types.Any)
+	exprTyped, err := expr.Expr.TypeCheck(ctx, semaCtx, types.AnyElement)
 	if err != nil {
 		return nil, err
 	}
@@ -1884,7 +1884,7 @@ func (expr *Tuple) TypeCheck(
 	var labels []string
 	contents := make([]*types.T, len(expr.Exprs))
 	for i, subExpr := range expr.Exprs {
-		desiredElem := types.Any
+		desiredElem := types.AnyElement
 		if desired.Family() == types.TupleFamily && len(desired.TupleContents()) > i {
 			desiredElem = desired.TupleContents()[i]
 		}
@@ -1911,7 +1911,7 @@ var errAmbiguousArrayType = pgerror.Newf(pgcode.IndeterminateDatatype, "cannot d
 func (expr *Array) TypeCheck(
 	ctx context.Context, semaCtx *SemaContext, desired *types.T,
 ) (TypedExpr, error) {
-	desiredParam := types.Any
+	desiredParam := types.AnyElement
 	if desired.Family() == types.ArrayFamily {
 		desiredParam = desired.ArrayContents()
 	}
@@ -1946,7 +1946,7 @@ func (expr *Array) TypeCheck(
 func (expr *ArrayFlatten) TypeCheck(
 	ctx context.Context, semaCtx *SemaContext, desired *types.T,
 ) (TypedExpr, error) {
-	desiredParam := types.Any
+	desiredParam := types.AnyElement
 	if desired.Family() == types.ArrayFamily {
 		desiredParam = desired.ArrayContents()
 	}
@@ -2339,7 +2339,7 @@ func typeCheckComparisonOpWithSubOperator(
 		sameTypeExprs[0] = left
 		copy(sameTypeExprs[1:], array.Exprs)
 
-		typedSubExprs, retType, err := typeCheckSameTypedExprs(ctx, semaCtx, types.Any, sameTypeExprs...)
+		typedSubExprs, retType, err := typeCheckSameTypedExprs(ctx, semaCtx, types.AnyElement, sameTypeExprs...)
 		if err != nil {
 			sigWithErr := fmt.Sprintf(compExprsWithSubOpFmt, left, subOp, op, right, err)
 			return nil, nil, nil, false,
@@ -2368,7 +2368,7 @@ func typeCheckComparisonOpWithSubOperator(
 		// If the right expression is not an array constructor, we type the left
 		// expression in isolation.
 		var err error
-		leftTyped, err = left.TypeCheck(ctx, semaCtx, types.Any)
+		leftTyped, err = left.TypeCheck(ctx, semaCtx, types.AnyElement)
 		if err != nil {
 			return nil, nil, nil, false, err
 		}
@@ -2509,13 +2509,13 @@ func typeCheckComparisonOp(
 			switched = false
 		}
 		disallowSwitch = true
-		typedLeft, err = foldedLeft.TypeCheck(ctx, semaCtx, types.Any)
+		typedLeft, err = foldedLeft.TypeCheck(ctx, semaCtx, types.AnyElement)
 		if err != nil {
 			sigWithErr := fmt.Sprintf(compExprsFmt, left, op, right, err)
 			return nil, nil, nil, false,
 				pgerror.Newf(pgcode.InvalidParameterValue, unsupportedCompErrFmt, sigWithErr)
 		}
-		typedRight, err = foldedRight.TypeCheck(ctx, semaCtx, types.Any)
+		typedRight, err = foldedRight.TypeCheck(ctx, semaCtx, types.AnyElement)
 		if err != nil {
 			sigWithErr := fmt.Sprintf(compExprsFmt, left, op, right, err)
 			return nil, nil, nil, false,
@@ -2536,7 +2536,7 @@ func typeCheckComparisonOp(
 		sameTypeExprs[0] = foldedLeft
 		copy(sameTypeExprs[1:], rightTuple.Exprs)
 
-		typedSubExprs, retType, err := typeCheckSameTypedExprs(ctx, semaCtx, types.Any, sameTypeExprs...)
+		typedSubExprs, retType, err := typeCheckSameTypedExprs(ctx, semaCtx, types.AnyElement, sameTypeExprs...)
 		if err != nil {
 			sigWithErr := fmt.Sprintf(compExprsFmt, left, op, right, err)
 			return nil, nil, nil, false,
@@ -2564,7 +2564,7 @@ func typeCheckComparisonOp(
 		return typedLeft, rightTuple, fn, false, nil
 
 	case foldedOp.Symbol == treecmp.In && rightIsSubquery:
-		typedLeft, err = foldedLeft.TypeCheck(ctx, semaCtx, types.Any)
+		typedLeft, err = foldedLeft.TypeCheck(ctx, semaCtx, types.AnyElement)
 		if err != nil {
 			sigWithErr := fmt.Sprintf(compExprsFmt, left, op, right, err)
 			return nil, nil, nil, false,
@@ -2615,8 +2615,8 @@ func typeCheckComparisonOp(
 	case leftIsTuple || rightIsTuple:
 		var errLeft, errRight error
 		// Tuple must compare with a tuple type, as handled above.
-		typedLeft, errLeft = foldedLeft.TypeCheck(ctx, semaCtx, types.Any)
-		typedRight, errRight = foldedRight.TypeCheck(ctx, semaCtx, types.Any)
+		typedLeft, errLeft = foldedLeft.TypeCheck(ctx, semaCtx, types.AnyElement)
+		typedRight, errRight = foldedRight.TypeCheck(ctx, semaCtx, types.AnyElement)
 		if errLeft == nil && errRight == nil &&
 			((typedLeft.ResolvedType().Family() == types.TupleFamily &&
 				typedRight.ResolvedType().Family() != types.TupleFamily) ||
@@ -2683,9 +2683,9 @@ func typeCheckComparisonOp(
 		placeholderComparison = true
 	}
 	if !disallowSwitch && !placeholderComparison && !columnComparison {
-		_, _, err := typeCheckSameTypedExprs(ctx, semaCtx, types.Any, foldedLeft, foldedRight)
+		_, _, err := typeCheckSameTypedExprs(ctx, semaCtx, types.AnyElement, foldedLeft, foldedRight)
 		if err != nil {
-			_, _, err = typeCheckSameTypedExprs(ctx, semaCtx, types.Any, foldedRight, foldedLeft)
+			_, _, err = typeCheckSameTypedExprs(ctx, semaCtx, types.AnyElement, foldedRight, foldedLeft)
 			if err == nil {
 				s = getOverloadTypeChecker(ops, foldedRight, foldedLeft)
 				switched = !switched
@@ -2701,7 +2701,7 @@ func typeCheckComparisonOp(
 		}
 	}
 	defer s.release()
-	if err := s.typeCheckOverloadedExprs(ctx, semaCtx, types.Any, true); err != nil {
+	if err := s.typeCheckOverloadedExprs(ctx, semaCtx, types.AnyElement, true); err != nil {
 		return nil, nil, nil, false, err
 	}
 	typedSubExprs := s.typedExprs
@@ -2988,7 +2988,7 @@ func typeCheckSameTypedConsts(
 		for i, ok := s.constIdxs.Next(0); ok; i, ok = s.constIdxs.Next(i + 1) {
 			if !canConstantBecome(s.exprs[i].(Constant), typ) {
 				if required {
-					typedExpr, err := s.exprs[i].TypeCheck(s.ctx, s.semaCtx, types.Any)
+					typedExpr, err := s.exprs[i].TypeCheck(s.ctx, s.semaCtx, types.AnyElement)
 					if err != nil {
 						return nil, err
 					}
@@ -3164,7 +3164,7 @@ func typeCheckSameTypedTupleExprs(
 			sameTypeExprs = append(sameTypeExprs, expr.(*Tuple).Exprs[elemIdx])
 			sameTypeExprsIndices = append(sameTypeExprsIndices, exprIdx)
 		}
-		desiredElem := types.Any
+		desiredElem := types.AnyElement
 		if len(desired.TupleContents()) > elemIdx {
 			desiredElem = desired.TupleContents()[elemIdx]
 		}
@@ -3212,7 +3212,7 @@ func checkAllExprsAreTuplesOrNulls(ctx context.Context, semaCtx *SemaContext, ex
 		if !(isTuple || isNull) {
 			// We avoid calling TypeCheck on Tuple exprs since that causes the
 			// types to be resolved, which we only want to do later in type-checking.
-			typedExpr, err := expr.TypeCheck(ctx, semaCtx, types.Any)
+			typedExpr, err := expr.TypeCheck(ctx, semaCtx, types.AnyElement)
 			if err != nil {
 				return err
 			}

--- a/pkg/sql/sem/tree/type_check_internal_test.go
+++ b/pkg/sql/sem/tree/type_check_internal_test.go
@@ -61,7 +61,7 @@ func TestTypeCheckNormalize(t *testing.T) {
 				t.Fatal(err)
 			}
 			semaCtx := tree.MakeSemaContext(nil /* resolver */)
-			typeChecked, err := tree.TypeCheck(ctx, expr, &semaCtx, types.Any)
+			typeChecked, err := tree.TypeCheck(ctx, expr, &semaCtx, types.AnyElement)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -182,7 +182,7 @@ func attemptTypeCheckSameTypedExprs(t *testing.T, idx int, test sameTypedExprsTe
 	forEachPerm(test.exprs, 0, func(exprs []copyableExpr) {
 		semaCtx := tree.MakeSemaContext(nil /* resolver */)
 		semaCtx.Placeholders.Init(len(test.ptypes), clonePlaceholderTypes(test.ptypes))
-		desired := types.Any
+		desired := types.AnyElement
 		if test.desired != nil {
 			desired = test.desired
 		}
@@ -337,7 +337,7 @@ func TestTypeCheckSameTypedExprsError(t *testing.T) {
 		t.Run(fmt.Sprintf("test_%d", i), func(t *testing.T) {
 			semaCtx := tree.MakeSemaContext(nil /* resolver */)
 			semaCtx.Placeholders.Init(len(d.ptypes), d.ptypes)
-			desired := types.Any
+			desired := types.AnyElement
 			if d.desired != nil {
 				desired = d.desired
 			}
@@ -377,7 +377,7 @@ func TestTypeCheckSameTypedExprsImplicitCastOneWay(t *testing.T) {
 		t.Run(fmt.Sprintf("test_%d", i), func(t *testing.T) {
 			semaCtx := tree.MakeSemaContext(nil /* resolver */)
 			semaCtx.Placeholders.Init(len(d.ptypes), d.ptypes)
-			desired := types.Any
+			desired := types.AnyElement
 			if d.desired != nil {
 				desired = d.desired
 			}

--- a/pkg/sql/sem/tree/type_check_test.go
+++ b/pkg/sql/sem/tree/type_check_test.go
@@ -230,7 +230,7 @@ func TestTypeCheck(t *testing.T) {
 			}
 			semaCtx := tree.MakeSemaContext(mapResolver)
 			semaCtx.Placeholders.Init(1 /* numPlaceholders */, nil /* typeHints */)
-			typeChecked, err := tree.TypeCheck(ctx, expr, &semaCtx, types.Any)
+			typeChecked, err := tree.TypeCheck(ctx, expr, &semaCtx, types.AnyElement)
 			if err != nil {
 				t.Fatalf("%s: unexpected error %s", d.expr, err)
 			}
@@ -355,7 +355,7 @@ func TestTypeCheckError(t *testing.T) {
 				if err != nil {
 					t.Fatalf("%s: %v", d.expr, err)
 				}
-				if _, err := tree.TypeCheck(ctx, expr, &semaCtx, types.Any); !testutils.IsError(err, regexp.QuoteMeta(d.expected)) {
+				if _, err := tree.TypeCheck(ctx, expr, &semaCtx, types.AnyElement); !testutils.IsError(err, regexp.QuoteMeta(d.expected)) {
 					t.Errorf("%s: expected %s, but found %v", d.expr, d.expected, err)
 				}
 			})
@@ -364,7 +364,7 @@ func TestTypeCheckError(t *testing.T) {
 				if err != nil {
 					t.Fatalf("%s: %v", d.expr, err)
 				}
-				if _, err := tree.TypeCheck(ctx, expr, nil, types.Any); !testutils.IsError(err, regexp.QuoteMeta(d.expected)) {
+				if _, err := tree.TypeCheck(ctx, expr, nil, types.AnyElement); !testutils.IsError(err, regexp.QuoteMeta(d.expected)) {
 					t.Errorf("%s: expected %s, but found %v", d.expr, d.expected, err)
 				}
 			})
@@ -411,7 +411,7 @@ func TestTypeCheckVolatility(t *testing.T) {
 		if err != nil {
 			t.Fatalf("%s: %v", sql, err)
 		}
-		_, err = tree.TypeCheck(ctx, expr, &semaCtx, types.Any)
+		_, err = tree.TypeCheck(ctx, expr, &semaCtx, types.AnyElement)
 		return err
 	}
 
@@ -458,7 +458,7 @@ func TestTypeCheckCollatedString(t *testing.T) {
 	// the type-checker chooses the collated string overload first.
 	expr, err := parser.ParseExpr("'cat'::STRING COLLATE \"en-US-u-ks-level2\" = ($1)")
 	require.NoError(t, err)
-	typed, err := tree.TypeCheck(ctx, expr, &semaCtx, types.Any)
+	typed, err := tree.TypeCheck(ctx, expr, &semaCtx, types.AnyElement)
 	require.NoError(t, err)
 
 	rightTyp := typed.(*tree.ComparisonExpr).Right.(tree.TypedExpr).ResolvedType()
@@ -482,7 +482,7 @@ func TestTypeCheckCollatedStringNestedCaseComparison(t *testing.T) {
 		`('' COLLATE "es_ES") >= CASE WHEN false THEN CASE WHEN (NOT (false)) THEN NULL END ELSE ('' COLLATE "es_ES") END`} {
 		expr, err := parser.ParseExpr(exprStr)
 		require.NoError(t, err)
-		typed, err := tree.TypeCheck(ctx, expr, &semaCtx, types.Any)
+		typed, err := tree.TypeCheck(ctx, expr, &semaCtx, types.AnyElement)
 		require.NoError(t, err)
 
 		for _, ex := range []tree.Expr{typed.(*tree.ComparisonExpr).Left, typed.(*tree.ComparisonExpr).Right} {
@@ -508,7 +508,7 @@ func TestTypeCheckCaseExprWithPlaceholders(t *testing.T) {
 
 	expr, err := parser.ParseExpr("case when 1 < $1 then $2 else $3 end = $4")
 	require.NoError(t, err)
-	typed, err := tree.TypeCheck(ctx, expr, &semaCtx, types.Any)
+	typed, err := tree.TypeCheck(ctx, expr, &semaCtx, types.AnyElement)
 	require.NoError(t, err)
 
 	leftTyp := typed.(*tree.ComparisonExpr).Left.(tree.TypedExpr).ResolvedType()
@@ -530,7 +530,7 @@ func TestTypeCheckCaseExprWithConstantsAndUnresolvedPlaceholders(t *testing.T) {
 
 	expr, err := parser.ParseExpr("case when 1 < $1 then $2 when 1 < $3 then $4 else 3 end = $5")
 	require.NoError(t, err)
-	typed, err := tree.TypeCheck(ctx, expr, &semaCtx, types.Any)
+	typed, err := tree.TypeCheck(ctx, expr, &semaCtx, types.AnyElement)
 	require.NoError(t, err)
 
 	leftTyp := typed.(*tree.ComparisonExpr).Left.(tree.TypedExpr).ResolvedType()
@@ -560,7 +560,7 @@ func TestTypeCheckArrayWithNullAndPlaceholder(t *testing.T) {
 
 	expr, err := parser.ParseExpr("array[null, $1]::int[]")
 	require.NoError(t, err)
-	typed, err := tree.TypeCheck(ctx, expr, &semaCtx, types.Any)
+	typed, err := tree.TypeCheck(ctx, expr, &semaCtx, types.AnyElement)
 	require.NoError(t, err)
 	require.Equal(t, types.IntArray, typed.ResolvedType())
 

--- a/pkg/sql/set_cluster_setting.go
+++ b/pkg/sql/set_cluster_setting.go
@@ -265,7 +265,7 @@ func (p *planner) getAndValidateTypedClusterSetting(
 				requiredType = types.Float
 			case settings.AnyEnumSetting:
 				// EnumSettings can be set with either strings or integers.
-				requiredType = types.Any
+				requiredType = types.AnyElement
 			case *settings.DurationSetting:
 				requiredType = types.Interval
 			case *settings.DurationSettingWithExplicitUnit:

--- a/pkg/sql/storageparam/storage_param.go
+++ b/pkg/sql/storageparam/storage_param.go
@@ -65,7 +65,7 @@ func Set(
 		semaCtx.Properties.Require("table storage parameters", tree.RejectSubqueries)
 
 		// Convert the expressions to a datum.
-		typedExpr, err := tree.TypeCheck(ctx, expr, semaCtx, types.Any)
+		typedExpr, err := tree.TypeCheck(ctx, expr, semaCtx, types.AnyElement)
 		if err != nil {
 			return err
 		}

--- a/pkg/sql/types/oid.go
+++ b/pkg/sql/types/oid.go
@@ -54,7 +54,7 @@ var (
 // instead of a method so that other packages can iterate over the map directly.
 // Note that additional elements for the array Oid types are added in init().
 var OidToType = map[oid.Oid]*T{
-	oid.T_anyelement: Any,
+	oid.T_anyelement: AnyElement,
 	oid.T_bit:        typeBit,
 	oid.T_bool:       Bool,
 	oid.T_bpchar:     BPChar,

--- a/pkg/sql/types/types.go
+++ b/pkg/sql/types/types.go
@@ -582,19 +582,19 @@ var (
 		VarBit,
 	}
 
-	// Any is a special type used only during static analysis as a wildcard type
+	// AnyElement is a special type used only during static analysis as a wildcard type
 	// that matches any other type, including scalar, array, and tuple types.
 	// Execution-time values should never have this type. As an example of its
 	// use, many SQL builtin functions allow an input value to be of any type,
 	// and so use this type in their static definitions.
-	Any = &T{InternalType: InternalType{
+	AnyElement = &T{InternalType: InternalType{
 		Family: AnyFamily, Oid: oid.T_anyelement, Locale: &emptyLocale}}
 
 	// AnyArray is a special type used only during static analysis as a wildcard
 	// type that matches an array having elements of any (uniform) type (including
 	// nested array types). Execution-time values should never have this type.
 	AnyArray = &T{InternalType: InternalType{
-		Family: ArrayFamily, ArrayContents: Any, Oid: oid.T_anyarray, Locale: &emptyLocale}}
+		Family: ArrayFamily, ArrayContents: AnyElement, Oid: oid.T_anyarray, Locale: &emptyLocale}}
 
 	// AnyEnum is a special type only used during static analysis as a wildcard
 	// type that matches an possible enum value. Execution-time values should
@@ -606,7 +606,7 @@ var (
 	// type that matches a tuple with any number of fields of any type (including
 	// tuple types). Execution-time values should never have this type.
 	AnyTuple = &T{InternalType: InternalType{
-		Family: TupleFamily, TupleContents: []*T{Any}, Oid: oid.T_record, Locale: &emptyLocale}}
+		Family: TupleFamily, TupleContents: []*T{AnyElement}, Oid: oid.T_record, Locale: &emptyLocale}}
 
 	// AnyTupleArray is a special type used only during static analysis as a wildcard
 	// type that matches an array of tuples with any number of fields of any type (including
@@ -2160,7 +2160,7 @@ func fallbackFormatTypeName(UserDefinedTypeName, bool) string {
 // other attributes of equivalent types, such as width, precision, and oid, can
 // be different.
 //
-// Wildcard types (e.g. Any, AnyArray, AnyTuple, etc) have special equivalence
+// Wildcard types (e.g. AnyElement, AnyArray, AnyTuple, etc) have special equivalence
 // behavior. AnyFamily types match any other type, including other AnyFamily
 // types. And a wildcard collation (empty string) matches any other collation.
 func (t *T) Equivalent(other *T) bool {
@@ -2274,7 +2274,7 @@ func (t *T) Equal(other *T) bool {
 // static analysis, and cannot be used during execution.
 func (t *T) IsWildcardType() bool {
 	for _, wildcard := range []*T{
-		Any, AnyArray, AnyCollatedString, AnyEnum, AnyEnumArray, AnyTuple, AnyTupleArray,
+		AnyElement, AnyArray, AnyCollatedString, AnyEnum, AnyEnumArray, AnyTuple, AnyTupleArray,
 	} {
 		// Note that pointer comparison is insufficient since we might have
 		// deserialized t from disk.
@@ -2289,7 +2289,7 @@ func (t *T) IsWildcardType() bool {
 // return-type of a polymorphic function. Note that this does not include RECORD
 // (AnyTuple) or RECORD[].
 func (t *T) IsPolymorphicType() bool {
-	for _, poly := range []*T{Any, AnyArray, AnyEnum, AnyEnumArray} {
+	for _, poly := range []*T{AnyElement, AnyArray, AnyEnum, AnyEnumArray} {
 		if t.Identical(poly) {
 			return true
 		}

--- a/pkg/sql/types/types_test.go
+++ b/pkg/sql/types/types_test.go
@@ -27,9 +27,9 @@ func TestTypes(t *testing.T) {
 		expected *T
 	}{
 		// ARRAY
-		{MakeArray(Any), AnyArray},
-		{MakeArray(Any), &T{InternalType: InternalType{
-			Family: ArrayFamily, ArrayContents: Any, Oid: oid.T_anyarray, Locale: &emptyLocale}}},
+		{MakeArray(AnyElement), AnyArray},
+		{MakeArray(AnyElement), &T{InternalType: InternalType{
+			Family: ArrayFamily, ArrayContents: AnyElement, Oid: oid.T_anyarray, Locale: &emptyLocale}}},
 
 		{MakeArray(Float), FloatArray},
 		{MakeArray(Float), &T{InternalType: InternalType{
@@ -482,7 +482,7 @@ func TestTypes(t *testing.T) {
 
 		// TUPLE
 		{MakeTuple(nil), EmptyTuple},
-		{MakeTuple([]*T{Any}), AnyTuple},
+		{MakeTuple([]*T{AnyElement}), AnyTuple},
 		{MakeTuple([]*T{Int}), &T{InternalType: InternalType{
 			Family: TupleFamily, Oid: oid.T_record, TupleContents: []*T{Int}, Locale: &emptyLocale}}},
 		{MakeTuple([]*T{Int, String}), &T{InternalType: InternalType{
@@ -580,7 +580,7 @@ func TestEquivalent(t *testing.T) {
 		// BIT
 		{MakeBit(1), MakeBit(2), true},
 		{MakeBit(1), MakeVarBit(2), true},
-		{MakeVarBit(10), Any, true},
+		{MakeVarBit(10), AnyElement, true},
 		{VarBit, Bytes, false},
 
 		// COLLATEDSTRING
@@ -593,13 +593,13 @@ func TestEquivalent(t *testing.T) {
 		// DECIMAL
 		{Decimal, MakeDecimal(3, 2), true},
 		{MakeDecimal(3, 2), MakeDecimal(3, 0), true},
-		{Any, MakeDecimal(10, 0), true},
+		{AnyElement, MakeDecimal(10, 0), true},
 		{Decimal, Float, false},
 
 		// INT
 		{Int2, Int4, true},
 		{Int4, Int, true},
-		{Int, Any, true},
+		{Int, AnyElement, true},
 		{Int, IntArray, false},
 
 		// TUPLE
@@ -620,7 +620,7 @@ func TestEquivalent(t *testing.T) {
 		// UNKNOWN
 		{Unknown, &T{InternalType: InternalType{
 			Family: UnknownFamily, Oid: oid.T_unknown, Locale: &emptyLocale}}, true},
-		{Any, Unknown, true},
+		{AnyElement, Unknown, true},
 		{Unknown, Int, false},
 	}
 
@@ -667,7 +667,7 @@ func TestIdentical(t *testing.T) {
 		{MakeBit(1), MakeBit(1), true},
 		{MakeBit(1), MakeBit(2), false},
 		{MakeBit(1), MakeVarBit(1), false},
-		{MakeVarBit(10), Any, false},
+		{MakeVarBit(10), AnyElement, false},
 		{VarBit, Bytes, false},
 
 		// COLLATEDSTRING
@@ -686,7 +686,7 @@ func TestIdentical(t *testing.T) {
 		{Decimal, MakeDecimal(3, 2), false},
 		{MakeDecimal(3, 2), MakeDecimal(3, 2), true},
 		{MakeDecimal(3, 2), MakeDecimal(3, 0), false},
-		{Any, MakeDecimal(10, 0), false},
+		{AnyElement, MakeDecimal(10, 0), false},
 		{Decimal, Float, false},
 
 		// INT
@@ -694,7 +694,7 @@ func TestIdentical(t *testing.T) {
 		{Int4, Int4, true},
 		{Int2, Int4, false},
 		{Int4, Int, false},
-		{Int, Any, false},
+		{Int, AnyElement, false},
 		{Int, IntArray, false},
 
 		// TUPLE
@@ -716,7 +716,7 @@ func TestIdentical(t *testing.T) {
 		// UNKNOWN
 		{Unknown, &T{InternalType: InternalType{
 			Family: UnknownFamily, Oid: oid.T_unknown, Locale: &emptyLocale}}, true},
-		{Any, Unknown, false},
+		{AnyElement, Unknown, false},
 		{Unknown, Int, false},
 	}
 
@@ -1066,7 +1066,7 @@ func TestOidSetDuringUpgrade(t *testing.T) {
 }
 
 func TestSQLStandardName(t *testing.T) {
-	for _, typ := range append([]*T{Any, AnyArray}, Scalar...) {
+	for _, typ := range append([]*T{AnyElement, AnyArray}, Scalar...) {
 		t.Run(typ.Name(), func(t *testing.T) {
 			require.NotEmpty(t, typ.SQLStandardName())
 		})


### PR DESCRIPTION
Speaketh Tom Lane, from 2006:

""any" isn't the same as "anyelement", because it doesn't have the property of constraining different argument positions to be the same type.  For instance, compare(any,any) and compare(anyelement,anyelement) would accept different sets of input types."

https://postgrespro.com/list/thread-id/1677535

What CockroachDB refers to as types.Any is actually types.AnyElement. In order to properly implement certain builtin functions, like concat(), we need an actual types.Any implementation. Rather than break the world by changing the implementation of our current types.Any, this patch moves it out of the way for the incoming new implementation. Users of types.AnyElement can then decide on a case-by-case basis whether types.Any is more appropriate.

Informs: #136295
Release note: None