### PR TITLE
scripts: update tc-trigger-pr to also trigger arbitrary master SHAs

### DIFF
--- a/scripts/trigger-pr-roachtest.sh
+++ b/scripts/trigger-pr-roachtest.sh
@@ -9,49 +9,87 @@ set -euo pipefail
 
 token=${TEAMCITY_TOKEN-}
 if [ -z $token ]; then
-	cat <<EOF
+  cat <<EOF
 TEAMCITY_TOKEN not set. Get one here:
 
 https://teamcity.cockroachdb.com/profile.html?item=accessTokens
 EOF
-	exit 1
+  exit 1
 fi
 
 pr=${1-}
 
-while [ -z $pr ] || ! [[ $pr =~ ^[0-9]+$ ]]; do
-	read -p 'PR number (defaults to first arg): ' pr
+while [ -z $pr ]; do
+  read -p 'PR number (defaults to first arg, can also use branch name): ' pr
 done
 
 tests=${2-}
 
-while [ -z $tests ]; do
-	read -p 'Regexp (defaults to second arg): ' tests
+while [ -z "$tests" ]; do
+  read -p 'Test Regexp (defaults to second arg): ' tests
 done
+
+sha=${3-}
+if [ -z "${sha}" ]; then
+  read -p 'Long Commit SHA (defaults to third arg, empty for latest changes): ' sha
+fi
+
+dump_json() {
+  if echo "$1" | jq '.' >/dev/null 2>&1; then
+    echo "$1" | jq '.'
+  else
+    echo "$1"
+  fi
+}
 
 json_payload=$(jq -n \
   --arg branch_name "$pr" \
   --arg tests "$tests" \
-  --arg branch_name "$pr" \
-  '
-{
+  --arg envDebug "${DEBUG-false}" \
+  --arg envCount "${COUNT-1}" \
+  '{
   buildType: {id: "Cockroach_Nightlies_RoachtestNightlyGceBazel"},
   branchName: $branch_name,
   properties: {
     property: [
       {name: "env.ARM_PROBABILITY", value: "0"},
       {name: "env.COCKROACH_EA_PROBABILITY", value: "0"},
-      {name: "env.DEBUG", value: "true"},
+      {name: "env.DEBUG", value: $envDebug},
+      {name: "env.COUNT", value: $envCount},
       {name: "env.TESTS", value: $tests}
     ]
   }
 }')
 
-curl -ss -X POST \
+if [ -n "${sha}" ]; then
+  json_payload=$(echo "${json_payload}" | jq \
+    --arg branch_name "$pr" \
+    --arg sha "$sha" \
+    '. + {
+  revisions: {
+    revision: [
+      {
+        version: $sha,
+        vcsBranchName: ("refs/heads/" + $branch_name),
+        "vcs-root-instance": {
+          "vcs-root-id": "Cockroach_Cockroach"
+        }
+      }
+    ]
+  }
+}')
+fi
+
+echo "Input:"
+dump_json "$json_payload"
+echo "======================================="
+echo "Output:"
+result=$(curl -ss -X POST \
   https://teamcity.cockroachdb.com/app/rest/buildQueue \
   -H 'Content-Type: application/json' \
   -H 'Accept: application/json' \
   -H "Authorization: Bearer $token" \
-  -d "$json_payload" | jq -r '.webUrl'
-
-
+  -d "$json_payload")
+dump_json "$result"
+echo "======================================="
+echo "${result}" | jq -r '.webUrl' 2>/dev/null


### PR DESCRIPTION
The following worked before:

```
$0 <prnumber> <regexp>

Now you can trigger builds on all branches for specific commits:

$0 release-24.2 <regexp>             # latest commit
$0 release-24.2 <regexp> <commitsha> # specific commit
$0 <prnumber> <regexp> <sha>         # specific commit in PR
```

This can help bisect roachtest failures more efficiently.

Epic: none
Release note: None