### PR TITLE
kvserver: preserve unreplicated locks during range merge

### DIFF
--- a/pkg/kv/kvpb/api.proto
+++ b/pkg/kv/kvpb/api.proto
@@ -2266,6 +2266,10 @@ message SubsumeRequest {
   // The range descriptor for the right-hand side of the merge. Should match
   // the range descriptor of the range evaluating this request.
   RangeDescriptor right_desc = 3 [(gogoproto.nullable) = false];
+
+  // PreserveUnreplicatedLocks instructs the Subsume request to flush any unreplicated
+  // locks to the replicated lock table before returning.
+  bool preserve_unreplicated_locks = 4;
 }
 
 // SubsumeResponse is the response to a SubsumeRequest.

--- a/pkg/kv/kvserver/concurrency/concurrency_control.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_control.go
@@ -293,6 +293,10 @@ type RangeStateListener interface {
 	// going to modify the lock table as its evaluating.
 	OnRangeLeaseTransferEval() []*roachpb.LockAcquisition
 
+	// OnRangeSubsumeEval informs the concurrency manager that the range is
+	// evaluating a merge.
+	OnRangeSubsumeEval() []*roachpb.LockAcquisition
+
 	// OnRangeLeaseUpdated informs the concurrency manager that its range's
 	// lease has been updated. The argument indicates whether this manager's
 	// replica is the leaseholder going forward.

--- a/pkg/kv/kvserver/replica_application_result.go
+++ b/pkg/kv/kvserver/replica_application_result.go
@@ -273,6 +273,15 @@ func (r *Replica) prepareLocalResult(ctx context.Context, cmd *replicatedCmd) {
 		}
 	}
 
+	// Repopulate SubsumeResponse if requested.
+	if pErr == nil && cmd.proposal.Local.DetachRepopulateSubsumeResponse() {
+		if resp := cmd.response.Reply.Responses[0].GetSubsume(); resp != nil {
+			resp.LeaseAppliedIndex = cmd.LeaseIndex
+		} else {
+			log.Fatalf(ctx, "RepopulateSubsumeResponse for %T", cmd.response.Reply.Responses[0].GetInner())
+		}
+	}
+
 	if pErr == nil {
 		cmd.localResult = cmd.proposal.Local
 	} else if cmd.localResult != nil {

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -128,6 +128,10 @@ func (r *Replica) evalAndPropose(
 		}
 		intents := proposal.Local.DetachEncounteredIntents()
 		endTxns := proposal.Local.DetachEndTxns(pErr != nil /* alwaysOnly */)
+
+		// If we had no proposal, then the existing LeaseAppliedIndex is sufficient.
+		proposal.Local.DetachRepopulateSubsumeResponse()
+
 		r.handleReadWriteLocalEvalResult(ctx, *proposal.Local)
 
 		// NB: it is intentional that this returns both an error and results.


### PR DESCRIPTION
Similar to lease transfer, range merge now writes unreplicated locks
via raft to prevent losing them. This happens during Subsume.

To ensure that these new writes are replicated before the merge
completes, we now also update SubsumeResponse's LeaseAppliedIndex
field to references the LAI of the Subsume request itself.

Epic: none
Release note: None