### PR TITLE
[dnm] sep-raft-log runnable prototype

### DIFF
--- a/pkg/base/store_spec.go
+++ b/pkg/base/store_spec.go
@@ -198,11 +198,12 @@ func newStoreProvisionedRateSpec(
 // StoreSpec contains the details that can be specified in the cli pertaining
 // to the --store flag.
 type StoreSpec struct {
-	Path        string
-	Size        SizeSpec
-	BallastSize *SizeSpec
-	InMemory    bool
-	Attributes  roachpb.Attributes
+	Path             string
+	StateMachinePath string
+	Size             SizeSpec
+	BallastSize      *SizeSpec
+	InMemory         bool
+	Attributes       roachpb.Attributes
 	// StickyVFSID is a unique identifier associated with a given store which
 	// will preserve the in-memory virtual file system (VFS) even after the
 	// storage engine has been closed. This only applies to in-memory storage

--- a/pkg/base/store_spec.go
+++ b/pkg/base/store_spec.go
@@ -198,12 +198,11 @@ func newStoreProvisionedRateSpec(
 // StoreSpec contains the details that can be specified in the cli pertaining
 // to the --store flag.
 type StoreSpec struct {
-	Path             string
-	StateMachinePath string
-	Size             SizeSpec
-	BallastSize      *SizeSpec
-	InMemory         bool
-	Attributes       roachpb.Attributes
+	Path        string
+	Size        SizeSpec
+	BallastSize *SizeSpec
+	InMemory    bool
+	Attributes  roachpb.Attributes
 	// StickyVFSID is a unique identifier associated with a given store which
 	// will preserve the in-memory virtual file system (VFS) even after the
 	// storage engine has been closed. This only applies to in-memory storage

--- a/pkg/cli/debug_check_store.go
+++ b/pkg/cli/debug_check_store.go
@@ -121,7 +121,7 @@ func worker(ctx context.Context, in checkInput) checkResult {
 	desc, eng := in.desc, in.eng
 
 	res := checkResult{desc: desc}
-	claimedMS, err := in.sl.LoadMVCCStats(ctx, eng)
+	claimedMS, err := in.sl.LoadMVCCStats(ctx, stateloader.MakeStateReader(eng))
 	if err != nil {
 		res.err = err
 		return res

--- a/pkg/cli/debug_check_store.go
+++ b/pkg/cli/debug_check_store.go
@@ -164,7 +164,7 @@ func checkStoreRangeStats(
 	}
 
 	go func() {
-		if err := kvstorage.IterateRangeDescriptorsFromDisk(ctx, eng,
+		if err := kvstorage.IterateRangeDescriptorsFromDisk(ctx, stateloader.MakeStateReader(eng),
 			func(desc roachpb.RangeDescriptor) error {
 				inCh <- checkInput{eng: eng, desc: &desc, sl: stateloader.Make(desc.RangeID)}
 				return nil

--- a/pkg/kv/kvserver/batcheval/BUILD.bazel
+++ b/pkg/kv/kvserver/batcheval/BUILD.bazel
@@ -150,6 +150,7 @@ go_test(
         "//pkg/kv/kvserver/kvserverbase",
         "//pkg/kv/kvserver/kvserverpb",
         "//pkg/kv/kvserver/lockspanset",
+        "//pkg/kv/kvserver/logstore",
         "//pkg/kv/kvserver/readsummary",
         "//pkg/kv/kvserver/readsummary/rspb",
         "//pkg/kv/kvserver/spanset",

--- a/pkg/kv/kvserver/batcheval/BUILD.bazel
+++ b/pkg/kv/kvserver/batcheval/BUILD.bazel
@@ -68,7 +68,6 @@ go_library(
         "//pkg/kv/kvserver/kvserverbase",
         "//pkg/kv/kvserver/kvserverpb",
         "//pkg/kv/kvserver/lockspanset",
-        "//pkg/kv/kvserver/logstore",
         "//pkg/kv/kvserver/rditer",
         "//pkg/kv/kvserver/readsummary",
         "//pkg/kv/kvserver/readsummary/rspb",

--- a/pkg/kv/kvserver/batcheval/BUILD.bazel
+++ b/pkg/kv/kvserver/batcheval/BUILD.bazel
@@ -68,6 +68,7 @@ go_library(
         "//pkg/kv/kvserver/kvserverbase",
         "//pkg/kv/kvserver/kvserverpb",
         "//pkg/kv/kvserver/lockspanset",
+        "//pkg/kv/kvserver/logstore",
         "//pkg/kv/kvserver/rditer",
         "//pkg/kv/kvserver/readsummary",
         "//pkg/kv/kvserver/readsummary/rspb",

--- a/pkg/kv/kvserver/batcheval/cmd_delete_range.go
+++ b/pkg/kv/kvserver/batcheval/cmd_delete_range.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/lockspanset"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/spanset"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/stateloader"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
@@ -138,7 +139,7 @@ func deleteRangeUsingTombstone(
 			return nil
 		}
 		sl := MakeStateLoader(cArgs.EvalCtx)
-		hint, err := sl.LoadGCHint(ctx, readWriter)
+		hint, err := sl.LoadGCHint(ctx, stateloader.MakeStateReader(readWriter))
 		if err != nil {
 			return err
 		}
@@ -154,7 +155,7 @@ func deleteRangeUsingTombstone(
 			return nil
 		}
 
-		if err := sl.SetGCHint(ctx, readWriter, cArgs.Stats, hint); err != nil {
+		if err := sl.SetGCHint(ctx, stateloader.MakeStateRW(readWriter), cArgs.Stats, hint); err != nil {
 			return err
 		}
 		res.Replicated.State = &kvserverpb.ReplicaState{

--- a/pkg/kv/kvserver/batcheval/cmd_end_transaction.go
+++ b/pkg/kv/kvserver/batcheval/cmd_end_transaction.go
@@ -20,7 +20,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/lockspanset"
-	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/logstore"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/rditer"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/readsummary"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/spanset"
@@ -1414,7 +1413,7 @@ func splitTriggerHelper(
 			return enginepb.MVCCStats{}, result.Result{}, errors.Wrap(err, "unable to load replica version")
 		}
 		*h.AbsPostSplitRight(), err = stateloader.WriteInitialReplicaState(ctx,
-			stateloader.MakeStateRW(batch), logstore.MakeLogWriter(batch),
+			stateloader.MakeStateRW(batch),
 			*h.AbsPostSplitRight(), split.RightDesc, rightLease,
 			*gcThreshold, *gcHint, replicaVersion,
 		)

--- a/pkg/kv/kvserver/batcheval/cmd_end_transaction.go
+++ b/pkg/kv/kvserver/batcheval/cmd_end_transaction.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/lockspanset"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/logstore"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/rditer"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/readsummary"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/spanset"
@@ -1412,8 +1413,9 @@ func splitTriggerHelper(
 		if err != nil {
 			return enginepb.MVCCStats{}, result.Result{}, errors.Wrap(err, "unable to load replica version")
 		}
-		*h.AbsPostSplitRight(), err = stateloader.WriteInitialReplicaState(
-			ctx, batch, *h.AbsPostSplitRight(), split.RightDesc, rightLease,
+		*h.AbsPostSplitRight(), err = stateloader.WriteInitialReplicaState(ctx,
+			stateloader.MakeStateRW(batch), logstore.MakeLogWriter(batch),
+			*h.AbsPostSplitRight(), split.RightDesc, rightLease,
 			*gcThreshold, *gcHint, replicaVersion,
 		)
 		if err != nil {

--- a/pkg/kv/kvserver/batcheval/cmd_end_transaction_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_end_transaction_test.go
@@ -2353,13 +2353,9 @@ func TestSplitTriggerWritesInitialReplicaState(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, loadedGCHint)
 	require.Equal(t, gcHint, *loadedGCHint)
-	expTruncState := kvserverpb.RaftTruncatedState{
-		Term:  stateloader.RaftInitialLogTerm,
-		Index: stateloader.RaftInitialLogIndex,
-	}
 	loadedTruncState, err := slRight.LoadRaftTruncatedState(ctx, logstore.MakeLogReader(batch))
 	require.NoError(t, err)
-	require.Equal(t, expTruncState, loadedTruncState)
+	require.Equal(t, kvserverpb.RaftTruncatedState{}, loadedTruncState)
 	loadedVersion, err := slRight.LoadVersion(ctx, rw.Reader())
 	require.NoError(t, err)
 	require.Equal(t, version, loadedVersion)

--- a/pkg/kv/kvserver/batcheval/cmd_lease.go
+++ b/pkg/kv/kvserver/batcheval/cmd_lease.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/readsummary"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/readsummary/rspb"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/stateloader"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
@@ -82,7 +83,9 @@ func evalNewLease(
 	}
 
 	// Store the lease to disk & in-memory.
-	if err := MakeStateLoader(rec).SetLeaseBlind(ctx, readWriter, ms, lease, prevLease); err != nil {
+	if err := MakeStateLoader(rec).SetLeaseBlind(
+		ctx, stateloader.MakeStateRW(readWriter), ms, lease, prevLease,
+	); err != nil {
 		return newFailedLeaseTrigger(isTransfer), err
 	}
 

--- a/pkg/kv/kvserver/batcheval/cmd_migrate.go
+++ b/pkg/kv/kvserver/batcheval/cmd_migrate.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/lockspanset"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/spanset"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/stateloader"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/errors"
@@ -71,7 +72,7 @@ func Migrate(
 	// Since we're a below raft migration, we'll need update our replica state
 	// version.
 	if err := MakeStateLoader(cArgs.EvalCtx).SetVersion(
-		ctx, readWriter, cArgs.Stats, &migrationVersion,
+		ctx, stateloader.MakeStateRW(readWriter), cArgs.Stats, &migrationVersion,
 	); err != nil {
 		return result.Result{}, err
 	}

--- a/pkg/kv/kvserver/batcheval/cmd_recompute_stats.go
+++ b/pkg/kv/kvserver/batcheval/cmd_recompute_stats.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/lockspanset"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/rditer"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/spanset"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/stateloader"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
@@ -80,7 +81,8 @@ func RecomputeStats(
 		return result.Result{}, err
 	}
 
-	currentStats, err := MakeStateLoader(cArgs.EvalCtx).LoadMVCCStats(ctx, reader)
+	currentStats, err := MakeStateLoader(cArgs.EvalCtx).LoadMVCCStats(
+		ctx, stateloader.MakeStateReader(reader))
 	if err != nil {
 		return result.Result{}, err
 	}

--- a/pkg/kv/kvserver/client_manual_proposal_test.go
+++ b/pkg/kv/kvserver/client_manual_proposal_test.go
@@ -117,7 +117,7 @@ LIMIT
 	require.NoError(t, err)
 	defer it.Close()
 	rsl := logstore.NewStateLoader(rangeID)
-	lastIndex, err := rsl.LoadLastIndex(ctx, eng)
+	lastIndex, err := rsl.LoadLastIndex(ctx, logstore.MakeLogReader(eng))
 	require.NoError(t, err)
 	t.Logf("loaded LastIndex: %d", lastIndex)
 	ok, err := it.SeekGE(lastIndex)
@@ -138,7 +138,7 @@ LIMIT
 		}))
 
 	sl := stateloader.Make(rangeID)
-	lease, err := sl.LoadLease(ctx, eng)
+	lease, err := sl.LoadLease(ctx, stateloader.MakeStateReader(eng))
 	require.NoError(t, err)
 
 	for batchIdx := 0; batchIdx < batches; batchIdx++ {

--- a/pkg/kv/kvserver/client_merge_test.go
+++ b/pkg/kv/kvserver/client_merge_test.go
@@ -1366,7 +1366,7 @@ func TestStoreRangeMergeStats(t *testing.T) {
 	// merge below.
 
 	// Get the range stats for both ranges now that we have data.
-	snap := store.TODOEngine().NewSnapshot()
+	snap := stateloader.MakeStateReader(store.TODOEngine().NewSnapshot())
 	defer snap.Close()
 	msA, err := stateloader.Make(lhsDesc.RangeID).LoadMVCCStats(ctx, snap)
 	require.NoError(t, err)
@@ -1384,7 +1384,7 @@ func TestStoreRangeMergeStats(t *testing.T) {
 	replMerged := store.LookupReplica(lhsDesc.StartKey)
 
 	// Get the range stats for the merged range and verify.
-	snap = store.TODOEngine().NewSnapshot()
+	snap = stateloader.MakeStateReader(store.TODOEngine().NewSnapshot())
 	defer snap.Close()
 	msMerged, err := stateloader.Make(replMerged.RangeID).LoadMVCCStats(ctx, snap)
 	require.NoError(t, err)

--- a/pkg/kv/kvserver/client_raft_test.go
+++ b/pkg/kv/kvserver/client_raft_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness/livenesspb"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/logstore"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/rditer"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/stateloader"
 	raft "github.com/cockroachdb/cockroach/pkg/raft"
@@ -5312,7 +5313,8 @@ func TestProcessSplitAfterRightHandSideHasBeenRemoved(t *testing.T) {
 		getHardState := func(
 			t *testing.T, store *kvserver.Store, rangeID roachpb.RangeID,
 		) raftpb.HardState {
-			hs, err := stateloader.Make(rangeID).LoadHardState(ctx, store.TODOEngine())
+			hs, err := stateloader.Make(rangeID).LoadHardState(
+				ctx, logstore.MakeLogReader(store.TODOEngine()))
 			require.NoError(t, err)
 			return hs
 		}

--- a/pkg/kv/kvserver/client_replica_test.go
+++ b/pkg/kv/kvserver/client_replica_test.go
@@ -4917,7 +4917,7 @@ func TestRangeMigration(t *testing.T) {
 		}
 
 		sl := stateloader.Make(rangeID)
-		persistedV, err := sl.LoadVersion(ctx, store.TODOEngine())
+		persistedV, err := sl.LoadVersion(ctx, stateloader.MakeStateReader(store.TODOEngine()))
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/kv/kvserver/client_store_test.go
+++ b/pkg/kv/kvserver/client_store_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/logstore"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/stateloader"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server"
@@ -93,7 +94,8 @@ func TestStoreRaftReplicaID(t *testing.T) {
 	require.NoError(t, err)
 	repl, err := store.GetReplica(desc.RangeID)
 	require.NoError(t, err)
-	replicaID, err := stateloader.Make(desc.RangeID).LoadRaftReplicaID(ctx, store.TODOEngine())
+	replicaID, err := stateloader.Make(desc.RangeID).LoadRaftReplicaID(
+		ctx, logstore.MakeLogReader(store.TODOEngine()))
 	require.NoError(t, err)
 	require.Equal(t, repl.ReplicaID(), replicaID.ReplicaID)
 
@@ -103,8 +105,8 @@ func TestStoreRaftReplicaID(t *testing.T) {
 	require.NoError(t, err)
 	rhsRepl, err := store.GetReplica(rhsDesc.RangeID)
 	require.NoError(t, err)
-	rhsReplicaID, err :=
-		stateloader.Make(rhsDesc.RangeID).LoadRaftReplicaID(ctx, store.TODOEngine())
+	rhsReplicaID, err := stateloader.Make(rhsDesc.RangeID).LoadRaftReplicaID(
+		ctx, logstore.MakeLogReader(store.TODOEngine()))
 	require.NoError(t, err)
 	require.Equal(t, rhsRepl.ReplicaID(), rhsReplicaID.ReplicaID)
 }

--- a/pkg/kv/kvserver/client_test.go
+++ b/pkg/kv/kvserver/client_test.go
@@ -173,7 +173,8 @@ func assertRangeStats(
 ) {
 	t.Helper()
 
-	ms, err := stateloader.Make(rangeID).LoadMVCCStats(context.Background(), r)
+	ms, err := stateloader.Make(rangeID).LoadMVCCStats(
+		context.Background(), stateloader.MakeStateReader(r))
 	require.NoError(t, err)
 	// When used with a real wall clock these will not be the same, since it
 	// takes time to load stats.

--- a/pkg/kv/kvserver/consistency_queue_test.go
+++ b/pkg/kv/kvserver/consistency_queue_test.go
@@ -537,7 +537,7 @@ func testConsistencyQueueRecomputeStatsImpl(t *testing.T, hadEstimates bool) {
 		defer eng.Close()
 
 		rsl := stateloader.Make(rangeID)
-		ms, err := rsl.LoadMVCCStats(ctx, eng)
+		ms, err := rsl.LoadMVCCStats(ctx, stateloader.MakeStateReader(eng))
 		require.NoError(t, err)
 
 		// Put some garbage in the stats that we're hoping the consistency queue will
@@ -553,7 +553,7 @@ func testConsistencyQueueRecomputeStatsImpl(t *testing.T, hadEstimates bool) {
 		// Overwrite with the new stats; remember that this range hasn't upreplicated,
 		// so the consistency checker won't see any replica divergence when it runs,
 		// but it should definitely see that its recomputed stats mismatch.
-		require.NoError(t, rsl.SetMVCCStats(ctx, eng, &ms))
+		require.NoError(t, rsl.SetMVCCStats(ctx, stateloader.MakeStateRW(eng), &ms))
 	}()
 
 	// Now that we've tampered with the stats, restart the cluster and extend it

--- a/pkg/kv/kvserver/flow_control_integration_test.go
+++ b/pkg/kv/kvserver/flow_control_integration_test.go
@@ -5822,7 +5822,7 @@ func TestFlowControlSendQueueRangeMigrate(t *testing.T) {
 		}
 
 		sl := stateloader.Make(desc.RangeID)
-		persistedV, err := sl.LoadVersion(ctx, store.TODOEngine())
+		persistedV, err := sl.LoadVersion(ctx, stateloader.MakeStateReader(store.TODOEngine()))
 		if err != nil {
 			return err
 		}

--- a/pkg/kv/kvserver/kvstorage/BUILD.bazel
+++ b/pkg/kv/kvserver/kvstorage/BUILD.bazel
@@ -6,7 +6,6 @@ go_library(
         "cluster_version.go",
         "destroy.go",
         "doc.go",
-        "engine.go",
         "init.go",
         "replica_state.go",
     ],

--- a/pkg/kv/kvserver/kvstorage/BUILD.bazel
+++ b/pkg/kv/kvserver/kvstorage/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
         "cluster_version.go",
         "destroy.go",
         "doc.go",
+        "engine.go",
         "init.go",
         "replica_state.go",
     ],

--- a/pkg/kv/kvserver/kvstorage/datadriven_test.go
+++ b/pkg/kv/kvserver/kvstorage/datadriven_test.go
@@ -65,9 +65,10 @@ func (e *env) handleNewReplica(
 	k, ek roachpb.RKey,
 ) *roachpb.RangeDescriptor {
 	sl := logstore.NewStateLoader(id.RangeID)
-	require.NoError(t, sl.SetHardState(ctx, e.eng, raftpb.HardState{}))
+	writer := logstore.MakeLogWriter(e.eng)
+	require.NoError(t, sl.SetHardState(ctx, writer, raftpb.HardState{}))
 	if !skipRaftReplicaID && id.ReplicaID != 0 {
-		require.NoError(t, sl.SetRaftReplicaID(ctx, e.eng, id.ReplicaID))
+		require.NoError(t, sl.SetRaftReplicaID(ctx, writer, id.ReplicaID))
 	}
 	if len(ek) == 0 {
 		return nil

--- a/pkg/kv/kvserver/kvstorage/destroy.go
+++ b/pkg/kv/kvserver/kvstorage/destroy.go
@@ -106,6 +106,7 @@ func DestroyReplica(
 	rangeID roachpb.RangeID,
 	reader storage.Reader,
 	writer storage.Writer,
+	r LogReader,
 	nextReplicaID roachpb.ReplicaID,
 	opts ClearRangeDataOptions,
 ) error {

--- a/pkg/kv/kvserver/kvstorage/destroy.go
+++ b/pkg/kv/kvserver/kvstorage/destroy.go
@@ -106,11 +106,11 @@ func DestroyReplica(
 	rangeID roachpb.RangeID,
 	reader storage.Reader,
 	writer storage.Writer,
-	r LogReader,
 	nextReplicaID roachpb.ReplicaID,
 	opts ClearRangeDataOptions,
 ) error {
-	diskReplicaID, err := logstore.NewStateLoader(rangeID).LoadRaftReplicaID(ctx, reader)
+	diskReplicaID, err := logstore.NewStateLoader(rangeID).LoadRaftReplicaID(
+		ctx, logstore.MakeLogReader(reader))
 	if err != nil {
 		return err
 	}

--- a/pkg/kv/kvserver/kvstorage/engine.go
+++ b/pkg/kv/kvserver/kvstorage/engine.go
@@ -1,0 +1,13 @@
+package kvstorage
+
+import "github.com/cockroachdb/cockroach/pkg/storage"
+
+// SeparatedEngine is a stepping stone for separating the raft log and state
+// machine storages. It allows callers of NewStore to pass in "two engines"
+// masquerading as one. This is not the intended end state, where it will most
+// likely make sense to pass in two engines. But for prototyping an
+// experimentation, this approach avoids large amounts of refactoring.
+type SeparatedEngine interface {
+	storage.Engine
+	LogEngine() storage.Engine
+}

--- a/pkg/kv/kvserver/kvstorage/engine.go
+++ b/pkg/kv/kvserver/kvstorage/engine.go
@@ -1,0 +1,30 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package kvstorage
+
+import "github.com/cockroachdb/cockroach/pkg/storage"
+
+type StateEngine storage.Engine
+
+type StateReader struct {
+	storage.Reader
+}
+
+func MakeStateReader(r storage.Reader) StateReader {
+	return StateReader{Reader: r}
+}
+
+type StateReadWriter struct {
+	storage.ReadWriter
+}
+
+func MakeStateRW(rw storage.ReadWriter) StateReadWriter {
+	return StateReadWriter{ReadWriter: rw}
+}
+
+func (rw StateReadWriter) Reader() StateReader {
+	return StateReader{Reader: rw.ReadWriter}
+}

--- a/pkg/kv/kvserver/kvstorage/init.go
+++ b/pkg/kv/kvserver/kvstorage/init.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/logstore"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/stateloader"
 	"github.com/cockroachdb/cockroach/pkg/raft/raftpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -405,10 +406,14 @@ func (r Replica) Load(
 	}
 	sl := stateloader.Make(r.Desc.RangeID)
 	var err error
-	if ls.LastIndex, err = sl.LoadLastIndex(ctx, eng); err != nil {
+	if ls.LastIndex, err = sl.LoadLastIndex(
+		ctx, logstore.MakeLogReader(eng),
+	); err != nil {
 		return LoadedReplicaState{}, err
 	}
-	if ls.TruncState, err = sl.LoadRaftTruncatedState(ctx, eng); err != nil {
+	if ls.TruncState, err = sl.LoadRaftTruncatedState(
+		ctx, logstore.MakeLogReader(eng),
+	); err != nil {
 		return LoadedReplicaState{}, err
 	}
 	if ls.ReplState, err = sl.Load(ctx, eng, r.Desc); err != nil {

--- a/pkg/kv/kvserver/kvstorage/init.go
+++ b/pkg/kv/kvserver/kvstorage/init.go
@@ -416,7 +416,7 @@ func (r Replica) Load(
 	); err != nil {
 		return LoadedReplicaState{}, err
 	}
-	if ls.ReplState, err = sl.Load(ctx, eng, r.Desc); err != nil {
+	if ls.ReplState, err = sl.Load(ctx, stateloader.MakeStateReader(eng), r.Desc); err != nil {
 		return LoadedReplicaState{}, err
 	}
 

--- a/pkg/kv/kvserver/kvstorage/replica_state.go
+++ b/pkg/kv/kvserver/kvstorage/replica_state.go
@@ -63,7 +63,7 @@ func LoadReplicaState(
 	if ls.LastIndex, err = sl.LoadLastIndex(ctx, logstore.MakeLogReader(eng)); err != nil {
 		return LoadedReplicaState{}, err
 	}
-	if ls.ReplState, err = sl.Load(ctx, eng, desc); err != nil {
+	if ls.ReplState, err = sl.Load(ctx, stateloader.MakeStateReader(eng), desc); err != nil {
 		return LoadedReplicaState{}, err
 	}
 

--- a/pkg/kv/kvserver/liveness/BUILD.bazel
+++ b/pkg/kv/kvserver/liveness/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
         "//pkg/keys",
         "//pkg/kv",
         "//pkg/kv/kvpb",
+        "//pkg/kv/kvserver/kvstorage",
         "//pkg/kv/kvserver/liveness/livenesspb",
         "//pkg/roachpb",
         "//pkg/rpc",

--- a/pkg/kv/kvserver/liveness/liveness.go
+++ b/pkg/kv/kvserver/liveness/liveness.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/gossip"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvstorage"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness/livenesspb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
@@ -1089,6 +1090,9 @@ func (nl *NodeLiveness) updateLiveness(
 func (nl *NodeLiveness) verifyDiskHealth(ctx context.Context) error {
 	resultCs := make([]singleflight.Future, len(nl.engines))
 	for i, eng := range nl.engines {
+		if se, ok := eng.(kvstorage.SeparatedEngine); ok {
+			eng = se.LogEngine()
+		}
 		resultCs[i], _ = nl.engineSyncs.DoChan(ctx,
 			strconv.Itoa(i),
 			singleflight.DoOpts{

--- a/pkg/kv/kvserver/logstore/BUILD.bazel
+++ b/pkg/kv/kvserver/logstore/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "logstore",
     srcs = [
         "bytes_tracker.go",
+        "engine.go",
         "logstore.go",
         "sideload.go",
         "sideload_disk.go",

--- a/pkg/kv/kvserver/logstore/engine.go
+++ b/pkg/kv/kvserver/logstore/engine.go
@@ -1,0 +1,37 @@
+package logstore
+
+import "github.com/cockroachdb/cockroach/pkg/storage"
+
+type LogEngine storage.Engine
+
+type LogReader struct {
+	storage.Reader
+}
+
+func MakeLogReader(r storage.Reader) LogReader {
+	return LogReader{Reader: r}
+}
+
+type LogWriter struct {
+	storage.Writer
+}
+
+func MakeLogWriter(w storage.Writer) LogWriter {
+	return LogWriter{Writer: w}
+}
+
+type LogReadWriter struct {
+	storage.ReadWriter
+}
+
+func MakeLogRW(rw storage.ReadWriter) LogReadWriter {
+	return LogReadWriter{ReadWriter: rw}
+}
+
+func (rw LogReadWriter) Writer() LogWriter {
+	return LogWriter{Writer: rw.ReadWriter}
+}
+
+func (rw LogReadWriter) Reader() LogReader {
+	return LogReader{Reader: rw.ReadWriter}
+}

--- a/pkg/kv/kvserver/logstore/stateloader.go
+++ b/pkg/kv/kvserver/logstore/stateloader.go
@@ -151,7 +151,7 @@ func (sl StateLoader) SetHardState(
 // taking care that a HardState compatible with the existing data is written.
 func (sl StateLoader) SynthesizeHardState(
 	ctx context.Context,
-	writer storage.Writer,
+	writer LogWriter,
 	oldHS raftpb.HardState,
 	truncState kvserverpb.RaftTruncatedState,
 	raftAppliedIndex kvpb.RaftIndex,
@@ -192,7 +192,7 @@ func (sl StateLoader) SynthesizeHardState(
 
 // SetRaftReplicaID overwrites the RaftReplicaID.
 func (sl StateLoader) SetRaftReplicaID(
-	ctx context.Context, writer storage.Writer, replicaID roachpb.ReplicaID,
+	ctx context.Context, writer LogWriter, replicaID roachpb.ReplicaID,
 ) error {
 	rid := kvserverpb.RaftReplicaID{ReplicaID: replicaID}
 	// "Blind" because opts.Stats == nil and timestamp.IsEmpty().
@@ -208,7 +208,7 @@ func (sl StateLoader) SetRaftReplicaID(
 
 // LoadRaftReplicaID loads the RaftReplicaID.
 func (sl StateLoader) LoadRaftReplicaID(
-	ctx context.Context, reader storage.Reader,
+	ctx context.Context, reader LogReader,
 ) (*kvserverpb.RaftReplicaID, error) {
 	var replicaID kvserverpb.RaftReplicaID
 	found, err := storage.MVCCGetProto(ctx, reader, sl.RaftReplicaIDKey(),

--- a/pkg/kv/kvserver/loqrecovery/BUILD.bazel
+++ b/pkg/kv/kvserver/loqrecovery/BUILD.bazel
@@ -28,6 +28,7 @@ go_library(
         "//pkg/kv/kvserver/kvstorage",
         "//pkg/kv/kvserver/liveness",
         "//pkg/kv/kvserver/liveness/livenesspb",
+        "//pkg/kv/kvserver/logstore",
         "//pkg/kv/kvserver/loqrecovery/loqrecoverypb",
         "//pkg/kv/kvserver/raftlog",
         "//pkg/kv/kvserver/stateloader",

--- a/pkg/kv/kvserver/loqrecovery/BUILD.bazel
+++ b/pkg/kv/kvserver/loqrecovery/BUILD.bazel
@@ -90,6 +90,7 @@ go_test(
         "//pkg/kv/kvserver/kvserverbase",
         "//pkg/kv/kvserver/kvserverpb",
         "//pkg/kv/kvserver/kvstorage",
+        "//pkg/kv/kvserver/logstore",
         "//pkg/kv/kvserver/loqrecovery/loqrecoverypb",
         "//pkg/kv/kvserver/raftlog",
         "//pkg/kv/kvserver/stateloader",

--- a/pkg/kv/kvserver/loqrecovery/apply.go
+++ b/pkg/kv/kvserver/loqrecovery/apply.go
@@ -210,7 +210,7 @@ func applyReplicaUpdate(
 	}
 
 	sl := stateloader.Make(localDesc.RangeID)
-	ms, err := sl.LoadMVCCStats(ctx, readWriter)
+	ms, err := sl.LoadMVCCStats(ctx, stateloader.MakeStateReader(readWriter))
 	if err != nil {
 		return PrepareReplicaReport{}, errors.Wrap(err, "loading MVCCStats")
 	}
@@ -307,7 +307,7 @@ func applyReplicaUpdate(
 	}
 
 	// Refresh stats
-	if err := sl.SetMVCCStats(ctx, readWriter, &ms); err != nil {
+	if err := sl.SetMVCCStats(ctx, stateloader.MakeStateRW(readWriter), &ms); err != nil {
 		return PrepareReplicaReport{}, errors.Wrap(err, "updating MVCCStats")
 	}
 

--- a/pkg/kv/kvserver/loqrecovery/collect.go
+++ b/pkg/kv/kvserver/loqrecovery/collect.go
@@ -185,7 +185,7 @@ func visitStoreReplicas(
 	targetVersion clusterversion.ClusterVersion,
 	send func(info loqrecoverypb.ReplicaInfo) error,
 ) error {
-	if err := kvstorage.IterateRangeDescriptorsFromDisk(ctx, reader, func(desc roachpb.RangeDescriptor) error {
+	if err := kvstorage.IterateRangeDescriptorsFromDisk(ctx, stateloader.MakeStateReader(reader), func(desc roachpb.RangeDescriptor) error {
 		rsl := stateloader.Make(desc.RangeID)
 		rstate, err := rsl.Load(ctx, stateloader.MakeStateReader(reader), &desc)
 		if err != nil {

--- a/pkg/kv/kvserver/loqrecovery/collect.go
+++ b/pkg/kv/kvserver/loqrecovery/collect.go
@@ -187,7 +187,7 @@ func visitStoreReplicas(
 ) error {
 	if err := kvstorage.IterateRangeDescriptorsFromDisk(ctx, reader, func(desc roachpb.RangeDescriptor) error {
 		rsl := stateloader.Make(desc.RangeID)
-		rstate, err := rsl.Load(ctx, reader, &desc)
+		rstate, err := rsl.Load(ctx, stateloader.MakeStateReader(reader), &desc)
 		if err != nil {
 			return err
 		}

--- a/pkg/kv/kvserver/loqrecovery/collect.go
+++ b/pkg/kv/kvserver/loqrecovery/collect.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvstorage"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/logstore"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/loqrecovery/loqrecoverypb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/raftlog"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/stateloader"
@@ -190,7 +191,7 @@ func visitStoreReplicas(
 		if err != nil {
 			return err
 		}
-		hstate, err := rsl.LoadHardState(ctx, reader)
+		hstate, err := rsl.LoadHardState(ctx, logstore.MakeLogReader(reader))
 		if err != nil {
 			return err
 		}

--- a/pkg/kv/kvserver/metrics.go
+++ b/pkg/kv/kvserver/metrics.go
@@ -1008,6 +1008,12 @@ bytes preserved during flushes and compactions over the lifetime of the process.
 		Measurement: "Nanoseconds",
 		Unit:        metric.Unit_NANOSECONDS,
 	}
+	metaBatchCommitSyncs = metric.Metadata{
+		Name:        "storage.batch-commit.syncs",
+		Help:        "Number of times a batch commit was done with WAL sync.",
+		Measurement: "Count",
+		Unit:        metric.Unit_COUNT,
+	}
 	metaSSTableZombieBytes = metric.Metadata{
 		Name: "storage.sstable.zombie.bytes",
 		Help: "Bytes in SSTables that have been logically deleted, " +
@@ -2754,6 +2760,7 @@ type StoreMetrics struct {
 	BatchCommitL0StallDuration        *metric.Counter
 	BatchCommitWALRotWaitDuration     *metric.Counter
 	BatchCommitCommitWaitDuration     *metric.Counter
+	BatchCommitSyncs                  *metric.Counter
 	SSTableZombieBytes                *metric.Gauge
 	SSTableCompressionSnappy          *metric.Gauge
 	SSTableCompressionZstd            *metric.Gauge
@@ -3475,6 +3482,7 @@ func newStoreMetrics(histogramWindow time.Duration) *StoreMetrics {
 		BatchCommitL0StallDuration:        metric.NewCounter(metaBatchCommitL0StallDuration),
 		BatchCommitWALRotWaitDuration:     metric.NewCounter(metaBatchCommitWALRotDuration),
 		BatchCommitCommitWaitDuration:     metric.NewCounter(metaBatchCommitCommitWaitDuration),
+		BatchCommitSyncs:                  metric.NewCounter(metaBatchCommitSyncs),
 		SSTableZombieBytes:                metric.NewGauge(metaSSTableZombieBytes),
 		SSTableCompressionSnappy:          metric.NewGauge(metaSSTableCompressionSnappy),
 		SSTableCompressionZstd:            metric.NewGauge(metaSSTableCompressionZstd),
@@ -3933,6 +3941,7 @@ func (sm *StoreMetrics) updateEngineMetrics(m storage.Metrics) {
 	sm.BatchCommitL0StallDuration.Update(int64(m.BatchCommitStats.L0ReadAmpWriteStallDuration))
 	sm.BatchCommitWALRotWaitDuration.Update(int64(m.BatchCommitStats.WALRotationDuration))
 	sm.BatchCommitCommitWaitDuration.Update(int64(m.BatchCommitStats.CommitWaitDuration))
+	sm.BatchCommitSyncs.Update(int64(m.BatchCommitStats.Syncs))
 	sm.SSTableZombieBytes.Update(int64(m.Table.ZombieSize))
 	sm.SSTableCompressionSnappy.Update(m.Table.CompressedCountSnappy)
 	sm.SSTableCompressionZstd.Update(m.Table.CompressedCountZstd)

--- a/pkg/kv/kvserver/raft_log_truncator.go
+++ b/pkg/kv/kvserver/raft_log_truncator.go
@@ -526,7 +526,7 @@ func (t *raftLogTruncator) tryEnactTruncations(
 
 	// Use the reader to decide what is durable.
 	stateLoader := r.getStateLoader()
-	as, err := stateLoader.LoadRangeAppliedState(ctx, reader)
+	as, err := stateLoader.LoadRangeAppliedState(ctx, stateloader.MakeStateReader(reader))
 	if err != nil {
 		log.Errorf(ctx, "error loading RangeAppliedState, dropping all pending log truncations: %s",
 			err)

--- a/pkg/kv/kvserver/raftlog/BUILD.bazel
+++ b/pkg/kv/kvserver/raftlog/BUILD.bazel
@@ -18,7 +18,6 @@ go_library(
         "//pkg/kv/kvserver/kvflowcontrol/kvflowcontrolpb",
         "//pkg/kv/kvserver/kvserverbase",
         "//pkg/kv/kvserver/kvserverpb",
-        "//pkg/kv/kvserver/logstore",
         "//pkg/raft/raftpb",
         "//pkg/roachpb",
         "//pkg/storage",

--- a/pkg/kv/kvserver/raftlog/BUILD.bazel
+++ b/pkg/kv/kvserver/raftlog/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "//pkg/kv/kvserver/kvflowcontrol/kvflowcontrolpb",
         "//pkg/kv/kvserver/kvserverbase",
         "//pkg/kv/kvserver/kvserverpb",
+        "//pkg/kv/kvserver/logstore",
         "//pkg/raft/raftpb",
         "//pkg/roachpb",
         "//pkg/storage",

--- a/pkg/kv/kvserver/raftlog/iterator.go
+++ b/pkg/kv/kvserver/raftlog/iterator.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
-	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/logstore"
 	"github.com/cockroachdb/cockroach/pkg/raft/raftpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
@@ -67,7 +66,7 @@ type IterOptions struct {
 //
 // Callers that can afford allocating a closure may prefer using Visit.
 func NewIterator(
-	ctx context.Context, rangeID roachpb.RangeID, eng logstore.LogReader, opts IterOptions,
+	ctx context.Context, rangeID roachpb.RangeID, eng storage.Reader, opts IterOptions,
 ) (*Iterator, error) {
 	// TODO(tbg): can pool these most of the things below, incl. the *Iterator.
 	prefixBuf := keys.MakeRangeIDPrefixBuf(rangeID)
@@ -140,7 +139,7 @@ func (it *Iterator) Entry() raftpb.Entry {
 // without returning an error.
 func Visit(
 	ctx context.Context,
-	reader logstore.LogReader,
+	reader storage.Reader,
 	rangeID roachpb.RangeID,
 	lo, hi kvpb.RaftIndex,
 	fn func(raftpb.Entry) error,

--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -1779,7 +1779,7 @@ func (r *Replica) assertStateRaftMuLockedReplicaMuRLocked(
 	}
 
 	diskState, err := r.mu.stateLoader.Load(
-		ctx, stateloader.MakeStateReader(reader), r.shMu.state.Desc)
+		ctx, stateloader.MakeStateReader(r.store.StateEngine()), r.shMu.state.Desc)
 	if err != nil {
 		log.Fatalf(ctx, "%v", err)
 	}

--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -1778,7 +1778,8 @@ func (r *Replica) assertStateRaftMuLockedReplicaMuRLocked(
 			redact.Safe(pretty.Diff(loaded, ts)))
 	}
 
-	diskState, err := r.mu.stateLoader.Load(ctx, reader, r.shMu.state.Desc)
+	diskState, err := r.mu.stateLoader.Load(
+		ctx, stateloader.MakeStateReader(reader), r.shMu.state.Desc)
 	if err != nil {
 		log.Fatalf(ctx, "%v", err)
 	}

--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -1769,7 +1769,9 @@ func (r *Replica) assertStateRaftMuLockedReplicaMuRLocked(
 ) {
 	if ts := r.shMu.state.TruncatedState; ts != nil {
 		log.Fatalf(ctx, "non-empty RaftTruncatedState in ReplicaState: %+v", ts)
-	} else if loaded, err := r.mu.stateLoader.LoadRaftTruncatedState(ctx, reader); err != nil {
+	} else if loaded, err := r.mu.stateLoader.LoadRaftTruncatedState(
+		ctx, logstore.MakeLogReader(reader),
+	); err != nil {
 		log.Fatalf(ctx, "%s", err)
 	} else if ts := r.shMu.raftTruncState; loaded != ts {
 		log.Fatalf(ctx, "on-disk and in-memory RaftTruncatedState diverged: %s",
@@ -1833,7 +1835,7 @@ func (r *Replica) assertStateRaftMuLockedReplicaMuRLocked(
 			log.Fatalf(ctx, "replica's replicaID %d diverges from descriptor %+v", r.replicaID, r.shMu.state.Desc)
 		}
 	}
-	diskReplID, err := r.mu.stateLoader.LoadRaftReplicaID(ctx, reader)
+	diskReplID, err := r.mu.stateLoader.LoadRaftReplicaID(ctx, logstore.MakeLogReader(reader))
 	if err != nil {
 		log.Fatalf(ctx, "%s", err)
 	}

--- a/pkg/kv/kvserver/replica_app_batch.go
+++ b/pkg/kv/kvserver/replica_app_batch.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvstorage"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/stateloader"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -578,7 +579,8 @@ func (b *replicaAppBatch) stageTrivialReplicatedEvalResult(
 		// are all safe.
 		b.state.ForceFlushIndex = roachpb.ForceFlushIndex{Index: cmd.Entry.Index}
 		if err := b.r.raftMu.stateLoader.SetForceFlushIndex(
-			ctx, b.batch, b.state.Stats, &b.state.ForceFlushIndex); err != nil {
+			ctx, stateloader.MakeStateRW(b.batch), b.state.Stats, &b.state.ForceFlushIndex,
+		); err != nil {
 			return err
 		}
 	}
@@ -709,7 +711,8 @@ func (b *replicaAppBatch) addAppliedStateKeyToBatch(ctx context.Context) error {
 	// lease index along with the mvcc stats, all in one key.
 	loader := &b.r.raftMu.stateLoader
 	return loader.SetRangeAppliedState(
-		ctx, b.batch, b.state.RaftAppliedIndex, b.state.LeaseAppliedIndex, b.state.RaftAppliedIndexTerm,
+		ctx, stateloader.MakeStateRW(b.batch), b.state.RaftAppliedIndex,
+		b.state.LeaseAppliedIndex, b.state.RaftAppliedIndexTerm,
 		b.state.Stats, b.state.RaftClosedTimestamp, &b.asAlloc,
 	)
 }

--- a/pkg/kv/kvserver/replica_app_batch.go
+++ b/pkg/kv/kvserver/replica_app_batch.go
@@ -308,7 +308,9 @@ func (b *replicaAppBatch) runPostAddTriggersReplicaOnly(
 		//
 		// Alternatively if we discover that the RHS has already been removed
 		// from this store, clean up its data.
-		splitPreApply(ctx, b.r, b.batch, res.Split.SplitTrigger, cmd.Cmd.ClosedTimestamp)
+		splitPreApply(ctx, b.r,
+			stateloader.MakeStateRW(b.batch), logstore.MakeLogRW(b.batch),
+			res.Split.SplitTrigger, cmd.Cmd.ClosedTimestamp)
 
 		// The rangefeed processor will no longer be provided logical ops for
 		// its entire range, so it needs to be shut down and all registrations

--- a/pkg/kv/kvserver/replica_application_state_machine.go
+++ b/pkg/kv/kvserver/replica_application_state_machine.go
@@ -140,7 +140,8 @@ func (sm *replicaStateMachine) NewBatch() apply.Batch {
 	b := &sm.batch
 	b.r = r
 	b.applyStats = &sm.applyStats
-	b.batch = r.store.TODOEngine().NewBatch()
+	b.batch = r.store.StateEngine().NewBatch()
+	b.logBatch = r.store.LogEngine().NewBatch()
 	r.mu.RLock()
 	b.state = r.shMu.state
 	b.truncState = r.shMu.raftTruncState

--- a/pkg/kv/kvserver/replica_application_state_machine.go
+++ b/pkg/kv/kvserver/replica_application_state_machine.go
@@ -203,7 +203,7 @@ func (sm *replicaStateMachine) ApplySideEffects(
 			sm.r.mu.RLock()
 			// TODO(sep-raft-log): either check only statemachine invariants or
 			// pass both engines in.
-			sm.r.assertStateRaftMuLockedReplicaMuRLocked(ctx, sm.r.store.TODOEngine())
+			sm.r.assertStateRaftMuLockedReplicaMuRLocked(ctx, sm.r.store.LogEngine())
 			sm.r.mu.RUnlock()
 			sm.applyStats.stateAssertions++
 		}

--- a/pkg/kv/kvserver/replica_application_state_machine_test.go
+++ b/pkg/kv/kvserver/replica_application_state_machine_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/apply"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/logstore"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/raftlog"
 	"github.com/cockroachdb/cockroach/pkg/raft/raftpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -248,7 +249,8 @@ func TestReplicaStateMachineRaftLogTruncationStronglyCoupled(t *testing.T) {
 			}
 			require.Equal(t, expectedSize, r.shMu.raftLogSize)
 			require.Equal(t, accurate, r.shMu.raftLogSizeTrusted)
-			truncState, err := r.mu.stateLoader.LoadRaftTruncatedState(context.Background(), tc.engine)
+			truncState, err := r.mu.stateLoader.LoadRaftTruncatedState(context.Background(),
+				logstore.MakeLogReader(tc.engine))
 			require.NoError(t, err)
 			require.Equal(t, r.shMu.raftTruncState.Index, truncState.Index)
 		}()

--- a/pkg/kv/kvserver/replica_consistency.go
+++ b/pkg/kv/kvserver/replica_consistency.go
@@ -636,7 +636,8 @@ func CalcReplicaDigest(
 		result.RecomputedMS = ms
 	}
 
-	rangeAppliedState, err := stateloader.Make(desc.RangeID).LoadRangeAppliedState(ctx, snap)
+	rangeAppliedState, err := stateloader.Make(desc.RangeID).LoadRangeAppliedState(
+		ctx, stateloader.MakeStateReader(snap))
 	if err != nil {
 		return nil, err
 	}
@@ -697,7 +698,7 @@ func (r *Replica) computeChecksumPostApply(
 	}
 	if cc.Checkpoint {
 		sl := stateloader.Make(r.RangeID)
-		as, err := sl.LoadRangeAppliedState(ctx, snap)
+		as, err := sl.LoadRangeAppliedState(ctx, stateloader.MakeStateReader(snap))
 		if err != nil {
 			log.Warningf(ctx, "unable to load applied index, continuing anyway")
 		}

--- a/pkg/kv/kvserver/replica_init.go
+++ b/pkg/kv/kvserver/replica_init.go
@@ -209,7 +209,7 @@ func newUninitializedReplicaWithoutRaftGroup(
 	)
 	r.raftMu.logStorage = &logstore.LogStore{
 		RangeID:     rangeID,
-		Engine:      store.TODOEngine(),
+		Engine:      store.LogEngine(),
 		Sideload:    r.raftMu.sideloaded,
 		StateLoader: r.raftMu.stateLoader.StateLoader,
 		// NOTE: use the same SyncWaiter loop for all raft log writes performed by a

--- a/pkg/kv/kvserver/replica_init.go
+++ b/pkg/kv/kvserver/replica_init.go
@@ -65,7 +65,10 @@ func loadInitializedReplicaForTesting(
 	if !desc.IsInitialized() {
 		return nil, errors.AssertionFailedf("can not load with uninitialized descriptor: %s", desc)
 	}
-	state, err := kvstorage.LoadReplicaState(ctx, store.TODOEngine(), store.StoreID(), desc, replicaID)
+	state, err := kvstorage.LoadReplicaState(ctx,
+		logstore.MakeLogReader(store.LogEngine()),
+		stateloader.MakeStateReader(store.StateEngine()),
+		store.StoreID(), desc, replicaID)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kv/kvserver/replica_raft_truncation_test.go
+++ b/pkg/kv/kvserver/replica_raft_truncation_test.go
@@ -64,7 +64,7 @@ func TestHandleTruncatedStateBelowRaft(t *testing.T) {
 					Term:  kvpb.RaftTerm(term),
 				}
 
-				require.NoError(t, loader.SetRaftTruncatedState(ctx, eng, truncState))
+				require.NoError(t, loader.SetRaftTruncatedState(ctx, logstore.MakeLogWriter(eng), truncState))
 				return ""
 
 			case "handle":
@@ -77,7 +77,7 @@ func TestHandleTruncatedStateBelowRaft(t *testing.T) {
 					Index: kvpb.RaftIndex(index),
 					Term:  kvpb.RaftTerm(term),
 				}
-				currentTruncatedState, err := loader.LoadRaftTruncatedState(ctx, eng)
+				currentTruncatedState, err := loader.LoadRaftTruncatedState(ctx, logstore.MakeLogReader(eng))
 				require.NoError(t, err)
 
 				// Write log entries at start, middle, end, and above the truncated interval.

--- a/pkg/kv/kvserver/replica_raftlog.go
+++ b/pkg/kv/kvserver/replica_raftlog.go
@@ -80,7 +80,7 @@ func (r *replicaLogStorage) entriesLocked(
 	// TODO(pav-kv): r.raftMu.bytesAccount is broken - can't rely on raftMu here.
 	entries, _, loadedSize, err := logstore.LoadEntries(
 		r.AnnotateCtx(context.TODO()),
-		r.mu.stateLoader.StateLoader, r.store.TODOEngine(), r.RangeID,
+		r.mu.stateLoader.StateLoader, r.store.LogEngine(), r.RangeID,
 		r.store.raftEntryCache, r.raftMu.sideloaded, lo, hi, maxBytes,
 		&r.raftMu.bytesAccount,
 	)
@@ -117,7 +117,7 @@ func (r *replicaLogStorage) termLocked(i kvpb.RaftIndex) (kvpb.RaftTerm, error) 
 		return r.shMu.lastTermNotDurable, nil
 	}
 	return logstore.LoadTerm(r.AnnotateCtx(context.TODO()),
-		r.mu.stateLoader.StateLoader, r.store.TODOEngine(), r.RangeID,
+		r.mu.stateLoader.StateLoader, r.store.LogEngine(), r.RangeID,
 		r.store.raftEntryCache, i,
 	)
 }
@@ -225,7 +225,7 @@ func (r *replicaRaftMuLogSnap) entriesRaftMuLocked(
 	// TODO(pav-kv): de-duplicate this code and the one where r.mu must be held.
 	entries, _, loadedSize, err := logstore.LoadEntries(
 		r.AnnotateCtx(context.TODO()),
-		r.raftMu.stateLoader.StateLoader, r.store.TODOEngine(), r.RangeID,
+		r.raftMu.stateLoader.StateLoader, r.store.LogEngine(), r.RangeID,
 		r.store.raftEntryCache, r.raftMu.sideloaded, lo, hi, maxBytes,
 		&r.raftMu.bytesAccount,
 	)
@@ -252,7 +252,7 @@ func (r *replicaRaftMuLogSnap) termRaftMuLocked(i kvpb.RaftIndex) (kvpb.RaftTerm
 		return r.shMu.lastTermNotDurable, nil
 	}
 	return logstore.LoadTerm(r.AnnotateCtx(context.TODO()),
-		r.raftMu.stateLoader.StateLoader, r.store.TODOEngine(), r.RangeID,
+		r.raftMu.stateLoader.StateLoader, r.store.LogEngine(), r.RangeID,
 		r.store.raftEntryCache, i,
 	)
 }

--- a/pkg/kv/kvserver/replica_raftstorage.go
+++ b/pkg/kv/kvserver/replica_raftstorage.go
@@ -986,7 +986,11 @@ func clearSubsumedReplicaDiskData(
 			UnreplicatedByRangeID: opts.ClearUnreplicatedByRangeID,
 		})
 		clearedSpans = append(clearedSpans, subsumedClearedSpans...)
-		if err := kvstorage.DestroyReplica(ctx, subDesc.RangeID, reader, &subsumedReplSST, subsumedNextReplicaID, opts); err != nil {
+		if err := kvstorage.DestroyReplica(ctx, subDesc.RangeID,
+			logstore.MakeLogRW(nil),      // FIXME: reader
+			stateloader.MakeStateRW(nil), // &subsumedReplSST
+			subsumedNextReplicaID, opts,
+		); err != nil {
 			subsumedReplSST.Close()
 			return nil, err
 		}

--- a/pkg/kv/kvserver/replica_raftstorage.go
+++ b/pkg/kv/kvserver/replica_raftstorage.go
@@ -345,7 +345,7 @@ func snapshot(
 	// TODO(sep-raft-log): do not load the state that is not useful for sending
 	// snapshots, e.g. Lease, GCThreshold, etc. Only applied indices and the
 	// descriptor are used, everything else is included in the snapshot data.
-	state, err := rsl.Load(ctx, snap, &desc)
+	state, err := rsl.Load(ctx, stateloader.MakeStateReader(snap), &desc)
 	if err != nil {
 		return OutgoingSnapshot{}, err
 	}
@@ -660,7 +660,7 @@ func (r *Replica) applySnapshot(
 	// treated as fatal.
 
 	sl := stateloader.Make(desc.RangeID)
-	state, err := sl.Load(ctx, r.store.TODOEngine(), desc)
+	state, err := sl.Load(ctx, stateloader.MakeStateReader(r.store.TODOEngine()), desc)
 	if err != nil {
 		log.Fatalf(ctx, "unable to load replica state: %s", err)
 	}

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -6394,7 +6394,8 @@ func TestReplicaResolveIntentRange(t *testing.T) {
 func verifyRangeStats(
 	reader storage.Reader, rangeID roachpb.RangeID, expMS enginepb.MVCCStats,
 ) error {
-	ms, err := stateloader.Make(rangeID).LoadMVCCStats(context.Background(), reader)
+	ms, err := stateloader.Make(rangeID).LoadMVCCStats(
+		context.Background(), stateloader.MakeStateReader(reader))
 	if err != nil {
 		return err
 	}
@@ -10440,7 +10441,7 @@ func TestReplicaRecomputeStats(t *testing.T) {
 	disturbMS := enginepb.NewPopulatedMVCCStats(rnd, false)
 	disturbMS.ContainsEstimates = 0
 	ms.Add(*disturbMS)
-	err := repl.raftMu.stateLoader.SetMVCCStats(ctx, tc.engine, ms)
+	err := repl.raftMu.stateLoader.SetMVCCStats(ctx, stateloader.MakeStateRW(tc.engine), ms)
 	repl.assertStateRaftMuLockedReplicaMuRLocked(ctx, tc.engine)
 	repl.mu.Unlock()
 	repl.raftMu.Unlock()

--- a/pkg/kv/kvserver/split_queue_test.go
+++ b/pkg/kv/kvserver/split_queue_test.go
@@ -93,8 +93,9 @@ func TestSplitQueueShouldQueue(t *testing.T) {
 		cpy.StartKey = test.start
 		cpy.EndKey = test.end
 		replicaID := cpy.Replicas().VoterDescriptors()[0].ReplicaID
-		require.NoError(t,
-			logstore.NewStateLoader(cpy.RangeID).SetRaftReplicaID(ctx, tc.store.TODOEngine(), replicaID))
+		require.NoError(t, logstore.NewStateLoader(cpy.RangeID).SetRaftReplicaID(
+			ctx, logstore.MakeLogWriter(tc.store.TODOEngine()), replicaID,
+		))
 		repl, err := loadInitializedReplicaForTesting(ctx, tc.store, &cpy, replicaID)
 		if err != nil {
 			t.Fatal(err)

--- a/pkg/kv/kvserver/stateloader/BUILD.bazel
+++ b/pkg/kv/kvserver/stateloader/BUILD.bazel
@@ -35,6 +35,7 @@ go_test(
     deps = [
         "//pkg/kv/kvpb",
         "//pkg/kv/kvserver/kvserverpb",
+        "//pkg/kv/kvserver/logstore",
         "//pkg/raft/raftpb",
         "//pkg/roachpb",
         "//pkg/storage",

--- a/pkg/kv/kvserver/stateloader/BUILD.bazel
+++ b/pkg/kv/kvserver/stateloader/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "stateloader",
     srcs = [
+        "engine.go",
         "initial.go",
         "stateloader.go",
     ],

--- a/pkg/kv/kvserver/stateloader/engine.go
+++ b/pkg/kv/kvserver/stateloader/engine.go
@@ -1,9 +1,4 @@
-// Copyright 2025 The Cockroach Authors.
-//
-// Use of this software is governed by the CockroachDB Software License
-// included in the /LICENSE file.
-
-package kvstorage
+package stateloader
 
 import "github.com/cockroachdb/cockroach/pkg/storage"
 

--- a/pkg/kv/kvserver/stateloader/initial.go
+++ b/pkg/kv/kvserver/stateloader/initial.go
@@ -9,6 +9,7 @@ import (
 	"context"
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/logstore"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
@@ -89,7 +90,9 @@ func WriteInitialReplicaState(
 
 	// TODO(sep-raft-log): SetRaftTruncatedState will be in a separate batch when
 	// the Raft log engine is separated. Figure out the ordering required here.
-	if err := rsl.SetRaftTruncatedState(ctx, readWriter, truncState); err != nil {
+	if err := rsl.SetRaftTruncatedState(
+		ctx, logstore.MakeLogWriter(readWriter), truncState,
+	); err != nil {
 		return enginepb.MVCCStats{}, err
 	}
 	newMS, err := rsl.Save(ctx, readWriter, s)
@@ -129,7 +132,9 @@ func WriteInitialRangeState(
 	}
 	// Maintain the invariant that any replica (uninitialized or initialized),
 	// with persistent state, has a RaftReplicaID.
-	if err := sl.SetRaftReplicaID(ctx, readWriter, replicaID); err != nil {
+	if err := sl.SetRaftReplicaID(
+		ctx, logstore.MakeLogWriter(readWriter), replicaID,
+	); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/kv/kvserver/stateloader/initial_test.go
+++ b/pkg/kv/kvserver/stateloader/initial_test.go
@@ -64,8 +64,9 @@ func TestSynthesizeHardState(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			err = rsl.SynthesizeHardState(
-				context.Background(), batch.Writer(), oldHS, kvserverpb.RaftTruncatedState{Term: test.TruncTerm}, test.RaftAppliedIndex,
+			err = rsl.SynthesizeHardState(context.Background(), batch.Writer(),
+				oldHS, kvserverpb.RaftTruncatedState{Term: test.TruncTerm},
+				test.RaftAppliedIndex, test.TruncTerm,
 			)
 			if !testutils.IsError(err, test.Err) {
 				t.Fatalf("%d: expected %q got %v", i, test.Err, err)

--- a/pkg/kv/kvserver/stateloader/stateloader.go
+++ b/pkg/kv/kvserver/stateloader/stateloader.go
@@ -48,7 +48,7 @@ func Make(rangeID roachpb.RangeID) StateLoader {
 // updated transactionally, and is populated from the supplied RangeDescriptor
 // under the convention that that is the latest committed version.
 func (rsl StateLoader) Load(
-	ctx context.Context, reader storage.Reader, desc *roachpb.RangeDescriptor,
+	ctx context.Context, reader StateReader, desc *roachpb.RangeDescriptor,
 ) (kvserverpb.ReplicaState, error) {
 	var s kvserverpb.ReplicaState
 	// TODO(tschottdorf): figure out whether this is always synchronous with
@@ -111,7 +111,7 @@ func (rsl StateLoader) Load(
 // missing whenever save is called. Optional values should be reserved
 // strictly for use in Result. Do before merge.
 func (rsl StateLoader) Save(
-	ctx context.Context, readWriter storage.ReadWriter, state kvserverpb.ReplicaState,
+	ctx context.Context, readWriter StateReadWriter, state kvserverpb.ReplicaState,
 ) (enginepb.MVCCStats, error) {
 	ms := state.Stats
 	if err := rsl.SetLease(ctx, readWriter, ms, *state.Lease); err != nil {
@@ -144,9 +144,7 @@ func (rsl StateLoader) Save(
 }
 
 // LoadLease loads the lease.
-func (rsl StateLoader) LoadLease(
-	ctx context.Context, reader storage.Reader,
-) (roachpb.Lease, error) {
+func (rsl StateLoader) LoadLease(ctx context.Context, reader StateReader) (roachpb.Lease, error) {
 	var lease roachpb.Lease
 	_, err := storage.MVCCGetProto(ctx, reader, rsl.RangeLeaseKey(),
 		hlc.Timestamp{}, &lease, storage.MVCCGetOptions{})
@@ -155,7 +153,7 @@ func (rsl StateLoader) LoadLease(
 
 // SetLease persists a lease.
 func (rsl StateLoader) SetLease(
-	ctx context.Context, readWriter storage.ReadWriter, ms *enginepb.MVCCStats, lease roachpb.Lease,
+	ctx context.Context, readWriter StateReadWriter, ms *enginepb.MVCCStats, lease roachpb.Lease,
 ) error {
 	return storage.MVCCPutProto(ctx, readWriter, rsl.RangeLeaseKey(),
 		hlc.Timestamp{}, &lease, storage.MVCCWriteOptions{Stats: ms})
@@ -173,7 +171,7 @@ func (rsl StateLoader) SetLease(
 // fail below Raft, so it doesn't matter if the stats are wrong.
 func (rsl StateLoader) SetLeaseBlind(
 	ctx context.Context,
-	readWriter storage.ReadWriter,
+	readWriter StateReadWriter,
 	ms *enginepb.MVCCStats,
 	lease, prevLease roachpb.Lease,
 ) error {
@@ -194,7 +192,7 @@ func (rsl StateLoader) SetLeaseBlind(
 
 // LoadRangeAppliedState loads the Range applied state.
 func (rsl StateLoader) LoadRangeAppliedState(
-	ctx context.Context, reader storage.Reader,
+	ctx context.Context, reader StateReader,
 ) (*kvserverpb.RangeAppliedState, error) {
 	var as kvserverpb.RangeAppliedState
 	_, err := storage.MVCCGetProto(ctx, reader, rsl.RangeAppliedStateKey(), hlc.Timestamp{}, &as,
@@ -204,7 +202,7 @@ func (rsl StateLoader) LoadRangeAppliedState(
 
 // LoadMVCCStats loads the MVCC stats.
 func (rsl StateLoader) LoadMVCCStats(
-	ctx context.Context, reader storage.Reader,
+	ctx context.Context, reader StateReader,
 ) (enginepb.MVCCStats, error) {
 	// Check the applied state key.
 	as, err := rsl.LoadRangeAppliedState(ctx, reader)
@@ -222,7 +220,7 @@ func (rsl StateLoader) LoadMVCCStats(
 // by the range applied state key.
 func (rsl StateLoader) SetRangeAppliedState(
 	ctx context.Context,
-	readWriter storage.ReadWriter,
+	readWriter StateReadWriter,
 	appliedIndex kvpb.RaftIndex,
 	leaseAppliedIndex kvpb.LeaseAppliedIndex,
 	appliedIndexTerm kvpb.RaftTerm,
@@ -252,9 +250,9 @@ func (rsl StateLoader) SetRangeAppliedState(
 // RangeAppliedState key before overwriting the stats. Use SetRangeAppliedState
 // when performance is important.
 func (rsl StateLoader) SetMVCCStats(
-	ctx context.Context, readWriter storage.ReadWriter, newMS *enginepb.MVCCStats,
+	ctx context.Context, readWriter StateReadWriter, newMS *enginepb.MVCCStats,
 ) error {
-	as, err := rsl.LoadRangeAppliedState(ctx, readWriter)
+	as, err := rsl.LoadRangeAppliedState(ctx, readWriter.Reader())
 	if err != nil {
 		return err
 	}
@@ -266,9 +264,9 @@ func (rsl StateLoader) SetMVCCStats(
 
 // SetClosedTimestamp overwrites the closed timestamp.
 func (rsl StateLoader) SetClosedTimestamp(
-	ctx context.Context, readWriter storage.ReadWriter, closedTS hlc.Timestamp,
+	ctx context.Context, readWriter StateReadWriter, closedTS hlc.Timestamp,
 ) error {
-	as, err := rsl.LoadRangeAppliedState(ctx, readWriter)
+	as, err := rsl.LoadRangeAppliedState(ctx, readWriter.Reader())
 	if err != nil {
 		return err
 	}
@@ -280,7 +278,7 @@ func (rsl StateLoader) SetClosedTimestamp(
 
 // LoadGCThreshold loads the GC threshold.
 func (rsl StateLoader) LoadGCThreshold(
-	ctx context.Context, reader storage.Reader,
+	ctx context.Context, reader StateReader,
 ) (*hlc.Timestamp, error) {
 	var t hlc.Timestamp
 	_, err := storage.MVCCGetProto(ctx, reader, rsl.RangeGCThresholdKey(),
@@ -290,10 +288,7 @@ func (rsl StateLoader) LoadGCThreshold(
 
 // SetGCThreshold sets the GC threshold.
 func (rsl StateLoader) SetGCThreshold(
-	ctx context.Context,
-	readWriter storage.ReadWriter,
-	ms *enginepb.MVCCStats,
-	threshold *hlc.Timestamp,
+	ctx context.Context, readWriter StateReadWriter, ms *enginepb.MVCCStats, threshold *hlc.Timestamp,
 ) error {
 	if threshold == nil {
 		return errors.New("cannot persist nil GCThreshold")
@@ -304,7 +299,7 @@ func (rsl StateLoader) SetGCThreshold(
 
 // LoadGCHint loads GC hint.
 func (rsl StateLoader) LoadGCHint(
-	ctx context.Context, reader storage.Reader,
+	ctx context.Context, reader StateReader,
 ) (*roachpb.GCHint, error) {
 	var h roachpb.GCHint
 	_, err := storage.MVCCGetProto(ctx, reader, rsl.RangeGCHintKey(),
@@ -317,7 +312,7 @@ func (rsl StateLoader) LoadGCHint(
 
 // SetGCHint writes the GC hint.
 func (rsl StateLoader) SetGCHint(
-	ctx context.Context, readWriter storage.ReadWriter, ms *enginepb.MVCCStats, hint *roachpb.GCHint,
+	ctx context.Context, readWriter StateReadWriter, ms *enginepb.MVCCStats, hint *roachpb.GCHint,
 ) error {
 	if hint == nil {
 		return errors.New("cannot persist nil GCHint")
@@ -328,7 +323,7 @@ func (rsl StateLoader) SetGCHint(
 
 // LoadVersion loads the replica version.
 func (rsl StateLoader) LoadVersion(
-	ctx context.Context, reader storage.Reader,
+	ctx context.Context, reader StateReader,
 ) (roachpb.Version, error) {
 	var version roachpb.Version
 	_, err := storage.MVCCGetProto(ctx, reader, rsl.RangeVersionKey(),
@@ -338,10 +333,7 @@ func (rsl StateLoader) LoadVersion(
 
 // SetVersion sets the replica version.
 func (rsl StateLoader) SetVersion(
-	ctx context.Context,
-	readWriter storage.ReadWriter,
-	ms *enginepb.MVCCStats,
-	version *roachpb.Version,
+	ctx context.Context, readWriter StateReadWriter, ms *enginepb.MVCCStats, version *roachpb.Version,
 ) error {
 	return storage.MVCCPutProto(ctx, readWriter, rsl.RangeVersionKey(),
 		hlc.Timestamp{}, version, storage.MVCCWriteOptions{Stats: ms})
@@ -349,7 +341,7 @@ func (rsl StateLoader) SetVersion(
 
 // LoadRangeForceFlushIndex loads the force-flush index.
 func (rsl StateLoader) LoadRangeForceFlushIndex(
-	ctx context.Context, reader storage.Reader,
+	ctx context.Context, reader StateReader,
 ) (roachpb.ForceFlushIndex, error) {
 	var ffIndex roachpb.ForceFlushIndex
 	// If not found, ffIndex.Index will stay 0.
@@ -361,7 +353,7 @@ func (rsl StateLoader) LoadRangeForceFlushIndex(
 // SetForceFlushIndex sets the force-flush index.
 func (rsl StateLoader) SetForceFlushIndex(
 	ctx context.Context,
-	readWriter storage.ReadWriter,
+	readWriter StateReadWriter,
 	ms *enginepb.MVCCStats,
 	ffIndex *roachpb.ForceFlushIndex,
 ) error {
@@ -401,7 +393,7 @@ func (rsl StateLoader) SynthesizeRaftState(
 	if err != nil {
 		return err
 	}
-	as, err := rsl.LoadRangeAppliedState(ctx, readWriter)
+	as, err := rsl.LoadRangeAppliedState(ctx, MakeStateReader(readWriter))
 	if err != nil {
 		return err
 	}

--- a/pkg/kv/kvserver/stateloader/stateloader.go
+++ b/pkg/kv/kvserver/stateloader/stateloader.go
@@ -382,21 +382,20 @@ func UninitializedReplicaState(rangeID roachpb.RangeID) kvserverpb.ReplicaState 
 // WriteInitialReplicaState and, on a split, perhaps the activity of an
 // uninitialized Raft group)
 func (rsl StateLoader) SynthesizeRaftState(
-	ctx context.Context, readWriter storage.ReadWriter,
+	ctx context.Context, stateReader StateReader, logRW logstore.LogReadWriter,
 ) error {
-	hs, err := rsl.LoadHardState(ctx, logstore.MakeLogReader(readWriter))
+	hs, err := rsl.LoadHardState(ctx, logRW.Reader())
 	if err != nil {
 		return err
 	}
-	truncState, err := rsl.LoadRaftTruncatedState(
-		ctx, logstore.MakeLogReader(readWriter))
+	truncState, err := rsl.LoadRaftTruncatedState(ctx, logRW.Reader())
 	if err != nil {
 		return err
 	}
-	as, err := rsl.LoadRangeAppliedState(ctx, MakeStateReader(readWriter))
+	as, err := rsl.LoadRangeAppliedState(ctx, stateReader)
 	if err != nil {
 		return err
 	}
 	return rsl.SynthesizeHardState(
-		ctx, logstore.MakeLogWriter(readWriter), hs, truncState, as.RaftAppliedIndex)
+		ctx, logRW.Writer(), hs, truncState, as.RaftAppliedIndex)
 }

--- a/pkg/kv/kvserver/stateloader/stateloader.go
+++ b/pkg/kv/kvserver/stateloader/stateloader.go
@@ -392,11 +392,12 @@ func UninitializedReplicaState(rangeID roachpb.RangeID) kvserverpb.ReplicaState 
 func (rsl StateLoader) SynthesizeRaftState(
 	ctx context.Context, readWriter storage.ReadWriter,
 ) error {
-	hs, err := rsl.LoadHardState(ctx, readWriter)
+	hs, err := rsl.LoadHardState(ctx, logstore.MakeLogReader(readWriter))
 	if err != nil {
 		return err
 	}
-	truncState, err := rsl.LoadRaftTruncatedState(ctx, readWriter)
+	truncState, err := rsl.LoadRaftTruncatedState(
+		ctx, logstore.MakeLogReader(readWriter))
 	if err != nil {
 		return err
 	}
@@ -404,5 +405,6 @@ func (rsl StateLoader) SynthesizeRaftState(
 	if err != nil {
 		return err
 	}
-	return rsl.SynthesizeHardState(ctx, readWriter, hs, truncState, as.RaftAppliedIndex)
+	return rsl.SynthesizeHardState(
+		ctx, logstore.MakeLogWriter(readWriter), hs, truncState, as.RaftAppliedIndex)
 }

--- a/pkg/kv/kvserver/stateloader/stateloader.go
+++ b/pkg/kv/kvserver/stateloader/stateloader.go
@@ -396,6 +396,6 @@ func (rsl StateLoader) SynthesizeRaftState(
 	if err != nil {
 		return err
 	}
-	return rsl.SynthesizeHardState(
-		ctx, logRW.Writer(), hs, truncState, as.RaftAppliedIndex)
+	return rsl.SynthesizeHardState(ctx, logRW.Writer(),
+		hs, truncState, as.RaftAppliedIndex, as.RaftAppliedIndexTerm)
 }

--- a/pkg/kv/kvserver/stateloader/stateloader_test.go
+++ b/pkg/kv/kvserver/stateloader/stateloader_test.go
@@ -18,7 +18,7 @@ func TestUninitializedReplicaState(t *testing.T) {
 	eng := storage.NewDefaultInMemForTesting()
 	defer eng.Close()
 	desc := roachpb.RangeDescriptor{RangeID: 123}
-	exp, err := Make(desc.RangeID).Load(context.Background(), eng, &desc)
+	exp, err := Make(desc.RangeID).Load(context.Background(), MakeStateReader(eng), &desc)
 	require.NoError(t, err)
 	act := UninitializedReplicaState(desc.RangeID)
 	require.Equal(t, exp, act)

--- a/pkg/kv/kvserver/stats_test.go
+++ b/pkg/kv/kvserver/stats_test.go
@@ -44,10 +44,10 @@ func TestRangeStatsInit(t *testing.T) {
 		LastUpdateNanos: 11,
 	}
 	rsl := stateloader.Make(tc.repl.RangeID)
-	if err := rsl.SetMVCCStats(ctx, tc.engine, &ms); err != nil {
+	if err := rsl.SetMVCCStats(ctx, stateloader.MakeStateRW(tc.engine), &ms); err != nil {
 		t.Fatal(err)
 	}
-	loadMS, err := rsl.LoadMVCCStats(ctx, tc.engine)
+	loadMS, err := rsl.LoadMVCCStats(ctx, stateloader.MakeStateReader(tc.engine))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -3682,9 +3682,10 @@ func (s *Store) computeMetricsLocked(ctx context.Context) (m storage.Metrics, er
 	}
 
 	// Get the latest engine metrics.
-	m = s.TODOEngine().GetMetrics()
+	m = s.StateEngine().GetMetrics()
 	_ = s.TODOEngine() // TODO(sep-raft-log): log engine should also have metrics
 	s.metrics.updateEngineMetrics(m)
+	s.metrics.updateLogEngineMetrics(s.LogEngine().GetMetrics())
 
 	// Get engine Env stats.
 	envStats, err := s.TODOEngine().GetEnvStats()

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -1463,6 +1463,16 @@ func (sc *StoreConfig) Tracer() *tracing.Tracer {
 	return sc.AmbientCtx.Tracer
 }
 
+// SeparatedEngine is a stepping stone for separating the raft log and state
+// machine storages. It allows callers of NewStore to pass in "two engines"
+// masquerading as one. This is not the intended end state, where it will most
+// likely make sense to pass in two engines. But for prototyping an
+// experimentation, this approach avoids large amounts of refactoring.
+type SeparatedEngine interface {
+	storage.Engine
+	LogEngine() storage.Engine
+}
+
 // NewStore returns a new instance of a store.
 func NewStore(
 	ctx context.Context, cfg StoreConfig, eng storage.Engine, nodeDesc *roachpb.NodeDescriptor,
@@ -1472,6 +1482,10 @@ func NewStore(
 	}
 	iot := ioThresholds{}
 	iot.Replace(nil, 1.0) // init as empty
+	logEngine := eng
+	if engines, ok := eng.(SeparatedEngine); ok {
+		logEngine = engines.LogEngine()
+	}
 	s := &Store{
 		// NB: do not access these fields directly. Instead, use
 		// the StateEngine, TODOEngine, LogEngine methods.
@@ -1480,7 +1494,7 @@ func NewStore(
 		internalEngines: internalEngines{
 			stateEngine: eng,
 			todoEngine:  eng,
-			logEngine:   eng,
+			logEngine:   logEngine,
 		},
 		cfg:                               cfg,
 		db:                                cfg.DB, // TODO(tschottdorf): remove redundancy.

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -1464,16 +1464,6 @@ func (sc *StoreConfig) Tracer() *tracing.Tracer {
 	return sc.AmbientCtx.Tracer
 }
 
-// SeparatedEngine is a stepping stone for separating the raft log and state
-// machine storages. It allows callers of NewStore to pass in "two engines"
-// masquerading as one. This is not the intended end state, where it will most
-// likely make sense to pass in two engines. But for prototyping an
-// experimentation, this approach avoids large amounts of refactoring.
-type SeparatedEngine interface {
-	storage.Engine
-	LogEngine() storage.Engine
-}
-
 // NewStore returns a new instance of a store.
 func NewStore(
 	ctx context.Context, cfg StoreConfig, eng storage.Engine, nodeDesc *roachpb.NodeDescriptor,
@@ -1484,7 +1474,7 @@ func NewStore(
 	iot := ioThresholds{}
 	iot.Replace(nil, 1.0) // init as empty
 	logEngine := eng
-	if engines, ok := eng.(SeparatedEngine); ok {
+	if engines, ok := eng.(kvstorage.SeparatedEngine); ok {
 		logEngine = engines.LogEngine()
 	}
 	s := &Store{

--- a/pkg/kv/kvserver/store_init.go
+++ b/pkg/kv/kvserver/store_init.go
@@ -209,7 +209,7 @@ func WriteInitialClusterData(
 		}
 
 		logBatch := batch
-		if sepEng, ok := eng.(SeparatedEngine); ok {
+		if sepEng, ok := eng.(kvstorage.SeparatedEngine); ok {
 			logBatch = sepEng.LogEngine().NewBatch()
 			defer logBatch.Close()
 		}

--- a/pkg/kv/kvserver/store_init.go
+++ b/pkg/kv/kvserver/store_init.go
@@ -11,6 +11,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvstorage"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness/livenesspb"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/logstore"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/rditer"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/stateloader"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -207,8 +208,11 @@ func WriteInitialClusterData(
 			}
 		}
 
-		if err := stateloader.WriteInitialRangeState(
-			ctx, batch, *desc, firstReplicaID, initialReplicaVersion); err != nil {
+		if err := stateloader.WriteInitialRangeState(ctx,
+			stateloader.MakeStateRW(batch),
+			logstore.MakeLogRW(batch),
+			*desc, firstReplicaID, initialReplicaVersion,
+		); err != nil {
 			return err
 		}
 		computedStats, err := rditer.ComputeStatsForRange(ctx, desc, batch, now.WallTime)

--- a/pkg/kv/kvserver/store_init.go
+++ b/pkg/kv/kvserver/store_init.go
@@ -217,7 +217,7 @@ func WriteInitialClusterData(
 		}
 
 		sl := stateloader.Make(rangeID)
-		if err := sl.SetMVCCStats(ctx, batch, &computedStats); err != nil {
+		if err := sl.SetMVCCStats(ctx, stateloader.MakeStateRW(batch), &computedStats); err != nil {
 			return err
 		}
 

--- a/pkg/kv/kvserver/store_pool_test.go
+++ b/pkg/kv/kvserver/store_pool_test.go
@@ -263,7 +263,8 @@ func TestStorePoolUpdateLocalStoreBeforeGossip(t *testing.T) {
 
 	const replicaID = 1
 	require.NoError(t,
-		logstore.NewStateLoader(rg.RangeID).SetRaftReplicaID(ctx, store.TODOEngine(), replicaID))
+		logstore.NewStateLoader(rg.RangeID).SetRaftReplicaID(
+			ctx, logstore.MakeLogWriter(store.TODOEngine()), replicaID))
 	replica, err := loadInitializedReplicaForTesting(ctx, store, &rg, replicaID)
 	if err != nil {
 		t.Fatalf("make replica error : %+v", err)

--- a/pkg/kv/kvserver/store_snapshot.go
+++ b/pkg/kv/kvserver/store_snapshot.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/allocator/storepool"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/logstore"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/multiqueue"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/rditer"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/stateloader"
@@ -1943,7 +1944,8 @@ func SendEmptySnapshot(
 
 	ms, err = stateloader.WriteInitialReplicaState(
 		ctx,
-		eng,
+		stateloader.MakeStateRW(eng),
+		logstore.MakeLogWriter(eng),
 		ms,
 		desc,
 		roachpb.Lease{},

--- a/pkg/kv/kvserver/store_snapshot.go
+++ b/pkg/kv/kvserver/store_snapshot.go
@@ -17,7 +17,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/allocator/storepool"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
-	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/logstore"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/multiqueue"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/rditer"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/stateloader"
@@ -1945,7 +1944,6 @@ func SendEmptySnapshot(
 	ms, err = stateloader.WriteInitialReplicaState(
 		ctx,
 		stateloader.MakeStateRW(eng),
-		logstore.MakeLogWriter(eng),
 		ms,
 		desc,
 		roachpb.Lease{},

--- a/pkg/kv/kvserver/store_snapshot.go
+++ b/pkg/kv/kvserver/store_snapshot.go
@@ -1957,7 +1957,7 @@ func SendEmptySnapshot(
 
 	// Use stateloader to load state out of memory from the previously created engine.
 	sl := stateloader.Make(desc.RangeID)
-	state, err := sl.Load(ctx, eng, &desc)
+	state, err := sl.Load(ctx, stateloader.MakeStateReader(eng), &desc)
 	if err != nil {
 		return err
 	}

--- a/pkg/kv/kvserver/store_split.go
+++ b/pkg/kv/kvserver/store_split.go
@@ -138,7 +138,9 @@ func splitPreApply(
 	// replica is initialized (combining it with existing or default
 	// Term and Vote). This is the common case.
 	rsl := stateloader.Make(split.RightDesc.RangeID)
-	if err := rsl.SynthesizeRaftState(ctx, readWriter); err != nil {
+	if err := rsl.SynthesizeRaftState(ctx,
+		stateloader.MakeStateReader(readWriter), logstore.MakeLogRW(readWriter),
+	); err != nil {
 		log.Fatalf(ctx, "%v", err)
 	}
 	// Write the RaftReplicaID for the RHS to maintain the invariant that any

--- a/pkg/kv/kvserver/store_split.go
+++ b/pkg/kv/kvserver/store_split.go
@@ -247,8 +247,10 @@ func prepareRightReplicaForSplit(
 	}
 	// Finish initialization of the RHS replica.
 
-	state, err := kvstorage.LoadReplicaState(
-		ctx, r.store.TODOEngine(), r.StoreID(), &split.RightDesc, rightRepl.replicaID)
+	state, err := kvstorage.LoadReplicaState(ctx,
+		logstore.MakeLogReader(r.store.LogEngine()),
+		stateloader.MakeStateReader(r.store.StateEngine()),
+		r.StoreID(), &split.RightDesc, rightRepl.replicaID)
 	if err != nil {
 		log.Fatalf(ctx, "%v", err)
 	}

--- a/pkg/kv/kvserver/store_split.go
+++ b/pkg/kv/kvserver/store_split.go
@@ -163,7 +163,9 @@ func splitPreApply(
 		initClosedTS = &hlc.Timestamp{}
 	}
 	initClosedTS.Forward(r.GetCurrentClosedTimestamp(ctx))
-	if err := rsl.SetClosedTimestamp(ctx, readWriter, *initClosedTS); err != nil {
+	if err := rsl.SetClosedTimestamp(
+		ctx, stateloader.MakeStateRW(readWriter), *initClosedTS,
+	); err != nil {
 		log.Fatalf(ctx, "%s", err)
 	}
 }

--- a/pkg/kv/kvserver/store_test.go
+++ b/pkg/kv/kvserver/store_test.go
@@ -589,8 +589,10 @@ func createReplica(s *Store, rangeID roachpb.RangeID, start, end roachpb.RKey) *
 		NextReplicaID: 2,
 	}
 	const replicaID = 1
-	if err := stateloader.WriteInitialRangeState(
-		ctx, s.TODOEngine(), *desc, replicaID, clusterversion.TestingClusterVersion.Version,
+	if err := stateloader.WriteInitialRangeState(ctx,
+		stateloader.MakeStateRW(s.TODOEngine()),
+		logstore.MakeLogRW(s.TODOEngine()),
+		*desc, replicaID, clusterversion.TestingClusterVersion.Version,
 	); err != nil {
 		panic(err)
 	}

--- a/pkg/kv/kvserver/store_test.go
+++ b/pkg/kv/kvserver/store_test.go
@@ -902,8 +902,8 @@ func TestMarkReplicaInitialized(t *testing.T) {
 
 	newRangeID := roachpb.RangeID(3)
 	const replicaID = 1
-	require.NoError(t,
-		logstore.NewStateLoader(newRangeID).SetRaftReplicaID(ctx, store.TODOEngine(), replicaID))
+	require.NoError(t, logstore.NewStateLoader(newRangeID).SetRaftReplicaID(
+		ctx, logstore.MakeLogWriter(store.TODOEngine()), replicaID))
 
 	r, err := newUninitializedReplica(store, newRangeID, replicaID)
 	require.NoError(t, err)
@@ -2790,7 +2790,8 @@ func TestStoreGCThreshold(t *testing.T) {
 		}
 		repl.mu.Lock()
 		gcThreshold := *repl.shMu.state.GCThreshold
-		pgcThreshold, err := repl.mu.stateLoader.LoadGCThreshold(context.Background(), store.TODOEngine())
+		pgcThreshold, err := repl.mu.stateLoader.LoadGCThreshold(
+			context.Background(), stateloader.MakeStateReader(store.TODOEngine()))
 		repl.mu.Unlock()
 		if err != nil {
 			t.Fatal(err)
@@ -4124,7 +4125,8 @@ func TestStoreGetOrCreateReplicaWritesRaftReplicaID(t *testing.T) {
 		})
 	require.NoError(t, err)
 	require.True(t, created)
-	replicaID, err := repl.mu.stateLoader.LoadRaftReplicaID(ctx, tc.store.TODOEngine())
+	replicaID, err := repl.mu.stateLoader.LoadRaftReplicaID(
+		ctx, logstore.MakeLogReader(tc.store.TODOEngine()))
 	require.NoError(t, err)
 	require.Equal(t, &kvserverpb.RaftReplicaID{ReplicaID: 7}, replicaID)
 }

--- a/pkg/kv/kvserver/stores_server.go
+++ b/pkg/kv/kvserver/stores_server.go
@@ -101,7 +101,7 @@ func (is Server) WaitForApplication(
 				// everything up to this point to disk.
 				//
 				// https://github.com/cockroachdb/cockroach/issues/33120
-				return storage.WriteSyncNoop(s.TODOEngine())
+				return storage.WriteSyncNoop(s.StateEngine())
 			}
 		}
 		if ctx.Err() == nil {

--- a/pkg/kv/kvserver/stores_test.go
+++ b/pkg/kv/kvserver/stores_test.go
@@ -154,8 +154,8 @@ func TestStoresGetReplicaForRangeID(t *testing.T) {
 			},
 		}
 
-		require.NoError(t,
-			logstore.NewStateLoader(desc.RangeID).SetRaftReplicaID(ctx, store.TODOEngine(), replicaID))
+		require.NoError(t, logstore.NewStateLoader(desc.RangeID).SetRaftReplicaID(
+			ctx, logstore.MakeLogWriter(store.TODOEngine()), replicaID))
 		replica, err := loadInitializedReplicaForTesting(ctx, store, desc, replicaID)
 		if err != nil {
 			t.Fatalf("unexpected error when creating replica: %+v", err)

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/rangefeed"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvstorage"
 	"github.com/cockroachdb/cockroach/pkg/multitenant/tenantcapabilities"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc"
@@ -696,7 +697,7 @@ type sepEngine struct {
 	logEng storage.Engine
 }
 
-var _ kvserver.SeparatedEngine = (*sepEngine)(nil)
+var _ kvstorage.SeparatedEngine = (*sepEngine)(nil)
 
 // LogEngine implements kvserver.SeparatedEngine.
 func (e *sepEngine) LogEngine() storage.Engine {

--- a/pkg/storage/engine.go
+++ b/pkg/storage/engine.go
@@ -1310,6 +1310,7 @@ type AggregatedIteratorStats struct {
 // histograms once we know which ones are more useful.
 type AggregatedBatchCommitStats struct {
 	Count uint64
+	Syncs uint64
 	BatchCommitStats
 }
 

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -1634,7 +1634,7 @@ func (p *Pebble) aggregateIterStats(stats IteratorStats) {
 	p.iterStats.InternalSteps += stats.Stats.ForwardStepCount[pebble.InternalIterCall] + stats.Stats.ReverseStepCount[pebble.InternalIterCall]
 }
 
-func (p *Pebble) aggregateBatchCommitStats(stats BatchCommitStats) {
+func (p *Pebble) aggregateBatchCommitStats(stats BatchCommitStats, sync bool) {
 	p.batchCommitStats.Lock()
 	p.batchCommitStats.Count++
 	p.batchCommitStats.TotalDuration += stats.TotalDuration
@@ -1644,6 +1644,9 @@ func (p *Pebble) aggregateBatchCommitStats(stats BatchCommitStats) {
 	p.batchCommitStats.L0ReadAmpWriteStallDuration += stats.L0ReadAmpWriteStallDuration
 	p.batchCommitStats.WALRotationDuration += stats.WALRotationDuration
 	p.batchCommitStats.CommitWaitDuration += stats.CommitWaitDuration
+	if sync {
+		p.batchCommitStats.Syncs++
+	}
 	p.batchCommitStats.Unlock()
 }
 

--- a/pkg/storage/pebble_batch.go
+++ b/pkg/storage/pebble_batch.go
@@ -69,7 +69,7 @@ type writeBatch struct {
 var _ WriteBatch = (*writeBatch)(nil)
 
 type batchStatsReporter interface {
-	aggregateBatchCommitStats(stats BatchCommitStats)
+	aggregateBatchCommitStats(stats BatchCommitStats, sync bool)
 }
 
 // ApplyBatchRepr implements the Writer interface.
@@ -365,7 +365,7 @@ func (wb *writeBatch) Commit(sync bool) error {
 		panic(err)
 	}
 	wb.batchStatsReporter.aggregateBatchCommitStats(
-		BatchCommitStats{wb.batch.CommitStats()})
+		BatchCommitStats{wb.batch.CommitStats()}, sync)
 	return err
 }
 
@@ -405,7 +405,7 @@ func (wb *writeBatch) SyncWait() error {
 		panic(err)
 	}
 	wb.batchStatsReporter.aggregateBatchCommitStats(
-		BatchCommitStats{wb.batch.CommitStats()})
+		BatchCommitStats{wb.batch.CommitStats()}, true)
 	return err
 }
 


### PR DESCRIPTION
Does not include:
- crash recovery
- engine tuning (can be added in `CreateEngines`)
- metrics for both engines (only have it for one or the other engine; plus there is a new metric for engine batches with sync=true).

To run:

```bash
dev build --cross cockroach
export COCKROACH_LOG_ENGINE_PATH=/mnt/data1/log-eng
roachtest run kv0/enc=false/nodes=3/cpu=32/seq$ --cockroach=artifacts/cockroach
```