### PR TITLE
pkg/util/jsonpath: add variable, array indexing support for jsonpath parser

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/jsonpath
+++ b/pkg/sql/logictest/testdata/logic_test/jsonpath
@@ -65,7 +65,7 @@ true
 statement error pq: could not parse "" as type jsonpath: at or near "EOF": syntax error
 SELECT ''::JSONPATH
 
-statement error pq: could not parse "\$\.1a\[\*\]" as type jsonpath: at or near "1": syntax error
+statement error pq: could not parse "\$\.1a\[\*\]" as type jsonpath
 SELECT '$.1a[*]'::JSONPATH
 
 query T
@@ -159,3 +159,8 @@ $.ABC[*].DEF.GHI[*]
 # SELECT '$.a.type()'::JSONPATH
 # ----
 # $.a.type()
+
+# query T
+# SELECT '$.a ? ($.b == 1)'::JSONPATH
+# ----
+# $.a ? ($.b == 1)

--- a/pkg/sql/logictest/testdata/logic_test/jsonpath
+++ b/pkg/sql/logictest/testdata/logic_test/jsonpath
@@ -8,7 +8,7 @@ jsonpath
 query T
 SELECT '$.a'::JSONPATH
 ----
-$.a
+$."a"
 
 statement error pq: value type jsonpath cannot be used for table columns
 CREATE TABLE a (j JSONPATH)
@@ -34,7 +34,7 @@ $
 query T
 SELECT '$.a1[*]'::JSONPATH
 ----
-$.a1[*]
+$."a1"[*]
 
 query B
 SELECT '$'::JSONPATH IS NULL
@@ -71,12 +71,12 @@ SELECT '$.1a[*]'::JSONPATH
 query T
 SELECT '$.abc[*].DEF.ghi[*]'::JSONPATH
 ----
-$.abc[*].DEF.ghi[*]
+$."abc"[*]."DEF"."ghi"[*]
 
 query T
 SELECT '$.ABC[*].DEF.GHI[*]'::JSONPATH
 ----
-$.ABC[*].DEF.GHI[*]
+$."ABC"[*]."DEF"."GHI"[*]
 
 ## When we allow table creation
 

--- a/pkg/sql/scanner/jsonpath_scan.go
+++ b/pkg/sql/scanner/jsonpath_scan.go
@@ -23,12 +23,19 @@ func (s *JSONPathScanner) Scan(lval ScanSymType) {
 		return
 	}
 
