### PR TITLE
sql: add notice delete rate limit is per leaseholder when configured

### DIFF
--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -751,6 +751,13 @@ func (n *alterTableNode) startExec(params runParams) error {
 				return err
 			}
 
+			paramIsDelete := t.StorageParams.GetVal("ttl_delete_rate_limit") != nil
+			paramIsSelect := t.StorageParams.GetVal("ttl_select_rate_limit") != nil
+
+			if paramIsDelete || paramIsSelect {
+				printTTLRateLimitNotice(params.ctx, params.p)
+			}
+
 		case *tree.AlterTableResetStorageParams:
 			setter := tablestorageparam.NewSetter(n.tableDesc)
 			if err := storageparam.Reset(

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -1423,6 +1423,14 @@ func NewTableDesc(
 	); err != nil {
 		return nil, err
 	}
+
+	paramIsDelete := n.StorageParams.GetVal("ttl_delete_rate_limit") != nil
+	paramIsSelect := n.StorageParams.GetVal("ttl_select_rate_limit") != nil
+
+	if paramIsDelete || paramIsSelect {
+		printTTLRateLimitNotice(ctx, evalCtx.ClientNoticeSender)
+	}
+
 	setter.TableDesc.RowLevelTTL = setter.UpdatedRowLevelTTL
 
 	indexEncodingVersion := descpb.StrictIndexColumnIDGuaranteesVersion

--- a/pkg/sql/logictest/testdata/logic_test/cluster_settings
+++ b/pkg/sql/logictest/testdata/logic_test/cluster_settings
@@ -448,3 +448,25 @@ query B
 SHOW CLUSTER SETTING sql.explain_analyze.include_ru_estimation.enabled FOR TENANT "cluster-10"
 ----
 false
+
+subtest notice_on_ttl_default_rate_limit
+
+query T noticetrace
+SET CLUSTER SETTING sql.ttl.default_delete_rate_limit = 90;
+----
+NOTICE: The TTL rate limit is per leaseholder per table.
+DETAIL: See the documentation for additional details: https://www.cockroachlabs.com/docs/dev/row-level-ttl#ttl-storage-parameters
+
+statement ok
+SET CLUSTER SETTING sql.ttl.default_delete_rate_limit = 100;
+
+query T noticetrace
+SET CLUSTER SETTING sql.ttl.default_select_rate_limit = 100;
+----
+NOTICE: The TTL rate limit is per leaseholder per table.
+DETAIL: See the documentation for additional details: https://www.cockroachlabs.com/docs/dev/row-level-ttl#ttl-storage-parameters
+
+statement ok
+SET CLUSTER SETTING sql.ttl.default_select_rate_limit = 0;
+
+subtest end

--- a/pkg/sql/logictest/testdata/logic_test/row_level_ttl
+++ b/pkg/sql/logictest/testdata/logic_test/row_level_ttl
@@ -778,6 +778,7 @@ subtest end
 
 subtest set_ttl_params
 
+onlyif config local-read-committed local-repeatable-read
 statement ok
 CREATE TABLE tbl_set_ttl_params (
   id INT PRIMARY KEY
@@ -793,6 +794,25 @@ CREATE TABLE tbl_set_ttl_params (
   ttl_disable_changefeed_replication = true
 )
 
+skipif config local-read-committed local-repeatable-read
+query T noticetrace
+CREATE TABLE tbl_set_ttl_params (
+  id INT PRIMARY KEY
+) WITH (
+  ttl_expire_after = '10 minutes',
+  ttl_select_batch_size = 10,
+  ttl_delete_batch_size = 20,
+  ttl_select_rate_limit = 30,
+  ttl_delete_rate_limit = 40,
+  ttl_pause = true,
+  ttl_row_stats_poll_interval = '1 minute',
+  ttl_label_metrics = true,
+  ttl_disable_changefeed_replication = true
+)
+----
+NOTICE: The TTL rate limit is per leaseholder per table.
+DETAIL: See the documentation for additional details: https://www.cockroachlabs.com/docs/dev/row-level-ttl#ttl-storage-parameters
+
 query T
 SELECT create_statement FROM [SHOW CREATE TABLE tbl_set_ttl_params]
 ----
@@ -802,6 +822,14 @@ CREATE TABLE public.tbl_set_ttl_params (
   CONSTRAINT tbl_set_ttl_params_pkey PRIMARY KEY (id ASC)
 ) WITH (ttl = 'on', ttl_expire_after = '00:10:00':::INTERVAL, ttl_select_batch_size = 10, ttl_delete_batch_size = 20, ttl_select_rate_limit = 30, ttl_delete_rate_limit = 40, ttl_pause = true, ttl_row_stats_poll_interval = '1m0s', ttl_label_metrics = true, ttl_disable_changefeed_replication = true)
 
+skipif config local-read-committed local-repeatable-read
+query T noticetrace
+ALTER TABLE tbl_set_ttl_params SET (ttl_select_batch_size = 110, ttl_delete_batch_size = 120, ttl_select_rate_limit = 130, ttl_delete_rate_limit = 140, ttl_row_stats_poll_interval = '2m0s')
+----
+NOTICE: The TTL rate limit is per leaseholder per table.
+DETAIL: See the documentation for additional details: https://www.cockroachlabs.com/docs/dev/row-level-ttl#ttl-storage-parameters
+
+onlyif config local-read-committed local-repeatable-read
 statement ok
 ALTER TABLE tbl_set_ttl_params SET (ttl_select_batch_size = 110, ttl_delete_batch_size = 120, ttl_select_rate_limit = 130, ttl_delete_rate_limit = 140, ttl_row_stats_poll_interval = '2m0s')
 

--- a/pkg/sql/set_cluster_setting.go
+++ b/pkg/sql/set_cluster_setting.go
@@ -233,6 +233,10 @@ func (p *planner) SetClusterSetting(
 		return nil, err
 	}
 
+	if name == "sql.ttl.default_delete_rate_limit" || name == "sql.ttl.default_select_rate_limit" {
+		printTTLRateLimitNotice(ctx, p)
+	}
+
 	csNode := setClusterSettingNode{
 		name:    name,
 		st:      st,
@@ -240,6 +244,18 @@ func (p *planner) SetClusterSetting(
 		value:   value,
 	}
 	return &csNode, nil
+}
+
+func printTTLRateLimitNotice(ctx context.Context, p eval.ClientNoticeSender) {
+	ttlDocDetail := "See the documentation for additional details: " +
+		docs.URL("row-level-ttl#ttl-storage-parameters")
+	p.BufferClientNotice(
+		ctx,
+		errors.WithDetail(
+			pgnotice.Newf("The TTL rate limit is per leaseholder per table."),
+			ttlDocDetail,
+		),
+	)
 }
 
 func (p *planner) getAndValidateTypedClusterSetting(


### PR DESCRIPTION
Lots of customers keep getting confused that the TTL rate limit is per leaseholder. With these code changes we now print this notice when the cluster setting `sql.ttl.default_delete_rate_limit` is set:

```
NOTICE: The TTL rate limit is not per leaseholder.
DETAIL:  See the documentation for additional details:https://www.cockroachlabs.com/docs/dev/row-level-ttl
```

Fixes: #140644
Release note: When configuring the `sql.ttl.default_delete_rate_limit` cluster setting a notice is displayed informing that the TTL rate limit is not per leaseholder with a link to the docs.