### PR TITLE
util/json: add `AllPathsWithDepth`

### DIFF
--- a/pkg/util/json/encoded.go
+++ b/pkg/util/json/encoded.go
@@ -797,12 +797,12 @@ func (j *jsonEncoded) numInvertedIndexEntries() (int, error) {
 	return decoded.numInvertedIndexEntries()
 }
 
-func (j *jsonEncoded) allPaths() ([]JSON, error) {
+func (j *jsonEncoded) allPathsWithDepth(depth int) ([]JSON, error) {
 	decoded, err := j.decode()
 	if err != nil {
 		return nil, err
 	}
-	return decoded.allPaths()
+	return decoded.allPathsWithDepth(depth)
 }
 
 // HasContainerLeaf implements the JSON interface.

--- a/pkg/util/json/json.go
+++ b/pkg/util/json/json.go
@@ -136,10 +136,12 @@ type JSON interface {
 	// produced if this JSON gets included in an inverted index.
 	numInvertedIndexEntries() (int, error)
 
-	// allPaths returns a slice of new JSON documents, each a path to a leaf
-	// through the receiver. Note that leaves include the empty object and array
-	// in addition to scalars.
-	allPaths() ([]JSON, error)
+	// allPathsWithDepth returns a slice of new JSON documents, each a path
+	// through the receiver. The depth parameter specifies the maximum depth of
+	// the paths to return. If the depth is negative, all paths of any depth are
+	// returned. If the depth is 0, the receiver itself is returned. Note that
+	// leaves include the empty object and array in addition to scalars.
+	allPathsWithDepth(depth int) ([]JSON, error)
 
 	// FetchValKey implements the `->` operator for strings, returning nil if the
 	// key is not found.
@@ -1717,36 +1719,51 @@ func (j jsonObject) numInvertedIndexEntries() (int, error) {
 // through the input. Note that leaves include the empty object and array
 // in addition to scalars.
 func AllPaths(j JSON) ([]JSON, error) {
-	return j.allPaths()
+	return j.allPathsWithDepth(-1)
 }
 
-func (j jsonNull) allPaths() ([]JSON, error) {
+// AllPathsWithDepth returns a slice of new JSON documents, each a path
+// through the receiver. The depth parameter specifies the maximum depth of
+// the paths to return. If the depth is negative, all paths of any depth are
+// returned. If the depth is 0, the receiver itself is returned. Note that
+// leaves include the empty object and array in addition to scalars.
+func AllPathsWithDepth(j JSON, depth int) ([]JSON, error) {
+	return j.allPathsWithDepth(depth)
+}
+
+func (j jsonNull) allPathsWithDepth(depth int) ([]JSON, error) {
 	return []JSON{j}, nil
 }
 
-func (j jsonTrue) allPaths() ([]JSON, error) {
+func (j jsonTrue) allPathsWithDepth(depth int) ([]JSON, error) {
 	return []JSON{j}, nil
 }
 
-func (j jsonFalse) allPaths() ([]JSON, error) {
+func (j jsonFalse) allPathsWithDepth(depth int) ([]JSON, error) {
 	return []JSON{j}, nil
 }
 
-func (j jsonString) allPaths() ([]JSON, error) {
+func (j jsonString) allPathsWithDepth(depth int) ([]JSON, error) {
 	return []JSON{j}, nil
 }
 
-func (j jsonNumber) allPaths() ([]JSON, error) {
+func (j jsonNumber) allPathsWithDepth(depth int) ([]JSON, error) {
 	return []JSON{j}, nil
 }
 
-func (j jsonArray) allPaths() ([]JSON, error) {
-	if len(j) == 0 {
+func (j jsonArray) allPathsWithDepth(depth int) ([]JSON, error) {
+	if len(j) == 0 || depth == 0 {
 		return []JSON{j}, nil
 	}
 	ret := make([]JSON, 0, len(j))
 	for i := range j {
-		paths, err := j[i].allPaths()
+		var paths []JSON
+		var err error
+		if depth > 0 {
+			paths, err = j[i].allPathsWithDepth(depth - 1)
+		} else {
+			paths, err = j[i].allPathsWithDepth(depth)
+		}
 		if err != nil {
 			return nil, err
 		}
@@ -1757,13 +1774,19 @@ func (j jsonArray) allPaths() ([]JSON, error) {
 	return ret, nil
 }
 
-func (j jsonObject) allPaths() ([]JSON, error) {
-	if len(j) == 0 {
+func (j jsonObject) allPathsWithDepth(depth int) ([]JSON, error) {
+	if len(j) == 0 || depth == 0 {
 		return []JSON{j}, nil
 	}
 	ret := make([]JSON, 0, len(j))
 	for i := range j {
-		paths, err := j[i].v.allPaths()
+		var paths []JSON
+		var err error
+		if depth > 0 {
+			paths, err = j[i].v.allPathsWithDepth(depth - 1)
+		} else {
+			paths, err = j[i].v.allPathsWithDepth(depth)
+		}
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/util/json/json_test.go
+++ b/pkg/util/json/json_test.go
@@ -2825,3 +2825,104 @@ func TestToDecimal(t *testing.T) {
 		})
 	}
 }
+
+func TestAllPaths(t *testing.T) {
+	cases := []struct {
+		json     string
+		expected []string
+	}{
+		{`{}`, []string{`{}`}},
+		{`[]`, []string{`[]`}},
+		{`[1, 2, 3]`, []string{`[1]`, `[2]`, `[3]`}},
+		{`{"foo": {"bar": [1, 2, 3]}}`, []string{`{"foo": {"bar": [1]}}`, `{"foo": {"bar": [2]}}`, `{"foo": {"bar": [3]}}`}},
+		{
+			`{"a": [1, 2, true, false], "b": {"ba": 0, "bb": null}, "c": {}}`,
+			[]string{`{"a": [1]}`, `{"a": [2]}`, `{"a": [true]}`, `{"a": [false]}`, `{"b": {"ba": 0}}`, `{"b": {"bb": null}}`, `{"c": {}}`},
+		},
+	}
+
+	for i, tc := range cases {
+		t.Run(fmt.Sprintf("all paths - %d", i), func(t *testing.T) {
+			j := parseJSON(t, tc.json)
+			paths, err := AllPaths(j)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(paths) != len(tc.expected) {
+				t.Fatalf("expected %d paths, got %d", len(tc.expected), len(paths))
+			}
+			for k, p := range paths {
+				cmp, err := p.Compare(parseJSON(t, tc.expected[k]))
+				if err != nil {
+					t.Fatal(err)
+				}
+				if cmp != 0 {
+					t.Fatalf("expected %s, got %s", tc.expected[k], p.String())
+				}
+			}
+		})
+	}
+}
+
+func TestAllPathsWithDepth(t *testing.T) {
+	cases := []struct {
+		json            string
+		depthToExpected map[int][]string
+	}{
+		{`{}`, map[int][]string{
+			-1: {`{}`},
+			0:  {`{}`},
+			1:  {`{}`},
+			2:  {`{}`},
+		}},
+		{`[]`, map[int][]string{
+			-1: {`[]`},
+			0:  {`[]`},
+			1:  {`[]`},
+			2:  {`[]`},
+		}},
+		{`[1, 2, 3]`, map[int][]string{
+			-1: {`[1]`, `[2]`, `[3]`},
+			0:  {`[1, 2, 3]`},
+			1:  {`[1]`, `[2]`, `[3]`},
+			2:  {`[1]`, `[2]`, `[3]`},
+		}},
+		{`{"foo": {"bar": [1, 2, 3]}}`, map[int][]string{
+			-1: {`{"foo": {"bar": [1]}}`, `{"foo": {"bar": [2]}}`, `{"foo": {"bar": [3]}}`},
+			0:  {`{"foo": {"bar": [1, 2, 3]}}`},
+			1:  {`{"foo": {"bar": [1, 2, 3]}}`},
+			2:  {`{"foo": {"bar": [1, 2, 3]}}`},
+			3:  {`{"foo": {"bar": [1]}}`, `{"foo": {"bar": [2]}}`, `{"foo": {"bar": [3]}}`},
+		}},
+		{`{"a": [1, 2, true, false], "b": {"ba": 0, "bb": null}, "c": {}}`, map[int][]string{
+			-1: {`{"a": [1]}`, `{"a": [2]}`, `{"a": [true]}`, `{"a": [false]}`, `{"b": {"ba": 0}}`, `{"b": {"bb": null}}`, `{"c": {}}`},
+			0:  {`{"a": [1, 2, true, false], "b": {"ba": 0, "bb": null}, "c": {}}`},
+			1:  {`{"a": [1, 2, true, false]}`, `{"b": {"ba": 0, "bb": null}}`, `{"c": {}}`},
+			2:  {`{"a": [1]}`, `{"a": [2]}`, `{"a": [true]}`, `{"a": [false]}`, `{"b": {"ba": 0}}`, `{"b": {"bb": null}}`, `{"c": {}}`},
+		}},
+	}
+
+	for i, tc := range cases {
+		t.Run(fmt.Sprintf("all paths with depth - %d", i), func(t *testing.T) {
+			j := parseJSON(t, tc.json)
+			for depth, expected := range tc.depthToExpected {
+				paths, err := AllPathsWithDepth(j, depth)
+				if err != nil {
+					t.Fatal(err)
+				}
+				if len(paths) != len(expected) {
+					t.Fatalf("expected %d paths, got %d", len(expected), len(paths))
+				}
+				for k, p := range paths {
+					cmp, err := p.Compare(parseJSON(t, expected[k]))
+					if err != nil {
+						t.Fatal(err)
+					}
+					if cmp != 0 {
+						t.Fatalf("expected %s, got %s", expected[k], p.String())
+					}
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Previously, `AllPaths` within the `json` package would search the entire JSON document until a leaf is found. This PR adds another function, `AllPathsWithDepth` which limits how deep into the JSON document to search. This will be helpful for `jsonb_path_query`, as wildcard accessors (`[*]`) need to search for all paths one level deep.

Epic: None
Release note: None