### PR TITLE
roachprod: chronyd config bad format

### DIFF
--- a/pkg/roachprod/vm/azure/testdata/startup_script
+++ b/pkg/roachprod/vm/azure/testdata/startup_script
@@ -126,6 +126,7 @@ logchange 0.01
 hwclockfile /etc/adjtime
 rtcsync
 server time1.google.com prefer iburst
+server time2.google.com prefer iburst
 makestep 0.1 3
 EOF
 

--- a/pkg/roachprod/vm/azure/utils_test.go
+++ b/pkg/roachprod/vm/azure/utils_test.go
@@ -31,6 +31,7 @@ func TestWriteStartupScriptTemplate(t *testing.T) {
 				StartupLogs:          vm.StartupLogs,
 				ChronyServers: []string{
 					"time1.google.com",
+					"time2.google.com",
 				},
 			},
 		})

--- a/pkg/roachprod/vm/startup.go
+++ b/pkg/roachprod/vm/startup.go
@@ -65,7 +65,9 @@ dumpdir /var/lib/chrony
 logchange 0.01
 hwclockfile /etc/adjtime
 rtcsync
-{{ range .ChronyServers }}server {{.}} prefer iburst{{ end }}
+{{ range .ChronyServers -}}
+server {{.}} prefer iburst
+{{ end -}}
 makestep 0.1 3
 EOF
 


### PR DESCRIPTION
Previously, the chronyd templating configuration was writting source servers on the same line instead of one source per line.

This was resulting in a configuration parsing error, and preventing the instance from ever being ready to use with roachprod/roachtest.

This patch fixes the configuration.

Epic: none
Release note: None