### PR TITLE
sql/schemachanger: Log events for CREATE/DROP POLICY

### DIFF
--- a/docs/generated/eventlog.md
+++ b/docs/generated/eventlog.md
@@ -1317,6 +1317,30 @@ An event of type `create_index` is recorded when an index is created.
 | `ApplicationName` | The application name for the session where the event was emitted. This is included in the event to ease filtering of logging output by application. | no |
 | `PlaceholderValues` | The mapping of SQL placeholders to their values, for prepared statements. | yes |
 
+### `create_policy`
+
+An event of type `create_policy` is recorded when a policy is created.
+
+
+| Field | Description | Sensitive |
+|--|--|--|
+| `TableName` | Name of the policy's table. | no |
+| `PolicyName` | Name of the created policy. | no |
+
+
+#### Common fields
+
+| Field | Description | Sensitive |
+|--|--|--|
+| `Timestamp` | The timestamp of the event. Expressed as nanoseconds since the Unix epoch. | no |
+| `EventType` | The type of the event. | no |
+| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | partially |
+| `Tag` | The statement tag. This is separate from the statement string, since the statement string can contain sensitive information. The tag is guaranteed not to. | no |
+| `User` | The user account that triggered the event. The special usernames `root` and `node` are not considered sensitive. | depends |
+| `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
+| `ApplicationName` | The application name for the session where the event was emitted. This is included in the event to ease filtering of logging output by application. | no |
+| `PlaceholderValues` | The mapping of SQL placeholders to their values, for prepared statements. | yes |
+
 ### `create_schema`
 
 An event of type `create_schema` is recorded when a schema is created.
@@ -1547,6 +1571,30 @@ An event of type `drop_index` is recorded when an index is dropped.
 | `IndexName` | The name of the affected index. | no |
 | `MutationID` | The mutation ID for the asynchronous job that is processing the index update. | no |
 | `CascadeDroppedViews` | The names of the views dropped as a result of a cascade operation. | no |
+
+
+#### Common fields
+
+| Field | Description | Sensitive |
+|--|--|--|
+| `Timestamp` | The timestamp of the event. Expressed as nanoseconds since the Unix epoch. | no |
+| `EventType` | The type of the event. | no |
+| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | partially |
+| `Tag` | The statement tag. This is separate from the statement string, since the statement string can contain sensitive information. The tag is guaranteed not to. | no |
+| `User` | The user account that triggered the event. The special usernames `root` and `node` are not considered sensitive. | depends |
+| `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
+| `ApplicationName` | The application name for the session where the event was emitted. This is included in the event to ease filtering of logging output by application. | no |
+| `PlaceholderValues` | The mapping of SQL placeholders to their values, for prepared statements. | yes |
+
+### `drop_policy`
+
+An event of type `drop_policy` is recorded when a policy is dropped.
+
+
+| Field | Description | Sensitive |
+|--|--|--|
+| `TableName` | Name of the policy's table. | no |
+| `PolicyName` | Name of the dropped policy. | no |
 
 
 #### Common fields

--- a/pkg/sql/logictest/testdata/logic_test/row_level_security
+++ b/pkg/sql/logictest/testdata/logic_test/row_level_security
@@ -47,6 +47,12 @@ CREATE TABLE sanity1();
 statement ok
 CREATE POLICY p1 on sanity1 USING (true);
 
+# Verify we log to the event log.
+query T
+select "eventType" from system.eventlog order by timestamp desc limit 1;
+----
+create_policy
+
 statement error pq: policy with name "p1" already exists on table "sanity1"
 CREATE POLICY p1 on sanity1 WITH CHECK (true);
 
@@ -64,6 +70,12 @@ DROP POLICY notthere on sanity1;
 
 statement ok
 DROP POLICY p1 on sanity1;
+
+# Verify we log to the event log.
+query T
+select "eventType" from system.eventlog order by timestamp desc limit 1;
+----
+drop_policy
 
 statement ok
 DROP POLICY p2 on sanity1;

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/create_policy.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/create_policy.go
@@ -49,12 +49,13 @@ func CreatePolicy(b BuildCtx, n *tree.CreatePolicy) {
 	})
 
 	policyID := b.NextTablePolicyID(tbl.TableID)
