### PR TITLE
performance: disable Transparent Huge Pages on Linux

### DIFF
--- a/pkg/cmd/cockroach/main.go
+++ b/pkg/cmd/cockroach/main.go
@@ -8,6 +8,8 @@
 // The ccl hook import below means building this will produce CCL'ed binaries.
 // This file itself remains Apache2 to preserve the organization of ccl code
 // under the /pkg/ccl subtree, but is unused for pure FLOSS builds.
+
+//go:debug disablethp=1
 package main
 
 import (


### PR DESCRIPTION
Prior to Go 1.21, the Go runtime contained mitigations for memory management issues arising from interactions with THP. When those mitigations were removed (for performance reasons), our customers started to see inefficient memory usage and OOMs in some cases.

Adding the `disablethp` GODEBUG flag causes the runtime to opt out of THP at the process level, which is the right thing for CRDB.

Epic: none

Fixes: https://cockroachlabs.atlassian.net/browse/TREQ-888

Release note (performance improvement): Cockroach will now opt out of Transparent Huge Pages on Linux, improving memory efficiency on some system configurations.