### PR TITLE
sql: integrate jsonpath parser with jsonpath type

### DIFF
--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -570,6 +570,7 @@ go_library(
         "//pkg/util/ioctx",
         "//pkg/util/iterutil",
         "//pkg/util/json",
+        "//pkg/util/jsonpath/parser",
         "//pkg/util/log",
         "//pkg/util/log/eventpb",
         "//pkg/util/log/logcrash",

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -56,6 +56,9 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/duration"
 	"github.com/cockroachdb/cockroach/pkg/util/fsm"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	// TODO(normanchenn): temporarily import the parser here to ensure that
+	// init() is called.
+	_ "github.com/cockroachdb/cockroach/pkg/util/jsonpath/parser"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/log/eventpb"
 	"github.com/cockroachdb/cockroach/pkg/util/log/logpb"

--- a/pkg/sql/logictest/testdata/logic_test/jsonpath
+++ b/pkg/sql/logictest/testdata/logic_test/jsonpath
@@ -22,11 +22,6 @@ SELECT '$'::JSONPATH
 $
 
 query T
-SELECT '$.*'::JSONPATH
-----
-$.*
-
-query T
 SELECT 'strict $'::JSONPATH
 ----
 strict $
@@ -34,67 +29,12 @@ strict $
 query T
 SELECT 'lax $'::JSONPATH
 ----
-lax $
-
-query T
-SELECT '$.1a[*]'::JSONPATH
-----
-$.1a[*]
+$
 
 query T
 SELECT '$.a1[*]'::JSONPATH
 ----
 $.a1[*]
-
-query T
-SELECT '$.a[*] ? (@.b == 1 && @.c != 1)'::JSONPATH
-----
-$.a[*] ? (@.b == 1 && @.c != 1)
-
-query T
-SELECT '$.a[*] ? (@.b != 1)'::JSONPATH
-----
-$.a[*] ? (@.b != 1)
-
-query T
-SELECT '$.a[*] ? (@.b < 1)'::JSONPATH
-----
-$.a[*] ? (@.b < 1)
-
-query T
-SELECT '$.a[*] ? (@.b <= 1)'::JSONPATH
-----
-$.a[*] ? (@.b <= 1)
-
-query T
-SELECT '$.a[*] ? (@.b > 1)'::JSONPATH
-----
-$.a[*] ? (@.b > 1)
-
-query T
-SELECT '$.a[*] ? (@.b >= 1)'::JSONPATH
-----
-$.a[*] ? (@.b >= 1)
-
-query T
-SELECT '$.a ? (@.b == 1).c ? (@.d == 2)'::JSONPATH
-----
-$.a ? (@.b == 1).c ? (@.d == 2)
-
-query T
-SELECT '$.a?(@.b==1).c?(@.d==2)'::JSONPATH
-----
-$.a?(@.b==1).c?(@.d==2)
-
-query T
-SELECT '$  .  a  ?  (  @  .  b  ==  1  )  .  c  ?  (  @  .  d  ==  2  )  '::JSONPATH
-----
-$  .  a  ?  (  @  .  b  ==  1  )  .  c  ?  (  @  .  d  ==  2  )
-
-query T
-SELECT '$.a.type()'::JSONPATH
-----
-$.a.type()
 
 query B
 SELECT '$'::JSONPATH IS NULL
@@ -105,9 +45,6 @@ query B
 SELECT '$'::JSONPATH IS NOT NULL
 ----
 true
-
-statement error invalid jsonpath
-SELECT ''::JSONPATH
 
 statement error pq: unsupported comparison operator: jsonpath IS NOT DISTINCT FROM jsonpath
 SELECT '$'::JSONPATH IS NOT DISTINCT FROM '$'::JSONPATH
@@ -125,25 +62,26 @@ SELECT '$'::JSONPATH IS DISTINCT FROM NULL
 ----
 true
 
+statement error pq: could not parse "" as type jsonpath: at or near "EOF": syntax error
+SELECT ''::JSONPATH
+
+statement error pq: could not parse "\$\.1a\[\*\]" as type jsonpath: at or near "1": syntax error
+SELECT '$.1a[*]'::JSONPATH
+
+query T
+SELECT '$.abc[*].DEF.ghi[*]'::JSONPATH
+----
+$.abc[*].DEF.ghi[*]
+
+query T
+SELECT '$.ABC[*].DEF.GHI[*]'::JSONPATH
+----
+$.ABC[*].DEF.GHI[*]
+
+## When we allow table creation
+
 # statement ok
 # SELECT * FROM a WHERE j IS NULL
-
-## Jsonpath checks that shouldn't work when the type is fully implemented
-
-query T
-SELECT '$.'::JSONPATH
-----
-$.
-
-query T
-SELECT 'word $'::JSONPATH
-----
-word $
-
-query T
-SELECT '$a'::JSONPATH;
-----
-$a
 
 # statement ok
 # INSERT INTO a VALUES ('$.something'), ('$.other.thing'), ('$.another.thing'), ('$.a[*].b.c[*]')
@@ -164,3 +102,60 @@ $a
 
 # statement error unsupported comparison operator
 # SELECT * FROM a WHERE j = '$.a'
+
+## Unsupported Jsonpath
+
+# query T
+# SELECT '$.*'::JSONPATH
+# ----
+# $.*
+
+# query T
+# SELECT '$.a[*] ? (@.b == 1 && @.c != 1)'::JSONPATH
+# ----
+# $.a[*] ? (@.b == 1 && @.c != 1)
+
+# query T
+# SELECT '$.a[*] ? (@.b != 1)'::JSONPATH
+# ----
+# $.a[*] ? (@.b != 1)
+
+# query T
+# SELECT '$.a[*] ? (@.b < 1)'::JSONPATH
+# ----
+# $.a[*] ? (@.b < 1)
+
+# query T
+# SELECT '$.a[*] ? (@.b <= 1)'::JSONPATH
+# ----
+# $.a[*] ? (@.b <= 1)
+
+# query T
+# SELECT '$.a[*] ? (@.b > 1)'::JSONPATH
+# ----
+# $.a[*] ? (@.b > 1)
+
+# query T
+# SELECT '$.a[*] ? (@.b >= 1)'::JSONPATH
+# ----
+# $.a[*] ? (@.b >= 1)
+
+# query T
+# SELECT '$.a ? (@.b == 1).c ? (@.d == 2)'::JSONPATH
+# ----
+# $.a ? (@.b == 1).c ? (@.d == 2)
+
+# query T
+# SELECT '$.a?(@.b==1).c?(@.d==2)'::JSONPATH
+# ----
+# $.a?(@.b==1).c?(@.d==2)
+
+# query T
+# SELECT '$  .  a  ?  (  @  .  b  ==  1  )  .  c  ?  (  @  .  d  ==  2  )  '::JSONPATH
+# ----
+# $  .  a  ?  (  @  .  b  ==  1  )  .  c  ?  (  @  .  d  ==  2  )
+
+# query T
+# SELECT '$.a.type()'::JSONPATH
+# ----
+# $.a.type()

--- a/pkg/sql/randgen/BUILD.bazel
+++ b/pkg/sql/randgen/BUILD.bazel
@@ -44,6 +44,7 @@ go_library(
         "//pkg/util/duration",
         "//pkg/util/ipaddr",
         "//pkg/util/json",
+        "//pkg/util/jsonpath/parser",
         "//pkg/util/randident",
         "//pkg/util/randident/randidentcfg",
         "//pkg/util/randutil",

--- a/pkg/sql/randgen/datum.go
+++ b/pkg/sql/randgen/datum.go
@@ -577,7 +577,7 @@ func randJSONSimpleDepth(rng *rand.Rand, depth int) json.JSON {
 	}
 }
 
-const charSet = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789"
+const charSet = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ"
 
 // TODO(normanchenn): Add support for more complex jsonpath queries.
 func randJsonpath(rng *rand.Rand) string {

--- a/pkg/sql/randgen/datum.go
+++ b/pkg/sql/randgen/datum.go
@@ -27,6 +27,9 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/duration"
 	"github.com/cockroachdb/cockroach/pkg/util/ipaddr"
 	"github.com/cockroachdb/cockroach/pkg/util/json"
+	// TODO(normanchenn): temporarily import the parser here to ensure that
+	// init() is called.
+	_ "github.com/cockroachdb/cockroach/pkg/util/jsonpath/parser"
 	"github.com/cockroachdb/cockroach/pkg/util/timeofday"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil/pgdate"
@@ -847,16 +850,16 @@ func getRandInterestingDatums(typ types.Family) ([]tree.Datum, bool) {
 					"$",
 					"strict $",
 					"lax $",
-					"$.*",
-					"$.1a[*]",
 					"$.a1[*]",
-					"$.a ? (@.b == 1)",
-					"$.a ? (@.b == 1).b",
-					"$.a ? (@.b == 'true').c",
-					"$.a ? (@.b == 1).c ? (@.d == 2)",
-					"$.a?(@.b==1).c?(@.d==2)",
-					"$  .  a  ?  (  @  .  b  ==  1  )  .  c  ?  (  @  .  d  ==  2  )  ",
-					"$.a.type()",
+					// "$.*",
+					// "$.1a[*]",
+					// "$.a ? (@.b == 1)",
+					// "$.a ? (@.b == 1).b",
+					// "$.a ? (@.b == 'true').c",
+					// "$.a ? (@.b == 1).c ? (@.d == 2)",
+					// "$.a?(@.b==1).c?(@.d==2)",
+					// "$  .  a  ?  (  @  .  b  ==  1  )  .  c  ?  (  @  .  d  ==  2  )  ",
+					// "$.a.type()",
 				} {
 					d, err := tree.ParseDJsonpath(s)
 					if err != nil {

--- a/pkg/sql/scanner/jsonpath_scan.go
+++ b/pkg/sql/scanner/jsonpath_scan.go
@@ -41,6 +41,6 @@ func isIdentMiddle(ch int) bool {
 
 // scanIdent is similar to Scanner.scanIdent, but uses Jsonpath tokens.
 func (s *JSONPathScanner) scanIdent(lval ScanSymType) {
-	s.lowerCaseAndNormalizeIdent(lval, isIdentMiddle)
+	s.normalizeIdent(lval, isIdentMiddle, false /* toLower */)
 	lval.SetID(lexbase.GetKeywordID(lval.Str()))
 }

--- a/pkg/sql/scanner/plpgsql_scan.go
+++ b/pkg/sql/scanner/plpgsql_scan.go
@@ -433,6 +433,6 @@ func (s *PLpgSQLScanner) scanNumber(lval ScanSymType, ch int) {
 
 // scanIdent is similar to Scanner.scanIdent, but uses PL/pgSQL tokens.
 func (s *PLpgSQLScanner) scanIdent(lval ScanSymType) {
-	s.lowerCaseAndNormalizeIdent(lval, sqllex.IsIdentMiddle)
+	s.normalizeIdent(lval, sqllex.IsIdentMiddle, true /* toLower */)
 	lval.SetID(lexbase.GetKeywordID(lval.Str()))
 }

--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -3956,10 +3956,11 @@ func (d *DJsonpath) Format(ctx *FmtCtx) {
 }
 
 func ParseDJsonpath(s string) (Datum, error) {
-	if s == "" {
-		return nil, MakeParseError("invalid jsonpath", types.Jsonpath, nil)
+	jp, err := ValidateJSONPath(s)
+	if err != nil {
+		return nil, MakeParseError(s, types.Jsonpath, err)
 	}
-	return NewDJsonpath(s), nil
+	return NewDJsonpath(jp), nil
 }
 
 // DJSON is the JSON Datum.

--- a/pkg/util/jsonpath/parser/parse.go
+++ b/pkg/util/jsonpath/parser/parse.go
@@ -83,12 +83,13 @@ func (p *Parser) Parse(jsonpath string) (statements.JsonpathStatement, error) {
 	defer p.scanner.Cleanup()
 
 	query, tokens, done := p.scan()
+	if !done {
+		return statements.JsonpathStatement{}, errors.AssertionFailedf("invalid jsonpath query: %s", jsonpath)
+	}
+
 	stmt, err := p.parse(query, tokens)
 	if err != nil {
 		return statements.JsonpathStatement{}, err
-	}
-	if !done {
-		return statements.JsonpathStatement{}, errors.AssertionFailedf("invalid jsonpath query: %s", jsonpath)
 	}
 	return stmt, nil
 }

--- a/pkg/util/jsonpath/parser/testdata/jsonpath
+++ b/pkg/util/jsonpath/parser/testdata/jsonpath
@@ -129,6 +129,16 @@ DETAIL: source SQL:
 $.1e
   ^
 
+parse
+$.abc.ABC
+----
+$.abc.ABC
+
+parse
+$.mLmTGLKZsrNL.ZawfwNmnfbFoRsISbQXD[*].JgTODFNN
+----
+$.mLmTGLKZsrNL.ZawfwNmnfbFoRsISbQXD[*].JgTODFNN
+
 # parse
 # $.1a
 # ----


### PR DESCRIPTION
Previously, the `jsonpath` data type and `jsonpath` parsers were created. This PR integrates the parser with the data type.

Epic: None
Release note (sql change): Adding parser for jsonpath type. Accepts setting mode (`strict/lax`), key accessors (`.name`), and array wildcards (`[*]`).