### PR TITLE
sql: add substring_index built-in function

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -3161,6 +3161,9 @@ Case mode values range between 0 - 1, representing lower casing and upper casing
 </span></td><td>Immutable</td></tr>
 <tr><td><a name="substring"></a><code>substring(input: varbit, start_pos: <a href="int.html">int</a>, length: <a href="int.html">int</a>) &rarr; varbit</code></td><td><span class="funcdesc"><p>Returns a bit subarray of <code>input</code> starting at <code>start_pos</code> (count starts at 1) and including up to <code>length</code> characters.</p>
 </span></td><td>Immutable</td></tr>
+<tr><td><a name="substring_index"></a><code>substring_index(input: <a href="string.html">string</a>, delim: <a href="string.html">string</a>, count: <a href="int.html">int</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Returns a substring of <code>input</code> before <code>count</code> occurrences of <code>delim</code>.
+If <code>count</code> is positive, the leftmost part is returned. If <code>count</code> is negative, the rightmost part is returned.</p>
+</span></td><td>Immutable</td></tr>
 <tr><td><a name="to_char_with_style"></a><code>to_char_with_style(date: <a href="date.html">date</a>, datestyle: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Convert an date to a string assuming the string is formatted using the given DateStyle.</p>
 </span></td><td>Immutable</td></tr>
 <tr><td><a name="to_char_with_style"></a><code>to_char_with_style(interval: <a href="interval.html">interval</a>, style: <a href="string.html">string</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Convert an interval to a string using the given IntervalStyle.</p>

--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -4407,4 +4407,106 @@ SELECT crdb_internal.type_is_indexable(NULL);
 ----
 NULL
 
+subtest substring_index
+
+# Test basic behavior of substring_index
+query T
+SELECT substring_index('www.cockroachlabs.com', '.', 2);
+----
+www.cockroachlabs
+
+query T
+SELECT substring_index('www.cockroachlabs.com', '.', -2);
+----
+cockroachlabs.com
+
+query T
+SELECT substring_index('hello.world.example.com', '.', 3);
+----
+hello.world.example
+
+query T
+SELECT substring_index('hello.world.example.com', '.', -1);
+----
+com
+
+# Test when count is 0, should return empty string
+query T
+SELECT substring_index('111-22222-3333', '-', 0);
+----
+·
+
+# Test when count exceeds available delimiters, should return full string
+query T
+SELECT substring_index('example.com', '.', 5);
+----
+example.com
+
+query T
+SELECT substring_index('example.com', '.', -5);
+----
+example.com
+
+# Test when delimiter is not found in the string, should return full string
+query T
+SELECT substring_index('no.delimiters.here', ':', 1);
+----
+no.delimiters.here
+
+query T
+SELECT substring_index('singleword', '.', 1);
+----
+singleword
+
+# Test when input is empty, should return empty string
+query T
+SELECT substring_index('', '.', 1);
+----
+·
+
+
+# Test when delimiter is empty, should return empty string
+query T
+SELECT substring_index('teststring', '', 1);
+----
+·
+
+# Test NULL behavior, should return NULL if any argument is NULL
+query T
+SELECT substring_index(NULL, '.', 1);
+----
+NULL
+
+query T
+SELECT substring_index('test.string', NULL, 1);
+----
+NULL
+
+query T
+SELECT substring_index('test.string', '.', NULL);
+----
+NULL
+
+# Test with multi-character delimiters
+query T
+SELECT substring_index('apple--banana--cherry--date', '--', 2);
+----
+apple--banana
+
+query T
+SELECT substring_index('apple--banana--cherry--date', '--', -2);
+----
+cherry--date
+
+# Test when the string contains repeated delimiters
+query T
+SELECT substring_index('a..b..c..d', '..', 2);
+----
+a..b
+
+query T
+SELECT substring_index('a..b..c..d', '..', -2);
+----
+c..d
+
 subtest end

--- a/pkg/sql/sem/builtins/fixed_oids.go
+++ b/pkg/sql/sem/builtins/fixed_oids.go
@@ -2643,6 +2643,7 @@ var builtinOidsArray = []string{
 	2680: `jsonpath(jsonpath: jsonpath) -> jsonpath`,
 	2681: `varchar(jsonpath: jsonpath) -> varchar`,
 	2682: `char(jsonpath: jsonpath) -> "char"`,
+	2683: `substring_index(input: string, delim: string, count: int) -> string`,
 }
 
 var builtinOidsBySignature map[string]oid.Oid


### PR DESCRIPTION
This commit introduces the `substring_index` built-in function, mirroring MySQL's behavior. `substring_index` returns a substring of `input` before `count` occurrences of `delim`. If `count` is positive, the leftmost part is returned. If `count` is negative, the rightmost part is returned.

```
demo@127.0.0.1:26257/demoapp/db> SELECT substring_index('www.cockroachlabs.com', '.', 2);
   substring_index
---------------------
  www.cockroachlabs
(1 row)

Time: 3ms total (execution 3ms / network 0ms)

demo@127.0.0.1:26257/demoapp/db> SELECT substring_index('www.cockroachlabs.com', '.', -2);
   substring_index
---------------------
  cockroachlabs.com
(1 row)

Time: 1ms total (execution 1ms / network 0ms)
```

[TREQ-900](https://cockroachlabs.atlassian.net/browse/TREQ-900)
Epic: none
Release note (sql change): Added the `substring_index` built-in function, which extracts a portion of a string based on a specified delimiter and occurrence count, following MySQL behavior.