### PR TITLE
kvserver: more logging in TestTxnReadWithinUncertaintyIntervalAfterLeaseTransfer

### DIFF
--- a/pkg/kv/kvserver/client_replica_test.go
+++ b/pkg/kv/kvserver/client_replica_test.go
@@ -865,7 +865,7 @@ func TestTxnReadWithinUncertaintyIntervalAfterLeaseTransfer(t *testing.T) {
 	assert.True(t, txn.ObservedTimestamps[0].Timestamp.ToTimestamp().Less(writeTs))
 
 	if t.Failed() {
-		t.Logf("writeTs=%s, txn=%+v", writeTs, txn)
+		t.Logf("writeTs=%s, txn=%+v, obsTs=%+v", writeTs, txn, txn.ObservedTimestamps)
 		t.FailNow()
 	}
 


### PR DESCRIPTION
Log the observed timestamps as well. This is what it looks like (this was a passing run that I made fail on purpose, since the flake is hard to repro):

    client_replica_test.go:869: writeTs=1739273727.738545100,1, txn="test" meta={id=6fe77d84 key="b" iso=Serializable
    pri=0.03472329 epo=0 ts=1739273727.738545000,0 min=1739273727.738545000,0 seq=0} lock=true stat=PENDING
    rts=1739273727.738545000,0 wto=false gul=1739273728.238545000,0,
    obsTs=[{NodeID:2 Timestamp:1739273727.738545000,3}]

Note that here the observed timestamp equals the txn's timestamp, mod some logical ticks.  This isn't true in the failure case, where the (or at least an) observed timestamp seems to be 100+ns in the future.

Touches https://github.com/cockroachdb/cockroach/issues/141041.

Epic: none

Release note: None