### PR TITLE
kvserver: report store-liveness unreachable replicas

### DIFF
--- a/pkg/kv/kvserver/client_raft_test.go
+++ b/pkg/kv/kvserver/client_raft_test.go
@@ -38,6 +38,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/stateloader"
 	raft "github.com/cockroachdb/cockroach/pkg/raft"
 	"github.com/cockroachdb/cockroach/pkg/raft/raftpb"
+	"github.com/cockroachdb/cockroach/pkg/raft/tracker"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/rpc/nodedialer"
@@ -2885,6 +2886,64 @@ func TestReportUnreachableHeartbeats(t *testing.T) {
 	if status.Term != initialTerm {
 		t.Errorf("while sleeping, term changed from %d to %d", initialTerm, status.Term)
 	}
+}
+
+// TestReportUnreachableStoreLiveness tests that if a follower's store liveness
+// is expired, ReportUnreachable is called and the corresponding raft flow is
+// transferred to StateProbe.
+func TestReportUnreachableStoreLiveness(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	// Enable leader fortification, store liveness, and leader leases.
+	ctx := context.Background()
+	st := cluster.MakeTestingClusterSettings()
+	kvserver.OverrideDefaultLeaseType(ctx, &st.SV, roachpb.LeaseLeader)
+
+	tc := testcluster.StartTestCluster(t, 3, base.TestClusterArgs{
+		ReplicationMode: base.ReplicationManual,
+		ServerArgs:      base.TestServerArgs{Settings: st},
+	})
+	defer tc.Stopper().Stop(ctx)
+
+	key := tc.ScratchRange(t)
+	tc.AddVotersOrFatal(t, key, tc.Targets(1, 2)...)
+	desc := tc.LookupRangeOrFatal(t, key)
+
+	// Send a write, to get things going.
+	s1 := tc.GetFirstStoreFromServer(t, 0)
+	incArgs := incrementArgs(key, 5)
+	if _, err := kv.SendWrapped(ctx, s1.TestSender(), incArgs); err != nil {
+		t.Fatal(err)
+	}
+
+	// Partition n3 from other nodes (including the leader on n1).
+	partRange, err := setupPartitionedRange(tc, desc.RangeID, 0, 2,
+		true /* activated */, unreliableRaftHandlerFuncs{})
+	require.NoError(t, err)
+
+	leaderRepl := s1.LookupReplica(roachpb.RKey(key))
+	require.NotNil(t, leaderRepl)
+	s3Repl := tc.GetFirstStoreFromServer(t, 2).LookupReplica(roachpb.RKey(key))
+	require.NotNil(t, s3Repl)
+
+	waitForFlowState := func(state tracker.StateType) {
+		t.Helper()
+		testutils.SucceedsSoon(t, func() error {
+			pr, ok := leaderRepl.RaftStatus().Progress[raftpb.PeerID(s3Repl.ReplicaID())]
+			require.True(t, ok)
+			if pr.State != state {
+				return errors.Newf("raft flow in %v, want %v", pr.State, state)
+			}
+			return nil
+		})
+	}
+
+	// Eventually, the s3 store liveness expires, and the flow transfers to StateProbe.
+	waitForFlowState(tracker.StateProbe)
+	// After healing the partition, the flow returns back to StateReplicate.
+	partRange.deactivate()
+	waitForFlowState(tracker.StateReplicate)
 }
 
 // TestReportUnreachableRemoveRace adds and removes the raft leader replica

--- a/pkg/kv/kvserver/client_raft_test.go
+++ b/pkg/kv/kvserver/client_raft_test.go
@@ -2721,7 +2721,7 @@ func TestWedgedReplicaDetection(t *testing.T) {
 			if len(lastUpdateTimes) == 3 {
 				return nil
 			}
-			return errors.Errorf("expected leader replica to have 3 entries in lastUpdateTimes map, found %s", lastUpdateTimes)
+			return errors.Errorf("expected leader replica to have 3 entries in lastUpdateTimes map, found %v", lastUpdateTimes)
 		})
 
 		// Lock the follower replica to prevent it from making progress from now
