### PR TITLE
github, microbench-ci: remove label check

### DIFF
--- a/.github/workflows/microbenchmarks-ci.yaml
+++ b/.github/workflows/microbenchmarks-ci.yaml
@@ -91,7 +91,6 @@ jobs:
         if: always()
   post:
     runs-on: [ self-hosted, basic_runner_group ]
-    if: contains(github.event.pull_request.labels.*.name, 'T-microbench-post') # TODO: remove this check once results are confirmed to be stable on CI.
     timeout-minutes: 30
     permissions:
         contents: read


### PR DESCRIPTION
Previously, the microbench-ci github post only ran if the `T-microbench-post` label was added, to the PR, prior to a commit. This change removes the label requirement, and the post will now be made automatically to all PRs for all commits.

Epic: None
Release note: None