### PR TITLE
storeliveness,kvserver: optimize store liveness sleep

### DIFF
--- a/pkg/kv/kvserver/replica_metrics.go
+++ b/pkg/kv/kvserver/replica_metrics.go
@@ -76,9 +76,9 @@ func (r *Replica) Metrics(
 	vitalityMap livenesspb.NodeVitalityMap,
 	clusterNodes int,
 ) ReplicaMetrics {
-	r.store.unquiescedOrAwakeReplicas.Lock()
-	_, ticking := r.store.unquiescedOrAwakeReplicas.m[r.RangeID]
-	r.store.unquiescedOrAwakeReplicas.Unlock()
+	r.store.quiescence.Lock()
+	_, ticking := r.store.quiescence.unquiescedOrAwake[r.RangeID]
+	r.store.quiescence.Unlock()
 
 	latchMetrics := r.concMgr.LatchMetrics()
 	lockTableMetrics := r.concMgr.LockTableMetrics()

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -677,7 +677,7 @@ func (r *Replica) stepRaftGroupRaftMuLocked(req *kvserverpb.RaftMessageRequest) 
 			wakeLeader := hasLeader && !fromLeader
 			r.maybeUnquiesceLocked(wakeLeader, false /* mayCampaign */)
 		}
-		r.maybeWakeUpRMuLocked()
+		r.maybeWakeUpReplicaMuLocked()
 
 		{
 			// Update the lastUpdateTimes map, unless configured not to by a testing

--- a/pkg/kv/kvserver/replica_raft_quiesce.go
+++ b/pkg/kv/kvserver/replica_raft_quiesce.go
@@ -39,9 +39,9 @@ func (r *Replica) quiesceLocked(ctx context.Context, lagging laggingReplicaSet) 
 		}
 		r.mu.quiescent = true
 		r.mu.laggingFollowersOnQuiesce = lagging
-		r.store.unquiescedOrAwakeReplicas.Lock()
-		delete(r.store.unquiescedOrAwakeReplicas.m, r.RangeID)
-		r.store.unquiescedOrAwakeReplicas.Unlock()
+		r.store.quiescence.Lock()
+		delete(r.store.quiescence.unquiescedOrAwake, r.RangeID)
+		r.store.quiescence.Unlock()
 	} else if log.V(4) {
 		log.Infof(ctx, "r%d already quiesced", r.RangeID)
 	}
@@ -82,9 +82,9 @@ func (r *Replica) maybeUnquiesceLocked(wakeLeader, mayCampaign bool) bool {
 	}
 	r.mu.quiescent = false
 	r.mu.laggingFollowersOnQuiesce = nil
