### PR TITLE
build: fix microbenchmark weekly fetch

### DIFF
--- a/build/teamcity/cockroach/nightlies/microbenchmark_build_support.sh
+++ b/build/teamcity/cockroach/nightlies/microbenchmark_build_support.sh
@@ -63,6 +63,7 @@ EOF
 current_sha=$(git rev-parse HEAD)
 shas=("$@")
 for sha in "${shas[@]}"; do
+  git fetch origin "$sha"
   git checkout "$sha"
   build_and_upload_binaries "$sha"
 done

--- a/build/teamcity/cockroach/nightlies/microbenchmark_weekly.sh
+++ b/build/teamcity/cockroach/nightlies/microbenchmark_weekly.sh
@@ -44,6 +44,41 @@ remote_dir="/mnt/data1"
 benchmarks_commit=$(git rev-parse HEAD)
 exit_status=0
 
+# Check if a string is a valid SHA (otherwise it's a branch or tag name).
+is_sha() {
+  local sha="$1"
+  [[ "$sha" =~ ^[0-9a-f]{40}$ ]]
+}
+
+get_latest_patch_tag() {
+  local latest_tag
+  latest_tag=$(git tag -l 'v*' \
+    | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
+    | sort -t. -k1,1 -k2,2n -k3,3n \
+    | tail -n 1)
+  echo "$latest_tag"
+}
+
+# Create arrays for the revisions and their corresponding SHAs.
+revisions=("${BENCH_REVISION}" "${BENCH_COMPARE_REVISION}")
+declare -a sha_arr
+declare -a name_arr
+for rev in "${revisions[@]}"; do
+  if [ "$rev" == "LATEST_PATCH_RELEASE" ]; then
+    git fetch origin --tags
+    rev=$(get_latest_patch_tag)
+  fi
+  if is_sha "$rev"; then
+    sha="$rev"
+    name="${sha:0:8}"
+  else
+    sha=$(git ls-remote origin "$rev" | awk '{print $1}')
+    name="$rev (${sha:0:8})"
+  fi
+  name_arr+=("$name")
+  sha_arr+=("$sha")
+done
+
 # Set up credentials
 google_credentials="$GOOGLE_EPHEMERAL_CREDENTIALS"
 log_into_gcloud
@@ -65,64 +100,6 @@ cp $BAZEL_BIN/pkg/cmd/roachprod/roachprod_/roachprod bin
 cp $BAZEL_BIN/pkg/cmd/roachprod-microbench/roachprod-microbench_/roachprod-microbench bin
 chmod a+w bin/roachprod bin/roachprod-microbench
 EOF
-
-# Check if a string is a valid SHA (otherwise it's a branch or tag name).
-is_sha() {
-  local sha="$1"
-  [[ "$sha" =~ ^[0-9a-f]{40}$ ]]
-}
-
-# Check if a string is a valid branch
-is_branch() {
-  local branch="$1"
-  git rev-parse --verify "refs/heads/$branch" >/dev/null 2>&1
-}
-
-# Check if a string is a valid tag
-is_tag() {
-  local tag="$1"
-  git rev-parse --verify "refs/tags/$tag" >/dev/null 2>&1
-}
-
-get_latest_patch_tag() {
-  local latest_tag
-  latest_tag=$(git tag -l 'v*' \
-    | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' \
-    | sort -t. -k1,1 -k2,2n -k3,3n \
-    | tail -n 1)
-  echo "$latest_tag"
-}
-
-git fetch origin --tags
-
-# Create arrays for the revisions and their corresponding SHAs.
-revisions=("${BENCH_REVISION}" "${BENCH_COMPARE_REVISION}")
-declare -a sha_arr
-declare -a name_arr
-for rev in "${revisions[@]}"; do
-  if [ "$rev" == "LATEST_PATCH_RELEASE" ]; then
-    rev=$(get_latest_patch_tag)
-  fi
-  if is_sha "$rev"; then
-    sha="$rev"
-    name="${sha:0:8}"
-  else
-    # Named revision (branch or tag)
-    if is_branch "$rev"; then
-      git fetch origin "$rev"
-      sha=$(git rev-parse origin/"$rev")
-    elif is_tag "$rev"; then
-      sha=$(git rev-parse "$rev")
-    else
-      echo "Invalid revision: $rev"
-      exit 1
-    fi
-    name="$rev (${sha:0:8})"
-  fi
-
-  name_arr+=("$name")
-  sha_arr+=("$sha")
-done
 
 # Check if the baseline cache exists and copy it to the output directory.
 baseline_cache_path="gs://$BENCH_BUCKET/cache/$GCE_MACHINE_TYPE/$SANITIZED_BENCH_PACKAGE/${sha_arr[1]}"


### PR DESCRIPTION
The fetch should happen before checking `is_branch` or `is_tag` otherwise it won't be able to find the ref.

Epic: None
Release note: None