### PR TITLE
sqlutils: refactor parsing functions for easier parser extensions

### DIFF
--- a/pkg/sql/parser/parse_test.go
+++ b/pkg/sql/parser/parse_test.go
@@ -53,14 +53,13 @@ func TestParseDataDriven(t *testing.T) {
 		datadriven.RunTest(t, path, func(t *testing.T, d *datadriven.TestData) string {
 			switch d.Cmd {
 			case "parse":
-				const plpgsql = false
 				reparseWithoutLiterals := true
 				for _, arg := range d.CmdArgs {
 					if arg.Key == "no-parse-without-literals" {
 						reparseWithoutLiterals = false
 					}
 				}
-				return sqlutils.VerifyParseFormat(t, d.Input, d.Pos, plpgsql, reparseWithoutLiterals)
+				return sqlutils.VerifyParseFormat(t, d.Input, d.Pos, sqlutils.SQL, reparseWithoutLiterals)
 			case "parse-no-verify":
 				_, err := parser.Parse(d.Input)
 				if err != nil {

--- a/pkg/sql/plpgsql/parser/parser_test.go
+++ b/pkg/sql/plpgsql/parser/parser_test.go
@@ -37,14 +37,13 @@ func TestParseDataDriven(t *testing.T) {
 		datadriven.RunTest(t, path, func(t *testing.T, d *datadriven.TestData) string {
 			switch d.Cmd {
 			case "parse":
-				const plpgsql = true
 				reParseWithoutLiterals := true
 				for _, arg := range d.CmdArgs {
 					if arg.Key == "no-parse-without-literals" {
 						reParseWithoutLiterals = false
 					}
 				}
-				return sqlutils.VerifyParseFormat(t, d.Input, d.Pos, plpgsql, reParseWithoutLiterals)
+				return sqlutils.VerifyParseFormat(t, d.Input, d.Pos, sqlutils.PLpgSQL, reParseWithoutLiterals)
 			case "error":
 				_, err := plpgsql.Parse(d.Input)
 				if err == nil {

--- a/pkg/testutils/sqlutils/pretty.go
+++ b/pkg/testutils/sqlutils/pretty.go
@@ -23,7 +23,7 @@ func VerifyStatementPrettyRoundtrip(t *testing.T, sql string) {
 	}
 	for i := range stmts {
 		origStmt := stmts[i].AST
-		verifyStatementPrettyRoundTrip(t, sql, origStmt, false /* plpgsql */)
+		verifyStatementPrettyRoundTrip(t, sql, origStmt, SQL)
 
 		// Verify that the AST can be walked.
 		if _, err := tree.SimpleStmtVisit(
@@ -39,7 +39,7 @@ func VerifyStatementPrettyRoundtrip(t *testing.T, sql string) {
 // verifyStatementPrettyRoundTrip verifies that a SQL or PL/pgSQL statement
 // correctly round trips through the pretty printer.
 func verifyStatementPrettyRoundTrip(
-	t *testing.T, sql string, origStmt tree.NodeFormatter, plpgsql bool,
+	t *testing.T, sql string, origStmt tree.NodeFormatter, p Parser,
 ) {
 	t.Helper()
 	// Dataflow of the statement through these checks:
@@ -83,7 +83,7 @@ func verifyStatementPrettyRoundTrip(
 	if err != nil {
 		t.Fatalf("%s: %s", err, prettyStmt)
 	}
-	parsedPretty, err := parseOne(t, prettyStmt, plpgsql)
+	parsedPretty, err := parseOne(t, prettyStmt, p)
 	if err != nil {
 		t.Fatalf("%s: %s", err, prettyStmt)
 	}
@@ -93,7 +93,7 @@ func verifyStatementPrettyRoundTrip(
 		// Type annotations and unicode strings don't round trip well. Sometimes we
 		// need to reparse the original formatted output and format that for these
 		// to match.
-		reparsedStmt, err := parseOne(t, origFormatted, plpgsql)
+		reparsedStmt, err := parseOne(t, origFormatted, p)
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
Previously, only SQL and PLpgSQL parsers were supported, but in the future there may be others. This PR makes `sqlutils` parsing functions more easily extendable.

Epic: None
Release note: None