### PR TITLE
crosscluster/logical: remove useless log line

### DIFF
--- a/pkg/crosscluster/logical/offline_initial_scan_processor.go
+++ b/pkg/crosscluster/logical/offline_initial_scan_processor.go
@@ -374,7 +374,6 @@ func (o *offlineInitialScanProcessor) checkpoint(
 		}
 	}
 
-	log.Infof(ctx, "flushing batcher on checkpoint")
 	if err := o.flushBatch(ctx); err != nil {
 		return errors.Wrap(err, "flushing batcher on checkpoint")
 	}


### PR DESCRIPTION
Noticed this while investigating #141569

Epic: none

Release note: none