### PR TITLE
microbench-ci: enable Position Independent Execution (PIE) builds

### DIFF
--- a/build/github/microbenchmarks/build.sh
+++ b/build/github/microbenchmarks/build.sh
@@ -26,6 +26,7 @@ fi
 bazel build "//${TEST_PKG}:tests_test" \
   --jobs 100 \
   --crdb_test_off \
+  --linkopt=-pie \
   --bes_keywords integration-test-artifact-build \
   --config=crosslinux \
   --remote_download_minimal \


### PR DESCRIPTION
Previously, microbenchmark binaries were built without Position Independent
Execution (PIE). This patch enables PIE to improve benchmark reliability by
allowing Address Space Layout Randomization (ASLR) to vary the binary's base
address between runs, which helps avoid hitting a local minimum. While this is a
step towards more robust benchmarking, additional measures may still be needed
for fully sound statistical comparisons.

Epic: None
Release note: None