### PR TITLE
release-24.3: rac2,kvserver: start the StreamCloseScheduler

### DIFF
--- a/pkg/kv/kvserver/kvflowcontrol/replica_rac2/close_scheduler_test.go
+++ b/pkg/kv/kvserver/kvflowcontrol/replica_rac2/close_scheduler_test.go
@@ -84,8 +84,8 @@ func TestStreamCloseScheduler(t *testing.T) {
 			stopper = stop.NewStopper()
 			clock = timeutil.NewManualTime(timeutil.UnixEpoch)
 			raftScheduler = &testingRaftScheduler{clock: clock}
-			closeScheduler = NewStreamCloseScheduler(stopper, clock, raftScheduler)
-			require.NoError(t, closeScheduler.Start(ctx))
+			closeScheduler = NewStreamCloseScheduler(clock, raftScheduler)
+			require.NoError(t, closeScheduler.Start(ctx, stopper))
 			return fmt.Sprintf("now=%vs", clock.Now().Unix())
 
 		case "schedule":

--- a/pkg/kv/kvserver/kvflowcontrol/replica_rac2/processor.go
+++ b/pkg/kv/kvserver/kvflowcontrol/replica_rac2/processor.go
@@ -131,7 +131,7 @@ type rangeControllerInitState struct {
 // RangeControllerFactory abstracts RangeController creation for testing.
 type RangeControllerFactory interface {
 	// New creates a new RangeController.
-	New(ctx context.Context, state rangeControllerInitState) rac2.RangeController
+	New(context.Context, rangeControllerInitState) rac2.RangeController
 }
 
 // ProcessorOptions are specified when creating a new Processor.

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -1558,22 +1558,6 @@ func NewStore(
 		cfg.RaftSchedulerConcurrency, cfg.RaftSchedulerShardSize, cfg.RaftSchedulerConcurrencyPriority,
 		cfg.RaftElectionTimeoutTicks)
 
-	// kvflowRangeControllerFactory depends on the raft scheduler, so it must be
-	// created per-store rather than per-node like other replication admission
-	// control (flow control) v2 components.
-	s.kvflowRangeControllerFactory = replica_rac2.NewRangeControllerFactoryImpl(
-		s.Clock(),
-		s.cfg.KVFlowEvalWaitMetrics,
-		s.cfg.KVFlowRangeControllerMetrics,
-		s.cfg.KVFlowStreamTokenProvider,
-		replica_rac2.NewStreamCloseScheduler(
-			s.stopper, timeutil.DefaultTimeSource{}, s.scheduler),
-		(*racV2Scheduler)(s.scheduler),
-		s.cfg.KVFlowSendTokenWatcher,
-		s.cfg.KVFlowWaitForEvalConfig,
-		s.TestingKnobs().FlowControlTestingKnobs,
-	)
-
 	// Run a log SyncWaiter loop for every 32 raft scheduler goroutines.
 	// Experiments on c5d.12xlarge instances (48 vCPUs, the largest single-socket
 	// instance AWS offers) show that with fewer SyncWaiters, raft log callback
@@ -2247,6 +2231,27 @@ func (s *Store) Start(ctx context.Context, stopper *stop.Stopper) error {
 			return errors.New("missing KVFlowSendTokenWatcher")
 		}
 	}
+
+	scs := replica_rac2.NewStreamCloseScheduler(timeutil.DefaultTimeSource{}, s.scheduler)
+	if err := scs.Start(ctx, stopper); err != nil {
+		return err
+	}
+	// kvflowRangeControllerFactory depends on the raft scheduler, so it must be
+	// created per-store rather than per-node like other replication admission
+	// control (flow control) v2 components.
+	// NB: this factory is used in the Replica initialization flow (below), so we
+	// must create it no later than here.
+	s.kvflowRangeControllerFactory = replica_rac2.NewRangeControllerFactoryImpl(
+		s.Clock(),
+		s.cfg.KVFlowEvalWaitMetrics,
+		s.cfg.KVFlowRangeControllerMetrics,
+		s.cfg.KVFlowStreamTokenProvider,
+		scs,
+		(*racV2Scheduler)(s.scheduler),
+		s.cfg.KVFlowSendTokenWatcher,
+		s.cfg.KVFlowWaitForEvalConfig,
+		s.TestingKnobs().FlowControlTestingKnobs,
+	)
 
 	now := s.cfg.Clock.Now()
 	s.startedAt = now.WallTime


### PR DESCRIPTION
Backport 1/1 commits from #140785.

/cc @cockroachdb/release

---

This commit enables the `StreamCloseScheduler`, which is responsible for closing RACv2 streams some time (400ms) after they enter `StateProbe`.

The initialization had to move from `NewStore` to `Store.Start()` because it needs the `stopper` to start the job.

Epic: none
Release note: none
Release justification: bug fix
