### PR TITLE
microbench-ci: merge profiles

### DIFF
--- a/pkg/cmd/microbench-ci/BUILD.bazel
+++ b/pkg/cmd/microbench-ci/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "//pkg/cmd/roachprod-microbench/parser",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_google_go_github_v61//github",
+        "@com_github_google_pprof//profile",
         "@com_github_spf13_cobra//:cobra",
         "@in_gopkg_yaml_v2//:yaml_v2",
         "@org_golang_x_exp//maps",
@@ -42,6 +43,7 @@ go_test(
     deps = [
         "//pkg/testutils/datapathutils",
         "@com_github_cockroachdb_datadriven//:datadriven",
+        "@com_github_google_pprof//profile",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/cmd/microbench-ci/config/pull-request-suite.yml
+++ b/pkg/cmd/microbench-ci/config/pull-request-suite.yml
@@ -4,9 +4,8 @@ benchmarks:
     name: "BenchmarkSysbench/SQL/3node/oltp_read_write"
     package: "pkg/sql/tests"
     runner_group: 1
-    measure_count: 10
-    measure:
-      iterations: 3000
+    count: 10
+    iterations: 3000
     thresholds:
       "sec/op": .03
       "B/op": .02
@@ -17,9 +16,8 @@ benchmarks:
     name: "BenchmarkSysbench/KV/1node_local/oltp_read_only"
     package: "pkg/sql/tests"
     runner_group: 2
-    measure_count: 10
-    measure:
-      iterations: 12000
+    count: 10
+    iterations: 12000
     thresholds:
       "sec/op": .02
       "B/op": .015
@@ -30,9 +28,8 @@ benchmarks:
     name: "BenchmarkSysbench/KV/1node_local/oltp_write_only"
     package: "pkg/sql/tests"
     runner_group: 2
-    measure_count: 10
-    measure:
-      iterations: 12000
+    count: 10
+    iterations: 12000
     thresholds:
       "sec/op": .025
       "B/op": .0175

--- a/pkg/cmd/microbench-ci/testdata/summary.txt
+++ b/pkg/cmd/microbench-ci/testdata/summary.txt
@@ -6,9 +6,8 @@ benchmarks:
     name: "BenchmarkSysbench/SQL/3node/oltp_read_write"
     package: "pkg/sql/tests"
     runner_group: 1
-    measure_count: 10
-    measure:
-      iterations: 3000
+    count: 10
+    iterations: 3000
     thresholds:
       "sec/op": .03
       "B/op": .02
@@ -100,5 +99,28 @@ gcloud storage cp gs://cockroach-microbench-ci/artifacts/abcdef123//\* old/
 No regressions detected!
 
 _built with commit: [qwerty456](https://github.com/cockroachdb/cockroach/commit/qwerty456)_
+----
+----
+
+tree
+----
+----
+
+/abcdef123
+/abcdef123/artifacts
+/abcdef123/artifacts/cleaned_Sysbench_SQL_3node_oltp_read_write.log
+/abcdef123/artifacts/cpu_Sysbench_SQL_3node_oltp_read_write_merged.prof
+/abcdef123/artifacts/memory_Sysbench_SQL_3node_oltp_read_write_merged.prof
+/abcdef123/artifacts/mutex_Sysbench_SQL_3node_oltp_read_write_merged.prof
+/abcdef123/artifacts/raw_Sysbench_SQL_3node_oltp_read_write.log
+/github-summary.md
+/qwerty456
+/qwerty456/artifacts
+/qwerty456/artifacts/cleaned_Sysbench_SQL_3node_oltp_read_write.log
+/qwerty456/artifacts/cpu_Sysbench_SQL_3node_oltp_read_write_merged.prof
+/qwerty456/artifacts/memory_Sysbench_SQL_3node_oltp_read_write_merged.prof
+/qwerty456/artifacts/mutex_Sysbench_SQL_3node_oltp_read_write_merged.prof
+/qwerty456/artifacts/raw_Sysbench_SQL_3node_oltp_read_write.log
+/suite.yml
 ----
 ----


### PR DESCRIPTION
Previously, profiles would only run if the benchmark regressed. The profiles also had a separate config to determine iterations to run for each profile.

This change opts to always runs profiles during the main iterations of each benchmark. The profiles are merged into a single profile containing the combined results of all iterations for each revision. Interim profiles are deleted.

Epic: None
Release note: None