### PR TITLE
release-23.2: settings: increase number of cores test can use

### DIFF
--- a/pkg/settings/integration_tests/BUILD.bazel
+++ b/pkg/settings/integration_tests/BUILD.bazel
@@ -8,6 +8,7 @@ go_test(
         "settings_test.go",
     ],
     args = ["-test.timeout=295s"],
+    exec_properties = {"test.Pool": "large"},
     shard_count = 6,
     deps = [
         "//pkg/base",


### PR DESCRIPTION
Backport 1/1 commits from #138717.

/cc @cockroachdb/release

---

Clutser setting updates on one node occasionally take over 45 seconds to propagate to other nodes. This test has failed a few times recently. The issue is not reproducible, even under stress testing with 10000 repetitions. Increasing the number of cores the test can use to determine if it resolves the problem.

Epic: None
Fixes: https://github.com/cockroachdb/cockroach/issues/136474
Release note: None

----

Release justification: fix test flake