### PR TITLE
release-24.3: dev: add extra startup flag to fix breakage on Darwin/ARM64 machines

### DIFF
--- a/build/bazelutil/darwinarm64cross.bazelrc
+++ b/build/bazelutil/darwinarm64cross.bazelrc
@@ -1,0 +1,7 @@
+# As of late 2024/early 2025, current versions of java crash when run in a guest
+# VM on a MacOS 15.2 host running on an M4 chip. Disbaling SVE avoids this
+# crash until patched versions of Java become available.
+
+# NB: We mount this into the Docker container when building on macOS ARM64 host
+# machines specifically. Other machines get empty.bazelrc.
+startup --host_jvm_args="-XX:UseSVE=0"

--- a/dev
+++ b/dev
@@ -8,7 +8,7 @@ fi
 set -euo pipefail
 
 # Bump this counter to force rebuilding `dev` on all machines.
-DEV_VERSION=105
+DEV_VERSION=24301
 
 THIS_DIR=$(cd "$(dirname "$0")" && pwd)
 BINARY_DIR=$THIS_DIR/bin/dev-versions

--- a/pkg/cmd/dev/builder.go
+++ b/pkg/cmd/dev/builder.go
@@ -11,9 +11,11 @@ import (
 	"fmt"
 	"log"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 
+	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
 	"github.com/spf13/cobra"
 )
 
@@ -151,7 +153,11 @@ func (d *dev) getDockerRunArgs(
 	}
 	args = append(args, "-v", workspace+":/cockroach")
 	args = append(args, "--workdir=/cockroach")
-	args = append(args, "-v", filepath.Join(workspace, "build", "bazelutil", "empty.bazelrc")+":/cockroach/.bazelrc.user")
+	bazelRc := "empty.bazelrc"
+	if !buildutil.CrdbTestBuild && (runtime.GOOS == "darwin" && runtime.GOARCH == "arm64") {
+		bazelRc = "darwinarm64cross.bazelrc"
+	}
+	args = append(args, "-v", filepath.Join(workspace, "build", "bazelutil", bazelRc)+":/cockroach/.bazelrc.user")
 	// Create the artifacts directory.
 	artifacts := filepath.Join(workspace, "artifacts")
 	err = d.os.MkdirAll(artifacts)


### PR DESCRIPTION
Backport 1/1 commits from #139797.

/cc @cockroachdb/release

Release justification: Non-production code changes

---

When cross-building, Java can crash on Darwin/ARM64 machines due to an error that looks like this:

```
A fatal error has been detected by the Java Runtime Environment:
SIGILL (0x4) at pc=0x0000ffffadf3fc1c, pid=39, tid=40
```

This was addressed in #139670, which adds a startup flag to disable the use of SVE. Unfortunately this broke the build on x86-64 machines (#139756). So now we must apply the flag conditionally only where relevant.

Closes: #139756

Epic: none
Release note: None
