### PR TITLE
uuid: unredact UUID, Short, and Timestamp

### DIFF
--- a/pkg/kv/kvpb/api_test.go
+++ b/pkg/kv/kvpb/api_test.go
@@ -306,7 +306,7 @@ func TestContentionEvent_SafeFormat(t *testing.T) {
 		Key:     roachpb.Key("foo"),
 		TxnMeta: enginepb.TxnMeta{ID: uuid.FromStringOrNil("51b5ef6a-f18f-4e85-bc3f-c44e33f2bb27"), CoordinatorNodeID: 6},
 	}
-	const exp = redact.RedactableString(`conflicted with ‹51b5ef6a-f18f-4e85-bc3f-c44e33f2bb27› on ‹"foo"› for 0.000s`)
+	const exp = redact.RedactableString(`conflicted with 51b5ef6a-f18f-4e85-bc3f-c44e33f2bb27 on ‹"foo"› for 0.000s`)
 	require.Equal(t, exp, redact.Sprint(ce))
 }
 

--- a/pkg/kv/kvserver/concurrency/lock/lock_waiter_test.go
+++ b/pkg/kv/kvserver/concurrency/lock/lock_waiter_test.go
@@ -49,7 +49,7 @@ func TestWaiterSafeFormat(t *testing.T) {
 		"waiting_txn:6ba7b810 active_waiter:true strength:Exclusive wait_duration:2m15s",
 		redact.Sprint(waiter).Redact())
 	require.EqualValues(t,
-		"waiting_txn:‹×› active_waiter:true strength:Exclusive wait_duration:2m15s",
+		"waiting_txn:6ba7b810-9dad-11d1-80b4-00c04fd430c8 active_waiter:true strength:Exclusive wait_duration:2m15s",
 		redact.Sprintf("%+v", waiter).Redact())
 
 	nonTxnWaiter := &lock.Waiter{

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/basic
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/basic
@@ -126,7 +126,7 @@ on-txn-updated txn=txn2 status=committed
 [-] update txn: committing txn2
 [2] sequence req3: resolving intent ‹"k"› for txn 00000002 with COMMITTED status
 [2] sequence req3: lock wait-queue event: done waiting
-[2] sequence req3: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"k"› for 123.000s
+[2] sequence req3: conflicted with 00000002-0000-0000-0000-000000000000 on ‹"k"› for 123.000s
 [2] sequence req3: acquiring latches
 [2] sequence req3: scanning lock table for conflicting locks
 [2] sequence req3: sequencing complete, returned guard
@@ -228,13 +228,13 @@ on-txn-updated txn=txn2 status=pending ts=18,1
 [-] update txn: increasing timestamp of txn2
 [2] sequence req5: resolving intent ‹"k"› for txn 00000002 with PENDING status and clock observation {1 246.000000000,0}
 [2] sequence req5: lock wait-queue event: done waiting
-[2] sequence req5: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"k"› for 123.000s
+[2] sequence req5: conflicted with 00000002-0000-0000-0000-000000000000 on ‹"k"› for 123.000s
 [2] sequence req5: acquiring latches
 [2] sequence req5: scanning lock table for conflicting locks
 [2] sequence req5: sequencing complete, returned guard
 [3] sequence req6: resolving intent ‹"k"› for txn 00000002 with PENDING status and clock observation {1 246.000000000,1}
 [3] sequence req6: lock wait-queue event: done waiting
-[3] sequence req6: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"k"› for 123.000s
+[3] sequence req6: conflicted with 00000002-0000-0000-0000-000000000000 on ‹"k"› for 123.000s
 [3] sequence req6: acquiring latches
 [3] sequence req6: scanning lock table for conflicting locks
 [3] sequence req6: sequencing complete, returned guard
@@ -274,7 +274,7 @@ on-txn-updated txn=txn2 status=committed
 [-] update txn: committing txn2
 [4] sequence req7: resolving intent ‹"k"› for txn 00000002 with COMMITTED status
 [4] sequence req7: lock wait-queue event: done waiting
-[4] sequence req7: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"k"› for 123.000s
+[4] sequence req7: conflicted with 00000002-0000-0000-0000-000000000000 on ‹"k"› for 123.000s
 [4] sequence req7: acquiring latches
 [4] sequence req7: scanning lock table for conflicting locks
 [4] sequence req7: sequencing complete, returned guard

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/clear_abandoned_intents
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/clear_abandoned_intents
@@ -105,7 +105,7 @@ on-txn-updated txn=txn2 status=aborted
 [-] update txn: aborting txn2
 [3] sequence req1: resolving intent ‹"a"› for txn 00000002 with ABORTED status
 [3] sequence req1: lock wait-queue event: done waiting
-[3] sequence req1: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"a"› for 123.000s
+[3] sequence req1: conflicted with 00000002-0000-0000-0000-000000000000 on ‹"a"› for 123.000s
 [3] sequence req1: resolving a batch of 9 intent(s)
 [3] sequence req1: resolving intent ‹"b"› for txn 00000002 with ABORTED status
 [3] sequence req1: resolving intent ‹"c"› for txn 00000002 with ABORTED status
@@ -186,7 +186,7 @@ on-txn-updated txn=txn2 status=committed
 [-] update txn: committing txn2
 [3] sequence req1: resolving intent ‹"a"› for txn 00000002 with COMMITTED status
 [3] sequence req1: lock wait-queue event: done waiting
-[3] sequence req1: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"a"› for 123.000s
+[3] sequence req1: conflicted with 00000002-0000-0000-0000-000000000000 on ‹"a"› for 123.000s
 [3] sequence req1: acquiring latches
 [3] sequence req1: scanning lock table for conflicting locks
 [3] sequence req1: sequencing complete, returned guard
@@ -378,7 +378,7 @@ on-txn-updated txn=txn2 status=aborted
 [-] update txn: aborting txn2
 [4] sequence req1: resolving intent ‹"a"› for txn 00000002 with ABORTED status
 [4] sequence req1: lock wait-queue event: done waiting
-[4] sequence req1: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"a"› for 123.000s
+[4] sequence req1: conflicted with 00000002-0000-0000-0000-000000000000 on ‹"a"› for 123.000s
 [4] sequence req1: resolving a batch of 1 intent(s)
 [4] sequence req1: resolving intent ‹"b"› for txn 00000002 with ABORTED status
 [4] sequence req1: acquiring latches
@@ -592,13 +592,13 @@ on-txn-updated txn=txn3 status=aborted
 [-] update txn: aborting txn3
 [3] sequence req1: resolving intent ‹"c"› for txn 00000003 with ABORTED status
 [3] sequence req1: lock wait-queue event: wait for txn 00000005 holding lock @ key ‹"e"› (queuedLockingRequests: 1, queuedReaders: 0)
-[3] sequence req1: conflicted with ‹00000003-0000-0000-0000-000000000000› on ‹"c"› for 123.000s
+[3] sequence req1: conflicted with 00000003-0000-0000-0000-000000000000 on ‹"c"› for 123.000s
 [3] sequence req1: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [3] sequence req1: pushing txn 00000005 to abort
 [3] sequence req1: blocked on select in concurrency_test.(*cluster).PushTransaction
 [6] sequence req2: resolving intent ‹"a"› for txn 00000003 with ABORTED status
 [6] sequence req2: lock wait-queue event: wait for txn 00000004 holding lock @ key ‹"b"› (queuedLockingRequests: 0, queuedReaders: 1)
-[6] sequence req2: conflicted with ‹00000003-0000-0000-0000-000000000000› on ‹"a"› for 123.000s
+[6] sequence req2: conflicted with 00000003-0000-0000-0000-000000000000 on ‹"a"› for 123.000s
 [6] sequence req2: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [6] sequence req2: pushing timestamp of txn 00000004 above 11.000000000,1
 [6] sequence req2: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -632,7 +632,7 @@ on-txn-updated txn=txn4 status=aborted
 [-] update txn: aborting txn4
 [6] sequence req2: resolving intent ‹"b"› for txn 00000004 with ABORTED status
 [6] sequence req2: lock wait-queue event: done waiting
-[6] sequence req2: conflicted with ‹00000004-0000-0000-0000-000000000000› on ‹"b"› for 123.000s
+[6] sequence req2: conflicted with 00000004-0000-0000-0000-000000000000 on ‹"b"› for 123.000s
 [6] sequence req2: resolving a batch of 1 intent(s)
 [6] sequence req2: resolving intent ‹"d"› for txn 00000003 with ABORTED status
 [6] sequence req2: acquiring latches
@@ -664,7 +664,7 @@ on-txn-updated txn=txn5 status=aborted
 [-] update txn: aborting txn5
 [3] sequence req1: resolving intent ‹"e"› for txn 00000005 with ABORTED status
 [3] sequence req1: lock wait-queue event: done waiting
-[3] sequence req1: conflicted with ‹00000005-0000-0000-0000-000000000000› on ‹"e"› for 123.000s
+[3] sequence req1: conflicted with 00000005-0000-0000-0000-000000000000 on ‹"e"› for 123.000s
 [3] sequence req1: acquiring latches
 [3] sequence req1: scanning lock table for conflicting locks
 [3] sequence req1: sequencing complete, returned guard

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/clear_abandoned_intents_wait_policy_error
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/clear_abandoned_intents_wait_policy_error
@@ -82,7 +82,7 @@ sequence req=req1
 [3] sequence req1: pushing timestamp of txn 00000002 above 10.000000000,1
 [3] sequence req1: resolving intent ‹"a"› for txn 00000002 with ABORTED status
 [3] sequence req1: lock wait-queue event: done waiting
-[3] sequence req1: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"a"› for 0.000s
+[3] sequence req1: conflicted with 00000002-0000-0000-0000-000000000000 on ‹"a"› for 0.000s
 [3] sequence req1: resolving a batch of 9 intent(s)
 [3] sequence req1: resolving intent ‹"b"› for txn 00000002 with ABORTED status
 [3] sequence req1: resolving intent ‹"c"› for txn 00000002 with ABORTED status

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/clear_abandoned_intents_without_adding_to_lock_table
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/clear_abandoned_intents_without_adding_to_lock_table
@@ -65,7 +65,7 @@ on-txn-updated txn=txn2 status=aborted
 [-] update txn: aborting txn2
 [3] sequence req1: resolving intent ‹"a"› for txn 00000002 with ABORTED status
 [3] sequence req1: lock wait-queue event: done waiting
-[3] sequence req1: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"a"› for 123.000s
+[3] sequence req1: conflicted with 00000002-0000-0000-0000-000000000000 on ‹"a"› for 123.000s
 [3] sequence req1: acquiring latches
 [3] sequence req1: scanning lock table for conflicting locks
 [3] sequence req1: sequencing complete, returned guard

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/deadlocks
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/deadlocks
@@ -162,11 +162,11 @@ on-txn-updated txn=txn1 status=aborted
 ----
 [-] update txn: aborting txn1
 [4] sequence req1r: detected pusher aborted
-[4] sequence req1r: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"b"› for 0.000s
+[4] sequence req1r: conflicted with 00000002-0000-0000-0000-000000000000 on ‹"b"› for 0.000s
 [4] sequence req1r: sequencing complete, returned error: TransactionAbortedError(ABORT_REASON_PUSHER_ABORTED)
 [6] sequence req3r: resolving intent ‹"a"› for txn 00000001 with ABORTED status
 [6] sequence req3r: lock wait-queue event: done waiting
-[6] sequence req3r: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"a"› for 0.000s
+[6] sequence req3r: conflicted with 00000001-0000-0000-0000-000000000000 on ‹"a"› for 0.000s
 [6] sequence req3r: acquiring latches
 [6] sequence req3r: scanning lock table for conflicting locks
 [6] sequence req3r: sequencing complete, returned guard
@@ -181,7 +181,7 @@ on-txn-updated txn=txn3 status=committed
 [-] update txn: committing txn3
 [5] sequence req2r: resolving intent ‹"c"› for txn 00000003 with COMMITTED status
 [5] sequence req2r: lock wait-queue event: done waiting
-[5] sequence req2r: conflicted with ‹00000003-0000-0000-0000-000000000000› on ‹"c"› for 0.000s
+[5] sequence req2r: conflicted with 00000003-0000-0000-0000-000000000000 on ‹"c"› for 0.000s
 [5] sequence req2r: acquiring latches
 [5] sequence req2r: scanning lock table for conflicting locks
 [5] sequence req2r: sequencing complete, returned guard
@@ -386,16 +386,16 @@ on-txn-updated txn=txn1 status=aborted
 [-] update txn: aborting txn1
 [4] sequence req4w: resolving intent ‹"a"› for txn 00000001 with ABORTED status
 [4] sequence req4w: lock wait-queue event: done waiting
-[4] sequence req4w: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"a"› for 0.000s
+[4] sequence req4w: conflicted with 00000001-0000-0000-0000-000000000000 on ‹"a"› for 0.000s
 [4] sequence req4w: acquiring latches
 [4] sequence req4w: scanning lock table for conflicting locks
 [4] sequence req4w: sequencing complete, returned guard
 [5] sequence req1w2: detected pusher aborted
-[5] sequence req1w2: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"b"› for 0.000s
+[5] sequence req1w2: conflicted with 00000002-0000-0000-0000-000000000000 on ‹"b"› for 0.000s
 [5] sequence req1w2: sequencing complete, returned error: TransactionAbortedError(ABORT_REASON_PUSHER_ABORTED)
 [7] sequence req3w2: resolving intent ‹"a"› for txn 00000001 with ABORTED status
 [7] sequence req3w2: lock wait-queue event: wait for txn 00000004 running request @ key ‹"a"› (queuedLockingRequests: 2, queuedReaders: 0)
-[7] sequence req3w2: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"a"› for 0.000s
+[7] sequence req3w2: conflicted with 00000001-0000-0000-0000-000000000000 on ‹"a"› for 0.000s
 [7] sequence req3w2: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [7] sequence req3w2: pushing txn 00000004 to detect request deadlock
 [7] sequence req3w2: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -405,7 +405,7 @@ finish req=req4w
 ----
 [-] finish req4w: finishing request
 [7] sequence req3w2: lock wait-queue event: done waiting
-[7] sequence req3w2: conflicted with ‹00000004-0000-0000-0000-000000000000› on ‹"a"› for 0.000s
+[7] sequence req3w2: conflicted with 00000004-0000-0000-0000-000000000000 on ‹"a"› for 0.000s
 [7] sequence req3w2: acquiring latches
 [7] sequence req3w2: scanning lock table for conflicting locks
 [7] sequence req3w2: sequencing complete, returned guard
@@ -420,7 +420,7 @@ on-txn-updated txn=txn3 status=committed
 [-] update txn: committing txn3
 [6] sequence req2w2: resolving intent ‹"c"› for txn 00000003 with COMMITTED status
 [6] sequence req2w2: lock wait-queue event: done waiting
-[6] sequence req2w2: conflicted with ‹00000003-0000-0000-0000-000000000000› on ‹"c"› for 0.000s
+[6] sequence req2w2: conflicted with 00000003-0000-0000-0000-000000000000 on ‹"c"› for 0.000s
 [6] sequence req2w2: acquiring latches
 [6] sequence req2w2: scanning lock table for conflicting locks
 [6] sequence req2w2: sequencing complete, returned guard
@@ -558,7 +558,7 @@ on-txn-updated txn=txn2 status=committed
 [-] update txn: committing txn2
 [4] sequence req4w: resolving intent ‹"b"› for txn 00000002 with COMMITTED status
 [4] sequence req4w: lock wait-queue event: wait for txn 00000003 holding lock @ key ‹"c"› (queuedLockingRequests: 1, queuedReaders: 0)
-[4] sequence req4w: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"b"› for 0.000s
+[4] sequence req4w: conflicted with 00000002-0000-0000-0000-000000000000 on ‹"b"› for 0.000s
 [4] sequence req4w: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [4] sequence req4w: pushing txn 00000003 to abort
 [4] sequence req4w: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -634,10 +634,10 @@ on-txn-updated txn=txn4 status=aborted
 ----
 [-] update txn: aborting txn4
 [4] sequence req4w: detected pusher aborted
-[4] sequence req4w: conflicted with ‹00000003-0000-0000-0000-000000000000› on ‹"c"› for 0.000s
+[4] sequence req4w: conflicted with 00000003-0000-0000-0000-000000000000 on ‹"c"› for 0.000s
 [4] sequence req4w: sequencing complete, returned error: TransactionAbortedError(ABORT_REASON_PUSHER_ABORTED)
 [5] sequence req1w2: lock wait-queue event: done waiting
-[5] sequence req1w2: conflicted with ‹00000004-0000-0000-0000-000000000000› on ‹"b"› for 0.000s
+[5] sequence req1w2: conflicted with 00000004-0000-0000-0000-000000000000 on ‹"b"› for 0.000s
 [5] sequence req1w2: acquiring latches
 [5] sequence req1w2: scanning lock table for conflicting locks
 [5] sequence req1w2: sequencing complete, returned guard
@@ -652,7 +652,7 @@ on-txn-updated txn=txn1 status=committed
 [-] update txn: committing txn1
 [6] sequence req3w2: resolving intent ‹"a"› for txn 00000001 with COMMITTED status
 [6] sequence req3w2: lock wait-queue event: done waiting
-[6] sequence req3w2: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"a"› for 0.000s
+[6] sequence req3w2: conflicted with 00000001-0000-0000-0000-000000000000 on ‹"a"› for 0.000s
 [6] sequence req3w2: acquiring latches
 [6] sequence req3w2: scanning lock table for conflicting locks
 [6] sequence req3w2: sequencing complete, returned guard
@@ -790,7 +790,7 @@ on-txn-updated txn=txn2 status=committed
 [-] update txn: committing txn2
 [4] sequence req4w: resolving intent ‹"b"› for txn 00000002 with COMMITTED status
 [4] sequence req4w: lock wait-queue event: wait for txn 00000003 holding lock @ key ‹"c"› (queuedLockingRequests: 1, queuedReaders: 0)
-[4] sequence req4w: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"b"› for 0.000s
+[4] sequence req4w: conflicted with 00000002-0000-0000-0000-000000000000 on ‹"b"› for 0.000s
 [4] sequence req4w: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [4] sequence req4w: pushing txn 00000003 to abort
 [4] sequence req4w: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -866,11 +866,11 @@ on-txn-updated txn=txn1 status=aborted
 ----
 [-] update txn: aborting txn1
 [5] sequence req1w2: detected pusher aborted
-[5] sequence req1w2: conflicted with ‹00000004-0000-0000-0000-000000000000› on ‹"b"› for 0.000s
+[5] sequence req1w2: conflicted with 00000004-0000-0000-0000-000000000000 on ‹"b"› for 0.000s
 [5] sequence req1w2: sequencing complete, returned error: TransactionAbortedError(ABORT_REASON_PUSHER_ABORTED)
 [6] sequence req3w2: resolving intent ‹"a"› for txn 00000001 with ABORTED status
 [6] sequence req3w2: lock wait-queue event: done waiting
-[6] sequence req3w2: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"a"› for 0.000s
+[6] sequence req3w2: conflicted with 00000001-0000-0000-0000-000000000000 on ‹"a"› for 0.000s
 [6] sequence req3w2: acquiring latches
 [6] sequence req3w2: scanning lock table for conflicting locks
 [6] sequence req3w2: sequencing complete, returned guard
@@ -885,7 +885,7 @@ on-txn-updated txn=txn3 status=committed
 [-] update txn: committing txn3
 [4] sequence req4w: resolving intent ‹"c"› for txn 00000003 with COMMITTED status
 [4] sequence req4w: lock wait-queue event: done waiting
-[4] sequence req4w: conflicted with ‹00000003-0000-0000-0000-000000000000› on ‹"c"› for 0.000s
+[4] sequence req4w: conflicted with 00000003-0000-0000-0000-000000000000 on ‹"c"› for 0.000s
 [4] sequence req4w: acquiring latches
 [4] sequence req4w: scanning lock table for conflicting locks
 [4] sequence req4w: sequencing complete, returned guard
@@ -1045,7 +1045,7 @@ on-txn-updated txn=txn1 status=committed
 [-] update txn: committing txn1
 [5] sequence req4w: resolving intent ‹"a"› for txn 00000001 with COMMITTED status
 [5] sequence req4w: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"b"› (queuedLockingRequests: 2, queuedReaders: 0)
-[5] sequence req4w: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"a"› for 0.000s
+[5] sequence req4w: conflicted with 00000001-0000-0000-0000-000000000000 on ‹"a"› for 0.000s
 [5] sequence req4w: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [5] sequence req4w: pushing txn 00000002 to abort
 [5] sequence req4w: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -1055,13 +1055,13 @@ on-txn-updated txn=txn2 status=committed
 [-] update txn: committing txn2
 [4] sequence req5w: resolving intent ‹"b"› for txn 00000002 with COMMITTED status
 [4] sequence req5w: lock wait-queue event: wait for txn 00000003 holding lock @ key ‹"c"› (queuedLockingRequests: 1, queuedReaders: 0)
-[4] sequence req5w: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"b"› for 0.000s
+[4] sequence req5w: conflicted with 00000002-0000-0000-0000-000000000000 on ‹"b"› for 0.000s
 [4] sequence req5w: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [4] sequence req5w: pushing txn 00000003 to abort
 [4] sequence req5w: blocked on select in concurrency_test.(*cluster).PushTransaction
 [5] sequence req4w: resolving intent ‹"b"› for txn 00000002 with COMMITTED status
 [5] sequence req4w: lock wait-queue event: wait for txn 00000005 running request @ key ‹"b"› (queuedLockingRequests: 2, queuedReaders: 0)
-[5] sequence req4w: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"b"› for 0.000s
+[5] sequence req4w: conflicted with 00000002-0000-0000-0000-000000000000 on ‹"b"› for 0.000s
 [5] sequence req4w: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [5] sequence req4w: pushing txn 00000005 to detect request deadlock
 [5] sequence req4w: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -1124,10 +1124,10 @@ on-txn-updated txn=txn4 status=aborted
 ----
 [-] update txn: aborting txn4
 [5] sequence req4w: detected pusher aborted
-[5] sequence req4w: conflicted with ‹00000005-0000-0000-0000-000000000000› on ‹"b"› for 0.000s
+[5] sequence req4w: conflicted with 00000005-0000-0000-0000-000000000000 on ‹"b"› for 0.000s
 [5] sequence req4w: sequencing complete, returned error: TransactionAbortedError(ABORT_REASON_PUSHER_ABORTED)
 [6] sequence req3w2: lock wait-queue event: done waiting
-[6] sequence req3w2: conflicted with ‹00000004-0000-0000-0000-000000000000› on ‹"a"› for 0.000s
+[6] sequence req3w2: conflicted with 00000004-0000-0000-0000-000000000000 on ‹"a"› for 0.000s
 [6] sequence req3w2: acquiring latches
 [6] sequence req3w2: scanning lock table for conflicting locks
 [6] sequence req3w2: sequencing complete, returned guard
@@ -1142,7 +1142,7 @@ on-txn-updated txn=txn3 status=committed
 [-] update txn: committing txn3
 [4] sequence req5w: resolving intent ‹"c"› for txn 00000003 with COMMITTED status
 [4] sequence req5w: lock wait-queue event: done waiting
-[4] sequence req5w: conflicted with ‹00000003-0000-0000-0000-000000000000› on ‹"c"› for 0.000s
+[4] sequence req5w: conflicted with 00000003-0000-0000-0000-000000000000 on ‹"c"› for 0.000s
 [4] sequence req5w: acquiring latches
 [4] sequence req5w: scanning lock table for conflicting locks
 [4] sequence req5w: sequencing complete, returned guard
@@ -1285,11 +1285,11 @@ on-txn-updated txn=txn1 status=aborted
 ----
 [-] update txn: aborting txn1
 [3] sequence req3w: detected pusher aborted
-[3] sequence req3w: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"b"› for 0.000s
+[3] sequence req3w: conflicted with 00000002-0000-0000-0000-000000000000 on ‹"b"› for 0.000s
 [3] sequence req3w: sequencing complete, returned error: TransactionAbortedError(ABORT_REASON_PUSHER_ABORTED)
 [4] sequence req4w: resolving intent ‹"a"› for txn 00000001 with ABORTED status
 [4] sequence req4w: lock wait-queue event: done waiting
-[4] sequence req4w: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"a"› for 0.000s
+[4] sequence req4w: conflicted with 00000001-0000-0000-0000-000000000000 on ‹"a"› for 0.000s
 [4] sequence req4w: acquiring latches
 [4] sequence req4w: scanning lock table for conflicting locks
 [4] sequence req4w: sequencing complete, returned guard

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/discover_lock_after_lease_race
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/discover_lock_after_lease_race
@@ -181,13 +181,13 @@ on-txn-updated txn=txn3 status=committed
 [-] update txn: committing txn3
 [5] sequence req4: resolving intent ‹"k"› for txn 00000003 with COMMITTED status
 [5] sequence req4: lock wait-queue event: done waiting
-[5] sequence req4: conflicted with ‹00000003-0000-0000-0000-000000000000› on ‹"k"› for 0.000s
+[5] sequence req4: conflicted with 00000003-0000-0000-0000-000000000000 on ‹"k"› for 0.000s
 [5] sequence req4: acquiring latches
 [5] sequence req4: scanning lock table for conflicting locks
 [5] sequence req4: sequencing complete, returned guard
 [7] sequence req2: resolving intent ‹"k"› for txn 00000003 with COMMITTED status
 [7] sequence req2: lock wait-queue event: done waiting
-[7] sequence req2: conflicted with ‹00000003-0000-0000-0000-000000000000› on ‹"k"› for 0.000s
+[7] sequence req2: conflicted with 00000003-0000-0000-0000-000000000000 on ‹"k"› for 0.000s
 [7] sequence req2: acquiring latches
 [7] sequence req2: scanning lock table for conflicting locks
 [7] sequence req2: sequencing complete, returned guard

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/discovered_lock
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/discovered_lock
@@ -47,7 +47,7 @@ on-txn-updated txn=txn1 status=aborted
 [-] update txn: aborting txn1
 [3] sequence req1: resolving intent ‹"k"› for txn 00000001 with ABORTED status
 [3] sequence req1: lock wait-queue event: done waiting
-[3] sequence req1: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"k"› for 0.000s
+[3] sequence req1: conflicted with 00000001-0000-0000-0000-000000000000 on ‹"k"› for 0.000s
 [3] sequence req1: acquiring latches
 [3] sequence req1: scanning lock table for conflicting locks
 [3] sequence req1: sequencing complete, returned guard

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/isolation_level
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/isolation_level
@@ -291,7 +291,7 @@ sequence req=req6
 ----
 [7] sequence req5: resolving intent ‹"kSSINormal1"› for txn 00000001 with PENDING status and clock observation {1 123.000000000,1}
 [7] sequence req5: lock wait-queue event: done waiting
-[7] sequence req5: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"kSSINormal1"› for 0.000s
+[7] sequence req5: conflicted with 00000001-0000-0000-0000-000000000000 on ‹"kSSINormal1"› for 0.000s
 [7] sequence req5: acquiring latches
 [7] sequence req5: scanning lock table for conflicting locks
 [7] sequence req5: sequencing complete, returned guard
@@ -305,7 +305,7 @@ sequence req=req6
 [8] sequence req6: pusher pushed pushee to 11.000000000,2
 [8] sequence req6: resolving intent ‹"kSSINormal2"› for txn 00000001 with PENDING status and clock observation {1 123.000000000,3}
 [8] sequence req6: lock wait-queue event: done waiting
-[8] sequence req6: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"kSSINormal2"› for 0.000s
+[8] sequence req6: conflicted with 00000001-0000-0000-0000-000000000000 on ‹"kSSINormal2"› for 0.000s
 [8] sequence req6: acquiring latches
 [8] sequence req6: scanning lock table for conflicting locks
 [8] sequence req6: sequencing complete, returned guard
@@ -342,7 +342,7 @@ sequence req=req7
 [9] sequence req7: pusher pushed pushee to 12.000000000,2
 [9] sequence req7: resolving intent ‹"kSSINormal3"› for txn 00000001 with PENDING status and clock observation {1 123.000000000,5}
 [9] sequence req7: lock wait-queue event: done waiting
-[9] sequence req7: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"kSSINormal3"› for 0.000s
+[9] sequence req7: conflicted with 00000001-0000-0000-0000-000000000000 on ‹"kSSINormal3"› for 0.000s
 [9] sequence req7: acquiring latches
 [9] sequence req7: scanning lock table for conflicting locks
 [9] sequence req7: sequencing complete, returned guard
@@ -375,7 +375,7 @@ sequence req=req8
 [10] sequence req8: pusher pushed pushee to 13.000000000,2
 [10] sequence req8: resolving intent ‹"kSSINormal4"› for txn 00000001 with PENDING status and clock observation {1 123.000000000,7}
 [10] sequence req8: lock wait-queue event: done waiting
-[10] sequence req8: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"kSSINormal4"› for 0.000s
+[10] sequence req8: conflicted with 00000001-0000-0000-0000-000000000000 on ‹"kSSINormal4"› for 0.000s
 [10] sequence req8: acquiring latches
 [10] sequence req8: scanning lock table for conflicting locks
 [10] sequence req8: sequencing complete, returned guard
@@ -500,19 +500,19 @@ sequence req=req12
 ----
 [11] sequence req9: resolving intent ‹"kSSIHigh1"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,9}
 [11] sequence req9: lock wait-queue event: done waiting
