### PR TITLE
stop: prefer launching goroutines at caller

### DIFF
--- a/pkg/kv/kvserver/scheduler.go
+++ b/pkg/kv/kvserver/scheduler.go
@@ -307,21 +307,24 @@ func (s *raftScheduler) Start(stopper *stop.Stopper) {
 
 	for _, shard := range s.shards {
 		s.done.Add(shard.numWorkers)
+		f := func(ctx context.Context, hdl *stop.Handle) {
+			defer hdl.Activate(ctx).Release(ctx)
+			defer s.done.Done()
+			shard.worker(ctx, s.processor, s.metrics)
+		}
+
 		for i := 0; i < shard.numWorkers; i++ {
-			if err := stopper.RunAsyncTaskEx(ctx,
+			ctx, hdl, err := stopper.GetHandle(ctx,
 				stop.TaskOpts{
 					TaskName: "raft-worker",
 					// This task doesn't reference a parent because it runs for the server's
 					// lifetime.
 					SpanOpt: stop.SterileRootSpan,
-				},
-				func(ctx context.Context) {
-					shard.worker(ctx, s.processor, s.metrics)
-					s.done.Done()
-				},
-			); err != nil {
+				})
+			if err != nil {
 				s.done.Done()
 			}
+			go f(ctx, hdl)
 		}
 	}
 }

--- a/pkg/util/stop/BUILD.bazel
+++ b/pkg/util/stop/BUILD.bazel
@@ -2,7 +2,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "stop",
-    srcs = ["stopper.go"],
+    srcs = [
+        "handle.go",
+        "stopper.go",
+    ],
     importpath = "github.com/cockroachdb/cockroach/pkg/util/stop",
     visibility = ["//visibility:public"],
     deps = [
@@ -24,11 +27,13 @@ go_test(
     name = "stop_test",
     size = "small",
     srcs = [
+        "example_test.go",
         "main_test.go",
+        "stopper_bench_test.go",
         "stopper_test.go",
     ],
+    embed = [":stop"],
     deps = [
-        ":stop",
         "//pkg/kv/kvpb",
         "//pkg/testutils",
         "//pkg/util/leaktest",

--- a/pkg/util/stop/example_test.go
+++ b/pkg/util/stop/example_test.go
@@ -1,0 +1,41 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package stop_test
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
+)
+
+// ExampleStopper_GetHandle demonstrates the basic usage of the Handle API.
+func ExampleStopper_GetHandle() {
+	ctx := context.Background()
+
+	s := stop.NewStopper()
+	defer s.Stop(ctx)
+
+	ctx, hdl, err := s.GetHandle(ctx, stop.TaskOpts{})
+	if err != nil {
+		fmt.Println("error:", err)
+		return
+	}
+
+	done := make(chan struct{})
+	go func(ctx context.Context, hdl *stop.Handle) {
+		defer hdl.Activate(ctx).Release(ctx)
+		defer close(done)
+		fmt.Println("Working...")
+	}(ctx, hdl)
+
+	<-done
+	fmt.Println("Done")
+
+	// Output:
+	// Working...
+	// Done
+}

--- a/pkg/util/stop/handle.go
+++ b/pkg/util/stop/handle.go
@@ -1,0 +1,63 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package stop
+
+import (
+	"context"
+	"sync"
+
+	"github.com/cockroachdb/cockroach/pkg/util/growstack"
+	"github.com/cockroachdb/cockroach/pkg/util/quotapool"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing"
+)
+
+var handlePool = sync.Pool{New: func() interface{} {
+	return &Handle{}
+}}
+
+type Handle struct {
+	s        *Stopper
+	taskName string
+	spanOpt  SpanOption
+	alloc    *quotapool.IntAlloc // possibly nil
+	sp       *tracing.Span       // possibly nil (but nil is functional)
+
+	// The below fields are allocated only in Activate, i.e. on the async
+	// goroutine.
+	region region
+}
+
+type activeHandle Handle
+
+type ActiveHandle interface {
+	Release(ctx context.Context)
+	stopperHandleMarker() // makes it easy to navigate to impl
+}
+
+func (hdl *Handle) Activate(ctx context.Context) ActiveHandle {
+	growstack.Grow()
+
+	hdl.region = hdl.s.startRegion(ctx, hdl.taskName)
+	// NB: it's tempting for ergonomics to make `release` a method on `Handle` and
+	// to return `hdl.release` here, but that allocates.
+	return (*activeHandle)(hdl)
+}
+
+func (ah *activeHandle) stopperHandleMarker() {}
+
+// Release must be called in a defer.
+func (ah *activeHandle) Release(ctx context.Context) {
+	hdl := (*Handle)(ah)
+	hdl.s.recover(ctx)
+	hdl.region.End()
+	hdl.sp.Finish()
+	if hdl.alloc != nil {
+		hdl.alloc.Release()
+	}
+	hdl.s.runPostlude()
+	*hdl = Handle{}
+	handlePool.Put(hdl)
+}

--- a/pkg/util/stop/stopper_bench_test.go
+++ b/pkg/util/stop/stopper_bench_test.go
@@ -1,0 +1,70 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package stop
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+)
+
+func BenchmarkStopper(b *testing.B) {
+	defer leaktest.AfterTest(b)()
+	ctx := context.Background()
+	s := NewStopper()
+	defer s.Stop(ctx)
+
+	opts := TaskOpts{
+		TaskName: "testTask",
+	}
+
+	b.Run("RunTask", func(b *testing.B) {
+		b.ReportAllocs()
+		var wg sync.WaitGroup // for fairness
+		wg.Add(b.N)
+		for i := 0; i < b.N; i++ {
+			if err := s.RunTask(ctx, opts.TaskName, func(context.Context) { wg.Done() }); err != nil {
+				b.Fatal(err)
+			}
+		}
+		wg.Wait() // noop
+	})
+
+	b.Run("AsyncTaskEx", func(b *testing.B) {
+		b.ReportAllocs()
+		var wg sync.WaitGroup
+		for i := 0; i < b.N; i++ {
+			wg.Add(1)
+			if err := s.RunAsyncTaskEx(ctx, opts, func(ctx context.Context) {
+				defer wg.Done()
+			}); err != nil {
+				b.Fatal(err)
+			}
+			wg.Wait()
+		}
+	})
+
+	hdlf := func(ctx context.Context, hdl *Handle, wg *sync.WaitGroup) {
+		defer hdl.Activate(ctx).Release(ctx)
+		defer wg.Done()
+	}
+
+	b.Run("Handle", func(b *testing.B) {
+		b.ReportAllocs()
+		var wg sync.WaitGroup
+		for i := 0; i < b.N; i++ {
+			ctx, hdl, err := s.GetHandle(ctx, opts)
+			if err != nil {
+				b.Fatal(err)
+			}
+			wg.Add(1)
+			go hdlf(ctx, hdl, &wg)
+			wg.Wait()
+		}
+	})
+}

--- a/pkg/util/stop/stopper_test.go
+++ b/pkg/util/stop/stopper_test.go
@@ -700,3 +700,45 @@ func TestHandleOnFinishedTraceSpan(t *testing.T) {
 		defer hdl.Activate(ctx).Release(ctx)
 	}(ctx, hdl)
 }
