### PR TITLE
kvserver,storage: Get option to lock on non-existing keys

### DIFF
--- a/pkg/kv/kvpb/api.proto
+++ b/pkg/kv/kvpb/api.proto
@@ -219,6 +219,10 @@ message GetRequest {
   // This option is not compatible for reads over inline values (see
   // https://github.com/cockroachdb/cockroach/issues/131667)
   bool return_raw_mvcc_values = 4 [(gogoproto.customname) = "ReturnRawMVCCValues"];
+
+  // LockNonExisting indicates whether the Get request should acquire a lock
+  // on keys that don't exist.
+  bool lock_non_existing = 5;
 }
 
 // A GetResponse is the return value from the Get() method.

--- a/pkg/kv/kvpb/batch_test.go
+++ b/pkg/kv/kvpb/batch_test.go
@@ -694,7 +694,7 @@ func TestResponseKeyIterate(t *testing.T) {
 			var keys []roachpb.Key
 			err := ResponseKeyIterate(tc.req, tc.resp, func(key roachpb.Key) {
 				keys = append(keys, key)
-			})
+			}, false /* includeLockedNonExisting */)
 			if tc.expErr == "" {
 				require.Equal(t, tc.expKeys, keys)
 				require.NoError(t, err)

--- a/pkg/kv/kvserver/BUILD.bazel
+++ b/pkg/kv/kvserver/BUILD.bazel
@@ -277,6 +277,7 @@ go_test(
         "client_decommission_test.go",
         "client_invalidsplit_test.go",
         "client_lease_test.go",
+        "client_lock_table_test.go",
         "client_manual_proposal_test.go",
         "client_merge_test.go",
         "client_metrics_test.go",

--- a/pkg/kv/kvserver/batcheval/cmd_get.go
+++ b/pkg/kv/kvserver/batcheval/cmd_get.go
@@ -88,8 +88,9 @@ func Get(
 		}
 	}
 
+	shouldLockKey := getRes.Value != nil || args.LockNonExisting
 	var res result.Result
-	if args.KeyLockingStrength != lock.None && getRes.Value != nil {
+	if args.KeyLockingStrength != lock.None && shouldLockKey {
 		acq, err := acquireLockOnKey(ctx, readWriter, h.Txn, args.KeyLockingStrength,
 			args.KeyLockingDurability, args.Key, cArgs.Stats, cArgs.EvalCtx.ClusterSettings())
 		if err != nil {

--- a/pkg/kv/kvserver/client_lock_table_test.go
+++ b/pkg/kv/kvserver/client_lock_table_test.go
@@ -1,0 +1,371 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package kvserver_test
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/lock"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/cockroachdb/cockroach/pkg/testutils/datapathutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/datadriven"
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/require"
+)
+
+// TestClientLockTableDataDriven tests the behavior of lock table and
+// concurrency manager using end-to-end requests from the client.
+//
+// Each file runs in the context of a single test server.
+func TestClientLockTableDataDriven(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+
+	datadriven.Walk(t, datapathutils.TestDataPath(t, "lock_table"), func(t *testing.T, path string) {
+		defer log.Scope(t).Close(t)
+
+		srv, sqlDB, db := serverutils.StartServer(t, base.TestServerArgs{
+			// TODO(ssd): We could remove this if we mad
+			// it easier to get something like a "scratch
+			// range" in a secondary tenant keyspace
+			DefaultTestTenant: base.TestIsSpecificToStorageLayerAndNeedsASystemTenant,
+		})
+		defer srv.Stopper().Stop(ctx)
+
+		s := srv.StorageLayer()
+		rangeStartKey, err := s.ScratchRange()
+		require.NoError(t, err)
+
+		store, err := s.GetStores().(*kvserver.Stores).GetStore(s.GetFirstStoreID())
+		require.NoError(t, err)
+		evalCtx := newEvalCtx(t, rangeStartKey, store.StateEngine(), db)
+
+		datadriven.RunTest(t, path, func(t *testing.T, d *datadriven.TestData) string {
+
+			switch d.Cmd {
+			case "new-txn":
+				evalCtx.newTxn(ctx, d)
+				return ""
+			case "batch":
+				txn := evalCtx.mustGetTxn(d)
+				b := txn.NewBatch()
+				b.Header.WaitPolicy = evalCtx.getLockWaitPolicy(d)
+				for _, line := range strings.Split(d.Input, "\n") {
+					if err := evalCtx.cmdInBatch(line, b); err != nil {
+						d.Fatalf(t, "batch command error: %v", err.Error())
+					}
+				}
+				err := txn.Run(ctx, b)
+				if err != nil {
+					return fmt.Sprintf("error: %s", err.Error())
+				}
+				return ""
+			case "get":
+				txn := evalCtx.mustGetTxn(d)
+				key := evalCtx.getKey(d)
+
+				if d.HasArg("lock") {
+					str := evalCtx.getLockStr(d)
+					dur := evalCtx.getLockDurability(d)
+
+					b := txn.NewBatch()
+					b.Header.WaitPolicy = evalCtx.getLockWaitPolicy(d)
+
+					switch str {
+					case lock.Exclusive:
+						b.GetForUpdate(key, dur)
+					case lock.Shared:
+						b.GetForShare(key, dur)
+					}
+					b.Requests()[0].GetGet().LockNonExisting = d.HasArg("lock-non-existing")
+					err := txn.Run(ctx, b)
+					if err != nil {
+						return fmt.Sprintf("error: %s", err.Error())
+					}
+					res := b.Results[0]
+					if res.Err != nil {
+						return fmt.Sprintf("error: %s", err.Error())
+					}
+					return fmt.Sprintf("get: %s", res.Rows[0].String())
+				} else {
+					kv, err := txn.Get(ctx, key)
+					if err != nil {
+						return fmt.Sprintf("error: %s", err.Error())
+					}
+					return fmt.Sprintf("get: %s", kv.String())
+				}
+			case "put":
+				txn := evalCtx.mustGetTxn(d)
+				b := txn.NewBatch()
+				b.Header.WaitPolicy = evalCtx.getLockWaitPolicy(d)
+				evalCtx.putInBatch(d, b)
+				err := txn.Run(ctx, b)
+				if err != nil {
+					return fmt.Sprintf("error: %s", err.Error())
+				}
+				return ""
+			case "commit":
+				if err := evalCtx.commitTxn(ctx, d); err != nil {
+					return fmt.Sprintf("error: %s", err.Error())
+				}
+				return ""
+			case "rollback":
+				if err := evalCtx.rollbackTxn(ctx, d); err != nil {
+					return fmt.Sprintf("error: %s", err.Error())
+				}
+				return ""
+			case "print-in-memory-lock-table":
+				rangeDesc, err := s.LookupRange(rangeStartKey)
+				if err != nil {
+					d.Fatalf(t, "lookup range: %s", err)
+				}
+				r, err := store.GetReplica(rangeDesc.RangeID)
+				if err != nil {
+					d.Fatalf(t, "get replica: %s", err)
+				}
+				return evalCtx.scrubTS(evalCtx.replaceAllTxnUUIDs(r.GetConcurrencyManager().TestingLockTableString()))
+			case "print-replicated-lock-table":
+				startKey := evalCtx.getNamedKey("start", d)
+				endKey := evalCtx.getNamedKey("end", d)
+				actual := evalCtx.printLockTable(ctx, d, startKey, endKey)
+				// Because of pipelined writes, the lock table might not be up to date
+				// if we check it too quickly, so we retry a few times.
+				const maxRetries = 100
+				for try := 0; try < maxRetries && actual != d.Expected; try++ {
+					time.Sleep(100 * time.Millisecond)
+					actual = evalCtx.printLockTable(ctx, d, startKey, endKey)
+				}
+				return actual
+			case "exec-sql":
+				_, err := sqlDB.Exec(d.Input)
+				if err != nil {
+					return fmt.Sprintf("error: %s", err.Error())
+				}
+				return ""
+			default:
+				d.Fatalf(t, "unknown command: %s", d.Cmd)
+				return ""
+			}
+		})
+	})
+}
+
+type evalCtx struct {
+	t             *testing.T
+	s             storage.Reader
+	db            *kv.DB
+	rangeStartKey roachpb.Key
+
+	txnsByName       map[string]*kv.Txn
+	txnsByUUIDToName map[string]string
+}
+
+func newEvalCtx(t *testing.T, rsk roachpb.Key, s storage.Reader, db *kv.DB) *evalCtx {
+	return &evalCtx{
+		t:             t,
+		s:             s,
+		db:            db,
+		rangeStartKey: rsk,
+
+		txnsByName:       make(map[string]*kv.Txn),
+		txnsByUUIDToName: make(map[string]string),
+	}
+}
+
+var (
+	txnKey = "txn"
+	keyKey = "k"
+	valKey = "v"
+)
+
+func (e *evalCtx) newTxn(ctx context.Context, d *datadriven.TestData) {
+	var name string
+	d.ScanArgs(e.t, txnKey, &name)
+	if _, ok := e.txnsByName[name]; ok {
+		d.Fatalf(e.t, "txn %q already exists", name)
+	} else {
+		txn := e.db.NewTxn(ctx, name)
+
+		e.txnsByName[name] = txn
+		e.txnsByUUIDToName[txn.ID().String()] = name
+	}
+}
+
+func (e *evalCtx) mustGetTxn(d *datadriven.TestData) *kv.Txn {
+	var txnName string
+	d.ScanArgs(e.t, txnKey, &txnName)
+	txn, ok := e.txnsByName[txnName]
+	if !ok {
+		d.Fatalf(e.t, "txn %q doesn't exists", txnName)
+	}
+	return txn
+}
+
+func (e *evalCtx) mustGetAndRemoveTxn(d *datadriven.TestData) *kv.Txn {
+	var txnName string
+	d.ScanArgs(e.t, txnKey, &txnName)
+	txn, ok := e.txnsByName[txnName]
+	if !ok {
+		d.Fatalf(e.t, "txn %q doesn't exists", txnName)
+	}
+	delete(e.txnsByName, txnName)
+	delete(e.txnsByUUIDToName, txn.ID().String())
+	return txn
+}
+
+func (e *evalCtx) commitTxn(ctx context.Context, d *datadriven.TestData) error {
+	txn := e.mustGetAndRemoveTxn(d)
+	return txn.Commit(ctx)
+}
+
+func (e *evalCtx) rollbackTxn(ctx context.Context, d *datadriven.TestData) error {
+	txn := e.mustGetAndRemoveTxn(d)
+	return txn.Rollback(ctx)
+}
+
+func (e *evalCtx) getNamedKey(name string, d *datadriven.TestData) roachpb.Key {
+	e.t.Helper()
+	var keyS string
+	d.ScanArgs(e.t, name, &keyS)
+	return append(e.rangeStartKey.Clone(), []byte(keyS)...)
+}
+
+func (e *evalCtx) getKey(d *datadriven.TestData) roachpb.Key {
+	return e.getNamedKey(keyKey, d)
+}
+
+func (e *evalCtx) getValue(d *datadriven.TestData) []byte {
+	e.t.Helper()
+	var valueS string
+	d.ScanArgs(e.t, valKey, &valueS)
+	return []byte(valueS)
+}
+
+func (e *evalCtx) getLockStr(d *datadriven.TestData) lock.Strength {
+	var lockStr string
+	d.ScanArgs(e.t, "lock", &lockStr)
+	return lock.Strength(lock.Strength_value[lockStr])
+}
+
+func (e *evalCtx) getLockDurability(d *datadriven.TestData) kvpb.KeyLockingDurabilityType {
+	var lockDur string
+	// TODO(ssd): I tend to think in terms of the lock package while the
+	// client takes arguments in terms of the kvpb package. This creates
+	// a small mess.
+	d.ScanArgs(e.t, "dur", &lockDur)
+	var dur kvpb.KeyLockingDurabilityType
+	switch lock.Durability(lock.Durability_value[lockDur]) {
+	case lock.Replicated:
+		dur = kvpb.GuaranteedDurability
+	default:
+		dur = kvpb.BestEffort
+	}
+	return dur
+}
+
+func (e *evalCtx) getLockWaitPolicy(d *datadriven.TestData) lock.WaitPolicy {
+	if d.HasArg("wait") {
+		var waitPolicyStr string
+		d.ScanArgs(e.t, "wait", &waitPolicyStr)
+		return lock.WaitPolicy(lock.WaitPolicy_value[waitPolicyStr])
+	} else {
+		return lock.WaitPolicy_Block
+	}
+}
+
+func (e *evalCtx) cmdInBatch(cmdStr string, b *kv.Batch) error {
+	d := datadriven.TestData{}
+	var err error
+	d.Cmd, d.CmdArgs, err = datadriven.ParseLine(cmdStr)
+	if err != nil {
+		return err
+	}
+	switch d.Cmd {
+	case "put":
+		e.putInBatch(&d, b)
+	default:
+		return errors.Newf("unknown command: %s", d.Cmd)
+	}
+	return nil
+}
+
+func (e *evalCtx) putInBatch(d *datadriven.TestData, b *kv.Batch) {
+	key := e.getKey(d)
+	value := e.getValue(d)
+	b.Put(key, value)
+}
+
+func (e *evalCtx) printLockTable(
+	ctx context.Context, d *datadriven.TestData, startKey, endKey roachpb.Key,
+) string {
+	var outBuf strings.Builder
+	ltStart, _ := keys.LockTableSingleKey(startKey, nil)
+	ltEnd, _ := keys.LockTableSingleKey(endKey, nil)
+	iter, err := storage.NewLockTableIterator(ctx, e.s, storage.LockTableIteratorOptions{
+		LowerBound:  ltStart,
+		UpperBound:  ltEnd,
+		MatchMinStr: lock.Shared,
+	})
+	if err != nil {
+		d.Fatalf(e.t, "lock table iter: %s", err.Error())
+	}
+	defer iter.Close()
+
+	for valid, err := iter.SeekEngineKeyGE(storage.EngineKey{Key: ltStart}); ; valid, err = iter.NextEngineKey() {
+		if err != nil {
+			d.Fatalf(e.t, "next engine key: %s", err.Error())
+		}
+		if !valid {
+			break
+		}
+		engineKey, err := iter.EngineKey()
+		if err != nil {
+			d.Fatalf(e.t, "engine key: %s", err.Error())
+		}
+		ltKey, err := engineKey.ToLockTableKey()
+		if err != nil {
+			d.Fatalf(e.t, "lock table key: %s", err.Error())
+		}
+		fmt.Fprintf(&outBuf, "key: %s, str: %s, txn: %s\n", ltKey.Key, ltKey.Strength, e.uuidToTxnName(ltKey.TxnUUID.String()))
+	}
+	return outBuf.String()
+}
+
+func (e *evalCtx) uuidToTxnName(uuid string) string {
+	if name, ok := e.txnsByUUIDToName[uuid]; ok {
+		return name
+	} else {
+		return "unknown txn"
+	}
+}
+
+func (e *evalCtx) replaceAllTxnUUIDs(input string) string {
+	for uuid, name := range e.txnsByUUIDToName {
+		input = strings.Replace(input, uuid, name, -1)
+	}
+	return input
+}
+
+// ts: 1739967161.672801000,0,
+var tsRegex = regexp.MustCompile(`ts: [0-9]+\.[0-9]+,[0-9],`)
+
+func (e *evalCtx) scrubTS(input string) string {
+	return tsRegex.ReplaceAllString(input, "ts: <stripped>,")
+}

--- a/pkg/kv/kvserver/concurrency/concurrency_manager.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_manager.go
@@ -120,7 +120,7 @@ var UnreplicatedLockReliability = settings.RegisterBoolSetting(
 	settings.SystemOnly,
 	"kv.lock_table.unreplicated_lock_reliability.enabled",
 	"whether the replica should attempt to keep unreplicated locks during various node operations",
-	metamorphic.ConstantWithTestBool("kv.lock_table.unreplicated_lock_reliability_upgrade.enabled", true),
+	metamorphic.ConstantWithTestBool("kv.lock_table.unreplicated_lock_reliability.enabled", true),
 )
 
 // managerImpl implements the Manager interface.

--- a/pkg/kv/kvserver/concurrency/lock/locking.go
+++ b/pkg/kv/kvserver/concurrency/lock/locking.go
@@ -45,6 +45,16 @@ var ExclusiveLocksBlockNonLockingReads = settings.RegisterBoolSetting(
 	true,
 )
 
+// LockNonExistentKeys controls whether the replica allows locking on
+// non-existent keys is allowed. When true, locking Get and Delete requests that
+// don't find a key will acquire a lock. This isn't a setting because in the
+// most important places a setting doesn't help since we need to check the lock
+// table if it is possible that any currenly running transaction might have
+// locked a non-existent key. For now this is a simple bool that will allow us
+// to quickly turn off the riskier parts of the feature if we need to back out
+// close to development.
+const LockNonExistentKeys = true
+
 // MaxStrength is the maximum value in the Strength enum.
 const MaxStrength = Intent
 

--- a/pkg/kv/kvserver/concurrency/lock/locking.proto
+++ b/pkg/kv/kvserver/concurrency/lock/locking.proto
@@ -45,7 +45,7 @@ enum Strength {
   // transactions are forced to restart. See the comment on txnSpanRefresher
   // for more.
   None = 0;
-  
+
   // Shared (S) locks are used by read-only operations and allow concurrent
   // transactions to read under pessimistic concurrency control. Shared locks
   // are compatible with each other but are not compatible with Update or

--- a/pkg/kv/kvserver/replica_read.go
+++ b/pkg/kv/kvserver/replica_read.go
@@ -583,7 +583,7 @@ func (r *Replica) collectSpansRead(
 				getAlloc.union.Get = &getAlloc.get
 				ru := kvpb.RequestUnion{Value: &getAlloc.union}
 				baCopy.Requests = append(baCopy.Requests, ru)
-			}); err != nil {
+			}, false /* includeLockedNonExisting */); err != nil {
 				return nil, nil, err
 			}
 			continue

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -3031,7 +3031,7 @@ func TestReplicaLatchingOptimisticEvaluationSkipLocked(t *testing.T) {
 						resp := br.Responses[i]
 						if err := kvpb.ResponseKeyIterate(req.GetInner(), resp.GetInner(), func(k roachpb.Key) {
 							respKeys = append(respKeys, k)
-						}); err != nil {
+						}, false /* includeLockedNonExisting */); err != nil {
 							return kvpb.NewError(err)
 						}
 					}

--- a/pkg/kv/kvserver/replica_tscache.go
+++ b/pkg/kv/kvserver/replica_tscache.go
@@ -152,7 +152,7 @@ func (r *Replica) updateTimestampCache(
 			//  [Get("a"), Get("c")]
 			if err := kvpb.ResponseKeyIterate(req, resp, func(key roachpb.Key) {
 				addToTSCache(key, nil, ts, txnID)
-			}); err != nil {
+			}, false /* includeLockedNonExisting */); err != nil {
 				log.Errorf(ctx, "error iterating over response keys while "+
 					"updating timestamp cache for ba=%v, br=%v: %v", ba, br, err)
 			}

--- a/pkg/kv/kvserver/store_test.go
+++ b/pkg/kv/kvserver/store_test.go
@@ -2166,7 +2166,7 @@ func TestStoreSkipLockedTSCache(t *testing.T) {
 				req, resp := ba.Requests[i].GetInner(), ru.GetInner()
 				require.NoError(t, kvpb.ResponseKeyIterate(req, resp, func(k roachpb.Key) {
 					respKeys = append(respKeys, string(k))
-				}))
+				}, false /* includeLockedNonExisting */))
 			}
 			sort.Strings(respKeys) // normalize reverse scan
 			require.Equal(t, []string{"a", "c"}, respKeys)

