### PR TITLE
server: only cache ui assets for http requests

### DIFF
--- a/pkg/server/server_http.go
+++ b/pkg/server/server_http.go
@@ -353,7 +353,7 @@ func startHTTPService(
 // gzip middleware, then delegates to the mux for handling the request.
 func (s *httpServer) baseHandler(w http.ResponseWriter, r *http.Request) {
 	// Disable caching of responses.
-	w.Header().Set("Cache-control", "no-cache")
+	w.Header().Set("Cache-control", "no-store")
 
 	if HSTSEnabled.Get(&s.cfg.Settings.SV) {
 		w.Header().Set("Strict-Transport-Security", hstsHeaderValue)

--- a/pkg/util/httputil/etag_handler_test.go
+++ b/pkg/util/httputil/etag_handler_test.go
@@ -110,6 +110,12 @@ func TestEtagHandler(t *testing.T) {
 					resp.Header.Get("ETag"),
 					"Requests for hashed files must always include an ETag response header",
 				)
+				require.Equal(
+					t,
+					"no-cache",
+					resp.Header.Get("Cache-Control"),
+					`Requests for hashed files must always include a "Cache-control: no-cache" response header`,
+				)
 			}
 
 			bodyBytes, err := io.ReadAll(resp.Body)

--- a/pkg/util/httputil/handlers.go
+++ b/pkg/util/httputil/handlers.go
@@ -41,6 +41,7 @@ func EtagHandler(contentHashes map[string]string, next http.Handler) http.Handle
 			//   incorrect If-None-Match header, the content has changed since the
 			//   last value and must be served with its identifying hash.
 			w.Header().Add("ETag", wrappedChecksum)
+			w.Header().Set("Cache-Control", "no-cache")
 		}
 
 		if ifNoneMatch != "" && wrappedChecksum == ifNoneMatch {


### PR DESCRIPTION
Previously, all server http responses were setting the "Cache-control" header to "no-cache". This still caches responses, but requires the client to validate the each request with the origin server.

Due to privacy concerns, this is being changed to "no-store", which does not cache the responses at all. In order to ensure that UI assets are still cached, the "no-cache" cache control will be set only for UI assets that include ETag headers.

Resolves: CRDB-48220
Release note (general change): This change updates the response headers of http request to include: "Cache-control: no-store" instead of "Cache-control:no-cache". This change means that http requests to the server will no longer be cached in the client. requests for UI assets, such as bundle.js, fonts, etc. will still include "Cache-control:no-cache" to ensure they are cached and that db console loads quickly.