### PR TITLE
distsql: only modify eval.Context when needed

### DIFF
--- a/pkg/crosscluster/logical/logical_replication_job.go
+++ b/pkg/crosscluster/logical/logical_replication_job.go
@@ -146,7 +146,6 @@ func (r *logicalReplicationResumer) ingest(
 	var (
 		execCfg        = jobExecCtx.ExecCfg()
 		distSQLPlanner = jobExecCtx.DistSQLPlanner()
-		evalCtx        = jobExecCtx.ExtendedEvalContext()
 
 		progress = r.job.Progress().Details.(*jobspb.Progress_LogicalReplication).LogicalReplication
 		payload  = r.job.Details().(jobspb.LogicalReplicationDetails)
@@ -289,18 +288,18 @@ func (r *logicalReplicationResumer) ingest(
 			execCfg.RangeDescriptorCache,
 			nil, /* txn */
 			nil, /* clockUpdater */
-			evalCtx.Tracing,
+			jobExecCtx.ExtendedEvalContext().Tracing,
 		)
 		defer distSQLReceiver.Release()
-		// Copy the evalCtx, as dsp.Run() might change it.
-		evalCtxCopy := *evalCtx
+		// Copy the eval.Context, as dsp.Run() might change it.
+		evalCtxCopy := jobExecCtx.ExtendedEvalContext().Context.Copy()
 		distSQLPlanner.Run(
 			ctx,
 			initialPlanCtx,
 			nil, /* txn */
 			initialPlan,
 			distSQLReceiver,
-			&evalCtxCopy,
+			evalCtxCopy,
 			nil, /* finishedSetupFn */
 		)
 

--- a/pkg/crosscluster/physical/stream_ingestion_dist.go
+++ b/pkg/crosscluster/physical/stream_ingestion_dist.go
@@ -226,9 +226,9 @@ func startDistIngestion(
 		)
 		defer recv.Release()
 
-		// Copy the evalCtx, as dsp.Run() might change it.
-		evalCtxCopy := *execCtx.ExtendedEvalContext()
-		dsp.Run(ctx, planner.initialPlanCtx, noTxn, planner.initialPlan, recv, &evalCtxCopy, nil /* finishedSetupFn */)
+		// Copy the eval.Context, as dsp.Run() might change it.
+		evalCtxCopy := execCtx.ExtendedEvalContext().Context.Copy()
+		dsp.Run(ctx, planner.initialPlanCtx, noTxn, planner.initialPlan, recv, evalCtxCopy, nil /* finishedSetupFn */)
 		return rw.Err()
 	}
 

--- a/pkg/sql/distsql_plan_ctas.go
+++ b/pkg/sql/distsql_plan_ctas.go
@@ -47,10 +47,10 @@ func PlanAndRunCTAS(
 	// The bulk row writers will emit a binary encoded BulkOpSummary.
 	physPlan.PlanToStreamColMap = []int{0}
 
-	// Make copy of evalCtx as Run might modify it.
-	evalCtxCopy := planner.ExtendedEvalContextCopy()
 	FinalizePlan(ctx, planCtx, physPlan)
 	finishedSetupFn, cleanup := getFinishedSetupFn(planner)
 	defer cleanup()
+	// Copy the eval.Context, as dsp.Run() might change it.
+	evalCtxCopy := planner.ExtendedEvalContext().Context.Copy()
 	dsp.Run(ctx, planCtx, txn, physPlan, recv, evalCtxCopy, finishedSetupFn)
 }

--- a/pkg/sql/distsql_plan_stats.go
+++ b/pkg/sql/distsql_plan_stats.go
@@ -763,7 +763,7 @@ func (dsp *DistSQLPlanner) createPlanForCreateStats(
 
 func (dsp *DistSQLPlanner) planAndRunCreateStats(
 	ctx context.Context,
-	evalCtx *extendedEvalContext,
+	extEvalCtx *extendedEvalContext,
 	planCtx *PlanningCtx,
 	semaCtx *tree.SemaContext,
 	txn *kv.Txn,
@@ -786,13 +786,15 @@ func (dsp *DistSQLPlanner) planAndRunCreateStats(
 		ctx,
 		resultWriter,
 		tree.DDL,
-		evalCtx.ExecCfg.RangeDescriptorCache,
+		extEvalCtx.ExecCfg.RangeDescriptorCache,
 		txn,
-		evalCtx.ExecCfg.Clock,
-		evalCtx.Tracing,
+		extEvalCtx.ExecCfg.Clock,
+		extEvalCtx.Tracing,
 	)
 	defer recv.Release()
 
-	dsp.Run(ctx, planCtx, txn, physPlan, recv, evalCtx, nil /* finishedSetupFn */)
+	// Copy the eval.Context, as dsp.Run() might change it.
+	evalCtxCopy := extEvalCtx.Context.Copy()
+	dsp.Run(ctx, planCtx, txn, physPlan, recv, evalCtxCopy, nil /* finishedSetupFn */)
 	return resultWriter.Err()
 }

--- a/pkg/sql/importer/import_processor_planning.go
+++ b/pkg/sql/importer/import_processor_planning.go
@@ -116,7 +116,6 @@ func distImport(
 	if err != nil {
 		return kvpb.BulkOpSummary{}, err
 	}
-	evalCtx := planCtx.ExtendedEvalCtx
 
 	// accumulatedBulkSummary accumulates the BulkOpSummary returned from each
 	// processor in their progress updates. It stores stats about the amount of
@@ -209,7 +208,7 @@ func distImport(
 		return nil
 	})
 
-	if evalCtx.Codec.ForSystemTenant() {
+	if planCtx.ExtendedEvalCtx.Codec.ForSystemTenant() {
 		if err := presplitTableBoundaries(ctx, execCtx.ExecCfg(), tables); err != nil {
 			return kvpb.BulkOpSummary{}, err
 		}
@@ -222,7 +221,7 @@ func distImport(
 		nil, /* rangeCache */
 		nil, /* txn - the flow does not read or write the database */
 		nil, /* clockUpdater */
-		evalCtx.Tracing,
+		planCtx.ExtendedEvalCtx.Tracing,
 	)
 	defer recv.Release()
 
@@ -267,9 +266,9 @@ func distImport(
 		execCfg := execCtx.ExecCfg()
 		jobsprofiler.StorePlanDiagram(ctx, execCfg.DistSQLSrv.Stopper, p, execCfg.InternalDB, job.ID())
 
-		// Copy the evalCtx, as dsp.Run() might change it.
-		evalCtxCopy := *evalCtx
-		dsp.Run(ctx, planCtx, nil, p, recv, &evalCtxCopy, testingKnobs.onSetupFinish)
+		// Copy the eval.Context, as dsp.Run() might change it.
+		evalCtxCopy := planCtx.ExtendedEvalCtx.Context.Copy()
+		dsp.Run(ctx, planCtx, nil, p, recv, evalCtxCopy, testingKnobs.onSetupFinish)
 		return rowResultWriter.Err()
 	})
 


### PR DESCRIPTION
**sql: adjust Run method to take eval.Context rather than extended one**

There is no reason for `DistSQLPlanner.Run` to require
`extendedEvalContext`, so this commit switches to passing `eval.Context`
instead. It additionally makes a copy of `eval.Context` in two places to
match all others, but otherwise it should be a no-op.

Release note: NoneThere is no reason for `DistSQLPlanner.Run` to require
`extendedEvalContext`, so this commit switches to passing `eval.Context`
instead. It additionally makes a copy of `eval.Context` in two places to
match all others, but otherwise it should be a no-op.

Release note: None

**distsql: only modify eval.Context when needed**

When setting up the distsql flow we need to decide whether we must use
a LeafTxn or can use the RootTxn. If it's the former, we additionally
modify `eval.Context.Txn` to refer to the correct txn, and on the flow
cleanup we need to restore the original value of `eval.Context.Txn`
field. Previously, we would do the restoration (i.e. a modification of
the eval context) for all gateway flows, even when we don't use the
LeafTxn, so we don't actually modify the eval context. This commit fixes
that oversight to only restore the original state if we modified it.

I was looking into this area since we saw an extremely rare data race
around the restoration of `eval.Context.Txn` field in the CDC tests.
I didn't quite figure out how it happened, but I'm optimistic that this
commit addresses the root cause, at least when we don't have
a distributed plan (so we aren't forced to use the LeafTxn).

Fixes: #140977.

Release note: None