--- a/pkg/kv/kvserver/testdata/lock_table/get
+++ b/pkg/kv/kvserver/testdata/lock_table/get
@@ -1,0 +1,127 @@
+# Sanity-check: put creates an intent, get reads back the value.
+new-txn txn=t1
+----
+
+put txn=t1 k=a v=bar
+----
+
+print-in-memory-lock-table
+----
+num=0
+
+print-replicated-lock-table start=a end=z
+----
+key: "\xfaa", str: Intent, txn: t1
+
+get txn=t1 k=a
+----
+get: "\xfaa"="bar"
+
+commit txn=t1
+----
+
+# Unreplicated locking get request for non-existent key without lock-non-existing set.
+new-txn txn=t2
+----
+
+get txn=t2 k=a0 lock=Exclusive dur=Unreplicated
+----
+get: "\xfaa0"=nil
+
+print-in-memory-lock-table
+----
+num=0
+
+print-replicated-lock-table start=a0 end=z
+----
+
+commit txn=t2
+----
+
+# Replicated locking get request for non-existent key without lock-non-existing set.
+new-txn txn=t3
+----
+
+get txn=t3 k=a1 lock=Exclusive dur=Replicated
+----
+get: "\xfaa1"=nil
+
+print-in-memory-lock-table
+----
+num=0
+
+print-replicated-lock-table start=a1 end=z
+----
+
+commit txn=t3
+----
+
+# Unreplicated locking get request for non-existing key with lock-non-existing
+new-txn txn=t4
+----
+
+get txn=t4 k=a4 lock=Exclusive dur=Unreplicated lock-non-existing
+----
+get: "\xfaa4"=nil
+
+print-in-memory-lock-table
+----
+num=1
+ lock: "\xfaa4"
+  holder: txn: t4 epoch: 0, iso: Serializable, ts: <stripped>, info: unrepl [(str: Exclusive seq: 0)]
+
+print-replicated-lock-table start=a4 end=z
+----
+
+commit txn=t4
+----
+
+# Replicated locking get request for non-existing key with experimental setting
+new-txn txn=t5
+----
+
+get txn=t5 k=a5 lock=Exclusive dur=Replicated lock-non-existing
+----
+get: "\xfaa5"=nil
+
+print-replicated-lock-table start=a5 end=z
+----
+key: "\xfaa5", str: Exclusive, txn: t5
+
+# This lock is uncontended so it doesn't end up in the in-memory lock table.
+print-in-memory-lock-table
+----
+num=0
+
+commit txn=t5
+----
+
+# Replicated lock on non-existing key is found by concurrent write.
+new-txn txn=t6
+----
+
+new-txn txn=t7
+----
+
+get txn=t6 k=a1 lock=Exclusive dur=Replicated lock-non-existing
+----
+get: "\xfaa1"=nil
+
+print-replicated-lock-table start=a1 end=z
+----
+key: "\xfaa1", str: Exclusive, txn: t6
+
+# This lock is uncontended so it doesn't end up in the in-memory lock table.
+print-in-memory-lock-table
+----
+num=0
+
+put txn=t7 k=a1 v=v1 wait=Error
+----
+error: conflicting locks on "\xfaa1" [reason=wait_policy]
+
+commit txn=t6
+----
+
+rollback txn=t7
+----

