### PR TITLE
ui: improve network latency page performance

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/network/latency/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/network/latency/index.tsx
@@ -48,6 +48,38 @@ type DetailedIdentity = Identity & {
   title?: string;
 };
 
+// SimpleTooltip is a specialized fast-rendering
+// component for the network latency table.
+const SimpleTooltip: React.FC<{
+  content: React.ReactNode;
+  children: React.ReactNode;
+}> = ({ content, children }) => {
+  const [isVisible, setIsVisible] = React.useState(false);
+  const tooltipRef = React.useRef<HTMLDivElement>(null);
+  const triggerRef = React.useRef<HTMLDivElement>(null);
+
+  // Handle mouse events
+  const handleMouseEnter = () => setIsVisible(true);
+  const handleMouseLeave = () => setIsVisible(false);
+
+  return (
+    <div
+      ref={triggerRef}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+      style={{ position: "relative", display: "inline-block" }}
+    >
+      {children}
+      {isVisible && (
+        <div ref={tooltipRef} className={"Chip--tooltip"}>
+          {content}
+          <div className={"Chip--tooltip-arrow"} />
+        </div>
+      )}
+    </div>
+  );
+};
+
 // createHeaderCell creates and decorates a header cell.
 function createHeaderCell(
   identity: DetailedIdentity,
@@ -360,10 +392,8 @@ const getLatencyCell = (
       {collapsed ? (
         <Chip title={`${latency.toFixed(2)}ms`} type={type} />
       ) : (
-        <Tooltip
-          overlayClassName="Chip--tooltip"
-          placement="bottom"
-          title={
+        <SimpleTooltip
+          content={
             <div>
               <div className="Chip--tooltip__nodes">
                 <div className="Chip--tooltip__nodes--item">
@@ -429,7 +459,7 @@ const getLatencyCell = (
               type={type}
             />
           </div>
-        </Tooltip>
+        </SimpleTooltip>
       )}
     </td>
   );
@@ -474,7 +504,7 @@ export const Latency: React.SFC<ILatencyProps> = ({
               <th
                 className="region-name"
                 colSpan={data[index].length}
-                key={index}
+                key={`region-${index}`}
               >
                 {value[0].title}
               </th>
@@ -514,15 +544,17 @@ export const Latency: React.SFC<ILatencyProps> = ({
                     </th>
                   )}
                   {createHeaderCell(identityA, false, collapsed)}
-                  {map(identityA.row, (identity: any, indexB: number) =>
-                    getLatencyCell(
-                      { ...identity, identityA },
-                      getVerticalLines(data, indexB),
-                      false,
-                      std,
-                      collapsed,
-                    ),
-                  )}
+                  {map(identityA.row, (identity: any, indexB: number) => (
+                    <React.Fragment key={`cell-${indexB}`}>
+                      {getLatencyCell(
+                        { ...identity, identityA },
+                        getVerticalLines(data, indexB),
+                        false,
+                        std,
+                        collapsed,
+                      )}
+                    </React.Fragment>
+                  ))}
                 </tr>
               );
             }),

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/network/latency/latency.styl
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/network/latency/latency.styl
@@ -78,14 +78,21 @@
 .latency-table__empty
   padding: 30px;
 
-
-.crdb-ant-tooltip.Chip--tooltip
-  min-width 384px
-  .crdb-ant-tooltip-inner
-    background-color black
-    padding 12px 18px
-  .crdb-ant-tooltip-content
-    width 100%
+.Chip--tooltip
+  font-family $font-family--base
+  font-size 12px
+  color white
+  background-color black
+  position: absolute
+  bottom: 100%
+  left: 50%
+  transform: translateX(-50%)
+  margin-bottom: 8px
+  padding: 8px
+  border-radius: 4px
+  box-shadow: 0 2px 8px rgba(0,0,0,0.15)
+  z-index: 1000
+  min-width: 384px
   span, p
     font-family $font-family--base
     font-size 14px
@@ -103,9 +110,6 @@
         margin-right 8px
       &:last-child
         margin-left 8px
-    .crdb-ant-divider
-      background #3b4a60
-      margin 0
     &--item-title, &--item-description
       font-family $font-family--base
       font-size 14px
@@ -128,3 +132,14 @@
       color $colors--functional-yellow-3
     &--red
       color $colors--functional-red-3
+
+.Chip--tooltip-arrow
+  position: absolute
+  bottom: -8px
+  left: 50%
+  transform: translateX(-50%)
+  width: 0
+  height: 0
+  border-left: 8px solid transparent
+  border-right: 8px solid transparent
+  border-top: 8px solid black


### PR DESCRIPTION
Added React `key` field to latency cells. This change should reduce the amount of re-rendering happening on this page.

Replace antd `Tooltip` component with a custom `SimpleTooltip` which renders more quickly and positions using CSS. Some effort was taken to keep the tooltip visual similar to the existing one.

Fixes: #134827
Release note: None