### PR TITLE
microbench-ci: restore branch after build

### DIFF
--- a/.github/actions/microbenchmark-build/action.yml
+++ b/.github/actions/microbenchmark-build/action.yml
@@ -47,8 +47,7 @@ runs:
       shell: bash
       env:
         TEST_PKG: ${{ inputs.pkg }}
-    - name: Checkout # required for post job cleanup (if still on the base ref)
-      if: inputs.ref == 'base'
+    - name: Checkout # required for post job cleanup
       uses: actions/checkout@v4
     - name: Clean up
       run: ./build/github/cleanup-engflow-keys.sh


### PR DESCRIPTION
Previously, a restorative checkout for the build action would only be performed if the merge base SHA was being built. But we require this for the head build as well. Hence, removing the 'if' block for the restorative checkout.

Epic: None
Release note: None