### PR TITLE
vecindex: move randomization to index from quantizer

### DIFF
--- a/pkg/cmd/vecbench/main.go
+++ b/pkg/cmd/vecbench/main.go
@@ -502,9 +502,8 @@ func createIndex(
 		MinPartitionSize: minPartitionSize,
 		MaxPartitionSize: maxPartitionSize,
 		BaseBeamSize:     *flagBeamSize,
-		Seed:             seed,
 	}
-	index, err := vecindex.NewVectorIndex(ctx, store, quantizer, &options, stopper)
+	index, err := vecindex.NewVectorIndex(ctx, store, quantizer, seed, &options, stopper)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/sql/vecindex/fixup_worker.go
+++ b/pkg/sql/vecindex/fixup_worker.go
@@ -267,7 +267,7 @@ func (fw *fixupWorker) splitPartition(
 	if parentPartition == nil {
 		// Add a new level to the tree by setting a new root partition that points
 		// to the two new partitions.
-		centroids := vector.MakeSet(fw.index.rootQuantizer.GetRandomDims())
+		centroids := vector.MakeSet(fw.index.rootQuantizer.GetDims())
 		centroids.EnsureCapacity(2)
 		centroids.Add(leftSplit.Partition.Centroid())
 		centroids.Add(rightSplit.Partition.Centroid())
@@ -331,7 +331,7 @@ func (fw *fixupWorker) splitPartitionData(
 	centroidDistances := slices.Clone(splitPartition.QuantizedSet().GetCentroidDistances())
 	childKeys := slices.Clone(splitPartition.ChildKeys())
 
-	tempVector := fw.workspace.AllocFloats(fw.index.quantizer.GetRandomDims())
+	tempVector := fw.workspace.AllocFloats(fw.index.quantizer.GetDims())
 	defer fw.workspace.FreeFloats(tempVector)
 
 	// Any left offsets that point beyond the end of the left list indicate that
@@ -490,7 +490,7 @@ func (fw *fixupWorker) linkNearbyVectors(
 		return err
 	}
 
-	tempVector := fw.workspace.AllocVector(fw.index.quantizer.GetRandomDims())
+	tempVector := fw.workspace.AllocVector(fw.index.quantizer.GetDims())
 	defer fw.workspace.FreeVector(tempVector)
 
 	// Filter the results.
@@ -510,7 +510,7 @@ func (fw *fixupWorker) linkNearbyVectors(
 		// Leaf vectors from the primary index need to be randomized.
 		vector := result.Vector
 		if partition.Level() == vecstore.LeafLevel {
-			fw.index.quantizer.RandomizeVector(ctx, vector, tempVector, false /* invert */)
+			fw.index.randomizeVector(vector, tempVector)
 			vector = tempVector
 		}
 
@@ -699,13 +699,12 @@ func (fw *fixupWorker) getFullVectorsForPartition(
 		i--
 	}
 
-	vectors := vector.MakeSet(fw.index.quantizer.GetRandomDims())
+	vectors := vector.MakeSet(fw.index.quantizer.GetDims())
 	vectors.AddUndefined(len(fw.tempVectorsWithKeys))
 	for i := range fw.tempVectorsWithKeys {
 		// Leaf vectors from the primary index need to be randomized.
 		if partition.Level() == vecstore.LeafLevel {
-			fw.index.quantizer.RandomizeVector(
-				ctx, fw.tempVectorsWithKeys[i].Vector, vectors.At(i), false /* invert */)
+			fw.index.randomizeVector(fw.tempVectorsWithKeys[i].Vector, vectors.At(i))
 		} else {
 			copy(vectors.At(i), fw.tempVectorsWithKeys[i].Vector)
 		}

--- a/pkg/sql/vecindex/fixup_worker_test.go
+++ b/pkg/sql/vecindex/fixup_worker_test.go
@@ -27,10 +27,10 @@ func TestSplitPartitionData(t *testing.T) {
 	ctx := internal.WithWorkspace(context.Background(), &internal.Workspace{})
 	quantizer := quantize.NewRaBitQuantizer(2, 42)
 	store := vecstore.NewInMemoryStore(2, 42)
-	options := VectorIndexOptions{Seed: 42}
+	options := VectorIndexOptions{IsDeterministic: true}
 	stopper := stop.NewStopper()
 	defer stopper.Stop(ctx)
-	index, err := NewVectorIndex(ctx, store, quantizer, &options, stopper)
+	index, err := NewVectorIndex(ctx, store, quantizer, 42, &options, stopper)
 	require.NoError(t, err)
 	worker := NewFixupWorker(&index.fixups)
 

--- a/pkg/sql/vecindex/manager.go
+++ b/pkg/sql/vecindex/manager.go
@@ -127,7 +127,7 @@ func (m *Manager) Get(
 		// Use the stored context so that the VectorIndex can outlive the context of the
 		// Get call. The fixup process gets a child context from the context passed to
 		// NewVectorIndex, and we don't want that to be the context of the Get call.
-		return NewVectorIndex(m.ctx, store, quantizer, &VectorIndexOptions{}, m.stopper)
+		return NewVectorIndex(m.ctx, store, quantizer, config.Seed, &VectorIndexOptions{}, m.stopper)
 	}()
 	e.mustWait = false
 	e.idx, e.err = idx, err

--- a/pkg/sql/vecindex/quantize/rabitq.go
+++ b/pkg/sql/vecindex/quantize/rabitq.go
@@ -40,9 +40,6 @@ type RaBitQuantizer struct {
 	sqrtDims float32
 	// sqrtDimsInv precomputes "1 / sqrtDims".
 	sqrtDimsInv float32
-	// rot is a square dims x dims matrix that performs random orthogonal
-	// transformations on input vectors, in order to distribute skew more evenly.
-	rot num32.Matrix
 	// unbias is a precomputed slice of "dims" random values in the [0, 1)
 	// interval that's used to remove bias when quantizing query vectors.
 	unbias []float32
@@ -72,30 +69,6 @@ func NewRaBitQuantizer(dims int, seed int64) Quantizer {
 
 	rng := rand.New(rand.NewSource(seed))
 
-	// Generate dims x dims random orthogonal matrix to mitigate the impact of
-	// skewed input data distributions:
-	//
-	//   1. Set skew: some dimensions can have higher variance than others. For
-	//      example, perhaps all vectors in a set have similar values for one
-	//      dimension but widely differing values in another dimension.
-	//   2. Vector skew: Individual vectors can have internal skew, such that
-	//      values higher than the mean are more spread out than values lower
-	//      than the mean.
-	//
-	// Multiplying vectors by this matrix helps with both forms of skew. While
-	// total skew does not change, the skew is more evenly distributed across
-	// the dimensions. Now quantizing the vector will have more uniform
-	// information loss across dimensions. Critically, none of this impacts
-	// distance calculations, as orthogonal transformations do not change
-	// distances or angles between vectors.
-	//
-	// Ultimately, performing a random orthogonal transformation (ROT) means that
-	// the index will work more consistently across a diversity of input data
-	// sets, even those with skewed data distributions. In addition, the RaBitQ
-	// algorithm depends on the statistical properties that are granted by the
-	// ROT.
-	rot := num32.MakeRandomOrthoMatrix(rng, dims)
-
 	// Create random offsets in range [0, 1) to remove bias when quantizing
 	// query vectors.
 	unbias := make([]float32, dims)
@@ -108,30 +81,13 @@ func NewRaBitQuantizer(dims int, seed int64) Quantizer {
 		dims:        dims,
 		sqrtDims:    sqrtDims,
 		sqrtDimsInv: 1.0 / sqrtDims,
-		rot:         rot,
 		unbias:      unbias,
 	}
 }
 
 // GetOriginalDims implements the Quantizer interface.
-func (q *RaBitQuantizer) GetOriginalDims() int {
+func (q *RaBitQuantizer) GetDims() int {
 	return q.dims
-}
-
-// GetRandomDims implements the Quantizer interface.
-func (q *RaBitQuantizer) GetRandomDims() int {
-	return q.dims
-}
-
-// RandomizeVector implements the Quantizer interface.
-func (q *RaBitQuantizer) RandomizeVector(
-	ctx context.Context, input vector.T, output vector.T, invert bool,
-) {
-	if !invert {
-		num32.MulMatrixByVector(&q.rot, input, output, num32.NoTranspose)
-	} else {
-		num32.MulMatrixByVector(&q.rot, input, output, num32.Transpose)
-	}
 }
 
 // Quantize implements the Quantizer interface.
@@ -159,7 +115,7 @@ func (q *RaBitQuantizer) QuantizeInSet(
 
 // NewQuantizedVectorSet implements the Quantizer interface
 func (q *RaBitQuantizer) NewQuantizedVectorSet(capacity int, centroid vector.T) QuantizedVectorSet {
-	codeWidth := RaBitQCodeSetWidth(q.GetRandomDims())
+	codeWidth := RaBitQCodeSetWidth(q.GetDims())
 	dataBuffer := make([]uint64, 0, capacity*codeWidth)
 	if capacity <= 1 {
 		// Special case capacity of zero or one by using in-line storage.

--- a/pkg/sql/vecindex/quantize/unquantizedpb_test.go
+++ b/pkg/sql/vecindex/quantize/unquantizedpb_test.go
@@ -8,6 +8,7 @@ package quantize
 import (
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/sql/vecindex/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/vector"
 	"github.com/stretchr/testify/require"
 )
@@ -27,7 +28,7 @@ func TestUnQuantizedVectorSet(t *testing.T) {
 	vectors = vector.MakeSetFromRawData([]float32{7, 8, 9, 10}, 2)
 	quantizedSet.AddSet(vectors)
 	require.Equal(t, 5, quantizedSet.GetCount())
-	distances := roundFloats(quantizedSet.GetCentroidDistances(), 4)
+	distances := testutils.RoundFloats(quantizedSet.GetCentroidDistances(), 4)
 	require.Equal(t, []float32{3, 2.2361, 4.1231, 6.7082, 9.434}, distances)
 
 	// Ensure that cloning does not disturb anything.
@@ -40,15 +41,15 @@ func TestUnQuantizedVectorSet(t *testing.T) {
 	// Remove vector.
 	quantizedSet.ReplaceWithLast(2)
 	require.Equal(t, 4, quantizedSet.GetCount())
-	distances = roundFloats(quantizedSet.GetCentroidDistances(), 4)
+	distances = testutils.RoundFloats(quantizedSet.GetCentroidDistances(), 4)
 	require.Equal(t, []float32{3, 2.2361, 9.434, 6.7082}, distances)
 
 	// ComputeSquaredDistances on vectors.
 	quantizedSet.ComputeSquaredDistances(vector.T{-1, 1}, distances)
-	require.Equal(t, []float32{5, 25, 181, 113}, roundFloats(distances, 4))
+	require.Equal(t, []float32{5, 25, 181, 113}, testutils.RoundFloats(distances, 4))
 
 	// Check that clone is unaffected.
 	require.Equal(t, []float32{10, 2}, cloned.Centroid)
-	require.Equal(t, []float32{10, 9.43, 4.12, 6.71}, roundFloats(cloned.CentroidDistances, 2))
+	require.Equal(t, []float32{10, 9.43, 4.12, 6.71}, testutils.RoundFloats(cloned.CentroidDistances, 2))
 	require.Equal(t, vector.Set{Dims: 2, Count: 4, Data: []float32{0, 0, 9, 10, 5, 6, 7, 8}}, cloned.Vectors)
 }

--- a/pkg/sql/vecindex/quantize/unquantizer.go
+++ b/pkg/sql/vecindex/quantize/unquantizer.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/util/num32"
 	"github.com/cockroachdb/cockroach/pkg/util/vector"
-	"github.com/cockroachdb/errors"
 )
 
 // UnQuantizer trivially implements the Quantizer interface, storing the
@@ -29,29 +28,9 @@ func NewUnQuantizer(dims int) Quantizer {
 	return &UnQuantizer{dims: dims}
 }
 
-// GetOriginalDims implements the Quantizer interface.
-func (q *UnQuantizer) GetOriginalDims() int {
+// GetDims implements the Quantizer interface.
+func (q *UnQuantizer) GetDims() int {
 	return q.dims
-}
-
-// GetRandomDims implements the Quantizer interface.
-func (q *UnQuantizer) GetRandomDims() int {
-	return q.dims
-}
-
-// RandomizeVector implements the Quantizer interface.
-func (q *UnQuantizer) RandomizeVector(
-	ctx context.Context, input vector.T, output vector.T, invert bool,
-) {
-	if len(input) != q.dims {
-		panic(errors.AssertionFailedf(
-			"input dimensions %d do not match quantizer dims %d", len(input), q.dims))
-	}
-	if len(output) != q.dims {
-		panic(errors.AssertionFailedf(
-			"output dimensions %d do not match quantizer dims %d", len(output), q.dims))
-	}
-	copy(output, input)
 }
 
 // Quantize implements the Quantizer interface.
@@ -77,10 +56,10 @@ func (q *UnQuantizer) QuantizeInSet(
 
 // NewQuantizedVectorSet implements the Quantizer interface
 func (q *UnQuantizer) NewQuantizedVectorSet(capacity int, centroid vector.T) QuantizedVectorSet {
-	dataBuffer := make([]float32, 0, capacity*q.GetRandomDims())
+	dataBuffer := make([]float32, 0, capacity*q.GetDims())
 	unquantizedSet := &UnQuantizedVectorSet{
 		Centroid: centroid,
-		Vectors:  vector.MakeSetFromRawData(dataBuffer, q.GetRandomDims()),
+		Vectors:  vector.MakeSetFromRawData(dataBuffer, q.GetDims()),
 	}
 	return unquantizedSet
 }

--- a/pkg/sql/vecindex/quantize/unquantizer_test.go
+++ b/pkg/sql/vecindex/quantize/unquantizer_test.go
@@ -9,7 +9,7 @@ import (
 	"context"
 	"testing"
 
-	"github.com/cockroachdb/cockroach/pkg/util/num32"
+	"github.com/cockroachdb/cockroach/pkg/sql/vecindex/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/vector"
 	"github.com/stretchr/testify/require"
 )
@@ -18,65 +18,57 @@ import (
 func TestUnQuantizerSimple(t *testing.T) {
 	ctx := context.Background()
 	quantizer := NewUnQuantizer(2)
-	require.Equal(t, 2, quantizer.GetOriginalDims())
-	require.Equal(t, 2, quantizer.GetRandomDims())
+	require.Equal(t, 2, quantizer.GetDims())
 
 	// Quantize empty set.
 	vectors := vector.MakeSet(2)
 	quantizedSet := quantizer.Quantize(ctx, vectors)
 	require.Equal(t, vector.T{0, 0}, quantizedSet.GetCentroid())
-	require.Equal(t, []float32{}, roundFloats(quantizedSet.GetCentroidDistances(), 2))
+	require.Equal(t, []float32{}, testutils.RoundFloats(quantizedSet.GetCentroidDistances(), 2))
 
 	// Add 3 vectors and verify centroid and centroid distances.
 	vectors = vector.MakeSetFromRawData([]float32{5, 2, 1, 2, 6, 5}, 2)
 	quantizedSet = quantizer.Quantize(ctx, vectors)
 	require.Equal(t, vector.T{4, 3}, quantizedSet.GetCentroid())
-	require.Equal(t, []float32{1.41, 3.16, 2.83}, roundFloats(quantizedSet.GetCentroidDistances(), 2))
+	require.Equal(t, []float32{1.41, 3.16, 2.83}, testutils.RoundFloats(quantizedSet.GetCentroidDistances(), 2))
 
 	// Add 2 more vectors to existing set.
 	vectors = vector.MakeSetFromRawData([]float32{4, 3, 6, 5}, 2)
 	quantizer.QuantizeInSet(ctx, quantizedSet, vectors)
 	require.Equal(t, 5, quantizedSet.GetCount())
-	require.Equal(t, []float32{1.41, 3.16, 2.83, 0, 2.83}, roundFloats(quantizedSet.GetCentroidDistances(), 2))
+	require.Equal(t, []float32{1.41, 3.16, 2.83, 0, 2.83}, testutils.RoundFloats(quantizedSet.GetCentroidDistances(), 2))
 
 	// Ensure distances and error bounds are correct.
 	distances := make([]float32, quantizedSet.GetCount())
 	errorBounds := make([]float32, quantizedSet.GetCount())
 	quantizer.EstimateSquaredDistances(ctx, quantizedSet, vector.T{1, 1}, distances, errorBounds)
-	require.Equal(t, []float32{17, 1, 41, 13, 41}, roundFloats(distances, 2))
-	require.Equal(t, []float32{0, 0, 0, 0, 0}, roundFloats(errorBounds, 2))
+	require.Equal(t, []float32{17, 1, 41, 13, 41}, testutils.RoundFloats(distances, 2))
+	require.Equal(t, []float32{0, 0, 0, 0, 0}, testutils.RoundFloats(errorBounds, 2))
 	require.Equal(t, vector.T{4, 3}, quantizedSet.GetCentroid())
 
 	// Query vector is centroid.
 	quantizer.EstimateSquaredDistances(ctx, quantizedSet, vector.T{0, 0}, distances, errorBounds)
-	require.Equal(t, []float32{29, 5, 61, 25, 61}, roundFloats(distances, 2))
-	require.Equal(t, []float32{0, 0, 0, 0, 0}, roundFloats(errorBounds, 2))
-
-	// Call RandomizeVector.
-	output := vector.T{3, 4}
-	quantizer.RandomizeVector(ctx, vector.T{1, 2}, output, false /* invert */)
-	require.Equal(t, vector.T{1, 2}, output)
-	quantizer.RandomizeVector(ctx, vector.T{5, 6}, output, true /* invert */)
-	require.Equal(t, vector.T{5, 6}, output)
+	require.Equal(t, []float32{29, 5, 61, 25, 61}, testutils.RoundFloats(distances, 2))
+	require.Equal(t, []float32{0, 0, 0, 0, 0}, testutils.RoundFloats(errorBounds, 2))
 
 	// Remove quantized vectors.
 	quantizedSet.ReplaceWithLast(1)
 	quantizedSet.ReplaceWithLast(3)
 	quantizedSet.ReplaceWithLast(1)
 	require.Equal(t, 2, quantizedSet.GetCount())
-	require.Equal(t, []float32{1.41, 2.83}, roundFloats(quantizedSet.GetCentroidDistances(), 2))
+	require.Equal(t, []float32{1.41, 2.83}, testutils.RoundFloats(quantizedSet.GetCentroidDistances(), 2))
 	distances = distances[:2]
 	errorBounds = errorBounds[:2]
 	quantizer.EstimateSquaredDistances(ctx, quantizedSet, vector.T{1, 1}, distances, errorBounds)
-	require.Equal(t, []float32{17, 41}, roundFloats(distances, 2))
-	require.Equal(t, []float32{0, 0}, roundFloats(errorBounds, 2))
+	require.Equal(t, []float32{17, 41}, testutils.RoundFloats(distances, 2))
+	require.Equal(t, []float32{0, 0}, testutils.RoundFloats(errorBounds, 2))
 
 	// Remove remaining quantized vectors.
 	quantizedSet.ReplaceWithLast(0)
 	quantizedSet.ReplaceWithLast(0)
 	require.Equal(t, 0, quantizedSet.GetCount())
 	require.Equal(t, vector.T{4, 3}, quantizedSet.GetCentroid())
-	require.Equal(t, []float32{}, roundFloats(quantizedSet.GetCentroidDistances(), 2))
+	require.Equal(t, []float32{}, testutils.RoundFloats(quantizedSet.GetCentroidDistances(), 2))
 	distances = distances[:0]
 	errorBounds = errorBounds[:0]
 	quantizer.EstimateSquaredDistances(ctx, quantizedSet, vector.T{1, 1}, distances, errorBounds)
@@ -91,17 +83,10 @@ func TestUnQuantizerSimple(t *testing.T) {
 	vectors = vector.T{4, 4}.AsSet()
 	quantizer.QuantizeInSet(ctx, quantizedSet, vectors)
 	require.Equal(t, 1, quantizedSet.GetCount())
-	require.Equal(t, []float32{5.66}, roundFloats(quantizedSet.GetCentroidDistances(), 2))
+	require.Equal(t, []float32{5.66}, testutils.RoundFloats(quantizedSet.GetCentroidDistances(), 2))
 	distances = distances[:1]
 	errorBounds = errorBounds[:1]
 	quantizer.EstimateSquaredDistances(ctx, quantizedSet, vector.T{1, 1}, distances, errorBounds)
-	require.Equal(t, []float32{18}, roundFloats(distances, 2))
-	require.Equal(t, []float32{0}, roundFloats(errorBounds, 2))
-}
-
-func roundFloats(s []float32, prec int) []float32 {
-	t := make([]float32, len(s))
-	copy(t, s)
-	num32.Round(t, prec)
-	return t
+	require.Equal(t, []float32{18}, testutils.RoundFloats(distances, 2))
+	require.Equal(t, []float32{0}, testutils.RoundFloats(errorBounds, 2))
 }

--- a/pkg/sql/vecindex/testdata/search-features.ddt
+++ b/pkg/sql/vecindex/testdata/search-features.ddt
@@ -4,16 +4,16 @@
 new-index dims=512 min-partition-size=4 max-partition-size=16 quality-samples=8 beam-size=4 load-features=1000 hide-tree
 ----
 Created index with 1000 vectors with 512 dimensions.
-3 levels, 91 partitions, 12.91 vectors/partition.
+3 levels, 92 partitions, 12.57 vectors/partition.
 CV stats:
-  level 2 - mean: 0.1306, stdev: 0.0340
-  level 3 - mean: 0.0000, stdev: 0.0000
+  level 2 - mean: 0.1301, stdev: 0.0335
+  level 3 - mean: 0.1568, stdev: 0.0161
 
 # Search with small beam size.
 search max-results=1 use-feature=5000 beam-size=1
 ----
 vec356: 0.5976 (centroid=0.5)
-23 leaf vectors, 46 vectors, 3 full vectors, 4 partitions
+23 leaf vectors, 47 vectors, 3 full vectors, 4 partitions
 
 # Search for additional results.
 search max-results=6 use-feature=5000 beam-size=1
@@ -24,29 +24,29 @@ vec979: 0.8066 (centroid=0.6)
 vec133: 0.8381 (centroid=0.51)
 vec527: 0.845 (centroid=0.38)
 vec50: 0.8542 (centroid=0.55)
-23 leaf vectors, 46 vectors, 18 full vectors, 4 partitions
+23 leaf vectors, 47 vectors, 18 full vectors, 4 partitions
 
 # Use a larger beam size.
 search max-results=6 use-feature=5000 beam-size=4
 ----
 vec356: 0.5976 (centroid=0.5)
-vec95: 0.7008 (centroid=0.65)
+vec302: 0.6601 (centroid=0.55)
+vec329: 0.6871 (centroid=0.62)
+vec386: 0.7301 (centroid=0.67)
 vec309: 0.7311 (centroid=0.52)
-vec704: 0.7916 (centroid=0.63)
-vec637: 0.8039 (centroid=0.52)
-vec410: 0.8062 (centroid=0.58)
-104 leaf vectors, 136 vectors, 26 full vectors, 11 partitions
+vec117: 0.7576 (centroid=0.49)
+95 leaf vectors, 149 vectors, 22 full vectors, 13 partitions
 
 # Turn off re-ranking, which results in increased inaccuracy.
 search max-results=6 use-feature=5000 beam-size=4 skip-rerank
 ----
-vec356: 0.6241 ±0.03 (centroid=0.5)
-vec95: 0.7145 ±0.05 (centroid=0.65)
-vec704: 0.715 ±0.04 (centroid=0.63)
-vec309: 0.7382 ±0.04 (centroid=0.52)
-vec133: 0.7885 ±0.03 (centroid=0.51)
-vec202: 0.7968 ±0.04 (centroid=0.55)
-104 leaf vectors, 136 vectors, 0 full vectors, 11 partitions
+vec302: 0.5957 ±0.04 (centroid=0.55)
+vec356: 0.6234 ±0.03 (centroid=0.5)
+vec386: 0.6868 ±0.04 (centroid=0.67)
+vec329: 0.6988 ±0.04 (centroid=0.62)
+vec11: 0.7207 ±0.04 (centroid=0.6)
+vec117: 0.7295 ±0.03 (centroid=0.49)
+95 leaf vectors, 149 vectors, 0 full vectors, 13 partitions
 
 # Return top 25 results with large beam size.
 search max-results=25 use-feature=5000 beam-size=16
@@ -55,7 +55,7 @@ vec771: 0.5624 (centroid=0.65)
 vec356: 0.5976 (centroid=0.5)
 vec640: 0.6525 (centroid=0.58)
 vec302: 0.6601 (centroid=0.55)
-vec329: 0.6871 (centroid=0.69)
+vec329: 0.6871 (centroid=0.62)
 vec95: 0.7008 (centroid=0.65)
 vec249: 0.7268 (centroid=0.48)
 vec386: 0.7301 (centroid=0.67)
@@ -64,7 +64,7 @@ vec117: 0.7576 (centroid=0.49)
 vec25: 0.761 (centroid=0.49)
 vec859: 0.7708 (centroid=0.64)
 vec240: 0.7723 (centroid=0.67)
-vec347: 0.7745 (centroid=0.56)
+vec347: 0.7745 (centroid=0.54)
 vec11: 0.777 (centroid=0.6)
 vec340: 0.7858 (centroid=0.66)
 vec239: 0.7878 (centroid=0.51)
@@ -76,42 +76,42 @@ vec637: 0.8039 (centroid=0.52)
 vec410: 0.8062 (centroid=0.58)
 vec979: 0.8066 (centroid=0.6)
 vec457: 0.8084 (centroid=0.42)
-395 leaf vectors, 487 vectors, 85 full vectors, 40 partitions
+391 leaf vectors, 485 vectors, 82 full vectors, 41 partitions
 
 # Search for an "easy" result, where adaptive search inspects less partitions.
 recall topk=20 use-feature=8601 beam-size=4
 ----
-65.00% recall@20
-23.00 leaf vectors, 48.00 vectors, 23.00 full vectors, 5.00 partitions
+40.00% recall@20
+49.00 leaf vectors, 64.00 vectors, 28.00 full vectors, 6.00 partitions
 
 # Search for a "hard" result, where adaptive search inspects more partitions.
 recall topk=20 use-feature=2717 beam-size=4
 ----
-40.00% recall@20
-118.00 leaf vectors, 157.00 vectors, 50.00 full vectors, 11.00 partitions
+50.00% recall@20
+116.00 leaf vectors, 168.00 vectors, 50.00 full vectors, 13.00 partitions
 
 # Test recall at different beam sizes.
 recall topk=10 beam-size=2 samples=50
 ----
-34.40% recall@10
-34.70 leaf vectors, 54.84 vectors, 17.62 full vectors, 4.96 partitions
+47.20% recall@10
+34.46 leaf vectors, 60.54 vectors, 18.06 full vectors, 5.42 partitions
 
 recall topk=10 beam-size=4 samples=50
 ----
-59.20% recall@10
-73.86 leaf vectors, 106.56 vectors, 23.28 full vectors, 9.14 partitions
+66.40% recall@10
+73.50 leaf vectors, 114.00 vectors, 22.48 full vectors, 9.98 partitions
 
 recall topk=10 beam-size=8 samples=50
 ----
-83.00% recall@10
-150.40 leaf vectors, 206.08 vectors, 27.08 full vectors, 17.48 partitions
+84.00% recall@10
+147.94 leaf vectors, 216.26 vectors, 26.22 full vectors, 18.98 partitions
 
 recall topk=10 beam-size=16 samples=50
 ----
-94.40% recall@10
-300.22 leaf vectors, 392.22 vectors, 30.38 full vectors, 32.84 partitions
+93.40% recall@10
+294.30 leaf vectors, 376.50 vectors, 29.68 full vectors, 32.72 partitions
 
 recall topk=10 beam-size=32 samples=50
 ----
-99.20% recall@10
-591.04 leaf vectors, 683.04 vectors, 33.30 full vectors, 57.58 partitions
+98.80% recall@10
+582.06 leaf vectors, 676.06 vectors, 31.44 full vectors, 58.54 partitions

--- a/pkg/sql/vecindex/testutils/BUILD.bazel
+++ b/pkg/sql/vecindex/testutils/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/build/bazel",
+        "//pkg/util/num32",
         "//pkg/util/vector",
         "@com_github_stretchr_testify//require",
     ],

--- a/pkg/sql/vecindex/testutils/testutils.go
+++ b/pkg/sql/vecindex/testutils/testutils.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/build/bazel"
+	"github.com/cockroachdb/cockroach/pkg/util/num32"
 	"github.com/cockroachdb/cockroach/pkg/util/vector"
 	"github.com/stretchr/testify/require"
 )
@@ -46,4 +47,12 @@ func LoadFeatures(t testing.TB, count int) vector.Set {
 	require.NoError(t, err)
 
 	return vector.MakeSetFromRawData(data[:count*512], 512)
+}
+
+// RoundFloats rounds all float32 values in the slice using the given precision.
+func RoundFloats(s []float32, prec int) []float32 {
+	t := make([]float32, len(s))
+	copy(t, s)
+	num32.Round(t, prec)
+	return t
 }

--- a/pkg/sql/vecindex/vecstore/in_memory_store_test.go
+++ b/pkg/sql/vecindex/vecstore/in_memory_store_test.go
@@ -286,7 +286,7 @@ func TestInMemoryStoreMarshalling(t *testing.T) {
 	require.Equal(t, uint64(1), store2.mu.partitions[10].lock.created)
 	require.Equal(t, Level(1), store2.mu.partitions[10].lock.partition.level)
 	require.Equal(t, 3, store2.mu.partitions[10].lock.partition.quantizedSet.GetCount())
-	require.Equal(t, 2, store2.mu.partitions[20].lock.partition.quantizer.GetOriginalDims())
+	require.Equal(t, 2, store2.mu.partitions[20].lock.partition.quantizer.GetDims())
 	require.Len(t, store2.mu.partitions[20].lock.partition.childKeys, 3)
 	require.Equal(t, PartitionKey(100), store2.mu.nextKey)
 	require.Len(t, store2.mu.vectors, 2)

--- a/pkg/sql/vecindex/vecstore/persistent_store.go
+++ b/pkg/sql/vecindex/vecstore/persistent_store.go
@@ -61,7 +61,7 @@ func NewPersistentStoreWithColumnID(
 		tableID:       tableDesc.GetID(),
 		indexID:       indexID,
 		quantizer:     quantizer,
-		rootQuantizer: quantize.NewUnQuantizer(quantizer.GetOriginalDims()),
+		rootQuantizer: quantize.NewUnQuantizer(quantizer.GetDims()),
 	}
 
 	pk := tableDesc.GetPrimaryIndex()


### PR DESCRIPTION
Move the vector randomization code from the quantizer RandomizeVector method to the vector index. Now, vectors will always be randomized by the index rather than conditionally based on whether the quantization algorithm decides to do it. This prevents subtle bugs where the index needed to always be aware of which quantizer was in use so that it passed the right vector - either the original or randomized version. There should not be a performance impact, since we were already doing randomization on vectors anyway in the common case of using RaBitQ quantization.

Epic: CRDB-42943

Release note: None