### PR TITLE
opt: minor fixes for queries that perform locking

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/plpgsql_cursor
+++ b/pkg/ccl/logictestccl/testdata/logic_test/plpgsql_cursor
@@ -1936,8 +1936,8 @@ $$ LANGUAGE PLpgSQL;
 
 subtest hold_setting
 
-# Test the open_plpgsql_cursor_with_hold setting, which causes PL/pgSQL cursors
-# to remain open after their transaction closes.
+# Test the close_cursors_at_commit setting, which determines whether PL/pgSQL
+# cursors remain open after their transaction closes.
 statement ok
 CREATE PROCEDURE make_curs(curs REFCURSOR) AS $$
   BEGIN
@@ -1954,7 +1954,7 @@ query T
 SELECT name FROM pg_cursors;
 ----
 
-# The cursors should be visible within the explicit transcation.
+# The cursors should be visible within the explicit transaction.
 statement ok
 BEGIN;
 CALL make_curs('foo');
@@ -2054,6 +2054,44 @@ FETCH FROM foo;
 # The preexisting cursor should still be closed by CLOSE ALL.
 statement ok
 CLOSE ALL;
+
+query T
+SELECT name FROM pg_cursors;
+----
+
+# Test a holdable cursor opened in a DO block.
+statement ok
+DO $$
+DECLARE
+  curs REFCURSOR := 'foo';
+BEGIN
+  OPEN curs FOR SELECT * FROM xy ORDER BY x;
+END
+$$;
+
+query II
+FETCH FROM foo;
+----
+1  2
+
+query T
+SELECT name FROM pg_cursors;
+----
+foo
+
+statement ok
+CLOSE foo;
+
+# If the query contains locking, the cursor is not holdable, and should be
+# closed when the transaction ends.
+statement ok
+DO $$
+DECLARE
+  curs REFCURSOR := 'foo';
+BEGIN
+  OPEN curs FOR SELECT * FROM xy FOR UPDATE;
+END
+$$;
 
 query T
 SELECT name FROM pg_cursors;

--- a/pkg/ccl/logictestccl/testdata/logic_test/read_committed
+++ b/pkg/ccl/logictestccl/testdata/logic_test/read_committed
@@ -553,6 +553,8 @@ user testuser
 statement ok
 COMMIT
 
+subtest end
+
 subtest regression_130661
 
 statement ok
@@ -575,5 +577,20 @@ SELECT * FROM t130661 WHERE id = 1 FOR UPDATE
 
 statement ok
 COMMIT
+
+subtest end
+
+subtest regression_141961
+
+statement ok
+BEGIN ISOLATION LEVEL READ COMMITTED;
+
+query I
+SELECT * FROM (WITH foo AS (SELECT * FROM t FOR UPDATE LIMIT 1) SELECT 1);
+----
+1
+
+statement ok
+ROLLBACK;
 
 subtest end

--- a/pkg/sql/opt/exec/execbuilder/testdata/select_for_update_read_committed
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select_for_update_read_committed
@@ -83,6 +83,7 @@ vectorized: true
 │   │ estimated row count: 0 (missing stats)
 │   │ table: supermarket
 │   │ set: aisle
+│   │ auto commit
 │   │
 │   └── • render
 │       │ columns: (person, aisle, starts_with, ends_with, aisle_new)

--- a/pkg/sql/opt/norm/testdata/rules/limit
+++ b/pkg/sql/opt/norm/testdata/rules/limit
@@ -1604,7 +1604,7 @@ lock abcde
  ├── lock columns: (8-12)
  ├── locking: for-update
  ├── cardinality: [0 - 1]
- ├── volatile, mutations
+ ├── volatile
  ├── key: ()
  ├── fd: ()-->(1-5)
  └── index-join abcde
@@ -1626,7 +1626,7 @@ lock abcde
  ├── key columns: a:1
  ├── lock columns: (8-12)
  ├── locking: for-update
- ├── volatile, mutations
+ ├── volatile
  ├── key: (1)
  ├── fd: ()-->(4), (1)-->(2,3,5)
  └── index-join abcde
@@ -1651,7 +1651,7 @@ SELECT * FROM abcde WHERE d IS NULL LIMIT 1 FOR UPDATE SKIP LOCKED
 limit
  ├── columns: a:1!null b:2 c:3!null d:4 e:5
  ├── cardinality: [0 - 1]
