### PR TITLE
changefeedccl: per-row header support for kafka

### DIFF
--- a/pkg/ccl/changefeedccl/avro/avro_test.go
+++ b/pkg/ccl/changefeedccl/avro/avro_test.go
@@ -160,7 +160,7 @@ func parseAvroSchema(t *testing.T, evalCtx *eval.Context, j string) (*DataRecord
 	return TableToAvroSchema(
 		cdcevent.TestingMakeEventRow(
 			tabledesc.NewBuilder(&tableDesc).BuildImmutableTable(), 0, nil, false,
-		), "", "")
+		), "", "", "")
 }
 
 func avroFieldMetadataToColDesc(
@@ -401,7 +401,7 @@ func TestAvroSchema(t *testing.T) {
 			require.NoError(t, err)
 			origSchema, err := TableToAvroSchema(
 				cdcevent.TestingMakeEventRow(tableDesc, 0, nil, false),
-				SchemaNoSuffix, "")
+				SchemaNoSuffix, "", "")
 			require.NoError(t, err)
 			jsonSchema := origSchema.codec.Schema()
 			roundtrippedSchema, err := parseAvroSchema(t, evalCtx, jsonSchema)
@@ -441,7 +441,7 @@ func TestAvroSchema(t *testing.T) {
 		tableDesc, err := parseTableDesc(`CREATE TABLE "☃" (🍦 INT PRIMARY KEY)`)
 		require.NoError(t, err)
 		tableSchema, err := TableToAvroSchema(
-			cdcevent.TestingMakeEventRow(tableDesc, 0, nil, false), SchemaNoSuffix, "")
+			cdcevent.TestingMakeEventRow(tableDesc, 0, nil, false), SchemaNoSuffix, "", "")
 		require.NoError(t, err)
 		require.Equal(t,
 			`{"type":"record","name":"_u2603_","fields":[`+
@@ -685,7 +685,7 @@ func TestAvroSchema(t *testing.T) {
 
 			row := cdcevent.TestingMakeEventRow(tableDesc, 0, encDatums[0], false)
 			schema, err := TableToAvroSchema(
-				row, SchemaNoSuffix, "")
+				row, SchemaNoSuffix, "", "")
 			require.NoError(t, err)
 			if test.numRawBytes > 0 {
 				overhead := 4
@@ -742,7 +742,7 @@ func TestAvroSchema(t *testing.T) {
 			require.NoError(t, err)
 
 			row := cdcevent.TestingMakeEventRow(tableDesc, 0, encDatums[0], false)
-			schema, err := TableToAvroSchema(row, SchemaNoSuffix, "")
+			schema, err := TableToAvroSchema(row, SchemaNoSuffix, "", "")
 			require.NoError(t, err)
 			textual, err := schema.textualFromRow(row)
 			require.NoError(t, err)
@@ -846,13 +846,13 @@ func TestAvroMigration(t *testing.T) {
 				fmt.Sprintf(`CREATE TABLE "%s" %s`, test.name, test.writerSchema))
 			require.NoError(t, err)
 			writerSchema, err := TableToAvroSchema(
-				cdcevent.TestingMakeEventRow(writerDesc, 0, nil, false), SchemaNoSuffix, "")
+				cdcevent.TestingMakeEventRow(writerDesc, 0, nil, false), SchemaNoSuffix, "", "")
 			require.NoError(t, err)
 			readerDesc, err := parseTableDesc(
 				fmt.Sprintf(`CREATE TABLE "%s" %s`, test.name, test.readerSchema))
 			require.NoError(t, err)
 			readerSchema, err := TableToAvroSchema(
-				cdcevent.TestingMakeEventRow(readerDesc, 0, nil, false), SchemaNoSuffix, "")
+				cdcevent.TestingMakeEventRow(readerDesc, 0, nil, false), SchemaNoSuffix, "", "")
 			require.NoError(t, err)
 
 			writerRows, err := parseValues(writerDesc, `VALUES `+test.writerValues)
@@ -930,7 +930,7 @@ func benchmarkEncodeType(b *testing.B, typ *types.T, encRow rowenc.EncDatumRow) 
 		fmt.Sprintf(`CREATE TABLE bench_table (bench_field %s)`, typ.SQLString()))
 	require.NoError(b, err)
 	row := cdcevent.TestingMakeEventRow(tableDesc, 0, encRow, false)
-	schema, err := TableToAvroSchema(row, "suffix", "namespace")
+	schema, err := TableToAvroSchema(row, "suffix", "namespace", "")
 	require.NoError(b, err)
 
 	b.ReportAllocs()

--- a/pkg/ccl/changefeedccl/cdctest/testfeed.go
+++ b/pkg/ccl/changefeedccl/cdctest/testfeed.go
@@ -27,12 +27,31 @@ type TestFeedFactory interface {
 	AsUser(user string, fn func(runner *sqlutils.SQLRunner)) error
 }
 
+type Header struct {
+	K string
+	V []byte
+}
+
+type Headers []Header
+
+func (h Headers) String() string {
+	if len(h) == 0 {
+		return ""
+	}
+	s := "("
+	for _, v := range h {
+		s += fmt.Sprintf("%s: %s, ", v.K, v.V)
+	}
+	return s[:len(s)-2] + ")"
+}
+
 // TestFeedMessage represents one row update or resolved timestamp message from
 // a changefeed.
 type TestFeedMessage struct {
 	Topic, Partition string
 	Key, Value       []byte
 	Resolved         []byte
+	Headers          Headers
 
 	// RawMessage is the sink-specific message type.
 	RawMessage interface{}
@@ -42,7 +61,7 @@ func (m TestFeedMessage) String() string {
 	if m.Resolved != nil {
 		return string(m.Resolved)
 	}
-	return fmt.Sprintf(`%s: %s->%s`, m.Topic, m.Key, m.Value)
+	return fmt.Sprintf(`%s: %s%s->%s`, m.Topic, m.Key, m.Headers.String(), m.Value)
 }
 
 // TestFeed abstracts over reading from the various types of

--- a/pkg/ccl/changefeedccl/changefeedbase/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/changefeedbase/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",
+        "//pkg/sql/types",
         "//pkg/util",
         "//pkg/util/iterutil",
         "//pkg/util/metamorphic",

--- a/pkg/ccl/changefeedccl/changefeedvalidators/table_validator.go
+++ b/pkg/ccl/changefeedccl/changefeedvalidators/table_validator.go
@@ -89,6 +89,16 @@ func validateTable(
 		}
 	}
 
+	for name, typ := range canHandle.RequiredColumnTypes {
+		col := catalog.FindColumnByName(tableDesc, name)
+		if col == nil {
+			return errors.Errorf("required column %s not present on table %s", name, tableDesc.GetName())
+		}
+		if !col.GetType().Equivalent(typ) {
+			return errors.Errorf("column %s of type %s does not match required type %s", name, col.GetType(), typ)
+		}
+	}
+
 	return err
 }
 

