### PR TITLE
tests: remove deprecated cluster setting from cdc roachtest

### DIFF
--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -2017,11 +2017,6 @@ func registerCDC(r registry.Registry) {
 
 			ct.runTPCCWorkload(tpccArgs{warehouses: 100, duration: "30m"})
 
-			// The deprecated webhook sink is unable to handle the throughput required for 100 warehouses
-			if _, err := ct.DB().Exec("SET CLUSTER SETTING changefeed.new_webhook_sink_enabled = true;"); err != nil {
-				ct.t.Fatal(err)
-			}
-
 			feed := ct.newChangefeed(feedArgs{
 				sinkType: webhookSink,
 				targets:  allTpccTargets,


### PR DESCRIPTION
The cluster setting changefeed.new_webhook_sink_enabled is deprecated.

Epic: none
Fixes: #142070

Release note: none