### PR TITLE
sql: Fix trigger dependency cleanup in legacy schema changer

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/triggers
+++ b/pkg/ccl/logictestccl/testdata/logic_test/triggers
@@ -4018,4 +4018,54 @@ DROP TRIGGER foo ON xy;
 statement ok
 CREATE OR REPLACE FUNCTION f() RETURNS TRIGGER LANGUAGE PLpgSQL AS $$ BEGIN RETURN NEW; END $$;
 
+# ==============================================================================
+# Test that descriptor backreferences are cleaned up
+# ==============================================================================
+
+subtest ensure_back_ref_cleanup
+
+statement ok
+create table listings_balance (c1 int);
+
+# Create a function that references listings_balance
+statement ok
+create or replace function update_listing_balance()
+returns TRIGGER language PLpgSQL AS
+$$
+BEGIN
+  INSERT INTO listings_balance VALUES (1);
+  RETURN NEW;
+END
+$$;
+
+statement ok
+CREATE TABLE transaction_entries (c1 int);
+
+# Create a trigger that references listings_balance through the trigger function.
+statement ok
+create trigger tr AFTER INSERT OR UPDATE ON transaction_entries FOR EACH ROW execute function update_listing_balance();
+
+# Force the legacy schema change for the drop table. We will save the original
+# DSC setting so that it be reset properly.
+let $use_decl_sc
+SHOW use_declarative_schema_changer
+
+statement ok
+SET use_declarative_schema_changer = off;
+
+# This should cleanup the dependency in listings_balance.
+statement ok
+DROP TABLE transaction_entries;
+
+# Reinstate original DSC setting
+statement ok
+SET use_declarative_schema_changer = $use_decl_sc;
+
+statement ok
+DROP FUNCTION update_listing_balance ;
+
+# Sanity to verify the dependency no longer exists.
+statement ok
+drop table listings_balance cascade;
+
 subtest end

--- a/pkg/sql/drop_table.go
+++ b/pkg/sql/drop_table.go
@@ -278,7 +278,7 @@ func (p *planner) dropTableImpl(
 	for i := range tableDesc.Triggers {
 		trigger := &tableDesc.Triggers[i]
 		for _, id := range trigger.DependsOn {
-			if err := p.removeTriggerBackReference(ctx, tableDesc, id); err != nil {
+			if err := p.removeTriggerBackReference(ctx, tableDesc, id, trigger.Name); err != nil {
 				return droppedViews, err
 			}
 		}
@@ -672,7 +672,7 @@ func removeFKBackReferenceFromTable(
 // removeTriggerBackReference removes the trigger back reference for the
 // referenced table with the given ID.
 func (p *planner) removeTriggerBackReference(
-	ctx context.Context, tableDesc *tabledesc.Mutable, refID descpb.ID,
+	ctx context.Context, tableDesc *tabledesc.Mutable, refID descpb.ID, triggerName string,
 ) error {
 	var refTableDesc *tabledesc.Mutable
 	// We don't want to lookup/edit a second copy of the same table.
@@ -690,7 +690,18 @@ func (p *planner) removeTriggerBackReference(
 		return nil
 	}
 	refTableDesc.DependedOnBy = removeMatchingReferences(refTableDesc.DependedOnBy, tableDesc.ID)
-	return nil
+
+	name, err := p.getQualifiedTableName(ctx, tableDesc)
+	if err != nil {
+		return err
+	}
+	refName, err := p.getQualifiedTableName(ctx, refTableDesc)
+	if err != nil {
+		return err
+	}
+	jobDesc := fmt.Sprintf("updating table %q after removing trigger %q from table %q",
+		refName.FQString(), triggerName, name.FQString())
+	return p.writeSchemaChange(ctx, refTableDesc, descpb.InvalidMutationID, jobDesc)
 }
 
 // removeMatchingReferences removes all refs from the provided slice that


### PR DESCRIPTION
In the legacy schema changer for DROP TABLE, there was special logic to clean up dependencies created by triggers. However, a bug in this logic caused the dependent table’s descriptor to remain unchanged, leaving behind a dangling reference. This commit ensures that the dependent table’s descriptor is correctly updated.

Epic: none
informs https://github.com/cockroachlabs/support/issues/3174
Release note (bug fix): Fixed a bug where dropping a table with a trigger using the legacy schema changer could leave an orphaned reference in the descriptor. This occurred when two tables were dependent on each other via a trigger, and the table containing the trigger was dropped.