### PR TITLE
sql/opt: Generate synthetic check constraint to enforce RLS policies for new rows

### DIFF
--- a/pkg/sql/opt/cat/policy.go
+++ b/pkg/sql/opt/cat/policy.go
@@ -44,10 +44,16 @@ type Policy struct {
 	// read operations. If the policy does not define a USING expression, this is
 	// an empty string.
 	UsingExpr string
+	// UsingColumnIDs is a set of column IDs that are referenced in the USING
+	// expression.
+	UsingColumnIDs descpb.ColumnIDs
 	// WithCheckExpr is the optional validation expression applied to new rows
 	// during write operations. If the policy does not define a WITH CHECK expression,
 	// this is an empty string.
 	WithCheckExpr string
+	// WithCheckColumnIDs is a set of column IDs that are referenced in the WITH
+	// CHECK expression.
+	WithCheckColumnIDs descpb.ColumnIDs
 	// Command is the command that the policy was defined for.
 	Command catpb.PolicyCommand
 	// roles are the roles the applies to. If the policy applies to all roles (aka

--- a/pkg/sql/opt/cat/table.go
+++ b/pkg/sql/opt/cat/table.go
@@ -46,6 +46,9 @@ type Table interface {
 	// that they cannot be mutated.
 	IsMaterializedView() bool
 
+	// LookupColumnOrdinal returns the ordinal of the column with the given ID.
+	LookupColumnOrdinal(colID descpb.ColumnID) (int, error)
+
 	// ColumnCount returns the number of columns in the table. This includes
 	// public columns, write-only columns, etc.
 	ColumnCount() int
@@ -185,12 +188,8 @@ type Table interface {
 	// IsRowLevelSecurityEnabled is true if policies should be applied during the query.
 	IsRowLevelSecurityEnabled() bool
 
-	// PolicyCount returns the number of policies in the table for the given type.
-	PolicyCount(polType tree.PolicyType) int
-
-	// Policy retrieves the policy of the specified type at the given index (i),
-	// where i < PolicyCount for the specified type.
-	Policy(polType tree.PolicyType, i int) Policy
+	// Policies returns all the policies defined for this table.
+	Policies() *Policies
 }
 
 // CheckConstraint represents a check constraint on a table. Check constraints
@@ -212,6 +211,10 @@ type CheckConstraint interface {
 	// ColumnOrdinal returns the table column ordinal of the ith column in this
 	// constraint.
 	ColumnOrdinal(i int) int
+
+	// IsRLSConstraint is true if this is a constraint used to enforce
+	// row-level security policies.
+	IsRLSConstraint() bool
 }
 
 // TableStatistic is an interface to a table statistic. Each statistic is

--- a/pkg/sql/opt/cat/utils.go
+++ b/pkg/sql/opt/cat/utils.go
@@ -81,6 +81,11 @@ func FormatTable(
 	}
 
 	for i := 0; i < tab.CheckCount(); i++ {
+		// We only show constraints that are constant and known when the catalog is
+		// built. For this reason, skip the one we add for row-level security.
+		if tab.Check(i).IsRLSConstraint() {
+			continue
+		}
 		child.Childf("CHECK (%s)", MaybeMarkRedactable(tab.Check(i).Constraint(), redactableValues))
 	}
 

--- a/pkg/sql/opt/exec/explain/emit.go
+++ b/pkg/sql/opt/exec/explain/emit.go
@@ -1366,8 +1366,10 @@ func (e *emitter) emitPolicies(
 		ob.AddField("policies", "row-level security enabled, no policies applied.")
 	} else {
 		var sb strings.Builder
-		for i := 0; i < table.PolicyCount(tree.PolicyTypePermissive); i++ {
-			policy := table.Policy(tree.PolicyTypePermissive, i)
+		policies := table.Policies()
+		// TODO(136742): Add support for restrictive policies.
+		for i := range policies.Permissive {
+			policy := policies.Permissive[i]
 			if applied.Policies.Contains(policy.ID) {
 				if sb.Len() > 0 {
 					sb.WriteString(", ")

--- a/pkg/sql/opt/exec/explain/plan_gist_factory.go
+++ b/pkg/sql/opt/exec/explain/plan_gist_factory.go
@@ -530,6 +530,10 @@ func (u *unknownTable) IsMaterializedView() bool {
 	return false
 }
 
+func (u *unknownTable) LookupColumnOrdinal(descpb.ColumnID) (int, error) {
+	panic(errors.AssertionFailedf("not implemented"))
+}
+
 func (u *unknownTable) ColumnCount() int {
 	return 0
 }
@@ -662,13 +666,8 @@ func (u *unknownTable) Trigger(i int) cat.Trigger {
 // IsRowLevelSecurityEnabled is part of the cat.Table interface
 func (u *unknownTable) IsRowLevelSecurityEnabled() bool { return false }
 
-// PolicyCount is part of the cat.Table interface
-func (u *unknownTable) PolicyCount(polType tree.PolicyType) int { return 0 }
-
-// Policy is part of the cat.Table interface
-func (u *unknownTable) Policy(polType tree.PolicyType, i int) cat.Policy {
-	panic(errors.AssertionFailedf("not implemented"))
-}
+// Policies is part of the cat.Table interface.
+func (u *unknownTable) Policies() *cat.Policies { return nil }
 
 var _ cat.Table = &unknownTable{}
 

--- a/pkg/sql/opt/optbuilder/row_level_security.go
+++ b/pkg/sql/opt/optbuilder/row_level_security.go
@@ -6,13 +6,19 @@
 package optbuilder
 
 import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
-	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/intsets"
 	"github.com/cockroachdb/errors"
 )
 
@@ -48,9 +54,8 @@ func (b *Builder) buildRowLevelSecurityUsingExpression(
 	tabMeta *opt.TableMeta, tableScope *scope, cmdScope cat.PolicyCommandScope,
 ) opt.ScalarExpr {
 	var policiesUsed opt.PolicyIDSet
-	for i := 0; i < tabMeta.Table.PolicyCount(tree.PolicyTypePermissive); i++ {
-		policy := tabMeta.Table.Policy(tree.PolicyTypePermissive, i)
-
+	policies := tabMeta.Table.Policies()
+	for _, policy := range policies.Permissive {
 		if !policy.AppliesToRole(b.checkPrivilegeUser) || !b.policyAppliesToCommandScope(policy, cmdScope) {
 			continue
 		}
@@ -102,3 +107,144 @@ func (b *Builder) policyAppliesToCommandScope(
 		panic(errors.AssertionFailedf("unknown policy command %v", cmd))
 	}
 }
+
+// optRLSConstraintBuilder is used synthesize a check constraint to enforce the
+// RLS policies for new rows.
+type optRLSConstraintBuilder struct {
+	tab      cat.Table
+	md       *opt.Metadata
+	tabMeta  *opt.TableMeta
+	oc       cat.Catalog
+	user     username.SQLUsername
+	isUpdate bool
+}
+
+// Build will construct a CheckConstraint to enforce the policies for the
+// current user and command.
+func (r *optRLSConstraintBuilder) Build(ctx context.Context) cat.CheckConstraint {
+	expr, colIDs := r.genExpression(ctx)
+	if expr == "" {
+		panic(fmt.Sprintf("must return some expression but empty string returned for user: %v", r.user))
+	}
+	return &rlsCheckConstraint{
+		constraint: expr,
+		colIDs:     colIDs,
+		tab:        r.tab,
+	}
+}
+
+// genExpression builds the expression that will be used within the check
+// constraint built for RLS.
+func (r *optRLSConstraintBuilder) genExpression(ctx context.Context) (string, []int) {
+	var sb strings.Builder
+
+	// colIDs tracks the column IDs referenced in all the policy expressions
+	// that are applied. We use a set as we need to combine the columns used
+	// for multiple policies.
+	var colIDs intsets.Fast
+
+	// Admin users are exempt from any RLS policies.
+	isAdmin, err := r.oc.UserHasAdminRole(ctx, r.user)
+	if err != nil {
+		panic(err)
+	}
+	r.md.SetRLSEnabled(r.user, isAdmin, r.tabMeta.MetaID)
+	if isAdmin {
+		// Return a constraint check that always passes.
+		return "true", nil
+	}
+
+	var policiesUsed opt.PolicyIDSet
+	for i := range r.tab.Policies().Permissive {
+		p := &r.tab.Policies().Permissive[i]
+
+		if !p.AppliesToRole(r.user) || !r.policyAppliesToCommand(p, r.isUpdate) {
+			continue
+		}
+		policiesUsed.Add(p.ID)
+		var expr string
+		// If the WITH CHECK expression is missing, we default to the USING
+		// expression. If both are missing, then this policy doesn't apply and can
+		// be skipped.
+		if p.WithCheckExpr == "" {
+			if p.UsingExpr == "" {
+				continue
+			}
+			expr = p.UsingExpr
+			for _, id := range p.UsingColumnIDs {
+				colIDs.Add(int(id))
+			}
+		} else {
+			expr = p.WithCheckExpr
+			for _, id := range p.WithCheckColumnIDs {
+				colIDs.Add(int(id))
+			}
+		}
+		if sb.Len() != 0 {
+			sb.WriteString(" OR ")
+		}
+		sb.WriteString("(")
+		sb.WriteString(expr)
+		sb.WriteString(")")
+		// TODO(136742): Add support for multiple policies.
+		r.md.GetRLSMeta().AddPoliciesUsed(r.tabMeta.MetaID, policiesUsed)
+		break
+	}
+
+	// TODO(136742): Add support for restrictive policies.
+
+	// If no policies apply, then we will add a false check as nothing is allowed
+	// to be written.
+	if sb.Len() == 0 {
+		r.md.GetRLSMeta().NoPoliciesApplied = true
+		return "false", nil
+	}
+
+	return sb.String(), colIDs.Ordered()
+}
+
+// policyAppliesToCommand will return true iff the command set in the policy
+// applies to the current mutation action.
+func (r *optRLSConstraintBuilder) policyAppliesToCommand(policy *cat.Policy, isUpdate bool) bool {
+	switch policy.Command {
+	case catpb.PolicyCommand_ALL:
+		return true
+	case catpb.PolicyCommand_SELECT, catpb.PolicyCommand_DELETE:
+		return false
+	case catpb.PolicyCommand_INSERT:
+		return !isUpdate
+	case catpb.PolicyCommand_UPDATE:
+		return isUpdate
+	default:
+		panic(errors.AssertionFailedf("unknown policy command %v", policy.Command))
+	}
+}
+
+// rlsCheckConstraint is an implementation of cat.CheckConstraint for the
+// check constraint built to enforce the RLS policies on write.
+type rlsCheckConstraint struct {
+	constraint string
+	colIDs     []int
+	tab        cat.Table
+}
+
+// Constraint implements the cat.CheckConstraint interface.
+func (r *rlsCheckConstraint) Constraint() string { return r.constraint }
+
+// Validated implements the cat.CheckConstraint interface.
+func (r *rlsCheckConstraint) Validated() bool { return true }
+
+// ColumnCount implements the cat.CheckConstraint interface.
+func (r *rlsCheckConstraint) ColumnCount() int { return len(r.colIDs) }
+
+// ColumnOrdinal implements the cat.CheckConstraint interface.
+func (r *rlsCheckConstraint) ColumnOrdinal(i int) int {
+	ord, err := r.tab.LookupColumnOrdinal(descpb.ColumnID(r.colIDs[i]))
+	if err != nil {
+		panic(err)
+	}
+	return ord
+}
+
+// IsRLSConstraint implements the cat.CheckConstraint interface.
+func (r *rlsCheckConstraint) IsRLSConstraint() bool { return true }

--- a/pkg/sql/opt/optbuilder/testdata/row_level_security
+++ b/pkg/sql/opt/optbuilder/testdata/row_level_security
@@ -1,7 +1,7 @@
 # Tests for row-level security policies.
 
 exec-ddl
-CREATE TABLE t1 (c1 INT);
+CREATE TABLE t1 (c1 INT, c2 TEXT, c3 DATE);
 ----
 
 exec-ddl
@@ -17,7 +17,7 @@ SELECT c1 FROM T1;
 project
  ├── columns: c1:1
  └── scan t1
-      └── columns: c1:1 rowid:2!null crdb_internal_mvcc_timestamp:3 tableoid:4
+      └── columns: c1:1 c2:2 c3:3 rowid:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
 
 # Repeat for a user that isn't an admin. All rows should be filtered.
 
@@ -35,9 +35,9 @@ SELECT c1 FROM T1;
 project
  ├── columns: c1:1
  └── select
-      ├── columns: c1:1 rowid:2!null crdb_internal_mvcc_timestamp:3 tableoid:4
+      ├── columns: c1:1 c2:2 c3:3 rowid:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
       ├── scan t1
-      │    └── columns: c1:1 rowid:2!null crdb_internal_mvcc_timestamp:3 tableoid:4
+      │    └── columns: c1:1 c2:2 c3:3 rowid:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
       └── filters
            └── false
 
@@ -54,9 +54,9 @@ SELECT c1 FROM T1;
 project
  ├── columns: c1:1!null
  └── select
-      ├── columns: c1:1!null rowid:2!null crdb_internal_mvcc_timestamp:3 tableoid:4
+      ├── columns: c1:1!null c2:2 c3:3 rowid:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
       ├── scan t1
-      │    └── columns: c1:1 rowid:2!null crdb_internal_mvcc_timestamp:3 tableoid:4
+      │    └── columns: c1:1 c2:2 c3:3 rowid:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
       └── filters
            └── c1:1 > 0
 
@@ -75,24 +75,29 @@ UPDATE T1 SET c1 = c1 * 2 WHERE c1 > 0;
 ----
 update t1
  ├── columns: <none>
- ├── fetch columns: c1:5 rowid:6
+ ├── fetch columns: c1:7 c2:8 c3:9 rowid:10
  ├── update-mapping:
- │    └── c1_new:9 => c1:1
+ │    └── c1_new:13 => c1:1
+ ├── check columns: rls:14
  └── project
-      ├── columns: c1_new:9!null c1:5!null rowid:6!null crdb_internal_mvcc_timestamp:7 tableoid:8
-      ├── select
-      │    ├── columns: c1:5!null rowid:6!null crdb_internal_mvcc_timestamp:7 tableoid:8
+      ├── columns: rls:14!null c1:7!null c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12 c1_new:13!null
+      ├── project
+      │    ├── columns: c1_new:13!null c1:7!null c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
       │    ├── select
-      │    │    ├── columns: c1:5 rowid:6!null crdb_internal_mvcc_timestamp:7 tableoid:8
-      │    │    ├── scan t1
-      │    │    │    ├── columns: c1:5 rowid:6!null crdb_internal_mvcc_timestamp:7 tableoid:8
-      │    │    │    └── flags: avoid-full-scan
+      │    │    ├── columns: c1:7!null c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
+      │    │    ├── select
+      │    │    │    ├── columns: c1:7 c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
+      │    │    │    ├── scan t1
+      │    │    │    │    ├── columns: c1:7 c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
+      │    │    │    │    └── flags: avoid-full-scan
+      │    │    │    └── filters
+      │    │    │         └── false
       │    │    └── filters
-      │    │         └── false
-      │    └── filters
-      │         └── c1:5 > 0
+      │    │         └── c1:7 > 0
+      │    └── projections
+      │         └── c1:7 * 2 [as=c1_new:13]
       └── projections
-           └── c1:5 * 2 [as=c1_new:9]
+           └── false [as=rls:14]
 
 exec-ddl
 CREATE POLICY p2 on t1 FOR UPDATE USING (c1 < 100);
@@ -103,24 +108,29 @@ UPDATE T1 SET c1 = c1 * 2 WHERE c1 > 0;
 ----
 update t1
  ├── columns: <none>
- ├── fetch columns: c1:5 rowid:6
+ ├── fetch columns: c1:7 c2:8 c3:9 rowid:10
  ├── update-mapping:
- │    └── c1_new:9 => c1:1
+ │    └── c1_new:13 => c1:1
+ ├── check columns: rls:14
  └── project
-      ├── columns: c1_new:9!null c1:5!null rowid:6!null crdb_internal_mvcc_timestamp:7 tableoid:8
-      ├── select
-      │    ├── columns: c1:5!null rowid:6!null crdb_internal_mvcc_timestamp:7 tableoid:8
+      ├── columns: rls:14!null c1:7!null c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12 c1_new:13!null
+      ├── project
+      │    ├── columns: c1_new:13!null c1:7!null c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
       │    ├── select
-      │    │    ├── columns: c1:5!null rowid:6!null crdb_internal_mvcc_timestamp:7 tableoid:8
-      │    │    ├── scan t1
-      │    │    │    ├── columns: c1:5 rowid:6!null crdb_internal_mvcc_timestamp:7 tableoid:8
-      │    │    │    └── flags: avoid-full-scan
+      │    │    ├── columns: c1:7!null c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
+      │    │    ├── select
+      │    │    │    ├── columns: c1:7!null c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
+      │    │    │    ├── scan t1
+      │    │    │    │    ├── columns: c1:7 c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
+      │    │    │    │    └── flags: avoid-full-scan
+      │    │    │    └── filters
+      │    │    │         └── c1:7 < 100
       │    │    └── filters
-      │    │         └── c1:5 < 100
-      │    └── filters
-      │         └── c1:5 > 0
+      │    │         └── c1:7 > 0
+      │    └── projections
+      │         └── c1:7 * 2 [as=c1_new:13]
       └── projections
-           └── c1:5 * 2 [as=c1_new:9]
+           └── c1_new:13 < 100 [as=rls:14]
 
 # Verify a DELETE won't use policies for SELECT or UPDATE.
 
@@ -129,18 +139,18 @@ DELETE FROM T1 WHERE c1 BETWEEN 0 AND 20;
 ----
 delete t1
  ├── columns: <none>
- ├── fetch columns: c1:5 rowid:6
+ ├── fetch columns: c1:7 c2:8 c3:9 rowid:10
  └── select
-      ├── columns: c1:5!null rowid:6!null crdb_internal_mvcc_timestamp:7 tableoid:8
+      ├── columns: c1:7!null c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
       ├── select
-      │    ├── columns: c1:5 rowid:6!null crdb_internal_mvcc_timestamp:7 tableoid:8
+      │    ├── columns: c1:7 c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
       │    ├── scan t1
-      │    │    ├── columns: c1:5 rowid:6!null crdb_internal_mvcc_timestamp:7 tableoid:8
+      │    │    ├── columns: c1:7 c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
       │    │    └── flags: avoid-full-scan
       │    └── filters
       │         └── false
       └── filters
-           └── (c1:5 >= 0) AND (c1:5 <= 20)
+           └── (c1:7 >= 0) AND (c1:7 <= 20)
 
 exec-ddl
 CREATE POLICY p3 on t1 FOR DELETE USING (c1 between 8 and 12);
@@ -151,18 +161,18 @@ DELETE FROM T1 WHERE c1 BETWEEN 0 AND 20;
 ----
 delete t1
  ├── columns: <none>
- ├── fetch columns: c1:5 rowid:6
+ ├── fetch columns: c1:7 c2:8 c3:9 rowid:10
  └── select
-      ├── columns: c1:5!null rowid:6!null crdb_internal_mvcc_timestamp:7 tableoid:8
+      ├── columns: c1:7!null c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
       ├── select
-      │    ├── columns: c1:5!null rowid:6!null crdb_internal_mvcc_timestamp:7 tableoid:8
+      │    ├── columns: c1:7!null c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
       │    ├── scan t1
-      │    │    ├── columns: c1:5 rowid:6!null crdb_internal_mvcc_timestamp:7 tableoid:8
+      │    │    ├── columns: c1:7 c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
       │    │    └── flags: avoid-full-scan
       │    └── filters
-      │         └── (c1:5 >= 8) AND (c1:5 <= 12)
+      │         └── (c1:7 >= 8) AND (c1:7 <= 12)
       └── filters
-           └── (c1:5 >= 0) AND (c1:5 <= 20)
+           └── (c1:7 >= 0) AND (c1:7 <= 20)
 
 exec-ddl
 DROP POLICY p1 on t1;
@@ -192,11 +202,11 @@ SELECT c1 FROM t1 where C1 between 0 and 9;
 project
  ├── columns: c1:1!null
  └── select
-      ├── columns: c1:1!null rowid:2!null crdb_internal_mvcc_timestamp:3 tableoid:4
+      ├── columns: c1:1!null c2:2 c3:3 rowid:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
       ├── select
-      │    ├── columns: c1:1 rowid:2!null crdb_internal_mvcc_timestamp:3 tableoid:4
+      │    ├── columns: c1:1 c2:2 c3:3 rowid:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
       │    ├── scan t1
-      │    │    └── columns: c1:1 rowid:2!null crdb_internal_mvcc_timestamp:3 tableoid:4
+      │    │    └── columns: c1:1 c2:2 c3:3 rowid:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
       │    └── filters
       │         └── false
       └── filters
@@ -212,12 +222,405 @@ SELECT c1 FROM t1 where C1 between 0 and 9;
 project
  ├── columns: c1:1!null
  └── select
-      ├── columns: c1:1!null rowid:2!null crdb_internal_mvcc_timestamp:3 tableoid:4
+      ├── columns: c1:1!null c2:2 c3:3 rowid:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
       ├── select
-      │    ├── columns: c1:1!null rowid:2!null crdb_internal_mvcc_timestamp:3 tableoid:4
+      │    ├── columns: c1:1!null c2:2 c3:3 rowid:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
       │    ├── scan t1
-      │    │    └── columns: c1:1 rowid:2!null crdb_internal_mvcc_timestamp:3 tableoid:4
+      │    │    └── columns: c1:1 c2:2 c3:3 rowid:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
       │    └── filters
       │         └── c1:1 > 0
       └── filters
            └── (c1:1 >= 0) AND (c1:1 <= 9)
+
+# Verify policies applied for insert
+
+build
+INSERT INTO t1 VALUES (0),(1),(2);
+----
+insert t1
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├── column1:7 => c1:1
+ │    ├── c2_default:8 => c2:2
+ │    ├── c3_default:9 => c3:3
+ │    └── rowid_default:10 => rowid:4
+ ├── check columns: rls:11
+ └── project
+      ├── columns: rls:11!null column1:7!null c2_default:8 c3_default:9 rowid_default:10
+      ├── project
+      │    ├── columns: c2_default:8 c3_default:9 rowid_default:10 column1:7!null
+      │    ├── values
+      │    │    ├── columns: column1:7!null
+      │    │    ├── (0,)
+      │    │    ├── (1,)
+      │    │    └── (2,)
+      │    └── projections
+      │         ├── NULL::STRING [as=c2_default:8]
+      │         ├── NULL::DATE [as=c3_default:9]
+      │         └── unique_rowid() [as=rowid_default:10]
+      └── projections
+           └── column1:7 > 0 [as=rls:11]
+
+# Verify policies apply to table with an existing check constraint.
+
+exec-ddl
+CREATE TABLE t1_with_check (c1 int, c2 int, CHECK (c1 > 0));
+----
+
+exec-ddl
+ALTER TABLE t1_with_check ENABLE ROW LEVEL SECURITY;
+----
+
+exec-ddl
+CREATE POLICY p1 on t1_with_check WITH CHECK (c2 > 2);
+----
+
+build
+INSERT INTO t1_with_check VALUES (0);
+----
+insert t1_with_check
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├── column1:6 => c1:1
+ │    ├── c2_default:7 => c2:2
+ │    └── rowid_default:8 => rowid:3
+ ├── check columns: check1:9 rls:10
+ └── project
+      ├── columns: check1:9!null rls:10 column1:6!null c2_default:7 rowid_default:8
+      ├── project
+      │    ├── columns: c2_default:7 rowid_default:8 column1:6!null
+      │    ├── values
+      │    │    ├── columns: column1:6!null
+      │    │    └── (0,)
+      │    └── projections
+      │         ├── NULL::INT8 [as=c2_default:7]
+      │         └── unique_rowid() [as=rowid_default:8]
+      └── projections
+           ├── column1:6 > 0 [as=check1:9]
+           └── c2_default:7 > 2 [as=rls:10]
+
+# Verify a policy that has no WITH CHECK will use the USING expression for new rows.
+
+exec-ddl
+DROP POLICY p1 on t1;
+----
+
+exec-ddl
+CREATE POLICY p1 on t1 AS PERMISSIVE FOR SELECT TO fred USING (true);
+----
+
+exec-ddl
+CREATE POLICY p2 on t1 AS PERMISSIVE FOR ALL TO fred USING (c2 = 'Hello, World' OR c3 = '2024-12-24');
+----
+
+build
+INSERT INTO t1(c1) VALUES (10);
+----
+insert t1
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├── column1:7 => c1:1
+ │    ├── c2_default:8 => c2:2
+ │    ├── c3_default:9 => c3:3
+ │    └── rowid_default:10 => rowid:4
+ ├── check columns: rls:11
+ └── project
+      ├── columns: rls:11 column1:7!null c2_default:8 c3_default:9 rowid_default:10
+      ├── project
+      │    ├── columns: c2_default:8 c3_default:9 rowid_default:10 column1:7!null
+      │    ├── values
+      │    │    ├── columns: column1:7!null
+      │    │    └── (10,)
+      │    └── projections
+      │         ├── NULL::STRING [as=c2_default:8]
+      │         ├── NULL::DATE [as=c3_default:9]
+      │         └── unique_rowid() [as=rowid_default:10]
+      └── projections
+           └── (c2_default:8 = 'Hello, World') OR (c3_default:9 = '2024-12-24') [as=rls:11]
+
+build
+UPDATE t1 SET c2 = 'new val';
+----
+update t1
+ ├── columns: <none>
+ ├── fetch columns: c1:7 c2:8 c3:9 rowid:10
+ ├── update-mapping:
+ │    └── c2_new:13 => c2:2
+ ├── check columns: rls:14
+ └── project
+      ├── columns: rls:14 c1:7 c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12 c2_new:13!null
+      ├── project
+      │    ├── columns: c2_new:13!null c1:7 c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
+      │    ├── select
+      │    │    ├── columns: c1:7 c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
+      │    │    ├── scan t1
+      │    │    │    ├── columns: c1:7 c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
+      │    │    │    └── flags: avoid-full-scan
+      │    │    └── filters
+      │    │         └── (c2:8 = 'Hello, World') OR (c3:9 = '2024-12-24')
+      │    └── projections
+      │         └── 'new val' [as=c2_new:13]
+      └── projections
+           └── (c2_new:13 = 'Hello, World') OR (c3:9 = '2024-12-24') [as=rls:14]
+
+# Verify insert and update code path when no policy applies to role.
+
+exec-ddl
+DROP POLICY p2 on t1;
+----
+
+build
+INSERT INTO t1(c1) VALUES (10);
+----
+insert t1
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├── column1:7 => c1:1
+ │    ├── c2_default:8 => c2:2
+ │    ├── c3_default:9 => c3:3
+ │    └── rowid_default:10 => rowid:4
+ ├── check columns: rls:11
+ └── project
+      ├── columns: rls:11!null column1:7!null c2_default:8 c3_default:9 rowid_default:10
+      ├── project
+      │    ├── columns: c2_default:8 c3_default:9 rowid_default:10 column1:7!null
+      │    ├── values
+      │    │    ├── columns: column1:7!null
+      │    │    └── (10,)
+      │    └── projections
+      │         ├── NULL::STRING [as=c2_default:8]
+      │         ├── NULL::DATE [as=c3_default:9]
+      │         └── unique_rowid() [as=rowid_default:10]
+      └── projections
+           └── false [as=rls:11]
+
+build
+UPDATE t1 SET c2 = 'new val';
+----
+update t1
+ ├── columns: <none>
+ ├── fetch columns: c1:7 c2:8 c3:9 rowid:10
+ ├── update-mapping:
+ │    └── c2_new:13 => c2:2
+ ├── check columns: rls:14
+ └── project
+      ├── columns: rls:14!null c1:7 c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12 c2_new:13!null
+      ├── project
+      │    ├── columns: c2_new:13!null c1:7 c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
+      │    ├── select
+      │    │    ├── columns: c1:7 c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
+      │    │    ├── scan t1
+      │    │    │    ├── columns: c1:7 c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
+      │    │    │    └── flags: avoid-full-scan
+      │    │    └── filters
+      │    │         └── false
+      │    └── projections
+      │         └── 'new val' [as=c2_new:13]
+      └── projections
+           └── false [as=rls:14]
+
+# Verify that an INSERT ... SELECT statement applies the RLS check constraint
+# and uses different policies for the SELECT and INSERT portions of the query.
+
+exec-ddl
+DROP POLICY p1 on t1;
+----
+
+exec-ddl
+CREATE POLICY p_select on t1 FOR SELECT USING (c3 IN ('2013-06-02', '1988-07-01'));
+----
+
+exec-ddl
+CREATE POLICY p_insert on t1 FOR INSERT USING (char_length(c2) < 10);
+----
+
+build
+INSERT INTO t1 SELECT * FROM t1;
+----
+insert t1
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├── c1:7 => c1:1
+ │    ├── c2:8 => c2:2
+ │    ├── c3:9 => c3:3
+ │    └── rowid_default:13 => rowid:4
+ ├── check columns: rls:14
+ └── project
+      ├── columns: rls:14 c1:7 c2:8 c3:9!null rowid_default:13
+      ├── project
+      │    ├── columns: rowid_default:13 c1:7 c2:8 c3:9!null
+      │    ├── project
+      │    │    ├── columns: c1:7 c2:8 c3:9!null
+      │    │    └── select
+      │    │         ├── columns: c1:7 c2:8 c3:9!null rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
+      │    │         ├── scan t1
+      │    │         │    └── columns: c1:7 c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
+      │    │         └── filters
+      │    │              └── c3:9 IN ('2013-06-02', '1988-07-01')
+      │    └── projections
+      │         └── unique_rowid() [as=rowid_default:13]
+      └── projections
+           └── char_length(c2:8) < 10 [as=rls:14]
+
+exec-ddl
+DROP POLICY p_select on t1;
+----
+
+exec-ddl
+DROP POLICY p_insert on t1;
+----
+
+# Verify that an update fetches the column if a policy references it, even when
+# the column itself is not being modified.
+
+exec-ddl
+CREATE POLICY p_update on t1 FOR UPDATE USING (c3 in ('2025-01-01', '2024-12-31')) WITH CHECK (c2 like '%');
+----
+
+build
+UPDATE t1 SET c1 = c1 + 1;
+----
+update t1
+ ├── columns: <none>
+ ├── fetch columns: c1:7 c2:8 c3:9 rowid:10
+ ├── update-mapping:
+ │    └── c1_new:13 => c1:1
+ ├── check columns: rls:14
+ └── project
+      ├── columns: rls:14 c1:7 c2:8 c3:9!null rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12 c1_new:13
+      ├── project
+      │    ├── columns: c1_new:13 c1:7 c2:8 c3:9!null rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
+      │    ├── select
+      │    │    ├── columns: c1:7 c2:8 c3:9!null rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
+      │    │    ├── scan t1
+      │    │    │    ├── columns: c1:7 c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
+      │    │    │    └── flags: avoid-full-scan
+      │    │    └── filters
+      │    │         └── c3:9 IN ('2025-01-01', '2024-12-31')
+      │    └── projections
+      │         └── c1:7 + 1 [as=c1_new:13]
+      └── projections
+           └── c2:8 LIKE '%' [as=rls:14]
+
+exec-ddl
+DROP POLICY p_update on t1;
+----
+
+# Verify an upsert operation.
+# TODO(141998): There is more work needed to enforce the proper policies for upsert.
+
+exec-ddl
+CREATE TABLE t1_explicit_pk (C1 INT NOT NULL PRIMARY KEY, C2 TEXT, C3 DATE);
+----
+
+exec-ddl
+ALTER TABLE t1_explicit_pk ENABLE ROW LEVEL SECURITY;
+----
+
+exec-ddl
+CREATE POLICY p_insert ON t1_explicit_pk FOR INSERT WITH CHECK (c3 != '2023-05-02');
+----
+
+exec-ddl
+CREATE POLICY p_update ON t1_explicit_pk FOR UPDATE WITH CHECK (c3 >= '2000-01-01');
+----
+
+build
+UPSERT INTO t1_explicit_pk VALUES (1, 'first', '2010-08-08');
+----
+upsert t1_explicit_pk
+ ├── columns: <none>
+ ├── upsert-mapping:
+ │    ├── column1:6 => c1:1
+ │    ├── column2:7 => c2:2
+ │    └── column3:8 => c3:3
+ ├── check columns: rls:9
+ └── project
+      ├── columns: rls:9!null column1:6!null column2:7!null column3:8!null
+      ├── values
+      │    ├── columns: column1:6!null column2:7!null column3:8!null
+      │    └── (1, 'first', '2010-08-08')
+      └── projections
+           └── column3:8 != '2023-05-02' [as=rls:9]
+
+build
+INSERT INTO t1_explicit_pk VALUES (2, 'second', '2008-11-19') ON CONFLICT DO NOTHING;
+----
+insert t1_explicit_pk
+ ├── arbiter indexes: t1_explicit_pk_pkey
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├── column1:6 => c1:1
+ │    ├── column2:7 => c2:2
+ │    └── column3:8 => c3:3
+ ├── check columns: rls:14
+ └── project
+      ├── columns: rls:14!null column1:6!null column2:7!null column3:8!null
+      ├── upsert-distinct-on
+      │    ├── columns: column1:6!null column2:7!null column3:8!null
+      │    ├── grouping columns: column1:6!null
+      │    ├── anti-join (hash)
+      │    │    ├── columns: column1:6!null column2:7!null column3:8!null
+      │    │    ├── values
+      │    │    │    ├── columns: column1:6!null column2:7!null column3:8!null
+      │    │    │    └── (2, 'second', '2008-11-19')
+      │    │    ├── scan t1_explicit_pk
+      │    │    │    ├── columns: c1:9!null c2:10 c3:11
+      │    │    │    └── flags: avoid-full-scan disabled not visible index feature
+      │    │    └── filters
+      │    │         └── column1:6 = c1:9
+      │    └── aggregations
+      │         ├── first-agg [as=column2:7]
+      │         │    └── column2:7
+      │         └── first-agg [as=column3:8]
+      │              └── column3:8
+      └── projections
+           └── column3:8 != '2023-05-02' [as=rls:14]
+
+build
+INSERT INTO t1_explicit_pk VALUES (2, 'second', '2008-11-19') ON CONFLICT (c1) DO UPDATE SET c2 = 'updated';
+----
+upsert t1_explicit_pk
+ ├── arbiter indexes: t1_explicit_pk_pkey
+ ├── columns: <none>
+ ├── canary column: c1:9
+ ├── fetch columns: c1:9 c2:10 c3:11
+ ├── insert-mapping:
+ │    ├── column1:6 => c1:1
+ │    ├── column2:7 => c2:2
+ │    └── column3:8 => c3:3
+ ├── update-mapping:
+ │    └── upsert_c2:16 => c2:2
+ ├── check columns: rls:18
+ └── project
+      ├── columns: rls:18 column1:6!null column2:7!null column3:8!null c1:9 c2:10 c3:11 crdb_internal_mvcc_timestamp:12 tableoid:13 c2_new:14!null upsert_c1:15 upsert_c2:16!null upsert_c3:17
+      ├── project
+      │    ├── columns: upsert_c1:15 upsert_c2:16!null upsert_c3:17 column1:6!null column2:7!null column3:8!null c1:9 c2:10 c3:11 crdb_internal_mvcc_timestamp:12 tableoid:13 c2_new:14!null
+      │    ├── project
+      │    │    ├── columns: c2_new:14!null column1:6!null column2:7!null column3:8!null c1:9 c2:10 c3:11 crdb_internal_mvcc_timestamp:12 tableoid:13
+      │    │    ├── left-join (hash)
+      │    │    │    ├── columns: column1:6!null column2:7!null column3:8!null c1:9 c2:10 c3:11 crdb_internal_mvcc_timestamp:12 tableoid:13
+      │    │    │    ├── ensure-upsert-distinct-on
+      │    │    │    │    ├── columns: column1:6!null column2:7!null column3:8!null
+      │    │    │    │    ├── grouping columns: column1:6!null
+      │    │    │    │    ├── values
+      │    │    │    │    │    ├── columns: column1:6!null column2:7!null column3:8!null
+      │    │    │    │    │    └── (2, 'second', '2008-11-19')
+      │    │    │    │    └── aggregations
+      │    │    │    │         ├── first-agg [as=column2:7]
+      │    │    │    │         │    └── column2:7
+      │    │    │    │         └── first-agg [as=column3:8]
+      │    │    │    │              └── column3:8
+      │    │    │    ├── scan t1_explicit_pk
+      │    │    │    │    ├── columns: c1:9!null c2:10 c3:11 crdb_internal_mvcc_timestamp:12 tableoid:13
+      │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
+      │    │    │    └── filters
+      │    │    │         └── column1:6 = c1:9
+      │    │    └── projections
+      │    │         └── 'updated' [as=c2_new:14]
+      │    └── projections
+      │         ├── CASE WHEN c1:9 IS NULL THEN column1:6 ELSE c1:9 END [as=upsert_c1:15]
+      │         ├── CASE WHEN c1:9 IS NULL THEN column2:7 ELSE c2_new:14 END [as=upsert_c2:16]
+      │         └── CASE WHEN c1:9 IS NULL THEN column3:8 ELSE c3:11 END [as=upsert_c3:17]
+      └── projections
+           └── upsert_c3:17 != '2023-05-02' [as=rls:18]

--- a/pkg/sql/opt/testutils/testcat/alter_table.go
+++ b/pkg/sql/opt/testutils/testcat/alter_table.go
@@ -96,8 +96,10 @@ func toggleRLSMode(tt *Table, mode tree.TableRLSMode) {
 	switch mode {
 	case tree.TableRLSEnable:
 		tt.rlsEnabled = true
+		tt.addRLSConstraint()
 	case tree.TableRLSDisable:
 		tt.rlsEnabled = false
+		tt.removeRLSConstraint()
 	default:
 		panic(errors.AssertionFailedf("unsupported RLS mode %v", mode))
 	}


### PR DESCRIPTION
With row-level security, policies include a WITH CHECK expression to enforce constraints on new rows. This commit begins adding support for enforcing these policies by modifying the optbuilder to construct the check constraint, evaluate the expression, and pass the result to the execution engine. A future commit will integrate the execution engine to fully enforce these policies.

Since the expression for the synthetic check constraint is determined at INSERT or UPDATE time, a placeholder check constraint is added when building the optimizer table catalog. The check constraint is then finalized in the mutationBuilder.

Because the check constraint is constructed late in the process, a function is needed to look up the column ordinal for a given column ID. To facilitate this, the previously internal function lookupColumnOrdinal has been made external as LookupColumnOrdinal.

Epic: CRDB-45203
Release note: None
Informs: #136704