### PR TITLE
drtprod: datadog api key in remote VM

### DIFF
--- a/pkg/cmd/drtprod/configs/drt_remote.yaml
+++ b/pkg/cmd/drtprod/configs/drt_remote.yaml
@@ -25,3 +25,4 @@ targets:
       - command: sync
         flags:
           clouds: gce
+      - script: pkg/cmd/drtprod/scripts/add_dd_api_key_to_bash.sh

--- a/pkg/cmd/drtprod/scripts/add_dd_api_key_to_bash.sh
+++ b/pkg/cmd/drtprod/scripts/add_dd_api_key_to_bash.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Copyright 2025 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+# this script adds the datadog api key as environment variable "DD_API_KEY" in .bashrc of drt remote VM
+
+if [ -z "${MONITOR_CLUSTER}" ]; then
+  echo "environment MONITOR_CLUSTER is not set"
+  exit 1
+fi
+
+
+# API key value (replace with your actual key)
+DD_API_KEY="$(gcloud --project=cockroach-drt secrets versions access latest --secret datadog-api-key)"
+
+drtprod ssh "${MONITOR_CLUSTER}" -- "echo export DD_API_KEY=\"${DD_API_KEY}\" >> \$HOME/.bashrc"

--- a/pkg/cmd/drtprod/scripts/create_run_operation.sh
+++ b/pkg/cmd/drtprod/scripts/create_run_operation.sh
@@ -23,10 +23,11 @@ if [ -z "${WORKLOAD_CLUSTER}" ]; then
   echo "environment CLUSTER is not set"
   exit 1
 fi
+if [ -z "${DD_API_KEY}" ]; then
+  DD_API_KEY="$(gcloud --project=cockroach-drt secrets versions access latest --secret datadog-api-key)"
+fi
 
-dd_api_key="$(gcloud --project=cockroach-drt secrets versions access latest --secret datadog-api-key)"
-
-if [ -z "${dd_api_key}" ]; then
+if [ -z "${DD_API_KEY}" ]; then
   echo "Missing Datadog API key!"
   exit 1
 fi
@@ -56,7 +57,7 @@ for entry in "$@"; do
 
 export ROACHPROD_GCE_DEFAULT_PROJECT=${ROACHPROD_GCE_DEFAULT_PROJECT}
 export ROACHPROD_DNS=${ROACHPROD_DNS}
-${pwd}/roachtest-operations run-operation ${CLUSTER} \"${operation_regex}\" --datadog-api-key ${dd_api_key} \
+${pwd}/roachtest-operations run-operation ${CLUSTER} \"${operation_regex}\" --datadog-api-key ${DD_API_KEY} \
 --datadog-tags env:development,cluster:${WORKLOAD_CLUSTER},team:drt,service:drt-cockroachdb \
 --datadog-app-key 1 --certs-dir ./certs  | tee -a roachtest_ops_${identifier}.log
 EOF"

--- a/pkg/cmd/drtprod/scripts/setup_datadog_cluster
+++ b/pkg/cmd/drtprod/scripts/setup_datadog_cluster
@@ -8,9 +8,11 @@ if [ -z "${CLUSTER}" ]; then
   exit 1
 fi
 
-dd_api_key="$(gcloud --project=cockroach-drt secrets versions access latest --secret datadog-api-key)"
+if [ -z "${DD_API_KEY}" ]; then
+  DD_API_KEY="$(gcloud --project=cockroach-drt secrets versions access latest --secret datadog-api-key)"
+fi
 
-if [ -z "${dd_api_key}" ]; then
+if [ -z "${DD_API_KEY}" ]; then
   echo "Missing Datadog API key!"
   exit 1
 fi
@@ -33,7 +35,7 @@ pipeline:
    host: http-intake.logs.${dd_site}
    tls: on
    compress: gzip
-   apikey: ${dd_api_key}
+   apikey: ${DD_API_KEY}
    dd_source: audit
    dd_service: drt-cockroachdb
    dd_tags: env:development,cluster:${CLUSTER%:*},service:drt-cockroachdb,team:drt
@@ -43,16 +45,16 @@ EOF"
 
 drtprod ssh $CLUSTER -- "sudo tee /etc/profile.d/99-datadog.sh > /dev/null << EOF
 export DD_SITE=${dd_site}
-export DD_API_KEY=${dd_api_key}
+export DD_API_KEY=${DD_API_KEY}
 export DD_TAGS=env:development,cluster${CLUSTER%:*},team:drt,service:drt-cockroachdb
 EOF"
 
 drtprod opentelemetry-start $CLUSTER \
-  --datadog-api-key "${dd_api_key}" \
+  --datadog-api-key "${DD_API_KEY}" \
   --datadog-tags 'service:drt-cockroachdb,team:drt'
 
 drtprod fluent-bit-start $CLUSTER \
-  --datadog-api-key "${dd_api_key}" \
+  --datadog-api-key "${DD_API_KEY}" \
   --datadog-service drt-cockroachdb \
   --datadog-tags 'service:drt-cockroachdb,team:drt'
 

--- a/pkg/cmd/drtprod/scripts/setup_datadog_workload
+++ b/pkg/cmd/drtprod/scripts/setup_datadog_workload
@@ -8,9 +8,11 @@ if [ -z "${WORKLOAD_CLUSTER}" ]; then
   exit 1
 fi
 
-dd_api_key="$(gcloud --project=cockroach-drt secrets versions access latest --secret datadog-api-key)"
+if [ -z "${DD_API_KEY}" ]; then
+  DD_API_KEY="$(gcloud --project=cockroach-drt secrets versions access latest --secret datadog-api-key)"
+fi
 
-if [ -z "${dd_api_key}" ]; then
+if [ -z "${DD_API_KEY}" ]; then
   echo "Missing Datadog API key!"
   exit 1
 fi
@@ -95,16 +97,16 @@ EOF"
 
 drtprod ssh $WORKLOAD_CLUSTER -- "sudo tee /etc/profile.d/99-datadog.sh > /dev/null << EOF
 export DD_SITE=${dd_site}
-export DD_API_KEY=${dd_api_key}
+export DD_API_KEY=${DD_API_KEY}
 export DD_TAGS=env:development,cluster${CLUSTER%:*},team:drt,service:drt-cockroachdb
 EOF"
 
 drtprod opentelemetry-start $WORKLOAD_CLUSTER \
-  --datadog-api-key "${dd_api_key}" \
+  --datadog-api-key "${DD_API_KEY}" \
   --datadog-tags 'service:drt-cockroachdb,team:drt'
 
 drtprod fluent-bit-start $WORKLOAD_CLUSTER \
-  --datadog-api-key "${dd_api_key}" \
+  --datadog-api-key "${DD_API_KEY}" \
   --datadog-service drt-cockroachdb \
   --datadog-tags 'service:drt-cockroachdb,team:drt'
 


### PR DESCRIPTION
The Datadog API key (used to set the DD_API_KEY environment variable) is expected to be accessible on the machine where the YAML is executed. However, the remote VM lacks the necessary permissions to retrieve the key. To resolve this, the change extracts the API key locally and configures it in the .bashrc file of the remote VM. The other scripts have been updated accordingly to handle this.

Epic: None
Release Note: None