### PR TITLE
roachtest: Update lib/pq block list

### DIFF
--- a/pkg/cmd/roachtest/tests/libpq_blocklist.go
+++ b/pkg/cmd/roachtest/tests/libpq_blocklist.go
@@ -30,6 +30,11 @@ var libPQBlocklist = blocklist{
 	"pq.TestRowsColumnTypes":                         "41688",
 	"pq.TestRuntimeParameters":                       "12137",
 	"pq.TestStringWithNul":                           "26366",
+	// The following tests fail because they weren't designed for the
+	// autocommit_before_ddl behaviour in CRDB.
+	"pq.TestCopyInWrongType":      "142038",
+	"pq.TestCopyInMultipleValues": "142038",
+	"pq.TestCopyFromError":        "142038",
 }
 
 // The test names here do not include "pq." since `go test -list` returns


### PR DESCRIPTION
The recent autocommit_before_ddl change (#141145) has affected three lib/pq tests that were not designed with autocommit behavior in mind.

These tests were executing the following sequence:
```
BEGIN
CREATE TEMP TABLE
COPY
```

Since CREATE TEMP TABLE now triggers an auto-commit, the subsequent COPY command fails because it must run inside an active transaction. The error observed was: "pq: COPY is only allowed inside a transaction."

Epic: none
Release note: none

Closes #141899