### PR TITLE
microbench-ci: extended config + checkout base

### DIFF
--- a/.github/actions/microbenchmark-build/action.yml
+++ b/.github/actions/microbenchmark-build/action.yml
@@ -11,6 +11,12 @@ outputs:
   merge_base:
     description: "merge base"
     value: ${{ steps.determine-merge-base.outputs.merge_base }}
+  extended:
+    description: "extended run"
+    value: ${{ steps.config.outputs.extended }}
+  config:
+    description: "config"
+    value: ${{ steps.config.outputs.config }}
 
 runs:
   using: "composite"
@@ -23,8 +29,7 @@ runs:
     - run: |
         echo "FETCH_DEPTH=$(( ${{ github.event.pull_request.commits }} + 1 ))" >> "${GITHUB_ENV}"
       shell: bash
-    - name: Checkout revision with limited depth
-      if: inputs.ref == 'base'
+    - name: Checkout revision with required depth
       uses: actions/checkout@v4
       with:
         ref: ${{ github.event.pull_request.head.sha }}
@@ -38,7 +43,18 @@ runs:
         MERGE_BASE=$(git rev-parse HEAD~${NUM_COMMITS})
         echo "merge_base=$MERGE_BASE" >> "$GITHUB_OUTPUT"
       shell: bash
-    - name: Checkout build commit
+    - name: Config
+      id: config
+      run: |
+        if ${{ contains(github.event.pull_request.labels.*.name, 'T-microbench-extended') }}; then
+          echo "extended=true" >> "$GITHUB_OUTPUT"
+          echo "config=pull-request-ext-suite.yml" >> "$GITHUB_OUTPUT"
+        else
+          echo "extended=false" >> "$GITHUB_OUTPUT"
+          echo "config=pull-request-suite.yml" >> "$GITHUB_OUTPUT"
+        fi
+      shell: bash
+    - name: Checkout base if needed
       if: inputs.ref == 'base'
       uses: actions/checkout@v4
       with:
@@ -48,11 +64,9 @@ runs:
       shell: bash
       env:
         TEST_PKG: ${{ inputs.pkg }}
-    - name: Checkout Head # required for post job cleanup (if still on the base ref)
-      uses: actions/checkout@v4
-      with:
-        ref: ${{ github.event.pull_request.head.sha || github.ref }}
+    - name: Checkout # required for post job cleanup (if still on the base ref)
       if: inputs.ref == 'base'
+      uses: actions/checkout@v4
     - name: Clean up
       run: ./build/github/cleanup-engflow-keys.sh
       shell: bash

--- a/.github/actions/microbenchmark-run/action.yml
+++ b/.github/actions/microbenchmark-run/action.yml
@@ -10,18 +10,27 @@ inputs:
   group:
     description: "Runner group"
     required: true
-
+  config:
+    description: "Config to run"
+    required: true
 runs:
   using: "composite"
   steps:
     - name: Unique Build ID
       run: echo "BUILD_ID=${{ github.run_id }}-${{ github.run_attempt }}" >> $GITHUB_ENV
       shell: bash
+    - run: ./build/github/get-engflow-keys.sh
+      shell: bash
     - name: Run benchmarks
       run: ./build/github/microbenchmarks/run.sh
       shell: bash
       env:
         BASE_SHA: ${{ inputs.base }}
-        HEAD_SHA: ${{ github.event.pull_request.head.sha || github.ref }}
+        HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         TEST_PACKAGES: ${{ inputs.pkg }}
         GROUP: ${{ inputs.group }}
+        CONFIG: ${{ inputs.config }}
+    - name: Clean up
+      run: ./build/github/cleanup-engflow-keys.sh
+      shell: bash
+      if: always()

--- a/.github/workflows/microbenchmarks-ci.yaml
+++ b/.github/workflows/microbenchmarks-ci.yaml
@@ -7,7 +7,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 env:
-  HEAD: ${{ github.event.pull_request.head.sha || github.ref }}
+  HEAD: ${{ github.event.pull_request.head.sha }}
   BUCKET: "cockroach-microbench-ci"
   PACKAGE: "pkg/sql/tests"
 jobs:
