### PR TITLE
sql/opt: add policy information to EXPLAIN for writes

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/mutation.go
+++ b/pkg/sql/opt/exec/execbuilder/mutation.go
@@ -643,32 +643,42 @@ func (b *Builder) buildDelete(del *memo.DeleteExpr) (_ execPlan, outputCols colO
 	return ep, outputCols, nil
 }
 
-// tryBuildDeleteRange attempts to construct a fast DeleteRange execution for a
-// logical Delete operator, checking all required conditions. See
-// exec.Factory.ConstructDeleteRange.
-func (b *Builder) tryBuildDeleteRange(del *memo.DeleteExpr) (_ execPlan, ok bool, _ error) {
+// canUseDeleteRange checks whether the memo.DeleteExpr can be built into
+// a delete range plan.
+func (b *Builder) canUseDeleteRange(del *memo.DeleteExpr) bool {
 	// If rows need to be returned from the Delete operator (i.e. RETURNING
 	// clause), no fast path is possible, because row values must be fetched.
 	if del.NeedResults() {
-		return execPlan{}, false, nil
+		return false
 	}
 
 	// Check for simple Scan input operator without a limit; anything else is not
 	// supported by a range delete.
 	if scan, ok := del.Input.(*memo.ScanExpr); !ok || scan.HardLimit != 0 {
-		return execPlan{}, false, nil
+		return false
 	}
 
 	tab := b.mem.Metadata().Table(del.Table)
 	if tab.DeletableIndexCount() > 1 {
 		// Any secondary index prevents fast path, because separate delete batches
 		// must be formulated to delete rows from them.
-		return execPlan{}, false, nil
+		return false
 	}
 
 	// We can use the fast path if we don't need to buffer the input to the
 	// delete operator (for foreign key checks/cascades).
 	if del.WithID != 0 {
+		return false
+	}
+
+	return true
+}
+
+// tryBuildDeleteRange attempts to construct a fast DeleteRange execution for a
+// logical Delete operator, checking all required conditions. See
+// exec.Factory.ConstructDeleteRange.
+func (b *Builder) tryBuildDeleteRange(del *memo.DeleteExpr) (_ execPlan, ok bool, _ error) {
+	if !b.canUseDeleteRange(del) {
 		return execPlan{}, false, nil
 	}
 

--- a/pkg/sql/opt/exec/explain/emit.go
+++ b/pkg/sql/opt/exec/explain/emit.go
@@ -705,10 +705,7 @@ func (e *emitter) emitNodeAttributes(ctx context.Context, evalCtx *eval.Context,
 			ob.VAttr("parallel", "")
 		}
 		e.emitLockingPolicy(a.Params.Locking)
-
-		if val, ok := n.annotations[exec.PolicyInfoID]; ok {
-			e.emitPolicies(ob, a.Table, val.(*exec.RLSPoliciesApplied))
-		}
+		e.emitPolicies(ob, a.Table, n)
 
 	case valuesOp:
 		a := n.args.(*valuesArgs)
@@ -716,9 +713,7 @@ func (e *emitter) emitNodeAttributes(ctx context.Context, evalCtx *eval.Context,
 		if len(a.Rows) > 0 && (len(a.Rows) > 1 || len(a.Columns) > 0) {
 			e.emitTuples(tree.RawRows(a.Rows), len(a.Columns))
 		} else if len(a.Rows) == 0 {
-			if val, ok := n.annotations[exec.PolicyInfoID]; ok {
-				e.emitPolicies(ob, nil, val.(*exec.RLSPoliciesApplied))
-			}
+			e.emitPolicies(ob, nil, n)
 		}
 
 	case filterOp:
@@ -1000,6 +995,7 @@ func (e *emitter) emitNodeAttributes(ctx context.Context, evalCtx *eval.Context,
 			}
 			ob.LeaveNode()
 		}
+		e.emitPolicies(ob, a.Table, n)
 
 	case insertFastPathOp:
 		a := n.args.(*insertFastPathArgs)
@@ -1034,6 +1030,7 @@ func (e *emitter) emitNodeAttributes(ctx context.Context, evalCtx *eval.Context,
 			// triggers.
 			return errors.AssertionFailedf("insert fast path with before-triggers")
 		}
+		e.emitPolicies(ob, a.Table, n)
 
 	case upsertOp:
 		a := n.args.(*upsertArgs)
@@ -1073,6 +1070,7 @@ func (e *emitter) emitNodeAttributes(ctx context.Context, evalCtx *eval.Context,
 			}
 			ob.LeaveNode()
 		}
+		e.emitPolicies(ob, a.Table, n)
 
 	case updateOp:
 		a := n.args.(*updateArgs)
@@ -1094,6 +1092,7 @@ func (e *emitter) emitNodeAttributes(ctx context.Context, evalCtx *eval.Context,
 			}
 			ob.LeaveNode()
 		}
