### PR TITLE
builtins: add jsonb_path_query

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -1262,6 +1262,25 @@ available replica will error.</p>
 </span></td><td>Stable</td></tr></tbody>
 </table>
 
+### Jsonpath functions
+
+<table>
+<thead><tr><th>Function &rarr; Returns</th><th>Description</th><th>Volatility</th></tr></thead>
+<tbody>
+<tr><td><a name="jsonb_path_query"></a><code>jsonb_path_query(target: jsonb, path: jsonpath) &rarr; jsonb</code></td><td><span class="funcdesc"><p>Returns all JSON items returned by the JSON path for the specified JSON value.</p>
+</span></td><td>Immutable</td></tr>
+<tr><td><a name="jsonb_path_query"></a><code>jsonb_path_query(target: jsonb, path: jsonpath, vars: jsonb) &rarr; jsonb</code></td><td><span class="funcdesc"><p>Returns all JSON items returned by the JSON path for the specified JSON value.
+The vars argument must be a JSON object, and its fields provide named values
+to be substituted into the jsonpath expression. Note: Vars is not supported yet.</p>
+</span></td><td>Immutable</td></tr>
+<tr><td><a name="jsonb_path_query"></a><code>jsonb_path_query(target: jsonb, path: jsonpath, vars: jsonb, silent: <a href="bool.html">bool</a>) &rarr; jsonb</code></td><td><span class="funcdesc"><p>Returns all JSON items returned by the JSON path for the specified JSON value.
+The vars argument must be a JSON object, and its fields provide named values
+to be substituted into the jsonpath expression. If the silent argument is true,
+the function suppresses the following errors: missing object field or array
+element, unexpected JSON item type, datetime and numeric errors. Note: Vars is not supported yet.</p>
+</span></td><td>Immutable</td></tr></tbody>
+</table>
+
 ### Multi-region functions
 
 <table>

