### PR TITLE
microbench-ci: context based checkout

### DIFF
--- a/.github/actions/microbenchmark-build/action.yml
+++ b/.github/actions/microbenchmark-build/action.yml
@@ -23,8 +23,7 @@ runs:
     - run: |
         echo "FETCH_DEPTH=$(( ${{ github.event.pull_request.commits }} + 1 ))" >> "${GITHUB_ENV}"
       shell: bash
-    - name: Checkout revision with limited depth
-      if: inputs.ref == 'base'
+    - name: Checkout revision with required depth
       uses: actions/checkout@v4
       with:
         ref: ${{ github.event.pull_request.head.sha }}
@@ -38,7 +37,7 @@ runs:
         MERGE_BASE=$(git rev-parse HEAD~${NUM_COMMITS})
         echo "merge_base=$MERGE_BASE" >> "$GITHUB_OUTPUT"
       shell: bash
-    - name: Checkout build commit
+    - name: Checkout base if needed
       if: inputs.ref == 'base'
       uses: actions/checkout@v4
       with:
@@ -48,11 +47,9 @@ runs:
       shell: bash
       env:
         TEST_PKG: ${{ inputs.pkg }}
-    - name: Checkout Head # required for post job cleanup (if still on the base ref)
-      uses: actions/checkout@v4
-      with:
-        ref: ${{ github.event.pull_request.head.sha || github.ref }}
+    - name: Checkout # required for post job cleanup (if still on the base ref)
       if: inputs.ref == 'base'
+      uses: actions/checkout@v4
     - name: Clean up
       run: ./build/github/cleanup-engflow-keys.sh
       shell: bash

--- a/.github/actions/microbenchmark-run/action.yml
+++ b/.github/actions/microbenchmark-run/action.yml
@@ -10,18 +10,23 @@ inputs:
   group:
     description: "Runner group"
     required: true
-
 runs:
   using: "composite"
   steps:
     - name: Unique Build ID
       run: echo "BUILD_ID=${{ github.run_id }}-${{ github.run_attempt }}" >> $GITHUB_ENV
       shell: bash
+    - run: ./build/github/get-engflow-keys.sh
+      shell: bash
     - name: Run benchmarks
       run: ./build/github/microbenchmarks/run.sh
       shell: bash
       env:
         BASE_SHA: ${{ inputs.base }}
-        HEAD_SHA: ${{ github.event.pull_request.head.sha || github.ref }}
+        HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         TEST_PACKAGES: ${{ inputs.pkg }}
         GROUP: ${{ inputs.group }}
+    - name: Clean up
+      run: ./build/github/cleanup-engflow-keys.sh
+      shell: bash
+      if: always()

--- a/.github/workflows/microbenchmarks-ci.yaml
+++ b/.github/workflows/microbenchmarks-ci.yaml
@@ -7,7 +7,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 env:
-  HEAD: ${{ github.event.pull_request.head.sha || github.ref }}
+  HEAD: ${{ github.event.pull_request.head.sha }}
   BUCKET: "cockroach-microbench-ci"
   PACKAGE: "pkg/sql/tests"
 jobs:
@@ -18,10 +18,8 @@ jobs:
     outputs:
       merge_base: ${{ steps.build.outputs.merge_base }}
     steps:
-      - name: Checkout Head
+      - name: Checkout
         uses: actions/checkout@v4
-        with:
-          ref: ${{ env.HEAD }}
       - name: Build
         id: build
         uses: ./.github/actions/microbenchmark-build
@@ -32,13 +30,9 @@ jobs:
     name: build head
     runs-on: [self-hosted, basic_runner_group]
     timeout-minutes: 30
-    outputs:
-      merge_base: ${{ steps.build.outputs.merge_base }}
     steps:
-      - name: Checkout Head
+      - name: Checkout
         uses: actions/checkout@v4
-        with:
-          ref: ${{ env.HEAD }}
       - name: Build
         id: build
         uses: ./.github/actions/microbenchmark-build
