### PR TITLE
roachtest: add kv(0|95)/*/size=64kb/splt=100 test variants

### DIFF
--- a/pkg/cmd/roachtest/tests/kv.go
+++ b/pkg/cmd/roachtest/tests/kv.go
@@ -237,6 +237,14 @@ func registerKV(r registry.Registry) {
 		{nodes: 3, cpus: 32, readPercent: 0, blockSize: 1 << 16 /* 64 KB */},
 		{nodes: 3, cpus: 32, readPercent: 95, blockSize: 1 << 16 /* 64 KB */},
 
+		// Configs with large (64kb only) block sizes and pre-splits. These examine
+		// the impact of large block sizes without range splits occurring during
+		// the workload run. +100 replicas per-node, with RF=3 and 3 nodes.
+		{nodes: 3, cpus: 8, readPercent: 0, blockSize: 1 << 16 /* 64 KB */, splits: 100},
+		{nodes: 3, cpus: 8, readPercent: 95, blockSize: 1 << 16 /* 64 KB */, splits: 100},
+		{nodes: 3, cpus: 32, readPercent: 0, blockSize: 1 << 16 /* 64 KB */, splits: 100},
+		{nodes: 3, cpus: 32, readPercent: 95, blockSize: 1 << 16 /* 64 KB */, splits: 100},
+
 		// Configs with large batch sizes.
 		{nodes: 3, cpus: 8, readPercent: 0, batchSize: 16},
 		{nodes: 3, cpus: 8, readPercent: 95, batchSize: 16},


### PR DESCRIPTION
This commit introduces four additional `kv` roachtests:

```
kv95/enc=false/nodes=3/size=64kb/splt=100
kv95/enc=false/nodes=3/cpu=32/size=64kb/splt=100
kv0/enc=false/nodes=3/size=64kb/splt=100
kv0/enc=false/nodes=3/cpu=32/size=64kb/splt=100
```

Resolves: #141624
Release note: None