### PR TITLE
sql: Store column IDs in RLS policy expressions

### DIFF
--- a/pkg/sql/catalog/descpb/structured.proto
+++ b/pkg/sql/catalog/descpb/structured.proto
@@ -725,10 +725,19 @@ message PolicyDescriptor {
   // field is omitted, the policy will not be used for reads.
   optional string using_expr = 6 [(gogoproto.nullable) = false];
 
+  // UsingColumnIDs is an ordered list of column IDs used by the USING expression.
+  repeated uint32 using_column_ids = 11 [(gogoproto.customname) = "UsingColumnIDs",
+    (gogoproto.casttype) = "ColumnID"];
+
   // WithCheck defines the condition applied to validate new rows during
   // write operations (e.g., INSERT or UPDATE). If omitted, the UsingExpr
   // will serve as a fallback, provided it is defined.
   optional string with_check_expr = 7 [(gogoproto.nullable) = false];
+
+  // WithCheckColumnIDs is an ordered list of column IDs used by the WITH CHECK
+  // expression.
+  repeated uint32 with_check_column_ids = 12 [(gogoproto.customname) = "WithCheckColumnIDs",
+    (gogoproto.casttype) = "ColumnID"];
 
   // DependsOnTypes are the IDs of all user defined types that the policy
   // expressions depend on.
@@ -741,6 +750,8 @@ message PolicyDescriptor {
   // DependsOnRelations are the IDs of the tables, views and sequences that the
   // policy expressions depend on.
   repeated uint32 depends_on_relations = 10 [(gogoproto.casttype) = "ID"];
+
+  // Next ID: 13
 }
 
 // A DescriptorMutation represents a column or an index that

--- a/pkg/sql/schemachanger/scexec/scmutationexec/policy.go
+++ b/pkg/sql/schemachanger/scexec/scmutationexec/policy.go
@@ -109,6 +109,7 @@ func (i *immediateVisitor) SetPolicyWithCheckExpression(
 		return err
 	}
 	policy.WithCheckExpr = op.Expr
+	policy.WithCheckColumnIDs = op.ColumnIDs
 	return nil
 }
 
@@ -120,6 +121,7 @@ func (i *immediateVisitor) SetPolicyUsingExpression(
 		return err
 	}
 	policy.UsingExpr = op.Expr
+	policy.UsingColumnIDs = op.ColumnIDs
 	return nil
 }
 

