### PR TITLE
vecindex: add support for vector index prefix columns

### DIFF
--- a/pkg/cmd/vecbench/main.go
+++ b/pkg/cmd/vecbench/main.go
@@ -213,7 +213,7 @@ func searchIndex(ctx context.Context, stopper *stop.Stopper, datasetName string)
 			searchOptions := cspann.SearchOptions{BaseBeamSize: beamSize}
 
 			// Calculate prediction set for the vector.
-			err = index.Search(ctx, &idxCtx, queryVector, &searchSet, searchOptions)
+			err = index.Search(ctx, &idxCtx, nil /* treeKey */, queryVector, &searchSet, searchOptions)
 			if err != nil {
 				panic(err)
 			}
@@ -419,7 +419,7 @@ func buildIndex(
 			vec := data.Train.At(i)
 			store.InsertVector(key, vec)
 			startMono := crtime.NowMono()
-			if err := index.Insert(ctx, idxCtx, vec, key); err != nil {
+			if err := index.Insert(ctx, idxCtx, nil /* treeKey */, vec, key); err != nil {
 				panic(err)
 			}
 			estimator.Add(startMono.Elapsed().Seconds())

--- a/pkg/sql/logictest/testdata/logic_test/vector_index
+++ b/pkg/sql/logictest/testdata/logic_test/vector_index
@@ -270,8 +270,6 @@ CREATE TABLE exec_test (
 )
 
 # TODO(drewk): write these tests once execution is supported.
-statement error partition not found
-INSERT INTO exec_test (a, vec1) values (1, '[1, 2, 3]')
 
 statement ok
 DROP TABLE exec_test

--- a/pkg/sql/vecindex/cspann/commontest/BUILD.bazel
+++ b/pkg/sql/vecindex/cspann/commontest/BUILD.bazel
@@ -2,7 +2,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "commontest",
-    srcs = ["storetests.go"],
+    srcs = [
+        "storetests.go",
+        "utils.go",
+    ],
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/vecindex/cspann/commontest",
     visibility = ["//visibility:public"],
     deps = [
@@ -10,8 +13,11 @@ go_library(
         "//pkg/sql/vecindex/cspann/quantize",
         "//pkg/sql/vecindex/cspann/testutils",
         "//pkg/sql/vecindex/cspann/workspace",
+        "//pkg/util/num32",
         "//pkg/util/vector",
+        "@com_github_cockroachdb_errors//:errors",
         "@com_github_stretchr_testify//require",
+        "@com_github_stretchr_testify//suite",
         "@org_gonum_v1_gonum//floats/scalar",
     ],
 )

--- a/pkg/sql/vecindex/cspann/commontest/storetests.go
+++ b/pkg/sql/vecindex/cspann/commontest/storetests.go
@@ -13,331 +13,628 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/vecindex/cspann/quantize"
 	"github.com/cockroachdb/cockroach/pkg/sql/vecindex/cspann/testutils"
 	"github.com/cockroachdb/cockroach/pkg/sql/vecindex/cspann/workspace"
+	"github.com/cockroachdb/cockroach/pkg/util/num32"
 	"github.com/cockroachdb/cockroach/pkg/util/vector"
-	"github.com/stretchr/testify/require"
-	"gonum.org/v1/gonum/floats/scalar"
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/suite"
 )
 
-// StoreTests run a set of generic tests that should work the same against any
-// vector store.
-func StoreTests(
-	ctx context.Context,
-	t *testing.T,
-	store cspann.Store,
-	quantizer quantize.Quantizer,
-	testPKs []cspann.KeyBytes,
-	testVectors []vector.T,
-) {
-	var workspace workspace.T
-	childKey2 := cspann.ChildKey{PartitionKey: 2}
-	valueBytes2 := cspann.ValueBytes{0}
-	primaryKey100 := cspann.ChildKey{KeyBytes: cspann.KeyBytes{1, 00}}
-	primaryKey200 := cspann.ChildKey{KeyBytes: cspann.KeyBytes{2, 00}}
-	primaryKey300 := cspann.ChildKey{KeyBytes: cspann.KeyBytes{3, 00}}
-	primaryKey400 := cspann.ChildKey{KeyBytes: cspann.KeyBytes{4, 00}}
-	primaryKey500 := cspann.ChildKey{KeyBytes: cspann.KeyBytes{5, 00}}
-	primaryKey600 := cspann.ChildKey{KeyBytes: cspann.KeyBytes{6, 00}}
-	valueBytes100 := cspann.ValueBytes{1, 2}
-	valueBytes200 := cspann.ValueBytes{3, 4}
-	valueBytes300 := cspann.ValueBytes{5, 6}
-	valueBytes400 := cspann.ValueBytes{7, 8}
-	valueBytes500 := cspann.ValueBytes{9, 10}
-	valueBytes600 := cspann.ValueBytes{11, 12}
+type equaler interface {
+	Equal(that interface{}) bool
+}
 
-	t.Run("get full vectors", func(t *testing.T) {
-		txn := BeginTransaction(ctx, t, store)
-		defer CommitTransaction(ctx, t, store, txn)
+var vec1 = vector.T{1, 2}
+var vec2 = vector.T{7, 4}
+var vec3 = vector.T{4, 3}
+var vec4 = vector.T{6, -2}
 
-		// Include primary keys that cannot be found.
+var primaryKey1 = cspann.ChildKey{KeyBytes: cspann.KeyBytes{1, 00}}
+var primaryKey2 = cspann.ChildKey{KeyBytes: cspann.KeyBytes{2, 00}}
+var primaryKey3 = cspann.ChildKey{KeyBytes: cspann.KeyBytes{3, 00}}
+var primaryKey4 = cspann.ChildKey{KeyBytes: cspann.KeyBytes{4, 00}}
+
+var partitionKey1 = cspann.ChildKey{PartitionKey: 10}
+var partitionKey2 = cspann.ChildKey{PartitionKey: 20}
+var partitionKey3 = cspann.ChildKey{PartitionKey: 30}
+
+var valueBytes1 = cspann.ValueBytes{1, 2}
+var valueBytes2 = cspann.ValueBytes{3, 4}
+var valueBytes3 = cspann.ValueBytes{5, 6}
+var valueBytes4 = cspann.ValueBytes{7, 8}
+
+// TestStore wraps a Store interface so that it can be tested by a common set of
+// tests.
+type TestStore interface {
+	cspann.Store
+
+	// AllowMultipleTrees is true if the Store supports storing vectors in
+	// multiple distinct trees that are identified by the cspann.TreeKey
+	// parameter. This is used by prefixed vector indexes, e.g. where non-vector
+	// column(s) precede the vector column in the index definition.
+	AllowMultipleTrees() bool
+
+	// MakeTreeKey converts a tree identifier into a tree key. The treeID is
+	// convenient for testing, but it must be converted into a TreeKey in a way
+	// that is specific to each store.
+	MakeTreeKey(t *testing.T, treeID int) cspann.TreeKey
+
+	// InsertVector inserts a vector into the store and returns the primary key
+	// bytes that can be used to retrieve that vector via GetFullVectors.
+	InsertVector(t *testing.T, treeID int, vec vector.T) cspann.KeyBytes
+}
+
+// MakeStoreFunc defines a function that creates a new TestStore instance for
+// use by the common Store tests.
+type MakeStoreFunc func(quantizer quantize.Quantizer) TestStore
+
+type StoreTestSuite struct {
+	suite.Suite
+
+	ctx           context.Context
+	workspace     workspace.T
+	makeStore     MakeStoreFunc
+	rootQuantizer quantize.Quantizer
+	quantizer     quantize.Quantizer
+}
+
+// NewStoreTestSuite constructs a new suite of tests that run against
+// implementations of the cspann.Store interface. Implementations do not need to
+// have their own tests; instead, they can be validated using a common set of
+// tests.
+func NewStoreTestSuite(ctx context.Context, makeStore MakeStoreFunc) *StoreTestSuite {
+	return &StoreTestSuite{
+		ctx:           ctx,
+		makeStore:     makeStore,
+		rootQuantizer: quantize.NewUnQuantizer(2),
+		quantizer:     quantize.NewRaBitQuantizer(2, 42)}
+}
+
+// TestRootPartition runs tests against the root partition, which has special
+// rules as compared to other partitions.
+func (suite *StoreTestSuite) TestRootPartition() {
+	store := suite.makeStore(suite.quantizer)
+
+	// Test missing root partition.
+	suite.testEmptyOrMissingRoot(store, 0, "missing root partition", true /* isMissing */)
+
+	// Add a vector to the root partition.
+	rootVec := vector.T{1, 2}
+	rootChildKey := cspann.ChildKey{KeyBytes: cspann.KeyBytes{10, 20}}
+	suite.runInTransaction(store, 0, func(tx cspann.Txn, treeKey cspann.TreeKey) {
+		val := cspann.ValueBytes{100, 200}
+		metadata, err := tx.AddToPartition(
+			suite.ctx, treeKey, cspann.RootKey, rootVec, rootChildKey, val)
+		suite.NoError(err)
+		CheckPartitionMetadata(suite.T(), metadata, cspann.LeafLevel, vector.T{0, 0}, 1)
+	})
+
+	if store.AllowMultipleTrees() {
+		// Other trees' root partitions should still be missing.
+		suite.testEmptyOrMissingRoot(
+			store, 1, "missing root partition, different tree", true /* isMissing */)
+	}
+
+	// Now remove the only vector from the root partition, making it empty, but
+	// not missing.
+	suite.runInTransaction(store, 0, func(tx cspann.Txn, treeKey cspann.TreeKey) {
+		metadata, err := tx.RemoveFromPartition(suite.ctx, treeKey, cspann.RootKey, rootChildKey)
+		suite.NoError(err)
+		CheckPartitionMetadata(suite.T(), metadata, cspann.LeafLevel, vector.T{0, 0}, 0)
+	})
+
+	// Test empty root partition.
+	suite.testEmptyOrMissingRoot(store, 0, "empty root partition", false /* isMissing */)
+
+	// Now add vectors to root partition and test it.
+	suite.addToRoot(store, 0)
+	suite.Run("test root partition", func() {
+		suite.testLeafPartition(store, 0, cspann.RootKey, vector.T{0, 0})
+	})
+
+	if store.AllowMultipleTrees() {
+		// Other root partitions should be independent.
+		suite.addToRoot(store, 1)
+		suite.Run("test root partition, different tree", func() {
+			suite.testLeafPartition(store, 1, cspann.RootKey, vector.T{0, 0})
+		})
+	}
+
+	// Replace the entire root partition with a new set of vectors.
+	suite.Run("replace root partition", func() {
+		suite.setRootPartition(store, 0)
+	})
+
+	if store.AllowMultipleTrees() {
+		suite.Run("replace root partition, different tree", func() {
+			suite.setRootPartition(store, 1)
+		})
+	}
+
+	// Delete the root partition and re-test.
+	suite.Run("deleted root partition", func() {
+		suite.deletePartition(store, 0, cspann.RootKey)
+		suite.testEmptyOrMissingRoot(store, 0, "deleted root partition", true /* isMissing */)
+	})
+
+	if store.AllowMultipleTrees() {
+		suite.Run("deleted root partition, different tree", func() {
+			suite.deletePartition(store, 1, cspann.RootKey)
+			suite.testEmptyOrMissingRoot(store, 1, "deleted root partition", true /* isMissing */)
+		})
+	}
+}
+
+// TestNonRootPartition tests non-root partitions at interior and leaf levels.
+func (suite *StoreTestSuite) TestNonRootPartition() {
+	store := suite.makeStore(suite.quantizer)
+
+	// Construct non-root leaf partition and add/remove vectors.
+	suite.Run("test non-root leaf partition", func() {
+		partitionKey := suite.insertLeafPartition(store, 0)
+		suite.testLeafPartition(store, 0, partitionKey, vector.T{4, 3})
+		suite.deletePartition(store, 0, partitionKey)
+	})
+
+	if store.AllowMultipleTrees() {
+		suite.Run("test non-root leaf partition, different tree", func() {
+			partitionKey := suite.insertLeafPartition(store, 1)
+			suite.testLeafPartition(store, 1, partitionKey, vector.T{4, 3})
+			suite.deletePartition(store, 1, partitionKey)
+		})
+	}
+
+	doTest := func(treeID int) {
+		tx := BeginTransaction(suite.ctx, suite.T(), store)
+		defer CommitTransaction(suite.ctx, suite.T(), store, tx)
+		treeKey := store.MakeTreeKey(suite.T(), treeID)
+
+		vectors := vector.MakeSet(2)
+		vectors.Add(vec1)
+		vectors.Add(vec2)
+		quantizedSet := suite.quantizer.Quantize(&suite.workspace, vectors)
+		childKeys := []cspann.ChildKey{partitionKey1, partitionKey2}
+		valueBytes := []cspann.ValueBytes{valueBytes1, valueBytes2}
+		partition := cspann.NewPartition(
+			suite.quantizer, quantizedSet, childKeys, valueBytes, cspann.SecondLevel)
+
+		partitionKey, err := tx.InsertPartition(suite.ctx, treeKey, partition)
+		suite.NoError(err)
+
+		// Read back and verify the partition.
+		readPartition, err := tx.GetPartition(suite.ctx, treeKey, partitionKey)
+		suite.NoError(err)
+		ValidatePartitionsEqual(suite.T(), partition, readPartition)
+
+		// Add and remove vectors from partition.
+		_, err = tx.AddToPartition(suite.ctx, treeKey, partitionKey, vec3, partitionKey3, valueBytes3)
+		suite.NoError(err)
+		_, err = tx.RemoveFromPartition(suite.ctx, treeKey, partitionKey, partitionKey1)
+		suite.NoError(err)
+
+		// Search partition.
+		partitionCounts := []int{0}
+		searchSet := cspann.SearchSet{MaxResults: 1}
+		searchLevel, err := tx.SearchPartitions(suite.ctx, treeKey,
+			[]cspann.PartitionKey{partitionKey}, vector.T{5, -1}, &searchSet, partitionCounts)
+		suite.NoError(err)
+		suite.Equal(cspann.SecondLevel, searchLevel)
+		result1 := cspann.SearchResult{
+			QuerySquaredDistance: 17, ErrorBound: 0, CentroidDistance: 0,
+			ParentPartitionKey: partitionKey, ChildKey: partitionKey3, ValueBytes: valueBytes3}
+		results := searchSet.PopResults()
+		RoundResults(results, 4)
+		suite.Equal(cspann.SearchResults{result1}, results)
+		suite.Equal(2, partitionCounts[0])
+	}
+
+	suite.Run("test non-root interior partition", func() {
+		doTest(0)
+	})
+
+	if store.AllowMultipleTrees() {
+		suite.Run("test non-root interior partition, different tree", func() {
+			doTest(1)
+		})
+	}
+}
+
+// TestGetFullVectors tests the GetFullVectors method on the store, fetching
+// vectors by primary key and centroids by partition key.
+func (suite *StoreTestSuite) TestGetFullVectors() {
+	store := suite.makeStore(suite.quantizer)
+
+	doTest := func(treeID int) {
+		// Create partitions.
+		suite.addToRoot(store, treeID)
+		partitionKey := suite.insertLeafPartition(store, treeID)
+
+		tx := BeginTransaction(suite.ctx, suite.T(), store)
+		defer CommitTransaction(suite.ctx, suite.T(), store, tx)
+		treeKey := store.MakeTreeKey(suite.T(), treeID)
+
+		// Insert some full vectors into the test store.
+		key1 := store.InsertVector(suite.T(), treeID, vec1)
+		key2 := store.InsertVector(suite.T(), treeID, vec2)
+		key3 := store.InsertVector(suite.T(), treeID, vec3)
+
+		// Include primary keys, partition keys, and keys that cannot be found.
 		results := []cspann.VectorWithKey{
-			{Key: cspann.ChildKey{KeyBytes: testPKs[0]}},
+			{Key: cspann.ChildKey{KeyBytes: key1}},
 			{Key: cspann.ChildKey{KeyBytes: cspann.KeyBytes{0}}},
-			{Key: cspann.ChildKey{KeyBytes: testPKs[1]}},
+			{Key: cspann.ChildKey{PartitionKey: cspann.RootKey}},
+			{Key: cspann.ChildKey{KeyBytes: key2}},
 			{Key: cspann.ChildKey{KeyBytes: cspann.KeyBytes{0}}},
-			{Key: cspann.ChildKey{KeyBytes: testPKs[0]}},
+			{Key: cspann.ChildKey{PartitionKey: partitionKey}},
+			{Key: cspann.ChildKey{KeyBytes: key3}},
 		}
-		err := txn.GetFullVectors(ctx, results)
-		require.NoError(t, err)
-		require.Equal(t, testVectors[0], results[0].Vector)
-		require.Nil(t, results[1].Vector)
-		require.Equal(t, testVectors[1], results[2].Vector)
-		require.Nil(t, results[3].Vector)
-		require.Equal(t, testVectors[0], results[4].Vector)
+		err := tx.GetFullVectors(suite.ctx, treeKey, results)
+		suite.NoError(err)
+		suite.Equal(vec1, results[0].Vector)
+		suite.Nil(results[1].Vector)
+		suite.Equal(vector.T{0, 0}, results[2].Vector)
+		suite.Equal(vec2, results[3].Vector)
+		suite.Nil(results[4].Vector)
+		suite.Equal(vector.T{4, 3}, results[5].Vector)
+		suite.Equal(vec3, results[6].Vector)
 
 		// Grab another set of vectors to ensure that saved state is properly reset.
 		results = []cspann.VectorWithKey{
 			{Key: cspann.ChildKey{KeyBytes: cspann.KeyBytes{0}}},
-			{Key: cspann.ChildKey{KeyBytes: testPKs[0]}},
+			{Key: cspann.ChildKey{KeyBytes: key3}},
 			{Key: cspann.ChildKey{KeyBytes: cspann.KeyBytes{0}}},
-			{Key: cspann.ChildKey{KeyBytes: testPKs[1]}},
+			{Key: cspann.ChildKey{KeyBytes: key2}},
 			{Key: cspann.ChildKey{KeyBytes: cspann.KeyBytes{0}}},
-			{Key: cspann.ChildKey{KeyBytes: testPKs[1]}},
+			{Key: cspann.ChildKey{KeyBytes: key1}},
 		}
-		err = txn.GetFullVectors(ctx, results)
-		require.NoError(t, err)
-		require.Nil(t, results[0].Vector)
-		require.Equal(t, testVectors[0], results[1].Vector)
-		require.Nil(t, results[2].Vector)
-		require.Equal(t, testVectors[1], results[3].Vector)
-		require.Nil(t, results[4].Vector)
-		require.Equal(t, testVectors[1], results[5].Vector)
+		err = tx.GetFullVectors(suite.ctx, treeKey, results)
+		suite.NoError(err)
+		suite.Nil(results[0].Vector)
+		suite.Equal(vec3, results[1].Vector)
+		suite.Nil(results[2].Vector)
+		suite.Equal(vec2, results[3].Vector)
+		suite.Nil(results[4].Vector)
+		suite.Equal(vec1, results[5].Vector)
+	}
+
+	suite.Run("default tree", func() {
+		doTest(0)
 	})
 
-	t.Run("search empty root partition", func(t *testing.T) {
-		txn := BeginTransaction(ctx, t, store)
-		defer CommitTransaction(ctx, t, store, txn)
+	if store.AllowMultipleTrees() {
+		// Ensure that vectors are independent across trees.
+		suite.Run("different tree", func() {
+			doTest(1)
+		})
+	}
+}
 
-		searchSet := cspann.SearchSet{MaxResults: 2}
-		partitionCounts := []int{0}
-		level, err := txn.SearchPartitions(
-			ctx, []cspann.PartitionKey{cspann.RootKey}, vector.T{1, 1}, &searchSet, partitionCounts)
-		require.NoError(t, err)
-		require.Equal(t, cspann.LeafLevel, level)
-		require.Nil(t, searchSet.PopResults())
-		require.Equal(t, 0, partitionCounts[0])
+// TestSearchMultiplePartitions tests the store's SearchPartitions method across
+// more than one partition.
+func (suite *StoreTestSuite) TestSearchMultiplePartitions() {
+	store := suite.makeStore(suite.quantizer)
 
-		// Get partition metadata.
-		metadata, err := txn.GetPartitionMetadata(ctx, cspann.RootKey, false /* forUpdate */)
-		require.NoError(t, err)
-		CheckPartitionMetadata(t, metadata, cspann.Level(1), vector.T{0, 0}, 0)
-	})
+	doTest := func(treeID int) {
+		// Create some partitions to search.
+		suite.addToRoot(store, treeID)
+		partitionKey := suite.insertLeafPartition(store, treeID)
 
-	t.Run("add to root partition", func(t *testing.T) {
-		txn := BeginTransaction(ctx, t, store)
-		defer CommitTransaction(ctx, t, store, txn)
+		tx := BeginTransaction(suite.ctx, suite.T(), store)
+		defer CommitTransaction(suite.ctx, suite.T(), store, tx)
+		treeKey := store.MakeTreeKey(suite.T(), treeID)
 
-		// Get partition metadata with forUpdate = true before updates.
-		metadata, err := txn.GetPartitionMetadata(ctx, cspann.RootKey, true /* forUpdate */)
-		require.NoError(t, err)
-		CheckPartitionMetadata(t, metadata, cspann.Level(1), vector.T{0, 0}, 0)
-
-		// Add to root partition.
-		metadata, err = txn.AddToPartition(
-			ctx, cspann.RootKey, vector.T{1, 2}, primaryKey100, valueBytes100)
-		require.NoError(t, err)
-		CheckPartitionMetadata(t, metadata, cspann.LeafLevel, vector.T{0, 0}, 1)
-		metadata, err = txn.AddToPartition(
-			ctx, cspann.RootKey, vector.T{7, 4}, primaryKey200, valueBytes200)
-		require.NoError(t, err)
-		CheckPartitionMetadata(t, metadata, cspann.LeafLevel, vector.T{0, 0}, 2)
-		metadata, err = txn.AddToPartition(
-			ctx, cspann.RootKey, vector.T{4, 3}, primaryKey300, valueBytes300)
-		require.NoError(t, err)
-		CheckPartitionMetadata(t, metadata, cspann.LeafLevel, vector.T{0, 0}, 3)
-
-		// Add duplicate and expect value to be overwritten
-		metadata, err = txn.AddToPartition(
-			ctx, cspann.RootKey, vector.T{5, 5}, primaryKey300, valueBytes300)
-		require.NoError(t, err)
-		CheckPartitionMetadata(t, metadata, cspann.LeafLevel, vector.T{0, 0}, 3)
-
-		// Search root partition.
-		searchSet := cspann.SearchSet{MaxResults: 2}
-		partitionCounts := []int{0}
-		level, err := txn.SearchPartitions(
-			ctx, []cspann.PartitionKey{cspann.RootKey}, vector.T{1, 1}, &searchSet, partitionCounts)
-		require.NoError(t, err)
-		require.Equal(t, cspann.Level(1), level)
-		result1 := cspann.SearchResult{
-			QuerySquaredDistance: 1, ErrorBound: 0, CentroidDistance: 2.2361,
-			ParentPartitionKey: 1, ChildKey: primaryKey100, ValueBytes: valueBytes100}
-		result2 := cspann.SearchResult{
-			QuerySquaredDistance: 32, ErrorBound: 0, CentroidDistance: 7.0711,
-			ParentPartitionKey: 1, ChildKey: primaryKey300, ValueBytes: valueBytes300}
-		results := searchSet.PopResults()
-		RoundResults(results, 4)
-		require.Equal(t, cspann.SearchResults{result1, result2}, results)
-		require.Equal(t, 3, partitionCounts[0])
-
-		// Ensure partition metadata is updated.
-		metadata, err = txn.GetPartitionMetadata(ctx, cspann.RootKey, true /* forUpdate */)
-		require.NoError(t, err)
-		CheckPartitionMetadata(t, metadata, cspann.Level(1), vector.T{0, 0}, 3)
-	})
-
-	var root *cspann.Partition
-	t.Run("get root partition", func(t *testing.T) {
-		txn := BeginTransaction(ctx, t, store)
-		defer CommitTransaction(ctx, t, store, txn)
-
-		// Get root partition.
-		var err error
-		root, err = txn.GetPartition(ctx, cspann.RootKey)
-		require.NoError(t, err)
-		require.Equal(t, cspann.Level(1), root.Level())
-		require.Equal(t, []cspann.ChildKey{primaryKey100, primaryKey200, primaryKey300}, root.ChildKeys())
-		require.Equal(t, []cspann.ValueBytes{valueBytes100, valueBytes200, valueBytes300}, root.ValueBytes())
-		require.Equal(t, vector.T{0, 0}, root.Centroid())
-
-		// Get partition centroid + full vectors.
-		results := []cspann.VectorWithKey{
-			{Key: cspann.ChildKey{PartitionKey: cspann.RootKey}},
-			{Key: cspann.ChildKey{KeyBytes: testPKs[0]}},
-			{Key: cspann.ChildKey{KeyBytes: cspann.KeyBytes{0}}},
-		}
-		err = txn.GetFullVectors(ctx, results)
-		require.NoError(t, err)
-		require.Equal(t, vector.T{0, 0}, results[0].Vector)
-		require.Equal(t, testVectors[0], results[1].Vector)
-		require.Nil(t, results[2].Vector)
-
-		// Get partition metadata.
-		metadata, err := txn.GetPartitionMetadata(ctx, cspann.RootKey, false /* forUpdate */)
-		require.NoError(t, err)
-		CheckPartitionMetadata(t, metadata, cspann.Level(1), vector.T{0, 0}, 3)
-	})
-
-	t.Run("replace root partition", func(t *testing.T) {
-		txn := BeginTransaction(ctx, t, store)
-		defer CommitTransaction(ctx, t, store, txn)
-
-		// Replace root partition.
-		_, err := txn.GetPartition(ctx, cspann.RootKey)
-		require.NoError(t, err)
-		vectors := vector.T{4, 3}.AsSet()
-		quantizedSet := quantizer.Quantize(&workspace, vectors)
-		newRoot := cspann.NewPartition(quantizer, quantizedSet,
-			[]cspann.ChildKey{childKey2}, []cspann.ValueBytes{valueBytes2}, cspann.Level(2))
-		require.NoError(t, txn.SetRootPartition(ctx, newRoot))
-		newRoot, err = txn.GetPartition(ctx, cspann.RootKey)
-		require.NoError(t, err)
-		require.Equal(t, cspann.Level(2), newRoot.Level())
-		require.Equal(t, []cspann.ChildKey{childKey2}, newRoot.ChildKeys())
-		require.Equal(t, []cspann.ValueBytes{valueBytes2}, newRoot.ValueBytes())
-
-		searchSet := cspann.SearchSet{MaxResults: 2}
-		partitionCounts := []int{0}
-		level, err := txn.SearchPartitions(
-			ctx, []cspann.PartitionKey{cspann.RootKey}, vector.T{2, 2}, &searchSet, partitionCounts)
-		require.NoError(t, err)
-		require.Equal(t, cspann.Level(2), level)
-		result3 := cspann.SearchResult{
-			QuerySquaredDistance: 5, ErrorBound: 0, CentroidDistance: 0, ParentPartitionKey: 1, ChildKey: childKey2, ValueBytes: valueBytes2}
-		require.Equal(t, cspann.SearchResults{result3}, searchSet.PopResults())
-		require.Equal(t, 1, partitionCounts[0])
-
-		// Get partition metadata.
-		metadata, err := txn.GetPartitionMetadata(ctx, cspann.RootKey, false /* forUpdate */)
-		require.NoError(t, err)
-		CheckPartitionMetadata(t, metadata, cspann.Level(2), vector.T{4, 3}, 1)
-	})
-
-	var partitionKey1 cspann.PartitionKey
-	t.Run("insert another partition and update it", func(t *testing.T) {
-		txn := BeginTransaction(ctx, t, store)
-		defer CommitTransaction(ctx, t, store, txn)
-
-		_, err := txn.GetPartition(ctx, cspann.RootKey)
-		require.NoError(t, err)
-		partitionKey1, err = txn.InsertPartition(ctx, root)
-		require.NoError(t, err)
-		metadata, err := txn.RemoveFromPartition(ctx, partitionKey1, primaryKey200)
-		require.NoError(t, err)
-		CheckPartitionMetadata(t, metadata, cspann.LeafLevel, vector.T{0, 0}, 2)
-
-		// Try to remove the same key again.
-		metadata, err = txn.RemoveFromPartition(ctx, partitionKey1, primaryKey200)
-		require.NoError(t, err)
-		CheckPartitionMetadata(t, metadata, cspann.LeafLevel, vector.T{0, 0}, 2)
-
-		// Add an alternate element and add duplicate, expecting value to be overwritten.
-		metadata, err = txn.AddToPartition(
-			ctx, partitionKey1, vector.T{-1, 0}, primaryKey400, valueBytes400)
-		require.NoError(t, err)
-		CheckPartitionMetadata(t, metadata, cspann.LeafLevel, vector.T{0, 0}, 3)
-		metadata, err = txn.AddToPartition(
-			ctx, partitionKey1, vector.T{1, 1}, primaryKey400, valueBytes400)
-		require.NoError(t, err)
-		CheckPartitionMetadata(t, metadata, cspann.LeafLevel, vector.T{0, 0}, 3)
-
-		searchSet := cspann.SearchSet{MaxResults: 2}
-		partitionCounts := []int{0}
-		level, err := txn.SearchPartitions(
-			ctx, []cspann.PartitionKey{partitionKey1}, vector.T{1, 1}, &searchSet, partitionCounts)
-		require.NoError(t, err)
-		require.Equal(t, cspann.Level(1), level)
-		result4 := cspann.SearchResult{
-			QuerySquaredDistance: 0, ErrorBound: 0, CentroidDistance: 1.4142,
-			ParentPartitionKey: partitionKey1, ChildKey: primaryKey400, ValueBytes: valueBytes400}
-		result5 := cspann.SearchResult{
-			QuerySquaredDistance: 1, ErrorBound: 0, CentroidDistance: 2.2361,
-			ParentPartitionKey: partitionKey1, ChildKey: primaryKey100, ValueBytes: valueBytes100}
-		require.Equal(t, cspann.SearchResults{result4, result5}, RoundResults(searchSet.PopResults(), 4))
-		require.Equal(t, 3, partitionCounts[0])
-	})
-
-	t.Run("search multiple partitions at leaf level", func(t *testing.T) {
-		txn := BeginTransaction(ctx, t, store)
-		defer CommitTransaction(ctx, t, store, txn)
-
-		_, err := txn.GetPartition(ctx, cspann.RootKey)
-		require.NoError(t, err)
-
-		vectors := vector.MakeSet(2)
-		vectors.Add(vector.T{4, -1})
-		vectors.Add(vector.T{2, 8})
-		quantizedSet := quantizer.Quantize(&workspace, vectors)
-		partition := cspann.NewPartition(
-			quantizer, quantizedSet, []cspann.ChildKey{primaryKey500, primaryKey600},
-			[]cspann.ValueBytes{valueBytes500, valueBytes600}, cspann.LeafLevel)
-		partitionKey2, err := txn.InsertPartition(ctx, partition)
-		require.NoError(t, err)
+		// Remove a vector from the non-root partition so they are not the same.
+		_, err := tx.RemoveFromPartition(suite.ctx, treeKey, partitionKey, primaryKey3)
+		suite.NoError(err)
 
 		searchSet := cspann.SearchSet{MaxResults: 2}
 		partitionCounts := []int{0, 0}
-		level, err := txn.SearchPartitions(
-			ctx, []cspann.PartitionKey{partitionKey1, partitionKey2}, vector.T{3, 1},
+		level, err := tx.SearchPartitions(suite.ctx, treeKey,
+			[]cspann.PartitionKey{cspann.RootKey, partitionKey}, vec4,
 			&searchSet, partitionCounts)
-		require.NoError(t, err)
-		require.Equal(t, cspann.Level(1), level)
-		result4 := cspann.SearchResult{
-			QuerySquaredDistance: 4, ErrorBound: 0, CentroidDistance: 1.41,
-			ParentPartitionKey: partitionKey1, ChildKey: primaryKey400, ValueBytes: valueBytes400}
-		result5 := cspann.SearchResult{
-			QuerySquaredDistance: 5, ErrorBound: 0, CentroidDistance: 2.24,
-			ParentPartitionKey: partitionKey1, ChildKey: primaryKey100, ValueBytes: valueBytes100}
-		require.Equal(t, cspann.SearchResults{result4, result5}, RoundResults(searchSet.PopResults(), 2))
-		require.Equal(t, []int{3, 2}, partitionCounts)
+		suite.NoError(err)
+		suite.Equal(cspann.LeafLevel, level)
+		result1 := cspann.SearchResult{
+			QuerySquaredDistance: 24, ErrorBound: 24.08, CentroidDistance: 3.16,
+			ParentPartitionKey: partitionKey, ChildKey: primaryKey1, ValueBytes: valueBytes1}
+		result2 := cspann.SearchResult{
+			QuerySquaredDistance: 29, ErrorBound: 0, CentroidDistance: 5,
+			ParentPartitionKey: cspann.RootKey, ChildKey: primaryKey3, ValueBytes: valueBytes3}
+		suite.Equal(cspann.SearchResults{result1, result2}, RoundResults(searchSet.PopResults(), 2))
+		suite.Equal([]int{3, 2}, partitionCounts)
+	}
+
+	suite.Run("default tree", func() {
+		doTest(0)
+	})
+
+	if store.AllowMultipleTrees() {
+		// Ensure that different tree is independent.
+		suite.Run("different tree", func() {
+			doTest(1)
+		})
+	}
+}
+
+func (suite *StoreTestSuite) runInTransaction(
+	store TestStore, treeID int, fn func(tx cspann.Txn, treeKey cspann.TreeKey),
+) {
+	tx := BeginTransaction(suite.ctx, suite.T(), store)
+	defer CommitTransaction(suite.ctx, suite.T(), store, tx)
+	fn(tx, store.MakeTreeKey(suite.T(), treeID))
+}
+
+// testEmptyOrMissingRoot includes tests against a missing or empty root
+// partition. Operations against the root partition should not return "partition
+// not found" errors, even if it is missing. The root partition needs to be
+// lazily created when the first vector is added to it.
+func (suite *StoreTestSuite) testEmptyOrMissingRoot(
+	store TestStore, treeID int, desc string, isMissing bool,
+) {
+	tx := BeginTransaction(suite.ctx, suite.T(), store)
+	defer CommitTransaction(suite.ctx, suite.T(), store, tx)
+
+	treeKey := store.MakeTreeKey(suite.T(), treeID)
+
+	suite.Run("get metadata for "+desc, func() {
+		metadata, err := tx.GetPartitionMetadata(
+			suite.ctx, treeKey, cspann.RootKey, false /* forUpdate */)
+		suite.NoError(err)
+		CheckPartitionMetadata(suite.T(), metadata, cspann.LeafLevel, vector.T{0, 0}, 0)
+	})
+
+	suite.Run("get "+desc, func() {
+		partition, err := tx.GetPartition(suite.ctx, treeKey, cspann.RootKey)
+		suite.NoError(err)
+		suite.Equal(cspann.Level(1), partition.Level())
+		suite.Equal([]cspann.ChildKey(nil), testutils.NormalizeSlice(partition.ChildKeys()))
+		suite.Equal([]cspann.ValueBytes(nil), testutils.NormalizeSlice(partition.ValueBytes()))
+		suite.Equal(vector.T{0, 0}, partition.Centroid())
+	})
+
+	suite.Run("search "+desc, func() {
+		searchSet := cspann.SearchSet{MaxResults: 2}
+		partitionCounts := []int{0}
+		level, err := tx.SearchPartitions(suite.ctx, treeKey,
+			[]cspann.PartitionKey{cspann.RootKey}, vector.T{1, 1}, &searchSet, partitionCounts)
+		suite.NoError(err)
+		suite.Equal(cspann.LeafLevel, level)
+		suite.Nil(searchSet.PopResults())
+		suite.Equal(0, partitionCounts[0])
+	})
+
+	suite.Run("try to remove vector from "+desc, func() {
+		metadata, err := tx.RemoveFromPartition(
+			suite.ctx, treeKey, cspann.RootKey, cspann.ChildKey{KeyBytes: cspann.KeyBytes{1, 2, 3}})
+		if isMissing {
+			suite.ErrorIs(err, cspann.ErrPartitionNotFound)
+		} else {
+			suite.NoError(err)
+			CheckPartitionMetadata(suite.T(), metadata, cspann.LeafLevel, vector.T{0, 0}, 0)
+		}
 	})
 }
 
-// CheckPartitionMetadata tests the correctness of the given metadata's fields.
-func CheckPartitionMetadata(
-	t *testing.T, metadata cspann.PartitionMetadata, level cspann.Level, centroid vector.T, count int,
+// addToRoot inserts vec1, vec2, and vec3 into the root partition.
+func (suite *StoreTestSuite) addToRoot(store TestStore, treeID int) {
+	tx := BeginTransaction(suite.ctx, suite.T(), store)
+	defer CommitTransaction(suite.ctx, suite.T(), store, tx)
+
+	treeKey := store.MakeTreeKey(suite.T(), treeID)
+
+	// Get partition metadata with forUpdate = true before updates.
+	metadata, err := tx.GetPartitionMetadata(suite.ctx, treeKey, cspann.RootKey, true /* forUpdate */)
+	suite.NoError(err)
+	CheckPartitionMetadata(suite.T(), metadata, cspann.LeafLevel, vector.T{0, 0}, 0)
+
+	// Add vectors to partition.
+	metadata, err = tx.AddToPartition(
+		suite.ctx, treeKey, cspann.RootKey, vec1, primaryKey1, valueBytes1)
+	suite.NoError(err)
+	CheckPartitionMetadata(suite.T(), metadata, cspann.LeafLevel, vector.T{0, 0}, 1)
+	metadata, err = tx.AddToPartition(
+		suite.ctx, treeKey, cspann.RootKey, vec2, primaryKey2, valueBytes2)
+	suite.NoError(err)
+	CheckPartitionMetadata(suite.T(), metadata, cspann.LeafLevel, vector.T{0, 0}, 2)
+	metadata, err = tx.AddToPartition(
+		suite.ctx, treeKey, cspann.RootKey, vec3, primaryKey3, valueBytes3)
+	suite.NoError(err)
+	CheckPartitionMetadata(suite.T(), metadata, cspann.LeafLevel, vector.T{0, 0}, 3)
+}
+
+// insertLeafPartition inserts a new leaf partition containing vec1, vec2, and
+// vec3, and then validates it.
+func (suite *StoreTestSuite) insertLeafPartition(store TestStore, treeID int) cspann.PartitionKey {
+	tx := BeginTransaction(suite.ctx, suite.T(), store)
+	defer CommitTransaction(suite.ctx, suite.T(), store, tx)
+	treeKey := store.MakeTreeKey(suite.T(), treeID)
+
+	vectors := vector.MakeSet(2)
+	vectors.Add(vec1)
+	vectors.Add(vec2)
+	vectors.Add(vec3)
+	quantizedSet := suite.quantizer.Quantize(&suite.workspace, vectors)
+	childKeys := []cspann.ChildKey{primaryKey1, primaryKey2, primaryKey3}
+	valueBytes := []cspann.ValueBytes{valueBytes1, valueBytes2, valueBytes3}
+	partition := cspann.NewPartition(
+		suite.quantizer, quantizedSet, childKeys, valueBytes, cspann.LeafLevel)
+
+	partitionKey, err := tx.InsertPartition(suite.ctx, treeKey, partition)
+	suite.NoError(err)
+
+	// Read back and verify the partition.
+	readPartition, err := tx.GetPartition(suite.ctx, treeKey, partitionKey)
+	suite.NoError(err)
+	ValidatePartitionsEqual(suite.T(), partition, readPartition)
+
+	return partitionKey
+}
+
+// testLeafPartition assumes that the partition already has vec1, vec2, and vec3
+// in it, either from calling addToRoot or insertLeafPartition. From that
+// starting point, it adds, removes, and searches vectors in the partition.
+func (suite *StoreTestSuite) testLeafPartition(
+	store TestStore, treeID int, partitionKey cspann.PartitionKey, centroid vector.T,
 ) {
-	require.Equal(t, level, metadata.Level)
-	require.Equal(t, []float32(centroid), testutils.RoundFloats(metadata.Centroid, 2))
-	require.Equal(t, count, metadata.Count)
-}
+	tx := BeginTransaction(suite.ctx, suite.T(), store)
+	defer CommitTransaction(suite.ctx, suite.T(), store, tx)
+	treeKey := store.MakeTreeKey(suite.T(), treeID)
 
-// BeginTransaction starts a new transaction for the given store and returns it.
-func BeginTransaction(ctx context.Context, t *testing.T, store cspann.Store) cspann.Txn {
-	txn, err := store.BeginTransaction(ctx)
-	require.NoError(t, err)
-	return txn
-}
+	// Get partition metadata with forUpdate = true before update.
+	metadata, err := tx.GetPartitionMetadata(suite.ctx, treeKey, partitionKey, true /* forUpdate */)
+	suite.NoError(err)
+	CheckPartitionMetadata(suite.T(), metadata, cspann.LeafLevel, centroid, 3)
 
-// CommitTransaction commits a transaction that was started by BeginTransaction.
-func CommitTransaction(ctx context.Context, t *testing.T, store cspann.Store, txn cspann.Txn) {
-	err := store.CommitTransaction(ctx, txn)
-	require.NoError(t, err)
-}
+	// Add duplicate and expect value to be overwritten. Centroid should not
+	// change.
+	dupVec := vector.T{5, 5}
+	metadata, err = tx.AddToPartition(
+		suite.ctx, treeKey, partitionKey, dupVec, primaryKey3, valueBytes3)
+	suite.NoError(err)
+	CheckPartitionMetadata(suite.T(), metadata, cspann.LeafLevel, centroid, 3)
 
-// AbortTransaction aborts a transaction that was started by BeginTransaction.
-func AbortTransaction(ctx context.Context, t *testing.T, store cspann.Store, txn cspann.Txn) {
-	err := store.AbortTransaction(ctx, txn)
-	require.NoError(t, err)
-}
-
-// RoundResults rounds all float fields in the given set of results, using the
-// requested precision.
-func RoundResults(results cspann.SearchResults, prec int) cspann.SearchResults {
-	for i := range results {
-		result := &results[i]
-		result.QuerySquaredDistance = float32(scalar.Round(float64(result.QuerySquaredDistance), prec))
-		result.ErrorBound = float32(scalar.Round(float64(result.ErrorBound), prec))
-		result.CentroidDistance = float32(scalar.Round(float64(result.CentroidDistance), prec))
-		result.Vector = testutils.RoundFloats(result.Vector, prec)
+	// Search partition.
+	searchSet := cspann.SearchSet{MaxResults: 2}
+	partitionCounts := []int{0}
+	searchLevel, err := tx.SearchPartitions(suite.ctx, treeKey,
+		[]cspann.PartitionKey{partitionKey}, vector.T{1, 1}, &searchSet, partitionCounts)
+	suite.NoError(err)
+	suite.Equal(cspann.LeafLevel, searchLevel)
+	result1 := cspann.SearchResult{
+		QuerySquaredDistance: 1, ErrorBound: 0,
+		CentroidDistance:   testutils.RoundFloat(num32.L2Distance(vec1, centroid), 4),
+		ParentPartitionKey: partitionKey, ChildKey: primaryKey1, ValueBytes: valueBytes1}
+	result2 := cspann.SearchResult{
+		QuerySquaredDistance: 32, ErrorBound: 0,
+		CentroidDistance:   testutils.RoundFloat(num32.L2Distance(dupVec, centroid), 4),
+		ParentPartitionKey: partitionKey, ChildKey: primaryKey3, ValueBytes: valueBytes3}
+	if partitionKey != cspann.RootKey {
+		// Non-root partitions use RaBitQuantizer, where distances are approximate.
+		result1.QuerySquaredDistance = 0
+		result1.ErrorBound = 16.1245
+		result2.QuerySquaredDistance = 34.6667
+		result2.ErrorBound = 11.4018
 	}
-	return results
+	results := searchSet.PopResults()
+	RoundResults(results, 4)
+	suite.Equal(cspann.SearchResults{result1, result2}, results)
+	suite.Equal(3, partitionCounts[0])
+
+	// Ensure partition metadata is updated.
+	metadata, err = tx.GetPartitionMetadata(suite.ctx, treeKey, partitionKey, true /* forUpdate */)
+	suite.NoError(err)
+	CheckPartitionMetadata(suite.T(), metadata, cspann.LeafLevel, centroid, 3)
+
+	// Remove vector from partition.
+	metadata, err = tx.RemoveFromPartition(suite.ctx, treeKey, partitionKey, primaryKey1)
+	suite.NoError(err)
+	CheckPartitionMetadata(suite.T(), metadata, cspann.LeafLevel, centroid, 2)
+
+	// Try to remove the same key again.
+	metadata, err = tx.RemoveFromPartition(suite.ctx, treeKey, partitionKey, primaryKey1)
+	suite.NoError(err)
+	CheckPartitionMetadata(suite.T(), metadata, cspann.LeafLevel, centroid, 2)
+
+	// Add an alternate element and add duplicate, expecting value to be overwritten.
+	metadata, err = tx.AddToPartition(
+		suite.ctx, treeKey, partitionKey, vec4, primaryKey4, valueBytes4)
+	suite.NoError(err)
+	CheckPartitionMetadata(suite.T(), metadata, cspann.LeafLevel, centroid, 3)
+
+	// Search partition.
+	searchSet = cspann.SearchSet{MaxResults: 1}
+	searchLevel, err = tx.SearchPartitions(suite.ctx, treeKey,
+		[]cspann.PartitionKey{partitionKey}, vector.T{10, -5}, &searchSet, partitionCounts)
+	suite.NoError(err)
+	suite.Equal(cspann.LeafLevel, searchLevel)
+	result1 = cspann.SearchResult{
+		QuerySquaredDistance: 25, ErrorBound: 0,
+		CentroidDistance:   testutils.RoundFloat(num32.L2Distance(vec4, centroid), 4),
+		ParentPartitionKey: partitionKey, ChildKey: primaryKey4, ValueBytes: valueBytes4}
+	if partitionKey != cspann.RootKey {
+		// Distances are approximate.
+		result1.QuerySquaredDistance = 13
+		result1.ErrorBound = 76.1577
+	}
+	results = searchSet.PopResults()
+	RoundResults(results, 4)
+	suite.Equal(cspann.SearchResults{result1}, results)
+	suite.Equal(3, partitionCounts[0])
+}
+
+// setRootPartition first validates that the root partition starts with 3
+// vectors. It then replaces that with a new set of data and validates it.
+func (suite *StoreTestSuite) setRootPartition(store TestStore, treeID int) {
+	tx := BeginTransaction(suite.ctx, suite.T(), store)
+	defer CommitTransaction(suite.ctx, suite.T(), store, tx)
+
+	treeKey := store.MakeTreeKey(suite.T(), treeID)
+
+	// Create new root partition that's at level 2 of the tree, pointing to leaf
+	// partition centroids.
+	vectors := vector.MakeSet(2)
+	vectors.Add(vec1)
+	vectors.Add(vec2)
+	centroid := vector.T{4, 3}
+
+	quantizedSet := suite.rootQuantizer.Quantize(&suite.workspace, vectors)
+	childKeys := []cspann.ChildKey{partitionKey1, partitionKey2}
+	valueBytes := []cspann.ValueBytes{valueBytes1, valueBytes2}
+	newRoot := cspann.NewPartition(
+		suite.rootQuantizer, quantizedSet, childKeys, valueBytes, cspann.SecondLevel)
+
+	err := tx.SetRootPartition(suite.ctx, treeKey, newRoot)
+	suite.NoError(err)
+
+	// Check partition metadata.
+	metadata, err := tx.GetPartitionMetadata(suite.ctx, treeKey, cspann.RootKey, false /* forUpdate */)
+	suite.NoError(err)
+	CheckPartitionMetadata(suite.T(), metadata, cspann.SecondLevel, centroid, 2)
+
+	// Read back and verify the partition.
+	readRoot, err := tx.GetPartition(suite.ctx, treeKey, cspann.RootKey)
+	suite.NoError(err)
+	ValidatePartitionsEqual(suite.T(), newRoot, readRoot)
+
+	// Search partition.
+	searchSet := cspann.SearchSet{MaxResults: 1}
+	partitionCounts := []int{0}
+	searchLevel, err := tx.SearchPartitions(suite.ctx, treeKey,
+		[]cspann.PartitionKey{cspann.RootKey}, vector.T{5, 5}, &searchSet, partitionCounts)
+	suite.NoError(err)
+	suite.Equal(cspann.SecondLevel, searchLevel)
+	result1 := cspann.SearchResult{
+		QuerySquaredDistance: 5, ErrorBound: 0, CentroidDistance: 3.1623,
+		ParentPartitionKey: cspann.RootKey, ChildKey: partitionKey2, ValueBytes: valueBytes2}
+	results := searchSet.PopResults()
+	RoundResults(results, 4)
+	suite.Equal(cspann.SearchResults{result1}, results)
+	suite.Equal(2, partitionCounts[0])
+}
+
+// deletePartition tests deleting the given partition.
+func (suite *StoreTestSuite) deletePartition(
+	store TestStore, treeID int, partitionKey cspann.PartitionKey,
+) {
+	tx := BeginTransaction(suite.ctx, suite.T(), store)
+	defer CommitTransaction(suite.ctx, suite.T(), store, tx)
+
+	treeKey := store.MakeTreeKey(suite.T(), treeID)
+
+	// Delete the partition and validate it is really gone.
+	err := tx.DeletePartition(suite.ctx, treeKey, partitionKey)
+	suite.NoError(err)
+	partition, err := tx.GetPartition(suite.ctx, treeKey, partitionKey)
+	if err != nil {
+		// Validate the error.
+		suite.True(
+			errors.Is(err, cspann.ErrPartitionNotFound) || errors.Is(err, cspann.ErrRestartOperation))
+	} else {
+		// The root partition is lazily materialized.
+		suite.Equal(cspann.RootKey, partitionKey)
+		suite.Equal(0, partition.Count())
+	}
+
+	// Now try to delete again, and ensure it's a no-op.
+	err = tx.DeletePartition(suite.ctx, treeKey, partitionKey)
+	suite.NoError(err)
 }

--- a/pkg/sql/vecindex/cspann/commontest/utils.go
+++ b/pkg/sql/vecindex/cspann/commontest/utils.go
@@ -1,0 +1,72 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package commontest
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/vecindex/cspann"
+	"github.com/cockroachdb/cockroach/pkg/sql/vecindex/cspann/testutils"
+	"github.com/cockroachdb/cockroach/pkg/util/vector"
+	"github.com/stretchr/testify/require"
+	"gonum.org/v1/gonum/floats/scalar"
+)
+
+// CheckPartitionMetadata tests the correctness of the given metadata's fields.
+func CheckPartitionMetadata(
+	t *testing.T, metadata cspann.PartitionMetadata, level cspann.Level, centroid vector.T, count int,
+) {
+	require.Equal(t, level, metadata.Level)
+	require.Equal(t, []float32(centroid), testutils.RoundFloats(metadata.Centroid, 2))
+	require.Equal(t, count, metadata.Count)
+}
+
+// BeginTransaction starts a new transaction for the given store and returns it.
+func BeginTransaction(ctx context.Context, t *testing.T, store cspann.Store) cspann.Txn {
+	txn, err := store.BeginTransaction(ctx)
+	require.NoError(t, err)
+	return txn
+}
+
+// CommitTransaction commits a transaction that was started by BeginTransaction.
+func CommitTransaction(ctx context.Context, t *testing.T, store cspann.Store, txn cspann.Txn) {
+	err := store.CommitTransaction(ctx, txn)
+	require.NoError(t, err)
+}
+
+// AbortTransaction aborts a transaction that was started by BeginTransaction.
+func AbortTransaction(ctx context.Context, t *testing.T, store cspann.Store, txn cspann.Txn) {
+	err := store.AbortTransaction(ctx, txn)
+	require.NoError(t, err)
+}
+
+// RoundResults rounds all float fields in the given set of results, using the
+// requested precision.
+func RoundResults(results cspann.SearchResults, prec int) cspann.SearchResults {
+	for i := range results {
+		result := &results[i]
+		result.QuerySquaredDistance = float32(scalar.Round(float64(result.QuerySquaredDistance), prec))
+		result.ErrorBound = float32(scalar.Round(float64(result.ErrorBound), prec))
+		result.CentroidDistance = float32(scalar.Round(float64(result.CentroidDistance), prec))
+		result.Vector = testutils.RoundFloats(result.Vector, prec)
+	}
+	return results
+}
+
+// ValidatePartitionsEqual validates that the two partitions match.
+func ValidatePartitionsEqual(t *testing.T, l, r *cspann.Partition) {
+	q1, q2 := l.QuantizedSet(), r.QuantizedSet()
+	require.Equal(t, l.Level(), r.Level(), "levels do not match")
+	require.Equal(t, l.ChildKeys(), r.ChildKeys(), "childKeys do not match")
+	require.Equal(t, l.ValueBytes(), r.ValueBytes(), "valueBytes do not match")
+	require.Equal(t, q1.GetCentroid(), q2.GetCentroid(), "centroids do not match")
+	require.Equal(t, q1.GetCount(), q2.GetCount(), "counts do not match")
+	require.Equal(t, q1.GetCentroidDistances(), q2.GetCentroidDistances(), "distances do not match")
+	if eq, ok := q1.(equaler); ok {
+		require.True(t, eq.Equal(q2))
+	}
+}

--- a/pkg/sql/vecindex/cspann/memstore/BUILD.bazel
+++ b/pkg/sql/vecindex/cspann/memstore/BUILD.bazel
@@ -65,6 +65,7 @@ go_test(
         "//pkg/util/log",
         "//pkg/util/vector",
         "@com_github_stretchr_testify//require",
+        "@com_github_stretchr_testify//suite",
         "@org_gonum_v1_gonum//floats/scalar",
     ],
 )

--- a/pkg/sql/vecindex/cspann/memstore/memstore.proto
+++ b/pkg/sql/vecindex/cspann/memstore/memstore.proto
@@ -25,12 +25,13 @@ message StoreProto {
 
 // PartitionProto serializes the fields of a partition.
 message PartitionProto {
-  uint64 partition_key = 1 [(gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/sql/vecindex/cspann.PartitionKey"];
-  quantize.RaBitQuantizedVectorSet ra_bit_q = 2;
-  quantize.UnQuantizedVectorSet un_quantized = 3;
-  repeated cspann.ChildKey child_keys = 4 [(gogoproto.nullable) = false];
-  repeated bytes value_bytes = 5 [(gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/sql/vecindex/cspann.ValueBytes"];
-  uint64 level = 6 [(gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/sql/vecindex/cspann.Level"];
+  uint64 tree_id = 1 [(gogoproto.casttype) = "TreeID"];
+  uint64 partition_key = 2 [(gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/sql/vecindex/cspann.PartitionKey"];
+  quantize.RaBitQuantizedVectorSet ra_bit_q = 3;
+  quantize.UnQuantizedVectorSet un_quantized = 4;
+  repeated cspann.ChildKey child_keys = 5 [(gogoproto.nullable) = false];
+  repeated bytes value_bytes = 6 [(gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/sql/vecindex/cspann.ValueBytes"];
+  uint64 level = 7 [(gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/sql/vecindex/cspann.Level"];
 }
 
 // Vector serializes an original, full-size vector and its key bytes.

--- a/pkg/sql/vecindex/cspann/partition.go
+++ b/pkg/sql/vecindex/cspann/partition.go
@@ -25,6 +25,10 @@ const (
 	RootKey PartitionKey = 1
 )
 
+// TreeKey identifies a particular K-means tree among the forest of trees that
+// make up a C-SPANN index. This enables partitioning of the index.
+type TreeKey []byte
+
 // KeyBytes refers to the unique row in the primary index that contains the
 // indexed vector. It typically contains part or all of the primary key for the
 // row.
@@ -233,4 +237,13 @@ func (p *Partition) Find(childKey ChildKey) int {
 		}
 	}
 	return -1
+}
+
+// CreateEmptyPartition returns an empty partition for the given quantizer and
+// level.
+func CreateEmptyPartition(quantizer quantize.Quantizer, level Level) *Partition {
+	var workspace workspace.T
+	var empty vector.Set
+	quantizedSet := quantizer.Quantize(&workspace, empty)
+	return NewPartition(quantizer, quantizedSet, []ChildKey(nil), []ValueBytes(nil), level)
 }

--- a/pkg/sql/vecindex/cspann/quantize/quantize.proto
+++ b/pkg/sql/vecindex/cspann/quantize/quantize.proto
@@ -15,6 +15,8 @@ option (gogoproto.goproto_getters_all) = false;
 // RaBitQCodeSet is a set of RaBitQ quantization codes. Each code represents a
 // quantized vector.
 message RaBitQCodeSet {
+  option (gogoproto.equal) = true;
+
   // Count is the number of codes in the set.
   int64 count = 1 [(gogoproto.casttype) = "int"];
   // Width is the number of uint64 values that store a single code.
@@ -28,6 +30,8 @@ message RaBitQCodeSet {
 // includes enough information to estimate the distance from the original
 // full-size vectors to a user-provided query vector.
 message RaBitQuantizedVectorSet {
+  option (gogoproto.equal) = true;
+
   // Centroid is the average of vectors in the set, representing its "center of
   // mass". Note that the centroid is computed when a vector set is created and
   // is not updated when vectors are added or removed.
@@ -49,6 +53,8 @@ message RaBitQuantizedVectorSet {
 // storing the original full-size vectors without quantization. This is used in
 // testing and for the root partition, which is never quantized.
 message UnQuantizedVectorSet {
+  option (gogoproto.equal) = true;
+
   // Centroid is the average of vectors in the set, representing its "center of
   // mass". Note that the centroid is computed when a vector set is created and
   // is not updated when vectors are added or removed.

--- a/pkg/sql/vecindex/cspann/quantize/rabitq.go
+++ b/pkg/sql/vecindex/cspann/quantize/rabitq.go
@@ -247,7 +247,7 @@ func (q *RaBitQuantizer) EstimateSquaredDistances(
 		//        <o¯,q> = <x¯,q'> ~ <x¯,q¯>
 		//        <o,q> ~ <o¯,q> / <o¯,o>
 		//
-		// Note one tweak to the paper, where <o¯,o> (i.e. vector_products) is
+		// Note one tweak to the paper, where <o¯,o> (i.e. DotProducts) is
 		// stored as an inverted value so that it can be multiplied rather than
 		// divided, in order to avoid divide-by-zero.
 		term1 := 2 * delta * q.sqrtDimsInv * float32(bitProduct)

--- a/pkg/sql/vecindex/cspann/store.go
+++ b/pkg/sql/vecindex/cspann/store.go
@@ -89,20 +89,20 @@ type Txn interface {
 	// ErrPartitionNotFound if the key cannot be found. The returned partition
 	// can be modified by the caller in the scope of the transaction with a
 	// guarantee it won't be changed by other agents.
-	GetPartition(ctx context.Context, partitionKey PartitionKey) (*Partition, error)
+	GetPartition(ctx context.Context, treeKey TreeKey, partitionKey PartitionKey) (*Partition, error)
 
 	// SetRootPartition makes the given partition the root partition in the store.
 	// If the root partition already exists, it is replaced, else it is newly
 	// inserted into the store.
-	SetRootPartition(ctx context.Context, partition *Partition) error
+	SetRootPartition(ctx context.Context, treeKey TreeKey, partition *Partition) error
 
 	// InsertPartition inserts the given partition into the store and returns a
 	// new key that identifies it.
-	InsertPartition(ctx context.Context, partition *Partition) (PartitionKey, error)
+	InsertPartition(ctx context.Context, treeKey TreeKey, partition *Partition) (PartitionKey, error)
 
 	// DeletePartition deletes the partition with the given key from the store,
 	// or returns ErrPartitionNotFound if the key cannot be found.
-	DeletePartition(ctx context.Context, partitionKey PartitionKey) error
+	DeletePartition(ctx context.Context, treeKey TreeKey, partitionKey PartitionKey) error
 
 	// GetPartitionMetadata returns metadata for the given partition, including
 	// its size, its centroid, and its level in the K-means tree. If "forUpdate"
@@ -112,7 +112,7 @@ type Txn interface {
 	// ErrRestartOperation if the caller should retry the operation that triggered
 	// this call.
 	GetPartitionMetadata(
-		ctx context.Context, partitionKey PartitionKey, forUpdate bool,
+		ctx context.Context, treeKey TreeKey, partitionKey PartitionKey, forUpdate bool,
 	) (PartitionMetadata, error)
 
 	// AddToPartition adds the given vector and its associated child key and value
@@ -124,6 +124,7 @@ type Txn interface {
 	// triggered this call.
 	AddToPartition(
 		ctx context.Context,
+		treeKey TreeKey,
 		partitionKey PartitionKey,
 		vec vector.T,
 		childKey ChildKey,
@@ -138,7 +139,7 @@ type Txn interface {
 	// ErrRestartOperation if the caller should retry the delete operation that
 	// triggered this call.
 	RemoveFromPartition(
-		ctx context.Context, partitionKey PartitionKey, childKey ChildKey,
+		ctx context.Context, treeKey TreeKey, partitionKey PartitionKey, childKey ChildKey,
 	) (PartitionMetadata, error)
 
 	// SearchPartitions finds vectors that are closest to the given query vector.
@@ -157,6 +158,7 @@ type Txn interface {
 	// the search operation that triggered this call.
 	SearchPartitions(
 		ctx context.Context,
+		treeKey TreeKey,
 		partitionKey []PartitionKey,
 		queryVector vector.T,
 		searchSet *SearchSet,
@@ -171,7 +173,6 @@ type Txn interface {
 	// TODO(andyk): what if the row exists but the vector column is NULL? Right
 	// now, this whole library expects vectors passed to it to be non-nil and have
 	// the same number of dims. We should look into how pgvector handles NULL
-	// values - could we just treat them as if they were the zero vector, for
-	// example?
-	GetFullVectors(ctx context.Context, refs []VectorWithKey) error
+	// values - could we just treat them as if they were missing, for example?
+	GetFullVectors(ctx context.Context, treeKey TreeKey, refs []VectorWithKey) error
 }

--- a/pkg/sql/vecindex/cspann/testdata/tree-key.ddt
+++ b/pkg/sql/vecindex/cspann/testdata/tree-key.ddt
@@ -1,0 +1,101 @@
+new-index min-partition-size=2 max-partition-size=4 beam-size=2 tree=0
+vec1: (1, 2)
+vec2: (7, 4)
+vec3: (4, 3)
+----
+• 1 (0, 0)
+│
+├───• vec1 (1, 2)
+├───• vec2 (7, 4)
+└───• vec3 (4, 3)
+
+# Insert into the same index, but a different tree.
+insert tree=2
+vec4: (8, 11)
+vec5: (14, 1)
+vec6: (0, 0)
+----
+• 1 (0, 0)
+│
+├───• vec4 (8, 11)
+├───• vec5 (14, 1)
+└───• vec6 (0, 0)
+
+# Split tree #2.
+insert tree=2
+vec7: (0, 4)
+vec8: (-2, 8)
+----
+• 1 (4.5, 4.0833)
+│
+├───• 2 (2, 7.6667)
+│   │
+│   ├───• vec4 (8, 11)
+│   ├───• vec8 (-2, 8)
+│   └───• vec7 (0, 4)
+│
+└───• 3 (7, 0.5)
+    │
+    ├───• vec6 (0, 0)
+    └───• vec5 (14, 1)
+
+# Search tree #2
+search tree=2
+(5, 5)
+----
+vec7: 26 (centroid=4.18)
+5 leaf vectors, 7 vectors, 5 full vectors, 3 partitions
+
+# Delete from tree #2.
+delete tree=2
+vec6
+----
+• 1 (4.5, 4.0833)
+│
+├───• 2 (2, 7.6667)
+│   │
+│   ├───• vec4 (8, 11)
+│   ├───• vec8 (-2, 8)
+│   └───• vec7 (0, 4)
+│
+└───• 3 (7, 0.5)
+    │
+    └───• vec5 (14, 1)
+
+# Merge partition in tree #2.
+force-merge partition-key=3 parent-partition-key=1 tree=2
+----
+• 1 (4.5, 4.0833)
+│
+└───• 2 (2, 7.6667)
+    │
+    ├───• vec4 (8, 11)
+    ├───• vec8 (-2, 8)
+    ├───• vec7 (0, 4)
+    └───• vec5 (14, 1)
+
+# Validate tree #2.
+validate-tree tree=2
+----
+Validated index with 4 vectors.
+
+# Search for insert into tree #2.
+search-for-insert tree=2
+(5, 5)
+----
+partition 2, centroid=(2, 7.6667), sqdist=16.1111
+
+# Search for delete from tree #2.
+search-for-delete tree=2
+vec8
+----
+vec8: partition 2
+
+# Ensure that tree #1 remains undisturbed.
+format-tree
+----
+• 1 (0, 0)
+│
+├───• vec1 (1, 2)
+├───• vec2 (7, 4)
+└───• vec3 (4, 3)

--- a/pkg/sql/vecindex/cspann/testutils/BUILD.bazel
+++ b/pkg/sql/vecindex/cspann/testutils/BUILD.bazel
@@ -10,5 +10,6 @@ go_library(
         "//pkg/util/num32",
         "//pkg/util/vector",
         "@com_github_stretchr_testify//require",
+        "@org_gonum_v1_gonum//floats/scalar",
     ],
 )

--- a/pkg/sql/vecindex/cspann/testutils/testutils.go
+++ b/pkg/sql/vecindex/cspann/testutils/testutils.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/num32"
 	"github.com/cockroachdb/cockroach/pkg/util/vector"
 	"github.com/stretchr/testify/require"
+	"gonum.org/v1/gonum/floats/scalar"
 )
 
 // LoadFeatures loads up to 10K 512 dimension float32 unit vectors that are laid
@@ -47,6 +48,11 @@ func LoadFeatures(t testing.TB, count int) vector.Set {
 	require.NoError(t, err)
 
 	return vector.MakeSetFromRawData(data[:count*512], 512)
+}
+
+// RoundFloat rounds the given float32 value using the given precision.
+func RoundFloat(s float32, prec int) float32 {
+	return float32(scalar.Round(float64(s), prec))
 }
 
 // RoundFloats rounds all float32 values in the slice using the given precision.

--- a/pkg/sql/vecindex/manager.go
+++ b/pkg/sql/vecindex/manager.go
@@ -88,8 +88,8 @@ func (m *Manager) Get(
 	if e != nil {
 		if e.mustWait {
 			// We are in the process of grabbing the index config and starting the
-			// VectorIndex. Wait until that is complete, at which point e.idx will be
-			// populated.
+			// vector index. Wait until that is complete, at which point e.idx will
+			// be populated.
 			log.VEventf(ctx, 1, "waiting for config for index %d of table %d", indexID, tableID)
 			if m.testingKnobs != nil && m.testingKnobs.BeforeVecIndexWait != nil {
 				m.testingKnobs.BeforeVecIndexWait()

--- a/pkg/sql/vecindex/vecstore/BUILD.bazel
+++ b/pkg/sql/vecindex/vecstore/BUILD.bazel
@@ -53,7 +53,6 @@ go_test(
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/catalog/descs",
         "//pkg/sql/catalog/desctestutils",
-        "//pkg/sql/catalog/tabledesc",
         "//pkg/sql/randgen",
         "//pkg/sql/sem/idxtype",
         "//pkg/sql/sem/tree",
@@ -71,5 +70,6 @@ go_test(
         "//pkg/util/randutil",
         "//pkg/util/vector",
         "@com_github_stretchr_testify//require",
+        "@com_github_stretchr_testify//suite",
     ],
 )


### PR DESCRIPTION
The CREATE VECTOR INDEX syntax allows indexing over multiple columns, as long as the vector column to be indexed is the last column in the index definition. The other "prefix" columns can be used to partition the index by tenants, regions, users, etc. The execution engine encodes prefix columns as a byte slice and passes it as a parameter to vector index operations like Insert and Search. While the index itself treats these bytes as an opaque "TreeKey", the CRDB Store implementation incorporates these prefix bytes into KV keys.

This prefixing mechanism has the effect of separating the index into distinct K-means trees, each identified by a unique TreeKey. CRDB partitioning can control where those trees are located, e.g. an app that stores indexed user photo embeddings in a region close to them.

Epic: CRDB-42943

Release note: None