### PR TITLE
testutils: move `sideeye` helper to its own package

### DIFF
--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -2416,6 +2416,7 @@ GO_TARGETS = [
     "//pkg/testutils/serverutils/regionlatency:regionlatency",
     "//pkg/testutils/serverutils:serverutils",
     "//pkg/testutils/serverutils:serverutils_test",
+    "//pkg/testutils/sideeye:sideeye",
     "//pkg/testutils/skip:skip",
     "//pkg/testutils/sqlutils:sqlutils",
     "//pkg/testutils/sqlutils:sqlutils_test",

--- a/pkg/testutils/BUILD.bazel
+++ b/pkg/testutils/BUILD.bazel
@@ -12,7 +12,6 @@ go_library(
         "keys.go",
         "net.go",
         "pprof.go",
-        "sideeye.go",
         "soon.go",
         "sort.go",
         "subtest.go",
@@ -33,9 +32,7 @@ go_library(
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",
-        "@com_github_dataexmachina_dev_side_eye_go//sideeye",
         "@com_github_petermattis_goid//:goid",
-        "@com_github_stretchr_testify//require",
     ],
 )
 

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -703,7 +703,7 @@ func TestLint(t *testing.T) {
 					":!acceptance/test_acceptance.go",           // For COCKROACH_RUN_ACCEPTANCE
 					":!compose/compare/compare/compare_test.go", // For COCKROACH_RUN_COMPOSE_COMPARE
 					":!compose/compose_test.go",                 // For COCKROACH_RUN_COMPOSE
-					":!testutils/sideeye.go",                    // For SIDE_EYE_API_TOKEN
+					":!testutils/sideeye/sideeye.go",            // For SIDE_EYE_API_TOKEN
 				},
 			},
 		} {

--- a/pkg/testutils/sideeye/BUILD.bazel
+++ b/pkg/testutils/sideeye/BUILD.bazel
@@ -1,0 +1,14 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "sideeye",
+    srcs = ["sideeye.go"],
+    importpath = "github.com/cockroachdb/cockroach/pkg/testutils/sideeye",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/testutils",
+        "@com_github_cockroachdb_errors//:errors",
+        "@com_github_dataexmachina_dev_side_eye_go//sideeye",
+        "@com_github_stretchr_testify//require",
+    ],
+)

--- a/pkg/testutils/sideeye/sideeye.go
+++ b/pkg/testutils/sideeye/sideeye.go
@@ -12,13 +12,14 @@ import (
 	"time"
 
 	"github.com/DataExMachina-dev/side-eye-go/sideeye"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 )
 
 type testingT interface {
 	require.TestingT
-	TestFatalerLogger
+	testutils.TestFatalerLogger
 }
 
 // CaptureSideEyeSnapshot captures a Side-Eye snapshot if the
@@ -39,7 +40,7 @@ func CaptureSideEyeSnapshot(ctx context.Context, t testingT) {
 	require.NoError(t, err)
 
 	var name string
-	if t, ok := t.(TestNamedFatalerLogger); ok {
+	if t, ok := t.(testutils.TestNamedFatalerLogger); ok {
 		name = t.Name()
 	} else {
 		name = "unknown test"


### PR DESCRIPTION
This being directly present in `pkg/testutils` meant that `side-eye` is directly linked into `cockroach`, which was not intentional. It also made `cockroach` impossible to build for `s390x` as `side-eye` doesn't support it. Since the helper is unused, we can just move the helper to its own package.

Epic: CRDB-21133
Release note: None