### PR TITLE
logstore: don't load LastIndex in Load{Term,Entries}

### DIFF
--- a/pkg/kv/kvserver/logstore/logstore.go
+++ b/pkg/kv/kvserver/logstore/logstore.go
@@ -601,6 +601,16 @@ func (s *LogStore) ComputeSize(ctx context.Context) (int64, error) {
 
 // LoadTerm returns the term of the entry at the given index for the specified
 // range. The result is loaded from the storage engine if it's not in the cache.
+// The valid range for index is [FirstIndex-1, LastIndex].
+//
+// There are 3 cases for when the term is not found: (1) the index has been
+// compacted away, (2) index > LastIndex, or (3) there is a gap in the log. In
+// the first case, we return ErrCompacted, and ErrUnavailable otherwise. Most
+// callers never try to read indices above LastIndex, so an error means (3)
+// which is a serious issue. But if the caller is unsure, they can check the
+// LastIndex to distinguish.
+//
+// TODO(#132114): eliminate both ErrCompacted and ErrUnavailable.
 func LoadTerm(
 	ctx context.Context,
 	rsl StateLoader,
@@ -646,28 +656,18 @@ func LoadTerm(
 		}
 		return kvpb.RaftTerm(entry.Term), nil
 	}
-	// Otherwise, the entry at the given index is not found. This can happen if
-	// the index is ahead of lastIndex, or it has been compacted away.
 
-	lastIndex, err := rsl.LoadLastIndex(ctx, reader)
-	if err != nil {
-		return 0, err
-	}
-	if index > lastIndex {
-		return 0, raft.ErrUnavailable
-	}
-
+	// Otherwise, the entry at the given index is not found. See the function
+	// comment for how this case is handled.
 	ts, err := rsl.LoadRaftTruncatedState(ctx, reader)
 	if err != nil {
 		return 0, err
-	}
-	if index == ts.Index {
+	} else if index == ts.Index {
 		return ts.Term, nil
+	} else if index < ts.Index {
+		return 0, raft.ErrCompacted
 	}
-	if index > ts.Index {
-		return 0, errors.Errorf("there is a gap at index %d", index)
-	}
-	return 0, raft.ErrCompacted
+	return 0, raft.ErrUnavailable
 }
 
 // LoadEntries retrieves entries from the engine. It inlines the sideloaded

--- a/pkg/kv/kvserver/logstore/logstore.go
+++ b/pkg/kv/kvserver/logstore/logstore.go
@@ -670,10 +670,21 @@ func LoadTerm(
 	return 0, raft.ErrUnavailable
 }
 
-// LoadEntries retrieves entries from the engine. It inlines the sideloaded
-// entries, and caches all the loaded entries. The size of the returned entries
-// does not exceed maxSize, unless only one entry is returned.
+// LoadEntries loads a slice of consecutive log entries in [lo, hi), starting
+// from lo. It inlines the sideloaded entries, and caches all the loaded
+// entries. The size of the returned entries does not exceed maxSize, unless the
+// first entry exceeds the limit (in which case it is returned regardless).
 //
+// The valid range for lo/hi is: FirstIndex <= lo <= hi <= LastIndex+1.
+//
+// There are 3 cases for when an entry is not found: (1) the lo index has been
+// compacted away, (2) hi > LastIndex+1, or (3) there is a gap in the log. In
+// the first case, we return ErrCompacted, and ErrUnavailable otherwise. Most
+// callers never try to read indices above LastIndex, so an error means (3)
+// which is a serious issue. But if the caller is unsure, they can check the
+// LastIndex to distinguish.
+//
+// TODO(#132114): eliminate both ErrCompacted and ErrUnavailable.
 // TODO(pavelkalinnikov): return all entries we've read, consider maxSize a
 // target size. Currently we may read one extra entry and drop it.
 func LoadEntries(
@@ -768,30 +779,15 @@ func LoadEntries(
 		return ents, cachedSize, sh.bytes - cachedSize, nil
 	}
 
-	// Did we get any results at all? Because something went wrong.
-	if len(ents) > 0 {
-		// Was the missing index after the last index?
-		lastIndex, err := rsl.LoadLastIndex(ctx, reader)
-		if err != nil {
-			return nil, 0, 0, err
-		}
-		if lastIndex <= expectedIndex {
-			return nil, 0, 0, raft.ErrUnavailable
-		}
-
-		// We have a gap in the record, if so, return a nasty error.
-		return nil, 0, 0, errors.Errorf("there is a gap in the index record between lo:%d and hi:%d at index:%d", lo, hi, expectedIndex)
-	}
-
-	// No results, was it due to unavailability or truncation?
+	// Something went wrong, and we could not load enough entries.
 	ts, err := rsl.LoadRaftTruncatedState(ctx, reader)
 	if err != nil {
 		return nil, 0, 0, err
-	}
-	if ts.Index >= lo {
+	} else if lo <= ts.Index {
 		// The requested lo index has already been truncated.
 		return nil, 0, 0, raft.ErrCompacted
 	}
-	// The requested lo index does not yet exist.
+	// We either have a gap in the log, or hi > LastIndex. Let the caller
+	// distinguish if they need to.
 	return nil, 0, 0, raft.ErrUnavailable
 }

