### PR TITLE
sql: add test-only assertion for memory aliasing of TableReaderSpec.Spans

### DIFF
--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -2137,9 +2137,6 @@ func (dsp *DistSQLPlanner) convertOrdering(
 func initTableReaderSpecTemplate(
 	n *scanNode, codec keys.SQLCodec,
 ) (*execinfrapb.TableReaderSpec, execinfrapb.PostProcessSpec, error) {
-	if n.isCheck {
-		return nil, execinfrapb.PostProcessSpec{}, errors.AssertionFailedf("isCheck no longer supported")
-	}
 	colIDs := make([]descpb.ColumnID, len(n.cols))
 	for i := range n.cols {
 		colIDs[i] = n.cols[i].GetID()

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -9,11 +9,13 @@ import (
 	"context"
 	"fmt"
 	"math"
+	"reflect"
 	"runtime"
 	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
+	"unsafe"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
@@ -395,12 +397,44 @@ func (dsp *DistSQLPlanner) setupFlows(
 	statementSQL string,
 ) (context.Context, flowinfra.Flow, error) {
 	thisNodeID := dsp.gatewaySQLInstanceID
-	_, ok := flows[thisNodeID]
+	thisNodeSpec, ok := flows[thisNodeID]
 	if !ok {
 		return nil, nil, errors.AssertionFailedf("missing gateway flow")
 	}
 	if localState.IsLocal && len(flows) != 1 {
 		return nil, nil, errors.AssertionFailedf("IsLocal set but there's multiple flows")
+	}
+
+	if buildutil.CrdbTestBuild && len(flows) > 1 {
+		// Ensure that we don't have memory aliasing of some fields between the
+		// local flow and the remote ones. At the time of writing only
+		// TableReaderSpec.Spans is known to be problematic.
+		gatewayFlowSpans := make(map[uintptr]int32)
+		for _, p := range thisNodeSpec.Processors {
+			if tr := p.Core.TableReader; tr != nil {
+				//lint:ignore SA1019 SliceHeader is deprecated, but no clear replacement
+				ptr := (*reflect.SliceHeader)(unsafe.Pointer(&tr.Spans))
+				gatewayFlowSpans[ptr.Data] = p.ProcessorID
+			}
+		}
+		for sqlInstanceID, flow := range flows {
+			if sqlInstanceID == thisNodeID {
+				continue
+			}
+			for _, p := range flow.Processors {
+				if tr := p.Core.TableReader; tr != nil {
+					//lint:ignore SA1019 SliceHeader is deprecated, but no clear replacement
+					ptr := (*reflect.SliceHeader)(unsafe.Pointer(&tr.Spans))
+					if procID, found := gatewayFlowSpans[ptr.Data]; found {
+						return nil, nil, errors.AssertionFailedf(
+							"found TableReaderSpec.Spans memory aliasing between local and remote flows\n"+
+								"statement: %s, local proc ID %d, remote proc ID %d\n%v",
+							statementSQL, procID, p.ProcessorID, flows,
+						)
+					}
+				}
+			}
+		}
 	}
 
 	const setupFlowRequestStmtMaxLength = 500
@@ -456,7 +490,7 @@ func (dsp *DistSQLPlanner) setupFlows(
 	}
 
 	// First, set up the flow on this node.
-	setupReq.Flow = *flows[thisNodeID]
+	setupReq.Flow = *thisNodeSpec
 	var batchReceiver execinfra.BatchReceiver
 	if recv.batchWriter != nil {
 		// Use the DistSQLReceiver as an execinfra.BatchReceiver only if the

--- a/pkg/sql/scan.go
+++ b/pkg/sql/scan.go
@@ -75,10 +75,6 @@ type scanNode struct {
 	// Is this a full scan of an index?
 	isFull bool
 
-	// Indicates if this scanNode will do a physical data check. This is
-	// only true when running SCRUB commands.
-	isCheck bool
-
 	// estimatedRowCount is the estimated number of rows that this scanNode will
 	// output. When there are no statistics to make the estimation, it will be
 	// set to zero.


### PR DESCRIPTION
We just saw a data race `TableReaderSpec.Spans` field being modified during the execution of the local flow and being serialized as part of SetupFlowRequest RPC for a remote flow. I don't quite understand how this could have happened since we should never be sharing the same slice in such a scenario, so in order to have more information if it happens again we add an assertion that explicitly checks for memory sharing of this field.

Fixes: #140326.

Release note: None