### PR TITLE
server: Implement 'gossip' endpoint in multitenant setup

### DIFF
--- a/pkg/ccl/changefeedccl/mocks/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/mocks/BUILD.bazel
@@ -48,6 +48,7 @@ go_library(
     visibility = ["//visibility:public"],
     # keep
     deps = [
+        "//pkg/gossip",
         "//pkg/roachpb",
         "//pkg/server/serverpb",
         "@com_github_golang_mock//gomock",

--- a/pkg/ccl/changefeedccl/mocks/tenant_status_server_generated.go
+++ b/pkg/ccl/changefeedccl/mocks/tenant_status_server_generated.go
@@ -8,6 +8,7 @@ import (
 	context "context"
 	reflect "reflect"
 
+	gossip "github.com/cockroachdb/cockroach/pkg/gossip"
 	roachpb "github.com/cockroachdb/cockroach/pkg/roachpb"
 	serverpb "github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	gomock "github.com/golang/mock/gomock"
@@ -49,6 +50,21 @@ func (m *MockTenantStatusServer) DownloadSpan(arg0 context.Context, arg1 *server
 func (mr *MockTenantStatusServerMockRecorder) DownloadSpan(arg0, arg1 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DownloadSpan", reflect.TypeOf((*MockTenantStatusServer)(nil).DownloadSpan), arg0, arg1)
+}
+
+// Gossip mocks base method.
+func (m *MockTenantStatusServer) Gossip(arg0 context.Context, arg1 *serverpb.GossipRequest) (*gossip.InfoStatus, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Gossip", arg0, arg1)
+	ret0, _ := ret[0].(*gossip.InfoStatus)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Gossip indicates an expected call of Gossip.
+func (mr *MockTenantStatusServerMockRecorder) Gossip(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Gossip", reflect.TypeOf((*MockTenantStatusServer)(nil).Gossip), arg0, arg1)
 }
 
 // HotRangesV2 mocks base method.

--- a/pkg/cli/testdata/zip/testzip_external_process_virtualization
+++ b/pkg/cli/testdata/zip/testzip_external_process_virtualization
@@ -39,9 +39,7 @@ debug zip --concurrency=1 --cpu-profile-duration=1s /dev/null
 [node 1] retrieving SQL data for crdb_internal.node_tenant_capabilities_cache: last request failed: ERROR: operation node_tenant_capabilities_cache supported only by system tenant (SQLSTATE XXUUU)
 <dumping SQL tables>
 [node 1] requesting data for debug/nodes/1/details... received response... writing JSON output: debug/nodes/1/details.json... done
-[node 1] requesting data for debug/nodes/1/gossip... received response...
-[node 1] requesting data for debug/nodes/1/gossip: last request failed: rpc error: ...
-[node 1] requesting data for debug/nodes/1/gossip: creating error output: debug/nodes/1/gossip.json.err.txt... done
+[node 1] requesting data for debug/nodes/1/gossip... received response... writing JSON output: debug/nodes/1/gossip.json... done
 [node 1] requesting stacks... received response... writing binary output: debug/nodes/1/stacks.txt... done
 [node 1] requesting stacks with labels... received response... writing binary output: debug/nodes/1/stacks_with_labels.txt... done
 [node 1] requesting heap profile... received response... writing binary output: debug/nodes/1/heap.pprof... done

--- a/pkg/cli/testdata/zip/testzip_shared_process_virtualization
+++ b/pkg/cli/testdata/zip/testzip_shared_process_virtualization
@@ -78,9 +78,7 @@ debug zip --concurrency=1 --cpu-profile-duration=1s /dev/null
 [node 1] retrieving SQL data for crdb_internal.node_tenant_capabilities_cache: last request failed: ERROR: operation node_tenant_capabilities_cache supported only by system tenant (SQLSTATE XXUUU)
 <dumping SQL tables>
 [node 1] requesting data for debug/cluster/test-tenant/nodes/1/details... received response... writing JSON output: debug/cluster/test-tenant/nodes/1/details.json... done
-[node 1] requesting data for debug/cluster/test-tenant/nodes/1/gossip... received response...
-[node 1] requesting data for debug/cluster/test-tenant/nodes/1/gossip: last request failed: rpc error: ...
-[node 1] requesting data for debug/cluster/test-tenant/nodes/1/gossip: creating error output: debug/cluster/test-tenant/nodes/1/gossip.json.err.txt... done
+[node 1] requesting data for debug/cluster/test-tenant/nodes/1/gossip... received response... writing JSON output: debug/cluster/test-tenant/nodes/1/gossip.json... done
 [node 1] requesting stacks... received response... writing binary output: debug/cluster/test-tenant/nodes/1/stacks.txt... done
 [node 1] requesting stacks with labels... received response... writing binary output: debug/cluster/test-tenant/nodes/1/stacks_with_labels.txt... done
 [node 1] requesting heap profile... received response... writing binary output: debug/cluster/test-tenant/nodes/1/heap.pprof... done

--- a/pkg/cli/testdata/zip/testzip_shared_process_virtualization_with_default_tenant
+++ b/pkg/cli/testdata/zip/testzip_shared_process_virtualization_with_default_tenant
@@ -78,9 +78,7 @@ debug zip --concurrency=1 --cpu-profile-duration=1s /dev/null
 [node 1] retrieving SQL data for crdb_internal.node_tenant_capabilities_cache: last request failed: ERROR: operation node_tenant_capabilities_cache supported only by system tenant (SQLSTATE XXUUU)
 <dumping SQL tables>
 [node 1] requesting data for debug/cluster/test-tenant/nodes/1/details... received response... writing JSON output: debug/cluster/test-tenant/nodes/1/details.json... done
-[node 1] requesting data for debug/cluster/test-tenant/nodes/1/gossip... received response...
-[node 1] requesting data for debug/cluster/test-tenant/nodes/1/gossip: last request failed: rpc error: ...
-[node 1] requesting data for debug/cluster/test-tenant/nodes/1/gossip: creating error output: debug/cluster/test-tenant/nodes/1/gossip.json.err.txt... done
+[node 1] requesting data for debug/cluster/test-tenant/nodes/1/gossip... received response... writing JSON output: debug/cluster/test-tenant/nodes/1/gossip.json... done
 [node 1] requesting stacks... received response... writing binary output: debug/cluster/test-tenant/nodes/1/stacks.txt... done
 [node 1] requesting stacks with labels... received response... writing binary output: debug/cluster/test-tenant/nodes/1/stacks_with_labels.txt... done
 [node 1] requesting heap profile... received response... writing binary output: debug/cluster/test-tenant/nodes/1/heap.pprof... done

--- a/pkg/kv/kvclient/kvtenant/connector.go
+++ b/pkg/kv/kvclient/kvtenant/connector.go
@@ -695,6 +695,17 @@ func (c *connector) NetworkConnectivity(
 	return
 }
 
+// Gossip implements the serverpb.TenantStatusServer interface
+func (c *connector) Gossip(
+	ctx context.Context, req *serverpb.GossipRequest,
+) (resp *gossip.InfoStatus, retErr error) {
+	retErr = c.withClient(ctx, func(ctx context.Context, client *client) (err error) {
+		resp, err = client.Gossip(ctx, req)
+		return
+	})
+	return
+}
+
 // NewIterator implements the rangedesc.IteratorFactory interface.
 func (c *connector) NewIterator(
 	ctx context.Context, span roachpb.Span,

--- a/pkg/rpc/auth_tenant.go
+++ b/pkg/rpc/auth_tenant.go
@@ -121,6 +121,9 @@ func (a tenantAuthorizer) authorize(
 	case "/cockroach.server.serverpb.Status/NetworkConnectivity":
 		return a.capabilitiesAuthorizer.HasProcessDebugCapability(ctx, tenID)
 
+	case "/cockroach.server.serverpb.Status/Gossip":
+		return a.capabilitiesAuthorizer.HasProcessDebugCapability(ctx, tenID)
+
 	case "/cockroach.server.serverpb.Status/TransactionContentionEvents":
 		return a.authTenant(tenID)
 

--- a/pkg/rpc/auth_tenant.go
+++ b/pkg/rpc/auth_tenant.go
@@ -122,7 +122,7 @@ func (a tenantAuthorizer) authorize(
 		return a.capabilitiesAuthorizer.HasProcessDebugCapability(ctx, tenID)
 
 	case "/cockroach.server.serverpb.Status/Gossip":
-		return a.capabilitiesAuthorizer.HasProcessDebugCapability(ctx, tenID)
+		return a.capabilitiesAuthorizer.HasNodeStatusCapability(ctx, tenID)
 
 	case "/cockroach.server.serverpb.Status/TransactionContentionEvents":
 		return a.authTenant(tenID)

--- a/pkg/server/serverpb/BUILD.bazel
+++ b/pkg/server/serverpb/BUILD.bazel
@@ -108,6 +108,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/server/serverpb",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/gossip",
         "//pkg/roachpb",
         "//pkg/util/errorutil",
         "//pkg/util/metric",

--- a/pkg/server/serverpb/status.go
+++ b/pkg/server/serverpb/status.go
@@ -8,6 +8,7 @@ package serverpb
 import (
 	"context"
 
+	"github.com/cockroachdb/cockroach/pkg/gossip"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil"
 )
@@ -91,6 +92,7 @@ type TenantStatusServer interface {
 	// status server and so in the long run we should move it.
 	DownloadSpan(ctx context.Context, request *DownloadSpanRequest) (*DownloadSpanResponse, error)
 	NetworkConnectivity(context.Context, *NetworkConnectivityRequest) (*NetworkConnectivityResponse, error)
+	Gossip(context.Context, *GossipRequest) (*gossip.InfoStatus, error)
 }
 
 // OptionalNodesStatusServer returns the wrapped NodesStatusServer, if it is

--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -721,6 +721,21 @@ func (s *statusServer) dialNode(
 	return serverpb.NewStatusClient(conn), nil
 }
 
+// Gossip returns current state of gossip information on the given node
+// which is crucial for monitoring and debugging the gossip protocol in
+// CockroachDB cluster.
+func (t *statusServer) Gossip(
+	ctx context.Context, req *serverpb.GossipRequest,
+) (*gossip.InfoStatus, error) {
+	ctx = t.AnnotateCtx(ctx)
+
+	if err := t.privilegeChecker.RequireViewClusterMetadataPermission(ctx); err != nil {
+		return nil, err
+	}
+
+	return t.sqlServer.tenantConnect.Gossip(ctx, req)
+}
+
 // Gossip returns gossip network status. It is implemented
 // in the systemStatusServer since the system tenant has
 // access to gossip.

--- a/pkg/server/storage_api/gossip_test.go
+++ b/pkg/server/storage_api/gossip_test.go
@@ -32,12 +32,12 @@ func TestStatusGossipJson(t *testing.T) {
 	if srv.TenantController().StartedDefaultTestTenant() {
 		// explicitly enabling debug capability for the secondary/application tenant
 		_, err := srv.SystemLayer().SQLConn(t).Exec(
-			`ALTER TENANT [$1] GRANT CAPABILITY can_debug_process=true`,
+			`ALTER TENANT [$1] GRANT CAPABILITY can_view_node_info=true`,
 			serverutils.TestTenantID().ToUint64(),
 		)
 		require.NoError(t, err)
 		serverutils.WaitForTenantCapabilities(t, srv, serverutils.TestTenantID(),
-			map[tenantcapabilities.ID]string{tenantcapabilities.CanDebugProcess: "true"}, "")
+			map[tenantcapabilities.ID]string{tenantcapabilities.CanViewNodeInfo: "true"}, "")
 	}
 	s := srv.ApplicationLayer()
 	require.NoError(t, validateGossipResponse(s))
@@ -59,7 +59,7 @@ func TestStatusGossipJsonWithoutTenantCapability(t *testing.T) {
 		s := srv.ApplicationLayer()
 		actualErr := validateGossipResponse(s)
 		require.Error(t, actualErr)
-		require.Contains(t, actualErr.Error(), "client tenant does not have capability to debug the process")
+		require.Contains(t, actualErr.Error(), "client tenant does not have capability to query cluster node metadata")
 	}
 }
 

--- a/pkg/server/storage_api/gossip_test.go
+++ b/pkg/server/storage_api/gossip_test.go
@@ -7,42 +7,75 @@ package storage_api_test
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/gossip"
+	"github.com/cockroachdb/cockroach/pkg/multitenant/tenantcapabilities"
 	"github.com/cockroachdb/cockroach/pkg/server/srvtestutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/stretchr/testify/require"
 )
 
-// TestStatusGossipJson ensures that the output response for the full gossip
-// info contains the required fields.
 func TestStatusGossipJson(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
 	srv := serverutils.StartServerOnly(t, base.TestServerArgs{
-		DefaultTestTenant: base.TestIsForStuffThatShouldWorkWithSecondaryTenantsButDoesntYet(110022),
+		DefaultTestTenant: base.TestTenantProbabilistic,
 	})
 	defer srv.Stopper().Stop(context.Background())
+
+	if srv.TenantController().StartedDefaultTestTenant() {
+		// explicitly enabling debug capability for the secondary/application tenant
+		_, err := srv.SystemLayer().SQLConn(t).Exec(
+			`ALTER TENANT [$1] GRANT CAPABILITY can_debug_process=true`,
+			serverutils.TestTenantID().ToUint64(),
+		)
+		require.NoError(t, err)
+		serverutils.WaitForTenantCapabilities(t, srv, serverutils.TestTenantID(),
+			map[tenantcapabilities.ID]string{tenantcapabilities.CanDebugProcess: "true"}, "")
+	}
 	s := srv.ApplicationLayer()
+	require.NoError(t, validateGossipResponse(s))
+}
 
-	// TODO(#110022): grant a special capability to the secondary tenant
-	// before the endpoint can be accessed.
+func TestStatusGossipJsonWithoutTenantCapability(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
 
+	srv := serverutils.StartServerOnly(t, base.TestServerArgs{
+		// Note: We're only testing external-process mode because shared service
+		// mode tenants have all capabilities.
+		DefaultTestTenant: base.ExternalTestTenantAlwaysEnabled,
+	})
+	defer srv.Stopper().Stop(context.Background())
+
+	if srv.TenantController().StartedDefaultTestTenant() {
+		// application tenant with debug capability
+		s := srv.ApplicationLayer()
+		actualErr := validateGossipResponse(s)
+		require.Error(t, actualErr)
+		require.Contains(t, actualErr.Error(), "client tenant does not have capability to debug the process")
+	}
+}
+
+func validateGossipResponse(s serverutils.ApplicationLayerInterface) error {
 	var data gossip.InfoStatus
 	if err := srvtestutils.GetStatusJSONProto(s, "gossip/local", &data); err != nil {
-		t.Fatal(err)
+		return err
 	}
 	if _, ok := data.Infos["first-range"]; !ok {
-		t.Errorf("no first-range info returned: %v", data)
+		return fmt.Errorf("no first-range info returned: %v", data)
 	}
 	if _, ok := data.Infos["cluster-id"]; !ok {
-		t.Errorf("no clusterID info returned: %v", data)
+		return fmt.Errorf("no clusterID info returned: %v", data)
 	}
 	if _, ok := data.Infos["node:1"]; !ok {
-		t.Errorf("no node 1 info returned: %v", data)
+		return fmt.Errorf("no node 1 info returned: %v", data)
 	}
+	return nil
 }

--- a/pkg/server/storage_api/gossip_test.go
+++ b/pkg/server/storage_api/gossip_test.go
@@ -25,12 +25,12 @@ func TestStatusGossipJson(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	srv := serverutils.StartServerOnly(t, base.TestServerArgs{
-		DefaultTestTenant: base.TestTenantProbabilistic,
+		DefaultTestTenant: base.TestTenantProbabilisticOnly,
 	})
 	defer srv.Stopper().Stop(context.Background())
 
 	if srv.TenantController().StartedDefaultTestTenant() {
-		// explicitly enabling debug capability for the secondary/application tenant
+		// explicitly enabling CanViewNodeInfo capability for the secondary/application tenant
 		_, err := srv.SystemLayer().SQLConn(t).Exec(
 			`ALTER TENANT [$1] GRANT CAPABILITY can_view_node_info=true`,
 			serverutils.TestTenantID().ToUint64(),
@@ -54,13 +54,10 @@ func TestStatusGossipJsonWithoutTenantCapability(t *testing.T) {
 	})
 	defer srv.Stopper().Stop(context.Background())
 
-	if srv.TenantController().StartedDefaultTestTenant() {
-		// application tenant with debug capability
-		s := srv.ApplicationLayer()
-		actualErr := validateGossipResponse(s)
-		require.Error(t, actualErr)
-		require.Contains(t, actualErr.Error(), "client tenant does not have capability to query cluster node metadata")
-	}
+	s := srv.ApplicationLayer()
+	actualErr := validateGossipResponse(s)
+	require.Error(t, actualErr)
+	require.Contains(t, actualErr.Error(), "client tenant does not have capability to query cluster node metadata")
 }
 
 func validateGossipResponse(s serverutils.ApplicationLayerInterface) error {


### PR DESCRIPTION

What was there before: previously, gossip endpoint wasn't accessible from secondary tenant why it needed to change: gossip endpoint provides crucial information for debugging and this should be accessible from secondary tenant for troubleshooting issues within gossip protocol of the cluster
What you did about it: To address this, we created gossip endpoint in tenant status server. The implementation uses connector to redirect the call to the system tenant on the requested kv node. Access to this endpoint is guarded by `can_debug_process` capability as this is node's debugging information albeit gossip related one. Updated the gossip status unit test for both system tenant and application tenant.

Epic: CRDB-38968
Fixes: #110022

Release note: None