### PR TITLE
scexec/backfiller: don't stop writing progress and checkpoints

### DIFF
--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -3044,7 +3044,7 @@ func (sc *SchemaChanger) distIndexMerge(
 	}
 
 	stop := periodicFlusher.StartPeriodicUpdates(ctx, tracker)
-	defer func() { _ = stop() }()
+	defer stop()
 
 	run, err := planner.plan(ctx, tableDesc, progress.TodoSpans, progress.AddedIndexes,
 		progress.TemporaryIndexes, metaFn, mergeTimestamp)
@@ -3053,10 +3053,6 @@ func (sc *SchemaChanger) distIndexMerge(
 	}
 
 	if err := run(ctx); err != nil {
-		return err
-	}
-
-	if err := stop(); err != nil {
 		return err
 	}
 

--- a/pkg/sql/schemachanger/scdeps/exec_deps.go
+++ b/pkg/sql/schemachanger/scdeps/exec_deps.go
@@ -629,8 +629,8 @@ func NewNoopPeriodicProgressFlusher() scexec.PeriodicProgressFlusher {
 
 func (n noopPeriodicProgressFlusher) StartPeriodicUpdates(
 	ctx context.Context, tracker scexec.BackfillerProgressFlusher,
-) (stop func() error) {
-	return func() error { return nil }
+) (stop func()) {
+	return func() {}
 }
 
 type constantClock struct {

--- a/pkg/sql/schemachanger/scexec/backfiller/BUILD.bazel
+++ b/pkg/sql/schemachanger/scexec/backfiller/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "//pkg/sql/isql",
         "//pkg/sql/schemachanger/scexec",
         "//pkg/util/intsets",
+        "//pkg/util/log",
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",

--- a/pkg/sql/schemachanger/scexec/backfiller/periodic_progress_flusher.go
+++ b/pkg/sql/schemachanger/scexec/backfiller/periodic_progress_flusher.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/backfill"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scexec"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"golang.org/x/sync/errgroup"
 )
@@ -54,7 +55,7 @@ type periodicProgressFlusher struct {
 
 func (p *periodicProgressFlusher) StartPeriodicUpdates(
 	ctx context.Context, tracker scexec.BackfillerProgressFlusher,
-) (stop func() error) {
+) (stop func()) {
 	stopCh := make(chan struct{})
 	runPeriodicWrite := func(
 		ctx context.Context,
@@ -73,7 +74,7 @@ func (p *periodicProgressFlusher) StartPeriodicUpdates(
 			case <-timer.Ch():
 				timer.MarkRead()
 				if err := write(ctx); err != nil {
-					return err
+					log.Warningf(ctx, "could not flush progress: %v", err)
 				}
 			}
 		}
@@ -88,11 +89,13 @@ func (p *periodicProgressFlusher) StartPeriodicUpdates(
 			ctx, tracker.FlushCheckpoint, p.checkpointInterval)
 	})
 	toClose := stopCh // make the returned function idempotent
-	return func() error {
+	return func() {
 		if toClose != nil {
 			close(toClose)
 			toClose = nil
 		}
-		return g.Wait()
+		if err := g.Wait(); err != nil {
+			log.Warningf(ctx, "waiting for progress flushing goroutines: %v", err)
+		}
 	}
 }

--- a/pkg/sql/schemachanger/scexec/backfiller/tracker.go
+++ b/pkg/sql/schemachanger/scexec/backfiller/tracker.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/isql"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scexec"
 	"github.com/cockroachdb/cockroach/pkg/util/intsets"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 )
 
