### PR TITLE
kvcoord: ship entire write buffer on leaf txns

### DIFF
--- a/pkg/kv/kvclient/kvcoord/txn_coord_sender.go
+++ b/pkg/kv/kvclient/kvcoord/txn_coord_sender.go
@@ -1431,14 +1431,6 @@ func (tc *TxnCoordSender) GetLeafTxnFinalState(
 	//   	return nil, pErr.GoError()
 	//   }
 
-	// For compatibility with pre-20.1 nodes: populate the command
-	// count.
-	// TODO(knz,andrei): Remove this and the command count
-	// field in 20.2.
-	if tc.mu.active {
-		tfs.DeprecatedCommandCount = 1
-	}
-
 	// Copy mutable state so access is safe for the caller.
 	tfs.Txn = tc.mu.txn
 	for _, reqInt := range tc.interceptorStack {

--- a/pkg/kv/kvclient/kvcoord/txn_coord_sender.go
+++ b/pkg/kv/kvclient/kvcoord/txn_coord_sender.go
@@ -193,6 +193,10 @@ type txnInterceptor interface {
 	// for a LeafTxn.
 	populateLeafInputState(*roachpb.LeafTxnInputState)
 
+	// initializeLeaf updates any internal state held inside the interceptor
+	// from the given LeafTxn input state.
+	initializeLeaf(*roachpb.LeafTxnInputState)
+
 	// populateLeafFinalState populates the final payload
 	// for a LeafTxn to bring back into a RootTxn.
 	populateLeafFinalState(*roachpb.LeafTxnFinalState)
@@ -379,20 +383,16 @@ func newLeafTxnCoordSender(
 	// is initialized.
 	tcs.initCommonInterceptors(tcf, txn, kv.LeafTxn)
 
-	// Per-interceptor leaf initialization. If/when more interceptors
-	// need leaf initialization, this should be turned into an interface
-	// method on txnInterceptor with a loop here.
-	tcs.interceptorAlloc.txnPipeliner.initializeLeaf(tis)
-	tcs.interceptorAlloc.txnSeqNumAllocator.initializeLeaf(tis)
-
-	// Once the interceptors are initialized, piece them all together in the
-	// correct order.
+	// Piece necessary interceptors together in the correct order.
 	tcs.interceptorAlloc.arr = [cap(tcs.interceptorAlloc.arr)]txnInterceptor{
 		// LeafTxns never perform writes so the sequence number allocator
 		// should never increment its sequence number counter over its
 		// lifetime, but it still plays the important role of assigning each
 		// read request the latest sequence number.
 		&tcs.interceptorAlloc.txnSeqNumAllocator,
+		// The write buffer is needed on leaves in order to serve
+		// read-your-own-writes that were buffered on the root.
+		&tcs.interceptorAlloc.txnWriteBuffer,
 		// The pipeliner is needed on leaves to ensure that in-flight writes
 		// are chained onto by reads that should see them.
 		&tcs.interceptorAlloc.txnPipeliner,
@@ -409,9 +409,14 @@ func newLeafTxnCoordSender(
 	// If the root has informed us that the read spans are not needed by
 	// the root, we don't need the txnSpanRefresher.
 	if tis.RefreshInvalid {
-		tcs.interceptorStack = tcs.interceptorAlloc.arr[:2]
-	} else {
 		tcs.interceptorStack = tcs.interceptorAlloc.arr[:3]
+	} else {
+		tcs.interceptorStack = tcs.interceptorAlloc.arr[:4]
+	}
+
+	// Per-interceptor leaf initialization.
+	for _, reqInt := range tcs.interceptorStack {
+		reqInt.initializeLeaf(tis)
 	}
 
 	tcs.connectInterceptors()

--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_committer.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_committer.go
@@ -600,6 +600,9 @@ func (tc *txnCommitter) setWrapped(wrapped lockedSender) { tc.wrapped = wrapped 
 // populateLeafInputState is part of the txnInterceptor interface.
 func (*txnCommitter) populateLeafInputState(*roachpb.LeafTxnInputState) {}
 
+// initializeLeaf is part of the txnInterceptor interface.
+func (*txnCommitter) initializeLeaf(tis *roachpb.LeafTxnInputState) {}
+
 // populateLeafFinalState is part of the txnInterceptor interface.
 func (*txnCommitter) populateLeafFinalState(*roachpb.LeafTxnFinalState) {}
 

--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_heartbeater.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_heartbeater.go
@@ -285,6 +285,9 @@ func (h *txnHeartbeater) setWrapped(wrapped lockedSender) {
 // populateLeafInputState is part of the txnInterceptor interface.
 func (*txnHeartbeater) populateLeafInputState(*roachpb.LeafTxnInputState) {}
 
+// initializeLeaf is part of the txnInterceptor interface.
+func (*txnHeartbeater) initializeLeaf(tis *roachpb.LeafTxnInputState) {}
+
 // populateLeafFinalState is part of the txnInterceptor interface.
 func (*txnHeartbeater) populateLeafFinalState(*roachpb.LeafTxnFinalState) {}
 

--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_metric_recorder.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_metric_recorder.go
@@ -61,6 +61,9 @@ func (m *txnMetricRecorder) setWrapped(wrapped lockedSender) { m.wrapped = wrapp
 // populateLeafInputState is part of the txnInterceptor interface.
 func (*txnMetricRecorder) populateLeafInputState(*roachpb.LeafTxnInputState) {}
 
+// initializeLeaf is part of the txnInterceptor interface.
+func (*txnMetricRecorder) initializeLeaf(tis *roachpb.LeafTxnInputState) {}
+
 // populateLeafFinalState is part of the txnInterceptor interface.
 func (*txnMetricRecorder) populateLeafFinalState(*roachpb.LeafTxnFinalState) {}
 

--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_pipeliner.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_pipeliner.go
@@ -955,7 +955,7 @@ func (tp *txnPipeliner) populateLeafInputState(tis *roachpb.LeafTxnInputState) {
 	tis.InFlightWrites = tp.ifWrites.asSlice()
 }
 
-// initializeLeaf loads the in-flight writes for a leaf transaction.
+// initializeLeaf is part of the txnInterceptor interface.
 func (tp *txnPipeliner) initializeLeaf(tis *roachpb.LeafTxnInputState) {
 	// Copy all in-flight writes into the inFlightWrite tree.
 	for _, w := range tis.InFlightWrites {

--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_seq_num_allocator.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_seq_num_allocator.go
@@ -122,7 +122,7 @@ func (s *txnSeqNumAllocator) populateLeafInputState(tis *roachpb.LeafTxnInputSta
 	tis.ReadSeqNum = s.readSeq
 }
 
-// initializeLeaf loads the read seqnum for a leaf transaction.
+// initializeLeaf is part of the txnInterceptor interface.
 func (s *txnSeqNumAllocator) initializeLeaf(tis *roachpb.LeafTxnInputState) {
 	s.steppingMode = kv.SteppingMode(tis.SteppingModeEnabled)
 	s.readSeq = tis.ReadSeqNum

--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_span_refresher.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_span_refresher.go
@@ -769,6 +769,9 @@ func (sr *txnSpanRefresher) populateLeafInputState(tis *roachpb.LeafTxnInputStat
 	tis.RefreshInvalid = sr.refreshInvalid
 }
 
+// initializeLeaf is part of the txnInterceptor interface.
+func (*txnSpanRefresher) initializeLeaf(tis *roachpb.LeafTxnInputState) {}
+
 // populateLeafFinalState is part of the txnInterceptor interface.
 func (sr *txnSpanRefresher) populateLeafFinalState(tfs *roachpb.LeafTxnFinalState) {
 	tfs.RefreshInvalid = sr.refreshInvalid

--- a/pkg/roachpb/data.proto
+++ b/pkg/roachpb/data.proto
@@ -768,6 +768,18 @@ message AbortSpanEntry {
     (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/storage/enginepb.TxnPriority"];
 }
 
+// BufferedWrite contains information about all writes buffered on the root txn
+// for a given key.
+message BufferedWrite {
+  message Val {
+    Value val = 1 [(gogoproto.nullable) = false];
+    int32 seq = 2 [(gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/storage/enginepb.TxnSeq"];
+  }
+  uint64 id = 1 [(gogoproto.customname) = "ID"];
+  bytes key = 2 [(gogoproto.casttype) = "Key"];
+  repeated Val vals = 3 [(gogoproto.nullable) = false];
+}
+
 // LeafTxnInputState is the state from a transaction coordinator
 // necessary and sufficient to set up a leaf transaction coordinator
 // on another node.
@@ -796,6 +808,13 @@ message LeafTxnInputState {
   // updated via the (kv.TxnSender).Step() operation.
   int32 read_seq_num = 10 [
     (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/storage/enginepb.TxnSeq"];
+  // buffered_writes stores all writes that are buffered on the root txn (on the
+  // gateway node). Overlapping read requests need to be aware of these in order
+  // to support read-your-own-writes.
+  // TODO(#139060): ship only a part of the write buffer that intersects with
+  // tables that we'll be scanned by the leaf. Also consider applying the same
+  // optimization to in_flight_writes.
+  repeated BufferedWrite buffered_writes = 11 [(gogoproto.nullable) = false];
 }
 
 // LeafTxnFinalState is the state from a leaf transaction coordinator

--- a/pkg/roachpb/data.proto
+++ b/pkg/roachpb/data.proto
@@ -807,17 +807,11 @@ message LeafTxnFinalState {
   // record. This can be simplified.
   // See: https://github.com/cockroachdb/cockroach/issues/43192
   Transaction txn = 1 [(gogoproto.nullable) = false];
-  reserved 2;
-  // deprecated_command_count indicates that at least one request
-  // has been processed in this transaction.
-  // Populated only for compatibility with pre-20.1 nodes.
-  // TODO(knz,andrei): Remove this in 20.2.
-  int32 deprecated_command_count = 3;
+  reserved 2, 3;
   // refresh_spans contains the key spans read by the leaf. The root will add
   // them to its own tracking of reads.
   repeated Span refresh_spans = 4 [(gogoproto.nullable) = false];
-  reserved 5;
-  reserved 6;
+  reserved 5, 6;
   // refresh_invalid is set if refresh spans have not been collected. In this
   // case, refresh_spans is empty. It may be set because the leaf was asked not
   // to collect spans or because the leaf's reads exceeded the tracking memory


### PR DESCRIPTION
**roachpb: remove deprecated LeafTxnFinalState.DeprecatedCommandCount**

**kvcoord: ship entire write buffer on leaf txns**

In order to support read-your-own-writes semantics for DistSQL flows,
we need to communicate writes that are buffered on the root txn on
the gateway node to all remote nodes. This is done by extending the
LeafTxnInputState to contain all writes that are currently buffered by
the root and then injecting all of them into the write buffer on each
remote node. The LeafTxn interceptor stack has been adjusted to include
the write buffer. Additionally, `initializeLeaf` method is now lifted
up to the `txnInterceptor` interface.

For the moment, the whole write buffer is shipped (similar to in-flight
writes set), but we plan to reduce this to only those writes that might
actually be read by the remote processors. That is left as a TODO.

Fixes: #139058.
Release note: None