### PR TITLE
opt: fix handling of prefix and suffix vector index columns

### DIFF
--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -764,12 +764,17 @@ func (f *ExprFmtCtx) formatRelational(e RelExpr, tp treeprinter.Node) {
 		tp.Childf("target nearest neighbors: %d", t.TargetNeighborCount)
 
 	case *VectorMutationSearchExpr:
+		if t.IsIndexPut {
+			tp.Childf("index put")
+		} else {
+			tp.Childf("index del")
+		}
 		if len(t.PrefixKeyCols) > 0 {
 			tp.Childf("prefix key columns: %v", t.PrefixKeyCols)
 		}
 		tp.Childf("query vector column: %s", f.ColumnString(t.QueryVectorCol))
-		if !t.PrimaryKeyCols.Empty() {
-			tp.Childf("primary key columns: %v", t.PrimaryKeyCols)
+		if len(t.SuffixKeyCols) > 0 {
+			tp.Childf("suffix key columns: %v", t.SuffixKeyCols)
 		}
 		tp.Childf("partition col: %s", f.ColumnString(t.PartitionCol))
 		if t.QuantizedVectorCol != 0 {

--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -746,21 +746,6 @@ func (f *ExprFmtCtx) formatRelational(e RelExpr, tp treeprinter.Node) {
 		}
 
 	case *VectorSearchExpr:
-		if c := t.PrefixConstraint; c != nil {
-			if c.IsContradiction() {
-				tp.Childf("prefix constraint: contradiction")
-			} else if c.Spans.Count() == 1 {
-				tp.Childf(
-					"prefix constraint: %s: %s", c.Columns.String(),
-					cat.MaybeMarkRedactable(c.Spans.Get(0).String(), f.RedactableValues),
-				)
-			} else {
-				n := tp.Childf("prefix constraint: %s", c.Columns.String())
-				for i := 0; i < c.Spans.Count(); i++ {
-					n.Child(cat.MaybeMarkRedactable(c.Spans.Get(i).String(), f.RedactableValues))
-				}
-			}
-		}
 		tp.Childf("target nearest neighbors: %d", t.TargetNeighborCount)
 
 	case *VectorMutationSearchExpr:

--- a/pkg/sql/opt/memo/testdata/stats/vector-search
+++ b/pkg/sql/opt/memo/testdata/stats/vector-search
@@ -22,6 +22,7 @@ insert t
  ├── stats: [rows=0]
  └── vector-mutation-search t@t_v_idx,vector
       ├── columns: column1:5(int!null) v_cast:7(vector!null) vector_index_put_partition1:8(int) vector_index_put_quantized_vec1:9(bytes)
+      ├── index put
       ├── query vector column: v_cast:7
       ├── partition col: vector_index_put_partition1:8
       ├── quantized vector col: vector_index_put_quantized_vec1:9
@@ -63,6 +64,7 @@ insert t
  ├── stats: [rows=0]
  └── vector-mutation-search t@t_v_idx,vector
       ├── columns: column1:5(int!null) v_cast:7(vector!null) vector_index_put_partition1:8(int) vector_index_put_quantized_vec1:9(bytes)
+      ├── index put
       ├── query vector column: v_cast:7
       ├── partition col: vector_index_put_partition1:8
       ├── quantized vector col: vector_index_put_quantized_vec1:9

--- a/pkg/sql/opt/ops/relational.opt
+++ b/pkg/sql/opt/ops/relational.opt
@@ -1508,11 +1508,14 @@ define VectorMutationSearchPrivate {
     # columns will be NULL.
     QueryVectorCol ColumnID
 
-    # PrimaryKeyCols is the optional set of input columns used to constrain
+    # SuffixKeyCols is the optional list of input columns used to constrain
     # the search to a specific row. This is used for deletion from the index.
     # In rare cases it is possible not to find the requested row, in which case
     # the partition key will be NULL.
-    PrimaryKeyCols ColSet
+    #
+    # If it is set, SuffixKeyCols must contain every primary key column that is
+    # not part of PrefixKeyCols.
+    SuffixKeyCols ColList
 
     # PartitionCol is the output column that contains the partition key for each
     # vector. It is always set.
@@ -1522,6 +1525,10 @@ define VectorMutationSearchPrivate {
     # encoded form of the vector, which will be inserted as a value into the
     # index. It is only set for inserts into the index.
     QuantizedVectorCol ColumnID
+
+    # IsIndexPut if the vector index search is being conducted to prepare an
+    # index PUT operation. Otherwise, it is an index DELETE operation.
+    IsIndexPut bool
 }
 
 # Barrier is a relational operator that simply passes through its input columns

--- a/pkg/sql/opt/ops/relational.opt
+++ b/pkg/sql/opt/ops/relational.opt
@@ -1439,6 +1439,11 @@ define RecursiveCTEPrivate {
 # distances to the query vector, and applies the NN limit.
 [Relational, Telemetry]
 define VectorSearch {
+    # PrefixVals is set iff the vector index has a prefix of non-vector columns.
+    # It contains a list of constant values or placeholders that map 1-1 to the
+    # prefix columns.
+    PrefixVals ScalarListExpr
+
     # QueryVector is the scalar query vector. It is either a constant or a
     # placeholder.
     QueryVector ScalarExpr
@@ -1458,12 +1463,6 @@ define VectorSearchPrivate {
     # Cols is the set of columns produced by the vector search operator. This
     # is currently always the set of primary key columns.
     Cols ColSet
-
-    # PrefixConstraint is set iff the vector index has a prefix of non-vector
-    # columns. It contains one or more spans that each constrain every prefix
-    # column to a single value. The vector search will be conducted within each
-    # span independently.
-    PrefixConstraint Constraint
 
     # TargetNeighborCount is the number of nearest neighbors to search for.
     # The set of candidates returning will generally be larger than this number.

--- a/pkg/sql/opt/optbuilder/delete.go
+++ b/pkg/sql/opt/optbuilder/delete.go
@@ -112,7 +112,7 @@ func (mb *mutationBuilder) buildDelete(returning *tree.ReturningExprs) {
 	mb.projectPartialIndexDelCols()
 
 	// Project vector index DEL columns.
-	mb.projectVectorIndexColsForDelete()
+	mb.projectVectorIndexCols(opt.DeleteOp)
 
 	private := mb.makeMutationPrivate(returning != nil)
 	for _, col := range mb.extraAccessibleCols {

--- a/pkg/sql/opt/optbuilder/insert.go
+++ b/pkg/sql/opt/optbuilder/insert.go
@@ -749,7 +749,7 @@ func (mb *mutationBuilder) buildInsert(returning *tree.ReturningExprs) {
 	mb.projectPartialIndexPutCols()
 
 	// Project vector index PUT columns.
-	mb.projectVectorIndexCols()
+	mb.projectVectorIndexCols(opt.InsertOp)
 
 	mb.buildUniqueChecksForInsert()
 
@@ -969,7 +969,7 @@ func (mb *mutationBuilder) buildUpsert(returning *tree.ReturningExprs) {
 	}
 
 	// Project vector index PUT and DEL columns.
-	mb.projectVectorIndexCols()
+	mb.projectVectorIndexCols(opt.UpsertOp)
 
 	mb.buildUniqueChecksForUpsert()
 

--- a/pkg/sql/opt/optbuilder/mutation_builder.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder.go
@@ -1053,84 +1053,62 @@ func (mb *mutationBuilder) projectPartialIndexColsImpl(putScope, delScope *scope
 	}
 }
 
-// projectVectorIndexCols builds VectorMutationSearch operators for the input
-// of a non-DELETE mutation. See projectVectorIndexColsImpl for details.
-func (mb *mutationBuilder) projectVectorIndexCols() {
-	mb.projectVectorIndexColsImpl(false /* delete */)
-}
-
-// projectVectorIndexCols builds VectorMutationSearch operators for the input
-// of a DELETE mutation. See projectVectorIndexColsImpl for details.
-func (mb *mutationBuilder) projectVectorIndexColsForDelete() {
-	mb.projectVectorIndexColsImpl(true /* delete */)
-}
-
-// projectVectorIndexColsImpl builds VectorMutationSearch operators that
-// project partitions to be the target of index insertions and deletions for
-// each vector index defined on the target table. This is needed because vector
-// indexes must perform a search to determine which partition a given vector
-// belongs to.
+// projectVectorIndexCols builds VectorMutationSearch operators that project
+// partitions to be the target of index insertions and deletions for each vector
+// index defined on the target table. This is needed because vector indexes must
+// perform a search to determine which partition a given vector belongs to.
 //
 // See the vectorIndexPutPartitionColIDs, vectorIndexPutQuantizedVecColIDs, and
 // vectorIndexDelPartitionColIDs fields for more information.
-func (mb *mutationBuilder) projectVectorIndexColsImpl(delete bool) {
+func (mb *mutationBuilder) projectVectorIndexCols(op opt.Operator) {
 	if vectorIndexCount(mb.tab) > 0 {
-		getPutCol := func(colOrd int) opt.ColumnID {
-			if mb.upsertColIDs[colOrd] != 0 {
-				// If set, the upsert column will have the new value for the column
-				// regardless of whether the row is inserted or updated.
-				return mb.upsertColIDs[colOrd]
-			}
-			if mb.insertColIDs[colOrd] != 0 {
-				// A new value is being inserted for the column.
-				return mb.insertColIDs[colOrd]
-			}
-			// Either the column is being updated, or it does not have a new value.
-			return mb.updateColIDs[colOrd]
-		}
-		getDelCol := func(colOrd int) opt.ColumnID {
-			if !delete && mb.updateColIDs[colOrd] == 0 {
-				// For INSERT, UPDATE, and UPSERT, old index entries are only deleted
-				// for rows where the vector column is being updated.
-				return 0
-			}
-			// If there is an old version of the vector column, delete its entry from
-			// the vector index.
-			return mb.fetchColIDs[colOrd]
-		}
 		addCol := func(name string, typ *types.T) opt.ColumnID {
 			colName := scopeColName("").WithMetadataName(name)
 			sc := mb.b.synthesizeColumn(mb.outScope, colName, typ, nil /* expr */, nil /* expr */)
 			return sc.id
 		}
 		idxOrd := 0
-		for i, n := 0, mb.tab.DeletableIndexCount(); i < n; i++ {
+		for i := range mb.tab.DeletableIndexCount() {
 			index := mb.tab.Index(i)
 
 			// Skip non-vector indexes.
 			if index.Type() != idxtype.VECTOR {
 				continue
 			}
-			vectorColOrd := index.VectorColumn().Ordinal()
-			if delCol := getDelCol(vectorColOrd); delCol != 0 {
+
+			// Determine whether index PUT and DEL operations will be necessary.
+			indexColIsUpdated := false
+			if op == opt.UpsertOp || op == opt.UpdateOp {
+				// UPSERT and UPDATE statements can target specific columns for update.
+				// Check if any columns from the index are being updated.
+				for colIndexOrd := 0; colIndexOrd < index.ColumnCount(); colIndexOrd++ {
+					colTableOrd := index.Column(colIndexOrd).Ordinal()
+					if mb.upsertColIDs[colTableOrd] != 0 || mb.updateColIDs[colTableOrd] != 0 {
+						indexColIsUpdated = true
+						break
+					}
+				}
+			}
+			// It is possible for a vector index to be the target of both PUT and DEL
+			// operations, in which case two search operators are needed in order to
+			// locate the old index entry, as well as the partition for the new one.
+			//
+			// TODO(drewk): we may be able to avoid the DEL for updates to stored
+			// columns (once they're supported).
+			if op == opt.DeleteOp || indexColIsUpdated {
 				const isIndexPut = false
 				partitionCol := addCol(fmt.Sprintf("vector_index_del_partition%d", idxOrd+1), types.Int)
-				suffixStart := index.PrefixColumnCount() + 1
-				suffixCols := make(opt.ColList, 0, index.KeyColumnCount()-suffixStart)
-				for colOrd := suffixStart; colOrd < index.KeyColumnCount(); colOrd++ {
-					suffixCols = append(suffixCols, mb.fetchColIDs[index.Column(colOrd).Ordinal()])
-				}
 				mb.outScope.expr = mb.buildVectorMutationSearch(
-					mb.outScope.expr, index, delCol, partitionCol, 0 /* encVectorCol */, suffixCols, isIndexPut,
+					mb.outScope.expr, index, partitionCol, 0 /* encVectorCol */, isIndexPut,
 				)
 				mb.vectorIndexDelPartitionColIDs[idxOrd] = partitionCol
 			}
-			if putCol := getPutCol(vectorColOrd); putCol != 0 {
+			if op == opt.InsertOp || op == opt.UpsertOp || indexColIsUpdated {
 				const isIndexPut = true
 				partitionCol := addCol(fmt.Sprintf("vector_index_put_partition%d", idxOrd+1), types.Int)
 				quantizedVecCol := addCol(fmt.Sprintf("vector_index_put_quantized_vec%d", idxOrd+1), types.Bytes)
 				mb.outScope.expr = mb.buildVectorMutationSearch(
-					mb.outScope.expr, index, putCol, partitionCol, quantizedVecCol, nil /* suffixCols */, isIndexPut,
+					mb.outScope.expr, index, partitionCol, quantizedVecCol, isIndexPut,
 				)
 				mb.vectorIndexPutPartitionColIDs[idxOrd] = partitionCol
 				mb.vectorIndexPutQuantizedVecColIDs[idxOrd] = quantizedVecCol
@@ -1143,20 +1121,48 @@ func (mb *mutationBuilder) projectVectorIndexColsImpl(delete bool) {
 // buildVectorMutationSearch builds a VectorMutationSearch operator that will
 // find the partition (and quantized vector, if requested) for vectors in the
 // given queryVectorCol.
-//
-// pkCols should only be set for an index del operation. It is used to locate
-// the partition for a specific row in the table.
 func (mb *mutationBuilder) buildVectorMutationSearch(
-	input memo.RelExpr,
-	index cat.Index,
-	queryVectorCol, partitionCol, quantizedVecCol opt.ColumnID,
-	suffixCols opt.ColList,
-	isIndexPut bool,
+	input memo.RelExpr, index cat.Index, partitionCol, quantizedVecCol opt.ColumnID, isIndexPut bool,
 ) memo.RelExpr {
+	getCol := func(colOrd int) (colID opt.ColumnID) {
+		// Check in turn if the column is being upserted, inserted, updated, or
+		// fetched.
+		if isIndexPut {
+			colID = mb.upsertColIDs[colOrd]
+			if colID == 0 {
+				colID = mb.insertColIDs[colOrd]
+			}
+			if colID == 0 {
+				colID = mb.updateColIDs[colOrd]
+			}
+		}
+		if colID == 0 {
+			colID = mb.fetchColIDs[colOrd]
+		}
+		if colID == 0 {
+			panic(errors.AssertionFailedf("column %d not found", colOrd))
+		}
+		return colID
+	}
+	prefixCols := make(opt.ColList, 0, index.PrefixColumnCount())
+	for colIdx := range index.PrefixColumnCount() {
+		prefixCols = append(prefixCols, getCol(index.Column(colIdx).Ordinal()))
+	}
+	var suffixCols opt.ColList
+	if !isIndexPut {
+		// Index DEL operations must specify the full key to ensure the correct
+		// index entry is deleted.
+		suffixStart := index.PrefixColumnCount() + 1
+		suffixCols = make(opt.ColList, 0, index.KeyColumnCount()-suffixStart)
+		for colIdx := suffixStart; colIdx < index.KeyColumnCount(); colIdx++ {
+			suffixCols = append(suffixCols, getCol(index.Column(colIdx).Ordinal()))
+		}
+	}
 	private := memo.VectorMutationSearchPrivate{
 		Table:              mb.tabID,
 		Index:              index.Ordinal(),
-		QueryVectorCol:     queryVectorCol,
+		PrefixKeyCols:      prefixCols,
+		QueryVectorCol:     getCol(index.VectorColumn().Ordinal()),
 		SuffixKeyCols:      suffixCols,
 		PartitionCol:       partitionCol,
 		QuantizedVectorCol: quantizedVecCol,

--- a/pkg/sql/opt/optbuilder/testdata/vector_mutation
+++ b/pkg/sql/opt/optbuilder/testdata/vector_mutation
@@ -1,239 +1,315 @@
 exec-ddl
-CREATE TABLE t (x INT PRIMARY KEY, v VECTOR(3), w VECTOR(2));
+CREATE TABLE t (x INT PRIMARY KEY, a INT, v VECTOR(3), w VECTOR(2), VECTOR INDEX (v));
 ----
 
 exec-ddl
-CREATE VECTOR INDEX ON t (v);
+CREATE TABLE t_multi (
+  x INT,
+  y INT,
+  a INT,
+  b INT,
+  c INT,
+  v VECTOR (3),
+  PRIMARY KEY (x, y),
+  VECTOR INDEX (a, b, v)
+);
 ----
 
 build
-INSERT INTO t VALUES (1, '[1,2,3]'), (2, '[4,5,6]');
+INSERT INTO t VALUES (1, 1, '[1,2,3]'), (2, 2, '[4,5,6]');
 ----
 insert t
  ├── columns: <none>
  ├── insert-mapping:
- │    ├── column1:6 => x:1
- │    ├── v_cast:8 => v:2
- │    └── w_default:9 => w:3
- ├── vector index put partition columns: vector_index_put_partition1:10
- ├── vector index put quantized vector columns: vector_index_put_quantized_vec1:11
+ │    ├── column1:7 => x:1
+ │    ├── column2:8 => a:2
+ │    ├── v_cast:10 => v:3
+ │    └── w_default:11 => w:4
+ ├── vector index put partition columns: vector_index_put_partition1:12
+ ├── vector index put quantized vector columns: vector_index_put_quantized_vec1:13
  └── vector-mutation-search t@t_v_idx,vector
-      ├── columns: column1:6!null v_cast:8!null w_default:9 vector_index_put_partition1:10 vector_index_put_quantized_vec1:11
+      ├── columns: column1:7!null column2:8!null v_cast:10!null w_default:11 vector_index_put_partition1:12 vector_index_put_quantized_vec1:13
       ├── index put
-      ├── query vector column: v_cast:8
-      ├── partition col: vector_index_put_partition1:10
-      ├── quantized vector col: vector_index_put_quantized_vec1:11
+      ├── query vector column: v_cast:10
+      ├── partition col: vector_index_put_partition1:12
+      ├── quantized vector col: vector_index_put_quantized_vec1:13
       └── project
-           ├── columns: w_default:9 column1:6!null v_cast:8!null
+           ├── columns: w_default:11 column1:7!null column2:8!null v_cast:10!null
            ├── project
-           │    ├── columns: v_cast:8!null column1:6!null
+           │    ├── columns: v_cast:10!null column1:7!null column2:8!null
            │    ├── values
-           │    │    ├── columns: column1:6!null column2:7!null
-           │    │    ├── (1, '[1,2,3]')
-           │    │    └── (2, '[4,5,6]')
+           │    │    ├── columns: column1:7!null column2:8!null column3:9!null
+           │    │    ├── (1, 1, '[1,2,3]')
+           │    │    └── (2, 2, '[4,5,6]')
            │    └── projections
-           │         └── assignment-cast: VECTOR(3) [as=v_cast:8]
-           │              └── column2:7
+           │         └── assignment-cast: VECTOR(3) [as=v_cast:10]
+           │              └── column3:9
            └── projections
-                └── NULL::VECTOR(2) [as=w_default:9]
+                └── NULL::VECTOR(2) [as=w_default:11]
 
 build
 UPDATE t SET v = '[4,5,6]' WHERE x = 1;
 ----
 update t
  ├── columns: <none>
- ├── fetch columns: x:6 v:7 w:8
+ ├── fetch columns: x:7 a:8 v:9 w:10
  ├── update-mapping:
- │    └── v_cast:12 => v:2
- ├── vector index del partition columns: vector_index_del_partition1:13
- ├── vector index put partition columns: vector_index_put_partition1:14
- ├── vector index put quantized vector columns: vector_index_put_quantized_vec1:15
+ │    └── v_cast:14 => v:3
+ ├── vector index del partition columns: vector_index_del_partition1:15
+ ├── vector index put partition columns: vector_index_put_partition1:16
+ ├── vector index put quantized vector columns: vector_index_put_quantized_vec1:17
  └── vector-mutation-search t@t_v_idx,vector
-      ├── columns: x:6!null v:7 w:8 crdb_internal_mvcc_timestamp:9 tableoid:10 v_cast:12!null vector_index_del_partition1:13 vector_index_put_partition1:14 vector_index_put_quantized_vec1:15
+      ├── columns: x:7!null a:8 v:9 w:10 crdb_internal_mvcc_timestamp:11 tableoid:12 v_cast:14!null vector_index_del_partition1:15 vector_index_put_partition1:16 vector_index_put_quantized_vec1:17
       ├── index put
-      ├── query vector column: v_cast:12
-      ├── partition col: vector_index_put_partition1:14
-      ├── quantized vector col: vector_index_put_quantized_vec1:15
+      ├── query vector column: v_cast:14
+      ├── partition col: vector_index_put_partition1:16
+      ├── quantized vector col: vector_index_put_quantized_vec1:17
       └── vector-mutation-search t@t_v_idx,vector
-           ├── columns: x:6!null v:7 w:8 crdb_internal_mvcc_timestamp:9 tableoid:10 v_cast:12!null vector_index_del_partition1:13
+           ├── columns: x:7!null a:8 v:9 w:10 crdb_internal_mvcc_timestamp:11 tableoid:12 v_cast:14!null vector_index_del_partition1:15
            ├── index del
-           ├── query vector column: v:7
-           ├── suffix key columns: [6]
-           ├── partition col: vector_index_del_partition1:13
+           ├── query vector column: v:9
+           ├── suffix key columns: [7]
+           ├── partition col: vector_index_del_partition1:15
            └── project
-                ├── columns: v_cast:12!null x:6!null v:7 w:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+                ├── columns: v_cast:14!null x:7!null a:8 v:9 w:10 crdb_internal_mvcc_timestamp:11 tableoid:12
                 ├── project
-                │    ├── columns: v_new:11!null x:6!null v:7 w:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+                │    ├── columns: v_new:13!null x:7!null a:8 v:9 w:10 crdb_internal_mvcc_timestamp:11 tableoid:12
                 │    ├── select
-                │    │    ├── columns: x:6!null v:7 w:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+                │    │    ├── columns: x:7!null a:8 v:9 w:10 crdb_internal_mvcc_timestamp:11 tableoid:12
                 │    │    ├── scan t
-                │    │    │    ├── columns: x:6!null v:7 w:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+                │    │    │    ├── columns: x:7!null a:8 v:9 w:10 crdb_internal_mvcc_timestamp:11 tableoid:12
                 │    │    │    └── flags: avoid-full-scan
                 │    │    └── filters
-                │    │         └── x:6 = 1
+                │    │         └── x:7 = 1
                 │    └── projections
-                │         └── '[4,5,6]' [as=v_new:11]
+                │         └── '[4,5,6]' [as=v_new:13]
                 └── projections
-                     └── assignment-cast: VECTOR(3) [as=v_cast:12]
-                          └── v_new:11
+                     └── assignment-cast: VECTOR(3) [as=v_cast:14]
+                          └── v_new:13
+
+# Index entries must be updated if *any* column from the index is modified, not
+# just the vector column.
+build
+UPDATE t SET x = 3 WHERE x = 1;
+----
+update t
+ ├── columns: <none>
+ ├── fetch columns: x:7 a:8 v:9 w:10
+ ├── update-mapping:
+ │    └── x_new:13 => x:1
+ ├── vector index del partition columns: vector_index_del_partition1:14
+ ├── vector index put partition columns: vector_index_put_partition1:15
+ ├── vector index put quantized vector columns: vector_index_put_quantized_vec1:16
+ └── vector-mutation-search t@t_v_idx,vector
+      ├── columns: x:7!null a:8 v:9 w:10 crdb_internal_mvcc_timestamp:11 tableoid:12 x_new:13!null vector_index_del_partition1:14 vector_index_put_partition1:15 vector_index_put_quantized_vec1:16
+      ├── index put
+      ├── query vector column: v:9
+      ├── partition col: vector_index_put_partition1:15
+      ├── quantized vector col: vector_index_put_quantized_vec1:16
+      └── vector-mutation-search t@t_v_idx,vector
+           ├── columns: x:7!null a:8 v:9 w:10 crdb_internal_mvcc_timestamp:11 tableoid:12 x_new:13!null vector_index_del_partition1:14
+           ├── index del
+           ├── query vector column: v:9
+           ├── suffix key columns: [7]
+           ├── partition col: vector_index_del_partition1:14
+           └── project
+                ├── columns: x_new:13!null x:7!null a:8 v:9 w:10 crdb_internal_mvcc_timestamp:11 tableoid:12
+                ├── select
+                │    ├── columns: x:7!null a:8 v:9 w:10 crdb_internal_mvcc_timestamp:11 tableoid:12
+                │    ├── scan t
+                │    │    ├── columns: x:7!null a:8 v:9 w:10 crdb_internal_mvcc_timestamp:11 tableoid:12
+                │    │    └── flags: avoid-full-scan
+                │    └── filters
+                │         └── x:7 = 1
+                └── projections
+                     └── 3 [as=x_new:13]
+
+# Case with a non-indexed column modified.
+build
+UPDATE t SET a = 1 WHERE x = 3;
+----
+update t
+ ├── columns: <none>
+ ├── fetch columns: x:7 a:8 v:9 w:10
+ ├── update-mapping:
+ │    └── a_new:13 => a:2
+ └── project
+      ├── columns: a_new:13!null x:7!null a:8 v:9 w:10 crdb_internal_mvcc_timestamp:11 tableoid:12
+      ├── select
+      │    ├── columns: x:7!null a:8 v:9 w:10 crdb_internal_mvcc_timestamp:11 tableoid:12
+      │    ├── scan t
+      │    │    ├── columns: x:7!null a:8 v:9 w:10 crdb_internal_mvcc_timestamp:11 tableoid:12
+      │    │    └── flags: avoid-full-scan
+      │    └── filters
+      │         └── x:7 = 3
+      └── projections
+           └── 1 [as=a_new:13]
 
 build
 DELETE FROM t WHERE x = 1;
 ----
 delete t
  ├── columns: <none>
- ├── fetch columns: x:6 v:7 w:8
- ├── vector index del partition columns: vector_index_del_partition1:11
+ ├── fetch columns: x:7 a:8 v:9 w:10
+ ├── vector index del partition columns: vector_index_del_partition1:13
  └── vector-mutation-search t@t_v_idx,vector
-      ├── columns: x:6!null v:7 w:8 crdb_internal_mvcc_timestamp:9 tableoid:10 vector_index_del_partition1:11
+      ├── columns: x:7!null a:8 v:9 w:10 crdb_internal_mvcc_timestamp:11 tableoid:12 vector_index_del_partition1:13
       ├── index del
-      ├── query vector column: v:7
-      ├── suffix key columns: [6]
-      ├── partition col: vector_index_del_partition1:11
+      ├── query vector column: v:9
+      ├── suffix key columns: [7]
+      ├── partition col: vector_index_del_partition1:13
       └── select
-           ├── columns: x:6!null v:7 w:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+           ├── columns: x:7!null a:8 v:9 w:10 crdb_internal_mvcc_timestamp:11 tableoid:12
            ├── scan t
-           │    ├── columns: x:6!null v:7 w:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+           │    ├── columns: x:7!null a:8 v:9 w:10 crdb_internal_mvcc_timestamp:11 tableoid:12
            │    └── flags: avoid-full-scan
            └── filters
-                └── x:6 = 1
+                └── x:7 = 1
 
 build
-UPSERT INTO t VALUES (1, '[1,2,3]'), (2, '[4,5,6]');
+UPSERT INTO t VALUES (1, 1, '[1,2,3]'), (2, 2, '[4,5,6]');
 ----
 upsert t
  ├── arbiter indexes: t_pkey
  ├── columns: <none>
- ├── canary column: x:10
- ├── fetch columns: x:10 v:11 w:12
+ ├── canary column: x:12
+ ├── fetch columns: x:12 a:13 v:14 w:15
  ├── insert-mapping:
- │    ├── column1:6 => x:1
- │    ├── v_cast:8 => v:2
- │    └── w_default:9 => w:3
+ │    ├── column1:7 => x:1
+ │    ├── column2:8 => a:2
+ │    ├── v_cast:10 => v:3
+ │    └── w_default:11 => w:4
  ├── update-mapping:
- │    ├── v_cast:8 => v:2
- │    └── w_default:9 => w:3
- ├── vector index del partition columns: vector_index_del_partition1:16
- ├── vector index put partition columns: vector_index_put_partition1:17
- ├── vector index put quantized vector columns: vector_index_put_quantized_vec1:18
+ │    ├── column2:8 => a:2
+ │    ├── v_cast:10 => v:3
+ │    └── w_default:11 => w:4
+ ├── vector index del partition columns: vector_index_del_partition1:19
+ ├── vector index put partition columns: vector_index_put_partition1:20
+ ├── vector index put quantized vector columns: vector_index_put_quantized_vec1:21
  └── vector-mutation-search t@t_v_idx,vector
-      ├── columns: column1:6!null v_cast:8!null w_default:9 x:10 v:11 w:12 crdb_internal_mvcc_timestamp:13 tableoid:14 upsert_x:15 vector_index_del_partition1:16 vector_index_put_partition1:17 vector_index_put_quantized_vec1:18
+      ├── columns: column1:7!null column2:8!null v_cast:10!null w_default:11 x:12 a:13 v:14 w:15 crdb_internal_mvcc_timestamp:16 tableoid:17 upsert_x:18 vector_index_del_partition1:19 vector_index_put_partition1:20 vector_index_put_quantized_vec1:21
       ├── index put
-      ├── query vector column: v_cast:8
-      ├── partition col: vector_index_put_partition1:17
-      ├── quantized vector col: vector_index_put_quantized_vec1:18
+      ├── query vector column: v_cast:10
+      ├── partition col: vector_index_put_partition1:20
+      ├── quantized vector col: vector_index_put_quantized_vec1:21
       └── vector-mutation-search t@t_v_idx,vector
-           ├── columns: column1:6!null v_cast:8!null w_default:9 x:10 v:11 w:12 crdb_internal_mvcc_timestamp:13 tableoid:14 upsert_x:15 vector_index_del_partition1:16
+           ├── columns: column1:7!null column2:8!null v_cast:10!null w_default:11 x:12 a:13 v:14 w:15 crdb_internal_mvcc_timestamp:16 tableoid:17 upsert_x:18 vector_index_del_partition1:19
            ├── index del
-           ├── query vector column: v:11
-           ├── suffix key columns: [10]
-           ├── partition col: vector_index_del_partition1:16
+           ├── query vector column: v:14
+           ├── suffix key columns: [12]
+           ├── partition col: vector_index_del_partition1:19
            └── project
-                ├── columns: upsert_x:15 column1:6!null v_cast:8!null w_default:9 x:10 v:11 w:12 crdb_internal_mvcc_timestamp:13 tableoid:14
+                ├── columns: upsert_x:18 column1:7!null column2:8!null v_cast:10!null w_default:11 x:12 a:13 v:14 w:15 crdb_internal_mvcc_timestamp:16 tableoid:17
                 ├── left-join (hash)
-                │    ├── columns: column1:6!null v_cast:8!null w_default:9 x:10 v:11 w:12 crdb_internal_mvcc_timestamp:13 tableoid:14
+                │    ├── columns: column1:7!null column2:8!null v_cast:10!null w_default:11 x:12 a:13 v:14 w:15 crdb_internal_mvcc_timestamp:16 tableoid:17
                 │    ├── ensure-upsert-distinct-on
-                │    │    ├── columns: column1:6!null v_cast:8!null w_default:9
-                │    │    ├── grouping columns: column1:6!null
+                │    │    ├── columns: column1:7!null column2:8!null v_cast:10!null w_default:11
+                │    │    ├── grouping columns: column1:7!null
                 │    │    ├── project
-                │    │    │    ├── columns: w_default:9 column1:6!null v_cast:8!null
+                │    │    │    ├── columns: w_default:11 column1:7!null column2:8!null v_cast:10!null
                 │    │    │    ├── project
-                │    │    │    │    ├── columns: v_cast:8!null column1:6!null
+                │    │    │    │    ├── columns: v_cast:10!null column1:7!null column2:8!null
                 │    │    │    │    ├── values
-                │    │    │    │    │    ├── columns: column1:6!null column2:7!null
-                │    │    │    │    │    ├── (1, '[1,2,3]')
-                │    │    │    │    │    └── (2, '[4,5,6]')
+                │    │    │    │    │    ├── columns: column1:7!null column2:8!null column3:9!null
+                │    │    │    │    │    ├── (1, 1, '[1,2,3]')
+                │    │    │    │    │    └── (2, 2, '[4,5,6]')
                 │    │    │    │    └── projections
-                │    │    │    │         └── assignment-cast: VECTOR(3) [as=v_cast:8]
-                │    │    │    │              └── column2:7
+                │    │    │    │         └── assignment-cast: VECTOR(3) [as=v_cast:10]
+                │    │    │    │              └── column3:9
                 │    │    │    └── projections
-                │    │    │         └── NULL::VECTOR(2) [as=w_default:9]
+                │    │    │         └── NULL::VECTOR(2) [as=w_default:11]
                 │    │    └── aggregations
-                │    │         ├── first-agg [as=v_cast:8]
-                │    │         │    └── v_cast:8
-                │    │         └── first-agg [as=w_default:9]
-                │    │              └── w_default:9
+                │    │         ├── first-agg [as=column2:8]
+                │    │         │    └── column2:8
+                │    │         ├── first-agg [as=v_cast:10]
+                │    │         │    └── v_cast:10
+                │    │         └── first-agg [as=w_default:11]
+                │    │              └── w_default:11
                 │    ├── scan t
-                │    │    ├── columns: x:10!null v:11 w:12 crdb_internal_mvcc_timestamp:13 tableoid:14
+                │    │    ├── columns: x:12!null a:13 v:14 w:15 crdb_internal_mvcc_timestamp:16 tableoid:17
                 │    │    └── flags: avoid-full-scan disabled not visible index feature
                 │    └── filters
-                │         └── column1:6 = x:10
+                │         └── column1:7 = x:12
                 └── projections
-                     └── CASE WHEN x:10 IS NULL THEN column1:6 ELSE x:10 END [as=upsert_x:15]
+                     └── CASE WHEN x:12 IS NULL THEN column1:7 ELSE x:12 END [as=upsert_x:18]
 
 build
-INSERT INTO t VALUES (1, '[1,2,3]'), (2, '[4,5,6]')
+INSERT INTO t VALUES (1, 1, '[1,2,3]'), (2, 2, '[4,5,6]')
 ON CONFLICT (x) DO UPDATE SET v = '[-4,-5,-6]';
 ----
 upsert t
  ├── arbiter indexes: t_pkey
  ├── columns: <none>
- ├── canary column: x:10
- ├── fetch columns: x:10 v:11 w:12
+ ├── canary column: x:12
+ ├── fetch columns: x:12 a:13 v:14 w:15
  ├── insert-mapping:
- │    ├── column1:6 => x:1
- │    ├── v_cast:8 => v:2
- │    └── w_default:9 => w:3
+ │    ├── column1:7 => x:1
+ │    ├── column2:8 => a:2
+ │    ├── v_cast:10 => v:3
+ │    └── w_default:11 => w:4
  ├── update-mapping:
- │    └── upsert_v:18 => v:2
- ├── vector index del partition columns: vector_index_del_partition1:20
- ├── vector index put partition columns: vector_index_put_partition1:21
- ├── vector index put quantized vector columns: vector_index_put_quantized_vec1:22
+ │    └── upsert_v:22 => v:3
+ ├── vector index del partition columns: vector_index_del_partition1:24
+ ├── vector index put partition columns: vector_index_put_partition1:25
+ ├── vector index put quantized vector columns: vector_index_put_quantized_vec1:26
  └── vector-mutation-search t@t_v_idx,vector
-      ├── columns: column1:6!null v_cast:8!null w_default:9 x:10 v:11 w:12 crdb_internal_mvcc_timestamp:13 tableoid:14 v_cast:16!null upsert_x:17 upsert_v:18!null upsert_w:19 vector_index_del_partition1:20 vector_index_put_partition1:21 vector_index_put_quantized_vec1:22
+      ├── columns: column1:7!null column2:8!null v_cast:10!null w_default:11 x:12 a:13 v:14 w:15 crdb_internal_mvcc_timestamp:16 tableoid:17 v_cast:19!null upsert_x:20 upsert_a:21 upsert_v:22!null upsert_w:23 vector_index_del_partition1:24 vector_index_put_partition1:25 vector_index_put_quantized_vec1:26
       ├── index put
-      ├── query vector column: upsert_v:18
-      ├── partition col: vector_index_put_partition1:21
-      ├── quantized vector col: vector_index_put_quantized_vec1:22
+      ├── query vector column: upsert_v:22
+      ├── partition col: vector_index_put_partition1:25
+      ├── quantized vector col: vector_index_put_quantized_vec1:26
       └── vector-mutation-search t@t_v_idx,vector
-           ├── columns: column1:6!null v_cast:8!null w_default:9 x:10 v:11 w:12 crdb_internal_mvcc_timestamp:13 tableoid:14 v_cast:16!null upsert_x:17 upsert_v:18!null upsert_w:19 vector_index_del_partition1:20
+           ├── columns: column1:7!null column2:8!null v_cast:10!null w_default:11 x:12 a:13 v:14 w:15 crdb_internal_mvcc_timestamp:16 tableoid:17 v_cast:19!null upsert_x:20 upsert_a:21 upsert_v:22!null upsert_w:23 vector_index_del_partition1:24
            ├── index del
-           ├── query vector column: v:11
-           ├── suffix key columns: [10]
-           ├── partition col: vector_index_del_partition1:20
+           ├── query vector column: v:14
+           ├── suffix key columns: [12]
+           ├── partition col: vector_index_del_partition1:24
            └── project
-                ├── columns: upsert_x:17 upsert_v:18!null upsert_w:19 column1:6!null v_cast:8!null w_default:9 x:10 v:11 w:12 crdb_internal_mvcc_timestamp:13 tableoid:14 v_cast:16!null
+                ├── columns: upsert_x:20 upsert_a:21 upsert_v:22!null upsert_w:23 column1:7!null column2:8!null v_cast:10!null w_default:11 x:12 a:13 v:14 w:15 crdb_internal_mvcc_timestamp:16 tableoid:17 v_cast:19!null
                 ├── project
-                │    ├── columns: v_cast:16!null column1:6!null v_cast:8!null w_default:9 x:10 v:11 w:12 crdb_internal_mvcc_timestamp:13 tableoid:14
+                │    ├── columns: v_cast:19!null column1:7!null column2:8!null v_cast:10!null w_default:11 x:12 a:13 v:14 w:15 crdb_internal_mvcc_timestamp:16 tableoid:17
                 │    ├── project
-                │    │    ├── columns: v_new:15!null column1:6!null v_cast:8!null w_default:9 x:10 v:11 w:12 crdb_internal_mvcc_timestamp:13 tableoid:14
+                │    │    ├── columns: v_new:18!null column1:7!null column2:8!null v_cast:10!null w_default:11 x:12 a:13 v:14 w:15 crdb_internal_mvcc_timestamp:16 tableoid:17
                 │    │    ├── left-join (hash)
-                │    │    │    ├── columns: column1:6!null v_cast:8!null w_default:9 x:10 v:11 w:12 crdb_internal_mvcc_timestamp:13 tableoid:14
+                │    │    │    ├── columns: column1:7!null column2:8!null v_cast:10!null w_default:11 x:12 a:13 v:14 w:15 crdb_internal_mvcc_timestamp:16 tableoid:17
                 │    │    │    ├── ensure-upsert-distinct-on
-                │    │    │    │    ├── columns: column1:6!null v_cast:8!null w_default:9
-                │    │    │    │    ├── grouping columns: column1:6!null
+                │    │    │    │    ├── columns: column1:7!null column2:8!null v_cast:10!null w_default:11
+                │    │    │    │    ├── grouping columns: column1:7!null
                 │    │    │    │    ├── project
-                │    │    │    │    │    ├── columns: w_default:9 column1:6!null v_cast:8!null
+                │    │    │    │    │    ├── columns: w_default:11 column1:7!null column2:8!null v_cast:10!null
                 │    │    │    │    │    ├── project
-                │    │    │    │    │    │    ├── columns: v_cast:8!null column1:6!null
+                │    │    │    │    │    │    ├── columns: v_cast:10!null column1:7!null column2:8!null
                 │    │    │    │    │    │    ├── values
-                │    │    │    │    │    │    │    ├── columns: column1:6!null column2:7!null
-                │    │    │    │    │    │    │    ├── (1, '[1,2,3]')
-                │    │    │    │    │    │    │    └── (2, '[4,5,6]')
+                │    │    │    │    │    │    │    ├── columns: column1:7!null column2:8!null column3:9!null
+                │    │    │    │    │    │    │    ├── (1, 1, '[1,2,3]')
+                │    │    │    │    │    │    │    └── (2, 2, '[4,5,6]')
                 │    │    │    │    │    │    └── projections
-                │    │    │    │    │    │         └── assignment-cast: VECTOR(3) [as=v_cast:8]
-                │    │    │    │    │    │              └── column2:7
+                │    │    │    │    │    │         └── assignment-cast: VECTOR(3) [as=v_cast:10]
+                │    │    │    │    │    │              └── column3:9
                 │    │    │    │    │    └── projections
-                │    │    │    │    │         └── NULL::VECTOR(2) [as=w_default:9]
+                │    │    │    │    │         └── NULL::VECTOR(2) [as=w_default:11]
                 │    │    │    │    └── aggregations
-                │    │    │    │         ├── first-agg [as=v_cast:8]
-                │    │    │    │         │    └── v_cast:8
-                │    │    │    │         └── first-agg [as=w_default:9]
-                │    │    │    │              └── w_default:9
+                │    │    │    │         ├── first-agg [as=column2:8]
+                │    │    │    │         │    └── column2:8
+                │    │    │    │         ├── first-agg [as=v_cast:10]
+                │    │    │    │         │    └── v_cast:10
+                │    │    │    │         └── first-agg [as=w_default:11]
+                │    │    │    │              └── w_default:11
                 │    │    │    ├── scan t
-                │    │    │    │    ├── columns: x:10!null v:11 w:12 crdb_internal_mvcc_timestamp:13 tableoid:14
+                │    │    │    │    ├── columns: x:12!null a:13 v:14 w:15 crdb_internal_mvcc_timestamp:16 tableoid:17
                 │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
                 │    │    │    └── filters
-                │    │    │         └── column1:6 = x:10
+                │    │    │         └── column1:7 = x:12
                 │    │    └── projections
-                │    │         └── '[-4,-5,-6]' [as=v_new:15]
+                │    │         └── '[-4,-5,-6]' [as=v_new:18]
                 │    └── projections
-                │         └── assignment-cast: VECTOR(3) [as=v_cast:16]
-                │              └── v_new:15
+                │         └── assignment-cast: VECTOR(3) [as=v_cast:19]
+                │              └── v_new:18
                 └── projections
-                     ├── CASE WHEN x:10 IS NULL THEN column1:6 ELSE x:10 END [as=upsert_x:17]
-                     ├── CASE WHEN x:10 IS NULL THEN v_cast:8 ELSE v_cast:16 END [as=upsert_v:18]
-                     └── CASE WHEN x:10 IS NULL THEN w_default:9 ELSE w:12 END [as=upsert_w:19]
+                     ├── CASE WHEN x:12 IS NULL THEN column1:7 ELSE x:12 END [as=upsert_x:20]
+                     ├── CASE WHEN x:12 IS NULL THEN column2:8 ELSE a:13 END [as=upsert_a:21]
+                     ├── CASE WHEN x:12 IS NULL THEN v_cast:10 ELSE v_cast:19 END [as=upsert_v:22]
+                     └── CASE WHEN x:12 IS NULL THEN w_default:11 ELSE w:15 END [as=upsert_w:23]
 
 # Create another vector index, verify that mutations correctly update both
 # indexes.
@@ -242,344 +318,566 @@ CREATE VECTOR INDEX ON t (w);
 ----
 
 build
-INSERT INTO t VALUES (1, '[1,2,3]', '[10, 20]'), (2, '[4,5,6]', '[30, 40]');
+INSERT INTO t VALUES (1, 1, '[1,2,3]', '[10, 20]'), (2, 2, '[4,5,6]', '[30, 40]');
 ----
 insert t
  ├── columns: <none>
  ├── insert-mapping:
- │    ├── column1:6 => x:1
- │    ├── v_cast:9 => v:2
- │    └── w_cast:10 => w:3
- ├── vector index put partition columns: vector_index_put_partition1:11 vector_index_put_partition2:13
- ├── vector index put quantized vector columns: vector_index_put_quantized_vec1:12 vector_index_put_quantized_vec2:14
+ │    ├── column1:7 => x:1
+ │    ├── column2:8 => a:2
+ │    ├── v_cast:11 => v:3
+ │    └── w_cast:12 => w:4
+ ├── vector index put partition columns: vector_index_put_partition1:13 vector_index_put_partition2:15
+ ├── vector index put quantized vector columns: vector_index_put_quantized_vec1:14 vector_index_put_quantized_vec2:16
  └── vector-mutation-search t@t_w_idx,vector
-      ├── columns: column1:6!null v_cast:9!null w_cast:10!null vector_index_put_partition1:11 vector_index_put_quantized_vec1:12 vector_index_put_partition2:13 vector_index_put_quantized_vec2:14
+      ├── columns: column1:7!null column2:8!null v_cast:11!null w_cast:12!null vector_index_put_partition1:13 vector_index_put_quantized_vec1:14 vector_index_put_partition2:15 vector_index_put_quantized_vec2:16
       ├── index put
-      ├── query vector column: w_cast:10
-      ├── partition col: vector_index_put_partition2:13
-      ├── quantized vector col: vector_index_put_quantized_vec2:14
+      ├── query vector column: w_cast:12
+      ├── partition col: vector_index_put_partition2:15
+      ├── quantized vector col: vector_index_put_quantized_vec2:16
       └── vector-mutation-search t@t_v_idx,vector
-           ├── columns: column1:6!null v_cast:9!null w_cast:10!null vector_index_put_partition1:11 vector_index_put_quantized_vec1:12
+           ├── columns: column1:7!null column2:8!null v_cast:11!null w_cast:12!null vector_index_put_partition1:13 vector_index_put_quantized_vec1:14
            ├── index put
-           ├── query vector column: v_cast:9
-           ├── partition col: vector_index_put_partition1:11
-           ├── quantized vector col: vector_index_put_quantized_vec1:12
+           ├── query vector column: v_cast:11
+           ├── partition col: vector_index_put_partition1:13
+           ├── quantized vector col: vector_index_put_quantized_vec1:14
            └── project
-                ├── columns: v_cast:9!null w_cast:10!null column1:6!null
+                ├── columns: v_cast:11!null w_cast:12!null column1:7!null column2:8!null
                 ├── values
-                │    ├── columns: column1:6!null column2:7!null column3:8!null
-                │    ├── (1, '[1,2,3]', '[10,20]')
-                │    └── (2, '[4,5,6]', '[30,40]')
+                │    ├── columns: column1:7!null column2:8!null column3:9!null column4:10!null
+                │    ├── (1, 1, '[1,2,3]', '[10,20]')
+                │    └── (2, 2, '[4,5,6]', '[30,40]')
                 └── projections
-                     ├── assignment-cast: VECTOR(3) [as=v_cast:9]
-                     │    └── column2:7
-                     └── assignment-cast: VECTOR(2) [as=w_cast:10]
-                          └── column3:8
+                     ├── assignment-cast: VECTOR(3) [as=v_cast:11]
+                     │    └── column3:9
+                     └── assignment-cast: VECTOR(2) [as=w_cast:12]
+                          └── column4:10
 
 build
 UPDATE t SET v = '[4,5,6]', w = '[20, 40]' WHERE x = 1;
 ----
 update t
  ├── columns: <none>
- ├── fetch columns: x:6 v:7 w:8
+ ├── fetch columns: x:7 a:8 v:9 w:10
  ├── update-mapping:
- │    ├── v_cast:13 => v:2
- │    └── w_cast:14 => w:3
- ├── vector index del partition columns: vector_index_del_partition1:15 vector_index_del_partition2:18
- ├── vector index put partition columns: vector_index_put_partition1:16 vector_index_put_partition2:19
- ├── vector index put quantized vector columns: vector_index_put_quantized_vec1:17 vector_index_put_quantized_vec2:20
+ │    ├── v_cast:15 => v:3
+ │    └── w_cast:16 => w:4
+ ├── vector index del partition columns: vector_index_del_partition1:17 vector_index_del_partition2:20
+ ├── vector index put partition columns: vector_index_put_partition1:18 vector_index_put_partition2:21
+ ├── vector index put quantized vector columns: vector_index_put_quantized_vec1:19 vector_index_put_quantized_vec2:22
  └── vector-mutation-search t@t_w_idx,vector
-      ├── columns: x:6!null v:7 w:8 crdb_internal_mvcc_timestamp:9 tableoid:10 v_cast:13!null w_cast:14!null vector_index_del_partition1:15 vector_index_put_partition1:16 vector_index_put_quantized_vec1:17 vector_index_del_partition2:18 vector_index_put_partition2:19 vector_index_put_quantized_vec2:20
+      ├── columns: x:7!null a:8 v:9 w:10 crdb_internal_mvcc_timestamp:11 tableoid:12 v_cast:15!null w_cast:16!null vector_index_del_partition1:17 vector_index_put_partition1:18 vector_index_put_quantized_vec1:19 vector_index_del_partition2:20 vector_index_put_partition2:21 vector_index_put_quantized_vec2:22
       ├── index put
-      ├── query vector column: w_cast:14
-      ├── partition col: vector_index_put_partition2:19
-      ├── quantized vector col: vector_index_put_quantized_vec2:20
+      ├── query vector column: w_cast:16
+      ├── partition col: vector_index_put_partition2:21
+      ├── quantized vector col: vector_index_put_quantized_vec2:22
       └── vector-mutation-search t@t_w_idx,vector
-           ├── columns: x:6!null v:7 w:8 crdb_internal_mvcc_timestamp:9 tableoid:10 v_cast:13!null w_cast:14!null vector_index_del_partition1:15 vector_index_put_partition1:16 vector_index_put_quantized_vec1:17 vector_index_del_partition2:18
+           ├── columns: x:7!null a:8 v:9 w:10 crdb_internal_mvcc_timestamp:11 tableoid:12 v_cast:15!null w_cast:16!null vector_index_del_partition1:17 vector_index_put_partition1:18 vector_index_put_quantized_vec1:19 vector_index_del_partition2:20
            ├── index del
-           ├── query vector column: w:8
-           ├── suffix key columns: [6]
-           ├── partition col: vector_index_del_partition2:18
+           ├── query vector column: w:10
+           ├── suffix key columns: [7]
+           ├── partition col: vector_index_del_partition2:20
            └── vector-mutation-search t@t_v_idx,vector
-                ├── columns: x:6!null v:7 w:8 crdb_internal_mvcc_timestamp:9 tableoid:10 v_cast:13!null w_cast:14!null vector_index_del_partition1:15 vector_index_put_partition1:16 vector_index_put_quantized_vec1:17
+                ├── columns: x:7!null a:8 v:9 w:10 crdb_internal_mvcc_timestamp:11 tableoid:12 v_cast:15!null w_cast:16!null vector_index_del_partition1:17 vector_index_put_partition1:18 vector_index_put_quantized_vec1:19
                 ├── index put
-                ├── query vector column: v_cast:13
-                ├── partition col: vector_index_put_partition1:16
-                ├── quantized vector col: vector_index_put_quantized_vec1:17
+                ├── query vector column: v_cast:15
+                ├── partition col: vector_index_put_partition1:18
+                ├── quantized vector col: vector_index_put_quantized_vec1:19
                 └── vector-mutation-search t@t_v_idx,vector
-                     ├── columns: x:6!null v:7 w:8 crdb_internal_mvcc_timestamp:9 tableoid:10 v_cast:13!null w_cast:14!null vector_index_del_partition1:15
+                     ├── columns: x:7!null a:8 v:9 w:10 crdb_internal_mvcc_timestamp:11 tableoid:12 v_cast:15!null w_cast:16!null vector_index_del_partition1:17
                      ├── index del
-                     ├── query vector column: v:7
-                     ├── suffix key columns: [6]
-                     ├── partition col: vector_index_del_partition1:15
+                     ├── query vector column: v:9
+                     ├── suffix key columns: [7]
+                     ├── partition col: vector_index_del_partition1:17
                      └── project
-                          ├── columns: v_cast:13!null w_cast:14!null x:6!null v:7 w:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+                          ├── columns: v_cast:15!null w_cast:16!null x:7!null a:8 v:9 w:10 crdb_internal_mvcc_timestamp:11 tableoid:12
                           ├── project
-                          │    ├── columns: v_new:11!null w_new:12!null x:6!null v:7 w:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+                          │    ├── columns: v_new:13!null w_new:14!null x:7!null a:8 v:9 w:10 crdb_internal_mvcc_timestamp:11 tableoid:12
                           │    ├── select
-                          │    │    ├── columns: x:6!null v:7 w:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+                          │    │    ├── columns: x:7!null a:8 v:9 w:10 crdb_internal_mvcc_timestamp:11 tableoid:12
                           │    │    ├── scan t
-                          │    │    │    ├── columns: x:6!null v:7 w:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+                          │    │    │    ├── columns: x:7!null a:8 v:9 w:10 crdb_internal_mvcc_timestamp:11 tableoid:12
                           │    │    │    └── flags: avoid-full-scan
                           │    │    └── filters
-                          │    │         └── x:6 = 1
+                          │    │         └── x:7 = 1
                           │    └── projections
-                          │         ├── '[4,5,6]' [as=v_new:11]
-                          │         └── '[20,40]' [as=w_new:12]
+                          │         ├── '[4,5,6]' [as=v_new:13]
+                          │         └── '[20,40]' [as=w_new:14]
                           └── projections
-                               ├── assignment-cast: VECTOR(3) [as=v_cast:13]
-                               │    └── v_new:11
-                               └── assignment-cast: VECTOR(2) [as=w_cast:14]
-                                    └── w_new:12
+                               ├── assignment-cast: VECTOR(3) [as=v_cast:15]
+                               │    └── v_new:13
+                               └── assignment-cast: VECTOR(2) [as=w_cast:16]
+                                    └── w_new:14
 
 build
 DELETE FROM t WHERE x = 1;
 ----
 delete t
  ├── columns: <none>
- ├── fetch columns: x:6 v:7 w:8
- ├── vector index del partition columns: vector_index_del_partition1:11 vector_index_del_partition2:12
+ ├── fetch columns: x:7 a:8 v:9 w:10
+ ├── vector index del partition columns: vector_index_del_partition1:13 vector_index_del_partition2:14
  └── vector-mutation-search t@t_w_idx,vector
-      ├── columns: x:6!null v:7 w:8 crdb_internal_mvcc_timestamp:9 tableoid:10 vector_index_del_partition1:11 vector_index_del_partition2:12
+      ├── columns: x:7!null a:8 v:9 w:10 crdb_internal_mvcc_timestamp:11 tableoid:12 vector_index_del_partition1:13 vector_index_del_partition2:14
       ├── index del
-      ├── query vector column: w:8
-      ├── suffix key columns: [6]
-      ├── partition col: vector_index_del_partition2:12
+      ├── query vector column: w:10
+      ├── suffix key columns: [7]
+      ├── partition col: vector_index_del_partition2:14
       └── vector-mutation-search t@t_v_idx,vector
-           ├── columns: x:6!null v:7 w:8 crdb_internal_mvcc_timestamp:9 tableoid:10 vector_index_del_partition1:11
+           ├── columns: x:7!null a:8 v:9 w:10 crdb_internal_mvcc_timestamp:11 tableoid:12 vector_index_del_partition1:13
            ├── index del
-           ├── query vector column: v:7
-           ├── suffix key columns: [6]
-           ├── partition col: vector_index_del_partition1:11
+           ├── query vector column: v:9
+           ├── suffix key columns: [7]
+           ├── partition col: vector_index_del_partition1:13
            └── select
-                ├── columns: x:6!null v:7 w:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+                ├── columns: x:7!null a:8 v:9 w:10 crdb_internal_mvcc_timestamp:11 tableoid:12
                 ├── scan t
-                │    ├── columns: x:6!null v:7 w:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+                │    ├── columns: x:7!null a:8 v:9 w:10 crdb_internal_mvcc_timestamp:11 tableoid:12
                 │    └── flags: avoid-full-scan
                 └── filters
-                     └── x:6 = 1
+                     └── x:7 = 1
 
 build
-UPSERT INTO t VALUES (1, '[1,2,3]', '[10, 20]'), (2, '[4,5,6]', '[30, 40]');;
+UPSERT INTO t VALUES (1, 1, '[1,2,3]', '[10, 20]'), (2, 2, '[4,5,6]', '[30, 40]');;
 ----
 upsert t
  ├── arbiter indexes: t_pkey
  ├── columns: <none>
- ├── canary column: x:11
- ├── fetch columns: x:11 v:12 w:13
+ ├── canary column: x:13
+ ├── fetch columns: x:13 a:14 v:15 w:16
  ├── insert-mapping:
- │    ├── column1:6 => x:1
- │    ├── v_cast:9 => v:2
- │    └── w_cast:10 => w:3
+ │    ├── column1:7 => x:1
+ │    ├── column2:8 => a:2
+ │    ├── v_cast:11 => v:3
+ │    └── w_cast:12 => w:4
  ├── update-mapping:
- │    ├── v_cast:9 => v:2
- │    └── w_cast:10 => w:3
- ├── vector index del partition columns: vector_index_del_partition1:17 vector_index_del_partition2:20
- ├── vector index put partition columns: vector_index_put_partition1:18 vector_index_put_partition2:21
- ├── vector index put quantized vector columns: vector_index_put_quantized_vec1:19 vector_index_put_quantized_vec2:22
+ │    ├── column2:8 => a:2
+ │    ├── v_cast:11 => v:3
+ │    └── w_cast:12 => w:4
+ ├── vector index del partition columns: vector_index_del_partition1:20 vector_index_del_partition2:23
+ ├── vector index put partition columns: vector_index_put_partition1:21 vector_index_put_partition2:24
+ ├── vector index put quantized vector columns: vector_index_put_quantized_vec1:22 vector_index_put_quantized_vec2:25
  └── vector-mutation-search t@t_w_idx,vector
-      ├── columns: column1:6!null v_cast:9!null w_cast:10!null x:11 v:12 w:13 crdb_internal_mvcc_timestamp:14 tableoid:15 upsert_x:16 vector_index_del_partition1:17 vector_index_put_partition1:18 vector_index_put_quantized_vec1:19 vector_index_del_partition2:20 vector_index_put_partition2:21 vector_index_put_quantized_vec2:22
+      ├── columns: column1:7!null column2:8!null v_cast:11!null w_cast:12!null x:13 a:14 v:15 w:16 crdb_internal_mvcc_timestamp:17 tableoid:18 upsert_x:19 vector_index_del_partition1:20 vector_index_put_partition1:21 vector_index_put_quantized_vec1:22 vector_index_del_partition2:23 vector_index_put_partition2:24 vector_index_put_quantized_vec2:25
       ├── index put
-      ├── query vector column: w_cast:10
-      ├── partition col: vector_index_put_partition2:21
-      ├── quantized vector col: vector_index_put_quantized_vec2:22
+      ├── query vector column: w_cast:12
+      ├── partition col: vector_index_put_partition2:24
+      ├── quantized vector col: vector_index_put_quantized_vec2:25
       └── vector-mutation-search t@t_w_idx,vector
-           ├── columns: column1:6!null v_cast:9!null w_cast:10!null x:11 v:12 w:13 crdb_internal_mvcc_timestamp:14 tableoid:15 upsert_x:16 vector_index_del_partition1:17 vector_index_put_partition1:18 vector_index_put_quantized_vec1:19 vector_index_del_partition2:20
+           ├── columns: column1:7!null column2:8!null v_cast:11!null w_cast:12!null x:13 a:14 v:15 w:16 crdb_internal_mvcc_timestamp:17 tableoid:18 upsert_x:19 vector_index_del_partition1:20 vector_index_put_partition1:21 vector_index_put_quantized_vec1:22 vector_index_del_partition2:23
            ├── index del
-           ├── query vector column: w:13
-           ├── suffix key columns: [11]
-           ├── partition col: vector_index_del_partition2:20
+           ├── query vector column: w:16
+           ├── suffix key columns: [13]
+           ├── partition col: vector_index_del_partition2:23
            └── vector-mutation-search t@t_v_idx,vector
-                ├── columns: column1:6!null v_cast:9!null w_cast:10!null x:11 v:12 w:13 crdb_internal_mvcc_timestamp:14 tableoid:15 upsert_x:16 vector_index_del_partition1:17 vector_index_put_partition1:18 vector_index_put_quantized_vec1:19
+                ├── columns: column1:7!null column2:8!null v_cast:11!null w_cast:12!null x:13 a:14 v:15 w:16 crdb_internal_mvcc_timestamp:17 tableoid:18 upsert_x:19 vector_index_del_partition1:20 vector_index_put_partition1:21 vector_index_put_quantized_vec1:22
                 ├── index put
-                ├── query vector column: v_cast:9
-                ├── partition col: vector_index_put_partition1:18
-                ├── quantized vector col: vector_index_put_quantized_vec1:19
+                ├── query vector column: v_cast:11
+                ├── partition col: vector_index_put_partition1:21
+                ├── quantized vector col: vector_index_put_quantized_vec1:22
                 └── vector-mutation-search t@t_v_idx,vector
-                     ├── columns: column1:6!null v_cast:9!null w_cast:10!null x:11 v:12 w:13 crdb_internal_mvcc_timestamp:14 tableoid:15 upsert_x:16 vector_index_del_partition1:17
+                     ├── columns: column1:7!null column2:8!null v_cast:11!null w_cast:12!null x:13 a:14 v:15 w:16 crdb_internal_mvcc_timestamp:17 tableoid:18 upsert_x:19 vector_index_del_partition1:20
                      ├── index del
-                     ├── query vector column: v:12
-                     ├── suffix key columns: [11]
-                     ├── partition col: vector_index_del_partition1:17
+                     ├── query vector column: v:15
+                     ├── suffix key columns: [13]
+                     ├── partition col: vector_index_del_partition1:20
                      └── project
-                          ├── columns: upsert_x:16 column1:6!null v_cast:9!null w_cast:10!null x:11 v:12 w:13 crdb_internal_mvcc_timestamp:14 tableoid:15
+                          ├── columns: upsert_x:19 column1:7!null column2:8!null v_cast:11!null w_cast:12!null x:13 a:14 v:15 w:16 crdb_internal_mvcc_timestamp:17 tableoid:18
                           ├── left-join (hash)
-                          │    ├── columns: column1:6!null v_cast:9!null w_cast:10!null x:11 v:12 w:13 crdb_internal_mvcc_timestamp:14 tableoid:15
+                          │    ├── columns: column1:7!null column2:8!null v_cast:11!null w_cast:12!null x:13 a:14 v:15 w:16 crdb_internal_mvcc_timestamp:17 tableoid:18
                           │    ├── ensure-upsert-distinct-on
-                          │    │    ├── columns: column1:6!null v_cast:9!null w_cast:10!null
-                          │    │    ├── grouping columns: column1:6!null
+                          │    │    ├── columns: column1:7!null column2:8!null v_cast:11!null w_cast:12!null
+                          │    │    ├── grouping columns: column1:7!null
                           │    │    ├── project
-                          │    │    │    ├── columns: v_cast:9!null w_cast:10!null column1:6!null
+                          │    │    │    ├── columns: v_cast:11!null w_cast:12!null column1:7!null column2:8!null
                           │    │    │    ├── values
-                          │    │    │    │    ├── columns: column1:6!null column2:7!null column3:8!null
-                          │    │    │    │    ├── (1, '[1,2,3]', '[10,20]')
-                          │    │    │    │    └── (2, '[4,5,6]', '[30,40]')
+                          │    │    │    │    ├── columns: column1:7!null column2:8!null column3:9!null column4:10!null
+                          │    │    │    │    ├── (1, 1, '[1,2,3]', '[10,20]')
+                          │    │    │    │    └── (2, 2, '[4,5,6]', '[30,40]')
                           │    │    │    └── projections
-                          │    │    │         ├── assignment-cast: VECTOR(3) [as=v_cast:9]
-                          │    │    │         │    └── column2:7
-                          │    │    │         └── assignment-cast: VECTOR(2) [as=w_cast:10]
-                          │    │    │              └── column3:8
+                          │    │    │         ├── assignment-cast: VECTOR(3) [as=v_cast:11]
+                          │    │    │         │    └── column3:9
+                          │    │    │         └── assignment-cast: VECTOR(2) [as=w_cast:12]
+                          │    │    │              └── column4:10
                           │    │    └── aggregations
-                          │    │         ├── first-agg [as=v_cast:9]
-                          │    │         │    └── v_cast:9
-                          │    │         └── first-agg [as=w_cast:10]
-                          │    │              └── w_cast:10
+                          │    │         ├── first-agg [as=column2:8]
+                          │    │         │    └── column2:8
+                          │    │         ├── first-agg [as=v_cast:11]
+                          │    │         │    └── v_cast:11
+                          │    │         └── first-agg [as=w_cast:12]
+                          │    │              └── w_cast:12
                           │    ├── scan t
-                          │    │    ├── columns: x:11!null v:12 w:13 crdb_internal_mvcc_timestamp:14 tableoid:15
+                          │    │    ├── columns: x:13!null a:14 v:15 w:16 crdb_internal_mvcc_timestamp:17 tableoid:18
                           │    │    └── flags: avoid-full-scan disabled not visible index feature
                           │    └── filters
-                          │         └── column1:6 = x:11
+                          │         └── column1:7 = x:13
                           └── projections
-                               └── CASE WHEN x:11 IS NULL THEN column1:6 ELSE x:11 END [as=upsert_x:16]
+                               └── CASE WHEN x:13 IS NULL THEN column1:7 ELSE x:13 END [as=upsert_x:19]
 
 build
-INSERT INTO t VALUES (1, '[1,2,3]', '[10, 20]'), (2, '[4,5,6]', '[30, 40]')
+INSERT INTO t VALUES (1, 1, '[1,2,3]', '[10, 20]'), (2, 2, '[4,5,6]', '[30, 40]')
 ON CONFLICT (x) DO UPDATE SET v = '[-4,-5,-6]', w = '[-40, -30]';
 ----
 upsert t
  ├── arbiter indexes: t_pkey
  ├── columns: <none>
- ├── canary column: x:11
- ├── fetch columns: x:11 v:12 w:13
+ ├── canary column: x:13
+ ├── fetch columns: x:13 a:14 v:15 w:16
  ├── insert-mapping:
- │    ├── column1:6 => x:1
- │    ├── v_cast:9 => v:2
- │    └── w_cast:10 => w:3
+ │    ├── column1:7 => x:1
+ │    ├── column2:8 => a:2
+ │    ├── v_cast:11 => v:3
+ │    └── w_cast:12 => w:4
  ├── update-mapping:
- │    ├── upsert_v:21 => v:2
- │    └── upsert_w:22 => w:3
- ├── vector index del partition columns: vector_index_del_partition1:23 vector_index_del_partition2:26
- ├── vector index put partition columns: vector_index_put_partition1:24 vector_index_put_partition2:27
- ├── vector index put quantized vector columns: vector_index_put_quantized_vec1:25 vector_index_put_quantized_vec2:28
+ │    ├── upsert_v:25 => v:3
+ │    └── upsert_w:26 => w:4
+ ├── vector index del partition columns: vector_index_del_partition1:27 vector_index_del_partition2:30
+ ├── vector index put partition columns: vector_index_put_partition1:28 vector_index_put_partition2:31
+ ├── vector index put quantized vector columns: vector_index_put_quantized_vec1:29 vector_index_put_quantized_vec2:32
  └── vector-mutation-search t@t_w_idx,vector
-      ├── columns: column1:6!null v_cast:9!null w_cast:10!null x:11 v:12 w:13 crdb_internal_mvcc_timestamp:14 tableoid:15 v_cast:18!null w_cast:19!null upsert_x:20 upsert_v:21!null upsert_w:22!null vector_index_del_partition1:23 vector_index_put_partition1:24 vector_index_put_quantized_vec1:25 vector_index_del_partition2:26 vector_index_put_partition2:27 vector_index_put_quantized_vec2:28
+      ├── columns: column1:7!null column2:8!null v_cast:11!null w_cast:12!null x:13 a:14 v:15 w:16 crdb_internal_mvcc_timestamp:17 tableoid:18 v_cast:21!null w_cast:22!null upsert_x:23 upsert_a:24 upsert_v:25!null upsert_w:26!null vector_index_del_partition1:27 vector_index_put_partition1:28 vector_index_put_quantized_vec1:29 vector_index_del_partition2:30 vector_index_put_partition2:31 vector_index_put_quantized_vec2:32
       ├── index put
-      ├── query vector column: upsert_w:22
-      ├── partition col: vector_index_put_partition2:27
-      ├── quantized vector col: vector_index_put_quantized_vec2:28
+      ├── query vector column: upsert_w:26
+      ├── partition col: vector_index_put_partition2:31
+      ├── quantized vector col: vector_index_put_quantized_vec2:32
       └── vector-mutation-search t@t_w_idx,vector
-           ├── columns: column1:6!null v_cast:9!null w_cast:10!null x:11 v:12 w:13 crdb_internal_mvcc_timestamp:14 tableoid:15 v_cast:18!null w_cast:19!null upsert_x:20 upsert_v:21!null upsert_w:22!null vector_index_del_partition1:23 vector_index_put_partition1:24 vector_index_put_quantized_vec1:25 vector_index_del_partition2:26
+           ├── columns: column1:7!null column2:8!null v_cast:11!null w_cast:12!null x:13 a:14 v:15 w:16 crdb_internal_mvcc_timestamp:17 tableoid:18 v_cast:21!null w_cast:22!null upsert_x:23 upsert_a:24 upsert_v:25!null upsert_w:26!null vector_index_del_partition1:27 vector_index_put_partition1:28 vector_index_put_quantized_vec1:29 vector_index_del_partition2:30
            ├── index del
-           ├── query vector column: w:13
-           ├── suffix key columns: [11]
-           ├── partition col: vector_index_del_partition2:26
+           ├── query vector column: w:16
+           ├── suffix key columns: [13]
+           ├── partition col: vector_index_del_partition2:30
            └── vector-mutation-search t@t_v_idx,vector
-                ├── columns: column1:6!null v_cast:9!null w_cast:10!null x:11 v:12 w:13 crdb_internal_mvcc_timestamp:14 tableoid:15 v_cast:18!null w_cast:19!null upsert_x:20 upsert_v:21!null upsert_w:22!null vector_index_del_partition1:23 vector_index_put_partition1:24 vector_index_put_quantized_vec1:25
+                ├── columns: column1:7!null column2:8!null v_cast:11!null w_cast:12!null x:13 a:14 v:15 w:16 crdb_internal_mvcc_timestamp:17 tableoid:18 v_cast:21!null w_cast:22!null upsert_x:23 upsert_a:24 upsert_v:25!null upsert_w:26!null vector_index_del_partition1:27 vector_index_put_partition1:28 vector_index_put_quantized_vec1:29
                 ├── index put
-                ├── query vector column: upsert_v:21
-                ├── partition col: vector_index_put_partition1:24
-                ├── quantized vector col: vector_index_put_quantized_vec1:25
+                ├── query vector column: upsert_v:25
+                ├── partition col: vector_index_put_partition1:28
+                ├── quantized vector col: vector_index_put_quantized_vec1:29
                 └── vector-mutation-search t@t_v_idx,vector
-                     ├── columns: column1:6!null v_cast:9!null w_cast:10!null x:11 v:12 w:13 crdb_internal_mvcc_timestamp:14 tableoid:15 v_cast:18!null w_cast:19!null upsert_x:20 upsert_v:21!null upsert_w:22!null vector_index_del_partition1:23
+                     ├── columns: column1:7!null column2:8!null v_cast:11!null w_cast:12!null x:13 a:14 v:15 w:16 crdb_internal_mvcc_timestamp:17 tableoid:18 v_cast:21!null w_cast:22!null upsert_x:23 upsert_a:24 upsert_v:25!null upsert_w:26!null vector_index_del_partition1:27
                      ├── index del
-                     ├── query vector column: v:12
-                     ├── suffix key columns: [11]
-                     ├── partition col: vector_index_del_partition1:23
+                     ├── query vector column: v:15
+                     ├── suffix key columns: [13]
+                     ├── partition col: vector_index_del_partition1:27
                      └── project
-                          ├── columns: upsert_x:20 upsert_v:21!null upsert_w:22!null column1:6!null v_cast:9!null w_cast:10!null x:11 v:12 w:13 crdb_internal_mvcc_timestamp:14 tableoid:15 v_cast:18!null w_cast:19!null
+                          ├── columns: upsert_x:23 upsert_a:24 upsert_v:25!null upsert_w:26!null column1:7!null column2:8!null v_cast:11!null w_cast:12!null x:13 a:14 v:15 w:16 crdb_internal_mvcc_timestamp:17 tableoid:18 v_cast:21!null w_cast:22!null
                           ├── project
-                          │    ├── columns: v_cast:18!null w_cast:19!null column1:6!null v_cast:9!null w_cast:10!null x:11 v:12 w:13 crdb_internal_mvcc_timestamp:14 tableoid:15
+                          │    ├── columns: v_cast:21!null w_cast:22!null column1:7!null column2:8!null v_cast:11!null w_cast:12!null x:13 a:14 v:15 w:16 crdb_internal_mvcc_timestamp:17 tableoid:18
                           │    ├── project
-                          │    │    ├── columns: v_new:16!null w_new:17!null column1:6!null v_cast:9!null w_cast:10!null x:11 v:12 w:13 crdb_internal_mvcc_timestamp:14 tableoid:15
+                          │    │    ├── columns: v_new:19!null w_new:20!null column1:7!null column2:8!null v_cast:11!null w_cast:12!null x:13 a:14 v:15 w:16 crdb_internal_mvcc_timestamp:17 tableoid:18
                           │    │    ├── left-join (hash)
-                          │    │    │    ├── columns: column1:6!null v_cast:9!null w_cast:10!null x:11 v:12 w:13 crdb_internal_mvcc_timestamp:14 tableoid:15
+                          │    │    │    ├── columns: column1:7!null column2:8!null v_cast:11!null w_cast:12!null x:13 a:14 v:15 w:16 crdb_internal_mvcc_timestamp:17 tableoid:18
                           │    │    │    ├── ensure-upsert-distinct-on
-                          │    │    │    │    ├── columns: column1:6!null v_cast:9!null w_cast:10!null
-                          │    │    │    │    ├── grouping columns: column1:6!null
+                          │    │    │    │    ├── columns: column1:7!null column2:8!null v_cast:11!null w_cast:12!null
+                          │    │    │    │    ├── grouping columns: column1:7!null
                           │    │    │    │    ├── project
-                          │    │    │    │    │    ├── columns: v_cast:9!null w_cast:10!null column1:6!null
+                          │    │    │    │    │    ├── columns: v_cast:11!null w_cast:12!null column1:7!null column2:8!null
                           │    │    │    │    │    ├── values
-                          │    │    │    │    │    │    ├── columns: column1:6!null column2:7!null column3:8!null
-                          │    │    │    │    │    │    ├── (1, '[1,2,3]', '[10,20]')
-                          │    │    │    │    │    │    └── (2, '[4,5,6]', '[30,40]')
+                          │    │    │    │    │    │    ├── columns: column1:7!null column2:8!null column3:9!null column4:10!null
+                          │    │    │    │    │    │    ├── (1, 1, '[1,2,3]', '[10,20]')
+                          │    │    │    │    │    │    └── (2, 2, '[4,5,6]', '[30,40]')
                           │    │    │    │    │    └── projections
-                          │    │    │    │    │         ├── assignment-cast: VECTOR(3) [as=v_cast:9]
-                          │    │    │    │    │         │    └── column2:7
-                          │    │    │    │    │         └── assignment-cast: VECTOR(2) [as=w_cast:10]
-                          │    │    │    │    │              └── column3:8
+                          │    │    │    │    │         ├── assignment-cast: VECTOR(3) [as=v_cast:11]
+                          │    │    │    │    │         │    └── column3:9
+                          │    │    │    │    │         └── assignment-cast: VECTOR(2) [as=w_cast:12]
+                          │    │    │    │    │              └── column4:10
                           │    │    │    │    └── aggregations
-                          │    │    │    │         ├── first-agg [as=v_cast:9]
-                          │    │    │    │         │    └── v_cast:9
-                          │    │    │    │         └── first-agg [as=w_cast:10]
-                          │    │    │    │              └── w_cast:10
+                          │    │    │    │         ├── first-agg [as=column2:8]
+                          │    │    │    │         │    └── column2:8
+                          │    │    │    │         ├── first-agg [as=v_cast:11]
+                          │    │    │    │         │    └── v_cast:11
+                          │    │    │    │         └── first-agg [as=w_cast:12]
+                          │    │    │    │              └── w_cast:12
                           │    │    │    ├── scan t
-                          │    │    │    │    ├── columns: x:11!null v:12 w:13 crdb_internal_mvcc_timestamp:14 tableoid:15
+                          │    │    │    │    ├── columns: x:13!null a:14 v:15 w:16 crdb_internal_mvcc_timestamp:17 tableoid:18
                           │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
                           │    │    │    └── filters
-                          │    │    │         └── column1:6 = x:11
+                          │    │    │         └── column1:7 = x:13
                           │    │    └── projections
-                          │    │         ├── '[-4,-5,-6]' [as=v_new:16]
-                          │    │         └── '[-40,-30]' [as=w_new:17]
+                          │    │         ├── '[-4,-5,-6]' [as=v_new:19]
+                          │    │         └── '[-40,-30]' [as=w_new:20]
                           │    └── projections
-                          │         ├── assignment-cast: VECTOR(3) [as=v_cast:18]
-                          │         │    └── v_new:16
-                          │         └── assignment-cast: VECTOR(2) [as=w_cast:19]
-                          │              └── w_new:17
+                          │         ├── assignment-cast: VECTOR(3) [as=v_cast:21]
+                          │         │    └── v_new:19
+                          │         └── assignment-cast: VECTOR(2) [as=w_cast:22]
+                          │              └── w_new:20
                           └── projections
-                               ├── CASE WHEN x:11 IS NULL THEN column1:6 ELSE x:11 END [as=upsert_x:20]
-                               ├── CASE WHEN x:11 IS NULL THEN v_cast:9 ELSE v_cast:18 END [as=upsert_v:21]
-                               └── CASE WHEN x:11 IS NULL THEN w_cast:10 ELSE w_cast:19 END [as=upsert_w:22]
+                               ├── CASE WHEN x:13 IS NULL THEN column1:7 ELSE x:13 END [as=upsert_x:23]
+                               ├── CASE WHEN x:13 IS NULL THEN column2:8 ELSE a:14 END [as=upsert_a:24]
+                               ├── CASE WHEN x:13 IS NULL THEN v_cast:11 ELSE v_cast:21 END [as=upsert_v:25]
+                               └── CASE WHEN x:13 IS NULL THEN w_cast:12 ELSE w_cast:22 END [as=upsert_w:26]
 
-# If the indexed column is not modified, no VectorMutationSearch is needed for
-# that index.
 build
 UPDATE t SET x = 3, v = '[1,2,3]' WHERE x = 3;
 ----
 update t
  ├── columns: <none>
- ├── fetch columns: x:6 v:7 w:8
+ ├── fetch columns: x:7 a:8 v:9 w:10
  ├── update-mapping:
- │    ├── x_new:11 => x:1
- │    └── v_cast:13 => v:2
- ├── vector index del partition columns: vector_index_del_partition1:14
- ├── vector index put partition columns: vector_index_put_partition1:15
- ├── vector index put quantized vector columns: vector_index_put_quantized_vec1:16
- └── vector-mutation-search t@t_v_idx,vector
-      ├── columns: x:6!null v:7 w:8 crdb_internal_mvcc_timestamp:9 tableoid:10 x_new:11!null v_cast:13!null vector_index_del_partition1:14 vector_index_put_partition1:15 vector_index_put_quantized_vec1:16
+ │    ├── x_new:13 => x:1
+ │    └── v_cast:15 => v:3
+ ├── vector index del partition columns: vector_index_del_partition1:16 vector_index_del_partition2:19
+ ├── vector index put partition columns: vector_index_put_partition1:17 vector_index_put_partition2:20
+ ├── vector index put quantized vector columns: vector_index_put_quantized_vec1:18 vector_index_put_quantized_vec2:21
+ └── vector-mutation-search t@t_w_idx,vector
+      ├── columns: x:7!null a:8 v:9 w:10 crdb_internal_mvcc_timestamp:11 tableoid:12 x_new:13!null v_cast:15!null vector_index_del_partition1:16 vector_index_put_partition1:17 vector_index_put_quantized_vec1:18 vector_index_del_partition2:19 vector_index_put_partition2:20 vector_index_put_quantized_vec2:21
       ├── index put
-      ├── query vector column: v_cast:13
-      ├── partition col: vector_index_put_partition1:15
-      ├── quantized vector col: vector_index_put_quantized_vec1:16
-      └── vector-mutation-search t@t_v_idx,vector
-           ├── columns: x:6!null v:7 w:8 crdb_internal_mvcc_timestamp:9 tableoid:10 x_new:11!null v_cast:13!null vector_index_del_partition1:14
+      ├── query vector column: w:10
+      ├── partition col: vector_index_put_partition2:20
+      ├── quantized vector col: vector_index_put_quantized_vec2:21
+      └── vector-mutation-search t@t_w_idx,vector
+           ├── columns: x:7!null a:8 v:9 w:10 crdb_internal_mvcc_timestamp:11 tableoid:12 x_new:13!null v_cast:15!null vector_index_del_partition1:16 vector_index_put_partition1:17 vector_index_put_quantized_vec1:18 vector_index_del_partition2:19
            ├── index del
-           ├── query vector column: v:7
-           ├── suffix key columns: [6]
-           ├── partition col: vector_index_del_partition1:14
-           └── project
-                ├── columns: v_cast:13!null x:6!null v:7 w:8 crdb_internal_mvcc_timestamp:9 tableoid:10 x_new:11!null
-                ├── project
-                │    ├── columns: x_new:11!null v_new:12!null x:6!null v:7 w:8 crdb_internal_mvcc_timestamp:9 tableoid:10
-                │    ├── select
-                │    │    ├── columns: x:6!null v:7 w:8 crdb_internal_mvcc_timestamp:9 tableoid:10
-                │    │    ├── scan t
-                │    │    │    ├── columns: x:6!null v:7 w:8 crdb_internal_mvcc_timestamp:9 tableoid:10
-                │    │    │    └── flags: avoid-full-scan
-                │    │    └── filters
-                │    │         └── x:6 = 3
-                │    └── projections
-                │         ├── 3 [as=x_new:11]
-                │         └── '[1,2,3]' [as=v_new:12]
-                └── projections
-                     └── assignment-cast: VECTOR(3) [as=v_cast:13]
-                          └── v_new:12
+           ├── query vector column: w:10
+           ├── suffix key columns: [7]
+           ├── partition col: vector_index_del_partition2:19
+           └── vector-mutation-search t@t_v_idx,vector
+                ├── columns: x:7!null a:8 v:9 w:10 crdb_internal_mvcc_timestamp:11 tableoid:12 x_new:13!null v_cast:15!null vector_index_del_partition1:16 vector_index_put_partition1:17 vector_index_put_quantized_vec1:18
+                ├── index put
+                ├── query vector column: v_cast:15
+                ├── partition col: vector_index_put_partition1:17
+                ├── quantized vector col: vector_index_put_quantized_vec1:18
+                └── vector-mutation-search t@t_v_idx,vector
+                     ├── columns: x:7!null a:8 v:9 w:10 crdb_internal_mvcc_timestamp:11 tableoid:12 x_new:13!null v_cast:15!null vector_index_del_partition1:16
+                     ├── index del
+                     ├── query vector column: v:9
+                     ├── suffix key columns: [7]
+                     ├── partition col: vector_index_del_partition1:16
+                     └── project
+                          ├── columns: v_cast:15!null x:7!null a:8 v:9 w:10 crdb_internal_mvcc_timestamp:11 tableoid:12 x_new:13!null
+                          ├── project
+                          │    ├── columns: x_new:13!null v_new:14!null x:7!null a:8 v:9 w:10 crdb_internal_mvcc_timestamp:11 tableoid:12
+                          │    ├── select
+                          │    │    ├── columns: x:7!null a:8 v:9 w:10 crdb_internal_mvcc_timestamp:11 tableoid:12
+                          │    │    ├── scan t
+                          │    │    │    ├── columns: x:7!null a:8 v:9 w:10 crdb_internal_mvcc_timestamp:11 tableoid:12
+                          │    │    │    └── flags: avoid-full-scan
+                          │    │    └── filters
+                          │    │         └── x:7 = 3
+                          │    └── projections
+                          │         ├── 3 [as=x_new:13]
+                          │         └── '[1,2,3]' [as=v_new:14]
+                          └── projections
+                               └── assignment-cast: VECTOR(3) [as=v_cast:15]
+                                    └── v_new:14
 
 build
 UPDATE t SET x = 3 WHERE x = 3;
 ----
 update t
  ├── columns: <none>
- ├── fetch columns: x:6 v:7 w:8
+ ├── fetch columns: x:7 a:8 v:9 w:10
  ├── update-mapping:
- │    └── x_new:11 => x:1
+ │    └── x_new:13 => x:1
+ ├── vector index del partition columns: vector_index_del_partition1:14 vector_index_del_partition2:17
+ ├── vector index put partition columns: vector_index_put_partition1:15 vector_index_put_partition2:18
+ ├── vector index put quantized vector columns: vector_index_put_quantized_vec1:16 vector_index_put_quantized_vec2:19
+ └── vector-mutation-search t@t_w_idx,vector
+      ├── columns: x:7!null a:8 v:9 w:10 crdb_internal_mvcc_timestamp:11 tableoid:12 x_new:13!null vector_index_del_partition1:14 vector_index_put_partition1:15 vector_index_put_quantized_vec1:16 vector_index_del_partition2:17 vector_index_put_partition2:18 vector_index_put_quantized_vec2:19
+      ├── index put
+      ├── query vector column: w:10
+      ├── partition col: vector_index_put_partition2:18
+      ├── quantized vector col: vector_index_put_quantized_vec2:19
+      └── vector-mutation-search t@t_w_idx,vector
+           ├── columns: x:7!null a:8 v:9 w:10 crdb_internal_mvcc_timestamp:11 tableoid:12 x_new:13!null vector_index_del_partition1:14 vector_index_put_partition1:15 vector_index_put_quantized_vec1:16 vector_index_del_partition2:17
+           ├── index del
+           ├── query vector column: w:10
+           ├── suffix key columns: [7]
+           ├── partition col: vector_index_del_partition2:17
+           └── vector-mutation-search t@t_v_idx,vector
+                ├── columns: x:7!null a:8 v:9 w:10 crdb_internal_mvcc_timestamp:11 tableoid:12 x_new:13!null vector_index_del_partition1:14 vector_index_put_partition1:15 vector_index_put_quantized_vec1:16
+                ├── index put
+                ├── query vector column: v:9
+                ├── partition col: vector_index_put_partition1:15
+                ├── quantized vector col: vector_index_put_quantized_vec1:16
+                └── vector-mutation-search t@t_v_idx,vector
+                     ├── columns: x:7!null a:8 v:9 w:10 crdb_internal_mvcc_timestamp:11 tableoid:12 x_new:13!null vector_index_del_partition1:14
+                     ├── index del
+                     ├── query vector column: v:9
+                     ├── suffix key columns: [7]
+                     ├── partition col: vector_index_del_partition1:14
+                     └── project
+                          ├── columns: x_new:13!null x:7!null a:8 v:9 w:10 crdb_internal_mvcc_timestamp:11 tableoid:12
+                          ├── select
+                          │    ├── columns: x:7!null a:8 v:9 w:10 crdb_internal_mvcc_timestamp:11 tableoid:12
+                          │    ├── scan t
+                          │    │    ├── columns: x:7!null a:8 v:9 w:10 crdb_internal_mvcc_timestamp:11 tableoid:12
+                          │    │    └── flags: avoid-full-scan
+                          │    └── filters
+                          │         └── x:7 = 3
+                          └── projections
+                               └── 3 [as=x_new:13]
+
+build
+INSERT INTO t_multi VALUES (1, 2, 1, 2, 3, '[1, 2, 3]');
+----
+insert t_multi
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├── column1:9 => x:1
+ │    ├── column2:10 => y:2
+ │    ├── column3:11 => a:3
+ │    ├── column4:12 => b:4
+ │    ├── column5:13 => c:5
+ │    └── v_cast:15 => v:6
+ ├── vector index put partition columns: vector_index_put_partition1:16
+ ├── vector index put quantized vector columns: vector_index_put_quantized_vec1:17
+ └── vector-mutation-search t_multi@t_multi_a_b_v_idx,vector
+      ├── columns: column1:9!null column2:10!null column3:11!null column4:12!null column5:13!null v_cast:15!null vector_index_put_partition1:16 vector_index_put_quantized_vec1:17
+      ├── index put
+      ├── prefix key columns: [11 12]
+      ├── query vector column: v_cast:15
+      ├── partition col: vector_index_put_partition1:16
+      ├── quantized vector col: vector_index_put_quantized_vec1:17
+      └── project
+           ├── columns: v_cast:15!null column1:9!null column2:10!null column3:11!null column4:12!null column5:13!null
+           ├── values
+           │    ├── columns: column1:9!null column2:10!null column3:11!null column4:12!null column5:13!null column6:14!null
+           │    └── (1, 2, 1, 2, 3, '[1,2,3]')
+           └── projections
+                └── assignment-cast: VECTOR(3) [as=v_cast:15]
+                     └── column6:14
+
+build
+UPDATE t_multi SET v = '[1, 2, 3]' WHERE a = 1 AND b = 2;
+----
+update t_multi
+ ├── columns: <none>
+ ├── fetch columns: x:9 y:10 a:11 b:12 c:13 v:14
+ ├── update-mapping:
+ │    └── v_cast:18 => v:6
+ ├── vector index del partition columns: vector_index_del_partition1:19
+ ├── vector index put partition columns: vector_index_put_partition1:20
+ ├── vector index put quantized vector columns: vector_index_put_quantized_vec1:21
+ └── vector-mutation-search t_multi@t_multi_a_b_v_idx,vector
+      ├── columns: x:9!null y:10!null a:11!null b:12!null c:13 v:14 crdb_internal_mvcc_timestamp:15 tableoid:16 v_cast:18!null vector_index_del_partition1:19 vector_index_put_partition1:20 vector_index_put_quantized_vec1:21
+      ├── index put
+      ├── prefix key columns: [11 12]
+      ├── query vector column: v_cast:18
+      ├── partition col: vector_index_put_partition1:20
+      ├── quantized vector col: vector_index_put_quantized_vec1:21
+      └── vector-mutation-search t_multi@t_multi_a_b_v_idx,vector
+           ├── columns: x:9!null y:10!null a:11!null b:12!null c:13 v:14 crdb_internal_mvcc_timestamp:15 tableoid:16 v_cast:18!null vector_index_del_partition1:19
+           ├── index del
+           ├── prefix key columns: [11 12]
+           ├── query vector column: v:14
+           ├── suffix key columns: [9 10]
+           ├── partition col: vector_index_del_partition1:19
+           └── project
+                ├── columns: v_cast:18!null x:9!null y:10!null a:11!null b:12!null c:13 v:14 crdb_internal_mvcc_timestamp:15 tableoid:16
+                ├── project
+                │    ├── columns: v_new:17!null x:9!null y:10!null a:11!null b:12!null c:13 v:14 crdb_internal_mvcc_timestamp:15 tableoid:16
+                │    ├── select
+                │    │    ├── columns: x:9!null y:10!null a:11!null b:12!null c:13 v:14 crdb_internal_mvcc_timestamp:15 tableoid:16
+                │    │    ├── scan t_multi
+                │    │    │    ├── columns: x:9!null y:10!null a:11 b:12 c:13 v:14 crdb_internal_mvcc_timestamp:15 tableoid:16
+                │    │    │    └── flags: avoid-full-scan
+                │    │    └── filters
+                │    │         └── (a:11 = 1) AND (b:12 = 2)
+                │    └── projections
+                │         └── '[1,2,3]' [as=v_new:17]
+                └── projections
+                     └── assignment-cast: VECTOR(3) [as=v_cast:18]
+                          └── v_new:17
+
+# Case where a non-vector column from the index is modified. The vector index
+# still must be updated.
+build
+UPDATE t_multi SET a = 2 WHERE a = 1;
+----
+update t_multi
+ ├── columns: <none>
+ ├── fetch columns: x:9 y:10 a:11 b:12 c:13 v:14
+ ├── update-mapping:
+ │    └── a_new:17 => a:3
+ ├── vector index del partition columns: vector_index_del_partition1:18
+ ├── vector index put partition columns: vector_index_put_partition1:19
+ ├── vector index put quantized vector columns: vector_index_put_quantized_vec1:20
+ └── vector-mutation-search t_multi@t_multi_a_b_v_idx,vector
+      ├── columns: x:9!null y:10!null a:11!null b:12 c:13 v:14 crdb_internal_mvcc_timestamp:15 tableoid:16 a_new:17!null vector_index_del_partition1:18 vector_index_put_partition1:19 vector_index_put_quantized_vec1:20
+      ├── index put
+      ├── prefix key columns: [17 12]
+      ├── query vector column: v:14
+      ├── partition col: vector_index_put_partition1:19
+      ├── quantized vector col: vector_index_put_quantized_vec1:20
+      └── vector-mutation-search t_multi@t_multi_a_b_v_idx,vector
+           ├── columns: x:9!null y:10!null a:11!null b:12 c:13 v:14 crdb_internal_mvcc_timestamp:15 tableoid:16 a_new:17!null vector_index_del_partition1:18
+           ├── index del
+           ├── prefix key columns: [11 12]
+           ├── query vector column: v:14
+           ├── suffix key columns: [9 10]
+           ├── partition col: vector_index_del_partition1:18
+           └── project
+                ├── columns: a_new:17!null x:9!null y:10!null a:11!null b:12 c:13 v:14 crdb_internal_mvcc_timestamp:15 tableoid:16
+                ├── select
+                │    ├── columns: x:9!null y:10!null a:11!null b:12 c:13 v:14 crdb_internal_mvcc_timestamp:15 tableoid:16
+                │    ├── scan t_multi
+                │    │    ├── columns: x:9!null y:10!null a:11 b:12 c:13 v:14 crdb_internal_mvcc_timestamp:15 tableoid:16
+                │    │    └── flags: avoid-full-scan
+                │    └── filters
+                │         └── a:11 = 1
+                └── projections
+                     └── 2 [as=a_new:17]
+
+# Case with a non-indexed column modified.
+build
+UPDATE t_multi SET c = 2 WHERE a = 1;
+----
+update t_multi
+ ├── columns: <none>
+ ├── fetch columns: x:9 y:10 a:11 b:12 c:13 v:14
+ ├── update-mapping:
+ │    └── c_new:17 => c:5
  └── project
-      ├── columns: x_new:11!null x:6!null v:7 w:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+      ├── columns: c_new:17!null x:9!null y:10!null a:11!null b:12 c:13 v:14 crdb_internal_mvcc_timestamp:15 tableoid:16
       ├── select
-      │    ├── columns: x:6!null v:7 w:8 crdb_internal_mvcc_timestamp:9 tableoid:10
-      │    ├── scan t
-      │    │    ├── columns: x:6!null v:7 w:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+      │    ├── columns: x:9!null y:10!null a:11!null b:12 c:13 v:14 crdb_internal_mvcc_timestamp:15 tableoid:16
+      │    ├── scan t_multi
+      │    │    ├── columns: x:9!null y:10!null a:11 b:12 c:13 v:14 crdb_internal_mvcc_timestamp:15 tableoid:16
       │    │    └── flags: avoid-full-scan
       │    └── filters
-      │         └── x:6 = 3
+      │         └── a:11 = 1
       └── projections
-           └── 3 [as=x_new:11]
+           └── 2 [as=c_new:17]
+
+build
+DELETE FROM t_multi WHERE a = 1 AND b = 2;
+----
+delete t_multi
+ ├── columns: <none>
+ ├── fetch columns: x:9 y:10 a:11 b:12 c:13 v:14
+ ├── vector index del partition columns: vector_index_del_partition1:17
+ └── vector-mutation-search t_multi@t_multi_a_b_v_idx,vector
+      ├── columns: x:9!null y:10!null a:11!null b:12!null c:13 v:14 crdb_internal_mvcc_timestamp:15 tableoid:16 vector_index_del_partition1:17
+      ├── index del
+      ├── prefix key columns: [11 12]
+      ├── query vector column: v:14
+      ├── suffix key columns: [9 10]
+      ├── partition col: vector_index_del_partition1:17
+      └── select
+           ├── columns: x:9!null y:10!null a:11!null b:12!null c:13 v:14 crdb_internal_mvcc_timestamp:15 tableoid:16
+           ├── scan t_multi
+           │    ├── columns: x:9!null y:10!null a:11 b:12 c:13 v:14 crdb_internal_mvcc_timestamp:15 tableoid:16
+           │    └── flags: avoid-full-scan
+           └── filters
+                └── (a:11 = 1) AND (b:12 = 2)
+
+build
+DELETE FROM t_multi WHERE a = 1;
+----
+delete t_multi
+ ├── columns: <none>
+ ├── fetch columns: x:9 y:10 a:11 b:12 c:13 v:14
+ ├── vector index del partition columns: vector_index_del_partition1:17
+ └── vector-mutation-search t_multi@t_multi_a_b_v_idx,vector
+      ├── columns: x:9!null y:10!null a:11!null b:12 c:13 v:14 crdb_internal_mvcc_timestamp:15 tableoid:16 vector_index_del_partition1:17
+      ├── index del
+      ├── prefix key columns: [11 12]
+      ├── query vector column: v:14
+      ├── suffix key columns: [9 10]
+      ├── partition col: vector_index_del_partition1:17
+      └── select
+           ├── columns: x:9!null y:10!null a:11!null b:12 c:13 v:14 crdb_internal_mvcc_timestamp:15 tableoid:16
+           ├── scan t_multi
+           │    ├── columns: x:9!null y:10!null a:11 b:12 c:13 v:14 crdb_internal_mvcc_timestamp:15 tableoid:16
+           │    └── flags: avoid-full-scan
+           └── filters
+                └── a:11 = 1

--- a/pkg/sql/opt/optbuilder/testdata/vector_mutation
+++ b/pkg/sql/opt/optbuilder/testdata/vector_mutation
@@ -19,6 +19,7 @@ insert t
  ├── vector index put quantized vector columns: vector_index_put_quantized_vec1:11
  └── vector-mutation-search t@t_v_idx,vector
       ├── columns: column1:6!null v_cast:8!null w_default:9 vector_index_put_partition1:10 vector_index_put_quantized_vec1:11
+      ├── index put
       ├── query vector column: v_cast:8
       ├── partition col: vector_index_put_partition1:10
       ├── quantized vector col: vector_index_put_quantized_vec1:11
@@ -49,13 +50,15 @@ update t
  ├── vector index put quantized vector columns: vector_index_put_quantized_vec1:15
  └── vector-mutation-search t@t_v_idx,vector
       ├── columns: x:6!null v:7 w:8 crdb_internal_mvcc_timestamp:9 tableoid:10 v_cast:12!null vector_index_del_partition1:13 vector_index_put_partition1:14 vector_index_put_quantized_vec1:15
+      ├── index put
       ├── query vector column: v_cast:12
       ├── partition col: vector_index_put_partition1:14
       ├── quantized vector col: vector_index_put_quantized_vec1:15
       └── vector-mutation-search t@t_v_idx,vector
            ├── columns: x:6!null v:7 w:8 crdb_internal_mvcc_timestamp:9 tableoid:10 v_cast:12!null vector_index_del_partition1:13
+           ├── index del
            ├── query vector column: v:7
-           ├── primary key columns: (6)
+           ├── suffix key columns: [6]
            ├── partition col: vector_index_del_partition1:13
            └── project
                 ├── columns: v_cast:12!null x:6!null v:7 w:8 crdb_internal_mvcc_timestamp:9 tableoid:10
@@ -83,8 +86,9 @@ delete t
  ├── vector index del partition columns: vector_index_del_partition1:11
  └── vector-mutation-search t@t_v_idx,vector
       ├── columns: x:6!null v:7 w:8 crdb_internal_mvcc_timestamp:9 tableoid:10 vector_index_del_partition1:11
+      ├── index del
       ├── query vector column: v:7
-      ├── primary key columns: (6)
+      ├── suffix key columns: [6]
       ├── partition col: vector_index_del_partition1:11
       └── select
            ├── columns: x:6!null v:7 w:8 crdb_internal_mvcc_timestamp:9 tableoid:10
@@ -114,13 +118,15 @@ upsert t
  ├── vector index put quantized vector columns: vector_index_put_quantized_vec1:18
  └── vector-mutation-search t@t_v_idx,vector
       ├── columns: column1:6!null v_cast:8!null w_default:9 x:10 v:11 w:12 crdb_internal_mvcc_timestamp:13 tableoid:14 upsert_x:15 vector_index_del_partition1:16 vector_index_put_partition1:17 vector_index_put_quantized_vec1:18
+      ├── index put
       ├── query vector column: v_cast:8
       ├── partition col: vector_index_put_partition1:17
       ├── quantized vector col: vector_index_put_quantized_vec1:18
       └── vector-mutation-search t@t_v_idx,vector
            ├── columns: column1:6!null v_cast:8!null w_default:9 x:10 v:11 w:12 crdb_internal_mvcc_timestamp:13 tableoid:14 upsert_x:15 vector_index_del_partition1:16
+           ├── index del
            ├── query vector column: v:11
-           ├── primary key columns: (10)
+           ├── suffix key columns: [10]
            ├── partition col: vector_index_del_partition1:16
            └── project
                 ├── columns: upsert_x:15 column1:6!null v_cast:8!null w_default:9 x:10 v:11 w:12 crdb_internal_mvcc_timestamp:13 tableoid:14
@@ -175,13 +181,15 @@ upsert t
  ├── vector index put quantized vector columns: vector_index_put_quantized_vec1:22
  └── vector-mutation-search t@t_v_idx,vector
       ├── columns: column1:6!null v_cast:8!null w_default:9 x:10 v:11 w:12 crdb_internal_mvcc_timestamp:13 tableoid:14 v_cast:16!null upsert_x:17 upsert_v:18!null upsert_w:19 vector_index_del_partition1:20 vector_index_put_partition1:21 vector_index_put_quantized_vec1:22
+      ├── index put
       ├── query vector column: upsert_v:18
       ├── partition col: vector_index_put_partition1:21
       ├── quantized vector col: vector_index_put_quantized_vec1:22
       └── vector-mutation-search t@t_v_idx,vector
            ├── columns: column1:6!null v_cast:8!null w_default:9 x:10 v:11 w:12 crdb_internal_mvcc_timestamp:13 tableoid:14 v_cast:16!null upsert_x:17 upsert_v:18!null upsert_w:19 vector_index_del_partition1:20
+           ├── index del
            ├── query vector column: v:11
-           ├── primary key columns: (10)
+           ├── suffix key columns: [10]
            ├── partition col: vector_index_del_partition1:20
            └── project
                 ├── columns: upsert_x:17 upsert_v:18!null upsert_w:19 column1:6!null v_cast:8!null w_default:9 x:10 v:11 w:12 crdb_internal_mvcc_timestamp:13 tableoid:14 v_cast:16!null
@@ -246,11 +254,13 @@ insert t
  ├── vector index put quantized vector columns: vector_index_put_quantized_vec1:12 vector_index_put_quantized_vec2:14
  └── vector-mutation-search t@t_w_idx,vector
       ├── columns: column1:6!null v_cast:9!null w_cast:10!null vector_index_put_partition1:11 vector_index_put_quantized_vec1:12 vector_index_put_partition2:13 vector_index_put_quantized_vec2:14
+      ├── index put
       ├── query vector column: w_cast:10
       ├── partition col: vector_index_put_partition2:13
       ├── quantized vector col: vector_index_put_quantized_vec2:14
       └── vector-mutation-search t@t_v_idx,vector
            ├── columns: column1:6!null v_cast:9!null w_cast:10!null vector_index_put_partition1:11 vector_index_put_quantized_vec1:12
+           ├── index put
            ├── query vector column: v_cast:9
            ├── partition col: vector_index_put_partition1:11
            ├── quantized vector col: vector_index_put_quantized_vec1:12
@@ -280,23 +290,27 @@ update t
  ├── vector index put quantized vector columns: vector_index_put_quantized_vec1:17 vector_index_put_quantized_vec2:20
  └── vector-mutation-search t@t_w_idx,vector
       ├── columns: x:6!null v:7 w:8 crdb_internal_mvcc_timestamp:9 tableoid:10 v_cast:13!null w_cast:14!null vector_index_del_partition1:15 vector_index_put_partition1:16 vector_index_put_quantized_vec1:17 vector_index_del_partition2:18 vector_index_put_partition2:19 vector_index_put_quantized_vec2:20
+      ├── index put
       ├── query vector column: w_cast:14
       ├── partition col: vector_index_put_partition2:19
       ├── quantized vector col: vector_index_put_quantized_vec2:20
       └── vector-mutation-search t@t_w_idx,vector
            ├── columns: x:6!null v:7 w:8 crdb_internal_mvcc_timestamp:9 tableoid:10 v_cast:13!null w_cast:14!null vector_index_del_partition1:15 vector_index_put_partition1:16 vector_index_put_quantized_vec1:17 vector_index_del_partition2:18
+           ├── index del
            ├── query vector column: w:8
-           ├── primary key columns: (6)
+           ├── suffix key columns: [6]
            ├── partition col: vector_index_del_partition2:18
            └── vector-mutation-search t@t_v_idx,vector
                 ├── columns: x:6!null v:7 w:8 crdb_internal_mvcc_timestamp:9 tableoid:10 v_cast:13!null w_cast:14!null vector_index_del_partition1:15 vector_index_put_partition1:16 vector_index_put_quantized_vec1:17
+                ├── index put
                 ├── query vector column: v_cast:13
                 ├── partition col: vector_index_put_partition1:16
                 ├── quantized vector col: vector_index_put_quantized_vec1:17
                 └── vector-mutation-search t@t_v_idx,vector
                      ├── columns: x:6!null v:7 w:8 crdb_internal_mvcc_timestamp:9 tableoid:10 v_cast:13!null w_cast:14!null vector_index_del_partition1:15
+                     ├── index del
                      ├── query vector column: v:7
-                     ├── primary key columns: (6)
+                     ├── suffix key columns: [6]
                      ├── partition col: vector_index_del_partition1:15
                      └── project
                           ├── columns: v_cast:13!null w_cast:14!null x:6!null v:7 w:8 crdb_internal_mvcc_timestamp:9 tableoid:10
@@ -327,13 +341,15 @@ delete t
  ├── vector index del partition columns: vector_index_del_partition1:11 vector_index_del_partition2:12
  └── vector-mutation-search t@t_w_idx,vector
       ├── columns: x:6!null v:7 w:8 crdb_internal_mvcc_timestamp:9 tableoid:10 vector_index_del_partition1:11 vector_index_del_partition2:12
+      ├── index del
       ├── query vector column: w:8
-      ├── primary key columns: (6)
+      ├── suffix key columns: [6]
       ├── partition col: vector_index_del_partition2:12
       └── vector-mutation-search t@t_v_idx,vector
            ├── columns: x:6!null v:7 w:8 crdb_internal_mvcc_timestamp:9 tableoid:10 vector_index_del_partition1:11
+           ├── index del
            ├── query vector column: v:7
-           ├── primary key columns: (6)
+           ├── suffix key columns: [6]
            ├── partition col: vector_index_del_partition1:11
            └── select
                 ├── columns: x:6!null v:7 w:8 crdb_internal_mvcc_timestamp:9 tableoid:10
@@ -363,23 +379,27 @@ upsert t
  ├── vector index put quantized vector columns: vector_index_put_quantized_vec1:19 vector_index_put_quantized_vec2:22
  └── vector-mutation-search t@t_w_idx,vector
       ├── columns: column1:6!null v_cast:9!null w_cast:10!null x:11 v:12 w:13 crdb_internal_mvcc_timestamp:14 tableoid:15 upsert_x:16 vector_index_del_partition1:17 vector_index_put_partition1:18 vector_index_put_quantized_vec1:19 vector_index_del_partition2:20 vector_index_put_partition2:21 vector_index_put_quantized_vec2:22
+      ├── index put
       ├── query vector column: w_cast:10
       ├── partition col: vector_index_put_partition2:21
       ├── quantized vector col: vector_index_put_quantized_vec2:22
       └── vector-mutation-search t@t_w_idx,vector
            ├── columns: column1:6!null v_cast:9!null w_cast:10!null x:11 v:12 w:13 crdb_internal_mvcc_timestamp:14 tableoid:15 upsert_x:16 vector_index_del_partition1:17 vector_index_put_partition1:18 vector_index_put_quantized_vec1:19 vector_index_del_partition2:20
+           ├── index del
            ├── query vector column: w:13
-           ├── primary key columns: (11)
+           ├── suffix key columns: [11]
            ├── partition col: vector_index_del_partition2:20
            └── vector-mutation-search t@t_v_idx,vector
                 ├── columns: column1:6!null v_cast:9!null w_cast:10!null x:11 v:12 w:13 crdb_internal_mvcc_timestamp:14 tableoid:15 upsert_x:16 vector_index_del_partition1:17 vector_index_put_partition1:18 vector_index_put_quantized_vec1:19
+                ├── index put
                 ├── query vector column: v_cast:9
                 ├── partition col: vector_index_put_partition1:18
                 ├── quantized vector col: vector_index_put_quantized_vec1:19
                 └── vector-mutation-search t@t_v_idx,vector
                      ├── columns: column1:6!null v_cast:9!null w_cast:10!null x:11 v:12 w:13 crdb_internal_mvcc_timestamp:14 tableoid:15 upsert_x:16 vector_index_del_partition1:17
+                     ├── index del
                      ├── query vector column: v:12
-                     ├── primary key columns: (11)
+                     ├── suffix key columns: [11]
                      ├── partition col: vector_index_del_partition1:17
                      └── project
                           ├── columns: upsert_x:16 column1:6!null v_cast:9!null w_cast:10!null x:11 v:12 w:13 crdb_internal_mvcc_timestamp:14 tableoid:15
@@ -433,23 +453,27 @@ upsert t
  ├── vector index put quantized vector columns: vector_index_put_quantized_vec1:25 vector_index_put_quantized_vec2:28
  └── vector-mutation-search t@t_w_idx,vector
       ├── columns: column1:6!null v_cast:9!null w_cast:10!null x:11 v:12 w:13 crdb_internal_mvcc_timestamp:14 tableoid:15 v_cast:18!null w_cast:19!null upsert_x:20 upsert_v:21!null upsert_w:22!null vector_index_del_partition1:23 vector_index_put_partition1:24 vector_index_put_quantized_vec1:25 vector_index_del_partition2:26 vector_index_put_partition2:27 vector_index_put_quantized_vec2:28
+      ├── index put
       ├── query vector column: upsert_w:22
       ├── partition col: vector_index_put_partition2:27
       ├── quantized vector col: vector_index_put_quantized_vec2:28
       └── vector-mutation-search t@t_w_idx,vector
            ├── columns: column1:6!null v_cast:9!null w_cast:10!null x:11 v:12 w:13 crdb_internal_mvcc_timestamp:14 tableoid:15 v_cast:18!null w_cast:19!null upsert_x:20 upsert_v:21!null upsert_w:22!null vector_index_del_partition1:23 vector_index_put_partition1:24 vector_index_put_quantized_vec1:25 vector_index_del_partition2:26
+           ├── index del
            ├── query vector column: w:13
-           ├── primary key columns: (11)
+           ├── suffix key columns: [11]
            ├── partition col: vector_index_del_partition2:26
            └── vector-mutation-search t@t_v_idx,vector
                 ├── columns: column1:6!null v_cast:9!null w_cast:10!null x:11 v:12 w:13 crdb_internal_mvcc_timestamp:14 tableoid:15 v_cast:18!null w_cast:19!null upsert_x:20 upsert_v:21!null upsert_w:22!null vector_index_del_partition1:23 vector_index_put_partition1:24 vector_index_put_quantized_vec1:25
+                ├── index put
                 ├── query vector column: upsert_v:21
                 ├── partition col: vector_index_put_partition1:24
                 ├── quantized vector col: vector_index_put_quantized_vec1:25
                 └── vector-mutation-search t@t_v_idx,vector
                      ├── columns: column1:6!null v_cast:9!null w_cast:10!null x:11 v:12 w:13 crdb_internal_mvcc_timestamp:14 tableoid:15 v_cast:18!null w_cast:19!null upsert_x:20 upsert_v:21!null upsert_w:22!null vector_index_del_partition1:23
+                     ├── index del
                      ├── query vector column: v:12
-                     ├── primary key columns: (11)
+                     ├── suffix key columns: [11]
                      ├── partition col: vector_index_del_partition1:23
                      └── project
                           ├── columns: upsert_x:20 upsert_v:21!null upsert_w:22!null column1:6!null v_cast:9!null w_cast:10!null x:11 v:12 w:13 crdb_internal_mvcc_timestamp:14 tableoid:15 v_cast:18!null w_cast:19!null
@@ -512,13 +536,15 @@ update t
  ├── vector index put quantized vector columns: vector_index_put_quantized_vec1:16
  └── vector-mutation-search t@t_v_idx,vector
       ├── columns: x:6!null v:7 w:8 crdb_internal_mvcc_timestamp:9 tableoid:10 x_new:11!null v_cast:13!null vector_index_del_partition1:14 vector_index_put_partition1:15 vector_index_put_quantized_vec1:16
+      ├── index put
       ├── query vector column: v_cast:13
       ├── partition col: vector_index_put_partition1:15
       ├── quantized vector col: vector_index_put_quantized_vec1:16
       └── vector-mutation-search t@t_v_idx,vector
            ├── columns: x:6!null v:7 w:8 crdb_internal_mvcc_timestamp:9 tableoid:10 x_new:11!null v_cast:13!null vector_index_del_partition1:14
+           ├── index del
            ├── query vector column: v:7
-           ├── primary key columns: (6)
+           ├── suffix key columns: [6]
            ├── partition col: vector_index_del_partition1:14
            └── project
                 ├── columns: v_cast:13!null x:6!null v:7 w:8 crdb_internal_mvcc_timestamp:9 tableoid:10 x_new:11!null

--- a/pkg/sql/opt/optbuilder/update.go
+++ b/pkg/sql/opt/optbuilder/update.go
@@ -347,7 +347,7 @@ func (mb *mutationBuilder) buildUpdate(returning *tree.ReturningExprs) {
 	mb.projectPartialIndexPutAndDelCols()
 
 	// Project vector index PUT and DEL columns.
-	mb.projectVectorIndexCols()
+	mb.projectVectorIndexCols(opt.UpdateOp)
 
 	mb.buildUniqueChecksForUpdate()
 

--- a/pkg/sql/opt/xform/limit_funcs.go
+++ b/pkg/sql/opt/xform/limit_funcs.go
@@ -469,14 +469,17 @@ func (c *CustomFuncs) TryGenerateVectorSearch(
 			// This index is for a different vector column.
 			return
 		}
+		var prefixVals memo.ScalarListExpr
 		if index.PrefixColumnCount() > 0 {
 			// TODO(drewk, mw5h): support multi-column vector indexes.
 			return
 		}
+
 		// VectorSearch operators return the primary-key columns.
 		limitInt := int64(*limit.(*tree.DInt))
 		indexCols := c.PrimaryKeyCols(sp.Table)
-		vectorSearch := c.e.f.ConstructVectorSearch(queryVector,
+		vectorSearch := c.e.f.ConstructVectorSearch(
+			prefixVals, queryVector,
 			&memo.VectorSearchPrivate{
 				Table:               sp.Table,
 				Index:               index.Ordinal(),


### PR DESCRIPTION
#### optbuilder: fix suffix column handling

This commit renames the `PrimaryKeyCols` field of `VectorMutationSearch`
to `SuffixKeyCols`, since the suffix doesn't necessarily contain the
entire primary key. It also changes the field from a `ColSet` to a
`ColList`. This will be necessary to correctly handle multi-column
suffixes, since the ordering of the columns is important.

Epic: CRDB-42943

Release note: None

#### opt/optbuilder: fix vector index mutation planning

Previously, the vector-mutation-search planning logic only checked if
the vector column was updated. This meant that it could fail to detect
that a different index column was updated (prefix or suffix). This commit
fixes the bug and adds proper handling for prefix columns.

Epic: CRDB-42943

Release note: None

#### opt: improve vector search prefix value handling

This commit changes the `PrefixConstraint` field of `VectorSearch`
operators to a `ScalarListExpr` which contains a constant or placeholder
expression for each vector index prefix column. The generality of a full
constraint is unnecessary because the prefix columns must all be
constrained to a single value. This will simplify plumbing into the
execution engine.

Epic: CRDB-42943

Release note: None