### PR TITLE
sqlstats: remove insights.AnomalyDetector field

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -454,7 +454,6 @@ func NewServer(cfg *ExecutorConfig, pool *mon.BytesMonitor) *Server {
 		pool,
 		nil, /* reportedProvider */
 		cfg.SQLStatsTestingKnobs,
-		insightsProvider.Anomalies(),
 	)
 	reportedSQLStatsController := reportedSQLStats.GetController(cfg.SQLStatusServer)
 	memSQLStats := sslocal.New(
@@ -466,7 +465,6 @@ func NewServer(cfg *ExecutorConfig, pool *mon.BytesMonitor) *Server {
 		pool,
 		reportedSQLStats,
 		cfg.SQLStatsTestingKnobs,
-		insightsProvider.Anomalies(),
 	)
 	s := &Server{
 		cfg:                     cfg,

--- a/pkg/sql/sqlstats/sslocal/sql_stats.go
+++ b/pkg/sql/sqlstats/sslocal/sql_stats.go
@@ -12,7 +12,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats"
-	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats/insights"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats/ssmemstorage"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
@@ -44,8 +43,6 @@ type SQLStats struct {
 	flushTarget Sink
 
 	knobs *sqlstats.TestingKnobs
-
-	anomalies *insights.AnomalyDetector
 }
 
 func newSQLStats(
@@ -57,7 +54,6 @@ func newSQLStats(
 	parentMon *mon.BytesMonitor,
 	flushTarget Sink,
 	knobs *sqlstats.TestingKnobs,
-	anomalies *insights.AnomalyDetector,
 ) *SQLStats {
 	monitor := mon.NewMonitor(mon.Options{
 		Name:       mon.MakeMonitorName("SQLStats"),
@@ -70,7 +66,6 @@ func newSQLStats(
 		st:          st,
 		flushTarget: flushTarget,
 		knobs:       knobs,
-		anomalies:   anomalies,
 	}
 	s.atomic = ssmemstorage.NewSQLStatsAtomicCounters(
 		st,
@@ -113,7 +108,6 @@ func (s *SQLStats) getStatsForApplication(appName string) *ssmemstorage.Containe
 		s.mu.mon,
 		appName,
 		s.knobs,
-		s.anomalies,
 	)
 	s.mu.apps[appName] = a
 	return a

--- a/pkg/sql/sqlstats/sslocal/sql_stats_test.go
+++ b/pkg/sql/sqlstats/sslocal/sql_stats_test.go
@@ -453,7 +453,6 @@ func TestExplicitTxnFingerprintAccounting(t *testing.T) {
 		monitor,
 		nil, /* reportingSink */
 		nil, /* knobs */
-		insightsProvider.Anomalies(),
 	)
 
 	appStats := sqlStats.GetApplicationStats("" /* appName */)
@@ -581,7 +580,6 @@ func TestAssociatingStmtStatsWithTxnFingerprint(t *testing.T) {
 			monitor,
 			nil,
 			nil,
-			insightsProvider.Anomalies(),
 		)
 		appStats := sqlStats.GetApplicationStats("" /* appName */)
 		statsCollector := sslocal.NewStatsCollector(
@@ -1711,7 +1709,6 @@ func TestSQLStats_ConsumeStats(t *testing.T) {
 		Name:     mon.MakeMonitorName("test"),
 		Settings: st,
 	})
-	insightsProvider := insights.New(st, insights.NewMetrics(), nil)
 
 	sqlStats := sslocal.New(
 		st,
@@ -1722,7 +1719,6 @@ func TestSQLStats_ConsumeStats(t *testing.T) {
 		monitor,
 		nil, /* reportingSink */
 		nil, /* knobs */
-		insightsProvider.Anomalies(),
 	)
 
 	stmtContainer, _, _ := ssmemstorage.NewTempContainerFromExistingStmtStats(testStmtData)

--- a/pkg/sql/sqlstats/sslocal/sslocal_provider.go
+++ b/pkg/sql/sqlstats/sslocal/sslocal_provider.go
@@ -15,7 +15,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats"
-	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats/insights"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats/ssmemstorage"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
@@ -35,7 +34,6 @@ func New(
 	pool *mon.BytesMonitor,
 	reportingSink Sink,
 	knobs *sqlstats.TestingKnobs,
-	anomalies *insights.AnomalyDetector,
 ) *SQLStats {
 	return newSQLStats(
 		settings,
@@ -46,7 +44,6 @@ func New(
 		pool,
 		reportingSink,
 		knobs,
-		anomalies,
 	)
 }
 
@@ -101,7 +98,6 @@ func (s *SQLStats) GetApplicationStats(appName string) *ssmemstorage.Container {
 		s.mu.mon,
 		appName,
 		s.knobs,
-		s.anomalies,
 	)
 	s.mu.apps[appName] = a
 	return a

--- a/pkg/sql/sqlstats/ssmemstorage/BUILD.bazel
+++ b/pkg/sql/sqlstats/ssmemstorage/BUILD.bazel
@@ -19,7 +19,6 @@ go_library(
         "//pkg/sql/execstats",
         "//pkg/sql/pgwire/pgerror",
         "//pkg/sql/sqlstats",
-        "//pkg/sql/sqlstats/insights",
         "//pkg/util",
         "//pkg/util/log",
         "//pkg/util/mon",
@@ -36,9 +35,7 @@ go_test(
     deps = [
         "//pkg/settings/cluster",
         "//pkg/sql/appstatspb",
-        "//pkg/sql/clusterunique",
         "//pkg/sql/sqlstats",
-        "//pkg/sql/sqlstats/insights",
         "//pkg/util/leaktest",
         "//pkg/util/log",
         "//pkg/util/mon",

--- a/pkg/sql/sqlstats/ssmemstorage/ss_mem_storage.go
+++ b/pkg/sql/sqlstats/ssmemstorage/ss_mem_storage.go
@@ -21,7 +21,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/appstatspb"
 	"github.com/cockroachdb/cockroach/pkg/sql/execstats"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats"
-	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats/insights"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
@@ -90,8 +89,7 @@ type Container struct {
 	txnCounts transactionCounts
 	mon       *mon.BytesMonitor
 
-	knobs     *sqlstats.TestingKnobs
-	anomalies *insights.AnomalyDetector
+	knobs *sqlstats.TestingKnobs
 }
 
 // New returns a new instance of Container.
@@ -101,14 +99,12 @@ func New(
 	mon *mon.BytesMonitor,
 	appName string,
 	knobs *sqlstats.TestingKnobs,
-	anomalies *insights.AnomalyDetector,
 ) *Container {
 	s := &Container{
 		st:                st,
 		appName:           appName,
 		mon:               mon,
 		knobs:             knobs,
-		anomalies:         anomalies,
 		uniqueServerCount: uniqueServerCount,
 	}
 
@@ -205,7 +201,6 @@ func NewTempContainerFromExistingStmtStats(
 		nil, /* mon */
 		appName,
 		nil, /* knobs */
-		nil, /*anomalies */
 	)
 
 	for i := range statistics {
@@ -278,7 +273,6 @@ func NewTempContainerFromExistingTxnStats(
 		nil, /* mon */
 		appName,
 		nil, /* knobs */
-		nil, /* anomalies */
 	)
 
 	for i := range statistics {
@@ -310,7 +304,6 @@ func (s *Container) NewApplicationStatsWithInheritedOptions() *Container {
 		s.mon,
 		s.appName,
 		s.knobs,
-		s.anomalies,
 	)
 }
 

--- a/pkg/sql/sqlstats/ssmemstorage/ss_mem_writer_test.go
+++ b/pkg/sql/sqlstats/ssmemstorage/ss_mem_writer_test.go
@@ -11,9 +11,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/appstatspb"
-	"github.com/cockroachdb/cockroach/pkg/sql/clusterunique"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats"
-	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats/insights"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
@@ -32,18 +30,11 @@ func TestRecordStatement(t *testing.T) {
 		settings.Manual.Store(true)
 		sqlstats.TxnStatsEnable.Override(ctx, &settings.SV, false)
 		// Initialize knobs & mem container.
-		numStmtInsights := 0
-		knobs := &insights.TestingKnobs{
-			InsightsWriterStmtInterceptor: func(sessionID clusterunique.ID, statement *insights.Statement) {
-				numStmtInsights++
-			},
-		}
 		memContainer := New(settings,
 			nil, /* uniqueServerCount */
 			testMonitor(ctx, "test-mon", settings),
 			"test-app",
 			nil,
-			insights.New(settings, insights.NewMetrics(), knobs).Anomalies(),
 		)
 		// Record a statement, ensure no insights are generated.
 		statsKey := appstatspb.StatementStatisticsKey{
@@ -51,7 +42,6 @@ func TestRecordStatement(t *testing.T) {
 		}
 		err := memContainer.RecordStatement(ctx, statsKey, sqlstats.RecordedStmtStats{})
 		require.NoError(t, err)
-		require.Zero(t, numStmtInsights)
 	})
 }
 
@@ -66,22 +56,14 @@ func TestRecordTransaction(t *testing.T) {
 		settings.Manual.Store(true)
 		sqlstats.TxnStatsEnable.Override(ctx, &settings.SV, false)
 		// Initialize knobs & mem container.
-		numTxnInsights := 0
-		knobs := &insights.TestingKnobs{
-			InsightsWriterTxnInterceptor: func(sessionID clusterunique.ID, transaction *insights.Transaction) {
-				numTxnInsights++
-			},
-		}
 		memContainer := New(settings,
 			nil, /* uniqueServerCount */
 			testMonitor(ctx, "test-mon", settings),
 			"test-app",
 			nil,
-			insights.New(settings, insights.NewMetrics(), knobs).Anomalies(),
 		)
 		// Record a transaction, ensure no insights are generated.
 		require.NoError(t, memContainer.RecordTransaction(ctx, appstatspb.TransactionFingerprintID(123), sqlstats.RecordedTxnStats{}))
-		require.Zero(t, numTxnInsights)
 	})
 }
 


### PR DESCRIPTION
Remove field `anomalies` where appropriate since this is no longer in use.

Epic: none

Release note: None