### PR TITLE
microbench-ci: missing metrics warning

### DIFF
--- a/pkg/cmd/microbench-ci/compare.go
+++ b/pkg/cmd/microbench-ci/compare.go
@@ -43,6 +43,9 @@ func (c *CompareResult) status(metricName string) Status {
 		return NoChange
 	}
 	cc := entry.ComputeComparison(c.EntryName, string(Old), string(New))
+	if cc == nil {
+		return NoChange
+	}
 	status := NoChange
 	threshold := c.Benchmark.Thresholds[metricName] * 100.0
 	if cc.Delta*float64(entry.Better) > 0 {

--- a/pkg/cmd/microbench-ci/report.go
+++ b/pkg/cmd/microbench-ci/report.go
@@ -9,6 +9,7 @@ import (
 	_ "embed"
 	"encoding/json"
 	"fmt"
+	"log"
 	"math"
 	"os"
 	"sort"
@@ -58,6 +59,10 @@ func (c *CompareResult) generateSummaryData(
 	for metricName, entry := range c.MetricMap {
 		benchmark := entry.BenchmarkEntries[c.EntryName]
 		cc := entry.ComputeComparison(c.EntryName, string(Old), string(New))
+		if cc == nil {
+			log.Printf("WARN: no comparison found for benchmark metric %q:%q", c.EntryName, metricName)
+			continue
+		}
 		threshold := c.Benchmark.Thresholds[metricName] * 100.0
 		status := statusTemplateFunc(c.status(metricName))
 		oldSum := benchmark.Summaries[string(Old)]

--- a/pkg/cmd/microbench-ci/testdata/summary.txt
+++ b/pkg/cmd/microbench-ci/testdata/summary.txt
@@ -17,16 +17,16 @@ benchmarks:
 ----
 
 logs name=BenchmarkSysbench/SQL/3node/oltp_read_write path=/abcdef123/bin/pkg_sql_tests
-BenchmarkSysbench/SQL/3node/oltp_read_write-16 2500 9852036 ns/op 2368213 B/op 10378 allocs/op
-BenchmarkSysbench/SQL/3node/oltp_read_write-16 2500 9852036 ns/op 2375306 B/op 10377 allocs/op
-BenchmarkSysbench/SQL/3node/oltp_read_write-16 2500 9852036 ns/op 2358650 B/op 10287 allocs/op
-BenchmarkSysbench/SQL/3node/oltp_read_write-16 2500 9982428 ns/op 2370670 B/op 10411 allocs/op
-BenchmarkSysbench/SQL/3node/oltp_read_write-16 2500 9926623 ns/op 2367582 B/op 10386 allocs/op
-BenchmarkSysbench/SQL/3node/oltp_read_write-16 2500 9898707 ns/op 2365463 B/op 10398 allocs/op
-BenchmarkSysbench/SQL/3node/oltp_read_write-16 2500 9879350 ns/op 2364281 B/op 10361 allocs/op
-BenchmarkSysbench/SQL/3node/oltp_read_write-16 2500 9808429 ns/op 2352326 B/op 10246 allocs/op
-BenchmarkSysbench/SQL/3node/oltp_read_write-16 2500 9849367 ns/op 2369187 B/op 10379 allocs/op
-BenchmarkSysbench/SQL/3node/oltp_read_write-16 2500 9872510 ns/op 2367752 B/op 10392 allocs/op
+BenchmarkSysbench/SQL/3node/oltp_read_write-16 2500 9852036 ns/op 2368213 B/op 10378 allocs/op 0 errs/op
+BenchmarkSysbench/SQL/3node/oltp_read_write-16 2500 9852036 ns/op 2375306 B/op 10377 allocs/op 0 errs/op
+BenchmarkSysbench/SQL/3node/oltp_read_write-16 2500 9852036 ns/op 2358650 B/op 10287 allocs/op 0 errs/op
+BenchmarkSysbench/SQL/3node/oltp_read_write-16 2500 9982428 ns/op 2370670 B/op 10411 allocs/op 0 errs/op
+BenchmarkSysbench/SQL/3node/oltp_read_write-16 2500 9926623 ns/op 2367582 B/op 10386 allocs/op 0 errs/op
+BenchmarkSysbench/SQL/3node/oltp_read_write-16 2500 9898707 ns/op 2365463 B/op 10398 allocs/op 0 errs/op
+BenchmarkSysbench/SQL/3node/oltp_read_write-16 2500 9879350 ns/op 2364281 B/op 10361 allocs/op 0 errs/op
+BenchmarkSysbench/SQL/3node/oltp_read_write-16 2500 9808429 ns/op 2352326 B/op 10246 allocs/op 0 errs/op
+BenchmarkSysbench/SQL/3node/oltp_read_write-16 2500 9849367 ns/op 2369187 B/op 10379 allocs/op 0 errs/op
+BenchmarkSysbench/SQL/3node/oltp_read_write-16 2500 9872510 ns/op 2367752 B/op 10392 allocs/op 0 errs/op
 
 ----
 


### PR DESCRIPTION
Previously, if a new metric is added to one of the benchmarks in the CI suite a panic occurred if it was missing from the base revision. This change causes a warning to be printed, and the metric will be disregarded until it becomes available in the base branch.

Epic: None
Release note: None