### PR TITLE
sql: Include RLS policies in EXPLAIN output

### DIFF
--- a/pkg/sql/opt/cat/policy.go
+++ b/pkg/sql/opt/cat/policy.go
@@ -8,6 +8,7 @@ package cat
 import (
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 )
 
@@ -37,6 +38,8 @@ type Policy struct {
 	// Name is the name of the policy. The name is unique within a table
 	// and cannot be qualified.
 	Name tree.Name
+	// ID is the unique identifier for this policy within the table.
+	ID descpb.PolicyID
 	// UsingExpr is the optional filter expression evaluated on rows during
 	// read operations. If the policy does not define a USING expression, this is
 	// an empty string.

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -378,6 +378,7 @@ func (b *Builder) buildRelational(e memo.RelExpr) (_ execPlan, outputCols colOrd
 	}
 
 	b.maybeAnnotateWithEstimates(ep.root, e)
+	b.maybeAnnotatePolicyInfo(ep.root, e)
 
 	if saveTableName != "" {
 		// The output columns do not change in applySaveTable.
@@ -439,6 +440,57 @@ func (b *Builder) maybeAnnotateWithEstimates(node exec.Node, e memo.RelExpr) {
 			}
 		}
 		ef.AnnotateNode(node, exec.EstimatedStatsID, &val)
+	}
+}
+
+// maybeAnnotatePolicyInfo checks if we are building against an
+// ExplainFactory and annotates the node with row-level security policy
+// information.
+func (b *Builder) maybeAnnotatePolicyInfo(node exec.Node, e memo.RelExpr) {
+	if ef, ok := b.factory.(exec.ExplainFactory); ok {
+		rlsMeta := b.mem.Metadata().GetRLSMeta()
+		// RLS is lazily initialized, and only when it comes across a RLS enabled
+		// table.
+		if !rlsMeta.IsInitialized {
+			return
+		}
+		// Helper to annotate a node for the given table ID.
+		annotateNodeForTable := func(tabID opt.TableID) {
+			// Pull out the policy information for the table the node was built for.
+			policies, found := rlsMeta.PoliciesApplied[tabID]
+			if found {
+				val := exec.RLSPoliciesApplied{
+					PoliciesSkippedForRole: rlsMeta.HasAdminRole,
+					Policies:               policies,
+				}
+				ef.AnnotateNode(node, exec.PolicyInfoID, &val)
+			}
+		}
+		switch e := e.(type) {
+		case *memo.ValuesExpr:
+			// Normally, since policies apply to specific tables, we annotate when we
+			// come across a scan of a single table. We need to annotate a "norows"
+			// value as this can be emitted when scanning a table and RLS forced all
+			// rows to be filtered out because none of the policies applied.
+			if len(e.Rows) == 0 && rlsMeta.NoPoliciesApplied {
+				ef.AnnotateNode(node, exec.PolicyInfoID, &exec.RLSPoliciesApplied{})
+			}
+		case *memo.ScanExpr:
+			annotateNodeForTable(e.Table)
+		case *memo.LookupJoinExpr:
+			annotateNodeForTable(e.Table)
+		case *memo.ZigzagJoinExpr:
+			annotateNodeForTable(e.LeftTable)
+			annotateNodeForTable(e.RightTable)
+		case *memo.InvertedJoinExpr:
+			annotateNodeForTable(e.Table)
+		case *memo.PlaceholderScanExpr:
+			annotateNodeForTable(e.Table)
+		case *memo.IndexJoinExpr:
+			annotateNodeForTable(e.Table)
+		case *memo.VectorSearchExpr:
+			annotateNodeForTable(e.Table)
+		}
 	}
 }
 

--- a/pkg/sql/opt/exec/explain/flags.go
+++ b/pkg/sql/opt/exec/explain/flags.go
@@ -30,6 +30,9 @@ type Flags struct {
 
 	// Flags to hide various fields for testing purposes.
 	Deflake DeflakeFlags
+	// ShowPolicyInfo indicates that row-level security policy information is
+	// shown.
+	ShowPolicyInfo bool
 }
 
 // DeflakeFlags control hiding of various field values. They are used to
