### PR TITLE
physicalplan: minor fixes to pooling of FlowSpecs

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_dist.go
+++ b/pkg/ccl/changefeedccl/changefeed_dist.go
@@ -555,7 +555,8 @@ func makePlan(
 
 		// Log the plan diagram URL so that we don't have to rely on it being in system.job_info.
 		const maxLenDiagURL = 1 << 20 // 1 MiB
-		flowSpecs := p.GenerateFlowSpecs()
+		flowSpecs, cleanup := p.GenerateFlowSpecs()
+		defer cleanup(flowSpecs)
 		if _, diagURL, err := execinfrapb.GeneratePlanDiagramURL(
 			fmt.Sprintf("changefeed: %d", jobID),
 			flowSpecs,

--- a/pkg/jobs/jobsprofiler/profiler.go
+++ b/pkg/jobs/jobsprofiler/profiler.go
@@ -41,7 +41,8 @@ func StorePlanDiagram(
 		ctx, cancel = stopper.WithCancelOnQuiesce(ctx)
 		defer cancel()
 
-		flowSpecs := p.GenerateFlowSpecs()
+		flowSpecs, cleanup := p.GenerateFlowSpecs()
+		defer cleanup(flowSpecs)
 		_, diagURL, err := execinfrapb.GeneratePlanDiagramURL(fmt.Sprintf("job:%d", jobID), flowSpecs,
 			execinfrapb.DiagramFlags{})
 		if err != nil {

--- a/pkg/sql/distsql_plan_bulk.go
+++ b/pkg/sql/distsql_plan_bulk.go
@@ -121,8 +121,10 @@ type PhysicalPlanMaker func(context.Context, *DistSQLPlanner) (*PhysicalPlan, *P
 // the number in the old one.
 func calculatePlanGrowth(before, after *PhysicalPlan) (int, float64) {
 	var changed int
-	beforeSpecs := before.GenerateFlowSpecs()
-	afterSpecs := after.GenerateFlowSpecs()
+	beforeSpecs, beforeCleanup := before.GenerateFlowSpecs()
+	defer beforeCleanup(beforeSpecs)
+	afterSpecs, afterCleanup := after.GenerateFlowSpecs()
+	defer afterCleanup(afterSpecs)
 
 	// How many nodes are in after that are not in before, or are in both but
 	// have changed their spec?

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -675,7 +675,8 @@ func (dsp *DistSQLPlanner) Run(
 	evalCtx *extendedEvalContext,
 	finishedSetupFn func(localFlow flowinfra.Flow),
 ) {
-	flows := plan.GenerateFlowSpecs()
+	// Ignore the cleanup function since we will release each spec separately.
+	flows, _ := plan.GenerateFlowSpecs()
 	gatewayFlowSpec, ok := flows[dsp.gatewaySQLInstanceID]
 	if !ok {
 		recv.SetError(errors.Errorf("expected to find gateway flow"))

--- a/pkg/sql/explain_plan.go
+++ b/pkg/sql/explain_plan.go
@@ -88,7 +88,8 @@ func (e *explainPlanNode) startExec(params runParams) error {
 			// cause an error or panic, so swallow the error. See #40677 for example.
 			finalizePlanWithRowCount(params.ctx, planCtx, physicalPlan, plan.mainRowCount)
 			ob.AddDistribution(physicalPlan.Distribution.String())
-			flows := physicalPlan.GenerateFlowSpecs()
+			flows, flowsCleanup := physicalPlan.GenerateFlowSpecs()
+			defer flowsCleanup(flows)
 
 			ctxSessionData := planCtx.EvalContext().SessionData()
 			var willVectorize bool

--- a/pkg/sql/explain_vec.go
+++ b/pkg/sql/explain_vec.go
@@ -56,7 +56,8 @@ func (n *explainVecNode) startExec(params runParams) error {
 	}
 
 	finalizePlanWithRowCount(params.ctx, planCtx, physPlan, n.plan.mainRowCount)
-	flows := physPlan.GenerateFlowSpecs()
+	flows, flowsCleanup := physPlan.GenerateFlowSpecs()
+	defer flowsCleanup(flows)
 	flowCtx := newFlowCtxForExplainPurposes(params.ctx, params.p)
 
 	// We want to get the vectorized plan which would be executed with the

--- a/pkg/sql/physicalplan/specs.go
+++ b/pkg/sql/physicalplan/specs.go
@@ -34,6 +34,7 @@ func ReleaseFlowSpec(spec *execinfrapb.FlowSpec) {
 		if tr := spec.Processors[i].Core.TableReader; tr != nil {
 			releaseTableReaderSpec(tr)
 		}
+		spec.Processors[i] = execinfrapb.ProcessorSpec{}
 	}
 	*spec = execinfrapb.FlowSpec{
 		Processors: spec.Processors[:0],


### PR DESCRIPTION
**physicalplan: ensure that FlowSpecs are released**

We pool `FlowSpec` allocations in `GenerateFlowSpecs`, but previously we would only release them back to the pool on the main query path. This commit fixes that oversight.

**physicalplan: fix minor leak with pooling of FlowSpecs**

The only thing that we reuse when pooling `FlowSpec` objects is the capacity of `Processors` slice. Previously, we forgot to unset each element of that slice, so we could have hold onto to some processor specs which in turn could have hold onto some large objects (like `roachpb.Span`s in the TableReader) until a particular index of the slice is overwritten. This oversight is now fixed.

Found while looking at #140326.
Epic: None
Release note: None