--- a/pkg/ccl/changefeedccl/helpers_test.go
+++ b/pkg/ccl/changefeedccl/helpers_test.go
@@ -121,9 +121,10 @@ func readNextMessages(
 		if len(m.Key) > 0 || len(m.Value) > 0 {
 			actual = append(actual,
 				cdctest.TestFeedMessage{
-					Topic: m.Topic,
-					Key:   m.Key,
-					Value: m.Value,
+					Topic:   m.Topic,
+					Key:     m.Key,
+					Value:   m.Value,
+					Headers: m.Headers,
 				},
 			)
 		}
@@ -240,7 +241,7 @@ func assertPayloadsBaseErr(
 
 	var actualFormatted []string
 	for _, m := range actual {
-		actualFormatted = append(actualFormatted, fmt.Sprintf(`%s: %s->%s`, m.Topic, m.Key, m.Value))
+		actualFormatted = append(actualFormatted, m.String())
 	}
 
 	if perKeyOrdered {

--- a/pkg/ccl/changefeedccl/parquet_sink_cloudstorage.go
+++ b/pkg/ccl/changefeedccl/parquet_sink_cloudstorage.go
@@ -108,6 +108,7 @@ func (parquetSink *parquetCloudStorageSink) EmitRow(
 	key, value []byte,
 	updated, mvcc hlc.Timestamp,
 	alloc kvevent.Alloc,
+	headers rowHeaders,
 ) error {
 	return errors.AssertionFailedf("EmitRow unimplemented by the parquet cloud storage sink")
 }

--- a/pkg/ccl/changefeedccl/sink_cloudstorage.go
+++ b/pkg/ccl/changefeedccl/sink_cloudstorage.go
@@ -548,6 +548,7 @@ func (s *cloudStorageSink) EmitRow(
 	key, value []byte,
 	updated, mvcc hlc.Timestamp,
 	alloc kvevent.Alloc,
+	headers rowHeaders,
 ) (retErr error) {
 	if s.files == nil {
 		return errors.New(`cannot EmitRow on a closed sink`)
@@ -570,7 +571,7 @@ func (s *cloudStorageSink) EmitRow(
 		}
 	}()
 
-	s.metrics.recordMessageSize(int64(len(key) + len(value)))
+	s.metrics.recordMessageSize(int64(len(key) + len(value) + headersLen(headers)))
 	file, err := s.getOrCreateFile(topic, mvcc)
 	if err != nil {
 		return err

--- a/pkg/ccl/changefeedccl/sink_cloudstorage_test.go
+++ b/pkg/ccl/changefeedccl/sink_cloudstorage_test.go
@@ -214,7 +214,7 @@ func TestCloudStorageSink(t *testing.T) {
 		defer func() { require.NoError(t, s.Close()) }()
 		s.(*cloudStorageSink).sinkID = 7 // Force a deterministic sinkID.
 
-		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`v1`), ts(1), ts(1), zeroAlloc))
+		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`v1`), ts(1), ts(1), zeroAlloc, nil))
 		require.NoError(t, s.Flush(ctx))
 
 		require.Equal(t, []string{
@@ -274,9 +274,9 @@ func TestCloudStorageSink(t *testing.T) {
 				// the ordering among these two files is non-deterministic as either of them could
 				// be flushed first (and thus be assigned fileID 0).
 				var pool testAllocPool
-				require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`v1`), ts(1), ts(1), pool.alloc()))
-				require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`v2`), ts(1), ts(1), pool.alloc()))
-				require.NoError(t, s.EmitRow(ctx, t2, noKey, []byte(`w1`), ts(3), ts(3), pool.alloc()))
+				require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`v1`), ts(1), ts(1), pool.alloc(), nil))
+				require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`v2`), ts(1), ts(1), pool.alloc(), nil))
+				require.NoError(t, s.EmitRow(ctx, t2, noKey, []byte(`w1`), ts(3), ts(3), pool.alloc(), nil))
 				require.NoError(t, s.Flush(ctx))
 				require.EqualValues(t, 0, pool.used())
 				expected := []string{
@@ -294,7 +294,7 @@ func TestCloudStorageSink(t *testing.T) {
 				require.Equal(t, expected, actual)
 
 				// Without a flush, nothing new shows up.
-				require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`v3`), ts(3), ts(3), zeroAlloc))
+				require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`v3`), ts(3), ts(3), zeroAlloc, nil))
 				actual = slurpDir(t)
 				sort.Strings(actual)
 				require.Equal(t, expected, actual)
