### PR TITLE
flowinfra: enable some outbox error logging by default

### DIFF
--- a/pkg/sql/colflow/colrpc/BUILD.bazel
+++ b/pkg/sql/colflow/colrpc/BUILD.bazel
@@ -57,6 +57,7 @@ go_test(
         "//pkg/col/coldata",
         "//pkg/col/coldatatestutils",
         "//pkg/col/colserde",
+        "//pkg/roachpb",
         "//pkg/rpc",
         "//pkg/settings/cluster",
         "//pkg/sql/colexec/colexecargs",

--- a/pkg/sql/colflow/colrpc/BUILD.bazel
+++ b/pkg/sql/colflow/colrpc/BUILD.bazel
@@ -32,6 +32,7 @@ go_library(
         "//pkg/util/log",
         "//pkg/util/log/logcrash",
         "//pkg/util/mon",
+        "//pkg/util/stop",
         "//pkg/util/timeutil",
         "//pkg/util/tracing",
         "@com_github_cockroachdb_errors//:errors",

--- a/pkg/sql/colflow/colrpc/colrpc_test.go
+++ b/pkg/sql/colflow/colrpc/colrpc_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coldatatestutils"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/colexecargs"
@@ -116,7 +117,7 @@ func handleStream(
 ) chan error {
 	handleStreamErrCh := make(chan error, 1)
 	go func() {
-		handleStreamErrCh <- inbox.RunWithStream(ctx, stream)
+		handleStreamErrCh <- inbox.RunWithStream(ctx, stream, nil /* header */)
 		if doneFn != nil {
 			doneFn()
 		}
@@ -274,8 +275,10 @@ func TestOutboxInbox(t *testing.T) {
 			defer outboxMemAcc.Close(outboxCtx)
 			outboxConverterMemAcc := testMemMonitor.MakeBoundAccount()
 			defer outboxConverterMemAcc.Close(ctx)
+			var nodeid base.NodeIDContainer
+			nodeid.Set(ctx, roachpb.NodeID(7))
 			outbox, err := NewOutbox(
-				&execinfra.FlowCtx{Gateway: false},
+				&execinfra.FlowCtx{NodeID: base.NewSQLIDContainerForNode(&nodeid), Gateway: false},
 				0, /* processorID */
 				colmem.NewAllocator(outboxCtx, &outboxMemAcc, coldata.StandardColumnFactory),
 				&outboxConverterMemAcc, colexecargs.OpWithMetaInfo{Root: input}, typs, nil, /* getStats */
@@ -519,8 +522,10 @@ func TestInboxHostCtxCancellation(t *testing.T) {
 	outboxInput := colexecutils.NewFixedNumTuplesNoInputOp(testAllocator, 1 /* numTuples */, nil /* opToInitialize */)
 	outboxMemAcc := testMemMonitor.MakeBoundAccount()
 	defer outboxMemAcc.Close(outboxHostCtx)
+	var nodeid base.NodeIDContainer
+	nodeid.Set(ctx, roachpb.NodeID(7))
 	outbox, err := NewOutbox(
-		&execinfra.FlowCtx{Gateway: false},
+		&execinfra.FlowCtx{NodeID: base.NewSQLIDContainerForNode(&nodeid), Gateway: false},
 		0, /* processorID */
 		colmem.NewAllocator(outboxHostCtx, &outboxMemAcc, coldata.StandardColumnFactory),
 		testMemAcc, colexecargs.OpWithMetaInfo{Root: outboxInput}, typs, nil, /* getStats */
@@ -711,8 +716,10 @@ func TestOutboxInboxMetadataPropagation(t *testing.T) {
 			if tc.overrideExpectedMetadata != nil {
 				expectedMetadata = tc.overrideExpectedMetadata
 			}
+			var nodeid base.NodeIDContainer
+			nodeid.Set(ctx, roachpb.NodeID(7))
 			outbox, err := NewOutbox(
-				&execinfra.FlowCtx{Gateway: false},
+				&execinfra.FlowCtx{NodeID: base.NewSQLIDContainerForNode(&nodeid), Gateway: false},
 				0, /* processorID */
 				colmem.NewAllocator(ctx, &outboxMemAcc, coldata.StandardColumnFactory),
 				testMemAcc,
@@ -809,8 +816,10 @@ func BenchmarkOutboxInbox(b *testing.B) {
 
 	outboxMemAcc := testMemMonitor.MakeBoundAccount()
 	defer outboxMemAcc.Close(ctx)
+	var nodeid base.NodeIDContainer
+	nodeid.Set(ctx, roachpb.NodeID(7))
 	outbox, err := NewOutbox(
-		&execinfra.FlowCtx{Gateway: false},
+		&execinfra.FlowCtx{NodeID: base.NewSQLIDContainerForNode(&nodeid), Gateway: false},
 		0, /* processorID */
 		colmem.NewAllocator(ctx, &outboxMemAcc, coldata.StandardColumnFactory),
 		testMemAcc, colexecargs.OpWithMetaInfo{Root: input}, typs, nil, /* getStats */
@@ -876,8 +885,11 @@ func TestOutboxStreamIDPropagation(t *testing.T) {
 
 	outboxMemAcc := testMemMonitor.MakeBoundAccount()
 	defer outboxMemAcc.Close(ctx)
+	var nodeid base.NodeIDContainer
+	nodeid.Set(ctx, roachpb.NodeID(7))
 	outbox, err := NewOutbox(
 		&execinfra.FlowCtx{
+			NodeID:  base.NewSQLIDContainerForNode(&nodeid),
 			Gateway: false,
 			Cfg: &execinfra.ServerConfig{
 				Settings:   cluster.MakeTestingClusterSettings(),

--- a/pkg/sql/colflow/colrpc/inbox.go
+++ b/pkg/sql/colflow/colrpc/inbox.go
@@ -11,6 +11,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/obs/ash"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/colexecutils"
@@ -36,6 +37,13 @@ type flowStreamServer interface {
 	Recv() (*execinfrapb.ProducerMessage, error)
 }
 
+// streamAndProducerHeader is sent over Inbox.streamCh to pass both the
+// stream and the producer identity from RunWithStream to Init.
+type streamAndProducerHeader struct {
+	stream flowStreamServer
+	header *execinfrapb.ProducerHeader
+}
+
 // Inbox is used to expose data from remote flows through a colexecop.Operator
 // interface. FlowStream RPC handlers should call RunWithStream (which blocks
 // until operation terminates, gracefully or unexpectedly) to pass the stream
@@ -59,9 +67,12 @@ type Inbox struct {
 	// in the ctx argument of Next and DrainMeta.
 	streamID execinfrapb.StreamID
 
+	// producer is the ID of the producer, used for debugging.
+	producer base.SQLInstanceID
+
 	// streamCh is the channel over which the stream is passed from the stream
 	// handler to the reader goroutine.
-	streamCh chan flowStreamServer
+	streamCh chan streamAndProducerHeader
 	// contextCh is the channel over which the reader goroutine passes the
 	// context to the stream handler so that it can listen for context
 	// cancellation.
@@ -126,7 +137,7 @@ func NewInbox(
 		typs:                     typs,
 		allocator:                allocator,
 		streamID:                 streamID,
-		streamCh:                 make(chan flowStreamServer, 1),
+		streamCh:                 make(chan streamAndProducerHeader, 1),
 		contextCh:                make(chan context.Context, 1),
 		timeoutCh:                make(chan error, 1),
 		errCh:                    make(chan error, 1),
@@ -198,13 +209,19 @@ func (i *Inbox) checkFlowCtxCancellation() error {
 // canceled, the Inbox's host cancels the flow context, a caller of Next cancels
 // the context passed into Init, or any error is encountered on the stream by
 // the Next goroutine.
-func (i *Inbox) RunWithStream(streamCtx context.Context, stream flowStreamServer) error {
+func (i *Inbox) RunWithStream(
+	streamCtx context.Context, stream flowStreamServer, firstMsgHeader *execinfrapb.ProducerHeader,
+) error {
 	streamCtx = logtags.AddTag(streamCtx, "streamID", i.streamID)
-	log.VEvent(streamCtx, 2, "Inbox handling stream")
+	var producer base.SQLInstanceID
+	if firstMsgHeader != nil {
+		producer = firstMsgHeader.Producer
+	}
+	log.VEventf(streamCtx, 2, "Inbox handling stream from %d", producer)
 	defer log.VEvent(streamCtx, 2, "Inbox exited stream handler")
 	// Pass the stream to the reader goroutine (non-blocking) and get the
 	// context to listen for cancellation.
-	i.streamCh <- stream
+	i.streamCh <- streamAndProducerHeader{stream: stream, header: firstMsgHeader}
 	var readerCtx context.Context
 	select {
 	case err := <-i.errCh:
@@ -213,7 +230,11 @@ func (i *Inbox) RunWithStream(streamCtx context.Context, stream flowStreamServer
 	case readerCtx = <-i.contextCh:
 		log.VEvent(streamCtx, 2, "Inbox reader arrived")
 	case <-streamCtx.Done():
-		return errors.Wrap(streamCtx.Err(), "streamCtx error while waiting for reader (remote client canceled)")
+		return errors.Wrapf(
+			streamCtx.Err(),
+			"streamCtx error while waiting for reader (remote client %d canceled stream %d)",
+			producer, i.streamID,
+		)
 	case <-i.flowCtxDone:
 		// The flow context of the inbox host has been canceled. This can occur
 		// e.g. when the query is canceled, or when another stream encountered
@@ -241,7 +262,11 @@ func (i *Inbox) RunWithStream(streamCtx context.Context, stream flowStreamServer
 		return i.checkFlowCtxCancellation()
 	case <-streamCtx.Done():
 		// The client canceled the stream.
-		return errors.Wrap(streamCtx.Err(), "streamCtx error in Inbox stream handler (remote client canceled)")
+		return errors.Wrapf(
+			streamCtx.Err(),
+			"streamCtx error in Inbox stream handler (remote client %d canceled stream %d)",
+			producer, i.streamID,
+		)
 	}
 }
 
@@ -264,7 +289,11 @@ func (i *Inbox) Init(ctx context.Context) {
 		// Wait for the stream to be initialized. We're essentially waiting for
 		// the remote connection.
 		select {
-		case i.stream = <-i.streamCh:
+		case streamAndHeader := <-i.streamCh:
+			i.stream = streamAndHeader.stream
+			if streamAndHeader.header != nil {
+				i.producer = streamAndHeader.header.Producer
+			}
 		case err := <-i.timeoutCh:
 			i.errCh <- errors.Wrap(err, "remote stream arrived too late")
 			return err
@@ -359,8 +388,13 @@ func (i *Inbox) Next() (coldata.Batch, *execinfrapb.ProducerMetadata) {
 			// Regardless of the cause we want to propagate such an error as
 			// expected one in all cases so that the caller could decide on how
 			// to handle it.
-			log.VEventf(i.Ctx, 2, "Inbox communication error: %v", err)
-			err = pgerror.Wrap(err, pgcode.InternalConnectionFailure, "inbox communication error")
+			log.VEventf(
+				i.Ctx, 2, "Inbox communication error in stream %d from %d: %v", i.streamID, i.producer, err,
+			)
+			err = pgerror.Wrapf(
+				err, pgcode.InternalConnectionFailure, "inbox communication error in stream %d from %d",
+				i.streamID, i.producer,
+			)
 			i.errCh <- err
 			ungracefulStreamTermination = true
 			colexecerror.ExpectedError(err)
@@ -448,7 +482,7 @@ func (i *Inbox) GetNumMessages() int64 {
 func (i *Inbox) sendDrainSignal(ctx context.Context) error {
 	log.VEvent(ctx, 2, "Inbox sending drain signal to Outbox")
 	if err := i.stream.Send(&execinfrapb.ConsumerSignal{DrainRequest: &execinfrapb.DrainRequest{}}); err != nil {
-		log.Dev.VWarningf(ctx, 1, "Inbox unable to send drain signal to Outbox: %+v", err)
+		log.Dev.VWarningf(ctx, 1, "Inbox unable to send drain signal to Outbox from %d: %+v", i.producer, err)
 		return err
 	}
 	return nil
@@ -482,7 +516,10 @@ func (i *Inbox) DrainMeta() []execinfrapb.ProducerMetadata {
 			if err == io.EOF {
 				break
 			}
-			log.VEventf(i.Ctx, 1, "Inbox communication error while draining metadata: %v", err)
+			log.VEventf(
+				i.Ctx, 1, "Inbox communication error in stream %d from %d while draining metadata: %v",
+				i.streamID, i.producer, err,
+			)
 			return allMeta
 		}
 		if len(msg.Data.Metadata) == 0 {

--- a/pkg/sql/colflow/colrpc/inbox_test.go
+++ b/pkg/sql/colflow/colrpc/inbox_test.go
@@ -66,7 +66,7 @@ func TestInboxCancellation(t *testing.T) {
 		err = colexecerror.CatchVectorizedRuntimeError(func() { inbox.Init(ctx) })
 		require.True(t, testutils.IsError(err, "context canceled"), err)
 		// Now, the remote stream arrives.
-		err = inbox.RunWithStream(context.Background(), mockFlowStreamServer{})
+		err = inbox.RunWithStream(context.Background(), mockFlowStreamServer{}, nil /* header */)
 		// We expect no error from the stream handler since we canceled it
 		// ourselves (a graceful termination).
 		require.Nil(t, err)

--- a/pkg/sql/colflow/colrpc/outbox.go
+++ b/pkg/sql/colflow/colrpc/outbox.go
@@ -269,7 +269,13 @@ func (o *Outbox) Run(
 		log.VEvent(ctx, 2, "Outbox sending header")
 		// Send header message to establish the remote server (consumer).
 		if err = stream.Send(
-			&execinfrapb.ProducerMessage{Header: &execinfrapb.ProducerHeader{FlowID: o.flowCtx.ID, StreamID: streamID}},
+			&execinfrapb.ProducerMessage{
+				Header: &execinfrapb.ProducerHeader{
+					FlowID:   o.flowCtx.ID,
+					StreamID: streamID,
+					Producer: o.flowCtx.NodeID.SQLInstanceID(),
+				},
+			},
 		); err != nil {
 			log.Dev.VWarningf(ctx, 1, "Outbox Send header error, distributed query will fail: %+v", err)
 			return err

--- a/pkg/sql/colflow/colrpc/outbox.go
+++ b/pkg/sql/colflow/colrpc/outbox.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
@@ -185,6 +186,13 @@ func (o *Outbox) workloadType() workloadid.WorkloadType {
 		return o.flowCtx.EvalCtx.WorkloadType
 	}
 	return workloadid.WorkloadTypeUnknown
+}
+
+func (o *Outbox) cfgStopper() *stop.Stopper {
+	if o.flowCtx != nil && o.flowCtx.Cfg != nil {
+		return o.flowCtx.Cfg.Stopper
+	}
+	return nil
 }
 
 // Run starts an outbox by connecting to the provided node and pushing
@@ -347,7 +355,7 @@ func (o *Outbox) sendBatches(
 				err := stream.Send(o.scratch.msg)
 				sendCleanup()
 				if err != nil {
-					flowinfra.HandleStreamErr(ctx, "Send (streaming metadata)", err, flowCtxCancel, outboxCtxCancel)
+					flowinfra.HandleStreamErr(ctx, "Send (streaming metadata)", err, flowCtxCancel, outboxCtxCancel, o.cfgStopper())
 					return
 				}
 				continue
@@ -397,7 +405,7 @@ func (o *Outbox) sendBatches(
 			err = stream.Send(o.scratch.msg)
 			sendCleanup()
 			if err != nil {
-				flowinfra.HandleStreamErr(ctx, "Send (batches)", err, flowCtxCancel, outboxCtxCancel)
+				flowinfra.HandleStreamErr(ctx, "Send (batches)", err, flowCtxCancel, outboxCtxCancel, o.cfgStopper())
 				return
 			}
 		}
@@ -490,7 +498,7 @@ func (o *Outbox) runWithStream(
 		for {
 			msg, err := stream.Recv()
 			if err != nil {
-				flowinfra.HandleStreamErr(ctx, "watchdog Recv", err, flowCtxCancel, outboxCtxCancel)
+				flowinfra.HandleStreamErr(ctx, "watchdog Recv", err, flowCtxCancel, outboxCtxCancel, o.cfgStopper())
 				break
 			}
 			switch {
@@ -514,14 +522,14 @@ func (o *Outbox) runWithStream(
 		}
 		o.moveToDraining(ctx, reason)
 		if err := o.sendDrainedMetadata(ctx, stream, errToSend); err != nil {
-			flowinfra.HandleStreamErr(ctx, "Send (draining metadata)", err, flowCtxCancel, outboxCtxCancel)
+			flowinfra.HandleStreamErr(ctx, "Send (draining metadata)", err, flowCtxCancel, outboxCtxCancel, o.cfgStopper())
 		} else {
 			// Close the stream. Note that if this block isn't reached, the stream
 			// is unusable.
 			// The receiver goroutine will read from the stream until any error
 			// is returned (most likely an io.EOF).
 			if err := stream.CloseSend(); err != nil {
-				flowinfra.HandleStreamErr(ctx, "CloseSend", err, flowCtxCancel, outboxCtxCancel)
+				flowinfra.HandleStreamErr(ctx, "CloseSend", err, flowCtxCancel, outboxCtxCancel, o.cfgStopper())
 			}
 		}
 	}

--- a/pkg/sql/colflow/vectorized_flow.go
+++ b/pkg/sql/colflow/vectorized_flow.go
@@ -1278,10 +1278,10 @@ var _ flowinfra.InboundStreamHandler = vectorizedInboundStreamHandler{}
 func (s vectorizedInboundStreamHandler) Run(
 	ctx context.Context,
 	stream execinfrapb.RPCDistSQL_FlowStreamStream,
-	_ *execinfrapb.ProducerMessage,
+	firstMsg *execinfrapb.ProducerMessage,
 	_ *flowinfra.FlowBase,
 ) error {
-	return s.RunWithStream(ctx, stream)
+	return s.RunWithStream(ctx, stream, firstMsg.Header)
 }
 
 // Timeout is part of the flowinfra.InboundStreamHandler interface.

--- a/pkg/sql/colflow/vectorized_flow_shutdown_test.go
+++ b/pkg/sql/colflow/vectorized_flow_shutdown_test.go
@@ -13,8 +13,10 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/col/coldatatestutils"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec"
@@ -247,8 +249,11 @@ func TestVectorizedFlowShutdown(t *testing.T) {
 					id int,
 					outboxMetadataSources []colexecop.MetadataSource,
 				) {
+					var nodeid base.NodeIDContainer
+					nodeid.Set(context.Background(), roachpb.NodeID(7))
 					outbox, err := colrpc.NewOutbox(
 						&execinfra.FlowCtx{
+							NodeID:  base.NewSQLIDContainerForNode(&nodeid),
 							Gateway: false,
 							Cfg: &execinfra.ServerConfig{
 								Settings:   st,
@@ -287,7 +292,7 @@ func TestVectorizedFlowShutdown(t *testing.T) {
 					doneFn := func() { close(serverStreamNotification.Donec) }
 					wg.Add(1)
 					go func(id int, stream execinfrapb.DistSQL_FlowStreamServer, doneFn func()) {
-						handleStreamErrCh[id] <- inbox.RunWithStream(stream.Context(), stream)
+						handleStreamErrCh[id] <- inbox.RunWithStream(stream.Context(), stream, nil /* header */)
 						doneFn()
 						wg.Done()
 					}(id, serverStream, doneFn)

--- a/pkg/sql/distsql/server.go
+++ b/pkg/sql/distsql/server.go
@@ -875,17 +875,19 @@ func (ds *ServerImpl) flowStreamInt(
 	log.VEvent(ctx, 2, "FlowStream (server) received header")
 	flowID := msg.Header.FlowID
 	streamID := msg.Header.StreamID
+	producer := msg.Header.Producer
 	if log.V(1) {
-		log.Dev.Infof(ctx, "connecting inbound stream %s/%d", flowID.Short(), streamID)
+		log.Dev.Infof(ctx, "connecting inbound stream %s/%d from %d", flowID.Short(), streamID, producer)
 	}
 	f, streamStrategy, cleanup, err := ds.flowRegistry.ConnectInboundStream(
-		ctx, flowID, streamID, stream, flowinfra.SettingFlowStreamTimeout.Get(&ds.Settings.SV),
+		ctx, flowID, streamID, producer, stream,
+		flowinfra.SettingFlowStreamTimeout.Get(&ds.Settings.SV),
 	)
 	if err != nil {
 		return err
 	}
 	defer cleanup()
-	log.VEventf(ctx, 1, "connected inbound stream %s/%d", flowID.Short(), streamID)
+	log.VEventf(ctx, 1, "connected inbound stream %s/%d from %d", flowID.Short(), streamID, producer)
 	ctx = f.AmbientContext.AnnotateCtx(ctx)
 	ctx, undo := pprofutil.SetProfilerLabelsFromCtxTags(ctx)
 	defer undo()

--- a/pkg/sql/execinfrapb/data.proto
+++ b/pkg/sql/execinfrapb/data.proto
@@ -217,6 +217,10 @@ message ProducerHeader {
   optional int32 stream_id = 2 [(gogoproto.nullable) = false,
     (gogoproto.customname) = "StreamID",
     (gogoproto.casttype) = "StreamID"];
+
+  // The SQLInstanceID of the producer. Used for debugging.
+  optional int32 producer = 3 [(gogoproto.nullable) = false,
+    (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/base.SQLInstanceID"];
 }
 
 // ProducerData is a message that can be sent multiple times as part of a stream

--- a/pkg/sql/flowinfra/flow_registry.go
+++ b/pkg/sql/flowinfra/flow_registry.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -541,6 +542,7 @@ func (fr *FlowRegistry) ConnectInboundStream(
 	ctx context.Context,
 	flowID execinfrapb.FlowID,
 	streamID execinfrapb.StreamID,
+	producer base.SQLInstanceID,
 	stream execinfrapb.RPCDistSQL_FlowStreamStream,
 	timeout time.Duration,
 ) (_ *FlowBase, _ InboundStreamHandler, cleanup func(), retErr error) {
@@ -592,7 +594,9 @@ func (fr *FlowRegistry) ConnectInboundStream(
 	// the map is not modified after Flow.Setup.
 	s, ok := entry.inboundStreams[streamID]
 	if !ok {
-		return nil, nil, nil, errors.Errorf("flow %s: no inbound stream %d", flowID, streamID)
+		return nil, nil, nil, errors.Errorf(
+			"flow %s: no inbound stream %d from %d", flowID, streamID, producer,
+		)
 	}
 
 	// Don't mark s as connected until after the handshake succeeds.
@@ -607,7 +611,9 @@ func (fr *FlowRegistry) ConnectInboundStream(
 	if s.mu.canceled {
 		// Regardless of whether the handshake succeeded or not, this inbound
 		// stream has already been canceled and properly finished.
-		return nil, nil, nil, errors.Errorf("flow %s: inbound stream %d came too late", flowID, streamID)
+		return nil, nil, nil, errors.Errorf(
+			"flow %s: inbound stream %d from %d came too late", flowID, streamID, producer,
+		)
 	}
 	if handshakeErr != nil {
 		// The handshake failed, so we're canceling this stream.
@@ -619,7 +625,9 @@ func (fr *FlowRegistry) ConnectInboundStream(
 		// outboxes for the same stream. We are processing the second RPC call
 		// right now, so there is another goroutine that will handle the
 		// cleanup, so we defer the cleanup to that goroutine.
-		return nil, nil, nil, errors.AssertionFailedf("flow %s: inbound stream %d already connected", flowID, streamID)
+		return nil, nil, nil, errors.AssertionFailedf(
+			"flow %s: inbound stream %d from %d already connected", flowID, streamID, producer,
+		)
 	}
 	s.mu.connected = true
 	return flow, s.receiver, s.finish, nil

--- a/pkg/sql/flowinfra/inbound.go
+++ b/pkg/sql/flowinfra/inbound.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"io"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/obs/ash"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
@@ -108,7 +109,14 @@ func processInboundStreamHelper(
 		dst.ProducerDone()
 	}
 
+	var streamID execinfrapb.StreamID
+	var producer base.SQLInstanceID
+
 	if firstMsg != nil {
+		if firstMsg.Header != nil {
+			streamID = firstMsg.Header.StreamID
+			producer = firstMsg.Header.Producer
+		}
 		if res := processProducerMessage(
 			ctx, f, stream, dst, &sd, &draining, firstMsg,
 		); res.err != nil || res.consumerClosed {
@@ -148,8 +156,13 @@ func processInboundStreamHelper(
 			if err != nil {
 				if err != io.EOF {
 					// Communication error.
-					log.VEventf(ctx, 2, "Inbox communication error: %v", err)
-					err = pgerror.Wrap(err, pgcode.InternalConnectionFailure, "inbox communication error")
+					log.VEventf(
+						ctx, 2, "Inbox communication error in stream %d from %d: %v", streamID, producer, err,
+					)
+					err = pgerror.Wrapf(
+						err, pgcode.InternalConnectionFailure, "inbox communication error in stream %d from %d",
+						streamID, producer,
+					)
 					sendErrToConsumer(err)
 					errChan <- err
 					return
@@ -160,7 +173,7 @@ func processInboundStreamHelper(
 				return
 			}
 
-			log.VEvent(ctx, 2, "Inbox received message")
+			log.VEventf(ctx, 2, "Inbox received message in stream %d from %d", streamID, producer)
 			if res := processProducerMessage(
 				ctx, f, stream, dst, &sd, &draining, msg,
 			); res.err != nil || res.consumerClosed {

--- a/pkg/sql/flowinfra/outbox.go
+++ b/pkg/sql/flowinfra/outbox.go
@@ -112,7 +112,7 @@ func NewOutbox(
 	isGatewayNode bool,
 ) *Outbox {
 	m := &Outbox{flowCtx: flowCtx, processorID: processorID, sqlInstanceID: sqlInstanceID}
-	m.encoder.SetHeaderFields(flowCtx.ID, streamID)
+	m.encoder.SetHeaderFields(flowCtx.ID, streamID, flowCtx.NodeID.SQLInstanceID())
 	m.streamID = streamID
 	m.numOutboxes = numOutboxes
 	m.isGatewayNode = isGatewayNode

--- a/pkg/sql/flowinfra/outbox.go
+++ b/pkg/sql/flowinfra/outbox.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/admission"
 	"github.com/cockroachdb/cockroach/pkg/util/growstack"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
@@ -207,14 +208,13 @@ func (m *Outbox) flush(ctx context.Context) error {
 		}
 	}
 	if sendErr != nil {
-		HandleStreamErr(ctx, "flushing", sendErr, m.flowCtxCancel, m.outboxCtxCancel)
+		HandleStreamErr(ctx, "flushing", sendErr, m.flowCtxCancel, m.outboxCtxCancel, m.flowCtx.Cfg.Stopper)
 		// This error probably won't reach the client, but we wrap it with an
 		// internal connection failure error code anyway for consistency with
 		// other DistSQL connection failures.
 		sendErr = pgerror.Wrap(sendErr, pgcode.InternalConnectionFailure, "outbox communication error")
 		// Make sure the stream is not used any more.
 		m.stream = nil
-		log.Dev.VWarningf(ctx, 1, "Outbox flush error: %s", sendErr)
 	} else {
 		log.VEvent(ctx, 2, "Outbox flushed")
 	}
@@ -433,7 +433,7 @@ func (m *Outbox) startWatchdogGoroutine(
 					err = pgerror.Wrap(err, pgcode.InternalConnectionFailure, "outbox communication error")
 					m.setErr(err)
 				}
-				HandleStreamErr(ctx, "watchdog Recv", err, m.flowCtxCancel, m.outboxCtxCancel)
+				HandleStreamErr(ctx, "watchdog Recv", err, m.flowCtxCancel, m.outboxCtxCancel, m.flowCtx.Cfg.Stopper)
 				break
 			}
 			switch {
@@ -489,19 +489,32 @@ func (m *Outbox) Err() error {
 
 // HandleStreamErr is a utility method used to handle an error when calling
 // a method on a flowStreamClient. If err is an io.EOF, outboxCtxCancel is
-// called, for all other errors flowCtxCancel is. The given error is logged with
-// the associated opName.
+// called, for all other errors flowCtxCancel is called and the error is
+// logged at WARNING level (since it cannot be sent back via the broken
+// stream). The warning is suppressed when the stopper is quiescing, since
+// connection errors are expected during server shutdown.
 func HandleStreamErr(
 	ctx context.Context,
 	opName redact.SafeString,
 	err error,
 	flowCtxCancel, outboxCtxCancel context.CancelFunc,
+	stopper *stop.Stopper,
 ) {
 	if err == io.EOF {
 		log.VEventf(ctx, 2, "Outbox calling outboxCtxCancel after %s EOF", opName)
 		outboxCtxCancel()
 	} else {
-		log.VEventf(ctx, 1, "Outbox calling flowCtxCancel after %s connection error: %+v", opName, err)
+		quiescing := false
+		if stopper != nil {
+			select {
+			case <-stopper.ShouldQuiesce():
+				quiescing = true
+			default:
+			}
+		}
+		if !quiescing {
+			log.Dev.Warningf(ctx, "Outbox calling flowCtxCancel after %s connection error: %+v", opName, err)
+		}
 		flowCtxCancel()
 	}
 }

--- a/pkg/sql/flowinfra/stream_encoder.go
+++ b/pkg/sql/flowinfra/stream_encoder.go
@@ -8,6 +8,7 @@ package flowinfra
 import (
 	"context"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catenumpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
@@ -65,9 +66,12 @@ func (se *StreamEncoder) HasHeaderBeenSent() bool {
 }
 
 // SetHeaderFields sets the header fields.
-func (se *StreamEncoder) SetHeaderFields(flowID execinfrapb.FlowID, streamID execinfrapb.StreamID) {
+func (se *StreamEncoder) SetHeaderFields(
+	flowID execinfrapb.FlowID, streamID execinfrapb.StreamID, producer base.SQLInstanceID,
+) {
 	se.msgHdr.FlowID = flowID
 	se.msgHdr.StreamID = streamID
+	se.msgHdr.Producer = producer
 }
 
 // Init initializes the encoder.


### PR DESCRIPTION
**flowinfra: enable some outbox error logging by default**

When the gRPC streams between outbox and inbox are broken, errors from
the outbox side are lost. This can make it difficult to understand what
happened. This commit enables some of the outbox error logging by
default, so that the outbox error is preserved in the logs.

Fixes: #141447

Release note: None
    
---
    
**flowinfra, colflow, \*: add producer ID to inbox logging and errors**

When debugging DistSQL query failures, it can be difficult to figure out
which stream caused an "inbox communication error". This commit plumbs a
SQLInstanceID from the outbox to the inbox via the ProducerHeader, so
that we can add the remote SQL node ID to inbox error messages.

Informs: #141447

Release note: None