### PR TITLE
util: introduce a reverse overlapping iterator for interval b-trees

### DIFF
--- a/pkg/kv/kvclient/kvcoord/bufferedwrite_interval_btree.go
+++ b/pkg/kv/kvclient/kvcoord/bufferedwrite_interval_btree.go
@@ -1021,14 +1021,23 @@ func (i *iterator) Cur() *bufferedWrite {
 	return i.n.items[i.pos]
 }
 
-// An overlap scan is a scan over all items that overlap with the provided
-// item in order of the overlapping items' start keys. The goal of the scan
-// is to minimize the number of key comparisons performed in total. The
-// algorithm operates based on the following two invariants maintained by
-// augmented interval btree:
+// An overlap scan is a scan over all items that overlap with the provided item
+// (start key inclusive, end key exclusive) in order of the overlapping items'
+// start keys. The goal of the scan is to minimize the number of key comparisons
+// performed in total. The algorithm operates based on the following two
+// invariants maintained by augmented interval btree:
 //  1. all items are sorted in the btree based on their start key.
 //  2. all btree nodes maintain the upper bound end key of all items
 //     in their subtree.
+//
+// An overlapping scan can be performed either in the forward or reverse
+// direction. The algorithm for each is slightly different. First, we present
+// each algorithm, and then we talk about the differences (and the reasons for
+// for them).
+//
+// -----------------------------------------------------------------------------
+// Forward Overlap Scan Algorithm
+// -----------------------------------------------------------------------------
 //
 // The scan algorithm starts in "unconstrained minimum" and "unconstrained
 // maximum" states. To enter a "constrained minimum" state, the scan must reach
