### PR TITLE
roachtest: tune kv/splits/nodes=3/quiesce=false/lease=leader

### DIFF
--- a/pkg/cmd/roachtest/tests/kv.go
+++ b/pkg/cmd/roachtest/tests/kv.go
@@ -731,31 +731,47 @@ func registerKVSplits(r registry.Registry) {
 		splits  int
 		leases  registry.LeaseType
 		timeout time.Duration
+		envVars []string
 	}{
 		// NB: with 500000 splits, this test sometimes fails since it's pushing
 		// far past the number of replicas per node we support, at least if the
 		// ranges start to unquiesce (which can set off a cascade due to resource
 		// exhaustion).
-		{true, 300_000, registry.EpochLeases, 2 * time.Hour},
+		{true, 300_000, registry.EpochLeases, 2 * time.Hour, nil},
 		// This version of the test prevents range quiescence to trigger the
 		// badness described above more reliably for when we wish to improve
 		// the performance. For now, just verify that 30k unquiesced ranges
 		// is tenable.
-		{false, 30_000, registry.EpochLeases, 2 * time.Hour},
+		{false, 30_000, registry.EpochLeases, 2 * time.Hour, nil},
 		// Expiration-based leases prevent quiescence, and are also more expensive
 		// to keep alive. Again, just verify that 30k ranges is ok.
-		{false, 30_000, registry.ExpirationLeases, 2 * time.Hour},
-		// Leader leases don't need quiescence, as they use store liveness for
-		// failure detection and lease extension, so they don't issue raft
-		// heartbeats or periodic lease extensions. However, the cost of raft
-		// ticking is not entirely negligible (see #133885), so each range isn't
-		// completely free. Currently, they should be able to support 80k ranges in
-		// this cluster configuration.
-		{false, 80_000, registry.LeaderLeases, 2 * time.Hour},
+		{false, 30_000, registry.ExpirationLeases, 2 * time.Hour, nil},
+		// Leader leases without quiescence perform similarly to epoch leases
+		// without quiescence. Even though epoch leases are set to reach 30k, they
+		// also reach 60k reliably.
+		{false, 60_000, registry.LeaderLeases, 2 * time.Hour, nil},
+		// Leader leases with quiescence don't quite match epoch leases with
+		// quiescence because in leader leases only the followers ever quiesce.
+		{true, 90_000, registry.LeaderLeases, 2 * time.Hour, nil},
+		// With some additional tuning, leader leases can do even better. The extended interval allow
+		// for more flexibility in extending store liveness support, and prevent support withdrawals at
+		// higher CPU utilization when goroutine scheduling latency is high.
+		{
+			true, 120_000, registry.LeaderLeases, 2 * time.Hour,
+			[]string{
+				"COCKROACH_STORE_LIVENESS_SUPPORT_EXPIRY_INTERVAL=1s",
+				"COCKROACH_STORE_LIVENESS_HEARTBEAT_INTERVAL=3s",
+				"COCKROACH_STORE_LIVENESS_SUPPORT_DURATION=6s",
+			},
+		},
 	} {
 		item := item // for use in closure below
+		name := fmt.Sprintf("kv/splits/nodes=3/quiesce=%t/lease=%s", item.quiesce, item.leases)
+		if item.envVars != nil {
+			name += "/tuned"
+		}
 		r.Add(registry.TestSpec{
-			Name:    fmt.Sprintf("kv/splits/nodes=3/quiesce=%t/lease=%s", item.quiesce, item.leases),
+			Name:    name,
 			Owner:   registry.OwnerKV,
 			Timeout: item.timeout,
 			Cluster: r.MakeClusterSpec(4, spec.WorkloadNode()),
@@ -769,6 +785,7 @@ func registerKVSplits(r registry.Registry) {
 
 				settings := install.MakeClusterSettings()
 				settings.Env = append(settings.Env, "COCKROACH_MEMPROF_INTERVAL=1m", "COCKROACH_DISABLE_QUIESCENCE="+strconv.FormatBool(!item.quiesce))
+				settings.Env = append(settings.Env, item.envVars...)
 				startOpts := option.NewStartOpts(option.NoBackupSchedule)
 				startOpts.RoachprodOpts.ExtraArgs = append(startOpts.RoachprodOpts.ExtraArgs, "--cache=256MiB")
 				c.Start(ctx, t.L(), startOpts, settings, c.CRDBNodes())

--- a/pkg/kv/kvserver/storeliveness/BUILD.bazel
+++ b/pkg/kv/kvserver/storeliveness/BUILD.bazel
@@ -25,6 +25,7 @@ go_library(
         "//pkg/settings",
         "//pkg/settings/cluster",
         "//pkg/storage",
+        "//pkg/util/envutil",
         "//pkg/util/hlc",
         "//pkg/util/log",
         "//pkg/util/metric",

--- a/pkg/kv/kvserver/storeliveness/config.go
+++ b/pkg/kv/kvserver/storeliveness/config.go
@@ -8,6 +8,21 @@ package storeliveness
 import (
 	"sync/atomic"
 	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/util/envutil"
+)
+
+var (
+	// defaultSupportExpiryInterval is the default value for SupportExpiryInterval.
+	defaultSupportExpiryInterval = envutil.EnvOrDefaultDuration(
+		"COCKROACH_STORE_LIVENESS_SUPPORT_EXPIRY_INTERVAL", 100*time.Millisecond,
+	)
+
+	// defaultIdleSupportFromInterval is the default value for
+	// IdleSupportFromInterval.
+	defaultIdleSupportFromInterval = envutil.EnvOrDefaultDuration(
+		"COCKROACH_STORE_LIVENESS_IDLE_SUPPORT_FROM_INTERVAL", time.Minute,
+	)
 )
 
 // Options includes all Store Liveness durations needed by the SupportManager.
@@ -37,8 +52,8 @@ func NewOptions(
 	return Options{
 		SupportDuration:              supportDuration,
 		HeartbeatInterval:            heartbeatInterval,
-		SupportExpiryInterval:        100 * time.Millisecond,
-		IdleSupportFromInterval:      1 * time.Minute,
+		SupportExpiryInterval:        defaultSupportExpiryInterval,
+		IdleSupportFromInterval:      defaultIdleSupportFromInterval,
 		SupportWithdrawalGracePeriod: supportWithdrawalGracePeriod,
 	}
 }


### PR DESCRIPTION
This test was expected to reach 80k ranges with leader leases but has
been failing occasionally. In this commit, we lower this expectation to
60k range, and intriduce two new variants of the test:

- With follower quiescence, reaching 90k ranges.
- With follower quiescence and extended store liveness intervals,
  reaching 120k ranges.

These thresholds have been determined empirically, and may require more
adjustments.

Fixes: [#141190](https://github.com/cockroachdb/cockroach/issues/141190)

Release note: None