### PR TITLE
kvserver: cache the storeClockTimestamp every tick

### DIFF
--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -935,6 +935,10 @@ type Replica struct {
 		// raftTracer is used to trace raft messages that are sent with a
 		// tracing context.
 		raftTracer rafttrace.RaftTracer
+
+		// lastTickTimestamp records the timestamp captured before the last tick of
+		// this replica.
+		lastTickTimestamp hlc.ClockTimestamp
 	}
 
 	// The raft log truncations that are pending. Access is protected by its own

--- a/pkg/kv/kvserver/replica_store_liveness.go
+++ b/pkg/kv/kvserver/replica_store_liveness.go
@@ -129,5 +129,5 @@ func raftFortificationEnabledForRangeID(fracEnabled float64, rangeID roachpb.Ran
 func (r *replicaRLockedStoreLiveness) SupportExpired(ts hlc.Timestamp) bool {
 	// A support expiration timestamp equal to the current time is considered
 	// expired, to be consistent with support withdrawal in Store Liveness.
-	return ts.LessEq(r.store.Clock().Now())
+	return ts.LessEq(r.mu.lastTickTimestamp.ToTimestamp())
 }


### PR DESCRIPTION
Instead of calculating the time now() multiple times during the tick. This commit caches timestamp during the tick(), and then it gets reused instead of redoing the work again.

Preliminary testing showed  that this reduces the clock mutex contention by 50%.

Fixes: #142049
Release note: None