### PR TITLE
release-24.2: roachtest: skip online restore tests on released versions

### DIFF
--- a/pkg/ccl/backupccl/backuptestutils/BUILD.bazel
+++ b/pkg/ccl/backupccl/backuptestutils/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
     deps = [
         "//pkg/base",
         "//pkg/ccl/backupccl/backupbase",
+        "//pkg/clusterversion",
         "//pkg/jobs",
         "//pkg/keyvisualizer",
         "//pkg/kv/kvserver",

--- a/pkg/ccl/backupccl/backuptestutils/testutils.go
+++ b/pkg/ccl/backupccl/backuptestutils/testutils.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	_ "github.com/cockroachdb/cockroach/pkg/ccl/backupccl/backupbase" // imported for cluster settings.
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/keyvisualizer"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
@@ -30,6 +31,11 @@ import (
 	"github.com/kr/pretty"
 	"github.com/stretchr/testify/require"
 )
+
+func IsOnlineRestoreSupported() bool {
+	// TODO(jeffswenson): relax this check once online restore is in preview.
+	return clusterversion.DevelopmentBranch
+}
 
 const (
 	// SingleNode is the size of a single node test cluster.

--- a/pkg/cmd/roachtest/tests/BUILD.bazel
+++ b/pkg/cmd/roachtest/tests/BUILD.bazel
@@ -206,6 +206,7 @@ go_library(
     deps = [
         "//pkg/base",
         "//pkg/blobs",
+        "//pkg/ccl/backupccl/backuptestutils",
         "//pkg/ccl/changefeedccl",
         "//pkg/ccl/changefeedccl/cdctest",
         "//pkg/ccl/changefeedccl/changefeedbase",

--- a/pkg/cmd/roachtest/tests/online_restore.go
+++ b/pkg/cmd/roachtest/tests/online_restore.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/ccl/backupccl/backuptestutils"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/clusterstats"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
@@ -131,6 +132,10 @@ func registerOnlineRestorePerf(r registry.Registry) {
 					if !useWorkarounds {
 						sp.skip = "used for ad hoc experiments"
 						sp.namePrefix = sp.namePrefix + fmt.Sprintf("/workarounds=%t", useWorkarounds)
+					}
+
+					if sp.skip == "" && !backuptestutils.IsOnlineRestoreSupported() {
+						sp.skip = "online restore is only tested on development branch"
 					}
 
 					sp.initTestName()


### PR DESCRIPTION
Backport 1/1 commits from #141640.

/cc @cockroachdb/release

Release justification: test only change

---

Online restore is currently under development. We will skip online roachtests on released versions in order to minimize test toil.

Release note: none
Fixes: #138931
Fixes: #139124
Fixes: #139507
