### PR TITLE
Reapply "jobs: parse internal jobs queries at init time"

### DIFF
--- a/pkg/jobs/BUILD.bazel
+++ b/pkg/jobs/BUILD.bazel
@@ -52,6 +52,8 @@ go_library(
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/catalog/descs",
         "//pkg/sql/isql",
+        "//pkg/sql/parser",
+        "//pkg/sql/parser/statements",
         "//pkg/sql/pgwire/pgerror",
         "//pkg/sql/protoreflect",
         "//pkg/sql/sem/catconstants",

--- a/pkg/jobs/job_info_storage.go
+++ b/pkg/jobs/job_info_storage.go
@@ -15,6 +15,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/sql/isql"
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
+	"github.com/cockroachdb/cockroach/pkg/sql/parser/statements"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlliveness"
@@ -33,6 +35,16 @@ var (
 	)
 )
 
+// Parse all job storage SQL statements at init time to avoid parsing them on
+// every execution.
+func mustParseOne(s string) statements.Statement[tree.Statement] {
+	stmt, err := parser.ParseOne(s)
+	if err != nil {
+		panic(err)
+	}
+	return stmt
+}
+
 // ProgressStorage reads and writes progress rows.
 type ProgressStorage jobspb.JobID
 
@@ -40,6 +52,10 @@ type ProgressStorage jobspb.JobID
 func (j *Job) ProgressStorage() ProgressStorage {
 	return ProgressStorage(j.id)
 }
+
+var getJobProgressQuery = mustParseOne(
+	"SELECT written, fraction, resolved FROM system.job_progress WHERE job_id = $1",
+)
 
 // Get returns the latest progress report for the job along with when it was
 // written. If the fraction is null it is returned as NaN, and if the resolved