--- a/pkg/sql/schemachanger/scop/immediate_mutation.go
+++ b/pkg/sql/schemachanger/scop/immediate_mutation.go
@@ -623,17 +623,19 @@ type RemovePolicyRole struct {
 // SetPolicyUsingExpression will set a new USING expression for a policy.
 type SetPolicyUsingExpression struct {
 	immediateMutationOp
-	TableID  descpb.ID
-	PolicyID descpb.PolicyID
-	Expr     string
+	TableID   descpb.ID
+	PolicyID  descpb.PolicyID
+	Expr      string
+	ColumnIDs descpb.ColumnIDs
 }
 
 // SetPolicyWithCheckExpression will set a new WITH CHECK expression for a policy.
 type SetPolicyWithCheckExpression struct {
 	immediateMutationOp
-	TableID  descpb.ID
-	PolicyID descpb.PolicyID
-	Expr     string
+	TableID   descpb.ID
+	PolicyID  descpb.PolicyID
+	Expr      string
+	ColumnIDs descpb.ColumnIDs
 }
 
 // SetPolicyForwardReferences sets new forward references to relations, types,

--- a/pkg/sql/schemachanger/scplan/internal/opgen/opgen_policy_using_expression.go
+++ b/pkg/sql/schemachanger/scplan/internal/opgen/opgen_policy_using_expression.go
@@ -17,9 +17,10 @@ func init() {
 			to(scpb.Status_PUBLIC,
 				emit(func(this *scpb.PolicyUsingExpr) *scop.SetPolicyUsingExpression {
 					return &scop.SetPolicyUsingExpression{
-						TableID:  this.TableID,
-						PolicyID: this.PolicyID,
-						Expr:     string(this.Expression.Expr),
+						TableID:   this.TableID,
+						PolicyID:  this.PolicyID,
+						Expr:      string(this.Expression.Expr),
+						ColumnIDs: this.Expression.ReferencedColumnIDs,
 					}
 				}),
 			),
@@ -29,9 +30,10 @@ func init() {
 			to(scpb.Status_ABSENT,
 				emit(func(this *scpb.PolicyUsingExpr) *scop.SetPolicyUsingExpression {
 					return &scop.SetPolicyUsingExpression{
-						TableID:  this.TableID,
-						PolicyID: this.PolicyID,
-						Expr:     "",
+						TableID:   this.TableID,
+						PolicyID:  this.PolicyID,
+						Expr:      "",
+						ColumnIDs: nil,
 					}
 				}),
 			),

--- a/pkg/sql/schemachanger/scplan/internal/opgen/opgen_policy_with_check_expression.go
+++ b/pkg/sql/schemachanger/scplan/internal/opgen/opgen_policy_with_check_expression.go
@@ -17,9 +17,10 @@ func init() {
 			to(scpb.Status_PUBLIC,
 				emit(func(this *scpb.PolicyWithCheckExpr) *scop.SetPolicyWithCheckExpression {
 					return &scop.SetPolicyWithCheckExpression{
-						TableID:  this.TableID,
-						PolicyID: this.PolicyID,
-						Expr:     string(this.Expression.Expr),
+						TableID:   this.TableID,
+						PolicyID:  this.PolicyID,
+						Expr:      string(this.Expression.Expr),
+						ColumnIDs: this.Expression.ReferencedColumnIDs,
 					}
 				}),
 			),
@@ -29,9 +30,10 @@ func init() {
 			to(scpb.Status_ABSENT,
 				emit(func(this *scpb.PolicyWithCheckExpr) *scop.SetPolicyWithCheckExpression {
 					return &scop.SetPolicyWithCheckExpression{
-						TableID:  this.TableID,
-						PolicyID: this.PolicyID,
-						Expr:     "",
+						TableID:   this.TableID,
+						PolicyID:  this.PolicyID,
+						Expr:      "",
+						ColumnIDs: nil,
 					}
 				}),
 			),

--- a/pkg/sql/schemachanger/scplan/testdata/create_policy
+++ b/pkg/sql/schemachanger/scplan/testdata/create_policy
@@ -49,6 +49,9 @@ StatementPhase stage 1 of 1 with 9 MutationType ops
         RoleName: public
         TableID: 106
     *scop.SetPolicyUsingExpression
+      ColumnIDs:
+      - 1
+      - 2
       Expr: (tenant_id = '01538898-f55c-44db-a306-89078e2c430e':::UUID) AND ((c1).x > 0:::INT8)
       PolicyID: 1
       TableID: 106
@@ -116,6 +119,9 @@ PreCommitPhase stage 2 of 2 with 9 MutationType ops
         RoleName: public
         TableID: 106
     *scop.SetPolicyUsingExpression
+      ColumnIDs:
+      - 1
+      - 2
       Expr: (tenant_id = '01538898-f55c-44db-a306-89078e2c430e':::UUID) AND ((c1).x > 0:::INT8)
       PolicyID: 1
       TableID: 106
@@ -162,10 +168,14 @@ StatementPhase stage 1 of 1 with 7 MutationType ops
         RoleName: public
         TableID: 106
     *scop.SetPolicyUsingExpression
+      ColumnIDs:
+      - 3
       Expr: c2::@100108 = b'\xc0':::@100108
       PolicyID: 1
       TableID: 106
     *scop.SetPolicyWithCheckExpression
+      ColumnIDs:
+      - 3
       Expr: c2::@100108 = b'@':::@100108
       PolicyID: 1
       TableID: 106
@@ -217,10 +227,14 @@ PreCommitPhase stage 2 of 2 with 7 MutationType ops
         RoleName: public
         TableID: 106
     *scop.SetPolicyUsingExpression
+      ColumnIDs:
+      - 3
       Expr: c2::@100108 = b'\xc0':::@100108
       PolicyID: 1
       TableID: 106
     *scop.SetPolicyWithCheckExpression
+      ColumnIDs:
+      - 3
       Expr: c2::@100108 = b'@':::@100108
       PolicyID: 1
       TableID: 106
@@ -265,10 +279,14 @@ StatementPhase stage 1 of 1 with 7 MutationType ops
         RoleName: public
         TableID: 106
     *scop.SetPolicyUsingExpression
+      ColumnIDs:
+      - 2
       Expr: '[FUNCTION 100110]((c1).x)'
       PolicyID: 1
       TableID: 106
     *scop.SetPolicyWithCheckExpression
+      ColumnIDs:
+      - 2
       Expr: '[FUNCTION 100111]((c1).y)'
       PolicyID: 1
       TableID: 106
@@ -321,10 +339,14 @@ PreCommitPhase stage 2 of 2 with 7 MutationType ops
         RoleName: public
         TableID: 106
     *scop.SetPolicyUsingExpression
+      ColumnIDs:
+      - 2
       Expr: '[FUNCTION 100110]((c1).x)'
       PolicyID: 1
       TableID: 106
     *scop.SetPolicyWithCheckExpression
+      ColumnIDs:
+      - 2
       Expr: '[FUNCTION 100111]((c1).y)'
       PolicyID: 1
       TableID: 106

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_policy/create_policy.side_effects
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_policy/create_policy.side_effects
@@ -34,6 +34,8 @@ upsert descriptor #104
   +    roleNames:
   +    - public
   +    type: PERMISSIVE
+  +    usingColumnIds:
+  +    - 1
   +    usingExpr: tenant_id = '01538898-f55c-44db-a306-89078e2c430e':::UUID
      primaryIndex:
        constraintId: 1
@@ -61,6 +63,8 @@ upsert descriptor #104
   +    roleNames:
   +    - public
   +    type: PERMISSIVE
+  +    usingColumnIds:
+  +    - 1
   +    usingExpr: tenant_id = '01538898-f55c-44db-a306-89078e2c430e':::UUID
      primaryIndex:
        constraintId: 1


### PR DESCRIPTION
Row-Level Security (RLS) policies consist of two expressions: USING and WITH CHECK. To enforce the WITH CHECK expression — intended to be implemented using a synthetic CHECK constraint — we need to identify the columns referenced within these expressions. Storing the column IDs in the policy descriptor, which is associated with the table descriptor, allows us to efficiently retrieve the necessary columns when using the CHECK constraint at runtime. This eliminates the need to compute them at runtime when building the constraint. I'm storing the column IDs for the USING expression too. As that expression will be used for writes if the WITH CHECK expression is omitted.

Epic: CRDB-45203
Release note: none

Informs: #136704