### PR TITLE
ui: add Content-Security-Policy header DB console index.html

### DIFF
--- a/pkg/ui/ui_test.go
+++ b/pkg/ui/ui_test.go
@@ -43,7 +43,6 @@ func (t testFs) Open(name string) (fs.File, error) {
 func TestUIHandlerDevelopment(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-
 	defer func() func() {
 		hold := Assets
 		Assets = &testFs{}
@@ -117,6 +116,12 @@ func TestUIHandlerDevelopment(t *testing.T) {
 			resp2, err := server.Client().Do(req2)
 			require.NoError(t, err)
 			require.Equal(t, 200, resp2.StatusCode)
+
+			if tc.devHeader || tc.haveUI {
+				require.Equal(t, resp.Header.Get("Content-Security-Policy"), cspHeader)
+			} else {
+				require.Empty(t, resp.Header.Get("Content-Security-Policy"))
+			}
 		})
 	}
 


### PR DESCRIPTION
Previously, DB console returned the index.html file with no Content-Security-Policy (CSP) header, leaving it open for potential XSS attacks.

This commit adds the CSP header, setting the default-src to 'self', with a few overrides on necessary directives. As a result, only resources that have the same origin as index.html will be loaded.

Overriden directives:
 - style-src: 'unsafe-inline' is set to render inline styles in react.
 - front-src, img-src: data: is set to allow embeded images and fonts.
 - connect-src: https://register.cockroachdb.com/ allows db console to send analytics data to the registration service

Epic: [CRDB-43154](https://cockroachlabs.atlassian.net/browse/CRDB-43154)
Resolves: https://cockroachlabs.atlassian.net/browse/CRDB-48221
Release note (ui change): DB console's index.html page now includes a Content-Security-Policy (CSP) header to help prevent malicious XSS attacks.