### PR TITLE
[WIP] metric: implement static labeling system

### DIFF
--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -917,28 +917,56 @@ var (
 		Unit:        metric.Unit_COUNT,
 	}
 	MetaSelectStarted = metric.Metadata{
-		Name:        "sql.select.started.count",
-		Help:        "Number of SQL SELECT statements started",
-		Measurement: "SQL Statements",
-		Unit:        metric.Unit_COUNT,
+		Name:             "sql.started.count",
+		Help:             "Number of SQL SELECT statements started",
+		Measurement:      "SQL Statements",
+		Unit:             metric.Unit_COUNT,
+		LegacyStaticName: "sql.select.started.count",
+		StaticLabels: []*metric.StaticLabel{
+			{
+				Key:   "query_type",
+				Value: "select",
+			},
+		},
 	}
 	MetaUpdateStarted = metric.Metadata{
-		Name:        "sql.update.started.count",
-		Help:        "Number of SQL UPDATE statements started",
-		Measurement: "SQL Statements",
-		Unit:        metric.Unit_COUNT,
+		Name:             "sql.started.count",
+		Help:             "Number of SQL UPDATE statements started",
+		Measurement:      "SQL Statements",
+		Unit:             metric.Unit_COUNT,
+		LegacyStaticName: "sql.update.started.count",
+		StaticLabels: []*metric.StaticLabel{
+			{
+				Key:   "query_type",
+				Value: "update",
+			},
+		},
 	}
 	MetaInsertStarted = metric.Metadata{
-		Name:        "sql.insert.started.count",
-		Help:        "Number of SQL INSERT statements started",
-		Measurement: "SQL Statements",
-		Unit:        metric.Unit_COUNT,
+		Name:             "sql.started.count",
+		Help:             "Number of SQL INSERT statements started",
+		Measurement:      "SQL Statements",
+		Unit:             metric.Unit_COUNT,
+		LegacyStaticName: "sql.insert.started.count",
+		StaticLabels: []*metric.StaticLabel{
+			{
+				Key:   "query_type",
+				Value: "insert",
+			},
+		},
 	}
 	MetaDeleteStarted = metric.Metadata{
-		Name:        "sql.delete.started.count",
-		Help:        "Number of SQL DELETE statements started",
-		Measurement: "SQL Statements",
-		Unit:        metric.Unit_COUNT,
+		Name:             "sql.started.count",
+		Help:             "Number of SQL DELETE statements started",
+		Measurement:      "SQL Statements",
+		Unit:             metric.Unit_COUNT,
+		LegacyStaticName: "sql.delete.started.count",
+		StaticLabels: []*metric.StaticLabel{
+			{
+				Key:   "query_type",
+				Value: "delete",
+			},
+		},
 	}
 	MetaCRUDStarted = metric.Metadata{
 		Name:        "sql.crud_query.started.count",
@@ -1255,6 +1283,7 @@ var (
 func getMetricMeta(meta metric.Metadata, internal bool) metric.Metadata {
 	if internal {
 		meta.Name += ".internal"
+		meta.LegacyStaticName += ".internal"
 		meta.Help += " (internal queries)"
 		meta.Measurement = "SQL Internal Statements"
 	}

--- a/pkg/util/metric/aggmetric/counter.go
+++ b/pkg/util/metric/aggmetric/counter.go
@@ -36,6 +36,9 @@ func NewCounter(metadata metric.Metadata, childLabels ...string) *AggCounter {
 // GetName is part of the metric.Iterable interface.
 func (c *AggCounter) GetName() string { return c.g.GetName() }
 
+// GetPrometheusName is part of the metric.PrometheusExportable interface.
+func (c *AggCounter) GetPrometheusName() string { return c.g.GetPrometheusName() }
+
 // GetHelp is part of the metric.Iterable interface.
 func (c *AggCounter) GetHelp() string { return c.g.GetHelp() }
 
@@ -144,6 +147,9 @@ func NewCounterFloat64(metadata metric.Metadata, childLabels ...string) *AggCoun
 
 // GetName is part of the metric.Iterable interface.
 func (c *AggCounterFloat64) GetName() string { return c.g.GetName() }
+
+// GetPrometheusName is part of the metric.PrometheusExportable interface.
+func (c *AggCounterFloat64) GetPrometheusName() string { return c.g.GetPrometheusName() }
 
 // GetHelp is part of the metric.Iterable interface.
 func (c *AggCounterFloat64) GetHelp() string { return c.g.GetHelp() }

--- a/pkg/util/metric/aggmetric/gauge.go
+++ b/pkg/util/metric/aggmetric/gauge.go
@@ -61,6 +61,9 @@ func NewFunctionalGauge(
 // GetName is part of the metric.Iterable interface.
 func (g *AggGauge) GetName() string { return g.g.GetName() }
 
+// GetPrometheusName is part of the metric.PrometheusExportable interface.
+func (g *AggGauge) GetPrometheusName() string { return g.g.GetPrometheusName() }
+
 // GetHelp is part of the metric.Iterable interface.
 func (g *AggGauge) GetHelp() string { return g.g.GetHelp() }
 
@@ -202,6 +205,9 @@ func NewGaugeFloat64(metadata metric.Metadata, childLabels ...string) *AggGaugeF
 
 // GetName is part of the metric.Iterable interface.
 func (g *AggGaugeFloat64) GetName() string { return g.g.GetName() }
+
+// GetPrometheusName is part of the metric.PrometheusExportable interface.
+func (g *AggGaugeFloat64) GetPrometheusName() string { return g.g.GetPrometheusName() }
 
 // GetHelp is part of the metric.Iterable interface.
 func (g *AggGaugeFloat64) GetHelp() string { return g.g.GetHelp() }

--- a/pkg/util/metric/aggmetric/histogram.go
+++ b/pkg/util/metric/aggmetric/histogram.go
@@ -95,6 +95,9 @@ func NewHistogram(opts metric.HistogramOptions, childLabels ...string) *AggHisto
 // GetName is part of the metric.Iterable interface.
 func (a *AggHistogram) GetName() string { return a.h.GetName() }
 
+// GetPrometheusName is part of the metric.PrometheusExportable interface.
+func (a *AggHistogram) GetPrometheusName() string { return a.h.GetPrometheusName() }
+
 // GetHelp is part of the metric.Iterable interface.
 func (a *AggHistogram) GetHelp() string { return a.h.GetHelp() }
 

--- a/pkg/util/metric/metric.proto
+++ b/pkg/util/metric/metric.proto
@@ -46,14 +46,40 @@ enum Unit {
   TIMESTAMP_SEC = 8;
 }
 
+message StaticLabel {
+  required string key = 1 [(gogoproto.nullable) = false];
+  required string value = 2 [(gogoproto.nullable) = false];
+}
+
 // Metadata holds metadata about a metric. It must be embedded in
 // each metric object. It's used to export information about the
 // metric to Prometheus and for Admin UI charts.
+// Naming in TSDB:
+// - if `legacy_static_name` is set, that will be used.
+// - otherwise, the metric name will be generated based on 
+//   `name` and `static_labels`. if `static_labels` is 
+//   empty, it will just be `name`.
+// Naming in `_status/vars`:
+// - the metric name is always just `name`.
+// - if `static_labels` is not empty, those 
+//   labels will be added to the metric name.
+//
+// Note(davidh): we may eventually remove the legacy_static_name field,
+// but we'll need to migrate all existing TSDB usage on the read 
+// and write side to use static labels when recording the metrics.
 message Metadata {
-  required string name = 1 [(gogoproto.nullable) = false];
+  required string name = 1 [(gogoproto.nullable) = false];  
   required string help = 2 [(gogoproto.nullable) = false];
   required string measurement = 3 [(gogoproto.nullable) = false];
   required Unit unit = 4 [(gogoproto.nullable) = false];
   optional io.prometheus.client.MetricType metricType = 5 [(gogoproto.nullable) = false];
   repeated LabelPair labels = 6;
+
+  // legacy_static_name is the name of the metric as it will appear in the tsdb.
+  // Use this to set tsdb names when constructing statically labeled metrics.
+  required string legacy_static_name = 7 [(gogoproto.nullable) = false];
+
+  // static_labels is a set of metric label key/value pairs that are set 
+  // at compile-time and are not expected to change.
+  repeated StaticLabel static_labels = 8;
 }

--- a/pkg/util/metric/prometheus_exporter.go
+++ b/pkg/util/metric/prometheus_exporter.go
@@ -56,7 +56,7 @@ func MakePrometheusExporterForSelectedMetrics(selection map[string]struct{}) Pro
 func (pm *PrometheusExporter) findOrCreateFamily(
 	prom PrometheusCompatible,
 ) *prometheusgo.MetricFamily {
-	familyName := exportedName(prom.GetName())
+	familyName := exportedName(prom.GetPrometheusName())
 	if family, ok := pm.families[familyName]; ok {
 		return family
 	}


### PR DESCRIPTION
On the left: the metrics you know and love in DB Console
On the right: prometheus endpoint with same metrics split by label.

<img width="2385" alt="Screenshot 2025-02-27 at 15 54 47" src="https://github.com/user-attachments/assets/37e77af3-5677-4849-89bb-541ccb8901ad" />

This is the minimum viable implementation that enables this. Some challenges to note:
- Raw manipulation of `Metadata.Name` is very problematic. There are other parts of the codebase that do this.
- When combining metrics into a single name w/ labels, it's crucial to make sure that the sum of the labeled metrics rolls up into a coherent thing. It's easy to combine, say, two different counts into a single metric where the sum is nonsense.
