### PR TITLE
sql: remove unnecessary StatementSampled check

### DIFF
--- a/pkg/sql/sqlstats/sslocal/sslocal_stats_collector.go
+++ b/pkg/sql/sqlstats/sslocal/sslocal_stats_collector.go
@@ -197,10 +197,6 @@ func (s *StatsCollector) ShouldSampleNewStatement(
 		// statement.
 		return false
 	}
-	previouslySampled := s.flushTarget.StatementSampled(fingerprint, implicitTxn, database)
-	if previouslySampled {
-		return false
-	}
 	return s.flushTarget.TrySetStatementSampled(fingerprint, implicitTxn, database)
 }
 


### PR DESCRIPTION
Since we swapped to Mutex there's no point in having this check.

Epic: none

Release note: None