### PR TITLE
roachtest: get `CopyRoachprodState` before other artifacts

### DIFF
--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -1709,6 +1709,11 @@ func (r *testRunner) collectArtifacts(
 		// NB: fetch the logs *first* in case one of the other steps
 		// below has problems.
 		t.L().PrintfCtx(ctx, "collecting cluster logs")
+		// Do this before collecting any other logs to make sure we _always_ have roachprod state;
+		// i.e., we don't want an uncaught panic to preempt us.
+		if err := c.CopyRoachprodState(ctx); err != nil {
+			t.L().Printf("failed to copy roachprod state: %s", err)
+		}
 		// Do this before collecting logs to make sure the file gets
 		// downloaded below.
 		if err := saveDiskUsageToLogsDir(ctx, c); err != nil {
@@ -1725,9 +1730,6 @@ func (r *testRunner) collectArtifacts(
 		}
 		if err := c.FetchCores(ctx, t.L()); err != nil {
 			t.L().Printf("failed to fetch cores: %s", err)
-		}
-		if err := c.CopyRoachprodState(ctx); err != nil {
-			t.L().Printf("failed to copy roachprod state: %s", err)
 		}
 		if err := c.FetchPebbleCheckpoints(ctx, t.L()); err != nil {
 			t.L().Printf("failed to fetch Pebble checkpoints: %s", err)


### PR DESCRIPTION
We've seen a `panic` in `getArtifacts`, due to n4
being outside VMs loaded by `LoadClusters`; i.e.,
`len(c.VMs) <= 3`. The cluster creation log
does indeed contain 4 VMs, which suggests
this was an "eventual consistency" issue
emanating from AWS cloud API.

Since the panic preempted `CopyRoachprodState`,
we're unable to confirm that's indeed what
happened, even though there is seemingly
no other possible alternative. This change
merely moves `CopyRoachprodState` to be
executed _before_ any other artifact collection
functions. Thus, the roachprod state will
always be collected, even if any subsequent
collectors panic.

Epic: none

Release note: None