### PR TITLE
sql: initialize virtual table descriptors concurrently; skip some vtable validations

### DIFF
--- a/pkg/sql/catalog/tabledesc/BUILD.bazel
+++ b/pkg/sql/catalog/tabledesc/BUILD.bazel
@@ -60,6 +60,7 @@ go_library(
         "//pkg/sql/types",
         "//pkg/sql/vecindex/vecpb",
         "//pkg/util",
+        "//pkg/util/buildutil",
         "//pkg/util/errorutil/unimplemented",
         "//pkg/util/hlc",
         "//pkg/util/interval",

--- a/pkg/sql/virtual_schema.go
+++ b/pkg/sql/virtual_schema.go
@@ -444,9 +444,6 @@ type VirtualSchemaHolder struct {
 	orderedNames  []string
 
 	catalogCache nstree.MutableCatalog
-	// Needed for backward-compat on crdb_internal.ranges{_no_leases}.
-	// Remove in v23.2.
-	st *cluster.Settings
 }
 
 var _ VirtualTabler = (*VirtualSchemaHolder)(nil)
@@ -930,10 +927,6 @@ func NewVirtualSchemaHolder(
 		schemasByID:   make(map[descpb.ID]*virtualSchemaEntry, len(virtualSchemas)),
 		orderedNames:  make([]string, len(virtualSchemas)),
 		defsByID:      make(map[descpb.ID]*virtualDefEntry, math.MaxUint32-catconstants.MinVirtualID),
-
-		// Needed for backward-compat on crdb_internal.ranges{_no_leases}.
-		// Remove in v23.2.
-		st: st,
 	}
 
 	order := 0

--- a/pkg/sql/virtual_schema.go
+++ b/pkg/sql/virtual_schema.go
@@ -41,10 +41,12 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlerrors"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
+	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/iterutil"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/redact"
 )
@@ -978,16 +980,29 @@ func NewVirtualSchemaHolder(
 			return tableDesc, entry, nil
 		}
 
+		// Initialize virtual tables concurrently. This happens all at once during
+		// server startup, which is a bottleneck for startup time, especially in
+		// the TestServer used by unit tests. Adding concurrency here speeds up
+		// TestServer startup by about 7% in SharedTenant mode.
+		g := ctxgroup.WithContext(ctx)
+		var mu syncutil.Mutex
 		for id, def := range schema.tableDefs {
-			tableDesc, entry, err := doTheWork(id, def, false /* bumpVersion */)
-			if err != nil {
-				return nil, err
-			}
-			defs[tableDesc.Name] = entry
-			vs.defsByID[tableDesc.ID] = entry
-			orderedDefNames = append(orderedDefNames, tableDesc.Name)
+			g.GoCtx(func(ctx context.Context) error {
+				tableDesc, entry, err := doTheWork(id, def, false /* bumpVersion */)
+				if err != nil {
+					return err
+				}
+				mu.Lock()
+				defer mu.Unlock()
+				defs[tableDesc.Name] = entry
+				vs.defsByID[tableDesc.ID] = entry
+				orderedDefNames = append(orderedDefNames, tableDesc.Name)
+				return nil
+			})
 		}
-
+		if err := g.Wait(); err != nil {
+			return nil, err
+		}
 		sort.Strings(orderedDefNames)
 
 		vse := &virtualSchemaEntry{

--- a/pkg/util/ctxgroup/ctxgroup.go
+++ b/pkg/util/ctxgroup/ctxgroup.go
@@ -166,6 +166,16 @@ func WithContext(ctx context.Context) Group {
 	}
 }
 
+// SetLimit limits the number of active goroutines in this group to at most n. A
+// negative value indicates no limit. A limit of zero will prevent any new
+// goroutines from being added. Any subsequent call to the Go method will block
+// until it can add an active goroutine without exceeding the configured limit.
+// The limit must not be modified while any goroutines in the group are active.
+// This delegates to errgroup.Group.SetLimit.
+func (g Group) SetLimit(n int) {
+	g.wrapped.SetLimit(n)
+}
+
 // Go calls the given function in a new goroutine.
 func (g Group) Go(f func() error) {
 	g.wrapped.Go(f)


### PR DESCRIPTION
See individual commits.

```
$ benchdiff --old 4348689e5d8 --new 959ef1f5c66 ./pkg/server -r BenchmarkTestServerStartup -c 10 -b -d 5s
old:  4348689 Merge #142011
new:  959ef1f sql: don't validate virtual tables upon creation u
args: benchdiff "--old" "4348689e5d8" "--new" "959ef1f5c66" "./pkg/server" "-r" "BenchmarkTestServerStartup" "-c" "10" "-b" "-d" "5s"

name                                   old time/op    new time/op    delta
TestServerStartup/SystemTenantOnly-24     388ms ± 4%     353ms ± 7%  -9.02%  (p=0.000 n=10+10)
TestServerStartup/ExternalTenant-24       389ms ± 4%     360ms ± 6%  -7.42%  (p=0.000 n=10+10)
TestServerStartup/SharedTenant-24         385ms ± 5%     363ms ± 6%  -5.75%  (p=0.000 n=9+10)

name                                   old alloc/op   new alloc/op   delta
TestServerStartup/SharedTenant-24         132MB ± 0%     132MB ± 0%  +0.21%  (p=0.003 n=10+10)
TestServerStartup/ExternalTenant-24       132MB ± 0%     132MB ± 0%  +0.28%  (p=0.001 n=10+10)
TestServerStartup/SystemTenantOnly-24     132MB ± 0%     132MB ± 0%  +0.39%  (p=0.000 n=9+9)

name                                   old allocs/op  new allocs/op  delta
TestServerStartup/SharedTenant-24          797k ± 0%      798k ± 0%  +0.16%  (p=0.000 n=10+10)
TestServerStartup/ExternalTenant-24        797k ± 0%      798k ± 0%  +0.19%  (p=0.000 n=10+10)
TestServerStartup/SystemTenantOnly-24      797k ± 0%      798k ± 0%  +0.21%  (p=0.000 n=10+10)
```

Epic: None