### PR TITLE
logictest: deflake regression test for #138809 in distsql_stats

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/distsql_stats
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_stats
@@ -3531,7 +3531,7 @@ column_names  row_count  null_count  distinct_count  avg_size  has_histogram
 {b}           2          0           2               8         true
 {c}           2          0           2               8         true
 
-query T
+query T retry
 EXPLAIN SELECT count(*) FROM t138809 WHERE b > 1
 ----
 distribution: full


### PR DESCRIPTION
Similar to #125150, #81560, etc, sometimes there's a race in the stats cache for the first statement after ANALYZE. Add a retry.

Fixes: #140353

Release note: None