### PR TITLE
sql: allow negative field position in split_part

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -3119,8 +3119,8 @@ Case mode values range between 0 - 1, representing lower casing and upper casing
 </span></td><td>Immutable</td></tr>
 <tr><td><a name="similar_to_escape"></a><code>similar_to_escape(unescaped: <a href="string.html">string</a>, pattern: <a href="string.html">string</a>, escape: <a href="string.html">string</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Matches <code>unescaped</code> with <code>pattern</code> using <code>escape</code> as an escape token.</p>
 </span></td><td>Immutable</td></tr>
-<tr><td><a name="split_part"></a><code>split_part(input: <a href="string.html">string</a>, delimiter: <a href="string.html">string</a>, return_index_pos: <a href="int.html">int</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Splits <code>input</code> on <code>delimiter</code> and return the value in the <code>return_index_pos</code>  position (starting at 1).</p>
-<p>For example, <code>split_part('123.456.789.0','.',3)</code>returns <code>789</code>.</p>
+<tr><td><a name="split_part"></a><code>split_part(input: <a href="string.html">string</a>, delimiter: <a href="string.html">string</a>, return_index_pos: <a href="int.html">int</a>) &rarr; <a href="string.html">string</a></code></td><td><span class="funcdesc"><p>Splits <code>input</code> using <code>delimiter</code> and returns the field at <code>return_index_pos</code> (starting from 1). If <code>return_index_pos</code> is negative, it returns the |<code>return_index_pos</code>|'th field from the end.</p>
+<p>For example, <code>split_part('123.456.789.0', '.', 3)</code> returns <code>789</code>.</p>
 </span></td><td>Immutable</td></tr>
 <tr><td><a name="strpos"></a><code>strpos(input: <a href="bytes.html">bytes</a>, find: <a href="bytes.html">bytes</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Calculates the position where the byte subarray <code>find</code> begins in <code>input</code>.</p>
 </span></td><td>Immutable</td></tr>

--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -429,6 +429,46 @@ SELECT split_part('abc~@~def~@~ghi', '~@~', 2)
 def
 
 query T
+SELECT split_part('abc,def,ghi,jkl', ',', -2)
+----
+ghi
+
+statement error pq: split_part\(\): field position must not be zero
+SELECT split_part('abc,def,ghi,jkl', ',', 0)
+
+# To maintain compatibility with postgres, if the separator is not found and
+# the request is for the first or last field, return the entire input text.
+query T
+SELECT split_part('joeuser@mydatabase', '', 1)
+----
+joeuser@mydatabase
+
+query T
+SELECT split_part('joeuser@mydatabase', '', -1)
+----
+joeuser@mydatabase
+
+query T
+SELECT split_part('joeuser@mydatabase', '?', 1)
+----
+joeuser@mydatabase
+
+query T
+SELECT split_part('joeuser@mydatabase', '?', -1)
+----
+joeuser@mydatabase
+
+query T
+SELECT split_part('joeuser@mydatabase', '', 2)
+----
+·
+
+query T
+SELECT split_part('joeuser@mydatabase', '?', -2)
+----
+·
+
+query T
 SELECT repeat('Pg', 4)
 ----
 PgPgPgPg

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -1121,20 +1121,34 @@ var regularBuiltins = map[string]builtinDefinition{
 				sep := string(tree.MustBeDString(args[1]))
 				field := int(tree.MustBeDInt(args[2]))
 
-				if field <= 0 {
+				if field == 0 {
 					return nil, pgerror.Newf(
-						pgcode.InvalidParameterValue, "field position %d must be greater than zero", field)
+						pgcode.InvalidParameterValue, "field position must not be zero")
+				}
+
+				if sep == "" {
+					// Return the entire text if requesting the first or last field.
+					if field == 1 || field == -1 {
+						return tree.NewDString(text), nil
+					}
+					return tree.NewDString(""), nil
 				}
 
 				splits := strings.Split(text, sep)
-				if field > len(splits) {
+				if field > len(splits) || -1*field > len(splits) {
 					return tree.NewDString(""), nil
 				}
+
+				// If field is negative, select from the end
+				if field < 0 {
+					return tree.NewDString(splits[len(splits)+field]), nil
+				}
+				// Otherwise, return from the beginning (1-based index)
 				return tree.NewDString(splits[field-1]), nil
 			},
-			Info: "Splits `input` on `delimiter` and return the value in the `return_index_pos`  " +
-				"position (starting at 1). \n\nFor example, `split_part('123.456.789.0','.',3)`" +
-				"returns `789`.",
+			Info: "Splits `input` using `delimiter` and returns the field at `return_index_pos` (starting from 1). " +
+				"If `return_index_pos` is negative, it returns the |`return_index_pos`|'th field from the end. " +
+				"\n\nFor example, `split_part('123.456.789.0', '.', 3)` returns `789`.",
 			Volatility: volatility.Immutable,
 		},
 	),


### PR DESCRIPTION
This commit enhances the `split_part` built-in function to support negative values for `return_index_pos` (3rd parameter). When negative, the function now returns the |`return_index_pos`|'th field from the end, aligning with postgres' behavior.

If a blank separator is passed in, and the request is for the first or last field, we will return the entire input text. This is to align with the postgres behaviour.

Epic: none
Release note (sql change): The `split_part` built-in function now supports negative `return_index_pos` values, returning the |n|th field from the end when specified.