-[11] sequence req9: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"kSSIHigh1"› for 0.000s
+[11] sequence req9: conflicted with 00000002-0000-0000-0000-000000000000 on ‹"kSSIHigh1"› for 0.000s
 [11] sequence req9: acquiring latches
 [11] sequence req9: scanning lock table for conflicting locks
 [11] sequence req9: sequencing complete, returned guard
 [12] sequence req10: resolving intent ‹"kSSIHigh2"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,11}
 [12] sequence req10: lock wait-queue event: done waiting
-[12] sequence req10: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"kSSIHigh2"› for 0.000s
+[12] sequence req10: conflicted with 00000002-0000-0000-0000-000000000000 on ‹"kSSIHigh2"› for 0.000s
 [12] sequence req10: acquiring latches
 [12] sequence req10: scanning lock table for conflicting locks
 [12] sequence req10: sequencing complete, returned guard
 [13] sequence req11: resolving intent ‹"kSSIHigh3"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,13}
 [13] sequence req11: lock wait-queue event: done waiting
-[13] sequence req11: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"kSSIHigh3"› for 0.000s
+[13] sequence req11: conflicted with 00000002-0000-0000-0000-000000000000 on ‹"kSSIHigh3"› for 0.000s
 [13] sequence req11: acquiring latches
 [13] sequence req11: scanning lock table for conflicting locks
 [13] sequence req11: sequencing complete, returned guard
@@ -526,7 +526,7 @@ sequence req=req12
 [14] sequence req12: pusher pushed pushee to 13.000000000,2
 [14] sequence req12: resolving intent ‹"kSSIHigh4"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,15}
 [14] sequence req12: lock wait-queue event: done waiting
-[14] sequence req12: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"kSSIHigh4"› for 0.000s
+[14] sequence req12: conflicted with 00000002-0000-0000-0000-000000000000 on ‹"kSSIHigh4"› for 0.000s
 [14] sequence req12: acquiring latches
 [14] sequence req12: scanning lock table for conflicting locks
 [14] sequence req12: sequencing complete, returned guard
@@ -590,7 +590,7 @@ sequence req=req13
 [15] sequence req13: pusher pushed pushee to 10.000000000,2
 [15] sequence req13: resolving intent ‹"kRCNormal1"› for txn 00000003 with PENDING status and clock observation {1 123.000000000,17}
 [15] sequence req13: lock wait-queue event: done waiting