@@ -17,11 +17,11 @@ jobs:
     timeout-minutes: 30
     outputs:
       merge_base: ${{ steps.build.outputs.merge_base }}
+      extended: ${{ steps.build.outputs.extended }}
+      config: ${{ steps.build.outputs.config }}
     steps:
-      - name: Checkout Head
+      - name: Checkout
         uses: actions/checkout@v4
-        with:
-          ref: ${{ env.HEAD }}
       - name: Build
         id: build
         uses: ./.github/actions/microbenchmark-build
@@ -32,13 +32,9 @@ jobs:
     name: build head
     runs-on: [self-hosted, basic_runner_group]
     timeout-minutes: 30
-    outputs:
-      merge_base: ${{ steps.build.outputs.merge_base }}
     steps:
-      - name: Checkout Head
+      - name: Checkout
         uses: actions/checkout@v4
-        with:
-          ref: ${{ env.HEAD }}
       - name: Build
         id: build
         uses: ./.github/actions/microbenchmark-build
@@ -50,14 +46,13 @@ jobs:
     timeout-minutes: 30
     needs: [base, head]
     steps:
-      - name: Checkout Head
+      - name: Checkout
         uses: actions/checkout@v4
-        with:
-          ref: ${{ env.HEAD }}
       - name: Run
         uses: ./.github/actions/microbenchmark-run
         with:
           base: ${{ needs.base.outputs.merge_base }}
+          config: ${{ needs.base.outputs.config }}
           pkg: ${{ env.PACKAGE }}
           group: 1
   run-group-2:
@@ -65,25 +60,39 @@ jobs:
     timeout-minutes: 30
     needs: [base, head]
     steps:
-      - name: Checkout Head
+      - name: Checkout
         uses: actions/checkout@v4
-        with:
-          ref: ${{ env.HEAD }}
       - name: Run
         uses: ./.github/actions/microbenchmark-run
         with:
           base: ${{ needs.base.outputs.merge_base }}
+          config: ${{ needs.base.outputs.config }}
           pkg: ${{ env.PACKAGE }}
           group: 2
+  run-group-ext: # This group will only run if the PR has the label T-microbench-extended
+    runs-on: [self-hosted, basic_big_runner_group]
+    if: ${{ needs.base.outputs.extended == 'true' }}
+    timeout-minutes: 30
+    needs: [base, head]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Run
+        uses: ./.github/actions/microbenchmark-run
+        with:
+          base: ${{ needs.base.outputs.merge_base }}
+          config: ${{ needs.base.outputs.config }}
+          pkg: ${{ env.PACKAGE }}
+          group: 3
   compare:
     runs-on: [self-hosted, basic_runner_group]
     timeout-minutes: 30
     needs: [base, run-group-1, run-group-2]
     steps:
-      - name: Checkout Head
+      - name: Checkout
         uses: actions/checkout@v4
-        with:
-          ref: ${{ env.HEAD }}
+      - run: ./build/github/get-engflow-keys.sh
+        shell: bash
       - name: Unique Build ID
         run: echo "BUILD_ID=${{ github.run_id }}-${{ github.run_attempt }}" >> $GITHUB_ENV
       - name: Compare and Post
@@ -91,6 +100,11 @@ jobs:
         env:
           BASE_SHA: ${{ needs.base.outputs.merge_base }}
           HEAD_SHA: ${{ env.HEAD }}
+          CONFIG: ${{ needs.base.outputs.config }}
+      - name: Clean up
+        run: ./build/github/cleanup-engflow-keys.sh
+        shell: bash
+        if: always()
   post:
     runs-on: [ self-hosted, basic_runner_group ]
     if: contains(github.event.pull_request.labels.*.name, 'T-microbench-post') # TODO: remove this check once results are confirmed to be stable on CI.

