### PR TITLE
db-console: rm paused follower graph on repl dashboard

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/graphTooltips.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/graphTooltips.tsx
@@ -161,10 +161,6 @@ export const CircuitBreakerTrippedEventsTooltip: React.ReactNode = (
   </div>
 );
 
-export const PausedFollowersTooltip: React.ReactNode = (
-  <div>The number of nonessential followers that have replication paused.</div>
-);
-
 export const ReceiverSnapshotsQueuedTooltip: React.ReactNode = (
   <div>
     The number of snapshots queued to be applied on a receiver which can only{" "}

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/replication.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/replication.tsx
@@ -11,7 +11,6 @@ import LineGraph from "src/views/cluster/components/linegraph";
 import {
   CircuitBreakerTrippedReplicasTooltip,
   LogicalBytesGraphTooltip,
-  PausedFollowersTooltip,
   ReceiverSnapshotsQueuedTooltip,
 } from "src/views/cluster/containers/nodeGraphs/dashboards/graphTooltips";
 import { Axis, Metric } from "src/views/shared/components/metricQuery";
@@ -345,25 +344,6 @@ export default function (props: GraphDashboardProps) {
             title={nodeDisplayName(nodeDisplayNameByID, nid)}
             sources={storeIDsForNode(storeIDsByNodeID, nid)}
             downsampler={TimeSeriesQueryAggregator.SUM}
-          />
-        ))}
-      </Axis>
-    </LineGraph>,
-    <LineGraph
-      title="Paused Followers"
-      sources={storeSources}
-      tenantSource={tenantSource}
-      tooltip={PausedFollowersTooltip}
-      showMetricsInTooltip={true}
-    >
-      <Axis label="replicas">
-        {nodeIDs.map(nid => (
-          <Metric
-            key={nid}
-            name="cr.store.admission.raft.paused_replicas"
-            title={nodeDisplayName(nodeDisplayNameByID, nid)}
-            sources={storeIDsForNode(storeIDsByNodeID, nid)}
-            nonNegativeRate
           />
         ))}
       </Axis>


### PR DESCRIPTION
We no longer pause followers by default
(`kvadmission.flow_control.mode=apply_to_all`) >= 25.1 (#132606).

Remove the `Paused Follower` graph from the `Replication Dashboard` to avoid confusing users and reclaim realestate.

Fixes: #141425
Release note (ui change): The Paused Follower graph is removed from the Replication Dashboard in DB Console as followers are no longer paused by default from v25.1.