### PR TITLE
Revert "jobs: parse internal jobs queries at init time"

### DIFF
--- a/pkg/jobs/BUILD.bazel
+++ b/pkg/jobs/BUILD.bazel
@@ -52,8 +52,6 @@ go_library(
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/catalog/descs",
         "//pkg/sql/isql",
-        "//pkg/sql/parser",
-        "//pkg/sql/parser/statements",
         "//pkg/sql/pgwire/pgerror",
         "//pkg/sql/protoreflect",
         "//pkg/sql/sem/catconstants",


### PR DESCRIPTION
This reverts commit 28315dab66e835fceb4bc4679eaf368d3e1310f3.

Epic: None