### PR TITLE
backup: fix panic on encrypted incremental after non-encrypted backup

### DIFF
--- a/pkg/backup/backupencryption/encryption.go
+++ b/pkg/backup/backupencryption/encryption.go
@@ -363,6 +363,9 @@ func GetEncryptionFromBaseStore(
 		return nil, nil
 	}
 	opts, err := ReadEncryptionOptions(ctx, baseStore)
+	if err != nil {
+		return nil, err
+	}
 	var encryptionOptions *jobspb.BackupEncryptionOptions
 	switch encryptionParams.Mode {
 	case jobspb.EncryptionMode_Passphrase:


### PR DESCRIPTION
When attempting an encrypted backup on a non-encrypted backup chain, an error should be surfaced to the user indicating an error and inability to do so. Due to a missing error check, this currently panics.

Epic: none

Release note: None