### PR TITLE
stats: disallow auto stats on system.span_configurations

### DIFF
--- a/pkg/sql/stats/automatic_stats_test.go
+++ b/pkg/sql/stats/automatic_stats_test.go
@@ -225,8 +225,8 @@ func TestEnsureAllTablesQueries(t *testing.T) {
 	require.NoError(t, cache.Start(ctx, codec, s.RangeFeedFactory().(*rangefeed.Factory)))
 	r := MakeRefresher(s.AmbientCtx(), st, internalDB, cache, time.Microsecond /* asOfTime */, nil /* knobs */)
 
-	// Exclude the 3 system tables which don't use autostats.
-	systemTablesWithStats := bootstrap.NumSystemTablesForSystemTenant - 3
+	// Exclude the 4 system tables which don't use autostats.
+	systemTablesWithStats := bootstrap.NumSystemTablesForSystemTenant - 4
 	numUserTablesWithStats := 2
 
 	// This now includes 36 system tables as well as the 2 created above.

--- a/pkg/sql/stats/stats_cache.go
+++ b/pkg/sql/stats/stats_cache.go
@@ -265,7 +265,10 @@ func DisallowedOnSystemTable(tableID descpb.ID) bool {
 	// benefit is not worth the potential performance hit.
 	// TODO(yuzefovich): re-evaluate this assumption. Perhaps we could at
 	// least enable manual collection on this table.
-	case keys.TableStatisticsTableID, keys.LeaseTableID, keys.ScheduledJobsTableID:
+	// Disable stats on system.span_configurations since we've seen excessively
+	// many collections on it in some cases, and the stats are unlikely to
+	// provide any benefit on this table.
+	case keys.TableStatisticsTableID, keys.LeaseTableID, keys.ScheduledJobsTableID, keys.SpanConfigurationsTableID:
 		return true
 	}
 	return false


### PR DESCRIPTION
We've seen excessively many collections on it in some cases, and the stats are unlikely to provide any benefit on this table.

Epic: None
Release note: None