- ├── volatile, mutations
+ ├── volatile
  ├── key: ()
  ├── fd: ()-->(1-5)
  ├── lock abcde
@@ -1659,7 +1659,7 @@ limit
  │    ├── key columns: a:1
  │    ├── lock columns: (8-12)
  │    ├── locking: for-update,skip-locked
- │    ├── volatile, mutations
+ │    ├── volatile
  │    ├── key: (1)
  │    ├── fd: ()-->(4), (1)-->(2,3,5)
  │    ├── limit hint: 1.00
@@ -1684,14 +1684,14 @@ SELECT a FROM abcde WHERE d IS NULL OFFSET 1 FOR UPDATE SKIP LOCKED
 ----
 offset
  ├── columns: a:1!null
- ├── volatile, mutations
+ ├── volatile
  ├── key: (1)
  ├── lock abcde
  │    ├── columns: a:1!null
  │    ├── key columns: a:1
  │    ├── lock columns: (8-12)
  │    ├── locking: for-update,skip-locked
- │    ├── volatile, mutations
+ │    ├── volatile
  │    ├── key: (1)
  │    └── project
  │         ├── columns: a:1!null
@@ -1722,7 +1722,7 @@ lock abcde
  ├── lock columns: (8-12)
  ├── locking: for-update,durability-guaranteed
  ├── cardinality: [0 - 1]
- ├── volatile, mutations
+ ├── volatile
  ├── key: ()
  ├── fd: ()-->(1-5)
  └── index-join abcde
@@ -1744,7 +1744,7 @@ lock abcde
  ├── key columns: a:1
  ├── lock columns: (8-12)
  ├── locking: for-update,durability-guaranteed
- ├── volatile, mutations
+ ├── volatile
  ├── key: (1)
  ├── fd: ()-->(4), (1)-->(2,3,5)
  └── index-join abcde
@@ -1769,7 +1769,7 @@ SELECT * FROM abcde WHERE d IS NULL LIMIT 1 FOR UPDATE SKIP LOCKED
 limit
  ├── columns: a:1!null b:2 c:3!null d:4 e:5
  ├── cardinality: [0 - 1]
- ├── volatile, mutations
+ ├── volatile
  ├── key: ()
  ├── fd: ()-->(1-5)
  ├── lock abcde
@@ -1777,7 +1777,7 @@ limit
  │    ├── key columns: a:1
  │    ├── lock columns: (8-12)
  │    ├── locking: for-update,skip-locked,durability-guaranteed
- │    ├── volatile, mutations
+ │    ├── volatile
  │    ├── key: (1)
  │    ├── fd: ()-->(4), (1)-->(2,3,5)
  │    ├── limit hint: 1.00
@@ -1802,7 +1802,7 @@ SELECT * FROM abcde WHERE d IS NULL OFFSET 1 FOR UPDATE SKIP LOCKED
 ----
 offset
  ├── columns: a:1!null b:2 c:3!null d:4 e:5
- ├── volatile, mutations
+ ├── volatile
  ├── key: (1)
  ├── fd: ()-->(4), (1)-->(2,3,5)
  ├── lock abcde
@@ -1810,7 +1810,7 @@ offset
  │    ├── key columns: a:1
  │    ├── lock columns: (8-12)
  │    ├── locking: for-update,skip-locked,durability-guaranteed
- │    ├── volatile, mutations
+ │    ├── volatile
  │    ├── key: (1)
  │    ├── fd: ()-->(4), (1)-->(2,3,5)
  │    └── index-join abcde

--- a/pkg/sql/opt/norm/testdata/rules/mutation
+++ b/pkg/sql/opt/norm/testdata/rules/mutation
@@ -369,7 +369,7 @@ lock t
  ├── key columns: k:1
  ├── lock columns: (12-20)
  ├── locking: for-share
- ├── volatile, mutations
+ ├── volatile
  ├── key: (1)
  ├── fd: ()-->(2)
  └── select

