### PR TITLE
sql/stats: speed up sample sorting

### DIFF
--- a/pkg/sql/stats/BUILD.bazel
+++ b/pkg/sql/stats/BUILD.bazel
@@ -48,6 +48,7 @@ go_library(
         "//pkg/sql/sessiondata",
         "//pkg/sql/sqlerrors",
         "//pkg/sql/types",
+        "//pkg/util/buildutil",
         "//pkg/util/cache",
         "//pkg/util/container/heap",
         "//pkg/util/encoding",


### PR DESCRIPTION
#### sql: expand BenchmarkAnalyze

`BenchmarkAnalyze` now has two sub-benchmarks that sample 10k rows and
100k rows.

Release note: None

#### sql/stats: speed up sample sorting

The sorting of sampled datums, which occurs while building histograms
during stats collection, has been sped up using the same technique
introduced to the vectorized sorting operator in #67451. See that PR and
the code comments added in this commit for more details.

This optimization currently only applies to DInt, DString, and DBytes datums.
Future work can extend this to other datum types, like DUuid.

```
name            old time/op    new time/op    delta
Analyze/10000      157ms ± 5%     143ms ± 3%   -8.59%  (p=0.000 n=20+18)
Analyze/100000     334ms ± 6%     247ms ± 7%  -26.03%  (p=0.000 n=20+20)

name            old alloc/op   new alloc/op   delta
Analyze/10000     63.7MB ± 4%    64.2MB ± 3%   +0.64%  (p=0.001 n=19+18)
Analyze/100000     170MB ± 2%     173MB ± 1%   +1.72%  (p=0.000 n=17+17)

name            old allocs/op  new allocs/op  delta
Analyze/10000       355k ± 1%      356k ± 3%     ~     (p=0.817 n=16+17)
Analyze/100000      768k ± 0%      768k ± 0%   -0.05%  (p=0.017 n=16+16)
```

Epic: None
Release note: None