+
+// TestHandleWithoutActivateOrRelease demonstrates that acquiring a Handle
+// without releasing it blocks the stopper on drain, meaning that such mistakes
+// are likely to be caught quickly.
+func TestHandleWithoutActivateOrRelease(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+
+	testutils.RunTrueAndFalse(t, "activate", func(t *testing.T, activate bool) {
+		s := stop.NewStopper()
+		defer s.Stop(ctx)
+
+		ctx, hdl, err := s.GetHandle(ctx, stop.TaskOpts{})
+		require.NoError(t, err)
+
+		relCh := make(chan stop.ActiveHandle, 1)
+		go func() {
+			if activate {
+				relCh <- hdl.Activate(ctx)
+				// Oops, forgot release!
+			} // otherwise, forgot Activate too
+		}()
+
+		stopCh := make(chan struct{})
+		go func() {
+			s.Quiesce(ctx)
+			close(stopCh)
+		}()
+		select {
+		case <-time.After(time.Millisecond):
+			// Expected: we acquired a handle, but never released it.
+		case <-stopCh:
+			t.Fatal("stopper unexpectedly quiesced")
+		}
+		// Release the handle, allowing the deferred Stop to work.
+		if !activate {
+			hdl.Activate(ctx).Release(ctx)
+		} else {
+			(<-relCh).Release(ctx)
+		}
+	})
+}

--- a/pkg/util/stop/stopper_test.go
+++ b/pkg/util/stop/stopper_test.go
@@ -7,7 +7,6 @@ package stop_test
 
 import (
 	"context"
-	"fmt"
 	"runtime"
 	"sync"
 	"sync/atomic"
@@ -569,59 +568,6 @@ func TestStopperRunLimitedAsyncTaskCancelContext(t *testing.T) {
 	}
 }
 
