### PR TITLE
github: temporarily disable microbenchmarks CI

### DIFF
--- a/.github/workflows/microbenchmarks-ci.yaml.disabled
+++ b/.github/workflows/microbenchmarks-ci.yaml.disabled
@@ -1,8 +1,9 @@
 name: Microbenchmarks CI
-on:
-  pull_request_target:
-    types: [ opened, reopened, synchronize ]
-    branches: [ master ]
+# TODO: This workflow is temporarily disabled until the new pool of runners for it is ready.
+#on:
+#  pull_request_target:
+#    types: [ opened, reopened, synchronize ]
+#    branches: [ master ]
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true


### PR DESCRIPTION
This job is currently overloading CI, and we require a new pool of machines for it to be stable.

Epic: None
Release note: None