### PR TITLE
rpc: export outlier resistant clock skew metrics.

### DIFF
--- a/docs/generated/metrics/metrics.html
+++ b/docs/generated/metrics/metrics.html
@@ -1008,6 +1008,8 @@
 <tr><td>APPLICATION</td><td>changefeed.usage.query_duration</td><td>Time taken by the queries used to generate usage metrics for changefeeds</td><td>Nanoseconds</td><td>HISTOGRAM</td><td>NANOSECONDS</td><td>AVG</td><td>NONE</td></tr>
 <tr><td>APPLICATION</td><td>changefeed.usage.table_bytes</td><td>Aggregated number of bytes of data per table watched by changefeeds</td><td>Storage</td><td>GAUGE</td><td>BYTES</td><td>AVG</td><td>NONE</td></tr>
 <tr><td>APPLICATION</td><td>clock-offset.meannanos</td><td>Mean clock offset with other nodes</td><td>Clock Offset</td><td>GAUGE</td><td>NANOSECONDS</td><td>AVG</td><td>NONE</td></tr>
+<tr><td>APPLICATION</td><td>clock-offset.medianabsdevnanos</td><td>Median Absolute Deviation (MAD) with other nodes</td><td>Clock Offset</td><td>GAUGE</td><td>NANOSECONDS</td><td>AVG</td><td>NONE</td></tr>
+<tr><td>APPLICATION</td><td>clock-offset.mediannanos</td><td>Median clock offset with other nodes</td><td>Clock Offset</td><td>GAUGE</td><td>NANOSECONDS</td><td>AVG</td><td>NONE</td></tr>
 <tr><td>APPLICATION</td><td>clock-offset.stddevnanos</td><td>Stddev clock offset with other nodes</td><td>Clock Offset</td><td>GAUGE</td><td>NANOSECONDS</td><td>AVG</td><td>NONE</td></tr>
 <tr><td>APPLICATION</td><td>cloud.conns_opened</td><td>HTTP connections opened by cloud operations</td><td>Connections</td><td>COUNTER</td><td>COUNT</td><td>AVG</td><td>NON_NEGATIVE_DERIVATIVE</td></tr>
 <tr><td>APPLICATION</td><td>cloud.conns_reused</td><td>HTTP connections reused by cloud operations</td><td>Connections</td><td>COUNTER</td><td>COUNT</td><td>AVG</td><td>NON_NEGATIVE_DERIVATIVE</td></tr>