@@ -313,9 +313,9 @@ func TestCloudStorageSink(t *testing.T) {
 				// after the rows emitted above.
 				require.True(t, forwardFrontier(sf, testSpan, 4))
 				require.NoError(t, s.Flush(ctx))
-				require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`v4`), ts(4), ts(4), zeroAlloc))
+				require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`v4`), ts(4), ts(4), zeroAlloc, nil))
 				t1.Version = 2
-				require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`v5`), ts(5), ts(5), zeroAlloc))
+				require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`v5`), ts(5), ts(5), zeroAlloc, nil))
 				require.NoError(t, s.Flush(ctx))
 				expected = []string{
 					"v4\n",
@@ -359,8 +359,8 @@ func TestCloudStorageSink(t *testing.T) {
 		// Each node writes some data at the same timestamp. When this data is
 		// written out, the files have different names and don't conflict because
 		// the sinks have different job session IDs.
-		require.NoError(t, s1.EmitRow(ctx, t1, noKey, []byte(`v1`), ts(1), ts(1), zeroAlloc))
-		require.NoError(t, s2.EmitRow(ctx, t1, noKey, []byte(`w1`), ts(1), ts(1), zeroAlloc))
+		require.NoError(t, s1.EmitRow(ctx, t1, noKey, []byte(`v1`), ts(1), ts(1), zeroAlloc, nil))
+		require.NoError(t, s2.EmitRow(ctx, t1, noKey, []byte(`w1`), ts(1), ts(1), zeroAlloc, nil))
 		require.NoError(t, s1.Flush(ctx))
 		require.NoError(t, s2.Flush(ctx))
 		require.Equal(t, []string{
@@ -394,8 +394,8 @@ func TestCloudStorageSink(t *testing.T) {
 		s1R.(*cloudStorageSink).jobSessionID = "a"
 		s2R.(*cloudStorageSink).jobSessionID = "b"
 		// Each resends the data it did before.
-		require.NoError(t, s1R.EmitRow(ctx, t1, noKey, []byte(`v1`), ts(1), ts(1), zeroAlloc))
-		require.NoError(t, s2R.EmitRow(ctx, t1, noKey, []byte(`w1`), ts(1), ts(1), zeroAlloc))
+		require.NoError(t, s1R.EmitRow(ctx, t1, noKey, []byte(`v1`), ts(1), ts(1), zeroAlloc, nil))
+		require.NoError(t, s2R.EmitRow(ctx, t1, noKey, []byte(`w1`), ts(1), ts(1), zeroAlloc, nil))
 		require.NoError(t, s1R.Flush(ctx))
 		require.NoError(t, s2R.Flush(ctx))
 		// s1 data ends up being overwritten, s2 data ends up duplicated.
@@ -437,17 +437,17 @@ func TestCloudStorageSink(t *testing.T) {
 		s2.(*cloudStorageSink).jobSessionID = "b" // Force deterministic job session ID.
 
 		// Good job writes
-		require.NoError(t, s1.EmitRow(ctx, t1, noKey, []byte(`v1`), ts(1), ts(1), zeroAlloc))
-		require.NoError(t, s1.EmitRow(ctx, t1, noKey, []byte(`v2`), ts(2), ts(2), zeroAlloc))
+		require.NoError(t, s1.EmitRow(ctx, t1, noKey, []byte(`v1`), ts(1), ts(1), zeroAlloc, nil))
+		require.NoError(t, s1.EmitRow(ctx, t1, noKey, []byte(`v2`), ts(2), ts(2), zeroAlloc, nil))
 		require.NoError(t, s1.Flush(ctx))
 
 		// Zombie job writes partial duplicate data
-		require.NoError(t, s2.EmitRow(ctx, t1, noKey, []byte(`v1`), ts(1), ts(1), zeroAlloc))
+		require.NoError(t, s2.EmitRow(ctx, t1, noKey, []byte(`v1`), ts(1), ts(1), zeroAlloc, nil))
 		require.NoError(t, s2.Flush(ctx))
 
 		// Good job continues. There are duplicates in the data but nothing was
 		// lost.
-		require.NoError(t, s1.EmitRow(ctx, t1, noKey, []byte(`v3`), ts(3), ts(3), zeroAlloc))
+		require.NoError(t, s1.EmitRow(ctx, t1, noKey, []byte(`v3`), ts(3), ts(3), zeroAlloc, nil))
 		require.NoError(t, s1.Flush(ctx))
 		require.Equal(t, []string{
 			"v1\nv2\n",
@@ -477,7 +477,7 @@ func TestCloudStorageSink(t *testing.T) {
 		// Writing more than the max file size chunks the file up and flushes it
 		// out as necessary.
 		for i := int64(1); i <= 5; i++ {
-			require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(fmt.Sprintf(`v%d`, i)), ts(i), ts(i), zeroAlloc))
+			require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(fmt.Sprintf(`v%d`, i)), ts(i), ts(i), zeroAlloc, nil))
 		}
 		require.NoError(t, waitAsyncFlush(s))
 		require.Equal(t, []string{
@@ -500,7 +500,7 @@ func TestCloudStorageSink(t *testing.T) {
 		// Some more data is written. Some of it flushed out because of the max
 		// file size.
 		for i := int64(6); i < 10; i++ {
-			require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(fmt.Sprintf(`v%d`, i)), ts(i), ts(i), zeroAlloc))
+			require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(fmt.Sprintf(`v%d`, i)), ts(i), ts(i), zeroAlloc, nil))
 		}
 		require.NoError(t, waitAsyncFlush(s))
 		require.Equal(t, []string{
@@ -624,7 +624,7 @@ func TestCloudStorageSink(t *testing.T) {
 						require.NoError(t, err)
 						require.NoError(t, s.Flush(ctx))
 
-						require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(fmt.Sprintf(`v%d`, i)), hlcTime, hlcTime, zeroAlloc))
+						require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(fmt.Sprintf(`v%d`, i)), hlcTime, hlcTime, zeroAlloc, nil))
 					}
 
 					require.NoError(t, s.Flush(ctx)) // Flush the last file
@@ -650,8 +650,8 @@ func TestCloudStorageSink(t *testing.T) {
 
 		// Simulate initial scan, which emits data at a timestamp, then an equal
 		// resolved timestamp.
-		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`is1`), ts(1), ts(1), zeroAlloc))
-		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`is2`), ts(1), ts(1), zeroAlloc))
+		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`is1`), ts(1), ts(1), zeroAlloc, nil))
+		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`is2`), ts(1), ts(1), zeroAlloc, nil))
 		require.NoError(t, s.Flush(ctx))
 		require.NoError(t, s.EmitResolvedTimestamp(ctx, e, ts(1)))
 
