### PR TITLE
release-25.1: opt: set min row count of 1 for FK and uniqueness check WithScans

### DIFF
--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -4026,6 +4026,10 @@ func (m *sessionDataMutator) SetOptimizerMinRowCount(val float64) {
 	m.data.OptimizerMinRowCount = val
 }
 
+func (m *sessionDataMutator) SetOptFKUniqCheckLowerBoundEnabled(val bool) {
+	m.data.OptFKUniqCheckLowerBoundEnabled = val
+}
+
 // Utility functions related to scrubbing sensitive information on SQL Stats.
 
 // quantizeCounts ensures that the Count field in the

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -4002,6 +4002,7 @@ max_retries_for_read_committed                             10
 node_id                                                    1
 null_ordered_last                                          off
 on_update_rehome_row_enabled                               on
+opt_fk_uniq_check_lower_bound_enabled                      off
 opt_split_scan_limit                                       2048
 optimizer                                                  on
 optimizer_always_use_histograms                            on

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -3003,6 +3003,7 @@ max_retries_for_read_committed                             10                  N
 node_id                                                    1                   NULL      NULL        NULL        string
 null_ordered_last                                          off                 NULL      NULL        NULL        string
 on_update_rehome_row_enabled                               on                  NULL      NULL        NULL        string
+opt_fk_uniq_check_lower_bound_enabled                      off                 NULL      NULL        NULL        string
 opt_split_scan_limit                                       2048                NULL      NULL        NULL        string
 optimizer_always_use_histograms                            on                  NULL      NULL        NULL        string
 optimizer_hoist_uncorrelated_equality_subqueries           on                  NULL      NULL        NULL        string
@@ -3210,6 +3211,7 @@ max_retries_for_read_committed                             10                  N
 node_id                                                    1                   NULL  user     NULL      1                   1
 null_ordered_last                                          off                 NULL  user     NULL      off                 off
 on_update_rehome_row_enabled                               on                  NULL  user     NULL      on                  on
+opt_fk_uniq_check_lower_bound_enabled                      off                 NULL  user     NULL      off                 off
 opt_split_scan_limit                                       2048                NULL  user     NULL      2048                2048
 optimizer_always_use_histograms                            on                  NULL  user     NULL      on                  on
 optimizer_hoist_uncorrelated_equality_subqueries           on                  NULL  user     NULL      on                  on
@@ -3415,6 +3417,7 @@ multiple_active_portals_enabled                            NULL    NULL     NULL
 node_id                                                    NULL    NULL     NULL     NULL        NULL
 null_ordered_last                                          NULL    NULL     NULL     NULL        NULL
 on_update_rehome_row_enabled                               NULL    NULL     NULL     NULL        NULL
+opt_fk_uniq_check_lower_bound_enabled                      NULL    NULL     NULL     NULL        NULL
 opt_split_scan_limit                                       NULL    NULL     NULL     NULL        NULL
 optimizer                                                  NULL    NULL     NULL     NULL        NULL
 optimizer_always_use_histograms                            NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -134,6 +134,7 @@ max_retries_for_read_committed                             10
 node_id                                                    1
 null_ordered_last                                          off
 on_update_rehome_row_enabled                               on
+opt_fk_uniq_check_lower_bound_enabled                      off
 opt_split_scan_limit                                       2048
 optimizer_always_use_histograms                            on
 optimizer_hoist_uncorrelated_equality_subqueries           on

