### PR TITLE
sql: added support for row level security to pg_class

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/row_level_security
+++ b/pkg/sql/logictest/testdata/logic_test/row_level_security
@@ -572,6 +572,11 @@ roaches  CREATE TABLE public.roaches (
 statement ok
 ALTER TABLE roaches DISABLE ROW LEVEL SECURITY;
 
+query TBB
+select relname, relrowsecurity, relforcerowsecurity from pg_class where relname = 'roaches';
+----
+roaches  false  false
+
 query TT
 SHOW CREATE TABLE roaches
 ----
@@ -585,6 +590,11 @@ subtest alter_table_rls_force_no_force
 statement ok
 ALTER TABLE roaches FORCE ROW LEVEL SECURITY;
 
+query TBB
+select relname, relrowsecurity, relforcerowsecurity from pg_class where relname = 'roaches';
+----
+roaches  false  true
+
 query TT
 SHOW CREATE TABLE roaches
 ----
@@ -596,6 +606,11 @@ roaches  CREATE TABLE public.roaches (
 
 statement ok
 ALTER TABLE roaches NO FORCE ROW LEVEL SECURITY;
+
+query TBB
+select relname, relrowsecurity, relforcerowsecurity from pg_class where relname = 'roaches';
+----
+roaches  false  false
 
 query TT
 SHOW CREATE TABLE roaches
@@ -618,6 +633,11 @@ roaches  CREATE TABLE public.roaches (
            CONSTRAINT roaches_pkey PRIMARY KEY (rowid ASC)
          );
          ALTER TABLE public.roaches ENABLE ROW LEVEL SECURITY, FORCE ROW LEVEL SECURITY
+
+query TBB
+select relname, relrowsecurity, relforcerowsecurity from pg_class where relname = 'roaches';
+----
+roaches  true  true
 
 query T
 select create_statement from crdb_internal.create_statements where descriptor_name='roaches'

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -794,13 +794,13 @@ https://www.postgresql.org/docs/9.5/catalog-pg-class.html`,
 			tree.DNull,      // relacl
 			relOptions,      // reloptions
 			// These columns were automatically created by pg_catalog_test's missing column generator.
-			tree.DNull,                 // relforcerowsecurity
+			tree.MakeDBool(tree.DBool(table.IsRowLevelSecurityForced())), // relforcerowsecurity
 			tree.DNull,                 // relispartition
 			tree.DNull,                 // relispopulated
 			tree.NewDString(replIdent), // relreplident
 			tree.DNull,                 // relrewrite
-			tree.DNull,                 // relrowsecurity
-			tree.DNull,                 // relpartbound
+			tree.MakeDBool(tree.DBool(table.IsRowLevelSecurityEnabled())), // relrowsecurity
+			tree.DNull, // relpartbound
 			// These columns were automatically created by pg_catalog_test's missing column generator.
 			tree.DNull, // relminmxid
 		); err != nil {
@@ -854,12 +854,12 @@ https://www.postgresql.org/docs/9.5/catalog-pg-class.html`,
 				tree.DNull,      // relacl
 				tree.DNull,      // reloptions
 				// These columns were automatically created by pg_catalog_test's missing column generator.
-				tree.DNull,           // relforcerowsecurity
+				tree.DBoolFalse,      // relforcerowsecurity
 				tree.DNull,           // relispartition
 				tree.DNull,           // relispopulated
 				tree.NewDString("n"), // relreplident
 				tree.DNull,           // relrewrite
-				tree.DNull,           // relrowsecurity
+				tree.DBoolFalse,      // relrowsecurity
 				tree.DNull,           // relpartbound
 				// These columns were automatically created by pg_catalog_test's missing column generator.
 				tree.DNull, // relminmxid
@@ -3532,12 +3532,12 @@ func addPGClassRowForCompositeType(
 		zeroVal,                         // relfrozenxid
 		tree.DNull,                      // relacl
 		tree.DNull,                      // reloptions
-		tree.DNull,                      // relforcerowsecurity
+		tree.DBoolFalse,                 // relforcerowsecurity
 		tree.DNull,                      // relispartition
 		tree.DNull,                      // relispopulated
 		tree.NewDString("n"),            // relreplident (compositite types are views)
 		tree.DNull,                      // relrewrite
-		tree.DNull,                      // relrowsecurity
+		tree.DBoolFalse,                 // relrowsecurity
 		tree.DNull,                      // relpartbound
 		tree.DNull,                      // relminmxid
 	)


### PR DESCRIPTION
Previously the `pg_class` table was not populating the `relrowlevelsecurity` and `relforcerowlevelsecurity` columns.  With these code changes these columns are now populated accordingly.

Epic: CRDB-45205
Informs: #136702
Release note: None