### PR TITLE
release-23.2: opt: copy UDF body statements when assigning placeholders

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/udf
+++ b/pkg/sql/logictest/testdata/logic_test/udf
@@ -821,3 +821,28 @@ SELECT f('0');
 
 statement ok
 DROP FUNCTION f(TEXT);
+
+# Regression test for #104009.
+statement ok
+CREATE TABLE ab104009(a INT PRIMARY KEY, b INT)
+
+statement ok
+CREATE TABLE cd104009(c INT PRIMARY KEY, d INT)
+
+statement ok
+CREATE TABLE e104009(e INT PRIMARY KEY)
+
+statement ok
+CREATE FUNCTION f(o INT) RETURNS STRING STABLE LANGUAGE SQL AS $$
+  SELECT a
+  FROM ab104009
+  JOIN cd104009 ON a = c
+  JOIN e104009 ON b = e
+  WHERE b = $1
+$$
+
+statement ok
+PREPARE p AS SELECT f($1::REGCLASS::INT)
+
+statement ok
+EXECUTE p(10)

--- a/pkg/sql/opt/norm/factory.go
+++ b/pkg/sql/opt/norm/factory.go
@@ -350,32 +350,38 @@ func (f *Factory) AssignPlaceholders(from *memo.Memo) (err error) {
 	// the copy proceeds.
 	var replaceFn ReplaceFunc
 	replaceFn = func(e opt.Expr) opt.Expr {
-		if placeholder, ok := e.(*memo.PlaceholderExpr); ok {
+		switch t := e.(type) {
+		case *memo.PlaceholderExpr:
 			d, err := eval.Expr(f.ctx, f.evalCtx, e.(*memo.PlaceholderExpr).Value)
 			if err != nil {
 				panic(err)
 			}
-			return f.ConstructConstVal(d, placeholder.DataType())
-		}
-		// A recursive CTE may have the stats change on its Initial expression
-		// after placeholder assignment, if that happens we need to
-		// propagate that change to the Binding expression and rebuild
-		// everything.
-		if rcte, ok := e.(*memo.RecursiveCTEExpr); ok {
-			newInitial := f.CopyAndReplaceDefault(rcte.Initial, replaceFn).(memo.RelExpr)
-			if newInitial != rcte.Initial {
+			return f.ConstructConstVal(d, t.DataType())
+		case *memo.UDFCallExpr:
+			// Statements in the body of a UDF cannot have placeholders, but
+			// they must be copied so that they reference the new memo.
+			for i := range t.Def.Body {
+				t.Def.Body[i] = f.CopyAndReplaceDefault(t.Def.Body[i], replaceFn).(memo.RelExpr)
+			}
+		case *memo.RecursiveCTEExpr:
+			// A recursive CTE may have the stats change on its Initial expression
+			// after placeholder assignment, if that happens we need to
+			// propagate that change to the Binding expression and rebuild
+			// everything.
+			newInitial := f.CopyAndReplaceDefault(t.Initial, replaceFn).(memo.RelExpr)
+			if newInitial != t.Initial {
 				newBinding := f.ConstructFakeRel(&memo.FakeRelPrivate{
 					Props: MakeBindingPropsForRecursiveCTE(
-						props.AnyCardinality, rcte.Binding.Relational().OutputCols,
+						props.AnyCardinality, t.Binding.Relational().OutputCols,
 						newInitial.Relational().Statistics().RowCount)})
-				if id := rcte.WithBindingID(); id != 0 {
+				if id := t.WithBindingID(); id != 0 {
 					f.Metadata().AddWithBinding(id, newBinding)
 				}
 				return f.ConstructRecursiveCTE(
 					newBinding,
 					newInitial,
-					f.invokeReplace(rcte.Recursive, replaceFn).(memo.RelExpr),
-					&rcte.RecursiveCTEPrivate,
+					f.invokeReplace(t.Recursive, replaceFn).(memo.RelExpr),
+					&t.RecursiveCTEPrivate,
 				)
 			}
 		}


### PR DESCRIPTION
Backport 1/1 commits from #141596.

/cc @cockroachdb/release

---

Statements within a UDF body are now copied into the new memo when a
cached memo is reused. This ensures that references in the statements
correctly point to the new memo and its inner objects, like metadata.

Fixes #104009

Release note (bug fix): A bug has been fixed that could cause "nil
pointer dereference" errors when executing statements with UDFs. The
error could also occur when executing statements with some built-in
functions, like obj_description.

---

Release justification: Low-risk bug fix.

