### PR TITLE
release-24.1: opt/execbuilder: pick correct canary column ordinal

### DIFF
--- a/pkg/sql/opt/column_meta.go
+++ b/pkg/sql/opt/column_meta.go
@@ -94,6 +94,17 @@ func (ocl OptionalColList) IsEmpty() bool {
 	return true
 }
 
+// Len returns the number of columns in the list that are set.
+func (ocl OptionalColList) Len() int {
+	n := 0
+	for i := range ocl {
+		if ocl[i] != 0 {
+			n++
+		}
+	}
+	return n
+}
+
 // Equals returns true if this column list is identical to another list.
 func (ocl OptionalColList) Equals(other OptionalColList) bool {
 	if len(ocl) != len(other) {

--- a/pkg/sql/opt/exec/execbuilder/mutation.go
+++ b/pkg/sql/opt/exec/execbuilder/mutation.go
@@ -495,7 +495,7 @@ func (b *Builder) buildUpsert(ups *memo.UpsertExpr) (_ execPlan, outputCols colO
 	colList = appendColsWhenPresent(colList, ups.PartialIndexPutCols)
 	colList = appendColsWhenPresent(colList, ups.PartialIndexDelCols)
 
-	input, inputCols, err := b.buildMutationInput(ups, ups.Input, colList, &ups.MutationPrivate)
+	input, _, err := b.buildMutationInput(ups, ups.Input, colList, &ups.MutationPrivate)
 	if err != nil {
 		return execPlan{}, colOrdMap{}, err
 	}
@@ -505,9 +505,13 @@ func (b *Builder) buildUpsert(ups *memo.UpsertExpr) (_ execPlan, outputCols colO
 	tab := md.Table(ups.Table)
 	canaryCol := exec.NodeColumnOrdinal(-1)
 	if ups.CanaryCol != 0 {
-		canaryCol, err = getNodeColumnOrdinal(inputCols, ups.CanaryCol)
-		if err != nil {
-			return execPlan{}, colOrdMap{}, err
+		// The canary column comes after the insert, fetch, and update columns.
+		canaryCol = exec.NodeColumnOrdinal(
+			ups.InsertCols.Len() + ups.FetchCols.Len() + ups.UpdateCols.Len(),
+		)
+		if colList[canaryCol] != ups.CanaryCol {
+			return execPlan{}, colOrdMap{},
+				errors.AssertionFailedf("canary column not found")
 		}
 	}
 	insertColOrds := ordinalSetFromColList(ups.InsertCols)

--- a/pkg/sql/opt/exec/execbuilder/testdata/upsert
+++ b/pkg/sql/opt/exec/execbuilder/testdata/upsert
@@ -1096,3 +1096,12 @@ vectorized: true
               missing stats
               table: t121322_c@t121322_c_pkey
               spans: FULL SCAN
+
+# Regression test for #136458. The canary column ordinal should be correctly
+# selected when the canary column is also a partial index DEL column.
+
+statement ok
+CREATE TABLE t136458 (c BOOL PRIMARY KEY, INDEX (c) WHERE c)
+
+statement ok
+UPSERT INTO t136458 (c) VALUES (false)


### PR DESCRIPTION
Backport 1/2 commits from #141728.

/cc @cockroachdb/release

---

#### opt/execbuilder: pick correct canary column ordinal

The execbuilder previously used the `colOrdMap` of an Upsert's input to
find the ordinal of the canary column. In rare cases, the canary column
could also be used as a partial index DEL column. Because a `colOrdMap`
can only map each column ID to a single ordinal, and because partial
index columns are positioned after the canary column, the ordinal
fetched from the `colOrdMap` would be the partial index DEL column
ordinal, not the canary column ordinal.

This could cause node-crashing panics during execution when trying to
access the canary canary column in the input row after the partial index
columns are sliced off.

As an example, consider the table and mutation:

    CREATE TABLE t (c BOOL PRIMARY KEY, INDEX (c) WHERE c)

    UPSERT INTO t VALUES (false)

The input to the Upsert operator produces 4 physical columns:

  1. An insert column with the value to insert if a row with the same
     PK does not already exist. We'll call this logical column `new_c`.
  2. A canary column which is non-NULL if a row with the same PK already
     exists. This is always a PK column fetched from the table—in our
     example this is `c`. Let's call this logical column `old_c`.
  3. A partial index PUT column which is true if the new row should be
     added to the partial index. Since the partial index predicate
     expression is the PK column, this is the same logical column as
    `new_c`.
  4. A partial index DEL column which is true if the old row should be
     removed from the partial index. This is the same logical column as
    `old_c`.

So, the physical columns produced by the input of the Upsert are:

| insert column | canary column | partial index PUT | partial index DEL
| ------------- | ------------- | ----------------- | -----------------
|    `new_c`    |    `old_c`    |     `new_c`       |     `old_c`

Using the `colOrdMap` to find the ordinal of `old_c` yields `3`, instead
of `1`.

During execution the partial index columns are sliced off, and the row
becomes:

| insert column | canary column |
| ------------- | ------------- |
|    `new_c`    |    `old_c`    |

When the execution engine attempts to access index `3` of this row, the
process panics with an out-of-bounds exception.

This has been fixed by using the lengths of the insert (and other)
columns to find the canary column ordinal, instead of the `colOrdMap`.

Fixes #136458

Release note (bug fix): A bug has been fixed that could cause gateway
nodes to panic when performing an `UPSERT` on a table with a `BOOL`
primary key column and a partial index with the PK column as the
predicate expression.

----

Release justification: Low-risk bug fix.