--- a/pkg/rpc/clock_offset.go
+++ b/pkg/rpc/clock_offset.go
@@ -22,9 +22,11 @@ import (
 
 // RemoteClockMetrics is the collection of metrics for the clock monitor.
 type RemoteClockMetrics struct {
-	ClockOffsetMeanNanos   *metric.Gauge
-	ClockOffsetStdDevNanos *metric.Gauge
-	RoundTripLatency       metric.IHistogram
+	ClockOffsetMeanNanos         *metric.Gauge
+	ClockOffsetStdDevNanos       *metric.Gauge
+	ClockOffsetMedianNanos       *metric.Gauge
+	ClockOffsetMedianAbsDevNanos *metric.Gauge
+	RoundTripLatency             metric.IHistogram
 }
 
 // avgLatencyMeasurementAge determines how to exponentially weight the
@@ -47,7 +49,24 @@ var (
 		Measurement: "Clock Offset",
 		Unit:        metric.Unit_NANOSECONDS,
 	}
-
+	metaClockOffsetMedianNanos = metric.Metadata{
+		// An outlier resistant measure of centrality, useful for
+		// diagnosing unhealthy nodes.
+		// Demo: https://docs.google.com/spreadsheets/d/1gmzQxEVYDKb_b-Mn50ZTje-LqZw6TZwUxxUPY2rG69M/edit?gid=0#gid=0
+		Name:        "clock-offset.mediannanos",
+		Help:        "Median clock offset with other nodes",
+		Measurement: "Clock Offset",
+		Unit:        metric.Unit_NANOSECONDS,
+	}
+	metaClockOffsetMedianAbsDevNanos = metric.Metadata{
+		// An outlier resistant measure of dispersion, see
+		// https://en.wikipedia.org/wiki/Median_absolute_deviation
+		// and demo above.
+		Name:        "clock-offset.medianabsdevnanos",
+		Help:        "Median Absolute Deviation (MAD) with other nodes",
+		Measurement: "Clock Offset",
+		Unit:        metric.Unit_NANOSECONDS,
+	}
 	metaConnectionRoundTripLatency = metric.Metadata{
 		// NB: the name is legacy and should not be changed since customers
 		// rely on it.
@@ -143,8 +162,10 @@ func newRemoteClockMonitor(
 		histogramWindowInterval = time.Duration(math.MaxInt64)
 	}
 	r.metrics = RemoteClockMetrics{
-		ClockOffsetMeanNanos:   metric.NewGauge(metaClockOffsetMeanNanos),
-		ClockOffsetStdDevNanos: metric.NewGauge(metaClockOffsetStdDevNanos),
+		ClockOffsetMeanNanos:         metric.NewGauge(metaClockOffsetMeanNanos),
+		ClockOffsetStdDevNanos:       metric.NewGauge(metaClockOffsetStdDevNanos),
+		ClockOffsetMedianNanos:       metric.NewGauge(metaClockOffsetMedianNanos),
+		ClockOffsetMedianAbsDevNanos: metric.NewGauge(metaClockOffsetMedianAbsDevNanos),
 		RoundTripLatency: metric.NewHistogram(metric.HistogramOptions{
 			Mode:     metric.HistogramModePreferHdrLatency,
 			Metadata: metaConnectionRoundTripLatency,
@@ -344,8 +365,18 @@ func (r *RemoteClockMonitor) VerifyClockOffset(ctx context.Context) error {
 	if err != nil && !errors.Is(err, stats.EmptyInput) {
 		return err
 	}
+	median, err := offsets.Median()
+	if err != nil && !errors.Is(err, stats.EmptyInput) {
+		return err
+	}
+	medianAbsoluteDeviation, err := offsets.MedianAbsoluteDeviation()
+	if err != nil && !errors.Is(err, stats.EmptyInput) {
+		return err
+	}
 	r.metrics.ClockOffsetMeanNanos.Update(int64(mean))
 	r.metrics.ClockOffsetStdDevNanos.Update(int64(stdDev))
+	r.metrics.ClockOffsetMedianNanos.Update(int64(median))
+	r.metrics.ClockOffsetMedianAbsDevNanos.Update(int64(medianAbsoluteDeviation))
 
 	if numClocks > 0 && healthyOffsetCount <= numClocks/2 {
 		return errors.Errorf(

--- a/pkg/rpc/clock_offset_test.go
+++ b/pkg/rpc/clock_offset_test.go
@@ -178,6 +178,12 @@ func TestClockOffsetMetrics(t *testing.T) {
 	if a, e := monitor.Metrics().ClockOffsetStdDevNanos.Value(), int64(7); a != e {
 		t.Errorf("stdDev %d != expected %d", a, e)
 	}
+	if a, e := monitor.Metrics().ClockOffsetMedianNanos.Value(), int64(13); a != e {
+		t.Errorf("median %d != expected %d", a, e)
+	}
+	if a, e := monitor.Metrics().ClockOffsetMedianAbsDevNanos.Value(), int64(7); a != e {
+		t.Errorf("MAD %d != expected %d", a, e)
+	}
 }
 
 // TestLatencies tests the tracking of round-trip latency between nodes.


### PR DESCRIPTION
Exports two outlier-resistant metrics that are helpful for identifying a faulty node in the case of clock skew:
- clock-offset.mediannanos
- clock-offset.medianabsdevnanos

Testing:
- Ran cluster locally and ensured metrics correctly showed up in UI. Also simulated network latency for some more real examples.
- Was not able to figure out how to simulate severe clock skew in a non-contrived way, so I demonstrated a proof of concept of how this should work for cases with an outlier. [Demo calculations](https://docs.google.com/spreadsheets/d/1gmzQxEVYDKb_b-Mn50ZTje-LqZw6TZwUxxUPY2rG69M/edit?gid=0#gid=0)

References:
- [Median Absolute Deviation](https://en.wikipedia.org/wiki/Median_absolute_deviation) is similar in principle to IQR, but more robust to skew and makes sense for 3 nodes.

resolves: https://github.com/cockroachdb/cockroach/issues/139181
Epic: none
Release note: none