### PR TITLE
roachtest: do not start crdb instances on the workload node

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -2174,7 +2174,8 @@ func (c *clusterImpl) StartE(
 
 	clusterSettingsOpts := c.configureClusterSettingOptions(c.clusterSettings, settings)
 
-	if err := roachprod.Start(ctx, l, c.MakeNodes(opts...), startOpts.RoachprodOpts, clusterSettingsOpts...); err != nil {
+	nodes := selectedNodesOrDefault(opts, c.CRDBNodes())
+	if err := roachprod.Start(ctx, l, c.MakeNodes(nodes), startOpts.RoachprodOpts, clusterSettingsOpts...); err != nil {
 		return err
 	}
 
@@ -2185,7 +2186,6 @@ func (c *clusterImpl) StartE(
 			return err
 		}
 	}
-	nodes := selectedNodesOrDefault(opts, c.CRDBNodes())
 	// N.B. If `SkipInit` is set, we don't wait for SQL since node(s) may not join the cluster in any definite time.
 	if !startOpts.RoachprodOpts.SkipInit {
 		// Wait for SQL to be ready on all nodes, for 'system' tenant, only.


### PR DESCRIPTION
Previously, if a roachtest cluster contained a workload node, starting a CRDB would start a CRDB instance on the workload node. This is undesirable because the workload node is undersized and is not supposed to be part of the CRDB cluster.

Epic: none
Release note: none