### PR TITLE
sql: add support for CREATE TABLE AS ... AS OF SYSTEM TIME

### DIFF
--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/appstatspb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catsessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
 	"github.com/cockroachdb/cockroach/pkg/sql/clusterunique"
@@ -54,6 +55,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/cancelchecker"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxlog"
 	"github.com/cockroachdb/cockroach/pkg/util/duration"
+	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 	"github.com/cockroachdb/cockroach/pkg/util/fsm"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -2266,16 +2268,18 @@ func (ex *connExecutor) handleAOST(ctx context.Context, stmt tree.Statement) err
 	if ex.implicitTxn() && !ex.extraTxnState.firstStmtExecuted {
 		if p.extendedEvalCtx.AsOfSystemTime == nil {
 			p.extendedEvalCtx.AsOfSystemTime = asOf
-			if !asOf.BoundedStaleness {
-				p.extendedEvalCtx.SetTxnTimestamp(asOf.Timestamp.GoTime())
-				if err := ex.state.setHistoricalTimestamp(ctx, asOf.Timestamp); err != nil {
+			if !asOf.ForBackfill {
+				if !asOf.BoundedStaleness {
+					p.extendedEvalCtx.SetTxnTimestamp(asOf.Timestamp.GoTime())
+					if err := ex.state.setHistoricalTimestamp(ctx, asOf.Timestamp); err != nil {
+						return err
+					}
+				}
+				if err := ex.state.setReadOnlyMode(tree.ReadOnly); err != nil {
 					return err
 				}
+				p.extendedEvalCtx.TxnReadOnly = ex.state.readOnly.Load()
 			}
-			if err := ex.state.setReadOnlyMode(tree.ReadOnly); err != nil {
-				return err
-			}
-			p.extendedEvalCtx.TxnReadOnly = ex.state.readOnly.Load()
 			return nil
 		}
 		if *p.extendedEvalCtx.AsOfSystemTime == *asOf {
@@ -2297,16 +2301,24 @@ func (ex *connExecutor) handleAOST(ctx context.Context, stmt tree.Statement) err
 			asOf.Timestamp,
 		)
 	}
-	// If we're in an explicit txn, we allow AOST but only if it matches with
-	// the transaction's timestamp. This is useful for running AOST statements
-	// using the Executor inside an external transaction; one might want
-	// to do that to force p.avoidLeasedDescriptors to be set below.
+	// Bounded staleness and backfills with a historical timestamp are both not
+	// allowed in explicit transactions.
 	if asOf.BoundedStaleness {
 		return pgerror.Newf(
 			pgcode.FeatureNotSupported,
 			"cannot use a bounded staleness query in a transaction",
 		)
 	}
+	if asOf.ForBackfill {
+		return unimplemented.NewWithIssuef(
+			35712,
+			"cannot run a backfill with AS OF SYSTEM TIME in a transaction",
+		)
+	}
+	// If we're in an explicit txn, we allow AOST but only if it matches with
+	// the transaction's timestamp. This is useful for running AOST statements
+	// using the Executor inside an external transaction; one might want
+	// to do that to force p.avoidLeasedDescriptors to be set below.
 	if readTs := ex.state.getReadTimestamp(); asOf.Timestamp != readTs {
 		err = pgerror.Newf(pgcode.FeatureNotSupported,
 			"inconsistent AS OF SYSTEM TIME timestamp; expected: %s, got: %s", readTs, asOf.Timestamp)
@@ -2756,8 +2768,46 @@ func (ex *connExecutor) dispatchToExecutionEngine(
 		}
 	}
 
-	var err error
+	// If we've been tasked with backfilling a schema change operation at a
+	// particular system time, it's important that we do planning for the
+	// operation at the timestamp that we're expecting to perform the backfill at,
+	// in case the schema of the objects that we read have changed in between the
+	// present transaction timestamp and the user-defined backfill timestamp.
+	//
+	// Set the planner's transaction to a new historical transaction pinned at
+	// that timestamp, and give it a new collection. We'll restore it after
+	// planning.
+	var restoreOriginalPlanner func() error
+	if asOf := planner.extendedEvalCtx.AsOfSystemTime; asOf != nil && asOf.ForBackfill {
+		nodeID, _ := planner.execCfg.NodeInfo.NodeID.OptionalNodeID()
+		historicalTxn := kv.NewTxnWithSteppingEnabled(ctx, planner.execCfg.DB, nodeID, ex.QualityOfService())
+		if err := historicalTxn.SetFixedTimestamp(ctx, asOf.Timestamp); err != nil {
+			res.SetError(err)
+			return nil
+		}
+		originalTxn := planner.txn
+		planner.txn = historicalTxn
+		planner.schemaResolver.txn = historicalTxn
+		dsdp := catsessiondata.NewDescriptorSessionDataStackProvider(planner.sessionDataStack)
+		historicalCollection := planner.execCfg.CollectionFactory.NewCollection(
+			ctx, descs.WithDescriptorSessionDataProvider(dsdp),
+		)
+		planner.descCollection = historicalCollection
+		planner.extendedEvalCtx.Descs = historicalCollection
+		restoreOriginalPlanner = func() error {
+			planner.txn = originalTxn
+			planner.schemaResolver.txn = originalTxn
+			planner.descCollection = ex.extraTxnState.descCollection
+			planner.extendedEvalCtx.Descs = ex.extraTxnState.descCollection
+			historicalCollection.ReleaseAll(ctx)
+			if err := historicalTxn.Commit(ctx); err != nil {
+				return err
+			}
+			return nil
+		}
+	}
 
+	var err error
 	if ppInfo := getPausablePortalInfo(); ppInfo != nil {
 		if !ppInfo.dispatchToExecutionEngine.cleanup.isComplete {
 			ctx, err = ex.makeExecPlan(ctx, planner)
@@ -2798,6 +2848,15 @@ func (ex *connExecutor) dispatchToExecutionEngine(
 	// https://github.com/cockroachdb/cockroach/issues/99410
 	ex.statsCollector.PhaseTimes().SetSessionPhaseTime(sessionphase.PlannerEndLogicalPlan, crtime.NowMono())
 	ex.sessionTracing.TracePlanEnd(ctx, err)
+
+	if restoreOriginalPlanner != nil {
+		// Reset the planner's transaction to the current-timestamp, original
+		// transaction.
+		if err := restoreOriginalPlanner(); err != nil {
+			res.SetError(err)
+			return nil
+		}
+	}
 
 	// Finally, process the planning error from above.
 	if err != nil {

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -2238,6 +2238,18 @@ func (p *planner) isAsOf(ctx context.Context, stmt tree.Statement) (*eval.AsOfSy
 		asOf = s.Options.AsOf
 	case *tree.Explain:
 		return p.isAsOf(ctx, s.Statement)
+	case *tree.CreateTable:
+		if !s.As() {
+			return nil, nil
+		}
+		ts, err := p.isAsOf(ctx, s.AsSource)
+		if err != nil {
+			return nil, err
+		}
+		if ts != nil {
+			ts.ForBackfill = true
+		}
+		return ts, nil
 	default:
 		return nil, nil
 	}

--- a/pkg/sql/logictest/testdata/logic_test/create_as
+++ b/pkg/sql/logictest/testdata/logic_test/create_as
@@ -1,3 +1,6 @@
+let $ts
+SELECT now()
+
 statement ok
 CREATE TABLE stock (item, quantity) AS VALUES ('cups', 10), ('plates', 15), ('forks', 30)
 
@@ -40,8 +43,8 @@ forks blue
 forks red
 forks green
 
-statement error pq: AS OF SYSTEM TIME must be provided on a top-level statement
-CREATE TABLE t AS SELECT * FROM stock AS OF SYSTEM TIME '2016-01-01'
+statement error pgcode 42P01 relation "stock" does not exist
+CREATE TABLE t AS SELECT * FROM stock AS OF SYSTEM TIME '$ts'
 
 statement error pgcode 42601 CREATE TABLE specifies 3 column names, but data source has 2 columns
 CREATE TABLE t2 (col1, col2, col3) AS SELECT * FROM stock
@@ -409,6 +412,9 @@ CREATE TABLE e105393 (a PRIMARY KEY, b) AS TABLE db105393_1.public.t105393;
 statement error pq: cross database type references are not supported: db105393_1.public.e105393
 CREATE TABLE e105393 (b) AS SELECT b FROM db105393_1.public.t105393;
 
+statement ok
+USE test
+
 # Regression test for #105887
 subtest regression_105887
 
@@ -461,3 +467,103 @@ CREATE TABLE v00 (c01 INT, c02 STRING);
 
 statement ok
 CREATE TEMP TABLE v300 AS ( ( TABLE [ SHOW EXPERIMENTAL_FINGERPRINTS FROM TABLE v00 ] ) ) ;
+
+# Test CTAS as of system time.
+subtest ctas_aost
+
+# Get a timestamp from after the insert into the stock table.
+let $ts
+SELECT now()
+
+statement ok
+CREATE TABLE stockcopy AS SELECT * FROM stock AS OF SYSTEM TIME '$ts'
+
+query TI rowsort
+SELECT item, quantity FROM stockcopy
+----
+cups    10
+plates  15
+forks   30
+
+statement ok
+INSERT INTO stock VALUES ('spoons', 10)
+
+statement ok
+CREATE TABLE stocknospoons AS SELECT * FROM stock AS OF SYSTEM TIME '$ts'
+
+query TI rowsort
+SELECT item, quantity FROM stocknospoons WHERE item = 'spoons'
+----
+
+# Make sure that testing after the timestamp produces a result that
+# includes the new row.
+
+let $ts
+SELECT now()
+
+statement ok
+CREATE TABLE stockwithspoons AS SELECT * FROM stock AS OF SYSTEM TIME '$ts'
+
+query TI rowsort
+SELECT item, quantity FROM stockwithspoons WHERE item = 'spoons'
+----
+spoons  10
+
+statement ok
+ALTER TABLE stock ADD COLUMN newcol INT DEFAULT 1
+
+statement ok
+CREATE TABLE stockafterschemachange AS SELECT * FROM stock AS OF SYSTEM TIME '$ts'
+
+query error column "newcol" does not exist
+SELECT newcol FROM stockafterschemachange
+
+query TI rowsort
+SELECT item, quantity FROM stockafterschemachange
+----
+cups    10
+plates  15
+forks   30
+spoons  10
+
+let $ts
+SELECT now()
+
+## Test that CTAS AOST doesn't mix with explicit txns.
+statement ok
+BEGIN TRANSACTION ISOLATION LEVEL SERIALIZABLE;
+SET LOCAL autocommit_before_ddl = false;
+
+statement error unimplemented: cannot run a backfill with AS OF SYSTEM TIME in a transaction
+CREATE TABLE willfail AS SELECT * FROM stock AS OF SYSTEM TIME '-1s'
+
+statement ok
+ROLLBACK
+
+statement error syntax error
+CREATE TABLE willfail (a INT) AS OF SYSTEM TIME '-1s'
+
+let $laterts
+SELECT now()
+
+statement error unimplemented: cannot specify AS OF SYSTEM TIME with different timestamps
+CREATE TABLE willfail AS
+SELECT *, (SELECT count(1) FROM stock AS OF SYSTEM TIME '$ts')
+FROM stock AS OF SYSTEM TIME '$laterts'
+
+statement ok
+DROP TABLE stock
+
+# Test that CTAS AOST works with a table that has been dropped.
+statement ok
+CREATE TABLE stockbeforedrop AS SELECT * FROM stock AS OF SYSTEM TIME '$ts'
+
+query TII rowsort
+SELECT item, quantity, newcol FROM stockbeforedrop
+----
+cups    10  1
+plates  15  1
+forks   30  1
+spoons  10  1
+
+subtest end

--- a/pkg/sql/logictest/testdata/logic_test/views
+++ b/pkg/sql/logictest/testdata/logic_test/views
@@ -733,14 +733,6 @@ dt2  CREATE VIEW public.dt2 (
 statement ok
 SELECT * FROM dt2
 
-# Ensure that creating a view doesn't leak any session-level settings that
-# could affect subsequent AS OF SYSTEM TIME queries (#13547).
-statement ok
-CREATE VIEW v AS SELECT d, t FROM t
-
-statement error pq: AS OF SYSTEM TIME must be provided on a top-level statement
-CREATE TABLE t2 AS SELECT d, t FROM t AS OF SYSTEM TIME '2017-02-13 21:30:00'
-
 statement ok
 DROP TABLE t CASCADE
 

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -1482,6 +1482,14 @@ func (b *Builder) validateAsOf(asOfClause tree.AsOfClause) {
 		panic(err)
 	}
 
+	// We need to look at the original statement to know if the AOST clause was
+	// specified for a backfill, This must be set correctly in order to pass
+	// the validations below.
+	switch b.stmt.(type) {
+	case *tree.CreateTable:
+		asOf.ForBackfill = true
+	}
+
 	if b.evalCtx.AsOfSystemTime == nil {
 		panic(pgerror.Newf(pgcode.Syntax,
 			"AS OF SYSTEM TIME must be provided on a top-level statement"))

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -373,6 +373,16 @@ func (sc *SchemaChanger) backfillQueryIntoTable(
 			return err
 		}
 
+		// If we are backfilling with AS OF SYSTEM TIME, we must update the
+		// evalCtx for the new planner that was created.
+		asOf, err := localPlanner.isAsOf(ctx, stmt.AST)
+		if err != nil {
+			return err
+		}
+		if asOf != nil {
+			localPlanner.extendedEvalCtx.AsOfSystemTime = asOf
+		}
+
 		localPlanner.MaybeReallocateAnnotations(stmt.NumAnnotations)
 		// Construct an optimized logical plan of the AS source stmt.
 		localPlanner.stmt = makeStatement(stmt, clusterunique.ID{}, /* queryID */

--- a/pkg/sql/sem/eval/deps.go
+++ b/pkg/sql/sem/eval/deps.go
@@ -765,4 +765,8 @@ type AsOfSystemTime struct {
 	// This is be zero if there is no maximum bound.
 	// In non-zero, we want a read t where Timestamp <= t < MaxTimestampBound.
 	MaxTimestampBound hlc.Timestamp
+
+	// ForBackfill indicates if this AOST expression was added to an operation
+	// that requires a backfill, like CREATE TABLE AS.
+	ForBackfill bool
 }


### PR DESCRIPTION
Previously, running a statement of the form

    CREATE TABLE t AS SELECT ... FROM ... AS OF SYSTEM TIME x

was not supported.

Now, it is supported. The semantics are that the table creation happens at the transaction timestamp, but the backfill that's performed to fetch the data from the `SELECT` is performed at the user-specified timestamp x.

This is useful for copying data from tables that are experiencing write traffic. Reading the contended table's data at a historical timestamp avoids contention on the CREATE TABLE AS.

informs https://github.com/cockroachdb/cockroach/issues/39123
Epic: CRDB-43310
Release note (sql change): CREATE TABLE AS SELECT ... FROM ... AS OF SYSTEM TIME x is now supported. It cannot be executed within an explicit transaction.