### PR TITLE
raft: introduce MsgPropConfig

### DIFF
--- a/pkg/kv/kvserver/raft.go
+++ b/pkg/kv/kvserver/raft.go
@@ -22,7 +22,7 @@ import (
 )
 
 // maxRaftMsgType is the maximum value in the raft.MessageType enum.
-const maxRaftMsgType = raftpb.MsgDeFortifyLeader
+const maxRaftMsgType = raftpb.MsgPropConfig
 
 func init() {
 	for v := range raftpb.MessageType_name {

--- a/pkg/raft/node.go
+++ b/pkg/raft/node.go
@@ -124,5 +124,5 @@ func confChangeToMsg(c pb.ConfChangeI) (pb.Message, error) {
 	if err != nil {
 		return pb.Message{}, err
 	}
-	return pb.Message{Type: pb.MsgProp, Entries: []pb.Entry{{Type: typ, Data: data}}}, nil
+	return pb.Message{Type: pb.MsgPropConfig, Entries: []pb.Entry{{Type: typ, Data: data}}}, nil
 }

--- a/pkg/raft/node_test.go
+++ b/pkg/raft/node_test.go
@@ -127,7 +127,7 @@ func TestNodeProposeConfig(t *testing.T) {
 
 	require.Len(t, msgs, 2)
 	assert.Equal(t, raftpb.MsgFortifyLeaderResp, msgs[0].Type)
-	assert.Equal(t, raftpb.MsgProp, msgs[1].Type)
+	assert.Equal(t, raftpb.MsgPropConfig, msgs[1].Type)
 	assert.Equal(t, ccdata, msgs[1].Entries[0].Data)
 }
 

--- a/pkg/raft/raft_test.go
+++ b/pkg/raft/raft_test.go
@@ -3274,7 +3274,7 @@ func TestStepConfig(t *testing.T) {
 	r.becomeCandidate()
 	r.becomeLeader()
 	index := r.raftLog.lastIndex()
-	r.Step(pb.Message{From: 1, To: 1, Type: pb.MsgProp, Entries: []pb.Entry{{Type: pb.EntryConfChange}}})
+	r.Step(pb.Message{From: 1, To: 1, Type: pb.MsgPropConfig, Entries: []pb.Entry{{Type: pb.EntryConfChange}}})
 	assert.Equal(t, index+1, r.raftLog.lastIndex())
 	assert.Equal(t, index+1, r.pendingConfIndex)
 }
@@ -3287,14 +3287,16 @@ func TestStepIgnoreConfig(t *testing.T) {
 	r := newTestRaft(1, 10, 1, newTestMemoryStorage(withPeers(1, 2)))
 	r.becomeCandidate()
 	r.becomeLeader()
-	r.Step(pb.Message{From: 1, To: 1, Type: pb.MsgProp, Entries: []pb.Entry{{Type: pb.EntryConfChange}}})
+	r.Step(pb.Message{From: 1, To: 1, Type: pb.MsgPropConfig, Entries: []pb.Entry{{Type: pb.EntryConfChange}}})
 	index := r.raftLog.lastIndex()
 	pendingConfIndex := r.pendingConfIndex
-	r.Step(pb.Message{From: 1, To: 1, Type: pb.MsgProp, Entries: []pb.Entry{{Type: pb.EntryConfChange}}})
-	wents := []pb.Entry{{Type: pb.EntryNormal, Term: 1, Index: 3, Data: nil}}
+	require.Error(t, ErrProposalDropped, r.Step(pb.Message{
+		From: 1, To: 1, Type: pb.MsgPropConfig,
+		Entries: []pb.Entry{{Type: pb.EntryConfChange}},
+	}))
 	ents, err := r.raftLog.entries(index, noLimit)
 	require.NoError(t, err)
-	assert.Equal(t, wents, ents)
+	assert.Empty(t, ents)
 	assert.Equal(t, pendingConfIndex, r.pendingConfIndex)
 }
 

--- a/pkg/raft/raftpb/raft.proto
+++ b/pkg/raft/raftpb/raft.proto
@@ -39,10 +39,13 @@ message Snapshot {
 
 // For description of different message types, see:
 // https://pkg.go.dev/go.etcd.io/raft/v3#hdr-MessageType
+//
+// Next value: 28.
 enum MessageType {
   MsgHup               = 0;
   MsgBeat              = 1;
   MsgProp              = 2;
+  MsgPropConfig        = 27;
   MsgApp               = 3;
   MsgAppResp           = 4;
   MsgVote              = 5;

--- a/pkg/raft/testdata/confchange_drop_if_unapplied.txt
+++ b/pkg/raft/testdata/confchange_drop_if_unapplied.txt
@@ -50,6 +50,7 @@ propose-conf-change 1
 l4
 ----
 INFO 1 ignoring conf change {ConfChangeTransitionAuto [{ConfChangeAddLearnerNode 4}] []} at config voters=(1): possible unapplied conf change at index 4 (applied to 3)
+raft proposal dropped
 
 # The new config change is appended to the log as an empty entry.
 stabilize 1
@@ -57,18 +58,13 @@ stabilize 1
 > 1 handling Ready
   Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:4 Lead:1 LeadEpoch:1
-  Entries:
-  1/5 EntryNormal ""
   CommittedEntries:
   1/4 EntryConfChangeV2 l2 l3
   INFO 1 switched to configuration voters=(1)&&(1) learners=(2 3)
 > 1 handling Ready
-  Ready MustSync=true:
-  HardState Term:1 Vote:1 Commit:5 Lead:1 LeadEpoch:1
-  CommittedEntries:
-  1/5 EntryNormal ""
+  Ready MustSync=false:
   Messages:
   1->2 MsgFortifyLeader Term:1 Log:0/0
   1->3 MsgFortifyLeader Term:1 Log:0/0
-  1->2 MsgApp Term:1 Log:1/4 Commit:4 Entries:[1/5 EntryNormal ""]
-  1->3 MsgApp Term:1 Log:1/4 Commit:4 Entries:[1/5 EntryNormal ""]
+  1->2 MsgApp Term:1 Log:1/3 Commit:4 Entries:[1/4 EntryConfChangeV2 l2 l3]
+  1->3 MsgApp Term:1 Log:1/3 Commit:4 Entries:[1/4 EntryConfChangeV2 l2 l3]

--- a/pkg/raft/testdata/confchange_fortification_safety.txt
+++ b/pkg/raft/testdata/confchange_fortification_safety.txt
@@ -134,17 +134,11 @@ propose-conf-change 1
 r2 l2
 ----
 INFO 1 ignoring conf change {ConfChangeTransitionAuto [{ConfChangeRemoveNode 2} {ConfChangeAddLearnerNode 2}] []} at config voters=(1 2 3 4): lead support has not caught up to previous configuration
+raft proposal dropped
 
 # Fortify v4 so that lead support catches up.
 stabilize 1 4
 ----
-> 1 handling Ready
-  Ready MustSync=true:
-  Entries:
-  1/5 EntryNormal ""
-  Messages:
-  1->2 MsgApp Term:1 Log:1/4 Commit:4 Entries:[1/5 EntryNormal ""]
-  1->3 MsgApp Term:1 Log:1/4 Commit:4 Entries:[1/5 EntryNormal ""]
 > 4 receiving messages
   1->4 MsgFortifyLeader Term:1 Log:0/0
   INFO 4 [term: 0] received a MsgFortifyLeader message with higher term from 1 [term: 1], new leader indicated, advancing term
@@ -166,25 +160,17 @@ stabilize 1 4
 > 1 handling Ready
   Ready MustSync=false:
   Messages:
-  1->4 MsgApp Term:1 Log:1/3 Commit:4 Entries:[
-    1/4 EntryConfChangeV2 v4
-    1/5 EntryNormal ""
-  ]
+  1->4 MsgApp Term:1 Log:1/3 Commit:4 Entries:[1/4 EntryConfChangeV2 v4]
   1->4 MsgApp Term:1 Log:1/2 Commit:4 Entries:[
     1/3 EntryNormal ""
     1/4 EntryConfChangeV2 v4
-    1/5 EntryNormal ""
   ]
 > 4 receiving messages
-  1->4 MsgApp Term:1 Log:1/3 Commit:4 Entries:[
-    1/4 EntryConfChangeV2 v4
-    1/5 EntryNormal ""
-  ]
+  1->4 MsgApp Term:1 Log:1/3 Commit:4 Entries:[1/4 EntryConfChangeV2 v4]
   DEBUG 4 [logterm: 0, index: 3] rejected MsgApp [logterm: 1, index: 3] from 1
   1->4 MsgApp Term:1 Log:1/2 Commit:4 Entries:[
     1/3 EntryNormal ""
     1/4 EntryConfChangeV2 v4
-    1/5 EntryNormal ""
   ]
 > 4 handling Ready
   Ready MustSync=true:
@@ -192,18 +178,17 @@ stabilize 1 4
   Entries:
   1/3 EntryNormal ""
   1/4 EntryConfChangeV2 v4
-  1/5 EntryNormal ""
   CommittedEntries:
   1/3 EntryNormal ""
   1/4 EntryConfChangeV2 v4
   Messages:
   4->1 MsgAppResp Term:1 Log:1/3 Rejected (Hint: 2) Commit:2
-  4->1 MsgAppResp Term:1 Log:0/5 Commit:4
+  4->1 MsgAppResp Term:1 Log:0/4 Commit:4
   INFO 4 switched to configuration voters=(1 2 3 4)
 > 1 receiving messages
   4->1 MsgAppResp Term:1 Log:1/3 Rejected (Hint: 2) Commit:2
   DEBUG 1 received MsgAppResp(rejected, hint: (index 2, term 1)) from 4 for index 3
-  4->1 MsgAppResp Term:1 Log:0/5 Commit:4
+  4->1 MsgAppResp Term:1 Log:0/4 Commit:4
 
 store-liveness
 ----
@@ -231,185 +216,161 @@ stabilize
 > 1 handling Ready
   Ready MustSync=true:
   Entries:
-  1/6 EntryConfChangeV2 r2 l2
+  1/5 EntryConfChangeV2 r2 l2
   Messages:
-  1->2 MsgApp Term:1 Log:1/5 Commit:4 Entries:[1/6 EntryConfChangeV2 r2 l2]
-  1->3 MsgApp Term:1 Log:1/5 Commit:4 Entries:[1/6 EntryConfChangeV2 r2 l2]
-  1->4 MsgApp Term:1 Log:1/5 Commit:4 Entries:[1/6 EntryConfChangeV2 r2 l2]
+  1->2 MsgApp Term:1 Log:1/4 Commit:4 Entries:[1/5 EntryConfChangeV2 r2 l2]
+  1->3 MsgApp Term:1 Log:1/4 Commit:4 Entries:[1/5 EntryConfChangeV2 r2 l2]
+  1->4 MsgApp Term:1 Log:1/4 Commit:4 Entries:[1/5 EntryConfChangeV2 r2 l2]
 > 2 receiving messages
-  1->2 MsgApp Term:1 Log:1/4 Commit:4 Entries:[1/5 EntryNormal ""]
-  1->2 MsgApp Term:1 Log:1/5 Commit:4 Entries:[1/6 EntryConfChangeV2 r2 l2]
+  1->2 MsgApp Term:1 Log:1/4 Commit:4 Entries:[1/5 EntryConfChangeV2 r2 l2]
 > 3 receiving messages
-  1->3 MsgApp Term:1 Log:1/4 Commit:4 Entries:[1/5 EntryNormal ""]
-  1->3 MsgApp Term:1 Log:1/5 Commit:4 Entries:[1/6 EntryConfChangeV2 r2 l2]
+  1->3 MsgApp Term:1 Log:1/4 Commit:4 Entries:[1/5 EntryConfChangeV2 r2 l2]
 > 4 receiving messages
-  1->4 MsgApp Term:1 Log:1/5 Commit:4 Entries:[1/6 EntryConfChangeV2 r2 l2]
+  1->4 MsgApp Term:1 Log:1/4 Commit:4 Entries:[1/5 EntryConfChangeV2 r2 l2]
 > 2 handling Ready
   Ready MustSync=true:
   Entries:
-  1/5 EntryNormal ""
-  1/6 EntryConfChangeV2 r2 l2
+  1/5 EntryConfChangeV2 r2 l2
   Messages:
   2->1 MsgAppResp Term:1 Log:0/5 Commit:4
-  2->1 MsgAppResp Term:1 Log:0/6 Commit:4
 > 3 handling Ready
   Ready MustSync=true:
   Entries:
-  1/5 EntryNormal ""
-  1/6 EntryConfChangeV2 r2 l2
+  1/5 EntryConfChangeV2 r2 l2
   Messages:
   3->1 MsgAppResp Term:1 Log:0/5 Commit:4
-  3->1 MsgAppResp Term:1 Log:0/6 Commit:4
 > 4 handling Ready
   Ready MustSync=true:
   Entries:
-  1/6 EntryConfChangeV2 r2 l2
+  1/5 EntryConfChangeV2 r2 l2
   Messages:
-  4->1 MsgAppResp Term:1 Log:0/6 Commit:4
+  4->1 MsgAppResp Term:1 Log:0/5 Commit:4
 > 1 receiving messages
   2->1 MsgAppResp Term:1 Log:0/5 Commit:4
-  2->1 MsgAppResp Term:1 Log:0/6 Commit:4
   3->1 MsgAppResp Term:1 Log:0/5 Commit:4
-  3->1 MsgAppResp Term:1 Log:0/6 Commit:4
-  4->1 MsgAppResp Term:1 Log:0/6 Commit:4
+  4->1 MsgAppResp Term:1 Log:0/5 Commit:4
+> 1 handling Ready
+  Ready MustSync=true:
+  HardState Term:1 Vote:1 Commit:5 Lead:1 LeadEpoch:1
+  CommittedEntries:
+  1/5 EntryConfChangeV2 r2 l2
+  Messages:
+  1->2 MsgApp Term:1 Log:1/5 Commit:5
+  1->3 MsgApp Term:1 Log:1/5 Commit:5
+  1->4 MsgApp Term:1 Log:1/5 Commit:5
+  INFO 1 switched to configuration voters=(1 3 4)&&(1 2 3 4) learners_next=(2) autoleave
+  INFO initiating automatic transition out of joint configuration voters=(1 3 4)&&(1 2 3 4) learners_next=(2) autoleave
+> 2 receiving messages
+  1->2 MsgApp Term:1 Log:1/5 Commit:5
+> 3 receiving messages
+  1->3 MsgApp Term:1 Log:1/5 Commit:5
+> 4 receiving messages
+  1->4 MsgApp Term:1 Log:1/5 Commit:5
+> 1 handling Ready
+  Ready MustSync=true:
+  Entries:
+  1/6 EntryConfChangeV2
+  Messages:
+  1->2 MsgApp Term:1 Log:1/5 Commit:5 Entries:[1/6 EntryConfChangeV2]
+  1->3 MsgApp Term:1 Log:1/5 Commit:5 Entries:[1/6 EntryConfChangeV2]
+  1->4 MsgApp Term:1 Log:1/5 Commit:5 Entries:[1/6 EntryConfChangeV2]
+> 2 handling Ready
+  Ready MustSync=true:
+  HardState Term:1 Vote:1 Commit:5 Lead:1 LeadEpoch:1
+  CommittedEntries:
+  1/5 EntryConfChangeV2 r2 l2
+  Messages:
+  2->1 MsgAppResp Term:1 Log:0/5 Commit:5
+  INFO 2 switched to configuration voters=(1 3 4)&&(1 2 3 4) learners_next=(2) autoleave
+> 3 handling Ready
+  Ready MustSync=true:
+  HardState Term:1 Vote:1 Commit:5 Lead:1 LeadEpoch:1
+  CommittedEntries:
+  1/5 EntryConfChangeV2 r2 l2
+  Messages:
+  3->1 MsgAppResp Term:1 Log:0/5 Commit:5
+  INFO 3 switched to configuration voters=(1 3 4)&&(1 2 3 4) learners_next=(2) autoleave
+> 4 handling Ready
+  Ready MustSync=true:
+  HardState Term:1 Commit:5 Lead:1 LeadEpoch:1
+  CommittedEntries:
+  1/5 EntryConfChangeV2 r2 l2
+  Messages:
+  4->1 MsgAppResp Term:1 Log:0/5 Commit:5
+  INFO 4 switched to configuration voters=(1 3 4)&&(1 2 3 4) learners_next=(2) autoleave
+> 1 receiving messages
+  2->1 MsgAppResp Term:1 Log:0/5 Commit:5
+  3->1 MsgAppResp Term:1 Log:0/5 Commit:5
+  4->1 MsgAppResp Term:1 Log:0/5 Commit:5
+> 2 receiving messages
+  1->2 MsgApp Term:1 Log:1/5 Commit:5 Entries:[1/6 EntryConfChangeV2]
+> 3 receiving messages
+  1->3 MsgApp Term:1 Log:1/5 Commit:5 Entries:[1/6 EntryConfChangeV2]
+> 4 receiving messages
+  1->4 MsgApp Term:1 Log:1/5 Commit:5 Entries:[1/6 EntryConfChangeV2]
+> 2 handling Ready
+  Ready MustSync=true:
+  Entries:
+  1/6 EntryConfChangeV2
+  Messages:
+  2->1 MsgAppResp Term:1 Log:0/6 Commit:5
+> 3 handling Ready
+  Ready MustSync=true:
+  Entries:
+  1/6 EntryConfChangeV2
+  Messages:
+  3->1 MsgAppResp Term:1 Log:0/6 Commit:5
+> 4 handling Ready
+  Ready MustSync=true:
+  Entries:
+  1/6 EntryConfChangeV2
+  Messages:
+  4->1 MsgAppResp Term:1 Log:0/6 Commit:5
+> 1 receiving messages
+  2->1 MsgAppResp Term:1 Log:0/6 Commit:5
+  3->1 MsgAppResp Term:1 Log:0/6 Commit:5
+  4->1 MsgAppResp Term:1 Log:0/6 Commit:5
 > 1 handling Ready
   Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:6 Lead:1 LeadEpoch:1
   CommittedEntries:
-  1/5 EntryNormal ""
-  1/6 EntryConfChangeV2 r2 l2
+  1/6 EntryConfChangeV2
   Messages:
-  1->2 MsgApp Term:1 Log:1/6 Commit:5
-  1->3 MsgApp Term:1 Log:1/6 Commit:5
-  1->4 MsgApp Term:1 Log:1/6 Commit:5
   1->2 MsgApp Term:1 Log:1/6 Commit:6
   1->3 MsgApp Term:1 Log:1/6 Commit:6
   1->4 MsgApp Term:1 Log:1/6 Commit:6
-  INFO 1 switched to configuration voters=(1 3 4)&&(1 2 3 4) learners_next=(2) autoleave
-  INFO initiating automatic transition out of joint configuration voters=(1 3 4)&&(1 2 3 4) learners_next=(2) autoleave
+  INFO 1 switched to configuration voters=(1 3 4) learners=(2)
 > 2 receiving messages
-  1->2 MsgApp Term:1 Log:1/6 Commit:5
   1->2 MsgApp Term:1 Log:1/6 Commit:6
 > 3 receiving messages
-  1->3 MsgApp Term:1 Log:1/6 Commit:5
   1->3 MsgApp Term:1 Log:1/6 Commit:6
 > 4 receiving messages
-  1->4 MsgApp Term:1 Log:1/6 Commit:5
   1->4 MsgApp Term:1 Log:1/6 Commit:6
-> 1 handling Ready
-  Ready MustSync=true:
-  Entries:
-  1/7 EntryConfChangeV2
-  Messages:
-  1->2 MsgApp Term:1 Log:1/6 Commit:6 Entries:[1/7 EntryConfChangeV2]
-  1->3 MsgApp Term:1 Log:1/6 Commit:6 Entries:[1/7 EntryConfChangeV2]
-  1->4 MsgApp Term:1 Log:1/6 Commit:6 Entries:[1/7 EntryConfChangeV2]
 > 2 handling Ready
   Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:6 Lead:1 LeadEpoch:1
   CommittedEntries:
-  1/5 EntryNormal ""
-  1/6 EntryConfChangeV2 r2 l2
+  1/6 EntryConfChangeV2
   Messages:
-  2->1 MsgAppResp Term:1 Log:0/6 Commit:5
   2->1 MsgAppResp Term:1 Log:0/6 Commit:6
-  INFO 2 switched to configuration voters=(1 3 4)&&(1 2 3 4) learners_next=(2) autoleave
+  INFO 2 switched to configuration voters=(1 3 4) learners=(2)
 > 3 handling Ready
   Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:6 Lead:1 LeadEpoch:1
   CommittedEntries:
-  1/5 EntryNormal ""
-  1/6 EntryConfChangeV2 r2 l2
+  1/6 EntryConfChangeV2
   Messages:
-  3->1 MsgAppResp Term:1 Log:0/6 Commit:5
   3->1 MsgAppResp Term:1 Log:0/6 Commit:6
-  INFO 3 switched to configuration voters=(1 3 4)&&(1 2 3 4) learners_next=(2) autoleave
+  INFO 3 switched to configuration voters=(1 3 4) learners=(2)
 > 4 handling Ready
   Ready MustSync=true:
   HardState Term:1 Commit:6 Lead:1 LeadEpoch:1
   CommittedEntries:
-  1/5 EntryNormal ""
-  1/6 EntryConfChangeV2 r2 l2
+  1/6 EntryConfChangeV2
   Messages:
-  4->1 MsgAppResp Term:1 Log:0/6 Commit:5
   4->1 MsgAppResp Term:1 Log:0/6 Commit:6
-  INFO 4 switched to configuration voters=(1 3 4)&&(1 2 3 4) learners_next=(2) autoleave
-> 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/6 Commit:5
-  2->1 MsgAppResp Term:1 Log:0/6 Commit:6
-  3->1 MsgAppResp Term:1 Log:0/6 Commit:5
-  3->1 MsgAppResp Term:1 Log:0/6 Commit:6
-  4->1 MsgAppResp Term:1 Log:0/6 Commit:5
-  4->1 MsgAppResp Term:1 Log:0/6 Commit:6
-> 2 receiving messages
-  1->2 MsgApp Term:1 Log:1/6 Commit:6 Entries:[1/7 EntryConfChangeV2]
-> 3 receiving messages
-  1->3 MsgApp Term:1 Log:1/6 Commit:6 Entries:[1/7 EntryConfChangeV2]
-> 4 receiving messages
-  1->4 MsgApp Term:1 Log:1/6 Commit:6 Entries:[1/7 EntryConfChangeV2]
-> 2 handling Ready
-  Ready MustSync=true:
-  Entries:
-  1/7 EntryConfChangeV2
-  Messages:
-  2->1 MsgAppResp Term:1 Log:0/7 Commit:6
-> 3 handling Ready
-  Ready MustSync=true:
-  Entries:
-  1/7 EntryConfChangeV2
-  Messages:
-  3->1 MsgAppResp Term:1 Log:0/7 Commit:6
-> 4 handling Ready
-  Ready MustSync=true:
-  Entries:
-  1/7 EntryConfChangeV2
-  Messages:
-  4->1 MsgAppResp Term:1 Log:0/7 Commit:6
-> 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/7 Commit:6
-  3->1 MsgAppResp Term:1 Log:0/7 Commit:6
-  4->1 MsgAppResp Term:1 Log:0/7 Commit:6
-> 1 handling Ready
-  Ready MustSync=true:
-  HardState Term:1 Vote:1 Commit:7 Lead:1 LeadEpoch:1
-  CommittedEntries:
-  1/7 EntryConfChangeV2
-  Messages:
-  1->2 MsgApp Term:1 Log:1/7 Commit:7
-  1->3 MsgApp Term:1 Log:1/7 Commit:7
-  1->4 MsgApp Term:1 Log:1/7 Commit:7
-  INFO 1 switched to configuration voters=(1 3 4) learners=(2)
-> 2 receiving messages
-  1->2 MsgApp Term:1 Log:1/7 Commit:7
-> 3 receiving messages
-  1->3 MsgApp Term:1 Log:1/7 Commit:7
-> 4 receiving messages
-  1->4 MsgApp Term:1 Log:1/7 Commit:7
-> 2 handling Ready
-  Ready MustSync=true:
-  HardState Term:1 Vote:1 Commit:7 Lead:1 LeadEpoch:1
-  CommittedEntries:
-  1/7 EntryConfChangeV2
-  Messages:
-  2->1 MsgAppResp Term:1 Log:0/7 Commit:7
-  INFO 2 switched to configuration voters=(1 3 4) learners=(2)
-> 3 handling Ready
-  Ready MustSync=true:
-  HardState Term:1 Vote:1 Commit:7 Lead:1 LeadEpoch:1
-  CommittedEntries:
-  1/7 EntryConfChangeV2
-  Messages:
-  3->1 MsgAppResp Term:1 Log:0/7 Commit:7
-  INFO 3 switched to configuration voters=(1 3 4) learners=(2)
-> 4 handling Ready
-  Ready MustSync=true:
-  HardState Term:1 Commit:7 Lead:1 LeadEpoch:1
-  CommittedEntries:
-  1/7 EntryConfChangeV2
-  Messages:
-  4->1 MsgAppResp Term:1 Log:0/7 Commit:7
   INFO 4 switched to configuration voters=(1 3 4) learners=(2)
 > 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/7 Commit:7
-  3->1 MsgAppResp Term:1 Log:0/7 Commit:7
-  4->1 MsgAppResp Term:1 Log:0/7 Commit:7
+  2->1 MsgAppResp Term:1 Log:0/6 Commit:6
+  3->1 MsgAppResp Term:1 Log:0/6 Commit:6
+  4->1 MsgAppResp Term:1 Log:0/6 Commit:6

--- a/pkg/raft/testdata/confchange_v1_remove_leader.txt
+++ b/pkg/raft/testdata/confchange_v1_remove_leader.txt
@@ -38,6 +38,7 @@ propose-conf-change 1 v1=true
 r1
 ----
 INFO 1 ignoring conf change {ConfChangeRemoveNode 1 [] 0} at config voters=(1 2 3): voters must be demoted to learners before being removed
+raft proposal dropped
 
 # Instead, demote n1 to a learner in a joint config.
 propose-conf-change 1 v1=false transition=explicit
@@ -70,40 +71,40 @@ process-ready 1
 ----
 Ready MustSync=true:
 Entries:
-1/6 EntryConfChangeV2
-1/7 EntryNormal "foo"
+1/5 EntryConfChangeV2
+1/6 EntryNormal "foo"
 Messages:
-1->2 MsgApp Term:1 Log:1/5 Commit:5 Entries:[1/6 EntryConfChangeV2]
-1->3 MsgApp Term:1 Log:1/5 Commit:5 Entries:[1/6 EntryConfChangeV2]
-1->2 MsgApp Term:1 Log:1/6 Commit:5 Entries:[1/7 EntryNormal "foo"]
-1->3 MsgApp Term:1 Log:1/6 Commit:5 Entries:[1/7 EntryNormal "foo"]
+1->2 MsgApp Term:1 Log:1/4 Commit:4 Entries:[1/5 EntryConfChangeV2]
+1->3 MsgApp Term:1 Log:1/4 Commit:4 Entries:[1/5 EntryConfChangeV2]
+1->2 MsgApp Term:1 Log:1/5 Commit:4 Entries:[1/6 EntryNormal "foo"]
+1->3 MsgApp Term:1 Log:1/5 Commit:4 Entries:[1/6 EntryNormal "foo"]
 
 # Send response from n2 and n3 (which is enough to commit the entries so far
 # next time n1 runs).
 stabilize 2 3
 ----
 > 2 receiving messages
-  1->2 MsgApp Term:1 Log:1/5 Commit:5 Entries:[1/6 EntryConfChangeV2]
-  1->2 MsgApp Term:1 Log:1/6 Commit:5 Entries:[1/7 EntryNormal "foo"]
+  1->2 MsgApp Term:1 Log:1/4 Commit:4 Entries:[1/5 EntryConfChangeV2]
+  1->2 MsgApp Term:1 Log:1/5 Commit:4 Entries:[1/6 EntryNormal "foo"]
 > 3 receiving messages
-  1->3 MsgApp Term:1 Log:1/5 Commit:5 Entries:[1/6 EntryConfChangeV2]
-  1->3 MsgApp Term:1 Log:1/6 Commit:5 Entries:[1/7 EntryNormal "foo"]
+  1->3 MsgApp Term:1 Log:1/4 Commit:4 Entries:[1/5 EntryConfChangeV2]
+  1->3 MsgApp Term:1 Log:1/5 Commit:4 Entries:[1/6 EntryNormal "foo"]
 > 2 handling Ready
   Ready MustSync=true:
   Entries:
-  1/6 EntryConfChangeV2
-  1/7 EntryNormal "foo"
+  1/5 EntryConfChangeV2
+  1/6 EntryNormal "foo"
   Messages:
-  2->1 MsgAppResp Term:1 Log:0/6 Commit:5
-  2->1 MsgAppResp Term:1 Log:0/7 Commit:5
+  2->1 MsgAppResp Term:1 Log:0/5 Commit:4
+  2->1 MsgAppResp Term:1 Log:0/6 Commit:4
 > 3 handling Ready
   Ready MustSync=true:
   Entries:
-  1/6 EntryConfChangeV2
-  1/7 EntryNormal "foo"
+  1/5 EntryConfChangeV2
+  1/6 EntryNormal "foo"
   Messages:
-  3->1 MsgAppResp Term:1 Log:0/6 Commit:5
-  3->1 MsgAppResp Term:1 Log:0/7 Commit:5
+  3->1 MsgAppResp Term:1 Log:0/5 Commit:4
+  3->1 MsgAppResp Term:1 Log:0/6 Commit:4
 
 # Put another entry in n1's log.
 propose 1 bar
@@ -117,26 +118,26 @@ stabilize 1
 > 1 handling Ready
   Ready MustSync=true:
   Entries:
-  1/8 EntryNormal "bar"
+  1/7 EntryNormal "bar"
   Messages:
-  1->2 MsgApp Term:1 Log:1/7 Commit:5 Entries:[1/8 EntryNormal "bar"]
-  1->3 MsgApp Term:1 Log:1/7 Commit:5 Entries:[1/8 EntryNormal "bar"]
+  1->2 MsgApp Term:1 Log:1/6 Commit:4 Entries:[1/7 EntryNormal "bar"]
+  1->3 MsgApp Term:1 Log:1/6 Commit:4 Entries:[1/7 EntryNormal "bar"]
 > 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/6 Commit:5
-  2->1 MsgAppResp Term:1 Log:0/7 Commit:5
-  3->1 MsgAppResp Term:1 Log:0/6 Commit:5
-  3->1 MsgAppResp Term:1 Log:0/7 Commit:5
+  2->1 MsgAppResp Term:1 Log:0/5 Commit:4
+  2->1 MsgAppResp Term:1 Log:0/6 Commit:4
+  3->1 MsgAppResp Term:1 Log:0/5 Commit:4
+  3->1 MsgAppResp Term:1 Log:0/6 Commit:4
 > 1 handling Ready
   Ready MustSync=true:
-  HardState Term:1 Vote:1 Commit:7 Lead:1 LeadEpoch:1
+  HardState Term:1 Vote:1 Commit:6 Lead:1 LeadEpoch:1
   CommittedEntries:
-  1/6 EntryConfChangeV2
-  1/7 EntryNormal "foo"
+  1/5 EntryConfChangeV2
+  1/6 EntryNormal "foo"
   Messages:
-  1->2 MsgApp Term:1 Log:1/8 Commit:6
-  1->3 MsgApp Term:1 Log:1/8 Commit:6
-  1->2 MsgApp Term:1 Log:1/8 Commit:7
-  1->3 MsgApp Term:1 Log:1/8 Commit:7
+  1->2 MsgApp Term:1 Log:1/7 Commit:5
+  1->3 MsgApp Term:1 Log:1/7 Commit:5
+  1->2 MsgApp Term:1 Log:1/7 Commit:6
+  1->3 MsgApp Term:1 Log:1/7 Commit:6
   INFO 1 switched to configuration voters=(2 3) learners=(1)
   DEBUG 1 setting election elapsed to start from 3 ticks after store liveness support expired
   INFO 1 became follower at term 1
@@ -144,7 +145,7 @@ stabilize 1
 > 1 handling Ready
   Ready MustSync=true:
   State:StateFollower
-  HardState Term:1 Vote:1 Commit:7 Lead:0 LeadEpoch:0
+  HardState Term:1 Vote:1 Commit:6 Lead:0 LeadEpoch:0
 
 raft-state
 ----
@@ -156,55 +157,55 @@ raft-state
 stabilize 2
 ----
 > 2 receiving messages
-  1->2 MsgApp Term:1 Log:1/7 Commit:5 Entries:[1/8 EntryNormal "bar"]
-  1->2 MsgApp Term:1 Log:1/8 Commit:6
-  1->2 MsgApp Term:1 Log:1/8 Commit:7
+  1->2 MsgApp Term:1 Log:1/6 Commit:4 Entries:[1/7 EntryNormal "bar"]
+  1->2 MsgApp Term:1 Log:1/7 Commit:5
+  1->2 MsgApp Term:1 Log:1/7 Commit:6
 > 2 handling Ready
   Ready MustSync=true:
-  HardState Term:1 Vote:1 Commit:7 Lead:1 LeadEpoch:1
+  HardState Term:1 Vote:1 Commit:6 Lead:1 LeadEpoch:1
   Entries:
-  1/8 EntryNormal "bar"
+  1/7 EntryNormal "bar"
   CommittedEntries:
-  1/6 EntryConfChangeV2
-  1/7 EntryNormal "foo"
+  1/5 EntryConfChangeV2
+  1/6 EntryNormal "foo"
   Messages:
-  2->1 MsgAppResp Term:1 Log:0/8 Commit:5
-  2->1 MsgAppResp Term:1 Log:0/8 Commit:6
-  2->1 MsgAppResp Term:1 Log:0/8 Commit:7
+  2->1 MsgAppResp Term:1 Log:0/7 Commit:4
+  2->1 MsgAppResp Term:1 Log:0/7 Commit:5
+  2->1 MsgAppResp Term:1 Log:0/7 Commit:6
   INFO 2 switched to configuration voters=(2 3) learners=(1)
 
 # ...because the old leader n1 ignores the append responses.
 stabilize 1
 ----
 > 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/8 Commit:5
-  2->1 MsgAppResp Term:1 Log:0/8 Commit:6
-  2->1 MsgAppResp Term:1 Log:0/8 Commit:7
+  2->1 MsgAppResp Term:1 Log:0/7 Commit:4
+  2->1 MsgAppResp Term:1 Log:0/7 Commit:5
+  2->1 MsgAppResp Term:1 Log:0/7 Commit:6
 
 # When n3 responds, quorum is reached and everything falls into place.
 stabilize
 ----
 > 3 receiving messages
-  1->3 MsgApp Term:1 Log:1/7 Commit:5 Entries:[1/8 EntryNormal "bar"]
-  1->3 MsgApp Term:1 Log:1/8 Commit:6
-  1->3 MsgApp Term:1 Log:1/8 Commit:7
+  1->3 MsgApp Term:1 Log:1/6 Commit:4 Entries:[1/7 EntryNormal "bar"]
+  1->3 MsgApp Term:1 Log:1/7 Commit:5
+  1->3 MsgApp Term:1 Log:1/7 Commit:6
 > 3 handling Ready
   Ready MustSync=true:
-  HardState Term:1 Vote:1 Commit:7 Lead:1 LeadEpoch:1
+  HardState Term:1 Vote:1 Commit:6 Lead:1 LeadEpoch:1
   Entries:
-  1/8 EntryNormal "bar"
+  1/7 EntryNormal "bar"
   CommittedEntries:
-  1/6 EntryConfChangeV2
-  1/7 EntryNormal "foo"
+  1/5 EntryConfChangeV2
+  1/6 EntryNormal "foo"
   Messages:
-  3->1 MsgAppResp Term:1 Log:0/8 Commit:5
-  3->1 MsgAppResp Term:1 Log:0/8 Commit:6
-  3->1 MsgAppResp Term:1 Log:0/8 Commit:7
+  3->1 MsgAppResp Term:1 Log:0/7 Commit:4
+  3->1 MsgAppResp Term:1 Log:0/7 Commit:5
+  3->1 MsgAppResp Term:1 Log:0/7 Commit:6
   INFO 3 switched to configuration voters=(2 3) learners=(1)
 > 1 receiving messages
-  3->1 MsgAppResp Term:1 Log:0/8 Commit:5
-  3->1 MsgAppResp Term:1 Log:0/8 Commit:6
-  3->1 MsgAppResp Term:1 Log:0/8 Commit:7
+  3->1 MsgAppResp Term:1 Log:0/7 Commit:4
+  3->1 MsgAppResp Term:1 Log:0/7 Commit:5
+  3->1 MsgAppResp Term:1 Log:0/7 Commit:6
 
 # n1 can no longer propose.
 propose 1 baz

--- a/pkg/raft/testdata/confchange_v2_add_double_auto.txt
+++ b/pkg/raft/testdata/confchange_v2_add_double_auto.txt
@@ -64,15 +64,13 @@ CommittedEntries:
 1/4 EntryConfChangeV2 v2 v3
 INFO 1 switched to configuration voters=(1 2 3)&&(1) autoleave
 INFO 1 ignoring conf change {ConfChangeTransitionAuto [] []} at config voters=(1 2 3)&&(1) autoleave: lead support has not caught up to previous configuration
-INFO initiating automatic transition out of joint configuration voters=(1 2 3)&&(1) autoleave
+DEBUG not initiating automatic transition out of joint configuration voters=(1 2 3)&&(1) autoleave: raft proposal dropped
 
 # n1 immediately probes n2 and n3.
 stabilize 1
 ----
 > 1 handling Ready
-  Ready MustSync=true:
-  Entries:
-  1/5 EntryNormal ""
+  Ready MustSync=false:
   Messages:
   1->2 MsgFortifyLeader Term:1 Log:0/0
   1->3 MsgFortifyLeader Term:1 Log:0/0
@@ -109,17 +107,11 @@ stabilize 1 2
 > 1 handling Ready
   Ready MustSync=false:
   Messages:
-  1->2 MsgApp Term:1 Log:1/3 Commit:4 Entries:[
-    1/4 EntryConfChangeV2 v2 v3
-    1/5 EntryNormal ""
-  ]
+  1->2 MsgApp Term:1 Log:1/3 Commit:4 Entries:[1/4 EntryConfChangeV2 v2 v3]
   1->2 MsgSnap Term:1 Log:0/0
     Snapshot: Index:4 Term:1 ConfState:Voters:[1 2 3] VotersOutgoing:[1] Learners:[] LearnersNext:[] AutoLeave:true
 > 2 receiving messages
-  1->2 MsgApp Term:1 Log:1/3 Commit:4 Entries:[
-    1/4 EntryConfChangeV2 v2 v3
-    1/5 EntryNormal ""
-  ]
+  1->2 MsgApp Term:1 Log:1/3 Commit:4 Entries:[1/4 EntryConfChangeV2 v2 v3]
   DEBUG 2 [logterm: 0, index: 3] rejected MsgApp [logterm: 1, index: 3] from 1
   1->2 MsgSnap Term:1 Log:0/0
     Snapshot: Index:4 Term:1 ConfState:Voters:[1 2 3] VotersOutgoing:[1] Learners:[] LearnersNext:[] AutoLeave:true
@@ -139,79 +131,6 @@ stabilize 1 2
   DEBUG 1 received MsgAppResp(rejected, hint: (index 0, term 0)) from 2 for index 3
   2->1 MsgAppResp Term:1 Log:0/4 Commit:4
   DEBUG 1 recovered from needing snapshot, resumed sending replication messages to 2 [StateSnapshot match=4 next=5 sentCommit=4 matchCommit=4 paused pendingSnap=4]
-> 1 handling Ready
-  Ready MustSync=false:
-  Messages:
-  1->2 MsgApp Term:1 Log:1/4 Commit:4 Entries:[1/5 EntryNormal ""]
-> 2 receiving messages
-  1->2 MsgApp Term:1 Log:1/4 Commit:4 Entries:[1/5 EntryNormal ""]
-> 2 handling Ready
-  Ready MustSync=true:
-  Entries:
-  1/5 EntryNormal ""
-  Messages:
-  2->1 MsgAppResp Term:1 Log:0/5 Commit:4
-> 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/5 Commit:4
-> 1 handling Ready
-  Ready MustSync=true:
-  HardState Term:1 Vote:1 Commit:5 Lead:1 LeadEpoch:1
-  CommittedEntries:
-  1/5 EntryNormal ""
-  Messages:
-  1->2 MsgApp Term:1 Log:1/5 Commit:5
-  INFO initiating automatic transition out of joint configuration voters=(1 2 3)&&(1) autoleave
-> 2 receiving messages
-  1->2 MsgApp Term:1 Log:1/5 Commit:5
-> 1 handling Ready
-  Ready MustSync=true:
-  Entries:
-  1/6 EntryConfChangeV2
-  Messages:
-  1->2 MsgApp Term:1 Log:1/5 Commit:5 Entries:[1/6 EntryConfChangeV2]
-> 2 handling Ready
-  Ready MustSync=true:
-  HardState Term:1 Commit:5 Lead:1 LeadEpoch:1
-  CommittedEntries:
-  1/5 EntryNormal ""
-  Messages:
-  2->1 MsgAppResp Term:1 Log:0/5 Commit:5
-> 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/5 Commit:5
-> 2 receiving messages
-  1->2 MsgApp Term:1 Log:1/5 Commit:5 Entries:[1/6 EntryConfChangeV2]
-> 2 handling Ready
-  Ready MustSync=true:
-  Entries:
-  1/6 EntryConfChangeV2
-  Messages:
-  2->1 MsgAppResp Term:1 Log:0/6 Commit:5
-> 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/6 Commit:5
-> 1 handling Ready
-  Ready MustSync=true:
-  HardState Term:1 Vote:1 Commit:6 Lead:1 LeadEpoch:1
-  CommittedEntries:
-  1/6 EntryConfChangeV2
-  Messages:
-  1->2 MsgApp Term:1 Log:1/6 Commit:6
-  INFO 1 switched to configuration voters=(1 2 3)
-> 2 receiving messages
-  1->2 MsgApp Term:1 Log:1/6 Commit:6
-> 1 handling Ready
-  Ready MustSync=false:
-  Messages:
-  1->3 MsgFortifyLeader Term:1 Log:0/0
-> 2 handling Ready
-  Ready MustSync=true:
-  HardState Term:1 Commit:6 Lead:1 LeadEpoch:1
-  CommittedEntries:
-  1/6 EntryConfChangeV2
-  Messages:
-  2->1 MsgAppResp Term:1 Log:0/6 Commit:6
-  INFO 2 switched to configuration voters=(1 2 3)
-> 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/6 Commit:6
 
 # n3 immediately receives a snapshot in the final configuration.
 stabilize 1 3
@@ -223,57 +142,46 @@ stabilize 1 3
   DEBUG 3 reset election elapsed to 0
   1->3 MsgApp Term:1 Log:1/3 Commit:4 Entries:[1/4 EntryConfChangeV2 v2 v3]
   DEBUG 3 [logterm: 0, index: 3] rejected MsgApp [logterm: 1, index: 3] from 1
-  1->3 MsgFortifyLeader Term:1 Log:0/0
 > 3 handling Ready
   Ready MustSync=true:
   HardState Term:1 Commit:0 Lead:1 LeadEpoch:1
   Messages:
   3->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:1
   3->1 MsgAppResp Term:1 Log:0/3 Rejected (Hint: 0)
-  3->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:1
 > 1 receiving messages
   3->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:1
   3->1 MsgAppResp Term:1 Log:0/3 Rejected (Hint: 0)
   DEBUG 1 received MsgAppResp(rejected, hint: (index 0, term 0)) from 3 for index 3
   DEBUG 1 decreased progress of 3 to [StateProbe match=0 next=1 sentCommit=0 matchCommit=0]
-  DEBUG 1 [firstindex: 3, commit: 6] sent snapshot[index: 6, term: 1] to 3 [StateProbe match=0 next=1 sentCommit=0 matchCommit=0]
-  DEBUG 1 paused sending replication messages to 3 [StateSnapshot match=0 next=7 sentCommit=6 matchCommit=0 paused pendingSnap=6]
-  3->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:1
+  DEBUG 1 [firstindex: 3, commit: 4] sent snapshot[index: 4, term: 1] to 3 [StateProbe match=0 next=1 sentCommit=0 matchCommit=0]
+  DEBUG 1 paused sending replication messages to 3 [StateSnapshot match=0 next=5 sentCommit=4 matchCommit=0 paused pendingSnap=4]
 > 1 handling Ready
   Ready MustSync=false:
   Messages:
-  1->3 MsgApp Term:1 Log:1/3 Commit:6 Entries:[
-    1/4 EntryConfChangeV2 v2 v3
-    1/5 EntryNormal ""
-    1/6 EntryConfChangeV2
-  ]
+  1->3 MsgApp Term:1 Log:1/3 Commit:4 Entries:[1/4 EntryConfChangeV2 v2 v3]
   1->3 MsgSnap Term:1 Log:0/0
-    Snapshot: Index:6 Term:1 ConfState:Voters:[1 2 3] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
+    Snapshot: Index:4 Term:1 ConfState:Voters:[1 2 3] VotersOutgoing:[1] Learners:[] LearnersNext:[] AutoLeave:true
 > 3 receiving messages
-  1->3 MsgApp Term:1 Log:1/3 Commit:6 Entries:[
-    1/4 EntryConfChangeV2 v2 v3
-    1/5 EntryNormal ""
-    1/6 EntryConfChangeV2
-  ]
+  1->3 MsgApp Term:1 Log:1/3 Commit:4 Entries:[1/4 EntryConfChangeV2 v2 v3]
   DEBUG 3 [logterm: 0, index: 3] rejected MsgApp [logterm: 1, index: 3] from 1
   1->3 MsgSnap Term:1 Log:0/0
-    Snapshot: Index:6 Term:1 ConfState:Voters:[1 2 3] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
-  INFO log [committed=0, applied=0, applying=0, unstable.offset=1, unstable.offsetInProgress=1, len(unstable.Entries)=0] starts to restore snapshot [index: 6, term: 1]
-  INFO 3 switched to configuration voters=(1 2 3)
-  INFO 3 [commit: 6, lastindex: 6, lastterm: 1] restored snapshot [index: 6, term: 1]
-  INFO 3 [commit: 6] restored snapshot [index: 6, term: 1]
+    Snapshot: Index:4 Term:1 ConfState:Voters:[1 2 3] VotersOutgoing:[1] Learners:[] LearnersNext:[] AutoLeave:true
+  INFO log [committed=0, applied=0, applying=0, unstable.offset=1, unstable.offsetInProgress=1, len(unstable.Entries)=0] starts to restore snapshot [index: 4, term: 1]
+  INFO 3 switched to configuration voters=(1 2 3)&&(1) autoleave
+  INFO 3 [commit: 4, lastindex: 4, lastterm: 1] restored snapshot [index: 4, term: 1]
+  INFO 3 [commit: 4] restored snapshot [index: 4, term: 1]
 > 3 handling Ready
   Ready MustSync=true:
-  HardState Term:1 Commit:6 Lead:1 LeadEpoch:1
-  Snapshot Index:6 Term:1 ConfState:Voters:[1 2 3] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
+  HardState Term:1 Commit:4 Lead:1 LeadEpoch:1
+  Snapshot Index:4 Term:1 ConfState:Voters:[1 2 3] VotersOutgoing:[1] Learners:[] LearnersNext:[] AutoLeave:true
   Messages:
   3->1 MsgAppResp Term:1 Log:0/3 Rejected (Hint: 0)
-  3->1 MsgAppResp Term:1 Log:0/6 Commit:6
+  3->1 MsgAppResp Term:1 Log:0/4 Commit:4
 > 1 receiving messages
   3->1 MsgAppResp Term:1 Log:0/3 Rejected (Hint: 0)
   DEBUG 1 received MsgAppResp(rejected, hint: (index 0, term 0)) from 3 for index 3
-  3->1 MsgAppResp Term:1 Log:0/6 Commit:6
-  DEBUG 1 recovered from needing snapshot, resumed sending replication messages to 3 [StateSnapshot match=6 next=7 sentCommit=6 matchCommit=6 paused pendingSnap=6]
+  3->1 MsgAppResp Term:1 Log:0/4 Commit:4
+  DEBUG 1 recovered from needing snapshot, resumed sending replication messages to 3 [StateSnapshot match=4 next=5 sentCommit=4 matchCommit=4 paused pendingSnap=4]
 
 # Nothing else happens.
 stabilize
@@ -286,38 +194,18 @@ ok
 propose-conf-change 1
 r2 r3 l2 l3
 ----
-ok
+INFO 1 ignoring conf change {ConfChangeTransitionAuto [{ConfChangeRemoveNode 2} {ConfChangeRemoveNode 3} {ConfChangeAddLearnerNode 2} {ConfChangeAddLearnerNode 3}] []} at config voters=(1 2 3)&&(1) autoleave: must transition out of joint config first
+raft proposal dropped
 
 # n1 sends out MsgApps.
 stabilize 1
 ----
-> 1 handling Ready
-  Ready MustSync=true:
-  Entries:
-  1/7 EntryConfChangeV2 r2 r3 l2 l3
-  Messages:
-  1->2 MsgApp Term:1 Log:1/6 Commit:6 Entries:[1/7 EntryConfChangeV2 r2 r3 l2 l3]
-  1->3 MsgApp Term:1 Log:1/6 Commit:6 Entries:[1/7 EntryConfChangeV2 r2 r3 l2 l3]
+ok
 
 # n2, n3 ack them.
 stabilize 2 3
 ----
-> 2 receiving messages
-  1->2 MsgApp Term:1 Log:1/6 Commit:6 Entries:[1/7 EntryConfChangeV2 r2 r3 l2 l3]
-> 3 receiving messages
-  1->3 MsgApp Term:1 Log:1/6 Commit:6 Entries:[1/7 EntryConfChangeV2 r2 r3 l2 l3]
-> 2 handling Ready
-  Ready MustSync=true:
-  Entries:
-  1/7 EntryConfChangeV2 r2 r3 l2 l3
-  Messages:
-  2->1 MsgAppResp Term:1 Log:0/7 Commit:6
-> 3 handling Ready
-  Ready MustSync=true:
-  Entries:
-  1/7 EntryConfChangeV2 r2 r3 l2 l3
-  Messages:
-  3->1 MsgAppResp Term:1 Log:0/7 Commit:6
+ok
 
 # n1 gets some more proposals. This is part of a regression test: There used to
 # be a bug in which these proposals would prompt the leader to transition out of
@@ -337,77 +225,39 @@ stabilize 1
 > 1 handling Ready
   Ready MustSync=true:
   Entries:
-  1/8 EntryNormal "foo"
-  1/9 EntryNormal "bar"
+  1/5 EntryNormal "foo"
+  1/6 EntryNormal "bar"
   Messages:
-  1->2 MsgApp Term:1 Log:1/7 Commit:6 Entries:[1/8 EntryNormal "foo"]
-  1->3 MsgApp Term:1 Log:1/7 Commit:6 Entries:[1/8 EntryNormal "foo"]
-  1->2 MsgApp Term:1 Log:1/8 Commit:6 Entries:[1/9 EntryNormal "bar"]
-  1->3 MsgApp Term:1 Log:1/8 Commit:6 Entries:[1/9 EntryNormal "bar"]
-> 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/7 Commit:6
-  3->1 MsgAppResp Term:1 Log:0/7 Commit:6
-> 1 handling Ready
-  Ready MustSync=true:
-  HardState Term:1 Vote:1 Commit:7 Lead:1 LeadEpoch:1
-  CommittedEntries:
-  1/7 EntryConfChangeV2 r2 r3 l2 l3
-  Messages:
-  1->2 MsgApp Term:1 Log:1/9 Commit:7
-  1->3 MsgApp Term:1 Log:1/9 Commit:7
-  INFO 1 switched to configuration voters=(1)&&(1 2 3) learners_next=(2 3) autoleave
-  INFO initiating automatic transition out of joint configuration voters=(1)&&(1 2 3) learners_next=(2 3) autoleave
-> 1 handling Ready
-  Ready MustSync=true:
-  Entries:
-  1/10 EntryConfChangeV2
-  Messages:
-  1->2 MsgApp Term:1 Log:1/9 Commit:7 Entries:[1/10 EntryConfChangeV2]
-  1->3 MsgApp Term:1 Log:1/9 Commit:7 Entries:[1/10 EntryConfChangeV2]
+  1->2 MsgApp Term:1 Log:1/4 Commit:4 Entries:[1/5 EntryNormal "foo"]
+  1->3 MsgApp Term:1 Log:1/4 Commit:4 Entries:[1/5 EntryNormal "foo"]
+  1->2 MsgApp Term:1 Log:1/5 Commit:4 Entries:[1/6 EntryNormal "bar"]
+  1->3 MsgApp Term:1 Log:1/5 Commit:4 Entries:[1/6 EntryNormal "bar"]
 
 # n2 and n3 also switch to the joint config, and ack the transition out of it.
 stabilize 2 3
 ----
 > 2 receiving messages
-  1->2 MsgApp Term:1 Log:1/7 Commit:6 Entries:[1/8 EntryNormal "foo"]
-  1->2 MsgApp Term:1 Log:1/8 Commit:6 Entries:[1/9 EntryNormal "bar"]
-  1->2 MsgApp Term:1 Log:1/9 Commit:7
-  1->2 MsgApp Term:1 Log:1/9 Commit:7 Entries:[1/10 EntryConfChangeV2]
+  1->2 MsgApp Term:1 Log:1/4 Commit:4 Entries:[1/5 EntryNormal "foo"]
+  1->2 MsgApp Term:1 Log:1/5 Commit:4 Entries:[1/6 EntryNormal "bar"]
 > 3 receiving messages
-  1->3 MsgApp Term:1 Log:1/7 Commit:6 Entries:[1/8 EntryNormal "foo"]
-  1->3 MsgApp Term:1 Log:1/8 Commit:6 Entries:[1/9 EntryNormal "bar"]
-  1->3 MsgApp Term:1 Log:1/9 Commit:7
-  1->3 MsgApp Term:1 Log:1/9 Commit:7 Entries:[1/10 EntryConfChangeV2]
+  1->3 MsgApp Term:1 Log:1/4 Commit:4 Entries:[1/5 EntryNormal "foo"]
+  1->3 MsgApp Term:1 Log:1/5 Commit:4 Entries:[1/6 EntryNormal "bar"]
 > 2 handling Ready
   Ready MustSync=true:
-  HardState Term:1 Commit:7 Lead:1 LeadEpoch:1
   Entries:
-  1/8 EntryNormal "foo"
-  1/9 EntryNormal "bar"
-  1/10 EntryConfChangeV2
-  CommittedEntries:
-  1/7 EntryConfChangeV2 r2 r3 l2 l3
+  1/5 EntryNormal "foo"
+  1/6 EntryNormal "bar"
   Messages:
-  2->1 MsgAppResp Term:1 Log:0/8 Commit:6
-  2->1 MsgAppResp Term:1 Log:0/9 Commit:6
-  2->1 MsgAppResp Term:1 Log:0/9 Commit:7
-  2->1 MsgAppResp Term:1 Log:0/10 Commit:7
-  INFO 2 switched to configuration voters=(1)&&(1 2 3) learners_next=(2 3) autoleave
+  2->1 MsgAppResp Term:1 Log:0/5 Commit:4
+  2->1 MsgAppResp Term:1 Log:0/6 Commit:4
 > 3 handling Ready
   Ready MustSync=true:
-  HardState Term:1 Commit:7 Lead:1 LeadEpoch:1
   Entries:
-  1/8 EntryNormal "foo"
-  1/9 EntryNormal "bar"
-  1/10 EntryConfChangeV2
-  CommittedEntries:
-  1/7 EntryConfChangeV2 r2 r3 l2 l3
+  1/5 EntryNormal "foo"
+  1/6 EntryNormal "bar"
   Messages:
-  3->1 MsgAppResp Term:1 Log:0/8 Commit:6
-  3->1 MsgAppResp Term:1 Log:0/9 Commit:6
-  3->1 MsgAppResp Term:1 Log:0/9 Commit:7
-  3->1 MsgAppResp Term:1 Log:0/10 Commit:7
-  INFO 3 switched to configuration voters=(1)&&(1 2 3) learners_next=(2 3) autoleave
+  3->1 MsgAppResp Term:1 Log:0/5 Commit:4
+  3->1 MsgAppResp Term:1 Log:0/6 Commit:4
 
 # n2 and n3 also leave the joint config and the dust settles. We see at the very
 # end that n1 receives some messages from them that it refuses because it does
@@ -415,65 +265,106 @@ stabilize 2 3
 stabilize
 ----
 > 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/8 Commit:6
-  2->1 MsgAppResp Term:1 Log:0/9 Commit:6
-  2->1 MsgAppResp Term:1 Log:0/9 Commit:7
-  2->1 MsgAppResp Term:1 Log:0/10 Commit:7
-  3->1 MsgAppResp Term:1 Log:0/8 Commit:6
-  3->1 MsgAppResp Term:1 Log:0/9 Commit:6
-  3->1 MsgAppResp Term:1 Log:0/9 Commit:7
-  3->1 MsgAppResp Term:1 Log:0/10 Commit:7
+  2->1 MsgAppResp Term:1 Log:0/5 Commit:4
+  2->1 MsgAppResp Term:1 Log:0/6 Commit:4
+  3->1 MsgAppResp Term:1 Log:0/5 Commit:4
+  3->1 MsgAppResp Term:1 Log:0/6 Commit:4
 > 1 handling Ready
   Ready MustSync=true:
-  HardState Term:1 Vote:1 Commit:10 Lead:1 LeadEpoch:1
+  HardState Term:1 Vote:1 Commit:6 Lead:1 LeadEpoch:1
   CommittedEntries:
-  1/8 EntryNormal "foo"
-  1/9 EntryNormal "bar"
-  1/10 EntryConfChangeV2
+  1/5 EntryNormal "foo"
+  1/6 EntryNormal "bar"
   Messages:
-  1->2 MsgApp Term:1 Log:1/10 Commit:8
-  1->3 MsgApp Term:1 Log:1/10 Commit:8
-  1->2 MsgApp Term:1 Log:1/10 Commit:9
-  1->3 MsgApp Term:1 Log:1/10 Commit:9
-  1->2 MsgApp Term:1 Log:1/10 Commit:10
-  1->3 MsgApp Term:1 Log:1/10 Commit:10
-  INFO 1 switched to configuration voters=(1) learners=(2 3)
+  1->2 MsgApp Term:1 Log:1/6 Commit:5
+  1->3 MsgApp Term:1 Log:1/6 Commit:5
+  1->2 MsgApp Term:1 Log:1/6 Commit:6
+  1->3 MsgApp Term:1 Log:1/6 Commit:6
+  INFO initiating automatic transition out of joint configuration voters=(1 2 3)&&(1) autoleave
 > 2 receiving messages
-  1->2 MsgApp Term:1 Log:1/10 Commit:8
-  1->2 MsgApp Term:1 Log:1/10 Commit:9
-  1->2 MsgApp Term:1 Log:1/10 Commit:10
+  1->2 MsgApp Term:1 Log:1/6 Commit:5
+  1->2 MsgApp Term:1 Log:1/6 Commit:6
 > 3 receiving messages
-  1->3 MsgApp Term:1 Log:1/10 Commit:8
-  1->3 MsgApp Term:1 Log:1/10 Commit:9
-  1->3 MsgApp Term:1 Log:1/10 Commit:10
+  1->3 MsgApp Term:1 Log:1/6 Commit:5
+  1->3 MsgApp Term:1 Log:1/6 Commit:6
+> 1 handling Ready
+  Ready MustSync=true:
+  Entries:
+  1/7 EntryConfChangeV2
+  Messages:
+  1->2 MsgApp Term:1 Log:1/6 Commit:6 Entries:[1/7 EntryConfChangeV2]
+  1->3 MsgApp Term:1 Log:1/6 Commit:6 Entries:[1/7 EntryConfChangeV2]
 > 2 handling Ready
   Ready MustSync=true:
-  HardState Term:1 Commit:10 Lead:1 LeadEpoch:1
+  HardState Term:1 Commit:6 Lead:1 LeadEpoch:1
   CommittedEntries:
-  1/8 EntryNormal "foo"
-  1/9 EntryNormal "bar"
-  1/10 EntryConfChangeV2
+  1/5 EntryNormal "foo"
+  1/6 EntryNormal "bar"
   Messages:
-  2->1 MsgAppResp Term:1 Log:0/10 Commit:8
-  2->1 MsgAppResp Term:1 Log:0/10 Commit:9
-  2->1 MsgAppResp Term:1 Log:0/10 Commit:10
-  INFO 2 switched to configuration voters=(1) learners=(2 3)
+  2->1 MsgAppResp Term:1 Log:0/6 Commit:5
+  2->1 MsgAppResp Term:1 Log:0/6 Commit:6
 > 3 handling Ready
   Ready MustSync=true:
-  HardState Term:1 Commit:10 Lead:1 LeadEpoch:1
+  HardState Term:1 Commit:6 Lead:1 LeadEpoch:1
   CommittedEntries:
-  1/8 EntryNormal "foo"
-  1/9 EntryNormal "bar"
-  1/10 EntryConfChangeV2
+  1/5 EntryNormal "foo"
+  1/6 EntryNormal "bar"
   Messages:
-  3->1 MsgAppResp Term:1 Log:0/10 Commit:8
-  3->1 MsgAppResp Term:1 Log:0/10 Commit:9
-  3->1 MsgAppResp Term:1 Log:0/10 Commit:10
-  INFO 3 switched to configuration voters=(1) learners=(2 3)
+  3->1 MsgAppResp Term:1 Log:0/6 Commit:5
+  3->1 MsgAppResp Term:1 Log:0/6 Commit:6
 > 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/10 Commit:8
-  2->1 MsgAppResp Term:1 Log:0/10 Commit:9
-  2->1 MsgAppResp Term:1 Log:0/10 Commit:10
-  3->1 MsgAppResp Term:1 Log:0/10 Commit:8
-  3->1 MsgAppResp Term:1 Log:0/10 Commit:9
-  3->1 MsgAppResp Term:1 Log:0/10 Commit:10
+  2->1 MsgAppResp Term:1 Log:0/6 Commit:5
+  2->1 MsgAppResp Term:1 Log:0/6 Commit:6
+  3->1 MsgAppResp Term:1 Log:0/6 Commit:5
+  3->1 MsgAppResp Term:1 Log:0/6 Commit:6
+> 2 receiving messages
+  1->2 MsgApp Term:1 Log:1/6 Commit:6 Entries:[1/7 EntryConfChangeV2]
+> 3 receiving messages
+  1->3 MsgApp Term:1 Log:1/6 Commit:6 Entries:[1/7 EntryConfChangeV2]
+> 2 handling Ready
+  Ready MustSync=true:
+  Entries:
+  1/7 EntryConfChangeV2
+  Messages:
+  2->1 MsgAppResp Term:1 Log:0/7 Commit:6
+> 3 handling Ready
+  Ready MustSync=true:
+  Entries:
+  1/7 EntryConfChangeV2
+  Messages:
+  3->1 MsgAppResp Term:1 Log:0/7 Commit:6
+> 1 receiving messages
+  2->1 MsgAppResp Term:1 Log:0/7 Commit:6
+  3->1 MsgAppResp Term:1 Log:0/7 Commit:6
+> 1 handling Ready
+  Ready MustSync=true:
+  HardState Term:1 Vote:1 Commit:7 Lead:1 LeadEpoch:1
+  CommittedEntries:
+  1/7 EntryConfChangeV2
+  Messages:
+  1->2 MsgApp Term:1 Log:1/7 Commit:7
+  1->3 MsgApp Term:1 Log:1/7 Commit:7
+  INFO 1 switched to configuration voters=(1 2 3)
+> 2 receiving messages
+  1->2 MsgApp Term:1 Log:1/7 Commit:7
+> 3 receiving messages
+  1->3 MsgApp Term:1 Log:1/7 Commit:7
+> 2 handling Ready
+  Ready MustSync=true:
+  HardState Term:1 Commit:7 Lead:1 LeadEpoch:1
+  CommittedEntries:
+  1/7 EntryConfChangeV2
+  Messages:
+  2->1 MsgAppResp Term:1 Log:0/7 Commit:7
+  INFO 2 switched to configuration voters=(1 2 3)
+> 3 handling Ready
+  Ready MustSync=true:
+  HardState Term:1 Commit:7 Lead:1 LeadEpoch:1
+  CommittedEntries:
+  1/7 EntryConfChangeV2
+  Messages:
+  3->1 MsgAppResp Term:1 Log:0/7 Commit:7
+  INFO 3 switched to configuration voters=(1 2 3)
+> 1 receiving messages
+  2->1 MsgAppResp Term:1 Log:0/7 Commit:7
+  3->1 MsgAppResp Term:1 Log:0/7 Commit:7

--- a/pkg/raft/testdata/confchange_v2_add_single_explicit.txt
+++ b/pkg/raft/testdata/confchange_v2_add_single_explicit.txt
@@ -116,6 +116,7 @@ propose-conf-change 1
 v3 v4 v5
 ----
 INFO 1 ignoring conf change {ConfChangeTransitionAuto [{ConfChangeAddNode 3} {ConfChangeAddNode 4} {ConfChangeAddNode 5}] []} at config voters=(1 2)&&(1): must transition out of joint config first
+raft proposal dropped
 
 # Propose a transition out of the joint config. We'll see this at index 6 below.
 propose-conf-change 1
@@ -128,91 +129,47 @@ stabilize
 > 1 handling Ready
   Ready MustSync=true:
   Entries:
-  1/5 EntryNormal ""
-  1/6 EntryConfChangeV2
+  1/5 EntryConfChangeV2
   Messages:
-  1->2 MsgApp Term:1 Log:1/4 Commit:4 Entries:[1/5 EntryNormal ""]
-  1->2 MsgApp Term:1 Log:1/5 Commit:4 Entries:[1/6 EntryConfChangeV2]
+  1->2 MsgApp Term:1 Log:1/4 Commit:4 Entries:[1/5 EntryConfChangeV2]
 > 2 receiving messages
-  1->2 MsgApp Term:1 Log:1/4 Commit:4 Entries:[1/5 EntryNormal ""]
-  1->2 MsgApp Term:1 Log:1/5 Commit:4 Entries:[1/6 EntryConfChangeV2]
+  1->2 MsgApp Term:1 Log:1/4 Commit:4 Entries:[1/5 EntryConfChangeV2]
 > 2 handling Ready
   Ready MustSync=true:
   Entries:
-  1/5 EntryNormal ""
-  1/6 EntryConfChangeV2
+  1/5 EntryConfChangeV2
   Messages:
   2->1 MsgAppResp Term:1 Log:0/5 Commit:4
-  2->1 MsgAppResp Term:1 Log:0/6 Commit:4
 > 1 receiving messages
   2->1 MsgAppResp Term:1 Log:0/5 Commit:4
-  2->1 MsgAppResp Term:1 Log:0/6 Commit:4
 > 1 handling Ready
   Ready MustSync=true:
-  HardState Term:1 Vote:1 Commit:6 Lead:1 LeadEpoch:1
+  HardState Term:1 Vote:1 Commit:5 Lead:1 LeadEpoch:1
   CommittedEntries:
-  1/5 EntryNormal ""
-  1/6 EntryConfChangeV2
+  1/5 EntryConfChangeV2
   Messages:
-  1->2 MsgApp Term:1 Log:1/6 Commit:5
-  1->2 MsgApp Term:1 Log:1/6 Commit:6
+  1->2 MsgApp Term:1 Log:1/5 Commit:5
   INFO 1 switched to configuration voters=(1 2)
 > 2 receiving messages
-  1->2 MsgApp Term:1 Log:1/6 Commit:5
-  1->2 MsgApp Term:1 Log:1/6 Commit:6
+  1->2 MsgApp Term:1 Log:1/5 Commit:5
 > 2 handling Ready
   Ready MustSync=true:
-  HardState Term:1 Commit:6 Lead:1 LeadEpoch:1
+  HardState Term:1 Commit:5 Lead:1 LeadEpoch:1
   CommittedEntries:
-  1/5 EntryNormal ""
-  1/6 EntryConfChangeV2
+  1/5 EntryConfChangeV2
   Messages:
-  2->1 MsgAppResp Term:1 Log:0/6 Commit:5
-  2->1 MsgAppResp Term:1 Log:0/6 Commit:6
+  2->1 MsgAppResp Term:1 Log:0/5 Commit:5
   INFO 2 switched to configuration voters=(1 2)
 > 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/6 Commit:5
-  2->1 MsgAppResp Term:1 Log:0/6 Commit:6
+  2->1 MsgAppResp Term:1 Log:0/5 Commit:5
 
 # Check that trying to transition out again won't do anything.
 propose-conf-change 1
 ----
 INFO 1 ignoring conf change {ConfChangeTransitionAuto [] []} at config voters=(1 2): not in joint state; refusing empty conf change
+raft proposal dropped
 
 # Finishes work for the empty entry we just proposed.
 stabilize
 ----
-> 1 handling Ready
-  Ready MustSync=true:
-  Entries:
-  1/7 EntryNormal ""
-  Messages:
-  1->2 MsgApp Term:1 Log:1/6 Commit:6 Entries:[1/7 EntryNormal ""]
-> 2 receiving messages
-  1->2 MsgApp Term:1 Log:1/6 Commit:6 Entries:[1/7 EntryNormal ""]
-> 2 handling Ready
-  Ready MustSync=true:
-  Entries:
-  1/7 EntryNormal ""
-  Messages:
-  2->1 MsgAppResp Term:1 Log:0/7 Commit:6
-> 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/7 Commit:6
-> 1 handling Ready
-  Ready MustSync=true:
-  HardState Term:1 Vote:1 Commit:7 Lead:1 LeadEpoch:1
-  CommittedEntries:
-  1/7 EntryNormal ""
-  Messages:
-  1->2 MsgApp Term:1 Log:1/7 Commit:7
-> 2 receiving messages
-  1->2 MsgApp Term:1 Log:1/7 Commit:7
-> 2 handling Ready
-  Ready MustSync=true:
-  HardState Term:1 Commit:7 Lead:1 LeadEpoch:1
-  CommittedEntries:
-  1/7 EntryNormal ""
-  Messages:
-  2->1 MsgAppResp Term:1 Log:0/7 Commit:7
-> 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/7 Commit:7
+ok

--- a/pkg/raft/testdata/confchange_v2_replace_leader.txt
+++ b/pkg/raft/testdata/confchange_v2_replace_leader.txt
@@ -71,9 +71,9 @@ stabilize
 > 4 handling Ready
   Ready MustSync=false:
   Messages:
-  4->1 MsgProp Term:0 Log:0/0 Entries:[0/0 EntryConfChangeV2]
+  4->1 MsgPropConfig Term:1 Log:0/0 Entries:[0/0 EntryConfChangeV2]
 > 1 receiving messages
-  4->1 MsgProp Term:0 Log:0/0 Entries:[0/0 EntryConfChangeV2]
+  4->1 MsgPropConfig Term:1 Log:0/0 Entries:[0/0 EntryConfChangeV2]
 > 1 handling Ready
   Ready MustSync=true:
   Entries:


### PR DESCRIPTION
Config changes are always proposed in a single-entry `MsgProp`. The `MsgProp` code is written in an overly generic way: it assumes any entry can be a config change, so it has to scan the entire slice to filter one out. It may also mutate config change entries when they are not allowed.

This PR makes config change proposals cleaner. There is a dedicated `MsgPropConfig` message type, which is handled like `MsgProp` for the most part. The gist of the improvement:

- The entry scanning is off the critical path of `MsgProp`. Only `MsgPropConfig` messages need to be checked for configs.
- Since `MsgPropConfig` contains exactly one entry, we don't need to mutate the proposal / make it empty in case of rejection. We just return `ErrProposalDropped`, which also gives the upper layer a better signal, and doesn't waste space in the raft log.
- In some future we might pursue decoupling config changes from log, so decoupling from `MsgProp` is a step in the right direction.

Epic: none
Release note: none