### PR TITLE
cloud: cloud.Delete returns nil if the object does not exist

### DIFF
--- a/pkg/cloud/cloudtestutils/cloud_test_helpers.go
+++ b/pkg/cloud/cloudtestutils/cloud_test_helpers.go
@@ -353,6 +353,13 @@ func checkExportStore(t *testing.T, info StoreInfo, skipSingleFile bool) {
 		require.True(t, errors.Is(err, cloud.ErrFileDoesNotExist), "Expected a file does not exist error but returned %s")
 
 		require.NoError(t, s.Delete(ctx, testingFilename))
+		// Deleting a file that does not exist is okay. This behavior is somewhat
+		// forced by the behavior of S3. In non-versioned S3 buckets, S3 does not
+		// return an error or metadata indicating the object did not exist before
+		// the delete. So if we want consistent behavior across all cloud.Storage
+		// interfaces, and we don't want to read before we delete an S3 object, we
+		// need to treat this as a non-error.
+		require.NoError(t, s.Delete(ctx, testingFilename))
 	})
 }
 

--- a/pkg/cloud/external_storage.go
+++ b/pkg/cloud/external_storage.go
@@ -82,7 +82,8 @@ type ExternalStorage interface {
 	// passed to the callback is undefined.
 	List(ctx context.Context, prefix, delimiter string, fn ListingFn) error
 
-	// Delete removes the named file from the store.
+	// Delete removes the named file from the store. If the file does not exist,
+	// Delete returns nil.
 	Delete(ctx context.Context, basename string) error
 
 	// Size returns the length of the named file in bytes.
@@ -128,7 +129,13 @@ type SQLConnI interface {
 // ErrFileDoesNotExist is a sentinel error for indicating that a specified
 // bucket/object/key/file (depending on storage terminology) does not exist.
 // This error is raised by the ReadFile method.
-var ErrFileDoesNotExist = errors.New("external_storage: file doesn't exist")
+var ErrFileDoesNotExist = errors.New("external_storage: file does not exist")
+
+// WrapErrFileDoesNotExist wraps an error with ErrFileDoesNotExist.
+func WrapErrFileDoesNotExist(err error, msg string) error {
+	//nolint:errwrap
+	return errors.Wrapf(ErrFileDoesNotExist, "%s: %s", err.Error(), msg)
+}
 
 // ErrListingUnsupported is a marker for indicating listing is unsupported.
 var ErrListingUnsupported = errors.New("listing is not supported")

--- a/pkg/cloud/httpsink/BUILD.bazel
+++ b/pkg/cloud/httpsink/BUILD.bazel
@@ -38,6 +38,7 @@ go_test(
         "//pkg/util/ioctx",
         "//pkg/util/leaktest",
         "//pkg/util/retry",
+        "@com_github_cockroachdb_errors//oserror",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/cloud/httpsink/http_storage.go
+++ b/pkg/cloud/httpsink/http_storage.go
@@ -178,6 +178,9 @@ func (h *httpStorage) Delete(ctx context.Context, basename string) error {
 	return timeutil.RunWithTimeout(ctx, redact.Sprintf("DELETE %s", basename),
 		cloud.Timeout.Get(&h.settings.SV), func(ctx context.Context) error {
 			_, err := h.reqNoBody(ctx, "DELETE", basename, nil)
+			if errors.Is(err, cloud.ErrFileDoesNotExist) {
+				return nil
+			}
 			return err
 		})
 }
@@ -211,6 +214,10 @@ func (h *httpStorage) reqNoBody(
 		resp.Body.Close()
 	}
 	return resp, err
+}
+
+func isNotFoundErr(resp *http.Response) bool {
+	return resp != nil && resp.StatusCode == http.StatusNotFound
 }
 
 func (h *httpStorage) req(
@@ -251,22 +258,17 @@ func (h *httpStorage) req(
 
 	switch resp.StatusCode {
 	case 200, 201, 204, 206:
-	// Pass.
+		// Pass.
+		return resp, nil
 	default:
 		body, _ := io.ReadAll(resp.Body)
 		_ = resp.Body.Close()
 		err := errors.Errorf("error response from server: %s %q", resp.Status, body)
-		if err != nil && resp.StatusCode == 404 {
-			// nolint:errwrap
-			err = errors.Wrapf(
-				errors.Wrap(cloud.ErrFileDoesNotExist, "http storage file does not exist"),
-				"%v",
-				err.Error(),
-			)
+		if isNotFoundErr(resp) {
+			return nil, cloud.WrapErrFileDoesNotExist(err, "http storage file does not exist")
 		}
 		return nil, err
 	}
-	return resp, nil
 }
 
 func init() {

--- a/pkg/cloud/httpsink/http_storage_test.go
+++ b/pkg/cloud/httpsink/http_storage_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/ioctx"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
+	"github.com/cockroachdb/errors/oserror"
 	"github.com/stretchr/testify/require"
 )
 
@@ -75,7 +76,12 @@ func TestPutHttp(t *testing.T) {
 				}
 				http.ServeFile(w, r, localfile)
 			case "DELETE":
-				if err := os.Remove(localfile); err != nil {
+				err := os.Remove(localfile)
+				if oserror.IsNotExist(err) {
+					http.Error(w, err.Error(), 404)
+					return
+				}
+				if err != nil {
 					http.Error(w, err.Error(), 500)
 					return
 				}

--- a/pkg/cloud/nodelocal/nodelocal_storage.go
+++ b/pkg/cloud/nodelocal/nodelocal_storage.go
@@ -146,6 +146,12 @@ func joinRelativePath(filePath string, file string) string {
 	return path.Join(".", filePath, file)
 }
 
+// isNotFoundErr checks if the error indicates a file not found condition,
+// handling both local and remote nodelocal store cases.
+func isNotFoundErr(err error) bool {
+	return oserror.IsNotExist(err) || status.Code(err) == codes.NotFound
+}
+
 func (l *localFileStorage) Writer(ctx context.Context, basename string) (io.WriteCloser, error) {
 	return l.blobClient.Writer(ctx, joinRelativePath(l.base, basename))
 }
@@ -154,19 +160,10 @@ func (l *localFileStorage) ReadFile(
 	ctx context.Context, basename string, opts cloud.ReadOptions,
 ) (ioctx.ReadCloserCtx, int64, error) {
 	reader, size, err := l.blobClient.ReadFile(ctx, joinRelativePath(l.base, basename), opts.Offset)
+	if err != nil && isNotFoundErr(err) {
+		return nil, 0, cloud.WrapErrFileDoesNotExist(err, "nodelocal storage file does not exist")
+	}
 	if err != nil {
-		// The format of the error returned by the above ReadFile call differs based
-		// on whether we are reading from a local or remote nodelocal store.
-		// The local store returns a golang native ErrNotFound, whereas the remote
-		// store returns a gRPC native NotFound error.
-		if oserror.IsNotExist(err) || status.Code(err) == codes.NotFound {
-			// nolint:errwrap
-			return nil, 0, errors.WithMessagef(
-				errors.Wrap(cloud.ErrFileDoesNotExist, "nodelocal storage file does not exist"),
-				"%s",
-				err.Error(),
-			)
-		}
 		return nil, 0, err
 	}
 	return reader, size, nil
@@ -204,7 +201,11 @@ func (l *localFileStorage) List(
 }
 
 func (l *localFileStorage) Delete(ctx context.Context, basename string) error {
-	return l.blobClient.Delete(ctx, joinRelativePath(l.base, basename))
+	err := l.blobClient.Delete(ctx, joinRelativePath(l.base, basename))
+	if isNotFoundErr(err) {
+		return nil
+	}
+	return err
 }
 
 func (l *localFileStorage) Size(ctx context.Context, basename string) (int64, error) {

--- a/pkg/cloud/userfile/file_table_storage.go
+++ b/pkg/cloud/userfile/file_table_storage.go
@@ -208,6 +208,11 @@ func checkBaseAndJoinFilePath(prefix, basename string) (string, error) {
 	return path.Join(prefix, basename), nil
 }
 
+// isNotExistErr checks if the error indicates a file does not exist
+func isNotExistErr(err error) bool {
+	return oserror.IsNotExist(err)
+}
+
 // ReadFile implements the ExternalStorage interface and returns the contents of
 // the file stored in the user scoped FileToTableSystem.
 func (f *fileTableStorage) ReadFile(
@@ -218,11 +223,9 @@ func (f *fileTableStorage) ReadFile(
 		return nil, 0, err
 	}
 	reader, size, err := f.fs.ReadFile(ctx, filepath, opts.Offset)
-	if oserror.IsNotExist(err) {
-		return nil, 0, errors.Wrapf(cloud.ErrFileDoesNotExist,
-			"file %s does not exist in the UserFileTableSystem", filepath)
+	if err != nil && isNotExistErr(err) {
+		return nil, 0, cloud.WrapErrFileDoesNotExist(err, "file does not exist in the UserFileTableSystem")
 	}
-
 	return reader, size, err
 }
 
@@ -276,7 +279,11 @@ func (f *fileTableStorage) Delete(ctx context.Context, basename string) error {
 	if err != nil {
 		return err
 	}
-	return f.fs.DeleteFile(ctx, filepath)
+	err = f.fs.DeleteFile(ctx, filepath)
+	if isNotExistErr(err) {
+		return nil
+	}
+	return err
 }
 
 // Size implements the ExternalStorage interface and returns the size of the


### PR DESCRIPTION
Previously, the external storage providers had different behavior when
deleting an object that does not exist. S3 treats deleting a
non-existent file as OK. All other storage providers returned an error.
This change updates all storage providers so they match the S3 behavior.

An alternative design would be to have Delete return ErrFileNotFound. I
was unable to find an efficient way to implement that in the S3 storage
provider. The S3 delete response provides no hint as to whether there
was an object at the path. So generating ErrFileNotFound would require
reading the path before issuing the delete.

Release note: none
Epic: none