### PR TITLE
grpcinterceptor: do not wrap io.EOF in SendMsg

### DIFF
--- a/pkg/util/tracing/grpcinterceptor/grpc_interceptor.go
+++ b/pkg/util/tracing/grpcinterceptor/grpc_interceptor.go
@@ -390,7 +390,11 @@ func (cs *tracingClientStream) Header() (metadata.MD, error) {
 
 func (cs *tracingClientStream) SendMsg(m interface{}) error {
 	err := cs.ClientStream.SendMsg(m)
-	if err != nil {
+	if err == io.EOF {
+		cs.finishFunc(nil)
+		// Do not wrap EOF.
+		return err
+	} else if err != nil {
 		cs.finishFunc(err)
 	}
 	return errors.Wrap(err, "send msg error")


### PR DESCRIPTION
`io.EOF` is a special marker error that indicates a graceful termination of the gRPC stream and it is often compared against with equality (i.e. `== io.EOF`) to check that the termination was graceful. Previously, we would avoid wrapping this error in `RecvMsg` but not in `SendMsg`, and this commit fixes that.

This change was prompted by the fact that we couldn't determine a graceful termination because of the wrapping in the DistSQL engine which resulted in a scary-looking trace:
```
Outbox calling flowCtxCancel after Send (metadata) connection error: send msg error: ‹EOF›
(1) attached stack trace
  -- stack trace:
  | github.com/cockroachdb/cockroach/pkg/util/tracing/grpcinterceptor.(*tracingClientStream).SendMsg
  | github.com/cockroachdb/cockroach/pkg/util/tracing/grpcinterceptor/grpc_interceptor.go:383
  | github.com/cockroachdb/cockroach/pkg/sql/execinfrapb.(*distSQLFlowStreamClient).Send
  | github.com/cockroachdb/cockroach/pkg/sql/execinfrapb/bazel-out/k8-opt/bin/pkg/sql/execinfrapb/execinfrapb_go_proto_/github.com/cockroachdb/cockroach/pkg/sql/execinfrapb/api.pb.go:530
  | github.com/cockroachdb/cockroach/pkg/sql/colflow/colrpc.(*Outbox).sendMetadata
  | github.com/cockroachdb/cockroach/pkg/sql/colflow/colrpc/outbox.go:348
...
```

The error wrapping was added in 00fd3ef1fadde1d01f28a44d2bbeb65e3ba64f06 and kept the special handling of `io.EOF` in `RecvMsg` that has been present since 429ab2dd873d8e7e3a1da38fdcb12c117d979e80.

Unfortunately, I wasn't able to reproduce this trace (that happened on 24.1.7) to confirm the behavior, still this patch seems sound to me.

Fixes: #141847.

Release note: None