### PR TITLE
roachtest: skip post validation replica divergence for corr splits

### DIFF
--- a/pkg/cmd/roachtest/tests/hotspotsplits.go
+++ b/pkg/cmd/roachtest/tests/hotspotsplits.go
@@ -91,6 +91,9 @@ func registerHotSpotSplits(r registry.Registry) {
 		CompatibleClouds: registry.AllExceptAWS,
 		Suites:           registry.Suites(registry.Nightly),
 		Leases:           registry.MetamorphicLeases,
+		// This test may timeout waiting for replica divergence post-test
+		// validation due to high write volume, see #141007.
+		SkipPostValidations: registry.PostValidationReplicaDivergence,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			if c.IsLocal() {
 				concurrency = 32

--- a/pkg/cmd/roachtest/tests/kv.go
+++ b/pkg/cmd/roachtest/tests/kv.go
@@ -355,6 +355,13 @@ func registerKV(r registry.Registry) {
 			tags["weekly"] = struct{}{}
 		}
 
+		var skipPostValidations registry.PostValidation
+		if opts.blockSize == 1<<16 {
+			// Large block size variations may timeout waiting for replica divergence
+			// post-test validation due to high write volume, see #141007.
+			skipPostValidations = registry.PostValidationReplicaDivergence
+		}
+
 		r.Add(registry.TestSpec{
 			Name:      strings.Join(nameParts, "/"),
 			Owner:     owner,
@@ -363,9 +370,10 @@ func registerKV(r registry.Registry) {
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				runKV(ctx, t, c, opts)
 			},
-			CompatibleClouds:  clouds,
-			Suites:            suites,
-			EncryptionSupport: encryption,
+			CompatibleClouds:    clouds,
+			Suites:              suites,
+			EncryptionSupport:   encryption,
+			SkipPostValidations: skipPostValidations,
 		})
 	}
 }


### PR DESCRIPTION
Skip `PostValidationReplicaDivergence` for the following tests:

```
kv95/.*/size=64kb
kv0/.*/size=64kb
hotspotsplits/nodes=4
```

As the post validation steps times out due to large send queues being flushed due to simultaneous range splitting, flushing range send queues (see #141007).

Resolves: #139204
Resolves: #140325
Resolves: #140335
Resolves: #140792
Release note: None