### PR TITLE
changefeedccl: add changefeed cancelations to telemetry log

### DIFF
--- a/docs/generated/eventlog.md
+++ b/docs/generated/eventlog.md
@@ -28,6 +28,25 @@ Events in this category pertain to changefeed usage and metrics.
 Events in this category are logged to the `TELEMETRY` channel.
 
 
+### `changefeed_canceled`
+
+An event of type `changefeed_canceled` is an event for any changefeed cancellations.
+
+
+
+
+#### Common fields
+
+| Field | Description | Sensitive |
+|--|--|--|
+| `Description` | The description of that would show up in the job's description field, redacted | yes |
+| `SinkType` | The type of sink being emitted to (ex: kafka, nodelocal, webhook-https). | no |
+| `NumTables` | The number of tables listed in the query that the changefeed is to run on. | no |
+| `Resolved` | The behavior of emitted resolved spans (ex: yes, no, 10s) | no |
+| `InitialScan` | The desired behavior of initial scans (ex: yes, no, only) | no |
+| `Format` | The data format being emitted (ex: JSON, Avro). | no |
+| `JobId` | The job id for enterprise changefeeds. | no |
+
 ### `changefeed_emitted_bytes`
 
 An event of type `changefeed_emitted_bytes` is an event representing the bytes emitted by a changefeed over an interval.

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -1577,6 +1577,7 @@ func (b *changefeedResumer) OnFailOrCancel(
 		errors.DecodeError(ctx, *b.job.Payload().FinalResumeError),
 	) {
 		telemetry.Count(`changefeed.enterprise.cancel`)
+		logChangefeedCanceledTelemetry(ctx, b.job)
 	} else {
 		telemetry.Count(`changefeed.enterprise.fail`)
 		exec.ExecCfg().JobRegistry.MetricsStruct().Changefeed.(*Metrics).Failures.Inc(1)
@@ -1696,6 +1697,19 @@ func logChangefeedFailedTelemetryDuringStartup(
 	}
 
 	log.StructuredEvent(ctx, severity.INFO, changefeedFailedEvent)
+}
+
+func logChangefeedCanceledTelemetry(ctx context.Context, job *jobs.Job) {
+	var changefeedEventDetails eventpb.CommonChangefeedEventDetails
+	if job != nil {
+		changefeedDetails := job.Details().(jobspb.ChangefeedDetails)
+		changefeedEventDetails = makeCommonChangefeedEventDetails(ctx, changefeedDetails, job.Payload().Description, job.ID())
+	}
+
+	changefeedCanceled := &eventpb.ChangefeedCanceled{
+		CommonChangefeedEventDetails: changefeedEventDetails,
+	}
+	log.StructuredEvent(ctx, severity.INFO, changefeedCanceled)
 }
 
 func makeCommonChangefeedEventDetails(

--- a/pkg/ccl/changefeedccl/helpers_test.go
+++ b/pkg/ccl/changefeedccl/helpers_test.go
@@ -1388,6 +1388,21 @@ func checkChangefeedFailedLogs(t *testing.T, startTime int64) []eventpb.Changefe
 	return matchingEntries
 }
 
+func checkChangefeedCanceledLogs(t *testing.T, startTime int64) []eventpb.ChangefeedCanceled {
+	var matchingEntries []eventpb.ChangefeedCanceled
+
+	for _, m := range checkStructuredLogs(t, "changefeed_canceled", startTime) {
+		jsonPayload := []byte(m)
+		var event eventpb.ChangefeedCanceled
+		if err := gojson.Unmarshal(jsonPayload, &event); err != nil {
+			t.Errorf("unmarshalling %q: %v", m, err)
+		}
+		matchingEntries = append(matchingEntries, event)
+	}
+
+	return matchingEntries
+}
+
 func checkS3Credentials(t *testing.T) (bucket string, accessKey string, secretKey string) {
 	accessKey = os.Getenv("AWS_ACCESS_KEY_ID")
 	if accessKey == "" {

--- a/pkg/util/log/eventpb/changefeed_events.proto
+++ b/pkg/util/log/eventpb/changefeed_events.proto
@@ -35,6 +35,11 @@ message ChangefeedFailed {
   string failure_type = 2 [(gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) = "redact:\"nonsensitive\""];
 }
 
+// ChangefeedCanceled is an event for any changefeed cancellations.
+message ChangefeedCanceled {
+  CommonChangefeedEventDetails common = 1 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "", (gogoproto.embed) = true];
+}
+
 // ChangefeedEmittedBytes is an event representing the bytes emitted by a changefeed over an interval.
 message ChangefeedEmittedBytes {
   CommonChangefeedEventDetails common = 1 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "", (gogoproto.embed) = true];

--- a/pkg/util/log/eventpb/eventlog_channels_generated.go
+++ b/pkg/util/log/eventpb/eventlog_channels_generated.go
@@ -5,6 +5,9 @@ package eventpb
 import "github.com/cockroachdb/cockroach/pkg/util/log/logpb"
 
 // LoggingChannel implements the EventPayload interface.
+func (m *ChangefeedCanceled) LoggingChannel() logpb.Channel { return logpb.Channel_TELEMETRY }
+
+// LoggingChannel implements the EventPayload interface.
 func (m *ChangefeedEmittedBytes) LoggingChannel() logpb.Channel { return logpb.Channel_TELEMETRY }
 
 // LoggingChannel implements the EventPayload interface.

--- a/pkg/util/log/eventpb/json_encode_generated.go
+++ b/pkg/util/log/eventpb/json_encode_generated.go
@@ -938,6 +938,14 @@ func (m *ChangeTypePrivilege) AppendJSONFields(printComma bool, b redact.Redacta
 }
 
 // AppendJSONFields implements the EventPayload interface.
+func (m *ChangefeedCanceled) AppendJSONFields(printComma bool, b redact.RedactableBytes) (bool, redact.RedactableBytes) {
+
+	printComma, b = m.CommonChangefeedEventDetails.AppendJSONFields(printComma, b)
+
+	return printComma, b
+}
+
+// AppendJSONFields implements the EventPayload interface.
 func (m *ChangefeedEmittedBytes) AppendJSONFields(printComma bool, b redact.RedactableBytes) (bool, redact.RedactableBytes) {
 
 	printComma, b = m.CommonChangefeedEventDetails.AppendJSONFields(printComma, b)


### PR DESCRIPTION
Previously we only logged create changefeed events and changedfeed failed events.

Epic: CRDB-42939
Release note (general): Adds the logging
of changefeed_canceled events to the telemetry log.