### PR TITLE
sql: handle DELETEs with buffered writes

### DIFF
--- a/pkg/crosscluster/logical/lww_kv_processor.go
+++ b/pkg/crosscluster/logical/lww_kv_processor.go
@@ -427,7 +427,7 @@ func newKVTableWriter(
 	if err != nil {
 		return nil, err
 	}
-	rd := row.MakeDeleter(evalCtx.Codec, tableDesc, readCols, &evalCtx.Settings.SV, internal, nil)
+	rd := row.MakeDeleter(evalCtx.Codec, tableDesc, nil /* lockedIndexes */, readCols, &evalCtx.Settings.SV, internal, nil)
 	ru, err := row.MakeUpdater(
 		ctx, nil, evalCtx.Codec, tableDesc, nil /* uniqueWithTombstoneIndexes */, readCols, writeCols, row.UpdaterDefault, a, &evalCtx.Settings.SV, internal, nil,
 	)

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -2953,8 +2953,8 @@ func indexTruncateInTxn(
 	for done := false; !done; done = sp.Key == nil {
 		internal := evalCtx.SessionData().Internal
 		rd := row.MakeDeleter(
-			execCfg.Codec, tableDesc, nil /* requestedCols */, &execCfg.Settings.SV, internal,
-			execCfg.GetRowMetrics(internal),
+			execCfg.Codec, tableDesc, nil /* lockedIndexes */, nil, /* requestedCols */
+			&execCfg.Settings.SV, internal, execCfg.GetRowMetrics(internal),
 		)
 		td := tableDeleter{rd: rd, alloc: alloc}
 		if err := td.init(ctx, txn.KV(), evalCtx); err != nil {

--- a/pkg/sql/colenc/bench_test.go
+++ b/pkg/sql/colenc/bench_test.go
@@ -144,6 +144,7 @@ func (n *noopPutter) CPutWithOriginTimestamp(
 func (n *noopPutter) Put(key, value interface{})                                {}
 func (n *noopPutter) PutMustAcquireExclusiveLock(key, value interface{})        {}
 func (n *noopPutter) Del(key ...interface{})                                    {}
+func (n *noopPutter) DelMustAcquireExclusiveLock(key ...interface{})            {}
 func (n *noopPutter) CPutBytesEmpty(kys []roachpb.Key, values [][]byte)         {}
 func (n *noopPutter) CPutValuesEmpty(kys []roachpb.Key, values []roachpb.Value) {}
 func (n *noopPutter) CPutTuplesEmpty(kys []roachpb.Key, values [][]byte)        {}

--- a/pkg/sql/colenc/encode_test.go
+++ b/pkg/sql/colenc/encode_test.go
@@ -728,6 +728,10 @@ func (c *capturePutter) Del(key ...interface{}) {
 	colexecerror.InternalError(errors.New("unimplemented"))
 }
 
+func (c *capturePutter) DelMustAcquireExclusiveLock(key ...interface{}) {
+	colexecerror.InternalError(errors.New("unimplemented"))
+}
+
 func (c *capturePutter) CPutBytesEmpty(kys []roachpb.Key, values [][]byte) {
 	for i, k := range kys {
 		if len(k) == 0 {

--- a/pkg/sql/distsql_spec_exec_factory.go
+++ b/pkg/sql/distsql_spec_exec_factory.go
@@ -1431,6 +1431,7 @@ func (e *distSQLSpecExecFactory) ConstructDelete(
 	fetchCols exec.TableColumnOrdinalSet,
 	returnCols exec.TableColumnOrdinalSet,
 	passthrough colinfo.ResultColumns,
+	lockedIndexes cat.IndexOrdinals,
 	autoCommit bool,
 ) (exec.Node, error) {
 	return nil, unimplemented.NewWithIssue(47473, "experimental opt-driven distsql planning: delete")

--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -3033,7 +3033,9 @@ func (t *logicTest) processSubtest(
 								} else {
 									sb.WriteString("OR ")
 								}
-								sb.WriteString(fmt.Sprintf("message like '%s %s%%' ", c, f))
+								// % wildcard between command and prefix is for
+								// optional '(locking)' substring.
+								sb.WriteString(fmt.Sprintf("message LIKE '%s %%%s%%' ", c, f))
 							}
 						}
 						return sb.String()

--- a/pkg/sql/opt/exec/execbuilder/mutation.go
+++ b/pkg/sql/opt/exec/execbuilder/mutation.go
@@ -26,10 +26,10 @@ import (
 
 func (b *Builder) buildMutationInput(
 	mutExpr, inputExpr memo.RelExpr, colList opt.ColList, p *memo.MutationPrivate,
-) (_ execPlan, err error) {
-	toLock, err := b.shouldApplyImplicitLockingToMutationInput(mutExpr)
+) (_ execPlan, lockedIndexes cat.IndexOrdinals, err error) {
+	toLock, toLockIndexes, err := b.shouldApplyImplicitLockingToMutationInput(mutExpr)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, nil, err
 	}
 	if toLock != 0 {
 		if b.forceForUpdateLocking != 0 {
@@ -38,7 +38,7 @@ func (b *Builder) buildMutationInput(
 				// assertion failure in test builds. Additionally, we will rely
 				// on forceForUpdateLocking set properly when buffered writes
 				// are enabled for correctness.
-				return execPlan{}, errors.AssertionFailedf(
+				return execPlan{}, nil, errors.AssertionFailedf(
 					"unexpectedly already locked %d, also want to lock %d", b.forceForUpdateLocking, toLock,
 				)
 			}
@@ -51,7 +51,7 @@ func (b *Builder) buildMutationInput(
 
 	input, inputCols, err := b.buildRelational(inputExpr)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, nil, err
 	}
 
 	// TODO(mgartner/radu): This can incorrectly append columns in a FK cascade
@@ -85,14 +85,14 @@ func (b *Builder) buildMutationInput(
 		inputExpr.ProvidedPhysical().Ordering, true, /* reuseInputCols */
 	)
 	if err != nil {
-		return execPlan{}, err
+		return execPlan{}, nil, err
 	}
 
 	if p.WithID != 0 {
 		label := fmt.Sprintf("buffer %d", p.WithID)
 		bufferNode, err := b.factory.ConstructBuffer(input.root, label)
 		if err != nil {
-			return execPlan{}, err
+			return execPlan{}, nil, err
 		}
 
 		b.addBuiltWithExpr(p.WithID, inputCols, bufferNode)
@@ -100,7 +100,7 @@ func (b *Builder) buildMutationInput(
 	} else {
 		b.colOrdsAlloc.Free(inputCols)
 	}
-	return input, nil
+	return input, toLockIndexes, nil
 }
 
 func (b *Builder) buildInsert(ins *memo.InsertExpr) (_ execPlan, outputCols colOrdMap, err error) {
@@ -113,7 +113,7 @@ func (b *Builder) buildInsert(ins *memo.InsertExpr) (_ execPlan, outputCols colO
 		ins.InsertCols, ins.CheckCols, ins.PartialIndexPutCols,
 		ins.VectorIndexPutPartitionCols, ins.VectorIndexPutQuantizedVecCols,
 	)
-	input, err := b.buildMutationInput(ins, ins.Input, colList, &ins.MutationPrivate)
+	input, _, err := b.buildMutationInput(ins, ins.Input, colList, &ins.MutationPrivate)
 	if err != nil {
 		return execPlan{}, colOrdMap{}, err
 	}
@@ -433,7 +433,8 @@ func (b *Builder) buildUpdate(upd *memo.UpdateExpr) (_ execPlan, outputCols colO
 		upd.VectorIndexDelPartitionCols,
 	)
 
-	input, err := b.buildMutationInput(upd, upd.Input, colList, &upd.MutationPrivate)
+	// TODO(yuzefovich): use lockedIndexes to optimize locking behavior.
+	input, _, err := b.buildMutationInput(upd, upd.Input, colList, &upd.MutationPrivate)
 	if err != nil {
 		return execPlan{}, colOrdMap{}, err
 	}
@@ -507,7 +508,8 @@ func (b *Builder) buildUpsert(ups *memo.UpsertExpr) (_ execPlan, outputCols colO
 		ups.VectorIndexDelPartitionCols,
 	)
 
-	input, err := b.buildMutationInput(ups, ups.Input, colList, &ups.MutationPrivate)
+	// TODO(yuzefovich): use lockedIndexes to optimize locking behavior.
+	input, _, err := b.buildMutationInput(ups, ups.Input, colList, &ups.MutationPrivate)
 	if err != nil {
 		return execPlan{}, colOrdMap{}, err
 	}
@@ -594,7 +596,7 @@ func (b *Builder) buildDelete(del *memo.DeleteExpr) (_ execPlan, outputCols colO
 		del.FetchCols, neededPassThroughCols, del.PartialIndexDelCols, del.VectorIndexDelPartitionCols,
 	)
 
-	input, err := b.buildMutationInput(del, del.Input, colList, &del.MutationPrivate)
+	input, lockedIndexes, err := b.buildMutationInput(del, del.Input, colList, &del.MutationPrivate)
 	if err != nil {
 		return execPlan{}, colOrdMap{}, err
 	}
@@ -620,6 +622,7 @@ func (b *Builder) buildDelete(del *memo.DeleteExpr) (_ execPlan, outputCols colO
 		fetchColOrds,
 		returnColOrds,
 		passthroughCols,
+		lockedIndexes,
 		b.allowAutoCommit && len(del.FKChecks) == 0 &&
 			len(del.FKCascades) == 0 && del.AfterTriggers == nil,
 	)
@@ -1133,12 +1136,21 @@ var forUpdateLocking = opt.Locking{
 // shouldApplyImplicitLockingToMutationInput determines whether or not the
 // builder should apply a FOR UPDATE row-level locking mode to the initial row
 // scan of a mutation expression. If the builder should lock the initial row
-// scan, it returns the TableID of the scan, otherwise it returns 0.
+// scan, it returns the TableID of the scan (as well as ordinals of indexes to
+// lock), otherwise it returns 0.
 func (b *Builder) shouldApplyImplicitLockingToMutationInput(
 	mutExpr memo.RelExpr,
-) (opt.TableID, error) {
+) (_ opt.TableID, retIndexes cat.IndexOrdinals, _ error) {
 	if !b.evalCtx.SessionData().ImplicitSelectForUpdate {
-		return 0, nil
+		return 0, nil, nil
+	}
+
+	if buildutil.CrdbTestBuild {
+		defer func() {
+			if len(retIndexes) > 2 {
+				panic(errors.AssertionFailedf("attempt to lock %d indexes: %v", len(retIndexes), retIndexes))
+			}
+		}()
 	}
 
 	switch t := mutExpr.(type) {
@@ -1147,28 +1159,32 @@ func (b *Builder) shouldApplyImplicitLockingToMutationInput(
 		// sense to apply implicit row-level locking to the input of an INSERT
 		// expression because any contention results in unique constraint
 		// violations.
-		return 0, nil
+		return 0, nil, nil
 
 	case *memo.UpdateExpr:
 		md := b.mem.Metadata()
-		return shouldApplyImplicitLockingToUpdateOrDeleteInput(md, t.Input, t.Table), nil
+		tableID, toLockIndexes := shouldApplyImplicitLockingToUpdateOrDeleteInput(md, t.Input, t.Table)
+		return tableID, toLockIndexes.Ordered(), nil
 
 	case *memo.UpsertExpr:
-		return shouldApplyImplicitLockingToUpsertInput(t), nil
+		tableID, toLockIndexes := shouldApplyImplicitLockingToUpsertInput(t)
+		return tableID, toLockIndexes.Ordered(), nil
 
 	case *memo.DeleteExpr:
 		md := b.mem.Metadata()
-		return shouldApplyImplicitLockingToUpdateOrDeleteInput(md, t.Input, t.Table), nil
+		tableID, toLockIndexes := shouldApplyImplicitLockingToUpdateOrDeleteInput(md, t.Input, t.Table)
+		return tableID, toLockIndexes.Ordered(), nil
 
 	default:
-		return 0, errors.AssertionFailedf("unexpected mutation expression %T", t)
+		return 0, nil, errors.AssertionFailedf("unexpected mutation expression %T", t)
 	}
 }
 
 // shouldApplyImplicitLockingToUpdateOrDeleteInput determines whether the
 // builder should apply a FOR UPDATE row-level locking mode to the initial row
 // scan of an UPDATE statement or a DELETE. If the builder should lock the
-// initial row scan, it returns the TableID of the scan, otherwise it returns 0.
+// initial row scan, it returns the TableID of the scan (as well as ordinals of
+// indexes to lock), otherwise it returns 0.
 //
 // Conceptually, if we picture an UPDATE statement as the composition of a
 // SELECT statement and an INSERT statement (with loosened semantics around
@@ -1193,7 +1209,8 @@ func (b *Builder) shouldApplyImplicitLockingToMutationInput(
 // reuse this function for both.
 func shouldApplyImplicitLockingToUpdateOrDeleteInput(
 	md *opt.Metadata, input memo.RelExpr, tabID opt.TableID,
-) opt.TableID {
+) (opt.TableID, intsets.Fast) {
+	var toLockIndexes intsets.Fast
 	// Try to match the mutation's input expression against the pattern:
 	//
 	//   [Project]* [IndexJoin] (Scan | LookupJoin [LookupJoin] Values)
@@ -1203,13 +1220,21 @@ func shouldApplyImplicitLockingToUpdateOrDeleteInput(
 	input = unwrapProjectExprs(input)
 	if idxJoin, ok := input.(*memo.IndexJoinExpr); ok {
 		input = idxJoin.Input
+		toLockIndexes.Add(cat.PrimaryIndex)
 	}
 	switch t := input.(type) {
 	case *memo.ScanExpr:
-		return t.Table
+		toLockIndexes.Add(t.Index)
+		return t.Table, toLockIndexes
 	case *memo.LookupJoinExpr:
+		toLockIndexes.Add(t.Index)
 		if innerJoin, ok := t.Input.(*memo.LookupJoinExpr); ok && innerJoin.Table == t.Table {
+			// When a generic query plan reads from a secondary index first,
+			// then performs a lookup into the primary index, the plan has a
+			// double lookup join pattern. We add implicit locks in this case
+			// where both lookup joins have the same table.
 			t = innerJoin
+			toLockIndexes.Add(t.Index)
 		}
 		mutStableID := md.Table(tabID).ID()
 		lookupStableID := md.Table(t.Table).ID()
@@ -1217,17 +1242,19 @@ func shouldApplyImplicitLockingToUpdateOrDeleteInput(
 		// same as the table being updated. Also, don't lock rows if there is an
 		// ON condition so that we don't lock rows that won't be updated.
 		if mutStableID == lookupStableID && t.On.IsTrue() && t.Input.Op() == opt.ValuesOp {
-			return t.Table
+			return t.Table, toLockIndexes
 		}
 	}
-	return 0
+	return 0, intsets.Fast{}
 }
 
 // tryApplyImplicitLockingToUpsertInput determines whether or not the builder
 // should apply a FOR UPDATE row-level locking mode to the initial row scan of
 // an UPSERT statement. If the builder should lock the initial row scan, it
-// returns the TableID of the scan, otherwise it returns 0.
-func shouldApplyImplicitLockingToUpsertInput(ups *memo.UpsertExpr) opt.TableID {
+// returns the TableID of the scan (as well as ordinals of indexes to lock),
+// otherwise it returns 0.
+func shouldApplyImplicitLockingToUpsertInput(ups *memo.UpsertExpr) (opt.TableID, intsets.Fast) {
+	var toLockIndexes intsets.Fast
 	// Try to match the Upsert's input expression against the pattern:
 	//
 	//   [Project]* (LeftJoin Scan | LookupJoin [LookupJoin]) [Project]* Values
@@ -1239,30 +1266,33 @@ func shouldApplyImplicitLockingToUpsertInput(ups *memo.UpsertExpr) opt.TableID {
 	case *memo.LeftJoinExpr:
 		scan, ok := join.Right.(*memo.ScanExpr)
 		if !ok {
-			return 0
+			return 0, intsets.Fast{}
 		}
 		input = join.Left
 		toLock = scan.Table
+		toLockIndexes.Add(scan.Index)
 
 	case *memo.LookupJoinExpr:
 		input = join.Input
+		toLockIndexes.Add(join.Index)
 		if inner, ok := input.(*memo.LookupJoinExpr); ok && inner.Table == join.Table {
 			// When a generic query plan reads from a secondary index first,
 			// then performs a lookup into the primary index, the plan has a
 			// double lookup join pattern. We add implicit locks in this case
 			// where both lookup joins have the same table.
 			input = inner.Input
+			toLockIndexes.Add(inner.Index)
 		}
 		toLock = join.Table
 
 	default:
-		return 0
+		return 0, intsets.Fast{}
 	}
 	input = unwrapProjectExprs(input)
 	if _, ok := input.(*memo.ValuesExpr); ok {
-		return toLock
+		return toLock, toLockIndexes
 	}
-	return 0
+	return 0, intsets.Fast{}
 }
 
 // unwrapProjectExprs unwraps zero or more nested ProjectExprs. It returns the

--- a/pkg/sql/opt/exec/execbuilder/testdata/cascade
+++ b/pkg/sql/opt/exec/execbuilder/testdata/cascade
@@ -73,24 +73,24 @@ WHERE message LIKE '%executing cascade %' OR message LIKE 'Del%'
 ----
 Del (locking) /Table/106/1/"a-pk1"/0
 executing cascade for constraint b1_delete_cascade_fkey
-Del /Table/107/1/"b1-pk1"/0
-Del /Table/107/1/"b1-pk2"/0
+Del (locking) /Table/107/1/"b1-pk1"/0
+Del (locking) /Table/107/1/"b1-pk2"/0
 executing cascade for constraint b2_delete_cascade_fkey
-Del /Table/108/1/"b2-pk1"/0
-Del /Table/108/1/"b2-pk2"/0
+Del (locking) /Table/108/1/"b2-pk1"/0
+Del (locking) /Table/108/1/"b2-pk2"/0
 executing cascade for constraint c1_delete_cascade_fkey
-Del /Table/109/1/"c1-pk1-b1-pk1"/0
-Del /Table/109/1/"c1-pk2-b1-pk1"/0
-Del /Table/109/1/"c1-pk3-b1-pk2"/0
-Del /Table/109/1/"c1-pk4-b1-pk2"/0
+Del (locking) /Table/109/1/"c1-pk1-b1-pk1"/0
+Del (locking) /Table/109/1/"c1-pk2-b1-pk1"/0
+Del (locking) /Table/109/1/"c1-pk3-b1-pk2"/0
+Del (locking) /Table/109/1/"c1-pk4-b1-pk2"/0
 executing cascade for constraint c2_delete_cascade_fkey
-Del /Table/110/1/"c2-pk1-b1-pk1"/0
-Del /Table/110/1/"c2-pk2-b1-pk1"/0
-Del /Table/110/1/"c2-pk3-b1-pk2"/0
-Del /Table/110/1/"c2-pk4-b1-pk2"/0
+Del (locking) /Table/110/1/"c2-pk1-b1-pk1"/0
+Del (locking) /Table/110/1/"c2-pk2-b1-pk1"/0
+Del (locking) /Table/110/1/"c2-pk3-b1-pk2"/0
+Del (locking) /Table/110/1/"c2-pk4-b1-pk2"/0
 executing cascade for constraint c3_id_fkey
-Del /Table/111/1/"b2-pk1"/0
-Del /Table/111/1/"b2-pk2"/0
+Del (locking) /Table/111/1/"b2-pk1"/0
+Del (locking) /Table/111/1/"b2-pk2"/0
 
 # Clean up after the test.
 statement ok
@@ -172,21 +172,21 @@ SELECT message FROM [SHOW TRACE FOR SESSION]
 WHERE message LIKE '%executing cascade %' OR message LIKE 'Del%' OR message LIKE 'CPut%' OR message LIKE 'Scan%updated%'
 ----
 Scan /Table/112/1/"updated"/0 lock Exclusive (Block, Unreplicated)
-Del /Table/112/1/"updated"/0
+Del (locking) /Table/112/1/"updated"/0
 CPut /Table/112/1/"latest"/0 -> /TUPLE/
 executing cascade for constraint b1_update_cascade_fkey
 Scan /Table/113/2/"updated"/0
-Del /Table/113/2/"updated"/0
+Del (locking) /Table/113/2/"updated"/0
 CPut /Table/113/2/"latest"/0 -> /BYTES/0x1262312d706b310001
 executing cascade for constraint b2_update_cascade_fkey
 Scan /Table/114/2/"updated"/0
-Del /Table/114/2/"updated"/0
+Del (locking) /Table/114/2/"updated"/0
 CPut /Table/114/2/"latest"/0 -> /BYTES/0x1262322d706b310001
 executing cascade for constraint c1_update_cascade_fkey
 executing cascade for constraint c2_update_cascade_fkey
 executing cascade for constraint c3_id_fkey
 Scan /Table/117/1/"updated"/0
-Del /Table/117/1/"updated"/0
+Del (locking) /Table/117/1/"updated"/0
 CPut /Table/117/1/"latest"/0 -> /TUPLE/
 
 # Clean up after the test.
@@ -242,7 +242,7 @@ SELECT message FROM [SHOW TRACE FOR SESSION]
 WHERE message LIKE '%executing cascade %' OR message LIKE 'Del%' OR message LIKE 'Scan%delete_me%'
 ----
 Scan /Table/118/1/"delete_me"/0 lock Exclusive (Block, Unreplicated)
-Del /Table/118/1/"delete_me"/0
+Del (locking) /Table/118/1/"delete_me"/0
 executing cascade for constraint b1_delete_set_null_fkey
 executing cascade for constraint b2_delete_set_null_fkey
 executing cascade for constraint b3_delete_set_null_fkey
@@ -322,11 +322,11 @@ WHERE message LIKE '%executing cascade %' OR message LIKE 'Del%'
 ----
 Del (locking) /Table/123/1/"a-pk1"/0
 executing cascade for constraint b1_delete_cascade_fkey
-Del /Table/124/1/"b1-pk1"/0
-Del /Table/124/1/"b1-pk2"/0
+Del (locking) /Table/124/1/"b1-pk1"/0
+Del (locking) /Table/124/1/"b1-pk2"/0
 executing cascade for constraint b2_delete_cascade_fkey
-Del /Table/125/1/"b2-pk1"/0
-Del /Table/125/1/"b2-pk2"/0
+Del (locking) /Table/125/1/"b2-pk1"/0
+Del (locking) /Table/125/1/"b2-pk2"/0
 executing cascade for constraint c1_delete_set_null_fkey
 executing cascade for constraint c2_delete_set_null_fkey
 executing cascade for constraint c3_delete_set_null_fkey
@@ -384,7 +384,7 @@ SELECT message FROM [SHOW TRACE FOR SESSION]
 WHERE message LIKE '%executing cascade %' OR message LIKE 'Del%' OR message LIKE 'CPut%' OR message LIKE 'Scan%original%'
 ----
 Scan /Table/129/1/"original"/0 lock Exclusive (Block, Unreplicated)
-Del /Table/129/1/"original"/0
+Del (locking) /Table/129/1/"original"/0
 CPut /Table/129/1/"updated"/0 -> /TUPLE/
 executing cascade for constraint b1_update_set_null_fkey
 executing cascade for constraint b2_update_set_null_fkey
@@ -466,15 +466,15 @@ SELECT message FROM [SHOW TRACE FOR SESSION]
 WHERE message LIKE '%executing cascade %' OR message LIKE 'Del%' OR message LIKE 'CPut%' OR message LIKE 'Scan%original%'
 ----
 Scan /Table/134/1/"original"/0 lock Exclusive (Block, Unreplicated)
-Del /Table/134/1/"original"/0
+Del (locking) /Table/134/1/"original"/0
 CPut /Table/134/1/"updated"/0 -> /TUPLE/
 executing cascade for constraint b1_update_cascade_fkey
 Scan /Table/135/2/"original"/0
-Del /Table/135/2/"original"/0
+Del (locking) /Table/135/2/"original"/0
 CPut /Table/135/2/"updated"/0 -> /BYTES/0x1262312d706b310001
 executing cascade for constraint b2_update_cascade_fkey
 Scan /Table/136/2/"original"/0
-Del /Table/136/2/"original"/0
+Del (locking) /Table/136/2/"original"/0
 CPut /Table/136/2/"updated"/0 -> /BYTES/0x1262322d706b310001
 executing cascade for constraint c1_update_set_null_fkey
 executing cascade for constraint c2_update_set_null_fkey
@@ -535,7 +535,7 @@ SELECT message FROM [SHOW TRACE FOR SESSION]
 WHERE message LIKE '%executing cascade %' OR message LIKE 'Del%' OR message LIKE 'Scan%delete_me%'
 ----
 Scan /Table/140/1/"delete_me"/0 lock Exclusive (Block, Unreplicated)
-Del /Table/140/1/"delete_me"/0
+Del (locking) /Table/140/1/"delete_me"/0
 executing cascade for constraint b1_delete_set_default_fkey
 executing cascade for constraint b2_delete_set_default_fkey
 executing cascade for constraint b3_delete_set_default_fkey
@@ -615,11 +615,11 @@ WHERE message LIKE '%executing cascade %' OR message LIKE 'Del%'
 ----
 Del (locking) /Table/145/1/"a-pk1"/0
 executing cascade for constraint b1_delete_cascade_fkey
-Del /Table/146/1/"b1-pk1"/0
-Del /Table/146/1/"b1-pk2"/0
+Del (locking) /Table/146/1/"b1-pk1"/0
+Del (locking) /Table/146/1/"b1-pk2"/0
 executing cascade for constraint b2_delete_cascade_fkey
-Del /Table/147/1/"b2-pk1"/0
-Del /Table/147/1/"b2-pk2"/0
+Del (locking) /Table/147/1/"b2-pk1"/0
+Del (locking) /Table/147/1/"b2-pk2"/0
 executing cascade for constraint c1_delete_set_default_fkey
 executing cascade for constraint c2_delete_set_default_fkey
 executing cascade for constraint c3_delete_set_default_fkey
@@ -677,7 +677,7 @@ SELECT message FROM [SHOW TRACE FOR SESSION]
 WHERE message LIKE '%executing cascade %' OR message LIKE 'Del%' OR message LIKE 'CPut%' OR message LIKE 'Scan%original%'
 ----
 Scan /Table/151/1/"original"/0 lock Exclusive (Block, Unreplicated)
-Del /Table/151/1/"original"/0
+Del (locking) /Table/151/1/"original"/0
 CPut /Table/151/1/"updated"/0 -> /TUPLE/
 executing cascade for constraint b1_update_set_null_fkey
 executing cascade for constraint b2_update_set_null_fkey
@@ -759,15 +759,15 @@ SELECT message FROM [SHOW TRACE FOR SESSION]
 WHERE message LIKE '%executing cascade %' OR message LIKE 'Del%' OR message LIKE 'CPut%' OR message LIKE 'Scan%original%'
 ----
 Scan /Table/156/1/"original"/0 lock Exclusive (Block, Unreplicated)
-Del /Table/156/1/"original"/0
+Del (locking) /Table/156/1/"original"/0
 CPut /Table/156/1/"updated"/0 -> /TUPLE/
 executing cascade for constraint b1_update_cascade_fkey
 Scan /Table/157/2/"original"/0
-Del /Table/157/2/"original"/0
+Del (locking) /Table/157/2/"original"/0
 CPut /Table/157/2/"updated"/0 -> /BYTES/0x1262312d706b310001
 executing cascade for constraint b2_update_cascade_fkey
 Scan /Table/158/2/"original"/0
-Del /Table/158/2/"original"/0
+Del (locking) /Table/158/2/"original"/0
 CPut /Table/158/2/"updated"/0 -> /BYTES/0x1262322d706b310001
 executing cascade for constraint c1_update_set_null_fkey
 executing cascade for constraint c2_update_set_null_fkey
@@ -805,10 +805,10 @@ query T kvtrace(Del,Scan)
 DELETE FROM parent WHERE x = 1
 ----
 Scan /Table/162/1/1/0 lock Exclusive (Block, Unreplicated)
-Del /Table/162/1/1/0
+Del (locking) /Table/162/1/1/0
 Scan /Table/163/{1-2}
-Del /Table/163/1/1/0
-Del /Table/163/1/2/0
+Del (locking) /Table/163/1/1/0
+Del (locking) /Table/163/1/2/0
 Scan /Table/164/{1-2}
 
 subtest DelRange

--- a/pkg/sql/opt/exec/execbuilder/testdata/cascade
+++ b/pkg/sql/opt/exec/execbuilder/testdata/cascade
@@ -165,25 +165,29 @@ statement ok
 UPDATE a SET id = 'updated' WHERE id = 'original';
 
 statement ok
-SET tracing = on,kv,results; UPDATE a SET id = 'updated2' WHERE id = 'updated'; SET tracing = off
+SET tracing = on,kv,results; UPDATE a SET id = 'latest' WHERE id = 'updated'; SET tracing = off
 
 query T
 SELECT message FROM [SHOW TRACE FOR SESSION]
-WHERE message LIKE '%executing cascade %' OR message LIKE 'Del%' OR message LIKE 'CPut%'
+WHERE message LIKE '%executing cascade %' OR message LIKE 'Del%' OR message LIKE 'CPut%' OR message LIKE 'Scan%updated%'
 ----
+Scan /Table/112/1/"updated"/0 lock Exclusive (Block, Unreplicated)
 Del /Table/112/1/"updated"/0
-CPut /Table/112/1/"updated2"/0 -> /TUPLE/
+CPut /Table/112/1/"latest"/0 -> /TUPLE/
 executing cascade for constraint b1_update_cascade_fkey
+Scan /Table/113/2/"updated"/0
 Del /Table/113/2/"updated"/0
-CPut /Table/113/2/"updated2"/0 -> /BYTES/0x1262312d706b310001
+CPut /Table/113/2/"latest"/0 -> /BYTES/0x1262312d706b310001
 executing cascade for constraint b2_update_cascade_fkey
+Scan /Table/114/2/"updated"/0
 Del /Table/114/2/"updated"/0
-CPut /Table/114/2/"updated2"/0 -> /BYTES/0x1262322d706b310001
+CPut /Table/114/2/"latest"/0 -> /BYTES/0x1262322d706b310001
 executing cascade for constraint c1_update_cascade_fkey
 executing cascade for constraint c2_update_cascade_fkey
 executing cascade for constraint c3_id_fkey
+Scan /Table/117/1/"updated"/0
 Del /Table/117/1/"updated"/0
-CPut /Table/117/1/"updated2"/0 -> /TUPLE/
+CPut /Table/117/1/"latest"/0 -> /TUPLE/
 
 # Clean up after the test.
 statement ok
@@ -235,8 +239,9 @@ SET tracing = on,kv,results; DELETE FROM a WHERE id = 'delete_me'; SET tracing =
 
 query T
 SELECT message FROM [SHOW TRACE FOR SESSION]
-WHERE message LIKE '%executing cascade %' OR message LIKE 'Del%'
+WHERE message LIKE '%executing cascade %' OR message LIKE 'Del%' OR message LIKE 'Scan%delete_me%'
 ----
+Scan /Table/118/1/"delete_me"/0 lock Exclusive (Block, Unreplicated)
 Del /Table/118/1/"delete_me"/0
 executing cascade for constraint b1_delete_set_null_fkey
 executing cascade for constraint b2_delete_set_null_fkey
@@ -376,8 +381,9 @@ SET tracing = on,kv,results; UPDATE a SET id = 'updated' WHERE id = 'original'; 
 
 query T
 SELECT message FROM [SHOW TRACE FOR SESSION]
-WHERE message LIKE '%executing cascade %' OR message LIKE 'Del%' OR message LIKE 'CPut%'
+WHERE message LIKE '%executing cascade %' OR message LIKE 'Del%' OR message LIKE 'CPut%' OR message LIKE 'Scan%original%'
 ----
+Scan /Table/129/1/"original"/0 lock Exclusive (Block, Unreplicated)
 Del /Table/129/1/"original"/0
 CPut /Table/129/1/"updated"/0 -> /TUPLE/
 executing cascade for constraint b1_update_set_null_fkey
@@ -457,14 +463,17 @@ SET tracing = on,kv,results; UPDATE a SET id = 'updated' WHERE id = 'original'; 
 
 query T
 SELECT message FROM [SHOW TRACE FOR SESSION]
-WHERE message LIKE '%executing cascade %' OR message LIKE 'Del%' OR message LIKE 'CPut%'
+WHERE message LIKE '%executing cascade %' OR message LIKE 'Del%' OR message LIKE 'CPut%' OR message LIKE 'Scan%original%'
 ----
+Scan /Table/134/1/"original"/0 lock Exclusive (Block, Unreplicated)
 Del /Table/134/1/"original"/0
 CPut /Table/134/1/"updated"/0 -> /TUPLE/
 executing cascade for constraint b1_update_cascade_fkey
+Scan /Table/135/2/"original"/0
 Del /Table/135/2/"original"/0
 CPut /Table/135/2/"updated"/0 -> /BYTES/0x1262312d706b310001
 executing cascade for constraint b2_update_cascade_fkey
+Scan /Table/136/2/"original"/0
 Del /Table/136/2/"original"/0
 CPut /Table/136/2/"updated"/0 -> /BYTES/0x1262322d706b310001
 executing cascade for constraint c1_update_set_null_fkey
@@ -523,8 +532,9 @@ SET tracing = on,kv,results; DELETE FROM a WHERE id = 'delete_me'; SET tracing =
 
 query T
 SELECT message FROM [SHOW TRACE FOR SESSION]
-WHERE message LIKE '%executing cascade %' OR message LIKE 'Del%'
+WHERE message LIKE '%executing cascade %' OR message LIKE 'Del%' OR message LIKE 'Scan%delete_me%'
 ----
+Scan /Table/140/1/"delete_me"/0 lock Exclusive (Block, Unreplicated)
 Del /Table/140/1/"delete_me"/0
 executing cascade for constraint b1_delete_set_default_fkey
 executing cascade for constraint b2_delete_set_default_fkey
@@ -664,8 +674,9 @@ SET tracing = on,kv,results; UPDATE a SET id = 'updated' WHERE id = 'original'; 
 
 query T
 SELECT message FROM [SHOW TRACE FOR SESSION]
-WHERE message LIKE '%executing cascade %' OR message LIKE 'Del%' OR message LIKE 'CPut%'
+WHERE message LIKE '%executing cascade %' OR message LIKE 'Del%' OR message LIKE 'CPut%' OR message LIKE 'Scan%original%'
 ----
+Scan /Table/151/1/"original"/0 lock Exclusive (Block, Unreplicated)
 Del /Table/151/1/"original"/0
 CPut /Table/151/1/"updated"/0 -> /TUPLE/
 executing cascade for constraint b1_update_set_null_fkey
@@ -745,14 +756,17 @@ SET tracing = on,kv,results; UPDATE a SET id = 'updated' WHERE id = 'original'; 
 
 query T
 SELECT message FROM [SHOW TRACE FOR SESSION]
-WHERE message LIKE '%executing cascade %' OR message LIKE 'Del%' OR message LIKE 'CPut%'
+WHERE message LIKE '%executing cascade %' OR message LIKE 'Del%' OR message LIKE 'CPut%' OR message LIKE 'Scan%original%'
 ----
+Scan /Table/156/1/"original"/0 lock Exclusive (Block, Unreplicated)
 Del /Table/156/1/"original"/0
 CPut /Table/156/1/"updated"/0 -> /TUPLE/
 executing cascade for constraint b1_update_cascade_fkey
+Scan /Table/157/2/"original"/0
 Del /Table/157/2/"original"/0
 CPut /Table/157/2/"updated"/0 -> /BYTES/0x1262312d706b310001
 executing cascade for constraint b2_update_cascade_fkey
+Scan /Table/158/2/"original"/0
 Del /Table/158/2/"original"/0
 CPut /Table/158/2/"updated"/0 -> /BYTES/0x1262322d706b310001
 executing cascade for constraint c1_update_set_null_fkey
@@ -787,12 +801,15 @@ INSERT INTO child2 VALUES (1, 1), (2, 1)
 # Here we ensure that after the cascaded deletes we don't need
 # to perform additional and unneeded Scan operations after
 # cascade deleting or setting null to referencing rows.
-query T kvtrace(Del)
+query T kvtrace(Del,Scan)
 DELETE FROM parent WHERE x = 1
 ----
+Scan /Table/162/1/1/0 lock Exclusive (Block, Unreplicated)
 Del /Table/162/1/1/0
+Scan /Table/163/{1-2}
 Del /Table/163/1/1/0
 Del /Table/163/1/2/0
+Scan /Table/164/{1-2}
 
 subtest DelRange
 

--- a/pkg/sql/opt/exec/execbuilder/testdata/cascade
+++ b/pkg/sql/opt/exec/execbuilder/testdata/cascade
@@ -242,7 +242,7 @@ SELECT message FROM [SHOW TRACE FOR SESSION]
 WHERE message LIKE '%executing cascade %' OR message LIKE 'Del%' OR message LIKE 'Scan%delete_me%'
 ----
 Scan /Table/118/1/"delete_me"/0 lock Exclusive (Block, Unreplicated)
-Del (locking) /Table/118/1/"delete_me"/0
+Del /Table/118/1/"delete_me"/0
 executing cascade for constraint b1_delete_set_null_fkey
 executing cascade for constraint b2_delete_set_null_fkey
 executing cascade for constraint b3_delete_set_null_fkey
@@ -535,7 +535,7 @@ SELECT message FROM [SHOW TRACE FOR SESSION]
 WHERE message LIKE '%executing cascade %' OR message LIKE 'Del%' OR message LIKE 'Scan%delete_me%'
 ----
 Scan /Table/140/1/"delete_me"/0 lock Exclusive (Block, Unreplicated)
-Del (locking) /Table/140/1/"delete_me"/0
+Del /Table/140/1/"delete_me"/0
 executing cascade for constraint b1_delete_set_default_fkey
 executing cascade for constraint b2_delete_set_default_fkey
 executing cascade for constraint b3_delete_set_default_fkey
@@ -805,7 +805,7 @@ query T kvtrace(Del,Scan)
 DELETE FROM parent WHERE x = 1
 ----
 Scan /Table/162/1/1/0 lock Exclusive (Block, Unreplicated)
-Del (locking) /Table/162/1/1/0
+Del /Table/162/1/1/0
 Scan /Table/163/{1-2}
 Del (locking) /Table/163/1/1/0
 Del (locking) /Table/163/1/2/0

--- a/pkg/sql/opt/exec/execbuilder/testdata/delete
+++ b/pkg/sql/opt/exec/execbuilder/testdata/delete
@@ -525,9 +525,9 @@ query T kvtrace
 EXECUTE p(1)
 ----
 Scan /Table/114/1/1/0 lock Exclusive (Block, Unreplicated)
-Del /Table/114/2/10/1/0
-Del /Table/114/3/100/1/0
-Del /Table/114/1/1/0
+Del (locking) /Table/114/2/10/1/0
+Del (locking) /Table/114/3/100/1/0
+Del (locking) /Table/114/1/1/0
 
 statement ok
 DEALLOCATE p
@@ -601,9 +601,9 @@ EXECUTE p(10)
 ----
 Scan /Table/114/2/1{0-1} lock Exclusive (Block, Unreplicated)
 Scan /Table/114/1/1/0 lock Exclusive (Block, Unreplicated)
-Del /Table/114/2/10/1/0
-Del /Table/114/3/100/1/0
-Del /Table/114/1/1/0
+Del (locking) /Table/114/2/10/1/0
+Del (locking) /Table/114/3/100/1/0
+Del (locking) /Table/114/1/1/0
 
 statement ok
 CREATE TABLE t139160 (
@@ -640,9 +640,9 @@ query T kvtrace
 DELETE FROM t139160 WHERE k = 1
 ----
 Scan /Table/115/1/1/0 lock Exclusive (Block, Unreplicated)
-Del /Table/115/2/2/1/0
-Del /Table/115/3/3/0
-Del /Table/115/1/1/0
+Del (locking) /Table/115/2/2/1/0
+Del (locking) /Table/115/3/3/0
+Del (locking) /Table/115/1/1/0
 
 # Only non-unique secondary index is scanned and locked.
 statement ok
@@ -668,9 +668,9 @@ query T kvtrace
 DELETE FROM t139160 WHERE i = 2
 ----
 Scan /Table/115/2/{2-3} lock Exclusive (Block, Unreplicated)
-Del /Table/115/2/2/1/0
-Del /Table/115/3/3/0
-Del /Table/115/1/1/0
+Del (locking) /Table/115/2/2/1/0
+Del (locking) /Table/115/3/3/0
+Del (locking) /Table/115/1/1/0
 
 statement ok
 INSERT INTO t139160 VALUES (1, 2, 3, 4);
@@ -701,9 +701,9 @@ DELETE FROM t139160 WHERE i = 2 RETURNING v
 ----
 Scan /Table/115/2/{2-3} lock Exclusive (Block, Unreplicated)
 Scan /Table/115/1/1/0 lock Exclusive (Block, Unreplicated)
-Del /Table/115/2/2/1/0
-Del /Table/115/3/3/0
-Del /Table/115/1/1/0
+Del (locking) /Table/115/2/2/1/0
+Del (locking) /Table/115/3/3/0
+Del (locking) /Table/115/1/1/0
 
 # Only unique secondary index is scanned and locked.
 statement ok
@@ -729,9 +729,9 @@ query T kvtrace
 DELETE FROM t139160 WHERE u = 3
 ----
 Scan /Table/115/3/3/0 lock Exclusive (Block, Unreplicated)
-Del /Table/115/2/2/1/0
-Del /Table/115/3/3/0
-Del /Table/115/1/1/0
+Del (locking) /Table/115/2/2/1/0
+Del (locking) /Table/115/3/3/0
+Del (locking) /Table/115/1/1/0
 
 statement ok
 INSERT INTO t139160 VALUES (1, 2, 3, 4);
@@ -762,9 +762,9 @@ DELETE FROM t139160 WHERE u = 3 RETURNING v
 ----
 Scan /Table/115/3/3/0 lock Exclusive (Block, Unreplicated)
 Scan /Table/115/1/1/0 lock Exclusive (Block, Unreplicated)
-Del /Table/115/2/2/1/0
-Del /Table/115/3/3/0
-Del /Table/115/1/1/0
+Del (locking) /Table/115/2/2/1/0
+Del (locking) /Table/115/3/3/0
+Del (locking) /Table/115/1/1/0
 
 statement ok
 INSERT INTO t139160 VALUES (1, 2, 3, 4);
@@ -792,6 +792,6 @@ query T kvtrace
 DELETE FROM t139160 WHERE v = 4
 ----
 Scan /Table/115/{1-2}
-Del /Table/115/2/2/1/0
-Del /Table/115/3/3/0
-Del /Table/115/1/1/0
+Del (locking) /Table/115/2/2/1/0
+Del (locking) /Table/115/3/3/0
+Del (locking) /Table/115/1/1/0

--- a/pkg/sql/opt/exec/execbuilder/testdata/delete
+++ b/pkg/sql/opt/exec/execbuilder/testdata/delete
@@ -464,7 +464,8 @@ CREATE TABLE t137352 (
   a INT,
   b INT,
   INDEX (a),
-  INDEX (b)
+  INDEX (b),
+  FAMILY (k, a, b)
 )
 
 statement ok
@@ -516,6 +517,17 @@ quality of service: regular
           regions: <hidden>
           actual row count: 1
           size: 1 column, 1 row
+
+statement ok
+INSERT INTO t137352 VALUES (1, 10, 100);
+
+query T kvtrace
+EXECUTE p(1)
+----
+Scan /Table/114/1/1/0 lock Exclusive (Block, Unreplicated)
+Del /Table/114/2/10/1/0
+Del /Table/114/3/100/1/0
+Del /Table/114/1/1/0
 
 statement ok
 DEALLOCATE p
@@ -580,3 +592,206 @@ quality of service: regular
               regions: <hidden>
               actual row count: 1
               size: 1 column, 1 row
+
+statement ok
+INSERT INTO t137352 VALUES (1, 10, 100);
+
+query T kvtrace
+EXECUTE p(10)
+----
+Scan /Table/114/2/1{0-1} lock Exclusive (Block, Unreplicated)
+Scan /Table/114/1/1/0 lock Exclusive (Block, Unreplicated)
+Del /Table/114/2/10/1/0
+Del /Table/114/3/100/1/0
+Del /Table/114/1/1/0
+
+statement ok
+CREATE TABLE t139160 (
+  k INT PRIMARY KEY,
+  i INT,
+  u INT,
+  v INT,
+  INDEX (i) STORING (u),
+  UNIQUE INDEX (u) STORING (i),
+  FAMILY (k, i, u, v)
+);
+
+statement ok
+INSERT INTO t139160 VALUES (1, 2, 3, 4);
+
+# The PK is scanned and locked.
+query T
+EXPLAIN DELETE FROM t139160 WHERE k = 1
+----
+distribution: local
+vectorized: true
+·
+• delete
+│ from: t139160
+│ auto commit
+│
+└── • scan
+      missing stats
+      table: t139160@t139160_pkey
+      spans: [/1 - /1]
+      locking strength: for update
+
+query T kvtrace
+DELETE FROM t139160 WHERE k = 1
+----
+Scan /Table/115/1/1/0 lock Exclusive (Block, Unreplicated)
+Del /Table/115/2/2/1/0
+Del /Table/115/3/3/0
+Del /Table/115/1/1/0
+
+# Only non-unique secondary index is scanned and locked.
+statement ok
+INSERT INTO t139160 VALUES (1, 2, 3, 4);
+
+query T
+EXPLAIN DELETE FROM t139160 WHERE i = 2
+----
+distribution: local
+vectorized: true
+·
+• delete
+│ from: t139160
+│ auto commit
+│
+└── • scan
+      missing stats
+      table: t139160@t139160_i_idx
+      spans: [/2 - /2]
+      locking strength: for update
+
+query T kvtrace
+DELETE FROM t139160 WHERE i = 2
+----
+Scan /Table/115/2/{2-3} lock Exclusive (Block, Unreplicated)
+Del /Table/115/2/2/1/0
+Del /Table/115/3/3/0
+Del /Table/115/1/1/0
+
+statement ok
+INSERT INTO t139160 VALUES (1, 2, 3, 4);
+
+# Both primary and non-unique secondary indexes are scanned and locked.
+query T
+EXPLAIN DELETE FROM t139160 WHERE i = 2 RETURNING v
+----
+distribution: local
+vectorized: true
+·
+• delete
+│ from: t139160
+│ auto commit
+│
+└── • index join
+    │ table: t139160@t139160_pkey
+    │ locking strength: for update
+    │
+    └── • scan
+          missing stats
+          table: t139160@t139160_i_idx
+          spans: [/2 - /2]
+          locking strength: for update
+
+query T kvtrace
+DELETE FROM t139160 WHERE i = 2 RETURNING v
+----
+Scan /Table/115/2/{2-3} lock Exclusive (Block, Unreplicated)
+Scan /Table/115/1/1/0 lock Exclusive (Block, Unreplicated)
+Del /Table/115/2/2/1/0
+Del /Table/115/3/3/0
+Del /Table/115/1/1/0
+
+# Only unique secondary index is scanned and locked.
+statement ok
+INSERT INTO t139160 VALUES (1, 2, 3, 4);
+
+query T
+EXPLAIN DELETE FROM t139160 WHERE u = 3
+----
+distribution: local
+vectorized: true
+·
+• delete
+│ from: t139160
+│ auto commit
+│
+└── • scan
+      missing stats
+      table: t139160@t139160_u_key
+      spans: [/3 - /3]
+      locking strength: for update
+
+query T kvtrace
+DELETE FROM t139160 WHERE u = 3
+----
+Scan /Table/115/3/3/0 lock Exclusive (Block, Unreplicated)
+Del /Table/115/2/2/1/0
+Del /Table/115/3/3/0
+Del /Table/115/1/1/0
+
+statement ok
+INSERT INTO t139160 VALUES (1, 2, 3, 4);
+
+# Both primary and unique secondary indexes are scanned and locked.
+query T
+EXPLAIN DELETE FROM t139160 WHERE u = 3 RETURNING v
+----
+distribution: local
+vectorized: true
+·
+• delete
+│ from: t139160
+│ auto commit
+│
+└── • index join
+    │ table: t139160@t139160_pkey
+    │ locking strength: for update
+    │
+    └── • scan
+          missing stats
+          table: t139160@t139160_u_key
+          spans: [/3 - /3]
+          locking strength: for update
+
+query T kvtrace
+DELETE FROM t139160 WHERE u = 3 RETURNING v
+----
+Scan /Table/115/3/3/0 lock Exclusive (Block, Unreplicated)
+Scan /Table/115/1/1/0 lock Exclusive (Block, Unreplicated)
+Del /Table/115/2/2/1/0
+Del /Table/115/3/3/0
+Del /Table/115/1/1/0
+
+statement ok
+INSERT INTO t139160 VALUES (1, 2, 3, 4);
+
+# The filter is not pushed down into the scan, so no index is locked.
+query T
+EXPLAIN DELETE FROM t139160 WHERE v = 4
+----
+distribution: local
+vectorized: true
+·
+• delete
+│ from: t139160
+│ auto commit
+│
+└── • filter
+    │ filter: v = 4
+    │
+    └── • scan
+          missing stats
+          table: t139160@t139160_pkey
+          spans: FULL SCAN
+
+query T kvtrace
+DELETE FROM t139160 WHERE v = 4
+----
+Scan /Table/115/{1-2}
+Del /Table/115/2/2/1/0
+Del /Table/115/3/3/0
+Del /Table/115/1/1/0

--- a/pkg/sql/opt/exec/execbuilder/testdata/delete
+++ b/pkg/sql/opt/exec/execbuilder/testdata/delete
@@ -525,8 +525,8 @@ query T kvtrace
 EXECUTE p(1)
 ----
 Scan /Table/114/1/1/0 lock Exclusive (Block, Unreplicated)
-Del (locking) /Table/114/2/10/1/0
-Del (locking) /Table/114/3/100/1/0
+Del /Table/114/2/10/1/0
+Del /Table/114/3/100/1/0
 Del /Table/114/1/1/0
 
 statement ok
@@ -602,7 +602,7 @@ EXECUTE p(10)
 Scan /Table/114/2/1{0-1} lock Exclusive (Block, Unreplicated)
 Scan /Table/114/1/1/0 lock Exclusive (Block, Unreplicated)
 Del /Table/114/2/10/1/0
-Del (locking) /Table/114/3/100/1/0
+Del /Table/114/3/100/1/0
 Del /Table/114/1/1/0
 
 statement ok
@@ -640,7 +640,7 @@ query T kvtrace
 DELETE FROM t139160 WHERE k = 1
 ----
 Scan /Table/115/1/1/0 lock Exclusive (Block, Unreplicated)
-Del (locking) /Table/115/2/2/1/0
+Del /Table/115/2/2/1/0
 Del (locking) /Table/115/3/3/0
 Del /Table/115/1/1/0
 
@@ -729,7 +729,7 @@ query T kvtrace
 DELETE FROM t139160 WHERE u = 3
 ----
 Scan /Table/115/3/3/0 lock Exclusive (Block, Unreplicated)
-Del (locking) /Table/115/2/2/1/0
+Del /Table/115/2/2/1/0
 Del /Table/115/3/3/0
 Del (locking) /Table/115/1/1/0
 
@@ -762,7 +762,7 @@ DELETE FROM t139160 WHERE u = 3 RETURNING v
 ----
 Scan /Table/115/3/3/0 lock Exclusive (Block, Unreplicated)
 Scan /Table/115/1/1/0 lock Exclusive (Block, Unreplicated)
-Del (locking) /Table/115/2/2/1/0
+Del /Table/115/2/2/1/0
 Del /Table/115/3/3/0
 Del /Table/115/1/1/0
 
@@ -792,6 +792,6 @@ query T kvtrace
 DELETE FROM t139160 WHERE v = 4
 ----
 Scan /Table/115/{1-2}
-Del (locking) /Table/115/2/2/1/0
+Del /Table/115/2/2/1/0
 Del (locking) /Table/115/3/3/0
 Del (locking) /Table/115/1/1/0

--- a/pkg/sql/opt/exec/execbuilder/testdata/delete
+++ b/pkg/sql/opt/exec/execbuilder/testdata/delete
@@ -527,7 +527,7 @@ EXECUTE p(1)
 Scan /Table/114/1/1/0 lock Exclusive (Block, Unreplicated)
 Del (locking) /Table/114/2/10/1/0
 Del (locking) /Table/114/3/100/1/0
-Del (locking) /Table/114/1/1/0
+Del /Table/114/1/1/0
 
 statement ok
 DEALLOCATE p
@@ -601,9 +601,9 @@ EXECUTE p(10)
 ----
 Scan /Table/114/2/1{0-1} lock Exclusive (Block, Unreplicated)
 Scan /Table/114/1/1/0 lock Exclusive (Block, Unreplicated)
-Del (locking) /Table/114/2/10/1/0
+Del /Table/114/2/10/1/0
 Del (locking) /Table/114/3/100/1/0
-Del (locking) /Table/114/1/1/0
+Del /Table/114/1/1/0
 
 statement ok
 CREATE TABLE t139160 (
@@ -642,7 +642,7 @@ DELETE FROM t139160 WHERE k = 1
 Scan /Table/115/1/1/0 lock Exclusive (Block, Unreplicated)
 Del (locking) /Table/115/2/2/1/0
 Del (locking) /Table/115/3/3/0
-Del (locking) /Table/115/1/1/0
+Del /Table/115/1/1/0
 
 # Only non-unique secondary index is scanned and locked.
 statement ok
@@ -668,7 +668,7 @@ query T kvtrace
 DELETE FROM t139160 WHERE i = 2
 ----
 Scan /Table/115/2/{2-3} lock Exclusive (Block, Unreplicated)
-Del (locking) /Table/115/2/2/1/0
+Del /Table/115/2/2/1/0
 Del (locking) /Table/115/3/3/0
 Del (locking) /Table/115/1/1/0
 
@@ -701,9 +701,9 @@ DELETE FROM t139160 WHERE i = 2 RETURNING v
 ----
 Scan /Table/115/2/{2-3} lock Exclusive (Block, Unreplicated)
 Scan /Table/115/1/1/0 lock Exclusive (Block, Unreplicated)
-Del (locking) /Table/115/2/2/1/0
+Del /Table/115/2/2/1/0
 Del (locking) /Table/115/3/3/0
-Del (locking) /Table/115/1/1/0
+Del /Table/115/1/1/0
 
 # Only unique secondary index is scanned and locked.
 statement ok
@@ -730,7 +730,7 @@ DELETE FROM t139160 WHERE u = 3
 ----
 Scan /Table/115/3/3/0 lock Exclusive (Block, Unreplicated)
 Del (locking) /Table/115/2/2/1/0
-Del (locking) /Table/115/3/3/0
+Del /Table/115/3/3/0
 Del (locking) /Table/115/1/1/0
 
 statement ok
@@ -763,8 +763,8 @@ DELETE FROM t139160 WHERE u = 3 RETURNING v
 Scan /Table/115/3/3/0 lock Exclusive (Block, Unreplicated)
 Scan /Table/115/1/1/0 lock Exclusive (Block, Unreplicated)
 Del (locking) /Table/115/2/2/1/0
-Del (locking) /Table/115/3/3/0
-Del (locking) /Table/115/1/1/0
+Del /Table/115/3/3/0
+Del /Table/115/1/1/0
 
 statement ok
 INSERT INTO t139160 VALUES (1, 2, 3, 4);

--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
@@ -52,7 +52,7 @@ DELETE FROM d WHERE a=1
 Scan /Table/106/1/1/0 lock Exclusive (Block, Unreplicated)
 Del (locking) /Table/106/2/Arr/0/1/0
 Del (locking) /Table/106/2/Arr/7/1/0
-Del (locking) /Table/106/1/1/0
+Del /Table/106/1/1/0
 
 query T kvtrace
 INSERT INTO d VALUES(2, '[{"a": "b"}, 3, {"a": "b"}]')
@@ -97,7 +97,7 @@ query T kvtrace
 DELETE FROM d WHERE a=4
 ----
 Scan /Table/106/1/4/0 lock Exclusive (Block, Unreplicated)
-Del (locking) /Table/106/1/4/0
+Del /Table/106/1/4/0
 
 # Tests for array inverted indexes.
 

--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
@@ -50,9 +50,9 @@ query T kvtrace
 DELETE FROM d WHERE a=1
 ----
 Scan /Table/106/1/1/0 lock Exclusive (Block, Unreplicated)
-Del /Table/106/2/Arr/0/1/0
-Del /Table/106/2/Arr/7/1/0
-Del /Table/106/1/1/0
+Del (locking) /Table/106/2/Arr/0/1/0
+Del (locking) /Table/106/2/Arr/7/1/0
+Del (locking) /Table/106/1/1/0
 
 query T kvtrace
 INSERT INTO d VALUES(2, '[{"a": "b"}, 3, {"a": "b"}]')
@@ -90,14 +90,14 @@ UPDATE d SET b=NULL WHERE a=4
 ----
 Scan /Table/106/1/4/0 lock Exclusive (Block, Unreplicated)
 Put /Table/106/1/4/0 -> /TUPLE/
-Del /Table/106/2/Arr/1/4/0
+Del (locking) /Table/106/2/Arr/1/4/0
 
 # Deleting a null shouldn't remove anything from the inv idx.
 query T kvtrace
 DELETE FROM d WHERE a=4
 ----
 Scan /Table/106/1/4/0 lock Exclusive (Block, Unreplicated)
-Del /Table/106/1/4/0
+Del (locking) /Table/106/1/4/0
 
 # Tests for array inverted indexes.
 
@@ -226,7 +226,7 @@ UPDATE f SET b = ARRAY[0,15,7,10] WHERE a = 0
 ----
 Scan /Table/108/1/0/0 lock Exclusive (Block, Unreplicated)
 Put /Table/108/1/0/0 -> /TUPLE/2:2:Array/ARRAY[0,15,7,10]
-Del /Table/108/2/1/0/0
+Del (locking) /Table/108/2/1/0/0
 CPut /Table/108/2/15/0/0 -> /BYTES/
 
 statement error pgcode XXUUU could not produce a query plan conforming to the FORCE_INVERTED_INDEX hint

--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
@@ -50,8 +50,8 @@ query T kvtrace
 DELETE FROM d WHERE a=1
 ----
 Scan /Table/106/1/1/0 lock Exclusive (Block, Unreplicated)
-Del (locking) /Table/106/2/Arr/0/1/0
-Del (locking) /Table/106/2/Arr/7/1/0
+Del /Table/106/2/Arr/0/1/0
+Del /Table/106/2/Arr/7/1/0
 Del /Table/106/1/1/0
 
 query T kvtrace

--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_index_multi_column
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_index_multi_column
@@ -66,20 +66,20 @@ query T kvtrace
 DELETE FROM t WHERE k = 2
 ----
 Scan /Table/106/1/2/0 lock Exclusive (Block, Unreplicated)
-Del (locking) /Table/106/2/333/Arr/0/2/0
-Del (locking) /Table/106/2/333/Arr/7/2/0
-Del (locking) /Table/106/3/333/"foo"/Arr/0/2/0
-Del (locking) /Table/106/3/333/"foo"/Arr/7/2/0
+Del /Table/106/2/333/Arr/0/2/0
+Del /Table/106/2/333/Arr/7/2/0
+Del /Table/106/3/333/"foo"/Arr/0/2/0
+Del /Table/106/3/333/"foo"/Arr/7/2/0
 Del /Table/106/1/2/0
 
 query T kvtrace
 DELETE FROM t WHERE k = 3
 ----
 Scan /Table/106/1/3/0 lock Exclusive (Block, Unreplicated)
-Del (locking) /Table/106/2/333/Arr/3/3/0
-Del (locking) /Table/106/2/333/Arr/"a"/"b"/3/0
-Del (locking) /Table/106/3/333/"foo"/Arr/3/3/0
-Del (locking) /Table/106/3/333/"foo"/Arr/"a"/"b"/3/0
+Del /Table/106/2/333/Arr/3/3/0
+Del /Table/106/2/333/Arr/"a"/"b"/3/0
+Del /Table/106/3/333/"foo"/Arr/3/3/0
+Del /Table/106/3/333/"foo"/Arr/"a"/"b"/3/0
 Del /Table/106/1/3/0
 
 # Don't insert NULL values in the inverted column.
@@ -148,6 +148,6 @@ query T kvtrace
 DELETE FROM t WHERE k = 5
 ----
 Scan /Table/106/1/5/0 lock Exclusive (Block, Unreplicated)
-Del (locking) /Table/106/2/NULL/"a"/"b"/5/0
-Del (locking) /Table/106/3/NULL/"foo"/"a"/"b"/5/0
+Del /Table/106/2/NULL/"a"/"b"/5/0
+Del /Table/106/3/NULL/"foo"/"a"/"b"/5/0
 Del /Table/106/1/5/0

--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_index_multi_column
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_index_multi_column
@@ -66,21 +66,21 @@ query T kvtrace
 DELETE FROM t WHERE k = 2
 ----
 Scan /Table/106/1/2/0 lock Exclusive (Block, Unreplicated)
-Del /Table/106/2/333/Arr/0/2/0
-Del /Table/106/2/333/Arr/7/2/0
-Del /Table/106/3/333/"foo"/Arr/0/2/0
-Del /Table/106/3/333/"foo"/Arr/7/2/0
-Del /Table/106/1/2/0
+Del (locking) /Table/106/2/333/Arr/0/2/0
+Del (locking) /Table/106/2/333/Arr/7/2/0
+Del (locking) /Table/106/3/333/"foo"/Arr/0/2/0
+Del (locking) /Table/106/3/333/"foo"/Arr/7/2/0
+Del (locking) /Table/106/1/2/0
 
 query T kvtrace
 DELETE FROM t WHERE k = 3
 ----
 Scan /Table/106/1/3/0 lock Exclusive (Block, Unreplicated)
-Del /Table/106/2/333/Arr/3/3/0
-Del /Table/106/2/333/Arr/"a"/"b"/3/0
-Del /Table/106/3/333/"foo"/Arr/3/3/0
-Del /Table/106/3/333/"foo"/Arr/"a"/"b"/3/0
-Del /Table/106/1/3/0
+Del (locking) /Table/106/2/333/Arr/3/3/0
+Del (locking) /Table/106/2/333/Arr/"a"/"b"/3/0
+Del (locking) /Table/106/3/333/"foo"/Arr/3/3/0
+Del (locking) /Table/106/3/333/"foo"/Arr/"a"/"b"/3/0
+Del (locking) /Table/106/1/3/0
 
 # Don't insert NULL values in the inverted column.
 query T kvtrace
@@ -103,15 +103,15 @@ UPDATE t SET j = NULL WHERE k = 4
 ----
 Scan /Table/106/1/4/0 lock Exclusive (Block, Unreplicated)
 Put /Table/106/1/4/0 -> /TUPLE/2:2:Int/333/1:3:Bytes/foo
-Del /Table/106/2/333/Arr/1/4/0
-Del /Table/106/3/333/"foo"/Arr/1/4/0
+Del (locking) /Table/106/2/333/Arr/1/4/0
+Del (locking) /Table/106/3/333/"foo"/Arr/1/4/0
 
 # Deleting a NULL shouldn't remove anything from the inv idx.
 query T kvtrace
 DELETE FROM t WHERE k = 4
 ----
 Scan /Table/106/1/4/0 lock Exclusive (Block, Unreplicated)
-Del /Table/106/1/4/0
+Del (locking) /Table/106/1/4/0
 
 # Insert NULL non-inverted value.
 query T kvtrace
@@ -127,9 +127,9 @@ UPDATE t SET i = 333 WHERE k = 5
 ----
 Scan /Table/106/1/5/0 lock Exclusive (Block, Unreplicated)
 Put /Table/106/1/5/0 -> /TUPLE/2:2:Int/333/1:3:Bytes/foo/1:4:SentinelType/{"a": "b"}
-Del /Table/106/2/NULL/"a"/"b"/5/0
+Del (locking) /Table/106/2/NULL/"a"/"b"/5/0
 CPut /Table/106/2/333/"a"/"b"/5/0 -> /BYTES/
-Del /Table/106/3/NULL/"foo"/"a"/"b"/5/0
+Del (locking) /Table/106/3/NULL/"foo"/"a"/"b"/5/0
 CPut /Table/106/3/333/"foo"/"a"/"b"/5/0 -> /BYTES/
 
 # Update back to NULL.
@@ -138,9 +138,9 @@ UPDATE t SET i = NULL WHERE k = 5
 ----
 Scan /Table/106/1/5/0 lock Exclusive (Block, Unreplicated)
 Put /Table/106/1/5/0 -> /TUPLE/3:3:Bytes/foo/1:4:SentinelType/{"a": "b"}
-Del /Table/106/2/333/"a"/"b"/5/0
+Del (locking) /Table/106/2/333/"a"/"b"/5/0
 CPut /Table/106/2/NULL/"a"/"b"/5/0 -> /BYTES/
-Del /Table/106/3/333/"foo"/"a"/"b"/5/0
+Del (locking) /Table/106/3/333/"foo"/"a"/"b"/5/0
 CPut /Table/106/3/NULL/"foo"/"a"/"b"/5/0 -> /BYTES/
 
 # Delete row with NULL non-inverted row.
@@ -148,6 +148,6 @@ query T kvtrace
 DELETE FROM t WHERE k = 5
 ----
 Scan /Table/106/1/5/0 lock Exclusive (Block, Unreplicated)
-Del /Table/106/2/NULL/"a"/"b"/5/0
-Del /Table/106/3/NULL/"foo"/"a"/"b"/5/0
-Del /Table/106/1/5/0
+Del (locking) /Table/106/2/NULL/"a"/"b"/5/0
+Del (locking) /Table/106/3/NULL/"foo"/"a"/"b"/5/0
+Del (locking) /Table/106/1/5/0

--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_index_multi_column
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_index_multi_column
@@ -70,7 +70,7 @@ Del (locking) /Table/106/2/333/Arr/0/2/0
 Del (locking) /Table/106/2/333/Arr/7/2/0
 Del (locking) /Table/106/3/333/"foo"/Arr/0/2/0
 Del (locking) /Table/106/3/333/"foo"/Arr/7/2/0
-Del (locking) /Table/106/1/2/0
+Del /Table/106/1/2/0
 
 query T kvtrace
 DELETE FROM t WHERE k = 3
@@ -80,7 +80,7 @@ Del (locking) /Table/106/2/333/Arr/3/3/0
 Del (locking) /Table/106/2/333/Arr/"a"/"b"/3/0
 Del (locking) /Table/106/3/333/"foo"/Arr/3/3/0
 Del (locking) /Table/106/3/333/"foo"/Arr/"a"/"b"/3/0
-Del (locking) /Table/106/1/3/0
+Del /Table/106/1/3/0
 
 # Don't insert NULL values in the inverted column.
 query T kvtrace
@@ -111,7 +111,7 @@ query T kvtrace
 DELETE FROM t WHERE k = 4
 ----
 Scan /Table/106/1/4/0 lock Exclusive (Block, Unreplicated)
-Del (locking) /Table/106/1/4/0
+Del /Table/106/1/4/0
 
 # Insert NULL non-inverted value.
 query T kvtrace
@@ -150,4 +150,4 @@ DELETE FROM t WHERE k = 5
 Scan /Table/106/1/5/0 lock Exclusive (Block, Unreplicated)
 Del (locking) /Table/106/2/NULL/"a"/"b"/5/0
 Del (locking) /Table/106/3/NULL/"foo"/"a"/"b"/5/0
-Del (locking) /Table/106/1/5/0
+Del /Table/106/1/5/0

--- a/pkg/sql/opt/exec/execbuilder/testdata/partial_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/partial_index
@@ -267,7 +267,7 @@ DELETE FROM t WHERE a = 5
 ----
 Scan /Table/112/1/5/0 lock Exclusive (Block, Unreplicated)
 Del (locking) /Table/112/2/4/5/0
-Del (locking) /Table/112/1/5/0
+Del /Table/112/1/5/0
 
 # Deleted row matches the first partial index.
 query T kvtrace
@@ -276,7 +276,7 @@ DELETE FROM t WHERE a = 6
 Scan /Table/112/1/6/0 lock Exclusive (Block, Unreplicated)
 Del (locking) /Table/112/2/11/6/0
 Del (locking) /Table/112/3/11/6/0
-Del (locking) /Table/112/1/6/0
+Del /Table/112/1/6/0
 
 # Deleted row matches both partial indexes.
 query T kvtrace
@@ -286,7 +286,7 @@ Scan /Table/112/1/12/0 lock Exclusive (Block, Unreplicated)
 Del (locking) /Table/112/2/11/12/0
 Del (locking) /Table/112/3/11/12/0
 Del (locking) /Table/112/4/"foo"/12/0
-Del (locking) /Table/112/1/12/0
+Del /Table/112/1/12/0
 
 # Deleted row does not match partial index with predicate column that is not
 # indexed.
@@ -294,7 +294,7 @@ query T kvtrace
 DELETE FROM u WHERE k = 1
 ----
 Scan /Table/113/1/1/0 lock Exclusive (Block, Unreplicated)
-Del (locking) /Table/113/1/1/0
+Del /Table/113/1/1/0
 
 # Deleted row matches partial index with predicate column that is not
 # indexed.
@@ -303,7 +303,7 @@ DELETE FROM u WHERE k = 2
 ----
 Scan /Table/113/1/2/0 lock Exclusive (Block, Unreplicated)
 Del (locking) /Table/113/2/3/2/0
-Del (locking) /Table/113/1/2/0
+Del /Table/113/1/2/0
 
 # ---------------------------------------------------------
 # UPDATE
@@ -893,13 +893,13 @@ DELETE FROM inv WHERE a = 1
 Scan /Table/107/1/1/0 lock Exclusive (Block, Unreplicated)
 Del (locking) /Table/107/2/"num"/1/1/0
 Del (locking) /Table/107/2/"x"/"y"/1/0
-Del (locking) /Table/107/1/1/0
+Del /Table/107/1/1/0
 
 query T kvtrace
 DELETE FROM inv WHERE a = 2
 ----
 Scan /Table/107/1/2/0 lock Exclusive (Block, Unreplicated)
-Del (locking) /Table/107/1/2/0
+Del /Table/107/1/2/0
 
 # ---------------------------------------------------------
 # UPDATE partial inverted index

--- a/pkg/sql/opt/exec/execbuilder/testdata/partial_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/partial_index
@@ -266,7 +266,7 @@ query T kvtrace
 DELETE FROM t WHERE a = 5
 ----
 Scan /Table/112/1/5/0 lock Exclusive (Block, Unreplicated)
-Del (locking) /Table/112/2/4/5/0
+Del /Table/112/2/4/5/0
 Del /Table/112/1/5/0
 
 # Deleted row matches the first partial index.
@@ -274,8 +274,8 @@ query T kvtrace
 DELETE FROM t WHERE a = 6
 ----
 Scan /Table/112/1/6/0 lock Exclusive (Block, Unreplicated)
-Del (locking) /Table/112/2/11/6/0
-Del (locking) /Table/112/3/11/6/0
+Del /Table/112/2/11/6/0
+Del /Table/112/3/11/6/0
 Del /Table/112/1/6/0
 
 # Deleted row matches both partial indexes.
@@ -283,9 +283,9 @@ query T kvtrace
 DELETE FROM t WHERE a = 12
 ----
 Scan /Table/112/1/12/0 lock Exclusive (Block, Unreplicated)
-Del (locking) /Table/112/2/11/12/0
-Del (locking) /Table/112/3/11/12/0
-Del (locking) /Table/112/4/"foo"/12/0
+Del /Table/112/2/11/12/0
+Del /Table/112/3/11/12/0
+Del /Table/112/4/"foo"/12/0
 Del /Table/112/1/12/0
 
 # Deleted row does not match partial index with predicate column that is not
@@ -302,7 +302,7 @@ query T kvtrace
 DELETE FROM u WHERE k = 2
 ----
 Scan /Table/113/1/2/0 lock Exclusive (Block, Unreplicated)
-Del (locking) /Table/113/2/3/2/0
+Del /Table/113/2/3/2/0
 Del /Table/113/1/2/0
 
 # ---------------------------------------------------------
@@ -437,8 +437,8 @@ query T kvtrace
 UPDATE t SET a = 21 WHERE a = 20
 ----
 Scan /Table/112/1/20/0 lock Exclusive (Block, Unreplicated)
-Del (locking) /Table/112/2/11/20/0
-Del (locking) /Table/112/3/11/20/0
+Del /Table/112/2/11/20/0
+Del /Table/112/3/11/20/0
 Del (locking) /Table/112/1/20/0
 CPut /Table/112/1/21/0 -> /TUPLE/2:2:Int/11/1:3:Bytes/bar
 CPut /Table/112/2/11/21/0 -> /BYTES/
@@ -451,8 +451,8 @@ query T kvtrace
 UPDATE t SET a = 22, b = 9, c = 'foo' WHERE a = 21
 ----
 Scan /Table/112/1/21/0 lock Exclusive (Block, Unreplicated)
-Del (locking) /Table/112/2/11/21/0
-Del (locking) /Table/112/3/11/21/0
+Del /Table/112/2/11/21/0
+Del /Table/112/3/11/21/0
 Del (locking) /Table/112/1/21/0
 CPut /Table/112/1/22/0 -> /TUPLE/2:2:Int/9/1:3:Bytes/foo
 CPut /Table/112/2/9/22/0 -> /BYTES/
@@ -687,7 +687,7 @@ query T kvtrace
 INSERT INTO t VALUES (5, 3, 'baz') ON CONFLICT (a) DO UPDATE SET a = 6
 ----
 Scan /Table/112/1/5/0 lock Exclusive (Block, Unreplicated)
-Del (locking) /Table/112/2/4/5/0
+Del /Table/112/2/4/5/0
 Del (locking) /Table/112/1/5/0
 CPut /Table/112/1/6/0 -> /TUPLE/2:2:Int/4/1:3:Bytes/bar
 CPut /Table/112/2/4/6/0 -> /BYTES/
@@ -698,7 +698,7 @@ query T kvtrace
 INSERT INTO t VALUES (6, 3, 'bar') ON CONFLICT (a) DO UPDATE SET a = 7, c = 'foo'
 ----
 Scan /Table/112/1/6/0 lock Exclusive (Block, Unreplicated)
-Del (locking) /Table/112/2/4/6/0
+Del /Table/112/2/4/6/0
 Del (locking) /Table/112/1/6/0
 CPut /Table/112/1/7/0 -> /TUPLE/2:2:Int/4/1:3:Bytes/foo
 CPut /Table/112/2/4/7/0 -> /BYTES/
@@ -711,8 +711,8 @@ query T kvtrace
 INSERT INTO t VALUES (7, 3, 'bar') ON CONFLICT (a) DO UPDATE SET a = 8, b = 11
 ----
 Scan /Table/112/1/7/0 lock Exclusive (Block, Unreplicated)
-Del (locking) /Table/112/2/4/7/0
-Del (locking) /Table/112/4/"foo"/7/0
+Del /Table/112/2/4/7/0
+Del /Table/112/4/"foo"/7/0
 Del (locking) /Table/112/1/7/0
 CPut /Table/112/1/8/0 -> /TUPLE/2:2:Int/11/1:3:Bytes/foo
 CPut /Table/112/2/11/8/0 -> /BYTES/
@@ -724,8 +724,8 @@ query T kvtrace
 INSERT INTO t VALUES (8, 4, 'bar') ON CONFLICT (a) DO UPDATE SET a = 9, c = 'foobar'
 ----
 Scan /Table/112/1/8/0 lock Exclusive (Block, Unreplicated)
-Del (locking) /Table/112/2/11/8/0
-Del (locking) /Table/112/3/11/8/0
+Del /Table/112/2/11/8/0
+Del /Table/112/3/11/8/0
 Del (locking) /Table/112/1/8/0
 CPut /Table/112/1/9/0 -> /TUPLE/2:2:Int/11/1:3:Bytes/foobar
 CPut /Table/112/2/11/9/0 -> /BYTES/
@@ -891,8 +891,8 @@ query T kvtrace
 DELETE FROM inv WHERE a = 1
 ----
 Scan /Table/107/1/1/0 lock Exclusive (Block, Unreplicated)
-Del (locking) /Table/107/2/"num"/1/1/0
-Del (locking) /Table/107/2/"x"/"y"/1/0
+Del /Table/107/2/"num"/1/1/0
+Del /Table/107/2/"x"/"y"/1/0
 Del /Table/107/1/1/0
 
 query T kvtrace
@@ -962,8 +962,8 @@ query T kvtrace
 UPDATE inv SET a = 4 WHERE a = 2
 ----
 Scan /Table/107/1/2/0 lock Exclusive (Block, Unreplicated)
-Del (locking) /Table/107/2/"num"/4/2/0
-Del (locking) /Table/107/2/"x"/"y"/2/0
+Del /Table/107/2/"num"/4/2/0
+Del /Table/107/2/"x"/"y"/2/0
 Del (locking) /Table/107/1/2/0
 CPut /Table/107/1/4/0 -> /TUPLE/2:2:SentinelType/{"num": 4, "x": "y"}/1:3:Bytes/bar
 CPut /Table/107/2/"num"/4/4/0 -> /BYTES/
@@ -1074,6 +1074,6 @@ DELETE FROM t57085_p WHERE p = 1;
 ----
 Del (locking) /Table/114/1/1/0
 Scan /Table/115/{1-2}
-Del (locking) /Table/115/2/1/10/0
+Del /Table/115/2/1/10/0
 Del (locking) /Table/115/1/10/0
 Del (locking) /Table/115/1/20/0

--- a/pkg/sql/opt/exec/execbuilder/testdata/partial_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/partial_index
@@ -266,27 +266,27 @@ query T kvtrace
 DELETE FROM t WHERE a = 5
 ----
 Scan /Table/112/1/5/0 lock Exclusive (Block, Unreplicated)
-Del /Table/112/2/4/5/0
-Del /Table/112/1/5/0
+Del (locking) /Table/112/2/4/5/0
+Del (locking) /Table/112/1/5/0
 
 # Deleted row matches the first partial index.
 query T kvtrace
 DELETE FROM t WHERE a = 6
 ----
 Scan /Table/112/1/6/0 lock Exclusive (Block, Unreplicated)
-Del /Table/112/2/11/6/0
-Del /Table/112/3/11/6/0
-Del /Table/112/1/6/0
+Del (locking) /Table/112/2/11/6/0
+Del (locking) /Table/112/3/11/6/0
+Del (locking) /Table/112/1/6/0
 
 # Deleted row matches both partial indexes.
 query T kvtrace
 DELETE FROM t WHERE a = 12
 ----
 Scan /Table/112/1/12/0 lock Exclusive (Block, Unreplicated)
-Del /Table/112/2/11/12/0
-Del /Table/112/3/11/12/0
-Del /Table/112/4/"foo"/12/0
-Del /Table/112/1/12/0
+Del (locking) /Table/112/2/11/12/0
+Del (locking) /Table/112/3/11/12/0
+Del (locking) /Table/112/4/"foo"/12/0
+Del (locking) /Table/112/1/12/0
 
 # Deleted row does not match partial index with predicate column that is not
 # indexed.
@@ -294,7 +294,7 @@ query T kvtrace
 DELETE FROM u WHERE k = 1
 ----
 Scan /Table/113/1/1/0 lock Exclusive (Block, Unreplicated)
-Del /Table/113/1/1/0
+Del (locking) /Table/113/1/1/0
 
 # Deleted row matches partial index with predicate column that is not
 # indexed.
@@ -302,8 +302,8 @@ query T kvtrace
 DELETE FROM u WHERE k = 2
 ----
 Scan /Table/113/1/2/0 lock Exclusive (Block, Unreplicated)
-Del /Table/113/2/3/2/0
-Del /Table/113/1/2/0
+Del (locking) /Table/113/2/3/2/0
+Del (locking) /Table/113/1/2/0
 
 # ---------------------------------------------------------
 # UPDATE
@@ -342,7 +342,7 @@ UPDATE t SET b = 11 WHERE a = 5
 ----
 Scan /Table/112/1/5/0 lock Exclusive (Block, Unreplicated)
 Put /Table/112/1/5/0 -> /TUPLE/2:2:Int/11/1:3:Bytes/baz
-Del /Table/112/2/4/5/0
+Del (locking) /Table/112/2/4/5/0
 CPut /Table/112/2/11/5/0 -> /BYTES/
 CPut /Table/112/3/11/5/0 -> /BYTES/
 
@@ -361,9 +361,9 @@ UPDATE t SET b = 12 WHERE a = 6
 ----
 Scan /Table/112/1/6/0 lock Exclusive (Block, Unreplicated)
 Put /Table/112/1/6/0 -> /TUPLE/2:2:Int/12/1:3:Bytes/baz
-Del /Table/112/2/11/6/0
+Del (locking) /Table/112/2/11/6/0
 CPut /Table/112/2/12/6/0 -> /BYTES/
-Del /Table/112/3/11/6/0
+Del (locking) /Table/112/3/11/6/0
 CPut /Table/112/3/12/6/0 -> /BYTES/
 
 # Update a row that matches the first partial index before the update, but does
@@ -373,9 +373,9 @@ UPDATE t SET b = 9 WHERE a = 6
 ----
 Scan /Table/112/1/6/0 lock Exclusive (Block, Unreplicated)
 Put /Table/112/1/6/0 -> /TUPLE/2:2:Int/9/1:3:Bytes/baz
-Del /Table/112/2/12/6/0
+Del (locking) /Table/112/2/12/6/0
 CPut /Table/112/2/9/6/0 -> /BYTES/
-Del /Table/112/3/12/6/0
+Del (locking) /Table/112/3/12/6/0
 
 # Update a row that matches both partial indexes before the update, the first
 # partial index entry needs to be updated, and the second needs to be deleted.
@@ -384,11 +384,11 @@ UPDATE t SET c = 'baz', b = 12 WHERE a = 13
 ----
 Scan /Table/112/1/13/0 lock Exclusive (Block, Unreplicated)
 Put /Table/112/1/13/0 -> /TUPLE/2:2:Int/12/1:3:Bytes/baz
-Del /Table/112/2/11/13/0
+Del (locking) /Table/112/2/11/13/0
 CPut /Table/112/2/12/13/0 -> /BYTES/
-Del /Table/112/3/11/13/0
+Del (locking) /Table/112/3/11/13/0
 CPut /Table/112/3/12/13/0 -> /BYTES/
-Del /Table/112/4/"foo"/13/0
+Del (locking) /Table/112/4/"foo"/13/0
 
 # Reversing the previous update should reverse the partial index changes.
 query T kvtrace
@@ -396,9 +396,9 @@ UPDATE t SET c = 'foo', b = 11 WHERE a = 13
 ----
 Scan /Table/112/1/13/0 lock Exclusive (Block, Unreplicated)
 Put /Table/112/1/13/0 -> /TUPLE/2:2:Int/11/1:3:Bytes/foo
-Del /Table/112/2/12/13/0
+Del (locking) /Table/112/2/12/13/0
 CPut /Table/112/2/11/13/0 -> /BYTES/
-Del /Table/112/3/12/13/0
+Del (locking) /Table/112/3/12/13/0
 CPut /Table/112/3/11/13/0 -> /BYTES/
 CPut /Table/112/4/"foo"/13/0 -> /BYTES/
 
@@ -421,7 +421,7 @@ UPDATE u SET v = 3 WHERE k = 1
 ----
 Scan /Table/113/1/1/0 lock Exclusive (Block, Unreplicated)
 Put /Table/113/1/1/0 -> /TUPLE/2:2:Int/2/1:3:Int/3
-Del /Table/113/2/2/1/0
+Del (locking) /Table/113/2/2/1/0
 
 # ---------------------------------------------------------
 # UPDATE primary key
@@ -437,9 +437,9 @@ query T kvtrace
 UPDATE t SET a = 21 WHERE a = 20
 ----
 Scan /Table/112/1/20/0 lock Exclusive (Block, Unreplicated)
-Del /Table/112/2/11/20/0
-Del /Table/112/3/11/20/0
-Del /Table/112/1/20/0
+Del (locking) /Table/112/2/11/20/0
+Del (locking) /Table/112/3/11/20/0
+Del (locking) /Table/112/1/20/0
 CPut /Table/112/1/21/0 -> /TUPLE/2:2:Int/11/1:3:Bytes/bar
 CPut /Table/112/2/11/21/0 -> /BYTES/
 CPut /Table/112/3/11/21/0 -> /BYTES/
@@ -451,9 +451,9 @@ query T kvtrace
 UPDATE t SET a = 22, b = 9, c = 'foo' WHERE a = 21
 ----
 Scan /Table/112/1/21/0 lock Exclusive (Block, Unreplicated)
-Del /Table/112/2/11/21/0
-Del /Table/112/3/11/21/0
-Del /Table/112/1/21/0
+Del (locking) /Table/112/2/11/21/0
+Del (locking) /Table/112/3/11/21/0
+Del (locking) /Table/112/1/21/0
 CPut /Table/112/1/22/0 -> /TUPLE/2:2:Int/9/1:3:Bytes/foo
 CPut /Table/112/2/9/22/0 -> /BYTES/
 CPut /Table/112/4/"foo"/22/0 -> /BYTES/
@@ -571,7 +571,7 @@ INSERT INTO t VALUES (5, 3, 'foo') ON CONFLICT (a) DO UPDATE SET b = 3
 ----
 Scan /Table/112/1/5/0 lock Exclusive (Block, Unreplicated)
 Put /Table/112/1/5/0 -> /TUPLE/2:2:Int/3/1:3:Bytes/bar
-Del /Table/112/2/4/5/0
+Del (locking) /Table/112/2/4/5/0
 CPut /Table/112/2/3/5/0 -> /BYTES/
 
 # Insert a conflicting row that does not match the first partial index
@@ -581,7 +581,7 @@ INSERT INTO t VALUES (5, 7, 'foo') ON CONFLICT (a) DO UPDATE SET b = 11
 ----
 Scan /Table/112/1/5/0 lock Exclusive (Block, Unreplicated)
 Put /Table/112/1/5/0 -> /TUPLE/2:2:Int/11/1:3:Bytes/bar
-Del /Table/112/2/3/5/0
+Del (locking) /Table/112/2/3/5/0
 CPut /Table/112/2/11/5/0 -> /BYTES/
 CPut /Table/112/3/11/5/0 -> /BYTES/
 
@@ -593,9 +593,9 @@ INSERT INTO t VALUES (5, 11, 'bar') ON CONFLICT (a) DO UPDATE SET b = 4, c = 'fo
 ----
 Scan /Table/112/1/5/0 lock Exclusive (Block, Unreplicated)
 Put /Table/112/1/5/0 -> /TUPLE/2:2:Int/4/1:3:Bytes/foo
-Del /Table/112/2/11/5/0
+Del (locking) /Table/112/2/11/5/0
 CPut /Table/112/2/4/5/0 -> /BYTES/
-Del /Table/112/3/11/5/0
+Del (locking) /Table/112/3/11/5/0
 CPut /Table/112/4/"foo"/5/0 -> /BYTES/
 
 # Insert a conflicting row that that matches the second partial index before and
@@ -605,7 +605,7 @@ INSERT INTO t VALUES (5, 11, 'bar') ON CONFLICT (a) DO UPDATE SET b = 3
 ----
 Scan /Table/112/1/5/0 lock Exclusive (Block, Unreplicated)
 Put /Table/112/1/5/0 -> /TUPLE/2:2:Int/3/1:3:Bytes/foo
-Del /Table/112/2/4/5/0
+Del (locking) /Table/112/2/4/5/0
 CPut /Table/112/2/3/5/0 -> /BYTES/
 
 # Insert a conflicting row that that matches the second partial index before and
@@ -615,7 +615,7 @@ INSERT INTO t VALUES (5, 11, 'bar') ON CONFLICT (a) DO UPDATE SET c = 'foobar'
 ----
 Scan /Table/112/1/5/0 lock Exclusive (Block, Unreplicated)
 Put /Table/112/1/5/0 -> /TUPLE/2:2:Int/3/1:3:Bytes/foobar
-Del /Table/112/4/"foo"/5/0
+Del (locking) /Table/112/4/"foo"/5/0
 CPut /Table/112/4/"foobar"/5/0 -> /BYTES/
 
 # Insert a non-conflicting row that matches the first partial index.
@@ -659,7 +659,7 @@ INSERT INTO u VALUES (2, 3, 11) ON CONFLICT (k) DO UPDATE SET u = 4, v = 12
 ----
 Scan /Table/113/1/2/0 lock Exclusive (Block, Unreplicated)
 Put /Table/113/1/2/0 -> /TUPLE/2:2:Int/4/1:3:Int/12
-Del /Table/113/2/3/2/0
+Del (locking) /Table/113/2/3/2/0
 CPut /Table/113/2/4/2/0 -> /BYTES/
 
 # ---------------------------------------------------------
@@ -687,8 +687,8 @@ query T kvtrace
 INSERT INTO t VALUES (5, 3, 'baz') ON CONFLICT (a) DO UPDATE SET a = 6
 ----
 Scan /Table/112/1/5/0 lock Exclusive (Block, Unreplicated)
-Del /Table/112/2/4/5/0
-Del /Table/112/1/5/0
+Del (locking) /Table/112/2/4/5/0
+Del (locking) /Table/112/1/5/0
 CPut /Table/112/1/6/0 -> /TUPLE/2:2:Int/4/1:3:Bytes/bar
 CPut /Table/112/2/4/6/0 -> /BYTES/
 
@@ -698,8 +698,8 @@ query T kvtrace
 INSERT INTO t VALUES (6, 3, 'bar') ON CONFLICT (a) DO UPDATE SET a = 7, c = 'foo'
 ----
 Scan /Table/112/1/6/0 lock Exclusive (Block, Unreplicated)
-Del /Table/112/2/4/6/0
-Del /Table/112/1/6/0
+Del (locking) /Table/112/2/4/6/0
+Del (locking) /Table/112/1/6/0
 CPut /Table/112/1/7/0 -> /TUPLE/2:2:Int/4/1:3:Bytes/foo
 CPut /Table/112/2/4/7/0 -> /BYTES/
 CPut /Table/112/4/"foo"/7/0 -> /BYTES/
@@ -711,9 +711,9 @@ query T kvtrace
 INSERT INTO t VALUES (7, 3, 'bar') ON CONFLICT (a) DO UPDATE SET a = 8, b = 11
 ----
 Scan /Table/112/1/7/0 lock Exclusive (Block, Unreplicated)
-Del /Table/112/2/4/7/0
-Del /Table/112/4/"foo"/7/0
-Del /Table/112/1/7/0
+Del (locking) /Table/112/2/4/7/0
+Del (locking) /Table/112/4/"foo"/7/0
+Del (locking) /Table/112/1/7/0
 CPut /Table/112/1/8/0 -> /TUPLE/2:2:Int/11/1:3:Bytes/foo
 CPut /Table/112/2/11/8/0 -> /BYTES/
 CPut /Table/112/3/11/8/0 -> /BYTES/
@@ -724,9 +724,9 @@ query T kvtrace
 INSERT INTO t VALUES (8, 4, 'bar') ON CONFLICT (a) DO UPDATE SET a = 9, c = 'foobar'
 ----
 Scan /Table/112/1/8/0 lock Exclusive (Block, Unreplicated)
-Del /Table/112/2/11/8/0
-Del /Table/112/3/11/8/0
-Del /Table/112/1/8/0
+Del (locking) /Table/112/2/11/8/0
+Del (locking) /Table/112/3/11/8/0
+Del (locking) /Table/112/1/8/0
 CPut /Table/112/1/9/0 -> /TUPLE/2:2:Int/11/1:3:Bytes/foobar
 CPut /Table/112/2/11/9/0 -> /BYTES/
 CPut /Table/112/3/11/9/0 -> /BYTES/
@@ -757,7 +757,7 @@ UPSERT INTO t VALUES (5, 3, 'bar')
 ----
 Scan /Table/112/1/5/0 lock Exclusive (Block, Unreplicated)
 Put /Table/112/1/5/0 -> /TUPLE/2:2:Int/3/1:3:Bytes/bar
-Del /Table/112/2/4/5/0
+Del (locking) /Table/112/2/4/5/0
 CPut /Table/112/2/3/5/0 -> /BYTES/
 
 # Upsert a conflicting row that does not match the first partial index before
@@ -767,7 +767,7 @@ UPSERT INTO t VALUES (5, 11, 'bar')
 ----
 Scan /Table/112/1/5/0 lock Exclusive (Block, Unreplicated)
 Put /Table/112/1/5/0 -> /TUPLE/2:2:Int/11/1:3:Bytes/bar
-Del /Table/112/2/3/5/0
+Del (locking) /Table/112/2/3/5/0
 CPut /Table/112/2/11/5/0 -> /BYTES/
 CPut /Table/112/3/11/5/0 -> /BYTES/
 
@@ -779,9 +779,9 @@ UPSERT INTO t VALUES (5, 3, 'foo')
 ----
 Scan /Table/112/1/5/0 lock Exclusive (Block, Unreplicated)
 Put /Table/112/1/5/0 -> /TUPLE/2:2:Int/3/1:3:Bytes/foo
-Del /Table/112/2/11/5/0
+Del (locking) /Table/112/2/11/5/0
 CPut /Table/112/2/3/5/0 -> /BYTES/
-Del /Table/112/3/11/5/0
+Del (locking) /Table/112/3/11/5/0
 CPut /Table/112/4/"foo"/5/0 -> /BYTES/
 
 # Upsert a conflicting row that that matches the second partial index before and
@@ -791,7 +791,7 @@ UPSERT INTO t VALUES (5, 4, 'foo')
 ----
 Scan /Table/112/1/5/0 lock Exclusive (Block, Unreplicated)
 Put /Table/112/1/5/0 -> /TUPLE/2:2:Int/4/1:3:Bytes/foo
-Del /Table/112/2/3/5/0
+Del (locking) /Table/112/2/3/5/0
 CPut /Table/112/2/4/5/0 -> /BYTES/
 
 # Upsert a conflicting row that that matches the second partial index before and
@@ -801,7 +801,7 @@ UPSERT INTO t VALUES (5, 4, 'foobar')
 ----
 Scan /Table/112/1/5/0 lock Exclusive (Block, Unreplicated)
 Put /Table/112/1/5/0 -> /TUPLE/2:2:Int/4/1:3:Bytes/foobar
-Del /Table/112/4/"foo"/5/0
+Del (locking) /Table/112/4/"foo"/5/0
 CPut /Table/112/4/"foobar"/5/0 -> /BYTES/
 
 # Upsert a non-conflicting row that matches the first partial index.
@@ -845,7 +845,7 @@ UPSERT INTO u VALUES (2, 4, 12)
 ----
 Scan /Table/113/1/2/0 lock Exclusive (Block, Unreplicated)
 Put /Table/113/1/2/0 -> /TUPLE/2:2:Int/4/1:3:Int/12
-Del /Table/113/2/3/2/0
+Del (locking) /Table/113/2/3/2/0
 CPut /Table/113/2/4/2/0 -> /BYTES/
 
 # Tests for partial inverted indexes.
@@ -891,15 +891,15 @@ query T kvtrace
 DELETE FROM inv WHERE a = 1
 ----
 Scan /Table/107/1/1/0 lock Exclusive (Block, Unreplicated)
-Del /Table/107/2/"num"/1/1/0
-Del /Table/107/2/"x"/"y"/1/0
-Del /Table/107/1/1/0
+Del (locking) /Table/107/2/"num"/1/1/0
+Del (locking) /Table/107/2/"x"/"y"/1/0
+Del (locking) /Table/107/1/1/0
 
 query T kvtrace
 DELETE FROM inv WHERE a = 2
 ----
 Scan /Table/107/1/2/0 lock Exclusive (Block, Unreplicated)
-Del /Table/107/1/2/0
+Del (locking) /Table/107/1/2/0
 
 # ---------------------------------------------------------
 # UPDATE partial inverted index
@@ -922,7 +922,7 @@ UPDATE inv SET b = '{"x": "y", "num": 3}' WHERE a = 1
 ----
 Scan /Table/107/1/1/0 lock Exclusive (Block, Unreplicated)
 Put /Table/107/1/1/0 -> /TUPLE/2:2:SentinelType/{"num": 3, "x": "y"}/1:3:Bytes/bar
-Del /Table/107/2/"num"/1/1/0
+Del (locking) /Table/107/2/"num"/1/1/0
 CPut /Table/107/2/"num"/3/1/0 -> /BYTES/
 
 # Update a non-JSON column so that the row is removed from the partial index.
@@ -931,8 +931,8 @@ UPDATE inv SET c = 'fud' WHERE a = 1
 ----
 Scan /Table/107/1/1/0 lock Exclusive (Block, Unreplicated)
 Put /Table/107/1/1/0 -> /TUPLE/2:2:SentinelType/{"num": 3, "x": "y"}/1:3:Bytes/fud
-Del /Table/107/2/"num"/3/1/0
-Del /Table/107/2/"x"/"y"/1/0
+Del (locking) /Table/107/2/"num"/3/1/0
+Del (locking) /Table/107/2/"x"/"y"/1/0
 
 # Update a non-JSON column so that the row remains not in the partial index.
 query T kvtrace
@@ -962,9 +962,9 @@ query T kvtrace
 UPDATE inv SET a = 4 WHERE a = 2
 ----
 Scan /Table/107/1/2/0 lock Exclusive (Block, Unreplicated)
-Del /Table/107/2/"num"/4/2/0
-Del /Table/107/2/"x"/"y"/2/0
-Del /Table/107/1/2/0
+Del (locking) /Table/107/2/"num"/4/2/0
+Del (locking) /Table/107/2/"x"/"y"/2/0
+Del (locking) /Table/107/1/2/0
 CPut /Table/107/1/4/0 -> /TUPLE/2:2:SentinelType/{"num": 4, "x": "y"}/1:3:Bytes/bar
 CPut /Table/107/2/"num"/4/4/0 -> /BYTES/
 CPut /Table/107/2/"x"/"y"/4/0 -> /BYTES/
@@ -974,7 +974,7 @@ query T kvtrace
 UPDATE inv SET a = 3 WHERE a = 1
 ----
 Scan /Table/107/1/1/0 lock Exclusive (Block, Unreplicated)
-Del /Table/107/1/1/0
+Del (locking) /Table/107/1/1/0
 CPut /Table/107/1/3/0 -> /TUPLE/2:2:SentinelType/{"num": 3, "x": "y"}/1:3:Bytes/fud
 
 # Update to multiple rows (one in and one not in the partial index) so that both
@@ -1000,7 +1000,7 @@ UPDATE inv SET c = 'fud' WHERE a IN (12, 13)
 ----
 Scan /Table/107/1/1{2-4} lock Exclusive (Block, Unreplicated)
 Put /Table/107/1/12/0 -> /TUPLE/2:2:SentinelType/{"a": "b"}/1:3:Bytes/fud
-Del /Table/107/2/"a"/"b"/12/0
+Del (locking) /Table/107/2/"a"/"b"/12/0
 Put /Table/107/1/13/0 -> /TUPLE/2:2:SentinelType/{"a": "b"}/1:3:Bytes/fud
 
 # ---------------------------------------------------------
@@ -1022,7 +1022,7 @@ UPSERT INTO inv VALUES (4, '{"x": "y", "num": 6}', 'foo')
 ----
 Scan /Table/107/1/4/0 lock Exclusive (Block, Unreplicated)
 Put /Table/107/1/4/0 -> /TUPLE/2:2:SentinelType/{"num": 6, "x": "y"}/1:3:Bytes/foo
-Del /Table/107/2/"num"/4/4/0
+Del (locking) /Table/107/2/"num"/4/4/0
 CPut /Table/107/2/"num"/6/4/0 -> /BYTES/
 
 # Upsert a conflicting row so that it is removed from the partial index.
@@ -1031,8 +1031,8 @@ UPSERT INTO inv VALUES (4, '{"x": "y", "num": 6}', 'fud')
 ----
 Scan /Table/107/1/4/0 lock Exclusive (Block, Unreplicated)
 Put /Table/107/1/4/0 -> /TUPLE/2:2:SentinelType/{"num": 6, "x": "y"}/1:3:Bytes/fud
-Del /Table/107/2/"num"/6/4/0
-Del /Table/107/2/"x"/"y"/4/0
+Del (locking) /Table/107/2/"num"/6/4/0
+Del (locking) /Table/107/2/"x"/"y"/4/0
 
 # Upsert a non-conflicting row that is added to the partial index.
 query T kvtrace
@@ -1074,6 +1074,6 @@ DELETE FROM t57085_p WHERE p = 1;
 ----
 Del (locking) /Table/114/1/1/0
 Scan /Table/115/{1-2}
-Del /Table/115/2/1/10/0
-Del /Table/115/1/10/0
-Del /Table/115/1/20/0
+Del (locking) /Table/115/2/1/10/0
+Del (locking) /Table/115/1/10/0
+Del (locking) /Table/115/1/20/0

--- a/pkg/sql/opt/exec/execbuilder/testdata/schema_change_in_txn
+++ b/pkg/sql/opt/exec/execbuilder/testdata/schema_change_in_txn
@@ -50,16 +50,16 @@ query T kvtrace(prefix=/Table/106/)
 UPDATE t SET a = a + 100
 ----
 Scan /Table/106/{1-2} lock Exclusive (Block, Unreplicated)
-Del /Table/106/1/100/0
-Del /Table/106/1/100/1/1
+Del (locking) /Table/106/1/100/0
+Del (locking) /Table/106/1/100/1/1
 CPut /Table/106/1/200/0 -> /TUPLE/2:2:Decimal/1000.2/1:3:Bytes/empty
 CPut /Table/106/1/200/1/1 -> /TUPLE/4:4:Decimal/0.00/2:6:Decimal/1200.2
-Del /Table/106/1/101/0
-Del /Table/106/1/101/1/1
+Del (locking) /Table/106/1/101/0
+Del (locking) /Table/106/1/101/1/1
 CPut /Table/106/1/201/0 -> /TUPLE/2:2:Decimal/1000.2/1:3:Bytes/empty
 CPut /Table/106/1/201/1/1 -> /TUPLE/4:4:Decimal/0.00/2:6:Decimal/1201.2
-Del /Table/106/1/102/0
-Del /Table/106/1/102/1/1
+Del (locking) /Table/106/1/102/0
+Del (locking) /Table/106/1/102/1/1
 CPut /Table/106/1/202/0 -> /TUPLE/2:2:Decimal/1000.2/1:3:Bytes/empty
 CPut /Table/106/1/202/1/1 -> /TUPLE/4:4:Decimal/0.00/2:6:Decimal/1202.2
 

--- a/pkg/sql/opt/exec/execbuilder/testdata/secondary_index_column_families
+++ b/pkg/sql/opt/exec/execbuilder/testdata/secondary_index_column_families
@@ -38,11 +38,11 @@ CPut /Table/106/5/1/3/1 -> /TUPLE/4:4:Int/1/1:5:Int/1
 query T kvtrace(Del,prefix=/Table/106/2/,prefix=/Table/106/3/,prefix=/Table/106/4/,prefix=/Table/106/5/)
 DELETE FROM t1 WHERE x = 1
 ----
-Del (locking) /Table/106/2/1/1/0
+Del /Table/106/2/1/1/0
 Del (locking) /Table/106/3/1/0
-Del (locking) /Table/106/4/1/1/0
-Del (locking) /Table/106/4/1/1/2/1
-Del (locking) /Table/106/4/1/1/3/1
+Del /Table/106/4/1/1/0
+Del /Table/106/4/1/1/2/1
+Del /Table/106/4/1/1/3/1
 Del (locking) /Table/106/5/1/0
 Del (locking) /Table/106/5/1/2/1
 Del (locking) /Table/106/5/1/3/1
@@ -158,8 +158,8 @@ ORDER BY message
 ----
 CPut /Table/106/2/2/2/0 -> /BYTES/
 CPut /Table/106/3/2/0 -> /BYTES/0x8a
-Del (locking) /Table/106/2/1/1/0
 Del (locking) /Table/106/3/1/0
+Del /Table/106/2/1/1/0
 
 # Updates on nonuniqueidxstoring should generate 3 K/V pairs.
 query T
@@ -171,9 +171,9 @@ ORDER BY message
 CPut /Table/106/4/2/2/0 -> /BYTES/
 CPut /Table/106/4/2/2/2/1 -> /TUPLE/3:3:Int/2
 CPut /Table/106/4/2/2/3/1 -> /TUPLE/4:4:Int/2/1:5:Int/2
-Del (locking) /Table/106/4/1/1/0
-Del (locking) /Table/106/4/1/1/2/1
-Del (locking) /Table/106/4/1/1/3/1
+Del /Table/106/4/1/1/0
+Del /Table/106/4/1/1/2/1
+Del /Table/106/4/1/1/3/1
 
 # Updates on uniqueidxstoring should generate 3 K/V pairs.
 query T

--- a/pkg/sql/opt/exec/execbuilder/testdata/secondary_index_column_families
+++ b/pkg/sql/opt/exec/execbuilder/testdata/secondary_index_column_families
@@ -38,14 +38,14 @@ CPut /Table/106/5/1/3/1 -> /TUPLE/4:4:Int/1/1:5:Int/1
 query T kvtrace(Del,prefix=/Table/106/2/,prefix=/Table/106/3/,prefix=/Table/106/4/,prefix=/Table/106/5/)
 DELETE FROM t1 WHERE x = 1
 ----
-Del /Table/106/2/1/1/0
-Del /Table/106/3/1/0
-Del /Table/106/4/1/1/0
-Del /Table/106/4/1/1/2/1
-Del /Table/106/4/1/1/3/1
-Del /Table/106/5/1/0
-Del /Table/106/5/1/2/1
-Del /Table/106/5/1/3/1
+Del (locking) /Table/106/2/1/1/0
+Del (locking) /Table/106/3/1/0
+Del (locking) /Table/106/4/1/1/0
+Del (locking) /Table/106/4/1/1/2/1
+Del (locking) /Table/106/4/1/1/3/1
+Del (locking) /Table/106/5/1/0
+Del (locking) /Table/106/5/1/2/1
+Del (locking) /Table/106/5/1/3/1
 
 # Put some data back into the table.
 statement ok
@@ -150,44 +150,44 @@ SET TRACING=off;
 # Updates on nonuniqueidx or uniqueidx (which don't store anything) should be a single kv pair of the old format.
 query T
 SELECT message FROM [SHOW KV TRACE FOR SESSION] WHERE
-message LIKE 'Del /Table/106/2/%' OR
+message LIKE 'Del %/Table/106/2/%' OR
 message LIKE '%Put /Table/106/2/%' OR
-message LIKE 'Del /Table/106/3/%' OR
+message LIKE 'Del %/Table/106/3/%' OR
 message LIKE '%Put /Table/106/3/%'
 ORDER BY message
 ----
 CPut /Table/106/2/2/2/0 -> /BYTES/
 CPut /Table/106/3/2/0 -> /BYTES/0x8a
-Del /Table/106/2/1/1/0
-Del /Table/106/3/1/0
+Del (locking) /Table/106/2/1/1/0
+Del (locking) /Table/106/3/1/0
 
 # Updates on nonuniqueidxstoring should generate 3 K/V pairs.
 query T
 SELECT message FROM [SHOW KV TRACE FOR SESSION] WHERE
-message LIKE 'Del /Table/106/4/%' OR
+message LIKE 'Del %/Table/106/4/%' OR
 message LIKE '%Put /Table/106/4/%'
 ORDER BY message
 ----
 CPut /Table/106/4/2/2/0 -> /BYTES/
 CPut /Table/106/4/2/2/2/1 -> /TUPLE/3:3:Int/2
 CPut /Table/106/4/2/2/3/1 -> /TUPLE/4:4:Int/2/1:5:Int/2
-Del /Table/106/4/1/1/0
-Del /Table/106/4/1/1/2/1
-Del /Table/106/4/1/1/3/1
+Del (locking) /Table/106/4/1/1/0
+Del (locking) /Table/106/4/1/1/2/1
+Del (locking) /Table/106/4/1/1/3/1
 
 # Updates on uniqueidxstoring should generate 3 K/V pairs.
 query T
 SELECT message FROM [SHOW KV TRACE FOR SESSION] WHERE
-message LIKE 'Del /Table/106/5/%' OR
+message LIKE 'Del %/Table/106/5/%' OR
 message LIKE '%Put /Table/106/5/%'
 ORDER BY message
 ----
 CPut /Table/106/5/2/0 -> /BYTES/0x8a
 CPut /Table/106/5/2/2/1 -> /TUPLE/3:3:Int/2
 CPut /Table/106/5/2/3/1 -> /TUPLE/4:4:Int/2/1:5:Int/2
-Del /Table/106/5/1/0
-Del /Table/106/5/1/2/1
-Del /Table/106/5/1/3/1
+Del (locking) /Table/106/5/1/0
+Del (locking) /Table/106/5/1/2/1
+Del (locking) /Table/106/5/1/3/1
 
 # Ensure that reads only scan the necessary k/v's.
 statement ok
@@ -363,9 +363,9 @@ CREATE INDEX i ON t (y) STORING (z, w)
 query T kvtrace(Del,prefix=/Table/111/3/)
 UPDATE t SET z = 3 WHERE y = 2
 ----
-Del /Table/111/3/2/1/0
-Del /Table/111/3/2/1/2/1
-Del /Table/111/3/2/1/3/1
+Del (locking) /Table/111/3/2/1/0
+Del (locking) /Table/111/3/2/1/2/1
+Del (locking) /Table/111/3/2/1/3/1
 
 statement ok
 COMMIT
@@ -409,9 +409,9 @@ UPDATE t SET b = 4, c = NULL, d = NULL, e = 7, f = NULL WHERE y = 2
 ----
 Scan /Table/112/2/{2-3} lock Exclusive (Block, Unreplicated)
 Put /Table/112/2/2/1/2/1 -> /TUPLE/3:3:Int/3/1:4:Int/4
-Del /Table/112/2/2/1/3/1
+Del (locking) /Table/112/2/2/1/3/1
 CPut /Table/112/2/2/1/4/1 -> /TUPLE/7:7:Int/7
-Del /Table/112/2/2/1/5/1
+Del (locking) /Table/112/2/2/1/5/1
 
 query IIIIIIII
 SELECT * FROM t@i2
@@ -437,10 +437,10 @@ query T kvtrace(Scan,Del,Put,CPut,prefix=/Table/112/2/)
 UPDATE t SET a = NULL, b = NULL, c = NULL, d = NULL, e = NULL, f = NULL WHERE y = 3
 ----
 Scan /Table/112/2/{3-4} lock Exclusive (Block, Unreplicated)
-Del /Table/112/2/3/3/2/1
-Del /Table/112/2/3/3/3/1
-Del /Table/112/2/3/3/4/1
-Del /Table/112/2/3/3/5/1
+Del (locking) /Table/112/2/3/3/2/1
+Del (locking) /Table/112/2/3/3/3/1
+Del (locking) /Table/112/2/3/3/4/1
+Del (locking) /Table/112/2/3/3/5/1
 
 
 # Test a case that each k/v in the index entry gets
@@ -452,13 +452,13 @@ query T kvtrace(Scan,Put,Del,CPut,prefix=/Table/112/2/)
 UPDATE t SET y = 22 WHERE y = 21
 ----
 Scan /Table/112/2/2{1-2} lock Exclusive (Block, Unreplicated)
-Del /Table/112/2/21/20/0
+Del (locking) /Table/112/2/21/20/0
 CPut /Table/112/2/22/20/0 -> /BYTES/
-Del /Table/112/2/21/20/2/1
+Del (locking) /Table/112/2/21/20/2/1
 CPut /Table/112/2/22/20/2/1 -> /TUPLE/3:3:Int/22
-Del /Table/112/2/21/20/3/1
+Del (locking) /Table/112/2/21/20/3/1
 CPut /Table/112/2/22/20/3/1 -> /TUPLE/6:6:Int/25
-Del /Table/112/2/21/20/5/1
+Del (locking) /Table/112/2/21/20/5/1
 CPut /Table/112/2/22/20/5/1 -> /TUPLE/8:8:Int/27
 
 # Ensure that the final results on both indexes make sense.
@@ -495,7 +495,7 @@ query T kvtrace(Scan,Put,CPut,Del,prefix=/Table/113/2/)
 UPDATE t SET y = 5 where y = 2
 ----
 Scan /Table/113/2/{2-3} lock Exclusive (Block, Unreplicated)
-Del /Table/113/2/2/1/0
+Del (locking) /Table/113/2/2/1/0
 CPut /Table/113/2/5/1/0 -> /BYTES/0x33061308
 
 # Changing the value just results in a cput.

--- a/pkg/sql/opt/exec/execbuilder/testdata/secondary_index_column_families
+++ b/pkg/sql/opt/exec/execbuilder/testdata/secondary_index_column_families
@@ -404,9 +404,10 @@ CPut /Table/112/3/2/5/1 -> /TUPLE/8:8:Int/8
 # Ensure success when some family k/v's are deleted,
 # some family k/v's have different values, and some
 # family k/v's are added.
-query T kvtrace(Put,Del,CPut,prefix=/Table/112/2/)
+query T kvtrace(Scan,Put,Del,CPut,prefix=/Table/112/2/)
 UPDATE t SET b = 4, c = NULL, d = NULL, e = 7, f = NULL WHERE y = 2
 ----
+Scan /Table/112/2/{2-3} lock Exclusive (Block, Unreplicated)
 Put /Table/112/2/2/1/2/1 -> /TUPLE/3:3:Int/3/1:4:Int/4
 Del /Table/112/2/2/1/3/1
 CPut /Table/112/2/2/1/4/1 -> /TUPLE/7:7:Int/7
@@ -432,9 +433,10 @@ CPut /Table/112/2/3/3/5/1 -> /TUPLE/8:8:Int/15
 
 # Test a case where the update causes all k/v's other than
 # the sentinel k/v to get deleted.
-query T kvtrace(Del,Put,CPut,prefix=/Table/112/2/)
+query T kvtrace(Scan,Del,Put,CPut,prefix=/Table/112/2/)
 UPDATE t SET a = NULL, b = NULL, c = NULL, d = NULL, e = NULL, f = NULL WHERE y = 3
 ----
+Scan /Table/112/2/{3-4} lock Exclusive (Block, Unreplicated)
 Del /Table/112/2/3/3/2/1
 Del /Table/112/2/3/3/3/1
 Del /Table/112/2/3/3/4/1
@@ -446,9 +448,10 @@ Del /Table/112/2/3/3/5/1
 statement ok
 INSERT INTO t VALUES (20, 21, 22, NULL, NULL, 25, NULL, 27);
 
-query T kvtrace(Put,Del,CPut,prefix=/Table/112/2/)
+query T kvtrace(Scan,Put,Del,CPut,prefix=/Table/112/2/)
 UPDATE t SET y = 22 WHERE y = 21
 ----
+Scan /Table/112/2/2{1-2} lock Exclusive (Block, Unreplicated)
 Del /Table/112/2/21/20/0
 CPut /Table/112/2/22/20/0 -> /BYTES/
 Del /Table/112/2/21/20/2/1
@@ -488,9 +491,10 @@ statement ok
 INSERT INTO t VALUES (1, 2, 3, 4)
 
 # When the key is changed, we always delete and cput.
-query T kvtrace(Put,CPut,Del,prefix=/Table/113/2/)
+query T kvtrace(Scan,Put,CPut,Del,prefix=/Table/113/2/)
 UPDATE t SET y = 5 where y = 2
 ----
+Scan /Table/113/2/{2-3} lock Exclusive (Block, Unreplicated)
 Del /Table/113/2/2/1/0
 CPut /Table/113/2/5/1/0 -> /BYTES/0x33061308
 

--- a/pkg/sql/opt/exec/execbuilder/testdata/show_trace
+++ b/pkg/sql/opt/exec/execbuilder/testdata/show_trace
@@ -195,7 +195,7 @@ $trace_query
 colbatchscan  Scan /Table/108/{1-2} lock Exclusive (Block, Unreplicated)
 colbatchscan  fetched: /kv/kv_pkey/1/v -> /2
 count         Del (locking) /Table/108/2/2/0
-count         Del (locking) /Table/108/1/1/0
+count         Del /Table/108/1/1/0
 count         fast path completed
 sql query     rows affected: 1
 

--- a/pkg/sql/opt/exec/execbuilder/testdata/show_trace
+++ b/pkg/sql/opt/exec/execbuilder/testdata/show_trace
@@ -194,8 +194,8 @@ $trace_query
 ----
 colbatchscan  Scan /Table/108/{1-2} lock Exclusive (Block, Unreplicated)
 colbatchscan  fetched: /kv/kv_pkey/1/v -> /2
-count         Del /Table/108/2/2/0
-count         Del /Table/108/1/1/0
+count         Del (locking) /Table/108/2/2/0
+count         Del (locking) /Table/108/1/1/0
 count         fast path completed
 sql query     rows affected: 1
 

--- a/pkg/sql/opt/exec/execbuilder/testdata/update
+++ b/pkg/sql/opt/exec/execbuilder/testdata/update
@@ -901,8 +901,8 @@ Scan /Table/115/{1-2} lock Exclusive (Block, Unreplicated)
 fetched: /tu/tu_pkey/1:cf=0 -> <undecoded>
 fetched: /tu/tu_pkey/1/b:cf=1 -> 2
 fetched: /tu/tu_pkey/1/c/d:cf=2 -> /4/4
-Del /Table/115/1/1/1/1
-Del /Table/115/1/1/2/1
+Del (locking) /Table/115/1/1/1/1
+Del (locking) /Table/115/1/1/2/1
 fast path completed
 rows affected: 1
 

--- a/pkg/sql/opt/exec/execbuilder/testdata/upsert
+++ b/pkg/sql/opt/exec/execbuilder/testdata/upsert
@@ -1051,8 +1051,8 @@ SELECT message FROM [SHOW KV TRACE FOR SESSION]
  WHERE operation != 'dist sender send'
 ----
 Put (locking) /Table/117/1/1/0 -> /TUPLE/
-Del /Table/117/1/1/1/1
-Del /Table/117/1/1/2/1
+Del (locking) /Table/117/1/1/1/1
+Del (locking) /Table/117/1/1/2/1
 fast path completed
 rows affected: 1
 
@@ -1100,7 +1100,7 @@ SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
 colbatchscan  Scan /Table/120/1/2/0 lock Exclusive (Block, Unreplicated)
 colbatchscan  fetched: /kv/kv_pkey/2/v -> /3
 count         Put /Table/120/1/2/0 -> /TUPLE/2:2:Int/2
-count         Del /Table/120/2/3/0
+count         Del (locking) /Table/120/2/3/0
 count         CPut /Table/120/2/2/0 -> /BYTES/0x8a
 sql query     execution failed after 0 rows: duplicate key value violates unique constraint "woo"
 

--- a/pkg/sql/opt/exec/factory.opt
+++ b/pkg/sql/opt/exec/factory.opt
@@ -624,6 +624,10 @@ define Delete {
     ReturnCols exec.TableColumnOrdinalSet
     Passthrough colinfo.ResultColumns
 
+    # If set, the input has already acquired the locks on the specified indexes
+    # on all keys that might be deleted from that index.
+    LockedIndexes cat.IndexOrdinals
+
     # If set, the operator will commit the transaction as part of its execution.
     # This is false when executing inside an explicit transaction, or there are
     # multiple mutations in a statement, or the output of the mutation is

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -1392,7 +1392,7 @@ func (ef *execFactory) ConstructShowTrace(typ tree.ShowTraceType, compact bool) 
 }
 
 func ordinalsToIndexes(table cat.Table, ords cat.IndexOrdinals) []catalog.Index {
-	if ords == nil {
+	if len(ords) == 0 {
 		return nil
 	}
 
@@ -1784,6 +1784,7 @@ func (ef *execFactory) ConstructDelete(
 	fetchColOrdSet exec.TableColumnOrdinalSet,
 	returnColOrdSet exec.TableColumnOrdinalSet,
 	passthrough colinfo.ResultColumns,
+	lockedIndexes cat.IndexOrdinals,
 	autoCommit bool,
 ) (exec.Node, error) {
 	// Derive table and column descriptors.
@@ -1796,6 +1797,7 @@ func (ef *execFactory) ConstructDelete(
 	rd := row.MakeDeleter(
 		ef.planner.ExecCfg().Codec,
 		tabDesc,
+		ordinalsToIndexes(table, lockedIndexes),
 		fetchCols,
 		&ef.planner.ExecCfg().Settings.SV,
 		internal,

--- a/pkg/sql/row/deleter.go
+++ b/pkg/sql/row/deleter.go
@@ -27,6 +27,13 @@ type Deleter struct {
 	FetchCols []catalog.Column
 	// FetchColIDtoRowIndex must be kept in sync with FetchCols.
 	FetchColIDtoRowIndex catalog.TableColMap
+	// primaryLocked, if true, indicates that no lock is needed when deleting
+	// from the primary index because the caller already acquired it.
+	primaryLocked bool
+	// secondaryLocked, if set, indicates that no lock is needed when deleting
+	// from this secondary index because the caller already acquired it.
+	secondaryLocked catalog.Index
+
 	// For allocation avoidance.
 	key         roachpb.Key
 	rawValueBuf []byte
@@ -39,9 +46,16 @@ type Deleter struct {
 // requestedCols is non-nil, then only the requested columns are included in
 // FetchCols; otherwise, all columns that are part of the key of any index
 // (either primary or secondary) are included in FetchCols.
+//
+// lockedIndexes describes the set of indexes such that any keys that might be
+// deleted from the index had already locks acquired on them. In other words,
+// the caller guarantees that the deleter has exclusive access to the keys in
+// these indexes. It is assumed that at most one secondary index is already
+// locked.
 func MakeDeleter(
 	codec keys.SQLCodec,
 	tableDesc catalog.TableDescriptor,
+	lockedIndexes []catalog.Index,
 	requestedCols []catalog.Column,
 	sv *settings.Values,
 	internal bool,
@@ -89,10 +103,24 @@ func MakeDeleter(
 		}
 	}
 
+	var primaryLocked bool
+	var secondaryLocked catalog.Index
+	for _, index := range lockedIndexes {
+		if index.Primary() {
+			primaryLocked = true
+		} else {
+			secondaryLocked = index
+		}
+	}
+	if len(lockedIndexes) > 1 && !primaryLocked {
+		panic(errors.AssertionFailedf("locked at least two secondary indexes in the initial scan: %v", lockedIndexes))
+	}
 	rd := Deleter{
 		Helper:               NewRowHelper(codec, tableDesc, indexes, nil /* uniqueWithTombstoneIndexes */, sv, internal, metrics),
 		FetchCols:            fetchCols,
 		FetchColIDtoRowIndex: fetchColIDtoRowIndex,
+		primaryLocked:        primaryLocked,
+		secondaryLocked:      secondaryLocked,
 	}
 
 	return rd
@@ -132,11 +160,9 @@ func (rd *Deleter) DeleteRow(
 		if err != nil {
 			return err
 		}
-		// TODO(yuzefovich): don't acquire the lock if we already locked this
-		// secondary index during the initial scan.
 		// TODO(yuzefovich): consider not acquiring the locks for non-unique
 		// indexes at all.
-		const needsLock = true
+		needsLock := rd.secondaryLocked == nil || rd.secondaryLocked.GetID() != index.GetID()
 		for _, e := range entries {
 			if err = rd.Helper.deleteIndexEntry(
 				ctx, b, index, &e.Key, needsLock, traceKV, rd.Helper.secIndexValDirs[i],
@@ -178,10 +204,7 @@ func (rd *Deleter) DeleteRow(
 			}
 			oth.DelWithCPut(ctx, b, &rd.key, expValue, traceKV)
 		} else {
-			// TODO(yuzefovich): don't acquire the lock if we already locked the
-			// primary during the initial scan.
-			const needsLock = true
-			delFn(ctx, b, &rd.key, needsLock, traceKV, rd.Helper.primIndexValDirs)
+			delFn(ctx, b, &rd.key, !rd.primaryLocked /* needsLock */, traceKV, rd.Helper.primIndexValDirs)
 		}
 
 		rd.key = nil

--- a/pkg/sql/row/deleter.go
+++ b/pkg/sql/row/deleter.go
@@ -160,9 +160,7 @@ func (rd *Deleter) DeleteRow(
 		if err != nil {
 			return err
 		}
-		// TODO(yuzefovich): consider not acquiring the locks for non-unique
-		// indexes at all.
-		needsLock := rd.secondaryLocked == nil || rd.secondaryLocked.GetID() != index.GetID()
+		needsLock := index.IsUnique() && (rd.secondaryLocked == nil || rd.secondaryLocked.GetID() != index.GetID())
 		for _, e := range entries {
 			if err = rd.Helper.deleteIndexEntry(
 				ctx, b, index, &e.Key, needsLock, traceKV, rd.Helper.secIndexValDirs[i],

--- a/pkg/sql/row/helper.go
+++ b/pkg/sql/row/helper.go
@@ -511,6 +511,8 @@ func (rh *RowHelper) deleteIndexEntry(
 			b.Put(key, deleteEncoding)
 		}
 	} else {
+		// TODO(yuzefovich): consider not acquiring the locks for non-unique
+		// indexes at all.
 		delFn(ctx, b, key, needsLock, traceKV, valDirs)
 	}
 	return nil

--- a/pkg/sql/row/helper.go
+++ b/pkg/sql/row/helper.go
@@ -11,7 +11,6 @@ import (
 	"sort"
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
-	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
@@ -460,30 +459,59 @@ var deleteEncoding protoutil.Message = &rowencpb.IndexValueWrapper{
 	Deleted: true,
 }
 
+func delFn(
+	ctx context.Context,
+	b Putter,
+	key *roachpb.Key,
+	needsLock bool,
+	traceKV bool,
+	keyEncodingDirs []encoding.Direction,
+) {
+	if needsLock {
+		if traceKV {
+			if keyEncodingDirs != nil {
+				log.VEventf(ctx, 2, "Del (locking) %s", keys.PrettyPrint(keyEncodingDirs, *key))
+			} else {
+				log.VEventf(ctx, 2, "Del (locking) %s", *key)
+			}
+		}
+		b.DelMustAcquireExclusiveLock(key)
+	} else {
+		if traceKV {
+			if keyEncodingDirs != nil {
+				log.VEventf(ctx, 2, "Del %s", keys.PrettyPrint(keyEncodingDirs, *key))
+			} else {
+				log.VEventf(ctx, 2, "Del %s", *key)
+			}
+		}
+		b.Del(key)
+	}
+}
+
 func (rh *RowHelper) deleteIndexEntry(
 	ctx context.Context,
-	batch *kv.Batch,
+	b Putter,
 	index catalog.Index,
-	valDirs []encoding.Direction,
-	entry *rowenc.IndexEntry,
+	key *roachpb.Key,
+	needsLock bool,
 	traceKV bool,
+	valDirs []encoding.Direction,
 ) error {
 	if index.UseDeletePreservingEncoding() {
 		if traceKV {
-			log.VEventf(ctx, 2, "Put (delete) %s", entry.Key)
-		}
-
-		batch.Put(entry.Key, deleteEncoding)
-	} else {
-		if traceKV {
-			if valDirs != nil {
-				log.VEventf(ctx, 2, "Del %s", keys.PrettyPrint(valDirs, entry.Key))
-			} else {
-				log.VEventf(ctx, 2, "Del %s", entry.Key)
+			var suffix string
+			if needsLock {
+				suffix = " (locking)"
 			}
+			log.VEventf(ctx, 2, "Put (delete)%s %s", suffix, *key)
 		}
-
-		batch.Del(entry.Key)
+		if needsLock {
+			b.PutMustAcquireExclusiveLock(key, deleteEncoding)
+		} else {
+			b.Put(key, deleteEncoding)
+		}
+	} else {
+		delFn(ctx, b, key, needsLock, traceKV, valDirs)
 	}
 	return nil
 }

--- a/pkg/sql/row/inserter.go
+++ b/pkg/sql/row/inserter.go
@@ -123,20 +123,6 @@ func insertPutMustAcquireExclusiveLockFn(
 	b.PutMustAcquireExclusiveLock(key, value)
 }
 
-// insertDelFn is used by insertRow to delete existing rows.
-func insertDelFn(
-	ctx context.Context,
-	b Putter,
-	key *roachpb.Key,
-	traceKV bool,
-	keyEncodingDirs []encoding.Direction,
-) {
-	if traceKV {
-		log.VEventfDepth(ctx, 1, 2, "Del %s", keys.PrettyPrint(keyEncodingDirs, *key))
-	}
-	b.Del(key)
-}
-
 func writeTombstones(
 	ctx context.Context,
 	helper *RowHelper,

--- a/pkg/sql/row/putter.go
+++ b/pkg/sql/row/putter.go
@@ -24,6 +24,7 @@ type Putter interface {
 	Put(key, value interface{})
 	PutMustAcquireExclusiveLock(key, value interface{})
 	Del(key ...interface{})
+	DelMustAcquireExclusiveLock(key ...interface{})
 
 	CPutBytesEmpty(kys []roachpb.Key, values [][]byte)
 	CPutValuesEmpty(kys []roachpb.Key, values []roachpb.Value)
@@ -65,6 +66,11 @@ func (t *TracePutter) PutMustAcquireExclusiveLock(key, value interface{}) {
 func (t *TracePutter) Del(key ...interface{}) {
 	log.VEventfDepth(t.Ctx, 1, 2, "Del %v", key...)
 	t.Putter.Del(key...)
+}
+
+func (t *TracePutter) DelMustAcquireExclusiveLock(key ...interface{}) {
+	log.VEventfDepth(t.Ctx, 1, 2, "Del (locking) %v", key...)
+	t.Putter.DelMustAcquireExclusiveLock(key...)
 }
 
 func (t *TracePutter) CPutBytesEmpty(kys []roachpb.Key, values [][]byte) {
@@ -193,6 +199,10 @@ func (s *SortingPutter) Del(key ...interface{}) {
 	s.Putter.Del(key...)
 }
 
+func (s *SortingPutter) DelMustAcquireExclusiveLock(key ...interface{}) {
+	s.Putter.DelMustAcquireExclusiveLock(key...)
+}
+
 func (s *SortingPutter) CPutBytesEmpty(kys []roachpb.Key, values [][]byte) {
 	kvs := KVBytes{Keys: kys, Values: values}
 	sort.Sort(&kvs)
@@ -288,6 +298,10 @@ func (k *KVBatchAdapter) PutMustAcquireExclusiveLock(key, value interface{}) {
 
 func (k *KVBatchAdapter) Del(key ...interface{}) {
 	k.Batch.Del(key...)
+}
+
+func (k *KVBatchAdapter) DelMustAcquireExclusiveLock(key ...interface{}) {
+	k.Batch.DelMustAcquireExclusiveLock(key...)
 }
 
 func (k *KVBatchAdapter) CPutBytesEmpty(kys []roachpb.Key, values [][]byte) {

--- a/pkg/sql/row/row_converter.go
+++ b/pkg/sql/row/row_converter.go
@@ -59,6 +59,11 @@ func (i KVInserter) Del(key ...interface{}) {
 	// empty).
 }
 
+// DelMustAcquireExclusiveLock is not implemented.
+func (i KVInserter) DelMustAcquireExclusiveLock(key ...interface{}) {
+	// See comment within Del for why this is a no-op.
+}
+
 // Put method of the row.Putter interface.
 func (i KVInserter) Put(key, value interface{}) {
 	i(roachpb.KeyValue{
@@ -67,16 +72,29 @@ func (i KVInserter) Put(key, value interface{}) {
 	})
 }
 
-func (c KVInserter) PutMustAcquireExclusiveLock(key, value interface{}) {}
+func (c KVInserter) PutMustAcquireExclusiveLock(key, value interface{}) {
+	panic(errors.AssertionFailedf("unimplemented"))
+}
 func (c KVInserter) CPutWithOriginTimestamp(
 	key, value interface{}, expValue []byte, ts hlc.Timestamp, shouldWinTie bool,
 ) {
+	panic(errors.AssertionFailedf("unimplemented"))
 }
-func (c KVInserter) CPutBytesEmpty(kys []roachpb.Key, values [][]byte)         {}
-func (c KVInserter) CPutTuplesEmpty(kys []roachpb.Key, values [][]byte)        {}
-func (c KVInserter) CPutValuesEmpty(kys []roachpb.Key, values []roachpb.Value) {}
-func (c KVInserter) PutBytes(kys []roachpb.Key, values [][]byte)               {}
-func (c KVInserter) PutTuples(kys []roachpb.Key, values [][]byte)              {}
+func (c KVInserter) CPutBytesEmpty(kys []roachpb.Key, values [][]byte) {
+	panic(errors.AssertionFailedf("unimplemented"))
+}
+func (c KVInserter) CPutTuplesEmpty(kys []roachpb.Key, values [][]byte) {
+	panic(errors.AssertionFailedf("unimplemented"))
+}
+func (c KVInserter) CPutValuesEmpty(kys []roachpb.Key, values []roachpb.Value) {
+	panic(errors.AssertionFailedf("unimplemented"))
+}
+func (c KVInserter) PutBytes(kys []roachpb.Key, values [][]byte) {
+	panic(errors.AssertionFailedf("unimplemented"))
+}
+func (c KVInserter) PutTuples(kys []roachpb.Key, values [][]byte) {
+	panic(errors.AssertionFailedf("unimplemented"))
+}
 
 // GenerateInsertRow prepares a row tuple for insertion. It fills in default
 // expressions, verifies non-nullable columns, and checks column widths.

--- a/pkg/sql/row/updater.go
+++ b/pkg/sql/row/updater.go
@@ -352,13 +352,13 @@ func (ru *Updater) UpdateRow(
 		}
 	}
 
-	putter := &KVBatchAdapter{Batch: batch}
+	b := &KVBatchAdapter{Batch: batch}
 	if rowPrimaryKeyChanged {
 		if err := ru.rd.DeleteRow(ctx, batch, oldValues, pm, oth, traceKV); err != nil {
 			return nil, err
 		}
 		if err := ru.ri.InsertRow(
-			ctx, putter, ru.newValues, pm, oth, CPutOp, traceKV,
+			ctx, b, ru.newValues, pm, oth, CPutOp, traceKV,
 		); err != nil {
 			return nil, err
 		}
@@ -367,7 +367,7 @@ func (ru *Updater) UpdateRow(
 	}
 
 	// Add the new values.
-	ru.valueBuf, err = prepareInsertOrUpdateBatch(ctx, putter,
+	ru.valueBuf, err = prepareInsertOrUpdateBatch(ctx, b,
 		&ru.Helper, primaryIndexKey, ru.FetchCols,
 		ru.newValues, ru.FetchColIDtoRowIndex,
 		ru.UpdateColIDtoRowIndex,
@@ -381,6 +381,8 @@ func (ru *Updater) UpdateRow(
 	// in the new and old values.
 	var writtenIndexes intsets.Fast
 	for i, index := range ru.Helper.Indexes {
+		// TODO(yuzefovich): think about this.
+		const needsLock = true
 		if index.GetType() == idxtype.FORWARD {
 			oldIdx, newIdx := 0, 0
 			oldEntries, newEntries := ru.oldIndexEntries[i], ru.newIndexEntries[i]
@@ -407,7 +409,7 @@ func (ru *Updater) UpdateRow(
 					newIdx++
 					var sameKey bool
 					if !bytes.Equal(oldEntry.Key, newEntry.Key) {
-						if err := ru.Helper.deleteIndexEntry(ctx, batch, index, ru.Helper.secIndexValDirs[i], oldEntry, traceKV); err != nil {
+						if err = ru.Helper.deleteIndexEntry(ctx, b, index, &oldEntry.Key, needsLock, traceKV, ru.Helper.secIndexValDirs[i]); err != nil {
 							return nil, err
 						}
 					} else if !newEntry.Value.EqualTagAndData(oldEntry.Value) {
@@ -425,9 +427,9 @@ func (ru *Updater) UpdateRow(
 
 					if index.ForcePut() || sameKey {
 						// See the comment on (catalog.Index).ForcePut() for more details.
-						insertPutFn(ctx, putter, &newEntry.Key, &newEntry.Value, traceKV, ru.Helper.secIndexValDirs[i])
+						insertPutFn(ctx, b, &newEntry.Key, &newEntry.Value, traceKV, ru.Helper.secIndexValDirs[i])
 					} else {
-						insertCPutFn(ctx, putter, &newEntry.Key, &newEntry.Value, traceKV, ru.Helper.secIndexValDirs[i])
+						insertCPutFn(ctx, b, &newEntry.Key, &newEntry.Value, traceKV, ru.Helper.secIndexValDirs[i])
 					}
 					writtenIndexes.Add(i)
 				} else if oldEntry.Family < newEntry.Family {
@@ -439,7 +441,7 @@ func (ru *Updater) UpdateRow(
 					}
 					// In this case, the index has a k/v for a family that does not exist in
 					// the new set of k/v's for the row. So, we need to delete the old k/v.
-					if err := ru.Helper.deleteIndexEntry(ctx, batch, index, ru.Helper.secIndexValDirs[i], oldEntry, traceKV); err != nil {
+					if err = ru.Helper.deleteIndexEntry(ctx, b, index, &oldEntry.Key, needsLock, traceKV, ru.Helper.secIndexValDirs[i]); err != nil {
 						return nil, err
 					}
 					oldIdx++
@@ -453,12 +455,12 @@ func (ru *Updater) UpdateRow(
 
 					if index.ForcePut() {
 						// See the comment on (catalog.Index).ForcePut() for more details.
-						insertPutFn(ctx, putter, &newEntry.Key, &newEntry.Value, traceKV, ru.Helper.secIndexValDirs[i])
+						insertPutFn(ctx, b, &newEntry.Key, &newEntry.Value, traceKV, ru.Helper.secIndexValDirs[i])
 					} else {
 						// In this case, the index now has a k/v that did not exist in the
 						// old row, so we should expect to not see a value for the new key,
 						// and put the new key in place.
-						insertCPutFn(ctx, putter, &newEntry.Key, &newEntry.Value, traceKV, ru.Helper.secIndexValDirs[i])
+						insertCPutFn(ctx, b, &newEntry.Key, &newEntry.Value, traceKV, ru.Helper.secIndexValDirs[i])
 					}
 					writtenIndexes.Add(i)
 					newIdx++
@@ -470,7 +472,7 @@ func (ru *Updater) UpdateRow(
 				// the new set of k/v's or 2) the index is a partial index and
 				// the new row values do not match the partial index predicate.
 				oldEntry := &oldEntries[oldIdx]
-				if err := ru.Helper.deleteIndexEntry(ctx, batch, index, ru.Helper.secIndexValDirs[i], oldEntry, traceKV); err != nil {
+				if err = ru.Helper.deleteIndexEntry(ctx, b, index, &oldEntry.Key, needsLock, traceKV, ru.Helper.secIndexValDirs[i]); err != nil {
 					return nil, err
 				}
 				oldIdx++
@@ -485,9 +487,9 @@ func (ru *Updater) UpdateRow(
 				newEntry := &newEntries[newIdx]
 				if index.ForcePut() {
 					// See the comment on (catalog.Index).ForcePut() for more details.
-					insertPutFn(ctx, putter, &newEntry.Key, &newEntry.Value, traceKV, ru.Helper.secIndexValDirs[i])
+					insertPutFn(ctx, b, &newEntry.Key, &newEntry.Value, traceKV, ru.Helper.secIndexValDirs[i])
 				} else {
-					insertCPutFn(ctx, putter, &newEntry.Key, &newEntry.Value, traceKV, ru.Helper.secIndexValDirs[i])
+					insertCPutFn(ctx, b, &newEntry.Key, &newEntry.Value, traceKV, ru.Helper.secIndexValDirs[i])
 				}
 				writtenIndexes.Add(i)
 				newIdx++
@@ -495,7 +497,7 @@ func (ru *Updater) UpdateRow(
 		} else {
 			// Remove all inverted index entries, and re-add them.
 			for j := range ru.oldIndexEntries[i] {
-				if err := ru.Helper.deleteIndexEntry(ctx, batch, index, nil /* valDirs */, &ru.oldIndexEntries[i][j], traceKV); err != nil {
+				if err = ru.Helper.deleteIndexEntry(ctx, b, index, &ru.oldIndexEntries[i][j].Key, needsLock, traceKV, nil /* valDirs */); err != nil {
 					return nil, err
 				}
 			}
@@ -503,9 +505,9 @@ func (ru *Updater) UpdateRow(
 			for j := range ru.newIndexEntries[i] {
 				if index.ForcePut() {
 					// See the comment on (catalog.Index).ForcePut() for more details.
-					insertPutFn(ctx, putter, &ru.newIndexEntries[i][j].Key, &ru.newIndexEntries[i][j].Value, traceKV, ru.Helper.secIndexValDirs[i])
+					insertPutFn(ctx, b, &ru.newIndexEntries[i][j].Key, &ru.newIndexEntries[i][j].Value, traceKV, ru.Helper.secIndexValDirs[i])
 				} else {
-					insertCPutFn(ctx, putter, &ru.newIndexEntries[i][j].Key, &ru.newIndexEntries[i][j].Value, traceKV, ru.Helper.secIndexValDirs[i])
+					insertCPutFn(ctx, b, &ru.newIndexEntries[i][j].Key, &ru.newIndexEntries[i][j].Value, traceKV, ru.Helper.secIndexValDirs[i])
 				}
 			}
 		}
@@ -513,7 +515,7 @@ func (ru *Updater) UpdateRow(
 
 	writtenIndexes.ForEach(func(idx int) {
 		if err == nil {
-			err = writeTombstones(ctx, &ru.Helper, ru.Helper.Indexes[idx], putter, ru.FetchColIDtoRowIndex, ru.newValues, traceKV)
+			err = writeTombstones(ctx, &ru.Helper, ru.Helper.Indexes[idx], b, ru.FetchColIDtoRowIndex, ru.newValues, traceKV)
 		}
 	})
 	if err != nil {
@@ -525,13 +527,14 @@ func (ru *Updater) UpdateRow(
 	if ru.DeleteHelper != nil {
 		// For determinism, add the entries for the secondary indexes in the same
 		// order as they appear in the helper.
-		for idx := range ru.DeleteHelper.Indexes {
-			index := ru.DeleteHelper.Indexes[idx]
+		for _, index := range ru.DeleteHelper.Indexes {
+			// TODO(yuzefovich): think about this.
+			const needsLock = true
 			deletedSecondaryIndexEntries, ok := deleteOldSecondaryIndexEntries[index]
 
 			if ok {
 				for _, deletedSecondaryIndexEntry := range deletedSecondaryIndexEntries {
-					if err := ru.DeleteHelper.deleteIndexEntry(ctx, batch, index, nil /* valDirs */, &deletedSecondaryIndexEntry, traceKV); err != nil {
+					if err = ru.DeleteHelper.deleteIndexEntry(ctx, b, index, &deletedSecondaryIndexEntry.Key, needsLock, traceKV, nil /* valDirs */); err != nil {
 						return nil, err
 					}
 				}

--- a/pkg/sql/row/updater.go
+++ b/pkg/sql/row/updater.go
@@ -177,7 +177,7 @@ func MakeUpdater(
 	if primaryKeyColChange {
 		// These fields are only used when the primary key is changing.
 		var err error
-		ru.rd = MakeDeleter(codec, tableDesc, requestedCols, sv, internal, metrics)
+		ru.rd = MakeDeleter(codec, tableDesc, nil /* lockedIndexes */, requestedCols, sv, internal, metrics)
 		if ru.ri, err = MakeInserter(
 			ctx, txn, codec, tableDesc, uniqueWithTombstoneIndexes, requestedCols, alloc, sv, internal, metrics,
 		); err != nil {

--- a/pkg/sql/row/writer.go
+++ b/pkg/sql/row/writer.go
@@ -200,7 +200,9 @@ func prepareInsertOrUpdateBatch(
 				} else if overwrite {
 					// If the new family contains a NULL value, then we must
 					// delete any pre-existing row.
-					insertDelFn(ctx, batch, kvKey, traceKV, helper.primIndexValDirs)
+					// TODO(yuzefovich): think about this.
+					const needsLock = true
+					delFn(ctx, batch, kvKey, needsLock, traceKV, helper.primIndexValDirs)
 				}
 			} else {
 				// We only output non-NULL values. Non-existent column keys are
@@ -261,7 +263,9 @@ func prepareInsertOrUpdateBatch(
 			} else if overwrite {
 				// The family might have already existed but every column in it is being
 				// set to NULL, so delete it.
-				insertDelFn(ctx, batch, kvKey, traceKV, helper.primIndexValDirs)
+				// TODO(yuzefovich): think about this.
+				const needsLock = true
+				delFn(ctx, batch, kvKey, needsLock, traceKV, helper.primIndexValDirs)
 			}
 		} else {
 			// Copy the contents of rawValueBuf into the roachpb.Value. This is

--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -2772,8 +2772,8 @@ CREATE TABLE t.test (
 	SET TRACING=off;
 	SELECT message FROM [SHOW KV TRACE FOR SESSION]
         WHERE
-		message LIKE 'Del %[1]s%%' OR
-                message LIKE 'Put (delete) %[1]s%%'
+		message LIKE 'Del %%%[1]s%%' OR
+                message LIKE 'Put (delete)%% %[1]s%%'
         ORDER BY message;`, tablePrefixStr))
 	if err != nil {
 		t.Fatal(err)
@@ -2781,18 +2781,18 @@ CREATE TABLE t.test (
 
 	expected = []string{
 		// Primary index should see this delete.
-		fmt.Sprintf("Del %s/1/1/0", tablePrefixStr),
-		fmt.Sprintf("Del %s/1/1/1/1", tablePrefixStr),
-		fmt.Sprintf("Del %s/1/1/2/1", tablePrefixStr),
-		fmt.Sprintf("Del %s/1/1/3/1", tablePrefixStr),
-		fmt.Sprintf("Del %s/1/1/4/1", tablePrefixStr),
+		fmt.Sprintf("Del (locking) %s/1/1/0", tablePrefixStr),
+		fmt.Sprintf("Del (locking) %s/1/1/1/1", tablePrefixStr),
+		fmt.Sprintf("Del (locking) %s/1/1/2/1", tablePrefixStr),
+		fmt.Sprintf("Del (locking) %s/1/1/3/1", tablePrefixStr),
+		fmt.Sprintf("Del (locking) %s/1/1/4/1", tablePrefixStr),
 
 		// The temporary indexes are delete-preserving -- they
 		// should see the delete and issue Puts.
-		fmt.Sprintf("Put (delete) %s/5/2/0", tablePrefixStr),
-		fmt.Sprintf("Put (delete) %s/5/2/2/1", tablePrefixStr),
-		fmt.Sprintf("Put (delete) %s/5/2/3/1", tablePrefixStr),
-		fmt.Sprintf("Put (delete) %s/5/2/4/1", tablePrefixStr),
+		fmt.Sprintf("Put (delete) (locking) %s/5/2/0", tablePrefixStr),
+		fmt.Sprintf("Put (delete) (locking) %s/5/2/2/1", tablePrefixStr),
+		fmt.Sprintf("Put (delete) (locking) %s/5/2/3/1", tablePrefixStr),
+		fmt.Sprintf("Put (delete) (locking) %s/5/2/4/1", tablePrefixStr),
 	}
 	require.Equal(t, expected, scanToArray(rows))
 
@@ -2804,7 +2804,7 @@ CREATE TABLE t.test (
 	SET TRACING=off;
 	SELECT message FROM [SHOW KV TRACE FOR SESSION] WHERE
 		message LIKE 'Put %[1]s/%%' OR
-		message LIKE 'Del %[1]s/%%' OR
+		message LIKE 'Del %%%[1]s/%%' OR
 		message LIKE 'CPut %[1]s/%%';`, tablePrefixStr))
 	if err != nil {
 		t.Fatal(err)
@@ -2828,7 +2828,7 @@ CREATE TABLE t.test (
 	SET TRACING=off;
 	SELECT message FROM [SHOW KV TRACE FOR SESSION] WHERE
 		message LIKE 'Put %[1]s/%%' OR
-		message LIKE 'Del %[1]s/%%' OR
+		message LIKE 'Del %%%[1]s/%%' OR
 		message LIKE 'CPut %[1]s/2%%';`, tablePrefixStr))
 	if err != nil {
 		t.Fatal(err)
@@ -2836,9 +2836,9 @@ CREATE TABLE t.test (
 
 	expected = []string{
 
-		fmt.Sprintf("Del %s/1/1/2/1", tablePrefixStr),
+		fmt.Sprintf("Del (locking) %s/1/1/2/1", tablePrefixStr),
 		fmt.Sprintf("Put %s/1/1/3/1 -> /INT/5", tablePrefixStr),
-		fmt.Sprintf("Del %s/1/1/4/1", tablePrefixStr),
+		fmt.Sprintf("Del (locking) %s/1/1/4/1", tablePrefixStr),
 		// The temporary index sees a Put in all families even though
 		// only some are changing. This is expected.
 		fmt.Sprintf("Put %s/5/3/0 -> /BYTES/0x0a030a1302", tablePrefixStr),

--- a/pkg/sql/testdata/index_mutations/delete_preserving_delete
+++ b/pkg/sql/testdata/index_mutations/delete_preserving_delete
@@ -23,7 +23,7 @@ DELETE FROM ti WHERE a = 1
 ----
 Scan /Table/106/1/1/0 lock Exclusive (Block, Unreplicated)
 Put (delete) (locking) /Table/106/2/2/100/1/0
-Del (locking) /Table/106/1/1/0
+Del /Table/106/1/1/0
 
 # ---------------------------------------------------------
 # Partial Index With Delete Preserving Encoding
@@ -50,7 +50,7 @@ kvtrace
 DELETE FROM tpi WHERE a = 1
 ----
 Scan /Table/107/1/1/0 lock Exclusive (Block, Unreplicated)
-Del (locking) /Table/107/1/1/0
+Del /Table/107/1/1/0
 
 # Delete a row that matches the partial index.
 kvtrace
@@ -58,7 +58,7 @@ DELETE FROM tpi WHERE a = 3
 ----
 Scan /Table/107/1/3/0 lock Exclusive (Block, Unreplicated)
 Put (delete) (locking) /Table/107/2/"foo"/3/0
-Del (locking) /Table/107/1/3/0
+Del /Table/107/1/3/0
 
 # ---------------------------------------------------------
 # Expression Index With Delete Preserving Encoding
@@ -115,7 +115,7 @@ Put (delete) (locking) /Table/109/2/NULL/1/0
 Put (delete) (locking) /Table/109/2/1/1/0
 Put (delete) (locking) /Table/109/2/2/1/0
 Put (delete) (locking) /Table/109/2/3/1/0
-Del (locking) /Table/109/1/1/0
+Del /Table/109/1/1/0
 
 # ---------------------------------------------------------
 # Multicolumn Inverted Index With Delete Preserving Encoding
@@ -144,4 +144,4 @@ DELETE FROM tmi WHERE a = 1
 Scan /Table/110/1/1/0 lock Exclusive (Block, Unreplicated)
 Put (delete) (locking) /Table/110/2/2/"a"/"foo"/1/0
 Put (delete) (locking) /Table/110/2/2/"b"/"bar"/1/0
-Del (locking) /Table/110/1/1/0
+Del /Table/110/1/1/0

--- a/pkg/sql/testdata/index_mutations/delete_preserving_delete
+++ b/pkg/sql/testdata/index_mutations/delete_preserving_delete
@@ -22,7 +22,7 @@ kvtrace
 DELETE FROM ti WHERE a = 1
 ----
 Scan /Table/106/1/1/0 lock Exclusive (Block, Unreplicated)
-Put (delete) (locking) /Table/106/2/2/100/1/0
+Put (delete) /Table/106/2/2/100/1/0
 Del /Table/106/1/1/0
 
 # ---------------------------------------------------------
@@ -57,7 +57,7 @@ kvtrace
 DELETE FROM tpi WHERE a = 3
 ----
 Scan /Table/107/1/3/0 lock Exclusive (Block, Unreplicated)
-Put (delete) (locking) /Table/107/2/"foo"/3/0
+Put (delete) /Table/107/2/"foo"/3/0
 Del /Table/107/1/3/0
 
 # ---------------------------------------------------------
@@ -84,7 +84,7 @@ kvtrace
 DELETE FROM tei WHERE a + b = 102
 ----
 Scan /Table/108/{1-2}
-Put (delete) (locking) /Table/108/2/102/1/0
+Put (delete) /Table/108/2/102/1/0
 Del (locking) /Table/108/1/1/0
 
 # ---------------------------------------------------------
@@ -111,10 +111,10 @@ kvtrace
 DELETE FROM tii WHERE a = 1
 ----
 Scan /Table/109/1/1/0 lock Exclusive (Block, Unreplicated)
-Put (delete) (locking) /Table/109/2/NULL/1/0
-Put (delete) (locking) /Table/109/2/1/1/0
-Put (delete) (locking) /Table/109/2/2/1/0
-Put (delete) (locking) /Table/109/2/3/1/0
+Put (delete) /Table/109/2/NULL/1/0
+Put (delete) /Table/109/2/1/1/0
+Put (delete) /Table/109/2/2/1/0
+Put (delete) /Table/109/2/3/1/0
 Del /Table/109/1/1/0
 
 # ---------------------------------------------------------
@@ -142,6 +142,6 @@ kvtrace
 DELETE FROM tmi WHERE a = 1
 ----
 Scan /Table/110/1/1/0 lock Exclusive (Block, Unreplicated)
-Put (delete) (locking) /Table/110/2/2/"a"/"foo"/1/0
-Put (delete) (locking) /Table/110/2/2/"b"/"bar"/1/0
+Put (delete) /Table/110/2/2/"a"/"foo"/1/0
+Put (delete) /Table/110/2/2/"b"/"bar"/1/0
 Del /Table/110/1/1/0

--- a/pkg/sql/testdata/index_mutations/delete_preserving_delete
+++ b/pkg/sql/testdata/index_mutations/delete_preserving_delete
@@ -22,8 +22,8 @@ kvtrace
 DELETE FROM ti WHERE a = 1
 ----
 Scan /Table/106/1/1/0 lock Exclusive (Block, Unreplicated)
-Put (delete) /Table/106/2/2/100/1/0
-Del /Table/106/1/1/0
+Put (delete) (locking) /Table/106/2/2/100/1/0
+Del (locking) /Table/106/1/1/0
 
 # ---------------------------------------------------------
 # Partial Index With Delete Preserving Encoding
@@ -50,15 +50,15 @@ kvtrace
 DELETE FROM tpi WHERE a = 1
 ----
 Scan /Table/107/1/1/0 lock Exclusive (Block, Unreplicated)
-Del /Table/107/1/1/0
+Del (locking) /Table/107/1/1/0
 
 # Delete a row that matches the partial index.
 kvtrace
 DELETE FROM tpi WHERE a = 3
 ----
 Scan /Table/107/1/3/0 lock Exclusive (Block, Unreplicated)
-Put (delete) /Table/107/2/"foo"/3/0
-Del /Table/107/1/3/0
+Put (delete) (locking) /Table/107/2/"foo"/3/0
+Del (locking) /Table/107/1/3/0
 
 # ---------------------------------------------------------
 # Expression Index With Delete Preserving Encoding
@@ -84,8 +84,8 @@ kvtrace
 DELETE FROM tei WHERE a + b = 102
 ----
 Scan /Table/108/{1-2}
-Put (delete) /Table/108/2/102/1/0
-Del /Table/108/1/1/0
+Put (delete) (locking) /Table/108/2/102/1/0
+Del (locking) /Table/108/1/1/0
 
 # ---------------------------------------------------------
 # Inverted Index With Delete Preserving Encoding
@@ -111,11 +111,11 @@ kvtrace
 DELETE FROM tii WHERE a = 1
 ----
 Scan /Table/109/1/1/0 lock Exclusive (Block, Unreplicated)
-Put (delete) /Table/109/2/NULL/1/0
-Put (delete) /Table/109/2/1/1/0
-Put (delete) /Table/109/2/2/1/0
-Put (delete) /Table/109/2/3/1/0
-Del /Table/109/1/1/0
+Put (delete) (locking) /Table/109/2/NULL/1/0
+Put (delete) (locking) /Table/109/2/1/1/0
+Put (delete) (locking) /Table/109/2/2/1/0
+Put (delete) (locking) /Table/109/2/3/1/0
+Del (locking) /Table/109/1/1/0
 
 # ---------------------------------------------------------
 # Multicolumn Inverted Index With Delete Preserving Encoding
@@ -142,6 +142,6 @@ kvtrace
 DELETE FROM tmi WHERE a = 1
 ----
 Scan /Table/110/1/1/0 lock Exclusive (Block, Unreplicated)
-Put (delete) /Table/110/2/2/"a"/"foo"/1/0
-Put (delete) /Table/110/2/2/"b"/"bar"/1/0
-Del /Table/110/1/1/0
+Put (delete) (locking) /Table/110/2/2/"a"/"foo"/1/0
+Put (delete) (locking) /Table/110/2/2/"b"/"bar"/1/0
+Del (locking) /Table/110/1/1/0

--- a/pkg/sql/testdata/index_mutations/delete_preserving_unique_index
+++ b/pkg/sql/testdata/index_mutations/delete_preserving_unique_index
@@ -24,8 +24,8 @@ kvtrace
 DELETE FROM ti WHERE a = 1
 ----
 Scan /Table/106/1/1/0 lock Exclusive (Block, Unreplicated)
-Put (delete) /Table/106/2/1/100/0
-Del /Table/106/1/1/0
+Put (delete) (locking) /Table/106/2/1/100/0
+Del (locking) /Table/106/1/1/0
 
 kvtrace
 INSERT INTO ti VALUES (1, 1, 100)
@@ -47,7 +47,7 @@ UPDATE ti SET c = 1 WHERE a = 2
 ----
 Scan /Table/106/1/2/0 lock Exclusive (Block, Unreplicated)
 Put /Table/106/1/2/0 -> /TUPLE/2:2:Int/2/1:3:Int/1
-Put (delete) /Table/106/2/2/200/0
+Put (delete) (locking) /Table/106/2/2/200/0
 
 kvtrace
 UPDATE ti SET c = 200 WHERE a = 2

--- a/pkg/sql/testdata/index_mutations/delete_preserving_unique_index
+++ b/pkg/sql/testdata/index_mutations/delete_preserving_unique_index
@@ -25,7 +25,7 @@ DELETE FROM ti WHERE a = 1
 ----
 Scan /Table/106/1/1/0 lock Exclusive (Block, Unreplicated)
 Put (delete) (locking) /Table/106/2/1/100/0
-Del (locking) /Table/106/1/1/0
+Del /Table/106/1/1/0
 
 kvtrace
 INSERT INTO ti VALUES (1, 1, 100)

--- a/pkg/sql/testdata/index_mutations/delete_preserving_update
+++ b/pkg/sql/testdata/index_mutations/delete_preserving_update
@@ -23,7 +23,7 @@ UPDATE ti SET b = b + 1, c = c + 1
 ----
 Scan /Table/106/{1-2} lock Exclusive (Block, Unreplicated)
 Put /Table/106/1/1/0 -> /TUPLE/2:2:Int/3/1:3:Int/101
-Put (delete) /Table/106/2/2/100/1/0
+Put (delete) (locking) /Table/106/2/2/100/1/0
 Put /Table/106/2/3/101/1/0 -> /BYTES/0x0a0103
 
 # ---------------------------------------------------------
@@ -78,7 +78,7 @@ UPDATE tpi SET b = b + 1, c = 'foobar'
 ----
 Scan /Table/107/{1-2} lock Exclusive (Block, Unreplicated)
 Put /Table/107/1/3/0 -> /TUPLE/2:2:Int/2/1:3:Bytes/foobar
-Put (delete) /Table/107/2/"foo"/3/0
+Put (delete) (locking) /Table/107/2/"foo"/3/0
 Put /Table/107/2/"foobar"/3/0 -> /BYTES/0x0a0103
 
 # Update a row that matches the partial index before but not after.
@@ -87,7 +87,7 @@ UPDATE tpi SET c = 'baz'
 ----
 Scan /Table/107/{1-2} lock Exclusive (Block, Unreplicated)
 Put /Table/107/1/3/0 -> /TUPLE/2:2:Int/2/1:3:Bytes/baz
-Put (delete) /Table/107/2/"foobar"/3/0
+Put (delete) (locking) /Table/107/2/"foobar"/3/0
 
 # ---------------------------------------------------------
 # Expression Index With Delete Preserving Encoding
@@ -115,7 +115,7 @@ UPDATE tei SET a = a + 1, b = b + 100
 ----
 Scan /Table/108/{1-2} lock Exclusive (Block, Unreplicated)
 Put /Table/108/1/1/0 -> /TUPLE/2:2:Int/3/1:3:Int/200
-Put (delete) /Table/108/2/102/1/0
+Put (delete) (locking) /Table/108/2/102/1/0
 Put /Table/108/2/203/1/0 -> /BYTES/0x0a0103
 
 # Update a row with different values without changing the expected index entry.
@@ -153,10 +153,10 @@ UPDATE tii SET b = ARRAY[1, 2, 2, NULL, 4, 4]
 ----
 Scan /Table/109/{1-2} lock Exclusive (Block, Unreplicated)
 Put /Table/109/1/1/0 -> /TUPLE/2:2:Array/ARRAY[1,2,2,NULL,4,4]
-Put (delete) /Table/109/2/NULL/1/0
-Put (delete) /Table/109/2/1/1/0
-Put (delete) /Table/109/2/2/1/0
-Put (delete) /Table/109/2/3/1/0
+Put (delete) (locking) /Table/109/2/NULL/1/0
+Put (delete) (locking) /Table/109/2/1/1/0
+Put (delete) (locking) /Table/109/2/2/1/0
+Put (delete) (locking) /Table/109/2/3/1/0
 Put /Table/109/2/NULL/1/0 -> /BYTES/0x0a0103
 Put /Table/109/2/1/1/0 -> /BYTES/0x0a0103
 Put /Table/109/2/2/1/0 -> /BYTES/0x0a0103
@@ -188,7 +188,7 @@ UPDATE tmi SET b = 3, c = '{"a": "foobar", "c": "baz"}'::json
 ----
 Scan /Table/110/{1-2} lock Exclusive (Block, Unreplicated)
 Put /Table/110/1/1/0 -> /TUPLE/2:2:Int/3/1:3:SentinelType/{"a": "foobar", "c": "baz"}
-Put (delete) /Table/110/2/2/"a"/"foo"/1/0
-Put (delete) /Table/110/2/2/"b"/"bar"/1/0
+Put (delete) (locking) /Table/110/2/2/"a"/"foo"/1/0
+Put (delete) (locking) /Table/110/2/2/"b"/"bar"/1/0
 Put /Table/110/2/3/"a"/"foobar"/1/0 -> /BYTES/0x0a0103
 Put /Table/110/2/3/"c"/"baz"/1/0 -> /BYTES/0x0a0103

--- a/pkg/sql/testdata/index_mutations/delete_preserving_upsert
+++ b/pkg/sql/testdata/index_mutations/delete_preserving_upsert
@@ -23,7 +23,7 @@ UPSERT INTO ti VALUES (1, 3, 101)
 ----
 Scan /Table/106/1/1/0 lock Exclusive (Block, Unreplicated)
 Put /Table/106/1/1/0 -> /TUPLE/2:2:Int/3/1:3:Int/101
-Put (delete) /Table/106/2/2/100/1/0
+Put (delete) (locking) /Table/106/2/2/100/1/0
 Put /Table/106/2/3/101/1/0 -> /BYTES/0x0a0103
 
 # ---------------------------------------------------------
@@ -78,7 +78,7 @@ UPSERT INTO tpi VALUES (3, 2, 'foobar')
 ----
 Scan /Table/107/1/3/0 lock Exclusive (Block, Unreplicated)
 Put /Table/107/1/3/0 -> /TUPLE/2:2:Int/2/1:3:Bytes/foobar
-Put (delete) /Table/107/2/"foo"/3/0
+Put (delete) (locking) /Table/107/2/"foo"/3/0
 Put /Table/107/2/"foobar"/3/0 -> /BYTES/0x0a0103
 
 # Upsert a row that matches the partial index before but not after.
@@ -87,7 +87,7 @@ UPSERT INTO tpi VALUES (3, 1, 'baz')
 ----
 Scan /Table/107/1/3/0 lock Exclusive (Block, Unreplicated)
 Put /Table/107/1/3/0 -> /TUPLE/2:2:Int/1/1:3:Bytes/baz
-Put (delete) /Table/107/2/"foobar"/3/0
+Put (delete) (locking) /Table/107/2/"foobar"/3/0
 
 # ---------------------------------------------------------
 # Expression Index With Delete Preserving Encoding
@@ -115,7 +115,7 @@ UPSERT INTO tei VALUES (1, 3, 500)
 ----
 Scan /Table/108/1/1/0
 Put /Table/108/1/1/0 -> /TUPLE/2:2:Int/3/1:3:Int/500
-Put (delete) /Table/108/2/102/1/0
+Put (delete) (locking) /Table/108/2/102/1/0
 Put /Table/108/2/503/1/0 -> /BYTES/0x0a0103
 
 # Upsert a row with different values without changing the index entry.
@@ -132,7 +132,7 @@ UPSERT INTO tei VALUES (2, 4, 499)
 ----
 Scan /Table/108/1/2/0
 Put /Table/108/1/2/0 -> /TUPLE/2:2:Int/4/1:3:Int/499
-Put (delete) /Table/108/2/203/2/0
+Put (delete) (locking) /Table/108/2/203/2/0
 Put /Table/108/2/503/2/0 -> /BYTES/0x0a0103
 
 # ---------------------------------------------------------
@@ -161,10 +161,10 @@ UPSERT INTO tii VALUES (1, ARRAY[1, 2, 2, NULL, 4, 4])
 ----
 Scan /Table/109/1/1/0 lock Exclusive (Block, Unreplicated)
 Put /Table/109/1/1/0 -> /TUPLE/2:2:Array/ARRAY[1,2,2,NULL,4,4]
-Put (delete) /Table/109/2/NULL/1/0
-Put (delete) /Table/109/2/1/1/0
-Put (delete) /Table/109/2/2/1/0
-Put (delete) /Table/109/2/3/1/0
+Put (delete) (locking) /Table/109/2/NULL/1/0
+Put (delete) (locking) /Table/109/2/1/1/0
+Put (delete) (locking) /Table/109/2/2/1/0
+Put (delete) (locking) /Table/109/2/3/1/0
 Put /Table/109/2/NULL/1/0 -> /BYTES/0x0a0103
 Put /Table/109/2/1/1/0 -> /BYTES/0x0a0103
 Put /Table/109/2/2/1/0 -> /BYTES/0x0a0103
@@ -195,8 +195,8 @@ UPSERT INTO tmi VALUES (1, 3, '{"a": "foobar", "c": "baz"}'::json)
 ----
 Scan /Table/110/1/1/0 lock Exclusive (Block, Unreplicated)
 Put /Table/110/1/1/0 -> /TUPLE/2:2:Int/3/1:3:SentinelType/{"a": "foobar", "c": "baz"}
-Put (delete) /Table/110/2/2/"a"/"foo"/1/0
-Put (delete) /Table/110/2/2/"b"/"bar"/1/0
+Put (delete) (locking) /Table/110/2/2/"a"/"foo"/1/0
+Put (delete) (locking) /Table/110/2/2/"b"/"bar"/1/0
 Put /Table/110/2/3/"a"/"foobar"/1/0 -> /BYTES/0x0a0103
 Put /Table/110/2/3/"c"/"baz"/1/0 -> /BYTES/0x0a0103
 
@@ -229,7 +229,7 @@ UPSERT INTO tui VALUES (1, 3, 200)
 ----
 Scan /Table/111/1/1/0 lock Exclusive (Block, Unreplicated)
 Put /Table/111/1/1/0 -> /TUPLE/2:2:Int/3/1:3:Int/200
-Put (delete) /Table/111/2/2/100/0
+Put (delete) (locking) /Table/111/2/2/100/0
 Put /Table/111/2/3/200/0 -> /BYTES/0x0a020389
 
 # ---------------------------------------------------------------
@@ -260,7 +260,7 @@ UPSERT INTO mcf VALUES (1, 1, 'baz')
 Scan /Table/112/1/{1-2} lock Exclusive (Block, Unreplicated)
 Put /Table/112/1/1/0 -> /TUPLE/2:2:Int/1
 Put /Table/112/1/1/1/1 -> /BYTES/baz
-Put (delete) /Table/112/2/2/1/0
+Put (delete) (locking) /Table/112/2/2/1/0
 Put /Table/112/2/1/1/0 -> /BYTES/0x0a0103
 
 # Upsert a row that changes the second family but not the first

--- a/pkg/sql/testdata/index_mutations/merging
+++ b/pkg/sql/testdata/index_mutations/merging
@@ -30,7 +30,7 @@ UPDATE ti SET b = 2 WHERE a = 4
 ----
 Scan /Table/106/1/4/0 lock Exclusive (Block, Unreplicated)
 Put /Table/106/1/4/0 -> /TUPLE/2:2:Int/2
-Del /Table/106/2/4/0
+Del (locking) /Table/106/2/4/0
 Put /Table/106/2/2/0 -> /BYTES/0x8c
 
 kvtrace
@@ -45,7 +45,7 @@ UPSERT INTO ti VALUES (2, 1)
 ----
 Scan /Table/106/1/2/0 lock Exclusive (Block, Unreplicated)
 Put /Table/106/1/2/0 -> /TUPLE/2:2:Int/1
-Del /Table/106/2/2/0
+Del (locking) /Table/106/2/2/0
 Put /Table/106/2/1/0 -> /BYTES/0x8a
 
 kvtrace
@@ -60,7 +60,7 @@ INSERT INTO ti VALUES (1, 2) ON CONFLICT (a) DO UPDATE SET b = excluded.b
 ----
 Scan /Table/106/1/1/0 lock Exclusive (Block, Unreplicated)
 Put /Table/106/1/1/0 -> /TUPLE/2:2:Int/2
-Del /Table/106/2/1/0
+Del (locking) /Table/106/2/1/0
 Put /Table/106/2/2/0 -> /BYTES/0x89
 
 # ---------------------------------------------------------
@@ -113,7 +113,7 @@ UPDATE tpfp SET b = b + 1, c = 'foobar'
 ----
 Scan /Table/107/{1-2} lock Exclusive (Block, Unreplicated)
 Put /Table/107/1/3/0 -> /TUPLE/2:2:Int/2/1:3:Bytes/foobar
-Del /Table/107/2/"foo"/0
+Del (locking) /Table/107/2/"foo"/0
 Put /Table/107/2/"foobar"/0 -> /BYTES/0x8b
 
 # Update a row that matches the partial index before but not after.
@@ -122,7 +122,7 @@ UPDATE tpfp SET c = 'baz'
 ----
 Scan /Table/107/{1-2} lock Exclusive (Block, Unreplicated)
 Put /Table/107/1/3/0 -> /TUPLE/2:2:Int/2/1:3:Bytes/baz
-Del /Table/107/2/"foobar"/0
+Del (locking) /Table/107/2/"foobar"/0
 
 # ---------------------------------------------------------
 # Expression Index With ForcePut
@@ -147,7 +147,7 @@ UPDATE tefp SET a = a + 1, b = b + 100
 ----
 Scan /Table/108/{1-2} lock Exclusive (Block, Unreplicated)
 Put /Table/108/1/1/0 -> /TUPLE/2:2:Int/3/1:3:Int/200
-Del /Table/108/2/102/0
+Del (locking) /Table/108/2/102/0
 CPut /Table/108/2/203/0 -> /BYTES/0x89
 
 # Update a row with different values without changing the index entry.
@@ -183,7 +183,7 @@ UPDATE tifp SET b = ARRAY[1, 2, 2, NULL, 4, 4]
 ----
 Scan /Table/109/{1-2} lock Exclusive (Block, Unreplicated)
 Put /Table/109/1/1/0 -> /TUPLE/2:2:Array/ARRAY[1,2,2,NULL,4,4]
-Del /Table/109/2/3/1/0
+Del (locking) /Table/109/2/3/1/0
 Put /Table/109/2/4/1/0 -> /BYTES/
 
 # ---------------------------------------------------------
@@ -211,7 +211,7 @@ UPDATE tmfp SET b = 3, c = '{"a": "foobar", "c": "baz"}'::json
 ----
 Scan /Table/110/{1-2} lock Exclusive (Block, Unreplicated)
 Put /Table/110/1/1/0 -> /TUPLE/2:2:Int/3/1:3:SentinelType/{"a": "foobar", "c": "baz"}
-Del /Table/110/2/2/"a"/"foo"/1/0
-Del /Table/110/2/2/"b"/"bar"/1/0
+Del (locking) /Table/110/2/2/"a"/"foo"/1/0
+Del (locking) /Table/110/2/2/"b"/"bar"/1/0
 Put /Table/110/2/3/"a"/"foobar"/1/0 -> /BYTES/
 Put /Table/110/2/3/"c"/"baz"/1/0 -> /BYTES/


### PR DESCRIPTION
This PR contains several commits to acquire locks on `Del`s. It starts by requiring locks on every usage, and then we'll skip lock acquisition when safe, and this PR does that in two cases that relate to DELETEs:
- when the lock was acquired over the relevant index during the initial scan
- when deleting from non-unique secondary indexes.

Usage of `Del`s for UPDATEs and UPSERTs will be optimized separately.

Informs: #139106.
Informs: #139160.
Epic: None
Release note: None