### PR TITLE
stmtbundle: skip including FK references for read-only queries

### DIFF
--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -2077,6 +2077,7 @@ with_comment ::=
 
 opt_show_create_format_options ::=
 	'WITH' 'REDACT'
+	| 'WITH' 'IGNORE_FOREIGN_KEYS'
 
 opt_on_targets_roles ::=
 	'ON' targets_roles

--- a/pkg/acceptance/generated_cli_test.go
+++ b/pkg/acceptance/generated_cli_test.go
@@ -377,6 +377,13 @@ func TestDockerCLI_test_sb_recreate(t *testing.T) {
 	runTestDockerCLI(t, "test_sb_recreate", "../cli/interactive_tests/test_sb_recreate.tcl")
 }
 
+func TestDockerCLI_test_sb_recreate_fks(t *testing.T) {
+	s := log.Scope(t)
+	defer s.Close(t)
+
+	runTestDockerCLI(t, "test_sb_recreate_fks", "../cli/interactive_tests/test_sb_recreate_fks.tcl")
+}
+
 func TestDockerCLI_test_sb_recreate_mr(t *testing.T) {
 	s := log.Scope(t)
 	defer s.Close(t)

--- a/pkg/cli/interactive_tests/test_sb_recreate_fks.tcl
+++ b/pkg/cli/interactive_tests/test_sb_recreate_fks.tcl
@@ -1,0 +1,189 @@
+#! /usr/bin/env expect -f
+
+source [file join [file dirname $argv0] common.tcl]
+
+proc file_exists {filepath} {
+  if {! [ file exist $filepath]} {
+    report "MISSING EXPECTED FILE: $filepath"
+    exit 1
+  }
+}
+
+start_test "Ensure that 'debug sb recreate' works with FK references"
+
+spawn $argv demo --no-line-editor --empty --log-dir=logs
+eexpect "defaultdb>"
+
+send "CREATE TABLE parent (pk INT PRIMARY KEY, v INT);\r"
+send "CREATE TABLE child (pk INT PRIMARY KEY, fk INT REFERENCES parent(pk));\r"
+send "CREATE TABLE grandchild (pk INT PRIMARY KEY, fk INT REFERENCES child(pk));\r"
+eexpect "defaultdb>"
+
+
+# First, perform writes against each table. These bundles should include FK
+# references.
+
+
+send "EXPLAIN ANALYZE (DEBUG) INSERT INTO parent VALUES (1, 1);\r"
+eexpect "Statement diagnostics bundle generated."
+expect -re "SQL shell: \\\\statement-diag download (\\d+)" {
+  set w1 $expect_out(1,string)
+}
+
+send "\\statement-diag download $w1\r"
+eexpect "Bundle saved to"
+eexpect root@
+
+file_exists "stmt-bundle-$w1.zip"
+
+send "EXPLAIN ANALYZE (DEBUG) INSERT INTO child VALUES (1, 1);\r"
+eexpect "Statement diagnostics bundle generated."
+expect -re "SQL shell: \\\\statement-diag download (\\d+)" {
+  set w2 $expect_out(1,string)
+}
+
+send "\\statement-diag download $w2\r"
+eexpect "Bundle saved to"
+eexpect root@
+
+file_exists "stmt-bundle-$w2.zip"
+
+send "EXPLAIN ANALYZE (DEBUG) INSERT INTO grandchild VALUES (1, 1);\r"
+eexpect "Statement diagnostics bundle generated."
+expect -re "SQL shell: \\\\statement-diag download (\\d+)" {
+  set w3 $expect_out(1,string)
+}
+
+send "\\statement-diag download $w3\r"
+eexpect "Bundle saved to"
+eexpect root@
+
+file_exists "stmt-bundle-$w3.zip"
+
+
+# Now perform reads against each table. These bundles shouldn't include FK
+# references yet must be recreatable.
+
+
+send "EXPLAIN ANALYZE (DEBUG) SELECT * FROM parent;\r"
+eexpect "Statement diagnostics bundle generated."
+expect -re "SQL shell: \\\\statement-diag download (\\d+)" {
+  set r1 $expect_out(1,string)
+}
+
+send "\\statement-diag download $r1\r"
+eexpect "Bundle saved to"
+eexpect root@
+
+file_exists "stmt-bundle-$r1.zip"
+
+send "EXPLAIN ANALYZE (DEBUG) SELECT * FROM child;\r"
+eexpect "Statement diagnostics bundle generated."
+expect -re "SQL shell: \\\\statement-diag download (\\d+)" {
+  set r2 $expect_out(1,string)
+}
+
+send "\\statement-diag download $r2\r"
+eexpect "Bundle saved to"
+eexpect root@
+
+file_exists "stmt-bundle-$r2.zip"
+
+send "EXPLAIN ANALYZE (DEBUG) SELECT * FROM grandchild;\r"
+eexpect "Statement diagnostics bundle generated."
+expect -re "SQL shell: \\\\statement-diag download (\\d+)" {
+  set r3 $expect_out(1,string)
+}
+
+send "\\statement-diag download $r3\r"
+eexpect "Bundle saved to"
+eexpect root@
+
+file_exists "stmt-bundle-$r3.zip"
+
+send_eof
+eexpect eof
+
+
+# Recreate each bundle.
+
+
+set python "python2.7"
+set pyfile [file join [file dirname $argv0] unzip.py]
+system "mkdir bundle1"
+system "$python $pyfile stmt-bundle-$w1.zip bundle1"
+
+spawn $argv debug sb recreate bundle1
+eexpect "Statement was:"
+eexpect "INSERT"
+eexpect "defaultdb>"
+
+send_eof
+eexpect eof
+
+set python "python2.7"
+set pyfile [file join [file dirname $argv0] unzip.py]
+system "mkdir bundle2"
+system "$python $pyfile stmt-bundle-$w2.zip bundle2"
+
+spawn $argv debug sb recreate bundle2
+eexpect "Statement was:"
+eexpect "INSERT"
+eexpect "defaultdb>"
+
+send_eof
+eexpect eof
+
+set python "python2.7"
+set pyfile [file join [file dirname $argv0] unzip.py]
+system "mkdir bundle3"
+system "$python $pyfile stmt-bundle-$w3.zip bundle3"
+
+spawn $argv debug sb recreate bundle3
+eexpect "Statement was:"
+eexpect "INSERT"
+eexpect "defaultdb>"
+
+send_eof
+eexpect eof
+
+set python "python2.7"
+set pyfile [file join [file dirname $argv0] unzip.py]
+system "mkdir bundle4"
+system "$python $pyfile stmt-bundle-$r1.zip bundle4"
+
+spawn $argv debug sb recreate bundle4
+eexpect "Statement was:"
+eexpect "SELECT"
+eexpect "defaultdb>"
+
+send_eof
+eexpect eof
+
+set python "python2.7"
+set pyfile [file join [file dirname $argv0] unzip.py]
+system "mkdir bundle5"
+system "$python $pyfile stmt-bundle-$r2.zip bundle5"
+
+spawn $argv debug sb recreate bundle5
+eexpect "Statement was:"
+eexpect "SELECT"
+eexpect "defaultdb>"
+
+send_eof
+eexpect eof
+
+set python "python2.7"
+set pyfile [file join [file dirname $argv0] unzip.py]
+system "mkdir bundle6"
+system "$python $pyfile stmt-bundle-$r3.zip bundle6"
+
+spawn $argv debug sb recreate bundle6
+eexpect "Statement was:"
+eexpect "SELECT"
+eexpect "defaultdb>"
+
+send_eof
+eexpect eof
+
+end_test

--- a/pkg/sql/delegate/show_table.go
+++ b/pkg/sql/delegate/show_table.go
@@ -53,6 +53,8 @@ func (d *delegator) delegateShowCreateTable(n *tree.ShowCreate) (tree.Statement,
 	switch n.FmtOpt {
 	case tree.ShowCreateFormatOptionRedactedValues:
 		createField = "crdb_internal.redact(create_redactable)"
+	case tree.ShowCreateFormatOptionIgnoreFKs:
+		createField = "create_nofks"
 	}
 
 	showCreateQuery := `

--- a/pkg/sql/explain_bundle_test.go
+++ b/pkg/sql/explain_bundle_test.go
@@ -280,10 +280,9 @@ CREATE TABLE users(id UUID DEFAULT gen_random_uuid() PRIMARY KEY, promo_id INT R
 		}
 	})
 
-	t.Run("foreign keys", func(t *testing.T) {
+	t.Run("foreign keys, mutation", func(t *testing.T) {
 		// All tables should be included in the stmt bundle, regardless of which
-		// one we query because all of them are considered "related" (even
-		// though we don't specify ON DELETE and ON UPDATE actions).
+		// one we delete from because all of them are considered "related".
 		tableNames := []string{"parent", "child1", "child2", "grandchild1", "grandchild2"}
 		r.Exec(t, "CREATE TABLE parent (pk INT PRIMARY KEY, v INT);")
 		r.Exec(t, "CREATE TABLE child1 (pk INT PRIMARY KEY, fk INT REFERENCES parent(pk));")
@@ -301,12 +300,58 @@ CREATE TABLE users(id UUID DEFAULT gen_random_uuid() PRIMARY KEY, promo_id INT R
 			}
 			return nil
 		}
+		expectedFiles := map[string]string{
+			"parent":      "distsql-1-main-query.html distsql-2-postquery.html distsql-3-postquery.html vec-1-main-query-v.txt vec-1-main-query.txt vec-2-postquery-v.txt vec-2-postquery.txt vec-3-postquery-v.txt vec-3-postquery.txt",
+			"child1":      "distsql-1-main-query.html distsql-2-postquery.html vec-1-main-query-v.txt vec-1-main-query.txt vec-2-postquery-v.txt vec-2-postquery.txt",
+			"child2":      "distsql-1-main-query.html distsql-2-postquery.html vec-1-main-query-v.txt vec-1-main-query.txt vec-2-postquery-v.txt vec-2-postquery.txt",
+			"grandchild1": "distsql.html vec.txt vec-v.txt",
+			"grandchild2": "distsql.html vec.txt vec-v.txt",
+		}
 		for _, tableName := range tableNames {
-			rows := r.QueryStr(t, "EXPLAIN ANALYZE (DEBUG) SELECT * FROM "+tableName)
+			rows := r.QueryStr(t, "EXPLAIN ANALYZE (DEBUG) DELETE FROM "+tableName+" WHERE true")
 			checkBundle(
 				t, fmt.Sprint(rows), "child", contentCheck, false, /* expectErrors */
 				base, plans, "stats-defaultdb.public.parent.sql", "stats-defaultdb.public.child1.sql", "stats-defaultdb.public.child2.sql",
-				"stats-defaultdb.public.grandchild1.sql", "stats-defaultdb.public.grandchild2.sql", "distsql.html vec.txt vec-v.txt",
+				"stats-defaultdb.public.grandchild1.sql", "stats-defaultdb.public.grandchild2.sql", expectedFiles[tableName],
+			)
+		}
+	})
+
+	t.Run("foreign keys, read-only", func(t *testing.T) {
+		// Only the target table should be included since we perform a read-only
+		// stmt.
+		tableNames := []string{"parent", "child1", "child2", "grandchild1", "grandchild2"}
+		r.Exec(t, "CREATE TABLE IF NOT EXISTS parent (pk INT PRIMARY KEY, v INT);")
+		r.Exec(t, "CREATE TABLE IF NOT EXISTS child1 (pk INT PRIMARY KEY, fk INT REFERENCES parent(pk));")
+		r.Exec(t, "CREATE TABLE IF NOT EXISTS child2 (pk INT PRIMARY KEY, fk INT REFERENCES parent(pk));")
+		r.Exec(t, "CREATE TABLE IF NOT EXISTS grandchild1 (pk INT PRIMARY KEY, fk INT REFERENCES child1(pk));")
+		r.Exec(t, "CREATE TABLE IF NOT EXISTS grandchild2 (pk INT PRIMARY KEY, fk INT REFERENCES child2(pk));")
+		var targetTableName string
+		contentCheck := func(name, contents string) error {
+			if name == "schema.sql" {
+				if regexp.MustCompile("USE defaultdb;\nCREATE TABLE public."+targetTableName).FindString(contents) == "" {
+					return errors.Newf(
+						"could not find 'USE defaultdb;\nCREATE TABLE public.%s' in schema.sql:\n%s", targetTableName, contents)
+				}
+				for _, tableName := range tableNames {
+					if targetTableName == tableName {
+						continue
+					}
+					if regexp.MustCompile("USE defaultdb;\nCREATE TABLE public."+tableName).FindString(contents) != "" {
+						return errors.Newf(
+							"unexpectedly found 'USE defaultdb;\nCREATE TABLE public.%s' in schema.sql:\n%s", tableName, contents)
+					}
+				}
+			}
+			return nil
+		}
+		for _, tableName := range tableNames {
+			targetTableName = tableName
+			rows := r.QueryStr(t, "EXPLAIN ANALYZE (DEBUG) SELECT * FROM "+targetTableName)
+			checkBundle(
+				t, fmt.Sprint(rows), targetTableName, contentCheck, false, /* expectErrors */
+				base, plans, fmt.Sprintf("stats-defaultdb.public.%s.sql", targetTableName),
+				"distsql.html vec.txt vec-v.txt",
 			)
 		}
 	})

--- a/pkg/sql/logictest/testdata/logic_test/show_create
+++ b/pkg/sql/logictest/testdata/logic_test/show_create
@@ -127,6 +127,28 @@ c  CREATE TABLE public.c (
    COMMENT ON COLUMN public.c.a IS 'column';
    COMMENT ON INDEX public.c@c_a_b_idx IS 'index'
 
+query TT
+SHOW CREATE c WITH IGNORE_FOREIGN_KEYS
+----
+c  CREATE TABLE public.c (
+     a INT8 NOT NULL,
+     b INT8 NULL,
+     rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+     CONSTRAINT c_pkey PRIMARY KEY (rowid ASC),
+     INDEX c_a_b_idx (a ASC, b ASC),
+     UNIQUE INDEX unique_a (a ASC),
+     FAMILY fam_0_a_rowid (a, rowid),
+     FAMILY fam_1_b (b),
+     CONSTRAINT check_b CHECK (b IN (1:::INT8, 2:::INT8, 3:::INT8)),
+     CONSTRAINT unique_a_b UNIQUE WITHOUT INDEX (a, b),
+     CONSTRAINT unique_a_partial UNIQUE WITHOUT INDEX (a) WHERE b > 0:::INT8,
+     CONSTRAINT unique_b UNIQUE WITHOUT INDEX (b),
+     CONSTRAINT unique_b_partial UNIQUE WITHOUT INDEX (b) WHERE a > 0:::INT8
+   );
+   COMMENT ON TABLE public.c IS 'table';
+   COMMENT ON COLUMN public.c.a IS 'column';
+   COMMENT ON INDEX public.c@c_a_b_idx IS 'index'
+
 subtest alter_column_type_not_break_show_create
 
 onlyif config local-legacy-schema-changer local-mixed-24.3

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -4097,6 +4097,7 @@ func (b *Builder) getEnvData() (exec.ExplainEnvData, error) {
 		func(ds cat.DataSource) (cat.DataSourceName, error) {
 			return b.catalog.FullyQualifiedName(b.ctx, ds)
 		},
+		true, /* includeFKReferences */
 		true, /* includeVirtualTables */
 	)
 	return envOpts, err

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -1281,7 +1281,7 @@ func (ef *execFactory) showEnv(plan string, envOpts exec.ExplainEnvData) (exec.N
 	for i := range envOpts.Tables {
 		out.writef("")
 		if err := c.PrintCreateTable(
-			&out.buf, &envOpts.Tables[i], false, /* redactValues */
+			&out.buf, &envOpts.Tables[i], false /* redactValues */, true, /* includeFKReferences */
 		); err != nil {
 			return nil, err
 		}

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -9716,6 +9716,10 @@ opt_show_create_format_options:
   {
     $$.val = tree.ShowCreateFormatOptionRedactedValues
   }
+| WITH IGNORE_FOREIGN_KEYS
+  {
+    $$.val = tree.ShowCreateFormatOptionIgnoreFKs
+  }
 
 // %Help: SHOW CREATE SCHEDULES - list CREATE statements for scheduled jobs
 // %Category: DDL

--- a/pkg/sql/parser/testdata/show
+++ b/pkg/sql/parser/testdata/show
@@ -1973,6 +1973,14 @@ SHOW CREATE t WITH REDACT -- literals removed
 SHOW CREATE _ WITH REDACT -- identifiers removed
 
 parse
+SHOW CREATE TABLE t WITH IGNORE_FOREIGN_KEYS
+----
+SHOW CREATE t WITH IGNORE_FOREIGN_KEYS -- normalized!
+SHOW CREATE t WITH IGNORE_FOREIGN_KEYS -- fully parenthesized
+SHOW CREATE t WITH IGNORE_FOREIGN_KEYS -- literals removed
+SHOW CREATE _ WITH IGNORE_FOREIGN_KEYS -- identifiers removed
+
+parse
 SHOW CREATE VIEW t
 ----
 SHOW CREATE t -- normalized!

--- a/pkg/sql/sem/tree/show.go
+++ b/pkg/sql/sem/tree/show.go
@@ -808,6 +808,10 @@ type ShowCreateFormatOption int
 const (
 	ShowCreateFormatOptionNone ShowCreateFormatOption = iota
 	ShowCreateFormatOptionRedactedValues
+	ShowCreateFormatOptionIgnoreFKs
+	// TODO(yuzefovich): consider adding an option that has both redacted values
+	// and ignores the FKs. This will require addition of a new column to
+	// crdb_internal.create_statements virtual table.
 )
 
 // ShowCreate represents a SHOW CREATE statement.
@@ -834,6 +838,8 @@ func (node *ShowCreate) Format(ctx *FmtCtx) {
 	switch node.FmtOpt {
 	case ShowCreateFormatOptionRedactedValues:
 		ctx.WriteString(" WITH REDACT")
+	case ShowCreateFormatOptionIgnoreFKs:
+		ctx.WriteString(" WITH IGNORE_FOREIGN_KEYS")
 	}
 }
 


### PR DESCRIPTION
As of 982abc239efa69a808e4a2b4ecbb01126b253d8f, we include all FK referenced and referencing tables, including transitively, into the stmt bundles for all queries. This information might be required to understand the plans in some cases (like when we have a mutation which results in a CASCADE post-query), so we initially went with "include everything all the time". This can be suboptimal since we could pull in information that isn't actually needed for a particular query. Additionally, we've just seen a case where in the multi-region cluster pulling in all these related tables was taking minutes.

To partially alleaviate this problem, this commit removes all FK reference tables for read-only queries since then we know for sure there won't be any cascades or triggers. To achieve this `SHOW CREATE TABLE` command has been extended with `WITH IGNORE_FOREIGN_KEYS` option which makes it so that we use existing `create_nofks` column of `crdb_internal.create_statements` virtual table. This new option cannot be combined with existing `WITH REDACT` option (because we don't have the corresponding column, at least yet), so if the redacted bundle is requested, we still will pull in all FK references.

Fixes: #139196.

Release note (sql change): New `WITH IGNORE_FOREIGN_KEYS` option is added to `SHOW CREATE TABLE` stmt which makes it so that the foreign key constraints are not included in the output schema. This option is also acceptable in `SHOW CREATE VIEW` but has no influence there. It cannot be combined with existing `WITH REDACT` option.