### PR TITLE
backup: fix faulty encrypted writes on compaction

### DIFF
--- a/pkg/backup/backup_compaction.go
+++ b/pkg/backup/backup_compaction.go
@@ -640,7 +640,7 @@ func updateCompactionBackupDetails(
 	var encryptionInfo *jobspb.EncryptionInfo
 	if encryption != nil {
 		var err error
-		encryption, encryptionInfo, err = backupencryption.MakeNewEncryptionOptions(
+		_, encryptionInfo, err = backupencryption.MakeNewEncryptionOptions(
 			ctx, encryption, kmsEnv,
 		)
 		if err != nil {


### PR DESCRIPTION
Encrypted compactions were broken due to the wrong encryption options being used for writes.

Epic: none

Release note: None