--- a/pkg/sql/opt/memo/memo.go
+++ b/pkg/sql/opt/memo/memo.go
@@ -201,6 +201,7 @@ type Memo struct {
 	unsafeAllowTriggersModifyingCascades       bool
 	legacyVarcharTyping                        bool
 	preferBoundedCardinality                   bool
+	useFKUniqCheckLowerBoundOne                bool
 	minRowCount                                float64
 	internal                                   bool
 
@@ -296,6 +297,7 @@ func (m *Memo) Init(ctx context.Context, evalCtx *eval.Context) {
 		unsafeAllowTriggersModifyingCascades:       evalCtx.SessionData().UnsafeAllowTriggersModifyingCascades,
 		legacyVarcharTyping:                        evalCtx.SessionData().LegacyVarcharTyping,
 		preferBoundedCardinality:                   evalCtx.SessionData().OptimizerPreferBoundedCardinality,
+		useFKUniqCheckLowerBoundOne:                evalCtx.SessionData().OptFKUniqCheckLowerBoundEnabled,
 		minRowCount:                                evalCtx.SessionData().OptimizerMinRowCount,
 		internal:                                   evalCtx.SessionData().Internal,
 		txnIsoLevel:                                evalCtx.TxnIsoLevel,
@@ -468,6 +470,7 @@ func (m *Memo) IsStale(
 		m.unsafeAllowTriggersModifyingCascades != evalCtx.SessionData().UnsafeAllowTriggersModifyingCascades ||
 		m.legacyVarcharTyping != evalCtx.SessionData().LegacyVarcharTyping ||
 		m.preferBoundedCardinality != evalCtx.SessionData().OptimizerPreferBoundedCardinality ||
+		m.useFKUniqCheckLowerBoundOne != evalCtx.SessionData().OptFKUniqCheckLowerBoundEnabled ||
 		m.minRowCount != evalCtx.SessionData().OptimizerMinRowCount ||
 		m.internal != evalCtx.SessionData().Internal ||
 		m.txnIsoLevel != evalCtx.TxnIsoLevel {

--- a/pkg/sql/opt/memo/memo_test.go
+++ b/pkg/sql/opt/memo/memo_test.go
@@ -543,6 +543,11 @@ func TestMemoIsStale(t *testing.T) {
 	evalCtx.SessionData().OptimizerPreferBoundedCardinality = false
 	notStale()
 
+	evalCtx.SessionData().OptFKUniqCheckLowerBoundEnabled = true
+	stale()
+	evalCtx.SessionData().OptFKUniqCheckLowerBoundEnabled = false
+	notStale()
+
 	evalCtx.SessionData().OptimizerMinRowCount = 1.0
 	stale()
 	evalCtx.SessionData().OptimizerMinRowCount = 0

--- a/pkg/sql/opt/memo/statistics_builder.go
+++ b/pkg/sql/opt/memo/statistics_builder.go
@@ -228,20 +228,22 @@ const (
 //
 // See props/statistics.go for more details.
 type statisticsBuilder struct {
-	ctx         context.Context
-	evalCtx     *eval.Context
-	md          *opt.Metadata
-	minRowCount float64
+	ctx                         context.Context
+	evalCtx                     *eval.Context
+	md                          *opt.Metadata
+	useFKUniqCheckLowerBoundOne bool
+	minRowCount                 float64
 }
 
 func (sb *statisticsBuilder) init(ctx context.Context, evalCtx *eval.Context, md *opt.Metadata) {
 	// This initialization pattern ensures that fields are not unwittingly
 	// reused. Field reuse must be explicit.
 	*sb = statisticsBuilder{
-		ctx:         ctx,
-		evalCtx:     evalCtx,
-		md:          md,
-		minRowCount: evalCtx.SessionData().OptimizerMinRowCount,
+		ctx:                         ctx,
+		evalCtx:                     evalCtx,
+		md:                          md,
+		useFKUniqCheckLowerBoundOne: evalCtx.SessionData().OptFKUniqCheckLowerBoundEnabled,
+		minRowCount:                 evalCtx.SessionData().OptimizerMinRowCount,
 	}
 }
 
@@ -2747,6 +2749,12 @@ func (sb *statisticsBuilder) buildWithScan(
 
 	s.Available = bindingProps.Statistics().Available
 	s.RowCount = bindingProps.Statistics().RowCount
+	if withScan.FKUniqCheckInput && sb.useFKUniqCheckLowerBoundOne {
+		// Assume that WithScans that are leaf expressions of FK and uniqueness
+		// checks produce at least one row. If there are no rows to check, then
+		// the plan should still be efficient.
+		s.RowCount = max(s.RowCount, 1)
+	}
 
 	// TODO(michae2): Set operations and with-scans currently act as barriers for
 	// VirtualCols, due to the column ID translation. To fix this we would need to

--- a/pkg/sql/opt/memo/testdata/stats/insert
+++ b/pkg/sql/opt/memo/testdata/stats/insert
@@ -129,3 +129,103 @@ insert xyz
            │    └── fd: (9)-->(6-8,10,11), (6)-->(8)
            └── filters
                 └── false [type=bool, constraints=(contradiction; tight)]
+
+exec-ddl
+CREATE TABLE p137547 (
+	region STRING,
+	id STRING,
+	i INT,
+	s STRING,
+	PRIMARY KEY (region, id),
+	UNIQUE INDEX (region, i)
+)
+----
+
+exec-ddl
+CREATE TABLE c137547 (
+	region STRING,
+	id STRING,
+	p_id STRING,
+	PRIMARY KEY (region, id),
+	FOREIGN KEY (region, p_id) REFERENCES p137547 (region, id)
+)
+----
+
+exec-ddl
+ALTER TABLE p137547 INJECT STATISTICS '[
+    {
+        "avg_size": 1500,
+        "columns": ["s"],
+        "created_at": "2024-11-29 16:18:00.835616",
+        "distinct_count": 14000000,
+        "null_count": 0,
+        "row_count": 14000000
+    }
+]';
+----
+
+# Regression test for #137547. Estimate that the FK check WithScan produces at
+# least 1 row to avoid a lookup into the secondary index of p137547 using just
+# the region column.
+opt set=(opt_fk_uniq_check_lower_bound_enabled=true) locality=(region=us)
+INSERT INTO c137547 VALUES ('us', 'foo', 'foo') ON CONFLICT DO NOTHING
+----
+insert c137547
+ ├── arbiter indexes: c137547_pkey
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├── column1:6 => c137547.region:1
+ │    ├── column2:7 => c137547.id:2
+ │    └── column3:8 => c137547.p_id:3
+ ├── input binding: &1
+ ├── cardinality: [0 - 0]
+ ├── volatile, mutations
+ ├── stats: [rows=0]
+ ├── distribution: us
+ ├── anti-join (cross)
+ │    ├── columns: column1:6(string!null) column2:7(string!null) column3:8(string!null)
+ │    ├── cardinality: [0 - 1]
+ │    ├── stats: [rows=1e-10, distinct(6)=1e-10, null(6)=0, distinct(8)=1e-10, null(8)=0]
+ │    ├── key: ()
+ │    ├── fd: ()-->(6-8)
+ │    ├── distribution: us
+ │    ├── values
+ │    │    ├── columns: column1:6(string!null) column2:7(string!null) column3:8(string!null)
+ │    │    ├── cardinality: [1 - 1]
+ │    │    ├── stats: [rows=1, distinct(6)=1, null(6)=0, distinct(8)=1, null(8)=0]
+ │    │    ├── key: ()
+ │    │    ├── fd: ()-->(6-8)
+ │    │    ├── distribution: us
+ │    │    └── ('us', 'foo', 'foo') [type=tuple{string, string, string}]
+ │    ├── scan c137547
+ │    │    ├── columns: c137547.region:9(string!null) c137547.id:10(string!null)
+ │    │    ├── constraint: /9/10: [/'us'/'foo' - /'us'/'foo']
+ │    │    ├── flags: avoid-full-scan
+ │    │    ├── cardinality: [0 - 1]
+ │    │    ├── stats: [rows=0.91, distinct(9)=0.91, null(9)=0, distinct(10)=0.91, null(10)=0, distinct(9,10)=0.91, null(9,10)=0]
+ │    │    ├── key: ()
+ │    │    ├── fd: ()-->(9,10)
+ │    │    └── distribution: us
+ │    └── filters (true)
+ └── f-k-checks
+      └── f-k-checks-item: c137547(region,p_id) -> p137547(region,id)
+           └── anti-join (lookup p137547)
+                ├── columns: region:14(string!null) p_id:15(string!null)
+                ├── key columns: [14 15] = [16 17]
+                ├── lookup columns are key
+                ├── cardinality: [0 - 1]
+                ├── stats: [rows=1e-10]
+                ├── key: ()
+                ├── fd: ()-->(14,15)
+                ├── distribution: us
+                ├── with-scan &1
+                │    ├── columns: region:14(string!null) p_id:15(string!null)
+                │    ├── mapping:
+                │    │    ├──  column1:6(string) => region:14(string)
+                │    │    └──  column3:8(string) => p_id:15(string)
+                │    ├── cardinality: [0 - 1]
+                │    ├── stats: [rows=1, distinct(14)=1e-10, null(14)=0, distinct(15)=1e-10, null(15)=0]
+                │    ├── key: ()
+                │    ├── fd: ()-->(14,15)
+                │    └── distribution: us
+                └── filters (true)

--- a/pkg/sql/opt/ops/relational.opt
+++ b/pkg/sql/opt/ops/relational.opt
@@ -1372,6 +1372,10 @@ define WithScanPrivate {
     # Mtr is the materialization behavior of the CTE referenced by the WithScan.
     # It matches the Mtr field of the WithPrivate with a matching WithID.
     Mtr CTEMaterializeClause
+
+    # FKUniqCheckInput is true if the WithScan is an input to a foreign key or a
+    # uniqueness check.
+    FKUniqCheckInput bool
 }
 
 # RecursiveCTE implements the logic of a recursive CTE:

--- a/pkg/sql/opt/optbuilder/mutation_builder.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder.go
@@ -1763,10 +1763,11 @@ func (mb *mutationBuilder) buildCheckInputScan(
 
 	mb.ensureWithID()
 	outScope.expr = mb.b.factory.ConstructWithScan(&memo.WithScanPrivate{
-		With:    mb.withID,
-		InCols:  inputCols,
-		OutCols: outScope.colList(),
-		ID:      mb.b.factory.Metadata().NextUniqueID(),
+		With:             mb.withID,
+		InCols:           inputCols,
+		OutCols:          outScope.colList(),
+		ID:               mb.b.factory.Metadata().NextUniqueID(),
+		FKUniqCheckInput: true,
 	})
 
 	return outScope, notNullOutCols

--- a/pkg/sql/sessiondatapb/local_only_session_data.proto
+++ b/pkg/sql/sessiondatapb/local_only_session_data.proto
@@ -604,6 +604,10 @@ message LocalOnlySessionData {
   // count of zero can still be estimated for expressions with a cardinality of
   // zero, e.g., for a contradictory filter.
   double optimizer_min_row_count = 155;
+  // OptFKUniqCheckLowerBoundEnabled controls whether the row count estimate for
+  // WithScans that are leaf expressions of FK and uniqueness checks is always
+  // bumped to at least 1.
+  bool opt_fk_uniq_check_lower_bound_enabled = 157  [(gogoproto.customname) = "OptFKUniqCheckLowerBoundEnabled"];
 
   ///////////////////////////////////////////////////////////////////////////
   // WARNING: consider whether a session parameter you're adding needs to  //

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -3783,6 +3783,23 @@ var varGen = map[string]sessionVar{
 			return nil
 		},
 	},
+
+	// CockroachDB extension.
+	`opt_fk_uniq_check_lower_bound_enabled`: {
+		Get: func(evalCtx *extendedEvalContext, _ *kv.Txn) (string, error) {
+			return formatBoolAsPostgresSetting(evalCtx.SessionData().OptFKUniqCheckLowerBoundEnabled), nil
+		},
+		GetStringVal: makePostgresBoolGetStringValFn("opt_fk_uniq_check_lower_bound_enabled"),
+		Set: func(ctx context.Context, m sessionDataMutator, s string) error {
+			b, err := paramparse.ParseBoolVar(`opt_fk_uniq_check_lower_bound_enabled`, s)
+			if err != nil {
+				return err
+			}
+			m.SetOptFKUniqCheckLowerBoundEnabled(b)
+			return nil
+		},
+		GlobalDefault: globalFalse,
+	},
 }
 
 func ReplicationModeFromString(s string) (sessiondatapb.ReplicationMode, error) {


### PR DESCRIPTION
Backport 1/1 commits from #141207.

/cc @cockroachdb/release

---

Backport of #140735, disabled by default.

Fixes #137547

Release note (performance improvement): The optimizer previously selected poor indexes to perform foreign key and uniqueness checks in rare cases (especially in multi-region setup). It can now select better indexes if newly-added `opt_fk_uniq_check_lower_bound_enabled` session variable set to `true` (default is `false`).

Release justification: bug fix disabled by default.