-	b.Add(&scpb.Policy{
+	policy := &scpb.Policy{
 		TableID:  tbl.TableID,
 		PolicyID: policyID,
 		Type:     convertPolicyType(n.Type),
 		Command:  convertPolicyCommand(n.Cmd),
-	})
+	}
+	b.Add(policy)
 	b.Add(&scpb.PolicyName{
 		TableID:  tbl.TableID,
 		PolicyID: policyID,
@@ -62,6 +63,7 @@ func CreatePolicy(b BuildCtx, n *tree.CreatePolicy) {
 	})
 	addRoleElements(b, n, tbl.TableID, policyID)
 	addPolicyExpressions(b, n, tbl.TableID, policyID)
+	b.LogEventForExistingTarget(policy)
 }
 
 // convertPolicyType will convert from a tree.PolicyType to a catpb.PolicyType

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/drop_policy.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/drop_policy.go
@@ -45,4 +45,5 @@ func DropPolicy(b BuildCtx, n *tree.DropPolicy) {
 		}
 	})
 	b.IncrementSchemaChangeDropCounter("policy")
+	b.LogEventForExistingTarget(policy)
 }

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_policy/create_policy.side_effects
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_policy/create_policy.side_effects
@@ -12,6 +12,14 @@ begin transaction #1
 checking for feature: CREATE POLICY
 increment telemetry for sql.schema.create_policy
 checking role/user "public" exists
+write *eventpb.CreatePolicy to event log:
+  policyName: policy 1
+  sql:
+    descriptorId: 104
+    statement: CREATE POLICY ‹"policy 1"› ON ‹t1› AS PERMISSIVE FOR SELECT USING (‹tenant_id› = ‹'01538898-f55c-44db-a306-89078e2c430e'›)
+    tag: CREATE POLICY
+    user: root
+  tableName: defaultdb.public.t1
 ## StatementPhase stage 1 of 1 with 5 MutationType ops
 upsert descriptor #104
   ...

--- a/pkg/sql/schemachanger/testdata/end_to_end/drop_policy/drop_policy.side_effects
+++ b/pkg/sql/schemachanger/testdata/end_to_end/drop_policy/drop_policy.side_effects
@@ -16,6 +16,14 @@ begin transaction #1
 # begin StatementPhase
 checking for feature: DROP POLICY
 increment telemetry for sql.schema.drop_policy
+write *eventpb.DropPolicy to event log:
+  policyName: policy 2
+  sql:
+    descriptorId: 104
+    statement: DROP POLICY ‹"policy 2"› ON ‹t1›
+    tag: DROP POLICY
+    user: root
+  tableName: defaultdb.public.t1
 ## StatementPhase stage 1 of 1 with 5 MutationType ops
 upsert descriptor #104
   ...

--- a/pkg/util/log/eventpb/ddl_events.proto
+++ b/pkg/util/log/eventpb/ddl_events.proto
@@ -622,3 +622,24 @@ message DropTrigger {
   // Name of the dropped trigger.
   string trigger_name = 4  [(gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) = "redact:\"nonsensitive\""];
 }
+
+// CreatePolicy is recorded when a policy is created.
+message CreatePolicy {
+  CommonEventDetails common = 1 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "", (gogoproto.embed) = true];
+  CommonSQLEventDetails sql = 2 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "", (gogoproto.embed) = true];
+  // Name of the policy's table.
+  string table_name = 3 [(gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) = "redact:\"nonsensitive\""];
+  // Name of the created policy.
+  string policy_name = 4  [(gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) = "redact:\"nonsensitive\""];
+}
+
+// DropPolicy is recorded when a policy is dropped.
+message DropPolicy {
+  CommonEventDetails common = 1 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "", (gogoproto.embed) = true];
+  CommonSQLEventDetails sql = 2 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "", (gogoproto.embed) = true];
+  // Name of the policy's table.
+  string table_name = 3 [(gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) = "redact:\"nonsensitive\""];
+  // Name of the dropped policy.
+  string policy_name = 4  [(gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) = "redact:\"nonsensitive\""];
+}
+

