### PR TITLE
catalog/lease: clean up orphaned session based leases 

### DIFF
--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -1753,7 +1753,7 @@ func (s *SQLServer) preStart(
 
 	// Delete all orphaned table leases created by a prior instance of this
 	// node. This also uses SQL.
-	s.leaseMgr.DeleteOrphanedLeases(ctx, orphanedLeasesTimeThresholdNanos)
+	s.leaseMgr.DeleteOrphanedLeases(ctx, orphanedLeasesTimeThresholdNanos, s.execCfg.Locality)
 
 	if err := s.statsRefresher.Start(ctx, stopper, stats.DefaultRefreshInterval); err != nil {
 		return err

--- a/pkg/sql/catalog/lease/BUILD.bazel
+++ b/pkg/sql/catalog/lease/BUILD.bazel
@@ -127,6 +127,7 @@ go_test(
         "//pkg/sql/sqlliveness",
         "//pkg/sql/sqlliveness/slbase",
         "//pkg/sql/sqlliveness/slprovider",
+        "//pkg/sql/sqlliveness/slstorage",
         "//pkg/sql/sqlliveness/sqllivenesstestutils",
         "//pkg/sql/sqltestutils",
         "//pkg/sql/stats",

--- a/pkg/sql/catalog/lease/lease.go
+++ b/pkg/sql/catalog/lease/lease.go
@@ -2092,68 +2092,10 @@ func (m *Manager) DeleteOrphanedLeases(
 	// filled by AnnotateCtx.
 	newCtx = logtags.AddTags(newCtx, logtags.FromContext(ctx))
 	_ = m.stopper.RunAsyncTask(newCtx, "del-orphaned-leases", func(ctx context.Context) {
-		m.deleteOrphanedLeasesFromStaleSession(ctx, timeThreshold, locality)
-		// This could have been implemented using DELETE WHERE, but DELETE WHERE
-		// doesn't implement AS OF SYSTEM TIME.
-
-		// Read orphaned leases from the system.lease table.
-		query := `SELECT s."desc_id",  s.version, s."session_id", s.crdb_region FROM system.lease as s 
-		WHERE s."sql_instance_id"=%d
-`
-		sqlQuery := fmt.Sprintf(query, instanceID)
-
-		var rows []tree.Datums
-		retryOptions := base.DefaultRetryOptions()
-		retryOptions.Closer = m.stopper.ShouldQuiesce()
-		// The retry is required because of errors caused by node restarts. Retry 30 times.
-		if err := retry.WithMaxAttempts(ctx, retryOptions, 30, func() error {
-			return m.storage.db.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
-				if err := txn.KV().SetFixedTimestamp(ctx, hlc.Timestamp{WallTime: timeThreshold}); err != nil {
-					return err
-				}
-				var err error
-				rows, err = txn.QueryBuffered(
-					ctx, "read orphaned leases", txn.KV(), sqlQuery,
-				)
-				return err
-			})
-		}); err != nil {
-			log.Warningf(ctx, "unable to read orphaned leases: %v", err)
-			return
-		}
-		var wg sync.WaitGroup
-		defer wg.Wait()
-		for i := range rows {
-			// Early exit?
-			row := rows[i]
-			wg.Add(1)
-			lease := &storedLease{
-				id:      descpb.ID(tree.MustBeDInt(row[0])),
-				version: int(tree.MustBeDInt(row[1])),
-			}
-			if row[2] != tree.DNull {
-				lease.sessionID = []byte(tree.MustBeDBytes(row[2]))
-			}
-			if ed, ok := row[3].(*tree.DEnum); ok {
-				lease.prefix = ed.PhysicalRep
-			} else if bd, ok := row[3].(*tree.DBytes); ok {
-				lease.prefix = []byte((*bd))
-			}
-			if err := m.stopper.RunAsyncTaskEx(
-				ctx,
-				stop.TaskOpts{
-					TaskName:   fmt.Sprintf("release lease %+v", lease),
-					Sem:        m.sem,
-					WaitForSem: true,
-				},
-				func(ctx context.Context) {
-					m.storage.release(ctx, m.stopper, lease)
-					log.Infof(ctx, "released orphaned lease: %+v", lease)
-					wg.Done()
-				}); err != nil {
-				wg.Done()
-			}
-		}
+		retryOpts := base.DefaultRetryOptions()
+		retryOpts.MaxRetries = 10
+		m.deleteOrphanedLeasesFromStaleSession(ctx, retryOpts, timeThreshold, locality)
+		m.deleteOrphanedLeasesWithSameInstanceID(ctx, retryOpts, timeThreshold, instanceID)
 	})
 }
 
@@ -2348,7 +2290,7 @@ func (m *Manager) TestingMarkInit() {
 // deleteOrphanedLeasesFromStaleSession deletes leases from sessions that are
 // no longer alive.
 func (m *Manager) deleteOrphanedLeasesFromStaleSession(
-	ctx context.Context, initialTimestamp int64, locality roachpb.Locality,
+	ctx context.Context, retryOpts retry.Options, initialTimestamp int64, locality roachpb.Locality,
 ) {
 	ex := m.storage.db.Executor()
 	row, err := ex.QueryRowEx(ctx, "check-system-db-multi-region", nil,
@@ -2366,8 +2308,6 @@ func (m *Manager) deleteOrphanedLeasesFromStaleSession(
 		region = locality.Tiers[0].Value
 	}
 
-	retryOpts := base.DefaultRetryOptions()
-	retryOpts.MaxRetries = 10
 	var distinctSessions []tree.Datums
 	aostTime := hlc.Timestamp{WallTime: initialTimestamp}
 	distinctSessionQuery := `SELECT DISTINCT(session_id) FROM system.lease AS OF SYSTEM TIME %s WHERE crdb_region=$1 AND NOT crdb_internal.sql_liveness_is_alive(session_id, true) LIMIT $2`
@@ -2450,4 +2390,72 @@ func deleteLeaseWithSessionIDWithBatch(
 		}
 	}
 	return nil
+}
+
+func (m *Manager) deleteOrphanedLeasesWithSameInstanceID(
+	ctx context.Context,
+	retryOptions retry.Options,
+	timeThreshold int64,
+	instanceID base.SQLInstanceID,
+) {
+	// This could have been implemented using DELETE WHERE, but DELETE WHERE
+	// doesn't implement AS OF SYSTEM TIME.
+
+	// Read orphaned leases from the system.lease table.
+	query := `SELECT s."desc_id",  s.version, s."session_id", s.crdb_region FROM system.lease as s 
+		WHERE s."sql_instance_id"=%d
+`
+	sqlQuery := fmt.Sprintf(query, instanceID)
+
+	var rows []tree.Datums
+	retryOptions.Closer = m.stopper.ShouldQuiesce()
+	// The retry is required because of errors caused by node restarts. Retry 30 times.
+	if err := retry.WithMaxAttempts(ctx, retryOptions, 30, func() error {
+		return m.storage.db.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
+			if err := txn.KV().SetFixedTimestamp(ctx, hlc.Timestamp{WallTime: timeThreshold}); err != nil {
+				return err
+			}
+			var err error
+			rows, err = txn.QueryBuffered(
+				ctx, "read orphaned leases", txn.KV(), sqlQuery,
+			)
+			return err
+		})
+	}); err != nil {
+		log.Warningf(ctx, "unable to read orphaned leases: %v", err)
+		return
+	}
+	var wg sync.WaitGroup
+	defer wg.Wait()
+	for i := range rows {
+		// Early exit?
+		row := rows[i]
+		wg.Add(1)
+		lease := &storedLease{
+			id:      descpb.ID(tree.MustBeDInt(row[0])),
+			version: int(tree.MustBeDInt(row[1])),
+		}
+		if row[2] != tree.DNull {
+			lease.sessionID = []byte(tree.MustBeDBytes(row[2]))
+		}
+		if ed, ok := row[3].(*tree.DEnum); ok {
+			lease.prefix = ed.PhysicalRep
+		} else if bd, ok := row[3].(*tree.DBytes); ok {
+			lease.prefix = []byte((*bd))
+		}
+		if err := m.stopper.RunAsyncTaskEx(
+			ctx,
+			stop.TaskOpts{
+				TaskName:   fmt.Sprintf("release lease %+v", lease),
+				Sem:        m.sem,
+				WaitForSem: true,
+			},
+			func(ctx context.Context) {
+				m.storage.release(ctx, m.stopper, lease)
+				log.Infof(ctx, "released orphaned lease: %+v", lease)
+				wg.Done()
+			}); err != nil {
+			wg.Done()
+		}
+	}
 }

