### PR TITLE
stats: use DatumAlloc in `(*SampleReservoir.copyRow)`

### DIFF
--- a/pkg/sql/create_stats_test.go
+++ b/pkg/sql/create_stats_test.go
@@ -7,6 +7,7 @@ package sql_test
 
 import (
 	"context"
+	"strconv"
 	"sync"
 	"testing"
 	"time"
@@ -180,4 +181,51 @@ INSERT INTO system.table_statistics (
 		`SELECT stxrelid::regclass::text, stxname, stxnamespace::regnamespace::text FROM pg_catalog.pg_statistic_ext`,
 		[][]string{{"t", "s", "public"}},
 	)
+}
+
+// BenchmarkAnalyze runs a benchmark for the ANALYZE statement on a
+// sysbench-like table.
+func BenchmarkAnalyze(b *testing.B) {
+	defer log.Scope(b).Close(b)
+	ctx := context.Background()
+
+	s, sqlDB, _ := serverutils.StartServer(b, base.TestServerArgs{})
+	defer s.Stopper().Stop(ctx)
+	stats.AutomaticStatisticsClusterMode.Override(ctx, &s.ClusterSettings().SV, false)
+
+	sqlRunner := sqlutils.MakeSQLRunner(sqlDB)
+	sqlRunner.Exec(b, `
+		CREATE TABLE t (
+			id INT8 PRIMARY KEY,
+			k INT8 NOT NULL DEFAULT 0,
+			c CHAR(120) NOT NULL DEFAULT '',
+			pad CHAR(60) NOT NULL DEFAULT '',
+			INDEX (k)
+		)
+	`)
+
+	const (
+		batchSize = 10_000
+		numRows   = 100_000
+	)
+
+	for i, n := 0, numRows; i < n; i += batchSize {
+		sqlRunner.Exec(b, `
+			INSERT INTO t (id, k, c, pad)
+			SELECT
+				i,
+				(random() * `+strconv.Itoa(numRows)+`)::INT, 
+				substr(md5(random()::TEXT) || md5(random()::TEXT) || md5(random()::TEXT) || md5(random()::TEXT), 0, 120),
+				substr(md5(random()::TEXT) || md5(random()::TEXT), 0, 60)
+			FROM generate_series($1, $2) AS g(i)
+		`, i, i+batchSize-1)
+	}
+
+	// Run a full table scan to resolve intents and reduce variance.
+	sqlRunner.Exec(b, `SELECT count(*) FROM t`)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		sqlRunner.Exec(b, `ANALYZE t`)
+	}
 }

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -407,13 +407,18 @@ func (dsp *DistSQLPlanner) setupFlows(
 	if len(statementSQL) > setupFlowRequestStmtMaxLength {
 		statementSQL = statementSQL[:setupFlowRequestStmtMaxLength]
 	}
-	execVersion := execversion.V24_3
-	if dsp.st.Version.IsActive(ctx, clusterversion.V25_1) {
-		execVersion = execversion.V25_1
+	var v execversion.V
+	switch {
+	case dsp.st.Version.IsActive(ctx, clusterversion.V25_2):
+		v = execversion.V25_2
+	case dsp.st.Version.IsActive(ctx, clusterversion.V25_1):
+		v = execversion.V25_1
+	default:
+		v = execversion.V24_3
 	}
 	setupReq := execinfrapb.SetupFlowRequest{
 		LeafTxnInputState: leafInputState,
-		Version:           execVersion,
+		Version:           v,
 		TraceKV:           evalCtx.Tracing.KVTracingEnabled(),
 		CollectStats:      planCtx.collectExecStats,
 		StatementSQL:      statementSQL,

--- a/pkg/sql/execversion/version.go
+++ b/pkg/sql/execversion/version.go
@@ -25,12 +25,16 @@ const V24_3 = V(71)
 // only be used by the flows once the cluster has upgraded to 25.1.
 const V25_1 = V(72)
 
+// V25_2 is the exec version of all binaries of 25.2 cockroach versions. It can
+// only be used by the flows once the cluster has upgraded to 25.2.
+const V25_2 = V(73)
+
 // MinAccepted is the oldest version that the server is compatible with. A
 // server will not accept flows with older versions.
 const MinAccepted = V24_3
 
 // Latest is the latest exec version supported by this binary.
-const Latest = V25_1
+const Latest = V25_2
 
 var contextVersionKey = ctxutil.RegisterFastValueKey()
 

--- a/pkg/sql/logictest/testdata/logic_test/distsql_stats
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_stats
@@ -3055,23 +3055,32 @@ upper_bound            range_rows  distinct_range_rows  equal_rows
 # Verify that the correct partial predicate is used for partial stats using
 # extremes when outer buckets exist (int column type).
 statement ok
-CREATE TABLE int_outer_buckets (a PRIMARY KEY) AS SELECT generate_series(0, 9999);
+CREATE TABLE int_outer_buckets (a INT PRIMARY KEY)
 
+# Inject a full stats collection with 2 outer buckets with upper bounds of
+# MaxInt64 and MinInt64.
 statement ok
-CREATE STATISTICS int_outer_buckets_full ON a FROM int_outer_buckets;
+ALTER TABLE int_outer_buckets INJECT STATISTICS '[
+  {
+    "name": "int_outer_buckets_full",
+    "columns": ["a"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 10000,
+    "distinct_count": 10000,
+    "null_count": 0,
+    "avg_size": 2,
+    "histo_col_type": "int",
+    "histo_buckets": [
+      {"num_eq": 0, "num_range": 0, "distinct_range": 0, "upper_bound": "-9223372036854775808"},
+      {"num_eq": 1, "num_range": 0, "distinct_range": 0, "upper_bound": "0"},
+      {"num_eq": 1, "num_range": 9998, "distinct_range": 0, "upper_bound": "9999"},
+      {"num_eq": 0, "num_range": 0, "distinct_range": 0, "upper_bound": "9223372036854775807"}
+    ]
+  }
+]'
 
 statement ok
 SELECT crdb_internal.clear_table_stats_cache();
-
-let $hist_id_int_outer_buckets_full
-SELECT histogram_id FROM [SHOW STATISTICS FOR TABLE int_outer_buckets] WHERE statistics_name = 'int_outer_buckets_full'
-
-# The full stats collection should have added 2 outer buckets for a total of 202
-# with upper bounds of MaxInt64 and MinInt64.
-query I
-SELECT count(*) FROM [SHOW HISTOGRAM $hist_id_int_outer_buckets_full]
-----
-202
 
 statement ok
 INSERT INTO int_outer_buckets SELECT generate_series(-10, -1) UNION ALL SELECT generate_series(10000, 10009);

--- a/pkg/sql/opt/exec/execbuilder/testdata/partial_stats
+++ b/pkg/sql/opt/exec/execbuilder/testdata/partial_stats
@@ -1243,32 +1243,35 @@ SET CLUSTER SETTING sql.stats.forecasts.enabled = $forecastsEnabledPrev
 statement ok
 CREATE TABLE ka (k INT PRIMARY KEY, a INT, INDEX(a))
 
+# Inject a full stats collection with 2 outer buckets with upper bounds of
+# MaxInt64 and MinInt64.
 statement ok
-INSERT INTO ka select x, x from generate_series(0, 9998) as g(x)
-
-statement ok
-INSERT INTO ka VALUES (9999, NULL)
-
-statement ok
-CREATE STATISTICS ka_fullstat ON a FROM ka
+ALTER TABLE ka INJECT STATISTICS '[
+  {
+    "name": "ka_fullstat",
+    "columns": ["a"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 10000,
+    "distinct_count": 10000,
+    "null_count": 1,
+    "avg_size": 2,
+    "histo_col_type": "int",
+    "histo_buckets": [
+      {"num_eq": 0, "num_range": 0, "distinct_range": 0, "upper_bound": "-9223372036854775808"},
+      {"num_eq": 1, "num_range": 0, "distinct_range": 0, "upper_bound": "0"},
+      {"num_eq": 1, "num_range": 9997, "distinct_range": 0, "upper_bound": "9998"},
+      {"num_eq": 0, "num_range": 0, "distinct_range": 0, "upper_bound": "9223372036854775807"}
+    ]
+  }
+]'
 
 # Clear the stat cache so that creating partial statistics has access to the
 # latest full statistic.
 statement ok
 SELECT crdb_internal.clear_table_stats_cache();
 
-let $hist_id_ka_outer_buckets_full
-SELECT histogram_id FROM [SHOW STATISTICS FOR TABLE ka] WHERE statistics_name = 'ka_fullstat'
-
-# The full stats collection should have added 2 outer buckets for a total of 202
-# with upper bounds of MaxInt64 and MinInt64.
-query I
-SELECT count(*) FROM [SHOW HISTOGRAM $hist_id_ka_outer_buckets_full]
-----
-202
-
 statement ok
-INSERT INTO ka VALUES (10000, 9999), (10001, 10000)
+INSERT INTO ka VALUES (10000, 9999), (10001, 10000), (9999, NULL)
 
 statement ok
 CREATE STATISTICS ka_partialstat ON a FROM ka USING EXTREMES
@@ -1279,8 +1282,8 @@ FROM [SHOW STATISTICS FOR TABLE ka WITH MERGE]
 ORDER BY statistics_name
 ----
 statistics_name  column_names  row_count  distinct_count  null_count
-__merged__       {a}           10002      9922            1
-ka_fullstat      {a}           10000      9920            1
+__merged__       {a}           10002      10002           1
+ka_fullstat      {a}           10000      10000           1
 ka_partialstat   {a}           3          3               1
 
 # Verify that the merged histogram correctly appends the partial stat buckets
@@ -1309,21 +1312,32 @@ LIMIT 3
     "upper_bound": "9999"
 }
 {
-    "distinct_range": 49.591730440470876,
+    "distinct_range": 9997,
     "num_eq": 1,
-    "num_range": 50,
+    "num_range": 9999,
     "upper_bound": "9998"
 }
 
 # Verify that distinct counts and null counts are merged correctly.
 statement ok
-SET CLUSTER SETTING sql.stats.histogram_samples.count = 10005
-
-statement ok
-INSERT INTO ka VALUES (10002, 10001)
-
-statement ok
-CREATE STATISTICS ka_fullstat ON a FROM ka
+ALTER TABLE ka INJECT STATISTICS '[
+  {
+    "name": "ka_fullstat",
+    "columns": ["a"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 10004,
+    "distinct_count": 10004,
+    "null_count": 1,
+    "avg_size": 2,
+    "histo_col_type": "int",
+    "histo_buckets": [
+      {"num_eq": 0, "num_range": 0, "distinct_range": 0, "upper_bound": "-9223372036854775808"},
+      {"num_eq": 1, "num_range": 0, "distinct_range": 0, "upper_bound": "0"},
+      {"num_eq": 1, "num_range": 10001, "distinct_range": 0, "upper_bound": "10002"},
+      {"num_eq": 0, "num_range": 0, "distinct_range": 0, "upper_bound": "9223372036854775807"}
+    ]
+  }
+]'
 
 # Clear the stat cache so that creating partial statistics has access to the
 # latest full statistic.
@@ -1342,9 +1356,9 @@ FROM [SHOW STATISTICS FOR TABLE ka WITH MERGE]
 ORDER BY statistics_name
 ----
 statistics_name  column_names  row_count  distinct_count  null_count
-__merged__       {a}           10005      9924            2
-ka_fullstat      {a}           10003      9923            1
-ka_partialstat   {a}           3          2               2
+__merged__       {a}           10005      10004           2
+ka_fullstat      {a}           10004      10004           1
+ka_partialstat   {a}           2          1               2
 
 statement ok
 RESET CLUSTER SETTING sql.stats.histogram_samples.count

--- a/pkg/sql/randgen/encdatum.go
+++ b/pkg/sql/randgen/encdatum.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/errors"
 )
 
 // RandDatumEncoding returns a random DatumEncoding value.
@@ -88,17 +89,35 @@ func NullEncDatum() rowenc.EncDatum {
 	return rowenc.EncDatum{Datum: tree.DNull}
 }
 
+// DatumEncoding_NONE is only for tests. It is not a valid encoding. It is used
+// to instruct random datum generators to skip encoding the returned datum(s).
+const DatumEncoding_NONE catenumpb.DatumEncoding = -1
+
+func shouldEncode(enc catenumpb.DatumEncoding) bool {
+	return enc != DatumEncoding_NONE
+}
+
 // GenEncDatumRowsInt converts rows of ints to rows of EncDatum DInts.
 // If an int is negative, the corresponding value is NULL.
-func GenEncDatumRowsInt(inputRows [][]int) rowenc.EncDatumRows {
+func GenEncDatumRowsInt(inputRows [][]int, enc catenumpb.DatumEncoding) rowenc.EncDatumRows {
+	var a tree.DatumAlloc
 	rows := make(rowenc.EncDatumRows, len(inputRows))
 	for i, inputRow := range inputRows {
 		for _, x := range inputRow {
+			var d rowenc.EncDatum
 			if x < 0 {
-				rows[i] = append(rows[i], NullEncDatum())
+				d = NullEncDatum()
 			} else {
-				rows[i] = append(rows[i], IntEncDatum(x))
+				d = IntEncDatum(x)
 			}
+			if shouldEncode(enc) {
+				b, err := d.Encode(types.Int, &a, enc, nil /* appendTo */)
+				if err != nil {
+					panic(err)
+				}
+				d = rowenc.EncDatumFromEncoded(enc, b)
+			}
+			rows[i] = append(rows[i], d)
 		}
 	}
 	return rows
@@ -159,17 +178,80 @@ func MakeRepeatedIntRows(n int, numRows int, numCols int) rowenc.EncDatumRows {
 	return rows
 }
 
-// GenEncDatumRowsString converts rows of strings to rows of EncDatum Strings.
-// If a string is empty, the corresponding value is NULL.
-func GenEncDatumRowsString(inputRows [][]string) rowenc.EncDatumRows {
+// GenEncDatumRowsFloat converts rows of strings to rows of EncDatum DFloats.
+func GenEncDatumRowsFloat(inputRows [][]string, enc catenumpb.DatumEncoding) rowenc.EncDatumRows {
+	var a tree.DatumAlloc
 	rows := make(rowenc.EncDatumRows, len(inputRows))
 	for i, inputRow := range inputRows {
 		for _, x := range inputRow {
-			if x == "" {
-				rows[i] = append(rows[i], NullEncDatum())
-			} else {
-				rows[i] = append(rows[i], stringEncDatum(x))
+			f, err := tree.ParseDFloat(x)
+			if err != nil {
+				panic(errors.AssertionFailedf("could not parse float: %v", x))
 			}
+			d := rowenc.EncDatum{Datum: f}
+			if shouldEncode(enc) {
+				b, err := d.Encode(types.Float, &a, enc, nil /* appendTo */)
+				if err != nil {
+					panic(err)
+				}
+				d = rowenc.EncDatumFromEncoded(enc, b)
+			}
+			rows[i] = append(rows[i], d)
+		}
+	}
+	return rows
+}
+
+// GenEncDatumRowsString converts rows of strings to rows of EncDatum Strings.
+// If a string is empty, the corresponding value is NULL.
+func GenEncDatumRowsString(inputRows [][]string, enc catenumpb.DatumEncoding) rowenc.EncDatumRows {
+	var a tree.DatumAlloc
+	rows := make(rowenc.EncDatumRows, len(inputRows))
+	for i, inputRow := range inputRows {
+		for _, x := range inputRow {
+			var d rowenc.EncDatum
+			if x == "" {
+				d = NullEncDatum()
+			} else {
+				d = stringEncDatum(x)
+			}
+			if shouldEncode(enc) {
+				b, err := d.Encode(types.String, &a, enc, nil /* appendTo */)
+				if err != nil {
+					panic(err)
+				}
+				d = rowenc.EncDatumFromEncoded(enc, b)
+			}
+			rows[i] = append(rows[i], d)
+		}
+	}
+	return rows
+}
+
+// GenEncDatumRowsCollatedString converts rows of strings to rows of EncDatum
+// collated Strings.
+// If a string is empty, the corresponding value is NULL.
+func GenEncDatumRowsCollatedString(
+	inputRows [][]string, typ *types.T, enc catenumpb.DatumEncoding,
+) rowenc.EncDatumRows {
+	var a tree.DatumAlloc
+	rows := make(rowenc.EncDatumRows, len(inputRows))
+	for i, inputRow := range inputRows {
+		for _, x := range inputRow {
+			var d rowenc.EncDatum
+			if x == "" {
+				d = NullEncDatum()
+			} else {
+				d = collatedStringEncDatum(x, typ.Locale())
+			}
+			if shouldEncode(enc) {
+				b, err := d.Encode(typ, &a, enc, nil /* appendTo */)
+				if err != nil {
+					panic(err)
+				}
+				d = rowenc.EncDatumFromEncoded(enc, b)
+			}
+			rows[i] = append(rows[i], d)
 		}
 	}
 	return rows
@@ -180,13 +262,30 @@ func stringEncDatum(s string) rowenc.EncDatum {
 	return rowenc.EncDatum{Datum: tree.NewDString(s)}
 }
 
+// collatedStringEncDatum returns an EncDatum representation of a string.
+func collatedStringEncDatum(s string, locale string) rowenc.EncDatum {
+	d, err := tree.NewDCollatedString(s, locale, &tree.CollationEnvironment{})
+	if err != nil {
+		panic(err)
+	}
+	return rowenc.EncDatum{Datum: d}
+}
+
+func bytesEncDatum(b []byte) rowenc.EncDatum {
+	return rowenc.EncDatum{Datum: tree.NewDBytes(tree.DBytes(b))}
+}
+
 // GenEncDatumRowsBytes converts rows of bytes to rows of EncDatum value encoded
 // bytes.
-func GenEncDatumRowsBytes(inputRows [][][]byte) rowenc.EncDatumRows {
+func GenEncDatumRowsBytes(inputRows [][][]byte, enc catenumpb.DatumEncoding) rowenc.EncDatumRows {
 	rows := make(rowenc.EncDatumRows, len(inputRows))
 	for i, inputRow := range inputRows {
 		for _, x := range inputRow {
-			rows[i] = append(rows[i], rowenc.EncDatumFromEncoded(catenumpb.DatumEncoding_VALUE, x))
+			d := bytesEncDatum(x)
+			if shouldEncode(enc) {
+				d = rowenc.EncDatumFromEncoded(catenumpb.DatumEncoding_VALUE, x)
+			}
+			rows[i] = append(rows[i], d)
 		}
 	}
 	return rows

--- a/pkg/sql/rowexec/BUILD.bazel
+++ b/pkg/sql/rowexec/BUILD.bazel
@@ -93,6 +93,7 @@ go_library(
         "//pkg/util",
         "//pkg/util/admission/admissionpb",
         "//pkg/util/cancelchecker",
+        "//pkg/util/collatedstring",
         "//pkg/util/ctxgroup",
         "//pkg/util/encoding",
         "//pkg/util/hlc",

--- a/pkg/sql/rowexec/sample_aggregator_test.go
+++ b/pkg/sql/rowexec/sample_aggregator_test.go
@@ -122,7 +122,7 @@ func runSampleAggregator(
 			rowPartitions[j] = append(rowPartitions[j], row)
 		}
 		for i := 0; i < numSamplers; i++ {
-			rows := randgen.GenEncDatumRowsInt(rowPartitions[i])
+			rows := randgen.GenEncDatumRowsInt(rowPartitions[i], randgen.DatumEncoding_NONE)
 			in[i] = distsqlutils.NewRowBuffer(types.TwoIntCols, rows, distsqlutils.RowBufferArgs{})
 		}
 
@@ -135,7 +135,7 @@ func runSampleAggregator(
 			rowPartitions[j] = append(rowPartitions[j], row)
 		}
 		for i := 0; i < numSamplers; i++ {
-			rows := randgen.GenEncDatumRowsString(rowPartitions[i])
+			rows := randgen.GenEncDatumRowsString(rowPartitions[i], randgen.DatumEncoding_NONE)
 			in[i] = distsqlutils.NewRowBuffer([]*types.T{types.String, types.String}, rows, distsqlutils.RowBufferArgs{})
 		}
 		// Override original columns in samplerOutTypes.

--- a/pkg/sql/rowexec/sampler.go
+++ b/pkg/sql/rowexec/sampler.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/stats"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/collatedstring"
 	"github.com/cockroachdb/cockroach/pkg/util/intsets"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
@@ -35,11 +36,12 @@ import (
 type sketchInfo struct {
 	spec execinfrapb.SketchSpec
 	// Exactly one of sketchOld and sketchNew will be set.
-	sketchOld *hllOld.Sketch
-	sketchNew *hllNew.Sketch
-	numNulls  int64
-	numRows   int64
-	size      int64
+	sketchOld            *hllOld.Sketch
+	sketchNew            *hllNew.Sketch
+	numNulls             int64
+	numRows              int64
+	size                 int64
+	legacyFingerprinting bool
 }
 
 // A sampler processor returns a random sample of rows, as well as "global"
@@ -100,6 +102,7 @@ func newSamplerProcessor(
 	post *execinfrapb.PostProcessSpec,
 ) (*samplerProcessor, error) {
 	useNewHLL := execversion.FromContext(ctx) >= execversion.V25_1
+	legacyFingerprinting := execversion.FromContext(ctx) < execversion.V25_2
 
 	// Limit the memory use by creating a child monitor with a hard limit.
 	// The processor will disable histogram collection if this limit is not
@@ -127,9 +130,10 @@ func newSamplerProcessor(
 	var sampleCols intsets.Fast
 	for i := range spec.Sketches {
 		s.sketches[i] = sketchInfo{
-			spec:     spec.Sketches[i],
-			numNulls: 0,
-			numRows:  0,
+			spec:                 spec.Sketches[i],
+			numNulls:             0,
+			numRows:              0,
+			legacyFingerprinting: legacyFingerprinting,
 		}
 		if useNewHLL {
 			s.sketches[i].sketchNew = hllNew.New14()
@@ -509,6 +513,120 @@ func (s *samplerProcessor) DoesNotUseTxn() bool {
 
 // addRow adds a row to the sketch and updates row counts.
 func (s *sketchInfo) addRow(
+	ctx context.Context, row rowenc.EncDatumRow, typs []*types.T, buf *[]byte,
+) (err error) {
+	if s.legacyFingerprinting {
+		return s.addRowLegacy(ctx, row, typs, buf)
+	}
+
+	s.numRows++
+	isNull := true
+	*buf = (*buf)[:0]
+	for _, col := range s.spec.Columns {
+		if b := row[col].EncodedBytes(); b != nil && !containsCollatedString(typs[col]) {
+			// If the datum is already encoded and does not contain a collated
+			// string, we can insert the encoded bytes directly into the sketch.
+			// Even though the encoded bytes contain the column ID and type,
+			// this will not break the "loose invariant" that equal datums will
+			// have equal bytes added to the sketch because we are always adding
+			// datums from the same table column, i.e., the column ID and type
+			// should be the same for every value in the column.
+			//
+			// Composite, value encoded datums may have different encodings for
+			// semantically equivalent types, so using the encoded bytes can
+			// skew the cardinality estimate slightly. This should be rare and
+			// hyperloglog cardinality is already an estimate, so it is
+			// considered acceptable. For floats, the only values affected are 0
+			// and -0, which are semantically equivalent but have different
+			// value encodings. For decimals, 0 and -0 are affected, as well as
+			// any equal values with different numbers of trailing zeros. JSON
+			// and array types containing decimals are also affected similarly.
+			//
+			// Value-encoded collated strings are more likely than other types
+			// to cause cardinality over-estimations because the ratio of
+			// physically distinct strings to semantically distinct strings can
+			// be much higher. For example, the und-u-ks-level2 locale is
+			// case-insensitive, so there are 8 different physical strings all
+			// equivalent to "foo": "foo", "Foo", "fOo", "foO", "FOo", "FoO",
+			// "fOO", and "FOO". For this reason, we fall-back to using
+			// Fingerprint for collated strings.
+			//
+			// TODO(mgartner): We should probably truncate b to some max size to
+			// prevent a really wide value from growing buf. Since the distinct
+			// count is an estimate anyway, truncating the value shouldn't have
+			// any real impact.
+			*buf = append(*buf, b...)
+		} else {
+			// Fallback to using the Fingerprint method to generate bytes to
+			// insert into the sketch.
+			//
+			// We pass nil DatumAlloc so that each datum allocation was
+			// independent (to prevent bounded memory leaks like we've seen in
+			// #136394). The problem in that issue was that the same backing
+			// slice of datums was shared across rows, so if a single row was
+			// kept as a sample, it could keep many garbage alive. To go around
+			// that we simply disabled the batching.
+			//
+			// We choose to not perform the memory accounting for possibly
+			// decoded tree.Datum because we will lose the references to row
+			// very soon.
+			*buf, err = row[col].Fingerprint(ctx, typs[col], nil /* da */, *buf, nil /* acc */)
+			if err != nil {
+				return err
+			}
+		}
+		if isNull {
+			// Avoid calling IsNull() if the datum is unset because it will
+			// panic. Instead return an assertion error that might help in
+			// debugging.
+			if row[col].IsUnset() {
+				return errors.AssertionFailedf("unset datum: col=%d row=%s", col, row.String(typs))
+			}
+			isNull = row[col].IsNull()
+		}
+		s.size += int64(row[col].DiskSize())
+	}
+
+	if isNull {
+		s.numNulls++
+	}
+	if s.sketchNew != nil {
+		s.sketchNew.Insert(*buf)
+	} else {
+		s.sketchOld.Insert(*buf)
+	}
+	return nil
+}
+
+// containsCollatedString returns true if the type is a collated string type
+// or a container type included a collated string type. It does not return
+// true with collated string types with a default-equivalent collation.
+func containsCollatedString(t *types.T) bool {
+	isNonDefaultEquivalentCollatedString := func(t *types.T) bool {
+		return t.Family() == types.CollatedStringFamily &&
+			!collatedstring.IsDefaultEquivalentCollation(t.Locale())
+	}
+	if isNonDefaultEquivalentCollatedString(t) {
+		return true
+	}
+	if t.Family() == types.ArrayFamily {
+		return isNonDefaultEquivalentCollatedString(t.ArrayContents())
+	}
+	if t.Family() == types.TupleFamily {
+		for _, t := range t.TupleContents() {
+			if isNonDefaultEquivalentCollatedString(t) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// addRowLegacy adds a row to the sketch and updates row counts. This is the
+// legacy implementation from versions prior to 25.2.
+//
+// TODO(mgartner): Remove this once compatibility with 25.1 is no longer needed.
+func (s *sketchInfo) addRowLegacy(
 	ctx context.Context, row rowenc.EncDatumRow, typs []*types.T, buf *[]byte,
 ) error {
 	var err error

--- a/pkg/sql/stats/row_sampling.go
+++ b/pkg/sql/stats/row_sampling.go
@@ -44,6 +44,7 @@ type SampledRow struct {
 type SampleReservoir struct {
 	samples  []SampledRow
 	colTypes []*types.T
+	da       tree.DatumAlloc
 	ra       rowenc.EncDatumRowAlloc
 	memAcc   *mon.BoundAccount
 
@@ -254,7 +255,7 @@ func (sr *SampleReservoir) copyRow(
 		// the encoded bytes. The encoded bytes would have been scanned in a batch
 		// of ~10000 rows, so we must delete the reference to allow the garbage
 		// collector to release the memory from the batch.
-		if err := src[i].EnsureDecoded(sr.colTypes[i], nil /* da */); err != nil {
+		if err := src[i].EnsureDecoded(sr.colTypes[i], &sr.da); err != nil {
 			return err
 		}
 		beforeRowSize += int64(dst[i].Size())


### PR DESCRIPTION
In #136780 we stopped using a `DatumAlloc` in fingerprinting and
`(*SampleReservoir).copyRow` in order to avoid holding references to
datums that were fingerprinted but not copied (because they were not
sampled). However, it is safe to use a `DatumAlloc` for sampled rows in
`copyRow` because all copied rows will be "live" for the duration of the
`samplerProcessor`. This reduces heap allocations.

```
name     old time/op    new time/op    delta
Analyze     175ms ±15%     178ms ±16%     ~     (p=0.912 n=10+10)

name     old alloc/op   new alloc/op   delta
Analyze    61.5MB ± 0%    61.6MB ± 0%     ~     (p=0.353 n=10+10)

name     old allocs/op  new allocs/op  delta
Analyze      341k ± 0%      171k ± 0%  -49.90%  (p=0.000 n=10+10)
```

Release note: None
