### PR TITLE
vecindex: rename vector parameters to vec

### DIFF
--- a/pkg/sql/vecindex/internal/workspace.go
+++ b/pkg/sql/vecindex/internal/workspace.go
@@ -62,8 +62,8 @@ func (w *Workspace) AllocVector(dims int) vector.T {
 }
 
 // FreeVector reclaims a temporary vector that was previously allocated.
-func (w *Workspace) FreeVector(vector vector.T) {
-	w.FreeFloats(vector)
+func (w *Workspace) FreeVector(vec vector.T) {
+	w.FreeFloats(vec)
 }
 
 // AllocVectorSet returns a temporary vector set having the given number of

--- a/pkg/sql/vecindex/vecstore/in_memory_store.go
+++ b/pkg/sql/vecindex/vecstore/in_memory_store.go
@@ -293,11 +293,11 @@ func (s *InMemoryStore) MergeStats(ctx context.Context, stats *IndexStats, skipM
 // InsertVector inserts a new full-size vector into the in-memory store,
 // associated with the given primary key. This mimics inserting a vector into
 // the primary index, and is used during testing and benchmarking.
-func (s *InMemoryStore) InsertVector(key KeyBytes, vector vector.T) {
+func (s *InMemoryStore) InsertVector(key KeyBytes, vec vector.T) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 
-	s.mu.vectors[string(key)] = vector
+	s.mu.vectors[string(key)] = vec
 }
 
 // DeleteVector deletes the vector associated with the given primary key from

--- a/pkg/sql/vecindex/vecstore/in_memory_txn.go
+++ b/pkg/sql/vecindex/vecstore/in_memory_txn.go
@@ -209,7 +209,7 @@ func (tx *inMemoryTxn) GetPartitionMetadata(
 func (tx *inMemoryTxn) AddToPartition(
 	ctx context.Context,
 	partitionKey PartitionKey,
-	vector vector.T,
+	vec vector.T,
 	childKey ChildKey,
 	valueBytes ValueBytes,
 ) (PartitionMetadata, error) {
@@ -235,7 +235,7 @@ func (tx *inMemoryTxn) AddToPartition(
 
 	// Add the vector to the partition.
 	partition := inMemPartition.lock.partition
-	if partition.Add(ctx, vector, childKey, valueBytes) {
+	if partition.Add(ctx, vec, childKey, valueBytes) {
 		tx.store.mu.Lock()
 		defer tx.store.mu.Unlock()
 		tx.store.reportPartitionSizeLocked(partition.Count())

--- a/pkg/sql/vecindex/vecstore/partition.go
+++ b/pkg/sql/vecindex/vecstore/partition.go
@@ -183,7 +183,7 @@ func (p *Partition) Search(
 // Add quantizes the given vector as part of this partition. If a vector with
 // the same key is already in the partition, update its value and return false.
 func (p *Partition) Add(
-	ctx context.Context, vector vector.T, childKey ChildKey, valueBytes ValueBytes,
+	ctx context.Context, vec vector.T, childKey ChildKey, valueBytes ValueBytes,
 ) bool {
 	offset := p.Find(childKey)
 	if offset != -1 {
@@ -191,7 +191,7 @@ func (p *Partition) Add(
 		p.ReplaceWithLast(offset)
 	}
 
-	vectorSet := vector.AsSet()
+	vectorSet := vec.AsSet()
 	p.quantizer.QuantizeInSet(ctx, p.quantizedSet, vectorSet)
 	p.childKeys = append(p.childKeys, childKey)
 	p.valueBytes = append(p.valueBytes, valueBytes)

--- a/pkg/sql/vecindex/vecstore/persistent_txn.go
+++ b/pkg/sql/vecindex/vecstore/persistent_txn.go
@@ -341,7 +341,7 @@ func (psTxn *persistentStoreTxn) GetPartitionMetadata(
 func (psTxn *persistentStoreTxn) AddToPartition(
 	ctx context.Context,
 	partitionKey PartitionKey,
-	vector vector.T,
+	vec vector.T,
 	childKey ChildKey,
 	valueBytes ValueBytes,
 ) (PartitionMetadata, error) {
@@ -373,7 +373,7 @@ func (psTxn *persistentStoreTxn) AddToPartition(
 
 	// Add the Put command to the batch.
 	codec := psTxn.getCodecForPartitionKey(partitionKey)
-	encodedValue, err := codec.encodeVector(ctx, vector, metadata.Centroid)
+	encodedValue, err := codec.encodeVector(ctx, vec, metadata.Centroid)
 	if err != nil {
 		return PartitionMetadata{}, err
 	}

--- a/pkg/sql/vecindex/vecstore/store.go
+++ b/pkg/sql/vecindex/vecstore/store.go
@@ -123,7 +123,7 @@ type Txn interface {
 	AddToPartition(
 		ctx context.Context,
 		partitionKey PartitionKey,
-		vector vector.T,
+		vec vector.T,
 		childKey ChildKey,
 		valueBytes ValueBytes,
 	) (PartitionMetadata, error)


### PR DESCRIPTION
Avoid using "vector" for parameter/variable names, since that's the name of a package.

Epic: CRDB-42943

Release note: None