### PR TITLE
sql/schemachanger: Fix test flake in triggers logic test

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/triggers
+++ b/pkg/ccl/logictestccl/testdata/logic_test/triggers
@@ -4009,7 +4009,7 @@ statement ok
 CREATE TRIGGER foo AFTER INSERT ON xy FOR EACH ROW EXECUTE FUNCTION f();
 
 # Verify we log to the event log.
-query T
+query T retry
 select "eventType" from system.eventlog order by timestamp desc limit 1;
 ----
 create_trigger
@@ -4021,7 +4021,7 @@ statement ok
 DROP TRIGGER foo ON xy;
 
 # Verify we log to the event log.
-query T
+query T retry
 select "eventType" from system.eventlog order by timestamp desc limit 1;
 ----
 drop_trigger


### PR DESCRIPTION
The triggers logic test has intermittently flaked when querying the system.eventlog after schema change operations. Since logging to system.eventlog is asynchronous for the schema changer, I suspect a timing issue where the DDL triggering the events may not have been logged before the test checks for them. To address this, I’ve added retry logic to these queries.

Epic: None
Release note: None
Closes #141158
Closes #141612