-[15] sequence req13: conflicted with ‹00000003-0000-0000-0000-000000000000› on ‹"kRCNormal1"› for 0.000s
+[15] sequence req13: conflicted with 00000003-0000-0000-0000-000000000000 on ‹"kRCNormal1"› for 0.000s
 [15] sequence req13: acquiring latches
 [15] sequence req13: scanning lock table for conflicting locks
 [15] sequence req13: sequencing complete, returned guard
@@ -622,7 +622,7 @@ sequence req=req14
 [16] sequence req14: pusher pushed pushee to 11.000000000,2
 [16] sequence req14: resolving intent ‹"kRCNormal2"› for txn 00000003 with PENDING status and clock observation {1 123.000000000,19}
 [16] sequence req14: lock wait-queue event: done waiting
-[16] sequence req14: conflicted with ‹00000003-0000-0000-0000-000000000000› on ‹"kRCNormal2"› for 0.000s
+[16] sequence req14: conflicted with 00000003-0000-0000-0000-000000000000 on ‹"kRCNormal2"› for 0.000s
 [16] sequence req14: acquiring latches
 [16] sequence req14: scanning lock table for conflicting locks
 [16] sequence req14: sequencing complete, returned guard
@@ -654,7 +654,7 @@ sequence req=req15
 [17] sequence req15: pusher pushed pushee to 12.000000000,2
 [17] sequence req15: resolving intent ‹"kRCNormal3"› for txn 00000003 with PENDING status and clock observation {1 123.000000000,21}
 [17] sequence req15: lock wait-queue event: done waiting
-[17] sequence req15: conflicted with ‹00000003-0000-0000-0000-000000000000› on ‹"kRCNormal3"› for 0.000s
+[17] sequence req15: conflicted with 00000003-0000-0000-0000-000000000000 on ‹"kRCNormal3"› for 0.000s
 [17] sequence req15: acquiring latches
 [17] sequence req15: scanning lock table for conflicting locks
 [17] sequence req15: sequencing complete, returned guard
@@ -686,7 +686,7 @@ sequence req=req16
 [18] sequence req16: pusher pushed pushee to 13.000000000,2
 [18] sequence req16: resolving intent ‹"kRCNormal4"› for txn 00000003 with PENDING status and clock observation {1 123.000000000,23}
 [18] sequence req16: lock wait-queue event: done waiting
-[18] sequence req16: conflicted with ‹00000003-0000-0000-0000-000000000000› on ‹"kRCNormal4"› for 0.000s
+[18] sequence req16: conflicted with 00000003-0000-0000-0000-000000000000 on ‹"kRCNormal4"› for 0.000s
 [18] sequence req16: acquiring latches
 [18] sequence req16: scanning lock table for conflicting locks
 [18] sequence req16: sequencing complete, returned guard
@@ -730,7 +730,7 @@ sequence req=req17
 [19] sequence req17: pusher pushed pushee to 10.000000000,2
 [19] sequence req17: resolving intent ‹"kRCHigh1"› for txn 00000004 with PENDING status and clock observation {1 123.000000000,25}
 [19] sequence req17: lock wait-queue event: done waiting
-[19] sequence req17: conflicted with ‹00000004-0000-0000-0000-000000000000› on ‹"kRCHigh1"› for 0.000s
+[19] sequence req17: conflicted with 00000004-0000-0000-0000-000000000000 on ‹"kRCHigh1"› for 0.000s
 [19] sequence req17: acquiring latches
 [19] sequence req17: scanning lock table for conflicting locks
 [19] sequence req17: sequencing complete, returned guard
@@ -762,7 +762,7 @@ sequence req=req18
 [20] sequence req18: pusher pushed pushee to 11.000000000,2
 [20] sequence req18: resolving intent ‹"kRCHigh2"› for txn 00000004 with PENDING status and clock observation {1 123.000000000,27}
 [20] sequence req18: lock wait-queue event: done waiting
-[20] sequence req18: conflicted with ‹00000004-0000-0000-0000-000000000000› on ‹"kRCHigh2"› for 0.000s
+[20] sequence req18: conflicted with 00000004-0000-0000-0000-000000000000 on ‹"kRCHigh2"› for 0.000s
 [20] sequence req18: acquiring latches
 [20] sequence req18: scanning lock table for conflicting locks
 [20] sequence req18: sequencing complete, returned guard
@@ -794,7 +794,7 @@ sequence req=req19
 [21] sequence req19: pusher pushed pushee to 12.000000000,2
 [21] sequence req19: resolving intent ‹"kRCHigh3"› for txn 00000004 with PENDING status and clock observation {1 123.000000000,29}
 [21] sequence req19: lock wait-queue event: done waiting
-[21] sequence req19: conflicted with ‹00000004-0000-0000-0000-000000000000› on ‹"kRCHigh3"› for 0.000s
+[21] sequence req19: conflicted with 00000004-0000-0000-0000-000000000000 on ‹"kRCHigh3"› for 0.000s
 [21] sequence req19: acquiring latches
 [21] sequence req19: scanning lock table for conflicting locks
 [21] sequence req19: sequencing complete, returned guard
@@ -826,7 +826,7 @@ sequence req=req20
 [22] sequence req20: pusher pushed pushee to 13.000000000,2
 [22] sequence req20: resolving intent ‹"kRCHigh4"› for txn 00000004 with PENDING status and clock observation {1 123.000000000,31}
 [22] sequence req20: lock wait-queue event: done waiting
-[22] sequence req20: conflicted with ‹00000004-0000-0000-0000-000000000000› on ‹"kRCHigh4"› for 0.000s
+[22] sequence req20: conflicted with 00000004-0000-0000-0000-000000000000 on ‹"kRCHigh4"› for 0.000s
 [22] sequence req20: acquiring latches
 [22] sequence req20: scanning lock table for conflicting locks
 [22] sequence req20: sequencing complete, returned guard

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/lock_timeout
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/lock_timeout
@@ -106,7 +106,7 @@ sequence req=reqTimeout1
 [4] sequence reqTimeout1: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = true, priority enforcement = false, wait policy error = false
 [4] sequence reqTimeout1: pushing timestamp of txn 00000001 above 12.000000000,1
 [4] sequence reqTimeout1: pushee not abandoned
-[4] sequence reqTimeout1: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"k"› for 0.000s
+[4] sequence reqTimeout1: conflicted with 00000001-0000-0000-0000-000000000000 on ‹"k"› for 0.000s
 [4] sequence reqTimeout1: sequencing complete, returned error: conflicting locks on ‹"k"› [reason=lock_timeout]
 
 # -------------------------------------------------------------
@@ -119,7 +119,7 @@ on-txn-updated txn=txn1 status=committed
 [-] update txn: committing txn1
 [3] sequence req3: resolving intent ‹"k2"› for txn 00000001 with COMMITTED status
 [3] sequence req3: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"k3"› (queuedLockingRequests: 1, queuedReaders: 0)
-[3] sequence req3: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"k2"› for 0.000s
+[3] sequence req3: conflicted with 00000001-0000-0000-0000-000000000000 on ‹"k2"› for 0.000s
 [3] sequence req3: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [3] sequence req3: pushing txn 00000002 to abort
 [3] sequence req3: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -166,7 +166,7 @@ sequence req=reqTimeout2
 [6] sequence reqTimeout2: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = true, priority enforcement = false, wait policy error = false
 [6] sequence reqTimeout2: pushing txn 00000003 to abort
 [6] sequence reqTimeout2: pushee not abandoned
-[6] sequence reqTimeout2: conflicted with ‹00000003-0000-0000-0000-000000000000› on ‹"k2"› for 0.000s
+[6] sequence reqTimeout2: conflicted with 00000003-0000-0000-0000-000000000000 on ‹"k2"› for 0.000s
 [6] sequence reqTimeout2: sequencing complete, returned error: conflicting locks on ‹"k2"› [reason=lock_timeout]
 
 # -------------------------------------------------------------
@@ -200,7 +200,7 @@ sequence req=reqTimeout3
 [9] sequence reqTimeout3: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = true, priority enforcement = false, wait policy error = false
 [9] sequence reqTimeout3: pushing timestamp of txn 00000002 above 12.000000000,1
 [9] sequence reqTimeout3: pushee not abandoned
-[9] sequence reqTimeout3: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"k4"› for 0.000s
+[9] sequence reqTimeout3: conflicted with 00000002-0000-0000-0000-000000000000 on ‹"k4"› for 0.000s
 [9] sequence reqTimeout3: sequencing complete, returned error: conflicting locks on ‹"k4"› [reason=lock_timeout]
 
 debug-lock-table
@@ -226,7 +226,7 @@ on-txn-updated txn=txn2 status=aborted
 [-] update txn: aborting txn2
 [3] sequence req3: resolving intent ‹"k3"› for txn 00000002 with ABORTED status
 [3] sequence req3: lock wait-queue event: done waiting
-[3] sequence req3: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"k3"› for 0.000s
+[3] sequence req3: conflicted with 00000002-0000-0000-0000-000000000000 on ‹"k3"› for 0.000s
 [3] sequence req3: acquiring latches
 [3] sequence req3: scanning lock table for conflicting locks
 [3] sequence req3: sequencing complete, returned guard

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/optimistic
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/optimistic
@@ -100,7 +100,7 @@ on-txn-updated txn=txn1 status=committed
 [-] update txn: committing txn1
 [4] sequence req3: resolving intent ‹"d"› for txn 00000001 with COMMITTED status
 [4] sequence req3: lock wait-queue event: done waiting
-[4] sequence req3: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"d"› for 0.000s
+[4] sequence req3: conflicted with 00000001-0000-0000-0000-000000000000 on ‹"d"› for 0.000s
 [4] sequence req3: acquiring latches
 [4] sequence req3: scanning lock table for conflicting locks
 [4] sequence req3: sequencing complete, returned guard

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/priority
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/priority
@@ -146,7 +146,7 @@ sequence req=req5
 ----
 [4] sequence req4: resolving intent ‹"kLow1"› for txn 00000001 with PENDING status and clock observation {1 123.000000000,1}
 [4] sequence req4: lock wait-queue event: done waiting
-[4] sequence req4: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"kLow1"› for 0.000s
+[4] sequence req4: conflicted with 00000001-0000-0000-0000-000000000000 on ‹"kLow1"› for 0.000s
 [4] sequence req4: acquiring latches
 [4] sequence req4: scanning lock table for conflicting locks
 [4] sequence req4: sequencing complete, returned guard
@@ -160,7 +160,7 @@ sequence req=req5
 [5] sequence req5: pusher pushed pushee to 10.000000000,2
 [5] sequence req5: resolving intent ‹"kLow1"› for txn 00000001 with PENDING status and clock observation {1 123.000000000,3}
 [5] sequence req5: lock wait-queue event: done waiting
-[5] sequence req5: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"kLow1"› for 0.000s
+[5] sequence req5: conflicted with 00000001-0000-0000-0000-000000000000 on ‹"kLow1"› for 0.000s
 [5] sequence req5: acquiring latches
 [5] sequence req5: scanning lock table for conflicting locks
 [5] sequence req5: sequencing complete, returned guard
@@ -218,7 +218,7 @@ sequence req=req7
 ----
 [6] sequence req6: resolving intent ‹"kLow2"› for txn 00000001 with ABORTED status
 [6] sequence req6: lock wait-queue event: done waiting
-[6] sequence req6: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"kLow2"› for 0.000s
+[6] sequence req6: conflicted with 00000001-0000-0000-0000-000000000000 on ‹"kLow2"› for 0.000s
 [6] sequence req6: acquiring latches
 [6] sequence req6: scanning lock table for conflicting locks
 [6] sequence req6: sequencing complete, returned guard
@@ -232,7 +232,7 @@ sequence req=req7
 [7] sequence req7: pusher aborted pushee
 [7] sequence req7: resolving intent ‹"kLow2"› for txn 00000001 with ABORTED status
 [7] sequence req7: lock wait-queue event: wait for txn 00000004 running request @ key ‹"kLow2"› (queuedLockingRequests: 2, queuedReaders: 0)
-[7] sequence req7: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"kLow2"› for 0.000s
+[7] sequence req7: conflicted with 00000001-0000-0000-0000-000000000000 on ‹"kLow2"› for 0.000s
 [7] sequence req7: pushing after 0s for: deadlock/liveness detection = false, timeout enforcement = false, priority enforcement = true, wait policy error = false
 [7] sequence req7: pushing txn 00000004 to detect request deadlock
 [7] sequence req7: pusher aborted pushee
@@ -242,7 +242,7 @@ finish req=req6
 ----
 [-] finish req6: finishing request
 [7] sequence req7: lock wait-queue event: done waiting
-[7] sequence req7: conflicted with ‹00000004-0000-0000-0000-000000000000› on ‹"kLow2"› for 0.000s
+[7] sequence req7: conflicted with 00000004-0000-0000-0000-000000000000 on ‹"kLow2"› for 0.000s
 [7] sequence req7: acquiring latches
 [7] sequence req7: scanning lock table for conflicting locks
 [7] sequence req7: sequencing complete, returned guard
@@ -294,7 +294,7 @@ sequence req=req9
 ----
 [8] sequence req8: resolving intent ‹"kNormal1"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,6}
 [8] sequence req8: lock wait-queue event: done waiting
-[8] sequence req8: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"kNormal1"› for 0.000s
+[8] sequence req8: conflicted with 00000002-0000-0000-0000-000000000000 on ‹"kNormal1"› for 0.000s
 [8] sequence req8: acquiring latches
 [8] sequence req8: scanning lock table for conflicting locks
 [8] sequence req8: sequencing complete, returned guard
@@ -308,7 +308,7 @@ sequence req=req9
 [9] sequence req9: pusher pushed pushee to 10.000000000,2
 [9] sequence req9: resolving intent ‹"kNormal1"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,8}
 [9] sequence req9: lock wait-queue event: done waiting
-[9] sequence req9: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"kNormal1"› for 0.000s
+[9] sequence req9: conflicted with 00000002-0000-0000-0000-000000000000 on ‹"kNormal1"› for 0.000s
 [9] sequence req9: acquiring latches
 [9] sequence req9: scanning lock table for conflicting locks
 [9] sequence req9: sequencing complete, returned guard
@@ -364,7 +364,7 @@ sequence req=req11
 ----
 [10] sequence req10: resolving intent ‹"kNormal2"› for txn 00000002 with ABORTED status
 [10] sequence req10: lock wait-queue event: done waiting
-[10] sequence req10: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"kNormal2"› for 0.000s
+[10] sequence req10: conflicted with 00000002-0000-0000-0000-000000000000 on ‹"kNormal2"› for 0.000s
 [10] sequence req10: acquiring latches
 [10] sequence req10: scanning lock table for conflicting locks
 [10] sequence req10: sequencing complete, returned guard
@@ -378,7 +378,7 @@ sequence req=req11
 [11] sequence req11: pusher aborted pushee
 [11] sequence req11: resolving intent ‹"kNormal2"› for txn 00000002 with ABORTED status
 [11] sequence req11: lock wait-queue event: wait for txn 00000007 running request @ key ‹"kNormal2"› (queuedLockingRequests: 2, queuedReaders: 0)
-[11] sequence req11: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"kNormal2"› for 0.000s
+[11] sequence req11: conflicted with 00000002-0000-0000-0000-000000000000 on ‹"kNormal2"› for 0.000s
 [11] sequence req11: pushing after 0s for: deadlock/liveness detection = false, timeout enforcement = false, priority enforcement = true, wait policy error = false
 [11] sequence req11: pushing txn 00000007 to detect request deadlock
 [11] sequence req11: pusher aborted pushee
@@ -388,7 +388,7 @@ finish req=req10
 ----
 [-] finish req10: finishing request
 [11] sequence req11: lock wait-queue event: done waiting
