### PR TITLE
ci: do not wait on disabled builds

### DIFF
--- a/build/teamcity/internal/release/process/check-gha.sh
+++ b/build/teamcity/internal/release/process/check-gha.sh
@@ -28,11 +28,7 @@ $BAZEL_BIN/pkg/cmd/github-action-poller/github-action-poller_/github-action-poll
   lint \
   linux_amd64_build \
   linux_amd64_fips_build \
-  linux_arm64_build \
   local_roachtest \
   local_roachtest_fips \
-  macos_amd64_build \
-  macos_arm64_build \
-  unit_tests \
-  windows_build
+  unit_tests
 EOF


### PR DESCRIPTION
In #141005 we disabled some CI builds, but our nightly builds still check for the results of those builds.

This PR removes the disabled build checks.

Part of: CRDB-46376
Release note: None