### PR TITLE
server: purge jemalloc when cgo mem overhead is high

### DIFF
--- a/pkg/server/env_sampler.go
+++ b/pkg/server/env_sampler.go
@@ -39,27 +39,23 @@ type sampleEnvironmentCfg struct {
 // when appropriate, creates goroutine and/or heap dumps.
 func startSampleEnvironment(
 	ctx context.Context,
-	settings *cluster.Settings,
+	srvCfg *BaseConfig,
 	stopper *stop.Stopper,
-	goroutineDumpDirName string,
-	heapProfileDirName string,
-	cpuProfileDirName string,
 	runtimeSampler *status.RuntimeStatSampler,
 	sessionRegistry *sql.SessionRegistry,
 	rootMemMonitor *mon.BytesMonitor,
-	testingKnobs base.TestingKnobs,
 ) error {
 	metricsSampleInterval := base.DefaultMetricsSampleInterval
-	if p, ok := testingKnobs.Server.(*TestingKnobs); ok && p.EnvironmentSampleInterval != time.Duration(0) {
+	if p, ok := srvCfg.TestingKnobs.Server.(*TestingKnobs); ok && p.EnvironmentSampleInterval != time.Duration(0) {
 		metricsSampleInterval = p.EnvironmentSampleInterval
 	}
 	cfg := sampleEnvironmentCfg{
-		st:                   settings,
+		st:                   srvCfg.Settings,
 		stopper:              stopper,
 		minSampleInterval:    metricsSampleInterval,
-		goroutineDumpDirName: goroutineDumpDirName,
-		heapProfileDirName:   heapProfileDirName,
-		cpuProfileDirName:    cpuProfileDirName,
+		goroutineDumpDirName: srvCfg.GoroutineDumpDirName,
+		heapProfileDirName:   srvCfg.HeapProfileDirName,
+		cpuProfileDirName:    srvCfg.CPUProfileDirName,
 		runtime:              runtimeSampler,
 		sessionRegistry:      sessionRegistry,
 		rootMemMonitor:       rootMemMonitor,

--- a/pkg/server/env_sampler.go
+++ b/pkg/server/env_sampler.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/server/goroutinedumper"
 	"github.com/cockroachdb/cockroach/pkg/server/profiler"
 	"github.com/cockroachdb/cockroach/pkg/server/status"
+	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -21,6 +22,22 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
+)
+
+var jemallocPurgeOverhead = settings.RegisterIntSetting(
+	settings.SystemVisible,
+	"server.jemalloc_purge_overhead_percent",
+	"a purge of jemalloc dirty pages is issued once the overhead exceeds this percent (0 disables purging)",
+	20,
+	settings.NonNegativeInt,
+)
+
+var jemallocPurgePeriod = settings.RegisterDurationSettingWithExplicitUnit(
+	settings.SystemVisible,
+	"server.jemalloc_purge_period",
+	"minimum amount of time that must pass between two jemalloc dirty page purges (0 disables purging)",
+	2*time.Minute,
+	settings.NonNegativeDuration,
 )
 
 type sampleEnvironmentCfg struct {
@@ -33,13 +50,17 @@ type sampleEnvironmentCfg struct {
 	runtime              *status.RuntimeStatSampler
 	sessionRegistry      *sql.SessionRegistry
 	rootMemMonitor       *mon.BytesMonitor
+	cgoMemTarget         uint64
 }
 
 // startSampleEnvironment starts a periodic loop that samples the environment and,
 // when appropriate, creates goroutine and/or heap dumps.
+//
+// The pebbleCacheSize is used to determine a target for CGO memory allocation.
 func startSampleEnvironment(
 	ctx context.Context,
 	srvCfg *BaseConfig,
+	pebbleCacheSize int64,
 	stopper *stop.Stopper,
 	runtimeSampler *status.RuntimeStatSampler,
 	sessionRegistry *sql.SessionRegistry,
@@ -59,6 +80,7 @@ func startSampleEnvironment(
 		runtime:              runtimeSampler,
 		sessionRegistry:      sessionRegistry,
 		rootMemMonitor:       rootMemMonitor,
+		cgoMemTarget:         max(uint64(pebbleCacheSize), 128*1024*1024),
 	}
 	// Immediately record summaries once on server startup.
 
@@ -151,6 +173,11 @@ func startSampleEnvironment(
 
 					cgoStats := status.GetCGoMemStats(ctx)
 					cfg.runtime.SampleEnvironment(ctx, cgoStats)
+
+					// Maybe purge jemalloc dirty pages.
+					if overhead, period := jemallocPurgeOverhead.Get(&cfg.st.SV), jemallocPurgePeriod.Get(&cfg.st.SV); overhead > 0 && period > 0 {
+						status.CGoMemMaybePurge(ctx, cgoStats.CGoAllocatedBytes, cgoStats.CGoTotalBytes, cfg.cgoMemTarget, int(overhead), period)
+					}
 
 					if goroutineDumper != nil {
 						goroutineDumper.MaybeDump(ctx, cfg.st, cfg.runtime.Goroutines.Value())

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1876,15 +1876,11 @@ func (s *topLevelServer) PreStart(ctx context.Context) error {
 
 	// Begin recording runtime statistics.
 	if err := startSampleEnvironment(workersCtx,
-		s.ClusterSettings(),
+		&s.cfg.BaseConfig,
 		s.stopper,
-		s.cfg.GoroutineDumpDirName,
-		s.cfg.HeapProfileDirName,
-		s.cfg.CPUProfileDirName,
 		s.runtime,
 		s.status.sessionRegistry,
 		s.sqlServer.execCfg.RootMemoryMonitor,
-		s.cfg.TestingKnobs,
 	); err != nil {
 		return err
 	}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1877,6 +1877,7 @@ func (s *topLevelServer) PreStart(ctx context.Context) error {
 	// Begin recording runtime statistics.
 	if err := startSampleEnvironment(workersCtx,
 		&s.cfg.BaseConfig,
+		s.cfg.CacheSize,
 		s.stopper,
 		s.runtime,
 		s.status.sessionRegistry,

--- a/pkg/server/status/BUILD.bazel
+++ b/pkg/server/status/BUILD.bazel
@@ -70,6 +70,7 @@ go_library(
         "//pkg/util/metric",
         "//pkg/util/syncutil",
         "//pkg/util/system",
+        "@com_github_cockroachdb_crlib//crtime",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_redact//:redact",
         "@com_github_dustin_go_humanize//:go-humanize",

--- a/pkg/server/tenant.go
+++ b/pkg/server/tenant.go
@@ -759,6 +759,7 @@ func (s *SQLServerWrapper) PreStart(ctx context.Context) error {
 		// Begin recording runtime statistics.
 		if err := startSampleEnvironment(workersCtx,
 			s.sqlServer.cfg,
+			0, /* pebbleCacheSize */
 			s.stopper,
 			s.runtime,
 			s.tenantStatus.sessionRegistry,

--- a/pkg/server/tenant.go
+++ b/pkg/server/tenant.go
@@ -758,15 +758,11 @@ func (s *SQLServerWrapper) PreStart(ctx context.Context) error {
 	if !s.sqlServer.cfg.DisableRuntimeStatsMonitor {
 		// Begin recording runtime statistics.
 		if err := startSampleEnvironment(workersCtx,
-			s.ClusterSettings(),
+			s.sqlServer.cfg,
 			s.stopper,
-			s.sqlServer.cfg.GoroutineDumpDirName,
-			s.sqlServer.cfg.HeapProfileDirName,
-			s.sqlServer.cfg.CPUProfileDirName,
 			s.runtime,
 			s.tenantStatus.sessionRegistry,
 			s.sqlServer.execCfg.RootMemoryMonitor,
-			s.cfg.TestingKnobs,
 		); err != nil {
 			return err
 		}


### PR DESCRIPTION
#### server: pass BaseConfig to startSampleEnvironment

Epic: none
Release note: None

#### server: purge jemalloc when cgo mem overhead is high

Whenever we sample the environment (every 10s by default), we check if
the CGo overhead is above 20%; in which case we tell jemalloc to purge
dirty pages. We limit the frequency of the purges to one every 2
minutes (these settings are configurable).

This is meant to be a backup safety mechanism to avoid OOMs. With the
updated jemalloc default configuration, I don't expect this to happen
much in practice (if at all).

Fixes: #141379
Release note: None

---

Here is an example of a 30min TPCC run (left is master, right is with the change). I used a terrible malloc conf (`background_thread:false,dirty_decay_ms:1000000,muzzy_decay_ms:500000,narenas:128`) to get a lot of overhead. The overhead graphs show the CGo Total minus 7.6GB which is the high watermark for CGO Alloc. The purge happens when the overhead goes above ~1.5Gb.

<img width="1116" alt="image" src="https://github.com/user-attachments/assets/dc32b081-88a3-4284-9880-33e2f7d82679" />


Purge logs from one of the nodes:
```
295:I250216 18:24:27.988224 546 server/status/runtime_jemalloc.go:191 ⋮ [T1,Vsystem,n1] 185  jemalloc arenas purged (took 203.915292ms)
303:I250216 18:29:18.462705 546 server/status/runtime_jemalloc.go:191 ⋮ [T1,Vsystem,n1] 193  jemalloc arenas purged (took 206.945658ms)
307:I250216 18:35:38.638441 546 server/status/runtime_jemalloc.go:191 ⋮ [T1,Vsystem,n1] 197  jemalloc arenas purged (took 235.908998ms)
311:I250216 18:42:28.758720 546 server/status/runtime_jemalloc.go:191 ⋮ [T1,Vsystem,n1] 201  jemalloc arenas purged (took 245.213056ms)
323:I250216 18:48:58.986148 546 server/status/runtime_jemalloc.go:191 ⋮ [T1,Vsystem,n1] 213  jemalloc arenas purged (took 98.60313ms)
```

