### PR TITLE
vecindex: allow opaque bytes to be associated with a vector

### DIFF
--- a/pkg/cmd/vecbench/main.go
+++ b/pkg/cmd/vecbench/main.go
@@ -217,13 +217,13 @@ func searchIndex(ctx context.Context, stopper *stop.Stopper, datasetName string)
 			}
 			results := searchSet.PopResults()
 
-			prediction := make([]vecstore.PrimaryKey, searchSet.MaxResults)
+			prediction := make([]vecstore.KeyBytes, searchSet.MaxResults)
 			for res := 0; res < len(results); res++ {
-				prediction[res] = results[res].ChildKey.PrimaryKey
+				prediction[res] = results[res].ChildKey.KeyBytes
 			}
 
 			primaryKeys := make([]byte, searchSet.MaxResults*4)
-			truth := make([]vecstore.PrimaryKey, searchSet.MaxResults)
+			truth := make([]vecstore.KeyBytes, searchSet.MaxResults)
 			for neighbor := 0; neighbor < searchSet.MaxResults; neighbor++ {
 				primaryKey := primaryKeys[neighbor*4 : neighbor*4+4]
 				binary.BigEndian.PutUint32(primaryKey, uint32(data.Neighbors[i][neighbor]))
@@ -592,7 +592,7 @@ func commitTransaction(ctx context.Context, store vecstore.Store, txn vecstore.T
 // results with the true set of results. Both sets are expected to be of equal
 // length. It returns the percentage overlap of the predicted set with the truth
 // set.
-func findMAP(prediction, truth []vecstore.PrimaryKey) float64 {
+func findMAP(prediction, truth []vecstore.KeyBytes) float64 {
 	if len(prediction) != len(truth) {
 		panic(errors.AssertionFailedf("prediction and truth sets are not same length"))
 	}

--- a/pkg/sql/rowenc/valueside/decode.go
+++ b/pkg/sql/rowenc/valueside/decode.go
@@ -224,7 +224,7 @@ func DecodeUntaggedDatum(
 		if err != nil {
 			return nil, b, err
 		}
-		vec, err := vector.Decode(data)
+		_, vec, err := vector.Decode(data)
 		if err != nil {
 			return nil, b, err
 		}

--- a/pkg/sql/rowenc/valueside/legacy.go
+++ b/pkg/sql/rowenc/valueside/legacy.go
@@ -432,7 +432,7 @@ func UnmarshalLegacy(a *tree.DatumAlloc, typ *types.T, value roachpb.Value) (tre
 		if err != nil {
 			return nil, err
 		}
-		vec, err := vector.Decode(v)
+		_, vec, err := vector.Decode(v)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/sql/vecindex/fixup_processor.go
+++ b/pkg/sql/vecindex/fixup_processor.go
@@ -56,7 +56,7 @@ type fixup struct {
 	// partition, if the fixup operates on a partition
 	ParentPartitionKey vecstore.PartitionKey
 	// VectorKey is the primary key of the fixup vector.
-	VectorKey vecstore.PrimaryKey
+	VectorKey vecstore.KeyBytes
 }
 
 // FixupProcessor applies index fixups in a background goroutine. Fixups repair
@@ -236,7 +236,7 @@ func (fp *FixupProcessor) AddMerge(
 
 // AddDeleteVector enqueues a vector deletion fixup for later processing.
 func (fp *FixupProcessor) AddDeleteVector(
-	ctx context.Context, partitionKey vecstore.PartitionKey, vectorKey vecstore.PrimaryKey,
+	ctx context.Context, partitionKey vecstore.PartitionKey, vectorKey vecstore.KeyBytes,
 ) {
 	fp.addFixup(ctx, fixup{
 		Type:         vectorDeleteFixup,

--- a/pkg/sql/vecindex/fixup_worker_test.go
+++ b/pkg/sql/vecindex/fixup_worker_test.go
@@ -49,13 +49,16 @@ func TestSplitPartitionData(t *testing.T) {
 		quantizer,
 		quantizedSet,
 		[]vecstore.ChildKey{
-			{PrimaryKey: vecstore.PrimaryKey("vec1")},
-			{PrimaryKey: vecstore.PrimaryKey("vec2")},
-			{PrimaryKey: vecstore.PrimaryKey("vec3")},
-			{PrimaryKey: vecstore.PrimaryKey("vec4")},
-			{PrimaryKey: vecstore.PrimaryKey("vec5")},
-			{PrimaryKey: vecstore.PrimaryKey("vec6")},
-			{PrimaryKey: vecstore.PrimaryKey("vec7")},
+			{KeyBytes: vecstore.KeyBytes("vec1")},
+			{KeyBytes: vecstore.KeyBytes("vec2")},
+			{KeyBytes: vecstore.KeyBytes("vec3")},
+			{KeyBytes: vecstore.KeyBytes("vec4")},
+			{KeyBytes: vecstore.KeyBytes("vec5")},
+			{KeyBytes: vecstore.KeyBytes("vec6")},
+			{KeyBytes: vecstore.KeyBytes("vec7")},
+		},
+		[]vecstore.ValueBytes{
+			{1, 2}, {3, 4}, {5, 6}, {7, 8}, {9, 10}, {11, 12}, {13, 14},
 		},
 		1)
 
@@ -76,6 +79,7 @@ func TestSplitPartitionData(t *testing.T) {
 			require.Equal(t, 0, cmp)
 			require.Equal(t, oldCentroidDistances[offset], split.OldCentroidDistances[i])
 			require.Equal(t, splitPartition.ChildKeys()[offset], split.Partition.ChildKeys()[i])
+			require.Equal(t, splitPartition.ValueBytes()[offset], split.Partition.ValueBytes()[i])
 
 			// Validate centroid distances.
 			expectedDistance := num32.L2Distance(centroid, split.Vectors.At(i))

--- a/pkg/sql/vecindex/split_data.go
+++ b/pkg/sql/vecindex/split_data.go
@@ -35,12 +35,13 @@ func (s *splitData) Init(
 	vectors vector.Set,
 	oldCentroidDistances []float32,
 	childKeys []vecstore.ChildKey,
+	valueBytes []vecstore.ValueBytes,
 	level vecstore.Level,
 ) {
 	s.Vectors = vectors
 	s.OldCentroidDistances = oldCentroidDistances
 	quantizedSet := quantizer.Quantize(ctx, s.Vectors)
-	s.Partition = vecstore.NewPartition(quantizer, quantizedSet, childKeys, level)
+	s.Partition = vecstore.NewPartition(quantizer, quantizedSet, childKeys, valueBytes, level)
 }
 
 // ReplaceWithLast removes the vector at the given offset in the set, replacing

--- a/pkg/sql/vecindex/vecstore/in_memory_store.go
+++ b/pkg/sql/vecindex/vecstore/in_memory_store.go
@@ -293,7 +293,7 @@ func (s *InMemoryStore) MergeStats(ctx context.Context, stats *IndexStats, skipM
 // InsertVector inserts a new full-size vector into the in-memory store,
 // associated with the given primary key. This mimics inserting a vector into
 // the primary index, and is used during testing and benchmarking.
-func (s *InMemoryStore) InsertVector(key PrimaryKey, vector vector.T) {
+func (s *InMemoryStore) InsertVector(key KeyBytes, vector vector.T) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -303,7 +303,7 @@ func (s *InMemoryStore) InsertVector(key PrimaryKey, vector vector.T) {
 // DeleteVector deletes the vector associated with the given primary key from
 // the in-memory store. This mimics deleting a vector from the primary index,
 // and is used during testing and benchmarking.
-func (s *InMemoryStore) DeleteVector(key PrimaryKey) {
+func (s *InMemoryStore) DeleteVector(key KeyBytes) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -312,7 +312,7 @@ func (s *InMemoryStore) DeleteVector(key PrimaryKey) {
 
 // GetVector returns a single vector from the store, by its primary key. This
 // is used for testing.
-func (s *InMemoryStore) GetVector(key PrimaryKey) vector.T {
+func (s *InMemoryStore) GetVector(key KeyBytes) vector.T {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
@@ -327,7 +327,7 @@ func (s *InMemoryStore) GetAllVectors() []VectorWithKey {
 
 	refs := make([]VectorWithKey, 0, len(s.mu.vectors))
 	for key, vec := range s.mu.vectors {
-		refs = append(refs, VectorWithKey{Key: ChildKey{PrimaryKey: PrimaryKey(key)}, Vector: vec})
+		refs = append(refs, VectorWithKey{Key: ChildKey{KeyBytes: KeyBytes(key)}, Vector: vec})
 	}
 	return refs
 }
@@ -376,7 +376,7 @@ func (s *InMemoryStore) MarshalBinary() (data []byte, err error) {
 
 	// Remap vectors to protobufs.
 	for key, vector := range s.mu.vectors {
-		vectorWithKey := VectorProto{PrimaryKey: []byte(key), Vector: vector}
+		vectorWithKey := VectorProto{KeyBytes: []byte(key), Vector: vector}
 		storeProto.Vectors = append(storeProto.Vectors, vectorWithKey)
 	}
 
@@ -438,7 +438,7 @@ func LoadInMemoryStore(data []byte) (*InMemoryStore, error) {
 	// Insert vectors into the in-memory store.
 	for i := range storeProto.Vectors {
 		vectorProto := storeProto.Vectors[i]
-		inMemStore.mu.vectors[string(vectorProto.PrimaryKey)] = vectorProto.Vector
+		inMemStore.mu.vectors[string(vectorProto.KeyBytes)] = vectorProto.Vector
 	}
 
 	return inMemStore, nil

--- a/pkg/sql/vecindex/vecstore/partition_test.go
+++ b/pkg/sql/vecindex/vecstore/partition_test.go
@@ -31,34 +31,46 @@ func TestPartition(t *testing.T) {
 	childKey40 := ChildKey{PartitionKey: 40}
 	childKey50 := ChildKey{PartitionKey: 50}
 
+	valueBytes10 := ValueBytes{1, 2}
+	valueBytes20 := ValueBytes{3, 4}
+	valueBytes30 := ValueBytes{5, 6}
+	valueBytes40 := ValueBytes{7, 8}
+	valueBytes50 := ValueBytes{9, 10}
+	valueBytes20b := ValueBytes{11, 12}
+
 	// Create new partition and add 4 vectors.
 	quantizer := quantize.NewUnQuantizer(2)
 	vectors := vector.MakeSetFromRawData([]float32{1, 2, 5, 2, 6, 6}, 2)
 	quantizedSet := quantizer.Quantize(ctx, vectors)
 	childKeys := []ChildKey{childKey10, childKey20, childKey30}
-	partition := NewPartition(quantizer, quantizedSet, childKeys, Level(1))
-	require.True(t, partition.Add(ctx, vector.T{4, 3}, childKey40))
+	valueBytes := []ValueBytes{valueBytes10, valueBytes20, valueBytes30, valueBytes40}
+	partition := NewPartition(quantizer, quantizedSet, childKeys, valueBytes, Level(1))
+	require.True(t, partition.Add(ctx, vector.T{4, 3}, childKey40, valueBytes40))
 
 	// Add vector and expect its value to be updated.
-	require.False(t, partition.Add(ctx, vector.T{10, 10}, childKey20))
+	require.False(t, partition.Add(ctx, vector.T{10, 10}, childKey20, valueBytes20b))
 
 	require.Equal(t, 4, partition.Count())
 	require.Equal(t, []ChildKey{childKey10, childKey40, childKey30, childKey20}, partition.ChildKeys())
+	require.Equal(t, []ValueBytes{valueBytes10, valueBytes40, valueBytes30, valueBytes20b}, partition.ValueBytes())
 	require.Equal(t, []float32{4, 3.33}, roundFloats(partition.Centroid(), 2))
 	checkPartitionMetadata(t, partition.Metadata(), Level(1), vector.T{4, 3.33}, 4)
 
 	// Ensure that cloning does not disturb anything.
 	cloned := partition.Clone()
-	cloned.Add(ctx, vector.T{0, -1}, childKey50)
+	cloned.Add(ctx, vector.T{0, -1}, childKey50, valueBytes50)
 
 	// Search method.
 	searchSet := SearchSet{MaxResults: 3}
 	level, count := partition.Search(ctx, RootKey, vector.T{1, 1}, &searchSet)
 	require.Equal(t, Level(1), level)
 	require.Equal(t, 4, count)
-	result1 := SearchResult{QuerySquaredDistance: 1, ErrorBound: 0, CentroidDistance: 3.2830, ParentPartitionKey: 1, ChildKey: childKey10}
-	result2 := SearchResult{QuerySquaredDistance: 13, ErrorBound: 0, CentroidDistance: 0.3333, ParentPartitionKey: 1, ChildKey: childKey40}
-	result3 := SearchResult{QuerySquaredDistance: 50, ErrorBound: 0, CentroidDistance: 3.3333, ParentPartitionKey: 1, ChildKey: childKey30}
+	result1 := SearchResult{
+		QuerySquaredDistance: 1, ErrorBound: 0, CentroidDistance: 3.2830, ParentPartitionKey: 1, ChildKey: childKey10, ValueBytes: valueBytes10}
+	result2 := SearchResult{
+		QuerySquaredDistance: 13, ErrorBound: 0, CentroidDistance: 0.3333, ParentPartitionKey: 1, ChildKey: childKey40, ValueBytes: valueBytes40}
+	result3 := SearchResult{
+		QuerySquaredDistance: 50, ErrorBound: 0, CentroidDistance: 3.3333, ParentPartitionKey: 1, ChildKey: childKey30, ValueBytes: valueBytes30}
 	results := roundResults(searchSet.PopResults(), 4)
 	require.Equal(t, SearchResults{result1, result2, result3}, results)
 
@@ -66,7 +78,7 @@ func TestPartition(t *testing.T) {
 	require.Equal(t, 2, partition.Find(childKey30))
 	require.Equal(t, 1, partition.Find(childKey40))
 	require.Equal(t, 3, partition.Find(childKey20))
-	require.Equal(t, -1, partition.Find(ChildKey{PrimaryKey: []byte{1, 2}}))
+	require.Equal(t, -1, partition.Find(ChildKey{KeyBytes: []byte{1, 2}}))
 
 	// Remove vectors.
 	require.True(t, partition.ReplaceWithLastByKey(childKey20))
@@ -83,6 +95,7 @@ func TestPartition(t *testing.T) {
 	require.Equal(t, 5, cloned.Count())
 	require.Equal(t, Level(1), cloned.Level())
 	require.Equal(t, []ChildKey{childKey10, childKey40, childKey30, childKey20, childKey50}, cloned.ChildKeys())
+	require.Equal(t, []ValueBytes{valueBytes10, valueBytes40, valueBytes30, valueBytes20b, valueBytes50}, cloned.ValueBytes())
 	squaredDistances := []float32{0, 0, 0, 0, 0}
 	errorBounds := []float32{0, 0, 0, 0, 0}
 	cloned.Quantizer().EstimateSquaredDistances(ctx, cloned.QuantizedSet(), vector.T{3, 4}, squaredDistances, errorBounds)

--- a/pkg/sql/vecindex/vecstore/search_set.go
+++ b/pkg/sql/vecindex/vecstore/search_set.go
@@ -49,6 +49,10 @@ type SearchResult struct {
 	// and is only set when SearchOptions.SkipRerank is false or
 	// SearchOptions.ReturnVectors is true.
 	Vector vector.T
+	// ValueBytes are the opaque bytes stored alongside the quantized vector.
+	// Depending on the store, this could be empty, or it could contain
+	// information associated with the vector, such as STORING columns.
+	ValueBytes []byte
 }
 
 // MaybeCloser returns true if this result's data vector may be closer (or the
@@ -175,7 +179,7 @@ type SearchSet struct {
 
 	// MatchKey, if non-nil, filters out all search candidates that do not have
 	// a matching primary key.
-	MatchKey PrimaryKey
+	MatchKey KeyBytes
 
 	// Stats tracks useful information about the search, such as how many vectors
 	// and partitions were scanned.
@@ -189,7 +193,7 @@ type SearchSet struct {
 // Add includes a new candidate in the search set. If set limits have been
 // reached, then the candidate with the farthest distance will be discarded.
 func (ss *SearchSet) Add(candidate *SearchResult) {
-	if ss.MatchKey != nil && !bytes.Equal(ss.MatchKey, candidate.ChildKey.PrimaryKey) {
+	if ss.MatchKey != nil && !bytes.Equal(ss.MatchKey, candidate.ChildKey.KeyBytes) {
 		// Filter out candidates without a matching primary key.
 		return
 	}

--- a/pkg/sql/vecindex/vecstore/search_set_test.go
+++ b/pkg/sql/vecindex/vecstore/search_set_test.go
@@ -22,35 +22,35 @@ func TestSearchResult(t *testing.T) {
 		ErrorBound:           0.5,
 		CentroidDistance:     10,
 		ParentPartitionKey:   100,
-		ChildKey:             ChildKey{PrimaryKey: []byte{10}},
+		ChildKey:             ChildKey{KeyBytes: []byte{10}},
 	}
 	r2 := SearchResult{
 		QuerySquaredDistance: 2,
 		ErrorBound:           0,
 		CentroidDistance:     20,
 		ParentPartitionKey:   200,
-		ChildKey:             ChildKey{PrimaryKey: []byte{20}},
+		ChildKey:             ChildKey{KeyBytes: []byte{20}},
 	}
 	r3 := SearchResult{
 		QuerySquaredDistance: 2,
 		ErrorBound:           1,
 		CentroidDistance:     20,
 		ParentPartitionKey:   200,
-		ChildKey:             ChildKey{PrimaryKey: []byte{30}},
+		ChildKey:             ChildKey{KeyBytes: []byte{30}},
 	}
 	r4 := SearchResult{
 		QuerySquaredDistance: 2,
 		ErrorBound:           1,
 		CentroidDistance:     30,
 		ParentPartitionKey:   300,
-		ChildKey:             ChildKey{PrimaryKey: []byte{40}},
+		ChildKey:             ChildKey{KeyBytes: []byte{40}},
 	}
 	r5 := SearchResult{
 		QuerySquaredDistance: 4,
 		ErrorBound:           1,
 		CentroidDistance:     30,
 		ParentPartitionKey:   300,
-		ChildKey:             ChildKey{PrimaryKey: []byte{40}},
+		ChildKey:             ChildKey{KeyBytes: []byte{40}},
 	}
 
 	// MaybeCloser.
@@ -101,13 +101,13 @@ func TestSearchSet(t *testing.T) {
 
 	// Exceed max results, outside of error bounds.
 	result1 := SearchResult{
-		QuerySquaredDistance: 3, ErrorBound: 0.5, CentroidDistance: 10, ParentPartitionKey: 100, ChildKey: ChildKey{PrimaryKey: []byte{10}}}
+		QuerySquaredDistance: 3, ErrorBound: 0.5, CentroidDistance: 10, ParentPartitionKey: 100, ChildKey: ChildKey{KeyBytes: []byte{10}}}
 	result2 := SearchResult{
-		QuerySquaredDistance: 6, ErrorBound: 1, CentroidDistance: 20, ParentPartitionKey: 200, ChildKey: ChildKey{PrimaryKey: []byte{20}}}
+		QuerySquaredDistance: 6, ErrorBound: 1, CentroidDistance: 20, ParentPartitionKey: 200, ChildKey: ChildKey{KeyBytes: []byte{20}}}
 	result3 := SearchResult{
-		QuerySquaredDistance: 1, ErrorBound: 0.5, CentroidDistance: 30, ParentPartitionKey: 300, ChildKey: ChildKey{PrimaryKey: []byte{30}}}
+		QuerySquaredDistance: 1, ErrorBound: 0.5, CentroidDistance: 30, ParentPartitionKey: 300, ChildKey: ChildKey{KeyBytes: []byte{30}}}
 	result4 := SearchResult{
-		QuerySquaredDistance: 4, ErrorBound: 0.5, CentroidDistance: 40, ParentPartitionKey: 400, ChildKey: ChildKey{PrimaryKey: []byte{40}}}
+		QuerySquaredDistance: 4, ErrorBound: 0.5, CentroidDistance: 40, ParentPartitionKey: 400, ChildKey: ChildKey{KeyBytes: []byte{40}}}
 	searchSet.Add(&result1)
 	searchSet.Add(&result2)
 	searchSet.Add(&result3)
@@ -116,9 +116,9 @@ func TestSearchSet(t *testing.T) {
 
 	// Exceed max results, but within error bounds.
 	result5 := SearchResult{
-		QuerySquaredDistance: 6, ErrorBound: 1.5, CentroidDistance: 50, ParentPartitionKey: 500, ChildKey: ChildKey{PrimaryKey: []byte{50}}}
+		QuerySquaredDistance: 6, ErrorBound: 1.5, CentroidDistance: 50, ParentPartitionKey: 500, ChildKey: ChildKey{KeyBytes: []byte{50}}}
 	result6 := SearchResult{
-		QuerySquaredDistance: 5, ErrorBound: 1, CentroidDistance: 60, ParentPartitionKey: 600, ChildKey: ChildKey{PrimaryKey: []byte{60}}}
+		QuerySquaredDistance: 5, ErrorBound: 1, CentroidDistance: 60, ParentPartitionKey: 600, ChildKey: ChildKey{KeyBytes: []byte{60}}}
 	searchSet.AddAll(SearchResults{result1, result2, result3, result4, result5, result6})
 	require.Equal(t, SearchResults{result3, result1, result4, result6, result5}, searchSet.PopResults())
 
@@ -129,12 +129,12 @@ func TestSearchSet(t *testing.T) {
 
 	// Add better results that invalidate farther candidates.
 	result7 := SearchResult{
-		QuerySquaredDistance: 4, ErrorBound: 1.5, CentroidDistance: 70, ParentPartitionKey: 700, ChildKey: ChildKey{PrimaryKey: []byte{70}}}
+		QuerySquaredDistance: 4, ErrorBound: 1.5, CentroidDistance: 70, ParentPartitionKey: 700, ChildKey: ChildKey{KeyBytes: []byte{70}}}
 	searchSet.AddAll(SearchResults{result1, result2, result3, result4, result5, result6, result7})
 	require.Equal(t, SearchResults{result3, result1, result4, result7, result6, result5}, searchSet.PopResults())
 
 	result8 := SearchResult{
-		QuerySquaredDistance: 0.5, ErrorBound: 0.5, CentroidDistance: 80, ParentPartitionKey: 800, ChildKey: ChildKey{PrimaryKey: []byte{80}}}
+		QuerySquaredDistance: 0.5, ErrorBound: 0.5, CentroidDistance: 80, ParentPartitionKey: 800, ChildKey: ChildKey{KeyBytes: []byte{80}}}
 	searchSet.AddAll(SearchResults{result1, result2, result3, result4})
 	searchSet.AddAll(SearchResults{result5, result6, result7, result8})
 	require.Equal(t, SearchResults{result8, result3, result1, result4, result7}, searchSet.PopResults())

--- a/pkg/sql/vecindex/vecstore/store.go
+++ b/pkg/sql/vecindex/vecstore/store.go
@@ -113,15 +113,19 @@ type Txn interface {
 		ctx context.Context, partitionKey PartitionKey, forUpdate bool,
 	) (PartitionMetadata, error)
 
-	// AddToPartition adds the given vector and its associated child key to the
-	// partition with the given key. If the vector already exists, it is
-	// overwritten with the new key. AddToPartition returns the partition's
+	// AddToPartition adds the given vector and its associated child key and value
+	// bytes to the partition with the given key. If the vector already exists, it
+	// is overwritten with the new key. AddToPartition returns the partition's
 	// metadata, reflecting its size after the add operation. It returns
 	// ErrPartitionNotFound if the partition cannot be found, or
 	// ErrRestartOperation if the caller should retry the insert operation that
 	// triggered this call.
 	AddToPartition(
-		ctx context.Context, partitionKey PartitionKey, vector vector.T, childKey ChildKey,
+		ctx context.Context,
+		partitionKey PartitionKey,
+		vector vector.T,
+		childKey ChildKey,
+		valueBytes ValueBytes,
 	) (PartitionMetadata, error)
 
 	// RemoveFromPartition removes the given vector and its associated child key

--- a/pkg/sql/vecindex/vecstore/store_test.go
+++ b/pkg/sql/vecindex/vecstore/store_test.go
@@ -19,16 +19,23 @@ func commonStoreTests(
 	t *testing.T,
 	store Store,
 	quantizer quantize.Quantizer,
-	testPKs []PrimaryKey,
+	testPKs []KeyBytes,
 	testVectors []vector.T,
 ) {
 	childKey2 := ChildKey{PartitionKey: 2}
-	primaryKey100 := ChildKey{PrimaryKey: PrimaryKey{1, 00}}
-	primaryKey200 := ChildKey{PrimaryKey: PrimaryKey{2, 00}}
-	primaryKey300 := ChildKey{PrimaryKey: PrimaryKey{3, 00}}
-	primaryKey400 := ChildKey{PrimaryKey: PrimaryKey{4, 00}}
-	primaryKey500 := ChildKey{PrimaryKey: PrimaryKey{5, 00}}
-	primaryKey600 := ChildKey{PrimaryKey: PrimaryKey{6, 00}}
+	valueBytes2 := ValueBytes{0}
+	primaryKey100 := ChildKey{KeyBytes: KeyBytes{1, 00}}
+	primaryKey200 := ChildKey{KeyBytes: KeyBytes{2, 00}}
+	primaryKey300 := ChildKey{KeyBytes: KeyBytes{3, 00}}
+	primaryKey400 := ChildKey{KeyBytes: KeyBytes{4, 00}}
+	primaryKey500 := ChildKey{KeyBytes: KeyBytes{5, 00}}
+	primaryKey600 := ChildKey{KeyBytes: KeyBytes{6, 00}}
+	valueBytes100 := ValueBytes{1, 2}
+	valueBytes200 := ValueBytes{3, 4}
+	valueBytes300 := ValueBytes{5, 6}
+	valueBytes400 := ValueBytes{7, 8}
+	valueBytes500 := ValueBytes{9, 10}
+	valueBytes600 := ValueBytes{11, 12}
 
 	t.Run("get full vectors", func(t *testing.T) {
 		txn := beginTransaction(ctx, t, store)
@@ -36,11 +43,11 @@ func commonStoreTests(
 
 		// Include primary keys that cannot be found.
 		results := []VectorWithKey{
-			{Key: ChildKey{PrimaryKey: testPKs[0]}},
-			{Key: ChildKey{PrimaryKey: PrimaryKey{0}}},
-			{Key: ChildKey{PrimaryKey: testPKs[1]}},
-			{Key: ChildKey{PrimaryKey: PrimaryKey{0}}},
-			{Key: ChildKey{PrimaryKey: testPKs[0]}},
+			{Key: ChildKey{KeyBytes: testPKs[0]}},
+			{Key: ChildKey{KeyBytes: KeyBytes{0}}},
+			{Key: ChildKey{KeyBytes: testPKs[1]}},
+			{Key: ChildKey{KeyBytes: KeyBytes{0}}},
+			{Key: ChildKey{KeyBytes: testPKs[0]}},
 		}
 		err := txn.GetFullVectors(ctx, results)
 		require.NoError(t, err)
@@ -52,12 +59,12 @@ func commonStoreTests(
 
 		// Grab another set of vectors to ensure that saved state is properly reset.
 		results = []VectorWithKey{
-			{Key: ChildKey{PrimaryKey: PrimaryKey{0}}},
-			{Key: ChildKey{PrimaryKey: testPKs[0]}},
-			{Key: ChildKey{PrimaryKey: PrimaryKey{0}}},
-			{Key: ChildKey{PrimaryKey: testPKs[1]}},
-			{Key: ChildKey{PrimaryKey: PrimaryKey{0}}},
-			{Key: ChildKey{PrimaryKey: testPKs[1]}},
+			{Key: ChildKey{KeyBytes: KeyBytes{0}}},
+			{Key: ChildKey{KeyBytes: testPKs[0]}},
+			{Key: ChildKey{KeyBytes: KeyBytes{0}}},
+			{Key: ChildKey{KeyBytes: testPKs[1]}},
+			{Key: ChildKey{KeyBytes: KeyBytes{0}}},
+			{Key: ChildKey{KeyBytes: testPKs[1]}},
 		}
 		err = txn.GetFullVectors(ctx, results)
 		require.NoError(t, err)
@@ -98,18 +105,18 @@ func commonStoreTests(
 		checkPartitionMetadata(t, metadata, Level(1), vector.T{0, 0}, 0)
 
 		// Add to root partition.
-		metadata, err = txn.AddToPartition(ctx, RootKey, vector.T{1, 2}, primaryKey100)
+		metadata, err = txn.AddToPartition(ctx, RootKey, vector.T{1, 2}, primaryKey100, valueBytes100)
 		require.NoError(t, err)
 		checkPartitionMetadata(t, metadata, LeafLevel, vector.T{0, 0}, 1)
-		metadata, err = txn.AddToPartition(ctx, RootKey, vector.T{7, 4}, primaryKey200)
+		metadata, err = txn.AddToPartition(ctx, RootKey, vector.T{7, 4}, primaryKey200, valueBytes200)
 		require.NoError(t, err)
 		checkPartitionMetadata(t, metadata, LeafLevel, vector.T{0, 0}, 2)
-		metadata, err = txn.AddToPartition(ctx, RootKey, vector.T{4, 3}, primaryKey300)
+		metadata, err = txn.AddToPartition(ctx, RootKey, vector.T{4, 3}, primaryKey300, valueBytes300)
 		require.NoError(t, err)
 		checkPartitionMetadata(t, metadata, LeafLevel, vector.T{0, 0}, 3)
 
 		// Add duplicate and expect value to be overwritten
-		metadata, err = txn.AddToPartition(ctx, RootKey, vector.T{5, 5}, primaryKey300)
+		metadata, err = txn.AddToPartition(ctx, RootKey, vector.T{5, 5}, primaryKey300, valueBytes300)
 		require.NoError(t, err)
 		checkPartitionMetadata(t, metadata, LeafLevel, vector.T{0, 0}, 3)
 
@@ -120,8 +127,10 @@ func commonStoreTests(
 			ctx, []PartitionKey{RootKey}, vector.T{1, 1}, &searchSet, partitionCounts)
 		require.NoError(t, err)
 		require.Equal(t, Level(1), level)
-		result1 := SearchResult{QuerySquaredDistance: 1, ErrorBound: 0, CentroidDistance: 2.2361, ParentPartitionKey: 1, ChildKey: primaryKey100}
-		result2 := SearchResult{QuerySquaredDistance: 32, ErrorBound: 0, CentroidDistance: 7.0711, ParentPartitionKey: 1, ChildKey: primaryKey300}
+		result1 := SearchResult{
+			QuerySquaredDistance: 1, ErrorBound: 0, CentroidDistance: 2.2361, ParentPartitionKey: 1, ChildKey: primaryKey100, ValueBytes: valueBytes100}
+		result2 := SearchResult{
+			QuerySquaredDistance: 32, ErrorBound: 0, CentroidDistance: 7.0711, ParentPartitionKey: 1, ChildKey: primaryKey300, ValueBytes: valueBytes300}
 		results := searchSet.PopResults()
 		roundResults(results, 4)
 		require.Equal(t, SearchResults{result1, result2}, results)
@@ -144,13 +153,14 @@ func commonStoreTests(
 		require.NoError(t, err)
 		require.Equal(t, Level(1), root.Level())
 		require.Equal(t, []ChildKey{primaryKey100, primaryKey200, primaryKey300}, root.ChildKeys())
+		require.Equal(t, []ValueBytes{valueBytes100, valueBytes200, valueBytes300}, root.ValueBytes())
 		require.Equal(t, vector.T{0, 0}, root.Centroid())
 
 		// Get partition centroid + full vectors.
 		results := []VectorWithKey{
 			{Key: ChildKey{PartitionKey: RootKey}},
-			{Key: ChildKey{PrimaryKey: testPKs[0]}},
-			{Key: ChildKey{PrimaryKey: PrimaryKey{0}}},
+			{Key: ChildKey{KeyBytes: testPKs[0]}},
+			{Key: ChildKey{KeyBytes: KeyBytes{0}}},
 		}
 		err = txn.GetFullVectors(ctx, results)
 		require.NoError(t, err)
@@ -173,12 +183,14 @@ func commonStoreTests(
 		require.NoError(t, err)
 		vectors := vector.T{4, 3}.AsSet()
 		quantizedSet := quantizer.Quantize(ctx, vectors)
-		newRoot := NewPartition(quantizer, quantizedSet, []ChildKey{childKey2}, Level(2))
+		newRoot := NewPartition(
+			quantizer, quantizedSet, []ChildKey{childKey2}, []ValueBytes{valueBytes2}, Level(2))
 		require.NoError(t, txn.SetRootPartition(ctx, newRoot))
 		newRoot, err = txn.GetPartition(ctx, RootKey)
 		require.NoError(t, err)
 		require.Equal(t, Level(2), newRoot.Level())
 		require.Equal(t, []ChildKey{childKey2}, newRoot.ChildKeys())
+		require.Equal(t, []ValueBytes{valueBytes2}, newRoot.ValueBytes())
 
 		searchSet := SearchSet{MaxResults: 2}
 		partitionCounts := []int{0}
@@ -186,7 +198,8 @@ func commonStoreTests(
 			ctx, []PartitionKey{RootKey}, vector.T{2, 2}, &searchSet, partitionCounts)
 		require.NoError(t, err)
 		require.Equal(t, Level(2), level)
-		result3 := SearchResult{QuerySquaredDistance: 5, ErrorBound: 0, CentroidDistance: 0, ParentPartitionKey: 1, ChildKey: childKey2}
+		result3 := SearchResult{
+			QuerySquaredDistance: 5, ErrorBound: 0, CentroidDistance: 0, ParentPartitionKey: 1, ChildKey: childKey2, ValueBytes: valueBytes2}
 		require.Equal(t, SearchResults{result3}, searchSet.PopResults())
 		require.Equal(t, 1, partitionCounts[0])
 
@@ -215,10 +228,12 @@ func commonStoreTests(
 		checkPartitionMetadata(t, metadata, LeafLevel, vector.T{0, 0}, 2)
 
 		// Add an alternate element and add duplicate, expecting value to be overwritten.
-		metadata, err = txn.AddToPartition(ctx, partitionKey1, vector.T{-1, 0}, primaryKey400)
+		metadata, err = txn.AddToPartition(
+			ctx, partitionKey1, vector.T{-1, 0}, primaryKey400, valueBytes400)
 		require.NoError(t, err)
 		checkPartitionMetadata(t, metadata, LeafLevel, vector.T{0, 0}, 3)
-		metadata, err = txn.AddToPartition(ctx, partitionKey1, vector.T{1, 1}, primaryKey400)
+		metadata, err = txn.AddToPartition(
+			ctx, partitionKey1, vector.T{1, 1}, primaryKey400, valueBytes400)
 		require.NoError(t, err)
 		checkPartitionMetadata(t, metadata, LeafLevel, vector.T{0, 0}, 3)
 
@@ -228,8 +243,10 @@ func commonStoreTests(
 			ctx, []PartitionKey{partitionKey1}, vector.T{1, 1}, &searchSet, partitionCounts)
 		require.NoError(t, err)
 		require.Equal(t, Level(1), level)
-		result4 := SearchResult{QuerySquaredDistance: 0, ErrorBound: 0, CentroidDistance: 1.4142, ParentPartitionKey: partitionKey1, ChildKey: primaryKey400}
-		result5 := SearchResult{QuerySquaredDistance: 1, ErrorBound: 0, CentroidDistance: 2.2361, ParentPartitionKey: partitionKey1, ChildKey: primaryKey100}
+		result4 := SearchResult{
+			QuerySquaredDistance: 0, ErrorBound: 0, CentroidDistance: 1.4142, ParentPartitionKey: partitionKey1, ChildKey: primaryKey400, ValueBytes: valueBytes400}
+		result5 := SearchResult{
+			QuerySquaredDistance: 1, ErrorBound: 0, CentroidDistance: 2.2361, ParentPartitionKey: partitionKey1, ChildKey: primaryKey100, ValueBytes: valueBytes100}
 		require.Equal(t, SearchResults{result4, result5}, roundResults(searchSet.PopResults(), 4))
 		require.Equal(t, 3, partitionCounts[0])
 	})
@@ -245,7 +262,9 @@ func commonStoreTests(
 		vectors.Add(vector.T{4, -1})
 		vectors.Add(vector.T{2, 8})
 		quantizedSet := quantizer.Quantize(ctx, vectors)
-		partition := NewPartition(quantizer, quantizedSet, []ChildKey{primaryKey500, primaryKey600}, LeafLevel)
+		partition := NewPartition(
+			quantizer, quantizedSet, []ChildKey{primaryKey500, primaryKey600},
+			[]ValueBytes{valueBytes500, valueBytes600}, LeafLevel)
 		partitionKey2, err := txn.InsertPartition(ctx, partition)
 		require.NoError(t, err)
 
@@ -255,8 +274,10 @@ func commonStoreTests(
 			ctx, []PartitionKey{partitionKey1, partitionKey2}, vector.T{3, 1}, &searchSet, partitionCounts)
 		require.NoError(t, err)
 		require.Equal(t, Level(1), level)
-		result4 := SearchResult{QuerySquaredDistance: 4, ErrorBound: 0, CentroidDistance: 1.41, ParentPartitionKey: partitionKey1, ChildKey: primaryKey400}
-		result5 := SearchResult{QuerySquaredDistance: 5, ErrorBound: 0, CentroidDistance: 2.24, ParentPartitionKey: partitionKey1, ChildKey: primaryKey100}
+		result4 := SearchResult{
+			QuerySquaredDistance: 4, ErrorBound: 0, CentroidDistance: 1.41, ParentPartitionKey: partitionKey1, ChildKey: primaryKey400, ValueBytes: valueBytes400}
+		result5 := SearchResult{
+			QuerySquaredDistance: 5, ErrorBound: 0, CentroidDistance: 2.24, ParentPartitionKey: partitionKey1, ChildKey: primaryKey100, ValueBytes: valueBytes100}
 		require.Equal(t, SearchResults{result4, result5}, roundResults(searchSet.PopResults(), 2))
 		require.Equal(t, []int{3, 2}, partitionCounts)
 	})

--- a/pkg/sql/vecindex/vecstore/vecstore.proto
+++ b/pkg/sql/vecindex/vecstore/vecstore.proto
@@ -20,9 +20,10 @@ message ChildKey {
   // PartitionKey references a child partition in the next lower level of the
   // K-means tree. This field is only set in branch/root partitions.
   uint64 partition_key = 1 [(gogoproto.casttype) = "PartitionKey"];
-  // PrimaryKey is the primary key of the row in the primary index that stores
-  // the original full-size vector. This field is only set in leaf partitions.
-  bytes primary_key = 2 [(gogoproto.casttype) = "PrimaryKey"];
+  // KeyBytes references a row in the primary index that stores the original
+  // full-size vector. Its format is store-dependent and typically contains part
+  // or all of the row's primary key. This field is only set in leaf partitions.
+  bytes key_bytes = 2 [(gogoproto.casttype) = "KeyBytes"];
 }
 
 // CVStats track coefficient of variation statistics that measure the "spread"
@@ -69,8 +70,8 @@ message PartitionProto {
   uint64 level = 5 [(gogoproto.casttype) = "Level"];
 }
 
-// Vector serializes an original, full-size vector and its primary key.
+// Vector serializes an original, full-size vector and its key bytes.
 message VectorProto {
-  bytes primary_key = 1 [(gogoproto.casttype) = "PrimaryKey"];
+  bytes key_bytes = 1 [(gogoproto.casttype) = "KeyBytes"];
   repeated float vector = 2;
 }

--- a/pkg/sql/vecindex/vecstore/vecstorepb.go
+++ b/pkg/sql/vecindex/vecstore/vecstorepb.go
@@ -41,15 +41,15 @@ func (s *IndexStats) String() string {
 // Equal returns true if this key has the same partition key and primary key as
 // the given key.
 func (k ChildKey) Equal(other ChildKey) bool {
-	return k.PartitionKey == other.PartitionKey && bytes.Equal(k.PrimaryKey, other.PrimaryKey)
+	return k.PartitionKey == other.PartitionKey && bytes.Equal(k.KeyBytes, other.KeyBytes)
 }
 
 // Compare returns an integer comparing two child keys. The result is zero if
 // the two are equal, -1 if this key is less than the other, and +1 if this key
 // is greater than the other.
 func (k ChildKey) Compare(other ChildKey) int {
-	if k.PrimaryKey != nil {
-		return bytes.Compare(k.PrimaryKey, other.PrimaryKey)
+	if k.KeyBytes != nil {
+		return bytes.Compare(k.KeyBytes, other.KeyBytes)
 	}
 	if k.PartitionKey < other.PartitionKey {
 		return -1

--- a/pkg/sql/vecindex/vecstore/vecstorepb_test.go
+++ b/pkg/sql/vecindex/vecstore/vecstorepb_test.go
@@ -69,9 +69,9 @@ func TestChildKey(t *testing.T) {
 
 	childKey1 := ChildKey{PartitionKey: 10}
 	childKey2 := ChildKey{PartitionKey: 20}
-	childKey3 := ChildKey{PrimaryKey: []byte{1, 2, 3}}
-	childKey4 := ChildKey{PrimaryKey: []byte{1, 10, 3}}
-	childKey5 := ChildKey{PartitionKey: 10, PrimaryKey: []byte{1, 10, 3}}
+	childKey3 := ChildKey{KeyBytes: []byte{1, 2, 3}}
+	childKey4 := ChildKey{KeyBytes: []byte{1, 10, 3}}
+	childKey5 := ChildKey{PartitionKey: 10, KeyBytes: []byte{1, 10, 3}}
 
 	// Equal method.
 	require.True(t, childKey1.Equal(childKey1))

--- a/pkg/util/vector/vector.go
+++ b/pkg/util/vector/vector.go
@@ -121,21 +121,21 @@ func Encode(appendTo []byte, t T) ([]byte, error) {
 	return appendTo, nil
 }
 
-// Decode decodes the byte array into a vector.
-func Decode(b []byte) (ret T, err error) {
+// Decode decodes the byte array into a vector and returns any remaining bytes.
+func Decode(b []byte) (remaining []byte, ret T, err error) {
 	var n uint32
 	b, n, err = encoding.DecodeUint32Ascending(b)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 	ret = make(T, n)
 	for i := range ret {
 		b, ret[i], err = encoding.DecodeUntaggedFloat32Value(b)
 		if err != nil {
-			return nil, err
+			return nil, nil, err
 		}
 	}
-	return ret, nil
+	return b, ret, nil
 }
 
 // L1Distance returns the L1 (Manhattan) distance between t and t2.

--- a/pkg/util/vector/vector_test.go
+++ b/pkg/util/vector/vector_test.go
@@ -65,16 +65,19 @@ func TestParseVector(t *testing.T) {
 
 func TestRoundtripRandomPGVector(t *testing.T) {
 	rng, _ := randutil.NewTestRand()
+	extra := randutil.RandBytes(rng, 10)
 	for i := 0; i < 1000; i++ {
 		v := Random(rng, 1000 /* maxDim */)
 		encoded, err := Encode(nil, v)
 		assert.NoError(t, err)
-		roundtripped, err := Decode(encoded)
+		encoded = append(encoded, extra...)
+		remaining, roundtripped, err := Decode(encoded)
 		assert.NoError(t, err)
 		assert.Equal(t, v.String(), roundtripped.String())
+		assert.Equal(t, extra, remaining)
 		reEncoded, err := Encode(nil, roundtripped)
 		assert.NoError(t, err)
-		assert.Equal(t, encoded, reEncoded)
+		assert.Equal(t, encoded, append(reEncoded, extra...))
 	}
 }
 


### PR DESCRIPTION
Previously, the vector library returned only the primary keys of matching vectors from searches. There were two issues with this:

  1. CRDB doesn't always need the full primary key, but sometimes only parts of it.
  2. CRDB sometimes also needs to store additional bytes alongside the quantized vector, e.g. for composite data types in the key.

This commit renames PrimaryKey to be PrimaryBytes, in order to make it more clear that this doesn't need to be the full primary key - it's up to the library caller. This commit also adds the concept of ValueBytes, which are additional bytes that are stored alongside the quantized vectors and are now returned from searches. The vector library treats these bytes as opaque.

Epic: CRDB-42943

Release note: None