### PR TITLE
crosscluster/logical: record batch time per row

### DIFF
--- a/docs/generated/metrics/metrics.html
+++ b/docs/generated/metrics/metrics.html
@@ -1550,7 +1550,7 @@
 <tr><td>APPLICATION</td><td>kv.streamer.batches.sent</td><td>Number of BatchRequests sent across all KV Streamer operators</td><td>Batches</td><td>COUNTER</td><td>COUNT</td><td>AVG</td><td>NON_NEGATIVE_DERIVATIVE</td></tr>
 <tr><td>APPLICATION</td><td>kv.streamer.batches.throttled</td><td>Number of BatchRequests currently being throttled due to reaching the concurrency limit, across all KV Streamer operators</td><td>Batches</td><td>GAUGE</td><td>COUNT</td><td>AVG</td><td>NONE</td></tr>
 <tr><td>APPLICATION</td><td>kv.streamer.operators.active</td><td>Number of KV Streamer operators currently in use</td><td>Operators</td><td>GAUGE</td><td>COUNT</td><td>AVG</td><td>NONE</td></tr>
-<tr><td>APPLICATION</td><td>logical_replication.batch_hist_nanos</td><td>Time spent flushing a batch</td><td>Nanoseconds</td><td>HISTOGRAM</td><td>NANOSECONDS</td><td>AVG</td><td>NONE</td></tr>
+<tr><td>APPLICATION</td><td>logical_replication.batch_hist_nanos</td><td>Time spent per row flushing a batch</td><td>Nanoseconds</td><td>HISTOGRAM</td><td>NANOSECONDS</td><td>AVG</td><td>NONE</td></tr>
 <tr><td>APPLICATION</td><td>logical_replication.catchup_ranges</td><td>Source side ranges undergoing catch up scans (inaccurate with multiple LDR jobs)</td><td>Ranges</td><td>GAUGE</td><td>COUNT</td><td>AVG</td><td>NONE</td></tr>
 <tr><td>APPLICATION</td><td>logical_replication.catchup_ranges_by_label</td><td>Source side ranges undergoing catch up scans</td><td>Ranges</td><td>GAUGE</td><td>COUNT</td><td>AVG</td><td>NONE</td></tr>
 <tr><td>APPLICATION</td><td>logical_replication.checkpoint_events_ingested</td><td>Checkpoint events ingested by all replication jobs</td><td>Events</td><td>COUNTER</td><td>COUNT</td><td>AVG</td><td>NON_NEGATIVE_DERIVATIVE</td></tr>

--- a/pkg/crosscluster/logical/logical_replication_writer_processor.go
+++ b/pkg/crosscluster/logical/logical_replication_writer_processor.go
@@ -1040,7 +1040,11 @@ func (lrw *logicalReplicationWriterProcessor) flushChunk(
 
 		batchTime := timeutil.Since(preBatchTime)
 		lrw.debug.RecordBatchApplied(batchTime, int64(len(batch)))
-		lrw.metrics.ApplyBatchNanosHist.RecordValue(batchTime.Nanoseconds())
+		nanosPerRow := batchTime.Nanoseconds()
+		if len(batch) > 0 {
+			nanosPerRow /= int64(len(batch))
+		}
+		lrw.metrics.ApplyBatchNanosHist.RecordValue(nanosPerRow)
 	}
 	return stats, nil
 }

--- a/pkg/crosscluster/logical/metrics.go
+++ b/pkg/crosscluster/logical/metrics.go
@@ -61,7 +61,7 @@ var (
 	}
 	metaApplyBatchNanosHist = metric.Metadata{
 		Name:        "logical_replication.batch_hist_nanos",
-		Help:        "Time spent flushing a batch",
+		Help:        "Time spent per row flushing a batch",
 		Measurement: "Nanoseconds",
 		Unit:        metric.Unit_NANOSECONDS,
 	}

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/logicalDataReplication.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/logicalDataReplication.tsx
@@ -118,7 +118,7 @@ export default function (props: GraphDashboardProps) {
     </LineGraph>,
 
     <LineGraph
-      title="Batch Application Processing Time: 50th percentile"
+      title="Row Application Processing Time: 50th percentile"
       isKvGraph={false}
       tenantSource={tenantSource}
       tooltip={
@@ -140,7 +140,7 @@ export default function (props: GraphDashboardProps) {
     </LineGraph>,
 
     <LineGraph
-      title="Batch Application Processing Time: 99th percentile"
+      title="Row Application Processing Time: 99th percentile"
       isKvGraph={false}
       tenantSource={tenantSource}
       tooltip={


### PR DESCRIPTION
Previously we recorded apply time as the total batch time. This is the same as the time spent per row for batches of only a single row, which is used in the default direct cput writing mode, but the 'validated' SQL querier mode puts up to 32 rows in a batch, which can make it hard to compare this performance metric across the modes.

Release note: none.
Epic: none.