### PR TITLE
kvserver/rangefeed: lift CrdbTestBuild on RangefeedUseBufferedSender

### DIFF
--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -931,16 +931,10 @@ func (r *testRunner) runWorker(
 				}
 
 				// 50% chance of enabling the rangefeed buffered sender. Disabled by
-				// default. This is the reason we check for run time assertions rather
-				// than using rand:
-				// 1. The cluster setting RangefeedUseBufferedSender validation will fail
-				// if buildutil.CrdbTestBuild tag is not set.
-				// 2. There is a 50% chance that the cockroach binary used in roachtests
-				// includes the buildutil.CrdbTestBuild tag. And runtime assertion is
-				// enabled if and only if cockroach binaries used in roachtests include
-				// the buildutil.CrdbTestBuild tag.
-				useBufferedSender := roachtestutil.UsingRuntimeAssertions(t)
-				if useBufferedSender {
+				// default. Disabled for mixed-version tests since this cluster setting
+				// is only supported in >= v25.2.
+				useBufferedSender := prng.Intn(2) == 0
+				if !t.spec.Suites.Contains(registry.MixedVersion) && useBufferedSender {
 					c.clusterSettings["kv.rangefeed.buffered_sender.enabled"] = "true"
 				}
 				c.status(fmt.Sprintf("metamorphically using buffered sender: %t", useBufferedSender))

--- a/pkg/kv/kvserver/BUILD.bazel
+++ b/pkg/kv/kvserver/BUILD.bazel
@@ -214,7 +214,6 @@ go_library(
         "//pkg/util/encoding",
         "//pkg/util/envutil",
         "//pkg/util/errorutil",
-        "//pkg/util/errorutil/unimplemented",
         "//pkg/util/growstack",
         "//pkg/util/grpcutil",
         "//pkg/util/grunning",

--- a/pkg/kv/kvserver/replica_rangefeed.go
+++ b/pkg/kv/kvserver/replica_rangefeed.go
@@ -25,9 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/fs"
 	"github.com/cockroachdb/cockroach/pkg/util/admission"
 	"github.com/cockroachdb/cockroach/pkg/util/admission/admissionpb"
-	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
-	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/limit"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -86,9 +84,6 @@ var RangeFeedUseScheduler = settings.RegisterBoolSetting(
 	settings.Retired,
 )
 
-var ErrBufferedSenderNotSupported = unimplemented.NewWithIssue(
-	126560, "buffered stream sender not supported for production use")
-
 // RangefeedUseBufferedSender controls whether rangefeed uses a node level
 // buffered sender to buffer events instead of buffering events separately in a
 // channel at a per client per registration level.
@@ -98,12 +93,6 @@ var RangefeedUseBufferedSender = settings.RegisterBoolSetting(
 	"use buffered sender for all range feeds instead of buffering events "+
 		"separately per client per range",
 	metamorphic.ConstantWithTestBool("kv.rangefeed.buffered_sender.enabled", false),
-	settings.WithValidateBool(func(_ *settings.Values, b bool) error {
-		if buildutil.CrdbTestBuild || !b {
-			return nil
-		}
-		return ErrBufferedSenderNotSupported
-	}),
 )
 
 func init() {


### PR DESCRIPTION
**kvserver/rangefeed: lift CrdbTestBuild on RangefeedUseBufferedSender**

This patch removes the buildutil.CRDBTestBuild check for
RangefeedUseBufferedSender, as the feature is now fully
implemented and safe to use without causing panics.

Epic: none
Release note: none

---

**roachtest: use prng to enable RangefeedUseBufferedSender**

Previously, we used UsingRuntimeAssertions to determine whether
to enable RangefeedUseBufferedSender because it was gated behind
the CRDBTestBuild flag. Now that this check has been removed,
we can use prng to enable the cluster setting 50% of the time.

Note that we still need to avoid enabling the cluster setting
for mixed-version roachtests to prevent it from being applied
to versions that enforce this restriction.

Epic: none
Fixes: #141478
Fixes: #141470
Fixes: #141494
Fixes: #141476
FIxes: #141466
Fixes: #141470
Fixes: #141471
Fixes: #141475
Fixes: #141465
