### PR TITLE
colexec: adjust a couple of tests due to recent removal

### DIFF
--- a/pkg/sql/colexec/colexectestutils/BUILD.bazel
+++ b/pkg/sql/colexec/colexectestutils/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
         "//pkg/sql/parser",
         "//pkg/sql/randgen",
         "//pkg/sql/rowenc/valueside",
+        "//pkg/sql/rowexec",
         "//pkg/sql/sem/eval",
         "//pkg/sql/sem/tree",
         "//pkg/sql/types",

--- a/pkg/sql/colexec/proj_utils_test.go
+++ b/pkg/sql/colexec/proj_utils_test.go
@@ -65,6 +65,9 @@ func assertProjOpAgainstRowByRow(
 	columnarizer := NewBufferingColumnarizerForTests(testAllocator, flowCtx, 1 /* processorID */, input)
 	projOp, err := colexectestutils.CreateTestProjectingOperator(
 		ctx, flowCtx, columnarizer, inputTypes, projExpr, testMemAcc,
+		// We don't support some casts to Oid types which requires the fallback
+		// to the row-by-row processors.
+		colexectestutils.AllowProcessorFallback{},
 	)
 	require.NoError(t, err)
 	// We will project out all input columns while keeping only the output


### PR DESCRIPTION
We just removed vectorized support of casts to Oid type in favor of falling back to the row-by-row engine. As a result, we need to set `NewColOperatorArgs.NewProcessor` constructor in a couple of tests. (An alternative would have been avoiding randomly picking Oid type in 3 affected tests, but it seems worse in terms of reducing the test coverage.)

Fixes: #141965.

Release note: None