### PR TITLE
crosscluster/logical: white list a few more ldr schema changes

### DIFF
--- a/pkg/sql/sem/tree/schema_helpers.go
+++ b/pkg/sql/sem/tree/schema_helpers.go
@@ -49,12 +49,20 @@ func IsAllowedLDRSchemaChange(n Statement, virtualColNames []string) bool {
 		return !s.Unique && s.Predicate == nil && s.Sharded == nil
 	case *DropIndex:
 		return true
+	case *AlterIndexVisible:
+		return true
+	case *RenameIndex:
+		return true
 	case *SetZoneConfig:
 		return true
 	case *AlterTable:
 		onlySafeStorageParams := true
 		for _, cmd := range s.Cmds {
 			switch c := cmd.(type) {
+			case *AlterTableSetVisible:
+				return true
+			case *AlterTableSetDefault:
+				return true
 			// Allow safe storage parameter changes.
 			case *AlterTableSetStorageParams:
 				// ttl_expire_after is not safe since it creates a new column and

--- a/pkg/sql/sem/tree/schema_helpers_test.go
+++ b/pkg/sql/sem/tree/schema_helpers_test.go
@@ -27,6 +27,18 @@ func TestIsAllowedLDRSchemaChange(t *testing.T) {
 			isAllowed: true,
 		},
 		{
+			stmt:      "ALTER INDEX idx NOT VISIBLE",
+			isAllowed: true,
+		},
+		{
+			stmt:      "ALTER INDEX idx CONFIGURE ZONE USING num_replicas = 3",
+			isAllowed: true,
+		},
+		{
+			stmt:      "ALTER INDEX idx RENAME TO idx2",
+			isAllowed: true,
+		},
+		{
 			stmt:      "CREATE UNIQUE INDEX idx ON t (a)",
 			isAllowed: false,
 		},
@@ -36,6 +48,18 @@ func TestIsAllowedLDRSchemaChange(t *testing.T) {
 		},
 		{
 			stmt:      "DROP INDEX idx",
+			isAllowed: true,
+		},
+		{
+			stmt:      "ALTER TABLE t ALTER COLUMN a SET DEFAULT 10",
+			isAllowed: true,
+		},
+		{
+			stmt:      "ALTER TABLE t ALTER COLUMN a DROP DEFAULT",
+			isAllowed: true,
+		},
+		{
+			stmt:      "ALTER TABLE t ALTER COLUMN a SET NOT VISIBLE",
 			isAllowed: true,
 		},
 		{
@@ -60,6 +84,14 @@ func TestIsAllowedLDRSchemaChange(t *testing.T) {
 		},
 		{
 			stmt:      "ALTER TABLE t ADD COLUMN a INT, SET (ttl = 'on', ttl_expiration_expression = 'expires_at')",
+			isAllowed: false,
+		},
+		{
+			stmt:      "ALTER TABLE t RENAME COLUMN a TO b",
+			isAllowed: false,
+		},
+		{
+			stmt:      "ALTER TABLE t DROP COLUMN a",
 			isAllowed: false,
 		},
 		{


### PR DESCRIPTION
In addition, a test was added for the already white listed schema change.
- ALTER INDEX CONFIGURE ZONE

Fixes: CRDB-47859
Epic: CRDB-44098

Release note (ops change): the following schema changes are now whitelisted to
run during LDR.
- ALTER INDEX RENAME
- ALTER INDEX .. NOT VISIBLE
- ALTER TABLE .. ALTER COLUMN .. SET DEFAULT
- ALTER TABLE .. ALTER COLUMN .. DROP DEFAULT
- ALTER TABLE .. ALTER COLUMN SET VISIBLE