--- a/pkg/raft/log.go
+++ b/pkg/raft/log.go
@@ -447,7 +447,15 @@ func (l LogSnapshot) term(index uint64) (uint64, error) {
 	term, err := l.storage.Term(index)
 	if err == nil {
 		return term, nil
-	} else if err == ErrCompacted || err == ErrUnavailable {
+	} else if err == ErrCompacted {
+		return 0, err
+	} else if err == ErrUnavailable {
+		// Invariant: the log is contiguous in [l.first-1, lastIndex]. Except in
+		// rare cases when there is a concurrent log truncation, and ErrCompacted is
+		// returned. The ErrUnavailable here means the supposedly contiguous part of
+		// this interval (note that we verified the boundaries above) in storage has
+		// a missing entry, and not because of being compacted. So there is a gap.
+		l.logger.Panicf("gap in the log at index %d", index)
 		return 0, err
 	}
 	panic(err) // TODO(pav-kv): return the error and handle it up the stack.

--- a/pkg/raft/log.go
+++ b/pkg/raft/log.go
@@ -424,12 +424,7 @@ func (l *raftLog) acceptUnstable() { l.unstable.acceptInProgress() }
 
 // lastEntryID returns the ID of the last entry in the log.
 func (l *raftLog) lastEntryID() entryID {
-	index := l.lastIndex()
-	t, err := l.term(index)
-	if err != nil {
-		l.logger.Panicf("unexpected error when getting the last term at %d: %v", index, err)
-	}
-	return entryID{term: t, index: index}
+	return l.unstable.lastEntryID()
 }
 
 func (l *raftLog) term(i uint64) (uint64, error) {

--- a/pkg/raft/storage.go
+++ b/pkg/raft/storage.go
@@ -35,8 +35,10 @@ var ErrCompacted = errors.New("requested index is unavailable due to compaction"
 // TODO(pav-kv): this is used only in tests. Remove it.
 var ErrSnapOutOfDate = errors.New("requested index is older than the existing snapshot")
 
-// ErrUnavailable is returned by Storage interface when the requested log entries
-// are unavailable.
+// ErrUnavailable is returned by Storage interface when the requested log
+// entries are unavailable. Typically, this means that the index is higher than
+// LastIndex, but otherwise it means a gap in the log. The receiver of this
+// error can distinguish the two cases if necessary.
 var ErrUnavailable = errors.New("requested entry at index is unavailable")
 
 // LogStorage is a read-only API for the raft log.


### PR DESCRIPTION
This PR broadens the meaning of `ErrUnavailable` to be a generic "entry not found" kind of error, and partially removes excessive log boundary checks in `LoadTerm` and `LoadEntries`.

Most callers check the log boundaries before reading from the log, so they can deduce that `ErrUnavailable` means a gap in the log if needed, and can error/panic accordingly. For example, any misaligned call to log storage `slice()` in `raft` will [panic](https://github.com/cockroachdb/cockroach/blob/19290ae07afa1a296fca9eee9f77d2e9c60eb804/pkg/raft/log.go#L597-L601) (and would have panicked before this PR).

Callers above `raft` don't ever check for `ErrUnavailable`, and treat it as any other error, so this change is a no-op w.r.t. them.

Prereq for #142013
Related to #132114, #136109