-[11] sequence req11: conflicted with ‹00000007-0000-0000-0000-000000000000› on ‹"kNormal2"› for 0.000s
+[11] sequence req11: conflicted with 00000007-0000-0000-0000-000000000000 on ‹"kNormal2"› for 0.000s
 [11] sequence req11: acquiring latches
 [11] sequence req11: scanning lock table for conflicting locks
 [11] sequence req11: sequencing complete, returned guard
@@ -450,13 +450,13 @@ on-txn-updated txn=txnHighPushee status=pending ts=10,2
 [-] update txn: increasing timestamp of txnHighPushee
 [12] sequence req12: resolving intent ‹"kHigh1"› for txn 00000003 with PENDING status and clock observation {1 123.000000000,11}
 [12] sequence req12: lock wait-queue event: done waiting
-[12] sequence req12: conflicted with ‹00000003-0000-0000-0000-000000000000› on ‹"kHigh1"› for 0.000s
+[12] sequence req12: conflicted with 00000003-0000-0000-0000-000000000000 on ‹"kHigh1"› for 0.000s
 [12] sequence req12: acquiring latches
 [12] sequence req12: scanning lock table for conflicting locks
 [12] sequence req12: sequencing complete, returned guard
 [13] sequence req13: resolving intent ‹"kHigh1"› for txn 00000003 with PENDING status and clock observation {1 123.000000000,13}
 [13] sequence req13: lock wait-queue event: done waiting
-[13] sequence req13: conflicted with ‹00000003-0000-0000-0000-000000000000› on ‹"kHigh1"› for 0.000s
+[13] sequence req13: conflicted with 00000003-0000-0000-0000-000000000000 on ‹"kHigh1"› for 0.000s
 [13] sequence req13: acquiring latches
 [13] sequence req13: scanning lock table for conflicting locks
 [13] sequence req13: sequencing complete, returned guard
@@ -522,13 +522,13 @@ on-txn-updated txn=txnHighPushee status=committed
 [-] update txn: committing txnHighPushee
 [14] sequence req14: resolving intent ‹"kHigh2"› for txn 00000003 with COMMITTED status
 [14] sequence req14: lock wait-queue event: done waiting
-[14] sequence req14: conflicted with ‹00000003-0000-0000-0000-000000000000› on ‹"kHigh2"› for 0.000s
+[14] sequence req14: conflicted with 00000003-0000-0000-0000-000000000000 on ‹"kHigh2"› for 0.000s
 [14] sequence req14: acquiring latches
 [14] sequence req14: scanning lock table for conflicting locks
 [14] sequence req14: sequencing complete, returned guard
 [15] sequence req15: resolving intent ‹"kHigh2"› for txn 00000003 with COMMITTED status
 [15] sequence req15: lock wait-queue event: wait for txn 00000008 running request @ key ‹"kHigh2"› (queuedLockingRequests: 2, queuedReaders: 0)
-[15] sequence req15: conflicted with ‹00000003-0000-0000-0000-000000000000› on ‹"kHigh2"› for 0.000s
+[15] sequence req15: conflicted with 00000003-0000-0000-0000-000000000000 on ‹"kHigh2"› for 0.000s
 [15] sequence req15: pushing after 0s for: deadlock/liveness detection = false, timeout enforcement = false, priority enforcement = true, wait policy error = false
 [15] sequence req15: pushing txn 00000008 to detect request deadlock
 [15] sequence req15: pusher aborted pushee
@@ -538,7 +538,7 @@ finish req=req14
 ----
 [-] finish req14: finishing request
 [15] sequence req15: lock wait-queue event: done waiting
-[15] sequence req15: conflicted with ‹00000008-0000-0000-0000-000000000000› on ‹"kHigh2"› for 0.000s
+[15] sequence req15: conflicted with 00000008-0000-0000-0000-000000000000 on ‹"kHigh2"› for 0.000s
 [15] sequence req15: acquiring latches
 [15] sequence req15: scanning lock table for conflicting locks
 [15] sequence req15: sequencing complete, returned guard

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/queue_length_exceeded
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/queue_length_exceeded
@@ -121,25 +121,25 @@ on-txn-updated txn=txn1 status=committed
 [-] update txn: committing txn1
 [2] sequence req2: resolving intent ‹"k"› for txn 00000001 with COMMITTED status
 [2] sequence req2: lock wait-queue event: done waiting
-[2] sequence req2: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"k"› for 0.000s
+[2] sequence req2: conflicted with 00000001-0000-0000-0000-000000000000 on ‹"k"› for 0.000s
 [2] sequence req2: acquiring latches
 [2] sequence req2: scanning lock table for conflicting locks
 [2] sequence req2: sequencing complete, returned guard
 [3] sequence req3: resolving intent ‹"k"› for txn 00000001 with COMMITTED status
 [3] sequence req3: lock wait-queue event: wait for txn 00000002 running request @ key ‹"k"› (queuedLockingRequests: 3, queuedReaders: 0)
-[3] sequence req3: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"k"› for 0.000s
+[3] sequence req3: conflicted with 00000001-0000-0000-0000-000000000000 on ‹"k"› for 0.000s
 [3] sequence req3: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [3] sequence req3: pushing txn 00000002 to detect request deadlock
 [3] sequence req3: blocked on select in concurrency_test.(*cluster).PushTransaction
 [4] sequence req4: resolving intent ‹"k"› for txn 00000001 with COMMITTED status
 [4] sequence req4: lock wait-queue event: wait for txn 00000002 running request @ key ‹"k"› (queuedLockingRequests: 3, queuedReaders: 0)
-[4] sequence req4: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"k"› for 0.000s
+[4] sequence req4: conflicted with 00000001-0000-0000-0000-000000000000 on ‹"k"› for 0.000s
 [4] sequence req4: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [4] sequence req4: pushing txn 00000002 to detect request deadlock
 [4] sequence req4: blocked on select in concurrency_test.(*cluster).PushTransaction
 [5] sequence req5r: resolving intent ‹"k"› for txn 00000001 with COMMITTED status
 [5] sequence req5r: lock wait-queue event: done waiting
-[5] sequence req5r: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"k"› for 0.000s
+[5] sequence req5r: conflicted with 00000001-0000-0000-0000-000000000000 on ‹"k"› for 0.000s
 [5] sequence req5r: acquiring latches
 [5] sequence req5r: scanning lock table for conflicting locks
 [5] sequence req5r: sequencing complete, returned guard
@@ -200,13 +200,13 @@ on-txn-updated txn=txn2 status=aborted
 [-] update txn: aborting txn2
 [3] sequence req3: resolving intent ‹"k"› for txn 00000002 with ABORTED status
 [3] sequence req3: lock wait-queue event: done waiting
-[3] sequence req3: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"k"› for 0.000s
+[3] sequence req3: conflicted with 00000002-0000-0000-0000-000000000000 on ‹"k"› for 0.000s
 [3] sequence req3: acquiring latches
 [3] sequence req3: scanning lock table for conflicting locks
 [3] sequence req3: sequencing complete, returned guard
 [4] sequence req4: resolving intent ‹"k"› for txn 00000002 with ABORTED status
 [4] sequence req4: lock wait-queue event: wait for txn 00000003 running request @ key ‹"k"› (queuedLockingRequests: 2, queuedReaders: 0)
-[4] sequence req4: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"k"› for 0.000s
+[4] sequence req4: conflicted with 00000002-0000-0000-0000-000000000000 on ‹"k"› for 0.000s
 [4] sequence req4: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [4] sequence req4: pushing txn 00000003 to detect request deadlock
 [4] sequence req4: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -215,7 +215,7 @@ finish req=req3
 ----
 [-] finish req3: finishing request
 [4] sequence req4: lock wait-queue event: done waiting
-[4] sequence req4: conflicted with ‹00000003-0000-0000-0000-000000000000› on ‹"k"› for 0.000s
+[4] sequence req4: conflicted with 00000003-0000-0000-0000-000000000000 on ‹"k"› for 0.000s
 [4] sequence req4: acquiring latches
 [4] sequence req4: scanning lock table for conflicting locks
 [4] sequence req4: sequencing complete, returned guard

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/range_state_listener
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/range_state_listener
@@ -112,7 +112,7 @@ on-lease-updated leaseholder=false lease-seq=2
 ----
 [-] transfer lease: released
 [2] sequence req2: lock wait-queue event: done waiting
-[2] sequence req2: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"k"› for 0.000s
+[2] sequence req2: conflicted with 00000001-0000-0000-0000-000000000000 on ‹"k"› for 0.000s
 [2] sequence req2: acquiring latches
 [2] sequence req2: scanning lock table for conflicting locks
 [2] sequence req2: sequencing complete, returned guard
@@ -192,7 +192,7 @@ on-lock-updated req=reqRes1 txn=txn1 key=k status=committed
 ----
 [-] update lock: committing txn 00000001 @ ‹k›
 [7] sequence req2: lock wait-queue event: done waiting
-[7] sequence req2: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"k"› for 0.000s
+[7] sequence req2: conflicted with 00000001-0000-0000-0000-000000000000 on ‹"k"› for 0.000s
 [7] sequence req2: acquiring latches
 [7] sequence req2: waiting to acquire read latch ‹k2›@10.000000000,1 for request Put [‹"k"›], Get [‹"k2"›], [txn: 00000002], held by write latch ‹k2›@10.000000000,1 for request ResolveIntent [‹"k"›], ResolveIntent [‹"k2"›]
 [7] sequence req2: blocked on select in spanlatch.(*Manager).waitForSignal
@@ -306,7 +306,7 @@ on-lock-updated req=reqRes2 txn=txn2 key=k status=committed
 ----
 [-] update lock: committing txn 00000002 @ ‹k›
 [13] sequence req3: lock wait-queue event: done waiting
-[13] sequence req3: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"k"› for 0.000s
+[13] sequence req3: conflicted with 00000002-0000-0000-0000-000000000000 on ‹"k"› for 0.000s
 [13] sequence req3: acquiring latches
 [13] sequence req3: waiting to acquire write latch ‹k›@10.000000000,1 for request Put [‹"k"›], [txn: 00000003], held by write latch ‹k›@10.000000000,1 for request ResolveIntent [‹"k"›]
 [13] sequence req3: blocked on select in spanlatch.(*Manager).waitForSignal
@@ -419,7 +419,7 @@ on-split key=a
 [-] split range: complete
 [-] split range: range split returned 1 locks for re-acquistion
 [2] sequence req2: lock wait-queue event: done waiting
-[2] sequence req2: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"k"› for 0.000s
+[2] sequence req2: conflicted with 00000001-0000-0000-0000-000000000000 on ‹"k"› for 0.000s
 [2] sequence req2: acquiring latches
 [2] sequence req2: scanning lock table for conflicting locks
 [2] sequence req2: sequencing complete, returned guard
@@ -465,7 +465,7 @@ on-lock-updated req=reqRes1 txn=txn1 key=k status=committed
 ----
 [-] update lock: committing txn 00000001 @ ‹k›
 [4] sequence req2: lock wait-queue event: done waiting
-[4] sequence req2: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"k"› for 0.000s
+[4] sequence req2: conflicted with 00000001-0000-0000-0000-000000000000 on ‹"k"› for 0.000s
 [4] sequence req2: acquiring latches
 [4] sequence req2: waiting to acquire write latch ‹k›@10.000000000,1 for request Put [‹"k"›], [txn: 00000002], held by write latch ‹k›@10.000000000,1 for request ResolveIntent [‹"k"›]
 [4] sequence req2: blocked on select in spanlatch.(*Manager).waitForSignal
@@ -636,7 +636,7 @@ on-split key=k2
 [-] split range: complete
 [-] split range: range split returned 1 locks for re-acquistion
 [4] sequence req4: lock wait-queue event: done waiting
-[4] sequence req4: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"k3"› for 0.000s
+[4] sequence req4: conflicted with 00000002-0000-0000-0000-000000000000 on ‹"k3"› for 0.000s
 [4] sequence req4: acquiring latches
 [4] sequence req4: scanning lock table for conflicting locks
 [4] sequence req4: sequencing complete, returned guard
@@ -668,7 +668,7 @@ on-lock-updated req=reqRes1 txn=txn1 key=k1 status=committed
 ----
 [-] update lock: committing txn 00000001 @ ‹k1›
 [3] sequence req3: lock wait-queue event: done waiting
-[3] sequence req3: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"k1"› for 0.000s
+[3] sequence req3: conflicted with 00000001-0000-0000-0000-000000000000 on ‹"k1"› for 0.000s
 [3] sequence req3: acquiring latches
 [3] sequence req3: waiting to acquire write latch ‹k1›@10.000000000,1 for request Put [‹"k1"›], [txn: 00000003], held by write latch ‹k1›@10.000000000,1 for request ResolveIntent [‹"k1"›]
 [3] sequence req3: blocked on select in spanlatch.(*Manager).waitForSignal
@@ -784,7 +784,7 @@ on-merge
 ----
 [-] merge range: complete
 [2] sequence req2: lock wait-queue event: done waiting
-[2] sequence req2: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"k"› for 0.000s
+[2] sequence req2: conflicted with 00000001-0000-0000-0000-000000000000 on ‹"k"› for 0.000s
 [2] sequence req2: acquiring latches
 [2] sequence req2: scanning lock table for conflicting locks
 [2] sequence req2: sequencing complete, returned guard
@@ -871,7 +871,7 @@ on-lock-updated req=reqRes1 txn=txn1 key=k status=committed
 ----
 [-] update lock: committing txn 00000001 @ ‹k›
 [8] sequence req2: lock wait-queue event: done waiting
-[8] sequence req2: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"k"› for 0.000s
+[8] sequence req2: conflicted with 00000001-0000-0000-0000-000000000000 on ‹"k"› for 0.000s
 [8] sequence req2: acquiring latches
 [8] sequence req2: waiting to acquire write latch ‹k›@10.000000000,1 for request Put [‹"k"›], [txn: 00000002], held by write latch ‹k›@10.000000000,1 for request ResolveIntent [‹"k"›]
 [8] sequence req2: blocked on select in spanlatch.(*Manager).waitForSignal
@@ -982,7 +982,7 @@ on-snapshot-applied
 ----
 [-] snapshot replica: applied
 [2] sequence req2: lock wait-queue event: done waiting
-[2] sequence req2: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"k"› for 0.000s
+[2] sequence req2: conflicted with 00000001-0000-0000-0000-000000000000 on ‹"k"› for 0.000s
 [2] sequence req2: acquiring latches
 [2] sequence req2: scanning lock table for conflicting locks
 [2] sequence req2: sequencing complete, returned guard
@@ -1028,7 +1028,7 @@ on-lock-updated req=reqRes1 txn=txn1 key=k status=committed
 ----
 [-] update lock: committing txn 00000001 @ ‹k›
 [4] sequence req2: lock wait-queue event: done waiting
-[4] sequence req2: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"k"› for 0.000s
+[4] sequence req2: conflicted with 00000001-0000-0000-0000-000000000000 on ‹"k"› for 0.000s
 [4] sequence req2: acquiring latches
 [4] sequence req2: waiting to acquire write latch ‹k›@10.000000000,1 for request Put [‹"k"›], [txn: 00000002], held by write latch ‹k›@10.000000000,1 for request ResolveIntent [‹"k"›]
 [4] sequence req2: blocked on select in spanlatch.(*Manager).waitForSignal

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/refresh
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/refresh
@@ -46,7 +46,7 @@ sequence req=reqNormalPriNoWait
 [2] sequence reqNormalPriNoWait: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = true
 [2] sequence reqNormalPriNoWait: pushing timestamp of txn 00000001 above 12.000000000,1
 [2] sequence reqNormalPriNoWait: pushee not abandoned
-[2] sequence reqNormalPriNoWait: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"k"› for 0.000s
+[2] sequence reqNormalPriNoWait: conflicted with 00000001-0000-0000-0000-000000000000 on ‹"k"› for 0.000s
 [2] sequence reqNormalPriNoWait: sequencing complete, returned error: conflicting locks on ‹"k"› [reason=wait_policy]
 
 debug-lock-table
