### PR TITLE
sem/tree: avoid assertion error on unimplemented builtins in views

### DIFF
--- a/pkg/crosscluster/logical/create_logical_replication_stmt.go
+++ b/pkg/crosscluster/logical/create_logical_replication_stmt.go
@@ -662,6 +662,9 @@ func lookupFunctionID(
 	if len(rf.Overloads) > 1 {
 		return 0, errors.Newf("function %q has more than 1 overload", u.String())
 	}
+	if rf.UnsupportedWithIssue != 0 {
+		return 0, rf.MakeUnsupportedError()
+	}
 	fnOID := rf.Overloads[0].Oid
 	descID := typedesc.UserDefinedTypeOIDToID(fnOID)
 	if descID == 0 {

--- a/pkg/sql/logictest/testdata/logic_test/views
+++ b/pkg/sql/logictest/testdata/logic_test/views
@@ -1942,3 +1942,8 @@ statement error cross database type references are not supported: db106602a.publ
 CREATE OR REPLACE VIEW v AS (SELECT 1 FROM (VALUES (1)) val(i) WHERE 'foo'::db106602a.e = 'foo'::db106602a.e)
 
 subtest end
+
+# Regression test for hitting an assertion error when using an unimplemented
+# builtin in the view (#128535).
+statement error pgcode 0A000 unimplemented
+CREATE VIEW v128535 AS SELECT json_to_tsvector()

--- a/pkg/sql/sem/eval/parse_doid.go
+++ b/pkg/sql/sem/eval/parse_doid.go
@@ -82,6 +82,9 @@ func ParseDOid(ctx context.Context, evalCtx *Context, s string, t *types.T) (*tr
 			return nil, pgerror.Newf(pgcode.AmbiguousAlias,
 				"more than one function named '%s'", funcDef.Name)
 		}
+		if funcDef.UnsupportedWithIssue != 0 {
+			return nil, funcDef.MakeUnsupportedError()
+		}
 		overload := funcDef.Overloads[0]
 		return tree.NewDOidWithTypeAndName(overload.Oid, t, funcDef.Name), nil
 	case oid.T_regprocedure:


### PR DESCRIPTION
Previously, we would hit an assertion error when trying to use an unimplemented builtin in the CREATE VIEW statement and this is now fixed. The issue is that we resolve unimplemented builtins as a definition with zero overloads, and all places that previously assumed at least one existing overload have been audited. The resolved function definition has been updated to have "unsupported with issue" integer indicating why there are no overloads.

Additionally, `UnsupportedWithIssue` property is now changed to be `uint` since we didn't use "negative value as having no corresponding issue" ability.

I decided to not include a release note since this seems like an edge case and we've only seen this a handful of times in sentry.

Fixes: #128535.

Release note: None