### PR TITLE
backup: jobify backup compactions

### DIFF
--- a/pkg/backup/backup_job.go
+++ b/pkg/backup/backup_job.go
@@ -581,6 +581,14 @@ func (b *backupResumer) Resume(ctx context.Context, execCtx interface{}) error {
 		return err
 	}
 
+	// TODO (kev-cao): there is a decent amount of overlap between the initial
+	// setup of classic backup and backup compaction with some minor differences,
+	// (e.g. lock writing, checkpointing, etc.). It would be nice to unify these
+	// with a common setup function.
+	if details.Compact {
+		return compactBackups(ctx, b.job.ID(), p, details)
+	}
+
 	kmsEnv := backupencryption.MakeBackupKMSEnv(
 		p.ExecCfg().Settings,
 		&p.ExecCfg().ExternalIODirConfig,

--- a/pkg/jobs/jobspb/jobs.proto
+++ b/pkg/jobs/jobspb/jobs.proto
@@ -374,7 +374,7 @@ message BackupDetails {
   // sub-paths of it based on date and time, etc. The actual path -- which is
   // derived from this destination -- is then captured in the field "URI" below.
   message Destination {
-    // To is either a backup path, path, or a collection path if subdir is set.
+    // To is a collection path 
     repeated string to = 1;
     // Subdir is the path within the collection path in to to backup to.
     string subdir = 2;
@@ -460,7 +460,7 @@ message BackupDetails {
 
   roachpb.Locality execution_locality = 24 [(gogoproto.nullable) = false];
 
-  // IncldeAllSecondaryTenants indicates whether a full tenant backup
+  // IncludeAllSecondaryTenants indicates whether a full tenant backup
   // should also include a tenant backup of all existing secondary
   // tenants.
   bool include_all_secondary_tenants = 25;
@@ -470,7 +470,15 @@ message BackupDetails {
   // time of a backup failure due to a KMS error.
   bool updates_cluster_monitoring_metrics = 26;
 
-  // NEXT ID: 27;
+  // Compact is set if the job is a compaction job. In that case, the StartTime
+  // and EndTime describe the time range of the compaction. StartTime will be
+  // the start time of the first backup to be compacted and EndTime will be the
+  // end time of the last backup to be compacted.
+  // NB: If Compact is set, the job is not a regular backup job and only a limited
+  //  set of fields are set meaningfully.
+  bool compact = 27;
+
+  // NEXT ID: 28;
 }
 
 message BackupProgress {

--- a/pkg/sql/sem/builtins/fixed_oids.go
+++ b/pkg/sql/sem/builtins/fixed_oids.go
@@ -2607,7 +2607,7 @@ var builtinOidsArray = []string{
 	2644: `crdb_internal.range_stats_with_errors(key: bytes) -> jsonb`,
 	2645: `crdb_internal.lease_holder_with_errors(key: bytes) -> jsonb`,
 	2646: `crdb_internal.pretty_key(raw_key: bytes) -> string`,
-	2647: `crdb_internal.backup_compaction(collection_uri: string[], full_backup_path: string, encryption_opts: bytes, start_time: decimal, end_time: decimal) -> void`,
+	2647: `crdb_internal.backup_compaction(collection_uri: string[], full_backup_path: string, encryption_opts: bytes, start_time: decimal, end_time: decimal) -> int`,
 }
 
 var builtinOidsBySignature map[string]oid.Oid


### PR DESCRIPTION
This patch moves backup compactions from a one-off operation to a asynchronous job. The builtin now starts a compaction job instead of directly running compactions. Another PR will be needed to add resume functionality to the compaction job.

Epic: none

Release note: None