### PR TITLE
ui: add 'view' link to job advance debug page items

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/jobs/jobDetailsPage/jobProfilerView.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/jobs/jobDetailsPage/jobProfilerView.module.scss
@@ -18,6 +18,14 @@
     width: 230px;
 }
 
+.view-execution-detail-button {
+    white-space: nowrap;
+
+    >svg {
+        margin-right: $spacing-x-small;
+    }
+}
+
 .download-execution-detail-button {
     white-space: nowrap;
 

--- a/pkg/ui/workspaces/cluster-ui/src/jobs/jobDetailsPage/jobProfilerView.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/jobs/jobDetailsPage/jobProfilerView.tsx
@@ -99,6 +99,32 @@ export function makeJobProfilerViewColumns(
               as="a"
               size="small"
               intent="tertiary"
+              className={cx("view-execution-detail-button")}
+              onClick={() => {
+                const req =
+                  new cockroach.server.serverpb.GetJobProfilerExecutionDetailRequest(
+                    {
+                      job_id: jobID,
+                      filename: executionDetailFile,
+                    },
+                  );
+                onDownloadExecutionFileClicked(req).then(resp => {
+                  const type = getContentTypeForFile(executionDetailFile);
+                  const executionFileBytes = new Blob([resp?.data], {
+                    type: type,
+                  });
+                  const url = URL.createObjectURL(executionFileBytes);
+                  window.open(url, "_blank");
+                });
+              }}
+            >
+              <Icon iconName="Open" />
+              View
+            </Button>
+            <Button
+              as="a"
+              size="small"
+              intent="tertiary"
               className={cx("download-execution-detail-button")}
               onClick={() => {
                 const req =


### PR DESCRIPTION
Previously we only had the Download links which required navigating to the downloaded file and opening it to inspect its content. The new 'view' links open the content in a new tab instead for immediate inspection.

Release note: none.
Epic: none.