--- a/build/github/microbenchmarks/build.sh
+++ b/build/github/microbenchmarks/build.sh
@@ -31,13 +31,6 @@ bazel build "//${TEST_PKG}:tests_test" \
   --remote_download_minimal \
   $(./build/github/engflow-args.sh)
 
-# Build microbenchmark CI utility
-bazel build --config=crosslinux $(./build/github/engflow-args.sh) \
-  --jobs 100 \
-  --bes_keywords integration-test-artifact-build \
-  //pkg/cmd/microbench-ci
-
 # Copy to GCS
 bazel_bin=$(bazel info bazel-bin --config=crosslinux)
 gcloud storage cp "${bazel_bin}/pkg/sql/tests/${pkg_last}_test_/${pkg_last}_test" "${output_url}/${pkg_bin}"
-gcloud storage cp "${bazel_bin}/pkg/cmd/microbench-ci/microbench-ci_/microbench-ci" "${output_url}/microbench-ci"

--- a/build/github/microbenchmarks/compare.sh
+++ b/build/github/microbenchmarks/compare.sh
@@ -21,12 +21,9 @@ for sha in "${shas[@]}"; do
   gcloud storage cp -r "gs://${storage_bucket}/artifacts/${sha}/${BUILD_ID}/*" "${working_dir}/${sha}/artifacts/"
 done
 
-# Get the microbenchmark CI utility (HEAD version)
-gcloud storage cp "gs://${storage_bucket}/builds/${HEAD_SHA}/bin/microbench-ci" "$working_dir/microbench-ci"
-chmod +x "$working_dir/microbench-ci"
-
 # Compare the microbenchmarks
-"$working_dir/microbench-ci" compare \
+./build/github/microbenchmarks/util.sh compare \
+  --config="pkg/cmd/microbench-ci/config/$CONFIG" \
   --working-dir="$working_dir" \
   --summary="$output_dir/summary.json" \
   --github-summary="$output_dir/summary.md" \

--- a/build/github/microbenchmarks/post.sh
+++ b/build/github/microbenchmarks/post.sh
@@ -10,19 +10,11 @@ set -euxo pipefail
 working_dir=$(mktemp -d)
 storage_bucket="$BUCKET"
 
-# Build microbenchmark CI utility (base version)
-bazel build --config=crosslinux $(./build/github/engflow-args.sh) \
-  --jobs 100 \
-  --bes_keywords integration-test-artifact-build \
-  //pkg/cmd/microbench-ci
-
-bazel_bin=$(bazel info bazel-bin --config=crosslinux)
-
 # Grab the summary from the previous step
 gcloud storage cp "gs://${storage_bucket}/results/${HEAD_SHA}/${BUILD_ID}/summary.md" "$working_dir/summary.md"
 
 # Post summary to GitHub on the PR
-"$bazel_bin/pkg/cmd/microbench-ci/microbench-ci_/microbench-ci" post \
+./build/github/microbenchmarks/util.sh post \
   --github-summary="$working_dir/summary.md" \
   --pr-number="$PR_NUMBER" \
   --repo="$REPO"

--- a/build/github/microbenchmarks/run.sh
+++ b/build/github/microbenchmarks/run.sh
@@ -20,19 +20,20 @@ for pkg in "${TEST_PACKAGES[@]}"; do
   for sha in "${shas[@]}"; do
     pkg_bin=$(echo "${pkg}" | tr '/' '_')
     url="gs://${storage_bucket}/builds/${sha}/bin/${pkg_bin}"
-    dest="$working_dir/$sha/bin/"
+    dest="$working_dir/$sha/bin"
     mkdir -p "$dest"
     gcloud storage cp "${url}" "$dest/${pkg_bin}"
     chmod +x "$dest/${pkg_bin}"
   done
 done
 
-# Get the microbenchmark CI utility (HEAD version)
-gcloud storage cp "gs://${storage_bucket}/builds/${HEAD_SHA}/bin/microbench-ci" "$working_dir/microbench-ci"
-chmod +x "$working_dir/microbench-ci"
-
 # Run the microbenchmarks
