### PR TITLE
sql: add support for holdable cursors

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -1344,7 +1344,7 @@ func (ex *connExecutor) close(ctx context.Context, closeType closeType) {
 	ex.extraTxnState.prepStmtsNamespaceAtTxnRewindPos.closeAllPortals(
 		ctx, &ex.extraTxnState.prepStmtsNamespaceMemAcc,
 	)
-	if err := ex.extraTxnState.sqlCursors.closeAll(cursorCloseForExplicitClose); err != nil {
+	if err := ex.extraTxnState.sqlCursors.closeAll(&ex.planner, cursorCloseForExplicitClose); err != nil {
 		log.Warningf(ctx, "error closing cursors: %v", err)
 	}
 
@@ -2184,11 +2184,16 @@ func (ex *connExecutor) resetExtraTxnState(ctx context.Context, ev txnEvent, pay
 	)
 
 	// Close all (non HOLD) cursors.
-	closeReason := cursorCloseForTxnCommit
-	if ev.eventType != txnCommit {
+	var closeReason cursorCloseReason
+	switch ev.eventType {
+	case txnCommit:
+		closeReason = cursorCloseForTxnCommit
+	case txnPrepare:
+		closeReason = cursorCloseForTxnPrepare
+	default:
 		closeReason = cursorCloseForTxnRollback
 	}
-	if err := ex.extraTxnState.sqlCursors.closeAll(closeReason); err != nil {
+	if err := ex.extraTxnState.sqlCursors.closeAll(&ex.planner, closeReason); err != nil {
 		log.Warningf(ctx, "error closing cursors: %v", err)
 	}
 
@@ -2658,7 +2663,7 @@ func (ex *connExecutor) execCmd() (retErr error) {
 			// txnState.finishSQLTxn() is being called, as the underlying resources of
 			// pausable portals hasn't been cleared yet.
 			ex.extraTxnState.prepStmtsNamespace.closeAllPausablePortals(ctx, &ex.extraTxnState.prepStmtsNamespaceMemAcc)
-			if err := ex.extraTxnState.sqlCursors.closeAll(cursorCloseForTxnRollback); err != nil {
+			if err := ex.extraTxnState.sqlCursors.closeAll(&ex.planner, cursorCloseForTxnRollback); err != nil {
 				log.Warningf(ctx, "error closing cursors: %v", err)
 			}
 		}

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -2451,7 +2451,7 @@ func (ex *connExecutor) commitSQLTransactionInternal(ctx context.Context) (retEr
 		ex.recordDDLTxnTelemetry(failed)
 	}()
 
-	if err := ex.extraTxnState.sqlCursors.closeAll(cursorCloseForTxnCommit); err != nil {
+	if err := ex.extraTxnState.sqlCursors.closeAll(&ex.planner, cursorCloseForTxnCommit); err != nil {
 		return err
 	}
 
@@ -2578,7 +2578,7 @@ func (ex *connExecutor) createJobs(ctx context.Context) error {
 func (ex *connExecutor) rollbackSQLTransaction(
 	ctx context.Context, stmt tree.Statement,
 ) (fsm.Event, fsm.EventPayload) {
-	if err := ex.extraTxnState.sqlCursors.closeAll(cursorCloseForTxnRollback); err != nil {
+	if err := ex.extraTxnState.sqlCursors.closeAll(&ex.planner, cursorCloseForTxnRollback); err != nil {
 		return ex.makeErrEvent(err, stmt)
 	}
 

--- a/pkg/sql/logictest/testdata/logic_test/cursor
+++ b/pkg/sql/logictest/testdata/logic_test/cursor
@@ -641,8 +641,26 @@ FETCH 1 a b;
 statement ok
 COMMIT;
 
-statement error DECLARE CURSOR WITH HOLD can only be used in transaction blocks
+# Test holdable cursors.
+subtest holdable
+
+statement ok
+CREATE TABLE t (x INT PRIMARY KEY, y INT);
+INSERT INTO t (SELECT t, t%123 FROM generate_series(1, 10000) g(t));
+
+# A holdable cursor can be declared in an implicit transaction.
+statement ok
 DECLARE foo CURSOR WITH HOLD FOR SELECT 1
+
+query I
+FETCH 1 foo;
+----
+1
+
+# A holdable cursor can be declared in an explicit transaction and remain open
+# after commit.
+statement ok
+CLOSE foo;
 
 statement ok
 BEGIN
@@ -662,29 +680,153 @@ statement ok
 CLOSE foo
 
 statement ok
+COMMIT
+
+query I
+FETCH 1 bar
+----
+2
+
+statement ok
 CLOSE bar
 
 statement ok
+BEGIN
+
+statement ok
+DECLARE foo CURSOR WITH HOLD FOR SELECT * FROM generate_series(1, 10)
+
+statement ok
 COMMIT
+
+query I rowsort
+FETCH 2 foo
+----
+1
+2
 
 statement ok
 BEGIN
 
 statement ok
-DECLARE foo CURSOR WITH HOLD FOR SELECT 1
+DECLARE bar CURSOR WITH HOLD FOR SELECT 1
 
-statement error cursor foo WITH HOLD must be closed before committing
-COMMIT
-
-statement ok
-BEGIN
-
-statement ok
-DECLARE foo CURSOR WITH HOLD FOR SELECT 1
-
-# ROLLBACK is fine, since it renders the cursor unusable anyway.
 statement ok
 ROLLBACK
+
+# The rollback should have closed the holdable cursor for that transaction, but
+# not the one from the previous committed transaction.
+query T rowsort
+SELECT name FROM pg_cursors
+----
+foo
+
+query I rowsort
+FETCH 2 foo
+----
+3
+4
+
+statement ok
+CLOSE foo;
+
+# Open a holdable cursor fetching from a table.
+statement ok
+DECLARE foo CURSOR WITH HOLD FOR SELECT * FROM t ORDER BY x
+
+query II rowsort
+FETCH 3 foo
+----
+1  1
+2  2
+3  3
+
+# Same as before, but in an explicit transaction.
+statement ok
+BEGIN;
+DECLARE bar CURSOR WITH HOLD FOR SELECT * FROM t ORDER BY x;
+
+query II rowsort
+FETCH 3 bar
+----
+1  1
+2  2
+3  3
+
+statement ok
+COMMIT
+
+query II rowsort
+FETCH 3 bar
+----
+4  4
+5  5
+6  6
+
+# Fetch again from the cursor declared in the implicit txn.
+query II rowsort
+FETCH 3 foo
+----
+4  4
+5  5
+6  6
+
+# CLOSE ALL should close holdable cursors.
+statement ok
+CLOSE ALL;
+
+query T rowsort
+SELECT name FROM pg_cursors
+----
+
+skipif config local-mixed-24.3
+# A transaction with an active holdable cursor cannot be prepared.
+statement ok
+BEGIN;
+
+skipif config local-mixed-24.3
+statement ok
+DECLARE foo CURSOR WITH HOLD FOR SELECT 1
+
+skipif config local-mixed-24.3
+statement error pgcode 0A000 pq: cannot PREPARE a transaction that has created a cursor WITH HOLD
+PREPARE TRANSACTION 'read-only'
+
+skipif config local-mixed-24.3
+query T rowsort
+SELECT name FROM pg_cursors
+----
+
+skipif config local-mixed-24.3
+statement ok
+BEGIN;
+
+skipif config local-mixed-24.3
+statement ok
+DECLARE foo CURSOR WITH HOLD FOR SELECT 1
+
+skipif config local-mixed-24.3
+statement ok
+CLOSE foo;
+
+skipif config local-mixed-24.3
+statement ok
+PREPARE TRANSACTION 'read-only'
+
+skipif config local-mixed-24.3
+statement ok
+COMMIT PREPARED 'read-only'
+
+# Holdable cursors cannot contain locking.
+statement error pgcode 0A000 pq: DECLARE CURSOR WITH HOLD must not contain locking
+DECLARE foo CURSOR WITH HOLD FOR SELECT * FROM t FOR UPDATE
+
+statement ok
+DROP TABLE t
+
+subtest end
+
+subtest regression
 
 # Regression test for using a SQL cursor that buffers a notice.
 # See https://github.com/cockroachdb/cockroach/issues/94344
@@ -728,3 +870,5 @@ COMMIT
 
 statement ok
 RESET autocommit_before_ddl
+
+subtest end

--- a/pkg/sql/two_phase_commit.go
+++ b/pkg/sql/two_phase_commit.go
@@ -71,7 +71,7 @@ func (ex *connExecutor) execPrepareTransactionInOpenStateInternal(
 	// TODO(nvanbenschoten): why are these needed here (and in the equivalent
 	// functions for commit and rollback)? Shouldn't they be handled by
 	// connExecutor.resetExtraTxnState?
-	if err := ex.extraTxnState.sqlCursors.closeAll(cursorCloseForTxnCommit); err != nil {
+	if err := ex.extraTxnState.sqlCursors.closeAll(&ex.planner, cursorCloseForTxnPrepare); err != nil {
 		return err
 	}
 	ex.extraTxnState.prepStmtsNamespace.closeAllPortals(ctx, &ex.extraTxnState.prepStmtsNamespaceMemAcc)


### PR DESCRIPTION
#### sql: refactor persistent cursor helper

This commit refactors `plpgsqlCursorHelper` so that the common logic
needed for a cursor stored in a row container now lives on the
embedded `persistedCursorHelper`. This will be useful for the following
commit that will implement holdable cursors.

Informs #77101

Release note: None

#### sql: support holdable cursors

This commit adds support for holdable cursors with the following syntax:
```
DECLARE <name> CURSOR WITH HOLD FOR <query>;
```
A holdable cursor is read into a row container upon txn commit, and
remains active on the session until it or the session is closed.
A transaction rollback drops any cursors opened within that transaction,
holdable or not. Rollback does not drop holdable cursors from previous
transactions. Prepared transactions cannot create holdable cursors.

Fixes #77101

Release note (sql change): Holdable cursors declared using `CURSOR WITH HOLD`
are now supported. A holdable cursor fully executes a query upon txn commit
and stores the result in a row container, which is maintained by the
session.