### PR TITLE
roachtest: global test monitor

### DIFF
--- a/pkg/cmd/roachtest/BUILD.bazel
+++ b/pkg/cmd/roachtest/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
         "slack.go",
         "test_filter.go",
         "test_impl.go",
+        "test_monitor.go",
         "test_registry.go",
         "test_runner.go",
         "work_pool.go",

--- a/pkg/cmd/roachtest/cluster_test.go
+++ b/pkg/cmd/roachtest/cluster_test.go
@@ -16,7 +16,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil/task"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
-	test2 "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/vm"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/vm/azure"
@@ -152,7 +152,11 @@ func (t testWrapper) NewErrorGroup(_ ...task.Option) task.ErrorGroup {
 	panic("implement me")
 }
 
-var _ test2.Test = testWrapper{}
+func (t testWrapper) Monitor() test.Monitor {
+	panic("implement me")
+}
+
+var _ test.Test = testWrapper{}
 
 // ArtifactsDir is part of the test.Test interface.
 func (t testWrapper) ArtifactsDir() string {

--- a/pkg/cmd/roachtest/clusterstats/mock_test_generated_test.go
+++ b/pkg/cmd/roachtest/clusterstats/mock_test_generated_test.go
@@ -9,6 +9,7 @@ import (
 	reflect "reflect"
 
 	task "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil/task"
+	test "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	logger "github.com/cockroachdb/cockroach/pkg/roachprod/logger"
 	version "github.com/cockroachdb/cockroach/pkg/util/version"
 	gomock "github.com/golang/mock/gomock"
@@ -327,6 +328,20 @@ func (m *MockTest) L() *logger.Logger {
 func (mr *MockTestMockRecorder) L() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "L", reflect.TypeOf((*MockTest)(nil).L))
+}
+
+// Monitor mocks base method.
+func (m *MockTest) Monitor() test.Monitor {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Monitor")
+	ret0, _ := ret[0].(test.Monitor)
+	return ret0
+}
+
+// Monitor indicates an expected call of Monitor.
+func (mr *MockTestMockRecorder) Monitor() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Monitor", reflect.TypeOf((*MockTest)(nil).Monitor))
 }
 
 // Name mocks base method.

--- a/pkg/cmd/roachtest/registry/test_spec.go
+++ b/pkg/cmd/roachtest/registry/test_spec.go
@@ -167,6 +167,12 @@ type TestSpec struct {
 	// important.
 	Randomized bool
 
+	// Monitor specifies whether the test initiates a process monitor. Eventually,
+	// this should replace all instances of `cluster.NewMonitor`. To make this
+	// transition, tests should be modified to utilize the `test.Monitor` and
+	// `roachtestutil.Task` interfaces provided with each test.
+	Monitor bool
+
 	// stats are populated by test selector based on previous execution data
 	stats *testStats
 }

