### PR TITLE
testserver: set default rf to 1 for single node servers

### DIFF
--- a/pkg/server/initial_sql.go
+++ b/pkg/server/initial_sql.go
@@ -36,7 +36,7 @@ func (s *topLevelServer) RunInitialSQL(
 		return nil
 	}
 
-	if startSingleNode {
+	if startSingleNode && (*s.cfg.DefaultSystemZoneConfig.NumReplicas != 1 || *s.cfg.DefaultZoneConfig.NumReplicas != 1) {
 		// For start-single-node, set the default replication factor to
 		// 1 so as to avoid warning messages and unnecessary rebalance
 		// churn.

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -2496,6 +2496,7 @@ func (testServerFactoryImpl) New(params base.TestServerArgs) (interface{}, error
 
 	if !params.PartOfCluster {
 		ts.Cfg.DefaultZoneConfig.NumReplicas = proto.Int32(1)
+		ts.Cfg.DefaultSystemZoneConfig.NumReplicas = proto.Int32(1)
 	}
 
 	// Needs to be called before NewServer to ensure resolvers are initialized.


### PR DESCRIPTION
We already set the default rf to 1 for non system ranges. This patch skips a schema change run to set num replicas for system ranges to 1 and sets the system ranges rf to 1 by default instead. This patch reduces the test runtime of server startup by abour 15%, post initialization:

```
❯ benchdiff --old  281a7294cf1360446177ceed1e25e141d19e0c6e --new c14e2c15b8697e62a8916cd5c60a1be43c54fdf1 ./pkg/server -r BenchmarkTestServerStartup  -c 15 --preview -b
old:  281a729 Merge #142062 #142079
new:  c14e2c1 testserver: set default rf to 1 for single node se
args: benchdiff "--old" "281a7294cf1360446177ceed1e25e141d19e0c6e" "--new" "c14e2c15b8697e62a8916cd5c60a1be43c54fdf1" "./pkg/server" "-r" "BenchmarkTestServerStartup" "-c" "15" "--preview" "-b"

name                                   old time/op    new time/op    delta
TestServerStartup/ExternalTenant-24       390ms ±10%     320ms ±26%  -18.06%  (p=0.000 n=15+15)
TestServerStartup/SharedTenant-24         390ms ±16%     328ms ± 7%  -15.85%  (p=0.000 n=15+14)
TestServerStartup/SystemTenantOnly-24     386ms ±13%     336ms ±12%  -13.01%  (p=0.000 n=15+15)

name                                   old alloc/op   new alloc/op   delta
TestServerStartup/SystemTenantOnly-24     133MB ± 0%     119MB ± 0%  -10.21%  (p=0.000 n=15+15)
TestServerStartup/ExternalTenant-24       133MB ± 0%     119MB ± 1%  -10.19%  (p=0.000 n=12+15)
TestServerStartup/SharedTenant-24         133MB ± 1%     119MB ± 1%  -10.18%  (p=0.000 n=15+14)

name                                   old allocs/op  new allocs/op  delta
TestServerStartup/SystemTenantOnly-24      799k ± 0%      701k ± 0%  -12.34%  (p=0.000 n=15+15)
TestServerStartup/SharedTenant-24          799k ± 0%      701k ± 0%  -12.33%  (p=0.000 n=15+15)
TestServerStartup/ExternalTenant-24        799k ± 0%      701k ± 0%  -12.29%  (p=0.000 n=15+15)
```

Epic: none

Release note: none