### PR TITLE
kvserver: show store number when printing metrics

### DIFF
--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -3705,6 +3705,7 @@ func (s *Store) computeMetricsLocked(ctx context.Context) (m storage.Metrics, er
 func (s *Store) ComputeMetricsPeriodically(
 	ctx context.Context, prevMetrics *storage.MetricsForInterval, tick int,
 ) (m storage.Metrics, err error) {
+	ctx = s.AnnotateCtx(ctx)
 	m, err = s.computeMetrics(ctx)
 	if err != nil {
 		return m, err
@@ -3779,9 +3780,7 @@ func (s *Store) ComputeMetricsPeriodically(
 	// non-periodic callers of this method don't trigger expensive
 	// stats.
 	if tick%logSSTInfoTicks == 1 /* every 10m */ {
-		// NB: The initial blank line ensures that compaction stats display
-		// will not contain the log prefix.
-		log.Storage.Infof(ctx, "\n%s", m.Metrics)
+		log.Storage.Infof(ctx, "Pebble metrics:\n%s", m.Metrics)
 	}
 	// Periodically emit a store stats structured event to the TELEMETRY channel,
 	// if reporting is enabled. These events are intended to be emitted at low


### PR DESCRIPTION
Annotate the context to include the store tag, and add a log line with
the store number as well.

```
I250218 15:01:57.233455 403 3@kv/kvserver/store.go:3785 ⋮ [T1,Vsystem,n1,s1] 31 Pebble metrics:
I250218 15:01:57.233455 403 3@kv/kvserver/store.go:3785 ⋮ [T1,Vsystem,n1,s1] 31 +      |                             |       |       |   ingested   |     moved    |    written   |       |    amp
I250218 15:01:57.233455 403 3@kv/kvserver/store.go:3785 ⋮ [T1,Vsystem,n1,s1] 31 +level | tables  size val-bl vtables | score |   in  | tables  size | tables  size | tables  size |  read |   r   w
I250218 15:01:57.233455 403 3@kv/kvserver/store.go:3785 ⋮ [T1,Vsystem,n1,s1] 31 +------+-----------------------------+-------+-------+--------------+--------------+--------------+-------+---------
```

Epic: none
Fixes: #141526