### PR TITLE
docs: update diagrams.go for removed restore syntax

### DIFF
--- a/docs/generated/sql/bnf/restore.bnf
+++ b/docs/generated/sql/bnf/restore.bnf
@@ -1,19 +1,19 @@
 restore_stmt ::=
-	'RESTORE' 'FROM' ( ( subdirectory | 'LATEST' ) ) 'IN' ( ( subdirectory | 'LATEST' ) )_opt_list 'AS' 'OF' 'SYSTEM' 'TIME' timestamp 'WITH' restore_options_list
-	| 'RESTORE' 'FROM' ( ( subdirectory | 'LATEST' ) ) 'IN' ( ( subdirectory | 'LATEST' ) )_opt_list 'AS' 'OF' 'SYSTEM' 'TIME' timestamp 'WITH' 'OPTIONS' '(' restore_options_list ')'
-	| 'RESTORE' 'FROM' ( ( subdirectory | 'LATEST' ) ) 'IN' ( ( subdirectory | 'LATEST' ) )_opt_list 'AS' 'OF' 'SYSTEM' 'TIME' timestamp 
-	| 'RESTORE' 'FROM' ( ( subdirectory | 'LATEST' ) ) 'IN' ( ( subdirectory | 'LATEST' ) )_opt_list  'WITH' restore_options_list
-	| 'RESTORE' 'FROM' ( ( subdirectory | 'LATEST' ) ) 'IN' ( ( subdirectory | 'LATEST' ) )_opt_list  'WITH' 'OPTIONS' '(' restore_options_list ')'
-	| 'RESTORE' 'FROM' ( ( subdirectory | 'LATEST' ) ) 'IN' ( ( subdirectory | 'LATEST' ) )_opt_list  
-	| 'RESTORE' ( 'TABLE' table_pattern ( ( ',' table_pattern ) )* | 'DATABASE' database_name ( ( ',' database_name ) )* ) 'FROM' ( ( subdirectory | 'LATEST' ) ) 'IN' ( ( subdirectory | 'LATEST' ) )_opt_list 'AS' 'OF' 'SYSTEM' 'TIME' timestamp 'WITH' restore_options_list
-	| 'RESTORE' ( 'TABLE' table_pattern ( ( ',' table_pattern ) )* | 'DATABASE' database_name ( ( ',' database_name ) )* ) 'FROM' ( ( subdirectory | 'LATEST' ) ) 'IN' ( ( subdirectory | 'LATEST' ) )_opt_list 'AS' 'OF' 'SYSTEM' 'TIME' timestamp 'WITH' 'OPTIONS' '(' restore_options_list ')'
-	| 'RESTORE' ( 'TABLE' table_pattern ( ( ',' table_pattern ) )* | 'DATABASE' database_name ( ( ',' database_name ) )* ) 'FROM' ( ( subdirectory | 'LATEST' ) ) 'IN' ( ( subdirectory | 'LATEST' ) )_opt_list 'AS' 'OF' 'SYSTEM' 'TIME' timestamp 
-	| 'RESTORE' ( 'TABLE' table_pattern ( ( ',' table_pattern ) )* | 'DATABASE' database_name ( ( ',' database_name ) )* ) 'FROM' ( ( subdirectory | 'LATEST' ) ) 'IN' ( ( subdirectory | 'LATEST' ) )_opt_list  'WITH' restore_options_list
-	| 'RESTORE' ( 'TABLE' table_pattern ( ( ',' table_pattern ) )* | 'DATABASE' database_name ( ( ',' database_name ) )* ) 'FROM' ( ( subdirectory | 'LATEST' ) ) 'IN' ( ( subdirectory | 'LATEST' ) )_opt_list  'WITH' 'OPTIONS' '(' restore_options_list ')'
-	| 'RESTORE' ( 'TABLE' table_pattern ( ( ',' table_pattern ) )* | 'DATABASE' database_name ( ( ',' database_name ) )* ) 'FROM' ( ( subdirectory | 'LATEST' ) ) 'IN' ( ( subdirectory | 'LATEST' ) )_opt_list  
-	| 'RESTORE' 'SYSTEM' 'USERS' 'FROM' ( ( subdirectory | 'LATEST' ) ) 'IN' ( ( subdirectory | 'LATEST' ) )_opt_list 'AS' 'OF' 'SYSTEM' 'TIME' timestamp 'WITH' restore_options_list
-	| 'RESTORE' 'SYSTEM' 'USERS' 'FROM' ( ( subdirectory | 'LATEST' ) ) 'IN' ( ( subdirectory | 'LATEST' ) )_opt_list 'AS' 'OF' 'SYSTEM' 'TIME' timestamp 'WITH' 'OPTIONS' '(' restore_options_list ')'
-	| 'RESTORE' 'SYSTEM' 'USERS' 'FROM' ( ( subdirectory | 'LATEST' ) ) 'IN' ( ( subdirectory | 'LATEST' ) )_opt_list 'AS' 'OF' 'SYSTEM' 'TIME' timestamp 
-	| 'RESTORE' 'SYSTEM' 'USERS' 'FROM' ( ( subdirectory | 'LATEST' ) ) 'IN' ( ( subdirectory | 'LATEST' ) )_opt_list  'WITH' restore_options_list
-	| 'RESTORE' 'SYSTEM' 'USERS' 'FROM' ( ( subdirectory | 'LATEST' ) ) 'IN' ( ( subdirectory | 'LATEST' ) )_opt_list  'WITH' 'OPTIONS' '(' restore_options_list ')'
-	| 'RESTORE' 'SYSTEM' 'USERS' 'FROM' ( ( subdirectory | 'LATEST' ) ) 'IN' ( ( subdirectory | 'LATEST' ) )_opt_list  
+	'RESTORE' 'FROM' string_or_placeholder 'IN' string_or_placeholder_opt_list 'AS' 'OF' 'SYSTEM' 'TIME' timestamp 'WITH' restore_options_list
+	| 'RESTORE' 'FROM' string_or_placeholder 'IN' string_or_placeholder_opt_list 'AS' 'OF' 'SYSTEM' 'TIME' timestamp 'WITH' 'OPTIONS' '(' restore_options_list ')'
+	| 'RESTORE' 'FROM' string_or_placeholder 'IN' string_or_placeholder_opt_list 'AS' 'OF' 'SYSTEM' 'TIME' timestamp 
+	| 'RESTORE' 'FROM' string_or_placeholder 'IN' string_or_placeholder_opt_list  'WITH' restore_options_list
+	| 'RESTORE' 'FROM' string_or_placeholder 'IN' string_or_placeholder_opt_list  'WITH' 'OPTIONS' '(' restore_options_list ')'
+	| 'RESTORE' 'FROM' string_or_placeholder 'IN' string_or_placeholder_opt_list  
+	| 'RESTORE' ( 'TABLE' table_pattern ( ( ',' table_pattern ) )* | 'DATABASE' database_name ( ( ',' database_name ) )* ) 'FROM' string_or_placeholder 'IN' string_or_placeholder_opt_list 'AS' 'OF' 'SYSTEM' 'TIME' timestamp 'WITH' restore_options_list
+	| 'RESTORE' ( 'TABLE' table_pattern ( ( ',' table_pattern ) )* | 'DATABASE' database_name ( ( ',' database_name ) )* ) 'FROM' string_or_placeholder 'IN' string_or_placeholder_opt_list 'AS' 'OF' 'SYSTEM' 'TIME' timestamp 'WITH' 'OPTIONS' '(' restore_options_list ')'
+	| 'RESTORE' ( 'TABLE' table_pattern ( ( ',' table_pattern ) )* | 'DATABASE' database_name ( ( ',' database_name ) )* ) 'FROM' string_or_placeholder 'IN' string_or_placeholder_opt_list 'AS' 'OF' 'SYSTEM' 'TIME' timestamp 
+	| 'RESTORE' ( 'TABLE' table_pattern ( ( ',' table_pattern ) )* | 'DATABASE' database_name ( ( ',' database_name ) )* ) 'FROM' string_or_placeholder 'IN' string_or_placeholder_opt_list  'WITH' restore_options_list
+	| 'RESTORE' ( 'TABLE' table_pattern ( ( ',' table_pattern ) )* | 'DATABASE' database_name ( ( ',' database_name ) )* ) 'FROM' string_or_placeholder 'IN' string_or_placeholder_opt_list  'WITH' 'OPTIONS' '(' restore_options_list ')'
+	| 'RESTORE' ( 'TABLE' table_pattern ( ( ',' table_pattern ) )* | 'DATABASE' database_name ( ( ',' database_name ) )* ) 'FROM' string_or_placeholder 'IN' string_or_placeholder_opt_list  
+	| 'RESTORE' 'SYSTEM' 'USERS' 'FROM' string_or_placeholder 'IN' string_or_placeholder_opt_list 'AS' 'OF' 'SYSTEM' 'TIME' timestamp 'WITH' restore_options_list
+	| 'RESTORE' 'SYSTEM' 'USERS' 'FROM' string_or_placeholder 'IN' string_or_placeholder_opt_list 'AS' 'OF' 'SYSTEM' 'TIME' timestamp 'WITH' 'OPTIONS' '(' restore_options_list ')'
+	| 'RESTORE' 'SYSTEM' 'USERS' 'FROM' string_or_placeholder 'IN' string_or_placeholder_opt_list 'AS' 'OF' 'SYSTEM' 'TIME' timestamp 
+	| 'RESTORE' 'SYSTEM' 'USERS' 'FROM' string_or_placeholder 'IN' string_or_placeholder_opt_list  'WITH' restore_options_list
+	| 'RESTORE' 'SYSTEM' 'USERS' 'FROM' string_or_placeholder 'IN' string_or_placeholder_opt_list  'WITH' 'OPTIONS' '(' restore_options_list ')'
+	| 'RESTORE' 'SYSTEM' 'USERS' 'FROM' string_or_placeholder 'IN' string_or_placeholder_opt_list  

