### PR TITLE
upgrades: report progress during 25.1 upgrade jobs backfill

### DIFF
--- a/pkg/upgrade/BUILD.bazel
+++ b/pkg/upgrade/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
     deps = [
         "//pkg/clusterversion",
         "//pkg/jobs",
+        "//pkg/jobs/jobspb",
         "//pkg/keys",
         "//pkg/keyvisualizer",
         "//pkg/kv",

--- a/pkg/upgrade/tenant_upgrade.go
+++ b/pkg/upgrade/tenant_upgrade.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/multitenant/mtinfo"
@@ -49,6 +50,9 @@ type TenantDeps struct {
 	SchemaResolverConstructor func( // A constructor that returns a schema resolver for `descriptors` in `currDb`.
 		txn *kv.Txn, descriptors *descs.Collection, currDb string,
 	) (resolver.SchemaResolver, func(), error)
+
+	// OptionalJobID is the job ID for this upgrade if it is running inside a job.
+	OptionalJobID jobspb.JobID
 }
 
 // TenantUpgradeFunc is used to perform sql-level upgrades. It may be run from

--- a/pkg/upgrade/upgradejob/upgrade_job.go
+++ b/pkg/upgrade/upgradejob/upgrade_job.go
@@ -95,6 +95,7 @@ func (r resumer) Resume(ctx context.Context, execCtxI interface{}) error {
 			SessionData:        execCtx.SessionData(),
 			ClusterID:          execCtx.ExtendedEvalContext().ClusterID,
 			TenantInfoAccessor: mc.SystemDeps().TenantInfoAccessor,
+			OptionalJobID:      r.j.ID(),
 		}
 
 		tenantDeps.SchemaResolverConstructor = func(


### PR DESCRIPTION
Release note: none.
Epic: none.