### PR TITLE
catalog/lease: populate SessionID for historical leases

### DIFF
--- a/pkg/sql/catalog/lease/descriptor_state.go
+++ b/pkg/sql/catalog/lease/descriptor_state.go
@@ -181,13 +181,12 @@ func newDescriptorVersionState(
 			version: int(desc.GetVersion()),
 		}
 		descState.mu.lease.sessionID = session.ID().UnsafeBytes()
-		descState.mu.session = session
-
 		if buildutil.CrdbTestBuild && !expiration.IsEmpty() {
 			panic(errors.AssertionFailedf("expiration should always be empty for "+
 				"session based leases (got: %s on Desc: %s(%d))", expiration.String(), desc.GetName(), desc.GetID()))
 		}
 	}
+	descState.mu.session = session
 	descState.mu.expiration = expiration
 
 	return descState

--- a/pkg/sql/catalog/lease/descriptor_version_state.go
+++ b/pkg/sql/catalog/lease/descriptor_version_state.go
@@ -60,9 +60,7 @@ type descriptorVersionState struct {
 		// when the version isn't associated with a lease.
 		expiration hlc.Timestamp
 
-		// The session that was used to acquire this descriptor version, which is
-		// only populated when the session based leasing mode is *at least* dual
-		// write.
+		// The session that was used to acquire this descriptor version.
 		session sqlliveness.Session
 
 		refcount int


### PR DESCRIPTION
Previously, we were seeing intermittent panics in scenarios where
historical descriptors were accessed followed by reads of newer
descriptor versions. This would happen because the SessionID on
historical versions would be blank, causing our checks for detecting
changes to fails. To address this, this patch always populates the
session ID inside the descriptor versions.

Fixes: #141877
Fixes: #141876
Fixes: #141855

Release note: None