### PR TITLE
catalog/lease: properly handle session ID changes

### DIFF
--- a/pkg/sql/catalog/lease/BUILD.bazel
+++ b/pkg/sql/catalog/lease/BUILD.bazel
@@ -127,6 +127,7 @@ go_test(
         "//pkg/sql/sqlliveness",
         "//pkg/sql/sqlliveness/slbase",
         "//pkg/sql/sqlliveness/slprovider",
+        "//pkg/sql/sqlliveness/sqllivenesstestutils",
         "//pkg/sql/sqltestutils",
         "//pkg/sql/stats",
         "//pkg/sql/types",

--- a/pkg/sql/catalog/lease/descriptor_state.go
+++ b/pkg/sql/catalog/lease/descriptor_state.go
@@ -125,7 +125,7 @@ func (t *descriptorState) upsertLeaseLocked(
 	desc catalog.Descriptor,
 	session sqlliveness.Session,
 	regionEnumPrefix []byte,
-) (createdDescriptorVersionState *descriptorVersionState, _ error) {
+) error {
 	if t.mu.maxVersionSeen < desc.GetVersion() {
 		t.mu.maxVersionSeen = desc.GetVersion()
 	}
@@ -136,10 +136,28 @@ func (t *descriptorState) upsertLeaseLocked(
 		}
 		descState := newDescriptorVersionState(t, desc, hlc.Timestamp{}, session, regionEnumPrefix, true /* isLease */)
 		t.mu.active.insert(descState)
-		return descState, nil
+		t.m.names.insert(ctx, descState)
+		return nil
 	}
-	// If the version already exists, nothing needs to be done.
-	return nil, nil
+	// If the version already exists and the session ID matches nothing
+	// needs to be done.
+	if s.getSessionID() == session.ID() {
+		return nil
+	}
+
+	// Otherwise, we need to update the existing lease to fix the session ID. The
+	// previously stored lease also needs to be deleted.
+	var existingLease storedLease
+	func() {
+		s.mu.Lock()
+		defer s.mu.Unlock()
+		existingLease = *s.mu.lease
+		s.mu.lease.sessionID = session.ID().UnsafeBytes()
+		s.mu.session = session
+	}()
+	// Delete the existing lease on behalf of the caller.
+	t.m.storage.release(ctx, t.m.stopper, &existingLease)
+	return nil
 }
 
 var _ redact.SafeFormatter = (*descriptorVersionState)(nil)

--- a/pkg/sql/catalog/lease/descriptor_version_state.go
+++ b/pkg/sql/catalog/lease/descriptor_version_state.go
@@ -108,6 +108,13 @@ func (s *descriptorVersionState) stringLocked() redact.RedactableString {
 	return redact.Sprintf("%d(%q,%s) ver=%d:%s, refcount=%d", s.GetID(), s.GetName(), redact.SafeString(sessionID), s.GetVersion(), s.mu.expiration, s.mu.refcount)
 }
 
+// getSessionID returns the current session ID from the lease.
+func (s *descriptorVersionState) getSessionID() sqlliveness.SessionID {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.mu.session.ID()
+}
+
 // hasExpired checks if the descriptor is too old to be used (by a txn
 // operating) at the given timestamp.
 func (s *descriptorVersionState) hasExpired(ctx context.Context, timestamp hlc.Timestamp) bool {


### PR DESCRIPTION
Previously, the lease manager did not properly handle cases when the session ID changes. This could happen because of failover scenarios, where a new session ID would be assigned. The lease manager would not update the in memory or on disk state to pick up the new session ID, if the descriptor version did not change.
This could lead to an infinite loop inside lease acquisition. To address this, this patch will allow upserting leases with a new session ID and the same version.

Fixes: #141567
Fixes: #141556
Fixes: #141555
Fixes: #141554
Fixes: #141553
Fixes: #141552
Fixes: #141549
Fixes: #141548
Fixes: #141547
Fixes: #141546
Fixes: #141545
Fixes: #141544
Fixes: #141543
Fixes: #141542
Fixes: #141541
Fixes: #141540
Fixes: #141539
Fixes: #141538
Fixes: #141484
Fixes: #141481
Fixes: #141480
Fixes :#141473
Fixes: #141473
Fixes: #141467
Fixes: #141685
Fixes: #141585
Fixes: #141566
Fixes: #141513
Fixes: #141479

Release note: None