### PR TITLE
packer: user `ssh-server` network tags

### DIFF
--- a/build/packer/teamcity-agent-x86-debug.json
+++ b/build/packer/teamcity-agent-x86-debug.json
@@ -6,6 +6,7 @@
   "builders": [{
       "type": "googlecompute",
       "account_file": "gcp_credentials.json",
+      "tags": ["ssh-server"],
       "project_id": "crl-teamcity-agents-debug",
       "source_image_family": "ubuntu-2004-lts",
       "zone": "us-east1-b",

--- a/build/packer/teamcity-agent-x86-fips.json
+++ b/build/packer/teamcity-agent-x86-fips.json
@@ -6,6 +6,7 @@
   "builders": [{
       "type": "googlecompute",
       "account_file": "gcp_credentials.json",
+      "tags": ["ssh-server"],
       "project_id": "crl-teamcity-agents",
       "source_image_family": "ubuntu-pro-fips-2004-lts",
       "zone": "us-east1-b",

--- a/build/packer/teamcity-agent-x86.json
+++ b/build/packer/teamcity-agent-x86.json
@@ -6,6 +6,7 @@
   "builders": [{
       "type": "googlecompute",
       "account_file": "gcp_credentials.json",
+      "tags": ["ssh-server"],
       "project_id": "crl-teamcity-agents",
       "source_image_family": "ubuntu-2004-lts",
       "zone": "us-east1-b",


### PR DESCRIPTION
This PR adds `ssh-server` network tag to the temporary GCE instances in order to allow inbound SSH connections.

The corresponding firewall rule has been created in terraform.

Fixes: DEVINF-1243
Release note: None