--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -2585,6 +2585,7 @@ GO_TARGETS = [
     "//pkg/util/json:json",
     "//pkg/util/json:json_test",
     "//pkg/util/jsonbytes:jsonbytes",
+    "//pkg/util/jsonpath/eval:eval",
     "//pkg/util/jsonpath/parser/lexbase:lexbase",
     "//pkg/util/jsonpath/parser:parser",
     "//pkg/util/jsonpath/parser:parser_test",

--- a/pkg/sql/logictest/testdata/logic_test/jsonb_path_query
+++ b/pkg/sql/logictest/testdata/logic_test/jsonb_path_query
@@ -1,0 +1,184 @@
+# LogicTest: local
+
+query T
+SELECT jsonb_path_query('{}', '$')
+----
+{}
+
+statement error pgcode 2203A JSON object does not contain key "a"
+SELECT jsonb_path_query('{}', 'strict $.a')
+
+query T
+SELECT jsonb_path_query('{"a": "b"}', '$')
+----
+{"a": "b"}
+
+query T
+SELECT jsonb_path_query('{"a": ["b", true, false, null]}', '$')
+----
+{"a": ["b", true, false, null]}
+
+# WITH a AS (
+#     SELECT '{
+#         "a": {
+#             "aa": {
+#                 "aaa": "s1",
+#                 "aab": 123,
+#                 "aac": true,
+#                 "aad": false,
+#                 "aae": null,
+#                 "aaf": [1, 2, 3],
+#                 "aag": {
+#                     "aaga": "s2"
+#                 }
+#             },
+#             "ab": "s3"
+#         },
+#         "b": "s4",
+#         "c": [
+#             {"ca": "s5"},
+#             {"ca": "s6"},
+#             1,
+#             true,
+#         ],
+#         "d": 123.45,
+#     }'::JSONB AS data
+# )
+
+statement ok
+CREATE TABLE a AS SELECT '{"a": {"aa": {"aaa": "s1", "aab": 123, "aac": true, "aad": false, "aae": null, "aaf": [1, 2, 3], "aag": {"aaga": "s2"}}, "ab": "s3"}, "b": "s4", "c": [{"ca": "s5"}, {"ca": "s6"}, 1, true], "d": 123.45}'::JSONB AS data
+
+query T
+SELECT jsonb_path_query(data, '$.a.aa.aaa') FROM a
+----
+"s1"
+
+query T
+SELECT jsonb_path_query(data, '$.a.aa.aab') FROM a
+----
+123
+
+query T
+SELECT jsonb_path_query(data, '$.a.aa.aac') FROM a
+----
+true
+
+query T
+SELECT jsonb_path_query(data, '$.a.aa.aad') FROM a
+----
+false
+
+query T
+SELECT jsonb_path_query(data, '$.a.aa.aae') FROM a
+----
+null
+
+query T
+SELECT jsonb_path_query(data, '$.a.aa.aaf') FROM a
+----
+[1, 2, 3]
+
+query T
+SELECT jsonb_path_query(data, '$.a.aa.aag') FROM a
+----
+{"aaga": "s2"}
+
+query T
+SELECT jsonb_path_query(data, '$.c') FROM a
+----
+[{"ca": "s5"}, {"ca": "s6"}, 1, true]
+
+query T
+SELECT jsonb_path_query(data, '$.d') FROM a
+----
+123.45
+
+query T rowsort
+SELECT jsonb_path_query(data, '$.c[*].ca') FROM a
+----
+"s5"
+"s6"
+
+statement error pgcode 2203A JSON object does not contain key "aa"
+SELECT jsonb_path_query(data, 'strict $.aa') FROM a
+
+statement error pgcode 2203A JSON object does not contain key "aa"
+SELECT jsonb_path_query(data, 'strict $.aa.aaa.aaaa') FROM a
+
+# empty return
+query T
+SELECT jsonb_path_query('{}', '$.a')
+----
+
+
+statement ok
+CREATE TABLE b (j JSONB)
+
+statement ok
+INSERT INTO b VALUES ('{"a": [1, 2, 3], "b": "hello"}'), ('{"a": false}')
+
+query T rowsort
+SELECT jsonb_path_query(j, '$.a') FROM b
+----
+[1, 2, 3]
+false
+
+query T
+SELECT jsonb_path_query(j, '$.b') FROM b
+----
+"hello"
+
+query T rowsort
+SELECT jsonb_path_query('{"a": [1, 2, {"b": [4, 5]}, null, [true, false]]}', '$.a[*]')
+----
+1
+2
+{"b": [4, 5]}
+null
+[true, false]
+
+query T rowsort
+SELECT jsonb_path_query('{"a": [1, 2, {"b": [{"c": true}, {"c": false}]}, null, [true, false], {"b": [{"c": 0.1}, {"d": null}, {"c": 10}]}]}', '$.a[*].b[*].c')
+----
+true
+false
+0.1
+10
+
+query T
+SELECT jsonb_path_query('{"a": [1]}', '$.a', '{}');
+----
+[1]
+
+statement error pgcode 22023 "vars" argument is not an object
+SELECT jsonb_path_query('{"a": [1]}', '$.a', '[]');
+
+query T
+SELECT jsonb_path_query('{"a": [1]}', '$.b', '{}', false);
+----
+
+query T
+SELECT jsonb_path_query('{"a": [1]}', '$.b', '{}', true);
+----
+
+statement error pgcode 2203A JSON object does not contain key "b"
+SELECT jsonb_path_query('{"a": [1]}', 'strict $.b', '{}', false);
+
+query T
+SELECT jsonb_path_query('{"a": [1]}', 'strict $.b', '{}', true);
+----
+
+
+query T rowsort
+SELECT jsonb_path_query('{"a": {"b": [1, 2, 3]}}', '$.a[*].b[*]');
+----
+1
+2
+3
+
+statement error pgcode 22039 jsonpath wildcard array accessor can only be applied to an array
+SELECT jsonb_path_query('{"a": {"b": [1, 2, 3]}}', 'strict $.a[*].b[*]');
+
+# select jsonb_path_query('[1, 2, 3, 4, 5]', '$[1]');
+# select jsonb_path_query('[1, 2, 3, 4, 5]', '$[-1]');
+# select jsonb_path_query('[1, 2, 3, 4, 5]', 'strict $[-1]');

--- a/pkg/sql/logictest/tests/local/generated_test.go
+++ b/pkg/sql/logictest/tests/local/generated_test.go
@@ -1256,6 +1256,13 @@ func TestLogic_json_index(
 	runLogicTest(t, "json_index")
 }
 
+func TestLogic_jsonb_path_query(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "jsonb_path_query")
+}
+
 func TestLogic_jsonpath(
 	t *testing.T,
 ) {

--- a/pkg/sql/pgwire/pgcode/codes.go
+++ b/pkg/sql/pgwire/pgcode/codes.go
@@ -124,6 +124,8 @@ var (
 	InvalidXMLContent                     = MakeCode("2200N")
 	InvalidXMLComment                     = MakeCode("2200S")
 	InvalidXMLProcessingInstruction       = MakeCode("2200T")
+	WildcardOnNonArray                    = MakeCode("22039")
+	KeyNotInJSON                          = MakeCode("2203A")
 	// Section: Class 23 - Integrity Constraint Violation
 	IntegrityConstraintViolation = MakeCode("23000")
 	RestrictViolation            = MakeCode("23001")

--- a/pkg/sql/sem/builtins/BUILD.bazel
+++ b/pkg/sql/sem/builtins/BUILD.bazel
@@ -114,6 +114,7 @@ go_library(
         "//pkg/util/intsets",
         "//pkg/util/ipaddr",
         "//pkg/util/json",
+        "//pkg/util/jsonpath/eval",
         "//pkg/util/log",
         "//pkg/util/mon",
         "//pkg/util/pretty",

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -4141,7 +4141,6 @@ value if you rely on the HLC for accuracy.`,
 	"jsonb_path_exists_opr":  makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 22513, Category: builtinconstants.CategoryJsonpath}),
 	"jsonb_path_match":       makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 22513, Category: builtinconstants.CategoryJsonpath}),
 	"jsonb_path_match_opr":   makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 22513, Category: builtinconstants.CategoryJsonpath}),
-	"jsonb_path_query":       makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 22513, Category: builtinconstants.CategoryJsonpath}),
 	"jsonb_path_query_array": makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 22513, Category: builtinconstants.CategoryJsonpath}),
 	"jsonb_path_query_first": makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 22513, Category: builtinconstants.CategoryJsonpath}),
 

--- a/pkg/sql/sem/builtins/fixed_oids.go
+++ b/pkg/sql/sem/builtins/fixed_oids.go
@@ -2644,6 +2644,9 @@ var builtinOidsArray = []string{
 	2681: `varchar(jsonpath: jsonpath) -> varchar`,
 	2682: `char(jsonpath: jsonpath) -> "char"`,
 	2683: `substring_index(input: string, delim: string, count: int) -> string`,
+	2684: `jsonb_path_query(target: jsonb, path: jsonpath) -> jsonb`,
+	2685: `jsonb_path_query(target: jsonb, path: jsonpath, vars: jsonb) -> jsonb`,
+	2686: `jsonb_path_query(target: jsonb, path: jsonpath, vars: jsonb, silent: bool) -> jsonb`,
 }
 
 var builtinOidsBySignature map[string]oid.Oid

--- a/pkg/sql/sem/builtins/generator_builtins.go
+++ b/pkg/sql/sem/builtins/generator_builtins.go
@@ -41,6 +41,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/duration"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/json"
+	jsonpath "github.com/cockroachdb/cockroach/pkg/util/jsonpath/eval"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/randident"
 	"github.com/cockroachdb/cockroach/pkg/util/randident/randidentcfg"
@@ -429,6 +430,49 @@ var generators = map[string]builtinDefinition{
 	"jsonb_to_record":    makeBuiltin(recordGenProps(), jsonToRecordImpl),
 	"json_to_recordset":  makeBuiltin(recordGenProps(), jsonToRecordSetImpl),
 	"jsonb_to_recordset": makeBuiltin(recordGenProps(), jsonToRecordSetImpl),
+
+	// See https://www.postgresql.org/docs/current/functions-json.html#SQLJSON-QUERY-FUNCTIONS
+	"jsonb_path_query": makeBuiltin(jsonpathProps(),
+		makeGeneratorOverload(
+			tree.ParamTypes{
+				{Name: "target", Typ: types.Jsonb},
+				{Name: "path", Typ: types.Jsonpath},
+			},
+			jsonPathQueryGeneratorType,
+			makeJsonpathQueryGenerator,
+			"Returns all JSON items returned by the JSON path for the specified JSON value.",
+			volatility.Immutable,
+		),
+		makeGeneratorOverload(
+			tree.ParamTypes{
+				{Name: "target", Typ: types.Jsonb},
+				{Name: "path", Typ: types.Jsonpath},
+				{Name: "vars", Typ: types.Jsonb},
+			},
+			jsonPathQueryGeneratorType,
+			makeJsonpathQueryGenerator,
+			`Returns all JSON items returned by the JSON path for the specified JSON value.
+			 The vars argument must be a JSON object, and its fields provide named values
+			 to be substituted into the jsonpath expression. Note: Vars is not supported yet.`,
+			volatility.Immutable,
+		),
+		makeGeneratorOverload(
+			tree.ParamTypes{
+				{Name: "target", Typ: types.Jsonb},
+				{Name: "path", Typ: types.Jsonpath},
+				{Name: "vars", Typ: types.Jsonb},
+				{Name: "silent", Typ: types.Bool},
+			},
+			jsonPathQueryGeneratorType,
+			makeJsonpathQueryGenerator,
+			`Returns all JSON items returned by the JSON path for the specified JSON value.
+			 The vars argument must be a JSON object, and its fields provide named values
+			 to be substituted into the jsonpath expression. If the silent argument is true,
+			 the function suppresses the following errors: missing object field or array
+			 element, unexpected JSON item type, datetime and numeric errors. Note: Vars is not supported yet.`,
+			volatility.Immutable,
+		),
+	),
 
 	"crdb_internal.check_consistency": makeBuiltin(
 		tree.FunctionProperties{
@@ -1577,6 +1621,73 @@ var jsonObjectKeysImpl = makeGeneratorOverload(
 	volatility.Immutable,
 )
 
+var jsonPathQueryGeneratorType = types.Jsonb
+
+type jsonPathQueryGenerator struct {
+	target tree.DJSON
+	path   tree.DJsonpath
+	vars   tree.DJSON
+	silent tree.DBool
+
+	res     []tree.DJSON
+	iterIdx int
+}
+
+func makeJsonpathQueryGenerator(
+	_ context.Context, _ *eval.Context, args tree.Datums,
+) (eval.ValueGenerator, error) {
+	target := tree.MustBeDJSON(args[0])
+	path := tree.MustBeDJsonpath(args[1])
+	vars := *tree.NewDJSON(json.NewObjectBuilder(0).Build())
+	silent := tree.DBool(false)
+	if len(args) > 2 {
+		vars = tree.MustBeDJSON(args[2])
+		if vars.Type() != json.ObjectJSONType {
+			return nil, pgerror.Newf(pgcode.InvalidParameterValue, `"vars" argument is not an object`)
+		}
+	}
+	if len(args) > 3 {
+		silent = tree.MustBeDBool(args[3])
+	}
+	return &jsonPathQueryGenerator{
+		target: target,
+		path:   path,
+		vars:   vars,
+		silent: silent,
+	}, nil
+}
+
+// ResolvedType implements the eval.ValueGenerator interface.
+func (g *jsonPathQueryGenerator) ResolvedType() *types.T {
+	return jsonPathQueryGeneratorType
+}
+
+// Start implements the eval.ValueGenerator interface.
+func (g *jsonPathQueryGenerator) Start(_ context.Context, _ *kv.Txn) error {
+	jsonb, err := jsonpath.JsonpathQuery(g.target, g.path, g.vars, g.silent)
+	if err != nil {
+		return err
+	}
+	g.res = jsonb
+	g.iterIdx = 0
+	return nil
+}
+
+// Close implements the eval.ValueGenerator interface.
+func (g *jsonPathQueryGenerator) Close(_ context.Context) {}
+
+// Next implements the eval.ValueGenerator interface.
+func (g *jsonPathQueryGenerator) Next(_ context.Context) (bool, error) {
+	g.iterIdx++
+	return g.iterIdx <= len(g.res), nil
+}
+
+// Values implements the eval.ValueGenerator interface.
+func (g *jsonPathQueryGenerator) Values() (tree.Datums, error) {
+	jp := g.res[g.iterIdx-1]
+	return tree.Datums{tree.NewDJSON(jp.JSON)}, nil
+}
+
 var jsonObjectKeysGeneratorType = types.String
 
 type jsonObjectKeysGenerator struct {
@@ -1757,6 +1868,12 @@ func (g *jsonEachGenerator) Values() (tree.Datums, error) {
 
 var jsonPopulateProps = tree.FunctionProperties{
 	Category: builtinconstants.CategoryJSON,
+}
+
+func jsonpathProps() tree.FunctionProperties {
+	return tree.FunctionProperties{
+		Category: builtinconstants.CategoryJsonpath,
+	}
 }
 
 func makeJSONPopulateImpl(gen eval.GeneratorWithExprsOverload, info string) tree.Overload {

--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -3963,6 +3963,30 @@ func ParseDJsonpath(s string) (Datum, error) {
 	return NewDJsonpath(jp), nil
 }
 
+// AsDJsonpath attempts to retrieve a *DJsonpath from an Expr, returning a *DJsonpath and
+// a flag signifying whether the assertion was successful. The function should
+// be used instead of direct type assertions wherever a *DJsonpath wrapped by a
+// *DOidWrapper is possible.
+func AsDJsonpath(e Expr) (*DJsonpath, bool) {
+	switch t := e.(type) {
+	case *DJsonpath:
+		return t, true
+	case *DOidWrapper:
+		return AsDJsonpath(t.Wrapped)
+	}
+	return nil, false
+}
+
+// MustBeDJsonpath attempts to retrieve a DJsonpath from an Expr, panicking if the
+// assertion fails.
+func MustBeDJsonpath(e Expr) DJsonpath {
+	i, ok := AsDJsonpath(e)
+	if !ok {
+		panic(errors.AssertionFailedf("expected *DJsonpath, found %T", e))
+	}
+	return *i
+}
+
 // DJSON is the JSON Datum.
 type DJSON struct{ json.JSON }
 

--- a/pkg/util/jsonpath/eval/BUILD.bazel
+++ b/pkg/util/jsonpath/eval/BUILD.bazel
@@ -1,0 +1,17 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "eval",
+    srcs = ["eval.go"],
+    importpath = "github.com/cockroachdb/cockroach/pkg/util/jsonpath/eval",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/sql/pgwire/pgcode",
+        "//pkg/sql/pgwire/pgerror",
+        "//pkg/sql/sem/tree",
+        "//pkg/util/json",
+        "//pkg/util/jsonpath",
+        "//pkg/util/jsonpath/parser",
+        "@com_github_cockroachdb_errors//:errors",
+    ],
+)

--- a/pkg/util/jsonpath/eval/eval.go
+++ b/pkg/util/jsonpath/eval/eval.go
@@ -1,0 +1,104 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package eval
+
+import (
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/util/json"
+	"github.com/cockroachdb/cockroach/pkg/util/jsonpath"
+	"github.com/cockroachdb/cockroach/pkg/util/jsonpath/parser"
+	"github.com/cockroachdb/errors"
+)
+
+var ErrUnimplemented = errors.New("unimplemented")
+var ErrInternal = errors.New("internal error")
+
+func JsonpathQuery(
+	target tree.DJSON, path tree.DJsonpath, vars tree.DJSON, silent tree.DBool,
+) ([]tree.DJSON, error) {
+	// vars is not supported yet, as it's not implemented in the parser ($variable).
+	_ = vars
+	parsedPath, err := parser.Parse(string(path))
+	if err != nil {
+		return []tree.DJSON{}, err
+	}
+	expr := parsedPath.AST
+
+	// When silent is true, overwrite the strict mode.
+	if bool(silent) {
+		expr.Strict = false
+	}
+
+	if len(expr.Query.Accessors) == 0 {
+		return []tree.DJSON{}, fmt.Errorf("at least one accessor is guaranteed: %w", ErrInternal)
+	}
+	_, ok := expr.Query.Accessors[0].(jsonpath.Root)
+	if !ok {
+		return []tree.DJSON{}, fmt.Errorf("the first accessor is the root: %w", ErrInternal)
+	}
+
+	results := []tree.DJSON{target}
+	for _, accessor := range expr.Query.Accessors[1:] {
+		var nextResults []tree.DJSON
+		switch a := accessor.(type) {
+		case jsonpath.Key:
+			for _, result := range results {
+				value, err := result.JSON.FetchValKey(a.Key)
+				if err != nil {
+					return []tree.DJSON{}, err
+				}
+				// Key is not found in the JSON object.
+				if value == nil {
+					if expr.Strict {
+						return []tree.DJSON{}, pgerror.Newf(pgcode.KeyNotInJSON,
+							"JSON object does not contain key %q", a.Key)
+					}
+					// Do not add current value to results.
+					continue
+				}
+				nextResults = append(nextResults, tree.DJSON{JSON: value})
+			}
+		case jsonpath.Wildcard:
+			for _, result := range results {
+				if result.JSON.Type() != json.ArrayJSONType {
+					if expr.Strict {
+						return []tree.DJSON{}, pgerror.Newf(pgcode.WildcardOnNonArray,
+							"jsonpath wildcard array accessor can only be applied to an array")
+					}
+					// When not strict and non array, the wildcard is treated
+					// as a no-op.
+					nextResults = append(nextResults, result)
+					continue
+				}
+				arrayElements, err := json.AllPathsWithDepth(result.JSON, 1)
+				if err != nil {
+					return []tree.DJSON{}, err
+				}
+				for _, element := range arrayElements {
+					// Each element returned is wrapped in an array, so we unwrap
+					// the array and add the element to the results.
+					unwrapped, err := element.FetchValIdx(0)
+					if err != nil {
+						return []tree.DJSON{}, err
+					}
+					if unwrapped == nil {
+						// This should never happen, as we check for array type above.
+						return []tree.DJSON{}, fmt.Errorf("unwrapping json element: %w", ErrInternal)
+					}
+					nextResults = append(nextResults, tree.DJSON{JSON: unwrapped})
+				}
+			}
+		default:
+			return []tree.DJSON{}, ErrUnimplemented
+		}
+		results = nextResults
+	}
+	return results, nil
+}


### PR DESCRIPTION
Previously, the `jsonpath` data type and parser were created and integrated within each other. This PR adds the `jsonb_path_query` function and a new `pkg/util/jsonpath/eval` package which uses the existing work done.

Epic: None
Release note (sql change): Add the `jsonb_path_query` function, which takes in a JSON object and a Jsonpath query, and returns the resulting JSON object.