### PR TITLE
multiregionccl: make sure sleep is longer than timeout when simulating failure in test

### DIFF
--- a/pkg/ccl/multiregionccl/regionliveness_test.go
+++ b/pkg/ccl/multiregionccl/regionliveness_test.go
@@ -176,7 +176,9 @@ func TestRegionLivenessProber(t *testing.T) {
 			// Attempt to keep on pushing out the unavailable_at time,
 			// these calls should be no-ops.
 			blockProbeQuery.Store(true)
-			require.NoError(t, regionProber.ProbeLiveness(ctx, expectedRegions[1]))
+			if err := regionProber.ProbeLiveness(ctx, expectedRegions[1]); err != nil {
+				return err
+			}
 			// Check if the time has expired yet.
 			regions, err := regionProber.QueryLiveness(ctx, txn)
 			if err != nil {

--- a/pkg/ccl/multiregionccl/regionliveness_test.go
+++ b/pkg/ccl/multiregionccl/regionliveness_test.go
@@ -424,16 +424,16 @@ func TestRegionLivenessProberForLeases(t *testing.T) {
 	tr := sqlutils.MakeSQLRunner(newRegionSQL)
 	// Validate everything was cleaned bringing up a new node in the down region.
 	require.Equalf(t,
-		tr.QueryStr(t, "SELECT * FROM system.region_liveness"),
 		[][]string{},
+		tr.QueryStr(t, "SELECT * FROM system.region_liveness"),
 		"expected no unavaialble regions.")
 	require.Equalf(t,
-		tr.QueryStr(t, "SELECT count(*) FROM system.sql_instances WHERE session_id IS NOT NULL"),
 		[][]string{{"3"}},
+		tr.QueryStr(t, "SELECT count(*) FROM system.sql_instances WHERE session_id IS NOT NULL"),
 		"extra sql instances are being used.")
 	require.Equalf(t,
-		tr.QueryStr(t, "SELECT count(*) FROM system.sqlliveness"),
 		[][]string{{"3"}},
+		tr.QueryStr(t, "SELECT count(*) FROM system.sqlliveness"),
 		"extra sql sessions detected.")
 	require.NoError(t, err)
 	// Validate that the stuck query will fail once we recover.

--- a/pkg/ccl/multiregionccl/regionliveness_test.go
+++ b/pkg/ccl/multiregionccl/regionliveness_test.go
@@ -100,7 +100,7 @@ func TestRegionLivenessProber(t *testing.T) {
 	var tenants []serverutils.ApplicationLayerInterface
 	var tenantSQL []*gosql.DB
 	blockProbeQuery := atomic.Bool{}
-	defer regionliveness.TestingSetProbeLivenessTimeout(
+	defer regionliveness.TestingSetBeforeProbeLivenessHook(
 		func() {
 			// Timeout attempts to probe intentionally.
 			if blockProbeQuery.Swap(false) {
@@ -254,7 +254,7 @@ func TestRegionLivenessProberForLeases(t *testing.T) {
 	targetCount := atomic.Int64{}
 	var tenants []serverutils.ApplicationLayerInterface
 	var tenantSQL []*gosql.DB
-	defer regionliveness.TestingSetProbeLivenessTimeout(
+	defer regionliveness.TestingSetBeforeProbeLivenessHook(
 		func() {
 			if !detectLeaseWait.Load() {
 				return
@@ -522,7 +522,7 @@ func TestRegionLivenessProberForSQLInstances(t *testing.T) {
 	var tenants []serverutils.ApplicationLayerInterface
 	var tenantSQL []*gosql.DB
 	blockProbeQuery := atomic.Bool{}
-	defer regionliveness.TestingSetProbeLivenessTimeout(
+	defer regionliveness.TestingSetBeforeProbeLivenessHook(
 		func() {
 			// Timeout attempts to probe intentionally.
 			if blockProbeQuery.Swap(false) {

--- a/pkg/ccl/multiregionccl/regionliveness_test.go
+++ b/pkg/ccl/multiregionccl/regionliveness_test.go
@@ -51,7 +51,7 @@ import (
 const (
 	// Use a low probe timeout number, but intentionally only manipulate to
 	// this value when *failures* are expected.
-	testingRegionLivenessProbeTimeout = time.Second * 2
+	testingRegionLivenessProbeTimeout = time.Second * 1
 	// Use a long probe timeout by default when running this test (since CI
 	// can easily hit query timeouts).
 	testingRegionLivenessProbeTimeoutLong = time.Minute
@@ -104,9 +104,10 @@ func TestRegionLivenessProber(t *testing.T) {
 		func() {
 			// Timeout attempts to probe intentionally.
 			if blockProbeQuery.Swap(false) {
-				time.Sleep(testingRegionLivenessProbeTimeout)
+				time.Sleep(2 * testingRegionLivenessProbeTimeout)
 			}
-		})()
+		},
+	)()
 
 	for _, s := range testCluster.Servers {
 		tenantArgs := base.TestTenantArgs{
@@ -253,14 +254,16 @@ func TestRegionLivenessProberForLeases(t *testing.T) {
 	targetCount := atomic.Int64{}
 	var tenants []serverutils.ApplicationLayerInterface
 	var tenantSQL []*gosql.DB
-	defer regionliveness.TestingSetProbeLivenessTimeout(func() {
-		if !detectLeaseWait.Load() {
-			return
-		}
-		time.Sleep(testingRegionLivenessProbeTimeout)
-		targetCount.Swap(0)
-		detectLeaseWait.Swap(false)
-	})()
+	defer regionliveness.TestingSetProbeLivenessTimeout(
+		func() {
+			if !detectLeaseWait.Load() {
+				return
+			}
+			time.Sleep(2 * testingRegionLivenessProbeTimeout)
+			targetCount.Swap(0)
+			detectLeaseWait.Swap(false)
+		},
+	)()
 
 	var keyToBlockMu syncutil.Mutex
 	var keyToBlock roachpb.Key
@@ -321,7 +324,7 @@ func TestRegionLivenessProberForLeases(t *testing.T) {
 							keyToBlockMu.Lock()
 							keyToBlock = tenant.Codec().TablePrefix(uint32(systemschema.RegionLivenessTable.GetID()))
 							keyToBlockMu.Unlock()
-							time.Sleep(testingRegionLivenessProbeTimeout)
+							time.Sleep(2 * testingRegionLivenessProbeTimeout)
 						}
 					},
 				},
@@ -523,9 +526,10 @@ func TestRegionLivenessProberForSQLInstances(t *testing.T) {
 		func() {
 			// Timeout attempts to probe intentionally.
 			if blockProbeQuery.Swap(false) {
-				time.Sleep(testingRegionLivenessProbeTimeout)
+				time.Sleep(2 * testingRegionLivenessProbeTimeout)
 			}
-		})()
+		},
+	)()
 
 	for _, s := range testCluster.Servers {
 		tenantArgs := base.TestTenantArgs{

--- a/pkg/ccl/multiregionccl/regionliveness_test.go
+++ b/pkg/ccl/multiregionccl/regionliveness_test.go
@@ -463,7 +463,6 @@ func TestRegionLivenessProberForLeases(t *testing.T) {
 			expectedTxnErr,
 			"txn should see a retry error")
 	}
-	require.ErrorContainsf(t, grp.Wait(), "context canceled", "connection should have been dropped, node is dead.")
 }
 
 // TestRegionLivenessProberForSQLInstances validates that regional avaibility issues

--- a/pkg/sql/regionliveness/prober.go
+++ b/pkg/sql/regionliveness/prober.go
@@ -113,13 +113,13 @@ type livenessProber struct {
 	settings        *clustersettings.Settings
 }
 
-var testingProbeQueryCallbackFunc func()
+var testingBeforeProbeLivenessHook func()
 var testingUnavailableAtTTLOverride time.Duration
 
-func TestingSetProbeLivenessTimeout(probeCallbackFn func()) func() {
-	testingProbeQueryCallbackFunc = probeCallbackFn
+func TestingSetBeforeProbeLivenessHook(hook func()) func() {
+	testingBeforeProbeLivenessHook = hook
 	return func() {
-		testingProbeQueryCallbackFunc = nil
+		testingBeforeProbeLivenessHook = nil
 	}
 }
 
@@ -183,8 +183,8 @@ func (l *livenessProber) ProbeLivenessWithPhysicalRegion(
 	err := timeutil.RunWithTimeout(ctx, "probe-liveness", tableTimeout,
 		func(ctx context.Context) error {
 			return l.db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
-				if testingProbeQueryCallbackFunc != nil {
-					testingProbeQueryCallbackFunc()
+				if testingBeforeProbeLivenessHook != nil {
+					testingBeforeProbeLivenessHook()
 				}
 				instancesTable := systemschema.SQLInstancesTable()
 				indexPrefix := l.codec.IndexPrefix(uint32(instancesTable.GetID()), uint32(instancesTable.GetPrimaryIndexID()))

--- a/pkg/sql/regionliveness/prober.go
+++ b/pkg/sql/regionliveness/prober.go
@@ -119,7 +119,7 @@ var testingUnavailableAtTTLOverride time.Duration
 func TestingSetProbeLivenessTimeout(probeCallbackFn func()) func() {
 	testingProbeQueryCallbackFunc = probeCallbackFn
 	return func() {
-		probeCallbackFn = nil
+		testingProbeQueryCallbackFunc = nil
 	}
 }
 


### PR DESCRIPTION
The test was flaky since it would sleep for exactly the same length as the timeout.

---

This also includes other commits to improve the test:

### multiregionccl: don't use require.NoError inside a SucceedsSoon

### multiregionccl: fix testing callback

It was setting the wrong variable to nil.

### multiregionccl: improve name of testing hook

It was called "timeout" but it's actually a hook.

###  multiregionccl: fix ordering of expected/actual params in assertion

### multiregionccl: avoid hanging when test fails 

###  multiregionccl: remove invalid assertion in TestRegionLivenessProberForLeases

This test was calling grp.Wait() twice on the same ctxgroup. The second
call is always guaranteed to return a context cancellation, so the
previous code wasn't really asserting anything.

---


fixes https://github.com/cockroachdb/cockroach/issues/140700
fixes https://github.com/cockroachdb/cockroach/issues/141632
fixes https://github.com/cockroachdb/cockroach/issues/141194
fixes https://github.com/cockroachdb/cockroach/issues/141632
fixes https://github.com/cockroachdb/cockroach/issues/140767