### PR TITLE
split: add key itself to popular key surface

### DIFF
--- a/pkg/kv/kvserver/split/unweighted_finder.go
+++ b/pkg/kv/kvserver/split/unweighted_finder.go
@@ -201,14 +201,15 @@ func (f *UnweightedFinder) NoSplitKeyCauseLogMsg() redact.RedactableString {
 		imbalanceAndTooManyContained)
 }
 
-// PopularKeyFrequency implements the LoadBasedSplitter interface.
-func (f *UnweightedFinder) PopularKeyFrequency() float64 {
+// PopularKey implements the LoadBasedSplitter interface.
+func (f *UnweightedFinder) PopularKey() PopularKey {
 	slices.SortFunc(f.samples[:], func(a, b sample) int {
 		return bytes.Compare(a.key, b.key)
 	})
 
 	currentKeyCount := 1
-	popularKeyCount := 1
+	popularKeyCount := 0
+	var key roachpb.Key
 	for i := 1; i < len(f.samples); i++ {
 		if bytes.Equal(f.samples[i].key, f.samples[i-1].key) {
 			currentKeyCount++
@@ -216,11 +217,15 @@ func (f *UnweightedFinder) PopularKeyFrequency() float64 {
 			currentKeyCount = 1
 		}
 		if popularKeyCount < currentKeyCount {
+			key = f.samples[i].key
 			popularKeyCount = currentKeyCount
 		}
 	}
 
-	return float64(popularKeyCount) / float64(splitKeySampleSize)
+	return PopularKey{
+		Key:       key,
+		Frequency: float64(popularKeyCount) / float64(splitKeySampleSize),
+	}
 }
 
 // SafeFormat implements the redact.SafeFormatter interface.

--- a/pkg/kv/kvserver/split/weighted_finder.go
+++ b/pkg/kv/kvserver/split/weighted_finder.go
@@ -252,8 +252,8 @@ func (f *WeightedFinder) NoSplitKeyCauseLogMsg() redact.RedactableString {
 		insufficientCounters, imbalance)
 }
 
-// PopularKeyFrequency implements the LoadBasedSplitter interface.
-func (f *WeightedFinder) PopularKeyFrequency() float64 {
+// PopularKey implements the LoadBasedSplitter interface.
+func (f *WeightedFinder) PopularKey() PopularKey {
 	// Sort the sample slice to determine the frequency that a popular key
 	// appears. We could copy the slice, however it would require an allocation.
 	// The probability a sample is replaced doesn't change as it is independent
@@ -263,6 +263,7 @@ func (f *WeightedFinder) PopularKeyFrequency() float64 {
 	})
 
 	weight := f.samples[0].weight
+	key := f.samples[0].key
 	currentKeyWeight := weight
 	popularKeyWeight := weight
 	totalWeight := weight
@@ -274,12 +275,16 @@ func (f *WeightedFinder) PopularKeyFrequency() float64 {
 			currentKeyWeight = weight
 		}
 		if popularKeyWeight < currentKeyWeight {
+			key = f.samples[i].key
 			popularKeyWeight = currentKeyWeight
 		}
 		totalWeight += weight
 	}
 
-	return popularKeyWeight / totalWeight
+	return PopularKey{
+		Key:       key,
+		Frequency: popularKeyWeight / totalWeight,
+	}
 }
 
 // SafeFormat implements the redact.SafeFormatter interface.


### PR DESCRIPTION
split: add key itself to popular key surface

historically, load based splitters have only ever exposed the frequency with which a popular key is accessed, and not the key itself. this change updates this so that the key is included in the function surface.

this may be used later, as part of the replica's split statistics.

Fixes: #138758
Epic: CRDB-43150

Release note: None