### PR TITLE
microbench-ci: use no-clobber copy for builds

### DIFF
--- a/.github/workflows/microbenchmarks-ci.yaml
+++ b/.github/workflows/microbenchmarks-ci.yaml
@@ -6,6 +6,10 @@ on:
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
+permissions:
+  contents: read
+  issues: read
+  pull-requests: read
 env:
   HEAD: ${{ github.event.pull_request.head.sha }}
   BUCKET: "cockroach-microbench-ci"

--- a/build/github/microbenchmarks/build.sh
+++ b/build/github/microbenchmarks/build.sh
@@ -33,4 +33,4 @@ bazel build "//${TEST_PKG}:tests_test" \
 
 # Copy to GCS
 bazel_bin=$(bazel info bazel-bin --config=crosslinux)
-gcloud storage cp "${bazel_bin}/pkg/sql/tests/${pkg_last}_test_/${pkg_last}_test" "${output_url}/${pkg_bin}"
+gcloud storage cp -n "${bazel_bin}/pkg/sql/tests/${pkg_last}_test_/${pkg_last}_test" "${output_url}/${pkg_bin}"


### PR DESCRIPTION
Previously, the merge base build would fail on a race between other PRs building the same base SHA and contending for the copy operation. This change ensures the copy still succeeds if another job finished first.

Epic: None
Release note: None