### PR TITLE
workflows: do not update releases YAML on 24.2

### DIFF
--- a/.github/workflows/update_releases.yaml
+++ b/.github/workflows/update_releases.yaml
@@ -29,7 +29,6 @@ jobs:
           - "master"
           - "release-23.2"
           - "release-24.1"
-          - "release-24.2"
           - "release-24.3"
           - "release-25.1"
     name: Update pkg/testutils/release/cockroach_releases.yaml on ${{ matrix.branch }}


### PR DESCRIPTION
This branch is EOL.

Epic: none
Release note: None