### PR TITLE
roachprod: ensure monitor is ready

### DIFF
--- a/pkg/cmd/roachtest/BUILD.bazel
+++ b/pkg/cmd/roachtest/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
         "slack.go",
         "test_filter.go",
         "test_impl.go",
+        "test_monitor.go",
         "test_registry.go",
         "test_runner.go",
         "work_pool.go",

--- a/pkg/cmd/roachtest/cluster_test.go
+++ b/pkg/cmd/roachtest/cluster_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil/task"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	test2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/vm"
@@ -149,6 +150,10 @@ func (t testWrapper) NewGroup(_ ...task.Option) task.Group {
 }
 
 func (t testWrapper) NewErrorGroup(_ ...task.Option) task.ErrorGroup {
+	panic("implement me")
+}
+
+func (t testWrapper) Monitor() test.Monitor {
 	panic("implement me")
 }
 

--- a/pkg/cmd/roachtest/clusterstats/mock_test_generated_test.go
+++ b/pkg/cmd/roachtest/clusterstats/mock_test_generated_test.go
@@ -9,6 +9,7 @@ import (
 	reflect "reflect"
 
 	task "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil/task"
+	test "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	logger "github.com/cockroachdb/cockroach/pkg/roachprod/logger"
 	version "github.com/cockroachdb/cockroach/pkg/util/version"
 	gomock "github.com/golang/mock/gomock"
@@ -327,6 +328,20 @@ func (m *MockTest) L() *logger.Logger {
 func (mr *MockTestMockRecorder) L() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "L", reflect.TypeOf((*MockTest)(nil).L))
+}
+
+// Monitor mocks base method.
+func (m *MockTest) Monitor() test.Monitor {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Monitor")
+	ret0, _ := ret[0].(test.Monitor)
+	return ret0
+}
+
+// Monitor indicates an expected call of Monitor.
+func (mr *MockTestMockRecorder) Monitor() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Monitor", reflect.TypeOf((*MockTest)(nil).Monitor))
 }
 
 // Name mocks base method.

--- a/pkg/cmd/roachtest/registry/test_spec.go
+++ b/pkg/cmd/roachtest/registry/test_spec.go
@@ -167,6 +167,12 @@ type TestSpec struct {
 	// important.
 	Randomized bool
 
+	// Monitor indicates if the test starts a process monitor. Eventually, this
+	// should replace all usages of `cluster.NewMonitor`. To replace the use of
+	// monitor, the test should be updated to use the `TestMonitor` and `Task`
+	// interfaces supplied with each test.
+	Monitor bool
+
 	// stats are populated by test selector based on previous execution data
 	stats *testStats
 }

