### PR TITLE
timeutil: avoid parsing non-numeric strings as ints/floats

### DIFF
--- a/pkg/sql/ttl/ttljob/ttljob_query_builder_test.go
+++ b/pkg/sql/ttl/ttljob/ttljob_query_builder_test.go
@@ -506,12 +506,16 @@ func BenchmarkTTLExpiration(b *testing.B) {
 		"create table db1.t1 (created_at timestamptz, expired_at timestamptz)",
 	)
 	// We are ingesting data. But we pick a timestamp so that the queries we do
-	// below don't return any rows. We don't want the process of returning rows
-	// to throw off the benchmark.
+	// below don't return any rows. We don't want the process of returning rows to
+	// throw off the benchmark. We insert rows in batches to speed up the test
+	// setup.
 	const numRows = 250000
-	for i := 0; i < numRows; i++ {
-		tdb.Exec(b,
-			fmt.Sprintf("insert into db1.t1 values (now(), now() + interval '%d seconds' +  interval '10 months')", i))
+	const batchSize = 10000
+	for i := 0; i < numRows; i += batchSize {
+		tdb.Exec(b, fmt.Sprintf(`
+        INSERT INTO db1.t1 (created_at, expired_at)
+        SELECT now(), now() + interval '10 months' + generate_series(%d, %d) * interval '1 second'
+    `, i, i+batchSize-1))
 	}
 
 	for _, tc := range []struct {

--- a/pkg/sql/ttl/ttljob/ttljob_query_builder_test.go
+++ b/pkg/sql/ttl/ttljob/ttljob_query_builder_test.go
@@ -536,14 +536,15 @@ func BenchmarkTTLExpiration(b *testing.B) {
 		// Execute the query once outside the timings to prime any caches.
 		tdb.Exec(b, tc.query)
 
-		b.ResetTimer()
-		for i := 0; i < b.N; i++ {
-			b.Run(tc.desc, func(b *testing.B) {
+		b.Run(tc.desc, func(b *testing.B) {
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
 				// Execute the query on the table. The actual results are irrelevant, as there
 				// shouldn't be any rows. We're only interested in measuring the execution time.
 				tdb.Exec(b, tc.query)
-			})
-		}
-		b.StopTimer()
+			}
+			b.StopTimer()
+		})
+
 	}
 }

--- a/pkg/util/timeutil/time_zone_util.go
+++ b/pkg/util/timeutil/time_zone_util.go
@@ -67,8 +67,11 @@ func TimeZoneStringToLocation(
 	// ParseTimeZoneOffset uses strconv.ParseFloat, which returns an error when
 	// parsing fails that is expensive to construct. We first check if the string
 	// contains any non-numeric characters to see if we can skip attempting to
-	// parse it as a timezone offset.
-	containsNonNumeric := strings.ContainsAny(locStr, "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ/")
+	// parse it as a timezone offset. `/` is also checked since that character
+	// appears in most timezone names. Since UTC is the most commonly used
+	// timezone, we also check for that explicitly to avoid calling ContainsAny if
+	// possible.
+	containsNonNumeric := strings.EqualFold(locStr, "utc") || strings.ContainsAny(locStr, "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ/")
 	if !containsNonNumeric {
 		offset, _, parsed := ParseTimeZoneOffset(locStr, std)
 		if parsed {

--- a/pkg/util/timeutil/time_zone_util.go
+++ b/pkg/util/timeutil/time_zone_util.go
@@ -64,25 +64,37 @@ const (
 func TimeZoneStringToLocation(
 	locStr string, std TimeZoneStringToLocationStandard,
 ) (*time.Location, error) {
-	offset, _, parsed := ParseTimeZoneOffset(locStr, std)
-	if parsed {
-		if offset < -maxUTCHourOffsetInSeconds || offset > maxUTCHourOffsetInSeconds {
-			return nil, errors.New("UTC timezone offset is out of range.")
+	// ParseTimeZoneOffset uses strconv.ParseFloat, which returns an error when
+	// parsing fails that is expensive to construct. We first check if the string
+	// contains any non-numeric characters to see if we can skip attempting to
+	// parse it as a timezone offset.
+	containsNonNumeric := strings.ContainsAny(locStr, "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ/")
+	if !containsNonNumeric {
+		offset, _, parsed := ParseTimeZoneOffset(locStr, std)
+		if parsed {
+			if offset < -maxUTCHourOffsetInSeconds || offset > maxUTCHourOffsetInSeconds {
+				return nil, errors.New("UTC timezone offset is out of range.")
+			}
+			return TimeZoneOffsetToLocation(offset), nil
 		}
-		return TimeZoneOffsetToLocation(offset), nil
 	}
 
-	// The time may just be a raw int value.
-	intVal, err := strconv.ParseInt(locStr, 10, 64)
-	if err == nil {
-		// Parsing an int has different behavior for POSIX and ISO8601.
-		if std == TimeZoneStringToLocationPOSIXStandard {
-			intVal *= -1
+	// The time may just be a raw int value. Similar to the above, in order to
+	// avoid constructing an expensive error, we first check if the string
+	// contains any non-numeric characters to see if we can skip attempting to
+	// parse it as an int.
+	if !containsNonNumeric {
+		intVal, err := strconv.ParseInt(locStr, 10, 64)
+		if err == nil {
+			// Parsing an int has different behavior for POSIX and ISO8601.
+			if std == TimeZoneStringToLocationPOSIXStandard {
+				intVal *= -1
+			}
+			if intVal < -maxUTCHourOffset || intVal > maxUTCHourOffset {
+				return nil, errors.New("UTC timezone offset is out of range.")
+			}
+			return TimeZoneOffsetToLocation(int(intVal) * 60 * 60), nil
 		}
-		if intVal < -maxUTCHourOffset || intVal > maxUTCHourOffset {
-			return nil, errors.New("UTC timezone offset is out of range.")
-		}
-		return TimeZoneOffsetToLocation(int(intVal) * 60 * 60), nil
 	}
 
 	locTransforms := []func(string) string{


### PR DESCRIPTION
### ttljob: fix sub-benchmark of BenchmarkTTLExpiration

The b.Run call defines a new subtest, and each subtest should run for
b.N iterations.

### ttljob: make BenchmarkTTLExpiration setup quicker 

### timeutil: avoid parsing non-numeric strings as ints/floats

Constructing the error of strconv.ParseInt and strconv.ParseFloat is
relatively expensive. It allocates a new byte array then clones the
input string into it. That makes it a bad thing to do eagerly -- it's
better to check if the string has non-numeric characters and avoid
paying the cost of constructing the parsing error if we can.

```
name                                  old time/op    new time/op    delta
TTLExpiration/query=tz_conv-10           203ms ± 5%     151ms ± 3%  -25.51%  (p=0.000 n=10+10)
TTLExpiration/query=interval_math-10     108ms ± 7%     106ms ± 1%     ~     (p=0.423 n=9+8)

name                                  old alloc/op   new alloc/op   delta
TTLExpiration/query=tz_conv-10           116MB ± 0%      64MB ± 0%  -45.42%  (p=0.000 n=9+10)
TTLExpiration/query=interval_math-10    33.0MB ± 0%    33.0MB ± 0%     ~     (p=0.243 n=9+10)

name                                  old allocs/op  new allocs/op  delta
TTLExpiration/query=tz_conv-10           4.00M ± 0%     1.50M ± 0%  -62.46%  (p=0.000 n=7+10)
TTLExpiration/query=interval_math-10      251k ± 0%      251k ± 0%     ~     (p=0.920 n=9+10)
```

Epic: None
Release note: None