### PR TITLE
sql: enforce RLS check constraint in the execution engine

### DIFF
--- a/pkg/sql/catalog/descriptor.go
+++ b/pkg/sql/catalog/descriptor.go
@@ -718,6 +718,10 @@ type TableDescriptor interface {
 	// EnforcedCheckConstraints returns the subset of check constraints in
 	// EnforcedConstraints for this table, in the same order.
 	EnforcedCheckConstraints() []CheckConstraint
+	// EnforcedCheckValidators returns all check constraints that should
+	// be validated for violations, including both actual check constraints and
+	// any synthetic ones added (e.g., for row-level security).
+	EnforcedCheckValidators() []CheckConstraintValidator
 
 	// OutboundForeignKeys returns the subset of foreign key constraints in
 	// AllConstraints for this table, in the same order.

--- a/pkg/sql/catalog/table_elements.go
+++ b/pkg/sql/catalog/table_elements.go
@@ -550,6 +550,22 @@ type CheckConstraint interface {
 	IsHashShardingConstraint() bool
 }
 
+// CheckConstraintValidator interface is designed for evaluating whether check
+// constraints are violated. It represents a subset of the CheckConstraint
+// interface, excluding certain elements that are not applicable to synthetic
+// constraints added for row-level security.
+type CheckConstraintValidator interface {
+	// GetName returns the name of this constraint update mutation.
+	GetName() string
+
+	// GetExpr returns the check expression as a string.
+	GetExpr() string
+
+	// IsRLSConstraint returns true iff ths check constraint is the synthethic one
+	// to enforce row-level security policies.
+	IsRLSConstraint() bool
+}
+
 // ForeignKeyConstraint is an interface around a check constraint.
 type ForeignKeyConstraint interface {
 	WithoutIndexConstraint

--- a/pkg/sql/catalog/tabledesc/constraint.go
+++ b/pkg/sql/catalog/tabledesc/constraint.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/semenumpb"
 	"github.com/cockroachdb/cockroach/pkg/util"
+	"github.com/cockroachdb/errors"
 )
 
 type constraintBase struct {
@@ -50,7 +51,7 @@ func (c checkConstraint) CheckDesc() *descpb.TableDescriptor_CheckConstraint {
 	return c.desc
 }
 
-// Expr implements the catalog.CheckConstraint interface.
+// GetExpr implements the catalog.CheckConstraint interface.
 func (c checkConstraint) GetExpr() string {
 	return c.desc.Expr
 }
@@ -76,6 +77,9 @@ func (c checkConstraint) CollectReferencedColumnIDs() catalog.TableColSet {
 func (c checkConstraint) IsNotNullColumnConstraint() bool {
 	return c.desc.IsNonNullConstraint
 }
+
+// IsRLSConstraint implements the catalog.CheckConstraintValidator interface.
+func (c checkConstraint) IsRLSConstraint() bool { return false }
 
 // IsHashShardingConstraint implements the catalog.CheckConstraint interface.
 func (c checkConstraint) IsHashShardingConstraint() bool {
@@ -120,6 +124,26 @@ func (c checkConstraint) String() string {
 // IsEnforced implements the catalog.Constraint interface.
 func (c checkConstraint) IsEnforced() bool {
 	return !c.IsMutation() || c.WriteAndDeleteOnly()
+}
+
+// rlsSyntheticCheckConstraint is an implementation of CheckConstraintValidator
+// for use with tables that have row-level security enabled.
+type rlsSyntheticCheckConstraint struct {
+}
+
+var _ catalog.CheckConstraintValidator = (*rlsSyntheticCheckConstraint)(nil)
+
+// GetExpr implements the catalog.CheckConstraintValidator interface.
+func (r rlsSyntheticCheckConstraint) GetExpr() string {
+	panic(errors.AssertionFailedf("not implemented"))
+}
+
+// IsRLSConstraint implements the catalog.CheckConstraintValidator interface.
+func (r rlsSyntheticCheckConstraint) IsRLSConstraint() bool { return true }
+
+// GetName implements the catalog.CheckConstraintValidator interface.
+func (r rlsSyntheticCheckConstraint) GetName() string {
+	return "rlsSyntheticCheckConstraint"
 }
 
 type uniqueWithoutIndexConstraint struct {
@@ -339,6 +363,7 @@ type constraintCache struct {
 	uwis, uwisEnforced     []catalog.UniqueWithIndexConstraint
 	uwois, uwoisEnforced   []catalog.UniqueWithoutIndexConstraint
 	fkBackRefs             []catalog.ForeignKeyConstraint
+	checkValidators        []catalog.CheckConstraintValidator
 }
 
 // newConstraintCache returns a fresh fully-populated constraintCache struct for the
@@ -389,6 +414,7 @@ func newConstraintCache(
 				c.allEnforced = append(c.allEnforced, ck)
 				c.checks = append(c.checks, ck)
 				c.checksEnforced = append(c.checksEnforced, ck)
+				c.checkValidators = append(c.checkValidators, ck)
 			}
 		}
 		for _, m := range mutations.checks {
@@ -478,6 +504,11 @@ func newConstraintCache(
 			fkBackRefBackingStructs[i].desc = &desc.InboundFKs[i]
 			c.fkBackRefs[i] = &fkBackRefBackingStructs[i]
 		}
+	}
+	// Populate the check constraint for row-level security to enforce RLS policies.
+	if desc.RowLevelSecurityEnabled {
+		ck := rlsSyntheticCheckConstraint{}
+		c.checkValidators = append(c.checkValidators, ck)
 	}
 	return &c
 }

--- a/pkg/sql/catalog/tabledesc/table.go
+++ b/pkg/sql/catalog/tabledesc/table.go
@@ -356,6 +356,10 @@ func (desc *wrapper) EnforcedCheckConstraints() []catalog.CheckConstraint {
 	return desc.getExistingOrNewConstraintCache().checksEnforced
 }
 
+func (desc *wrapper) EnforcedCheckValidators() []catalog.CheckConstraintValidator {
+	return desc.getExistingOrNewConstraintCache().checkValidators
+}
+
 // OutboundForeignKeys implements the catalog.TableDescriptor interface.
 func (desc *wrapper) OutboundForeignKeys() []catalog.ForeignKeyConstraint {
 	return desc.getExistingOrNewConstraintCache().fks

--- a/pkg/sql/check.go
+++ b/pkg/sql/check.go
@@ -858,7 +858,7 @@ func checkMutationInput(
 			"mismatched check constraint columns: expected %d, got %d", checkOrds.Len(), len(checkVals))
 	}
 
-	checks := tabDesc.EnforcedCheckConstraints()
+	checks := tabDesc.EnforcedCheckValidators()
 	colIdx := 0
 	for i := range checks {
 		if !checkOrds.Contains(i) {

--- a/pkg/sql/colexec/insert.go
+++ b/pkg/sql/colexec/insert.go
@@ -201,7 +201,7 @@ func (v *vectorInserter) Next() coldata.Batch {
 }
 
 func (v *vectorInserter) checkMutationInput(ctx context.Context, b coldata.Batch) error {
-	checks := v.desc.EnforcedCheckConstraints()
+	checks := v.desc.EnforcedCheckValidators()
 	colIdx := 0
 	for i, ch := range checks {
 		if !v.checkOrds.Contains(i) {

--- a/pkg/sql/distsql_plan_changefeed.go
+++ b/pkg/sql/distsql_plan_changefeed.go
@@ -557,6 +557,11 @@ func (d *familyTableDescriptor) EnforcedCheckConstraints() []catalog.CheckConstr
 	return filtered
 }
 
+// EnforcedCheckValidators implements catalog.TableDescriptor interface.
+func (d *familyTableDescriptor) EnforcedCheckValidators() []catalog.CheckConstraintValidator {
+	panic(errors.AssertionFailedf("not implemented"))
+}
+
 // familyColumns returns column list adopted for targeted column family.
 func (d *familyTableDescriptor) familyColumns(cols []catalog.Column) []catalog.Column {
 	filtered := make([]catalog.Column, 0, len(cols)+1)

--- a/pkg/sql/logictest/testdata/logic_test/row_level_security
+++ b/pkg/sql/logictest/testdata/logic_test/row_level_security
@@ -985,17 +985,46 @@ statement ok
 GRANT ALL ON sensitive_data_table TO sensitive_user;
 
 statement ok
-CREATE FUNCTION my_sec_definer_function() RETURNS TABLE(ID INT)
+CREATE FUNCTION my_sec_definer_reader_function() RETURNS TABLE(ID INT)
 LANGUAGE SQL AS
 $$
  SELECT * FROM sensitive_data_table
 $$ SECURITY DEFINER;
 
 statement ok
-CREATE FUNCTION my_non_sec_definer_function() RETURNS TABLE(ID INT)
+CREATE FUNCTION my_non_sec_definer_reader_function() RETURNS TABLE(ID INT)
 LANGUAGE SQL AS
 $$
  SELECT * FROM sensitive_data_table
+$$;
+
+statement ok
+CREATE FUNCTION my_sec_definer_inserter_function(v INT) RETURNS VOID
+LANGUAGE SQL AS
+$$
+ INSERT INTO sensitive_data_table VALUES (v)
+$$ SECURITY DEFINER;
+
+statement ok
+CREATE FUNCTION my_non_sec_definer_inserter_function(v INT) RETURNS VOID
+LANGUAGE SQL AS
+$$
+ INSERT INTO sensitive_data_table VALUES (v)
+$$;
+
+
+statement ok
+CREATE FUNCTION my_sec_definer_updater_function(v INT) RETURNS VOID
+LANGUAGE SQL AS
+$$
+ UPDATE sensitive_data_table SET c1=v*2 WHERE c1 = v
+$$ SECURITY DEFINER;
+
+statement ok
+CREATE FUNCTION my_non_sec_definer_updater_function(v INT) RETURNS VOID
+LANGUAGE SQL AS
+$$
+ UPDATE sensitive_data_table SET c1=v*2 WHERE c1 = v
 $$;
 
 statement ok
@@ -1005,16 +1034,45 @@ query I rowsort
 SELECT * FROM sensitive_data_table;
 ----
 
+query I
+select my_sec_definer_inserter_function(10);
+----
+NULL
+
+query I
+select my_sec_definer_updater_function(2);
+----
+NULL
+
 query I rowsort
-SELECT my_sec_definer_function();
+SELECT my_sec_definer_reader_function();
 ----
 0
 1
-2
+4
+10
 
 query I rowsort
-SELECT my_non_sec_definer_function();
+SELECT my_non_sec_definer_reader_function();
 -----
+
+statement error pq: new row violates row-level security policy for table "sensitive_data_table"
+select my_non_sec_definer_inserter_function(20);
+
+# No error from the update because the lack of policies won't read any rows to
+# update. We verify nothing has changed right after.
+query I
+select my_non_sec_definer_updater_function(4);
+----
+NULL
+
+query I rowsort
+SELECT my_sec_definer_reader_function();
+----
+0
+1
+4
+10
 
 statement ok
 SET ROLE root
@@ -1026,29 +1084,70 @@ statement ok
 SET ROLE sensitive_user;
 
 query I rowsort
-SELECT my_sec_definer_function();
+SELECT my_sec_definer_reader_function();
 ----
 0
 1
-2
+4
+10
 
 query I rowsort
-SELECT my_non_sec_definer_function()
+SELECT my_non_sec_definer_reader_function()
 ----
 1
-2
+4
+10
+
+statement ok
+SET ROLE root;
+
+statement ok
+CREATE POLICY p2 ON sensitive_data_table FOR INSERT TO sensitive_user WITH CHECK (C1 != 55);
+
+statement ok
+CREATE POLICY p3 ON sensitive_data_table FOR UPDATE TO sensitive_user USING (true) WITH CHECK (C1 >= 10);
+
+statement ok
+SET ROLE sensitive_user;
+
+# violates new policy for insert
+statement error pq: new row violates row-level security policy for table "sensitive_data_table"
+select my_non_sec_definer_inserter_function(55);
+
+query I
+select my_non_sec_definer_inserter_function(54);
+----
+NULL
+
+# violates new policy for update
+statement error pq: new row violates row-level security policy for table "sensitive_data_table"
+select my_non_sec_definer_updater_function(4);
+
+query I
+select my_non_sec_definer_updater_function(10);
+----
+NULL
+
+query I rowsort
+SELECT my_sec_definer_reader_function();
+----
+0
+1
+4
+20
+54
 
 statement ok
 SET ROLE root
 
 statement ok
-DROP FUNCTION my_sec_definer_function;
+DROP FUNCTION my_sec_definer_reader_function;
 
 statement ok
-DROP FUNCTION my_non_sec_definer_function;
+DROP FUNCTION my_non_sec_definer_reader_function;
 
 statement ok
-DROP TABLE sensitive_data_table;
+DROP TABLE sensitive_data_table CASCADE;
 
 subtest truncate
 
@@ -1327,5 +1426,168 @@ REVOKE SYSTEM EXTERNALIOIMPLICITACCESS FROM z;
 
 statement ok
 DROP USER z;
+
+subtest rls_for_insert
+
+statement ok
+CREATE TABLE rlsInsert (c1 int not null primary key, c2 text, c3 date, family (c1,c2,c3));
+
+statement ok
+ALTER TABLE rlsInsert ENABLE ROW LEVEL SECURITY, FORCE ROW LEVEL SECURITY;
+
+statement ok
+CREATE POLICY p_insert ON rlsInsert AS PERMISSIVE FOR INSERT TO buck WITH CHECK (c3 not between '2012-01-01' and '2012-12-31');
+
+statement ok
+CREATE POLICY p_select ON rlsInsert AS PERMISSIVE FOR SELECT TO buck USING (true);
+
+statement ok
+GRANT ALL on rlsInsert TO buck;
+
+# Sanity that the admin can insert anything
+statement ok
+INSERT INTO rlsInsert VALUES (1, 'first', '2012-06-30');
+
+statement ok
+SET ROLE buck;
+
+statement ok
+INSERT INTO rlsInsert VALUES (2, 'second', '2010-06-30');
+
+# Violates policy because date is in 2012.
+statement error pq: new row violates row-level security policy for table "rlsinsert"
+INSERT INTO rlsInsert VALUES (3, 'third', '2012-07-08');
+
+# Violates policy because date is in 2012.
+statement error pq: new row violates row-level security policy for table "rlsinsert"
+INSERT INTO rlsInsert SELECT c1 + 5, c2, c3 FROM rlsInsert;
+
+statement ok
+INSERT INTO rlsInsert SELECT c1 + 5, c2, c3 FROM rlsInsert WHERE c3 not between '2012-01-01' and '2012-12-31';
+
+statement ok
+SET ROLE root;
+
+query TT
+SHOW CREATE TABLE rlsInsert
+----
+rlsinsert  CREATE TABLE public.rlsinsert (
+             c1 INT8 NOT NULL,
+             c2 STRING NULL,
+             c3 DATE NULL,
+             CONSTRAINT rlsinsert_pkey PRIMARY KEY (c1 ASC),
+             FAMILY fam_0_c1_c2_c3 (c1, c2, c3)
+           );
+           ALTER TABLE public.rlsinsert ENABLE ROW LEVEL SECURITY, FORCE ROW LEVEL SECURITY;
+           CREATE POLICY p_insert ON public.rlsinsert AS PERMISSIVE FOR INSERT TO buck WITH CHECK (c3 NOT BETWEEN '2012-01-01':::DATE AND '2012-12-31':::DATE);
+           CREATE POLICY p_select ON public.rlsinsert AS PERMISSIVE FOR SELECT TO buck USING (true)
+
+statement ok
+DROP POLICY p_insert on rlsInsert;
+
+statement ok
+SET ROLE buck;
+
+# There is no policy for insert, so we deny everything.
+statement error pq: new row violates row-level security policy for table "rlsinsert"
+INSERT INTO rlsInsert VALUES (4, 'fourth', '2022-10-08');
+
+query I
+select c1 from rlsInsert ORDER BY c1;
+----
+1
+2
+7
+
+statement ok
+SET ROLE root;
+
+statement ok
+DROP TABLE rlsInsert;
+
+subtest rls_for_update
+
+statement ok
+CREATE TYPE league AS ENUM('AL','NL');
+
+statement ok
+CREATE FUNCTION al_only(l league) RETURNS BOOL AS $$
+BEGIN
+  RETURN l = 'AL';
+END;
+$$ LANGUAGE PLpgSQL;
+
+statement ok
+CREATE SEQUENCE seq1;
+
+statement ok
+CREATE TABLE bbteams (team text, league league, wins int, family (team, league, wins));
+
+statement ok
+ALTER TABLE bbteams ENABLE ROW LEVEL SECURITY;
+
+statement ok
+CREATE POLICY p_update ON bbteams FOR UPDATE TO buck USING (true) WITH CHECK (league = 'AL' and nextval('seq1') < 1000);
+
+statement ok
+CREATE POLICY p_select ON bbteams FOR SELECT TO buck USING (true);
+
+statement ok
+CREATE POLICY p_insert ON bbteams FOR INSERT TO buck WITH CHECK (nextval('seq1') < 1000);
+
+statement ok
+GRANT ALL on bbteams TO buck;
+
+statement ok
+GRANT USAGE ON seq1 TO buck;
+
+statement ok
+GRANT UPDATE ON seq1 TO buck;
+
+statement ok
+SET ROLE buck;
+
+statement ok
+INSERT INTO bbteams(team, league) VALUES ('guardians', 'AL'), ('royals', 'AL'), ('expos', 'NL');
+
+# Should be violated because expos are not in the AL league.
+statement error pq: new row violates row-level security policy for table "bbteams"
+UPDATE bbteams SET wins = 91 WHERE team = 'expos';
+
+# Is allowed because league changed to AL at the same time.
+statement ok
+UPDATE bbteams SET wins = 87, league = 'AL' WHERE team = 'expos';
+
+# Change the sequence so that it's value violates the WITH CHECK expression for
+# the update policy.
+statement ok
+select setval('seq1', 1500, true);
+
+statement error pq: new row violates row-level security policy for table "bbteams"
+UPDATE bbteams SET wins = 82  WHERE team = 'royals';
+
+statement ok
+SET ROLE root
+
+query I
+SELECT nextval('seq1')
+----
+1502
+
+query TTI
+select team, league, wins from bbteams order by team;
+----
+expos      AL  87
+guardians  AL  NULL
+royals     AL  NULL
+
+statement ok
+DROP TABLE bbteams;
+
+statement ok
+DROP FUNCTION al_only;
+
+statement ok
+DROP SEQUENCE seq1;
 
 subtest end

--- a/pkg/sql/row/errors.go
+++ b/pkg/sql/row/errors.go
@@ -300,8 +300,15 @@ func CheckFailed(
 	semaCtx *tree.SemaContext,
 	sessionData *sessiondata.SessionData,
 	tabDesc catalog.TableDescriptor,
-	check catalog.CheckConstraint,
+	check catalog.CheckConstraintValidator,
 ) error {
+	// If this is the synthetic check added for row-level security, we should
+	// return a different error.
+	if check.IsRLSConstraint() {
+		return pgerror.Newf(pgcode.InsufficientPrivilege,
+			"new row violates row-level security policy for table %q",
+			tabDesc.GetName())
+	}
 	// Failed to satisfy CHECK constraint, so unwrap the serialized
 	// check expression to display to the user.
 	expr, err := schemaexpr.FormatExprForDisplay(


### PR DESCRIPTION
This builds on the work in #141614, which introduced a synthetic check constraint for tables with row-level security (RLS) enabled. This change ensures that the execution engine evaluates the constraint and fails the operation if it is violated.

To achieve this, it adds a synthetic check constraint in the execution engine, mirroring the one created during query planning. Since this constraint is not a real check constraint, a new interface, CheckConstraintValidator, has been introduced to handle validation logic specifically for reporting constraint violations.

Epic: CRDB-45203
Release note: None
Informs: #136704