### PR TITLE
kvserver: deflake TestStoreRangeSplitWithConcurrentWrites

### DIFF
--- a/pkg/kv/kvserver/client_split_test.go
+++ b/pkg/kv/kvserver/client_split_test.go
@@ -957,9 +957,10 @@ func TestStoreRangeSplitWithConcurrentWrites(t *testing.T) {
 					s := serverutils.StartServerOnly(t, base.TestServerArgs{
 						Knobs: base.TestingKnobs{
 							Store: &kvserver.StoreTestingKnobs{
-								DisableMergeQueue:    true,
-								DisableSplitQueue:    true,
-								TestingRequestFilter: filter,
+								DisableMergeQueue:       true,
+								DisableSplitQueue:       true,
+								DisableConsistencyQueue: true,
+								TestingRequestFilter:    filter,
 							},
 						},
 						Settings: settings,
@@ -1061,8 +1062,7 @@ func TestStoreRangeSplitWithConcurrentWrites(t *testing.T) {
 						assertRecomputedStats(t, "LHS2 after second split", snap, lhs2Repl.Desc(), lhs2Stats, s.Clock().PhysicalNow())
 						assertRecomputedStats(t, "RHS1 after second split", snap, rhsRepl.Desc(), rhs1Stats, s.Clock().PhysicalNow())
 						assertRecomputedStats(t, "RHS2 after second split", snap, rhs2Repl.Desc(), rhs2Stats, s.Clock().PhysicalNow())
-					}
-					if expectContainsEstimates {
+					} else {
 						require.Greater(t, lhs1Stats.ContainsEstimates, int64(0))
 						require.Greater(t, lhs2Stats.ContainsEstimates, int64(0))
 						// The range corresponding to rhs1Stats is empty, so the split of the


### PR DESCRIPTION
This test had a bug where it was expecting MVCC stats with estimates even when they were supposed to be corrected. The test worked most of the time because the stats correction took some time to finish, so the test assrtion did see estimated stats before that. However, under deadlock or race, the stats were occasionally corrected before the test assertion.

This commit fixes the test assertion logic, and also disables the consistency checker queue to prevent it from potentially correcting the stats unexpectedly.

Fixes: #140031

Release note: None