### PR TITLE
sql: deflake TestDropDatabaseDeleteData

### DIFF
--- a/pkg/spanconfig/spanconfigreconciler/reconciler.go
+++ b/pkg/spanconfig/spanconfigreconciler/reconciler.go
@@ -217,6 +217,10 @@ type fullReconciler struct {
 func (f *fullReconciler) reconcile(
 	ctx context.Context,
 ) (storeWithLatestSpanConfigs *spanconfigstore.Store, _ hlc.Timestamp, _ error) {
+	if f.knobs != nil && f.knobs.OnFullReconcilerStart != nil {
+		f.knobs.OnFullReconcilerStart()
+	}
+
 	storeWithExistingSpanConfigs, err := f.fetchExistingSpanConfigs(ctx)
 	if err != nil {
 		return nil, hlc.Timestamp{}, err

--- a/pkg/spanconfig/testing_knobs.go
+++ b/pkg/spanconfig/testing_knobs.go
@@ -127,6 +127,9 @@ type TestingKnobs struct {
 	// fallback config that will be applied to the span.
 	OverrideFallbackConf func(roachpb.SpanConfig) roachpb.SpanConfig
 
+	// OnFullReconcilerStart is invoked when full reconciliation starts.
+	OnFullReconcilerStart func()
+
 	// OnWatchForZoneConfigUpdatesEstablished is invoked when the RangeFeed over
 	// system.zones starts.
 	OnWatchForZoneConfigUpdatesEstablished func()


### PR DESCRIPTION
This commit deflakes the test by blocking the full reconciliation from starting before we drop the database. This is used to avoid a race condition where the full reconciliation starts after we drop the database, it will ignore the dropped database. Then, there is a race between the SQLWatcher and the GC job where the SQLWatcher might write a zone config of table1 before table2, while the GC queue might not know that this range needs to be split because it has different span config.

Release note: None

Fixes: #138185