@@ -661,13 +661,13 @@ func TestCloudStorageSink(t *testing.T) {
 		// be after the resolved timestamp emitted above.
 		require.True(t, forwardFrontier(sf, testSpan, 2))
 		require.NoError(t, s.Flush(ctx))
-		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`e2`), ts(2), ts(2), zeroAlloc))
-		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`e3prev`), ts(3).Prev(), ts(3).Prev(), zeroAlloc))
-		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`e3`), ts(3), ts(3), zeroAlloc))
+		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`e2`), ts(2), ts(2), zeroAlloc, nil))
+		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`e3prev`), ts(3).Prev(), ts(3).Prev(), zeroAlloc, nil))
+		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`e3`), ts(3), ts(3), zeroAlloc, nil))
 		require.True(t, forwardFrontier(sf, testSpan, 3))
 		require.NoError(t, s.Flush(ctx))
 		require.NoError(t, s.EmitResolvedTimestamp(ctx, e, ts(3)))
-		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`e3next`), ts(3).Next(), ts(3).Next(), zeroAlloc))
+		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`e3next`), ts(3).Next(), ts(3).Next(), zeroAlloc, nil))
 		require.NoError(t, s.Flush(ctx))
 		require.NoError(t, s.EmitResolvedTimestamp(ctx, e, ts(4)))
 