--- a/pkg/util/log/eventpb/eventlog_channels_generated.go
+++ b/pkg/util/log/eventpb/eventlog_channels_generated.go
@@ -157,6 +157,9 @@ func (m *CreateFunction) LoggingChannel() logpb.Channel { return logpb.Channel_S
 func (m *CreateIndex) LoggingChannel() logpb.Channel { return logpb.Channel_SQL_SCHEMA }
 
 // LoggingChannel implements the EventPayload interface.
+func (m *CreatePolicy) LoggingChannel() logpb.Channel { return logpb.Channel_SQL_SCHEMA }
+
+// LoggingChannel implements the EventPayload interface.
 func (m *CreateSchema) LoggingChannel() logpb.Channel { return logpb.Channel_SQL_SCHEMA }
 
 // LoggingChannel implements the EventPayload interface.
@@ -185,6 +188,9 @@ func (m *DropFunction) LoggingChannel() logpb.Channel { return logpb.Channel_SQL
 
 // LoggingChannel implements the EventPayload interface.
 func (m *DropIndex) LoggingChannel() logpb.Channel { return logpb.Channel_SQL_SCHEMA }
+
+// LoggingChannel implements the EventPayload interface.
+func (m *DropPolicy) LoggingChannel() logpb.Channel { return logpb.Channel_SQL_SCHEMA }
 
 // LoggingChannel implements the EventPayload interface.
 func (m *DropSchema) LoggingChannel() logpb.Channel { return logpb.Channel_SQL_SCHEMA }

--- a/pkg/util/log/eventpb/json_encode_generated.go
+++ b/pkg/util/log/eventpb/json_encode_generated.go
@@ -2340,6 +2340,36 @@ func (m *CreateIndex) AppendJSONFields(printComma bool, b redact.RedactableBytes
 }
 
 // AppendJSONFields implements the EventPayload interface.
+func (m *CreatePolicy) AppendJSONFields(printComma bool, b redact.RedactableBytes) (bool, redact.RedactableBytes) {
+
+	printComma, b = m.CommonEventDetails.AppendJSONFields(printComma, b)
+
+	printComma, b = m.CommonSQLEventDetails.AppendJSONFields(printComma, b)
+
+	if m.TableName != "" {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"TableName\":\""...)
+		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(m.TableName)))
+		b = append(b, '"')
+	}
+
+	if m.PolicyName != "" {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"PolicyName\":\""...)
+		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(m.PolicyName)))
+		b = append(b, '"')
+	}
+
+	return printComma, b
+}
+
+// AppendJSONFields implements the EventPayload interface.
 func (m *CreateRole) AppendJSONFields(printComma bool, b redact.RedactableBytes) (bool, redact.RedactableBytes) {
 
 	printComma, b = m.CommonEventDetails.AppendJSONFields(printComma, b)
@@ -2825,6 +2855,36 @@ func (m *DropIndex) AppendJSONFields(printComma bool, b redact.RedactableBytes) 
 			b = append(b, '"')
 		}
 		b = append(b, ']')
+	}
+
+	return printComma, b
+}
+
+// AppendJSONFields implements the EventPayload interface.
+func (m *DropPolicy) AppendJSONFields(printComma bool, b redact.RedactableBytes) (bool, redact.RedactableBytes) {
+
+	printComma, b = m.CommonEventDetails.AppendJSONFields(printComma, b)
+
+	printComma, b = m.CommonSQLEventDetails.AppendJSONFields(printComma, b)
+
+	if m.TableName != "" {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"TableName\":\""...)
+		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(m.TableName)))
+		b = append(b, '"')
+	}
+
+	if m.PolicyName != "" {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"PolicyName\":\""...)
+		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(m.PolicyName)))
+		b = append(b, '"')
 	}
 
 	return printComma, b


### PR DESCRIPTION
Previously, RLS policy DDL actions were not logged in system.eventlog, making it harder to track changes during investigations. This change ensures that CREATE POLICY and DROP POLICY operations are properly logged.

Epic: CRDB-45203
Release note: none

Informs #136696