@@ -1043,33 +1052,113 @@ func (i *iterator) Cur() *bufferedWrite {
 //
 // The scan algorithm works like a standard btree forward scan with the
 // following augmentations:
-//  1. before tranversing the tree, the scan performs a binary search on the
+//  1. before traversing the tree, the scan performs a binary search on the
 //     root node's items to determine a "soft" lower-bound constraint position
 //     and a "hard" upper-bound constraint position in the root's children.
-//  2. when tranversing into a child node in the lower or upper bound constraint
+//  2. when traversing into a child node in the lower or upper bound constraint
 //     position, the constraint is refined by searching the child's items.
 //  3. the initial traversal down the tree follows the left-most children
 //     whose upper bound end keys are equal to or greater than the start key
 //     of the search range. The children followed will be equal to or less
 //     than the soft lower bound constraint.
-//  4. once the initial tranversal completes and the scan is in the left-most
+//  4. once the initial traversal completes and the scan is in the left-most
 //     btree node whose upper bound overlaps the search range, key comparisons
 //     must be performed with each item in the tree. This is necessary because
 //     any of these items may have end keys that cause them to overlap with the
 //     search range.
 //  5. once the scan reaches the lower bound constraint position (the first item
 //     with a start key equal to or greater than the search range's start key),
-//     it can begin scaning without performing key comparisons. This is allowed
+//     it can begin scanning without performing key comparisons. This is allowed
 //     because all items from this point forward will have end keys that are
 //     greater than the search range's start key.
 //  6. once the scan reaches the upper bound constraint position, it terminates.
 //     It does so because the item at this position is the first item with a
 //     start key larger than the search range's end key.
+//
+// -----------------------------------------------------------------------------
+// Reverse Overlap Scan Algorithm
+// -----------------------------------------------------------------------------
+//
+// The scan algorithm starts in a "unconstrained minimum" and "unconstrained
+// maximum" state. To enter the "constrained maximum" state, the scan must reach
+// items in the tree with start keys below the search range's end key. Once the
+// scan enters the "constrained maximum" state, it will remain there. To enter
+// the "constrained minimum" state, the scan must reach items in the tree with
+// start keys above the search range's start key. To enter a "constrained
+// minimum" state, the scan must determine the first child btree node in a given
+// subtree that can have items with start keys less than the search range's
+// start key. The scan then remains in the "constrained minimum" state, until it
+// traverses into this child node, at which point it moves to the "unconstrained
+// minimum" state again.
+//
+// The scan algorithm works like a standard btree reverse scan with the
+// following augmentations:
+//  1. before traversing the tree, the scan performs a binary search on the root
+//     node's items to determine a "soft" lower-bound constraint position and a
+//     "hard" upper-bound constraint position in the root's children.
+//  2. when traversing into a child node in the lower or upper bound constraint
+//     position the constraint is refined by searching the child's items.
+//  3. the initial traversal down the tree follows the right-most children whose
+//     upper bound end keys are equal to or greater than the start key of the search
+//     range. The children followed will be equal to or less than the hard
+//     upper-bound constraint.
+//  4. once the initial traversal completes and the scan is in the right-most
+//     btree node whose upper bound overlaps the search range, then jumps directly
+//     to the first item before the upper bound constraint position. This is because
+//     the upper bound constraint position is exclusive.
+//  5. as long as the scan hasn't reached the lower bound constraint position
+//     (the first item with a start key equal or greater than the search range's
+//     start key), it can continue scanning without performing key comparisions.
+//     This is allowed because all items until the lower bound constraint position
+//     is reached will have end keys greater than the search range's start key, and
+//     we know that all items in the tree have start keys less than the search
+//     range's end key.
+//  6. once the scan reaches the lower bound constraint position, key comparisons
+//     must be performed with each item in the tree. This is necessary because even
+//     though the scan is dealing with items that have start keys less than the
+//     serach range's start key, it is possible that these items have end keys that
+//     cause them to overlap with the search range.
+//
+// -----------------------------------------------------------------------------
+// Differences between forward and reverse overlap scans
+// -----------------------------------------------------------------------------
+//
+//  1. The forward overlapping scan can terminate early. It can do so once it
+//     reaches the hard upper bound constaint. This is the first item whose start
+//     key is greater than or equal to the search range's end key.
+//  2. The reverse overlaping scan can directly "jump" directly to the item right
+//     before the hard upper bound constraint. This allows it to skip any subtree/
+//     items that are past the search range's end key.
+//  3. Once the forward overlapping scan enters the inConstrMin condition, it
+//     stays there. The scan reaches inConstrMin at the first item whose start key
+//     is greater than the search range's start key. While inConstrMin is true, no
+//     key comparisons need to be performed[1].
+//  4. In contrast, the reverse overlapping starts off[2] in the inConstrMin
+//     state (where no key comparisons are needed). Once it exitst this state, key
+//     comparisons are needed.
+//
+// [1] This is because the search interval's end key must be greater than the
+// item's start key. Otherwise, we'd have terminated the scan. So, the item must
+// overlap with the search range, and we can skip key comparisons.
+// [2] After it's jumped to the item right before the "hard" upper bound
+// constraint.
+//
+// There's a few reasons for the differences here:
+//  1. All items in the b-tree are sorted by start key. This means that we have a
+//     "hard" upper bound, but a "soft" lower bound. For forward scans, this means
+//     that we can terminate early when this "hard" upper bound is reached. For
+//     reverse scans, this means that we can directly jump to the last item the scan
+//     will ever see.
+//  2. The number of children at an interior node is one more than the number of
+//     items. For a forward scan, the scan starts off at the 0th index regardless of
+//     the type of node. For a reverse scan, however, the scan must start off at the
+//     last child for interior nodes, and the last item for leaf-nodes. These are "off
+//     by one", which requires some care to get right.
 type overlapScan struct {
 	// The "soft" lower-bound constraint.
-	constrMinN       *node
-	constrMinPos     int16
-	constrMinReached bool
+	constrMinN   *node
+	constrMinPos int16
+	inConstrMin  bool
 
 	// The "hard" upper-bound constraint.
 	constrMaxN   *node
@@ -1084,10 +1173,23 @@ func (i *iterator) FirstOverlap(item *bufferedWrite) {
 		return
 	}
 	i.pos = 0
-	i.o = overlapScan{}
 	i.constrainMinSearchBounds(item)
 	i.constrainMaxSearchBounds(item)
 	i.findNextOverlap(item)
+}
+
+// LastOverlap seeks to the last item in the btree that overlaps with the
+// provided search item.
+func (i *iterator) LastOverlap(item *bufferedWrite) {
+	i.reset()
+	if i.n == nil {
+		return
+	}
+	i.pos = i.n.count
+	i.o.inConstrMin = true // reverse scans start inConstrMin
+	i.constrainMinSearchBounds(item)
+	i.constrainMaxSearchBounds(item)
+	i.findPrevOverlap(item)
 }
 
 // NextOverlap positions the iterator to the item immediately following
@@ -1100,6 +1202,24 @@ func (i *iterator) NextOverlap(item *bufferedWrite) {
 	i.findNextOverlap(item)
 }
 
+// PrevOverlap positions the iterator to the item immediately preceding
+// its current position that overlaps with the search item.
+func (i *iterator) PrevOverlap(item *bufferedWrite) {
+	if i.n == nil {
+		return
+	}
+	i.findPrevOverlap(item)
+}
+
+// constrainMinSearchBounds sets the "soft" lower-bound constraint. This is the
+// first item whose start key is greater than or equal to the supplied search
+// range's start key.
+//
+//	| search range:           [-------------)
+//	| items:         [----) [----) [----) [----) [----)
+//	|                                ^
+//	|                                |
+//	|                                +---constrMinPos
 func (i *iterator) constrainMinSearchBounds(item *bufferedWrite) {
 	k := item.Key()
 	j := sort.Search(int(i.n.count), func(j int) bool {
@@ -1109,6 +1229,15 @@ func (i *iterator) constrainMinSearchBounds(item *bufferedWrite) {
 	i.o.constrMinPos = int16(j)
 }
 
+// constrainMaxSearchBounds sets the "hard" upper-bound constraint. This is the
+// first item whose start key is greater than the supplied search range's end
+// key.
+//
+//	| search range:           [--------------)
+//	| items:         [----) [----) [----) [----) [----)
+//	|                                               ^
+//	|                                               |
+//	|                                               +---constrMaxPos
 func (i *iterator) constrainMaxSearchBounds(item *bufferedWrite) {
 	up := upperBound(item)
 	j := sort.Search(int(i.n.count), func(j int) bool {
@@ -1125,7 +1254,7 @@ func (i *iterator) findNextOverlap(item *bufferedWrite) {
 			i.ascend()
 		} else if !i.n.leaf() {
 			// Iterate down tree.
-			if i.o.constrMinReached || i.n.children[i.pos].max().contains(item) {
+			if i.o.inConstrMin || i.n.children[i.pos].max().contains(item) {
 				par := i.n
 				pos := i.pos
 				i.descend(par, pos)
@@ -1149,14 +1278,14 @@ func (i *iterator) findNextOverlap(item *bufferedWrite) {
 		}
 		if i.n == i.o.constrMinN && i.pos == i.o.constrMinPos {
 			// The scan reached the soft lower-bound constraint.
-			i.o.constrMinReached = true
+			i.o.inConstrMin = true
 		}
 
 		// Iterate across node.
 		if i.pos < i.n.count {
 			// Check for overlapping item.
-			if i.o.constrMinReached {
-				// Fast-path to avoid span comparison. i.o.constrMinReached
+			if i.o.inConstrMin {
+				// Fast-path to avoid span comparison. i.o.inConstrMin
 				// tells us that all items have end keys above our search
 				// span's start key.
 				return
@@ -1166,5 +1295,95 @@ func (i *iterator) findNextOverlap(item *bufferedWrite) {
 			}
 		}
 		i.pos++
+	}
+}
+
+func (i *iterator) findPrevOverlap(item *bufferedWrite) {
+	for {
+		// First off, we want to avoid exploring any items that are past the
+		// search range's end key.
+		if i.n == i.o.constrMaxN && i.pos > i.o.constrMaxPos {
+			// The item at i.o.constrMaxPos is the first item with a start key
+			// that's greater than the search range's end key. As such, it is
+			// the left-most item that does not overlap with the search range --
+			// we want to "jump" straight to the preceding position. However, we
+			// can't just position the iterator to i.o.constrMaxPos - 1; if this
+			// is an interior node, we might need to descend into the child on
+			// the right of i.o.constrMaxPos - 1 first. So, we set the position
+			// to that of the child node, and let the loop decide whether to
+			// descend further or not.
+			i.pos = i.o.constrMaxPos
+		}
+
+		if i.pos < 0 {
+			if i.s.len() > 0 {
+				// Iterate up tree, if possible.
+				i.ascend()
+			} else {
+				// We've reached the root, so there's no more ascending to do;
+				// the iterator is already invalid, so simply return.
+				return
+			}
+		} else if !i.n.leaf() {
+			// Iterate down tree, but only if there's any hope of finding an
+			// overlap. In particular, if the max key found in the child subtree
+			// is less than the search item's start key, there's no way we'll
+			// find an overlap.
+			if i.o.inConstrMin || i.n.children[i.pos].max().contains(item) {
+				par := i.n
+				pos := i.pos
+				i.descend(par, pos)
+				// Position the iterator to the last child. It's fine if we
+				// descended to a leaf node; we'll be positioned to the last
+				// item in the leaf node in the next iteration.
+				i.pos = i.n.count
+
+				// Refine the constraint bounds, if necessary.
+				if par == i.o.constrMinN && pos == i.o.constrMinPos {
+					i.constrainMinSearchBounds(item)
+				}
+				if par == i.o.constrMaxN && pos == i.o.constrMaxPos {
+					i.constrainMaxSearchBounds(item)
+				}
+				continue
+			}
+		}
+
+		if i.n == i.o.constrMinN && i.pos == i.o.constrMinPos {
+			// The item at i.o.constrMinPos is the left-most item whose start
+			// key is greater than or equal to the search range's start key. As
+			// such, it's the last item we can eschew key comparisons for. The
+			// i.pos-- is going to transition us from a constrained minimum to
+			// an unconstrained minimum scan; update state to reflect this.
+			i.o.inConstrMin = false
+		}
+
+		// NB: We decrement the position between descending into a child node
+		// and checking an item. This is in contrast to the forward scan, where
+		// the increment happens after doing both.
+		//
+		// This is because the number of children at an interior node is one
+		// more than the number of items. As such, positioning the iterator at
+		// the last child is different than positioning it at the last item
+		// (it's off by one). On the other hand, positioning the iterator at the
+		// first item or the first child is the same index (0).
+		i.pos--
+
+		// Iterate across node.
+		if i.pos >= 0 {
+			if i.o.inConstrMin {
+				// Fast-path to avoid span comparison. i.o.inConstrMin
+				// tells us that the item has a start key that's greater than
+				// the search range's start key.
+				return
+			}
+			if upperBound(i.n.items[i.pos]).contains(item) {
+				// We're not in the constrained minimum state, which means the
+				// item's start key is less than the search range's start key.
+				// We must check if the item's end key results in an overlap
+				// (i.e. if the end key is contained in the search range).
+				return
+			}
+		}
 	}
 }

--- a/pkg/kv/kvclient/kvcoord/bufferedwrite_interval_btree_test.go
+++ b/pkg/kv/kvclient/kvcoord/bufferedwrite_interval_btree_test.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"math/rand"
 	"reflect"
+	"slices"
 	"sync"
 	"testing"
 
@@ -232,6 +233,19 @@ func checkIter(t *testing.T, it iterator, start, end int, spanMemo map[int]roach
 	if i != end {
 		t.Fatalf("expected %d, but at %d", end, i)
 	}
+
+	for it.LastOverlap(all); it.Valid(); it.PrevOverlap(all) {
+		i--
+		item := it.Cur()
+
+		expected := spanWithMemo(i, spanMemo)
+		if !expected.Equal(spanFromItem(item)) {
+			t.Fatalf("expected %s, but found %s; i %v", expected, spanFromItem(item), i)
+		}
+	}
+	if i != start {
+		t.Fatalf("expected %d, but at %d: %+v; end was %d", start, i, it, end)
+	}
 }
 
 // TestBTree tests basic btree operations.
@@ -402,6 +416,86 @@ func TestBTreeSeekOverlap(t *testing.T) {
 		}
 	}
 	it.FirstOverlap(newItem(span(count + size + 1)))
+	if it.Valid() {
+		t.Fatalf("expected invalid iterator")
+	}
+}
+
+// TestBTreeSeekOverlapReverse tests btree iterator overlap operations in
+// reverse order.
+func TestBTreeSeekOverlapReverse(t *testing.T) {
+	const count = 513
+	const size = 2 * maxItems
+
+	var tr btree
+	for i := 0; i < count; i++ {
+		tr.Set(newItem(spanWithEnd(i, i+size+1)))
+	}
+
+	// Iterate over overlaps with a point scan.
+	it := tr.MakeIter()
+	for i := 0; i < count+size; i++ {
+		scanItem := newItem(spanWithEnd(i, i))
+		it.LastOverlap(scanItem)
+		for j := size; j >= 0; j-- {
+			expStart := i - size + j
+			if expStart < 0 {
+				continue
+			}
+			if expStart >= count {
+				continue
+			}
+
+			if !it.Valid() {
+				t.Fatalf("%d/%d: expected valid iterator", i, j)
+			}
+			item := it.Cur()
+			expected := spanWithEnd(expStart, expStart+size+1)
+			if !expected.Equal(spanFromItem(item)) {
+				t.Fatalf("%d: expected %s, but found %s", i, expected, spanFromItem(item))
+			}
+
+			it.PrevOverlap(scanItem)
+		}
+		if it.Valid() {
+			t.Fatalf("%d: expected invalid iterator %v", i, it.Cur())
+		}
+	}
+	it.LastOverlap(newItem(span(count + size + 1)))
+	if it.Valid() {
+		t.Fatalf("expected invalid iterator")
+	}
+
+	// Iterate over overlaps with a range scan.
+	it = tr.MakeIter()
+	for i := 0; i < count+size; i++ {
+		scanItem := newItem(spanWithEnd(i, i+size+1))
+		it.LastOverlap(scanItem)
+		for j := 2 * size; j >= 0; j-- {
+			expStart := i - size + j
+			if expStart < 0 {
+				continue
+			}
+			if expStart >= count {
+				continue
+			}
+
+			if !it.Valid() {
+				t.Fatalf("%d/%d: expected valid iterator", i, j)
+			}
+			item := it.Cur()
+			expected := spanWithEnd(expStart, expStart+size+1)
+			if !expected.Equal(spanFromItem(item)) {
+				t.Fatalf("%d: expected %s, but found %s", i, expected, spanFromItem(item))
+			}
+
+			it.PrevOverlap(scanItem)
+		}
+		if it.Valid() {
+			t.Fatalf("%d: expected invalid iterator %v", i, it.Cur())
+		}
+	}
+	it.LastOverlap(newItem(span(count + size + 1)))
 	if it.Valid() {
 		t.Fatalf("expected invalid iterator")
 	}
@@ -766,7 +860,7 @@ func TestBTreeSeekOverlapRandom(t *testing.T) {
 				scanItem = newItem(spanWithEnd(scanStart, scanEnd+1))
 			}
 
-			var exp, found []*bufferedWrite
+			var exp, found, reverseFound []*bufferedWrite
 			for startKey, endKey := range itemSpans {
 				if startKey <= scanEnd && endKey >= scanStart {
 					exp = append(exp, items[startKey])
@@ -780,7 +874,20 @@ func TestBTreeSeekOverlapRandom(t *testing.T) {
 				it.NextOverlap(scanItem)
 			}
 
+			// Check reverse scans as well.
+			it = tr.MakeIter()
+			it.LastOverlap(scanItem)
+			for it.Valid() {
+				reverseFound = append(reverseFound, it.Cur())
+				it.PrevOverlap(scanItem)
+			}
+
 			require.Equal(t, len(exp), len(found), "search for %v", spanFromItem(scanItem))
+			slices.SortFunc(found, compare)
+			require.Equal(t, exp, found)
+			require.Equal(t, len(exp), len(reverseFound), "search for %v", spanFromItem(scanItem))
+			slices.SortFunc(reverseFound, compare)
+			require.Equal(t, exp, reverseFound)
 		}
 	}
 }
@@ -1087,6 +1194,29 @@ func BenchmarkBTreeIterNextOverlap(b *testing.B) {
 	}
 }
 
+// BenchmarkBTreeIterPrevOverlap measures the cost of seeking a btree iterator
+// to the previous overlapping item in the tree.
+func BenchmarkBTreeIterPrevOverlap(b *testing.B) {
+	var tr btree
+
+	const count = 8 << 10
+	const size = 2 * maxItems
+	for i := 0; i < count; i++ {
+		item := newItem(spanWithEnd(i, i+size+1))
+		tr.Set(item)
+	}
+
+	allCmd := newItem(spanWithEnd(0, count+1))
+	it := tr.MakeIter()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if !it.Valid() {
+			it.LastOverlap(allCmd)
+		}
+		it.PrevOverlap(allCmd)
+	}
+}
+
 // BenchmarkBTreeIterOverlapScan measures the cost of scanning over all
 // overlapping items using a btree iterator.
 func BenchmarkBTreeIterOverlapScan(b *testing.B) {
@@ -1106,6 +1236,29 @@ func BenchmarkBTreeIterOverlapScan(b *testing.B) {
 		it.FirstOverlap(item)
 		for it.Valid() {
 			it.NextOverlap(item)
+		}
+	}
+}
+
+// BenchmarkBTreeIterReverseOverlapScan measures the cost of scanning over all
+// overlapping items using a btree iterator in reverse order.
+func BenchmarkBTreeIterReverseOverlapScan(b *testing.B) {
+	var tr btree
+	rng := rand.New(rand.NewSource(timeutil.Now().UnixNano()))
+
+	const count = 8 << 10
+	const size = 2 * maxItems
+	for i := 0; i < count; i++ {
+		tr.Set(newItem(spanWithEnd(i, i+size+1)))
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		item := newItem(randomSpan(rng, count))
+		it := tr.MakeIter()
+		it.LastOverlap(item)
+		for it.Valid() {
+			it.PrevOverlap(item)
 		}
 	}
 }

--- a/pkg/kv/kvserver/concurrency/keylocks_interval_btree.go
+++ b/pkg/kv/kvserver/concurrency/keylocks_interval_btree.go
@@ -1021,14 +1021,23 @@ func (i *iterator) Cur() *keyLocks {
 	return i.n.items[i.pos]
 }
 
-// An overlap scan is a scan over all items that overlap with the provided
-// item in order of the overlapping items' start keys. The goal of the scan
-// is to minimize the number of key comparisons performed in total. The
-// algorithm operates based on the following two invariants maintained by
-// augmented interval btree:
+// An overlap scan is a scan over all items that overlap with the provided item
+// (start key inclusive, end key exclusive) in order of the overlapping items'
+// start keys. The goal of the scan is to minimize the number of key comparisons
+// performed in total. The algorithm operates based on the following two
+// invariants maintained by augmented interval btree:
 //  1. all items are sorted in the btree based on their start key.
 //  2. all btree nodes maintain the upper bound end key of all items
 //     in their subtree.
+//
+// An overlapping scan can be performed either in the forward or reverse
+// direction. The algorithm for each is slightly different. First, we present
+// each algorithm, and then we talk about the differences (and the reasons for
+// for them).
+//
+// -----------------------------------------------------------------------------
+// Forward Overlap Scan Algorithm
+// -----------------------------------------------------------------------------
 //
 // The scan algorithm starts in "unconstrained minimum" and "unconstrained
 // maximum" states. To enter a "constrained minimum" state, the scan must reach
@@ -1043,33 +1052,113 @@ func (i *iterator) Cur() *keyLocks {
 //
 // The scan algorithm works like a standard btree forward scan with the
 // following augmentations:
-//  1. before tranversing the tree, the scan performs a binary search on the
+//  1. before traversing the tree, the scan performs a binary search on the
 //     root node's items to determine a "soft" lower-bound constraint position
 //     and a "hard" upper-bound constraint position in the root's children.
-//  2. when tranversing into a child node in the lower or upper bound constraint
+//  2. when traversing into a child node in the lower or upper bound constraint
 //     position, the constraint is refined by searching the child's items.
 //  3. the initial traversal down the tree follows the left-most children
 //     whose upper bound end keys are equal to or greater than the start key
 //     of the search range. The children followed will be equal to or less
 //     than the soft lower bound constraint.
-//  4. once the initial tranversal completes and the scan is in the left-most
+//  4. once the initial traversal completes and the scan is in the left-most
 //     btree node whose upper bound overlaps the search range, key comparisons
 //     must be performed with each item in the tree. This is necessary because
 //     any of these items may have end keys that cause them to overlap with the
 //     search range.
 //  5. once the scan reaches the lower bound constraint position (the first item
 //     with a start key equal to or greater than the search range's start key),
-//     it can begin scaning without performing key comparisons. This is allowed
+//     it can begin scanning without performing key comparisons. This is allowed
 //     because all items from this point forward will have end keys that are
 //     greater than the search range's start key.
 //  6. once the scan reaches the upper bound constraint position, it terminates.
 //     It does so because the item at this position is the first item with a
 //     start key larger than the search range's end key.
+//
+// -----------------------------------------------------------------------------
+// Reverse Overlap Scan Algorithm
+// -----------------------------------------------------------------------------
+//
+// The scan algorithm starts in a "unconstrained minimum" and "unconstrained
+// maximum" state. To enter the "constrained maximum" state, the scan must reach
+// items in the tree with start keys below the search range's end key. Once the
+// scan enters the "constrained maximum" state, it will remain there. To enter
+// the "constrained minimum" state, the scan must reach items in the tree with
+// start keys above the search range's start key. To enter a "constrained
+// minimum" state, the scan must determine the first child btree node in a given
+// subtree that can have items with start keys less than the search range's
+// start key. The scan then remains in the "constrained minimum" state, until it
+// traverses into this child node, at which point it moves to the "unconstrained
+// minimum" state again.
+//
+// The scan algorithm works like a standard btree reverse scan with the
+// following augmentations:
+//  1. before traversing the tree, the scan performs a binary search on the root
+//     node's items to determine a "soft" lower-bound constraint position and a
+//     "hard" upper-bound constraint position in the root's children.
+//  2. when traversing into a child node in the lower or upper bound constraint
+//     position the constraint is refined by searching the child's items.
+//  3. the initial traversal down the tree follows the right-most children whose
+//     upper bound end keys are equal to or greater than the start key of the search
+//     range. The children followed will be equal to or less than the hard
+//     upper-bound constraint.
+//  4. once the initial traversal completes and the scan is in the right-most
+//     btree node whose upper bound overlaps the search range, then jumps directly
+//     to the first item before the upper bound constraint position. This is because
+//     the upper bound constraint position is exclusive.
+//  5. as long as the scan hasn't reached the lower bound constraint position
+//     (the first item with a start key equal or greater than the search range's
+//     start key), it can continue scanning without performing key comparisions.
+//     This is allowed because all items until the lower bound constraint position
+//     is reached will have end keys greater than the search range's start key, and
+//     we know that all items in the tree have start keys less than the search
+//     range's end key.
+//  6. once the scan reaches the lower bound constraint position, key comparisons
+//     must be performed with each item in the tree. This is necessary because even
+//     though the scan is dealing with items that have start keys less than the
+//     serach range's start key, it is possible that these items have end keys that
+//     cause them to overlap with the search range.
+//
+// -----------------------------------------------------------------------------
+// Differences between forward and reverse overlap scans
+// -----------------------------------------------------------------------------
+//
+//  1. The forward overlapping scan can terminate early. It can do so once it
+//     reaches the hard upper bound constaint. This is the first item whose start
+//     key is greater than or equal to the search range's end key.
+//  2. The reverse overlaping scan can directly "jump" directly to the item right
+//     before the hard upper bound constraint. This allows it to skip any subtree/
+//     items that are past the search range's end key.
+//  3. Once the forward overlapping scan enters the inConstrMin condition, it
+//     stays there. The scan reaches inConstrMin at the first item whose start key
+//     is greater than the search range's start key. While inConstrMin is true, no
+//     key comparisons need to be performed[1].
+//  4. In contrast, the reverse overlapping starts off[2] in the inConstrMin
+//     state (where no key comparisons are needed). Once it exitst this state, key
+//     comparisons are needed.
+//
+// [1] This is because the search interval's end key must be greater than the
+// item's start key. Otherwise, we'd have terminated the scan. So, the item must
+// overlap with the search range, and we can skip key comparisons.
+// [2] After it's jumped to the item right before the "hard" upper bound
+// constraint.
+//
+// There's a few reasons for the differences here:
+//  1. All items in the b-tree are sorted by start key. This means that we have a
+//     "hard" upper bound, but a "soft" lower bound. For forward scans, this means
+//     that we can terminate early when this "hard" upper bound is reached. For
+//     reverse scans, this means that we can directly jump to the last item the scan
+//     will ever see.
+//  2. The number of children at an interior node is one more than the number of
+//     items. For a forward scan, the scan starts off at the 0th index regardless of
+//     the type of node. For a reverse scan, however, the scan must start off at the
+//     last child for interior nodes, and the last item for leaf-nodes. These are "off
+//     by one", which requires some care to get right.
 type overlapScan struct {
 	// The "soft" lower-bound constraint.
-	constrMinN       *node
-	constrMinPos     int16
-	constrMinReached bool
+	constrMinN   *node
+	constrMinPos int16
+	inConstrMin  bool
 
 	// The "hard" upper-bound constraint.
 	constrMaxN   *node
@@ -1084,10 +1173,23 @@ func (i *iterator) FirstOverlap(item *keyLocks) {
 		return
 	}
 	i.pos = 0
-	i.o = overlapScan{}
 	i.constrainMinSearchBounds(item)
 	i.constrainMaxSearchBounds(item)
 	i.findNextOverlap(item)
+}
+
+// LastOverlap seeks to the last item in the btree that overlaps with the
+// provided search item.
+func (i *iterator) LastOverlap(item *keyLocks) {
+	i.reset()
+	if i.n == nil {
+		return
+	}
+	i.pos = i.n.count
+	i.o.inConstrMin = true // reverse scans start inConstrMin
+	i.constrainMinSearchBounds(item)
+	i.constrainMaxSearchBounds(item)
+	i.findPrevOverlap(item)
 }
 
 // NextOverlap positions the iterator to the item immediately following
@@ -1100,6 +1202,24 @@ func (i *iterator) NextOverlap(item *keyLocks) {
 	i.findNextOverlap(item)
 }
 
+// PrevOverlap positions the iterator to the item immediately preceding
+// its current position that overlaps with the search item.
+func (i *iterator) PrevOverlap(item *keyLocks) {
+	if i.n == nil {
+		return
+	}
+	i.findPrevOverlap(item)
+}
+
+// constrainMinSearchBounds sets the "soft" lower-bound constraint. This is the
+// first item whose start key is greater than or equal to the supplied search
+// range's start key.
+//
+//	| search range:           [-------------)
+//	| items:         [----) [----) [----) [----) [----)
+//	|                                ^
+//	|                                |
+//	|                                +---constrMinPos
 func (i *iterator) constrainMinSearchBounds(item *keyLocks) {
 	k := item.Key()
 	j := sort.Search(int(i.n.count), func(j int) bool {
@@ -1109,6 +1229,15 @@ func (i *iterator) constrainMinSearchBounds(item *keyLocks) {
 	i.o.constrMinPos = int16(j)
 }
 
+// constrainMaxSearchBounds sets the "hard" upper-bound constraint. This is the
+// first item whose start key is greater than the supplied search range's end
+// key.
+//
+//	| search range:           [--------------)
+//	| items:         [----) [----) [----) [----) [----)
+//	|                                               ^
+//	|                                               |
+//	|                                               +---constrMaxPos
 func (i *iterator) constrainMaxSearchBounds(item *keyLocks) {
 	up := upperBound(item)
 	j := sort.Search(int(i.n.count), func(j int) bool {
@@ -1125,7 +1254,7 @@ func (i *iterator) findNextOverlap(item *keyLocks) {
 			i.ascend()
 		} else if !i.n.leaf() {
 			// Iterate down tree.
-			if i.o.constrMinReached || i.n.children[i.pos].max().contains(item) {
+			if i.o.inConstrMin || i.n.children[i.pos].max().contains(item) {
 				par := i.n
 				pos := i.pos
 				i.descend(par, pos)
@@ -1149,14 +1278,14 @@ func (i *iterator) findNextOverlap(item *keyLocks) {
 		}
 		if i.n == i.o.constrMinN && i.pos == i.o.constrMinPos {
 			// The scan reached the soft lower-bound constraint.
-			i.o.constrMinReached = true
+			i.o.inConstrMin = true
 		}
 
 		// Iterate across node.
 		if i.pos < i.n.count {
 			// Check for overlapping item.
-			if i.o.constrMinReached {
-				// Fast-path to avoid span comparison. i.o.constrMinReached
+			if i.o.inConstrMin {
+				// Fast-path to avoid span comparison. i.o.inConstrMin
 				// tells us that all items have end keys above our search
 				// span's start key.
 				return
@@ -1166,5 +1295,95 @@ func (i *iterator) findNextOverlap(item *keyLocks) {
 			}
 		}
 		i.pos++
+	}
+}
+
+func (i *iterator) findPrevOverlap(item *keyLocks) {
+	for {
+		// First off, we want to avoid exploring any items that are past the
+		// search range's end key.
+		if i.n == i.o.constrMaxN && i.pos > i.o.constrMaxPos {
+			// The item at i.o.constrMaxPos is the first item with a start key
+			// that's greater than the search range's end key. As such, it is
+			// the left-most item that does not overlap with the search range --
+			// we want to "jump" straight to the preceding position. However, we
+			// can't just position the iterator to i.o.constrMaxPos - 1; if this
+			// is an interior node, we might need to descend into the child on
+			// the right of i.o.constrMaxPos - 1 first. So, we set the position
+			// to that of the child node, and let the loop decide whether to
+			// descend further or not.
+			i.pos = i.o.constrMaxPos
+		}
+
+		if i.pos < 0 {
+			if i.s.len() > 0 {
+				// Iterate up tree, if possible.
+				i.ascend()
+			} else {
+				// We've reached the root, so there's no more ascending to do;
+				// the iterator is already invalid, so simply return.
+				return
+			}
+		} else if !i.n.leaf() {
+			// Iterate down tree, but only if there's any hope of finding an
+			// overlap. In particular, if the max key found in the child subtree
+			// is less than the search item's start key, there's no way we'll
+			// find an overlap.
+			if i.o.inConstrMin || i.n.children[i.pos].max().contains(item) {
+				par := i.n
+				pos := i.pos
+				i.descend(par, pos)
+				// Position the iterator to the last child. It's fine if we
+				// descended to a leaf node; we'll be positioned to the last
+				// item in the leaf node in the next iteration.
+				i.pos = i.n.count
+
+				// Refine the constraint bounds, if necessary.
+				if par == i.o.constrMinN && pos == i.o.constrMinPos {
+					i.constrainMinSearchBounds(item)
+				}
+				if par == i.o.constrMaxN && pos == i.o.constrMaxPos {
+					i.constrainMaxSearchBounds(item)
+				}
+				continue
+			}
+		}
+
+		if i.n == i.o.constrMinN && i.pos == i.o.constrMinPos {
+			// The item at i.o.constrMinPos is the left-most item whose start
+			// key is greater than or equal to the search range's start key. As
+			// such, it's the last item we can eschew key comparisons for. The
+			// i.pos-- is going to transition us from a constrained minimum to
+			// an unconstrained minimum scan; update state to reflect this.
+			i.o.inConstrMin = false
+		}
+
+		// NB: We decrement the position between descending into a child node
+		// and checking an item. This is in contrast to the forward scan, where
+		// the increment happens after doing both.
+		//
+		// This is because the number of children at an interior node is one
+		// more than the number of items. As such, positioning the iterator at
+		// the last child is different than positioning it at the last item
+		// (it's off by one). On the other hand, positioning the iterator at the
+		// first item or the first child is the same index (0).
+		i.pos--
+
+		// Iterate across node.
+		if i.pos >= 0 {
+			if i.o.inConstrMin {
+				// Fast-path to avoid span comparison. i.o.inConstrMin
+				// tells us that the item has a start key that's greater than
+				// the search range's start key.
+				return
+			}
+			if upperBound(i.n.items[i.pos]).contains(item) {
+				// We're not in the constrained minimum state, which means the
+				// item's start key is less than the search range's start key.
+				// We must check if the item's end key results in an overlap
+				// (i.e. if the end key is contained in the search range).
+				return
+			}
+		}
 	}
 }

--- a/pkg/kv/kvserver/concurrency/keylocks_interval_btree_test.go
+++ b/pkg/kv/kvserver/concurrency/keylocks_interval_btree_test.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"math/rand"
 	"reflect"
+	"slices"
 	"sync"
 	"testing"
 
@@ -232,6 +233,19 @@ func checkIter(t *testing.T, it iterator, start, end int, spanMemo map[int]roach
 	if i != end {
 		t.Fatalf("expected %d, but at %d", end, i)
 	}
+
+	for it.LastOverlap(all); it.Valid(); it.PrevOverlap(all) {
+		i--
+		item := it.Cur()
+
+		expected := spanWithMemo(i, spanMemo)
+		if !expected.Equal(spanFromItem(item)) {
+			t.Fatalf("expected %s, but found %s; i %v", expected, spanFromItem(item), i)
+		}
+	}
+	if i != start {
+		t.Fatalf("expected %d, but at %d: %+v; end was %d", start, i, it, end)
+	}
 }
 
 // TestBTree tests basic btree operations.
@@ -402,6 +416,86 @@ func TestBTreeSeekOverlap(t *testing.T) {
 		}
 	}
 	it.FirstOverlap(newItem(span(count + size + 1)))
+	if it.Valid() {
+		t.Fatalf("expected invalid iterator")
+	}
+}
+
+// TestBTreeSeekOverlapReverse tests btree iterator overlap operations in
+// reverse order.
+func TestBTreeSeekOverlapReverse(t *testing.T) {
+	const count = 513
+	const size = 2 * maxItems
+
+	var tr btree
+	for i := 0; i < count; i++ {
+		tr.Set(newItem(spanWithEnd(i, i+size+1)))
+	}
+
+	// Iterate over overlaps with a point scan.
+	it := tr.MakeIter()
+	for i := 0; i < count+size; i++ {
+		scanItem := newItem(spanWithEnd(i, i))
+		it.LastOverlap(scanItem)
+		for j := size; j >= 0; j-- {
+			expStart := i - size + j
+			if expStart < 0 {
+				continue
+			}
+			if expStart >= count {
+				continue
+			}
+
+			if !it.Valid() {
+				t.Fatalf("%d/%d: expected valid iterator", i, j)
+			}
+			item := it.Cur()
+			expected := spanWithEnd(expStart, expStart+size+1)
+			if !expected.Equal(spanFromItem(item)) {
+				t.Fatalf("%d: expected %s, but found %s", i, expected, spanFromItem(item))
+			}
+
+			it.PrevOverlap(scanItem)
+		}
+		if it.Valid() {
+			t.Fatalf("%d: expected invalid iterator %v", i, it.Cur())
+		}
+	}
+	it.LastOverlap(newItem(span(count + size + 1)))
+	if it.Valid() {
+		t.Fatalf("expected invalid iterator")
+	}
+
+	// Iterate over overlaps with a range scan.
+	it = tr.MakeIter()
+	for i := 0; i < count+size; i++ {
+		scanItem := newItem(spanWithEnd(i, i+size+1))
+		it.LastOverlap(scanItem)
+		for j := 2 * size; j >= 0; j-- {
+			expStart := i - size + j
+			if expStart < 0 {
+				continue
+			}
+			if expStart >= count {
+				continue
+			}
+
+			if !it.Valid() {
+				t.Fatalf("%d/%d: expected valid iterator", i, j)
+			}
+			item := it.Cur()
+			expected := spanWithEnd(expStart, expStart+size+1)
+			if !expected.Equal(spanFromItem(item)) {
+				t.Fatalf("%d: expected %s, but found %s", i, expected, spanFromItem(item))
+			}
+
+			it.PrevOverlap(scanItem)
+		}
+		if it.Valid() {
+			t.Fatalf("%d: expected invalid iterator %v", i, it.Cur())
+		}
+	}
+	it.LastOverlap(newItem(span(count + size + 1)))
 	if it.Valid() {
 		t.Fatalf("expected invalid iterator")
 	}
@@ -766,7 +860,7 @@ func TestBTreeSeekOverlapRandom(t *testing.T) {
 				scanItem = newItem(spanWithEnd(scanStart, scanEnd+1))
 			}
 
-			var exp, found []*keyLocks
+			var exp, found, reverseFound []*keyLocks
 			for startKey, endKey := range itemSpans {
 				if startKey <= scanEnd && endKey >= scanStart {
 					exp = append(exp, items[startKey])
@@ -780,7 +874,20 @@ func TestBTreeSeekOverlapRandom(t *testing.T) {
 				it.NextOverlap(scanItem)
 			}
 
+			// Check reverse scans as well.
+			it = tr.MakeIter()
+			it.LastOverlap(scanItem)
+			for it.Valid() {
+				reverseFound = append(reverseFound, it.Cur())
+				it.PrevOverlap(scanItem)
+			}
+
 			require.Equal(t, len(exp), len(found), "search for %v", spanFromItem(scanItem))
+			slices.SortFunc(found, compare)
+			require.Equal(t, exp, found)
+			require.Equal(t, len(exp), len(reverseFound), "search for %v", spanFromItem(scanItem))
+			slices.SortFunc(reverseFound, compare)
+			require.Equal(t, exp, reverseFound)
 		}
 	}
 }
@@ -1087,6 +1194,29 @@ func BenchmarkBTreeIterNextOverlap(b *testing.B) {
 	}
 }
 
+// BenchmarkBTreeIterPrevOverlap measures the cost of seeking a btree iterator
+// to the previous overlapping item in the tree.
+func BenchmarkBTreeIterPrevOverlap(b *testing.B) {
+	var tr btree
+
+	const count = 8 << 10
+	const size = 2 * maxItems
+	for i := 0; i < count; i++ {
+		item := newItem(spanWithEnd(i, i+size+1))
+		tr.Set(item)
+	}
+
+	allCmd := newItem(spanWithEnd(0, count+1))
+	it := tr.MakeIter()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if !it.Valid() {
+			it.LastOverlap(allCmd)
+		}
+		it.PrevOverlap(allCmd)
+	}
+}
+
 // BenchmarkBTreeIterOverlapScan measures the cost of scanning over all
 // overlapping items using a btree iterator.
 func BenchmarkBTreeIterOverlapScan(b *testing.B) {
@@ -1106,6 +1236,29 @@ func BenchmarkBTreeIterOverlapScan(b *testing.B) {
 		it.FirstOverlap(item)
 		for it.Valid() {
 			it.NextOverlap(item)
+		}
+	}
+}
+
+// BenchmarkBTreeIterReverseOverlapScan measures the cost of scanning over all
+// overlapping items using a btree iterator in reverse order.
+func BenchmarkBTreeIterReverseOverlapScan(b *testing.B) {
+	var tr btree
+	rng := rand.New(rand.NewSource(timeutil.Now().UnixNano()))
+
+	const count = 8 << 10
+	const size = 2 * maxItems
+	for i := 0; i < count; i++ {
+		tr.Set(newItem(spanWithEnd(i, i+size+1)))
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		item := newItem(randomSpan(rng, count))
+		it := tr.MakeIter()
+		it.LastOverlap(item)
+		for it.Valid() {
+			it.PrevOverlap(item)
 		}
 	}
 }

--- a/pkg/kv/kvserver/spanlatch/latch_interval_btree.go
+++ b/pkg/kv/kvserver/spanlatch/latch_interval_btree.go
@@ -1021,14 +1021,23 @@ func (i *iterator) Cur() *latch {
 	return i.n.items[i.pos]
 }
 
-// An overlap scan is a scan over all items that overlap with the provided
-// item in order of the overlapping items' start keys. The goal of the scan
-// is to minimize the number of key comparisons performed in total. The
-// algorithm operates based on the following two invariants maintained by
-// augmented interval btree:
+// An overlap scan is a scan over all items that overlap with the provided item
+// (start key inclusive, end key exclusive) in order of the overlapping items'
+// start keys. The goal of the scan is to minimize the number of key comparisons
+// performed in total. The algorithm operates based on the following two
+// invariants maintained by augmented interval btree:
 //  1. all items are sorted in the btree based on their start key.
 //  2. all btree nodes maintain the upper bound end key of all items
 //     in their subtree.
+//
+// An overlapping scan can be performed either in the forward or reverse
+// direction. The algorithm for each is slightly different. First, we present
+// each algorithm, and then we talk about the differences (and the reasons for
+// for them).
+//
+// -----------------------------------------------------------------------------
+// Forward Overlap Scan Algorithm
+// -----------------------------------------------------------------------------
 //
 // The scan algorithm starts in "unconstrained minimum" and "unconstrained
 // maximum" states. To enter a "constrained minimum" state, the scan must reach
@@ -1043,33 +1052,113 @@ func (i *iterator) Cur() *latch {
 //
 // The scan algorithm works like a standard btree forward scan with the
 // following augmentations:
-//  1. before tranversing the tree, the scan performs a binary search on the
+//  1. before traversing the tree, the scan performs a binary search on the
 //     root node's items to determine a "soft" lower-bound constraint position
 //     and a "hard" upper-bound constraint position in the root's children.
-//  2. when tranversing into a child node in the lower or upper bound constraint
+//  2. when traversing into a child node in the lower or upper bound constraint
 //     position, the constraint is refined by searching the child's items.
 //  3. the initial traversal down the tree follows the left-most children
 //     whose upper bound end keys are equal to or greater than the start key
 //     of the search range. The children followed will be equal to or less
 //     than the soft lower bound constraint.
-//  4. once the initial tranversal completes and the scan is in the left-most
+//  4. once the initial traversal completes and the scan is in the left-most
 //     btree node whose upper bound overlaps the search range, key comparisons
 //     must be performed with each item in the tree. This is necessary because
 //     any of these items may have end keys that cause them to overlap with the
 //     search range.
 //  5. once the scan reaches the lower bound constraint position (the first item
 //     with a start key equal to or greater than the search range's start key),
-//     it can begin scaning without performing key comparisons. This is allowed
+//     it can begin scanning without performing key comparisons. This is allowed
 //     because all items from this point forward will have end keys that are
 //     greater than the search range's start key.
 //  6. once the scan reaches the upper bound constraint position, it terminates.
 //     It does so because the item at this position is the first item with a
 //     start key larger than the search range's end key.
+//
+// -----------------------------------------------------------------------------
+// Reverse Overlap Scan Algorithm
+// -----------------------------------------------------------------------------
+//
+// The scan algorithm starts in a "unconstrained minimum" and "unconstrained
+// maximum" state. To enter the "constrained maximum" state, the scan must reach
+// items in the tree with start keys below the search range's end key. Once the
+// scan enters the "constrained maximum" state, it will remain there. To enter
+// the "constrained minimum" state, the scan must reach items in the tree with
+// start keys above the search range's start key. To enter a "constrained
+// minimum" state, the scan must determine the first child btree node in a given
+// subtree that can have items with start keys less than the search range's
+// start key. The scan then remains in the "constrained minimum" state, until it
+// traverses into this child node, at which point it moves to the "unconstrained
+// minimum" state again.
+//
+// The scan algorithm works like a standard btree reverse scan with the
+// following augmentations:
+//  1. before traversing the tree, the scan performs a binary search on the root
+//     node's items to determine a "soft" lower-bound constraint position and a
+//     "hard" upper-bound constraint position in the root's children.
+//  2. when traversing into a child node in the lower or upper bound constraint
+//     position the constraint is refined by searching the child's items.
+//  3. the initial traversal down the tree follows the right-most children whose
+//     upper bound end keys are equal to or greater than the start key of the search
+//     range. The children followed will be equal to or less than the hard
+//     upper-bound constraint.
+//  4. once the initial traversal completes and the scan is in the right-most
+//     btree node whose upper bound overlaps the search range, then jumps directly
+//     to the first item before the upper bound constraint position. This is because
+//     the upper bound constraint position is exclusive.
+//  5. as long as the scan hasn't reached the lower bound constraint position
+//     (the first item with a start key equal or greater than the search range's
+//     start key), it can continue scanning without performing key comparisions.
+//     This is allowed because all items until the lower bound constraint position
+//     is reached will have end keys greater than the search range's start key, and
+//     we know that all items in the tree have start keys less than the search
+//     range's end key.
+//  6. once the scan reaches the lower bound constraint position, key comparisons
+//     must be performed with each item in the tree. This is necessary because even
+//     though the scan is dealing with items that have start keys less than the
+//     serach range's start key, it is possible that these items have end keys that
+//     cause them to overlap with the search range.
+//
+// -----------------------------------------------------------------------------
+// Differences between forward and reverse overlap scans
+// -----------------------------------------------------------------------------
+//
+//  1. The forward overlapping scan can terminate early. It can do so once it
+//     reaches the hard upper bound constaint. This is the first item whose start
+//     key is greater than or equal to the search range's end key.
+//  2. The reverse overlaping scan can directly "jump" directly to the item right
+//     before the hard upper bound constraint. This allows it to skip any subtree/
+//     items that are past the search range's end key.
+//  3. Once the forward overlapping scan enters the inConstrMin condition, it
+//     stays there. The scan reaches inConstrMin at the first item whose start key
+//     is greater than the search range's start key. While inConstrMin is true, no
+//     key comparisons need to be performed[1].
+//  4. In contrast, the reverse overlapping starts off[2] in the inConstrMin
+//     state (where no key comparisons are needed). Once it exitst this state, key
+//     comparisons are needed.
+//
+// [1] This is because the search interval's end key must be greater than the
+// item's start key. Otherwise, we'd have terminated the scan. So, the item must
+// overlap with the search range, and we can skip key comparisons.
+// [2] After it's jumped to the item right before the "hard" upper bound
+// constraint.
+//
+// There's a few reasons for the differences here:
+//  1. All items in the b-tree are sorted by start key. This means that we have a
+//     "hard" upper bound, but a "soft" lower bound. For forward scans, this means
+//     that we can terminate early when this "hard" upper bound is reached. For
+//     reverse scans, this means that we can directly jump to the last item the scan
+//     will ever see.
+//  2. The number of children at an interior node is one more than the number of
+//     items. For a forward scan, the scan starts off at the 0th index regardless of
+//     the type of node. For a reverse scan, however, the scan must start off at the
+//     last child for interior nodes, and the last item for leaf-nodes. These are "off
+//     by one", which requires some care to get right.
 type overlapScan struct {
 	// The "soft" lower-bound constraint.
-	constrMinN       *node
-	constrMinPos     int16
-	constrMinReached bool
+	constrMinN   *node
+	constrMinPos int16
+	inConstrMin  bool
 
 	// The "hard" upper-bound constraint.
 	constrMaxN   *node
@@ -1084,10 +1173,23 @@ func (i *iterator) FirstOverlap(item *latch) {
 		return
 	}
 	i.pos = 0
-	i.o = overlapScan{}
 	i.constrainMinSearchBounds(item)
 	i.constrainMaxSearchBounds(item)
 	i.findNextOverlap(item)
+}
+
+// LastOverlap seeks to the last item in the btree that overlaps with the
+// provided search item.
+func (i *iterator) LastOverlap(item *latch) {
+	i.reset()
+	if i.n == nil {
+		return
+	}
+	i.pos = i.n.count
+	i.o.inConstrMin = true // reverse scans start inConstrMin
+	i.constrainMinSearchBounds(item)
+	i.constrainMaxSearchBounds(item)
+	i.findPrevOverlap(item)
 }
 
 // NextOverlap positions the iterator to the item immediately following
@@ -1100,6 +1202,24 @@ func (i *iterator) NextOverlap(item *latch) {
 	i.findNextOverlap(item)
 }
 
+// PrevOverlap positions the iterator to the item immediately preceding
+// its current position that overlaps with the search item.
+func (i *iterator) PrevOverlap(item *latch) {
+	if i.n == nil {
+		return
+	}
+	i.findPrevOverlap(item)
+}
+
+// constrainMinSearchBounds sets the "soft" lower-bound constraint. This is the
+// first item whose start key is greater than or equal to the supplied search
+// range's start key.
+//
+//	| search range:           [-------------)
+//	| items:         [----) [----) [----) [----) [----)
+//	|                                ^
+//	|                                |
+//	|                                +---constrMinPos
 func (i *iterator) constrainMinSearchBounds(item *latch) {
 	k := item.Key()
 	j := sort.Search(int(i.n.count), func(j int) bool {
@@ -1109,6 +1229,15 @@ func (i *iterator) constrainMinSearchBounds(item *latch) {
 	i.o.constrMinPos = int16(j)
 }
 
+// constrainMaxSearchBounds sets the "hard" upper-bound constraint. This is the
+// first item whose start key is greater than the supplied search range's end
+// key.
+//
+//	| search range:           [--------------)
+//	| items:         [----) [----) [----) [----) [----)
+//	|                                               ^
+//	|                                               |
+//	|                                               +---constrMaxPos
 func (i *iterator) constrainMaxSearchBounds(item *latch) {
 	up := upperBound(item)
 	j := sort.Search(int(i.n.count), func(j int) bool {
@@ -1125,7 +1254,7 @@ func (i *iterator) findNextOverlap(item *latch) {
 			i.ascend()
 		} else if !i.n.leaf() {
 			// Iterate down tree.
-			if i.o.constrMinReached || i.n.children[i.pos].max().contains(item) {
+			if i.o.inConstrMin || i.n.children[i.pos].max().contains(item) {
 				par := i.n
 				pos := i.pos
 				i.descend(par, pos)
@@ -1149,14 +1278,14 @@ func (i *iterator) findNextOverlap(item *latch) {
 		}
 		if i.n == i.o.constrMinN && i.pos == i.o.constrMinPos {
 			// The scan reached the soft lower-bound constraint.
-			i.o.constrMinReached = true
+			i.o.inConstrMin = true
 		}
 
 		// Iterate across node.
 		if i.pos < i.n.count {
 			// Check for overlapping item.
-			if i.o.constrMinReached {
-				// Fast-path to avoid span comparison. i.o.constrMinReached
+			if i.o.inConstrMin {
+				// Fast-path to avoid span comparison. i.o.inConstrMin
 				// tells us that all items have end keys above our search
 				// span's start key.
 				return
@@ -1166,5 +1295,95 @@ func (i *iterator) findNextOverlap(item *latch) {
 			}
 		}
 		i.pos++
+	}
+}
+
+func (i *iterator) findPrevOverlap(item *latch) {
+	for {
+		// First off, we want to avoid exploring any items that are past the
+		// search range's end key.
+		if i.n == i.o.constrMaxN && i.pos > i.o.constrMaxPos {
+			// The item at i.o.constrMaxPos is the first item with a start key
+			// that's greater than the search range's end key. As such, it is
+			// the left-most item that does not overlap with the search range --
+			// we want to "jump" straight to the preceding position. However, we
+			// can't just position the iterator to i.o.constrMaxPos - 1; if this
+			// is an interior node, we might need to descend into the child on
+			// the right of i.o.constrMaxPos - 1 first. So, we set the position
+			// to that of the child node, and let the loop decide whether to
+			// descend further or not.
+			i.pos = i.o.constrMaxPos
+		}
+
+		if i.pos < 0 {
+			if i.s.len() > 0 {
+				// Iterate up tree, if possible.
+				i.ascend()
+			} else {
+				// We've reached the root, so there's no more ascending to do;
+				// the iterator is already invalid, so simply return.
+				return
+			}
+		} else if !i.n.leaf() {
+			// Iterate down tree, but only if there's any hope of finding an
+			// overlap. In particular, if the max key found in the child subtree
+			// is less than the search item's start key, there's no way we'll
+			// find an overlap.
+			if i.o.inConstrMin || i.n.children[i.pos].max().contains(item) {
+				par := i.n
+				pos := i.pos
+				i.descend(par, pos)
+				// Position the iterator to the last child. It's fine if we
+				// descended to a leaf node; we'll be positioned to the last
+				// item in the leaf node in the next iteration.
+				i.pos = i.n.count
+
+				// Refine the constraint bounds, if necessary.
+				if par == i.o.constrMinN && pos == i.o.constrMinPos {
+					i.constrainMinSearchBounds(item)
+				}
+				if par == i.o.constrMaxN && pos == i.o.constrMaxPos {
+					i.constrainMaxSearchBounds(item)
+				}
+				continue
+			}
+		}
+
+		if i.n == i.o.constrMinN && i.pos == i.o.constrMinPos {
+			// The item at i.o.constrMinPos is the left-most item whose start
+			// key is greater than or equal to the search range's start key. As
+			// such, it's the last item we can eschew key comparisons for. The
+			// i.pos-- is going to transition us from a constrained minimum to
+			// an unconstrained minimum scan; update state to reflect this.
+			i.o.inConstrMin = false
+		}
+
+		// NB: We decrement the position between descending into a child node
+		// and checking an item. This is in contrast to the forward scan, where
+		// the increment happens after doing both.
+		//
+		// This is because the number of children at an interior node is one
+		// more than the number of items. As such, positioning the iterator at
+		// the last child is different than positioning it at the last item
+		// (it's off by one). On the other hand, positioning the iterator at the
+		// first item or the first child is the same index (0).
+		i.pos--
+
+		// Iterate across node.
+		if i.pos >= 0 {
+			if i.o.inConstrMin {
+				// Fast-path to avoid span comparison. i.o.inConstrMin
+				// tells us that the item has a start key that's greater than
+				// the search range's start key.
+				return
+			}
+			if upperBound(i.n.items[i.pos]).contains(item) {
+				// We're not in the constrained minimum state, which means the
+				// item's start key is less than the search range's start key.
+				// We must check if the item's end key results in an overlap
+				// (i.e. if the end key is contained in the search range).
+				return
+			}
+		}
 	}
 }

--- a/pkg/kv/kvserver/spanlatch/latch_interval_btree_test.go
+++ b/pkg/kv/kvserver/spanlatch/latch_interval_btree_test.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"math/rand"
 	"reflect"
+	"slices"
 	"sync"
 	"testing"
 
@@ -232,6 +233,19 @@ func checkIter(t *testing.T, it iterator, start, end int, spanMemo map[int]roach
 	if i != end {
 		t.Fatalf("expected %d, but at %d", end, i)
 	}
+
+	for it.LastOverlap(all); it.Valid(); it.PrevOverlap(all) {
+		i--
+		item := it.Cur()
+
+		expected := spanWithMemo(i, spanMemo)
+		if !expected.Equal(spanFromItem(item)) {
+			t.Fatalf("expected %s, but found %s; i %v", expected, spanFromItem(item), i)
+		}
+	}
+	if i != start {
+		t.Fatalf("expected %d, but at %d: %+v; end was %d", start, i, it, end)
+	}
 }
 
 // TestBTree tests basic btree operations.
@@ -402,6 +416,86 @@ func TestBTreeSeekOverlap(t *testing.T) {
 		}
 	}
 	it.FirstOverlap(newItem(span(count + size + 1)))
+	if it.Valid() {
+		t.Fatalf("expected invalid iterator")
+	}
+}
+
+// TestBTreeSeekOverlapReverse tests btree iterator overlap operations in
+// reverse order.
+func TestBTreeSeekOverlapReverse(t *testing.T) {
+	const count = 513
+	const size = 2 * maxItems
+
+	var tr btree
+	for i := 0; i < count; i++ {
+		tr.Set(newItem(spanWithEnd(i, i+size+1)))
+	}
+
+	// Iterate over overlaps with a point scan.
+	it := tr.MakeIter()
+	for i := 0; i < count+size; i++ {
+		scanItem := newItem(spanWithEnd(i, i))
+		it.LastOverlap(scanItem)
+		for j := size; j >= 0; j-- {
+			expStart := i - size + j
+			if expStart < 0 {
+				continue
+			}
+			if expStart >= count {
+				continue
+			}
+
+			if !it.Valid() {
+				t.Fatalf("%d/%d: expected valid iterator", i, j)
+			}
+			item := it.Cur()
+			expected := spanWithEnd(expStart, expStart+size+1)
+			if !expected.Equal(spanFromItem(item)) {
+				t.Fatalf("%d: expected %s, but found %s", i, expected, spanFromItem(item))
+			}
+
+			it.PrevOverlap(scanItem)
+		}
+		if it.Valid() {
+			t.Fatalf("%d: expected invalid iterator %v", i, it.Cur())
+		}
+	}
+	it.LastOverlap(newItem(span(count + size + 1)))
+	if it.Valid() {
+		t.Fatalf("expected invalid iterator")
+	}
+
+	// Iterate over overlaps with a range scan.
+	it = tr.MakeIter()
+	for i := 0; i < count+size; i++ {
+		scanItem := newItem(spanWithEnd(i, i+size+1))
+		it.LastOverlap(scanItem)
+		for j := 2 * size; j >= 0; j-- {
+			expStart := i - size + j
+			if expStart < 0 {
+				continue
+			}
+			if expStart >= count {
+				continue
+			}
+
+			if !it.Valid() {
+				t.Fatalf("%d/%d: expected valid iterator", i, j)
+			}
+			item := it.Cur()
+			expected := spanWithEnd(expStart, expStart+size+1)
+			if !expected.Equal(spanFromItem(item)) {
+				t.Fatalf("%d: expected %s, but found %s", i, expected, spanFromItem(item))
+			}
+
+			it.PrevOverlap(scanItem)
+		}
+		if it.Valid() {
+			t.Fatalf("%d: expected invalid iterator %v", i, it.Cur())
+		}
+	}
+	it.LastOverlap(newItem(span(count + size + 1)))
 	if it.Valid() {
 		t.Fatalf("expected invalid iterator")
 	}
@@ -766,7 +860,7 @@ func TestBTreeSeekOverlapRandom(t *testing.T) {
 				scanItem = newItem(spanWithEnd(scanStart, scanEnd+1))
 			}
 
-			var exp, found []*latch
+			var exp, found, reverseFound []*latch
 			for startKey, endKey := range itemSpans {
 				if startKey <= scanEnd && endKey >= scanStart {
 					exp = append(exp, items[startKey])
@@ -780,7 +874,20 @@ func TestBTreeSeekOverlapRandom(t *testing.T) {
 				it.NextOverlap(scanItem)
 			}
 
+			// Check reverse scans as well.
+			it = tr.MakeIter()
+			it.LastOverlap(scanItem)
+			for it.Valid() {
+				reverseFound = append(reverseFound, it.Cur())
+				it.PrevOverlap(scanItem)
+			}
+
 			require.Equal(t, len(exp), len(found), "search for %v", spanFromItem(scanItem))
+			slices.SortFunc(found, compare)
+			require.Equal(t, exp, found)
+			require.Equal(t, len(exp), len(reverseFound), "search for %v", spanFromItem(scanItem))
+			slices.SortFunc(reverseFound, compare)
+			require.Equal(t, exp, reverseFound)
 		}
 	}
 }
@@ -1087,6 +1194,29 @@ func BenchmarkBTreeIterNextOverlap(b *testing.B) {
 	}
 }
 
+// BenchmarkBTreeIterPrevOverlap measures the cost of seeking a btree iterator
+// to the previous overlapping item in the tree.
+func BenchmarkBTreeIterPrevOverlap(b *testing.B) {
+	var tr btree
+
+	const count = 8 << 10
+	const size = 2 * maxItems
+	for i := 0; i < count; i++ {
+		item := newItem(spanWithEnd(i, i+size+1))
+		tr.Set(item)
+	}
+
+	allCmd := newItem(spanWithEnd(0, count+1))
+	it := tr.MakeIter()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if !it.Valid() {
+			it.LastOverlap(allCmd)
+		}
+		it.PrevOverlap(allCmd)
+	}
+}
+
 // BenchmarkBTreeIterOverlapScan measures the cost of scanning over all
 // overlapping items using a btree iterator.
 func BenchmarkBTreeIterOverlapScan(b *testing.B) {
@@ -1106,6 +1236,29 @@ func BenchmarkBTreeIterOverlapScan(b *testing.B) {
 		it.FirstOverlap(item)
 		for it.Valid() {
 			it.NextOverlap(item)
+		}
+	}
+}
+
+// BenchmarkBTreeIterReverseOverlapScan measures the cost of scanning over all
+// overlapping items using a btree iterator in reverse order.
+func BenchmarkBTreeIterReverseOverlapScan(b *testing.B) {
+	var tr btree
+	rng := rand.New(rand.NewSource(timeutil.Now().UnixNano()))
+
+	const count = 8 << 10
+	const size = 2 * maxItems
+	for i := 0; i < count; i++ {
+		tr.Set(newItem(spanWithEnd(i, i+size+1)))
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		item := newItem(randomSpan(rng, count))
+		it := tr.MakeIter()
+		it.LastOverlap(item)
+		for it.Valid() {
+			it.PrevOverlap(item)
 		}
 	}
 }

--- a/pkg/spanconfig/spanconfigstore/entry_interval_btree.go
+++ b/pkg/spanconfig/spanconfigstore/entry_interval_btree.go
@@ -1021,14 +1021,23 @@ func (i *iterator) Cur() *entry {
 	return i.n.items[i.pos]
 }
 
-// An overlap scan is a scan over all items that overlap with the provided
-// item in order of the overlapping items' start keys. The goal of the scan
-// is to minimize the number of key comparisons performed in total. The
-// algorithm operates based on the following two invariants maintained by
-// augmented interval btree:
+// An overlap scan is a scan over all items that overlap with the provided item
+// (start key inclusive, end key exclusive) in order of the overlapping items'
+// start keys. The goal of the scan is to minimize the number of key comparisons
+// performed in total. The algorithm operates based on the following two
+// invariants maintained by augmented interval btree:
 //  1. all items are sorted in the btree based on their start key.
 //  2. all btree nodes maintain the upper bound end key of all items
 //     in their subtree.
+//
+// An overlapping scan can be performed either in the forward or reverse
+// direction. The algorithm for each is slightly different. First, we present
+// each algorithm, and then we talk about the differences (and the reasons for
+// for them).
+//
+// -----------------------------------------------------------------------------
+// Forward Overlap Scan Algorithm
+// -----------------------------------------------------------------------------
 //
 // The scan algorithm starts in "unconstrained minimum" and "unconstrained
 // maximum" states. To enter a "constrained minimum" state, the scan must reach
@@ -1043,33 +1052,113 @@ func (i *iterator) Cur() *entry {
 //
 // The scan algorithm works like a standard btree forward scan with the
 // following augmentations:
-//  1. before tranversing the tree, the scan performs a binary search on the
+//  1. before traversing the tree, the scan performs a binary search on the
 //     root node's items to determine a "soft" lower-bound constraint position
 //     and a "hard" upper-bound constraint position in the root's children.
-//  2. when tranversing into a child node in the lower or upper bound constraint
+//  2. when traversing into a child node in the lower or upper bound constraint
 //     position, the constraint is refined by searching the child's items.
 //  3. the initial traversal down the tree follows the left-most children
 //     whose upper bound end keys are equal to or greater than the start key
 //     of the search range. The children followed will be equal to or less
 //     than the soft lower bound constraint.
-//  4. once the initial tranversal completes and the scan is in the left-most
+//  4. once the initial traversal completes and the scan is in the left-most
 //     btree node whose upper bound overlaps the search range, key comparisons
 //     must be performed with each item in the tree. This is necessary because
 //     any of these items may have end keys that cause them to overlap with the
 //     search range.
 //  5. once the scan reaches the lower bound constraint position (the first item
 //     with a start key equal to or greater than the search range's start key),
-//     it can begin scaning without performing key comparisons. This is allowed
+//     it can begin scanning without performing key comparisons. This is allowed
 //     because all items from this point forward will have end keys that are
 //     greater than the search range's start key.
 //  6. once the scan reaches the upper bound constraint position, it terminates.
 //     It does so because the item at this position is the first item with a
 //     start key larger than the search range's end key.
+//
+// -----------------------------------------------------------------------------
+// Reverse Overlap Scan Algorithm
+// -----------------------------------------------------------------------------
+//
+// The scan algorithm starts in a "unconstrained minimum" and "unconstrained
+// maximum" state. To enter the "constrained maximum" state, the scan must reach
+// items in the tree with start keys below the search range's end key. Once the
+// scan enters the "constrained maximum" state, it will remain there. To enter
+// the "constrained minimum" state, the scan must reach items in the tree with
+// start keys above the search range's start key. To enter a "constrained
+// minimum" state, the scan must determine the first child btree node in a given
+// subtree that can have items with start keys less than the search range's
+// start key. The scan then remains in the "constrained minimum" state, until it
+// traverses into this child node, at which point it moves to the "unconstrained
+// minimum" state again.
+//
+// The scan algorithm works like a standard btree reverse scan with the
+// following augmentations:
+//  1. before traversing the tree, the scan performs a binary search on the root
+//     node's items to determine a "soft" lower-bound constraint position and a
+//     "hard" upper-bound constraint position in the root's children.
+//  2. when traversing into a child node in the lower or upper bound constraint
+//     position the constraint is refined by searching the child's items.
+//  3. the initial traversal down the tree follows the right-most children whose
+//     upper bound end keys are equal to or greater than the start key of the search
+//     range. The children followed will be equal to or less than the hard
+//     upper-bound constraint.
+//  4. once the initial traversal completes and the scan is in the right-most
+//     btree node whose upper bound overlaps the search range, then jumps directly
+//     to the first item before the upper bound constraint position. This is because
+//     the upper bound constraint position is exclusive.
+//  5. as long as the scan hasn't reached the lower bound constraint position
+//     (the first item with a start key equal or greater than the search range's
+//     start key), it can continue scanning without performing key comparisions.
+//     This is allowed because all items until the lower bound constraint position
+//     is reached will have end keys greater than the search range's start key, and
+//     we know that all items in the tree have start keys less than the search
+//     range's end key.
+//  6. once the scan reaches the lower bound constraint position, key comparisons
+//     must be performed with each item in the tree. This is necessary because even
+//     though the scan is dealing with items that have start keys less than the
+//     serach range's start key, it is possible that these items have end keys that
+//     cause them to overlap with the search range.
+//
+// -----------------------------------------------------------------------------
+// Differences between forward and reverse overlap scans
+// -----------------------------------------------------------------------------
+//
+//  1. The forward overlapping scan can terminate early. It can do so once it
+//     reaches the hard upper bound constaint. This is the first item whose start
+//     key is greater than or equal to the search range's end key.
+//  2. The reverse overlaping scan can directly "jump" directly to the item right
+//     before the hard upper bound constraint. This allows it to skip any subtree/
+//     items that are past the search range's end key.
+//  3. Once the forward overlapping scan enters the inConstrMin condition, it
+//     stays there. The scan reaches inConstrMin at the first item whose start key
+//     is greater than the search range's start key. While inConstrMin is true, no
+//     key comparisons need to be performed[1].
+//  4. In contrast, the reverse overlapping starts off[2] in the inConstrMin
+//     state (where no key comparisons are needed). Once it exitst this state, key
+//     comparisons are needed.
+//
+// [1] This is because the search interval's end key must be greater than the
+// item's start key. Otherwise, we'd have terminated the scan. So, the item must
+// overlap with the search range, and we can skip key comparisons.
+// [2] After it's jumped to the item right before the "hard" upper bound
+// constraint.
+//
+// There's a few reasons for the differences here:
+//  1. All items in the b-tree are sorted by start key. This means that we have a
+//     "hard" upper bound, but a "soft" lower bound. For forward scans, this means
+//     that we can terminate early when this "hard" upper bound is reached. For
+//     reverse scans, this means that we can directly jump to the last item the scan
+//     will ever see.
+//  2. The number of children at an interior node is one more than the number of
+//     items. For a forward scan, the scan starts off at the 0th index regardless of
+//     the type of node. For a reverse scan, however, the scan must start off at the
+//     last child for interior nodes, and the last item for leaf-nodes. These are "off
+//     by one", which requires some care to get right.
 type overlapScan struct {
 	// The "soft" lower-bound constraint.
-	constrMinN       *node
-	constrMinPos     int16
-	constrMinReached bool
+	constrMinN   *node
+	constrMinPos int16
+	inConstrMin  bool
 
 	// The "hard" upper-bound constraint.
 	constrMaxN   *node
@@ -1084,10 +1173,23 @@ func (i *iterator) FirstOverlap(item *entry) {
 		return
 	}
 	i.pos = 0
-	i.o = overlapScan{}
 	i.constrainMinSearchBounds(item)
 	i.constrainMaxSearchBounds(item)
 	i.findNextOverlap(item)
+}
+
+// LastOverlap seeks to the last item in the btree that overlaps with the
+// provided search item.
+func (i *iterator) LastOverlap(item *entry) {
+	i.reset()
+	if i.n == nil {
+		return
+	}
+	i.pos = i.n.count
+	i.o.inConstrMin = true // reverse scans start inConstrMin
+	i.constrainMinSearchBounds(item)
+	i.constrainMaxSearchBounds(item)
+	i.findPrevOverlap(item)
 }
 
 // NextOverlap positions the iterator to the item immediately following
@@ -1100,6 +1202,24 @@ func (i *iterator) NextOverlap(item *entry) {
 	i.findNextOverlap(item)
 }
 
+// PrevOverlap positions the iterator to the item immediately preceding
+// its current position that overlaps with the search item.
+func (i *iterator) PrevOverlap(item *entry) {
+	if i.n == nil {
+		return
+	}
+	i.findPrevOverlap(item)
+}
+
+// constrainMinSearchBounds sets the "soft" lower-bound constraint. This is the
+// first item whose start key is greater than or equal to the supplied search
+// range's start key.
+//
+//	| search range:           [-------------)
+//	| items:         [----) [----) [----) [----) [----)
+//	|                                ^
+//	|                                |
+//	|                                +---constrMinPos
 func (i *iterator) constrainMinSearchBounds(item *entry) {
 	k := item.Key()
 	j := sort.Search(int(i.n.count), func(j int) bool {
@@ -1109,6 +1229,15 @@ func (i *iterator) constrainMinSearchBounds(item *entry) {
 	i.o.constrMinPos = int16(j)
 }
 
+// constrainMaxSearchBounds sets the "hard" upper-bound constraint. This is the
+// first item whose start key is greater than the supplied search range's end
+// key.
+//
+//	| search range:           [--------------)
+//	| items:         [----) [----) [----) [----) [----)
+//	|                                               ^
+//	|                                               |
+//	|                                               +---constrMaxPos
 func (i *iterator) constrainMaxSearchBounds(item *entry) {
 	up := upperBound(item)
 	j := sort.Search(int(i.n.count), func(j int) bool {
@@ -1125,7 +1254,7 @@ func (i *iterator) findNextOverlap(item *entry) {
 			i.ascend()
 		} else if !i.n.leaf() {
 			// Iterate down tree.
-			if i.o.constrMinReached || i.n.children[i.pos].max().contains(item) {
+			if i.o.inConstrMin || i.n.children[i.pos].max().contains(item) {
 				par := i.n
 				pos := i.pos
 				i.descend(par, pos)
@@ -1149,14 +1278,14 @@ func (i *iterator) findNextOverlap(item *entry) {
 		}
 		if i.n == i.o.constrMinN && i.pos == i.o.constrMinPos {
 			// The scan reached the soft lower-bound constraint.
-			i.o.constrMinReached = true
+			i.o.inConstrMin = true
 		}
 
 		// Iterate across node.
 		if i.pos < i.n.count {
 			// Check for overlapping item.
-			if i.o.constrMinReached {
-				// Fast-path to avoid span comparison. i.o.constrMinReached
+			if i.o.inConstrMin {
+				// Fast-path to avoid span comparison. i.o.inConstrMin
 				// tells us that all items have end keys above our search
 				// span's start key.
 				return
@@ -1166,5 +1295,95 @@ func (i *iterator) findNextOverlap(item *entry) {
 			}
 		}
 		i.pos++
+	}
+}
+
+func (i *iterator) findPrevOverlap(item *entry) {
+	for {
+		// First off, we want to avoid exploring any items that are past the
+		// search range's end key.
+		if i.n == i.o.constrMaxN && i.pos > i.o.constrMaxPos {
+			// The item at i.o.constrMaxPos is the first item with a start key
+			// that's greater than the search range's end key. As such, it is
+			// the left-most item that does not overlap with the search range --
+			// we want to "jump" straight to the preceding position. However, we
+			// can't just position the iterator to i.o.constrMaxPos - 1; if this
+			// is an interior node, we might need to descend into the child on
+			// the right of i.o.constrMaxPos - 1 first. So, we set the position
+			// to that of the child node, and let the loop decide whether to
+			// descend further or not.
+			i.pos = i.o.constrMaxPos
+		}
+
+		if i.pos < 0 {
+			if i.s.len() > 0 {
+				// Iterate up tree, if possible.
+				i.ascend()
+			} else {
+				// We've reached the root, so there's no more ascending to do;
+				// the iterator is already invalid, so simply return.
+				return
+			}
+		} else if !i.n.leaf() {
+			// Iterate down tree, but only if there's any hope of finding an
+			// overlap. In particular, if the max key found in the child subtree
+			// is less than the search item's start key, there's no way we'll
+			// find an overlap.
+			if i.o.inConstrMin || i.n.children[i.pos].max().contains(item) {
+				par := i.n
+				pos := i.pos
+				i.descend(par, pos)
+				// Position the iterator to the last child. It's fine if we
+				// descended to a leaf node; we'll be positioned to the last
+				// item in the leaf node in the next iteration.
+				i.pos = i.n.count
+
+				// Refine the constraint bounds, if necessary.
+				if par == i.o.constrMinN && pos == i.o.constrMinPos {
+					i.constrainMinSearchBounds(item)
+				}
+				if par == i.o.constrMaxN && pos == i.o.constrMaxPos {
+					i.constrainMaxSearchBounds(item)
+				}
+				continue
+			}
+		}
+
+		if i.n == i.o.constrMinN && i.pos == i.o.constrMinPos {
+			// The item at i.o.constrMinPos is the left-most item whose start
+			// key is greater than or equal to the search range's start key. As
+			// such, it's the last item we can eschew key comparisons for. The
+			// i.pos-- is going to transition us from a constrained minimum to
+			// an unconstrained minimum scan; update state to reflect this.
+			i.o.inConstrMin = false
+		}
+
+		// NB: We decrement the position between descending into a child node
+		// and checking an item. This is in contrast to the forward scan, where
+		// the increment happens after doing both.
+		//
+		// This is because the number of children at an interior node is one
+		// more than the number of items. As such, positioning the iterator at
+		// the last child is different than positioning it at the last item
+		// (it's off by one). On the other hand, positioning the iterator at the
+		// first item or the first child is the same index (0).
+		i.pos--
+
+		// Iterate across node.
+		if i.pos >= 0 {
+			if i.o.inConstrMin {
+				// Fast-path to avoid span comparison. i.o.inConstrMin
+				// tells us that the item has a start key that's greater than
+				// the search range's start key.
+				return
+			}
+			if upperBound(i.n.items[i.pos]).contains(item) {
+				// We're not in the constrained minimum state, which means the
+				// item's start key is less than the search range's start key.
+				// We must check if the item's end key results in an overlap
+				// (i.e. if the end key is contained in the search range).
+				return
+			}
+		}
 	}
 }

--- a/pkg/spanconfig/spanconfigstore/entry_interval_btree_test.go
+++ b/pkg/spanconfig/spanconfigstore/entry_interval_btree_test.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"math/rand"
 	"reflect"
+	"slices"
 	"sync"
 	"testing"
 
@@ -232,6 +233,19 @@ func checkIter(t *testing.T, it iterator, start, end int, spanMemo map[int]roach
 	if i != end {
 		t.Fatalf("expected %d, but at %d", end, i)
 	}
+
+	for it.LastOverlap(all); it.Valid(); it.PrevOverlap(all) {
+		i--
+		item := it.Cur()
+
+		expected := spanWithMemo(i, spanMemo)
+		if !expected.Equal(spanFromItem(item)) {
+			t.Fatalf("expected %s, but found %s; i %v", expected, spanFromItem(item), i)
+		}
+	}
+	if i != start {
+		t.Fatalf("expected %d, but at %d: %+v; end was %d", start, i, it, end)
+	}
 }
 
 // TestBTree tests basic btree operations.
@@ -402,6 +416,86 @@ func TestBTreeSeekOverlap(t *testing.T) {
 		}
 	}
 	it.FirstOverlap(newItem(span(count + size + 1)))
+	if it.Valid() {
+		t.Fatalf("expected invalid iterator")
+	}
+}
+
+// TestBTreeSeekOverlapReverse tests btree iterator overlap operations in
+// reverse order.
+func TestBTreeSeekOverlapReverse(t *testing.T) {
+	const count = 513
+	const size = 2 * maxItems
+
+	var tr btree
+	for i := 0; i < count; i++ {
+		tr.Set(newItem(spanWithEnd(i, i+size+1)))
+	}
+
+	// Iterate over overlaps with a point scan.
+	it := tr.MakeIter()
+	for i := 0; i < count+size; i++ {
+		scanItem := newItem(spanWithEnd(i, i))
+		it.LastOverlap(scanItem)
+		for j := size; j >= 0; j-- {
+			expStart := i - size + j
+			if expStart < 0 {
+				continue
+			}
+			if expStart >= count {
+				continue
+			}
+
+			if !it.Valid() {
+				t.Fatalf("%d/%d: expected valid iterator", i, j)
+			}
+			item := it.Cur()
+			expected := spanWithEnd(expStart, expStart+size+1)
+			if !expected.Equal(spanFromItem(item)) {
+				t.Fatalf("%d: expected %s, but found %s", i, expected, spanFromItem(item))
+			}
+
+			it.PrevOverlap(scanItem)
+		}
+		if it.Valid() {
+			t.Fatalf("%d: expected invalid iterator %v", i, it.Cur())
+		}
+	}
+	it.LastOverlap(newItem(span(count + size + 1)))
+	if it.Valid() {
+		t.Fatalf("expected invalid iterator")
+	}
+
+	// Iterate over overlaps with a range scan.
+	it = tr.MakeIter()
+	for i := 0; i < count+size; i++ {
+		scanItem := newItem(spanWithEnd(i, i+size+1))
+		it.LastOverlap(scanItem)
+		for j := 2 * size; j >= 0; j-- {
+			expStart := i - size + j
+			if expStart < 0 {
+				continue
+			}
+			if expStart >= count {
+				continue
+			}
+
+			if !it.Valid() {
+				t.Fatalf("%d/%d: expected valid iterator", i, j)
+			}
+			item := it.Cur()
+			expected := spanWithEnd(expStart, expStart+size+1)
+			if !expected.Equal(spanFromItem(item)) {
+				t.Fatalf("%d: expected %s, but found %s", i, expected, spanFromItem(item))
+			}
+
+			it.PrevOverlap(scanItem)
+		}
+		if it.Valid() {
+			t.Fatalf("%d: expected invalid iterator %v", i, it.Cur())
+		}
+	}
+	it.LastOverlap(newItem(span(count + size + 1)))
 	if it.Valid() {
 		t.Fatalf("expected invalid iterator")
 	}
@@ -766,7 +860,7 @@ func TestBTreeSeekOverlapRandom(t *testing.T) {
 				scanItem = newItem(spanWithEnd(scanStart, scanEnd+1))
 			}
 
-			var exp, found []*entry
+			var exp, found, reverseFound []*entry
 			for startKey, endKey := range itemSpans {
 				if startKey <= scanEnd && endKey >= scanStart {
 					exp = append(exp, items[startKey])
@@ -780,7 +874,20 @@ func TestBTreeSeekOverlapRandom(t *testing.T) {
 				it.NextOverlap(scanItem)
 			}
 
+			// Check reverse scans as well.
+			it = tr.MakeIter()
+			it.LastOverlap(scanItem)
+			for it.Valid() {
+				reverseFound = append(reverseFound, it.Cur())
+				it.PrevOverlap(scanItem)
+			}
+
 			require.Equal(t, len(exp), len(found), "search for %v", spanFromItem(scanItem))
+			slices.SortFunc(found, compare)
+			require.Equal(t, exp, found)
+			require.Equal(t, len(exp), len(reverseFound), "search for %v", spanFromItem(scanItem))
+			slices.SortFunc(reverseFound, compare)
+			require.Equal(t, exp, reverseFound)
 		}
 	}
 }
@@ -1087,6 +1194,29 @@ func BenchmarkBTreeIterNextOverlap(b *testing.B) {
 	}
 }
 
+// BenchmarkBTreeIterPrevOverlap measures the cost of seeking a btree iterator
+// to the previous overlapping item in the tree.
+func BenchmarkBTreeIterPrevOverlap(b *testing.B) {
+	var tr btree
+
+	const count = 8 << 10
+	const size = 2 * maxItems
+	for i := 0; i < count; i++ {
+		item := newItem(spanWithEnd(i, i+size+1))
+		tr.Set(item)
+	}
+
+	allCmd := newItem(spanWithEnd(0, count+1))
+	it := tr.MakeIter()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if !it.Valid() {
+			it.LastOverlap(allCmd)
+		}
+		it.PrevOverlap(allCmd)
+	}
+}
+
 // BenchmarkBTreeIterOverlapScan measures the cost of scanning over all
 // overlapping items using a btree iterator.
 func BenchmarkBTreeIterOverlapScan(b *testing.B) {
@@ -1106,6 +1236,29 @@ func BenchmarkBTreeIterOverlapScan(b *testing.B) {
 		it.FirstOverlap(item)
 		for it.Valid() {
 			it.NextOverlap(item)
+		}
+	}
+}
+
+// BenchmarkBTreeIterReverseOverlapScan measures the cost of scanning over all
+// overlapping items using a btree iterator in reverse order.
+func BenchmarkBTreeIterReverseOverlapScan(b *testing.B) {
+	var tr btree
+	rng := rand.New(rand.NewSource(timeutil.Now().UnixNano()))
+
+	const count = 8 << 10
+	const size = 2 * maxItems
+	for i := 0; i < count; i++ {
+		tr.Set(newItem(spanWithEnd(i, i+size+1)))
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		item := newItem(randomSpan(rng, count))
+		it := tr.MakeIter()
+		it.LastOverlap(item)
+		for it.Valid() {
+			it.PrevOverlap(item)
 		}
 	}
 }

--- a/pkg/util/interval/generic/example_interval_btree.go
+++ b/pkg/util/interval/generic/example_interval_btree.go
@@ -1021,14 +1021,23 @@ func (i *iterator) Cur() *example {
 	return i.n.items[i.pos]
 }
 
-// An overlap scan is a scan over all items that overlap with the provided
-// item in order of the overlapping items' start keys. The goal of the scan
-// is to minimize the number of key comparisons performed in total. The
-// algorithm operates based on the following two invariants maintained by
-// augmented interval btree:
+// An overlap scan is a scan over all items that overlap with the provided item
+// (start key inclusive, end key exclusive) in order of the overlapping items'
+// start keys. The goal of the scan is to minimize the number of key comparisons
+// performed in total. The algorithm operates based on the following two
+// invariants maintained by augmented interval btree:
 //  1. all items are sorted in the btree based on their start key.
 //  2. all btree nodes maintain the upper bound end key of all items
 //     in their subtree.
+//
+// An overlapping scan can be performed either in the forward or reverse
+// direction. The algorithm for each is slightly different. First, we present
+// each algorithm, and then we talk about the differences (and the reasons for
+// for them).
+//
+// -----------------------------------------------------------------------------
+// Forward Overlap Scan Algorithm
+// -----------------------------------------------------------------------------
 //
 // The scan algorithm starts in "unconstrained minimum" and "unconstrained
 // maximum" states. To enter a "constrained minimum" state, the scan must reach
@@ -1043,33 +1052,113 @@ func (i *iterator) Cur() *example {
 //
 // The scan algorithm works like a standard btree forward scan with the
 // following augmentations:
-//  1. before tranversing the tree, the scan performs a binary search on the
+//  1. before traversing the tree, the scan performs a binary search on the
 //     root node's items to determine a "soft" lower-bound constraint position
 //     and a "hard" upper-bound constraint position in the root's children.
-//  2. when tranversing into a child node in the lower or upper bound constraint
+//  2. when traversing into a child node in the lower or upper bound constraint
 //     position, the constraint is refined by searching the child's items.
 //  3. the initial traversal down the tree follows the left-most children
 //     whose upper bound end keys are equal to or greater than the start key
 //     of the search range. The children followed will be equal to or less
 //     than the soft lower bound constraint.
-//  4. once the initial tranversal completes and the scan is in the left-most
+//  4. once the initial traversal completes and the scan is in the left-most
 //     btree node whose upper bound overlaps the search range, key comparisons
 //     must be performed with each item in the tree. This is necessary because
 //     any of these items may have end keys that cause them to overlap with the
 //     search range.
 //  5. once the scan reaches the lower bound constraint position (the first item
 //     with a start key equal to or greater than the search range's start key),
-//     it can begin scaning without performing key comparisons. This is allowed
+//     it can begin scanning without performing key comparisons. This is allowed
 //     because all items from this point forward will have end keys that are
 //     greater than the search range's start key.
 //  6. once the scan reaches the upper bound constraint position, it terminates.
 //     It does so because the item at this position is the first item with a
 //     start key larger than the search range's end key.
+//
+// -----------------------------------------------------------------------------
+// Reverse Overlap Scan Algorithm
+// -----------------------------------------------------------------------------
+//
+// The scan algorithm starts in a "unconstrained minimum" and "unconstrained
+// maximum" state. To enter the "constrained maximum" state, the scan must reach
+// items in the tree with start keys below the search range's end key. Once the
+// scan enters the "constrained maximum" state, it will remain there. To enter
+// the "constrained minimum" state, the scan must reach items in the tree with
+// start keys above the search range's start key. To enter a "constrained
+// minimum" state, the scan must determine the first child btree node in a given
+// subtree that can have items with start keys less than the search range's
+// start key. The scan then remains in the "constrained minimum" state, until it
+// traverses into this child node, at which point it moves to the "unconstrained
+// minimum" state again.
+//
+// The scan algorithm works like a standard btree reverse scan with the
+// following augmentations:
+//  1. before traversing the tree, the scan performs a binary search on the root
+//     node's items to determine a "soft" lower-bound constraint position and a
+//     "hard" upper-bound constraint position in the root's children.
+//  2. when traversing into a child node in the lower or upper bound constraint
+//     position the constraint is refined by searching the child's items.
+//  3. the initial traversal down the tree follows the right-most children whose
+//     upper bound end keys are equal to or greater than the start key of the search
+//     range. The children followed will be equal to or less than the hard
+//     upper-bound constraint.
+//  4. once the initial traversal completes and the scan is in the right-most
+//     btree node whose upper bound overlaps the search range, then jumps directly
+//     to the first item before the upper bound constraint position. This is because
+//     the upper bound constraint position is exclusive.
+//  5. as long as the scan hasn't reached the lower bound constraint position
+//     (the first item with a start key equal or greater than the search range's
+//     start key), it can continue scanning without performing key comparisions.
+//     This is allowed because all items until the lower bound constraint position
+//     is reached will have end keys greater than the search range's start key, and
+//     we know that all items in the tree have start keys less than the search
+//     range's end key.
+//  6. once the scan reaches the lower bound constraint position, key comparisons
+//     must be performed with each item in the tree. This is necessary because even
+//     though the scan is dealing with items that have start keys less than the
+//     serach range's start key, it is possible that these items have end keys that
+//     cause them to overlap with the search range.
+//
+// -----------------------------------------------------------------------------
+// Differences between forward and reverse overlap scans
+// -----------------------------------------------------------------------------
+//
+//  1. The forward overlapping scan can terminate early. It can do so once it
+//     reaches the hard upper bound constaint. This is the first item whose start
+//     key is greater than or equal to the search range's end key.
+//  2. The reverse overlaping scan can directly "jump" directly to the item right
+//     before the hard upper bound constraint. This allows it to skip any subtree/
+//     items that are past the search range's end key.
+//  3. Once the forward overlapping scan enters the inConstrMin condition, it
+//     stays there. The scan reaches inConstrMin at the first item whose start key
+//     is greater than the search range's start key. While inConstrMin is true, no
+//     key comparisons need to be performed[1].
+//  4. In contrast, the reverse overlapping starts off[2] in the inConstrMin
+//     state (where no key comparisons are needed). Once it exitst this state, key
+//     comparisons are needed.
+//
+// [1] This is because the search interval's end key must be greater than the
+// item's start key. Otherwise, we'd have terminated the scan. So, the item must
+// overlap with the search range, and we can skip key comparisons.
+// [2] After it's jumped to the item right before the "hard" upper bound
+// constraint.
+//
+// There's a few reasons for the differences here:
+//  1. All items in the b-tree are sorted by start key. This means that we have a
+//     "hard" upper bound, but a "soft" lower bound. For forward scans, this means
+//     that we can terminate early when this "hard" upper bound is reached. For
+//     reverse scans, this means that we can directly jump to the last item the scan
+//     will ever see.
+//  2. The number of children at an interior node is one more than the number of
+//     items. For a forward scan, the scan starts off at the 0th index regardless of
+//     the type of node. For a reverse scan, however, the scan must start off at the
+//     last child for interior nodes, and the last item for leaf-nodes. These are "off
+//     by one", which requires some care to get right.
 type overlapScan struct {
 	// The "soft" lower-bound constraint.
-	constrMinN       *node
-	constrMinPos     int16
-	constrMinReached bool
+	constrMinN   *node
+	constrMinPos int16
+	inConstrMin  bool
 
 	// The "hard" upper-bound constraint.
 	constrMaxN   *node
@@ -1084,10 +1173,23 @@ func (i *iterator) FirstOverlap(item *example) {
 		return
 	}
 	i.pos = 0
-	i.o = overlapScan{}
 	i.constrainMinSearchBounds(item)
 	i.constrainMaxSearchBounds(item)
 	i.findNextOverlap(item)
+}
+
+// LastOverlap seeks to the last item in the btree that overlaps with the
+// provided search item.
+func (i *iterator) LastOverlap(item *example) {
+	i.reset()
+	if i.n == nil {
+		return
+	}
+	i.pos = i.n.count
+	i.o.inConstrMin = true // reverse scans start inConstrMin
+	i.constrainMinSearchBounds(item)
+	i.constrainMaxSearchBounds(item)
+	i.findPrevOverlap(item)
 }
 
 // NextOverlap positions the iterator to the item immediately following
@@ -1100,6 +1202,24 @@ func (i *iterator) NextOverlap(item *example) {
 	i.findNextOverlap(item)
 }
 
+// PrevOverlap positions the iterator to the item immediately preceding
+// its current position that overlaps with the search item.
+func (i *iterator) PrevOverlap(item *example) {
+	if i.n == nil {
+		return
+	}
+	i.findPrevOverlap(item)
+}
+
+// constrainMinSearchBounds sets the "soft" lower-bound constraint. This is the
+// first item whose start key is greater than or equal to the supplied search
+// range's start key.
+//
+//	| search range:           [-------------)
+//	| items:         [----) [----) [----) [----) [----)
+//	|                                ^
+//	|                                |
+//	|                                +---constrMinPos
 func (i *iterator) constrainMinSearchBounds(item *example) {
 	k := item.Key()
 	j := sort.Search(int(i.n.count), func(j int) bool {
@@ -1109,6 +1229,15 @@ func (i *iterator) constrainMinSearchBounds(item *example) {
 	i.o.constrMinPos = int16(j)
 }
 
+// constrainMaxSearchBounds sets the "hard" upper-bound constraint. This is the
+// first item whose start key is greater than the supplied search range's end
+// key.
+//
+//	| search range:           [--------------)
+//	| items:         [----) [----) [----) [----) [----)
+//	|                                               ^
+//	|                                               |
+//	|                                               +---constrMaxPos
 func (i *iterator) constrainMaxSearchBounds(item *example) {
 	up := upperBound(item)
 	j := sort.Search(int(i.n.count), func(j int) bool {
@@ -1125,7 +1254,7 @@ func (i *iterator) findNextOverlap(item *example) {
 			i.ascend()
 		} else if !i.n.leaf() {
 			// Iterate down tree.
-			if i.o.constrMinReached || i.n.children[i.pos].max().contains(item) {
+			if i.o.inConstrMin || i.n.children[i.pos].max().contains(item) {
 				par := i.n
 				pos := i.pos
 				i.descend(par, pos)
@@ -1149,14 +1278,14 @@ func (i *iterator) findNextOverlap(item *example) {
 		}
 		if i.n == i.o.constrMinN && i.pos == i.o.constrMinPos {
 			// The scan reached the soft lower-bound constraint.
-			i.o.constrMinReached = true
+			i.o.inConstrMin = true
 		}
 
 		// Iterate across node.
 		if i.pos < i.n.count {
 			// Check for overlapping item.
-			if i.o.constrMinReached {
-				// Fast-path to avoid span comparison. i.o.constrMinReached
+			if i.o.inConstrMin {
+				// Fast-path to avoid span comparison. i.o.inConstrMin
 				// tells us that all items have end keys above our search
 				// span's start key.
 				return
@@ -1166,5 +1295,95 @@ func (i *iterator) findNextOverlap(item *example) {
 			}
 		}
 		i.pos++
+	}
+}
+
+func (i *iterator) findPrevOverlap(item *example) {
+	for {
+		// First off, we want to avoid exploring any items that are past the
+		// search range's end key.
+		if i.n == i.o.constrMaxN && i.pos > i.o.constrMaxPos {
+			// The item at i.o.constrMaxPos is the first item with a start key
+			// that's greater than the search range's end key. As such, it is
+			// the left-most item that does not overlap with the search range --
+			// we want to "jump" straight to the preceding position. However, we
+			// can't just position the iterator to i.o.constrMaxPos - 1; if this
+			// is an interior node, we might need to descend into the child on
+			// the right of i.o.constrMaxPos - 1 first. So, we set the position
+			// to that of the child node, and let the loop decide whether to
+			// descend further or not.
+			i.pos = i.o.constrMaxPos
+		}
+
+		if i.pos < 0 {
+			if i.s.len() > 0 {
+				// Iterate up tree, if possible.
+				i.ascend()
+			} else {
+				// We've reached the root, so there's no more ascending to do;
+				// the iterator is already invalid, so simply return.
+				return
+			}
+		} else if !i.n.leaf() {
+			// Iterate down tree, but only if there's any hope of finding an
+			// overlap. In particular, if the max key found in the child subtree
+			// is less than the search item's start key, there's no way we'll
+			// find an overlap.
+			if i.o.inConstrMin || i.n.children[i.pos].max().contains(item) {
+				par := i.n
+				pos := i.pos
+				i.descend(par, pos)
+				// Position the iterator to the last child. It's fine if we
+				// descended to a leaf node; we'll be positioned to the last
+				// item in the leaf node in the next iteration.
+				i.pos = i.n.count
+
+				// Refine the constraint bounds, if necessary.
+				if par == i.o.constrMinN && pos == i.o.constrMinPos {
+					i.constrainMinSearchBounds(item)
+				}
+				if par == i.o.constrMaxN && pos == i.o.constrMaxPos {
+					i.constrainMaxSearchBounds(item)
+				}
+				continue
+			}
+		}
+
+		if i.n == i.o.constrMinN && i.pos == i.o.constrMinPos {
+			// The item at i.o.constrMinPos is the left-most item whose start
+			// key is greater than or equal to the search range's start key. As
+			// such, it's the last item we can eschew key comparisons for. The
+			// i.pos-- is going to transition us from a constrained minimum to
+			// an unconstrained minimum scan; update state to reflect this.
+			i.o.inConstrMin = false
+		}
+
+		// NB: We decrement the position between descending into a child node
+		// and checking an item. This is in contrast to the forward scan, where
+		// the increment happens after doing both.
+		//
+		// This is because the number of children at an interior node is one
+		// more than the number of items. As such, positioning the iterator at
+		// the last child is different than positioning it at the last item
+		// (it's off by one). On the other hand, positioning the iterator at the
+		// first item or the first child is the same index (0).
+		i.pos--
+
+		// Iterate across node.
+		if i.pos >= 0 {
+			if i.o.inConstrMin {
+				// Fast-path to avoid span comparison. i.o.inConstrMin
+				// tells us that the item has a start key that's greater than
+				// the search range's start key.
+				return
+			}
+			if upperBound(i.n.items[i.pos]).contains(item) {
+				// We're not in the constrained minimum state, which means the
+				// item's start key is less than the search range's start key.
+				// We must check if the item's end key results in an overlap
+				// (i.e. if the end key is contained in the search range).
+				return
+			}
+		}
 	}
 }

--- a/pkg/util/interval/generic/internal/interval_btree_tmpl.go
+++ b/pkg/util/interval/generic/internal/interval_btree_tmpl.go
@@ -1021,14 +1021,23 @@ func (i *iterator) Cur() T {
 	return i.n.items[i.pos]
 }
 
-// An overlap scan is a scan over all items that overlap with the provided
-// item in order of the overlapping items' start keys. The goal of the scan
-// is to minimize the number of key comparisons performed in total. The
-// algorithm operates based on the following two invariants maintained by
-// augmented interval btree:
+// An overlap scan is a scan over all items that overlap with the provided item
+// (start key inclusive, end key exclusive) in order of the overlapping items'
+// start keys. The goal of the scan is to minimize the number of key comparisons
+// performed in total. The algorithm operates based on the following two
+// invariants maintained by augmented interval btree:
 //  1. all items are sorted in the btree based on their start key.
 //  2. all btree nodes maintain the upper bound end key of all items
 //     in their subtree.
+//
+// An overlapping scan can be performed either in the forward or reverse
+// direction. The algorithm for each is slightly different. First, we present
+// each algorithm, and then we talk about the differences (and the reasons for
+// for them).
+//
+// -----------------------------------------------------------------------------
+// Forward Overlap Scan Algorithm
+// -----------------------------------------------------------------------------
 //
 // The scan algorithm starts in "unconstrained minimum" and "unconstrained
 // maximum" states. To enter a "constrained minimum" state, the scan must reach
@@ -1043,33 +1052,113 @@ func (i *iterator) Cur() T {
 //
 // The scan algorithm works like a standard btree forward scan with the
 // following augmentations:
-//  1. before tranversing the tree, the scan performs a binary search on the
+//  1. before traversing the tree, the scan performs a binary search on the
 //     root node's items to determine a "soft" lower-bound constraint position
 //     and a "hard" upper-bound constraint position in the root's children.
-//  2. when tranversing into a child node in the lower or upper bound constraint
+//  2. when traversing into a child node in the lower or upper bound constraint
 //     position, the constraint is refined by searching the child's items.
 //  3. the initial traversal down the tree follows the left-most children
 //     whose upper bound end keys are equal to or greater than the start key
 //     of the search range. The children followed will be equal to or less
 //     than the soft lower bound constraint.
-//  4. once the initial tranversal completes and the scan is in the left-most
+//  4. once the initial traversal completes and the scan is in the left-most
 //     btree node whose upper bound overlaps the search range, key comparisons
 //     must be performed with each item in the tree. This is necessary because
 //     any of these items may have end keys that cause them to overlap with the
 //     search range.
 //  5. once the scan reaches the lower bound constraint position (the first item
 //     with a start key equal to or greater than the search range's start key),
-//     it can begin scaning without performing key comparisons. This is allowed
+//     it can begin scanning without performing key comparisons. This is allowed
 //     because all items from this point forward will have end keys that are
 //     greater than the search range's start key.
 //  6. once the scan reaches the upper bound constraint position, it terminates.
 //     It does so because the item at this position is the first item with a
 //     start key larger than the search range's end key.
+//
+// -----------------------------------------------------------------------------
+// Reverse Overlap Scan Algorithm
+// -----------------------------------------------------------------------------
+//
+// The scan algorithm starts in a "unconstrained minimum" and "unconstrained
+// maximum" state. To enter the "constrained maximum" state, the scan must reach
+// items in the tree with start keys below the search range's end key. Once the
+// scan enters the "constrained maximum" state, it will remain there. To enter
+// the "constrained minimum" state, the scan must reach items in the tree with
+// start keys above the search range's start key. To enter a "constrained
+// minimum" state, the scan must determine the first child btree node in a given
+// subtree that can have items with start keys less than the search range's
+// start key. The scan then remains in the "constrained minimum" state, until it
+// traverses into this child node, at which point it moves to the "unconstrained
+// minimum" state again.
+//
+// The scan algorithm works like a standard btree reverse scan with the
+// following augmentations:
+//  1. before traversing the tree, the scan performs a binary search on the root
+//     node's items to determine a "soft" lower-bound constraint position and a
+//     "hard" upper-bound constraint position in the root's children.
+//  2. when traversing into a child node in the lower or upper bound constraint
+//     position the constraint is refined by searching the child's items.
+//  3. the initial traversal down the tree follows the right-most children whose
+//     upper bound end keys are equal to or greater than the start key of the search
+//     range. The children followed will be equal to or less than the hard
+//     upper-bound constraint.
+//  4. once the initial traversal completes and the scan is in the right-most
+//     btree node whose upper bound overlaps the search range, then jumps directly
+//     to the first item before the upper bound constraint position. This is because
+//     the upper bound constraint position is exclusive.
+//  5. as long as the scan hasn't reached the lower bound constraint position
+//     (the first item with a start key equal or greater than the search range's
+//     start key), it can continue scanning without performing key comparisions.
+//     This is allowed because all items until the lower bound constraint position
+//     is reached will have end keys greater than the search range's start key, and
+//     we know that all items in the tree have start keys less than the search
+//     range's end key.
+//  6. once the scan reaches the lower bound constraint position, key comparisons
+//     must be performed with each item in the tree. This is necessary because even
+//     though the scan is dealing with items that have start keys less than the
+//     serach range's start key, it is possible that these items have end keys that
+//     cause them to overlap with the search range.
+//
+// -----------------------------------------------------------------------------
+// Differences between forward and reverse overlap scans
+// -----------------------------------------------------------------------------
+//
+//  1. The forward overlapping scan can terminate early. It can do so once it
+//     reaches the hard upper bound constaint. This is the first item whose start
+//     key is greater than or equal to the search range's end key.
+//  2. The reverse overlaping scan can directly "jump" directly to the item right
+//     before the hard upper bound constraint. This allows it to skip any subtree/
+//     items that are past the search range's end key.
+//  3. Once the forward overlapping scan enters the inConstrMin condition, it
+//     stays there. The scan reaches inConstrMin at the first item whose start key
+//     is greater than the search range's start key. While inConstrMin is true, no
+//     key comparisons need to be performed[1].
+//  4. In contrast, the reverse overlapping starts off[2] in the inConstrMin
+//     state (where no key comparisons are needed). Once it exitst this state, key
+//     comparisons are needed.
+//
+// [1] This is because the search interval's end key must be greater than the
+// item's start key. Otherwise, we'd have terminated the scan. So, the item must
+// overlap with the search range, and we can skip key comparisons.
+// [2] After it's jumped to the item right before the "hard" upper bound
+// constraint.
+//
+// There's a few reasons for the differences here:
+//  1. All items in the b-tree are sorted by start key. This means that we have a
+//     "hard" upper bound, but a "soft" lower bound. For forward scans, this means
+//     that we can terminate early when this "hard" upper bound is reached. For
+//     reverse scans, this means that we can directly jump to the last item the scan
+//     will ever see.
+//  2. The number of children at an interior node is one more than the number of
+//     items. For a forward scan, the scan starts off at the 0th index regardless of
+//     the type of node. For a reverse scan, however, the scan must start off at the
+//     last child for interior nodes, and the last item for leaf-nodes. These are "off
+//     by one", which requires some care to get right.
 type overlapScan struct {
 	// The "soft" lower-bound constraint.
-	constrMinN       *node
-	constrMinPos     int16
-	constrMinReached bool
+	constrMinN   *node
+	constrMinPos int16
+	inConstrMin  bool
 
 	// The "hard" upper-bound constraint.
 	constrMaxN   *node
@@ -1084,10 +1173,23 @@ func (i *iterator) FirstOverlap(item T) {
 		return
 	}
 	i.pos = 0
-	i.o = overlapScan{}
 	i.constrainMinSearchBounds(item)
 	i.constrainMaxSearchBounds(item)
 	i.findNextOverlap(item)
+}
+
+// LastOverlap seeks to the last item in the btree that overlaps with the
+// provided search item.
+func (i *iterator) LastOverlap(item T) {
+	i.reset()
+	if i.n == nil {
+		return
+	}
+	i.pos = i.n.count
+	i.o.inConstrMin = true // reverse scans start inConstrMin
+	i.constrainMinSearchBounds(item)
+	i.constrainMaxSearchBounds(item)
+	i.findPrevOverlap(item)
 }
 
 // NextOverlap positions the iterator to the item immediately following
@@ -1100,6 +1202,24 @@ func (i *iterator) NextOverlap(item T) {
 	i.findNextOverlap(item)
 }
 
+// PrevOverlap positions the iterator to the item immediately preceding
+// its current position that overlaps with the search item.
+func (i *iterator) PrevOverlap(item T) {
+	if i.n == nil {
+		return
+	}
+	i.findPrevOverlap(item)
+}
+
+// constrainMinSearchBounds sets the "soft" lower-bound constraint. This is the
+// first item whose start key is greater than or equal to the supplied search
+// range's start key.
+//
+//	| search range:           [-------------)
+//	| items:         [----) [----) [----) [----) [----)
+//	|                                ^
+//	|                                |
+//	|                                +---constrMinPos
 func (i *iterator) constrainMinSearchBounds(item T) {
 	k := item.Key()
 	j := sort.Search(int(i.n.count), func(j int) bool {
@@ -1109,6 +1229,15 @@ func (i *iterator) constrainMinSearchBounds(item T) {
 	i.o.constrMinPos = int16(j)
 }
 
+// constrainMaxSearchBounds sets the "hard" upper-bound constraint. This is the
+// first item whose start key is greater than the supplied search range's end
+// key.
+//
+//	| search range:           [--------------)
+//	| items:         [----) [----) [----) [----) [----)
+//	|                                               ^
+//	|                                               |
+//	|                                               +---constrMaxPos
 func (i *iterator) constrainMaxSearchBounds(item T) {
 	up := upperBound(item)
 	j := sort.Search(int(i.n.count), func(j int) bool {
@@ -1125,7 +1254,7 @@ func (i *iterator) findNextOverlap(item T) {
 			i.ascend()
 		} else if !i.n.leaf() {
 			// Iterate down tree.
-			if i.o.constrMinReached || i.n.children[i.pos].max().contains(item) {
+			if i.o.inConstrMin || i.n.children[i.pos].max().contains(item) {
 				par := i.n
 				pos := i.pos
 				i.descend(par, pos)
@@ -1149,14 +1278,14 @@ func (i *iterator) findNextOverlap(item T) {
 		}
 		if i.n == i.o.constrMinN && i.pos == i.o.constrMinPos {
 			// The scan reached the soft lower-bound constraint.
-			i.o.constrMinReached = true
+			i.o.inConstrMin = true
 		}
 
 		// Iterate across node.
 		if i.pos < i.n.count {
 			// Check for overlapping item.
-			if i.o.constrMinReached {
-				// Fast-path to avoid span comparison. i.o.constrMinReached
+			if i.o.inConstrMin {
+				// Fast-path to avoid span comparison. i.o.inConstrMin
 				// tells us that all items have end keys above our search
 				// span's start key.
 				return
@@ -1166,5 +1295,95 @@ func (i *iterator) findNextOverlap(item T) {
 			}
 		}
 		i.pos++
+	}
+}
+
+func (i *iterator) findPrevOverlap(item T) {
+	for {
+		// First off, we want to avoid exploring any items that are past the
+		// search range's end key.
+		if i.n == i.o.constrMaxN && i.pos > i.o.constrMaxPos {
+			// The item at i.o.constrMaxPos is the first item with a start key
+			// that's greater than the search range's end key. As such, it is
+			// the left-most item that does not overlap with the search range --
+			// we want to "jump" straight to the preceding position. However, we
+			// can't just position the iterator to i.o.constrMaxPos - 1; if this
+			// is an interior node, we might need to descend into the child on
+			// the right of i.o.constrMaxPos - 1 first. So, we set the position
+			// to that of the child node, and let the loop decide whether to
+			// descend further or not.
+			i.pos = i.o.constrMaxPos
+		}
+
+		if i.pos < 0 {
+			if i.s.len() > 0 {
+				// Iterate up tree, if possible.
+				i.ascend()
+			} else {
+				// We've reached the root, so there's no more ascending to do;
+				// the iterator is already invalid, so simply return.
+				return
+			}
+		} else if !i.n.leaf() {
+			// Iterate down tree, but only if there's any hope of finding an
+			// overlap. In particular, if the max key found in the child subtree
+			// is less than the search item's start key, there's no way we'll
+			// find an overlap.
+			if i.o.inConstrMin || i.n.children[i.pos].max().contains(item) {
+				par := i.n
+				pos := i.pos
+				i.descend(par, pos)
+				// Position the iterator to the last child. It's fine if we
+				// descended to a leaf node; we'll be positioned to the last
+				// item in the leaf node in the next iteration.
+				i.pos = i.n.count
+
+				// Refine the constraint bounds, if necessary.
+				if par == i.o.constrMinN && pos == i.o.constrMinPos {
+					i.constrainMinSearchBounds(item)
+				}
+				if par == i.o.constrMaxN && pos == i.o.constrMaxPos {
+					i.constrainMaxSearchBounds(item)
+				}
+				continue
+			}
+		}
+
+		if i.n == i.o.constrMinN && i.pos == i.o.constrMinPos {
+			// The item at i.o.constrMinPos is the left-most item whose start
+			// key is greater than or equal to the search range's start key. As
+			// such, it's the last item we can eschew key comparisons for. The
+			// i.pos-- is going to transition us from a constrained minimum to
+			// an unconstrained minimum scan; update state to reflect this.
+			i.o.inConstrMin = false
+		}
+
+		// NB: We decrement the position between descending into a child node
+		// and checking an item. This is in contrast to the forward scan, where
+		// the increment happens after doing both.
+		//
+		// This is because the number of children at an interior node is one
+		// more than the number of items. As such, positioning the iterator at
+		// the last child is different than positioning it at the last item
+		// (it's off by one). On the other hand, positioning the iterator at the
+		// first item or the first child is the same index (0).
+		i.pos--
+
+		// Iterate across node.
+		if i.pos >= 0 {
+			if i.o.inConstrMin {
+				// Fast-path to avoid span comparison. i.o.inConstrMin
+				// tells us that the item has a start key that's greater than
+				// the search range's start key.
+				return
+			}
+			if upperBound(i.n.items[i.pos]).contains(item) {
+				// We're not in the constrained minimum state, which means the
+				// item's start key is less than the search range's start key.
+				// We must check if the item's end key results in an overlap
+				// (i.e. if the end key is contained in the search range).
+				return
+			}
+		}
 	}
 }

--- a/pkg/util/interval/generic/internal/interval_btree_tmpl_test.go
+++ b/pkg/util/interval/generic/internal/interval_btree_tmpl_test.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"math/rand"
 	"reflect"
+	"slices"
 	"sync"
 	"testing"
 
@@ -232,6 +233,19 @@ func checkIter(t *testing.T, it iterator, start, end int, spanMemo map[int]roach
 	if i != end {
 		t.Fatalf("expected %d, but at %d", end, i)
 	}
+
+	for it.LastOverlap(all); it.Valid(); it.PrevOverlap(all) {
+		i--
+		item := it.Cur()
+
+		expected := spanWithMemo(i, spanMemo)
+		if !expected.Equal(spanFromItem(item)) {
+			t.Fatalf("expected %s, but found %s; i %v", expected, spanFromItem(item), i)
+		}
+	}
+	if i != start {
+		t.Fatalf("expected %d, but at %d: %+v; end was %d", start, i, it, end)
+	}
 }
 
 // TestBTree tests basic btree operations.
@@ -402,6 +416,86 @@ func TestBTreeSeekOverlap(t *testing.T) {
 		}
 	}
 	it.FirstOverlap(newItem(span(count + size + 1)))
+	if it.Valid() {
+		t.Fatalf("expected invalid iterator")
+	}
+}
+
+// TestBTreeSeekOverlapReverse tests btree iterator overlap operations in
+// reverse order.
+func TestBTreeSeekOverlapReverse(t *testing.T) {
+	const count = 513
+	const size = 2 * maxItems
+
+	var tr btree
+	for i := 0; i < count; i++ {
+		tr.Set(newItem(spanWithEnd(i, i+size+1)))
+	}
+
+	// Iterate over overlaps with a point scan.
+	it := tr.MakeIter()
+	for i := 0; i < count+size; i++ {
+		scanItem := newItem(spanWithEnd(i, i))
+		it.LastOverlap(scanItem)
+		for j := size; j >= 0; j-- {
+			expStart := i - size + j
+			if expStart < 0 {
+				continue
+			}
+			if expStart >= count {
+				continue
+			}
+
+			if !it.Valid() {
+				t.Fatalf("%d/%d: expected valid iterator", i, j)
+			}
+			item := it.Cur()
+			expected := spanWithEnd(expStart, expStart+size+1)
+			if !expected.Equal(spanFromItem(item)) {
+				t.Fatalf("%d: expected %s, but found %s", i, expected, spanFromItem(item))
+			}
+
+			it.PrevOverlap(scanItem)
+		}
+		if it.Valid() {
+			t.Fatalf("%d: expected invalid iterator %v", i, it.Cur())
+		}
+	}
+	it.LastOverlap(newItem(span(count + size + 1)))
+	if it.Valid() {
+		t.Fatalf("expected invalid iterator")
+	}
+
+	// Iterate over overlaps with a range scan.
+	it = tr.MakeIter()
+	for i := 0; i < count+size; i++ {
+		scanItem := newItem(spanWithEnd(i, i+size+1))
+		it.LastOverlap(scanItem)
+		for j := 2 * size; j >= 0; j-- {
+			expStart := i - size + j
+			if expStart < 0 {
+				continue
+			}
+			if expStart >= count {
+				continue
+			}
+
+			if !it.Valid() {
+				t.Fatalf("%d/%d: expected valid iterator", i, j)
+			}
+			item := it.Cur()
+			expected := spanWithEnd(expStart, expStart+size+1)
+			if !expected.Equal(spanFromItem(item)) {
+				t.Fatalf("%d: expected %s, but found %s", i, expected, spanFromItem(item))
+			}
+
+			it.PrevOverlap(scanItem)
+		}
+		if it.Valid() {
+			t.Fatalf("%d: expected invalid iterator %v", i, it.Cur())
+		}
+	}
+	it.LastOverlap(newItem(span(count + size + 1)))
 	if it.Valid() {
 		t.Fatalf("expected invalid iterator")
 	}
@@ -766,7 +860,7 @@ func TestBTreeSeekOverlapRandom(t *testing.T) {
 				scanItem = newItem(spanWithEnd(scanStart, scanEnd+1))
 			}
 
-			var exp, found []T
+			var exp, found, reverseFound []T
 			for startKey, endKey := range itemSpans {
 				if startKey <= scanEnd && endKey >= scanStart {
 					exp = append(exp, items[startKey])
@@ -780,7 +874,20 @@ func TestBTreeSeekOverlapRandom(t *testing.T) {
 				it.NextOverlap(scanItem)
 			}
 
+			// Check reverse scans as well.
+			it = tr.MakeIter()
+			it.LastOverlap(scanItem)
+			for it.Valid() {
+				reverseFound = append(reverseFound, it.Cur())
+				it.PrevOverlap(scanItem)
+			}
+
 			require.Equal(t, len(exp), len(found), "search for %v", spanFromItem(scanItem))
+			slices.SortFunc(found, compare)
+			require.Equal(t, exp, found)
+			require.Equal(t, len(exp), len(reverseFound), "search for %v", spanFromItem(scanItem))
+			slices.SortFunc(reverseFound, compare)
+			require.Equal(t, exp, reverseFound)
 		}
 	}
 }
@@ -1087,6 +1194,29 @@ func BenchmarkBTreeIterNextOverlap(b *testing.B) {
 	}
 }
 
+// BenchmarkBTreeIterPrevOverlap measures the cost of seeking a btree iterator
+// to the previous overlapping item in the tree.
+func BenchmarkBTreeIterPrevOverlap(b *testing.B) {
+	var tr btree
+
+	const count = 8 << 10
+	const size = 2 * maxItems
+	for i := 0; i < count; i++ {
+		item := newItem(spanWithEnd(i, i+size+1))
+		tr.Set(item)
+	}
+
+	allCmd := newItem(spanWithEnd(0, count+1))
+	it := tr.MakeIter()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if !it.Valid() {
+			it.LastOverlap(allCmd)
+		}
+		it.PrevOverlap(allCmd)
+	}
+}
+
 // BenchmarkBTreeIterOverlapScan measures the cost of scanning over all
 // overlapping items using a btree iterator.
 func BenchmarkBTreeIterOverlapScan(b *testing.B) {
@@ -1106,6 +1236,29 @@ func BenchmarkBTreeIterOverlapScan(b *testing.B) {
 		it.FirstOverlap(item)
 		for it.Valid() {
 			it.NextOverlap(item)
+		}
+	}
+}
+
+// BenchmarkBTreeIterReverseOverlapScan measures the cost of scanning over all
+// overlapping items using a btree iterator in reverse order.
+func BenchmarkBTreeIterReverseOverlapScan(b *testing.B) {
+	var tr btree
+	rng := rand.New(rand.NewSource(timeutil.Now().UnixNano()))
+
+	const count = 8 << 10
+	const size = 2 * maxItems
+	for i := 0; i < count; i++ {
+		tr.Set(newItem(spanWithEnd(i, i+size+1)))
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		item := newItem(randomSpan(rng, count))
+		it := tr.MakeIter()
+		it.LastOverlap(item)
+		for it.Valid() {
+			it.PrevOverlap(item)
 		}
 	}
 }

--- a/pkg/util/span/btreefrontierentry_interval_btree.go
+++ b/pkg/util/span/btreefrontierentry_interval_btree.go
@@ -1021,14 +1021,23 @@ func (i *iterator) Cur() *btreeFrontierEntry {
 	return i.n.items[i.pos]
 }
 
-// An overlap scan is a scan over all items that overlap with the provided
-// item in order of the overlapping items' start keys. The goal of the scan
-// is to minimize the number of key comparisons performed in total. The
-// algorithm operates based on the following two invariants maintained by
-// augmented interval btree:
+// An overlap scan is a scan over all items that overlap with the provided item
+// (start key inclusive, end key exclusive) in order of the overlapping items'
+// start keys. The goal of the scan is to minimize the number of key comparisons
+// performed in total. The algorithm operates based on the following two
+// invariants maintained by augmented interval btree:
 //  1. all items are sorted in the btree based on their start key.
 //  2. all btree nodes maintain the upper bound end key of all items
 //     in their subtree.
+//
+// An overlapping scan can be performed either in the forward or reverse
+// direction. The algorithm for each is slightly different. First, we present
+// each algorithm, and then we talk about the differences (and the reasons for
+// for them).
+//
+// -----------------------------------------------------------------------------
+// Forward Overlap Scan Algorithm
+// -----------------------------------------------------------------------------
 //
 // The scan algorithm starts in "unconstrained minimum" and "unconstrained
 // maximum" states. To enter a "constrained minimum" state, the scan must reach
@@ -1043,33 +1052,113 @@ func (i *iterator) Cur() *btreeFrontierEntry {
 //
 // The scan algorithm works like a standard btree forward scan with the
 // following augmentations:
-//  1. before tranversing the tree, the scan performs a binary search on the
+//  1. before traversing the tree, the scan performs a binary search on the
 //     root node's items to determine a "soft" lower-bound constraint position
 //     and a "hard" upper-bound constraint position in the root's children.
-//  2. when tranversing into a child node in the lower or upper bound constraint
+//  2. when traversing into a child node in the lower or upper bound constraint
 //     position, the constraint is refined by searching the child's items.
 //  3. the initial traversal down the tree follows the left-most children
 //     whose upper bound end keys are equal to or greater than the start key
 //     of the search range. The children followed will be equal to or less
 //     than the soft lower bound constraint.
-//  4. once the initial tranversal completes and the scan is in the left-most
+//  4. once the initial traversal completes and the scan is in the left-most
 //     btree node whose upper bound overlaps the search range, key comparisons
 //     must be performed with each item in the tree. This is necessary because
 //     any of these items may have end keys that cause them to overlap with the
 //     search range.
 //  5. once the scan reaches the lower bound constraint position (the first item
 //     with a start key equal to or greater than the search range's start key),
-//     it can begin scaning without performing key comparisons. This is allowed
+//     it can begin scanning without performing key comparisons. This is allowed
 //     because all items from this point forward will have end keys that are
 //     greater than the search range's start key.
 //  6. once the scan reaches the upper bound constraint position, it terminates.
 //     It does so because the item at this position is the first item with a
 //     start key larger than the search range's end key.
+//
+// -----------------------------------------------------------------------------
+// Reverse Overlap Scan Algorithm
+// -----------------------------------------------------------------------------
+//
+// The scan algorithm starts in a "unconstrained minimum" and "unconstrained
+// maximum" state. To enter the "constrained maximum" state, the scan must reach
+// items in the tree with start keys below the search range's end key. Once the
+// scan enters the "constrained maximum" state, it will remain there. To enter
+// the "constrained minimum" state, the scan must reach items in the tree with
+// start keys above the search range's start key. To enter a "constrained
+// minimum" state, the scan must determine the first child btree node in a given
+// subtree that can have items with start keys less than the search range's
+// start key. The scan then remains in the "constrained minimum" state, until it
+// traverses into this child node, at which point it moves to the "unconstrained
+// minimum" state again.
+//
+// The scan algorithm works like a standard btree reverse scan with the
+// following augmentations:
+//  1. before traversing the tree, the scan performs a binary search on the root
+//     node's items to determine a "soft" lower-bound constraint position and a
+//     "hard" upper-bound constraint position in the root's children.
+//  2. when traversing into a child node in the lower or upper bound constraint
+//     position the constraint is refined by searching the child's items.
+//  3. the initial traversal down the tree follows the right-most children whose
+//     upper bound end keys are equal to or greater than the start key of the search
+//     range. The children followed will be equal to or less than the hard
+//     upper-bound constraint.
+//  4. once the initial traversal completes and the scan is in the right-most
+//     btree node whose upper bound overlaps the search range, then jumps directly
+//     to the first item before the upper bound constraint position. This is because
+//     the upper bound constraint position is exclusive.
+//  5. as long as the scan hasn't reached the lower bound constraint position
+//     (the first item with a start key equal or greater than the search range's
+//     start key), it can continue scanning without performing key comparisions.
+//     This is allowed because all items until the lower bound constraint position
+//     is reached will have end keys greater than the search range's start key, and
+//     we know that all items in the tree have start keys less than the search
+//     range's end key.
+//  6. once the scan reaches the lower bound constraint position, key comparisons
+//     must be performed with each item in the tree. This is necessary because even
+//     though the scan is dealing with items that have start keys less than the
+//     serach range's start key, it is possible that these items have end keys that
+//     cause them to overlap with the search range.
+//
+// -----------------------------------------------------------------------------
+// Differences between forward and reverse overlap scans
+// -----------------------------------------------------------------------------
+//
+//  1. The forward overlapping scan can terminate early. It can do so once it
+//     reaches the hard upper bound constaint. This is the first item whose start
+//     key is greater than or equal to the search range's end key.
+//  2. The reverse overlaping scan can directly "jump" directly to the item right
+//     before the hard upper bound constraint. This allows it to skip any subtree/
+//     items that are past the search range's end key.
+//  3. Once the forward overlapping scan enters the inConstrMin condition, it
+//     stays there. The scan reaches inConstrMin at the first item whose start key
+//     is greater than the search range's start key. While inConstrMin is true, no
+//     key comparisons need to be performed[1].
+//  4. In contrast, the reverse overlapping starts off[2] in the inConstrMin
+//     state (where no key comparisons are needed). Once it exitst this state, key
+//     comparisons are needed.
+//
+// [1] This is because the search interval's end key must be greater than the
+// item's start key. Otherwise, we'd have terminated the scan. So, the item must
+// overlap with the search range, and we can skip key comparisons.
+// [2] After it's jumped to the item right before the "hard" upper bound
+// constraint.
+//
+// There's a few reasons for the differences here:
+//  1. All items in the b-tree are sorted by start key. This means that we have a
+//     "hard" upper bound, but a "soft" lower bound. For forward scans, this means
+//     that we can terminate early when this "hard" upper bound is reached. For
+//     reverse scans, this means that we can directly jump to the last item the scan
+//     will ever see.
+//  2. The number of children at an interior node is one more than the number of
+//     items. For a forward scan, the scan starts off at the 0th index regardless of
+//     the type of node. For a reverse scan, however, the scan must start off at the
+//     last child for interior nodes, and the last item for leaf-nodes. These are "off
+//     by one", which requires some care to get right.
 type overlapScan struct {
 	// The "soft" lower-bound constraint.
-	constrMinN       *node
-	constrMinPos     int16
-	constrMinReached bool
+	constrMinN   *node
+	constrMinPos int16
+	inConstrMin  bool
 
 	// The "hard" upper-bound constraint.
 	constrMaxN   *node
@@ -1084,10 +1173,23 @@ func (i *iterator) FirstOverlap(item *btreeFrontierEntry) {
 		return
 	}
 	i.pos = 0
-	i.o = overlapScan{}
 	i.constrainMinSearchBounds(item)
 	i.constrainMaxSearchBounds(item)
 	i.findNextOverlap(item)
+}
+
+// LastOverlap seeks to the last item in the btree that overlaps with the
+// provided search item.
+func (i *iterator) LastOverlap(item *btreeFrontierEntry) {
+	i.reset()
+	if i.n == nil {
+		return
+	}
+	i.pos = i.n.count
+	i.o.inConstrMin = true // reverse scans start inConstrMin
+	i.constrainMinSearchBounds(item)
+	i.constrainMaxSearchBounds(item)
+	i.findPrevOverlap(item)
 }
 
 // NextOverlap positions the iterator to the item immediately following
@@ -1100,6 +1202,24 @@ func (i *iterator) NextOverlap(item *btreeFrontierEntry) {
 	i.findNextOverlap(item)
 }
 
+// PrevOverlap positions the iterator to the item immediately preceding
+// its current position that overlaps with the search item.
+func (i *iterator) PrevOverlap(item *btreeFrontierEntry) {
+	if i.n == nil {
+		return
+	}
+	i.findPrevOverlap(item)
+}
+
+// constrainMinSearchBounds sets the "soft" lower-bound constraint. This is the
+// first item whose start key is greater than or equal to the supplied search
+// range's start key.
+//
+//	| search range:           [-------------)
+//	| items:         [----) [----) [----) [----) [----)
+//	|                                ^
+//	|                                |
+//	|                                +---constrMinPos
 func (i *iterator) constrainMinSearchBounds(item *btreeFrontierEntry) {
 	k := item.Key()
 	j := sort.Search(int(i.n.count), func(j int) bool {
@@ -1109,6 +1229,15 @@ func (i *iterator) constrainMinSearchBounds(item *btreeFrontierEntry) {
 	i.o.constrMinPos = int16(j)
 }
 
+// constrainMaxSearchBounds sets the "hard" upper-bound constraint. This is the
+// first item whose start key is greater than the supplied search range's end
+// key.
+//
+//	| search range:           [--------------)
+//	| items:         [----) [----) [----) [----) [----)
+//	|                                               ^
+//	|                                               |
+//	|                                               +---constrMaxPos
 func (i *iterator) constrainMaxSearchBounds(item *btreeFrontierEntry) {
 	up := upperBound(item)
 	j := sort.Search(int(i.n.count), func(j int) bool {
@@ -1125,7 +1254,7 @@ func (i *iterator) findNextOverlap(item *btreeFrontierEntry) {
 			i.ascend()
 		} else if !i.n.leaf() {
 			// Iterate down tree.
-			if i.o.constrMinReached || i.n.children[i.pos].max().contains(item) {
+			if i.o.inConstrMin || i.n.children[i.pos].max().contains(item) {
 				par := i.n
 				pos := i.pos
 				i.descend(par, pos)
@@ -1149,14 +1278,14 @@ func (i *iterator) findNextOverlap(item *btreeFrontierEntry) {
 		}
 		if i.n == i.o.constrMinN && i.pos == i.o.constrMinPos {
 			// The scan reached the soft lower-bound constraint.
-			i.o.constrMinReached = true
+			i.o.inConstrMin = true
 		}
 
 		// Iterate across node.
 		if i.pos < i.n.count {
 			// Check for overlapping item.
-			if i.o.constrMinReached {
-				// Fast-path to avoid span comparison. i.o.constrMinReached
+			if i.o.inConstrMin {
+				// Fast-path to avoid span comparison. i.o.inConstrMin
 				// tells us that all items have end keys above our search
 				// span's start key.
 				return
@@ -1166,5 +1295,95 @@ func (i *iterator) findNextOverlap(item *btreeFrontierEntry) {
 			}
 		}
 		i.pos++
+	}
+}
+
+func (i *iterator) findPrevOverlap(item *btreeFrontierEntry) {
+	for {
+		// First off, we want to avoid exploring any items that are past the
+		// search range's end key.
+		if i.n == i.o.constrMaxN && i.pos > i.o.constrMaxPos {
+			// The item at i.o.constrMaxPos is the first item with a start key
+			// that's greater than the search range's end key. As such, it is
+			// the left-most item that does not overlap with the search range --
+			// we want to "jump" straight to the preceding position. However, we
+			// can't just position the iterator to i.o.constrMaxPos - 1; if this
+			// is an interior node, we might need to descend into the child on
+			// the right of i.o.constrMaxPos - 1 first. So, we set the position
+			// to that of the child node, and let the loop decide whether to
+			// descend further or not.
+			i.pos = i.o.constrMaxPos
+		}
+
+		if i.pos < 0 {
+			if i.s.len() > 0 {
+				// Iterate up tree, if possible.
+				i.ascend()
+			} else {
+				// We've reached the root, so there's no more ascending to do;
+				// the iterator is already invalid, so simply return.
+				return
+			}
+		} else if !i.n.leaf() {
+			// Iterate down tree, but only if there's any hope of finding an
+			// overlap. In particular, if the max key found in the child subtree
+			// is less than the search item's start key, there's no way we'll
+			// find an overlap.
+			if i.o.inConstrMin || i.n.children[i.pos].max().contains(item) {
+				par := i.n
+				pos := i.pos
+				i.descend(par, pos)
+				// Position the iterator to the last child. It's fine if we
+				// descended to a leaf node; we'll be positioned to the last
+				// item in the leaf node in the next iteration.
+				i.pos = i.n.count
+
+				// Refine the constraint bounds, if necessary.
+				if par == i.o.constrMinN && pos == i.o.constrMinPos {
+					i.constrainMinSearchBounds(item)
+				}
+				if par == i.o.constrMaxN && pos == i.o.constrMaxPos {
+					i.constrainMaxSearchBounds(item)
+				}
+				continue
+			}
+		}
+
+		if i.n == i.o.constrMinN && i.pos == i.o.constrMinPos {
+			// The item at i.o.constrMinPos is the left-most item whose start
+			// key is greater than or equal to the search range's start key. As
+			// such, it's the last item we can eschew key comparisons for. The
+			// i.pos-- is going to transition us from a constrained minimum to
+			// an unconstrained minimum scan; update state to reflect this.
+			i.o.inConstrMin = false
+		}
+
+		// NB: We decrement the position between descending into a child node
+		// and checking an item. This is in contrast to the forward scan, where
+		// the increment happens after doing both.
+		//
+		// This is because the number of children at an interior node is one
+		// more than the number of items. As such, positioning the iterator at
+		// the last child is different than positioning it at the last item
+		// (it's off by one). On the other hand, positioning the iterator at the
+		// first item or the first child is the same index (0).
+		i.pos--
+
+		// Iterate across node.
+		if i.pos >= 0 {
+			if i.o.inConstrMin {
+				// Fast-path to avoid span comparison. i.o.inConstrMin
+				// tells us that the item has a start key that's greater than
+				// the search range's start key.
+				return
+			}
+			if upperBound(i.n.items[i.pos]).contains(item) {
+				// We're not in the constrained minimum state, which means the
+				// item's start key is less than the search range's start key.
+				// We must check if the item's end key results in an overlap
+				// (i.e. if the end key is contained in the search range).
+				return
+			}
+		}
 	}
 }

--- a/pkg/util/span/btreefrontierentry_interval_btree_test.go
+++ b/pkg/util/span/btreefrontierentry_interval_btree_test.go
@@ -11,6 +11,7 @@ import (
 	"fmt"
 	"math/rand"
 	"reflect"
+	"slices"
 	"sync"
 	"testing"
 
@@ -232,6 +233,19 @@ func checkIter(t *testing.T, it iterator, start, end int, spanMemo map[int]roach
 	if i != end {
 		t.Fatalf("expected %d, but at %d", end, i)
 	}
+
+	for it.LastOverlap(all); it.Valid(); it.PrevOverlap(all) {
+		i--
+		item := it.Cur()
+
+		expected := spanWithMemo(i, spanMemo)
+		if !expected.Equal(spanFromItem(item)) {
+			t.Fatalf("expected %s, but found %s; i %v", expected, spanFromItem(item), i)
+		}
+	}
+	if i != start {
+		t.Fatalf("expected %d, but at %d: %+v; end was %d", start, i, it, end)
+	}
 }
 
 // TestBTree tests basic btree operations.
@@ -402,6 +416,86 @@ func TestBTreeSeekOverlap(t *testing.T) {
 		}
 	}
 	it.FirstOverlap(newItem(span(count + size + 1)))
+	if it.Valid() {
+		t.Fatalf("expected invalid iterator")
+	}
+}
+
+// TestBTreeSeekOverlapReverse tests btree iterator overlap operations in
+// reverse order.
+func TestBTreeSeekOverlapReverse(t *testing.T) {
+	const count = 513
+	const size = 2 * maxItems
+
+	var tr btree
+	for i := 0; i < count; i++ {
+		tr.Set(newItem(spanWithEnd(i, i+size+1)))
+	}
+
+	// Iterate over overlaps with a point scan.
+	it := tr.MakeIter()
+	for i := 0; i < count+size; i++ {
+		scanItem := newItem(spanWithEnd(i, i))
+		it.LastOverlap(scanItem)
+		for j := size; j >= 0; j-- {
+			expStart := i - size + j
+			if expStart < 0 {
+				continue
+			}
+			if expStart >= count {
+				continue
+			}
+
+			if !it.Valid() {
+				t.Fatalf("%d/%d: expected valid iterator", i, j)
+			}
+			item := it.Cur()
+			expected := spanWithEnd(expStart, expStart+size+1)
+			if !expected.Equal(spanFromItem(item)) {
+				t.Fatalf("%d: expected %s, but found %s", i, expected, spanFromItem(item))
+			}
+
+			it.PrevOverlap(scanItem)
+		}
+		if it.Valid() {
+			t.Fatalf("%d: expected invalid iterator %v", i, it.Cur())
+		}
+	}
+	it.LastOverlap(newItem(span(count + size + 1)))
+	if it.Valid() {
+		t.Fatalf("expected invalid iterator")
+	}
+
+	// Iterate over overlaps with a range scan.
+	it = tr.MakeIter()
+	for i := 0; i < count+size; i++ {
+		scanItem := newItem(spanWithEnd(i, i+size+1))
+		it.LastOverlap(scanItem)
+		for j := 2 * size; j >= 0; j-- {
+			expStart := i - size + j
+			if expStart < 0 {
+				continue
+			}
+			if expStart >= count {
+				continue
+			}
+
+			if !it.Valid() {
+				t.Fatalf("%d/%d: expected valid iterator", i, j)
+			}
+			item := it.Cur()
+			expected := spanWithEnd(expStart, expStart+size+1)
+			if !expected.Equal(spanFromItem(item)) {
+				t.Fatalf("%d: expected %s, but found %s", i, expected, spanFromItem(item))
+			}
+
+			it.PrevOverlap(scanItem)
+		}
+		if it.Valid() {
+			t.Fatalf("%d: expected invalid iterator %v", i, it.Cur())
+		}
+	}
+	it.LastOverlap(newItem(span(count + size + 1)))
 	if it.Valid() {
 		t.Fatalf("expected invalid iterator")
 	}
@@ -766,7 +860,7 @@ func TestBTreeSeekOverlapRandom(t *testing.T) {
 				scanItem = newItem(spanWithEnd(scanStart, scanEnd+1))
 			}
 
-			var exp, found []*btreeFrontierEntry
+			var exp, found, reverseFound []*btreeFrontierEntry
 			for startKey, endKey := range itemSpans {
 				if startKey <= scanEnd && endKey >= scanStart {
 					exp = append(exp, items[startKey])
@@ -780,7 +874,20 @@ func TestBTreeSeekOverlapRandom(t *testing.T) {
 				it.NextOverlap(scanItem)
 			}
 
+			// Check reverse scans as well.
+			it = tr.MakeIter()
+			it.LastOverlap(scanItem)
+			for it.Valid() {
+				reverseFound = append(reverseFound, it.Cur())
+				it.PrevOverlap(scanItem)
+			}
+
 			require.Equal(t, len(exp), len(found), "search for %v", spanFromItem(scanItem))
+			slices.SortFunc(found, compare)
+			require.Equal(t, exp, found)
+			require.Equal(t, len(exp), len(reverseFound), "search for %v", spanFromItem(scanItem))
+			slices.SortFunc(reverseFound, compare)
+			require.Equal(t, exp, reverseFound)
 		}
 	}
 }
@@ -1087,6 +1194,29 @@ func BenchmarkBTreeIterNextOverlap(b *testing.B) {
 	}
 }
 
+// BenchmarkBTreeIterPrevOverlap measures the cost of seeking a btree iterator
+// to the previous overlapping item in the tree.
+func BenchmarkBTreeIterPrevOverlap(b *testing.B) {
+	var tr btree
+
+	const count = 8 << 10
+	const size = 2 * maxItems
+	for i := 0; i < count; i++ {
+		item := newItem(spanWithEnd(i, i+size+1))
+		tr.Set(item)
+	}
+
+	allCmd := newItem(spanWithEnd(0, count+1))
+	it := tr.MakeIter()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if !it.Valid() {
+			it.LastOverlap(allCmd)
+		}
+		it.PrevOverlap(allCmd)
+	}
+}
+
 // BenchmarkBTreeIterOverlapScan measures the cost of scanning over all
 // overlapping items using a btree iterator.
 func BenchmarkBTreeIterOverlapScan(b *testing.B) {
@@ -1106,6 +1236,29 @@ func BenchmarkBTreeIterOverlapScan(b *testing.B) {
 		it.FirstOverlap(item)
 		for it.Valid() {
 			it.NextOverlap(item)
+		}
+	}
+}
+
+// BenchmarkBTreeIterReverseOverlapScan measures the cost of scanning over all
+// overlapping items using a btree iterator in reverse order.
+func BenchmarkBTreeIterReverseOverlapScan(b *testing.B) {
+	var tr btree
+	rng := rand.New(rand.NewSource(timeutil.Now().UnixNano()))
+
+	const count = 8 << 10
+	const size = 2 * maxItems
+	for i := 0; i < count; i++ {
+		tr.Set(newItem(spanWithEnd(i, i+size+1)))
+	}
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		item := newItem(randomSpan(rng, count))
+		it := tr.MakeIter()
+		it.LastOverlap(item)
+		for it.Valid() {
+			it.PrevOverlap(item)
 		}
 	}
 }


### PR DESCRIPTION
This patch introduces a new iterator which performs an overlapping scan on interval b-trees in reverse order of interval start key.

The motivation for this is the txnWriteBuffer, which needs to join the result of a reverse scan (from KV) with locally buffered data stored in an interval b-tree.

References https://github.com/cockroachdb/cockroach/issues/139054

Release note: None