-	// TODO(normanchenn): This check will not work for valid JSONPath expressions
-	// like '$.1key'. We don't support this case yet since expressions like
-	// '$.1e' should fail due to being interpreted as a numeric literal.
-	if sqllexbase.IsIdentStart(ch) {
-		s.scanIdent(lval)
+	// TODO(normanchenn): We still need to handle $.Xe where X is any digit.
+	switch ch {
+	case identQuote:
+		// "[^"]"
+		if s.scanString(lval, identQuote, false /* allowEscapes */, true /* requireUTF8 */) {
+			lval.SetID(lexbase.IDENT)
+		}
 		return
+	default:
+		if sqllexbase.IsIdentStart(ch) {
+			s.scanIdent(lval)
+			return
+		}
 	}
 	// Everything else is a single character token which we already initialized
 	// lval for above.

--- a/pkg/sql/scanner/jsonpath_scan.go
+++ b/pkg/sql/scanner/jsonpath_scan.go
@@ -50,6 +50,10 @@ func (s *JSONPathScanner) Scan(lval ScanSymType) {
 		}
 		return
 	default:
+		if sqllexbase.IsDigit(ch) {
+			s.scanNumber(lval, ch)
+			return
+		}
 		if sqllexbase.IsIdentStart(ch) {
 			s.scanIdent(lval)
 			return
@@ -68,4 +72,9 @@ func isIdentMiddle(ch int) bool {
 func (s *JSONPathScanner) scanIdent(lval ScanSymType) {
 	s.normalizeIdent(lval, isIdentMiddle, false /* toLower */)
 	lval.SetID(lexbase.GetKeywordID(lval.Str()))
+}
+
+// scanNumber is similar to Scanner.scanNumber, but uses Jsonpath tokens.
+func (s *JSONPathScanner) scanNumber(lval ScanSymType, ch int) {
+	s.scanNumberImpl(lval, ch, lexbase.ERROR, lexbase.FCONST, lexbase.ICONST)
 }

--- a/pkg/sql/scanner/jsonpath_scan.go
+++ b/pkg/sql/scanner/jsonpath_scan.go
@@ -25,6 +25,24 @@ func (s *JSONPathScanner) Scan(lval ScanSymType) {
 
 	// TODO(normanchenn): We still need to handle $.Xe where X is any digit.
 	switch ch {
+	case '$':
+		// Root path ($.)
+		if s.peek() == '.' || s.peek() == eof || s.peek() == ' ' {
+			return
+		}
+
+		// Handle variables like $var, $1a, $"var", etc.
+		if s.peek() == identQuote {
+			s.pos++
+			if s.scanString(lval, identQuote, false /* allowEscapes */, true /* requireUTF8 */) {
+				lval.SetID(lexbase.VARIABLE)
+			}
+			return
+		}
+		s.pos++
+		s.scanIdent(lval)
+		lval.SetID(lexbase.VARIABLE)
+		return
 	case identQuote:
 		// "[^"]"
 		if s.scanString(lval, identQuote, false /* allowEscapes */, true /* requireUTF8 */) {

--- a/pkg/sql/scanner/plpgsql_scan.go
+++ b/pkg/sql/scanner/plpgsql_scan.go
@@ -6,9 +6,6 @@
 package scanner
 
 import (
-	"fmt"
-	"go/constant"
-	"go/token"
 	"strconv"
 	"unicode/utf8"
 
@@ -334,101 +331,7 @@ outer:
 
 // scanNumber is similar to Scanner.scanNumber, but uses PL/pgSQL tokens.
 func (s *PLpgSQLScanner) scanNumber(lval ScanSymType, ch int) {
-	start := s.pos - 1
-	isHex := false
-	hasDecimal := ch == '.'
-	hasExponent := false
-
-	for {
-		ch := s.peek()
-		if (isHex && sqllex.IsHexDigit(ch)) || sqllex.IsDigit(ch) {
-			s.pos++
-			continue
-		}
-		if ch == 'x' || ch == 'X' {
-			if isHex || s.in[start] != '0' || s.pos != start+1 {
-				lval.SetID(lexbase.ERROR)
-				lval.SetStr(errInvalidHexNumeric)
-				return
-			}
-			s.pos++
-			isHex = true
-			continue
-		}
-		if isHex {
-			break
-		}
-		if ch == '.' {
-			if hasDecimal || hasExponent {
-				break
-			}
-			s.pos++
-			if s.peek() == '.' {
-				// Found ".." while scanning a number: back up to the end of the
-				// integer.
-				s.pos--
-				break
-			}
-			hasDecimal = true
-			continue
-		}
-		if ch == 'e' || ch == 'E' {
-			if hasExponent {
-				break
-			}
-			hasExponent = true
-			s.pos++
-			ch = s.peek()
-			if ch == '-' || ch == '+' {
-				s.pos++
-			}
-			ch = s.peek()
-			if !sqllex.IsDigit(ch) {
-				lval.SetID(lexbase.ERROR)
-				lval.SetStr("invalid floating point literal")
-				return
-			}
-			continue
-		}
-		break
-	}
-
-	lval.SetStr(s.in[start:s.pos])
-	if hasDecimal || hasExponent {
-		lval.SetID(lexbase.FCONST)
-		floatConst := constant.MakeFromLiteral(lval.Str(), token.FLOAT, 0)
-		if floatConst.Kind() == constant.Unknown {
-			lval.SetID(lexbase.ERROR)
-			lval.SetStr(fmt.Sprintf("could not make constant float from literal %q", lval.Str()))
-			return
-		}
-		lval.SetUnionVal(NewNumValFn(floatConst, lval.Str(), false /* negative */))
-	} else {
-		if isHex && s.pos == start+2 {
-			lval.SetID(lexbase.ERROR)
-			lval.SetStr(errInvalidHexNumeric)
-			return
-		}
-
-		// Strip off leading zeros from non-hex (decimal) literals so that
-		// constant.MakeFromLiteral doesn't inappropriately interpret the
-		// string as an octal literal. Note: we can't use strings.TrimLeft
-		// here, because it will truncate '0' to ''.
-		if !isHex {
-			for len(lval.Str()) > 1 && lval.Str()[0] == '0' {
-				lval.SetStr(lval.Str()[1:])
-			}
-		}
-
-		lval.SetID(lexbase.ICONST)
-		intConst := constant.MakeFromLiteral(lval.Str(), token.INT, 0)
-		if intConst.Kind() == constant.Unknown {
-			lval.SetID(lexbase.ERROR)
-			lval.SetStr(fmt.Sprintf("could not make constant int from literal %q", lval.Str()))
-			return
-		}
-		lval.SetUnionVal(NewNumValFn(intConst, lval.Str(), false /* negative */))
-	}
+	s.scanNumberImpl(lval, ch, lexbase.ERROR, lexbase.FCONST, lexbase.ICONST)
 }
 
 // scanIdent is similar to Scanner.scanIdent, but uses PL/pgSQL tokens.

--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -3904,7 +3904,15 @@ func (d *DJsonpath) Compare(ctx context.Context, cmpCtx CompareContext, other Da
 	if !ok {
 		return 0, makeUnsupportedComparisonMessage(d, other)
 	}
-	return strings.Compare(string(*d), string(*v)), nil
+	dParsed, err := ValidateJSONPath(string(*d))
+	if err != nil {
+		return 0, err
+	}
+	vParsed, err := ValidateJSONPath(string(*v))
+	if err != nil {
+		return 0, err
+	}
+	return strings.Compare(dParsed, vParsed), nil
 }
 
 // Prev implements the Datum interface.

--- a/pkg/util/jsonpath/expr.go
+++ b/pkg/util/jsonpath/expr.go
@@ -112,7 +112,7 @@ type ArrayIndex Numeric
 var _ Path = ArrayIndex{}
 
 func (a ArrayIndex) String() string {
-	return fmt.Sprintf("[%s]", Numeric(a).String())
+	return Numeric(a).String()
 }
 
 type ArrayIndexRange struct {
@@ -123,5 +123,22 @@ type ArrayIndexRange struct {
 var _ Path = ArrayIndexRange{}
 
 func (a ArrayIndexRange) String() string {
-	return fmt.Sprintf("[%s to %s]", Numeric(a.Start), Numeric(a.End))
+	return fmt.Sprintf("%s to %s", Numeric(a.Start), Numeric(a.End))
+}
+
+type ArrayList []Path
+
+var _ Path = ArrayList{}
+
+func (a ArrayList) String() string {
+	var sb strings.Builder
+	sb.WriteString("[")
+	for i, p := range a {
+		if i > 0 {
+			sb.WriteString(",")
+		}
+		sb.WriteString(p.String())
+	}
+	sb.WriteString("]")
+	return sb.String()
 }

--- a/pkg/util/jsonpath/expr.go
+++ b/pkg/util/jsonpath/expr.go
@@ -12,81 +12,55 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 )
 
-type Expr interface {
-	fmt.Stringer
-	tree.NodeFormatter
-}
-
-// Identical to Expr for now.
-type Accessor interface {
-	Expr
-}
-
 type Jsonpath struct {
-	Query  Query
 	Strict bool
+	Path   Path
 }
-
-var _ Expr = Jsonpath{}
 
 func (j Jsonpath) String() string {
 	var mode string
 	if j.Strict {
 		mode = "strict "
 	}
-	return mode + j.Query.String()
+	return mode + j.Path.String()
 }
 
 func (j Jsonpath) Format(ctx *tree.FmtCtx) {
 	ctx.WriteString(j.String())
 }
 
-type Query struct {
-	Accessors []Accessor
-}
-
-var _ Expr = Query{}
-
-func (q Query) String() string {
-	var sb strings.Builder
-	for _, accessor := range q.Accessors {
-		sb.WriteString(accessor.String())
-	}
-	return sb.String()
-}
-
-func (q Query) Format(ctx *tree.FmtCtx) {
-	ctx.WriteString(q.String())
+type Path interface {
+	fmt.Stringer
 }
 
 type Root struct{}
 
-var _ Accessor = Root{}
+var _ Path = &Root{}
 
 func (r Root) String() string { return "$" }
-
-func (r Root) Format(ctx *tree.FmtCtx) {
-	ctx.WriteString(r.String())
-}
 
 type Key struct {
 	Key string
 }
 
-var _ Accessor = Key{}
+var _ Path = &Key{}
 
 func (k Key) String() string { return "." + k.Key }
 
-func (k Key) Format(ctx *tree.FmtCtx) {
-	ctx.WriteString(k.String())
-}
-
 type Wildcard struct{}
 
-var _ Accessor = Wildcard{}
+var _ Path = &Wildcard{}
 
 func (w Wildcard) String() string { return "[*]" }
 
-func (w Wildcard) Format(ctx *tree.FmtCtx) {
-	ctx.WriteString(w.String())
+type Paths []Path
+
+var _ Path = &Paths{}
+
+func (p Paths) String() string {
+	var sb strings.Builder
+	for _, i := range p {
+		sb.WriteString(i.String())
+	}
+	return sb.String()
 }

--- a/pkg/util/jsonpath/expr.go
+++ b/pkg/util/jsonpath/expr.go
@@ -114,3 +114,14 @@ var _ Path = ArrayIndex{}
 func (a ArrayIndex) String() string {
 	return fmt.Sprintf("[%s]", Numeric(a).String())
 }
+
+type ArrayIndexRange struct {
+	Start ArrayIndex
+	End   ArrayIndex
+}
+
+var _ Path = ArrayIndexRange{}
+
+func (a ArrayIndexRange) String() string {
+	return fmt.Sprintf("[%s to %s]", Numeric(a.Start), Numeric(a.End))
+}

--- a/pkg/util/jsonpath/expr.go
+++ b/pkg/util/jsonpath/expr.go
@@ -39,13 +39,13 @@ var _ Path = &Root{}
 
 func (r Root) String() string { return "$" }
 
-type Key struct {
-	Key string
+type Key string
+
+var _ Path = Key("")
+
+func (k Key) String() string {
+	return fmt.Sprintf(".%q", string(k))
 }
-
-var _ Path = &Key{}
-
-func (k Key) String() string { return "." + k.Key }
 
 type Wildcard struct{}
 

--- a/pkg/util/jsonpath/expr.go
+++ b/pkg/util/jsonpath/expr.go
@@ -64,3 +64,11 @@ func (p Paths) String() string {
 	}
 	return sb.String()
 }
+
+type Variable string
+
+var _ Path = Variable("")
+
+func (v Variable) String() string {
+	return fmt.Sprintf("$%q", string(v))
+}

--- a/pkg/util/jsonpath/expr.go
+++ b/pkg/util/jsonpath/expr.go
@@ -72,3 +72,45 @@ var _ Path = Variable("")
 func (v Variable) String() string {
 	return fmt.Sprintf("$%q", string(v))
 }
+
+type Numeric struct {
+	IsNegative bool
+	IsFloat    bool
+	FloatValue float64
+	IntValue   int64
+}
+
+var _ Path = Numeric{}
+
+func NewNumericFloat(f float64) Numeric {
+	return Numeric{
+		IsFloat:    true,
+		FloatValue: f,
+	}
+}
+
+func NewNumericInt(i int64) Numeric {
+	return Numeric{
+		IsFloat:    false,
+		IntValue:   i,
+		IsNegative: false,
+	}
+}
+
+func (n Numeric) String() string {
+	if n.IsFloat {
+		return fmt.Sprintf("%g", n.FloatValue)
+	}
+	if n.IsNegative {
+		return fmt.Sprintf("-%d", n.IntValue)
+	}
+	return fmt.Sprintf("%d", n.IntValue)
+}
+
+type ArrayIndex Numeric
+
+var _ Path = ArrayIndex{}
+
+func (a ArrayIndex) String() string {
+	return fmt.Sprintf("[%s]", Numeric(a).String())
+}

--- a/pkg/util/jsonpath/parser/BUILD.bazel
+++ b/pkg/util/jsonpath/parser/BUILD.bazel
@@ -40,6 +40,7 @@ go_library(
         "//pkg/sql/pgwire/pgerror",
         "//pkg/sql/scanner",
         "//pkg/sql/sem/tree",
+        "//pkg/util/errorutil/unimplemented",
         "//pkg/util/jsonpath",
         "@com_github_cockroachdb_errors//:errors",
     ],

--- a/pkg/util/jsonpath/parser/jsonpath.y
+++ b/pkg/util/jsonpath/parser/jsonpath.y
@@ -185,7 +185,7 @@ accessor_op:
 key:
   key_name
   {
-    $$.val = jsonpath.Key{Key: $1}
+    $$.val = jsonpath.Key($1)
   }
 ;
 

--- a/pkg/util/jsonpath/parser/jsonpath.y
+++ b/pkg/util/jsonpath/parser/jsonpath.y
@@ -101,6 +101,8 @@ func (u *jsonpathSymUnion) bool() bool {
 %token <str> STRICT
 %token <str> LAX
 
+%token <str> VARIABLE
+
 %type <jsonpath.Jsonpath> jsonpath
 %type <jsonpath.Path> expr_or_predicate
 %type <jsonpath.Path> expr
@@ -109,6 +111,7 @@ func (u *jsonpathSymUnion) bool() bool {
 %type <jsonpath.Path> path_primary
 %type <jsonpath.Path> key
 %type <jsonpath.Path> array_accessor
+%type <jsonpath.Path> scalar_value
 %type <str> key_name
 %type <str> any_identifier
 %type <str> unreserved_keyword
@@ -169,6 +172,10 @@ path_primary:
   {
     $$.val = jsonpath.Root{}
   }
+| scalar_value
+  {
+    $$.val = $1.path()
+  }
 ;
 
 accessor_op:
@@ -200,6 +207,13 @@ array_accessor:
   '[' '*' ']'
   {
     $$.val = jsonpath.Wildcard{}
+  }
+;
+
+scalar_value:
+  VARIABLE
+  {
+    $$.val = jsonpath.Variable($1)
   }
 ;
 

--- a/pkg/util/jsonpath/parser/jsonpath.y
+++ b/pkg/util/jsonpath/parser/jsonpath.y
@@ -90,6 +90,10 @@ func (u *jsonpathSymUnion) numVal() *tree.NumVal {
   return u.val.(*tree.NumVal)
 }
 
+func (u *jsonpathSymUnion) arrayList() jsonpath.ArrayList {
+  return u.val.(jsonpath.ArrayList)
+}
+
 func pathToIndex(path jsonpath.Path) (jsonpath.ArrayIndex, error) {
   paths := path.(jsonpath.Paths)
   if len(paths) != 1 {
@@ -240,14 +244,18 @@ array_accessor:
   }
 | '[' index_list ']'
   {
-    $$.val = jsonpath.Paths($2.paths())
+    $$.val = $2.path()
   }
 ;
 
 index_list:
   index_elem
   {
-    $$.val = []jsonpath.Path{$1.path()}
+    $$.val = jsonpath.ArrayList{$1.path()}
+  }
+| index_list ',' index_elem
+  {
+    $$.val = append($1.arrayList(), $3.path())
   }
 ;
 

--- a/pkg/util/jsonpath/parser/jsonpath.y
+++ b/pkg/util/jsonpath/parser/jsonpath.y
@@ -90,6 +90,18 @@ func (u *jsonpathSymUnion) numVal() *tree.NumVal {
   return u.val.(*tree.NumVal)
 }
 
+func pathToIndex(path jsonpath.Path) (jsonpath.ArrayIndex, error) {
+  paths := path.(jsonpath.Paths)
+  if len(paths) != 1 {
+    return jsonpath.ArrayIndex{}, errors.New("expected exactly one path")
+  }
+  n, ok := paths[0].(jsonpath.Numeric)
+  if !ok {
+    return jsonpath.ArrayIndex{}, errors.New("expected numeric index")
+  }
+  return jsonpath.ArrayIndex(n), nil
+}
+
 %}
 
 %union{
@@ -117,6 +129,7 @@ func (u *jsonpathSymUnion) numVal() *tree.NumVal {
 %token <str> LAX
 
 %token <str> VARIABLE
+%token <str> TO
 
 %type <jsonpath.Jsonpath> jsonpath
 %type <jsonpath.Path> expr_or_predicate
@@ -241,15 +254,25 @@ index_list:
 index_elem:
   expr
   {
-    paths := $1.path().(jsonpath.Paths)
-    if len(paths) != 1 {
-      return setErr(jsonpathlex, errors.New("expected exactly one path"))
+    index, err := pathToIndex($1.path())
+    if err != nil {
+      return setErr(jsonpathlex, err)
     }
-    n, ok := paths[0].(jsonpath.Numeric)
-    if !ok {
-      return setErr(jsonpathlex, errors.New("expected numeric index"))
+    $$.val = index
+  }
+| expr TO expr
+  {
+    firstIndex, err := pathToIndex($1.path())
+    if err != nil {
+      return setErr(jsonpathlex, err)
     }
-    $$.val = jsonpath.ArrayIndex(n)
+
+    secondIndex, err := pathToIndex($3.path())
+    if err != nil {
+      return setErr(jsonpathlex, err)
+    }
+
+    $$.val = jsonpath.ArrayIndexRange{Start: firstIndex, End: secondIndex}
   }
 ;
 
@@ -279,8 +302,9 @@ any_identifier:
 ;
 
 unreserved_keyword:
-  STRICT
-| LAX
+  LAX
+| STRICT
+| TO
 ;
 
 %%

--- a/pkg/util/jsonpath/parser/testdata/jsonpath
+++ b/pkg/util/jsonpath/parser/testdata/jsonpath
@@ -129,7 +129,7 @@ word $
 error
 $.1e
 ----
-at or near "1": syntax error
+at or near "invalid floating point literal": syntax error
 DETAIL: source SQL:
 $.1e
   ^
@@ -157,7 +157,7 @@ $."2e"
 error
 $.2e
 ----
-at or near "2": syntax error
+at or near "invalid floating point literal": syntax error
 DETAIL: source SQL:
 $.2e
   ^
@@ -187,7 +187,48 @@ $"2e"
 ----
 $"2e"
 
+parse
+$.a[1]
+----
+$."a"[1] -- normalized!
+
+parse
+$.abc[0]
+----
+$."abc"[0] -- normalized!
+
+parse
+$.abc[213].def[23198]
+----
+$."abc"[213]."def"[23198] -- normalized!
+
+# postgres allows floats as array indexes
+# parse
+# $.abc[1.0]
+# ----
+
+# parse
+# $.abc[1.1]
+# ----
+
+# in postgres this becomes $."a"[1000000000]
+# parse
+# $.abc[1e9]
+# ----
+
+# parse
+# $.abc[0.0]
+# ----
+
+# postgres allows negatives as array indexes
+# parse
+# $.abc[-0]
+# ----
+
+# parse
+# $.abc[-1.99]
+# ----
+
 # parse
 # $.1a
 # ----
-# $.1a

--- a/pkg/util/jsonpath/parser/testdata/jsonpath
+++ b/pkg/util/jsonpath/parser/testdata/jsonpath
@@ -217,6 +217,21 @@ $.abc[5 to 5]
 ----
 $."abc"[5 to 5] -- normalized!
 
+parse
+$.abc[1, 2, 3]
+----
+$."abc"[1,2,3] -- normalized!
+
+parse
+$.abc[1 to 3, 4 to 3, 5, 9 to 7]
+----
+$."abc"[1 to 3,4 to 3,5,9 to 7] -- normalized!
+
+parse
+$.abc[  1    to    3   , 4 to 3, 5  , 9     to 7]
+----
+$."abc"[1 to 3,4 to 3,5,9 to 7] -- normalized!
+
 # postgres allows floats as array indexes
 # parse
 # $.abc[1.0]

--- a/pkg/util/jsonpath/parser/testdata/jsonpath
+++ b/pkg/util/jsonpath/parser/testdata/jsonpath
@@ -101,11 +101,11 @@ $.a$
    ^
 
 error
-$.a$a
+$.a$b
 ----
-at or near "$": syntax error
+at or near "b": syntax error
 DETAIL: source SQL:
-$.a$a
+$.a$b
    ^
 
 parse
@@ -162,7 +162,32 @@ DETAIL: source SQL:
 $.2e
   ^
 
-#  parse
-#  $.1a
-#  ----
-#  $.1a
+parse
+$var
+----
+$"var" -- normalized!
+
+parse
+$1a
+----
+$"1a" -- normalized!
+
+parse
+$2e
+----
+$"2e" -- normalized!
+
+parse
+$"1a"
+----
+$"1a"
+
+parse
+$"2e"
+----
+$"2e"
+
+# parse
+# $.1a
+# ----
+# $.1a

--- a/pkg/util/jsonpath/parser/testdata/jsonpath
+++ b/pkg/util/jsonpath/parser/testdata/jsonpath
@@ -202,6 +202,21 @@ $.abc[213].def[23198]
 ----
 $."abc"[213]."def"[23198] -- normalized!
 
+parse
+$.abc[1 to 2]
+----
+$."abc"[1 to 2] -- normalized!
+
+parse
+$.abc[4 to 1]
+----
+$."abc"[4 to 1] -- normalized!
+
+parse
+$.abc[5 to 5]
+----
+$."abc"[5 to 5] -- normalized!
+
 # postgres allows floats as array indexes
 # parse
 # $.abc[1.0]

--- a/pkg/util/jsonpath/parser/testdata/jsonpath
+++ b/pkg/util/jsonpath/parser/testdata/jsonpath
@@ -139,7 +139,25 @@ $.mLmTGLKZsrNL.ZawfwNmnfbFoRsISbQXD[*].JgTODFNN
 ----
 $.mLmTGLKZsrNL.ZawfwNmnfbFoRsISbQXD[*].JgTODFNN
 
-# parse
-# $.1a
-# ----
-# $.1a
+parse
+$."1a"
+----
+$.1a -- normalized!
+
+parse
+$."2e"
+----
+$.2e -- normalized!
+
+error
+$.2e
+----
+at or near "2": syntax error
+DETAIL: source SQL:
+$.2e
+  ^
+
+#  parse
+#  $.1a
+#  ----
+#  $.1a

--- a/pkg/util/jsonpath/parser/testdata/jsonpath
+++ b/pkg/util/jsonpath/parser/testdata/jsonpath
@@ -23,27 +23,27 @@ $
 parse
 $.abc
 ----
-$.abc
+$."abc" -- normalized!
 
 parse
 $.a.b.c.d.e.f.g.h.i.j.k.l.m.n.o.p.q.r.s.t.u.v.w.x.y.z
 ----
-$.a.b.c.d.e.f.g.h.i.j.k.l.m.n.o.p.q.r.s.t.u.v.w.x.y.z
+$."a"."b"."c"."d"."e"."f"."g"."h"."i"."j"."k"."l"."m"."n"."o"."p"."q"."r"."s"."t"."u"."v"."w"."x"."y"."z" -- normalized!
 
 parse
    $ .a .b . c
 ----
-$.a.b.c -- normalized!
+$."a"."b"."c" -- normalized!
 
 parse
 $.a[*].b.c[*]
 ----
-$.a[*].b.c[*]
+$."a"[*]."b"."c"[*] -- normalized!
 
 parse
   $  .  a  [  *  ] .  bcd
 ----
-$.a[*].bcd -- normalized!
+$."a"[*]."bcd" -- normalized!
 
 error
 $.a[
@@ -74,7 +74,7 @@ $ -- normalized!
 parse
 strict $.strict.lax
 ----
-strict $.strict.lax
+strict $."strict"."lax" -- normalized!
 
 error
 strict lax $.strict.lax
@@ -109,9 +109,14 @@ $.a$a
    ^
 
 parse
+$."a$b"
+----
+$."a$b"
+
+parse
 $.a1
 ----
-$.a1
+$."a1" -- normalized!
 
 error
 word $
@@ -132,22 +137,22 @@ $.1e
 parse
 $.abc.ABC
 ----
-$.abc.ABC
+$."abc"."ABC" -- normalized!
 
 parse
 $.mLmTGLKZsrNL.ZawfwNmnfbFoRsISbQXD[*].JgTODFNN
 ----
-$.mLmTGLKZsrNL.ZawfwNmnfbFoRsISbQXD[*].JgTODFNN
+$."mLmTGLKZsrNL"."ZawfwNmnfbFoRsISbQXD"[*]."JgTODFNN" -- normalized!
 
 parse
 $."1a"
 ----
-$.1a -- normalized!
+$."1a"
 
 parse
 $."2e"
 ----
-$.2e -- normalized!
+$."2e"
 
 error
 $.2e


### PR DESCRIPTION
This PR adds a bunch of small changes to the jsonpath parser.
- The AST is refactored so that the nodes satisfy one interface
- Key accessors are now wrapped in double quotes to emulate postgres
- Add support for variables to be parsed within jsonpath queries
- Refactored `scanner.scanNumber` so sql and plpgsql scanners can use the same logic
- Add support for array indexes to be parsed within jsonpath queries
- Add support for array ranges to be parsed within jsonpath queries
- Add support for array unions to be parsed within jsonpath queries

Epic: None
Release note (sql change): Add support for variables, array indexing within jsonpath parser.