### PR TITLE
sqlstats: move meta fields out of stmtKey 

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -4046,7 +4046,17 @@ func (ex *connExecutor) txnStateTransitionsApplyWrapper(
 				return advanceInfo{}, err
 			}
 			if advInfo.txnEvent.eventType == txnUpgradeToExplicit {
+				// TODO (xinhaoz): This is a temporary hook until
+				// https://github.com/cockroachdb/cockroach/issues/141024
+				// is resolved. The reason this exists is because we
+				// need to recompute the statement fingerprint id for
+				// statements currently in the stats collector, which
+				// were computed once already for insights. There is an
+				// acknowledgement that this means the fingerprint id
+				// given to insights for upgraded transactions are
+				// currently incorrect.
 				ex.extraTxnState.txnFinishClosure.implicit = false
+				ex.statsCollector.UpgradeToExplicitTransaction()
 			}
 		}
 	case txnStart:

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -4180,11 +4180,7 @@ func (ex *connExecutor) onTxnFinish(ctx context.Context, ev txnEvent, txnErr err
 			}
 		}
 
-		discardedStats := ex.statsCollector.EndTransaction(
-			ctx,
-			transactionFingerprintID,
-			implicit,
-		)
+		discardedStats := ex.statsCollector.EndTransaction(ctx, transactionFingerprintID)
 		if discardedStats > 0 {
 			ex.server.ServerMetrics.StatsMetrics.DiscardedStatsCount.Inc(discardedStats)
 		}

--- a/pkg/sql/executor_statement_metrics.go
+++ b/pkg/sql/executor_statement_metrics.go
@@ -150,16 +150,6 @@ func (ex *connExecutor) recordStatementSummary(
 	ex.recordStatementLatencyMetrics(stmt, flags, automaticRetryCount, runLatRaw, svcLatRaw)
 
 	fullScan := flags.IsSet(planFlagContainsFullIndexScan) || flags.IsSet(planFlagContainsFullTableScan)
-	recordedStmtStatsKey := appstatspb.StatementStatisticsKey{
-		Query:        stmt.StmtNoConstants,
-		QuerySummary: stmt.StmtSummary,
-		DistSQL:      flags.ShouldBeDistributed(),
-		Vec:          flags.IsSet(planFlagVectorized),
-		ImplicitTxn:  flags.IsSet(planFlagImplicitTxn),
-		FullScan:     fullScan,
-		Database:     planner.SessionData().Database,
-		PlanHash:     planner.instrumentation.planGist.Hash(),
-	}
 
 	idxRecommendations := idxrecommendations.FormatIdxRecommendations(planner.instrumentation.indexRecs)
 	queryLevelStats, queryLevelStatsOk := planner.instrumentation.GetQueryLevelStats()
@@ -173,9 +163,17 @@ func (ex *connExecutor) recordStatementSummary(
 		}
 		kvNodeIDs = queryLevelStats.KVNodeIDs
 	}
-
 	startTime := phaseTimes.GetSessionPhaseTime(sessionphase.PlannerStartExecStmt).ToUTC()
