### PR TITLE
release: do not skip rc branches when bump version

### DIFF
--- a/pkg/cmd/release/update_versions.go
+++ b/pkg/cmd/release/update_versions.go
@@ -431,9 +431,9 @@ func generateRepoList(
 	log.Printf("will bump version in the following branches: %s", strings.Join(maybeVersionBumpBranches, ", "))
 
 	for _, branch := range maybeVersionBumpBranches {
-		// skip extraordinary and baking branches
-		if strings.HasPrefix(branch, "staging-") || strings.HasSuffix(branch, "-rc") {
-			log.Printf("not bumping version on staging/backing branch %s", branch)
+		// skip extraordinary branches
+		if strings.HasPrefix(branch, "staging-") {
+			log.Printf("not bumping version on staging branch %s", branch)
 			continue
 		}
 		ok, err := fileExistsInGit(branch, versionFile)


### PR DESCRIPTION
Previously, we skipped version bumps on the RC branches. This leads to not necessary work to backport the version bump PRs.

This PR changes the logic to apply version bumps to the RC branches. The bumps are skipped in case the version on the branch matches the desired version.

Epic: none
Release note: None