--- a/pkg/sql/opt/ops/mutation.opt
+++ b/pkg/sql/opt/ops/mutation.opt
@@ -399,7 +399,7 @@ define UniqueChecksItemPrivate {
 # The Lock operator does not necessarily have to be at the top of a plan. It
 # could appear within a subtree of the plan, and in this case acts as an
 # optimization barrier to ensure the correct rows are locked.
-[Relational, Mutation]
+[Relational]
 define Lock {
     Input RelExpr
     _ LockPrivate

--- a/pkg/sql/opt/xform/testdata/external/tpcc-read-committed
+++ b/pkg/sql/opt/xform/testdata/external/tpcc-read-committed
@@ -130,7 +130,7 @@ lock stock
  ├── lock columns: (20-36)
  ├── locking: for-update,durability-guaranteed
  ├── cardinality: [0 - 5]
- ├── volatile, mutations
+ ├── volatile
  ├── key: (1)
  ├── fd: ()-->(2), (1)-->(3,8,14-17)
  ├── ordering: +1 opt(2) [actual: +1]
@@ -834,7 +834,7 @@ lock new_order
  ├── lock columns: (6-8)
  ├── locking: for-update,durability-guaranteed
  ├── cardinality: [0 - 1]
- ├── volatile, mutations
+ ├── volatile
  ├── key: ()
  ├── fd: ()-->(1-3)
  └── scan new_order

--- a/pkg/sql/opt/xform/testdata/rules/limit
+++ b/pkg/sql/opt/xform/testdata/rules/limit
@@ -367,7 +367,7 @@ lock partial_index_const
  ├── lock columns: (7-10)
  ├── locking: for-update
  ├── cardinality: [0 - 5]
- ├── volatile, mutations
+ ├── volatile
  ├── key: (4)
  ├── fd: ()-->(2), (4)-->(1,3)
  └── project

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -10434,6 +10434,7 @@ inner-join (lookup b)
  │    ├── right fixed columns: [9] = ['\x376300012a0400']
  │    ├── left locking: for-update
  │    ├── right locking: for-update
+ │    ├── volatile
  │    └── filters (true)
  └── filters (true)
 

--- a/pkg/sql/opt/xform/testdata/rules/select_for_update
+++ b/pkg/sql/opt/xform/testdata/rules/select_for_update
@@ -171,6 +171,7 @@ inner-join (lookup inverted)
  │    ├── right fixed columns: [6] = ['\x8a']
  │    ├── left locking: for-update
  │    ├── right locking: for-update
+ │    ├── volatile
  │    └── filters (true)
  └── filters (true)
 
@@ -288,5 +289,6 @@ inner-join (lookup zigzag)
  │    ├── right fixed columns: [7] = ['\x3766000112670001']
  │    ├── left locking: for-update
  │    ├── right locking: for-update
+ │    ├── volatile
  │    └── filters (true)
  └── filters (true)

--- a/pkg/sql/routine.go
+++ b/pkg/sql/routine.go
@@ -573,9 +573,10 @@ func (g *routineGenerator) newCursorHelper(plan *planComponents) (*plpgsqlCursor
 		// "unnamed" portal, which always exists.
 		return nil, pgerror.Newf(pgcode.DuplicateCursor, "cursor \"\" already in use")
 	}
-	// The CloseCursorsAtCommit setting provides oracle-compatible behavior, where
-	// cursors are holdable by default.
-	withHold := !g.p.SessionData().CloseCursorsAtCommit
+	// Disabling the CloseCursorsAtCommit setting provides oracle-compatible
+	// behavior, where cursors are holdable by default unless they contain
+	// locking.
+	withHold := !g.p.SessionData().CloseCursorsAtCommit && !plan.flags.IsSet(planFlagContainsLocking)
 	planCols := plan.main.planColumns()
 	cursorHelper := &plpgsqlCursorHelper{
 		cursorName: cursorName,


### PR DESCRIPTION
#### opt: set volatility for locking operators

This commit sets the volatile property for operators that perform locking,
other than Scan, which was already handled. In most cases there is already
a locking scan below these operators, so there are few plan changes. This
is necessary for a following commit, which will cause `Lock` operators to
no longer be considered mutation operators (which was previously causing
volatility to be set).

Epic: None

Release note: None

#### opt: remove Mutation tag from lock operators

This commit removes the `Mutation` tag from the optimizer lock operator.
As a result, errors that result from checking `opt.IsMutationOp` or
`planFlagContainsMutation` will no longer incorrectly occur for plans
that contain lock operators.

Fixes #141961

Release note: None

#### plpgsql: don't make cursors with locking holdable

This commit changes the `close_cursors_at_commit` setting to be more
Oracle-compatible. Now, disabling the setting will cause cursors to
remain open after txn commit only for cursors without locking.

Informs #77101

Release note: None