### PR TITLE
sql/schemachanger: Fix test flake in row_level_security logic test

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/row_level_security
+++ b/pkg/sql/logictest/testdata/logic_test/row_level_security
@@ -48,7 +48,7 @@ statement ok
 CREATE POLICY p1 on sanity1 USING (true);
 
 # Verify we log to the event log.
-query T
+query T retry
 select "eventType" from system.eventlog order by timestamp desc limit 1;
 ----
 create_policy
@@ -72,7 +72,7 @@ statement ok
 DROP POLICY p1 on sanity1;
 
 # Verify we log to the event log.
-query T
+query T retry
 select "eventType" from system.eventlog order by timestamp desc limit 1;
 ----
 drop_policy


### PR DESCRIPTION
The row_level_security logic test has intermittently flaked when querying the system.eventlog after policy DDL operations. Since logging to system.eventlog is asynchronous for the schema changer, I suspect a timing issue where the CREATE POLICY and DROP POLICY events may not have been logged before the test checks for them. To address this, I’ve added retry logic to these queries.

Epic: CRDB-45203
Release note: None
Closes #141038
Closes https://github.com/cockroachdb/cockroach/issues/141462