@@ -2761,7 +2761,7 @@ func TestWedgedReplicaDetection(t *testing.T) {
 		leaderNow := leaderClock.PhysicalTime()
 		if !leaderRepl.IsFollowerActiveSince(followerID, leaderNow, inactivityThreshold) {
 			t.Fatalf("expected follower to still be considered active; "+
-				"follower id: %d, last update times: %s, leader clock: %s",
+				"follower id: %d, last update times: %v, leader clock: %s",
 				followerID, leaderRepl.LastUpdateTimes(), leaderNow)
 		}
 
@@ -2783,7 +2783,7 @@ func TestWedgedReplicaDetection(t *testing.T) {
 			leaderNow = leaderClock.PhysicalTime()
 			if leaderRepl.IsFollowerActiveSince(followerID, leaderNow, inactivityThreshold) {
 				return errors.Errorf("expected follower to be considered inactive; "+
-					"follower id: %d, last update times: %s, leader clock: %s",
+					"follower id: %d, last update times: %v, leader clock: %s",
 					followerID, leaderRepl.LastUpdateTimes(), leaderNow)
 			}
 			return nil

--- a/pkg/kv/kvserver/helpers_test.go
+++ b/pkg/kv/kvserver/helpers_test.go
@@ -415,7 +415,7 @@ func (r *Replica) NumPendingProposals() int64 {
 	return r.numPendingProposalsRLocked()
 }
 
-func (r *Replica) LastUpdateTimes() map[roachpb.ReplicaID]time.Time {
+func (r *Replica) LastUpdateTimes() map[roachpb.ReplicaID]lastReplicaUpdateTime {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 	return maps.Clone(r.mu.lastUpdateTimes)

--- a/pkg/kv/kvserver/raft_log_queue_test.go
+++ b/pkg/kv/kvserver/raft_log_queue_test.go
@@ -370,10 +370,10 @@ func TestUpdateRaftStatusActivity(t *testing.T) {
 		{
 			replicas: []roachpb.ReplicaDescriptor{{ReplicaID: 1}, {ReplicaID: 2}, {ReplicaID: 3}},
 			prs:      []tracker.Progress{{RecentActive: false}, {RecentActive: true}},
-			lastUpdate: map[roachpb.ReplicaID]time.Time{
-				1: now.Add(-1 * inactivityThreashold / 2),
-				2: now.Add(-1 - inactivityThreashold),
-				3: now,
+			lastUpdate: map[roachpb.ReplicaID]lastReplicaUpdateTime{
+				1: {update: now.Add(-1 * inactivityThreashold / 2)},
+				2: {update: now.Add(-1 - inactivityThreashold)},
+				3: {update: now},
 			},
 			now: now,
 

--- a/pkg/kv/kvserver/replica_proposal_quota.go
+++ b/pkg/kv/kvserver/replica_proposal_quota.go
@@ -147,7 +147,7 @@ func (r *Replica) updateProposalQuotaRaftMuLocked(
 	shouldInitQuotaPool := false
 	if r.mu.leaderID != lastLeaderID {
 		if r.replicaID == r.mu.leaderID {
-			r.mu.lastUpdateTimes = make(map[roachpb.ReplicaID]time.Time)
+			r.mu.lastUpdateTimes = make(map[roachpb.ReplicaID]lastReplicaUpdateTime)
 			r.mu.lastUpdateTimes.updateOnBecomeLeader(r.shMu.state.Desc.Replicas().Descriptors(), now)
 			r.mu.replicaFlowControlIntegration.onBecameLeader(ctx)
 			r.mu.lastProposalAtTicks = r.mu.ticks // delay imminent quiescence

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -1525,7 +1525,7 @@ func (r *Replica) tick(
 		r.mu.lastUpdateTimes.update(r.replicaID, r.Clock().PhysicalTime())
 		// We also update lastUpdateTimes for replicas that provide store liveness
 		// support to the leader.
-		r.updateLastUpdateTimesUsingStoreLivenessRLocked(storeClockTimestamp)
+		r.updateLastUpdateTimesUsingStoreLivenessLocked(storeClockTimestamp)
 	}
 
 	r.mu.ticks++
@@ -3098,8 +3098,8 @@ func (r *Replica) printRaftTail(
 // under the raft fortification protocol, where failure detection is subsumed by
 // store liveness.
 //
-// This method assume that Replica.mu is held in read mode.
-func (r *Replica) updateLastUpdateTimesUsingStoreLivenessRLocked(
+// This method assumes that Replica.mu is locked for writes.
+func (r *Replica) updateLastUpdateTimesUsingStoreLivenessLocked(
 	storeClockTimestamp hlc.ClockTimestamp,
 ) {
 	// If store liveness is not enabled, there is nothing to do. The


### PR DESCRIPTION
This commit triggers `addUnreachableRemoteReplica` when the corresponding store liveness is disconnected. Eventually, this triggers `ReportUnreachable` call to raft, which transfers the flow to `StateProbe`.

Epic: none
Release note: none