-	r.store.unquiescedOrAwakeReplicas.Lock()
-	r.store.unquiescedOrAwakeReplicas.m[r.RangeID] = struct{}{}
-	r.store.unquiescedOrAwakeReplicas.Unlock()
+	r.store.quiescence.Lock()
+	r.store.quiescence.unquiescedOrAwake[r.RangeID] = struct{}{}
+	r.store.quiescence.Unlock()
 
 	st := r.raftSparseStatusRLocked()
 	if st.RaftState == raftpb.StateLeader {

--- a/pkg/kv/kvserver/replica_store_liveness_sleep.go
+++ b/pkg/kv/kvserver/replica_store_liveness_sleep.go
@@ -6,9 +6,13 @@
 package kvserver
 
 import (
+	"context"
+
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/metamorphic"
 )
 
@@ -50,32 +54,69 @@ func (r *Replica) maybeFallAsleepRMuLocked(leaseStatus kvserverpb.LeaseStatus) b
 	if ticks := r.ticksSinceLastMessageRLocked(); ticks < goToSleepAfterTicks {
 		return false
 	}
-	// Grab the unquiescedOrAwakeReplicas lock here to prevent races between
-	// support withdrawal and falling asleep.
-	r.store.unquiescedOrAwakeReplicas.Lock()
-	defer r.store.unquiescedOrAwakeReplicas.Unlock()
+	// Grab the quiescence lock here to prevent races between support withdrawal
+	// and falling asleep.
+	r.store.quiescence.Lock()
+	defer r.store.quiescence.Unlock()
 	// If not supporting a fortified leader, do not fall asleep.
 	if !r.raftSupportingFortifiedLeaderRLocked() {
 		return false
 	}
-	// It's safe to fall asleep here: after locking unquiescedOrAwakeReplicas
-	// above, this follower supports the leader. If it withdrew support since
-	// then, the call to maybeWakeUpRMuLocked will wait for the unlock and wake up
-	// the replica.
+	leader, ok := r.lookupLeaderRLocked()
+	// If the leader is not found, do no fall asleep.
+	if !ok {
+		return false
+	}
+	// It's safe to fall asleep here: after quiescence.Lock() above, this follower
+	// supports the leader. If it withdrew support for the leader since then, the
+	// callback to wake up the replica will wait for the quiescence.Unlock().
 	r.mu.asleep = true
-	delete(r.store.unquiescedOrAwakeReplicas.m, r.RangeID)
+	delete(r.store.quiescence.unquiescedOrAwake, r.RangeID)
+	_, ok = r.store.quiescence.asleepByLeaderStore[leader.StoreID]
+	if !ok {
+		r.store.quiescence.asleepByLeaderStore[leader.StoreID] = make(map[*Replica]struct{})
+	}
+	r.store.quiescence.asleepByLeaderStore[leader.StoreID][r] = struct{}{}
 	return true
 }
 
