### PR TITLE
catalog/lease: avoid clearing session from stale versions

### DIFF
--- a/pkg/sql/catalog/lease/descriptor_set.go
+++ b/pkg/sql/catalog/lease/descriptor_set.go
@@ -108,10 +108,10 @@ func (l *descriptorSet) findPreviousToExpire(dropped bool) *descriptorVersionSta
 	}
 	exp.mu.Lock()
 	defer exp.mu.Unlock()
-	// If this version is not active, then it will go away on its own
-	// from the leases table, so no expiry needs to be setup. If the
-	// session is already cleared then an expiry has been setup too.
-	if exp.mu.refcount == 0 || exp.mu.session == nil {
+	// If the refcount has hit zero then this version will be cleaned up
+	// automatically. If an expiration time is already setup, then this
+	// version has already been expired.
+	if exp.mu.refcount == 0 || !exp.mu.expiration.IsEmpty() {
 		return nil
 	}
 	return exp

--- a/pkg/sql/catalog/lease/lease.go
+++ b/pkg/sql/catalog/lease/lease.go
@@ -991,7 +991,6 @@ func purgeOldVersions(
 				if sessionExpiry := leaseToExpire.mu.session.Expiration(); leaseDuration > 0 && leaseToExpire.mu.expiration.Less(sessionExpiry) {
 					leaseToExpire.mu.expiration = sessionExpiry
 				}
-				leaseToExpire.mu.session = nil
 				if leaseToExpire.mu.lease != nil {
 					m.storage.sessionBasedLeasesWaitingToExpire.Inc(1)
 					m.mu.leasesToExpire = append(m.mu.leasesToExpire, leaseToExpire)


### PR DESCRIPTION
Previously, we supported both expiry and session-based leases. Stale
session-based leases were expired by clearing the session and setting an
expiration time. This was necessary during the dual-write phase to
support both types. Now that expiry-based leasing has been removed, we
only need to check the expiration time to determine if a descriptor is
stale. This patch avoids clearing the session and relies solely on the
expiration to identify stale versions.

Fixes: #141801

Release note: None