### PR TITLE
release-24.1: sql: crdb_internal.zones no longer fails with offline database

### DIFF
--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -4805,7 +4805,7 @@ CREATE TABLE crdb_internal.zones (
 
 			var table catalog.TableDescriptor
 			if zs.Database != "" {
-				database, err := p.Descriptors().ByID(p.txn).WithoutNonPublic().Get().Database(ctx, descpb.ID(id))
+				database, err := p.Descriptors().ByID(p.txn).Get().Database(ctx, descpb.ID(id))
 				if err != nil {
 					return err
 				}
@@ -4815,7 +4815,7 @@ CREATE TABLE crdb_internal.zones (
 					continue
 				}
 			} else if zoneSpecifier.TableOrIndex.Table.ObjectName != "" {
-				tableEntry, err := p.Descriptors().ByID(p.txn).WithoutDropped().Get().Table(ctx, descpb.ID(id))
+				tableEntry, err := p.Descriptors().ByID(p.txn).Get().Table(ctx, descpb.ID(id))
 				if err != nil {
 					return err
 				}

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -611,6 +611,50 @@ ALTER RANGE default CONFIGURE ZONE USING
   constraints = '[]',
   lease_preferences = '[]'
 
+subtest zones_offline_db
+
+statement ok
+CREATE TABLE empty ()
+
+statement ok
+CREATE DATABASE a
+
+statement ok
+ALTER DATABASE a CONFIGURE ZONE USING gc.ttlseconds = 1000
+
+let $a_id
+SELECT id FROM system.namespace WHERE name = 'a' AND "parentID" = 0
+
+statement ok
+WITH to_update AS (
+	SELECT id, crdb_internal.pb_to_json('cockroach.sql.sqlbase.Descriptor', descriptor.descriptor) as descriptor
+	FROM system.descriptor
+	WHERE id = $a_id
+), updated AS (
+	SELECT id, json_set(descriptor, ARRAY['database', 'state'], '"OFFLINE"'::JSONB) as descriptor FROM to_update
+), encoded AS (
+	SELECT id, crdb_internal.json_to_pb('cockroach.sql.sqlbase.Descriptor', descriptor) as descriptor FROM updated
+)
+SELECT crdb_internal.unsafe_upsert_descriptor(id, descriptor, true) FROM encoded
+
+# Regression test for #139848. This query used to fail while querying
+# crdb_internal.zones because of the offline database.
+query TT
+SHOW CREATE empty
+----
+empty  CREATE TABLE public.empty (
+         rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+         CONSTRAINT empty_pkey PRIMARY KEY (rowid ASC)
+       )
+
+query T
+SELECT raw_config_sql FROM crdb_internal.zones WHERE zone_id = $a_id
+----
+ALTER DATABASE a CONFIGURE ZONE USING
+  gc.ttlseconds = 1000
+
+subtest end
+
 query error pq: foo
 SELECT crdb_internal.force_error('', 'foo')
 
@@ -709,7 +753,7 @@ query TTT colnames
 SELECT start_pretty, end_pretty, split_enforced_until FROM crdb_internal.ranges WHERE split_enforced_until IS NOT NULL
 ----
 start_pretty    end_pretty  split_enforced_until
-/Table/112/1/2  /Max        2262-04-11 23:47:16.854776 +0000 +0000
+/Table/115/1/2  /Max        2262-04-11 23:47:16.854776 +0000 +0000
 
 query TTT colnames
 SELECT start_key, end_key, split_enforced_until FROM [SHOW RANGES FROM TABLE foo] WHERE split_enforced_until IS NOT NULL
@@ -887,12 +931,12 @@ query TT colnames,rowsort
 SELECT start_pretty, end_pretty FROM crdb_internal.ranges WHERE split_enforced_until IS NOT NULL
 ----
 start_pretty    end_pretty
-/Table/112/1/1  /Table/112/1/2
-/Table/112/1/2  /Table/112/1/3
-/Table/112/1/3  /Table/112/2/1
-/Table/112/2/1  /Table/112/2/2
-/Table/112/2/2  /Table/112/2/3
-/Table/112/2/3  /Max
+/Table/115/1/1  /Table/115/1/2
+/Table/115/1/2  /Table/115/1/3
+/Table/115/1/3  /Table/115/2/1
+/Table/115/2/1  /Table/115/2/2
+/Table/115/2/2  /Table/115/2/3
+/Table/115/2/3  /Max
 
 # The cleanup we expect in the following truncate requires that the GCJob runs.
 # To avoid this taking 30 seconds, we lower the job adoption interval.
@@ -921,12 +965,12 @@ query TT colnames,retry,rowsort
 SELECT start_pretty, end_pretty FROM crdb_internal.ranges WHERE split_enforced_until IS NOT NULL
 ----
 start_pretty    end_pretty
-/Table/112/3/1  /Table/112/3/2
-/Table/112/3/2  /Table/112/3/3
-/Table/112/3/3  /Table/112/4/1
-/Table/112/4/1  /Table/112/4/2
-/Table/112/4/2  /Table/112/4/3
-/Table/112/4/3  /Max
+/Table/115/3/1  /Table/115/3/2
+/Table/115/3/2  /Table/115/3/3
+/Table/115/3/3  /Table/115/4/1
+/Table/115/4/1  /Table/115/4/2
+/Table/115/4/2  /Table/115/4/3
+/Table/115/4/3  /Max
 
 statement ok
 DROP TABLE foo
@@ -949,12 +993,12 @@ query TT colnames,retry,rowsort
 SELECT start_pretty, end_pretty FROM crdb_internal.ranges WHERE split_enforced_until IS NOT NULL
 ----
 start_pretty    end_pretty
-/Table/114/1/1  /Table/114/1/2
-/Table/114/1/2  /Table/114/1/3
-/Table/114/1/3  /Table/114/2/1
-/Table/114/2/1  /Table/114/2/2
-/Table/114/2/2  /Table/114/2/3
-/Table/114/2/3  /Max
+/Table/117/1/1  /Table/117/1/2
+/Table/117/1/2  /Table/117/1/3
+/Table/117/1/3  /Table/117/2/1
+/Table/117/2/1  /Table/117/2/2
+/Table/117/2/2  /Table/117/2/3
+/Table/117/2/3  /Max
 
 statement ok
 DROP INDEX foo@idx
@@ -965,9 +1009,9 @@ query T colnames,retry,rowsort
 SELECT start_pretty FROM crdb_internal.ranges WHERE split_enforced_until IS NOT NULL
 ----
 start_pretty
-/Table/114/1/1
-/Table/114/1/2
-/Table/114/1/3
+/Table/117/1/1
+/Table/117/1/2
+/Table/117/1/3
 
 query T
 SELECT crdb_internal.cluster_name()
@@ -1031,15 +1075,15 @@ CREATE TYPE enum2 AS ENUM ()
 query ITTITTT
 SELECT * FROM crdb_internal.create_type_statements ORDER BY descriptor_id
 ----
-104  test  public  116  enum1  CREATE TYPE public.enum1 AS ENUM ('hello', 'hi')  {hello,hi}
-104  test  public  118  enum2  CREATE TYPE public.enum2 AS ENUM ()               {}
+104  test  public  119  enum1  CREATE TYPE public.enum1 AS ENUM ('hello', 'hi')  {hello,hi}
+104  test  public  121  enum2  CREATE TYPE public.enum2 AS ENUM ()               {}
 
 # Test the virtual index as well.
 
 query ITTITTT
 SELECT * FROM crdb_internal.create_type_statements WHERE descriptor_id = (('enum1'::regtype::oid::int) - 100000)::oid
 ----
-104  test  public  116  enum1  CREATE TYPE public.enum1 AS ENUM ('hello', 'hi')  {hello,hi}
+104  test  public  119  enum1  CREATE TYPE public.enum1 AS ENUM ('hello', 'hi')  {hello,hi}
 
 query ITTITTT
 SELECT * FROM crdb_internal.create_type_statements WHERE descriptor_id = 'foo'::regclass::oid
@@ -1618,17 +1662,17 @@ FROM crdb_internal.create_procedure_statements
 WHERE procedure_name IN ('p', 'p2')
 ORDER BY procedure_id;
 ----
-104  test  105  public  139  p   CREATE PROCEDURE public.p(INT8)
+104  test  105  public  142  p   CREATE PROCEDURE public.p(INT8)
                                    LANGUAGE SQL
                                    AS $$
                                    SELECT 1;
                                  $$
-104  test  105  public  140  p   CREATE PROCEDURE public.p(STRING, b INT8)
+104  test  105  public  143  p   CREATE PROCEDURE public.p(STRING, b INT8)
                                    LANGUAGE SQL
                                    AS $$
                                    SELECT 'hello';
                                  $$
-104  test  142  sc      143  p2  CREATE PROCEDURE sc.p2(STRING)
+104  test  145  sc      146  p2  CREATE PROCEDURE sc.p2(STRING)
                                    LANGUAGE SQL
                                    AS $$
                                    SELECT 'hello';
@@ -1648,22 +1692,22 @@ FROM "".crdb_internal.create_procedure_statements
 WHERE procedure_name IN ('p', 'p2', 'p_cross_db')
 ORDER BY procedure_id;
 ----
-104  test           105  public  139  p           CREATE PROCEDURE public.p(INT8)
+104  test           105  public  142  p           CREATE PROCEDURE public.p(INT8)
                                                     LANGUAGE SQL
                                                     AS $$
                                                     SELECT 1;
                                                   $$
-104  test           105  public  140  p           CREATE PROCEDURE public.p(STRING, b INT8)
+104  test           105  public  143  p           CREATE PROCEDURE public.p(STRING, b INT8)
                                                     LANGUAGE SQL
                                                     AS $$
                                                     SELECT 'hello';
                                                   $$
-104  test           142  sc      143  p2          CREATE PROCEDURE sc.p2(STRING)
+104  test           145  sc      146  p2          CREATE PROCEDURE sc.p2(STRING)
                                                     LANGUAGE SQL
                                                     AS $$
                                                     SELECT 'hello';
                                                   $$
-144  test_cross_db  145  public  146  p_cross_db  CREATE PROCEDURE public.p_cross_db()
+147  test_cross_db  148  public  149  p_cross_db  CREATE PROCEDURE public.p_cross_db()
                                                     LANGUAGE SQL
                                                     AS $$
                                                     SELECT 1;


### PR DESCRIPTION
Backport 1/1 commits from #141195.

/cc @cockroachdb/release

Release justification: bug fix

---

fixes https://github.com/cockroachdb/cockroach/issues/139848
informs https://github.com/cockroachlabs/support/issues/3157
Release note (bug fix): Fixed a bug that could prevent SHOW CREATE TABLE from working if a database was offline (e.g., due to a RESTORE on that database).
