### PR TITLE
github, microbench-ci: add label check

### DIFF
--- a/.github/workflows/microbenchmarks-ci.yaml
+++ b/.github/workflows/microbenchmarks-ci.yaml
@@ -91,6 +91,7 @@ jobs:
         if: always()
   post:
     runs-on: [ self-hosted, basic_runner_group ]
+    if: contains(github.event.pull_request.labels.*.name, 'T-microbench-post') # TODO: remove this check once results are confirmed to be stable on CI.
     timeout-minutes: 30
     permissions:
         contents: read


### PR DESCRIPTION
For now keep the microbenchmark post hidden, util an appropriate method of
delivery can be decided. And the new `c4-standard-8` machine pool becomes
available.

Epic: None
Release note: None