@@ -50,10 +66,10 @@ func (i ProgressStorage) Get(
 	ctx, sp := tracing.ChildSpan(ctx, "get-job-progress")
 	defer sp.Finish()
 
-	row, err := txn.QueryRowEx(
+	row, err := txn.QueryRowExParsed(
 		ctx, "job-progress-get", txn.KV(),
 		sessiondata.NodeUserSessionDataOverride,
-		"SELECT written, fraction, resolved FROM system.job_progress WHERE job_id = $1", i,
+		getJobProgressQuery, i,
 	)
 
 	if err != nil || row == nil {
@@ -91,6 +107,22 @@ func (i ProgressStorage) Get(
 	return fraction, ts, written.Time, nil
 }
 
+var (
+	deleteJobProgressStmt = mustParseOne(
+		`DELETE FROM system.job_progress WHERE job_id = $1`,
+	)
+	insertJobProgressStmt = mustParseOne(
+		`INSERT INTO system.job_progress (job_id, written, fraction, resolved) VALUES ($1, now(), $2, $3)`,
+	)
+	insertJobProgressHistoryStmt = mustParseOne(
+		`UPSERT INTO system.job_progress_history (job_id, written, fraction, resolved) VALUES ($1, now(), $2, $3)`,
+	)
+	pruneJobProgressHistoryStmt = mustParseOne(
+		`DELETE FROM system.job_progress_history WHERE job_id = $1 AND written IN 
+			(SELECT written FROM system.job_progress_history WHERE job_id = $1 ORDER BY written DESC OFFSET $2)`,
+	)
+)
+
 // Set records a progress update. If fraction is NaN or resolved is empty, that
 // field is left null. The time at which the progress was reported is recorded.
 func (i ProgressStorage) Set(
@@ -99,9 +131,9 @@ func (i ProgressStorage) Set(
 	ctx, sp := tracing.ChildSpan(ctx, "write-job-progress")
 	defer sp.Finish()
 
-	if _, err := txn.ExecEx(
+	if _, err := txn.ExecParsed(
 		ctx, "write-job-progress-delete", txn.KV(), sessiondata.NodeUserSessionDataOverride,
-		`DELETE FROM system.job_progress WHERE job_id = $1`, i,
+		deleteJobProgressStmt, i,
 	); err != nil {
 		return err
 	}
@@ -114,26 +146,25 @@ func (i ProgressStorage) Set(
 		ts = resolved.AsOfSystemTime()
 	}
 
-	if _, err := txn.ExecEx(
+	if _, err := txn.ExecParsed(
 		ctx, "write-job-progress-insert", txn.KV(), sessiondata.NodeUserSessionDataOverride,
-		`INSERT INTO system.job_progress (job_id, written, fraction, resolved) VALUES ($1, now(), $2, $3)`,
+		insertJobProgressStmt,
 		i, frac, ts,
 	); err != nil {
 		return err
 	}
 
-	if _, err := txn.ExecEx(
+	if _, err := txn.ExecParsed(
 		ctx, "write-job-progress-history-insert", txn.KV(), sessiondata.NodeUserSessionDataOverride,
-		`UPSERT INTO system.job_progress_history (job_id, written, fraction, resolved) VALUES ($1, now(), $2, $3)`,
+		insertJobProgressHistoryStmt,
 		i, frac, ts,
 	); err != nil {
 		return err
 	}
 
-	if _, err := txn.ExecEx(
+	if _, err := txn.ExecParsed(
 		ctx, "write-job-progress-history-prune", txn.KV(), sessiondata.NodeUserSessionDataOverride,
-		`DELETE FROM system.job_progress_history WHERE job_id = $1 AND written IN 
-			(SELECT written FROM system.job_progress_history WHERE job_id = $1 ORDER BY written DESC OFFSET $2)`,
+		pruneJobProgressHistoryStmt,
 		i, retainedProgressHistory.Get(txn.KV().DB().SettingsValues()),
 	); err != nil {
 		return err
@@ -165,14 +196,22 @@ func (j *Job) StatusStorage() StatusStorage {
 	return StatusStorage(j.id)
 }
 
+var deleteJobStatusStmt = mustParseOne(
+	`DELETE FROM system.job_status WHERE job_id = $1`,
+)
+
 // Clear clears the status message row for the job, if it exists.
 func (i StatusStorage) Clear(ctx context.Context, txn isql.Txn) error {
-	_, err := txn.ExecEx(
+	_, err := txn.ExecParsed(
 		ctx, "clear-job-status-delete", txn.KV(), sessiondata.NodeUserSessionDataOverride,
-		`DELETE FROM system.job_status WHERE job_id = $1`, i,
+		deleteJobStatusStmt, i,
 	)
 	return err
 }
+
+var insertJobStatusStmt = mustParseOne(
+	`INSERT INTO system.job_status (job_id, written, status) VALUES ($1, now(), $2)`,
+)
 
 // Sets writes the current status, replacing the current one if it exists.
 // Setting an empty status is the same as calling Clear().
@@ -186,9 +225,9 @@ func (i StatusStorage) Set(ctx context.Context, txn isql.Txn, status string) err
 		return err
 	}
 
-	if _, err := txn.ExecEx(
+	if _, err := txn.ExecParsed(
 		ctx, "write-job-status-insert", txn.KV(), sessiondata.NodeUserSessionDataOverride,
-		`INSERT INTO system.job_status (job_id, written, status) VALUES ($1, now(), $2)`,
+		insertJobStatusStmt,
 		i, status,
 	); err != nil {
 		return err
@@ -201,14 +240,18 @@ func (i StatusStorage) Set(ctx context.Context, txn isql.Txn, status string) err
 	return nil
 }
 
+var getJobStatusQuery = mustParseOne(
+	"SELECT written, status FROM system.job_status WHERE job_id = $1",
+)
+
 // Get gets the current status mesasge for a job, if any.
 func (i StatusStorage) Get(ctx context.Context, txn isql.Txn) (string, time.Time, error) {
 	ctx, sp := tracing.ChildSpan(ctx, "get-job-status")
 	defer sp.Finish()
 
-	row, err := txn.QueryRowEx(
+	row, err := txn.QueryRowExParsed(
 		ctx, "job-status-get", txn.KV(), sessiondata.NodeUserSessionDataOverride,
-		"SELECT written, status FROM system.job_status WHERE job_id = $1",
+		getJobStatusQuery,
 		i,
 	)
 
@@ -249,6 +292,17 @@ func (j *Job) Messages() MessageStorage {
 	return MessageStorage(j.id)
 }
 
+var (
+	upsertJobMessageStmt = mustParseOne(
+		`UPSERT INTO system.job_message (job_id, written, kind, message) VALUES ($1, now(),$2, $3)`,
+	)
+	pruneJobMessageStmt = mustParseOne(
+		`DELETE FROM system.job_message WHERE job_id = $1 AND kind = $2 AND written IN (
+			SELECT written FROM system.job_message WHERE job_id = $1 AND kind = $2 ORDER BY written DESC OFFSET $3
+		)`,
+	)
+)
+
 // Record writes a human readable message of the specified kind to the message
 // log for this job, and prunes retained messages of the same kind based on the
 // configured limit to keep the total number of retained messages bounded.
@@ -257,20 +311,18 @@ func (i MessageStorage) Record(ctx context.Context, txn isql.Txn, kind, message 
 	defer sp.Finish()
 
 	// Insert the new message.
-	if _, err := txn.ExecEx(
+	if _, err := txn.ExecParsed(
 		ctx, "write-job-message-insert", txn.KV(), sessiondata.NodeUserSessionDataOverride,
-		`UPSERT INTO system.job_message (job_id, written, kind, message) VALUES ($1, now(),$2, $3)`,
+		upsertJobMessageStmt,
 		i, kind, message,
 	); err != nil {
 		return err
 	}
 
 	// Prune old messages of the same kind to bound historical data.
-	if _, err := txn.ExecEx(
+	if _, err := txn.ExecParsed(
 		ctx, "write-job-message-prune", txn.KV(), sessiondata.NodeUserSessionDataOverride,
-		`DELETE FROM system.job_message WHERE job_id = $1 AND kind = $2 AND written IN (
-			SELECT written FROM system.job_message WHERE job_id = $1 AND kind = $2 ORDER BY written DESC OFFSET $3
-		)`,
+		pruneJobMessageStmt,
 		i, kind, retainedMessageHistory.Get(txn.KV().DB().SettingsValues()),
 	); err != nil {
 		return err
@@ -352,14 +404,18 @@ func InfoStorageForJob(txn isql.Txn, jobID jobspb.JobID) InfoStorage {
 	return InfoStorage{j: &Job{id: jobID}, txn: txn}
 }
 
+var checkClaimSessionQuery = mustParseOne(
+	`SELECT claim_session_id FROM system.jobs WHERE id = $1`,
+)
+
 func (i *InfoStorage) checkClaimSession(ctx context.Context) error {
 	if i.claimChecked {
 		return nil
 	}
 
-	row, err := i.txn.QueryRowEx(ctx, "check-claim-session", i.txn.KV(),
+	row, err := i.txn.QueryRowExParsed(ctx, "check-claim-session", i.txn.KV(),
 		sessiondata.NodeUserSessionDataOverride,
-		`SELECT claim_session_id FROM system.jobs WHERE id = $1`, i.j.ID())
+		checkClaimSessionQuery, i.j.ID())
 	if err != nil {
 		return err
 	}
@@ -379,6 +435,10 @@ func (i *InfoStorage) checkClaimSession(ctx context.Context) error {
 	return nil
 }
 
+var getJobInfoQuery = mustParseOne(
+	"SELECT value FROM system.job_info WHERE job_id = $1 AND info_key::string = $2 ORDER BY written DESC LIMIT 1",
+)
+
 func (i InfoStorage) get(ctx context.Context, opName, infoKey string) ([]byte, bool, error) {
 	if i.txn == nil {
 		return nil, false, errors.New("cannot access the job info table without an associated txn")
@@ -392,10 +452,10 @@ func (i InfoStorage) get(ctx context.Context, opName, infoKey string) ([]byte, b
 	// We expect there to be only a single row for a given <job_id, info_key>.
 	// This is because all older revisions are deleted before a new one is
 	// inserted in `InfoStorage.Write`.
-	row, err := i.txn.QueryRowEx(
+	row, err := i.txn.QueryRowExParsed(
 		ctx, "job-info-get", i.txn.KV(),
 		sessiondata.NodeUserSessionDataOverride,
-		"SELECT value FROM system.job_info WHERE job_id = $1 AND info_key::string = $2 ORDER BY written DESC LIMIT 1",
+		getJobInfoQuery,
 		j.ID(), infoKey,
 	)
 
@@ -415,13 +475,22 @@ func (i InfoStorage) get(ctx context.Context, opName, infoKey string) ([]byte, b
 	return []byte(*value), true, nil
 }
 
+var (
+	deleteJobInfoStmt = mustParseOne(
+		`DELETE FROM system.job_info WHERE job_id = $1 AND info_key::string = $2`,
+	)
+	insertJobInfoStmt = mustParseOne(
+		`INSERT INTO system.job_info (job_id, info_key, written, value) VALUES ($1, $2, now(), $3)`,
+	)
+)
+
 func (i InfoStorage) write(ctx context.Context, infoKey string, value []byte) error {
 	return i.doWrite(ctx, func(ctx context.Context, j *Job, txn isql.Txn) error {
 		// First clear out any older revisions of this info.
-		_, err := txn.ExecEx(
+		_, err := txn.ExecParsed(
 			ctx, "write-job-info-delete", txn.KV(),
 			sessiondata.NodeUserSessionDataOverride,
-			"DELETE FROM system.job_info WHERE job_id = $1 AND info_key::string = $2",
+			deleteJobInfoStmt,
 			j.ID(), infoKey,
 		)
 		if err != nil {
@@ -433,10 +502,10 @@ func (i InfoStorage) write(ctx context.Context, infoKey string, value []byte) er
 			return nil
 		}
 		// Write the new info, using the same transaction.
-		_, err = txn.ExecEx(
+		_, err = txn.ExecParsed(
 			ctx, "write-job-info-insert", txn.KV(),
 			sessiondata.NodeUserSessionDataOverride,
-			`INSERT INTO system.job_info (job_id, info_key, written, value) VALUES ($1, $2, now(), $3)`,
+			insertJobInfoStmt,
 			j.ID(), infoKey, value,
 		)
 		return err
@@ -556,6 +625,16 @@ func (i InfoStorage) Delete(ctx context.Context, infoKey string) error {
 	return i.write(ctx, infoKey, nil /* value */)
 }
 
+var (
+	deleteJobInfoRangeLimitStmt = mustParseOne(
+		`DELETE FROM system.job_info WHERE job_id = $1 AND info_key >= $2 AND info_key < $3
+			ORDER BY info_key ASC LIMIT $4`,
+	)
+	deleteJobInfoRangeStmt = mustParseOne(
+		"DELETE FROM system.job_info WHERE job_id = $1 AND info_key >= $2 AND info_key < $3",
+	)
+)
+
 // DeleteRange removes the info records between the provided
 // start key (inclusive) and end key (exclusive).
 func (i InfoStorage) DeleteRange(
@@ -563,25 +642,28 @@ func (i InfoStorage) DeleteRange(
 ) error {
 	return i.doWrite(ctx, func(ctx context.Context, j *Job, txn isql.Txn) error {
 		if limit > 0 {
-			_, err := txn.ExecEx(
-				ctx, "write-job-info-delete", txn.KV(),
+			_, err := txn.ExecParsed(
+				ctx, "write-job-info-delete-limit", txn.KV(),
 				sessiondata.NodeUserSessionDataOverride,
-				"DELETE FROM system.job_info WHERE job_id = $1 AND info_key >= $2 AND info_key < $3 "+
-					"ORDER BY info_key ASC LIMIT $4",
+				deleteJobInfoRangeLimitStmt,
 				j.ID(), startInfoKey, endInfoKey, limit,
 			)
 			return err
 		} else {
-			_, err := txn.ExecEx(
+			_, err := txn.ExecParsed(
 				ctx, "write-job-info-delete", txn.KV(),
 				sessiondata.NodeUserSessionDataOverride,
-				"DELETE FROM system.job_info WHERE job_id = $1 AND info_key >= $2 AND info_key < $3",
+				deleteJobInfoRangeStmt,
 				j.ID(), startInfoKey, endInfoKey,
 			)
 			return err
 		}
 	})
 }
+
+var getJobInfoCountQuery = mustParseOne(
+	"SELECT count(*) FROM system.job_info WHERE job_id = $1 AND info_key >= $2 AND info_key < $3",
+)
 
 // Count counts the info records in the range [start, end).
 func (i InfoStorage) Count(ctx context.Context, startInfoKey, endInfoKey string) (int, error) {
@@ -592,10 +674,10 @@ func (i InfoStorage) Count(ctx context.Context, startInfoKey, endInfoKey string)
 	ctx, sp := tracing.ChildSpan(ctx, "count-job-info")
 	defer sp.Finish()
 
-	row, err := i.txn.QueryRowEx(
+	row, err := i.txn.QueryRowExParsed(
 		ctx, "job-info-count", i.txn.KV(),
 		sessiondata.NodeUserSessionDataOverride,
-		"SELECT count(*) FROM system.job_info WHERE job_id = $1 AND info_key >= $2 AND info_key < $3",
+		getJobInfoCountQuery,
 		i.j.ID(), startInfoKey, endInfoKey,
 	)
 

--- a/pkg/jobs/update.go
+++ b/pkg/jobs/update.go
@@ -53,6 +53,33 @@ func (j *Job) WithTxn(txn isql.Txn) Updater {
 	return Updater{j: j, txn: txn}
 }
 
+var (
+	updateJobStatusStmt = mustParseOne(
+		`UPDATE system.jobs SET status = $1 WHERE id = $2`,
+	)
+	loadJobQuery = mustParseOne(`
+WITH
+  latestpayload AS (
+    SELECT job_id, value
+    FROM system.job_info AS payload
+    WHERE info_key = 'legacy_payload' AND job_id = $1
+    ORDER BY written DESC LIMIT 1
+  ),
+  latestprogress AS (
+    SELECT job_id, value
+    FROM system.job_info AS progress
+    WHERE info_key = 'legacy_progress' AND job_id = $1
+    ORDER BY written DESC LIMIT 1
+  )
+SELECT status, payload.value AS payload, progress.value AS progress,
+       claim_session_id, COALESCE(last_run, created), COALESCE(num_runs, 0)
+FROM system.jobs AS j
+INNER JOIN latestpayload AS payload ON j.id = payload.job_id
+LEFT JOIN latestprogress AS progress ON j.id = progress.job_id
+WHERE id = $1
+`)
+)
+
 func (u Updater) update(ctx context.Context, updateFn UpdateFn) (retErr error) {
 	if u.txn == nil {
 		return u.j.registry.db.Txn(ctx, func(
@@ -90,28 +117,7 @@ func (u Updater) update(ctx context.Context, updateFn UpdateFn) (retErr error) {
 		}
 	}()
 
-	const loadJobQuery = `
-WITH
-  latestpayload AS (
-    SELECT job_id, value
-    FROM system.job_info AS payload
-    WHERE info_key = 'legacy_payload' AND job_id = $1
-    ORDER BY written DESC LIMIT 1
-  ),
-  latestprogress AS (
-    SELECT job_id, value
-    FROM system.job_info AS progress
-    WHERE info_key = 'legacy_progress' AND job_id = $1
-    ORDER BY written DESC LIMIT 1
-  )
-SELECT status, payload.value AS payload, progress.value AS progress,
-       claim_session_id, COALESCE(last_run, created), COALESCE(num_runs, 0)
-FROM system.jobs AS j
-INNER JOIN latestpayload AS payload ON j.id = payload.job_id
-LEFT JOIN latestprogress AS progress ON j.id = progress.job_id
-WHERE id = $1
-`
-	row, err := u.txn.QueryRowEx(
+	row, err := u.txn.QueryRowExParsed(
 		ctx, "select-job", u.txn.KV(),
 		sessiondata.NodeUserSessionDataOverride,
 		loadJobQuery, j.ID(),
@@ -204,28 +210,6 @@ WHERE id = $1
 		return nil
 	}
 
-	// Build a statement of the following form, depending on which properties
-	// need updating:
-	//
-	//   UPDATE system.jobs
-	//   SET
-	//     [status = $2,]
-	//     [payload = $y,]
-	//     [progress = $z]
-	//   WHERE
-	//     id = $1
-
-	var setters []string
-	params := []interface{}{j.ID()} // $1 is always the job ID.
-	addSetter := func(column string, value interface{}) {
-		params = append(params, value)
-		setters = append(setters, fmt.Sprintf("%s = $%d", column, len(params)))
-	}
-
-	if ju.md.Status != "" {
-		addSetter("status", ju.md.Status)
-	}
-
 	var payloadBytes []byte
 	if ju.md.Payload != nil {
 		payload = ju.md.Payload
@@ -247,15 +231,11 @@ WHERE id = $1
 		}
 	}
 
-	if len(setters) != 0 {
-		updateStmt := fmt.Sprintf(
-			"UPDATE system.jobs SET %s WHERE id = $1",
-			strings.Join(setters, ", "),
-		)
-		n, err := u.txn.ExecEx(
+	if ju.md.Status != "" {
+		n, err := u.txn.ExecParsed(
 			ctx, "job-update", u.txn.KV(),
 			sessiondata.NodeUserSessionDataOverride,
-			updateStmt, params...,
+			updateJobStatusStmt, ju.md.Status, j.ID(),
 		)
 		if err != nil {
 			return err
@@ -349,6 +329,8 @@ WHERE id = $1
 
 		}
 		if len(vals) > 1 {
+			// TODO(rafi): Can we use ExecParsed here to avoid parsing the
+			//  statement every time?
 			stmt := fmt.Sprintf("UPDATE system.jobs SET %s WHERE id = $1", update.String())
 			if _, err := u.txn.ExecEx(
 				ctx, "job-update-row", u.txn.KV(),


### PR DESCRIPTION
### sql: copy AST when using parsed queries with internal executor

This patch changes the internal executor to copy the parsed AST before
executing it. This is needed because type checking an AST mutates it, so
the AST is not save for concurrent usage by multiple internal executors.

fixes https://github.com/cockroachdb/cockroach/issues/140803

### Reapply "jobs: parse internal jobs queries at init time"

This reverts commit 8e5590c.

---

Release note: None