@@ -77,7 +77,7 @@ sequence req=reqHighPriNoWait
 [3] sequence reqHighPriNoWait: pusher pushed pushee to 11.000000000,2
 [3] sequence reqHighPriNoWait: resolving intent ‹"k"› for txn 00000001 with PENDING status and clock observation {1 123.000000000,3}
 [3] sequence reqHighPriNoWait: lock wait-queue event: done waiting
-[3] sequence reqHighPriNoWait: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"k"› for 0.000s
+[3] sequence reqHighPriNoWait: conflicted with 00000001-0000-0000-0000-000000000000 on ‹"k"› for 0.000s
 [3] sequence reqHighPriNoWait: acquiring latches
 [3] sequence reqHighPriNoWait: scanning lock table for conflicting locks
 [3] sequence reqHighPriNoWait: sequencing complete, returned guard

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/replicated
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/replicated
@@ -105,7 +105,7 @@ on-txn-updated txn=txn1 status=aborted
 [-] update txn: aborting txn1
 [5] sequence req3: resolving intent ‹"a"› for txn 00000001 with ABORTED status
 [5] sequence req3: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"a"› (queuedLockingRequests: 1, queuedReaders: 0)
-[5] sequence req3: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"a"› for 0.000s
+[5] sequence req3: conflicted with 00000001-0000-0000-0000-000000000000 on ‹"a"› for 0.000s
 [5] sequence req3: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [5] sequence req3: pushing txn 00000002 to abort
 [5] sequence req3: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -115,7 +115,7 @@ on-txn-updated txn=txn2 status=committed
 [-] update txn: committing txn2
 [5] sequence req3: resolving intent ‹"a"› for txn 00000002 with COMMITTED status
 [5] sequence req3: lock wait-queue event: done waiting
-[5] sequence req3: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"a"› for 0.000s
+[5] sequence req3: conflicted with 00000002-0000-0000-0000-000000000000 on ‹"a"› for 0.000s
 [5] sequence req3: acquiring latches
 [5] sequence req3: scanning lock table for conflicting locks
 [5] sequence req3: sequencing complete, returned guard
@@ -224,13 +224,13 @@ on-txn-updated txn=txn3 status=aborted
 [-] update txn: aborting txn3
 [4] sequence req5: resolving intent ‹"a"› for txn 00000003 with ABORTED status
 [4] sequence req5: lock wait-queue event: done waiting
-[4] sequence req5: conflicted with ‹00000003-0000-0000-0000-000000000000› on ‹"a"› for 0.000s
+[4] sequence req5: conflicted with 00000003-0000-0000-0000-000000000000 on ‹"a"› for 0.000s
 [4] sequence req5: acquiring latches
 [4] sequence req5: scanning lock table for conflicting locks
 [4] sequence req5: sequencing complete, returned guard
 [5] sequence req6: resolving intent ‹"a"› for txn 00000003 with ABORTED status
 [5] sequence req6: lock wait-queue event: done waiting
-[5] sequence req6: conflicted with ‹00000003-0000-0000-0000-000000000000› on ‹"a"› for 0.000s
+[5] sequence req6: conflicted with 00000003-0000-0000-0000-000000000000 on ‹"a"› for 0.000s
 [5] sequence req6: acquiring latches
 [5] sequence req6: scanning lock table for conflicting locks
 [5] sequence req6: sequencing complete, returned guard

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/resolve_pushed_intents
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/resolve_pushed_intents
@@ -84,7 +84,7 @@ sequence req=req2
 sequence req=req1
 ----
 [3] sequence req2: lock wait-queue event: done waiting
-[3] sequence req2: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"c"› for 0.000s
+[3] sequence req2: conflicted with 00000002-0000-0000-0000-000000000000 on ‹"c"› for 0.000s
 [3] sequence req2: acquiring latches
 [3] sequence req2: scanning lock table for conflicting locks
 [3] sequence req2: sequencing complete, returned guard
@@ -98,7 +98,7 @@ sequence req=req1
 [4] sequence req1: pusher pushed pushee to 10.000000000,2
 [4] sequence req1: resolving intent ‹"a"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,2}
 [4] sequence req1: lock wait-queue event: done waiting
-[4] sequence req1: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"a"› for 0.000s
+[4] sequence req1: conflicted with 00000002-0000-0000-0000-000000000000 on ‹"a"› for 0.000s
 [4] sequence req1: resolving a batch of 9 intent(s)
 [4] sequence req1: resolving intent ‹"b"› for txn 00000002 with PENDING status
 [4] sequence req1: resolving intent ‹"c"› for txn 00000002 with PENDING status
@@ -147,7 +147,7 @@ on-txn-updated txn=txn2 status=aborted
 [-] update txn: aborting txn2
 [6] sequence req2: resolving intent ‹"c"› for txn 00000002 with ABORTED status
 [6] sequence req2: lock wait-queue event: done waiting
-[6] sequence req2: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"c"› for 0.000s
+[6] sequence req2: conflicted with 00000002-0000-0000-0000-000000000000 on ‹"c"› for 0.000s
 [6] sequence req2: acquiring latches
 [6] sequence req2: scanning lock table for conflicting locks
 [6] sequence req2: sequencing complete, returned guard
@@ -244,7 +244,7 @@ sequence req=req1
 [4] sequence req1: pusher pushed pushee to 10.000000000,2
 [4] sequence req1: resolving intent ‹"a"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,5}
 [4] sequence req1: lock wait-queue event: done waiting
-[4] sequence req1: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"a"› for 0.000s
+[4] sequence req1: conflicted with 00000002-0000-0000-0000-000000000000 on ‹"a"› for 0.000s
 [4] sequence req1: resolving a batch of 1 intent(s)
 [4] sequence req1: resolving intent ‹"b"› for txn 00000002 with PENDING status
 [4] sequence req1: acquiring latches
@@ -318,17 +318,17 @@ sequence req=req1
 [3] sequence req1: pusher pushed pushee to 11.000000000,2
 [3] sequence req1: resolving intent ‹"a"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,7}
 [3] sequence req1: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"b"› (queuedLockingRequests: 0, queuedReaders: 1)
-[3] sequence req1: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"a"› for 0.000s
+[3] sequence req1: conflicted with 00000002-0000-0000-0000-000000000000 on ‹"a"› for 0.000s
 [3] sequence req1: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = true, wait policy error = false
 [3] sequence req1: pushing timestamp of txn 00000002 above 11.000000000,1
 [3] sequence req1: resolving intent ‹"b"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,9}
 [3] sequence req1: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"c"› (queuedLockingRequests: 0, queuedReaders: 1)
-[3] sequence req1: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"b"› for 0.000s
+[3] sequence req1: conflicted with 00000002-0000-0000-0000-000000000000 on ‹"b"› for 0.000s
 [3] sequence req1: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = true, wait policy error = false
 [3] sequence req1: pushing timestamp of txn 00000002 above 11.000000000,1
 [3] sequence req1: resolving intent ‹"c"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,11}
 [3] sequence req1: lock wait-queue event: done waiting
-[3] sequence req1: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"c"› for 0.000s
+[3] sequence req1: conflicted with 00000002-0000-0000-0000-000000000000 on ‹"c"› for 0.000s
 [3] sequence req1: acquiring latches
 [3] sequence req1: scanning lock table for conflicting locks
 [3] sequence req1: sequencing complete, returned guard
@@ -434,7 +434,7 @@ sequence req=req2
 sequence req=req1
 ----
 [3] sequence req2: lock wait-queue event: done waiting
-[3] sequence req2: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"c"› for 0.000s
+[3] sequence req2: conflicted with 00000002-0000-0000-0000-000000000000 on ‹"c"› for 0.000s
 [3] sequence req2: acquiring latches
 [3] sequence req2: scanning lock table for conflicting locks
 [3] sequence req2: sequencing complete, returned guard
@@ -448,52 +448,52 @@ sequence req=req1
 [4] sequence req1: pusher pushed pushee to 10.000000000,2
 [4] sequence req1: resolving intent ‹"a"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,14}
 [4] sequence req1: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"b"› (queuedLockingRequests: 0, queuedReaders: 1)
-[4] sequence req1: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"a"› for 0.000s
+[4] sequence req1: conflicted with 00000002-0000-0000-0000-000000000000 on ‹"a"› for 0.000s
 [4] sequence req1: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = true, wait policy error = false
 [4] sequence req1: pushing timestamp of txn 00000002 above 10.000000000,1
 [4] sequence req1: resolving intent ‹"b"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,16}
 [4] sequence req1: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"c"› (queuedLockingRequests: 1, queuedReaders: 1)
-[4] sequence req1: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"b"› for 0.000s
+[4] sequence req1: conflicted with 00000002-0000-0000-0000-000000000000 on ‹"b"› for 0.000s
 [4] sequence req1: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = true, wait policy error = false
 [4] sequence req1: pushing timestamp of txn 00000002 above 10.000000000,1
 [4] sequence req1: resolving intent ‹"c"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,18}
 [4] sequence req1: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"d"› (queuedLockingRequests: 0, queuedReaders: 1)
-[4] sequence req1: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"c"› for 0.000s
+[4] sequence req1: conflicted with 00000002-0000-0000-0000-000000000000 on ‹"c"› for 0.000s
 [4] sequence req1: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = true, wait policy error = false
 [4] sequence req1: pushing timestamp of txn 00000002 above 10.000000000,1
 [4] sequence req1: resolving intent ‹"d"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,20}
 [4] sequence req1: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"e"› (queuedLockingRequests: 0, queuedReaders: 1)
-[4] sequence req1: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"d"› for 0.000s
+[4] sequence req1: conflicted with 00000002-0000-0000-0000-000000000000 on ‹"d"› for 0.000s
 [4] sequence req1: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = true, wait policy error = false
 [4] sequence req1: pushing timestamp of txn 00000002 above 10.000000000,1
 [4] sequence req1: resolving intent ‹"e"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,22}
 [4] sequence req1: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"f"› (queuedLockingRequests: 0, queuedReaders: 1)
-[4] sequence req1: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"e"› for 0.000s
+[4] sequence req1: conflicted with 00000002-0000-0000-0000-000000000000 on ‹"e"› for 0.000s
 [4] sequence req1: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = true, wait policy error = false
 [4] sequence req1: pushing timestamp of txn 00000002 above 10.000000000,1
 [4] sequence req1: resolving intent ‹"f"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,24}
 [4] sequence req1: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"g"› (queuedLockingRequests: 0, queuedReaders: 1)
-[4] sequence req1: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"f"› for 0.000s
+[4] sequence req1: conflicted with 00000002-0000-0000-0000-000000000000 on ‹"f"› for 0.000s
 [4] sequence req1: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = true, wait policy error = false
 [4] sequence req1: pushing timestamp of txn 00000002 above 10.000000000,1
 [4] sequence req1: resolving intent ‹"g"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,26}
 [4] sequence req1: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"h"› (queuedLockingRequests: 0, queuedReaders: 1)
-[4] sequence req1: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"g"› for 0.000s
+[4] sequence req1: conflicted with 00000002-0000-0000-0000-000000000000 on ‹"g"› for 0.000s
 [4] sequence req1: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = true, wait policy error = false
 [4] sequence req1: pushing timestamp of txn 00000002 above 10.000000000,1
 [4] sequence req1: resolving intent ‹"h"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,28}
 [4] sequence req1: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"i"› (queuedLockingRequests: 0, queuedReaders: 1)
-[4] sequence req1: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"h"› for 0.000s
+[4] sequence req1: conflicted with 00000002-0000-0000-0000-000000000000 on ‹"h"› for 0.000s
 [4] sequence req1: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = true, wait policy error = false
 [4] sequence req1: pushing timestamp of txn 00000002 above 10.000000000,1
 [4] sequence req1: resolving intent ‹"i"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,30}
 [4] sequence req1: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"j"› (queuedLockingRequests: 0, queuedReaders: 1)
-[4] sequence req1: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"i"› for 0.000s
+[4] sequence req1: conflicted with 00000002-0000-0000-0000-000000000000 on ‹"i"› for 0.000s
 [4] sequence req1: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = true, wait policy error = false
 [4] sequence req1: pushing timestamp of txn 00000002 above 10.000000000,1
 [4] sequence req1: resolving intent ‹"j"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,32}
 [4] sequence req1: lock wait-queue event: done waiting
-[4] sequence req1: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"j"› for 0.000s
+[4] sequence req1: conflicted with 00000002-0000-0000-0000-000000000000 on ‹"j"› for 0.000s
 [4] sequence req1: acquiring latches
 [4] sequence req1: scanning lock table for conflicting locks
 [4] sequence req1: sequencing complete, returned guard
@@ -532,7 +532,7 @@ on-txn-updated txn=txn2 status=aborted
 [-] update txn: aborting txn2
 [6] sequence req2: resolving intent ‹"c"› for txn 00000002 with ABORTED status
 [6] sequence req2: lock wait-queue event: done waiting
-[6] sequence req2: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"c"› for 0.000s
+[6] sequence req2: conflicted with 00000002-0000-0000-0000-000000000000 on ‹"c"› for 0.000s
 [6] sequence req2: acquiring latches
 [6] sequence req2: scanning lock table for conflicting locks
 [6] sequence req2: sequencing complete, returned guard

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/resolve_pushed_intents_without_adding_to_lock_table
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/resolve_pushed_intents_without_adding_to_lock_table
@@ -48,7 +48,7 @@ sequence req=req1
 [3] sequence req1: pusher pushed pushee to 10.000000000,2
 [3] sequence req1: resolving intent ‹"a"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,1}
 [3] sequence req1: lock wait-queue event: done waiting
-[3] sequence req1: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"a"› for 0.000s
+[3] sequence req1: conflicted with 00000002-0000-0000-0000-000000000000 on ‹"a"› for 0.000s
 [3] sequence req1: acquiring latches
 [3] sequence req1: scanning lock table for conflicting locks
 [3] sequence req1: sequencing complete, returned guard
@@ -160,7 +160,7 @@ sequence req=req1
 [3] sequence req1: pusher pushed pushee to 11.000000000,2
 [3] sequence req1: resolving intent ‹"a"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,3}
 [3] sequence req1: lock wait-queue event: done waiting
-[3] sequence req1: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"a"› for 0.000s
+[3] sequence req1: conflicted with 00000002-0000-0000-0000-000000000000 on ‹"a"› for 0.000s
 [3] sequence req1: acquiring latches
 [3] sequence req1: scanning lock table for conflicting locks
 [3] sequence req1: sequencing complete, returned guard
@@ -231,47 +231,47 @@ sequence req=req2
 [6] sequence req2: pushing timestamp of txn 00000002 above 11.000000000,1
 [6] sequence req2: resolving intent ‹"b"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,5}
 [6] sequence req2: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"c"› (queuedLockingRequests: 0, queuedReaders: 1)
-[6] sequence req2: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"b"› for 0.000s
+[6] sequence req2: conflicted with 00000002-0000-0000-0000-000000000000 on ‹"b"› for 0.000s
 [6] sequence req2: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = true, wait policy error = false
 [6] sequence req2: pushing timestamp of txn 00000002 above 11.000000000,1
 [6] sequence req2: resolving intent ‹"c"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,7}
 [6] sequence req2: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"d"› (queuedLockingRequests: 0, queuedReaders: 1)
-[6] sequence req2: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"c"› for 0.000s
+[6] sequence req2: conflicted with 00000002-0000-0000-0000-000000000000 on ‹"c"› for 0.000s
 [6] sequence req2: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = true, wait policy error = false
 [6] sequence req2: pushing timestamp of txn 00000002 above 11.000000000,1
 [6] sequence req2: resolving intent ‹"d"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,9}
 [6] sequence req2: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"e"› (queuedLockingRequests: 0, queuedReaders: 1)
-[6] sequence req2: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"d"› for 0.000s
+[6] sequence req2: conflicted with 00000002-0000-0000-0000-000000000000 on ‹"d"› for 0.000s
 [6] sequence req2: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = true, wait policy error = false
 [6] sequence req2: pushing timestamp of txn 00000002 above 11.000000000,1
 [6] sequence req2: resolving intent ‹"e"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,11}
 [6] sequence req2: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"f"› (queuedLockingRequests: 0, queuedReaders: 1)
