### PR TITLE
docgen: update DO statement diagram

### DIFF
--- a/docs/generated/sql/bnf/do.bnf
+++ b/docs/generated/sql/bnf/do.bnf
@@ -1,3 +1,2 @@
 do_stmt ::=
-	'DO'  ( ( (  | 'LANGUAGE' ( 'PLPGSQL' ) routine_body_str ) ) )*
-	| 'DO' 'LANGUAGE' ( 'PLPGSQL' ) routine_body_str ( ( (  | 'LANGUAGE' ( 'PLPGSQL' ) routine_body_str ) ) )*
+	'DO' ( ( ( 'LANGUAGE' 'PLPGSQL'  | routine_body_str ) ) ( ( ( 'LANGUAGE' 'PLPGSQL'  | routine_body_str ) ) )* )

--- a/pkg/cmd/docgen/diagrams.go
+++ b/pkg/cmd/docgen/diagrams.go
@@ -669,10 +669,11 @@ var specs = []stmtSpec{
 		stmt:   "do_stmt",
 		inline: []string{"do_stmt_opt_list", "do_stmt_opt_item"},
 		replace: map[string]string{
-			"'SCONST'":                    "",
-			"non_reserved_word_or_sconst": "( 'PLPGSQL' ) routine_body_str",
+			"'SCONST' | ":                 "",
+			"non_reserved_word_or_sconst": "'PLPGSQL'  | routine_body_str",
 		},
-		unlink: []string{"routine_body_str"},
+		unlink:  []string{"routine_body_str"},
+		nosplit: true,
 	},
 	{
 		name:   "for_locking",


### PR DESCRIPTION
Correct the SQL diagram for `DO` blocks added in #140680. 

In the previous statement, `routine_body_str` could not be placed before `LANGUAGE PLPGSQL`, and an empty `DO`  statement was allowed. The corrected statement:

<img width="374" alt="image" src="https://github.com/user-attachments/assets/21772a89-994b-4836-a79f-09d4d00091bf" />

Epic: none
Release note: none
Release justification: non-production code change