### PR TITLE
kvserver: wait for all streams to be connected

### DIFF
--- a/pkg/kv/kvserver/flow_control_integration_test.go
+++ b/pkg/kv/kvserver/flow_control_integration_test.go
@@ -4397,6 +4397,7 @@ func (h *flowControlTestHelper) waitForConnectedStreams(
 	expConnectedStreams, serverIdx int,
 	lvl ...kvflowcontrol.V2EnabledWhenLeaderLevel,
 ) {
+	h.t.Helper()
 	level := h.resolveLevelArgs(lvl...)
 	testutils.SucceedsSoon(h.t, func() error {
 		state, found := h.getInspectHandlesForLevel(serverIdx, level).LookupInspect(rangeID)
@@ -4404,9 +4405,15 @@ func (h *flowControlTestHelper) waitForConnectedStreams(
 			return fmt.Errorf("handle for %s not found", rangeID)
 		}
 		require.True(h.t, found)
-		if len(state.ConnectedStreams) != expConnectedStreams {
-			return fmt.Errorf("expected %d connected streams, got %d",
-				expConnectedStreams, len(state.ConnectedStreams))
+		var connected int
+		for i := range state.ConnectedStreams {
+			if !state.ConnectedStreams[i].Disconnected {
+				connected++
+			}
+		}
+		if connected != expConnectedStreams {
+			return fmt.Errorf("expected %d connected streams, got %d/%d",
+				expConnectedStreams, connected, len(state.ConnectedStreams))
 		}
 		return nil
 	})

--- a/pkg/kv/kvserver/kvflowcontrol/kvflowhandle/testdata/handle_inspect
+++ b/pkg/kv/kvserver/kvflowcontrol/kvflowhandle/testdata/handle_inspect
@@ -26,7 +26,8 @@ echo
       "tracked_deductions": [
       ],
       "total_eval_deducted_tokens": "0",
-      "total_send_deducted_tokens": "0"
+      "total_send_deducted_tokens": "0",
+      "disconnected": false
     }
   ]
 }
@@ -65,7 +66,8 @@ echo
         }
       ],
       "total_eval_deducted_tokens": "0",
-      "total_send_deducted_tokens": "0"
+      "total_send_deducted_tokens": "0",
+      "disconnected": false
     }
   ]
 }
@@ -104,7 +106,8 @@ echo
         }
       ],
       "total_eval_deducted_tokens": "0",
-      "total_send_deducted_tokens": "0"
+      "total_send_deducted_tokens": "0",
+      "disconnected": false
     },
     {
       "stream": {
@@ -128,7 +131,8 @@ echo
         }
       ],
       "total_eval_deducted_tokens": "0",
-      "total_send_deducted_tokens": "0"
+      "total_send_deducted_tokens": "0",
+      "disconnected": false
     },
     {
       "stream": {
@@ -152,7 +156,8 @@ echo
         }
       ],
       "total_eval_deducted_tokens": "0",
-      "total_send_deducted_tokens": "0"
+      "total_send_deducted_tokens": "0",
+      "disconnected": false
     }
   ]
 }
@@ -191,7 +196,8 @@ echo
         }
       ],
       "total_eval_deducted_tokens": "0",
-      "total_send_deducted_tokens": "0"
+      "total_send_deducted_tokens": "0",
+      "disconnected": false
     },
     {
       "stream": {
@@ -215,7 +221,8 @@ echo
         }
       ],
       "total_eval_deducted_tokens": "0",
-      "total_send_deducted_tokens": "0"
+      "total_send_deducted_tokens": "0",
+      "disconnected": false
     }
   ]
 }
@@ -238,7 +245,8 @@ echo
       "tracked_deductions": [
       ],
       "total_eval_deducted_tokens": "0",
-      "total_send_deducted_tokens": "0"
+      "total_send_deducted_tokens": "0",
+      "disconnected": false
     },
     {
       "stream": {
@@ -254,7 +262,8 @@ echo
       "tracked_deductions": [
       ],
       "total_eval_deducted_tokens": "0",
-      "total_send_deducted_tokens": "0"
+      "total_send_deducted_tokens": "0",
+      "disconnected": false
     }
   ]
 }