-[6] sequence req2: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"e"› for 0.000s
+[6] sequence req2: conflicted with 00000002-0000-0000-0000-000000000000 on ‹"e"› for 0.000s
 [6] sequence req2: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = true, wait policy error = false
 [6] sequence req2: pushing timestamp of txn 00000002 above 11.000000000,1
 [6] sequence req2: resolving intent ‹"f"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,13}
 [6] sequence req2: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"g"› (queuedLockingRequests: 0, queuedReaders: 1)
-[6] sequence req2: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"f"› for 0.000s
+[6] sequence req2: conflicted with 00000002-0000-0000-0000-000000000000 on ‹"f"› for 0.000s
 [6] sequence req2: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = true, wait policy error = false
 [6] sequence req2: pushing timestamp of txn 00000002 above 11.000000000,1
 [6] sequence req2: resolving intent ‹"g"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,15}
 [6] sequence req2: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"h"› (queuedLockingRequests: 0, queuedReaders: 1)
-[6] sequence req2: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"g"› for 0.000s
+[6] sequence req2: conflicted with 00000002-0000-0000-0000-000000000000 on ‹"g"› for 0.000s
 [6] sequence req2: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = true, wait policy error = false
 [6] sequence req2: pushing timestamp of txn 00000002 above 11.000000000,1
 [6] sequence req2: resolving intent ‹"h"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,17}
 [6] sequence req2: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"i"› (queuedLockingRequests: 0, queuedReaders: 1)
-[6] sequence req2: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"h"› for 0.000s
+[6] sequence req2: conflicted with 00000002-0000-0000-0000-000000000000 on ‹"h"› for 0.000s
 [6] sequence req2: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = true, wait policy error = false
 [6] sequence req2: pushing timestamp of txn 00000002 above 11.000000000,1
 [6] sequence req2: resolving intent ‹"i"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,19}
 [6] sequence req2: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"j"› (queuedLockingRequests: 0, queuedReaders: 1)
-[6] sequence req2: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"i"› for 0.000s
+[6] sequence req2: conflicted with 00000002-0000-0000-0000-000000000000 on ‹"i"› for 0.000s
 [6] sequence req2: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = true, wait policy error = false
 [6] sequence req2: pushing timestamp of txn 00000002 above 11.000000000,1
 [6] sequence req2: resolving intent ‹"j"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,21}
 [6] sequence req2: lock wait-queue event: done waiting
-[6] sequence req2: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"j"› for 0.000s
+[6] sequence req2: conflicted with 00000002-0000-0000-0000-000000000000 on ‹"j"› for 0.000s
 [6] sequence req2: acquiring latches
 [6] sequence req2: scanning lock table for conflicting locks
 [6] sequence req2: sequencing complete, returned guard
@@ -331,7 +331,7 @@ sequence req=req1
 [3] sequence req1: pusher pushed pushee to 10.000000000,2
 [3] sequence req1: resolving intent ‹"a"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,23}
 [3] sequence req1: lock wait-queue event: done waiting
-[3] sequence req1: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"a"› for 0.000s
+[3] sequence req1: conflicted with 00000002-0000-0000-0000-000000000000 on ‹"a"› for 0.000s
 [3] sequence req1: acquiring latches
 [3] sequence req1: scanning lock table for conflicting locks
 [3] sequence req1: sequencing complete, returned guard
@@ -402,47 +402,47 @@ sequence req=req2
 [6] sequence req2: pushing timestamp of txn 00000002 above 10.000000000,1
 [6] sequence req2: resolving intent ‹"b"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,25}
 [6] sequence req2: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"c"› (queuedLockingRequests: 0, queuedReaders: 1)
-[6] sequence req2: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"b"› for 0.000s
+[6] sequence req2: conflicted with 00000002-0000-0000-0000-000000000000 on ‹"b"› for 0.000s
 [6] sequence req2: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = true, wait policy error = false
 [6] sequence req2: pushing timestamp of txn 00000002 above 10.000000000,1
 [6] sequence req2: resolving intent ‹"c"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,27}
 [6] sequence req2: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"d"› (queuedLockingRequests: 0, queuedReaders: 1)
-[6] sequence req2: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"c"› for 0.000s
+[6] sequence req2: conflicted with 00000002-0000-0000-0000-000000000000 on ‹"c"› for 0.000s
 [6] sequence req2: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = true, wait policy error = false
 [6] sequence req2: pushing timestamp of txn 00000002 above 10.000000000,1
 [6] sequence req2: resolving intent ‹"d"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,29}
 [6] sequence req2: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"e"› (queuedLockingRequests: 0, queuedReaders: 1)
-[6] sequence req2: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"d"› for 0.000s
+[6] sequence req2: conflicted with 00000002-0000-0000-0000-000000000000 on ‹"d"› for 0.000s
 [6] sequence req2: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = true, wait policy error = false
 [6] sequence req2: pushing timestamp of txn 00000002 above 10.000000000,1
 [6] sequence req2: resolving intent ‹"e"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,31}
 [6] sequence req2: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"f"› (queuedLockingRequests: 0, queuedReaders: 1)
-[6] sequence req2: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"e"› for 0.000s
+[6] sequence req2: conflicted with 00000002-0000-0000-0000-000000000000 on ‹"e"› for 0.000s
 [6] sequence req2: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = true, wait policy error = false
 [6] sequence req2: pushing timestamp of txn 00000002 above 10.000000000,1
 [6] sequence req2: resolving intent ‹"f"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,33}
 [6] sequence req2: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"g"› (queuedLockingRequests: 0, queuedReaders: 1)
-[6] sequence req2: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"f"› for 0.000s
+[6] sequence req2: conflicted with 00000002-0000-0000-0000-000000000000 on ‹"f"› for 0.000s
 [6] sequence req2: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = true, wait policy error = false
 [6] sequence req2: pushing timestamp of txn 00000002 above 10.000000000,1
 [6] sequence req2: resolving intent ‹"g"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,35}
 [6] sequence req2: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"h"› (queuedLockingRequests: 0, queuedReaders: 1)
-[6] sequence req2: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"g"› for 0.000s
+[6] sequence req2: conflicted with 00000002-0000-0000-0000-000000000000 on ‹"g"› for 0.000s
 [6] sequence req2: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = true, wait policy error = false
 [6] sequence req2: pushing timestamp of txn 00000002 above 10.000000000,1
 [6] sequence req2: resolving intent ‹"h"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,37}
 [6] sequence req2: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"i"› (queuedLockingRequests: 0, queuedReaders: 1)
-[6] sequence req2: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"h"› for 0.000s
+[6] sequence req2: conflicted with 00000002-0000-0000-0000-000000000000 on ‹"h"› for 0.000s
 [6] sequence req2: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = true, wait policy error = false
 [6] sequence req2: pushing timestamp of txn 00000002 above 10.000000000,1
 [6] sequence req2: resolving intent ‹"i"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,39}
 [6] sequence req2: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"j"› (queuedLockingRequests: 0, queuedReaders: 1)
-[6] sequence req2: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"i"› for 0.000s
+[6] sequence req2: conflicted with 00000002-0000-0000-0000-000000000000 on ‹"i"› for 0.000s
 [6] sequence req2: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = true, wait policy error = false
 [6] sequence req2: pushing timestamp of txn 00000002 above 10.000000000,1
 [6] sequence req2: resolving intent ‹"j"› for txn 00000002 with PENDING status and clock observation {1 123.000000000,41}
 [6] sequence req2: lock wait-queue event: done waiting
-[6] sequence req2: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"j"› for 0.000s
+[6] sequence req2: conflicted with 00000002-0000-0000-0000-000000000000 on ‹"j"› for 0.000s
 [6] sequence req2: acquiring latches
 [6] sequence req2: scanning lock table for conflicting locks
 [6] sequence req2: sequencing complete, returned guard

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/shared_locks
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/shared_locks
@@ -136,7 +136,7 @@ on-txn-updated txn=txn1 status=committed
 [-] update txn: committing txn1
 [5] sequence req5: resolving intent ‹"a"› for txn 00000001 with COMMITTED status
 [5] sequence req5: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"a"› (queuedLockingRequests: 1, queuedReaders: 0)
-[5] sequence req5: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"a"› for 0.000s
+[5] sequence req5: conflicted with 00000001-0000-0000-0000-000000000000 on ‹"a"› for 0.000s
 [5] sequence req5: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [5] sequence req5: pushing txn 00000002 to abort
 [5] sequence req5: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -148,7 +148,7 @@ on-txn-updated txn=txn2 status=aborted
 [-] update txn: aborting txn2
 [5] sequence req5: resolving intent ‹"a"› for txn 00000002 with ABORTED status
 [5] sequence req5: lock wait-queue event: wait for txn 00000003 holding lock @ key ‹"a"› (queuedLockingRequests: 1, queuedReaders: 0)
-[5] sequence req5: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"a"› for 0.000s
+[5] sequence req5: conflicted with 00000002-0000-0000-0000-000000000000 on ‹"a"› for 0.000s
 [5] sequence req5: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [5] sequence req5: pushing txn 00000003 to abort
 [5] sequence req5: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -175,12 +175,12 @@ on-txn-updated txn=txn3 status=committed
 [-] update txn: committing txn3
 [5] sequence req5: resolving intent ‹"a"› for txn 00000003 with COMMITTED status
 [5] sequence req5: lock wait-queue event: wait for txn 00000004 holding lock @ key ‹"a"› (queuedLockingRequests: 1, queuedReaders: 0)
-[5] sequence req5: conflicted with ‹00000003-0000-0000-0000-000000000000› on ‹"a"› for 0.000s
+[5] sequence req5: conflicted with 00000003-0000-0000-0000-000000000000 on ‹"a"› for 0.000s
 [5] sequence req5: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [5] sequence req5: pushing txn 00000004 to abort
 [5] sequence req5: resolving intent ‹"a"› for txn 00000004 with ABORTED status
 [5] sequence req5: lock wait-queue event: done waiting
-[5] sequence req5: conflicted with ‹00000004-0000-0000-0000-000000000000› on ‹"a"› for 0.000s
+[5] sequence req5: conflicted with 00000004-0000-0000-0000-000000000000 on ‹"a"› for 0.000s
 [5] sequence req5: acquiring latches
 [5] sequence req5: scanning lock table for conflicting locks
 [5] sequence req5: sequencing complete, returned guard
@@ -277,7 +277,7 @@ sequence req=req8
 [10] sequence req8: pusher pushed pushee to 11.000000000,2
 [10] sequence req8: resolving intent ‹"a"› for txn 00000006 with PENDING status and clock observation {1 123.000000000,5}
 [10] sequence req8: lock wait-queue event: done waiting
-[10] sequence req8: conflicted with ‹00000006-0000-0000-0000-000000000000› on ‹"a"› for 0.000s
+[10] sequence req8: conflicted with 00000006-0000-0000-0000-000000000000 on ‹"a"› for 0.000s
 [10] sequence req8: acquiring latches
 [10] sequence req8: scanning lock table for conflicting locks
 [10] sequence req8: sequencing complete, returned guard
@@ -346,7 +346,7 @@ new-request name=req10 txn=txn7 ts=10,1
 sequence req=req10
 ----
 [13] sequence req9: lock wait-queue event: done waiting
-[13] sequence req9: conflicted with ‹00000006-0000-0000-0000-000000000000› on ‹"a"› for 0.000s
+[13] sequence req9: conflicted with 00000006-0000-0000-0000-000000000000 on ‹"a"› for 0.000s
 [13] sequence req9: acquiring latches
 [13] sequence req9: scanning lock table for conflicting locks
 [13] sequence req9: sequencing complete, returned guard
@@ -359,7 +359,7 @@ sequence req=req10
 [14] sequence req10: pushing timestamp of txn 00000006 above 11.000000000,1
 [14] sequence req10: resolving intent ‹"a"› for txn 00000006 with PENDING status and clock observation {1 123.000000000,8}
 [14] sequence req10: lock wait-queue event: done waiting
-[14] sequence req10: conflicted with ‹00000006-0000-0000-0000-000000000000› on ‹"a"› for 0.000s
+[14] sequence req10: conflicted with 00000006-0000-0000-0000-000000000000 on ‹"a"› for 0.000s
 [14] sequence req10: acquiring latches
 [14] sequence req10: scanning lock table for conflicting locks
 [14] sequence req10: sequencing complete, returned guard
@@ -558,19 +558,19 @@ on-txn-updated txn=txn1 status=aborted
 [-] update txn: aborting txn1
 [6] sequence req16: resolving intent ‹"a"› for txn 00000001 with ABORTED status
 [6] sequence req16: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"a"› (queuedLockingRequests: 3, queuedReaders: 0)
-[6] sequence req16: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"a"› for 0.000s
+[6] sequence req16: conflicted with 00000001-0000-0000-0000-000000000000 on ‹"a"› for 0.000s
 [6] sequence req16: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [6] sequence req16: pushing txn 00000002 to abort
 [6] sequence req16: blocked on select in concurrency_test.(*cluster).PushTransaction
 [7] sequence req17: resolving intent ‹"a"› for txn 00000001 with ABORTED status
 [7] sequence req17: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"a"› (queuedLockingRequests: 3, queuedReaders: 0)
-[7] sequence req17: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"a"› for 0.000s
+[7] sequence req17: conflicted with 00000001-0000-0000-0000-000000000000 on ‹"a"› for 0.000s
 [7] sequence req17: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [7] sequence req17: pushing txn 00000002 to abort
 [7] sequence req17: blocked on select in concurrency_test.(*cluster).PushTransaction
 [8] sequence req18: resolving intent ‹"a"› for txn 00000001 with ABORTED status
 [8] sequence req18: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"a"› (queuedLockingRequests: 3, queuedReaders: 0)
-[8] sequence req18: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"a"› for 0.000s
+[8] sequence req18: conflicted with 00000001-0000-0000-0000-000000000000 on ‹"a"› for 0.000s
 [8] sequence req18: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [8] sequence req18: pushing txn 00000002 to abort
 [8] sequence req18: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -580,19 +580,19 @@ on-txn-updated txn=txn2 status=aborted
 [-] update txn: aborting txn2
 [6] sequence req16: resolving intent ‹"a"› for txn 00000002 with ABORTED status
 [6] sequence req16: lock wait-queue event: done waiting
-[6] sequence req16: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"a"› for 0.000s
+[6] sequence req16: conflicted with 00000002-0000-0000-0000-000000000000 on ‹"a"› for 0.000s
 [6] sequence req16: acquiring latches
 [6] sequence req16: scanning lock table for conflicting locks
 [6] sequence req16: sequencing complete, returned guard
 [7] sequence req17: resolving intent ‹"a"› for txn 00000002 with ABORTED status
 [7] sequence req17: lock wait-queue event: wait for txn 00000003 running request @ key ‹"a"› (queuedLockingRequests: 3, queuedReaders: 0)
-[7] sequence req17: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"a"› for 0.000s
+[7] sequence req17: conflicted with 00000002-0000-0000-0000-000000000000 on ‹"a"› for 0.000s
 [7] sequence req17: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [7] sequence req17: pushing txn 00000003 to detect request deadlock
 [7] sequence req17: blocked on select in concurrency_test.(*cluster).PushTransaction
 [8] sequence req18: resolving intent ‹"a"› for txn 00000002 with ABORTED status
 [8] sequence req18: lock wait-queue event: wait for txn 00000003 running request @ key ‹"a"› (queuedLockingRequests: 3, queuedReaders: 0)
-[8] sequence req18: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"a"› for 0.000s
+[8] sequence req18: conflicted with 00000002-0000-0000-0000-000000000000 on ‹"a"› for 0.000s
 [8] sequence req18: not pushing
 [8] sequence req18: blocked on select in concurrency.(*lockTableWaiterImpl).WaitOn
 
@@ -600,12 +600,12 @@ finish req=req16
 ----
 [-] finish req16: finishing request
 [7] sequence req17: lock wait-queue event: done waiting
