### PR TITLE
server,kvtenant: remove usages of gossip.KeyDeprecatedSystemConfig

### DIFF
--- a/pkg/cli/BUILD.bazel
+++ b/pkg/cli/BUILD.bazel
@@ -121,7 +121,6 @@ go_library(
         "//pkg/cloud/impl:cloudimpl",
         "//pkg/cloud/userfile",
         "//pkg/clusterversion",
-        "//pkg/config",
         "//pkg/docs",
         "//pkg/geo/geos",
         "//pkg/gossip",

--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -1277,13 +1277,6 @@ File containing the JSON output from a node's /_status/gossip/ endpoint.
 If specified, takes priority over host/port flags.`,
 	}
 
-	PrintSystemConfig = FlagInfo{
-		Name: "print-system-config",
-		Description: `
-If specified, print the system config contents. Beware that the output will be
-long and not particularly human-readable.`,
-	}
-
 	DecodeAsTable = FlagInfo{
 		Name: "decode-as-table",
 		Description: `

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -450,7 +450,6 @@ var debugCtx struct {
 	replicated        bool
 	inputFile         string
 	ballastSize       storagepb.SizeSpec
-	printSystemConfig bool
 	maxResults        int
 	decodeAsTableDesc string
 	verbose           bool
@@ -469,7 +468,6 @@ func setDebugContextDefaults() {
 	debugCtx.inputFile = ""
 	debugCtx.ballastSize = storagepb.SizeSpec{Capacity: 1000000000}
 	debugCtx.maxResults = 0
-	debugCtx.printSystemConfig = false
 	debugCtx.decodeAsTableDesc = ""
 	debugCtx.verbose = false
 	debugCtx.keyTypes = showAll

--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -29,7 +29,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cli/cliflags"
 	"github.com/cockroachdb/cockroach/pkg/cli/syncbench"
 	"github.com/cockroachdb/cockroach/pkg/cloud"
-	"github.com/cockroachdb/cockroach/pkg/config"
 	"github.com/cockroachdb/cockroach/pkg/gossip"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
@@ -1069,16 +1068,6 @@ func parseGossipValues(gossipInfo *gossip.InfoStatus) (string, error) {
 				return "", errors.Wrapf(err, "failed to parse value for key %q", key)
 			}
 			output = append(output, fmt.Sprintf("%q: %v", key, clusterID))
-		} else if key == gossip.KeyDeprecatedSystemConfig {
-			if debugCtx.printSystemConfig {
-				var config config.SystemConfigEntries
-				if err := protoutil.Unmarshal(bytes, &config); err != nil {
-					return "", errors.Wrapf(err, "failed to parse value for key %q", key)
-				}
-				output = append(output, fmt.Sprintf("%q: %+v", key, config))
-			} else {
-				output = append(output, fmt.Sprintf("%q: omitted", key))
-			}
 		} else if key == gossip.KeyFirstRangeDescriptor {
 			var desc roachpb.RangeDescriptor
 			if err := protoutil.Unmarshal(bytes, &desc); err != nil {

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -989,7 +989,6 @@ func init() {
 	{
 		f := debugGossipValuesCmd.Flags()
 		cliflagcfg.StringFlag(f, &debugCtx.inputFile, cliflags.GossipInputFile)
-		cliflagcfg.BoolFlag(f, &debugCtx.printSystemConfig, cliflags.PrintSystemConfig)
 	}
 	{
 		f := debugBallastCmd.Flags()

--- a/pkg/gossip/infostore_test.go
+++ b/pkg/gossip/infostore_test.go
@@ -376,7 +376,7 @@ func TestInfoStoreMostDistant(t *testing.T) {
 	scInfo := is.newInfo(nil, time.Second)
 	scInfo.Hops = 100
 	scInfo.NodeID = nodes[0]
-	if err := is.addInfo(KeyDeprecatedSystemConfig, scInfo); err != nil {
+	if err := is.addInfo(KeyDistSQLDrainingPrefix, scInfo); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/gossip/keys.go
+++ b/pkg/gossip/keys.go
@@ -58,17 +58,19 @@ const (
 	// bi-level key addressing scheme. The value is a roachpb.RangeDescriptor.
 	KeyFirstRangeDescriptor = "first-range"
 
-	// KeyDeprecatedSystemConfig is the gossip key for the system DB span.
-	// The value if a config.SystemConfig which holds all key/value
-	// pairs in the system DB span.
+	// KeyDeprecatedSystemConfig was used in the 21.2<->22.1 mixed version state,
+	// and it's no longer used anywhere. It was the gossip key for the system DB
+	// span. Its value was a config.SystemConfig which held all key/value	pairs
+	// in the system DB span.
 	//
-	// This key is used in the 21.2<->22.1 mixed version state. It is not used
-	// in 22.1. However, it was written without a TTL, so there no guarantee
-	// that it will actually be removed from the gossip network.
+	// This key was written without a TTL, so 	there is no guarantee that it will
+	// actually be removed from the gossip 	network. We would need to write a
+	// migration to remove the data. Until then, this placeholder key should
+	// remain to make sure the same key doesn't get reused.
 	//
-	// TODO(ajwerner): Write a migration to remove the data, or release a
-	// a version which drops the key entirely, and then, in a subsequent
-	// release, delete this key.
+	// TODO(rafi): Write a migration to remove the data, or release a a version
+	// which drops the key entirely, and then, in a subsequent release, delete
+	// this key.
 	KeyDeprecatedSystemConfig = "system-db"
 
 	// KeyDistSQLDrainingPrefix is the key prefix for each node's DistSQL

--- a/pkg/kv/kvclient/kvtenant/BUILD.bazel
+++ b/pkg/kv/kvclient/kvtenant/BUILD.bazel
@@ -11,7 +11,6 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvtenant",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/config",
         "//pkg/config/zonepb",
         "//pkg/gossip",
         "//pkg/keys",
@@ -66,7 +65,6 @@ go_test(
     embed = [":kvtenant"],
     deps = [
         "//pkg/base",
-        "//pkg/config",
         "//pkg/gossip",
         "//pkg/keys",
         "//pkg/kv/kvclient/kvcoord",

--- a/pkg/kv/kvclient/kvtenant/connector.go
+++ b/pkg/kv/kvclient/kvtenant/connector.go
@@ -13,7 +13,6 @@ import (
 	"sort"
 	"time"
 
-	"github.com/cockroachdb/cockroach/pkg/config"
 	"github.com/cockroachdb/cockroach/pkg/config/zonepb"
 	"github.com/cockroachdb/cockroach/pkg/gossip"
 	"github.com/cockroachdb/cockroach/pkg/keys"
@@ -128,12 +127,6 @@ type Connector interface {
 	// OverridesMonitor provides access to tenant cluster setting overrides.
 	settingswatcher.OverridesMonitor
 
-	// SystemConfigProvider provides access to basic host-tenant controlled
-	// information regarding tenant zone configs. This is critical for the
-	// mixed version 21.2->22.1 state where the tenant has not yet configured
-	// its own zones.
-	config.SystemConfigProvider
-
 	// GetClusterInitGracePeriodTS will return the timestamp used to signal the
 	// end of the grace period for clusters with a license. The timestamp is
 	// represented as the number of seconds since the Unix epoch.
@@ -181,11 +174,9 @@ type connector struct {
 
 	mu struct {
 		syncutil.RWMutex
-		client               *client
-		nodeDescs            map[roachpb.NodeID]*roachpb.NodeDescriptor
-		storeDescs           map[roachpb.StoreID]*roachpb.StoreDescriptor
-		systemConfig         *config.SystemConfig
-		systemConfigChannels map[chan<- struct{}]struct{}
+		client     *client
+		nodeDescs  map[roachpb.NodeID]*roachpb.NodeDescriptor
+		storeDescs map[roachpb.StoreID]*roachpb.StoreDescriptor
 	}
 
 	settingsMu struct {
@@ -249,12 +240,6 @@ var _ kvclient.NodeDescStore = (*connector)(nil)
 // requested owned by the requesting tenant?).
 var _ rangecache.RangeDescriptorDB = (*connector)(nil)
 
-// connector is capable of providing a filtered view of the SystemConfig
-// containing only information applicable to secondary tenants. This obviates
-// the need for SQL-only tenant servers to join the cluster-wide gossip
-// network.
-var _ config.SystemConfigProvider = (*connector)(nil)
-
 // connector is capable of finding debug information about the current
 // tenant within the cluster. This is necessary for things such as
 // debug zip and range reports.
@@ -295,7 +280,6 @@ func NewConnector(cfg ConnectorConfig, addrs []string) Connector {
 
 	c.mu.nodeDescs = make(map[roachpb.NodeID]*roachpb.NodeDescriptor)
 	c.mu.storeDescs = make(map[roachpb.StoreID]*roachpb.StoreDescriptor)
-	c.mu.systemConfigChannels = make(map[chan<- struct{}]struct{})
 	c.settingsMu.allTenantOverrides = make(map[settings.InternalKey]settings.EncodedValue)
 	c.settingsMu.specificOverrides = make(map[settings.InternalKey]settings.EncodedValue)
 	c.settingsMu.notifyCh = make(chan struct{})
@@ -454,8 +438,6 @@ var gossipSubsHandlers = map[string]func(*connector, context.Context, string, ro
 	gossip.MakePrefixPattern(gossip.KeyNodeDescPrefix): (*connector).updateNodeAddress,
 	// Subscribe to all *StoreDescriptor updates.
 	gossip.MakePrefixPattern(gossip.KeyStoreDescPrefix): (*connector).updateStoreMap,
-	// Subscribe to a filtered view of *SystemConfig updates.
-	gossip.KeyDeprecatedSystemConfig: (*connector).updateSystemConfig,
 }
 
 var gossipSubsPatterns = func() []string {
@@ -546,59 +528,6 @@ func (c *connector) GetStoreDescriptor(storeID roachpb.StoreID) (*roachpb.StoreD
 		return nil, kvpb.NewStoreDescNotFoundError(storeID)
 	}
 	return desc, nil
-}
-
-// updateSystemConfig handles updates to a filtered view of the "system-db"
-// gossip key, performing the corresponding update to the connector's cached
-// SystemConfig.
-func (c *connector) updateSystemConfig(ctx context.Context, key string, content roachpb.Value) {
-	cfg := config.NewSystemConfig(c.defaultZoneCfg)
-	if err := content.GetProto(&cfg.SystemConfigEntries); err != nil {
-		log.Errorf(ctx, "could not unmarshal system config: %v", err)
-		return
-	}
-
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.mu.systemConfig = cfg
-	for c := range c.mu.systemConfigChannels {
-		select {
-		case c <- struct{}{}:
-		default:
-		}
-	}
-}
-
-// GetSystemConfig implements the config.SystemConfigProvider interface.
-func (c *connector) GetSystemConfig() *config.SystemConfig {
-	// TODO(nvanbenschoten): we need to wait in `(*connector).Start()` until the
-	// system config is populated. As is, there's a small chance that we return
-	// nil, which SQL does not handle.
-	c.mu.RLock()
-	defer c.mu.RUnlock()
-	return c.mu.systemConfig
-}
-
-// RegisterSystemConfigChannel implements the config.SystemConfigProvider
-// interface.
-func (c *connector) RegisterSystemConfigChannel() (_ <-chan struct{}, unregister func()) {
-	// Create channel that receives new system config notifications. The channel
-	// has a size of 1 to prevent connector from having to block on it.
-	ch := make(chan struct{}, 1)
-
-	c.mu.Lock()
-	defer c.mu.Unlock()
-	c.mu.systemConfigChannels[ch] = struct{}{}
-
-	// Notify the channel right away if we have a config.
-	if c.mu.systemConfig != nil {
-		ch <- struct{}{}
-	}
-	return ch, func() {
-		c.mu.Lock()
-		defer c.mu.Unlock()
-		delete(c.mu.systemConfigChannels, ch)
-	}
 }
 
 // RangeLookup implements the kvcoord.RangeDescriptorDB interface.
@@ -1110,16 +1039,6 @@ func AddressResolver(s kvclient.NodeDescStore) nodedialer.AddressResolver {
 		return &nd.Address, nd.Locality, nil
 	}
 }
-
-// GossipSubscriptionSystemConfigMask filters a system config down to just the
-// keys that a tenant SQL servers needs access to. All system tenant objects are
-// filtered out (e.g. system tenant descriptors and users).
-var GossipSubscriptionSystemConfigMask = config.MakeSystemConfigMask(
-	// Tenant SQL servers need just enough of the zone hierarchy to understand
-	// which zone configurations apply to their keyspace.
-	config.MakeZoneKey(keys.SystemSQLCodec, keys.RootNamespaceID),
-	config.MakeZoneKey(keys.SystemSQLCodec, keys.TenantsRangesID),
-)
 
 // CombineKVAddresses combines the remote and loopback addresses into a single
 // slice, while aldo de-duplicating the loopback address if it's present in the

--- a/pkg/kv/kvclient/kvtenant/connector_test.go
+++ b/pkg/kv/kvclient/kvtenant/connector_test.go
@@ -13,7 +13,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cockroachdb/cockroach/pkg/config"
 	"github.com/cockroachdb/cockroach/pkg/gossip"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvcoord"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
@@ -201,18 +200,6 @@ func gossipEventForStoreDesc(desc *roachpb.StoreDescriptor) *kvpb.GossipSubscrip
 	}
 }
 
-func gossipEventForSystemConfig(cfg *config.SystemConfigEntries) *kvpb.GossipSubscriptionEvent {
-	val, err := protoutil.Marshal(cfg)
-	if err != nil {
-		panic(err)
-	}
-	return &kvpb.GossipSubscriptionEvent{
-		Key:            gossip.KeyDeprecatedSystemConfig,
-		Content:        roachpb.MakeValueFromBytesAndTimestamp(val, hlc.Timestamp{}),
-		PatternMatched: gossip.KeyDeprecatedSystemConfig,
-	}
-}
-
 func waitForNodeDesc(t *testing.T, c *connector, nodeID roachpb.NodeID) {
 	t.Helper()
 	testutils.SucceedsSoon(t, func() error {
@@ -234,7 +221,7 @@ func newConnector(cfg ConnectorConfig, addrs []string) *connector {
 }
 
 // TestConnectorGossipSubscription tests connector's roles as a
-// kvclient.NodeDescStore and as a config.SystemConfigProvider.
+// kvclient.NodeDescStore.
 func TestConnectorGossipSubscription(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -255,11 +242,10 @@ func TestConnectorGossipSubscription(t *testing.T) {
 	gossipSubC := make(chan *kvpb.GossipSubscriptionEvent)
 	defer close(gossipSubC)
 	gossipSubFn := func(req *kvpb.GossipSubscriptionRequest, stream kvpb.Internal_GossipSubscriptionServer) error {
-		assert.Len(t, req.Patterns, 4)
+		assert.Len(t, req.Patterns, 3)
 		assert.Equal(t, "cluster-id", req.Patterns[0])
 		assert.Equal(t, "node:.*", req.Patterns[1])
 		assert.Equal(t, "store:.*", req.Patterns[2])
-		assert.Equal(t, "system-db", req.Patterns[3])
 		for gossipSub := range gossipSubC {
 			if err := stream.Send(gossipSub); err != nil {
 				return err
@@ -354,42 +340,6 @@ func TestConnectorGossipSubscription(t *testing.T) {
 	desc, err = c.GetNodeDescriptor(3)
 	require.Equal(t, node3, desc)
 	require.NoError(t, err)
-
-	// Test config.SystemConfigProvider impl. Should not have a SystemConfig yet.
-	sysCfg := c.GetSystemConfig()
-	require.Nil(t, sysCfg)
-	sysCfgC, _ := c.RegisterSystemConfigChannel()
-	require.Len(t, sysCfgC, 0)
-
-	// Return first SystemConfig response.
-	sysCfgEntries := &config.SystemConfigEntries{Values: []roachpb.KeyValue{
-		{Key: roachpb.Key("a")},
-		{Key: roachpb.Key("b")},
-	}}
-	gossipSubC <- gossipEventForSystemConfig(sysCfgEntries)
-
-	// Test config.SystemConfigProvider impl. Wait for update first.
-	<-sysCfgC
-	sysCfg = c.GetSystemConfig()
-	require.NotNil(t, sysCfg)
-	require.Equal(t, sysCfgEntries.Values, sysCfg.Values)
-
-	// Return updated SystemConfig response.
-	sysCfgEntriesUp := &config.SystemConfigEntries{Values: []roachpb.KeyValue{
-		{Key: roachpb.Key("a")},
-		{Key: roachpb.Key("c")},
-	}}
-	gossipSubC <- gossipEventForSystemConfig(sysCfgEntriesUp)
-
-	// Test config.SystemConfigProvider impl. Wait for update first.
-	<-sysCfgC
-	sysCfg = c.GetSystemConfig()
-	require.NotNil(t, sysCfg)
-	require.Equal(t, sysCfgEntriesUp.Values, sysCfg.Values)
-
-	// A newly registered SystemConfig channel will be immediately notified.
-	sysCfgC2, _ := c.RegisterSystemConfigChannel()
-	require.Len(t, sysCfgC2, 1)
 }
 
 // TestConnectorGossipSubscription tests connector's role as a
@@ -495,11 +445,10 @@ func TestConnectorRetriesUnreachable(t *testing.T) {
 		gossipEventForNodeDesc(node2),
 	}
 	gossipSubFn := func(req *kvpb.GossipSubscriptionRequest, stream kvpb.Internal_GossipSubscriptionServer) error {
-		assert.Len(t, req.Patterns, 4)
+		assert.Len(t, req.Patterns, 3)
 		assert.Equal(t, "cluster-id", req.Patterns[0])
 		assert.Equal(t, "node:.*", req.Patterns[1])
 		assert.Equal(t, "store:.*", req.Patterns[2])
-		assert.Equal(t, "system-db", req.Patterns[3])
 		for _, event := range gossipSubEvents {
 			if err := stream.Send(event); err != nil {
 				return err

--- a/pkg/kv/kvserver/store_test.go
+++ b/pkg/kv/kvserver/store_test.go
@@ -318,14 +318,6 @@ func createTestStoreWithConfig(
 	ctx context.Context, t testing.TB, stopper *stop.Stopper, opts testStoreOpts, cfg *StoreConfig,
 ) *Store {
 	store := createTestStoreWithoutStart(ctx, t, stopper, opts, cfg)
-	// Put an empty system config into gossip.
-	//
-	// TODO(ajwerner): Remove this in 22.2. It's possible it can be removed
-	// already.
-	if err := store.Gossip().AddInfoProto(gossip.KeyDeprecatedSystemConfig,
-		&config.SystemConfigEntries{}, 0); err != nil {
-		t.Fatal(err)
-	}
 	if err := store.Start(ctx, stopper); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/rpc/auth_tenant.go
+++ b/pkg/rpc/auth_tenant.go
@@ -300,7 +300,6 @@ var gossipSubscriptionPatternAllowlist = []string{
 	"cluster-id",
 	"node:.*",
 	"store:.*",
-	"system-db",
 }
 
 // authTenantRanges authorizes the provided tenant to invoke the

--- a/pkg/rpc/auth_test.go
+++ b/pkg/rpc/auth_test.go
@@ -658,19 +658,15 @@ func TestTenantAuthRequest(t *testing.T) {
 				expErr: noError,
 			},
 			{
-				req:    &kvpb.GossipSubscriptionRequest{Patterns: []string{"system-db"}},
-				expErr: noError,
-			},
-			{
 				req:    &kvpb.GossipSubscriptionRequest{Patterns: []string{"table-stat-added"}},
 				expErr: `requested pattern "table-stat-added" not permitted`,
 			},
 			{
-				req:    &kvpb.GossipSubscriptionRequest{Patterns: []string{"node:.*", "system-db"}},
+				req:    &kvpb.GossipSubscriptionRequest{Patterns: []string{"node:.*", "store:.*"}},
 				expErr: noError,
 			},
 			{
-				req:    &kvpb.GossipSubscriptionRequest{Patterns: []string{"node:.*", "system-db", "table-stat-added"}},
+				req:    &kvpb.GossipSubscriptionRequest{Patterns: []string{"node:.*", "store:.*", "table-stat-added"}},
 				expErr: `requested pattern "table-stat-added" not permitted`,
 			},
 		},

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -29,7 +29,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvcoord"
-	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvtenant"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvadmission"
@@ -2427,8 +2426,6 @@ func (n *Node) GossipSubscription(
 	ctx := n.storeCfg.AmbientCtx.AnnotateCtx(stream.Context())
 	ctxDone := ctx.Done()
 
-	_, isSecondaryTenant := roachpb.ClientTenantFromContext(ctx)
-
 	// Register a callback for each of the requested patterns. We don't want to
 	// block the gossip callback goroutine on a slow consumer, so we instead
 	// handle all communication asynchronously. We could pick a channel size and
@@ -2439,27 +2436,12 @@ func (n *Node) GossipSubscription(
 	entC := make(chan *kvpb.GossipSubscriptionEvent, 256)
 	entCClosed := false
 	var callbackMu syncutil.Mutex
-	var systemConfigUpdateCh <-chan struct{}
 	for i := range args.Patterns {
 		pattern := args.Patterns[i] // copy for closure
 		switch pattern {
-		// Note that we need to support clients subscribing to the system config
-		// over this RPC even if the system config is no longer stored in gossip
-		// in the host cluster. To achieve this, we special-case the system config
-		// key and hook it up to the node's SystemConfigProvider. We need to
-		// support this because tenant clusters are upgraded *after* the system
-		// tenant of the host cluster. Tenant sql servers will still be expecting
-		// this information to drive GC TTLs for their GC jobs. It's worth noting
-		// that those zone configurations won't really map to reality, but that's
-		// okay, we just need to tell the pods something.
-		//
-		// TODO(ajwerner): Remove support for the system config key in the
-		// in 22.2, or leave it and make it a no-op.
 		case gossip.KeyDeprecatedSystemConfig:
-			var unregister func()
-			systemConfigUpdateCh, unregister = n.storeCfg.SystemConfigProvider.RegisterSystemConfigChannel()
-			//nolint:deferloop TODO(#137605)
-			defer unregister()
+			// This case must remain as a no-op until we entirely remove
+			// gossip.KeyDeprecatedSystemConfig.
 		default:
 			callback := func(key string, content roachpb.Value) {
 				callbackMu.Lock()
@@ -2490,29 +2472,8 @@ func (n *Node) GossipSubscription(
 			defer unregister()
 		}
 	}
-	handleSystemConfigUpdate := func() error {
-		cfg := n.storeCfg.SystemConfigProvider.GetSystemConfig()
-		ents := cfg.SystemConfigEntries
-		if isSecondaryTenant {
-			ents = kvtenant.GossipSubscriptionSystemConfigMask.Apply(ents)
-		}
-		var event kvpb.GossipSubscriptionEvent
-		var content roachpb.Value
-		if err := content.SetProto(&ents); err != nil {
-			event.Error = kvpb.NewError(errors.Wrap(err, "could not marshal system config"))
-		} else {
-			event.Key = gossip.KeyDeprecatedSystemConfig
-			event.Content = content
-			event.PatternMatched = gossip.KeyDeprecatedSystemConfig
-		}
-		return stream.Send(&event)
-	}
 	for {
 		select {
-		case <-systemConfigUpdateCh:
-			if err := handleSystemConfigUpdate(); err != nil {
-				return errors.Wrap(err, "handling system config update")
-			}
 		case e, ok := <-entC:
 			if !ok {
 				// The consumer was not keeping up with gossip updates, so its


### PR DESCRIPTION
followup after https://github.com/cockroachdb/cockroach/pull/141815

This key was only needed in the 21.2/22.2 mixed version state.

Removing it and the related machinery allows us to make
kvtenant.connector stop implementing SystemConfigProvider.

The key should not be reused until it's entirely deleted from the gossip
network of existing clusters, so for now the string constant remains as
a placeholder.

fixes https://github.com/cockroachdb/cockroach/issues/76625
Release note: None
