### PR TITLE
roachprod/failureinjection: add artificial latency failure

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -2501,7 +2501,7 @@ func (c *clusterImpl) RunE(ctx context.Context, options install.RunOptions, args
 		return errors.New("No command passed")
 	}
 	nodes := option.FromInstallNodes(options.Nodes)
-	l, logFile, err := c.loggerForCmd(nodes, args...)
+	l, logFile, err := roachtestutil.LoggerForCmd(c.l, nodes, args...)
 	if err != nil {
 		return err
 	}
@@ -2569,7 +2569,7 @@ func (c *clusterImpl) RunWithDetails(
 		return nil, errors.New("No command passed")
 	}
 	nodes := option.FromInstallNodes(options.Nodes)
-	l, logFile, err := c.loggerForCmd(nodes, args...)
+	l, logFile, err := roachtestutil.LoggerForCmd(c.l, nodes, args...)
 	if err != nil {
 		return nil, err
 	}
@@ -2651,30 +2651,6 @@ func (c *clusterImpl) Install(
 		return errors.New("Error running cluster.Install: no software passed")
 	}
 	return errors.Wrap(roachprod.Install(ctx, l, c.MakeNodes(nodes), software), "cluster.Install")
-}
-
-// cmdLogFileName comes up with a log file to use for the given argument string.
-func cmdLogFileName(t time.Time, nodes option.NodeListOption, args ...string) string {
-	logFile := fmt.Sprintf(
-		"run_%s_n%s_%s",
-		t.Format(`150405.000000000`),
-		nodes.String()[1:],
-		install.GenFilenameFromArgs(20, args...),
-	)
-	return logFile
-}
-
-func (c *clusterImpl) loggerForCmd(
-	node option.NodeListOption, args ...string,
-) (*logger.Logger, string, error) {
-	logFile := cmdLogFileName(timeutil.Now(), node, args...)
-
-	// NB: we set no prefix because it's only going to a file anyway.
-	l, err := c.l.ChildLogger(logFile, logger.QuietStderr, logger.QuietStdout)
-	if err != nil {
-		return nil, "", err
-	}
-	return l, logFile, nil
 }
 
 // pgURLErr returns the Postgres endpoint for the specified nodes. It accepts a

--- a/pkg/cmd/roachtest/cluster_test.go
+++ b/pkg/cmd/roachtest/cluster_test.go
@@ -11,7 +11,6 @@ import (
 	"strconv"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil/task"
@@ -24,7 +23,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/version"
 	"github.com/cockroachdb/datadriven"
 	"github.com/cockroachdb/errors"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -684,21 +682,6 @@ func TestMachineTypes(t *testing.T) {
 			return out.String()
 		})
 	})
