### PR TITLE
 cli: fix array lookup and remove gob register in dd upload

### DIFF
--- a/pkg/cli/tsdump.go
+++ b/pkg/cli/tsdump.go
@@ -204,7 +204,6 @@ will then convert it to the --format requested in the current invocation.
 			}
 
 			dec := gob.NewDecoder(f)
-			gob.Register(&roachpb.KeyValue{})
 			decodeOne := func() (*tspb.TimeSeriesData, error) {
 				var v roachpb.KeyValue
 				err := dec.Decode(&v)

--- a/pkg/cli/tsdump_upload.go
+++ b/pkg/cli/tsdump_upload.go
@@ -246,11 +246,17 @@ func (d *datadogWriter) emitDataDogMetrics(data []DatadogSeries) ([]string, erro
 	func() {
 		printLock.Lock()
 		defer printLock.Unlock()
-		fmt.Printf(
-			"\033[G\033[Ktsdump datadog upload: uploading metrics containing %d series including %s",
-			len(data),
-			data[0].Metric,
-		)
+		if len(data) > 0 {
+			fmt.Printf(
+				"\033[G\033[Ktsdump datadog upload: uploading metrics containing %d series including %s",
+				len(data),
+				data[0].Metric,
+			)
+		} else {
+			fmt.Printf(
+				"\033[G\033[Ktsdump datadog upload: uploading metrics containing 0 series",
+			)
+		}
 	}()
 
 	return emittedMetrics, d.flush(data)
@@ -333,7 +339,6 @@ func (d *datadogWriter) upload(fileName string) error {
 	}
 
 	dec := gob.NewDecoder(f)
-	gob.Register(&roachpb.KeyValue{})
 	decodeOne := func() ([]DatadogSeries, error) {
 		var ddSeries []DatadogSeries
 


### PR DESCRIPTION
This fixes a small bug in the logging for Datadog uploads, and removes
the unnecessary gob registration code since we encode/decode with the
same structure.

Release note: None