-func maybePrint(context.Context) {
-	if testing.Verbose() { // This just needs to be complicated enough not to inline.
-		fmt.Println("blah")
-	}
-}
-
-func BenchmarkDirectCall(b *testing.B) {
-	defer leaktest.AfterTest(b)()
-	s := stop.NewStopper()
-	ctx := context.Background()
-	defer s.Stop(ctx)
-	for i := 0; i < b.N; i++ {
-		maybePrint(ctx)
-	}
-}
-
-func BenchmarkStopper(b *testing.B) {
-	defer leaktest.AfterTest(b)()
-	ctx := context.Background()
-	s := stop.NewStopper()
-	defer s.Stop(ctx)
-	for i := 0; i < b.N; i++ {
-		if err := s.RunTask(ctx, "test", maybePrint); err != nil {
-			b.Fatal(err)
-		}
-	}
-}
-func BenchmarkDirectCallPar(b *testing.B) {
-	defer leaktest.AfterTest(b)()
-	s := stop.NewStopper()
-	ctx := context.Background()
-	defer s.Stop(ctx)
-	b.RunParallel(func(pb *testing.PB) {
-		for pb.Next() {
-			maybePrint(ctx)
-		}
-	})
-}
-
-func BenchmarkStopperPar(b *testing.B) {
-	defer leaktest.AfterTest(b)()
-	ctx := context.Background()
-	s := stop.NewStopper()
-	defer s.Stop(ctx)
-	b.RunParallel(func(pb *testing.PB) {
-		for pb.Next() {
-			if err := s.RunTask(ctx, "test", maybePrint); err != nil {
-				b.Fatal(err)
-			}
-		}
-	})
-}
-
 func TestCancelInCloser(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	ctx := context.Background()
@@ -728,4 +674,29 @@ func TestStopperRunAsyncTaskCreatesRootSpans(t *testing.T) {
 		))
 		require.Equal(t, hasSpan, <-c != nil)
 	})
+}
+
+// TestHandleOnFinishedTraceSpan shows that we can successfully use the Stopper
+// in situations in which the trace span gets finished after creating the Handle
+// but before launching the task.
+func TestHandleOnFinishedTraceSpan(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	tr := tracing.NewTracer()
+	ctx := context.Background()
+	s := stop.NewStopper(stop.WithTracer(tr))
+	defer s.Stop(ctx)
+
+	ctx, sp := tr.StartSpanCtx(ctx, "root", tracing.WithForceRealSpan())
+	// NB: can't `defer sp.Finish()` here since we'd then double-finish the span
+	// in this test and trip the assertion.
+	ctx, hdl, err := s.GetHandle(ctx, stop.TaskOpts{
+		TaskName: "test",
+		SpanOpt:  stop.ChildSpan,
+	})
+	require.NoError(t, err)
+
+	sp.Finish()
+	go func(ctx context.Context, hdl *stop.Handle) {
+		defer hdl.Activate(ctx).Release(ctx)
+	}(ctx, hdl)
 }


### PR DESCRIPTION
Prior to this change, the only option to launch async tasks was the stopper's
`RunAsyncTask{,Ex}` method. This method would accept a closure and invoke it in
a goroutine.

This has the undesirable property of recording a location in
`Stopper.RunAsyncTaskEx` as the async task's creating goroutine plus its
lowermost call frame. Anyone who's ever looked at any profile (CPU, heap,
anything really) will be familiar with this fact.

This is a particular problem for Go execution traces, since the root call frame
of the goroutine becomes its searchable identity. In other words, it becomes an
ordeal to search for a specific goroutine, since all goroutines started by the
Stopper get assigned the same searchable identity (root stack frame).

Exec trace regions or tasks don't solve this problem because execution traces
only record those that are set _while an execution trace is taken_. We have
numerous long-lived goroutines in the system.

----

We address these difficulties by introducing a new API that obligates the
*callers* to launch the goroutines directly. In doing so, we also shave off all
unnecessary allocations (from three down to just one, for actually launching
the goroutine).

The API is hopefully self-explanatory and reasonably economical - see
`example_test.go`.

The "old way" to start a task via `StartAsyncTaskEx` remains in place. The
hope is that we'll convert all important tasks to `GetHandle`. This can
be done as follow-up work.

----

```
$ go test -run - -bench BenchmarkStopper -v -test.benchtime=3s ./pkg/util/stop/
goos: darwin
goarch: arm64
pkg: github.com/cockroachdb/cockroach/pkg/util/stop
cpu: Apple M1 Pro
BenchmarkStopper
BenchmarkStopper/RunTask
BenchmarkStopper/RunTask-10         	140792008	        25.48 ns/op	       0 B/op	       0 allocs/op
BenchmarkStopper/AsyncTaskEx
BenchmarkStopper/AsyncTaskEx-10     	 3096800	      1169 ns/op	      72 B/op	       3 allocs/op
BenchmarkStopper/Handle
BenchmarkStopper/Handle-10          	 3165979	      1173 ns/op	      48 B/op	       1 allocs/op
PASS
ok  	github.com/cockroachdb/cockroach/pkg/util/stop	16.834s
```

Epic: CRDB-42584
Release note: None