--- a/pkg/kv/kvserver/testdata/lock_table/optimize_puts
+++ b/pkg/kv/kvserver/testdata/lock_table/optimize_puts
@@ -1,0 +1,52 @@
+# Test that optimize_puts correctly observes
+# locks on non-existent keys and does not incorrectly set the blind flag.
+
+#
+# Txn t1 will hold a replicated, exclusive lock on a non existent key a02.
+# Txn t2 will attempt apply a batch of puts on keys [a00, ... a15].
+# Txn t2 should observe the lock rather than blindly writing.
+#
+new-txn txn=t1
+----
+
+new-txn txn=t2
+----
+
+get txn=t1 k=a02 lock=Exclusive dur=Replicated lock-non-existing
+----
+get: "\xfaa02"=nil
+
+print-in-memory-lock-table
+----
+num=0
+
+print-replicated-lock-table start=a0 end=z
+----
+key: "\xfaa02", str: Exclusive, txn: t1
+
+
+batch txn=t2 wait=Error
+put k=a00 v=v0
+put k=a01 v=v1
+put k=a02 v=v2
+put k=a03 v=v3
+put k=a04 v=v4
+put k=a05 v=v5
+put k=a06 v=v6
+put k=a07 v=v7
+put k=a08 v=v8
+put k=a09 v=v9
+put k=a10 v=v10
+put k=a11 v=v11
+put k=a12 v=v12
+put k=a13 v=v13
+put k=a14 v=v14
+put k=a15 v=v15
+----
+error: conflicting locks on "\xfaa02" [reason=wait_policy]
+
+commit txn=t1
+----
+
+rollback txn=t2
+----

