### PR TITLE
sql: optimize locking behavior of delete portion of UPDATEs and UPSERTs

### DIFF
--- a/pkg/crosscluster/logical/lww_kv_processor.go
+++ b/pkg/crosscluster/logical/lww_kv_processor.go
@@ -429,7 +429,7 @@ func newKVTableWriter(
 	}
 	rd := row.MakeDeleter(evalCtx.Codec, tableDesc, nil /* lockedIndexes */, readCols, &evalCtx.Settings.SV, internal, nil)
 	ru, err := row.MakeUpdater(
-		ctx, nil, evalCtx.Codec, tableDesc, nil /* uniqueWithTombstoneIndexes */, readCols, writeCols, row.UpdaterDefault, a, &evalCtx.Settings.SV, internal, nil,
+		ctx, nil, evalCtx.Codec, tableDesc, nil /* uniqueWithTombstoneIndexes */, nil /* lockedIndexes */, readCols, writeCols, row.UpdaterDefault, a, &evalCtx.Settings.SV, internal, nil,
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/sql/backfill/backfill.go
+++ b/pkg/sql/backfill/backfill.go
@@ -301,6 +301,7 @@ func (cb *ColumnBackfiller) RunColumnBackfillChunk(
 		cb.evalCtx.Codec,
 		tableDesc,
 		nil, /* uniqueWithTombstoneIndexes */
+		nil, /* lockedIndexes */
 		cb.updateCols,
 		requestedCols,
 		row.UpdaterOnlyColumns,

--- a/pkg/sql/delete_range.go
+++ b/pkg/sql/delete_range.go
@@ -176,8 +176,6 @@ func (d *deleteRangeNode) deleteSpans(params runParams, b *kv.Batch, spans roach
 			// explicitly.
 			// - if buffered writes are disabled, then the KV layer will write
 			// an intent which acts as a lock.
-			// TODO(yuzefovich): add a tracing test to ensure that the lock is
-			// acquired here once the interceptor is updated.
 			b.DelMustAcquireExclusiveLock(span.Key)
 		} else {
 			if traceKV {

--- a/pkg/sql/distsql_spec_exec_factory.go
+++ b/pkg/sql/distsql_spec_exec_factory.go
@@ -1403,6 +1403,7 @@ func (e *distSQLSpecExecFactory) ConstructUpdate(
 	checks exec.CheckOrdinalSet,
 	passthrough colinfo.ResultColumns,
 	uniqueWithTombstoneIndexes cat.IndexOrdinals,
+	lockedIndexes cat.IndexOrdinals,
 	autoCommit bool,
 ) (exec.Node, error) {
 	return nil, unimplemented.NewWithIssue(47473, "experimental opt-driven distsql planning: update")
@@ -1420,6 +1421,7 @@ func (e *distSQLSpecExecFactory) ConstructUpsert(
 	returnCols exec.TableColumnOrdinalSet,
 	checks exec.CheckOrdinalSet,
 	uniqueWithTombstoneIndexes cat.IndexOrdinals,
+	lockedIndexes cat.IndexOrdinals,
 	autoCommit bool,
 ) (exec.Node, error) {
 	return nil, unimplemented.NewWithIssue(47473, "experimental opt-driven distsql planning: upsert")

--- a/pkg/sql/opt/exec/execbuilder/mutation.go
+++ b/pkg/sql/opt/exec/execbuilder/mutation.go
@@ -433,8 +433,7 @@ func (b *Builder) buildUpdate(upd *memo.UpdateExpr) (_ execPlan, outputCols colO
 		upd.VectorIndexDelPartitionCols,
 	)
 
-	// TODO(yuzefovich): use lockedIndexes to optimize locking behavior.
-	input, _, err := b.buildMutationInput(upd, upd.Input, colList, &upd.MutationPrivate)
+	input, lockedIndexes, err := b.buildMutationInput(upd, upd.Input, colList, &upd.MutationPrivate)
 	if err != nil {
 		return execPlan{}, colOrdMap{}, err
 	}
@@ -465,6 +464,7 @@ func (b *Builder) buildUpdate(upd *memo.UpdateExpr) (_ execPlan, outputCols colO
 		checkOrds,
 		passthroughCols,
 		upd.UniqueWithTombstoneIndexes,
+		lockedIndexes,
 		b.allowAutoCommit && len(upd.UniqueChecks) == 0 &&
 			len(upd.FKChecks) == 0 && len(upd.FKCascades) == 0 && upd.AfterTriggers == nil,
 	)
@@ -508,8 +508,7 @@ func (b *Builder) buildUpsert(ups *memo.UpsertExpr) (_ execPlan, outputCols colO
 		ups.VectorIndexDelPartitionCols,
 	)
 
-	// TODO(yuzefovich): use lockedIndexes to optimize locking behavior.
-	input, _, err := b.buildMutationInput(ups, ups.Input, colList, &ups.MutationPrivate)
+	input, lockedIndexes, err := b.buildMutationInput(ups, ups.Input, colList, &ups.MutationPrivate)
 	if err != nil {
 		return execPlan{}, colOrdMap{}, err
 	}
@@ -545,6 +544,7 @@ func (b *Builder) buildUpsert(ups *memo.UpsertExpr) (_ execPlan, outputCols colO
 		returnColOrds,
 		checkOrds,
 		ups.UniqueWithTombstoneIndexes,
+		lockedIndexes,
 		b.allowAutoCommit && len(ups.UniqueChecks) == 0 &&
 			len(ups.FKChecks) == 0 && len(ups.FKCascades) == 0 && ups.AfterTriggers == nil,
 	)

--- a/pkg/sql/opt/exec/execbuilder/testdata/cascade
+++ b/pkg/sql/opt/exec/execbuilder/testdata/cascade
@@ -172,7 +172,7 @@ SELECT message FROM [SHOW TRACE FOR SESSION]
 WHERE message LIKE '%executing cascade %' OR message LIKE 'Del%' OR message LIKE 'CPut%' OR message LIKE 'Scan%updated%'
 ----
 Scan /Table/112/1/"updated"/0 lock Exclusive (Block, Unreplicated)
-Del (locking) /Table/112/1/"updated"/0
+Del /Table/112/1/"updated"/0
 CPut /Table/112/1/"latest"/0 -> /TUPLE/
 executing cascade for constraint b1_update_cascade_fkey
 Scan /Table/113/2/"updated"/0
@@ -384,7 +384,7 @@ SELECT message FROM [SHOW TRACE FOR SESSION]
 WHERE message LIKE '%executing cascade %' OR message LIKE 'Del%' OR message LIKE 'CPut%' OR message LIKE 'Scan%original%'
 ----
 Scan /Table/129/1/"original"/0 lock Exclusive (Block, Unreplicated)
-Del (locking) /Table/129/1/"original"/0
+Del /Table/129/1/"original"/0
 CPut /Table/129/1/"updated"/0 -> /TUPLE/
 executing cascade for constraint b1_update_set_null_fkey
 executing cascade for constraint b2_update_set_null_fkey
@@ -466,7 +466,7 @@ SELECT message FROM [SHOW TRACE FOR SESSION]
 WHERE message LIKE '%executing cascade %' OR message LIKE 'Del%' OR message LIKE 'CPut%' OR message LIKE 'Scan%original%'
 ----
 Scan /Table/134/1/"original"/0 lock Exclusive (Block, Unreplicated)
-Del (locking) /Table/134/1/"original"/0
+Del /Table/134/1/"original"/0
 CPut /Table/134/1/"updated"/0 -> /TUPLE/
 executing cascade for constraint b1_update_cascade_fkey
 Scan /Table/135/2/"original"/0
@@ -677,7 +677,7 @@ SELECT message FROM [SHOW TRACE FOR SESSION]
 WHERE message LIKE '%executing cascade %' OR message LIKE 'Del%' OR message LIKE 'CPut%' OR message LIKE 'Scan%original%'
 ----
 Scan /Table/151/1/"original"/0 lock Exclusive (Block, Unreplicated)
-Del (locking) /Table/151/1/"original"/0
+Del /Table/151/1/"original"/0
 CPut /Table/151/1/"updated"/0 -> /TUPLE/
 executing cascade for constraint b1_update_set_null_fkey
 executing cascade for constraint b2_update_set_null_fkey
@@ -759,7 +759,7 @@ SELECT message FROM [SHOW TRACE FOR SESSION]
 WHERE message LIKE '%executing cascade %' OR message LIKE 'Del%' OR message LIKE 'CPut%' OR message LIKE 'Scan%original%'
 ----
 Scan /Table/156/1/"original"/0 lock Exclusive (Block, Unreplicated)
-Del (locking) /Table/156/1/"original"/0
+Del /Table/156/1/"original"/0
 CPut /Table/156/1/"updated"/0 -> /TUPLE/
 executing cascade for constraint b1_update_cascade_fkey
 Scan /Table/157/2/"original"/0

--- a/pkg/sql/opt/exec/execbuilder/testdata/delete
+++ b/pkg/sql/opt/exec/execbuilder/testdata/delete
@@ -795,3 +795,26 @@ Scan /Table/115/{1-2}
 Del /Table/115/2/2/1/0
 Del (locking) /Table/115/3/3/0
 Del (locking) /Table/115/1/1/0
+
+statement ok
+CREATE TABLE t139105 (k INT PRIMARY KEY, v INT, FAMILY (k, v));
+
+statement ok
+INSERT INTO t139160 VALUES (1, 2);
+
+query T
+EXPLAIN DELETE FROM t139105 WHERE k = 1
+----
+distribution: local
+vectorized: true
+·
+• delete range
+  from: t139105
+  auto commit
+  spans: [/1 - /1]
+
+# Delete fast-path - we need locking Del.
+query T kvtrace
+DELETE FROM t139105 WHERE k = 1
+----
+Del (locking) /Table/116/1/1/0

--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
@@ -90,7 +90,7 @@ UPDATE d SET b=NULL WHERE a=4
 ----
 Scan /Table/106/1/4/0 lock Exclusive (Block, Unreplicated)
 Put /Table/106/1/4/0 -> /TUPLE/
-Del (locking) /Table/106/2/Arr/1/4/0
+Del /Table/106/2/Arr/1/4/0
 
 # Deleting a null shouldn't remove anything from the inv idx.
 query T kvtrace
@@ -226,7 +226,7 @@ UPDATE f SET b = ARRAY[0,15,7,10] WHERE a = 0
 ----
 Scan /Table/108/1/0/0 lock Exclusive (Block, Unreplicated)
 Put /Table/108/1/0/0 -> /TUPLE/2:2:Array/ARRAY[0,15,7,10]
-Del (locking) /Table/108/2/1/0/0
+Del /Table/108/2/1/0/0
 CPut /Table/108/2/15/0/0 -> /BYTES/
 
 statement error pgcode XXUUU could not produce a query plan conforming to the FORCE_INVERTED_INDEX hint

--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_index_multi_column
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_index_multi_column
@@ -103,8 +103,8 @@ UPDATE t SET j = NULL WHERE k = 4
 ----
 Scan /Table/106/1/4/0 lock Exclusive (Block, Unreplicated)
 Put /Table/106/1/4/0 -> /TUPLE/2:2:Int/333/1:3:Bytes/foo
-Del (locking) /Table/106/2/333/Arr/1/4/0
-Del (locking) /Table/106/3/333/"foo"/Arr/1/4/0
+Del /Table/106/2/333/Arr/1/4/0
+Del /Table/106/3/333/"foo"/Arr/1/4/0
 
 # Deleting a NULL shouldn't remove anything from the inv idx.
 query T kvtrace
@@ -127,9 +127,9 @@ UPDATE t SET i = 333 WHERE k = 5
 ----
 Scan /Table/106/1/5/0 lock Exclusive (Block, Unreplicated)
 Put /Table/106/1/5/0 -> /TUPLE/2:2:Int/333/1:3:Bytes/foo/1:4:SentinelType/{"a": "b"}
-Del (locking) /Table/106/2/NULL/"a"/"b"/5/0
+Del /Table/106/2/NULL/"a"/"b"/5/0
 CPut /Table/106/2/333/"a"/"b"/5/0 -> /BYTES/
-Del (locking) /Table/106/3/NULL/"foo"/"a"/"b"/5/0
+Del /Table/106/3/NULL/"foo"/"a"/"b"/5/0
 CPut /Table/106/3/333/"foo"/"a"/"b"/5/0 -> /BYTES/
 
 # Update back to NULL.
@@ -138,9 +138,9 @@ UPDATE t SET i = NULL WHERE k = 5
 ----
 Scan /Table/106/1/5/0 lock Exclusive (Block, Unreplicated)
 Put /Table/106/1/5/0 -> /TUPLE/3:3:Bytes/foo/1:4:SentinelType/{"a": "b"}
-Del (locking) /Table/106/2/333/"a"/"b"/5/0
+Del /Table/106/2/333/"a"/"b"/5/0
 CPut /Table/106/2/NULL/"a"/"b"/5/0 -> /BYTES/
-Del (locking) /Table/106/3/333/"foo"/"a"/"b"/5/0
+Del /Table/106/3/333/"foo"/"a"/"b"/5/0
 CPut /Table/106/3/NULL/"foo"/"a"/"b"/5/0 -> /BYTES/
 
 # Delete row with NULL non-inverted row.

--- a/pkg/sql/opt/exec/execbuilder/testdata/partial_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/partial_index
@@ -342,7 +342,7 @@ UPDATE t SET b = 11 WHERE a = 5
 ----
 Scan /Table/112/1/5/0 lock Exclusive (Block, Unreplicated)
 Put /Table/112/1/5/0 -> /TUPLE/2:2:Int/11/1:3:Bytes/baz
-Del (locking) /Table/112/2/4/5/0
+Del /Table/112/2/4/5/0
 CPut /Table/112/2/11/5/0 -> /BYTES/
 CPut /Table/112/3/11/5/0 -> /BYTES/
 
@@ -361,9 +361,9 @@ UPDATE t SET b = 12 WHERE a = 6
 ----
 Scan /Table/112/1/6/0 lock Exclusive (Block, Unreplicated)
 Put /Table/112/1/6/0 -> /TUPLE/2:2:Int/12/1:3:Bytes/baz
-Del (locking) /Table/112/2/11/6/0
+Del /Table/112/2/11/6/0
 CPut /Table/112/2/12/6/0 -> /BYTES/
-Del (locking) /Table/112/3/11/6/0
+Del /Table/112/3/11/6/0
 CPut /Table/112/3/12/6/0 -> /BYTES/
 
 # Update a row that matches the first partial index before the update, but does
@@ -373,9 +373,9 @@ UPDATE t SET b = 9 WHERE a = 6
 ----
 Scan /Table/112/1/6/0 lock Exclusive (Block, Unreplicated)
 Put /Table/112/1/6/0 -> /TUPLE/2:2:Int/9/1:3:Bytes/baz
-Del (locking) /Table/112/2/12/6/0
+Del /Table/112/2/12/6/0
 CPut /Table/112/2/9/6/0 -> /BYTES/
-Del (locking) /Table/112/3/12/6/0
+Del /Table/112/3/12/6/0
 
 # Update a row that matches both partial indexes before the update, the first
 # partial index entry needs to be updated, and the second needs to be deleted.
@@ -384,11 +384,11 @@ UPDATE t SET c = 'baz', b = 12 WHERE a = 13
 ----
 Scan /Table/112/1/13/0 lock Exclusive (Block, Unreplicated)
 Put /Table/112/1/13/0 -> /TUPLE/2:2:Int/12/1:3:Bytes/baz
-Del (locking) /Table/112/2/11/13/0
+Del /Table/112/2/11/13/0
 CPut /Table/112/2/12/13/0 -> /BYTES/
-Del (locking) /Table/112/3/11/13/0
+Del /Table/112/3/11/13/0
 CPut /Table/112/3/12/13/0 -> /BYTES/
-Del (locking) /Table/112/4/"foo"/13/0
+Del /Table/112/4/"foo"/13/0
 
 # Reversing the previous update should reverse the partial index changes.
 query T kvtrace
@@ -396,9 +396,9 @@ UPDATE t SET c = 'foo', b = 11 WHERE a = 13
 ----
 Scan /Table/112/1/13/0 lock Exclusive (Block, Unreplicated)
 Put /Table/112/1/13/0 -> /TUPLE/2:2:Int/11/1:3:Bytes/foo
-Del (locking) /Table/112/2/12/13/0
+Del /Table/112/2/12/13/0
 CPut /Table/112/2/11/13/0 -> /BYTES/
-Del (locking) /Table/112/3/12/13/0
+Del /Table/112/3/12/13/0
 CPut /Table/112/3/11/13/0 -> /BYTES/
 CPut /Table/112/4/"foo"/13/0 -> /BYTES/
 
@@ -421,7 +421,7 @@ UPDATE u SET v = 3 WHERE k = 1
 ----
 Scan /Table/113/1/1/0 lock Exclusive (Block, Unreplicated)
 Put /Table/113/1/1/0 -> /TUPLE/2:2:Int/2/1:3:Int/3
-Del (locking) /Table/113/2/2/1/0
+Del /Table/113/2/2/1/0
 
 # ---------------------------------------------------------
 # UPDATE primary key
@@ -439,7 +439,7 @@ UPDATE t SET a = 21 WHERE a = 20
 Scan /Table/112/1/20/0 lock Exclusive (Block, Unreplicated)
 Del /Table/112/2/11/20/0
 Del /Table/112/3/11/20/0
-Del (locking) /Table/112/1/20/0
+Del /Table/112/1/20/0
 CPut /Table/112/1/21/0 -> /TUPLE/2:2:Int/11/1:3:Bytes/bar
 CPut /Table/112/2/11/21/0 -> /BYTES/
 CPut /Table/112/3/11/21/0 -> /BYTES/
@@ -453,7 +453,7 @@ UPDATE t SET a = 22, b = 9, c = 'foo' WHERE a = 21
 Scan /Table/112/1/21/0 lock Exclusive (Block, Unreplicated)
 Del /Table/112/2/11/21/0
 Del /Table/112/3/11/21/0
-Del (locking) /Table/112/1/21/0
+Del /Table/112/1/21/0
 CPut /Table/112/1/22/0 -> /TUPLE/2:2:Int/9/1:3:Bytes/foo
 CPut /Table/112/2/9/22/0 -> /BYTES/
 CPut /Table/112/4/"foo"/22/0 -> /BYTES/
@@ -571,7 +571,7 @@ INSERT INTO t VALUES (5, 3, 'foo') ON CONFLICT (a) DO UPDATE SET b = 3
 ----
 Scan /Table/112/1/5/0 lock Exclusive (Block, Unreplicated)
 Put /Table/112/1/5/0 -> /TUPLE/2:2:Int/3/1:3:Bytes/bar
-Del (locking) /Table/112/2/4/5/0
+Del /Table/112/2/4/5/0
 CPut /Table/112/2/3/5/0 -> /BYTES/
 
 # Insert a conflicting row that does not match the first partial index
@@ -581,7 +581,7 @@ INSERT INTO t VALUES (5, 7, 'foo') ON CONFLICT (a) DO UPDATE SET b = 11
 ----
 Scan /Table/112/1/5/0 lock Exclusive (Block, Unreplicated)
 Put /Table/112/1/5/0 -> /TUPLE/2:2:Int/11/1:3:Bytes/bar
-Del (locking) /Table/112/2/3/5/0
+Del /Table/112/2/3/5/0
 CPut /Table/112/2/11/5/0 -> /BYTES/
 CPut /Table/112/3/11/5/0 -> /BYTES/
 
@@ -593,9 +593,9 @@ INSERT INTO t VALUES (5, 11, 'bar') ON CONFLICT (a) DO UPDATE SET b = 4, c = 'fo
 ----
 Scan /Table/112/1/5/0 lock Exclusive (Block, Unreplicated)
 Put /Table/112/1/5/0 -> /TUPLE/2:2:Int/4/1:3:Bytes/foo
-Del (locking) /Table/112/2/11/5/0
+Del /Table/112/2/11/5/0
 CPut /Table/112/2/4/5/0 -> /BYTES/
-Del (locking) /Table/112/3/11/5/0
+Del /Table/112/3/11/5/0
 CPut /Table/112/4/"foo"/5/0 -> /BYTES/
 
 # Insert a conflicting row that that matches the second partial index before and
@@ -605,7 +605,7 @@ INSERT INTO t VALUES (5, 11, 'bar') ON CONFLICT (a) DO UPDATE SET b = 3
 ----
 Scan /Table/112/1/5/0 lock Exclusive (Block, Unreplicated)
 Put /Table/112/1/5/0 -> /TUPLE/2:2:Int/3/1:3:Bytes/foo
-Del (locking) /Table/112/2/4/5/0
+Del /Table/112/2/4/5/0
 CPut /Table/112/2/3/5/0 -> /BYTES/
 
 # Insert a conflicting row that that matches the second partial index before and
@@ -615,7 +615,7 @@ INSERT INTO t VALUES (5, 11, 'bar') ON CONFLICT (a) DO UPDATE SET c = 'foobar'
 ----
 Scan /Table/112/1/5/0 lock Exclusive (Block, Unreplicated)
 Put /Table/112/1/5/0 -> /TUPLE/2:2:Int/3/1:3:Bytes/foobar
-Del (locking) /Table/112/4/"foo"/5/0
+Del /Table/112/4/"foo"/5/0
 CPut /Table/112/4/"foobar"/5/0 -> /BYTES/
 
 # Insert a non-conflicting row that matches the first partial index.
@@ -659,7 +659,7 @@ INSERT INTO u VALUES (2, 3, 11) ON CONFLICT (k) DO UPDATE SET u = 4, v = 12
 ----
 Scan /Table/113/1/2/0 lock Exclusive (Block, Unreplicated)
 Put /Table/113/1/2/0 -> /TUPLE/2:2:Int/4/1:3:Int/12
-Del (locking) /Table/113/2/3/2/0
+Del /Table/113/2/3/2/0
 CPut /Table/113/2/4/2/0 -> /BYTES/
 
 # ---------------------------------------------------------
@@ -688,7 +688,7 @@ INSERT INTO t VALUES (5, 3, 'baz') ON CONFLICT (a) DO UPDATE SET a = 6
 ----
 Scan /Table/112/1/5/0 lock Exclusive (Block, Unreplicated)
 Del /Table/112/2/4/5/0
-Del (locking) /Table/112/1/5/0
+Del /Table/112/1/5/0
 CPut /Table/112/1/6/0 -> /TUPLE/2:2:Int/4/1:3:Bytes/bar
 CPut /Table/112/2/4/6/0 -> /BYTES/
 
@@ -699,7 +699,7 @@ INSERT INTO t VALUES (6, 3, 'bar') ON CONFLICT (a) DO UPDATE SET a = 7, c = 'foo
 ----
 Scan /Table/112/1/6/0 lock Exclusive (Block, Unreplicated)
 Del /Table/112/2/4/6/0
-Del (locking) /Table/112/1/6/0
+Del /Table/112/1/6/0
 CPut /Table/112/1/7/0 -> /TUPLE/2:2:Int/4/1:3:Bytes/foo
 CPut /Table/112/2/4/7/0 -> /BYTES/
 CPut /Table/112/4/"foo"/7/0 -> /BYTES/
@@ -713,7 +713,7 @@ INSERT INTO t VALUES (7, 3, 'bar') ON CONFLICT (a) DO UPDATE SET a = 8, b = 11
 Scan /Table/112/1/7/0 lock Exclusive (Block, Unreplicated)
 Del /Table/112/2/4/7/0
 Del /Table/112/4/"foo"/7/0
-Del (locking) /Table/112/1/7/0
+Del /Table/112/1/7/0
 CPut /Table/112/1/8/0 -> /TUPLE/2:2:Int/11/1:3:Bytes/foo
 CPut /Table/112/2/11/8/0 -> /BYTES/
 CPut /Table/112/3/11/8/0 -> /BYTES/
@@ -726,7 +726,7 @@ INSERT INTO t VALUES (8, 4, 'bar') ON CONFLICT (a) DO UPDATE SET a = 9, c = 'foo
 Scan /Table/112/1/8/0 lock Exclusive (Block, Unreplicated)
 Del /Table/112/2/11/8/0
 Del /Table/112/3/11/8/0
-Del (locking) /Table/112/1/8/0
+Del /Table/112/1/8/0
 CPut /Table/112/1/9/0 -> /TUPLE/2:2:Int/11/1:3:Bytes/foobar
 CPut /Table/112/2/11/9/0 -> /BYTES/
 CPut /Table/112/3/11/9/0 -> /BYTES/
@@ -757,7 +757,7 @@ UPSERT INTO t VALUES (5, 3, 'bar')
 ----
 Scan /Table/112/1/5/0 lock Exclusive (Block, Unreplicated)
 Put /Table/112/1/5/0 -> /TUPLE/2:2:Int/3/1:3:Bytes/bar
-Del (locking) /Table/112/2/4/5/0
+Del /Table/112/2/4/5/0
 CPut /Table/112/2/3/5/0 -> /BYTES/
 
 # Upsert a conflicting row that does not match the first partial index before
@@ -767,7 +767,7 @@ UPSERT INTO t VALUES (5, 11, 'bar')
 ----
 Scan /Table/112/1/5/0 lock Exclusive (Block, Unreplicated)
 Put /Table/112/1/5/0 -> /TUPLE/2:2:Int/11/1:3:Bytes/bar
-Del (locking) /Table/112/2/3/5/0
+Del /Table/112/2/3/5/0
 CPut /Table/112/2/11/5/0 -> /BYTES/
 CPut /Table/112/3/11/5/0 -> /BYTES/
 
@@ -779,9 +779,9 @@ UPSERT INTO t VALUES (5, 3, 'foo')
 ----
 Scan /Table/112/1/5/0 lock Exclusive (Block, Unreplicated)
 Put /Table/112/1/5/0 -> /TUPLE/2:2:Int/3/1:3:Bytes/foo
-Del (locking) /Table/112/2/11/5/0
+Del /Table/112/2/11/5/0
 CPut /Table/112/2/3/5/0 -> /BYTES/
-Del (locking) /Table/112/3/11/5/0
+Del /Table/112/3/11/5/0
 CPut /Table/112/4/"foo"/5/0 -> /BYTES/
 
 # Upsert a conflicting row that that matches the second partial index before and
@@ -791,7 +791,7 @@ UPSERT INTO t VALUES (5, 4, 'foo')
 ----
 Scan /Table/112/1/5/0 lock Exclusive (Block, Unreplicated)
 Put /Table/112/1/5/0 -> /TUPLE/2:2:Int/4/1:3:Bytes/foo
-Del (locking) /Table/112/2/3/5/0
+Del /Table/112/2/3/5/0
 CPut /Table/112/2/4/5/0 -> /BYTES/
 
 # Upsert a conflicting row that that matches the second partial index before and
@@ -801,7 +801,7 @@ UPSERT INTO t VALUES (5, 4, 'foobar')
 ----
 Scan /Table/112/1/5/0 lock Exclusive (Block, Unreplicated)
 Put /Table/112/1/5/0 -> /TUPLE/2:2:Int/4/1:3:Bytes/foobar
-Del (locking) /Table/112/4/"foo"/5/0
+Del /Table/112/4/"foo"/5/0
 CPut /Table/112/4/"foobar"/5/0 -> /BYTES/
 
 # Upsert a non-conflicting row that matches the first partial index.
@@ -845,7 +845,7 @@ UPSERT INTO u VALUES (2, 4, 12)
 ----
 Scan /Table/113/1/2/0 lock Exclusive (Block, Unreplicated)
 Put /Table/113/1/2/0 -> /TUPLE/2:2:Int/4/1:3:Int/12
-Del (locking) /Table/113/2/3/2/0
+Del /Table/113/2/3/2/0
 CPut /Table/113/2/4/2/0 -> /BYTES/
 
 # Tests for partial inverted indexes.
@@ -922,7 +922,7 @@ UPDATE inv SET b = '{"x": "y", "num": 3}' WHERE a = 1
 ----
 Scan /Table/107/1/1/0 lock Exclusive (Block, Unreplicated)
 Put /Table/107/1/1/0 -> /TUPLE/2:2:SentinelType/{"num": 3, "x": "y"}/1:3:Bytes/bar
-Del (locking) /Table/107/2/"num"/1/1/0
+Del /Table/107/2/"num"/1/1/0
 CPut /Table/107/2/"num"/3/1/0 -> /BYTES/
 
 # Update a non-JSON column so that the row is removed from the partial index.
@@ -931,8 +931,8 @@ UPDATE inv SET c = 'fud' WHERE a = 1
 ----
 Scan /Table/107/1/1/0 lock Exclusive (Block, Unreplicated)
 Put /Table/107/1/1/0 -> /TUPLE/2:2:SentinelType/{"num": 3, "x": "y"}/1:3:Bytes/fud
-Del (locking) /Table/107/2/"num"/3/1/0
-Del (locking) /Table/107/2/"x"/"y"/1/0
+Del /Table/107/2/"num"/3/1/0
+Del /Table/107/2/"x"/"y"/1/0
 
 # Update a non-JSON column so that the row remains not in the partial index.
 query T kvtrace
@@ -964,7 +964,7 @@ UPDATE inv SET a = 4 WHERE a = 2
 Scan /Table/107/1/2/0 lock Exclusive (Block, Unreplicated)
 Del /Table/107/2/"num"/4/2/0
 Del /Table/107/2/"x"/"y"/2/0
-Del (locking) /Table/107/1/2/0
+Del /Table/107/1/2/0
 CPut /Table/107/1/4/0 -> /TUPLE/2:2:SentinelType/{"num": 4, "x": "y"}/1:3:Bytes/bar
 CPut /Table/107/2/"num"/4/4/0 -> /BYTES/
 CPut /Table/107/2/"x"/"y"/4/0 -> /BYTES/
@@ -974,7 +974,7 @@ query T kvtrace
 UPDATE inv SET a = 3 WHERE a = 1
 ----
 Scan /Table/107/1/1/0 lock Exclusive (Block, Unreplicated)
-Del (locking) /Table/107/1/1/0
+Del /Table/107/1/1/0
 CPut /Table/107/1/3/0 -> /TUPLE/2:2:SentinelType/{"num": 3, "x": "y"}/1:3:Bytes/fud
 
 # Update to multiple rows (one in and one not in the partial index) so that both
@@ -1000,7 +1000,7 @@ UPDATE inv SET c = 'fud' WHERE a IN (12, 13)
 ----
 Scan /Table/107/1/1{2-4} lock Exclusive (Block, Unreplicated)
 Put /Table/107/1/12/0 -> /TUPLE/2:2:SentinelType/{"a": "b"}/1:3:Bytes/fud
-Del (locking) /Table/107/2/"a"/"b"/12/0
+Del /Table/107/2/"a"/"b"/12/0
 Put /Table/107/1/13/0 -> /TUPLE/2:2:SentinelType/{"a": "b"}/1:3:Bytes/fud
 
 # ---------------------------------------------------------
@@ -1022,7 +1022,7 @@ UPSERT INTO inv VALUES (4, '{"x": "y", "num": 6}', 'foo')
 ----
 Scan /Table/107/1/4/0 lock Exclusive (Block, Unreplicated)
 Put /Table/107/1/4/0 -> /TUPLE/2:2:SentinelType/{"num": 6, "x": "y"}/1:3:Bytes/foo
-Del (locking) /Table/107/2/"num"/4/4/0
+Del /Table/107/2/"num"/4/4/0
 CPut /Table/107/2/"num"/6/4/0 -> /BYTES/
 
 # Upsert a conflicting row so that it is removed from the partial index.
@@ -1031,8 +1031,8 @@ UPSERT INTO inv VALUES (4, '{"x": "y", "num": 6}', 'fud')
 ----
 Scan /Table/107/1/4/0 lock Exclusive (Block, Unreplicated)
 Put /Table/107/1/4/0 -> /TUPLE/2:2:SentinelType/{"num": 6, "x": "y"}/1:3:Bytes/fud
-Del (locking) /Table/107/2/"num"/6/4/0
-Del (locking) /Table/107/2/"x"/"y"/4/0
+Del /Table/107/2/"num"/6/4/0
+Del /Table/107/2/"x"/"y"/4/0
 
 # Upsert a non-conflicting row that is added to the partial index.
 query T kvtrace

--- a/pkg/sql/opt/exec/execbuilder/testdata/schema_change_in_txn
+++ b/pkg/sql/opt/exec/execbuilder/testdata/schema_change_in_txn
@@ -50,16 +50,16 @@ query T kvtrace(prefix=/Table/106/)
 UPDATE t SET a = a + 100
 ----
 Scan /Table/106/{1-2} lock Exclusive (Block, Unreplicated)
-Del (locking) /Table/106/1/100/0
-Del (locking) /Table/106/1/100/1/1
+Del /Table/106/1/100/0
+Del /Table/106/1/100/1/1
 CPut /Table/106/1/200/0 -> /TUPLE/2:2:Decimal/1000.2/1:3:Bytes/empty
 CPut /Table/106/1/200/1/1 -> /TUPLE/4:4:Decimal/0.00/2:6:Decimal/1200.2
-Del (locking) /Table/106/1/101/0
-Del (locking) /Table/106/1/101/1/1
+Del /Table/106/1/101/0
+Del /Table/106/1/101/1/1
 CPut /Table/106/1/201/0 -> /TUPLE/2:2:Decimal/1000.2/1:3:Bytes/empty
 CPut /Table/106/1/201/1/1 -> /TUPLE/4:4:Decimal/0.00/2:6:Decimal/1201.2
-Del (locking) /Table/106/1/102/0
-Del (locking) /Table/106/1/102/1/1
+Del /Table/106/1/102/0
+Del /Table/106/1/102/1/1
 CPut /Table/106/1/202/0 -> /TUPLE/2:2:Decimal/1000.2/1:3:Bytes/empty
 CPut /Table/106/1/202/1/1 -> /TUPLE/4:4:Decimal/0.00/2:6:Decimal/1202.2
 

--- a/pkg/sql/opt/exec/execbuilder/testdata/secondary_index_column_families
+++ b/pkg/sql/opt/exec/execbuilder/testdata/secondary_index_column_families
@@ -363,9 +363,9 @@ CREATE INDEX i ON t (y) STORING (z, w)
 query T kvtrace(Del,prefix=/Table/111/3/)
 UPDATE t SET z = 3 WHERE y = 2
 ----
-Del (locking) /Table/111/3/2/1/0
-Del (locking) /Table/111/3/2/1/2/1
-Del (locking) /Table/111/3/2/1/3/1
+Del /Table/111/3/2/1/0
+Del /Table/111/3/2/1/2/1
+Del /Table/111/3/2/1/3/1
 
 statement ok
 COMMIT
@@ -409,9 +409,9 @@ UPDATE t SET b = 4, c = NULL, d = NULL, e = 7, f = NULL WHERE y = 2
 ----
 Scan /Table/112/2/{2-3} lock Exclusive (Block, Unreplicated)
 Put /Table/112/2/2/1/2/1 -> /TUPLE/3:3:Int/3/1:4:Int/4
-Del (locking) /Table/112/2/2/1/3/1
+Del /Table/112/2/2/1/3/1
 CPut /Table/112/2/2/1/4/1 -> /TUPLE/7:7:Int/7
-Del (locking) /Table/112/2/2/1/5/1
+Del /Table/112/2/2/1/5/1
 
 query IIIIIIII
 SELECT * FROM t@i2
@@ -437,10 +437,10 @@ query T kvtrace(Scan,Del,Put,CPut,prefix=/Table/112/2/)
 UPDATE t SET a = NULL, b = NULL, c = NULL, d = NULL, e = NULL, f = NULL WHERE y = 3
 ----
 Scan /Table/112/2/{3-4} lock Exclusive (Block, Unreplicated)
-Del (locking) /Table/112/2/3/3/2/1
-Del (locking) /Table/112/2/3/3/3/1
-Del (locking) /Table/112/2/3/3/4/1
-Del (locking) /Table/112/2/3/3/5/1
+Del /Table/112/2/3/3/2/1
+Del /Table/112/2/3/3/3/1
+Del /Table/112/2/3/3/4/1
+Del /Table/112/2/3/3/5/1
 
 
 # Test a case that each k/v in the index entry gets
@@ -452,13 +452,13 @@ query T kvtrace(Scan,Put,Del,CPut,prefix=/Table/112/2/)
 UPDATE t SET y = 22 WHERE y = 21
 ----
 Scan /Table/112/2/2{1-2} lock Exclusive (Block, Unreplicated)
-Del (locking) /Table/112/2/21/20/0
+Del /Table/112/2/21/20/0
 CPut /Table/112/2/22/20/0 -> /BYTES/
-Del (locking) /Table/112/2/21/20/2/1
+Del /Table/112/2/21/20/2/1
 CPut /Table/112/2/22/20/2/1 -> /TUPLE/3:3:Int/22
-Del (locking) /Table/112/2/21/20/3/1
+Del /Table/112/2/21/20/3/1
 CPut /Table/112/2/22/20/3/1 -> /TUPLE/6:6:Int/25
-Del (locking) /Table/112/2/21/20/5/1
+Del /Table/112/2/21/20/5/1
 CPut /Table/112/2/22/20/5/1 -> /TUPLE/8:8:Int/27
 
 # Ensure that the final results on both indexes make sense.
@@ -495,7 +495,7 @@ query T kvtrace(Scan,Put,CPut,Del,prefix=/Table/113/2/)
 UPDATE t SET y = 5 where y = 2
 ----
 Scan /Table/113/2/{2-3} lock Exclusive (Block, Unreplicated)
-Del (locking) /Table/113/2/2/1/0
+Del /Table/113/2/2/1/0
 CPut /Table/113/2/5/1/0 -> /BYTES/0x33061308
 
 # Changing the value just results in a cput.

--- a/pkg/sql/opt/exec/execbuilder/testdata/update
+++ b/pkg/sql/opt/exec/execbuilder/testdata/update
@@ -901,8 +901,8 @@ Scan /Table/115/{1-2} lock Exclusive (Block, Unreplicated)
 fetched: /tu/tu_pkey/1:cf=0 -> <undecoded>
 fetched: /tu/tu_pkey/1/b:cf=1 -> 2
 fetched: /tu/tu_pkey/1/c/d:cf=2 -> /4/4
-Del (locking) /Table/115/1/1/1/1
-Del (locking) /Table/115/1/1/2/1
+Del /Table/115/1/1/1/1
+Del /Table/115/1/1/2/1
 fast path completed
 rows affected: 1
 
@@ -1050,9 +1050,9 @@ EXECUTE p(1, 10)
 ----
 Scan /Table/118/1/1/0 lock Exclusive (Block, Unreplicated)
 Put /Table/118/1/1/0 -> /TUPLE/2:2:Int/3/1:3:Int/10
-Del (locking) /Table/118/2/2/1/0
+Del /Table/118/2/2/1/0
 CPut /Table/118/2/3/1/0 -> /BYTES/
-Del (locking) /Table/118/3/3/1/0
+Del /Table/118/3/3/1/0
 CPut /Table/118/3/10/1/0 -> /BYTES/
 
 statement ok
@@ -1132,9 +1132,9 @@ EXECUTE p(10, 100)
 Scan /Table/118/2/1{0-1} lock Exclusive (Block, Unreplicated)
 Scan /Table/118/1/1/0 lock Exclusive (Block, Unreplicated)
 Put /Table/118/1/1/0 -> /TUPLE/2:2:Int/11/1:3:Int/100
-Del (locking) /Table/118/2/10/1/0
+Del /Table/118/2/10/1/0
 CPut /Table/118/2/11/1/0 -> /BYTES/
-Del (locking) /Table/118/3/3/1/0
+Del /Table/118/3/3/1/0
 CPut /Table/118/3/100/1/0 -> /BYTES/
 
 statement ok
@@ -1202,9 +1202,9 @@ EXECUTE p(1, 10)
 ----
 Scan /Table/118/1/1/0
 Put /Table/118/1/1/0 -> /TUPLE/2:2:Int/3/1:3:Int/10
-Del (locking) /Table/118/2/2/1/0
+Del /Table/118/2/2/1/0
 CPut /Table/118/2/3/1/0 -> /BYTES/
-Del (locking) /Table/118/3/3/1/0
+Del /Table/118/3/3/1/0
 CPut /Table/118/3/10/1/0 -> /BYTES/
 
 statement ok
@@ -1320,9 +1320,9 @@ Scan /Table/118/1/1/0
 Scan /Table/118/2/{1-2}
 Scan /Table/118/1/1/0
 Put /Table/118/1/1/0 -> /TUPLE/2:2:Int/2/1:3:Int/2
-Del (locking) /Table/118/2/1/1/0
+Del /Table/118/2/1/1/0
 CPut /Table/118/2/2/1/0 -> /BYTES/
-Del (locking) /Table/118/3/1/1/0
+Del /Table/118/3/1/1/0
 CPut /Table/118/3/2/1/0 -> /BYTES/
 
 statement ok
@@ -1368,7 +1368,7 @@ UPDATE t139160 SET i = i + 1, u = u + 1, v = v + 1, w = w + 1 WHERE k = 1
 Scan /Table/119/1/{1-2} lock Exclusive (Block, Unreplicated)
 Put /Table/119/1/1/0 -> /TUPLE/2:2:Int/3/1:3:Int/4/1:4:Int/5
 Put /Table/119/1/1/1/1 -> /INT/6
-Del (locking) /Table/119/2/2/1/0
+Del /Table/119/2/2/1/0
 CPut /Table/119/2/3/1/0 -> /BYTES/0x3308
 Del (locking) /Table/119/3/3/0
 CPut /Table/119/3/4/0 -> /BYTES/0x892306
@@ -1385,8 +1385,8 @@ UPDATE t139160 SET i = i + 1, u = u + 1, v = v + 1, w = NULL WHERE k = 1
 ----
 Scan /Table/119/1/{1-2} lock Exclusive (Block, Unreplicated)
 Put /Table/119/1/1/0 -> /TUPLE/2:2:Int/3/1:3:Int/4/1:4:Int/5
-Del (locking) /Table/119/1/1/1/1
-Del (locking) /Table/119/2/2/1/0
+Del /Table/119/1/1/1/1
+Del /Table/119/2/2/1/0
 CPut /Table/119/2/3/1/0 -> /BYTES/0x3308
 Del (locking) /Table/119/3/3/0
 CPut /Table/119/3/4/0 -> /BYTES/0x892306
@@ -1428,7 +1428,7 @@ Scan /Table/119/2/{2-3} lock Exclusive (Block, Unreplicated)
 Scan /Table/119/1/{1-2} lock Exclusive (Block, Unreplicated)
 Put /Table/119/1/1/0 -> /TUPLE/2:2:Int/3/1:3:Int/4/1:4:Int/5
 Put /Table/119/1/1/1/1 -> /INT/6
-Del (locking) /Table/119/2/2/1/0
+Del /Table/119/2/2/1/0
 CPut /Table/119/2/3/1/0 -> /BYTES/0x3308
 Del (locking) /Table/119/3/3/0
 CPut /Table/119/3/4/0 -> /BYTES/0x892306
@@ -1446,8 +1446,8 @@ UPDATE t139160 SET i = i + 1, u = u + 1, v = v + 1, w = NULL WHERE i = 2
 Scan /Table/119/2/{2-3} lock Exclusive (Block, Unreplicated)
 Scan /Table/119/1/{1-2} lock Exclusive (Block, Unreplicated)
 Put /Table/119/1/1/0 -> /TUPLE/2:2:Int/3/1:3:Int/4/1:4:Int/5
-Del (locking) /Table/119/1/1/1/1
-Del (locking) /Table/119/2/2/1/0
+Del /Table/119/1/1/1/1
+Del /Table/119/2/2/1/0
 CPut /Table/119/2/3/1/0 -> /BYTES/0x3308
 Del (locking) /Table/119/3/3/0
 CPut /Table/119/3/4/0 -> /BYTES/0x892306
@@ -1490,9 +1490,9 @@ Scan /Table/119/3/3/0 lock Exclusive (Block, Unreplicated)
 Scan /Table/119/1/{1-2} lock Exclusive (Block, Unreplicated)
 Put /Table/119/1/1/0 -> /TUPLE/2:2:Int/3/1:3:Int/4/1:4:Int/5
 Put /Table/119/1/1/1/1 -> /INT/6
-Del (locking) /Table/119/2/2/1/0
+Del /Table/119/2/2/1/0
 CPut /Table/119/2/3/1/0 -> /BYTES/0x3308
-Del (locking) /Table/119/3/3/0
+Del /Table/119/3/3/0
 CPut /Table/119/3/4/0 -> /BYTES/0x892306
 Del (locking) /Table/119/4/4/0
 CPut /Table/119/4/5/0 -> /BYTES/0x89
@@ -1508,10 +1508,10 @@ UPDATE t139160 SET i = i + 1, u = u + 1, v = v + 1, w = NULL WHERE u = 3
 Scan /Table/119/3/3/0 lock Exclusive (Block, Unreplicated)
 Scan /Table/119/1/{1-2} lock Exclusive (Block, Unreplicated)
 Put /Table/119/1/1/0 -> /TUPLE/2:2:Int/3/1:3:Int/4/1:4:Int/5
-Del (locking) /Table/119/1/1/1/1
-Del (locking) /Table/119/2/2/1/0
+Del /Table/119/1/1/1/1
+Del /Table/119/2/2/1/0
 CPut /Table/119/2/3/1/0 -> /BYTES/0x3308
-Del (locking) /Table/119/3/3/0
+Del /Table/119/3/3/0
 CPut /Table/119/3/4/0 -> /BYTES/0x892306
 Del (locking) /Table/119/4/4/0
 CPut /Table/119/4/5/0 -> /BYTES/0x89
@@ -1552,11 +1552,11 @@ Scan /Table/119/4/4/0 lock Exclusive (Block, Unreplicated)
 Scan /Table/119/1/{1-2} lock Exclusive (Block, Unreplicated)
 Put /Table/119/1/1/0 -> /TUPLE/2:2:Int/3/1:3:Int/4/1:4:Int/5
 Put /Table/119/1/1/1/1 -> /INT/6
-Del (locking) /Table/119/2/2/1/0
+Del /Table/119/2/2/1/0
 CPut /Table/119/2/3/1/0 -> /BYTES/0x3308
 Del (locking) /Table/119/3/3/0
 CPut /Table/119/3/4/0 -> /BYTES/0x892306
-Del (locking) /Table/119/4/4/0
+Del /Table/119/4/4/0
 CPut /Table/119/4/5/0 -> /BYTES/0x89
 
 statement ok
@@ -1570,12 +1570,12 @@ UPDATE t139160 SET i = i + 1, u = u + 1, v = v + 1, w = NULL WHERE v = 4
 Scan /Table/119/4/4/0 lock Exclusive (Block, Unreplicated)
 Scan /Table/119/1/{1-2} lock Exclusive (Block, Unreplicated)
 Put /Table/119/1/1/0 -> /TUPLE/2:2:Int/3/1:3:Int/4/1:4:Int/5
-Del (locking) /Table/119/1/1/1/1
-Del (locking) /Table/119/2/2/1/0
+Del /Table/119/1/1/1/1
+Del /Table/119/2/2/1/0
 CPut /Table/119/2/3/1/0 -> /BYTES/0x3308
 Del (locking) /Table/119/3/3/0
 CPut /Table/119/3/4/0 -> /BYTES/0x892306
-Del (locking) /Table/119/4/4/0
+Del /Table/119/4/4/0
 CPut /Table/119/4/5/0 -> /BYTES/0x89
 
 statement ok
@@ -1610,7 +1610,7 @@ UPDATE t139160 SET i = i + 1, u = u + 1, v = v + 1, w = w + 1 WHERE w = 5
 Scan /Table/119/{1-2}
 Put /Table/119/1/1/0 -> /TUPLE/2:2:Int/3/1:3:Int/4/1:4:Int/5
 Put /Table/119/1/1/1/1 -> /INT/6
-Del (locking) /Table/119/2/2/1/0
+Del /Table/119/2/2/1/0
 CPut /Table/119/2/3/1/0 -> /BYTES/0x3308
 Del (locking) /Table/119/3/3/0
 CPut /Table/119/3/4/0 -> /BYTES/0x892306
@@ -1628,7 +1628,7 @@ UPDATE t139160 SET i = i + 1, u = u + 1, v = v + 1, w = NULL WHERE w = 5
 Scan /Table/119/{1-2}
 Put /Table/119/1/1/0 -> /TUPLE/2:2:Int/3/1:3:Int/4/1:4:Int/5
 Del (locking) /Table/119/1/1/1/1
-Del (locking) /Table/119/2/2/1/0
+Del /Table/119/2/2/1/0
 CPut /Table/119/2/3/1/0 -> /BYTES/0x3308
 Del (locking) /Table/119/3/3/0
 CPut /Table/119/3/4/0 -> /BYTES/0x892306

--- a/pkg/sql/opt/exec/execbuilder/testdata/update
+++ b/pkg/sql/opt/exec/execbuilder/testdata/update
@@ -985,14 +985,15 @@ CREATE TABLE t137352 (
   a INT,
   b INT,
   INDEX (a),
-  INDEX (b)
+  INDEX (b),
+  FAMILY (k, a, b)
 )
 
 statement ok
 SET plan_cache_mode = force_generic_plan
 
 statement ok
-PREPARE p AS UPDATE t137352 SET b = $2 WHERE k = $1
+PREPARE p AS UPDATE t137352 SET a = a + 1, b = $2 WHERE k = $1
 
 query T
 EXPLAIN ANALYZE EXECUTE p(1, 10)
@@ -1014,7 +1015,7 @@ quality of service: regular
 │ regions: <hidden>
 │ actual row count: 0
 │ table: t137352
-│ set: b
+│ set: a, b
 │ auto commit
 │
 └── • render
@@ -1042,10 +1043,23 @@ quality of service: regular
               size: 1 column, 1 row
 
 statement ok
+INSERT INTO t137352 VALUES (1, 2, 3);
+
+query T kvtrace
+EXECUTE p(1, 10)
+----
+Scan /Table/118/1/1/0 lock Exclusive (Block, Unreplicated)
+Put /Table/118/1/1/0 -> /TUPLE/2:2:Int/3/1:3:Int/10
+Del (locking) /Table/118/2/2/1/0
+CPut /Table/118/2/3/1/0 -> /BYTES/
+Del (locking) /Table/118/3/3/1/0
+CPut /Table/118/3/10/1/0 -> /BYTES/
+
+statement ok
 DEALLOCATE p
 
 statement ok
-PREPARE p AS UPDATE t137352 SET b = $2 WHERE a = $1
+PREPARE p AS UPDATE t137352 SET a = a + 1, b = $2 WHERE a = $1
 
 query T
 EXPLAIN ANALYZE EXECUTE p(10, 100)
@@ -1067,7 +1081,7 @@ quality of service: regular
 │ regions: <hidden>
 │ actual row count: 0
 │ table: t137352
-│ set: b
+│ set: a, b
 │ auto commit
 │
 └── • render
@@ -1109,10 +1123,25 @@ quality of service: regular
                   size: 1 column, 1 row
 
 statement ok
+DELETE FROM t137352 WHERE true;
+INSERT INTO t137352 VALUES (1, 10, 3);
+
+query T kvtrace
+EXECUTE p(10, 100)
+----
+Scan /Table/118/2/1{0-1} lock Exclusive (Block, Unreplicated)
+Scan /Table/118/1/1/0 lock Exclusive (Block, Unreplicated)
+Put /Table/118/1/1/0 -> /TUPLE/2:2:Int/11/1:3:Int/100
+Del (locking) /Table/118/2/10/1/0
+CPut /Table/118/2/11/1/0 -> /BYTES/
+Del (locking) /Table/118/3/3/1/0
+CPut /Table/118/3/100/1/0 -> /BYTES/
+
+statement ok
 DEALLOCATE p
 
 statement ok
-PREPARE p AS UPDATE t137352 SET b = $2 WHERE k = $1 AND b > 0
+PREPARE p AS UPDATE t137352 SET a = a + 1, b = $2 WHERE k = $1 AND b > 0
 
 # Do not apply implicit FOR UPDATE locks if the lookup join has an ON condition.
 query T
@@ -1123,6 +1152,7 @@ execution time: 100µs
 distribution: <hidden>
 vectorized: <hidden>
 plan type: generic, re-optimized
+rows decoded from KV: 1 (8 B, 2 KVs, 1 gRPC calls)
 maximum memory usage: <hidden>
 network usage: <hidden>
 regions: <hidden>
@@ -1133,9 +1163,9 @@ quality of service: regular
 • update
 │ sql nodes: <hidden>
 │ regions: <hidden>
-│ actual row count: 0
+│ actual row count: 1
 │ table: t137352
-│ set: b
+│ set: a, b
 │ auto commit
 │
 └── • render
@@ -1144,12 +1174,13 @@ quality of service: regular
         │ sql nodes: <hidden>
         │ kv nodes: <hidden>
         │ regions: <hidden>
-        │ actual row count: 0
+        │ actual row count: 1
         │ KV time: 0µs
         │ KV contention time: 0µs
-        │ KV rows decoded: 0
-        │ KV bytes read: 0 B
-        │ KV gRPC calls: 0
+        │ KV rows decoded: 1
+        │ KV pairs read: 2
+        │ KV bytes read: 8 B
+        │ KV gRPC calls: 1
         │ estimated max memory allocated: 0 B
         │ table: t137352@t137352_pkey
         │ equality: ($1) = (k)
@@ -1163,10 +1194,24 @@ quality of service: regular
               size: 1 column, 1 row
 
 statement ok
+DELETE FROM t137352 WHERE true;
+INSERT INTO t137352 VALUES (1, 2, 3);
+
+query T kvtrace
+EXECUTE p(1, 10)
+----
+Scan /Table/118/1/1/0
+Put /Table/118/1/1/0 -> /TUPLE/2:2:Int/3/1:3:Int/10
+Del (locking) /Table/118/2/2/1/0
+CPut /Table/118/2/3/1/0 -> /BYTES/
+Del (locking) /Table/118/3/3/1/0
+CPut /Table/118/3/10/1/0 -> /BYTES/
+
+statement ok
 DEALLOCATE p
 
 statement ok
-PREPARE p AS UPDATE t137352 t1 SET b = t2.b + 1 FROM t137352 t2 WHERE t1.k = t2.a AND t1.k = $1
+PREPARE p AS UPDATE t137352 t1 SET a = t2.a + 1, b = t2.b + 1 FROM t137352 t2 WHERE t1.k = t2.a AND t1.k = $1
 
 statement ok
 ALTER TABLE t137352 INJECT STATISTICS '[
@@ -1189,6 +1234,7 @@ execution time: 100µs
 distribution: <hidden>
 vectorized: <hidden>
 plan type: generic, re-optimized
+rows decoded from KV: 1 (8 B, 2 KVs, 1 gRPC calls)
 maximum memory usage: <hidden>
 network usage: <hidden>
 regions: <hidden>
@@ -1201,7 +1247,7 @@ quality of service: regular
 │ regions: <hidden>
 │ actual row count: 0
 │ table: t137352
-│ set: b
+│ set: a, b
 │ auto commit
 │
 └── • render
@@ -1226,6 +1272,7 @@ quality of service: regular
             │
             └── • lookup join
                 │ sql nodes: <hidden>
+                │ kv nodes: <hidden>
                 │ regions: <hidden>
                 │ actual row count: 0
                 │ KV time: 0µs
@@ -1243,12 +1290,13 @@ quality of service: regular
                     │ sql nodes: <hidden>
                     │ kv nodes: <hidden>
                     │ regions: <hidden>
-                    │ actual row count: 0
+                    │ actual row count: 1
                     │ KV time: 0µs
                     │ KV contention time: 0µs
-                    │ KV rows decoded: 0
-                    │ KV bytes read: 0 B
-                    │ KV gRPC calls: 0
+                    │ KV rows decoded: 1
+                    │ KV pairs read: 2
+                    │ KV bytes read: 8 B
+                    │ KV gRPC calls: 1
                     │ estimated max memory allocated: 0 B
                     │ estimated row count: 1
                     │ table: t137352@t137352_pkey
@@ -1260,3 +1308,329 @@ quality of service: regular
                           regions: <hidden>
                           actual row count: 1
                           size: 1 column, 1 row
+
+statement ok
+DELETE FROM t137352 WHERE true;
+INSERT INTO t137352 VALUES (1, 1, 1);
+
+query T kvtrace
+EXECUTE p(1)
+----
+Scan /Table/118/1/1/0
+Scan /Table/118/2/{1-2}
+Scan /Table/118/1/1/0
+Put /Table/118/1/1/0 -> /TUPLE/2:2:Int/2/1:3:Int/2
+Del (locking) /Table/118/2/1/1/0
+CPut /Table/118/2/2/1/0 -> /BYTES/
+Del (locking) /Table/118/3/1/1/0
+CPut /Table/118/3/2/1/0 -> /BYTES/
+
+statement ok
+CREATE TABLE t139160 (
+  k INT PRIMARY KEY,
+  i INT,
+  u INT,
+  v INT NOT NULL,
+  w INT,
+  INDEX (i) STORING (u),
+  UNIQUE INDEX (u) STORING (i),
+  UNIQUE INDEX (v),
+  FAMILY (k, i, u, v),
+  FAMILY (w)
+);
+
+statement ok
+INSERT INTO t139160 VALUES (1, 2, 3, 4, 5);
+
+# The PK is scanned and locked.
+query T
+EXPLAIN UPDATE t139160 SET i = i + 1, u = u + 1, v = v + 1, w = w + 1 WHERE k = 1
+----
+distribution: local
+vectorized: true
+·
+• update
+│ table: t139160
+│ set: i, u, v, w
+│ auto commit
+│
+└── • render
+    │
+    └── • scan
+          missing stats
+          table: t139160@t139160_pkey
+          spans: [/1 - /1]
+          locking strength: for update
+
+query T kvtrace
+UPDATE t139160 SET i = i + 1, u = u + 1, v = v + 1, w = w + 1 WHERE k = 1
+----
+Scan /Table/119/1/{1-2} lock Exclusive (Block, Unreplicated)
+Put /Table/119/1/1/0 -> /TUPLE/2:2:Int/3/1:3:Int/4/1:4:Int/5
+Put /Table/119/1/1/1/1 -> /INT/6
+Del (locking) /Table/119/2/2/1/0
+CPut /Table/119/2/3/1/0 -> /BYTES/0x3308
+Del (locking) /Table/119/3/3/0
+CPut /Table/119/3/4/0 -> /BYTES/0x892306
+Del (locking) /Table/119/4/4/0
+CPut /Table/119/4/5/0 -> /BYTES/0x89
+
+statement ok
+DELETE FROM t139160 WHERE true;
+INSERT INTO t139160 VALUES (1, 2, 3, 4, 5);
+
+# Same as above, but the second column family is set to NULL.
+query T kvtrace
+UPDATE t139160 SET i = i + 1, u = u + 1, v = v + 1, w = NULL WHERE k = 1
+----
+Scan /Table/119/1/{1-2} lock Exclusive (Block, Unreplicated)
+Put /Table/119/1/1/0 -> /TUPLE/2:2:Int/3/1:3:Int/4/1:4:Int/5
+Del (locking) /Table/119/1/1/1/1
+Del (locking) /Table/119/2/2/1/0
+CPut /Table/119/2/3/1/0 -> /BYTES/0x3308
+Del (locking) /Table/119/3/3/0
+CPut /Table/119/3/4/0 -> /BYTES/0x892306
+Del (locking) /Table/119/4/4/0
+CPut /Table/119/4/5/0 -> /BYTES/0x89
+
+statement ok
+DELETE FROM t139160 WHERE true;
+INSERT INTO t139160 VALUES (1, 2, 3, 4, 5);
+
+# Both primary and non-unique secondary indexes are scanned and locked.
+query T
+EXPLAIN UPDATE t139160 SET i = i + 1, u = u + 1, v = v + 1, w = w + 1 WHERE i = 2
+----
+distribution: local
+vectorized: true
+·
+• update
+│ table: t139160
+│ set: i, u, v, w
+│ auto commit
+│
+└── • render
+    │
+    └── • index join
+        │ table: t139160@t139160_pkey
+        │ locking strength: for update
+        │
+        └── • scan
+              missing stats
+              table: t139160@t139160_i_idx
+              spans: [/2 - /2]
+              locking strength: for update
+
+query T kvtrace
+UPDATE t139160 SET i = i + 1, u = u + 1, v = v + 1, w = w + 1 WHERE i = 2
+----
+Scan /Table/119/2/{2-3} lock Exclusive (Block, Unreplicated)
+Scan /Table/119/1/{1-2} lock Exclusive (Block, Unreplicated)
+Put /Table/119/1/1/0 -> /TUPLE/2:2:Int/3/1:3:Int/4/1:4:Int/5
+Put /Table/119/1/1/1/1 -> /INT/6
+Del (locking) /Table/119/2/2/1/0
+CPut /Table/119/2/3/1/0 -> /BYTES/0x3308
+Del (locking) /Table/119/3/3/0
+CPut /Table/119/3/4/0 -> /BYTES/0x892306
+Del (locking) /Table/119/4/4/0
+CPut /Table/119/4/5/0 -> /BYTES/0x89
+
+statement ok
+DELETE FROM t139160 WHERE true;
+INSERT INTO t139160 VALUES (1, 2, 3, 4, 5);
+
+# Same as above, but the second column family is set to NULL.
+query T kvtrace
+UPDATE t139160 SET i = i + 1, u = u + 1, v = v + 1, w = NULL WHERE i = 2
+----
+Scan /Table/119/2/{2-3} lock Exclusive (Block, Unreplicated)
+Scan /Table/119/1/{1-2} lock Exclusive (Block, Unreplicated)
+Put /Table/119/1/1/0 -> /TUPLE/2:2:Int/3/1:3:Int/4/1:4:Int/5
+Del (locking) /Table/119/1/1/1/1
+Del (locking) /Table/119/2/2/1/0
+CPut /Table/119/2/3/1/0 -> /BYTES/0x3308
+Del (locking) /Table/119/3/3/0
+CPut /Table/119/3/4/0 -> /BYTES/0x892306
+Del (locking) /Table/119/4/4/0
+CPut /Table/119/4/5/0 -> /BYTES/0x89
+
+statement ok
+DELETE FROM t139160 WHERE true;
+INSERT INTO t139160 VALUES (1, 2, 3, 4, 5);
+
+# Both primary and unique secondary (on nullable column) indexes are scanned and
+# locked.
+query T
+EXPLAIN UPDATE t139160 SET i = i + 1, u = u + 1, v = v + 1, w = w + 1 WHERE u = 3
+----
+distribution: local
+vectorized: true
+·
+• update
+│ table: t139160
+│ set: i, u, v, w
+│ auto commit
+│
+└── • render
+    │
+    └── • index join
+        │ table: t139160@t139160_pkey
+        │ locking strength: for update
+        │
+        └── • scan
+              missing stats
+              table: t139160@t139160_u_key
+              spans: [/3 - /3]
+              locking strength: for update
+
+query T kvtrace
+UPDATE t139160 SET i = i + 1, u = u + 1, v = v + 1, w = w + 1 WHERE u = 3
+----
+Scan /Table/119/3/3/0 lock Exclusive (Block, Unreplicated)
+Scan /Table/119/1/{1-2} lock Exclusive (Block, Unreplicated)
+Put /Table/119/1/1/0 -> /TUPLE/2:2:Int/3/1:3:Int/4/1:4:Int/5
+Put /Table/119/1/1/1/1 -> /INT/6
+Del (locking) /Table/119/2/2/1/0
+CPut /Table/119/2/3/1/0 -> /BYTES/0x3308
+Del (locking) /Table/119/3/3/0
+CPut /Table/119/3/4/0 -> /BYTES/0x892306
+Del (locking) /Table/119/4/4/0
+CPut /Table/119/4/5/0 -> /BYTES/0x89
+
+statement ok
+DELETE FROM t139160 WHERE true;
+INSERT INTO t139160 VALUES (1, 2, 3, 4, 5);
+
+# Same as above, but the second column family is set to NULL.
+query T kvtrace
+UPDATE t139160 SET i = i + 1, u = u + 1, v = v + 1, w = NULL WHERE u = 3
+----
+Scan /Table/119/3/3/0 lock Exclusive (Block, Unreplicated)
+Scan /Table/119/1/{1-2} lock Exclusive (Block, Unreplicated)
+Put /Table/119/1/1/0 -> /TUPLE/2:2:Int/3/1:3:Int/4/1:4:Int/5
+Del (locking) /Table/119/1/1/1/1
+Del (locking) /Table/119/2/2/1/0
+CPut /Table/119/2/3/1/0 -> /BYTES/0x3308
+Del (locking) /Table/119/3/3/0
+CPut /Table/119/3/4/0 -> /BYTES/0x892306
+Del (locking) /Table/119/4/4/0
+CPut /Table/119/4/5/0 -> /BYTES/0x89
+
+statement ok
+DELETE FROM t139160 WHERE true;
+INSERT INTO t139160 VALUES (1, 2, 3, 4, 5);
+
+# Both primary and unique secondary (on non-nullable column) indexes are scanned
+# and locked.
+query T
+EXPLAIN UPDATE t139160 SET i = i + 1, u = u + 1, v = v + 1, w = w + 1 WHERE v = 4
+----
+distribution: local
+vectorized: true
+·
+• update
+│ table: t139160
+│ set: i, u, v, w
+│ auto commit
+│
+└── • render
+    │
+    └── • index join
+        │ table: t139160@t139160_pkey
+        │ locking strength: for update
+        │
+        └── • scan
+              missing stats
+              table: t139160@t139160_v_key
+              spans: [/4 - /4]
+              locking strength: for update
+
+query T kvtrace
+UPDATE t139160 SET i = i + 1, u = u + 1, v = v + 1, w = w + 1 WHERE v = 4
+----
+Scan /Table/119/4/4/0 lock Exclusive (Block, Unreplicated)
+Scan /Table/119/1/{1-2} lock Exclusive (Block, Unreplicated)
+Put /Table/119/1/1/0 -> /TUPLE/2:2:Int/3/1:3:Int/4/1:4:Int/5
+Put /Table/119/1/1/1/1 -> /INT/6
+Del (locking) /Table/119/2/2/1/0
+CPut /Table/119/2/3/1/0 -> /BYTES/0x3308
+Del (locking) /Table/119/3/3/0
+CPut /Table/119/3/4/0 -> /BYTES/0x892306
+Del (locking) /Table/119/4/4/0
+CPut /Table/119/4/5/0 -> /BYTES/0x89
+
+statement ok
+DELETE FROM t139160 WHERE true;
+INSERT INTO t139160 VALUES (1, 2, 3, 4, 5);
+
+# Same as above, but the second column family is set to NULL.
+query T kvtrace
+UPDATE t139160 SET i = i + 1, u = u + 1, v = v + 1, w = NULL WHERE v = 4
+----
+Scan /Table/119/4/4/0 lock Exclusive (Block, Unreplicated)
+Scan /Table/119/1/{1-2} lock Exclusive (Block, Unreplicated)
+Put /Table/119/1/1/0 -> /TUPLE/2:2:Int/3/1:3:Int/4/1:4:Int/5
+Del (locking) /Table/119/1/1/1/1
+Del (locking) /Table/119/2/2/1/0
+CPut /Table/119/2/3/1/0 -> /BYTES/0x3308
+Del (locking) /Table/119/3/3/0
+CPut /Table/119/3/4/0 -> /BYTES/0x892306
+Del (locking) /Table/119/4/4/0
+CPut /Table/119/4/5/0 -> /BYTES/0x89
+
+statement ok
+DELETE FROM t139160 WHERE true;
+INSERT INTO t139160 VALUES (1, 2, 3, 4, 5);
+
+# The filter is not pushed down into the scan, so no index is locked.
+query T
+EXPLAIN UPDATE t139160 SET i = i + 1, u = u + 1, v = v + 1, w = w + 1 WHERE w = 5
+----
+distribution: local
+vectorized: true
+·
+• update
+│ table: t139160
+│ set: i, u, v, w
+│ auto commit
+│
+└── • render
+    │
+    └── • filter
+        │ filter: w = 5
+        │
+        └── • scan
+              missing stats
+              table: t139160@t139160_pkey
+              spans: FULL SCAN
+
+query T kvtrace
+UPDATE t139160 SET i = i + 1, u = u + 1, v = v + 1, w = w + 1 WHERE w = 5
+----
+Scan /Table/119/{1-2}
+Put /Table/119/1/1/0 -> /TUPLE/2:2:Int/3/1:3:Int/4/1:4:Int/5
+Put /Table/119/1/1/1/1 -> /INT/6
+Del (locking) /Table/119/2/2/1/0
+CPut /Table/119/2/3/1/0 -> /BYTES/0x3308
+Del (locking) /Table/119/3/3/0
+CPut /Table/119/3/4/0 -> /BYTES/0x892306
+Del (locking) /Table/119/4/4/0
+CPut /Table/119/4/5/0 -> /BYTES/0x89
+
+statement ok
+DELETE FROM t139160 WHERE true;
+INSERT INTO t139160 VALUES (1, 2, 3, 4, 5);
+
+# Same as above, but the second column family is set to NULL.
+query T kvtrace
+UPDATE t139160 SET i = i + 1, u = u + 1, v = v + 1, w = NULL WHERE w = 5
+----
+Scan /Table/119/{1-2}
+Put /Table/119/1/1/0 -> /TUPLE/2:2:Int/3/1:3:Int/4/1:4:Int/5
+Del (locking) /Table/119/1/1/1/1
+Del (locking) /Table/119/2/2/1/0
+CPut /Table/119/2/3/1/0 -> /BYTES/0x3308
+Del (locking) /Table/119/3/3/0
+CPut /Table/119/3/4/0 -> /BYTES/0x892306
+Del (locking) /Table/119/4/4/0
+CPut /Table/119/4/5/0 -> /BYTES/0x89

--- a/pkg/sql/opt/exec/execbuilder/testdata/upsert
+++ b/pkg/sql/opt/exec/execbuilder/testdata/upsert
@@ -1154,7 +1154,8 @@ CREATE TABLE t137352 (
   k INT PRIMARY KEY,
   a INT,
   b INT,
-  UNIQUE INDEX (a)
+  UNIQUE INDEX (a),
+  FAMILY (k, a, b)
 )
 
 statement ok
@@ -1208,8 +1209,27 @@ quality of service: regular
           actual row count: 1
           size: 3 columns, 1 row
 
+# Only need to update 'b' - no need to modify the secondary index.
+query T kvtrace
+EXECUTE p(1, 10, 101)
+----
+Scan /Table/123/1/1/0 lock Exclusive (Block, Unreplicated)
+Put /Table/123/1/1/0 -> /TUPLE/2:2:Int/10/1:3:Int/101
+
+# Updating both 'a' and 'b' - need to modify the secondary index.
+query T kvtrace
+EXECUTE p(1, 11, 102)
+----
+Scan /Table/123/1/1/0 lock Exclusive (Block, Unreplicated)
+Put /Table/123/1/1/0 -> /TUPLE/2:2:Int/11/1:3:Int/102
+Del (locking) /Table/123/2/10/0
+CPut /Table/123/2/11/0 -> /BYTES/0x89
+
 statement ok
 DEALLOCATE p
+
+statement ok
+DELETE FROM t137352 WHERE true
 
 statement ok
 PREPARE p AS INSERT INTO t137352 VALUES ($1, $2, $3) ON CONFLICT (a) DO UPDATE SET b = $3
@@ -1222,7 +1242,6 @@ execution time: 100µs
 distribution: <hidden>
 vectorized: <hidden>
 plan type: generic, re-optimized
-rows decoded from KV: 2 (16 B, 4 KVs, 2 gRPC calls)
 maximum memory usage: <hidden>
 network usage: <hidden>
 regions: <hidden>
@@ -1242,15 +1261,13 @@ quality of service: regular
     │
     └── • lookup join (left outer)
         │ sql nodes: <hidden>
-        │ kv nodes: <hidden>
         │ regions: <hidden>
         │ actual row count: 1
         │ KV time: 0µs
         │ KV contention time: 0µs
-        │ KV rows decoded: 1
-        │ KV pairs read: 2
-        │ KV bytes read: 8 B
-        │ KV gRPC calls: 1
+        │ KV rows decoded: 0
+        │ KV bytes read: 0 B
+        │ KV gRPC calls: 0
         │ estimated max memory allocated: 0 B
         │ table: t137352@t137352_pkey
         │ equality: (k) = (k)
@@ -1264,10 +1281,9 @@ quality of service: regular
             │ actual row count: 1
             │ KV time: 0µs
             │ KV contention time: 0µs
-            │ KV rows decoded: 1
-            │ KV pairs read: 2
-            │ KV bytes read: 8 B
-            │ KV gRPC calls: 1
+            │ KV rows decoded: 0
+            │ KV bytes read: 0 B
+            │ KV gRPC calls: 0
             │ estimated max memory allocated: 0 B
             │ table: t137352@t137352_a_key
             │ equality: (column2) = (a)
@@ -1280,11 +1296,143 @@ quality of service: regular
                   actual row count: 1
                   size: 3 columns, 1 row
 
+# Conflict on 'a', so we're only updating the value of 'b'.
+query T kvtrace
+EXECUTE p(2, 10, 101)
+----
+Scan /Table/123/2/10/0 lock Exclusive (Block, Unreplicated)
+Scan /Table/123/1/1/0 lock Exclusive (Block, Unreplicated)
+Put /Table/123/1/1/0 -> /TUPLE/2:2:Int/10/1:3:Int/101
+
+# No conflict, so we're performing an INSERT.
+query T kvtrace
+EXECUTE p(3, 11, 101)
+----
+Scan /Table/123/2/11/0 lock Exclusive (Block, Unreplicated)
+CPut /Table/123/1/3/0 -> /TUPLE/2:2:Int/11/1:3:Int/101
+CPut /Table/123/2/11/0 -> /BYTES/0x8b
+
 # Regression test for #136458. The canary column ordinal should be correctly
-# selected when the canaray column is also a partial index DEL column.
+# selected when the canary column is also a partial index DEL column.
 
 statement ok
 CREATE TABLE t136458 (c BOOL PRIMARY KEY, INDEX (c) WHERE c)
 
 statement ok
 UPSERT INTO t136458 (c) VALUES (false)
+
+statement ok
+CREATE TABLE t139105 (k INT PRIMARY KEY, v INT, FAMILY (k, v));
+
+query T
+EXPLAIN UPSERT INTO t139105 VALUES (1, 1)
+----
+distribution: local
+vectorized: true
+·
+• upsert
+│ into: t139105(k, v)
+│ auto commit
+│
+└── • values
+      size: 2 columns, 1 row
+
+# Upsert fast-path - we need locking Put.
+query T kvtrace
+UPSERT INTO t139105 VALUES (1, 1)
+----
+Put (locking) /Table/125/1/1/0 -> /TUPLE/2:2:Int/1
+
+statement ok
+CREATE TABLE t139160 (
+  k INT PRIMARY KEY,
+  i INT,
+  u INT,
+  v INT,
+  INDEX (i) STORING (u),
+  UNIQUE INDEX (u) STORING (i),
+  FAMILY (k, i, u, v)
+);
+
+# Effectively an INSERT.
+query T kvtrace
+UPSERT INTO t139160 VALUES (1, 1, 1, 1)
+----
+Scan /Table/20/1/12{6-7}
+Scan /Table/126/1/1/0 lock Exclusive (Block, Unreplicated)
+CPut /Table/126/1/1/0 -> /TUPLE/2:2:Int/1/1:3:Int/1/1:4:Int/1
+CPut /Table/126/2/1/1/0 -> /BYTES/0x3302
+CPut /Table/126/3/1/0 -> /BYTES/0x892302
+
+# The PK is scanned and locked.
+query T
+EXPLAIN UPSERT INTO t139160 VALUES (1, 2, 3, 4)
+----
+distribution: local
+vectorized: true
+·
+• upsert
+│ into: t139160(k, i, u, v)
+│ auto commit
+│ arbiter indexes: t139160_pkey
+│
+└── • cross join (left outer)
+    │
+    ├── • values
+    │     size: 4 columns, 1 row
+    │
+    └── • scan
+          missing stats
+          table: t139160@t139160_pkey
+          spans: [/1 - /1]
+          locking strength: for update
+
+query T kvtrace
+UPSERT INTO t139160 VALUES (1, 2, 3, 4)
+----
+Scan /Table/126/1/1/0 lock Exclusive (Block, Unreplicated)
+Put /Table/126/1/1/0 -> /TUPLE/2:2:Int/2/1:3:Int/3/1:4:Int/4
+Del (locking) /Table/126/2/1/1/0
+CPut /Table/126/2/2/1/0 -> /BYTES/0x3306
+Del (locking) /Table/126/3/1/0
+CPut /Table/126/3/3/0 -> /BYTES/0x892304
+
+# Both primary and unique secondary indexes are scanned but are not locked. The
+# locking improvement is tracked by #143111.
+query T
+EXPLAIN INSERT INTO t139160 VALUES (11, 12, 3, 14) ON CONFLICT (u) DO UPDATE SET k = 11, i = 12, v = 14;
+----
+distribution: local
+vectorized: true
+·
+• upsert
+│ into: t139160(k, i, u, v)
+│ auto commit
+│ arbiter indexes: t139160_u_key
+│
+└── • render
+    │
+    └── • cross join (left outer)
+        │
+        ├── • values
+        │     size: 4 columns, 1 row
+        │
+        └── • index join
+            │ table: t139160@t139160_pkey
+            │
+            └── • scan
+                  missing stats
+                  table: t139160@t139160_u_key
+                  spans: [/3 - /3]
+
+query T kvtrace
+INSERT INTO t139160 VALUES (11, 12, 3, 14) ON CONFLICT (u) DO UPDATE SET k = 11, i = 12, v = 14;
+----
+Scan /Table/126/3/3/0
+Scan /Table/126/1/1/0
+Del /Table/126/2/2/1/0
+Del (locking) /Table/126/3/3/0
+Del (locking) /Table/126/1/1/0
+CPut /Table/126/1/11/0 -> /TUPLE/2:2:Int/12/1:3:Int/3/1:4:Int/14
+CPut /Table/126/2/12/11/0 -> /BYTES/0x3306
+CPut /Table/126/3/3/0 -> /BYTES/0x932318

--- a/pkg/sql/opt/exec/execbuilder/testdata/upsert
+++ b/pkg/sql/opt/exec/execbuilder/testdata/upsert
@@ -1392,7 +1392,7 @@ UPSERT INTO t139160 VALUES (1, 2, 3, 4)
 ----
 Scan /Table/126/1/1/0 lock Exclusive (Block, Unreplicated)
 Put /Table/126/1/1/0 -> /TUPLE/2:2:Int/2/1:3:Int/3/1:4:Int/4
-Del (locking) /Table/126/2/1/1/0
+Del /Table/126/2/1/1/0
 CPut /Table/126/2/2/1/0 -> /BYTES/0x3306
 Del (locking) /Table/126/3/1/0
 CPut /Table/126/3/3/0 -> /BYTES/0x892304

--- a/pkg/sql/opt/exec/execbuilder/testdata/vector_mutation
+++ b/pkg/sql/opt/exec/execbuilder/testdata/vector_mutation
@@ -38,11 +38,11 @@ UPSERT INTO exec_test VALUES (2, 10, 'bar', '[6, 5, 4]'), (4, 20, 'qux', '[10, 1
 ----
 Scan /Table/106/1/2/0, /Table/106/1/4/0
 Put /Table/106/1/2/0 -> /TUPLE/2:2:Int/10/1:3:Bytes/bar/
-Del (locking) /Table/106/2/1/1/2/0
+Del /Table/106/2/1/1/2/0
 CPut /Table/106/2/1/1/2/0 -> /BYTES/:redacted:
-Del (locking) /Table/106/3/10/1/1/2/0
+Del /Table/106/3/10/1/1/2/0
 CPut /Table/106/3/10/1/1/2/0 -> /BYTES/:redacted:
-Del (locking) /Table/106/4/"\x16\x05\x15\xef\x17\xbd\x00\x00\x00 \x00 \x00 "/1/1/2/0
+Del /Table/106/4/"\x16\x05\x15\xef\x17\xbd\x00\x00\x00 \x00 \x00 "/1/1/2/0
 CPut /Table/106/4/"\x16\x05\x15\xef\x17\xbd\x00\x00\x00 \x00 \x00 "/1/1/2/0 -> /BYTES/:redacted:
 CPut /Table/106/1/4/0 -> /TUPLE/2:2:Int/20/1:3:Bytes/qux/
 CPut /Table/106/2/1/1/4/0 -> /BYTES/:redacted:
@@ -55,11 +55,11 @@ UPDATE exec_test SET encoding = '[3, 2, 1]' WHERE id = 1
 ----
 Scan /Table/106/1/1/0
 Put /Table/106/1/1/0 -> /TUPLE/2:2:Int/1/1:3:Bytes/foo/
-Del (locking) /Table/106/2/1/1/1/0
+Del /Table/106/2/1/1/1/0
 CPut /Table/106/2/1/1/1/0 -> /BYTES/:redacted:
-Del (locking) /Table/106/3/1/1/1/1/0
+Del /Table/106/3/1/1/1/1/0
 CPut /Table/106/3/1/1/1/1/0 -> /BYTES/:redacted:
-Del (locking) /Table/106/4/"\x16\x84\x17q\x17q\x00\x00\x00 \x00 \x00 "/1/1/1/0
+Del /Table/106/4/"\x16\x84\x17q\x17q\x00\x00\x00 \x00 \x00 "/1/1/1/0
 CPut /Table/106/4/"\x16\x84\x17q\x17q\x00\x00\x00 \x00 \x00 "/1/1/1/0 -> /BYTES/:redacted:
 
 query T kvtrace(redactbytes)
@@ -68,7 +68,7 @@ UPDATE exec_test SET data = 'fooo' WHERE user_id = 15;
 Scan /Table/106/5/1{5-6}
 Scan /Table/106/1/3/0
 Put /Table/106/1/3/0 -> /TUPLE/2:2:Int/15/1:3:Bytes/fooo/
-Del (locking) /Table/106/4/"\x16\x05\x15\xef\x18\x95\x00\x00\x00 \x00 \x00 "/1/1/3/0
+Del /Table/106/4/"\x16\x05\x15\xef\x18\x95\x00\x00\x00 \x00 \x00 "/1/1/3/0
 CPut /Table/106/4/"\x16\x84\x17q\x17q\x17q\x00\x00\x00 \x00 \x00 \x00 "/1/1/3/0 -> /BYTES/:redacted:
 
 query T kvtrace

--- a/pkg/sql/opt/exec/factory.opt
+++ b/pkg/sql/opt/exec/factory.opt
@@ -558,6 +558,10 @@ define Update {
     Passthrough colinfo.ResultColumns
     UniqueWithTombstonesIndexes cat.IndexOrdinals
 
+    # If set, the input has already acquired the locks during the initial scan
+    # of the Update (i.e. on the "old" KVs within these indexes).
+    LockedIndexes cat.IndexOrdinals
+
     # If set, the operator will commit the transaction as part of its execution.
     AutoCommit bool
 }
@@ -598,6 +602,10 @@ define Upsert {
     ReturnCols exec.TableColumnOrdinalSet
     Checks exec.CheckOrdinalSet
     UniqueWithTombstonesIndexes cat.IndexOrdinals
+
+    # If set, the input has already acquired the locks during the initial scan
+    # of the Upsert (i.e. on the "old" KVs within these indexes).
+    LockedIndexes cat.IndexOrdinals
 
     # If set, the operator will commit the transaction as part of its execution.
     # This is false when executing inside an explicit transaction, or there are

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -1586,6 +1586,7 @@ func (ef *execFactory) ConstructUpdate(
 	checks exec.CheckOrdinalSet,
 	passthrough colinfo.ResultColumns,
 	uniqueWithTombstoneIndexes cat.IndexOrdinals,
+	lockedIndexes cat.IndexOrdinals,
 	autoCommit bool,
 ) (exec.Node, error) {
 	// TODO(radu): the execution code has an annoying limitation that the fetch
@@ -1610,6 +1611,7 @@ func (ef *execFactory) ConstructUpdate(
 		ef.planner.ExecCfg().Codec,
 		tabDesc,
 		ordinalsToIndexes(table, uniqueWithTombstoneIndexes),
+		ordinalsToIndexes(table, lockedIndexes),
 		updateCols,
 		fetchCols,
 		row.UpdaterDefault,
@@ -1684,6 +1686,7 @@ func (ef *execFactory) ConstructUpsert(
 	returnColOrdSet exec.TableColumnOrdinalSet,
 	checks exec.CheckOrdinalSet,
 	uniqueWithTombstoneIndexes cat.IndexOrdinals,
+	lockedIndexes cat.IndexOrdinals,
 	autoCommit bool,
 ) (exec.Node, error) {
 	// Derive table and column descriptors.
@@ -1718,6 +1721,7 @@ func (ef *execFactory) ConstructUpsert(
 		ef.planner.ExecCfg().Codec,
 		tabDesc,
 		ordinalsToIndexes(table, uniqueWithTombstoneIndexes),
+		ordinalsToIndexes(table, lockedIndexes),
 		updateCols,
 		fetchCols,
 		row.UpdaterDefault,

--- a/pkg/sql/row/helper.go
+++ b/pkg/sql/row/helper.go
@@ -497,10 +497,11 @@ func (rh *RowHelper) deleteIndexEntry(
 	b Putter,
 	index catalog.Index,
 	key *roachpb.Key,
-	needsLock bool,
+	alreadyLocked bool,
 	traceKV bool,
 	valDirs []encoding.Direction,
 ) error {
+	needsLock := !alreadyLocked && index.IsUnique()
 	if index.UseDeletePreservingEncoding() {
 		if traceKV {
 			var suffix string
@@ -515,8 +516,6 @@ func (rh *RowHelper) deleteIndexEntry(
 			b.Put(key, deleteEncoding)
 		}
 	} else {
-		// TODO(yuzefovich): consider not acquiring the locks for non-unique
-		// indexes at all.
 		delFn(ctx, b, key, needsLock, traceKV, valDirs)
 	}
 	return nil

--- a/pkg/sql/row/inserter.go
+++ b/pkg/sql/row/inserter.go
@@ -199,11 +199,11 @@ func (ri *Inserter) InsertRow(
 	}
 
 	// Add the new values.
-	ri.valueBuf, err = prepareInsertOrUpdateBatch(ctx, b,
-		&ri.Helper, primaryIndexKey, ri.InsertCols,
-		values, ri.InsertColIDtoRowIndex,
-		ri.InsertColIDtoRowIndex,
-		&ri.key, &ri.value, ri.valueBuf, oth, nil /* oldValues */, kvOp, traceKV)
+	ri.valueBuf, err = prepareInsertOrUpdateBatch(
+		ctx, b, &ri.Helper, primaryIndexKey, ri.InsertCols, values, ri.InsertColIDtoRowIndex,
+		ri.InsertColIDtoRowIndex, &ri.key, &ri.value, ri.valueBuf, oth, nil, /* oldValues */
+		kvOp, false /* oldKeysLocked */, traceKV,
+	)
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/tablewriter_upsert.go
+++ b/pkg/sql/tablewriter_upsert.go
@@ -185,8 +185,6 @@ func (tu *tableUpserter) row(
 		// read, we need to tell the KV layer to acquire the lock explicitly.
 		// - if buffered writes are disabled, then the KV layer will write an
 		// intent which acts as a lock.
-		// TODO(yuzefovich): add a tracing test to ensure that the lock is
-		// acquired here once the interceptor is updated.
 		kvOp := row.PutMustAcquireExclusiveLockOp
 		return tu.insertNonConflictingRow(ctx, datums[:insertEnd], pm, vh, kvOp, traceKV)
 	}

--- a/pkg/sql/testdata/index_mutations/delete_preserving_update
+++ b/pkg/sql/testdata/index_mutations/delete_preserving_update
@@ -23,7 +23,7 @@ UPDATE ti SET b = b + 1, c = c + 1
 ----
 Scan /Table/106/{1-2} lock Exclusive (Block, Unreplicated)
 Put /Table/106/1/1/0 -> /TUPLE/2:2:Int/3/1:3:Int/101
-Put (delete) (locking) /Table/106/2/2/100/1/0
+Put (delete) /Table/106/2/2/100/1/0
 Put /Table/106/2/3/101/1/0 -> /BYTES/0x0a0103
 
 # ---------------------------------------------------------
@@ -78,7 +78,7 @@ UPDATE tpi SET b = b + 1, c = 'foobar'
 ----
 Scan /Table/107/{1-2} lock Exclusive (Block, Unreplicated)
 Put /Table/107/1/3/0 -> /TUPLE/2:2:Int/2/1:3:Bytes/foobar
-Put (delete) (locking) /Table/107/2/"foo"/3/0
+Put (delete) /Table/107/2/"foo"/3/0
 Put /Table/107/2/"foobar"/3/0 -> /BYTES/0x0a0103
 
 # Update a row that matches the partial index before but not after.
@@ -87,7 +87,7 @@ UPDATE tpi SET c = 'baz'
 ----
 Scan /Table/107/{1-2} lock Exclusive (Block, Unreplicated)
 Put /Table/107/1/3/0 -> /TUPLE/2:2:Int/2/1:3:Bytes/baz
-Put (delete) (locking) /Table/107/2/"foobar"/3/0
+Put (delete) /Table/107/2/"foobar"/3/0
 
 # ---------------------------------------------------------
 # Expression Index With Delete Preserving Encoding
@@ -115,7 +115,7 @@ UPDATE tei SET a = a + 1, b = b + 100
 ----
 Scan /Table/108/{1-2} lock Exclusive (Block, Unreplicated)
 Put /Table/108/1/1/0 -> /TUPLE/2:2:Int/3/1:3:Int/200
-Put (delete) (locking) /Table/108/2/102/1/0
+Put (delete) /Table/108/2/102/1/0
 Put /Table/108/2/203/1/0 -> /BYTES/0x0a0103
 
 # Update a row with different values without changing the expected index entry.
@@ -153,10 +153,10 @@ UPDATE tii SET b = ARRAY[1, 2, 2, NULL, 4, 4]
 ----
 Scan /Table/109/{1-2} lock Exclusive (Block, Unreplicated)
 Put /Table/109/1/1/0 -> /TUPLE/2:2:Array/ARRAY[1,2,2,NULL,4,4]
-Put (delete) (locking) /Table/109/2/NULL/1/0
-Put (delete) (locking) /Table/109/2/1/1/0
-Put (delete) (locking) /Table/109/2/2/1/0
-Put (delete) (locking) /Table/109/2/3/1/0
+Put (delete) /Table/109/2/NULL/1/0
+Put (delete) /Table/109/2/1/1/0
+Put (delete) /Table/109/2/2/1/0
+Put (delete) /Table/109/2/3/1/0
 Put /Table/109/2/NULL/1/0 -> /BYTES/0x0a0103
 Put /Table/109/2/1/1/0 -> /BYTES/0x0a0103
 Put /Table/109/2/2/1/0 -> /BYTES/0x0a0103
@@ -188,7 +188,7 @@ UPDATE tmi SET b = 3, c = '{"a": "foobar", "c": "baz"}'::json
 ----
 Scan /Table/110/{1-2} lock Exclusive (Block, Unreplicated)
 Put /Table/110/1/1/0 -> /TUPLE/2:2:Int/3/1:3:SentinelType/{"a": "foobar", "c": "baz"}
-Put (delete) (locking) /Table/110/2/2/"a"/"foo"/1/0
-Put (delete) (locking) /Table/110/2/2/"b"/"bar"/1/0
+Put (delete) /Table/110/2/2/"a"/"foo"/1/0
+Put (delete) /Table/110/2/2/"b"/"bar"/1/0
 Put /Table/110/2/3/"a"/"foobar"/1/0 -> /BYTES/0x0a0103
 Put /Table/110/2/3/"c"/"baz"/1/0 -> /BYTES/0x0a0103

--- a/pkg/sql/testdata/index_mutations/delete_preserving_upsert
+++ b/pkg/sql/testdata/index_mutations/delete_preserving_upsert
@@ -23,7 +23,7 @@ UPSERT INTO ti VALUES (1, 3, 101)
 ----
 Scan /Table/106/1/1/0 lock Exclusive (Block, Unreplicated)
 Put /Table/106/1/1/0 -> /TUPLE/2:2:Int/3/1:3:Int/101
-Put (delete) (locking) /Table/106/2/2/100/1/0
+Put (delete) /Table/106/2/2/100/1/0
 Put /Table/106/2/3/101/1/0 -> /BYTES/0x0a0103
 
 # ---------------------------------------------------------
@@ -78,7 +78,7 @@ UPSERT INTO tpi VALUES (3, 2, 'foobar')
 ----
 Scan /Table/107/1/3/0 lock Exclusive (Block, Unreplicated)
 Put /Table/107/1/3/0 -> /TUPLE/2:2:Int/2/1:3:Bytes/foobar
-Put (delete) (locking) /Table/107/2/"foo"/3/0
+Put (delete) /Table/107/2/"foo"/3/0
 Put /Table/107/2/"foobar"/3/0 -> /BYTES/0x0a0103
 
 # Upsert a row that matches the partial index before but not after.
@@ -87,7 +87,7 @@ UPSERT INTO tpi VALUES (3, 1, 'baz')
 ----
 Scan /Table/107/1/3/0 lock Exclusive (Block, Unreplicated)
 Put /Table/107/1/3/0 -> /TUPLE/2:2:Int/1/1:3:Bytes/baz
-Put (delete) (locking) /Table/107/2/"foobar"/3/0
+Put (delete) /Table/107/2/"foobar"/3/0
 
 # ---------------------------------------------------------
 # Expression Index With Delete Preserving Encoding
@@ -115,7 +115,7 @@ UPSERT INTO tei VALUES (1, 3, 500)
 ----
 Scan /Table/108/1/1/0
 Put /Table/108/1/1/0 -> /TUPLE/2:2:Int/3/1:3:Int/500
-Put (delete) (locking) /Table/108/2/102/1/0
+Put (delete) /Table/108/2/102/1/0
 Put /Table/108/2/503/1/0 -> /BYTES/0x0a0103
 
 # Upsert a row with different values without changing the index entry.
@@ -132,7 +132,7 @@ UPSERT INTO tei VALUES (2, 4, 499)
 ----
 Scan /Table/108/1/2/0
 Put /Table/108/1/2/0 -> /TUPLE/2:2:Int/4/1:3:Int/499
-Put (delete) (locking) /Table/108/2/203/2/0
+Put (delete) /Table/108/2/203/2/0
 Put /Table/108/2/503/2/0 -> /BYTES/0x0a0103
 
 # ---------------------------------------------------------
@@ -161,10 +161,10 @@ UPSERT INTO tii VALUES (1, ARRAY[1, 2, 2, NULL, 4, 4])
 ----
 Scan /Table/109/1/1/0 lock Exclusive (Block, Unreplicated)
 Put /Table/109/1/1/0 -> /TUPLE/2:2:Array/ARRAY[1,2,2,NULL,4,4]
-Put (delete) (locking) /Table/109/2/NULL/1/0
-Put (delete) (locking) /Table/109/2/1/1/0
-Put (delete) (locking) /Table/109/2/2/1/0
-Put (delete) (locking) /Table/109/2/3/1/0
+Put (delete) /Table/109/2/NULL/1/0
+Put (delete) /Table/109/2/1/1/0
+Put (delete) /Table/109/2/2/1/0
+Put (delete) /Table/109/2/3/1/0
 Put /Table/109/2/NULL/1/0 -> /BYTES/0x0a0103
 Put /Table/109/2/1/1/0 -> /BYTES/0x0a0103
 Put /Table/109/2/2/1/0 -> /BYTES/0x0a0103
@@ -195,8 +195,8 @@ UPSERT INTO tmi VALUES (1, 3, '{"a": "foobar", "c": "baz"}'::json)
 ----
 Scan /Table/110/1/1/0 lock Exclusive (Block, Unreplicated)
 Put /Table/110/1/1/0 -> /TUPLE/2:2:Int/3/1:3:SentinelType/{"a": "foobar", "c": "baz"}
-Put (delete) (locking) /Table/110/2/2/"a"/"foo"/1/0
-Put (delete) (locking) /Table/110/2/2/"b"/"bar"/1/0
+Put (delete) /Table/110/2/2/"a"/"foo"/1/0
+Put (delete) /Table/110/2/2/"b"/"bar"/1/0
 Put /Table/110/2/3/"a"/"foobar"/1/0 -> /BYTES/0x0a0103
 Put /Table/110/2/3/"c"/"baz"/1/0 -> /BYTES/0x0a0103
 
@@ -260,7 +260,7 @@ UPSERT INTO mcf VALUES (1, 1, 'baz')
 Scan /Table/112/1/{1-2} lock Exclusive (Block, Unreplicated)
 Put /Table/112/1/1/0 -> /TUPLE/2:2:Int/1
 Put /Table/112/1/1/1/1 -> /BYTES/baz
-Put (delete) (locking) /Table/112/2/2/1/0
+Put (delete) /Table/112/2/2/1/0
 Put /Table/112/2/1/1/0 -> /BYTES/0x0a0103
 
 # Upsert a row that changes the second family but not the first

--- a/pkg/sql/testdata/index_mutations/merging
+++ b/pkg/sql/testdata/index_mutations/merging
@@ -183,7 +183,7 @@ UPDATE tifp SET b = ARRAY[1, 2, 2, NULL, 4, 4]
 ----
 Scan /Table/109/{1-2} lock Exclusive (Block, Unreplicated)
 Put /Table/109/1/1/0 -> /TUPLE/2:2:Array/ARRAY[1,2,2,NULL,4,4]
-Del (locking) /Table/109/2/3/1/0
+Del /Table/109/2/3/1/0
 Put /Table/109/2/4/1/0 -> /BYTES/
 
 # ---------------------------------------------------------
@@ -211,7 +211,7 @@ UPDATE tmfp SET b = 3, c = '{"a": "foobar", "c": "baz"}'::json
 ----
 Scan /Table/110/{1-2} lock Exclusive (Block, Unreplicated)
 Put /Table/110/1/1/0 -> /TUPLE/2:2:Int/3/1:3:SentinelType/{"a": "foobar", "c": "baz"}
-Del (locking) /Table/110/2/2/"a"/"foo"/1/0
-Del (locking) /Table/110/2/2/"b"/"bar"/1/0
+Del /Table/110/2/2/"a"/"foo"/1/0
+Del /Table/110/2/2/"b"/"bar"/1/0
 Put /Table/110/2/3/"a"/"foobar"/1/0 -> /BYTES/
 Put /Table/110/2/3/"c"/"baz"/1/0 -> /BYTES/


### PR DESCRIPTION
**execbuilder: improve tracing tests for UPDATEs and UPSERTs**

The updated tests will be used to show-case changes to lock acquisitions
for UPDATEs and UPSERTs with buffered writes. Also address a couple
TODOs by adding tests for "blind" Upsert and Delete fast-paths.

**sql: optimize locking behavior of delete portion of UPDATEs and UPSERTs**

This commit applies the same lock acquisition optimizations to `Del`
commands that are issued as part of UPDATEs and UPSERTs as we've already
applied for DELETEs. Namely, we don't need to performing locking Dels
when
- the initial scan has already acquired locks on the keys being deleted
- when deleting from non-unique secondary indexes.

Informs: #139106.
Informs: #139160.

Epic: None
Release note: None