@@ -67,9 +70,11 @@ func MakeFlags(options *tree.ExplainOptions) Flags {
 	var f Flags
 	if options.Flags[tree.ExplainFlagVerbose] {
 		f.Verbose = true
+		f.ShowPolicyInfo = true
 	}
 	if options.Flags[tree.ExplainFlagTypes] {
 		f.Verbose = true
+		f.ShowPolicyInfo = true
 		f.ShowTypes = true
 	}
 	if options.Flags[tree.ExplainFlagShape] {

--- a/pkg/sql/opt/exec/explain/plan_gist_test.go
+++ b/pkg/sql/opt/exec/explain/plan_gist_test.go
@@ -74,7 +74,7 @@ func plan(ot *opttester.OptTester, t *testing.T) string {
 	if explainPlan == nil {
 		t.Fatal("Couldn't ExecBuild memo, use a logictest instead?")
 	}
-	flags := explain.Flags{HideValues: true, Deflake: explain.DeflakeAll, OnlyShape: true}
+	flags := explain.Flags{HideValues: true, Deflake: explain.DeflakeAll, OnlyShape: true, ShowPolicyInfo: true}
 	ob := explain.NewOutputBuilder(flags)
 	err = explain.Emit(context.Background(), &eval.Context{}, explainPlan.(*explain.Plan), ob, func(table cat.Table, index cat.Index, scanParams exec.ScanParams) string { return "" }, false /* createPostQueryPlanIfMissing */)
 	if err != nil {
@@ -85,7 +85,7 @@ func plan(ot *opttester.OptTester, t *testing.T) string {
 	return str
 }
 
-func TestPlanGistBuilder(t *testing.T) {
+func TestExplainBuilder(t *testing.T) {
 	catalog := testcat.New()
 	testGists := func(t *testing.T, d *datadriven.TestData) string {
 		ot := opttester.New(catalog, d.Input)
@@ -116,10 +116,13 @@ func TestPlanGistBuilder(t *testing.T) {
 		}
 	}
 	// RFC: should I move this to opt_tester?
-	datadriven.RunTest(t, datapathutils.TestDataPath(t, "gists"), testGists)
-	// Reset the catalog for the next test.
-	catalog = testcat.New()
-	datadriven.RunTest(t, datapathutils.TestDataPath(t, "gists_tpce"), testGists)
+	for _, testfile := range []string{"gists", "gists_tpce", "row_level_security"} {
+		t.Run(testfile, func(t *testing.T) {
+			datadriven.RunTest(t, datapathutils.TestDataPath(t, testfile), testGists)
+			// Reset the catalog for the next test.
+			catalog = testcat.New()
+		})
+	}
 }
 
 func TestPlanGistHashEquivalency(t *testing.T) {

--- a/pkg/sql/opt/exec/explain/testdata/row_level_security
+++ b/pkg/sql/opt/exec/explain/testdata/row_level_security
@@ -1,0 +1,173 @@
+# Setup
+# ----------------------------------------------------------------------
+
+exec-ddl
+CREATE USER rls_accessor
+----
+
+exec-ddl
+SET ROLE rls_accessor
+----
+
+exec-ddl
+CREATE TABLE t1 (c1 int);
+----
+
+exec-ddl
+CREATE TABLE t2 (c1 int);
+----
+
+# Ensure non-RLS enabled tables don't show any policy info.
+# ----------------------------------------------------------------------
+
+plan
+select * from t1,t2 where t1.c1 = t2.c1;
+----
+• hash join
+│ equality: (c1) = (c1)
+│
+├── • scan
+│     table: t1@t1_pkey
+│     spans: FULL SCAN
+│
+└── • scan
+      table: t2@t2_pkey
+      spans: FULL SCAN
+
+# Enable RLS on only one table (t1)
+# ----------------------------------------------------------------------
+
+exec-ddl
+ALTER TABLE t1 ENABLE ROW LEVEL SECURITY
+----
+
+plan
+select * from t1,t2 where t1.c1 = t2.c1;
+----
+• norows
+  policies: row-level security enabled, no policies applied.
+
+# Enable RLS on both tables (t1 and t2)
+# ----------------------------------------------------------------------
+
+exec-ddl
+ALTER TABLE t2 ENABLE ROW LEVEL SECURITY
+----
+
+plan
+select * from t1,t2 where t1.c1 = t2.c1;
+----
+• norows
+  policies: row-level security enabled, no policies applied.
+
+# Ensure admin shows that we are exempt from all policies
+# ----------------------------------------------------------------------
+
+exec-ddl
+SET ROLE root
+----
+
+plan
+select max(t1.c1) from t1,t2 where t1.c1 = t2.c1;
+----
+• group (scalar)
+│
+└── • hash join
+    │ equality: (c1) = (c1)
+    │
+    ├── • scan
+    │     table: t1@t1_pkey
+    │     spans: FULL SCAN
+    │     policies: exempt for role
+    │
+    └── • scan
+          table: t2@t2_pkey
+          spans: FULL SCAN
+          policies: exempt for role
+
+exec-ddl
+SET ROLE rls_accessor
+----
+
+# Add select policies to each table
+# ----------------------------------------------------------------------
+
+exec-ddl
+CREATE POLICY "policy 1" ON t1 USING (true);
+----
+
+exec-ddl
+CREATE POLICY t2_pol_1 on t2 FOR SELECT USING (true);
+----
+
+plan
+select count(*) from t1,t2 where t1.c1 = t2.c1;
+----
+• group (scalar)
+│
+└── • hash join
+    │ equality: (c1) = (c1)
+    │
+    ├── • scan
+    │     table: t1@t1_pkey
+    │     spans: FULL SCAN
+    │     policies: policy 1
+    │
+    └── • scan
+          table: t2@t2_pkey
+          spans: FULL SCAN
+          policies: t2_pol_1
+
+# Add multiple policies on the same table
+# ----------------------------------------------------------------------
+
+exec-ddl
+CREATE POLICY p2 on t1 USING (true);
+----
+
+exec-ddl
+CREATE POLICY p3 on t1 USING (true);
+----
+
+exec-ddl
+CREATE POLICY r1 on t1 AS RESTRICTIVE USING (true);
+----
+
+exec-ddl
+CREATE POLICY r2 on t1 AS RESTRICTIVE USING (true);
+----
+
+# TODO(136742): We currently only support at most one permissive policy. Update
+# this when we support multiple and restrictive policies.
+plan
+select * from t1
+----
+• scan
+  table: t1@t1_pkey
+  spans: FULL SCAN
+  policies: policy 1
+
+# Show policy information where an index scan is used for one table
+# ----------------------------------------------------------------------
+
+exec-ddl
+CREATE INDEX t1_idx ON t1 (c1)
+----
+
+plan
+select t1.c1 from t1, t2 where t1.c1 = t2.c1 and t1.c1 = 1;
+----
+• cross join
+│
+├── • scan
+│     table: t1@t1_idx
+│     spans: 1+ spans
+│     policies: policy 1
+│
+└── • filter
+    │ filter: c1 = _
+    │
+    └── • scan
+          table: t2@t2_pkey
+          spans: FULL SCAN
+          policies: t2_pol_1

--- a/pkg/sql/opt/exec/factory.go
+++ b/pkg/sql/opt/exec/factory.go
@@ -383,6 +383,9 @@ const (
 
 	// ExecutionStatsID is an annotation with a *ExecutionStats value.
 	ExecutionStatsID
+
+	// PolicyInfoID is an annotation with a *RLSPoliciesApplied value.
+	PolicyInfoID
 )
 
 // EstimatedStats contains estimated statistics about a given operator.
@@ -520,6 +523,19 @@ type ExecutionStats struct {
 	// UsedFollowerRead indicates whether at least some reads were served by the
 	// follower replicas.
 	UsedFollowerRead bool
+}
+
+// RLSPoliciesApplied contains information about the row-level security policies
+// that were applied during the query.
+type RLSPoliciesApplied struct {
+	// PoliciesSkippedForRole is true if the user is a member of a role that is
+	// exempt from all policies (e.g., admin).
+	PoliciesSkippedForRole bool
+	// Policies is the list of policy IDs applied to the scan of a single table.
+	// This applies to the table that this annotation was attached to. If this is
+	// empty, it either means policies were skipped due to the role, or none were
+	// applied.
+	Policies opt.PolicyIDSet
 }
 
 // BuildPlanForExplainFn builds an execution plan against the given

--- a/pkg/sql/opt/memo/memo_test.go
+++ b/pkg/sql/opt/memo/memo_test.go
@@ -623,7 +623,7 @@ func TestMemoIsStale(t *testing.T) {
 	notStale()
 
 	// User changes (with RLS)
-	o.Memo().Metadata().SetRLSEnabled(evalCtx.SessionData().User(), true /* admin */)
+	o.Memo().Metadata().SetRLSEnabled(evalCtx.SessionData().User(), true /* admin */, 1 /* tableID */)
 	notStale()
 	evalCtx.SessionData().UserProto = newUser
 	stale()

--- a/pkg/sql/opt/metadata.go
+++ b/pkg/sql/opt/metadata.go
@@ -336,6 +336,10 @@ func (md *Metadata) CopyFrom(from *Metadata, copyScalarFn func(Expr) Expr) {
 	md.withBindings = nil
 
 	md.rlsMeta = from.rlsMeta
+	md.rlsMeta.PoliciesApplied = make(map[TableID]PolicyIDSet)
+	for id, policies := range from.rlsMeta.PoliciesApplied {
+		md.rlsMeta.PoliciesApplied[id] = policies.Copy()
+	}
 }
 
 // MDDepName stores either the unresolved DataSourceName or the StableID from
@@ -1296,14 +1300,20 @@ func (md *Metadata) TestingPrivileges() map[cat.StableID]privilegeBitmap {
 
 // SetRLSEnabled will update the metadata to indicate we came across a table
 // that had row-level security enabled.
-func (md *Metadata) SetRLSEnabled(user username.SQLUsername, isAdmin bool) {
+func (md *Metadata) SetRLSEnabled(user username.SQLUsername, isAdmin bool, tableID TableID) {
 	md.rlsMeta.MaybeInit(user, isAdmin)
+	md.rlsMeta.AddTableUse(tableID)
 }
 
 // ClearRLSEnabled will clear out the initialized state for the rls meta. This
 // is used as a test helper.
 func (md *Metadata) ClearRLSEnabled() {
 	md.rlsMeta.Clear()
+}
+
+// GetRLSMeta returns the rls metadata struct
+func (md *Metadata) GetRLSMeta() *RowLevelSecurityMeta {
+	return &md.rlsMeta
 }
 
 // checkRLSDependencies will check the metadata for row-level security

--- a/pkg/sql/opt/row_level_security.go
+++ b/pkg/sql/opt/row_level_security.go
@@ -5,7 +5,11 @@
 
 package opt
 
-import "github.com/cockroachdb/cockroach/pkg/security/username"
+import (
+	"github.com/cockroachdb/cockroach/pkg/security/username"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/util/intsets"
+)
 
 // RowLevelSecurityMeta contains metadata pertaining to row-level security
 // policies that were enforced when building the query plan.
@@ -22,6 +26,14 @@ type RowLevelSecurityMeta struct {
 	// HasAdminRole is true if the current user was part of the admin role when
 	// creating the query plan.
 	HasAdminRole bool
+
+	// NoPoliciesApplied is set to true if one of the tables didn't have any
+	// applicable policies and so all rows are filtered out.
+	NoPoliciesApplied bool
+
+	// PoliciesApplied is the set of policies that were applied for each relation
+	// in the query.
+	PoliciesApplied map[TableID]PolicyIDSet
 }
 
 func (r *RowLevelSecurityMeta) MaybeInit(user username.SQLUsername, hasAdminRole bool) {
@@ -30,10 +42,59 @@ func (r *RowLevelSecurityMeta) MaybeInit(user username.SQLUsername, hasAdminRole
 	}
 	r.User = user
 	r.HasAdminRole = hasAdminRole
+	r.PoliciesApplied = make(map[TableID]PolicyIDSet)
 	r.IsInitialized = true
 }
 
 // Clear unsets the initialized property. This is used as a test helper.
 func (r *RowLevelSecurityMeta) Clear() {
 	r = &RowLevelSecurityMeta{}
+}
+
+// AddTableUse indicates that an RLS-enabled table was encountered while
+// building the query plan. If any policies are in use, they will be added
+// via the AddPolicyUse call.
+func (r *RowLevelSecurityMeta) AddTableUse(tableID TableID) {
+	if _, found := r.PoliciesApplied[tableID]; !found {
+		r.PoliciesApplied[tableID] = PolicyIDSet{}
+	}
+}
+
+// AddPoliciesUsed is used to indicate the given set of policyID of a table were
+// applied in the query.
+func (r *RowLevelSecurityMeta) AddPoliciesUsed(tableID TableID, policies PolicyIDSet) {
+	s := r.PoliciesApplied[tableID]
+	r.PoliciesApplied[tableID] = s.Union(policies)
+}
+
+// PolicyIDSet stores an unordered set of policy ids.
+type PolicyIDSet struct {
+	set intsets.Fast
+}
+
+// Add adds an id to the set. No-op if the id is already in the set.
+func (s *PolicyIDSet) Add(id descpb.PolicyID) {
+	s.set.Add(int(id))
+}
+
+// Union returns the union of d and o as a new set.
+func (s PolicyIDSet) Union(other PolicyIDSet) PolicyIDSet {
+	return PolicyIDSet{
+		set: s.set.Union(other.set),
+	}
+}
+
+// Len returns the number of the policyIDs in the set.
+func (s PolicyIDSet) Len() int {
+	return s.set.Len()
+}
+
+// Copy makes a deep copy of the set.
+func (s PolicyIDSet) Copy() PolicyIDSet {
+	return PolicyIDSet{set: s.set.Copy()}
+}
+
+// Contains checks if the set contains the given id.
+func (s PolicyIDSet) Contains(id descpb.PolicyID) bool {
+	return s.set.Contains(int(id))
 }

--- a/pkg/sql/opt/testutils/testcat/create_policy.go
+++ b/pkg/sql/opt/testutils/testcat/create_policy.go
@@ -32,7 +32,7 @@ func (tc *Catalog) CreatePolicy(n *tree.CreatePolicy) {
 		panic(errors.Newf(`policy %q already exists on table %q`, n.PolicyName, ts.Name()))
 	}
 
-	policy := cat.Policy{Name: n.PolicyName}
+	policy := cat.Policy{Name: n.PolicyName, ID: ts.nextPolicyID}
 	switch n.Cmd {
 	case tree.PolicyCommandAll, tree.PolicyCommandDefault:
 		policy.Command = catpb.PolicyCommand_ALL
@@ -67,4 +67,5 @@ func (tc *Catalog) CreatePolicy(n *tree.CreatePolicy) {
 	default:
 		ts.policies.Restrictive = append(ts.policies.Restrictive, policy)
 	}
+	ts.nextPolicyID++
 }

--- a/pkg/sql/opt/testutils/testcat/create_table.go
+++ b/pkg/sql/opt/testutils/testcat/create_table.go
@@ -87,6 +87,8 @@ func (tc *Catalog) CreateTable(stmt *tree.CreateTable) *Table {
 		tab.homeRegion = string(stmt.Locality.TableRegion)
 	}
 
+	tab.nextPolicyID = 1
+
 	if isRbr && stmt.PartitionByTable == nil {
 		// Build the table as LOCALITY REGIONAL BY ROW.
 		tab.multiRegion = true

--- a/pkg/sql/opt/testutils/testcat/test_catalog.go
+++ b/pkg/sql/opt/testutils/testcat/test_catalog.go
@@ -844,8 +844,9 @@ type Table struct {
 
 	homeRegion string
 
-	rlsEnabled bool
-	policies   cat.Policies
+	rlsEnabled   bool
+	policies     cat.Policies
+	nextPolicyID descpb.PolicyID
 }
 
 var _ cat.Table = &Table{}

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -2985,6 +2985,7 @@ func getOptPolicies(descPolicies []descpb.PolicyDescriptor) cat.Policies {
 		descPolicy := &descPolicies[i]
 		policy := cat.Policy{
 			Name:          tree.Name(descPolicy.Name),
+			ID:            descPolicy.ID,
 			UsingExpr:     descPolicy.UsingExpr,
 			WithCheckExpr: descPolicy.WithCheckExpr,
 			Command:       descPolicy.Command,


### PR DESCRIPTION
This change updates EXPLAIN output to list the RLS policies applied during query execution. Policies are shown only when the verbose option is used (e.g., `EXPLAIN (VERBOSE) …`) and at least one table with row-level security (RLS) is involved. The policy information is stored inline within the scan node.

Example output for a simple query:

```
                      info
------------------------------------------------
  distribution: local
  vectorized: true

  • scan
    columns: (c1)
    estimated row count: 1,000 (missing stats)
    table: t1@t1_pkey
    spans: FULL SCAN
    policies: pol1, pol2

(10 rows)
```

Epic: CRDB-11724
Release note: None

Closes #138824