### PR TITLE
microbench-ci: fix merge base

### DIFF
--- a/.github/actions/microbenchmark-build/action.yml
+++ b/.github/actions/microbenchmark-build/action.yml
@@ -24,6 +24,7 @@ runs:
       if: inputs.ref == 'base'
       uses: actions/checkout@v4
       with:
+        ref: ${{ github.event.pull_request.head.sha }}
         fetch-depth: 15
     - name: Determine merge base
       id: determine-merge-base


### PR DESCRIPTION
The microbenchmark build action is missing an explicit set to the ref required for determining the merge base.

Epic: None
Release note: None