### PR TITLE
sql/schemachanger: Log events for CREATE/DROP trigger

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/triggers
+++ b/pkg/ccl/logictestccl/testdata/logic_test/triggers
@@ -4008,11 +4008,23 @@ CREATE TRIGGER foo AFTER UPDATE OF y ON xy FOR EACH ROW EXECUTE FUNCTION f();
 statement ok
 CREATE TRIGGER foo AFTER INSERT ON xy FOR EACH ROW EXECUTE FUNCTION f();
 
+# Verify we log to the event log.
+query T
+select "eventType" from system.eventlog order by timestamp desc limit 1;
+----
+create_trigger
+
 statement error pgcode 0A000 pq: unimplemented: cannot replace a trigger function with an active trigger
 CREATE OR REPLACE FUNCTION f() RETURNS TRIGGER LANGUAGE PLpgSQL AS $$ BEGIN RETURN NEW; END $$;
 
 statement ok
 DROP TRIGGER foo ON xy;
+
+# Verify we log to the event log.
+query T
+select "eventType" from system.eventlog order by timestamp desc limit 1;
+----
+drop_trigger
 
 # CREATE OR REPLACE still works if there are no referencing triggers.
 statement ok

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/create_trigger/create_trigger.side_effects
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/create_trigger/create_trigger.side_effects
@@ -17,6 +17,14 @@ begin transaction #1
 # begin StatementPhase
 checking for feature: CREATE TRIGGER
 increment telemetry for sql.schema.create_trigger
+write *eventpb.CreateTrigger to event log:
+  sql:
+    descriptorId: 104
+    statement: CREATE TRIGGER tr BEFORE INSERT OR UPDATE OR DELETE ON ‹defaultdb›.‹t› FOR EACH ROW EXECUTE FUNCTION ‹f›()
+    tag: CREATE TRIGGER
+    user: root
+  tableName: defaultdb.public.t
+  triggerName: tr
 ## StatementPhase stage 1 of 1 with 8 MutationType ops
 upsert descriptor #104
   ...

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/drop_trigger/drop_trigger.side_effects
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/drop_trigger/drop_trigger.side_effects
@@ -9,6 +9,14 @@ DROP TRIGGER tr ON defaultdb.t;
 begin transaction #1
 # begin StatementPhase
 checking for feature: DROP TRIGGER
+write *eventpb.DropTrigger to event log:
+  sql:
+    descriptorId: 104
+    statement: DROP TRIGGER ‹tr› ON ‹defaultdb›.‹t›
+    tag: DROP TRIGGER
+    user: root
+  tableName: defaultdb.public.t
+  triggerName: tr
 ## StatementPhase stage 1 of 1 with 2 MutationType ops
 upsert descriptor #104
   ...

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/create_trigger.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/create_trigger.go
@@ -38,10 +38,11 @@ func CreateTrigger(b BuildCtx, n *tree.CreateTrigger) {
 	_, _, tbl := scpb.FindTable(relationElements)
 	tableID, triggerID := tbl.TableID, b.NextTableTriggerID(tbl.TableID)
 
-	b.Add(&scpb.Trigger{
+	trigger := &scpb.Trigger{
 		TableID:   tableID,
 		TriggerID: triggerID,
-	})
+	}
+	b.Add(trigger)
 	b.Add(&scpb.TriggerName{
 		TableID:   tableID,
 		TriggerID: triggerID,
@@ -144,4 +145,5 @@ func CreateTrigger(b BuildCtx, n *tree.CreateTrigger) {
 		UsesTypeIDs:     refProvider.ReferencedTypes().Ordered(),
 		UsesRoutineIDs:  refProvider.ReferencedRoutines().Ordered(),
 	})
+	b.LogEventForExistingTarget(trigger)
 }

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/drop_trigger.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/drop_trigger.go
@@ -50,4 +50,5 @@ func DropTrigger(b BuildCtx, n *tree.DropTrigger) {
 			b.Drop(e)
 		}
 	})
+	b.LogEventForExistingTarget(trigger)
 }


### PR DESCRIPTION
While debugging an issue, I noticed that CREATE TRIGGER and DROP TRIGGER actions do not generate entries in system.eventlog. The necessary components were mostly in place, but we weren’t calling LogEventForExistingTarget to record the events. This change ensures that trigger creation and deletion are properly logged.

Epic: none
Release note: none