### PR TITLE
roachtest: ramp workloads in cluster to cluster tests

### DIFF
--- a/pkg/cmd/roachtest/tests/cluster_to_cluster.go
+++ b/pkg/cmd/roachtest/tests/cluster_to_cluster.go
@@ -231,6 +231,7 @@ func (tpcc replicateTPCC) sourceInitCmd(tenantName string, nodes option.NodeList
 func (tpcc replicateTPCC) sourceRunCmd(tenantName string, nodes option.NodeListOption) string {
 	cmd := roachtestutil.NewCommand(`./cockroach workload run tpcc`).
 		Flag("warehouses", tpcc.warehouses).
+		Flag("ramp", "2m").
 		MaybeFlag(tpcc.duration > 0, "duration", tpcc.duration).
 		MaybeOption(tpcc.tolerateErrors, "tolerate-errors").
 		MaybeOption(tpcc.repairOrderIDs, "repair-order-ids").


### PR DESCRIPTION
Previously, the LDR/PCR roach tests started a full cluster scan and the TPC-C workload at the same time. Opening all of the connections for TPC-C while starting a large scan of the cluster is known to trigger meta-stable behavior in the TPC-C workload. Now, TPC-C is configured to ramp the workload.

Release note: none
Part of: #142077
Part of: #142073