### PR TITLE
release-24.3: colexecbase: remove incorrect casts to Oid types

### DIFF
--- a/pkg/sql/colexec/colexecbase/cast.eg.go
+++ b/pkg/sql/colexec/colexecbase/cast.eg.go
@@ -71,6 +71,8 @@ func isIdentityCast(fromType, toType *types.T) bool {
 	return false
 }
 
+var errUnhandledCastToOid = errors.New("unhandled cast to oid")
+
 func GetCastOperator(
 	allocator *colmem.Allocator,
 	input colexecop.Operator,
@@ -87,6 +89,11 @@ func GetCastOperator(
 		colIdx:                   colIdx,
 		outputIdx:                resultIdx,
 		evalCtx:                  evalCtx,
+	}
+	if toType.Family() == types.OidFamily {
+		// Casting to Oid has special logic that involves resolving different
+		// objects, so we'll fall back to the row-by-row engine for that.
+		return nil, errUnhandledCastToOid
 	}
 	if fromType.Family() == types.UnknownFamily {
 		return &castOpNullAny{castOpBase: base}, nil
@@ -635,6 +642,11 @@ func GetCastOperator(
 }
 
 func IsCastSupported(fromType, toType *types.T) bool {
+	if toType.Family() == types.OidFamily {
+		// Casting to Oid has special logic that involves resolving different
+		// objects, so we'll fall back to the row-by-row engine for that.
+		return false
+	}
 	if fromType.Family() == types.UnknownFamily {
 		return true
 	}

--- a/pkg/sql/logictest/testdata/logic_test/cast
+++ b/pkg/sql/logictest/testdata/logic_test/cast
@@ -1548,3 +1548,17 @@ SELECT f::INT FROM t112515
 0
 2
 2
+
+statement ok
+CREATE TABLE t128294 (r REGCLASS);
+
+let $table_id
+SELECT 't128294'::REGCLASS::OID;
+
+statement ok
+INSERT INTO t128294 (r) VALUES ($table_id);
+
+query T
+SELECT (SELECT r FROM t128294) FROM t128294;
+----
+t128294

--- a/pkg/sql/opt/exec/execbuilder/testdata/experimental_distsql_planning_5node
+++ b/pkg/sql/opt/exec/execbuilder/testdata/experimental_distsql_planning_5node
@@ -74,14 +74,13 @@ EXPLAIN (VEC) SELECT * FROM kv WHERE k::REGCLASS IS NOT NULL
 ----
 │
 ├ Node 1
-│ └ *colexec.isNullSelOp
-│   └ *colexecbase.castNativeToDatumOp
-│     └ *colexec.ParallelUnorderedSynchronizer
-│       ├ *colfetcher.ColBatchScan
-│       ├ *colrpc.Inbox
-│       ├ *colrpc.Inbox
-│       ├ *colrpc.Inbox
-│       └ *colrpc.Inbox
+│ └ *rowexec.filtererProcessor
+│   └ *colexec.ParallelUnorderedSynchronizer
+│     ├ *colfetcher.ColBatchScan
+│     ├ *colrpc.Inbox
+│     ├ *colrpc.Inbox
+│     ├ *colrpc.Inbox
+│     └ *colrpc.Inbox
 ├ Node 2
 │ └ *colrpc.Outbox
 │   └ *colfetcher.ColBatchScan
@@ -104,9 +103,8 @@ EXPLAIN (VEC) SELECT * FROM kv WHERE k::REGCLASS IS NOT NULL
 ----
 │
 └ Node 1
-  └ *colexec.isNullSelOp
-    └ *colexecbase.castNativeToDatumOp
-      └ *colfetcher.ColBatchScan
+  └ *rowexec.filtererProcessor
+    └ *colfetcher.ColBatchScan
 
 statement ok
 SET experimental_distsql_planning = always
@@ -118,7 +116,7 @@ EXPLAIN (VEC) SELECT k::REGCLASS FROM kv
 ----
 │
 ├ Node 1
-│ └ *colexecbase.castNativeToDatumOp
+│ └ *rowexec.noopProcessor
 │   └ *colexec.ParallelUnorderedSynchronizer
 │     ├ *colfetcher.ColBatchScan
 │     ├ *colrpc.Inbox
@@ -149,7 +147,7 @@ EXPLAIN (VEC) SELECT k::REGCLASS FROM kv
 ----
 │
 ├ Node 1
-│ └ *colexecbase.castNativeToDatumOp
+│ └ *rowexec.noopProcessor
 │   └ *colexec.ParallelUnorderedSynchronizer
 │     ├ *colfetcher.ColBatchScan
 │     ├ *colrpc.Inbox

--- a/pkg/sql/opt/exec/execbuilder/testdata/vectorize_local
+++ b/pkg/sql/opt/exec/execbuilder/testdata/vectorize_local
@@ -129,7 +129,7 @@ execution time: 100µs
 distribution: <hidden>
 vectorized: <hidden>
 plan type: custom
-rows decoded from KV: 3 (24 B, 6 KVs, 3 gRPC calls)
+rows decoded from KV: 2 (16 B, 4 KVs, 2 gRPC calls)
 maximum memory usage: <hidden>
 network usage: <hidden>
 regions: <hidden>
@@ -141,16 +141,8 @@ quality of service: regular
 │
 └── • lookup join
     │ sql nodes: <hidden>
-    │ kv nodes: <hidden>
     │ regions: <hidden>
     │ actual row count: 2
-    │ KV time: 0µs
-    │ KV contention time: 0µs
-    │ KV rows decoded: 1
-    │ KV pairs read: 2
-    │ KV bytes read: 8 B
-    │ KV gRPC calls: 1
-    │ estimated max memory allocated: 0 B
     │ table: d@d_pkey
     │ equality: (b) = (b)
     │
@@ -170,7 +162,7 @@ quality of service: regular
           table: c@sec
           spans: FULL SCAN
 ·
-Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJy0lFFqGzEQht97imGeWlCSXVNKERScOm5xGtthHfJSTJCliaNaK20lLbEJPlYv0JOVXdkhjpPQQqMHw_zze2akb9g7DD8Ncpz0z_q9C5CHgvOi_3V0POxPzo97ffhSjIcg4XQ8GIGC8QjU4Qw-gTycIUPrFI1ESQH5d8xxyrDyTlIIzjfSXWsYqCXyjKG2VR0becpQOk_I7zDqaAg5XoiZoYKEIn-UIUNFUWjTlpXdQBIZ9pypSxs4CAZN70klmugAGX67hKZR4GDzFHqaa9ekI4WYpKhL4pD9_hVSLJ2NZKN2di_l3W0ARdIpUhw6SZytIgXwJBSH_AN8Tuq8OO-BFMaEe2MltN8a3yPD4WWvByFSBdLVNsJbWsYjbeM7Dll72WQgWjxnKMUSSiqdX4EwxkkRm7mydoaZiPKGArg6VnXk0Pjb-bdCB6drhinavH6IYk7I8we4BifIszX7e2KnTtsNsHwXmOqqq2pBK2R45tyiruCH0xac5dDtPATZUCzIKvIcuvnu3uGme8siPW2KQxTG7BF7Rfz5Pv6PT9HP9-l3_gt9WpKs9wd9paXoPFqK_F-WoqBQORtoZyGe65Q96nSQr6cMSc0pfTuCq72kc-9k603huC3UCopCTNk8BQO7TYXoSZT3O_2wUv5ipc5LlaYMr427vdIKOWabc_DEz_Zg8wcxD80TTW7cbVv2YlU1F7wWJhDDoVjQCUXypbY6RC2RR1_Tev3mTwAAAP__KdvF2w==
+Diagram: https://cockroachdb.github.io/distsqlplan/decode.html#eJykU8FqGzEQvfcrhjm1oCS7pvQgKDh13OI0toMdcikmyNLEUb0rbaVZYhP8Wf2BflnZlR3spAkt1WHhvXk7M3pv9wHjjwIlTvsX_d4V6GMl5aT_ZXQ67E8vT3t9-DwZD0HD-XgwAgPjEZjjOXwEfTxHgc4bGqmSIspvmONMYBW8phh9aKiHVjAwK5SZQOuqmht6JlD7QCgfkC0XhBKv1LygCSlD4SRDgYZY2aJtq7uRNArs-aIuXZSgBDSzp5Vq0BEK_HoNzaAoweUJBlpY35SZIieKbUkSsl8_Y8LaOybH1rtnpeDvIxjS3pCR0EnkfM0UIZAyEvIP8Cmxi8llD7QqivgorJQNO-F7FDi87vUgMlWgfe0Y3tKKT6zjdxKy9rJJQLR8SVCqFZRU-rAGVRReK272ytod5or1HUXwNVc1S2j07f47ooOzjcCEtu5HVgtCme_FNThDmW3E3yd27q3bBpYfBma65qZa0hoFXni_rCv47q0D7yR0O_tBNilOyBkKErr54XeH2-ltFsnahCOrojhMjFak6-dB_ocznSfO5P_izIRi5V2kA1dempQ9mXSUb2YCySwo_UDR10HTZfC61SY4bhu1hKHIqZonMHC7UuRAqnwMdr9T_mqnzmudZgJvC39_Yw1KzLbn6A-P3cHmBbWIjUXTO3_ftr1aV80Fb1URSeBQLemMmEJpnY1sNUoONW02b34HAAD__xZ9eDE=
 
 query T
 EXPLAIN (OPT, VERBOSE) SELECT c.a FROM c INNER MERGE JOIN d ON c.a = d.b


### PR DESCRIPTION
Backport 1/1 commits from #141946.

/cc @cockroachdb/release

---

Casting to some Oid types results in resolving different objects based on the provided Oid values. Previously, when performing the cast in the vectorized engine we would do no special resolution, so this commit disables casts to Oid types to fall back to the row-by-row engine.

Fixes: #128294.

Release note (bug fix): CockroachDB could previously incorrectly evaluate casts to some Oid types (like REGCLASS) in some cases and this has now been fixed. The bug has been present since at least 22.1 version.

Release justification: bug fix.