### PR TITLE
catalog/lease: fix panic in TestAsOfSystemTimeUsesCache

### DIFF
--- a/pkg/sql/catalog/lease/storage.go
+++ b/pkg/sql/catalog/lease/storage.go
@@ -234,6 +234,11 @@ func (s storage) acquire(
 		case err != nil:
 			return nil, nil, err
 		}
+		// If a new lease was not acquired, then there is no other work to be
+		// done.
+		if desc == nil {
+			return nil, nil, nil
+		}
 		log.VEventf(ctx, 2, "storage acquired lease %v", desc)
 		if s.testingKnobs.LeaseAcquiredEvent != nil {
 			s.testingKnobs.LeaseAcquiredEvent(desc, err)


### PR DESCRIPTION
Previously, the test TestAsOfSystemTimeUsesCache could panic since the LeaseAcquiredEvent testing knob was being invoked with nil descriptors. This could happen if there was no new lease for a descriptor to acquire. To address this, this patch skips over logic that should only be executed if a new lease was acquired.

Fixes: #141479
Release note: None