### PR TITLE
sql/schemachanger: Block invalid expressions in CREATE POLICY

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/row_level_security
+++ b/pkg/sql/logictest/testdata/logic_test/row_level_security
@@ -813,7 +813,7 @@ set role root
 
 # Add policies that apply to other commands. Only SELECT will return rows.
 statement ok
-CREATE POLICY restrict_insert ON bbteams FOR INSERT TO buck USING (false);
+CREATE POLICY restrict_insert ON bbteams FOR INSERT TO buck WITH CHECK (false);
 
 statement ok
 CREATE POLICY restrict_delete ON bbteams FOR DELETE TO buck USING (false);
@@ -894,7 +894,7 @@ statement ok
 DROP POLICY restrict_delete on bbteams;
 
 statement ok
-create policy restrict_delete on bbteams for delete to buck using (is_valid(league) and team = 'tigers' and nextval('seq1') < 1000) with check (true);
+create policy restrict_delete on bbteams for delete to buck using (is_valid(league) and team = 'tigers' and nextval('seq1') < 1000);
 
 statement ok
 set role buck
@@ -920,9 +920,9 @@ bbteams  CREATE TABLE public.bbteams (
          );
          ALTER TABLE public.bbteams ENABLE ROW LEVEL SECURITY;
          CREATE POLICY restrict_select ON public.bbteams AS PERMISSIVE FOR SELECT TO buck, root USING (public.is_valid(league) AND (nextval('public.seq1'::REGCLASS) < 1000:::INT8));
-         CREATE POLICY restrict_insert ON public.bbteams AS PERMISSIVE FOR INSERT TO buck USING (false);
+         CREATE POLICY restrict_insert ON public.bbteams AS PERMISSIVE FOR INSERT TO buck WITH CHECK (false);
          CREATE POLICY restrict_update ON public.bbteams AS PERMISSIVE FOR UPDATE TO buck USING (public.is_valid(league) AND (nextval('public.seq1'::REGCLASS) < 1000:::INT8));
-         CREATE POLICY restrict_delete ON public.bbteams AS PERMISSIVE FOR DELETE TO buck USING ((public.is_valid(league) AND (team = 'tigers':::STRING)) AND (nextval('public.seq1'::REGCLASS) < 1000:::INT8)) WITH CHECK (true)
+         CREATE POLICY restrict_delete ON public.bbteams AS PERMISSIVE FOR DELETE TO buck USING ((public.is_valid(league) AND (team = 'tigers':::STRING)) AND (nextval('public.seq1'::REGCLASS) < 1000:::INT8))
 
 statement ok
 set role root
@@ -955,7 +955,7 @@ statement ok
 ALTER TABLE animals ENABLE ROW LEVEL SECURITY;
 
 statement ok
-create policy p1 on animals for select to current_user using (class in ('mammals','birds')) with check (class in ('reptiles', 'amphibians'));
+create policy p1 on animals for select to current_user using (class in ('mammals','birds'));
 
 statement ok
 use defaultdb;
@@ -1137,5 +1137,22 @@ SET ROLE root
 
 statement ok
 DROP ROLE rls_cache_user;
+
+subtest block_invalid_expressions
+
+statement ok
+CREATE TABLE blocker();
+
+statement error pq: only WITH CHECK expression allowed for INSERT
+CREATE POLICY p_insert on blocker FOR INSERT USING (1 = 1);
+
+statement error pq: WITH CHECK cannot be applied to SELECT or DELETE
+CREATE POLICY p_select on blocker FOR SELECT WITH CHECK (false);
+
+statement error pq: WITH CHECK cannot be applied to SELECT or DELETE
+CREATE POLICY p_delete on blocker FOR DELETE WITH CHECK (1 = 1);
+
+statement ok
+DROP TABLE blocker;
 
 subtest end

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/create_policy.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/create_policy.go
@@ -48,6 +48,13 @@ func CreatePolicy(b BuildCtx, n *tree.CreatePolicy) {
 		}
 	})
 
