### PR TITLE
backup: deflake TestEncryptedBackupRestoreSystemJobs

### DIFF
--- a/pkg/testutils/jobutils/BUILD.bazel
+++ b/pkg/testutils/jobutils/BUILD.bazel
@@ -18,6 +18,6 @@ go_library(
         "//pkg/testutils/sqlutils",
         "//pkg/util/protoutil",
         "@com_github_cockroachdb_errors//:errors",
-        "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
     ],
 )


### PR DESCRIPTION
This patch removes a descriptor id equality check, which can flake.

Informs #140678

Release note: none