@@ -216,9 +217,14 @@ func (b *Tracker) SetMergeProgress(ctx context.Context, progress scexec.MergePro
 // FlushFractionCompleted is part of the scexec.BackfillerProgressFlusher interface.
 func (b *Tracker) FlushFractionCompleted(ctx context.Context) error {
 	updated, fractionRangesFinished, err := b.getFractionRangesFinished(ctx)
-	if err != nil || !updated {
+	if err != nil {
 		return err
 	}
+	if !updated {
+		log.VInfof(ctx, 2, "backfill has no fraction completed to flush")
+		return nil
+	}
+	log.Infof(ctx, "backfill fraction completed is %.3f / 1.000", fractionRangesFinished)
 	return b.writeProgressFraction(ctx, fractionRangesFinished)
 }
 
@@ -226,6 +232,7 @@ func (b *Tracker) FlushFractionCompleted(ctx context.Context) error {
 func (b *Tracker) FlushCheckpoint(ctx context.Context) error {
 	needsFlush, bps, mps := b.collectProgressForCheckpointFlush()
 	if !needsFlush {
+		log.VInfof(ctx, 2, "backfill has no checkpoint to flush")
 		return nil
 	}
 	sort.Slice(bps, func(i, j int) bool {
@@ -248,6 +255,7 @@ func (b *Tracker) FlushCheckpoint(ctx context.Context) error {
 		}
 		return false
 	})
+	log.Infof(ctx, "writing %d backfill checkpoints and %d merge checkpoints", len(bps), len(mps))
 	return b.writeCheckpoint(ctx, bps, mps)
 }
 

--- a/pkg/sql/schemachanger/scexec/dependencies.go
+++ b/pkg/sql/schemachanger/scexec/dependencies.go
@@ -315,7 +315,7 @@ type BackfillerTracker interface {
 // PeriodicProgressFlusher is used to write updates to backfill progress
 // periodically.
 type PeriodicProgressFlusher interface {
-	StartPeriodicUpdates(ctx context.Context, tracker BackfillerProgressFlusher) (stop func() error)
+	StartPeriodicUpdates(ctx context.Context, tracker BackfillerProgressFlusher) (stop func())
 }
 
 // BackfillerProgressReader is used by the backfill execution layer to read

--- a/pkg/sql/schemachanger/scexec/exec_backfill.go
+++ b/pkg/sql/schemachanger/scexec/exec_backfill.go
@@ -340,7 +340,7 @@ func runBackfiller(
 		}
 	}
 	stop := deps.PeriodicProgressFlusher().StartPeriodicUpdates(ctx, tracker)
-	defer func() { _ = stop() }()
+	defer stop()
 	ib := deps.IndexBackfiller()
 	im := deps.IndexMerger()
 	const op = "run backfills and merges"
@@ -364,9 +364,6 @@ func runBackfiller(
 			deps.Telemetry().IncrementSchemaChangeErrorType("uncategorized")
 		}
 		return scerrors.SchemaChangerUserError(err)
-	}
-	if err := stop(); err != nil {
-		return err
 	}
 	if err := tracker.FlushFractionCompleted(ctx); err != nil {
 		return err

--- a/pkg/sql/schemachanger/scexec/mocks_generated_test.go
+++ b/pkg/sql/schemachanger/scexec/mocks_generated_test.go
@@ -850,10 +850,10 @@ func (m *MockPeriodicProgressFlusher) EXPECT() *MockPeriodicProgressFlusherMockR
 }
 
 // StartPeriodicUpdates mocks base method.
-func (m *MockPeriodicProgressFlusher) StartPeriodicUpdates(arg0 context.Context, arg1 scexec.BackfillerProgressFlusher) func() error {
+func (m *MockPeriodicProgressFlusher) StartPeriodicUpdates(arg0 context.Context, arg1 scexec.BackfillerProgressFlusher) func() {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "StartPeriodicUpdates", arg0, arg1)
-	ret0, _ := ret[0].(func() error)
+	ret0, _ := ret[0].(func())
 	return ret0
 }
 


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/140052
fixes https://github.com/cockroachdb/cockroach/issues/135888

Release note (bug fix): Fixed a bug where the fraction completed and internal checkpoints during an index backfill operation would stop getting written if any of the periodic fraction/checkpoint write operations failed.

Additional logging was added so that progress is logged in addition to being written to the job record.

This bug affected schema change operations such as creating an index or adding a non-nullable column to a table.