### PR TITLE
roachtest: add blob fixture gc

### DIFF
--- a/pkg/cmd/roachtest/tests/registry.go
+++ b/pkg/cmd/roachtest/tests/registry.go
@@ -27,6 +27,7 @@ func RegisterTests(r registry.Registry) {
 	registerBackupRestoreRoundTrip(r)
 	registerBackupFixtures(r)
 	registerBackupS3Clones(r)
+	registerBlobFixtureGC(r)
 	registerCDC(r)
 	registerCDCBench(r)
 	registerCDCFiltering(r)


### PR DESCRIPTION
This adds a blob-fixture/gc roachtest that will delete old fixture
instances.

Release note: None
Part of: #139159