### PR TITLE
testserver: introduce StartSlimServer

### DIFF
--- a/pkg/base/test_server_args.go
+++ b/pkg/base/test_server_args.go
@@ -169,6 +169,52 @@ type TestServerArgs struct {
 	// CockroachDB upgrades and periodically reports diagnostics to
 	// Cockroach Labs. Should remain disabled during unit testing.
 	StartDiagnosticsReporting bool
+
+	SlimTestSeverConfig *SlimTestServerConfig
+}
+
+type slimOptions struct {
+	EnableSpanConfigJob bool
+	EnableAutoStats     bool
+	EnableTimeseries    bool
+}
+
+type SlimServerOption func(*slimOptions)
+
+func WithSpanConfigJob() SlimServerOption {
+	return func(o *slimOptions) {
+		o.EnableSpanConfigJob = true
+	}
+}
+
+func WithAutoStats() SlimServerOption {
+	return func(o *slimOptions) {
+		o.EnableAutoStats = true
+	}
+}
+
+func WithTimeseries() SlimServerOption {
+	return func(o *slimOptions) {
+		o.EnableTimeseries = true
+	}
+}
+
+func processOptions(opts []SlimServerOption) *slimOptions {
+	ret := &slimOptions{}
+	for _, o := range opts {
+		o(ret)
+	}
+	return ret
+}
+
+func (a *TestServerArgs) SlimServerConfig(opts ...SlimServerOption) {
+	a.SlimTestSeverConfig = &SlimTestServerConfig{
+		Options: *processOptions(opts),
+	}
+}
+
+type SlimTestServerConfig struct {
+	Options slimOptions
 }
 
 // TestClusterArgs contains the parameters one can set when creating a test

--- a/pkg/server/testserver_test.go
+++ b/pkg/server/testserver_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -71,7 +72,6 @@ func TestServerStartup(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-
 		args := base.TestServerArgs{
 			DefaultTestTenant: tc.tenantOpt,
 			Settings:          cluster.MakeTestingClusterSettings(),
@@ -80,8 +80,16 @@ func TestServerStartup(t *testing.T) {
 		kvserver.RaftLeaderFortificationFractionEnabled.Override(context.Background(), &args.Settings.SV, 0.0)
 
 		t.Run(tc.name, func(t *testing.T) {
-			s := serverutils.StartServerOnly(t, args)
-			s.Stopper().Stop(context.Background())
+			testutils.RunTrueAndFalse(t, "slim", func(t *testing.T, useSlimServer bool) {
+				var s serverutils.TestServerInterface
+				if useSlimServer {
+					s = serverutils.StartSlimServerOnly(t, args)
+				} else {
+					s = serverutils.StartServerOnly(t, args)
+
+				}
+				s.Stopper().Stop(context.Background())
+			})
 		})
 	}
 }

--- a/pkg/spanconfig/spanconfigmanager/manager.go
+++ b/pkg/spanconfig/spanconfigmanager/manager.go
@@ -38,7 +38,7 @@ var checkReconciliationJobInterval = settings.RegisterDurationSetting(
 //
 // TODO(irfansharif): This should be a tenant read-only setting once the work
 // for #73349 is completed.
-var jobEnabledSetting = settings.RegisterBoolSetting(
+var JobEnabledSetting = settings.RegisterBoolSetting(
 	settings.ApplicationLevel,
 	"spanconfig.reconciliation_job.enabled",
 	"enable the use of the kv accessor", true)
@@ -109,7 +109,7 @@ func (m *Manager) run(ctx context.Context) {
 	//   skip starting the reconciliation job, learning about the cluster
 	//   version shortly, and only checking the job after an interval has
 	//   passed.
-	jobEnabledSetting.SetOnChange(&m.settings.SV, func(ctx context.Context) {
+	JobEnabledSetting.SetOnChange(&m.settings.SV, func(ctx context.Context) {
 		triggerJobCheck()
 	})
 	checkReconciliationJobInterval.SetOnChange(&m.settings.SV, func(ctx context.Context) {
@@ -124,7 +124,7 @@ func (m *Manager) run(ctx context.Context) {
 			fn()
 		}
 
-		if !jobEnabledSetting.Get(&m.settings.SV) {
+		if !JobEnabledSetting.Get(&m.settings.SV) {
 			return
 		}
 

--- a/pkg/testutils/serverutils/test_server_shim.go
+++ b/pkg/testutils/serverutils/test_server_shim.go
@@ -293,6 +293,24 @@ func StartServerOnly(t TestFataler, params base.TestServerArgs) TestServerInterf
 	return s
 }
 
+var ConfigureSlimTestServer func(params base.TestServerArgs) base.TestServerArgs
+
+func StartSlimServerOnly(
+	t TestFataler, params base.TestServerArgs, slimOpts ...base.SlimServerOption,
+) TestServerInterface {
+	params.SlimServerConfig(slimOpts...)
+	return StartServerOnly(t, params)
+}
+
+func StartSlimServer(
+	t TestFataler, params base.TestServerArgs, slimOpts ...base.SlimServerOption,
+) (TestServerInterface, *gosql.DB, *kv.DB) {
+	s := StartSlimServerOnly(t, params, slimOpts...)
+	goDB := s.ApplicationLayer().SQLConn(t, DBName(params.UseDatabase))
+	kvDB := s.ApplicationLayer().DB()
+	return s, goDB, kvDB
+}
+
 // StartServer creates and starts a test server.
 // The returned server should be stopped by calling
 // server.Stopper().Stop().


### PR DESCRIPTION
This patch introduces a new API for initializing a test server with a default
configuration that reduces server background work, and subequently, a faster
startup time. Currently, the slim server disables the time series db, auto
stats collection, and the span config reconcilation job. Each of these can be
reenabled by passing functional args to StartSlimServer. Future patches will
remove additional bells and whistles from the server. With these background
tasks disabled, slim server is 0.1 seconds faster under stress to startup
relative to a regular server.

```
./dev test pkg/server -f TestServerStartup/SystemTenantOnly/slim=false --stress --count=100 --ignore-cache
Stats over 100 runs: max = 2.1s, min = 1.0s, avg = 1.8s, dev = 0.2s

./dev test pkg/server -f TestServerStartup/SystemTenantOnly/slim=true --stress --count=100 --ignore-cache
Stats over 100 runs: max = 2.0s, min = 1.0s, avg = 1.7s, dev = 0.2s
```

Epic: none

Release note: none