### PR TITLE
roachtest: lower foreground throughput on AC disk bandwidth test

### DIFF
--- a/pkg/cmd/roachtest/tests/admission_control_disk_bandwidth_overload.go
+++ b/pkg/cmd/roachtest/tests/admission_control_disk_bandwidth_overload.go
@@ -85,7 +85,7 @@ func registerDiskBandwidthOverload(r registry.Registry) {
 
 			c.Run(ctx, option.WithNodes(c.WorkloadNode()),
 				"./cockroach workload init kv --drop --insert-count=400 "+
-					"--max-block-bytes=512 --min-block-bytes=512"+foregroundDB+url)
+					"--max-block-bytes=256 --min-block-bytes=256"+foregroundDB+url)
 
 			c.Run(ctx, option.WithNodes(c.WorkloadNode()),
 				"./cockroach workload init kv --drop --insert-count=400 "+
@@ -104,7 +104,7 @@ func registerDiskBandwidthOverload(r registry.Registry) {
 				}
 				url := fmt.Sprintf(" {pgurl%s}", c.CRDBNodes())
 				cmd := fmt.Sprintf("./cockroach workload run kv %s --concurrency=2 "+
-					"--splits=1000 --read-percent=50 --min-block-bytes=512 --max-block-bytes=512 "+
+					"--splits=1000 --read-percent=50 --min-block-bytes=256 --max-block-bytes=256 "+
 					"--txn-qos='regular' --tolerate-errors %s %s %s",
 					roachtestutil.GetWorkloadHistogramArgs(t, c, labels), foregroundDB, dur, url)
 				c.Run(ctx, option.WithNodes(c.WorkloadNode()), cmd)

--- a/pkg/cmd/roachtest/tests/admission_control_disk_bandwidth_overload.go
+++ b/pkg/cmd/roachtest/tests/admission_control_disk_bandwidth_overload.go
@@ -171,9 +171,11 @@ func registerDiskBandwidthOverload(r registry.Registry) {
 
 				// Allow a 5% room for error.
 				const bandwidthThreshold = bandwidthLimit * 1.05
+				const sampleCountForBW = 12
 				const collectionIntervalSeconds = 10.0
 				// Loop for ~20 minutes.
 				const numIterations = int(20 / (collectionIntervalSeconds / 60))
+				var writeBWValues []float64
 				numErrors := 0
 				numSuccesses := 0
 				for i := 0; i < numIterations; i++ {
@@ -189,10 +191,16 @@ func registerDiskBandwidthOverload(r registry.Registry) {
 						continue
 					}
 					totalBW := writeVal + readVal
-					// TODO(aaditya): We should be asserting on total bandwidth once reads
-					// are being paced.
-					if writeVal > bandwidthThreshold {
-						t.Fatalf("write bandwidth %f exceeded threshold of %f, read bandwidth: %f, total bandwidth: %f", writeVal, bandwidthThreshold, readVal, totalBW)
+					writeBWValues = append(writeBWValues, writeVal)
+					// We want to use the mean of the last 2m of data to avoid short-lived
+					// spikes causing failures.
+					if len(writeBWValues) >= sampleCountForBW {
+						// TODO(aaditya): We should be asserting on total bandwidth once reads
+						// are being paced.
+						latestSampleMeanForBW := roachtestutil.GetMeanOverLastN(sampleCountForBW, writeBWValues)
+						if latestSampleMeanForBW > bandwidthThreshold {
+							t.Fatalf("mean write bandwidth over the last 2m %f (last iter: %f) exceeded threshold of %f, read bandwidth: %f, total bandwidth: %f", latestSampleMeanForBW, writeVal, bandwidthThreshold, readVal, totalBW)
+						}
 					}
 					numSuccesses++
 				}


### PR DESCRIPTION
First commit is being reviewed separately. We should only merge this if the flakiness of the test persists after the other one is merged.

----

This is to avoid overload caused by foreground workloads which often leads to flaky tests.

Informs https://github.com/cockroachdb/cockroach/issues/141694.

Release note: None