@@ -682,7 +682,7 @@ func TestCloudStorageSink(t *testing.T) {
 
 		// Test that files with timestamp lower than the least resolved timestamp
 		// as of file creation time are ignored.
-		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`noemit`), ts(1).Next(), ts(1).Next(), zeroAlloc))
+		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`noemit`), ts(1).Next(), ts(1).Next(), zeroAlloc, nil))
 		require.Equal(t, []string{
 			"is1\nis2\n",
 			`{"resolved":"1.0000000000"}`,
@@ -706,13 +706,13 @@ func TestCloudStorageSink(t *testing.T) {
 		require.NoError(t, err)
 		defer func() { require.NoError(t, s.Close()) }()
 
-		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`v1`), ts(1), ts(1), zeroAlloc))
+		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`v1`), ts(1), ts(1), zeroAlloc, nil))
 		t1.Version = 1
-		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`v3`), ts(1), ts(1), zeroAlloc))
+		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`v3`), ts(1), ts(1), zeroAlloc, nil))
 		// Make the first file exceed its file size threshold. This should trigger a flush
 		// for the first file but not the second one.
 		t1.Version = 0
-		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`trigger-flush-v1`), ts(1), ts(1), zeroAlloc))
+		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`trigger-flush-v1`), ts(1), ts(1), zeroAlloc, nil))
 		require.NoError(t, waitAsyncFlush(s))
 		require.Equal(t, []string{
 			"v1\ntrigger-flush-v1\n",
@@ -720,9 +720,9 @@ func TestCloudStorageSink(t *testing.T) {
 
 		// Now make the file with the newer schema exceed its file size threshold and ensure
 		// that the file with the older schema is flushed (and ordered) before.
-		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`v2`), ts(1), ts(1), zeroAlloc))
+		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`v2`), ts(1), ts(1), zeroAlloc, nil))
 		t1.Version = 1