-// maybeWakeUpRMuLocked marks a follower as awake.
-func (r *Replica) maybeWakeUpRMuLocked() {
+// maybeWakeUpReplicaMuLocked marks a follower as awake.
+func (r *Replica) maybeWakeUpReplicaMuLocked() {
+	r.mu.AssertHeld()
 	if !r.mu.asleep {
 		return
 	}
+	r.maybeRemoveAsleepReplicaFromQuiescenceStateReplicaMuLocked()
 	// Prevent immediate falling asleep.
 	r.mu.lastMessageAtTicks = r.mu.ticks
 	r.mu.asleep = false
-	r.store.unquiescedOrAwakeReplicas.Lock()
-	defer r.store.unquiescedOrAwakeReplicas.Unlock()
-	r.store.unquiescedOrAwakeReplicas.m[r.RangeID] = struct{}{}
+}
+
+func (r *Replica) maybeRemoveAsleepReplicaFromQuiescenceStateReplicaMuLocked() {
+	r.mu.AssertHeld()
+	if !r.mu.asleep {
+		return
+	}
+	r.store.quiescence.Lock()
+	defer r.store.quiescence.Unlock()
+	r.store.quiescence.unquiescedOrAwake[r.RangeID] = struct{}{}
+	leader, ok := r.lookupLeaderRLocked()
+	// This shouldn't be possible because the replica's view of its leader can't
+	// change while it's asleep. A change in the leader's descriptor would require
+	// consensus, which would wake up the replica.
+	// TODO(mira): turn into an assertion?
+	if !ok {
+		ctx := r.AnnotateCtx(context.TODO())
+		log.Warningf(ctx, "asleep replica %v can't find its leader", r.replicaID)
+		return
+	}
+	delete(r.store.quiescence.asleepByLeaderStore[leader.StoreID], r)
+	if len(r.store.quiescence.asleepByLeaderStore[leader.StoreID]) == 0 {
+		delete(r.store.quiescence.asleepByLeaderStore, leader.StoreID)
+	}
+}
+
+// lookupLeaderRLocked attempts to find the leader's descriptor.
+func (r *Replica) lookupLeaderRLocked() (roachpb.ReplicaDescriptor, bool) {
+	return r.shMu.state.Desc.GetReplicaDescriptorByID(r.mu.leaderID)
 }

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -1081,10 +1081,19 @@ type Store struct {
 		replicaPlaceholders map[roachpb.RangeID]*ReplicaPlaceholder
 	}
 
-	// The unquiesced or awake subset of replicas.
-	unquiescedOrAwakeReplicas struct {
+	// quiescence stores quiesced/asleep and unquiesced/awake replicas.
+	quiescence struct {
+		// Replica.mu > quiescence; i.e. if acquiring both mutexes, acquire
+		// Replica.mu first.
 		syncutil.Mutex
-		m map[roachpb.RangeID]struct{}
+		// unquiescedOrAwake is the set of unquiesced or awake ranges; the Raft
+		// scheduler iterates over this set to schedule replicas for Raft ticks.
+		unquiescedOrAwake map[roachpb.RangeID]struct{}
+		// asleepByLeaderStore is a map from a store ID to the set of asleep
+		// replicas that have a leader on that store; it is used to easily locate
+		// all replicas that need to be awakened when the local store withdraws
+		// store liveness support for a remote store (the leader's store).
+		asleepByLeaderStore map[roachpb.StoreID]map[*Replica]struct{}
 	}
 
 	// The subset of replicas with active rangefeeds.
@@ -1605,9 +1614,10 @@ func NewStore(
 	s.mu.uninitReplicas = map[roachpb.RangeID]*Replica{}
 	s.mu.Unlock()
 
-	s.unquiescedOrAwakeReplicas.Lock()
-	s.unquiescedOrAwakeReplicas.m = map[roachpb.RangeID]struct{}{}
-	s.unquiescedOrAwakeReplicas.Unlock()
+	s.quiescence.Lock()
+	s.quiescence.unquiescedOrAwake = map[roachpb.RangeID]struct{}{}
+	s.quiescence.asleepByLeaderStore = map[roachpb.StoreID]map[*Replica]struct{}{}
+	s.quiescence.Unlock()
 
 	s.rangefeedReplicas.Lock()
 	s.rangefeedReplicas.m = map[roachpb.RangeID]int64{}

--- a/pkg/kv/kvserver/store_raft.go
+++ b/pkg/kv/kvserver/store_raft.go
@@ -818,34 +818,18 @@ func (s *Store) nodeIsLiveCallback(l livenesspb.Liveness) {
 // support form other stores in store liveness. The goal of this callback is to
 // unquiesce any replicas on the local store that have leaders on any of the
 // remote stores.
-func (s *Store) supportWithdrawnCallback(supportWithdrawnForStoreIDs map[roachpb.StoreID]struct{}) {
-	// TODO(mira): It might be tempting to check the cluster setting
-	// RaftStoreLivenessQuiescenceEnabled here and not proceed if it's disabled.
-	// But that seems risky; if the setting transitions from enabled to disabled,
-	// replicas could get stuck in an asleep state indefinitely.
-	//
-	// TODO(mira): Is it expensive to iterate over all replicas? This callback
-	// will be called at most every SupportExpiryInterval (100ms). The
-	// nodeIsLiveCallback above uses the same pattern. Alternatively, we'd have to
-	// maintain a map from remote store to a list of replicas that have leaders on
-	// that remote store. And we'd have to serialize access to it and keep it in
-	// sync with store.unquiescedOrAwakeReplicas.
-	s.mu.replicasByRangeID.Range(func(_ roachpb.RangeID, r *Replica) bool {
-		r.mu.RLock()
-		defer r.mu.RUnlock()
-		leader, err := r.getReplicaDescriptorByIDRLocked(r.mu.leaderID, roachpb.ReplicaDescriptor{})
-		// If we couldn't locate the leader, wake up the replica.
-		if err != nil || leader.StoreID == 0 {
-			r.maybeWakeUpRMuLocked()
-			return true
+func (s *Store) supportWithdrawnCallback(supportWithdrawnForStoreIDs []roachpb.StoreID) {
+	for _, storeID := range supportWithdrawnForStoreIDs {
+		asleepReplicas, ok := s.quiescence.asleepByLeaderStore[storeID]
+		if !ok || len(asleepReplicas) == 0 {
+			continue
 		}
-		// If a replica is asleep, and we just withdrew support for its leader,
-		// wake it up.
-		if _, ok := supportWithdrawnForStoreIDs[leader.StoreID]; ok {
-			r.maybeWakeUpRMuLocked()
+		for replica := range asleepReplicas {
+			replica.mu.Lock()
+			replica.maybeWakeUpReplicaMuLocked()
+			replica.mu.Unlock()
 		}
-		return true
-	})
+	}
 }
 
 func (s *Store) processRaft(ctx context.Context) {
@@ -898,17 +882,17 @@ func (s *Store) raftTickLoop(ctx context.Context) {
 			}
 			s.updateIOThresholdMap()
 
-			s.unquiescedOrAwakeReplicas.Lock()
+			s.quiescence.Lock()
 			// Why do we bother to ever queue a Replica on the Raft scheduler for
 			// tick processing? Couldn't we just call Replica.tick() here? Yes, but
 			// then a single bad/slow Replica can disrupt tick processing for every
 			// Replica on the store which cascades into Raft elections and more
 			// disruption.
 			batch := s.scheduler.NewEnqueueBatch()
-			for rangeID := range s.unquiescedOrAwakeReplicas.m {
+			for rangeID := range s.quiescence.unquiescedOrAwake {
 				batch.Add(rangeID)
 			}
-			s.unquiescedOrAwakeReplicas.Unlock()
+			s.quiescence.Unlock()
 
 			s.scheduler.EnqueueRaftTicks(batch)
 			batch.Close()

--- a/pkg/kv/kvserver/store_remove_replica.go
+++ b/pkg/kv/kvserver/store_remove_replica.go
@@ -132,6 +132,9 @@ func (s *Store) removeInitializedReplicaRaftMuLocked(
 				repDesc.ReplicaID, nextReplicaID)
 		}
 
+		// Remove the replica from the quiescence data structures.
+		rep.maybeRemoveAsleepReplicaFromQuiescenceStateReplicaMuLocked()
+
 		// Sanity checks passed. Mark the replica as removed before deleting data.
 		rep.mu.destroyStatus.Set(kvpb.NewRangeNotFoundError(rep.RangeID, rep.StoreID()),
 			destroyReasonRemoved)
@@ -297,9 +300,9 @@ func (s *Store) removeUninitializedReplicaRaftMuLocked(
 // store.mu must be held.
 func (s *Store) unlinkReplicaByRangeIDLocked(ctx context.Context, rangeID roachpb.RangeID) {
 	s.mu.AssertHeld()
-	s.unquiescedOrAwakeReplicas.Lock()
-	delete(s.unquiescedOrAwakeReplicas.m, rangeID)
-	s.unquiescedOrAwakeReplicas.Unlock()
+	s.quiescence.Lock()
+	delete(s.quiescence.unquiescedOrAwake, rangeID)
+	s.quiescence.Unlock()
 	delete(s.mu.uninitReplicas, rangeID)
 	s.mu.replicasByRangeID.Delete(rangeID)
 	s.unregisterLeaseholderByID(ctx, rangeID)

--- a/pkg/kv/kvserver/storeliveness/fabric.go
+++ b/pkg/kv/kvserver/storeliveness/fabric.go
@@ -67,7 +67,7 @@ type Fabric interface {
 	// liveness). The replica may need to help elect a new leader.
 	//
 	// Returns the set of stores for which support was withdrawn.
-	RegisterSupportWithdrawalCallback(func(storeIDs map[roachpb.StoreID]struct{}))
+	RegisterSupportWithdrawalCallback(func(storeIDs []roachpb.StoreID))
 }
 
 // InspectFabric is an interface that exposes all in-memory support state for a

--- a/pkg/kv/kvserver/storeliveness/support_manager.go
+++ b/pkg/kv/kvserver/storeliveness/support_manager.go
@@ -49,7 +49,7 @@ type SupportManager struct {
 	receiveQueue          receiveQueue
 	storesToAdd           storesToAdd
 	minWithdrawalTS       hlc.Timestamp
-	withdrawalCallback    func(map[roachpb.StoreID]struct{})
+	withdrawalCallback    func([]roachpb.StoreID)
 	supporterStateHandler *supporterStateHandler
 	requesterStateHandler *requesterStateHandler
 	metrics               *SupportManagerMetrics
@@ -155,7 +155,7 @@ func (sm *SupportManager) SupportFrom(id slpb.StoreIdent) (slpb.Epoch, hlc.Times
 
 // RegisterSupportWithdrawalCallback implements the Fabric interface and
 // registers a callback to be invoked on each support withdrawal.
-func (sm *SupportManager) RegisterSupportWithdrawalCallback(cb func(map[roachpb.StoreID]struct{})) {
+func (sm *SupportManager) RegisterSupportWithdrawalCallback(cb func([]roachpb.StoreID)) {
 	sm.withdrawalCallback = cb
 }
 

--- a/pkg/kv/kvserver/storeliveness/support_manager_test.go
+++ b/pkg/kv/kvserver/storeliveness/support_manager_test.go
@@ -124,10 +124,9 @@ func TestSupportManagerProvidesSupport(t *testing.T) {
 	clock := hlc.NewClockForTesting(manual)
 	sender := &testMessageSender{}
 	sm := NewSupportManager(store, engine, options, settings, stopper, clock, sender, nil)
-	cb := func(supportWithdrawn map[roachpb.StoreID]struct{}) {
+	cb := func(supportWithdrawn []roachpb.StoreID) {
 		require.Equal(t, 1, len(supportWithdrawn))
-		_, ok := supportWithdrawn[roachpb.StoreID(2)]
-		require.True(t, ok)
+		require.Equal(t, roachpb.StoreID(2), supportWithdrawn[0])
 	}
 	sm.RegisterSupportWithdrawalCallback(cb)
 	require.NoError(t, sm.Start(ctx))

--- a/pkg/kv/kvserver/storeliveness/supporter_state.go
+++ b/pkg/kv/kvserver/storeliveness/supporter_state.go
@@ -306,14 +306,13 @@ func logSupportForChange(ctx context.Context, ss slpb.SupportState, ssNew slpb.S
 // The function returns the store IDs for which support was withdrawn.
 func (ssfu *supporterStateForUpdate) withdrawSupport(
 	ctx context.Context, now hlc.ClockTimestamp,
-) (supportWithdrawnForStoreIDs map[roachpb.StoreID]struct{}) {
+) (supportWithdrawnForStoreIDs []roachpb.StoreID) {
 	// Assert that there are no updates in ssfu.inProgress.supportFor to make
 	// sure we can iterate over ssfu.checkedIn.supportFor in the loop below.
 	assert(
 		len(ssfu.inProgress.supportFor) == 0, "reading from supporterStateForUpdate."+
 			"checkedIn.supportFor while supporterStateForUpdate.inProgress.supportFor is not empty",
 	)
-	supportWithdrawnForStoreIDs = make(map[roachpb.StoreID]struct{})
 	for id, ss := range ssfu.checkedIn.supportFor {
 		ssNew := maybeWithdrawSupport(ss, now)
 		if ss != ssNew {
@@ -323,7 +322,7 @@ func (ssfu *supporterStateForUpdate) withdrawSupport(
 			if meta.MaxWithdrawn.Forward(now) {
 				ssfu.inProgress.meta = meta
 			}
-			supportWithdrawnForStoreIDs[id.StoreID] = struct{}{}
+			supportWithdrawnForStoreIDs = append(supportWithdrawnForStoreIDs, id.StoreID)
 		}
 	}
 	return supportWithdrawnForStoreIDs


### PR DESCRIPTION
The initial version of store liveness sleep (equivalent of quiescence) was fairly inefficient: every time store liveness withdrew support from a local store for a remote store, we iterated through all local-store replicas and woke up any of them that had a leader on the remote store; this was done while blocking the main store liveness goroutine.

This commit adds a map from a store ID to the set of asleep replicas that have a leader on that store, which makes it easy to locate all replicas that need to be awakened when support is withdrawn. The new map uses the same mutex as the existing set of unquiesced/awake replicas in order to keep the two in sync.

Fixes: #140476

Release note: None