### PR TITLE
testutils: add `GrantTenantCapabilities` to test interfaces

### DIFF
--- a/pkg/ccl/changefeedccl/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/BUILD.bazel
@@ -261,6 +261,7 @@ go_test(
         "//pkg/kv/kvserver/kvserverbase",
         "//pkg/kv/kvserver/protectedts",
         "//pkg/kv/kvserver/protectedts/ptpb",
+        "//pkg/multitenant/tenantcapabilities",
         "//pkg/roachpb",
         "//pkg/scheduledjobs",
         "//pkg/scheduledjobs/schedulebase",

--- a/pkg/ccl/changefeedccl/changefeed_dist_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_dist_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvcoord"
+	"github.com/cockroachdb/cockroach/pkg/multitenant/tenantcapabilities"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
@@ -400,8 +401,13 @@ func newRangeDistributionTester(
 
 	systemDB := sqlutils.MakeSQLRunner(tc.SystemLayer(len(tc.Servers) - 1).SQLConn(t))
 	systemDB.Exec(t, "SET CLUSTER SETTING kv.rangefeed.enabled = true")
+	if tc.DefaultTenantDeploymentMode().IsExternal() {
+		tc.GrantTenantCapabilities(
+			ctx, t, serverutils.TestTenantID(),
+			map[tenantcapabilities.ID]string{tenantcapabilities.CanAdminRelocateRange: "true"})
+	}
+
 	if tc.StartedDefaultTestTenant() {
-		systemDB.Exec(t, `ALTER TENANT [$1] GRANT CAPABILITY can_admin_relocate_range=true`, serverutils.TestTenantID().ToUint64())
 		// Give 1,000,000 upfront tokens to the tenant, and keep the tokens per
 		// second rate to the default value of 10,000. This helps avoid throttling
 		// in the tests.

--- a/pkg/server/authserver/authentication_test.go
+++ b/pkg/server/authserver/authentication_test.go
@@ -94,15 +94,11 @@ func TestSSLEnforcement(t *testing.T) {
 	})
 	defer srv.Stopper().Stop(ctx)
 
-	if srv.TenantController().StartedDefaultTestTenant() {
+	if srv.DeploymentMode().IsExternal() {
 		// Enable access to the nodes endpoint for the test tenant.
-		_, err := srv.SystemLayer().SQLConn(t).Exec(
-			`ALTER TENANT [$1] GRANT CAPABILITY can_view_node_info=true`, serverutils.TestTenantID().ToUint64())
-		require.NoError(t, err)
-
-		serverutils.WaitForTenantCapabilities(t, srv, serverutils.TestTenantID(), map[tenantcapabilities.ID]string{
-			tenantcapabilities.CanViewNodeInfo: "true",
-		}, "")
+		require.NoError(t, srv.GrantTenantCapabilities(
+			ctx, serverutils.TestTenantID(),
+			map[tenantcapabilities.ID]string{tenantcapabilities.CanViewNodeInfo: "true"}))
 	}
 
 	s := srv.ApplicationLayer()

--- a/pkg/server/storage_api/health_test.go
+++ b/pkg/server/storage_api/health_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 )
 
 func TestHealthAPI(t *testing.T) {
@@ -123,16 +122,14 @@ func TestLivenessAPI(t *testing.T) {
 	tc := testcluster.StartTestCluster(t, 3, base.TestClusterArgs{})
 	defer tc.Stopper().Stop(context.Background())
 
-	// The liveness endpoint needs a special tenant capability.
-	if tc.Server(0).TenantController().StartedDefaultTestTenant() {
-		// Enable access to the nodes endpoint for the test tenant.
-		_, err := tc.SystemLayer(0).SQLConn(t).Exec(
-			`ALTER TENANT [$1] GRANT CAPABILITY can_view_node_info=true`, serverutils.TestTenantID().ToUint64())
-		require.NoError(t, err)
+	ctx := context.Background()
 
-		tc.WaitForTenantCapabilities(t, serverutils.TestTenantID(), map[tenantcapabilities.ID]string{
-			tenantcapabilities.CanViewNodeInfo: "true",
-		})
+	// The liveness endpoint needs a special tenant capability.
+	if tc.DefaultTenantDeploymentMode().IsExternal() {
+		// Enable access to the nodes endpoint for the test tenant.
+		tc.GrantTenantCapabilities(
+			ctx, t, serverutils.TestTenantID(),
+			map[tenantcapabilities.ID]string{tenantcapabilities.CanViewNodeInfo: "true"})
 	}
 
 	ts := tc.Server(0).ApplicationLayer()

--- a/pkg/server/storage_api/nodes_test.go
+++ b/pkg/server/storage_api/nodes_test.go
@@ -221,15 +221,11 @@ func TestNodesGRPCResponse(t *testing.T) {
 	})
 	defer srv.Stopper().Stop(ctx)
 
-	if srv.TenantController().StartedDefaultTestTenant() {
+	if srv.DeploymentMode().IsExternal() {
 		// Enable access to the nodes endpoint for the test tenant.
-		_, err := srv.SystemLayer().SQLConn(t).Exec(
-			`ALTER TENANT [$1] GRANT CAPABILITY can_view_node_info=true`, serverutils.TestTenantID().ToUint64())
-		require.NoError(t, err)
-
-		serverutils.WaitForTenantCapabilities(t, srv, serverutils.TestTenantID(), map[tenantcapabilities.ID]string{
-			tenantcapabilities.CanViewNodeInfo: "true",
-		}, "")
+		require.NoError(t, srv.GrantTenantCapabilities(
+			ctx, serverutils.TestTenantID(),
+			map[tenantcapabilities.ID]string{tenantcapabilities.CanViewNodeInfo: "true"}))
 	}
 
 	var request serverpb.NodesRequest

--- a/pkg/sql/colflow/draining_test.go
+++ b/pkg/sql/colflow/draining_test.go
@@ -54,13 +54,10 @@ func TestDrainingAfterRemoteError(t *testing.T) {
 	tc := testcluster.StartTestCluster(t, 2 /* nodes */, args)
 	defer tc.Stopper().Stop(ctx)
 
-	if srv := tc.Server(0); srv.TenantController().StartedDefaultTestTenant() {
-		systemSqlDB := srv.SystemLayer().SQLConn(t, serverutils.DBName("system"))
-		_, err := systemSqlDB.Exec(`ALTER TENANT [$1] GRANT CAPABILITY can_admin_relocate_range=true`, serverutils.TestTenantID().ToUint64())
-		require.NoError(t, err)
-		serverutils.WaitForTenantCapabilities(t, srv, serverutils.TestTenantID(), map[tenantcapabilities.ID]string{
-			tenantcapabilities.CanAdminRelocateRange: "true",
-		}, "")
+	if tc.DefaultTenantDeploymentMode().IsExternal() {
+		tc.GrantTenantCapabilities(
+			ctx, t, serverutils.TestTenantID(),
+			map[tenantcapabilities.ID]string{tenantcapabilities.CanAdminRelocateRange: "true"})
 	}
 
 	// Create two tables, one with small values, and another with large rows.

--- a/pkg/sql/distsql_physical_planner_test.go
+++ b/pkg/sql/distsql_physical_planner_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvcoord"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/rangecache"
+	"github.com/cockroachdb/cockroach/pkg/multitenant/tenantcapabilities"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
@@ -449,10 +450,9 @@ func TestDistSQLUnavailableHosts(t *testing.T) {
 			}
 
 			// Grant capability to run RELOCATE to secondary (test) tenant.
-			systemDB := sqlutils.MakeSQLRunner(tc.SystemLayer(0).SQLConn(t))
-			systemDB.Exec(t,
-				`ALTER TENANT [$1] GRANT CAPABILITY can_admin_relocate_range=true`,
-				serverutils.TestTenantID().ToUint64())
+			tc.GrantTenantCapabilities(
+				ctx, t, serverutils.TestTenantID(),
+				map[tenantcapabilities.ID]string{tenantcapabilities.CanAdminRelocateRange: "true"})
 		}
 
 		// Connect to node 1 (gateway node)

--- a/pkg/sql/execstats/traceanalyzer_test.go
+++ b/pkg/sql/execstats/traceanalyzer_test.go
@@ -78,13 +78,10 @@ func TestTraceAnalyzer(t *testing.T) {
 
 	const gatewayNode = 0
 	srv, s := tc.Server(gatewayNode), tc.ApplicationLayer(gatewayNode)
-	if srv.TenantController().StartedDefaultTestTenant() {
-		systemSqlDB := srv.SystemLayer().SQLConn(t, serverutils.DBName("system"))
-		_, err := systemSqlDB.Exec(`ALTER TENANT [$1] GRANT CAPABILITY can_admin_relocate_range=true`, serverutils.TestTenantID().ToUint64())
-		require.NoError(t, err)
-		serverutils.WaitForTenantCapabilities(t, srv, serverutils.TestTenantID(), map[tenantcapabilities.ID]string{
-			tenantcapabilities.CanAdminRelocateRange: "true",
-		}, "")
+	if srv.DeploymentMode().IsExternal() {
+		require.NoError(t, srv.GrantTenantCapabilities(
+			ctx, serverutils.TestTenantID(),
+			map[tenantcapabilities.ID]string{tenantcapabilities.CanAdminRelocateRange: "true"}))
 	}
 	db := s.SQLConn(t)
 	sqlDB := sqlutils.MakeSQLRunner(db)

--- a/pkg/sql/flowinfra/cluster_test.go
+++ b/pkg/sql/flowinfra/cluster_test.go
@@ -594,13 +594,10 @@ func TestEvalCtxTxnOnRemoteNodes(t *testing.T) {
 		})
 	defer tc.Stopper().Stop(ctx)
 
-	if srv := tc.Server(0); srv.TenantController().StartedDefaultTestTenant() {
-		systemSqlDB := srv.SystemLayer().SQLConn(t, serverutils.DBName("system"))
-		_, err := systemSqlDB.Exec(`ALTER TENANT [$1] GRANT CAPABILITY can_admin_relocate_range=true`, serverutils.TestTenantID().ToUint64())
-		require.NoError(t, err)
-		serverutils.WaitForTenantCapabilities(t, srv, serverutils.TestTenantID(), map[tenantcapabilities.ID]string{
-			tenantcapabilities.CanAdminRelocateRange: "true",
-		}, "")
+	if tc.DefaultTenantDeploymentMode().IsExternal() {
+		tc.GrantTenantCapabilities(
+			ctx, t, serverutils.TestTenantID(),
+			map[tenantcapabilities.ID]string{tenantcapabilities.CanAdminRelocateRange: "true"})
 	}
 
 	db := tc.ServerConn(0)

--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -1728,12 +1728,6 @@ func (t *logicTest) newCluster(
 
 		capabilities := toa.capabilities
 		if len(capabilities) > 0 {
-			for name, value := range capabilities {
-				query := fmt.Sprintf("ALTER TENANT [$1] GRANT CAPABILITY %s = $2", name)
-				if _, err := conn.Exec(query, tenantID.ToUint64(), value); err != nil {
-					t.Fatal(err)
-				}
-			}
 			capabilityMap := make(map[tenantcapabilities.ID]string, len(capabilities))
 			for k, v := range capabilities {
 				capability, ok := tenantcapabilities.FromName(k)
@@ -1742,7 +1736,7 @@ func (t *logicTest) newCluster(
 				}
 				capabilityMap[capability.ID()] = v
 			}
-			t.cluster.WaitForTenantCapabilities(t.t(), tenantID, capabilityMap)
+			t.cluster.GrantTenantCapabilities(context.Background(), t.t(), tenantID, capabilityMap)
 		}
 	}
 

--- a/pkg/sql/opt/exec/explain/output_test.go
+++ b/pkg/sql/opt/exec/explain/output_test.go
@@ -163,13 +163,9 @@ func TestCPUTimeEndToEnd(t *testing.T) {
 	ctx := context.Background()
 	defer tc.Stopper().Stop(ctx)
 
-	if srv := tc.Server(0); srv.TenantController().StartedDefaultTestTenant() {
-		systemSqlDB := srv.SystemLayer().SQLConn(t, serverutils.DBName("system"))
-		_, err := systemSqlDB.Exec(`ALTER TENANT [$1] GRANT CAPABILITY can_admin_relocate_range=true`, serverutils.TestTenantID().ToUint64())
-		require.NoError(t, err)
-		serverutils.WaitForTenantCapabilities(t, srv, serverutils.TestTenantID(), map[tenantcapabilities.ID]string{
-			tenantcapabilities.CanAdminRelocateRange: "true",
-		}, "")
+	if tc.DefaultTenantDeploymentMode().IsExternal() {
+		tc.GrantTenantCapabilities(ctx, t, serverutils.TestTenantID(),
+			map[tenantcapabilities.ID]string{tenantcapabilities.CanAdminRelocateRange: "true"})
 	}
 
 	db := sqlutils.MakeSQLRunner(tc.Conns[0])

--- a/pkg/testutils/serverutils/api.go
+++ b/pkg/testutils/serverutils/api.go
@@ -141,6 +141,10 @@ const (
 	ExternalProcess
 )
 
+func (d DeploymentMode) IsExternal() bool {
+	return d == ExternalProcess
+}
+
 // ApplicationLayerInterface defines accessors to the application
 // layer of a test server. Tests written against this interface are
 // effectively agnostic to whether they use a virtual cluster or not.
@@ -505,6 +509,16 @@ type TenantControlInterface interface {
 	// this is called can run into a "missing record" error even
 	// if the tenant record exists in KV.
 	WaitForTenantReadiness(ctx context.Context, tenantID roachpb.TenantID) error
+
+	// GrantTenantCapabilities grants a capability to a tenant and waits until the
+	// in-memory cache reflects the change.
+	//
+	// Note: There is no need to call WaitForTenantCapabilities separately.
+	GrantTenantCapabilities(
+		context.Context,
+		roachpb.TenantID,
+		map[tenantcapabilities.ID]string,
+	) error
 
 	// WaitForTenantCapabilities waits until the in-RAM cache of
 	// tenant capabilities has been populated for the given tenant ID

--- a/pkg/testutils/serverutils/test_cluster_shim.go
+++ b/pkg/testutils/serverutils/test_cluster_shim.go
@@ -250,6 +250,11 @@ type TestClusterInterface interface {
 	// cluster.
 	StorageLayer(idx int) StorageLayerInterface
 
+	// DefaultTenantDeploymentMode returns the deployment mode of the default
+	// server or tenant, which can be single-tenant (system-only),
+	// shared-process, or external-process.
+	DefaultTenantDeploymentMode() DeploymentMode
+
 	// SplitTable splits a range in the table, creates a replica for the right
 	// side of the split on TargetNodeIdx, and moves the lease for the right
 	// side of the split to TargetNodeIdx for each SplitPoint. This forces the
@@ -258,6 +263,17 @@ type TestClusterInterface interface {
 	// TODO(radu): we should verify that the queries in tests using SplitTable
 	// are indeed distributed as intended.
 	SplitTable(t TestFataler, desc catalog.TableDescriptor, sps []SplitPoint)
+
+	// GrantTenantCapabilities grants a capability to a tenant and waits until all
+	// servers have the in-memory cache reflects the change.
+	//
+	// Note: There is no need to call WaitForTenantCapabilities separately.
+	GrantTenantCapabilities(
+		context.Context,
+		TestFataler,
+		roachpb.TenantID,
+		map[tenantcapabilities.ID]string,
+	)
 
 	// WaitForTenantCapabilities waits until all servers have the specified
 	// tenant capabilities for the specified tenant ID.

--- a/pkg/testutils/testcluster/testcluster.go
+++ b/pkg/testutils/testcluster/testcluster.go
@@ -135,6 +135,11 @@ func (tc *TestCluster) StorageLayer(idx int) serverutils.StorageLayerInterface {
 	return tc.Server(idx).StorageLayer()
 }
 
+// DefaultTenantDeploymentMode implements TestClusterInterface.
+func (tc *TestCluster) DefaultTenantDeploymentMode() serverutils.DeploymentMode {
+	return tc.Server(0).DeploymentMode()
+}
+
 // stopServers stops the stoppers for each individual server in the cluster.
 // This method ensures that servers that were previously stopped explicitly are
 // not double-stopped.
@@ -2080,6 +2085,17 @@ func (tc *TestCluster) SplitTable(
 			}
 		}
 	}
+}
+
+// GrantTenantCapabilities implements TestClusterInterface.
+func (tc *TestCluster) GrantTenantCapabilities(
+	ctx context.Context,
+	t serverutils.TestFataler,
+	tenID roachpb.TenantID,
+	targetCaps map[tenantcapabilities.ID]string,
+) {
+	require.NoError(t, tc.Server(0).TenantController().GrantTenantCapabilities(ctx, tenID, targetCaps))
+	tc.WaitForTenantCapabilities(t, tenID, targetCaps)
 }
 
 // WaitForTenantCapabilities implements TestClusterInterface.


### PR DESCRIPTION
Many tests require granting a capability when using external-process mode. Since this pattern is repeated in multiple places, it makes sense to provide it as a utility.

As part of this cleanup, I've also adjusted when it runs: it now applies only to external-process tenants, as shared-process tenants always have all capabilities.

Informs: #138912
Epic: CRDB-38970
Release note: None