-		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`trigger-flush-v3`), ts(1), ts(1), zeroAlloc))
+		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`trigger-flush-v3`), ts(1), ts(1), zeroAlloc, nil))
 		require.NoError(t, waitAsyncFlush(s))
 		require.Equal(t, []string{
 			"v1\ntrigger-flush-v1\n",
@@ -731,9 +731,9 @@ func TestCloudStorageSink(t *testing.T) {
 		}, slurpDir(t))
 
 		// Calling `Flush()` on the sink should emit files in the order of their schema IDs.
-		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`w1`), ts(1), ts(1), zeroAlloc))
+		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`w1`), ts(1), ts(1), zeroAlloc, nil))
 		t1.Version = 0
-		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`x1`), ts(1), ts(1), zeroAlloc))
+		require.NoError(t, s.EmitRow(ctx, t1, noKey, []byte(`x1`), ts(1), ts(1), zeroAlloc, nil))
 		require.NoError(t, s.Flush(ctx))
 		require.Equal(t, []string{
 			"v1\ntrigger-flush-v1\n",
@@ -770,7 +770,7 @@ func TestCloudStorageSink(t *testing.T) {
 				// Write few megs worth of data.
 				for n := 0; n < 20; n++ {
 					eventTS := ts(int64(n + 1))
-					require.NoError(t, s.EmitRow(ctx, topic, noKey, data, eventTS, eventTS, zeroAlloc))
+					require.NoError(t, s.EmitRow(ctx, topic, noKey, data, eventTS, eventTS, zeroAlloc, nil))
 				}
 
 				// Close the sink.  That's it -- we rely on leaktest detector to determine
@@ -816,7 +816,7 @@ func TestCloudStorageSink(t *testing.T) {
 					// Write few megs worth of data.
 					for n := 0; n < 20; n++ {
 						eventTS := ts(int64(n + 1))
-						require.NoError(t, s.EmitRow(ctx, topic, noKey, data, eventTS, eventTS, zeroAlloc))
+						require.NoError(t, s.EmitRow(ctx, topic, noKey, data, eventTS, eventTS, zeroAlloc, nil))
 					}
 					cancledCtx, cancel := context.WithCancel(ctx)
 					cancel()
@@ -824,7 +824,7 @@ func TestCloudStorageSink(t *testing.T) {
 					// Write 1 more piece of data.  We want to make sure that when error happens
 					// (context cancellation in this case) that any resources used by compression
 					// codec are released (this is checked by leaktest).
-					require.Equal(t, context.Canceled, s.EmitRow(cancledCtx, topic, noKey, data, ts(1), ts(1), zeroAlloc))
+					require.Equal(t, context.Canceled, s.EmitRow(cancledCtx, topic, noKey, data, ts(1), ts(1), zeroAlloc, nil))
 				}()
 			})
 		}
@@ -904,7 +904,7 @@ func TestCloudStorageSinkFastGzip(t *testing.T) {
 			newTopic := makeTopic(fmt.Sprintf(`t%d`, i))
 			byteSlice := make([]byte, sizeInBytes)
 			ts := hlc.Timestamp{WallTime: int64(i)}
-			_ = s.EmitRow(ctx, newTopic, noKey, byteSlice, ts, ts, zeroAlloc)
+			_ = s.EmitRow(ctx, newTopic, noKey, byteSlice, ts, ts, zeroAlloc, nil)
 		}
 
 		// Flush the files and close the sink. Any leaks should be caught after the
@@ -930,7 +930,7 @@ func TestCloudStorageSinkFastGzip(t *testing.T) {
 			byteSlice := make([]byte, sizeInBytes)
 			ts := hlc.Timestamp{WallTime: int64(i)}
 			newTopic.Version++
-			_ = s.EmitRow(ctx, newTopic, noKey, byteSlice, ts, ts, zeroAlloc)
+			_ = s.EmitRow(ctx, newTopic, noKey, byteSlice, ts, ts, zeroAlloc, nil)
 		}
 
 		// Flush the files and close the sink. Any leaks should be caught after the

--- a/pkg/ccl/changefeedccl/sink_kafka_connection_test.go
+++ b/pkg/ccl/changefeedccl/sink_kafka_connection_test.go
@@ -70,7 +70,12 @@ func (e *externalConnectionKafkaSink) Close() error {
 
 // EmitRow implements the Sink interface.
 func (e *externalConnectionKafkaSink) EmitRow(
-	_ context.Context, _ TopicDescriptor, _, _ []byte, _, _ hlc.Timestamp, _ kvevent.Alloc,
+	_ context.Context,
+	_ TopicDescriptor,
+	_, _ []byte,
+	_, _ hlc.Timestamp,
+	_ kvevent.Alloc,
+	_ rowHeaders,
 ) error {
 	return nil
 }

--- a/pkg/ccl/changefeedccl/sink_kafka_v2_test.go
+++ b/pkg/ccl/changefeedccl/sink_kafka_v2_test.go
@@ -199,7 +199,7 @@ func TestKafkaSinkClientV2_Naming(t *testing.T) {
 			return rec.Topic == `_u2603_` && string(rec.Key) == `k☃` && string(rec.Value) == `v☃`
 		})).Times(1).Return(nil)
 
