### PR TITLE
release-24.1: opt: set min row count of 1 for FK and uniqueness check WithScans

### DIFF
--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -3849,6 +3849,10 @@ func (m *sessionDataMutator) SetOptimizerMinRowCount(val float64) {
 	m.data.OptimizerMinRowCount = val
 }
 
+func (m *sessionDataMutator) SetOptimizerCheckInputMinRowCount(val float64) {
+	m.data.OptimizerCheckInputMinRowCount = val
+}
+
 // Utility functions related to scrubbing sensitive information on SQL Stats.
 
 // quantizeCounts ensures that the Count field in the

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -6170,6 +6170,7 @@ opt_split_scan_limit                                       2048
 optimizer                                                  on
 optimizer_always_use_histograms                            on
 optimizer_apply_full_scan_penalty_to_virtual_tables        off
+optimizer_check_input_min_row_count                        0
 optimizer_hoist_uncorrelated_equality_subqueries           on
 optimizer_merge_joins_enabled                              on
 optimizer_min_row_count                                    0

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -2930,6 +2930,7 @@ on_update_rehome_row_enabled                               on                  N
 opt_split_scan_limit                                       2048                NULL      NULL        NULL        string
 optimizer_always_use_histograms                            on                  NULL      NULL        NULL        string
 optimizer_apply_full_scan_penalty_to_virtual_tables        off                 NULL      NULL        NULL        string
+optimizer_check_input_min_row_count                        0                   NULL      NULL        NULL        string
 optimizer_hoist_uncorrelated_equality_subqueries           on                  NULL      NULL        NULL        string
 optimizer_merge_joins_enabled                              on                  NULL      NULL        NULL        string
 optimizer_min_row_count                                    0                   NULL      NULL        NULL        string
@@ -3122,6 +3123,7 @@ on_update_rehome_row_enabled                               on                  N
 opt_split_scan_limit                                       2048                NULL  user     NULL      2048                2048
 optimizer_always_use_histograms                            on                  NULL  user     NULL      on                  on
 optimizer_apply_full_scan_penalty_to_virtual_tables        off                 NULL  user     NULL      off                 off
+optimizer_check_input_min_row_count                        0                   NULL  user     NULL      0                   0
 optimizer_hoist_uncorrelated_equality_subqueries           on                  NULL  user     NULL      on                  on
 optimizer_merge_joins_enabled                              on                  NULL  user     NULL      on                  on
 optimizer_min_row_count                                    0                   NULL  user     NULL      0                   0
@@ -3313,6 +3315,7 @@ opt_split_scan_limit                                       NULL    NULL     NULL
 optimizer                                                  NULL    NULL     NULL     NULL        NULL
 optimizer_always_use_histograms                            NULL    NULL     NULL     NULL        NULL
 optimizer_apply_full_scan_penalty_to_virtual_tables        NULL    NULL     NULL     NULL        NULL
+optimizer_check_input_min_row_count                        NULL    NULL     NULL     NULL        NULL
 optimizer_hoist_uncorrelated_equality_subqueries           NULL    NULL     NULL     NULL        NULL
 optimizer_merge_joins_enabled                              NULL    NULL     NULL     NULL        NULL
 optimizer_min_row_count                                    NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -126,6 +126,7 @@ on_update_rehome_row_enabled                               on
 opt_split_scan_limit                                       2048
 optimizer_always_use_histograms                            on
 optimizer_apply_full_scan_penalty_to_virtual_tables        off
+optimizer_check_input_min_row_count                        0
 optimizer_hoist_uncorrelated_equality_subqueries           on
 optimizer_merge_joins_enabled                              on
 optimizer_min_row_count                                    0

