### PR TITLE
add cluster and node data to enriched envelope source

### DIFF
--- a/pkg/ccl/changefeedccl/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/BUILD.bazel
@@ -226,6 +226,7 @@ go_test(
     deps = [
         "//pkg/base",
         "//pkg/blobs",
+        "//pkg/build",
         "//pkg/ccl",
         "//pkg/ccl/changefeedccl/cdceval",
         "//pkg/ccl/changefeedccl/cdcevent",

--- a/pkg/ccl/changefeedccl/alter_changefeed_test.go
+++ b/pkg/ccl/changefeedccl/alter_changefeed_test.go
@@ -1440,7 +1440,7 @@ func TestAlterChangefeedAddTargetsDuringBackfill(t *testing.T) {
 				expectedValues[j] = fmt.Sprintf(`foo: [%d]->{"after": {"val": %d}}`, j, j)
 				expectedValues[j+numRowsPerTable] = fmt.Sprintf(`bar: [%d]->{"after": {"val": %d}}`, j, j)
 			}
-			return assertPayloadsBaseErr(context.Background(), testFeed, expectedValues, false, false, changefeedbase.OptEnvelopeWrapped)
+			return assertPayloadsBaseErr(context.Background(), testFeed, expectedValues, false, false, nil, changefeedbase.OptEnvelopeWrapped)
 		})
 
 		defer func() {

--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -1248,7 +1248,9 @@ func newChangeFrontierProcessor(
 		return nil, err
 	}
 
-	sourceProvider := newEnrichedSourceProvider(encodingOpts, enrichedSourceData{jobId: cf.spec.JobID.String()})
+	// This changeFrontier's encoder will only be used for resolved events which
+	// never have a source field, so we pass an empty enriched source provider.
+	sourceProvider := newEnrichedSourceProvider(encodingOpts, enrichedSourceData{})
 	if cf.encoder, err = getEncoder(
 		ctx, encodingOpts, AllTargets(spec.Feed), spec.Feed.Select != "",
 		makeExternalConnectionProvider(ctx, flowCtx.Cfg.DB), sliMetrics,

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -598,12 +598,13 @@ func createChangefeedJobRecord(
 		return nil, err
 	}
 
-	// Validate the encoder. We can pass an empty slimetrics struct here since the encoder will not be used.
+	// Validate the encoder. We can pass an empty slimetrics struct and source provider
+	// here since the encoder will not be used.
 	encodingOpts, err := opts.GetEncodingOptions()
 	if err != nil {
 		return nil, err
 	}
-	sourceProvider := newEnrichedSourceProvider(encodingOpts, enrichedSourceData{jobId: jobID.String()})
+	sourceProvider := newEnrichedSourceProvider(encodingOpts, enrichedSourceData{})
 	if _, err := getEncoder(ctx, encodingOpts, AllTargets(details), details.Select != "",
 		makeExternalConnectionProvider(ctx, p.ExecCfg().InternalDB), nil, sourceProvider); err != nil {
 		return nil, err

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/IBM/sarama"
 	"github.com/cockroachdb/cockroach-go/v2/crdb"
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/build"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/cdceval"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/cdctest"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeedbase"
@@ -1304,7 +1305,7 @@ func TestChangefeedRandomExpressions(t *testing.T) {
 			for i, id := range expectedRowIDs {
 				assertedPayloads[i] = fmt.Sprintf(`seed: [%s]->{"rowid": %s}`, id, id)
 			}
-			err = assertPayloadsBaseErr(context.Background(), seedFeed, assertedPayloads, false, false, changefeedbase.OptEnvelopeWrapped)
+			err = assertPayloadsBaseErr(context.Background(), seedFeed, assertedPayloads, false, false, nil, changefeedbase.OptEnvelopeWrapped)
 			closeFeedIgnoreError(t, seedFeed)
 			if err != nil {
 				// Skip errors that may come up during SQL execution. If the SQL query
@@ -3881,25 +3882,22 @@ func TestChangefeedEnriched(t *testing.T) {
 					topic = ""
 				}
 
-				var jobID int64
-				// Fetching the jobId this way is not supported by the sinkless sink.
-				// In that case we will assert the job_id is 0, so we don't need this query.
-				if _, ok := foo.(*sinklessFeed); !ok {
-					sqlDB.QueryRow(t, `SELECT job_id FROM [SHOW JOBS] where job_type='CHANGEFEED'`).Scan(&jobID)
-				}
-
-				var sourceMsg string
-				if slices.Contains(tc.enrichedProperties, "source") {
-					sourceMsg = fmt.Sprintf(`, "source": {"job_id": "%d"}`, jobID)
-				}
-
-				msg := fmt.Sprintf(`%s: {"a": 0}->{"after": {"a": 0, "b": "dog"}, "op": "c"%s}`, topic, sourceMsg)
+				msg := fmt.Sprintf(`%s: {"a": 0}->{"after": {"a": 0, "b": "dog"}, "op": "c"}`, topic)
 				if slices.Contains(tc.enrichedProperties, "schema") {
 					// TODO(#139658): add the schema to the key and the value here
-					msg = fmt.Sprintf(`%s: {"payload": {"a": 0}}->{"payload": {"after": {"a": 0, "b": "dog"}, "op": "c"%s}}`, topic, sourceMsg)
+					msg = fmt.Sprintf(`%s: {"payload": {"a": 0}}->{"payload": {"after": {"a": 0, "b": "dog"}, "op": "c"}}`, topic)
 				}
 
-				assertPayloadsEnvelopeStripTs(t, foo, changefeedbase.OptEnvelopeEnriched, []string{msg})
+				sourceIsNotNilWhenSpecified := func(actualSource map[string]any) {
+					if slices.Contains(tc.enrichedProperties, "source") {
+						require.NotNil(t, actualSource)
+						return
+					}
+
+					require.Nil(t, actualSource)
+				}
+
+				assertPayloadsEnriched(t, foo, []string{msg}, sourceIsNotNilWhenSpecified)
 			}
 			supportedSinks := []string{"kafka", "pubsub", "sinkless", "webhook"}
 			for _, sink := range supportedSinks {
@@ -3907,7 +3905,6 @@ func TestChangefeedEnriched(t *testing.T) {
 			}
 		})
 	}
-
 }
 
 func TestChangefeedEnrichedAvro(t *testing.T) {
@@ -3929,14 +3926,131 @@ func TestChangefeedEnrichedAvro(t *testing.T) {
 
 		assertionKey := `{"a":{"long":0}}`
 		assertionAfter := `"after": {"foo": {"a": {"long": 0}, "b": {"string": "dog"}}}`
-		assertionSource := fmt.Sprintf(`"source": {"source": {"job_id": {"string": "%d"}}}`, jobID)
 
-		assertPayloadsEnvelopeStripTs(t, foo, changefeedbase.OptEnvelopeEnriched, []string{
-			fmt.Sprintf(`foo: %s->{%s, "op": {"string": "c"}, %s}`,
-				assertionKey, assertionAfter, assertionSource),
-		})
+		assertPayloadsEnriched(t, foo, []string{
+			fmt.Sprintf(`foo: %s->{%s, "op": {"string": "c"}}`,
+				assertionKey, assertionAfter),
+		}, nil)
 	}
 	cdcTest(t, testFn, feedTestForceSink("kafka"))
+}
+
+func TestChangefeedEnrichedSourceWithNodeAndClusterInfo(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	cases := []struct {
+		name            string
+		format          string
+		expectedMessage string
+		supportedSinks  []string
+	}{
+		{
+			name:            "json",
+			format:          "json",
+			expectedMessage: `foo: {"i": 0}->{"after": {"i": 0}, "op": "c"}`,
+			supportedSinks:  []string{"kafka", "pubsub", "sinkless"},
+		},
+		{
+			// TODO(#139660): the webhook sink forces topic_in_value, but
+			// this is not supported by the enriched envelope type. We should adapt
+			// the test framework to account for this.
+			name:            "json-webhook",
+			format:          "json",
+			expectedMessage: `: {"i": 0}->{"after": {"i": 0}, "op": "c"}`,
+			supportedSinks:  []string{"webhook"},
+		},
+		{
+			name:            "avro",
+			format:          "avro",
+			expectedMessage: `foo: {"i":{"long":0}}->{"after": {"foo": {"i": {"long": 0}}}, "op": {"string": "c"}}`,
+			supportedSinks:  []string{"kafka"},
+		},
+	}
+
+	for _, testCase := range cases {
+		t.Run(testCase.name, func(t *testing.T) {
+			clusterName := "clusterName123"
+			dbVersion := "v999.0.0"
+			defer build.TestingOverrideVersion(dbVersion)()
+			testFn := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
+				clusterID := s.Server.ExecutorConfig().(sql.ExecutorConfig).NodeInfo.LogicalClusterID().String()
+
+				sqlDB := sqlutils.MakeSQLRunner(s.DB)
+
+				sqlDB.Exec(t, `CREATE TABLE foo (i INT PRIMARY KEY)`)
+				sqlDB.Exec(t, `INSERT INTO foo values (0)`)
+				testFeed := feed(t, f, fmt.Sprintf(`CREATE CHANGEFEED FOR foo WITH envelope=enriched, enriched_properties='source', format=%s`, testCase.format))
+				defer closeFeed(t, testFeed)
+
+				var jobID int64
+				var nodeName string
+				var sourceAssertion func(actualSource map[string]any)
+				if ef, ok := testFeed.(cdctest.EnterpriseTestFeed); ok {
+					jobID = int64(ef.JobID())
+				}
+				sqlDB.QueryRow(t, `SELECT value FROM crdb_internal.node_runtime_info where component = 'DB' and field = 'Host'`).Scan(&nodeName)
+
+				sourceAssertion = func(actualSource map[string]any) {
+					var nodeID any
+					if testCase.format == "avro" {
+						actualSourceValue := actualSource["source"].(map[string]any)
+						nodeID = actualSourceValue["node_id"].(map[string]any)["string"]
+					} else {
+						nodeID = actualSource["node_id"]
+					}
+					require.NotNil(t, nodeID)
+
+					sourceNodeLocality := fmt.Sprintf(`region=%s`, testServerRegion)
+
+					var assertion string
+					if testCase.format == "avro" {
+						assertion = fmt.Sprintf(
+							`{
+								"source": {
+									"cluster_id": {"string": "%s"},
+									"cluster_name": {"string": "%s"},
+									"db_version": {"string": "%s"},
+									"job_id": {"string": "%d"},
+									"node_id": {"string": "%s"},
+									"node_name": {"string": "%s"},
+									"source_node_locality": {"string": "%s"}
+								}
+							}`,
+							clusterID, clusterName, dbVersion, jobID, nodeID, nodeName, sourceNodeLocality)
+					} else {
+						assertion = fmt.Sprintf(
+							`{
+								"cluster_id": "%s",
+								"cluster_name": "%s",
+								"db_version": "%s",
+								"job_id": "%d",
+								"node_id": "%s",
+								"node_name": "%s",
+								"source_node_locality": "%s"
+							}`,
+							clusterID, clusterName, dbVersion, jobID, nodeID, nodeName, sourceNodeLocality)
+					}
+
+					value, err := reformatJSON(actualSource)
+					require.NoError(t, err)
+					require.JSONEq(t, assertion, string(value))
+				}
+
+				assertPayloadsEnriched(t, testFeed, []string{testCase.expectedMessage}, sourceAssertion)
+			}
+
+			for _, sink := range testCase.supportedSinks {
+				testLocality := roachpb.Locality{
+					Tiers: []roachpb.Tier{{
+						Key:   "region",
+						Value: testServerRegion,
+					}}}
+				cdcTest(t, testFn, feedTestForceSink(sink), feedTestUseClusterName(clusterName),
+					feedTestUseLocality(testLocality))
+			}
+		})
+	}
 }
 
 func TestChangefeedExpressionUsesSerializedSessionData(t *testing.T) {
@@ -9164,7 +9278,7 @@ func TestChangefeedTestTimesOut(t *testing.T) {
 					nada, expectTimeout,
 					func(ctx context.Context) error {
 						return assertPayloadsBaseErr(
-							ctx, nada, []string{`nada: [2]->{"after": {}}`}, false, false, changefeedbase.OptEnvelopeWrapped)
+							ctx, nada, []string{`nada: [2]->{"after": {}}`}, false, false, nil, changefeedbase.OptEnvelopeWrapped)
 					})
 				return nil
 			}, 20*expectTimeout))

