### PR TITLE
rowexec: improve change of using encoding for distinct in stats

### DIFF
--- a/pkg/roachpb/data.go
+++ b/pkg/roachpb/data.go
@@ -945,17 +945,17 @@ func (v Value) PrettyPrint() (ret string) {
 			if i != 0 {
 				buf.WriteRune('/')
 			}
-			_, _, colIDDiff, typ, err := encoding.DecodeValueTag(b)
+			_, _, colIDDelta, typ, err := encoding.DecodeValueTag(b)
 			if err != nil {
 				break
 			}
-			colID += colIDDiff
+			colID += colIDDelta
 			var s string
 			b, s, err = encoding.PrettyPrintValueEncoded(b)
 			if err != nil {
 				break
 			}
-			fmt.Fprintf(&buf, "%d:%d:%s/%s", colIDDiff, colID, typ, s)
+			fmt.Fprintf(&buf, "%d:%d:%s/%s", colIDDelta, colID, typ, s)
 		}
 	case ValueType_INT:
 		var i int64

--- a/pkg/sql/colfetcher/cfetcher.go
+++ b/pkg/sql/colfetcher/cfetcher.go
@@ -1271,7 +1271,7 @@ func (cf *cFetcher) processValueBytes(
 	cf.machine.remainingValueColsByIdx.UnionWith(cf.table.compositeIndexColOrdinals)
 
 	var (
-		colIDDiff      uint32
+		colIDDelta     uint32
 		lastColID      descpb.ColumnID
 		dataOffset     int
 		typ            encoding.Type
@@ -1283,11 +1283,11 @@ func (cf *cFetcher) processValueBytes(
 	// it's expensive to keep calling .Len() in the loop.
 	remainingValueCols := cf.machine.remainingValueColsByIdx.Len()
 	for len(valueBytes) > 0 && remainingValueCols > 0 {
-		_, dataOffset, colIDDiff, typ, err = encoding.DecodeValueTag(valueBytes)
+		_, dataOffset, colIDDelta, typ, err = encoding.DecodeValueTag(valueBytes)
 		if err != nil {
 			return "", "", err
 		}
-		colID := lastColID + descpb.ColumnID(colIDDiff)
+		colID := lastColID + descpb.ColumnID(colIDDelta)
 		lastColID = colID
 		vecIdx := -1
 		// Find the ordinal into table.cols for the column ID we just decoded,

--- a/pkg/sql/logictest/testdata/logic_test/stats
+++ b/pkg/sql/logictest/testdata/logic_test/stats
@@ -106,3 +106,19 @@ FROM [SHOW STATISTICS FOR TABLE t139381]
 {k}  histogram_collected
 {j}  histogram_collected
 {v}  histogram_collected
+
+# Regression test for inflating the distinct count due to including column ID
+# delta in the sketch (#141448).
+statement ok
+CREATE TABLE t141448 (i INT, f FLOAT, b BOOL);
+
+statement ok
+INSERT INTO t141448 VALUES (NULL, NULL, false), (NULL, 1, false), (1, 1, false);
+
+statement ok
+ANALYZE t141448;
+
+query II
+SELECT row_count, distinct_count FROM [SHOW STATISTICS FOR TABLE t141448] WHERE column_names = ARRAY['b'];
+----
+3  1

--- a/pkg/sql/rowenc/index_encoding.go
+++ b/pkg/sql/rowenc/index_encoding.go
@@ -494,11 +494,11 @@ func DecodeIndexKeyToDatums(
 
 		var lastColID descpb.ColumnID = 0
 		for len(valueBytes) > 0 {
-			typeOffset, dataOffset, colIDDiff, typ, err := encoding.DecodeValueTag(valueBytes)
+			typeOffset, dataOffset, colIDDelta, typ, err := encoding.DecodeValueTag(valueBytes)
 			if err != nil {
 				return nil, err
 			}
-			colID := lastColID + descpb.ColumnID(colIDDiff)
+			colID := lastColID + descpb.ColumnID(colIDDelta)
 			lastColID = colID
 			colOrdinal, ok := colIDs.Get(colID)
 			if !ok {
@@ -1824,16 +1824,16 @@ func SkipColumnNotInPrimaryIndexValue(
 func DecodeValueBytes(
 	colIdxMap catalog.TableColMap, valueBytes []byte, neededValueCols int, row EncDatumRow,
 ) (colOrds intsets.Fast, err error) {
-	var colIDDiff uint32
+	var colIDDelta uint32
 	var lastColID descpb.ColumnID
 	var typeOffset, dataOffset int
 	var typ encoding.Type
 	for len(valueBytes) > 0 && colOrds.Len() < neededValueCols {
-		typeOffset, dataOffset, colIDDiff, typ, err = encoding.DecodeValueTag(valueBytes)
+		typeOffset, dataOffset, colIDDelta, typ, err = encoding.DecodeValueTag(valueBytes)
 		if err != nil {
 			return intsets.Fast{}, err
 		}
-		colID := lastColID + descpb.ColumnID(colIDDiff)
+		colID := lastColID + descpb.ColumnID(colIDDelta)
 		lastColID = colID
 		idx, ok := colIdxMap.Get(colID)
 		if !ok {

--- a/pkg/sql/rowenc/valueside/decode.go
+++ b/pkg/sql/rowenc/valueside/decode.go
@@ -306,11 +306,11 @@ func (d *Decoder) Decode(a *tree.DatumAlloc, bytes []byte) (tree.Datums, error) 
 
 	var lastColID descpb.ColumnID
 	for len(bytes) > 0 {
-		_, dataOffset, colIDDiff, typ, err := encoding.DecodeValueTag(bytes)
+		_, dataOffset, colIDDelta, typ, err := encoding.DecodeValueTag(bytes)
 		if err != nil {
 			return nil, err
 		}
-		colID := lastColID + descpb.ColumnID(colIDDiff)
+		colID := lastColID + descpb.ColumnID(colIDDelta)
 		lastColID = colID
 		idx, ok := d.colIdxMap.Get(colID)
 		if !ok {


### PR DESCRIPTION
**util/encoding: clarify colID return argument in value encoding**

`colID` return argument in the value encoding functions is actually
"column ID Delta" (i.e. difference from the previous column within
the same value). This commit renames some of the variables to
`colIDDelta` to make that clearer. For example in a recent change to
use the available value encoding when calculating distinct count multiple
engineers treated this return argument incorrectly.

Release note: None

**rowexec: improve change of using encoding for distinct in stats**

This commit improves the recent change to use available datum encoding
for distinct estimation in the table stats. We overlooked one aspect of
the value encoding - that "column ID" there refers to the "column ID
delta", so the value encoding for the same actual datums could differ
based on datums in the _other_ columns. This commit plumbs some
knowledge of the encoding into the sketch so that we discard the column
ID delta. Note that we still include the value tag (i.e. type) of the
value to differentiate from NULL datums. We also fallback to Fingerprint
method for handling NULLs to guarantee that they use the same encoding.

Fixes: #141448.

Release note: None