### PR TITLE
rac2,kvserver: start the StreamCloseScheduler

### DIFF
--- a/pkg/kv/kvserver/kvflowcontrol/replica_rac2/close_scheduler_test.go
+++ b/pkg/kv/kvserver/kvflowcontrol/replica_rac2/close_scheduler_test.go
@@ -84,8 +84,8 @@ func TestStreamCloseScheduler(t *testing.T) {
 			stopper = stop.NewStopper()
 			clock = timeutil.NewManualTime(timeutil.UnixEpoch)
 			raftScheduler = &testingRaftScheduler{clock: clock}
-			closeScheduler = NewStreamCloseScheduler(stopper, clock, raftScheduler)
-			require.NoError(t, closeScheduler.Start(ctx))
+			closeScheduler = NewStreamCloseScheduler(clock, raftScheduler)
+			require.NoError(t, closeScheduler.Start(ctx, stopper))
 			return fmt.Sprintf("now=%vs", clock.Now().Unix())
 
 		case "schedule":

--- a/pkg/kv/kvserver/kvflowcontrol/replica_rac2/processor.go
+++ b/pkg/kv/kvserver/kvflowcontrol/replica_rac2/processor.go
@@ -133,7 +133,7 @@ type rangeControllerInitState struct {
 // RangeControllerFactory abstracts RangeController creation for testing.
 type RangeControllerFactory interface {
 	// New creates a new RangeController.
-	New(ctx context.Context, state rangeControllerInitState) rac2.RangeController
+	New(context.Context, rangeControllerInitState) rac2.RangeController
 }
 
 // ProcessorOptions are specified when creating a new Processor.


### PR DESCRIPTION
This commit enables the `StreamCloseScheduler`, which is responsible for closing RACv2 streams some time (400ms) after they enter `StateProbe`.

The initialization had to move from `NewStore` to `Store.Start()` because it needs the `stopper` to start the job.

Epic: none
Release note: none