### PR TITLE
upgrades: lock rows before backfilling them during upgrade

### DIFF
--- a/pkg/jobs/update.go
+++ b/pkg/jobs/update.go
@@ -267,6 +267,20 @@ WHERE id = $1
 		}
 	}
 
+	// Insert the job payload and progress into the system.jobs_info table.
+	infoStorage := j.InfoStorage(u.txn)
+	infoStorage.claimChecked = true
+	if payloadBytes != nil {
+		if err := infoStorage.WriteLegacyPayload(ctx, payloadBytes); err != nil {
+			return err
+		}
+	}
+	if progressBytes != nil {
+		if err := infoStorage.WriteLegacyProgress(ctx, progressBytes); err != nil {
+			return err
+		}
+	}
+
 	v, err := u.txn.GetSystemSchemaVersion(ctx)
 	if err != nil {
 		return err
@@ -357,20 +371,6 @@ WHERE id = $1
 			); err != nil {
 				return err
 			}
-		}
-	}
-
-	// Insert the job payload and progress into the system.jobs_info table.
-	infoStorage := j.InfoStorage(u.txn)
-	infoStorage.claimChecked = true
-	if payloadBytes != nil {
-		if err := infoStorage.WriteLegacyPayload(ctx, payloadBytes); err != nil {
-			return err
-		}
-	}
-	if progressBytes != nil {
-		if err := infoStorage.WriteLegacyProgress(ctx, progressBytes); err != nil {
-			return err
 		}
 	}
 


### PR DESCRIPTION
Release note (bug fix): A step in the 25.1 upgrade finalization process that required backfilling jobs now uses locks to ensure it makes progress even when there is contention on the jobs table to prevent the possibility of becoming stuck under heavy load.

Fixes: #140967
Epic: none.