### PR TITLE
cdc: Export should emit "done" indicator

### DIFF
--- a/pkg/ccl/changefeedccl/changefeedbase/options.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/options.go
@@ -492,7 +492,7 @@ type OptionsSet map[string]struct{}
 
 // InitialScanOnlyUnsupportedOptions is options that are not supported with the
 // initial scan only option
-var InitialScanOnlyUnsupportedOptions OptionsSet = makeStringSet(OptEndTime, OptResolvedTimestamps, OptDiff,
+var InitialScanOnlyUnsupportedOptions OptionsSet = makeStringSet(OptEndTime, OptDiff,
 	OptMVCCTimestamps, OptUpdatedTimestamps)
 
 // ParquetFormatUnsupportedOptions is options that are not supported with the

--- a/pkg/ccl/changefeedccl/scheduled_changefeed_test.go
+++ b/pkg/ccl/changefeedccl/scheduled_changefeed_test.go
@@ -640,17 +640,6 @@ func TestScheduledChangefeedErrors(t *testing.T) {
 		hintStr string
 	}{
 		{
-			name:    "implicit-conflict-with-initial-scan-only",
-			stmt:    "CREATE SCHEDULE test_schedule FOR CHANGEFEED t1 INTO 'null://sink' WITH resolved RECURRING '@daily';",
-			errRE:   "cannot specify both initial_scan='only' and resolved",
-			hintStr: "scheduled changefeeds implicitly pass the option initial_scan='only'",
-		},
-		{
-			name:  "explicit-conflict-with-initial-scan-only",
-			stmt:  "CREATE SCHEDULE test_schedule FOR CHANGEFEED t1 INTO 'null://sink' WITH resolved, initial_scan='only' RECURRING '@daily';",
-			errRE: "cannot specify both initial_scan='only' and resolved",
-		},
-		{
 			name:  "explicit-conflict-with-initial-scan-only",
 			stmt:  "CREATE SCHEDULE test_schedule FOR CHANGEFEED t1 INTO 'null://sink' WITH resolved, initial_scan='no' RECURRING '@daily';",
 			errRE: "initial_scan must be `only` for scheduled changefeeds",

--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -565,9 +565,6 @@ func (ct *cdcTester) newChangefeed(args feedArgs) changefeedJob {
 
 	for option, value := range args.opts {
 		feedOptions[option] = value
-		if option == "initial_scan_only" || (option == "initial_scan" && value == "'only'") {
-			delete(feedOptions, "resolved")
-		}
 	}
 
 	ct.t.Status(fmt.Sprintf(


### PR DESCRIPTION
Fixes: #110985 
Jira issue: [CRDB-31703](https://cockroachlabs.atlassian.net/browse/CRDB-31703)

Allows `"resolved"` option to be used when `initial_scan=only` option specified.
This enables consumers to determine export completion without querying job status as a done marker is emitted.