### PR TITLE
opt/norm: remove assertion when failing to resolve function when folding

### DIFF
--- a/pkg/sql/opt/norm/BUILD.bazel
+++ b/pkg/sql/opt/norm/BUILD.bazel
@@ -58,6 +58,7 @@ go_library(
         "//pkg/util/errorutil",
         "//pkg/util/intsets",
         "//pkg/util/json",
+        "//pkg/util/log",
         "//pkg/util/sentryutil",
         "@com_github_cockroachdb_apd_v3//:apd",
         "@com_github_cockroachdb_errors//:errors",

--- a/pkg/sql/opt/norm/fold_constants_funcs.go
+++ b/pkg/sql/opt/norm/fold_constants_funcs.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/volatility"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/redact"
 	"github.com/lib/pq/oid"
@@ -671,7 +672,8 @@ func (c *CustomFuncs) FoldFunction(
 			context.Background(), tree.MakeUnresolvedFunctionName(&unresolved),
 			&c.f.evalCtx.SessionData().SearchPath)
 		if err != nil {
-			panic(errors.AssertionFailedf("function %s() not defined", redact.Safe(private.Name)))
+			log.Warningf(c.f.ctx, "function %s() not defined: %v", redact.Safe(private.Name), err)
+			return nil, false
 		}
 		funcRef = tree.ResolvableFunctionReference{FunctionReference: def}
 	} else {


### PR DESCRIPTION
The assertion was added in b5cb99073a0dee584d7a4ca126f8a060cc5f4dd1. We've seen a handful of sentry reports from this, so we'll instead skip function folding (and log the error).

Fixes: #137517.
Release note: None