### PR TITLE
microbench-ci: improve signal to noise ratio

### DIFF
--- a/.github/workflows/microbenchmarks-ci.yaml
+++ b/.github/workflows/microbenchmarks-ci.yaml
@@ -45,7 +45,7 @@ jobs:
           pkg: ${{ env.PACKAGE }}
   run-group-1:
     runs-on: [self-hosted, basic_microbench_runner_group]
-    timeout-minutes: 30
+    timeout-minutes: 60
     needs: [base, head]
     steps:
       - name: Checkout
@@ -58,7 +58,7 @@ jobs:
           group: 1
   run-group-2:
     runs-on: [self-hosted, basic_microbench_runner_group]
-    timeout-minutes: 30
+    timeout-minutes: 60
     needs: [base, head]
     steps:
       - name: Checkout

--- a/pkg/cmd/microbench-ci/benchmark.go
+++ b/pkg/cmd/microbench-ci/benchmark.go
@@ -26,8 +26,7 @@ type (
 		RunnerGroup int      `yaml:"runner_group"`
 		Count       int      `yaml:"count"`
 		Iterations  int      `yaml:"iterations"`
-
-		Thresholds map[string]float64 `yaml:"thresholds"`
+		Metrics     []string `yaml:"metrics"`
 	}
 	Benchmarks  []Benchmark
 	ProfileType string

