### PR TITLE
sql: concurrent DML can prevent PK swaps from succeeding

### DIFF
--- a/pkg/sql/catalog/lease/lease.go
+++ b/pkg/sql/catalog/lease/lease.go
@@ -1730,9 +1730,15 @@ func (m *Manager) StartRefreshLeasesTask(ctx context.Context, s *stop.Stopper, d
 				// will be acquired if the schema is already leased to invalidate metadata
 				// caches (like optimizer memos).
 				purgeOldVersionsOrAcquireInitialVersion := func(ctx context.Context) {
+					if m.testingKnobs.TestingOnNewVersion != nil {
+						m.testingKnobs.TestingOnNewVersion(desc.GetID())
+					}
 					// Notify of any new / modified descriptors below once a new lease is
 					// acquired.
 					defer m.leaseGeneration.Add(1)
+					if m.testingKnobs.TestingOnLeaseGenerationBumpForNewVersion != nil {
+						defer m.testingKnobs.TestingOnLeaseGenerationBumpForNewVersion(desc.GetID())
+					}
 
 					// Whenever a new relation / type is created under an already leased
 					// schema we are going to lease the object out immediately. This allows

--- a/pkg/sql/catalog/lease/testutils.go
+++ b/pkg/sql/catalog/lease/testutils.go
@@ -50,6 +50,14 @@ type ManagerTestingKnobs struct {
 	// the lease manager attempts to acquire a lease for descriptor `id`.
 	TestingBeforeAcquireLeaseDuringRefresh func(id descpb.ID) error
 
+	// TestingOnNewVersion invoked when the range feed detects a new descriptor.
+	TestingOnNewVersion func(id descpb.ID)
+
+	// TestingOnLeaseGenerationBumpForNewVersion invoked when the lease generation,
+	// after a new descriptor or initial descriptor version are observed via
+	// the range feed.
+	TestingOnLeaseGenerationBumpForNewVersion func(id descpb.ID)
+
 	// To disable the deletion of orphaned leases at server startup.
 	DisableDeleteOrphanedLeases bool
 

--- a/pkg/sql/opt/cat/catalog.go
+++ b/pkg/sql/opt/cat/catalog.go
@@ -49,6 +49,11 @@ type StableID uint64
 // always return this value as their ID.
 const DefaultStableID = StableID(catid.InvalidDescID)
 
+// InvalidVersion is the version number used to represent objects that
+// are not versioned in any way. For example the GlobalPrivilege object,
+// which is not backed by a descriptor.
+const InvalidVersion = uint64(0)
+
 // SchemaName is an alias for tree.ObjectNamePrefix, since it consists of the
 // catalog + schema name.
 type SchemaName = tree.ObjectNamePrefix
@@ -260,8 +265,8 @@ type Catalog interface {
 	GetDependencyDigest() DependencyDigest
 
 	// LeaseByStableID leases out a descriptor by the stable ID, which will block
-	// schema changes. The underlying schema object is not returned.
-	LeaseByStableID(ctx context.Context, id StableID) error
+	// schema changes. The version of the underlying object is returned.
+	LeaseByStableID(ctx context.Context, id StableID) (uint64, error)
 
 	// GetRoutineOwner returns the username.SQLUsername of the routine's
 	// (specified by routineOid) owner.

--- a/pkg/sql/opt/cat/object.go
+++ b/pkg/sql/opt/cat/object.go
@@ -28,4 +28,7 @@ type Object interface {
 	//
 	// Used for invalidating cached plans.
 	Equals(other Object) bool
+
+	// Version returns the underlying version of the descriptor backing this object.
+	Version() uint64
 }

--- a/pkg/sql/opt/exec/explain/plan_gist_factory.go
+++ b/pkg/sql/opt/exec/explain/plan_gist_factory.go
@@ -498,6 +498,10 @@ func (u *unknownTable) ID() cat.StableID {
 	panic(errors.AssertionFailedf("not implemented"))
 }
 
+func (u *unknownTable) Version() uint64 {
+	panic(errors.AssertionFailedf("not implemented"))
+}
+
 func (u *unknownTable) PostgresDescriptorID() catid.DescID {
 	panic(errors.AssertionFailedf("not implemented"))
 }

--- a/pkg/sql/opt/indexrec/hypothetical_table.go
+++ b/pkg/sql/opt/indexrec/hypothetical_table.go
@@ -187,3 +187,8 @@ func (ht *HypotheticalTable) addInvertedCol(invertedSourceCol *cat.Column) *cat.
 	ht.invertedCols = append(ht.invertedCols, &invertedCol)
 	return &invertedCol
 }
+
+// Version is part of the cat.Object interface.
+func (ht *HypotheticalTable) Version() uint64 {
+	return 1
+}

--- a/pkg/sql/opt/testutils/testcat/test_catalog.go
+++ b/pkg/sql/opt/testutils/testcat/test_catalog.go
@@ -487,8 +487,8 @@ func (tc *Catalog) GetDependencyDigest() cat.DependencyDigest {
 }
 
 // LeaseByStableID does not do anything since no leasing is used here.
-func (tc *Catalog) LeaseByStableID(_ context.Context, _ cat.StableID) error {
-	return nil
+func (tc *Catalog) LeaseByStableID(ctx context.Context, id cat.StableID) (uint64, error) {
+	return 1, nil
 }
 
 // ExecuteMultipleDDL parses the given semicolon-separated DDL SQL statements
@@ -690,6 +690,11 @@ func (s *Schema) ID() cat.StableID {
 	return s.SchemaID
 }
 
+// Version is a part of cat.Object
+func (s *Schema) Version() uint64 {
+	return 1
+}
+
 // PostgresDescriptorID is part of the cat.Object interface.
 func (s *Schema) PostgresDescriptorID() catid.DescID {
 	return catid.DescID(s.SchemaID)
@@ -746,6 +751,11 @@ func (tv *View) String() string {
 // ID is part of the cat.DataSource interface.
 func (tv *View) ID() cat.StableID {
 	return tv.ViewID
+}
+
+// Version is a part of cat.Object
+func (tv *View) Version() uint64 {
+	return 1
 }
 
 // PostgresDescriptorID is part of the cat.Object interface.
@@ -866,6 +876,11 @@ func (tt *Table) SetMultiRegion(val bool) {
 // ID is part of the cat.DataSource interface.
 func (tt *Table) ID() cat.StableID {
 	return tt.TabID
+}
+
+// Version is a part of cat.Object
+func (tt *Table) Version() uint64 {
+	return 1
 }
 
 // PostgresDescriptorID is part of the cat.Object interface.
@@ -1759,6 +1774,11 @@ var _ cat.Sequence = &Sequence{}
 // ID is part of the cat.DataSource interface.
 func (ts *Sequence) ID() cat.StableID {
 	return ts.SeqID
+}
+
+// Version is a part of cat.Object
+func (ts *Sequence) Version() uint64 {
+	return 1
 }
 
 // PostgresDescriptorID is part of the cat.Object interface.

--- a/pkg/sql/syntheticprivilege/global_privilege.go
+++ b/pkg/sql/syntheticprivilege/global_privilege.go
@@ -64,6 +64,11 @@ func (p *GlobalPrivilege) ID() cat.StableID {
 	return cat.DefaultStableID
 }
 
+// Version implements the cat.Object interface.
+func (p *GlobalPrivilege) Version() uint64 {
+	return cat.InvalidVersion
+}
+
 // PostgresDescriptorID implements the cat.Object interface.
 func (p *GlobalPrivilege) PostgresDescriptorID() catid.DescID {
 	return descpb.InvalidID


### PR DESCRIPTION
Previously, we added an optimization to skip re-resolving object metadata if no leased descriptors had changed. This change also leased descriptors to ensure schema changes couldn't progress, as otherwise we could corrupt data by writing incompatible information. While this resolved most failures associated with concurrent DML/DDL execution by leasing required descriptors, intermittent failures still occur if a primary key change happens.  This is because we can end up using an old descriptor version, which results in DML not writing information into the temporary indexes. While there's no risk of generating a corrupt index because validation catches the missing rows, this bug can cause these schema changes to fail. To address this, this patch adds logic to ensure descriptor versions match; otherwise, the memo will be re-planned.

Fixes: #140475
Fixes: https://github.com/cockroachdb/cockroach/issues/140954
Release note (bug fix): Addresses a bug that could cause concurrent DML to prevent primary key changes from succeeding