### PR TITLE
roachtest: add post process step for tpccbench

### DIFF
--- a/pkg/cmd/roachtest/tests/BUILD.bazel
+++ b/pkg/cmd/roachtest/tests/BUILD.bazel
@@ -359,6 +359,7 @@ go_test(
     deps = [
         "//pkg/cmd/roachtest/option",
         "//pkg/cmd/roachtest/registry",
+        "//pkg/cmd/roachtest/roachtestutil",
         "//pkg/cmd/roachtest/roachtestutil/task",
         "//pkg/cmd/roachtest/spec",
         "//pkg/roachprod/logger",
@@ -366,11 +367,13 @@ go_test(
         "//pkg/testutils/skip",
         "//pkg/util/leaktest",
         "//pkg/util/version",
+        "//pkg/workload/tpcc",
         "@com_github_golang_mock//gomock",
         "@com_github_google_go_github//github",
         "@com_github_prometheus_client_golang//prometheus/promauto",
         "@com_github_prometheus_common//model",
         "@com_github_stretchr_testify//require",
+        "@org_golang_x_exp//rand",
         "@org_golang_x_oauth2//:oauth2",
     ],
 )


### PR DESCRIPTION
This PR builds upon https://github.com/cockroachdb/cockroach/pull/138617
and adds the post process step for `tpccbench` benchmark. The following
metrics are emitted
1. `tpmc` and `effiency` of each warehouse
2. max warehouse which is over the threshold efficiency of 85%

Epic: https://cockroachlabs.atlassian.net/browse/CRDB-41852
    
Release note: None
