### PR TITLE
mma: make constraintMatcher return all stores for an empty expression

### DIFF
--- a/pkg/kv/kvserver/allocator/mma/BUILD.bazel
+++ b/pkg/kv/kvserver/allocator/mma/BUILD.bazel
@@ -33,6 +33,7 @@ go_test(
     embed = [":mma"],
     deps = [
         "//pkg/roachpb",
+        "//pkg/util/randutil",
         "@com_github_cockroachdb_datadriven//:datadriven",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_stretchr_testify//require",

--- a/pkg/kv/kvserver/allocator/mma/testdata/constraint_matcher
+++ b/pkg/kv/kvserver/allocator/mma/testdata/constraint_matcher
@@ -1,8 +1,10 @@
 store store-id=5 attrs=ssd,green locality-tiers=region=us-west
 ----
+all-stores: 5
 
 remove-store store-id=2
 ----
+all-stores: 5
 
 store-matches store-id=5
 +region=us-west
@@ -12,6 +14,7 @@ true
 print
 ----
 +region=us-west: 5
+all-stores: 5
 
 store-matches store-id=5
 +=ssd
@@ -33,6 +36,7 @@ print
 +green: 5
 +blue:
 +region=us-west: 5
+all-stores: 5
 
 store store-id=2 attrs=slow-disk,purple locality-tiers=continent=na,region=us-west
 ----
@@ -40,6 +44,7 @@ store store-id=2 attrs=slow-disk,purple locality-tiers=continent=na,region=us-we
 +green: 5
 +blue:
 +region=us-west: 2, 5
+all-stores: 2, 5
 
 match-stores
 +=blue
@@ -56,6 +61,7 @@ print
 +purple: 2
 +region=us-west: 2, 5
 +continent=na: 2
+all-stores: 2, 5
 
 store store-id=4 attrs=slow-disk,blue locality-tiers=continent=na,region=us-east
 ----
@@ -65,6 +71,7 @@ store store-id=4 attrs=slow-disk,blue locality-tiers=continent=na,region=us-east
 +purple: 2
 +region=us-west: 2, 5
 +continent=na: 2, 4
+all-stores: 2, 4, 5
 
 store-matches store-id=5
 -=slow-disk
@@ -80,6 +87,7 @@ print
 +region=us-west: 2, 5
 +continent=na: 2, 4
 -slow-disk: 5
+all-stores: 2, 4, 5
 
 store-matches store-id=5
 +=slow-disk
@@ -96,6 +104,7 @@ print
 +region=us-west: 2, 5
 +continent=na: 2, 4
 -slow-disk: 5
+all-stores: 2, 4, 5
 
 store-matches store-id=5
 +region=us-east
@@ -113,6 +122,7 @@ print
 +region=us-east: 4
 +continent=na: 2, 4
 -slow-disk: 5
+all-stores: 2, 4, 5
 
 store store-id=5 attrs=slow-disk,green locality-tiers=region=us-east
 ----
@@ -125,6 +135,27 @@ store store-id=5 attrs=slow-disk,green locality-tiers=region=us-east
 +region=us-east: 4, 5
 +continent=na: 2, 4
 -slow-disk:
+all-stores: 2, 4, 5
+
+# No conjunction, so matches.
+store-matches store-id=2
+----
+true
+
+# No conjunction, so matches.
+store-matches store-id=4
+----
+true
+
+# No conjunction, so matches.
+store-matches store-id=5
+----
+true
+
+# No conjunction, so everything matches.
+match-stores
+----
+2, 4, 5
 
 remove-store store-id=4
 ----
@@ -137,3 +168,4 @@ remove-store store-id=4
 +region=us-east: 5
 +continent=na: 2
 -slow-disk:
+all-stores: 2, 5


### PR DESCRIPTION
This is useful when meansMemo is called with an empty expression.

Informs #103320

Epic: CRDB-25222

Release note: None