### PR TITLE
sql/importer: Block IMPORT INTO on RLS tables

### DIFF
--- a/pkg/sql/importer/import_planning.go
+++ b/pkg/sql/importer/import_planning.go
@@ -817,6 +817,19 @@ func importPlanHook(
 				return errors.Newf("cannot run an import on table %s which is apart of a Logical Data Replication stream", table)
 			}
 
+			// Import into an RLS table is blocked, unless this is the admin. It is
+			// allowed for admins since they are exempt from RLS policies and have
+			// unrestricted read/write access.
+			if found.IsRowLevelSecurityEnabled() {
+				admin, err := p.HasAdminRole(ctx)
+				if err != nil {
+					return err
+				} else if !admin {
+					return pgerror.New(pgcode.FeatureNotSupported,
+						"IMPORT INTO not supported with row-level security for non-admin users")
+				}
+			}
+
 			// Validate target columns.
 			var intoCols []string
 			isTargetCol := make(map[string]bool)

--- a/pkg/sql/logictest/testdata/logic_test/row_level_security
+++ b/pkg/sql/logictest/testdata/logic_test/row_level_security
@@ -1274,4 +1274,58 @@ CREATE POLICY p_delete on blocker FOR DELETE WITH CHECK (1 = 1);
 statement ok
 DROP TABLE blocker;
 
+subtest block_import
+
+statement ok
+CREATE TABLE importer (c1 INT);
+
+statement ok
+ALTER TABLE importer ENABLE ROW LEVEL SECURITY;
+
+statement ok
+CREATE USER z;
+
+statement ok
+GRANT ALL ON importer TO z;
+
+statement ok
+GRANT SYSTEM EXTERNALIOIMPLICITACCESS TO z;
+
+# Ensure non-admin's are blocked
+statement ok
+SET ROLE z;
+
+let $exp_file
+WITH cte AS (EXPORT INTO CSV 'nodelocal://1/rls-importer' FROM select 99 UNION ALL SELECT 98 UNION ALL SELECT 97) SELECT filename FROM cte;
+
+statement error pq: IMPORT INTO not supported with row-level security for non-admin users
+IMPORT INTO importer CSV DATA ('nodelocal://1/rls-importer/$exp_file');
+
+# Ensure import from the admin role works
+statement
+SET ROLE root;
+
+# In general, IMPORT isn't compatible with the fake span resolver. So we skip
+# in those configs.
+skipif config fakedist fakedist-disk fakedist-vec-off
+statement ok
+IMPORT INTO importer CSV DATA ('nodelocal://1/rls-importer/$exp_file');
+
+skipif config fakedist fakedist-disk fakedist-vec-off
+query I
+SELECT c1 FROM importer ORDER BY c1;
+----
+97
+98
+99
+
+statement ok
+DROP TABLE importer;
+
+statement ok
+REVOKE SYSTEM EXTERNALIOIMPLICITACCESS FROM z;
+
+statement ok
+DROP USER z;
+
 subtest end


### PR DESCRIPTION
Tables enabled for row-level security (RLS) have policies that restrict which rows can be added. Since IMPORT bypasses the query engine where these policies are enforced, we need to block IMPORT INTO for RLS tables. There is one exception: admin users can still run this command, as RLS policies are not enforced for administrators.

Epic: CRDB-45203
Release note: none
Informs #136807