### PR TITLE
raft: optimize ComputeLeadSupportUntil

### DIFF
--- a/pkg/raft/quorum/joint.go
+++ b/pkg/raft/quorum/joint.go
@@ -91,11 +91,17 @@ func (c JointConfig) VoteResult(votes map[pb.PeerID]bool) VoteResult {
 	return VotePending
 }
 
-// LeadSupportExpiration takes a mapping of timestamps peers have promised a
-// leader support until and returns the timestamp until which the leader is
-// guaranteed support until.
-func (c JointConfig) LeadSupportExpiration(supported map[pb.PeerID]hlc.Timestamp) hlc.Timestamp {
-	qse := c[0].LeadSupportExpiration(supported)
-	qse.Backward(c[1].LeadSupportExpiration(supported))
+// LeadSupportExpiration takes slices of timestamps peers in both configurations
+// have promised a leader support until and returns the timestamp until which
+// the leader is guaranteed support until.
+//
+// Note that we accept two slices of timestamps instead of one map of a joint
+// configuration for performance reasons. Having two contiguous slices is more
+// performant than one map based on the ComputeLeadSupportUntil microbenchmark.
+func (c JointConfig) LeadSupportExpiration(
+	supportedC0 []hlc.Timestamp, supportedC1 []hlc.Timestamp,
+) hlc.Timestamp {
+	qse := c[0].LeadSupportExpiration(supportedC0)
+	qse.Backward(c[1].LeadSupportExpiration(supportedC1))
 	return qse
 }

--- a/pkg/raft/quorum/majority.go
+++ b/pkg/raft/quorum/majority.go
@@ -193,10 +193,10 @@ func (c MajorityConfig) VoteResult(votes map[pb.PeerID]bool) VoteResult {
 	return VoteLost
 }
 
-// LeadSupportExpiration takes a mapping of timestamps peers have promised a
+// LeadSupportExpiration takes a slice of timestamps peers have promised a
 // fortified leader support until and returns the timestamp until which the
 // leader is guaranteed support until.
-func (c MajorityConfig) LeadSupportExpiration(supported map[pb.PeerID]hlc.Timestamp) hlc.Timestamp {
+func (c MajorityConfig) LeadSupportExpiration(support []hlc.Timestamp) hlc.Timestamp {
 	if len(c) == 0 {
 		// There are no peers in the config, and therefore no leader, so we return
 		// MaxTimestamp as a sentinel value. This also plays well with joint quorums
@@ -206,33 +206,7 @@ func (c MajorityConfig) LeadSupportExpiration(supported map[pb.PeerID]hlc.Timest
 	}
 
 	n := len(c)
-
-	// Use an on-stack slice whenever n <= 7 (otherwise we alloc). The assumption
-	// is that running with a replication factor of >7 is rare, and in cases in
-	// which it happens, performance is less of a concern (it's not like
-	// performance implications of an allocation here are drastic).
-	var stk [7]hlc.Timestamp
-	var srt []hlc.Timestamp
-	if len(stk) >= n {
-		srt = stk[:n]
-	} else {
-		srt = make([]hlc.Timestamp, n)
-	}
-
-	{
-		// Fill the slice with Timestamps for peers in the configuration. Any unused
-		// slots will be left as empty Timestamps  for our calculation. We fill from
-		// the right (since the zeros will end up on the left after sorting anyway).
-		i := n - 1
-		for id := range c {
-			if e, ok := supported[id]; ok {
-				srt[i] = e
-				i--
-			}
-		}
-	}
-
-	slices.SortFunc(srt, func(a hlc.Timestamp, b hlc.Timestamp) int {
+	slices.SortFunc(support, func(a hlc.Timestamp, b hlc.Timestamp) int {
 		return a.Compare(b)
 	})
 
@@ -240,9 +214,9 @@ func (c MajorityConfig) LeadSupportExpiration(supported map[pb.PeerID]hlc.Timest
 	// assumption is that if a timestamp is supported by a peer, so are all
 	// timestamps less than that timestamp. For this, we can simply consider the
 	// quorum formed by picking the highest value elements and pick the minimum
-	// from this. In other words, from our sorted (in increasing order) array srt,
-	// we want to move n/2 + 1 to the left from the end (accounting for
+	// from this. In other words, from our sorted (in increasing order) array
+	// support, we want to move n/2 + 1 to the left from the end (accounting for
 	// zero-indexing).
 	pos := n - (n/2 + 1)
-	return srt[pos]
+	return support[pos]
 }

--- a/pkg/raft/quorum/quorum_test.go
+++ b/pkg/raft/quorum/quorum_test.go
@@ -71,7 +71,14 @@ func TestLeadSupportExpiration(t *testing.T) {
 			m[id] = struct{}{}
 		}
 
-		require.Equal(t, tc.exp, m.LeadSupportExpiration(tc.support))
+		// Convert the map to a slice of support timestamps.
+		supportSlice := make([]hlc.Timestamp, len(tc.ids))
+		i := 0
+		for _, ts := range tc.support {
+			supportSlice[i] = ts
+			i++
+		}
+		require.Equal(t, tc.exp, m.LeadSupportExpiration(supportSlice))
 	}
 }
 
@@ -132,7 +139,26 @@ func TestLeadSupportExpirationJointConfig(t *testing.T) {
 			j[1][id] = struct{}{}
 		}
 
-		require.Equal(t, tc.exp, j.LeadSupportExpiration(tc.support))
+		// Convert the support map into two slices, one for each majority config.
+		supportSlice1 := make([]hlc.Timestamp, len(tc.cfg1))
+		i := 0
+		for _, id := range tc.cfg1 {
+			if ts, ok := tc.support[id]; ok {
+				supportSlice1[i] = ts
+				i++
+			}
+		}
+
+		supportSlice2 := make([]hlc.Timestamp, len(tc.cfg2))
+		i = 0
+		for _, id := range tc.cfg2 {
+			if ts, ok := tc.support[id]; ok {
+				supportSlice2[i] = ts
+				i++
+			}
+		}
+
+		require.Equal(t, tc.exp, j.LeadSupportExpiration(supportSlice1, supportSlice2))
 	}
 }
 


### PR DESCRIPTION
This commit optimizes ComputeLeadSupportUntil by swapping the map that was previously used with a slice (on stack if possible).


Benchmark results before:
```
benchdiff "--run=^BenchmarkComputeLeadSupportUntil$" "--old=HEAD^" "--new=HEAD" "./pkg/raft/tracker"                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                                     
name                                    old time/op    new time/op    delta                                                                                                                                                                                                                          
ComputeLeadSupportUntil/members=100-24    14.2µs ± 1%     5.0µs ± 2%  -65.17%  (p=0.000 n=9+10)                                                                                                                                                                                                      
ComputeLeadSupportUntil/members=7-24       542ns ± 0%     246ns ± 0%  -54.51%  (p=0.000 n=8+9)                                                                                                                                                                                                       
ComputeLeadSupportUntil/members=5-24       420ns ± 0%     196ns ± 0%  -53.33%  (p=0.000 n=9+9)                                                                                                                                                                                                       
ComputeLeadSupportUntil/members=3-24       300ns ± 0%     144ns ± 0%  -52.14%  (p=0.000 n=8+8)                                                                                                                                                                                                       
ComputeLeadSupportUntil/members=1-24       177ns ± 0%      85ns ± 0%  -51.89%  (p=0.000 n=10+9)                                                                                                                                                                                                      
                                                                                                                                                                                                                                                                                                     
name                                    old alloc/op   new alloc/op   delta                                                                                                                                                                                                                          
ComputeLeadSupportUntil/members=100-24    1.92kB ± 0%    1.79kB ± 0%   -6.72%  (p=0.002 n=8+10)                                                                                                                                                                                                      
ComputeLeadSupportUntil/members=1-24       0.00B          0.00B          ~     (all equal)                                                                                                                                                                                                           
ComputeLeadSupportUntil/members=3-24       0.00B          0.00B          ~     (all equal)                                                                                                                                                                                                           
ComputeLeadSupportUntil/members=5-24       0.00B          0.00B          ~     (all equal)                                                                                                                                                                                                           
ComputeLeadSupportUntil/members=7-24       0.00B          0.00B          ~     (all equal)                                                                                                                                                                                                           
                                                                                                                                                                                                                                                                                                     
name                                    old allocs/op  new allocs/op  delta                                                                                                                                                                                                                          
ComputeLeadSupportUntil/members=100-24      4.00 ± 0%      1.00 ± 0%  -75.00%  (p=0.000 n=10+10)                                                                                                                                                                                                     
ComputeLeadSupportUntil/members=1-24        0.00           0.00          ~     (all equal)                                                                                                                                                                                                           
ComputeLeadSupportUntil/members=3-24        0.00           0.00          ~     (all equal)                                                                                                                                                                                                           
ComputeLeadSupportUntil/members=5-24        0.00           0.00          ~     (all equal)                                                                                                                                                                                                           
ComputeLeadSupportUntil/members=7-24        0.00           0.00          ~     (all equal) 
```

Release note: None

Fixes: #141511