### PR TITLE
sqlstats: buffer statement stats in regular slice instead of sqlstats container

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -4035,14 +4035,9 @@ func (ex *connExecutor) txnStateTransitionsApplyWrapper(
 			if err != nil {
 				return advanceInfo{}, err
 			}
-
 			if advInfo.txnEvent.eventType == txnUpgradeToExplicit {
 				ex.extraTxnState.txnFinishClosure.implicit = false
-				if err = ex.statsCollector.UpgradeImplicitTxn(ex.Ctx()); err != nil {
-					return advanceInfo{}, err
-				}
 			}
-
 		}
 	case txnStart:
 		ex.recordTransactionStart(advInfo.txnEvent.txnID)

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -4068,6 +4068,7 @@ func (ex *connExecutor) onTxnFinish(ctx context.Context, ev txnEvent, txnErr err
 		discardedStats := ex.statsCollector.EndTransaction(
 			ctx,
 			transactionFingerprintID,
+			implicit,
 		)
 		if discardedStats > 0 {
 			ex.server.ServerMetrics.StatsMetrics.DiscardedStatsCount.Inc(discardedStats)

--- a/pkg/sql/executor_statement_metrics.go
+++ b/pkg/sql/executor_statement_metrics.go
@@ -212,10 +212,6 @@ func (ex *connExecutor) recordStatementSummary(
 		ex.server.ServerMetrics.StatsMetrics.DiscardedStatsCount.Inc(1)
 	}
 
-	// TODO(xinhaoz): This can be set directly within statsCollector once
-	// https://github.com/cockroachdb/cockroach/pull/123698 is merged.
-	ex.statsCollector.SetStatementFingerprintID(stmtFingerprintID)
-
 	// Record statement execution statistics if span is recorded and no error was
 	// encountered while collecting query-level statistics.
 	if queryLevelStatsOk {

--- a/pkg/sql/logictest/testdata/logic_test/statement_statistics
+++ b/pkg/sql/logictest/testdata/logic_test/statement_statistics
@@ -207,7 +207,7 @@ SET application_name = 'implicit_txn_test'
 statement ok
 BEGIN; SELECT x FROM test where y=1; COMMIT;
 
-# Upgraded implicit txn.
+# Upgraded implicit txn. All statements should be in explicit txn.
 statement ok
 select 1; BEGIN; select 1; select 1; COMMIT
 
@@ -231,7 +231,6 @@ ORDER BY key, implicit_txn;
 ----
 key                             implicit_txn
 SELECT _                        false
-SELECT _                        true
 SELECT x FROM test WHERE y = _  false
 SELECT x FROM test WHERE y = _  false
 SELECT x FROM test WHERE y = _  true

--- a/pkg/sql/sqlstats/persistedsqlstats/bench_test.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/bench_test.go
@@ -405,7 +405,7 @@ func BenchmarkSqlStatsMaxFlushTime(b *testing.B) {
 				QuerySummary:             "",
 				TransactionFingerprintID: appstatspb.TransactionFingerprintID(i),
 			}
-			_, err := appContainer.RecordStatement(ctx, stmtKey, mockStmtValue)
+			err := appContainer.RecordStatement(ctx, stmtKey, mockStmtValue)
 			if errors.Is(err, ssmemstorage.ErrFingerprintLimitReached) {
 				break
 			}

--- a/pkg/sql/sqlstats/sslocal/sql_stats_test.go
+++ b/pkg/sql/sqlstats/sslocal/sql_stats_test.go
@@ -471,7 +471,7 @@ func TestExplicitTxnFingerprintAccounting(t *testing.T) {
 		txnFingerprintIDHash := util.MakeFNV64()
 		statsCollector.StartTransaction()
 		defer func() {
-			statsCollector.EndTransaction(ctx, txnFingerprintID)
+			statsCollector.EndTransaction(ctx, txnFingerprintID, false /* implicit */)
 			require.NoError(t,
 				statsCollector.
 					RecordTransaction(ctx, txnFingerprintID, sqlstats.RecordedTxnStats{
@@ -609,7 +609,7 @@ func TestAssociatingStmtStatsWithTxnFingerprint(t *testing.T) {
 			}
 
 			transactionFingerprintID := appstatspb.TransactionFingerprintID(txnFingerprintIDHash.Sum())
-			statsCollector.EndTransaction(ctx, transactionFingerprintID)
+			statsCollector.EndTransaction(ctx, transactionFingerprintID, false /* implicit */)
 			err := statsCollector.RecordTransaction(ctx, transactionFingerprintID, sqlstats.RecordedTxnStats{
 				SessionData: &sessiondata.SessionData{
 					SessionData: sessiondatapb.SessionData{

--- a/pkg/sql/sqlstats/sslocal/sslocal_stats_collector.go
+++ b/pkg/sql/sqlstats/sslocal/sslocal_stats_collector.go
@@ -20,17 +20,33 @@ import (
 	"github.com/cockroachdb/redact"
 )
 
+type bufferedStmtStats struct {
+	key   appstatspb.StatementStatisticsKey
+	value sqlstats.RecordedStmtStats
+}
+
 // StatsCollector is used to collect statistics for transactions and
 // statements for the entire lifetime of a session. It must be closed
 // with Close() when the session is done.
 type StatsCollector struct {
 
-	// currentTransactionStatementStats contains the current transaction's statement
+	// stmtBuf contains the current transaction's statement
 	// statistics. They will be flushed to flushTarget when the transaction is done
 	// so that we can include the transaction fingerprint ID as part of the
-	// statement's key. This container is local per stats collector and
-	// is cleared for reuse after every transaction.
-	currentTransactionStatementStats *ssmemstorage.Container
+	// statement's key. This buffer is cleared for reuse after every transaction.
+	stmtBuf []*bufferedStmtStats
+
+	// If writeDirectlyToFlushTarget is set to true, the stmtBuf
+	// will be written directly to the flushTarget instead of being buffered to be written
+	// at the end of the transaction.
+	// See #124935 for more details. When we have a statement from an outer txn,
+	// the executor owning the stats collector is not responsible for
+	// starting or committing the transaction. Since the statements
+	// are merged into flushTarget on EndTransaction, in this case the
+	// container would never be merged into the flushTarget. Instead
+	// we'll write directly to the flushTarget when we're collecting
+	// stats for a conn exec belonging to an outer transaction.
+	writeDirectlyToFlushTarget bool
 
 	// stmtFingerprintID is the fingerprint ID of the current statement we are
 	// recording. Note that we don't observe sql stats for all statements (e.g. COMMIT).
@@ -81,30 +97,16 @@ func NewStatsCollector(
 	underOuterTxn bool,
 	knobs *sqlstats.TestingKnobs,
 ) *StatsCollector {
-	// See #124935 for more details. If underOuterTxn is true, the
-	// executor owning the stats collector is not responsible for
-	// starting or committing the transaction. Since the statements
-	// are merged into flushTarget on EndTransaction, in this case the
-	// container would never be merged into the flushTarget. Instead
-	// we'll write directly to the flushTarget when we're collecting
-	// stats for a conn exec belonging to an outer transaction.
-	currentTransactionStatementStats := appStats
-	if !underOuterTxn {
-		currentTransactionStatementStats = appStats.NewApplicationStatsWithInheritedOptions()
-	}
 	return &StatsCollector{
-		flushTarget:                      appStats,
-		currentTransactionStatementStats: currentTransactionStatementStats,
-		insightsWriter:                   insights,
-		phaseTimes:                       *phaseTime,
-		uniqueServerCounts:               uniqueServerCounts,
-		st:                               st,
-		knobs:                            knobs,
+		flushTarget:                appStats,
+		stmtBuf:                    make([]*bufferedStmtStats, 0, 1),
+		writeDirectlyToFlushTarget: underOuterTxn,
+		insightsWriter:             insights,
+		phaseTimes:                 *phaseTime,
+		uniqueServerCounts:         uniqueServerCounts,
+		st:                         st,
+		knobs:                      knobs,
 	}
-}
-
-func (s *StatsCollector) SetStatementFingerprintID(fingerprintID appstatspb.StmtFingerprintID) {
-	s.stmtFingerprintID = fingerprintID
 }
 
 // StatementFingerprintID returns the fingerprint ID for the current statement.
@@ -137,13 +139,7 @@ func (s *StatsCollector) Reset(appStats *ssmemstorage.Container, phaseTime *sess
 // any memory allocated by underlying sql stats systems for the session
 // that owns this stats collector.
 func (s *StatsCollector) Close(ctx context.Context, sessionID clusterunique.ID) {
-	// For stats collectors for executors with outer transactions,
-	// the currentTransactionStatementStats is the flush target.
-	// We should make sure we're never freeing the flush target,
-	// since that container exists beyond the stats collector.
-	if s.currentTransactionStatementStats != s.flushTarget {
-		s.currentTransactionStatementStats.Free(ctx)
-	}
+	s.stmtBuf = nil
 	if s.insightsWriter != nil {
 		s.insightsWriter.ClearSession(sessionID)
 	}
@@ -160,7 +156,9 @@ func (s *StatsCollector) StartTransaction() {
 // the transaction fingerprint ID field of all the statement statistics for that
 // txn.
 func (s *StatsCollector) EndTransaction(
-	ctx context.Context, transactionFingerprintID appstatspb.TransactionFingerprintID,
+	ctx context.Context,
+	transactionFingerprintID appstatspb.TransactionFingerprintID,
+	implicitTxn bool,
 ) (discardedStats int64) {
 	// We possibly ignore the transactionFingerprintID, for situations where
 	// grouping by it would otherwise result in collecting higher-cardinality
@@ -170,16 +168,20 @@ func (s *StatsCollector) EndTransaction(
 		transactionFingerprintID = appstatspb.InvalidTransactionFingerprintID
 	}
 
-	discardedStats += int64(s.flushTarget.MergeApplicationStatementStats(
-		ctx, s.currentTransactionStatementStats, transactionFingerprintID,
-	))
+	for _, stmt := range s.stmtBuf {
+		stmt.key.TransactionFingerprintID = transactionFingerprintID
+		stmt.key.ImplicitTxn = implicitTxn
+		if err := s.flushTarget.RecordStatement(ctx, stmt.key, stmt.value); err != nil {
+			discardedStats++
+		}
+	}
 
 	// Avoid taking locks if no stats are discarded.
 	if discardedStats > 0 {
 		s.flushTarget.MaybeLogDiscardMessage(ctx)
 	}
 
-	s.currentTransactionStatementStats.Clear(ctx)
+	s.stmtBuf = make([]*bufferedStmtStats, 0, len(s.stmtBuf)/2)
 
 	return discardedStats
 }
@@ -202,19 +204,6 @@ func (s *StatsCollector) SetStatementSampled(
 	fingerprint string, implicitTxn bool, database string,
 ) {
 	s.flushTarget.TrySetStatementSampled(fingerprint, implicitTxn, database)
-}
-
-// UpgradeImplicitTxn informs the StatsCollector that the current txn has been
-// upgraded to an explicit transaction, thus all previously recorded statements
-// should be updated accordingly.
-func (s *StatsCollector) UpgradeImplicitTxn(ctx context.Context) error {
-	err := s.currentTransactionStatementStats.IterateStatementStats(ctx, sqlstats.IteratorOptions{},
-		func(_ context.Context, statistics *appstatspb.CollectedStatementStatistics) error {
-			statistics.Key.ImplicitTxn = false
-			return nil
-		})
-
-	return err
 }
 
 func getInsightStatus(statementError error) insights.Statement_Status {
@@ -346,7 +335,20 @@ func (s *StatsCollector) ObserveTransaction(
 func (s *StatsCollector) RecordStatement(
 	ctx context.Context, key appstatspb.StatementStatisticsKey, value sqlstats.RecordedStmtStats,
 ) (appstatspb.StmtFingerprintID, error) {
-	return s.currentTransactionStatementStats.RecordStatement(ctx, key, value)
+	s.stmtFingerprintID = appstatspb.ConstructStatementFingerprintID(key.Query, key.ImplicitTxn, key.Database)
+	value.FingerprintID = s.stmtFingerprintID
+	if s.writeDirectlyToFlushTarget {
+		err := s.flushTarget.RecordStatement(ctx, key, value)
+		return s.stmtFingerprintID, err
+	}
+	s.stmtFingerprintID = appstatspb.ConstructStatementFingerprintID(key.Query, key.ImplicitTxn, key.Database)
+	// TODO(xinhaoz): This isn't the best place to set this, but we'll clean this up
+	// when we refactor the stats collection code to send the stats to an ingester.
+	s.stmtBuf = append(s.stmtBuf, &bufferedStmtStats{
+		key:   key,
+		value: value,
+	})
+	return s.stmtFingerprintID, nil
 }
 
 // RecordTransaction records the statistics of a transaction.
@@ -354,6 +356,17 @@ func (s *StatsCollector) RecordStatement(
 func (s *StatsCollector) RecordTransaction(
 	ctx context.Context, key appstatspb.TransactionFingerprintID, value sqlstats.RecordedTxnStats,
 ) error {
+	// TODO(117690): Unify StmtStatsEnable and TxnStatsEnable into a single cluster setting.
+	if !sqlstats.TxnStatsEnable.Get(&s.st.SV) {
+		return nil
+	}
+	// Do not collect transaction statistics if the stats collection latency
+	// threshold is set, since our transaction UI relies on having stats for every
+	// statement in the transaction.
+	t := sqlstats.StatsCollectionLatencyThreshold.Get(&s.st.SV)
+	if t > 0 {
+		return nil
+	}
 	return s.flushTarget.RecordTransaction(ctx, key, value)
 }
 

--- a/pkg/sql/sqlstats/ssmemstorage/ss_mem_writer_test.go
+++ b/pkg/sql/sqlstats/ssmemstorage/ss_mem_writer_test.go
@@ -49,7 +49,7 @@ func TestRecordStatement(t *testing.T) {
 		statsKey := appstatspb.StatementStatisticsKey{
 			Query: "SELECT _",
 		}
-		_, err := memContainer.RecordStatement(ctx, statsKey, sqlstats.RecordedStmtStats{})
+		err := memContainer.RecordStatement(ctx, statsKey, sqlstats.RecordedStmtStats{})
 		require.NoError(t, err)
 		require.Zero(t, numStmtInsights)
 	})

--- a/pkg/sql/sqlstats/ssprovider.go
+++ b/pkg/sql/sqlstats/ssprovider.go
@@ -55,6 +55,7 @@ type AggregatedTransactionVisitor func(appName string, statistics *appstatspb.Tx
 
 // RecordedStmtStats stores the statistics of a statement to be recorded.
 type RecordedStmtStats struct {
+	FingerprintID        appstatspb.StmtFingerprintID
 	SessionID            clusterunique.ID
 	StatementID          clusterunique.ID
 	TransactionID        uuid.UUID


### PR DESCRIPTION
Previously, each stats collector for a sql session  would buffer a
transaciton's stmt stats in a ssmemstorage.Container struct which has
a lot of additional overhead when reading and writing as it manages
synchronization logic. For this per-session writing, this writing
is synchronous so there's no need to use such a container. We should
just buffer the stmts in a simple slice. Essentially, this shouldn't
make anything worse as we're just simplifying the buffer.

Note that this is simply a temporary simplified state. Eventually as part of https://github.com/cockroachdb/cockroach/issues/141024 
we will move the writing to the shared container to be
async from query execution.

Epic: none

Release note: None