### PR TITLE
external catalog: support rewriting table names in IngestExternalCatalog

### DIFF
--- a/pkg/crosscluster/logical/create_logical_replication_stmt.go
+++ b/pkg/crosscluster/logical/create_logical_replication_stmt.go
@@ -435,7 +435,11 @@ func doLDRPlan(
 			ingestedCatalog externalpb.ExternalCatalog
 		)
 		if details.CreateTable {
-			ingestedCatalog, err = externalcatalog.IngestExternalCatalog(ctx, execCfg, user, srcExternalCatalog, txn, txn.Descriptors(), resolvedDestObjects.ParentDatabaseID, resolvedDestObjects.ParentSchemaID, true /* setOffline */)
+			ingestingTableNames := make([]string, len(resolvedDestObjects.TableNames))
+			for i := range resolvedDestObjects.TableNames {
+				ingestingTableNames[i] = resolvedDestObjects.TableNames[i].Table()
+			}
+			ingestedCatalog, err = externalcatalog.IngestExternalCatalog(ctx, execCfg, user, srcExternalCatalog, txn, txn.Descriptors(), resolvedDestObjects.ParentDatabaseID, resolvedDestObjects.ParentSchemaID, true /* setOffline */, ingestingTableNames)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Informs: #142107

Release note (bugfix): previously the CREATE LOGICALLY REPLICATED syntax would always create the destination side table with the source side name, instead of the user provided name. This patch ensures the user provided name is used.