### PR TITLE
crosscluster/producer: use job auth with provided stream id for some builtins

### DIFF
--- a/pkg/ccl/changefeedccl/alter_changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/alter_changefeed_stmt.go
@@ -113,7 +113,7 @@ func alterChangefeedPlanHook(
 		getLegacyPayload := func(ctx context.Context) (*jobspb.Payload, error) {
 			return &jobPayload, nil
 		}
-		err = jobsauth.Authorize(
+		err = jobsauth.AuthorizeAllowLegacyAuth(
 			ctx, p, jobID, getLegacyPayload, jobPayload.UsernameProto.Decode(), jobPayload.Type(), jobsauth.ControlAccess, globalPrivileges,
 		)
 		if err != nil {

--- a/pkg/crosscluster/producer/BUILD.bazel
+++ b/pkg/crosscluster/producer/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
         "//pkg/crosscluster/replicationutils",
         "//pkg/crosscluster/streamclient",
         "//pkg/jobs",
+        "//pkg/jobs/jobsauth",
         "//pkg/jobs/jobspb",
         "//pkg/jobs/jobsprotectedts",
         "//pkg/keys",

--- a/pkg/crosscluster/producer/replication_manager.go
+++ b/pkg/crosscluster/producer/replication_manager.go
@@ -14,6 +14,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/crosscluster/replicationutils"
 	"github.com/cockroachdb/cockroach/pkg/crosscluster/streamclient"
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobsauth"
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobsprotectedts"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
@@ -41,11 +43,12 @@ import (
 )
 
 type replicationStreamManagerImpl struct {
-	evalCtx   *eval.Context
-	resolver  resolver.SchemaResolver
-	txn       descs.Txn
-	sessionID clusterunique.ID
-	knobs     *sql.StreamingTestingKnobs
+	evalCtx    *eval.Context
+	resolver   resolver.SchemaResolver
+	txn        descs.Txn
+	sessionID  clusterunique.ID
+	knobs      *sql.StreamingTestingKnobs
+	authorized bool
 }
 
 // StartReplicationStream implements streaming.ReplicationStreamManager interface.
@@ -53,6 +56,9 @@ func (r *replicationStreamManagerImpl) StartReplicationStream(
 	ctx context.Context, tenantName roachpb.TenantName, req streampb.ReplicationProducerRequest,
 ) (streampb.ReplicationProducerSpec, error) {
 	if err := r.checkLicense(); err != nil {
+		return streampb.ReplicationProducerSpec{}, err
+	}
+	if err := r.Authorized("StartReplicationStream"); err != nil {
 		return streampb.ReplicationProducerSpec{}, err
 	}
 	return StartReplicationProducerJob(ctx, r.evalCtx, r.txn, tenantName, req, false)
@@ -63,6 +69,9 @@ func (r *replicationStreamManagerImpl) StartReplicationStreamForTables(
 	ctx context.Context, req streampb.ReplicationProducerRequest,
 ) (streampb.ReplicationProducerSpec, error) {
 	if err := r.checkLicense(); err != nil {
+		return streampb.ReplicationProducerSpec{}, err
+	}
+	if err := r.Authorized("StartReplicationStreamForTables"); err != nil {
 		return streampb.ReplicationProducerSpec{}, err
 	}
 
@@ -221,6 +230,11 @@ var useStreaksInLDR = settings.RegisterBoolSetting(
 func (r *replicationStreamManagerImpl) PlanLogicalReplication(
 	ctx context.Context, req streampb.LogicalReplicationPlanRequest,
 ) (*streampb.ReplicationStreamSpec, error) {
+
+	if err := r.Authorized("PlanLogicalReplication"); err != nil {
+		return nil, err
+	}
+
 	_, tenID, err := keys.DecodeTenantPrefix(r.evalCtx.Codec.TenantPrefix())
 	if err != nil {
 		return nil, err
@@ -270,6 +284,9 @@ func (r *replicationStreamManagerImpl) HeartbeatReplicationStream(
 	if err := r.checkLicense(); err != nil {
 		return streampb.StreamReplicationStatus{}, err
 	}
+	if err := r.Authorized("HeartbeatReplicationStream"); err != nil {
+		return streampb.StreamReplicationStatus{}, err
+	}
 	return heartbeatReplicationStream(ctx, r.evalCtx, r.txn, streamID, frontier)
 }
 
@@ -278,6 +295,9 @@ func (r *replicationStreamManagerImpl) StreamPartition(
 	ctx context.Context, streamID streampb.StreamID, opaqueSpec []byte,
 ) (eval.ValueGenerator, error) {
 	if err := r.checkLicense(); err != nil {
+		return nil, err
+	}
+	if err := r.Authorized("StreamPartition"); err != nil {
 		return nil, err
 	}
 
@@ -309,6 +329,9 @@ func (r *replicationStreamManagerImpl) GetPhysicalReplicationStreamSpec(
 	if err := r.checkLicense(); err != nil {
 		return nil, err
 	}
+	if err := r.Authorized("GetPhysicalReplicationStreamSpec"); err != nil {
+		return nil, err
+	}
 	return r.getPhysicalReplicationStreamSpec(ctx, r.evalCtx, r.txn, streamID)
 }
 
@@ -317,6 +340,9 @@ func (r *replicationStreamManagerImpl) CompleteReplicationStream(
 	ctx context.Context, streamID streampb.StreamID, successfulIngestion bool,
 ) error {
 	if err := r.checkLicense(); err != nil {
+		return err
+	}
+	if err := r.Authorized("CompleteReplicationStream"); err != nil {
 		return err
 	}
 	return completeReplicationStream(ctx, r.evalCtx, r.txn, streamID, successfulIngestion)
@@ -328,12 +354,15 @@ func (r *replicationStreamManagerImpl) SetupSpanConfigsStream(
 	if err := r.checkLicense(); err != nil {
 		return nil, err
 	}
+	if err := r.Authorized("SetupSpanConfigStream"); err != nil {
+		return nil, err
+	}
 	return r.setupSpanConfigsStream(ctx, r.evalCtx, r.txn, tenantName)
 }
 
 func (r *replicationStreamManagerImpl) DebugGetProducerStatuses(
 	ctx context.Context,
-) []streampb.DebugProducerStatus {
+) ([]streampb.DebugProducerStatus, error) {
 	// NB: we don't check license here since if a stream started but the license
 	// expired or was removed, we still want visibility into it during debugging.
 
@@ -343,7 +372,10 @@ func (r *replicationStreamManagerImpl) DebugGetProducerStatuses(
 	// is not the end of the world since only the system tenant can run these so
 	// as long as it is the only one that can see into the singleton we're ok.
 	if !r.evalCtx.Codec.ForSystemTenant() {
-		return nil
+		return nil, nil
+	}
+	if err := r.Authorized("DebugGetProducerStatuses"); err != nil {
+		return nil, err
 	}
 
 	res := streampb.GetActiveProducerStatuses()
@@ -351,21 +383,24 @@ func (r *replicationStreamManagerImpl) DebugGetProducerStatuses(
 		return res[i].Spec.ConsumerNode < res[j].Spec.ConsumerNode ||
 			(res[i].Spec.ConsumerNode == res[j].Spec.ConsumerNode && res[i].Spec.ConsumerProc < res[j].Spec.ConsumerProc)
 	})
-	return res
+	return res, nil
 }
 
 // DebugGetLogicalConsumerStatuses gets all logical consumer debug statuses in
 // active in this process.
 func (r *replicationStreamManagerImpl) DebugGetLogicalConsumerStatuses(
 	ctx context.Context,
-) []*streampb.DebugLogicalConsumerStatus {
+) ([]*streampb.DebugLogicalConsumerStatus, error) {
 	// NB: we don't check license here since if a stream started but the license
 	// expired or was removed, we still want visibility into it during debugging.
 
 	// TODO(dt): since this is per-process, not per-server, we can only let the
 	// the sys tenant inspect it; remove this when we move this into job registry.
 	if !r.evalCtx.Codec.ForSystemTenant() {
-		return nil
+		return nil, nil
+	}
+	if err := r.Authorized("DebugGetLogicalConsumerStatuses"); err != nil {
+		return nil, err
 	}
 
 	res := streampb.GetActiveLogicalConsumerStatuses()
@@ -374,22 +409,55 @@ func (r *replicationStreamManagerImpl) DebugGetLogicalConsumerStatuses(
 		return res[i].ProcessorID < res[j].ProcessorID
 	})
 
-	return res
+	return res, nil
 }
 
-func newReplicationStreamManagerWithPrivilegesCheck(
+func (r *replicationStreamManagerImpl) AuthorizeViaJob(
+	ctx context.Context, streamID streampb.StreamID,
+) error {
+	planHook, ok := r.evalCtx.Planner.(sql.PlanHookState)
+	if !ok {
+		return errors.AssertionFailedf("expected planner to implement PlanHookState")
+	}
+
+	globalPrivileges, err := jobsauth.GetGlobalJobPrivileges(ctx, planHook)
+	if err != nil {
+		return err
+	}
+
+	if err := jobsauth.Authorize(
+		ctx, planHook, jobspb.JobID(streamID), planHook.User(), jobspb.TypeReplicationStreamProducer, jobsauth.ControlAccess, globalPrivileges,
+	); err != nil {
+		return err
+	}
+	r.authorized = true
+	return nil
+}
+
+func (r *replicationStreamManagerImpl) AuthorizeViaReplicationPriv(ctx context.Context) error {
+	if err := r.evalCtx.SessionAccessor.CheckPrivilege(ctx,
+		syntheticprivilege.GlobalPrivilegeObject,
+		privilege.REPLICATION); err != nil {
+		return err
+	}
+	r.authorized = true
+	return nil
+}
+
+func (r *replicationStreamManagerImpl) Authorized(operation string) error {
+	if !r.authorized {
+		return errors.Newf("replication manager not authorized run %s", operation)
+	}
+	return nil
+}
+
+func newReplicationStreamManager(
 	ctx context.Context,
 	evalCtx *eval.Context,
 	sc resolver.SchemaResolver,
 	txn descs.Txn,
 	sessionID clusterunique.ID,
 ) (eval.ReplicationStreamManager, error) {
-	if err := evalCtx.SessionAccessor.CheckPrivilege(ctx,
-		syntheticprivilege.GlobalPrivilegeObject,
-		privilege.REPLICATION); err != nil {
-		return nil, err
-	}
-
 	execCfg := evalCtx.Planner.ExecutorConfig().(*sql.ExecutorConfig)
 	knobs := execCfg.StreamingTestingKnobs
 
@@ -405,5 +473,5 @@ func (r *replicationStreamManagerImpl) checkLicense() error {
 }
 
 func init() {
-	repstream.GetReplicationStreamManagerHook = newReplicationStreamManagerWithPrivilegesCheck
+	repstream.GetReplicationStreamManagerHook = newReplicationStreamManager
 }

--- a/pkg/crosscluster/producer/replication_manager_test.go
+++ b/pkg/crosscluster/producer/replication_manager_test.go
@@ -61,7 +61,12 @@ func TestReplicationManagerRequiresReplicationPrivilege(t *testing.T) {
 		})
 		defer cleanup()
 		ec := pi.EvalContext()
-		return newReplicationStreamManagerWithPrivilegesCheck(ctx, ec, p.(resolver.SchemaResolver), pi.InternalSQLTxn(), clusterunique.ID{})
+		mgr, err := newReplicationStreamManager(ctx, ec, p.(resolver.SchemaResolver), pi.InternalSQLTxn(), clusterunique.ID{})
+		require.NoError(t, err)
+		if err := mgr.AuthorizeViaReplicationPriv(context.Background()); err != nil {
+			return nil, err
+		}
+		return mgr, nil
 	}
 
 	tDB.Exec(t, "CREATE ROLE somebody")

--- a/pkg/jobs/jobsauth/BUILD.bazel
+++ b/pkg/jobs/jobsauth/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
         "//pkg/sql/pgwire/pgerror",
         "//pkg/sql/privilege",
         "//pkg/sql/roleoption",
+        "@com_github_cockroachdb_errors//:errors",
     ],
 )
 

--- a/pkg/jobs/jobsauth/authorization_test.go
+++ b/pkg/jobs/jobsauth/authorization_test.go
@@ -354,7 +354,7 @@ func TestAuthorization(t *testing.T) {
 			ctx := context.Background()
 			globalPrivileges, err := jobsauth.GetGlobalJobPrivileges(ctx, testAuth)
 			assert.NoError(t, err)
-			err = jobsauth.Authorize(
+			err = jobsauth.AuthorizeAllowLegacyAuth(
 				ctx, testAuth, 0,
 				func(ctx context.Context) (*jobspb.Payload, error) { return tc.payload, nil },
 				tc.payload.UsernameProto.Decode(), tc.payload.Type(), tc.accessLevel, globalPrivileges,

--- a/pkg/sql/control_jobs.go
+++ b/pkg/sql/control_jobs.go
@@ -71,7 +71,7 @@ func (n *controlJobsNode) startExec(params runParams) error {
 				getLegacyPayload := func(ctx context.Context) (*jobspb.Payload, error) {
 					return md.Payload, nil
 				}
-				if err := jobsauth.Authorize(params.ctx, params.p,
+				if err := jobsauth.AuthorizeAllowLegacyAuth(params.ctx, params.p,
 					md.ID, getLegacyPayload, md.Payload.UsernameProto.Decode(), md.Payload.Type(), jobsauth.ControlAccess, globalPrivileges); err != nil {
 					return err
 				}

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -9537,6 +9537,9 @@ CREATE TABLE crdb_internal.cluster_replication_node_streams (
 			}
 			return err
 		}
+		if err := sm.AuthorizeViaReplicationPriv(ctx); err != nil {
+			return err
+		}
 		now := p.EvalContext().GetStmtTimestamp()
 
 		// Transform `.0000000000` to `.0` to shorted/de-noise HLCs.
@@ -9562,7 +9565,12 @@ CREATE TABLE crdb_internal.cluster_replication_node_streams (
 			return dur(now.Sub(t).Nanoseconds())
 		}
 
-		for _, s := range sm.DebugGetProducerStatuses(ctx) {
+		statuses, err := sm.DebugGetProducerStatuses(ctx)
+		if err != nil {
+			return err
+		}
+
+		for _, s := range statuses {
 			resolved := time.UnixMicro(s.RF.ResolvedMicros)
 			resolvedDatum := tree.DNull
 			if resolved.Unix() != 0 {
@@ -9637,7 +9645,14 @@ CREATE TABLE crdb_internal.cluster_replication_node_stream_spans (
 			}
 			return err
 		}
-		for _, status := range sm.DebugGetProducerStatuses(ctx) {
+		if err := sm.AuthorizeViaReplicationPriv(ctx); err != nil {
+			return err
+		}
+		statuses, err := sm.DebugGetProducerStatuses(ctx)
+		if err != nil {
+			return err
+		}
+		for _, status := range statuses {
 			for _, s := range status.Spec.Spans {
 				if err := addRow(
 					tree.NewDInt(tree.DInt(status.StreamID)),
@@ -9673,7 +9688,14 @@ CREATE TABLE crdb_internal.cluster_replication_node_stream_checkpoints (
 			}
 			return err
 		}
-		for _, status := range sm.DebugGetProducerStatuses(ctx) {
+		if err := sm.AuthorizeViaReplicationPriv(ctx); err != nil {
+			return err
+		}
+		statuses, err := sm.DebugGetProducerStatuses(ctx)
+		if err != nil {
+			return err
+		}
+		for _, status := range statuses {
 			for _, s := range status.LastCheckpoint.Spans {
 				if err := addRow(
 					tree.NewDInt(tree.DInt(status.StreamID)),
@@ -9728,6 +9750,9 @@ CREATE TABLE crdb_internal.logical_replication_node_processors (
 			}
 			return err
 		}
+		if err := sm.AuthorizeViaReplicationPriv(ctx); err != nil {
+			return err
+		}
 		now := p.EvalContext().GetStmtTimestamp()
 		dur := func(nanos int64) tree.Datum {
 			return tree.NewDInterval(duration.MakeDuration(nanos, 0, 0), types.DefaultIntervalTypeMetadata)
@@ -9744,8 +9769,11 @@ CREATE TABLE crdb_internal.logical_replication_node_processors (
 			}
 			return tree.NewDInterval(duration.Age(now, t), types.DefaultIntervalTypeMetadata)
 		}
-
-		for _, container := range sm.DebugGetLogicalConsumerStatuses(ctx) {
+		statuses, err := sm.DebugGetLogicalConsumerStatuses(ctx)
+		if err != nil {
+			return err
+		}
+		for _, container := range statuses {
 			status := container.GetStats()
 			curOrLast := func(currentNanos int64, lastNanos int64, currentState streampb.LogicalConsumerState) tree.Datum {
 				if status.CurrentState == currentState {

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -1116,7 +1116,7 @@ func populateSystemJobsTableRows(
 		getLegacyPayload := func(ctx context.Context) (*jobspb.Payload, error) {
 			return payload, nil
 		}
-		err = jobsauth.Authorize(
+		err = jobsauth.AuthorizeAllowLegacyAuth(
 			ctx, p, jobspb.JobID(jobID), getLegacyPayload, payload.UsernameProto.Decode(), payload.Type(), jobsauth.ViewAccess, globalPrivileges,
 		)
 		if err != nil {
@@ -1529,7 +1529,7 @@ LEFT OUTER JOIN system.public.job_status AS s ON j.id = s.job_id
 				errorMsg = emptyString
 			}
 
-			if err := jobsauth.Authorize(
+			if err := jobsauth.AuthorizeAllowLegacyAuth(
 				ctx, p, jobID, getLegacyPayloadForAuth, owner, typ, jobsauth.ViewAccess, globalPrivileges,
 			); err != nil {
 				// Filter out jobs which the user is not allowed to see.

--- a/pkg/sql/sem/eval/context.go
+++ b/pkg/sql/sem/eval/context.go
@@ -915,8 +915,8 @@ type ReplicationStreamManager interface {
 		successfulIngestion bool,
 	) error
 
-	DebugGetProducerStatuses(ctx context.Context) []streampb.DebugProducerStatus
-	DebugGetLogicalConsumerStatuses(ctx context.Context) []*streampb.DebugLogicalConsumerStatus
+	DebugGetProducerStatuses(ctx context.Context) ([]streampb.DebugProducerStatus, error)
+	DebugGetLogicalConsumerStatuses(ctx context.Context) ([]*streampb.DebugLogicalConsumerStatus, error)
 
 	PlanLogicalReplication(
 		ctx context.Context,
@@ -927,6 +927,9 @@ type ReplicationStreamManager interface {
 		ctx context.Context,
 		req streampb.ReplicationProducerRequest,
 	) (streampb.ReplicationProducerSpec, error)
+
+	AuthorizeViaJob(ctx context.Context, streamID streampb.StreamID) error
+	AuthorizeViaReplicationPriv(ctx context.Context) error
 }
 
 // StreamIngestManager represents a collection of APIs that streaming replication supports


### PR DESCRIPTION
Previously, all replication builtins required authorization via the REPLICATION
privilege. With this patch, all builtins with a stream id arg can authorize if
the user connecting to the source cluser has control privs on the producer job.

In other words, once a user has created the producer job associated with the
LDR or PCR stream, authorized via their REPLICATION priv, they can run
subsequent replication commands, authorized via job auth.

This patch paves the way for subsequent privilege refactors, like table level
LDR authentication, without the need to refactor the replication builtins args.

Epic: none

Release note: none