### PR TITLE
changefeedccl: improve print notice when changefeed has resolved < min_checkpoint_frequency

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -724,21 +724,25 @@ func createChangefeedJobRecord(
 		return nil, err
 	}
 	var resolved time.Duration
+	resolvedStr := " by default"
 	if resolvedOpt != nil {
 		resolved = *resolvedOpt
+		resolvedStr = ""
 	}
 	freqOpt, err := opts.GetMinCheckpointFrequency()
 	if err != nil {
 		return nil, err
 	}
 	freq := changefeedbase.DefaultMinCheckpointFrequency
+	freqStr := "default"
 	if freqOpt != nil {
 		freq = *freqOpt
+		freqStr = "configured"
 	}
 	if emit && (resolved < freq) {
-		p.BufferClientNotice(ctx, errors.Newf("resolved (%s) messages will not be emitted "+
-			"more frequently than the configured min_checkpoint_frequency (%s), but may be emitted "+
-			"less frequently", resolved, freq))
+		p.BufferClientNotice(ctx, pgnotice.Newf("resolved (%s%s) messages will not be emitted "+
+			"more frequently than the %s min_checkpoint_frequency (%s), but may be emitted "+
+			"less frequently", resolved, resolvedStr, freqStr, freq))
 	}
 
 	ptsExpiration, err := opts.GetPTSExpiration()

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -4080,7 +4080,7 @@ func TestChangefeedResolvedNotice(t *testing.T) {
 		testFeed := feed(t, f, `CREATE CHANGEFEED FOR ☃ INTO 'kafka://does.not.matter/' WITH resolved='20ms'`)
 		defer closeFeed(t, testFeed)
 		// Note: default min_checkpoint_frequency is set to 100ms in startTestCluster.
-		require.Equal(t, `resolved (20ms) messages will not be emitted more frequently than the configured min_checkpoint_frequency (100ms), but may be emitted less frequently`, actual)
+		require.Equal(t, `resolved (20ms) messages will not be emitted more frequently than the default min_checkpoint_frequency (100ms), but may be emitted less frequently`, actual)
 	})
 	t.Run("resolved=min_checkpoint_frequency", func(t *testing.T) {
 		actual = "(no notice)"
@@ -4101,7 +4101,7 @@ func TestChangefeedResolvedNotice(t *testing.T) {
 		f := makeKafkaFeedFactory(t, s, dbWithHandler)
 		testFeed := feed(t, f, `CREATE CHANGEFEED FOR ☃ INTO 'kafka://does.not.matter/' WITH resolved, min_checkpoint_frequency='10s'`)
 		defer closeFeed(t, testFeed)
-		require.Equal(t, `resolved (0s) messages will not be emitted more frequently than the configured min_checkpoint_frequency (10s), but may be emitted less frequently`, actual)
+		require.Equal(t, `resolved (0s by default) messages will not be emitted more frequently than the configured min_checkpoint_frequency (10s), but may be emitted less frequently`, actual)
 	})
 }
 


### PR DESCRIPTION
Previously, we printed a message when the resolved and min_checkpoint_frequency options (or defaults) were different than what would normally be expected. This PR changes the message to a notice and adds extra text to the message when the values are defaults.

Epic: none

Release note (general change): When changefeeds are created with a resolved option lower than the min_checkpoint_frequency option, a message was printed to inform the user. This message is now a notice, and includes extra information if either option was a default.