-		require.NoError(t, fx.bs.EmitRow(fx.ctx, topic(`☃`), []byte(`k☃`), []byte(`v☃`), zeroTS, zeroTS, zeroAlloc))
+		require.NoError(t, fx.bs.EmitRow(fx.ctx, topic(`☃`), []byte(`k☃`), []byte(`v☃`), zeroTS, zeroTS, zeroAlloc, nil))
 
 		testutils.SucceedsSoon(t, func() error {
 			select {
@@ -222,7 +222,7 @@ func TestKafkaSinkClientV2_Naming(t *testing.T) {
 			return rec.Topic == `general` && string(rec.Key) == `k☃` && string(rec.Value) == `v☃`
 		})).Times(1).Return(nil)
 
-		require.NoError(t, fx.bs.EmitRow(fx.ctx, topic(`t1`), []byte(`k☃`), []byte(`v☃`), zeroTS, zeroTS, zeroAlloc))
+		require.NoError(t, fx.bs.EmitRow(fx.ctx, topic(`t1`), []byte(`k☃`), []byte(`v☃`), zeroTS, zeroTS, zeroAlloc, nil))
 
 		testutils.SucceedsSoon(t, func() error {
 			select {
@@ -245,7 +245,7 @@ func TestKafkaSinkClientV2_Naming(t *testing.T) {
 			return rec.Topic == `prefix-_u2603_` && string(rec.Key) == `k☃` && string(rec.Value) == `v☃`
 		})).Times(1).Return(nil)
 
-		require.NoError(t, fx.bs.EmitRow(fx.ctx, topic(`t1`), []byte(`k☃`), []byte(`v☃`), zeroTS, zeroTS, zeroAlloc))
+		require.NoError(t, fx.bs.EmitRow(fx.ctx, topic(`t1`), []byte(`k☃`), []byte(`v☃`), zeroTS, zeroTS, zeroAlloc, nil))
 
 		testutils.SucceedsSoon(t, func() error {
 			select {

--- a/pkg/ccl/changefeedccl/sink_pulsar.go
+++ b/pkg/ccl/changefeedccl/sink_pulsar.go
@@ -135,6 +135,7 @@ func (p *pulsarSink) EmitRow(
 	updated hlc.Timestamp,
 	mvcc hlc.Timestamp,
 	alloc kvevent.Alloc,
+	_headers rowHeaders,
 ) error {
 	// TODO(jayant): cache the encoded topics to save an alloc
 	// TODO(#118863): support updated, mvcc, topic_prefix etc.

--- a/pkg/ccl/changefeedccl/sink_sql.go
+++ b/pkg/ccl/changefeedccl/sink_sql.go
@@ -132,6 +132,7 @@ func (s *sqlSink) EmitRow(
 	key, value []byte,
 	updated, mvcc hlc.Timestamp,
 	alloc kvevent.Alloc,
+	_headers rowHeaders,
 ) error {
 	defer alloc.Release(ctx)
 	defer s.metrics.recordOneMessage()(mvcc, len(key)+len(value), sinkDoesNotCompress)


### PR DESCRIPTION
Adds the `headers_json_column_name` option, usable
only with the kafka sink, which allows users to
specify a column in their table(s) of type JSONB
to be used as the kafka headers for each row.

In the future we may want this to flow into
pub/sub attributes, webhook http headers, cloud
storage tracing headers, etc.

Fixes #142106

Release note (general change): Added the
`headers_json_column_name option to the kafka
sink, allowing users to specify a column in their
table(s) of type JSONB to be used as the kafka
headers for each row.
