### PR TITLE
pkg/cli: allow system.zones in debug zip

### DIFF
--- a/pkg/cli/testdata/zip/file-filters/testzip_file_filters
+++ b/pkg/cli/testdata/zip/file-filters/testzip_file_filters
@@ -117,6 +117,7 @@ debug/system.tenant_settings.txt
 debug/system.tenant_tasks.txt
 debug/system.tenant_usage.txt
 debug/system.tenants.txt
+debug/system.zones.txt
 debug/tenant_ranges.err.txt
 
 
@@ -246,6 +247,7 @@ debug/system.tenant_settings.txt
 debug/system.tenant_tasks.txt
 debug/system.tenant_usage.txt
 debug/system.tenants.txt
+debug/system.zones.txt
 debug/tenant_ranges.err.txt
 
 
@@ -406,6 +408,7 @@ debug/system.tenant_settings.txt
 debug/system.tenant_tasks.txt
 debug/system.tenant_usage.txt
 debug/system.tenants.txt
+debug/system.zones.txt
 debug/tenant_ranges.err.txt
 
 
@@ -541,6 +544,7 @@ debug/system.tenant_settings.txt
 debug/system.tenant_tasks.txt
 debug/system.tenant_usage.txt
 debug/system.tenants.txt
+debug/system.zones.txt
 debug/tenant_ranges.err.txt
 
 #include only txt files with system table file exclustion

--- a/pkg/cli/zip_table_registry.go
+++ b/pkg/cli/zip_table_registry.go
@@ -1125,7 +1125,6 @@ var zipInternalTablesPerNode = DebugZipTableRegistry{
 //   - system.join_tokens: avoid downloading secret join keys.
 //   - system.comments: avoid downloading noise from SQL schema.
 //   - system.ui: avoid downloading noise from UI customizations.
-//   - system.zones: the contents of crdb_internal.zones is easier to use.
 //   - system.statement_bundle_chunks: avoid downloading a large table that's
 //     hard to interpret currently.
 //   - system.statement_statistics: historical data, usually too much to
@@ -1603,5 +1602,12 @@ limit 5000;`,
 			"active",
 			"info",
 		},
+	},
+	"system.zones": {
+		customQueryRedacted: `SELECT "id" FROM system.zones;`,
+		customQueryUnredacted: `SELECT 
+			"id", 
+			crdb_internal.pb_to_json('cockroach.config.zonepb.ZoneConfig', config)
+			FROM system.zones;`,
 	},
 }

--- a/pkg/cli/zip_table_registry_test.go
+++ b/pkg/cli/zip_table_registry_test.go
@@ -128,7 +128,6 @@ func TestNoForbiddenSystemTablesInDebugZip(t *testing.T) {
 		"system.join_tokens",
 		"system.comments",
 		"system.ui",
-		"system.zones",
 		"system.statement_bundle_chunks",
 		"system.statement_statistics",
 		"system.transaction_statistics",


### PR DESCRIPTION
This patch adds `system.zones` into debug zip collection.

Epic: none

Release note: None