### PR TITLE
microbench-ci: refactor posting

### DIFF
--- a/.github/workflows/microbenchmarks-ci.yaml
+++ b/.github/workflows/microbenchmarks-ci.yaml
@@ -104,13 +104,18 @@ jobs:
         uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.base.sha }}
+      - run: ./build/github/get-engflow-keys.sh
+        shell: bash
       - name: Unique Build ID
         run: echo "BUILD_ID=${{ github.run_id }}-${{ github.run_attempt }}" >> $GITHUB_ENV
       - name: Compare and Post
         run: ./build/github/microbenchmarks/post.sh
         env:
-          BASE_SHA: ${{ needs.base.outputs.merge_base }}
           HEAD_SHA: ${{ env.HEAD }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           REPO: "cockroachdb/cockroach"
           PR_NUMBER: ${{ github.event.pull_request.number }}
+      - name: Clean up
+        run: ./build/github/cleanup-engflow-keys.sh
+        shell: bash
+        if: always()

--- a/.github/workflows/microbenchmarks-ci.yaml
+++ b/.github/workflows/microbenchmarks-ci.yaml
@@ -97,6 +97,7 @@ jobs:
     timeout-minutes: 30
     permissions:
         contents: read
+        pull-requests: write
         issues: write
     needs: [ base, compare ]
     steps:

--- a/build/github/microbenchmarks/post.sh
+++ b/build/github/microbenchmarks/post.sh
@@ -10,16 +10,19 @@ set -euxo pipefail
 working_dir=$(mktemp -d)
 storage_bucket="$BUCKET"
 
-# Get the microbenchmark CI utility (BASE version). It is important that we only
-# use the base version of the utility here, as the GitHub token has elevated
-# permissions.
-gcloud storage cp "gs://${storage_bucket}/builds/${BASE_SHA}/bin/microbench-ci" "$working_dir/microbench-ci"
-chmod +x "$working_dir/microbench-ci"
+# Build microbenchmark CI utility (base version)
+bazel build --config=crosslinux $(./build/github/engflow-args.sh) \
+  --jobs 100 \
+  --bes_keywords integration-test-artifact-build \
+  //pkg/cmd/microbench-ci
+
+bazel_bin=$(bazel info bazel-bin --config=crosslinux)
 
 # Grab the summary from the previous step
 gcloud storage cp "gs://${storage_bucket}/results/${HEAD_SHA}/${BUILD_ID}/summary.md" "$working_dir/summary.md"
 
 # Post summary to GitHub on the PR
-"$working_dir/microbench-ci" post --github-summary="$working_dir/summary.md" \
+"$bazel_bin/pkg/cmd/microbench-ci/microbench-ci_/microbench-ci" post \
+  --github-summary="$working_dir/summary.md" \
   --pr-number="$PR_NUMBER" \
   --repo="$REPO"


### PR DESCRIPTION
This change ensures that for post `microbench-ci` is built from base, which is more secure given this part of the job has access to PRs & posting on GH. The change also adds the pull requests write permissions required for posting comments to a PR.

Epic: None
Release note: None