### PR TITLE
release-23.2: changefeedccl: Avoid logging when context may be canceled

### DIFF
--- a/pkg/ccl/changefeedccl/event_processing.go
+++ b/pkg/ccl/changefeedccl/event_processing.go
@@ -10,7 +10,6 @@ import (
 	"hash"
 	"hash/crc32"
 	"runtime"
-	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/cdceval"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/cdcevent"
@@ -33,10 +32,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 )
-
-// pacerLogEvery is used for logging errors instead of returning terminal
-// errors when pacer.Pace returns an error.
-var pacerLogEvery log.EveryN = log.Every(100 * time.Millisecond)
 
 // eventContext holds metadata pertaining to event.
 type eventContext struct {
@@ -325,9 +320,7 @@ func (c *kvEventToRowConsumer) ConsumeEvent(ctx context.Context, ev kvevent.Even
 	// unavailable. If there is unused CPU time left from the last call to
 	// Pace, then use that time instead of blocking.
 	if err := c.pacer.Pace(ctx); err != nil {
-		if pacerLogEvery.ShouldLog() {
-			log.Errorf(ctx, "automatic pacing: %v", err)
-		}
+		return err
 	}
 
 	schemaTimestamp := ev.KV().Value.Timestamp


### PR DESCRIPTION
Backport 1/1 commits from #114583.

/cc @cockroachdb/release

---

Calling log  methods on a context that's already canceled may produce "use of Span after Finish" under tests. Avoid doing that when pacing CPU usage.

Fixes #114130

Release note: None

---

Release justification: removes a use of Span after Finish 

---

Fixes #141917