@@ -50,10 +44,8 @@ jobs:
     timeout-minutes: 30
     needs: [base, head]
     steps:
-      - name: Checkout Head
+      - name: Checkout
         uses: actions/checkout@v4
-        with:
-          ref: ${{ env.HEAD }}
       - name: Run
         uses: ./.github/actions/microbenchmark-run
         with:
@@ -65,10 +57,8 @@ jobs:
     timeout-minutes: 30
     needs: [base, head]
     steps:
-      - name: Checkout Head
+      - name: Checkout
         uses: actions/checkout@v4
-        with:
-          ref: ${{ env.HEAD }}
       - name: Run
         uses: ./.github/actions/microbenchmark-run
         with:
@@ -80,10 +70,10 @@ jobs:
     timeout-minutes: 30
     needs: [base, run-group-1, run-group-2]
     steps:
-      - name: Checkout Head
+      - name: Checkout
         uses: actions/checkout@v4
-        with:
-          ref: ${{ env.HEAD }}
+      - run: ./build/github/get-engflow-keys.sh
+        shell: bash
       - name: Unique Build ID
         run: echo "BUILD_ID=${{ github.run_id }}-${{ github.run_attempt }}" >> $GITHUB_ENV
       - name: Compare and Post
@@ -91,6 +81,10 @@ jobs:
         env:
           BASE_SHA: ${{ needs.base.outputs.merge_base }}
           HEAD_SHA: ${{ env.HEAD }}
+      - name: Clean up
+        run: ./build/github/cleanup-engflow-keys.sh
+        shell: bash
+        if: always()
   post:
     runs-on: [ self-hosted, basic_runner_group ]
     if: contains(github.event.pull_request.labels.*.name, 'T-microbench-post') # TODO: remove this check once results are confirmed to be stable on CI.
@@ -101,10 +95,8 @@ jobs:
         issues: write
     needs: [ base, compare ]
     steps:
-      - name: Checkout Base
+      - name: Checkout
         uses: actions/checkout@v4
-        with:
-          ref: ${{ github.event.pull_request.base.sha }}
       - run: ./build/github/get-engflow-keys.sh
         shell: bash
       - name: Unique Build ID

--- a/build/github/microbenchmarks/build.sh
+++ b/build/github/microbenchmarks/build.sh
@@ -31,13 +31,6 @@ bazel build "//${TEST_PKG}:tests_test" \
   --remote_download_minimal \
   $(./build/github/engflow-args.sh)
 
-# Build microbenchmark CI utility
-bazel build --config=crosslinux $(./build/github/engflow-args.sh) \
-  --jobs 100 \
-  --bes_keywords integration-test-artifact-build \
-  //pkg/cmd/microbench-ci
-
 # Copy to GCS
 bazel_bin=$(bazel info bazel-bin --config=crosslinux)
 gcloud storage cp "${bazel_bin}/pkg/sql/tests/${pkg_last}_test_/${pkg_last}_test" "${output_url}/${pkg_bin}"
-gcloud storage cp "${bazel_bin}/pkg/cmd/microbench-ci/microbench-ci_/microbench-ci" "${output_url}/microbench-ci"

--- a/build/github/microbenchmarks/compare.sh
+++ b/build/github/microbenchmarks/compare.sh
@@ -21,12 +21,8 @@ for sha in "${shas[@]}"; do
   gcloud storage cp -r "gs://${storage_bucket}/artifacts/${sha}/${BUILD_ID}/*" "${working_dir}/${sha}/artifacts/"
 done
 
-# Get the microbenchmark CI utility (HEAD version)
-gcloud storage cp "gs://${storage_bucket}/builds/${HEAD_SHA}/bin/microbench-ci" "$working_dir/microbench-ci"
-chmod +x "$working_dir/microbench-ci"
-
 # Compare the microbenchmarks
-"$working_dir/microbench-ci" compare \
+./build/github/microbenchmarks/util.sh compare \
   --working-dir="$working_dir" \
   --summary="$output_dir/summary.json" \
   --github-summary="$output_dir/summary.md" \

