### PR TITLE
sql,opt: support lookup joins that perform reverse scans

### DIFF
--- a/pkg/kv/kvclient/kvstreamer/BUILD.bazel
+++ b/pkg/kv/kvclient/kvstreamer/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "results_buffer.go",
         "size.go",
         "streamer.go",
+        "util.go",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvstreamer",
     visibility = ["//visibility:public"],

--- a/pkg/kv/kvclient/kvstreamer/large_keys_test.go
+++ b/pkg/kv/kvclient/kvstreamer/large_keys_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvstreamer"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
@@ -33,6 +34,8 @@ import (
 func TestLargeKeys(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+
+	skip.UnderRace(t, "test takes too long")
 
 	testCases := []struct {
 		name  string
@@ -53,6 +56,14 @@ func TestLargeKeys(t *testing.T) {
 		{
 			name:  "lookup join, with ordering",
 			query: "SELECT * FROM bar INNER LOOKUP JOIN foo ON lookup_blob = pk_blob ORDER BY pk_blob",
+		},
+		{
+			name:  "lookup join on non-unique index, with ordering",
+			query: "SELECT * FROM bar INNER LOOKUP JOIN foo ON lookup_attribute = attribute ORDER BY pk_blob",
+		},
+		{
+			name:  "lookup join on non-unique index, with reverse ordering",
+			query: "SELECT * FROM bar INNER LOOKUP JOIN foo ON lookup_attribute = attribute ORDER BY pk_blob DESC",
 		},
 	}
 
@@ -133,7 +144,7 @@ func TestLargeKeys(t *testing.T) {
 						INDEX (attribute)%s
 					);`, familiesSuffix))
 				require.NoError(t, err)
-				_, err = db.Exec("CREATE TABLE bar (lookup_blob STRING PRIMARY KEY)")
+				_, err = db.Exec("CREATE TABLE bar (lookup_blob STRING PRIMARY KEY, lookup_attribute INT8)")
 				require.NoError(t, err)
 
 				// Insert some number of rows.
@@ -151,7 +162,7 @@ func TestLargeKeys(t *testing.T) {
 					blobSize := int(float64(valueSize)*5.0*rng.Float64()) + 1
 					_, err = db.Exec("INSERT INTO foo SELECT repeat($1, $2), 1, 1, repeat($1, $3);", letter, valueSize, blobSize)
 					require.NoError(t, err)
-					_, err = db.Exec("INSERT INTO bar SELECT repeat($1, $2);", letter, valueSize)
+					_, err = db.Exec("INSERT INTO bar SELECT repeat($1, $2), $3;", letter, valueSize, i)
 					require.NoError(t, err)
 				}
 

--- a/pkg/kv/kvclient/kvstreamer/results_buffer.go
+++ b/pkg/kv/kvclient/kvstreamer/results_buffer.go
@@ -377,7 +377,9 @@ type ResultDiskBuffer interface {
 // TestResultDiskBufferConstructor constructs a ResultDiskBuffer for tests. It
 // is injected to be rowcontainer.NewKVStreamerResultDiskBuffer in order to
 // avoid an import cycle.
-var TestResultDiskBufferConstructor func(_ diskmap.Factory, memAcc mon.BoundAccount, diskMonitor *mon.BytesMonitor) ResultDiskBuffer
+var TestResultDiskBufferConstructor func(
+	_ diskmap.Factory, memAcc mon.BoundAccount, diskMonitor *mon.BytesMonitor, reverse bool,
+) ResultDiskBuffer
 
 // inOrderResultsBuffer is a resultsBuffer that returns the Results in the same
 // order as the original requests were Enqueued into the Streamer (in other

--- a/pkg/kv/kvclient/kvstreamer/size.go
+++ b/pkg/kv/kvclient/kvstreamer/size.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/errors"
 )
 
 const (
@@ -93,8 +94,14 @@ func getResponseSize(get *kvpb.GetResponse) int64 {
 	return int64(len(get.Value.RawBytes))
 }
 
-// scanResponseSize calculates the size of the ScanResponse similar to how it is
-// accounted for TargetBytes parameter by the KV layer.
-func scanResponseSize(scan *kvpb.ScanResponse) int64 {
-	return scan.NumBytes
+// scanResponseSize calculates the size of a ScanResponse or ReverseScanResponse
+// similar to how it is accounted for TargetBytes parameter by the KV layer.
+func scanResponseSize(scan kvpb.Response) int64 {
+	switch response := scan.(type) {
+	case *kvpb.ScanResponse:
+		return response.NumBytes
+	case *kvpb.ReverseScanResponse:
+		return response.NumBytes
+	}
+	panic(errors.AssertionFailedf("unexpected response type: %v", scan))
 }

--- a/pkg/kv/kvclient/kvstreamer/streamer_accounting_test.go
+++ b/pkg/kv/kvclient/kvstreamer/streamer_accounting_test.go
@@ -8,6 +8,7 @@ package kvstreamer
 import (
 	"context"
 	"math"
+	"strconv"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
@@ -72,7 +73,7 @@ func TestStreamerMemoryAccounting(t *testing.T) {
 	acc := monitor.MakeBoundAccount()
 	defer acc.Close(ctx)
 
-	getStreamer := func() *Streamer {
+	getStreamer := func(reverse bool) *Streamer {
 		require.Zero(t, acc.Used())
 		rootTxn := kv.NewTxn(ctx, s.DB(), s.DistSQLPlanningNodeID())
 		leafInputState, err := rootTxn.GetLeafTxnInputState(ctx)
@@ -101,6 +102,7 @@ func TestStreamerMemoryAccounting(t *testing.T) {
 			nil, /* kvPairsRead */
 			lock.None,
 			lock.Unreplicated,
+			reverse,
 		)
 		s.Init(OutOfOrder, Hints{UniqueRequests: true}, 1 /* maxKeysPerRow */, nil /* diskBuffer */)
 		return s
@@ -108,7 +110,7 @@ func TestStreamerMemoryAccounting(t *testing.T) {
 
 	t.Run("get", func(t *testing.T) {
 		acc.Clear(ctx)
-		streamer := getStreamer()
+		streamer := getStreamer(false /* reverse */)
 		defer streamer.Close(ctx)
 
 		// Get the row with pk=0.
@@ -126,48 +128,66 @@ func TestStreamerMemoryAccounting(t *testing.T) {
 	})
 
 	t.Run("scan", func(t *testing.T) {
-		acc.Clear(ctx)
-		streamer := getStreamer()
-		defer streamer.Close(ctx)
+		for _, reverse := range []bool{false, true} {
+			t.Run("reverse="+strconv.FormatBool(reverse), func(t *testing.T) {
+				acc.Clear(ctx)
+				streamer := getStreamer(reverse)
+				defer streamer.Close(ctx)
 
-		// Scan the row with pk=0.
-		reqs := make([]kvpb.RequestUnion, 1)
-		reqs[0] = makeScanRequest(codec, uint32(tableID), 0, 1)
-		require.NoError(t, streamer.Enqueue(ctx, reqs))
-		results, err := streamer.GetResults(ctx)
-		require.NoError(t, err)
-		require.Equal(t, 1, len(results))
-		// 29 is usually the number of bytes in
-		// ScanResponse.BatchResponse[0]. We choose to hard-code this number
-		// rather than consult NumBytes field directly as an additional
-		// sanity-check. We also adjust the estimate to account for possible
-		// tenant prefix.
-		expectedMemToken := scanResponseOverhead + 29 + int64(len(codec.TenantPrefix()))
-		if results[0].ScanResp.NumBytes == 33+int64(len(codec.TenantPrefix())) {
-			// For some reason, sometimes it's not 29, but 33, and we do
-			// allow for this.
-			expectedMemToken += 4
+				// Scan the row with pk=0.
+				reqs := make([]kvpb.RequestUnion, 1)
+				reqs[0] = makeScanRequest(codec, uint32(tableID), 0, 1, reverse)
+				require.NoError(t, streamer.Enqueue(ctx, reqs))
+				results, err := streamer.GetResults(ctx)
+				require.NoError(t, err)
+				require.Equal(t, 1, len(results))
+				// 29 is usually the number of bytes in
+				// ScanResponse.BatchResponse[0]. We choose to hard-code this number
+				// rather than consult NumBytes field directly as an additional
+				// sanity-check. We also adjust the estimate to account for possible
+				// tenant prefix.
+				expectedMemToken := scanResponseOverhead + 29 + int64(len(codec.TenantPrefix()))
+				var numBytes int64
+				if reverse {
+					numBytes = results[0].ScanResp.(*kvpb.ReverseScanResponse).NumBytes
+				} else {
+					numBytes = results[0].ScanResp.(*kvpb.ScanResponse).NumBytes
+				}
+				if numBytes == 33+int64(len(codec.TenantPrefix())) {
+					// For some reason, sometimes it's not 29, but 33, and we do
+					// allow for this.
+					expectedMemToken += 4
+				}
+				require.Equal(t, expectedMemToken, results[0].memoryTok.toRelease)
+				expectedUsed := expectedMemToken + resultSize
+				// This is streamer.numRangesPerScanRequestAccountedFor.
+				expectedUsed += 4
+				require.Equal(t, expectedUsed, acc.Used())
+			})
 		}
-		require.Equal(t, expectedMemToken, results[0].memoryTok.toRelease)
-		expectedUsed := expectedMemToken + resultSize
-		// This is streamer.numRangesPerScanRequestAccountedFor.
-		expectedUsed += 4
-		require.Equal(t, expectedUsed, acc.Used())
 	})
 }
 
-func makeScanRequest(codec keys.SQLCodec, tableID uint32, start, end int) kvpb.RequestUnion {
+func makeScanRequest(
+	codec keys.SQLCodec, tableID uint32, start, end int, reverse bool,
+) kvpb.RequestUnion {
 	var res kvpb.RequestUnion
-	var scan kvpb.ScanRequest
-	var union kvpb.RequestUnion_Scan
 	makeKey := func(pk int) []byte {
 		// These numbers essentially make a key like '/t/primary/pk'.
 		return append(codec.IndexPrefix(tableID, 1), byte(136+pk))
 	}
-	scan.Key = makeKey(start)
-	scan.EndKey = makeKey(end)
-	scan.ScanFormat = kvpb.BATCH_RESPONSE
-	union.Scan = &scan
-	res.Value = &union
+	if reverse {
+		var scan kvpb.ReverseScanRequest
+		scan.Key = makeKey(start)
+		scan.EndKey = makeKey(end)
+		scan.ScanFormat = kvpb.BATCH_RESPONSE
+		res.Value = &kvpb.RequestUnion_ReverseScan{ReverseScan: &scan}
+	} else {
+		var scan kvpb.ScanRequest
+		scan.Key = makeKey(start)
+		scan.EndKey = makeKey(end)
+		scan.ScanFormat = kvpb.BATCH_RESPONSE
+		res.Value = &kvpb.RequestUnion_Scan{Scan: &scan}
+	}
 	return res
 }

--- a/pkg/kv/kvclient/kvstreamer/util.go
+++ b/pkg/kv/kvclient/kvstreamer/util.go
@@ -1,0 +1,72 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package kvstreamer
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/errors"
+)
+
+// GetScanBatchResponses returns the BatchResponses field from a ScanResponse or
+// ReverseScanResponse.
+func GetScanBatchResponses(response kvpb.Response) (batchResponses [][]byte) {
+	switch scan := response.(type) {
+	case *kvpb.ScanResponse:
+		return scan.BatchResponses
+	case *kvpb.ReverseScanResponse:
+		return scan.BatchResponses
+	}
+	panic(errors.AssertionFailedf("unexpected response: %v", response))
+}
+
+// getScanRows returns the Rows field from a ScanResponse or
+// ReverseScanResponse.
+func getScanRows(response kvpb.Response) (rows []roachpb.KeyValue) {
+	switch scan := response.(type) {
+	case *kvpb.ScanResponse:
+		return scan.Rows
+	case *kvpb.ReverseScanResponse:
+		return scan.Rows
+	}
+	panic(errors.AssertionFailedf("unexpected response: %v", response))
+}
+
+// getScanIntentRows returns the IntentRows field from a ScanResponse or
+// ReverseScanResponse.
+func getScanIntentRows(response kvpb.Response) (intentRows []roachpb.KeyValue) {
+	switch scan := response.(type) {
+	case *kvpb.ScanResponse:
+		return scan.IntentRows
+	case *kvpb.ReverseScanResponse:
+		return scan.IntentRows
+	}
+	panic(errors.AssertionFailedf("unexpected response: %v", response))
+}
+
+// getScanResumeSpan returns the ResumeSpan field from a ScanResponse or
+// ReverseScanResponse.
+func getScanResumeSpan(response kvpb.Response) (resumeSpan *roachpb.Span) {
+	switch scan := response.(type) {
+	case *kvpb.ScanResponse:
+		return scan.ResumeSpan
+	case *kvpb.ReverseScanResponse:
+		return scan.ResumeSpan
+	}
+	panic(errors.AssertionFailedf("unexpected response: %v", response))
+}
+
+// getScanResumeNextBytes returns the ResumeNextBytes field from a ScanResponse
+// or ReverseScanResponse.
+func getScanResumeNextBytes(response kvpb.Response) (resumeNextBytes int64) {
+	switch scan := response.(type) {
+	case *kvpb.ScanResponse:
+		return scan.ResumeNextBytes
+	case *kvpb.ReverseScanResponse:
+		return scan.ResumeNextBytes
+	}
+	panic(errors.AssertionFailedf("unexpected response: %v", response))
+}

--- a/pkg/sql/colfetcher/index_join.go
+++ b/pkg/sql/colfetcher/index_join.go
@@ -550,7 +550,7 @@ func NewColIndexJoin(
 			// which will close the acc.
 			diskBufferMemAcc := streamerBudgetAcc.Monitor().MakeBoundAccount()
 			diskBuffer = rowcontainer.NewKVStreamerResultDiskBuffer(
-				flowCtx.Cfg.TempStorage, diskBufferMemAcc, diskMonitor,
+				flowCtx.Cfg.TempStorage, diskBufferMemAcc, diskMonitor, false, /* reverse */
 			)
 		}
 		kvFetcher = row.NewStreamingKVFetcher(
@@ -568,6 +568,7 @@ func NewColIndexJoin(
 			maintainOrdering,
 			true, /* singleRowLookup */
 			int(spec.FetchSpec.MaxKeysPerRow),
+			false, /* reverse */
 			diskBuffer,
 			kvFetcherMemAcc,
 			spec.FetchSpec.External,

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -3438,6 +3438,7 @@ func (dsp *DistSQLPlanner) planLookupJoin(
 		LookupBatchBytesLimit:             dsp.distSQLSrv.TestingKnobs.JoinReaderBatchBytesLimit,
 		LimitHint:                         planInfo.limitHint,
 		RemoteOnlyLookups:                 planInfo.remoteOnlyLookups,
+		ReverseScans:                      planInfo.reverseScans,
 	}
 
 	fetchColIDs := make([]descpb.ColumnID, len(planInfo.fetch.catalogCols))

--- a/pkg/sql/distsql_spec_exec_factory.go
+++ b/pkg/sql/distsql_spec_exec_factory.go
@@ -896,6 +896,7 @@ func (e *distSQLSpecExecFactory) ConstructLookupJoin(
 	locking opt.Locking,
 	limitHint int64,
 	remoteOnlyLookups bool,
+	reverseScans bool,
 ) (exec.Node, error) {
 	physPlan, plan := getPhysPlan(input)
 	var planNodesToClose []planNode
@@ -943,6 +944,7 @@ func (e *distSQLSpecExecFactory) ConstructLookupJoin(
 			reqOrdering:                ReqOrdering(reqOrdering),
 			limitHint:                  limitHint,
 			remoteOnlyLookups:          remoteOnlyLookups,
+			reverseScans:               reverseScans,
 		}
 		if onCond != tree.DBoolTrue {
 			planInfo.onCond = onCond

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -4093,6 +4093,10 @@ func (m *sessionDataMutator) SetOptimizerCheckInputMinRowCount(val float64) {
 	m.data.OptimizerCheckInputMinRowCount = val
 }
 
+func (m *sessionDataMutator) SetOptimizerPlanLookupJoinsWithReverseScans(val bool) {
+	m.data.OptimizerPlanLookupJoinsWithReverseScans = val
+}
+
 // Utility functions related to scrubbing sensitive information on SQL Stats.
 
 // quantizeCounts ensures that the Count field in the

--- a/pkg/sql/execinfrapb/processors_sql.proto
+++ b/pkg/sql/execinfrapb/processors_sql.proto
@@ -379,6 +379,12 @@ message JoinReaderSpec {
   // that read into remote regions, though the lookups are defined in
   // LookupExpr, not RemoteLookupExpr.
   optional bool remote_only_lookups = 23 [(gogoproto.nullable) = false];
+
+  // If true, causes lookups to use ReverseScan requests instead of Scan
+  // requests. This causes lookups *for each input row* to return results in
+  // reverse order. This is only useful if a lookup can return more than one
+  // row.
+  optional bool reverse_scans = 25 [(gogoproto.nullable) = false];
 }
 
 // SorterSpec is the specification for a "sorting aggregator". A sorting

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -4010,6 +4010,7 @@ optimizer_check_input_min_row_count                        1
 optimizer_hoist_uncorrelated_equality_subqueries           on
 optimizer_merge_joins_enabled                              on
 optimizer_min_row_count                                    0
+optimizer_plan_lookup_joins_with_reverse_scans             on
 optimizer_prefer_bounded_cardinality                       off
 optimizer_prove_implication_with_virtual_computed_columns  on
 optimizer_push_limit_into_project_filtered_scan            on

--- a/pkg/sql/logictest/testdata/logic_test/lookup_join
+++ b/pkg/sql/logictest/testdata/logic_test/lookup_join
@@ -1484,6 +1484,113 @@ SELECT a, b, c, d, e, f FROM abc INNER LOOKUP JOIN def ON f < a AND f >= b ORDER
 statement ok
 RESET variable_inequality_lookup_join_enabled
 
+query IIIIII colnames
+SELECT * FROM abc INNER LOOKUP JOIN def ON f = a ORDER BY a, c, e;
+----
+a  b     c  d     e  f
+1  1     2  2     1  1
+1  1     2  NULL  2  1
+2  1     1  1     1  2
+2  NULL  2  1     1  2
+
+query IIIIII colnames
+SELECT * FROM abc INNER LOOKUP JOIN def ON f = a ORDER BY a, c, e DESC;
+----
+a  b     c  d     e  f
+1  1     2  NULL  2  1
+1  1     2  2     1  1
+2  1     1  1     1  2
+2  NULL  2  1     1  2
+
+query IIIIII colnames
+SELECT * FROM abc INNER LOOKUP JOIN def_e_desc ON f = a ORDER BY a, c, e;
+----
+a  b     c  d     e  f
+1  1     2  2     1  1
+1  1     2  NULL  2  1
+2  1     1  1     1  2
+2  NULL  2  1     1  2
+
+query IIIIII colnames
+SELECT * FROM abc INNER LOOKUP JOIN def_e_desc ON f = a ORDER BY a, c, e DESC;
+----
+a  b     c  d     e  f
+1  1     2  NULL  2  1
+1  1     2  2     1  1
+2  1     1  1     1  2
+2  NULL  2  1     1  2
+
+query IIIIII colnames
+SELECT * FROM abc INNER LOOKUP JOIN def ON f = a AND e >= c-1 ORDER BY a, c, e;
+----
+a  b     c  d     e  f
+1  1     2  2     1  1
+1  1     2  NULL  2  1
+2  1     1  1     1  2
+2  NULL  2  1     1  2
+
+query IIIIII colnames
+SELECT * FROM abc INNER LOOKUP JOIN def ON f = a AND e >= c-1 ORDER BY a, c, e DESC;
+----
+a  b     c  d     e  f
+1  1     2  NULL  2  1
+1  1     2  2     1  1
+2  1     1  1     1  2
+2  NULL  2  1     1  2
+
+query IIIIII colnames
+SELECT * FROM abc INNER LOOKUP JOIN def ON f = a AND e <= c ORDER BY a, c, e;
+----
+a  b     c  d     e  f
+1  1     2  2     1  1
+1  1     2  NULL  2  1
+2  1     1  1     1  2
+2  NULL  2  1     1  2
+
+query IIIIII colnames
+SELECT * FROM abc INNER LOOKUP JOIN def ON f = a AND e <= c ORDER BY a, c, e DESC;
+----
+a  b     c  d     e  f
+1  1     2  NULL  2  1
+1  1     2  2     1  1
+2  1     1  1     1  2
+2  NULL  2  1     1  2
+
+query IIIIII colnames
+SELECT * FROM abc INNER LOOKUP JOIN def_e_desc ON f = a AND e >= c-1 ORDER BY a, c, e;
+----
+a  b     c  d     e  f
+1  1     2  2     1  1
+1  1     2  NULL  2  1
+2  1     1  1     1  2
+2  NULL  2  1     1  2
+
+query IIIIII colnames
+SELECT * FROM abc INNER LOOKUP JOIN def_e_desc ON f = a AND e >= c-1 ORDER BY a, c, e DESC;
+----
+a  b     c  d     e  f
+1  1     2  NULL  2  1
+1  1     2  2     1  1
+2  1     1  1     1  2
+2  NULL  2  1     1  2
+
+query IIIIII colnames
+SELECT * FROM abc INNER LOOKUP JOIN def_e_desc ON f = a AND e <= c ORDER BY a, c, e;
+----
+a  b     c  d     e  f
+1  1     2  2     1  1
+1  1     2  NULL  2  1
+2  1     1  1     1  2
+2  NULL  2  1     1  2
+
+query IIIIII colnames
+SELECT * FROM abc INNER LOOKUP JOIN def_e_desc ON f = a AND e <= c ORDER BY a, c, e DESC;
+----
+a  b     c  d     e  f
+1  1     2  NULL  2  1
+1  1     2  2     1  1
+2  1     1  1     1  2
+2  NULL  2  1     1  2
 
 subtest regression_89576
 

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -3020,6 +3020,7 @@ optimizer_check_input_min_row_count                        1                   N
 optimizer_hoist_uncorrelated_equality_subqueries           on                  NULL      NULL        NULL        string
 optimizer_merge_joins_enabled                              on                  NULL      NULL        NULL        string
 optimizer_min_row_count                                    0                   NULL      NULL        NULL        string
+optimizer_plan_lookup_joins_with_reverse_scans             on                  NULL      NULL        NULL        string
 optimizer_prefer_bounded_cardinality                       off                 NULL      NULL        NULL        string
 optimizer_prove_implication_with_virtual_computed_columns  on                  NULL      NULL        NULL        string
 optimizer_push_limit_into_project_filtered_scan            on                  NULL      NULL        NULL        string
@@ -3229,6 +3230,7 @@ optimizer_check_input_min_row_count                        1                   N
 optimizer_hoist_uncorrelated_equality_subqueries           on                  NULL  user     NULL      on                  on
 optimizer_merge_joins_enabled                              on                  NULL  user     NULL      on                  on
 optimizer_min_row_count                                    0                   NULL  user     NULL      0                   0
+optimizer_plan_lookup_joins_with_reverse_scans             on                  NULL  user     NULL      on                  on
 optimizer_prefer_bounded_cardinality                       off                 NULL  user     NULL      off                 off
 optimizer_prove_implication_with_virtual_computed_columns  on                  NULL  user     NULL      on                  on
 optimizer_push_limit_into_project_filtered_scan            on                  NULL  user     NULL      on                  on
@@ -3437,6 +3439,7 @@ optimizer_check_input_min_row_count                        NULL    NULL     NULL
 optimizer_hoist_uncorrelated_equality_subqueries           NULL    NULL     NULL     NULL        NULL
 optimizer_merge_joins_enabled                              NULL    NULL     NULL     NULL        NULL
 optimizer_min_row_count                                    NULL    NULL     NULL     NULL        NULL
+optimizer_plan_lookup_joins_with_reverse_scans             NULL    NULL     NULL     NULL        NULL
 optimizer_prefer_bounded_cardinality                       NULL    NULL     NULL     NULL        NULL
 optimizer_prove_implication_with_virtual_computed_columns  NULL    NULL     NULL     NULL        NULL
 optimizer_push_limit_into_project_filtered_scan            NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -141,6 +141,7 @@ optimizer_check_input_min_row_count                        1
 optimizer_hoist_uncorrelated_equality_subqueries           on
 optimizer_merge_joins_enabled                              on
 optimizer_min_row_count                                    0
+optimizer_plan_lookup_joins_with_reverse_scans             on
 optimizer_prefer_bounded_cardinality                       off
 optimizer_prove_implication_with_virtual_computed_columns  on
 optimizer_push_limit_into_project_filtered_scan            on

--- a/pkg/sql/lookup_join.go
+++ b/pkg/sql/lookup_join.go
@@ -79,6 +79,12 @@ type lookupJoinPlanningInfo struct {
 	// lookupExpr, not remoteLookupExpr.
 	remoteOnlyLookups bool
 
+	// If true, reverseScans indicates that the lookups should use ReverseScan
+	// requests instead of Scan requests. This causes lookups *for each input row*
+	// to return results in reverse order. This is only useful when each lookup
+	// can return more than one row.
+	reverseScans bool
+
 	// finalizeLastStageCb will be nil in the spec factory.
 	finalizeLastStageCb func(*physicalplan.PhysicalPlan)
 }

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -2826,6 +2826,13 @@ func (b *Builder) buildLookupJoin(
 	if err != nil {
 		return execPlan{}, colOrdMap{}, err
 	}
+	ok, requiredDirection := ordering.LookupJoinCanProvideOrdering(
+		b.mem, join, &join.RequiredPhysical().Ordering,
+	)
+	if !ok {
+		return execPlan{}, colOrdMap{}, errors.AssertionFailedf("lookup join can't provide required ordering")
+	}
+	reverse := requiredDirection == ordering.ReverseDirection
 	var res execPlan
 	res.root, err = b.factory.ConstructLookupJoin(
 		joinType,
@@ -2844,6 +2851,7 @@ func (b *Builder) buildLookupJoin(
 		locking,
 		join.RequiredPhysical().LimitHintInt64(),
 		join.RemoteOnlyLookups,
+		reverse,
 	)
 	if err != nil {
 		return execPlan{}, colOrdMap{}, err

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -2827,7 +2827,7 @@ func (b *Builder) buildLookupJoin(
 		return execPlan{}, colOrdMap{}, err
 	}
 	ok, requiredDirection := ordering.LookupJoinCanProvideOrdering(
-		b.mem, join, &join.RequiredPhysical().Ordering,
+		b.ctx, b.evalCtx, b.mem, join, &join.RequiredPhysical().Ordering,
 	)
 	if !ok {
 		return execPlan{}, colOrdMap{}, errors.AssertionFailedf("lookup join can't provide required ordering")

--- a/pkg/sql/opt/exec/execbuilder/testdata/lookup_join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/lookup_join
@@ -2571,3 +2571,37 @@ vectorized: true
       estimated row count: 100 (100% of the table; stats collected <hidden> ago)
       table: abc@abc_pkey
       spans: FULL SCAN
+
+# Do not plan a lookup join with reverse scans if the session setting is
+# turned off.
+statement ok
+SET optimizer_plan_lookup_joins_with_reverse_scans = false
+
+query T
+EXPLAIN (VERBOSE) SELECT * FROM abc INNER LOOKUP JOIN def@primary ON f = a ORDER BY a, c, e DESC;
+----
+distribution: local
+vectorized: true
+·
+• sort
+│ columns: (a, b, c, d, e, f)
+│ estimated row count: 100
+│ order: +a,+c,-e
+│ already ordered: +a,+c
+│
+└── • lookup join (inner)
+    │ columns: (a, b, c, d, e, f)
+    │ ordering: +a,+c
+    │ estimated row count: 100
+    │ table: def@def_pkey
+    │ equality: (a) = (f)
+    │
+    └── • scan
+          columns: (a, b, c)
+          ordering: +a,+c
+          estimated row count: 100 (100% of the table; stats collected <hidden> ago)
+          table: abc@abc_pkey
+          spans: FULL SCAN
+
+statement ok
+RESET optimizer_plan_lookup_joins_with_reverse_scans

--- a/pkg/sql/opt/exec/execbuilder/testdata/lookup_join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/lookup_join
@@ -2277,3 +2277,297 @@ vectorized: true
 
 statement ok
 RESET variable_inequality_lookup_join_enabled
+
+query T
+EXPLAIN (VERBOSE) SELECT * FROM abc INNER LOOKUP JOIN def@primary ON f = a ORDER BY a, c, e;
+----
+distribution: local
+vectorized: true
+·
+• lookup join (inner)
+│ columns: (a, b, c, d, e, f)
+│ ordering: +a,+c,+e
+│ estimated row count: 100
+│ table: def@def_pkey
+│ equality: (a) = (f)
+│
+└── • scan
+      columns: (a, b, c)
+      ordering: +a,+c
+      estimated row count: 100 (100% of the table; stats collected <hidden> ago)
+      table: abc@abc_pkey
+      spans: FULL SCAN
+
+query T
+EXPLAIN (VERBOSE) SELECT * FROM abc INNER LOOKUP JOIN def@primary ON f = a ORDER BY a, c, e DESC;
+----
+distribution: local
+vectorized: true
+·
+• lookup join (inner)
+│ columns: (a, b, c, d, e, f)
+│ ordering: +a,+c,-e
+│ estimated row count: 100
+│ table: def@def_pkey
+│ equality: (a) = (f)
+│ reverse scans
+│
+└── • scan
+      columns: (a, b, c)
+      ordering: +a,+c
+      estimated row count: 100 (100% of the table; stats collected <hidden> ago)
+      table: abc@abc_pkey
+      spans: FULL SCAN
+
+query T
+EXPLAIN (VERBOSE) SELECT * FROM abc INNER LOOKUP JOIN def@desc_idx ON f = a ORDER BY a, c, e;
+----
+distribution: local
+vectorized: true
+·
+• lookup join (inner)
+│ columns: (a, b, c, d, e, f)
+│ ordering: +a,+c,+e
+│ estimated row count: 100
+│ table: def@desc_idx
+│ equality: (a) = (f)
+│ reverse scans
+│
+└── • scan
+      columns: (a, b, c)
+      ordering: +a,+c
+      estimated row count: 100 (100% of the table; stats collected <hidden> ago)
+      table: abc@abc_pkey
+      spans: FULL SCAN
+
+query T
+EXPLAIN (VERBOSE) SELECT * FROM abc INNER LOOKUP JOIN def@desc_idx ON f = a ORDER BY a, c, e DESC;
+----
+distribution: local
+vectorized: true
+·
+• lookup join (inner)
+│ columns: (a, b, c, d, e, f)
+│ ordering: +a,+c,-e
+│ estimated row count: 100
+│ table: def@desc_idx
+│ equality: (a) = (f)
+│
+└── • scan
+      columns: (a, b, c)
+      ordering: +a,+c
+      estimated row count: 100 (100% of the table; stats collected <hidden> ago)
+      table: abc@abc_pkey
+      spans: FULL SCAN
+
+query T
+EXPLAIN (VERBOSE) SELECT * FROM abc INNER LOOKUP JOIN def@primary ON f = a AND e >= c-1 ORDER BY a, c, e;
+----
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (a, b, c, d, e, f)
+│ ordering: +a,+c,+e
+│
+└── • lookup join (inner)
+    │ columns: (column15, a, b, c, d, e, f)
+    │ ordering: +a,+c,+e
+    │ estimated row count: 33
+    │ table: def@def_pkey
+    │ lookup condition: (column15 <= e) AND (a = f)
+    │
+    └── • render
+        │ columns: (column15, a, b, c)
+        │ ordering: +a,+c
+        │ render column15: c - 1
+        │ render a: a
+        │ render b: b
+        │ render c: c
+        │
+        └── • scan
+              columns: (a, b, c)
+              ordering: +a,+c
+              estimated row count: 100 (100% of the table; stats collected <hidden> ago)
+              table: abc@abc_pkey
+              spans: FULL SCAN
+
+query T
+EXPLAIN (VERBOSE) SELECT * FROM abc INNER LOOKUP JOIN def@primary ON f = a AND e >= c-1 ORDER BY a, c, e DESC;
+----
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (a, b, c, d, e, f)
+│ ordering: +a,+c,-e
+│
+└── • lookup join (inner)
+    │ columns: (column15, a, b, c, d, e, f)
+    │ ordering: +a,+c,-e
+    │ estimated row count: 33
+    │ table: def@def_pkey
+    │ reverse scans
+    │ lookup condition: (column15 <= e) AND (a = f)
+    │
+    └── • render
+        │ columns: (column15, a, b, c)
+        │ ordering: +a,+c
+        │ render column15: c - 1
+        │ render a: a
+        │ render b: b
+        │ render c: c
+        │
+        └── • scan
+              columns: (a, b, c)
+              ordering: +a,+c
+              estimated row count: 100 (100% of the table; stats collected <hidden> ago)
+              table: abc@abc_pkey
+              spans: FULL SCAN
+
+query T
+EXPLAIN (VERBOSE) SELECT * FROM abc INNER LOOKUP JOIN def@primary ON f = a AND e <= c ORDER BY a, c, e;
+----
+distribution: local
+vectorized: true
+·
+• lookup join (inner)
+│ columns: (a, b, c, d, e, f)
+│ ordering: +a,+c,+e
+│ estimated row count: 33
+│ table: def@def_pkey
+│ lookup condition: (e <= c) AND (a = f)
+│
+└── • scan
+      columns: (a, b, c)
+      ordering: +a,+c
+      estimated row count: 100 (100% of the table; stats collected <hidden> ago)
+      table: abc@abc_pkey
+      spans: FULL SCAN
+
+query T
+EXPLAIN (VERBOSE) SELECT * FROM abc INNER LOOKUP JOIN def@primary ON f = a AND e <= c ORDER BY a, c, e DESC;
+----
+distribution: local
+vectorized: true
+·
+• lookup join (inner)
+│ columns: (a, b, c, d, e, f)
+│ ordering: +a,+c,-e
+│ estimated row count: 33
+│ table: def@def_pkey
+│ reverse scans
+│ lookup condition: (e <= c) AND (a = f)
+│
+└── • scan
+      columns: (a, b, c)
+      ordering: +a,+c
+      estimated row count: 100 (100% of the table; stats collected <hidden> ago)
+      table: abc@abc_pkey
+      spans: FULL SCAN
+
+query T
+EXPLAIN (VERBOSE) SELECT * FROM abc INNER LOOKUP JOIN def@desc_idx ON f = a AND e >= c-1 ORDER BY a, c, e;
+----
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (a, b, c, d, e, f)
+│ ordering: +a,+c,+e
+│
+└── • lookup join (inner)
+    │ columns: (column15, a, b, c, d, e, f)
+    │ ordering: +a,+c,+e
+    │ estimated row count: 33
+    │ table: def@desc_idx
+    │ reverse scans
+    │ lookup condition: (column15 <= e) AND (a = f)
+    │
+    └── • render
+        │ columns: (column15, a, b, c)
+        │ ordering: +a,+c
+        │ render column15: c - 1
+        │ render a: a
+        │ render b: b
+        │ render c: c
+        │
+        └── • scan
+              columns: (a, b, c)
+              ordering: +a,+c
+              estimated row count: 100 (100% of the table; stats collected <hidden> ago)
+              table: abc@abc_pkey
+              spans: FULL SCAN
+
+query T
+EXPLAIN (VERBOSE) SELECT * FROM abc INNER LOOKUP JOIN def@desc_idx ON f = a AND e >= c-1 ORDER BY a, c, e DESC;
+----
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (a, b, c, d, e, f)
+│ ordering: +a,+c,-e
+│
+└── • lookup join (inner)
+    │ columns: (column15, a, b, c, d, e, f)
+    │ ordering: +a,+c,-e
+    │ estimated row count: 33
+    │ table: def@desc_idx
+    │ lookup condition: (column15 <= e) AND (a = f)
+    │
+    └── • render
+        │ columns: (column15, a, b, c)
+        │ ordering: +a,+c
+        │ render column15: c - 1
+        │ render a: a
+        │ render b: b
+        │ render c: c
+        │
+        └── • scan
+              columns: (a, b, c)
+              ordering: +a,+c
+              estimated row count: 100 (100% of the table; stats collected <hidden> ago)
+              table: abc@abc_pkey
+              spans: FULL SCAN
+
+query T
+EXPLAIN (VERBOSE) SELECT * FROM abc INNER LOOKUP JOIN def@desc_idx ON f = a AND e <= c ORDER BY a, c, e;
+----
+distribution: local
+vectorized: true
+·
+• lookup join (inner)
+│ columns: (a, b, c, d, e, f)
+│ ordering: +a,+c,+e
+│ estimated row count: 33
+│ table: def@desc_idx
+│ reverse scans
+│ lookup condition: (e <= c) AND (a = f)
+│
+└── • scan
+      columns: (a, b, c)
+      ordering: +a,+c
+      estimated row count: 100 (100% of the table; stats collected <hidden> ago)
+      table: abc@abc_pkey
+      spans: FULL SCAN
+
+query T
+EXPLAIN (VERBOSE) SELECT * FROM abc INNER LOOKUP JOIN def@desc_idx ON f = a AND e <= c ORDER BY a, c, e DESC;
+----
+distribution: local
+vectorized: true
+·
+• lookup join (inner)
+│ columns: (a, b, c, d, e, f)
+│ ordering: +a,+c,-e
+│ estimated row count: 33
+│ table: def@desc_idx
+│ lookup condition: (e <= c) AND (a = f)
+│
+└── • scan
+      columns: (a, b, c)
+      ordering: +a,+c
+      estimated row count: 100 (100% of the table; stats collected <hidden> ago)
+      table: abc@abc_pkey
+      spans: FULL SCAN

--- a/pkg/sql/opt/exec/execbuilder/testdata/mixed_version_lookup_join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/mixed_version_lookup_join
@@ -1,0 +1,35 @@
+# LogicTest: local-mixed-25.1
+
+statement ok
+CREATE TABLE abc (a INT, b INT, c INT, PRIMARY KEY (a, c))
+
+statement ok
+CREATE TABLE def (d INT, e INT, f INT, PRIMARY KEY (f, e), INDEX desc_idx (f, e DESC) STORING (d))
+
+# In a mixed-version cluster, do not plan a lookup join that does reverse scans.
+# Instead, a sort after the join should be planned.
+query T
+EXPLAIN (VERBOSE) SELECT * FROM abc INNER LOOKUP JOIN def@primary ON f = a ORDER BY a, c, e DESC;
+----
+distribution: local
+vectorized: true
+·
+• sort
+│ columns: (a, b, c, d, e, f)
+│ estimated row count: 10,000 (missing stats)
+│ order: +a,+c,-e
+│ already ordered: +a,+c
+│
+└── • lookup join (inner)
+    │ columns: (a, b, c, d, e, f)
+    │ ordering: +a,+c
+    │ estimated row count: 10,000 (missing stats)
+    │ table: def@def_pkey
+    │ equality: (a) = (f)
+    │
+    └── • scan
+          columns: (a, b, c)
+          ordering: +a,+c
+          estimated row count: 1,000 (missing stats)
+          table: abc@abc_pkey
+          spans: FULL SCAN

--- a/pkg/sql/opt/exec/execbuilder/tests/local-mixed-25.1/BUILD.bazel
+++ b/pkg/sql/opt/exec/execbuilder/tests/local-mixed-25.1/BUILD.bazel
@@ -12,7 +12,7 @@ go_test(
         "//build/toolchains:is_heavy": {"test.Pool": "heavy"},
         "//conditions:default": {"test.Pool": "large"},
     }),
-    shard_count = 1,
+    shard_count = 2,
     tags = ["cpu:1"],
     deps = [
         "//pkg/base",

--- a/pkg/sql/opt/exec/execbuilder/tests/local-mixed-25.1/generated_test.go
+++ b/pkg/sql/opt/exec/execbuilder/tests/local-mixed-25.1/generated_test.go
@@ -91,3 +91,10 @@ func TestExecBuild_geospatial(
 	defer leaktest.AfterTest(t)()
 	runExecBuildLogicTest(t, "geospatial")
 }
+
+func TestExecBuild_mixed_version_lookup_join(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runExecBuildLogicTest(t, "mixed_version_lookup_join")
+}

--- a/pkg/sql/opt/exec/explain/emit.go
+++ b/pkg/sql/opt/exec/explain/emit.go
@@ -864,6 +864,9 @@ func (e *emitter) emitNodeAttributes(ctx context.Context, evalCtx *eval.Context,
 		if a.EqColsAreKey {
 			ob.Attr("equality cols are key", "")
 		}
+		if a.ReverseScans {
+			ob.Attr("reverse scans", "")
+		}
 		ob.Expr("lookup condition", a.LookupExpr, appendColumns(inputCols, tableColumns(a.Table, a.LookupCols)...))
 		ob.Expr("remote lookup condition", a.RemoteLookupExpr, appendColumns(inputCols, tableColumns(a.Table, a.LookupCols)...))
 		ob.Expr("pred", a.OnCond, appendColumns(inputCols, tableColumns(a.Table, a.LookupCols)...))

--- a/pkg/sql/opt/exec/factory.opt
+++ b/pkg/sql/opt/exec/factory.opt
@@ -325,6 +325,7 @@ define LookupJoin {
     Locking opt.Locking
     LimitHint int64
     RemoteOnlyLookups bool
+    ReverseScans bool
 }
 
 # InvertedJoin performs a lookup join into an inverted index.

--- a/pkg/sql/opt/memo/memo.go
+++ b/pkg/sql/opt/memo/memo.go
@@ -204,6 +204,7 @@ type Memo struct {
 	preferBoundedCardinality                   bool
 	minRowCount                                float64
 	checkInputMinRowCount                      float64
+	planLookupJoinsWithReverseScans            bool
 	internal                                   bool
 
 	// txnIsoLevel is the isolation level under which the plan was created. This
@@ -300,6 +301,7 @@ func (m *Memo) Init(ctx context.Context, evalCtx *eval.Context) {
 		preferBoundedCardinality:                   evalCtx.SessionData().OptimizerPreferBoundedCardinality,
 		minRowCount:                                evalCtx.SessionData().OptimizerMinRowCount,
 		checkInputMinRowCount:                      evalCtx.SessionData().OptimizerCheckInputMinRowCount,
+		planLookupJoinsWithReverseScans:            evalCtx.SessionData().OptimizerPlanLookupJoinsWithReverseScans,
 		internal:                                   evalCtx.SessionData().Internal,
 		txnIsoLevel:                                evalCtx.TxnIsoLevel,
 	}
@@ -473,6 +475,7 @@ func (m *Memo) IsStale(
 		m.preferBoundedCardinality != evalCtx.SessionData().OptimizerPreferBoundedCardinality ||
 		m.minRowCount != evalCtx.SessionData().OptimizerMinRowCount ||
 		m.checkInputMinRowCount != evalCtx.SessionData().OptimizerCheckInputMinRowCount ||
+		m.planLookupJoinsWithReverseScans != evalCtx.SessionData().OptimizerPlanLookupJoinsWithReverseScans ||
 		m.internal != evalCtx.SessionData().Internal ||
 		m.txnIsoLevel != evalCtx.TxnIsoLevel {
 		return true, nil

--- a/pkg/sql/opt/memo/memo_test.go
+++ b/pkg/sql/opt/memo/memo_test.go
@@ -554,6 +554,11 @@ func TestMemoIsStale(t *testing.T) {
 	evalCtx.SessionData().OptimizerCheckInputMinRowCount = 0
 	notStale()
 
+	evalCtx.SessionData().OptimizerPlanLookupJoinsWithReverseScans = true
+	stale()
+	evalCtx.SessionData().OptimizerPlanLookupJoinsWithReverseScans = false
+	notStale()
+
 	evalCtx.SessionData().Internal = true
 	stale()
 	evalCtx.SessionData().Internal = false

--- a/pkg/sql/opt/ordering/BUILD.bazel
+++ b/pkg/sql/opt/ordering/BUILD.bazel
@@ -26,6 +26,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/opt/ordering",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/clusterversion",
         "//pkg/sql/opt",
         "//pkg/sql/opt/cat",
         "//pkg/sql/opt/memo",

--- a/pkg/sql/opt/ordering/BUILD.bazel
+++ b/pkg/sql/opt/ordering/BUILD.bazel
@@ -67,5 +67,6 @@ go_test(
         "//pkg/sql/sem/tree",
         "//pkg/sql/types",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/sql/opt/ordering/lookup_join.go
+++ b/pkg/sql/opt/ordering/lookup_join.go
@@ -89,11 +89,7 @@ func LookupJoinCanProvideOrdering(
 func lookupJoinCanProvideOrdering(
 	mem *memo.Memo, expr memo.RelExpr, required *props.OrderingChoice,
 ) bool {
-	canProvide, direction := LookupJoinCanProvideOrdering(mem, expr, required)
-	if direction == ReverseDirection {
-		// Do not allow reverse scans for now.
-		return false
-	}
+	canProvide, _ := LookupJoinCanProvideOrdering(mem, expr, required)
 	return canProvide
 }
 

--- a/pkg/sql/opt/ordering/lookup_join.go
+++ b/pkg/sql/opt/ordering/lookup_join.go
@@ -18,9 +18,17 @@ func indexJoinCanProvideOrdering(expr memo.RelExpr, required *props.OrderingChoi
 	return required.CanProjectCols(inputCols)
 }
 
-func lookupJoinCanProvideOrdering(
+// LookupJoinCanProvideOrdering determines whether the given LookupJoin
+// expression can provide the given ordering, as well as the direction
+// indicating whether forward or reverse scans are required. The default
+// direction indicates that either forward or reverse scans are acceptable.
+func LookupJoinCanProvideOrdering(
 	mem *memo.Memo, expr memo.RelExpr, required *props.OrderingChoice,
-) bool {
+) (canProvide bool, direction ScanDirection) {
+	if required.Any() {
+		// LookupJoin can always provide the empty ordering.
+		return true, EitherDirection
+	}
 	lookupJoin := expr.(*memo.LookupJoinExpr)
 
 	// LookupJoin can pass through its ordering if the ordering depends only on
@@ -28,53 +36,65 @@ func lookupJoinCanProvideOrdering(
 	inputCols := lookupJoin.Input.Relational().OutputCols
 	canProjectUsingOnlyInputCols := required.CanProjectCols(inputCols)
 
-	if canProjectUsingOnlyInputCols && lookupJoin.IsSecondJoinInPairedJoiner {
-		// Can only pass through ordering if the ordering can be provided by the
-		// child, since we don't want a sort to be interposed between the child
-		// and this join.
-		//
-		// We may need to remove ordering columns that are not output by the input
-		// expression. This results in an equivalent ordering, but with fewer
-		// options in the OrderingChoice.
-		child := lookupJoin.Input
-		res := projectOrderingToInput(child, required)
-		// It is in principle possible that the lookup join has an ON condition that
-		// forces an equality on two columns in the input. In this case we need to
-		// trim the column groups to keep the ordering valid w.r.t the child FDs
-		// (similar to Select).
-		//
-		// This case indicates that we didn't do a good job pushing down equalities
-		// (see #36219), but it should be handled correctly here nevertheless.
-		res = trimColumnGroups(&res, &child.Relational().FuncDeps)
-		return CanProvide(mem, child, &res)
-	}
-	if !canProjectUsingOnlyInputCols {
-		// It is not possible to serve the required ordering using only input
-		// columns. However, the lookup join may be able to satisfy the required
-		// ordering by appending index columns to the input ordering. See the
-		// getLookupOrdCols comment for more information.
-		//
-		// Iterate through the prefix of the required columns that can project input
-		// columns, and set up to test whether the input ordering can be extended
-		// with index columns.
-		var remainingRequired props.OrderingChoice
-		canProjectPrefixCols := required.Optional.Copy()
-		for i := range required.Columns {
-			if !required.Columns[i].Group.Intersects(inputCols) {
-				// We have reached the end of the prefix of the required ordering that
-				// can be projected by input columns. Keep track of the rest of the
-				// columns that cannot be satisfied by an ordering on the input.
-				remainingRequired.Columns = required.Columns[i:]
-				break
-			}
-			canProjectPrefixCols.UnionWith(required.Columns[i].Group)
+	if canProjectUsingOnlyInputCols {
+		if lookupJoin.IsSecondJoinInPairedJoiner {
+			// Can only pass through ordering if the ordering can be provided by the
+			// child, since we don't want a sort to be interposed between the child
+			// and this join.
+			//
+			// We may need to remove ordering columns that are not output by the input
+			// expression. This results in an equivalent ordering, but with fewer
+			// options in the OrderingChoice.
+			child := lookupJoin.Input
+			res := projectOrderingToInput(child, required)
+			// It is in principle possible that the lookup join has an ON condition that
+			// forces an equality on two columns in the input. In this case we need to
+			// trim the column groups to keep the ordering valid w.r.t the child FDs
+			// (similar to Select).
+			//
+			// This case indicates that we didn't do a good job pushing down equalities
+			// (see #36219), but it should be handled correctly here nevertheless.
+			res = trimColumnGroups(&res, &child.Relational().FuncDeps)
+			return CanProvide(mem, child, &res), EitherDirection
 		}
-		// Check whether appending index columns to the input ordering would satisfy
-		// the required ordering.
-		_, ok := getLookupOrdCols(mem, lookupJoin, &remainingRequired, canProjectPrefixCols)
-		return ok
+		return true, EitherDirection
 	}
-	return canProjectUsingOnlyInputCols
+
+	// It is not possible to serve the required ordering using only input
+	// columns. However, the lookup join may be able to satisfy the required
+	// ordering by appending index columns to the input ordering. See the
+	// getLookupOrdCols comment for more information.
+	//
+	// Iterate through the prefix of the required columns that can project input
+	// columns, and set up to test whether the input ordering can be extended
+	// with index columns.
+	var remainingRequired props.OrderingChoice
+	canProjectPrefixCols := required.Optional.Copy()
+	for i := range required.Columns {
+		if !required.Columns[i].Group.Intersects(inputCols) {
+			// We have reached the end of the prefix of the required ordering that
+			// can be projected by input columns. Keep track of the rest of the
+			// columns that cannot be satisfied by an ordering on the input.
+			remainingRequired.Columns = required.Columns[i:]
+			break
+		}
+		canProjectPrefixCols.UnionWith(required.Columns[i].Group)
+	}
+	// Check whether appending index columns to the input ordering would satisfy
+	// the required ordering.
+	_, direction, ok := getLookupOrdCols(mem, lookupJoin, &remainingRequired, canProjectPrefixCols)
+	return ok, direction
+}
+
+func lookupJoinCanProvideOrdering(
+	mem *memo.Memo, expr memo.RelExpr, required *props.OrderingChoice,
+) bool {
+	canProvide, direction := LookupJoinCanProvideOrdering(mem, expr, required)
+	if direction == ReverseDirection {
+		// Do not allow reverse scans for now.
+		return false
+	}
+	return canProvide
 }
 
 func lookupOrIndexJoinBuildChildReqOrdering(
@@ -144,13 +164,14 @@ func lookupJoinBuildProvided(
 	provided := lookupJoin.Input.ProvidedPhysical().Ordering
 
 	var toExtend *props.OrderingChoice
-	if provided, toExtend = trySatisfyRequired(required, provided); toExtend != nil {
+	provided, toExtend, _ = trySatisfyRequired(required, provided)
+	if toExtend != nil {
 		// The input provided ordering cannot satisfy the required ordering. It may
 		// be possible to append lookup columns in order to do so. See the
 		// getLookupOrdColumns for more details.
 		inputOrderingCols := provided.ColSet()
 		inputOrderingCols.UnionWith(required.Optional)
-		if lookupProvided, ok := getLookupOrdCols(mem, lookupJoin, toExtend, inputOrderingCols); ok {
+		if lookupProvided, _, ok := getLookupOrdCols(mem, lookupJoin, toExtend, inputOrderingCols); ok {
 			newProvided := make(opt.Ordering, len(provided)+len(lookupProvided))
 			copy(newProvided, provided)
 			copy(newProvided[len(provided):], lookupProvided)
@@ -230,7 +251,7 @@ func getLookupOrdCols(
 	lookupJoin *memo.LookupJoinExpr,
 	required *props.OrderingChoice,
 	inputOrderingCols opt.ColSet,
-) (lookupOrdering opt.Ordering, ok bool) {
+) (lookupOrdering opt.Ordering, direction ScanDirection, ok bool) {
 	if !lookupJoin.Input.Relational().FuncDeps.ColsAreStrictKey(inputOrderingCols) {
 		// Ensure that the ordering forms a key over the input columns. Lookup
 		// joins can only maintain the index ordering for each individual input
@@ -243,7 +264,7 @@ func getLookupOrdCols(
 		// However, in this case the addition of the index ordering columns would be
 		// trivial, since the ordering could be simplified to just include the input
 		// ordering columns (see OrderingChoice.Simplify).
-		return nil, false
+		return nil, EitherDirection, false
 	}
 	// The columns from the prefix of the required ordering satisfied by the
 	// input are considered optional for the index ordering.
@@ -276,22 +297,34 @@ func getLookupOrdCols(
 		}
 		indexOrder = append(indexOrder, opt.MakeOrderingColumn(idxColID, idx.Column(i).Descending))
 	}
+
 	// Check if the index ordering satisfies the postfix of the required
 	// ordering that cannot be satisfied by the input.
-	indexOrder, remaining := trySatisfyRequired(required, indexOrder)
-	return indexOrder, remaining == nil
+	indexOrder, remaining, direction := trySatisfyRequired(required, indexOrder)
+	if direction == ReverseDirection {
+		// Invert the directions of the ordering columns.
+		for i := range indexOrder {
+			indexOrder[i] = opt.MakeOrderingColumn(indexOrder[i].ID(), !indexOrder[i].Descending())
+		}
+	}
+	return indexOrder, direction, remaining == nil
 }
 
-// trySatisfyRequired returns a prefix of the given provided Ordering that is
-// compatible with the required ordering (e.g. all columns either line up with
-// the required columns or are optional), as well as an OrderingChoice that
-// indicates how the prefix needs to be extended in order to imply the required
-// OrderingChoice. If the prefix satisfies the required props, toExtend will be
-// nil. The returned fields reference the slices of the inputs, so they are not
-// safe to mutate.
+// trySatisfyRequired returns the following:
+// * A prefix of the given provided ordering that is compatible with the
+// required ordering (e.g. all columns either line up with the required columns
+// or are optional).
+// * An OrderingChoice that indicates how the prefix needs to be extended in
+// order to imply the required ordering choice.
+// * The direction in which each lookup must scan the index. EitherDirection
+// indicates that either forward or reverse scans are acceptable.
+//
+// If the prefix satisfies the required props, toExtend will be nil. The
+// returned fields reference the slices of the inputs, so they are not safe to
+// mutate.
 func trySatisfyRequired(
 	required *props.OrderingChoice, provided opt.Ordering,
-) (prefix opt.Ordering, toExtend *props.OrderingChoice) {
+) (prefix opt.Ordering, toExtend *props.OrderingChoice, direction ScanDirection) {
 	var requiredIdx, providedIdx int
 	for requiredIdx < len(required.Columns) && providedIdx < len(provided) {
 		requiredCol, providedCol := required.Columns[requiredIdx], provided[providedIdx]
@@ -300,12 +333,20 @@ func trySatisfyRequired(
 			providedIdx++
 			continue
 		}
-		if !requiredCol.Group.Contains(providedCol.ID()) ||
-			requiredCol.Descending != providedCol.Descending() {
+		if !requiredCol.Group.Contains(providedCol.ID()) {
 			// The provided ordering columns must either line up with the
 			// OrderingChoice columns, or be part of the optional column set.
-			// Additionally, the provided ordering must have the same column
-			// directions as the OrderingChoice.
+			break
+		}
+		columnRequiredDirection := ForwardDirection
+		if requiredCol.Descending != providedCol.Descending() {
+			columnRequiredDirection = ReverseDirection
+		}
+		if direction == EitherDirection {
+			direction = columnRequiredDirection
+		} else if columnRequiredDirection != direction {
+			// We've determined the direction the index must be scanned, and this
+			// column doesn't match up.
 			break
 		}
 		// The current OrderingChoice and provided columns match up.
@@ -321,5 +362,5 @@ func trySatisfyRequired(
 			Columns:  required.Columns[requiredIdx:],
 		}
 	}
-	return prefix, toExtend
+	return prefix, toExtend, direction
 }

--- a/pkg/sql/opt/ordering/lookup_join_test.go
+++ b/pkg/sql/opt/ordering/lookup_join_test.go
@@ -233,7 +233,9 @@ func TestLookupJoinCanProvide(t *testing.T) {
 		t.Fatal(err)
 	}
 	st := cluster.MakeTestingClusterSettings()
+	ctx := context.Background()
 	evalCtx := eval.NewTestingEvalContext(st)
+	evalCtx.SessionData().OptimizerPlanLookupJoinsWithReverseScans = true
 	var f norm.Factory
 	f.Init(context.Background(), evalCtx, tc)
 	md := f.Metadata()
@@ -432,7 +434,7 @@ func TestLookupJoinCanProvide(t *testing.T) {
 				},
 			)
 			req := props.ParseOrderingChoice(tc.required)
-			canProvide, _ := LookupJoinCanProvideOrdering(f.Memo(), lookupJoin, &req)
+			canProvide, _ := LookupJoinCanProvideOrdering(ctx, evalCtx, f.Memo(), lookupJoin, &req)
 			if canProvide != tc.canProvide {
 				t.Errorf(errorString(tc.canProvide), req)
 			}

--- a/pkg/sql/opt/ordering/lookup_join_test.go
+++ b/pkg/sql/opt/ordering/lookup_join_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/stretchr/testify/require"
 )
 
 func TestLookupJoinProvided(t *testing.T) {
@@ -119,7 +120,16 @@ func TestLookupJoinProvided(t *testing.T) {
 			input:    "+5,+6",
 			provided: "+5,+6,+2",
 		},
-		{ // case 6: the lookup join outputs all columns and adds column c2 as an
+		{ // Case 6: previous case, reversed. The lookup join would have to perform
+			// reverse scans.
+			keyCols:  opt.ColList{5},
+			inputKey: c(5, 6),
+			outCols:  c(2, 3, 4, 5, 6),
+			required: "+(1|5),+6,-2",
+			input:    "+5,+6",
+			provided: "+5,+6,-2",
+		},
+		{ // case 7: the lookup join outputs all columns and adds column c2 as an
 			// ordering column. Joining on c1 = c6.
 			keyCols:  opt.ColList{6},
 			inputKey: c(6),
@@ -128,7 +138,16 @@ func TestLookupJoinProvided(t *testing.T) {
 			input:    "-5,+6",
 			provided: "-5,+6,+2",
 		},
-		{ // case 7: the lookup join does not produce input columns 5,6; we must
+		{ // Case 8: previous case, reversed. The lookup join would have to perform
+			// reverse scans.
+			keyCols:  opt.ColList{6},
+			inputKey: c(6),
+			outCols:  c(1, 2, 3, 4, 5, 6),
+			required: "-5,+(1|6),-2",
+			input:    "-5,+6",
+			provided: "-5,+6,-2",
+		},
+		{ // case 9: the lookup join does not produce input columns 5,6; we must
 			// remap the input ordering to refer to output column 1 instead.
 			keyCols:  opt.ColList{5},
 			inputKey: c(5),
@@ -137,7 +156,16 @@ func TestLookupJoinProvided(t *testing.T) {
 			input:    "+5",
 			provided: "+1,+2",
 		},
-		{ // case 8: the lookup join preserves the input ordering and maintains the
+		{ // Case 10: previous case, reversed. The lookup join would have to perform
+			// reverse scans.
+			keyCols:  opt.ColList{5},
+			inputKey: c(5),
+			outCols:  c(1, 2, 3, 4),
+			required: "+(1|5),-2",
+			input:    "+5",
+			provided: "+1,-2",
+		},
+		{ // case 11: the lookup join preserves the input ordering and maintains the
 			// ordering of the descending index on lookups. Joining on c1 = c5.
 			index:    descendingIndex,
 			keyCols:  opt.ColList{5},
@@ -146,6 +174,16 @@ func TestLookupJoinProvided(t *testing.T) {
 			required: "+(1|5),+6,-2",
 			input:    "+5,+6",
 			provided: "+5,+6,-2",
+		},
+		{ // Case 12: previous case, reversed. The lookup join would have to perform
+			// reverse scans.
+			index:    descendingIndex,
+			keyCols:  opt.ColList{5},
+			inputKey: c(5, 6),
+			outCols:  c(2, 3, 4, 5, 6),
+			required: "+(1|5),+6,+2",
+			input:    "+5,+6",
+			provided: "+5,+6,+2",
 		},
 	}
 
@@ -258,7 +296,15 @@ func TestLookupJoinCanProvide(t *testing.T) {
 			required:   "+(1|5),+6,+2",
 			canProvide: true,
 		},
-		{ // Case 4: the ordering cannot project only input columns, but the lookup
+		{ // Case 4: previous case, reversed. The lookup join would have to perform
+			// reverse scans.
+			keyCols:    opt.ColList{5},
+			outCols:    c(1, 2, 5, 6),
+			inputKey:   c(5, 6),
+			required:   "+(1|5),+6,-2",
+			canProvide: true,
+		},
+		{ // Case 5: the ordering cannot project only input columns, but the lookup
 			// can maintain the ordering on both input and lookup columns.
 			idx:        secondaryIndex,
 			keyCols:    opt.ColList{5},
@@ -267,7 +313,16 @@ func TestLookupJoinCanProvide(t *testing.T) {
 			required:   "+(3|5),+4",
 			canProvide: true,
 		},
-		{ // Case 5: the ordering cannot project only input columns, but the lookup
+		{ // Case 6: previous case, reversed. The lookup join would have to perform
+			// reverse scans.
+			idx:        secondaryIndex,
+			keyCols:    opt.ColList{5},
+			outCols:    c(1, 2, 3, 4, 5, 6),
+			inputKey:   c(5),
+			required:   "+(3|5),-4",
+			canProvide: true,
+		},
+		{ // Case 7: the ordering cannot project only input columns, but the lookup
 			// can maintain the ordering on both input and lookup columns.
 			idx:        secondaryIndex,
 			keyCols:    opt.ColList{5},
@@ -276,7 +331,16 @@ func TestLookupJoinCanProvide(t *testing.T) {
 			required:   "+(3|5),+6,+4,+2 opt(1)",
 			canProvide: true,
 		},
-		{ // Case 6: the ordering cannot be satisfied because the input and lookup
+		{ // Case 8: previous case, reversed. The lookup join would have to perform
+			// reverse scans.
+			idx:        secondaryIndex,
+			keyCols:    opt.ColList{5},
+			outCols:    c(1, 2, 5, 6),
+			inputKey:   c(5, 6),
+			required:   "+(3|5),+6,-4,-2 opt(1)",
+			canProvide: true,
+		},
+		{ // Case 9: the ordering cannot be satisfied because the input and lookup
 			// ordering columns are interleaved.
 			keyCols:    opt.ColList{5},
 			outCols:    c(1, 2, 5, 6),
@@ -284,7 +348,7 @@ func TestLookupJoinCanProvide(t *testing.T) {
 			required:   "+(1|5),+2,+6",
 			canProvide: false,
 		},
-		{ // Case 7: the ordering cannot be satisfied because the input ordering
+		{ // Case 10: the ordering cannot be satisfied because the input ordering
 			// columns do not form a key over the input.
 			keyCols:    opt.ColList{5},
 			outCols:    c(1, 2, 5, 6),
@@ -292,7 +356,7 @@ func TestLookupJoinCanProvide(t *testing.T) {
 			required:   "+(1|5),+2",
 			canProvide: false,
 		},
-		{ // Case 8: the ordering cannot be satisfied because the lookup ordering
+		{ // Case 11: the ordering cannot be satisfied because the lookup ordering
 			// involves columns that are not part of the index.
 			keyCols:    opt.ColList{5, 6},
 			outCols:    c(1, 3, 5, 6),
@@ -300,7 +364,7 @@ func TestLookupJoinCanProvide(t *testing.T) {
 			required:   "+(1|5),+6,+3",
 			canProvide: false,
 		},
-		{ // Case 9: the ordering cannot be satisfied because the lookup ordering
+		{ // Case 12: the ordering cannot be satisfied because the lookup ordering
 			// columns are not in index order.
 			idx:        secondaryIndex,
 			keyCols:    opt.ColList{5},
@@ -309,15 +373,16 @@ func TestLookupJoinCanProvide(t *testing.T) {
 			required:   "+(3|5),+1,+4",
 			canProvide: false,
 		},
-		{ // Case 10: the ordering cannot be satisfied because one of the lookup
+		{ // Case 13: the ordering cannot be satisfied because one of the lookup
 			// ordering columns is sorted in the wrong direction.
+			idx:        secondaryIndex,
 			keyCols:    opt.ColList{5},
 			outCols:    c(1, 2, 5, 6),
 			inputKey:   c(5, 6),
-			required:   "+(1|5),+6,-2",
+			required:   "+(3|5),+6,+4,-2 opt(1)",
 			canProvide: false,
 		},
-		{ // Case 11: an ordering with a descending column can be satisfied..
+		{ // Case 14: an ordering with a descending column can be satisfied.
 			idx:        descendingIndex,
 			keyCols:    opt.ColList{5},
 			outCols:    c(1, 2, 5, 6),
@@ -325,7 +390,16 @@ func TestLookupJoinCanProvide(t *testing.T) {
 			required:   "+(1|5),+6,-2",
 			canProvide: true,
 		},
-		{ // Case 12: the ordering cannot be satisfied because the required ordering
+		{ // Case 15: previous case, reversed. The lookup join would have to perform
+			// reverse scans.
+			idx:        descendingIndex,
+			keyCols:    opt.ColList{5},
+			outCols:    c(1, 2, 5, 6),
+			inputKey:   c(5, 6),
+			required:   "+(1|5),+6,+2",
+			canProvide: true,
+		},
+		{ // Case 16: the ordering cannot be satisfied because the required ordering
 			// is missing index column c1.
 			idx:        secondaryIndex,
 			keyCols:    opt.ColList{5},
@@ -358,7 +432,7 @@ func TestLookupJoinCanProvide(t *testing.T) {
 				},
 			)
 			req := props.ParseOrderingChoice(tc.required)
-			canProvide := lookupJoinCanProvideOrdering(f.Memo(), lookupJoin, &req)
+			canProvide, _ := LookupJoinCanProvideOrdering(f.Memo(), lookupJoin, &req)
 			if canProvide != tc.canProvide {
 				t.Errorf(errorString(tc.canProvide), req)
 			}
@@ -368,74 +442,125 @@ func TestLookupJoinCanProvide(t *testing.T) {
 
 func TestTrySatisfyRequired(t *testing.T) {
 	testCases := []struct {
-		required string
-		provided string
-		prefix   string
-		toExtend string
+		required  string
+		provided  string
+		prefix    string
+		toExtend  string
+		direction string
 	}{
 		{ // Case 1: required ordering is prefix of provided.
-			required: "+1,+2,+3",
-			provided: "+1,+2,+3,+4",
-			prefix:   "+1,+2,+3",
-			toExtend: "",
+			required:  "+1,+2,+3",
+			provided:  "+1,+2,+3,+4",
+			prefix:    "+1,+2,+3",
+			toExtend:  "",
+			direction: "forward",
 		},
-		{ // Case 2: required ordering is empty.
-			required: "",
-			provided: "+1,-2",
-			prefix:   "",
-			toExtend: "",
+		{ // Case 2: required ordering is prefix of provided, reversed.
+			required:  "-1,-2,-3",
+			provided:  "+1,+2,+3,+4",
+			prefix:    "+1,+2,+3",
+			toExtend:  "",
+			direction: "reverse",
 		},
-		{ // Case 3: provided ordering includes optional columns.
-			required: "+1,+2,+3 opt(4,5)",
-			provided: "+1,-4,+2,+5,+3",
-			prefix:   "+1,-4,+2,+5,+3",
-			toExtend: "",
+		{ // Case 3: required ordering is empty.
+			required:  "",
+			provided:  "+1,-2",
+			prefix:    "",
+			toExtend:  "",
+			direction: "either",
 		},
-		{ // Case 4: required ordering includes equivalent columns.
-			required: "+(1|4),-(2|5),+3",
-			provided: "+1,-2,+3",
-			prefix:   "+1,-2,+3",
-			toExtend: "",
+		{ // Case 4: provided ordering includes optional columns.
+			required:  "+1,+2,+3 opt(4,5)",
+			provided:  "+1,-4,+2,+5,+3",
+			prefix:    "+1,-4,+2,+5,+3",
+			toExtend:  "",
+			direction: "forward",
 		},
-		{ // Case 5: provided ordering is prefix of required.
-			required: "+1,+2,+3",
-			provided: "+1,+2",
-			prefix:   "+1,+2",
-			toExtend: "+3",
+		{ // Case 5: provided ordering includes optional columns, reversed.
+			required:  "-1,-2,+3 opt(4,5)",
+			provided:  "+1,+4,+2,-5,-3",
+			prefix:    "+1,+4,+2,-5,-3",
+			toExtend:  "",
+			direction: "reverse",
 		},
-		{ // Case 6: provided ordering has non-optional columns between required
+		{ // Case 6: required ordering includes equivalent columns.
+			required:  "+(1|4),-(2|5),+3",
+			provided:  "+1,-2,+3",
+			prefix:    "+1,-2,+3",
+			toExtend:  "",
+			direction: "forward",
+		},
+		{ // Case 7: required ordering includes equivalent columns, reversed.
+			required:  "+(1|4),-(2|5),+3",
+			provided:  "-1,+2,-3",
+			prefix:    "-1,+2,-3",
+			toExtend:  "",
+			direction: "reverse",
+		},
+		{ // Case 8: provided ordering is prefix of required.
+			required:  "+1,+2,+3",
+			provided:  "+1,+2",
+			prefix:    "+1,+2",
+			toExtend:  "+3",
+			direction: "forward",
+		},
+		{ // Case 9: provided ordering is prefix of required, reversed.
+			required:  "+1,+2,+3",
+			provided:  "-1,-2",
+			prefix:    "-1,-2",
+			toExtend:  "+3",
+			direction: "reverse",
+		},
+		{ // Case 10: provided ordering has non-optional columns between required
 			// columns.
-			required: "+1,+2,+3",
-			provided: "+1,+2,+4,+3",
-			prefix:   "+1,+2",
-			toExtend: "+3",
+			required:  "+1,+2,+3",
+			provided:  "+1,+2,+4,+3",
+			prefix:    "+1,+2",
+			toExtend:  "+3",
+			direction: "forward",
 		},
-		{ // Case 7: provided ordering column is in the wrong direction.
-			required: "+1,+2,+3",
-			provided: "+1,-2,+3",
-			prefix:   "+1",
-			toExtend: "+2,+3",
+		{ // Case 11: provided ordering has non-optional columns between required
+			// columns, reversed.
+			required:  "+1,-2,+3",
+			provided:  "-1,+2,+4,-3",
+			prefix:    "-1,+2",
+			toExtend:  "+3",
+			direction: "reverse",
 		},
-		{ // Case 8: provided ordering is empty and required is non-empty.
-			required: "+1",
-			provided: "",
-			prefix:   "",
-			toExtend: "+1",
+		{ // Case 12: second provided ordering column is in the wrong direction.
+			required:  "+1,+2,+3",
+			provided:  "+1,-2,+3",
+			prefix:    "+1",
+			toExtend:  "+2,+3",
+			direction: "forward",
+		},
+		{ // Case 13: second provided ordering column is in the wrong direction,
+			// reversed.
+			required:  "+1,+2,+3",
+			provided:  "-1,+2,-3",
+			prefix:    "-1",
+			toExtend:  "+2,+3",
+			direction: "reverse",
+		},
+		{ // Case 14: provided ordering is empty and required is non-empty.
+			required:  "+1",
+			provided:  "",
+			prefix:    "",
+			toExtend:  "+1",
+			direction: "either",
 		},
 	}
 
 	expect := func(exp, got string) {
 		t.Helper()
-		if got != exp {
-			t.Errorf("expected %s; got %s", exp, got)
-		}
+		require.Equalf(t, exp, got, "expected %s; got %s", exp, got)
 	}
 
 	for i, tc := range testCases {
 		t.Run(fmt.Sprintf("case%d", i+1), func(t *testing.T) {
 			required := props.ParseOrderingChoice(tc.required)
 			provided := props.ParseOrdering(tc.provided)
-			prefix, toExtend := trySatisfyRequired(&required, provided)
+			prefix, toExtend, direction := trySatisfyRequired(&required, provided)
 			prefixString, toExtendString := "", ""
 			if prefix != nil {
 				prefixString = prefix.String()
@@ -445,6 +570,7 @@ func TestTrySatisfyRequired(t *testing.T) {
 			}
 			expect(tc.prefix, prefixString)
 			expect(tc.toExtend, toExtendString)
+			expect(tc.direction, direction.String())
 		})
 	}
 }

--- a/pkg/sql/opt/ordering/scan.go
+++ b/pkg/sql/opt/ordering/scan.go
@@ -40,6 +40,33 @@ func ScanIsReverse(mem *memo.Memo, scan *memo.ScanExpr, required *props.Ordering
 	return reverse
 }
 
+// ScanDirection represents the direction of a scan, either for a Scan operator
+// or a LookupJoin.
+type ScanDirection uint8
+
+const (
+	// EitherDirection indicates that the scan can be in either direction.
+	EitherDirection ScanDirection = iota
+	// ForwardDirection indicates a forward scan.
+	ForwardDirection
+	// ReverseDirection indicates a reverse scan.
+	ReverseDirection
+)
+
+// String implements the fmt.Stringer interface.
+func (d ScanDirection) String() string {
+	switch d {
+	case EitherDirection:
+		return "either"
+	case ForwardDirection:
+		return "forward"
+	case ReverseDirection:
+		return "reverse"
+	default:
+		return "unknown"
+	}
+}
+
 // ScanPrivateCanProvide returns true if the scan operator returns rows
 // that satisfy the given required ordering; it also returns whether the scan
 // needs to be in reverse order to match the required ordering.
@@ -57,23 +84,18 @@ func ScanPrivateCanProvide(
 	// We start off as accepting either a forward or a reverse scan. Until then,
 	// the reverse variable is unset. Once the direction is known, reverseSet is
 	// true and reverse indicates whether we need to do a reverse scan.
-	const (
-		either = 0
-		fwd    = 1
-		rev    = 2
-	)
-	direction := either
+	var direction ScanDirection
 	if s.HardLimit.IsSet() {
 		// When we have a limit, the limit forces a certain scan direction (because
 		// it affects the results, not just their ordering).
-		direction = fwd
+		direction = ForwardDirection
 		if s.HardLimit.Reverse() {
-			direction = rev
+			direction = ReverseDirection
 		}
 	} else if s.Flags.Direction != 0 {
-		direction = fwd
+		direction = ForwardDirection
 		if s.Flags.Direction == tree.Descending {
-			direction = rev
+			direction = ReverseDirection
 		}
 	}
 	index := md.Table(s.Table).Index(s.Index)
@@ -98,13 +120,13 @@ func ScanPrivateCanProvide(
 		}
 		// The directions of the index column and the required column impose either
 		// a forward or a reverse scan.
-		required := fwd
+		requiredDirection := ForwardDirection
 		if indexCol.Descending != reqCol.Descending {
-			required = rev
+			requiredDirection = ReverseDirection
 		}
-		if direction == either {
-			direction = required
-		} else if direction != required {
+		if direction == EitherDirection {
+			direction = requiredDirection
+		} else if direction != requiredDirection {
 			// We already determined the direction, and according to it, this column
 			// has the wrong direction.
 			return false, false
@@ -112,7 +134,7 @@ func ScanPrivateCanProvide(
 		left, right = left+1, right+1
 	}
 	// If direction is either, we prefer forward scan.
-	return true, direction == rev
+	return true, direction == ReverseDirection
 }
 
 func scanBuildProvided(

--- a/pkg/sql/opt/xform/physical_props.go
+++ b/pkg/sql/opt/xform/physical_props.go
@@ -38,7 +38,8 @@ func CanProvidePhysicalProps(
 ) bool {
 	// All operators can provide the Presentation and LimitHint properties, so no
 	// need to check for that.
-	canProvideOrdering := e.Op() == opt.SortOp || ordering.CanProvide(mem, e, &required.Ordering)
+	canProvideOrdering := e.Op() == opt.SortOp ||
+		ordering.CanProvide(ctx, evalCtx, mem, e, &required.Ordering)
 	canProvideDistribution := e.Op() == opt.DistributeOp ||
 		distribution.CanProvide(ctx, evalCtx, mem, e, &required.Distribution)
 	return canProvideOrdering && canProvideDistribution

--- a/pkg/sql/opt/xform/testdata/physprops/ordering
+++ b/pkg/sql/opt/xform/testdata/physprops/ordering
@@ -2734,7 +2734,25 @@ inner-join (lookup abc)
  │    └── ordering: +1,+2,+3
  └── filters (true)
 
-# Preserving lookup ordering (no sort should be added). The 'u' and 'v' columns
+# Previous case with reversed orderings, which will require reverse scans.
+opt
+SELECT * FROM xyz INNER LOOKUP JOIN abc ON x = a ORDER BY x, y, z, a DESC, b DESC, c DESC
+----
+inner-join (lookup abc)
+ ├── columns: x:1!null y:2!null z:3!null a:6!null b:7!null c:8!null
+ ├── flags: force lookup join (into right side)
+ ├── key columns: [1] = [6]
+ ├── reverse-scans
+ ├── key: (2,3,6-8)
+ ├── fd: (1)==(6), (6)==(1)
+ ├── ordering: +(1|6),+2,+3,-7,-8 [actual: +1,+2,+3,-7,-8]
+ ├── scan xyz
+ │    ├── columns: x:1!null y:2!null z:3!null
+ │    ├── key: (1-3)
+ │    └── ordering: +1,+2,+3
+ └── filters (true)
+
+# Preserving lookup ordering (no sort should be added). The 'a' and 'b' columns
 # are equivalent to input ordering columns and can be considered optional.
 opt
 SELECT * FROM xyz INNER LOOKUP JOIN abc ON x = a AND y = b ORDER BY a, x, b, y, z, c
@@ -2746,6 +2764,24 @@ inner-join (lookup abc)
  ├── key: (3,6-8)
  ├── fd: (1)==(6), (6)==(1), (2)==(7), (7)==(2)
  ├── ordering: +(1|6),+(2|7),+3,+8 [actual: +1,+2,+3,+8]
+ ├── scan xyz
+ │    ├── columns: x:1!null y:2!null z:3!null
+ │    ├── key: (1-3)
+ │    └── ordering: +1,+2,+3
+ └── filters (true)
+
+# Previous case with reversed orderings, which will require reverse scans.
+opt
+SELECT * FROM xyz INNER LOOKUP JOIN abc ON x = a AND y = b ORDER BY a, x, b, y, z, c DESC
+----
+inner-join (lookup abc)
+ ├── columns: x:1!null y:2!null z:3!null a:6!null b:7!null c:8!null
+ ├── flags: force lookup join (into right side)
+ ├── key columns: [1 2] = [6 7]
+ ├── reverse-scans
+ ├── key: (3,6-8)
+ ├── fd: (1)==(6), (6)==(1), (2)==(7), (7)==(2)
+ ├── ordering: +(1|6),+(2|7),+3,-8 [actual: +1,+2,+3,-8]
  ├── scan xyz
  │    ├── columns: x:1!null y:2!null z:3!null
  │    ├── key: (1-3)
@@ -2769,6 +2805,24 @@ inner-join (lookup abc)
  │    └── ordering: +1,+2,+3
  └── filters (true)
 
+# Previous case with reversed orderings, which will require reverse scans.
+opt
+SELECT * FROM xyz INNER LOOKUP JOIN abc ON x = a ORDER BY x, y, z, b DESC
+----
+inner-join (lookup abc)
+ ├── columns: x:1!null y:2!null z:3!null a:6!null b:7!null c:8!null
+ ├── flags: force lookup join (into right side)
+ ├── key columns: [1] = [6]
+ ├── reverse-scans
+ ├── key: (2,3,6-8)
+ ├── fd: (1)==(6), (6)==(1)
+ ├── ordering: +(1|6),+2,+3,-7 [actual: +1,+2,+3,-7]
+ ├── scan xyz
+ │    ├── columns: x:1!null y:2!null z:3!null
+ │    ├── key: (1-3)
+ │    └── ordering: +1,+2,+3
+ └── filters (true)
+
 # Preserving lookup ordering (no sort should be added).
 opt
 SELECT * FROM xyz INNER LOOKUP JOIN abc@abc_desc ON x = a ORDER BY x, y, z, a, b
@@ -2780,6 +2834,24 @@ inner-join (lookup abc@abc_desc)
  ├── key: (2,3,6-8)
  ├── fd: (1)==(6), (6)==(1)
  ├── ordering: +(1|6),+2,+3,+7 [actual: +1,+2,+3,+7]
+ ├── scan xyz
+ │    ├── columns: x:1!null y:2!null z:3!null
+ │    ├── key: (1-3)
+ │    └── ordering: +1,+2,+3
+ └── filters (true)
+
+# Previous case with reversed orderings, which will require reverse scans.
+opt
+SELECT * FROM xyz INNER LOOKUP JOIN abc@abc_desc ON x = a ORDER BY x, y, z, a DESC, b DESC
+----
+inner-join (lookup abc@abc_desc)
+ ├── columns: x:1!null y:2!null z:3!null a:6!null b:7!null c:8!null
+ ├── flags: force lookup join (into right side)
+ ├── key columns: [1] = [6]
+ ├── reverse-scans
+ ├── key: (2,3,6-8)
+ ├── fd: (1)==(6), (6)==(1)
+ ├── ordering: +(1|6),+2,+3,-7 [actual: +1,+2,+3,-7]
  ├── scan xyz
  │    ├── columns: x:1!null y:2!null z:3!null
  │    ├── key: (1-3)
@@ -2798,6 +2870,24 @@ inner-join (lookup abc@abc_desc)
  ├── key: (2,3,6-8)
  ├── fd: (1)==(6), (6)==(1)
  ├── ordering: +(1|6),+2,+3,+7,-8 [actual: +1,+2,+3,+7,-8]
+ ├── scan xyz
+ │    ├── columns: x:1!null y:2!null z:3!null
+ │    ├── key: (1-3)
+ │    └── ordering: +1,+2,+3
+ └── filters (true)
+
+# Previous case with reversed orderings, which will require reverse scans.
+opt
+SELECT * FROM xyz INNER LOOKUP JOIN abc@abc_desc ON x = a ORDER BY x, y, z, a DESC, b DESC, c
+----
+inner-join (lookup abc@abc_desc)
+ ├── columns: x:1!null y:2!null z:3!null a:6!null b:7!null c:8!null
+ ├── flags: force lookup join (into right side)
+ ├── key columns: [1] = [6]
+ ├── reverse-scans
+ ├── key: (2,3,6-8)
+ ├── fd: (1)==(6), (6)==(1)
+ ├── ordering: +(1|6),+2,+3,-7,+8 [actual: +1,+2,+3,-7,+8]
  ├── scan xyz
  │    ├── columns: x:1!null y:2!null z:3!null
  │    ├── key: (1-3)

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -743,6 +743,7 @@ func (ef *execFactory) ConstructLookupJoin(
 	locking opt.Locking,
 	limitHint int64,
 	remoteOnlyLookups bool,
+	reverseScans bool,
 ) (exec.Node, error) {
 	if table.IsVirtualTable() {
 		return constructVirtualTableLookupJoin(
@@ -785,6 +786,7 @@ func (ef *execFactory) ConstructLookupJoin(
 			reqOrdering:                ReqOrdering(reqOrdering),
 			limitHint:                  limitHint,
 			remoteOnlyLookups:          remoteOnlyLookups,
+			reverseScans:               reverseScans,
 		},
 	}
 	if onCond != tree.DBoolTrue {

--- a/pkg/sql/row/kv_batch_fetcher.go
+++ b/pkg/sql/row/kv_batch_fetcher.go
@@ -893,12 +893,12 @@ func (f *txnKVFetcher) nextBatch(ctx context.Context) (resp KVBatchFetcherRespon
 			}
 			if len(t.Rows) > 0 {
 				return KVBatchFetcherResponse{}, errors.AssertionFailedf(
-					"unexpectedly got a ScanResponse using KEY_VALUES response format",
+					"unexpectedly got a ReverseScanResponse using KEY_VALUES response format",
 				)
 			}
 			if len(t.IntentRows) > 0 {
 				return KVBatchFetcherResponse{}, errors.AssertionFailedf(
-					"unexpectedly got a ScanResponse with non-nil IntentRows",
+					"unexpectedly got a ReverseScanResponse with non-nil IntentRows",
 				)
 			}
 			// Note that ret.BatchResponse and ret.ColBatch might be nil when

--- a/pkg/sql/row/kv_fetcher.go
+++ b/pkg/sql/row/kv_fetcher.go
@@ -198,6 +198,7 @@ func NewStreamingKVFetcher(
 	maintainOrdering bool,
 	singleRowLookup bool,
 	maxKeysPerRow int,
+	reverse bool,
 	diskBuffer kvstreamer.ResultDiskBuffer,
 	kvFetcherMemAcc *mon.BoundAccount,
 	ext *fetchpb.IndexFetchSpec_ExternalRowData,
@@ -220,6 +221,7 @@ func NewStreamingKVFetcher(
 		&kvPairsRead,
 		GetKeyLockingStrength(lockStrength),
 		GetKeyLockingDurability(lockDurability),
+		reverse,
 	)
 	mode := kvstreamer.OutOfOrder
 	if maintainOrdering {
@@ -234,7 +236,10 @@ func NewStreamingKVFetcher(
 		maxKeysPerRow,
 		diskBuffer,
 	)
-	return newKVFetcher(newTxnKVStreamer(streamer, lockStrength, lockDurability, kvFetcherMemAcc, &kvPairsRead, &batchRequestsIssued, rawMVCCValues))
+	return newKVFetcher(newTxnKVStreamer(
+		streamer, lockStrength, lockDurability, kvFetcherMemAcc,
+		&kvPairsRead, &batchRequestsIssued, rawMVCCValues, reverse,
+	))
 }
 
 func newKVFetcher(batchFetcher KVBatchFetcher) *KVFetcher {

--- a/pkg/sql/rowexec/joinreader.go
+++ b/pkg/sql/rowexec/joinreader.go
@@ -551,7 +551,7 @@ func newJoinReader(
 				ctx, jr.FlowCtx.DiskMonitor, "streamer-disk", /* name */
 			)
 			diskBuffer = rowcontainer.NewKVStreamerResultDiskBuffer(
-				jr.FlowCtx.Cfg.TempStorage, diskBufferMemAcc, jr.streamerInfo.diskMonitor,
+				jr.FlowCtx.Cfg.TempStorage, diskBufferMemAcc, jr.streamerInfo.diskMonitor, spec.ReverseScans,
 			)
 		}
 		singleRowLookup := readerType == indexJoinReaderType || spec.LookupColumnsAreKey
@@ -570,6 +570,7 @@ func newJoinReader(
 			jr.streamerInfo.maintainOrdering,
 			singleRowLookup,
 			int(spec.FetchSpec.MaxKeysPerRow),
+			spec.ReverseScans,
 			diskBuffer,
 			&jr.streamerInfo.txnKVStreamerMemAcc,
 			spec.FetchSpec.External,
@@ -591,6 +592,7 @@ func newJoinReader(
 		row.FetcherInitArgs{
 			StreamingKVFetcher:         streamingKVFetcher,
 			Txn:                        jr.txn,
+			Reverse:                    spec.ReverseScans,
 			LockStrength:               spec.LockingStrength,
 			LockWaitPolicy:             spec.LockingWaitPolicy,
 			LockDurability:             spec.LockingDurability,

--- a/pkg/sql/sessiondatapb/local_only_session_data.proto
+++ b/pkg/sql/sessiondatapb/local_only_session_data.proto
@@ -613,6 +613,10 @@ message LocalOnlySessionData {
   // for the buffer scan of FK and uniqueness checks. A value of zero indicates
   // no lower bound.
   double optimizer_check_input_min_row_count = 157;
+  // OptimizerPlanLookupJoinsWithReverseScans enables planning for lookup joins
+  // that use reverse scans to get results in reverse index order on each
+  // lookup.
+  bool optimizer_plan_lookup_joins_with_reverse_scans = 158;
 
   ///////////////////////////////////////////////////////////////////////////
   // WARNING: consider whether a session parameter you're adding needs to  //

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -3823,6 +3823,23 @@ var varGen = map[string]sessionVar{
 			return nil
 		},
 	},
+
+	// CockroachDB extension.
+	`optimizer_plan_lookup_joins_with_reverse_scans`: {
+		GetStringVal: makePostgresBoolGetStringValFn(`optimizer_plan_lookup_joins_with_reverse_scans`),
+		Set: func(_ context.Context, m sessionDataMutator, s string) error {
+			b, err := paramparse.ParseBoolVar("optimizer_plan_lookup_joins_with_reverse_scans", s)
+			if err != nil {
+				return err
+			}
+			m.SetOptimizerPlanLookupJoinsWithReverseScans(b)
+			return nil
+		},
+		Get: func(evalCtx *extendedEvalContext, _ *kv.Txn) (string, error) {
+			return formatBoolAsPostgresSetting(evalCtx.SessionData().OptimizerPlanLookupJoinsWithReverseScans), nil
+		},
+		GlobalDefault: globalTrue,
+	},
 }
 
 func ReplicationModeFromString(s string) (sessiondatapb.ReplicationMode, error) {


### PR DESCRIPTION
#### sql,kvstreamer: enable reverse scans in lookup joins

This commit makes the execution changes necessary to allow lookup joins
to perform lookups as reverse scans rather than forward scans. This mostly
involves making the streamer capable of handling reverse scans, since the
`DistSender` already knows how to handle them. This commit also adds a
`ReverseScans` field to the lookup join spec and plumbs that information
to the fetcher implementations. A follow-up will determine when and how
to set the field.

Informs #128702

Release note: None

#### opt/ordering: add support for reverse scans for lookup joins

This commit adds support to the lookup-join ordering logic for using
reverse scans to provide an ordering opposite the index ordering.
The following commit will plumb support for this through the optimizer.

Informs #128702

Release note: None

#### sql,opt: add support for lookup joins that perform reverse scans

This commit adds support for planning lookup joins that perform reverse
scans for each lookup. This will allow the optimizer to avoid planning
sorts in more cases. This is particularly useful for generic query plans,
which plan lookup joins in place of scans.

Fixes #128702

Release note: None

#### opt: check cluster version and session setting for reverse-scan lookup joins

This commit adds a session setting to toggle planning for lookup joins
that perform reverse scans: `optimizer_plan_lookup_joins_with_reverse_scans`.
A lookup join with reverse scans will only be planned if this setting
is enabled (default on) and the cluster version is at least v25.2.

Informs #128702

Release note: None