### PR TITLE
roachtest: annotate tests on Grafana for all clouds

### DIFF
--- a/pkg/cmd/roachtest/BUILD.bazel
+++ b/pkg/cmd/roachtest/BUILD.bazel
@@ -49,6 +49,7 @@ go_library(
         "//pkg/roachprod/install",
         "//pkg/roachprod/logger",
         "//pkg/roachprod/prometheus",
+        "//pkg/roachprod/promhelperclient",
         "//pkg/roachprod/vm",
         "//pkg/roachprod/vm/gce",
         "//pkg/testutils/skip",

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -38,6 +38,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/promhelperclient"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/vm"
 	"github.com/cockroachdb/cockroach/pkg/util/allstacks"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
@@ -1115,7 +1116,15 @@ func (r *testRunner) runTest(
 
 	s := t.Spec().(*registry.TestSpec)
 
-	grafanaAvailable := roachtestflags.Cloud == spec.GCE
+	// Get the Prometheus reachability for the cloud we run the tests on.
+	promReachability := promhelperclient.ProviderReachability(
+		roachtestflags.Cloud.String(),
+		promhelperclient.Default,
+	)
+
+	// If reachability is not None, we can assume that metrics will be scrapped
+	// and that Grafana will display something.
+	grafanaAvailable := promReachability != promhelperclient.None
 	if err := c.addLabels(map[string]string{VmLabelTestName: testRunID, VmLabelTestOwner: t.Owner()}); err != nil {
 		shout(ctx, l, stdout, "failed to add label to cluster [%s] - %s", c.Name(), err)
 		grafanaAvailable = false

--- a/pkg/roachprod/cloud/cluster_cloud.go
+++ b/pkg/roachprod/cloud/cluster_cloud.go
@@ -494,7 +494,10 @@ func (c *Cluster) DeletePrometheusConfig(ctx context.Context, l *logger.Logger) 
 
 	for _, node := range c.VMs {
 
-		reachability := cl.ProviderReachability(node.Provider)
+		reachability := promhelperclient.ProviderReachability(
+			node.Provider,
+			promhelperclient.CloudEnvironment(node.Project),
+		)
 		if reachability == promhelperclient.None {
 			continue
 		}


### PR DESCRIPTION
Previously, Prometheus metrics were only available on GCP, so roachtest was not annotating the tests on Grafana outisde of GCP.

Now that all cloud providers are scraped by Prometheus, this patch allows grafana annotation for all cloud providers.

This patch also adds a distinction in reachability between the project `cockroach-ephemeral` and other GCP projects as only `cockroach-ephemeral` can be scraped internally.

Lastly, two new tags are added to metrics:
- provider: the Cloud provider
- node_id: the node ID of the VM (last part of the name)

Epic: none
Release note: None