### PR TITLE
roachtest: Update pgx block list

### DIFF
--- a/pkg/cmd/roachtest/tests/pgx_blocklist.go
+++ b/pkg/cmd/roachtest/tests/pgx_blocklist.go
@@ -8,7 +8,9 @@ package tests
 // Please keep these lists alphabetized for easy diffing.
 // After a failed run, an updated version of this blocklist should be available
 // in the test log.
-var pgxBlocklist = blocklist{}
+var pgxBlocklist = blocklist{
+	"v5.TestBeginReadOnly": "142043",
+}
 
 var pgxIgnorelist = blocklist{
 	"v5.TestBeginIsoLevels": "We don't support isolation levels",


### PR DESCRIPTION
The pgx test v5.TestBeginReadOnly previously expected an error when executing:

```
BEGIN READ ONLY
CREATE TABLE foo(id serial primary key)
```

Due to the recent autocommit_before_ddl change in #141145, the transaction is auto-committed before the CREATE TABLE, allowing the command to succeed. This update adjusts the block list so that we ignore this failed test.

I will backport this in: #141987 #141851.

Epic: none
Release note: none

Closes #141903