--- a/build/github/microbenchmarks/post.sh
+++ b/build/github/microbenchmarks/post.sh
@@ -10,19 +10,11 @@ set -euxo pipefail
 working_dir=$(mktemp -d)
 storage_bucket="$BUCKET"
 
-# Build microbenchmark CI utility (base version)
-bazel build --config=crosslinux $(./build/github/engflow-args.sh) \
-  --jobs 100 \
-  --bes_keywords integration-test-artifact-build \
-  //pkg/cmd/microbench-ci
-
-bazel_bin=$(bazel info bazel-bin --config=crosslinux)
-
 # Grab the summary from the previous step
 gcloud storage cp "gs://${storage_bucket}/results/${HEAD_SHA}/${BUILD_ID}/summary.md" "$working_dir/summary.md"
 
 # Post summary to GitHub on the PR
-"$bazel_bin/pkg/cmd/microbench-ci/microbench-ci_/microbench-ci" post \
+./build/github/microbenchmarks/util.sh post \
   --github-summary="$working_dir/summary.md" \
   --pr-number="$PR_NUMBER" \
   --repo="$REPO"

--- a/build/github/microbenchmarks/run.sh
+++ b/build/github/microbenchmarks/run.sh
@@ -20,19 +20,19 @@ for pkg in "${TEST_PACKAGES[@]}"; do
   for sha in "${shas[@]}"; do
     pkg_bin=$(echo "${pkg}" | tr '/' '_')
     url="gs://${storage_bucket}/builds/${sha}/bin/${pkg_bin}"
-    dest="$working_dir/$sha/bin/"
+    dest="$working_dir/$sha/bin"
     mkdir -p "$dest"
     gcloud storage cp "${url}" "$dest/${pkg_bin}"
     chmod +x "$dest/${pkg_bin}"
   done
 done
 
-# Get the microbenchmark CI utility (HEAD version)
-gcloud storage cp "gs://${storage_bucket}/builds/${HEAD_SHA}/bin/microbench-ci" "$working_dir/microbench-ci"
-chmod +x "$working_dir/microbench-ci"
-
 # Run the microbenchmarks
-"$working_dir/microbench-ci" run --group="$GROUP" --working-dir="$working_dir" --old="$BASE_SHA" --new="$HEAD_SHA"
+./build/github/microbenchmarks/util.sh run \
+  --group="$GROUP" \
+  --working-dir="$working_dir" \
+  --old="$BASE_SHA" \
+  --new="$HEAD_SHA"
 
 # Copy benchmark results to GCS
 curl -H "Metadata-Flavor: Google" \

--- a/build/github/microbenchmarks/util.sh
+++ b/build/github/microbenchmarks/util.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Copyright 2025 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+set -euxo pipefail
+
+bazel build --config=crosslinux $(./build/github/engflow-args.sh) \
+  --jobs 100 \
+  --bes_keywords integration-test-artifact-build \
+  //pkg/cmd/microbench-ci
+
+bazel_bin=$(bazel info bazel-bin --config=crosslinux)
+
+"$bazel_bin/pkg/cmd/microbench-ci/microbench-ci_/microbench-ci" "$@"


### PR DESCRIPTION
Previously, the checkout steps of the microbenchmark workflow specified revisions explicitly. It should rather use the defaults that will change based on if the workflow is triggered on "pull_request" or "pull_request_target". The latter will check out the base revision by default, while "pull_request" checks out the PR head revision by default. Hence, if changes to the microbenchmark workflow need to be tested the flow can be updated to "pull_request", and before merging changed back to "pull_request_target" (that is necessary for the permissions required for commenting on a PR).

The microbench-ci utility will now be built for each job that requires it, as the revision is dependent on the context. Build times for the utility is low, and as it is done through eng-flow there will be some caching. The test binaries still get cached on GCS, as developers need access to these in case they wish to reproduce the results.

Epic: None
Release note: None