### PR TITLE
kvserver: leader lease can't be reacquired immediately after restart

### DIFF
--- a/pkg/kv/kvserver/replica_init.go
+++ b/pkg/kv/kvserver/replica_init.go
@@ -69,19 +69,26 @@ func loadInitializedReplicaForTesting(
 	if err != nil {
 		return nil, err
 	}
-	return newInitializedReplica(store, state)
+
+	// No need to wait for previous lease to expire since this is only used in
+	// tests and some tests don't expect the extra delay.
+	return newInitializedReplica(store, state, false /* waitForPrevLeaseToExpire */)
 }
 
 // newInitializedReplica creates an initialized Replica from its loaded state.
-func newInitializedReplica(store *Store, loaded kvstorage.LoadedReplicaState) (*Replica, error) {
+func newInitializedReplica(
+	store *Store, loaded kvstorage.LoadedReplicaState, waitForPrevLeaseToExpire bool,
+) (*Replica, error) {
 	r := newUninitializedReplicaWithoutRaftGroup(store, loaded.ReplState.Desc.RangeID, loaded.ReplicaID)
 	r.raftMu.Lock()
 	defer r.raftMu.Unlock()
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	if err := r.initRaftMuLockedReplicaMuLocked(loaded); err != nil {
+
+	if err := r.initRaftMuLockedReplicaMuLocked(loaded, waitForPrevLeaseToExpire); err != nil {
 		return nil, err
 	}
+
 	return r, nil
 }
 
@@ -288,7 +295,9 @@ func (r *Replica) setStartKeyLocked(startKey roachpb.RKey) {
 
 // initRaftMuLockedReplicaMuLocked initializes the Replica using the state
 // loaded from storage. Must not be called more than once on a Replica.
-func (r *Replica) initRaftMuLockedReplicaMuLocked(s kvstorage.LoadedReplicaState) error {
+func (r *Replica) initRaftMuLockedReplicaMuLocked(
+	s kvstorage.LoadedReplicaState, waitForPrevLeaseToExpire bool,
+) error {
 	desc := s.ReplState.Desc
 	// Ensure that the loaded state corresponds to the same replica.
 	if desc.RangeID != r.RangeID || s.ReplicaID != r.replicaID {
@@ -332,6 +341,21 @@ func (r *Replica) initRaftMuLockedReplicaMuLocked(s kvstorage.LoadedReplicaState
 	// Instead, we make the first lease special (which is OK) and the problem
 	// disappears.
 	if r.shMu.state.Lease.Sequence > 0 {
+		if waitForPrevLeaseToExpire {
+			// Wait for the previous lease to expire. This is important because if the
+			// node was restarted, we don't want to reacquire the lease with a start
+			// time that overlaps the previous lease.
+			// This ensures that we don't serve a write request with the new
+			// lease that contradicts a future read served by the old lease before the
+			// restart (we would have lost that timestamp cache).
+			// Note that we need to sleep (instead of just forwarding the
+			// minLeaseProposedTS) because we will run into assertions where the
+			// lease proposed time is in the future compared to r.Clock().Now(), and
+			// we don't allow acquiring a lease that starts in the future.
+			if err := r.waitForPreviousLeaseToExpire(r.store); err != nil {
+				return err
+			}
+		}
 		r.mu.minLeaseProposedTS = r.Clock().NowAsClockTimestamp()
 	}
 
@@ -487,4 +511,23 @@ func (r *Replica) setDescLockedRaftMuLocked(ctx context.Context, desc *roachpb.R
 			r.store.scheduler.AddPriorityID(desc.RangeID)
 		}
 	}
+}
+
+// waitForPreviousLeaseToExpire waits for the previous lease to expire. It does
+// so by sleeping until Clock().Now() is in the future of the previous lease
+// expiration. This works for expiration-based leases, and leader-leases but
+// only best-effort for epoch-based leases since the liveness record might not
+// be found in cache after the restart.
+func (r *Replica) waitForPreviousLeaseToExpire(store *Store) error {
+	st := r.leaseStatusAtRLocked(r.AnnotateCtx(context.TODO()), r.Clock().NowAsClockTimestamp())
+	if st.OwnedBy(store.StoreID()) {
+		// Only sleep if we were the previous lease owner.
+		if err := r.Clock().SleepUntil(
+			r.AnnotateCtx(context.TODO()),
+			st.Expiration().Next(),
+		); err != nil {
+			return err
+		}
+	}
+	return nil
 }

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -2318,7 +2318,7 @@ func (s *Store) Start(ctx context.Context, stopper *stop.Stopper) error {
 		if err != nil {
 			return err
 		}
-		rep, err := newInitializedReplica(s, state)
+		rep, err := newInitializedReplica(s, state, true /* waitForPrevLeaseToExpire */)
 		if err != nil {
 			return err
 		}

--- a/pkg/kv/kvserver/store_split.go
+++ b/pkg/kv/kvserver/store_split.go
@@ -248,7 +248,9 @@ func prepareRightReplicaForSplit(
 	// Already holding raftMu, see above.
 	rightRepl.mu.Lock()
 	defer rightRepl.mu.Unlock()
-	if err := rightRepl.initRaftMuLockedReplicaMuLocked(state); err != nil {
+	if err := rightRepl.initRaftMuLockedReplicaMuLocked(
+		state, false, /* waitForPrevLeaseToExpire */
+	); err != nil {
 		log.Fatalf(ctx, "%v", err)
 	}
 


### PR DESCRIPTION
This commit causes the node to wait for previous acquired leases to expire after a restart. This works for expiration and leader leases, but not epoch leases since liveness record might not be found in cache. This doesn't change the current behaviour for epoch-based leases. However, it fixes the problem for both expiration-based and leader leases.

This is important to avoid situations where we might accept a write operation that violates a previously served future read with the previous lease before the restart (We lose the timestamp cache after restarts).

Release note: None

References: #59874