### PR TITLE
opt: prune non-inverted columns after inverted filter

### DIFF
--- a/pkg/sql/opt/xform/index_scan_builder.go
+++ b/pkg/sql/opt/xform/index_scan_builder.go
@@ -272,11 +272,23 @@ func (b *indexScanBuilder) Build(grp memo.RelExpr) {
 	// 4. Wrap input in inverted filter if it was added.
 	if b.hasInvertedFilter() {
 		if !b.hasIndexJoin() {
-			invertedFilter := &memo.InvertedFilterExpr{
-				Input: input, InvertedFilterPrivate: b.invertedFilterPrivate,
+			// An inverted filter can only project-away the inverted column. If
+			// more columns must be pruned, then a project expression is needed.
+			extraCols := input.Relational().OutputCols.Difference(grp.Relational().OutputCols)
+			if extraCols.SingletonOf(b.invertedFilterPrivate.InvertedColumn) {
+				invertedFilter := &memo.InvertedFilterExpr{
+					Input: input, InvertedFilterPrivate: b.invertedFilterPrivate,
+				}
+				b.mem.AddInvertedFilterToGroup(invertedFilter, grp)
+				return
+			} else {
+				project := &memo.ProjectExpr{
+					Input:       b.f.ConstructInvertedFilter(input, &b.invertedFilterPrivate),
+					Passthrough: grp.Relational().OutputCols,
+				}
+				b.mem.AddProjectToGroup(project, grp)
+				return
 			}
-			b.mem.AddInvertedFilterToGroup(invertedFilter, grp)
-			return
 		}
 
 		input = b.f.ConstructInvertedFilter(input, &b.invertedFilterPrivate)

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -8554,6 +8554,50 @@ project
  └── projections
       └── 1 [as="?column?":15]
 
+# Regression test for #136078. A project expression must be added above an
+# inverted filter to prune output columns to match the original group when there
+# is no index join to do so.
+exec-ddl
+CREATE TABLE t136078 (
+  a INT,
+  b STRING,
+  col3_8 STRING AS (lower(b)) VIRTUAL,
+  PRIMARY KEY (a, b),
+  INVERTED INDEX (col3_8 gin_trgm_ops)
+)
+----
+
+opt set=(optimizer_use_trigram_similarity_optimization=false)
+SELECT b FROM t136078 WHERE 'abc' % col3_8
+----
+project
+ ├── columns: b:2!null
+ ├── stable
+ └── inverted-filter
+      ├── columns: a:1!null b:2!null
+      ├── inverted expression: /6
+      │    ├── tight: false, unique: false
+      │    └── union spans
+      │         ├── ["  a", "  a"]
+      │         ├── [" ab", " ab"]
+      │         ├── ["abc", "abc"]
+      │         └── ["bc ", "bc "]
+      ├── stable
+      ├── key: (1,2)
+      └── select
+           ├── columns: a:1!null b:2!null col3_8_inverted_key:6!null
+           ├── stable
+           ├── scan t136078@t136078_col3_8_idx,inverted
+           │    ├── columns: a:1!null b:2!null col3_8_inverted_key:6!null
+           │    └── inverted constraint: /6/1/2
+           │         └── spans
+           │              ├── ["  a", "  a"]
+           │              ├── [" ab", " ab"]
+           │              ├── ["abc", "abc"]
+           │              └── ["bc ", "bc "]
+           └── filters
+                └── 'abc' % lower(b:2) [outer=(2), stable]
+
 
 # --------------------------------------------------
 # GenerateMinimalInvertedIndexScans


### PR DESCRIPTION
The GenerateInvertedIndexScans exploration rule typically prunes output
columns above an inverted filter with an index join. When an index join
is not needed, columns were not correctly pruned, causing test-only
assertion errors. This has been fixed by correctly planning a Project
expression above the inverted filter to prune unnecessary columns.

Fixes #136078

There is no release note because this causes no known bugs.

Release note: None