--- a/pkg/cmd/roachtest/test/BUILD.bazel
+++ b/pkg/cmd/roachtest/test/BUILD.bazel
@@ -2,7 +2,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "test",
-    srcs = ["test_interface.go"],
+    srcs = [
+        "test_interface.go",
+        "test_monitor.go",
+    ],
     importpath = "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test",
     visibility = ["//visibility:public"],
     deps = [

--- a/pkg/cmd/roachtest/test/test_interface.go
+++ b/pkg/cmd/roachtest/test/test_interface.go
@@ -85,6 +85,7 @@ type Test interface {
 	GoWithCancel(task.Func, ...task.Option) context.CancelFunc
 	NewGroup(...task.Option) task.Group
 	NewErrorGroup(...task.Option) task.ErrorGroup
+	Monitor() Monitor
 
 	// DeprecatedWorkload returns the path to the workload binary.
 	// Don't use this, invoke `./cockroach workload` instead.

--- a/pkg/cmd/roachtest/test/test_monitor.go
+++ b/pkg/cmd/roachtest/test/test_monitor.go
@@ -1,0 +1,8 @@
+package test
+
+// Monitor is an interface for monitoring cockroach processes during a test.
+type Monitor interface {
+	ExpectDeath()
+	ExpectDeaths(count int32)
+	ResetDeaths()
+}

--- a/pkg/cmd/roachtest/test_impl.go
+++ b/pkg/cmd/roachtest/test_impl.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestflags"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil/task"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
@@ -81,6 +82,9 @@ type testImpl struct {
 
 	// taskManager manages tasks (goroutines) for tests.
 	taskManager task.Manager
+
+	// monitor monitors for process death in the cluster.
+	monitor test.Monitor
 
 	runner string
 	// runnerID is the test's main goroutine ID.
@@ -718,6 +722,11 @@ func (t *testImpl) NewGroup(opts ...task.Option) task.Group {
 // NewErrorGroup starts a new task error group.
 func (t *testImpl) NewErrorGroup(opts ...task.Option) task.ErrorGroup {
 	return t.taskManager.NewErrorGroup(task.OptionList(defaultTaskOptions()...), task.OptionList(opts...))
+}
+
+// Monitor returns the test's monitor.
+func (t *testImpl) Monitor() test.Monitor {
+	return t.monitor
 }
 
 // TeamCityEscape escapes a string for use as <value> in a key='<value>' attribute

--- a/pkg/cmd/roachtest/test_monitor.go
+++ b/pkg/cmd/roachtest/test_monitor.go
@@ -1,0 +1,33 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package main
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
+)
+
+var _ test.Monitor = &testMonitorImpl{}
+
+type testMonitorImpl struct {
+	*monitorImpl
+}
+
+func newTestMonitor(ctx context.Context, t test.Test, c *clusterImpl) *testMonitorImpl {
+	return &testMonitorImpl{
+		monitorImpl: newMonitor(ctx, t, c),
+	}
+}
+
+func (m *testMonitorImpl) start() {
+	go func() {
+		err := m.WaitForNodeDeath()
+		if err != nil {
+			m.t.Fatal(err)
+		}
+	}()
+}

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -1287,6 +1287,9 @@ func (r *testRunner) runTest(
 	defer cancel()
 
 	t.taskManager = task.NewManager(runCtx, t.L())
+	testMonitor := newTestMonitor(runCtx, t, c)
+	t.monitor = testMonitor
+
 	t.mu.Lock()
 	// t.Fatal() will cancel this context.
 	t.mu.cancel = cancel
@@ -1314,28 +1317,13 @@ func (r *testRunner) runTest(
 		// Actively poll for VM preemptions, so we can bail out of tests early and
 		// avoid situations where a test times out and the flake assignment logic fails.
 		monitorForPreemptedVMs(runCtx, t, c, l)
+
+		monitorTasks(runCtx, t.taskManager, t, l)
+		if t.spec.Monitor {
+			testMonitor.start()
+		}
 		// This is the call to actually run the test.
 		s.Run(runCtx, t, c)
-	}()
-
-	// Monitor the task manager for completed events, or failure events and log
-	// them. A failure will call t.Errorf which cancels the test's context.
-	go func() {
-		for {
-			select {
-			case event := <-t.taskManager.CompletedEvents():
-				if event.Err == nil {
-					t.L().Printf("task finished: %s", event.Name)
-					continue
-				} else if event.TriggeredByTest {
-					t.L().Printf("task canceled by test: %s", event.Name)
-					continue
-				}
-				t.Errorf("task `%s` returned error: %v", event.Name, event.Err)
-			case <-runCtx.Done():
-				return
-			}
-		}
 	}()
 
 	var timedOut bool
@@ -2151,6 +2139,28 @@ var getPreemptedVMsHook = func(c cluster.Cluster, ctx context.Context, l *logger
 var pollPreemptionInterval struct {
 	syncutil.Mutex
 	interval time.Duration
+}
+
+func monitorTasks(ctx context.Context, taskManager task.Manager, t test.Test, l *logger.Logger) {
+	// Monitor the task manager for completed events, or failure events and log
+	// them. A failure will call t.Errorf which cancels the test's context.
+	go func() {
+		for {
+			select {
+			case event := <-taskManager.CompletedEvents():
+				if event.Err == nil {
+					l.Printf("task finished: %s", event.Name)
+					continue
+				} else if event.TriggeredByTest {
+					t.L().Printf("task canceled by test: %s", event.Name)
+					continue
+				}
+				t.Errorf("task `%s` returned error: %v", event.Name, event.Err)
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
 }
 
 func monitorForPreemptedVMs(ctx context.Context, t test.Test, c cluster.Cluster, l *logger.Logger) {

--- a/pkg/cmd/roachtest/tests/process_lock.go
+++ b/pkg/cmd/roachtest/tests/process_lock.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/stretchr/testify/require"
 )
@@ -39,6 +40,7 @@ func registerProcessLock(r registry.Registry) {
 		EncryptionSupport: registry.EncryptionMetamorphic,
 		Leases:            registry.MetamorphicLeases,
 		Timeout:           2 * runDuration,
+		Monitor:           true,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			startOpts := option.DefaultStartOpts()
 			startSettings := install.MakeClusterSettings()
@@ -59,15 +61,14 @@ func registerProcessLock(r registry.Registry) {
 			rng := randutil.NewTestRandWithSeed(seed)
 
 			t.Status("starting workload")
-			m := c.NewMonitor(ctx, c.CRDBNodes())
-			m.Go(func(ctx context.Context) error {
+			t.Go(func(ctx context.Context, _ *logger.Logger) error {
 				c.Run(ctx, option.WithNodes(c.WorkloadNode()), fmt.Sprintf(`./cockroach workload run kv --read-percent 0 `+
 					`--duration %s --concurrency 512 --max-rate 4096 --tolerate-errors `+
 					` --min-block-bytes=1024 --max-block-bytes=1024 `+
 					`{pgurl:1-3}`, runDuration.String()))
 				return nil
 			})
-			m.Go(func(ctx context.Context) error {
+			t.Go(func(ctx context.Context, l *logger.Logger) error {
 				// Query /proc/ on each of the nodes to retrieve the exact
 				// command used to start the node. This is more future proof
 				// than trying to reconstruct the command deposited into the
@@ -80,7 +81,7 @@ func registerProcessLock(r registry.Registry) {
 					// grepping for `./cockroach start` in ps's output, and
 					// grabbing the first field after stripping leading
 					// whitespace. Then, use this pid cat /proc/<pid>/cmdline.
-					result, err := c.RunWithDetailsSingleNode(ctx, t.L(), option.WithNodes(c.Node(n)),
+					result, err := c.RunWithDetailsSingleNode(ctx, l, option.WithNodes(c.Node(n)),
 						"cat /proc/`ps -eo pid,args | grep -E '([0-9]+) ./cockroach start' |  sed 's/^ *//' | cut -d ' ' -f 1`/cmdline")
 					if err != nil {
 						return err
@@ -107,7 +108,7 @@ func registerProcessLock(r registry.Registry) {
 						}
 					}
 					startCommands[n-1] = cmd.String()
-					t.L().PrintfCtx(ctx, "Retrieved n%d's start command: %s", n, startCommands[n-1])
+					l.PrintfCtx(ctx, "Retrieved n%d's start command: %s", n, startCommands[n-1])
 				}
 
 				done := time.After(runDuration)
@@ -128,30 +129,28 @@ func registerProcessLock(r registry.Registry) {
 							func() {
 								// Try to start the node again.
 								err := c.RunE(ctx, option.WithNodes(c.Node(n)), startCommands[n-1])
-								t.L().PrintfCtx(ctx, "Attempt to start cockroach process on n%d while another cockroach process is still running; error expected: %v", n, err)
+								l.PrintfCtx(ctx, "Attempt to start cockroach process on n%d while another cockroach process is still running; error expected: %v", n, err)
 							},
 							func() {
 								// Try to perform a manual compaction.
 								err := c.RunE(ctx, option.WithNodes(c.Node(n)), fmt.Sprintf("./cockroach debug compact /mnt/data1/cockroach %s", enterpriseEncryption[n-1]))
-								t.L().PrintfCtx(ctx, "Attempt to manual compact store on n%d while another cockroach process is still running; error expected: %v", n, err)
+								l.PrintfCtx(ctx, "Attempt to manual compact store on n%d while another cockroach process is still running; error expected: %v", n, err)
 							},
 							func() {
 								// Restart the node. This verifies that the
 								// other operations that were performed
 								// concurrently with the running process did not
 								// corrupt the on-disk state.
-								m.ExpectDeath()
-								c.Stop(ctx, t.L(), option.DefaultStopOpts(), c.Node(n))
-								c.Start(ctx, t.L(), startOpts, startSettings, c.Node(n))
-								m.ResetDeaths()
+								t.Monitor().ExpectDeath()
+								c.Stop(ctx, l, option.DefaultStopOpts(), c.Node(n))
+								c.Start(ctx, l, startOpts, startSettings, c.Node(n))
+								t.Monitor().ResetDeaths()
 							},
 						}
 						ops[randutil.RandIntInRange(rng, 0, len(ops))]()
 					}
 				}
 			})
-
-			m.Wait()
 		},
 	})
 }

--- a/pkg/roachprod/install/monitor.go
+++ b/pkg/roachprod/install/monitor.go
@@ -16,6 +16,7 @@ import (
 	"strings"
 	"sync"
 	"text/template"
+	"time"
 
 	"github.com/alessio/shellescape"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
@@ -48,6 +49,8 @@ type MonitorProcessDead struct {
 	SQLInstance        int
 	ExitCode           string
 }
+
+type MonitorReady struct{}
 
 type MonitorError struct {
 	Err error
@@ -111,6 +114,11 @@ func (e MonitorProcessDead) String() string {
 		virtualClusterDesc(e.VirtualClusterName, e.SQLInstance), e.ExitCode,
 	)
 }
+
+func (e MonitorReady) String() string {
+	return "monitor is ready"
+}
+
 func (e MonitorError) String() string {
 	return fmt.Sprintf("error: %s", e.Err.Error())
 }
@@ -289,6 +297,7 @@ func (m *monitorNode) monitorNode(ctx context.Context, l *logger.Logger) {
 		m.sendEvent(NodeMonitorInfo{Node: m.node, Event: MonitorError{err}})
 		return
 	}
+	m.sendEvent(NodeMonitorInfo{Node: m.node, Event: MonitorReady{}})
 
 	// Watch for context cancellation, which can happen if the test
 	// fails, or if the monitor loop exits.
@@ -336,18 +345,39 @@ func (c *SyncedCluster) Monitor(
 	l *logger.Logger, ctx context.Context, opts MonitorOpts,
 ) chan NodeMonitorInfo {
 	ch := make(chan NodeMonitorInfo)
+
 	nodes := c.TargetNodes()
 	var wg sync.WaitGroup
 	monitorCtx, cancel := context.WithCancel(ctx)
+
+	type Ready struct {
+		once sync.Once
+		ch   chan struct{}
+	}
+	nodeReady := make(map[Node]*Ready)
+	for _, node := range nodes {
+		nodeReady[node] = &Ready{
+			ch:   make(chan struct{}),
+			once: sync.Once{},
+		}
+	}
 
 	// sendEvent sends the NodeMonitorInfo passed through the channel
 	// that is listened to by the caller. Bails if the context is
 	// canceled.
 	sendEvent := func(info NodeMonitorInfo) {
+		nodeReady[info.Node].once.Do(func() {
+			close(nodeReady[info.Node].ch)
+		})
 		// if the monitor's context is already canceled, do not attempt to
 		// send the error down the channel, as it is most likely *caused*
 		// by the cancelation itself.
 		if monitorCtx.Err() != nil {
+			return
+		}
+
+		// Do not forward the MonitorReady event to the caller.
+		if _, ok := info.Event.(MonitorReady); ok {
 			return
 		}
 
@@ -381,6 +411,19 @@ func (c *SyncedCluster) Monitor(
 		cancel()
 		close(ch)
 	}()
+
+	// Wait for all monitoring goroutines to be ready.
+	for node, ready := range nodeReady {
+		select {
+		case <-ready.ch:
+			fmt.Println("READY!")
+		case <-monitorCtx.Done():
+			return ch
+		case <-time.After(30 * time.Second):
+			sendEvent(NodeMonitorInfo{Node: node, Event: MonitorError{errors.New("timed out waiting for monitor to start")}})
+			return ch
+		}
+	}
 
 	return ch
 }


### PR DESCRIPTION
Previously, tests would use `roachprod.Monitor` to start monitoring cockroach
processes on a cluster, but there is no guarantee that the monitor is
immediately active right after the call to start monitoring. The goroutines that
watch the processes are all started in the background. This could create a
situation where a process event goes unnoticed.

This change adds a ready event that the internal monitor logic waits for before
returning from the function. This ensures the monitor is ready to detect any
process changes before returning control to the caller.

Epic: None
Release note: None