-[7] sequence req17: conflicted with ‹00000003-0000-0000-0000-000000000000› on ‹"a"› for 0.000s
+[7] sequence req17: conflicted with 00000003-0000-0000-0000-000000000000 on ‹"a"› for 0.000s
 [7] sequence req17: acquiring latches
 [7] sequence req17: scanning lock table for conflicting locks
 [7] sequence req17: sequencing complete, returned guard
 [8] sequence req18: lock wait-queue event: wait for txn 00000004 running request @ key ‹"a"› (queuedLockingRequests: 2, queuedReaders: 0)
-[8] sequence req18: conflicted with ‹00000003-0000-0000-0000-000000000000› on ‹"a"› for 0.000s
+[8] sequence req18: conflicted with 00000003-0000-0000-0000-000000000000 on ‹"a"› for 0.000s
 [8] sequence req18: not pushing
 [8] sequence req18: blocked on select in concurrency.(*lockTableWaiterImpl).WaitOn
 
@@ -613,7 +613,7 @@ finish req=req17
 ----
 [-] finish req17: finishing request
 [8] sequence req18: lock wait-queue event: done waiting
-[8] sequence req18: conflicted with ‹00000004-0000-0000-0000-000000000000› on ‹"a"› for 0.000s
+[8] sequence req18: conflicted with 00000004-0000-0000-0000-000000000000 on ‹"a"› for 0.000s
 [8] sequence req18: acquiring latches
 [8] sequence req18: scanning lock table for conflicting locks
 [8] sequence req18: sequencing complete, returned guard
@@ -742,31 +742,31 @@ on-txn-updated txn=txn1 status=committed
 [-] update txn: committing txn1
 [2] sequence req20: resolving intent ‹"a"› for txn 00000001 with COMMITTED status
 [2] sequence req20: lock wait-queue event: done waiting
-[2] sequence req20: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"a"› for 0.000s
+[2] sequence req20: conflicted with 00000001-0000-0000-0000-000000000000 on ‹"a"› for 0.000s
 [2] sequence req20: acquiring latches
 [2] sequence req20: scanning lock table for conflicting locks
 [2] sequence req20: sequencing complete, returned guard
 [3] sequence req21: resolving intent ‹"a"› for txn 00000001 with COMMITTED status
 [3] sequence req21: lock wait-queue event: done waiting
-[3] sequence req21: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"a"› for 0.000s
+[3] sequence req21: conflicted with 00000001-0000-0000-0000-000000000000 on ‹"a"› for 0.000s
 [3] sequence req21: acquiring latches
 [3] sequence req21: scanning lock table for conflicting locks
 [3] sequence req21: sequencing complete, returned guard
 [4] sequence req22: resolving intent ‹"a"› for txn 00000001 with COMMITTED status
 [4] sequence req22: lock wait-queue event: done waiting
-[4] sequence req22: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"a"› for 0.000s
+[4] sequence req22: conflicted with 00000001-0000-0000-0000-000000000000 on ‹"a"› for 0.000s
 [4] sequence req22: acquiring latches
 [4] sequence req22: scanning lock table for conflicting locks
 [4] sequence req22: sequencing complete, returned guard
 [5] sequence req23: resolving intent ‹"a"› for txn 00000001 with COMMITTED status
 [5] sequence req23: lock wait-queue event: wait for txn 00000002 running request @ key ‹"a"› (queuedLockingRequests: 5, queuedReaders: 0)
-[5] sequence req23: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"a"› for 0.000s
+[5] sequence req23: conflicted with 00000001-0000-0000-0000-000000000000 on ‹"a"› for 0.000s
 [5] sequence req23: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [5] sequence req23: pushing txn 00000002 to detect request deadlock
 [5] sequence req23: blocked on select in concurrency_test.(*cluster).PushTransaction
 [6] sequence req24: resolving intent ‹"a"› for txn 00000001 with COMMITTED status
 [6] sequence req24: lock wait-queue event: wait for txn 00000002 running request @ key ‹"a"› (queuedLockingRequests: 5, queuedReaders: 0)
-[6] sequence req24: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"a"› for 0.000s
+[6] sequence req24: conflicted with 00000001-0000-0000-0000-000000000000 on ‹"a"› for 0.000s
 [6] sequence req24: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [6] sequence req24: pushing txn 00000002 to detect request deadlock
 [6] sequence req24: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -790,12 +790,12 @@ finish req=req20
 ----
 [-] finish req20: finishing request
 [5] sequence req23: lock wait-queue event: wait for txn 00000003 running request @ key ‹"a"› (queuedLockingRequests: 3, queuedReaders: 0)
-[5] sequence req23: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"a"› for 0.000s
+[5] sequence req23: conflicted with 00000002-0000-0000-0000-000000000000 on ‹"a"› for 0.000s
 [5] sequence req23: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [5] sequence req23: pushing txn 00000003 to detect request deadlock
 [5] sequence req23: blocked on select in concurrency_test.(*cluster).PushTransaction
 [6] sequence req24: lock wait-queue event: wait for txn 00000003 running request @ key ‹"a"› (queuedLockingRequests: 3, queuedReaders: 0)
-[6] sequence req24: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"a"› for 0.000s
+[6] sequence req24: conflicted with 00000002-0000-0000-0000-000000000000 on ‹"a"› for 0.000s
 [6] sequence req24: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [6] sequence req24: pushing txn 00000003 to detect request deadlock
 [6] sequence req24: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -819,12 +819,12 @@ finish req=req21
 ----
 [-] finish req21: finishing request
 [5] sequence req23: lock wait-queue event: done waiting
-[5] sequence req23: conflicted with ‹00000003-0000-0000-0000-000000000000› on ‹"a"› for 0.000s
+[5] sequence req23: conflicted with 00000003-0000-0000-0000-000000000000 on ‹"a"› for 0.000s
 [5] sequence req23: acquiring latches
 [5] sequence req23: scanning lock table for conflicting locks
 [5] sequence req23: sequencing complete, returned guard
 [6] sequence req24: lock wait-queue event: wait for txn 00000004 running request @ key ‹"a"› (queuedLockingRequests: 2, queuedReaders: 0)
-[6] sequence req24: conflicted with ‹00000003-0000-0000-0000-000000000000› on ‹"a"› for 0.000s
+[6] sequence req24: conflicted with 00000003-0000-0000-0000-000000000000 on ‹"a"› for 0.000s
 [6] sequence req24: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [6] sequence req24: pushing txn 00000004 to detect request deadlock
 [6] sequence req24: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -841,7 +841,7 @@ finish req=req23
 ----
 [-] finish req23: finishing request
 [6] sequence req24: lock wait-queue event: done waiting
-[6] sequence req24: conflicted with ‹00000004-0000-0000-0000-000000000000› on ‹"a"› for 0.000s
+[6] sequence req24: conflicted with 00000004-0000-0000-0000-000000000000 on ‹"a"› for 0.000s
 [6] sequence req24: acquiring latches
 [6] sequence req24: scanning lock table for conflicting locks
 [6] sequence req24: sequencing complete, returned guard
@@ -925,13 +925,13 @@ on-txn-updated txn=txn1 status=aborted
 [-] update txn: aborting txn1
 [2] sequence req26: resolving intent ‹"a"› for txn 00000001 with ABORTED status
 [2] sequence req26: lock wait-queue event: done waiting
-[2] sequence req26: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"a"› for 0.000s
+[2] sequence req26: conflicted with 00000001-0000-0000-0000-000000000000 on ‹"a"› for 0.000s
 [2] sequence req26: acquiring latches
 [2] sequence req26: scanning lock table for conflicting locks
 [2] sequence req26: sequencing complete, returned guard
 [3] sequence req27: resolving intent ‹"a"› for txn 00000001 with ABORTED status
 [3] sequence req27: lock wait-queue event: wait for txn 00000002 running request @ key ‹"a"› (queuedLockingRequests: 2, queuedReaders: 0)
-[3] sequence req27: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"a"› for 0.000s
+[3] sequence req27: conflicted with 00000001-0000-0000-0000-000000000000 on ‹"a"› for 0.000s
 [3] sequence req27: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [3] sequence req27: pushing txn 00000002 to detect request deadlock
 [3] sequence req27: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -940,7 +940,7 @@ finish req=req26
 ----
 [-] finish req26: finishing request
 [3] sequence req27: lock wait-queue event: done waiting
-[3] sequence req27: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"a"› for 0.000s
+[3] sequence req27: conflicted with 00000002-0000-0000-0000-000000000000 on ‹"a"› for 0.000s
 [3] sequence req27: acquiring latches
 [3] sequence req27: scanning lock table for conflicting locks
 [3] sequence req27: sequencing complete, returned guard
@@ -1045,11 +1045,11 @@ on-txn-updated txn=txn1 status=aborted
 ----
 [-] update txn: aborting txn1
 [3] sequence req30: detected pusher aborted
-[3] sequence req30: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"b"› for 0.000s
+[3] sequence req30: conflicted with 00000002-0000-0000-0000-000000000000 on ‹"b"› for 0.000s
 [3] sequence req30: sequencing complete, returned error: TransactionAbortedError(ABORT_REASON_PUSHER_ABORTED)
 [4] sequence req31: resolving intent ‹"a"› for txn 00000001 with ABORTED status
 [4] sequence req31: lock wait-queue event: done waiting
-[4] sequence req31: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"a"› for 0.000s
+[4] sequence req31: conflicted with 00000001-0000-0000-0000-000000000000 on ‹"a"› for 0.000s
 [4] sequence req31: acquiring latches
 [4] sequence req31: scanning lock table for conflicting locks
 [4] sequence req31: sequencing complete, returned guard
@@ -1159,11 +1159,11 @@ on-txn-updated txn=txn1 status=aborted
 ----
 [-] update txn: aborting txn1
 [3] sequence req3: detected pusher aborted
-[3] sequence req3: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"b"› for 0.000s
+[3] sequence req3: conflicted with 00000002-0000-0000-0000-000000000000 on ‹"b"› for 0.000s
 [3] sequence req3: sequencing complete, returned error: TransactionAbortedError(ABORT_REASON_PUSHER_ABORTED)
 [4] sequence req4: resolving intent ‹"a"› for txn 00000001 with ABORTED status
 [4] sequence req4: lock wait-queue event: done waiting
-[4] sequence req4: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"a"› for 0.000s
+[4] sequence req4: conflicted with 00000001-0000-0000-0000-000000000000 on ‹"a"› for 0.000s
 [4] sequence req4: acquiring latches
 [4] sequence req4: scanning lock table for conflicting locks
 [4] sequence req4: sequencing complete, returned guard
@@ -1304,7 +1304,7 @@ on-txn-updated txn=txn1 status=committed
 [4] sequence req4: dependency cycle detected 00000002->00000003->00000002
 [5] sequence req5: resolving intent ‹"a"› for txn 00000001 with COMMITTED status
 [5] sequence req5: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"a"› (queuedLockingRequests: 1, queuedReaders: 0)
-[5] sequence req5: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"a"› for 0.000s
+[5] sequence req5: conflicted with 00000001-0000-0000-0000-000000000000 on ‹"a"› for 0.000s
 [5] sequence req5: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [5] sequence req5: pushing txn 00000002 to abort
 [5] sequence req5: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -1315,11 +1315,11 @@ on-txn-updated txn=txn2 status=aborted
 ----
 [-] update txn: aborting txn2
 [4] sequence req4: detected pusher aborted
-[4] sequence req4: conflicted with ‹00000003-0000-0000-0000-000000000000› on ‹"b"› for 0.000s
+[4] sequence req4: conflicted with 00000003-0000-0000-0000-000000000000 on ‹"b"› for 0.000s
 [4] sequence req4: sequencing complete, returned error: TransactionAbortedError(ABORT_REASON_PUSHER_ABORTED)
 [5] sequence req5: resolving intent ‹"a"› for txn 00000002 with ABORTED status
 [5] sequence req5: lock wait-queue event: done waiting
-[5] sequence req5: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"a"› for 0.000s
+[5] sequence req5: conflicted with 00000002-0000-0000-0000-000000000000 on ‹"a"› for 0.000s
 [5] sequence req5: acquiring latches
 [5] sequence req5: scanning lock table for conflicting locks
 [5] sequence req5: sequencing complete, returned guard

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/uncertainty
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/uncertainty
@@ -49,7 +49,7 @@ on-txn-updated txn=txn1 status=pending ts=15,2
 [-] update txn: increasing timestamp of txn1
 [3] sequence req1: resolving intent ‹"k"› for txn 00000001 with PENDING status and clock observation {1 123.000000000,1}
 [3] sequence req1: lock wait-queue event: done waiting
-[3] sequence req1: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"k"› for 0.000s
+[3] sequence req1: conflicted with 00000001-0000-0000-0000-000000000000 on ‹"k"› for 0.000s
 [3] sequence req1: acquiring latches
 [3] sequence req1: scanning lock table for conflicting locks
 [3] sequence req1: sequencing complete, returned guard
@@ -115,7 +115,7 @@ on-txn-updated txn=txn1 status=pending ts=135,1
 [-] update txn: increasing timestamp of txn1
 [3] sequence req1: resolving intent ‹"k"› for txn 00000001 with PENDING status and clock observation {1 135.000000000,1}
 [3] sequence req1: lock wait-queue event: done waiting
-[3] sequence req1: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"k"› for 0.000s
+[3] sequence req1: conflicted with 00000001-0000-0000-0000-000000000000 on ‹"k"› for 0.000s
 [3] sequence req1: acquiring latches
 [3] sequence req1: scanning lock table for conflicting locks
 [3] sequence req1: sequencing complete, returned guard
@@ -230,13 +230,13 @@ on-txn-updated txn=txn1 status=committed
 [-] update txn: committing txn1
 [3] sequence req1: resolving intent ‹"k"› for txn 00000001 with COMMITTED status
 [3] sequence req1: lock wait-queue event: done waiting
-[3] sequence req1: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"k"› for 0.000s
+[3] sequence req1: conflicted with 00000001-0000-0000-0000-000000000000 on ‹"k"› for 0.000s
 [3] sequence req1: acquiring latches
 [3] sequence req1: scanning lock table for conflicting locks
 [3] sequence req1: sequencing complete, returned guard
 [5] sequence req2-retry: resolving intent ‹"k"› for txn 00000001 with COMMITTED status
 [5] sequence req2-retry: lock wait-queue event: done waiting
-[5] sequence req2-retry: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"k"› for 0.000s
+[5] sequence req2-retry: conflicted with 00000001-0000-0000-0000-000000000000 on ‹"k"› for 0.000s
 [5] sequence req2-retry: acquiring latches
 [5] sequence req2-retry: scanning lock table for conflicting locks
 [5] sequence req2-retry: sequencing complete, returned guard

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/update
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/update
@@ -71,7 +71,7 @@ on-txn-updated txn=txn1 status=pending ts=12,2
 [-] update txn: increasing timestamp of txn1
 [2] sequence req2: resolving intent ‹"k"› for txn 00000001 with PENDING status and clock observation {1 123.000000000,1}
 [2] sequence req2: lock wait-queue event: done waiting
-[2] sequence req2: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"k"› for 0.000s
+[2] sequence req2: conflicted with 00000001-0000-0000-0000-000000000000 on ‹"k"› for 0.000s
 [2] sequence req2: acquiring latches
 [2] sequence req2: scanning lock table for conflicting locks
 [2] sequence req2: sequencing complete, returned guard
@@ -189,7 +189,7 @@ on-txn-updated txn=txn1 status=pending ts=12,2
 [-] update txn: increasing timestamp of txn1
 [2] sequence req2: resolving intent ‹"k"› for txn 00000001 with PENDING status and clock observation {1 123.000000000,3}
 [2] sequence req2: lock wait-queue event: done waiting
-[2] sequence req2: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"k"› for 0.000s
+[2] sequence req2: conflicted with 00000001-0000-0000-0000-000000000000 on ‹"k"› for 0.000s
 [2] sequence req2: acquiring latches
 [2] sequence req2: scanning lock table for conflicting locks
 [2] sequence req2: sequencing complete, returned guard