--- a/pkg/sql/faketreeeval/BUILD.bazel
+++ b/pkg/sql/faketreeeval/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
         "//pkg/sql/sem/tree",
         "//pkg/sql/sessiondata",
         "//pkg/sql/sessiondatapb",
+        "//pkg/sql/sqlliveness",
         "//pkg/sql/types",
         "//pkg/util/duration",
         "//pkg/util/errorutil/unimplemented",

--- a/pkg/sql/faketreeeval/BUILD.bazel
+++ b/pkg/sql/faketreeeval/BUILD.bazel
@@ -19,7 +19,6 @@ go_library(
         "//pkg/sql/sem/tree",
         "//pkg/sql/sessiondata",
         "//pkg/sql/sessiondatapb",
-        "//pkg/sql/sqlliveness",
         "//pkg/sql/types",
         "//pkg/util/duration",
         "//pkg/util/errorutil/unimplemented",

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -121,6 +121,7 @@ func (evalCtx *extendedEvalContext) copyFromExecCfg(execCfg *ExecutorConfig) {
 	evalCtx.Tracer = execCfg.AmbientCtx.Tracer
 	if execCfg.SQLLiveness != nil { // nil in some tests
 		evalCtx.SQLLivenessReader = execCfg.SQLLiveness.CachedReader()
+		evalCtx.BlockingSQLLivenessReader = execCfg.SQLLiveness.BlockingReader()
 	}
 	evalCtx.CompactEngineSpan = execCfg.CompactEngineSpanFunc
 	evalCtx.SetCompactionConcurrency = execCfg.CompactionConcurrencyFunc

--- a/pkg/sql/schemachanger/scexec/BUILD.bazel
+++ b/pkg/sql/schemachanger/scexec/BUILD.bazel
@@ -78,7 +78,6 @@ go_test(
         "//pkg/sql/catalog/catenumpb",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/catalog/descs",
-        "//pkg/sql/catalog/lease",
         "//pkg/sql/catalog/nstree",
         "//pkg/sql/catalog/tabledesc",
         "//pkg/sql/isql",
@@ -109,6 +108,7 @@ go_test(
         "@com_github_golang_mock//gomock",
         "@com_github_stretchr_testify//require",
         "//pkg/sql/sem/idxtype",
+        "//pkg/sql/catalog/lease",
     ],
 )
 

--- a/pkg/sql/sem/builtins/fixed_oids.go
+++ b/pkg/sql/sem/builtins/fixed_oids.go
@@ -2644,6 +2644,7 @@ var builtinOidsArray = []string{
 	2681: `varchar(jsonpath: jsonpath) -> varchar`,
 	2682: `char(jsonpath: jsonpath) -> "char"`,
 	2683: `substring_index(input: string, delim: string, count: int) -> string`,
+	2684: `crdb_internal.sql_liveness_is_alive(session_id: bytes, is_sync: bool) -> bool`,
 }
 
 var builtinOidsBySignature map[string]oid.Oid

--- a/pkg/sql/sem/eval/context.go
+++ b/pkg/sql/sem/eval/context.go
@@ -207,6 +207,11 @@ type Context struct {
 
 	SQLLivenessReader sqlliveness.Reader
 
+	// BlockingSQLLivenessReader is a sqlliveness.Reader that synchronously
+	// blocks to determine the status of a session which it does not know about or
+	// thinks might be expired.
+	BlockingSQLLivenessReader sqlliveness.Reader
+
 	SQLStatsController SQLStatsController
 
 	SchemaTelemetryController SchemaTelemetryController


### PR DESCRIPTION
### builtins: add overload for semi-cached session liveness check
This patch adds an overload to `crdb_internal.sql_liveness_is_alive` that
has an `is_sync` option. If `is_sync` is true, we perform session liveness
checks using a BlockingReader -- which synchronously checks
session liveness if the session does not have any cached information.

Epic: none
Informs: https://github.com/cockroachdb/cockroach/issues/130529

Release note: None

---

### catalog/lease: clean up orphaned session based leases
Previously, our logic for cleaning up orphaned leases relied
on a node starting up with the same SQL instance ID, which would
trigger it to delete its previously owned rows. There are two issues
with this exisiting logic:
1. This works fine on-premises where the SQL instance IDs are stable, but
on serverless, these may change.
2. Our existing cleanup logic relies on a cached liveness check -- which
is susceptible of false positives as it does not wait for the result of
our `IsAlive` check and instead assumes liveness.

If an excessive buildup of expired leases occurs, schema change wait
operations may start failing because our session cache can only track up to
1024 dead sessions. This will cause `IsAlive` checks for SQL sessions to
incorrectly identify sessions as live due to cache eviction. To address this,
this patch updates the CRDB start-up logic to delete any dead sessions from
the `system.lease` table. This job runs performs liveness checks synchronously.

Epic: None
Fixes: https://github.com/cockroachdb/cockroach/issues/130529

Release note (bug fix): Fixed a bug where orphaned leases were not
properly cleaned up.