### PR TITLE
release-24.3: rowexec: use BulkNormalPri for backfill constructIndexEntries

### DIFF
--- a/pkg/sql/rowexec/indexbackfiller.go
+++ b/pkg/sql/rowexec/indexbackfiller.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/row"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/admission/admissionpb"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -419,7 +420,7 @@ func (ib *indexBackfiller) buildIndexEntryBatch(
 			ctx, txn.KV(), ib.desc, sp, ib.spec.ChunkSize, false, /* traceKV */
 		)
 		return err
-	}); err != nil {
+	}, isql.WithPriority(admissionpb.BulkNormalPri)); err != nil {
 		return nil, nil, 0, err
 	}
 	prepTime := timeutil.Since(start)


### PR DESCRIPTION
Backport 1/1 commits from #139360.

/cc @cockroachdb/release

Release justification: low risk bug fix

---

This appears to have been an oversight. Adding this should help reduce impact on foreground latencies.

Epic: CRDB-42901
Release note: None
