### PR TITLE
sql/vecindex: add SearchForDelete method to VectorIndex

### DIFF
--- a/pkg/sql/vecindex/testdata/search-for-delete.ddt
+++ b/pkg/sql/vecindex/testdata/search-for-delete.ddt
@@ -1,0 +1,155 @@
+# ----------
+# Search tree with multiple partitions and duplicate data.
+# ----------
+new-index dims=2 min-partition-size=1 max-partition-size=4 beam-size=2
+vec1: (1, 2)
+vec2: (7, 4)
+vec3: (4, 3)
+vec4: (2, 8)
+vec5: (5, 1)
+vec6: (3, 6)
+vec7: (6, 5)
+vec8: (8, 3)
+vec9: (1, 7)
+vec10: (1, 7)
+vec11: (1, 7)
+vec12: (1, 7)
+vec13: (1, 7)
+----
+• 1 (3.2083, 5.125)
+│
+├───• 10 (1.5, 7)
+│   │
+│   ├───• 9 (1, 7)
+│   │   │
+│   │   ├───• vec9 (1, 7)
+│   │   └───• vec13 (1, 7)
+│   │
+│   ├───• 8 (1, 7)
+│   │   │
+│   │   ├───• vec12 (1, 7)
+│   │   ├───• vec10 (1, 7)
+│   │   └───• vec11 (1, 7)
+│   │
+│   └───• 7 (2.5, 7)
+│       │
+│       ├───• vec4 (2, 8)
+│       └───• vec6 (3, 6)
+│
+└───• 11 (4.9167, 3.25)
+    │
+    ├───• 5 (6.5, 4.5)
+    │   │
+    │   ├───• vec7 (6, 5)
+    │   ├───• vec2 (7, 4)
+    │   └───• vec8 (8, 3)
+    │
+    └───• 3 (3.3333, 2)
+        │
+        ├───• vec3 (4, 3)
+        ├───• vec5 (5, 1)
+        └───• vec1 (1, 2)
+
+# Search for vector that exists.
+search-for-delete
+vec1
+----
+vec1: partition 3
+
+# Search for vector that does not exist in tree.
+search-for-delete
+vec100: (10, 10)
+----
+vec100: vector not found
+
+# Search for vector that exists, but without a matching key.
+search-for-delete
+vec100: (1, 2)
+----
+vec100: vector not found
+
+# Search for duplicate vector.
+search-for-delete
+vec12
+----
+vec12: partition 8
+
+# Delete vector from store, but leave it in index.
+delete not-found
+vec1
+----
+• 1 (3.2083, 5.125)
+│
+├───• 10 (1.5, 7)
+│   │
+│   ├───• 9 (1, 7)
+│   │   │
+│   │   ├───• vec9 (1, 7)
+│   │   └───• vec13 (1, 7)
+│   │
+│   ├───• 8 (1, 7)
+│   │   │
+│   │   ├───• vec12 (1, 7)
+│   │   ├───• vec10 (1, 7)
+│   │   └───• vec11 (1, 7)
+│   │
+│   └───• 7 (2.5, 7)
+│       │
+│       ├───• vec4 (2, 8)
+│       └───• vec6 (3, 6)
+│
+└───• 11 (4.9167, 3.25)
+    │
+    ├───• 5 (6.5, 4.5)
+    │   │
+    │   ├───• vec7 (6, 5)
+    │   ├───• vec2 (7, 4)
+    │   └───• vec8 (8, 3)
+    │
+    └───• 3 (3.3333, 2)
+        │
+        ├───• vec3 (4, 3)
+        ├───• vec5 (5, 1)
+        └───• vec1 (MISSING)
+
+# Try to find the missing vector.
+search-for-delete
+vec1: (1, 2)
+----
+vec1: vector not found
+
+# Vector should now be gone from the index.
+format-tree
+----
+• 1 (3.2083, 5.125)
+│
+├───• 10 (1.5, 7)
+│   │
+│   ├───• 9 (1, 7)
+│   │   │
+│   │   ├───• vec9 (1, 7)
+│   │   └───• vec13 (1, 7)
+│   │
+│   ├───• 8 (1, 7)
+│   │   │
+│   │   ├───• vec12 (1, 7)
+│   │   ├───• vec10 (1, 7)
+│   │   └───• vec11 (1, 7)
+│   │
+│   └───• 7 (2.5, 7)
+│       │
+│       ├───• vec4 (2, 8)
+│       └───• vec6 (3, 6)
+│
+└───• 11 (4.9167, 3.25)
+    │
+    ├───• 5 (6.5, 4.5)
+    │   │
+    │   ├───• vec7 (6, 5)
+    │   ├───• vec2 (7, 4)
+    │   └───• vec8 (8, 3)
+    │
+    └───• 3 (3.3333, 2)
+        │
+        ├───• vec3 (4, 3)
+        └───• vec5 (5, 1)


### PR DESCRIPTION
Previously, the Delete method had both searched for a vector's partition and handle deleting the vector from that partition. However, the execution engine wants to find the partition without actually deleting the vector, since it will do the deletion as part of its own KV batching logic.

The new SearchForDelete method handles just the search portion of deletion, returning the SearchResult containing the partition key. In addition, the Delete method has been refactored to use SearchForDelete internally.

Epic: CRDB-42943

Release note: None