+	// Depending on the command for the policy, some expressions are blocked.
+	if n.Cmd == tree.PolicyCommandInsert && n.Exprs.Using != nil {
+		panic(pgerror.Newf(pgcode.Syntax, "only WITH CHECK expression allowed for INSERT"))
+	} else if (n.Cmd == tree.PolicyCommandDelete || n.Cmd == tree.PolicyCommandSelect) && n.Exprs.WithCheck != nil {
+		panic(pgerror.Newf(pgcode.Syntax, "WITH CHECK cannot be applied to SELECT or DELETE"))
+	}
+
 	policyID := b.NextTablePolicyID(tbl.TableID)
 	policy := &scpb.Policy{
 		TableID:  tbl.TableID,

--- a/pkg/sql/schemachanger/scbuild/testdata/create_policy
+++ b/pkg/sql/schemachanger/scbuild/testdata/create_policy
@@ -5,14 +5,14 @@ CREATE FUNCTION is_valid(n INT) returns bool as $$ begin return n < 10; end; $$ 
 ----
 
 build
-CREATE POLICY "first policy" on defaultdb.foo AS PERMISSIVE FOR SELECT TO fred USING (i > 0) WITH CHECK (i % 2 = 0);
+CREATE POLICY "first policy" on defaultdb.foo AS PERMISSIVE FOR UPDATE TO fred USING (i > 0) WITH CHECK (i % 2 = 0);
 ----
 - [[IndexData:{DescID: 104, IndexID: 1}, PUBLIC], PUBLIC]
   {indexId: 1, tableId: 104}
 - [[TableData:{DescID: 104, ReferencedDescID: 100}, PUBLIC], PUBLIC]
   {databaseId: 100, tableId: 104}
 - [[Policy:{DescID: 104, PolicyID: 1}, PUBLIC], ABSENT]
-  {command: 2, policyId: 1, tableId: 104, type: 1}
+  {command: 4, policyId: 1, tableId: 104, type: 1}
 - [[PolicyName:{DescID: 104, Name: first policy, PolicyID: 1}, PUBLIC], ABSENT]
   {name: first policy, policyId: 1, tableId: 104}
 - [[PolicyRole:{DescID: 104, Name: fred, PolicyID: 1}, PUBLIC], ABSENT]
@@ -25,7 +25,7 @@ CREATE POLICY "first policy" on defaultdb.foo AS PERMISSIVE FOR SELECT TO fred U
   {policyId: 1, tableId: 104}
 
 build
-CREATE POLICY "second policy" on defaultdb.foo AS RESTRICTIVE FOR INSERT USING (false);
+CREATE POLICY "second policy" on defaultdb.foo AS RESTRICTIVE FOR INSERT WITH CHECK (false);
 ----
 - [[IndexData:{DescID: 104, IndexID: 1}, PUBLIC], PUBLIC]
   {indexId: 1, tableId: 104}
@@ -37,13 +37,13 @@ CREATE POLICY "second policy" on defaultdb.foo AS RESTRICTIVE FOR INSERT USING (
   {name: second policy, policyId: 1, tableId: 104}
 - [[PolicyRole:{DescID: 104, Name: public, PolicyID: 1}, PUBLIC], ABSENT]
   {policyId: 1, roleName: public, tableId: 104}
-- [[PolicyUsingExpr:{DescID: 104, Expr: false, PolicyID: 1}, PUBLIC], ABSENT]
+- [[PolicyWithCheckExpr:{DescID: 104, Expr: false, PolicyID: 1}, PUBLIC], ABSENT]
   {expr: "false", policyId: 1, tableId: 104}
 - [[PolicyDeps:{DescID: 104, PolicyID: 1}, PUBLIC], ABSENT]
   {policyId: 1, tableId: 104}
 
 build
-CREATE POLICY "third policy" on defaultdb.foo FOR DELETE TO CURRENT_USER,fred WITH CHECK (i < 0);
+CREATE POLICY "third policy" on defaultdb.foo FOR DELETE TO CURRENT_USER,fred USING (i < 0);
 ----
 - [[IndexData:{DescID: 104, IndexID: 1}, PUBLIC], PUBLIC]
   {indexId: 1, tableId: 104}
@@ -57,7 +57,7 @@ CREATE POLICY "third policy" on defaultdb.foo FOR DELETE TO CURRENT_USER,fred WI
   {policyId: 1, roleName: root, tableId: 104}
 - [[PolicyRole:{DescID: 104, Name: fred, PolicyID: 1}, PUBLIC], ABSENT]
   {policyId: 1, roleName: fred, tableId: 104}
-- [[PolicyWithCheckExpr:{DescID: 104, Expr: i < 0:::INT8, PolicyID: 1}, PUBLIC], ABSENT]
+- [[PolicyUsingExpr:{DescID: 104, Expr: i < 0:::INT8, PolicyID: 1}, PUBLIC], ABSENT]
   {expr: 'i < 0:::INT8', policyId: 1, referencedColumnIds: [1], tableId: 104}
 - [[PolicyDeps:{DescID: 104, PolicyID: 1}, PUBLIC], ABSENT]
   {policyId: 1, tableId: 104}

--- a/pkg/sql/schemachanger/scbuild/testdata/drop_policy
+++ b/pkg/sql/schemachanger/scbuild/testdata/drop_policy
@@ -3,9 +3,9 @@ SET enable_row_level_security = true;
 CREATE FUNCTION is_valid(n INT) returns bool as $$ begin return n < 10; end; $$ language plpgsql;
 CREATE TABLE defaultdb.foo (i INT PRIMARY KEY);
 CREATE USER fred;
-CREATE POLICY "first policy" on defaultdb.foo AS PERMISSIVE FOR SELECT TO fred USING (i > 0) WITH CHECK (i % 2 = 0);
-CREATE POLICY "second policy" on defaultdb.foo AS RESTRICTIVE FOR INSERT USING (false);
-CREATE POLICY "third policy" on defaultdb.foo FOR DELETE TO CURRENT_USER,fred WITH CHECK (i < 0);
+CREATE POLICY "first policy" on defaultdb.foo AS PERMISSIVE FOR UPDATE TO fred USING (i > 0) WITH CHECK (i % 2 = 0);
+CREATE POLICY "second policy" on defaultdb.foo AS RESTRICTIVE FOR INSERT WITH CHECK (false);
+CREATE POLICY "third policy" on defaultdb.foo FOR DELETE TO CURRENT_USER,fred USING (i < 0);
 CREATE POLICY "fourth policy" on defaultdb.foo AS PERMISSIVE TO PUBLIC,SESSION_USER;
 CREATE POLICY "fifth policy" on defaultdb.foo USING (is_valid(i));
 CREATE POLICY "sixth policy" on defaultdb.foo WITH CHECK (is_valid(i));
@@ -17,7 +17,7 @@ DROP POLICY "first policy" on defaultdb.foo;
 - [[IndexData:{DescID: 105, IndexID: 1}, PUBLIC], PUBLIC]
   {indexId: 1, tableId: 105}
 - [[Policy:{DescID: 105, PolicyID: 1}, ABSENT], PUBLIC]
-  {command: 2, policyId: 1, tableId: 105, type: 1}
+  {command: 4, policyId: 1, tableId: 105, type: 1}
 - [[PolicyName:{DescID: 105, Name: first policy, PolicyID: 1}, ABSENT], PUBLIC]
   {name: first policy, policyId: 1, tableId: 105}
 - [[PolicyRole:{DescID: 105, Name: fred, PolicyID: 1}, ABSENT], PUBLIC]
@@ -42,7 +42,7 @@ DROP POLICY "second policy" on defaultdb.foo CASCADE;
   {name: second policy, policyId: 2, tableId: 105}
 - [[PolicyRole:{DescID: 105, Name: public, PolicyID: 2}, ABSENT], PUBLIC]
   {policyId: 2, roleName: public, tableId: 105}
-- [[PolicyUsingExpr:{DescID: 105, Expr: false, PolicyID: 2}, ABSENT], PUBLIC]
+- [[PolicyWithCheckExpr:{DescID: 105, Expr: false, PolicyID: 2}, ABSENT], PUBLIC]
   {expr: "false", policyId: 2, tableId: 105}
 - [[PolicyDeps:{DescID: 105, PolicyID: 2}, ABSENT], PUBLIC]
   {policyId: 2, tableId: 105}
@@ -62,7 +62,7 @@ DROP POLICY "third policy" on defaultdb.foo RESTRICT;
   {policyId: 3, roleName: root, tableId: 105}
 - [[PolicyRole:{DescID: 105, Name: fred, PolicyID: 3}, ABSENT], PUBLIC]
   {policyId: 3, roleName: fred, tableId: 105}
-- [[PolicyWithCheckExpr:{DescID: 105, Expr: i < 0:::INT8, PolicyID: 3}, ABSENT], PUBLIC]
+- [[PolicyUsingExpr:{DescID: 105, Expr: i < 0:::INT8, PolicyID: 3}, ABSENT], PUBLIC]
   {expr: 'i < 0:::INT8', policyId: 3, referencedColumnIds: [1], tableId: 105}
 - [[PolicyDeps:{DescID: 105, PolicyID: 3}, ABSENT], PUBLIC]
   {policyId: 3, tableId: 105}

--- a/pkg/sql/schemachanger/scplan/testdata/create_policy
+++ b/pkg/sql/schemachanger/scplan/testdata/create_policy
@@ -10,7 +10,7 @@ CREATE FUNCTION is_even(n INT) returns bool as $$ begin return n % 2 = 0; end; $
 ----
 
 ops
-CREATE POLICY "policy 1" on t1 AS PERMISSIVE FOR SELECT TO user1,user2,public USING (tenant_id = '01538898-f55c-44db-a306-89078e2c430e' AND (c1).x > 0) WITH CHECK (nextval('seq1') < 10);
+CREATE POLICY "policy 1" on t1 AS PERMISSIVE FOR UPDATE TO user1,user2,public USING (tenant_id = '01538898-f55c-44db-a306-89078e2c430e' AND (c1).x > 0) WITH CHECK (nextval('seq1') < 10);
 ----
 StatementPhase stage 1 of 1 with 9 MutationType ops
   transitions:
@@ -25,7 +25,7 @@ StatementPhase stage 1 of 1 with 9 MutationType ops
   ops:
     *scop.AddPolicy
       Policy:
-        Command: 2
+        Command: 4
         PolicyID: 1
         TableID: 106
         Type: 1
@@ -95,7 +95,7 @@ PreCommitPhase stage 2 of 2 with 9 MutationType ops
   ops:
     *scop.AddPolicy
       Policy:
-        Command: 2
+        Command: 4
         PolicyID: 1
         TableID: 106
         Type: 1

--- a/pkg/sql/schemachanger/scplan/testdata/drop_policy
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_policy
@@ -8,7 +8,7 @@ SET enable_row_level_security=on;
 CREATE TYPE greeting AS ENUM('hi', 'howdy', 'hello');
 CREATE FUNCTION is_valid(n INT) returns bool as $$ begin return n < 10; end; $$ language plpgsql;
 CREATE FUNCTION is_even(n INT) returns bool as $$ begin return n % 2 = 0; end; $$ language plpgsql;
-CREATE POLICY "policy 1" on t1 AS PERMISSIVE FOR SELECT TO user1,user2,public USING (tenant_id = '01538898-f55c-44db-a306-89078e2c430e' AND (c1).x > 0) WITH CHECK (nextval('seq1') < 10);
+CREATE POLICY "policy 1" on t1 AS PERMISSIVE FOR UPDATE TO user1,user2,public USING (tenant_id = '01538898-f55c-44db-a306-89078e2c430e' AND (c1).x > 0) WITH CHECK (nextval('seq1') < 10);
 CREATE POLICY "policy 2" on t1 USING (c2::greeting = 'hello'::greeting) WITH CHECK (c2::greeting = 'hi'::greeting);
 CREATE POLICY "policy 3" on t1 USING (is_valid((c1).x)) WITH CHECK (is_even((c1).y));
 ----
@@ -58,7 +58,7 @@ StatementPhase stage 1 of 1 with 8 MutationType ops
       - 107
     *scop.RemovePolicy
       Policy:
-        Command: 2
+        Command: 4
         PolicyID: 1
         TableID: 106
         Type: 1
@@ -117,7 +117,7 @@ PreCommitPhase stage 2 of 2 with 8 MutationType ops
       - 107
     *scop.RemovePolicy
       Policy:
-        Command: 2
+        Command: 4
         PolicyID: 1
         TableID: 106
         Type: 1


### PR DESCRIPTION
This change adds a check to prevent CREATE POLICY from using expressions that are not applicable to the specified command. For example:
- A policy for INSERT should not use a USING expression, as USING applies only to existing rows.
- Policies for DELETE or SELECT should not include a WITH CHECK expression, since they do not add new rows.

Postgres enforces these same restrictions, so this update aligns our behaviour for consistency. The error messages are also identical to those in postgres.

Epic:  CRDB-45203
Release note: none
Informs #136696