### PR TITLE
release-24.3: sqlstats: clarify latency percentile limitations

### DIFF
--- a/pkg/sql/appstatspb/app_stats.go
+++ b/pkg/sql/appstatspb/app_stats.go
@@ -285,24 +285,4 @@ func (s *LatencyInfo) Add(other LatencyInfo) {
 	if other.Max > s.Max {
 		s.Max = other.Max
 	}
-	s.checkPercentiles()
-}
-
-// checkPercentiles is a patchy solution and not ideal.
-// When the execution count for a period is smaller than 500,
-// the percentiles sample is including previous aggregation periods,
-// making the p99 possible be greater than the max.
-// For now, we just do a check and update the percentiles to the max
-// possible size.
-// TODO(maryliag): use a proper sample size (#99070)
-func (s *LatencyInfo) checkPercentiles() {
-	if s.P99 > s.Max {
-		s.P99 = s.Max
-	}
-	if s.P90 > s.Max {
-		s.P90 = s.Max
-	}
-	if s.P50 > s.Max {
-		s.P50 = s.Max
-	}
 }

--- a/pkg/ui/workspaces/cluster-ui/src/statsTableUtil/statsTableUtil.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statsTableUtil/statsTableUtil.tsx
@@ -964,6 +964,14 @@ export const statisticsTableTitles: StatisticTableTitleType = {
           <p>
             The 50th latency percentile for sampled {contentModifier} executions
             with this fingerprint.
+            <br />
+            <br />
+            <strong>Warning:</strong> the data source for latency percentiles is
+            different from the source for other execution statistics. These
+            percentiles are not calculated from the same set of executions as
+            the other columns and can be inconsistent. The data is provided for
+            informational purposes here and is not expected to be consistent
+            with max, min, or average latency that is also presented.
           </p>
         }
       >
@@ -990,6 +998,14 @@ export const statisticsTableTitles: StatisticTableTitleType = {
           <p>
             The 90th latency percentile for sampled {contentModifier} executions
             with this fingerprint.
+            <br />
+            <br />
+            <strong>Warning:</strong> the data source for latency percentiles is
+            different from the source for other execution statistics. These
+            percentiles are not calculated from the same set of executions as
+            the other columns and can be inconsistent. The data is provided for
+            informational purposes here and is not expected to be consistent
+            with max, min, or average latency that is also presented.
           </p>
         }
       >
@@ -1016,6 +1032,14 @@ export const statisticsTableTitles: StatisticTableTitleType = {
           <p>
             The 99th latency percentile for sampled {contentModifier} executions
             with this fingerprint.
+            <br />
+            <br />
+            <strong>Warning:</strong> the data source for latency percentiles is
+            different from the source for other execution statistics. These
+            percentiles are not calculated from the same set of executions as
+            the other columns and can be inconsistent. The data is provided for
+            informational purposes here and is not expected to be consistent
+            with max, min, or average latency that is also presented.
           </p>
         }
       >


### PR DESCRIPTION
Previously, there were some band-aids in place to limit the confusion around latency percentile estimates for SQL stats. These limitations cannot be obscured and result in confusion from customers.

This PR takes the opposite approach:
- Removal of code that would artificially clamp down reported quantiles to hide inconsistencies with max.
- Addition of explanatory text to DB Console to clarify the limitations of these numbers.

Resolves #139253

Release note: None

----

Additional note: This PR is going directly onto 24.3 because these features are removed in `master`.

----

Release justification: low-risk high impact change