### PR TITLE
sql, ui: add SQL commenter support

### DIFF
--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -245,6 +245,7 @@ go_library(
         "split.go",
         "spool.go",
         "sql_activity_update_job.go",
+        "sql_commenter.go",
         "sql_cursor.go",
         "statement.go",
         "subquery.go",

--- a/pkg/sql/appstatspb/app_stats.proto
+++ b/pkg/sql/appstatspb/app_stats.proto
@@ -221,6 +221,7 @@ message StatementStatisticsKey {
   optional string database = 9 [(gogoproto.nullable) = false];
   optional uint64 plan_hash = 10 [(gogoproto.nullable) = false];
   optional string query_summary = 12 [(gogoproto.nullable) = false];
+  optional string sql_commenter_tags = 13 [(gogoproto.nullable) = false];
 
   reserved 4, 5;
   optional uint64 transaction_fingerprint_id = 11

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -2977,7 +2977,7 @@ func populateQueriesTable(
 // formatActiveQuery formats a serverpb.ActiveQuery by interpolating its
 // placeholders within the string.
 func formatActiveQuery(query serverpb.ActiveQuery) string {
-	parsed, parseErr := parser.ParseOneRetainComments(query.Sql)
+	parsed, parseErr := parser.ParseOne(query.Sql, parser.WithComments(true))
 	if parseErr != nil {
 		// If we failed to interpolate, rather than give up just send out the
 		// SQL without interpolated placeholders. Hallelujah!

--- a/pkg/sql/executor_statement_metrics.go
+++ b/pkg/sql/executor_statement_metrics.go
@@ -146,14 +146,15 @@ func (ex *connExecutor) recordStatementSummary(
 
 	fullScan := flags.IsSet(planFlagContainsFullIndexScan) || flags.IsSet(planFlagContainsFullTableScan)
 	recordedStmtStatsKey := appstatspb.StatementStatisticsKey{
-		Query:        stmt.StmtNoConstants,
-		QuerySummary: stmt.StmtSummary,
-		DistSQL:      flags.IsDistributed(),
-		Vec:          flags.IsSet(planFlagVectorized),
-		ImplicitTxn:  flags.IsSet(planFlagImplicitTxn),
-		FullScan:     fullScan,
-		Database:     planner.SessionData().Database,
-		PlanHash:     planner.instrumentation.planGist.Hash(),
+		Query:            stmt.StmtNoConstants,
+		SqlCommenterTags: buildSqlCommenterTagsStr(stmt.SQLCommenterTags),
+		QuerySummary:     stmt.StmtSummary,
+		DistSQL:          flags.IsDistributed(),
+		Vec:              flags.IsSet(planFlagVectorized),
+		ImplicitTxn:      flags.IsSet(planFlagImplicitTxn),
+		FullScan:         fullScan,
+		Database:         planner.SessionData().Database,
+		PlanHash:         planner.instrumentation.planGist.Hash(),
 	}
 
 	idxRecommendations := idxrecommendations.FormatIdxRecommendations(planner.instrumentation.indexRecs)
@@ -199,8 +200,9 @@ func (ex *connExecutor) recordStatementSummary(
 		ExecStats:            queryLevelStats,
 		// TODO(mgartner): Use a slice of struct{uint64, uint64} instead of
 		// converting to strings.
-		Indexes:  planner.instrumentation.indexesUsed.Strings(),
-		Database: planner.SessionData().Database,
+		Indexes:          planner.instrumentation.indexesUsed.Strings(),
+		Database:         planner.SessionData().Database,
+		SQLCommenterTags: stmt.SQLCommenterTags,
 	}
 
 	stmtFingerprintID, err :=

--- a/pkg/sql/pgwire/conn.go
+++ b/pkg/sql/pgwire/conn.go
@@ -380,7 +380,7 @@ func (c *conn) handleSimpleQuery(
 			},
 		)
 	}
-	stmts, err := c.parser.ParseWithInt(query, unqualifiedIntSize)
+	stmts, err := c.parser.Parse(query, parser.WithIntType(unqualifiedIntSize))
 	if err != nil {
 		log.SqlExec.Infof(ctx, "could not parse simple query: %s", query)
 		return c.stmtBuf.Push(ctx, sql.SendError{Err: err})
@@ -516,7 +516,7 @@ func (c *conn) handleParse(ctx context.Context, nakedIntSize *types.T) error {
 	}
 
 	startParse := crtime.NowMono()
-	stmts, err := c.parser.ParseWithInt(query, nakedIntSize)
+	stmts, err := c.parser.Parse(query, parser.WithIntType(nakedIntSize))
 	if err != nil {
 		log.SqlExec.Infof(ctx, "could not parse: %s", query)
 		return c.stmtBuf.Push(ctx, sql.SendError{Err: err})

--- a/pkg/sql/pgwire/conn.go
+++ b/pkg/sql/pgwire/conn.go
@@ -380,7 +380,7 @@ func (c *conn) handleSimpleQuery(
 			},
 		)
 	}
-	stmts, err := c.parser.Parse(query, parser.WithIntType(unqualifiedIntSize))
+	stmts, err := c.parser.Parse(query, parser.WithIntType(unqualifiedIntSize), parser.WithComments(true))
 	if err != nil {
 		log.SqlExec.Infof(ctx, "could not parse simple query: %s", query)
 		return c.stmtBuf.Push(ctx, sql.SendError{Err: err})
@@ -516,7 +516,7 @@ func (c *conn) handleParse(ctx context.Context, nakedIntSize *types.T) error {
 	}
 
 	startParse := crtime.NowMono()
-	stmts, err := c.parser.Parse(query, parser.WithIntType(nakedIntSize))
+	stmts, err := c.parser.Parse(query, parser.WithIntType(nakedIntSize), parser.WithComments(true))
 	if err != nil {
 		log.SqlExec.Infof(ctx, "could not parse: %s", query)
 		return c.stmtBuf.Push(ctx, sql.SendError{Err: err})

--- a/pkg/sql/session_state.go
+++ b/pkg/sql/session_state.go
@@ -141,8 +141,8 @@ func (p *planner) DeserializeSessionState(
 	}
 
 	for _, prepStmt := range m.PreparedStatements {
-		stmts, err := parser.ParseWithInt(
-			prepStmt.SQL, parser.NakedIntTypeFromDefaultIntSize(sd.DefaultIntSize),
+		stmts, err := parser.Parse(
+			prepStmt.SQL, parser.WithIntType(parser.NakedIntTypeFromDefaultIntSize(sd.DefaultIntSize)),
 		)
 		if err != nil {
 			return nil, err

--- a/pkg/sql/sql_commenter.go
+++ b/pkg/sql/sql_commenter.go
@@ -1,0 +1,62 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package sql
+
+import (
+	"fmt"
+	"net/url"
+	"strconv"
+	"strings"
+)
+
+// Parsing log to parse the comments added by
+// SQL commenter: https://google.github.io/sqlcommenter/spec/#parsing.
+func extractSQLCommenterTags(comment string) (map[string]string, error) {
+	comment = strings.TrimSpace(comment)
+	comment = strings.Replace(comment, "--", "", 1)
+	comment = strings.Replace(comment, "/*", "", 1)
+	comment = strings.Replace(comment, "*/", "", 1)
+
+	pairs := strings.Split(comment, ",")
+	if len(pairs) == 0 {
+		return nil, fmt.Errorf("error parsing SQL comment")
+	}
+
+	normalize := func(s string) string {
+		if us, err := strconv.Unquote(s); err == nil {
+			s = us
+		}
+		s, _ = url.QueryUnescape(s)
+		s, _ = url.PathUnescape(s)
+		return s
+	}
+
+	sqlCommenterTags := make(map[string]string)
+	for _, pair := range pairs {
+		elems := strings.Split(pair, "=")
+		if len(elems) != 2 {
+			return nil, fmt.Errorf("error parsing SQL comment")
+		}
+		key := normalize(strings.TrimSpace(elems[0]))
+		value := normalize(strings.Trim(strings.TrimSpace(elems[1]), "'"))
+		sqlCommenterTags[key] = value
+	}
+
+	return sqlCommenterTags, nil
+}
+
+// buildSqlCommenterTagsStr builds the comment string from the commenter tags
+// using spec outlined in https://google.github.io/sqlcommenter/spec/#parsing.
+func buildSqlCommenterTagsStr(sqlCommenterTags map[string]string) string {
+	b := strings.Builder{}
+	for k, v := range sqlCommenterTags {
+		b.WriteString(k)
+		b.WriteString("=")
+		b.WriteString(v)
+		b.WriteString(";")
+	}
+	return b.String()
+}

--- a/pkg/sql/sqlstats/insights/insights.proto
+++ b/pkg/sql/sqlstats/insights/insights.proto
@@ -133,6 +133,10 @@ message Statement {
   // KVNodeIDs is the ordered list of KV node ids which were used to evaluate KV
   // read requests.
   repeated int32 kv_node_ids = 26 [(gogoproto.customname) = "KVNodeIDs"];
+  // SQL commenter tags capture application context and provide developers with
+  // visibility into the code responsible for generating slow queries. They also
+  // map application traces to data query plans.
+  repeated SqlCommenterTag sql_commenter_tags = 27;
 }
 
 
@@ -150,4 +154,9 @@ message Insight {
 
   reserved  4; // Previously problem.
   reserved 5; // Previously causes.
+}
+
+message SqlCommenterTag {
+  string name = 1;
+  string value = 2 ;
 }

--- a/pkg/sql/sqlstats/sslocal/sslocal_stats_collector.go
+++ b/pkg/sql/sqlstats/sslocal/sslocal_stats_collector.go
@@ -268,10 +268,23 @@ func (s *StatsCollector) ObserveStatement(
 		CPUSQLNanos:          cpuSQLNanos,
 		ErrorCode:            errorCode,
 		ErrorMsg:             errorMsg,
+		SqlCommenterTags:     s.buildSQLCommenterTags(value.SQLCommenterTags),
 	}
 	if s.insightsWriter != nil {
 		s.insightsWriter.ObserveStatement(value.SessionID, &insight)
 	}
+}
+
+func (s *StatsCollector) buildSQLCommenterTags(m map[string]string) []*insights.SqlCommenterTag {
+	tags := make([]*insights.SqlCommenterTag, 0, len(m))
+	for k, v := range m {
+		tags = append(tags, &insights.SqlCommenterTag{
+			Name:  k,
+			Value: v,
+		})
+	}
+
+	return tags
 }
 
 // ObserveTransaction sends the recorded transaction stats to the insights system

--- a/pkg/sql/sqlstats/ssmemstorage/ss_mem_storage.go
+++ b/pkg/sql/sqlstats/ssmemstorage/ss_mem_storage.go
@@ -40,9 +40,10 @@ type stmtKey struct {
 
 // sampledPlanKey is used by the Optimizer to determine if we should build a full EXPLAIN plan.
 type sampledPlanKey struct {
-	stmtNoConstants string
-	implicitTxn     bool
-	database        string
+	stmtNoConstants  string
+	sqlCommenterTags string
+	implicitTxn      bool
+	database         string
 }
 
 func (p sampledPlanKey) size() int64 {

--- a/pkg/sql/sqlstats/ssmemstorage/ss_mem_writer.go
+++ b/pkg/sql/sqlstats/ssmemstorage/ss_mem_writer.go
@@ -49,9 +49,10 @@ func (s *Container) RecordStatement(
 
 	statementKey := stmtKey{
 		sampledPlanKey: sampledPlanKey{
-			stmtNoConstants: key.Query,
-			implicitTxn:     key.ImplicitTxn,
-			database:        key.Database,
+			stmtNoConstants:  key.Query,
+			sqlCommenterTags: key.SqlCommenterTags,
+			implicitTxn:      key.ImplicitTxn,
+			database:         key.Database,
 		},
 		planHash:                 key.PlanHash,
 		transactionFingerprintID: key.TransactionFingerprintID,

--- a/pkg/sql/sqlstats/ssprovider.go
+++ b/pkg/sql/sqlstats/ssprovider.go
@@ -86,6 +86,7 @@ type RecordedStmtStats struct {
 	ExecStats            *execstats.QueryLevelStats
 	Indexes              []string
 	Database             string
+	SQLCommenterTags     map[string]string
 }
 
 // RecordedTxnStats stores the statistics of a transaction to be recorded.

--- a/pkg/sql/statement.go
+++ b/pkg/sql/statement.go
@@ -1,4 +1,4 @@
-// Copyright 2017 The Cockroach Authors.
+// Copyright 2017 The Cockroach Authors.pkg/sql/statement.go
 //
 // Use of this software is governed by the CockroachDB Software License
 // included in the /LICENSE file.
@@ -33,27 +33,50 @@ type Statement struct {
 	// Given that the PreparedStatement can be modified during planning, it is
 	// not safe for use on multiple threads.
 	Prepared *PreparedStatement
+
+	// Application specific tags added by SQL commenter
+	SQLCommenterTags map[string]string
 }
 
 func makeStatement(
 	parserStmt statements.Statement[tree.Statement], queryID clusterunique.ID, fmtFlags tree.FmtFlags,
 ) Statement {
+	sqlCommenterTags := make(map[string]string)
+	cl := len(parserStmt.Comments)
+	if cl > 0 {
+		tags, err := extractSQLCommenterTags(parserStmt.Comments[cl-1])
+		if err == nil {
+			sqlCommenterTags = tags
+		}
+	}
+
 	return Statement{
-		Statement:       parserStmt,
-		StmtNoConstants: formatStatementHideConstants(parserStmt.AST, fmtFlags),
-		StmtSummary:     formatStatementSummary(parserStmt.AST, fmtFlags),
-		QueryID:         queryID,
+		Statement:        parserStmt,
+		StmtNoConstants:  formatStatementHideConstants(parserStmt.AST, fmtFlags),
+		StmtSummary:      formatStatementSummary(parserStmt.AST, fmtFlags),
+		QueryID:          queryID,
+		SQLCommenterTags: sqlCommenterTags,
 	}
 }
 
 func makeStatementFromPrepared(prepared *PreparedStatement, queryID clusterunique.ID) Statement {
+	sqlCommenterTags := make(map[string]string)
+	cl := len(prepared.Comments)
+	if cl > 0 {
+		tags, err := extractSQLCommenterTags(prepared.Comments[cl-1])
+		if err == nil {
+			sqlCommenterTags = tags
+		}
+	}
+
 	return Statement{
-		Statement:       prepared.Statement,
-		Prepared:        prepared,
-		ExpectedTypes:   prepared.Columns,
-		StmtNoConstants: prepared.StatementNoConstants,
-		StmtSummary:     prepared.StatementSummary,
-		QueryID:         queryID,
+		Statement:        prepared.Statement,
+		Prepared:         prepared,
+		ExpectedTypes:    prepared.Columns,
+		StmtNoConstants:  prepared.StatementNoConstants,
+		StmtSummary:      prepared.StatementSummary,
+		QueryID:          queryID,
+		SQLCommenterTags: sqlCommenterTags,
 	}
 }
 

--- a/pkg/ui/workspaces/cluster-ui/src/api/stmtInsightsApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/stmtInsightsApi.ts
@@ -8,6 +8,7 @@ import moment from "moment-timezone";
 import {
   ContentionDetails,
   InsightExecEnum,
+  SQLComment,
   StatementStatus,
   StmtInsightEvent,
 } from "src/insights/types";
@@ -65,6 +66,7 @@ export type StmtInsightsResponseRow = {
   cpu_sql_nanos: number;
   error_code: string;
   last_error_redactable: string;
+  comments: SQLComment[];
   status: StatementStatus;
 };
 
@@ -97,6 +99,7 @@ plan_gist,
 cpu_sql_nanos,
 error_code,
 last_error_redactable,
+comments,
 status
 `;
 
@@ -241,6 +244,7 @@ export function formatStmtInsights(
       errorCode: row.error_code,
       errorMsg: row.last_error_redactable,
       status: row.status,
+      comments: row.comments,
     } as StmtInsightEvent;
   });
 }

--- a/pkg/ui/workspaces/cluster-ui/src/insights/types.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/types.ts
@@ -108,6 +108,11 @@ export type TxnInsightDetails = {
   statements?: StmtInsightEvent[];
 };
 
+export type SQLComment = {
+  name: string;
+  value: string;
+};
+
 // Shown on the stmt insights overview page.
 export type StmtInsightEvent = InsightEventBase & {
   statementExecutionID: string;
@@ -120,6 +125,7 @@ export type StmtInsightEvent = InsightEventBase & {
   execType?: InsightExecEnum;
   status: StatementStatus;
   errorMsg?: string;
+  comments?: SQLComment[];
 };
 
 export type Insight = {

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/statementInsightDetailsOverviewTab.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsightDetails/statementInsightDetailsOverviewTab.tsx
@@ -26,7 +26,7 @@ import { CockroachCloudContext } from "../../contexts";
 import { WaitTimeInsightsLabels } from "../../detailsPanels/waitTimeInsightsPanel";
 import { SortSetting } from "../../sortedtable";
 import { Timestamp } from "../../timestamp";
-import { StmtInsightEvent } from "../types";
+import { SQLComment, StmtInsightEvent } from "../types";
 import { getStmtInsightRecommendations } from "../utils";
 import {
   StatementDetailsLink,
@@ -172,6 +172,23 @@ export const StatementInsightDetailsOverviewTab: React.FC<
               value={StatementDetailsLink(insightDetails)}
             />
           </SummaryCard>
+        </Col>
+      </Row>
+      <Row gutter={24}>
+        <Col span={12}>
+          <SummaryCard>
+						<SummaryCardItem
+							label="SQLCommenter Tags"
+							value={insightDetails?.comments?.length ?? 0}
+						/>
+						<p className={summaryCardStylesCx("summary--card__divider")} />
+						{insightDetails?.comments?.map((comment: SQLComment) => (
+							<SummaryCardItem
+								label={comment.name}
+								value={comment.value}
+							/>
+						))}
+					</SummaryCard>
         </Col>
       </Row>
       <Row gutter={24}>

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/util/insightsColumns.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/util/insightsColumns.tsx
@@ -36,6 +36,7 @@ export const insightsColumnLabels = {
   tableName: "Table Name",
   indexName: "Index Name",
   cpu: "SQL CPU Time",
+  sqlCommenterTags: "SQLCommenter Tags"
 };
 
 export type InsightsTableColumnKeys = keyof typeof insightsColumnLabels;
@@ -238,6 +239,12 @@ export const insightsTableTitles: InsightsTableTitleType = {
       <p>{`SQL CPU Time spent executing within the specified time interval. It
       does not include SQL planning time nor KV execution time.`}</p>,
       "cpu",
+    );
+  },
+  sqlCommenterTags: (_: InsightExecEnum) => {
+    return makeToolTip(
+      <p>{`sqlcommenter tags`}</p>,
+      "sqlCommenterTags",
     );
   },
 };


### PR DESCRIPTION
To support SQL commenter integration, parser should also take comment mode as another option. Using functional options the code looks much cleaner.