### PR TITLE
backup: set autoddl to false universially in test driver

### DIFF
--- a/pkg/backup/backuptestutils/testutils.go
+++ b/pkg/backup/backuptestutils/testutils.go
@@ -133,7 +133,18 @@ func StartBackupRestoreTestCluster(
 	tc := testcluster.StartTestCluster(t, clusterSize, opts.testClusterArgs)
 	opts.initFunc(tc)
 
+	// Disable autocommit before DDLs in order to make schema changes during test
+	// setup faster. Becuase the cluster setting only enacts on new conns in
+	// the pool, temprorarily reduce the number of max open conns to 1, and apply
+	// the session var to the existing conn.
+	for i := 0; i < clusterSize; i++ {
+		tc.Conns[i].SetMaxOpenConns(1)
+		_, err := tc.Conns[i].Exec("SET autocommit_before_ddl = false")
+		require.NoError(t, err)
+		tc.Conns[i].SetMaxOpenConns(0)
+	}
 	sqlDB := sqlutils.MakeSQLRunner(tc.Conns[0])
+	sqlDB.Exec(t, `SET CLUSTER SETTING sql.defaults.autocommit_before_ddl.enabled = 'false'`)
 
 	if opts.bankArgs != nil {
 		const payloadSize = 100
@@ -149,11 +160,6 @@ func StartBackupRestoreTestCluster(
 		// monitor.
 		sqlDB.Exec(t, `SET CLUSTER SETTING kv.bulk_ingest.pk_buffer_size = '16MiB'`)
 		sqlDB.Exec(t, `SET CLUSTER SETTING kv.bulk_ingest.index_buffer_size = '16MiB'`)
-
-		// Disable autocommit before DDLs in order to make schema changes during
-		// test setup faster.
-		sqlDB.Exec(t, `SET CLUSTER SETTING sql.defaults.autocommit_before_ddl.enabled = 'false'`)
-		sqlDB.Exec(t, "SET autocommit_before_ddl = false")
 
 		// Set the max buffer size to something low to prevent
 		// backup/restore tests from hitting OOM errors. If any test

--- a/pkg/backup/testdata/backup-restore/backup-permissions-deprecated
+++ b/pkg/backup/testdata/backup-restore/backup-permissions-deprecated
@@ -141,9 +141,6 @@ REVOKE CONNECT ON DATABASE d FROM public;
 CREATE USER testuser;
 GRANT CONNECT ON DATABASE d TO testuser;
 ----
-NOTICE: auto-committing transaction before processing DDL due to autocommit_before_ddl setting
-NOTICE: auto-committing transaction before processing DDL due to autocommit_before_ddl setting
-NOTICE: auto-committing transaction before processing DDL due to autocommit_before_ddl setting
 
 exec-sql cluster=s3 user=testuser
 SHOW BACKUP FROM LATEST IN 'http://COCKROACH_TEST_HTTP_SERVER/'

--- a/pkg/backup/testdata/backup-restore/in-progress-imports
+++ b/pkg/backup/testdata/backup-restore/in-progress-imports
@@ -227,8 +227,6 @@ DROP TABLE d.foo;
 DROP TABLE d.foofoo;
 DROP TABLE d.baz;
 ----
-NOTICE: auto-committing transaction before processing DDL due to autocommit_before_ddl setting
-NOTICE: auto-committing transaction before processing DDL due to autocommit_before_ddl setting
 
 
 restore aost=t0
@@ -298,9 +296,6 @@ DROP TABLE d.foo;
 DROP TABLE d.foofoo;
 DROP TABLE d.baz;
 ----
-NOTICE: auto-committing transaction before processing DDL due to autocommit_before_ddl setting
-NOTICE: auto-committing transaction before processing DDL due to autocommit_before_ddl setting
-
 
 exec-sql
 RESTORE TABLE d.* FROM LATEST IN 'nodelocal://1/table/' WITH into_db= d;

--- a/pkg/backup/testdata/backup-restore/in-progress-restores
+++ b/pkg/backup/testdata/backup-restore/in-progress-restores
@@ -173,8 +173,6 @@ exec-sql
 USE d;
 DROP SCHEMA IF EXISTS me CASCADE;
 ----
-NOTICE: auto-committing transaction before processing DDL due to autocommit_before_ddl setting
-
 
 exec-sql
 SET CLUSTER SETTING jobs.debug.pausepoints = restore.before_publishing_descriptors;
@@ -285,10 +283,6 @@ CREATE DATABASE d_with_schema;
 CREATE SCHEMA d_with_schema.me;
 CREATE TABLE d_with_schema.me.bar (x INT);
 ----
-NOTICE: auto-committing transaction before processing DDL due to autocommit_before_ddl setting
-NOTICE: auto-committing transaction before processing DDL due to autocommit_before_ddl setting
-NOTICE: auto-committing transaction before processing DDL due to autocommit_before_ddl setting
-NOTICE: auto-committing transaction before processing DDL due to autocommit_before_ddl setting
 
 
 exec-sql
@@ -377,10 +371,6 @@ DROP SCHEMA d.me CASCADE;
 CREATE DATABASE d_aost;
 CREATE DATABASE d_latest;
 ----
-NOTICE: auto-committing transaction before processing DDL due to autocommit_before_ddl setting
-NOTICE: auto-committing transaction before processing DDL due to autocommit_before_ddl setting
-NOTICE: auto-committing transaction before processing DDL due to autocommit_before_ddl setting
-NOTICE: auto-committing transaction before processing DDL due to autocommit_before_ddl setting
 
 
 exec-sql

--- a/pkg/backup/testdata/backup-restore/multiregion
+++ b/pkg/backup/testdata/backup-restore/multiregion
@@ -90,13 +90,6 @@ ALTER DATABASE d DROP REGION 'us-west-1';
 ALTER DATABASE d ADD REGION 'eu-north-1';
 ALTER DATABASE d SET SECONDARY REGION 'eu-north-1';
 ----
-NOTICE: auto-committing transaction before processing DDL due to autocommit_before_ddl setting
-NOTICE: auto-committing transaction before processing DDL due to autocommit_before_ddl setting
-NOTICE: auto-committing transaction before processing DDL due to autocommit_before_ddl setting
-NOTICE: auto-committing transaction before processing DDL due to autocommit_before_ddl setting
-NOTICE: auto-committing transaction before processing DDL due to autocommit_before_ddl setting
-NOTICE: auto-committing transaction before processing DDL due to autocommit_before_ddl setting
-NOTICE: auto-committing transaction before processing DDL due to autocommit_before_ddl setting
 
 exec-sql
 RESTORE DATABASE d FROM LATEST IN 'nodelocal://1/database_backup/' WITH skip_localities_check, new_db_name='d_new';
@@ -116,13 +109,6 @@ ALTER DATABASE d_new DROP REGION 'us-west-1';
 ALTER DATABASE d_new ADD REGION 'eu-north-1';
 ALTER DATABASE d_new SET SECONDARY REGION 'eu-north-1';
 ----
-NOTICE: auto-committing transaction before processing DDL due to autocommit_before_ddl setting
-NOTICE: auto-committing transaction before processing DDL due to autocommit_before_ddl setting
-NOTICE: auto-committing transaction before processing DDL due to autocommit_before_ddl setting
-NOTICE: auto-committing transaction before processing DDL due to autocommit_before_ddl setting
-NOTICE: auto-committing transaction before processing DDL due to autocommit_before_ddl setting
-NOTICE: auto-committing transaction before processing DDL due to autocommit_before_ddl setting
-NOTICE: auto-committing transaction before processing DDL due to autocommit_before_ddl setting
 
 exec-sql
 DROP DATABASE d_new;
@@ -148,8 +134,6 @@ CREATE DATABASE no_region_db_2;
 CREATE TABLE no_region_db_2.t (x INT);
 INSERT INTO no_region_db_2.t VALUES (1), (2), (3);
 ----
-NOTICE: auto-committing transaction before processing DDL due to autocommit_before_ddl setting
-NOTICE: auto-committing transaction before processing DDL due to autocommit_before_ddl setting
 
 exec-sql
 BACKUP DATABASE no_region_db INTO 'nodelocal://1/no_region_database_backup/';
@@ -207,7 +191,6 @@ CREATE TABLE eu_central_db.t (x INT);
 INSERT INTO eu_central_db.t VALUES (1), (2), (3);
 ----
 NOTICE: defaulting to 'WITH PRIMARY REGION "eu-central-1"' as no primary region was specified
-NOTICE: auto-committing transaction before processing DDL due to autocommit_before_ddl setting
 
 exec-sql
 BACKUP DATABASE eu_central_db INTO 'nodelocal://1/eu_central_database_backup/';

--- a/pkg/backup/testdata/backup-restore/regression-tests
+++ b/pkg/backup/testdata/backup-restore/regression-tests
@@ -47,12 +47,6 @@ GRANT ZONECONFIG ON DATABASE test TO testuser;
 GRANT ZONECONFIG ON test_table TO testuser;
 GRANT ALL ON test_table2 TO testuser;
 ----
-NOTICE: auto-committing transaction before processing DDL due to autocommit_before_ddl setting
-NOTICE: auto-committing transaction before processing DDL due to autocommit_before_ddl setting
-NOTICE: auto-committing transaction before processing DDL due to autocommit_before_ddl setting
-NOTICE: auto-committing transaction before processing DDL due to autocommit_before_ddl setting
-NOTICE: auto-committing transaction before processing DDL due to autocommit_before_ddl setting
-NOTICE: auto-committing transaction before processing DDL due to autocommit_before_ddl setting
 
 exec-sql
 BACKUP INTO 'nodelocal://1/priv-zone-cfg'
@@ -219,8 +213,6 @@ CREATE SCHEMA d.foo;
 CREATE SCHEMA d.bar;
 CREATE SCHEMA d.baz;
 ----
-NOTICE: auto-committing transaction before processing DDL due to autocommit_before_ddl setting
-NOTICE: auto-committing transaction before processing DDL due to autocommit_before_ddl setting
 
 # The ID of "collide" is normally 109. However, we can't add an assertion for that since ID
 # generation is not deterministic.
@@ -243,7 +235,6 @@ exec-sql
 CREATE DATABASE d2;
 CREATE SCHEMA d2.me;
 ----
-NOTICE: auto-committing transaction before processing DDL due to autocommit_before_ddl setting
 
 exec-sql
 RESTORE TABLE b.me.foo FROM LATEST IN 'nodelocal://1/cluster' WITH into_db=d2

--- a/pkg/backup/testdata/backup-restore/restore-grants
+++ b/pkg/backup/testdata/backup-restore/restore-grants
@@ -416,7 +416,6 @@ exec-sql
 USE defaultdb;
 DROP DATABASE testdb CASCADE;
 ----
-NOTICE: auto-committing transaction before processing DDL due to autocommit_before_ddl setting
 
 exec-sql
 RESTORE DATABASE testdb FROM LATEST IN 'nodelocal://1/test/';
@@ -502,8 +501,6 @@ USE defaultdb;
 DROP DATABASE testdb CASCADE;
 ALTER USER testuser CREATEDB;
 ----
-NOTICE: auto-committing transaction before processing DDL due to autocommit_before_ddl setting
-NOTICE: auto-committing transaction before processing DDL due to autocommit_before_ddl setting
 
 # Lastly, restore the database as a non-admin (testuser). We expect only root
 # and admin to have privileges, but testuser to be the owner of all objects.

--- a/pkg/backup/testdata/backup-restore/restore-schema-only-multiregion
+++ b/pkg/backup/testdata/backup-restore/restore-schema-only-multiregion
@@ -80,8 +80,6 @@ CREATE DATABASE no_region_db_2;
 CREATE TABLE no_region_db_2.t (x INT);
 INSERT INTO no_region_db_2.t VALUES (1), (2), (3);
 ----
-NOTICE: auto-committing transaction before processing DDL due to autocommit_before_ddl setting
-NOTICE: auto-committing transaction before processing DDL due to autocommit_before_ddl setting
 
 exec-sql
 BACKUP DATABASE no_region_db INTO 'nodelocal://1/no_region_database_backup/';
@@ -139,7 +137,6 @@ CREATE TABLE eu_central_db.t (x INT);
 INSERT INTO eu_central_db.t VALUES (1), (2), (3);
 ----
 NOTICE: defaulting to 'WITH PRIMARY REGION "eu-central-1"' as no primary region was specified
-NOTICE: auto-committing transaction before processing DDL due to autocommit_before_ddl setting
 
 exec-sql
 BACKUP DATABASE eu_central_db INTO 'nodelocal://1/eu_central_database_backup/';


### PR DESCRIPTION
We were only setting it if args.bank was not nil.

Fixes #141020

Release note: none