### PR TITLE
sql: unify "distribution" in EXPLAIN and EXPLAIN ANALYZE

### DIFF
--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -2963,8 +2963,6 @@ func (ex *connExecutor) dispatchToExecutionEngine(
 		planner.curPlan.flags.Set(planFlagFullyDistributed)
 	case physicalplan.PartiallyDistributedPlan:
 		planner.curPlan.flags.Set(planFlagPartiallyDistributed)
-	default:
-		planner.curPlan.flags.Set(planFlagNotDistributed)
 	}
 
 	ex.sessionTracing.TraceRetryInformation(ctx, int(ex.state.mu.autoRetryCounter), ex.state.mu.autoRetryReason)

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -1097,7 +1097,7 @@ func getDefaultSaveFlowsFunc(
 		var explainVecVerbose []string
 		if planner.instrumentation.collectBundle && vectorized {
 			flowCtx := newFlowCtxForExplainPurposes(ctx, planner)
-			flowCtx.Local = !planner.curPlan.flags.IsDistributed()
+			flowCtx.Local = !planner.curPlan.flags.ShouldBeDistributed()
 			getExplain := func(verbose bool) []string {
 				gatewaySQLInstanceID := planner.extendedEvalCtx.DistSQLPlanner.gatewaySQLInstanceID
 				// When we're collecting the bundle, we're always recording the

--- a/pkg/sql/executor_statement_metrics.go
+++ b/pkg/sql/executor_statement_metrics.go
@@ -156,7 +156,7 @@ func (ex *connExecutor) recordStatementSummary(
 	recordedStmtStatsKey := appstatspb.StatementStatisticsKey{
 		Query:        stmt.StmtNoConstants,
 		QuerySummary: stmt.StmtSummary,
-		DistSQL:      flags.IsDistributed(),
+		DistSQL:      flags.ShouldBeDistributed(),
 		Vec:          flags.IsSet(planFlagVectorized),
 		ImplicitTxn:  flags.IsSet(planFlagImplicitTxn),
 		FullScan:     fullScan,
@@ -302,7 +302,7 @@ func (ex *connExecutor) recordStatementLatencyMetrics(
 
 		m.StatementFingerprintCount.Add([]byte(stmt.StmtNoConstants))
 
-		if flags.IsDistributed() {
+		if flags.ShouldBeDistributed() {
 			if _, ok := stmt.AST.(*tree.Select); ok {
 				m.DistSQLSelectCount.Inc(1)
 				if flags.IsSet(planFlagDistributedExecution) {

--- a/pkg/sql/explain_test.go
+++ b/pkg/sql/explain_test.go
@@ -348,7 +348,7 @@ func TestExplainKVInfo(t *testing.T) {
 			}
 
 			scanQuery := "SELECT count(*) FROM ab"
-			info := getKVInfo(t, r, scanQuery)
+			info, fullOutput := getKVInfo(t, r, scanQuery)
 
 			assert.Equal(t, 1, info.counters[kvNodes])
 			assert.Equal(t, 1000, info.counters[rowsRead])
@@ -357,9 +357,14 @@ func TestExplainKVInfo(t *testing.T) {
 			assert.Equal(t, 1, info.counters[gRPCCalls])
 			assert.Equal(t, 1000, info.counters[stepCount])
 			assert.Equal(t, 1, info.counters[seekCount])
+			// Additionally assert that correct distribution is shown.
+			assert.Truef(
+				t, strings.Contains(fullOutput, "distribution: local"),
+				"expected local distribution, found\n\n%s", fullOutput,
+			)
 
 			lookupJoinQuery := "SELECT count(*) FROM ab INNER LOOKUP JOIN bc ON ab.b = bc.b"
-			info = getKVInfo(t, r, lookupJoinQuery)
+			info, fullOutput = getKVInfo(t, r, lookupJoinQuery)
 
 			assert.Equal(t, 1, info.counters[kvNodes])
 			assert.Equal(t, 1000, info.counters[rowsRead])
@@ -368,6 +373,10 @@ func TestExplainKVInfo(t *testing.T) {
 			assert.Equal(t, 1, info.counters[gRPCCalls])
 			assert.Equal(t, 0, info.counters[stepCount])
 			assert.Equal(t, 1000, info.counters[seekCount])
+			assert.Truef(
+				t, strings.Contains(fullOutput, "distribution: local"),
+				"expected local distribution\n\n%s", fullOutput,
+			)
 		}
 	}
 }
@@ -405,7 +414,10 @@ func init() {
 // of the given query from the top-most operator in the plan (i.e. if there are
 // multiple operators exposing the scan stats, then the first info that appears
 // in the EXPLAIN output is used).
-func getKVInfo(t *testing.T, r *sqlutils.SQLRunner, query string) kvInfo {
+//
+// It additionally returns the full output of EXPLAIN ANALYZE of the given
+// query.
+func getKVInfo(t *testing.T, r *sqlutils.SQLRunner, query string) (_ kvInfo, fullOutput string) {
 	rows := r.Query(t, "EXPLAIN ANALYZE (VERBOSE) "+query)
 	var output strings.Builder
 	var str string
@@ -441,7 +453,7 @@ func getKVInfo(t *testing.T, r *sqlutils.SQLRunner, query string) kvInfo {
 		fmt.Println("Explain output:")
 		fmt.Println(output.String())
 	}
-	return info
+	return info, output.String()
 }
 
 // TestExplainAnalyzeWarnings verifies that warnings are printed whenever the

--- a/pkg/sql/testdata/telemetry_logging/logging/force_logging
+++ b/pkg/sql/testdata/telemetry_logging/logging/force_logging
@@ -31,7 +31,7 @@ SELECT * FROM t LIMIT 1;
 {
 	"ApplicationName": "telemetry-logging-datadriven",
 	"Database": "defaultdb",
-	"Distribution": "full",
+	"Distribution": "local",
 	"EventType": "sampled_query",
 	"PlanGist": "AgHQAQIAAAAAAg==",
 	"ScanCount": 1,
@@ -164,7 +164,7 @@ SELECT * FROM t LIMIT 1;
 {
 	"ApplicationName": "$ internal-console-app",
 	"Database": "defaultdb",
-	"Distribution": "full",
+	"Distribution": "local",
 	"EventType": "sampled_query",
 	"PlanGist": "AgHQAQIAAAAAAg==",
 	"ScanCount": 1,

--- a/pkg/sql/testdata/telemetry_logging/logging/transaction_mode
+++ b/pkg/sql/testdata/telemetry_logging/logging/transaction_mode
@@ -208,7 +208,7 @@ SELECT * FROM t LIMIT 2
 {
 	"ApplicationName": "telemetry-logging-datadriven",
 	"Database": "defaultdb",
-	"Distribution": "full",
+	"Distribution": "local",
 	"EventType": "sampled_query",
 	"PlanGist": "AgHQAQQAAAAAAg==",
 	"ScanCount": 1,
@@ -246,7 +246,7 @@ BEGIN; SELECT * FROM t LIMIT 4; SELECT * FROM t LIMIT 5; COMMIT
 {
 	"ApplicationName": "telemetry-logging-datadriven",
 	"Database": "defaultdb",
-	"Distribution": "full",
+	"Distribution": "local",
 	"EventType": "sampled_query",
 	"PlanGist": "AgHQAQQAAAAAAg==",
 	"ScanCount": 1,
@@ -260,7 +260,7 @@ BEGIN; SELECT * FROM t LIMIT 4; SELECT * FROM t LIMIT 5; COMMIT
 {
 	"ApplicationName": "telemetry-logging-datadriven",
 	"Database": "defaultdb",
-	"Distribution": "full",
+	"Distribution": "local",
 	"EventType": "sampled_query",
 	"PlanGist": "AgHQAQQAAAAAAg==",
 	"ScanCount": 1,


### PR DESCRIPTION
Previously, it was possible to observe different `distribution` property between EXPLAIN and EXPLAIN ANALYZE output of the same query. The reason for that was that in the former we looked at the physical plan's distribution which indicates whether the physical plan is actually local or not, whereas for EXPLAIN ANALYZE we looked at presence of some plan flags which indicate the _recommendation_ about the physical plan, and the actual physical plan depends on the range placement. Concretely, it was possible to show `distribution: full` in the output of EXPLAIN ANALYZE when we only had a single flow on the gateway. This commit fixes that and unifies two EXPLAIN variants.

It also removes `planFlagNotDistributed` plan flag since it's not used anywhere.

Fixes: #128623.

Release note (bug fix): EXPLAIN ANALYZE output could previously incorrectly show `distribution: full` when the physical plan only ran on the gateway node in some cases (meaning it should've shown `distribution: local`), and this is now fixed. Note that "vanilla" EXPLAIN showed the correct information. The bug has been present since before 23.1 version.