--- a/pkg/kv/kvserver/kvflowcontrol/kvflowinspectpb/kvflowinspect.proto
+++ b/pkg/kv/kvserver/kvflowcontrol/kvflowinspectpb/kvflowinspect.proto
@@ -79,6 +79,9 @@ message ConnectedStream {
   // before sending, for this connected stream. Only populated on versions >=
   // 24.3.
   int64 total_send_deducted_tokens = 4;
+  // Disconnected is true if the stream has recently disconnected and no longer
+  // actively replicating, i.e. recently left StateReplicate in raft.
+  bool disconnected = 5;
 }
 
 // Stream represents a given kvflowcontrol.Stream and the number of tokens

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/range_controller.go
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/range_controller.go
@@ -1631,6 +1631,7 @@ func (rc *rangeController) InspectRaftMuLocked(ctx context.Context) kvflowinspec
 			}
 			streams = append(streams, kvflowinspectpb.ConnectedStream{
 				Stream:                  rc.opts.SSTokenCounter.InspectStream(rs.stream),
+				Disconnected:            rs.sendStream.mu.connectedState != replicate,
 				TrackedDeductions:       trackedDeductions,
 				TotalEvalDeductedTokens: int64(evalTokens),
 				TotalSendDeductedTokens: int64(sendTokens),

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/inspect
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/testdata/range_controller/inspect
@@ -25,7 +25,8 @@ inspect range_id=1
       "tracked_deductions": [
       ],
       "total_eval_deducted_tokens": "0",
-      "total_send_deducted_tokens": "0"
+      "total_send_deducted_tokens": "0",
+      "disconnected": false
     }
   ]
 }
@@ -59,7 +60,8 @@ inspect range_id=1
       "tracked_deductions": [
       ],
       "total_eval_deducted_tokens": "0",
-      "total_send_deducted_tokens": "0"
+      "total_send_deducted_tokens": "0",
+      "disconnected": false
     },
     {
       "stream": {
@@ -75,7 +77,8 @@ inspect range_id=1
       "tracked_deductions": [
       ],
       "total_eval_deducted_tokens": "0",
-      "total_send_deducted_tokens": "0"
+      "total_send_deducted_tokens": "0",
+      "disconnected": false
     },
     {
       "stream": {
@@ -91,7 +94,8 @@ inspect range_id=1
       "tracked_deductions": [
       ],
       "total_eval_deducted_tokens": "0",
-      "total_send_deducted_tokens": "0"
+      "total_send_deducted_tokens": "0",
+      "disconnected": false
     }
   ]
 }
@@ -153,7 +157,8 @@ inspect range_id=1
         }
       ],
       "total_eval_deducted_tokens": "8388608",
-      "total_send_deducted_tokens": "8388608"
+      "total_send_deducted_tokens": "8388608",
+      "disconnected": false
     },
     {
       "stream": {
@@ -193,7 +198,8 @@ inspect range_id=1
         }
       ],
       "total_eval_deducted_tokens": "8388608",
-      "total_send_deducted_tokens": "8388608"
+      "total_send_deducted_tokens": "8388608",
+      "disconnected": false
     },
     {
       "stream": {
@@ -233,7 +239,8 @@ inspect range_id=1
         }
       ],
       "total_eval_deducted_tokens": "8388608",
-      "total_send_deducted_tokens": "8388608"
+      "total_send_deducted_tokens": "8388608",
+      "disconnected": false
     }
   ]
 }
@@ -292,7 +299,8 @@ inspect range_id=1
         }
       ],
       "total_eval_deducted_tokens": "8388608",
-      "total_send_deducted_tokens": "8388608"
+      "total_send_deducted_tokens": "8388608",
+      "disconnected": false
     },
     {
       "stream": {
@@ -332,7 +340,8 @@ inspect range_id=1
         }
       ],
       "total_eval_deducted_tokens": "8388608",
-      "total_send_deducted_tokens": "8388608"
+      "total_send_deducted_tokens": "8388608",
+      "disconnected": false
     }
   ]
 }
@@ -386,7 +395,8 @@ inspect range_id=1
         }
       ],
       "total_eval_deducted_tokens": "5242880",
-      "total_send_deducted_tokens": "5242880"
+      "total_send_deducted_tokens": "5242880",
+      "disconnected": false
     },
     {
       "stream": {
@@ -410,7 +420,8 @@ inspect range_id=1
         }
       ],
       "total_eval_deducted_tokens": "2097152",
-      "total_send_deducted_tokens": "2097152"
+      "total_send_deducted_tokens": "2097152",
+      "disconnected": false
     }
   ]
 }


### PR DESCRIPTION
Previously, `waitForConnectedStreams` could return prematurely when one of the streams is in `StateProbe` and about to be closed. This commit ensures we wait for the streams to be connected / in `StateReplicate`.

Fixes #138103, #139229