+	implicitTxn := flags.IsSet(planFlagImplicitTxn)
+	stmtFingerprintID := appstatspb.ConstructStatementFingerprintID(
+		stmt.StmtNoConstants, implicitTxn, planner.SessionData().Database)
 	recordedStmtStats := sqlstats.RecordedStmtStats{
+		FingerprintID:        stmtFingerprintID,
+		QuerySummary:         stmt.StmtSummary,
+		DistSQL:              flags.ShouldBeDistributed(),
+		Vec:                  flags.IsSet(planFlagVectorized),
+		ImplicitTxn:          implicitTxn,
+		PlanHash:             planner.instrumentation.planGist.Hash(),
 		SessionID:            ex.planner.extendedEvalCtx.SessionID,
 		StatementID:          stmt.QueryID,
 		AutoRetryCount:       automaticRetryCount,
@@ -208,8 +206,7 @@ func (ex *connExecutor) recordStatementSummary(
 		Database: planner.SessionData().Database,
 	}
 
-	stmtFingerprintID, err :=
-		ex.statsCollector.RecordStatement(ctx, recordedStmtStatsKey, recordedStmtStats)
+	err := ex.statsCollector.RecordStatement(ctx, recordedStmtStats)
 	if err != nil {
 		if log.V(1) {
 			log.Warningf(ctx, "failed to record statement: %s", err)
@@ -238,9 +235,7 @@ func (ex *connExecutor) recordStatementSummary(
 		}
 	}
 
-	if stmtFingerprintID != 0 {
-		ex.statsCollector.ObserveStatement(stmtFingerprintID, recordedStmtStats)
-	}
+	ex.statsCollector.ObserveStatement(stmtFingerprintID, recordedStmtStats)
 
 	// Do some transaction level accounting for the transaction this statement is
 	// a part of.

--- a/pkg/sql/logictest/testdata/logic_test/statement_statistics
+++ b/pkg/sql/logictest/testdata/logic_test/statement_statistics
@@ -61,13 +61,13 @@ select 1, 2; select 1, 2, 3; select 'ok'
 statement ok
 SET application_name = ''
 
-query TTB
-SELECT txn_fingerprint_id, key, implicit_txn FROM crdb_internal.node_statement_statistics WHERE application_name = 'multi_stmts_test' ORDER BY txn_fingerprint_id
+query TTTB
+SELECT statement_id, txn_fingerprint_id, key, implicit_txn FROM crdb_internal.node_statement_statistics WHERE application_name = 'multi_stmts_test' ORDER BY key, txn_fingerprint_id
 ----
-11423158778792053189  SELECT _                  true
-11423158778792053189  SELECT _, _               true
-11423158778792053189  SELECT _, _, _            true
-6692757627851618087   SET application_name = _  true
+10543509969653713415  11423158778792053189  SELECT _                  true
+5745311157220589890   11423158778792053189  SELECT _, _               true
+5153809228704478449   11423158778792053189  SELECT _, _, _            true
+17546814520094097656  6692757627851618087   SET application_name = _  true
 
 statement ok
 CREATE TABLE test(x INT, y INT, z INT); INSERT INTO test(x, y, z) VALUES (0,0,0);
@@ -223,19 +223,19 @@ SELECT z FROM test where y=2;
 statement ok
 SELECT x FROM test where y=1;
 
-query TB colnames
-SELECT key, implicit_txn
+query TTTB colnames
+SELECT statement_id, txn_fingerprint_id, key, implicit_txn
   FROM crdb_internal.node_statement_statistics
  WHERE application_name = 'implicit_txn_test'
-ORDER BY key, implicit_txn;
+ORDER BY statement_id, key, implicit_txn;
 ----
-key                             implicit_txn
-SELECT _                        false
-SELECT x FROM test WHERE y = _  false
-SELECT x FROM test WHERE y = _  false
-SELECT x FROM test WHERE y = _  true
-SELECT x, z FROM test           false
-SELECT z FROM test WHERE y = _  true
+statement_id          txn_fingerprint_id    key                             implicit_txn
+10408858296841757952  4544145443417805535   SELECT x FROM test WHERE y = _  false
+10408858296841757952  13478531408983698331  SELECT x FROM test WHERE y = _  false
+10408858296841757964  4544145443417805523   SELECT x FROM test WHERE y = _  true
+10543509969653713419  646847662919799570    SELECT _                        false
+15907252083884073594  8332314834087515557   SELECT z FROM test WHERE y = _  true
+3710577796014427302   13478531408983698331  SELECT x, z FROM test           false
 
 # Test throttling of storing statistics per application
 

--- a/pkg/sql/sqlstats/persistedsqlstats/bench_test.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/bench_test.go
@@ -392,9 +392,8 @@ func BenchmarkSqlStatsMaxFlushTime(b *testing.B) {
 	// Fills the in-memory stats for the 'bench' application until the fingerprint limit is reached.
 	fillBenchAppMemStats := func() {
 		appContainer := sqlStats.GetApplicationStats("bench")
-		mockStmtValue := sqlstats.RecordedStmtStats{}
 		for i := int64(1); i <= stmtFingerprintLimit; i++ {
-			stmtKey := appstatspb.StatementStatisticsKey{
+			mockStmtValue := sqlstats.RecordedStmtStats{
 				Query:                    "SELECT 1",
 				App:                      "bench",
 				DistSQL:                  false,
@@ -406,7 +405,7 @@ func BenchmarkSqlStatsMaxFlushTime(b *testing.B) {
 				QuerySummary:             "",
 				TransactionFingerprintID: appstatspb.TransactionFingerprintID(i),
 			}
-			err := appContainer.RecordStatement(ctx, stmtKey, mockStmtValue)
+			err := appContainer.RecordStatement(ctx, mockStmtValue)
 			if errors.Is(err, ssmemstorage.ErrFingerprintLimitReached) {
 				break
 			}

--- a/pkg/sql/sqlstats/sslocal/sql_stats_test.go
+++ b/pkg/sql/sqlstats/sslocal/sql_stats_test.go
@@ -69,6 +69,7 @@ func TestStmtStatsBulkIngestWithRandomMetadata(t *testing.T) {
 		var stats serverpb.StatementsResponse_CollectedStatementStatistics
 		randomData := sqlstatstestutil.GetRandomizedCollectedStatementStatisticsForTest(t)
 		stats.Key.KeyData = randomData.Key
+		stats.ID = appstatspb.StmtFingerprintID(i)
 		testData = append(testData, stats)
 	}
 
@@ -90,7 +91,7 @@ func TestStmtStatsBulkIngestWithRandomMetadata(t *testing.T) {
 						break
 					}
 				}
-				require.True(t, found, "expected metadata %+v, but not found", statistics.Key)
+				require.True(t, found, "expected metadata %+v, but not found")
 				return nil
 			}))
 }
@@ -444,7 +445,6 @@ func TestExplicitTxnFingerprintAccounting(t *testing.T) {
 		Settings: st,
 	})
 
-	insightsProvider := insights.New(st, insights.NewMetrics(), nil)
 	sqlStats := sslocal.New(
 		st,
 		sqlstats.MaxMemSQLStatsStmtFingerprints,
@@ -460,7 +460,7 @@ func TestExplicitTxnFingerprintAccounting(t *testing.T) {
 	statsCollector := sslocal.NewStatsCollector(
 		st,
 		appStats,
-		insightsProvider.Writer(),
+		nil,
 		sessionphase.NewTimes(),
 		sqlStats.GetCounters(),
 		false, /* underOuterTxn */
@@ -472,7 +472,7 @@ func TestExplicitTxnFingerprintAccounting(t *testing.T) {
 		txnFingerprintIDHash := util.MakeFNV64()
 		statsCollector.StartTransaction()
 		defer func() {
-			statsCollector.EndTransaction(ctx, txnFingerprintID, false /* implicit */)
+			statsCollector.EndTransaction(ctx, txnFingerprintID)
 			require.NoError(t,
 				statsCollector.
 					RecordTransaction(ctx, txnFingerprintID, sqlstats.RecordedTxnStats{
@@ -486,13 +486,13 @@ func TestExplicitTxnFingerprintAccounting(t *testing.T) {
 					}))
 		}()
 		for _, fingerprint := range testCase.fingerprints {
-			stmtFingerprintID, err := statsCollector.RecordStatement(
-				ctx,
-				appstatspb.StatementStatisticsKey{
-					Query:       fingerprint,
-					ImplicitTxn: testCase.implicit,
+			stmtFingerprintID := appstatspb.ConstructStatementFingerprintID(fingerprint, testCase.implicit, "defaultdb")
+			err := statsCollector.RecordStatement(
+				ctx, sqlstats.RecordedStmtStats{
+					FingerprintID: stmtFingerprintID,
+					Query:         fingerprint,
+					ImplicitTxn:   testCase.implicit,
 				},
-				sqlstats.RecordedStmtStats{},
 			)
 			require.NoError(t, err)
 			txnFingerprintIDHash.Add(uint64(stmtFingerprintID))
@@ -596,20 +596,17 @@ func TestAssociatingStmtStatsWithTxnFingerprint(t *testing.T) {
 		for _, txn := range simulatedTxns {
 			// Collect stats for the simulated transaction.
 			txnFingerprintIDHash := util.MakeFNV64()
-			statsCollector.StartTransaction()
-
 			for _, fingerprint := range txn.stmtFingerprints {
-				stmtFingerprintID, err := statsCollector.RecordStatement(
-					ctx,
-					appstatspb.StatementStatisticsKey{Query: fingerprint},
-					sqlstats.RecordedStmtStats{},
+				stmtFingerprintID := appstatspb.ConstructStatementFingerprintID(fingerprint, false, "defaultdb")
+				err := statsCollector.RecordStatement(
+					ctx, sqlstats.RecordedStmtStats{FingerprintID: stmtFingerprintID, Query: fingerprint},
 				)
 				require.NoError(t, err)
 				txnFingerprintIDHash.Add(uint64(stmtFingerprintID))
 			}
 
 			transactionFingerprintID := appstatspb.TransactionFingerprintID(txnFingerprintIDHash.Sum())
-			statsCollector.EndTransaction(ctx, transactionFingerprintID, false /* implicit */)
+			statsCollector.EndTransaction(ctx, transactionFingerprintID)
 			err := statsCollector.RecordTransaction(ctx, transactionFingerprintID, sqlstats.RecordedTxnStats{
 				SessionData: &sessiondata.SessionData{
 					SessionData: sessiondatapb.SessionData{
@@ -2081,6 +2078,7 @@ func populateSqlStats(t testing.TB, sqlStats *sslocal.SQLStats, expectedCountSta
 	for i := 0; i < expectedCountStats; i++ {
 		var stats serverpb.StatementsResponse_CollectedStatementStatistics
 		randomData := sqlstatstestutil.GetRandomizedCollectedStatementStatisticsForTest(t)
+		stats.ID = appstatspb.StmtFingerprintID(i)
 		stats.Key.KeyData = randomData.Key
 		testStmtData = append(testStmtData, stats)
 

--- a/pkg/sql/sqlstats/ssmemstorage/BUILD.bazel
+++ b/pkg/sql/sqlstats/ssmemstorage/BUILD.bazel
@@ -39,6 +39,7 @@ go_test(
         "//pkg/util/leaktest",
         "//pkg/util/log",
         "//pkg/util/mon",
+        "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_redact//:redact",
         "@com_github_stretchr_testify//require",
     ],

--- a/pkg/sql/sqlstats/ssmemstorage/ss_mem_iterator.go
+++ b/pkg/sql/sqlstats/ssmemstorage/ss_mem_iterator.go
@@ -81,20 +81,19 @@ func (s *StmtStatsIterator) Next() bool {
 	distSQLUsed := statementStats.mu.distSQLUsed
 	vectorized := statementStats.mu.vectorized
 	fullScan := statementStats.mu.fullScan
-	database := statementStats.mu.database
 	querySummary := statementStats.mu.querySummary
 	statementStats.mu.Unlock()
 
 	s.currentValue = &appstatspb.CollectedStatementStatistics{
 		Key: appstatspb.StatementStatisticsKey{
-			Query:                    stmtKey.stmtNoConstants,
+			Query:                    statementStats.meta.stmtNoConstants,
 			QuerySummary:             querySummary,
 			DistSQL:                  distSQLUsed,
 			Vec:                      vectorized,
-			ImplicitTxn:              stmtKey.implicitTxn,
+			ImplicitTxn:              statementStats.meta.implicitTxn,
 			FullScan:                 fullScan,
 			App:                      s.container.appName,
-			Database:                 database,
+			Database:                 statementStats.meta.database,
 			PlanHash:                 stmtKey.planHash,
 			TransactionFingerprintID: stmtKey.transactionFingerprintID,
 		},

--- a/pkg/sql/sqlstats/ssmemstorage/ss_mem_writer_test.go
+++ b/pkg/sql/sqlstats/ssmemstorage/ss_mem_writer_test.go
@@ -10,6 +10,7 @@ import (
 	"math"
 	"math/rand"
 	"testing"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/appstatspb"
@@ -17,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
+	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/redact"
 	"github.com/stretchr/testify/require"
 )
@@ -38,11 +40,9 @@ func TestRecordStatement(t *testing.T) {
 			"test-app",
 			nil,
 		)
-		// Record a statement, ensure no insights are generated.
-		statsKey := appstatspb.StatementStatisticsKey{
+		err := memContainer.RecordStatement(ctx, sqlstats.RecordedStmtStats{
 			Query: "SELECT _",
-		}
-		err := memContainer.RecordStatement(ctx, statsKey, sqlstats.RecordedStmtStats{})
+		})
 		require.NoError(t, err)
 	})
 }
@@ -67,6 +67,203 @@ func TestRecordTransaction(t *testing.T) {
 		// Record a transaction, ensure no insights are generated.
 		require.NoError(t, memContainer.RecordTransaction(ctx, appstatspb.TransactionFingerprintID(123), sqlstats.RecordedTxnStats{}))
 	})
+}
+
+// TestContainer_Add verifies that the Container's Add method correctly merges statistics
+// from a source container into a destination container. It tests two scenarios via adding
+// the same container repeatedly to sanity check that the add operation works as expected:
+//  1. Multiple adds of the same stats (values should accumulate, stats averages should not change)
+//  2. Multiple adds of a stats with zero values (values should accumulate, stats averages should decrease)
+func TestContainer_Add(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	t.Run("basic statement and transaction stats merge", func(t *testing.T) {
+		ctx := context.Background()
+		settings := cluster.MakeTestingClusterSettings()
+
+		// Create source container and dest container.
+		src := New(settings,
+			nil, /* uniqueServerCount */
+			testMonitor(ctx, "test-mon", settings),
+			"test-app-src",
+			nil,
+		)
+		dest := New(settings,
+			nil, /* uniqueServerCount */
+			testMonitor(ctx, "test-mon", settings),
+			"test-app-dest",
+			nil,
+		)
+
+		// Add some statement stats to the source container
+		mockedStmtKey := stmtKey{
+			fingerprintID: 1,
+		}
+		stmtStats := sqlstats.RecordedStmtStats{
+			FingerprintID:      1,
+			Query:              "SELECT * FROM test_table",
+			Database:           "test_db",
+			ServiceLatencySec:  0.1,
+			RowsAffected:       10,
+			IdleLatencySec:     0.01,
+			ParseLatencySec:    0.02,
+			PlanLatencySec:     0.03,
+			RunLatencySec:      0.04,
+			OverheadLatencySec: 0.5,
+			BytesRead:          100,
+			RowsRead:           20,
+			RowsWritten:        5,
+			Failed:             true,
+			StatementError:     errors.New("test error"),
+		}
+		require.NoError(t, src.RecordStatement(ctx, stmtStats))
+
+		// Add some transaction stats to the source container
+		txnFingerprintID := appstatspb.TransactionFingerprintID(123)
+		txnStats := sqlstats.RecordedTxnStats{
+			RowsAffected:   10,
+			ServiceLatency: 1,
+			RetryLatency:   2,
+			CommitLatency:  3,
+			IdleLatency:    4,
+			RetryCount:     1,
+			RowsRead:       20,
+			RowsWritten:    5,
+			BytesRead:      100,
+		}
+		require.NoError(t, src.RecordTransaction(ctx, txnFingerprintID, txnStats))
+
+		// In the src destination, these 'reduced' entries will have
+		// 0 values.
+		// The Add() calls should increment the count and other counters,
+		// but decrease any appstatspb.NumericStats averages.
+		emptyStmtStatsKey := stmtKey{
+			fingerprintID: 321,
+		}
+		reducedStmtStats := sqlstats.RecordedStmtStats{
+			FingerprintID:      appstatspb.StmtFingerprintID(321),
+			Query:              "SELECT * FROM test_table",
+			ServiceLatencySec:  50,
+			RowsAffected:       1000,
+			IdleLatencySec:     10,
+			ParseLatencySec:    20,
+			PlanLatencySec:     30,
+			RunLatencySec:      40,
+			OverheadLatencySec: 58,
+			BytesRead:          60,
+			RowsRead:           70,
+			RowsWritten:        80,
+			Failed:             true,
+			StatementError:     errors.New("test error"),
+		}
+		reducedTxnFingerprintID := appstatspb.TransactionFingerprintID(321)
+		reducedTxnStats := sqlstats.RecordedTxnStats{
+			RowsAffected:   100,
+			ServiceLatency: 500 * time.Millisecond,
+			RetryLatency:   100 * time.Millisecond,
+			CommitLatency:  200 * time.Millisecond,
+			IdleLatency:    50 * time.Millisecond,
+			RetryCount:     53,
+			RowsRead:       20,
+			RowsWritten:    5,
+			BytesRead:      100,
+		}
+		require.NoError(t, dest.RecordStatement(ctx, reducedStmtStats))
+		require.NoError(t, dest.RecordTransaction(ctx, reducedTxnFingerprintID, reducedTxnStats))
+		require.NoError(t, src.RecordStatement(ctx, sqlstats.RecordedStmtStats{
+			FingerprintID: appstatspb.StmtFingerprintID(321),
+		}))
+		require.NoError(t, src.RecordTransaction(ctx, reducedTxnFingerprintID, sqlstats.RecordedTxnStats{}))
+
+		for i := 0; i < 10; i++ {
+			require.NoError(t, dest.Add(ctx, src))
+			// Check results.
+			verifyStmtStatsMultiple(t, i+1, &stmtStats, dest.getStatsForStmtWithKey(mockedStmtKey))
+			verifyStmtStatsReduced(t, i+2, &reducedStmtStats, dest.getStatsForStmtWithKey(emptyStmtStatsKey))
+			verifyTxnStatsMultiple(t, i+1, &txnStats, dest.getStatsForTxnWithKey(txnFingerprintID))
+			verifyTxnStatsReduced(t, i+2, &reducedTxnStats, dest.getStatsForTxnWithKey(reducedTxnFingerprintID))
+		}
+	})
+}
+
+const epsilon = 0.0000001
+
+// verifyStmtStatsMultiple verifies that statement statistics have been recorded
+// exactly 'count' times in destStmtStats. The averaged values should match the
+// original stmtStats values.
+func verifyStmtStatsMultiple(
+	t *testing.T, count int, stmtStats *sqlstats.RecordedStmtStats, destStmtStats *stmtStats,
+) {
+	require.NotNil(t, destStmtStats)
+	require.Equal(t, destStmtStats.mu.data.Count, int64(count))
+	require.Equal(t, destStmtStats.mu.data.FailureCount, int64(count))
+	require.InEpsilon(t, float64(stmtStats.RowsAffected), destStmtStats.mu.data.NumRows.Mean, epsilon)
+	require.InEpsilon(t, float64(stmtStats.RowsAffected), destStmtStats.mu.data.NumRows.Mean, epsilon)
+	require.InEpsilon(t, stmtStats.IdleLatencySec, destStmtStats.mu.data.IdleLat.Mean, epsilon)
+	require.InEpsilon(t, stmtStats.ParseLatencySec, destStmtStats.mu.data.ParseLat.Mean, epsilon)
+	require.InEpsilon(t, stmtStats.PlanLatencySec, destStmtStats.mu.data.PlanLat.Mean, epsilon)
+	require.InEpsilon(t, stmtStats.RunLatencySec, destStmtStats.mu.data.RunLat.Mean, epsilon)
+	require.InEpsilon(t, stmtStats.OverheadLatencySec, destStmtStats.mu.data.OverheadLat.Mean, epsilon)
+	require.InEpsilon(t, float64(stmtStats.BytesRead), destStmtStats.mu.data.BytesRead.Mean, epsilon)
+	require.InEpsilon(t, float64(stmtStats.RowsRead), destStmtStats.mu.data.RowsRead.Mean, epsilon)
+	require.InEpsilon(t, float64(stmtStats.RowsWritten), destStmtStats.mu.data.RowsWritten.Mean, epsilon)
+}
+
+// verifyStmtStatsReduced verifies that statement statistics have been properly
+// averaged over 'count' recordings in destStmtStats.
+func verifyStmtStatsReduced(
+	t *testing.T, count int, stmtStats *sqlstats.RecordedStmtStats, destStmtStats *stmtStats,
+) {
+	cnt := float64(count)
+	require.NotNil(t, destStmtStats)
+	require.Equal(t, destStmtStats.mu.data.Count, int64(count))
+	require.Equal(t, destStmtStats.mu.data.FailureCount, int64(1))
+	require.InEpsilon(t, float64(stmtStats.RowsAffected)/cnt, destStmtStats.mu.data.NumRows.Mean, epsilon)
+	require.InEpsilon(t, stmtStats.IdleLatencySec/cnt, destStmtStats.mu.data.IdleLat.Mean, epsilon)
+	require.InEpsilon(t, stmtStats.ParseLatencySec/cnt, destStmtStats.mu.data.ParseLat.Mean, epsilon)
+	require.InEpsilon(t, stmtStats.PlanLatencySec/cnt, destStmtStats.mu.data.PlanLat.Mean, epsilon)
+	require.InEpsilon(t, stmtStats.RunLatencySec/cnt, destStmtStats.mu.data.RunLat.Mean, epsilon)
+	require.InEpsilon(t, stmtStats.OverheadLatencySec/cnt, destStmtStats.mu.data.OverheadLat.Mean, epsilon)
+	require.InEpsilon(t, float64(stmtStats.BytesRead)/cnt, destStmtStats.mu.data.BytesRead.Mean, epsilon)
+	require.InEpsilon(t, float64(stmtStats.RowsRead)/cnt, destStmtStats.mu.data.RowsRead.Mean, epsilon)
+	require.InEpsilon(t, float64(stmtStats.RowsWritten)/cnt, destStmtStats.mu.data.RowsWritten.Mean, epsilon)
+}
+
+// verifyTxnStatsMultiple verifies that transaction statistics have been recorded
+// exactly 'count' times in destTxnStats. The averaged values should match the original
+// txnStats values.
+func verifyTxnStatsMultiple(
+	t *testing.T, count int, txnStats *sqlstats.RecordedTxnStats, destTxnStats *txnStats,
+) {
+	require.NotNil(t, destTxnStats)
+	require.Equal(t, destTxnStats.mu.data.Count, int64(count))
+	require.InEpsilon(t, float64(txnStats.RowsAffected), destTxnStats.mu.data.NumRows.Mean, epsilon)
+	require.InEpsilon(t, txnStats.ServiceLatency.Seconds(), destTxnStats.mu.data.ServiceLat.Mean, epsilon)
+	require.InEpsilon(t, txnStats.RetryLatency.Seconds(), destTxnStats.mu.data.RetryLat.Mean, epsilon)
+	require.InEpsilon(t, txnStats.CommitLatency.Seconds(), destTxnStats.mu.data.CommitLat.Mean, epsilon)
+	require.InEpsilon(t, txnStats.IdleLatency.Seconds(), destTxnStats.mu.data.IdleLat.Mean, epsilon)
+	require.InEpsilon(t, float64(txnStats.RowsRead), destTxnStats.mu.data.RowsRead.Mean, epsilon)
+	require.InEpsilon(t, float64(txnStats.RowsWritten), destTxnStats.mu.data.RowsWritten.Mean, epsilon)
+	require.InEpsilon(t, float64(txnStats.BytesRead), destTxnStats.mu.data.BytesRead.Mean, epsilon)
+}
+
+// verifyTxnStatsReduced verifies that transaction statistics have been properly
+// averaged over 'count' recordings in destTxnStats.
+func verifyTxnStatsReduced(
+	t *testing.T, count int, txnStats *sqlstats.RecordedTxnStats, destTxnStats *txnStats,
+) {
+	cnt := float64(count)
+	require.NotNil(t, destTxnStats)
+	require.Equal(t, destTxnStats.mu.data.Count, int64(count))
+	require.InEpsilon(t, float64(txnStats.RowsAffected)/cnt, destTxnStats.mu.data.NumRows.Mean, epsilon)
+	require.InEpsilon(t, txnStats.ServiceLatency.Seconds()/cnt, destTxnStats.mu.data.ServiceLat.Mean, epsilon)
+	require.InEpsilon(t, txnStats.RetryLatency.Seconds()/cnt, destTxnStats.mu.data.RetryLat.Mean, epsilon)
+	require.InEpsilon(t, txnStats.CommitLatency.Seconds()/cnt, destTxnStats.mu.data.CommitLat.Mean, epsilon)
+	require.InEpsilon(t, txnStats.IdleLatency.Seconds()/cnt, destTxnStats.mu.data.IdleLat.Mean, epsilon)
+	require.InEpsilon(t, float64(txnStats.RowsRead)/cnt, destTxnStats.mu.data.RowsRead.Mean, epsilon)
+	require.InEpsilon(t, float64(txnStats.RowsWritten)/cnt, destTxnStats.mu.data.RowsWritten.Mean, epsilon)
+	require.InEpsilon(t, float64(txnStats.BytesRead)/cnt, destTxnStats.mu.data.BytesRead.Mean, epsilon)
 }
 
 func testMonitor(
@@ -95,31 +292,27 @@ func TestContainerMemoryAccountClearing(t *testing.T) {
 	container := New(st, nil, memMonitor, "test-app", nil)
 
 	// Create statement keys
-	stmt1Key := appstatspb.StatementStatisticsKey{
+	stmt1Stats := sqlstats.RecordedStmtStats{
+		FingerprintID:            appstatspb.StmtFingerprintID(1),
 		Query:                    "SELECT * FROM table1",
 		ImplicitTxn:              true,
 		Database:                 "testdb",
 		TransactionFingerprintID: appstatspb.TransactionFingerprintID(100),
 	}
-	stmt1Stats := sqlstats.RecordedStmtStats{
-		FingerprintID: appstatspb.StmtFingerprintID(1),
-	}
 
-	stmt2Key := appstatspb.StatementStatisticsKey{
+	stmt2Stats := sqlstats.RecordedStmtStats{
+		FingerprintID:            appstatspb.StmtFingerprintID(2),
 		Query:                    "SELECT * FROM table2",
 		ImplicitTxn:              true,
 		Database:                 "testdb",
 		TransactionFingerprintID: appstatspb.TransactionFingerprintID(100),
 	}
-	stmt2Stats := sqlstats.RecordedStmtStats{
-		FingerprintID: appstatspb.StmtFingerprintID(2),
-	}
 
 	// Record statements to allocate memory.
-	err := container.RecordStatement(ctx, stmt1Key, stmt1Stats)
+	err := container.RecordStatement(ctx, stmt1Stats)
 	require.NoError(t, err)
 
-	err = container.RecordStatement(ctx, stmt2Key, stmt2Stats)
+	err = container.RecordStatement(ctx, stmt2Stats)
 	require.NoError(t, err)
 
 	// Record a transaction to allocate more memory.
@@ -141,17 +334,15 @@ func TestContainerMemoryAccountClearing(t *testing.T) {
 	require.Equal(t, int64(0), memUsedAfterClear, "Memory account should be cleared after Clear")
 
 	// Add more statements to allocate memory again.
-	stmt3Key := appstatspb.StatementStatisticsKey{
+	stmt3Stats := sqlstats.RecordedStmtStats{
+		FingerprintID:            appstatspb.StmtFingerprintID(3),
 		Query:                    "SELECT * FROM table3",
 		ImplicitTxn:              true,
 		Database:                 "testdb",
 		TransactionFingerprintID: appstatspb.TransactionFingerprintID(100),
 	}
-	stmt3Stats := sqlstats.RecordedStmtStats{
-		FingerprintID: appstatspb.StmtFingerprintID(3),
-	}
 
-	err = container.RecordStatement(ctx, stmt3Key, stmt3Stats)
+	err = container.RecordStatement(ctx, stmt3Stats)
 	require.NoError(t, err)
 
 	// Verify memory is allocated again
@@ -167,17 +358,15 @@ func TestContainerMemoryAccountClearing(t *testing.T) {
 
 	// Verify that the container can still be used after Free
 	// by adding more statements.
-	stmt4Key := appstatspb.StatementStatisticsKey{
+	stmt4Stats := sqlstats.RecordedStmtStats{
+		FingerprintID:            appstatspb.StmtFingerprintID(4),
 		Query:                    "SELECT * FROM table4",
 		ImplicitTxn:              true,
 		Database:                 "testdb",
 		TransactionFingerprintID: appstatspb.TransactionFingerprintID(100),
 	}
-	stmt4Stats := sqlstats.RecordedStmtStats{
-		FingerprintID: appstatspb.StmtFingerprintID(4),
-	}
 
-	err = container.RecordStatement(ctx, stmt4Key, stmt4Stats)
+	err = container.RecordStatement(ctx, stmt4Stats)
 	require.NoError(t, err)
 
 	// Verify memory is allocated again
@@ -188,26 +377,8 @@ func TestContainerMemoryAccountClearing(t *testing.T) {
 }
 
 func generateRandomKey() stmtKey {
-	const stmtLength = 32
-	const charset = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ "
-	stmt := make([]byte, stmtLength)
-	for i := range stmt {
-		stmt[i] = charset[rand.Intn(len(charset))]
-	}
-
-	// Generate random database name
-	const dbLength = 16
-	db := make([]byte, dbLength)
-	for i := range db {
-		db[i] = charset[rand.Intn(len(charset))]
-	}
-
 	return stmtKey{
-		sampledPlanKey: sampledPlanKey{
-			stmtNoConstants: string(stmt),
-			implicitTxn:     rand.Intn(2) == 1, // random boolean
-			database:        string(db),
-		},
+		fingerprintID:            appstatspb.StmtFingerprintID(rand.Uint64()),
 		planHash:                 rand.Uint64(),
 		transactionFingerprintID: appstatspb.TransactionFingerprintID(rand.Uint64()),
 	}
@@ -232,7 +403,6 @@ func BenchmarkStmtKeyMapOperations(b *testing.B) {
 	})
 
 	b.Run("MapLookup", func(b *testing.B) {
-		b.ResetTimer()
 		m := make(map[stmtKey]int)
 		for j := 0; j < numKeys; j++ {
 			m[keys[j]] = j

--- a/pkg/sql/sqlstats/ssmemstorage/utils.go
+++ b/pkg/sql/sqlstats/ssmemstorage/utils.go
@@ -5,11 +5,7 @@
 
 package ssmemstorage
 
-import (
-	"strings"
-
-	"github.com/cockroachdb/cockroach/pkg/sql/appstatspb"
-)
+import "github.com/cockroachdb/cockroach/pkg/sql/appstatspb"
 
 type stmtList []stmtKey
 
@@ -20,12 +16,10 @@ func (s stmtList) Swap(i, j int) {
 	s[i], s[j] = s[j], s[i]
 }
 func (s stmtList) Less(i, j int) bool {
-	cmp := strings.Compare(s[i].stmtNoConstants, s[j].stmtNoConstants)
-	if cmp == -1 {
+	if s[i].fingerprintID < s[j].fingerprintID {
 		return true
 	}
-
-	if cmp == 1 {
+	if s[i].fingerprintID > s[j].fingerprintID {
 		return false
 	}
 	return s[i].transactionFingerprintID < s[j].transactionFingerprintID

--- a/pkg/sql/sqlstats/ssprovider.go
+++ b/pkg/sql/sqlstats/ssprovider.go
@@ -55,37 +55,44 @@ type AggregatedTransactionVisitor func(appName string, statistics *appstatspb.Tx
 
 // RecordedStmtStats stores the statistics of a statement to be recorded.
 type RecordedStmtStats struct {
-	FingerprintID        appstatspb.StmtFingerprintID
-	SessionID            clusterunique.ID
-	StatementID          clusterunique.ID
-	TransactionID        uuid.UUID
-	AutoRetryCount       int
-	Failed               bool
-	AutoRetryReason      error
-	RowsAffected         int
-	IdleLatencySec       float64
-	ParseLatencySec      float64
-	PlanLatencySec       float64
-	RunLatencySec        float64
-	ServiceLatencySec    float64
-	OverheadLatencySec   float64
-	BytesRead            int64
-	RowsRead             int64
-	RowsWritten          int64
-	Nodes                []int64
-	KVNodeIDs            []int32
-	StatementType        tree.StatementType
-	Plan                 *appstatspb.ExplainTreePlanNode
-	PlanGist             string
-	StatementError       error
-	IndexRecommendations []string
-	Query                string
-	StartTime            time.Time
-	EndTime              time.Time
-	FullScan             bool
-	ExecStats            *execstats.QueryLevelStats
-	Indexes              []string
-	Database             string
+	FingerprintID            appstatspb.StmtFingerprintID
+	Query                    string
+	App                      string
+	DistSQL                  bool
+	ImplicitTxn              bool
+	Vec                      bool
+	FullScan                 bool
+	Database                 string
+	PlanHash                 uint64
+	QuerySummary             string
+	TransactionFingerprintID appstatspb.TransactionFingerprintID
+	SessionID                clusterunique.ID
+	StatementID              clusterunique.ID
+	TransactionID            uuid.UUID
+	AutoRetryCount           int
+	Failed                   bool
+	AutoRetryReason          error
+	RowsAffected             int
+	IdleLatencySec           float64
+	ParseLatencySec          float64
+	PlanLatencySec           float64
+	RunLatencySec            float64
+	ServiceLatencySec        float64
+	OverheadLatencySec       float64
+	BytesRead                int64
+	RowsRead                 int64
+	RowsWritten              int64
+	Nodes                    []int64
+	KVNodeIDs                []int32
+	StatementType            tree.StatementType
+	Plan                     *appstatspb.ExplainTreePlanNode
+	PlanGist                 string
+	StatementError           error
+	IndexRecommendations     []string
+	StartTime                time.Time
+	EndTime                  time.Time
+	ExecStats                *execstats.QueryLevelStats
+	Indexes                  []string
 }
 
 // RecordedTxnStats stores the statistics of a transaction to be recorded.


### PR DESCRIPTION
Previously the following 3 fields were part of the
key in the stmtStats map:
- query fingerprint (string)
- database (string)
- implicit txn (bool)

To slightly reduce the overhead of looking into the map,
an operation we perform frequently, we can replace all these
fields with the stmt fingerprint id (uint64).

This commit also does the following:
- Updates TestSQLStatsPlanSampling - updating that
to TestSQLStatsStmtSampling and making it more accurately
reflect the goal of the underlying cache it is testing.

```
name                               old time/op    new time/op    delta
StmtKeyMapOperations/MapInsert-10    1.38ms ± 2%    0.67ms ± 3%  -51.41%  (p=0.000 n=10+10)
StmtKeyMapOperations/MapLookup-10     544µs ± 1%     267µs ± 2%  -50.83%  (p=0.000 n=10+9)

name                               old alloc/op   new alloc/op   delta
StmtKeyMapOperations/MapInsert-10    2.48MB ± 0%    1.29MB ± 0%  -48.07%  (p=0.000 n=10+9)
StmtKeyMapOperations/MapLookup-10     0.00B          0.00B          ~     (all equal)

name                               old allocs/op  new allocs/op  delta
StmtKeyMapOperations/MapLookup-10      0.00           0.00          ~     (all equal)
StmtKeyMapOperations/MapInsert-10       266 ± 0%       274 ± 0%   +3.01%  (p=0.000 n=10+10)
```

Epic: none

Release note: None