--- a/pkg/ccl/changefeedccl/encoder_json.go
+++ b/pkg/ccl/changefeedccl/encoder_json.go
@@ -571,7 +571,6 @@ func (e *jsonEncoder) initEnrichedEnvelope(ctx context.Context) error {
 				return nil, err
 			}
 		}
-
 		if e.sourceField {
 			sourceJson, err := e.enrichedEnvelopeSourceProvider.GetJSON(updated)
 			if err != nil {
@@ -661,9 +660,10 @@ func EncodeAsJSONChangefeedWithFlags(
 	if err != nil {
 		return nil, err
 	}
-	sourceProvider := newEnrichedSourceProvider(opts, enrichedSourceData{
-		jobId: "ccl_builtin", // This encoder is not used in the context of a real changefeed.
-	})
+	// This encoder is not used in the context of a real changefeed so make an empty
+	// source provider.
+	sourceProvider := newEnrichedSourceProvider(opts, enrichedSourceData{})
+
 	// If this function ends up needing to be optimized, cache or pool these.
 	// Nontrivial to do as an encoder generally isn't safe to call on different
 	// rows in parallel.

--- a/pkg/ccl/changefeedccl/enriched_source_provider.go
+++ b/pkg/ccl/changefeedccl/enriched_source_provider.go
@@ -6,9 +6,19 @@
 package changefeedccl
 
 import (
+	"context"
+	"net"
+	"net/url"
+	"strings"
+
+	"github.com/cockroachdb/cockroach/pkg/build"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/avro"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/cdcevent"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeedbase"
+	"github.com/cockroachdb/cockroach/pkg/security/username"
+	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/util/json"
 	"github.com/linkedin/goavro/v2"
 )
@@ -17,7 +27,8 @@ type enrichedSourceProviderOpts struct {
 	updated, mvccTimestamp bool
 }
 type enrichedSourceData struct {
-	jobId string
+	jobID,
+	dbVersion, clusterName, sourceNodeLocality, nodeName, nodeID, clusterID string
 	// TODO(#139692): Add schema info support.
 	// TODO(#139691): Add job info support.
 	// TODO(#139690): Add node/cluster info support.
@@ -25,6 +36,48 @@ type enrichedSourceData struct {
 type enrichedSourceProvider struct {
 	opts       enrichedSourceProviderOpts
 	sourceData enrichedSourceData
+}
+
+func newEnrichedSourceData(
+	ctx context.Context, cfg *execinfra.ServerConfig, spec execinfrapb.ChangeAggregatorSpec,
+) (enrichedSourceData, error) {
+	var sourceNodeLocality, nodeName, nodeID string
+	tiers := cfg.Locality.Tiers
+
+	nodeLocalities := make([]string, 0, len(tiers))
+	for _, t := range tiers {
+		nodeLocalities = append(nodeLocalities, t.String())
+	}
+	sourceNodeLocality = strings.Join(nodeLocalities, ",")
+
+	nodeInfo := cfg.ExecutorConfig.(*sql.ExecutorConfig).NodeInfo
+	getPGURL := nodeInfo.PGURL
+	pgurl, err := getPGURL(url.User(username.RootUser))
+	if err != nil {
+		return enrichedSourceData{}, err
+	}
+	parsedUrl, err := url.Parse(pgurl.String())
+	if err != nil {
+		return enrichedSourceData{}, err
+	}
+	host, _, err := net.SplitHostPort(parsedUrl.Host)
+	if err == nil {
+		nodeName = host
+	}
+
+	if optionalNodeID, ok := nodeInfo.NodeID.OptionalNodeID(); ok {
+		nodeID = optionalNodeID.String()
+	}
+
+	return enrichedSourceData{
+		jobID:              spec.JobID.String(),
+		dbVersion:          build.GetInfo().Tag,
+		clusterName:        cfg.ExecutorConfig.(*sql.ExecutorConfig).RPCContext.ClusterName(),
+		clusterID:          nodeInfo.LogicalClusterID().String(),
+		sourceNodeLocality: sourceNodeLocality,
+		nodeName:           nodeName,
+		nodeID:             nodeID,
+	}, nil
 }
 
 func newEnrichedSourceProvider(
@@ -41,13 +94,25 @@ func newEnrichedSourceProvider(
 
 func (p *enrichedSourceProvider) avroSourceFunction(row cdcevent.Row) (map[string]any, error) {
 	return map[string]any{
-		"job_id": goavro.Union(avro.SchemaTypeString, p.sourceData.jobId),
+		"job_id":               goavro.Union(avro.SchemaTypeString, p.sourceData.jobID),
+		"db_version":           goavro.Union(avro.SchemaTypeString, p.sourceData.dbVersion),
+		"cluster_name":         goavro.Union(avro.SchemaTypeString, p.sourceData.clusterName),
+		"cluster_id":           goavro.Union(avro.SchemaTypeString, p.sourceData.clusterID),
+		"source_node_locality": goavro.Union(avro.SchemaTypeString, p.sourceData.sourceNodeLocality),
+		"node_name":            goavro.Union(avro.SchemaTypeString, p.sourceData.nodeName),
+		"node_id":              goavro.Union(avro.SchemaTypeString, p.sourceData.nodeID),
 	}, nil
 }
 
 func (p *enrichedSourceProvider) getAvroFields() []*avro.SchemaField {
 	return []*avro.SchemaField{
 		{Name: "job_id", SchemaType: []avro.SchemaType{avro.SchemaTypeNull, avro.SchemaTypeString}},
+		{Name: "db_version", SchemaType: []avro.SchemaType{avro.SchemaTypeNull, avro.SchemaTypeString}},
+		{Name: "cluster_name", SchemaType: []avro.SchemaType{avro.SchemaTypeNull, avro.SchemaTypeString}},
+		{Name: "cluster_id", SchemaType: []avro.SchemaType{avro.SchemaTypeNull, avro.SchemaTypeString}},
+		{Name: "source_node_locality", SchemaType: []avro.SchemaType{avro.SchemaTypeNull, avro.SchemaTypeString}},
+		{Name: "node_name", SchemaType: []avro.SchemaType{avro.SchemaTypeNull, avro.SchemaTypeString}},
+		{Name: "node_id", SchemaType: []avro.SchemaType{avro.SchemaTypeNull, avro.SchemaTypeString}},
 	}
 }
 
@@ -59,15 +124,36 @@ func (p *enrichedSourceProvider) Schema() (*avro.FunctionalRecord, error) {
 	return rec, nil
 }
 
-func (p *enrichedSourceProvider) GetJSON(row cdcevent.Row) (json.JSON, error) {
+func (p *enrichedSourceProvider) GetJSON(updated cdcevent.Row) (json.JSON, error) {
 	// TODO(various): Add fields here.
-	keys := []string{"job_id"}
+	keys := []string{
+		"job_id", "db_version", "cluster_name", "cluster_id", "source_node_locality", "node_name", "node_id",
+	}
+
 	b, err := json.NewFixedKeysObjectBuilder(keys)
 	if err != nil {
 		return nil, err
 	}
 
-	if err := b.Set("job_id", json.FromString(p.sourceData.jobId)); err != nil {
+	if err := b.Set("job_id", json.FromString(p.sourceData.jobID)); err != nil {
+		return nil, err
+	}
+	if err := b.Set("db_version", json.FromString(p.sourceData.dbVersion)); err != nil {
+		return nil, err
+	}
+	if err := b.Set("cluster_name", json.FromString(p.sourceData.clusterName)); err != nil {
+		return nil, err
+	}
+	if err := b.Set("cluster_id", json.FromString(p.sourceData.clusterID)); err != nil {
+		return nil, err
+	}
+	if err := b.Set("source_node_locality", json.FromString(p.sourceData.sourceNodeLocality)); err != nil {
+		return nil, err
+	}
+	if err := b.Set("node_name", json.FromString(p.sourceData.nodeName)); err != nil {
+		return nil, err
+	}
+	if err := b.Set("node_id", json.FromString(p.sourceData.nodeID)); err != nil {
 		return nil, err
 	}
 

--- a/pkg/ccl/changefeedccl/event_processing.go
+++ b/pkg/ccl/changefeedccl/event_processing.go
@@ -99,12 +99,16 @@ func newEventConsumer(
 	enablePacer := changefeedbase.PerEventElasticCPUControlEnabled.Get(&cfg.Settings.SV)
 
 	makeConsumer := func(s EventSink, frontier frontier) (eventConsumer, error) {
-		var err error
+		sourceData := enrichedSourceData{}
+		if encodingOpts.Envelope == changefeedbase.OptEnvelopeEnriched {
+			sourceData, err = newEnrichedSourceData(ctx, cfg, spec)
+			if err != nil {
+				return nil, err
+			}
+		}
 		encoder, err := getEncoder(ctx, encodingOpts, feed.Targets, spec.Select.Expr != "",
 			makeExternalConnectionProvider(ctx, cfg.DB), sliMetrics, newEnrichedSourceProvider(
-				encodingOpts, enrichedSourceData{
-					jobId: spec.JobID.String(),
-				}),
+				encodingOpts, sourceData),
 		)
 		if err != nil {
 			return nil, err

--- a/pkg/ccl/changefeedccl/helpers_test.go
+++ b/pkg/ccl/changefeedccl/helpers_test.go
@@ -131,6 +131,38 @@ func readNextMessages(
 	return actual, nil
 }
 
+func applySourceAssertion(
+	payloads []cdctest.TestFeedMessage, sourceAssertion func(source map[string]any),
+) error {
+	if sourceAssertion == nil {
+		sourceAssertion = func(source map[string]any) {}
+	}
+	for _, m := range payloads {
+		var message map[string]any
+		if err := gojson.Unmarshal(m.Value, &message); err != nil {
+			return errors.Wrapf(err, `unmarshal: %s`, m.Value)
+		}
+
+		// This message may have a `payload` wrapper if format=json and `enriched_properties` includes `schema`
+		if message["payload"] == nil {
+			if message["source"] != nil {
+				sourceAssertion(message["source"].(map[string]any))
+			} else {
+				sourceAssertion(nil)
+			}
+		} else {
+			payload := message["payload"].(map[string]any)
+			source := payload["source"]
+			if source != nil {
+				sourceAssertion(source.(map[string]any))
+			} else {
+				sourceAssertion(nil)
+			}
+		}
+	}
+	return nil
+}
+
 func stripTsFromPayloads(
 	envelopeType changefeedbase.EnvelopeType, payloads []cdctest.TestFeedMessage,
 ) ([]string, error) {
@@ -147,8 +179,11 @@ func stripTsFromPayloads(
 			// This message may have a `payload` wrapper if format=json and `enriched_properties` includes `schema`
 			if message["payload"] == nil {
 				delete(message, "ts_ns")
+				delete(message, "source")
 			} else {
-				delete(message["payload"].(map[string]any), "ts_ns")
+				payload := message["payload"].(map[string]any)
+				delete(payload, "ts_ns")
+				delete(payload, "source")
 			}
 		case changefeedbase.OptEnvelopeWrapped:
 			delete(message, "updated")
@@ -220,7 +255,7 @@ func assertPayloadsBase(
 	require.NoError(t,
 		withTimeout(f, timeout,
 			func(ctx context.Context) (err error) {
-				return assertPayloadsBaseErr(ctx, f, expected, stripTs, perKeyOrdered, envelopeType)
+				return assertPayloadsBaseErr(ctx, f, expected, stripTs, perKeyOrdered, nil, envelopeType)
 			},
 		))
 }
@@ -231,6 +266,7 @@ func assertPayloadsBaseErr(
 	expected []string,
 	stripTs bool,
 	perKeyOrdered bool,
+	sourceAssertion func(map[string]any),
 	envelopeType changefeedbase.EnvelopeType,
 ) error {
 	actual, err := readNextMessages(ctx, f, len(expected))
@@ -251,6 +287,13 @@ func assertPayloadsBaseErr(
 		if !ordered {
 			return errors.Newf("payloads violate CDC per-key ordering guarantees:\n  %s",
 				strings.Join(actualFormatted, "\n  "))
+		}
+	}
+
+	if sourceAssertion != nil {
+		err := applySourceAssertion(actual, sourceAssertion)
+		if err != nil {
+			return err
 		}
 	}
 
@@ -300,11 +343,26 @@ func assertPayloads(t testing.TB, f cdctest.TestFeed, expected []string) {
 	assertPayloadsBase(t, f, expected, false, false, changefeedbase.OptEnvelopeWrapped)
 }
 
-func assertPayloadsEnvelopeStripTs(
-	t testing.TB, f cdctest.TestFeed, envelopeType changefeedbase.EnvelopeType, expected []string,
+// assertPayloadsEnriched is used to assert payloads for the enriched envelope.
+// When the source is included with includeSource, we dynamically make assertions
+// about the "source" fields but when it's false we remove the source fields entirely.
+// In either case we strip the timestamps.
+func assertPayloadsEnriched(
+	t testing.TB, f cdctest.TestFeed, expected []string, sourceAssertion func(map[string]any),
 ) {
 	t.Helper()
-	assertPayloadsBase(t, f, expected, true, false, envelopeType)
+	timeout := assertPayloadsTimeout()
+	if len(expected) > 100 {
+		// Webhook sink is very slow; We have few tests that read 1000 messages.
+		timeout += time.Duration(math.Log(float64(len(expected)))) * time.Minute
+	}
+
+	require.NoError(t,
+		withTimeout(f, timeout,
+			func(ctx context.Context) (err error) {
+				return assertPayloadsBaseErr(ctx, f, expected, true, false, sourceAssertion, changefeedbase.OptEnvelopeEnriched)
+			},
+		))
 }
 
 func assertPayloadsStripTs(t testing.TB, f cdctest.TestFeed, expected []string) {
@@ -443,6 +501,8 @@ func startTestFullServer(
 		UseDatabase:       `d`,
 		ExternalIODir:     options.externalIODir,
 		Settings:          options.settings,
+		ClusterName:       options.clusterName,
+		Locality:          options.locality,
 	}
 
 	if options.debugUseAfterFinish {
@@ -557,6 +617,7 @@ func startTestTenant(
 		TestingKnobs:  knobs,
 		ExternalIODir: options.externalIODir,
 		Settings:      options.settings,
+		Locality:      options.locality,
 	}
 
 	if options.debugUseAfterFinish {
@@ -593,6 +654,8 @@ type feedTestOptions struct {
 	settings                     *cluster.Settings
 	additionalSystemPrivs        []string
 	debugUseAfterFinish          bool
+	clusterName                  string
+	locality                     roachpb.Locality
 }
 
 type feedTestOption func(opts *feedTestOptions)
@@ -631,6 +694,18 @@ var feedTestOmitSinks = func(sinkTypes ...string) feedTestOption {
 var feedTestAdditionalSystemPrivs = func(privs ...string) feedTestOption {
 	return func(opts *feedTestOptions) {
 		opts.additionalSystemPrivs = append(opts.additionalSystemPrivs, privs...)
+	}
+}
+
+var feedTestUseClusterName = func(clusterName string) feedTestOption {
+	return func(opts *feedTestOptions) {
+		opts.clusterName = clusterName
+	}
+}
+
+var feedTestUseLocality = func(locality roachpb.Locality) feedTestOption {
+	return func(opts *feedTestOptions) {
+		opts.locality = locality
 	}
 }
 
@@ -1469,7 +1544,15 @@ func ChangefeedJobPermissionsTestSetup(t *testing.T, s TestServer) {
 // getTestingEnrichedSourceData creates an enrichedSourceData
 // for use in tests.
 func getTestingEnrichedSourceData() enrichedSourceData {
-	return enrichedSourceData{jobId: "test_id"}
+	return enrichedSourceData{
+		jobID:              "test_id",
+		dbVersion:          "test_db_version",
+		clusterName:        "test_cluster_name",
+		clusterID:          "test_cluster_id",
+		sourceNodeLocality: "test_source_node_locality",
+		nodeName:           "test_node_name",
+		nodeID:             "test_node_id",
+	}
 }
 
 // getTestingEnrichedSourceProvider creates an enrichedSourceProvider


### PR DESCRIPTION
This adds the fields cluster_id, cluster_name, db_version, job_id,
node_name, node_id and source_node_locality to the source for
changefeed messages with enriched envelope that specify "source".

Fixes: https://github.com/cockroachdb/cockroach/issues/139690

Epic: [CRDB-8665](https://cockroachlabs.atlassian.net/browse/CRDB-8665)

Release note: None