### PR TITLE
sql: fix auto-retry behavior with autocommit_before_ddl

### DIFF
--- a/pkg/sql/conn_executor_ddl.go
+++ b/pkg/sql/conn_executor_ddl.go
@@ -41,7 +41,7 @@ func (ex *connExecutor) maybeAutoCommitBeforeDDL(
 		ex.sessionData().AutoCommitBeforeDDL &&
 		(!ex.planner.EvalContext().TxnIsSingleStmt || !ex.implicitTxn()) &&
 		ex.extraTxnState.firstStmtExecuted {
-		if err := ex.planner.SendClientNotice(
+		if err := ex.planner.BufferClientNoticeInConnection(
 			ctx,
 			pgnotice.Newf("auto-committing transaction before processing DDL due to autocommit_before_ddl setting"),
 		); err != nil {

--- a/pkg/sql/conn_io.go
+++ b/pkg/sql/conn_io.go
@@ -838,6 +838,10 @@ type RestrictedCommandResult interface {
 	// This gets flushed only when the CommandResult is closed.
 	BufferNotice(notice pgnotice.Notice)
 
+	// BufferNoticeInConnection buffers the notice in the client connection,
+	// but does not flush it yet.
+	BufferNoticeInConnection(ctx context.Context, notice pgnotice.Notice) error
+
 	// SendNotice immediately flushes a notice to the client.
 	SendNotice(ctx context.Context, notice pgnotice.Notice) error
 
@@ -1111,6 +1115,13 @@ func (r *streamingCommandResult) BufferParamStatusUpdate(key string, val string)
 // BufferNotice is part of the RestrictedCommandResult interface.
 func (r *streamingCommandResult) BufferNotice(notice pgnotice.Notice) {
 	// Unimplemented: the internal executor does not support notices.
+}
+
+// BufferNoticeInConnection is part of the RestrictedCommandResult interface.
+func (r *streamingCommandResult) BufferNoticeInConnection(
+	ctx context.Context, notice pgnotice.Notice,
+) error {
+	return nil
 }
 
 // SendNotice is part of the RestrictedCommandResult interface.

--- a/pkg/sql/faketreeeval/evalctx.go
+++ b/pkg/sql/faketreeeval/evalctx.go
@@ -650,6 +650,13 @@ var _ eval.ClientNoticeSender = &DummyClientNoticeSender{}
 // BufferClientNotice is part of the eval.ClientNoticeSender interface.
 func (c *DummyClientNoticeSender) BufferClientNotice(context.Context, pgnotice.Notice) {}
 
+// BufferClientNoticeInConnection is part of the eval.ClientNoticeSender interface.
+func (c *DummyClientNoticeSender) BufferClientNoticeInConnection(
+	context.Context, pgnotice.Notice,
+) error {
+	return nil
+}
+
 // SendClientNotice is part of the eval.ClientNoticeSender interface.
 func (c *DummyClientNoticeSender) SendClientNotice(context.Context, pgnotice.Notice) error {
 	return nil

--- a/pkg/sql/logictest/BUILD.bazel
+++ b/pkg/sql/logictest/BUILD.bazel
@@ -62,7 +62,6 @@ go_library(
         "//pkg/kv/kvclient/rangefeed",
         "//pkg/kv/kvserver",
         "//pkg/kv/kvserver/kvserverbase",
-        "//pkg/kv/kvserver/txnwait",
         "//pkg/multitenant/tenantcapabilities",
         "//pkg/security/username",
         "//pkg/server",

--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -41,7 +41,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/rangefeed"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
-	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/txnwait"
 	"github.com/cockroachdb/cockroach/pkg/multitenant/tenantcapabilities"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/server"
@@ -4388,18 +4387,6 @@ func RunLogicTest(
 	}
 	if *printErrorSummary {
 		defer lt.printErrorSummary()
-	}
-	if config.UseSecondaryTenant == logictestbase.Always {
-		// Under multitenant configs running in EngFlow, we have seen that logic
-		// tests can be flaky due to an overload condition where schema change
-		// transactions do not heartbeat quickly enough. This allows background jobs
-		// such as the spanconfig reconciler or the job registry "remove claims from
-		// dead sessions" loop.
-		// See https://github.com/cockroachdb/cockroach/pull/140400#issuecomment-2634346278
-		// and https://github.com/cockroachdb/cockroach/issues/140494#issuecomment-2640208187
-		// for a detailed analysis of this issue.
-		cleanup := txnwait.TestingOverrideTxnLivenessThreshold(30 * time.Second)
-		defer cleanup()
 	}
 	// Each test needs a copy because of Parallel
 	serverArgsCopy := serverArgs

--- a/pkg/sql/logictest/testdata/logic_test/upsert
+++ b/pkg/sql/logictest/testdata/logic_test/upsert
@@ -623,6 +623,7 @@ CREATE TABLE t29494(x INT); INSERT INTO t29494 VALUES (12)
 
 statement ok
 BEGIN TRANSACTION ISOLATION LEVEL SERIALIZABLE;
+SET LOCAL autocommit_before_ddl = false;
 ALTER TABLE t29494 ADD COLUMN y INT NOT NULL DEFAULT 123
 
 # Check that the new column is not visible
@@ -643,6 +644,7 @@ UPSERT INTO t29494(x) VALUES (123) RETURNING y
 statement ok
 ROLLBACK;
 BEGIN TRANSACTION ISOLATION LEVEL SERIALIZABLE;
+SET LOCAL autocommit_before_ddl = false;
 ALTER TABLE t29494 ADD COLUMN y INT NOT NULL DEFAULT 123
 
 statement error column "y" does not exist
@@ -653,6 +655,7 @@ ROLLBACK
 
 statement ok
 BEGIN TRANSACTION ISOLATION LEVEL SERIALIZABLE;
+SET LOCAL autocommit_before_ddl = false;
 ALTER TABLE t29494 ADD COLUMN y INT NOT NULL DEFAULT 123
 
 query I
@@ -694,6 +697,7 @@ CREATE TABLE t29497(x INT PRIMARY KEY);
 
 statement ok
 BEGIN TRANSACTION ISOLATION LEVEL SERIALIZABLE;
+SET LOCAL autocommit_before_ddl = false;
 ALTER TABLE t29497 ADD COLUMN y INT NOT NULL DEFAULT 123
 
 statement error UPSERT has more expressions than target columns
@@ -704,6 +708,7 @@ ROLLBACK;
 
 statement ok
 BEGIN TRANSACTION ISOLATION LEVEL SERIALIZABLE;
+SET LOCAL autocommit_before_ddl = false;
 ALTER TABLE t29497 ADD COLUMN y INT NOT NULL DEFAULT 123
 
 statement error column "y" does not exist
@@ -716,6 +721,7 @@ subtest visible_returning_columns
 
 statement ok
 BEGIN TRANSACTION ISOLATION LEVEL SERIALIZABLE;
+SET LOCAL autocommit_before_ddl = false;
 ALTER TABLE tc DROP COLUMN y
 
 query I colnames,rowsort
@@ -974,6 +980,7 @@ CREATE TABLE table38627 (a INT PRIMARY KEY, b INT); INSERT INTO table38627 VALUE
 
 statement ok
 BEGIN TRANSACTION ISOLATION LEVEL SERIALIZABLE;
+SET LOCAL autocommit_before_ddl = false;
 ALTER TABLE table38627 ADD COLUMN c INT NOT NULL DEFAULT 5
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/virtual_columns
+++ b/pkg/sql/logictest/testdata/logic_test/virtual_columns
@@ -823,7 +823,8 @@ a  b   v
 
 # Add virtual columns inside an explicit transactions.
 statement ok
-BEGIN
+BEGIN TRANSACTION ISOLATION LEVEL SERIALIZABLE;
+SET LOCAL autocommit_before_ddl = false;
 
 statement ok
 ALTER TABLE sc ADD COLUMN w1 INT AS (a*b) VIRTUAL
@@ -878,7 +879,8 @@ ALTER TABLE sc DROP COLUMN v
 
 # Add a column and an index on that column in the same transaction.
 statement ok
-BEGIN
+BEGIN TRANSACTION ISOLATION LEVEL SERIALIZABLE;
+SET LOCAL autocommit_before_ddl = false;
 
 statement ok
 ALTER TABLE sc ADD COLUMN v INT AS (a+b) VIRTUAL
@@ -905,10 +907,8 @@ ALTER TABLE sc DROP COLUMN v
 # Adding a column and a partial index using that column in the predicate in the
 # same transaction is not allowed.
 statement ok
-SET autocommit_before_ddl = false
-
-statement ok
 BEGIN TRANSACTION ISOLATION LEVEL SERIALIZABLE;
+SET LOCAL autocommit_before_ddl = false;
 
 statement ok
 ALTER TABLE sc ADD COLUMN v INT AS (a+b) VIRTUAL
@@ -918,9 +918,6 @@ CREATE INDEX partial_idx ON sc(b) WHERE v > 20
 
 statement ok
 END
-
-statement ok
-RESET autocommit_before_ddl
 
 statement ok
 ALTER TABLE sc ADD COLUMN v INT AS (a+b) VIRTUAL
@@ -1088,11 +1085,9 @@ statement error pgcode 0A000 virtual computed column "k" referencing columns \("
 ALTER TABLE t_ref ADD COLUMN j INT NOT NULL DEFAULT 42,
    ADD COLUMN k INT AS (i+j) VIRTUAL;
 
-statement ok
-SET autocommit_before_ddl = false
-
 statement error pgcode 0A000 virtual computed column "l" referencing columns \("j", "k"\) added in the current transaction
 BEGIN TRANSACTION ISOLATION LEVEL SERIALIZABLE;
+    SET LOCAL autocommit_before_ddl = false;
     ALTER TABLE t_ref ADD COLUMN j INT NOT NULL DEFAULT 42;
     ALTER TABLE t_ref ADD COLUMN k INT NOT NULL DEFAULT 42;
     ALTER TABLE t_ref ADD COLUMN l INT AS (i+j+k) VIRTUAL;
@@ -1101,9 +1096,6 @@ COMMIT;
 statement ok
 ROLLBACK;
 
-statement ok
-RESET autocommit_before_ddl
-
 # Test that adding virtual computed columns to tables which have been created
 # in the current transaction is fine.
 
@@ -1111,10 +1103,8 @@ statement ok
 DROP TABLE t_ref;
 
 statement ok
-SET autocommit_before_ddl = false
-
-statement ok
 BEGIN TRANSACTION ISOLATION LEVEL SERIALIZABLE;
+    SET LOCAL autocommit_before_ddl = false;
     CREATE TABLE t_ref (i INT PRIMARY KEY);
     ALTER TABLE t_ref ADD COLUMN j INT NOT NULL DEFAULT 42;
     ALTER TABLE t_ref ADD COLUMN k INT AS (i+j) VIRTUAL;
@@ -1122,9 +1112,6 @@ COMMIT;
 
 statement ok
 DROP TABLE t_ref;
-
-statement ok
-RESET autocommit_before_ddl
 
 # Tests for virtual computed columns that reference foreign key columns.
 subtest referencing_fks
@@ -1315,12 +1302,14 @@ ALTER TABLE virtual_pk DROP COLUMN d;
 # the legacy schema changer.
 statement ok
 BEGIN TRANSACTION ISOLATION LEVEL SERIALIZABLE;
+SET LOCAL autocommit_before_ddl = false;
 SET LOCAL use_declarative_schema_changer = off;
 ALTER TABLE virtual_pk ADD COLUMN d INT NOT NULL DEFAULT 42;
 COMMIT;
 
 statement ok
 BEGIN TRANSACTION ISOLATION LEVEL SERIALIZABLE;
+SET LOCAL autocommit_before_ddl = false;
 SET LOCAL use_declarative_schema_changer = off;
 ALTER TABLE virtual_pk DROP COLUMN d;
 COMMIT;

--- a/pkg/sql/pgwire/command_result.go
+++ b/pkg/sql/pgwire/command_result.go
@@ -327,6 +327,13 @@ func (r *commandResult) BufferNotice(notice pgnotice.Notice) {
 	r.buffer.notices = append(r.buffer.notices, notice)
 }
 
+// BufferNoticeInConnection is part of the sql.RestrictedCommandResult interface.
+func (r *commandResult) BufferNoticeInConnection(
+	ctx context.Context, notice pgnotice.Notice,
+) error {
+	return r.conn.bufferNotice(ctx, notice)
+}
+
 // SendNotice is part of the sql.RestrictedCommandResult interface.
 func (r *commandResult) SendNotice(ctx context.Context, notice pgnotice.Notice) error {
 	if err := r.conn.bufferNotice(ctx, notice); err != nil {

--- a/pkg/sql/planhook.go
+++ b/pkg/sql/planhook.go
@@ -114,6 +114,7 @@ type PlanHookState interface {
 	SpanConfigReconciler() spanconfig.Reconciler
 	SpanStatsConsumer() keyvisualizer.SpanStatsConsumer
 	BufferClientNotice(ctx context.Context, notice pgnotice.Notice)
+	BufferClientNoticeInConnection(ctx context.Context, notice pgnotice.Notice) error
 	SendClientNotice(ctx context.Context, notice pgnotice.Notice) error
 	Txn() *kv.Txn
 	LookupTenantInfo(ctx context.Context, tenantSpec *tree.TenantSpec, op string) (*mtinfopb.TenantInfo, error)

--- a/pkg/sql/sem/eval/deps.go
+++ b/pkg/sql/sem/eval/deps.go
@@ -550,6 +550,12 @@ type ClientNoticeSender interface {
 	// BufferClientNotice buffers the notice to send to the client.
 	// This is flushed before the connection is closed.
 	BufferClientNotice(ctx context.Context, notice pgnotice.Notice)
+	// BufferClientNoticeInConnection buffers the notice in the client connection
+	// buffer rather than in the ClientNoticeSender itself. This should only be
+	// used when the notice should be buffered even if the current command will be
+	// executed again, like with the autocommit_before_ddl notice. Most cases
+	// should use BufferClientNotice.
+	BufferClientNoticeInConnection(ctx context.Context, notice pgnotice.Notice) error
 	// SendClientNotice immediately flushes the notice to the client. This is used
 	// to implement PLpgSQL RAISE statements; most cases should use
 	// BufferClientNotice.


### PR DESCRIPTION
When the autocommit_before_ddl setting was enabled, we were
sending a notice to the client without any buffering. This prevents
auto-retry logic for retriable errors from kicking in, since if results
have already sent to the client, it's not safe to retry the current
statement.

The fix is to buffer the notice for sending instead. It will get sent
whenever results are flushed back to the client. In order to achieve
this, I introduced a new BufferClientNoticeInConnection function. The
existing BufferClientNotice function is not sufficient since that only
buffers notices in the command result, and that buffer is discarded due
to how the connExecutor state transitions are defined. Namely, the
connExecutor will execute the schema change command twice: once to
autocommit the current transaction, and another time to run the schema
change. To avoid losing the notice from the autocommit, it must be
buffered all the way into the client connection, and not just the
command result.

Running with this patch makes logic tests less flaky, since schema
changes that encounter retryable errors are way more likely to be able
to be automatically retried now. This allows us to remove the testing
knob that overrode the transaction liveness threshold. I verified the
flakiness is gone by using:
```
./dev testlogic ccl --config=3node-tenant --stress --ignore-cache
```

informs https://github.com/cockroachdb/cockroach/issues/133180
Release note (bug fix): Fixed a bug that prevented transaction retry
errors encountered during implicit transactions from being automatically
retried internally if the autocommit_before_ddl session variable was
enabled and the statement was a schema change.