### PR TITLE
roachprod: minor fix in grow command

### DIFF
--- a/pkg/roachprod/vm/gce/gcloud.go
+++ b/pkg/roachprod/vm/gce/gcloud.go
@@ -2471,7 +2471,7 @@ type jsonInstanceTemplate struct {
 }
 
 func (t *jsonInstanceTemplate) getZone() string {
-	namePrefix := instanceTemplateNamePrefix(t.Properties.Labels[vm.TagCluster])
+	namePrefix := fmt.Sprintf("%s-", instanceTemplateNamePrefix(t.Properties.Labels[vm.TagCluster]))
 	return strings.TrimPrefix(t.Name, namePrefix)
 }
 


### PR DESCRIPTION
The grow command is failing due to minor parsing error to extract the zone from the instance template name. The template name is of the format "instance_name-zone". So, the extracted zone had a "-" in the front. This PR fixes the same.

Epic: None
Release Note: None