-}
-
-func TestCmdLogFileName(t *testing.T) {
-	ts := time.Date(2000, 1, 1, 15, 4, 12, 0, time.Local)
-
-	const exp = `run_150412.000000000_n1,3-4,9_cockroach-bla-foo-ba`
-	nodes := option.NodeListOption{1, 3, 4, 9}
-	assert.Equal(t,
-		exp,
-		cmdLogFileName(ts, nodes, "./cockroach", "bla", "--foo", "bar"),
-	)
-	assert.Equal(t,
-		exp,
-		cmdLogFileName(ts, nodes, "./cockroach bla --foo bar"),
-	)
 }
 
 func TestVerifyLibraries(t *testing.T) {

--- a/pkg/cmd/roachtest/roachtestutil/BUILD.bazel
+++ b/pkg/cmd/roachtest/roachtestutil/BUILD.bazel
@@ -51,10 +51,12 @@ go_test(
     srcs = [
         "commandbuilder_test.go",
         "load_group_test.go",
+        "utils_test.go",
     ],
     embed = [":roachtestutil"],
     deps = [
         "//pkg/cmd/roachtest/option",
+        "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/cmd/roachtest/roachtestutil/utils.go
+++ b/pkg/cmd/roachtest/roachtestutil/utils.go
@@ -13,6 +13,7 @@ import (
 	"net/http"
 	"os"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -236,4 +237,20 @@ func CheckPortBlocked(
 		return false, err
 	}
 	return strings.Contains(res.Stdout, "filtered"), nil
+}
+
+// PortLatency returns the latency from one node to another port.
+// Requires nmap to be installed.
+func PortLatency(
+	ctx context.Context, l *logger.Logger, c cluster.Cluster, fromNode, toNode option.NodeListOption,
+) (time.Duration, error) {
+	res, err := c.RunWithDetailsSingleNode(ctx, l, option.WithNodes(fromNode), fmt.Sprintf("nmap -p {pgport%[1]s} -Pn {ip%[1]s} -oG - | grep 'scanned in' | awk '{print $(NF-1)}'", toNode))
+	if err != nil {
+		return 0, err
+	}
+	avgRTT, err := strconv.ParseFloat(strings.TrimSpace(res.Stdout), 64)
+	if err != nil {
+		return 0, err
+	}
+	return time.Duration(avgRTT * float64(time.Second)), nil
 }

--- a/pkg/cmd/roachtest/roachtestutil/utils.go
+++ b/pkg/cmd/roachtest/roachtestutil/utils.go
@@ -219,6 +219,31 @@ func IfLocal(c cluster.Cluster, trueVal, falseVal string) string {
 	return falseVal
 }
 
+// LoggerForCmd creates a logger to a file with quiet stdout and stderr.
+func LoggerForCmd(
+	l *logger.Logger, node option.NodeListOption, args ...string,
+) (*logger.Logger, string, error) {
+	logFile := cmdLogFileName(timeutil.Now(), node, args...)
+
+	// NB: we set no prefix because it's only going to a file anyway.
+	l, err := l.ChildLogger(logFile, logger.QuietStderr, logger.QuietStdout)
+	if err != nil {
+		return nil, "", err
+	}
+	return l, logFile, nil
+}
+
+// cmdLogFileName comes up with a log file to use for the given argument string.
+func cmdLogFileName(t time.Time, nodes option.NodeListOption, args ...string) string {
+	logFile := fmt.Sprintf(
+		"run_%s_n%s_%s",
+		t.Format(`150405.000000000`),
+		nodes.String()[1:],
+		install.GenFilenameFromArgs(20, args...),
+	)
+	return logFile
+}
+
 // CheckPortBlocked returns true if a connection from a node to a port on another node
 // can be established. Requires nmap to be installed.
 func CheckPortBlocked(

--- a/pkg/cmd/roachtest/roachtestutil/utils_test.go
+++ b/pkg/cmd/roachtest/roachtestutil/utils_test.go
@@ -1,0 +1,29 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package roachtestutil
+
+import (
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCmdLogFileName(t *testing.T) {
+	ts := time.Date(2000, 1, 1, 15, 4, 12, 0, time.Local)
+
+	const exp = `run_150412.000000000_n1,3-4,9_cockroach-bla-foo-ba`
+	nodes := option.NodeListOption{1, 3, 4, 9}
+	assert.Equal(t,
+		exp,
+		cmdLogFileName(ts, nodes, "./cockroach", "bla", "--foo", "bar"),
+	)
+	assert.Equal(t,
+		exp,
+		cmdLogFileName(ts, nodes, "./cockroach bla --foo bar"),
+	)
+}

--- a/pkg/cmd/roachtest/tests/failure_injection.go
+++ b/pkg/cmd/roachtest/tests/failure_injection.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
@@ -35,14 +36,18 @@ type failureSmokeTest struct {
 
 func (t *failureSmokeTest) run(
 	ctx context.Context, l *logger.Logger, c cluster.Cluster, fr *failures.FailureRegistry,
-) error {
+) (err error) {
 	// TODO(darryl): In the future, roachtests should interact with the failure injection library
 	// through helper functions in roachtestutil so they don't have to interface with roachprod
 	// directly.
-	failureMode, err := fr.GetFailureMode(c.MakeNodes(), t.failureName, l, c.IsSecure())
+	failureMode, err := fr.GetFailureMode(c.MakeNodes(c.CRDBNodes()), t.failureName, l, c.IsSecure())
 	if err != nil {
 		return err
 	}
+	// Make sure to cleanup the failure mode even if the test fails.
+	defer func() {
+		err = errors.CombineErrors(err, failureMode.Cleanup(ctx, l, t.args))
+	}()
 	if err = failureMode.Setup(ctx, l, t.args); err != nil {
 		return err
 	}
@@ -67,13 +72,7 @@ func (t *failureSmokeTest) run(
 		return err
 	}
 
-	if err = t.validateRestore(ctx, l, c); err != nil {
-		return err
-	}
-	if err = failureMode.Cleanup(ctx, l, t.args); err != nil {
-		return err
-	}
-	return nil
+	return t.validateRestore(ctx, l, c)
 }
 
 func (t *failureSmokeTest) noopRun(
@@ -233,6 +232,69 @@ var asymmetricOutgoingNetworkPartitionTest = func(c cluster.Cluster) failureSmok
 	}
 }
 
+var latencyTest = func(c cluster.Cluster) failureSmokeTest {
+	nodes := c.CRDBNodes()
+	rand.Shuffle(len(nodes), func(i, j int) {
+		nodes[i], nodes[j] = nodes[j], nodes[i]
+	})
+	srcNode := nodes[0]
+	destNode := nodes[1]
+	unaffectedNode := nodes[2]
+	return failureSmokeTest{
+		testName:    "Network Latency",
+		failureName: failures.NetworkLatencyName,
+		args: failures.NetworkLatencyArgs{
+			ArtificialLatencies: []failures.ArtificialLatency{
+				{
+					Source:      install.Nodes{install.Node(srcNode)},
+					Destination: install.Nodes{install.Node(destNode)},
+					Delay:       2 * time.Second,
+				},
+				{
+					Source:      install.Nodes{install.Node(destNode)},
+					Destination: install.Nodes{install.Node(srcNode)},
+					Delay:       2 * time.Second,
+				},
+			},
+		},
+		validateFailure: func(ctx context.Context, l *logger.Logger, c cluster.Cluster) error {
+			// Note that this is one way latency, since the sender doesn't have the matching port.
+			delayedLatency, err := roachtestutil.PortLatency(ctx, l, c, c.Nodes(srcNode), c.Nodes(destNode))
+			if err != nil {
+				return err
+			}
+			normalLatency, err := roachtestutil.PortLatency(ctx, l, c, c.Nodes(unaffectedNode), c.Nodes(destNode))
+			if err != nil {
+				return err
+			}
+			if delayedLatency < normalLatency*2 {
+				return errors.Errorf("expected latency between nodes with artificial latency (n%d and n%d) to be much higher than between nodes without (n%d and n%d)", srcNode, destNode, unaffectedNode, destNode)
+			}
+			if delayedLatency < time.Second || delayedLatency > 3*time.Second {
+				return errors.Errorf("expected latency between nodes with artificial latency (n%d and n%d) to be at least within 1s and 3s", srcNode, destNode)
+			}
+			return nil
+		},
+		validateRestore: func(ctx context.Context, l *logger.Logger, c cluster.Cluster) error {
+			delayedLatency, err := roachtestutil.PortLatency(ctx, l, c, c.Nodes(srcNode), c.Nodes(destNode))
+			if err != nil {
+				return err
+			}
+			normalLatency, err := roachtestutil.PortLatency(ctx, l, c, c.Nodes(unaffectedNode), c.Nodes(destNode))
+			if err != nil {
+				return err
+			}
+			if delayedLatency > 2*normalLatency {
+				return errors.Errorf("expected latency between nodes with artificial latency (n%d and n%d) to be close to latency between nodes without (n%d and n%d)", srcNode, destNode, unaffectedNode, destNode)
+			}
+			if delayedLatency > 500*time.Millisecond {
+				return errors.Errorf("expected latency between nodes with artificial latency (n%d and n%d) to have restored to at least less than 500ms", srcNode, destNode)
+			}
+			return nil
+		},
+	}
+}
+
 func setupFailureSmokeTests(ctx context.Context, t test.Test, c cluster.Cluster) error {
 	// Download any dependencies needed.
 	if err := c.Install(ctx, t.L(), c.CRDBNodes(), "nmap"); err != nil {
@@ -258,6 +320,7 @@ func runFailureSmokeTest(ctx context.Context, t test.Test, c cluster.Cluster, no
 		bidirectionalNetworkPartitionTest(c),
 		asymmetricIncomingNetworkPartitionTest(c),
 		asymmetricOutgoingNetworkPartitionTest(c),
+		latencyTest(c),
 	}
 
 	// Randomize the order of the tests in case any of the failures have unexpected side
@@ -284,7 +347,7 @@ func runFailureSmokeTest(ctx context.Context, t test.Test, c cluster.Cluster, no
 
 func registerFISmokeTest(r registry.Registry) {
 	r.Add(registry.TestSpec{
-		Name:             "failure-injection-smoke-test",
+		Name:             "failure-injection/smoke-test",
 		Owner:            registry.OwnerTestEng,
 		Cluster:          r.MakeClusterSpec(4, spec.WorkloadNode(), spec.CPU(2), spec.WorkloadNodeCPU(2), spec.ReuseNone()),
 		CompatibleClouds: registry.OnlyGCE,
@@ -295,7 +358,7 @@ func registerFISmokeTest(r registry.Registry) {
 		},
 	})
 	r.Add(registry.TestSpec{
-		Name:             "failure-injection-noop-smoke-test",
+		Name:             "failure-injection/smoke-test/noop",
 		Owner:            registry.OwnerTestEng,
 		Cluster:          r.MakeClusterSpec(4, spec.WorkloadNode(), spec.CPU(2), spec.WorkloadNodeCPU(2), spec.ReuseNone()),
 		CompatibleClouds: registry.OnlyGCE,

--- a/pkg/roachprod/failureinjection/failures/BUILD.bazel
+++ b/pkg/roachprod/failureinjection/failures/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "failures",
     srcs = [
         "failure.go",
+        "latency.go",
         "network_partition.go",
         "registry.go",
     ],
@@ -13,5 +14,6 @@ go_library(
         "//pkg/roachprod",
         "//pkg/roachprod/install",
         "//pkg/roachprod/logger",
+        "@com_github_cockroachdb_errors//:errors",
     ],
 )

--- a/pkg/roachprod/failureinjection/failures/latency.go
+++ b/pkg/roachprod/failureinjection/failures/latency.go
@@ -1,0 +1,274 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package failures
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/roachprod"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
+	"github.com/cockroachdb/errors"
+)
+
+// NetworkLatency is a failure mode that injects artificial network latency between nodes
+// using tc and iptables.
+type NetworkLatency struct {
+	GenericFailure
+	// For each ArtificialLatency rule, we create a new class and qdisc since it simplifies keeping
+	// track of which rule to delete. Creating too many (hundreds) qdiscs can lead to increased cpu
+	// usage, but we don't expect to have more than a few dozen rules for most use cases, e.g. a 50
+	// node cluster simulating MR deployment only needs ~66 qdiscs per node.
+	classesInUse       map[int]struct{}
+	nextAvailableClass int
+	// filterNameToClassMap keeps track of which ArtificialLatency rule is associated with which class.
+	// We need this as the only way to remove specific TC filters/qdiscs is by knowing the class number.
+	// A filter name is just the ArtificialLatency rule as a string. Adding the same exact rule twice
+	// is disallowed.
+	filterNameToClassMap map[string]int
+}
+
+// ArtificialLatency represents the one way artificial (added) latency from one group of nodes to another.
+type ArtificialLatency struct {
+	Source      install.Nodes
+	Destination install.Nodes
+	Delay       time.Duration
+}
+
+func (l *ArtificialLatency) String() string {
+	return fmt.Sprintf("%d-%d-%s", l.Source, l.Destination, l.Delay)
+}
+
+type NetworkLatencyArgs struct {
+	ArtificialLatencies []ArtificialLatency
+}
+
+func registerNetworkLatencyFailure(r *FailureRegistry) {
+	r.add(NetworkLatencyName, NetworkLatencyArgs{}, MakeNetworkLatencyFailure)
+}
+
+func MakeNetworkLatencyFailure(
+	clusterName string, l *logger.Logger, secure bool,
+) (FailureMode, error) {
+	c, err := roachprod.GetClusterFromCache(l, clusterName, install.SecureOption(secure))
+	if err != nil {
+		return nil, err
+	}
+
+	genericFailure := GenericFailure{c: c, runTitle: "latency"}
+	return &NetworkLatency{
+		GenericFailure:       genericFailure,
+		classesInUse:         make(map[int]struct{}),
+		nextAvailableClass:   1,
+		filterNameToClassMap: make(map[string]int),
+	}, nil
+}
+
+const NetworkLatencyName = "network-latency"
+
+func (f *NetworkLatency) Description() string {
+	return NetworkLatencyName
+}
+
+func (f *NetworkLatency) Setup(ctx context.Context, l *logger.Logger, args FailureArgs) error {
+	interfaces, err := f.NetworkInterfaces(ctx, l)
+	if err != nil {
+		return err
+	}
+	cmd := failScriptEarlyCmd
+	for _, iface := range interfaces {
+		// Ignore the loopback interface since no CRDB traffic should go through it
+		// in roachprod deployments.
+		if iface == "lo" {
+			continue
+		}
+		cmd += fmt.Sprintf(setupQdiscsCmd, iface)
+	}
+	l.Printf("Setting up root htb qdisc with cmd: %s", cmd)
+	if err := f.Run(ctx, l, f.c.Nodes, cmd); err != nil {
+		return err
+	}
+	return nil
+}
+
+const (
+	failScriptEarlyCmd = `# ensure any failure fails the entire script.
+set -e;`
+
+	setupQdiscsCmd = `
+NETWORK_IFACE=%[1]s
+
+# Create a root htb qdisc that all other qdiscs will be attached to.
+sudo tc qdisc replace dev ${NETWORK_IFACE} root handle 1: htb default 12	
+`
+	addFilterCmd = `
+NETWORK_IFACE=%[1]s
+CLASS=%[2]d
+HANDLE=%[3]d
+DELAY=%[4]s
+
+# Create a class for the new latency rule. htb makes us set a bandwidth limit so set it
+# arbitrarily high.
+sudo tc class add dev ${NETWORK_IFACE} parent 1: classid 1:${CLASS} htb rate 10000mbit
+
+# Attach a netem qdisc to the class with the specified delay.
+sudo tc qdisc add dev ${NETWORK_IFACE} parent 1:${CLASS} handle ${HANDLE}: netem delay ${DELAY}
+
+# Add a filter to mark all packets matching the IP and port to be routed
+# to the netem qdisc we added above which actually adds the delay.
+#
+# We set the filter priority to the class number as a hack so we can easily
+# remove the filter later in one shot. We don't really care about priority 
+# since our rules are relatively simplistic. Without this, we would have to
+# grep and parse the output of 'tc filter show'' to find the filter(s) we want to
+# remove since a priority would be randomly assigned.
+sudo tc filter add dev ${NETWORK_IFACE} parent 1: protocol ip prio ${CLASS} u32 \
+match ip dst {ip:%[5]d}/32 \
+match ip dport {pgport:%[5]d} 0xffff \
+flowid 1:${CLASS}
+
+# Same as above but with the public IP.
+sudo tc filter add dev ${NETWORK_IFACE} parent 1: protocol ip prio ${CLASS} u32 \
+match ip dst {ip:%[5]d:public}/32 \
+match ip dport {pgport:%[5]d} 0xffff \
+flowid 1:${CLASS}
+`
+
+	removeFilterCmd = `
+NETWORK_IFACE=%[1]s
+CLASS=%[2]d
+
+# Delete in reverse order as added above to avoid resource is busy errors.
+sudo tc filter del dev ${NETWORK_IFACE} parent 1: protocol ip prio ${CLASS} u32
+sudo tc qdisc del dev ${NETWORK_IFACE} parent 1:${CLASS}
+sudo tc class del dev ${NETWORK_IFACE} parent 1: classid 1:${CLASS}
+`
+
+	removeQdiscCmd = `
+NETWORK_IFACE=%[1]s
+sudo tc qdisc del dev ${NETWORK_IFACE} root
+`
+)
+
+// findNextOpenClass returns the lowest available class number that
+// can be used to add a new latency rule.
+func (f *NetworkLatency) findNextOpenClass() int {
+	class := f.nextAvailableClass
+	f.classesInUse[class] = struct{}{}
+	// Iterate until we find the next available class.
+	for {
+		if _, ok := f.classesInUse[f.nextAvailableClass]; !ok {
+			break
+		}
+		f.nextAvailableClass++
+	}
+	return class
+}
+
+func (f *NetworkLatency) Inject(ctx context.Context, l *logger.Logger, args FailureArgs) error {
+	latencies := args.(NetworkLatencyArgs).ArtificialLatencies
+	for _, latency := range latencies {
+		for _, dest := range latency.Destination {
+			interfaces, err := f.NetworkInterfaces(ctx, l)
+			if err != nil {
+				return err
+			}
+
+			// Enforce we don't have duplicate rules, as it complicates the removal process of filters
+			// and is something the user likely didn't intend.
+			class := f.findNextOpenClass()
+			if _, ok := f.filterNameToClassMap[latency.String()]; ok {
+				return errors.Newf("failed trying to inject ArtificialLatency, rule already exists: %+v", latency)
+			}
+			f.filterNameToClassMap[latency.String()] = class
+			handle := 10 * class
+
+			cmd := failScriptEarlyCmd
+			for _, iface := range interfaces {
+				if iface == "lo" {
+					continue
+				}
+				cmd += fmt.Sprintf(addFilterCmd, iface, class, handle, latency.Delay, dest)
+			}
+			l.Printf("Adding artificial latency from nodes %d to node %d with cmd: %s", latency.Source, dest, cmd)
+			if err := f.Run(ctx, l, latency.Source, cmd); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func (f *NetworkLatency) Restore(ctx context.Context, l *logger.Logger, args FailureArgs) error {
+	latencies := args.(NetworkLatencyArgs).ArtificialLatencies
+	for _, latency := range latencies {
+		for _, dest := range latency.Destination {
+			interfaces, err := f.NetworkInterfaces(ctx, l)
+			if err != nil {
+				return err
+			}
+
+			class, ok := f.filterNameToClassMap[latency.String()]
+			if !ok {
+				return errors.New("failed trying to restore latency failure, ArtificialLatency rule was not found: %+v")
+			}
+
+			cmd := failScriptEarlyCmd
+			for _, iface := range interfaces {
+				if iface == "lo" {
+					continue
+				}
+				cmd = cmd + fmt.Sprintf(removeFilterCmd, iface, class)
+			}
+			l.Printf("Removing artificial latency from nodes %d to node %d with cmd: %s", latency.Source, dest, cmd)
+			if err := f.Run(ctx, l, latency.Source, cmd); err != nil {
+				return err
+			}
+			if class < f.nextAvailableClass {
+				f.nextAvailableClass = class
+			}
+			delete(f.filterNameToClassMap, latency.String())
+		}
+	}
+	return nil
+}
+
+func (f *NetworkLatency) Cleanup(ctx context.Context, l *logger.Logger, args FailureArgs) error {
+	interfaces, err := f.NetworkInterfaces(ctx, l)
+	if err != nil {
+		return err
+	}
+	cmd := failScriptEarlyCmd
+	for _, iface := range interfaces {
+		if iface == "lo" {
+			continue
+		}
+		cmd += fmt.Sprintf(removeQdiscCmd, iface)
+
+	}
+	l.Printf("Removing root htb qdisc with cmd: %s", cmd)
+	if err = f.Run(ctx, l, f.c.Nodes, cmd); err != nil {
+		return err
+	}
+	f.classesInUse = make(map[int]struct{})
+	return nil
+}
+
+func (f *NetworkLatency) WaitForFailureToPropagate(
+	ctx context.Context, l *logger.Logger, args FailureArgs,
+) error {
+	// TODO(Darryl): Monitor cluster (e.g. for replica convergence) and block until it's stable.
+	return nil
+}
+
+func (f *NetworkLatency) WaitForFailureToRestore(
+	ctx context.Context, l *logger.Logger, args FailureArgs,
+) error {
+	// TODO(Darryl): Monitor cluster (e.g. for replica convergence) and block until it's stable.
+	return nil
+}

--- a/pkg/roachprod/failureinjection/failures/network_partition.go
+++ b/pkg/roachprod/failureinjection/failures/network_partition.go
@@ -193,13 +193,13 @@ func (f *IPTablesPartitionFailure) Cleanup(
 func (f *IPTablesPartitionFailure) WaitForFailureToPropagate(
 	_ context.Context, _ *logger.Logger, _ FailureArgs,
 ) error {
-	// IPTables rules are applied immediately, so we don't need to wait for them to propagate.
+	// TODO(Darryl): Monitor cluster (e.g. for replica convergence) and block until it's stable.
 	return nil
 }
 
 func (f *IPTablesPartitionFailure) WaitForFailureToRestore(
 	_ context.Context, _ *logger.Logger, _ FailureArgs,
 ) error {
-	// IPTables rules are applied immediately, so we don't need to wait for them to propagate.
+	// TODO(Darryl): Monitor cluster (e.g. for replica convergence) and block until it's stable.
 	return nil
 }

--- a/pkg/roachprod/failureinjection/failures/registry.go
+++ b/pkg/roachprod/failureinjection/failures/registry.go
@@ -28,6 +28,7 @@ func NewFailureRegistry() *FailureRegistry {
 
 func (r *FailureRegistry) Register() {
 	registerIPTablesPartitionFailure(r)
+	registerNetworkLatencyFailure(r)
 }
 
 func (r *FailureRegistry) add(


### PR DESCRIPTION
This change adds a new artificial latency failure mode. This
failure mode uses TC to create traffic filters that can be used
to add latency between nodes.

Informs: https://github.com/cockroachdb/cockroach/issues/138970
Release note: none