### PR TITLE
changefeedccl: convert legacy checkpoint to new checkpoint on startup

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_dist.go
+++ b/pkg/ccl/changefeedccl/changefeed_dist.go
@@ -457,6 +457,7 @@ func makePlan(
 		// Use the same checkpoint for all aggregators; each aggregator will only look at
 		// spans that are assigned to it.
 		// We could compute per-aggregator checkpoint, but that's probably an overkill.
+		//lint:ignore SA1019 deprecated usage
 		var aggregatorCheckpoint execinfrapb.ChangeAggregatorSpec_Checkpoint
 		var checkpointSpanGroup roachpb.SpanGroup
 

--- a/pkg/ccl/changefeedccl/changefeed_processors_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors_test.go
@@ -152,9 +152,10 @@ func TestSetupSpansAndFrontierWithNewSpec(t *testing.T) {
 	statementTime := hlc.Timestamp{WallTime: 10}
 
 	for _, tc := range []struct {
-		name                 string
-		initialHighWater     hlc.Timestamp
-		watches              []execinfrapb.ChangeAggregatorSpec_Watch
+		name             string
+		initialHighWater hlc.Timestamp
+		watches          []execinfrapb.ChangeAggregatorSpec_Watch
+		//lint:ignore SA1019 deprecated usage
 		checkpoints          execinfrapb.ChangeAggregatorSpec_Checkpoint
 		expectedFrontierTs   hlc.Timestamp
 		expectedFrontierSpan checkpointSpans
@@ -197,6 +198,7 @@ func TestSetupSpansAndFrontierWithNewSpec(t *testing.T) {
 				{Span: roachpb.Span{Key: roachpb.Key("b"), EndKey: roachpb.Key("c")}},
 				{Span: roachpb.Span{Key: roachpb.Key("c"), EndKey: roachpb.Key("d")}},
 			},
+			//lint:ignore SA1019 deprecated usage
 			checkpoints: execinfrapb.ChangeAggregatorSpec_Checkpoint{
 				Spans:     []roachpb.Span{{Key: roachpb.Key("a"), EndKey: roachpb.Key("b")}, {Key: roachpb.Key("c"), EndKey: roachpb.Key("d")}},
 				Timestamp: hlc.Timestamp{WallTime: 5},
@@ -216,6 +218,7 @@ func TestSetupSpansAndFrontierWithNewSpec(t *testing.T) {
 				{Span: roachpb.Span{Key: roachpb.Key("b"), EndKey: roachpb.Key("c")}},
 				{Span: roachpb.Span{Key: roachpb.Key("c"), EndKey: roachpb.Key("d")}},
 			},
+			//lint:ignore SA1019 deprecated usage
 			checkpoints: execinfrapb.ChangeAggregatorSpec_Checkpoint{
 				Spans: []roachpb.Span{{Key: roachpb.Key("a"), EndKey: roachpb.Key("b")}, {Key: roachpb.Key("c"), EndKey: roachpb.Key("d")}},
 			},
@@ -234,6 +237,7 @@ func TestSetupSpansAndFrontierWithNewSpec(t *testing.T) {
 				{Span: roachpb.Span{Key: roachpb.Key("b"), EndKey: roachpb.Key("c")}},
 				{Span: roachpb.Span{Key: roachpb.Key("c"), EndKey: roachpb.Key("d")}},
 			},
+			//lint:ignore SA1019 deprecated usage
 			checkpoints: execinfrapb.ChangeAggregatorSpec_Checkpoint{
 				Spans:     []roachpb.Span{{Key: roachpb.Key("a"), EndKey: roachpb.Key("b")}, {Key: roachpb.Key("c"), EndKey: roachpb.Key("d")}},
 				Timestamp: hlc.Timestamp{WallTime: 7},
@@ -253,6 +257,7 @@ func TestSetupSpansAndFrontierWithNewSpec(t *testing.T) {
 				{Span: roachpb.Span{Key: roachpb.Key("b"), EndKey: roachpb.Key("c")}},
 				{Span: roachpb.Span{Key: roachpb.Key("c"), EndKey: roachpb.Key("d")}},
 			},
+			//lint:ignore SA1019 deprecated usage
 			checkpoints: execinfrapb.ChangeAggregatorSpec_Checkpoint{
 				Spans: []roachpb.Span{{Key: roachpb.Key("a"), EndKey: roachpb.Key("b")}, {Key: roachpb.Key("c"), EndKey: roachpb.Key("d")}},
 			},

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -2447,6 +2447,11 @@ func TestChangefeedSchemaChangeBackfillCheckpoint(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
+	// TODO(#141405): Remove this once llrbFrontier starts merging
+	// adjacent spans. The current lack of merging causes issues
+	// with the checks in this test around expected resolved spans.
+	defer span.EnableBtreeFrontier(true)()
+
 	rnd, seed := randutil.NewPseudoRand()
 	t.Logf("random seed: %d", seed)
 
@@ -7402,6 +7407,11 @@ func TestChangefeedCheckpointSchemaChange(t *testing.T) {
 func TestChangefeedBackfillCheckpoint(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+
+	// TODO(#141405): Remove this once llrbFrontier starts merging
+	// adjacent spans. The current lack of merging causes issues
+	// with the checks in this test around expected resolved spans.
+	defer span.EnableBtreeFrontier(true)()
 
 	skip.UnderRace(t)
 	skip.UnderShort(t)

--- a/pkg/ccl/changefeedccl/checkpoint/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/checkpoint/BUILD.bazel
@@ -30,7 +30,6 @@ go_test(
         "//pkg/jobs/jobspb",
         "//pkg/kv/kvserver/rangefeed",
         "//pkg/roachpb",
-        "//pkg/testutils",
         "//pkg/util/hlc",
         "//pkg/util/leaktest",
         "//pkg/util/log",
@@ -38,7 +37,6 @@ go_test(
         "//pkg/util/randutil",
         "//pkg/util/shuffle",
         "//pkg/util/span",
-        "@com_github_cockroachdb_errors//:errors",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/ccl/changefeedccl/kvfeed/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/kvfeed/BUILD.bazel
@@ -75,7 +75,6 @@ go_test(
         "//pkg/sql/catalog/desctestutils",
         "//pkg/sql/rowenc/keyside",
         "//pkg/sql/sem/tree",
-        "//pkg/testutils",
         "//pkg/testutils/serverutils",
         "//pkg/testutils/sqlutils",
         "//pkg/testutils/testcluster",

--- a/pkg/jobs/jobspb/jobs.go
+++ b/pkg/jobs/jobspb/jobs.go
@@ -93,3 +93,7 @@ func (tsm *TimestampSpansMap) ToGoMap() map[hlc.Timestamp]roachpb.Spans {
 	}
 	return m
 }
+
+func (m *ChangefeedProgress_Checkpoint) IsZero() bool {
+	return len(m.Spans) == 0 && m.Timestamp.IsEmpty()
+}

--- a/pkg/sql/execinfrapb/BUILD.bazel
+++ b/pkg/sql/execinfrapb/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
         "expr.go",
         "flow_diagram.go",
         "processors.go",
+        "processors_changefeed.go",
     ],
     embed = [":execinfrapb_go_proto"],
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/execinfrapb",

--- a/pkg/sql/execinfrapb/processors_changefeed.go
+++ b/pkg/sql/execinfrapb/processors_changefeed.go
@@ -1,0 +1,10 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package execinfrapb
+
+func (m *ChangeAggregatorSpec_Checkpoint) IsZero() bool {
+	return len(m.Spans) == 0 && m.Timestamp.IsEmpty()
+}

--- a/pkg/sql/execinfrapb/processors_changefeeds.proto
+++ b/pkg/sql/execinfrapb/processors_changefeeds.proto
@@ -30,13 +30,16 @@ message ChangeAggregatorSpec {
   repeated Watch watches = 1 [(gogoproto.nullable) = false];
 
   // Checkpoint enables change aggregators to resume faster on restart.
+  // TODO(#139734): Delete this nested message type.
   message Checkpoint {
+    option deprecated = true;
     repeated roachpb.Span spans = 1 [(gogoproto.nullable) = false];
     optional util.hlc.Timestamp timestamp = 2 [(gogoproto.nullable) = false];
   }
 
   // Change aggregator checkpoint
-  optional Checkpoint checkpoint = 5 [(gogoproto.nullable) = false];
+  // TODO(#139734): Delete this field and mark field number as reserved.
+  optional Checkpoint checkpoint = 5 [(gogoproto.nullable) = false, deprecated=true];
 
   // Feed is the specification for this changefeed.
   optional cockroach.sql.jobs.jobspb.ChangefeedDetails feed = 2 [(gogoproto.nullable) = false];

--- a/pkg/util/span/frontier.go
+++ b/pkg/util/span/frontier.go
@@ -106,7 +106,8 @@ type Operation func(roachpb.Span, hlc.Timestamp) (done OpResult)
 var useBtreeFrontier = envutil.EnvOrDefaultBool("COCKROACH_BTREE_SPAN_FRONTIER_ENABLED",
 	metamorphic.ConstantWithTestBool("COCKROACH_BTREE_SPAN_FRONTIER_ENABLED", true))
 
-func enableBtreeFrontier(enabled bool) func() {
+// EnableBtreeFrontier sets useBtreeFrontier for testing purposes.
+func EnableBtreeFrontier(enabled bool) func() {
 	old := useBtreeFrontier
 	useBtreeFrontier = enabled
 	return func() {
@@ -114,19 +115,19 @@ func enableBtreeFrontier(enabled bool) func() {
 	}
 }
 
-func newBTreeFrontier() Frontier {
+func newBtreeFrontier() Frontier {
 	return &btreeFrontier{}
 }
 
-func newLLBRFrontier() Frontier {
+func newLLRBFrontier() Frontier {
 	return &llrbFrontier{tree: interval.NewTree(interval.ExclusiveOverlapper)}
 }
 
 func newFrontier() Frontier {
 	if useBtreeFrontier {
-		return newBTreeFrontier()
+		return newBtreeFrontier()
 	}
-	return newLLBRFrontier()
+	return newLLRBFrontier()
 }
 
 // MakeFrontier returns a Frontier that tracks the given set of spans.

--- a/pkg/util/span/frontier_fuzz_test.go
+++ b/pkg/util/span/frontier_fuzz_test.go
@@ -58,11 +58,11 @@ func fuzzFrontier(f *testing.F) {
 }
 
 func FuzzBtreeFrontier(f *testing.F) {
-	defer enableBtreeFrontier(true)()
+	defer EnableBtreeFrontier(true)()
 	fuzzFrontier(f)
 }
 
 func FuzzLLRBFrontier(f *testing.F) {
-	defer enableBtreeFrontier(false)()
+	defer EnableBtreeFrontier(false)()
 	fuzzFrontier(f)
 }

--- a/pkg/util/span/frontier_test.go
+++ b/pkg/util/span/frontier_test.go
@@ -73,7 +73,7 @@ func TestSpanFrontier(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	testutils.RunTrueAndFalse(t, "btree", func(t *testing.T, useBtreeFrontier bool) {
-		defer enableBtreeFrontier(useBtreeFrontier)()
+		defer EnableBtreeFrontier(useBtreeFrontier)()
 
 		keyA, keyB := roachpb.Key("a"), roachpb.Key("b")
 		keyC, keyD := roachpb.Key("c"), roachpb.Key("d")
@@ -197,7 +197,7 @@ func TestSpanFrontierDisjointSpans(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	testutils.RunTrueAndFalse(t, "btree", func(t *testing.T, useBtreeFrontier bool) {
-		defer enableBtreeFrontier(useBtreeFrontier)()
+		defer EnableBtreeFrontier(useBtreeFrontier)()
 
 		keyA, keyB, keyC := roachpb.Key("a"), roachpb.Key("b"), roachpb.Key("c")
 		keyD, keyE, keyF := roachpb.Key("d"), roachpb.Key("e"), roachpb.Key("f")
@@ -295,7 +295,7 @@ func TestSequentialSpans(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	testutils.RunTrueAndFalse(t, "btree", func(t *testing.T, useBtreeFrontier bool) {
-		defer enableBtreeFrontier(useBtreeFrontier)()
+		defer EnableBtreeFrontier(useBtreeFrontier)()
 
 		f, err := MakeFrontier(roachpb.Span{Key: roachpb.Key("A"), EndKey: roachpb.Key("Z")})
 		require.NoError(t, err)
@@ -339,7 +339,7 @@ func TestSpanEntries(t *testing.T) {
 	}
 
 	testutils.RunTrueAndFalse(t, "btree", func(t *testing.T, useBtreeFrontier bool) {
-		defer enableBtreeFrontier(useBtreeFrontier)()
+		defer EnableBtreeFrontier(useBtreeFrontier)()
 
 		t.Run("contiguous frontier", func(t *testing.T) {
 			spAZ := makeSpan("A", "Z")
@@ -410,7 +410,7 @@ func TestForwardInvertedSpan(t *testing.T) {
 
 	spAZ := makeSpan("A", "Z")
 	testutils.RunTrueAndFalse(t, "btree", func(t *testing.T, useBtreeFrontier bool) {
-		defer enableBtreeFrontier(useBtreeFrontier)()
+		defer EnableBtreeFrontier(useBtreeFrontier)()
 
 		f, err := MakeFrontier(spAZ)
 		require.NoError(t, err)
@@ -435,7 +435,7 @@ func TestForwardInvertedSpan(t *testing.T) {
 }
 
 func TestForwardToSameTimestamp(t *testing.T) {
-	defer enableBtreeFrontier(true)() // LLRB frontier fails this test
+	defer EnableBtreeFrontier(true)() // LLRB frontier fails this test
 	spAZ := makeSpan("A", "Z")
 
 	f, err := MakeFrontier(spAZ)
@@ -461,8 +461,8 @@ func TestFrontierImplementationsMatch(t *testing.T) {
 	totalSpan := mkSpan(start, start+total)
 
 	for run := 1; run <= 10; run++ {
-		l := newLLBRFrontier()
-		b := newBTreeFrontier()
+		l := newLLRBFrontier()
+		b := newBtreeFrontier()
 		require.NoError(t, l.AddSpansAt(hlc.Timestamp{}, totalSpan))
 		require.NoError(t, b.AddSpansAt(hlc.Timestamp{}, totalSpan))
 
@@ -499,7 +499,7 @@ func TestAddOverlappingSpans(t *testing.T) {
 	}
 
 	testutils.RunTrueAndFalse(t, "btree", func(t *testing.T, useBtreeFrontier bool) {
-		defer enableBtreeFrontier(useBtreeFrontier)()
+		defer EnableBtreeFrontier(useBtreeFrontier)()
 
 		f, err := MakeFrontier()
 		require.NoError(t, err)
@@ -518,7 +518,7 @@ func TestBtreeFrontierMergesSpansDuringInitialization(t *testing.T) {
 	}
 
 	testutils.RunTrueAndFalse(t, "btree", func(t *testing.T, useBtreeFrontier bool) {
-		defer enableBtreeFrontier(useBtreeFrontier)()
+		defer EnableBtreeFrontier(useBtreeFrontier)()
 
 		f, err := MakeFrontier()
 		require.NoError(t, err)
@@ -543,7 +543,7 @@ func TestForwardDeepNestedFrontierEntry(t *testing.T) {
 	}
 
 	testutils.RunTrueAndFalse(t, "btree", func(t *testing.T, useBtreeFrontier bool) {
-		defer enableBtreeFrontier(useBtreeFrontier)()
+		defer EnableBtreeFrontier(useBtreeFrontier)()
 		f, err := MakeFrontier()
 		require.NoError(t, err)
 
@@ -609,7 +609,7 @@ func BenchmarkFrontier(b *testing.B) {
 
 	for _, enableBtree := range []bool{false, true} {
 		b.Run(fmt.Sprintf("btree=%t/rnd", enableBtree), func(b *testing.B) {
-			defer enableBtreeFrontier(enableBtree)()
+			defer EnableBtreeFrontier(enableBtree)()
 
 			b.StopTimer()
 			// Reset rnd so that we get the same inputs for both benchmarks.
@@ -627,7 +627,7 @@ func BenchmarkFrontier(b *testing.B) {
 		// Bench a case where frontier tracks multiple disjoint spans.
 		for _, numRanges := range []int{128, 1024, 4096, 8192, 16384} {
 			b.Run(fmt.Sprintf("btree=%t/r=%d", enableBtree, numRanges), func(b *testing.B) {
-				defer enableBtreeFrontier(enableBtree)()
+				defer EnableBtreeFrontier(enableBtree)()
 
 				b.StopTimer()
 				// Reset rnd so that we get the same inputs for both benchmarks.


### PR DESCRIPTION
This patch converts the legacy checkpoint to the new checkpoint type on
change aggregator startup to avoid having to handle multiple checkpoint
formats throughout the code.

Fixes #140686
Fixes #141188

Release note: None