### PR TITLE
packer: TeamCity agent with rcodesign

### DIFF
--- a/build/packer/setup_signing.sh
+++ b/build/packer/setup_signing.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# Copyright 2023 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
+set -euo pipefail
+
+# Install rustup, because the current rustc version is too old to build apple-codesign.
+apt-get install --yes rustup
+apt-get clean
+rustup default stable
+cargo install --root=/usr/local apple-codesign@0.29.0

--- a/build/packer/teamcity-agent-x86-signing.json
+++ b/build/packer/teamcity-agent-x86-signing.json
@@ -1,0 +1,39 @@
+{
+  "variables": {
+    "image_id": "teamcity-agent-signing-{{timestamp}}"
+  },
+
+  "builders": [{
+      "type": "googlecompute",
+      "account_file": "gcp_credentials.json",
+      "project_id": "crl-teamcity-agents",
+      "source_image_family": "ubuntu-2404-lts-amd64",
+      "zone": "us-east1-b",
+      "machine_type": "n2-standard-32",
+      "image_name": "{{user `image_id`}}",
+      "image_description": "{{user `image_id`}}",
+      "ssh_username": "packer",
+      "disk_size": 256,
+      "disk_type": "pd-ssd",
+      "tags": ["ssh-server"],
+      "state_timeout": "15m"
+  }],
+
+  "provisioners": [{
+    "type": "shell",
+    "script": "teamcity-agent.sh",
+    "execute_command": "sudo sh -c '{{ .Vars }} {{ .Path }}'"
+  },{
+    "type": "shell",
+    "script": "setup_signing.sh",
+    "execute_command": "sudo sh -c '{{ .Vars }} {{ .Path }}'"
+  },{
+    "type": "file",
+    "source": "filebeat/filebeat-agent.yml",
+    "destination": "/tmp/filebeat.yml"
+  },{
+    "type": "shell",
+    "script": "setup_filebeat_on_teamcity_agent.sh",
+    "execute_command": "sudo sh -c '{{ .Vars }} {{ .Path }}'"
+  }]
+}

--- a/build/packer/teamcity-agent.sh
+++ b/build/packer/teamcity-agent.sh
@@ -25,7 +25,7 @@ ARCH=$(uname -m)
 # Add third-party APT repositories.
 apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0EBFCD88
 cat > /etc/apt/sources.list.d/docker.list <<EOF
-deb https://download.docker.com/linux/ubuntu focal stable
+deb https://download.docker.com/linux/ubuntu $(lsb_release -cs) stable
 EOF
 
 curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
@@ -41,6 +41,10 @@ sleep 3m
 add-apt-repository ppa:git-core/ppa
 apt-get update
 
+python_packages="python3"
+if [[ $(lsb_release -cs) = "focal" ]]; then
+    python_packages="$python_packages python2"
+fi
 # Installing gnome-keyring prevents the error described in
 # https://github.com/moby/moby/issues/34048
 apt-get install --yes \
@@ -60,15 +64,14 @@ apt-get install --yes \
   jq \
   openjdk-11-jre-headless \
   pass \
-  python2 \
-  python3 \
+  $python_packages \
   sudo \
   unzip \
   zip
 
 # Enable support for executing binaries of all architectures via qemu emulation
 # (necessary for building arm64 Docker images)
-apt-get install --yes qemu binfmt-support qemu-user-static
+apt-get install --yes binfmt-support qemu-user-static
 
 # Verify that both of the platforms we support Docker for can be built.
 if [[ $ARCH = x86_64 ]]; then


### PR DESCRIPTION
This PR creates a TeamCity agent VM image, based on Ubuntu 24.04, which installs `rcodesign`.

Part of: DEVINF-1406