--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -2303,24 +2303,26 @@ func mvccPutInternal(
 			return false, roachpb.LockAcquisition{}, errors.Errorf("%q: put is inline=%t, but existing value is inline=%t",
 				metaKey, putIsInline, meta.IsInline())
 		}
-		if ok && !meta.IsInline() {
+
+		// If at least one version is found, scan the lock table for conflicting
+		// locks and/or an intent on the key from different transactions. If any
+		// such conflicts are found, the lock table scanner will return a
+		// LockConflictError.
+		mustScanLockTable := ok && !meta.IsInline()
+		// We now (20-02-2025) allow locks on non-existing keys. Unfortunately, this
+		// means we must also scan the lock table even if we haven't found a key. As a result,
+		// writes to non-existent keys now perform 2 seeks rather than 1.
+		//
+		// We need to double check that the put isn't inline so that our assumption
+		// that the ltScanner scanner is non-nil holds.
+		mustScanLockTable = mustScanLockTable || (!putIsInline && lock.LockNonExistentKeys)
+		if mustScanLockTable {
 			// INVARIANTS:
 			//   !putIsBlind
 			//   !meta.IsInline()
 			//   !meta.IsInline() => !putIsInline (due to previous if-block)
 			//   !putIsInline && !putIsBlind => ltScanner != nil (due to error check earlier in function)
 			//   So we can use ltScanner safely.
-			//
-			// If at least one version is found, scan the lock table for conflicting
-			// locks and/or an intent on the key from different transactions. If any
-			// such conflicts are found, the lock table scanner will return a
-			// LockConflictError.
-			//
-			// We only need to scan the lock table if we find at least one version.
-			// This is because locks cannot be acquired on non-existent keys. This
-			// constraint permits an important performance optimization — writes to
-			// non-existent keys only perform a single seek (of the MVCC keyspace) and
-			// no second seek (of the lock table keyspace).
 			err = ltScanner.scan(key)
 			if err != nil {
 				return false, roachpb.LockAcquisition{}, err


### PR DESCRIPTION
This adds a new GetRequest option LockNonExisting which instructs the kvserver to acquire a lock on the key even if key is non-existing.

The intended future use of this is for buffered writes in which we we will need to lock buffered writes for unique secondary indexes.

Follow-up work will add a similar option to DeleteRequest.

In this PR, this option is only used in a newly added data driven test that confirms some basic behavior of these locking Get requests.

This option comes at a non-trivial cost: storage Put requests must now _always_ check the lock table for conflicting locks, adding an extra iterator seek for every Put.

The hope is that the cost of this seek is made up for by the overal buffered write performance improvement. However, we can see the non-trivial impact in many of the storage benchmarks:

    MVCCBatchPut/valueSize=10/batchSize=10 1.282µ±2% 1.437µ±1% +12.09% (p=0.000 n=25)

Informs #139232

Release note: None