-"$working_dir/microbench-ci" run --group="$GROUP" --working-dir="$working_dir" --old="$BASE_SHA" --new="$HEAD_SHA"
+./build/github/microbenchmarks/util.sh run \
+  --config="pkg/cmd/microbench-ci/config/$CONFIG" \
+  --group="$GROUP" \
+  --working-dir="$working_dir" \
+  --old="$BASE_SHA" \
+  --new="$HEAD_SHA"
 
 # Copy benchmark results to GCS
 curl -H "Metadata-Flavor: Google" \

--- a/build/github/microbenchmarks/util.sh
+++ b/build/github/microbenchmarks/util.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Copyright 2025 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+set -euxo pipefail
+
+bazel build --config=crosslinux $(./build/github/engflow-args.sh) \
+  --jobs 100 \
+  --bes_keywords integration-test-artifact-build \
+  //pkg/cmd/microbench-ci
+
+bazel_bin=$(bazel info bazel-bin --config=crosslinux)
+
+"$bazel_bin/pkg/cmd/microbench-ci/microbench-ci_/microbench-ci" "$@"

--- a/pkg/cmd/microbench-ci/config/pull-request-ext-suite.yml
+++ b/pkg/cmd/microbench-ci/config/pull-request-ext-suite.yml
@@ -1,0 +1,53 @@
+benchmarks:
+  - display_name: Sysbench
+    labels: ["SQL", "3node", "oltp_read_write"]
+    name: "BenchmarkSysbench/SQL/3node/oltp_read_write"
+    package: "pkg/sql/tests"
+    runner_group: 1
+    measure_count: 10
+    measure:
+      iterations: 3000
+    thresholds:
+      "sec/op": .03
+      "B/op": .02
+      "allocs/op": .02
+
+  - display_name: Sysbench
+    labels: ["KV", "1node", "local", "oltp_read_only"]
+    name: "BenchmarkSysbench/KV/1node_local/oltp_read_only"
+    package: "pkg/sql/tests"
+    runner_group: 2
+    measure_count: 10
+    measure:
+      iterations: 12000
+    thresholds:
+      "sec/op": .02
+      "B/op": .015
+      "allocs/op": .015
+
+  - display_name: Sysbench
+    labels: ["KV", "1node", "local", "oltp_write_only"]
+    name: "BenchmarkSysbench/KV/1node_local/oltp_write_only"
+    package: "pkg/sql/tests"
+    runner_group: 2
+    measure_count: 10
+    measure:
+      iterations: 12000
+    thresholds:
+      "sec/op": .025
+      "B/op": .0175
+      "allocs/op": .0175
+
+  - display_name: Parallel Sysbench
+    labels: ["SQL", "3node", "oltp_read_write"]
+    name: "BenchmarkParallelSysbench/SQL/3node/oltp_read_write"
+    package: "pkg/sql/tests"
+    runner_group: 3
+    measure_count: 10
+    measure:
+      iterations: 3000
+    thresholds:
+      "sec/op": .03
+      "B/op": .02
+      "allocs/op": .02
+      "errs/op": 1.0


### PR DESCRIPTION
Previously, the checkout steps of the microbenchmark workflow specified
revisions explicitly. It should rather use the defaults that will change based
on if the workflow is triggered on "pull_request" or "pull_request_target". The
latter will check out the base revision by default, while "pull_request" checks
out the PR head revision by default. Hence, if changes to the microbenchmark
workflow need to be tested the flow can be updated to "pull_request", and before
merging changed back to "pull_request_target" (that is necessary for the
permissions required for commenting on a PR).

The microbench-ci utility will now be built for each job that requires it, as
the revision is dependent on the context. Build times for the utility is low,
and as it is done through eng-flow there will be some caching. The test binaries
still get cached on GCS, as developers need access to these in case they wish to
reproduce the results.

Additionally, this change introduces the option of using an extended benchmark
suite configuration that will run additional benchmarks if the PR contains the
"T-microbenchmark-extended" label.

Epic: None
Release note: None