### PR TITLE
rac2: print range_id in all range_controller log lines

### DIFF
--- a/pkg/kv/kvserver/kvflowcontrol/rac2/range_controller.go
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/range_controller.go
@@ -2306,7 +2306,8 @@ func (rs *replicaState) createReplicaSendStreamRaftMuLocked(
 	rs.parent.opts.ReplicaMutexAsserter.RaftMuAssertHeld()
 	// Must be in StateReplicate on creation.
 	if log.ExpensiveLogEnabled(ctx, 1) {
-		log.VEventf(ctx, 1, "creating send stream %v for replica %v", rs.stream, rs.desc)
+		log.VEventf(ctx, 1, "r%v creating send stream %v for replica %v",
+			rs.parent.opts.RangeID, rs.stream, rs.desc)
 	}
 	rs.sendStream = &replicaSendStream{
 		parent: rs,
@@ -2694,7 +2695,8 @@ func (rs *replicaState) scheduledRaftMuLocked(
 func (rs *replicaState) closeSendStreamRaftMuLocked(ctx context.Context) {
 	rs.parent.opts.ReplicaMutexAsserter.RaftMuAssertHeld()
 	if log.ExpensiveLogEnabled(ctx, 1) {
-		log.VEventf(ctx, 1, "closing send stream %v for replica %v", rs.stream, rs.desc)
+		log.VEventf(ctx, 1, "r%v closing send stream %v for replica %v",
+			rs.parent.opts.RangeID, rs.stream, rs.desc)
 	}
 	rs.sendStream.mu.Lock()
 	defer rs.sendStream.mu.Unlock()


### PR DESCRIPTION
Ensure that the `RangeID` associated with the `RangeController` is printed in all relevant logging.

Part of: #141620
Release note: None