### PR TITLE
lease: don't print stack trace on error in DeleteOrphanedLeases

### DIFF
--- a/pkg/sql/catalog/lease/lease.go
+++ b/pkg/sql/catalog/lease/lease.go
@@ -2112,7 +2112,7 @@ func (m *Manager) DeleteOrphanedLeases(ctx context.Context, timeThreshold int64)
 				return err
 			})
 		}); err != nil {
-			log.Warningf(ctx, "unable to read orphaned leases: %+v", err)
+			log.Warningf(ctx, "unable to read orphaned leases: %v", err)
 			return
 		}
 		var wg sync.WaitGroup


### PR DESCRIPTION
This can look scary for no reason (for example, when the server is being shutdown), and I don't think it provides any value.

See [this](https://cockroachlabs.slack.com/archives/C01CDD4HRC5/p1740794240371799?thread_ts=1740782753.618289&cid=C01CDD4HRC5) slack thread for some context.

Epic: None
Release note: None