### PR TITLE
sql: miscellaneous cleanup

### DIFF
--- a/pkg/sql/delete.go
+++ b/pkg/sql/delete.go
@@ -155,7 +155,7 @@ func (d *deleteNode) processSourceRow(params runParams, sourceVals tree.Datums) 
 	if n := len(d.run.td.tableDesc().PartialIndexes()); n > 0 {
 		partialIndexDelVals := sourceVals[deleteCols : deleteCols+n]
 
-		err := pm.Init(nil /*partialIndexPutVals */, partialIndexDelVals, d.run.td.tableDesc())
+		err := pm.Init(nil /* partialIndexPutVals */, partialIndexDelVals, d.run.td.tableDesc())
 		if err != nil {
 			return err
 		}

--- a/pkg/sql/opt/exec/execbuilder/builder.go
+++ b/pkg/sql/opt/exec/execbuilder/builder.go
@@ -20,7 +20,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil"
-	"github.com/cockroachdb/cockroach/pkg/util/intsets"
 	"github.com/cockroachdb/cockroach/pkg/util/metamorphic"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/redact"
@@ -106,10 +105,13 @@ type Builder struct {
 
 	allowInsertFastPath bool
 
-	// forceForUpdateLocking is a set of opt catalog table IDs that serve as input
-	// for mutation operators, and should be locked using forUpdateLocking to
-	// reduce query retries.
-	forceForUpdateLocking intsets.Fast
+	// forceForUpdateLocking, if set, is the table ID of the table being mutated
+	// that should be locked using forUpdateLocking in mutation's input
+	// operators to reduce query retries. In other words, it allows us to apply
+	// the implicit locking during the initial scan of the mutation. It will
+	// only be set if we are guaranteed to never scan data that won't be
+	// mutated.
+	forceForUpdateLocking opt.TableID
 
 	// planLazySubqueries is true if the builder should plan subqueries that are
 	// lazily evaluated as routines instead of a subquery which is evaluated

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -3164,7 +3164,7 @@ func (b *Builder) buildZigzagJoin(
 }
 
 func (b *Builder) buildLocking(toLock opt.TableID, locking opt.Locking) (opt.Locking, error) {
-	if b.forceForUpdateLocking.Contains(int(toLock)) {
+	if b.forceForUpdateLocking == toLock {
 		locking = locking.Max(forUpdateLocking)
 	}
 	if locking.IsLocking() {

--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -451,7 +451,7 @@ func (f *ExprFmtCtx) formatRelational(e RelExpr, tp treeprinter.Node) {
 			partialIndexPredicates := tab.PartialIndexPredicatesUnsafe()
 			if partialIndexPredicates != nil {
 				c := tp.Child("partial index predicates")
-				indexOrds := make([]cat.IndexOrdinal, 0, len(partialIndexPredicates))
+				indexOrds := make(cat.IndexOrdinals, 0, len(partialIndexPredicates))
 				for ord := range partialIndexPredicates {
 					indexOrds = append(indexOrds, ord)
 				}

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -1573,10 +1573,6 @@ func (ef *execFactory) ConstructUpdate(
 	rowsNeeded := !returnColOrdSet.Empty()
 	tabDesc := table.(*optTable).desc
 	fetchCols := makeColList(table, fetchColOrdSet)
-
-	// Add each column to update as a sourceSlot. The CBO only uses scalarSlot,
-	// since it compiles tuples and subqueries into a simple sequence of target
-	// columns.
 	updateCols := makeColList(table, updateColOrdSet)
 
 	// Create the table updater, which does the bulk of the work.
@@ -1768,10 +1764,7 @@ func (ef *execFactory) ConstructDelete(
 	tabDesc := table.(*optTable).desc
 	fetchCols := makeColList(table, fetchColOrdSet)
 
-	// Create the table deleter, which does the bulk of the work. In the HP,
-	// the deleter derives the columns that need to be fetched. By contrast, the
-	// CBO will have already determined the set of fetch columns, and passes
-	// those sets into the deleter (which will basically be a no-op).
+	// Create the table deleter, which does the bulk of the work.
 	internal := ef.planner.SessionData().Internal
 	rd := row.MakeDeleter(
 		ef.planner.ExecCfg().Codec,

--- a/pkg/sql/row/deleter.go
+++ b/pkg/sql/row/deleter.go
@@ -100,9 +100,7 @@ func MakeDeleter(
 }
 
 // DeleteRow adds to the batch the kv operations necessary to delete a table row
-// with the given values. It also will cascade as required and check for
-// orphaned rows. The bytesMonitor is only used if cascading/fk checking and can
-// be nil if not.
+// with the given values.
 func (rd *Deleter) DeleteRow(
 	ctx context.Context,
 	b *kv.Batch,

--- a/pkg/sql/row/helper.go
+++ b/pkg/sql/row/helper.go
@@ -471,7 +471,7 @@ func (rh *RowHelper) deleteIndexEntry(
 	return nil
 }
 
-// OriginTimetampCPutHelper is used by callers of Inserter, Updater,
+// OriginTimestampCPutHelper is used by callers of Inserter, Updater,
 // and Deleter when the caller wants updates to the primary key to be
 // constructed using ConditionalPutRequests with the OriginTimestamp
 // option set.

--- a/pkg/sql/row/inserter.go
+++ b/pkg/sql/row/inserter.go
@@ -124,9 +124,15 @@ func insertPutMustAcquireExclusiveLockFn(
 }
 
 // insertDelFn is used by insertRow to delete existing rows.
-func insertDelFn(ctx context.Context, b Putter, key *roachpb.Key, traceKV bool) {
+func insertDelFn(
+	ctx context.Context,
+	b Putter,
+	key *roachpb.Key,
+	traceKV bool,
+	keyEncodingDirs []encoding.Direction,
+) {
 	if traceKV {
-		log.VEventfDepth(ctx, 1, 2, "Del %s", *key)
+		log.VEventfDepth(ctx, 1, 2, "Del %s", keys.PrettyPrint(keyEncodingDirs, *key))
 	}
 	b.Del(key)
 }

--- a/pkg/sql/row/updater.go
+++ b/pkg/sql/row/updater.go
@@ -493,7 +493,7 @@ func (ru *Updater) UpdateRow(
 		} else {
 			// Remove all inverted index entries, and re-add them.
 			for j := range ru.oldIndexEntries[i] {
-				if err := ru.Helper.deleteIndexEntry(ctx, batch, index, nil /*valDir*/, &ru.oldIndexEntries[i][j], traceKV); err != nil {
+				if err := ru.Helper.deleteIndexEntry(ctx, batch, index, nil /* valDirs */, &ru.oldIndexEntries[i][j], traceKV); err != nil {
 					return nil, err
 				}
 			}
@@ -529,7 +529,7 @@ func (ru *Updater) UpdateRow(
 
 			if ok {
 				for _, deletedSecondaryIndexEntry := range deletedSecondaryIndexEntries {
-					if err := ru.DeleteHelper.deleteIndexEntry(ctx, batch, index, nil /*valDir*/, &deletedSecondaryIndexEntry, traceKV); err != nil {
+					if err := ru.DeleteHelper.deleteIndexEntry(ctx, batch, index, nil /* valDirs */, &deletedSecondaryIndexEntry, traceKV); err != nil {
 						return nil, err
 					}
 				}

--- a/pkg/sql/row/writer.go
+++ b/pkg/sql/row/writer.go
@@ -200,7 +200,7 @@ func prepareInsertOrUpdateBatch(
 				} else if overwrite {
 					// If the new family contains a NULL value, then we must
 					// delete any pre-existing row.
-					insertDelFn(ctx, batch, kvKey, traceKV)
+					insertDelFn(ctx, batch, kvKey, traceKV, helper.primIndexValDirs)
 				}
 			} else {
 				// We only output non-NULL values. Non-existent column keys are
@@ -261,7 +261,7 @@ func prepareInsertOrUpdateBatch(
 			} else if overwrite {
 				// The family might have already existed but every column in it is being
 				// set to NULL, so delete it.
-				insertDelFn(ctx, batch, kvKey, traceKV)
+				insertDelFn(ctx, batch, kvKey, traceKV, helper.primIndexValDirs)
 			}
 		} else {
 			// Copy the contents of rawValueBuf into the roachpb.Value. This is


### PR DESCRIPTION
This commit contains a few cleanups that I noticed while looking into adjustments for DELETEs with buffered writes. This involves adjusting comments as well as removing stale ones. The only "prod" changes are:
- we replace `exec.Builder.forceForUpdateLocking` to be a tableID rather than an int set of table IDs. This field tracks which tables to lock during the initial row scan of a mutation, and since we only ever want to lock the table we're mutating, we can have at most one table to lock. Thus, having just a tableID is clearer.
- add pretty-printing of keys in one Del usage.

Epic: None
Release note: None