### PR TITLE
roachtest: disable rangefeed buffered sender in mvt

### DIFF
--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -939,7 +939,10 @@ func (r *testRunner) runWorker(
 				// includes the buildutil.CrdbTestBuild tag. And runtime assertion is
 				// enabled if and only if cockroach binaries used in roachtests include
 				// the buildutil.CrdbTestBuild tag.
-				useBufferedSender := roachtestutil.UsingRuntimeAssertions(t)
+				// N.B. some tests, e.g. the mixed version tests, do not use the Cockroach
+				// harness for invoking the binary and upload their own. We must also opt
+				// those out as we do not know if they are CrdbTestBuild binaries.
+				useBufferedSender := roachtestutil.UsingRuntimeAssertions(t) && !t.spec.Suites.Contains(registry.MixedVersion)
 				if useBufferedSender {
 					c.clusterSettings["kv.rangefeed.buffered_sender.enabled"] = "true"
 				}


### PR DESCRIPTION
Recently, metamorphic rangefeed buffered senders were enabled, gated behind the crdb_test binary. However, mixed version tests upload their own binary so we must opt them out.

Fixes: #141478
Fixes: #141470
Fixes: https://github.com/cockroachdb/cockroach/issues/141494
Fixes: https://github.com/cockroachdb/cockroach/issues/141476
FIxes: https://github.com/cockroachdb/cockroach/issues/141466
Fixes: https://github.com/cockroachdb/cockroach/issues/141470
Fixes: https://github.com/cockroachdb/cockroach/issues/141471
Fixes: https://github.com/cockroachdb/cockroach/issues/141475
Fixes: https://github.com/cockroachdb/cockroach/issues/141465