### PR TITLE
ci: do not update releases YAML on 23.1

### DIFF
--- a/.github/workflows/update_releases.yaml
+++ b/.github/workflows/update_releases.yaml
@@ -27,7 +27,6 @@ jobs:
       matrix:
         branch:
           - "master"
-          - "release-23.1"
           - "release-23.2"
           - "release-24.1"
           - "release-24.2"


### PR DESCRIPTION
This disables updates to the releases YAML file on the `release-23.1` branch.

Epic: none
Release note: None