### PR TITLE
sql: record transaction idle time during rollback

### DIFF
--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -2621,6 +2621,9 @@ func (ex *connExecutor) createJobs(ctx context.Context) error {
 func (ex *connExecutor) rollbackSQLTransaction(
 	ctx context.Context, stmt tree.Statement,
 ) (fsm.Event, fsm.EventPayload) {
+	ex.extraTxnState.idleLatency += ex.statsCollector.PhaseTimes().
+		GetIdleLatency(ex.statsCollector.PreviousPhaseTimes())
+
 	if err := ex.extraTxnState.sqlCursors.closeAll(&ex.planner, cursorCloseForTxnRollback); err != nil {
 		return ex.makeErrEvent(err, stmt)
 	}

--- a/pkg/sql/sqlstats/sslocal/sql_stats_test.go
+++ b/pkg/sql/sqlstats/sslocal/sql_stats_test.go
@@ -1326,6 +1326,21 @@ func TestSQLStatsIdleLatencies(t *testing.T) {
 			},
 		},
 		{
+			name:     "simple statement with rollback",
+			stmtLats: map[string]float64{"SELECT _": 0.1},
+			txnLat:   0.2,
+			ops: func(t *testing.T, db *gosql.DB) {
+				tx, err := db.Begin()
+				require.NoError(t, err)
+				time.Sleep(100 * time.Millisecond)
+				_, err = tx.Exec("SELECT 1")
+				require.NoError(t, err)
+				time.Sleep(100 * time.Millisecond)
+				err = tx.Rollback()
+				require.NoError(t, err)
+			},
+		},
+		{
 			name:     "compound statement",
 			stmtLats: map[string]float64{"SELECT _": 0.1, "SELECT count(*) FROM crdb_internal.statement_statistics": 0},
 			txnLat:   0.2,


### PR DESCRIPTION
Transaction idle time is recorded when we execute the next statement, including COMMIT. The ROLLBACK path was not doing so, this fixes that.

Epic: none
Release note: none