### PR TITLE
sql/schemachanger: fix unusable secondary indexes during pk swap

### DIFF
--- a/pkg/ccl/changefeedccl/schemafeed/testdata/alter_primary_key
+++ b/pkg/ccl/changefeedccl/schemafeed/testdata/alter_primary_key
@@ -17,13 +17,14 @@ t 2->3: Unknown
 t 3->4: Unknown
 t 4->5: Unknown
 t 5->6: Unknown
-t 6->7: PrimaryKeyChange
+t 6->7: Unknown
 t 7->8: Unknown
 t 8->9: Unknown
 t 9->10: Unknown
 t 10->11: Unknown
-t 11->12: Unknown
+t 11->12: PrimaryKeyChange
 t 12->13: Unknown
+t 13->14: Unknown
 
 exec
 ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (k, j);
@@ -31,15 +32,16 @@ ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (k, j);
 
 pop f=1
 ----
-t 13->14: Unknown
 t 14->15: Unknown
 t 15->16: Unknown
 t 16->17: Unknown
 t 17->18: Unknown
-t 18->19: PrimaryKeyChange
+t 18->19: Unknown
 t 19->20: Unknown
 t 20->21: Unknown
 t 21->22: Unknown
 t 22->23: Unknown
 t 23->24: Unknown
-t 24->25: Unknown
+t 24->25: PrimaryKeyChange
+t 25->26: Unknown
+t 26->27: Unknown

--- a/pkg/ccl/schemachangerccl/backup_base_generated_test.go
+++ b/pkg/ccl/schemachangerccl/backup_base_generated_test.go
@@ -295,6 +295,13 @@ func TestBackupRollbacks_base_alter_table_alter_primary_key_drop_rowid(t *testin
 	sctest.BackupRollbacks(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestBackupRollbacks_base_alter_table_alter_primary_key_drop_rowid_with_idx(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx"
+	sctest.BackupRollbacks(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestBackupRollbacks_base_alter_table_alter_primary_key_using_hash(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -964,6 +971,13 @@ func TestBackupRollbacksMixedVersion_base_alter_table_alter_primary_key_drop_row
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid"
+	sctest.BackupRollbacksMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestBackupRollbacksMixedVersion_base_alter_table_alter_primary_key_drop_rowid_with_idx(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx"
 	sctest.BackupRollbacksMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
@@ -1639,6 +1653,13 @@ func TestBackupSuccess_base_alter_table_alter_primary_key_drop_rowid(t *testing.
 	sctest.BackupSuccess(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestBackupSuccess_base_alter_table_alter_primary_key_drop_rowid_with_idx(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx"
+	sctest.BackupSuccess(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestBackupSuccess_base_alter_table_alter_primary_key_using_hash(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -2308,6 +2329,13 @@ func TestBackupSuccessMixedVersion_base_alter_table_alter_primary_key_drop_rowid
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid"
+	sctest.BackupSuccessMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestBackupSuccessMixedVersion_base_alter_table_alter_primary_key_drop_rowid_with_idx(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx"
 	sctest.BackupSuccessMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 

--- a/pkg/ccl/schemachangerccl/testdata/decomp/partitioning
+++ b/pkg/ccl/schemachangerccl/testdata/decomp/partitioning
@@ -525,6 +525,7 @@ ElementState:
     isNotVisible: false
     isUnique: false
     recreateSourceId: 0
+    recreateTargetId: 0
     sharding: null
     sourceIndexId: 0
     tableId: 104
@@ -960,6 +961,7 @@ ElementState:
     isNotVisible: false
     isUnique: true
     recreateSourceId: 0
+    recreateTargetId: 0
     sharding: null
     sourceIndexId: 0
     tableId: 105

--- a/pkg/ccl/testccl/sqlccl/BUILD.bazel
+++ b/pkg/ccl/testccl/sqlccl/BUILD.bazel
@@ -43,7 +43,6 @@ go_test(
         "//pkg/sql",
         "//pkg/sql/catalog/lease",
         "//pkg/sql/catalog/replication",
-        "//pkg/sql/colexecerror",
         "//pkg/sql/gcjob",
         "//pkg/sql/isql",
         "//pkg/sql/lexbase",

--- a/pkg/ccl/testccl/sqlccl/explain_test.go
+++ b/pkg/ccl/testccl/sqlccl/explain_test.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/internal/sqlsmith"
-	"github.com/cockroachdb/cockroach/pkg/sql/colexecerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/lexbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltestutils"
 	"github.com/cockroachdb/cockroach/pkg/sql/tests"
@@ -137,11 +136,6 @@ func TestExplainGist(t *testing.T) {
 
 	skip.UnderDeadlock(t, "the test is too slow")
 	skip.UnderRace(t, "the test is too slow")
-
-	// Use the release-build panic-catching behavior instead of the
-	// crdb_test-build behavior. This is needed so that some known bugs like
-	// #119045 and #133129 don't result in a test failure.
-	defer colexecerror.ProductionBehaviorForTests()()
 
 	ctx := context.Background()
 	rng, _ := randutil.NewTestRand()

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -1045,7 +1045,7 @@ func (sc *SchemaChanger) distIndexBackfill(
 		)
 		indexBatchSize := indexBackfillBatchSize.Get(&sc.execCfg.Settings.SV)
 		chunkSize := sc.getChunkSize(indexBatchSize)
-		spec, err := initIndexBackfillerSpec(*tableDesc.TableDesc(), writeAsOf, readAsOf, writeAtRequestTimestamp, chunkSize, addedIndexes)
+		spec, err := initIndexBackfillerSpec(*tableDesc.TableDesc(), writeAsOf, readAsOf, writeAtRequestTimestamp, chunkSize, addedIndexes, 0 /* sourceIndexID*/)
 		if err != nil {
 			return err
 		}

--- a/pkg/sql/backfill/BUILD.bazel
+++ b/pkg/sql/backfill/BUILD.bazel
@@ -26,6 +26,7 @@ go_library(
         "//pkg/sql/execinfra",
         "//pkg/sql/execinfrapb",
         "//pkg/sql/isql",
+        "//pkg/sql/parser",
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",
         "//pkg/sql/row",

--- a/pkg/sql/backfill/backfill.go
+++ b/pkg/sql/backfill/backfill.go
@@ -479,6 +479,10 @@ type IndexBackfiller struct {
 	// backfilled.
 	indexesToEncode []catalog.Index
 
+	// sourceIndex the primary index that should be used to execute this
+	// backfill.
+	sourceIndex catalog.Index
+
 	// keyPrefixes is a slice of key prefixes for each index in indexesToEncode.
 	// indexesToEncode and keyPrefixes should both have the same ordering.
 	keyPrefixes [][]byte
@@ -512,7 +516,7 @@ func (ib *IndexBackfiller) InitForLocalUse(
 ) error {
 
 	// Initialize ib.added.
-	ib.initIndexes(evalCtx.Codec, desc, nil /* allowList */)
+	ib.initIndexes(evalCtx.Codec, desc, nil /* allowList */, 0 /*sourceIndex*/)
 
 	// Initialize ib.cols and ib.colIdxMap.
 	if err := ib.initCols(desc); err != nil {
@@ -648,6 +652,7 @@ func (ib *IndexBackfiller) InitForDistributedUse(
 	flowCtx *execinfra.FlowCtx,
 	desc catalog.TableDescriptor,
 	allowList []catid.IndexID,
+	sourceIndexID catid.IndexID,
 	mon *mon.BytesMonitor,
 ) error {
 	// We'll be modifying the eval.Context in BuildIndexEntriesChunk, so we need
@@ -655,7 +660,7 @@ func (ib *IndexBackfiller) InitForDistributedUse(
 	evalCtx := flowCtx.NewEvalCtx()
 
 	// Initialize ib.added.
-	ib.initIndexes(evalCtx.Codec, desc, allowList)
+	ib.initIndexes(evalCtx.Codec, desc, allowList, sourceIndexID)
 
 	// Initialize ib.indexBackfillerCols.
 	if err := ib.initCols(desc); err != nil {
@@ -733,7 +738,7 @@ func (ib *IndexBackfiller) ShrinkBoundAccount(ctx context.Context, shrinkBy int6
 // populates the cols and colIdxMap fields.
 func (ib *IndexBackfiller) initCols(desc catalog.TableDescriptor) (err error) {
 	ib.indexBackfillerCols, err = makeIndexBackfillColumns(
-		desc.DeletableColumns(), desc.GetPrimaryIndex(), ib.added,
+		desc.DeletableColumns(), ib.sourceIndex, ib.added,
 	)
 	return err
 }
@@ -745,7 +750,10 @@ func (ib *IndexBackfiller) initCols(desc catalog.TableDescriptor) (err error) {
 // If `allowList` is non-nil, we only add those in this list.
 // If `allowList` is nil, we add all adding index mutations.
 func (ib *IndexBackfiller) initIndexes(
-	codec keys.SQLCodec, desc catalog.TableDescriptor, allowList []catid.IndexID,
+	codec keys.SQLCodec,
+	desc catalog.TableDescriptor,
+	allowList []catid.IndexID,
+	sourceIndexID catid.IndexID,
 ) {
 	var allowListAsSet catid.IndexSet
 	if len(allowList) > 0 {
@@ -754,6 +762,11 @@ func (ib *IndexBackfiller) initIndexes(
 
 	mutations := desc.AllMutations()
 	mutationID := mutations[0].MutationID()
+	if sourceIndexID != 0 {
+		ib.sourceIndex = catalog.FindIndexByID(desc, sourceIndexID)
+	} else {
+		ib.sourceIndex = desc.GetPrimaryIndex()
+	}
 	ib.keyPrefixes = make([][]byte, 0, len(ib.added))
 	// Mutations in the same transaction have the same ID. Loop through the
 	// mutations and collect all index mutations.
@@ -859,7 +872,7 @@ func (ib *IndexBackfiller) BuildIndexEntriesChunk(
 	// read or used
 	var spec fetchpb.IndexFetchSpec
 	if err := rowenc.InitIndexFetchSpec(
-		&spec, ib.evalCtx.Codec, tableDesc, tableDesc.GetPrimaryIndex(), fetcherCols,
+		&spec, ib.evalCtx.Codec, tableDesc, ib.sourceIndex, fetcherCols,
 	); err != nil {
 		return nil, nil, memUsedPerChunk, err
 	}

--- a/pkg/sql/backfill/backfill.go
+++ b/pkg/sql/backfill/backfill.go
@@ -738,7 +738,7 @@ func (ib *IndexBackfiller) ShrinkBoundAccount(ctx context.Context, shrinkBy int6
 // populates the cols and colIdxMap fields.
 func (ib *IndexBackfiller) initCols(desc catalog.TableDescriptor) (err error) {
 	ib.indexBackfillerCols, err = makeIndexBackfillColumns(
-		desc.DeletableColumns(), ib.sourceIndex, ib.added,
+		desc, desc.DeletableColumns(), ib.sourceIndex, ib.added,
 	)
 	return err
 }

--- a/pkg/sql/backfill/index_backfiller_cols.go
+++ b/pkg/sql/backfill/index_backfiller_cols.go
@@ -8,6 +8,8 @@ package backfill
 import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catenumpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/schemaexpr"
+	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/util/intsets"
 	"github.com/cockroachdb/errors"
 )
@@ -52,7 +54,10 @@ type indexBackfillerCols struct {
 // requirements due to references in expressions. That needs to be added after
 // constructing this information.
 func makeIndexBackfillColumns(
-	deletableColumns []catalog.Column, sourcePrimaryIndex catalog.Index, addedIndexes []catalog.Index,
+	tableDesc catalog.TableDescriptor,
+	deletableColumns []catalog.Column,
+	sourcePrimaryIndex catalog.Index,
+	addedIndexes []catalog.Index,
 ) (indexBackfillerCols, error) {
 
 	// We will need to evaluate default or computed expressions for
@@ -71,6 +76,14 @@ func makeIndexBackfillColumns(
 	for _, idx := range addedIndexes {
 		allIndexColumns.UnionWith(indexColumns(idx))
 	}
+	if tableDesc != nil {
+		var err error
+		// Add any dependent columns needed to evaluate expressions.
+		allIndexColumns, err = addIndexColumnsFromExpressions(allIndexColumns, tableDesc, addedIndexes)
+		if err != nil {
+			return indexBackfillerCols{}, err
+		}
+	}
 	for _, column := range deletableColumns {
 		if !column.Public() &&
 			// Include columns we are adding, in case we are adding them to a
@@ -85,6 +98,23 @@ func makeIndexBackfillColumns(
 			!(column.Dropped() && primaryColumns.Contains(column.GetID()) &&
 				allIndexColumns.Contains(column.GetID())) {
 			continue
+		}
+		// Public columns that are not in the source primary index and not
+		// needed by the secondary index can be skipped. If there are virtual
+		// columns that are needed by the secondary index then pick those up.
+		if column.Public() && !primaryColumns.Contains(column.GetID()) {
+			// If a non-virtual column requested by the secondary index is missing
+			// we are going to error out.
+			if allIndexColumns.Contains(column.GetID()) && !column.IsVirtual() {
+				return indexBackfillerCols{}, errors.AssertionFailedf(
+					"column %s is public but not in the source primary index",
+					column.GetName(),
+				)
+			}
+			// If the column is not needed by the secondary index then we can skip it.
+			if !allIndexColumns.Contains(column.GetID()) {
+				continue
+			}
 		}
 		if column.IsComputed() && column.IsVirtual() {
 			computedVirtual.Add(column.GetID())
@@ -182,4 +212,46 @@ func indexColumns(idx catalog.Index) (s catalog.TableColSet) {
 	s.UnionWith(idx.CollectPrimaryStoredColumnIDs())
 	s.UnionWith(idx.CollectSecondaryStoredColumnIDs())
 	return s
+}
+
+// addIndexColumnsFromExpressions takes a set of columns stored in an index,
+// and computes any dependent columns needed for computed expressions or partial
+// indexes.
+func addIndexColumnsFromExpressions(
+	s catalog.TableColSet, table catalog.TableDescriptor, addIndexes []catalog.Index,
+) (catalog.TableColSet, error) {
+	addReferencesFromExpression := func(expression string) error {
+		expr, err := parser.ParseExpr(expression)
+		if err != nil {
+			return err
+		}
+		referencedColumns, err := schemaexpr.ExtractColumnIDs(table, expr)
+		if err != nil {
+			return err
+		}
+		for _, colID := range referencedColumns.Ordered() {
+			s.Add(colID)
+		}
+		return nil
+	}
+	// First get any columns needed to compute virtual expressions.
+	for _, colID := range s.Ordered() {
+		column := catalog.FindColumnByID(table, colID)
+		if !column.IsVirtual() || !column.IsComputed() {
+			continue
+		}
+		if err := addReferencesFromExpression(column.GetComputeExpr()); err != nil {
+			return s, err
+		}
+	}
+	// Next get any expressions needed to evaluate index predicates.
+	for _, idx := range addIndexes {
+		if len(idx.GetPredicate()) == 0 {
+			continue
+		}
+		if err := addReferencesFromExpression(idx.GetPredicate()); err != nil {
+			return s, err
+		}
+	}
+	return s, nil
 }

--- a/pkg/sql/backfill/index_backfiller_cols_test.go
+++ b/pkg/sql/backfill/index_backfiller_cols_test.go
@@ -113,9 +113,8 @@ func TestIndexBackfillerColumns(t *testing.T) {
 					keyCols: colIDs{1},
 				},
 			},
-			expCols:     colIDs{1, 2, 3},
-			expComputed: colIDs{3},
-			expNeeded:   colIDs{1},
+			expCols:   colIDs{1, 2},
+			expNeeded: colIDs{1},
 		},
 		{
 			name: "one virtual, one computed mutation column in primary",
@@ -333,7 +332,7 @@ func TestIndexBackfillerColumns(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			out, err := makeIndexBackfillColumns(
-				asColumnSlice(tc.cols), tc.src, asIndexSlice(tc.toEncode),
+				nil, asColumnSlice(tc.cols), tc.src, asIndexSlice(tc.toEncode),
 			)
 			if tc.expErr != "" {
 				require.Regexp(t, tc.expErr, err)

--- a/pkg/sql/backfill/index_backfiller_cols_test.go
+++ b/pkg/sql/backfill/index_backfiller_cols_test.go
@@ -412,7 +412,7 @@ func TestInitIndexesAllowList(t *testing.T) {
 	t.Run("nil allowList", func(t *testing.T) {
 		// A nil allowList means no filtering.
 		ib := &IndexBackfiller{}
-		ib.initIndexes(keys.SystemSQLCodec, desc, nil /* allowList */)
+		ib.initIndexes(keys.SystemSQLCodec, desc, nil /* allowList */, 0 /* sourceIndexID */)
 		require.Equal(t, 2, len(ib.added))
 		require.Equal(t, catid.IndexID(2), ib.added[0].GetID())
 		require.Equal(t, catid.IndexID(3), ib.added[1].GetID())
@@ -420,7 +420,7 @@ func TestInitIndexesAllowList(t *testing.T) {
 
 	t.Run("non-nil allowList", func(t *testing.T) {
 		ib := &IndexBackfiller{}
-		ib.initIndexes(keys.SystemSQLCodec, desc, []catid.IndexID{3} /* allowList */)
+		ib.initIndexes(keys.SystemSQLCodec, desc, []catid.IndexID{3} /* allowList */, 0 /* sourceIndexID */)
 		require.Equal(t, 1, len(ib.added))
 		require.Equal(t, catid.IndexID(3), ib.added[0].GetID())
 	})

--- a/pkg/sql/catalog/tabledesc/validate.go
+++ b/pkg/sql/catalog/tabledesc/validate.go
@@ -1791,13 +1791,10 @@ func (desc *wrapper) validateTableIndexes(
 			}
 
 			// When newPKColIDs is not empty, it means there is an in-progress `ALTER
-			// PRIMARY KEY`. We don't allow queueing schema changes when there's a
-			// primary key mutation, so it's safe to make the assumption that `Adding`
-			// indexes are associated with the new primary key because they are
-			// rewritten and `Non-adding` indexes should only contain virtual column
-			// from old primary key.
+			// PRIMARY KEY`. Certain schema changes will make the new virtual columns
+			// public earlier than the new primary key, which should be acceptable.
 			isOldPKCol := !idx.Adding() && curPKColIDs.Contains(colID)
-			isNewPKCol := idx.Adding() && newPKColIDs.Contains(colID)
+			isNewPKCol := newPKColIDs.Contains(colID)
 			if newPKColIDs.Len() > 0 && (isOldPKCol || isNewPKCol) {
 				continue
 			}

--- a/pkg/sql/catalog/tabledesc/validate_test.go
+++ b/pkg/sql/catalog/tabledesc/validate_test.go
@@ -1948,7 +1948,7 @@ func TestValidateTableDesc(t *testing.T) {
 				NextConstraintID: 3,
 				Privileges:       catpb.NewBasePrivilegeDescriptor(username.AdminRoleName()),
 			}},
-		{err: `index "sec" cannot store virtual column "c3"`,
+		{err: ``,
 			desc: descpb.TableDescriptor{
 				ID:            2,
 				ParentID:      1,

--- a/pkg/sql/distsql_plan_backfill.go
+++ b/pkg/sql/distsql_plan_backfill.go
@@ -44,6 +44,7 @@ func initIndexBackfillerSpec(
 	writeAtBatchTimestamp bool,
 	chunkSize int64,
 	indexesToBackfill []descpb.IndexID,
+	sourceIndexID descpb.IndexID,
 ) (execinfrapb.BackfillerSpec, error) {
 	return execinfrapb.BackfillerSpec{
 		Table:                 desc,
@@ -53,6 +54,7 @@ func initIndexBackfillerSpec(
 		Type:                  execinfrapb.BackfillerSpec_Index,
 		ChunkSize:             chunkSize,
 		IndexesToBackfill:     indexesToBackfill,
+		SourceIndexID:         sourceIndexID,
 	}, nil
 }
 

--- a/pkg/sql/execinfrapb/processors_bulk_io.proto
+++ b/pkg/sql/execinfrapb/processors_bulk_io.proto
@@ -81,7 +81,11 @@ message BackfillerSpec {
   // AddSSTableRequest.SSTTimestampToRequestTimestamp.
   optional bool write_at_batch_timestamp = 12 [(gogoproto.nullable) = false];
 
-  // NEXTID: 15.
+  // SourceIndexID is the source index that will be used for this backfill. If
+  // the value of 0 is specified then the primary index will be used implicitly.
+  optional uint32 source_index_id = 16 [(gogoproto.nullable) = false, (gogoproto.customname) = "SourceIndexID", (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb.IndexID"];
+
+  // NEXTID: 17.
 }
 
 // JobProgress identifies the job to report progress on. This reporting

--- a/pkg/sql/index_backfiller.go
+++ b/pkg/sql/index_backfiller.go
@@ -125,6 +125,7 @@ func (ib *IndexBackfillPlanner) BackfillIndexes(
 		progress.MinimumWriteTimestamp,
 		spansToDo,
 		progress.DestIndexIDs,
+		progress.SourceIndexID,
 		updateFunc,
 	)
 	if retErr != nil {
@@ -175,6 +176,7 @@ func (ib *IndexBackfillPlanner) plan(
 	nowTimestamp, writeAsOf, readAsOf hlc.Timestamp,
 	sourceSpans []roachpb.Span,
 	indexesToBackfill []descpb.IndexID,
+	sourceIndexID descpb.IndexID,
 	callback func(_ context.Context, meta *execinfrapb.ProducerMetadata) error,
 ) (runFunc func(context.Context) error, _ error) {
 
@@ -197,6 +199,7 @@ func (ib *IndexBackfillPlanner) plan(
 		spec, err := initIndexBackfillerSpec(
 			*td.TableDesc(), writeAsOf, readAsOf, writeAtRequestTimestamp, chunkSize,
 			indexesToBackfill,
+			sourceIndexID,
 		)
 		if err != nil {
 			return err

--- a/pkg/sql/rowexec/indexbackfiller.go
+++ b/pkg/sql/rowexec/indexbackfiller.go
@@ -94,7 +94,7 @@ func newIndexBackfiller(
 	}
 
 	if err := ib.IndexBackfiller.InitForDistributedUse(ctx, flowCtx, ib.desc,
-		ib.spec.IndexesToBackfill, indexBackfillerMon); err != nil {
+		ib.spec.IndexesToBackfill, ib.spec.SourceIndexID, indexBackfillerMon); err != nil {
 		return nil, err
 	}
 

--- a/pkg/sql/schemachanger/dml_injection_test.go
+++ b/pkg/sql/schemachanger/dml_injection_test.go
@@ -368,7 +368,6 @@ func TestAlterTableDMLInjection(t *testing.T) {
 			// Run a query against the secondary index at each stage.
 			query:        "SELECT operation FROM tbl@i1",
 			schemaChange: "ALTER TABLE tbl ALTER PRIMARY KEY USING COLUMNS (insert_phase_ordinal, operation_phase_ordinal, operation)",
-			skipIssue:    133129,
 		},
 		{
 			desc:        "alter primary key using columns using hash",

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_alter_primary_key.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_alter_primary_key.go
@@ -738,6 +738,7 @@ func recreateAllSecondaryIndexes(
 		}
 		in, temp := makeSwapIndexSpec(b, out, sourcePrimaryIndex.IndexID, inColumns, false /* inUseTempIDs */)
 		in.secondary.RecreateSourceIndexID = out.indexID()
+		in.secondary.RecreateTargetIndexID = newPrimaryIndex.IndexID
 		out.apply(b.Drop)
 		in.apply(b.Add)
 		temp.apply(b.AddTransient)

--- a/pkg/sql/schemachanger/scdecomp/testdata/table
+++ b/pkg/sql/schemachanger/scdecomp/testdata/table
@@ -913,6 +913,7 @@ ElementState:
     isNotVisible: false
     isUnique: false
     recreateSourceId: 0
+    recreateTargetId: 0
     referencedColumnIds:
     - 1
     sharding: null

--- a/pkg/sql/schemachanger/scdecomp/testdata/type
+++ b/pkg/sql/schemachanger/scdecomp/testdata/type
@@ -688,6 +688,7 @@ ElementState:
     isNotVisible: false
     isUnique: false
     recreateSourceId: 0
+    recreateTargetId: 0
     referencedColumnIds:
     - 2
     sharding: null
@@ -1691,6 +1692,7 @@ ElementState:
     isNotVisible: false
     isUnique: false
     recreateSourceId: 0
+    recreateTargetId: 0
     referencedColumnIds:
     - 2
     sharding: null

--- a/pkg/sql/schemachanger/scop/immediate_mutation.go
+++ b/pkg/sql/schemachanger/scop/immediate_mutation.go
@@ -1148,3 +1148,22 @@ type ForcedRowLevelSecurityMode struct {
 	TableID descpb.ID
 	Forced  bool
 }
+
+// MarkRecreatedIndexAsInvisible is used to mark secondary indexes recreated
+// after a primary key swap as invisible. This is to prevent their use before
+// primary key swap is complete.
+type MarkRecreatedIndexAsInvisible struct {
+	immediateMutationOp
+	TableID              descpb.ID
+	IndexID              descpb.IndexID
+	TargetPrimaryIndexID descpb.IndexID
+}
+
+// MarkRecreatedIndexesAsVisible is used to mark secondary indexes recreated
+// after a primary key swap as visible. This is to allow their use after
+// primary key swap is complete.
+type MarkRecreatedIndexesAsVisible struct {
+	immediateMutationOp
+	TableID           descpb.ID
+	IndexVisibilities map[descpb.IndexID]float64
+}

--- a/pkg/sql/schemachanger/scop/immediate_mutation_visitor_generated.go
+++ b/pkg/sql/schemachanger/scop/immediate_mutation_visitor_generated.go
@@ -166,6 +166,8 @@ type ImmediateMutationVisitor interface {
 	AddPartitionZoneConfig(context.Context, AddPartitionZoneConfig) error
 	EnableRowLevelSecurityMode(context.Context, EnableRowLevelSecurityMode) error
 	ForcedRowLevelSecurityMode(context.Context, ForcedRowLevelSecurityMode) error
+	MarkRecreatedIndexAsInvisible(context.Context, MarkRecreatedIndexAsInvisible) error
+	MarkRecreatedIndexesAsVisible(context.Context, MarkRecreatedIndexesAsVisible) error
 }
 
 // Visit is part of the ImmediateMutationOp interface.
@@ -911,4 +913,14 @@ func (op EnableRowLevelSecurityMode) Visit(ctx context.Context, v ImmediateMutat
 // Visit is part of the ImmediateMutationOp interface.
 func (op ForcedRowLevelSecurityMode) Visit(ctx context.Context, v ImmediateMutationVisitor) error {
 	return v.ForcedRowLevelSecurityMode(ctx, op)
+}
+
+// Visit is part of the ImmediateMutationOp interface.
+func (op MarkRecreatedIndexAsInvisible) Visit(ctx context.Context, v ImmediateMutationVisitor) error {
+	return v.MarkRecreatedIndexAsInvisible(ctx, op)
+}
+
+// Visit is part of the ImmediateMutationOp interface.
+func (op MarkRecreatedIndexesAsVisible) Visit(ctx context.Context, v ImmediateMutationVisitor) error {
+	return v.MarkRecreatedIndexesAsVisible(ctx, op)
 }

--- a/pkg/sql/schemachanger/scpb/elements.proto
+++ b/pkg/sql/schemachanger/scpb/elements.proto
@@ -342,6 +342,10 @@ message SecondaryIndex {
   // secondary index that we are trying to replace (this
   // is done for primary key changes).
   uint32 recreate_source_id = 4 [(gogoproto.customname) = "RecreateSourceIndexID", (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/sql/sem/catid.IndexID"];
+  // If an index is being recreated, this is the final primary
+  // index that will make it usable (i.e. the columns required
+  // to back this index will be public in this index)
+  uint32 recreate_target_id = 5 [(gogoproto.customname) = "RecreateTargetIndexID", (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/sql/sem/catid.IndexID"];
 }
 
 message TemporaryIndex {

--- a/pkg/sql/schemachanger/scpb/uml/table.puml
+++ b/pkg/sql/schemachanger/scpb/uml/table.puml
@@ -383,6 +383,7 @@ object SecondaryIndex
 SecondaryIndex :  Index
 SecondaryIndex :  EmbeddedExpr
 SecondaryIndex :  RecreateSourceIndexID
+SecondaryIndex :  RecreateTargetIndexID
 
 object SecondaryIndexPartial
 

--- a/pkg/sql/schemachanger/scplan/internal/opgen/opgen_secondary_index.go
+++ b/pkg/sql/schemachanger/scplan/internal/opgen/opgen_secondary_index.go
@@ -125,6 +125,19 @@ func init() {
 				}),
 			),
 			to(scpb.Status_PUBLIC,
+				emit(func(this *scpb.SecondaryIndex) *scop.MarkRecreatedIndexAsInvisible {
+					// Recreated indexes are not visible until their final primary index
+					// is usable. While they maybe made public we need to make sure they
+					// are not accidentally used.
+					if this.RecreateTargetIndexID == 0 {
+						return nil
+					}
+					return &scop.MarkRecreatedIndexAsInvisible{
+						TableID:              this.TableID,
+						IndexID:              this.IndexID,
+						TargetPrimaryIndexID: this.RecreateTargetIndexID,
+					}
+				}),
 				emit(func(this *scpb.SecondaryIndex) *scop.MakeValidatedSecondaryIndexPublic {
 					return &scop.MakeValidatedSecondaryIndexPublic{
 						TableID: this.TableID,

--- a/pkg/sql/schemachanger/scplan/internal/rules/current/dep_add_index.go
+++ b/pkg/sql/schemachanger/scplan/internal/rules/current/dep_add_index.go
@@ -203,7 +203,7 @@ func init() {
 func init() {
 
 	registerDepRule(
-		"primary index with new columns should exist before secondary indexes",
+		"primary index with new columns should validated before secondary indexes",
 		scgraph.Precedence,
 		"primary-index", "secondary-index",
 		func(from, to NodeVars) rel.Clauses {
@@ -216,7 +216,27 @@ func init() {
 					to, screl.SourceIndexID,
 					"primary-index-id",
 				),
-				StatusesToPublicOrTransient(from, scpb.Status_PUBLIC, to, scpb.Status_BACKFILL_ONLY),
+				StatusesToPublicOrTransient(from, scpb.Status_VALIDATED, to, scpb.Status_BACKFILL_ONLY),
+			}
+		})
+
+	// This rule guarantees that the primary index can only go public, once the
+	// secondary index is ready to go public.
+	registerDepRule(
+		"secondary indexes should be in a validated state before primary indexes can go public",
+		scgraph.Precedence,
+		"secondary-index", "primary-index",
+		func(from, to NodeVars) rel.Clauses {
+			return rel.Clauses{
+				from.Type((*scpb.SecondaryIndex)(nil)),
+				to.Type((*scpb.PrimaryIndex)(nil)),
+				JoinOnDescID(from, to, "table-id"),
+				JoinOn(
+					from, screl.SourceIndexID,
+					to, screl.IndexID,
+					"primary-index-id",
+				),
+				StatusesToPublicOrTransient(from, scpb.Status_VALIDATED, to, scpb.Status_PUBLIC),
 			}
 		})
 
@@ -234,7 +254,7 @@ func init() {
 					to, screl.SourceIndexID,
 					"primary-index-id",
 				),
-				StatusesToPublicOrTransient(from, scpb.Status_PUBLIC, to, scpb.Status_DELETE_ONLY),
+				StatusesToPublicOrTransient(from, scpb.Status_VALIDATED, to, scpb.Status_DELETE_ONLY),
 			}
 		})
 }

--- a/pkg/sql/schemachanger/scplan/internal/rules/current/testdata/deprules
+++ b/pkg/sql/schemachanger/scplan/internal/rules/current/testdata/deprules
@@ -4031,21 +4031,6 @@ deprules
     - $old-index-Node[CurrentStatus] = PUBLIC
     - joinTargetNode($new-index, $new-index-Target, $new-index-Node)
     - joinTargetNode($old-index, $old-index-Target, $old-index-Node)
-- name: primary index with new columns should exist before secondary indexes
-  from: primary-index-Node
-  kind: Precedence
-  to: secondary-index-Node
-  query:
-    - $primary-index[Type] = '*scpb.PrimaryIndex'
-    - $secondary-index[Type] = '*scpb.SecondaryIndex'
-    - joinOnDescID($primary-index, $secondary-index, $table-id)
-    - $primary-index[IndexID] = $primary-index-id
-    - $secondary-index[SourceIndexID] = $primary-index-id
-    - ToPublicOrTransient($primary-index-Target, $secondary-index-Target)
-    - $primary-index-Node[CurrentStatus] = PUBLIC
-    - $secondary-index-Node[CurrentStatus] = BACKFILL_ONLY
-    - joinTargetNode($primary-index, $primary-index-Target, $primary-index-Node)
-    - joinTargetNode($secondary-index, $secondary-index-Target, $secondary-index-Node)
 - name: primary index with new columns should exist before temp indexes
   from: primary-index-Node
   kind: Precedence
@@ -4057,10 +4042,25 @@ deprules
     - $primary-index[IndexID] = $primary-index-id
     - $temp-index[SourceIndexID] = $primary-index-id
     - ToPublicOrTransient($primary-index-Target, $temp-index-Target)
-    - $primary-index-Node[CurrentStatus] = PUBLIC
+    - $primary-index-Node[CurrentStatus] = VALIDATED
     - $temp-index-Node[CurrentStatus] = DELETE_ONLY
     - joinTargetNode($primary-index, $primary-index-Target, $primary-index-Node)
     - joinTargetNode($temp-index, $temp-index-Target, $temp-index-Node)
+- name: primary index with new columns should validated before secondary indexes
+  from: primary-index-Node
+  kind: Precedence
+  to: secondary-index-Node
+  query:
+    - $primary-index[Type] = '*scpb.PrimaryIndex'
+    - $secondary-index[Type] = '*scpb.SecondaryIndex'
+    - joinOnDescID($primary-index, $secondary-index, $table-id)
+    - $primary-index[IndexID] = $primary-index-id
+    - $secondary-index[SourceIndexID] = $primary-index-id
+    - ToPublicOrTransient($primary-index-Target, $secondary-index-Target)
+    - $primary-index-Node[CurrentStatus] = VALIDATED
+    - $secondary-index-Node[CurrentStatus] = BACKFILL_ONLY
+    - joinTargetNode($primary-index, $primary-index-Target, $primary-index-Node)
+    - joinTargetNode($secondary-index, $secondary-index-Target, $secondary-index-Node)
 - name: relation dropped before dependent column
   from: descriptor-Node
   kind: Precedence
@@ -4462,6 +4462,21 @@ deprules
     - isIndexKeyColumnKey(*scpb.IndexColumn)($index-column)
     - joinTargetNode($index, $index-Target, $index-Node)
     - joinTargetNode($column, $column-Target, $column-Node)
+- name: secondary indexes should be in a validated state before primary indexes can go public
+  from: secondary-index-Node
+  kind: Precedence
+  to: primary-index-Node
+  query:
+    - $secondary-index[Type] = '*scpb.SecondaryIndex'
+    - $primary-index[Type] = '*scpb.PrimaryIndex'
+    - joinOnDescID($secondary-index, $primary-index, $table-id)
+    - $secondary-index[SourceIndexID] = $primary-index-id
+    - $primary-index[IndexID] = $primary-index-id
+    - ToPublicOrTransient($secondary-index-Target, $primary-index-Target)
+    - $secondary-index-Node[CurrentStatus] = VALIDATED
+    - $primary-index-Node[CurrentStatus] = PUBLIC
+    - joinTargetNode($secondary-index, $secondary-index-Target, $secondary-index-Node)
+    - joinTargetNode($primary-index, $primary-index-Target, $primary-index-Node)
 - name: simple constraint public right before its dependents
   from: simple-constraint-Node
   kind: SameStagePrecedence
@@ -8687,21 +8702,6 @@ deprules
     - $old-index-Node[CurrentStatus] = PUBLIC
     - joinTargetNode($new-index, $new-index-Target, $new-index-Node)
     - joinTargetNode($old-index, $old-index-Target, $old-index-Node)
-- name: primary index with new columns should exist before secondary indexes
-  from: primary-index-Node
-  kind: Precedence
-  to: secondary-index-Node
-  query:
-    - $primary-index[Type] = '*scpb.PrimaryIndex'
-    - $secondary-index[Type] = '*scpb.SecondaryIndex'
-    - joinOnDescID($primary-index, $secondary-index, $table-id)
-    - $primary-index[IndexID] = $primary-index-id
-    - $secondary-index[SourceIndexID] = $primary-index-id
-    - ToPublicOrTransient($primary-index-Target, $secondary-index-Target)
-    - $primary-index-Node[CurrentStatus] = PUBLIC
-    - $secondary-index-Node[CurrentStatus] = BACKFILL_ONLY
-    - joinTargetNode($primary-index, $primary-index-Target, $primary-index-Node)
-    - joinTargetNode($secondary-index, $secondary-index-Target, $secondary-index-Node)
 - name: primary index with new columns should exist before temp indexes
   from: primary-index-Node
   kind: Precedence
@@ -8713,10 +8713,25 @@ deprules
     - $primary-index[IndexID] = $primary-index-id
     - $temp-index[SourceIndexID] = $primary-index-id
     - ToPublicOrTransient($primary-index-Target, $temp-index-Target)
-    - $primary-index-Node[CurrentStatus] = PUBLIC
+    - $primary-index-Node[CurrentStatus] = VALIDATED
     - $temp-index-Node[CurrentStatus] = DELETE_ONLY
     - joinTargetNode($primary-index, $primary-index-Target, $primary-index-Node)
     - joinTargetNode($temp-index, $temp-index-Target, $temp-index-Node)
+- name: primary index with new columns should validated before secondary indexes
+  from: primary-index-Node
+  kind: Precedence
+  to: secondary-index-Node
+  query:
+    - $primary-index[Type] = '*scpb.PrimaryIndex'
+    - $secondary-index[Type] = '*scpb.SecondaryIndex'
+    - joinOnDescID($primary-index, $secondary-index, $table-id)
+    - $primary-index[IndexID] = $primary-index-id
+    - $secondary-index[SourceIndexID] = $primary-index-id
+    - ToPublicOrTransient($primary-index-Target, $secondary-index-Target)
+    - $primary-index-Node[CurrentStatus] = VALIDATED
+    - $secondary-index-Node[CurrentStatus] = BACKFILL_ONLY
+    - joinTargetNode($primary-index, $primary-index-Target, $primary-index-Node)
+    - joinTargetNode($secondary-index, $secondary-index-Target, $secondary-index-Node)
 - name: relation dropped before dependent column
   from: descriptor-Node
   kind: Precedence
@@ -9118,6 +9133,21 @@ deprules
     - isIndexKeyColumnKey(*scpb.IndexColumn)($index-column)
     - joinTargetNode($index, $index-Target, $index-Node)
     - joinTargetNode($column, $column-Target, $column-Node)
+- name: secondary indexes should be in a validated state before primary indexes can go public
+  from: secondary-index-Node
+  kind: Precedence
+  to: primary-index-Node
+  query:
+    - $secondary-index[Type] = '*scpb.SecondaryIndex'
+    - $primary-index[Type] = '*scpb.PrimaryIndex'
+    - joinOnDescID($secondary-index, $primary-index, $table-id)
+    - $secondary-index[SourceIndexID] = $primary-index-id
+    - $primary-index[IndexID] = $primary-index-id
+    - ToPublicOrTransient($secondary-index-Target, $primary-index-Target)
+    - $secondary-index-Node[CurrentStatus] = VALIDATED
+    - $primary-index-Node[CurrentStatus] = PUBLIC
+    - joinTargetNode($secondary-index, $secondary-index-Target, $secondary-index-Node)
+    - joinTargetNode($primary-index, $primary-index-Target, $primary-index-Node)
 - name: simple constraint public right before its dependents
   from: simple-constraint-Node
   kind: SameStagePrecedence

--- a/pkg/sql/schemachanger/scplan/testdata/alter_table_add_column
+++ b/pkg/sql/schemachanger/scplan/testdata/alter_table_add_column
@@ -2196,12 +2196,8 @@ PostCommitPhase stage 7 of 15 with 1 ValidationType op
     *scop.ValidateIndex
       IndexID: 4
       TableID: 108
-PostCommitPhase stage 8 of 15 with 15 MutationType ops
+PostCommitPhase stage 8 of 15 with 11 MutationType ops
   transitions:
-    [[PrimaryIndex:{DescID: 108, IndexID: 1, ConstraintID: 1}, ABSENT], PUBLIC] -> VALIDATED
-    [[IndexName:{DescID: 108, Name: t_pkey, IndexID: 1}, ABSENT], PUBLIC] -> ABSENT
-    [[PrimaryIndex:{DescID: 108, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1}, PUBLIC], VALIDATED] -> PUBLIC
-    [[IndexName:{DescID: 108, Name: t_pkey, IndexID: 4}, PUBLIC], ABSENT] -> PUBLIC
     [[SecondaryIndex:{DescID: 108, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 4, RecreateSourceIndexID: 0}, PUBLIC], ABSENT] -> BACKFILL_ONLY
     [[IndexData:{DescID: 108, IndexID: 2}, PUBLIC], ABSENT] -> PUBLIC
     [[TemporaryIndex:{DescID: 108, IndexID: 3, ConstraintID: 3, SourceIndexID: 4}, TRANSIENT_ABSENT], ABSENT] -> DELETE_ONLY
@@ -2211,20 +2207,6 @@ PostCommitPhase stage 8 of 15 with 15 MutationType ops
     [[IndexColumn:{DescID: 108, ColumnID: 2, IndexID: 3}, TRANSIENT_ABSENT], ABSENT] -> PUBLIC
     [[IndexName:{DescID: 108, Name: t_i_key, IndexID: 2}, PUBLIC], ABSENT] -> PUBLIC
   ops:
-    *scop.MakePublicPrimaryIndexWriteOnly
-      IndexID: 1
-      TableID: 108
-    *scop.SetIndexName
-      IndexID: 1
-      Name: crdb_internal_index_1_name_placeholder
-      TableID: 108
-    *scop.SetIndexName
-      IndexID: 4
-      Name: t_pkey
-      TableID: 108
-    *scop.MakeValidatedPrimaryIndexPublic
-      IndexID: 4
-      TableID: 108
     *scop.MakeAbsentIndexBackfilling
       Index:
         ConstraintID: 2
@@ -2346,11 +2328,12 @@ PostCommitPhase stage 15 of 15 with 1 ValidationType op
     *scop.ValidateIndex
       IndexID: 2
       TableID: 108
-PostCommitNonRevertiblePhase stage 1 of 2 with 13 MutationType ops
+PostCommitNonRevertiblePhase stage 1 of 3 with 14 MutationType ops
   transitions:
-    [[IndexColumn:{DescID: 108, ColumnID: 1, IndexID: 1}, ABSENT], PUBLIC] -> ABSENT
-    [[IndexColumn:{DescID: 108, ColumnID: 2, IndexID: 1}, ABSENT], PUBLIC] -> ABSENT
-    [[PrimaryIndex:{DescID: 108, IndexID: 1, ConstraintID: 1}, ABSENT], VALIDATED] -> DELETE_ONLY
+    [[PrimaryIndex:{DescID: 108, IndexID: 1, ConstraintID: 1}, ABSENT], PUBLIC] -> VALIDATED
+    [[IndexName:{DescID: 108, Name: t_pkey, IndexID: 1}, ABSENT], PUBLIC] -> ABSENT
+    [[PrimaryIndex:{DescID: 108, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1}, PUBLIC], VALIDATED] -> PUBLIC
+    [[IndexName:{DescID: 108, Name: t_pkey, IndexID: 4}, PUBLIC], ABSENT] -> PUBLIC
     [[TemporaryIndex:{DescID: 108, IndexID: 5, ConstraintID: 5, SourceIndexID: 1}, TRANSIENT_ABSENT], TRANSIENT_DELETE_ONLY] -> TRANSIENT_ABSENT
     [[IndexColumn:{DescID: 108, ColumnID: 1, IndexID: 5}, TRANSIENT_ABSENT], PUBLIC] -> TRANSIENT_ABSENT
     [[IndexColumn:{DescID: 108, ColumnID: 2, IndexID: 5}, TRANSIENT_ABSENT], PUBLIC] -> TRANSIENT_ABSENT
@@ -2359,6 +2342,17 @@ PostCommitNonRevertiblePhase stage 1 of 2 with 13 MutationType ops
     [[IndexColumn:{DescID: 108, ColumnID: 1, IndexID: 3}, TRANSIENT_ABSENT], PUBLIC] -> TRANSIENT_ABSENT
     [[IndexColumn:{DescID: 108, ColumnID: 2, IndexID: 3}, TRANSIENT_ABSENT], PUBLIC] -> TRANSIENT_ABSENT
   ops:
+    *scop.MakePublicPrimaryIndexWriteOnly
+      IndexID: 1
+      TableID: 108
+    *scop.SetIndexName
+      IndexID: 1
+      Name: crdb_internal_index_1_name_placeholder
+      TableID: 108
+    *scop.SetIndexName
+      IndexID: 4
+      Name: t_pkey
+      TableID: 108
     *scop.RemoveColumnFromIndex
       ColumnID: 1
       IndexID: 5
@@ -2382,14 +2376,28 @@ PostCommitNonRevertiblePhase stage 1 of 2 with 13 MutationType ops
       IndexID: 3
       Kind: 1
       TableID: 108
-    *scop.MakeWriteOnlyIndexDeleteOnly
-      IndexID: 1
+    *scop.MakeValidatedPrimaryIndexPublic
+      IndexID: 4
       TableID: 108
     *scop.MakeIndexAbsent
       IndexID: 5
       TableID: 108
     *scop.MakeIndexAbsent
       IndexID: 3
+      TableID: 108
+    *scop.SetJobStateOnDescriptor
+      DescriptorID: 108
+    *scop.UpdateSchemaChangerJob
+      IsNonCancelable: true
+      JobID: 1
+PostCommitNonRevertiblePhase stage 2 of 3 with 5 MutationType ops
+  transitions:
+    [[IndexColumn:{DescID: 108, ColumnID: 1, IndexID: 1}, ABSENT], PUBLIC] -> ABSENT
+    [[IndexColumn:{DescID: 108, ColumnID: 2, IndexID: 1}, ABSENT], PUBLIC] -> ABSENT
+    [[PrimaryIndex:{DescID: 108, IndexID: 1, ConstraintID: 1}, ABSENT], VALIDATED] -> DELETE_ONLY
+  ops:
+    *scop.MakeWriteOnlyIndexDeleteOnly
+      IndexID: 1
       TableID: 108
     *scop.RemoveColumnFromIndex
       ColumnID: 1
@@ -2405,7 +2413,7 @@ PostCommitNonRevertiblePhase stage 1 of 2 with 13 MutationType ops
     *scop.UpdateSchemaChangerJob
       IsNonCancelable: true
       JobID: 1
-PostCommitNonRevertiblePhase stage 2 of 2 with 6 MutationType ops
+PostCommitNonRevertiblePhase stage 3 of 3 with 6 MutationType ops
   transitions:
     [[PrimaryIndex:{DescID: 108, IndexID: 1, ConstraintID: 1}, ABSENT], DELETE_ONLY] -> ABSENT
     [[IndexData:{DescID: 108, IndexID: 1}, ABSENT], PUBLIC] -> ABSENT
@@ -2709,12 +2717,8 @@ PostCommitPhase stage 7 of 15 with 1 ValidationType op
     *scop.ValidateIndex
       IndexID: 4
       TableID: 109
-PostCommitPhase stage 8 of 15 with 15 MutationType ops
+PostCommitPhase stage 8 of 15 with 11 MutationType ops
   transitions:
-    [[PrimaryIndex:{DescID: 109, IndexID: 1, ConstraintID: 1}, ABSENT], PUBLIC] -> VALIDATED
-    [[IndexName:{DescID: 109, Name: baz_pkey, IndexID: 1}, ABSENT], PUBLIC] -> ABSENT
-    [[PrimaryIndex:{DescID: 109, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1}, PUBLIC], VALIDATED] -> PUBLIC
-    [[IndexName:{DescID: 109, Name: baz_pkey, IndexID: 4}, PUBLIC], ABSENT] -> PUBLIC
     [[IndexColumn:{DescID: 109, ColumnID: 2, IndexID: 2}, PUBLIC], ABSENT] -> PUBLIC
     [[IndexColumn:{DescID: 109, ColumnID: 1, IndexID: 2}, PUBLIC], ABSENT] -> PUBLIC
     [[SecondaryIndex:{DescID: 109, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 4, RecreateSourceIndexID: 0}, PUBLIC], ABSENT] -> BACKFILL_ONLY
@@ -2724,20 +2728,6 @@ PostCommitPhase stage 8 of 15 with 15 MutationType ops
     [[IndexColumn:{DescID: 109, ColumnID: 1, IndexID: 3}, TRANSIENT_ABSENT], ABSENT] -> PUBLIC
     [[TemporaryIndex:{DescID: 109, IndexID: 3, ConstraintID: 3, SourceIndexID: 4}, TRANSIENT_ABSENT], ABSENT] -> DELETE_ONLY
   ops:
-    *scop.MakePublicPrimaryIndexWriteOnly
-      IndexID: 1
-      TableID: 109
-    *scop.SetIndexName
-      IndexID: 1
-      Name: crdb_internal_index_1_name_placeholder
-      TableID: 109
-    *scop.SetIndexName
-      IndexID: 4
-      Name: baz_pkey
-      TableID: 109
-    *scop.MakeValidatedPrimaryIndexPublic
-      IndexID: 4
-      TableID: 109
     *scop.MakeAbsentIndexBackfilling
       Index:
         ConstraintID: 2
@@ -2859,11 +2849,13 @@ PostCommitPhase stage 15 of 15 with 1 ValidationType op
     *scop.ValidateIndex
       IndexID: 2
       TableID: 109
-PostCommitNonRevertiblePhase stage 1 of 2 with 14 MutationType ops
+PostCommitNonRevertiblePhase stage 1 of 3 with 16 MutationType ops
   transitions:
-    [[IndexColumn:{DescID: 109, ColumnID: 1, IndexID: 1}, ABSENT], PUBLIC] -> ABSENT
-    [[PrimaryIndex:{DescID: 109, IndexID: 1, ConstraintID: 1}, ABSENT], VALIDATED] -> DELETE_ONLY
+    [[PrimaryIndex:{DescID: 109, IndexID: 1, ConstraintID: 1}, ABSENT], PUBLIC] -> VALIDATED
+    [[IndexName:{DescID: 109, Name: baz_pkey, IndexID: 1}, ABSENT], PUBLIC] -> ABSENT
     [[Column:{DescID: 109, ColumnID: 2}, PUBLIC], WRITE_ONLY] -> PUBLIC
+    [[PrimaryIndex:{DescID: 109, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1}, PUBLIC], VALIDATED] -> PUBLIC
+    [[IndexName:{DescID: 109, Name: baz_pkey, IndexID: 4}, PUBLIC], ABSENT] -> PUBLIC
     [[TemporaryIndex:{DescID: 109, IndexID: 5, ConstraintID: 5, SourceIndexID: 1}, TRANSIENT_ABSENT], TRANSIENT_DELETE_ONLY] -> TRANSIENT_ABSENT
     [[IndexColumn:{DescID: 109, ColumnID: 1, IndexID: 5}, TRANSIENT_ABSENT], PUBLIC] -> TRANSIENT_ABSENT
     [[IndexColumn:{DescID: 109, ColumnID: 2, IndexID: 5}, TRANSIENT_ABSENT], PUBLIC] -> TRANSIENT_ABSENT
@@ -2872,10 +2864,16 @@ PostCommitNonRevertiblePhase stage 1 of 2 with 14 MutationType ops
     [[IndexColumn:{DescID: 109, ColumnID: 1, IndexID: 3}, TRANSIENT_ABSENT], PUBLIC] -> TRANSIENT_ABSENT
     [[TemporaryIndex:{DescID: 109, IndexID: 3, ConstraintID: 3, SourceIndexID: 4}, TRANSIENT_ABSENT], TRANSIENT_DELETE_ONLY] -> TRANSIENT_ABSENT
   ops:
-    *scop.MakeWriteOnlyColumnPublic
-      ColumnID: 2
+    *scop.MakePublicPrimaryIndexWriteOnly
+      IndexID: 1
       TableID: 109
-    *scop.RefreshStats
+    *scop.SetIndexName
+      IndexID: 1
+      Name: crdb_internal_index_1_name_placeholder
+      TableID: 109
+    *scop.SetIndexName
+      IndexID: 4
+      Name: baz_pkey
       TableID: 109
     *scop.RemoveColumnFromIndex
       ColumnID: 1
@@ -2903,11 +2901,29 @@ PostCommitNonRevertiblePhase stage 1 of 2 with 14 MutationType ops
     *scop.MakeIndexAbsent
       IndexID: 3
       TableID: 109
-    *scop.MakeWriteOnlyIndexDeleteOnly
-      IndexID: 1
+    *scop.MakeValidatedPrimaryIndexPublic
+      IndexID: 4
       TableID: 109
     *scop.MakeIndexAbsent
       IndexID: 5
+      TableID: 109
+    *scop.MakeWriteOnlyColumnPublic
+      ColumnID: 2
+      TableID: 109
+    *scop.RefreshStats
+      TableID: 109
+    *scop.SetJobStateOnDescriptor
+      DescriptorID: 109
+    *scop.UpdateSchemaChangerJob
+      IsNonCancelable: true
+      JobID: 1
+PostCommitNonRevertiblePhase stage 2 of 3 with 4 MutationType ops
+  transitions:
+    [[IndexColumn:{DescID: 109, ColumnID: 1, IndexID: 1}, ABSENT], PUBLIC] -> ABSENT
+    [[PrimaryIndex:{DescID: 109, IndexID: 1, ConstraintID: 1}, ABSENT], VALIDATED] -> DELETE_ONLY
+  ops:
+    *scop.MakeWriteOnlyIndexDeleteOnly
+      IndexID: 1
       TableID: 109
     *scop.RemoveColumnFromIndex
       ColumnID: 1
@@ -2918,7 +2934,7 @@ PostCommitNonRevertiblePhase stage 1 of 2 with 14 MutationType ops
     *scop.UpdateSchemaChangerJob
       IsNonCancelable: true
       JobID: 1
-PostCommitNonRevertiblePhase stage 2 of 2 with 6 MutationType ops
+PostCommitNonRevertiblePhase stage 3 of 3 with 6 MutationType ops
   transitions:
     [[PrimaryIndex:{DescID: 109, IndexID: 1, ConstraintID: 1}, ABSENT], DELETE_ONLY] -> ABSENT
     [[IndexData:{DescID: 109, IndexID: 1}, ABSENT], PUBLIC] -> ABSENT
@@ -3223,18 +3239,18 @@ ALTER TABLE defaultdb.baz ADD g INT UNIQUE DEFAULT 1
   to:   [Column:{DescID: 109, ColumnID: 2}, PUBLIC]
   kind: Precedence
   rule: swapped primary index public before column
-- from: [PrimaryIndex:{DescID: 109, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1}, PUBLIC]
-  to:   [SecondaryIndex:{DescID: 109, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 4, RecreateSourceIndexID: 0}, BACKFILL_ONLY]
-  kind: Precedence
-  rule: primary index with new columns should exist before secondary indexes
-- from: [PrimaryIndex:{DescID: 109, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1}, PUBLIC]
-  to:   [TemporaryIndex:{DescID: 109, IndexID: 3, ConstraintID: 3, SourceIndexID: 4}, DELETE_ONLY]
-  kind: Precedence
-  rule: primary index with new columns should exist before temp indexes
 - from: [PrimaryIndex:{DescID: 109, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1}, VALIDATED]
   to:   [PrimaryIndex:{DescID: 109, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1}, PUBLIC]
   kind: PreviousTransactionPrecedence
   rule: PrimaryIndex transitions to PUBLIC uphold 2-version invariant: VALIDATED->PUBLIC
+- from: [PrimaryIndex:{DescID: 109, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1}, VALIDATED]
+  to:   [SecondaryIndex:{DescID: 109, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 4, RecreateSourceIndexID: 0}, BACKFILL_ONLY]
+  kind: Precedence
+  rule: primary index with new columns should validated before secondary indexes
+- from: [PrimaryIndex:{DescID: 109, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1}, VALIDATED]
+  to:   [TemporaryIndex:{DescID: 109, IndexID: 3, ConstraintID: 3, SourceIndexID: 4}, DELETE_ONLY]
+  kind: Precedence
+  rule: primary index with new columns should exist before temp indexes
 - from: [PrimaryIndex:{DescID: 109, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1}, WRITE_ONLY]
   to:   [PrimaryIndex:{DescID: 109, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1}, VALIDATED]
   kind: PreviousTransactionPrecedence
@@ -3283,6 +3299,10 @@ ALTER TABLE defaultdb.baz ADD g INT UNIQUE DEFAULT 1
   to:   [SecondaryIndex:{DescID: 109, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 4, RecreateSourceIndexID: 0}, MERGED]
   kind: PreviousTransactionPrecedence
   rule: SecondaryIndex transitions to PUBLIC uphold 2-version invariant: MERGE_ONLY->MERGED
+- from: [SecondaryIndex:{DescID: 109, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 4, RecreateSourceIndexID: 0}, VALIDATED]
+  to:   [PrimaryIndex:{DescID: 109, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1}, PUBLIC]
+  kind: Precedence
+  rule: secondary indexes should be in a validated state before primary indexes can go public
 - from: [SecondaryIndex:{DescID: 109, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 4, RecreateSourceIndexID: 0}, VALIDATED]
   to:   [SecondaryIndex:{DescID: 109, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 4, RecreateSourceIndexID: 0}, PUBLIC]
   kind: PreviousTransactionPrecedence

--- a/pkg/sql/schemachanger/scplan/testdata/alter_table_add_column_generated
+++ b/pkg/sql/schemachanger/scplan/testdata/alter_table_add_column_generated
@@ -2684,12 +2684,8 @@ PostCommitPhase stage 7 of 15 with 1 ValidationType op
     *scop.ValidateIndex
       IndexID: 4
       TableID: 107
-PostCommitPhase stage 8 of 15 with 15 MutationType ops
+PostCommitPhase stage 8 of 15 with 11 MutationType ops
   transitions:
-    [[PrimaryIndex:{DescID: 107, IndexID: 1, ConstraintID: 1}, ABSENT], PUBLIC] -> VALIDATED
-    [[IndexName:{DescID: 107, Name: t_pkey, IndexID: 1}, ABSENT], PUBLIC] -> ABSENT
-    [[PrimaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1}, PUBLIC], VALIDATED] -> PUBLIC
-    [[IndexName:{DescID: 107, Name: t_pkey, IndexID: 4}, PUBLIC], ABSENT] -> PUBLIC
     [[SecondaryIndex:{DescID: 107, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 4, RecreateSourceIndexID: 0}, PUBLIC], ABSENT] -> BACKFILL_ONLY
     [[IndexData:{DescID: 107, IndexID: 2}, PUBLIC], ABSENT] -> PUBLIC
     [[TemporaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 3, SourceIndexID: 4}, TRANSIENT_ABSENT], ABSENT] -> DELETE_ONLY
@@ -2699,20 +2695,6 @@ PostCommitPhase stage 8 of 15 with 15 MutationType ops
     [[IndexColumn:{DescID: 107, ColumnID: 2, IndexID: 3}, TRANSIENT_ABSENT], ABSENT] -> PUBLIC
     [[IndexName:{DescID: 107, Name: t_i_key, IndexID: 2}, PUBLIC], ABSENT] -> PUBLIC
   ops:
-    *scop.MakePublicPrimaryIndexWriteOnly
-      IndexID: 1
-      TableID: 107
-    *scop.SetIndexName
-      IndexID: 1
-      Name: crdb_internal_index_1_name_placeholder
-      TableID: 107
-    *scop.SetIndexName
-      IndexID: 4
-      Name: t_pkey
-      TableID: 107
-    *scop.MakeValidatedPrimaryIndexPublic
-      IndexID: 4
-      TableID: 107
     *scop.MakeAbsentIndexBackfilling
       Index:
         ConstraintID: 2
@@ -2834,11 +2816,12 @@ PostCommitPhase stage 15 of 15 with 1 ValidationType op
     *scop.ValidateIndex
       IndexID: 2
       TableID: 107
-PostCommitNonRevertiblePhase stage 1 of 2 with 13 MutationType ops
+PostCommitNonRevertiblePhase stage 1 of 3 with 14 MutationType ops
   transitions:
-    [[IndexColumn:{DescID: 107, ColumnID: 1, IndexID: 1}, ABSENT], PUBLIC] -> ABSENT
-    [[IndexColumn:{DescID: 107, ColumnID: 2, IndexID: 1}, ABSENT], PUBLIC] -> ABSENT
-    [[PrimaryIndex:{DescID: 107, IndexID: 1, ConstraintID: 1}, ABSENT], VALIDATED] -> DELETE_ONLY
+    [[PrimaryIndex:{DescID: 107, IndexID: 1, ConstraintID: 1}, ABSENT], PUBLIC] -> VALIDATED
+    [[IndexName:{DescID: 107, Name: t_pkey, IndexID: 1}, ABSENT], PUBLIC] -> ABSENT
+    [[PrimaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1}, PUBLIC], VALIDATED] -> PUBLIC
+    [[IndexName:{DescID: 107, Name: t_pkey, IndexID: 4}, PUBLIC], ABSENT] -> PUBLIC
     [[TemporaryIndex:{DescID: 107, IndexID: 5, ConstraintID: 5, SourceIndexID: 1}, TRANSIENT_ABSENT], TRANSIENT_DELETE_ONLY] -> TRANSIENT_ABSENT
     [[IndexColumn:{DescID: 107, ColumnID: 1, IndexID: 5}, TRANSIENT_ABSENT], PUBLIC] -> TRANSIENT_ABSENT
     [[IndexColumn:{DescID: 107, ColumnID: 2, IndexID: 5}, TRANSIENT_ABSENT], PUBLIC] -> TRANSIENT_ABSENT
@@ -2847,6 +2830,17 @@ PostCommitNonRevertiblePhase stage 1 of 2 with 13 MutationType ops
     [[IndexColumn:{DescID: 107, ColumnID: 1, IndexID: 3}, TRANSIENT_ABSENT], PUBLIC] -> TRANSIENT_ABSENT
     [[IndexColumn:{DescID: 107, ColumnID: 2, IndexID: 3}, TRANSIENT_ABSENT], PUBLIC] -> TRANSIENT_ABSENT
   ops:
+    *scop.MakePublicPrimaryIndexWriteOnly
+      IndexID: 1
+      TableID: 107
+    *scop.SetIndexName
+      IndexID: 1
+      Name: crdb_internal_index_1_name_placeholder
+      TableID: 107
+    *scop.SetIndexName
+      IndexID: 4
+      Name: t_pkey
+      TableID: 107
     *scop.RemoveColumnFromIndex
       ColumnID: 1
       IndexID: 5
@@ -2870,14 +2864,28 @@ PostCommitNonRevertiblePhase stage 1 of 2 with 13 MutationType ops
       IndexID: 3
       Kind: 1
       TableID: 107
-    *scop.MakeWriteOnlyIndexDeleteOnly
-      IndexID: 1
+    *scop.MakeValidatedPrimaryIndexPublic
+      IndexID: 4
       TableID: 107
     *scop.MakeIndexAbsent
       IndexID: 5
       TableID: 107
     *scop.MakeIndexAbsent
       IndexID: 3
+      TableID: 107
+    *scop.SetJobStateOnDescriptor
+      DescriptorID: 107
+    *scop.UpdateSchemaChangerJob
+      IsNonCancelable: true
+      JobID: 1
+PostCommitNonRevertiblePhase stage 2 of 3 with 5 MutationType ops
+  transitions:
+    [[IndexColumn:{DescID: 107, ColumnID: 1, IndexID: 1}, ABSENT], PUBLIC] -> ABSENT
+    [[IndexColumn:{DescID: 107, ColumnID: 2, IndexID: 1}, ABSENT], PUBLIC] -> ABSENT
+    [[PrimaryIndex:{DescID: 107, IndexID: 1, ConstraintID: 1}, ABSENT], VALIDATED] -> DELETE_ONLY
+  ops:
+    *scop.MakeWriteOnlyIndexDeleteOnly
+      IndexID: 1
       TableID: 107
     *scop.RemoveColumnFromIndex
       ColumnID: 1
@@ -2893,7 +2901,7 @@ PostCommitNonRevertiblePhase stage 1 of 2 with 13 MutationType ops
     *scop.UpdateSchemaChangerJob
       IsNonCancelable: true
       JobID: 1
-PostCommitNonRevertiblePhase stage 2 of 2 with 6 MutationType ops
+PostCommitNonRevertiblePhase stage 3 of 3 with 6 MutationType ops
   transitions:
     [[PrimaryIndex:{DescID: 107, IndexID: 1, ConstraintID: 1}, ABSENT], DELETE_ONLY] -> ABSENT
     [[IndexData:{DescID: 107, IndexID: 1}, ABSENT], PUBLIC] -> ABSENT
@@ -3197,12 +3205,8 @@ PostCommitPhase stage 7 of 15 with 1 ValidationType op
     *scop.ValidateIndex
       IndexID: 4
       TableID: 108
-PostCommitPhase stage 8 of 15 with 15 MutationType ops
+PostCommitPhase stage 8 of 15 with 11 MutationType ops
   transitions:
-    [[PrimaryIndex:{DescID: 108, IndexID: 1, ConstraintID: 1}, ABSENT], PUBLIC] -> VALIDATED
-    [[IndexName:{DescID: 108, Name: baz_pkey, IndexID: 1}, ABSENT], PUBLIC] -> ABSENT
-    [[PrimaryIndex:{DescID: 108, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1}, PUBLIC], VALIDATED] -> PUBLIC
-    [[IndexName:{DescID: 108, Name: baz_pkey, IndexID: 4}, PUBLIC], ABSENT] -> PUBLIC
     [[IndexColumn:{DescID: 108, ColumnID: 2, IndexID: 2}, PUBLIC], ABSENT] -> PUBLIC
     [[IndexColumn:{DescID: 108, ColumnID: 1, IndexID: 2}, PUBLIC], ABSENT] -> PUBLIC
     [[SecondaryIndex:{DescID: 108, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 4, RecreateSourceIndexID: 0}, PUBLIC], ABSENT] -> BACKFILL_ONLY
@@ -3212,20 +3216,6 @@ PostCommitPhase stage 8 of 15 with 15 MutationType ops
     [[IndexColumn:{DescID: 108, ColumnID: 1, IndexID: 3}, TRANSIENT_ABSENT], ABSENT] -> PUBLIC
     [[TemporaryIndex:{DescID: 108, IndexID: 3, ConstraintID: 3, SourceIndexID: 4}, TRANSIENT_ABSENT], ABSENT] -> DELETE_ONLY
   ops:
-    *scop.MakePublicPrimaryIndexWriteOnly
-      IndexID: 1
-      TableID: 108
-    *scop.SetIndexName
-      IndexID: 1
-      Name: crdb_internal_index_1_name_placeholder
-      TableID: 108
-    *scop.SetIndexName
-      IndexID: 4
-      Name: baz_pkey
-      TableID: 108
-    *scop.MakeValidatedPrimaryIndexPublic
-      IndexID: 4
-      TableID: 108
     *scop.MakeAbsentIndexBackfilling
       Index:
         ConstraintID: 2
@@ -3347,11 +3337,13 @@ PostCommitPhase stage 15 of 15 with 1 ValidationType op
     *scop.ValidateIndex
       IndexID: 2
       TableID: 108
-PostCommitNonRevertiblePhase stage 1 of 2 with 14 MutationType ops
+PostCommitNonRevertiblePhase stage 1 of 3 with 16 MutationType ops
   transitions:
-    [[IndexColumn:{DescID: 108, ColumnID: 1, IndexID: 1}, ABSENT], PUBLIC] -> ABSENT
-    [[PrimaryIndex:{DescID: 108, IndexID: 1, ConstraintID: 1}, ABSENT], VALIDATED] -> DELETE_ONLY
+    [[PrimaryIndex:{DescID: 108, IndexID: 1, ConstraintID: 1}, ABSENT], PUBLIC] -> VALIDATED
+    [[IndexName:{DescID: 108, Name: baz_pkey, IndexID: 1}, ABSENT], PUBLIC] -> ABSENT
     [[Column:{DescID: 108, ColumnID: 2}, PUBLIC], WRITE_ONLY] -> PUBLIC
+    [[PrimaryIndex:{DescID: 108, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1}, PUBLIC], VALIDATED] -> PUBLIC
+    [[IndexName:{DescID: 108, Name: baz_pkey, IndexID: 4}, PUBLIC], ABSENT] -> PUBLIC
     [[TemporaryIndex:{DescID: 108, IndexID: 5, ConstraintID: 5, SourceIndexID: 1}, TRANSIENT_ABSENT], TRANSIENT_DELETE_ONLY] -> TRANSIENT_ABSENT
     [[IndexColumn:{DescID: 108, ColumnID: 1, IndexID: 5}, TRANSIENT_ABSENT], PUBLIC] -> TRANSIENT_ABSENT
     [[IndexColumn:{DescID: 108, ColumnID: 2, IndexID: 5}, TRANSIENT_ABSENT], PUBLIC] -> TRANSIENT_ABSENT
@@ -3360,10 +3352,16 @@ PostCommitNonRevertiblePhase stage 1 of 2 with 14 MutationType ops
     [[IndexColumn:{DescID: 108, ColumnID: 1, IndexID: 3}, TRANSIENT_ABSENT], PUBLIC] -> TRANSIENT_ABSENT
     [[TemporaryIndex:{DescID: 108, IndexID: 3, ConstraintID: 3, SourceIndexID: 4}, TRANSIENT_ABSENT], TRANSIENT_DELETE_ONLY] -> TRANSIENT_ABSENT
   ops:
-    *scop.MakeWriteOnlyColumnPublic
-      ColumnID: 2
+    *scop.MakePublicPrimaryIndexWriteOnly
+      IndexID: 1
       TableID: 108
-    *scop.RefreshStats
+    *scop.SetIndexName
+      IndexID: 1
+      Name: crdb_internal_index_1_name_placeholder
+      TableID: 108
+    *scop.SetIndexName
+      IndexID: 4
+      Name: baz_pkey
       TableID: 108
     *scop.RemoveColumnFromIndex
       ColumnID: 1
@@ -3391,11 +3389,29 @@ PostCommitNonRevertiblePhase stage 1 of 2 with 14 MutationType ops
     *scop.MakeIndexAbsent
       IndexID: 3
       TableID: 108
-    *scop.MakeWriteOnlyIndexDeleteOnly
-      IndexID: 1
+    *scop.MakeValidatedPrimaryIndexPublic
+      IndexID: 4
       TableID: 108
     *scop.MakeIndexAbsent
       IndexID: 5
+      TableID: 108
+    *scop.MakeWriteOnlyColumnPublic
+      ColumnID: 2
+      TableID: 108
+    *scop.RefreshStats
+      TableID: 108
+    *scop.SetJobStateOnDescriptor
+      DescriptorID: 108
+    *scop.UpdateSchemaChangerJob
+      IsNonCancelable: true
+      JobID: 1
+PostCommitNonRevertiblePhase stage 2 of 3 with 4 MutationType ops
+  transitions:
+    [[IndexColumn:{DescID: 108, ColumnID: 1, IndexID: 1}, ABSENT], PUBLIC] -> ABSENT
+    [[PrimaryIndex:{DescID: 108, IndexID: 1, ConstraintID: 1}, ABSENT], VALIDATED] -> DELETE_ONLY
+  ops:
+    *scop.MakeWriteOnlyIndexDeleteOnly
+      IndexID: 1
       TableID: 108
     *scop.RemoveColumnFromIndex
       ColumnID: 1
@@ -3406,7 +3422,7 @@ PostCommitNonRevertiblePhase stage 1 of 2 with 14 MutationType ops
     *scop.UpdateSchemaChangerJob
       IsNonCancelable: true
       JobID: 1
-PostCommitNonRevertiblePhase stage 2 of 2 with 6 MutationType ops
+PostCommitNonRevertiblePhase stage 3 of 3 with 6 MutationType ops
   transitions:
     [[PrimaryIndex:{DescID: 108, IndexID: 1, ConstraintID: 1}, ABSENT], DELETE_ONLY] -> ABSENT
     [[IndexData:{DescID: 108, IndexID: 1}, ABSENT], PUBLIC] -> ABSENT
@@ -3711,18 +3727,18 @@ ALTER TABLE defaultdb.baz ADD g INT UNIQUE DEFAULT 1
   to:   [Column:{DescID: 108, ColumnID: 2}, PUBLIC]
   kind: Precedence
   rule: swapped primary index public before column
-- from: [PrimaryIndex:{DescID: 108, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1}, PUBLIC]
-  to:   [SecondaryIndex:{DescID: 108, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 4, RecreateSourceIndexID: 0}, BACKFILL_ONLY]
-  kind: Precedence
-  rule: primary index with new columns should exist before secondary indexes
-- from: [PrimaryIndex:{DescID: 108, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1}, PUBLIC]
-  to:   [TemporaryIndex:{DescID: 108, IndexID: 3, ConstraintID: 3, SourceIndexID: 4}, DELETE_ONLY]
-  kind: Precedence
-  rule: primary index with new columns should exist before temp indexes
 - from: [PrimaryIndex:{DescID: 108, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1}, VALIDATED]
   to:   [PrimaryIndex:{DescID: 108, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1}, PUBLIC]
   kind: PreviousTransactionPrecedence
   rule: PrimaryIndex transitions to PUBLIC uphold 2-version invariant: VALIDATED->PUBLIC
+- from: [PrimaryIndex:{DescID: 108, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1}, VALIDATED]
+  to:   [SecondaryIndex:{DescID: 108, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 4, RecreateSourceIndexID: 0}, BACKFILL_ONLY]
+  kind: Precedence
+  rule: primary index with new columns should validated before secondary indexes
+- from: [PrimaryIndex:{DescID: 108, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1}, VALIDATED]
+  to:   [TemporaryIndex:{DescID: 108, IndexID: 3, ConstraintID: 3, SourceIndexID: 4}, DELETE_ONLY]
+  kind: Precedence
+  rule: primary index with new columns should exist before temp indexes
 - from: [PrimaryIndex:{DescID: 108, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1}, WRITE_ONLY]
   to:   [PrimaryIndex:{DescID: 108, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1}, VALIDATED]
   kind: PreviousTransactionPrecedence
@@ -3771,6 +3787,10 @@ ALTER TABLE defaultdb.baz ADD g INT UNIQUE DEFAULT 1
   to:   [SecondaryIndex:{DescID: 108, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 4, RecreateSourceIndexID: 0}, MERGED]
   kind: PreviousTransactionPrecedence
   rule: SecondaryIndex transitions to PUBLIC uphold 2-version invariant: MERGE_ONLY->MERGED
+- from: [SecondaryIndex:{DescID: 108, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 4, RecreateSourceIndexID: 0}, VALIDATED]
+  to:   [PrimaryIndex:{DescID: 108, IndexID: 4, ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1}, PUBLIC]
+  kind: Precedence
+  rule: secondary indexes should be in a validated state before primary indexes can go public
 - from: [SecondaryIndex:{DescID: 108, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 4, RecreateSourceIndexID: 0}, VALIDATED]
   to:   [SecondaryIndex:{DescID: 108, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 4, RecreateSourceIndexID: 0}, PUBLIC]
   kind: PreviousTransactionPrecedence

--- a/pkg/sql/schemachanger/scplan/testdata/alter_table_alter_column_type
+++ b/pkg/sql/schemachanger/scplan/testdata/alter_table_alter_column_type
@@ -529,9 +529,6 @@ PostCommitPhase stage 8 of 15 with 10 MutationType ops
       IndexID: 2
       Name: act_pkey
       TableID: 104
-    *scop.MakeValidatedPrimaryIndexPublic
-      IndexID: 2
-      TableID: 104
     *scop.MakeAbsentTempIndexDeleteOnly
       Index:
         ConstraintID: 5
@@ -550,6 +547,9 @@ PostCommitPhase stage 8 of 15 with 10 MutationType ops
       ColumnID: 3
       IndexID: 5
       Kind: 2
+      TableID: 104
+    *scop.MakeValidatedPrimaryIndexPublic
+      IndexID: 2
       TableID: 104
     *scop.SetJobStateOnDescriptor
       DescriptorID: 104

--- a/pkg/sql/schemachanger/scplan/testdata/alter_table_alter_primary_key
+++ b/pkg/sql/schemachanger/scplan/testdata/alter_table_alter_primary_key
@@ -305,9 +305,6 @@ PostCommitPhase stage 8 of 15 with 10 MutationType ops
       IndexID: 2
       Name: t_pkey
       TableID: 104
-    *scop.MakeValidatedPrimaryIndexPublic
-      IndexID: 2
-      TableID: 104
     *scop.MakeAbsentTempIndexDeleteOnly
       Index:
         ConstraintID: 5
@@ -326,6 +323,9 @@ PostCommitPhase stage 8 of 15 with 10 MutationType ops
       ColumnID: 2
       IndexID: 5
       Kind: 2
+      TableID: 104
+    *scop.MakeValidatedPrimaryIndexPublic
+      IndexID: 2
       TableID: 104
     *scop.SetJobStateOnDescriptor
       DescriptorID: 104
@@ -927,10 +927,6 @@ ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (k);
   to:   [PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}, TRANSIENT_VALIDATED]
   kind: PreviousTransactionPrecedence
   rule: PrimaryIndex transitions to TRANSIENT_ABSENT uphold 2-version invariant: PUBLIC->TRANSIENT_VALIDATED
-- from: [PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}, PUBLIC]
-  to:   [TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}, DELETE_ONLY]
-  kind: Precedence
-  rule: primary index with new columns should exist before temp indexes
 - from: [PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}, TRANSIENT_ABSENT]
   to:   [Column:{DescID: 104, ColumnID: 3}, ABSENT]
   kind: Precedence
@@ -971,6 +967,10 @@ ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (k);
   to:   [PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}, PUBLIC]
   kind: PreviousTransactionPrecedence
   rule: PrimaryIndex transitions to TRANSIENT_ABSENT uphold 2-version invariant: VALIDATED->PUBLIC
+- from: [PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}, VALIDATED]
+  to:   [TemporaryIndex:{DescID: 104, IndexID: 5, ConstraintID: 5, SourceIndexID: 2}, DELETE_ONLY]
+  kind: Precedence
+  rule: primary index with new columns should exist before temp indexes
 - from: [PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}, WRITE_ONLY]
   to:   [PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}, VALIDATED]
   kind: PreviousTransactionPrecedence

--- a/pkg/sql/schemachanger/sctest_generated_test.go
+++ b/pkg/sql/schemachanger/sctest_generated_test.go
@@ -295,6 +295,13 @@ func TestEndToEndSideEffects_alter_table_alter_primary_key_drop_rowid(t *testing
 	sctest.EndToEndSideEffects(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestEndToEndSideEffects_alter_table_alter_primary_key_drop_rowid_with_idx(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx"
+	sctest.EndToEndSideEffects(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestEndToEndSideEffects_alter_table_alter_primary_key_using_hash(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -964,6 +971,13 @@ func TestExecuteWithDMLInjection_alter_table_alter_primary_key_drop_rowid(t *tes
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid"
+	sctest.ExecuteWithDMLInjection(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestExecuteWithDMLInjection_alter_table_alter_primary_key_drop_rowid_with_idx(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx"
 	sctest.ExecuteWithDMLInjection(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
@@ -1639,6 +1653,13 @@ func TestGenerateSchemaChangeCorpus_alter_table_alter_primary_key_drop_rowid(t *
 	sctest.GenerateSchemaChangeCorpus(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestGenerateSchemaChangeCorpus_alter_table_alter_primary_key_drop_rowid_with_idx(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx"
+	sctest.GenerateSchemaChangeCorpus(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestGenerateSchemaChangeCorpus_alter_table_alter_primary_key_using_hash(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -2308,6 +2329,13 @@ func TestPause_alter_table_alter_primary_key_drop_rowid(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid"
+	sctest.Pause(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestPause_alter_table_alter_primary_key_drop_rowid_with_idx(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx"
 	sctest.Pause(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
@@ -2983,6 +3011,13 @@ func TestPauseMixedVersion_alter_table_alter_primary_key_drop_rowid(t *testing.T
 	sctest.PauseMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestPauseMixedVersion_alter_table_alter_primary_key_drop_rowid_with_idx(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx"
+	sctest.PauseMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestPauseMixedVersion_alter_table_alter_primary_key_using_hash(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -3652,6 +3687,13 @@ func TestRollback_alter_table_alter_primary_key_drop_rowid(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid"
+	sctest.Rollback(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestRollback_alter_table_alter_primary_key_drop_rowid_with_idx(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx"
 	sctest.Rollback(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_default_unique/add_column_default_unique.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_default_unique/add_column_default_unique.explain
@@ -130,26 +130,17 @@ Schema change plan for ALTER TABLE ‹db›.‹public›.‹tbl› ADD COLUMN �
  │    │    └── 1 Validation operation
  │    │         └── ValidateIndex {"IndexID":4,"TableID":106}
  │    ├── Stage 8 of 15 in PostCommitPhase
- │    │    ├── 7 elements transitioning toward PUBLIC
- │    │    │    ├── VALIDATED → PUBLIC        PrimaryIndex:{DescID: 106 (tbl), IndexID: 4 (tbl_pkey+), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1 (tbl_pkey-)}
- │    │    │    ├── ABSENT    → PUBLIC        IndexName:{DescID: 106 (tbl), Name: "tbl_pkey", IndexID: 4 (tbl_pkey+)}
- │    │    │    ├── ABSENT    → PUBLIC        IndexColumn:{DescID: 106 (tbl), ColumnID: 2 (j+), IndexID: 2 (tbl_j_key+)}
- │    │    │    ├── ABSENT    → PUBLIC        IndexColumn:{DescID: 106 (tbl), ColumnID: 1 (i), IndexID: 2 (tbl_j_key+)}
- │    │    │    ├── ABSENT    → BACKFILL_ONLY SecondaryIndex:{DescID: 106 (tbl), IndexID: 2 (tbl_j_key+), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 4 (tbl_pkey+), RecreateSourceIndexID: 0}
- │    │    │    ├── ABSENT    → PUBLIC        IndexData:{DescID: 106 (tbl), IndexID: 2 (tbl_j_key+)}
- │    │    │    └── ABSENT    → PUBLIC        IndexName:{DescID: 106 (tbl), Name: "tbl_j_key", IndexID: 2 (tbl_j_key+)}
+ │    │    ├── 5 elements transitioning toward PUBLIC
+ │    │    │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 106 (tbl), ColumnID: 2 (j+), IndexID: 2 (tbl_j_key+)}
+ │    │    │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 106 (tbl), ColumnID: 1 (i), IndexID: 2 (tbl_j_key+)}
+ │    │    │    ├── ABSENT → BACKFILL_ONLY SecondaryIndex:{DescID: 106 (tbl), IndexID: 2 (tbl_j_key+), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 4 (tbl_pkey+), RecreateSourceIndexID: 0}
+ │    │    │    ├── ABSENT → PUBLIC        IndexData:{DescID: 106 (tbl), IndexID: 2 (tbl_j_key+)}
+ │    │    │    └── ABSENT → PUBLIC        IndexName:{DescID: 106 (tbl), Name: "tbl_j_key", IndexID: 2 (tbl_j_key+)}
  │    │    ├── 3 elements transitioning toward TRANSIENT_ABSENT
- │    │    │    ├── ABSENT    → PUBLIC        IndexColumn:{DescID: 106 (tbl), ColumnID: 2 (j+), IndexID: 3}
- │    │    │    ├── ABSENT    → PUBLIC        IndexColumn:{DescID: 106 (tbl), ColumnID: 1 (i), IndexID: 3}
- │    │    │    └── ABSENT    → DELETE_ONLY   TemporaryIndex:{DescID: 106 (tbl), IndexID: 3, ConstraintID: 3, SourceIndexID: 4 (tbl_pkey+)}
- │    │    ├── 2 elements transitioning toward ABSENT
- │    │    │    ├── PUBLIC    → VALIDATED     PrimaryIndex:{DescID: 106 (tbl), IndexID: 1 (tbl_pkey-), ConstraintID: 1}
- │    │    │    └── PUBLIC    → ABSENT        IndexName:{DescID: 106 (tbl), Name: "tbl_pkey", IndexID: 1 (tbl_pkey-)}
- │    │    └── 15 Mutation operations
- │    │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":1,"TableID":106}
- │    │         ├── SetIndexName {"IndexID":1,"Name":"crdb_internal_in...","TableID":106}
- │    │         ├── SetIndexName {"IndexID":4,"Name":"tbl_pkey","TableID":106}
- │    │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":4,"TableID":106}
+ │    │    │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 106 (tbl), ColumnID: 2 (j+), IndexID: 3}
+ │    │    │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 106 (tbl), ColumnID: 1 (i), IndexID: 3}
+ │    │    │    └── ABSENT → DELETE_ONLY   TemporaryIndex:{DescID: 106 (tbl), IndexID: 3, ConstraintID: 3, SourceIndexID: 4 (tbl_pkey+)}
+ │    │    └── 11 Mutation operations
  │    │         ├── MakeAbsentIndexBackfilling {"IsSecondaryIndex":true}
  │    │         ├── MaybeAddSplitForIndex {"IndexID":2,"TableID":106}
  │    │         ├── SetIndexName {"IndexID":2,"Name":"tbl_j_key","TableID":106}
@@ -209,9 +200,11 @@ Schema change plan for ALTER TABLE ‹db›.‹public›.‹tbl› ADD COLUMN �
  │         └── 1 Validation operation
  │              └── ValidateIndex {"IndexID":2,"TableID":106}
  └── PostCommitNonRevertiblePhase
-      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
-      │    ├── 2 elements transitioning toward PUBLIC
+      ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 4 elements transitioning toward PUBLIC
       │    │    ├── WRITE_ONLY            → PUBLIC           Column:{DescID: 106 (tbl), ColumnID: 2 (j+)}
+      │    │    ├── VALIDATED             → PUBLIC           PrimaryIndex:{DescID: 106 (tbl), IndexID: 4 (tbl_pkey+), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1 (tbl_pkey-)}
+      │    │    ├── ABSENT                → PUBLIC           IndexName:{DescID: 106 (tbl), Name: "tbl_pkey", IndexID: 4 (tbl_pkey+)}
       │    │    └── VALIDATED             → PUBLIC           SecondaryIndex:{DescID: 106 (tbl), IndexID: 2 (tbl_j_key+), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 4 (tbl_pkey+), RecreateSourceIndexID: 0}
       │    ├── 6 elements transitioning toward TRANSIENT_ABSENT
       │    │    ├── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT TemporaryIndex:{DescID: 106 (tbl), IndexID: 5, ConstraintID: 5, SourceIndexID: 1 (tbl_pkey-)}
@@ -221,11 +214,12 @@ Schema change plan for ALTER TABLE ‹db›.‹public›.‹tbl› ADD COLUMN �
       │    │    ├── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 106 (tbl), ColumnID: 1 (i), IndexID: 3}
       │    │    └── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT TemporaryIndex:{DescID: 106 (tbl), IndexID: 3, ConstraintID: 3, SourceIndexID: 4 (tbl_pkey+)}
       │    ├── 2 elements transitioning toward ABSENT
-      │    │    ├── PUBLIC                → ABSENT           IndexColumn:{DescID: 106 (tbl), ColumnID: 1 (i), IndexID: 1 (tbl_pkey-)}
-      │    │    └── VALIDATED             → DELETE_ONLY      PrimaryIndex:{DescID: 106 (tbl), IndexID: 1 (tbl_pkey-), ConstraintID: 1}
-      │    └── 14 Mutation operations
-      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":2,"TableID":106}
-      │         ├── RefreshStats {"TableID":106}
+      │    │    ├── PUBLIC                → VALIDATED        PrimaryIndex:{DescID: 106 (tbl), IndexID: 1 (tbl_pkey-), ConstraintID: 1}
+      │    │    └── PUBLIC                → ABSENT           IndexName:{DescID: 106 (tbl), Name: "tbl_pkey", IndexID: 1 (tbl_pkey-)}
+      │    └── 16 Mutation operations
+      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":1,"TableID":106}
+      │         ├── SetIndexName {"IndexID":1,"Name":"crdb_internal_in...","TableID":106}
+      │         ├── SetIndexName {"IndexID":4,"Name":"tbl_pkey","TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"Kind":2,"TableID":106}
       │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":2,"TableID":106}
@@ -233,12 +227,22 @@ Schema change plan for ALTER TABLE ‹db›.‹public›.‹tbl› ADD COLUMN �
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"Kind":1,"TableID":106}
       │         ├── MakeIndexAbsent {"IndexID":3,"TableID":106}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":1,"TableID":106}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":4,"TableID":106}
       │         ├── MakeIndexAbsent {"IndexID":5,"TableID":106}
+      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":2,"TableID":106}
+      │         ├── RefreshStats {"TableID":106}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":106}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 2 elements transitioning toward ABSENT
+      │    │    ├── PUBLIC    → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 1 (i), IndexID: 1 (tbl_pkey-)}
+      │    │    └── VALIDATED → DELETE_ONLY PrimaryIndex:{DescID: 106 (tbl), IndexID: 1 (tbl_pkey-), ConstraintID: 1}
+      │    └── 4 Mutation operations
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":1,"TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":1,"TableID":106}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":106}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
-      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+      └── Stage 3 of 3 in PostCommitNonRevertiblePhase
            ├── 2 elements transitioning toward TRANSIENT_ABSENT
            │    ├── PUBLIC      → TRANSIENT_ABSENT IndexData:{DescID: 106 (tbl), IndexID: 5}
            │    └── PUBLIC      → TRANSIENT_ABSENT IndexData:{DescID: 106 (tbl), IndexID: 3}

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_default_unique/add_column_default_unique.explain_shape
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_default_unique/add_column_default_unique.explain_shape
@@ -22,4 +22,4 @@ Schema change plan for ALTER TABLE ‹db›.‹public›.‹tbl› ADD COLUMN �
  │    └── from tbl@[3] into tbl_j_key+
  ├── execute 1 system table mutations transaction
  ├── validate UNIQUE constraint backed by index tbl_j_key+ in relation tbl
- └── execute 2 system table mutations transactions
+ └── execute 3 system table mutations transactions

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_default_unique/add_column_default_unique.side_effects
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_default_unique/add_column_default_unique.side_effects
@@ -365,66 +365,11 @@ begin transaction #9
 validate forward indexes [4] in table #106
 commit transaction #9
 begin transaction #10
-## PostCommitPhase stage 8 of 15 with 15 MutationType ops
+## PostCommitPhase stage 8 of 15 with 11 MutationType ops
 upsert descriptor #106
   ...
        mutationId: 1
-       state: WRITE_ONLY
-  -  - direction: ADD
-  +  - direction: DROP
-       index:
-  -      constraintId: 4
-  +      constraintId: 5
-         createdExplicitly: true
-         encodingType: 1
-         foreignKey: {}
-         geoConfig: {}
-  -      id: 4
-  +      id: 5
-         interleave: {}
-         keyColumnDirections:
-  ...
-         keyColumnNames:
-         - i
-  -      name: crdb_internal_index_4_name_placeholder
-  +      name: crdb_internal_index_5_name_placeholder
-         partitioning: {}
-         sharded: {}
-  ...
-         - j
-         unique: true
-  +      useDeletePreservingEncoding: true
-         vecConfig: {}
-         version: 4
-       mutationId: 1
-  -    state: WRITE_ONLY
-  +    state: DELETE_ONLY
-     - direction: DROP
-       index:
-  -      constraintId: 5
-  -      createdExplicitly: true
-  +      constraintId: 1
-  +      createdAtNanos: "1640995200000000000"
-         encodingType: 1
-         foreignKey: {}
-         geoConfig: {}
-  -      id: 5
-  +      id: 1
-         interleave: {}
-         keyColumnDirections:
-  ...
-         keyColumnNames:
-         - i
-  -      name: crdb_internal_index_5_name_placeholder
-  +      name: crdb_internal_index_1_name_placeholder
-         partitioning: {}
-         sharded: {}
-  -      storeColumnIds:
-  +      unique: true
-  +      vecConfig: {}
-  +      version: 4
-  +    mutationId: 1
-  +    state: WRITE_ONLY
+       state: DELETE_ONLY
   +  - direction: ADD
   +    index:
   +      constraintId: 2
@@ -437,17 +382,16 @@ upsert descriptor #106
   +      keyColumnDirections:
   +      - ASC
   +      keyColumnIds:
-         - 2
-  -      storeColumnNames:
+  +      - 2
   +      keyColumnNames:
-         - j
+  +      - j
   +      keySuffixColumnIds:
   +      - 1
   +      name: tbl_j_key
   +      partitioning: {}
   +      sharded: {}
   +      storeColumnNames: []
-         unique: true
+  +      unique: true
   +      vecConfig: {}
   +      version: 4
   +    mutationId: 1
@@ -473,31 +417,13 @@ upsert descriptor #106
   +      sharded: {}
   +      storeColumnNames: []
   +      unique: true
-         useDeletePreservingEncoding: true
-         vecConfig: {}
-  ...
-     parentId: 104
-     primaryIndex:
-  -    constraintId: 1
-  -    createdAtNanos: "1640995200000000000"
-  +    constraintId: 4
-  +    createdExplicitly: true
-       encodingType: 1
-       foreignKey: {}
-       geoConfig: {}
-  -    id: 1
-  +    id: 4
-       interleave: {}
-       keyColumnDirections:
-  ...
-       partitioning: {}
-       sharded: {}
-  +    storeColumnIds:
-  +    - 2
-  +    storeColumnNames:
-  +    - j
-       unique: true
-       vecConfig: {}
+  +      useDeletePreservingEncoding: true
+  +      vecConfig: {}
+  +      version: 4
+  +    mutationId: 1
+  +    state: DELETE_ONLY
+     name: tbl
+     nextColumnId: 3
   ...
        time: {}
      unexposedParentSchemaId: 105
@@ -600,7 +526,7 @@ begin transaction #17
 validate forward indexes [2] in table #106
 commit transaction #17
 begin transaction #18
-## PostCommitNonRevertiblePhase stage 1 of 2 with 14 MutationType ops
+## PostCommitNonRevertiblePhase stage 1 of 3 with 16 MutationType ops
 upsert descriptor #106
   ...
          oid: 20
@@ -661,14 +587,14 @@ upsert descriptor #106
   -    direction: ADD
   -    mutationId: 1
   -    state: WRITE_ONLY
-     - direction: DROP
-       index:
-  -      constraintId: 5
+  -  - direction: ADD
+  -    index:
+  -      constraintId: 4
   -      createdExplicitly: true
   -      encodingType: 1
   -      foreignKey: {}
   -      geoConfig: {}
-  -      id: 5
+  -      id: 4
   -      interleave: {}
   -      keyColumnDirections:
   -      - ASC
@@ -676,7 +602,7 @@ upsert descriptor #106
   -      - 1
   -      keyColumnNames:
   -      - i
-  -      name: crdb_internal_index_5_name_placeholder
+  -      name: crdb_internal_index_4_name_placeholder
   -      partitioning: {}
   -      sharded: {}
   -      storeColumnIds:
@@ -684,19 +610,40 @@ upsert descriptor #106
   -      storeColumnNames:
   -      - j
   -      unique: true
-  -      useDeletePreservingEncoding: true
   -      vecConfig: {}
   -      version: 4
   -    mutationId: 1
-  -    state: DELETE_ONLY
-  -  - direction: DROP
-  -    index:
-         constraintId: 1
-         createdAtNanos: "1640995200000000000"
+  -    state: WRITE_ONLY
+     - direction: DROP
+       index:
+  -      constraintId: 5
+  -      createdExplicitly: true
+  +      constraintId: 1
+  +      createdAtNanos: "1640995200000000000"
+         encodingType: 1
+         foreignKey: {}
+         geoConfig: {}
+  -      id: 5
+  +      id: 1
+         interleave: {}
+         keyColumnDirections:
   ...
+         keyColumnNames:
+         - i
+  -      name: crdb_internal_index_5_name_placeholder
+  +      name: crdb_internal_index_1_name_placeholder
+         partitioning: {}
+         sharded: {}
+  -      storeColumnIds:
+  -      - 2
+  -      storeColumnNames:
+  -      - j
+         unique: true
+  -      useDeletePreservingEncoding: true
+         vecConfig: {}
          version: 4
        mutationId: 1
-  -    state: WRITE_ONLY
+  -    state: DELETE_ONLY
   -  - direction: ADD
   -    index:
   -      constraintId: 2
@@ -722,7 +669,7 @@ upsert descriptor #106
   -      vecConfig: {}
   -      version: 4
   -    mutationId: 1
-  -    state: WRITE_ONLY
+       state: WRITE_ONLY
   -  - direction: DROP
   -    index:
   -      constraintId: 3
@@ -748,8 +695,32 @@ upsert descriptor #106
   -      vecConfig: {}
   -      version: 4
   -    mutationId: 1
-       state: DELETE_ONLY
+  -    state: DELETE_ONLY
      name: tbl
+     nextColumnId: 3
+  ...
+     parentId: 104
+     primaryIndex:
+  -    constraintId: 1
+  -    createdAtNanos: "1640995200000000000"
+  +    constraintId: 4
+  +    createdExplicitly: true
+       encodingType: 1
+       foreignKey: {}
+       geoConfig: {}
+  -    id: 1
+  +    id: 4
+       interleave: {}
+       keyColumnDirections:
+  ...
+       partitioning: {}
+       sharded: {}
+  +    storeColumnIds:
+  +    - 2
+  +    storeColumnNames:
+  +    - j
+       unique: true
+       vecConfig: {}
   ...
        time: {}
      unexposedParentSchemaId: 105
@@ -757,11 +728,29 @@ upsert descriptor #106
   +  version: "12"
 persist all catalog changes to storage
 adding table for stats refresh: 106
-update progress of schema change job #1: "PostCommitNonRevertiblePhase stage 2 of 2 with 4 MutationType ops pending"
+update progress of schema change job #1: "PostCommitNonRevertiblePhase stage 2 of 3 with 2 MutationType ops pending"
 set schema change job #1 to non-cancellable
 commit transaction #18
 begin transaction #19
-## PostCommitNonRevertiblePhase stage 2 of 2 with 6 MutationType ops
+## PostCommitNonRevertiblePhase stage 2 of 3 with 4 MutationType ops
+upsert descriptor #106
+  ...
+         version: 4
+       mutationId: 1
+  -    state: WRITE_ONLY
+  +    state: DELETE_ONLY
+     name: tbl
+     nextColumnId: 3
+  ...
+       time: {}
+     unexposedParentSchemaId: 105
+  -  version: "12"
+  +  version: "13"
+persist all catalog changes to storage
+update progress of schema change job #1: "PostCommitNonRevertiblePhase stage 3 of 3 with 4 MutationType ops pending"
+commit transaction #19
+begin transaction #20
+## PostCommitNonRevertiblePhase stage 3 of 3 with 6 MutationType ops
 upsert descriptor #106
   ...
      createAsOfTime:
@@ -828,8 +817,8 @@ upsert descriptor #106
   ...
        time: {}
      unexposedParentSchemaId: 105
-  -  version: "12"
-  +  version: "13"
+  -  version: "13"
+  +  version: "14"
 persist all catalog changes to storage
 create job #2 (non-cancelable: true): "GC for ALTER TABLE db.public.tbl ADD COLUMN j INT8 UNIQUE DEFAULT CAST(date_part('year', now()) AS INT8)"
   descriptor IDs: [106]
@@ -839,6 +828,6 @@ updated schema change job #1 descriptor IDs to []
 write *eventpb.FinishSchemaChange to event log:
   sc:
     descriptorId: 106
-commit transaction #19
+commit transaction #20
 notified job registry to adopt jobs: [2]
 # end PostCommitPhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_default_unique/add_column_default_unique__rollback_10_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_default_unique/add_column_default_unique__rollback_10_of_15.explain
@@ -8,17 +8,15 @@ EXPLAIN (DDL) rollback at post-commit stage 10 of 15;
 ----
 Schema change plan for rolling back ALTER TABLE db.public.tbl ADD COLUMN j INT8 UNIQUE DEFAULT CAST(date_part(‹'year'›, now()) AS INT8);
  └── PostCommitNonRevertiblePhase
-      ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 2 elements transitioning toward PUBLIC
-      │    │    ├── VALIDATED             → PUBLIC      PrimaryIndex:{DescID: 106 (tbl), IndexID: 1 (tbl_pkey+), ConstraintID: 1}
-      │    │    └── ABSENT                → PUBLIC      IndexName:{DescID: 106 (tbl), Name: "tbl_pkey", IndexID: 1 (tbl_pkey+)}
-      │    ├── 14 elements transitioning toward ABSENT
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 15 elements transitioning toward ABSENT
       │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 106 (tbl), ColumnID: 2 (j-)}
       │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 106 (tbl), Name: "j", ColumnID: 2 (j-)}
-      │    │    ├── PUBLIC                → VALIDATED   PrimaryIndex:{DescID: 106 (tbl), IndexID: 4 (tbl_pkey-), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1 (tbl_pkey+)}
-      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 106 (tbl), Name: "tbl_pkey", IndexID: 4 (tbl_pkey-)}
+      │    │    ├── VALIDATED             → DELETE_ONLY PrimaryIndex:{DescID: 106 (tbl), IndexID: 4 (tbl_pkey-), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1 (tbl_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 1 (i), IndexID: 4 (tbl_pkey-)}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 106 (tbl), IndexID: 5, ConstraintID: 5, SourceIndexID: 1 (tbl_pkey+)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 1 (i), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 2 (j-), IndexID: 4 (tbl_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 2 (j-), IndexID: 5}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 2 (j-), IndexID: 2 (tbl_j_key-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 1 (i), IndexID: 2 (tbl_j_key-)}
@@ -27,18 +25,17 @@ Schema change plan for rolling back ALTER TABLE db.public.tbl ADD COLUMN j INT8 
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 2 (j-), IndexID: 3}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 1 (i), IndexID: 3}
       │    │    └── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 106 (tbl), IndexID: 3, ConstraintID: 3, SourceIndexID: 4 (tbl_pkey-)}
-      │    └── 18 Mutation operations
-      │         ├── SetIndexName {"IndexID":1,"Name":"tbl_pkey","TableID":106}
+      │    └── 17 Mutation operations
       │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":2,"TableID":106}
       │         ├── SetColumnName {"ColumnID":2,"Name":"crdb_internal_co...","TableID":106}
-      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":4,"TableID":106}
-      │         ├── SetIndexName {"IndexID":4,"Name":"crdb_internal_in...","TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"Kind":2,"TableID":106}
       │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":106}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":3,"TableID":106}
-      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":106}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":106}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":106}
       │         ├── MakeIndexAbsent {"IndexID":5,"TableID":106}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"Kind":2,"TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":2,"TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"Kind":1,"TableID":106}
       │         ├── MakeIndexAbsent {"IndexID":2,"TableID":106}
@@ -46,21 +43,8 @@ Schema change plan for rolling back ALTER TABLE db.public.tbl ADD COLUMN j INT8 
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"Kind":1,"TableID":106}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":106}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
-      ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 4 elements transitioning toward ABSENT
-      │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 106 (tbl), IndexID: 4 (tbl_pkey-), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1 (tbl_pkey+)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 1 (i), IndexID: 4 (tbl_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 2 (j-), IndexID: 4 (tbl_pkey-)}
-      │    │    └── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 106 (tbl), IndexID: 3, ConstraintID: 3, SourceIndexID: 4 (tbl_pkey-)}
-      │    └── 6 Mutation operations
-      │         ├── MakeIndexAbsent {"IndexID":3,"TableID":106}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":106}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":106}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"Kind":2,"TableID":106}
-      │         ├── SetJobStateOnDescriptor {"DescriptorID":106}
-      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
-      └── Stage 3 of 3 in PostCommitNonRevertiblePhase
-           ├── 8 elements transitioning toward ABSENT
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 9 elements transitioning toward ABSENT
            │    ├── DELETE_ONLY → ABSENT Column:{DescID: 106 (tbl), ColumnID: 2 (j-)}
            │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 106 (tbl), ColumnFamilyID: 0 (primary), ColumnID: 2 (j-), TypeName: "INT8"}
            │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 106 (tbl), ColumnID: 2 (j-), Expr: CAST(date_part('year':::STRING, now():::TIMESTAMPTZ) AS INT8)}
@@ -68,11 +52,13 @@ Schema change plan for rolling back ALTER TABLE db.public.tbl ADD COLUMN j INT8 
            │    ├── PUBLIC      → ABSENT IndexData:{DescID: 106 (tbl), IndexID: 4 (tbl_pkey-)}
            │    ├── PUBLIC      → ABSENT IndexData:{DescID: 106 (tbl), IndexID: 5}
            │    ├── PUBLIC      → ABSENT IndexData:{DescID: 106 (tbl), IndexID: 2 (tbl_j_key-)}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 106 (tbl), IndexID: 3, ConstraintID: 3, SourceIndexID: 4 (tbl_pkey-)}
            │    └── PUBLIC      → ABSENT IndexData:{DescID: 106 (tbl), IndexID: 3}
-           └── 9 Mutation operations
+           └── 10 Mutation operations
                 ├── RemoveColumnDefaultExpression {"ColumnID":2,"TableID":106}
                 ├── MakeIndexAbsent {"IndexID":4,"TableID":106}
                 ├── CreateGCJobForIndex {"IndexID":2,"TableID":106}
+                ├── MakeIndexAbsent {"IndexID":3,"TableID":106}
                 ├── CreateGCJobForIndex {"IndexID":3,"TableID":106}
                 ├── CreateGCJobForIndex {"IndexID":4,"TableID":106}
                 ├── CreateGCJobForIndex {"IndexID":5,"TableID":106}

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_default_unique/add_column_default_unique__rollback_11_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_default_unique/add_column_default_unique__rollback_11_of_15.explain
@@ -8,17 +8,15 @@ EXPLAIN (DDL) rollback at post-commit stage 11 of 15;
 ----
 Schema change plan for rolling back ALTER TABLE db.public.tbl ADD COLUMN j INT8 UNIQUE DEFAULT CAST(date_part(‹'year'›, now()) AS INT8);
  └── PostCommitNonRevertiblePhase
-      ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 2 elements transitioning toward PUBLIC
-      │    │    ├── VALIDATED             → PUBLIC      PrimaryIndex:{DescID: 106 (tbl), IndexID: 1 (tbl_pkey+), ConstraintID: 1}
-      │    │    └── ABSENT                → PUBLIC      IndexName:{DescID: 106 (tbl), Name: "tbl_pkey", IndexID: 1 (tbl_pkey+)}
-      │    ├── 14 elements transitioning toward ABSENT
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 15 elements transitioning toward ABSENT
       │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 106 (tbl), ColumnID: 2 (j-)}
       │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 106 (tbl), Name: "j", ColumnID: 2 (j-)}
-      │    │    ├── PUBLIC                → VALIDATED   PrimaryIndex:{DescID: 106 (tbl), IndexID: 4 (tbl_pkey-), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1 (tbl_pkey+)}
-      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 106 (tbl), Name: "tbl_pkey", IndexID: 4 (tbl_pkey-)}
+      │    │    ├── VALIDATED             → DELETE_ONLY PrimaryIndex:{DescID: 106 (tbl), IndexID: 4 (tbl_pkey-), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1 (tbl_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 1 (i), IndexID: 4 (tbl_pkey-)}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 106 (tbl), IndexID: 5, ConstraintID: 5, SourceIndexID: 1 (tbl_pkey+)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 1 (i), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 2 (j-), IndexID: 4 (tbl_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 2 (j-), IndexID: 5}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 2 (j-), IndexID: 2 (tbl_j_key-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 1 (i), IndexID: 2 (tbl_j_key-)}
@@ -27,18 +25,17 @@ Schema change plan for rolling back ALTER TABLE db.public.tbl ADD COLUMN j INT8 
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 2 (j-), IndexID: 3}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 1 (i), IndexID: 3}
       │    │    └── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 106 (tbl), IndexID: 3, ConstraintID: 3, SourceIndexID: 4 (tbl_pkey-)}
-      │    └── 18 Mutation operations
-      │         ├── SetIndexName {"IndexID":1,"Name":"tbl_pkey","TableID":106}
+      │    └── 17 Mutation operations
       │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":2,"TableID":106}
       │         ├── SetColumnName {"ColumnID":2,"Name":"crdb_internal_co...","TableID":106}
-      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":4,"TableID":106}
-      │         ├── SetIndexName {"IndexID":4,"Name":"crdb_internal_in...","TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"Kind":2,"TableID":106}
       │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":106}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":3,"TableID":106}
-      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":106}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":106}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":106}
       │         ├── MakeIndexAbsent {"IndexID":5,"TableID":106}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"Kind":2,"TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":2,"TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"Kind":1,"TableID":106}
       │         ├── MakeIndexAbsent {"IndexID":2,"TableID":106}
@@ -46,21 +43,8 @@ Schema change plan for rolling back ALTER TABLE db.public.tbl ADD COLUMN j INT8 
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"Kind":1,"TableID":106}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":106}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
-      ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 4 elements transitioning toward ABSENT
-      │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 106 (tbl), IndexID: 4 (tbl_pkey-), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1 (tbl_pkey+)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 1 (i), IndexID: 4 (tbl_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 2 (j-), IndexID: 4 (tbl_pkey-)}
-      │    │    └── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 106 (tbl), IndexID: 3, ConstraintID: 3, SourceIndexID: 4 (tbl_pkey-)}
-      │    └── 6 Mutation operations
-      │         ├── MakeIndexAbsent {"IndexID":3,"TableID":106}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":106}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":106}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"Kind":2,"TableID":106}
-      │         ├── SetJobStateOnDescriptor {"DescriptorID":106}
-      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
-      └── Stage 3 of 3 in PostCommitNonRevertiblePhase
-           ├── 8 elements transitioning toward ABSENT
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 9 elements transitioning toward ABSENT
            │    ├── DELETE_ONLY → ABSENT Column:{DescID: 106 (tbl), ColumnID: 2 (j-)}
            │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 106 (tbl), ColumnFamilyID: 0 (primary), ColumnID: 2 (j-), TypeName: "INT8"}
            │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 106 (tbl), ColumnID: 2 (j-), Expr: CAST(date_part('year':::STRING, now():::TIMESTAMPTZ) AS INT8)}
@@ -68,11 +52,13 @@ Schema change plan for rolling back ALTER TABLE db.public.tbl ADD COLUMN j INT8 
            │    ├── PUBLIC      → ABSENT IndexData:{DescID: 106 (tbl), IndexID: 4 (tbl_pkey-)}
            │    ├── PUBLIC      → ABSENT IndexData:{DescID: 106 (tbl), IndexID: 5}
            │    ├── PUBLIC      → ABSENT IndexData:{DescID: 106 (tbl), IndexID: 2 (tbl_j_key-)}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 106 (tbl), IndexID: 3, ConstraintID: 3, SourceIndexID: 4 (tbl_pkey-)}
            │    └── PUBLIC      → ABSENT IndexData:{DescID: 106 (tbl), IndexID: 3}
-           └── 9 Mutation operations
+           └── 10 Mutation operations
                 ├── RemoveColumnDefaultExpression {"ColumnID":2,"TableID":106}
                 ├── MakeIndexAbsent {"IndexID":4,"TableID":106}
                 ├── CreateGCJobForIndex {"IndexID":2,"TableID":106}
+                ├── MakeIndexAbsent {"IndexID":3,"TableID":106}
                 ├── CreateGCJobForIndex {"IndexID":3,"TableID":106}
                 ├── CreateGCJobForIndex {"IndexID":4,"TableID":106}
                 ├── CreateGCJobForIndex {"IndexID":5,"TableID":106}

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_default_unique/add_column_default_unique__rollback_12_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_default_unique/add_column_default_unique__rollback_12_of_15.explain
@@ -8,17 +8,15 @@ EXPLAIN (DDL) rollback at post-commit stage 12 of 15;
 ----
 Schema change plan for rolling back ALTER TABLE db.public.tbl ADD COLUMN j INT8 UNIQUE DEFAULT CAST(date_part(‹'year'›, now()) AS INT8);
  └── PostCommitNonRevertiblePhase
-      ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 2 elements transitioning toward PUBLIC
-      │    │    ├── VALIDATED             → PUBLIC      PrimaryIndex:{DescID: 106 (tbl), IndexID: 1 (tbl_pkey+), ConstraintID: 1}
-      │    │    └── ABSENT                → PUBLIC      IndexName:{DescID: 106 (tbl), Name: "tbl_pkey", IndexID: 1 (tbl_pkey+)}
-      │    ├── 14 elements transitioning toward ABSENT
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 15 elements transitioning toward ABSENT
       │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 106 (tbl), ColumnID: 2 (j-)}
       │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 106 (tbl), Name: "j", ColumnID: 2 (j-)}
-      │    │    ├── PUBLIC                → VALIDATED   PrimaryIndex:{DescID: 106 (tbl), IndexID: 4 (tbl_pkey-), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1 (tbl_pkey+)}
-      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 106 (tbl), Name: "tbl_pkey", IndexID: 4 (tbl_pkey-)}
+      │    │    ├── VALIDATED             → DELETE_ONLY PrimaryIndex:{DescID: 106 (tbl), IndexID: 4 (tbl_pkey-), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1 (tbl_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 1 (i), IndexID: 4 (tbl_pkey-)}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 106 (tbl), IndexID: 5, ConstraintID: 5, SourceIndexID: 1 (tbl_pkey+)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 1 (i), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 2 (j-), IndexID: 4 (tbl_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 2 (j-), IndexID: 5}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 2 (j-), IndexID: 2 (tbl_j_key-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 1 (i), IndexID: 2 (tbl_j_key-)}
@@ -27,40 +25,26 @@ Schema change plan for rolling back ALTER TABLE db.public.tbl ADD COLUMN j INT8 
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 2 (j-), IndexID: 3}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 1 (i), IndexID: 3}
       │    │    └── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 106 (tbl), IndexID: 3, ConstraintID: 3, SourceIndexID: 4 (tbl_pkey-)}
-      │    └── 18 Mutation operations
-      │         ├── SetIndexName {"IndexID":1,"Name":"tbl_pkey","TableID":106}
+      │    └── 17 Mutation operations
       │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":2,"TableID":106}
       │         ├── SetColumnName {"ColumnID":2,"Name":"crdb_internal_co...","TableID":106}
-      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":4,"TableID":106}
-      │         ├── SetIndexName {"IndexID":4,"Name":"crdb_internal_in...","TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"Kind":2,"TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":2,"TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"Kind":1,"TableID":106}
       │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":106}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":3,"TableID":106}
-      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":106}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":106}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":106}
       │         ├── MakeIndexAbsent {"IndexID":5,"TableID":106}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"Kind":2,"TableID":106}
       │         ├── MakeIndexAbsent {"IndexID":2,"TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"Kind":1,"TableID":106}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":106}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
-      ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 4 elements transitioning toward ABSENT
-      │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 106 (tbl), IndexID: 4 (tbl_pkey-), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1 (tbl_pkey+)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 1 (i), IndexID: 4 (tbl_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 2 (j-), IndexID: 4 (tbl_pkey-)}
-      │    │    └── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 106 (tbl), IndexID: 3, ConstraintID: 3, SourceIndexID: 4 (tbl_pkey-)}
-      │    └── 6 Mutation operations
-      │         ├── MakeIndexAbsent {"IndexID":3,"TableID":106}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":106}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":106}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"Kind":2,"TableID":106}
-      │         ├── SetJobStateOnDescriptor {"DescriptorID":106}
-      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
-      └── Stage 3 of 3 in PostCommitNonRevertiblePhase
-           ├── 8 elements transitioning toward ABSENT
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 9 elements transitioning toward ABSENT
            │    ├── DELETE_ONLY → ABSENT Column:{DescID: 106 (tbl), ColumnID: 2 (j-)}
            │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 106 (tbl), ColumnFamilyID: 0 (primary), ColumnID: 2 (j-), TypeName: "INT8"}
            │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 106 (tbl), ColumnID: 2 (j-), Expr: CAST(date_part('year':::STRING, now():::TIMESTAMPTZ) AS INT8)}
@@ -68,11 +52,13 @@ Schema change plan for rolling back ALTER TABLE db.public.tbl ADD COLUMN j INT8 
            │    ├── PUBLIC      → ABSENT IndexData:{DescID: 106 (tbl), IndexID: 4 (tbl_pkey-)}
            │    ├── PUBLIC      → ABSENT IndexData:{DescID: 106 (tbl), IndexID: 5}
            │    ├── PUBLIC      → ABSENT IndexData:{DescID: 106 (tbl), IndexID: 2 (tbl_j_key-)}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 106 (tbl), IndexID: 3, ConstraintID: 3, SourceIndexID: 4 (tbl_pkey-)}
            │    └── PUBLIC      → ABSENT IndexData:{DescID: 106 (tbl), IndexID: 3}
-           └── 9 Mutation operations
+           └── 10 Mutation operations
                 ├── RemoveColumnDefaultExpression {"ColumnID":2,"TableID":106}
                 ├── MakeIndexAbsent {"IndexID":4,"TableID":106}
                 ├── CreateGCJobForIndex {"IndexID":2,"TableID":106}
+                ├── MakeIndexAbsent {"IndexID":3,"TableID":106}
                 ├── CreateGCJobForIndex {"IndexID":3,"TableID":106}
                 ├── CreateGCJobForIndex {"IndexID":4,"TableID":106}
                 ├── CreateGCJobForIndex {"IndexID":5,"TableID":106}

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_default_unique/add_column_default_unique__rollback_13_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_default_unique/add_column_default_unique__rollback_13_of_15.explain
@@ -8,17 +8,15 @@ EXPLAIN (DDL) rollback at post-commit stage 13 of 15;
 ----
 Schema change plan for rolling back ALTER TABLE db.public.tbl ADD COLUMN j INT8 UNIQUE DEFAULT CAST(date_part(‹'year'›, now()) AS INT8);
  └── PostCommitNonRevertiblePhase
-      ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 2 elements transitioning toward PUBLIC
-      │    │    ├── VALIDATED             → PUBLIC      PrimaryIndex:{DescID: 106 (tbl), IndexID: 1 (tbl_pkey+), ConstraintID: 1}
-      │    │    └── ABSENT                → PUBLIC      IndexName:{DescID: 106 (tbl), Name: "tbl_pkey", IndexID: 1 (tbl_pkey+)}
-      │    ├── 14 elements transitioning toward ABSENT
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 15 elements transitioning toward ABSENT
       │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 106 (tbl), ColumnID: 2 (j-)}
       │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 106 (tbl), Name: "j", ColumnID: 2 (j-)}
-      │    │    ├── PUBLIC                → VALIDATED   PrimaryIndex:{DescID: 106 (tbl), IndexID: 4 (tbl_pkey-), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1 (tbl_pkey+)}
-      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 106 (tbl), Name: "tbl_pkey", IndexID: 4 (tbl_pkey-)}
+      │    │    ├── VALIDATED             → DELETE_ONLY PrimaryIndex:{DescID: 106 (tbl), IndexID: 4 (tbl_pkey-), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1 (tbl_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 1 (i), IndexID: 4 (tbl_pkey-)}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 106 (tbl), IndexID: 5, ConstraintID: 5, SourceIndexID: 1 (tbl_pkey+)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 1 (i), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 2 (j-), IndexID: 4 (tbl_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 2 (j-), IndexID: 5}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 2 (j-), IndexID: 2 (tbl_j_key-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 1 (i), IndexID: 2 (tbl_j_key-)}
@@ -27,17 +25,16 @@ Schema change plan for rolling back ALTER TABLE db.public.tbl ADD COLUMN j INT8 
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 2 (j-), IndexID: 3}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 1 (i), IndexID: 3}
       │    │    └── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 106 (tbl), IndexID: 3, ConstraintID: 3, SourceIndexID: 4 (tbl_pkey-)}
-      │    └── 18 Mutation operations
-      │         ├── SetIndexName {"IndexID":1,"Name":"tbl_pkey","TableID":106}
+      │    └── 17 Mutation operations
       │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":2,"TableID":106}
       │         ├── SetColumnName {"ColumnID":2,"Name":"crdb_internal_co...","TableID":106}
-      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":4,"TableID":106}
-      │         ├── SetIndexName {"IndexID":4,"Name":"crdb_internal_in...","TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"Kind":2,"TableID":106}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":3,"TableID":106}
-      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":106}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":106}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":106}
       │         ├── MakeIndexAbsent {"IndexID":5,"TableID":106}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"Kind":2,"TableID":106}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":2,"TableID":106}
       │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"TableID":106}
@@ -46,35 +43,24 @@ Schema change plan for rolling back ALTER TABLE db.public.tbl ADD COLUMN j INT8 
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"Kind":1,"TableID":106}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":106}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
-      ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 5 elements transitioning toward ABSENT
-      │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 106 (tbl), IndexID: 4 (tbl_pkey-), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1 (tbl_pkey+)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 1 (i), IndexID: 4 (tbl_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 2 (j-), IndexID: 4 (tbl_pkey-)}
-      │    │    ├── DELETE_ONLY → ABSENT      SecondaryIndex:{DescID: 106 (tbl), IndexID: 2 (tbl_j_key-), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 4 (tbl_pkey-), RecreateSourceIndexID: 0}
-      │    │    └── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 106 (tbl), IndexID: 3, ConstraintID: 3, SourceIndexID: 4 (tbl_pkey-)}
-      │    └── 7 Mutation operations
-      │         ├── MakeIndexAbsent {"IndexID":2,"TableID":106}
-      │         ├── MakeIndexAbsent {"IndexID":3,"TableID":106}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":106}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":106}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"Kind":2,"TableID":106}
-      │         ├── SetJobStateOnDescriptor {"DescriptorID":106}
-      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
-      └── Stage 3 of 3 in PostCommitNonRevertiblePhase
-           ├── 8 elements transitioning toward ABSENT
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 10 elements transitioning toward ABSENT
            │    ├── DELETE_ONLY → ABSENT Column:{DescID: 106 (tbl), ColumnID: 2 (j-)}
            │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 106 (tbl), ColumnFamilyID: 0 (primary), ColumnID: 2 (j-), TypeName: "INT8"}
            │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 106 (tbl), ColumnID: 2 (j-), Expr: CAST(date_part('year':::STRING, now():::TIMESTAMPTZ) AS INT8)}
            │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 106 (tbl), IndexID: 4 (tbl_pkey-), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1 (tbl_pkey+)}
            │    ├── PUBLIC      → ABSENT IndexData:{DescID: 106 (tbl), IndexID: 4 (tbl_pkey-)}
            │    ├── PUBLIC      → ABSENT IndexData:{DescID: 106 (tbl), IndexID: 5}
+           │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 106 (tbl), IndexID: 2 (tbl_j_key-), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 4 (tbl_pkey-), RecreateSourceIndexID: 0}
            │    ├── PUBLIC      → ABSENT IndexData:{DescID: 106 (tbl), IndexID: 2 (tbl_j_key-)}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 106 (tbl), IndexID: 3, ConstraintID: 3, SourceIndexID: 4 (tbl_pkey-)}
            │    └── PUBLIC      → ABSENT IndexData:{DescID: 106 (tbl), IndexID: 3}
-           └── 9 Mutation operations
+           └── 11 Mutation operations
                 ├── RemoveColumnDefaultExpression {"ColumnID":2,"TableID":106}
                 ├── MakeIndexAbsent {"IndexID":4,"TableID":106}
+                ├── MakeIndexAbsent {"IndexID":2,"TableID":106}
                 ├── CreateGCJobForIndex {"IndexID":2,"TableID":106}
+                ├── MakeIndexAbsent {"IndexID":3,"TableID":106}
                 ├── CreateGCJobForIndex {"IndexID":3,"TableID":106}
                 ├── CreateGCJobForIndex {"IndexID":4,"TableID":106}
                 ├── CreateGCJobForIndex {"IndexID":5,"TableID":106}

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_default_unique/add_column_default_unique__rollback_14_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_default_unique/add_column_default_unique__rollback_14_of_15.explain
@@ -8,17 +8,15 @@ EXPLAIN (DDL) rollback at post-commit stage 14 of 15;
 ----
 Schema change plan for rolling back ALTER TABLE db.public.tbl ADD COLUMN j INT8 UNIQUE DEFAULT CAST(date_part(‹'year'›, now()) AS INT8);
  └── PostCommitNonRevertiblePhase
-      ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 2 elements transitioning toward PUBLIC
-      │    │    ├── VALIDATED             → PUBLIC      PrimaryIndex:{DescID: 106 (tbl), IndexID: 1 (tbl_pkey+), ConstraintID: 1}
-      │    │    └── ABSENT                → PUBLIC      IndexName:{DescID: 106 (tbl), Name: "tbl_pkey", IndexID: 1 (tbl_pkey+)}
-      │    ├── 14 elements transitioning toward ABSENT
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 15 elements transitioning toward ABSENT
       │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 106 (tbl), ColumnID: 2 (j-)}
       │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 106 (tbl), Name: "j", ColumnID: 2 (j-)}
-      │    │    ├── PUBLIC                → VALIDATED   PrimaryIndex:{DescID: 106 (tbl), IndexID: 4 (tbl_pkey-), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1 (tbl_pkey+)}
-      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 106 (tbl), Name: "tbl_pkey", IndexID: 4 (tbl_pkey-)}
+      │    │    ├── VALIDATED             → DELETE_ONLY PrimaryIndex:{DescID: 106 (tbl), IndexID: 4 (tbl_pkey-), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1 (tbl_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 1 (i), IndexID: 4 (tbl_pkey-)}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 106 (tbl), IndexID: 5, ConstraintID: 5, SourceIndexID: 1 (tbl_pkey+)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 1 (i), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 2 (j-), IndexID: 4 (tbl_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 2 (j-), IndexID: 5}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 2 (j-), IndexID: 2 (tbl_j_key-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 1 (i), IndexID: 2 (tbl_j_key-)}
@@ -27,17 +25,16 @@ Schema change plan for rolling back ALTER TABLE db.public.tbl ADD COLUMN j INT8 
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 2 (j-), IndexID: 3}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 1 (i), IndexID: 3}
       │    │    └── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 106 (tbl), IndexID: 3, ConstraintID: 3, SourceIndexID: 4 (tbl_pkey-)}
-      │    └── 18 Mutation operations
-      │         ├── SetIndexName {"IndexID":1,"Name":"tbl_pkey","TableID":106}
+      │    └── 17 Mutation operations
       │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":2,"TableID":106}
       │         ├── SetColumnName {"ColumnID":2,"Name":"crdb_internal_co...","TableID":106}
-      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":4,"TableID":106}
-      │         ├── SetIndexName {"IndexID":4,"Name":"crdb_internal_in...","TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"Kind":2,"TableID":106}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":3,"TableID":106}
-      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":106}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":106}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":106}
       │         ├── MakeIndexAbsent {"IndexID":5,"TableID":106}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"Kind":2,"TableID":106}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":2,"TableID":106}
       │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"TableID":106}
@@ -46,35 +43,24 @@ Schema change plan for rolling back ALTER TABLE db.public.tbl ADD COLUMN j INT8 
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"Kind":1,"TableID":106}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":106}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
-      ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 5 elements transitioning toward ABSENT
-      │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 106 (tbl), IndexID: 4 (tbl_pkey-), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1 (tbl_pkey+)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 1 (i), IndexID: 4 (tbl_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 2 (j-), IndexID: 4 (tbl_pkey-)}
-      │    │    ├── DELETE_ONLY → ABSENT      SecondaryIndex:{DescID: 106 (tbl), IndexID: 2 (tbl_j_key-), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 4 (tbl_pkey-), RecreateSourceIndexID: 0}
-      │    │    └── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 106 (tbl), IndexID: 3, ConstraintID: 3, SourceIndexID: 4 (tbl_pkey-)}
-      │    └── 7 Mutation operations
-      │         ├── MakeIndexAbsent {"IndexID":2,"TableID":106}
-      │         ├── MakeIndexAbsent {"IndexID":3,"TableID":106}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":106}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":106}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"Kind":2,"TableID":106}
-      │         ├── SetJobStateOnDescriptor {"DescriptorID":106}
-      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
-      └── Stage 3 of 3 in PostCommitNonRevertiblePhase
-           ├── 8 elements transitioning toward ABSENT
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 10 elements transitioning toward ABSENT
            │    ├── DELETE_ONLY → ABSENT Column:{DescID: 106 (tbl), ColumnID: 2 (j-)}
            │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 106 (tbl), ColumnFamilyID: 0 (primary), ColumnID: 2 (j-), TypeName: "INT8"}
            │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 106 (tbl), ColumnID: 2 (j-), Expr: CAST(date_part('year':::STRING, now():::TIMESTAMPTZ) AS INT8)}
            │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 106 (tbl), IndexID: 4 (tbl_pkey-), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1 (tbl_pkey+)}
            │    ├── PUBLIC      → ABSENT IndexData:{DescID: 106 (tbl), IndexID: 4 (tbl_pkey-)}
            │    ├── PUBLIC      → ABSENT IndexData:{DescID: 106 (tbl), IndexID: 5}
+           │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 106 (tbl), IndexID: 2 (tbl_j_key-), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 4 (tbl_pkey-), RecreateSourceIndexID: 0}
            │    ├── PUBLIC      → ABSENT IndexData:{DescID: 106 (tbl), IndexID: 2 (tbl_j_key-)}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 106 (tbl), IndexID: 3, ConstraintID: 3, SourceIndexID: 4 (tbl_pkey-)}
            │    └── PUBLIC      → ABSENT IndexData:{DescID: 106 (tbl), IndexID: 3}
-           └── 9 Mutation operations
+           └── 11 Mutation operations
                 ├── RemoveColumnDefaultExpression {"ColumnID":2,"TableID":106}
                 ├── MakeIndexAbsent {"IndexID":4,"TableID":106}
+                ├── MakeIndexAbsent {"IndexID":2,"TableID":106}
                 ├── CreateGCJobForIndex {"IndexID":2,"TableID":106}
+                ├── MakeIndexAbsent {"IndexID":3,"TableID":106}
                 ├── CreateGCJobForIndex {"IndexID":3,"TableID":106}
                 ├── CreateGCJobForIndex {"IndexID":4,"TableID":106}
                 ├── CreateGCJobForIndex {"IndexID":5,"TableID":106}

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_default_unique/add_column_default_unique__rollback_15_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_default_unique/add_column_default_unique__rollback_15_of_15.explain
@@ -8,17 +8,15 @@ EXPLAIN (DDL) rollback at post-commit stage 15 of 15;
 ----
 Schema change plan for rolling back ALTER TABLE db.public.tbl ADD COLUMN j INT8 UNIQUE DEFAULT CAST(date_part(‹'year'›, now()) AS INT8);
  └── PostCommitNonRevertiblePhase
-      ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 2 elements transitioning toward PUBLIC
-      │    │    ├── VALIDATED             → PUBLIC      PrimaryIndex:{DescID: 106 (tbl), IndexID: 1 (tbl_pkey+), ConstraintID: 1}
-      │    │    └── ABSENT                → PUBLIC      IndexName:{DescID: 106 (tbl), Name: "tbl_pkey", IndexID: 1 (tbl_pkey+)}
-      │    ├── 14 elements transitioning toward ABSENT
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 15 elements transitioning toward ABSENT
       │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 106 (tbl), ColumnID: 2 (j-)}
       │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 106 (tbl), Name: "j", ColumnID: 2 (j-)}
-      │    │    ├── PUBLIC                → VALIDATED   PrimaryIndex:{DescID: 106 (tbl), IndexID: 4 (tbl_pkey-), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1 (tbl_pkey+)}
-      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 106 (tbl), Name: "tbl_pkey", IndexID: 4 (tbl_pkey-)}
+      │    │    ├── VALIDATED             → DELETE_ONLY PrimaryIndex:{DescID: 106 (tbl), IndexID: 4 (tbl_pkey-), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1 (tbl_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 1 (i), IndexID: 4 (tbl_pkey-)}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 106 (tbl), IndexID: 5, ConstraintID: 5, SourceIndexID: 1 (tbl_pkey+)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 1 (i), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 2 (j-), IndexID: 4 (tbl_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 2 (j-), IndexID: 5}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 2 (j-), IndexID: 2 (tbl_j_key-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 1 (i), IndexID: 2 (tbl_j_key-)}
@@ -27,18 +25,17 @@ Schema change plan for rolling back ALTER TABLE db.public.tbl ADD COLUMN j INT8 
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 2 (j-), IndexID: 3}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 1 (i), IndexID: 3}
       │    │    └── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 106 (tbl), IndexID: 3, ConstraintID: 3, SourceIndexID: 4 (tbl_pkey-)}
-      │    └── 18 Mutation operations
-      │         ├── SetIndexName {"IndexID":1,"Name":"tbl_pkey","TableID":106}
+      │    └── 17 Mutation operations
       │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":2,"TableID":106}
       │         ├── SetColumnName {"ColumnID":2,"Name":"crdb_internal_co...","TableID":106}
-      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":4,"TableID":106}
-      │         ├── SetIndexName {"IndexID":4,"Name":"crdb_internal_in...","TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"Kind":2,"TableID":106}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":2,"TableID":106}
       │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":106}
-      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":106}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":106}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":106}
       │         ├── MakeIndexAbsent {"IndexID":5,"TableID":106}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"Kind":2,"TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":2,"TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"Kind":1,"TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"TableID":106}
@@ -46,32 +43,21 @@ Schema change plan for rolling back ALTER TABLE db.public.tbl ADD COLUMN j INT8 
       │         ├── MakeIndexAbsent {"IndexID":3,"TableID":106}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":106}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
-      ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 4 elements transitioning toward ABSENT
-      │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 106 (tbl), IndexID: 4 (tbl_pkey-), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1 (tbl_pkey+)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 1 (i), IndexID: 4 (tbl_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 2 (j-), IndexID: 4 (tbl_pkey-)}
-      │    │    └── DELETE_ONLY → ABSENT      SecondaryIndex:{DescID: 106 (tbl), IndexID: 2 (tbl_j_key-), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 4 (tbl_pkey-), RecreateSourceIndexID: 0}
-      │    └── 6 Mutation operations
-      │         ├── MakeIndexAbsent {"IndexID":2,"TableID":106}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":106}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":106}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"Kind":2,"TableID":106}
-      │         ├── SetJobStateOnDescriptor {"DescriptorID":106}
-      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
-      └── Stage 3 of 3 in PostCommitNonRevertiblePhase
-           ├── 8 elements transitioning toward ABSENT
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 9 elements transitioning toward ABSENT
            │    ├── DELETE_ONLY → ABSENT Column:{DescID: 106 (tbl), ColumnID: 2 (j-)}
            │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 106 (tbl), ColumnFamilyID: 0 (primary), ColumnID: 2 (j-), TypeName: "INT8"}
            │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 106 (tbl), ColumnID: 2 (j-), Expr: CAST(date_part('year':::STRING, now():::TIMESTAMPTZ) AS INT8)}
            │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 106 (tbl), IndexID: 4 (tbl_pkey-), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1 (tbl_pkey+)}
            │    ├── PUBLIC      → ABSENT IndexData:{DescID: 106 (tbl), IndexID: 4 (tbl_pkey-)}
            │    ├── PUBLIC      → ABSENT IndexData:{DescID: 106 (tbl), IndexID: 5}
+           │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 106 (tbl), IndexID: 2 (tbl_j_key-), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 4 (tbl_pkey-), RecreateSourceIndexID: 0}
            │    ├── PUBLIC      → ABSENT IndexData:{DescID: 106 (tbl), IndexID: 2 (tbl_j_key-)}
            │    └── PUBLIC      → ABSENT IndexData:{DescID: 106 (tbl), IndexID: 3}
-           └── 9 Mutation operations
+           └── 10 Mutation operations
                 ├── RemoveColumnDefaultExpression {"ColumnID":2,"TableID":106}
                 ├── MakeIndexAbsent {"IndexID":4,"TableID":106}
+                ├── MakeIndexAbsent {"IndexID":2,"TableID":106}
                 ├── CreateGCJobForIndex {"IndexID":2,"TableID":106}
                 ├── CreateGCJobForIndex {"IndexID":3,"TableID":106}
                 ├── CreateGCJobForIndex {"IndexID":4,"TableID":106}

--- a/pkg/sql/schemachanger/testdata/end_to_end/add_column_default_unique/add_column_default_unique__rollback_9_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/add_column_default_unique/add_column_default_unique__rollback_9_of_15.explain
@@ -8,17 +8,15 @@ EXPLAIN (DDL) rollback at post-commit stage 9 of 15;
 ----
 Schema change plan for rolling back ALTER TABLE db.public.tbl ADD COLUMN j INT8 UNIQUE DEFAULT CAST(date_part(‹'year'›, now()) AS INT8);
  └── PostCommitNonRevertiblePhase
-      ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 2 elements transitioning toward PUBLIC
-      │    │    ├── VALIDATED             → PUBLIC      PrimaryIndex:{DescID: 106 (tbl), IndexID: 1 (tbl_pkey+), ConstraintID: 1}
-      │    │    └── ABSENT                → PUBLIC      IndexName:{DescID: 106 (tbl), Name: "tbl_pkey", IndexID: 1 (tbl_pkey+)}
-      │    ├── 14 elements transitioning toward ABSENT
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 15 elements transitioning toward ABSENT
       │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 106 (tbl), ColumnID: 2 (j-)}
       │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 106 (tbl), Name: "j", ColumnID: 2 (j-)}
-      │    │    ├── PUBLIC                → VALIDATED   PrimaryIndex:{DescID: 106 (tbl), IndexID: 4 (tbl_pkey-), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1 (tbl_pkey+)}
-      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 106 (tbl), Name: "tbl_pkey", IndexID: 4 (tbl_pkey-)}
+      │    │    ├── VALIDATED             → DELETE_ONLY PrimaryIndex:{DescID: 106 (tbl), IndexID: 4 (tbl_pkey-), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1 (tbl_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 1 (i), IndexID: 4 (tbl_pkey-)}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 106 (tbl), IndexID: 5, ConstraintID: 5, SourceIndexID: 1 (tbl_pkey+)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 1 (i), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 2 (j-), IndexID: 4 (tbl_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 2 (j-), IndexID: 5}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 2 (j-), IndexID: 2 (tbl_j_key-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 1 (i), IndexID: 2 (tbl_j_key-)}
@@ -27,37 +25,25 @@ Schema change plan for rolling back ALTER TABLE db.public.tbl ADD COLUMN j INT8 
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 2 (j-), IndexID: 3}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 1 (i), IndexID: 3}
       │    │    └── DELETE_ONLY           → ABSENT      TemporaryIndex:{DescID: 106 (tbl), IndexID: 3, ConstraintID: 3, SourceIndexID: 4 (tbl_pkey-)}
-      │    └── 18 Mutation operations
-      │         ├── SetIndexName {"IndexID":1,"Name":"tbl_pkey","TableID":106}
+      │    └── 17 Mutation operations
       │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":2,"TableID":106}
       │         ├── SetColumnName {"ColumnID":2,"Name":"crdb_internal_co...","TableID":106}
-      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":4,"TableID":106}
-      │         ├── SetIndexName {"IndexID":4,"Name":"crdb_internal_in...","TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"Kind":2,"TableID":106}
       │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"Kind":1,"TableID":106}
       │         ├── MakeIndexAbsent {"IndexID":3,"TableID":106}
-      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":106}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":106}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":106}
       │         ├── MakeIndexAbsent {"IndexID":5,"TableID":106}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"Kind":2,"TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":2,"TableID":106}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"Kind":1,"TableID":106}
       │         ├── MakeIndexAbsent {"IndexID":2,"TableID":106}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":106}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
-      ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 3 elements transitioning toward ABSENT
-      │    │    ├── VALIDATED → DELETE_ONLY PrimaryIndex:{DescID: 106 (tbl), IndexID: 4 (tbl_pkey-), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 1 (tbl_pkey+)}
-      │    │    ├── PUBLIC    → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 1 (i), IndexID: 4 (tbl_pkey-)}
-      │    │    └── PUBLIC    → ABSENT      IndexColumn:{DescID: 106 (tbl), ColumnID: 2 (j-), IndexID: 4 (tbl_pkey-)}
-      │    └── 5 Mutation operations
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":106}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":106}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"Kind":2,"TableID":106}
-      │         ├── SetJobStateOnDescriptor {"DescriptorID":106}
-      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
-      └── Stage 3 of 3 in PostCommitNonRevertiblePhase
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
            ├── 7 elements transitioning toward ABSENT
            │    ├── DELETE_ONLY → ABSENT Column:{DescID: 106 (tbl), ColumnID: 2 (j-)}
            │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 106 (tbl), ColumnFamilyID: 0 (primary), ColumnID: 2 (j-), TypeName: "INT8"}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid/alter_table_add_primary_key_drop_rowid.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid/alter_table_add_primary_key_drop_rowid.explain
@@ -139,10 +139,10 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ADD PRIM
  │    │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":1,"TableID":104}
  │    │         ├── SetIndexName {"IndexID":1,"Name":"crdb_internal_in...","TableID":104}
  │    │         ├── SetIndexName {"IndexID":2,"Name":"t_pkey","TableID":104}
- │    │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":2,"TableID":104}
  │    │         ├── MakeAbsentTempIndexDeleteOnly {"Index":{"ConstraintID":5,"IndexID":5,"IsUnique":true,"SourceIndexID":2,"TableID":104}}
  │    │         ├── MaybeAddSplitForIndex {"IndexID":5,"TableID":104}
  │    │         ├── AddColumnToIndex {"ColumnID":1,"IndexID":5,"TableID":104}
+ │    │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":2,"TableID":104}
  │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
  │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
  │    ├── Stage 9 of 15 in PostCommitPhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx.definition
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx.definition
@@ -52,5 +52,5 @@ idx_b
 t_pkey
 
 test
-alter table t add primary key (a);
+alter table t add primary key (a) USING HASH WITH (bucket_count=10);
 ----

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx.explain
@@ -3,232 +3,269 @@ CREATE TABLE t (a INT NOT NULL, b INT NOT NULL);
 CREATE INDEX idx_b ON t(b);
 
 /* test */
-EXPLAIN (DDL) alter table t add primary key (a);
+EXPLAIN (DDL) alter table t add primary key (a) USING HASH WITH (bucket_count=10);
 ----
-Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ADD PRIMARY KEY (‹a›);
+Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ADD PRIMARY KEY (‹a›) USING HASH WITH ('bucket_count' = ‹10›);
  ├── StatementPhase
  │    └── Stage 1 of 1 in StatementPhase
- │         ├── 4 elements transitioning toward PUBLIC
- │         │    ├── ABSENT → BACKFILL_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey+), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey~)}
+ │         ├── 9 elements transitioning toward PUBLIC
+ │         │    ├── ABSENT → BACKFILL_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey+), ConstraintID: 7, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey~)}
  │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 8 (t_pkey+)}
  │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 8 (t_pkey+)}
- │         │    └── ABSENT → PUBLIC        IndexData:{DescID: 104 (t), IndexID: 8 (t_pkey+)}
- │         ├── 9 elements transitioning toward TRANSIENT_ABSENT
- │         │    ├── ABSENT → BACKFILL_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey~), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey-)}
+ │         │    ├── ABSENT → PUBLIC        IndexData:{DescID: 104 (t), IndexID: 8 (t_pkey+)}
+ │         │    ├── ABSENT → DELETE_ONLY   Column:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10+)}
+ │         │    ├── ABSENT → PUBLIC        ColumnName:{DescID: 104 (t), Name: "crdb_internal_a_shard_10", ColumnID: 4 (crdb_internal_a_shard_10+)}
+ │         │    ├── ABSENT → PUBLIC        ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 4 (crdb_internal_a_shard_10+), TypeName: "INT8"}
+ │         │    ├── ABSENT → PUBLIC        ColumnComputeExpression:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10+), Usage: REGULAR}
+ │         │    └── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10+), IndexID: 8 (t_pkey+)}
+ │         ├── 11 elements transitioning toward TRANSIENT_ABSENT
+ │         │    ├── ABSENT → BACKFILL_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey~), ConstraintID: 5, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey-)}
  │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid-), IndexID: 6 (t_pkey~)}
  │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (t_pkey~)}
  │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (t_pkey~)}
  │         │    ├── ABSENT → PUBLIC        IndexData:{DescID: 104 (t), IndexID: 6 (t_pkey~)}
- │         │    ├── ABSENT → DELETE_ONLY   TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 5, SourceIndexID: 1 (t_pkey-)}
+ │         │    ├── ABSENT → DELETE_ONLY   TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 6, SourceIndexID: 1 (t_pkey-)}
  │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid-), IndexID: 7}
  │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 7}
- │         │    └── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 7}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 7}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10+), IndexID: 6 (t_pkey~)}
+ │         │    └── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10+), IndexID: 7}
  │         ├── 1 element transitioning toward ABSENT
  │         │    └── PUBLIC → VALIDATED     ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (rowid-), IndexID: 0}
- │         └── 12 Mutation operations
+ │         └── 19 Mutation operations
  │              ├── MakePublicColumnNotNullValidated {"ColumnID":3,"TableID":104}
- │              ├── MakeAbsentIndexBackfilling {"Index":{"ConstraintID":4,"IndexID":6,"IsUnique":true,"SourceIndexID":1,"TableID":104,"TemporaryIndexID":7}}
+ │              ├── MakeAbsentColumnDeleteOnly {"Column":{"ColumnID":4,"IsHidden":true,"TableID":104}}
+ │              ├── SetColumnName {"ColumnID":4,"Name":"crdb_internal_a_...","TableID":104}
+ │              ├── UpsertColumnType {"ColumnType":{"ColumnID":4,"IsVirtual":true,"TableID":104}}
+ │              ├── AddColumnComputeExpression {"ComputeExpression":{"ColumnID":4,"TableID":104}}
+ │              ├── MakeAbsentIndexBackfilling {"Index":{"ConstraintID":5,"IndexID":6,"IsUnique":true,"SourceIndexID":1,"TableID":104,"TemporaryIndexID":7}}
  │              ├── AddColumnToIndex {"ColumnID":3,"IndexID":6,"Kind":2,"TableID":104}
- │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":6,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":6,"Ordinal":1,"TableID":104}
  │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":104}
- │              ├── MakeAbsentTempIndexDeleteOnly {"Index":{"ConstraintID":5,"IndexID":7,"IsUnique":true,"SourceIndexID":1,"TableID":104}}
+ │              ├── MakeAbsentTempIndexDeleteOnly {"Index":{"ConstraintID":6,"IndexID":7,"IsUnique":true,"SourceIndexID":1,"TableID":104}}
  │              ├── AddColumnToIndex {"ColumnID":3,"IndexID":7,"Kind":2,"TableID":104}
- │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":7,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":7,"Ordinal":1,"TableID":104}
  │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":104}
- │              ├── MakeAbsentIndexBackfilling {"Index":{"ConstraintID":6,"IndexID":8,"IsUnique":true,"SourceIndexID":6,"TableID":104,"TemporaryIndexID":9}}
- │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":8,"TableID":104}
- │              └── AddColumnToIndex {"ColumnID":2,"IndexID":8,"Kind":2,"TableID":104}
+ │              ├── MakeAbsentIndexBackfilling {"Index":{"ConstraintID":7,"IndexID":8,"IsUnique":true,"SourceIndexID":6,"TableID":104,"TemporaryIndexID":9}}
+ │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":8,"Ordinal":1,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":8,"Kind":2,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":4,"IndexID":6,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":4,"IndexID":7,"TableID":104}
+ │              └── AddColumnToIndex {"ColumnID":4,"IndexID":8,"TableID":104}
  ├── PreCommitPhase
  │    ├── Stage 1 of 2 in PreCommitPhase
- │    │    ├── 4 elements transitioning toward PUBLIC
- │    │    │    ├── BACKFILL_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey+), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey~)}
+ │    │    ├── 9 elements transitioning toward PUBLIC
+ │    │    │    ├── BACKFILL_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey+), ConstraintID: 7, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey~)}
  │    │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 8 (t_pkey+)}
  │    │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 8 (t_pkey+)}
- │    │    │    └── PUBLIC        → ABSENT IndexData:{DescID: 104 (t), IndexID: 8 (t_pkey+)}
- │    │    ├── 9 elements transitioning toward TRANSIENT_ABSENT
- │    │    │    ├── BACKFILL_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey~), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey-)}
+ │    │    │    ├── PUBLIC        → ABSENT IndexData:{DescID: 104 (t), IndexID: 8 (t_pkey+)}
+ │    │    │    ├── DELETE_ONLY   → ABSENT Column:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10+)}
+ │    │    │    ├── PUBLIC        → ABSENT ColumnName:{DescID: 104 (t), Name: "crdb_internal_a_shard_10", ColumnID: 4 (crdb_internal_a_shard_10+)}
+ │    │    │    ├── PUBLIC        → ABSENT ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 4 (crdb_internal_a_shard_10+), TypeName: "INT8"}
+ │    │    │    ├── PUBLIC        → ABSENT ColumnComputeExpression:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10+), Usage: REGULAR}
+ │    │    │    └── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10+), IndexID: 8 (t_pkey+)}
+ │    │    ├── 11 elements transitioning toward TRANSIENT_ABSENT
+ │    │    │    ├── BACKFILL_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey~), ConstraintID: 5, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey-)}
  │    │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid-), IndexID: 6 (t_pkey~)}
  │    │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (t_pkey~)}
  │    │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (t_pkey~)}
  │    │    │    ├── PUBLIC        → ABSENT IndexData:{DescID: 104 (t), IndexID: 6 (t_pkey~)}
- │    │    │    ├── DELETE_ONLY   → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 5, SourceIndexID: 1 (t_pkey-)}
+ │    │    │    ├── DELETE_ONLY   → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 6, SourceIndexID: 1 (t_pkey-)}
  │    │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid-), IndexID: 7}
  │    │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 7}
- │    │    │    └── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 7}
+ │    │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 7}
+ │    │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10+), IndexID: 6 (t_pkey~)}
+ │    │    │    └── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10+), IndexID: 7}
  │    │    ├── 1 element transitioning toward ABSENT
  │    │    │    └── VALIDATED     → PUBLIC ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (rowid-), IndexID: 0}
  │    │    └── 1 Mutation operation
  │    │         └── UndoAllInTxnImmediateMutationOpSideEffects
  │    └── Stage 2 of 2 in PreCommitPhase
- │         ├── 4 elements transitioning toward PUBLIC
- │         │    ├── ABSENT → BACKFILL_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey+), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey~)}
+ │         ├── 9 elements transitioning toward PUBLIC
+ │         │    ├── ABSENT → BACKFILL_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey+), ConstraintID: 7, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey~)}
  │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 8 (t_pkey+)}
  │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 8 (t_pkey+)}
- │         │    └── ABSENT → PUBLIC        IndexData:{DescID: 104 (t), IndexID: 8 (t_pkey+)}
- │         ├── 9 elements transitioning toward TRANSIENT_ABSENT
- │         │    ├── ABSENT → BACKFILL_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey~), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey-)}
+ │         │    ├── ABSENT → PUBLIC        IndexData:{DescID: 104 (t), IndexID: 8 (t_pkey+)}
+ │         │    ├── ABSENT → DELETE_ONLY   Column:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10+)}
+ │         │    ├── ABSENT → PUBLIC        ColumnName:{DescID: 104 (t), Name: "crdb_internal_a_shard_10", ColumnID: 4 (crdb_internal_a_shard_10+)}
+ │         │    ├── ABSENT → PUBLIC        ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 4 (crdb_internal_a_shard_10+), TypeName: "INT8"}
+ │         │    ├── ABSENT → PUBLIC        ColumnComputeExpression:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10+), Usage: REGULAR}
+ │         │    └── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10+), IndexID: 8 (t_pkey+)}
+ │         ├── 11 elements transitioning toward TRANSIENT_ABSENT
+ │         │    ├── ABSENT → BACKFILL_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey~), ConstraintID: 5, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey-)}
  │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid-), IndexID: 6 (t_pkey~)}
  │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (t_pkey~)}
  │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (t_pkey~)}
  │         │    ├── ABSENT → PUBLIC        IndexData:{DescID: 104 (t), IndexID: 6 (t_pkey~)}
- │         │    ├── ABSENT → DELETE_ONLY   TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 5, SourceIndexID: 1 (t_pkey-)}
+ │         │    ├── ABSENT → DELETE_ONLY   TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 6, SourceIndexID: 1 (t_pkey-)}
  │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid-), IndexID: 7}
  │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 7}
- │         │    └── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 7}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 7}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10+), IndexID: 6 (t_pkey~)}
+ │         │    └── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10+), IndexID: 7}
  │         ├── 1 element transitioning toward ABSENT
  │         │    └── PUBLIC → VALIDATED     ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (rowid-), IndexID: 0}
- │         └── 17 Mutation operations
+ │         └── 24 Mutation operations
  │              ├── MakePublicColumnNotNullValidated {"ColumnID":3,"TableID":104}
- │              ├── MakeAbsentIndexBackfilling {"Index":{"ConstraintID":4,"IndexID":6,"IsUnique":true,"SourceIndexID":1,"TableID":104,"TemporaryIndexID":7}}
+ │              ├── MakeAbsentColumnDeleteOnly {"Column":{"ColumnID":4,"IsHidden":true,"TableID":104}}
+ │              ├── SetColumnName {"ColumnID":4,"Name":"crdb_internal_a_...","TableID":104}
+ │              ├── UpsertColumnType {"ColumnType":{"ColumnID":4,"IsVirtual":true,"TableID":104}}
+ │              ├── AddColumnComputeExpression {"ComputeExpression":{"ColumnID":4,"TableID":104}}
+ │              ├── MakeAbsentIndexBackfilling {"Index":{"ConstraintID":5,"IndexID":6,"IsUnique":true,"SourceIndexID":1,"TableID":104,"TemporaryIndexID":7}}
  │              ├── MaybeAddSplitForIndex {"IndexID":6,"TableID":104}
  │              ├── AddColumnToIndex {"ColumnID":3,"IndexID":6,"Kind":2,"TableID":104}
- │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":6,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":6,"Ordinal":1,"TableID":104}
  │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":104}
- │              ├── MakeAbsentTempIndexDeleteOnly {"Index":{"ConstraintID":5,"IndexID":7,"IsUnique":true,"SourceIndexID":1,"TableID":104}}
+ │              ├── MakeAbsentTempIndexDeleteOnly {"Index":{"ConstraintID":6,"IndexID":7,"IsUnique":true,"SourceIndexID":1,"TableID":104}}
  │              ├── MaybeAddSplitForIndex {"IndexID":7,"TableID":104}
  │              ├── AddColumnToIndex {"ColumnID":3,"IndexID":7,"Kind":2,"TableID":104}
- │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":7,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":7,"Ordinal":1,"TableID":104}
  │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":104}
- │              ├── MakeAbsentIndexBackfilling {"Index":{"ConstraintID":6,"IndexID":8,"IsUnique":true,"SourceIndexID":6,"TableID":104,"TemporaryIndexID":9}}
+ │              ├── MakeAbsentIndexBackfilling {"Index":{"ConstraintID":7,"IndexID":8,"IsUnique":true,"SourceIndexID":6,"TableID":104,"TemporaryIndexID":9}}
  │              ├── MaybeAddSplitForIndex {"IndexID":8,"TableID":104}
- │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":8,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":8,"Ordinal":1,"TableID":104}
  │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":8,"Kind":2,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":4,"IndexID":6,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":4,"IndexID":7,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":4,"IndexID":8,"TableID":104}
  │              ├── SetJobStateOnDescriptor {"DescriptorID":104,"Initialize":true}
  │              └── CreateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
  ├── PostCommitPhase
- │    ├── Stage 1 of 15 in PostCommitPhase
+ │    ├── Stage 1 of 16 in PostCommitPhase
+ │    │    ├── 2 elements transitioning toward PUBLIC
+ │    │    │    ├── DELETE_ONLY → WRITE_ONLY Column:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10+)}
+ │    │    │    └── ABSENT      → WRITE_ONLY ColumnNotNull:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10+), IndexID: 8 (t_pkey+)}
  │    │    ├── 2 elements transitioning toward TRANSIENT_ABSENT
- │    │    │    ├── DELETE_ONLY → WRITE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 5, SourceIndexID: 1 (t_pkey-)}
+ │    │    │    ├── DELETE_ONLY → WRITE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 6, SourceIndexID: 1 (t_pkey-)}
  │    │    │    └── ABSENT      → PUBLIC     IndexData:{DescID: 104 (t), IndexID: 7}
- │    │    └── 3 Mutation operations
+ │    │    └── 5 Mutation operations
+ │    │         ├── MakeDeleteOnlyColumnWriteOnly {"ColumnID":4,"TableID":104}
+ │    │         ├── MakeAbsentColumnNotNullWriteOnly {"ColumnID":4,"TableID":104}
  │    │         ├── MakeDeleteOnlyIndexWriteOnly {"IndexID":7,"TableID":104}
  │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
  │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
- │    ├── Stage 2 of 15 in PostCommitPhase
+ │    ├── Stage 2 of 16 in PostCommitPhase
  │    │    ├── 1 element transitioning toward TRANSIENT_ABSENT
- │    │    │    └── BACKFILL_ONLY → BACKFILLED PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey~), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey-)}
+ │    │    │    └── BACKFILL_ONLY → BACKFILLED PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey~), ConstraintID: 5, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey-)}
  │    │    └── 1 Backfill operation
  │    │         └── BackfillIndex {"IndexID":6,"SourceIndexID":1,"TableID":104}
- │    ├── Stage 3 of 15 in PostCommitPhase
+ │    ├── Stage 3 of 16 in PostCommitPhase
  │    │    ├── 1 element transitioning toward TRANSIENT_ABSENT
- │    │    │    └── BACKFILLED → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey~), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey-)}
+ │    │    │    └── BACKFILLED → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey~), ConstraintID: 5, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey-)}
  │    │    └── 3 Mutation operations
  │    │         ├── MakeBackfillingIndexDeleteOnly {"IndexID":6,"TableID":104}
  │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
  │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
- │    ├── Stage 4 of 15 in PostCommitPhase
+ │    ├── Stage 4 of 16 in PostCommitPhase
  │    │    ├── 1 element transitioning toward TRANSIENT_ABSENT
- │    │    │    └── DELETE_ONLY → MERGE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey~), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey-)}
+ │    │    │    └── DELETE_ONLY → MERGE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey~), ConstraintID: 5, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey-)}
  │    │    └── 3 Mutation operations
  │    │         ├── MakeBackfilledIndexMerging {"IndexID":6,"TableID":104}
  │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
  │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
- │    ├── Stage 5 of 15 in PostCommitPhase
+ │    ├── Stage 5 of 16 in PostCommitPhase
  │    │    ├── 1 element transitioning toward TRANSIENT_ABSENT
- │    │    │    └── MERGE_ONLY → MERGED PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey~), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey-)}
+ │    │    │    └── MERGE_ONLY → MERGED PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey~), ConstraintID: 5, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey-)}
  │    │    └── 1 Backfill operation
  │    │         └── MergeIndex {"BackfilledIndexID":6,"TableID":104,"TemporaryIndexID":7}
- │    ├── Stage 6 of 15 in PostCommitPhase
+ │    ├── Stage 6 of 16 in PostCommitPhase
  │    │    ├── 2 elements transitioning toward TRANSIENT_ABSENT
- │    │    │    ├── MERGED     → WRITE_ONLY            PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey~), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey-)}
- │    │    │    └── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 5, SourceIndexID: 1 (t_pkey-)}
+ │    │    │    ├── MERGED     → WRITE_ONLY            PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey~), ConstraintID: 5, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey-)}
+ │    │    │    └── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 6, SourceIndexID: 1 (t_pkey-)}
  │    │    └── 4 Mutation operations
  │    │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":7,"TableID":104}
  │    │         ├── MakeMergedIndexWriteOnly {"IndexID":6,"TableID":104}
  │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
  │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
- │    ├── Stage 7 of 15 in PostCommitPhase
+ │    ├── Stage 7 of 16 in PostCommitPhase
  │    │    ├── 1 element transitioning toward TRANSIENT_ABSENT
- │    │    │    └── WRITE_ONLY → VALIDATED PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey~), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey-)}
+ │    │    │    └── WRITE_ONLY → VALIDATED PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey~), ConstraintID: 5, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey-)}
  │    │    └── 1 Validation operation
  │    │         └── ValidateIndex {"IndexID":6,"TableID":104}
- │    ├── Stage 8 of 15 in PostCommitPhase
- │    │    ├── 4 elements transitioning toward PUBLIC
- │    │    │    ├── ABSENT    → BACKFILL_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 4 (idx_b+), ConstraintID: 2, TemporaryIndexID: 5, SourceIndexID: 6 (t_pkey~), RecreateSourceIndexID: 2}
- │    │    │    ├── ABSENT    → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 4 (idx_b+)}
- │    │    │    ├── ABSENT    → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 4 (idx_b+)}
- │    │    │    └── ABSENT    → PUBLIC        IndexData:{DescID: 104 (t), IndexID: 4 (idx_b+)}
- │    │    ├── 8 elements transitioning toward TRANSIENT_ABSENT
- │    │    │    ├── VALIDATED → PUBLIC        PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey~), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey-)}
- │    │    │    ├── ABSENT    → PUBLIC        IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 6 (t_pkey~)}
- │    │    │    ├── ABSENT    → DELETE_ONLY   TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 7, SourceIndexID: 6 (t_pkey~)}
- │    │    │    ├── ABSENT    → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 9}
- │    │    │    ├── ABSENT    → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 9}
- │    │    │    ├── ABSENT    → DELETE_ONLY   TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 3, SourceIndexID: 6 (t_pkey~)}
- │    │    │    ├── ABSENT    → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 5}
- │    │    │    └── ABSENT    → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 5}
- │    │    ├── 2 elements transitioning toward ABSENT
- │    │    │    ├── PUBLIC    → VALIDATED     PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey-), ConstraintID: 1}
- │    │    │    └── PUBLIC    → ABSENT        IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey-)}
- │    │    └── 18 Mutation operations
- │    │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":1,"TableID":104}
- │    │         ├── SetIndexName {"IndexID":1,"Name":"crdb_internal_in...","TableID":104}
- │    │         ├── SetIndexName {"IndexID":6,"Name":"t_pkey","TableID":104}
- │    │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":6,"TableID":104}
- │    │         ├── MakeAbsentTempIndexDeleteOnly {"Index":{"ConstraintID":7,"IndexID":9,"IsUnique":true,"SourceIndexID":6,"TableID":104}}
+ │    ├── Stage 8 of 16 in PostCommitPhase
+ │    │    ├── 6 elements transitioning toward PUBLIC
+ │    │    │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10+), IndexID: 9}
+ │    │    │    ├── ABSENT → BACKFILL_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 4 (idx_b+), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 6 (t_pkey~), RecreateSourceIndexID: 2}
+ │    │    │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 4 (idx_b+)}
+ │    │    │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 4 (idx_b+)}
+ │    │    │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10+), IndexID: 4 (idx_b+)}
+ │    │    │    └── ABSENT → PUBLIC        IndexData:{DescID: 104 (t), IndexID: 4 (idx_b+)}
+ │    │    ├── 7 elements transitioning toward TRANSIENT_ABSENT
+ │    │    │    ├── ABSENT → DELETE_ONLY   TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 8, SourceIndexID: 6 (t_pkey~)}
+ │    │    │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 9}
+ │    │    │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 9}
+ │    │    │    ├── ABSENT → DELETE_ONLY   TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 4, SourceIndexID: 6 (t_pkey~)}
+ │    │    │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 5}
+ │    │    │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 5}
+ │    │    │    └── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10+), IndexID: 5}
+ │    │    └── 17 Mutation operations
+ │    │         ├── MakeAbsentTempIndexDeleteOnly {"Index":{"ConstraintID":8,"IndexID":9,"IsUnique":true,"SourceIndexID":6,"TableID":104}}
  │    │         ├── MaybeAddSplitForIndex {"IndexID":9,"TableID":104}
- │    │         ├── AddColumnToIndex {"ColumnID":1,"IndexID":9,"TableID":104}
+ │    │         ├── AddColumnToIndex {"ColumnID":1,"IndexID":9,"Ordinal":1,"TableID":104}
  │    │         ├── AddColumnToIndex {"ColumnID":2,"IndexID":9,"Kind":2,"TableID":104}
+ │    │         ├── AddColumnToIndex {"ColumnID":4,"IndexID":9,"TableID":104}
  │    │         ├── MakeAbsentIndexBackfilling {"IsSecondaryIndex":true}
  │    │         ├── MaybeAddSplitForIndex {"IndexID":4,"TableID":104}
  │    │         ├── AddColumnToIndex {"ColumnID":2,"IndexID":4,"TableID":104}
  │    │         ├── AddColumnToIndex {"ColumnID":1,"IndexID":4,"Kind":1,"TableID":104}
+ │    │         ├── AddColumnToIndex {"ColumnID":4,"IndexID":4,"Kind":1,"Ordinal":1,"TableID":104}
  │    │         ├── MakeAbsentTempIndexDeleteOnly {"IsSecondaryIndex":true}
  │    │         ├── MaybeAddSplitForIndex {"IndexID":5,"TableID":104}
  │    │         ├── AddColumnToIndex {"ColumnID":2,"IndexID":5,"TableID":104}
  │    │         ├── AddColumnToIndex {"ColumnID":1,"IndexID":5,"Kind":1,"TableID":104}
+ │    │         ├── AddColumnToIndex {"ColumnID":4,"IndexID":5,"Kind":1,"Ordinal":1,"TableID":104}
  │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
  │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
- │    ├── Stage 9 of 15 in PostCommitPhase
+ │    ├── Stage 9 of 16 in PostCommitPhase
  │    │    ├── 4 elements transitioning toward TRANSIENT_ABSENT
- │    │    │    ├── DELETE_ONLY → WRITE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 7, SourceIndexID: 6 (t_pkey~)}
+ │    │    │    ├── DELETE_ONLY → WRITE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 8, SourceIndexID: 6 (t_pkey~)}
  │    │    │    ├── ABSENT      → PUBLIC     IndexData:{DescID: 104 (t), IndexID: 9}
- │    │    │    ├── DELETE_ONLY → WRITE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 3, SourceIndexID: 6 (t_pkey~)}
+ │    │    │    ├── DELETE_ONLY → WRITE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 4, SourceIndexID: 6 (t_pkey~)}
  │    │    │    └── ABSENT      → PUBLIC     IndexData:{DescID: 104 (t), IndexID: 5}
  │    │    └── 4 Mutation operations
  │    │         ├── MakeDeleteOnlyIndexWriteOnly {"IndexID":9,"TableID":104}
  │    │         ├── MakeDeleteOnlyIndexWriteOnly {"IndexID":5,"TableID":104}
  │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
  │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
- │    ├── Stage 10 of 15 in PostCommitPhase
+ │    ├── Stage 10 of 16 in PostCommitPhase
  │    │    ├── 2 elements transitioning toward PUBLIC
- │    │    │    ├── BACKFILL_ONLY → BACKFILLED PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey+), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey~)}
- │    │    │    └── BACKFILL_ONLY → BACKFILLED SecondaryIndex:{DescID: 104 (t), IndexID: 4 (idx_b+), ConstraintID: 2, TemporaryIndexID: 5, SourceIndexID: 6 (t_pkey~), RecreateSourceIndexID: 2}
+ │    │    │    ├── BACKFILL_ONLY → BACKFILLED PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey+), ConstraintID: 7, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey~)}
+ │    │    │    └── BACKFILL_ONLY → BACKFILLED SecondaryIndex:{DescID: 104 (t), IndexID: 4 (idx_b+), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 6 (t_pkey~), RecreateSourceIndexID: 2}
  │    │    └── 2 Backfill operations
  │    │         ├── BackfillIndex {"IndexID":8,"SourceIndexID":6,"TableID":104}
  │    │         └── BackfillIndex {"IndexID":4,"SourceIndexID":6,"TableID":104}
- │    ├── Stage 11 of 15 in PostCommitPhase
+ │    ├── Stage 11 of 16 in PostCommitPhase
  │    │    ├── 2 elements transitioning toward PUBLIC
- │    │    │    ├── BACKFILLED → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey+), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey~)}
- │    │    │    └── BACKFILLED → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 4 (idx_b+), ConstraintID: 2, TemporaryIndexID: 5, SourceIndexID: 6 (t_pkey~), RecreateSourceIndexID: 2}
+ │    │    │    ├── BACKFILLED → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey+), ConstraintID: 7, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey~)}
+ │    │    │    └── BACKFILLED → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 4 (idx_b+), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 6 (t_pkey~), RecreateSourceIndexID: 2}
  │    │    └── 4 Mutation operations
  │    │         ├── MakeBackfillingIndexDeleteOnly {"IndexID":8,"TableID":104}
  │    │         ├── MakeBackfillingIndexDeleteOnly {"IndexID":4,"TableID":104}
  │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
  │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
- │    ├── Stage 12 of 15 in PostCommitPhase
+ │    ├── Stage 12 of 16 in PostCommitPhase
  │    │    ├── 2 elements transitioning toward PUBLIC
- │    │    │    ├── DELETE_ONLY → MERGE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey+), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey~)}
- │    │    │    └── DELETE_ONLY → MERGE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 4 (idx_b+), ConstraintID: 2, TemporaryIndexID: 5, SourceIndexID: 6 (t_pkey~), RecreateSourceIndexID: 2}
+ │    │    │    ├── DELETE_ONLY → MERGE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey+), ConstraintID: 7, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey~)}
+ │    │    │    └── DELETE_ONLY → MERGE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 4 (idx_b+), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 6 (t_pkey~), RecreateSourceIndexID: 2}
  │    │    └── 4 Mutation operations
  │    │         ├── MakeBackfilledIndexMerging {"IndexID":8,"TableID":104}
  │    │         ├── MakeBackfilledIndexMerging {"IndexID":4,"TableID":104}
  │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
  │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
- │    ├── Stage 13 of 15 in PostCommitPhase
+ │    ├── Stage 13 of 16 in PostCommitPhase
  │    │    ├── 2 elements transitioning toward PUBLIC
- │    │    │    ├── MERGE_ONLY → MERGED PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey+), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey~)}
- │    │    │    └── MERGE_ONLY → MERGED SecondaryIndex:{DescID: 104 (t), IndexID: 4 (idx_b+), ConstraintID: 2, TemporaryIndexID: 5, SourceIndexID: 6 (t_pkey~), RecreateSourceIndexID: 2}
+ │    │    │    ├── MERGE_ONLY → MERGED PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey+), ConstraintID: 7, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey~)}
+ │    │    │    └── MERGE_ONLY → MERGED SecondaryIndex:{DescID: 104 (t), IndexID: 4 (idx_b+), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 6 (t_pkey~), RecreateSourceIndexID: 2}
  │    │    └── 2 Backfill operations
  │    │         ├── MergeIndex {"BackfilledIndexID":8,"TableID":104,"TemporaryIndexID":9}
  │    │         └── MergeIndex {"BackfilledIndexID":4,"TableID":104,"TemporaryIndexID":5}
- │    ├── Stage 14 of 15 in PostCommitPhase
+ │    ├── Stage 14 of 16 in PostCommitPhase
  │    │    ├── 2 elements transitioning toward PUBLIC
- │    │    │    ├── MERGED     → WRITE_ONLY            PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey+), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey~)}
- │    │    │    └── MERGED     → WRITE_ONLY            SecondaryIndex:{DescID: 104 (t), IndexID: 4 (idx_b+), ConstraintID: 2, TemporaryIndexID: 5, SourceIndexID: 6 (t_pkey~), RecreateSourceIndexID: 2}
+ │    │    │    ├── MERGED     → WRITE_ONLY            PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey+), ConstraintID: 7, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey~)}
+ │    │    │    └── MERGED     → WRITE_ONLY            SecondaryIndex:{DescID: 104 (t), IndexID: 4 (idx_b+), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 6 (t_pkey~), RecreateSourceIndexID: 2}
  │    │    ├── 2 elements transitioning toward TRANSIENT_ABSENT
- │    │    │    ├── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 7, SourceIndexID: 6 (t_pkey~)}
- │    │    │    └── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 3, SourceIndexID: 6 (t_pkey~)}
+ │    │    │    ├── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 8, SourceIndexID: 6 (t_pkey~)}
+ │    │    │    └── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 4, SourceIndexID: 6 (t_pkey~)}
  │    │    └── 6 Mutation operations
  │    │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":9,"TableID":104}
  │    │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":5,"TableID":104}
@@ -236,30 +273,55 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ADD PRIM
  │    │         ├── MakeMergedIndexWriteOnly {"IndexID":4,"TableID":104}
  │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
  │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
- │    └── Stage 15 of 15 in PostCommitPhase
- │         ├── 2 elements transitioning toward PUBLIC
- │         │    ├── WRITE_ONLY → VALIDATED PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey+), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey~)}
- │         │    └── WRITE_ONLY → VALIDATED SecondaryIndex:{DescID: 104 (t), IndexID: 4 (idx_b+), ConstraintID: 2, TemporaryIndexID: 5, SourceIndexID: 6 (t_pkey~), RecreateSourceIndexID: 2}
- │         └── 2 Validation operations
- │              ├── ValidateIndex {"IndexID":8,"TableID":104}
- │              └── ValidateIndex {"IndexID":4,"TableID":104}
+ │    ├── Stage 15 of 16 in PostCommitPhase
+ │    │    ├── 3 elements transitioning toward PUBLIC
+ │    │    │    ├── WRITE_ONLY → VALIDATED PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey+), ConstraintID: 7, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey~)}
+ │    │    │    ├── WRITE_ONLY → VALIDATED ColumnNotNull:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10+), IndexID: 8 (t_pkey+)}
+ │    │    │    └── WRITE_ONLY → VALIDATED SecondaryIndex:{DescID: 104 (t), IndexID: 4 (idx_b+), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 6 (t_pkey~), RecreateSourceIndexID: 2}
+ │    │    └── 3 Validation operations
+ │    │         ├── ValidateIndex {"IndexID":8,"TableID":104}
+ │    │         ├── ValidateColumnNotNull {"ColumnID":4,"IndexIDForValidation":8,"TableID":104}
+ │    │         └── ValidateIndex {"IndexID":4,"TableID":104}
+ │    └── Stage 16 of 16 in PostCommitPhase
+ │         ├── 3 elements transitioning toward PUBLIC
+ │         │    ├── VALIDATED → PUBLIC    ColumnNotNull:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10+), IndexID: 8 (t_pkey+)}
+ │         │    ├── VALIDATED → PUBLIC    SecondaryIndex:{DescID: 104 (t), IndexID: 4 (idx_b+), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 6 (t_pkey~), RecreateSourceIndexID: 2}
+ │         │    └── ABSENT    → PUBLIC    IndexName:{DescID: 104 (t), Name: "idx_b", IndexID: 4 (idx_b+)}
+ │         ├── 2 elements transitioning toward TRANSIENT_ABSENT
+ │         │    ├── VALIDATED → PUBLIC    PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey~), ConstraintID: 5, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey-)}
+ │         │    └── ABSENT    → PUBLIC    IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 6 (t_pkey~)}
+ │         ├── 3 elements transitioning toward ABSENT
+ │         │    ├── PUBLIC    → VALIDATED PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey-), ConstraintID: 1}
+ │         │    ├── PUBLIC    → ABSENT    IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey-)}
+ │         │    └── PUBLIC    → VALIDATED SecondaryIndex:{DescID: 104 (t), IndexID: 2 (idx_b-), RecreateSourceIndexID: 0}
+ │         └── 11 Mutation operations
+ │              ├── MakePublicPrimaryIndexWriteOnly {"IndexID":1,"TableID":104}
+ │              ├── SetIndexName {"IndexID":1,"Name":"crdb_internal_in...","TableID":104}
+ │              ├── SetIndexName {"IndexID":6,"Name":"t_pkey","TableID":104}
+ │              ├── MakeValidatedColumnNotNullPublic {"ColumnID":4,"TableID":104}
+ │              ├── SetIndexName {"IndexID":4,"Name":"idx_b","TableID":104}
+ │              ├── MakeValidatedPrimaryIndexPublic {"IndexID":6,"TableID":104}
+ │              ├── MakeValidatedSecondaryIndexPublic {"IndexID":4,"TableID":104}
+ │              ├── RefreshStats {"TableID":104}
+ │              ├── MakePublicSecondaryIndexWriteOnly {"IndexID":2,"TableID":104}
+ │              ├── SetJobStateOnDescriptor {"DescriptorID":104}
+ │              └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
  └── PostCommitNonRevertiblePhase
-      ├── Stage 1 of 4 in PostCommitNonRevertiblePhase
-      │    ├── 2 elements transitioning toward PUBLIC
-      │    │    ├── VALIDATED             → PUBLIC           SecondaryIndex:{DescID: 104 (t), IndexID: 4 (idx_b+), ConstraintID: 2, TemporaryIndexID: 5, SourceIndexID: 6 (t_pkey~), RecreateSourceIndexID: 2}
-      │    │    └── ABSENT                → PUBLIC           IndexName:{DescID: 104 (t), Name: "idx_b", IndexID: 4 (idx_b+)}
-      │    ├── 10 elements transitioning toward TRANSIENT_ABSENT
-      │    │    ├── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 5, SourceIndexID: 1 (t_pkey-)}
+      ├── Stage 1 of 5 in PostCommitNonRevertiblePhase
+      │    ├── 12 elements transitioning toward TRANSIENT_ABSENT
+      │    │    ├── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 6, SourceIndexID: 1 (t_pkey-)}
       │    │    ├── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid-), IndexID: 7}
       │    │    ├── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 7}
       │    │    ├── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 7}
-      │    │    ├── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 7, SourceIndexID: 6 (t_pkey~)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 8, SourceIndexID: 6 (t_pkey~)}
       │    │    ├── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 9}
       │    │    ├── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 9}
-      │    │    ├── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 3, SourceIndexID: 6 (t_pkey~)}
+      │    │    ├── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10+), IndexID: 7}
+      │    │    ├── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 4, SourceIndexID: 6 (t_pkey~)}
       │    │    ├── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 5}
-      │    │    └── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 5}
-      │    ├── 8 elements transitioning toward ABSENT
+      │    │    ├── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 5}
+      │    │    └── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10+), IndexID: 5}
+      │    ├── 11 elements transitioning toward ABSENT
       │    │    ├── PUBLIC                → WRITE_ONLY       Column:{DescID: 104 (t), ColumnID: 3 (rowid-)}
       │    │    ├── PUBLIC                → ABSENT           ColumnName:{DescID: 104 (t), Name: "rowid", ColumnID: 3 (rowid-)}
       │    │    ├── VALIDATED             → ABSENT           ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (rowid-), IndexID: 0}
@@ -267,77 +329,90 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ADD PRIM
       │    │    ├── PUBLIC                → ABSENT           IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 1 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT           IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 1 (t_pkey-)}
       │    │    ├── VALIDATED             → DELETE_ONLY      PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey-), ConstraintID: 1}
-      │    │    └── PUBLIC                → VALIDATED        SecondaryIndex:{DescID: 104 (t), IndexID: 2 (idx_b-), RecreateSourceIndexID: 0}
-      │    └── 23 Mutation operations
+      │    │    ├── PUBLIC                → ABSENT           IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 2 (idx_b-)}
+      │    │    ├── PUBLIC                → ABSENT           IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid-), IndexID: 2 (idx_b-)}
+      │    │    ├── VALIDATED             → DELETE_ONLY      SecondaryIndex:{DescID: 104 (t), IndexID: 2 (idx_b-), RecreateSourceIndexID: 0}
+      │    │    └── PUBLIC                → ABSENT           IndexName:{DescID: 104 (t), Name: "idx_b", IndexID: 2 (idx_b-)}
+      │    └── 25 Mutation operations
       │         ├── RemoveColumnNotNull {"ColumnID":3,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Ordinal":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Ordinal":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"Kind":2,"TableID":104}
-      │         ├── SetIndexName {"IndexID":4,"Name":"idx_b","TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"Kind":1,"TableID":104}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":1,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
-      │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":4,"TableID":104}
-      │         ├── RefreshStats {"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":1,"Kind":2,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":1,"Kind":2,"Ordinal":1,"TableID":104}
-      │         ├── MakePublicSecondaryIndexWriteOnly {"IndexID":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":5,"Kind":1,"Ordinal":1,"TableID":104}
       │         ├── MakePublicColumnWriteOnly {"ColumnID":3,"TableID":104}
       │         ├── SetColumnName {"ColumnID":3,"Name":"crdb_internal_co...","TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":2,"TableID":104}
+      │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":7,"Kind":2,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":1,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":1,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":2,"Kind":1,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
-      ├── Stage 2 of 4 in PostCommitNonRevertiblePhase
-      │    ├── 2 elements transitioning toward PUBLIC
-      │    │    ├── VALIDATED   → PUBLIC              PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey+), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey~)}
-      │    │    └── ABSENT      → PUBLIC              IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 8 (t_pkey+)}
+      ├── Stage 2 of 5 in PostCommitNonRevertiblePhase
+      │    ├── 5 elements transitioning toward PUBLIC
+      │    │    ├── VALIDATED   → PUBLIC              PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey+), ConstraintID: 7, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey~)}
+      │    │    ├── ABSENT      → PUBLIC              IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 8 (t_pkey+)}
+      │    │    ├── WRITE_ONLY  → PUBLIC              Column:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10+)}
+      │    │    ├── ABSENT      → WRITE_ONLY          CheckConstraint:{DescID: 104 (t), IndexID: 8 (t_pkey+), ConstraintID: 2 (check_crdb_internal_a_shard_10+), ReferencedColumnIDs: [4]}
+      │    │    └── ABSENT      → PUBLIC              ConstraintWithoutIndexName:{DescID: 104 (t), Name: "check_crdb_internal_a_shard_10", ConstraintID: 2 (check_crdb_internal_a_shard_10+)}
       │    ├── 2 elements transitioning toward TRANSIENT_ABSENT
-      │    │    ├── PUBLIC      → TRANSIENT_VALIDATED PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey~), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey-)}
+      │    │    ├── PUBLIC      → TRANSIENT_VALIDATED PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey~), ConstraintID: 5, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey-)}
       │    │    └── PUBLIC      → TRANSIENT_ABSENT    IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 6 (t_pkey~)}
-      │    ├── 6 elements transitioning toward ABSENT
+      │    ├── 3 elements transitioning toward ABSENT
       │    │    ├── WRITE_ONLY  → DELETE_ONLY         Column:{DescID: 104 (t), ColumnID: 3 (rowid-)}
       │    │    ├── DELETE_ONLY → ABSENT              PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey-), ConstraintID: 1}
-      │    │    ├── PUBLIC      → ABSENT              IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 2 (idx_b-)}
-      │    │    ├── PUBLIC      → ABSENT              IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid-), IndexID: 2 (idx_b-)}
-      │    │    ├── VALIDATED   → DELETE_ONLY         SecondaryIndex:{DescID: 104 (t), IndexID: 2 (idx_b-), RecreateSourceIndexID: 0}
-      │    │    └── PUBLIC      → ABSENT              IndexName:{DescID: 104 (t), Name: "idx_b", IndexID: 2 (idx_b-)}
-      │    └── 12 Mutation operations
+      │    │    └── DELETE_ONLY → ABSENT              SecondaryIndex:{DescID: 104 (t), IndexID: 2 (idx_b-), RecreateSourceIndexID: 0}
+      │    └── 13 Mutation operations
       │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":3,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":1,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":2,"TableID":104}
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":6,"TableID":104}
       │         ├── SetIndexName {"IndexID":6,"Name":"crdb_internal_in...","TableID":104}
       │         ├── SetIndexName {"IndexID":8,"Name":"t_pkey","TableID":104}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":2,"TableID":104}
-      │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":104}
       │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":8,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":2,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":2,"Kind":1,"TableID":104}
+      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":4,"TableID":104}
+      │         ├── RefreshStats {"TableID":104}
+      │         ├── AddCheckConstraint {"CheckExpr":"crdb_internal_a_...","ConstraintID":2,"FromHashShardedColumn":true,"TableID":104,"Validity":2}
+      │         ├── SetConstraintName {"ConstraintID":2,"Name":"check_crdb_inter...","TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
-      ├── Stage 3 of 4 in PostCommitNonRevertiblePhase
-      │    ├── 4 elements transitioning toward TRANSIENT_ABSENT
-      │    │    ├── TRANSIENT_VALIDATED → TRANSIENT_DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey~), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey-)}
+      ├── Stage 3 of 5 in PostCommitNonRevertiblePhase
+      │    ├── 1 element transitioning toward PUBLIC
+      │    │    └── WRITE_ONLY → VALIDATED CheckConstraint:{DescID: 104 (t), IndexID: 8 (t_pkey+), ConstraintID: 2 (check_crdb_internal_a_shard_10+), ReferencedColumnIDs: [4]}
+      │    └── 1 Validation operation
+      │         └── ValidateConstraint {"ConstraintID":2,"IndexIDForValidation":8,"TableID":104}
+      ├── Stage 4 of 5 in PostCommitNonRevertiblePhase
+      │    ├── 1 element transitioning toward PUBLIC
+      │    │    └── VALIDATED           → PUBLIC                CheckConstraint:{DescID: 104 (t), IndexID: 8 (t_pkey+), ConstraintID: 2 (check_crdb_internal_a_shard_10+), ReferencedColumnIDs: [4]}
+      │    ├── 5 elements transitioning toward TRANSIENT_ABSENT
+      │    │    ├── TRANSIENT_VALIDATED → TRANSIENT_DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey~), ConstraintID: 5, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey-)}
       │    │    ├── PUBLIC              → TRANSIENT_ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid-), IndexID: 6 (t_pkey~)}
       │    │    ├── PUBLIC              → TRANSIENT_ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (t_pkey~)}
-      │    │    └── PUBLIC              → TRANSIENT_ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (t_pkey~)}
-      │    ├── 1 element transitioning toward ABSENT
-      │    │    └── DELETE_ONLY         → ABSENT                SecondaryIndex:{DescID: 104 (t), IndexID: 2 (idx_b-), RecreateSourceIndexID: 0}
-      │    └── 7 Mutation operations
-      │         ├── MakeIndexAbsent {"IndexID":2,"TableID":104}
+      │    │    ├── PUBLIC              → TRANSIENT_ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (t_pkey~)}
+      │    │    └── PUBLIC              → TRANSIENT_ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10+), IndexID: 6 (t_pkey~)}
+      │    └── 8 Mutation operations
+      │         ├── MakeValidatedCheckConstraintPublic {"ConstraintID":2,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"Kind":2,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Ordinal":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":6,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
-      └── Stage 4 of 4 in PostCommitNonRevertiblePhase
+      └── Stage 5 of 5 in PostCommitNonRevertiblePhase
            ├── 5 elements transitioning toward TRANSIENT_ABSENT
-           │    ├── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey~), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey-)}
+           │    ├── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey~), ConstraintID: 5, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey-)}
            │    ├── PUBLIC                → TRANSIENT_ABSENT IndexData:{DescID: 104 (t), IndexID: 6 (t_pkey~)}
            │    ├── PUBLIC                → TRANSIENT_ABSENT IndexData:{DescID: 104 (t), IndexID: 7}
            │    ├── PUBLIC                → TRANSIENT_ABSENT IndexData:{DescID: 104 (t), IndexID: 9}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx.explain
@@ -294,13 +294,14 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ADD PRIM
  │         │    ├── PUBLIC    → VALIDATED PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey-), ConstraintID: 1}
  │         │    ├── PUBLIC    → ABSENT    IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey-)}
  │         │    └── PUBLIC    → VALIDATED SecondaryIndex:{DescID: 104 (t), IndexID: 2 (idx_b-), RecreateSourceIndexID: 0}
- │         └── 11 Mutation operations
+ │         └── 12 Mutation operations
  │              ├── MakePublicPrimaryIndexWriteOnly {"IndexID":1,"TableID":104}
  │              ├── SetIndexName {"IndexID":1,"Name":"crdb_internal_in...","TableID":104}
  │              ├── SetIndexName {"IndexID":6,"Name":"t_pkey","TableID":104}
  │              ├── MakeValidatedColumnNotNullPublic {"ColumnID":4,"TableID":104}
  │              ├── SetIndexName {"IndexID":4,"Name":"idx_b","TableID":104}
  │              ├── MakeValidatedPrimaryIndexPublic {"IndexID":6,"TableID":104}
+ │              ├── MarkRecreatedIndexAsInvisible {"IndexID":4,"TableID":104,"TargetPrimaryIndexID":8}
  │              ├── MakeValidatedSecondaryIndexPublic {"IndexID":4,"TableID":104}
  │              ├── RefreshStats {"TableID":104}
  │              ├── MakePublicSecondaryIndexWriteOnly {"IndexID":2,"TableID":104}
@@ -373,7 +374,7 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ADD PRIM
       │    │    ├── WRITE_ONLY  → DELETE_ONLY         Column:{DescID: 104 (t), ColumnID: 3 (rowid-)}
       │    │    ├── DELETE_ONLY → ABSENT              PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey-), ConstraintID: 1}
       │    │    └── DELETE_ONLY → ABSENT              SecondaryIndex:{DescID: 104 (t), IndexID: 2 (idx_b-), RecreateSourceIndexID: 0}
-      │    └── 13 Mutation operations
+      │    └── 14 Mutation operations
       │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":3,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":1,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":2,"TableID":104}
@@ -381,6 +382,7 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ADD PRIM
       │         ├── SetIndexName {"IndexID":6,"Name":"crdb_internal_in...","TableID":104}
       │         ├── SetIndexName {"IndexID":8,"Name":"t_pkey","TableID":104}
       │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":8,"TableID":104}
+      │         ├── MarkRecreatedIndexesAsVisible {"TableID":104}
       │         ├── MakeWriteOnlyColumnPublic {"ColumnID":4,"TableID":104}
       │         ├── RefreshStats {"TableID":104}
       │         ├── AddCheckConstraint {"CheckExpr":"crdb_internal_a_...","ConstraintID":2,"FromHashShardedColumn":true,"TableID":104,"Validity":2}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx.explain_shape
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx.explain_shape
@@ -3,12 +3,12 @@ CREATE TABLE t (a INT NOT NULL, b INT NOT NULL);
 CREATE INDEX idx_b ON t(b);
 
 /* test */
-EXPLAIN (DDL, SHAPE) alter table t add primary key (a);
+EXPLAIN (DDL, SHAPE) alter table t add primary key (a) USING HASH WITH (bucket_count=10);
 ----
-Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ADD PRIMARY KEY (‹a›);
+Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ADD PRIMARY KEY (‹a›) USING HASH WITH ('bucket_count' = ‹10›);
  ├── execute 2 system table mutations transactions
  ├── backfill using primary index t_pkey- in relation t
- │    └── into t_pkey~ (a; rowid-, b)
+ │    └── into t_pkey~ (a, crdb_internal_a_shard_10+; rowid-, b)
  ├── execute 2 system table mutations transactions
  ├── merge temporary indexes into backfilled indexes in relation t
  │    └── from t@[7] into t_pkey~
@@ -16,13 +16,16 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ADD PRIM
  ├── validate UNIQUE constraint backed by index t_pkey~ in relation t
  ├── execute 2 system table mutations transactions
  ├── backfill using primary index t_pkey~ in relation t
- │    ├── into idx_b+ (b: a)
- │    └── into t_pkey+ (a; b)
+ │    ├── into idx_b+ (b: a, crdb_internal_a_shard_10+)
+ │    └── into t_pkey+ (a, crdb_internal_a_shard_10+; b)
  ├── execute 2 system table mutations transactions
  ├── merge temporary indexes into backfilled indexes in relation t
  │    ├── from t@[5] into idx_b+
  │    └── from t@[9] into t_pkey+
  ├── execute 1 system table mutations transaction
  ├── validate UNIQUE constraint backed by index t_pkey+ in relation t
+ ├── validate NOT NULL constraint on column crdb_internal_a_shard_10+ in index t_pkey+ in relation t
  ├── validate UNIQUE constraint backed by index idx_b+ in relation t
- └── execute 4 system table mutations transactions
+ ├── execute 3 system table mutations transactions
+ ├── validate non-index-backed constraint check_crdb_internal_a_shard_10+ in relation t
+ └── execute 2 system table mutations transactions

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx.side_effects
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx.side_effects
@@ -806,7 +806,7 @@ validate CHECK constraint crdb_internal_a_shard_10_auto_not_null in table #104
 validate forward indexes [4] in table #104
 commit transaction #17
 begin transaction #18
-## PostCommitPhase stage 16 of 16 with 11 MutationType ops
+## PostCommitPhase stage 16 of 16 with 12 MutationType ops
 upsert descriptor #104
   ...
        name: rowid_auto_not_null
@@ -837,7 +837,9 @@ upsert descriptor #104
   -    id: 2
   +    id: 4
        interleave: {}
+  +    invisibility: 1
        keyColumnDirections:
+       - ASC
   ...
        - b
        keySuffixColumnIds:
@@ -845,6 +847,7 @@ upsert descriptor #104
   +    - 1
   +    - 4
        name: idx_b
+  +    notVisible: true
        partitioning: {}
        sharded: {}
   +    storeColumnNames: []
@@ -1277,10 +1280,10 @@ upsert descriptor #104
   -  version: "18"
   +  version: "19"
 persist all catalog changes to storage
-update progress of schema change job #1: "PostCommitNonRevertiblePhase stage 2 of 5 with 11 MutationType ops pending"
+update progress of schema change job #1: "PostCommitNonRevertiblePhase stage 2 of 5 with 12 MutationType ops pending"
 commit transaction #19
 begin transaction #20
-## PostCommitNonRevertiblePhase stage 2 of 5 with 13 MutationType ops
+## PostCommitNonRevertiblePhase stage 2 of 5 with 14 MutationType ops
 upsert descriptor #104
    table:
   -  checks: []
@@ -1308,6 +1311,18 @@ upsert descriptor #104
   +    virtual: true
      createAsOfTime:
        wallTime: "1640995200000000000"
+  ...
+       id: 4
+       interleave: {}
+  -    invisibility: 1
+       keyColumnDirections:
+       - ASC
+  ...
+       - 4
+       name: idx_b
+  -    notVisible: true
+       partitioning: {}
+       sharded: {}
   ...
      mutations:
      - column:

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx.side_effects
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx.side_effects
@@ -6,7 +6,7 @@ CREATE INDEX idx_b ON t(b);
 +object {100 101 t} -> 104
 
 /* test */
-alter table t add primary key (a);
+alter table t add primary key (a) USING HASH WITH (bucket_count=10);
 ----
 begin transaction #1
 # begin StatementPhase
@@ -17,11 +17,11 @@ write *eventpb.AlterTable to event log:
   mutationId: 1
   sql:
     descriptorId: 104
-    statement: ALTER TABLE ‹defaultdb›.‹public›.‹t› ADD PRIMARY KEY (‹a›)
+    statement: ALTER TABLE ‹defaultdb›.‹public›.‹t› ADD PRIMARY KEY (‹a›) USING HASH WITH ('bucket_count' = ‹10›)
     tag: ALTER TABLE
     user: root
   tableName: defaultdb.public.t
-## StatementPhase stage 1 of 1 with 12 MutationType ops
+## StatementPhase stage 1 of 1 with 19 MutationType ops
 upsert descriptor #104
    table:
   +  checks:
@@ -59,9 +59,23 @@ upsert descriptor #104
   +    direction: DROP
   +    mutationId: 1
   +    state: WRITE_ONLY
+  +  - column:
+  +      computeExpr: mod(fnv32(md5(crdb_internal.datums_to_bytes(a))), 10:::INT8)
+  +      hidden: true
+  +      id: 4
+  +      name: crdb_internal_a_shard_10
+  +      nullable: true
+  +      type:
+  +        family: IntFamily
+  +        oid: 20
+  +        width: 64
+  +      virtual: true
+  +    direction: ADD
+  +    mutationId: 1
+  +    state: DELETE_ONLY
   +  - direction: ADD
   +    index:
-  +      constraintId: 4
+  +      constraintId: 5
   +      createdExplicitly: true
   +      encodingType: 1
   +      foreignKey: {}
@@ -70,13 +84,21 @@ upsert descriptor #104
   +      interleave: {}
   +      keyColumnDirections:
   +      - ASC
+  +      - ASC
   +      keyColumnIds:
+  +      - 4
   +      - 1
   +      keyColumnNames:
+  +      - crdb_internal_a_shard_10
   +      - a
   +      name: crdb_internal_index_6_name_placeholder
   +      partitioning: {}
-  +      sharded: {}
+  +      sharded:
+  +        columnNames:
+  +        - a
+  +        isSharded: true
+  +        name: crdb_internal_a_shard_10
+  +        shardBuckets: 10
   +      storeColumnIds:
   +      - 3
   +      - 2
@@ -90,7 +112,7 @@ upsert descriptor #104
   +    state: BACKFILLING
   +  - direction: ADD
   +    index:
-  +      constraintId: 5
+  +      constraintId: 6
   +      createdExplicitly: true
   +      encodingType: 1
   +      foreignKey: {}
@@ -99,13 +121,21 @@ upsert descriptor #104
   +      interleave: {}
   +      keyColumnDirections:
   +      - ASC
+  +      - ASC
   +      keyColumnIds:
+  +      - 4
   +      - 1
   +      keyColumnNames:
+  +      - crdb_internal_a_shard_10
   +      - a
   +      name: crdb_internal_index_7_name_placeholder
   +      partitioning: {}
-  +      sharded: {}
+  +      sharded:
+  +        columnNames:
+  +        - a
+  +        isSharded: true
+  +        name: crdb_internal_a_shard_10
+  +        shardBuckets: 10
   +      storeColumnIds:
   +      - 3
   +      - 2
@@ -120,7 +150,7 @@ upsert descriptor #104
   +    state: DELETE_ONLY
   +  - direction: ADD
   +    index:
-  +      constraintId: 6
+  +      constraintId: 7
   +      createdExplicitly: true
   +      encodingType: 1
   +      foreignKey: {}
@@ -129,13 +159,21 @@ upsert descriptor #104
   +      interleave: {}
   +      keyColumnDirections:
   +      - ASC
+  +      - ASC
   +      keyColumnIds:
+  +      - 4
   +      - 1
   +      keyColumnNames:
+  +      - crdb_internal_a_shard_10
   +      - a
   +      name: crdb_internal_index_8_name_placeholder
   +      partitioning: {}
-  +      sharded: {}
+  +      sharded:
+  +        columnNames:
+  +        - a
+  +        isSharded: true
+  +        name: crdb_internal_a_shard_10
+  +        shardBuckets: 10
   +      storeColumnIds:
   +      - 2
   +      storeColumnNames:
@@ -146,9 +184,10 @@ upsert descriptor #104
   +    mutationId: 1
   +    state: BACKFILLING
      name: t
-     nextColumnId: 4
+  -  nextColumnId: 4
   -  nextConstraintId: 2
-  +  nextConstraintId: 7
+  +  nextColumnId: 5
+  +  nextConstraintId: 8
      nextFamilyId: 1
   -  nextIndexId: 4
   +  nextIndexId: 9
@@ -164,7 +203,7 @@ upsert descriptor #104
 ## PreCommitPhase stage 1 of 2 with 1 MutationType op
 undo all catalog changes within txn #1
 persist all catalog changes to storage
-## PreCommitPhase stage 2 of 2 with 17 MutationType ops
+## PreCommitPhase stage 2 of 2 with 24 MutationType ops
 upsert descriptor #104
    table:
   +  checks:
@@ -194,10 +233,13 @@ upsert descriptor #104
   +      columns:
   +        "1": a
   +        "2": b
+  +        "4": crdb_internal_a_shard_10
   +        "4294967292": crdb_internal_origin_timestamp
   +        "4294967293": crdb_internal_origin_id
   +        "4294967294": tableoid
   +        "4294967295": crdb_internal_mvcc_timestamp
+  +      constraints:
+  +        "2": check_crdb_internal_a_shard_10
   +      families:
   +        "0": primary
   +      id: 104
@@ -207,8 +249,8 @@ upsert descriptor #104
   +      name: t
   +    relevantStatements:
   +    - statement:
-  +        redactedStatement: ALTER TABLE ‹defaultdb›.‹public›.‹t› ADD PRIMARY KEY (‹a›)
-  +        statement: ALTER TABLE t ADD PRIMARY KEY (a)
+  +        redactedStatement: ALTER TABLE ‹defaultdb›.‹public›.‹t› ADD PRIMARY KEY (‹a›) USING HASH WITH ('bucket_count' = ‹10›)
+  +        statement: ALTER TABLE t ADD PRIMARY KEY (a) USING HASH WITH ('bucket_count' = 10)
   +        statementTag: ALTER TABLE
   +    revertible: true
   +    targetRanks: <redacted>
@@ -235,9 +277,23 @@ upsert descriptor #104
   +    direction: DROP
   +    mutationId: 1
   +    state: WRITE_ONLY
+  +  - column:
+  +      computeExpr: mod(fnv32(md5(crdb_internal.datums_to_bytes(a))), 10:::INT8)
+  +      hidden: true
+  +      id: 4
+  +      name: crdb_internal_a_shard_10
+  +      nullable: true
+  +      type:
+  +        family: IntFamily
+  +        oid: 20
+  +        width: 64
+  +      virtual: true
+  +    direction: ADD
+  +    mutationId: 1
+  +    state: DELETE_ONLY
   +  - direction: ADD
   +    index:
-  +      constraintId: 4
+  +      constraintId: 5
   +      createdExplicitly: true
   +      encodingType: 1
   +      foreignKey: {}
@@ -246,13 +302,21 @@ upsert descriptor #104
   +      interleave: {}
   +      keyColumnDirections:
   +      - ASC
+  +      - ASC
   +      keyColumnIds:
+  +      - 4
   +      - 1
   +      keyColumnNames:
+  +      - crdb_internal_a_shard_10
   +      - a
   +      name: crdb_internal_index_6_name_placeholder
   +      partitioning: {}
-  +      sharded: {}
+  +      sharded:
+  +        columnNames:
+  +        - a
+  +        isSharded: true
+  +        name: crdb_internal_a_shard_10
+  +        shardBuckets: 10
   +      storeColumnIds:
   +      - 3
   +      - 2
@@ -266,7 +330,7 @@ upsert descriptor #104
   +    state: BACKFILLING
   +  - direction: ADD
   +    index:
-  +      constraintId: 5
+  +      constraintId: 6
   +      createdExplicitly: true
   +      encodingType: 1
   +      foreignKey: {}
@@ -275,13 +339,21 @@ upsert descriptor #104
   +      interleave: {}
   +      keyColumnDirections:
   +      - ASC
+  +      - ASC
   +      keyColumnIds:
+  +      - 4
   +      - 1
   +      keyColumnNames:
+  +      - crdb_internal_a_shard_10
   +      - a
   +      name: crdb_internal_index_7_name_placeholder
   +      partitioning: {}
-  +      sharded: {}
+  +      sharded:
+  +        columnNames:
+  +        - a
+  +        isSharded: true
+  +        name: crdb_internal_a_shard_10
+  +        shardBuckets: 10
   +      storeColumnIds:
   +      - 3
   +      - 2
@@ -296,7 +368,7 @@ upsert descriptor #104
   +    state: DELETE_ONLY
   +  - direction: ADD
   +    index:
-  +      constraintId: 6
+  +      constraintId: 7
   +      createdExplicitly: true
   +      encodingType: 1
   +      foreignKey: {}
@@ -305,13 +377,21 @@ upsert descriptor #104
   +      interleave: {}
   +      keyColumnDirections:
   +      - ASC
+  +      - ASC
   +      keyColumnIds:
+  +      - 4
   +      - 1
   +      keyColumnNames:
+  +      - crdb_internal_a_shard_10
   +      - a
   +      name: crdb_internal_index_8_name_placeholder
   +      partitioning: {}
-  +      sharded: {}
+  +      sharded:
+  +        columnNames:
+  +        - a
+  +        isSharded: true
+  +        name: crdb_internal_a_shard_10
+  +        shardBuckets: 10
   +      storeColumnIds:
   +      - 2
   +      storeColumnNames:
@@ -322,9 +402,10 @@ upsert descriptor #104
   +    mutationId: 1
   +    state: BACKFILLING
      name: t
-     nextColumnId: 4
+  -  nextColumnId: 4
   -  nextConstraintId: 2
-  +  nextConstraintId: 7
+  +  nextColumnId: 5
+  +  nextConstraintId: 8
      nextFamilyId: 1
   -  nextIndexId: 4
   +  nextIndexId: 9
@@ -336,7 +417,7 @@ upsert descriptor #104
   -  version: "7"
   +  version: "8"
 persist all catalog changes to storage
-create job #1 (non-cancelable: false): "ALTER TABLE defaultdb.public.t ADD PRIMARY KEY (a)"
+create job #1 (non-cancelable: false): "ALTER TABLE defaultdb.public.t ADD PRIMARY KEY (a) USING HASH WITH ('bucket_count' = 10)"
   descriptor IDs: [104]
 # end PreCommitPhase
 commit transaction #1
@@ -345,8 +426,26 @@ notified job registry to adopt jobs: [1]
 begin transaction #2
 commit transaction #2
 begin transaction #3
-## PostCommitPhase stage 1 of 15 with 3 MutationType ops
+## PostCommitPhase stage 1 of 16 with 5 MutationType ops
 upsert descriptor #104
+  ...
+       name: rowid_auto_not_null
+       validity: Dropping
+  +  - columnIds:
+  +    - 4
+  +    expr: crdb_internal_a_shard_10 IS NOT NULL
+  +    isNonNullConstraint: true
+  +    name: crdb_internal_a_shard_10_auto_not_null
+  +    validity: Validating
+     columns:
+     - id: 1
+  ...
+       direction: ADD
+       mutationId: 1
+  -    state: DELETE_ONLY
+  +    state: WRITE_ONLY
+     - direction: ADD
+       index:
   ...
          version: 4
        mutationId: 1
@@ -355,19 +454,40 @@ upsert descriptor #104
      - direction: ADD
        index:
   ...
+       mutationId: 1
+       state: BACKFILLING
+  +  - constraint:
+  +      check:
+  +        columnIds:
+  +        - 4
+  +        expr: crdb_internal_a_shard_10 IS NOT NULL
+  +        isNonNullConstraint: true
+  +        name: crdb_internal_a_shard_10_auto_not_null
+  +        validity: Validating
+  +      constraintType: NOT_NULL
+  +      foreignKey: {}
+  +      name: crdb_internal_a_shard_10_auto_not_null
+  +      notNullColumn: 4
+  +      uniqueWithoutIndexConstraint: {}
+  +    direction: ADD
+  +    mutationId: 1
+  +    state: WRITE_ONLY
+     name: t
+     nextColumnId: 5
+  ...
        time: {}
      unexposedParentSchemaId: 101
   -  version: "8"
   +  version: "9"
 persist all catalog changes to storage
-update progress of schema change job #1: "PostCommitPhase stage 2 of 15 with 1 BackfillType op pending"
+update progress of schema change job #1: "PostCommitPhase stage 2 of 16 with 1 BackfillType op pending"
 commit transaction #3
 begin transaction #4
-## PostCommitPhase stage 2 of 15 with 1 BackfillType op
+## PostCommitPhase stage 2 of 16 with 1 BackfillType op
 backfill indexes [6] from index #1 in table #104
 commit transaction #4
 begin transaction #5
-## PostCommitPhase stage 3 of 15 with 3 MutationType ops
+## PostCommitPhase stage 3 of 16 with 3 MutationType ops
 upsert descriptor #104
   ...
          version: 4
@@ -382,10 +502,10 @@ upsert descriptor #104
   -  version: "9"
   +  version: "10"
 persist all catalog changes to storage
-update progress of schema change job #1: "PostCommitPhase stage 4 of 15 with 1 MutationType op pending"
+update progress of schema change job #1: "PostCommitPhase stage 4 of 16 with 1 MutationType op pending"
 commit transaction #5
 begin transaction #6
-## PostCommitPhase stage 4 of 15 with 3 MutationType ops
+## PostCommitPhase stage 4 of 16 with 3 MutationType ops
 upsert descriptor #104
   ...
          version: 4
@@ -400,14 +520,14 @@ upsert descriptor #104
   -  version: "10"
   +  version: "11"
 persist all catalog changes to storage
-update progress of schema change job #1: "PostCommitPhase stage 5 of 15 with 1 BackfillType op pending"
+update progress of schema change job #1: "PostCommitPhase stage 5 of 16 with 1 BackfillType op pending"
 commit transaction #6
 begin transaction #7
-## PostCommitPhase stage 5 of 15 with 1 BackfillType op
+## PostCommitPhase stage 5 of 16 with 1 BackfillType op
 merge temporary indexes [7] into backfilled indexes [6] in table #104
 commit transaction #7
 begin transaction #8
-## PostCommitPhase stage 6 of 15 with 4 MutationType ops
+## PostCommitPhase stage 6 of 16 with 4 MutationType ops
 upsert descriptor #104
   ...
          version: 4
@@ -417,7 +537,7 @@ upsert descriptor #104
   +    state: WRITE_ONLY
   +  - direction: DROP
        index:
-         constraintId: 5
+         constraintId: 6
   ...
          version: 4
        mutationId: 1
@@ -431,138 +551,57 @@ upsert descriptor #104
   -  version: "11"
   +  version: "12"
 persist all catalog changes to storage
-update progress of schema change job #1: "PostCommitPhase stage 7 of 15 with 1 ValidationType op pending"
+update progress of schema change job #1: "PostCommitPhase stage 7 of 16 with 1 ValidationType op pending"
 commit transaction #8
 begin transaction #9
-## PostCommitPhase stage 7 of 15 with 1 ValidationType op
+## PostCommitPhase stage 7 of 16 with 1 ValidationType op
 validate forward indexes [6] in table #104
 commit transaction #9
 begin transaction #10
-## PostCommitPhase stage 8 of 15 with 18 MutationType ops
+## PostCommitPhase stage 8 of 16 with 17 MutationType ops
 upsert descriptor #104
   ...
        mutationId: 1
        state: WRITE_ONLY
-  -  - direction: ADD
-  +  - direction: DROP
-       index:
-  -      constraintId: 4
-  +      constraintId: 5
-         createdExplicitly: true
-         encodingType: 1
-         foreignKey: {}
-         geoConfig: {}
-  -      id: 6
-  +      id: 7
-         interleave: {}
-         keyColumnDirections:
-  ...
-         keyColumnNames:
-         - a
-  -      name: crdb_internal_index_6_name_placeholder
-  +      name: crdb_internal_index_7_name_placeholder
-         partitioning: {}
-         sharded: {}
-  ...
-         - b
-         unique: true
-  +      useDeletePreservingEncoding: true
-         vecConfig: {}
-         version: 4
-       mutationId: 1
-  -    state: WRITE_ONLY
-  -  - direction: DROP
-  +    state: DELETE_ONLY
   +  - direction: ADD
-       index:
-  -      constraintId: 5
-  +      constraintId: 6
-         createdExplicitly: true
-         encodingType: 1
-         foreignKey: {}
-         geoConfig: {}
-  -      id: 7
-  +      id: 8
-         interleave: {}
-         keyColumnDirections:
-  ...
-         keyColumnNames:
-         - a
-  -      name: crdb_internal_index_7_name_placeholder
-  +      name: crdb_internal_index_8_name_placeholder
-         partitioning: {}
-         sharded: {}
-         storeColumnIds:
-  -      - 3
-         - 2
-         storeColumnNames:
-  +      - b
-  +      unique: true
-  +      vecConfig: {}
-  +      version: 4
-  +    mutationId: 1
-  +    state: BACKFILLING
-  +  - direction: DROP
   +    index:
-  +      constraintId: 1
-  +      createdAtNanos: "1640995200000000000"
+  +      constraintId: 8
+  +      createdExplicitly: true
   +      encodingType: 1
   +      foreignKey: {}
   +      geoConfig: {}
-  +      id: 1
+  +      id: 9
   +      interleave: {}
   +      keyColumnDirections:
   +      - ASC
+  +      - ASC
   +      keyColumnIds:
-  +      - 3
-  +      keyColumnNames:
-         - rowid
-  +      name: crdb_internal_index_1_name_placeholder
-  +      partitioning: {}
-  +      sharded: {}
-  +      storeColumnIds:
+  +      - 4
   +      - 1
+  +      keyColumnNames:
+  +      - crdb_internal_a_shard_10
+  +      - a
+  +      name: crdb_internal_index_9_name_placeholder
+  +      partitioning: {}
+  +      sharded:
+  +        columnNames:
+  +        - a
+  +        isSharded: true
+  +        name: crdb_internal_a_shard_10
+  +        shardBuckets: 10
+  +      storeColumnIds:
   +      - 2
   +      storeColumnNames:
-  +      - a
-         - b
-         unique: true
-  -      useDeletePreservingEncoding: true
-         vecConfig: {}
-         version: 4
-       mutationId: 1
-  -    state: DELETE_ONLY
-  +    state: WRITE_ONLY
-     - direction: ADD
-       index:
-  -      constraintId: 6
-  +      constraintId: 7
-         createdExplicitly: true
-         encodingType: 1
-         foreignKey: {}
-         geoConfig: {}
-  -      id: 8
-  +      id: 9
-         interleave: {}
-         keyColumnDirections:
-  ...
-         keyColumnNames:
-         - a
-  -      name: crdb_internal_index_8_name_placeholder
-  +      name: crdb_internal_index_9_name_placeholder
-         partitioning: {}
-         sharded: {}
-  ...
-         - b
-         unique: true
+  +      - b
+  +      unique: true
   +      useDeletePreservingEncoding: true
-         vecConfig: {}
-         version: 4
-       mutationId: 1
+  +      vecConfig: {}
+  +      version: 4
+  +    mutationId: 1
   +    state: DELETE_ONLY
   +  - direction: ADD
   +    index:
-  +      constraintId: 2
+  +      constraintId: 3
   +      createdAtNanos: "1640998800000000000"
   +      createdExplicitly: true
   +      foreignKey: {}
@@ -577,6 +616,7 @@ upsert descriptor #104
   +      - b
   +      keySuffixColumnIds:
   +      - 1
+  +      - 4
   +      name: crdb_internal_index_4_name_placeholder
   +      partitioning: {}
   +      sharded: {}
@@ -584,10 +624,10 @@ upsert descriptor #104
   +      vecConfig: {}
   +      version: 4
   +    mutationId: 1
-       state: BACKFILLING
+  +    state: BACKFILLING
   +  - direction: ADD
   +    index:
-  +      constraintId: 3
+  +      constraintId: 4
   +      createdExplicitly: true
   +      foreignKey: {}
   +      geoConfig: {}
@@ -601,6 +641,7 @@ upsert descriptor #104
   +      - b
   +      keySuffixColumnIds:
   +      - 1
+  +      - 4
   +      name: crdb_internal_index_5_name_placeholder
   +      partitioning: {}
   +      sharded: {}
@@ -611,55 +652,24 @@ upsert descriptor #104
   +    mutationId: 1
   +    state: DELETE_ONLY
      name: t
-     nextColumnId: 4
-  -  nextConstraintId: 7
-  +  nextConstraintId: 8
+     nextColumnId: 5
+  -  nextConstraintId: 8
+  +  nextConstraintId: 9
      nextFamilyId: 1
   -  nextIndexId: 9
   +  nextIndexId: 10
      nextMutationId: 1
      parentId: 100
-     primaryIndex:
-  -    constraintId: 1
-  -    createdAtNanos: "1640995200000000000"
-  +    constraintId: 4
-  +    createdExplicitly: true
-       encodingType: 1
-       foreignKey: {}
-       geoConfig: {}
-  -    id: 1
-  +    id: 6
-       interleave: {}
-       keyColumnDirections:
-       - ASC
-       keyColumnIds:
-  -    - 3
-  +    - 1
-       keyColumnNames:
-  -    - rowid
-  +    - a
-       name: t_pkey
-       partitioning: {}
-       sharded: {}
-       storeColumnIds:
-  -    - 1
-  +    - 3
-       - 2
-       storeColumnNames:
-  -    - a
-  +    - rowid
-       - b
-       unique: true
   ...
        time: {}
      unexposedParentSchemaId: 101
   -  version: "12"
   +  version: "13"
 persist all catalog changes to storage
-update progress of schema change job #1: "PostCommitPhase stage 9 of 15 with 2 MutationType ops pending"
+update progress of schema change job #1: "PostCommitPhase stage 9 of 16 with 2 MutationType ops pending"
 commit transaction #10
 begin transaction #11
-## PostCommitPhase stage 9 of 15 with 4 MutationType ops
+## PostCommitPhase stage 9 of 16 with 4 MutationType ops
 upsert descriptor #104
   ...
          version: 4
@@ -674,29 +684,29 @@ upsert descriptor #104
   -    state: DELETE_ONLY
   +    state: WRITE_ONLY
      name: t
-     nextColumnId: 4
+     nextColumnId: 5
   ...
        time: {}
      unexposedParentSchemaId: 101
   -  version: "13"
   +  version: "14"
 persist all catalog changes to storage
-update progress of schema change job #1: "PostCommitPhase stage 10 of 15 with 2 BackfillType ops pending"
+update progress of schema change job #1: "PostCommitPhase stage 10 of 16 with 2 BackfillType ops pending"
 commit transaction #11
 begin transaction #12
-## PostCommitPhase stage 10 of 15 with 2 BackfillType ops
+## PostCommitPhase stage 10 of 16 with 2 BackfillType ops
 backfill indexes [4 8] from index #6 in table #104
 commit transaction #12
 begin transaction #13
-## PostCommitPhase stage 11 of 15 with 4 MutationType ops
+## PostCommitPhase stage 11 of 16 with 4 MutationType ops
 upsert descriptor #104
   ...
          version: 4
        mutationId: 1
   -    state: BACKFILLING
   +    state: DELETE_ONLY
-     - direction: DROP
-       index:
+     - constraint:
+         check:
   ...
          version: 4
        mutationId: 1
@@ -710,18 +720,18 @@ upsert descriptor #104
   -  version: "14"
   +  version: "15"
 persist all catalog changes to storage
-update progress of schema change job #1: "PostCommitPhase stage 12 of 15 with 2 MutationType ops pending"
+update progress of schema change job #1: "PostCommitPhase stage 12 of 16 with 2 MutationType ops pending"
 commit transaction #13
 begin transaction #14
-## PostCommitPhase stage 12 of 15 with 4 MutationType ops
+## PostCommitPhase stage 12 of 16 with 4 MutationType ops
 upsert descriptor #104
   ...
          version: 4
        mutationId: 1
   -    state: DELETE_ONLY
   +    state: MERGING
-     - direction: DROP
-       index:
+     - constraint:
+         check:
   ...
          version: 4
        mutationId: 1
@@ -735,29 +745,29 @@ upsert descriptor #104
   -  version: "15"
   +  version: "16"
 persist all catalog changes to storage
-update progress of schema change job #1: "PostCommitPhase stage 13 of 15 with 2 BackfillType ops pending"
+update progress of schema change job #1: "PostCommitPhase stage 13 of 16 with 2 BackfillType ops pending"
 commit transaction #14
 begin transaction #15
-## PostCommitPhase stage 13 of 15 with 2 BackfillType ops
+## PostCommitPhase stage 13 of 16 with 2 BackfillType ops
 merge temporary indexes [5 9] into backfilled indexes [4 8] in table #104
 commit transaction #15
 begin transaction #16
-## PostCommitPhase stage 14 of 15 with 6 MutationType ops
+## PostCommitPhase stage 14 of 16 with 6 MutationType ops
 upsert descriptor #104
   ...
          version: 4
        mutationId: 1
   -    state: MERGING
   +    state: WRITE_ONLY
-     - direction: DROP
-       index:
+     - constraint:
+         check:
   ...
        mutationId: 1
        state: WRITE_ONLY
   -  - direction: ADD
   +  - direction: DROP
        index:
-         constraintId: 7
+         constraintId: 8
   ...
          version: 4
        mutationId: 1
@@ -773,29 +783,284 @@ upsert descriptor #104
   +    state: WRITE_ONLY
   +  - direction: DROP
        index:
-         constraintId: 3
+         constraintId: 4
   ...
          version: 4
        mutationId: 1
   -    state: WRITE_ONLY
   +    state: DELETE_ONLY
      name: t
-     nextColumnId: 4
+     nextColumnId: 5
   ...
        time: {}
      unexposedParentSchemaId: 101
   -  version: "16"
   +  version: "17"
 persist all catalog changes to storage
-update progress of schema change job #1: "PostCommitPhase stage 15 of 15 with 2 ValidationType ops pending"
+update progress of schema change job #1: "PostCommitPhase stage 15 of 16 with 3 ValidationType ops pending"
 commit transaction #16
 begin transaction #17
-## PostCommitPhase stage 15 of 15 with 2 ValidationType ops
+## PostCommitPhase stage 15 of 16 with 3 ValidationType ops
 validate forward indexes [8] in table #104
+validate CHECK constraint crdb_internal_a_shard_10_auto_not_null in table #104
 validate forward indexes [4] in table #104
 commit transaction #17
 begin transaction #18
-## PostCommitNonRevertiblePhase stage 1 of 4 with 23 MutationType ops
+## PostCommitPhase stage 16 of 16 with 11 MutationType ops
+upsert descriptor #104
+  ...
+       name: rowid_auto_not_null
+       validity: Dropping
+  -  - columnIds:
+  -    - 4
+  -    expr: crdb_internal_a_shard_10 IS NOT NULL
+  -    isNonNullConstraint: true
+  -    name: crdb_internal_a_shard_10_auto_not_null
+  -    validity: Validating
+     columns:
+     - id: 1
+  ...
+           statement: ALTER TABLE t ADD PRIMARY KEY (a) USING HASH WITH ('bucket_count' = 10)
+           statementTag: ALTER TABLE
+  -    revertible: true
+       targetRanks: <redacted>
+       targets: <redacted>
+  ...
+     id: 104
+     indexes:
+  -  - createdAtNanos: "1640995200000000000"
+  +  - constraintId: 3
+  +    createdAtNanos: "1640998800000000000"
+       createdExplicitly: true
+       foreignKey: {}
+       geoConfig: {}
+  -    id: 2
+  +    id: 4
+       interleave: {}
+       keyColumnDirections:
+  ...
+       - b
+       keySuffixColumnIds:
+  -    - 3
+  +    - 1
+  +    - 4
+       name: idx_b
+       partitioning: {}
+       sharded: {}
+  +    storeColumnNames: []
+       vecConfig: {}
+       version: 4
+  ...
+         id: 4
+         name: crdb_internal_a_shard_10
+  -      nullable: true
+         type:
+           family: IntFamily
+  ...
+       mutationId: 1
+       state: WRITE_ONLY
+  -  - direction: ADD
+  -    index:
+  -      constraintId: 5
+  -      createdExplicitly: true
+  -      encodingType: 1
+  -      foreignKey: {}
+  -      geoConfig: {}
+  -      id: 6
+  -      interleave: {}
+  -      keyColumnDirections:
+  -      - ASC
+  -      - ASC
+  -      keyColumnIds:
+  -      - 4
+  -      - 1
+  -      keyColumnNames:
+  -      - crdb_internal_a_shard_10
+  -      - a
+  -      name: crdb_internal_index_6_name_placeholder
+  -      partitioning: {}
+  -      sharded:
+  -        columnNames:
+  -        - a
+  -        isSharded: true
+  -        name: crdb_internal_a_shard_10
+  -        shardBuckets: 10
+  -      storeColumnIds:
+  -      - 3
+  -      - 2
+  -      storeColumnNames:
+  -      - rowid
+  -      - b
+  -      unique: true
+  -      vecConfig: {}
+  -      version: 4
+  -    mutationId: 1
+  -    state: WRITE_ONLY
+     - direction: DROP
+       index:
+  ...
+       mutationId: 1
+       state: WRITE_ONLY
+  -  - constraint:
+  -      check:
+  -        columnIds:
+  -        - 4
+  -        expr: crdb_internal_a_shard_10 IS NOT NULL
+  -        isNonNullConstraint: true
+  -        name: crdb_internal_a_shard_10_auto_not_null
+  -        validity: Validating
+  -      constraintType: NOT_NULL
+  -      foreignKey: {}
+  -      name: crdb_internal_a_shard_10_auto_not_null
+  -      notNullColumn: 4
+  -      uniqueWithoutIndexConstraint: {}
+  -    direction: ADD
+  -    mutationId: 1
+  -    state: WRITE_ONLY
+     - direction: DROP
+       index:
+  ...
+       mutationId: 1
+       state: DELETE_ONLY
+  -  - direction: ADD
+  +  - direction: DROP
+       index:
+  -      constraintId: 3
+  -      createdAtNanos: "1640998800000000000"
+  +      constraintId: 4
+         createdExplicitly: true
+         foreignKey: {}
+         geoConfig: {}
+  -      id: 4
+  +      id: 5
+         interleave: {}
+         keyColumnDirections:
+  ...
+         - 1
+         - 4
+  -      name: crdb_internal_index_4_name_placeholder
+  +      name: crdb_internal_index_5_name_placeholder
+         partitioning: {}
+         sharded: {}
+         storeColumnNames: []
+  +      useDeletePreservingEncoding: true
+         vecConfig: {}
+         version: 4
+       mutationId: 1
+  +    state: DELETE_ONLY
+  +  - direction: DROP
+  +    index:
+  +      constraintId: 1
+  +      createdAtNanos: "1640995200000000000"
+  +      encodingType: 1
+  +      foreignKey: {}
+  +      geoConfig: {}
+  +      id: 1
+  +      interleave: {}
+  +      keyColumnDirections:
+  +      - ASC
+  +      keyColumnIds:
+  +      - 3
+  +      keyColumnNames:
+  +      - rowid
+  +      name: crdb_internal_index_1_name_placeholder
+  +      partitioning: {}
+  +      sharded: {}
+  +      storeColumnIds:
+  +      - 1
+  +      - 2
+  +      storeColumnNames:
+  +      - a
+  +      - b
+  +      unique: true
+  +      vecConfig: {}
+  +      version: 4
+  +    mutationId: 1
+       state: WRITE_ONLY
+     - direction: DROP
+       index:
+  -      constraintId: 4
+  +      createdAtNanos: "1640995200000000000"
+         createdExplicitly: true
+         foreignKey: {}
+         geoConfig: {}
+  -      id: 5
+  +      id: 2
+         interleave: {}
+         keyColumnDirections:
+  ...
+         - b
+         keySuffixColumnIds:
+  -      - 1
+  -      - 4
+  -      name: crdb_internal_index_5_name_placeholder
+  +      - 3
+  +      name: idx_b
+         partitioning: {}
+         sharded: {}
+  -      storeColumnNames: []
+  -      useDeletePreservingEncoding: true
+         vecConfig: {}
+         version: 4
+       mutationId: 1
+  -    state: DELETE_ONLY
+  +    state: WRITE_ONLY
+     name: t
+     nextColumnId: 5
+  ...
+     parentId: 100
+     primaryIndex:
+  -    constraintId: 1
+  -    createdAtNanos: "1640995200000000000"
+  +    constraintId: 5
+  +    createdExplicitly: true
+       encodingType: 1
+       foreignKey: {}
+       geoConfig: {}
+  -    id: 1
+  +    id: 6
+       interleave: {}
+       keyColumnDirections:
+       - ASC
+  +    - ASC
+       keyColumnIds:
+  -    - 3
+  +    - 4
+  +    - 1
+       keyColumnNames:
+  -    - rowid
+  +    - crdb_internal_a_shard_10
+  +    - a
+       name: t_pkey
+       partitioning: {}
+  -    sharded: {}
+  +    sharded:
+  +      columnNames:
+  +      - a
+  +      isSharded: true
+  +      name: crdb_internal_a_shard_10
+  +      shardBuckets: 10
+       storeColumnIds:
+  -    - 1
+  +    - 3
+       - 2
+       storeColumnNames:
+  -    - a
+  +    - rowid
+       - b
+       unique: true
+  ...
+       time: {}
+     unexposedParentSchemaId: 101
+  -  version: "17"
+  +  version: "18"
+persist all catalog changes to storage
+adding table for stats refresh: 104
+update progress of schema change job #1: "PostCommitNonRevertiblePhase stage 1 of 5 with 23 MutationType ops pending"
+set schema change job #1 to non-cancellable
+commit transaction #18
+begin transaction #19
+## PostCommitNonRevertiblePhase stage 1 of 5 with 25 MutationType ops
 upsert descriptor #104
    table:
   -  checks:
@@ -823,41 +1088,13 @@ upsert descriptor #104
      createAsOfTime:
        wallTime: "1640995200000000000"
   ...
-           statement: ALTER TABLE t ADD PRIMARY KEY (a)
-           statementTag: ALTER TABLE
-  -    revertible: true
-       targetRanks: <redacted>
-       targets: <redacted>
-  ...
        - a
        - b
   -    - rowid
   +    - crdb_internal_column_3_name_placeholder
        name: primary
      formatVersion: 3
-     id: 104
-     indexes:
-  -  - createdAtNanos: "1640995200000000000"
-  +  - constraintId: 2
-  +    createdAtNanos: "1640998800000000000"
-       createdExplicitly: true
-       foreignKey: {}
-       geoConfig: {}
-  -    id: 2
-  +    id: 4
-       interleave: {}
-       keyColumnDirections:
   ...
-       - b
-       keySuffixColumnIds:
-  -    - 3
-  +    - 1
-       name: idx_b
-       partitioning: {}
-       sharded: {}
-  +    storeColumnNames: []
-       vecConfig: {}
-       version: 4
      modificationTime: {}
      mutations:
   -  - constraint:
@@ -876,9 +1113,14 @@ upsert descriptor #104
   -    direction: DROP
   -    mutationId: 1
   -    state: WRITE_ONLY
+     - column:
+         computeExpr: mod(fnv32(md5(crdb_internal.datums_to_bytes(a))), 10:::INT8)
+  ...
+       mutationId: 1
+       state: WRITE_ONLY
   -  - direction: DROP
   -    index:
-  -      constraintId: 5
+  -      constraintId: 6
   -      createdExplicitly: true
   -      encodingType: 1
   -      foreignKey: {}
@@ -887,13 +1129,21 @@ upsert descriptor #104
   -      interleave: {}
   -      keyColumnDirections:
   -      - ASC
+  -      - ASC
   -      keyColumnIds:
+  -      - 4
   -      - 1
   -      keyColumnNames:
+  -      - crdb_internal_a_shard_10
   -      - a
   -      name: crdb_internal_index_7_name_placeholder
   -      partitioning: {}
-  -      sharded: {}
+  -      sharded:
+  -        columnNames:
+  -        - a
+  -        isSharded: true
+  -        name: crdb_internal_a_shard_10
+  -        shardBuckets: 10
   -      storeColumnIds:
   -      - 3
   -      - 2
@@ -909,39 +1159,34 @@ upsert descriptor #104
      - direction: ADD
        index:
   ...
-         - 3
-         keyColumnNames:
-  -      - rowid
-  +      - crdb_internal_column_3_name_placeholder
-         name: crdb_internal_index_1_name_placeholder
-         partitioning: {}
-  ...
-         version: 4
-       mutationId: 1
-  -    state: WRITE_ONLY
-  +    state: DELETE_ONLY
      - direction: DROP
        index:
-  -      constraintId: 7
-  +      createdAtNanos: "1640995200000000000"
-         createdExplicitly: true
+  -      constraintId: 8
+  -      createdExplicitly: true
   -      encodingType: 1
-         foreignKey: {}
-         geoConfig: {}
+  -      foreignKey: {}
+  -      geoConfig: {}
   -      id: 9
-  +      id: 2
-         interleave: {}
-         keyColumnDirections:
-         - ASC
-         keyColumnIds:
+  -      interleave: {}
+  -      keyColumnDirections:
+  -      - ASC
+  -      - ASC
+  -      keyColumnIds:
+  -      - 4
   -      - 1
   -      keyColumnNames:
+  -      - crdb_internal_a_shard_10
   -      - a
   -      name: crdb_internal_index_9_name_placeholder
   -      partitioning: {}
-  -      sharded: {}
+  -      sharded:
+  -        columnNames:
+  -        - a
+  -        isSharded: true
+  -        name: crdb_internal_a_shard_10
+  -        shardBuckets: 10
   -      storeColumnIds:
-         - 2
+  -      - 2
   -      storeColumnNames:
   -      - b
   -      unique: true
@@ -950,36 +1195,9 @@ upsert descriptor #104
   -      version: 4
   -    mutationId: 1
   -    state: DELETE_ONLY
-  -  - direction: ADD
-  -    index:
-  -      constraintId: 2
-  -      createdAtNanos: "1640998800000000000"
-  -      createdExplicitly: true
-  -      foreignKey: {}
-  -      geoConfig: {}
-  -      id: 4
-  -      interleave: {}
-  -      keyColumnDirections:
-  -      - ASC
-  -      keyColumnIds:
-  -      - 2
-         keyColumnNames:
-         - b
-         keySuffixColumnIds:
-  -      - 1
-  -      name: crdb_internal_index_4_name_placeholder
-  +      - 3
-  +      name: idx_b
-         partitioning: {}
-         sharded: {}
-  -      storeColumnNames: []
-         vecConfig: {}
-         version: 4
-       mutationId: 1
-       state: WRITE_ONLY
   -  - direction: DROP
   -    index:
-  -      constraintId: 3
+  -      constraintId: 4
   -      createdExplicitly: true
   -      foreignKey: {}
   -      geoConfig: {}
@@ -993,6 +1211,7 @@ upsert descriptor #104
   -      - b
   -      keySuffixColumnIds:
   -      - 1
+  -      - 4
   -      name: crdb_internal_index_5_name_placeholder
   -      partitioning: {}
   -      sharded: {}
@@ -1000,80 +1219,36 @@ upsert descriptor #104
   -      useDeletePreservingEncoding: true
   -      vecConfig: {}
   -      version: 4
-  +  - column:
-  +      defaultExpr: unique_rowid()
-  +      hidden: true
-  +      id: 3
-  +      name: crdb_internal_column_3_name_placeholder
-  +      nullable: true
-  +      type:
-  +        family: IntFamily
-  +        oid: 20
-  +        width: 64
-  +    direction: DROP
-       mutationId: 1
+  -    mutationId: 1
   -    state: DELETE_ONLY
-  +    state: WRITE_ONLY
-     name: t
-     nextColumnId: 4
+  -  - direction: DROP
+  -    index:
+         constraintId: 1
+         createdAtNanos: "1640995200000000000"
   ...
-       - 2
-       storeColumnNames:
-  -    - rowid
-  +    - crdb_internal_column_3_name_placeholder
-       - b
-       unique: true
-  ...
-       time: {}
-     unexposedParentSchemaId: 101
-  -  version: "17"
-  +  version: "18"
-persist all catalog changes to storage
-adding table for stats refresh: 104
-update progress of schema change job #1: "PostCommitNonRevertiblePhase stage 2 of 4 with 10 MutationType ops pending"
-set schema change job #1 to non-cancellable
-commit transaction #18
-begin transaction #19
-## PostCommitNonRevertiblePhase stage 2 of 4 with 12 MutationType ops
-upsert descriptor #104
-  ...
-     modificationTime: {}
-     mutations:
-  -  - direction: ADD
-  +  - direction: DROP
-       index:
-  -      constraintId: 6
-  +      createdAtNanos: "1640995200000000000"
-         createdExplicitly: true
-  -      encodingType: 1
-         foreignKey: {}
-         geoConfig: {}
-  -      id: 8
-  +      id: 2
-         interleave: {}
-         keyColumnDirections:
-         - ASC
-         keyColumnIds:
-  -      - 1
-  +      - 2
+         - 3
          keyColumnNames:
-  -      - a
-  -      name: crdb_internal_index_8_name_placeholder
-  +      - b
-  +      keySuffixColumnIds:
-  +      - 3
-  +      name: crdb_internal_index_2_name_placeholder
+  -      - rowid
+  +      - crdb_internal_column_3_name_placeholder
+         name: crdb_internal_index_1_name_placeholder
          partitioning: {}
-         sharded: {}
-  -      storeColumnIds:
-  -      - 2
-  -      storeColumnNames:
-  -      - b
-  -      unique: true
-         vecConfig: {}
+  ...
          version: 4
        mutationId: 1
   -    state: WRITE_ONLY
+  +    state: DELETE_ONLY
+     - direction: DROP
+       index:
+  ...
+         keySuffixColumnIds:
+         - 3
+  -      name: idx_b
+  +      name: crdb_internal_index_2_name_placeholder
+         partitioning: {}
+         sharded: {}
+  ...
+         version: 4
+       mutationId: 1
   +    state: DELETE_ONLY
   +  - column:
   +      defaultExpr: unique_rowid()
@@ -1087,102 +1262,13 @@ upsert descriptor #104
   +        width: 64
   +    direction: DROP
   +    mutationId: 1
-  +    state: DELETE_ONLY
-     - direction: DROP
-       index:
-  -      constraintId: 1
-  -      createdAtNanos: "1640995200000000000"
-  +      constraintId: 4
-  +      createdExplicitly: true
-         encodingType: 1
-         foreignKey: {}
-         geoConfig: {}
-  -      id: 1
-  +      id: 6
-         interleave: {}
-         keyColumnDirections:
-         - ASC
-         keyColumnIds:
-  -      - 3
-  +      - 1
-         keyColumnNames:
-  -      - crdb_internal_column_3_name_placeholder
-  -      name: crdb_internal_index_1_name_placeholder
-  +      - a
-  +      name: crdb_internal_index_6_name_placeholder
-         partitioning: {}
-         sharded: {}
-         storeColumnIds:
-  -      - 1
-  +      - 3
-         - 2
-         storeColumnNames:
-  -      - a
-  +      - crdb_internal_column_3_name_placeholder
-         - b
-         unique: true
-  ...
-         version: 4
-       mutationId: 1
-  -    state: DELETE_ONLY
-  -  - direction: DROP
-  -    index:
-  -      createdAtNanos: "1640995200000000000"
-  -      createdExplicitly: true
-  -      foreignKey: {}
-  -      geoConfig: {}
-  -      id: 2
-  -      interleave: {}
-  -      keyColumnDirections:
-  -      - ASC
-  -      keyColumnIds:
-  -      - 2
-  -      keyColumnNames:
-  -      - b
-  -      keySuffixColumnIds:
-  -      - 3
-  -      name: idx_b
-  -      partitioning: {}
-  -      sharded: {}
-  -      vecConfig: {}
-  -      version: 4
-  -    mutationId: 1
        state: WRITE_ONLY
-  -  - column:
-  -      defaultExpr: unique_rowid()
-  -      hidden: true
-  -      id: 3
-  -      name: crdb_internal_column_3_name_placeholder
-  -      nullable: true
-  -      type:
-  -        family: IntFamily
-  -        oid: 20
-  -        width: 64
-  -    direction: DROP
-  -    mutationId: 1
-  -    state: WRITE_ONLY
      name: t
-     nextColumnId: 4
   ...
-     parentId: 100
-     primaryIndex:
-  -    constraintId: 4
-  +    constraintId: 6
-       createdExplicitly: true
-       encodingType: 1
-       foreignKey: {}
-       geoConfig: {}
-  -    id: 6
-  +    id: 8
-       interleave: {}
-       keyColumnDirections:
-  ...
-       sharded: {}
-       storeColumnIds:
-  -    - 3
        - 2
        storeColumnNames:
-  -    - crdb_internal_column_3_name_placeholder
+  -    - rowid
+  +    - crdb_internal_column_3_name_placeholder
        - b
        unique: true
   ...
@@ -1191,14 +1277,131 @@ upsert descriptor #104
   -  version: "18"
   +  version: "19"
 persist all catalog changes to storage
-update progress of schema change job #1: "PostCommitNonRevertiblePhase stage 3 of 4 with 5 MutationType ops pending"
+update progress of schema change job #1: "PostCommitNonRevertiblePhase stage 2 of 5 with 11 MutationType ops pending"
 commit transaction #19
 begin transaction #20
-## PostCommitNonRevertiblePhase stage 3 of 4 with 7 MutationType ops
+## PostCommitNonRevertiblePhase stage 2 of 5 with 13 MutationType ops
 upsert descriptor #104
+   table:
+  -  checks: []
+  +  checks:
+  +  - columnIds:
+  +    - 4
+  +    constraintId: 2
+  +    expr: crdb_internal_a_shard_10 IN (0,1,2,3,4,5,6,7,8,9)
+  +    fromHashShardedColumn: true
+  +    name: check_crdb_internal_a_shard_10
+  +    validity: Validating
+     columns:
+     - id: 1
   ...
-     modificationTime: {}
+         oid: 20
+         width: 64
+  +  - computeExpr: mod(fnv32(md5(crdb_internal.datums_to_bytes(a))), 10:::INT8)
+  +    hidden: true
+  +    id: 4
+  +    name: crdb_internal_a_shard_10
+  +    type:
+  +      family: IntFamily
+  +      oid: 20
+  +      width: 64
+  +    virtual: true
+     createAsOfTime:
+       wallTime: "1640995200000000000"
+  ...
      mutations:
+     - column:
+  -      computeExpr: mod(fnv32(md5(crdb_internal.datums_to_bytes(a))), 10:::INT8)
+  +      defaultExpr: unique_rowid()
+         hidden: true
+  -      id: 4
+  -      name: crdb_internal_a_shard_10
+  +      id: 3
+  +      name: crdb_internal_column_3_name_placeholder
+  +      nullable: true
+         type:
+           family: IntFamily
+           oid: 20
+           width: 64
+  -      virtual: true
+  -    direction: ADD
+  +    direction: DROP
+       mutationId: 1
+  -    state: WRITE_ONLY
+  -  - direction: ADD
+  +    state: DELETE_ONLY
+  +  - direction: DROP
+       index:
+  -      constraintId: 7
+  +      constraintId: 5
+         createdExplicitly: true
+         encodingType: 1
+         foreignKey: {}
+         geoConfig: {}
+  -      id: 8
+  +      id: 6
+         interleave: {}
+         keyColumnDirections:
+  ...
+         - crdb_internal_a_shard_10
+         - a
+  -      name: crdb_internal_index_8_name_placeholder
+  +      name: crdb_internal_index_6_name_placeholder
+         partitioning: {}
+         sharded:
+  ...
+           shardBuckets: 10
+         storeColumnIds:
+  +      - 3
+         - 2
+         storeColumnNames:
+  +      - crdb_internal_column_3_name_placeholder
+         - b
+         unique: true
+  ...
+       mutationId: 1
+       state: WRITE_ONLY
+  -  - direction: DROP
+  -    index:
+  -      constraintId: 1
+  -      createdAtNanos: "1640995200000000000"
+  -      encodingType: 1
+  +  - constraint:
+  +      check:
+  +        columnIds:
+  +        - 4
+  +        constraintId: 2
+  +        expr: crdb_internal_a_shard_10 IN (0,1,2,3,4,5,6,7,8,9)
+  +        fromHashShardedColumn: true
+  +        name: crdb_internal_constraint_2_name_placeholder
+  +        validity: Validating
+         foreignKey: {}
+  -      geoConfig: {}
+  -      id: 1
+  -      interleave: {}
+  -      keyColumnDirections:
+  -      - ASC
+  -      keyColumnIds:
+  -      - 3
+  -      keyColumnNames:
+  -      - crdb_internal_column_3_name_placeholder
+  -      name: crdb_internal_index_1_name_placeholder
+  -      partitioning: {}
+  -      sharded: {}
+  -      storeColumnIds:
+  -      - 1
+  -      - 2
+  -      storeColumnNames:
+  -      - a
+  -      - b
+  -      unique: true
+  -      vecConfig: {}
+  -      version: 4
+  +      name: crdb_internal_constraint_2_name_placeholder
+  +      uniqueWithoutIndexConstraint: {}
+  +    direction: ADD
+       mutationId: 1
+  -    state: DELETE_ONLY
   -  - direction: DROP
   -    index:
   -      createdAtNanos: "1640995200000000000"
@@ -1222,25 +1425,96 @@ upsert descriptor #104
   -      version: 4
   -    mutationId: 1
   -    state: DELETE_ONLY
-     - column:
-         defaultExpr: unique_rowid()
-  ...
-         version: 4
-       mutationId: 1
-  -    state: WRITE_ONLY
-  +    state: DELETE_ONLY
+  -  - column:
+  -      defaultExpr: unique_rowid()
+  -      hidden: true
+  -      id: 3
+  -      name: crdb_internal_column_3_name_placeholder
+  -      nullable: true
+  -      type:
+  -        family: IntFamily
+  -        oid: 20
+  -        width: 64
+  -    direction: DROP
+  -    mutationId: 1
+       state: WRITE_ONLY
      name: t
-     nextColumnId: 4
+  ...
+     parentId: 100
+     primaryIndex:
+  -    constraintId: 5
+  +    constraintId: 7
+       createdExplicitly: true
+       encodingType: 1
+       foreignKey: {}
+       geoConfig: {}
+  -    id: 6
+  +    id: 8
+       interleave: {}
+       keyColumnDirections:
+  ...
+         shardBuckets: 10
+       storeColumnIds:
+  -    - 3
+       - 2
+       storeColumnNames:
+  -    - crdb_internal_column_3_name_placeholder
+       - b
+       unique: true
   ...
        time: {}
      unexposedParentSchemaId: 101
   -  version: "19"
   +  version: "20"
 persist all catalog changes to storage
-update progress of schema change job #1: "PostCommitNonRevertiblePhase stage 4 of 4 with 9 MutationType ops pending"
+adding table for stats refresh: 104
+update progress of schema change job #1: "PostCommitNonRevertiblePhase stage 3 of 5 with 1 ValidationType op pending"
 commit transaction #20
 begin transaction #21
-## PostCommitNonRevertiblePhase stage 4 of 4 with 11 MutationType ops
+## PostCommitNonRevertiblePhase stage 3 of 5 with 1 ValidationType op
+validate CHECK constraint check_crdb_internal_a_shard_10 in table #104
+commit transaction #21
+begin transaction #22
+## PostCommitNonRevertiblePhase stage 4 of 5 with 8 MutationType ops
+upsert descriptor #104
+  ...
+       fromHashShardedColumn: true
+       name: check_crdb_internal_a_shard_10
+  -    validity: Validating
+     columns:
+     - id: 1
+  ...
+         version: 4
+       mutationId: 1
+  -    state: WRITE_ONLY
+  -  - constraint:
+  -      check:
+  -        columnIds:
+  -        - 4
+  -        constraintId: 2
+  -        expr: crdb_internal_a_shard_10 IN (0,1,2,3,4,5,6,7,8,9)
+  -        fromHashShardedColumn: true
+  -        name: crdb_internal_constraint_2_name_placeholder
+  -        validity: Validating
+  -      foreignKey: {}
+  -      name: crdb_internal_constraint_2_name_placeholder
+  -      uniqueWithoutIndexConstraint: {}
+  -    direction: ADD
+  -    mutationId: 1
+  -    state: WRITE_ONLY
+  +    state: DELETE_ONLY
+     name: t
+     nextColumnId: 5
+  ...
+       time: {}
+     unexposedParentSchemaId: 101
+  -  version: "20"
+  +  version: "21"
+persist all catalog changes to storage
+update progress of schema change job #1: "PostCommitNonRevertiblePhase stage 5 of 5 with 9 MutationType ops pending"
+commit transaction #22
+begin transaction #23
+## PostCommitNonRevertiblePhase stage 5 of 5 with 11 MutationType ops
 upsert descriptor #104
   ...
      createAsOfTime:
@@ -1254,10 +1528,13 @@ upsert descriptor #104
   -      columns:
   -        "1": a
   -        "2": b
+  -        "4": crdb_internal_a_shard_10
   -        "4294967292": crdb_internal_origin_timestamp
   -        "4294967293": crdb_internal_origin_id
   -        "4294967294": tableoid
   -        "4294967295": crdb_internal_mvcc_timestamp
+  -      constraints:
+  -        "2": check_crdb_internal_a_shard_10
   -      families:
   -        "0": primary
   -      id: 104
@@ -1267,8 +1544,8 @@ upsert descriptor #104
   -      name: t
   -    relevantStatements:
   -    - statement:
-  -        redactedStatement: ALTER TABLE ‹defaultdb›.‹public›.‹t› ADD PRIMARY KEY (‹a›)
-  -        statement: ALTER TABLE t ADD PRIMARY KEY (a)
+  -        redactedStatement: ALTER TABLE ‹defaultdb›.‹public›.‹t› ADD PRIMARY KEY (‹a›) USING HASH WITH ('bucket_count' = ‹10›)
+  -        statement: ALTER TABLE t ADD PRIMARY KEY (a) USING HASH WITH ('bucket_count' = 10)
   -        statementTag: ALTER TABLE
   -    targetRanks: <redacted>
   -    targets: <redacted>
@@ -1302,7 +1579,7 @@ upsert descriptor #104
   -    state: DELETE_ONLY
   -  - direction: DROP
   -    index:
-  -      constraintId: 4
+  -      constraintId: 5
   -      createdExplicitly: true
   -      encodingType: 1
   -      foreignKey: {}
@@ -1311,13 +1588,21 @@ upsert descriptor #104
   -      interleave: {}
   -      keyColumnDirections:
   -      - ASC
+  -      - ASC
   -      keyColumnIds:
+  -      - 4
   -      - 1
   -      keyColumnNames:
+  -      - crdb_internal_a_shard_10
   -      - a
   -      name: crdb_internal_index_6_name_placeholder
   -      partitioning: {}
-  -      sharded: {}
+  -      sharded:
+  -        columnNames:
+  -        - a
+  -        isSharded: true
+  -        name: crdb_internal_a_shard_10
+  -        shardBuckets: 10
   -      storeColumnIds:
   -      - 3
   -      - 2
@@ -1331,14 +1616,14 @@ upsert descriptor #104
   -    state: DELETE_ONLY
   +  mutations: []
      name: t
-     nextColumnId: 4
+     nextColumnId: 5
   ...
        time: {}
      unexposedParentSchemaId: 101
-  -  version: "20"
-  +  version: "21"
+  -  version: "21"
+  +  version: "22"
 persist all catalog changes to storage
-create job #2 (non-cancelable: true): "GC for ALTER TABLE defaultdb.public.t ADD PRIMARY KEY (a)"
+create job #2 (non-cancelable: true): "GC for ALTER TABLE defaultdb.public.t ADD PRIMARY KEY (a) USING HASH WITH ('bucket_count' = 10)"
   descriptor IDs: [104]
 update progress of schema change job #1: "all stages completed"
 set schema change job #1 to non-cancellable
@@ -1346,6 +1631,6 @@ updated schema change job #1 descriptor IDs to []
 write *eventpb.FinishSchemaChange to event log:
   sc:
     descriptorId: 104
-commit transaction #21
+commit transaction #23
 notified job registry to adopt jobs: [2]
 # end PostCommitPhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx__rollback_10_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx__rollback_10_of_15.explain
@@ -8,14 +8,14 @@ EXPLAIN (DDL) rollback at post-commit stage 10 of 15;
 ----
 Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY KEY (a);
  └── PostCommitNonRevertiblePhase
-      ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 3 elements transitioning toward PUBLIC
-      │    │    ├── VALIDATED             → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 0}
-      │    │    ├── VALIDATED             → PUBLIC      PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey+), ConstraintID: 1}
-      │    │    └── ABSENT                → PUBLIC      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey+)}
-      │    ├── 18 elements transitioning toward ABSENT
-      │    │    ├── PUBLIC                → VALIDATED   PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 6 (t_pkey-)}
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 1 element transitioning toward PUBLIC
+      │    │    └── VALIDATED             → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 0}
+      │    ├── 20 elements transitioning toward ABSENT
+      │    │    ├── VALIDATED             → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (t_pkey-)}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 7}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 7}
@@ -34,9 +34,6 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY K
       │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 5}
       │    └── 23 Mutation operations
       │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":3,"TableID":104}
-      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
-      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":6,"TableID":104}
-      │         ├── SetIndexName {"IndexID":6,"Name":"crdb_internal_in...","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":7,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":104}
@@ -50,41 +47,31 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY K
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":5,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"Kind":1,"TableID":104}
-      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
-      ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 6 elements transitioning toward ABSENT
-      │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 6 (t_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (t_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (t_pkey-)}
-      │    │    ├── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 7, SourceIndexID: 6 (t_pkey-)}
-      │    │    └── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 3, SourceIndexID: 6 (t_pkey-)}
-      │    └── 8 Mutation operations
-      │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"Kind":2,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":104}
-      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
-      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
-      └── Stage 3 of 3 in PostCommitNonRevertiblePhase
-           ├── 7 elements transitioning toward ABSENT
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 9 elements transitioning toward ABSENT
            │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
            │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 6 (t_pkey-)}
            │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 7}
            │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 8 (t_pkey-)}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 7, SourceIndexID: 6 (t_pkey-)}
            │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 9}
            │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 4 (idx_b-)}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 3, SourceIndexID: 6 (t_pkey-)}
            │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 5}
-           └── 9 Mutation operations
+           └── 11 Mutation operations
                 ├── MakeIndexAbsent {"IndexID":6,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
                 ├── CreateGCJobForIndex {"IndexID":4,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
                 ├── CreateGCJobForIndex {"IndexID":5,"TableID":104}
                 ├── CreateGCJobForIndex {"IndexID":6,"TableID":104}
                 ├── CreateGCJobForIndex {"IndexID":7,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx__rollback_10_of_16.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx__rollback_10_of_16.explain
@@ -1,0 +1,104 @@
+/* setup */
+CREATE TABLE t (a INT NOT NULL, b INT NOT NULL);
+CREATE INDEX idx_b ON t(b);
+
+/* test */
+alter table t add primary key (a) USING HASH WITH (bucket_count=10);
+EXPLAIN (DDL) rollback at post-commit stage 10 of 16;
+----
+Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY KEY (a) USING HASH WITH ('bucket_count' = ‹10›);
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 1 element transitioning toward PUBLIC
+      │    │    └── VALIDATED             → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 0}
+      │    ├── 29 elements transitioning toward ABSENT
+      │    │    ├── VALIDATED             → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 5, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (t_pkey-)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 6, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 7}
+      │    │    ├── BACKFILL_ONLY         → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey-), ConstraintID: 7, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 8 (t_pkey-)}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 8, SourceIndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 9}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 104 (t), Name: "crdb_internal_a_shard_10", ColumnID: 4 (crdb_internal_a_shard_10-)}
+      │    │    ├── WRITE_ONLY            → ABSENT      ColumnNotNull:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-), IndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-), IndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-), IndexID: 9}
+      │    │    ├── BACKFILL_ONLY         → ABSENT      SecondaryIndex:{DescID: 104 (t), IndexID: 4 (idx_b-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 6 (t_pkey-), RecreateSourceIndexID: 2}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 4 (idx_b-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 4 (idx_b-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-), IndexID: 4 (idx_b-)}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 4, SourceIndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 5}
+      │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-), IndexID: 5}
+      │    └── 32 Mutation operations
+      │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":3,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":7,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"Kind":2,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":9,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"Kind":2,"TableID":104}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":4,"TableID":104}
+      │         ├── SetColumnName {"ColumnID":4,"Name":"crdb_internal_co...","TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"Kind":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":4,"Kind":1,"Ordinal":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":5,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"Kind":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":5,"Kind":1,"Ordinal":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
+      │         ├── RemoveColumnNotNull {"ColumnID":4,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":6,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 12 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 5, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 6 (t_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 7}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 8 (t_pkey-)}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 8, SourceIndexID: 6 (t_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 9}
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 4 (crdb_internal_a_shard_10-), TypeName: "INT8"}
+           │    ├── PUBLIC      → ABSENT ColumnComputeExpression:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-), Usage: REGULAR}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 4 (idx_b-)}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 4, SourceIndexID: 6 (t_pkey-)}
+           │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 5}
+           └── 13 Mutation operations
+                ├── MakeIndexAbsent {"IndexID":6,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
+                ├── RemoveColumnComputeExpression {"ColumnID":4,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":4,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":5,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":6,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":7,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":8,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":9,"TableID":104}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":4,"TableID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx__rollback_11_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx__rollback_11_of_15.explain
@@ -8,14 +8,14 @@ EXPLAIN (DDL) rollback at post-commit stage 11 of 15;
 ----
 Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY KEY (a);
  └── PostCommitNonRevertiblePhase
-      ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 3 elements transitioning toward PUBLIC
-      │    │    ├── VALIDATED             → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 0}
-      │    │    ├── VALIDATED             → PUBLIC      PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey+), ConstraintID: 1}
-      │    │    └── ABSENT                → PUBLIC      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey+)}
-      │    ├── 18 elements transitioning toward ABSENT
-      │    │    ├── PUBLIC                → VALIDATED   PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 6 (t_pkey-)}
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 1 element transitioning toward PUBLIC
+      │    │    └── VALIDATED             → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 0}
+      │    ├── 20 elements transitioning toward ABSENT
+      │    │    ├── VALIDATED             → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (t_pkey-)}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 7}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 7}
@@ -34,9 +34,6 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY K
       │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 5}
       │    └── 23 Mutation operations
       │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":3,"TableID":104}
-      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
-      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":6,"TableID":104}
-      │         ├── SetIndexName {"IndexID":6,"Name":"crdb_internal_in...","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":7,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":104}
@@ -50,41 +47,31 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY K
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":5,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"Kind":1,"TableID":104}
-      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
-      ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 6 elements transitioning toward ABSENT
-      │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 6 (t_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (t_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (t_pkey-)}
-      │    │    ├── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 7, SourceIndexID: 6 (t_pkey-)}
-      │    │    └── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 3, SourceIndexID: 6 (t_pkey-)}
-      │    └── 8 Mutation operations
-      │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"Kind":2,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":104}
-      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
-      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
-      └── Stage 3 of 3 in PostCommitNonRevertiblePhase
-           ├── 7 elements transitioning toward ABSENT
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 9 elements transitioning toward ABSENT
            │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
            │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 6 (t_pkey-)}
            │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 7}
            │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 8 (t_pkey-)}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 7, SourceIndexID: 6 (t_pkey-)}
            │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 9}
            │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 4 (idx_b-)}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 3, SourceIndexID: 6 (t_pkey-)}
            │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 5}
-           └── 9 Mutation operations
+           └── 11 Mutation operations
                 ├── MakeIndexAbsent {"IndexID":6,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
                 ├── CreateGCJobForIndex {"IndexID":4,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
                 ├── CreateGCJobForIndex {"IndexID":5,"TableID":104}
                 ├── CreateGCJobForIndex {"IndexID":6,"TableID":104}
                 ├── CreateGCJobForIndex {"IndexID":7,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx__rollback_11_of_16.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx__rollback_11_of_16.explain
@@ -1,0 +1,104 @@
+/* setup */
+CREATE TABLE t (a INT NOT NULL, b INT NOT NULL);
+CREATE INDEX idx_b ON t(b);
+
+/* test */
+alter table t add primary key (a) USING HASH WITH (bucket_count=10);
+EXPLAIN (DDL) rollback at post-commit stage 11 of 16;
+----
+Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY KEY (a) USING HASH WITH ('bucket_count' = ‹10›);
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 1 element transitioning toward PUBLIC
+      │    │    └── VALIDATED             → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 0}
+      │    ├── 29 elements transitioning toward ABSENT
+      │    │    ├── VALIDATED             → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 5, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (t_pkey-)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 6, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 7}
+      │    │    ├── BACKFILL_ONLY         → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey-), ConstraintID: 7, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 8 (t_pkey-)}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 8, SourceIndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 9}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 104 (t), Name: "crdb_internal_a_shard_10", ColumnID: 4 (crdb_internal_a_shard_10-)}
+      │    │    ├── WRITE_ONLY            → ABSENT      ColumnNotNull:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-), IndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-), IndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-), IndexID: 9}
+      │    │    ├── BACKFILL_ONLY         → ABSENT      SecondaryIndex:{DescID: 104 (t), IndexID: 4 (idx_b-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 6 (t_pkey-), RecreateSourceIndexID: 2}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 4 (idx_b-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 4 (idx_b-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-), IndexID: 4 (idx_b-)}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 4, SourceIndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 5}
+      │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-), IndexID: 5}
+      │    └── 32 Mutation operations
+      │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":3,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":7,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"Kind":2,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":9,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"Kind":2,"TableID":104}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":4,"TableID":104}
+      │         ├── SetColumnName {"ColumnID":4,"Name":"crdb_internal_co...","TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"Kind":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":4,"Kind":1,"Ordinal":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":5,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"Kind":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":5,"Kind":1,"Ordinal":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
+      │         ├── RemoveColumnNotNull {"ColumnID":4,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":6,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 12 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 5, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 6 (t_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 7}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 8 (t_pkey-)}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 8, SourceIndexID: 6 (t_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 9}
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 4 (crdb_internal_a_shard_10-), TypeName: "INT8"}
+           │    ├── PUBLIC      → ABSENT ColumnComputeExpression:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-), Usage: REGULAR}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 4 (idx_b-)}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 4, SourceIndexID: 6 (t_pkey-)}
+           │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 5}
+           └── 13 Mutation operations
+                ├── MakeIndexAbsent {"IndexID":6,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
+                ├── RemoveColumnComputeExpression {"ColumnID":4,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":4,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":5,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":6,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":7,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":8,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":9,"TableID":104}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":4,"TableID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx__rollback_12_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx__rollback_12_of_15.explain
@@ -8,14 +8,14 @@ EXPLAIN (DDL) rollback at post-commit stage 12 of 15;
 ----
 Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY KEY (a);
  └── PostCommitNonRevertiblePhase
-      ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 3 elements transitioning toward PUBLIC
-      │    │    ├── VALIDATED             → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 0}
-      │    │    ├── VALIDATED             → PUBLIC      PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey+), ConstraintID: 1}
-      │    │    └── ABSENT                → PUBLIC      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey+)}
-      │    ├── 18 elements transitioning toward ABSENT
-      │    │    ├── PUBLIC                → VALIDATED   PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 6 (t_pkey-)}
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 1 element transitioning toward PUBLIC
+      │    │    └── VALIDATED             → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 0}
+      │    ├── 20 elements transitioning toward ABSENT
+      │    │    ├── VALIDATED             → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (t_pkey-)}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 7}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 7}
@@ -34,9 +34,6 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY K
       │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 5}
       │    └── 23 Mutation operations
       │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":3,"TableID":104}
-      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
-      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":6,"TableID":104}
-      │         ├── SetIndexName {"IndexID":6,"Name":"crdb_internal_in...","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":7,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":104}
@@ -50,41 +47,31 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY K
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":5,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"Kind":1,"TableID":104}
-      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
-      ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 6 elements transitioning toward ABSENT
-      │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 6 (t_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (t_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (t_pkey-)}
-      │    │    ├── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 7, SourceIndexID: 6 (t_pkey-)}
-      │    │    └── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 3, SourceIndexID: 6 (t_pkey-)}
-      │    └── 8 Mutation operations
-      │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"Kind":2,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":104}
-      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
-      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
-      └── Stage 3 of 3 in PostCommitNonRevertiblePhase
-           ├── 7 elements transitioning toward ABSENT
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 9 elements transitioning toward ABSENT
            │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
            │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 6 (t_pkey-)}
            │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 7}
            │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 8 (t_pkey-)}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 7, SourceIndexID: 6 (t_pkey-)}
            │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 9}
            │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 4 (idx_b-)}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 3, SourceIndexID: 6 (t_pkey-)}
            │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 5}
-           └── 9 Mutation operations
+           └── 11 Mutation operations
                 ├── MakeIndexAbsent {"IndexID":6,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
                 ├── CreateGCJobForIndex {"IndexID":4,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
                 ├── CreateGCJobForIndex {"IndexID":5,"TableID":104}
                 ├── CreateGCJobForIndex {"IndexID":6,"TableID":104}
                 ├── CreateGCJobForIndex {"IndexID":7,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx__rollback_12_of_16.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx__rollback_12_of_16.explain
@@ -1,0 +1,104 @@
+/* setup */
+CREATE TABLE t (a INT NOT NULL, b INT NOT NULL);
+CREATE INDEX idx_b ON t(b);
+
+/* test */
+alter table t add primary key (a) USING HASH WITH (bucket_count=10);
+EXPLAIN (DDL) rollback at post-commit stage 12 of 16;
+----
+Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY KEY (a) USING HASH WITH ('bucket_count' = ‹10›);
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 1 element transitioning toward PUBLIC
+      │    │    └── VALIDATED             → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 0}
+      │    ├── 29 elements transitioning toward ABSENT
+      │    │    ├── VALIDATED             → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 5, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (t_pkey-)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 6, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 7}
+      │    │    ├── DELETE_ONLY           → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey-), ConstraintID: 7, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 8 (t_pkey-)}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 8, SourceIndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 9}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 104 (t), Name: "crdb_internal_a_shard_10", ColumnID: 4 (crdb_internal_a_shard_10-)}
+      │    │    ├── WRITE_ONLY            → ABSENT      ColumnNotNull:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-), IndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-), IndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-), IndexID: 9}
+      │    │    ├── DELETE_ONLY           → ABSENT      SecondaryIndex:{DescID: 104 (t), IndexID: 4 (idx_b-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 6 (t_pkey-), RecreateSourceIndexID: 2}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 4 (idx_b-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 4 (idx_b-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-), IndexID: 4 (idx_b-)}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 4, SourceIndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 5}
+      │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-), IndexID: 5}
+      │    └── 32 Mutation operations
+      │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":3,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":7,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"Kind":2,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":9,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"Kind":2,"TableID":104}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":4,"TableID":104}
+      │         ├── SetColumnName {"ColumnID":4,"Name":"crdb_internal_co...","TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"Kind":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":4,"Kind":1,"Ordinal":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":5,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"Kind":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":5,"Kind":1,"Ordinal":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
+      │         ├── RemoveColumnNotNull {"ColumnID":4,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":6,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 12 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 5, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 6 (t_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 7}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 8 (t_pkey-)}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 8, SourceIndexID: 6 (t_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 9}
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 4 (crdb_internal_a_shard_10-), TypeName: "INT8"}
+           │    ├── PUBLIC      → ABSENT ColumnComputeExpression:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-), Usage: REGULAR}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 4 (idx_b-)}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 4, SourceIndexID: 6 (t_pkey-)}
+           │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 5}
+           └── 13 Mutation operations
+                ├── MakeIndexAbsent {"IndexID":6,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
+                ├── RemoveColumnComputeExpression {"ColumnID":4,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":4,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":5,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":6,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":7,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":8,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":9,"TableID":104}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":4,"TableID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx__rollback_13_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx__rollback_13_of_15.explain
@@ -8,14 +8,14 @@ EXPLAIN (DDL) rollback at post-commit stage 13 of 15;
 ----
 Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY KEY (a);
  └── PostCommitNonRevertiblePhase
-      ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 3 elements transitioning toward PUBLIC
-      │    │    ├── VALIDATED             → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 0}
-      │    │    ├── VALIDATED             → PUBLIC      PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey+), ConstraintID: 1}
-      │    │    └── ABSENT                → PUBLIC      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey+)}
-      │    ├── 18 elements transitioning toward ABSENT
-      │    │    ├── PUBLIC                → VALIDATED   PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 6 (t_pkey-)}
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 1 element transitioning toward PUBLIC
+      │    │    └── VALIDATED             → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 0}
+      │    ├── 20 elements transitioning toward ABSENT
+      │    │    ├── VALIDATED             → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (t_pkey-)}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 7}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 7}
@@ -34,9 +34,6 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY K
       │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 5}
       │    └── 23 Mutation operations
       │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":3,"TableID":104}
-      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
-      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":6,"TableID":104}
-      │         ├── SetIndexName {"IndexID":6,"Name":"crdb_internal_in...","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":7,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":104}
@@ -46,7 +43,10 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY K
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":5,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"Kind":1,"TableID":104}
-      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"TableID":104}
@@ -56,39 +56,26 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY K
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"Kind":1,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
-      ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 8 elements transitioning toward ABSENT
-      │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 6 (t_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (t_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (t_pkey-)}
-      │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey-)}
-      │    │    ├── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 7, SourceIndexID: 6 (t_pkey-)}
-      │    │    ├── DELETE_ONLY → ABSENT      SecondaryIndex:{DescID: 104 (t), IndexID: 4 (idx_b-), ConstraintID: 2, TemporaryIndexID: 5, SourceIndexID: 6 (t_pkey-), RecreateSourceIndexID: 2}
-      │    │    └── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 3, SourceIndexID: 6 (t_pkey-)}
-      │    └── 10 Mutation operations
-      │         ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"Kind":2,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":104}
-      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
-      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
-      └── Stage 3 of 3 in PostCommitNonRevertiblePhase
-           ├── 7 elements transitioning toward ABSENT
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 11 elements transitioning toward ABSENT
            │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
            │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 6 (t_pkey-)}
            │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 7}
+           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey-)}
            │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 8 (t_pkey-)}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 7, SourceIndexID: 6 (t_pkey-)}
            │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 9}
+           │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 4 (idx_b-), ConstraintID: 2, TemporaryIndexID: 5, SourceIndexID: 6 (t_pkey-), RecreateSourceIndexID: 2}
            │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 4 (idx_b-)}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 3, SourceIndexID: 6 (t_pkey-)}
            │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 5}
-           └── 9 Mutation operations
+           └── 13 Mutation operations
                 ├── MakeIndexAbsent {"IndexID":6,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
                 ├── CreateGCJobForIndex {"IndexID":4,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
                 ├── CreateGCJobForIndex {"IndexID":5,"TableID":104}
                 ├── CreateGCJobForIndex {"IndexID":6,"TableID":104}
                 ├── CreateGCJobForIndex {"IndexID":7,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx__rollback_13_of_16.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx__rollback_13_of_16.explain
@@ -1,0 +1,108 @@
+/* setup */
+CREATE TABLE t (a INT NOT NULL, b INT NOT NULL);
+CREATE INDEX idx_b ON t(b);
+
+/* test */
+alter table t add primary key (a) USING HASH WITH (bucket_count=10);
+EXPLAIN (DDL) rollback at post-commit stage 13 of 16;
+----
+Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY KEY (a) USING HASH WITH ('bucket_count' = ‹10›);
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 1 element transitioning toward PUBLIC
+      │    │    └── VALIDATED             → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 0}
+      │    ├── 29 elements transitioning toward ABSENT
+      │    │    ├── VALIDATED             → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 5, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (t_pkey-)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 6, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 7}
+      │    │    ├── MERGE_ONLY            → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey-), ConstraintID: 7, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 8 (t_pkey-)}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 8, SourceIndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 9}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 104 (t), Name: "crdb_internal_a_shard_10", ColumnID: 4 (crdb_internal_a_shard_10-)}
+      │    │    ├── WRITE_ONLY            → ABSENT      ColumnNotNull:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-), IndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-), IndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-), IndexID: 9}
+      │    │    ├── MERGE_ONLY            → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 4 (idx_b-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 6 (t_pkey-), RecreateSourceIndexID: 2}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 4 (idx_b-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 4 (idx_b-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-), IndexID: 4 (idx_b-)}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 4, SourceIndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 5}
+      │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-), IndexID: 5}
+      │    └── 32 Mutation operations
+      │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":3,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":7,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":9,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"Kind":2,"TableID":104}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":4,"TableID":104}
+      │         ├── SetColumnName {"ColumnID":4,"Name":"crdb_internal_co...","TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":5,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"Kind":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":5,"Kind":1,"Ordinal":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnNotNull {"ColumnID":4,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":6,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"Kind":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":4,"Kind":1,"Ordinal":1,"TableID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 14 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 5, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 6 (t_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 7}
+           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey-), ConstraintID: 7, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 8 (t_pkey-)}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 8, SourceIndexID: 6 (t_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 9}
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 4 (crdb_internal_a_shard_10-), TypeName: "INT8"}
+           │    ├── PUBLIC      → ABSENT ColumnComputeExpression:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-), Usage: REGULAR}
+           │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 4 (idx_b-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 6 (t_pkey-), RecreateSourceIndexID: 2}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 4 (idx_b-)}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 4, SourceIndexID: 6 (t_pkey-)}
+           │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 5}
+           └── 15 Mutation operations
+                ├── MakeIndexAbsent {"IndexID":6,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
+                ├── RemoveColumnComputeExpression {"ColumnID":4,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":4,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":5,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":6,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":7,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":8,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":9,"TableID":104}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":4,"TableID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx__rollback_14_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx__rollback_14_of_15.explain
@@ -8,14 +8,14 @@ EXPLAIN (DDL) rollback at post-commit stage 14 of 15;
 ----
 Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY KEY (a);
  └── PostCommitNonRevertiblePhase
-      ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 3 elements transitioning toward PUBLIC
-      │    │    ├── VALIDATED             → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 0}
-      │    │    ├── VALIDATED             → PUBLIC      PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey+), ConstraintID: 1}
-      │    │    └── ABSENT                → PUBLIC      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey+)}
-      │    ├── 18 elements transitioning toward ABSENT
-      │    │    ├── PUBLIC                → VALIDATED   PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 6 (t_pkey-)}
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 1 element transitioning toward PUBLIC
+      │    │    └── VALIDATED             → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 0}
+      │    ├── 20 elements transitioning toward ABSENT
+      │    │    ├── VALIDATED             → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (t_pkey-)}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 7}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 7}
@@ -34,9 +34,6 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY K
       │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 5}
       │    └── 23 Mutation operations
       │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":3,"TableID":104}
-      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
-      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":6,"TableID":104}
-      │         ├── SetIndexName {"IndexID":6,"Name":"crdb_internal_in...","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":7,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":104}
@@ -46,7 +43,10 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY K
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":5,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"Kind":1,"TableID":104}
-      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"TableID":104}
@@ -56,39 +56,26 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY K
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"Kind":1,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
-      ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 8 elements transitioning toward ABSENT
-      │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 6 (t_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (t_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (t_pkey-)}
-      │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey-)}
-      │    │    ├── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 7, SourceIndexID: 6 (t_pkey-)}
-      │    │    ├── DELETE_ONLY → ABSENT      SecondaryIndex:{DescID: 104 (t), IndexID: 4 (idx_b-), ConstraintID: 2, TemporaryIndexID: 5, SourceIndexID: 6 (t_pkey-), RecreateSourceIndexID: 2}
-      │    │    └── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 3, SourceIndexID: 6 (t_pkey-)}
-      │    └── 10 Mutation operations
-      │         ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"Kind":2,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":104}
-      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
-      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
-      └── Stage 3 of 3 in PostCommitNonRevertiblePhase
-           ├── 7 elements transitioning toward ABSENT
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 11 elements transitioning toward ABSENT
            │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
            │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 6 (t_pkey-)}
            │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 7}
+           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey-)}
            │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 8 (t_pkey-)}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 7, SourceIndexID: 6 (t_pkey-)}
            │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 9}
+           │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 4 (idx_b-), ConstraintID: 2, TemporaryIndexID: 5, SourceIndexID: 6 (t_pkey-), RecreateSourceIndexID: 2}
            │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 4 (idx_b-)}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 3, SourceIndexID: 6 (t_pkey-)}
            │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 5}
-           └── 9 Mutation operations
+           └── 13 Mutation operations
                 ├── MakeIndexAbsent {"IndexID":6,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
                 ├── CreateGCJobForIndex {"IndexID":4,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
                 ├── CreateGCJobForIndex {"IndexID":5,"TableID":104}
                 ├── CreateGCJobForIndex {"IndexID":6,"TableID":104}
                 ├── CreateGCJobForIndex {"IndexID":7,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx__rollback_14_of_16.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx__rollback_14_of_16.explain
@@ -1,0 +1,108 @@
+/* setup */
+CREATE TABLE t (a INT NOT NULL, b INT NOT NULL);
+CREATE INDEX idx_b ON t(b);
+
+/* test */
+alter table t add primary key (a) USING HASH WITH (bucket_count=10);
+EXPLAIN (DDL) rollback at post-commit stage 14 of 16;
+----
+Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY KEY (a) USING HASH WITH ('bucket_count' = ‹10›);
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 1 element transitioning toward PUBLIC
+      │    │    └── VALIDATED             → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 0}
+      │    ├── 29 elements transitioning toward ABSENT
+      │    │    ├── VALIDATED             → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 5, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (t_pkey-)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 6, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 7}
+      │    │    ├── MERGE_ONLY            → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey-), ConstraintID: 7, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 8 (t_pkey-)}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 8, SourceIndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 9}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 104 (t), Name: "crdb_internal_a_shard_10", ColumnID: 4 (crdb_internal_a_shard_10-)}
+      │    │    ├── WRITE_ONLY            → ABSENT      ColumnNotNull:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-), IndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-), IndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-), IndexID: 9}
+      │    │    ├── MERGE_ONLY            → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 4 (idx_b-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 6 (t_pkey-), RecreateSourceIndexID: 2}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 4 (idx_b-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 4 (idx_b-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-), IndexID: 4 (idx_b-)}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 4, SourceIndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 5}
+      │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-), IndexID: 5}
+      │    └── 32 Mutation operations
+      │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":3,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":7,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":9,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"Kind":2,"TableID":104}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":4,"TableID":104}
+      │         ├── SetColumnName {"ColumnID":4,"Name":"crdb_internal_co...","TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":5,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"Kind":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":5,"Kind":1,"Ordinal":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnNotNull {"ColumnID":4,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":6,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"Kind":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":4,"Kind":1,"Ordinal":1,"TableID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 14 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 5, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 6 (t_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 7}
+           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey-), ConstraintID: 7, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 8 (t_pkey-)}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 8, SourceIndexID: 6 (t_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 9}
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 4 (crdb_internal_a_shard_10-), TypeName: "INT8"}
+           │    ├── PUBLIC      → ABSENT ColumnComputeExpression:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-), Usage: REGULAR}
+           │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 4 (idx_b-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 6 (t_pkey-), RecreateSourceIndexID: 2}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 4 (idx_b-)}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 4, SourceIndexID: 6 (t_pkey-)}
+           │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 5}
+           └── 15 Mutation operations
+                ├── MakeIndexAbsent {"IndexID":6,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
+                ├── RemoveColumnComputeExpression {"ColumnID":4,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":4,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":5,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":6,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":7,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":8,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":9,"TableID":104}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":4,"TableID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx__rollback_15_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx__rollback_15_of_15.explain
@@ -8,14 +8,14 @@ EXPLAIN (DDL) rollback at post-commit stage 15 of 15;
 ----
 Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY KEY (a);
  └── PostCommitNonRevertiblePhase
-      ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 3 elements transitioning toward PUBLIC
-      │    │    ├── VALIDATED             → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 0}
-      │    │    ├── VALIDATED             → PUBLIC      PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey+), ConstraintID: 1}
-      │    │    └── ABSENT                → PUBLIC      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey+)}
-      │    ├── 18 elements transitioning toward ABSENT
-      │    │    ├── PUBLIC                → VALIDATED   PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 6 (t_pkey-)}
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 1 element transitioning toward PUBLIC
+      │    │    └── VALIDATED             → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 0}
+      │    ├── 20 elements transitioning toward ABSENT
+      │    │    ├── VALIDATED             → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (t_pkey-)}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 7}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 7}
@@ -34,9 +34,6 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY K
       │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 5}
       │    └── 23 Mutation operations
       │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":3,"TableID":104}
-      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
-      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":6,"TableID":104}
-      │         ├── SetIndexName {"IndexID":6,"Name":"crdb_internal_in...","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":7,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":104}
@@ -50,40 +47,30 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY K
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"Kind":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"Kind":1,"TableID":104}
-      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
-      ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 6 elements transitioning toward ABSENT
-      │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 6 (t_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (t_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (t_pkey-)}
-      │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey-)}
-      │    │    └── DELETE_ONLY → ABSENT      SecondaryIndex:{DescID: 104 (t), IndexID: 4 (idx_b-), ConstraintID: 2, TemporaryIndexID: 5, SourceIndexID: 6 (t_pkey-), RecreateSourceIndexID: 2}
-      │    └── 8 Mutation operations
-      │         ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"Kind":2,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":104}
-      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
-      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
-      └── Stage 3 of 3 in PostCommitNonRevertiblePhase
-           ├── 7 elements transitioning toward ABSENT
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 9 elements transitioning toward ABSENT
            │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
            │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 6 (t_pkey-)}
            │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 7}
+           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey-)}
            │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 8 (t_pkey-)}
            │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 9}
+           │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 4 (idx_b-), ConstraintID: 2, TemporaryIndexID: 5, SourceIndexID: 6 (t_pkey-), RecreateSourceIndexID: 2}
            │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 4 (idx_b-)}
            │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 5}
-           └── 9 Mutation operations
+           └── 11 Mutation operations
                 ├── MakeIndexAbsent {"IndexID":6,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
                 ├── CreateGCJobForIndex {"IndexID":4,"TableID":104}
                 ├── CreateGCJobForIndex {"IndexID":5,"TableID":104}
                 ├── CreateGCJobForIndex {"IndexID":6,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx__rollback_15_of_16.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx__rollback_15_of_16.explain
@@ -1,0 +1,104 @@
+/* setup */
+CREATE TABLE t (a INT NOT NULL, b INT NOT NULL);
+CREATE INDEX idx_b ON t(b);
+
+/* test */
+alter table t add primary key (a) USING HASH WITH (bucket_count=10);
+EXPLAIN (DDL) rollback at post-commit stage 15 of 16;
+----
+Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY KEY (a) USING HASH WITH ('bucket_count' = ‹10›);
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 1 element transitioning toward PUBLIC
+      │    │    └── VALIDATED             → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 0}
+      │    ├── 29 elements transitioning toward ABSENT
+      │    │    ├── VALIDATED             → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 5, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (t_pkey-)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 6, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 7}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey-), ConstraintID: 7, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 8 (t_pkey-)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 8, SourceIndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 9}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 104 (t), Name: "crdb_internal_a_shard_10", ColumnID: 4 (crdb_internal_a_shard_10-)}
+      │    │    ├── WRITE_ONLY            → ABSENT      ColumnNotNull:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-), IndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-), IndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-), IndexID: 9}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 4 (idx_b-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 6 (t_pkey-), RecreateSourceIndexID: 2}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 4 (idx_b-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 4 (idx_b-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-), IndexID: 4 (idx_b-)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 4, SourceIndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 5}
+      │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-), IndexID: 5}
+      │    └── 32 Mutation operations
+      │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":3,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":7,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"Kind":2,"TableID":104}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":4,"TableID":104}
+      │         ├── SetColumnName {"ColumnID":4,"Name":"crdb_internal_co...","TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"Kind":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":4,"Kind":1,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"Kind":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":5,"Kind":1,"Ordinal":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
+      │         ├── RemoveColumnNotNull {"ColumnID":4,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":6,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 12 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 5, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 6 (t_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 7}
+           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey-), ConstraintID: 7, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 8 (t_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 9}
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 4 (crdb_internal_a_shard_10-), TypeName: "INT8"}
+           │    ├── PUBLIC      → ABSENT ColumnComputeExpression:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-), Usage: REGULAR}
+           │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 4 (idx_b-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 6 (t_pkey-), RecreateSourceIndexID: 2}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 4 (idx_b-)}
+           │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 5}
+           └── 13 Mutation operations
+                ├── MakeIndexAbsent {"IndexID":6,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
+                ├── RemoveColumnComputeExpression {"ColumnID":4,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":4,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":5,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":6,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":7,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":8,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":9,"TableID":104}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":4,"TableID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx__rollback_16_of_16.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx__rollback_16_of_16.explain
@@ -1,0 +1,104 @@
+/* setup */
+CREATE TABLE t (a INT NOT NULL, b INT NOT NULL);
+CREATE INDEX idx_b ON t(b);
+
+/* test */
+alter table t add primary key (a) USING HASH WITH (bucket_count=10);
+EXPLAIN (DDL) rollback at post-commit stage 16 of 16;
+----
+Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY KEY (a) USING HASH WITH ('bucket_count' = ‹10›);
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 1 element transitioning toward PUBLIC
+      │    │    └── VALIDATED             → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 0}
+      │    ├── 29 elements transitioning toward ABSENT
+      │    │    ├── VALIDATED             → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 5, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (t_pkey-)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 6, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 7}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey-), ConstraintID: 7, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 8 (t_pkey-)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 8, SourceIndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 9}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 104 (t), Name: "crdb_internal_a_shard_10", ColumnID: 4 (crdb_internal_a_shard_10-)}
+      │    │    ├── WRITE_ONLY            → ABSENT      ColumnNotNull:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-), IndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-), IndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-), IndexID: 9}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 4 (idx_b-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 6 (t_pkey-), RecreateSourceIndexID: 2}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 4 (idx_b-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 4 (idx_b-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-), IndexID: 4 (idx_b-)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 4, SourceIndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 5}
+      │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-), IndexID: 5}
+      │    └── 32 Mutation operations
+      │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":3,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":7,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"Kind":2,"TableID":104}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":4,"TableID":104}
+      │         ├── SetColumnName {"ColumnID":4,"Name":"crdb_internal_co...","TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"Kind":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":4,"Kind":1,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"Kind":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":5,"Kind":1,"Ordinal":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
+      │         ├── RemoveColumnNotNull {"ColumnID":4,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":6,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 12 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 5, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 6 (t_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 7}
+           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey-), ConstraintID: 7, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 8 (t_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 9}
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 4 (crdb_internal_a_shard_10-), TypeName: "INT8"}
+           │    ├── PUBLIC      → ABSENT ColumnComputeExpression:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-), Usage: REGULAR}
+           │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 4 (idx_b-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 6 (t_pkey-), RecreateSourceIndexID: 2}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 4 (idx_b-)}
+           │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 5}
+           └── 13 Mutation operations
+                ├── MakeIndexAbsent {"IndexID":6,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
+                ├── RemoveColumnComputeExpression {"ColumnID":4,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":4,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":5,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":6,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":7,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":8,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":9,"TableID":104}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":4,"TableID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx__rollback_1_of_16.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx__rollback_1_of_16.explain
@@ -1,0 +1,57 @@
+/* setup */
+CREATE TABLE t (a INT NOT NULL, b INT NOT NULL);
+CREATE INDEX idx_b ON t(b);
+
+/* test */
+alter table t add primary key (a) USING HASH WITH (bucket_count=10);
+EXPLAIN (DDL) rollback at post-commit stage 1 of 16;
+----
+Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY KEY (a) USING HASH WITH ('bucket_count' = ‹10›);
+ └── PostCommitNonRevertiblePhase
+      └── Stage 1 of 1 in PostCommitNonRevertiblePhase
+           ├── 1 element transitioning toward PUBLIC
+           │    └── VALIDATED     → PUBLIC ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 0}
+           ├── 20 elements transitioning toward ABSENT
+           │    ├── BACKFILL_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 5, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
+           │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 6 (t_pkey-)}
+           │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (t_pkey-)}
+           │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (t_pkey-)}
+           │    ├── PUBLIC        → ABSENT IndexData:{DescID: 104 (t), IndexID: 6 (t_pkey-)}
+           │    ├── DELETE_ONLY   → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 6, SourceIndexID: 1 (t_pkey+)}
+           │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 7}
+           │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 7}
+           │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 7}
+           │    ├── BACKFILL_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey-), ConstraintID: 7, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey-)}
+           │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 8 (t_pkey-)}
+           │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 8 (t_pkey-)}
+           │    ├── PUBLIC        → ABSENT IndexData:{DescID: 104 (t), IndexID: 8 (t_pkey-)}
+           │    ├── DELETE_ONLY   → ABSENT Column:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-)}
+           │    ├── PUBLIC        → ABSENT ColumnName:{DescID: 104 (t), Name: "crdb_internal_a_shard_10", ColumnID: 4 (crdb_internal_a_shard_10-)}
+           │    ├── PUBLIC        → ABSENT ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 4 (crdb_internal_a_shard_10-), TypeName: "INT8"}
+           │    ├── PUBLIC        → ABSENT ColumnComputeExpression:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-), Usage: REGULAR}
+           │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-), IndexID: 6 (t_pkey-)}
+           │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-), IndexID: 7}
+           │    └── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-), IndexID: 8 (t_pkey-)}
+           └── 22 Mutation operations
+                ├── MakeValidatedColumnNotNullPublic {"ColumnID":3,"TableID":104}
+                ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"Kind":2,"TableID":104}
+                ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Ordinal":1,"TableID":104}
+                ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":104}
+                ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":7,"Kind":2,"TableID":104}
+                ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Ordinal":1,"TableID":104}
+                ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":104}
+                ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Ordinal":1,"TableID":104}
+                ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"Kind":2,"TableID":104}
+                ├── SetColumnName {"ColumnID":4,"Name":"crdb_internal_co...","TableID":104}
+                ├── RemoveColumnComputeExpression {"ColumnID":4,"TableID":104}
+                ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":6,"TableID":104}
+                ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"TableID":104}
+                ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":6,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":6,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":8,"TableID":104}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":4,"TableID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx__rollback_2_of_16.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx__rollback_2_of_16.explain
@@ -1,0 +1,70 @@
+/* setup */
+CREATE TABLE t (a INT NOT NULL, b INT NOT NULL);
+CREATE INDEX idx_b ON t(b);
+
+/* test */
+alter table t add primary key (a) USING HASH WITH (bucket_count=10);
+EXPLAIN (DDL) rollback at post-commit stage 2 of 16;
+----
+Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY KEY (a) USING HASH WITH ('bucket_count' = ‹10›);
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 1 element transitioning toward PUBLIC
+      │    │    └── VALIDATED     → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 0}
+      │    ├── 17 elements transitioning toward ABSENT
+      │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 5, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (t_pkey-)}
+      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 6, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 7}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 7}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 7}
+      │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey-), ConstraintID: 7, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 8 (t_pkey-)}
+      │    │    ├── WRITE_ONLY    → DELETE_ONLY Column:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-)}
+      │    │    ├── PUBLIC        → ABSENT      ColumnName:{DescID: 104 (t), Name: "crdb_internal_a_shard_10", ColumnID: 4 (crdb_internal_a_shard_10-)}
+      │    │    ├── WRITE_ONLY    → ABSENT      ColumnNotNull:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-), IndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-), IndexID: 7}
+      │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-), IndexID: 8 (t_pkey-)}
+      │    └── 20 Mutation operations
+      │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":3,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":7,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":7,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"Kind":2,"TableID":104}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":4,"TableID":104}
+      │         ├── SetColumnName {"ColumnID":4,"Name":"crdb_internal_co...","TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":6,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":6,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
+      │         ├── RemoveColumnNotNull {"ColumnID":4,"TableID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 7 elements transitioning toward ABSENT
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 6 (t_pkey-)}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 6, SourceIndexID: 1 (t_pkey+)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 7}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 8 (t_pkey-)}
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 4 (crdb_internal_a_shard_10-), TypeName: "INT8"}
+           │    └── PUBLIC      → ABSENT ColumnComputeExpression:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-), Usage: REGULAR}
+           └── 8 Mutation operations
+                ├── CreateGCJobForIndex {"IndexID":6,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":7,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":8,"TableID":104}
+                ├── RemoveColumnComputeExpression {"ColumnID":4,"TableID":104}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":4,"TableID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx__rollback_3_of_16.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx__rollback_3_of_16.explain
@@ -1,0 +1,70 @@
+/* setup */
+CREATE TABLE t (a INT NOT NULL, b INT NOT NULL);
+CREATE INDEX idx_b ON t(b);
+
+/* test */
+alter table t add primary key (a) USING HASH WITH (bucket_count=10);
+EXPLAIN (DDL) rollback at post-commit stage 3 of 16;
+----
+Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY KEY (a) USING HASH WITH ('bucket_count' = ‹10›);
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 1 element transitioning toward PUBLIC
+      │    │    └── VALIDATED     → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 0}
+      │    ├── 17 elements transitioning toward ABSENT
+      │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 5, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (t_pkey-)}
+      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 6, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 7}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 7}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 7}
+      │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey-), ConstraintID: 7, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 8 (t_pkey-)}
+      │    │    ├── WRITE_ONLY    → DELETE_ONLY Column:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-)}
+      │    │    ├── PUBLIC        → ABSENT      ColumnName:{DescID: 104 (t), Name: "crdb_internal_a_shard_10", ColumnID: 4 (crdb_internal_a_shard_10-)}
+      │    │    ├── WRITE_ONLY    → ABSENT      ColumnNotNull:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-), IndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-), IndexID: 7}
+      │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-), IndexID: 8 (t_pkey-)}
+      │    └── 20 Mutation operations
+      │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":3,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":7,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":7,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"Kind":2,"TableID":104}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":4,"TableID":104}
+      │         ├── SetColumnName {"ColumnID":4,"Name":"crdb_internal_co...","TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":6,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":6,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
+      │         ├── RemoveColumnNotNull {"ColumnID":4,"TableID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 7 elements transitioning toward ABSENT
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 6 (t_pkey-)}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 6, SourceIndexID: 1 (t_pkey+)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 7}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 8 (t_pkey-)}
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 4 (crdb_internal_a_shard_10-), TypeName: "INT8"}
+           │    └── PUBLIC      → ABSENT ColumnComputeExpression:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-), Usage: REGULAR}
+           └── 8 Mutation operations
+                ├── CreateGCJobForIndex {"IndexID":6,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":7,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":8,"TableID":104}
+                ├── RemoveColumnComputeExpression {"ColumnID":4,"TableID":104}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":4,"TableID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx__rollback_4_of_16.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx__rollback_4_of_16.explain
@@ -1,0 +1,70 @@
+/* setup */
+CREATE TABLE t (a INT NOT NULL, b INT NOT NULL);
+CREATE INDEX idx_b ON t(b);
+
+/* test */
+alter table t add primary key (a) USING HASH WITH (bucket_count=10);
+EXPLAIN (DDL) rollback at post-commit stage 4 of 16;
+----
+Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY KEY (a) USING HASH WITH ('bucket_count' = ‹10›);
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 1 element transitioning toward PUBLIC
+      │    │    └── VALIDATED     → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 0}
+      │    ├── 17 elements transitioning toward ABSENT
+      │    │    ├── DELETE_ONLY   → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 5, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (t_pkey-)}
+      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 6, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 7}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 7}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 7}
+      │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey-), ConstraintID: 7, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 8 (t_pkey-)}
+      │    │    ├── WRITE_ONLY    → DELETE_ONLY Column:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-)}
+      │    │    ├── PUBLIC        → ABSENT      ColumnName:{DescID: 104 (t), Name: "crdb_internal_a_shard_10", ColumnID: 4 (crdb_internal_a_shard_10-)}
+      │    │    ├── WRITE_ONLY    → ABSENT      ColumnNotNull:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-), IndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-), IndexID: 7}
+      │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-), IndexID: 8 (t_pkey-)}
+      │    └── 20 Mutation operations
+      │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":3,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":7,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":7,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"Kind":2,"TableID":104}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":4,"TableID":104}
+      │         ├── SetColumnName {"ColumnID":4,"Name":"crdb_internal_co...","TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":6,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":6,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
+      │         ├── RemoveColumnNotNull {"ColumnID":4,"TableID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 7 elements transitioning toward ABSENT
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 6 (t_pkey-)}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 6, SourceIndexID: 1 (t_pkey+)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 7}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 8 (t_pkey-)}
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 4 (crdb_internal_a_shard_10-), TypeName: "INT8"}
+           │    └── PUBLIC      → ABSENT ColumnComputeExpression:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-), Usage: REGULAR}
+           └── 8 Mutation operations
+                ├── CreateGCJobForIndex {"IndexID":6,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":7,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":8,"TableID":104}
+                ├── RemoveColumnComputeExpression {"ColumnID":4,"TableID":104}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":4,"TableID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx__rollback_5_of_16.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx__rollback_5_of_16.explain
@@ -1,0 +1,72 @@
+/* setup */
+CREATE TABLE t (a INT NOT NULL, b INT NOT NULL);
+CREATE INDEX idx_b ON t(b);
+
+/* test */
+alter table t add primary key (a) USING HASH WITH (bucket_count=10);
+EXPLAIN (DDL) rollback at post-commit stage 5 of 16;
+----
+Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY KEY (a) USING HASH WITH ('bucket_count' = ‹10›);
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 1 element transitioning toward PUBLIC
+      │    │    └── VALIDATED     → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 0}
+      │    ├── 17 elements transitioning toward ABSENT
+      │    │    ├── MERGE_ONLY    → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 5, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (t_pkey-)}
+      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 6, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 7}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 7}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 7}
+      │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey-), ConstraintID: 7, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 8 (t_pkey-)}
+      │    │    ├── WRITE_ONLY    → DELETE_ONLY Column:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-)}
+      │    │    ├── PUBLIC        → ABSENT      ColumnName:{DescID: 104 (t), Name: "crdb_internal_a_shard_10", ColumnID: 4 (crdb_internal_a_shard_10-)}
+      │    │    ├── WRITE_ONLY    → ABSENT      ColumnNotNull:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-), IndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-), IndexID: 7}
+      │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-), IndexID: 8 (t_pkey-)}
+      │    └── 20 Mutation operations
+      │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":3,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":7,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":7,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"Kind":2,"TableID":104}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":4,"TableID":104}
+      │         ├── SetColumnName {"ColumnID":4,"Name":"crdb_internal_co...","TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
+      │         ├── RemoveColumnNotNull {"ColumnID":4,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":6,"TableID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 8 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 5, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 6 (t_pkey-)}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 6, SourceIndexID: 1 (t_pkey+)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 7}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 8 (t_pkey-)}
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 4 (crdb_internal_a_shard_10-), TypeName: "INT8"}
+           │    └── PUBLIC      → ABSENT ColumnComputeExpression:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-), Usage: REGULAR}
+           └── 9 Mutation operations
+                ├── MakeIndexAbsent {"IndexID":6,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":6,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":7,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":8,"TableID":104}
+                ├── RemoveColumnComputeExpression {"ColumnID":4,"TableID":104}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":4,"TableID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx__rollback_6_of_16.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx__rollback_6_of_16.explain
@@ -1,0 +1,72 @@
+/* setup */
+CREATE TABLE t (a INT NOT NULL, b INT NOT NULL);
+CREATE INDEX idx_b ON t(b);
+
+/* test */
+alter table t add primary key (a) USING HASH WITH (bucket_count=10);
+EXPLAIN (DDL) rollback at post-commit stage 6 of 16;
+----
+Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY KEY (a) USING HASH WITH ('bucket_count' = ‹10›);
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 1 element transitioning toward PUBLIC
+      │    │    └── VALIDATED     → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 0}
+      │    ├── 17 elements transitioning toward ABSENT
+      │    │    ├── MERGE_ONLY    → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 5, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (t_pkey-)}
+      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 6, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 7}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 7}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 7}
+      │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey-), ConstraintID: 7, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 8 (t_pkey-)}
+      │    │    ├── WRITE_ONLY    → DELETE_ONLY Column:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-)}
+      │    │    ├── PUBLIC        → ABSENT      ColumnName:{DescID: 104 (t), Name: "crdb_internal_a_shard_10", ColumnID: 4 (crdb_internal_a_shard_10-)}
+      │    │    ├── WRITE_ONLY    → ABSENT      ColumnNotNull:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-), IndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-), IndexID: 7}
+      │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-), IndexID: 8 (t_pkey-)}
+      │    └── 20 Mutation operations
+      │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":3,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":7,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":7,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"Kind":2,"TableID":104}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":4,"TableID":104}
+      │         ├── SetColumnName {"ColumnID":4,"Name":"crdb_internal_co...","TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
+      │         ├── RemoveColumnNotNull {"ColumnID":4,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":6,"TableID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 8 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 5, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 6 (t_pkey-)}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 6, SourceIndexID: 1 (t_pkey+)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 7}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 8 (t_pkey-)}
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 4 (crdb_internal_a_shard_10-), TypeName: "INT8"}
+           │    └── PUBLIC      → ABSENT ColumnComputeExpression:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-), Usage: REGULAR}
+           └── 9 Mutation operations
+                ├── MakeIndexAbsent {"IndexID":6,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":6,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":7,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":8,"TableID":104}
+                ├── RemoveColumnComputeExpression {"ColumnID":4,"TableID":104}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":4,"TableID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx__rollback_7_of_16.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx__rollback_7_of_16.explain
@@ -1,0 +1,70 @@
+/* setup */
+CREATE TABLE t (a INT NOT NULL, b INT NOT NULL);
+CREATE INDEX idx_b ON t(b);
+
+/* test */
+alter table t add primary key (a) USING HASH WITH (bucket_count=10);
+EXPLAIN (DDL) rollback at post-commit stage 7 of 16;
+----
+Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY KEY (a) USING HASH WITH ('bucket_count' = ‹10›);
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 1 element transitioning toward PUBLIC
+      │    │    └── VALIDATED             → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 0}
+      │    ├── 17 elements transitioning toward ABSENT
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 5, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (t_pkey-)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 6, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 7}
+      │    │    ├── BACKFILL_ONLY         → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey-), ConstraintID: 7, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 8 (t_pkey-)}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 104 (t), Name: "crdb_internal_a_shard_10", ColumnID: 4 (crdb_internal_a_shard_10-)}
+      │    │    ├── WRITE_ONLY            → ABSENT      ColumnNotNull:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-), IndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-), IndexID: 7}
+      │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-), IndexID: 8 (t_pkey-)}
+      │    └── 20 Mutation operations
+      │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":3,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":7,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"Kind":2,"TableID":104}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":4,"TableID":104}
+      │         ├── SetColumnName {"ColumnID":4,"Name":"crdb_internal_co...","TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":6,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
+      │         ├── RemoveColumnNotNull {"ColumnID":4,"TableID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 7 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 5, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 6 (t_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 7}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 8 (t_pkey-)}
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 4 (crdb_internal_a_shard_10-), TypeName: "INT8"}
+           │    └── PUBLIC      → ABSENT ColumnComputeExpression:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-), Usage: REGULAR}
+           └── 8 Mutation operations
+                ├── MakeIndexAbsent {"IndexID":6,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":6,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":7,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":8,"TableID":104}
+                ├── RemoveColumnComputeExpression {"ColumnID":4,"TableID":104}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":4,"TableID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx__rollback_8_of_16.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx__rollback_8_of_16.explain
@@ -1,0 +1,70 @@
+/* setup */
+CREATE TABLE t (a INT NOT NULL, b INT NOT NULL);
+CREATE INDEX idx_b ON t(b);
+
+/* test */
+alter table t add primary key (a) USING HASH WITH (bucket_count=10);
+EXPLAIN (DDL) rollback at post-commit stage 8 of 16;
+----
+Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY KEY (a) USING HASH WITH ('bucket_count' = ‹10›);
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 1 element transitioning toward PUBLIC
+      │    │    └── VALIDATED             → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 0}
+      │    ├── 17 elements transitioning toward ABSENT
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 5, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (t_pkey-)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 6, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 7}
+      │    │    ├── BACKFILL_ONLY         → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey-), ConstraintID: 7, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 8 (t_pkey-)}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 104 (t), Name: "crdb_internal_a_shard_10", ColumnID: 4 (crdb_internal_a_shard_10-)}
+      │    │    ├── WRITE_ONLY            → ABSENT      ColumnNotNull:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-), IndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-), IndexID: 7}
+      │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-), IndexID: 8 (t_pkey-)}
+      │    └── 20 Mutation operations
+      │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":3,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":7,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"Kind":2,"TableID":104}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":4,"TableID":104}
+      │         ├── SetColumnName {"ColumnID":4,"Name":"crdb_internal_co...","TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":6,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
+      │         ├── RemoveColumnNotNull {"ColumnID":4,"TableID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 7 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 5, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 6 (t_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 7}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 8 (t_pkey-)}
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 4 (crdb_internal_a_shard_10-), TypeName: "INT8"}
+           │    └── PUBLIC      → ABSENT ColumnComputeExpression:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-), Usage: REGULAR}
+           └── 8 Mutation operations
+                ├── MakeIndexAbsent {"IndexID":6,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":6,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":7,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":8,"TableID":104}
+                ├── RemoveColumnComputeExpression {"ColumnID":4,"TableID":104}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":4,"TableID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx__rollback_9_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx__rollback_9_of_15.explain
@@ -8,35 +8,32 @@ EXPLAIN (DDL) rollback at post-commit stage 9 of 15;
 ----
 Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY KEY (a);
  └── PostCommitNonRevertiblePhase
-      ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 3 elements transitioning toward PUBLIC
-      │    │    ├── VALIDATED             → PUBLIC    ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 0}
-      │    │    ├── VALIDATED             → PUBLIC    PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey+), ConstraintID: 1}
-      │    │    └── ABSENT                → PUBLIC    IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey+)}
-      │    ├── 18 elements transitioning toward ABSENT
-      │    │    ├── PUBLIC                → VALIDATED PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC                → ABSENT    IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 6 (t_pkey-)}
-      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT    TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC                → ABSENT    IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 7}
-      │    │    ├── PUBLIC                → ABSENT    IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 7}
-      │    │    ├── PUBLIC                → ABSENT    IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 7}
-      │    │    ├── BACKFILL_ONLY         → ABSENT    PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT    IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 8 (t_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT    IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 8 (t_pkey-)}
-      │    │    ├── DELETE_ONLY           → ABSENT    TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 7, SourceIndexID: 6 (t_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT    IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 9}
-      │    │    ├── PUBLIC                → ABSENT    IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 9}
-      │    │    ├── BACKFILL_ONLY         → ABSENT    SecondaryIndex:{DescID: 104 (t), IndexID: 4 (idx_b-), ConstraintID: 2, TemporaryIndexID: 5, SourceIndexID: 6 (t_pkey-), RecreateSourceIndexID: 2}
-      │    │    ├── PUBLIC                → ABSENT    IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 4 (idx_b-)}
-      │    │    ├── PUBLIC                → ABSENT    IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 4 (idx_b-)}
-      │    │    ├── DELETE_ONLY           → ABSENT    TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 3, SourceIndexID: 6 (t_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT    IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 5}
-      │    │    └── PUBLIC                → ABSENT    IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 5}
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 1 element transitioning toward PUBLIC
+      │    │    └── VALIDATED             → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 0}
+      │    ├── 20 elements transitioning toward ABSENT
+      │    │    ├── VALIDATED             → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (t_pkey-)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 7}
+      │    │    ├── BACKFILL_ONLY         → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 8 (t_pkey-)}
+      │    │    ├── DELETE_ONLY           → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 7, SourceIndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 9}
+      │    │    ├── BACKFILL_ONLY         → ABSENT      SecondaryIndex:{DescID: 104 (t), IndexID: 4 (idx_b-), ConstraintID: 2, TemporaryIndexID: 5, SourceIndexID: 6 (t_pkey-), RecreateSourceIndexID: 2}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 4 (idx_b-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 4 (idx_b-)}
+      │    │    ├── DELETE_ONLY           → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 3, SourceIndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 5}
+      │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 5}
       │    └── 23 Mutation operations
       │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":3,"TableID":104}
-      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
-      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":6,"TableID":104}
-      │         ├── SetIndexName {"IndexID":6,"Name":"crdb_internal_in...","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":7,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":104}
@@ -48,7 +45,10 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY K
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"Kind":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"Kind":1,"TableID":104}
-      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
@@ -56,20 +56,7 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY K
       │         ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
-      ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 4 elements transitioning toward ABSENT
-      │    │    ├── VALIDATED → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC    → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 6 (t_pkey-)}
-      │    │    ├── PUBLIC    → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (t_pkey-)}
-      │    │    └── PUBLIC    → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (t_pkey-)}
-      │    └── 6 Mutation operations
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"Kind":2,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":104}
-      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
-      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
-      └── Stage 3 of 3 in PostCommitNonRevertiblePhase
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
            ├── 5 elements transitioning toward ABSENT
            │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
            │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 6 (t_pkey-)}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx__rollback_9_of_16.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx__rollback_9_of_16.explain
@@ -1,0 +1,96 @@
+/* setup */
+CREATE TABLE t (a INT NOT NULL, b INT NOT NULL);
+CREATE INDEX idx_b ON t(b);
+
+/* test */
+alter table t add primary key (a) USING HASH WITH (bucket_count=10);
+EXPLAIN (DDL) rollback at post-commit stage 9 of 16;
+----
+Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD PRIMARY KEY (a) USING HASH WITH ('bucket_count' = ‹10›);
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 1 element transitioning toward PUBLIC
+      │    │    └── VALIDATED             → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 0}
+      │    ├── 29 elements transitioning toward ABSENT
+      │    │    ├── VALIDATED             → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 5, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (t_pkey-)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 6, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 7}
+      │    │    ├── BACKFILL_ONLY         → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey-), ConstraintID: 7, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 8 (t_pkey-)}
+      │    │    ├── DELETE_ONLY           → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 8, SourceIndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 9}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 104 (t), Name: "crdb_internal_a_shard_10", ColumnID: 4 (crdb_internal_a_shard_10-)}
+      │    │    ├── WRITE_ONLY            → ABSENT      ColumnNotNull:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-), IndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-), IndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-), IndexID: 9}
+      │    │    ├── BACKFILL_ONLY         → ABSENT      SecondaryIndex:{DescID: 104 (t), IndexID: 4 (idx_b-), ConstraintID: 3, TemporaryIndexID: 5, SourceIndexID: 6 (t_pkey-), RecreateSourceIndexID: 2}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 4 (idx_b-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 4 (idx_b-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-), IndexID: 4 (idx_b-)}
+      │    │    ├── DELETE_ONLY           → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 4, SourceIndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 5}
+      │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-), IndexID: 5}
+      │    └── 32 Mutation operations
+      │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":3,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":7,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"Kind":2,"TableID":104}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":4,"TableID":104}
+      │         ├── SetColumnName {"ColumnID":4,"Name":"crdb_internal_co...","TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"Kind":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":4,"Kind":1,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"Kind":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":5,"Kind":1,"Ordinal":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
+      │         ├── RemoveColumnNotNull {"ColumnID":4,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":6,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 8 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 5, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 6 (t_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 7}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 8 (t_pkey-)}
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 4 (crdb_internal_a_shard_10-), TypeName: "INT8"}
+           │    ├── PUBLIC      → ABSENT ColumnComputeExpression:{DescID: 104 (t), ColumnID: 4 (crdb_internal_a_shard_10-), Usage: REGULAR}
+           │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 4 (idx_b-)}
+           └── 9 Mutation operations
+                ├── MakeIndexAbsent {"IndexID":6,"TableID":104}
+                ├── RemoveColumnComputeExpression {"ColumnID":4,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":4,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":6,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":7,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":8,"TableID":104}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":4,"TableID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_type_general/alter_table_alter_column_type_general.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_type_general/alter_table_alter_column_type_general.explain
@@ -166,11 +166,11 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ALTER CO
  │    │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":1,"TableID":104}
  │    │         ├── SetIndexName {"IndexID":1,"Name":"crdb_internal_in...","TableID":104}
  │    │         ├── SetIndexName {"IndexID":2,"Name":"t_pkey","TableID":104}
- │    │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":2,"TableID":104}
  │    │         ├── MakeAbsentTempIndexDeleteOnly {"Index":{"ConstraintID":5,"IndexID":5,"IsUnique":true,"SourceIndexID":2,"TableID":104}}
  │    │         ├── MaybeAddSplitForIndex {"IndexID":5,"TableID":104}
  │    │         ├── AddColumnToIndex {"ColumnID":1,"IndexID":5,"TableID":104}
  │    │         ├── AddColumnToIndex {"ColumnID":3,"IndexID":5,"Kind":2,"TableID":104}
+ │    │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":2,"TableID":104}
  │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
  │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
  │    ├── Stage 9 of 15 in PostCommitPhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_type_general_expr/alter_table_alter_column_type_general_expr.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_column_type_general_expr/alter_table_alter_column_type_general_expr.explain
@@ -166,11 +166,11 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ALTER CO
  │    │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":1,"TableID":104}
  │    │         ├── SetIndexName {"IndexID":1,"Name":"crdb_internal_in...","TableID":104}
  │    │         ├── SetIndexName {"IndexID":2,"Name":"t_pkey","TableID":104}
- │    │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":2,"TableID":104}
  │    │         ├── MakeAbsentTempIndexDeleteOnly {"Index":{"ConstraintID":5,"IndexID":5,"IsUnique":true,"SourceIndexID":2,"TableID":104}}
  │    │         ├── MaybeAddSplitForIndex {"IndexID":5,"TableID":104}
  │    │         ├── AddColumnToIndex {"ColumnID":1,"IndexID":5,"TableID":104}
  │    │         ├── AddColumnToIndex {"ColumnID":3,"IndexID":5,"Kind":2,"TableID":104}
+ │    │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":2,"TableID":104}
  │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
  │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
  │    ├── Stage 9 of 15 in PostCommitPhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid/alter_table_alter_primary_key_drop_rowid.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid/alter_table_alter_primary_key_drop_rowid.explain
@@ -139,10 +139,10 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ALTER PR
  │    │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":1,"TableID":104}
  │    │         ├── SetIndexName {"IndexID":1,"Name":"crdb_internal_in...","TableID":104}
  │    │         ├── SetIndexName {"IndexID":2,"Name":"t_pkey","TableID":104}
- │    │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":2,"TableID":104}
  │    │         ├── MakeAbsentTempIndexDeleteOnly {"Index":{"ConstraintID":5,"IndexID":5,"IsUnique":true,"SourceIndexID":2,"TableID":104}}
  │    │         ├── MaybeAddSplitForIndex {"IndexID":5,"TableID":104}
  │    │         ├── AddColumnToIndex {"ColumnID":1,"IndexID":5,"TableID":104}
+ │    │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":2,"TableID":104}
  │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
  │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
  │    ├── Stage 9 of 15 in PostCommitPhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx/alter_table_alter_primary_key_drop_rowid_with_idx.definition
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx/alter_table_alter_primary_key_drop_rowid_with_idx.definition
@@ -1,0 +1,44 @@
+setup
+CREATE TABLE t (a INT NOT NULL, b int8 not null default unique_rowid());
+INSERT INTO t(a) VALUES (1), (2), (2);
+CREATE INDEX on t(a);
+----
+
+stage-exec phase=PostCommitPhase stage=:
+INSERT INTO t(a) VALUES($stageKey);
+INSERT INTO t(a) VALUES($stageKey + 1);
+----
+
+# Each insert will be injected twice per stage, so we should always,
+# see a count of 2.
+stage-query phase=PostCommitPhase stage=:
+SELECT count(*)=3+($successfulStageCount*2) FROM t;
+----
+true
+
+# Ensure the index is accessible
+stage-query phase=PostCommitPhase stage=:
+SELECT count(*)=3+($successfulStageCount*2) FROM t@t_a_idx WHERE b > 0;
+----
+true
+
+stage-exec phase=PostCommitNonRevertiblePhase stage=:
+INSERT INTO t(a) VALUES($stageKey);
+INSERT INTO t(a) VALUES($stageKey + 1);
+----
+
+# Each insert will be injected twice per stage, so we should always,
+# see a count of 2.
+stage-query phase=PostCommitNonRevertiblePhase stage=:
+SELECT count(*)=3+($successfulStageCount*2) FROM t;
+----
+true
+
+stage-query phase=PostCommitNonRevertiblePhase stage=:
+SELECT count(*)=3+($successfulStageCount*2) FROM t@t_a_idx WHERE b > 0;
+----
+true
+
+test
+alter table t add column m int8 default unique_rowid(), alter primary key using columns(b);
+----

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx/alter_table_alter_primary_key_drop_rowid_with_idx.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx/alter_table_alter_primary_key_drop_rowid_with_idx.explain
@@ -411,7 +411,7 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ADD COLU
       │    │    ├── PUBLIC                → ABSENT              IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 1 (t_pkey-)}
       │    │    ├── VALIDATED             → DELETE_ONLY         PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey-), ConstraintID: 1}
       │    │    └── PUBLIC                → VALIDATED           SecondaryIndex:{DescID: 104 (t), IndexID: 2 (t_a_idx-), RecreateSourceIndexID: 0}
-      │    └── 34 Mutation operations
+      │    └── 35 Mutation operations
       │         ├── RemoveColumnNotNull {"ColumnID":3,"TableID":104}
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":6,"TableID":104}
       │         ├── SetIndexName {"IndexID":6,"Name":"crdb_internal_in...","TableID":104}
@@ -431,6 +431,7 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ADD COLU
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":1,"TableID":104}
       │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":8,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":11,"TableID":104}
+      │         ├── MarkRecreatedIndexAsInvisible {"IndexID":4,"TableID":104,"TargetPrimaryIndexID":10}
       │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":4,"TableID":104}
       │         ├── RefreshStats {"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
@@ -466,7 +467,7 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ADD COLU
       │    │    ├── PUBLIC              → ABSENT                IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid-), IndexID: 2 (t_a_idx-)}
       │    │    ├── VALIDATED           → DELETE_ONLY           SecondaryIndex:{DescID: 104 (t), IndexID: 2 (t_a_idx-), RecreateSourceIndexID: 0}
       │    │    └── PUBLIC              → ABSENT                IndexName:{DescID: 104 (t), Name: "t_a_idx", IndexID: 2 (t_a_idx-)}
-      │    └── 19 Mutation operations
+      │    └── 20 Mutation operations
       │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":3,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":1,"TableID":104}
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":8,"TableID":104}
@@ -479,6 +480,7 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ADD COLU
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":104}
       │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":10,"TableID":104}
+      │         ├── MarkRecreatedIndexesAsVisible {"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":6,"Kind":2,"Ordinal":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":2,"Kind":1,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx/alter_table_alter_primary_key_drop_rowid_with_idx.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx/alter_table_alter_primary_key_drop_rowid_with_idx.explain
@@ -1,0 +1,537 @@
+/* setup */
+CREATE TABLE t (a INT NOT NULL, b int8 not null default unique_rowid());
+INSERT INTO t(a) VALUES (1), (2), (2);
+CREATE INDEX on t(a);
+
+/* test */
+EXPLAIN (DDL) alter table t add column m int8 default unique_rowid(), alter primary key using columns(b);
+----
+Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ADD COLUMN ‹m› INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (‹b›);
+ ├── StatementPhase
+ │    └── Stage 1 of 1 in StatementPhase
+ │         ├── 9 elements transitioning toward PUBLIC
+ │         │    ├── ABSENT → DELETE_ONLY   Column:{DescID: 104 (t), ColumnID: 4 (m+)}
+ │         │    ├── ABSENT → PUBLIC        ColumnName:{DescID: 104 (t), Name: "m", ColumnID: 4 (m+)}
+ │         │    ├── ABSENT → PUBLIC        ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 4 (m+), TypeName: "INT8"}
+ │         │    ├── ABSENT → PUBLIC        ColumnDefaultExpression:{DescID: 104 (t), ColumnID: 4 (m+), Expr: unique_rowid()}
+ │         │    ├── ABSENT → BACKFILL_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey+), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 8 (t_pkey~)}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 10 (t_pkey+)}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 10 (t_pkey+)}
+ │         │    ├── ABSENT → PUBLIC        IndexData:{DescID: 104 (t), IndexID: 10 (t_pkey+)}
+ │         │    └── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 4 (m+), IndexID: 10 (t_pkey+)}
+ │         ├── 17 elements transitioning toward TRANSIENT_ABSENT
+ │         │    ├── ABSENT → BACKFILL_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey~), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey-)}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid-), IndexID: 6 (t_pkey~)}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (t_pkey~)}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (t_pkey~)}
+ │         │    ├── ABSENT → PUBLIC        IndexData:{DescID: 104 (t), IndexID: 6 (t_pkey~)}
+ │         │    ├── ABSENT → DELETE_ONLY   TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 5, SourceIndexID: 1 (t_pkey-)}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid-), IndexID: 7}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 7}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 7}
+ │         │    ├── ABSENT → BACKFILL_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey~), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey~)}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid-), IndexID: 8 (t_pkey~)}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 8 (t_pkey~)}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 8 (t_pkey~)}
+ │         │    ├── ABSENT → PUBLIC        IndexData:{DescID: 104 (t), IndexID: 8 (t_pkey~)}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 4 (m+), IndexID: 6 (t_pkey~)}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 4 (m+), IndexID: 7}
+ │         │    └── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 4 (m+), IndexID: 8 (t_pkey~)}
+ │         ├── 1 element transitioning toward ABSENT
+ │         │    └── PUBLIC → VALIDATED     ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (rowid-), IndexID: 0}
+ │         └── 24 Mutation operations
+ │              ├── MakePublicColumnNotNullValidated {"ColumnID":3,"TableID":104}
+ │              ├── MakeAbsentColumnDeleteOnly {"Column":{"ColumnID":4,"TableID":104}}
+ │              ├── SetColumnName {"ColumnID":4,"Name":"m","TableID":104}
+ │              ├── UpsertColumnType {"ColumnType":{"ColumnID":4,"IsNullable":true,"TableID":104}}
+ │              ├── AddColumnDefaultExpression {"Default":{"ColumnID":4,"TableID":104}}
+ │              ├── MakeAbsentIndexBackfilling {"Index":{"ConstraintID":4,"IndexID":6,"IsUnique":true,"SourceIndexID":1,"TableID":104,"TemporaryIndexID":7}}
+ │              ├── AddColumnToIndex {"ColumnID":3,"IndexID":6,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":6,"Kind":2,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":104}
+ │              ├── MakeAbsentTempIndexDeleteOnly {"Index":{"ConstraintID":5,"IndexID":7,"IsUnique":true,"SourceIndexID":1,"TableID":104}}
+ │              ├── AddColumnToIndex {"ColumnID":3,"IndexID":7,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":7,"Kind":2,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":104}
+ │              ├── MakeAbsentIndexBackfilling {"Index":{"ConstraintID":6,"IndexID":8,"IsUnique":true,"SourceIndexID":6,"TableID":104,"TemporaryIndexID":9}}
+ │              ├── AddColumnToIndex {"ColumnID":3,"IndexID":8,"Kind":2,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":8,"TableID":104}
+ │              ├── MakeAbsentIndexBackfilling {"Index":{"ConstraintID":8,"IndexID":10,"IsUnique":true,"SourceIndexID":8,"TableID":104,"TemporaryIndexID":11}}
+ │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":10,"Kind":2,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":10,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":4,"IndexID":6,"Kind":2,"Ordinal":2,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":4,"IndexID":7,"Kind":2,"Ordinal":2,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":4,"IndexID":8,"Kind":2,"Ordinal":2,"TableID":104}
+ │              └── AddColumnToIndex {"ColumnID":4,"IndexID":10,"Kind":2,"Ordinal":1,"TableID":104}
+ ├── PreCommitPhase
+ │    ├── Stage 1 of 2 in PreCommitPhase
+ │    │    ├── 9 elements transitioning toward PUBLIC
+ │    │    │    ├── DELETE_ONLY   → ABSENT Column:{DescID: 104 (t), ColumnID: 4 (m+)}
+ │    │    │    ├── PUBLIC        → ABSENT ColumnName:{DescID: 104 (t), Name: "m", ColumnID: 4 (m+)}
+ │    │    │    ├── PUBLIC        → ABSENT ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 4 (m+), TypeName: "INT8"}
+ │    │    │    ├── PUBLIC        → ABSENT ColumnDefaultExpression:{DescID: 104 (t), ColumnID: 4 (m+), Expr: unique_rowid()}
+ │    │    │    ├── BACKFILL_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey+), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 8 (t_pkey~)}
+ │    │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 10 (t_pkey+)}
+ │    │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 10 (t_pkey+)}
+ │    │    │    ├── PUBLIC        → ABSENT IndexData:{DescID: 104 (t), IndexID: 10 (t_pkey+)}
+ │    │    │    └── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 4 (m+), IndexID: 10 (t_pkey+)}
+ │    │    ├── 17 elements transitioning toward TRANSIENT_ABSENT
+ │    │    │    ├── BACKFILL_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey~), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey-)}
+ │    │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid-), IndexID: 6 (t_pkey~)}
+ │    │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (t_pkey~)}
+ │    │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (t_pkey~)}
+ │    │    │    ├── PUBLIC        → ABSENT IndexData:{DescID: 104 (t), IndexID: 6 (t_pkey~)}
+ │    │    │    ├── DELETE_ONLY   → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 5, SourceIndexID: 1 (t_pkey-)}
+ │    │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid-), IndexID: 7}
+ │    │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 7}
+ │    │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 7}
+ │    │    │    ├── BACKFILL_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey~), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey~)}
+ │    │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid-), IndexID: 8 (t_pkey~)}
+ │    │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 8 (t_pkey~)}
+ │    │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 8 (t_pkey~)}
+ │    │    │    ├── PUBLIC        → ABSENT IndexData:{DescID: 104 (t), IndexID: 8 (t_pkey~)}
+ │    │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 4 (m+), IndexID: 6 (t_pkey~)}
+ │    │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 4 (m+), IndexID: 7}
+ │    │    │    └── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 4 (m+), IndexID: 8 (t_pkey~)}
+ │    │    ├── 1 element transitioning toward ABSENT
+ │    │    │    └── VALIDATED     → PUBLIC ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (rowid-), IndexID: 0}
+ │    │    └── 1 Mutation operation
+ │    │         └── UndoAllInTxnImmediateMutationOpSideEffects
+ │    └── Stage 2 of 2 in PreCommitPhase
+ │         ├── 9 elements transitioning toward PUBLIC
+ │         │    ├── ABSENT → DELETE_ONLY   Column:{DescID: 104 (t), ColumnID: 4 (m+)}
+ │         │    ├── ABSENT → PUBLIC        ColumnName:{DescID: 104 (t), Name: "m", ColumnID: 4 (m+)}
+ │         │    ├── ABSENT → PUBLIC        ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 4 (m+), TypeName: "INT8"}
+ │         │    ├── ABSENT → PUBLIC        ColumnDefaultExpression:{DescID: 104 (t), ColumnID: 4 (m+), Expr: unique_rowid()}
+ │         │    ├── ABSENT → BACKFILL_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey+), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 8 (t_pkey~)}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 10 (t_pkey+)}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 10 (t_pkey+)}
+ │         │    ├── ABSENT → PUBLIC        IndexData:{DescID: 104 (t), IndexID: 10 (t_pkey+)}
+ │         │    └── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 4 (m+), IndexID: 10 (t_pkey+)}
+ │         ├── 17 elements transitioning toward TRANSIENT_ABSENT
+ │         │    ├── ABSENT → BACKFILL_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey~), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey-)}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid-), IndexID: 6 (t_pkey~)}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (t_pkey~)}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (t_pkey~)}
+ │         │    ├── ABSENT → PUBLIC        IndexData:{DescID: 104 (t), IndexID: 6 (t_pkey~)}
+ │         │    ├── ABSENT → DELETE_ONLY   TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 5, SourceIndexID: 1 (t_pkey-)}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid-), IndexID: 7}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 7}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 7}
+ │         │    ├── ABSENT → BACKFILL_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey~), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey~)}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid-), IndexID: 8 (t_pkey~)}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 8 (t_pkey~)}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 8 (t_pkey~)}
+ │         │    ├── ABSENT → PUBLIC        IndexData:{DescID: 104 (t), IndexID: 8 (t_pkey~)}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 4 (m+), IndexID: 6 (t_pkey~)}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 4 (m+), IndexID: 7}
+ │         │    └── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 4 (m+), IndexID: 8 (t_pkey~)}
+ │         ├── 1 element transitioning toward ABSENT
+ │         │    └── PUBLIC → VALIDATED     ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (rowid-), IndexID: 0}
+ │         └── 30 Mutation operations
+ │              ├── MakePublicColumnNotNullValidated {"ColumnID":3,"TableID":104}
+ │              ├── MakeAbsentColumnDeleteOnly {"Column":{"ColumnID":4,"TableID":104}}
+ │              ├── SetColumnName {"ColumnID":4,"Name":"m","TableID":104}
+ │              ├── UpsertColumnType {"ColumnType":{"ColumnID":4,"IsNullable":true,"TableID":104}}
+ │              ├── AddColumnDefaultExpression {"Default":{"ColumnID":4,"TableID":104}}
+ │              ├── MakeAbsentIndexBackfilling {"Index":{"ConstraintID":4,"IndexID":6,"IsUnique":true,"SourceIndexID":1,"TableID":104,"TemporaryIndexID":7}}
+ │              ├── MaybeAddSplitForIndex {"IndexID":6,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":3,"IndexID":6,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":6,"Kind":2,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":104}
+ │              ├── MakeAbsentTempIndexDeleteOnly {"Index":{"ConstraintID":5,"IndexID":7,"IsUnique":true,"SourceIndexID":1,"TableID":104}}
+ │              ├── MaybeAddSplitForIndex {"IndexID":7,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":3,"IndexID":7,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":7,"Kind":2,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":104}
+ │              ├── MakeAbsentIndexBackfilling {"Index":{"ConstraintID":6,"IndexID":8,"IsUnique":true,"SourceIndexID":6,"TableID":104,"TemporaryIndexID":9}}
+ │              ├── MaybeAddSplitForIndex {"IndexID":8,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":3,"IndexID":8,"Kind":2,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":8,"TableID":104}
+ │              ├── MakeAbsentIndexBackfilling {"Index":{"ConstraintID":8,"IndexID":10,"IsUnique":true,"SourceIndexID":8,"TableID":104,"TemporaryIndexID":11}}
+ │              ├── MaybeAddSplitForIndex {"IndexID":10,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":10,"Kind":2,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":10,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":4,"IndexID":6,"Kind":2,"Ordinal":2,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":4,"IndexID":7,"Kind":2,"Ordinal":2,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":4,"IndexID":8,"Kind":2,"Ordinal":2,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":4,"IndexID":10,"Kind":2,"Ordinal":1,"TableID":104}
+ │              ├── SetJobStateOnDescriptor {"DescriptorID":104,"Initialize":true}
+ │              └── CreateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
+ ├── PostCommitPhase
+ │    ├── Stage 1 of 23 in PostCommitPhase
+ │    │    ├── 1 element transitioning toward PUBLIC
+ │    │    │    └── DELETE_ONLY → WRITE_ONLY Column:{DescID: 104 (t), ColumnID: 4 (m+)}
+ │    │    ├── 2 elements transitioning toward TRANSIENT_ABSENT
+ │    │    │    ├── DELETE_ONLY → WRITE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 5, SourceIndexID: 1 (t_pkey-)}
+ │    │    │    └── ABSENT      → PUBLIC     IndexData:{DescID: 104 (t), IndexID: 7}
+ │    │    └── 4 Mutation operations
+ │    │         ├── MakeDeleteOnlyColumnWriteOnly {"ColumnID":4,"TableID":104}
+ │    │         ├── MakeDeleteOnlyIndexWriteOnly {"IndexID":7,"TableID":104}
+ │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+ │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
+ │    ├── Stage 2 of 23 in PostCommitPhase
+ │    │    ├── 1 element transitioning toward TRANSIENT_ABSENT
+ │    │    │    └── BACKFILL_ONLY → BACKFILLED PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey~), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey-)}
+ │    │    └── 1 Backfill operation
+ │    │         └── BackfillIndex {"IndexID":6,"SourceIndexID":1,"TableID":104}
+ │    ├── Stage 3 of 23 in PostCommitPhase
+ │    │    ├── 1 element transitioning toward TRANSIENT_ABSENT
+ │    │    │    └── BACKFILLED → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey~), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey-)}
+ │    │    └── 3 Mutation operations
+ │    │         ├── MakeBackfillingIndexDeleteOnly {"IndexID":6,"TableID":104}
+ │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+ │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
+ │    ├── Stage 4 of 23 in PostCommitPhase
+ │    │    ├── 1 element transitioning toward TRANSIENT_ABSENT
+ │    │    │    └── DELETE_ONLY → MERGE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey~), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey-)}
+ │    │    └── 3 Mutation operations
+ │    │         ├── MakeBackfilledIndexMerging {"IndexID":6,"TableID":104}
+ │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+ │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
+ │    ├── Stage 5 of 23 in PostCommitPhase
+ │    │    ├── 1 element transitioning toward TRANSIENT_ABSENT
+ │    │    │    └── MERGE_ONLY → MERGED PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey~), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey-)}
+ │    │    └── 1 Backfill operation
+ │    │         └── MergeIndex {"BackfilledIndexID":6,"TableID":104,"TemporaryIndexID":7}
+ │    ├── Stage 6 of 23 in PostCommitPhase
+ │    │    ├── 2 elements transitioning toward TRANSIENT_ABSENT
+ │    │    │    ├── MERGED     → WRITE_ONLY            PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey~), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey-)}
+ │    │    │    └── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 5, SourceIndexID: 1 (t_pkey-)}
+ │    │    └── 4 Mutation operations
+ │    │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":7,"TableID":104}
+ │    │         ├── MakeMergedIndexWriteOnly {"IndexID":6,"TableID":104}
+ │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+ │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
+ │    ├── Stage 7 of 23 in PostCommitPhase
+ │    │    ├── 1 element transitioning toward TRANSIENT_ABSENT
+ │    │    │    └── WRITE_ONLY → VALIDATED PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey~), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey-)}
+ │    │    └── 1 Validation operation
+ │    │         └── ValidateIndex {"IndexID":6,"TableID":104}
+ │    ├── Stage 8 of 23 in PostCommitPhase
+ │    │    ├── 7 elements transitioning toward TRANSIENT_ABSENT
+ │    │    │    ├── VALIDATED → PUBLIC      PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey~), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey-)}
+ │    │    │    ├── ABSENT    → PUBLIC      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 6 (t_pkey~)}
+ │    │    │    ├── ABSENT    → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 7, SourceIndexID: 6 (t_pkey~)}
+ │    │    │    ├── ABSENT    → PUBLIC      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid-), IndexID: 9}
+ │    │    │    ├── ABSENT    → PUBLIC      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 9}
+ │    │    │    ├── ABSENT    → PUBLIC      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 9}
+ │    │    │    └── ABSENT    → PUBLIC      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m+), IndexID: 9}
+ │    │    ├── 2 elements transitioning toward ABSENT
+ │    │    │    ├── PUBLIC    → VALIDATED   PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey-), ConstraintID: 1}
+ │    │    │    └── PUBLIC    → ABSENT      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey-)}
+ │    │    └── 12 Mutation operations
+ │    │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":1,"TableID":104}
+ │    │         ├── SetIndexName {"IndexID":1,"Name":"crdb_internal_in...","TableID":104}
+ │    │         ├── SetIndexName {"IndexID":6,"Name":"t_pkey","TableID":104}
+ │    │         ├── MakeAbsentTempIndexDeleteOnly {"Index":{"ConstraintID":7,"IndexID":9,"IsUnique":true,"SourceIndexID":6,"TableID":104}}
+ │    │         ├── MaybeAddSplitForIndex {"IndexID":9,"TableID":104}
+ │    │         ├── AddColumnToIndex {"ColumnID":3,"IndexID":9,"Kind":2,"TableID":104}
+ │    │         ├── AddColumnToIndex {"ColumnID":1,"IndexID":9,"Kind":2,"Ordinal":1,"TableID":104}
+ │    │         ├── AddColumnToIndex {"ColumnID":2,"IndexID":9,"TableID":104}
+ │    │         ├── AddColumnToIndex {"ColumnID":4,"IndexID":9,"Kind":2,"Ordinal":2,"TableID":104}
+ │    │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":6,"TableID":104}
+ │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+ │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
+ │    ├── Stage 9 of 23 in PostCommitPhase
+ │    │    ├── 2 elements transitioning toward TRANSIENT_ABSENT
+ │    │    │    ├── DELETE_ONLY → WRITE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 7, SourceIndexID: 6 (t_pkey~)}
+ │    │    │    └── ABSENT      → PUBLIC     IndexData:{DescID: 104 (t), IndexID: 9}
+ │    │    └── 3 Mutation operations
+ │    │         ├── MakeDeleteOnlyIndexWriteOnly {"IndexID":9,"TableID":104}
+ │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+ │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
+ │    ├── Stage 10 of 23 in PostCommitPhase
+ │    │    ├── 1 element transitioning toward TRANSIENT_ABSENT
+ │    │    │    └── BACKFILL_ONLY → BACKFILLED PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey~), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey~)}
+ │    │    └── 1 Backfill operation
+ │    │         └── BackfillIndex {"IndexID":8,"SourceIndexID":6,"TableID":104}
+ │    ├── Stage 11 of 23 in PostCommitPhase
+ │    │    ├── 1 element transitioning toward TRANSIENT_ABSENT
+ │    │    │    └── BACKFILLED → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey~), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey~)}
+ │    │    └── 3 Mutation operations
+ │    │         ├── MakeBackfillingIndexDeleteOnly {"IndexID":8,"TableID":104}
+ │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+ │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
+ │    ├── Stage 12 of 23 in PostCommitPhase
+ │    │    ├── 1 element transitioning toward TRANSIENT_ABSENT
+ │    │    │    └── DELETE_ONLY → MERGE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey~), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey~)}
+ │    │    └── 3 Mutation operations
+ │    │         ├── MakeBackfilledIndexMerging {"IndexID":8,"TableID":104}
+ │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+ │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
+ │    ├── Stage 13 of 23 in PostCommitPhase
+ │    │    ├── 1 element transitioning toward TRANSIENT_ABSENT
+ │    │    │    └── MERGE_ONLY → MERGED PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey~), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey~)}
+ │    │    └── 1 Backfill operation
+ │    │         └── MergeIndex {"BackfilledIndexID":8,"TableID":104,"TemporaryIndexID":9}
+ │    ├── Stage 14 of 23 in PostCommitPhase
+ │    │    ├── 2 elements transitioning toward TRANSIENT_ABSENT
+ │    │    │    ├── MERGED     → WRITE_ONLY            PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey~), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey~)}
+ │    │    │    └── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 7, SourceIndexID: 6 (t_pkey~)}
+ │    │    └── 4 Mutation operations
+ │    │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":9,"TableID":104}
+ │    │         ├── MakeMergedIndexWriteOnly {"IndexID":8,"TableID":104}
+ │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+ │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
+ │    ├── Stage 15 of 23 in PostCommitPhase
+ │    │    ├── 1 element transitioning toward TRANSIENT_ABSENT
+ │    │    │    └── WRITE_ONLY → VALIDATED PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey~), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey~)}
+ │    │    └── 1 Validation operation
+ │    │         └── ValidateIndex {"IndexID":8,"TableID":104}
+ │    ├── Stage 16 of 23 in PostCommitPhase
+ │    │    ├── 4 elements transitioning toward PUBLIC
+ │    │    │    ├── ABSENT → BACKFILL_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_a_idx+), ConstraintID: 2, TemporaryIndexID: 5, SourceIndexID: 8 (t_pkey~), RecreateSourceIndexID: 2}
+ │    │    │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 4 (t_a_idx+)}
+ │    │    │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 4 (t_a_idx+)}
+ │    │    │    └── ABSENT → PUBLIC        IndexData:{DescID: 104 (t), IndexID: 4 (t_a_idx+)}
+ │    │    ├── 7 elements transitioning toward TRANSIENT_ABSENT
+ │    │    │    ├── ABSENT → DELETE_ONLY   TemporaryIndex:{DescID: 104 (t), IndexID: 11, ConstraintID: 9, SourceIndexID: 8 (t_pkey~)}
+ │    │    │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 11}
+ │    │    │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 11}
+ │    │    │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 4 (m+), IndexID: 11}
+ │    │    │    ├── ABSENT → DELETE_ONLY   TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 3, SourceIndexID: 8 (t_pkey~)}
+ │    │    │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 5}
+ │    │    │    └── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 5}
+ │    │    └── 15 Mutation operations
+ │    │         ├── MakeAbsentTempIndexDeleteOnly {"Index":{"ConstraintID":9,"IndexID":11,"IsUnique":true,"SourceIndexID":8,"TableID":104}}
+ │    │         ├── MaybeAddSplitForIndex {"IndexID":11,"TableID":104}
+ │    │         ├── AddColumnToIndex {"ColumnID":1,"IndexID":11,"Kind":2,"TableID":104}
+ │    │         ├── AddColumnToIndex {"ColumnID":2,"IndexID":11,"TableID":104}
+ │    │         ├── AddColumnToIndex {"ColumnID":4,"IndexID":11,"Kind":2,"Ordinal":1,"TableID":104}
+ │    │         ├── MakeAbsentIndexBackfilling {"IsSecondaryIndex":true}
+ │    │         ├── MaybeAddSplitForIndex {"IndexID":4,"TableID":104}
+ │    │         ├── AddColumnToIndex {"ColumnID":1,"IndexID":4,"TableID":104}
+ │    │         ├── AddColumnToIndex {"ColumnID":2,"IndexID":4,"Kind":1,"TableID":104}
+ │    │         ├── MakeAbsentTempIndexDeleteOnly {"IsSecondaryIndex":true}
+ │    │         ├── MaybeAddSplitForIndex {"IndexID":5,"TableID":104}
+ │    │         ├── AddColumnToIndex {"ColumnID":1,"IndexID":5,"TableID":104}
+ │    │         ├── AddColumnToIndex {"ColumnID":2,"IndexID":5,"Kind":1,"TableID":104}
+ │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+ │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
+ │    ├── Stage 17 of 23 in PostCommitPhase
+ │    │    ├── 4 elements transitioning toward TRANSIENT_ABSENT
+ │    │    │    ├── DELETE_ONLY → WRITE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 11, ConstraintID: 9, SourceIndexID: 8 (t_pkey~)}
+ │    │    │    ├── ABSENT      → PUBLIC     IndexData:{DescID: 104 (t), IndexID: 11}
+ │    │    │    ├── DELETE_ONLY → WRITE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 3, SourceIndexID: 8 (t_pkey~)}
+ │    │    │    └── ABSENT      → PUBLIC     IndexData:{DescID: 104 (t), IndexID: 5}
+ │    │    └── 4 Mutation operations
+ │    │         ├── MakeDeleteOnlyIndexWriteOnly {"IndexID":11,"TableID":104}
+ │    │         ├── MakeDeleteOnlyIndexWriteOnly {"IndexID":5,"TableID":104}
+ │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+ │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
+ │    ├── Stage 18 of 23 in PostCommitPhase
+ │    │    ├── 2 elements transitioning toward PUBLIC
+ │    │    │    ├── BACKFILL_ONLY → BACKFILLED PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey+), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 8 (t_pkey~)}
+ │    │    │    └── BACKFILL_ONLY → BACKFILLED SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_a_idx+), ConstraintID: 2, TemporaryIndexID: 5, SourceIndexID: 8 (t_pkey~), RecreateSourceIndexID: 2}
+ │    │    └── 2 Backfill operations
+ │    │         ├── BackfillIndex {"IndexID":10,"SourceIndexID":8,"TableID":104}
+ │    │         └── BackfillIndex {"IndexID":4,"SourceIndexID":8,"TableID":104}
+ │    ├── Stage 19 of 23 in PostCommitPhase
+ │    │    ├── 2 elements transitioning toward PUBLIC
+ │    │    │    ├── BACKFILLED → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey+), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 8 (t_pkey~)}
+ │    │    │    └── BACKFILLED → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_a_idx+), ConstraintID: 2, TemporaryIndexID: 5, SourceIndexID: 8 (t_pkey~), RecreateSourceIndexID: 2}
+ │    │    └── 4 Mutation operations
+ │    │         ├── MakeBackfillingIndexDeleteOnly {"IndexID":10,"TableID":104}
+ │    │         ├── MakeBackfillingIndexDeleteOnly {"IndexID":4,"TableID":104}
+ │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+ │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
+ │    ├── Stage 20 of 23 in PostCommitPhase
+ │    │    ├── 2 elements transitioning toward PUBLIC
+ │    │    │    ├── DELETE_ONLY → MERGE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey+), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 8 (t_pkey~)}
+ │    │    │    └── DELETE_ONLY → MERGE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_a_idx+), ConstraintID: 2, TemporaryIndexID: 5, SourceIndexID: 8 (t_pkey~), RecreateSourceIndexID: 2}
+ │    │    └── 4 Mutation operations
+ │    │         ├── MakeBackfilledIndexMerging {"IndexID":10,"TableID":104}
+ │    │         ├── MakeBackfilledIndexMerging {"IndexID":4,"TableID":104}
+ │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+ │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
+ │    ├── Stage 21 of 23 in PostCommitPhase
+ │    │    ├── 2 elements transitioning toward PUBLIC
+ │    │    │    ├── MERGE_ONLY → MERGED PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey+), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 8 (t_pkey~)}
+ │    │    │    └── MERGE_ONLY → MERGED SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_a_idx+), ConstraintID: 2, TemporaryIndexID: 5, SourceIndexID: 8 (t_pkey~), RecreateSourceIndexID: 2}
+ │    │    └── 2 Backfill operations
+ │    │         ├── MergeIndex {"BackfilledIndexID":10,"TableID":104,"TemporaryIndexID":11}
+ │    │         └── MergeIndex {"BackfilledIndexID":4,"TableID":104,"TemporaryIndexID":5}
+ │    ├── Stage 22 of 23 in PostCommitPhase
+ │    │    ├── 2 elements transitioning toward PUBLIC
+ │    │    │    ├── MERGED     → WRITE_ONLY            PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey+), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 8 (t_pkey~)}
+ │    │    │    └── MERGED     → WRITE_ONLY            SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_a_idx+), ConstraintID: 2, TemporaryIndexID: 5, SourceIndexID: 8 (t_pkey~), RecreateSourceIndexID: 2}
+ │    │    ├── 2 elements transitioning toward TRANSIENT_ABSENT
+ │    │    │    ├── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 11, ConstraintID: 9, SourceIndexID: 8 (t_pkey~)}
+ │    │    │    └── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 3, SourceIndexID: 8 (t_pkey~)}
+ │    │    └── 6 Mutation operations
+ │    │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":11,"TableID":104}
+ │    │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":5,"TableID":104}
+ │    │         ├── MakeMergedIndexWriteOnly {"IndexID":10,"TableID":104}
+ │    │         ├── MakeMergedIndexWriteOnly {"IndexID":4,"TableID":104}
+ │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+ │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
+ │    └── Stage 23 of 23 in PostCommitPhase
+ │         ├── 2 elements transitioning toward PUBLIC
+ │         │    ├── WRITE_ONLY → VALIDATED PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey+), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 8 (t_pkey~)}
+ │         │    └── WRITE_ONLY → VALIDATED SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_a_idx+), ConstraintID: 2, TemporaryIndexID: 5, SourceIndexID: 8 (t_pkey~), RecreateSourceIndexID: 2}
+ │         └── 2 Validation operations
+ │              ├── ValidateIndex {"IndexID":10,"TableID":104}
+ │              └── ValidateIndex {"IndexID":4,"TableID":104}
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 4 in PostCommitNonRevertiblePhase
+      │    ├── 2 elements transitioning toward PUBLIC
+      │    │    ├── VALIDATED             → PUBLIC              SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_a_idx+), ConstraintID: 2, TemporaryIndexID: 5, SourceIndexID: 8 (t_pkey~), RecreateSourceIndexID: 2}
+      │    │    └── ABSENT                → PUBLIC              IndexName:{DescID: 104 (t), Name: "t_a_idx", IndexID: 4 (t_a_idx+)}
+      │    ├── 21 elements transitioning toward TRANSIENT_ABSENT
+      │    │    ├── PUBLIC                → TRANSIENT_VALIDATED PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey~), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey-)}
+      │    │    ├── PUBLIC                → TRANSIENT_ABSENT    IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 6 (t_pkey~)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT    TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 5, SourceIndexID: 1 (t_pkey-)}
+      │    │    ├── PUBLIC                → TRANSIENT_ABSENT    IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid-), IndexID: 7}
+      │    │    ├── PUBLIC                → TRANSIENT_ABSENT    IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 7}
+      │    │    ├── PUBLIC                → TRANSIENT_ABSENT    IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 7}
+      │    │    ├── VALIDATED             → PUBLIC              PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey~), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey~)}
+      │    │    ├── ABSENT                → PUBLIC              IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 8 (t_pkey~)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT    TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 7, SourceIndexID: 6 (t_pkey~)}
+      │    │    ├── PUBLIC                → TRANSIENT_ABSENT    IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid-), IndexID: 9}
+      │    │    ├── PUBLIC                → TRANSIENT_ABSENT    IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 9}
+      │    │    ├── PUBLIC                → TRANSIENT_ABSENT    IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 9}
+      │    │    ├── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT    TemporaryIndex:{DescID: 104 (t), IndexID: 11, ConstraintID: 9, SourceIndexID: 8 (t_pkey~)}
+      │    │    ├── PUBLIC                → TRANSIENT_ABSENT    IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 11}
+      │    │    ├── PUBLIC                → TRANSIENT_ABSENT    IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 11}
+      │    │    ├── PUBLIC                → TRANSIENT_ABSENT    IndexColumn:{DescID: 104 (t), ColumnID: 4 (m+), IndexID: 7}
+      │    │    ├── PUBLIC                → TRANSIENT_ABSENT    IndexColumn:{DescID: 104 (t), ColumnID: 4 (m+), IndexID: 9}
+      │    │    ├── PUBLIC                → TRANSIENT_ABSENT    IndexColumn:{DescID: 104 (t), ColumnID: 4 (m+), IndexID: 11}
+      │    │    ├── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT    TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 3, SourceIndexID: 8 (t_pkey~)}
+      │    │    ├── PUBLIC                → TRANSIENT_ABSENT    IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 5}
+      │    │    └── PUBLIC                → TRANSIENT_ABSENT    IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 5}
+      │    ├── 8 elements transitioning toward ABSENT
+      │    │    ├── PUBLIC                → WRITE_ONLY          Column:{DescID: 104 (t), ColumnID: 3 (rowid-)}
+      │    │    ├── PUBLIC                → ABSENT              ColumnName:{DescID: 104 (t), Name: "rowid", ColumnID: 3 (rowid-)}
+      │    │    ├── VALIDATED             → ABSENT              ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (rowid-), IndexID: 0}
+      │    │    ├── PUBLIC                → ABSENT              IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid-), IndexID: 1 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT              IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 1 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT              IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 1 (t_pkey-)}
+      │    │    ├── VALIDATED             → DELETE_ONLY         PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey-), ConstraintID: 1}
+      │    │    └── PUBLIC                → VALIDATED           SecondaryIndex:{DescID: 104 (t), IndexID: 2 (t_a_idx-), RecreateSourceIndexID: 0}
+      │    └── 34 Mutation operations
+      │         ├── RemoveColumnNotNull {"ColumnID":3,"TableID":104}
+      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":6,"TableID":104}
+      │         ├── SetIndexName {"IndexID":6,"Name":"crdb_internal_in...","TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── SetIndexName {"IndexID":8,"Name":"t_pkey","TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":11,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":11,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"Kind":2,"Ordinal":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"Kind":2,"Ordinal":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":11,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── SetIndexName {"IndexID":4,"Name":"t_a_idx","TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"Kind":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":1,"TableID":104}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":8,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":11,"TableID":104}
+      │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":4,"TableID":104}
+      │         ├── RefreshStats {"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":1,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":1,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── MakePublicSecondaryIndexWriteOnly {"IndexID":2,"TableID":104}
+      │         ├── MakePublicColumnWriteOnly {"ColumnID":3,"TableID":104}
+      │         ├── SetColumnName {"ColumnID":3,"Name":"crdb_internal_co...","TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":7,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":9,"Kind":2,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      ├── Stage 2 of 4 in PostCommitNonRevertiblePhase
+      │    ├── 3 elements transitioning toward PUBLIC
+      │    │    ├── WRITE_ONLY          → PUBLIC                Column:{DescID: 104 (t), ColumnID: 4 (m+)}
+      │    │    ├── VALIDATED           → PUBLIC                PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey+), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 8 (t_pkey~)}
+      │    │    └── ABSENT              → PUBLIC                IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 10 (t_pkey+)}
+      │    ├── 7 elements transitioning toward TRANSIENT_ABSENT
+      │    │    ├── TRANSIENT_VALIDATED → TRANSIENT_DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey~), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey-)}
+      │    │    ├── PUBLIC              → TRANSIENT_ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid-), IndexID: 6 (t_pkey~)}
+      │    │    ├── PUBLIC              → TRANSIENT_ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (t_pkey~)}
+      │    │    ├── PUBLIC              → TRANSIENT_ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (t_pkey~)}
+      │    │    ├── PUBLIC              → TRANSIENT_VALIDATED   PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey~), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey~)}
+      │    │    ├── PUBLIC              → TRANSIENT_ABSENT      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 8 (t_pkey~)}
+      │    │    └── PUBLIC              → TRANSIENT_ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m+), IndexID: 6 (t_pkey~)}
+      │    ├── 6 elements transitioning toward ABSENT
+      │    │    ├── WRITE_ONLY          → DELETE_ONLY           Column:{DescID: 104 (t), ColumnID: 3 (rowid-)}
+      │    │    ├── DELETE_ONLY         → ABSENT                PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey-), ConstraintID: 1}
+      │    │    ├── PUBLIC              → ABSENT                IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 2 (t_a_idx-)}
+      │    │    ├── PUBLIC              → ABSENT                IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid-), IndexID: 2 (t_a_idx-)}
+      │    │    ├── VALIDATED           → DELETE_ONLY           SecondaryIndex:{DescID: 104 (t), IndexID: 2 (t_a_idx-), RecreateSourceIndexID: 0}
+      │    │    └── PUBLIC              → ABSENT                IndexName:{DescID: 104 (t), Name: "t_a_idx", IndexID: 2 (t_a_idx-)}
+      │    └── 19 Mutation operations
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":3,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":1,"TableID":104}
+      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":8,"TableID":104}
+      │         ├── SetIndexName {"IndexID":8,"Name":"crdb_internal_in...","TableID":104}
+      │         ├── SetIndexName {"IndexID":10,"Name":"t_pkey","TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":2,"TableID":104}
+      │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":10,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":6,"Kind":2,"Ordinal":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":2,"Kind":1,"TableID":104}
+      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":4,"TableID":104}
+      │         ├── RefreshStats {"TableID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      ├── Stage 3 of 4 in PostCommitNonRevertiblePhase
+      │    ├── 6 elements transitioning toward TRANSIENT_ABSENT
+      │    │    ├── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey~), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey-)}
+      │    │    ├── TRANSIENT_VALIDATED   → TRANSIENT_DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey~), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey~)}
+      │    │    ├── PUBLIC                → TRANSIENT_ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid-), IndexID: 8 (t_pkey~)}
+      │    │    ├── PUBLIC                → TRANSIENT_ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 8 (t_pkey~)}
+      │    │    ├── PUBLIC                → TRANSIENT_ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 8 (t_pkey~)}
+      │    │    └── PUBLIC                → TRANSIENT_ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m+), IndexID: 8 (t_pkey~)}
+      │    ├── 1 element transitioning toward ABSENT
+      │    │    └── DELETE_ONLY           → ABSENT                SecondaryIndex:{DescID: 104 (t), IndexID: 2 (t_a_idx-), RecreateSourceIndexID: 0}
+      │    └── 9 Mutation operations
+      │         ├── MakeIndexAbsent {"IndexID":2,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":6,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":8,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"Kind":2,"Ordinal":2,"TableID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 4 of 4 in PostCommitNonRevertiblePhase
+           ├── 7 elements transitioning toward TRANSIENT_ABSENT
+           │    ├── PUBLIC                → TRANSIENT_ABSENT IndexData:{DescID: 104 (t), IndexID: 6 (t_pkey~)}
+           │    ├── PUBLIC                → TRANSIENT_ABSENT IndexData:{DescID: 104 (t), IndexID: 7}
+           │    ├── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey~), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey~)}
+           │    ├── PUBLIC                → TRANSIENT_ABSENT IndexData:{DescID: 104 (t), IndexID: 8 (t_pkey~)}
+           │    ├── PUBLIC                → TRANSIENT_ABSENT IndexData:{DescID: 104 (t), IndexID: 9}
+           │    ├── PUBLIC                → TRANSIENT_ABSENT IndexData:{DescID: 104 (t), IndexID: 11}
+           │    └── PUBLIC                → TRANSIENT_ABSENT IndexData:{DescID: 104 (t), IndexID: 5}
+           ├── 5 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY           → ABSENT           Column:{DescID: 104 (t), ColumnID: 3 (rowid-)}
+           │    ├── PUBLIC                → ABSENT           ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 3 (rowid-), TypeName: "INT8"}
+           │    ├── PUBLIC                → ABSENT           ColumnDefaultExpression:{DescID: 104 (t), ColumnID: 3 (rowid-), Expr: unique_rowid()}
+           │    ├── PUBLIC                → ABSENT           IndexData:{DescID: 104 (t), IndexID: 1 (t_pkey-)}
+           │    └── PUBLIC                → ABSENT           IndexData:{DescID: 104 (t), IndexID: 2 (t_a_idx-)}
+           └── 13 Mutation operations
+                ├── RemoveColumnDefaultExpression {"ColumnID":3,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":1,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":2,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":5,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":6,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":7,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":8,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":9,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":11,"TableID":104}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":3,"TableID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx/alter_table_alter_primary_key_drop_rowid_with_idx.explain_shape
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx/alter_table_alter_primary_key_drop_rowid_with_idx.explain_shape
@@ -1,0 +1,37 @@
+/* setup */
+CREATE TABLE t (a INT NOT NULL, b int8 not null default unique_rowid());
+INSERT INTO t(a) VALUES (1), (2), (2);
+CREATE INDEX on t(a);
+
+/* test */
+EXPLAIN (DDL, SHAPE) alter table t add column m int8 default unique_rowid(), alter primary key using columns(b);
+----
+Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ADD COLUMN ‹m› INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (‹b›);
+ ├── execute 2 system table mutations transactions
+ ├── backfill using primary index t_pkey- in relation t
+ │    └── into t_pkey~ (rowid-; m+, a, b)
+ ├── execute 2 system table mutations transactions
+ ├── merge temporary indexes into backfilled indexes in relation t
+ │    └── from t@[7] into t_pkey~
+ ├── execute 1 system table mutations transaction
+ ├── validate UNIQUE constraint backed by index t_pkey~ in relation t
+ ├── execute 2 system table mutations transactions
+ ├── backfill using primary index t_pkey~ in relation t
+ │    └── into t_pkey~ (b; rowid-, a, m+)
+ ├── execute 2 system table mutations transactions
+ ├── merge temporary indexes into backfilled indexes in relation t
+ │    └── from t@[9] into t_pkey~
+ ├── execute 1 system table mutations transaction
+ ├── validate UNIQUE constraint backed by index t_pkey~ in relation t
+ ├── execute 2 system table mutations transactions
+ ├── backfill using primary index t_pkey~ in relation t
+ │    ├── into t_a_idx+ (a: b)
+ │    └── into t_pkey+ (b; a, m+)
+ ├── execute 2 system table mutations transactions
+ ├── merge temporary indexes into backfilled indexes in relation t
+ │    ├── from t@[5] into t_a_idx+
+ │    └── from t@[11] into t_pkey+
+ ├── execute 1 system table mutations transaction
+ ├── validate UNIQUE constraint backed by index t_pkey+ in relation t
+ ├── validate UNIQUE constraint backed by index t_a_idx+ in relation t
+ └── execute 4 system table mutations transactions

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx/alter_table_alter_primary_key_drop_rowid_with_idx.side_effects
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx/alter_table_alter_primary_key_drop_rowid_with_idx.side_effects
@@ -1120,7 +1120,7 @@ validate forward indexes [10] in table #104
 validate forward indexes [4] in table #104
 commit transaction #25
 begin transaction #26
-## PostCommitNonRevertiblePhase stage 1 of 4 with 34 MutationType ops
+## PostCommitNonRevertiblePhase stage 1 of 4 with 35 MutationType ops
 upsert descriptor #104
    table:
   -  checks:
@@ -1172,13 +1172,16 @@ upsert descriptor #104
   -    id: 2
   +    id: 4
        interleave: {}
+  +    invisibility: 1
        keyColumnDirections:
+       - ASC
   ...
        - a
        keySuffixColumnIds:
   -    - 3
   +    - 2
        name: t_a_idx
+  +    notVisible: true
        partitioning: {}
        sharded: {}
   +    storeColumnNames: []
@@ -1462,11 +1465,11 @@ upsert descriptor #104
   +  version: "23"
 persist all catalog changes to storage
 adding table for stats refresh: 104
-update progress of schema change job #1: "PostCommitNonRevertiblePhase stage 2 of 4 with 17 MutationType ops pending"
+update progress of schema change job #1: "PostCommitNonRevertiblePhase stage 2 of 4 with 18 MutationType ops pending"
 set schema change job #1 to non-cancellable
 commit transaction #26
 begin transaction #27
-## PostCommitNonRevertiblePhase stage 2 of 4 with 19 MutationType ops
+## PostCommitNonRevertiblePhase stage 2 of 4 with 20 MutationType ops
 upsert descriptor #104
   ...
          oid: 20
@@ -1481,6 +1484,18 @@ upsert descriptor #104
   +      width: 64
      createAsOfTime:
        wallTime: "1640995200000000000"
+  ...
+       id: 4
+       interleave: {}
+  -    invisibility: 1
+       keyColumnDirections:
+       - ASC
+  ...
+       - 2
+       name: t_a_idx
+  -    notVisible: true
+       partitioning: {}
+       sharded: {}
   ...
      modificationTime: {}
      mutations:

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx/alter_table_alter_primary_key_drop_rowid_with_idx.side_effects
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx/alter_table_alter_primary_key_drop_rowid_with_idx.side_effects
@@ -1,0 +1,1840 @@
+/* setup */
+CREATE TABLE t (a INT NOT NULL, b int8 not null default unique_rowid());
+INSERT INTO t(a) VALUES (1), (2), (2);
+CREATE INDEX on t(a);
+----
+...
++object {100 101 t} -> 104
+
+/* test */
+alter table t add column m int8 default unique_rowid(), alter primary key using columns(b);
+----
+begin transaction #1
+# begin StatementPhase
+checking for feature: ALTER TABLE
+increment telemetry for sql.schema.alter_table
+increment telemetry for sql.schema.alter_table.add_column
+increment telemetry for sql.schema.qualifcation.default_expr
+increment telemetry for sql.schema.new_column_type.int8
+increment telemetry for sql.schema.alter_table.alter_primary_key
+write *eventpb.AlterTable to event log:
+  mutationId: 1
+  sql:
+    descriptorId: 104
+    statement: ALTER TABLE ‹defaultdb›.‹public›.‹t› ADD COLUMN ‹m› INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (‹b›)
+    tag: ALTER TABLE
+    user: root
+  tableName: defaultdb.public.t
+write *eventpb.AlterTable to event log:
+  mutationId: 1
+  sql:
+    descriptorId: 104
+    statement: ALTER TABLE ‹defaultdb›.‹public›.‹t› ADD COLUMN ‹m› INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (‹b›)
+    tag: ALTER TABLE
+    user: root
+  tableName: defaultdb.public.t
+## StatementPhase stage 1 of 1 with 24 MutationType ops
+upsert descriptor #104
+   table:
+  +  checks:
+  +  - columnIds:
+  +    - 3
+  +    expr: rowid IS NOT NULL
+  +    isNonNullConstraint: true
+  +    name: rowid_auto_not_null
+  +    validity: Dropping
+     columns:
+     - id: 1
+  ...
+       id: 3
+       name: rowid
+  +    nullable: true
+       type:
+         family: IntFamily
+  ...
+       - 2
+       - 3
+  +    - 4
+       columnNames:
+       - a
+       - b
+       - rowid
+  +    - m
+       name: primary
+     formatVersion: 3
+  ...
+       version: 4
+     modificationTime: {}
+  +  mutations:
+  +  - constraint:
+  +      check:
+  +        columnIds:
+  +        - 3
+  +        expr: rowid IS NOT NULL
+  +        isNonNullConstraint: true
+  +        name: rowid_auto_not_null
+  +        validity: Dropping
+  +      constraintType: NOT_NULL
+  +      foreignKey: {}
+  +      name: rowid_auto_not_null
+  +      notNullColumn: 3
+  +      uniqueWithoutIndexConstraint: {}
+  +    direction: DROP
+  +    mutationId: 1
+  +    state: WRITE_ONLY
+  +  - column:
+  +      defaultExpr: unique_rowid()
+  +      id: 4
+  +      name: m
+  +      nullable: true
+  +      type:
+  +        family: IntFamily
+  +        oid: 20
+  +        width: 64
+  +    direction: ADD
+  +    mutationId: 1
+  +    state: DELETE_ONLY
+  +  - direction: ADD
+  +    index:
+  +      constraintId: 4
+  +      createdExplicitly: true
+  +      encodingType: 1
+  +      foreignKey: {}
+  +      geoConfig: {}
+  +      id: 6
+  +      interleave: {}
+  +      keyColumnDirections:
+  +      - ASC
+  +      keyColumnIds:
+  +      - 3
+  +      keyColumnNames:
+  +      - rowid
+  +      name: crdb_internal_index_6_name_placeholder
+  +      partitioning: {}
+  +      sharded: {}
+  +      storeColumnIds:
+  +      - 1
+  +      - 2
+  +      - 4
+  +      storeColumnNames:
+  +      - a
+  +      - b
+  +      - m
+  +      unique: true
+  +      vecConfig: {}
+  +      version: 4
+  +    mutationId: 1
+  +    state: BACKFILLING
+  +  - direction: ADD
+  +    index:
+  +      constraintId: 5
+  +      createdExplicitly: true
+  +      encodingType: 1
+  +      foreignKey: {}
+  +      geoConfig: {}
+  +      id: 7
+  +      interleave: {}
+  +      keyColumnDirections:
+  +      - ASC
+  +      keyColumnIds:
+  +      - 3
+  +      keyColumnNames:
+  +      - rowid
+  +      name: crdb_internal_index_7_name_placeholder
+  +      partitioning: {}
+  +      sharded: {}
+  +      storeColumnIds:
+  +      - 1
+  +      - 2
+  +      - 4
+  +      storeColumnNames:
+  +      - a
+  +      - b
+  +      - m
+  +      unique: true
+  +      useDeletePreservingEncoding: true
+  +      vecConfig: {}
+  +      version: 4
+  +    mutationId: 1
+  +    state: DELETE_ONLY
+  +  - direction: ADD
+  +    index:
+  +      constraintId: 6
+  +      createdExplicitly: true
+  +      encodingType: 1
+  +      foreignKey: {}
+  +      geoConfig: {}
+  +      id: 8
+  +      interleave: {}
+  +      keyColumnDirections:
+  +      - ASC
+  +      keyColumnIds:
+  +      - 2
+  +      keyColumnNames:
+  +      - b
+  +      name: crdb_internal_index_8_name_placeholder
+  +      partitioning: {}
+  +      sharded: {}
+  +      storeColumnIds:
+  +      - 3
+  +      - 1
+  +      - 4
+  +      storeColumnNames:
+  +      - rowid
+  +      - a
+  +      - m
+  +      unique: true
+  +      vecConfig: {}
+  +      version: 4
+  +    mutationId: 1
+  +    state: BACKFILLING
+  +  - direction: ADD
+  +    index:
+  +      constraintId: 8
+  +      createdExplicitly: true
+  +      encodingType: 1
+  +      foreignKey: {}
+  +      geoConfig: {}
+  +      id: 10
+  +      interleave: {}
+  +      keyColumnDirections:
+  +      - ASC
+  +      keyColumnIds:
+  +      - 2
+  +      keyColumnNames:
+  +      - b
+  +      name: crdb_internal_index_10_name_placeholder
+  +      partitioning: {}
+  +      sharded: {}
+  +      storeColumnIds:
+  +      - 1
+  +      - 4
+  +      storeColumnNames:
+  +      - a
+  +      - m
+  +      unique: true
+  +      vecConfig: {}
+  +      version: 4
+  +    mutationId: 1
+  +    state: BACKFILLING
+     name: t
+  -  nextColumnId: 4
+  -  nextConstraintId: 2
+  +  nextColumnId: 5
+  +  nextConstraintId: 9
+     nextFamilyId: 1
+  -  nextIndexId: 4
+  +  nextIndexId: 11
+     nextMutationId: 1
+     parentId: 100
+  ...
+       time: {}
+     unexposedParentSchemaId: 101
+  -  version: "7"
+  +  version: "8"
+# end StatementPhase
+# begin PreCommitPhase
+## PreCommitPhase stage 1 of 2 with 1 MutationType op
+undo all catalog changes within txn #1
+persist all catalog changes to storage
+## PreCommitPhase stage 2 of 2 with 30 MutationType ops
+upsert descriptor #104
+   table:
+  +  checks:
+  +  - columnIds:
+  +    - 3
+  +    expr: rowid IS NOT NULL
+  +    isNonNullConstraint: true
+  +    name: rowid_auto_not_null
+  +    validity: Dropping
+     columns:
+     - id: 1
+  ...
+       id: 3
+       name: rowid
+  +    nullable: true
+       type:
+         family: IntFamily
+  ...
+     createAsOfTime:
+       wallTime: "1640995200000000000"
+  +  declarativeSchemaChangerState:
+  +    authorization:
+  +      userName: root
+  +    currentStatuses: <redacted>
+  +    jobId: "1"
+  +    nameMapping:
+  +      columns:
+  +        "1": a
+  +        "2": b
+  +        "4": m
+  +        "4294967292": crdb_internal_origin_timestamp
+  +        "4294967293": crdb_internal_origin_id
+  +        "4294967294": tableoid
+  +        "4294967295": crdb_internal_mvcc_timestamp
+  +      families:
+  +        "0": primary
+  +      id: 104
+  +      indexes:
+  +        "4": t_a_idx
+  +        "10": t_pkey
+  +      name: t
+  +    relevantStatements:
+  +    - statement:
+  +        redactedStatement: ALTER TABLE ‹defaultdb›.‹public›.‹t› ADD COLUMN ‹m› INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (‹b›)
+  +        statement: ALTER TABLE t ADD COLUMN m INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (b)
+  +        statementTag: ALTER TABLE
+  +    revertible: true
+  +    targetRanks: <redacted>
+  +    targets: <redacted>
+     families:
+     - columnIds:
+  ...
+       - 2
+       - 3
+  +    - 4
+       columnNames:
+       - a
+       - b
+       - rowid
+  +    - m
+       name: primary
+     formatVersion: 3
+  ...
+       version: 4
+     modificationTime: {}
+  +  mutations:
+  +  - constraint:
+  +      check:
+  +        columnIds:
+  +        - 3
+  +        expr: rowid IS NOT NULL
+  +        isNonNullConstraint: true
+  +        name: rowid_auto_not_null
+  +        validity: Dropping
+  +      constraintType: NOT_NULL
+  +      foreignKey: {}
+  +      name: rowid_auto_not_null
+  +      notNullColumn: 3
+  +      uniqueWithoutIndexConstraint: {}
+  +    direction: DROP
+  +    mutationId: 1
+  +    state: WRITE_ONLY
+  +  - column:
+  +      defaultExpr: unique_rowid()
+  +      id: 4
+  +      name: m
+  +      nullable: true
+  +      type:
+  +        family: IntFamily
+  +        oid: 20
+  +        width: 64
+  +    direction: ADD
+  +    mutationId: 1
+  +    state: DELETE_ONLY
+  +  - direction: ADD
+  +    index:
+  +      constraintId: 4
+  +      createdExplicitly: true
+  +      encodingType: 1
+  +      foreignKey: {}
+  +      geoConfig: {}
+  +      id: 6
+  +      interleave: {}
+  +      keyColumnDirections:
+  +      - ASC
+  +      keyColumnIds:
+  +      - 3
+  +      keyColumnNames:
+  +      - rowid
+  +      name: crdb_internal_index_6_name_placeholder
+  +      partitioning: {}
+  +      sharded: {}
+  +      storeColumnIds:
+  +      - 1
+  +      - 2
+  +      - 4
+  +      storeColumnNames:
+  +      - a
+  +      - b
+  +      - m
+  +      unique: true
+  +      vecConfig: {}
+  +      version: 4
+  +    mutationId: 1
+  +    state: BACKFILLING
+  +  - direction: ADD
+  +    index:
+  +      constraintId: 5
+  +      createdExplicitly: true
+  +      encodingType: 1
+  +      foreignKey: {}
+  +      geoConfig: {}
+  +      id: 7
+  +      interleave: {}
+  +      keyColumnDirections:
+  +      - ASC
+  +      keyColumnIds:
+  +      - 3
+  +      keyColumnNames:
+  +      - rowid
+  +      name: crdb_internal_index_7_name_placeholder
+  +      partitioning: {}
+  +      sharded: {}
+  +      storeColumnIds:
+  +      - 1
+  +      - 2
+  +      - 4
+  +      storeColumnNames:
+  +      - a
+  +      - b
+  +      - m
+  +      unique: true
+  +      useDeletePreservingEncoding: true
+  +      vecConfig: {}
+  +      version: 4
+  +    mutationId: 1
+  +    state: DELETE_ONLY
+  +  - direction: ADD
+  +    index:
+  +      constraintId: 6
+  +      createdExplicitly: true
+  +      encodingType: 1
+  +      foreignKey: {}
+  +      geoConfig: {}
+  +      id: 8
+  +      interleave: {}
+  +      keyColumnDirections:
+  +      - ASC
+  +      keyColumnIds:
+  +      - 2
+  +      keyColumnNames:
+  +      - b
+  +      name: crdb_internal_index_8_name_placeholder
+  +      partitioning: {}
+  +      sharded: {}
+  +      storeColumnIds:
+  +      - 3
+  +      - 1
+  +      - 4
+  +      storeColumnNames:
+  +      - rowid
+  +      - a
+  +      - m
+  +      unique: true
+  +      vecConfig: {}
+  +      version: 4
+  +    mutationId: 1
+  +    state: BACKFILLING
+  +  - direction: ADD
+  +    index:
+  +      constraintId: 8
+  +      createdExplicitly: true
+  +      encodingType: 1
+  +      foreignKey: {}
+  +      geoConfig: {}
+  +      id: 10
+  +      interleave: {}
+  +      keyColumnDirections:
+  +      - ASC
+  +      keyColumnIds:
+  +      - 2
+  +      keyColumnNames:
+  +      - b
+  +      name: crdb_internal_index_10_name_placeholder
+  +      partitioning: {}
+  +      sharded: {}
+  +      storeColumnIds:
+  +      - 1
+  +      - 4
+  +      storeColumnNames:
+  +      - a
+  +      - m
+  +      unique: true
+  +      vecConfig: {}
+  +      version: 4
+  +    mutationId: 1
+  +    state: BACKFILLING
+     name: t
+  -  nextColumnId: 4
+  -  nextConstraintId: 2
+  +  nextColumnId: 5
+  +  nextConstraintId: 9
+     nextFamilyId: 1
+  -  nextIndexId: 4
+  +  nextIndexId: 11
+     nextMutationId: 1
+     parentId: 100
+  ...
+       time: {}
+     unexposedParentSchemaId: 101
+  -  version: "7"
+  +  version: "8"
+persist all catalog changes to storage
+create job #1 (non-cancelable: false): "ALTER TABLE defaultdb.public.t ADD COLUMN m INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (b)"
+  descriptor IDs: [104]
+# end PreCommitPhase
+commit transaction #1
+notified job registry to adopt jobs: [1]
+# begin PostCommitPhase
+begin transaction #2
+commit transaction #2
+begin transaction #3
+## PostCommitPhase stage 1 of 23 with 4 MutationType ops
+upsert descriptor #104
+  ...
+       direction: ADD
+       mutationId: 1
+  -    state: DELETE_ONLY
+  +    state: WRITE_ONLY
+     - direction: ADD
+       index:
+  ...
+         version: 4
+       mutationId: 1
+  -    state: DELETE_ONLY
+  +    state: WRITE_ONLY
+     - direction: ADD
+       index:
+  ...
+       time: {}
+     unexposedParentSchemaId: 101
+  -  version: "8"
+  +  version: "9"
+persist all catalog changes to storage
+update progress of schema change job #1: "PostCommitPhase stage 2 of 23 with 1 BackfillType op pending"
+commit transaction #3
+begin transaction #4
+## PostCommitPhase stage 2 of 23 with 1 BackfillType op
+backfill indexes [6] from index #1 in table #104
+commit transaction #4
+begin transaction #5
+## PostCommitPhase stage 3 of 23 with 3 MutationType ops
+upsert descriptor #104
+  ...
+         version: 4
+       mutationId: 1
+  -    state: BACKFILLING
+  +    state: DELETE_ONLY
+     - direction: ADD
+       index:
+  ...
+       time: {}
+     unexposedParentSchemaId: 101
+  -  version: "9"
+  +  version: "10"
+persist all catalog changes to storage
+update progress of schema change job #1: "PostCommitPhase stage 4 of 23 with 1 MutationType op pending"
+commit transaction #5
+begin transaction #6
+## PostCommitPhase stage 4 of 23 with 3 MutationType ops
+upsert descriptor #104
+  ...
+         version: 4
+       mutationId: 1
+  -    state: DELETE_ONLY
+  +    state: MERGING
+     - direction: ADD
+       index:
+  ...
+       time: {}
+     unexposedParentSchemaId: 101
+  -  version: "10"
+  +  version: "11"
+persist all catalog changes to storage
+update progress of schema change job #1: "PostCommitPhase stage 5 of 23 with 1 BackfillType op pending"
+commit transaction #6
+begin transaction #7
+## PostCommitPhase stage 5 of 23 with 1 BackfillType op
+merge temporary indexes [7] into backfilled indexes [6] in table #104
+commit transaction #7
+begin transaction #8
+## PostCommitPhase stage 6 of 23 with 4 MutationType ops
+upsert descriptor #104
+  ...
+         version: 4
+       mutationId: 1
+  -    state: MERGING
+  -  - direction: ADD
+  +    state: WRITE_ONLY
+  +  - direction: DROP
+       index:
+         constraintId: 5
+  ...
+         version: 4
+       mutationId: 1
+  -    state: WRITE_ONLY
+  +    state: DELETE_ONLY
+     - direction: ADD
+       index:
+  ...
+       time: {}
+     unexposedParentSchemaId: 101
+  -  version: "11"
+  +  version: "12"
+persist all catalog changes to storage
+update progress of schema change job #1: "PostCommitPhase stage 7 of 23 with 1 ValidationType op pending"
+commit transaction #8
+begin transaction #9
+## PostCommitPhase stage 7 of 23 with 1 ValidationType op
+validate forward indexes [6] in table #104
+commit transaction #9
+begin transaction #10
+## PostCommitPhase stage 8 of 23 with 12 MutationType ops
+upsert descriptor #104
+  ...
+       mutationId: 1
+       state: WRITE_ONLY
+  -  - direction: ADD
+  +  - direction: DROP
+       index:
+  -      constraintId: 4
+  +      constraintId: 5
+         createdExplicitly: true
+         encodingType: 1
+         foreignKey: {}
+         geoConfig: {}
+  -      id: 6
+  +      id: 7
+         interleave: {}
+         keyColumnDirections:
+  ...
+         keyColumnNames:
+         - rowid
+  -      name: crdb_internal_index_6_name_placeholder
+  +      name: crdb_internal_index_7_name_placeholder
+         partitioning: {}
+         sharded: {}
+  ...
+         - m
+         unique: true
+  +      useDeletePreservingEncoding: true
+         vecConfig: {}
+         version: 4
+       mutationId: 1
+  -    state: WRITE_ONLY
+  -  - direction: DROP
+  +    state: DELETE_ONLY
+  +  - direction: ADD
+       index:
+  -      constraintId: 5
+  +      constraintId: 6
+         createdExplicitly: true
+         encodingType: 1
+         foreignKey: {}
+         geoConfig: {}
+  -      id: 7
+  +      id: 8
+         interleave: {}
+         keyColumnDirections:
+         - ASC
+         keyColumnIds:
+  -      - 3
+  +      - 2
+         keyColumnNames:
+  -      - rowid
+  -      name: crdb_internal_index_7_name_placeholder
+  +      - b
+  +      name: crdb_internal_index_8_name_placeholder
+         partitioning: {}
+         sharded: {}
+         storeColumnIds:
+  +      - 3
+         - 1
+  -      - 2
+         - 4
+         storeColumnNames:
+  +      - rowid
+         - a
+  -      - b
+         - m
+         unique: true
+  -      useDeletePreservingEncoding: true
+         vecConfig: {}
+         version: 4
+       mutationId: 1
+  -    state: DELETE_ONLY
+  +    state: BACKFILLING
+     - direction: ADD
+       index:
+  -      constraintId: 6
+  +      constraintId: 8
+         createdExplicitly: true
+         encodingType: 1
+         foreignKey: {}
+         geoConfig: {}
+  -      id: 8
+  +      id: 10
+         interleave: {}
+         keyColumnDirections:
+  ...
+         keyColumnNames:
+         - b
+  -      name: crdb_internal_index_8_name_placeholder
+  +      name: crdb_internal_index_10_name_placeholder
+         partitioning: {}
+         sharded: {}
+         storeColumnIds:
+  -      - 3
+         - 1
+         - 4
+         storeColumnNames:
+  -      - rowid
+         - a
+         - m
+  ...
+       mutationId: 1
+       state: BACKFILLING
+  +  - direction: DROP
+  +    index:
+  +      constraintId: 1
+  +      createdAtNanos: "1640995200000000000"
+  +      encodingType: 1
+  +      foreignKey: {}
+  +      geoConfig: {}
+  +      id: 1
+  +      interleave: {}
+  +      keyColumnDirections:
+  +      - ASC
+  +      keyColumnIds:
+  +      - 3
+  +      keyColumnNames:
+  +      - rowid
+  +      name: crdb_internal_index_1_name_placeholder
+  +      partitioning: {}
+  +      sharded: {}
+  +      storeColumnIds:
+  +      - 1
+  +      - 2
+  +      storeColumnNames:
+  +      - a
+  +      - b
+  +      unique: true
+  +      vecConfig: {}
+  +      version: 4
+  +    mutationId: 1
+  +    state: WRITE_ONLY
+     - direction: ADD
+       index:
+  -      constraintId: 8
+  +      constraintId: 7
+         createdExplicitly: true
+         encodingType: 1
+         foreignKey: {}
+         geoConfig: {}
+  -      id: 10
+  +      id: 9
+         interleave: {}
+         keyColumnDirections:
+  ...
+         keyColumnNames:
+         - b
+  -      name: crdb_internal_index_10_name_placeholder
+  +      name: crdb_internal_index_9_name_placeholder
+         partitioning: {}
+         sharded: {}
+         storeColumnIds:
+  +      - 3
+         - 1
+         - 4
+         storeColumnNames:
+  +      - rowid
+         - a
+         - m
+         unique: true
+  +      useDeletePreservingEncoding: true
+         vecConfig: {}
+         version: 4
+       mutationId: 1
+  -    state: BACKFILLING
+  +    state: DELETE_ONLY
+     name: t
+     nextColumnId: 5
+  ...
+     parentId: 100
+     primaryIndex:
+  -    constraintId: 1
+  -    createdAtNanos: "1640995200000000000"
+  +    constraintId: 4
+  +    createdExplicitly: true
+       encodingType: 1
+       foreignKey: {}
+       geoConfig: {}
+  -    id: 1
+  +    id: 6
+       interleave: {}
+       keyColumnDirections:
+  ...
+       - 1
+       - 2
+  +    - 4
+       storeColumnNames:
+       - a
+       - b
+  +    - m
+       unique: true
+       vecConfig: {}
+  ...
+       time: {}
+     unexposedParentSchemaId: 101
+  -  version: "12"
+  +  version: "13"
+persist all catalog changes to storage
+update progress of schema change job #1: "PostCommitPhase stage 9 of 23 with 1 MutationType op pending"
+commit transaction #10
+begin transaction #11
+## PostCommitPhase stage 9 of 23 with 3 MutationType ops
+upsert descriptor #104
+  ...
+         version: 4
+       mutationId: 1
+  -    state: DELETE_ONLY
+  +    state: WRITE_ONLY
+     name: t
+     nextColumnId: 5
+  ...
+       time: {}
+     unexposedParentSchemaId: 101
+  -  version: "13"
+  +  version: "14"
+persist all catalog changes to storage
+update progress of schema change job #1: "PostCommitPhase stage 10 of 23 with 1 BackfillType op pending"
+commit transaction #11
+begin transaction #12
+## PostCommitPhase stage 10 of 23 with 1 BackfillType op
+backfill indexes [8] from index #6 in table #104
+commit transaction #12
+begin transaction #13
+## PostCommitPhase stage 11 of 23 with 3 MutationType ops
+upsert descriptor #104
+  ...
+         version: 4
+       mutationId: 1
+  -    state: BACKFILLING
+  +    state: DELETE_ONLY
+     - direction: ADD
+       index:
+  ...
+       time: {}
+     unexposedParentSchemaId: 101
+  -  version: "14"
+  +  version: "15"
+persist all catalog changes to storage
+update progress of schema change job #1: "PostCommitPhase stage 12 of 23 with 1 MutationType op pending"
+commit transaction #13
+begin transaction #14
+## PostCommitPhase stage 12 of 23 with 3 MutationType ops
+upsert descriptor #104
+  ...
+         version: 4
+       mutationId: 1
+  -    state: DELETE_ONLY
+  +    state: MERGING
+     - direction: ADD
+       index:
+  ...
+       time: {}
+     unexposedParentSchemaId: 101
+  -  version: "15"
+  +  version: "16"
+persist all catalog changes to storage
+update progress of schema change job #1: "PostCommitPhase stage 13 of 23 with 1 BackfillType op pending"
+commit transaction #14
+begin transaction #15
+## PostCommitPhase stage 13 of 23 with 1 BackfillType op
+merge temporary indexes [9] into backfilled indexes [8] in table #104
+commit transaction #15
+begin transaction #16
+## PostCommitPhase stage 14 of 23 with 4 MutationType ops
+upsert descriptor #104
+  ...
+         version: 4
+       mutationId: 1
+  -    state: MERGING
+  +    state: WRITE_ONLY
+     - direction: ADD
+       index:
+  ...
+       mutationId: 1
+       state: WRITE_ONLY
+  -  - direction: ADD
+  +  - direction: DROP
+       index:
+         constraintId: 7
+  ...
+         version: 4
+       mutationId: 1
+  -    state: WRITE_ONLY
+  +    state: DELETE_ONLY
+     name: t
+     nextColumnId: 5
+  ...
+       time: {}
+     unexposedParentSchemaId: 101
+  -  version: "16"
+  +  version: "17"
+persist all catalog changes to storage
+update progress of schema change job #1: "PostCommitPhase stage 15 of 23 with 1 ValidationType op pending"
+commit transaction #16
+begin transaction #17
+## PostCommitPhase stage 15 of 23 with 1 ValidationType op
+validate forward indexes [8] in table #104
+commit transaction #17
+begin transaction #18
+## PostCommitPhase stage 16 of 23 with 15 MutationType ops
+upsert descriptor #104
+  ...
+       mutationId: 1
+       state: DELETE_ONLY
+  +  - direction: ADD
+  +    index:
+  +      constraintId: 9
+  +      createdExplicitly: true
+  +      encodingType: 1
+  +      foreignKey: {}
+  +      geoConfig: {}
+  +      id: 11
+  +      interleave: {}
+  +      keyColumnDirections:
+  +      - ASC
+  +      keyColumnIds:
+  +      - 2
+  +      keyColumnNames:
+  +      - b
+  +      name: crdb_internal_index_11_name_placeholder
+  +      partitioning: {}
+  +      sharded: {}
+  +      storeColumnIds:
+  +      - 1
+  +      - 4
+  +      storeColumnNames:
+  +      - a
+  +      - m
+  +      unique: true
+  +      useDeletePreservingEncoding: true
+  +      vecConfig: {}
+  +      version: 4
+  +    mutationId: 1
+  +    state: DELETE_ONLY
+  +  - direction: ADD
+  +    index:
+  +      constraintId: 2
+  +      createdAtNanos: "1640998800000000000"
+  +      createdExplicitly: true
+  +      foreignKey: {}
+  +      geoConfig: {}
+  +      id: 4
+  +      interleave: {}
+  +      keyColumnDirections:
+  +      - ASC
+  +      keyColumnIds:
+  +      - 1
+  +      keyColumnNames:
+  +      - a
+  +      keySuffixColumnIds:
+  +      - 2
+  +      name: crdb_internal_index_4_name_placeholder
+  +      partitioning: {}
+  +      sharded: {}
+  +      storeColumnNames: []
+  +      vecConfig: {}
+  +      version: 4
+  +    mutationId: 1
+  +    state: BACKFILLING
+  +  - direction: ADD
+  +    index:
+  +      constraintId: 3
+  +      createdExplicitly: true
+  +      foreignKey: {}
+  +      geoConfig: {}
+  +      id: 5
+  +      interleave: {}
+  +      keyColumnDirections:
+  +      - ASC
+  +      keyColumnIds:
+  +      - 1
+  +      keyColumnNames:
+  +      - a
+  +      keySuffixColumnIds:
+  +      - 2
+  +      name: crdb_internal_index_5_name_placeholder
+  +      partitioning: {}
+  +      sharded: {}
+  +      storeColumnNames: []
+  +      useDeletePreservingEncoding: true
+  +      vecConfig: {}
+  +      version: 4
+  +    mutationId: 1
+  +    state: DELETE_ONLY
+     name: t
+     nextColumnId: 5
+  -  nextConstraintId: 9
+  +  nextConstraintId: 10
+     nextFamilyId: 1
+  -  nextIndexId: 11
+  +  nextIndexId: 12
+     nextMutationId: 1
+     parentId: 100
+  ...
+       time: {}
+     unexposedParentSchemaId: 101
+  -  version: "17"
+  +  version: "18"
+persist all catalog changes to storage
+update progress of schema change job #1: "PostCommitPhase stage 17 of 23 with 2 MutationType ops pending"
+commit transaction #18
+begin transaction #19
+## PostCommitPhase stage 17 of 23 with 4 MutationType ops
+upsert descriptor #104
+  ...
+         version: 4
+       mutationId: 1
+  -    state: DELETE_ONLY
+  +    state: WRITE_ONLY
+     - direction: ADD
+       index:
+  ...
+         version: 4
+       mutationId: 1
+  -    state: DELETE_ONLY
+  +    state: WRITE_ONLY
+     name: t
+     nextColumnId: 5
+  ...
+       time: {}
+     unexposedParentSchemaId: 101
+  -  version: "18"
+  +  version: "19"
+persist all catalog changes to storage
+update progress of schema change job #1: "PostCommitPhase stage 18 of 23 with 2 BackfillType ops pending"
+commit transaction #19
+begin transaction #20
+## PostCommitPhase stage 18 of 23 with 2 BackfillType ops
+backfill indexes [4 10] from index #8 in table #104
+commit transaction #20
+begin transaction #21
+## PostCommitPhase stage 19 of 23 with 4 MutationType ops
+upsert descriptor #104
+  ...
+         version: 4
+       mutationId: 1
+  -    state: BACKFILLING
+  +    state: DELETE_ONLY
+     - direction: DROP
+       index:
+  ...
+         version: 4
+       mutationId: 1
+  -    state: BACKFILLING
+  +    state: DELETE_ONLY
+     - direction: ADD
+       index:
+  ...
+       time: {}
+     unexposedParentSchemaId: 101
+  -  version: "19"
+  +  version: "20"
+persist all catalog changes to storage
+update progress of schema change job #1: "PostCommitPhase stage 20 of 23 with 2 MutationType ops pending"
+commit transaction #21
+begin transaction #22
+## PostCommitPhase stage 20 of 23 with 4 MutationType ops
+upsert descriptor #104
+  ...
+         version: 4
+       mutationId: 1
+  -    state: DELETE_ONLY
+  +    state: MERGING
+     - direction: DROP
+       index:
+  ...
+         version: 4
+       mutationId: 1
+  -    state: DELETE_ONLY
+  +    state: MERGING
+     - direction: ADD
+       index:
+  ...
+       time: {}
+     unexposedParentSchemaId: 101
+  -  version: "20"
+  +  version: "21"
+persist all catalog changes to storage
+update progress of schema change job #1: "PostCommitPhase stage 21 of 23 with 2 BackfillType ops pending"
+commit transaction #22
+begin transaction #23
+## PostCommitPhase stage 21 of 23 with 2 BackfillType ops
+merge temporary indexes [5 11] into backfilled indexes [4 10] in table #104
+commit transaction #23
+begin transaction #24
+## PostCommitPhase stage 22 of 23 with 6 MutationType ops
+upsert descriptor #104
+  ...
+         version: 4
+       mutationId: 1
+  -    state: MERGING
+  +    state: WRITE_ONLY
+     - direction: DROP
+       index:
+  ...
+       mutationId: 1
+       state: DELETE_ONLY
+  -  - direction: ADD
+  +  - direction: DROP
+       index:
+         constraintId: 9
+  ...
+         version: 4
+       mutationId: 1
+  -    state: WRITE_ONLY
+  +    state: DELETE_ONLY
+     - direction: ADD
+       index:
+  ...
+         version: 4
+       mutationId: 1
+  -    state: MERGING
+  -  - direction: ADD
+  +    state: WRITE_ONLY
+  +  - direction: DROP
+       index:
+         constraintId: 3
+  ...
+         version: 4
+       mutationId: 1
+  -    state: WRITE_ONLY
+  +    state: DELETE_ONLY
+     name: t
+     nextColumnId: 5
+  ...
+       time: {}
+     unexposedParentSchemaId: 101
+  -  version: "21"
+  +  version: "22"
+persist all catalog changes to storage
+update progress of schema change job #1: "PostCommitPhase stage 23 of 23 with 2 ValidationType ops pending"
+commit transaction #24
+begin transaction #25
+## PostCommitPhase stage 23 of 23 with 2 ValidationType ops
+validate forward indexes [10] in table #104
+validate forward indexes [4] in table #104
+commit transaction #25
+begin transaction #26
+## PostCommitNonRevertiblePhase stage 1 of 4 with 34 MutationType ops
+upsert descriptor #104
+   table:
+  -  checks:
+  -  - columnIds:
+  -    - 3
+  -    expr: rowid IS NOT NULL
+  -    isNonNullConstraint: true
+  -    name: rowid_auto_not_null
+  -    validity: Dropping
+  +  checks: []
+     columns:
+     - id: 1
+  ...
+         oid: 20
+         width: 64
+  -  - defaultExpr: unique_rowid()
+  -    hidden: true
+  -    id: 3
+  -    name: rowid
+  -    nullable: true
+  -    type:
+  -      family: IntFamily
+  -      oid: 20
+  -      width: 64
+     createAsOfTime:
+       wallTime: "1640995200000000000"
+  ...
+           statement: ALTER TABLE t ADD COLUMN m INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (b)
+           statementTag: ALTER TABLE
+  -    revertible: true
+       targetRanks: <redacted>
+       targets: <redacted>
+  ...
+       - a
+       - b
+  -    - rowid
+  +    - crdb_internal_column_3_name_placeholder
+       - m
+       name: primary
+  ...
+     id: 104
+     indexes:
+  -  - createdAtNanos: "1640995200000000000"
+  +  - constraintId: 2
+  +    createdAtNanos: "1640998800000000000"
+       createdExplicitly: true
+       foreignKey: {}
+       geoConfig: {}
+  -    id: 2
+  +    id: 4
+       interleave: {}
+       keyColumnDirections:
+  ...
+       - a
+       keySuffixColumnIds:
+  -    - 3
+  +    - 2
+       name: t_a_idx
+       partitioning: {}
+       sharded: {}
+  +    storeColumnNames: []
+       vecConfig: {}
+       version: 4
+     modificationTime: {}
+     mutations:
+  -  - constraint:
+  -      check:
+  -        columnIds:
+  -        - 3
+  -        expr: rowid IS NOT NULL
+  -        isNonNullConstraint: true
+  -        name: rowid_auto_not_null
+  -        validity: Dropping
+  -      constraintType: NOT_NULL
+  -      foreignKey: {}
+  -      name: rowid_auto_not_null
+  -      notNullColumn: 3
+  -      uniqueWithoutIndexConstraint: {}
+  -    direction: DROP
+  -    mutationId: 1
+  -    state: WRITE_ONLY
+     - column:
+         defaultExpr: unique_rowid()
+  ...
+       mutationId: 1
+       state: WRITE_ONLY
+  -  - direction: DROP
+  -    index:
+  -      constraintId: 5
+  -      createdExplicitly: true
+  -      encodingType: 1
+  -      foreignKey: {}
+  -      geoConfig: {}
+  -      id: 7
+  -      interleave: {}
+  -      keyColumnDirections:
+  -      - ASC
+  -      keyColumnIds:
+  -      - 3
+  -      keyColumnNames:
+  -      - rowid
+  -      name: crdb_internal_index_7_name_placeholder
+  -      partitioning: {}
+  -      sharded: {}
+  -      storeColumnIds:
+  -      - 1
+  -      - 2
+  -      - 4
+  -      storeColumnNames:
+  -      - a
+  -      - b
+  -      - m
+  -      unique: true
+  -      useDeletePreservingEncoding: true
+  -      vecConfig: {}
+  -      version: 4
+  -    mutationId: 1
+  -    state: DELETE_ONLY
+     - direction: ADD
+       index:
+  -      constraintId: 6
+  -      createdExplicitly: true
+  -      encodingType: 1
+  -      foreignKey: {}
+  -      geoConfig: {}
+  -      id: 8
+  -      interleave: {}
+  -      keyColumnDirections:
+  -      - ASC
+  -      keyColumnIds:
+  -      - 2
+  -      keyColumnNames:
+  -      - b
+  -      name: crdb_internal_index_8_name_placeholder
+  -      partitioning: {}
+  -      sharded: {}
+  -      storeColumnIds:
+  -      - 3
+  -      - 1
+  -      - 4
+  -      storeColumnNames:
+  -      - rowid
+  -      - a
+  -      - m
+  -      unique: true
+  -      vecConfig: {}
+  -      version: 4
+  -    mutationId: 1
+  -    state: WRITE_ONLY
+  -  - direction: ADD
+  -    index:
+         constraintId: 8
+         createdExplicitly: true
+  ...
+         - 3
+         keyColumnNames:
+  -      - rowid
+  +      - crdb_internal_column_3_name_placeholder
+         name: crdb_internal_index_1_name_placeholder
+         partitioning: {}
+  ...
+         version: 4
+       mutationId: 1
+  -    state: WRITE_ONLY
+  -  - direction: DROP
+  -    index:
+  -      constraintId: 7
+  -      createdExplicitly: true
+  -      encodingType: 1
+  -      foreignKey: {}
+  -      geoConfig: {}
+  -      id: 9
+  -      interleave: {}
+  -      keyColumnDirections:
+  -      - ASC
+  -      keyColumnIds:
+  -      - 2
+  -      keyColumnNames:
+  -      - b
+  -      name: crdb_internal_index_9_name_placeholder
+  -      partitioning: {}
+  -      sharded: {}
+  -      storeColumnIds:
+  -      - 3
+  -      - 1
+  -      - 4
+  -      storeColumnNames:
+  -      - rowid
+  -      - a
+  -      - m
+  -      unique: true
+  -      useDeletePreservingEncoding: true
+  -      vecConfig: {}
+  -      version: 4
+  -    mutationId: 1
+       state: DELETE_ONLY
+     - direction: DROP
+       index:
+  -      constraintId: 9
+  +      constraintId: 4
+         createdExplicitly: true
+         encodingType: 1
+         foreignKey: {}
+         geoConfig: {}
+  -      id: 11
+  +      id: 6
+         interleave: {}
+         keyColumnDirections:
+         - ASC
+         keyColumnIds:
+  -      - 2
+  +      - 3
+         keyColumnNames:
+  -      - b
+  -      name: crdb_internal_index_11_name_placeholder
+  +      - crdb_internal_column_3_name_placeholder
+  +      name: crdb_internal_index_6_name_placeholder
+         partitioning: {}
+         sharded: {}
+         storeColumnIds:
+         - 1
+  +      - 2
+         - 4
+         storeColumnNames:
+         - a
+  +      - b
+         - m
+         unique: true
+  -      useDeletePreservingEncoding: true
+         vecConfig: {}
+         version: 4
+       mutationId: 1
+  -    state: DELETE_ONLY
+  -  - direction: ADD
+  -    index:
+  -      constraintId: 2
+  -      createdAtNanos: "1640998800000000000"
+  -      createdExplicitly: true
+  -      foreignKey: {}
+  -      geoConfig: {}
+  -      id: 4
+  -      interleave: {}
+  -      keyColumnDirections:
+  -      - ASC
+  -      keyColumnIds:
+  -      - 1
+  -      keyColumnNames:
+  -      - a
+  -      keySuffixColumnIds:
+  -      - 2
+  -      name: crdb_internal_index_4_name_placeholder
+  -      partitioning: {}
+  -      sharded: {}
+  -      storeColumnNames: []
+  -      vecConfig: {}
+  -      version: 4
+  -    mutationId: 1
+       state: WRITE_ONLY
+     - direction: DROP
+       index:
+  -      constraintId: 3
+  +      createdAtNanos: "1640995200000000000"
+         createdExplicitly: true
+         foreignKey: {}
+         geoConfig: {}
+  -      id: 5
+  +      id: 2
+         interleave: {}
+         keyColumnDirections:
+  ...
+         - a
+         keySuffixColumnIds:
+  -      - 2
+  -      name: crdb_internal_index_5_name_placeholder
+  +      - 3
+  +      name: t_a_idx
+         partitioning: {}
+         sharded: {}
+  -      storeColumnNames: []
+  -      useDeletePreservingEncoding: true
+         vecConfig: {}
+         version: 4
+       mutationId: 1
+  -    state: DELETE_ONLY
+  +    state: WRITE_ONLY
+  +  - column:
+  +      defaultExpr: unique_rowid()
+  +      hidden: true
+  +      id: 3
+  +      name: crdb_internal_column_3_name_placeholder
+  +      nullable: true
+  +      type:
+  +        family: IntFamily
+  +        oid: 20
+  +        width: 64
+  +    direction: DROP
+  +    mutationId: 1
+  +    state: WRITE_ONLY
+     name: t
+     nextColumnId: 5
+  ...
+     parentId: 100
+     primaryIndex:
+  -    constraintId: 4
+  +    constraintId: 6
+       createdExplicitly: true
+       encodingType: 1
+       foreignKey: {}
+       geoConfig: {}
+  -    id: 6
+  +    id: 8
+       interleave: {}
+       keyColumnDirections:
+       - ASC
+       keyColumnIds:
+  -    - 3
+  +    - 2
+       keyColumnNames:
+  -    - rowid
+  +    - b
+       name: t_pkey
+       partitioning: {}
+       sharded: {}
+       storeColumnIds:
+  +    - 3
+       - 1
+  -    - 2
+       - 4
+       storeColumnNames:
+  +    - crdb_internal_column_3_name_placeholder
+       - a
+  -    - b
+       - m
+       unique: true
+  ...
+       time: {}
+     unexposedParentSchemaId: 101
+  -  version: "22"
+  +  version: "23"
+persist all catalog changes to storage
+adding table for stats refresh: 104
+update progress of schema change job #1: "PostCommitNonRevertiblePhase stage 2 of 4 with 17 MutationType ops pending"
+set schema change job #1 to non-cancellable
+commit transaction #26
+begin transaction #27
+## PostCommitNonRevertiblePhase stage 2 of 4 with 19 MutationType ops
+upsert descriptor #104
+  ...
+         oid: 20
+         width: 64
+  +  - defaultExpr: unique_rowid()
+  +    id: 4
+  +    name: m
+  +    nullable: true
+  +    type:
+  +      family: IntFamily
+  +      oid: 20
+  +      width: 64
+     createAsOfTime:
+       wallTime: "1640995200000000000"
+  ...
+     modificationTime: {}
+     mutations:
+  -  - column:
+  -      defaultExpr: unique_rowid()
+  -      id: 4
+  -      name: m
+  -      nullable: true
+  -      type:
+  -        family: IntFamily
+  -        oid: 20
+  -        width: 64
+  -    direction: ADD
+  -    mutationId: 1
+  -    state: WRITE_ONLY
+  -  - direction: ADD
+  -    index:
+  -      constraintId: 8
+  -      createdExplicitly: true
+  -      encodingType: 1
+  -      foreignKey: {}
+  -      geoConfig: {}
+  -      id: 10
+  -      interleave: {}
+  -      keyColumnDirections:
+  -      - ASC
+  -      keyColumnIds:
+  -      - 2
+  -      keyColumnNames:
+  -      - b
+  -      name: crdb_internal_index_10_name_placeholder
+  -      partitioning: {}
+  -      sharded: {}
+  -      storeColumnIds:
+  -      - 1
+  -      - 4
+  -      storeColumnNames:
+  -      - a
+  -      - m
+  -      unique: true
+  -      vecConfig: {}
+  -      version: 4
+  -    mutationId: 1
+  -    state: WRITE_ONLY
+     - direction: DROP
+       index:
+  -      constraintId: 1
+  -      createdAtNanos: "1640995200000000000"
+  -      encodingType: 1
+  -      foreignKey: {}
+  -      geoConfig: {}
+  -      id: 1
+  -      interleave: {}
+  -      keyColumnDirections:
+  -      - ASC
+  -      keyColumnIds:
+  -      - 3
+  -      keyColumnNames:
+  -      - crdb_internal_column_3_name_placeholder
+  -      name: crdb_internal_index_1_name_placeholder
+  -      partitioning: {}
+  -      sharded: {}
+  -      storeColumnIds:
+  -      - 1
+  -      - 2
+  -      storeColumnNames:
+  -      - a
+  -      - b
+  -      unique: true
+  -      vecConfig: {}
+  -      version: 4
+  -    mutationId: 1
+  -    state: DELETE_ONLY
+  -  - direction: DROP
+  -    index:
+         constraintId: 4
+         createdExplicitly: true
+  ...
+         version: 4
+       mutationId: 1
+  -    state: WRITE_ONLY
+  +    state: DELETE_ONLY
+     - direction: DROP
+       index:
+  ...
+         keySuffixColumnIds:
+         - 3
+  -      name: t_a_idx
+  +      name: crdb_internal_index_2_name_placeholder
+         partitioning: {}
+         sharded: {}
+  ...
+         version: 4
+       mutationId: 1
+  -    state: WRITE_ONLY
+  +    state: DELETE_ONLY
+     - column:
+         defaultExpr: unique_rowid()
+  ...
+       direction: DROP
+       mutationId: 1
+  +    state: DELETE_ONLY
+  +  - direction: DROP
+  +    index:
+  +      constraintId: 6
+  +      createdExplicitly: true
+  +      encodingType: 1
+  +      foreignKey: {}
+  +      geoConfig: {}
+  +      id: 8
+  +      interleave: {}
+  +      keyColumnDirections:
+  +      - ASC
+  +      keyColumnIds:
+  +      - 2
+  +      keyColumnNames:
+  +      - b
+  +      name: crdb_internal_index_8_name_placeholder
+  +      partitioning: {}
+  +      sharded: {}
+  +      storeColumnIds:
+  +      - 3
+  +      - 1
+  +      - 4
+  +      storeColumnNames:
+  +      - crdb_internal_column_3_name_placeholder
+  +      - a
+  +      - m
+  +      unique: true
+  +      vecConfig: {}
+  +      version: 4
+  +    mutationId: 1
+       state: WRITE_ONLY
+     name: t
+  ...
+     parentId: 100
+     primaryIndex:
+  -    constraintId: 6
+  +    constraintId: 8
+       createdExplicitly: true
+       encodingType: 1
+       foreignKey: {}
+       geoConfig: {}
+  -    id: 8
+  +    id: 10
+       interleave: {}
+       keyColumnDirections:
+  ...
+       sharded: {}
+       storeColumnIds:
+  -    - 3
+       - 1
+       - 4
+       storeColumnNames:
+  -    - crdb_internal_column_3_name_placeholder
+       - a
+       - m
+  ...
+       time: {}
+     unexposedParentSchemaId: 101
+  -  version: "23"
+  +  version: "24"
+persist all catalog changes to storage
+adding table for stats refresh: 104
+update progress of schema change job #1: "PostCommitNonRevertiblePhase stage 3 of 4 with 7 MutationType ops pending"
+commit transaction #27
+begin transaction #28
+## PostCommitNonRevertiblePhase stage 3 of 4 with 9 MutationType ops
+upsert descriptor #104
+  ...
+     modificationTime: {}
+     mutations:
+  -  - direction: DROP
+  -    index:
+  -      constraintId: 4
+  -      createdExplicitly: true
+  -      encodingType: 1
+  -      foreignKey: {}
+  -      geoConfig: {}
+  -      id: 6
+  -      interleave: {}
+  -      keyColumnDirections:
+  -      - ASC
+  -      keyColumnIds:
+  -      - 3
+  -      keyColumnNames:
+  -      - crdb_internal_column_3_name_placeholder
+  -      name: crdb_internal_index_6_name_placeholder
+  -      partitioning: {}
+  -      sharded: {}
+  -      storeColumnIds:
+  -      - 1
+  -      - 2
+  -      - 4
+  -      storeColumnNames:
+  -      - a
+  -      - b
+  -      - m
+  -      unique: true
+  -      vecConfig: {}
+  -      version: 4
+  -    mutationId: 1
+  -    state: DELETE_ONLY
+  -  - direction: DROP
+  -    index:
+  -      createdAtNanos: "1640995200000000000"
+  -      createdExplicitly: true
+  -      foreignKey: {}
+  -      geoConfig: {}
+  -      id: 2
+  -      interleave: {}
+  -      keyColumnDirections:
+  -      - ASC
+  -      keyColumnIds:
+  -      - 1
+  -      keyColumnNames:
+  -      - a
+  -      keySuffixColumnIds:
+  -      - 3
+  -      name: crdb_internal_index_2_name_placeholder
+  -      partitioning: {}
+  -      sharded: {}
+  -      vecConfig: {}
+  -      version: 4
+  -    mutationId: 1
+  -    state: DELETE_ONLY
+     - column:
+         defaultExpr: unique_rowid()
+  ...
+         version: 4
+       mutationId: 1
+  -    state: WRITE_ONLY
+  +    state: DELETE_ONLY
+     name: t
+     nextColumnId: 5
+  ...
+       time: {}
+     unexposedParentSchemaId: 101
+  -  version: "24"
+  +  version: "25"
+persist all catalog changes to storage
+update progress of schema change job #1: "PostCommitNonRevertiblePhase stage 4 of 4 with 11 MutationType ops pending"
+commit transaction #28
+begin transaction #29
+## PostCommitNonRevertiblePhase stage 4 of 4 with 13 MutationType ops
+upsert descriptor #104
+  ...
+     createAsOfTime:
+       wallTime: "1640995200000000000"
+  -  declarativeSchemaChangerState:
+  -    authorization:
+  -      userName: root
+  -    currentStatuses: <redacted>
+  -    jobId: "1"
+  -    nameMapping:
+  -      columns:
+  -        "1": a
+  -        "2": b
+  -        "4": m
+  -        "4294967292": crdb_internal_origin_timestamp
+  -        "4294967293": crdb_internal_origin_id
+  -        "4294967294": tableoid
+  -        "4294967295": crdb_internal_mvcc_timestamp
+  -      families:
+  -        "0": primary
+  -      id: 104
+  -      indexes:
+  -        "4": t_a_idx
+  -        "10": t_pkey
+  -      name: t
+  -    relevantStatements:
+  -    - statement:
+  -        redactedStatement: ALTER TABLE ‹defaultdb›.‹public›.‹t› ADD COLUMN ‹m› INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (‹b›)
+  -        statement: ALTER TABLE t ADD COLUMN m INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (b)
+  -        statementTag: ALTER TABLE
+  -    targetRanks: <redacted>
+  -    targets: <redacted>
+     families:
+     - columnIds:
+       - 1
+       - 2
+  -    - 3
+       - 4
+       columnNames:
+       - a
+       - b
+  -    - crdb_internal_column_3_name_placeholder
+       - m
+       name: primary
+  ...
+       version: 4
+     modificationTime: {}
+  -  mutations:
+  -  - column:
+  -      defaultExpr: unique_rowid()
+  -      hidden: true
+  -      id: 3
+  -      name: crdb_internal_column_3_name_placeholder
+  -      nullable: true
+  -      type:
+  -        family: IntFamily
+  -        oid: 20
+  -        width: 64
+  -    direction: DROP
+  -    mutationId: 1
+  -    state: DELETE_ONLY
+  -  - direction: DROP
+  -    index:
+  -      constraintId: 6
+  -      createdExplicitly: true
+  -      encodingType: 1
+  -      foreignKey: {}
+  -      geoConfig: {}
+  -      id: 8
+  -      interleave: {}
+  -      keyColumnDirections:
+  -      - ASC
+  -      keyColumnIds:
+  -      - 2
+  -      keyColumnNames:
+  -      - b
+  -      name: crdb_internal_index_8_name_placeholder
+  -      partitioning: {}
+  -      sharded: {}
+  -      storeColumnIds:
+  -      - 3
+  -      - 1
+  -      - 4
+  -      storeColumnNames:
+  -      - crdb_internal_column_3_name_placeholder
+  -      - a
+  -      - m
+  -      unique: true
+  -      vecConfig: {}
+  -      version: 4
+  -    mutationId: 1
+  -    state: DELETE_ONLY
+  +  mutations: []
+     name: t
+     nextColumnId: 5
+  ...
+       time: {}
+     unexposedParentSchemaId: 101
+  -  version: "25"
+  +  version: "26"
+persist all catalog changes to storage
+create job #2 (non-cancelable: true): "GC for ALTER TABLE defaultdb.public.t ADD COLUMN m INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (b)"
+  descriptor IDs: [104]
+update progress of schema change job #1: "all stages completed"
+set schema change job #1 to non-cancellable
+updated schema change job #1 descriptor IDs to []
+write *eventpb.FinishSchemaChange to event log:
+  sc:
+    descriptorId: 104
+commit transaction #29
+notified job registry to adopt jobs: [2]
+# end PostCommitPhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx/alter_table_alter_primary_key_drop_rowid_with_idx__rollback_10_of_23.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx/alter_table_alter_primary_key_drop_rowid_with_idx__rollback_10_of_23.explain
@@ -1,0 +1,108 @@
+/* setup */
+CREATE TABLE t (a INT NOT NULL, b int8 not null default unique_rowid());
+INSERT INTO t(a) VALUES (1), (2), (2);
+CREATE INDEX on t(a);
+
+/* test */
+alter table t add column m int8 default unique_rowid(), alter primary key using columns(b);
+EXPLAIN (DDL) rollback at post-commit stage 10 of 23;
+----
+Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN m INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (b);
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 3 elements transitioning toward PUBLIC
+      │    │    ├── VALIDATED             → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 0}
+      │    │    ├── VALIDATED             → PUBLIC      PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey+), ConstraintID: 1}
+      │    │    └── ABSENT                → PUBLIC      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey+)}
+      │    ├── 23 elements transitioning toward ABSENT
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 104 (t), ColumnID: 4 (m-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 104 (t), Name: "m", ColumnID: 4 (m-)}
+      │    │    ├── PUBLIC                → VALIDATED   PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 6 (t_pkey-)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 7}
+      │    │    ├── BACKFILL_ONLY         → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 8 (t_pkey-)}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 7, SourceIndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 9}
+      │    │    ├── BACKFILL_ONLY         → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey-), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 10 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 10 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 9}
+      │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 10 (t_pkey-)}
+      │    └── 28 Mutation operations
+      │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":3,"TableID":104}
+      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":4,"TableID":104}
+      │         ├── SetColumnName {"ColumnID":4,"Name":"crdb_internal_co...","TableID":104}
+      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":6,"TableID":104}
+      │         ├── SetIndexName {"IndexID":6,"Name":"crdb_internal_in...","TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":7,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":8,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":9,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":9,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":10,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":10,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"Kind":2,"Ordinal":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"Kind":2,"Ordinal":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"Kind":2,"Ordinal":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":10,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":10,"TableID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 6 elements transitioning toward ABSENT
+      │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (t_pkey-)}
+      │    │    ├── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 7, SourceIndexID: 6 (t_pkey-)}
+      │    │    └── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 6 (t_pkey-)}
+      │    └── 8 Mutation operations
+      │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":6,"Kind":2,"Ordinal":2,"TableID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 3 of 3 in PostCommitNonRevertiblePhase
+           ├── 9 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 104 (t), ColumnID: 4 (m-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 4 (m-), TypeName: "INT8"}
+           │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 104 (t), ColumnID: 4 (m-), Expr: unique_rowid()}
+           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 6 (t_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 7}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 8 (t_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 9}
+           │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 10 (t_pkey-)}
+           └── 10 Mutation operations
+                ├── RemoveColumnDefaultExpression {"ColumnID":4,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":6,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":6,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":7,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":8,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":9,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":10,"TableID":104}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":4,"TableID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx/alter_table_alter_primary_key_drop_rowid_with_idx__rollback_11_of_23.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx/alter_table_alter_primary_key_drop_rowid_with_idx__rollback_11_of_23.explain
@@ -1,0 +1,108 @@
+/* setup */
+CREATE TABLE t (a INT NOT NULL, b int8 not null default unique_rowid());
+INSERT INTO t(a) VALUES (1), (2), (2);
+CREATE INDEX on t(a);
+
+/* test */
+alter table t add column m int8 default unique_rowid(), alter primary key using columns(b);
+EXPLAIN (DDL) rollback at post-commit stage 11 of 23;
+----
+Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN m INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (b);
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 3 elements transitioning toward PUBLIC
+      │    │    ├── VALIDATED             → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 0}
+      │    │    ├── VALIDATED             → PUBLIC      PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey+), ConstraintID: 1}
+      │    │    └── ABSENT                → PUBLIC      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey+)}
+      │    ├── 23 elements transitioning toward ABSENT
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 104 (t), ColumnID: 4 (m-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 104 (t), Name: "m", ColumnID: 4 (m-)}
+      │    │    ├── PUBLIC                → VALIDATED   PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 6 (t_pkey-)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 7}
+      │    │    ├── BACKFILL_ONLY         → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 8 (t_pkey-)}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 7, SourceIndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 9}
+      │    │    ├── BACKFILL_ONLY         → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey-), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 10 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 10 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 9}
+      │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 10 (t_pkey-)}
+      │    └── 28 Mutation operations
+      │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":3,"TableID":104}
+      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":4,"TableID":104}
+      │         ├── SetColumnName {"ColumnID":4,"Name":"crdb_internal_co...","TableID":104}
+      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":6,"TableID":104}
+      │         ├── SetIndexName {"IndexID":6,"Name":"crdb_internal_in...","TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":7,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":8,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":9,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":9,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":10,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":10,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"Kind":2,"Ordinal":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"Kind":2,"Ordinal":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"Kind":2,"Ordinal":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":10,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":10,"TableID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 6 elements transitioning toward ABSENT
+      │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (t_pkey-)}
+      │    │    ├── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 7, SourceIndexID: 6 (t_pkey-)}
+      │    │    └── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 6 (t_pkey-)}
+      │    └── 8 Mutation operations
+      │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":6,"Kind":2,"Ordinal":2,"TableID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 3 of 3 in PostCommitNonRevertiblePhase
+           ├── 9 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 104 (t), ColumnID: 4 (m-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 4 (m-), TypeName: "INT8"}
+           │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 104 (t), ColumnID: 4 (m-), Expr: unique_rowid()}
+           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 6 (t_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 7}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 8 (t_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 9}
+           │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 10 (t_pkey-)}
+           └── 10 Mutation operations
+                ├── RemoveColumnDefaultExpression {"ColumnID":4,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":6,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":6,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":7,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":8,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":9,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":10,"TableID":104}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":4,"TableID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx/alter_table_alter_primary_key_drop_rowid_with_idx__rollback_12_of_23.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx/alter_table_alter_primary_key_drop_rowid_with_idx__rollback_12_of_23.explain
@@ -1,0 +1,108 @@
+/* setup */
+CREATE TABLE t (a INT NOT NULL, b int8 not null default unique_rowid());
+INSERT INTO t(a) VALUES (1), (2), (2);
+CREATE INDEX on t(a);
+
+/* test */
+alter table t add column m int8 default unique_rowid(), alter primary key using columns(b);
+EXPLAIN (DDL) rollback at post-commit stage 12 of 23;
+----
+Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN m INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (b);
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 3 elements transitioning toward PUBLIC
+      │    │    ├── VALIDATED             → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 0}
+      │    │    ├── VALIDATED             → PUBLIC      PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey+), ConstraintID: 1}
+      │    │    └── ABSENT                → PUBLIC      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey+)}
+      │    ├── 23 elements transitioning toward ABSENT
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 104 (t), ColumnID: 4 (m-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 104 (t), Name: "m", ColumnID: 4 (m-)}
+      │    │    ├── PUBLIC                → VALIDATED   PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 6 (t_pkey-)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 7}
+      │    │    ├── DELETE_ONLY           → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 8 (t_pkey-)}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 7, SourceIndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 9}
+      │    │    ├── BACKFILL_ONLY         → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey-), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 10 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 10 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 9}
+      │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 10 (t_pkey-)}
+      │    └── 28 Mutation operations
+      │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":3,"TableID":104}
+      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":4,"TableID":104}
+      │         ├── SetColumnName {"ColumnID":4,"Name":"crdb_internal_co...","TableID":104}
+      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":6,"TableID":104}
+      │         ├── SetIndexName {"IndexID":6,"Name":"crdb_internal_in...","TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":7,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":8,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":9,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":9,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":10,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":10,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"Kind":2,"Ordinal":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"Kind":2,"Ordinal":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"Kind":2,"Ordinal":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":10,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":10,"TableID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 6 elements transitioning toward ABSENT
+      │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (t_pkey-)}
+      │    │    ├── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 7, SourceIndexID: 6 (t_pkey-)}
+      │    │    └── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 6 (t_pkey-)}
+      │    └── 8 Mutation operations
+      │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":6,"Kind":2,"Ordinal":2,"TableID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 3 of 3 in PostCommitNonRevertiblePhase
+           ├── 9 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 104 (t), ColumnID: 4 (m-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 4 (m-), TypeName: "INT8"}
+           │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 104 (t), ColumnID: 4 (m-), Expr: unique_rowid()}
+           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 6 (t_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 7}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 8 (t_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 9}
+           │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 10 (t_pkey-)}
+           └── 10 Mutation operations
+                ├── RemoveColumnDefaultExpression {"ColumnID":4,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":6,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":6,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":7,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":8,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":9,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":10,"TableID":104}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":4,"TableID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx/alter_table_alter_primary_key_drop_rowid_with_idx__rollback_13_of_23.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx/alter_table_alter_primary_key_drop_rowid_with_idx__rollback_13_of_23.explain
@@ -1,0 +1,110 @@
+/* setup */
+CREATE TABLE t (a INT NOT NULL, b int8 not null default unique_rowid());
+INSERT INTO t(a) VALUES (1), (2), (2);
+CREATE INDEX on t(a);
+
+/* test */
+alter table t add column m int8 default unique_rowid(), alter primary key using columns(b);
+EXPLAIN (DDL) rollback at post-commit stage 13 of 23;
+----
+Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN m INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (b);
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 3 elements transitioning toward PUBLIC
+      │    │    ├── VALIDATED             → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 0}
+      │    │    ├── VALIDATED             → PUBLIC      PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey+), ConstraintID: 1}
+      │    │    └── ABSENT                → PUBLIC      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey+)}
+      │    ├── 23 elements transitioning toward ABSENT
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 104 (t), ColumnID: 4 (m-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 104 (t), Name: "m", ColumnID: 4 (m-)}
+      │    │    ├── PUBLIC                → VALIDATED   PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 6 (t_pkey-)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 7}
+      │    │    ├── MERGE_ONLY            → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 8 (t_pkey-)}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 7, SourceIndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 9}
+      │    │    ├── BACKFILL_ONLY         → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey-), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 10 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 10 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 9}
+      │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 10 (t_pkey-)}
+      │    └── 28 Mutation operations
+      │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":3,"TableID":104}
+      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":4,"TableID":104}
+      │         ├── SetColumnName {"ColumnID":4,"Name":"crdb_internal_co...","TableID":104}
+      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":6,"TableID":104}
+      │         ├── SetIndexName {"IndexID":6,"Name":"crdb_internal_in...","TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":7,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":9,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":9,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":10,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":10,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"Kind":2,"Ordinal":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"Kind":2,"Ordinal":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":10,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":8,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":10,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"Kind":2,"Ordinal":2,"TableID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 7 elements transitioning toward ABSENT
+      │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (t_pkey-)}
+      │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey-)}
+      │    │    ├── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 7, SourceIndexID: 6 (t_pkey-)}
+      │    │    └── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 6 (t_pkey-)}
+      │    └── 9 Mutation operations
+      │         ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":6,"Kind":2,"Ordinal":2,"TableID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 3 of 3 in PostCommitNonRevertiblePhase
+           ├── 9 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 104 (t), ColumnID: 4 (m-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 4 (m-), TypeName: "INT8"}
+           │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 104 (t), ColumnID: 4 (m-), Expr: unique_rowid()}
+           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 6 (t_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 7}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 8 (t_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 9}
+           │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 10 (t_pkey-)}
+           └── 10 Mutation operations
+                ├── RemoveColumnDefaultExpression {"ColumnID":4,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":6,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":6,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":7,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":8,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":9,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":10,"TableID":104}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":4,"TableID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx/alter_table_alter_primary_key_drop_rowid_with_idx__rollback_14_of_23.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx/alter_table_alter_primary_key_drop_rowid_with_idx__rollback_14_of_23.explain
@@ -1,0 +1,110 @@
+/* setup */
+CREATE TABLE t (a INT NOT NULL, b int8 not null default unique_rowid());
+INSERT INTO t(a) VALUES (1), (2), (2);
+CREATE INDEX on t(a);
+
+/* test */
+alter table t add column m int8 default unique_rowid(), alter primary key using columns(b);
+EXPLAIN (DDL) rollback at post-commit stage 14 of 23;
+----
+Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN m INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (b);
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 3 elements transitioning toward PUBLIC
+      │    │    ├── VALIDATED             → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 0}
+      │    │    ├── VALIDATED             → PUBLIC      PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey+), ConstraintID: 1}
+      │    │    └── ABSENT                → PUBLIC      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey+)}
+      │    ├── 23 elements transitioning toward ABSENT
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 104 (t), ColumnID: 4 (m-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 104 (t), Name: "m", ColumnID: 4 (m-)}
+      │    │    ├── PUBLIC                → VALIDATED   PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 6 (t_pkey-)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 7}
+      │    │    ├── MERGE_ONLY            → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 8 (t_pkey-)}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 7, SourceIndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 9}
+      │    │    ├── BACKFILL_ONLY         → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey-), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 10 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 10 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 9}
+      │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 10 (t_pkey-)}
+      │    └── 28 Mutation operations
+      │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":3,"TableID":104}
+      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":4,"TableID":104}
+      │         ├── SetColumnName {"ColumnID":4,"Name":"crdb_internal_co...","TableID":104}
+      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":6,"TableID":104}
+      │         ├── SetIndexName {"IndexID":6,"Name":"crdb_internal_in...","TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":7,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":9,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":9,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":10,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":10,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"Kind":2,"Ordinal":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"Kind":2,"Ordinal":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":10,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":8,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":10,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"Kind":2,"Ordinal":2,"TableID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 7 elements transitioning toward ABSENT
+      │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (t_pkey-)}
+      │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey-)}
+      │    │    ├── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 7, SourceIndexID: 6 (t_pkey-)}
+      │    │    └── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 6 (t_pkey-)}
+      │    └── 9 Mutation operations
+      │         ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":6,"Kind":2,"Ordinal":2,"TableID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 3 of 3 in PostCommitNonRevertiblePhase
+           ├── 9 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 104 (t), ColumnID: 4 (m-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 4 (m-), TypeName: "INT8"}
+           │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 104 (t), ColumnID: 4 (m-), Expr: unique_rowid()}
+           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 6 (t_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 7}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 8 (t_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 9}
+           │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 10 (t_pkey-)}
+           └── 10 Mutation operations
+                ├── RemoveColumnDefaultExpression {"ColumnID":4,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":6,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":6,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":7,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":8,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":9,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":10,"TableID":104}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":4,"TableID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx/alter_table_alter_primary_key_drop_rowid_with_idx__rollback_15_of_23.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx/alter_table_alter_primary_key_drop_rowid_with_idx__rollback_15_of_23.explain
@@ -1,0 +1,108 @@
+/* setup */
+CREATE TABLE t (a INT NOT NULL, b int8 not null default unique_rowid());
+INSERT INTO t(a) VALUES (1), (2), (2);
+CREATE INDEX on t(a);
+
+/* test */
+alter table t add column m int8 default unique_rowid(), alter primary key using columns(b);
+EXPLAIN (DDL) rollback at post-commit stage 15 of 23;
+----
+Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN m INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (b);
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 3 elements transitioning toward PUBLIC
+      │    │    ├── VALIDATED             → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 0}
+      │    │    ├── VALIDATED             → PUBLIC      PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey+), ConstraintID: 1}
+      │    │    └── ABSENT                → PUBLIC      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey+)}
+      │    ├── 23 elements transitioning toward ABSENT
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 104 (t), ColumnID: 4 (m-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 104 (t), Name: "m", ColumnID: 4 (m-)}
+      │    │    ├── PUBLIC                → VALIDATED   PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 6 (t_pkey-)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 7}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 8 (t_pkey-)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 7, SourceIndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 9}
+      │    │    ├── BACKFILL_ONLY         → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey-), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 10 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 10 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 9}
+      │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 10 (t_pkey-)}
+      │    └── 28 Mutation operations
+      │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":3,"TableID":104}
+      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":4,"TableID":104}
+      │         ├── SetColumnName {"ColumnID":4,"Name":"crdb_internal_co...","TableID":104}
+      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":6,"TableID":104}
+      │         ├── SetIndexName {"IndexID":6,"Name":"crdb_internal_in...","TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":7,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":8,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":9,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":10,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":10,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"Kind":2,"Ordinal":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"Kind":2,"Ordinal":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"Kind":2,"Ordinal":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":10,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":10,"TableID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 6 elements transitioning toward ABSENT
+      │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (t_pkey-)}
+      │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey-)}
+      │    │    └── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 6 (t_pkey-)}
+      │    └── 8 Mutation operations
+      │         ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":6,"Kind":2,"Ordinal":2,"TableID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 3 of 3 in PostCommitNonRevertiblePhase
+           ├── 9 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 104 (t), ColumnID: 4 (m-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 4 (m-), TypeName: "INT8"}
+           │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 104 (t), ColumnID: 4 (m-), Expr: unique_rowid()}
+           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 6 (t_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 7}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 8 (t_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 9}
+           │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 10 (t_pkey-)}
+           └── 10 Mutation operations
+                ├── RemoveColumnDefaultExpression {"ColumnID":4,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":6,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":6,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":7,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":8,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":9,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":10,"TableID":104}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":4,"TableID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx/alter_table_alter_primary_key_drop_rowid_with_idx__rollback_16_of_23.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx/alter_table_alter_primary_key_drop_rowid_with_idx__rollback_16_of_23.explain
@@ -1,0 +1,108 @@
+/* setup */
+CREATE TABLE t (a INT NOT NULL, b int8 not null default unique_rowid());
+INSERT INTO t(a) VALUES (1), (2), (2);
+CREATE INDEX on t(a);
+
+/* test */
+alter table t add column m int8 default unique_rowid(), alter primary key using columns(b);
+EXPLAIN (DDL) rollback at post-commit stage 16 of 23;
+----
+Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN m INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (b);
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 3 elements transitioning toward PUBLIC
+      │    │    ├── VALIDATED             → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 0}
+      │    │    ├── VALIDATED             → PUBLIC      PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey+), ConstraintID: 1}
+      │    │    └── ABSENT                → PUBLIC      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey+)}
+      │    ├── 23 elements transitioning toward ABSENT
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 104 (t), ColumnID: 4 (m-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 104 (t), Name: "m", ColumnID: 4 (m-)}
+      │    │    ├── PUBLIC                → VALIDATED   PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 6 (t_pkey-)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 7}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 8 (t_pkey-)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 7, SourceIndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 9}
+      │    │    ├── BACKFILL_ONLY         → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey-), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 10 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 10 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 9}
+      │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 10 (t_pkey-)}
+      │    └── 28 Mutation operations
+      │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":3,"TableID":104}
+      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":4,"TableID":104}
+      │         ├── SetColumnName {"ColumnID":4,"Name":"crdb_internal_co...","TableID":104}
+      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":6,"TableID":104}
+      │         ├── SetIndexName {"IndexID":6,"Name":"crdb_internal_in...","TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":7,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":8,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":9,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":10,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":10,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"Kind":2,"Ordinal":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"Kind":2,"Ordinal":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"Kind":2,"Ordinal":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":10,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":10,"TableID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 6 elements transitioning toward ABSENT
+      │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (t_pkey-)}
+      │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey-)}
+      │    │    └── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 6 (t_pkey-)}
+      │    └── 8 Mutation operations
+      │         ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":6,"Kind":2,"Ordinal":2,"TableID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 3 of 3 in PostCommitNonRevertiblePhase
+           ├── 9 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 104 (t), ColumnID: 4 (m-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 4 (m-), TypeName: "INT8"}
+           │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 104 (t), ColumnID: 4 (m-), Expr: unique_rowid()}
+           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 6 (t_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 7}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 8 (t_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 9}
+           │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 10 (t_pkey-)}
+           └── 10 Mutation operations
+                ├── RemoveColumnDefaultExpression {"ColumnID":4,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":6,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":6,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":7,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":8,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":9,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":10,"TableID":104}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":4,"TableID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx/alter_table_alter_primary_key_drop_rowid_with_idx__rollback_17_of_23.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx/alter_table_alter_primary_key_drop_rowid_with_idx__rollback_17_of_23.explain
@@ -1,0 +1,130 @@
+/* setup */
+CREATE TABLE t (a INT NOT NULL, b int8 not null default unique_rowid());
+INSERT INTO t(a) VALUES (1), (2), (2);
+CREATE INDEX on t(a);
+
+/* test */
+alter table t add column m int8 default unique_rowid(), alter primary key using columns(b);
+EXPLAIN (DDL) rollback at post-commit stage 17 of 23;
+----
+Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN m INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (b);
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 3 elements transitioning toward PUBLIC
+      │    │    ├── VALIDATED             → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 0}
+      │    │    ├── VALIDATED             → PUBLIC      PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey+), ConstraintID: 1}
+      │    │    └── ABSENT                → PUBLIC      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey+)}
+      │    ├── 33 elements transitioning toward ABSENT
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 104 (t), ColumnID: 4 (m-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 104 (t), Name: "m", ColumnID: 4 (m-)}
+      │    │    ├── PUBLIC                → VALIDATED   PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 6 (t_pkey-)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 7}
+      │    │    ├── VALIDATED             → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 8 (t_pkey-)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 7, SourceIndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 9}
+      │    │    ├── BACKFILL_ONLY         → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey-), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 10 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 10 (t_pkey-)}
+      │    │    ├── DELETE_ONLY           → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 11, ConstraintID: 9, SourceIndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 11}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 11}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 10 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 11}
+      │    │    ├── BACKFILL_ONLY         → ABSENT      SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_a_idx-), ConstraintID: 2, TemporaryIndexID: 5, SourceIndexID: 8 (t_pkey-), RecreateSourceIndexID: 2}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 4 (t_a_idx-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 4 (t_a_idx-)}
+      │    │    ├── DELETE_ONLY           → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 3, SourceIndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 5}
+      │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 5}
+      │    └── 38 Mutation operations
+      │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":3,"TableID":104}
+      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":4,"TableID":104}
+      │         ├── SetColumnName {"ColumnID":4,"Name":"crdb_internal_co...","TableID":104}
+      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":6,"TableID":104}
+      │         ├── SetIndexName {"IndexID":6,"Name":"crdb_internal_in...","TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":7,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":9,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":10,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":10,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":11,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":11,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"Kind":2,"Ordinal":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"Kind":2,"Ordinal":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":10,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":11,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"Kind":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"Kind":1,"TableID":104}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":8,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":10,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":11,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"Kind":2,"Ordinal":2,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 6 elements transitioning toward ABSENT
+      │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (t_pkey-)}
+      │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey-)}
+      │    │    └── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 6 (t_pkey-)}
+      │    └── 8 Mutation operations
+      │         ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":6,"Kind":2,"Ordinal":2,"TableID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 3 of 3 in PostCommitNonRevertiblePhase
+           ├── 10 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 104 (t), ColumnID: 4 (m-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 4 (m-), TypeName: "INT8"}
+           │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 104 (t), ColumnID: 4 (m-), Expr: unique_rowid()}
+           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 6 (t_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 7}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 8 (t_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 9}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 10 (t_pkey-)}
+           │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 4 (t_a_idx-)}
+           └── 11 Mutation operations
+                ├── RemoveColumnDefaultExpression {"ColumnID":4,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":6,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":4,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":6,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":7,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":8,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":9,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":10,"TableID":104}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":4,"TableID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx/alter_table_alter_primary_key_drop_rowid_with_idx__rollback_18_of_23.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx/alter_table_alter_primary_key_drop_rowid_with_idx__rollback_18_of_23.explain
@@ -1,0 +1,138 @@
+/* setup */
+CREATE TABLE t (a INT NOT NULL, b int8 not null default unique_rowid());
+INSERT INTO t(a) VALUES (1), (2), (2);
+CREATE INDEX on t(a);
+
+/* test */
+alter table t add column m int8 default unique_rowid(), alter primary key using columns(b);
+EXPLAIN (DDL) rollback at post-commit stage 18 of 23;
+----
+Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN m INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (b);
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 3 elements transitioning toward PUBLIC
+      │    │    ├── VALIDATED             → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 0}
+      │    │    ├── VALIDATED             → PUBLIC      PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey+), ConstraintID: 1}
+      │    │    └── ABSENT                → PUBLIC      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey+)}
+      │    ├── 33 elements transitioning toward ABSENT
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 104 (t), ColumnID: 4 (m-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 104 (t), Name: "m", ColumnID: 4 (m-)}
+      │    │    ├── PUBLIC                → VALIDATED   PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 6 (t_pkey-)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 7}
+      │    │    ├── VALIDATED             → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 8 (t_pkey-)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 7, SourceIndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 9}
+      │    │    ├── BACKFILL_ONLY         → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey-), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 10 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 10 (t_pkey-)}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 11, ConstraintID: 9, SourceIndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 11}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 11}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 10 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 11}
+      │    │    ├── BACKFILL_ONLY         → ABSENT      SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_a_idx-), ConstraintID: 2, TemporaryIndexID: 5, SourceIndexID: 8 (t_pkey-), RecreateSourceIndexID: 2}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 4 (t_a_idx-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 4 (t_a_idx-)}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 3, SourceIndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 5}
+      │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 5}
+      │    └── 38 Mutation operations
+      │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":3,"TableID":104}
+      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":4,"TableID":104}
+      │         ├── SetColumnName {"ColumnID":4,"Name":"crdb_internal_co...","TableID":104}
+      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":6,"TableID":104}
+      │         ├── SetIndexName {"IndexID":6,"Name":"crdb_internal_in...","TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":7,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":9,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":10,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":10,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":11,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":11,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":11,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"Kind":2,"Ordinal":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"Kind":2,"Ordinal":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":10,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":11,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"Kind":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":5,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"Kind":1,"TableID":104}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":8,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":10,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"Kind":2,"Ordinal":2,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 8 elements transitioning toward ABSENT
+      │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (t_pkey-)}
+      │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey-)}
+      │    │    ├── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 11, ConstraintID: 9, SourceIndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 6 (t_pkey-)}
+      │    │    └── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 3, SourceIndexID: 8 (t_pkey-)}
+      │    └── 10 Mutation operations
+      │         ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":11,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":6,"Kind":2,"Ordinal":2,"TableID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 3 of 3 in PostCommitNonRevertiblePhase
+           ├── 12 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 104 (t), ColumnID: 4 (m-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 4 (m-), TypeName: "INT8"}
+           │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 104 (t), ColumnID: 4 (m-), Expr: unique_rowid()}
+           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 6 (t_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 7}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 8 (t_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 9}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 10 (t_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 11}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 4 (t_a_idx-)}
+           │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 5}
+           └── 13 Mutation operations
+                ├── RemoveColumnDefaultExpression {"ColumnID":4,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":6,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":4,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":5,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":6,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":7,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":8,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":9,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":10,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":11,"TableID":104}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":4,"TableID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx/alter_table_alter_primary_key_drop_rowid_with_idx__rollback_19_of_23.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx/alter_table_alter_primary_key_drop_rowid_with_idx__rollback_19_of_23.explain
@@ -1,0 +1,138 @@
+/* setup */
+CREATE TABLE t (a INT NOT NULL, b int8 not null default unique_rowid());
+INSERT INTO t(a) VALUES (1), (2), (2);
+CREATE INDEX on t(a);
+
+/* test */
+alter table t add column m int8 default unique_rowid(), alter primary key using columns(b);
+EXPLAIN (DDL) rollback at post-commit stage 19 of 23;
+----
+Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN m INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (b);
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 3 elements transitioning toward PUBLIC
+      │    │    ├── VALIDATED             → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 0}
+      │    │    ├── VALIDATED             → PUBLIC      PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey+), ConstraintID: 1}
+      │    │    └── ABSENT                → PUBLIC      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey+)}
+      │    ├── 33 elements transitioning toward ABSENT
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 104 (t), ColumnID: 4 (m-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 104 (t), Name: "m", ColumnID: 4 (m-)}
+      │    │    ├── PUBLIC                → VALIDATED   PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 6 (t_pkey-)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 7}
+      │    │    ├── VALIDATED             → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 8 (t_pkey-)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 7, SourceIndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 9}
+      │    │    ├── BACKFILL_ONLY         → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey-), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 10 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 10 (t_pkey-)}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 11, ConstraintID: 9, SourceIndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 11}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 11}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 10 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 11}
+      │    │    ├── BACKFILL_ONLY         → ABSENT      SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_a_idx-), ConstraintID: 2, TemporaryIndexID: 5, SourceIndexID: 8 (t_pkey-), RecreateSourceIndexID: 2}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 4 (t_a_idx-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 4 (t_a_idx-)}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 3, SourceIndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 5}
+      │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 5}
+      │    └── 38 Mutation operations
+      │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":3,"TableID":104}
+      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":4,"TableID":104}
+      │         ├── SetColumnName {"ColumnID":4,"Name":"crdb_internal_co...","TableID":104}
+      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":6,"TableID":104}
+      │         ├── SetIndexName {"IndexID":6,"Name":"crdb_internal_in...","TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":7,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":9,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":10,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":10,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":11,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":11,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":11,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"Kind":2,"Ordinal":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"Kind":2,"Ordinal":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":10,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":11,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"Kind":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":5,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"Kind":1,"TableID":104}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":8,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":10,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"Kind":2,"Ordinal":2,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 8 elements transitioning toward ABSENT
+      │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (t_pkey-)}
+      │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey-)}
+      │    │    ├── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 11, ConstraintID: 9, SourceIndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 6 (t_pkey-)}
+      │    │    └── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 3, SourceIndexID: 8 (t_pkey-)}
+      │    └── 10 Mutation operations
+      │         ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":11,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":6,"Kind":2,"Ordinal":2,"TableID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 3 of 3 in PostCommitNonRevertiblePhase
+           ├── 12 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 104 (t), ColumnID: 4 (m-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 4 (m-), TypeName: "INT8"}
+           │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 104 (t), ColumnID: 4 (m-), Expr: unique_rowid()}
+           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 6 (t_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 7}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 8 (t_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 9}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 10 (t_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 11}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 4 (t_a_idx-)}
+           │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 5}
+           └── 13 Mutation operations
+                ├── RemoveColumnDefaultExpression {"ColumnID":4,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":6,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":4,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":5,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":6,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":7,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":8,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":9,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":10,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":11,"TableID":104}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":4,"TableID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx/alter_table_alter_primary_key_drop_rowid_with_idx__rollback_1_of_23.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx/alter_table_alter_primary_key_drop_rowid_with_idx__rollback_1_of_23.explain
@@ -1,0 +1,70 @@
+/* setup */
+CREATE TABLE t (a INT NOT NULL, b int8 not null default unique_rowid());
+INSERT INTO t(a) VALUES (1), (2), (2);
+CREATE INDEX on t(a);
+
+/* test */
+alter table t add column m int8 default unique_rowid(), alter primary key using columns(b);
+EXPLAIN (DDL) rollback at post-commit stage 1 of 23;
+----
+Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN m INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (b);
+ └── PostCommitNonRevertiblePhase
+      └── Stage 1 of 1 in PostCommitNonRevertiblePhase
+           ├── 1 element transitioning toward PUBLIC
+           │    └── VALIDATED     → PUBLIC ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 0}
+           ├── 26 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY   → ABSENT Column:{DescID: 104 (t), ColumnID: 4 (m-)}
+           │    ├── PUBLIC        → ABSENT ColumnName:{DescID: 104 (t), Name: "m", ColumnID: 4 (m-)}
+           │    ├── PUBLIC        → ABSENT ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 4 (m-), TypeName: "INT8"}
+           │    ├── PUBLIC        → ABSENT ColumnDefaultExpression:{DescID: 104 (t), ColumnID: 4 (m-), Expr: unique_rowid()}
+           │    ├── BACKFILL_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
+           │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 6 (t_pkey-)}
+           │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (t_pkey-)}
+           │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (t_pkey-)}
+           │    ├── PUBLIC        → ABSENT IndexData:{DescID: 104 (t), IndexID: 6 (t_pkey-)}
+           │    ├── DELETE_ONLY   → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
+           │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 7}
+           │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 7}
+           │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 7}
+           │    ├── BACKFILL_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey-)}
+           │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 8 (t_pkey-)}
+           │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 8 (t_pkey-)}
+           │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 8 (t_pkey-)}
+           │    ├── PUBLIC        → ABSENT IndexData:{DescID: 104 (t), IndexID: 8 (t_pkey-)}
+           │    ├── BACKFILL_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey-), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 8 (t_pkey-)}
+           │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 10 (t_pkey-)}
+           │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 10 (t_pkey-)}
+           │    ├── PUBLIC        → ABSENT IndexData:{DescID: 104 (t), IndexID: 10 (t_pkey-)}
+           │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 6 (t_pkey-)}
+           │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 7}
+           │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 8 (t_pkey-)}
+           │    └── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 10 (t_pkey-)}
+           └── 28 Mutation operations
+                ├── MakeValidatedColumnNotNullPublic {"ColumnID":3,"TableID":104}
+                ├── SetColumnName {"ColumnID":4,"Name":"crdb_internal_co...","TableID":104}
+                ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"TableID":104}
+                ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Kind":2,"TableID":104}
+                ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":104}
+                ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":7,"TableID":104}
+                ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Kind":2,"TableID":104}
+                ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":104}
+                ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":8,"Kind":2,"TableID":104}
+                ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":104}
+                ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"TableID":104}
+                ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":10,"Kind":2,"TableID":104}
+                ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":10,"TableID":104}
+                ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":6,"Kind":2,"Ordinal":2,"TableID":104}
+                ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"Kind":2,"Ordinal":2,"TableID":104}
+                ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"Kind":2,"Ordinal":2,"TableID":104}
+                ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":10,"Kind":2,"Ordinal":1,"TableID":104}
+                ├── RemoveColumnDefaultExpression {"ColumnID":4,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":6,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":6,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":8,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":10,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":10,"TableID":104}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":4,"TableID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx/alter_table_alter_primary_key_drop_rowid_with_idx__rollback_20_of_23.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx/alter_table_alter_primary_key_drop_rowid_with_idx__rollback_20_of_23.explain
@@ -1,0 +1,138 @@
+/* setup */
+CREATE TABLE t (a INT NOT NULL, b int8 not null default unique_rowid());
+INSERT INTO t(a) VALUES (1), (2), (2);
+CREATE INDEX on t(a);
+
+/* test */
+alter table t add column m int8 default unique_rowid(), alter primary key using columns(b);
+EXPLAIN (DDL) rollback at post-commit stage 20 of 23;
+----
+Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN m INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (b);
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 3 elements transitioning toward PUBLIC
+      │    │    ├── VALIDATED             → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 0}
+      │    │    ├── VALIDATED             → PUBLIC      PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey+), ConstraintID: 1}
+      │    │    └── ABSENT                → PUBLIC      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey+)}
+      │    ├── 33 elements transitioning toward ABSENT
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 104 (t), ColumnID: 4 (m-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 104 (t), Name: "m", ColumnID: 4 (m-)}
+      │    │    ├── PUBLIC                → VALIDATED   PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 6 (t_pkey-)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 7}
+      │    │    ├── VALIDATED             → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 8 (t_pkey-)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 7, SourceIndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 9}
+      │    │    ├── DELETE_ONLY           → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey-), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 10 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 10 (t_pkey-)}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 11, ConstraintID: 9, SourceIndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 11}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 11}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 10 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 11}
+      │    │    ├── DELETE_ONLY           → ABSENT      SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_a_idx-), ConstraintID: 2, TemporaryIndexID: 5, SourceIndexID: 8 (t_pkey-), RecreateSourceIndexID: 2}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 4 (t_a_idx-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 4 (t_a_idx-)}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 3, SourceIndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 5}
+      │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 5}
+      │    └── 38 Mutation operations
+      │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":3,"TableID":104}
+      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":4,"TableID":104}
+      │         ├── SetColumnName {"ColumnID":4,"Name":"crdb_internal_co...","TableID":104}
+      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":6,"TableID":104}
+      │         ├── SetIndexName {"IndexID":6,"Name":"crdb_internal_in...","TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":7,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":9,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":10,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":10,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":11,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":11,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":11,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"Kind":2,"Ordinal":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"Kind":2,"Ordinal":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":10,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":11,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"Kind":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":5,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"Kind":1,"TableID":104}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":8,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":10,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"Kind":2,"Ordinal":2,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 8 elements transitioning toward ABSENT
+      │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (t_pkey-)}
+      │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey-)}
+      │    │    ├── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 11, ConstraintID: 9, SourceIndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 6 (t_pkey-)}
+      │    │    └── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 3, SourceIndexID: 8 (t_pkey-)}
+      │    └── 10 Mutation operations
+      │         ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":11,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":6,"Kind":2,"Ordinal":2,"TableID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 3 of 3 in PostCommitNonRevertiblePhase
+           ├── 12 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 104 (t), ColumnID: 4 (m-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 4 (m-), TypeName: "INT8"}
+           │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 104 (t), ColumnID: 4 (m-), Expr: unique_rowid()}
+           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 6 (t_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 7}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 8 (t_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 9}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 10 (t_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 11}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 4 (t_a_idx-)}
+           │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 5}
+           └── 13 Mutation operations
+                ├── RemoveColumnDefaultExpression {"ColumnID":4,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":6,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":4,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":5,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":6,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":7,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":8,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":9,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":10,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":11,"TableID":104}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":4,"TableID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx/alter_table_alter_primary_key_drop_rowid_with_idx__rollback_21_of_23.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx/alter_table_alter_primary_key_drop_rowid_with_idx__rollback_21_of_23.explain
@@ -1,0 +1,142 @@
+/* setup */
+CREATE TABLE t (a INT NOT NULL, b int8 not null default unique_rowid());
+INSERT INTO t(a) VALUES (1), (2), (2);
+CREATE INDEX on t(a);
+
+/* test */
+alter table t add column m int8 default unique_rowid(), alter primary key using columns(b);
+EXPLAIN (DDL) rollback at post-commit stage 21 of 23;
+----
+Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN m INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (b);
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 3 elements transitioning toward PUBLIC
+      │    │    ├── VALIDATED             → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 0}
+      │    │    ├── VALIDATED             → PUBLIC      PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey+), ConstraintID: 1}
+      │    │    └── ABSENT                → PUBLIC      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey+)}
+      │    ├── 33 elements transitioning toward ABSENT
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 104 (t), ColumnID: 4 (m-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 104 (t), Name: "m", ColumnID: 4 (m-)}
+      │    │    ├── PUBLIC                → VALIDATED   PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 6 (t_pkey-)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 7}
+      │    │    ├── VALIDATED             → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 8 (t_pkey-)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 7, SourceIndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 9}
+      │    │    ├── MERGE_ONLY            → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey-), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 10 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 10 (t_pkey-)}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 11, ConstraintID: 9, SourceIndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 11}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 11}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 10 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 11}
+      │    │    ├── MERGE_ONLY            → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_a_idx-), ConstraintID: 2, TemporaryIndexID: 5, SourceIndexID: 8 (t_pkey-), RecreateSourceIndexID: 2}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 4 (t_a_idx-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 4 (t_a_idx-)}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 3, SourceIndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 5}
+      │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 5}
+      │    └── 38 Mutation operations
+      │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":3,"TableID":104}
+      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":4,"TableID":104}
+      │         ├── SetColumnName {"ColumnID":4,"Name":"crdb_internal_co...","TableID":104}
+      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":6,"TableID":104}
+      │         ├── SetIndexName {"IndexID":6,"Name":"crdb_internal_in...","TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":7,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":9,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":11,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":11,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":11,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"Kind":2,"Ordinal":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"Kind":2,"Ordinal":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":11,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":5,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"Kind":1,"TableID":104}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":8,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":10,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":10,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":10,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"Kind":2,"Ordinal":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":10,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"Kind":1,"TableID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 10 elements transitioning toward ABSENT
+      │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (t_pkey-)}
+      │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey-)}
+      │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey-), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 8 (t_pkey-)}
+      │    │    ├── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 11, ConstraintID: 9, SourceIndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 6 (t_pkey-)}
+      │    │    ├── DELETE_ONLY → ABSENT      SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_a_idx-), ConstraintID: 2, TemporaryIndexID: 5, SourceIndexID: 8 (t_pkey-), RecreateSourceIndexID: 2}
+      │    │    └── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 3, SourceIndexID: 8 (t_pkey-)}
+      │    └── 12 Mutation operations
+      │         ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":10,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":11,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":6,"Kind":2,"Ordinal":2,"TableID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 3 of 3 in PostCommitNonRevertiblePhase
+           ├── 12 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 104 (t), ColumnID: 4 (m-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 4 (m-), TypeName: "INT8"}
+           │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 104 (t), ColumnID: 4 (m-), Expr: unique_rowid()}
+           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 6 (t_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 7}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 8 (t_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 9}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 10 (t_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 11}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 4 (t_a_idx-)}
+           │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 5}
+           └── 13 Mutation operations
+                ├── RemoveColumnDefaultExpression {"ColumnID":4,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":6,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":4,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":5,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":6,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":7,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":8,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":9,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":10,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":11,"TableID":104}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":4,"TableID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx/alter_table_alter_primary_key_drop_rowid_with_idx__rollback_22_of_23.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx/alter_table_alter_primary_key_drop_rowid_with_idx__rollback_22_of_23.explain
@@ -1,0 +1,142 @@
+/* setup */
+CREATE TABLE t (a INT NOT NULL, b int8 not null default unique_rowid());
+INSERT INTO t(a) VALUES (1), (2), (2);
+CREATE INDEX on t(a);
+
+/* test */
+alter table t add column m int8 default unique_rowid(), alter primary key using columns(b);
+EXPLAIN (DDL) rollback at post-commit stage 22 of 23;
+----
+Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN m INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (b);
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 3 elements transitioning toward PUBLIC
+      │    │    ├── VALIDATED             → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 0}
+      │    │    ├── VALIDATED             → PUBLIC      PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey+), ConstraintID: 1}
+      │    │    └── ABSENT                → PUBLIC      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey+)}
+      │    ├── 33 elements transitioning toward ABSENT
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 104 (t), ColumnID: 4 (m-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 104 (t), Name: "m", ColumnID: 4 (m-)}
+      │    │    ├── PUBLIC                → VALIDATED   PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 6 (t_pkey-)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 7}
+      │    │    ├── VALIDATED             → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 8 (t_pkey-)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 7, SourceIndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 9}
+      │    │    ├── MERGE_ONLY            → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey-), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 10 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 10 (t_pkey-)}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 11, ConstraintID: 9, SourceIndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 11}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 11}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 10 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 11}
+      │    │    ├── MERGE_ONLY            → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_a_idx-), ConstraintID: 2, TemporaryIndexID: 5, SourceIndexID: 8 (t_pkey-), RecreateSourceIndexID: 2}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 4 (t_a_idx-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 4 (t_a_idx-)}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 3, SourceIndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 5}
+      │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 5}
+      │    └── 38 Mutation operations
+      │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":3,"TableID":104}
+      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":4,"TableID":104}
+      │         ├── SetColumnName {"ColumnID":4,"Name":"crdb_internal_co...","TableID":104}
+      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":6,"TableID":104}
+      │         ├── SetIndexName {"IndexID":6,"Name":"crdb_internal_in...","TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":7,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":9,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":11,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":11,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":11,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"Kind":2,"Ordinal":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"Kind":2,"Ordinal":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":11,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":5,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"Kind":1,"TableID":104}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":8,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":10,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":10,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":10,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"Kind":2,"Ordinal":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":10,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"Kind":1,"TableID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 10 elements transitioning toward ABSENT
+      │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (t_pkey-)}
+      │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey-)}
+      │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey-), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 8 (t_pkey-)}
+      │    │    ├── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 11, ConstraintID: 9, SourceIndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 6 (t_pkey-)}
+      │    │    ├── DELETE_ONLY → ABSENT      SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_a_idx-), ConstraintID: 2, TemporaryIndexID: 5, SourceIndexID: 8 (t_pkey-), RecreateSourceIndexID: 2}
+      │    │    └── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 3, SourceIndexID: 8 (t_pkey-)}
+      │    └── 12 Mutation operations
+      │         ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":10,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":11,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":6,"Kind":2,"Ordinal":2,"TableID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 3 of 3 in PostCommitNonRevertiblePhase
+           ├── 12 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 104 (t), ColumnID: 4 (m-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 4 (m-), TypeName: "INT8"}
+           │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 104 (t), ColumnID: 4 (m-), Expr: unique_rowid()}
+           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 6 (t_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 7}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 8 (t_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 9}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 10 (t_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 11}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 4 (t_a_idx-)}
+           │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 5}
+           └── 13 Mutation operations
+                ├── RemoveColumnDefaultExpression {"ColumnID":4,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":6,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":4,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":5,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":6,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":7,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":8,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":9,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":10,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":11,"TableID":104}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":4,"TableID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx/alter_table_alter_primary_key_drop_rowid_with_idx__rollback_23_of_23.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx/alter_table_alter_primary_key_drop_rowid_with_idx__rollback_23_of_23.explain
@@ -1,0 +1,138 @@
+/* setup */
+CREATE TABLE t (a INT NOT NULL, b int8 not null default unique_rowid());
+INSERT INTO t(a) VALUES (1), (2), (2);
+CREATE INDEX on t(a);
+
+/* test */
+alter table t add column m int8 default unique_rowid(), alter primary key using columns(b);
+EXPLAIN (DDL) rollback at post-commit stage 23 of 23;
+----
+Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN m INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (b);
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 3 elements transitioning toward PUBLIC
+      │    │    ├── VALIDATED             → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 0}
+      │    │    ├── VALIDATED             → PUBLIC      PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey+), ConstraintID: 1}
+      │    │    └── ABSENT                → PUBLIC      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey+)}
+      │    ├── 33 elements transitioning toward ABSENT
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 104 (t), ColumnID: 4 (m-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 104 (t), Name: "m", ColumnID: 4 (m-)}
+      │    │    ├── PUBLIC                → VALIDATED   PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 6 (t_pkey-)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 7}
+      │    │    ├── VALIDATED             → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 8 (t_pkey-)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 7, SourceIndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 9}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey-), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 10 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 10 (t_pkey-)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 11, ConstraintID: 9, SourceIndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 11}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 11}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 10 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 11}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_a_idx-), ConstraintID: 2, TemporaryIndexID: 5, SourceIndexID: 8 (t_pkey-), RecreateSourceIndexID: 2}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 4 (t_a_idx-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 4 (t_a_idx-)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 3, SourceIndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 5}
+      │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 5}
+      │    └── 38 Mutation operations
+      │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":3,"TableID":104}
+      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":4,"TableID":104}
+      │         ├── SetColumnName {"ColumnID":4,"Name":"crdb_internal_co...","TableID":104}
+      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":6,"TableID":104}
+      │         ├── SetIndexName {"IndexID":6,"Name":"crdb_internal_in...","TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":7,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":9,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":10,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":10,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":10,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":11,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":11,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"Kind":2,"Ordinal":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"Kind":2,"Ordinal":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":10,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":11,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"Kind":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"Kind":1,"TableID":104}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":8,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":11,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"Kind":2,"Ordinal":2,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 8 elements transitioning toward ABSENT
+      │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (t_pkey-)}
+      │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey-)}
+      │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey-), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 6 (t_pkey-)}
+      │    │    └── DELETE_ONLY → ABSENT      SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_a_idx-), ConstraintID: 2, TemporaryIndexID: 5, SourceIndexID: 8 (t_pkey-), RecreateSourceIndexID: 2}
+      │    └── 10 Mutation operations
+      │         ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":10,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":6,"Kind":2,"Ordinal":2,"TableID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 3 of 3 in PostCommitNonRevertiblePhase
+           ├── 12 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 104 (t), ColumnID: 4 (m-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 4 (m-), TypeName: "INT8"}
+           │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 104 (t), ColumnID: 4 (m-), Expr: unique_rowid()}
+           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 6 (t_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 7}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 8 (t_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 9}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 10 (t_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 11}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 4 (t_a_idx-)}
+           │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 5}
+           └── 13 Mutation operations
+                ├── RemoveColumnDefaultExpression {"ColumnID":4,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":6,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":4,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":5,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":6,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":7,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":8,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":9,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":10,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":11,"TableID":104}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":4,"TableID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx/alter_table_alter_primary_key_drop_rowid_with_idx__rollback_2_of_23.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx/alter_table_alter_primary_key_drop_rowid_with_idx__rollback_2_of_23.explain
@@ -1,0 +1,81 @@
+/* setup */
+CREATE TABLE t (a INT NOT NULL, b int8 not null default unique_rowid());
+INSERT INTO t(a) VALUES (1), (2), (2);
+CREATE INDEX on t(a);
+
+/* test */
+alter table t add column m int8 default unique_rowid(), alter primary key using columns(b);
+EXPLAIN (DDL) rollback at post-commit stage 2 of 23;
+----
+Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN m INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (b);
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 1 element transitioning toward PUBLIC
+      │    │    └── VALIDATED     → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 0}
+      │    ├── 21 elements transitioning toward ABSENT
+      │    │    ├── WRITE_ONLY    → DELETE_ONLY Column:{DescID: 104 (t), ColumnID: 4 (m-)}
+      │    │    ├── PUBLIC        → ABSENT      ColumnName:{DescID: 104 (t), Name: "m", ColumnID: 4 (m-)}
+      │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (t_pkey-)}
+      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 7}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 7}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 7}
+      │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 8 (t_pkey-)}
+      │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey-), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 10 (t_pkey-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 10 (t_pkey-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 7}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 8 (t_pkey-)}
+      │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 10 (t_pkey-)}
+      │    └── 24 Mutation operations
+      │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":3,"TableID":104}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":4,"TableID":104}
+      │         ├── SetColumnName {"ColumnID":4,"Name":"crdb_internal_co...","TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":7,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":7,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":8,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":10,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":10,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":6,"Kind":2,"Ordinal":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"Kind":2,"Ordinal":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"Kind":2,"Ordinal":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":10,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":6,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":10,"TableID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 8 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 104 (t), ColumnID: 4 (m-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 4 (m-), TypeName: "INT8"}
+           │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 104 (t), ColumnID: 4 (m-), Expr: unique_rowid()}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 6 (t_pkey-)}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 7}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 8 (t_pkey-)}
+           │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 10 (t_pkey-)}
+           └── 9 Mutation operations
+                ├── RemoveColumnDefaultExpression {"ColumnID":4,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":6,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":7,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":8,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":10,"TableID":104}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":4,"TableID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx/alter_table_alter_primary_key_drop_rowid_with_idx__rollback_3_of_23.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx/alter_table_alter_primary_key_drop_rowid_with_idx__rollback_3_of_23.explain
@@ -1,0 +1,81 @@
+/* setup */
+CREATE TABLE t (a INT NOT NULL, b int8 not null default unique_rowid());
+INSERT INTO t(a) VALUES (1), (2), (2);
+CREATE INDEX on t(a);
+
+/* test */
+alter table t add column m int8 default unique_rowid(), alter primary key using columns(b);
+EXPLAIN (DDL) rollback at post-commit stage 3 of 23;
+----
+Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN m INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (b);
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 1 element transitioning toward PUBLIC
+      │    │    └── VALIDATED     → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 0}
+      │    ├── 21 elements transitioning toward ABSENT
+      │    │    ├── WRITE_ONLY    → DELETE_ONLY Column:{DescID: 104 (t), ColumnID: 4 (m-)}
+      │    │    ├── PUBLIC        → ABSENT      ColumnName:{DescID: 104 (t), Name: "m", ColumnID: 4 (m-)}
+      │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (t_pkey-)}
+      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 7}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 7}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 7}
+      │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 8 (t_pkey-)}
+      │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey-), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 10 (t_pkey-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 10 (t_pkey-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 7}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 8 (t_pkey-)}
+      │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 10 (t_pkey-)}
+      │    └── 24 Mutation operations
+      │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":3,"TableID":104}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":4,"TableID":104}
+      │         ├── SetColumnName {"ColumnID":4,"Name":"crdb_internal_co...","TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":7,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":7,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":8,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":10,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":10,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":6,"Kind":2,"Ordinal":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"Kind":2,"Ordinal":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"Kind":2,"Ordinal":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":10,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":6,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":10,"TableID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 8 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 104 (t), ColumnID: 4 (m-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 4 (m-), TypeName: "INT8"}
+           │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 104 (t), ColumnID: 4 (m-), Expr: unique_rowid()}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 6 (t_pkey-)}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 7}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 8 (t_pkey-)}
+           │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 10 (t_pkey-)}
+           └── 9 Mutation operations
+                ├── RemoveColumnDefaultExpression {"ColumnID":4,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":6,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":7,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":8,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":10,"TableID":104}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":4,"TableID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx/alter_table_alter_primary_key_drop_rowid_with_idx__rollback_4_of_23.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx/alter_table_alter_primary_key_drop_rowid_with_idx__rollback_4_of_23.explain
@@ -1,0 +1,81 @@
+/* setup */
+CREATE TABLE t (a INT NOT NULL, b int8 not null default unique_rowid());
+INSERT INTO t(a) VALUES (1), (2), (2);
+CREATE INDEX on t(a);
+
+/* test */
+alter table t add column m int8 default unique_rowid(), alter primary key using columns(b);
+EXPLAIN (DDL) rollback at post-commit stage 4 of 23;
+----
+Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN m INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (b);
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 1 element transitioning toward PUBLIC
+      │    │    └── VALIDATED     → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 0}
+      │    ├── 21 elements transitioning toward ABSENT
+      │    │    ├── WRITE_ONLY    → DELETE_ONLY Column:{DescID: 104 (t), ColumnID: 4 (m-)}
+      │    │    ├── PUBLIC        → ABSENT      ColumnName:{DescID: 104 (t), Name: "m", ColumnID: 4 (m-)}
+      │    │    ├── DELETE_ONLY   → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (t_pkey-)}
+      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 7}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 7}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 7}
+      │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 8 (t_pkey-)}
+      │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey-), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 10 (t_pkey-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 10 (t_pkey-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 7}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 8 (t_pkey-)}
+      │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 10 (t_pkey-)}
+      │    └── 24 Mutation operations
+      │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":3,"TableID":104}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":4,"TableID":104}
+      │         ├── SetColumnName {"ColumnID":4,"Name":"crdb_internal_co...","TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":7,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":7,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":8,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":10,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":10,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":6,"Kind":2,"Ordinal":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"Kind":2,"Ordinal":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"Kind":2,"Ordinal":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":10,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":6,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":10,"TableID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 8 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 104 (t), ColumnID: 4 (m-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 4 (m-), TypeName: "INT8"}
+           │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 104 (t), ColumnID: 4 (m-), Expr: unique_rowid()}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 6 (t_pkey-)}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 7}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 8 (t_pkey-)}
+           │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 10 (t_pkey-)}
+           └── 9 Mutation operations
+                ├── RemoveColumnDefaultExpression {"ColumnID":4,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":6,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":7,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":8,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":10,"TableID":104}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":4,"TableID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx/alter_table_alter_primary_key_drop_rowid_with_idx__rollback_5_of_23.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx/alter_table_alter_primary_key_drop_rowid_with_idx__rollback_5_of_23.explain
@@ -1,0 +1,83 @@
+/* setup */
+CREATE TABLE t (a INT NOT NULL, b int8 not null default unique_rowid());
+INSERT INTO t(a) VALUES (1), (2), (2);
+CREATE INDEX on t(a);
+
+/* test */
+alter table t add column m int8 default unique_rowid(), alter primary key using columns(b);
+EXPLAIN (DDL) rollback at post-commit stage 5 of 23;
+----
+Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN m INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (b);
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 1 element transitioning toward PUBLIC
+      │    │    └── VALIDATED     → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 0}
+      │    ├── 21 elements transitioning toward ABSENT
+      │    │    ├── WRITE_ONLY    → DELETE_ONLY Column:{DescID: 104 (t), ColumnID: 4 (m-)}
+      │    │    ├── PUBLIC        → ABSENT      ColumnName:{DescID: 104 (t), Name: "m", ColumnID: 4 (m-)}
+      │    │    ├── MERGE_ONLY    → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (t_pkey-)}
+      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 7}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 7}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 7}
+      │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 8 (t_pkey-)}
+      │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey-), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 10 (t_pkey-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 10 (t_pkey-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 7}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 8 (t_pkey-)}
+      │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 10 (t_pkey-)}
+      │    └── 24 Mutation operations
+      │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":3,"TableID":104}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":4,"TableID":104}
+      │         ├── SetColumnName {"ColumnID":4,"Name":"crdb_internal_co...","TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":7,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":7,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":8,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":10,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":10,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"Kind":2,"Ordinal":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"Kind":2,"Ordinal":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":10,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":10,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":6,"Kind":2,"Ordinal":2,"TableID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 9 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 104 (t), ColumnID: 4 (m-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 4 (m-), TypeName: "INT8"}
+           │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 104 (t), ColumnID: 4 (m-), Expr: unique_rowid()}
+           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 6 (t_pkey-)}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 7}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 8 (t_pkey-)}
+           │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 10 (t_pkey-)}
+           └── 10 Mutation operations
+                ├── RemoveColumnDefaultExpression {"ColumnID":4,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":6,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":6,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":7,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":8,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":10,"TableID":104}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":4,"TableID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx/alter_table_alter_primary_key_drop_rowid_with_idx__rollback_6_of_23.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx/alter_table_alter_primary_key_drop_rowid_with_idx__rollback_6_of_23.explain
@@ -1,0 +1,83 @@
+/* setup */
+CREATE TABLE t (a INT NOT NULL, b int8 not null default unique_rowid());
+INSERT INTO t(a) VALUES (1), (2), (2);
+CREATE INDEX on t(a);
+
+/* test */
+alter table t add column m int8 default unique_rowid(), alter primary key using columns(b);
+EXPLAIN (DDL) rollback at post-commit stage 6 of 23;
+----
+Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN m INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (b);
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 1 element transitioning toward PUBLIC
+      │    │    └── VALIDATED     → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 0}
+      │    ├── 21 elements transitioning toward ABSENT
+      │    │    ├── WRITE_ONLY    → DELETE_ONLY Column:{DescID: 104 (t), ColumnID: 4 (m-)}
+      │    │    ├── PUBLIC        → ABSENT      ColumnName:{DescID: 104 (t), Name: "m", ColumnID: 4 (m-)}
+      │    │    ├── MERGE_ONLY    → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (t_pkey-)}
+      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 7}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 7}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 7}
+      │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 8 (t_pkey-)}
+      │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey-), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 10 (t_pkey-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 10 (t_pkey-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 7}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 8 (t_pkey-)}
+      │    │    └── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 10 (t_pkey-)}
+      │    └── 24 Mutation operations
+      │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":3,"TableID":104}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":4,"TableID":104}
+      │         ├── SetColumnName {"ColumnID":4,"Name":"crdb_internal_co...","TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":7,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":7,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":8,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":10,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":10,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"Kind":2,"Ordinal":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"Kind":2,"Ordinal":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":10,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":10,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":6,"Kind":2,"Ordinal":2,"TableID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 9 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 104 (t), ColumnID: 4 (m-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 4 (m-), TypeName: "INT8"}
+           │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 104 (t), ColumnID: 4 (m-), Expr: unique_rowid()}
+           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 6 (t_pkey-)}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 7}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 8 (t_pkey-)}
+           │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 10 (t_pkey-)}
+           └── 10 Mutation operations
+                ├── RemoveColumnDefaultExpression {"ColumnID":4,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":6,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":6,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":7,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":8,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":10,"TableID":104}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":4,"TableID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx/alter_table_alter_primary_key_drop_rowid_with_idx__rollback_7_of_23.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx/alter_table_alter_primary_key_drop_rowid_with_idx__rollback_7_of_23.explain
@@ -1,0 +1,81 @@
+/* setup */
+CREATE TABLE t (a INT NOT NULL, b int8 not null default unique_rowid());
+INSERT INTO t(a) VALUES (1), (2), (2);
+CREATE INDEX on t(a);
+
+/* test */
+alter table t add column m int8 default unique_rowid(), alter primary key using columns(b);
+EXPLAIN (DDL) rollback at post-commit stage 7 of 23;
+----
+Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN m INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (b);
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 1 element transitioning toward PUBLIC
+      │    │    └── VALIDATED             → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 0}
+      │    ├── 21 elements transitioning toward ABSENT
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 104 (t), ColumnID: 4 (m-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 104 (t), Name: "m", ColumnID: 4 (m-)}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (t_pkey-)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 7}
+      │    │    ├── BACKFILL_ONLY         → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 8 (t_pkey-)}
+      │    │    ├── BACKFILL_ONLY         → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey-), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 10 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 10 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 8 (t_pkey-)}
+      │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 10 (t_pkey-)}
+      │    └── 24 Mutation operations
+      │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":3,"TableID":104}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":4,"TableID":104}
+      │         ├── SetColumnName {"ColumnID":4,"Name":"crdb_internal_co...","TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":7,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":8,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":10,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":10,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":6,"Kind":2,"Ordinal":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"Kind":2,"Ordinal":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"Kind":2,"Ordinal":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":10,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":10,"TableID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 8 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 104 (t), ColumnID: 4 (m-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 4 (m-), TypeName: "INT8"}
+           │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 104 (t), ColumnID: 4 (m-), Expr: unique_rowid()}
+           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 6 (t_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 7}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 8 (t_pkey-)}
+           │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 10 (t_pkey-)}
+           └── 9 Mutation operations
+                ├── RemoveColumnDefaultExpression {"ColumnID":4,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":6,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":6,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":7,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":8,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":10,"TableID":104}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":4,"TableID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx/alter_table_alter_primary_key_drop_rowid_with_idx__rollback_8_of_23.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx/alter_table_alter_primary_key_drop_rowid_with_idx__rollback_8_of_23.explain
@@ -1,0 +1,81 @@
+/* setup */
+CREATE TABLE t (a INT NOT NULL, b int8 not null default unique_rowid());
+INSERT INTO t(a) VALUES (1), (2), (2);
+CREATE INDEX on t(a);
+
+/* test */
+alter table t add column m int8 default unique_rowid(), alter primary key using columns(b);
+EXPLAIN (DDL) rollback at post-commit stage 8 of 23;
+----
+Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN m INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (b);
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 1 element transitioning toward PUBLIC
+      │    │    └── VALIDATED             → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 0}
+      │    ├── 21 elements transitioning toward ABSENT
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 104 (t), ColumnID: 4 (m-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 104 (t), Name: "m", ColumnID: 4 (m-)}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (t_pkey-)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 7}
+      │    │    ├── BACKFILL_ONLY         → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 8 (t_pkey-)}
+      │    │    ├── BACKFILL_ONLY         → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey-), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 10 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 10 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 8 (t_pkey-)}
+      │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 10 (t_pkey-)}
+      │    └── 24 Mutation operations
+      │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":3,"TableID":104}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":4,"TableID":104}
+      │         ├── SetColumnName {"ColumnID":4,"Name":"crdb_internal_co...","TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":7,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":8,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":10,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":10,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":6,"Kind":2,"Ordinal":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"Kind":2,"Ordinal":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"Kind":2,"Ordinal":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":10,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":10,"TableID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 8 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 104 (t), ColumnID: 4 (m-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 4 (m-), TypeName: "INT8"}
+           │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 104 (t), ColumnID: 4 (m-), Expr: unique_rowid()}
+           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 6 (t_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 7}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 8 (t_pkey-)}
+           │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 10 (t_pkey-)}
+           └── 9 Mutation operations
+                ├── RemoveColumnDefaultExpression {"ColumnID":4,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":6,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":6,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":7,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":8,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":10,"TableID":104}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":4,"TableID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx/alter_table_alter_primary_key_drop_rowid_with_idx__rollback_9_of_23.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_drop_rowid_with_idx/alter_table_alter_primary_key_drop_rowid_with_idx__rollback_9_of_23.explain
@@ -1,0 +1,104 @@
+/* setup */
+CREATE TABLE t (a INT NOT NULL, b int8 not null default unique_rowid());
+INSERT INTO t(a) VALUES (1), (2), (2);
+CREATE INDEX on t(a);
+
+/* test */
+alter table t add column m int8 default unique_rowid(), alter primary key using columns(b);
+EXPLAIN (DDL) rollback at post-commit stage 9 of 23;
+----
+Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN m INT8 DEFAULT unique_rowid(), ALTER PRIMARY KEY USING COLUMNS (b);
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 3 elements transitioning toward PUBLIC
+      │    │    ├── VALIDATED             → PUBLIC      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 0}
+      │    │    ├── VALIDATED             → PUBLIC      PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey+), ConstraintID: 1}
+      │    │    └── ABSENT                → PUBLIC      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey+)}
+      │    ├── 23 elements transitioning toward ABSENT
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 104 (t), ColumnID: 4 (m-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 104 (t), Name: "m", ColumnID: 4 (m-)}
+      │    │    ├── PUBLIC                → VALIDATED   PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 6 (t_pkey-)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 7, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 7}
+      │    │    ├── BACKFILL_ONLY         → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 8 (t_pkey-), ConstraintID: 6, TemporaryIndexID: 9, SourceIndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 8 (t_pkey-)}
+      │    │    ├── DELETE_ONLY           → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 7, SourceIndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 9}
+      │    │    ├── BACKFILL_ONLY         → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 10 (t_pkey-), ConstraintID: 8, TemporaryIndexID: 11, SourceIndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 10 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 10 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 8 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 9}
+      │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 10 (t_pkey-)}
+      │    └── 28 Mutation operations
+      │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":3,"TableID":104}
+      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":4,"TableID":104}
+      │         ├── SetColumnName {"ColumnID":4,"Name":"crdb_internal_co...","TableID":104}
+      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":6,"TableID":104}
+      │         ├── SetIndexName {"IndexID":6,"Name":"crdb_internal_in...","TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":7,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":8,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":8,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":9,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":9,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":10,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":10,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"Kind":2,"Ordinal":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"Kind":2,"Ordinal":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"Kind":2,"Ordinal":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":10,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":7,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":10,"TableID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 5 elements transitioning toward ABSENT
+      │    │    ├── VALIDATED → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC    → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (rowid+), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC    → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (a), IndexID: 6 (t_pkey-)}
+      │    │    ├── PUBLIC    → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (b), IndexID: 6 (t_pkey-)}
+      │    │    └── PUBLIC    → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 4 (m-), IndexID: 6 (t_pkey-)}
+      │    └── 7 Mutation operations
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":6,"Kind":2,"Ordinal":2,"TableID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 3 of 3 in PostCommitNonRevertiblePhase
+           ├── 8 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 104 (t), ColumnID: 4 (m-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 4 (m-), TypeName: "INT8"}
+           │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 104 (t), ColumnID: 4 (m-), Expr: unique_rowid()}
+           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 6 (t_pkey-), ConstraintID: 4, TemporaryIndexID: 7, SourceIndexID: 1 (t_pkey+)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 6 (t_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 7}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 8 (t_pkey-)}
+           │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 10 (t_pkey-)}
+           └── 9 Mutation operations
+                ├── RemoveColumnDefaultExpression {"ColumnID":4,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":6,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":6,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":7,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":8,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":10,"TableID":104}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":4,"TableID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash.explain
@@ -143,9 +143,7 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ALTER PR
  │    │         ├── ValidateIndex {"IndexID":4,"TableID":104}
  │    │         └── ValidateColumnNotNull {"ColumnID":3,"IndexIDForValidation":4,"TableID":104}
  │    ├── Stage 8 of 16 in PostCommitPhase
- │    │    ├── 9 elements transitioning toward PUBLIC
- │    │    │    ├── VALIDATED → PUBLIC        PrimaryIndex:{DescID: 104 (t), IndexID: 4 (t_pkey+), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey-)}
- │    │    │    ├── ABSENT    → PUBLIC        IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 4 (t_pkey+)}
+ │    │    ├── 7 elements transitioning toward PUBLIC
  │    │    │    ├── VALIDATED → PUBLIC        ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3+), IndexID: 4 (t_pkey+)}
  │    │    │    ├── ABSENT    → BACKFILL_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 2 (t_i_key+), ConstraintID: 3, TemporaryIndexID: 3, SourceIndexID: 4 (t_pkey+), RecreateSourceIndexID: 0}
  │    │    │    ├── ABSENT    → PUBLIC        IndexData:{DescID: 104 (t), IndexID: 2 (t_i_key+)}
@@ -158,15 +156,8 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ALTER PR
  │    │    │    ├── ABSENT    → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 3}
  │    │    │    ├── ABSENT    → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3+), IndexID: 3}
  │    │    │    └── ABSENT    → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 3}
- │    │    ├── 2 elements transitioning toward ABSENT
- │    │    │    ├── PUBLIC    → VALIDATED     PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey-), ConstraintID: 1}
- │    │    │    └── PUBLIC    → ABSENT        IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey-)}
- │    │    └── 18 Mutation operations
- │    │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":1,"TableID":104}
- │    │         ├── SetIndexName {"IndexID":1,"Name":"crdb_internal_in...","TableID":104}
- │    │         ├── SetIndexName {"IndexID":4,"Name":"t_pkey","TableID":104}
+ │    │    └── 14 Mutation operations
  │    │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":3,"TableID":104}
- │    │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":4,"TableID":104}
  │    │         ├── MakeAbsentIndexBackfilling {"IsSecondaryIndex":true}
  │    │         ├── MaybeAddSplitForIndex {"IndexID":2,"TableID":104}
  │    │         ├── MakeAbsentTempIndexDeleteOnly {"IsSecondaryIndex":true}
@@ -228,11 +219,20 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ALTER PR
  │    │    └── 1 Validation operation
  │    │         └── ValidateIndex {"IndexID":2,"TableID":104}
  │    └── Stage 16 of 16 in PostCommitPhase
- │         ├── 1 element transitioning toward PUBLIC
- │         │    └── VALIDATED → PUBLIC SecondaryIndex:{DescID: 104 (t), IndexID: 2 (t_i_key+), ConstraintID: 3, TemporaryIndexID: 3, SourceIndexID: 4 (t_pkey+), RecreateSourceIndexID: 0}
- │         └── 4 Mutation operations
+ │         ├── 3 elements transitioning toward PUBLIC
+ │         │    ├── VALIDATED → PUBLIC    PrimaryIndex:{DescID: 104 (t), IndexID: 4 (t_pkey+), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey-)}
+ │         │    ├── ABSENT    → PUBLIC    IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 4 (t_pkey+)}
+ │         │    └── VALIDATED → PUBLIC    SecondaryIndex:{DescID: 104 (t), IndexID: 2 (t_i_key+), ConstraintID: 3, TemporaryIndexID: 3, SourceIndexID: 4 (t_pkey+), RecreateSourceIndexID: 0}
+ │         ├── 2 elements transitioning toward ABSENT
+ │         │    ├── PUBLIC    → VALIDATED PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey-), ConstraintID: 1}
+ │         │    └── PUBLIC    → ABSENT    IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey-)}
+ │         └── 8 Mutation operations
+ │              ├── MakePublicPrimaryIndexWriteOnly {"IndexID":1,"TableID":104}
+ │              ├── SetIndexName {"IndexID":1,"Name":"crdb_internal_in...","TableID":104}
+ │              ├── SetIndexName {"IndexID":4,"Name":"t_pkey","TableID":104}
  │              ├── MakeValidatedSecondaryIndexPublic {"IndexID":2,"TableID":104}
  │              ├── RefreshStats {"TableID":104}
+ │              ├── MakeValidatedPrimaryIndexPublic {"IndexID":4,"TableID":104}
  │              ├── SetJobStateOnDescriptor {"DescriptorID":104}
  │              └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
  └── PostCommitNonRevertiblePhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash.side_effects
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash.side_effects
@@ -410,7 +410,7 @@ validate forward indexes [4] in table #104
 validate CHECK constraint crdb_internal_j_shard_3_auto_not_null in table #104
 commit transaction #9
 begin transaction #10
-## PostCommitPhase stage 8 of 16 with 18 MutationType ops
+## PostCommitPhase stage 8 of 16 with 14 MutationType ops
 upsert descriptor #104
    table:
   -  checks:
@@ -431,103 +431,47 @@ upsert descriptor #104
            family: IntFamily
   ...
        mutationId: 1
-       state: WRITE_ONLY
-  -  - direction: ADD
-  +  - direction: DROP
-       index:
-  -      constraintId: 5
-  +      constraintId: 6
-         createdExplicitly: true
-         encodingType: 1
-         foreignKey: {}
-         geoConfig: {}
-  -      id: 4
-  +      id: 5
-         interleave: {}
-         keyColumnDirections:
-  ...
-         - crdb_internal_j_shard_3
-         - j
-  -      name: crdb_internal_index_4_name_placeholder
-  +      name: crdb_internal_index_5_name_placeholder
-         partitioning: {}
-         sharded:
-  ...
-         - i
-         unique: true
-  +      useDeletePreservingEncoding: true
-         vecConfig: {}
-         version: 4
-       mutationId: 1
-  -    state: WRITE_ONLY
-  +    state: DELETE_ONLY
-     - direction: DROP
-       index:
-  -      constraintId: 6
-  -      createdExplicitly: true
-  +      constraintId: 1
-  +      createdAtNanos: "1640995200000000000"
-         encodingType: 1
-         foreignKey: {}
-         geoConfig: {}
-  -      id: 5
-  +      id: 1
-         interleave: {}
-         keyColumnDirections:
-         - ASC
-  +      keyColumnIds:
-  +      - 1
-  +      keyColumnNames:
-  +      - i
-  +      name: crdb_internal_index_1_name_placeholder
-  +      partitioning: {}
-  +      sharded: {}
-  +      storeColumnIds:
-  +      - 2
-  +      storeColumnNames:
-  +      - j
-  +      unique: true
-  +      vecConfig: {}
-  +      version: 4
-  +    mutationId: 1
-  +    state: WRITE_ONLY
+       state: DELETE_ONLY
+  -  - constraint:
+  -      check:
+  -        columnIds:
+  -        - 3
+  -        expr: crdb_internal_j_shard_3 IS NOT NULL
+  -        isNonNullConstraint: true
+  -        name: crdb_internal_j_shard_3_auto_not_null
+  -        validity: Validating
+  -      constraintType: NOT_NULL
   +  - direction: ADD
   +    index:
   +      constraintId: 3
   +      createdAtNanos: "1640998800000000000"
   +      createdExplicitly: true
-  +      foreignKey: {}
+         foreignKey: {}
+  -      name: crdb_internal_j_shard_3_auto_not_null
+  -      notNullColumn: 3
+  -      uniqueWithoutIndexConstraint: {}
+  -    direction: ADD
   +      geoConfig: {}
   +      id: 2
   +      interleave: {}
   +      keyColumnDirections:
-         - ASC
-         keyColumnIds:
+  +      - ASC
+  +      keyColumnIds:
   +      - 1
   +      keyColumnNames:
   +      - i
   +      keySuffixColumnIds:
-         - 3
-         - 2
-  -      keyColumnNames:
-  -      - crdb_internal_j_shard_3
-  -      - j
-  -      name: crdb_internal_index_5_name_placeholder
+  +      - 3
+  +      - 2
   +      name: t_i_key
-         partitioning: {}
-  -      sharded:
-  -        columnNames:
-  -        - j
-  -        isSharded: true
-  -        name: crdb_internal_j_shard_3
-  -        shardBuckets: 3
-  -      storeColumnIds:
+  +      partitioning: {}
   +      sharded: {}
   +      storeColumnNames: []
   +      unique: true
   +      vecConfig: {}
   +      version: 4
-  +    mutationId: 1
+       mutationId: 1
+  -    state: WRITE_ONLY
   +    state: BACKFILLING
   +  - direction: ADD
   +    index:
@@ -540,10 +484,9 @@ upsert descriptor #104
   +      keyColumnDirections:
   +      - ASC
   +      keyColumnIds:
-         - 1
-  -      storeColumnNames:
+  +      - 1
   +      keyColumnNames:
-         - i
+  +      - i
   +      keySuffixColumnIds:
   +      - 3
   +      - 2
@@ -551,70 +494,14 @@ upsert descriptor #104
   +      partitioning: {}
   +      sharded: {}
   +      storeColumnNames: []
-         unique: true
-         useDeletePreservingEncoding: true
-  ...
-       mutationId: 1
-       state: DELETE_ONLY
-  -  - constraint:
-  -      check:
-  -        columnIds:
-  -        - 3
-  -        expr: crdb_internal_j_shard_3 IS NOT NULL
-  -        isNonNullConstraint: true
-  -        name: crdb_internal_j_shard_3_auto_not_null
-  -        validity: Validating
-  -      constraintType: NOT_NULL
-  -      foreignKey: {}
-  -      name: crdb_internal_j_shard_3_auto_not_null
-  -      notNullColumn: 3
-  -      uniqueWithoutIndexConstraint: {}
-  -    direction: ADD
-  -    mutationId: 1
-  -    state: WRITE_ONLY
+  +      unique: true
+  +      useDeletePreservingEncoding: true
+  +      vecConfig: {}
+  +      version: 4
+  +    mutationId: 1
+  +    state: DELETE_ONLY
      name: t
      nextColumnId: 4
-  ...
-     parentId: 100
-     primaryIndex:
-  -    constraintId: 1
-  -    createdAtNanos: "1640995200000000000"
-  +    constraintId: 5
-  +    createdExplicitly: true
-       encodingType: 1
-       foreignKey: {}
-       geoConfig: {}
-  -    id: 1
-  +    id: 4
-       interleave: {}
-       keyColumnDirections:
-       - ASC
-  +    - ASC
-       keyColumnIds:
-  -    - 1
-  +    - 3
-  +    - 2
-       keyColumnNames:
-  -    - i
-  +    - crdb_internal_j_shard_3
-  +    - j
-       name: t_pkey
-       partitioning: {}
-  -    sharded: {}
-  +    sharded:
-  +      columnNames:
-  +      - j
-  +      isSharded: true
-  +      name: crdb_internal_j_shard_3
-  +      shardBuckets: 3
-       storeColumnIds:
-  -    - 2
-  +    - 1
-       storeColumnNames:
-  -    - j
-  +    - i
-       unique: true
-       vecConfig: {}
   ...
        time: {}
      unexposedParentSchemaId: 101
@@ -717,7 +604,7 @@ begin transaction #17
 validate forward indexes [2] in table #104
 commit transaction #17
 begin transaction #18
-## PostCommitPhase stage 16 of 16 with 4 MutationType ops
+## PostCommitPhase stage 16 of 16 with 8 MutationType ops
 upsert descriptor #104
   ...
            statement: ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (j) USING HASH WITH ('bucket_count' = 3)
@@ -759,26 +646,34 @@ upsert descriptor #104
        state: WRITE_ONLY
   -  - direction: ADD
   -    index:
-  -      constraintId: 3
-  -      createdAtNanos: "1640998800000000000"
+  -      constraintId: 5
   -      createdExplicitly: true
+  -      encodingType: 1
   -      foreignKey: {}
   -      geoConfig: {}
-  -      id: 2
+  -      id: 4
   -      interleave: {}
   -      keyColumnDirections:
   -      - ASC
+  -      - ASC
   -      keyColumnIds:
-  -      - 1
-  -      keyColumnNames:
-  -      - i
-  -      keySuffixColumnIds:
   -      - 3
   -      - 2
-  -      name: t_i_key
+  -      keyColumnNames:
+  -      - crdb_internal_j_shard_3
+  -      - j
+  -      name: crdb_internal_index_4_name_placeholder
   -      partitioning: {}
-  -      sharded: {}
-  -      storeColumnNames: []
+  -      sharded:
+  -        columnNames:
+  -        - j
+  -        isSharded: true
+  -        name: crdb_internal_j_shard_3
+  -        shardBuckets: 3
+  -      storeColumnIds:
+  -      - 1
+  -      storeColumnNames:
+  -      - i
   -      unique: true
   -      vecConfig: {}
   -      version: 4
@@ -786,6 +681,115 @@ upsert descriptor #104
   -    state: WRITE_ONLY
      - direction: DROP
        index:
+  ...
+       mutationId: 1
+       state: DELETE_ONLY
+  -  - direction: ADD
+  +  - direction: DROP
+       index:
+  -      constraintId: 3
+  -      createdAtNanos: "1640998800000000000"
+  +      constraintId: 4
+         createdExplicitly: true
+         foreignKey: {}
+         geoConfig: {}
+  -      id: 2
+  +      id: 3
+         interleave: {}
+         keyColumnDirections:
+  ...
+         - 3
+         - 2
+  -      name: t_i_key
+  +      name: crdb_internal_index_3_name_placeholder
+         partitioning: {}
+         sharded: {}
+         storeColumnNames: []
+         unique: true
+  +      useDeletePreservingEncoding: true
+         vecConfig: {}
+         version: 4
+       mutationId: 1
+  -    state: WRITE_ONLY
+  +    state: DELETE_ONLY
+     - direction: DROP
+       index:
+  -      constraintId: 4
+  -      createdExplicitly: true
+  +      constraintId: 1
+  +      createdAtNanos: "1640995200000000000"
+  +      encodingType: 1
+         foreignKey: {}
+         geoConfig: {}
+  -      id: 3
+  +      id: 1
+         interleave: {}
+         keyColumnDirections:
+  ...
+         keyColumnNames:
+         - i
+  -      keySuffixColumnIds:
+  -      - 3
+  -      - 2
+  -      name: crdb_internal_index_3_name_placeholder
+  +      name: crdb_internal_index_1_name_placeholder
+         partitioning: {}
+         sharded: {}
+  -      storeColumnNames: []
+  +      storeColumnIds:
+  +      - 2
+  +      storeColumnNames:
+  +      - j
+         unique: true
+  -      useDeletePreservingEncoding: true
+         vecConfig: {}
+         version: 4
+       mutationId: 1
+  -    state: DELETE_ONLY
+  +    state: WRITE_ONLY
+     name: t
+     nextColumnId: 4
+  ...
+     parentId: 100
+     primaryIndex:
+  -    constraintId: 1
+  -    createdAtNanos: "1640995200000000000"
+  +    constraintId: 5
+  +    createdExplicitly: true
+       encodingType: 1
+       foreignKey: {}
+       geoConfig: {}
+  -    id: 1
+  +    id: 4
+       interleave: {}
+       keyColumnDirections:
+       - ASC
+  +    - ASC
+       keyColumnIds:
+  -    - 1
+  +    - 3
+  +    - 2
+       keyColumnNames:
+  -    - i
+  +    - crdb_internal_j_shard_3
+  +    - j
+       name: t_pkey
+       partitioning: {}
+  -    sharded: {}
+  +    sharded:
+  +      columnNames:
+  +      - j
+  +      isSharded: true
+  +      name: crdb_internal_j_shard_3
+  +      shardBuckets: 3
+       storeColumnIds:
+  -    - 2
+  +    - 1
+       storeColumnNames:
+  -    - j
+  +    - i
+       unique: true
+       vecConfig: {}
   ...
        time: {}
      unexposedParentSchemaId: 101
@@ -879,27 +883,9 @@ upsert descriptor #104
   -    state: DELETE_ONLY
   -  - direction: DROP
   -    index:
-         constraintId: 1
-         createdAtNanos: "1640995200000000000"
-  ...
-         version: 4
-       mutationId: 1
-  -    state: WRITE_ONLY
-  -  - direction: DROP
-  -    index:
   -      constraintId: 4
   -      createdExplicitly: true
-  +    state: DELETE_ONLY
-  +  - constraint:
-  +      check:
-  +        columnIds:
-  +        - 3
-  +        constraintId: 2
-  +        expr: crdb_internal_j_shard_3 IN (0,1,2)
-  +        fromHashShardedColumn: true
-  +        name: crdb_internal_constraint_2_name_placeholder
-  +        validity: Validating
-         foreignKey: {}
+  -      foreignKey: {}
   -      geoConfig: {}
   -      id: 3
   -      interleave: {}
@@ -920,14 +906,32 @@ upsert descriptor #104
   -      useDeletePreservingEncoding: true
   -      vecConfig: {}
   -      version: 4
+  -    mutationId: 1
+  -    state: DELETE_ONLY
+  -  - direction: DROP
+  -    index:
+         constraintId: 1
+         createdAtNanos: "1640995200000000000"
+  ...
+         version: 4
+       mutationId: 1
+  +    state: DELETE_ONLY
+  +  - constraint:
+  +      check:
+  +        columnIds:
+  +        - 3
+  +        constraintId: 2
+  +        expr: crdb_internal_j_shard_3 IN (0,1,2)
+  +        fromHashShardedColumn: true
+  +        name: crdb_internal_constraint_2_name_placeholder
+  +        validity: Validating
+  +      foreignKey: {}
   +      name: crdb_internal_constraint_2_name_placeholder
   +      uniqueWithoutIndexConstraint: {}
   +    direction: ADD
-       mutationId: 1
-  -    state: DELETE_ONLY
-  +    state: WRITE_ONLY
+  +    mutationId: 1
+       state: WRITE_ONLY
      name: t
-     nextColumnId: 4
   ...
        time: {}
      unexposedParentSchemaId: 101

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash__rollback_10_of_16.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash__rollback_10_of_16.explain
@@ -7,19 +7,18 @@ EXPLAIN (DDL) rollback at post-commit stage 10 of 16;
 ----
 Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY USING COLUMNS (j) USING HASH WITH ('bucket_count' = ‹3›);
  └── PostCommitNonRevertiblePhase
-      ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 2 elements transitioning toward PUBLIC
-      │    │    ├── VALIDATED             → PUBLIC      PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey+), ConstraintID: 1}
-      │    │    └── ABSENT                → PUBLIC      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey+)}
-      │    ├── 18 elements transitioning toward ABSENT
-      │    │    ├── PUBLIC                → VALIDATED   PrimaryIndex:{DescID: 104 (t), IndexID: 4 (t_pkey-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 4 (t_pkey-)}
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 20 elements transitioning toward ABSENT
+      │    │    ├── VALIDATED             → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 4 (t_pkey-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 4 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 4 (t_pkey-)}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 6, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 5}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 5}
       │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-)}
       │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 104 (t), Name: "crdb_internal_j_shard_3", ColumnID: 3 (crdb_internal_j_shard_3-)}
       │    │    ├── PUBLIC                → VALIDATED   ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-), IndexID: 4 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-), IndexID: 4 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-), IndexID: 5}
       │    │    ├── BACKFILL_ONLY         → ABSENT      SecondaryIndex:{DescID: 104 (t), IndexID: 2 (t_i_key-), ConstraintID: 3, TemporaryIndexID: 3, SourceIndexID: 4 (t_pkey-), RecreateSourceIndexID: 0}
       │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 3, ConstraintID: 4, SourceIndexID: 4 (t_pkey-)}
@@ -31,9 +30,6 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 3}
       │    │    └── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_i_key", IndexID: 2 (t_i_key-)}
       │    └── 22 Mutation operations
-      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
-      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":4,"TableID":104}
-      │         ├── SetIndexName {"IndexID":4,"Name":"crdb_internal_in...","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"Ordinal":1,"TableID":104}
       │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":3,"TableID":104}
@@ -48,42 +44,32 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":2,"Kind":1,"Ordinal":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"Kind":1,"Ordinal":1,"TableID":104}
       │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":104}
-      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":2,"TableID":104}
-      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
-      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
-      ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 6 elements transitioning toward ABSENT
-      │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 4 (t_pkey-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 4 (t_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 4 (t_pkey-)}
-      │    │    ├── VALIDATED   → ABSENT      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-), IndexID: 4 (t_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-), IndexID: 4 (t_pkey-)}
-      │    │    └── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 3, ConstraintID: 4, SourceIndexID: 4 (t_pkey-)}
-      │    └── 8 Mutation operations
-      │         ├── RemoveColumnNotNull {"ColumnID":3,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"Ordinal":1,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":4,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":2,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
-      └── Stage 3 of 3 in PostCommitNonRevertiblePhase
-           ├── 8 elements transitioning toward ABSENT
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 10 elements transitioning toward ABSENT
            │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 4 (t_pkey-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+)}
            │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 4 (t_pkey-)}
            │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 5}
            │    ├── DELETE_ONLY → ABSENT Column:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-)}
            │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 3 (crdb_internal_j_shard_3-), TypeName: "INT8"}
            │    ├── PUBLIC      → ABSENT ColumnComputeExpression:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-), Usage: REGULAR}
+           │    ├── VALIDATED   → ABSENT ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-), IndexID: 4 (t_pkey-)}
            │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 2 (t_i_key-)}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 3, ConstraintID: 4, SourceIndexID: 4 (t_pkey-)}
            │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 3}
-           └── 9 Mutation operations
+           └── 11 Mutation operations
                 ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
                 ├── RemoveColumnComputeExpression {"ColumnID":3,"TableID":104}
+                ├── RemoveColumnNotNull {"ColumnID":3,"TableID":104}
                 ├── CreateGCJobForIndex {"IndexID":2,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
                 ├── CreateGCJobForIndex {"IndexID":3,"TableID":104}
                 ├── CreateGCJobForIndex {"IndexID":4,"TableID":104}
                 ├── CreateGCJobForIndex {"IndexID":5,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash__rollback_11_of_16.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash__rollback_11_of_16.explain
@@ -7,19 +7,18 @@ EXPLAIN (DDL) rollback at post-commit stage 11 of 16;
 ----
 Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY USING COLUMNS (j) USING HASH WITH ('bucket_count' = ‹3›);
  └── PostCommitNonRevertiblePhase
-      ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 2 elements transitioning toward PUBLIC
-      │    │    ├── VALIDATED             → PUBLIC      PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey+), ConstraintID: 1}
-      │    │    └── ABSENT                → PUBLIC      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey+)}
-      │    ├── 18 elements transitioning toward ABSENT
-      │    │    ├── PUBLIC                → VALIDATED   PrimaryIndex:{DescID: 104 (t), IndexID: 4 (t_pkey-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 4 (t_pkey-)}
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 20 elements transitioning toward ABSENT
+      │    │    ├── VALIDATED             → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 4 (t_pkey-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 4 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 4 (t_pkey-)}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 6, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 5}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 5}
       │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-)}
       │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 104 (t), Name: "crdb_internal_j_shard_3", ColumnID: 3 (crdb_internal_j_shard_3-)}
       │    │    ├── PUBLIC                → VALIDATED   ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-), IndexID: 4 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-), IndexID: 4 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-), IndexID: 5}
       │    │    ├── BACKFILL_ONLY         → ABSENT      SecondaryIndex:{DescID: 104 (t), IndexID: 2 (t_i_key-), ConstraintID: 3, TemporaryIndexID: 3, SourceIndexID: 4 (t_pkey-), RecreateSourceIndexID: 0}
       │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 3, ConstraintID: 4, SourceIndexID: 4 (t_pkey-)}
@@ -31,9 +30,6 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 3}
       │    │    └── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_i_key", IndexID: 2 (t_i_key-)}
       │    └── 22 Mutation operations
-      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
-      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":4,"TableID":104}
-      │         ├── SetIndexName {"IndexID":4,"Name":"crdb_internal_in...","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"Ordinal":1,"TableID":104}
       │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":3,"TableID":104}
@@ -48,42 +44,32 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":2,"Kind":1,"Ordinal":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"Kind":1,"Ordinal":1,"TableID":104}
       │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":104}
-      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":2,"TableID":104}
-      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
-      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
-      ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 6 elements transitioning toward ABSENT
-      │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 4 (t_pkey-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 4 (t_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 4 (t_pkey-)}
-      │    │    ├── VALIDATED   → ABSENT      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-), IndexID: 4 (t_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-), IndexID: 4 (t_pkey-)}
-      │    │    └── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 3, ConstraintID: 4, SourceIndexID: 4 (t_pkey-)}
-      │    └── 8 Mutation operations
-      │         ├── RemoveColumnNotNull {"ColumnID":3,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"Ordinal":1,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":4,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":2,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
-      └── Stage 3 of 3 in PostCommitNonRevertiblePhase
-           ├── 8 elements transitioning toward ABSENT
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 10 elements transitioning toward ABSENT
            │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 4 (t_pkey-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+)}
            │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 4 (t_pkey-)}
            │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 5}
            │    ├── DELETE_ONLY → ABSENT Column:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-)}
            │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 3 (crdb_internal_j_shard_3-), TypeName: "INT8"}
            │    ├── PUBLIC      → ABSENT ColumnComputeExpression:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-), Usage: REGULAR}
+           │    ├── VALIDATED   → ABSENT ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-), IndexID: 4 (t_pkey-)}
            │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 2 (t_i_key-)}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 3, ConstraintID: 4, SourceIndexID: 4 (t_pkey-)}
            │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 3}
-           └── 9 Mutation operations
+           └── 11 Mutation operations
                 ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
                 ├── RemoveColumnComputeExpression {"ColumnID":3,"TableID":104}
+                ├── RemoveColumnNotNull {"ColumnID":3,"TableID":104}
                 ├── CreateGCJobForIndex {"IndexID":2,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
                 ├── CreateGCJobForIndex {"IndexID":3,"TableID":104}
                 ├── CreateGCJobForIndex {"IndexID":4,"TableID":104}
                 ├── CreateGCJobForIndex {"IndexID":5,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash__rollback_12_of_16.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash__rollback_12_of_16.explain
@@ -7,19 +7,18 @@ EXPLAIN (DDL) rollback at post-commit stage 12 of 16;
 ----
 Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY USING COLUMNS (j) USING HASH WITH ('bucket_count' = ‹3›);
  └── PostCommitNonRevertiblePhase
-      ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 2 elements transitioning toward PUBLIC
-      │    │    ├── VALIDATED             → PUBLIC      PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey+), ConstraintID: 1}
-      │    │    └── ABSENT                → PUBLIC      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey+)}
-      │    ├── 18 elements transitioning toward ABSENT
-      │    │    ├── PUBLIC                → VALIDATED   PrimaryIndex:{DescID: 104 (t), IndexID: 4 (t_pkey-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 4 (t_pkey-)}
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 20 elements transitioning toward ABSENT
+      │    │    ├── VALIDATED             → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 4 (t_pkey-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 4 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 4 (t_pkey-)}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 6, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 5}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 5}
       │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-)}
       │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 104 (t), Name: "crdb_internal_j_shard_3", ColumnID: 3 (crdb_internal_j_shard_3-)}
       │    │    ├── PUBLIC                → VALIDATED   ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-), IndexID: 4 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-), IndexID: 4 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-), IndexID: 5}
       │    │    ├── DELETE_ONLY           → ABSENT      SecondaryIndex:{DescID: 104 (t), IndexID: 2 (t_i_key-), ConstraintID: 3, TemporaryIndexID: 3, SourceIndexID: 4 (t_pkey-), RecreateSourceIndexID: 0}
       │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 3, ConstraintID: 4, SourceIndexID: 4 (t_pkey-)}
@@ -31,9 +30,6 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 3}
       │    │    └── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_i_key", IndexID: 2 (t_i_key-)}
       │    └── 22 Mutation operations
-      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
-      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":4,"TableID":104}
-      │         ├── SetIndexName {"IndexID":4,"Name":"crdb_internal_in...","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"Ordinal":1,"TableID":104}
       │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":3,"TableID":104}
@@ -48,42 +44,32 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":2,"Kind":1,"Ordinal":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"Kind":1,"Ordinal":1,"TableID":104}
       │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":104}
-      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":2,"TableID":104}
-      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
-      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
-      ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 6 elements transitioning toward ABSENT
-      │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 4 (t_pkey-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 4 (t_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 4 (t_pkey-)}
-      │    │    ├── VALIDATED   → ABSENT      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-), IndexID: 4 (t_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-), IndexID: 4 (t_pkey-)}
-      │    │    └── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 3, ConstraintID: 4, SourceIndexID: 4 (t_pkey-)}
-      │    └── 8 Mutation operations
-      │         ├── RemoveColumnNotNull {"ColumnID":3,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"Ordinal":1,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":4,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":2,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
-      └── Stage 3 of 3 in PostCommitNonRevertiblePhase
-           ├── 8 elements transitioning toward ABSENT
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 10 elements transitioning toward ABSENT
            │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 4 (t_pkey-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+)}
            │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 4 (t_pkey-)}
            │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 5}
            │    ├── DELETE_ONLY → ABSENT Column:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-)}
            │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 3 (crdb_internal_j_shard_3-), TypeName: "INT8"}
            │    ├── PUBLIC      → ABSENT ColumnComputeExpression:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-), Usage: REGULAR}
+           │    ├── VALIDATED   → ABSENT ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-), IndexID: 4 (t_pkey-)}
            │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 2 (t_i_key-)}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 3, ConstraintID: 4, SourceIndexID: 4 (t_pkey-)}
            │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 3}
-           └── 9 Mutation operations
+           └── 11 Mutation operations
                 ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
                 ├── RemoveColumnComputeExpression {"ColumnID":3,"TableID":104}
+                ├── RemoveColumnNotNull {"ColumnID":3,"TableID":104}
                 ├── CreateGCJobForIndex {"IndexID":2,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
                 ├── CreateGCJobForIndex {"IndexID":3,"TableID":104}
                 ├── CreateGCJobForIndex {"IndexID":4,"TableID":104}
                 ├── CreateGCJobForIndex {"IndexID":5,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash__rollback_13_of_16.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash__rollback_13_of_16.explain
@@ -7,19 +7,18 @@ EXPLAIN (DDL) rollback at post-commit stage 13 of 16;
 ----
 Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY USING COLUMNS (j) USING HASH WITH ('bucket_count' = ‹3›);
  └── PostCommitNonRevertiblePhase
-      ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 2 elements transitioning toward PUBLIC
-      │    │    ├── VALIDATED             → PUBLIC      PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey+), ConstraintID: 1}
-      │    │    └── ABSENT                → PUBLIC      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey+)}
-      │    ├── 18 elements transitioning toward ABSENT
-      │    │    ├── PUBLIC                → VALIDATED   PrimaryIndex:{DescID: 104 (t), IndexID: 4 (t_pkey-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 4 (t_pkey-)}
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 20 elements transitioning toward ABSENT
+      │    │    ├── VALIDATED             → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 4 (t_pkey-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 4 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 4 (t_pkey-)}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 6, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 5}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 5}
       │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-)}
       │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 104 (t), Name: "crdb_internal_j_shard_3", ColumnID: 3 (crdb_internal_j_shard_3-)}
       │    │    ├── PUBLIC                → VALIDATED   ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-), IndexID: 4 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-), IndexID: 4 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-), IndexID: 5}
       │    │    ├── MERGE_ONLY            → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 2 (t_i_key-), ConstraintID: 3, TemporaryIndexID: 3, SourceIndexID: 4 (t_pkey-), RecreateSourceIndexID: 0}
       │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 3, ConstraintID: 4, SourceIndexID: 4 (t_pkey-)}
@@ -31,9 +30,6 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 3}
       │    │    └── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_i_key", IndexID: 2 (t_i_key-)}
       │    └── 22 Mutation operations
-      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
-      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":4,"TableID":104}
-      │         ├── SetIndexName {"IndexID":4,"Name":"crdb_internal_in...","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"Ordinal":1,"TableID":104}
       │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":3,"TableID":104}
@@ -44,8 +40,11 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":3,"Kind":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"Kind":1,"Ordinal":1,"TableID":104}
-      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"Ordinal":1,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":4,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":2,"Kind":1,"TableID":104}
@@ -53,39 +52,26 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
-      ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 7 elements transitioning toward ABSENT
-      │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 4 (t_pkey-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 4 (t_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 4 (t_pkey-)}
-      │    │    ├── VALIDATED   → ABSENT      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-), IndexID: 4 (t_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-), IndexID: 4 (t_pkey-)}
-      │    │    ├── DELETE_ONLY → ABSENT      SecondaryIndex:{DescID: 104 (t), IndexID: 2 (t_i_key-), ConstraintID: 3, TemporaryIndexID: 3, SourceIndexID: 4 (t_pkey-), RecreateSourceIndexID: 0}
-      │    │    └── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 3, ConstraintID: 4, SourceIndexID: 4 (t_pkey-)}
-      │    └── 9 Mutation operations
-      │         ├── RemoveColumnNotNull {"ColumnID":3,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":2,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"Kind":2,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"Ordinal":1,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":4,"TableID":104}
-      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
-      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
-      └── Stage 3 of 3 in PostCommitNonRevertiblePhase
-           ├── 8 elements transitioning toward ABSENT
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 11 elements transitioning toward ABSENT
            │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 4 (t_pkey-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+)}
            │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 4 (t_pkey-)}
            │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 5}
            │    ├── DELETE_ONLY → ABSENT Column:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-)}
            │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 3 (crdb_internal_j_shard_3-), TypeName: "INT8"}
            │    ├── PUBLIC      → ABSENT ColumnComputeExpression:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-), Usage: REGULAR}
+           │    ├── VALIDATED   → ABSENT ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-), IndexID: 4 (t_pkey-)}
+           │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 2 (t_i_key-), ConstraintID: 3, TemporaryIndexID: 3, SourceIndexID: 4 (t_pkey-), RecreateSourceIndexID: 0}
            │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 2 (t_i_key-)}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 3, ConstraintID: 4, SourceIndexID: 4 (t_pkey-)}
            │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 3}
-           └── 9 Mutation operations
+           └── 12 Mutation operations
                 ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
                 ├── RemoveColumnComputeExpression {"ColumnID":3,"TableID":104}
+                ├── RemoveColumnNotNull {"ColumnID":3,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":2,"TableID":104}
                 ├── CreateGCJobForIndex {"IndexID":2,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
                 ├── CreateGCJobForIndex {"IndexID":3,"TableID":104}
                 ├── CreateGCJobForIndex {"IndexID":4,"TableID":104}
                 ├── CreateGCJobForIndex {"IndexID":5,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash__rollback_14_of_16.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash__rollback_14_of_16.explain
@@ -7,19 +7,18 @@ EXPLAIN (DDL) rollback at post-commit stage 14 of 16;
 ----
 Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY USING COLUMNS (j) USING HASH WITH ('bucket_count' = ‹3›);
  └── PostCommitNonRevertiblePhase
-      ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 2 elements transitioning toward PUBLIC
-      │    │    ├── VALIDATED             → PUBLIC      PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey+), ConstraintID: 1}
-      │    │    └── ABSENT                → PUBLIC      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey+)}
-      │    ├── 18 elements transitioning toward ABSENT
-      │    │    ├── PUBLIC                → VALIDATED   PrimaryIndex:{DescID: 104 (t), IndexID: 4 (t_pkey-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 4 (t_pkey-)}
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 20 elements transitioning toward ABSENT
+      │    │    ├── VALIDATED             → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 4 (t_pkey-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 4 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 4 (t_pkey-)}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 6, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 5}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 5}
       │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-)}
       │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 104 (t), Name: "crdb_internal_j_shard_3", ColumnID: 3 (crdb_internal_j_shard_3-)}
       │    │    ├── PUBLIC                → VALIDATED   ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-), IndexID: 4 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-), IndexID: 4 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-), IndexID: 5}
       │    │    ├── MERGE_ONLY            → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 2 (t_i_key-), ConstraintID: 3, TemporaryIndexID: 3, SourceIndexID: 4 (t_pkey-), RecreateSourceIndexID: 0}
       │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 3, ConstraintID: 4, SourceIndexID: 4 (t_pkey-)}
@@ -31,9 +30,6 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 3}
       │    │    └── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_i_key", IndexID: 2 (t_i_key-)}
       │    └── 22 Mutation operations
-      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
-      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":4,"TableID":104}
-      │         ├── SetIndexName {"IndexID":4,"Name":"crdb_internal_in...","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"Ordinal":1,"TableID":104}
       │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":3,"TableID":104}
@@ -44,8 +40,11 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":3,"Kind":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"Kind":1,"Ordinal":1,"TableID":104}
-      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"Ordinal":1,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":4,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":2,"Kind":1,"TableID":104}
@@ -53,39 +52,26 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
-      ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 7 elements transitioning toward ABSENT
-      │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 4 (t_pkey-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 4 (t_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 4 (t_pkey-)}
-      │    │    ├── VALIDATED   → ABSENT      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-), IndexID: 4 (t_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-), IndexID: 4 (t_pkey-)}
-      │    │    ├── DELETE_ONLY → ABSENT      SecondaryIndex:{DescID: 104 (t), IndexID: 2 (t_i_key-), ConstraintID: 3, TemporaryIndexID: 3, SourceIndexID: 4 (t_pkey-), RecreateSourceIndexID: 0}
-      │    │    └── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 3, ConstraintID: 4, SourceIndexID: 4 (t_pkey-)}
-      │    └── 9 Mutation operations
-      │         ├── RemoveColumnNotNull {"ColumnID":3,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":2,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"Kind":2,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"Ordinal":1,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":4,"TableID":104}
-      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
-      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
-      └── Stage 3 of 3 in PostCommitNonRevertiblePhase
-           ├── 8 elements transitioning toward ABSENT
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 11 elements transitioning toward ABSENT
            │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 4 (t_pkey-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+)}
            │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 4 (t_pkey-)}
            │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 5}
            │    ├── DELETE_ONLY → ABSENT Column:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-)}
            │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 3 (crdb_internal_j_shard_3-), TypeName: "INT8"}
            │    ├── PUBLIC      → ABSENT ColumnComputeExpression:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-), Usage: REGULAR}
+           │    ├── VALIDATED   → ABSENT ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-), IndexID: 4 (t_pkey-)}
+           │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 2 (t_i_key-), ConstraintID: 3, TemporaryIndexID: 3, SourceIndexID: 4 (t_pkey-), RecreateSourceIndexID: 0}
            │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 2 (t_i_key-)}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 3, ConstraintID: 4, SourceIndexID: 4 (t_pkey-)}
            │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 3}
-           └── 9 Mutation operations
+           └── 12 Mutation operations
                 ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
                 ├── RemoveColumnComputeExpression {"ColumnID":3,"TableID":104}
+                ├── RemoveColumnNotNull {"ColumnID":3,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":2,"TableID":104}
                 ├── CreateGCJobForIndex {"IndexID":2,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
                 ├── CreateGCJobForIndex {"IndexID":3,"TableID":104}
                 ├── CreateGCJobForIndex {"IndexID":4,"TableID":104}
                 ├── CreateGCJobForIndex {"IndexID":5,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash__rollback_15_of_16.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash__rollback_15_of_16.explain
@@ -7,19 +7,18 @@ EXPLAIN (DDL) rollback at post-commit stage 15 of 16;
 ----
 Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY USING COLUMNS (j) USING HASH WITH ('bucket_count' = ‹3›);
  └── PostCommitNonRevertiblePhase
-      ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 2 elements transitioning toward PUBLIC
-      │    │    ├── VALIDATED             → PUBLIC      PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey+), ConstraintID: 1}
-      │    │    └── ABSENT                → PUBLIC      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey+)}
-      │    ├── 18 elements transitioning toward ABSENT
-      │    │    ├── PUBLIC                → VALIDATED   PrimaryIndex:{DescID: 104 (t), IndexID: 4 (t_pkey-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 4 (t_pkey-)}
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 20 elements transitioning toward ABSENT
+      │    │    ├── VALIDATED             → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 4 (t_pkey-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 4 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 4 (t_pkey-)}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 6, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 5}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 5}
       │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-)}
       │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 104 (t), Name: "crdb_internal_j_shard_3", ColumnID: 3 (crdb_internal_j_shard_3-)}
       │    │    ├── PUBLIC                → VALIDATED   ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-), IndexID: 4 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-), IndexID: 4 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-), IndexID: 5}
       │    │    ├── WRITE_ONLY            → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 2 (t_i_key-), ConstraintID: 3, TemporaryIndexID: 3, SourceIndexID: 4 (t_pkey-), RecreateSourceIndexID: 0}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 3, ConstraintID: 4, SourceIndexID: 4 (t_pkey-)}
@@ -31,9 +30,6 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 3}
       │    │    └── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_i_key", IndexID: 2 (t_i_key-)}
       │    └── 22 Mutation operations
-      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
-      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":4,"TableID":104}
-      │         ├── SetIndexName {"IndexID":4,"Name":"crdb_internal_in...","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"Ordinal":1,"TableID":104}
       │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":3,"TableID":104}
@@ -48,41 +44,31 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":2,"Kind":1,"Ordinal":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"Kind":1,"Ordinal":1,"TableID":104}
       │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":104}
-      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
-      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
-      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
-      ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 6 elements transitioning toward ABSENT
-      │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 4 (t_pkey-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 4 (t_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 4 (t_pkey-)}
-      │    │    ├── VALIDATED   → ABSENT      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-), IndexID: 4 (t_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-), IndexID: 4 (t_pkey-)}
-      │    │    └── DELETE_ONLY → ABSENT      SecondaryIndex:{DescID: 104 (t), IndexID: 2 (t_i_key-), ConstraintID: 3, TemporaryIndexID: 3, SourceIndexID: 4 (t_pkey-), RecreateSourceIndexID: 0}
-      │    └── 8 Mutation operations
-      │         ├── RemoveColumnNotNull {"ColumnID":3,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":2,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"Ordinal":1,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":4,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
-      └── Stage 3 of 3 in PostCommitNonRevertiblePhase
-           ├── 8 elements transitioning toward ABSENT
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 10 elements transitioning toward ABSENT
            │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 4 (t_pkey-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+)}
            │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 4 (t_pkey-)}
            │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 5}
            │    ├── DELETE_ONLY → ABSENT Column:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-)}
            │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 3 (crdb_internal_j_shard_3-), TypeName: "INT8"}
            │    ├── PUBLIC      → ABSENT ColumnComputeExpression:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-), Usage: REGULAR}
+           │    ├── VALIDATED   → ABSENT ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-), IndexID: 4 (t_pkey-)}
+           │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 2 (t_i_key-), ConstraintID: 3, TemporaryIndexID: 3, SourceIndexID: 4 (t_pkey-), RecreateSourceIndexID: 0}
            │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 2 (t_i_key-)}
            │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 3}
-           └── 9 Mutation operations
+           └── 11 Mutation operations
                 ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
                 ├── RemoveColumnComputeExpression {"ColumnID":3,"TableID":104}
+                ├── RemoveColumnNotNull {"ColumnID":3,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":2,"TableID":104}
                 ├── CreateGCJobForIndex {"IndexID":2,"TableID":104}
                 ├── CreateGCJobForIndex {"IndexID":3,"TableID":104}
                 ├── CreateGCJobForIndex {"IndexID":4,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash__rollback_16_of_16.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash__rollback_16_of_16.explain
@@ -7,19 +7,18 @@ EXPLAIN (DDL) rollback at post-commit stage 16 of 16;
 ----
 Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY USING COLUMNS (j) USING HASH WITH ('bucket_count' = ‹3›);
  └── PostCommitNonRevertiblePhase
-      ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 2 elements transitioning toward PUBLIC
-      │    │    ├── VALIDATED             → PUBLIC      PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey+), ConstraintID: 1}
-      │    │    └── ABSENT                → PUBLIC      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey+)}
-      │    ├── 18 elements transitioning toward ABSENT
-      │    │    ├── PUBLIC                → VALIDATED   PrimaryIndex:{DescID: 104 (t), IndexID: 4 (t_pkey-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 4 (t_pkey-)}
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 20 elements transitioning toward ABSENT
+      │    │    ├── VALIDATED             → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 4 (t_pkey-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 4 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 4 (t_pkey-)}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 6, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 5}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 5}
       │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-)}
       │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 104 (t), Name: "crdb_internal_j_shard_3", ColumnID: 3 (crdb_internal_j_shard_3-)}
       │    │    ├── PUBLIC                → VALIDATED   ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-), IndexID: 4 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-), IndexID: 4 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-), IndexID: 5}
       │    │    ├── WRITE_ONLY            → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 2 (t_i_key-), ConstraintID: 3, TemporaryIndexID: 3, SourceIndexID: 4 (t_pkey-), RecreateSourceIndexID: 0}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 3, ConstraintID: 4, SourceIndexID: 4 (t_pkey-)}
@@ -31,9 +30,6 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 3}
       │    │    └── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_i_key", IndexID: 2 (t_i_key-)}
       │    └── 22 Mutation operations
-      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
-      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":4,"TableID":104}
-      │         ├── SetIndexName {"IndexID":4,"Name":"crdb_internal_in...","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"Ordinal":1,"TableID":104}
       │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":3,"TableID":104}
@@ -48,41 +44,31 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":2,"Kind":1,"Ordinal":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"Kind":1,"Ordinal":1,"TableID":104}
       │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":104}
-      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
-      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
-      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
-      ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 6 elements transitioning toward ABSENT
-      │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 4 (t_pkey-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 4 (t_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 4 (t_pkey-)}
-      │    │    ├── VALIDATED   → ABSENT      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-), IndexID: 4 (t_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-), IndexID: 4 (t_pkey-)}
-      │    │    └── DELETE_ONLY → ABSENT      SecondaryIndex:{DescID: 104 (t), IndexID: 2 (t_i_key-), ConstraintID: 3, TemporaryIndexID: 3, SourceIndexID: 4 (t_pkey-), RecreateSourceIndexID: 0}
-      │    └── 8 Mutation operations
-      │         ├── RemoveColumnNotNull {"ColumnID":3,"TableID":104}
-      │         ├── MakeIndexAbsent {"IndexID":2,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"Ordinal":1,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":4,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
-      └── Stage 3 of 3 in PostCommitNonRevertiblePhase
-           ├── 8 elements transitioning toward ABSENT
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 10 elements transitioning toward ABSENT
            │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 4 (t_pkey-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+)}
            │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 4 (t_pkey-)}
            │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 5}
            │    ├── DELETE_ONLY → ABSENT Column:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-)}
            │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 3 (crdb_internal_j_shard_3-), TypeName: "INT8"}
            │    ├── PUBLIC      → ABSENT ColumnComputeExpression:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-), Usage: REGULAR}
+           │    ├── VALIDATED   → ABSENT ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-), IndexID: 4 (t_pkey-)}
+           │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 2 (t_i_key-), ConstraintID: 3, TemporaryIndexID: 3, SourceIndexID: 4 (t_pkey-), RecreateSourceIndexID: 0}
            │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 2 (t_i_key-)}
            │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 3}
-           └── 9 Mutation operations
+           └── 11 Mutation operations
                 ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
                 ├── RemoveColumnComputeExpression {"ColumnID":3,"TableID":104}
+                ├── RemoveColumnNotNull {"ColumnID":3,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":2,"TableID":104}
                 ├── CreateGCJobForIndex {"IndexID":2,"TableID":104}
                 ├── CreateGCJobForIndex {"IndexID":3,"TableID":104}
                 ├── CreateGCJobForIndex {"IndexID":4,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash__rollback_9_of_16.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash__rollback_9_of_16.explain
@@ -7,19 +7,18 @@ EXPLAIN (DDL) rollback at post-commit stage 9 of 16;
 ----
 Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY USING COLUMNS (j) USING HASH WITH ('bucket_count' = ‹3›);
  └── PostCommitNonRevertiblePhase
-      ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 2 elements transitioning toward PUBLIC
-      │    │    ├── VALIDATED             → PUBLIC      PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey+), ConstraintID: 1}
-      │    │    └── ABSENT                → PUBLIC      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey+)}
-      │    ├── 18 elements transitioning toward ABSENT
-      │    │    ├── PUBLIC                → VALIDATED   PrimaryIndex:{DescID: 104 (t), IndexID: 4 (t_pkey-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 4 (t_pkey-)}
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 20 elements transitioning toward ABSENT
+      │    │    ├── VALIDATED             → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 4 (t_pkey-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 4 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 4 (t_pkey-)}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 5, ConstraintID: 6, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 5}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 5}
       │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-)}
       │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 104 (t), Name: "crdb_internal_j_shard_3", ColumnID: 3 (crdb_internal_j_shard_3-)}
       │    │    ├── PUBLIC                → VALIDATED   ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-), IndexID: 4 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-), IndexID: 4 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-), IndexID: 5}
       │    │    ├── BACKFILL_ONLY         → ABSENT      SecondaryIndex:{DescID: 104 (t), IndexID: 2 (t_i_key-), ConstraintID: 3, TemporaryIndexID: 3, SourceIndexID: 4 (t_pkey-), RecreateSourceIndexID: 0}
       │    │    ├── DELETE_ONLY           → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 3, ConstraintID: 4, SourceIndexID: 4 (t_pkey-)}
@@ -31,9 +30,6 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 3}
       │    │    └── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_i_key", IndexID: 2 (t_i_key-)}
       │    └── 22 Mutation operations
-      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
-      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":4,"TableID":104}
-      │         ├── SetIndexName {"IndexID":4,"Name":"crdb_internal_in...","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":5,"Ordinal":1,"TableID":104}
       │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":3,"TableID":104}
@@ -47,39 +43,29 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":2,"Kind":1,"Ordinal":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"Kind":1,"Ordinal":1,"TableID":104}
       │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":104}
-      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"Ordinal":1,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":4,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":2,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
-      ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 5 elements transitioning toward ABSENT
-      │    │    ├── VALIDATED → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 4 (t_pkey-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC    → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 4 (t_pkey-)}
-      │    │    ├── PUBLIC    → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 4 (t_pkey-)}
-      │    │    ├── VALIDATED → ABSENT      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-), IndexID: 4 (t_pkey-)}
-      │    │    └── PUBLIC    → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-), IndexID: 4 (t_pkey-)}
-      │    └── 7 Mutation operations
-      │         ├── RemoveColumnNotNull {"ColumnID":3,"TableID":104}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"Kind":2,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"Ordinal":1,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":4,"TableID":104}
-      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
-      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
-      └── Stage 3 of 3 in PostCommitNonRevertiblePhase
-           ├── 7 elements transitioning toward ABSENT
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 8 elements transitioning toward ABSENT
            │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 4 (t_pkey-), ConstraintID: 5, TemporaryIndexID: 5, SourceIndexID: 1 (t_pkey+)}
            │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 4 (t_pkey-)}
            │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 5}
            │    ├── DELETE_ONLY → ABSENT Column:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-)}
            │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 3 (crdb_internal_j_shard_3-), TypeName: "INT8"}
            │    ├── PUBLIC      → ABSENT ColumnComputeExpression:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-), Usage: REGULAR}
+           │    ├── VALIDATED   → ABSENT ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (crdb_internal_j_shard_3-), IndexID: 4 (t_pkey-)}
            │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 2 (t_i_key-)}
-           └── 8 Mutation operations
+           └── 9 Mutation operations
                 ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
                 ├── RemoveColumnComputeExpression {"ColumnID":3,"TableID":104}
+                ├── RemoveColumnNotNull {"ColumnID":3,"TableID":104}
                 ├── CreateGCJobForIndex {"IndexID":2,"TableID":104}
                 ├── CreateGCJobForIndex {"IndexID":4,"TableID":104}
                 ├── CreateGCJobForIndex {"IndexID":5,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_vanilla/alter_table_alter_primary_key_vanilla.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_vanilla/alter_table_alter_primary_key_vanilla.explain
@@ -294,7 +294,7 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ALTER PR
  │    │    │    ├── PUBLIC    → VALIDATED     SecondaryIndex:{DescID: 104 (t), IndexID: 2 (t_i_idx-), RecreateSourceIndexID: 0}
  │    │    │    ├── PUBLIC    → VALIDATED     SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_j_idx-), RecreateSourceIndexID: 0}
  │    │    │    └── PUBLIC    → VALIDATED     SecondaryIndex:{DescID: 104 (t), IndexID: 6 (t_k_idx-), RecreateSourceIndexID: 0}
- │    │    └── 23 Mutation operations
+ │    │    └── 26 Mutation operations
  │    │         ├── SetIndexName {"IndexID":8,"Name":"t_i_idx","TableID":104}
  │    │         ├── SetIndexName {"IndexID":10,"Name":"t_j_idx","TableID":104}
  │    │         ├── SetIndexName {"IndexID":12,"Name":"t_k_idx","TableID":104}
@@ -307,10 +307,13 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ALTER PR
  │    │         ├── AddColumnToIndex {"ColumnID":2,"IndexID":14,"Kind":1,"TableID":104}
  │    │         ├── AddColumnToIndex {"ColumnID":2,"IndexID":15,"Kind":1,"TableID":104}
  │    │         ├── SetIndexName {"IndexID":14,"Name":"t_i_key","TableID":104}
+ │    │         ├── MarkRecreatedIndexAsInvisible {"IndexID":8,"TableID":104,"TargetPrimaryIndexID":16}
  │    │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":8,"TableID":104}
  │    │         ├── RefreshStats {"TableID":104}
+ │    │         ├── MarkRecreatedIndexAsInvisible {"IndexID":10,"TableID":104,"TargetPrimaryIndexID":16}
  │    │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":10,"TableID":104}
  │    │         ├── RefreshStats {"TableID":104}
+ │    │         ├── MarkRecreatedIndexAsInvisible {"IndexID":12,"TableID":104,"TargetPrimaryIndexID":16}
  │    │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":12,"TableID":104}
  │    │         ├── RefreshStats {"TableID":104}
  │    │         ├── MakePublicSecondaryIndexWriteOnly {"IndexID":2,"TableID":104}
@@ -401,7 +404,7 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ALTER PR
       │    │    ├── PUBLIC                → ABSENT           IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 6 (t_k_idx-)}
       │    │    ├── VALIDATED             → DELETE_ONLY      SecondaryIndex:{DescID: 104 (t), IndexID: 6 (t_k_idx-), RecreateSourceIndexID: 0}
       │    │    └── PUBLIC                → ABSENT           IndexName:{DescID: 104 (t), Name: "t_k_idx", IndexID: 6 (t_k_idx-)}
-      │    └── 36 Mutation operations
+      │    └── 37 Mutation operations
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":1,"TableID":104}
       │         ├── SetIndexName {"IndexID":1,"Name":"crdb_internal_in...","TableID":104}
       │         ├── SetIndexName {"IndexID":16,"Name":"t_pkey","TableID":104}
@@ -426,6 +429,7 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ALTER PR
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":104}
       │         ├── SetIndexName {"IndexID":6,"Name":"crdb_internal_in...","TableID":104}
       │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":16,"TableID":104}
+      │         ├── MarkRecreatedIndexesAsVisible {"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":17,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":11,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_vanilla/alter_table_alter_primary_key_vanilla.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_vanilla/alter_table_alter_primary_key_vanilla.explain
@@ -274,9 +274,7 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ALTER PR
  │    │         ├── ValidateIndex {"IndexID":10,"TableID":104}
  │    │         └── ValidateIndex {"IndexID":12,"TableID":104}
  │    ├── Stage 8 of 15 in PostCommitPhase
- │    │    ├── 13 elements transitioning toward PUBLIC
- │    │    │    ├── VALIDATED → PUBLIC        PrimaryIndex:{DescID: 104 (t), IndexID: 16 (t_pkey+), ConstraintID: 10, TemporaryIndexID: 17, SourceIndexID: 1 (t_pkey-)}
- │    │    │    ├── ABSENT    → PUBLIC        IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 16 (t_pkey+)}
+ │    │    ├── 11 elements transitioning toward PUBLIC
  │    │    │    ├── VALIDATED → PUBLIC        SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx+), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 2}
  │    │    │    ├── ABSENT    → PUBLIC        IndexName:{DescID: 104 (t), Name: "t_i_idx", IndexID: 8 (t_i_idx+)}
  │    │    │    ├── VALIDATED → PUBLIC        SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx+), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey-), RecreateSourceIndexID: 4}
@@ -292,26 +290,14 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ALTER PR
  │    │    │    ├── ABSENT    → DELETE_ONLY   TemporaryIndex:{DescID: 104 (t), IndexID: 15, ConstraintID: 9, SourceIndexID: 16 (t_pkey+)}
  │    │    │    ├── ABSENT    → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 15}
  │    │    │    └── ABSENT    → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 15}
- │    │    ├── 5 elements transitioning toward ABSENT
- │    │    │    ├── PUBLIC    → VALIDATED     PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey-), ConstraintID: 1}
- │    │    │    ├── PUBLIC    → ABSENT        IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey-)}
+ │    │    ├── 3 elements transitioning toward ABSENT
  │    │    │    ├── PUBLIC    → VALIDATED     SecondaryIndex:{DescID: 104 (t), IndexID: 2 (t_i_idx-), RecreateSourceIndexID: 0}
  │    │    │    ├── PUBLIC    → VALIDATED     SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_j_idx-), RecreateSourceIndexID: 0}
  │    │    │    └── PUBLIC    → VALIDATED     SecondaryIndex:{DescID: 104 (t), IndexID: 6 (t_k_idx-), RecreateSourceIndexID: 0}
- │    │    └── 27 Mutation operations
- │    │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":1,"TableID":104}
- │    │         ├── SetIndexName {"IndexID":1,"Name":"crdb_internal_in...","TableID":104}
- │    │         ├── SetIndexName {"IndexID":16,"Name":"t_pkey","TableID":104}
+ │    │    └── 23 Mutation operations
  │    │         ├── SetIndexName {"IndexID":8,"Name":"t_i_idx","TableID":104}
  │    │         ├── SetIndexName {"IndexID":10,"Name":"t_j_idx","TableID":104}
  │    │         ├── SetIndexName {"IndexID":12,"Name":"t_k_idx","TableID":104}
- │    │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":16,"TableID":104}
- │    │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":8,"TableID":104}
- │    │         ├── RefreshStats {"TableID":104}
- │    │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":10,"TableID":104}
- │    │         ├── RefreshStats {"TableID":104}
- │    │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":12,"TableID":104}
- │    │         ├── RefreshStats {"TableID":104}
  │    │         ├── MakeAbsentIndexBackfilling {"IsSecondaryIndex":true}
  │    │         ├── MaybeAddSplitForIndex {"IndexID":14,"TableID":104}
  │    │         ├── MakeAbsentTempIndexDeleteOnly {"IsSecondaryIndex":true}
@@ -321,6 +307,12 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ALTER PR
  │    │         ├── AddColumnToIndex {"ColumnID":2,"IndexID":14,"Kind":1,"TableID":104}
  │    │         ├── AddColumnToIndex {"ColumnID":2,"IndexID":15,"Kind":1,"TableID":104}
  │    │         ├── SetIndexName {"IndexID":14,"Name":"t_i_key","TableID":104}
+ │    │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":8,"TableID":104}
+ │    │         ├── RefreshStats {"TableID":104}
+ │    │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":10,"TableID":104}
+ │    │         ├── RefreshStats {"TableID":104}
+ │    │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":12,"TableID":104}
+ │    │         ├── RefreshStats {"TableID":104}
  │    │         ├── MakePublicSecondaryIndexWriteOnly {"IndexID":2,"TableID":104}
  │    │         ├── MakePublicSecondaryIndexWriteOnly {"IndexID":4,"TableID":104}
  │    │         ├── MakePublicSecondaryIndexWriteOnly {"IndexID":6,"TableID":104}
@@ -374,8 +366,10 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ALTER PR
  │         └── 1 Validation operation
  │              └── ValidateIndex {"IndexID":14,"TableID":104}
  └── PostCommitNonRevertiblePhase
-      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
-      │    ├── 1 element transitioning toward PUBLIC
+      ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 3 elements transitioning toward PUBLIC
+      │    │    ├── VALIDATED             → PUBLIC           PrimaryIndex:{DescID: 104 (t), IndexID: 16 (t_pkey+), ConstraintID: 10, TemporaryIndexID: 17, SourceIndexID: 1 (t_pkey-)}
+      │    │    ├── ABSENT                → PUBLIC           IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 16 (t_pkey+)}
       │    │    └── VALIDATED             → PUBLIC           SecondaryIndex:{DescID: 104 (t), IndexID: 14 (t_i_key+), ConstraintID: 8, TemporaryIndexID: 15, SourceIndexID: 16 (t_pkey+), RecreateSourceIndexID: 0}
       │    ├── 15 elements transitioning toward TRANSIENT_ABSENT
       │    │    ├── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 17, ConstraintID: 11, SourceIndexID: 1 (t_pkey-)}
@@ -393,11 +387,9 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ALTER PR
       │    │    ├── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 15, ConstraintID: 9, SourceIndexID: 16 (t_pkey+)}
       │    │    ├── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 15}
       │    │    └── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 15}
-      │    ├── 15 elements transitioning toward ABSENT
-      │    │    ├── PUBLIC                → ABSENT           IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 1 (t_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT           IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 1 (t_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT           IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 1 (t_pkey-)}
-      │    │    ├── VALIDATED             → DELETE_ONLY      PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey-), ConstraintID: 1}
+      │    ├── 13 elements transitioning toward ABSENT
+      │    │    ├── PUBLIC                → VALIDATED        PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey-), ConstraintID: 1}
+      │    │    ├── PUBLIC                → ABSENT           IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey-)}
       │    │    ├── PUBLIC                → ABSENT           IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 2 (t_i_idx-)}
       │    │    ├── VALIDATED             → DELETE_ONLY      SecondaryIndex:{DescID: 104 (t), IndexID: 2 (t_i_idx-), RecreateSourceIndexID: 0}
       │    │    ├── PUBLIC                → ABSENT           IndexName:{DescID: 104 (t), Name: "t_i_idx", IndexID: 2 (t_i_idx-)}
@@ -410,6 +402,9 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ALTER PR
       │    │    ├── VALIDATED             → DELETE_ONLY      SecondaryIndex:{DescID: 104 (t), IndexID: 6 (t_k_idx-), RecreateSourceIndexID: 0}
       │    │    └── PUBLIC                → ABSENT           IndexName:{DescID: 104 (t), Name: "t_k_idx", IndexID: 6 (t_k_idx-)}
       │    └── 36 Mutation operations
+      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":1,"TableID":104}
+      │         ├── SetIndexName {"IndexID":1,"Name":"crdb_internal_in...","TableID":104}
+      │         ├── SetIndexName {"IndexID":16,"Name":"t_pkey","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":17,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":17,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":17,"Kind":2,"Ordinal":1,"TableID":104}
@@ -422,7 +417,6 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ALTER PR
       │         ├── RefreshStats {"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":15,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":15,"Kind":1,"TableID":104}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":1,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":2,"TableID":104}
       │         ├── RemoveDroppedIndexPartialPredicate {"IndexID":2,"TableID":104}
       │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":104}
@@ -431,14 +425,12 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ALTER PR
       │         ├── SetIndexName {"IndexID":4,"Name":"crdb_internal_in...","TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":104}
       │         ├── SetIndexName {"IndexID":6,"Name":"crdb_internal_in...","TableID":104}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":16,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":17,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":11,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":13,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":15,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":1,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":1,"Kind":2,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":1,"Kind":2,"Ordinal":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":4,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"Kind":1,"TableID":104}
@@ -446,30 +438,43 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ALTER PR
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Kind":1,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
-      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+      ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 7 elements transitioning toward ABSENT
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 1 (t_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 1 (t_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 1 (t_pkey-)}
+      │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey-), ConstraintID: 1}
+      │    │    ├── DELETE_ONLY → ABSENT      SecondaryIndex:{DescID: 104 (t), IndexID: 2 (t_i_idx-), RecreateSourceIndexID: 0}
+      │    │    ├── DELETE_ONLY → ABSENT      SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_j_idx-), RecreateSourceIndexID: 0}
+      │    │    └── DELETE_ONLY → ABSENT      SecondaryIndex:{DescID: 104 (t), IndexID: 6 (t_k_idx-), RecreateSourceIndexID: 0}
+      │    └── 9 Mutation operations
+      │         ├── MakeIndexAbsent {"IndexID":2,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":6,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":1,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":1,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 3 of 3 in PostCommitNonRevertiblePhase
            ├── 5 elements transitioning toward TRANSIENT_ABSENT
            │    ├── PUBLIC      → TRANSIENT_ABSENT IndexData:{DescID: 104 (t), IndexID: 17}
            │    ├── PUBLIC      → TRANSIENT_ABSENT IndexData:{DescID: 104 (t), IndexID: 9}
            │    ├── PUBLIC      → TRANSIENT_ABSENT IndexData:{DescID: 104 (t), IndexID: 11}
            │    ├── PUBLIC      → TRANSIENT_ABSENT IndexData:{DescID: 104 (t), IndexID: 13}
            │    └── PUBLIC      → TRANSIENT_ABSENT IndexData:{DescID: 104 (t), IndexID: 15}
-           ├── 8 elements transitioning toward ABSENT
+           ├── 5 elements transitioning toward ABSENT
            │    ├── DELETE_ONLY → ABSENT           PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey-), ConstraintID: 1}
            │    ├── PUBLIC      → ABSENT           IndexData:{DescID: 104 (t), IndexID: 1 (t_pkey-)}
-           │    ├── DELETE_ONLY → ABSENT           SecondaryIndex:{DescID: 104 (t), IndexID: 2 (t_i_idx-), RecreateSourceIndexID: 0}
            │    ├── PUBLIC      → ABSENT           IndexData:{DescID: 104 (t), IndexID: 2 (t_i_idx-)}
-           │    ├── DELETE_ONLY → ABSENT           SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_j_idx-), RecreateSourceIndexID: 0}
            │    ├── PUBLIC      → ABSENT           IndexData:{DescID: 104 (t), IndexID: 4 (t_j_idx-)}
-           │    ├── DELETE_ONLY → ABSENT           SecondaryIndex:{DescID: 104 (t), IndexID: 6 (t_k_idx-), RecreateSourceIndexID: 0}
            │    └── PUBLIC      → ABSENT           IndexData:{DescID: 104 (t), IndexID: 6 (t_k_idx-)}
-           └── 15 Mutation operations
+           └── 12 Mutation operations
                 ├── MakeIndexAbsent {"IndexID":1,"TableID":104}
                 ├── CreateGCJobForIndex {"IndexID":1,"TableID":104}
-                ├── MakeIndexAbsent {"IndexID":2,"TableID":104}
                 ├── CreateGCJobForIndex {"IndexID":2,"TableID":104}
-                ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
                 ├── CreateGCJobForIndex {"IndexID":4,"TableID":104}
-                ├── MakeIndexAbsent {"IndexID":6,"TableID":104}
                 ├── CreateGCJobForIndex {"IndexID":6,"TableID":104}
                 ├── CreateGCJobForIndex {"IndexID":9,"TableID":104}
                 ├── CreateGCJobForIndex {"IndexID":11,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_vanilla/alter_table_alter_primary_key_vanilla.explain_shape
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_vanilla/alter_table_alter_primary_key_vanilla.explain_shape
@@ -34,4 +34,4 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ALTER PR
  │    └── from t@[15] into t_i_key+
  ├── execute 1 system table mutations transaction
  ├── validate UNIQUE constraint backed by index t_i_key+ in relation t
- └── execute 2 system table mutations transactions
+ └── execute 3 system table mutations transactions

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_vanilla/alter_table_alter_primary_key_vanilla.side_effects
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_vanilla/alter_table_alter_primary_key_vanilla.side_effects
@@ -741,7 +741,7 @@ validate forward indexes [10] in table #104
 validate forward indexes [12] in table #104
 commit transaction #9
 begin transaction #10
-## PostCommitPhase stage 8 of 15 with 23 MutationType ops
+## PostCommitPhase stage 8 of 15 with 26 MutationType ops
 upsert descriptor #104
   ...
      id: 104
@@ -755,13 +755,16 @@ upsert descriptor #104
   -    id: 2
   +    id: 8
        interleave: {}
+  +    invisibility: 1
        keyColumnDirections:
+       - ASC
   ...
        keyColumnNames:
        - i
   +    keySuffixColumnIds:
   +    - 2
        name: t_i_idx
+  +    notVisible: true
        partitioning: {}
        predicate: i <= 0:::INT8
        sharded: {}
@@ -777,13 +780,16 @@ upsert descriptor #104
   -    id: 4
   +    id: 10
        interleave: {}
+  +    invisibility: 1
        keyColumnDirections:
+       - ASC
   ...
        keyColumnNames:
        - j
   -    keySuffixColumnIds:
   -    - 1
        name: t_j_idx
+  +    notVisible: true
        partitioning: {}
        predicate: j <= 0:::INT8
        sharded: {}
@@ -799,13 +805,16 @@ upsert descriptor #104
   -    id: 6
   +    id: 12
        interleave: {}
+  +    invisibility: 1
        keyColumnDirections:
+       - ASC
   ...
        - k
        keySuffixColumnIds:
   -    - 1
   +    - 2
        name: t_k_idx
+  +    notVisible: true
        partitioning: {}
        sharded: {}
   +    storeColumnNames: []
@@ -1145,7 +1154,7 @@ begin transaction #17
 validate forward indexes [14] in table #104
 commit transaction #17
 begin transaction #18
-## PostCommitNonRevertiblePhase stage 1 of 3 with 36 MutationType ops
+## PostCommitNonRevertiblePhase stage 1 of 3 with 37 MutationType ops
 upsert descriptor #104
   ...
            statement: ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (j)
@@ -1153,6 +1162,42 @@ upsert descriptor #104
   -    revertible: true
        targetRanks: <redacted>
        targets: <redacted>
+  ...
+       id: 8
+       interleave: {}
+  -    invisibility: 1
+       keyColumnDirections:
+       - ASC
+  ...
+       - 2
+       name: t_i_idx
+  -    notVisible: true
+       partitioning: {}
+       predicate: i <= 0:::INT8
+  ...
+       id: 10
+       interleave: {}
+  -    invisibility: 1
+       keyColumnDirections:
+       - ASC
+  ...
+       - j
+       name: t_j_idx
+  -    notVisible: true
+       partitioning: {}
+       predicate: j <= 0:::INT8
+  ...
+       id: 12
+       interleave: {}
+  -    invisibility: 1
+       keyColumnDirections:
+       - ASC
+  ...
+       - 2
+       name: t_k_idx
+  -    notVisible: true
+       partitioning: {}
+       sharded: {}
   ...
        vecConfig: {}
        version: 4

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_vanilla/alter_table_alter_primary_key_vanilla.side_effects
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_vanilla/alter_table_alter_primary_key_vanilla.side_effects
@@ -741,7 +741,7 @@ validate forward indexes [10] in table #104
 validate forward indexes [12] in table #104
 commit transaction #9
 begin transaction #10
-## PostCommitPhase stage 8 of 15 with 27 MutationType ops
+## PostCommitPhase stage 8 of 15 with 23 MutationType ops
 upsert descriptor #104
   ...
      id: 104
@@ -811,95 +811,6 @@ upsert descriptor #104
   +    storeColumnNames: []
        vecConfig: {}
        version: 4
-     modificationTime: {}
-     mutations:
-  -  - direction: ADD
-  +  - direction: DROP
-       index:
-  -      constraintId: 10
-  +      constraintId: 11
-         createdExplicitly: true
-         encodingType: 1
-         foreignKey: {}
-         geoConfig: {}
-  -      id: 16
-  +      id: 17
-         interleave: {}
-         keyColumnDirections:
-  ...
-         keyColumnNames:
-         - j
-  -      name: crdb_internal_index_16_name_placeholder
-  +      name: crdb_internal_index_17_name_placeholder
-         partitioning: {}
-         sharded: {}
-  ...
-         - k
-         unique: true
-  +      useDeletePreservingEncoding: true
-         vecConfig: {}
-         version: 4
-       mutationId: 1
-  -    state: WRITE_ONLY
-  +    state: DELETE_ONLY
-     - direction: DROP
-       index:
-  -      constraintId: 11
-  +      constraintId: 3
-         createdExplicitly: true
-  -      encodingType: 1
-         foreignKey: {}
-         geoConfig: {}
-  -      id: 17
-  +      id: 9
-         interleave: {}
-         keyColumnDirections:
-         - ASC
-         keyColumnIds:
-  +      - 1
-  +      keyColumnNames:
-  +      - i
-  +      keySuffixColumnIds:
-         - 2
-  +      name: crdb_internal_index_9_name_placeholder
-  +      partitioning: {}
-  +      predicate: i <= 0:::INT8
-  +      sharded: {}
-  +      storeColumnNames: []
-  +      useDeletePreservingEncoding: true
-  +      vecConfig: {}
-  +      version: 4
-  +    mutationId: 1
-  +    state: DELETE_ONLY
-  +  - direction: DROP
-  +    index:
-  +      constraintId: 5
-  +      createdExplicitly: true
-  +      foreignKey: {}
-  +      geoConfig: {}
-  +      id: 11
-  +      interleave: {}
-  +      keyColumnDirections:
-  +      - ASC
-  +      keyColumnIds:
-  +      - 2
-         keyColumnNames:
-         - j
-  -      name: crdb_internal_index_17_name_placeholder
-  +      name: crdb_internal_index_11_name_placeholder
-         partitioning: {}
-  +      predicate: j <= 0:::INT8
-         sharded: {}
-  -      storeColumnIds:
-  -      - 1
-  -      - 3
-  -      storeColumnNames:
-  -      - i
-  -      - k
-  -      unique: true
-  +      storeColumnNames: []
-         useDeletePreservingEncoding: true
-         vecConfig: {}
   ...
        mutationId: 1
        state: DELETE_ONLY
@@ -908,27 +819,21 @@ upsert descriptor #104
        index:
   -      constraintId: 2
   -      createdAtNanos: "1640998800000000000"
-  +      constraintId: 7
+  +      constraintId: 3
          createdExplicitly: true
          foreignKey: {}
          geoConfig: {}
   -      id: 8
-  +      id: 13
+  +      id: 9
          interleave: {}
          keyColumnDirections:
-         - ASC
-         keyColumnIds:
-  -      - 1
-  +      - 3
-         keyColumnNames:
-  -      - i
-  +      - k
+  ...
          keySuffixColumnIds:
          - 2
   -      name: crdb_internal_index_8_name_placeholder
-  +      name: crdb_internal_index_13_name_placeholder
+  +      name: crdb_internal_index_9_name_placeholder
          partitioning: {}
-  -      predicate: i <= 0:::INT8
+         predicate: i <= 0:::INT8
          sharded: {}
          storeColumnNames: []
   +      useDeletePreservingEncoding: true
@@ -940,70 +845,64 @@ upsert descriptor #104
      - direction: DROP
        index:
   -      constraintId: 3
-  +      constraintId: 1
-  +      createdAtNanos: "1640995200000000000"
-  +      encodingType: 1
-  +      foreignKey: {}
-  +      geoConfig: {}
-  +      id: 1
-  +      interleave: {}
-  +      keyColumnDirections:
-  +      - ASC
-  +      keyColumnIds:
-  +      - 1
-  +      keyColumnNames:
-  +      - i
-  +      name: crdb_internal_index_1_name_placeholder
-  +      partitioning: {}
-  +      sharded: {}
-  +      storeColumnIds:
-  +      - 2
-  +      - 3
-  +      storeColumnNames:
-  +      - j
-  +      - k
-  +      unique: true
-  +      vecConfig: {}
-  +      version: 4
-  +    mutationId: 1
-  +    state: WRITE_ONLY
-  +  - direction: ADD
-  +    index:
-  +      constraintId: 8
-  +      createdAtNanos: "1640998800000000000"
+  +      constraintId: 5
          createdExplicitly: true
          foreignKey: {}
          geoConfig: {}
   -      id: 9
-  +      id: 14
+  +      id: 11
          interleave: {}
          keyColumnDirections:
-  ...
+         - ASC
+         keyColumnIds:
+  -      - 1
+  +      - 2
+         keyColumnNames:
+  -      - i
+  +      - j
+  +      name: crdb_internal_index_11_name_placeholder
+  +      partitioning: {}
+  +      predicate: j <= 0:::INT8
+  +      sharded: {}
+  +      storeColumnNames: []
+  +      useDeletePreservingEncoding: true
+  +      vecConfig: {}
+  +      version: 4
+  +    mutationId: 1
+  +    state: DELETE_ONLY
+  +  - direction: DROP
+  +    index:
+  +      constraintId: 7
+  +      createdExplicitly: true
+  +      foreignKey: {}
+  +      geoConfig: {}
+  +      id: 13
+  +      interleave: {}
+  +      keyColumnDirections:
+  +      - ASC
+  +      keyColumnIds:
+  +      - 3
+  +      keyColumnNames:
+  +      - k
          keySuffixColumnIds:
          - 2
   -      name: crdb_internal_index_9_name_placeholder
-  +      name: t_i_key
+  +      name: crdb_internal_index_13_name_placeholder
          partitioning: {}
   -      predicate: i <= 0:::INT8
          sharded: {}
          storeColumnNames: []
-  -      useDeletePreservingEncoding: true
-  +      unique: true
-         vecConfig: {}
-         version: 4
-       mutationId: 1
-  -    state: DELETE_ONLY
-  +    state: BACKFILLING
+  ...
      - direction: ADD
        index:
   -      constraintId: 4
-  -      createdAtNanos: "1640998800000000000"
-  +      constraintId: 9
+  +      constraintId: 8
+         createdAtNanos: "1640998800000000000"
          createdExplicitly: true
          foreignKey: {}
          geoConfig: {}
   -      id: 10
-  +      id: 15
+  +      id: 14
          interleave: {}
          keyColumnDirections:
          - ASC
@@ -1016,27 +915,27 @@ upsert descriptor #104
   +      - i
   +      keySuffixColumnIds:
   +      - 2
-  +      name: crdb_internal_index_15_name_placeholder
+  +      name: t_i_key
          partitioning: {}
   -      predicate: j <= 0:::INT8
          sharded: {}
          storeColumnNames: []
   +      unique: true
-  +      useDeletePreservingEncoding: true
          vecConfig: {}
          version: 4
        mutationId: 1
   -    state: WRITE_ONLY
-  +    state: DELETE_ONLY
-     - direction: DROP
+  -  - direction: DROP
+  +    state: BACKFILLING
+  +  - direction: ADD
        index:
   -      constraintId: 5
-  +      createdAtNanos: "1640995200000000000"
+  +      constraintId: 9
          createdExplicitly: true
          foreignKey: {}
          geoConfig: {}
   -      id: 11
-  +      id: 2
+  +      id: 15
          interleave: {}
          keyColumnDirections:
          - ASC
@@ -1047,19 +946,20 @@ upsert descriptor #104
   -      - j
   -      name: crdb_internal_index_11_name_placeholder
   +      - i
-  +      name: t_i_idx
+  +      keySuffixColumnIds:
+  +      - 2
+  +      name: crdb_internal_index_15_name_placeholder
          partitioning: {}
   -      predicate: j <= 0:::INT8
-  +      predicate: i <= 0:::INT8
          sharded: {}
-  -      storeColumnNames: []
-  -      useDeletePreservingEncoding: true
+         storeColumnNames: []
+  +      unique: true
+         useDeletePreservingEncoding: true
          vecConfig: {}
-         version: 4
+  ...
        mutationId: 1
-  -    state: DELETE_ONLY
+       state: DELETE_ONLY
   -  - direction: ADD
-  +    state: WRITE_ONLY
   +  - direction: DROP
        index:
   -      constraintId: 6
@@ -1069,19 +969,41 @@ upsert descriptor #104
          foreignKey: {}
          geoConfig: {}
   -      id: 12
-  +      id: 4
+  +      id: 2
          interleave: {}
          keyColumnDirections:
          - ASC
          keyColumnIds:
   -      - 3
-  +      - 2
+  +      - 1
          keyColumnNames:
   -      - k
-  +      - j
-         keySuffixColumnIds:
-  -      - 2
+  -      keySuffixColumnIds:
+  +      - i
+  +      name: t_i_idx
+  +      partitioning: {}
+  +      predicate: i <= 0:::INT8
+  +      sharded: {}
+  +      vecConfig: {}
+  +      version: 4
+  +    mutationId: 1
+  +    state: WRITE_ONLY
+  +  - direction: DROP
+  +    index:
+  +      createdAtNanos: "1640995200000000000"
+  +      createdExplicitly: true
+  +      foreignKey: {}
+  +      geoConfig: {}
+  +      id: 4
+  +      interleave: {}
+  +      keyColumnDirections:
+  +      - ASC
+  +      keyColumnIds:
+         - 2
   -      name: crdb_internal_index_12_name_placeholder
+  +      keyColumnNames:
+  +      - j
+  +      keySuffixColumnIds:
   +      - 1
   +      name: t_j_idx
          partitioning: {}
@@ -1120,39 +1042,6 @@ upsert descriptor #104
   +    state: WRITE_ONLY
      name: t
      nextColumnId: 4
-  ...
-     parentId: 100
-     primaryIndex:
-  -    constraintId: 1
-  -    createdAtNanos: "1640995200000000000"
-  +    constraintId: 10
-  +    createdExplicitly: true
-       encodingType: 1
-       foreignKey: {}
-       geoConfig: {}
-  -    id: 1
-  +    id: 16
-       interleave: {}
-       keyColumnDirections:
-       - ASC
-       keyColumnIds:
-  -    - 1
-  +    - 2
-       keyColumnNames:
-  -    - i
-  +    - j
-       name: t_pkey
-       partitioning: {}
-       sharded: {}
-       storeColumnIds:
-  -    - 2
-  +    - 1
-       - 3
-       storeColumnNames:
-  -    - j
-  +    - i
-       - k
-       unique: true
   ...
        time: {}
      unexposedParentSchemaId: 101
@@ -1256,7 +1145,7 @@ begin transaction #17
 validate forward indexes [14] in table #104
 commit transaction #17
 begin transaction #18
-## PostCommitNonRevertiblePhase stage 1 of 2 with 36 MutationType ops
+## PostCommitNonRevertiblePhase stage 1 of 3 with 36 MutationType ops
 upsert descriptor #104
   ...
            statement: ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (j)
@@ -1291,14 +1180,14 @@ upsert descriptor #104
   +    version: 4
      modificationTime: {}
      mutations:
-     - direction: DROP
-       index:
-  -      constraintId: 11
+  -  - direction: ADD
+  -    index:
+  -      constraintId: 10
   -      createdExplicitly: true
   -      encodingType: 1
   -      foreignKey: {}
   -      geoConfig: {}
-  -      id: 17
+  -      id: 16
   -      interleave: {}
   -      keyColumnDirections:
   -      - ASC
@@ -1306,11 +1195,42 @@ upsert descriptor #104
   -      - 2
   -      keyColumnNames:
   -      - j
-  -      name: crdb_internal_index_17_name_placeholder
+  -      name: crdb_internal_index_16_name_placeholder
   -      partitioning: {}
   -      sharded: {}
   -      storeColumnIds:
   -      - 1
+  -      - 3
+  -      storeColumnNames:
+  -      - i
+  -      - k
+  -      unique: true
+  -      vecConfig: {}
+  -      version: 4
+  -    mutationId: 1
+  -    state: WRITE_ONLY
+     - direction: DROP
+       index:
+  -      constraintId: 11
+  +      createdAtNanos: "1640995200000000000"
+         createdExplicitly: true
+  -      encodingType: 1
+         foreignKey: {}
+         geoConfig: {}
+  -      id: 17
+  +      id: 2
+         interleave: {}
+         keyColumnDirections:
+         - ASC
+         keyColumnIds:
+  -      - 2
+  -      keyColumnNames:
+  -      - j
+  -      name: crdb_internal_index_17_name_placeholder
+  -      partitioning: {}
+  -      sharded: {}
+  -      storeColumnIds:
+         - 1
   -      - 3
   -      storeColumnNames:
   -      - i
@@ -1333,59 +1253,60 @@ upsert descriptor #104
   -      - ASC
   -      keyColumnIds:
   -      - 1
-  -      keyColumnNames:
-  -      - i
+         keyColumnNames:
+         - i
   -      keySuffixColumnIds:
   -      - 2
   -      name: crdb_internal_index_9_name_placeholder
-  -      partitioning: {}
+  +      name: crdb_internal_index_2_name_placeholder
+         partitioning: {}
   -      predicate: i <= 0:::INT8
-  -      sharded: {}
+         sharded: {}
   -      storeColumnNames: []
   -      useDeletePreservingEncoding: true
-  -      vecConfig: {}
-  -      version: 4
-  -    mutationId: 1
-  -    state: DELETE_ONLY
-  -  - direction: DROP
-  -    index:
+         vecConfig: {}
+         version: 4
+  ...
+     - direction: DROP
+       index:
   -      constraintId: 5
-  -      createdExplicitly: true
-  -      foreignKey: {}
-  -      geoConfig: {}
+  +      createdAtNanos: "1640995200000000000"
+         createdExplicitly: true
+         foreignKey: {}
+         geoConfig: {}
   -      id: 11
-  -      interleave: {}
-  -      keyColumnDirections:
-  -      - ASC
-  -      keyColumnIds:
-  -      - 2
-  -      keyColumnNames:
-  -      - j
+  +      id: 4
+         interleave: {}
+         keyColumnDirections:
+  ...
+         keyColumnNames:
+         - j
   -      name: crdb_internal_index_11_name_placeholder
-  -      partitioning: {}
+  +      keySuffixColumnIds:
+  +      - 1
+  +      name: crdb_internal_index_4_name_placeholder
+         partitioning: {}
   -      predicate: j <= 0:::INT8
-  -      sharded: {}
+         sharded: {}
   -      storeColumnNames: []
   -      useDeletePreservingEncoding: true
-  -      vecConfig: {}
-  -      version: 4
-  -    mutationId: 1
-  -    state: DELETE_ONLY
-  -  - direction: DROP
-  -    index:
+         vecConfig: {}
+         version: 4
+  ...
+     - direction: DROP
+       index:
   -      constraintId: 7
-  -      createdExplicitly: true
-  -      foreignKey: {}
-  -      geoConfig: {}
+  +      createdAtNanos: "1640995200000000000"
+         createdExplicitly: true
+         foreignKey: {}
+         geoConfig: {}
   -      id: 13
-  -      interleave: {}
-  -      keyColumnDirections:
-  -      - ASC
-  -      keyColumnIds:
-  -      - 3
-  -      keyColumnNames:
-  -      - k
-  -      keySuffixColumnIds:
+  +      id: 6
+         interleave: {}
+         keyColumnDirections:
+  ...
+         - k
+         keySuffixColumnIds:
   -      - 2
   -      name: crdb_internal_index_13_name_placeholder
   -      partitioning: {}
@@ -1396,14 +1317,6 @@ upsert descriptor #104
   -      version: 4
   -    mutationId: 1
   -    state: DELETE_ONLY
-  -  - direction: DROP
-  -    index:
-         constraintId: 1
-         createdAtNanos: "1640995200000000000"
-  ...
-         version: 4
-       mutationId: 1
-  -    state: WRITE_ONLY
   -  - direction: ADD
   -    index:
   -      constraintId: 8
@@ -1416,19 +1329,20 @@ upsert descriptor #104
   -      keyColumnDirections:
   -      - ASC
   -      keyColumnIds:
-  -      - 1
+         - 1
   -      keyColumnNames:
   -      - i
   -      keySuffixColumnIds:
   -      - 2
   -      name: t_i_key
-  -      partitioning: {}
-  -      sharded: {}
+  +      name: crdb_internal_index_6_name_placeholder
+         partitioning: {}
+         sharded: {}
   -      storeColumnNames: []
   -      unique: true
-  -      vecConfig: {}
-  -      version: 4
-  -    mutationId: 1
+         vecConfig: {}
+         version: 4
+       mutationId: 1
   -    state: WRITE_ONLY
   -  - direction: DROP
   -    index:
@@ -1457,43 +1371,196 @@ upsert descriptor #104
   -    mutationId: 1
        state: DELETE_ONLY
      - direction: DROP
+       index:
+  +      constraintId: 1
+         createdAtNanos: "1640995200000000000"
+  -      createdExplicitly: true
+  +      encodingType: 1
+         foreignKey: {}
+         geoConfig: {}
+  -      id: 2
+  +      id: 1
+         interleave: {}
+         keyColumnDirections:
   ...
          keyColumnNames:
          - i
   -      name: t_i_idx
-  +      name: crdb_internal_index_2_name_placeholder
+  +      name: crdb_internal_index_1_name_placeholder
          partitioning: {}
   -      predicate: i <= 0:::INT8
          sharded: {}
-         vecConfig: {}
-         version: 4
-       mutationId: 1
+  -      vecConfig: {}
+  -      version: 4
+  -    mutationId: 1
   -    state: WRITE_ONLY
-  +    state: DELETE_ONLY
-     - direction: DROP
-       index:
-  ...
-         keySuffixColumnIds:
-         - 1
+  -  - direction: DROP
+  -    index:
+  -      createdAtNanos: "1640995200000000000"
+  -      createdExplicitly: true
+  -      foreignKey: {}
+  -      geoConfig: {}
+  -      id: 4
+  -      interleave: {}
+  -      keyColumnDirections:
+  -      - ASC
+  -      keyColumnIds:
+  +      storeColumnIds:
+         - 2
+  -      keyColumnNames:
+  -      - j
+  -      keySuffixColumnIds:
+  -      - 1
   -      name: t_j_idx
-  +      name: crdb_internal_index_4_name_placeholder
-         partitioning: {}
+  -      partitioning: {}
   -      predicate: j <= 0:::INT8
-         sharded: {}
+  -      sharded: {}
+  -      vecConfig: {}
+  -      version: 4
+  -    mutationId: 1
+  -    state: WRITE_ONLY
+  -  - direction: DROP
+  -    index:
+  -      createdAtNanos: "1640995200000000000"
+  -      createdExplicitly: true
+  -      foreignKey: {}
+  -      geoConfig: {}
+  -      id: 6
+  -      interleave: {}
+  -      keyColumnDirections:
+  -      - ASC
+  -      keyColumnIds:
+         - 3
+  -      keyColumnNames:
+  +      storeColumnNames:
+  +      - j
+         - k
+  -      keySuffixColumnIds:
+  -      - 1
+  -      name: t_k_idx
+  -      partitioning: {}
+  -      sharded: {}
+  +      unique: true
          vecConfig: {}
          version: 4
-       mutationId: 1
-  -    state: WRITE_ONLY
-  +    state: DELETE_ONLY
+  ...
+     parentId: 100
+     primaryIndex:
+  -    constraintId: 1
+  -    createdAtNanos: "1640995200000000000"
+  +    constraintId: 10
+  +    createdExplicitly: true
+       encodingType: 1
+       foreignKey: {}
+       geoConfig: {}
+  -    id: 1
+  +    id: 16
+       interleave: {}
+       keyColumnDirections:
+       - ASC
+       keyColumnIds:
+  -    - 1
+  +    - 2
+       keyColumnNames:
+  -    - i
+  +    - j
+       name: t_pkey
+       partitioning: {}
+       sharded: {}
+       storeColumnIds:
+  -    - 2
+  +    - 1
+       - 3
+       storeColumnNames:
+  -    - j
+  +    - i
+       - k
+       unique: true
+  ...
+       time: {}
+     unexposedParentSchemaId: 101
+  -  version: "29"
+  +  version: "30"
+persist all catalog changes to storage
+adding table for stats refresh: 104
+update progress of schema change job #1: "PostCommitNonRevertiblePhase stage 2 of 3 with 7 MutationType ops pending"
+set schema change job #1 to non-cancellable
+commit transaction #18
+begin transaction #19
+## PostCommitNonRevertiblePhase stage 2 of 3 with 9 MutationType ops
+upsert descriptor #104
+  ...
      - direction: DROP
        index:
-  ...
-         keySuffixColumnIds:
-         - 1
-  -      name: t_k_idx
-  +      name: crdb_internal_index_6_name_placeholder
-         partitioning: {}
-         sharded: {}
+  -      createdAtNanos: "1640995200000000000"
+  -      createdExplicitly: true
+  -      foreignKey: {}
+  -      geoConfig: {}
+  -      id: 2
+  -      interleave: {}
+  -      keyColumnDirections:
+  -      - ASC
+  -      keyColumnIds:
+  -      - 1
+  -      keyColumnNames:
+  -      - i
+  -      name: crdb_internal_index_2_name_placeholder
+  -      partitioning: {}
+  -      sharded: {}
+  -      vecConfig: {}
+  -      version: 4
+  -    mutationId: 1
+  -    state: DELETE_ONLY
+  -  - direction: DROP
+  -    index:
+  -      createdAtNanos: "1640995200000000000"
+  -      createdExplicitly: true
+  -      foreignKey: {}
+  -      geoConfig: {}
+  -      id: 4
+  -      interleave: {}
+  -      keyColumnDirections:
+  -      - ASC
+  -      keyColumnIds:
+  -      - 2
+  -      keyColumnNames:
+  -      - j
+  -      keySuffixColumnIds:
+  -      - 1
+  -      name: crdb_internal_index_4_name_placeholder
+  -      partitioning: {}
+  -      sharded: {}
+  -      vecConfig: {}
+  -      version: 4
+  -    mutationId: 1
+  -    state: DELETE_ONLY
+  -  - direction: DROP
+  -    index:
+  -      createdAtNanos: "1640995200000000000"
+  -      createdExplicitly: true
+  -      foreignKey: {}
+  -      geoConfig: {}
+  -      id: 6
+  -      interleave: {}
+  -      keyColumnDirections:
+  -      - ASC
+  -      keyColumnIds:
+  -      - 3
+  -      keyColumnNames:
+  -      - k
+  -      keySuffixColumnIds:
+  -      - 1
+  -      name: crdb_internal_index_6_name_placeholder
+  -      partitioning: {}
+  -      sharded: {}
+  -      vecConfig: {}
+  -      version: 4
+  -    mutationId: 1
+  -    state: DELETE_ONLY
+  -  - direction: DROP
+  -    index:
+         constraintId: 1
+         createdAtNanos: "1640995200000000000"
   ...
          version: 4
        mutationId: 1
@@ -1504,15 +1571,13 @@ upsert descriptor #104
   ...
        time: {}
      unexposedParentSchemaId: 101
-  -  version: "29"
-  +  version: "30"
+  -  version: "30"
+  +  version: "31"
 persist all catalog changes to storage
-adding table for stats refresh: 104
-update progress of schema change job #1: "PostCommitNonRevertiblePhase stage 2 of 2 with 13 MutationType ops pending"
-set schema change job #1 to non-cancellable
-commit transaction #18
-begin transaction #19
-## PostCommitNonRevertiblePhase stage 2 of 2 with 15 MutationType ops
+update progress of schema change job #1: "PostCommitNonRevertiblePhase stage 3 of 3 with 10 MutationType ops pending"
+commit transaction #19
+begin transaction #20
+## PostCommitNonRevertiblePhase stage 3 of 3 with 12 MutationType ops
 upsert descriptor #104
   ...
      createAsOfTime:
@@ -1583,81 +1648,14 @@ upsert descriptor #104
   -      version: 4
   -    mutationId: 1
   -    state: DELETE_ONLY
-  -  - direction: DROP
-  -    index:
-  -      createdAtNanos: "1640995200000000000"
-  -      createdExplicitly: true
-  -      foreignKey: {}
-  -      geoConfig: {}
-  -      id: 2
-  -      interleave: {}
-  -      keyColumnDirections:
-  -      - ASC
-  -      keyColumnIds:
-  -      - 1
-  -      keyColumnNames:
-  -      - i
-  -      name: crdb_internal_index_2_name_placeholder
-  -      partitioning: {}
-  -      sharded: {}
-  -      vecConfig: {}
-  -      version: 4
-  -    mutationId: 1
-  -    state: DELETE_ONLY
-  -  - direction: DROP
-  -    index:
-  -      createdAtNanos: "1640995200000000000"
-  -      createdExplicitly: true
-  -      foreignKey: {}
-  -      geoConfig: {}
-  -      id: 4
-  -      interleave: {}
-  -      keyColumnDirections:
-  -      - ASC
-  -      keyColumnIds:
-  -      - 2
-  -      keyColumnNames:
-  -      - j
-  -      keySuffixColumnIds:
-  -      - 1
-  -      name: crdb_internal_index_4_name_placeholder
-  -      partitioning: {}
-  -      sharded: {}
-  -      vecConfig: {}
-  -      version: 4
-  -    mutationId: 1
-  -    state: DELETE_ONLY
-  -  - direction: DROP
-  -    index:
-  -      createdAtNanos: "1640995200000000000"
-  -      createdExplicitly: true
-  -      foreignKey: {}
-  -      geoConfig: {}
-  -      id: 6
-  -      interleave: {}
-  -      keyColumnDirections:
-  -      - ASC
-  -      keyColumnIds:
-  -      - 3
-  -      keyColumnNames:
-  -      - k
-  -      keySuffixColumnIds:
-  -      - 1
-  -      name: crdb_internal_index_6_name_placeholder
-  -      partitioning: {}
-  -      sharded: {}
-  -      vecConfig: {}
-  -      version: 4
-  -    mutationId: 1
-  -    state: DELETE_ONLY
   +  mutations: []
      name: t
      nextColumnId: 4
   ...
        time: {}
      unexposedParentSchemaId: 101
-  -  version: "30"
-  +  version: "31"
+  -  version: "31"
+  +  version: "32"
 persist all catalog changes to storage
 create job #2 (non-cancelable: true): "GC for ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY USING COLUMNS (j)"
   descriptor IDs: [104]
@@ -1667,6 +1665,6 @@ updated schema change job #1 descriptor IDs to []
 write *eventpb.FinishSchemaChange to event log:
   sc:
     descriptorId: 104
-commit transaction #19
+commit transaction #20
 notified job registry to adopt jobs: [2]
 # end PostCommitPhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_vanilla/alter_table_alter_primary_key_vanilla__rollback_10_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_vanilla/alter_table_alter_primary_key_vanilla__rollback_10_of_15.explain
@@ -12,15 +12,15 @@ EXPLAIN (DDL) rollback at post-commit stage 10 of 15;
 Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY USING COLUMNS (j);
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 5 elements transitioning toward PUBLIC
-      │    │    ├── VALIDATED             → PUBLIC      PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey+), ConstraintID: 1}
-      │    │    ├── ABSENT                → PUBLIC      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey+)}
+      │    ├── 3 elements transitioning toward PUBLIC
       │    │    ├── VALIDATED             → PUBLIC      SecondaryIndex:{DescID: 104 (t), IndexID: 2 (t_i_idx+), RecreateSourceIndexID: 0}
       │    │    ├── VALIDATED             → PUBLIC      SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_j_idx+), RecreateSourceIndexID: 0}
       │    │    └── VALIDATED             → PUBLIC      SecondaryIndex:{DescID: 104 (t), IndexID: 6 (t_k_idx+), RecreateSourceIndexID: 0}
-      │    ├── 24 elements transitioning toward ABSENT
-      │    │    ├── PUBLIC                → VALIDATED   PrimaryIndex:{DescID: 104 (t), IndexID: 16 (t_pkey-), ConstraintID: 10, TemporaryIndexID: 17, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 16 (t_pkey-)}
+      │    ├── 26 elements transitioning toward ABSENT
+      │    │    ├── VALIDATED             → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 16 (t_pkey-), ConstraintID: 10, TemporaryIndexID: 17, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 16 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 16 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 16 (t_pkey-)}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 17, ConstraintID: 11, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 17}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 17}
@@ -44,15 +44,12 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 15}
       │    │    └── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_i_key", IndexID: 14 (t_i_key-)}
       │    └── 34 Mutation operations
-      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":2,"TableID":104}
       │         ├── RefreshStats {"TableID":104}
       │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":4,"TableID":104}
       │         ├── RefreshStats {"TableID":104}
       │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":6,"TableID":104}
       │         ├── RefreshStats {"TableID":104}
-      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":16,"TableID":104}
-      │         ├── SetIndexName {"IndexID":16,"Name":"crdb_internal_in...","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":17,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":17,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":17,"Kind":2,"Ordinal":1,"TableID":104}
@@ -70,7 +67,10 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":14,"Kind":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":15,"Kind":1,"TableID":104}
       │         ├── SetIndexName {"IndexID":14,"Name":"crdb_internal_in...","TableID":104}
-      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":16,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":16,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":16,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":16,"Kind":2,"Ordinal":1,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":17,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":11,"TableID":104}
@@ -79,11 +79,8 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 16 elements transitioning toward ABSENT
-      │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 16 (t_pkey-), ConstraintID: 10, TemporaryIndexID: 17, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 16 (t_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 16 (t_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 16 (t_pkey-)}
+      │    ├── 13 elements transitioning toward ABSENT
+      │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 16 (t_pkey-), ConstraintID: 10, TemporaryIndexID: 17, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx-), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2}
       │    │    ├── PUBLIC      → ABSENT      IndexName:{DescID: 104 (t), Name: "t_i_idx", IndexID: 8 (t_i_idx-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 8 (t_i_idx-)}
@@ -96,12 +93,9 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 12 (t_k_idx-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 12 (t_k_idx-)}
       │    │    └── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 15, ConstraintID: 9, SourceIndexID: 16 (t_pkey-)}
-      │    └── 20 Mutation operations
+      │    └── 17 Mutation operations
+      │         ├── MakeIndexAbsent {"IndexID":16,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":15,"TableID":104}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":16,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":16,"Kind":2,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":16,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":16,"Kind":2,"Ordinal":1,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":104}
       │         ├── RemoveDroppedIndexPartialPredicate {"IndexID":8,"TableID":104}
       │         ├── SetIndexName {"IndexID":8,"Name":"crdb_internal_in...","TableID":104}
@@ -118,8 +112,7 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 3 of 3 in PostCommitNonRevertiblePhase
-           ├── 14 elements transitioning toward ABSENT
-           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 16 (t_pkey-), ConstraintID: 10, TemporaryIndexID: 17, SourceIndexID: 1 (t_pkey+)}
+           ├── 13 elements transitioning toward ABSENT
            │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 16 (t_pkey-)}
            │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 17}
            │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx-), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2}
@@ -133,8 +126,7 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
            │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 13}
            │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 14 (t_i_key-)}
            │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 15}
-           └── 16 Mutation operations
-                ├── MakeIndexAbsent {"IndexID":16,"TableID":104}
+           └── 15 Mutation operations
                 ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
                 ├── CreateGCJobForIndex {"IndexID":8,"TableID":104}
                 ├── CreateGCJobForIndex {"IndexID":9,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_vanilla/alter_table_alter_primary_key_vanilla__rollback_11_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_vanilla/alter_table_alter_primary_key_vanilla__rollback_11_of_15.explain
@@ -12,15 +12,15 @@ EXPLAIN (DDL) rollback at post-commit stage 11 of 15;
 Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY USING COLUMNS (j);
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 5 elements transitioning toward PUBLIC
-      │    │    ├── VALIDATED             → PUBLIC      PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey+), ConstraintID: 1}
-      │    │    ├── ABSENT                → PUBLIC      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey+)}
+      │    ├── 3 elements transitioning toward PUBLIC
       │    │    ├── VALIDATED             → PUBLIC      SecondaryIndex:{DescID: 104 (t), IndexID: 2 (t_i_idx+), RecreateSourceIndexID: 0}
       │    │    ├── VALIDATED             → PUBLIC      SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_j_idx+), RecreateSourceIndexID: 0}
       │    │    └── VALIDATED             → PUBLIC      SecondaryIndex:{DescID: 104 (t), IndexID: 6 (t_k_idx+), RecreateSourceIndexID: 0}
-      │    ├── 24 elements transitioning toward ABSENT
-      │    │    ├── PUBLIC                → VALIDATED   PrimaryIndex:{DescID: 104 (t), IndexID: 16 (t_pkey-), ConstraintID: 10, TemporaryIndexID: 17, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 16 (t_pkey-)}
+      │    ├── 26 elements transitioning toward ABSENT
+      │    │    ├── VALIDATED             → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 16 (t_pkey-), ConstraintID: 10, TemporaryIndexID: 17, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 16 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 16 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 16 (t_pkey-)}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 17, ConstraintID: 11, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 17}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 17}
@@ -44,15 +44,12 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 15}
       │    │    └── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_i_key", IndexID: 14 (t_i_key-)}
       │    └── 34 Mutation operations
-      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":2,"TableID":104}
       │         ├── RefreshStats {"TableID":104}
       │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":4,"TableID":104}
       │         ├── RefreshStats {"TableID":104}
       │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":6,"TableID":104}
       │         ├── RefreshStats {"TableID":104}
-      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":16,"TableID":104}
-      │         ├── SetIndexName {"IndexID":16,"Name":"crdb_internal_in...","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":17,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":17,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":17,"Kind":2,"Ordinal":1,"TableID":104}
@@ -70,7 +67,10 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":14,"Kind":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":15,"Kind":1,"TableID":104}
       │         ├── SetIndexName {"IndexID":14,"Name":"crdb_internal_in...","TableID":104}
-      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":16,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":16,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":16,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":16,"Kind":2,"Ordinal":1,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":17,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":11,"TableID":104}
@@ -79,11 +79,8 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 16 elements transitioning toward ABSENT
-      │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 16 (t_pkey-), ConstraintID: 10, TemporaryIndexID: 17, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 16 (t_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 16 (t_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 16 (t_pkey-)}
+      │    ├── 13 elements transitioning toward ABSENT
+      │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 16 (t_pkey-), ConstraintID: 10, TemporaryIndexID: 17, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx-), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2}
       │    │    ├── PUBLIC      → ABSENT      IndexName:{DescID: 104 (t), Name: "t_i_idx", IndexID: 8 (t_i_idx-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 8 (t_i_idx-)}
@@ -96,12 +93,9 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 12 (t_k_idx-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 12 (t_k_idx-)}
       │    │    └── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 15, ConstraintID: 9, SourceIndexID: 16 (t_pkey-)}
-      │    └── 20 Mutation operations
+      │    └── 17 Mutation operations
+      │         ├── MakeIndexAbsent {"IndexID":16,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":15,"TableID":104}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":16,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":16,"Kind":2,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":16,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":16,"Kind":2,"Ordinal":1,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":104}
       │         ├── RemoveDroppedIndexPartialPredicate {"IndexID":8,"TableID":104}
       │         ├── SetIndexName {"IndexID":8,"Name":"crdb_internal_in...","TableID":104}
@@ -118,8 +112,7 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 3 of 3 in PostCommitNonRevertiblePhase
-           ├── 14 elements transitioning toward ABSENT
-           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 16 (t_pkey-), ConstraintID: 10, TemporaryIndexID: 17, SourceIndexID: 1 (t_pkey+)}
+           ├── 13 elements transitioning toward ABSENT
            │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 16 (t_pkey-)}
            │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 17}
            │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx-), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2}
@@ -133,8 +126,7 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
            │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 13}
            │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 14 (t_i_key-)}
            │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 15}
-           └── 16 Mutation operations
-                ├── MakeIndexAbsent {"IndexID":16,"TableID":104}
+           └── 15 Mutation operations
                 ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
                 ├── CreateGCJobForIndex {"IndexID":8,"TableID":104}
                 ├── CreateGCJobForIndex {"IndexID":9,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_vanilla/alter_table_alter_primary_key_vanilla__rollback_12_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_vanilla/alter_table_alter_primary_key_vanilla__rollback_12_of_15.explain
@@ -12,15 +12,15 @@ EXPLAIN (DDL) rollback at post-commit stage 12 of 15;
 Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY USING COLUMNS (j);
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 5 elements transitioning toward PUBLIC
-      │    │    ├── VALIDATED             → PUBLIC      PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey+), ConstraintID: 1}
-      │    │    ├── ABSENT                → PUBLIC      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey+)}
+      │    ├── 3 elements transitioning toward PUBLIC
       │    │    ├── VALIDATED             → PUBLIC      SecondaryIndex:{DescID: 104 (t), IndexID: 2 (t_i_idx+), RecreateSourceIndexID: 0}
       │    │    ├── VALIDATED             → PUBLIC      SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_j_idx+), RecreateSourceIndexID: 0}
       │    │    └── VALIDATED             → PUBLIC      SecondaryIndex:{DescID: 104 (t), IndexID: 6 (t_k_idx+), RecreateSourceIndexID: 0}
-      │    ├── 24 elements transitioning toward ABSENT
-      │    │    ├── PUBLIC                → VALIDATED   PrimaryIndex:{DescID: 104 (t), IndexID: 16 (t_pkey-), ConstraintID: 10, TemporaryIndexID: 17, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 16 (t_pkey-)}
+      │    ├── 26 elements transitioning toward ABSENT
+      │    │    ├── VALIDATED             → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 16 (t_pkey-), ConstraintID: 10, TemporaryIndexID: 17, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 16 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 16 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 16 (t_pkey-)}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 17, ConstraintID: 11, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 17}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 17}
@@ -44,15 +44,12 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 15}
       │    │    └── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_i_key", IndexID: 14 (t_i_key-)}
       │    └── 34 Mutation operations
-      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":2,"TableID":104}
       │         ├── RefreshStats {"TableID":104}
       │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":4,"TableID":104}
       │         ├── RefreshStats {"TableID":104}
       │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":6,"TableID":104}
       │         ├── RefreshStats {"TableID":104}
-      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":16,"TableID":104}
-      │         ├── SetIndexName {"IndexID":16,"Name":"crdb_internal_in...","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":17,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":17,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":17,"Kind":2,"Ordinal":1,"TableID":104}
@@ -70,7 +67,10 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":14,"Kind":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":15,"Kind":1,"TableID":104}
       │         ├── SetIndexName {"IndexID":14,"Name":"crdb_internal_in...","TableID":104}
-      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":16,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":16,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":16,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":16,"Kind":2,"Ordinal":1,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":17,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":11,"TableID":104}
@@ -79,11 +79,8 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 16 elements transitioning toward ABSENT
-      │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 16 (t_pkey-), ConstraintID: 10, TemporaryIndexID: 17, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 16 (t_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 16 (t_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 16 (t_pkey-)}
+      │    ├── 13 elements transitioning toward ABSENT
+      │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 16 (t_pkey-), ConstraintID: 10, TemporaryIndexID: 17, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx-), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2}
       │    │    ├── PUBLIC      → ABSENT      IndexName:{DescID: 104 (t), Name: "t_i_idx", IndexID: 8 (t_i_idx-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 8 (t_i_idx-)}
@@ -96,12 +93,9 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 12 (t_k_idx-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 12 (t_k_idx-)}
       │    │    └── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 15, ConstraintID: 9, SourceIndexID: 16 (t_pkey-)}
-      │    └── 20 Mutation operations
+      │    └── 17 Mutation operations
+      │         ├── MakeIndexAbsent {"IndexID":16,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":15,"TableID":104}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":16,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":16,"Kind":2,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":16,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":16,"Kind":2,"Ordinal":1,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":104}
       │         ├── RemoveDroppedIndexPartialPredicate {"IndexID":8,"TableID":104}
       │         ├── SetIndexName {"IndexID":8,"Name":"crdb_internal_in...","TableID":104}
@@ -118,8 +112,7 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 3 of 3 in PostCommitNonRevertiblePhase
-           ├── 14 elements transitioning toward ABSENT
-           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 16 (t_pkey-), ConstraintID: 10, TemporaryIndexID: 17, SourceIndexID: 1 (t_pkey+)}
+           ├── 13 elements transitioning toward ABSENT
            │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 16 (t_pkey-)}
            │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 17}
            │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx-), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2}
@@ -133,8 +126,7 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
            │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 13}
            │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 14 (t_i_key-)}
            │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 15}
-           └── 16 Mutation operations
-                ├── MakeIndexAbsent {"IndexID":16,"TableID":104}
+           └── 15 Mutation operations
                 ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
                 ├── CreateGCJobForIndex {"IndexID":8,"TableID":104}
                 ├── CreateGCJobForIndex {"IndexID":9,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_vanilla/alter_table_alter_primary_key_vanilla__rollback_13_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_vanilla/alter_table_alter_primary_key_vanilla__rollback_13_of_15.explain
@@ -12,15 +12,15 @@ EXPLAIN (DDL) rollback at post-commit stage 13 of 15;
 Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY USING COLUMNS (j);
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 5 elements transitioning toward PUBLIC
-      │    │    ├── VALIDATED             → PUBLIC      PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey+), ConstraintID: 1}
-      │    │    ├── ABSENT                → PUBLIC      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey+)}
+      │    ├── 3 elements transitioning toward PUBLIC
       │    │    ├── VALIDATED             → PUBLIC      SecondaryIndex:{DescID: 104 (t), IndexID: 2 (t_i_idx+), RecreateSourceIndexID: 0}
       │    │    ├── VALIDATED             → PUBLIC      SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_j_idx+), RecreateSourceIndexID: 0}
       │    │    └── VALIDATED             → PUBLIC      SecondaryIndex:{DescID: 104 (t), IndexID: 6 (t_k_idx+), RecreateSourceIndexID: 0}
-      │    ├── 24 elements transitioning toward ABSENT
-      │    │    ├── PUBLIC                → VALIDATED   PrimaryIndex:{DescID: 104 (t), IndexID: 16 (t_pkey-), ConstraintID: 10, TemporaryIndexID: 17, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 16 (t_pkey-)}
+      │    ├── 26 elements transitioning toward ABSENT
+      │    │    ├── VALIDATED             → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 16 (t_pkey-), ConstraintID: 10, TemporaryIndexID: 17, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 16 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 16 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 16 (t_pkey-)}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 17, ConstraintID: 11, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 17}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 17}
@@ -44,15 +44,12 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 15}
       │    │    └── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_i_key", IndexID: 14 (t_i_key-)}
       │    └── 34 Mutation operations
-      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":2,"TableID":104}
       │         ├── RefreshStats {"TableID":104}
       │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":4,"TableID":104}
       │         ├── RefreshStats {"TableID":104}
       │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":6,"TableID":104}
       │         ├── RefreshStats {"TableID":104}
-      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":16,"TableID":104}
-      │         ├── SetIndexName {"IndexID":16,"Name":"crdb_internal_in...","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":17,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":17,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":17,"Kind":2,"Ordinal":1,"TableID":104}
@@ -67,7 +64,10 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":15,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":15,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":15,"Kind":1,"TableID":104}
-      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":16,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":16,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":16,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":16,"Kind":2,"Ordinal":1,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":17,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":11,"TableID":104}
@@ -79,11 +79,8 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 17 elements transitioning toward ABSENT
-      │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 16 (t_pkey-), ConstraintID: 10, TemporaryIndexID: 17, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 16 (t_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 16 (t_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 16 (t_pkey-)}
+      │    ├── 14 elements transitioning toward ABSENT
+      │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 16 (t_pkey-), ConstraintID: 10, TemporaryIndexID: 17, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx-), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2}
       │    │    ├── PUBLIC      → ABSENT      IndexName:{DescID: 104 (t), Name: "t_i_idx", IndexID: 8 (t_i_idx-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 8 (t_i_idx-)}
@@ -97,13 +94,10 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 12 (t_k_idx-)}
       │    │    ├── DELETE_ONLY → ABSENT      SecondaryIndex:{DescID: 104 (t), IndexID: 14 (t_i_key-), ConstraintID: 8, TemporaryIndexID: 15, SourceIndexID: 16 (t_pkey-), RecreateSourceIndexID: 0}
       │    │    └── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 15, ConstraintID: 9, SourceIndexID: 16 (t_pkey-)}
-      │    └── 21 Mutation operations
+      │    └── 18 Mutation operations
+      │         ├── MakeIndexAbsent {"IndexID":16,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":14,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":15,"TableID":104}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":16,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":16,"Kind":2,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":16,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":16,"Kind":2,"Ordinal":1,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":104}
       │         ├── RemoveDroppedIndexPartialPredicate {"IndexID":8,"TableID":104}
       │         ├── SetIndexName {"IndexID":8,"Name":"crdb_internal_in...","TableID":104}
@@ -120,8 +114,7 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 3 of 3 in PostCommitNonRevertiblePhase
-           ├── 14 elements transitioning toward ABSENT
-           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 16 (t_pkey-), ConstraintID: 10, TemporaryIndexID: 17, SourceIndexID: 1 (t_pkey+)}
+           ├── 13 elements transitioning toward ABSENT
            │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 16 (t_pkey-)}
            │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 17}
            │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx-), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2}
@@ -135,8 +128,7 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
            │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 13}
            │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 14 (t_i_key-)}
            │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 15}
-           └── 16 Mutation operations
-                ├── MakeIndexAbsent {"IndexID":16,"TableID":104}
+           └── 15 Mutation operations
                 ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
                 ├── CreateGCJobForIndex {"IndexID":8,"TableID":104}
                 ├── CreateGCJobForIndex {"IndexID":9,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_vanilla/alter_table_alter_primary_key_vanilla__rollback_14_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_vanilla/alter_table_alter_primary_key_vanilla__rollback_14_of_15.explain
@@ -12,15 +12,15 @@ EXPLAIN (DDL) rollback at post-commit stage 14 of 15;
 Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY USING COLUMNS (j);
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 5 elements transitioning toward PUBLIC
-      │    │    ├── VALIDATED             → PUBLIC      PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey+), ConstraintID: 1}
-      │    │    ├── ABSENT                → PUBLIC      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey+)}
+      │    ├── 3 elements transitioning toward PUBLIC
       │    │    ├── VALIDATED             → PUBLIC      SecondaryIndex:{DescID: 104 (t), IndexID: 2 (t_i_idx+), RecreateSourceIndexID: 0}
       │    │    ├── VALIDATED             → PUBLIC      SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_j_idx+), RecreateSourceIndexID: 0}
       │    │    └── VALIDATED             → PUBLIC      SecondaryIndex:{DescID: 104 (t), IndexID: 6 (t_k_idx+), RecreateSourceIndexID: 0}
-      │    ├── 24 elements transitioning toward ABSENT
-      │    │    ├── PUBLIC                → VALIDATED   PrimaryIndex:{DescID: 104 (t), IndexID: 16 (t_pkey-), ConstraintID: 10, TemporaryIndexID: 17, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 16 (t_pkey-)}
+      │    ├── 26 elements transitioning toward ABSENT
+      │    │    ├── VALIDATED             → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 16 (t_pkey-), ConstraintID: 10, TemporaryIndexID: 17, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 16 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 16 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 16 (t_pkey-)}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 17, ConstraintID: 11, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 17}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 17}
@@ -44,15 +44,12 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 15}
       │    │    └── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_i_key", IndexID: 14 (t_i_key-)}
       │    └── 34 Mutation operations
-      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":2,"TableID":104}
       │         ├── RefreshStats {"TableID":104}
       │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":4,"TableID":104}
       │         ├── RefreshStats {"TableID":104}
       │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":6,"TableID":104}
       │         ├── RefreshStats {"TableID":104}
-      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":16,"TableID":104}
-      │         ├── SetIndexName {"IndexID":16,"Name":"crdb_internal_in...","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":17,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":17,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":17,"Kind":2,"Ordinal":1,"TableID":104}
@@ -67,7 +64,10 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":15,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":15,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":15,"Kind":1,"TableID":104}
-      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":16,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":16,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":16,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":16,"Kind":2,"Ordinal":1,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":17,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":11,"TableID":104}
@@ -79,11 +79,8 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 17 elements transitioning toward ABSENT
-      │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 16 (t_pkey-), ConstraintID: 10, TemporaryIndexID: 17, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 16 (t_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 16 (t_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 16 (t_pkey-)}
+      │    ├── 14 elements transitioning toward ABSENT
+      │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 16 (t_pkey-), ConstraintID: 10, TemporaryIndexID: 17, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx-), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2}
       │    │    ├── PUBLIC      → ABSENT      IndexName:{DescID: 104 (t), Name: "t_i_idx", IndexID: 8 (t_i_idx-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 8 (t_i_idx-)}
@@ -97,13 +94,10 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 12 (t_k_idx-)}
       │    │    ├── DELETE_ONLY → ABSENT      SecondaryIndex:{DescID: 104 (t), IndexID: 14 (t_i_key-), ConstraintID: 8, TemporaryIndexID: 15, SourceIndexID: 16 (t_pkey-), RecreateSourceIndexID: 0}
       │    │    └── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 15, ConstraintID: 9, SourceIndexID: 16 (t_pkey-)}
-      │    └── 21 Mutation operations
+      │    └── 18 Mutation operations
+      │         ├── MakeIndexAbsent {"IndexID":16,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":14,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":15,"TableID":104}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":16,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":16,"Kind":2,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":16,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":16,"Kind":2,"Ordinal":1,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":104}
       │         ├── RemoveDroppedIndexPartialPredicate {"IndexID":8,"TableID":104}
       │         ├── SetIndexName {"IndexID":8,"Name":"crdb_internal_in...","TableID":104}
@@ -120,8 +114,7 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 3 of 3 in PostCommitNonRevertiblePhase
-           ├── 14 elements transitioning toward ABSENT
-           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 16 (t_pkey-), ConstraintID: 10, TemporaryIndexID: 17, SourceIndexID: 1 (t_pkey+)}
+           ├── 13 elements transitioning toward ABSENT
            │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 16 (t_pkey-)}
            │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 17}
            │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx-), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2}
@@ -135,8 +128,7 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
            │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 13}
            │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 14 (t_i_key-)}
            │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 15}
-           └── 16 Mutation operations
-                ├── MakeIndexAbsent {"IndexID":16,"TableID":104}
+           └── 15 Mutation operations
                 ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
                 ├── CreateGCJobForIndex {"IndexID":8,"TableID":104}
                 ├── CreateGCJobForIndex {"IndexID":9,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_vanilla/alter_table_alter_primary_key_vanilla__rollback_15_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_vanilla/alter_table_alter_primary_key_vanilla__rollback_15_of_15.explain
@@ -12,15 +12,15 @@ EXPLAIN (DDL) rollback at post-commit stage 15 of 15;
 Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY USING COLUMNS (j);
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 5 elements transitioning toward PUBLIC
-      │    │    ├── VALIDATED             → PUBLIC      PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey+), ConstraintID: 1}
-      │    │    ├── ABSENT                → PUBLIC      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey+)}
+      │    ├── 3 elements transitioning toward PUBLIC
       │    │    ├── VALIDATED             → PUBLIC      SecondaryIndex:{DescID: 104 (t), IndexID: 2 (t_i_idx+), RecreateSourceIndexID: 0}
       │    │    ├── VALIDATED             → PUBLIC      SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_j_idx+), RecreateSourceIndexID: 0}
       │    │    └── VALIDATED             → PUBLIC      SecondaryIndex:{DescID: 104 (t), IndexID: 6 (t_k_idx+), RecreateSourceIndexID: 0}
-      │    ├── 24 elements transitioning toward ABSENT
-      │    │    ├── PUBLIC                → VALIDATED   PrimaryIndex:{DescID: 104 (t), IndexID: 16 (t_pkey-), ConstraintID: 10, TemporaryIndexID: 17, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 16 (t_pkey-)}
+      │    ├── 26 elements transitioning toward ABSENT
+      │    │    ├── VALIDATED             → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 16 (t_pkey-), ConstraintID: 10, TemporaryIndexID: 17, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 16 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 16 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 16 (t_pkey-)}
       │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 17, ConstraintID: 11, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 17}
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 17}
@@ -44,15 +44,12 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 15}
       │    │    └── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_i_key", IndexID: 14 (t_i_key-)}
       │    └── 34 Mutation operations
-      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":2,"TableID":104}
       │         ├── RefreshStats {"TableID":104}
       │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":4,"TableID":104}
       │         ├── RefreshStats {"TableID":104}
       │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":6,"TableID":104}
       │         ├── RefreshStats {"TableID":104}
-      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":16,"TableID":104}
-      │         ├── SetIndexName {"IndexID":16,"Name":"crdb_internal_in...","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":17,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":17,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":17,"Kind":2,"Ordinal":1,"TableID":104}
@@ -70,7 +67,10 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":14,"Kind":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":15,"Kind":1,"TableID":104}
       │         ├── SetIndexName {"IndexID":14,"Name":"crdb_internal_in...","TableID":104}
-      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":16,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":16,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":16,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":16,"Kind":2,"Ordinal":1,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":17,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":11,"TableID":104}
@@ -79,11 +79,8 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 16 elements transitioning toward ABSENT
-      │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 16 (t_pkey-), ConstraintID: 10, TemporaryIndexID: 17, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 16 (t_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 16 (t_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 16 (t_pkey-)}
+      │    ├── 13 elements transitioning toward ABSENT
+      │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 16 (t_pkey-), ConstraintID: 10, TemporaryIndexID: 17, SourceIndexID: 1 (t_pkey+)}
       │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx-), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2}
       │    │    ├── PUBLIC      → ABSENT      IndexName:{DescID: 104 (t), Name: "t_i_idx", IndexID: 8 (t_i_idx-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 8 (t_i_idx-)}
@@ -96,12 +93,9 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 12 (t_k_idx-)}
       │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 12 (t_k_idx-)}
       │    │    └── DELETE_ONLY → ABSENT      SecondaryIndex:{DescID: 104 (t), IndexID: 14 (t_i_key-), ConstraintID: 8, TemporaryIndexID: 15, SourceIndexID: 16 (t_pkey-), RecreateSourceIndexID: 0}
-      │    └── 20 Mutation operations
+      │    └── 17 Mutation operations
+      │         ├── MakeIndexAbsent {"IndexID":16,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":14,"TableID":104}
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":16,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":16,"Kind":2,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":16,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":16,"Kind":2,"Ordinal":1,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":104}
       │         ├── RemoveDroppedIndexPartialPredicate {"IndexID":8,"TableID":104}
       │         ├── SetIndexName {"IndexID":8,"Name":"crdb_internal_in...","TableID":104}
@@ -118,8 +112,7 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 3 of 3 in PostCommitNonRevertiblePhase
-           ├── 14 elements transitioning toward ABSENT
-           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 16 (t_pkey-), ConstraintID: 10, TemporaryIndexID: 17, SourceIndexID: 1 (t_pkey+)}
+           ├── 13 elements transitioning toward ABSENT
            │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 16 (t_pkey-)}
            │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 17}
            │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx-), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2}
@@ -133,8 +126,7 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
            │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 13}
            │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 14 (t_i_key-)}
            │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 15}
-           └── 16 Mutation operations
-                ├── MakeIndexAbsent {"IndexID":16,"TableID":104}
+           └── 15 Mutation operations
                 ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
                 ├── CreateGCJobForIndex {"IndexID":8,"TableID":104}
                 ├── CreateGCJobForIndex {"IndexID":9,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_vanilla/alter_table_alter_primary_key_vanilla__rollback_9_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_vanilla/alter_table_alter_primary_key_vanilla__rollback_9_of_15.explain
@@ -12,47 +12,44 @@ EXPLAIN (DDL) rollback at post-commit stage 9 of 15;
 Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY KEY USING COLUMNS (j);
  └── PostCommitNonRevertiblePhase
       ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 5 elements transitioning toward PUBLIC
-      │    │    ├── VALIDATED             → PUBLIC    PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey+), ConstraintID: 1}
-      │    │    ├── ABSENT                → PUBLIC    IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey+)}
-      │    │    ├── VALIDATED             → PUBLIC    SecondaryIndex:{DescID: 104 (t), IndexID: 2 (t_i_idx+), RecreateSourceIndexID: 0}
-      │    │    ├── VALIDATED             → PUBLIC    SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_j_idx+), RecreateSourceIndexID: 0}
-      │    │    └── VALIDATED             → PUBLIC    SecondaryIndex:{DescID: 104 (t), IndexID: 6 (t_k_idx+), RecreateSourceIndexID: 0}
-      │    ├── 24 elements transitioning toward ABSENT
-      │    │    ├── PUBLIC                → VALIDATED PrimaryIndex:{DescID: 104 (t), IndexID: 16 (t_pkey-), ConstraintID: 10, TemporaryIndexID: 17, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC                → ABSENT    IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 16 (t_pkey-)}
-      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT    TemporaryIndex:{DescID: 104 (t), IndexID: 17, ConstraintID: 11, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC                → ABSENT    IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 17}
-      │    │    ├── PUBLIC                → ABSENT    IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 17}
-      │    │    ├── PUBLIC                → ABSENT    IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 17}
-      │    │    ├── PUBLIC                → VALIDATED SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx-), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2}
-      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT    TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 3, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC                → ABSENT    IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 9}
-      │    │    ├── PUBLIC                → ABSENT    IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 9}
-      │    │    ├── PUBLIC                → VALIDATED SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx-), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4}
-      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT    TemporaryIndex:{DescID: 104 (t), IndexID: 11, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC                → ABSENT    IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 11}
-      │    │    ├── PUBLIC                → VALIDATED SecondaryIndex:{DescID: 104 (t), IndexID: 12 (t_k_idx-), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 6}
-      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT    TemporaryIndex:{DescID: 104 (t), IndexID: 13, ConstraintID: 7, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC                → ABSENT    IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 13}
-      │    │    ├── PUBLIC                → ABSENT    IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 13}
-      │    │    ├── BACKFILL_ONLY         → ABSENT    SecondaryIndex:{DescID: 104 (t), IndexID: 14 (t_i_key-), ConstraintID: 8, TemporaryIndexID: 15, SourceIndexID: 16 (t_pkey-), RecreateSourceIndexID: 0}
-      │    │    ├── DELETE_ONLY           → ABSENT    TemporaryIndex:{DescID: 104 (t), IndexID: 15, ConstraintID: 9, SourceIndexID: 16 (t_pkey-)}
-      │    │    ├── PUBLIC                → ABSENT    IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 14 (t_i_key-)}
-      │    │    ├── PUBLIC                → ABSENT    IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 15}
-      │    │    ├── PUBLIC                → ABSENT    IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 14 (t_i_key-)}
-      │    │    ├── PUBLIC                → ABSENT    IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 15}
-      │    │    └── PUBLIC                → ABSENT    IndexName:{DescID: 104 (t), Name: "t_i_key", IndexID: 14 (t_i_key-)}
+      │    ├── 3 elements transitioning toward PUBLIC
+      │    │    ├── VALIDATED             → PUBLIC      SecondaryIndex:{DescID: 104 (t), IndexID: 2 (t_i_idx+), RecreateSourceIndexID: 0}
+      │    │    ├── VALIDATED             → PUBLIC      SecondaryIndex:{DescID: 104 (t), IndexID: 4 (t_j_idx+), RecreateSourceIndexID: 0}
+      │    │    └── VALIDATED             → PUBLIC      SecondaryIndex:{DescID: 104 (t), IndexID: 6 (t_k_idx+), RecreateSourceIndexID: 0}
+      │    ├── 26 elements transitioning toward ABSENT
+      │    │    ├── VALIDATED             → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 16 (t_pkey-), ConstraintID: 10, TemporaryIndexID: 17, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 16 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 16 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 16 (t_pkey-)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 17, ConstraintID: 11, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 17}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 17}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 17}
+      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx-), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 9, ConstraintID: 3, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 9}
+      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx-), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 11, ConstraintID: 5, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 11}
+      │    │    ├── PUBLIC                → VALIDATED   SecondaryIndex:{DescID: 104 (t), IndexID: 12 (t_k_idx-), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 6}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 13, ConstraintID: 7, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 13}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 13}
+      │    │    ├── BACKFILL_ONLY         → ABSENT      SecondaryIndex:{DescID: 104 (t), IndexID: 14 (t_i_key-), ConstraintID: 8, TemporaryIndexID: 15, SourceIndexID: 16 (t_pkey-), RecreateSourceIndexID: 0}
+      │    │    ├── DELETE_ONLY           → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 15, ConstraintID: 9, SourceIndexID: 16 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 14 (t_i_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 15}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 14 (t_i_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 15}
+      │    │    └── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "t_i_key", IndexID: 14 (t_i_key-)}
       │    └── 34 Mutation operations
-      │         ├── SetIndexName {"IndexID":1,"Name":"t_pkey","TableID":104}
       │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":2,"TableID":104}
       │         ├── RefreshStats {"TableID":104}
       │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":4,"TableID":104}
       │         ├── RefreshStats {"TableID":104}
       │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":6,"TableID":104}
       │         ├── RefreshStats {"TableID":104}
-      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":16,"TableID":104}
-      │         ├── SetIndexName {"IndexID":16,"Name":"crdb_internal_in...","TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":17,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":17,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":17,"Kind":2,"Ordinal":1,"TableID":104}
@@ -69,7 +66,10 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":14,"Kind":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":15,"Kind":1,"TableID":104}
       │         ├── SetIndexName {"IndexID":14,"Name":"crdb_internal_in...","TableID":104}
-      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":16,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":16,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":16,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":16,"Kind":2,"Ordinal":1,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":17,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":9,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":11,"TableID":104}
@@ -79,27 +79,21 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 15 elements transitioning toward ABSENT
-      │    │    ├── VALIDATED → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 16 (t_pkey-), ConstraintID: 10, TemporaryIndexID: 17, SourceIndexID: 1 (t_pkey+)}
-      │    │    ├── PUBLIC    → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 16 (t_pkey-)}
-      │    │    ├── PUBLIC    → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 16 (t_pkey-)}
-      │    │    ├── PUBLIC    → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 16 (t_pkey-)}
-      │    │    ├── VALIDATED → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx-), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2}
-      │    │    ├── PUBLIC    → ABSENT      IndexName:{DescID: 104 (t), Name: "t_i_idx", IndexID: 8 (t_i_idx-)}
-      │    │    ├── PUBLIC    → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 8 (t_i_idx-)}
-      │    │    ├── PUBLIC    → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 8 (t_i_idx-)}
-      │    │    ├── VALIDATED → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx-), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4}
-      │    │    ├── PUBLIC    → ABSENT      IndexName:{DescID: 104 (t), Name: "t_j_idx", IndexID: 10 (t_j_idx-)}
-      │    │    ├── PUBLIC    → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 10 (t_j_idx-)}
-      │    │    ├── VALIDATED → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 12 (t_k_idx-), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 6}
-      │    │    ├── PUBLIC    → ABSENT      IndexName:{DescID: 104 (t), Name: "t_k_idx", IndexID: 12 (t_k_idx-)}
-      │    │    ├── PUBLIC    → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 12 (t_k_idx-)}
-      │    │    └── PUBLIC    → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 12 (t_k_idx-)}
-      │    └── 19 Mutation operations
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":16,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":16,"Kind":2,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":16,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":16,"Kind":2,"Ordinal":1,"TableID":104}
+      │    ├── 12 elements transitioning toward ABSENT
+      │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 16 (t_pkey-), ConstraintID: 10, TemporaryIndexID: 17, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx-), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2}
+      │    │    ├── PUBLIC      → ABSENT      IndexName:{DescID: 104 (t), Name: "t_i_idx", IndexID: 8 (t_i_idx-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 8 (t_i_idx-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 8 (t_i_idx-)}
+      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 10 (t_j_idx-), ConstraintID: 4, TemporaryIndexID: 11, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 4}
+      │    │    ├── PUBLIC      → ABSENT      IndexName:{DescID: 104 (t), Name: "t_j_idx", IndexID: 10 (t_j_idx-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 10 (t_j_idx-)}
+      │    │    ├── VALIDATED   → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 12 (t_k_idx-), ConstraintID: 6, TemporaryIndexID: 13, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 6}
+      │    │    ├── PUBLIC      → ABSENT      IndexName:{DescID: 104 (t), Name: "t_k_idx", IndexID: 12 (t_k_idx-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 12 (t_k_idx-)}
+      │    │    └── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j), IndexID: 12 (t_k_idx-)}
+      │    └── 16 Mutation operations
+      │         ├── MakeIndexAbsent {"IndexID":16,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":104}
       │         ├── RemoveDroppedIndexPartialPredicate {"IndexID":8,"TableID":104}
       │         ├── SetIndexName {"IndexID":8,"Name":"crdb_internal_in...","TableID":104}
@@ -116,8 +110,7 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
       └── Stage 3 of 3 in PostCommitNonRevertiblePhase
-           ├── 13 elements transitioning toward ABSENT
-           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 16 (t_pkey-), ConstraintID: 10, TemporaryIndexID: 17, SourceIndexID: 1 (t_pkey+)}
+           ├── 12 elements transitioning toward ABSENT
            │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 16 (t_pkey-)}
            │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 17}
            │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 8 (t_i_idx-), ConstraintID: 2, TemporaryIndexID: 9, SourceIndexID: 1 (t_pkey+), RecreateSourceIndexID: 2}
@@ -130,8 +123,7 @@ Schema change plan for rolling back ALTER TABLE defaultdb.public.t ALTER PRIMARY
            │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 12 (t_k_idx-)}
            │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 13}
            │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 14 (t_i_key-)}
-           └── 15 Mutation operations
-                ├── MakeIndexAbsent {"IndexID":16,"TableID":104}
+           └── 14 Mutation operations
                 ├── MakeIndexAbsent {"IndexID":8,"TableID":104}
                 ├── CreateGCJobForIndex {"IndexID":8,"TableID":104}
                 ├── CreateGCJobForIndex {"IndexID":9,"TableID":104}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_multiple_commands/alter_table_multiple_commands.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_multiple_commands/alter_table_multiple_commands.explain
@@ -199,12 +199,12 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› DROP COL
  │    │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":1,"TableID":104}
  │    │         ├── SetIndexName {"IndexID":1,"Name":"crdb_internal_in...","TableID":104}
  │    │         ├── SetIndexName {"IndexID":2,"Name":"t_pkey","TableID":104}
- │    │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":2,"TableID":104}
  │    │         ├── MakeAbsentTempIndexDeleteOnly {"Index":{"ConstraintID":5,"IndexID":5,"IsUnique":true,"SourceIndexID":2,"TableID":104}}
  │    │         ├── MaybeAddSplitForIndex {"IndexID":5,"TableID":104}
  │    │         ├── AddColumnToIndex {"ColumnID":1,"IndexID":5,"TableID":104}
  │    │         ├── AddColumnToIndex {"ColumnID":2,"IndexID":5,"Kind":2,"TableID":104}
  │    │         ├── AddColumnToIndex {"ColumnID":4,"IndexID":5,"Kind":2,"Ordinal":1,"TableID":104}
+ │    │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":2,"TableID":104}
  │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
  │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
  │    ├── Stage 9 of 15 in PostCommitPhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/drop_column_create_index_separate_statements/drop_column_create_index_separate_statements.side_effects
+++ b/pkg/sql/schemachanger/testdata/end_to_end/drop_column_create_index_separate_statements/drop_column_create_index_separate_statements.side_effects
@@ -391,7 +391,7 @@ notified job registry to adopt jobs: [1]
 begin transaction #2
 commit transaction #2
 begin transaction #3
-## PostCommitPhase stage 1 of 7 with 3 MutationType ops
+## PostCommitPhase stage 1 of 15 with 3 MutationType ops
 upsert descriptor #104
   ...
          version: 4
@@ -406,14 +406,14 @@ upsert descriptor #104
   -  version: "2"
   +  version: "3"
 persist all catalog changes to storage
-update progress of schema change job #1: "PostCommitPhase stage 2 of 7 with 1 BackfillType op pending"
+update progress of schema change job #1: "PostCommitPhase stage 2 of 15 with 1 BackfillType op pending"
 commit transaction #3
 begin transaction #4
-## PostCommitPhase stage 2 of 7 with 1 BackfillType op
+## PostCommitPhase stage 2 of 15 with 1 BackfillType op
 backfill indexes [3] from index #1 in table #104
 commit transaction #4
 begin transaction #5
-## PostCommitPhase stage 3 of 7 with 3 MutationType ops
+## PostCommitPhase stage 3 of 15 with 3 MutationType ops
 upsert descriptor #104
   ...
          version: 4
@@ -428,10 +428,10 @@ upsert descriptor #104
   -  version: "3"
   +  version: "4"
 persist all catalog changes to storage
-update progress of schema change job #1: "PostCommitPhase stage 4 of 7 with 1 MutationType op pending"
+update progress of schema change job #1: "PostCommitPhase stage 4 of 15 with 1 MutationType op pending"
 commit transaction #5
 begin transaction #6
-## PostCommitPhase stage 4 of 7 with 3 MutationType ops
+## PostCommitPhase stage 4 of 15 with 3 MutationType ops
 upsert descriptor #104
   ...
          version: 4
@@ -446,14 +446,14 @@ upsert descriptor #104
   -  version: "4"
   +  version: "5"
 persist all catalog changes to storage
-update progress of schema change job #1: "PostCommitPhase stage 5 of 7 with 1 BackfillType op pending"
+update progress of schema change job #1: "PostCommitPhase stage 5 of 15 with 1 BackfillType op pending"
 commit transaction #6
 begin transaction #7
-## PostCommitPhase stage 5 of 7 with 1 BackfillType op
+## PostCommitPhase stage 5 of 15 with 1 BackfillType op
 merge temporary indexes [4] into backfilled indexes [3] in table #104
 commit transaction #7
 begin transaction #8
-## PostCommitPhase stage 6 of 7 with 4 MutationType ops
+## PostCommitPhase stage 6 of 15 with 4 MutationType ops
 upsert descriptor #104
   ...
          version: 4
@@ -477,14 +477,182 @@ upsert descriptor #104
   -  version: "5"
   +  version: "6"
 persist all catalog changes to storage
-update progress of schema change job #1: "PostCommitPhase stage 7 of 7 with 1 ValidationType op pending"
+update progress of schema change job #1: "PostCommitPhase stage 7 of 15 with 1 ValidationType op pending"
 commit transaction #8
 begin transaction #9
-## PostCommitPhase stage 7 of 7 with 1 ValidationType op
+## PostCommitPhase stage 7 of 15 with 1 ValidationType op
 validate forward indexes [3] in table #104
 commit transaction #9
 begin transaction #10
-## PostCommitNonRevertiblePhase stage 1 of 10 with 11 MutationType ops
+## PostCommitPhase stage 8 of 15 with 11 MutationType ops
+upsert descriptor #104
+  ...
+       mutationId: 1
+       state: WRITE_ONLY
+  +  - direction: ADD
+  +    index:
+  +      constraintId: 4
+  +      createdAtNanos: "1640998800000000000"
+  +      createdExplicitly: true
+  +      foreignKey: {}
+  +      geoConfig: {}
+  +      id: 5
+  +      interleave: {}
+  +      keyColumnDirections:
+  +      - ASC
+  +      keyColumnIds:
+  +      - 3
+  +      keyColumnNames:
+  +      - k
+  +      keySuffixColumnIds:
+  +      - 1
+  +      name: idx
+  +      partitioning: {}
+  +      sharded: {}
+  +      storeColumnNames: []
+  +      unique: true
+  +      vecConfig: {}
+  +      version: 4
+  +    mutationId: 1
+  +    state: BACKFILLING
+  +  - direction: ADD
+  +    index:
+  +      constraintId: 5
+  +      createdExplicitly: true
+  +      foreignKey: {}
+  +      geoConfig: {}
+  +      id: 6
+  +      interleave: {}
+  +      keyColumnDirections:
+  +      - ASC
+  +      keyColumnIds:
+  +      - 3
+  +      keyColumnNames:
+  +      - k
+  +      keySuffixColumnIds:
+  +      - 1
+  +      name: crdb_internal_index_6_name_placeholder
+  +      partitioning: {}
+  +      sharded: {}
+  +      storeColumnNames: []
+  +      unique: true
+  +      useDeletePreservingEncoding: true
+  +      vecConfig: {}
+  +      version: 4
+  +    mutationId: 1
+  +    state: DELETE_ONLY
+     name: t
+     nextColumnId: 5
+  -  nextConstraintId: 4
+  +  nextConstraintId: 6
+     nextFamilyId: 1
+  -  nextIndexId: 5
+  +  nextIndexId: 7
+     nextMutationId: 1
+     parentId: 100
+  ...
+       time: {}
+     unexposedParentSchemaId: 101
+  -  version: "6"
+  +  version: "7"
+persist all catalog changes to storage
+update progress of schema change job #1: "PostCommitPhase stage 9 of 15 with 1 MutationType op pending"
+commit transaction #10
+begin transaction #11
+## PostCommitPhase stage 9 of 15 with 3 MutationType ops
+upsert descriptor #104
+  ...
+         version: 4
+       mutationId: 1
+  -    state: DELETE_ONLY
+  +    state: WRITE_ONLY
+     name: t
+     nextColumnId: 5
+  ...
+       time: {}
+     unexposedParentSchemaId: 101
+  -  version: "7"
+  +  version: "8"
+persist all catalog changes to storage
+update progress of schema change job #1: "PostCommitPhase stage 10 of 15 with 1 BackfillType op pending"
+commit transaction #11
+begin transaction #12
+## PostCommitPhase stage 10 of 15 with 1 BackfillType op
+backfill indexes [5] from index #3 in table #104
+commit transaction #12
+begin transaction #13
+## PostCommitPhase stage 11 of 15 with 3 MutationType ops
+upsert descriptor #104
+  ...
+         version: 4
+       mutationId: 1
+  -    state: BACKFILLING
+  +    state: DELETE_ONLY
+     - direction: ADD
+       index:
+  ...
+       time: {}
+     unexposedParentSchemaId: 101
+  -  version: "8"
+  +  version: "9"
+persist all catalog changes to storage
+update progress of schema change job #1: "PostCommitPhase stage 12 of 15 with 1 MutationType op pending"
+commit transaction #13
+begin transaction #14
+## PostCommitPhase stage 12 of 15 with 3 MutationType ops
+upsert descriptor #104
+  ...
+         version: 4
+       mutationId: 1
+  -    state: DELETE_ONLY
+  +    state: MERGING
+     - direction: ADD
+       index:
+  ...
+       time: {}
+     unexposedParentSchemaId: 101
+  -  version: "9"
+  +  version: "10"
+persist all catalog changes to storage
+update progress of schema change job #1: "PostCommitPhase stage 13 of 15 with 1 BackfillType op pending"
+commit transaction #14
+begin transaction #15
+## PostCommitPhase stage 13 of 15 with 1 BackfillType op
+merge temporary indexes [6] into backfilled indexes [5] in table #104
+commit transaction #15
+begin transaction #16
+## PostCommitPhase stage 14 of 15 with 4 MutationType ops
+upsert descriptor #104
+  ...
+         version: 4
+       mutationId: 1
+  -    state: MERGING
+  -  - direction: ADD
+  +    state: WRITE_ONLY
+  +  - direction: DROP
+       index:
+         constraintId: 5
+  ...
+         version: 4
+       mutationId: 1
+  -    state: WRITE_ONLY
+  +    state: DELETE_ONLY
+     name: t
+     nextColumnId: 5
+  ...
+       time: {}
+     unexposedParentSchemaId: 101
+  -  version: "10"
+  +  version: "11"
+persist all catalog changes to storage
+update progress of schema change job #1: "PostCommitPhase stage 15 of 15 with 1 ValidationType op pending"
+commit transaction #16
+begin transaction #17
+## PostCommitPhase stage 15 of 15 with 1 ValidationType op
+validate forward indexes [5] in table #104
+commit transaction #17
+begin transaction #18
+## PostCommitNonRevertiblePhase stage 1 of 4 with 16 MutationType ops
 upsert descriptor #104
   ...
            statementTag: CREATE INDEX
@@ -492,6 +660,35 @@ upsert descriptor #104
   -    revertible: true
        targetRanks: <redacted>
        targets: <redacted>
+  ...
+     formatVersion: 3
+     id: 104
+  -  indexes: []
+  +  indexes:
+  +  - constraintId: 4
+  +    createdAtNanos: "1640998800000000000"
+  +    createdExplicitly: true
+  +    foreignKey: {}
+  +    geoConfig: {}
+  +    id: 5
+  +    interleave: {}
+  +    keyColumnDirections:
+  +    - ASC
+  +    keyColumnIds:
+  +    - 3
+  +    keyColumnNames:
+  +    - k
+  +    keySuffixColumnIds:
+  +    - 1
+  +    name: idx
+  +    partitioning: {}
+  +    sharded: {}
+  +    storeColumnNames: []
+  +    unique: true
+  +    vecConfig: {}
+  +    version: 4
+     modificationTime: {}
+     mutations:
   ...
          keySuffixColumnIds:
          - 1
@@ -543,434 +740,6 @@ upsert descriptor #104
        direction: DROP
        mutationId: 1
   -    state: WRITE_ONLY
-  +    state: DELETE_ONLY
-     name: t
-     nextColumnId: 5
-  ...
-       time: {}
-     unexposedParentSchemaId: 101
-  -  version: "6"
-  +  version: "7"
-persist all catalog changes to storage
-update progress of schema change job #1: "PostCommitNonRevertiblePhase stage 2 of 10 with 18 MutationType ops pending"
-set schema change job #1 to non-cancellable
-commit transaction #10
-begin transaction #11
-## PostCommitNonRevertiblePhase stage 2 of 10 with 20 MutationType ops
-upsert descriptor #104
-  ...
-         oid: 20
-         width: 64
-  -  - id: 2
-  -    name: j
-  -    nullable: true
-  -    type:
-  -      family: IntFamily
-  -      oid: 20
-  -      width: 64
-     - defaultExpr: 32:::INT8
-       id: 3
-  ...
-       columnNames:
-       - i
-  -    - j
-  +    - crdb_internal_column_2_name_placeholder
-       - k
-       name: primary
-  ...
-     - direction: DROP
-       index:
-  +      constraintId: 1
-         createdAtNanos: "1640995200000000000"
-  +      encodingType: 1
-         foreignKey: {}
-         geoConfig: {}
-  +      id: 1
-  +      interleave: {}
-  +      keyColumnDirections:
-  +      - ASC
-  +      keyColumnIds:
-  +      - 1
-  +      keyColumnNames:
-  +      - i
-  +      name: crdb_internal_index_1_name_placeholder
-  +      partitioning: {}
-  +      sharded: {}
-  +      storeColumnIds:
-  +      - 2
-  +      - 3
-  +      storeColumnNames:
-  +      - crdb_internal_column_2_name_placeholder
-  +      - k
-  +      unique: true
-  +      vecConfig: {}
-  +      version: 4
-  +    mutationId: 1
-  +    state: WRITE_ONLY
-  +  - column:
-         id: 2
-  +      name: crdb_internal_column_2_name_placeholder
-  +      nullable: true
-  +      type:
-  +        family: IntFamily
-  +        oid: 20
-  +        width: 64
-  +    direction: DROP
-  +    mutationId: 1
-  +    state: WRITE_ONLY
-  +  - direction: ADD
-  +    index:
-  +      constraintId: 4
-  +      createdAtNanos: "1640998800000000000"
-  +      createdExplicitly: true
-  +      foreignKey: {}
-  +      geoConfig: {}
-  +      id: 5
-         interleave: {}
-         keyColumnDirections:
-         - ASC
-  -      - ASC
-         keyColumnIds:
-  -      - 4
-         - 3
-         keyColumnNames:
-  -      - crdb_internal_column_4_name_placeholder
-         - k
-         keySuffixColumnIds:
-         - 1
-  -      name: crdb_internal_index_2_name_placeholder
-  +      name: idx
-         partitioning: {}
-         sharded: {}
-  +      storeColumnNames: []
-  +      unique: true
-         vecConfig: {}
-  -      version: 3
-  +      version: 4
-       mutationId: 1
-  -    state: DELETE_ONLY
-  +    state: BACKFILLING
-     - direction: ADD
-       index:
-  -      constraintId: 2
-  +      constraintId: 5
-         createdExplicitly: true
-  -      encodingType: 1
-         foreignKey: {}
-         geoConfig: {}
-  -      id: 3
-  +      id: 6
-         interleave: {}
-         keyColumnDirections:
-         - ASC
-         keyColumnIds:
-  -      - 1
-  +      - 3
-         keyColumnNames:
-  -      - i
-  -      name: crdb_internal_index_3_name_placeholder
-  +      - k
-  +      keySuffixColumnIds:
-  +      - 1
-  +      name: crdb_internal_index_6_name_placeholder
-         partitioning: {}
-         sharded: {}
-  -      storeColumnIds:
-  -      - 3
-  -      storeColumnNames:
-  -      - k
-  +      storeColumnNames: []
-         unique: true
-  +      useDeletePreservingEncoding: true
-         vecConfig: {}
-         version: 4
-       mutationId: 1
-  -    state: WRITE_ONLY
-  -  - column:
-  -      computeExpr: j + 1:::INT8
-  -      id: 4
-  -      inaccessible: true
-  -      name: crdb_internal_column_4_name_placeholder
-  -      nullable: true
-  -      type:
-  -        family: IntFamily
-  -        oid: 20
-  -        width: 64
-  -      virtual: true
-  -    direction: DROP
-  -    mutationId: 1
-       state: DELETE_ONLY
-     name: t
-     nextColumnId: 5
-  -  nextConstraintId: 4
-  +  nextConstraintId: 6
-     nextFamilyId: 1
-  -  nextIndexId: 5
-  +  nextIndexId: 7
-     nextMutationId: 1
-     parentId: 100
-     primaryIndex:
-  -    constraintId: 1
-  -    createdAtNanos: "1640995200000000000"
-  +    constraintId: 2
-  +    createdExplicitly: true
-       encodingType: 1
-       foreignKey: {}
-       geoConfig: {}
-  -    id: 1
-  +    id: 3
-       interleave: {}
-       keyColumnDirections:
-  ...
-       sharded: {}
-       storeColumnIds:
-  -    - 2
-       - 3
-       storeColumnNames:
-  -    - j
-       - k
-       unique: true
-  ...
-       time: {}
-     unexposedParentSchemaId: 101
-  -  version: "7"
-  +  version: "8"
-persist all catalog changes to storage
-update progress of schema change job #1: "PostCommitNonRevertiblePhase stage 3 of 10 with 6 MutationType ops pending"
-commit transaction #11
-begin transaction #12
-## PostCommitNonRevertiblePhase stage 3 of 10 with 8 MutationType ops
-upsert descriptor #104
-  ...
-         version: 4
-       mutationId: 1
-  -    state: WRITE_ONLY
-  +    state: DELETE_ONLY
-     - column:
-         id: 2
-  ...
-       direction: DROP
-       mutationId: 1
-  -    state: WRITE_ONLY
-  +    state: DELETE_ONLY
-     - direction: ADD
-       index:
-  ...
-         version: 4
-       mutationId: 1
-  -    state: DELETE_ONLY
-  +    state: WRITE_ONLY
-     name: t
-     nextColumnId: 5
-  ...
-       time: {}
-     unexposedParentSchemaId: 101
-  -  version: "8"
-  +  version: "9"
-persist all catalog changes to storage
-update progress of schema change job #1: "PostCommitNonRevertiblePhase stage 4 of 10 with 1 BackfillType op pending"
-commit transaction #12
-begin transaction #13
-## PostCommitNonRevertiblePhase stage 4 of 10 with 1 BackfillType op
-backfill indexes [5] from index #3 in table #104
-commit transaction #13
-begin transaction #14
-## PostCommitNonRevertiblePhase stage 5 of 10 with 5 MutationType ops
-upsert descriptor #104
-  ...
-     - columnIds:
-       - 1
-  -    - 2
-       - 3
-       columnNames:
-       - i
-  -    - crdb_internal_column_2_name_placeholder
-       - k
-       name: primary
-  ...
-     modificationTime: {}
-     mutations:
-  -  - direction: DROP
-  -    index:
-  -      constraintId: 1
-  -      createdAtNanos: "1640995200000000000"
-  -      encodingType: 1
-  -      foreignKey: {}
-  -      geoConfig: {}
-  -      id: 1
-  -      interleave: {}
-  -      keyColumnDirections:
-  -      - ASC
-  -      keyColumnIds:
-  -      - 1
-  -      keyColumnNames:
-  -      - i
-  -      name: crdb_internal_index_1_name_placeholder
-  -      partitioning: {}
-  -      sharded: {}
-  -      storeColumnIds:
-  -      - 2
-  -      - 3
-  -      storeColumnNames:
-  -      - crdb_internal_column_2_name_placeholder
-  -      - k
-  -      unique: true
-  -      vecConfig: {}
-  -      version: 4
-  -    mutationId: 1
-  -    state: DELETE_ONLY
-  -  - column:
-  -      id: 2
-  -      name: crdb_internal_column_2_name_placeholder
-  -      nullable: true
-  -      type:
-  -        family: IntFamily
-  -        oid: 20
-  -        width: 64
-  -    direction: DROP
-  -    mutationId: 1
-  -    state: DELETE_ONLY
-     - direction: ADD
-       index:
-  ...
-         version: 4
-       mutationId: 1
-  -    state: BACKFILLING
-  +    state: DELETE_ONLY
-     - direction: ADD
-       index:
-  ...
-       time: {}
-     unexposedParentSchemaId: 101
-  -  version: "9"
-  +  version: "10"
-persist all catalog changes to storage
-update progress of schema change job #1: "PostCommitNonRevertiblePhase stage 6 of 10 with 1 MutationType op pending"
-commit transaction #14
-begin transaction #15
-## PostCommitNonRevertiblePhase stage 6 of 10 with 3 MutationType ops
-upsert descriptor #104
-  ...
-         version: 4
-       mutationId: 1
-  -    state: DELETE_ONLY
-  +    state: MERGING
-     - direction: ADD
-       index:
-  ...
-       time: {}
-     unexposedParentSchemaId: 101
-  -  version: "10"
-  +  version: "11"
-persist all catalog changes to storage
-update progress of schema change job #1: "PostCommitNonRevertiblePhase stage 7 of 10 with 1 BackfillType op pending"
-commit transaction #15
-begin transaction #16
-## PostCommitNonRevertiblePhase stage 7 of 10 with 1 BackfillType op
-merge temporary indexes [6] into backfilled indexes [5] in table #104
-commit transaction #16
-begin transaction #17
-## PostCommitNonRevertiblePhase stage 8 of 10 with 6 MutationType ops
-upsert descriptor #104
-  ...
-         version: 4
-       mutationId: 1
-  -    state: MERGING
-  -  - direction: ADD
-  +    state: WRITE_ONLY
-  +  - direction: DROP
-       index:
-         constraintId: 5
-  ...
-         version: 4
-       mutationId: 1
-  -    state: WRITE_ONLY
-  +    state: DELETE_ONLY
-     name: t
-     nextColumnId: 5
-  ...
-       time: {}
-     unexposedParentSchemaId: 101
-  -  version: "11"
-  +  version: "12"
-persist all catalog changes to storage
-update progress of schema change job #1: "PostCommitNonRevertiblePhase stage 9 of 10 with 1 ValidationType op pending"
-commit transaction #17
-begin transaction #18
-## PostCommitNonRevertiblePhase stage 9 of 10 with 1 ValidationType op
-validate forward indexes [5] in table #104
-commit transaction #18
-begin transaction #19
-## PostCommitNonRevertiblePhase stage 10 of 10 with 9 MutationType ops
-upsert descriptor #104
-  ...
-     createAsOfTime:
-       wallTime: "1640995200000000000"
-  -  declarativeSchemaChangerState:
-  -    authorization:
-  -      userName: root
-  -    currentStatuses: <redacted>
-  -    jobId: "1"
-  -    nameMapping:
-  -      columns:
-  -        "1": i
-  -        "3": k
-  -        "4": crdb_internal_column_4_name_placeholder
-  -        "4294967292": crdb_internal_origin_timestamp
-  -        "4294967293": crdb_internal_origin_id
-  -        "4294967294": tableoid
-  -        "4294967295": crdb_internal_mvcc_timestamp
-  -      families:
-  -        "0": primary
-  -      id: 104
-  -      indexes:
-  -        "3": t_pkey
-  -        "4": crdb_internal_index_4_name_placeholder
-  -        "5": idx
-  -      name: t
-  -    relevantStatements:
-  -    - statement:
-  -        redactedStatement: ALTER TABLE ‹defaultdb›.‹public›.‹t› DROP COLUMN ‹j› CASCADE
-  -        statement: ALTER TABLE t DROP COLUMN j CASCADE
-  -        statementTag: ALTER TABLE
-  -    - statement:
-  -        redactedStatement: CREATE UNIQUE INDEX ‹idx› ON ‹defaultdb›.‹public›.‹t› (‹k›)
-  -        statement: CREATE UNIQUE INDEX idx ON t (k)
-  -        statementTag: CREATE INDEX
-  -      statementRank: 1
-  -    targetRanks: <redacted>
-  -    targets: <redacted>
-     families:
-     - columnIds:
-  ...
-     formatVersion: 3
-     id: 104
-  -  indexes: []
-  +  indexes:
-  +  - constraintId: 4
-  +    createdAtNanos: "1640998800000000000"
-  +    createdExplicitly: true
-  +    foreignKey: {}
-  +    geoConfig: {}
-  +    id: 5
-  +    interleave: {}
-  +    keyColumnDirections:
-  +    - ASC
-  +    keyColumnIds:
-  +    - 3
-  +    keyColumnNames:
-  +    - k
-  +    keySuffixColumnIds:
-  +    - 1
-  +    name: idx
-  +    partitioning: {}
-  +    sharded: {}
-  +    storeColumnNames: []
-  +    unique: true
-  +    vecConfig: {}
-  +    version: 4
-     modificationTime: {}
-  -  mutations:
   -  - direction: ADD
   -    index:
   -      constraintId: 4
@@ -1022,6 +791,262 @@ upsert descriptor #104
   -      vecConfig: {}
   -      version: 4
   -    mutationId: 1
+       state: DELETE_ONLY
+     name: t
+  ...
+       time: {}
+     unexposedParentSchemaId: 101
+  -  version: "11"
+  +  version: "12"
+persist all catalog changes to storage
+adding table for stats refresh: 104
+update progress of schema change job #1: "PostCommitNonRevertiblePhase stage 2 of 4 with 9 MutationType ops pending"
+set schema change job #1 to non-cancellable
+commit transaction #18
+begin transaction #19
+## PostCommitNonRevertiblePhase stage 2 of 4 with 11 MutationType ops
+upsert descriptor #104
+  ...
+         oid: 20
+         width: 64
+  -  - id: 2
+  -    name: j
+  -    nullable: true
+  -    type:
+  -      family: IntFamily
+  -      oid: 20
+  -      width: 64
+     - defaultExpr: 32:::INT8
+       id: 3
+  ...
+       columnNames:
+       - i
+  -    - j
+  +    - crdb_internal_column_2_name_placeholder
+       - k
+       name: primary
+  ...
+     - direction: DROP
+       index:
+  +      constraintId: 1
+         createdAtNanos: "1640995200000000000"
+  -      foreignKey: {}
+  -      geoConfig: {}
+  -      id: 2
+  -      interleave: {}
+  -      keyColumnDirections:
+  -      - ASC
+  -      - ASC
+  -      keyColumnIds:
+  -      - 4
+  -      - 3
+  -      keyColumnNames:
+  -      - crdb_internal_column_4_name_placeholder
+  -      - k
+  -      keySuffixColumnIds:
+  -      - 1
+  -      name: crdb_internal_index_2_name_placeholder
+  -      partitioning: {}
+  -      sharded: {}
+  -      vecConfig: {}
+  -      version: 3
+  -    mutationId: 1
+  -    state: DELETE_ONLY
+  -  - direction: ADD
+  -    index:
+  -      constraintId: 2
+  -      createdExplicitly: true
+         encodingType: 1
+         foreignKey: {}
+         geoConfig: {}
+  -      id: 3
+  +      id: 1
+         interleave: {}
+         keyColumnDirections:
+  ...
+         keyColumnNames:
+         - i
+  -      name: crdb_internal_index_3_name_placeholder
+  +      name: crdb_internal_index_1_name_placeholder
+         partitioning: {}
+         sharded: {}
+         storeColumnIds:
+  +      - 2
+         - 3
+         storeColumnNames:
+  +      - crdb_internal_column_2_name_placeholder
+         - k
+         unique: true
+  ...
+       state: WRITE_ONLY
+     - column:
+  -      computeExpr: j + 1:::INT8
+  -      id: 4
+  -      inaccessible: true
+  -      name: crdb_internal_column_4_name_placeholder
+  +      id: 2
+  +      name: crdb_internal_column_2_name_placeholder
+         nullable: true
+         type:
+  ...
+           oid: 20
+           width: 64
+  -      virtual: true
+       direction: DROP
+       mutationId: 1
+  -    state: DELETE_ONLY
+  +    state: WRITE_ONLY
+     name: t
+     nextColumnId: 5
+  ...
+     parentId: 100
+     primaryIndex:
+  -    constraintId: 1
+  -    createdAtNanos: "1640995200000000000"
+  +    constraintId: 2
+  +    createdExplicitly: true
+       encodingType: 1
+       foreignKey: {}
+       geoConfig: {}
+  -    id: 1
+  +    id: 3
+       interleave: {}
+       keyColumnDirections:
+  ...
+       sharded: {}
+       storeColumnIds:
+  -    - 2
+       - 3
+       storeColumnNames:
+  -    - j
+       - k
+       unique: true
+  ...
+       time: {}
+     unexposedParentSchemaId: 101
+  -  version: "12"
+  +  version: "13"
+persist all catalog changes to storage
+update progress of schema change job #1: "PostCommitNonRevertiblePhase stage 3 of 4 with 5 MutationType ops pending"
+commit transaction #19
+begin transaction #20
+## PostCommitNonRevertiblePhase stage 3 of 4 with 7 MutationType ops
+upsert descriptor #104
+  ...
+         version: 4
+       mutationId: 1
+  -    state: WRITE_ONLY
+  +    state: DELETE_ONLY
+     - column:
+         id: 2
+  ...
+       direction: DROP
+       mutationId: 1
+  -    state: WRITE_ONLY
+  +    state: DELETE_ONLY
+     name: t
+     nextColumnId: 5
+  ...
+       time: {}
+     unexposedParentSchemaId: 101
+  -  version: "13"
+  +  version: "14"
+persist all catalog changes to storage
+update progress of schema change job #1: "PostCommitNonRevertiblePhase stage 4 of 4 with 6 MutationType ops pending"
+commit transaction #20
+begin transaction #21
+## PostCommitNonRevertiblePhase stage 4 of 4 with 8 MutationType ops
+upsert descriptor #104
+  ...
+     createAsOfTime:
+       wallTime: "1640995200000000000"
+  -  declarativeSchemaChangerState:
+  -    authorization:
+  -      userName: root
+  -    currentStatuses: <redacted>
+  -    jobId: "1"
+  -    nameMapping:
+  -      columns:
+  -        "1": i
+  -        "3": k
+  -        "4": crdb_internal_column_4_name_placeholder
+  -        "4294967292": crdb_internal_origin_timestamp
+  -        "4294967293": crdb_internal_origin_id
+  -        "4294967294": tableoid
+  -        "4294967295": crdb_internal_mvcc_timestamp
+  -      families:
+  -        "0": primary
+  -      id: 104
+  -      indexes:
+  -        "3": t_pkey
+  -        "4": crdb_internal_index_4_name_placeholder
+  -        "5": idx
+  -      name: t
+  -    relevantStatements:
+  -    - statement:
+  -        redactedStatement: ALTER TABLE ‹defaultdb›.‹public›.‹t› DROP COLUMN ‹j› CASCADE
+  -        statement: ALTER TABLE t DROP COLUMN j CASCADE
+  -        statementTag: ALTER TABLE
+  -    - statement:
+  -        redactedStatement: CREATE UNIQUE INDEX ‹idx› ON ‹defaultdb›.‹public›.‹t› (‹k›)
+  -        statement: CREATE UNIQUE INDEX idx ON t (k)
+  -        statementTag: CREATE INDEX
+  -      statementRank: 1
+  -    targetRanks: <redacted>
+  -    targets: <redacted>
+     families:
+     - columnIds:
+       - 1
+  -    - 2
+       - 3
+       columnNames:
+       - i
+  -    - crdb_internal_column_2_name_placeholder
+       - k
+       name: primary
+  ...
+       version: 4
+     modificationTime: {}
+  -  mutations:
+  -  - direction: DROP
+  -    index:
+  -      constraintId: 1
+  -      createdAtNanos: "1640995200000000000"
+  -      encodingType: 1
+  -      foreignKey: {}
+  -      geoConfig: {}
+  -      id: 1
+  -      interleave: {}
+  -      keyColumnDirections:
+  -      - ASC
+  -      keyColumnIds:
+  -      - 1
+  -      keyColumnNames:
+  -      - i
+  -      name: crdb_internal_index_1_name_placeholder
+  -      partitioning: {}
+  -      sharded: {}
+  -      storeColumnIds:
+  -      - 2
+  -      - 3
+  -      storeColumnNames:
+  -      - crdb_internal_column_2_name_placeholder
+  -      - k
+  -      unique: true
+  -      vecConfig: {}
+  -      version: 4
+  -    mutationId: 1
+  -    state: DELETE_ONLY
+  -  - column:
+  -      id: 2
+  -      name: crdb_internal_column_2_name_placeholder
+  -      nullable: true
+  -      type:
+  -        family: IntFamily
+  -        oid: 20
+  -        width: 64
+  -    direction: DROP
+  -    mutationId: 1
   -    state: DELETE_ONLY
   +  mutations: []
      name: t
@@ -1029,10 +1054,9 @@ upsert descriptor #104
   ...
        time: {}
      unexposedParentSchemaId: 101
-  -  version: "12"
-  +  version: "13"
+  -  version: "14"
+  +  version: "15"
 persist all catalog changes to storage
-adding table for stats refresh: 104
 create job #2 (non-cancelable: true): "GC for ALTER TABLE defaultdb.public.t DROP COLUMN j CASCADE; CREATE UNIQUE INDEX idx ON defaultdb.public.t (k)"
   descriptor IDs: [104]
 update progress of schema change job #1: "all stages completed"
@@ -1041,6 +1065,6 @@ updated schema change job #1 descriptor IDs to []
 write *eventpb.FinishSchemaChange to event log:
   sc:
     descriptorId: 104
-commit transaction #19
+commit transaction #21
 notified job registry to adopt jobs: [2]
 # end PostCommitPhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/drop_column_create_index_separate_statements/drop_column_create_index_separate_statements__rollback_10_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/drop_column_create_index_separate_statements/drop_column_create_index_separate_statements__rollback_10_of_15.explain
@@ -1,0 +1,67 @@
+/* setup */
+CREATE TABLE t (i INT PRIMARY KEY, j INT, k INT DEFAULT 32 ON UPDATE 42, INDEX((j+1), k));
+
+/* test */
+ALTER TABLE t DROP COLUMN j CASCADE;
+CREATE UNIQUE INDEX idx ON t(k);
+EXPLAIN (DDL) rollback at post-commit stage 10 of 15;
+----
+Schema change plan for rolling back CREATE UNIQUE INDEX idx ON defaultdb.public.t (k); following ALTER TABLE defaultdb.public.t DROP COLUMN j CASCADE;
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 3 elements transitioning toward PUBLIC
+      │    │    ├── WRITE_ONLY            → PUBLIC      Column:{DescID: 104 (t), ColumnID: 4 (crdb_internal_idx_expr+)}
+      │    │    ├── VALIDATED             → PUBLIC      SecondaryIndex:{DescID: 104 (t), IndexID: 2 (t_expr_k_idx+), RecreateSourceIndexID: 0}
+      │    │    └── ABSENT                → PUBLIC      ColumnName:{DescID: 104 (t), Name: "crdb_internal_idx_expr", ColumnID: 4 (crdb_internal_idx_expr+)}
+      │    ├── 13 elements transitioning toward ABSENT
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 3 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 3 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 4 (crdb_internal_index_4_name_placeholder)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 4 (crdb_internal_index_4_name_placeholder)}
+      │    │    ├── VALIDATED             → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 3 (t_pkey-), ConstraintID: 2, TemporaryIndexID: 4 (crdb_internal_index_4_name_placeholder), SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 4 (crdb_internal_index_4_name_placeholder), ConstraintID: 3, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── BACKFILL_ONLY         → ABSENT      SecondaryIndex:{DescID: 104 (t), IndexID: 5 (idx-), ConstraintID: 4, TemporaryIndexID: 6, SourceIndexID: 3 (t_pkey-), RecreateSourceIndexID: 0}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 5 (idx-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 5 (idx-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "idx", IndexID: 5 (idx-)}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 6, ConstraintID: 5, SourceIndexID: 3 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 6}
+      │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 6}
+      │    └── 20 Mutation operations
+      │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":2,"TableID":104}
+      │         ├── RefreshStats {"TableID":104}
+      │         ├── SetColumnName {"ColumnID":4,"Name":"crdb_internal_id...","TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":5,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"Kind":1,"TableID":104}
+      │         ├── SetIndexName {"IndexID":5,"Name":"crdb_internal_in...","TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Kind":1,"TableID":104}
+      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":4,"TableID":104}
+      │         ├── RefreshStats {"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":4,"Kind":2,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":3,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":3,"Kind":2,"TableID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 6 elements transitioning toward ABSENT
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 3 (t_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 4 (crdb_internal_index_4_name_placeholder)}
+           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 3 (t_pkey-), ConstraintID: 2, TemporaryIndexID: 4 (crdb_internal_index_4_name_placeholder), SourceIndexID: 1 (t_pkey+)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 5 (idx-)}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 6, ConstraintID: 5, SourceIndexID: 3 (t_pkey-)}
+           │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 6}
+           └── 8 Mutation operations
+                ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":6,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":3,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":4,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":5,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":6,"TableID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/drop_column_create_index_separate_statements/drop_column_create_index_separate_statements__rollback_11_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/drop_column_create_index_separate_statements/drop_column_create_index_separate_statements__rollback_11_of_15.explain
@@ -1,0 +1,67 @@
+/* setup */
+CREATE TABLE t (i INT PRIMARY KEY, j INT, k INT DEFAULT 32 ON UPDATE 42, INDEX((j+1), k));
+
+/* test */
+ALTER TABLE t DROP COLUMN j CASCADE;
+CREATE UNIQUE INDEX idx ON t(k);
+EXPLAIN (DDL) rollback at post-commit stage 11 of 15;
+----
+Schema change plan for rolling back CREATE UNIQUE INDEX idx ON defaultdb.public.t (k); following ALTER TABLE defaultdb.public.t DROP COLUMN j CASCADE;
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 3 elements transitioning toward PUBLIC
+      │    │    ├── WRITE_ONLY            → PUBLIC      Column:{DescID: 104 (t), ColumnID: 4 (crdb_internal_idx_expr+)}
+      │    │    ├── VALIDATED             → PUBLIC      SecondaryIndex:{DescID: 104 (t), IndexID: 2 (t_expr_k_idx+), RecreateSourceIndexID: 0}
+      │    │    └── ABSENT                → PUBLIC      ColumnName:{DescID: 104 (t), Name: "crdb_internal_idx_expr", ColumnID: 4 (crdb_internal_idx_expr+)}
+      │    ├── 13 elements transitioning toward ABSENT
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 3 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 3 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 4 (crdb_internal_index_4_name_placeholder)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 4 (crdb_internal_index_4_name_placeholder)}
+      │    │    ├── VALIDATED             → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 3 (t_pkey-), ConstraintID: 2, TemporaryIndexID: 4 (crdb_internal_index_4_name_placeholder), SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 4 (crdb_internal_index_4_name_placeholder), ConstraintID: 3, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── BACKFILL_ONLY         → ABSENT      SecondaryIndex:{DescID: 104 (t), IndexID: 5 (idx-), ConstraintID: 4, TemporaryIndexID: 6, SourceIndexID: 3 (t_pkey-), RecreateSourceIndexID: 0}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 5 (idx-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 5 (idx-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "idx", IndexID: 5 (idx-)}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 6, ConstraintID: 5, SourceIndexID: 3 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 6}
+      │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 6}
+      │    └── 20 Mutation operations
+      │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":2,"TableID":104}
+      │         ├── RefreshStats {"TableID":104}
+      │         ├── SetColumnName {"ColumnID":4,"Name":"crdb_internal_id...","TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":5,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"Kind":1,"TableID":104}
+      │         ├── SetIndexName {"IndexID":5,"Name":"crdb_internal_in...","TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Kind":1,"TableID":104}
+      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":4,"TableID":104}
+      │         ├── RefreshStats {"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":4,"Kind":2,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":3,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":3,"Kind":2,"TableID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 6 elements transitioning toward ABSENT
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 3 (t_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 4 (crdb_internal_index_4_name_placeholder)}
+           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 3 (t_pkey-), ConstraintID: 2, TemporaryIndexID: 4 (crdb_internal_index_4_name_placeholder), SourceIndexID: 1 (t_pkey+)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 5 (idx-)}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 6, ConstraintID: 5, SourceIndexID: 3 (t_pkey-)}
+           │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 6}
+           └── 8 Mutation operations
+                ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":6,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":3,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":4,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":5,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":6,"TableID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/drop_column_create_index_separate_statements/drop_column_create_index_separate_statements__rollback_12_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/drop_column_create_index_separate_statements/drop_column_create_index_separate_statements__rollback_12_of_15.explain
@@ -1,0 +1,67 @@
+/* setup */
+CREATE TABLE t (i INT PRIMARY KEY, j INT, k INT DEFAULT 32 ON UPDATE 42, INDEX((j+1), k));
+
+/* test */
+ALTER TABLE t DROP COLUMN j CASCADE;
+CREATE UNIQUE INDEX idx ON t(k);
+EXPLAIN (DDL) rollback at post-commit stage 12 of 15;
+----
+Schema change plan for rolling back CREATE UNIQUE INDEX idx ON defaultdb.public.t (k); following ALTER TABLE defaultdb.public.t DROP COLUMN j CASCADE;
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 3 elements transitioning toward PUBLIC
+      │    │    ├── WRITE_ONLY            → PUBLIC      Column:{DescID: 104 (t), ColumnID: 4 (crdb_internal_idx_expr+)}
+      │    │    ├── VALIDATED             → PUBLIC      SecondaryIndex:{DescID: 104 (t), IndexID: 2 (t_expr_k_idx+), RecreateSourceIndexID: 0}
+      │    │    └── ABSENT                → PUBLIC      ColumnName:{DescID: 104 (t), Name: "crdb_internal_idx_expr", ColumnID: 4 (crdb_internal_idx_expr+)}
+      │    ├── 13 elements transitioning toward ABSENT
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 3 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 3 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 4 (crdb_internal_index_4_name_placeholder)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 4 (crdb_internal_index_4_name_placeholder)}
+      │    │    ├── VALIDATED             → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 3 (t_pkey-), ConstraintID: 2, TemporaryIndexID: 4 (crdb_internal_index_4_name_placeholder), SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 4 (crdb_internal_index_4_name_placeholder), ConstraintID: 3, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── DELETE_ONLY           → ABSENT      SecondaryIndex:{DescID: 104 (t), IndexID: 5 (idx-), ConstraintID: 4, TemporaryIndexID: 6, SourceIndexID: 3 (t_pkey-), RecreateSourceIndexID: 0}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 5 (idx-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 5 (idx-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "idx", IndexID: 5 (idx-)}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 6, ConstraintID: 5, SourceIndexID: 3 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 6}
+      │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 6}
+      │    └── 20 Mutation operations
+      │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":2,"TableID":104}
+      │         ├── RefreshStats {"TableID":104}
+      │         ├── SetColumnName {"ColumnID":4,"Name":"crdb_internal_id...","TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":5,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"Kind":1,"TableID":104}
+      │         ├── SetIndexName {"IndexID":5,"Name":"crdb_internal_in...","TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Kind":1,"TableID":104}
+      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":4,"TableID":104}
+      │         ├── RefreshStats {"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":4,"Kind":2,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":3,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":3,"Kind":2,"TableID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 6 elements transitioning toward ABSENT
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 3 (t_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 4 (crdb_internal_index_4_name_placeholder)}
+           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 3 (t_pkey-), ConstraintID: 2, TemporaryIndexID: 4 (crdb_internal_index_4_name_placeholder), SourceIndexID: 1 (t_pkey+)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 5 (idx-)}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 6, ConstraintID: 5, SourceIndexID: 3 (t_pkey-)}
+           │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 6}
+           └── 8 Mutation operations
+                ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":6,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":3,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":4,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":5,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":6,"TableID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/drop_column_create_index_separate_statements/drop_column_create_index_separate_statements__rollback_13_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/drop_column_create_index_separate_statements/drop_column_create_index_separate_statements__rollback_13_of_15.explain
@@ -1,0 +1,69 @@
+/* setup */
+CREATE TABLE t (i INT PRIMARY KEY, j INT, k INT DEFAULT 32 ON UPDATE 42, INDEX((j+1), k));
+
+/* test */
+ALTER TABLE t DROP COLUMN j CASCADE;
+CREATE UNIQUE INDEX idx ON t(k);
+EXPLAIN (DDL) rollback at post-commit stage 13 of 15;
+----
+Schema change plan for rolling back CREATE UNIQUE INDEX idx ON defaultdb.public.t (k); following ALTER TABLE defaultdb.public.t DROP COLUMN j CASCADE;
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 3 elements transitioning toward PUBLIC
+      │    │    ├── WRITE_ONLY            → PUBLIC      Column:{DescID: 104 (t), ColumnID: 4 (crdb_internal_idx_expr+)}
+      │    │    ├── VALIDATED             → PUBLIC      SecondaryIndex:{DescID: 104 (t), IndexID: 2 (t_expr_k_idx+), RecreateSourceIndexID: 0}
+      │    │    └── ABSENT                → PUBLIC      ColumnName:{DescID: 104 (t), Name: "crdb_internal_idx_expr", ColumnID: 4 (crdb_internal_idx_expr+)}
+      │    ├── 13 elements transitioning toward ABSENT
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 3 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 3 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 4 (crdb_internal_index_4_name_placeholder)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 4 (crdb_internal_index_4_name_placeholder)}
+      │    │    ├── VALIDATED             → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 3 (t_pkey-), ConstraintID: 2, TemporaryIndexID: 4 (crdb_internal_index_4_name_placeholder), SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 4 (crdb_internal_index_4_name_placeholder), ConstraintID: 3, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── MERGE_ONLY            → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 5 (idx-), ConstraintID: 4, TemporaryIndexID: 6, SourceIndexID: 3 (t_pkey-), RecreateSourceIndexID: 0}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 5 (idx-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 5 (idx-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "idx", IndexID: 5 (idx-)}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 6, ConstraintID: 5, SourceIndexID: 3 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 6}
+      │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 6}
+      │    └── 20 Mutation operations
+      │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":2,"TableID":104}
+      │         ├── RefreshStats {"TableID":104}
+      │         ├── SetColumnName {"ColumnID":4,"Name":"crdb_internal_id...","TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Kind":1,"TableID":104}
+      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":4,"TableID":104}
+      │         ├── RefreshStats {"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":4,"Kind":2,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":3,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":5,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":5,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"Kind":1,"TableID":104}
+      │         ├── SetIndexName {"IndexID":5,"Name":"crdb_internal_in...","TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":3,"Kind":2,"TableID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 7 elements transitioning toward ABSENT
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 3 (t_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 4 (crdb_internal_index_4_name_placeholder)}
+           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 3 (t_pkey-), ConstraintID: 2, TemporaryIndexID: 4 (crdb_internal_index_4_name_placeholder), SourceIndexID: 1 (t_pkey+)}
+           │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 5 (idx-), ConstraintID: 4, TemporaryIndexID: 6, SourceIndexID: 3 (t_pkey-), RecreateSourceIndexID: 0}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 5 (idx-)}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 6, ConstraintID: 5, SourceIndexID: 3 (t_pkey-)}
+           │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 6}
+           └── 9 Mutation operations
+                ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":6,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":3,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":4,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":5,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":6,"TableID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/drop_column_create_index_separate_statements/drop_column_create_index_separate_statements__rollback_14_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/drop_column_create_index_separate_statements/drop_column_create_index_separate_statements__rollback_14_of_15.explain
@@ -1,0 +1,69 @@
+/* setup */
+CREATE TABLE t (i INT PRIMARY KEY, j INT, k INT DEFAULT 32 ON UPDATE 42, INDEX((j+1), k));
+
+/* test */
+ALTER TABLE t DROP COLUMN j CASCADE;
+CREATE UNIQUE INDEX idx ON t(k);
+EXPLAIN (DDL) rollback at post-commit stage 14 of 15;
+----
+Schema change plan for rolling back CREATE UNIQUE INDEX idx ON defaultdb.public.t (k); following ALTER TABLE defaultdb.public.t DROP COLUMN j CASCADE;
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 3 elements transitioning toward PUBLIC
+      │    │    ├── WRITE_ONLY            → PUBLIC      Column:{DescID: 104 (t), ColumnID: 4 (crdb_internal_idx_expr+)}
+      │    │    ├── VALIDATED             → PUBLIC      SecondaryIndex:{DescID: 104 (t), IndexID: 2 (t_expr_k_idx+), RecreateSourceIndexID: 0}
+      │    │    └── ABSENT                → PUBLIC      ColumnName:{DescID: 104 (t), Name: "crdb_internal_idx_expr", ColumnID: 4 (crdb_internal_idx_expr+)}
+      │    ├── 13 elements transitioning toward ABSENT
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 3 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 3 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 4 (crdb_internal_index_4_name_placeholder)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 4 (crdb_internal_index_4_name_placeholder)}
+      │    │    ├── VALIDATED             → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 3 (t_pkey-), ConstraintID: 2, TemporaryIndexID: 4 (crdb_internal_index_4_name_placeholder), SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 4 (crdb_internal_index_4_name_placeholder), ConstraintID: 3, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── MERGE_ONLY            → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 5 (idx-), ConstraintID: 4, TemporaryIndexID: 6, SourceIndexID: 3 (t_pkey-), RecreateSourceIndexID: 0}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 5 (idx-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 5 (idx-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "idx", IndexID: 5 (idx-)}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 6, ConstraintID: 5, SourceIndexID: 3 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 6}
+      │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 6}
+      │    └── 20 Mutation operations
+      │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":2,"TableID":104}
+      │         ├── RefreshStats {"TableID":104}
+      │         ├── SetColumnName {"ColumnID":4,"Name":"crdb_internal_id...","TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Kind":1,"TableID":104}
+      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":4,"TableID":104}
+      │         ├── RefreshStats {"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":4,"Kind":2,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":3,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":5,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":5,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"Kind":1,"TableID":104}
+      │         ├── SetIndexName {"IndexID":5,"Name":"crdb_internal_in...","TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":3,"Kind":2,"TableID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 7 elements transitioning toward ABSENT
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 3 (t_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 4 (crdb_internal_index_4_name_placeholder)}
+           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 3 (t_pkey-), ConstraintID: 2, TemporaryIndexID: 4 (crdb_internal_index_4_name_placeholder), SourceIndexID: 1 (t_pkey+)}
+           │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 5 (idx-), ConstraintID: 4, TemporaryIndexID: 6, SourceIndexID: 3 (t_pkey-), RecreateSourceIndexID: 0}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 5 (idx-)}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 6, ConstraintID: 5, SourceIndexID: 3 (t_pkey-)}
+           │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 6}
+           └── 9 Mutation operations
+                ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":6,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":3,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":4,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":5,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":6,"TableID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/drop_column_create_index_separate_statements/drop_column_create_index_separate_statements__rollback_15_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/drop_column_create_index_separate_statements/drop_column_create_index_separate_statements__rollback_15_of_15.explain
@@ -1,0 +1,67 @@
+/* setup */
+CREATE TABLE t (i INT PRIMARY KEY, j INT, k INT DEFAULT 32 ON UPDATE 42, INDEX((j+1), k));
+
+/* test */
+ALTER TABLE t DROP COLUMN j CASCADE;
+CREATE UNIQUE INDEX idx ON t(k);
+EXPLAIN (DDL) rollback at post-commit stage 15 of 15;
+----
+Schema change plan for rolling back CREATE UNIQUE INDEX idx ON defaultdb.public.t (k); following ALTER TABLE defaultdb.public.t DROP COLUMN j CASCADE;
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 3 elements transitioning toward PUBLIC
+      │    │    ├── WRITE_ONLY            → PUBLIC      Column:{DescID: 104 (t), ColumnID: 4 (crdb_internal_idx_expr+)}
+      │    │    ├── VALIDATED             → PUBLIC      SecondaryIndex:{DescID: 104 (t), IndexID: 2 (t_expr_k_idx+), RecreateSourceIndexID: 0}
+      │    │    └── ABSENT                → PUBLIC      ColumnName:{DescID: 104 (t), Name: "crdb_internal_idx_expr", ColumnID: 4 (crdb_internal_idx_expr+)}
+      │    ├── 13 elements transitioning toward ABSENT
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 3 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 3 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 4 (crdb_internal_index_4_name_placeholder)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 4 (crdb_internal_index_4_name_placeholder)}
+      │    │    ├── VALIDATED             → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 3 (t_pkey-), ConstraintID: 2, TemporaryIndexID: 4 (crdb_internal_index_4_name_placeholder), SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 4 (crdb_internal_index_4_name_placeholder), ConstraintID: 3, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 5 (idx-), ConstraintID: 4, TemporaryIndexID: 6, SourceIndexID: 3 (t_pkey-), RecreateSourceIndexID: 0}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 5 (idx-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 5 (idx-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "idx", IndexID: 5 (idx-)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 6, ConstraintID: 5, SourceIndexID: 3 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 6}
+      │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 6}
+      │    └── 20 Mutation operations
+      │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":2,"TableID":104}
+      │         ├── RefreshStats {"TableID":104}
+      │         ├── SetColumnName {"ColumnID":4,"Name":"crdb_internal_id...","TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":5,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":5,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"Kind":1,"TableID":104}
+      │         ├── SetIndexName {"IndexID":5,"Name":"crdb_internal_in...","TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Kind":1,"TableID":104}
+      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":4,"TableID":104}
+      │         ├── RefreshStats {"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":4,"Kind":2,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":3,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":6,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":3,"Kind":2,"TableID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 6 elements transitioning toward ABSENT
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 3 (t_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 4 (crdb_internal_index_4_name_placeholder)}
+           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 3 (t_pkey-), ConstraintID: 2, TemporaryIndexID: 4 (crdb_internal_index_4_name_placeholder), SourceIndexID: 1 (t_pkey+)}
+           │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 104 (t), IndexID: 5 (idx-), ConstraintID: 4, TemporaryIndexID: 6, SourceIndexID: 3 (t_pkey-), RecreateSourceIndexID: 0}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 5 (idx-)}
+           │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 6}
+           └── 8 Mutation operations
+                ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":3,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":4,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":5,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":6,"TableID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/drop_column_create_index_separate_statements/drop_column_create_index_separate_statements__rollback_1_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/drop_column_create_index_separate_statements/drop_column_create_index_separate_statements__rollback_1_of_15.explain
@@ -1,0 +1,38 @@
+/* setup */
+CREATE TABLE t (i INT PRIMARY KEY, j INT, k INT DEFAULT 32 ON UPDATE 42, INDEX((j+1), k));
+
+/* test */
+ALTER TABLE t DROP COLUMN j CASCADE;
+CREATE UNIQUE INDEX idx ON t(k);
+EXPLAIN (DDL) rollback at post-commit stage 1 of 15;
+----
+Schema change plan for rolling back CREATE UNIQUE INDEX idx ON defaultdb.public.t (k); following ALTER TABLE defaultdb.public.t DROP COLUMN j CASCADE;
+ └── PostCommitNonRevertiblePhase
+      └── Stage 1 of 1 in PostCommitNonRevertiblePhase
+           ├── 3 elements transitioning toward PUBLIC
+           │    ├── WRITE_ONLY    → PUBLIC Column:{DescID: 104 (t), ColumnID: 4 (crdb_internal_idx_expr+)}
+           │    ├── VALIDATED     → PUBLIC SecondaryIndex:{DescID: 104 (t), IndexID: 2 (t_expr_k_idx+), RecreateSourceIndexID: 0}
+           │    └── ABSENT        → PUBLIC ColumnName:{DescID: 104 (t), Name: "crdb_internal_idx_expr", ColumnID: 4 (crdb_internal_idx_expr+)}
+           ├── 7 elements transitioning toward ABSENT
+           │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 3 (t_pkey-)}
+           │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 3 (t_pkey-)}
+           │    ├── PUBLIC        → ABSENT IndexData:{DescID: 104 (t), IndexID: 3 (t_pkey-)}
+           │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 4 (crdb_internal_index_4_name_placeholder)}
+           │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 4 (crdb_internal_index_4_name_placeholder)}
+           │    ├── BACKFILL_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 3 (t_pkey-), ConstraintID: 2, TemporaryIndexID: 4 (crdb_internal_index_4_name_placeholder), SourceIndexID: 1 (t_pkey+)}
+           │    └── DELETE_ONLY   → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 4 (crdb_internal_index_4_name_placeholder), ConstraintID: 3, SourceIndexID: 1 (t_pkey+)}
+           └── 14 Mutation operations
+                ├── MakeValidatedSecondaryIndexPublic {"IndexID":2,"TableID":104}
+                ├── RefreshStats {"TableID":104}
+                ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":104}
+                ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":4,"Kind":2,"TableID":104}
+                ├── SetColumnName {"ColumnID":4,"Name":"crdb_internal_id...","TableID":104}
+                ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
+                ├── MakeWriteOnlyColumnPublic {"ColumnID":4,"TableID":104}
+                ├── RefreshStats {"TableID":104}
+                ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":104}
+                ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":3,"Kind":2,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":3,"TableID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/drop_column_create_index_separate_statements/drop_column_create_index_separate_statements__rollback_2_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/drop_column_create_index_separate_statements/drop_column_create_index_separate_statements__rollback_2_of_15.explain
@@ -1,0 +1,47 @@
+/* setup */
+CREATE TABLE t (i INT PRIMARY KEY, j INT, k INT DEFAULT 32 ON UPDATE 42, INDEX((j+1), k));
+
+/* test */
+ALTER TABLE t DROP COLUMN j CASCADE;
+CREATE UNIQUE INDEX idx ON t(k);
+EXPLAIN (DDL) rollback at post-commit stage 2 of 15;
+----
+Schema change plan for rolling back CREATE UNIQUE INDEX idx ON defaultdb.public.t (k); following ALTER TABLE defaultdb.public.t DROP COLUMN j CASCADE;
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 3 elements transitioning toward PUBLIC
+      │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 104 (t), ColumnID: 4 (crdb_internal_idx_expr+)}
+      │    │    ├── VALIDATED     → PUBLIC      SecondaryIndex:{DescID: 104 (t), IndexID: 2 (t_expr_k_idx+), RecreateSourceIndexID: 0}
+      │    │    └── ABSENT        → PUBLIC      ColumnName:{DescID: 104 (t), Name: "crdb_internal_idx_expr", ColumnID: 4 (crdb_internal_idx_expr+)}
+      │    ├── 6 elements transitioning toward ABSENT
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 3 (t_pkey-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 3 (t_pkey-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 4 (crdb_internal_index_4_name_placeholder)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 4 (crdb_internal_index_4_name_placeholder)}
+      │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 3 (t_pkey-), ConstraintID: 2, TemporaryIndexID: 4 (crdb_internal_index_4_name_placeholder), SourceIndexID: 1 (t_pkey+)}
+      │    │    └── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 4 (crdb_internal_index_4_name_placeholder), ConstraintID: 3, SourceIndexID: 1 (t_pkey+)}
+      │    └── 13 Mutation operations
+      │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":2,"TableID":104}
+      │         ├── RefreshStats {"TableID":104}
+      │         ├── SetColumnName {"ColumnID":4,"Name":"crdb_internal_id...","TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":104}
+      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":4,"TableID":104}
+      │         ├── RefreshStats {"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":3,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":4,"Kind":2,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 3 elements transitioning toward ABSENT
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 3 (t_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 4 (crdb_internal_index_4_name_placeholder)}
+           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 4 (crdb_internal_index_4_name_placeholder), ConstraintID: 3, SourceIndexID: 1 (t_pkey+)}
+           └── 5 Mutation operations
+                ├── CreateGCJobForIndex {"IndexID":3,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":4,"TableID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/drop_column_create_index_separate_statements/drop_column_create_index_separate_statements__rollback_3_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/drop_column_create_index_separate_statements/drop_column_create_index_separate_statements__rollback_3_of_15.explain
@@ -1,0 +1,47 @@
+/* setup */
+CREATE TABLE t (i INT PRIMARY KEY, j INT, k INT DEFAULT 32 ON UPDATE 42, INDEX((j+1), k));
+
+/* test */
+ALTER TABLE t DROP COLUMN j CASCADE;
+CREATE UNIQUE INDEX idx ON t(k);
+EXPLAIN (DDL) rollback at post-commit stage 3 of 15;
+----
+Schema change plan for rolling back CREATE UNIQUE INDEX idx ON defaultdb.public.t (k); following ALTER TABLE defaultdb.public.t DROP COLUMN j CASCADE;
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 3 elements transitioning toward PUBLIC
+      │    │    ├── WRITE_ONLY    → PUBLIC      Column:{DescID: 104 (t), ColumnID: 4 (crdb_internal_idx_expr+)}
+      │    │    ├── VALIDATED     → PUBLIC      SecondaryIndex:{DescID: 104 (t), IndexID: 2 (t_expr_k_idx+), RecreateSourceIndexID: 0}
+      │    │    └── ABSENT        → PUBLIC      ColumnName:{DescID: 104 (t), Name: "crdb_internal_idx_expr", ColumnID: 4 (crdb_internal_idx_expr+)}
+      │    ├── 6 elements transitioning toward ABSENT
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 3 (t_pkey-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 3 (t_pkey-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 4 (crdb_internal_index_4_name_placeholder)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 4 (crdb_internal_index_4_name_placeholder)}
+      │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 3 (t_pkey-), ConstraintID: 2, TemporaryIndexID: 4 (crdb_internal_index_4_name_placeholder), SourceIndexID: 1 (t_pkey+)}
+      │    │    └── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 4 (crdb_internal_index_4_name_placeholder), ConstraintID: 3, SourceIndexID: 1 (t_pkey+)}
+      │    └── 13 Mutation operations
+      │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":2,"TableID":104}
+      │         ├── RefreshStats {"TableID":104}
+      │         ├── SetColumnName {"ColumnID":4,"Name":"crdb_internal_id...","TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":104}
+      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":4,"TableID":104}
+      │         ├── RefreshStats {"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":3,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":4,"Kind":2,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 3 elements transitioning toward ABSENT
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 3 (t_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 4 (crdb_internal_index_4_name_placeholder)}
+           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 4 (crdb_internal_index_4_name_placeholder), ConstraintID: 3, SourceIndexID: 1 (t_pkey+)}
+           └── 5 Mutation operations
+                ├── CreateGCJobForIndex {"IndexID":3,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":4,"TableID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/drop_column_create_index_separate_statements/drop_column_create_index_separate_statements__rollback_4_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/drop_column_create_index_separate_statements/drop_column_create_index_separate_statements__rollback_4_of_15.explain
@@ -1,0 +1,47 @@
+/* setup */
+CREATE TABLE t (i INT PRIMARY KEY, j INT, k INT DEFAULT 32 ON UPDATE 42, INDEX((j+1), k));
+
+/* test */
+ALTER TABLE t DROP COLUMN j CASCADE;
+CREATE UNIQUE INDEX idx ON t(k);
+EXPLAIN (DDL) rollback at post-commit stage 4 of 15;
+----
+Schema change plan for rolling back CREATE UNIQUE INDEX idx ON defaultdb.public.t (k); following ALTER TABLE defaultdb.public.t DROP COLUMN j CASCADE;
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 3 elements transitioning toward PUBLIC
+      │    │    ├── WRITE_ONLY  → PUBLIC      Column:{DescID: 104 (t), ColumnID: 4 (crdb_internal_idx_expr+)}
+      │    │    ├── VALIDATED   → PUBLIC      SecondaryIndex:{DescID: 104 (t), IndexID: 2 (t_expr_k_idx+), RecreateSourceIndexID: 0}
+      │    │    └── ABSENT      → PUBLIC      ColumnName:{DescID: 104 (t), Name: "crdb_internal_idx_expr", ColumnID: 4 (crdb_internal_idx_expr+)}
+      │    ├── 6 elements transitioning toward ABSENT
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 3 (t_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 3 (t_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 4 (crdb_internal_index_4_name_placeholder)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 4 (crdb_internal_index_4_name_placeholder)}
+      │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 3 (t_pkey-), ConstraintID: 2, TemporaryIndexID: 4 (crdb_internal_index_4_name_placeholder), SourceIndexID: 1 (t_pkey+)}
+      │    │    └── WRITE_ONLY  → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 4 (crdb_internal_index_4_name_placeholder), ConstraintID: 3, SourceIndexID: 1 (t_pkey+)}
+      │    └── 13 Mutation operations
+      │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":2,"TableID":104}
+      │         ├── RefreshStats {"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":3,"Kind":2,"TableID":104}
+      │         ├── SetColumnName {"ColumnID":4,"Name":"crdb_internal_id...","TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":104}
+      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":4,"TableID":104}
+      │         ├── RefreshStats {"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":4,"Kind":2,"TableID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 3 elements transitioning toward ABSENT
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 3 (t_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 4 (crdb_internal_index_4_name_placeholder)}
+           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 4 (crdb_internal_index_4_name_placeholder), ConstraintID: 3, SourceIndexID: 1 (t_pkey+)}
+           └── 5 Mutation operations
+                ├── CreateGCJobForIndex {"IndexID":3,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":4,"TableID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/drop_column_create_index_separate_statements/drop_column_create_index_separate_statements__rollback_5_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/drop_column_create_index_separate_statements/drop_column_create_index_separate_statements__rollback_5_of_15.explain
@@ -1,0 +1,49 @@
+/* setup */
+CREATE TABLE t (i INT PRIMARY KEY, j INT, k INT DEFAULT 32 ON UPDATE 42, INDEX((j+1), k));
+
+/* test */
+ALTER TABLE t DROP COLUMN j CASCADE;
+CREATE UNIQUE INDEX idx ON t(k);
+EXPLAIN (DDL) rollback at post-commit stage 5 of 15;
+----
+Schema change plan for rolling back CREATE UNIQUE INDEX idx ON defaultdb.public.t (k); following ALTER TABLE defaultdb.public.t DROP COLUMN j CASCADE;
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 3 elements transitioning toward PUBLIC
+      │    │    ├── WRITE_ONLY → PUBLIC      Column:{DescID: 104 (t), ColumnID: 4 (crdb_internal_idx_expr+)}
+      │    │    ├── VALIDATED  → PUBLIC      SecondaryIndex:{DescID: 104 (t), IndexID: 2 (t_expr_k_idx+), RecreateSourceIndexID: 0}
+      │    │    └── ABSENT     → PUBLIC      ColumnName:{DescID: 104 (t), Name: "crdb_internal_idx_expr", ColumnID: 4 (crdb_internal_idx_expr+)}
+      │    ├── 6 elements transitioning toward ABSENT
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 3 (t_pkey-)}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 3 (t_pkey-)}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 4 (crdb_internal_index_4_name_placeholder)}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 4 (crdb_internal_index_4_name_placeholder)}
+      │    │    ├── MERGE_ONLY → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 3 (t_pkey-), ConstraintID: 2, TemporaryIndexID: 4 (crdb_internal_index_4_name_placeholder), SourceIndexID: 1 (t_pkey+)}
+      │    │    └── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 4 (crdb_internal_index_4_name_placeholder), ConstraintID: 3, SourceIndexID: 1 (t_pkey+)}
+      │    └── 13 Mutation operations
+      │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":2,"TableID":104}
+      │         ├── RefreshStats {"TableID":104}
+      │         ├── SetColumnName {"ColumnID":4,"Name":"crdb_internal_id...","TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":104}
+      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":4,"TableID":104}
+      │         ├── RefreshStats {"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":4,"Kind":2,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":3,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":3,"Kind":2,"TableID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 4 elements transitioning toward ABSENT
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 3 (t_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 4 (crdb_internal_index_4_name_placeholder)}
+           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 3 (t_pkey-), ConstraintID: 2, TemporaryIndexID: 4 (crdb_internal_index_4_name_placeholder), SourceIndexID: 1 (t_pkey+)}
+           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 4 (crdb_internal_index_4_name_placeholder), ConstraintID: 3, SourceIndexID: 1 (t_pkey+)}
+           └── 6 Mutation operations
+                ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":3,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":4,"TableID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/drop_column_create_index_separate_statements/drop_column_create_index_separate_statements__rollback_6_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/drop_column_create_index_separate_statements/drop_column_create_index_separate_statements__rollback_6_of_15.explain
@@ -1,0 +1,49 @@
+/* setup */
+CREATE TABLE t (i INT PRIMARY KEY, j INT, k INT DEFAULT 32 ON UPDATE 42, INDEX((j+1), k));
+
+/* test */
+ALTER TABLE t DROP COLUMN j CASCADE;
+CREATE UNIQUE INDEX idx ON t(k);
+EXPLAIN (DDL) rollback at post-commit stage 6 of 15;
+----
+Schema change plan for rolling back CREATE UNIQUE INDEX idx ON defaultdb.public.t (k); following ALTER TABLE defaultdb.public.t DROP COLUMN j CASCADE;
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 3 elements transitioning toward PUBLIC
+      │    │    ├── WRITE_ONLY → PUBLIC      Column:{DescID: 104 (t), ColumnID: 4 (crdb_internal_idx_expr+)}
+      │    │    ├── VALIDATED  → PUBLIC      SecondaryIndex:{DescID: 104 (t), IndexID: 2 (t_expr_k_idx+), RecreateSourceIndexID: 0}
+      │    │    └── ABSENT     → PUBLIC      ColumnName:{DescID: 104 (t), Name: "crdb_internal_idx_expr", ColumnID: 4 (crdb_internal_idx_expr+)}
+      │    ├── 6 elements transitioning toward ABSENT
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 3 (t_pkey-)}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 3 (t_pkey-)}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 4 (crdb_internal_index_4_name_placeholder)}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 4 (crdb_internal_index_4_name_placeholder)}
+      │    │    ├── MERGE_ONLY → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 3 (t_pkey-), ConstraintID: 2, TemporaryIndexID: 4 (crdb_internal_index_4_name_placeholder), SourceIndexID: 1 (t_pkey+)}
+      │    │    └── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 4 (crdb_internal_index_4_name_placeholder), ConstraintID: 3, SourceIndexID: 1 (t_pkey+)}
+      │    └── 13 Mutation operations
+      │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":2,"TableID":104}
+      │         ├── RefreshStats {"TableID":104}
+      │         ├── SetColumnName {"ColumnID":4,"Name":"crdb_internal_id...","TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":104}
+      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":4,"TableID":104}
+      │         ├── RefreshStats {"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":4,"Kind":2,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":3,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":3,"Kind":2,"TableID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 4 elements transitioning toward ABSENT
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 3 (t_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 4 (crdb_internal_index_4_name_placeholder)}
+           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 3 (t_pkey-), ConstraintID: 2, TemporaryIndexID: 4 (crdb_internal_index_4_name_placeholder), SourceIndexID: 1 (t_pkey+)}
+           │    └── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 4 (crdb_internal_index_4_name_placeholder), ConstraintID: 3, SourceIndexID: 1 (t_pkey+)}
+           └── 6 Mutation operations
+                ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":3,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":4,"TableID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/drop_column_create_index_separate_statements/drop_column_create_index_separate_statements__rollback_7_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/drop_column_create_index_separate_statements/drop_column_create_index_separate_statements__rollback_7_of_15.explain
@@ -1,0 +1,47 @@
+/* setup */
+CREATE TABLE t (i INT PRIMARY KEY, j INT, k INT DEFAULT 32 ON UPDATE 42, INDEX((j+1), k));
+
+/* test */
+ALTER TABLE t DROP COLUMN j CASCADE;
+CREATE UNIQUE INDEX idx ON t(k);
+EXPLAIN (DDL) rollback at post-commit stage 7 of 15;
+----
+Schema change plan for rolling back CREATE UNIQUE INDEX idx ON defaultdb.public.t (k); following ALTER TABLE defaultdb.public.t DROP COLUMN j CASCADE;
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 3 elements transitioning toward PUBLIC
+      │    │    ├── WRITE_ONLY            → PUBLIC      Column:{DescID: 104 (t), ColumnID: 4 (crdb_internal_idx_expr+)}
+      │    │    ├── VALIDATED             → PUBLIC      SecondaryIndex:{DescID: 104 (t), IndexID: 2 (t_expr_k_idx+), RecreateSourceIndexID: 0}
+      │    │    └── ABSENT                → PUBLIC      ColumnName:{DescID: 104 (t), Name: "crdb_internal_idx_expr", ColumnID: 4 (crdb_internal_idx_expr+)}
+      │    ├── 6 elements transitioning toward ABSENT
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 3 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 3 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 4 (crdb_internal_index_4_name_placeholder)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 4 (crdb_internal_index_4_name_placeholder)}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 3 (t_pkey-), ConstraintID: 2, TemporaryIndexID: 4 (crdb_internal_index_4_name_placeholder), SourceIndexID: 1 (t_pkey+)}
+      │    │    └── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 4 (crdb_internal_index_4_name_placeholder), ConstraintID: 3, SourceIndexID: 1 (t_pkey+)}
+      │    └── 13 Mutation operations
+      │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":2,"TableID":104}
+      │         ├── RefreshStats {"TableID":104}
+      │         ├── SetColumnName {"ColumnID":4,"Name":"crdb_internal_id...","TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":3,"TableID":104}
+      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":4,"TableID":104}
+      │         ├── RefreshStats {"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":3,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":4,"Kind":2,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 3 elements transitioning toward ABSENT
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 3 (t_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 4 (crdb_internal_index_4_name_placeholder)}
+           │    └── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 3 (t_pkey-), ConstraintID: 2, TemporaryIndexID: 4 (crdb_internal_index_4_name_placeholder), SourceIndexID: 1 (t_pkey+)}
+           └── 5 Mutation operations
+                ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":3,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":4,"TableID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/drop_column_create_index_separate_statements/drop_column_create_index_separate_statements__rollback_8_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/drop_column_create_index_separate_statements/drop_column_create_index_separate_statements__rollback_8_of_15.explain
@@ -1,0 +1,47 @@
+/* setup */
+CREATE TABLE t (i INT PRIMARY KEY, j INT, k INT DEFAULT 32 ON UPDATE 42, INDEX((j+1), k));
+
+/* test */
+ALTER TABLE t DROP COLUMN j CASCADE;
+CREATE UNIQUE INDEX idx ON t(k);
+EXPLAIN (DDL) rollback at post-commit stage 8 of 15;
+----
+Schema change plan for rolling back CREATE UNIQUE INDEX idx ON defaultdb.public.t (k); following ALTER TABLE defaultdb.public.t DROP COLUMN j CASCADE;
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 3 elements transitioning toward PUBLIC
+      │    │    ├── WRITE_ONLY            → PUBLIC      Column:{DescID: 104 (t), ColumnID: 4 (crdb_internal_idx_expr+)}
+      │    │    ├── VALIDATED             → PUBLIC      SecondaryIndex:{DescID: 104 (t), IndexID: 2 (t_expr_k_idx+), RecreateSourceIndexID: 0}
+      │    │    └── ABSENT                → PUBLIC      ColumnName:{DescID: 104 (t), Name: "crdb_internal_idx_expr", ColumnID: 4 (crdb_internal_idx_expr+)}
+      │    ├── 6 elements transitioning toward ABSENT
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 3 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 3 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 4 (crdb_internal_index_4_name_placeholder)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 4 (crdb_internal_index_4_name_placeholder)}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 3 (t_pkey-), ConstraintID: 2, TemporaryIndexID: 4 (crdb_internal_index_4_name_placeholder), SourceIndexID: 1 (t_pkey+)}
+      │    │    └── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 4 (crdb_internal_index_4_name_placeholder), ConstraintID: 3, SourceIndexID: 1 (t_pkey+)}
+      │    └── 13 Mutation operations
+      │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":2,"TableID":104}
+      │         ├── RefreshStats {"TableID":104}
+      │         ├── SetColumnName {"ColumnID":4,"Name":"crdb_internal_id...","TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":3,"TableID":104}
+      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":4,"TableID":104}
+      │         ├── RefreshStats {"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":3,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":4,"Kind":2,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 3 elements transitioning toward ABSENT
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 3 (t_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 4 (crdb_internal_index_4_name_placeholder)}
+           │    └── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 3 (t_pkey-), ConstraintID: 2, TemporaryIndexID: 4 (crdb_internal_index_4_name_placeholder), SourceIndexID: 1 (t_pkey+)}
+           └── 5 Mutation operations
+                ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":3,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":4,"TableID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/drop_column_create_index_separate_statements/drop_column_create_index_separate_statements__rollback_9_of_15.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/drop_column_create_index_separate_statements/drop_column_create_index_separate_statements__rollback_9_of_15.explain
@@ -1,0 +1,63 @@
+/* setup */
+CREATE TABLE t (i INT PRIMARY KEY, j INT, k INT DEFAULT 32 ON UPDATE 42, INDEX((j+1), k));
+
+/* test */
+ALTER TABLE t DROP COLUMN j CASCADE;
+CREATE UNIQUE INDEX idx ON t(k);
+EXPLAIN (DDL) rollback at post-commit stage 9 of 15;
+----
+Schema change plan for rolling back CREATE UNIQUE INDEX idx ON defaultdb.public.t (k); following ALTER TABLE defaultdb.public.t DROP COLUMN j CASCADE;
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 3 elements transitioning toward PUBLIC
+      │    │    ├── WRITE_ONLY            → PUBLIC      Column:{DescID: 104 (t), ColumnID: 4 (crdb_internal_idx_expr+)}
+      │    │    ├── VALIDATED             → PUBLIC      SecondaryIndex:{DescID: 104 (t), IndexID: 2 (t_expr_k_idx+), RecreateSourceIndexID: 0}
+      │    │    └── ABSENT                → PUBLIC      ColumnName:{DescID: 104 (t), Name: "crdb_internal_idx_expr", ColumnID: 4 (crdb_internal_idx_expr+)}
+      │    ├── 13 elements transitioning toward ABSENT
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 3 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 3 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 4 (crdb_internal_index_4_name_placeholder)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 4 (crdb_internal_index_4_name_placeholder)}
+      │    │    ├── VALIDATED             → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 3 (t_pkey-), ConstraintID: 2, TemporaryIndexID: 4 (crdb_internal_index_4_name_placeholder), SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 4 (crdb_internal_index_4_name_placeholder), ConstraintID: 3, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── BACKFILL_ONLY         → ABSENT      SecondaryIndex:{DescID: 104 (t), IndexID: 5 (idx-), ConstraintID: 4, TemporaryIndexID: 6, SourceIndexID: 3 (t_pkey-), RecreateSourceIndexID: 0}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 5 (idx-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 5 (idx-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 104 (t), Name: "idx", IndexID: 5 (idx-)}
+      │    │    ├── DELETE_ONLY           → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 6, ConstraintID: 5, SourceIndexID: 3 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 6}
+      │    │    └── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 6}
+      │    └── 20 Mutation operations
+      │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":2,"TableID":104}
+      │         ├── RefreshStats {"TableID":104}
+      │         ├── SetColumnName {"ColumnID":4,"Name":"crdb_internal_id...","TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":5,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"Kind":1,"TableID":104}
+      │         ├── SetIndexName {"IndexID":5,"Name":"crdb_internal_in...","TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Kind":1,"TableID":104}
+      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":4,"TableID":104}
+      │         ├── RefreshStats {"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":4,"Kind":2,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":3,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":5,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":6,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":3,"Kind":2,"TableID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 4 elements transitioning toward ABSENT
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 3 (t_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 4 (crdb_internal_index_4_name_placeholder)}
+           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 3 (t_pkey-), ConstraintID: 2, TemporaryIndexID: 4 (crdb_internal_index_4_name_placeholder), SourceIndexID: 1 (t_pkey+)}
+           │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 5 (idx-)}
+           └── 6 Mutation operations
+                ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":3,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":4,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":5,"TableID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/drop_column_create_index_separate_statements/drop_column_create_index_separate_statements__statement_2_of_2.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/drop_column_create_index_separate_statements/drop_column_create_index_separate_statements__statement_2_of_2.explain
@@ -54,7 +54,7 @@ Schema change plan for CREATE UNIQUE INDEX ‹idx› ON ‹defaultdb›.‹publi
  │              ├── SetJobStateOnDescriptor {"DescriptorID":104,"Initialize":true}
  │              └── CreateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
  ├── PostCommitPhase
- │    ├── Stage 1 of 7 in PostCommitPhase
+ │    ├── Stage 1 of 15 in PostCommitPhase
  │    │    ├── 2 elements transitioning toward TRANSIENT_ABSENT
  │    │    │    ├── ABSENT      → PUBLIC     IndexData:{DescID: 104 (t), IndexID: 4 (crdb_internal_index_4_name_placeholder)}
  │    │    │    └── DELETE_ONLY → WRITE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 4 (crdb_internal_index_4_name_placeholder), ConstraintID: 3, SourceIndexID: 1 (t_pkey-)}
@@ -62,31 +62,31 @@ Schema change plan for CREATE UNIQUE INDEX ‹idx› ON ‹defaultdb›.‹publi
  │    │         ├── MakeDeleteOnlyIndexWriteOnly {"IndexID":4,"TableID":104}
  │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
  │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
- │    ├── Stage 2 of 7 in PostCommitPhase
+ │    ├── Stage 2 of 15 in PostCommitPhase
  │    │    ├── 1 element transitioning toward PUBLIC
  │    │    │    └── BACKFILL_ONLY → BACKFILLED PrimaryIndex:{DescID: 104 (t), IndexID: 3 (t_pkey+), ConstraintID: 2, TemporaryIndexID: 4 (crdb_internal_index_4_name_placeholder), SourceIndexID: 1 (t_pkey-)}
  │    │    └── 1 Backfill operation
  │    │         └── BackfillIndex {"IndexID":3,"SourceIndexID":1,"TableID":104}
- │    ├── Stage 3 of 7 in PostCommitPhase
+ │    ├── Stage 3 of 15 in PostCommitPhase
  │    │    ├── 1 element transitioning toward PUBLIC
  │    │    │    └── BACKFILLED → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 3 (t_pkey+), ConstraintID: 2, TemporaryIndexID: 4 (crdb_internal_index_4_name_placeholder), SourceIndexID: 1 (t_pkey-)}
  │    │    └── 3 Mutation operations
  │    │         ├── MakeBackfillingIndexDeleteOnly {"IndexID":3,"TableID":104}
  │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
  │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
- │    ├── Stage 4 of 7 in PostCommitPhase
+ │    ├── Stage 4 of 15 in PostCommitPhase
  │    │    ├── 1 element transitioning toward PUBLIC
  │    │    │    └── DELETE_ONLY → MERGE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 3 (t_pkey+), ConstraintID: 2, TemporaryIndexID: 4 (crdb_internal_index_4_name_placeholder), SourceIndexID: 1 (t_pkey-)}
  │    │    └── 3 Mutation operations
  │    │         ├── MakeBackfilledIndexMerging {"IndexID":3,"TableID":104}
  │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
  │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
- │    ├── Stage 5 of 7 in PostCommitPhase
+ │    ├── Stage 5 of 15 in PostCommitPhase
  │    │    ├── 1 element transitioning toward PUBLIC
  │    │    │    └── MERGE_ONLY → MERGED PrimaryIndex:{DescID: 104 (t), IndexID: 3 (t_pkey+), ConstraintID: 2, TemporaryIndexID: 4 (crdb_internal_index_4_name_placeholder), SourceIndexID: 1 (t_pkey-)}
  │    │    └── 1 Backfill operation
  │    │         └── MergeIndex {"BackfilledIndexID":3,"TableID":104,"TemporaryIndexID":4}
- │    ├── Stage 6 of 7 in PostCommitPhase
+ │    ├── Stage 6 of 15 in PostCommitPhase
  │    │    ├── 1 element transitioning toward PUBLIC
  │    │    │    └── MERGED     → WRITE_ONLY            PrimaryIndex:{DescID: 104 (t), IndexID: 3 (t_pkey+), ConstraintID: 2, TemporaryIndexID: 4 (crdb_internal_index_4_name_placeholder), SourceIndexID: 1 (t_pkey-)}
  │    │    ├── 1 element transitioning toward TRANSIENT_ABSENT
@@ -96,17 +96,92 @@ Schema change plan for CREATE UNIQUE INDEX ‹idx› ON ‹defaultdb›.‹publi
  │    │         ├── MakeMergedIndexWriteOnly {"IndexID":3,"TableID":104}
  │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
  │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
- │    └── Stage 7 of 7 in PostCommitPhase
+ │    ├── Stage 7 of 15 in PostCommitPhase
+ │    │    ├── 1 element transitioning toward PUBLIC
+ │    │    │    └── WRITE_ONLY → VALIDATED PrimaryIndex:{DescID: 104 (t), IndexID: 3 (t_pkey+), ConstraintID: 2, TemporaryIndexID: 4 (crdb_internal_index_4_name_placeholder), SourceIndexID: 1 (t_pkey-)}
+ │    │    └── 1 Validation operation
+ │    │         └── ValidateIndex {"IndexID":3,"TableID":104}
+ │    ├── Stage 8 of 15 in PostCommitPhase
+ │    │    ├── 5 elements transitioning toward PUBLIC
+ │    │    │    ├── ABSENT → BACKFILL_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 5 (idx+), ConstraintID: 4, TemporaryIndexID: 6, SourceIndexID: 3 (t_pkey+), RecreateSourceIndexID: 0}
+ │    │    │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 5 (idx+)}
+ │    │    │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 5 (idx+)}
+ │    │    │    ├── ABSENT → PUBLIC        IndexData:{DescID: 104 (t), IndexID: 5 (idx+)}
+ │    │    │    └── ABSENT → PUBLIC        IndexName:{DescID: 104 (t), Name: "idx", IndexID: 5 (idx+)}
+ │    │    ├── 3 elements transitioning toward TRANSIENT_ABSENT
+ │    │    │    ├── ABSENT → DELETE_ONLY   TemporaryIndex:{DescID: 104 (t), IndexID: 6, ConstraintID: 5, SourceIndexID: 3 (t_pkey+)}
+ │    │    │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 6}
+ │    │    │    └── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 6}
+ │    │    └── 11 Mutation operations
+ │    │         ├── MakeAbsentIndexBackfilling {"IsSecondaryIndex":true}
+ │    │         ├── MaybeAddSplitForIndex {"IndexID":5,"TableID":104}
+ │    │         ├── AddColumnToIndex {"ColumnID":3,"IndexID":5,"TableID":104}
+ │    │         ├── AddColumnToIndex {"ColumnID":1,"IndexID":5,"Kind":1,"TableID":104}
+ │    │         ├── SetIndexName {"IndexID":5,"Name":"idx","TableID":104}
+ │    │         ├── MakeAbsentTempIndexDeleteOnly {"IsSecondaryIndex":true}
+ │    │         ├── MaybeAddSplitForIndex {"IndexID":6,"TableID":104}
+ │    │         ├── AddColumnToIndex {"ColumnID":3,"IndexID":6,"TableID":104}
+ │    │         ├── AddColumnToIndex {"ColumnID":1,"IndexID":6,"Kind":1,"TableID":104}
+ │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+ │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
+ │    ├── Stage 9 of 15 in PostCommitPhase
+ │    │    ├── 2 elements transitioning toward TRANSIENT_ABSENT
+ │    │    │    ├── DELETE_ONLY → WRITE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 6, ConstraintID: 5, SourceIndexID: 3 (t_pkey+)}
+ │    │    │    └── ABSENT      → PUBLIC     IndexData:{DescID: 104 (t), IndexID: 6}
+ │    │    └── 3 Mutation operations
+ │    │         ├── MakeDeleteOnlyIndexWriteOnly {"IndexID":6,"TableID":104}
+ │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+ │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
+ │    ├── Stage 10 of 15 in PostCommitPhase
+ │    │    ├── 1 element transitioning toward PUBLIC
+ │    │    │    └── BACKFILL_ONLY → BACKFILLED SecondaryIndex:{DescID: 104 (t), IndexID: 5 (idx+), ConstraintID: 4, TemporaryIndexID: 6, SourceIndexID: 3 (t_pkey+), RecreateSourceIndexID: 0}
+ │    │    └── 1 Backfill operation
+ │    │         └── BackfillIndex {"IndexID":5,"SourceIndexID":3,"TableID":104}
+ │    ├── Stage 11 of 15 in PostCommitPhase
+ │    │    ├── 1 element transitioning toward PUBLIC
+ │    │    │    └── BACKFILLED → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 5 (idx+), ConstraintID: 4, TemporaryIndexID: 6, SourceIndexID: 3 (t_pkey+), RecreateSourceIndexID: 0}
+ │    │    └── 3 Mutation operations
+ │    │         ├── MakeBackfillingIndexDeleteOnly {"IndexID":5,"TableID":104}
+ │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+ │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
+ │    ├── Stage 12 of 15 in PostCommitPhase
+ │    │    ├── 1 element transitioning toward PUBLIC
+ │    │    │    └── DELETE_ONLY → MERGE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 5 (idx+), ConstraintID: 4, TemporaryIndexID: 6, SourceIndexID: 3 (t_pkey+), RecreateSourceIndexID: 0}
+ │    │    └── 3 Mutation operations
+ │    │         ├── MakeBackfilledIndexMerging {"IndexID":5,"TableID":104}
+ │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+ │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
+ │    ├── Stage 13 of 15 in PostCommitPhase
+ │    │    ├── 1 element transitioning toward PUBLIC
+ │    │    │    └── MERGE_ONLY → MERGED SecondaryIndex:{DescID: 104 (t), IndexID: 5 (idx+), ConstraintID: 4, TemporaryIndexID: 6, SourceIndexID: 3 (t_pkey+), RecreateSourceIndexID: 0}
+ │    │    └── 1 Backfill operation
+ │    │         └── MergeIndex {"BackfilledIndexID":5,"TableID":104,"TemporaryIndexID":6}
+ │    ├── Stage 14 of 15 in PostCommitPhase
+ │    │    ├── 1 element transitioning toward PUBLIC
+ │    │    │    └── MERGED     → WRITE_ONLY            SecondaryIndex:{DescID: 104 (t), IndexID: 5 (idx+), ConstraintID: 4, TemporaryIndexID: 6, SourceIndexID: 3 (t_pkey+), RecreateSourceIndexID: 0}
+ │    │    ├── 1 element transitioning toward TRANSIENT_ABSENT
+ │    │    │    └── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 6, ConstraintID: 5, SourceIndexID: 3 (t_pkey+)}
+ │    │    └── 4 Mutation operations
+ │    │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":104}
+ │    │         ├── MakeMergedIndexWriteOnly {"IndexID":5,"TableID":104}
+ │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+ │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
+ │    └── Stage 15 of 15 in PostCommitPhase
  │         ├── 1 element transitioning toward PUBLIC
- │         │    └── WRITE_ONLY → VALIDATED PrimaryIndex:{DescID: 104 (t), IndexID: 3 (t_pkey+), ConstraintID: 2, TemporaryIndexID: 4 (crdb_internal_index_4_name_placeholder), SourceIndexID: 1 (t_pkey-)}
+ │         │    └── WRITE_ONLY → VALIDATED SecondaryIndex:{DescID: 104 (t), IndexID: 5 (idx+), ConstraintID: 4, TemporaryIndexID: 6, SourceIndexID: 3 (t_pkey+), RecreateSourceIndexID: 0}
  │         └── 1 Validation operation
- │              └── ValidateIndex {"IndexID":3,"TableID":104}
+ │              └── ValidateIndex {"IndexID":5,"TableID":104}
  └── PostCommitNonRevertiblePhase
-      ├── Stage 1 of 10 in PostCommitNonRevertiblePhase
-      │    ├── 3 elements transitioning toward TRANSIENT_ABSENT
+      ├── Stage 1 of 4 in PostCommitNonRevertiblePhase
+      │    ├── 1 element transitioning toward PUBLIC
+      │    │    └── VALIDATED             → PUBLIC           SecondaryIndex:{DescID: 104 (t), IndexID: 5 (idx+), ConstraintID: 4, TemporaryIndexID: 6, SourceIndexID: 3 (t_pkey+), RecreateSourceIndexID: 0}
+      │    ├── 6 elements transitioning toward TRANSIENT_ABSENT
       │    │    ├── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 4 (crdb_internal_index_4_name_placeholder)}
       │    │    ├── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 4 (crdb_internal_index_4_name_placeholder)}
-      │    │    └── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 4 (crdb_internal_index_4_name_placeholder), ConstraintID: 3, SourceIndexID: 1 (t_pkey-)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 4 (crdb_internal_index_4_name_placeholder), ConstraintID: 3, SourceIndexID: 1 (t_pkey-)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 6, ConstraintID: 5, SourceIndexID: 3 (t_pkey+)}
+      │    │    ├── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 6}
+      │    │    └── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 6}
       │    ├── 6 elements transitioning toward ABSENT
       │    │    ├── WRITE_ONLY            → DELETE_ONLY      Column:{DescID: 104 (t), ColumnID: 4 (crdb_internal_idx_expr-)}
       │    │    ├── PUBLIC                → ABSENT           IndexColumn:{DescID: 104 (t), ColumnID: 4 (crdb_internal_idx_expr-), IndexID: 2 (t_expr_k_idx-)}
@@ -114,41 +189,37 @@ Schema change plan for CREATE UNIQUE INDEX ‹idx› ON ‹defaultdb›.‹publi
       │    │    ├── PUBLIC                → ABSENT           IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 2 (t_expr_k_idx-)}
       │    │    ├── VALIDATED             → DELETE_ONLY      SecondaryIndex:{DescID: 104 (t), IndexID: 2 (t_expr_k_idx-), RecreateSourceIndexID: 0}
       │    │    └── PUBLIC                → ABSENT           IndexName:{DescID: 104 (t), Name: "t_expr_k_idx", IndexID: 2 (t_expr_k_idx-)}
-      │    └── 11 Mutation operations
+      │    └── 16 Mutation operations
       │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":4,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":4,"Kind":2,"TableID":104}
       │         ├── MakeIndexAbsent {"IndexID":4,"TableID":104}
+      │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":5,"TableID":104}
+      │         ├── RefreshStats {"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Kind":1,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":2,"TableID":104}
       │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":6,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":2,"Ordinal":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"Kind":1,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
-      ├── Stage 2 of 10 in PostCommitNonRevertiblePhase
-      │    ├── 7 elements transitioning toward PUBLIC
-      │    │    ├── VALIDATED   → PUBLIC        PrimaryIndex:{DescID: 104 (t), IndexID: 3 (t_pkey+), ConstraintID: 2, TemporaryIndexID: 4 (crdb_internal_index_4_name_placeholder), SourceIndexID: 1 (t_pkey-)}
-      │    │    ├── ABSENT      → PUBLIC        IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 3 (t_pkey+)}
-      │    │    ├── ABSENT      → BACKFILL_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 5 (idx+), ConstraintID: 4, TemporaryIndexID: 6, SourceIndexID: 3 (t_pkey+), RecreateSourceIndexID: 0}
-      │    │    ├── ABSENT      → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 5 (idx+)}
-      │    │    ├── ABSENT      → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 5 (idx+)}
-      │    │    ├── ABSENT      → PUBLIC        IndexData:{DescID: 104 (t), IndexID: 5 (idx+)}
-      │    │    └── ABSENT      → PUBLIC        IndexName:{DescID: 104 (t), Name: "idx", IndexID: 5 (idx+)}
-      │    ├── 3 elements transitioning toward TRANSIENT_ABSENT
-      │    │    ├── ABSENT      → DELETE_ONLY   TemporaryIndex:{DescID: 104 (t), IndexID: 6, ConstraintID: 5, SourceIndexID: 3 (t_pkey+)}
-      │    │    ├── ABSENT      → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 6}
-      │    │    └── ABSENT      → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 6}
+      ├── Stage 2 of 4 in PostCommitNonRevertiblePhase
+      │    ├── 2 elements transitioning toward PUBLIC
+      │    │    ├── VALIDATED   → PUBLIC     PrimaryIndex:{DescID: 104 (t), IndexID: 3 (t_pkey+), ConstraintID: 2, TemporaryIndexID: 4 (crdb_internal_index_4_name_placeholder), SourceIndexID: 1 (t_pkey-)}
+      │    │    └── ABSENT      → PUBLIC     IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 3 (t_pkey+)}
       │    ├── 8 elements transitioning toward ABSENT
-      │    │    ├── PUBLIC      → WRITE_ONLY    Column:{DescID: 104 (t), ColumnID: 2 (j-)}
-      │    │    ├── PUBLIC      → ABSENT        ColumnName:{DescID: 104 (t), Name: "j", ColumnID: 2 (j-)}
-      │    │    ├── DELETE_ONLY → ABSENT        Column:{DescID: 104 (t), ColumnID: 4 (crdb_internal_idx_expr-)}
-      │    │    ├── PUBLIC      → ABSENT        ColumnComputeExpression:{DescID: 104 (t), ColumnID: 4 (crdb_internal_idx_expr-), Usage: REGULAR}
-      │    │    ├── PUBLIC      → ABSENT        ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 4 (crdb_internal_idx_expr-), TypeName: "INT8"}
-      │    │    ├── PUBLIC      → VALIDATED     PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey-), ConstraintID: 1}
-      │    │    ├── PUBLIC      → ABSENT        IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey-)}
-      │    │    └── DELETE_ONLY → ABSENT        SecondaryIndex:{DescID: 104 (t), IndexID: 2 (t_expr_k_idx-), RecreateSourceIndexID: 0}
-      │    └── 20 Mutation operations
+      │    │    ├── PUBLIC      → WRITE_ONLY Column:{DescID: 104 (t), ColumnID: 2 (j-)}
+      │    │    ├── PUBLIC      → ABSENT     ColumnName:{DescID: 104 (t), Name: "j", ColumnID: 2 (j-)}
+      │    │    ├── DELETE_ONLY → ABSENT     Column:{DescID: 104 (t), ColumnID: 4 (crdb_internal_idx_expr-)}
+      │    │    ├── PUBLIC      → ABSENT     ColumnComputeExpression:{DescID: 104 (t), ColumnID: 4 (crdb_internal_idx_expr-), Usage: REGULAR}
+      │    │    ├── PUBLIC      → ABSENT     ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 4 (crdb_internal_idx_expr-), TypeName: "INT8"}
+      │    │    ├── PUBLIC      → VALIDATED  PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey-), ConstraintID: 1}
+      │    │    ├── PUBLIC      → ABSENT     IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey-)}
+      │    │    └── DELETE_ONLY → ABSENT     SecondaryIndex:{DescID: 104 (t), IndexID: 2 (t_expr_k_idx-), RecreateSourceIndexID: 0}
+      │    └── 11 Mutation operations
       │         ├── RemoveColumnComputeExpression {"ColumnID":4,"TableID":104}
       │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":1,"TableID":104}
       │         ├── SetIndexName {"IndexID":1,"Name":"crdb_internal_in...","TableID":104}
@@ -158,102 +229,39 @@ Schema change plan for CREATE UNIQUE INDEX ‹idx› ON ‹defaultdb›.‹publi
       │         ├── SetColumnName {"ColumnID":2,"Name":"crdb_internal_co...","TableID":104}
       │         ├── MakeDeleteOnlyColumnAbsent {"ColumnID":4,"TableID":104}
       │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":3,"TableID":104}
-      │         ├── MakeAbsentIndexBackfilling {"IsSecondaryIndex":true}
-      │         ├── MaybeAddSplitForIndex {"IndexID":5,"TableID":104}
-      │         ├── AddColumnToIndex {"ColumnID":3,"IndexID":5,"TableID":104}
-      │         ├── AddColumnToIndex {"ColumnID":1,"IndexID":5,"Kind":1,"TableID":104}
-      │         ├── SetIndexName {"IndexID":5,"Name":"idx","TableID":104}
-      │         ├── MakeAbsentTempIndexDeleteOnly {"IsSecondaryIndex":true}
-      │         ├── MaybeAddSplitForIndex {"IndexID":6,"TableID":104}
-      │         ├── AddColumnToIndex {"ColumnID":3,"IndexID":6,"TableID":104}
-      │         ├── AddColumnToIndex {"ColumnID":1,"IndexID":6,"Kind":1,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
-      ├── Stage 3 of 10 in PostCommitNonRevertiblePhase
-      │    ├── 2 elements transitioning toward TRANSIENT_ABSENT
-      │    │    ├── DELETE_ONLY → WRITE_ONLY  TemporaryIndex:{DescID: 104 (t), IndexID: 6, ConstraintID: 5, SourceIndexID: 3 (t_pkey+)}
-      │    │    └── ABSENT      → PUBLIC      IndexData:{DescID: 104 (t), IndexID: 6}
+      ├── Stage 3 of 4 in PostCommitNonRevertiblePhase
       │    ├── 5 elements transitioning toward ABSENT
-      │    │    ├── WRITE_ONLY  → DELETE_ONLY Column:{DescID: 104 (t), ColumnID: 2 (j-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 1 (t_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j-), IndexID: 1 (t_pkey-)}
-      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 1 (t_pkey-)}
-      │    │    └── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey-), ConstraintID: 1}
-      │    └── 8 Mutation operations
+      │    │    ├── WRITE_ONLY → DELETE_ONLY Column:{DescID: 104 (t), ColumnID: 2 (j-)}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 1 (t_pkey-)}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (j-), IndexID: 1 (t_pkey-)}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 1 (t_pkey-)}
+      │    │    └── VALIDATED  → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey-), ConstraintID: 1}
+      │    └── 7 Mutation operations
       │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":2,"TableID":104}
-      │         ├── MakeDeleteOnlyIndexWriteOnly {"IndexID":6,"TableID":104}
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":1,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":1,"Kind":2,"TableID":104}
       │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":1,"Kind":2,"Ordinal":1,"TableID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
-      ├── Stage 4 of 10 in PostCommitNonRevertiblePhase
-      │    ├── 1 element transitioning toward PUBLIC
-      │    │    └── BACKFILL_ONLY → BACKFILLED SecondaryIndex:{DescID: 104 (t), IndexID: 5 (idx+), ConstraintID: 4, TemporaryIndexID: 6, SourceIndexID: 3 (t_pkey+), RecreateSourceIndexID: 0}
-      │    └── 1 Backfill operation
-      │         └── BackfillIndex {"IndexID":5,"SourceIndexID":3,"TableID":104}
-      ├── Stage 5 of 10 in PostCommitNonRevertiblePhase
-      │    ├── 1 element transitioning toward PUBLIC
-      │    │    └── BACKFILLED  → DELETE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 5 (idx+), ConstraintID: 4, TemporaryIndexID: 6, SourceIndexID: 3 (t_pkey+), RecreateSourceIndexID: 0}
-      │    ├── 3 elements transitioning toward ABSENT
-      │    │    ├── DELETE_ONLY → ABSENT      Column:{DescID: 104 (t), ColumnID: 2 (j-)}
-      │    │    ├── PUBLIC      → ABSENT      ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 2 (j-), TypeName: "INT8"}
-      │    │    └── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey-), ConstraintID: 1}
-      │    └── 5 Mutation operations
-      │         ├── MakeIndexAbsent {"IndexID":1,"TableID":104}
-      │         ├── MakeBackfillingIndexDeleteOnly {"IndexID":5,"TableID":104}
-      │         ├── MakeDeleteOnlyColumnAbsent {"ColumnID":2,"TableID":104}
-      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
-      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
-      ├── Stage 6 of 10 in PostCommitNonRevertiblePhase
-      │    ├── 1 element transitioning toward PUBLIC
-      │    │    └── DELETE_ONLY → MERGE_ONLY SecondaryIndex:{DescID: 104 (t), IndexID: 5 (idx+), ConstraintID: 4, TemporaryIndexID: 6, SourceIndexID: 3 (t_pkey+), RecreateSourceIndexID: 0}
-      │    └── 3 Mutation operations
-      │         ├── MakeBackfilledIndexMerging {"IndexID":5,"TableID":104}
-      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
-      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
-      ├── Stage 7 of 10 in PostCommitNonRevertiblePhase
-      │    ├── 1 element transitioning toward PUBLIC
-      │    │    └── MERGE_ONLY → MERGED SecondaryIndex:{DescID: 104 (t), IndexID: 5 (idx+), ConstraintID: 4, TemporaryIndexID: 6, SourceIndexID: 3 (t_pkey+), RecreateSourceIndexID: 0}
-      │    └── 1 Backfill operation
-      │         └── MergeIndex {"BackfilledIndexID":5,"TableID":104,"TemporaryIndexID":6}
-      ├── Stage 8 of 10 in PostCommitNonRevertiblePhase
-      │    ├── 1 element transitioning toward PUBLIC
-      │    │    └── MERGED     → WRITE_ONLY            SecondaryIndex:{DescID: 104 (t), IndexID: 5 (idx+), ConstraintID: 4, TemporaryIndexID: 6, SourceIndexID: 3 (t_pkey+), RecreateSourceIndexID: 0}
-      │    ├── 3 elements transitioning toward TRANSIENT_ABSENT
-      │    │    ├── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 6, ConstraintID: 5, SourceIndexID: 3 (t_pkey+)}
-      │    │    ├── PUBLIC     → TRANSIENT_ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (k), IndexID: 6}
-      │    │    └── PUBLIC     → TRANSIENT_ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (i), IndexID: 6}
-      │    └── 6 Mutation operations
-      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"TableID":104}
-      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Kind":1,"TableID":104}
-      │         ├── MakeMergedIndexWriteOnly {"IndexID":5,"TableID":104}
-      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
-      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
-      ├── Stage 9 of 10 in PostCommitNonRevertiblePhase
-      │    ├── 1 element transitioning toward PUBLIC
-      │    │    └── WRITE_ONLY → VALIDATED SecondaryIndex:{DescID: 104 (t), IndexID: 5 (idx+), ConstraintID: 4, TemporaryIndexID: 6, SourceIndexID: 3 (t_pkey+), RecreateSourceIndexID: 0}
-      │    └── 1 Validation operation
-      │         └── ValidateIndex {"IndexID":5,"TableID":104}
-      └── Stage 10 of 10 in PostCommitNonRevertiblePhase
-           ├── 1 element transitioning toward PUBLIC
-           │    └── VALIDATED             → PUBLIC           SecondaryIndex:{DescID: 104 (t), IndexID: 5 (idx+), ConstraintID: 4, TemporaryIndexID: 6, SourceIndexID: 3 (t_pkey+), RecreateSourceIndexID: 0}
-           ├── 3 elements transitioning toward TRANSIENT_ABSENT
-           │    ├── PUBLIC                → TRANSIENT_ABSENT IndexData:{DescID: 104 (t), IndexID: 4 (crdb_internal_index_4_name_placeholder)}
-           │    ├── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 6, ConstraintID: 5, SourceIndexID: 3 (t_pkey+)}
-           │    └── PUBLIC                → TRANSIENT_ABSENT IndexData:{DescID: 104 (t), IndexID: 6}
-           ├── 2 elements transitioning toward ABSENT
-           │    ├── PUBLIC                → ABSENT           IndexData:{DescID: 104 (t), IndexID: 1 (t_pkey-)}
-           │    └── PUBLIC                → ABSENT           IndexData:{DescID: 104 (t), IndexID: 2 (t_expr_k_idx-)}
-           └── 9 Mutation operations
+      └── Stage 4 of 4 in PostCommitNonRevertiblePhase
+           ├── 2 elements transitioning toward TRANSIENT_ABSENT
+           │    ├── PUBLIC      → TRANSIENT_ABSENT IndexData:{DescID: 104 (t), IndexID: 4 (crdb_internal_index_4_name_placeholder)}
+           │    └── PUBLIC      → TRANSIENT_ABSENT IndexData:{DescID: 104 (t), IndexID: 6}
+           ├── 5 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY → ABSENT           Column:{DescID: 104 (t), ColumnID: 2 (j-)}
+           │    ├── PUBLIC      → ABSENT           ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 2 (j-), TypeName: "INT8"}
+           │    ├── DELETE_ONLY → ABSENT           PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey-), ConstraintID: 1}
+           │    ├── PUBLIC      → ABSENT           IndexData:{DescID: 104 (t), IndexID: 1 (t_pkey-)}
+           │    └── PUBLIC      → ABSENT           IndexData:{DescID: 104 (t), IndexID: 2 (t_expr_k_idx-)}
+           └── 8 Mutation operations
+                ├── MakeIndexAbsent {"IndexID":1,"TableID":104}
                 ├── CreateGCJobForIndex {"IndexID":1,"TableID":104}
                 ├── CreateGCJobForIndex {"IndexID":2,"TableID":104}
                 ├── CreateGCJobForIndex {"IndexID":4,"TableID":104}
-                ├── MakeValidatedSecondaryIndexPublic {"IndexID":5,"TableID":104}
-                ├── RefreshStats {"TableID":104}
-                ├── MakeIndexAbsent {"IndexID":6,"TableID":104}
                 ├── CreateGCJobForIndex {"IndexID":6,"TableID":104}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":2,"TableID":104}
                 ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
                 └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/testdata/end_to_end/drop_column_create_index_separate_statements/drop_column_create_index_separate_statements__statement_2_of_2.explain_shape
+++ b/pkg/sql/schemachanger/testdata/end_to_end/drop_column_create_index_separate_statements/drop_column_create_index_separate_statements__statement_2_of_2.explain_shape
@@ -14,7 +14,7 @@ Schema change plan for CREATE UNIQUE INDEX ‹idx› ON ‹defaultdb›.‹publi
  │    └── from crdb_internal_index_4_name_placeholder into t_pkey+
  ├── execute 1 system table mutations transaction
  ├── validate UNIQUE constraint backed by index t_pkey+ in relation t
- ├── execute 3 system table mutations transactions
+ ├── execute 2 system table mutations transactions
  ├── backfill using primary index t_pkey+ in relation t
  │    └── into idx+ (k: i)
  ├── execute 2 system table mutations transactions
@@ -22,4 +22,4 @@ Schema change plan for CREATE UNIQUE INDEX ‹idx› ON ‹defaultdb›.‹publi
  │    └── from t@[6] into idx+
  ├── execute 1 system table mutations transaction
  ├── validate UNIQUE constraint backed by index idx+ in relation t
- └── execute 1 system table mutations transaction
+ └── execute 4 system table mutations transactions

--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -2802,9 +2802,6 @@ func (og *operationGenerator) alterTableAlterPrimaryKey(
 		return nil, err
 	}
 
-	// TODO(sql-foundations): Until #130165 is resolved, we add this potential
-	// error.
-	og.potentialCommitErrors.add(pgcode.DuplicateColumn)
 	// There is a risk of unique violations if concurrent inserts
 	// happen during an ALTER PRIMARY KEY. So allow this to be
 	// a potential error on the commit.


### PR DESCRIPTION
Previously, the declarative schema changer during ALTER PRIMARY KEY, the declarative schema changer would make the new primary index public and then work on creating replacement secondary indexes. This could lead to broken behaviour where you could be left with either unusable old secondary indexes (causing trouble for DML queries) or potential validation errors. To address this, this patch adjusts the rules so that the new primary index is kept at a validated state, while replacement secondary indexes are constructed. This guarantees that all secondary indexes are usable during a PK swap, and the new primary key and replacement secondary indexes are swapped in an atomic fashion.

Additionally, to help support this change the index backfiller has been updated, so that a source index can be specified for backfilling indexes. This allows the index backfiller to use a validated primary index to create the secondary index, without exposing it to read queries.

Fixes: #133129
Fixes: #130165

Release note (bug fix): Addressed a bug where secondary indexes could be
unusable by DML while a primary key swap was occurring, if the new
primary key did not contain columns from the old primary key.