--- a/pkg/cmd/roachtest/test/BUILD.bazel
+++ b/pkg/cmd/roachtest/test/BUILD.bazel
@@ -2,7 +2,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "test",
-    srcs = ["test_interface.go"],
+    srcs = [
+        "test_interface.go",
+        "test_monitor.go",
+    ],
     importpath = "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test",
     visibility = ["//visibility:public"],
     deps = [

--- a/pkg/cmd/roachtest/test/test_interface.go
+++ b/pkg/cmd/roachtest/test/test_interface.go
@@ -85,6 +85,7 @@ type Test interface {
 	GoWithCancel(task.Func, ...task.Option) context.CancelFunc
 	NewGroup(...task.Option) task.Group
 	NewErrorGroup(...task.Option) task.ErrorGroup
+	Monitor() Monitor
 
 	// DeprecatedWorkload returns the path to the workload binary.
 	// Don't use this, invoke `./cockroach workload` instead.

--- a/pkg/cmd/roachtest/test/test_monitor.go
+++ b/pkg/cmd/roachtest/test/test_monitor.go
@@ -1,0 +1,13 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package test
+
+// Monitor is an interface for monitoring cockroach processes during a test.
+type Monitor interface {
+	ExpectDeath()
+	ExpectDeaths(count int32)
+	ResetDeaths()
+}

--- a/pkg/cmd/roachtest/test_impl.go
+++ b/pkg/cmd/roachtest/test_impl.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestflags"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil/task"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
@@ -81,6 +82,9 @@ type testImpl struct {
 
 	// taskManager manages tasks (goroutines) for tests.
 	taskManager task.Manager
+
+	// monitor monitors for process death in the cluster.
+	monitor test.Monitor
 
 	runner string
 	// runnerID is the test's main goroutine ID.
@@ -718,6 +722,11 @@ func (t *testImpl) NewGroup(opts ...task.Option) task.Group {
 // NewErrorGroup starts a new task error group.
 func (t *testImpl) NewErrorGroup(opts ...task.Option) task.ErrorGroup {
 	return t.taskManager.NewErrorGroup(task.OptionList(defaultTaskOptions()...), task.OptionList(opts...))
+}
+
+// Monitor returns the test's monitor.
+func (t *testImpl) Monitor() test.Monitor {
+	return t.monitor
 }
 
 // TeamCityEscape escapes a string for use as <value> in a key='<value>' attribute

--- a/pkg/cmd/roachtest/test_monitor.go
+++ b/pkg/cmd/roachtest/test_monitor.go
@@ -1,0 +1,33 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package main
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
+)
+
+var _ test.Monitor = &testMonitorImpl{}
+
+type testMonitorImpl struct {
+	*monitorImpl
+}
+
+func newTestMonitor(ctx context.Context, t test.Test, c *clusterImpl) *testMonitorImpl {
+	return &testMonitorImpl{
+		monitorImpl: newMonitor(ctx, t, c),
+	}
+}
+
+func (m *testMonitorImpl) start() {
+	go func() {
+		err := m.WaitForNodeDeath()
+		if err != nil {
+			m.t.Fatal(err)
+		}
+	}()
+}

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -1287,6 +1287,9 @@ func (r *testRunner) runTest(
 	defer cancel()
 
 	t.taskManager = task.NewManager(runCtx, t.L())
+	testMonitor := newTestMonitor(runCtx, t, c)
+	t.monitor = testMonitor
+
 	t.mu.Lock()
 	// t.Fatal() will cancel this context.
 	t.mu.cancel = cancel
@@ -1314,28 +1317,13 @@ func (r *testRunner) runTest(
 		// Actively poll for VM preemptions, so we can bail out of tests early and
 		// avoid situations where a test times out and the flake assignment logic fails.
 		monitorForPreemptedVMs(runCtx, t, c, l)
+
+		monitorTasks(runCtx, t.taskManager, t, l)
+		if t.spec.Monitor {
+			testMonitor.start()
+		}
 		// This is the call to actually run the test.
 		s.Run(runCtx, t, c)
-	}()
-
-	// Monitor the task manager for completed events, or failure events and log
-	// them. A failure will call t.Errorf which cancels the test's context.
-	go func() {
-		for {
-			select {
-			case event := <-t.taskManager.CompletedEvents():
-				if event.Err == nil {
-					t.L().Printf("task finished: %s", event.Name)
-					continue
-				} else if event.TriggeredByTest {
-					t.L().Printf("task canceled by test: %s", event.Name)
-					continue
-				}
-				t.Errorf("task `%s` returned error: %v", event.Name, event.Err)
-			case <-runCtx.Done():
-				return
-			}
-		}
 	}()
 
 	var timedOut bool
@@ -2151,6 +2139,28 @@ var getPreemptedVMsHook = func(c cluster.Cluster, ctx context.Context, l *logger
 var pollPreemptionInterval struct {
 	syncutil.Mutex
 	interval time.Duration
+}
+
+func monitorTasks(ctx context.Context, taskManager task.Manager, t test.Test, l *logger.Logger) {
+	// Monitor the task manager for completed events, or failure events and log
+	// them. A failure will call t.Errorf which cancels the test's context.
+	go func() {
+		for {
+			select {
+			case event := <-taskManager.CompletedEvents():
+				if event.Err == nil {
+					l.Printf("task finished: %s", event.Name)
+					continue
+				} else if event.TriggeredByTest {
+					t.L().Printf("task canceled by test: %s", event.Name)
+					continue
+				}
+				t.Errorf("task `%s` returned error: %v", event.Name, event.Err)
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
 }
 
 func monitorForPreemptedVMs(ctx context.Context, t test.Test, c cluster.Cluster, l *logger.Logger) {


### PR DESCRIPTION
Previously, test authors would use `monitor` in parts of the tests to monitor
cockroach processes. This was because monitor was unable to detect new
processes, but only watch already active processes. Monitor also serves as a
goroutine manager in these tests. But this has become problematic as the duality
of monitor is not always required. There is already a new task API available for
managing goroutines during tests.

This change adds a global monitor on the test interface. The global test monitor
is currently gated behind a test spec. Enabling it will automatically spawn a
monitor before the test starts and any unexpected cockroach process deaths will
result in a test failure. A new monitor interface on the test interface exposes
the required methods for setting process death expectations

Informs: #118214

Epic: None
Release note: None