### PR TITLE
release-24.2: ci: build in fewer configurations in CI

### DIFF
--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -10,13 +10,9 @@ status = [
        "lint",
        "linux_amd64_build",
        "linux_amd64_fips_build",
-       "linux_arm64_build",
        "local_roachtest",
        "local_roachtest_fips",
-       "macos_amd64_build",
-       "macos_arm64_build",
        "unit_tests",
-       "windows_build",
 ]
 
 # List of commit statuses that must not be failing on the PR commit when it is

--- a/.github/workflows/github-actions-essential-ci.yml
+++ b/.github/workflows/github-actions-essential-ci.yml
@@ -238,69 +238,6 @@ jobs:
       - name: clean up
         run: ./build/github/cleanup-engflow-keys.sh
         if: always()
-  linux_arm64_build:
-    runs-on: [self-hosted, basic_runner_group]
-    timeout-minutes: 30
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.ref }}
-      - name: compute metadata
-        run: echo GITHUB_ACTIONS_BRANCH=${{ github.event.pull_request.number || github.ref_name}} >> "$GITHUB_ENV"
-      - run: ./build/github/get-engflow-keys.sh
-      - run: ./build/github/prepare-summarize-build.sh
-      - name: build
-        run: ./build/github/build.sh crosslinuxarm
-      - name: upload build results
-        run: ./build/github/summarize-build.sh bes.bin
-        if: always()
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: clean up
-        run: ./build/github/cleanup-engflow-keys.sh
-        if: always()
-  macos_amd64_build:
-    runs-on: [self-hosted, basic_runner_group]
-    timeout-minutes: 30
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.ref }}
-      - name: compute metadata
-        run: echo GITHUB_ACTIONS_BRANCH=${{ github.event.pull_request.number || github.ref_name}} >> "$GITHUB_ENV"
-      - run: ./build/github/get-engflow-keys.sh
-      - run: ./build/github/prepare-summarize-build.sh
-      - name: build
-        run: ./build/github/build.sh crossmacos
-      - name: upload build results
-        run: ./build/github/summarize-build.sh bes.bin
-        if: always()
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: clean up
-        run: ./build/github/cleanup-engflow-keys.sh
-        if: always()
-  macos_arm64_build:
-    runs-on: [self-hosted, basic_runner_group]
-    timeout-minutes: 30
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.ref }}
-      - name: compute metadata
-        run: echo GITHUB_ACTIONS_BRANCH=${{ github.event.pull_request.number || github.ref_name}} >> "$GITHUB_ENV"
-      - run: ./build/github/get-engflow-keys.sh
-      - run: ./build/github/prepare-summarize-build.sh
-      - name: build
-        run: ./build/github/build.sh crossmacosarm
-      - name: upload build results
-        run: ./build/github/summarize-build.sh bes.bin
-        if: always()
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: clean up
-        run: ./build/github/cleanup-engflow-keys.sh
-        if: always()
   unit_tests:
     runs-on: [self-hosted, basic_runner_group]
     timeout-minutes: 60
@@ -317,27 +254,6 @@ jobs:
       - name: run tests
         run: ./build/github/unit-tests.sh
       - name: upload test results
-        run: ./build/github/summarize-build.sh bes.bin
-        if: always()
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - name: clean up
-        run: ./build/github/cleanup-engflow-keys.sh
-        if: always()
-  windows_build:
-    runs-on: [self-hosted, basic_runner_group]
-    timeout-minutes: 30
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.ref }}
-      - name: compute metadata
-        run: echo GITHUB_ACTIONS_BRANCH=${{ github.event.pull_request.number || github.ref_name}} >> "$GITHUB_ENV"
-      - run: ./build/github/get-engflow-keys.sh
-      - run: ./build/github/prepare-summarize-build.sh
-      - name: build
-        run: ./build/github/build.sh crosswindows
-      - name: upload build results
         run: ./build/github/summarize-build.sh bes.bin
         if: always()
         env:


### PR DESCRIPTION
Backport 1/1 commits from #141005.

/cc @cockroachdb/release

Release justification: Non-production code changes

---

We build `cockroach` duplicatively many times in different configurations, which increases load on the EngFlow cluster unnecessarily. We hope to give the cluster some relief by reducing the amount that is built.

Part of: CRDB-46376
Epic: none
Release note: None
