### PR TITLE
kvclient: serve ReverseScan read-your-own-writes with buffered writes  

### DIFF
--- a/pkg/kv/kvclient/kvcoord/txn_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_test.go
@@ -9,6 +9,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"sort"
 	"testing"
 	"time"
 
@@ -1708,124 +1709,156 @@ func TestTxnBufferedWritesOverlappingScan(t *testing.T) {
 	s := createTestDB(t)
 	defer s.Stop()
 
-	makeKV := func(key []byte, val []byte) roachpb.KeyValue {
-		return roachpb.KeyValue{Key: key, Value: roachpb.Value{RawBytes: val}}
-	}
-
-	ctx := context.Background()
-	valueA := []byte("valueA")
-	valueC := []byte("valueC")
-	valueF := []byte("valueF")
-	valueG := []byte("valueG")
-	valueTxn := []byte("valueTxn")
-
-	keyA := []byte("keyA")
-	keyB := []byte("keyB")
-	keyC := []byte("keyC")
-	keyD := []byte("keyD")
-	keyE := []byte("keyE")
-	keyF := []byte("keyF")
-	keyG := []byte("keyG")
-	keyH := []byte("keyH")
-	keyJ := []byte("keyJ")
-
-	// Before the test begins, write a value to keyA, keyC, keyF, and keyG.
-	txn := kv.NewTxn(ctx, s.DB, 0 /* gatewayNodeID */)
-	require.NoError(t, txn.Put(ctx, keyA, valueA))
-	require.NoError(t, txn.Put(ctx, keyC, valueC))
-	require.NoError(t, txn.Put(ctx, keyF, valueF))
-	require.NoError(t, txn.Put(ctx, keyG, valueG))
-	require.NoError(t, txn.Commit(ctx))
-
-	err := s.DB.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
-		txn.SetBufferedWritesEnabled(true)
-
-		// Write some values to keyB, keyC, and keyD.
-		if err := txn.Put(ctx, keyB, valueTxn); err != nil {
-			return err
-		}
-		if err := txn.Put(ctx, keyC, valueTxn); err != nil {
-			return err
-		}
-		if err := txn.Put(ctx, keyD, valueTxn); err != nil {
-			return err
-		}
-		// Delete some values. Do so at KeyE, where nothing was present, keyG
-		// where a value was present, and keyD where we just wrote in this
-		// transaction.
-		if _, err := txn.Del(ctx, keyE, keyG, keyD); err != nil {
-			return err
+	testutils.RunTrueAndFalse(t, "reverse", func(t *testing.T, reverse bool) {
+		makeKV := func(key []byte, val []byte) roachpb.KeyValue {
+			return roachpb.KeyValue{Key: key, Value: roachpb.Value{RawBytes: val}}
 		}
 
-		// Perform some scans.
-		for _, tc := range []struct {
-			key    roachpb.Key
-			endKey roachpb.Key
-			expRes []roachpb.KeyValue
-		}{
-			{
-				// Scan over the entire keyspace.
-				key:    keyA,
-				endKey: keyJ,
-				expRes: []roachpb.KeyValue{
-					makeKV(keyA, valueA), makeKV(keyB, valueTxn), makeKV(keyC, valueTxn), makeKV(keyF, valueF),
-				},
-			},
-			{
-				// The end key should be exclusive.
-				key:    keyA,
-				endKey: keyF,
-				expRes: []roachpb.KeyValue{
-					makeKV(keyA, valueA), makeKV(keyB, valueTxn), makeKV(keyC, valueTxn),
-				},
-			},
-			{
-				// Entirely within the buffer.
-				key:    keyB,
-				endKey: keyF,
-				expRes: []roachpb.KeyValue{
-					makeKV(keyB, valueTxn), makeKV(keyC, valueTxn),
-				},
-			},
-			{
-				// End key is present in the buffer, but isn't returned because the scan
-				// is exclusive.
-				key:    keyA,
-				endKey: keyB,
-				expRes: []roachpb.KeyValue{
-					makeKV(keyA, valueA),
-				},
-			},
-			{
-				key:    keyA,
-				endKey: keyD,
-				expRes: []roachpb.KeyValue{
-					makeKV(keyA, valueA), makeKV(keyB, valueTxn), makeKV(keyC, valueTxn),
-				},
-			},
-			{
-				key:    keyC,
-				endKey: keyF,
-				expRes: []roachpb.KeyValue{makeKV(keyC, valueTxn)},
-			},
-			{
-				// Doesn't overlap with the buffer at all.
-				key:    keyH,
-				endKey: keyJ,
-				expRes: []roachpb.KeyValue{},
-			},
-		} {
-			res, err := txn.Scan(ctx, tc.key, tc.endKey, 0 /* maxRows */)
-			require.NoError(t, err)
-			require.Len(t, res, len(tc.expRes))
-			for i, exp := range tc.expRes {
-				require.Equal(t, exp.Key, res[i].Key)
-				val, err := res[i].Value.GetBytes()
-				require.NoError(t, err)
-				require.Equal(t, exp.Value.RawBytes, val)
+		ctx := context.Background()
+		valueA := []byte("valueA")
+		valueC := []byte("valueC")
+		valueF := []byte("valueF")
+		valueG := []byte("valueG")
+		valueTxn := []byte("valueTxn")
+
+		keyA := []byte("keyA")
+		keyB := []byte("keyB")
+		keyC := []byte("keyC")
+		keyD := []byte("keyD")
+		keyE := []byte("keyE")
+		keyF := []byte("keyF")
+		keyG := []byte("keyG")
+		keyH := []byte("keyH")
+		keyJ := []byte("keyJ")
+		keyK := []byte("keyK")
+
+		// Before the test begins, write a value to keyA, keyC, keyF, and keyG.
+		txn := kv.NewTxn(ctx, s.DB, 0 /* gatewayNodeID */)
+		require.NoError(t, txn.Put(ctx, keyA, valueA))
+		require.NoError(t, txn.Put(ctx, keyC, valueC))
+		require.NoError(t, txn.Put(ctx, keyF, valueF))
+		require.NoError(t, txn.Put(ctx, keyG, valueG))
+		require.NoError(t, txn.Commit(ctx))
+
+		err := s.DB.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+			txn.SetBufferedWritesEnabled(true)
+
+			// Write some values to keyB, keyC, and keyD.
+			if err := txn.Put(ctx, keyB, valueTxn); err != nil {
+				return err
 			}
-		}
-		return nil
+			if err := txn.Put(ctx, keyC, valueTxn); err != nil {
+				return err
+			}
+			if err := txn.Put(ctx, keyD, valueTxn); err != nil {
+				return err
+			}
+			// Last key (lexicographically) that we write to the buffer. Ensure
+			// this is higher than any deleted key, and therefore must be
+			// included in the scan results (if the scan overlaps with this
+			// key). Useful to test the scan end key exclusivity logic.
+			if err := txn.Put(ctx, keyH, valueTxn); err != nil {
+				return err
+			}
+			// Delete some values. Do so at KeyE, where nothing was present, keyG
+			// where a value was present, and keyD where we just wrote in this
+			// transaction.
+			if _, err := txn.Del(ctx, keyE, keyG, keyD); err != nil {
+				return err
+			}
+
+			// Perform some scans.
+			for i, tc := range []struct {
+				key    roachpb.Key
+				endKey roachpb.Key
+				expRes []roachpb.KeyValue
+			}{
+				{
+					// Scan over the entire keyspace.
+					key:    keyA,
+					endKey: keyK,
+					expRes: []roachpb.KeyValue{
+						makeKV(keyA, valueA), makeKV(keyB, valueTxn),
+						makeKV(keyC, valueTxn), makeKV(keyF, valueF), makeKV(keyH, valueTxn),
+					},
+				},
+				{
+					// The end key should be exclusive.
+					key:    keyA,
+					endKey: keyF,
+					expRes: []roachpb.KeyValue{
+						makeKV(keyA, valueA), makeKV(keyB, valueTxn), makeKV(keyC, valueTxn),
+					},
+				},
+				{
+					// Entirely within the buffer.
+					key:    keyB,
+					endKey: keyF,
+					expRes: []roachpb.KeyValue{
+						makeKV(keyB, valueTxn), makeKV(keyC, valueTxn),
+					},
+				},
+				{
+					// End key is present in the buffer, but isn't returned because the scan
+					// is exclusive.
+					key:    keyA,
+					endKey: keyB,
+					expRes: []roachpb.KeyValue{
+						makeKV(keyA, valueA),
+					},
+				},
+				{
+					key:    keyA,
+					endKey: keyD,
+					expRes: []roachpb.KeyValue{
+						makeKV(keyA, valueA), makeKV(keyB, valueTxn), makeKV(keyC, valueTxn),
+					},
+				},
+				{
+					key:    keyC,
+					endKey: keyF,
+					expRes: []roachpb.KeyValue{makeKV(keyC, valueTxn)},
+				},
+				{
+					// Doesn't overlap with the buffer at all.
+					key:    keyJ,
+					endKey: keyK,
+					expRes: []roachpb.KeyValue{},
+				},
+				{
+					// Includes the last write in the buffer.
+					key:    keyA,
+					endKey: keyH,
+					expRes: []roachpb.KeyValue{
+						makeKV(keyA, valueA), makeKV(keyB, valueTxn), makeKV(keyC, valueTxn), makeKV(keyF, valueF),
+					},
+				},
+			} {
+				var res []kv.KeyValue
+				var err error
+				if reverse {
+					res, err = txn.ReverseScan(ctx, tc.key, tc.endKey, 0 /* maxRows */)
+					require.NoError(t, err)
+				} else {
+					res, err = txn.Scan(ctx, tc.key, tc.endKey, 0 /* maxRows */)
+					require.NoError(t, err)
+				}
+				if reverse {
+					// Reverse the expected result.
+					sort.Slice(tc.expRes, func(i, j int) bool {
+						return bytes.Compare(tc.expRes[i].Key, tc.expRes[j].Key) > 0
+					})
+				}
+				require.Len(t, res, len(tc.expRes), "failed %d", i)
+				for i, exp := range tc.expRes {
+					require.Equal(t, exp.Key, res[i].Key, "failed %d", i)
+					val, err := res[i].Value.GetBytes()
+					require.NoError(t, err)
+					require.Equal(t, exp.Value.RawBytes, val)
+				}
+			}
+			return nil
+		})
+		require.NoError(t, err)
 	})
-	require.NoError(t, err)
 }


### PR DESCRIPTION
First commit from: https://github.com/cockroachdb/cockroach/pull/142111

We taught Get and Scan requests to consult the write buffer to correctly
serve read-your-own-writes previously. This PR rounds up the trio by
including ReverseScans to that list. These are very similar to Scan
requests; the only difference is that the buffer needs to be iterated
upon in the reverse direction.

Closes https://github.com/cockroachdb/cockroach/issues/139054

Release note: None