+		e.emitPolicies(ob, a.Table, n)
 
 	case deleteOp:
 		a := n.args.(*deleteArgs)
@@ -1128,6 +1127,7 @@ func (e *emitter) emitNodeAttributes(ctx context.Context, evalCtx *eval.Context,
 			// DeleteRange should not be planned if there are applicable triggers.
 			return errors.AssertionFailedf("delete range with before-triggers")
 		}
+		e.emitPolicies(ob, a.Table, n)
 
 	case showCompletionsOp:
 		a := n.args.(*showCompletionsArgs)
@@ -1384,12 +1384,15 @@ func (e *emitter) emitJoinAttributes(
 	e.ob.Expr("pred", extraOnCond, appendColumns(leftCols, rightCols...))
 }
 
-func (e *emitter) emitPolicies(
-	ob *OutputBuilder, table cat.Table, applied *exec.RLSPoliciesApplied,
-) {
+func (e *emitter) emitPolicies(ob *OutputBuilder, table cat.Table, n *Node) {
 	if !ob.flags.ShowPolicyInfo {
 		return
 	}
+	val, ok := n.annotations[exec.PolicyInfoID]
+	if !ok {
+		return
+	}
+	applied := val.(*exec.RLSPoliciesApplied)
 
 	if applied.PoliciesSkippedForRole {
 		ob.AddField("policies", "exempt for role")

--- a/pkg/sql/opt/exec/explain/testdata/row_level_security
+++ b/pkg/sql/opt/exec/explain/testdata/row_level_security
@@ -171,3 +171,203 @@ select t1.c1 from t1, t2 where t1.c1 = t2.c1 and t1.c1 = 1;
           table: t2@t2_pkey
           spans: FULL SCAN
           policies: t2_pol_1
+
+# Show policy information for insert
+# ----------------------------------------------------------------------
+
+exec-ddl
+CREATE TABLE writer (key int not null primary key, value text);
+----
+
+exec-ddl
+ALTER TABLE writer ENABLE ROW LEVEL SECURITY;
+----
+
+plan
+INSERT INTO writer VALUES (0, 'zero')
+----
+• insert fast path
+  into: writer(key, value)
+  auto commit
+  size: 3 columns, 1 row
+  policies: row-level security enabled, no policies applied.
+
+exec-ddl
+CREATE POLICY p_insert on writer FOR INSERT WITH CHECK (value like 'inserted: %');
+----
+
+plan
+INSERT INTO writer VALUES (1, 'one'), (2, 'two');
+----
+• insert
+│ into: writer(key, value)
+│ auto commit
+│ policies: p_insert
+│
+└── • render
+    │
+    └── • values
+          size: 2 columns, 2 rows
+
+plan
+INSERT INTO writer VALUES (3, 'three');
+----
+• insert fast path
+  into: writer(key, value)
+  auto commit
+  size: 3 columns, 1 row
+  policies: p_insert
+
+exec-ddl
+CREATE TABLE populator (key int not null primary key, value text);
+----
+
+plan
+INSERT INTO writer SELECT * from populator
+----
+• insert
+│ into: writer(key, value)
+│ auto commit
+│ policies: p_insert
+│
+└── • render
+    │
+    └── • scan
+          table: populator@populator_pkey
+          spans: FULL SCAN
+
+# Show policy information for update
+# ----------------------------------------------------------------------
+
+plan
+UPDATE writer SET key = key * 10;
+----
+• update
+│ table: writer
+│ set: key
+│ auto commit
+│ policies: row-level security enabled, no policies applied.
+│
+└── • render
+    │
+    └── • norows
+          policies: row-level security enabled, no policies applied.
+
+exec-ddl
+CREATE POLICY p_update1 ON writer FOR UPDATE USING (key = 5)  WITH CHECK (value like 'updater: %')
+----
+
+exec-ddl
+CREATE POLICY p_update2 ON writer FOR UPDATE WITH CHECK (value IN ('updater: a', 'updater: b', 'updater: c'))
+----
+
+plan
+UPDATE writer SET key = key * 11;
+----
+• update
+│ table: writer
+│ set: key
+│ auto commit
+│ policies: p_update1
+│
+└── • render
+    │
+    └── • scan
+          table: writer@writer_pkey
+          spans: 1+ spans
+          locking strength: for update
+          policies: p_update1
+
+plan
+UPDATE writer SET key = key * 15 WHERE value = 'some-val' or value = 'other-val';
+----
+• update
+│ table: writer
+│ set: key
+│ auto commit
+│ policies: p_update1
+│
+└── • render
+    │
+    └── • filter
+        │ filter: (value = _) OR (value = _)
+        │
+        └── • scan
+              table: writer@writer_pkey
+              spans: 1+ spans
+              policies: p_update1
+
+plan
+UPDATE writer SET value = 'updated' WHERE key between 1 and 100;
+----
+• update
+│ table: writer
+│ set: value
+│ auto commit
+│ policies: p_update1
+│
+└── • render
+    │
+    └── • scan
+          table: writer@writer_pkey
+          spans: 1+ spans
+          locking strength: for update
+          policies: p_update1
+
+plan
+UPDATE writer SET value = value WHERE key = 5;
+----
+• update
+│ table: writer
+│ set: value
+│ auto commit
+│ policies: p_update1
+│
+└── • render
+    │
+    └── • scan
+          table: writer@writer_pkey
+          spans: 1+ spans
+          locking strength: for update
+          policies: p_update1
+
+# Show policy information for delete
+# ----------------------------------------------------------------------
+
+plan
+DELETE FROM writer WHERE key = 1;
+----
+• delete
+│ from: writer
+│ auto commit
+│
+└── • norows
+      policies: row-level security enabled, no policies applied.
+
+exec-ddl
+CREATE POLICY p_delete ON writer FOR DELETE USING (key = 1);
+----
+
+plan
+DELETE FROM writer WHERE key = 1;
+----
+• delete range
+  from: writer
+  auto commit
+  spans: 1+ spans
+  policies: p_delete
+
+plan
+DELETE FROM writer WHERE value = 'some-val' or value = 'other-val';
+----
+• delete
+│ from: writer
+│ auto commit
+│
+└── • filter
+    │ filter: (value = _) OR (value = _)
+    │
+    └── • scan
+          table: writer@writer_pkey
+          spans: 1+ spans
+          policies: p_delete

--- a/pkg/sql/opt/metadata.go
+++ b/pkg/sql/opt/metadata.go
@@ -335,7 +335,7 @@ func (md *Metadata) CopyFrom(from *Metadata, copyScalarFn func(Expr) Expr) {
 	md.withBindings = nil
 
 	md.rlsMeta = from.rlsMeta
-	md.rlsMeta.PoliciesApplied = make(map[TableID]PolicyIDSet)
+	md.rlsMeta.PoliciesApplied = make(map[TableID]PoliciesApplied)
 	for id, policies := range from.rlsMeta.PoliciesApplied {
 		md.rlsMeta.PoliciesApplied[id] = policies.Copy()
 	}

--- a/pkg/sql/opt/optbuilder/row_level_security.go
+++ b/pkg/sql/opt/optbuilder/row_level_security.go
@@ -71,7 +71,7 @@ func (b *Builder) buildRowLevelSecurityUsingExpression(
 		typedExpr := tableScope.resolveType(parsedExpr, types.AnyElement)
 		scalar := b.buildScalar(typedExpr, tableScope, nil, nil, nil)
 		// TODO(136742): Apply multiple RLS policies.
-		b.factory.Metadata().GetRLSMeta().AddPoliciesUsed(tabMeta.MetaID, policiesUsed)
+		b.factory.Metadata().GetRLSMeta().AddPoliciesUsed(tabMeta.MetaID, policiesUsed, true /* applyFilterExpr */)
 		return scalar
 	}
 
@@ -187,7 +187,7 @@ func (r *optRLSConstraintBuilder) genExpression(ctx context.Context) (string, []
 		sb.WriteString(expr)
 		sb.WriteString(")")
 		// TODO(136742): Add support for multiple policies.
-		r.md.GetRLSMeta().AddPoliciesUsed(r.tabMeta.MetaID, policiesUsed)
+		r.md.GetRLSMeta().AddPoliciesUsed(r.tabMeta.MetaID, policiesUsed, false /* applyFilterExpr */)
 		break
 	}
 


### PR DESCRIPTION
This builds on the previous change that annotated verbose EXPLAIN output with policy information, which applied only to read operations. This update extends that functionality to INSERT, UPDATE, DELETE, and UPSERT operations.

Epic: CRDB-45203
Release note: none
Informs #136704