### PR TITLE
kvserver: deflake TestReadLoadMetricAccounting

### DIFF
--- a/pkg/kv/kvserver/replica_learner_test.go
+++ b/pkg/kv/kvserver/replica_learner_test.go
@@ -2309,9 +2309,7 @@ func TestRebalancingAndCrossRegionZoneSnapshotMetrics(t *testing.T) {
 	// an epoch lease. For leader leases, however, the range starts off with no
 	// leader so the first lease that's proposed is an expiration lease, which
 	// gets upgraded to a leader lease once a leader is elected.
-	if !kvserver.ExpirationLeasesOnly.Get(&tc.Server(0).ClusterSettings().SV) {
-		tc.WaitForLeaseUpgrade(ctx, t, desc)
-	}
+	tc.MaybeWaitForLeaseUpgrade(ctx, t, desc)
 	// sendSnapshotFromServer is a testing helper that sends a learner snapshot
 	// from server[0] to server[serverIndex] and returns the expected size (in
 	// bytes) of the snapshot sent.

--- a/pkg/kv/kvserver/replica_rankings_test.go
+++ b/pkg/kv/kvserver/replica_rankings_test.go
@@ -497,6 +497,10 @@ func TestReadLoadMetricAccounting(t *testing.T) {
 	// Disable the consistency checker, to avoid interleaving requests
 	// artificially inflating measurement due to consistency checking.
 	sqlDB.Exec(t, `SET CLUSTER SETTING server.consistency_check.interval = '0'`)
+	// Wait for lease upgrade, to avoid interleaving upgrade requests inflating
+	// the measurements below.
+	desc := tc.LookupRangeOrFatal(t, scratchKey)
+	tc.MaybeWaitForLeaseUpgrade(ctx, t, desc)
 
 	for i, testCase := range testCases {
 		t.Logf("test #%d", i+1)

--- a/pkg/testutils/serverutils/test_cluster_shim.go
+++ b/pkg/testutils/serverutils/test_cluster_shim.go
@@ -185,6 +185,11 @@ type TestClusterInterface interface {
 		t TestFataler, rangeDesc roachpb.RangeDescriptor, dest roachpb.ReplicationTarget,
 	)
 
+	// MaybeWaitForLeaseUpgrade waits until the lease held for the given range
+	// descriptor is upgraded to an epoch-based or leader lease, but only if we
+	// expect the lease to be upgraded.
+	MaybeWaitForLeaseUpgrade(_ context.Context, _ TestFataler, _ roachpb.RangeDescriptor)
+
 	// MoveRangeLeaseNonCooperatively performs a non-cooperative transfer of the
 	// lease for a range from whoever has it to a particular store. That store
 	// must already have a replica of the range. If that replica already has the

--- a/pkg/testutils/testcluster/testcluster.go
+++ b/pkg/testutils/testcluster/testcluster.go
@@ -1157,8 +1157,8 @@ func (tc *TestCluster) TransferRangeLeaseOrFatal(
 }
 
 // MaybeWaitForLeaseUpgrade waits until the lease held for the given range
-// descriptor is upgraded to an epoch-based one, but only if we expect the lease
-// to be upgraded.
+// descriptor is upgraded to an epoch-based or leader lease, but only if we
+// expect the lease to be upgraded.
 func (tc *TestCluster) MaybeWaitForLeaseUpgrade(
 	ctx context.Context, t serverutils.TestFataler, desc roachpb.RangeDescriptor,
 ) {


### PR DESCRIPTION
Occasionally, a leader lease upgrade request interferes with the metrics measured by this test. This commit makes it wait for the upgrade first, before checking metrics.

Fixes #141716