--- a/pkg/cmd/docgen/diagrams.go
+++ b/pkg/cmd/docgen/diagrams.go
@@ -1297,9 +1297,8 @@ var specs = []stmtSpec{
 		replace: map[string]string{
 			"a_expr": "timestamp",
 			"'WITH' 'OPTIONS' '(' kv_option_list ')'": "",
-			"backup_targets":                         "( 'TABLE' table_pattern ( ( ',' table_pattern ) )* | 'DATABASE' database_name ( ( ',' database_name ) )* )",
-			"string_or_placeholder":                  "( ( subdirectory | 'LATEST' ) )",
-			"list_of_string_or_placeholder_opt_list": "( collectionURI | '(' localityURI ( ',' localityURI )* ')' )",
+			"backup_targets": "( 'TABLE' table_pattern ( ( ',' table_pattern ) )* | 'DATABASE' database_name ( ( ',' database_name ) )* )",
+			"string_or_placeholder IN string_or_placeholder_opt_list": "( ( subdirectory | 'LATEST' ) ) 'IN' ( collectionURI | '(' localityURI ( ',' localityURI )* ')' )",
 		},
 		unlink: []string{"subdirectory", "timestamp", "collectionURI", "localityURI"},
 		exclude: []*regexp.Regexp{


### PR DESCRIPTION
The old restore syntax was removed in #135135 and with it, the `list_of_string_or_placeholder` was removed. `diagrams.go`'s entry for `restore_stmt` was not updated accordingly, resulting in a bad match in the `.bnf` files.

Epic: none

Release note: None