--- a/pkg/sql/opt/memo/memo.go
+++ b/pkg/sql/opt/memo/memo.go
@@ -198,6 +198,7 @@ type Memo struct {
 	legacyVarcharTyping                        bool
 	preferBoundedCardinality                   bool
 	minRowCount                                float64
+	checkInputMinRowCount                      float64
 
 	// txnIsoLevel is the isolation level under which the plan was created. This
 	// affects the planning of some locking operations, so it must be included in
@@ -287,6 +288,7 @@ func (m *Memo) Init(ctx context.Context, evalCtx *eval.Context) {
 		legacyVarcharTyping:                        evalCtx.SessionData().LegacyVarcharTyping,
 		preferBoundedCardinality:                   evalCtx.SessionData().OptimizerPreferBoundedCardinality,
 		minRowCount:                                evalCtx.SessionData().OptimizerMinRowCount,
+		checkInputMinRowCount:                      evalCtx.SessionData().OptimizerCheckInputMinRowCount,
 		txnIsoLevel:                                evalCtx.TxnIsoLevel,
 	}
 	m.metadata.Init()
@@ -454,6 +456,7 @@ func (m *Memo) IsStale(
 		m.legacyVarcharTyping != evalCtx.SessionData().LegacyVarcharTyping ||
 		m.preferBoundedCardinality != evalCtx.SessionData().OptimizerPreferBoundedCardinality ||
 		m.minRowCount != evalCtx.SessionData().OptimizerMinRowCount ||
+		m.checkInputMinRowCount != evalCtx.SessionData().OptimizerCheckInputMinRowCount ||
 		m.txnIsoLevel != evalCtx.TxnIsoLevel {
 		return true, nil
 	}

--- a/pkg/sql/opt/memo/memo_test.go
+++ b/pkg/sql/opt/memo/memo_test.go
@@ -518,6 +518,11 @@ func TestMemoIsStale(t *testing.T) {
 	evalCtx.SessionData().OptimizerMinRowCount = 0
 	notStale()
 
+	evalCtx.SessionData().OptimizerCheckInputMinRowCount = 1.0
+	stale()
+	evalCtx.SessionData().OptimizerCheckInputMinRowCount = 0
+	notStale()
+
 	// User no longer has access to view.
 	catalog.View(tree.NewTableNameWithSchema("t", catconstants.PublicSchemaName, "abcview")).Revoked = true
 	_, err = o.Memo().IsStale(ctx, &evalCtx, catalog)

--- a/pkg/sql/opt/memo/statistics_builder.go
+++ b/pkg/sql/opt/memo/statistics_builder.go
@@ -228,20 +228,22 @@ const (
 //
 // See props/statistics.go for more details.
 type statisticsBuilder struct {
-	ctx         context.Context
-	evalCtx     *eval.Context
-	md          *opt.Metadata
-	minRowCount float64
+	ctx                   context.Context
+	evalCtx               *eval.Context
+	md                    *opt.Metadata
+	checkInputMinRowCount float64
+	minRowCount           float64
 }
 
 func (sb *statisticsBuilder) init(ctx context.Context, evalCtx *eval.Context, md *opt.Metadata) {
 	// This initialization pattern ensures that fields are not unwittingly
 	// reused. Field reuse must be explicit.
 	*sb = statisticsBuilder{
-		ctx:         ctx,
-		evalCtx:     evalCtx,
-		md:          md,
-		minRowCount: evalCtx.SessionData().OptimizerMinRowCount,
+		ctx:                   ctx,
+		evalCtx:               evalCtx,
+		md:                    md,
+		checkInputMinRowCount: evalCtx.SessionData().OptimizerCheckInputMinRowCount,
+		minRowCount:           evalCtx.SessionData().OptimizerMinRowCount,
 	}
 }
 
@@ -2733,6 +2735,9 @@ func (sb *statisticsBuilder) buildWithScan(
 
 	s.Available = bindingProps.Statistics().Available
 	s.RowCount = bindingProps.Statistics().RowCount
+	if withScan.CheckInput {
+		s.RowCount = max(s.RowCount, sb.checkInputMinRowCount)
+	}
 
 	// TODO(michae2): Set operations and with-scans currently act as barriers for
 	// VirtualCols, due to the column ID translation. To fix this we would need to

--- a/pkg/sql/opt/memo/testdata/stats/insert
+++ b/pkg/sql/opt/memo/testdata/stats/insert
@@ -129,3 +129,102 @@ insert xyz
            │    └── fd: (9)-->(6-8,10,11), (6)-->(8)
            └── filters
                 └── false [type=bool, constraints=(contradiction; tight)]
+
+exec-ddl
+CREATE TABLE p137547 (
+  region STRING,
+  id STRING,
+  i INT,
+  s STRING,
+  PRIMARY KEY (region, id),
+  UNIQUE INDEX (region, i)
+)
+----
+
+exec-ddl
+CREATE TABLE c137547 (
+  region STRING,
+  id STRING,
+  p_id STRING,
+  PRIMARY KEY (region, id),
+  FOREIGN KEY (region, p_id) REFERENCES p137547 (region, id)
+)
+----
+
+exec-ddl
+ALTER TABLE p137547 INJECT STATISTICS '[
+  {
+    "avg_size": 1500,
+    "columns": ["s"],
+    "created_at": "2024-11-29 16:18:00.835616",
+    "distinct_count": 14000000,
+    "null_count": 0,
+    "row_count": 14000000
+  }
+]';
+----
+
+# Regression test for #137547. Estimate that the FK check WithScan produces at
+# least 1 row to avoid a lookup into the secondary index of p137547 using just
+# the region column.
+opt locality=(region=us) set=(optimizer_check_input_min_row_count=1)
+INSERT INTO c137547 VALUES ('us', 'foo', 'foo') ON CONFLICT DO NOTHING
+----
+insert c137547
+ ├── arbiter indexes: c137547_pkey
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├── column1:6 => c137547.region:1
+ │    ├── column2:7 => c137547.id:2
+ │    └── column3:8 => c137547.p_id:3
+ ├── input binding: &1
+ ├── cardinality: [0 - 0]
+ ├── volatile, mutations
+ ├── stats: [rows=0]
+ ├── distribution: us
+ ├── anti-join (cross)
+ │    ├── columns: column1:6(string!null) column2:7(string!null) column3:8(string!null)
+ │    ├── cardinality: [0 - 1]
+ │    ├── stats: [rows=1e-10, distinct(6)=1e-10, null(6)=0, distinct(8)=1e-10, null(8)=0]
+ │    ├── key: ()
+ │    ├── fd: ()-->(6-8)
+ │    ├── distribution: us
+ │    ├── values
+ │    │    ├── columns: column1:6(string!null) column2:7(string!null) column3:8(string!null)
+ │    │    ├── cardinality: [1 - 1]
+ │    │    ├── stats: [rows=1, distinct(6)=1, null(6)=0, distinct(8)=1, null(8)=0]
+ │    │    ├── key: ()
+ │    │    ├── fd: ()-->(6-8)
+ │    │    ├── distribution: us
+ │    │    └── ('us', 'foo', 'foo') [type=tuple{string, string, string}]
+ │    ├── scan c137547
+ │    │    ├── columns: c137547.region:9(string!null) c137547.id:10(string!null)
+ │    │    ├── constraint: /9/10: [/'us'/'foo' - /'us'/'foo']
+ │    │    ├── cardinality: [0 - 1]
+ │    │    ├── stats: [rows=0.91, distinct(9)=0.91, null(9)=0, distinct(10)=0.91, null(10)=0, distinct(9,10)=0.91, null(9,10)=0]
+ │    │    ├── key: ()
+ │    │    ├── fd: ()-->(9,10)
+ │    │    └── distribution: us
+ │    └── filters (true)
+ └── f-k-checks
+      └── f-k-checks-item: c137547(region,p_id) -> p137547(region,id)
+           └── anti-join (lookup p137547)
+                ├── columns: region:14(string!null) p_id:15(string!null)
+                ├── key columns: [14 15] = [16 17]
+                ├── lookup columns are key
+                ├── cardinality: [0 - 1]
+                ├── stats: [rows=1e-10]
+                ├── key: ()
+                ├── fd: ()-->(14,15)
+                ├── distribution: us
+                ├── with-scan &1
+                │    ├── columns: region:14(string!null) p_id:15(string!null)
+                │    ├── mapping:
+                │    │    ├──  column1:6(string) => region:14(string)
+                │    │    └──  column3:8(string) => p_id:15(string)
+                │    ├── cardinality: [0 - 1]
+                │    ├── stats: [rows=1, distinct(14)=1e-10, null(14)=0, distinct(15)=1e-10, null(15)=0]
+                │    ├── key: ()
+                │    ├── fd: ()-->(14,15)
+                │    └── distribution: us
+                └── filters (true)

--- a/pkg/sql/opt/ops/relational.opt
+++ b/pkg/sql/opt/ops/relational.opt
@@ -1367,6 +1367,10 @@ define WithScanPrivate {
     # Mtr is the materialization behavior of the CTE referenced by the WithScan.
     # It matches the Mtr field of the WithPrivate with a matching WithID.
     Mtr CTEMaterializeClause
+
+    # CheckInput is true if the WithScan is an input to a foreign key or a
+    # uniqueness check.
+    CheckInput bool
 }
 
 # RecursiveCTE implements the logic of a recursive CTE:

--- a/pkg/sql/opt/optbuilder/mutation_builder.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder.go
@@ -1560,10 +1560,11 @@ func (mb *mutationBuilder) buildCheckInputScan(
 
 	mb.ensureWithID()
 	outScope.expr = mb.b.factory.ConstructWithScan(&memo.WithScanPrivate{
-		With:    mb.withID,
-		InCols:  inputCols,
-		OutCols: outScope.colList(),
-		ID:      mb.b.factory.Metadata().NextUniqueID(),
+		With:       mb.withID,
+		InCols:     inputCols,
+		OutCols:    outScope.colList(),
+		ID:         mb.b.factory.Metadata().NextUniqueID(),
+		CheckInput: true,
 	})
 
 	return outScope, notNullOutCols

--- a/pkg/sql/sessiondatapb/local_only_session_data.proto
+++ b/pkg/sql/sessiondatapb/local_only_session_data.proto
@@ -536,12 +536,16 @@ message LocalOnlySessionData {
   // plans in which every expression has a bounded cardinality over plans with
   // one or more expressions with unbounded cardinality.
   bool optimizer_prefer_bounded_cardinality = 154;
-  // OptimizerMinRowCount set a lower bound on row count estimates for
+  // OptimizerMinRowCount sets a lower bound on row count estimates for
   // relational expressions during query planning. A value of zero indicates no
   // lower bound. Note that if this is set to a value greater than zero, a row
   // count of zero can still be estimated for expressions with a cardinality of
   // zero, e.g., for a contradictory filter.
   double optimizer_min_row_count = 155;
+  // OptimizerCheckInputMinRowCount sets a lower bound on row count estimates
+  // for the buffer scan of FK and uniqueness checks. A value of zero indicates
+  // no lower bound.
+  double optimizer_check_input_min_row_count = 157;
 
   ///////////////////////////////////////////////////////////////////////////
   // WARNING: consider whether a session parameter you're adding needs to  //

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -3515,6 +3515,28 @@ var varGen = map[string]sessionVar{
 			return nil
 		},
 	},
+
+	// CockroachDB extension.
+	`optimizer_check_input_min_row_count`: {
+		GetStringVal: makeFloatGetStringValFn(`optimizer_check_input_min_row_count`),
+		Get: func(evalCtx *extendedEvalContext, _ *kv.Txn) (string, error) {
+			return formatFloatAsPostgresSetting(evalCtx.SessionData().OptimizerCheckInputMinRowCount), nil
+		},
+		GlobalDefault: func(sv *settings.Values) string {
+			return "0"
+		},
+		Set: func(ctx context.Context, m sessionDataMutator, s string) error {
+			f, err := strconv.ParseFloat(s, 64)
+			if err != nil {
+				return err
+			}
+			if f < 0 {
+				return pgerror.New(pgcode.InvalidParameterValue, "optimizer_check_input_min_row_count must be non-negative")
+			}
+			m.SetOptimizerCheckInputMinRowCount(f)
+			return nil
+		},
+	},
 }
 
 func ReplicationModeFromString(s string) (sessiondatapb.ReplicationMode, error) {


### PR DESCRIPTION
Backport 1/2 commits from #140735.

/cc @cockroachdb/release

---

#### opt: add optimizer_check_input_min_row_count

Informs #137547

Release note (sql change): The `optimizer_check_input_min_row_count`
session setting has been added to control the minimum row count estimate
for buffer scans of foreign key and unqiueness checks. It defaults to 0.

----

Release justification: New optimizer setting, off by default.

