### PR TITLE
(draft)logstore: log latency if raftentry cache miss when calling loadTerm

### DIFF
--- a/pkg/kv/kvserver/metrics.go
+++ b/pkg/kv/kvserver/metrics.go
@@ -526,7 +526,7 @@ var (
 		Unit:        metric.Unit_COUNT,
 	}
 
-	//Ingest metrics
+	// Ingest metrics
 	metaIngestCount = metric.Metadata{
 		Name:        "storage.ingest.count",
 		Help:        "Number of successful ingestions performed",
@@ -1449,6 +1449,12 @@ traffic), make it likely that the storage layer is healthy. Spikes in the
 latency bands can either hint at the presence of large sets of Raft entries
 being received, or at performance issues at the storage layer.
 `,
+		Measurement: "Latency",
+		Unit:        metric.Unit_NANOSECONDS,
+	}
+	metaLoadTermFromStorageLatency = metric.Metadata{
+		Name:        "raft.process.loadTerm.latency",
+		Help:        `Latency histogram for loading the term of a Raft log entries`,
 		Measurement: "Latency",
 		Unit:        metric.Unit_NANOSECONDS,
 	}
@@ -2840,6 +2846,7 @@ type StoreMetrics struct {
 	RaftCommandsPending        *metric.Gauge
 	RaftCommandsApplied        *metric.Counter
 	RaftLogCommitLatency       metric.IHistogram
+	LoadTermFromStorageLatency metric.IHistogram
 	RaftCommandCommitLatency   metric.IHistogram
 	RaftHandleReadyLatency     metric.IHistogram
 	RaftApplyCommittedLatency  metric.IHistogram
@@ -3566,6 +3573,12 @@ func newStoreMetrics(histogramWindow time.Duration) *StoreMetrics {
 		RaftLogCommitLatency: metric.NewHistogram(metric.HistogramOptions{
 			Mode:         metric.HistogramModePreferHdrLatency,
 			Metadata:     metaRaftLogCommitLatency,
+			Duration:     histogramWindow,
+			BucketConfig: metric.IOLatencyBuckets,
+		}),
+		LoadTermFromStorageLatency: metric.NewHistogram(metric.HistogramOptions{
+			Mode:         metric.HistogramModePreferHdrLatency,
+			Metadata:     metaLoadTermFromStorageLatency,
 			Duration:     histogramWindow,
 			BucketConfig: metric.IOLatencyBuckets,
 		}),

--- a/pkg/kv/kvserver/raftentry/metrics.go
+++ b/pkg/kv/kvserver/raftentry/metrics.go
@@ -32,6 +32,18 @@ var (
 		Measurement: "Hits",
 		Unit:        metric.Unit_COUNT,
 	}
+	metaLoadTermAccesses = metric.Metadata{
+		Name:        "raft.loadterm.accesses",
+		Help:        "Number of cache lookups in the Raft entry cache for entry term",
+		Measurement: "LoadTermAccesses",
+		Unit:        metric.Unit_COUNT,
+	}
+	metaLoadTermHits = metric.Metadata{
+		Name:        "raft.loadterm.hits",
+		Help:        "Number of successful cache lookups in the Raft entry cache for entry term",
+		Measurement: "LoadTermHits",
+		Unit:        metric.Unit_COUNT,
+	}
 	metaEntryCacheReadBytes = metric.Metadata{
 		Name:        "raft.entrycache.read_bytes",
 		Help:        "Counter of bytes in entries returned from the Raft entry cache",
@@ -44,19 +56,23 @@ var (
 type Metrics struct {
 	// NB: the values in the gauges are updated asynchronously and may hold stale
 	// values in the face of concurrent updates.
-	Size      *metric.Gauge
-	Bytes     *metric.Gauge
-	Accesses  *metric.Counter
-	Hits      *metric.Counter
-	ReadBytes *metric.Counter
+	Size             *metric.Gauge
+	Bytes            *metric.Gauge
+	Accesses         *metric.Counter
+	Hits             *metric.Counter
+	LoadTermAccesses *metric.Counter
+	LoadTermHits     *metric.Counter
+	ReadBytes        *metric.Counter
 }
 
 func makeMetrics() Metrics {
 	return Metrics{
-		Size:      metric.NewGauge(metaEntryCacheSize),
-		Bytes:     metric.NewGauge(metaEntryCacheBytes),
-		Accesses:  metric.NewCounter(metaEntryCacheAccesses),
-		Hits:      metric.NewCounter(metaEntryCacheHits),
-		ReadBytes: metric.NewCounter(metaEntryCacheReadBytes),
+		Size:             metric.NewGauge(metaEntryCacheSize),
+		Bytes:            metric.NewGauge(metaEntryCacheBytes),
+		Accesses:         metric.NewCounter(metaEntryCacheAccesses),
+		Hits:             metric.NewCounter(metaEntryCacheHits),
+		LoadTermAccesses: metric.NewCounter(metaLoadTermAccesses),
+		LoadTermHits:     metric.NewCounter(metaLoadTermHits),
+		ReadBytes:        metric.NewCounter(metaEntryCacheReadBytes),
 	}
 }

--- a/pkg/kv/kvserver/replica_init.go
+++ b/pkg/kv/kvserver/replica_init.go
@@ -218,7 +218,8 @@ func newUninitializedReplicaWithoutRaftGroup(
 		EntryCache: store.raftEntryCache,
 		Settings:   store.cfg.Settings,
 		Metrics: logstore.Metrics{
-			RaftLogCommitLatency: store.metrics.RaftLogCommitLatency,
+			RaftLogCommitLatency:       store.metrics.RaftLogCommitLatency,
+			LoadTermFromStorageLatency: store.metrics.LoadTermFromStorageLatency,
 		},
 		DisableSyncLogWriteToss: buildutil.CrdbTestBuild &&
 			store.TestingKnobs().DisableSyncLogWriteToss,

--- a/pkg/kv/kvserver/replica_raftlog.go
+++ b/pkg/kv/kvserver/replica_raftlog.go
@@ -118,7 +118,7 @@ func (r *replicaLogStorage) termLocked(i kvpb.RaftIndex) (kvpb.RaftTerm, error) 
 	}
 	return logstore.LoadTerm(r.AnnotateCtx(context.TODO()),
 		r.mu.stateLoader.StateLoader, r.store.TODOEngine(), r.RangeID,
-		r.store.raftEntryCache, i,
+		r.store.raftEntryCache, i, r.raftMu.logStorage.Metrics.LoadTermFromStorageLatency,
 	)
 }
 
@@ -253,7 +253,7 @@ func (r *replicaRaftMuLogSnap) termRaftMuLocked(i kvpb.RaftIndex) (kvpb.RaftTerm
 	}
 	return logstore.LoadTerm(r.AnnotateCtx(context.TODO()),
 		r.raftMu.stateLoader.StateLoader, r.store.TODOEngine(), r.RangeID,
-		r.store.raftEntryCache, i,
+		r.store.raftEntryCache, i, r.raftMu.logStorage.Metrics.LoadTermFromStorageLatency,
 	)
 }
 


### PR DESCRIPTION
(draft change) This is a draft commit that adds a metric to record the latency for loading term if there is a cache miss.

Also adds separate metrics for raftRntry cache accesses from loadTerm.

Running roachtests against this build will help us with understanding the access patterns of raftEntry Cache, and understand how much performance improvement we may get when we introduce a term cache.

This commit is only for reference purpose, **do not merge**.

References: cockroachdb#136296
Epic: None
Release note: None