### PR TITLE
roachtest: use artifacts/cockroach if possible

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -127,7 +127,9 @@ func findBinary(
 ) (abspath string, err error) {
 	// Check to see if binary exists and is a regular file and executable.
 	if fi, err := os.Stat(name); err == nil && fi.Mode().IsRegular() && (fi.Mode()&0111) != 0 {
-		return validateBinaryFormat(name, arch, checkEA)
+		if s, err := validateBinaryFormat(name, arch, checkEA); err == nil {
+			return s, nil
+		}
 	}
 	return findBinaryOrLibrary("bin", name, "", osName, arch, checkEA)
 }
@@ -154,6 +156,7 @@ func findLibrary(libraryName string, os string, arch vm.CPUArch) (string, error)
 
 // findBinaryOrLibrary searches for a binary or library, _first_ in the $PATH, _then_ in the following hardcoded paths,
 //
+//	$PWD/artifacts
 //	$GOPATH/src/github.com/cockroachdb/cockroach/
 //	$GOPATH/src/github.com/cockroachdb/artifacts/
 //	$PWD/binOrLib
@@ -197,6 +200,7 @@ func findBinaryOrLibrary(
 	}
 
 	dirs := []string{
+		filepath.Join(os.ExpandEnv("$PWD"), "artifacts"),
 		filepath.Join(gopath, "/src/github.com/cockroachdb/cockroach/"),
 		filepath.Join(gopath, "/src/github.com/cockroachdb/cockroach/artifacts/"),
 		filepath.Join(os.ExpandEnv("$PWD"), binOrLib),


### PR DESCRIPTION
This prepends PWD/artifacts to the paths searched for roachtest's required binaries, as this is where a binary built by dev cross, for use in a roachtest, is placed by default.

Additionally, if the binary in found before searching paths, i.e. the one directly in PWD, fails the arch check, we now fall through to the searching and validation step rather than failing immediately; having an invalid-arch binary in PWD is common and expected for CRL engineers working on Darwin/arm, so we should not be surprised to see it and instead just move on to search for a valid one.

Release note: none.
Epic: none.