--- a/pkg/cmd/microbench-ci/benchmark.go
+++ b/pkg/cmd/microbench-ci/benchmark.go
@@ -19,14 +19,15 @@ import (
 
 type (
 	Benchmark struct {
-		DisplayName string   `yaml:"display_name"`
-		Package     string   `yaml:"package"`
-		Labels      []string `yaml:"labels"`
-		Name        string   `yaml:"name"`
-		RunnerGroup int      `yaml:"runner_group"`
-		Count       int      `yaml:"count"`
-		Iterations  int      `yaml:"iterations"`
-		Metrics     []string `yaml:"metrics"`
+		DisplayName  string   `yaml:"display_name"`
+		Package      string   `yaml:"package"`
+		Labels       []string `yaml:"labels"`
+		Name         string   `yaml:"name"`
+		RunnerGroup  int      `yaml:"runner_group"`
+		Count        int      `yaml:"count"`
+		Iterations   int      `yaml:"iterations"`
+		CompareAlpha float64  `yaml:"compare_alpha"`
+		Metrics      []string `yaml:"metrics"`
 	}
 	Benchmarks  []Benchmark
 	ProfileType string

--- a/pkg/cmd/microbench-ci/benchmark.go
+++ b/pkg/cmd/microbench-ci/benchmark.go
@@ -27,6 +27,7 @@ type (
 		Count        int      `yaml:"count"`
 		Iterations   int      `yaml:"iterations"`
 		CompareAlpha float64  `yaml:"compare_alpha"`
+		Retries      int      `yaml:"retries"`
 		Metrics      []string `yaml:"metrics"`
 	}
 	Benchmarks  []Benchmark

--- a/pkg/cmd/microbench-ci/compare.go
+++ b/pkg/cmd/microbench-ci/compare.go
@@ -6,6 +6,7 @@
 package main
 
 import (
+	"bufio"
 	"bytes"
 	"fmt"
 	"os"
@@ -35,6 +36,20 @@ const (
 	Regressed
 )
 
+// String returns the string representation of the status.
+func (s Status) String() string {
+	switch s {
+	case NoChange:
+		return "No Change"
+	case Improved:
+		return "Improved"
+	case Regressed:
+		return "Regressed"
+	default:
+		panic(fmt.Sprintf("unknown status: %d", s))
+	}
+}
+
 // status returns the status of a metric in the comparison.
 func (c *CompareResult) status(metricName string) Status {
 	entry := c.MetricMap[metricName]
@@ -54,25 +69,28 @@ func (c *CompareResult) status(metricName string) Status {
 	return status
 }
 
-// regressed returns true if any metric in the comparison has regressed.
-func (c *CompareResult) regressed() bool {
+// top returns the top status of all metrics in the comparison.
+func (c *CompareResult) top() Status {
+	topStatus := NoChange
 	for metric := range c.MetricMap {
 		status := c.status(metric)
-		if status == Regressed {
-			return true
+		if status > topStatus {
+			topStatus = status
 		}
 	}
-	return false
+	return topStatus
 }
 
-// compare compares the metrics of a benchmark between two revisions.
-func (b *Benchmark) compare() (*CompareResult, error) {
+// compare compares the metrics of a benchmark between two revisions. Only the
+// specified last number of lines of the benchmark logs are considered. If lines
+// is 0, it considers the entire logs.
+func (b *Benchmark) compare(lines int) (*CompareResult, error) {
 	builder := model.NewBuilder(model.WithThresholds(&benchmath.Thresholds{
 		CompareAlpha: b.CompareAlpha,
 	}))
 	compareResult := CompareResult{Benchmark: b}
 	for _, revision := range []Revision{Old, New} {
-		data, err := os.ReadFile(path.Join(suite.artifactsDir(revision), b.cleanLog()))
+		data, err := logTail(path.Join(suite.artifactsDir(revision), b.cleanLog()), lines)
 		if err != nil {
 			return nil, err
 		}
@@ -107,11 +125,42 @@ func (b *Benchmark) compare() (*CompareResult, error) {
 func (b Benchmarks) compareBenchmarks() (CompareResults, error) {
 	compareResults := make(CompareResults, 0, len(b))
 	for _, benchmark := range b {
-		compareResult, err := benchmark.compare()
+		compareResult, err := benchmark.compare(0)
 		if err != nil {
 			return nil, err
 		}
 		compareResults = append(compareResults, compareResult)
 	}
 	return compareResults, nil
+}
+
+// logTail returns the last N lines of a file.
+// If N is 0, it returns the entire file.
+func logTail(filePath string, N int) ([]byte, error) {
+	if N == 0 {
+		return os.ReadFile(filePath)
+	}
+	file, err := os.Open(filePath)
+	if err != nil {
+		return nil, err
+	}
+	defer file.Close()
+
+	lines := make([]string, 0, N)
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		lines = append(lines, scanner.Text())
+		if len(lines) > N {
+			lines = lines[1:]
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+
+	var buffer bytes.Buffer
+	for _, line := range lines {
+		buffer.WriteString(line + "\n")
+	}
+	return buffer.Bytes(), nil
 }

--- a/pkg/cmd/microbench-ci/compare.go
+++ b/pkg/cmd/microbench-ci/compare.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cockroachdb/errors"
 	"golang.org/x/exp/maps"
 	"golang.org/x/perf/benchfmt"
+	"golang.org/x/perf/benchmath"
 )
 
 type (
@@ -66,7 +67,9 @@ func (c *CompareResult) regressed() bool {
 
 // compare compares the metrics of a benchmark between two revisions.
 func (b *Benchmark) compare() (*CompareResult, error) {
-	builder := model.NewBuilder()
+	builder := model.NewBuilder(model.WithThresholds(&benchmath.Thresholds{
+		CompareAlpha: b.CompareAlpha,
+	}))
 	compareResult := CompareResult{Benchmark: b}
 	for _, revision := range []Revision{Old, New} {
 		data, err := os.ReadFile(path.Join(suite.artifactsDir(revision), b.cleanLog()))

--- a/pkg/cmd/microbench-ci/compare.go
+++ b/pkg/cmd/microbench-ci/compare.go
@@ -8,7 +8,6 @@ package main
 import (
 	"bytes"
 	"fmt"
-	"math"
 	"os"
 	"path"
 
@@ -31,9 +30,8 @@ type (
 
 const (
 	NoChange Status = iota
-	Better
-	Worse
-	Regression
+	Improved
+	Regressed
 )
 
 // status returns the status of a metric in the comparison.
@@ -47,14 +45,10 @@ func (c *CompareResult) status(metricName string) Status {
 		return NoChange
 	}
 	status := NoChange
-	threshold := c.Benchmark.Thresholds[metricName] * 100.0
 	if cc.Delta*float64(entry.Better) > 0 {
-		status = Better
+		status = Improved
 	} else if cc.Delta*float64(entry.Better) < 0 {
-		status = Worse
-		if math.Abs(cc.Delta) >= threshold {
-			status = Regression
-		}
+		status = Regressed
 	}
 	return status
 }
@@ -63,7 +57,7 @@ func (c *CompareResult) status(metricName string) Status {
 func (c *CompareResult) regressed() bool {
 	for metric := range c.MetricMap {
 		status := c.status(metric)
-		if status == Regression {
+		if status == Regressed {
 			return true
 		}
 	}

--- a/pkg/cmd/microbench-ci/config/pull-request-suite.yml
+++ b/pkg/cmd/microbench-ci/config/pull-request-suite.yml
@@ -6,6 +6,7 @@ benchmarks:
     runner_group: 1
     count: 10
     iterations: 3000
+    compare_alpha: 0.025
     metrics:
       - "sec/op"
       - "allocs/op"
@@ -17,6 +18,7 @@ benchmarks:
     runner_group: 2
     count: 10
     iterations: 12000
+    compare_alpha: 0.025
     metrics:
       - "sec/op"
       - "allocs/op"
@@ -28,6 +30,7 @@ benchmarks:
     runner_group: 2
     count: 10
     iterations: 12000
+    compare_alpha: 0.025
     metrics:
       - "sec/op"
       - "allocs/op"

--- a/pkg/cmd/microbench-ci/config/pull-request-suite.yml
+++ b/pkg/cmd/microbench-ci/config/pull-request-suite.yml
@@ -4,9 +4,10 @@ benchmarks:
     name: "BenchmarkSysbench/SQL/3node/oltp_read_write"
     package: "pkg/sql/tests"
     runner_group: 1
-    count: 10
-    iterations: 3000
+    count: 15
+    iterations: 1500
     compare_alpha: 0.025
+    retries: 3
     metrics:
       - "sec/op"
       - "allocs/op"
@@ -16,9 +17,10 @@ benchmarks:
     name: "BenchmarkSysbench/KV/1node_local/oltp_read_only"
     package: "pkg/sql/tests"
     runner_group: 2
-    count: 10
-    iterations: 12000
+    count: 20
+    iterations: 6000
     compare_alpha: 0.025
+    retries: 3
     metrics:
       - "sec/op"
       - "allocs/op"
@@ -28,9 +30,10 @@ benchmarks:
     name: "BenchmarkSysbench/KV/1node_local/oltp_write_only"
     package: "pkg/sql/tests"
     runner_group: 2
-    count: 10
-    iterations: 12000
+    count: 20
+    iterations: 6000
     compare_alpha: 0.025
+    retries: 3
     metrics:
       - "sec/op"
       - "allocs/op"

--- a/pkg/cmd/microbench-ci/config/pull-request-suite.yml
+++ b/pkg/cmd/microbench-ci/config/pull-request-suite.yml
@@ -6,10 +6,9 @@ benchmarks:
     runner_group: 1
     count: 10
     iterations: 3000
-    thresholds:
-      "sec/op": .03
-      "B/op": .02
-      "allocs/op": .02
+    metrics:
+      - "sec/op"
+      - "allocs/op"
 
   - display_name: Sysbench
     labels: ["KV", "1node", "local", "oltp_read_only"]
@@ -18,10 +17,9 @@ benchmarks:
     runner_group: 2
     count: 10
     iterations: 12000
-    thresholds:
-      "sec/op": .02
-      "B/op": .015
-      "allocs/op": .015
+    metrics:
+      - "sec/op"
+      - "allocs/op"
 
   - display_name: Sysbench
     labels: ["KV", "1node", "local", "oltp_write_only"]
@@ -30,7 +28,6 @@ benchmarks:
     runner_group: 2
     count: 10
     iterations: 12000
-    thresholds:
-      "sec/op": .025
-      "B/op": .0175
-      "allocs/op": .0175
+    metrics:
+      - "sec/op"
+      - "allocs/op"

--- a/pkg/cmd/microbench-ci/report.go
+++ b/pkg/cmd/microbench-ci/report.go
@@ -64,7 +64,6 @@ func (c *CompareResult) generateSummaryData(
 			log.Printf("WARN: no comparison found for benchmark metric %q:%q", c.EntryName, metricName)
 			continue
 		}
-		threshold := c.Benchmark.Thresholds[metricName] * 100.0
 		status := statusTemplateFunc(c.status(metricName))
 		oldSum := benchmark.Summaries[string(Old)]
 		newSum := benchmark.Summaries[string(New)]
@@ -74,7 +73,6 @@ func (c *CompareResult) generateSummaryData(
 			NewCenter: fmt.Sprintf("%s ±%s", formatValue(newSum.Center, metricName), newSum.PctRangeString()),
 			Delta:     cc.FormattedDelta,
 			Note:      cc.Distribution.String(),
-			Threshold: fmt.Sprintf("%.1f%%", threshold),
 			Status:    status,
 		})
 	}
@@ -192,7 +190,7 @@ func (c CompareResults) writeGitHubSummary(path string) error {
 			if status > finalStatus {
 				finalStatus = status
 			}
-			if status == Regression {
+			if status == Regressed {
 				regressionDetected = true
 			}
 			return statusToDot(status)
@@ -227,7 +225,7 @@ func (c CompareResults) writeGitHubSummary(path string) error {
 }
 
 func statusToDot(status Status) string {
-	return string([]rune("⚪🟢🟡🔴")[status])
+	return string([]rune("⚪🟢🔴")[status])
 }
 
 // formatValue formats a value according to the unit of the metric.

--- a/pkg/cmd/microbench-ci/template/github_summary.md
+++ b/pkg/cmd/microbench-ci/template/github_summary.md
@@ -1,10 +1,10 @@
 {{- range .GitHubSummaryData}}
 <details><summary><strong>{{.BenchmarkStatus}} {{.DisplayName}}</strong> [{{.Labels}}]</summary>
 
-| Metric                      | Old Commit     | New Commit     | Delta      | Note         | Threshold      |
-|-----------------------------|----------------|----------------|------------|--------------|----------------|
+| Metric                      | Old Commit     | New Commit     | Delta      | Note         |
+|-----------------------------|----------------|----------------|------------|--------------|
 {{- range .Summaries}}
-| {{.Status}} **{{.Metric}}** | {{.OldCenter}} | {{.NewCenter}} | {{.Delta}} | {{.Note}}    | {{.Threshold}} |
+| {{.Status}} **{{.Metric}}** | {{.OldCenter}} | {{.NewCenter}} | {{.Delta}} | {{.Note}}    |
 {{- end}}
 
 <details><summary>Reproduce</summary>
@@ -43,9 +43,8 @@ gcloud storage cp {{$url}}\* {{$rev}}/
 <details><summary>Legend</summary>
 
 - ⚪ **Neutral:** No significant performance change.
-- 🟡 **Warning:** Slight degradation, likely due to variance, but still within thresholds.
 - 🔴 **Regression:** Likely performance regression, requiring investigation.
-- 🟢 **Improvement:** Possible performance gain.
+- 🟢 **Improvement:** Likely performance gain.
 
 </details>
 

--- a/pkg/cmd/microbench-ci/testdata/regression.txt
+++ b/pkg/cmd/microbench-ci/testdata/regression.txt
@@ -27,16 +27,26 @@ BenchmarkSysbench/SQL/3node/oltp_read_write-16 2500 9879350 ns/op 2364281 B/op 1
 BenchmarkSysbench/SQL/3node/oltp_read_write-16 2500 9808429 ns/op 2352326 B/op 10246 allocs/op 0 errs/op
 BenchmarkSysbench/SQL/3node/oltp_read_write-16 2500 9849367 ns/op 2369187 B/op 10379 allocs/op 0 errs/op
 BenchmarkSysbench/SQL/3node/oltp_read_write-16 2500 9872510 ns/op 2367752 B/op 10392 allocs/op 0 errs/op
-BenchmarkSysbench/SQL/3node/oltp_read_write-16 2500 9852000 ns/op 2368213 B/op 10378 allocs/op 0 errs/op
-BenchmarkSysbench/SQL/3node/oltp_read_write-16 2500 9852000 ns/op 2375306 B/op 10377 allocs/op 0 errs/op
-BenchmarkSysbench/SQL/3node/oltp_read_write-16 2500 9852000 ns/op 2358650 B/op 10287 allocs/op 0 errs/op
-BenchmarkSysbench/SQL/3node/oltp_read_write-16 2500 9852000 ns/op 2370670 B/op 10411 allocs/op 0 errs/op
-BenchmarkSysbench/SQL/3node/oltp_read_write-16 2500 9852000 ns/op 2367582 B/op 10386 allocs/op 0 errs/op
-BenchmarkSysbench/SQL/3node/oltp_read_write-16 2500 9852000 ns/op 2365463 B/op 10398 allocs/op 0 errs/op
-BenchmarkSysbench/SQL/3node/oltp_read_write-16 2500 9852000 ns/op 2364281 B/op 10361 allocs/op 0 errs/op
-BenchmarkSysbench/SQL/3node/oltp_read_write-16 2500 9852000 ns/op 2352326 B/op 10246 allocs/op 0 errs/op
-BenchmarkSysbench/SQL/3node/oltp_read_write-16 2500 9852000 ns/op 2369187 B/op 10379 allocs/op 0 errs/op
-BenchmarkSysbench/SQL/3node/oltp_read_write-16 2500 9852000 ns/op 2367752 B/op 10392 allocs/op 0 errs/op
+BenchmarkSysbench/SQL/3node/oltp_read_write-16 2500 9852036 ns/op 2368213 B/op 10378 allocs/op 0 errs/op
+BenchmarkSysbench/SQL/3node/oltp_read_write-16 2500 9852036 ns/op 2375306 B/op 10377 allocs/op 0 errs/op
+BenchmarkSysbench/SQL/3node/oltp_read_write-16 2500 9852036 ns/op 2358650 B/op 10287 allocs/op 0 errs/op
+BenchmarkSysbench/SQL/3node/oltp_read_write-16 2500 9982428 ns/op 2370670 B/op 10411 allocs/op 0 errs/op
+BenchmarkSysbench/SQL/3node/oltp_read_write-16 2500 9926623 ns/op 2367582 B/op 10386 allocs/op 0 errs/op
+BenchmarkSysbench/SQL/3node/oltp_read_write-16 2500 9898707 ns/op 2365463 B/op 10398 allocs/op 0 errs/op
+BenchmarkSysbench/SQL/3node/oltp_read_write-16 2500 9879350 ns/op 2364281 B/op 10361 allocs/op 0 errs/op
+BenchmarkSysbench/SQL/3node/oltp_read_write-16 2500 9808429 ns/op 2352326 B/op 10246 allocs/op 0 errs/op
+BenchmarkSysbench/SQL/3node/oltp_read_write-16 2500 9849367 ns/op 2369187 B/op 10379 allocs/op 0 errs/op
+BenchmarkSysbench/SQL/3node/oltp_read_write-16 2500 9872510 ns/op 2367752 B/op 10392 allocs/op 0 errs/op
+BenchmarkSysbench/SQL/3node/oltp_read_write-16 2500 9852036 ns/op 2368213 B/op 10378 allocs/op 0 errs/op
+BenchmarkSysbench/SQL/3node/oltp_read_write-16 2500 9852036 ns/op 2375306 B/op 10377 allocs/op 0 errs/op
+BenchmarkSysbench/SQL/3node/oltp_read_write-16 2500 9852036 ns/op 2358650 B/op 10287 allocs/op 0 errs/op
+BenchmarkSysbench/SQL/3node/oltp_read_write-16 2500 9982428 ns/op 2370670 B/op 10411 allocs/op 0 errs/op
+BenchmarkSysbench/SQL/3node/oltp_read_write-16 2500 9926623 ns/op 2367582 B/op 10386 allocs/op 0 errs/op
+BenchmarkSysbench/SQL/3node/oltp_read_write-16 2500 9898707 ns/op 2365463 B/op 10398 allocs/op 0 errs/op
+BenchmarkSysbench/SQL/3node/oltp_read_write-16 2500 9879350 ns/op 2364281 B/op 10361 allocs/op 0 errs/op
+BenchmarkSysbench/SQL/3node/oltp_read_write-16 2500 9808429 ns/op 2352326 B/op 10246 allocs/op 0 errs/op
+BenchmarkSysbench/SQL/3node/oltp_read_write-16 2500 9849367 ns/op 2369187 B/op 10379 allocs/op 0 errs/op
+BenchmarkSysbench/SQL/3node/oltp_read_write-16 2500 9872510 ns/op 2367752 B/op 10392 allocs/op 0 errs/op
 
 ----
 
@@ -51,16 +61,26 @@ BenchmarkSysbench/SQL/3node/oltp_read_write-16 2500 9979350 ns/op 2364281 B/op 1
 BenchmarkSysbench/SQL/3node/oltp_read_write-16 2500 9908429 ns/op 2352326 B/op 10246 allocs/op
 BenchmarkSysbench/SQL/3node/oltp_read_write-16 2500 9949367 ns/op 2369187 B/op 10379 allocs/op
 BenchmarkSysbench/SQL/3node/oltp_read_write-16 2500 9972510 ns/op 2367752 B/op 10392 allocs/op
-BenchmarkSysbench/SQL/3node/oltp_read_write-16 2500 9852000 ns/op 2368213 B/op 10378 allocs/op
-BenchmarkSysbench/SQL/3node/oltp_read_write-16 2500 9852000 ns/op 2375306 B/op 10377 allocs/op
-BenchmarkSysbench/SQL/3node/oltp_read_write-16 2500 9852000 ns/op 2358650 B/op 10287 allocs/op
-BenchmarkSysbench/SQL/3node/oltp_read_write-16 2500 9852000 ns/op 2370670 B/op 10411 allocs/op
-BenchmarkSysbench/SQL/3node/oltp_read_write-16 2500 9852000 ns/op 2367582 B/op 10386 allocs/op
-BenchmarkSysbench/SQL/3node/oltp_read_write-16 2500 9852000 ns/op 2365463 B/op 10398 allocs/op
-BenchmarkSysbench/SQL/3node/oltp_read_write-16 2500 9852000 ns/op 2364281 B/op 10361 allocs/op
-BenchmarkSysbench/SQL/3node/oltp_read_write-16 2500 9852000 ns/op 2352326 B/op 10246 allocs/op
-BenchmarkSysbench/SQL/3node/oltp_read_write-16 2500 9852000 ns/op 2369187 B/op 10379 allocs/op
-BenchmarkSysbench/SQL/3node/oltp_read_write-16 2500 9852000 ns/op 2367752 B/op 10392 allocs/op
+BenchmarkSysbench/SQL/3node/oltp_read_write-16 2500 9952036 ns/op 2368213 B/op 10378 allocs/op
+BenchmarkSysbench/SQL/3node/oltp_read_write-16 2500 9952036 ns/op 2375306 B/op 10377 allocs/op
+BenchmarkSysbench/SQL/3node/oltp_read_write-16 2500 9952036 ns/op 2358650 B/op 10287 allocs/op
+BenchmarkSysbench/SQL/3node/oltp_read_write-16 2500 9982428 ns/op 2370670 B/op 10411 allocs/op
+BenchmarkSysbench/SQL/3node/oltp_read_write-16 2500 9926623 ns/op 2367582 B/op 10386 allocs/op
+BenchmarkSysbench/SQL/3node/oltp_read_write-16 2500 9998707 ns/op 2365463 B/op 10398 allocs/op
+BenchmarkSysbench/SQL/3node/oltp_read_write-16 2500 9979350 ns/op 2364281 B/op 10361 allocs/op
+BenchmarkSysbench/SQL/3node/oltp_read_write-16 2500 9908429 ns/op 2352326 B/op 10246 allocs/op
+BenchmarkSysbench/SQL/3node/oltp_read_write-16 2500 9949367 ns/op 2369187 B/op 10379 allocs/op
+BenchmarkSysbench/SQL/3node/oltp_read_write-16 2500 9972510 ns/op 2367752 B/op 10392 allocs/op
+BenchmarkSysbench/SQL/3node/oltp_read_write-16 2500 9952036 ns/op 2368213 B/op 10378 allocs/op
+BenchmarkSysbench/SQL/3node/oltp_read_write-16 2500 9952036 ns/op 2375306 B/op 10377 allocs/op
+BenchmarkSysbench/SQL/3node/oltp_read_write-16 2500 9952036 ns/op 2358650 B/op 10287 allocs/op
+BenchmarkSysbench/SQL/3node/oltp_read_write-16 2500 9982428 ns/op 2370670 B/op 10411 allocs/op
+BenchmarkSysbench/SQL/3node/oltp_read_write-16 2500 9926623 ns/op 2367582 B/op 10386 allocs/op
+BenchmarkSysbench/SQL/3node/oltp_read_write-16 2500 9998707 ns/op 2365463 B/op 10398 allocs/op
+BenchmarkSysbench/SQL/3node/oltp_read_write-16 2500 9979350 ns/op 2364281 B/op 10361 allocs/op
+BenchmarkSysbench/SQL/3node/oltp_read_write-16 2500 9908429 ns/op 2352326 B/op 10246 allocs/op
+BenchmarkSysbench/SQL/3node/oltp_read_write-16 2500 9949367 ns/op 2369187 B/op 10379 allocs/op
+BenchmarkSysbench/SQL/3node/oltp_read_write-16 2500 9972510 ns/op 2367752 B/op 10392 allocs/op
 
 ----
 
@@ -68,12 +88,12 @@ run group=1
 ----
 ----
 
-<details><summary><strong>⚪ Sysbench</strong> [SQL, 3node, oltp_read_write]</summary>
+<details><summary><strong>🔴 Sysbench</strong> [SQL, 3node, oltp_read_write]</summary>
 
 | Metric                      | Old Commit     | New Commit     | Delta      | Note         |
 |-----------------------------|----------------|----------------|------------|--------------|
-| ⚪ **sec/op** | 9.852m ±0% | 9.880m ±1% | ~ | p=0.084 n=20    |
-| ⚪ **allocs/op** | 10.38k ±0% | 10.38k ±0% | ~ | p=1.000 n=20    |
+| 🔴 **sec/op** | 9.862m ±0% | 9.952m ±0% | +0.91% | p=0.000 n=30    |
+| ⚪ **allocs/op** | 10.38k ±0% | 10.38k ±0% | ~ | p=1.000 n=30    |
 
 <details><summary>Reproduce</summary>
 
@@ -115,7 +135,7 @@ gcloud storage cp gs://cockroach-microbench-ci/artifacts/abcdef123//\* old/
 
 </details>
 
-No regressions detected!
+A regression has been detected, please investigate further!
 
 _built with commit: [qwerty456](https://github.com/cockroachdb/cockroach/commit/qwerty456)_
 ----
@@ -161,31 +181,41 @@ json
             "Metric": "B/op",
             "Summary": {
               "Center": 2367667,
-              "Lo": 2364281,
-              "Hi": 2369187,
-              "Confidence": 0.95861,
+              "Lo": 2365463,
+              "Hi": 2368213,
+              "Confidence": 0.95723,
               "Warnings": null
             },
             "Sample": {
               "Values": [
                 2352326,
                 2352326,
+                2352326,
+                2358650,
                 2358650,
                 2358650,
                 2364281,
                 2364281,
+                2364281,
+                2365463,
                 2365463,
                 2365463,
                 2367582,
                 2367582,
+                2367582,
+                2367752,
                 2367752,
                 2367752,
                 2368213,
                 2368213,
+                2368213,
+                2369187,
                 2369187,
                 2369187,
                 2370670,
                 2370670,
+                2370670,
+                2375306,
                 2375306,
                 2375306
               ],
@@ -199,31 +229,41 @@ json
             "Metric": "allocs/op",
             "Summary": {
               "Center": 10378.50000,
-              "Lo": 10361,
-              "Hi": 10392,
-              "Confidence": 0.95861,
+              "Lo": 10377,
+              "Hi": 10386,
+              "Confidence": 0.95723,
               "Warnings": null
             },
             "Sample": {
               "Values": [
                 10246,
                 10246,
+                10246,
+                10287,
                 10287,
                 10287,
                 10361,
                 10361,
+                10361,
+                10377,
                 10377,
                 10377,
                 10378,
                 10378,
+                10378,
+                10379,
                 10379,
                 10379,
                 10386,
                 10386,
+                10386,
+                10392,
                 10392,
                 10392,
                 10398,
                 10398,
+                10398,
+                10411,
                 10411,
                 10411
               ],
@@ -236,33 +276,43 @@ json
           {
             "Metric": "sec/op",
             "Summary": {
-              "Center": 0.00988,
-              "Lo": 0.00985,
-              "Hi": 0.00995,
-              "Confidence": 0.95861,
+              "Center": 0.00995,
+              "Lo": 0.00995,
+              "Hi": 0.00997,
+              "Confidence": 0.95723,
               "Warnings": null
             },
             "Sample": {
               "Values": [
-                0.00985,
-                0.00985,
-                0.00985,
-                0.00985,
-                0.00985,
-                0.00985,
-                0.00985,
-                0.00985,
-                0.00985,
-                0.00985,
                 0.00991,
+                0.00991,
+                0.00991,
+                0.00993,
+                0.00993,
                 0.00993,
                 0.00995,
                 0.00995,
                 0.00995,
                 0.00995,
+                0.00995,
+                0.00995,
+                0.00995,
+                0.00995,
+                0.00995,
+                0.00995,
+                0.00995,
+                0.00995,
+                0.00997,
+                0.00997,
                 0.00997,
                 0.00998,
                 0.00998,
+                0.00998,
+                0.00998,
+                0.00998,
+                0.00998,
+                0.01000,
+                0.01000,
                 0.01000
               ],
               "Thresholds": {
@@ -277,31 +327,41 @@ json
             "Metric": "B/op",
             "Summary": {
               "Center": 2367667,
-              "Lo": 2364281,
-              "Hi": 2369187,
-              "Confidence": 0.95861,
+              "Lo": 2365463,
+              "Hi": 2368213,
+              "Confidence": 0.95723,
               "Warnings": null
             },
             "Sample": {
               "Values": [
                 2352326,
                 2352326,
+                2352326,
+                2358650,
                 2358650,
                 2358650,
                 2364281,
                 2364281,
+                2364281,
+                2365463,
                 2365463,
                 2365463,
                 2367582,
                 2367582,
+                2367582,
+                2367752,
                 2367752,
                 2367752,
                 2368213,
                 2368213,
+                2368213,
+                2369187,
                 2369187,
                 2369187,
                 2370670,
                 2370670,
+                2370670,
+                2375306,
                 2375306,
                 2375306
               ],
@@ -315,31 +375,41 @@ json
             "Metric": "allocs/op",
             "Summary": {
               "Center": 10378.50000,
-              "Lo": 10361,
-              "Hi": 10392,
-              "Confidence": 0.95861,
+              "Lo": 10377,
+              "Hi": 10386,
+              "Confidence": 0.95723,
               "Warnings": null
             },
             "Sample": {
               "Values": [
                 10246,
                 10246,
+                10246,
+                10287,
                 10287,
                 10287,
                 10361,
                 10361,
+                10361,
+                10377,
                 10377,
                 10377,
                 10378,
                 10378,
+                10378,
+                10379,
                 10379,
                 10379,
                 10386,
                 10386,
+                10386,
+                10392,
                 10392,
                 10392,
                 10398,
                 10398,
+                10398,
+                10411,
                 10411,
                 10411
               ],
@@ -355,11 +425,21 @@ json
               "Center": 0,
               "Lo": 0,
               "Hi": 0,
-              "Confidence": 0.95861,
+              "Confidence": 0.95723,
               "Warnings": null
             },
             "Sample": {
               "Values": [
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
                 0,
                 0,
                 0,
@@ -390,14 +470,16 @@ json
           {
             "Metric": "sec/op",
             "Summary": {
-              "Center": 0.00985,
+              "Center": 0.00986,
               "Lo": 0.00985,
-              "Hi": 0.00985,
-              "Confidence": 0.95861,
+              "Hi": 0.00988,
+              "Confidence": 0.95723,
               "Warnings": null
             },
             "Sample": {
               "Values": [
+                0.00981,
+                0.00981,
                 0.00981,
                 0.00985,
                 0.00985,
@@ -411,12 +493,20 @@ json
                 0.00985,
                 0.00985,
                 0.00985,
-                0.00985,
-                0.00985,
+                0.00987,
+                0.00987,
                 0.00987,
                 0.00988,
+                0.00988,
+                0.00988,
+                0.00990,
+                0.00990,
                 0.00990,
                 0.00993,
+                0.00993,
+                0.00993,
+                0.00998,
+                0.00998,
                 0.00998
               ],
               "Thresholds": {

--- a/pkg/cmd/microbench-ci/testdata/summary.txt
+++ b/pkg/cmd/microbench-ci/testdata/summary.txt
@@ -8,6 +8,7 @@ benchmarks:
     runner_group: 1
     count: 10
     iterations: 3000
+    compare_alpha: 0.05
     metrics:
       - "sec/op"
       - "allocs/op"

--- a/pkg/cmd/microbench-ci/testdata/summary.txt
+++ b/pkg/cmd/microbench-ci/testdata/summary.txt
@@ -8,10 +8,9 @@ benchmarks:
     runner_group: 1
     count: 10
     iterations: 3000
-    thresholds:
-      "sec/op": .03
-      "B/op": .02
-      "allocs/op": .02
+    metrics:
+      - "sec/op"
+      - "allocs/op"
 
 ----
 
@@ -47,13 +46,13 @@ run group=1
 ----
 ----
 
-<details><summary><strong>🟡 Sysbench</strong> [SQL, 3node, oltp_read_write]</summary>
+<details><summary><strong>🔴 Sysbench</strong> [SQL, 3node, oltp_read_write]</summary>
 
-| Metric                      | Old Commit     | New Commit     | Delta      | Note         | Threshold      |
-|-----------------------------|----------------|----------------|------------|--------------|----------------|
-| 🟡 **sec/op** | 9.862m ±1% | 9.952m ±0% | +0.91% | p=0.001 n=10    | 3.0% |
-| ⚪ **allocs/op** | 10.38k ±1% | 10.38k ±1% | ~ | p=1.000 n=10    | 2.0% |
-| ⚪ **B/op** | 2.258Mi ±0% | 2.258Mi ±0% | ~ | p=1.000 n=10    | 2.0% |
+| Metric                      | Old Commit     | New Commit     | Delta      | Note         |
+|-----------------------------|----------------|----------------|------------|--------------|
+| 🔴 **sec/op** | 9.862m ±1% | 9.952m ±0% | +0.91% | p=0.001 n=10    |
+| ⚪ **allocs/op** | 10.38k ±1% | 10.38k ±1% | ~ | p=1.000 n=10    |
+| ⚪ **B/op** | 2.258Mi ±0% | 2.258Mi ±0% | ~ | p=1.000 n=10    |
 
 <details><summary>Reproduce</summary>
 
@@ -90,13 +89,12 @@ gcloud storage cp gs://cockroach-microbench-ci/artifacts/abcdef123//\* old/
 <details><summary>Legend</summary>
 
 - ⚪ **Neutral:** No significant performance change.
-- 🟡 **Warning:** Slight degradation, likely due to variance, but still within thresholds.
 - 🔴 **Regression:** Likely performance regression, requiring investigation.
-- 🟢 **Improvement:** Possible performance gain.
+- 🟢 **Improvement:** Likely performance gain.
 
 </details>
 
-No regressions detected!
+A regression has been detected, please investigate further!
 
 _built with commit: [qwerty456](https://github.com/cockroachdb/cockroach/commit/qwerty456)_
 ----
@@ -108,6 +106,7 @@ tree
 
 /abcdef123
 /abcdef123/artifacts
+/abcdef123/artifacts/.FAILED
 /abcdef123/artifacts/cleaned_Sysbench_SQL_3node_oltp_read_write.log
 /abcdef123/artifacts/cpu_Sysbench_SQL_3node_oltp_read_write_merged.prof
 /abcdef123/artifacts/memory_Sysbench_SQL_3node_oltp_read_write_merged.prof
@@ -116,6 +115,7 @@ tree
 /github-summary.md
 /qwerty456
 /qwerty456/artifacts
+/qwerty456/artifacts/.FAILED
 /qwerty456/artifacts/cleaned_Sysbench_SQL_3node_oltp_read_write.log
 /qwerty456/artifacts/cpu_Sysbench_SQL_3node_oltp_read_write_merged.prof
 /qwerty456/artifacts/memory_Sysbench_SQL_3node_oltp_read_write_merged.prof

--- a/pkg/cmd/roachprod-microbench/model/BUILD.bazel
+++ b/pkg/cmd/roachprod-microbench/model/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "builder.go",
         "metric.go",
+        "options.go",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/cmd/roachprod-microbench/model",
     visibility = ["//visibility:public"],

--- a/pkg/cmd/roachprod-microbench/model/builder.go
+++ b/pkg/cmd/roachprod-microbench/model/builder.go
@@ -25,15 +25,17 @@ var metricUnitNames = map[string]string{
 type Builder struct {
 	metricMap  MetricMap
 	thresholds *benchmath.Thresholds
-	confidence float64
 }
 
 // NewBuilder creates a new builder.
-func NewBuilder() *Builder {
+func NewBuilder(opts ...BuilderOption) *Builder {
+	builderOptions := newBuilderOptions()
+	for _, opt := range opts {
+		opt(builderOptions)
+	}
 	return &Builder{
 		metricMap:  make(MetricMap),
-		thresholds: &benchmath.DefaultThresholds,
-		confidence: 0.95,
+		thresholds: builderOptions.thresholds,
 	}
 }
 
@@ -72,7 +74,7 @@ func (b *Builder) ComputeMetricMap() MetricMap {
 			for run, values := range benchmarkEntry.Values {
 				samples := benchmath.NewSample(values, b.thresholds)
 				benchmarkEntry.Samples[run] = samples
-				summary := assumption.Summary(samples, b.confidence)
+				summary := assumption.Summary(samples, 1.0-b.thresholds.CompareAlpha)
 				benchmarkEntry.Summaries[run] = &summary
 			}
 

--- a/pkg/cmd/roachprod-microbench/model/options.go
+++ b/pkg/cmd/roachprod-microbench/model/options.go
@@ -1,0 +1,28 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+//
+
+package model
+
+import "golang.org/x/perf/benchmath"
+
+type BuilderOptions struct {
+	// Thresholds stores the statistical thresholds used during comparison of
+	// samples.
+	thresholds *benchmath.Thresholds
+}
+
+type BuilderOption func(*BuilderOptions)
+
+func newBuilderOptions() *BuilderOptions {
+	return &BuilderOptions{
+		thresholds: &benchmath.DefaultThresholds,
+	}
+}
+func WithThresholds(t *benchmath.Thresholds) BuilderOption {
+	return func(o *BuilderOptions) {
+		o.thresholds = t
+	}
+}


### PR DESCRIPTION
This PR introduces several enhancements to the microbenchmarking process in CI. It modifies the microbenchmarks to require three consecutive runs to detect a regression, significantly reducing the chance of false positives. As a result, the total CI running time will dynamically adjust, ensuring that if a regression is detected CI will at most take approximately ±45 minutes to complete.

Additionally, it adds configurable compare alpha thresholds to reduce noise during benchmark comparisons. This allows for better tuning and more accurate results. The metrics builder has also been updated to accept options for configuring these thresholds, improving flexibility.

Lastly, the previous use of delta thresholds to filter out insignificant regressions has been removed. This change aims to lower the probability of false positives through alternative mechanisms.

Epic: None
Release note: None