### PR TITLE
release-23.2: teams: map cockroachdb/server to T-db-server team label

### DIFF
--- a/TEAMS.yaml
+++ b/TEAMS.yaml
@@ -81,6 +81,7 @@ cockroachdb/server:
   aliases:
     cockroachdb/cli-prs: other
     cockroachdb/server-prs: other
+  label: T-db-server
   triage_column_id: 2521812
 cockroachdb/jobs:
   aliases:


### PR DESCRIPTION
Backport 1/1 commits from #141963.

/cc @cockroachdb/release

---

This PR maps `@cockroachdb/server` to the `T-db-server` team label

Context is that this test failure didn't auto map to a team:
- https://github.com/cockroachdb/cockroach/issues/141817

It looks like previous test failures were manually mapped to `T-db-server`
- https://github.com/search?q=repo%3Acockroachdb%2Fcockroach+TestProfilesValidSQL&type=issues

Will also backport to release branches.

Release note: None
Epic: None
Release justification: test-only change
