### PR TITLE
release-24.3: crosscluster/logical: avoid panic in multi-table streams involving UDTs

### DIFF
--- a/pkg/ccl/crosscluster/logical/logical_replication_job_test.go
+++ b/pkg/ccl/crosscluster/logical/logical_replication_job_test.go
@@ -2015,7 +2015,9 @@ func TestUserDefinedTypes(t *testing.T) {
 	for _, mode := range []string{"validated", "immediate"} {
 		t.Run(mode, func(t *testing.T) {
 			dbA.Exec(t, "CREATE TABLE data (pk INT PRIMARY KEY, val1 my_enum DEFAULT 'two', val2 my_composite)")
+			dbA.Exec(t, "CREATE TABLE data2 (pk INT PRIMARY KEY, val1 my_enum DEFAULT 'two', val2 my_composite)")
 			dbB.Exec(t, "CREATE TABLE data (pk INT PRIMARY KEY, val1 my_enum DEFAULT 'two', val2 my_composite)")
+			dbB.Exec(t, "CREATE TABLE data2 (pk INT PRIMARY KEY, val1 my_enum DEFAULT 'two', val2 my_composite)")
 
 			dbB.Exec(t, "INSERT INTO data VALUES (1, 'one', (3, 'cat'))")
 			// Force default expression evaluation.
@@ -2023,7 +2025,7 @@ func TestUserDefinedTypes(t *testing.T) {
 
 			var jobAID jobspb.JobID
 			dbA.QueryRow(t,
-				fmt.Sprintf("CREATE LOGICAL REPLICATION STREAM FROM TABLE data ON $1 INTO TABLE data WITH mode = %s", mode),
+				fmt.Sprintf("CREATE LOGICAL REPLICATION STREAM FROM TABLES (data, data2) ON $1 INTO TABLES (data, data2) WITH mode = %s", mode),
 				dbBURL.String(),
 			).Scan(&jobAID)
 			WaitUntilReplicatedTime(t, s.Clock().Now(), dbA, jobAID)
@@ -2034,9 +2036,7 @@ func TestUserDefinedTypes(t *testing.T) {
 			var jobBID jobspb.JobID
 			dbB.QueryRow(t,
 				"SELECT job_id FROM [SHOW JOBS]"+
-					"WHERE job_type = 'REPLICATION STREAM PRODUCER' "+
-					"AND status = 'running' "+
-					"AND description = 'History Retention for Logical Replication of data'",
+					"WHERE job_type = 'REPLICATION STREAM PRODUCER' AND status = 'running'",
 			).Scan(&jobBID)
 
 			dbA.Exec(t, "CANCEL JOB $1", jobAID)
@@ -2044,7 +2044,9 @@ func TestUserDefinedTypes(t *testing.T) {
 			jobutils.WaitForJobToFail(t, dbB, jobBID)
 
 			dbA.Exec(t, "DROP TABLE data")
+			dbA.Exec(t, "DROP TABLE data2")
 			dbB.Exec(t, "DROP TABLE data")
+			dbB.Exec(t, "DROP TABLE data2")
 		})
 	}
 }

--- a/pkg/ccl/crosscluster/producer/replication_manager.go
+++ b/pkg/ccl/crosscluster/producer/replication_manager.go
@@ -180,7 +180,7 @@ func getUDTs(
 
 		typeDescriptors = append(typeDescriptors, typeDesc.TypeDescriptor)
 	}
-	return typeDescriptors, nil, nil
+	return typeDescriptors, foundTypeDescriptors, nil
 }
 
 var useStreaksInLDR = settings.RegisterBoolSetting(


### PR DESCRIPTION
Backport 1/1 commits from #141634.

/cc @cockroachdb/release

---

Previously a single LDR stream involving multiple tables would fail to be created if the tables used user-defined types due to a bug in the helper used to resolve UDTs when called in a loop where successfully resolving a type returned a nil map that was then passed to the next call in the loop, causing it to panic.

Release note (bug fix): fix a bug that prevented starting multi-table LDR streams on tables that used user-defined types.
Epic: none.

Fixes #141598.

Release justification: bug fix.