### PR TITLE
raft: single voter campaigns without store liveness support

### DIFF
--- a/pkg/raft/testdata/campaign_single_voter.txt
+++ b/pkg/raft/testdata/campaign_single_voter.txt
@@ -1,0 +1,45 @@
+log-level info
+----
+ok
+
+add-nodes 1 voters=(1) index=2
+----
+INFO 1 switched to configuration voters=(1)
+INFO 1 became follower at term 0
+INFO newRaft 1 [peers: [1], term: 0, commit: 2, applied: 2, lastindex: 2, lastterm: 1]
+
+# Withdraw support to simulate the case where the store doesn't support itself
+# yet (e.g. upon startup).
+withdraw-support 1 1
+----
+  1
+1 x
+
+# A new election is expected even though support is not provided yet, because
+# this is a single-voter group.
+campaign 1
+----
+INFO 1 is starting a new election at term 0
+INFO 1 became candidate at term 1
+
+stabilize
+----
+> 1 handling Ready
+  Ready MustSync=true:
+  State:StateCandidate
+  HardState Term:1 Vote:1 Commit:2 Lead:0 LeadEpoch:0
+  INFO 1 received MsgVoteResp from 1 at term 1
+  INFO 1 has received 1 MsgVoteResp votes and 0 vote rejections
+  INFO 1 became leader at term 1
+  INFO 1 leader at term 1 does not support itself in the liveness fabric
+> 1 handling Ready
+  Ready MustSync=true:
+  State:StateLeader
+  HardState Term:1 Vote:1 Commit:2 Lead:1 LeadEpoch:0
+  Entries:
+  1/3 EntryNormal ""
+> 1 handling Ready
+  Ready MustSync=true:
+  HardState Term:1 Vote:1 Commit:3 Lead:1 LeadEpoch:0
+  CommittedEntries:
+  1/3 EntryNormal ""

--- a/pkg/raft/tracker/fortificationtracker.go
+++ b/pkg/raft/tracker/fortificationtracker.go
@@ -391,7 +391,11 @@ func (ft *FortificationTracker) QuorumActive() bool {
 // RequireQuorumSupportOnCampaign returns true if quorum support before
 // campaigning is required.
 func (ft *FortificationTracker) RequireQuorumSupportOnCampaign() bool {
-	return ft.storeLiveness.SupportFromEnabled()
+	// Don't check for store liveness support if there is only one voter.
+	// Presumably, it supports itself; and if it doesn't for some reason (e.g.
+	// disk stall), it will not be able to fortify later, which is ok.
+	notSingleVoter := len(ft.config.Voters[0]) > 1 || len(ft.config.Voters[1]) > 1
+	return ft.storeLiveness.SupportFromEnabled() && notSingleVoter
 }
 
 // QuorumSupported returns whether this peer is currently supported by a quorum


### PR DESCRIPTION
Previously, in a single-voter scenario (e.g. single-node cluster), it was possible that the single voter did not yet have store liveness support for itself when campaigning initially. This led to a potential 3s delay in electing a leader because the single voter had to wait for another election timeout. This issue manifested in various ways: a regression in the `TestServer` startup time (from 2s to 5s), and a race between roachprod nodes obtaining node IDs, leading to roachprod-cockroach node ID mismatch. The latter is due to a delay in establishing a lease for the systems range of the `node-idgen` key.

This commit opts single-voter configs out of the store liveness quorum support check. If the single node happens to legitimately not support itself (e.g. due to a disk stall), it will fail to fortify later, which is ok. An alternative solution here is for each node to start supporting itself on startup; the main reasons to go with the Raft change are (a) treating self symmetrically to other stores in the cluster wrt store liveness, and (b) mirroring the lease verification logic, which also makes a special case for single-voter configs (in `verifyAcquisition`).

This commit also repurposes the `TestElectionAfterRestart` test to validate this behavior. The previous test assertions are no longer applicable for leader leases.

Part of: #136806

Release note: None