### PR TITLE
crosscluster/logical: avoid panic in multi-table streams involving UDTs

### DIFF
--- a/pkg/crosscluster/producer/replication_manager.go
+++ b/pkg/crosscluster/producer/replication_manager.go
@@ -208,7 +208,7 @@ func getUDTs(
 
 		typeDescriptors = append(typeDescriptors, typeDesc.TypeDescriptor)
 	}
-	return typeDescriptors, nil, nil
+	return typeDescriptors, foundTypeDescriptors, nil
 }
 
 var useStreaksInLDR = settings.RegisterBoolSetting(

--- a/pkg/sql/catalog/externalcatalog/external_catalog.go
+++ b/pkg/sql/catalog/externalcatalog/external_catalog.go
@@ -105,7 +105,7 @@ func getUDTsForTable(
 		}
 		typeDescriptors = append(typeDescriptors, *typeDesc.TypeDesc())
 	}
-	return typeDescriptors, nil, nil
+	return typeDescriptors, foundTypeDescriptors, nil
 }
 
 // IngestExternalCatalog ingests the tables in the external catalog into into


### PR DESCRIPTION
Previously a single LDR stream involving multiple tables would fail to be created if the tables used user-defined types due to a bug in the helper used to resolve UDTs when called in a loop where successfully resolving a type returned a nil map that was then passed to the next call in the loop, causing it to panic.

Release note (bug fix): fix a bug that prevented starting multi-table LDR streams on tables that used user-defined types.
Epic: none.

Fixes #141598.