### PR TITLE
split: add AccessDirection functions to split finders

### DIFF
--- a/pkg/kv/kvserver/split/decider.go
+++ b/pkg/kv/kvserver/split/decider.go
@@ -49,6 +49,10 @@ type LoadBasedSplitter interface {
 
 	// String formats the state of the load based splitter.
 	String() string
+
+	// AccessDirection returns a value in [-1, 1] indicating
+	// how requests are shifting over time (left/descending vs right/ascending).
+	AccessDirection() float64
 }
 
 type LoadSplitConfig interface {

--- a/pkg/kv/kvserver/split/unweighted_finder.go
+++ b/pkg/kv/kvserver/split/unweighted_finder.go
@@ -223,6 +223,23 @@ func (f *UnweightedFinder) PopularKeyFrequency() float64 {
 	return float64(popularKeyCount) / float64(splitKeySampleSize)
 }
 
+// AccessDirection returns a value in [-1, 1] indicating the direction of access
+// requests over time. A negative value implies more traffic is moving to the left
+// (lower keys), a positive value implies more traffic is moving to the right
+// (higher keys), and zero indicates even distribution.
+func (f *UnweightedFinder) AccessDirection() float64 {
+	var left, right int
+	for _, s := range f.samples {
+		left += s.left
+		right += s.right
+	}
+	if left+right == 0 {
+		return 0
+	}
+	// Return ratio in [-1, 1].
+	return float64(right-left) / float64(right+left)
+}
+
 // SafeFormat implements the redact.SafeFormatter interface.
 func (f *UnweightedFinder) SafeFormat(w redact.SafePrinter, r rune) {
 	w.Printf("key=%v start=%v count=%d samples=%v",

--- a/pkg/kv/kvserver/split/unweighted_finder_test.go
+++ b/pkg/kv/kvserver/split/unweighted_finder_test.go
@@ -401,3 +401,81 @@ func TestFinderPopularKeyFrequency(t *testing.T) {
 		assert.Equal(t, test.expectedPopularKeyFrequency, popularKeyFrequency, "unexpected popular key frequency in test %d", i)
 	}
 }
+
+func TestUnweightedFinderAccessDirection(t *testing.T) {
+	testCases := []struct {
+		name              string
+		samples           [splitKeySampleSize]sample
+		expectedDirection float64
+	}{
+		{
+			name: "all samples to the left",
+			samples: [splitKeySampleSize]sample{
+				{left: 10, right: 0, contained: 1},
+				{left: 20, right: 0, contained: 1},
+				{left: 30, right: 0, contained: 1},
+			},
+			expectedDirection: -1,
+		},
+		{
+			name: "all samples to the right",
+			samples: [splitKeySampleSize]sample{
+				{left: 0, right: 10, contained: 1},
+				{left: 0, right: 20, contained: 1},
+				{left: 0, right: 30, contained: 1},
+			},
+			expectedDirection: 1,
+		},
+		{
+			name: "balanced samples",
+			samples: [splitKeySampleSize]sample{
+				{left: 10, right: 10, contained: 1},
+				{left: 20, right: 20, contained: 1},
+				{left: 30, right: 30, contained: 1},
+			},
+			expectedDirection: 0,
+		},
+		{
+			name: "more samples to the left",
+			samples: [splitKeySampleSize]sample{
+				{left: 30, right: 10, contained: 1},
+				{left: 40, right: 20, contained: 1},
+				{left: 50, right: 30, contained: 1},
+			},
+			expectedDirection: -(1.0 / 3),
+		},
+		{
+			name: "more samples to the right",
+			samples: [splitKeySampleSize]sample{
+				{left: 10, right: 30, contained: 1},
+				{left: 20, right: 40, contained: 1},
+				{left: 30, right: 50, contained: 1},
+			},
+			expectedDirection: (1.0 / 3),
+		},
+		{
+			name: "contained samples does not influence direction",
+			samples: [splitKeySampleSize]sample{
+				{left: 10, right: 0, contained: 1},
+				{left: 0, right: 10, contained: 2},
+			},
+			expectedDirection: 0,
+		},
+		{
+			name:              "no samples",
+			samples:           [splitKeySampleSize]sample{},
+			expectedDirection: 0,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			finder := NewUnweightedFinder(timeutil.Now(), rand.New(rand.NewSource(2022)))
+			finder.samples = tc.samples
+			direction := finder.AccessDirection()
+			if direction != tc.expectedDirection {
+				t.Errorf("expected direction %v, but got %v", tc.expectedDirection, direction)
+			}
+		})
+	}
+}

--- a/pkg/kv/kvserver/split/weighted_finder.go
+++ b/pkg/kv/kvserver/split/weighted_finder.go
@@ -282,6 +282,22 @@ func (f *WeightedFinder) PopularKeyFrequency() float64 {
 	return popularKeyWeight / totalWeight
 }
 
+// AccessDirection returns a value in [-1, 1] indicating the direction of access
+// requests over time. A negative value implies more traffic is moving to the left
+// (lower keys), a positive value implies more traffic is moving to the right
+// (higher keys), and zero indicates even distribution.
+func (f *WeightedFinder) AccessDirection() float64 {
+	var left, right float64
+	for _, s := range f.samples {
+		left += s.left
+		right += s.right
+	}
+	if left+right == 0 {
+		return 0
+	}
+	return (right - left) / (right + left)
+}
+
 // SafeFormat implements the redact.SafeFormatter interface.
 func (f *WeightedFinder) SafeFormat(w redact.SafePrinter, _ rune) {
 	w.Printf("key=%v start=%v count=%d total=%.2f samples=%v",

--- a/pkg/kv/kvserver/split/weighted_finder_test.go
+++ b/pkg/kv/kvserver/split/weighted_finder_test.go
@@ -406,3 +406,89 @@ func TestWeightedFinderPopularKeyFrequency(t *testing.T) {
 			i, test.expectedPopularKeyFrequency, popularKeyFrequency)
 	}
 }
+
+func TestWeightedFinderAccessDirection(t *testing.T) {
+	testCases := []struct {
+		name              string
+		samples           [splitKeySampleSize]weightedSample
+		expectedDirection float64
+	}{
+		{
+			name: "all samples to the left",
+			samples: [splitKeySampleSize]weightedSample{
+				{left: 10, right: 0, count: 1, weight: 1},
+				{left: 20, right: 0, count: 1, weight: 1},
+				{left: 30, right: 0, count: 1, weight: 1},
+			},
+			expectedDirection: -1,
+		},
+		{
+			name: "all samples to the right",
+			samples: [splitKeySampleSize]weightedSample{
+				{left: 0, right: 10, count: 1, weight: 1},
+				{left: 0, right: 20, count: 1, weight: 1},
+				{left: 0, right: 30, count: 1, weight: 1},
+			},
+			expectedDirection: 1,
+		},
+		{
+			name: "balanced samples",
+			samples: [splitKeySampleSize]weightedSample{
+				{left: 10, right: 10, count: 1, weight: 1},
+				{left: 20, right: 20, count: 1, weight: 1},
+				{left: 30, right: 30, count: 1, weight: 1},
+			},
+			expectedDirection: 0,
+		},
+		{
+			name: "more samples to the left",
+			samples: [splitKeySampleSize]weightedSample{
+				{left: 30, right: 10, count: 1, weight: 1},
+				{left: 40, right: 20, count: 1, weight: 1},
+				{left: 50, right: 30, count: 1, weight: 1},
+			},
+			expectedDirection: -1.0 / 3.0,
+		},
+		{
+			name: "more samples to the right",
+			samples: [splitKeySampleSize]weightedSample{
+				{left: 10, right: 30, count: 1, weight: 1},
+				{left: 20, right: 40, count: 1, weight: 1},
+				{left: 30, right: 50, count: 1, weight: 1},
+			},
+			expectedDirection: 1.0 / 3.0,
+		},
+		{
+			name: "count does not influence direction",
+			samples: [splitKeySampleSize]weightedSample{
+				{left: 10, right: 0, count: 1, weight: 1},
+				{left: 0, right: 10, count: 2, weight: 1},
+			},
+			expectedDirection: 0,
+		},
+		{
+			name: "weight does not influence direction",
+			samples: [splitKeySampleSize]weightedSample{
+				{left: 10, right: 0, count: 1, weight: 1},
+				{left: 0, right: 10, count: 1, weight: 2},
+			},
+			expectedDirection: 0,
+		},
+		{
+			name:              "no samples",
+			samples:           [splitKeySampleSize]weightedSample{},
+			expectedDirection: 0,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			finder := NewWeightedFinder(timeutil.Now(), rand.New(rand.NewSource(2022)))
+			finder.samples = tc.samples
+			direction := finder.AccessDirection()
+			if math.Abs(direction-tc.expectedDirection) > 1e-9 {
+				t.Errorf("expected direction %v, but got %v", tc.expectedDirection, direction)
+			}
+		})
+	}
+}


### PR DESCRIPTION
split: add AccessDirection functions to split finders

To track the movement of samples within a replica, we expose a `SampleMovement` function, which exposes the proportion of samples to the left or right over time.

Doing so only occurs during replica traffic sampling, which requires a high threshold of traffic to funnel through a single range. Knowing "absolute sample movement", or rather, all of the movement on one side or the other will help us identify hotspots which are monotonically increasing.

Fixes: #138757
Epic: CRDB-43150

Release note: None