### PR TITLE
catalog: add faster path for leasing

### DIFF
--- a/pkg/sql/opt/metadata.go
+++ b/pkg/sql/opt/metadata.go
@@ -457,7 +457,7 @@ func (md *Metadata) CheckDependencies(
 		// code path below.
 		upToDate, err = md.leaseObjectsInMetaData(ctx, optCatalog)
 		if err == nil {
-			return upToDate, err
+			return upToDate, nil
 		}
 	}
 

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -526,12 +526,7 @@ func (oc *optCatalog) GetCurrentUser() username.SQLUsername {
 func (oc *optCatalog) LeaseByStableID(ctx context.Context, stableID cat.StableID) (uint64, error) {
 	// Lease the descriptor, so that schema changes cannot move forward
 	// after the current version.
-	desc, err := oc.planner.byIDGetterBuilder().WithoutNonPublic().Get().Desc(ctx, descpb.ID(stableID))
-	if err != nil {
-		return 0, err
-	}
-	// Return the current version of the descriptor.
-	return uint64(desc.GetVersion()), nil
+	return oc.planner.Descriptors().LockDescriptorWithLease(ctx, oc.planner.txn, descpb.ID(stableID))
 }
 
 // GetDependencyDigest is part of the cat.Catalog interface.


### PR DESCRIPTION
Previously, when acquiring leased descriptors for the purpose of just prevent schema changes inside the optimizer, the code path that we had would spend time materializing the descriptor. To address this, this patch adds a new collection API: LockDescriptorWithLease, and adopts it.

Fixes: #141032
Release note: None