### PR TITLE
ui: show coordinator node ID on job detail

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/jobs/jobDetailsPage/jobDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/jobs/jobDetailsPage/jobDetails.tsx
@@ -28,7 +28,7 @@ import { SummaryCard, SummaryCardItem } from "src/summaryCard";
 import summaryCardStyles from "src/summaryCard/summaryCard.module.scss";
 import { Text, TextTypes } from "src/text";
 import {
-  DATE_WITH_SECONDS_AND_MILLISECONDS_FORMAT_24_TZ,
+  DATE_WITH_SECONDS_FORMAT_24_TZ,
   DATE_WITH_SECONDS_FORMAT,
   TimestampToMoment,
   getMatchParamByName,
@@ -206,7 +206,7 @@ export class JobDetails extends React.Component<
               value={
                 <Timestamp
                   time={TimestampToMoment(job.created, null)}
-                  format={DATE_WITH_SECONDS_AND_MILLISECONDS_FORMAT_24_TZ}
+                  format={DATE_WITH_SECONDS_FORMAT_24_TZ}
                 />
               }
             />
@@ -216,7 +216,7 @@ export class JobDetails extends React.Component<
                 value={
                   <Timestamp
                     time={TimestampToMoment(job.modified, null)}
-                    format={DATE_WITH_SECONDS_AND_MILLISECONDS_FORMAT_24_TZ}
+                    format={DATE_WITH_SECONDS_FORMAT_24_TZ}
                   />
                 }
               />
@@ -227,7 +227,7 @@ export class JobDetails extends React.Component<
                 value={
                   <Timestamp
                     time={TimestampToMoment(job.finished, null)}
-                    format={DATE_WITH_SECONDS_AND_MILLISECONDS_FORMAT_24_TZ}
+                    format={DATE_WITH_SECONDS_FORMAT_24_TZ}
                   />
                 }
               />

--- a/pkg/ui/workspaces/cluster-ui/src/jobs/jobDetailsPage/jobDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/jobs/jobDetailsPage/jobDetails.tsx
@@ -244,6 +244,14 @@ export class JobDetails extends React.Component<
                 }
               />
             )}
+            <SummaryCardItem
+              label="Coordinator Node"
+              value={
+                job.coordinator_id.isZero()
+                  ? "-"
+                  : job.coordinator_id.toString()
+              }
+            />
           </SummaryCard>
         </Col>
         <Col className="gutter-row" span={16}>


### PR DESCRIPTION
Previously you could find this from the table view only and had to toggle it on to do so, but it is often useful if you are inspcting a specific job to know where it is running.

Release note: none.
Epic: none.