@@ -316,7 +316,7 @@ on-txn-updated txn=txn1 status=pending ts=12,2
 [-] update txn: increasing timestamp of txn1
 [2] sequence req2: resolving intent ‹"k"› for txn 00000001 with PENDING status and clock observation {1 123.000000000,5}
 [2] sequence req2: lock wait-queue event: done waiting
-[2] sequence req2: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"k"› for 0.000s
+[2] sequence req2: conflicted with 00000001-0000-0000-0000-000000000000 on ‹"k"› for 0.000s
 [2] sequence req2: acquiring latches
 [2] sequence req2: scanning lock table for conflicting locks
 [2] sequence req2: sequencing complete, returned guard
@@ -388,7 +388,7 @@ on-txn-updated txn=txn1 status=committed
 [-] update txn: committing txn1
 [3] sequence req4: resolving intent ‹"k"› for txn 00000001 with COMMITTED status
 [3] sequence req4: lock wait-queue event: done waiting
-[3] sequence req4: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"k"› for 0.000s
+[3] sequence req4: conflicted with 00000001-0000-0000-0000-000000000000 on ‹"k"› for 0.000s
 [3] sequence req4: acquiring latches
 [3] sequence req4: scanning lock table for conflicting locks
 [3] sequence req4: sequencing complete, returned guard

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/wait_elsewhere
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/wait_elsewhere
@@ -102,7 +102,7 @@ on-txn-updated txn=txnWriter status=aborted
 ----
 [-] update txn: aborting txnWriter
 [4] sequence reqWaiter: resolving intent ‹"k"› for txn 00000001 with ABORTED status
-[4] sequence reqWaiter: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"k"› for 123.000s
+[4] sequence reqWaiter: conflicted with 00000001-0000-0000-0000-000000000000 on ‹"k"› for 123.000s
 [4] sequence reqWaiter: acquiring latches
 [4] sequence reqWaiter: scanning lock table for conflicting locks
 [4] sequence reqWaiter: sequencing complete, returned guard
@@ -255,13 +255,13 @@ on-txn-updated txn=txnThreeKeyWriter status=pending ts=20,2
 [-] update txn: increasing timestamp of txnThreeKeyWriter
 [10] sequence reqTwoKeyWaiter: resolving intent ‹"k1"› for txn 00000003 with PENDING status and clock observation {1 246.000000000,1}
 [10] sequence reqTwoKeyWaiter: lock wait-queue event: done waiting
-[10] sequence reqTwoKeyWaiter: conflicted with ‹00000003-0000-0000-0000-000000000000› on ‹"k1"› for 0.000s
+[10] sequence reqTwoKeyWaiter: conflicted with 00000003-0000-0000-0000-000000000000 on ‹"k1"› for 0.000s
 [10] sequence reqTwoKeyWaiter: acquiring latches
 [10] sequence reqTwoKeyWaiter: scanning lock table for conflicting locks
 [10] sequence reqTwoKeyWaiter: sequencing complete, returned guard
 [12] sequence reqThreeKeyWaiter: resolving intent ‹"k1"› for txn 00000003 with PENDING status and clock observation {1 246.000000000,3}
 [12] sequence reqThreeKeyWaiter: lock wait-queue event: done waiting
-[12] sequence reqThreeKeyWaiter: conflicted with ‹00000003-0000-0000-0000-000000000000› on ‹"k1"› for 0.000s
+[12] sequence reqThreeKeyWaiter: conflicted with 00000003-0000-0000-0000-000000000000 on ‹"k1"› for 0.000s
 [12] sequence reqThreeKeyWaiter: acquiring latches
 [12] sequence reqThreeKeyWaiter: scanning lock table for conflicting locks
 [12] sequence reqThreeKeyWaiter: sequencing complete, returned guard

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/wait_policy_error
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/wait_policy_error
@@ -106,7 +106,7 @@ sequence req=reqNoWait1
 [4] sequence reqNoWait1: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = true
 [4] sequence reqNoWait1: pushing timestamp of txn 00000001 above 12.000000000,1
 [4] sequence reqNoWait1: pushee not abandoned
-[4] sequence reqNoWait1: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"k"› for 0.000s
+[4] sequence reqNoWait1: conflicted with 00000001-0000-0000-0000-000000000000 on ‹"k"› for 0.000s
 [4] sequence reqNoWait1: sequencing complete, returned error: conflicting locks on ‹"k"› [reason=wait_policy]
 
 # -------------------------------------------------------------
@@ -122,7 +122,7 @@ on-txn-updated txn=txn1 status=committed
 [-] update txn: committing txn1
 [3] sequence req3: resolving intent ‹"k2"› for txn 00000001 with COMMITTED status
 [3] sequence req3: lock wait-queue event: wait for txn 00000002 holding lock @ key ‹"k3"› (queuedLockingRequests: 1, queuedReaders: 0)
-[3] sequence req3: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"k2"› for 123.000s
+[3] sequence req3: conflicted with 00000001-0000-0000-0000-000000000000 on ‹"k2"› for 123.000s
 [3] sequence req3: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [3] sequence req3: pushing txn 00000002 to abort
 [3] sequence req3: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -169,7 +169,7 @@ sequence req=reqNoWait2
 [6] sequence reqNoWait2: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = true
 [6] sequence reqNoWait2: pushing txn 00000003 to abort
 [6] sequence reqNoWait2: pushee not abandoned
-[6] sequence reqNoWait2: conflicted with ‹00000003-0000-0000-0000-000000000000› on ‹"k2"› for 0.000s
+[6] sequence reqNoWait2: conflicted with 00000003-0000-0000-0000-000000000000 on ‹"k2"› for 0.000s
 [6] sequence reqNoWait2: sequencing complete, returned error: conflicting locks on ‹"k2"› [reason=wait_policy]
 
 # -------------------------------------------------------------
@@ -203,7 +203,7 @@ sequence req=reqNoWait3
 [9] sequence reqNoWait3: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = true
 [9] sequence reqNoWait3: pushing timestamp of txn 00000002 above 12.000000000,1
 [9] sequence reqNoWait3: pushee not abandoned
-[9] sequence reqNoWait3: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"k4"› for 0.000s
+[9] sequence reqNoWait3: conflicted with 00000002-0000-0000-0000-000000000000 on ‹"k4"› for 0.000s
 [9] sequence reqNoWait3: sequencing complete, returned error: conflicting locks on ‹"k4"› [reason=wait_policy]
 
 debug-lock-table
@@ -232,7 +232,7 @@ on-txn-updated txn=txn2 status=aborted
 [-] update txn: aborting txn2
 [3] sequence req3: resolving intent ‹"k3"› for txn 00000002 with ABORTED status
 [3] sequence req3: lock wait-queue event: done waiting
-[3] sequence req3: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"k3"› for 123.000s
+[3] sequence req3: conflicted with 00000002-0000-0000-0000-000000000000 on ‹"k3"› for 123.000s
 [3] sequence req3: acquiring latches
 [3] sequence req3: scanning lock table for conflicting locks
 [3] sequence req3: sequencing complete, returned guard

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/wait_policy_skip
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/wait_policy_skip
@@ -98,7 +98,7 @@ on-txn-updated txn=txn3 status=aborted
 [-] update txn: aborting txn3
 [4] sequence req4: resolving intent ‹"k4"› for txn 00000003 with ABORTED status
 [4] sequence req4: lock wait-queue event: done waiting
-[4] sequence req4: conflicted with ‹00000003-0000-0000-0000-000000000000› on ‹"k4"› for 0.000s
+[4] sequence req4: conflicted with 00000003-0000-0000-0000-000000000000 on ‹"k4"› for 0.000s
 [4] sequence req4: acquiring latches
 [4] sequence req4: scanning lock table for conflicting locks
 [4] sequence req4: sequencing complete, returned guard

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/wait_self
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/wait_self
@@ -82,19 +82,19 @@ on-txn-updated txn=txnOld status=committed
 [-] update txn: committing txnOld
 [2] sequence reqTxn1: resolving intent ‹"k"› for txn 00000002 with COMMITTED status
 [2] sequence reqTxn1: lock wait-queue event: done waiting
-[2] sequence reqTxn1: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"k"› for 123.000s
+[2] sequence reqTxn1: conflicted with 00000002-0000-0000-0000-000000000000 on ‹"k"› for 123.000s
 [2] sequence reqTxn1: acquiring latches
 [2] sequence reqTxn1: scanning lock table for conflicting locks
 [2] sequence reqTxn1: sequencing complete, returned guard
 [3] sequence reqTxnMiddle: resolving intent ‹"k"› for txn 00000002 with COMMITTED status
 [3] sequence reqTxnMiddle: lock wait-queue event: wait for txn 00000001 running request @ key ‹"k"› (queuedLockingRequests: 3, queuedReaders: 0)
-[3] sequence reqTxnMiddle: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"k"› for 123.000s
+[3] sequence reqTxnMiddle: conflicted with 00000002-0000-0000-0000-000000000000 on ‹"k"› for 123.000s
 [3] sequence reqTxnMiddle: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [3] sequence reqTxnMiddle: pushing txn 00000001 to detect request deadlock
 [3] sequence reqTxnMiddle: blocked on select in concurrency_test.(*cluster).PushTransaction
 [4] sequence reqTxn2: resolving intent ‹"k"› for txn 00000002 with COMMITTED status
 [4] sequence reqTxn2: lock wait-queue event: wait self @ key ‹"k"›
-[4] sequence reqTxn2: conflicted with ‹00000002-0000-0000-0000-000000000000› on ‹"k"› for 123.000s
+[4] sequence reqTxn2: conflicted with 00000002-0000-0000-0000-000000000000 on ‹"k"› for 123.000s
 [4] sequence reqTxn2: blocked on select in concurrency.(*lockTableWaiterImpl).WaitOn
 
 debug-lock-table
@@ -116,12 +116,12 @@ finish req=reqTxn1
 ----
 [-] finish reqTxn1: finishing request
 [3] sequence reqTxnMiddle: lock wait-queue event: done waiting
-[3] sequence reqTxnMiddle: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"k"› for 0.000s
+[3] sequence reqTxnMiddle: conflicted with 00000001-0000-0000-0000-000000000000 on ‹"k"› for 0.000s
 [3] sequence reqTxnMiddle: acquiring latches
 [3] sequence reqTxnMiddle: scanning lock table for conflicting locks
 [3] sequence reqTxnMiddle: sequencing complete, returned guard
 [4] sequence reqTxn2: lock wait-queue event: wait for txn 00000003 running request @ key ‹"k"› (queuedLockingRequests: 2, queuedReaders: 0)
-[4] sequence reqTxn2: conflicted with ‹00000001-0000-0000-0000-000000000000› on ‹"k"› for 0.000s
+[4] sequence reqTxn2: conflicted with 00000001-0000-0000-0000-000000000000 on ‹"k"› for 0.000s
 [4] sequence reqTxn2: pushing after 0s for: deadlock/liveness detection = true, timeout enforcement = false, priority enforcement = false, wait policy error = false
 [4] sequence reqTxn2: pushing txn 00000003 to detect request deadlock
 [4] sequence reqTxn2: blocked on select in concurrency_test.(*cluster).PushTransaction
@@ -130,7 +130,7 @@ finish req=reqTxnMiddle
 ----
 [-] finish reqTxnMiddle: finishing request
 [4] sequence reqTxn2: lock wait-queue event: done waiting
-[4] sequence reqTxn2: conflicted with ‹00000003-0000-0000-0000-000000000000› on ‹"k"› for 0.000s
+[4] sequence reqTxn2: conflicted with 00000003-0000-0000-0000-000000000000 on ‹"k"› for 0.000s
 [4] sequence reqTxn2: acquiring latches
 [4] sequence reqTxn2: scanning lock table for conflicting locks
 [4] sequence reqTxn2: sequencing complete, returned guard

--- a/pkg/roachpb/data_test.go
+++ b/pkg/roachpb/data_test.go
@@ -2520,9 +2520,9 @@ func TestLockStateInfoSafeFormat(t *testing.T) {
 			"  waiting_txn:<nil> active_waiter:false strength:None wait_duration:17ms",
 		redact.Sprint(lockStateInfo).Redact())
 	require.EqualValues(t,
-		"range_id=35 key=‹×› holder=‹×› durability=Unreplicated duration=5m0s\n"+
+		"range_id=35 key=‹×› holder=deadbeef-0000-0000-0000-000000000000 durability=Unreplicated duration=5m0s\n"+
 			" waiters:\n"+
-			"  waiting_txn:‹×› active_waiter:true strength:Exclusive wait_duration:2m15s\n"+
+			"  waiting_txn:6ba7b810-9dad-11d1-80b4-00c04fd430c8 active_waiter:true strength:Exclusive wait_duration:2m15s\n"+
 			"  waiting_txn:<nil> active_waiter:false strength:None wait_duration:17ms",
 		redact.Sprintf("%+v", lockStateInfo).Redact())
 }

--- a/pkg/testutils/lint/passes/redactcheck/redactcheck.go
+++ b/pkg/testutils/lint/passes/redactcheck/redactcheck.go
@@ -259,6 +259,12 @@ func runAnalyzer(pass *analysis.Pass) (interface{}, error) {
 						"LegacyTimestamp": {},
 						"Timestamp":       {},
 					},
+					"github.com/cockroachdb/cockroach/pkg/util/uuid": {
+						"Bytes":     {},
+						"Short":     {},
+						"UUID":      {},
+						"Timestamp": {},
+					},
 					"github.com/cockroachdb/pebble": {
 						"FormatMajorVersion": {},
 					},

--- a/pkg/util/uuid/BUILD.bazel
+++ b/pkg/util/uuid/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
         "//pkg/util/timeutil",
         "//pkg/util/uint128",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_cockroachdb_redact//:redact",
     ],
 )
 

--- a/pkg/util/uuid/uuid.go
+++ b/pkg/util/uuid/uuid.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/uint128"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 )
 
 // Size of a UUID in bytes.
@@ -33,6 +34,11 @@ const RFC4122StrSize = 36
 // encoding of a UUID.
 type Bytes []byte
 
+var _ redact.SafeValue = Bytes{}
+
+// SafeValue implements the redact.SafeValue interface.
+func (b Bytes) SafeValue() {}
+
 // GetUUID constructs a UUID from the bytes. If the data is not valid, a zero
 // value will be returned.
 func (b Bytes) GetUUID() UUID { return FromBytesOrNil(b) }
@@ -44,6 +50,11 @@ func (b Bytes) String() string {
 
 // UUID is an array type to represent the value of a UUID, as defined in RFC-4122.
 type UUID [Size]byte
+
+var _ redact.SafeValue = UUID{}
+
+// SafeValue implements the redact.SafeValue interface.
+func (u UUID) SafeValue() {}
 
 // UUID versions.
 const (
@@ -67,6 +78,11 @@ const (
 // 15 October 1582 within a V1 UUID. This type has no meaning for V2-V5
 // UUIDs since they don't have an embedded timestamp.
 type Timestamp uint64
+
+var _ redact.SafeValue = Timestamp(0)
+
+// SafeValue implements the redact.SafeValue interface.
+func (t Timestamp) SafeValue() {}
 
 const _100nsPerSecond = 10000000
 

--- a/pkg/util/uuid/uuid_wrapper.go
+++ b/pkg/util/uuid/uuid_wrapper.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/util/uint128"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 )
 
 const (
@@ -23,6 +24,11 @@ const (
 type Short struct {
 	b [shortSize]byte
 }
+
+var _ redact.SafeValue = Short{}
+
+// SafeValue implements the redact.SafeValue interface.
+func (s Short) SafeValue() {}
 
 // String returns the 8-character hexidecimal representation of the abbreviated
 // UUID.


### PR DESCRIPTION
These values are all randomized IDs or times, so they can never contain any PII. Seeing them unredacting is likely to make some logs more useful.

Epic: None
Release note: None