### PR TITLE
nightlies: for nightly stress decrease `RUNS_PER_TEST` to 10

### DIFF
--- a/build/teamcity/cockroach/nightlies/stress_engflow_impl.sh
+++ b/build/teamcity/cockroach/nightlies/stress_engflow_impl.sh
@@ -29,7 +29,7 @@ fi
 
 status=0
 bazel test //pkg:all_tests $ENGFLOW_FLAGS --remote_download_minimal \
-      --runs_per_test ${RUNS_PER_TEST=25} --verbose_failures --build_event_binary_file=artifacts/eventstream \
+      --runs_per_test ${RUNS_PER_TEST=10} --verbose_failures --build_event_binary_file=artifacts/eventstream \
       --profile=artifacts/profile.json.gz \
       ${EXTRA_TEST_ARGS:+$EXTRA_TEST_ARGS} \
       $BES_KEYWORDS_ARGS \


### PR DESCRIPTION
As we have added more release branches, these jobs have gotten extremely slow. The "nightlies" are often running into working hours. The latest run on `master` has already been going for 16 hours or so. This should provide some relief and reduce costs.

Epic: none
Release justification: Non-production code changes
Release note: None