### PR TITLE
release-24.3: roachprod: avoid syncing all the time

### DIFF
--- a/pkg/cmd/roachprod/main.go
+++ b/pkg/cmd/roachprod/main.go
@@ -204,7 +204,7 @@ if the user would like to update the keys on the remote hosts.
 
 	Args: cobra.ExactArgs(1),
 	Run: wrap(func(cmd *cobra.Command, args []string) (retErr error) {
-		return roachprod.SetupSSH(context.Background(), config.Logger, args[0])
+		return roachprod.SetupSSH(context.Background(), config.Logger, args[0], true)
 	}),
 }
 

--- a/pkg/roachprod/cloud/BUILD.bazel
+++ b/pkg/roachprod/cloud/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
         "//pkg/roachprod/vm/aws",
         "//pkg/roachprod/vm/azure",
         "//pkg/roachprod/vm/gce",
+        "//pkg/util/syncutil",
         "//pkg/util/timeutil",
         "@com_github_aws_aws_sdk_go//aws",
         "@com_github_aws_aws_sdk_go_v2_config//:config",

--- a/pkg/roachprod/clusters_cache.go
+++ b/pkg/roachprod/clusters_cache.go
@@ -113,6 +113,12 @@ func loadCluster(name string) (*cloud.Cluster, error) {
 	return c, nil
 }
 
+// deleteCluster deletes the file in config.ClusterDir for a given cluster name.
+func deleteCluster(name string) error {
+	filename := clusterFilename(name)
+	return os.Remove(filename)
+}
+
 // shouldIgnoreCluster returns true if the cluster references a project that is
 // not active. This is relevant if we have a cluster that was cached when
 // another project was in use.

--- a/pkg/roachprod/install/cluster_synced.go
+++ b/pkg/roachprod/install/cluster_synced.go
@@ -1432,7 +1432,7 @@ func (c *SyncedCluster) RunWithDetails(
 // Wait TODO(peter): document
 func (c *SyncedCluster) Wait(ctx context.Context, l *logger.Logger) error {
 	display := fmt.Sprintf("%s: waiting for nodes to start", c.Name)
-	_, hasError, err := c.ParallelE(ctx, l, WithNodes(c.Nodes).WithDisplay(display).WithRetryDisabled(),
+	results, hasError, err := c.ParallelE(ctx, l, WithNodes(c.Nodes).WithDisplay(display).WithRetryDisabled(),
 		func(ctx context.Context, node Node) (*RunResultDetails, error) {
 			res := &RunResultDetails{Node: node}
 			var err error
@@ -1468,7 +1468,13 @@ func (c *SyncedCluster) Wait(ctx context.Context, l *logger.Logger) error {
 	}
 
 	if hasError {
-		return errors.New("not all nodes booted successfully")
+		errs := []error{}
+		for _, res := range results {
+			if res != nil && res.Err != nil {
+				errs = append(errs, res.Err)
+			}
+		}
+		return errors.Wrap(errors.Join(errs...), "not all nodes booted successfully")
 	}
 	return nil
 }

--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -639,17 +639,22 @@ func Reset(l *logger.Logger, clusterName string) error {
 }
 
 // SetupSSH sets up the keys and host keys for the vms in the cluster.
-func SetupSSH(ctx context.Context, l *logger.Logger, clusterName string) error {
+func SetupSSH(ctx context.Context, l *logger.Logger, clusterName string, sync bool) error {
 	if err := LoadClusters(); err != nil {
 		return err
 	}
-	cld, err := Sync(l, vm.ListOptions{})
-	if err != nil {
-		return err
+	var cloudCluster *cloud.Cluster
+	if sync {
+		cld, err := Sync(l, vm.ListOptions{})
+		if err != nil {
+			return err
+		}
+		cloudCluster = cld.Clusters[clusterName]
+	} else {
+		cloudCluster, _ = readSyncedClusters(clusterName)
 	}
 
-	cloudCluster, ok := cld.Clusters[clusterName]
-	if !ok {
+	if cloudCluster == nil {
 		return fmt.Errorf("could not find %s in list of cluster", clusterName)
 	}
 
@@ -674,7 +679,7 @@ func SetupSSH(ctx context.Context, l *logger.Logger, clusterName string) error {
 		return err
 	}
 
-	if err = cloudCluster.PrintDetails(l); err != nil {
+	if err := cloudCluster.PrintDetails(l); err != nil {
 		return err
 	}
 	// Run ssh-keygen -R serially on each new VM in case an IP address has been recycled
@@ -715,6 +720,8 @@ func Extend(l *logger.Logger, clusterName string, lifetime time.Duration) error 
 	if err := LoadClusters(); err != nil {
 		return err
 	}
+
+	// We force a sync to ensure cluster was not previously extended
 	c, err := getClusterFromCloud(l, clusterName)
 	if err != nil {
 		return err
@@ -724,8 +731,8 @@ func Extend(l *logger.Logger, clusterName string, lifetime time.Duration) error 
 		return err
 	}
 
-	// Reload the clusters and print details.
-	c, err = getClusterFromCloud(l, clusterName)
+	// Save the cluster to the cache and print details.
+	err = saveCluster(l, c)
 	if err != nil {
 		return err
 	}
@@ -1452,7 +1459,16 @@ func Destroy(
 				// and let the caller retry.
 				cld, _ = cloud.ListCloud(l, vm.ListOptions{IncludeEmptyClusters: true})
 			}
-			return destroyCluster(ctx, cld, l, name)
+			err := destroyCluster(ctx, cld, l, name)
+			if err != nil {
+				return errors.Wrapf(err, "unable to destroy cluster %s", name)
+			}
+
+			err = deleteCluster(name)
+			if err != nil {
+				return errors.Wrapf(err, "unable to delete cluster %s from local cache", name)
+			}
+			return nil
 		}); err != nil {
 		return err
 	}
@@ -1643,8 +1659,15 @@ func Create(
 	}
 
 	l.Printf("Creating cluster %s with %d nodes...", clusterName, numNodes)
-	if createErr := cloud.CreateCluster(l, opts); createErr != nil {
+	c, createErr := cloud.CreateCluster(l, opts)
+	if createErr != nil {
 		return createErr
+	}
+
+	// Save the cluster to the cache.
+	err := saveCluster(l, c)
+	if err != nil {
+		return errors.Wrapf(err, "failed to save cluster %s", clusterName)
 	}
 
 	if config.IsLocalClusterName(clusterName) {
@@ -1652,7 +1675,7 @@ func Create(
 		return LoadClusters()
 	}
 	l.Printf("Created cluster %s; setting up SSH...", clusterName)
-	return SetupSSH(ctx, l, clusterName)
+	return SetupSSH(ctx, l, clusterName, false /* sync */)
 }
 
 func Grow(
@@ -1678,7 +1701,12 @@ func Grow(
 		// reload the clusters before returning.
 		err = LoadClusters()
 	default:
-		err = SetupSSH(ctx, l, clusterName)
+		// Save the cluster to the cache.
+		err = saveCluster(l, &c.Cluster)
+		if err != nil {
+			return err
+		}
+		err = SetupSSH(ctx, l, clusterName, false /* sync */)
 	}
 	if err != nil {
 		return err
@@ -1714,8 +1742,9 @@ func Shrink(ctx context.Context, l *logger.Logger, clusterName string, numNodes 
 		// clusters before returning.
 		return LoadClusters()
 	}
-	_, err = Sync(l, vm.ListOptions{})
-	return err
+
+	// Save the cluster to the cache.
+	return saveCluster(l, &c.Cluster)
 }
 
 // GC garbage-collects expired clusters, unused SSH key pairs in AWS, and unused

--- a/pkg/roachprod/vm/aws/BUILD.bazel
+++ b/pkg/roachprod/vm/aws/BUILD.bazel
@@ -24,6 +24,7 @@ go_library(
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_spf13_pflag//:pflag",
+        "@org_golang_x_exp//maps",
         "@org_golang_x_sync//errgroup",
         "@org_golang_x_time//rate",
     ],

--- a/pkg/roachprod/vm/aws/aws.go
+++ b/pkg/roachprod/vm/aws/aws.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 	"github.com/spf13/pflag"
+	"golang.org/x/exp/maps"
 	"golang.org/x/sync/errgroup"
 	"golang.org/x/time/rate"
 )
@@ -620,7 +621,7 @@ func (p *Provider) RemoveLabels(l *logger.Logger, vms vm.List, labels []string) 
 // Create is part of the vm.Provider interface.
 func (p *Provider) Create(
 	l *logger.Logger, names []string, opts vm.CreateOpts, vmProviderOpts vm.ProviderOpts,
-) error {
+) (vm.List, error) {
 	providerOpts := vmProviderOpts.(*ProviderOpts)
 	// There exist different flags to control the machine type when ssd is true.
 	// This enables sane defaults for either setting but the behavior can be
@@ -630,12 +631,12 @@ func (p *Provider) Create(
 	if opts.SSDOpts.UseLocalSSD &&
 		providerOpts.MachineType != defaultMachineType &&
 		providerOpts.SSDMachineType == defaultSSDMachineType {
-		return errors.Errorf("use the --aws-machine-type-ssd flag to set the " +
+		return nil, errors.Errorf("use the --aws-machine-type-ssd flag to set the " +
 			"machine type when --local-ssd=true")
 	} else if !opts.SSDOpts.UseLocalSSD &&
 		providerOpts.MachineType == defaultMachineType &&
 		providerOpts.SSDMachineType != defaultSSDMachineType {
-		return errors.Errorf("use the --aws-machine-type flag to set the " +
+		return nil, errors.Errorf("use the --aws-machine-type flag to set the " +
 			"machine type when --local-ssd=false")
 	}
 	var machineType string
@@ -648,7 +649,7 @@ func (p *Provider) Create(
 
 	expandedZones, err := vm.ExpandZonesFlag(providerOpts.CreateZones)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if len(expandedZones) == 0 {
@@ -661,15 +662,15 @@ func (p *Provider) Create(
 
 	// We need to make sure that the SSH keys have been distributed to all regions.
 	if err := p.ConfigSSH(l, expandedZones); err != nil {
-		return err
+		return nil, err
 	}
 
 	regions, err := p.allRegions(expandedZones)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	if len(regions) < 1 {
-		return errors.Errorf("Please specify a valid region.")
+		return nil, errors.Errorf("Please specify a valid region.")
 	}
 
 	// Distribute the nodes amongst availability zones.
@@ -688,18 +689,31 @@ func (p *Provider) Create(
 		res := limiter.Reserve()
 		g.Go(func() error {
 			time.Sleep(res.Delay())
-			return p.runInstance(l, capName, index, placement, machineType, opts, providerOpts)
+			_, err := p.runInstance(l, capName, index, placement, machineType, opts, providerOpts)
+			if err != nil {
+				return err
+			}
+
+			return nil
 		})
 	}
 	if err := g.Wait(); err != nil {
-		return err
+		return nil, err
 	}
 
-	return p.waitForIPs(l, names, regions, providerOpts)
+	// Our initial list of VMs does not include the IP addresses or volumes.
+	// waitForIPs() returns the VMs list with all information set, so we simply
+	// overwrite the list with the result of waitForIPs().
+	vmList, err := p.waitForIPs(l, names, regions, providerOpts)
+	if err != nil {
+		return nil, err
+	}
+
+	return vmList, nil
 }
 
-func (p *Provider) Grow(*logger.Logger, vm.List, string, []string) error {
-	return vm.UnimplementedError
+func (p *Provider) Grow(*logger.Logger, vm.List, string, []string) (vm.List, error) {
+	return nil, vm.UnimplementedError
 }
 
 func (p *Provider) Shrink(*logger.Logger, vm.List, string) error {
@@ -713,35 +727,34 @@ func (p *Provider) Shrink(*logger.Logger, vm.List, string) error {
 // commands hanging indefinitely.
 func (p *Provider) waitForIPs(
 	l *logger.Logger, names []string, regions []string, opts *ProviderOpts,
-) error {
+) ([]vm.VM, error) {
 	waitForIPRetry := retry.Start(retry.Options{
 		InitialBackoff: 100 * time.Millisecond,
 		MaxBackoff:     500 * time.Millisecond,
 		MaxRetries:     120, // wait a bit less than 90s for IPs
 	})
-	makeNameSet := func() map[string]struct{} {
-		m := make(map[string]struct{}, len(names))
-		for _, n := range names {
-			m[n] = struct{}{}
-		}
-		return m
-	}
 	for waitForIPRetry.Next() {
-		vms, err := p.listRegions(l, regions, *opts, vm.ListOptions{})
+		// We need to list the VMs in each region to get their IPs.
+		// We also include volumes in the list because they were not included
+		// in the initial list of VMs as they're only returned by run-instances
+		// when ready.
+		vms, err := p.listRegionsFiltered(l, regions, names, *opts, vm.ListOptions{
+			IncludeVolumes: true,
+		})
 		if err != nil {
-			return err
+			return nil, err
 		}
-		nameSet := makeNameSet()
+		ipAddressesFound := make(map[string]struct{})
 		for _, vm := range vms {
 			if vm.PublicIP != "" && vm.PrivateIP != "" {
-				delete(nameSet, vm.Name)
+				ipAddressesFound[vm.Name] = struct{}{}
 			}
 		}
-		if len(nameSet) == 0 {
-			return nil
+		if len(ipAddressesFound) == len(names) {
+			return vms, nil
 		}
 	}
-	return fmt.Errorf("failed to retrieve IPs for all vms")
+	return nil, fmt.Errorf("failed to retrieve IPs for all vms")
 }
 
 // Delete is part of vm.Provider.
@@ -882,20 +895,34 @@ func (p *Provider) List(l *logger.Logger, opts vm.ListOptions) (vm.List, error) 
 func (p *Provider) listRegions(
 	l *logger.Logger, regions []string, opts ProviderOpts, listOpts vm.ListOptions,
 ) (vm.List, error) {
+	return p.listRegionsFiltered(l, regions, nil, opts, listOpts)
+}
+
+// listRegionsFiltered lists VMs in the regions with a filter on instance names.
+// The filter makes it more efficient to list specific VMs than listRegions.
+func (p *Provider) listRegionsFiltered(
+	l *logger.Logger, regions, names []string, opts ProviderOpts, listOpts vm.ListOptions,
+) (vm.List, error) {
 	var ret vm.List
 	var mux syncutil.Mutex
 	var g errgroup.Group
 
+	// Create a filter for the instance names.
+	var namesFilter string
+	if names != nil {
+		namesFilter = fmt.Sprintf("Name=tag:Name,Values=%s", strings.Join(names, ","))
+	}
+
 	for _, r := range regions {
 		g.Go(func() error {
-			vms, err := p.listRegion(l, r, opts, listOpts)
+			vms, err := p.describeInstances(l, r, opts, listOpts, namesFilter)
 			if err != nil {
 				l.Printf("Failed to list AWS VMs in region: %s\n%v\n", r, err)
 				return nil
 			}
 			mux.Lock()
+			defer mux.Unlock()
 			ret = append(ret, vms...)
-			mux.Unlock()
 			return nil
 		})
 	}
@@ -930,9 +957,9 @@ func (p *Provider) allRegions(zones []string) (regions []string, err error) {
 	return regions, nil
 }
 
-func (p *Provider) getVolumesForInstance(
-	l *logger.Logger, region, instanceID string,
-) (vols map[string]vm.Volume, err error) {
+func (p *Provider) getVolumesForInstances(
+	l *logger.Logger, region string, instanceIDs []string,
+) (vols map[string]map[string]vm.Volume, err error) {
 	type describeVolume struct {
 		Volumes []struct {
 			Attachments []struct {
@@ -958,12 +985,13 @@ func (p *Provider) getVolumesForInstance(
 		} `json:"Volumes"`
 	}
 
-	vols = make(map[string]vm.Volume)
+	vols = make(map[string]map[string]vm.Volume)
 	var volumeOut describeVolume
 	getVolumesArgs := []string{
 		"ec2", "describe-volumes",
 		"--region", region,
-		"--filters", "Name=attachment.instance-id,Values=" + instanceID,
+		"--filters",
+		"Name=attachment.instance-id,Values=" + strings.Join(instanceIDs, ","),
 	}
 
 	err = p.runJSONCommand(l, getVolumesArgs, &volumeOut)
@@ -972,7 +1000,7 @@ func (p *Provider) getVolumesForInstance(
 	}
 	for _, vol := range volumeOut.Volumes {
 		tagMap := vol.Tags.MakeMap()
-		vols[vol.VolumeID] = vm.Volume{
+		volume := vm.Volume{
 			ProviderResourceID: vol.VolumeID,
 			ProviderVolumeType: vol.VolumeType,
 			Zone:               vol.AvailabilityZone,
@@ -981,6 +1009,13 @@ func (p *Provider) getVolumesForInstance(
 			Size:               vol.Size,
 			Name:               tagMap["Name"],
 		}
+
+		for _, attachment := range vol.Attachments {
+			if vols[attachment.InstanceID] == nil {
+				vols[attachment.InstanceID] = make(map[string]vm.Volume)
+			}
+			vols[attachment.InstanceID][vol.VolumeID] = volume
+		}
 	}
 	return vols, err
 }
@@ -988,45 +1023,110 @@ func (p *Provider) getVolumesForInstance(
 // DescribeInstancesOutput represents the output of the aws ec2 describe-instances command
 type DescribeInstancesOutput struct {
 	Reservations []struct {
-		Instances []struct {
-			InstanceID   string `json:"InstanceId"`
-			Architecture string
-			LaunchTime   string
-			Placement    struct {
-				AvailabilityZone string
+		Instances []DescribeInstancesOutputInstance
+	}
+}
+type DescribeInstancesOutputInstance struct {
+	InstanceID   string `json:"InstanceId"`
+	Architecture string
+	LaunchTime   string
+	Placement    struct {
+		AvailabilityZone string
+	}
+	PrivateDNSName   string `json:"PrivateDnsName"`
+	PrivateIPAddress string `json:"PrivateIpAddress"`
+	PublicDNSName    string `json:"PublicDnsName"`
+	PublicIPAddress  string `json:"PublicIpAddress"`
+	State            struct {
+		Code int
+		Name string
+	}
+	StateReason struct {
+		Code    string `json:"Code"`
+		Message string `json:"Message"`
+	} `json:"StateReason"`
+	RootDeviceName string
+
+	BlockDeviceMappings []struct {
+		DeviceName string `json:"DeviceName"`
+		Disk       struct {
+			AttachTime          time.Time `json:"AttachTime"`
+			DeleteOnTermination bool      `json:"DeleteOnTermination"`
+			Status              string    `json:"Status"`
+			VolumeID            string    `json:"VolumeId"`
+		} `json:"Ebs"`
+	} `json:"BlockDeviceMappings"`
+
+	Tags Tags
+
+	VpcID                 string `json:"VpcId"`
+	InstanceType          string
+	InstanceLifecycle     string `json:"InstanceLifecycle"`
+	SpotInstanceRequestId string `json:"SpotInstanceRequestId"`
+}
+
+// toVM converts an ec2 instance to a vm.VM struct.
+func (in *DescribeInstancesOutputInstance) toVM(
+	volumes map[string]vm.Volume, remoteUserName string,
+) *vm.VM {
+
+	// Convert the tag map into a more useful representation
+	tagMap := in.Tags.MakeMap()
+
+	var errs []error
+	createdAt, err := time.Parse(time.RFC3339, in.LaunchTime)
+	if err != nil {
+		errs = append(errs, vm.ErrNoExpiration)
+	}
+
+	var lifetime time.Duration
+	if lifeText, ok := tagMap["Lifetime"]; ok {
+		lifetime, err = time.ParseDuration(lifeText)
+		if err != nil {
+			errs = append(errs, err)
+		}
+	} else {
+		errs = append(errs, vm.ErrNoExpiration)
+	}
+
+	var nonBootableVolumes []vm.Volume
+	if len(volumes) > 0 {
+		rootDevice := in.RootDeviceName
+		for _, bdm := range in.BlockDeviceMappings {
+			if bdm.DeviceName != rootDevice {
+				if vol, ok := volumes[bdm.Disk.VolumeID]; ok {
+					nonBootableVolumes = append(nonBootableVolumes, vol)
+				} else {
+					errs = append(errs, errors.Newf(
+						"Attempted to add volume %s however it is not in the attached volumes for instance %s",
+						bdm.Disk.VolumeID,
+						in.InstanceID,
+					))
+				}
 			}
-			PrivateDNSName   string `json:"PrivateDnsName"`
-			PrivateIPAddress string `json:"PrivateIpAddress"`
-			PublicDNSName    string `json:"PublicDnsName"`
-			PublicIPAddress  string `json:"PublicIpAddress"`
-			State            struct {
-				Code int
-				Name string
-			}
-			StateReason struct {
-				Code    string `json:"Code"`
-				Message string `json:"Message"`
-			} `json:"StateReason"`
-			RootDeviceName string
-
-			BlockDeviceMappings []struct {
-				DeviceName string `json:"DeviceName"`
-				Disk       struct {
-					AttachTime          time.Time `json:"AttachTime"`
-					DeleteOnTermination bool      `json:"DeleteOnTermination"`
-					Status              string    `json:"Status"`
-					VolumeID            string    `json:"VolumeId"`
-				} `json:"Ebs"`
-			} `json:"BlockDeviceMappings"`
-
-			Tags Tags
-
-			VpcID                 string `json:"VpcId"`
-			InstanceType          string
-			InstanceLifecycle     string `json:"InstanceLifecycle"`
-			SpotInstanceRequestId string `json:"SpotInstanceRequestId"`
 		}
 	}
+
+	return &vm.VM{
+		CreatedAt:              createdAt,
+		DNS:                    in.PrivateDNSName,
+		Name:                   tagMap["Name"],
+		Errors:                 errs,
+		Lifetime:               lifetime,
+		Labels:                 tagMap,
+		PrivateIP:              in.PrivateIPAddress,
+		Provider:               ProviderName,
+		ProviderID:             in.InstanceID,
+		PublicIP:               in.PublicIPAddress,
+		RemoteUser:             remoteUserName,
+		VPC:                    in.VpcID,
+		MachineType:            in.InstanceType,
+		CPUArch:                vm.ParseArch(in.Architecture),
+		Zone:                   in.Placement.AvailabilityZone,
+		NonBootAttachedVolumes: nonBootableVolumes,
+		Preemptible:            in.InstanceLifecycle == "spot",
+	}
+
 }
 
 // CancelSpotInstanceRequestsOutput represents the output structure of the cancel-spot-instance-requests command.
@@ -1053,20 +1153,21 @@ type DescribeSpotInstanceRequestsOutput struct {
 
 // RunInstancesOutput represents the output of the aws ec2 run-instances command
 type RunInstancesOutput struct {
-	Instances []struct {
-		InstanceID string `json:"InstanceId"`
-	}
+	Instances []DescribeInstancesOutputInstance
 }
 
-// listRegion extracts the roachprod-managed instances in the
-// given region.
-func (p *Provider) listRegion(
-	l *logger.Logger, region string, opts ProviderOpts, listOpt vm.ListOptions,
+// describeInstances executes the ec2 describe-instances command
+// with the given filters.
+func (p *Provider) describeInstances(
+	l *logger.Logger, region string, opts ProviderOpts, listOpt vm.ListOptions, filters string,
 ) (vm.List, error) {
 
 	args := []string{
 		"ec2", "describe-instances",
 		"--region", region,
+	}
+	if filters != "" {
+		args = append(args, "--filters", filters)
 	}
 	var describeInstancesResponse DescribeInstancesOutput
 	err := p.runJSONCommand(l, args, &describeInstancesResponse)
@@ -1074,7 +1175,7 @@ func (p *Provider) listRegion(
 		return nil, err
 	}
 
-	var ret vm.List
+	var instances = make(map[string]DescribeInstancesOutputInstance)
 	for _, res := range describeInstancesResponse.Reservations {
 	in:
 		for _, in := range res.Instances {
@@ -1093,71 +1194,23 @@ func (p *Provider) listRegion(
 				continue in
 			}
 
-			var errs []error
-			createdAt, err := time.Parse(time.RFC3339, in.LaunchTime)
-			if err != nil {
-				errs = append(errs, vm.ErrNoExpiration)
-			}
-
-			var lifetime time.Duration
-			if lifeText, ok := tagMap["Lifetime"]; ok {
-				lifetime, err = time.ParseDuration(lifeText)
-				if err != nil {
-					errs = append(errs, err)
-				}
-			} else {
-				errs = append(errs, vm.ErrNoExpiration)
-			}
-
-			var nonBootableVolumes []vm.Volume
-			if listOpt.IncludeVolumes {
-				var volMap map[string]vm.Volume
-				rootDevice := in.RootDeviceName
-				for _, bdm := range in.BlockDeviceMappings {
-					if bdm.DeviceName != rootDevice {
-						// volMap does not exist so lazy initialize it here
-						if volMap == nil {
-							// TODO(leon, jackson): Change this to fetch the volumes in a
-							// batch instead of fetching them one at a time
-							volMap, err = p.getVolumesForInstance(l, region, in.InstanceID)
-							if err != nil {
-								errs = append(errs, err)
-							}
-						}
-						if vol, ok := volMap[bdm.Disk.VolumeID]; ok {
-							nonBootableVolumes = append(nonBootableVolumes, vol)
-						} else {
-							errs = append(errs, errors.Newf(
-								"Attempted to add volume %s however it is not in the attached volumes for instance %s",
-								bdm.Disk.VolumeID,
-								in.InstanceID,
-							))
-						}
-					}
-				}
-			}
-
-			m := vm.VM{
-				CreatedAt:              createdAt,
-				DNS:                    in.PrivateDNSName,
-				Name:                   tagMap["Name"],
-				Errors:                 errs,
-				Lifetime:               lifetime,
-				Labels:                 tagMap,
-				PrivateIP:              in.PrivateIPAddress,
-				Provider:               ProviderName,
-				ProviderID:             in.InstanceID,
-				PublicIP:               in.PublicIPAddress,
-				RemoteUser:             opts.RemoteUserName,
-				VPC:                    in.VpcID,
-				MachineType:            in.InstanceType,
-				CPUArch:                vm.ParseArch(in.Architecture),
-				Zone:                   in.Placement.AvailabilityZone,
-				NonBootAttachedVolumes: nonBootableVolumes,
-				Preemptible:            in.InstanceLifecycle == "spot",
-			}
-			ret = append(ret, m)
+			instances[in.InstanceID] = in
 		}
+	}
+
+	// Fetch volume info for all instances at once
+	var volumes map[string]map[string]vm.Volume
+	if listOpt.IncludeVolumes && len(instances) > 0 {
+		volumes, err = p.getVolumesForInstances(l, region, maps.Keys(instances))
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	var ret vm.List
+	for _, in := range instances {
+		v := in.toVM(volumes[in.InstanceID], opts.RemoteUserName)
+		ret = append(ret, *v)
 	}
 
 	return ret, nil
@@ -1175,16 +1228,16 @@ func (p *Provider) runInstance(
 	machineType string,
 	opts vm.CreateOpts,
 	providerOpts *ProviderOpts,
-) error {
+) (*vm.VM, error) {
 	az, ok := p.Config.AZByName[zone]
 	if !ok {
-		return fmt.Errorf("no region in %v corresponds to availability zone %v",
+		return nil, fmt.Errorf("no region in %v corresponds to availability zone %v",
 			p.Config.regionNames(), zone)
 	}
 
 	keyName, err := p.sshKeyName(l)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	cpuOptions := providerOpts.CPUOptions
 
@@ -1217,7 +1270,7 @@ func (p *Provider) runInstance(
 	for key, value := range opts.CustomLabels {
 		_, ok := m[strings.ToLower(key)]
 		if ok {
-			return fmt.Errorf("duplicate label name defined: %s", key)
+			return nil, fmt.Errorf("duplicate label name defined: %s", key)
 		}
 		addLabel(key, value)
 	}
@@ -1241,7 +1294,7 @@ func (p *Provider) runInstance(
 	}
 	filename, err := writeStartupScript(name, extraMountOpts, opts.SSDOpts.FileSystem, providerOpts.UseMultipleDisks, opts.Arch == string(vm.ArchFIPS))
 	if err != nil {
-		return errors.Wrapf(err, "could not write AWS startup script to temp file")
+		return nil, errors.Wrapf(err, "could not write AWS startup script to temp file")
 	}
 	defer func() {
 		_ = os.Remove(filename)
@@ -1257,7 +1310,7 @@ func (p *Provider) runInstance(
 	useArmAMI := strings.Index(machineType, "6g.") == 1 || strings.Index(machineType, "6gd.") == 1 ||
 		strings.Index(machineType, "7g.") == 1 || strings.Index(machineType, "7gd.") == 1
 	if useArmAMI && (opts.Arch != "" && opts.Arch != string(vm.ArchARM64)) {
-		return errors.Errorf("machine type %s is arm64, but requested arch is %s", machineType, opts.Arch)
+		return nil, errors.Errorf("machine type %s is arm64, but requested arch is %s", machineType, opts.Arch)
 	}
 	//TODO(srosenberg): remove this once we have a better way to detect ARM64 machines
 	if useArmAMI {
@@ -1297,21 +1350,35 @@ func (p *Provider) runInstance(
 	ebsVolumes := assignEBSVolumes(&opts, providerOpts)
 	args, err = genDeviceMapping(ebsVolumes, args)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	if providerOpts.UseSpot {
-		return runSpotInstance(l, p, args, az.Region.Name)
+		return runSpotInstance(l, p, args, az.Region.Name, providerOpts)
 		//todo(babusrithar): Add fallback to on-demand instances if spot instances are not available.
 	}
 	runInstancesOutput := RunInstancesOutput{}
-	return p.runJSONCommand(l, args, &runInstancesOutput)
+	err = p.runJSONCommand(l, args, &runInstancesOutput)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(runInstancesOutput.Instances) == 0 {
+		return nil, errors.Errorf("No instances found for run-instances command")
+	}
+
+	// Volumes are attached to the instance only after the instance is running.
+	// We will fill in the volume information during the waitForIPs call.
+	v := runInstancesOutput.Instances[0].toVM(map[string]vm.Volume{}, providerOpts.RemoteUserName)
+	return v, err
 }
 
 // runSpotInstance uses run-instances command to create a spot instance.
 // It returns an error if the spot request is not fulfilled within 2 minutes.
 // It uses describe-spot-instance-requests command to get the status of the spot request.
-func runSpotInstance(l *logger.Logger, p *Provider, args []string, regionName string) error {
+func runSpotInstance(
+	l *logger.Logger, p *Provider, args []string, regionName string, providerOpts *ProviderOpts,
+) (*vm.VM, error) {
 	waitForSpotDuration := 2 * time.Minute
 
 	// Add spot instance options to the run-instances command.
@@ -1321,16 +1388,19 @@ func runSpotInstance(l *logger.Logger, p *Provider, args []string, regionName st
 	runInstancesOutput := RunInstancesOutput{}
 	err := p.runJSONCommand(l, spotArgs, &runInstancesOutput)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	// If the spot request is accepted, the run-instances command will return an instance-id.
 	if len(runInstancesOutput.Instances) == 0 {
-		return errors.Errorf("No instances found for spot request, likely the spot request had bad parameter")
+		return nil, errors.Errorf("No instances found for spot request, likely the spot request had bad parameter")
 	}
+
+	v := runInstancesOutput.Instances[0].toVM(map[string]vm.Volume{}, providerOpts.RemoteUserName)
+
 	instanceId := runInstancesOutput.Instances[0].InstanceID
 	spotInstanceRequestId, err := getSpotInstanceRequestId(l, p, regionName, instanceId)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	// Loop every 10 seconds till the spot instance is fulfilled, for a maximum of 2 minutes.
@@ -1339,14 +1409,14 @@ func runSpotInstance(l *logger.Logger, p *Provider, args []string, regionName st
 	for {
 		describeSpotInstanceRequestsOutput, err := describeSpotInstanceRequest(l, p, regionName, spotInstanceRequestId)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		spotRequestFulfilled, err := processSpotInstanceRequestStatus(l, describeSpotInstanceRequestsOutput, spotInstanceRequestId, instanceId)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		if spotRequestFulfilled {
-			return nil
+			return v, nil
 		}
 		// This part of the code depends on demand/supply of AWS and can be hard to test.
 		// One way to manually test is tested by commenting out return nil above and check cancellation after 2 minutes.
@@ -1354,9 +1424,9 @@ func runSpotInstance(l *logger.Logger, p *Provider, args []string, regionName st
 			l.Printf("waitForSpotDuration passed, cancel the spot instance request and exit loop")
 			err := cancelSpotRequest(l, p, regionName, spotInstanceRequestId)
 			if err != nil {
-				return err
+				return nil, err
 			}
-			return errors.New("waitForSpotDuration over")
+			return nil, errors.New("waitForSpotDuration over")
 		}
 		l.Printf("Sleeping for 10 seconds before checking the status of the spot instance request again")
 		time.Sleep(10 * time.Second)

--- a/pkg/roachprod/vm/flagstub/flagstub.go
+++ b/pkg/roachprod/vm/flagstub/flagstub.go
@@ -114,13 +114,15 @@ func (p *provider) RemoveLabels(l *logger.Logger, vms vm.List, labels []string) 
 // Create implements vm.Provider and returns Unimplemented.
 func (p *provider) Create(
 	l *logger.Logger, names []string, opts vm.CreateOpts, providerOpts vm.ProviderOpts,
-) error {
-	return errors.Newf("%s", p.unimplemented)
+) (vm.List, error) {
+	return nil, errors.Newf("%s", p.unimplemented)
 }
 
 // Grow implements vm.Provider and returns Unimplemented.
-func (p *provider) Grow(l *logger.Logger, vms vm.List, clusterName string, names []string) error {
-	return errors.Newf("%s", p.unimplemented)
+func (p *provider) Grow(
+	l *logger.Logger, vms vm.List, clusterName string, names []string,
+) (vm.List, error) {
+	return nil, errors.Newf("%s", p.unimplemented)
 }
 
 func (p *provider) Shrink(*logger.Logger, vm.List, string) error {

--- a/pkg/roachprod/vm/gce/gcloud.go
+++ b/pkg/roachprod/vm/gce/gcloud.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachprod/ui"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/vm"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/vm/flagstub"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 	"github.com/spf13/pflag"
@@ -44,6 +45,19 @@ const (
 	FIPSImageProject    = "ubuntu-os-pro-cloud"
 	ManagedLabel        = "managed"
 	MaxConcurrentVMOps  = 16
+)
+
+type VolumeType string
+
+const (
+	// VolumeTypeUnknown represents an unknown volume type.
+	VolumeTypeUnknown VolumeType = ""
+	// VolumeTypeLocalSSD represents a local solid-state drive.
+	VolumeTypeLocalSSD VolumeType = "local-ssd"
+	// VolumeTypePremium represents a boot disk.
+	VolumeTypeBoot VolumeType = "boot"
+	// VolumeTypeStandard represents an attached persistent disk.
+	VolumeTypePersistent VolumeType = "persistent"
 )
 
 // providerInstance is the instance to be registered into vm.Providers by Init.
@@ -174,10 +188,8 @@ type jsonVM struct {
 	instanceDisksResponse
 }
 
-// Convert the JSON VM data into our common VM type
-func (jsonVM *jsonVM) toVM(
-	project string, disks []describeVolumeCommandResponse, opts *ProviderOpts, dnsDomain string,
-) (ret *vm.VM) {
+// Convert the JSON VM data into our common VM type.
+func (jsonVM *jsonVM) toVM(project string, dnsDomain string) (ret *vm.VM) {
 	var vmErrors []error
 	var err error
 
@@ -226,46 +238,23 @@ func (jsonVM *jsonVM) toVM(
 	var localDisks []vm.Volume
 	var bootVolume vm.Volume
 
-	parseDiskSize := func(size string) int {
-		if val, err := strconv.Atoi(size); err == nil {
-			return val
-		} else {
-			vmErrors = append(vmErrors, errors.Newf("invalid disk size: %q", size))
-		}
-		return 0
-	}
-
 	for _, jsonVMDisk := range jsonVM.Disks {
-		if jsonVMDisk.Source == "" && jsonVMDisk.Type == "SCRATCH" {
-			// This is a scratch disk.
-			localDisks = append(localDisks, vm.Volume{
-				Size:               parseDiskSize(jsonVMDisk.DiskSizeGB),
-				ProviderVolumeType: "local-ssd",
-			})
+
+		vol, volType, err := jsonVMDisk.toVolume()
+		if err != nil {
+			vmErrors = append(vmErrors, err)
 			continue
 		}
-		// Find a persistent volume (detailedDisk) matching the attached non-boot disk.
-		for _, detailedDisk := range disks {
-			if detailedDisk.SelfLink == jsonVMDisk.Source {
-				vol := vm.Volume{
-					// NB: See TODO in toDescribeVolumeCommandResponse. We
-					// should be able to "just" use detailedDisk.Name here,
-					// but we're abusing that field elsewhere, and
-					// incorrectly. Using SelfLink is correct.
-					ProviderResourceID: lastComponent(detailedDisk.SelfLink),
-					ProviderVolumeType: detailedDisk.Type,
-					Zone:               lastComponent(detailedDisk.Zone),
-					Name:               detailedDisk.Name,
-					Labels:             detailedDisk.Labels,
-					Size:               parseDiskSize(detailedDisk.SizeGB),
-				}
-				if !jsonVMDisk.Boot {
-					volumes = append(volumes, vol)
-				} else {
-					bootVolume = vol
-				}
-			}
+
+		switch volType {
+		case VolumeTypeBoot:
+			bootVolume = *vol
+		case VolumeTypeLocalSSD:
+			localDisks = append(localDisks, *vol)
+		default:
+			volumes = append(volumes, *vol)
 		}
+
 	}
 
 	return &vm.VM{
@@ -883,6 +872,41 @@ type attachDiskCmdDisk struct {
 	Type       string `json:"type"`
 }
 
+// toVolume converts an attachedDisk struct (disks returned by `instances list`)
+// to a vm.Volume struct.
+func (d *attachDiskCmdDisk) toVolume() (*vm.Volume, VolumeType, error) {
+	diskSize, err := strconv.Atoi(d.DiskSizeGB)
+	if err != nil {
+		return nil, VolumeTypeUnknown, err
+	}
+
+	// This is a scratch disk.
+	if d.Source == "" && d.Type == "SCRATCH" {
+		return &vm.Volume{
+			Size:               diskSize,
+			ProviderVolumeType: "local-ssd",
+		}, VolumeTypeLocalSSD, nil
+	}
+
+	volType := VolumeTypePersistent
+	if d.Boot {
+		volType = VolumeTypeBoot
+	}
+
+	vol := &vm.Volume{
+		Name:               lastComponent(d.Source),
+		Zone:               zoneFromSelfLink(d.Source),
+		Size:               diskSize,
+		ProviderResourceID: lastComponent(d.Source),
+		// Unfortunately, the attachedDisk struct does not return the actual type
+		// (standard or ssd) of the persistent disk. We assume `pd_ssd` as those
+		// are common and is a worst case scenario for cost computation.
+		ProviderVolumeType: "pd-ssd",
+	}
+
+	return vol, volType, nil
+}
+
 func (p *Provider) AttachVolume(l *logger.Logger, volume vm.Volume, vm *vm.VM) (string, error) {
 	// Volume attach.
 	args := []string{
@@ -1431,8 +1455,15 @@ func (p *Provider) computeInstanceArgs(
 	return args, cleanUpFn, nil
 }
 
+// instanceTemplateNamePrefix returns the prefix part of the instance template
+// (without the trailing zone).
+func instanceTemplateNamePrefix(clusterName string) string {
+	return fmt.Sprintf("%s-template", clusterName)
+}
+
+// instanceTemplateName returns the full instance template name (with the zone).
 func instanceTemplateName(clusterName string, zone string) string {
-	return fmt.Sprintf("%s-template-%s", clusterName, zone)
+	return fmt.Sprintf("%s-%s", instanceTemplateNamePrefix(clusterName), zone)
 }
 
 func instanceGroupName(clusterName string) string {
@@ -1444,7 +1475,9 @@ func instanceGroupName(clusterName string) string {
 // only used for managed instance group clusters.
 func createInstanceTemplates(
 	l *logger.Logger, clusterName string, zoneToInstanceArgs map[string][]string, labelsArg string,
-) error {
+) (map[string]jsonInstanceTemplate, error) {
+	zonesInstanceTemplates := make(map[string]jsonInstanceTemplate)
+	var instanceTemplatesMu syncutil.Mutex
 	g := ui.NewDefaultSpinnerGroup(l, "creating instance templates", len(zoneToInstanceArgs))
 	for zone, args := range zoneToInstanceArgs {
 		templateName := instanceTemplateName(clusterName, zone)
@@ -1452,16 +1485,27 @@ func createInstanceTemplates(
 		createTemplateArgs = append(createTemplateArgs, args...)
 		createTemplateArgs = append(createTemplateArgs, "--labels", labelsArg)
 		createTemplateArgs = append(createTemplateArgs, templateName)
+		createTemplateArgs = append(createTemplateArgs, "--format", "json")
 		g.Go(func() error {
-			cmd := exec.Command("gcloud", createTemplateArgs...)
-			output, err := cmd.CombinedOutput()
+			var j []jsonInstanceTemplate
+			err := runJSONCommand(createTemplateArgs, &j)
 			if err != nil {
-				return errors.Wrapf(err, "Command: gcloud %s\nOutput: %s", createTemplateArgs, output)
+				return errors.Wrapf(err, "Command: gcloud %s\n", createTemplateArgs)
+			}
+			// We expect only one template to be created, gcloud returns a list.
+			if len(j) > 0 {
+				instanceTemplatesMu.Lock()
+				defer instanceTemplatesMu.Unlock()
+				zonesInstanceTemplates[zone] = j[0]
 			}
 			return nil
 		})
 	}
-	return g.Wait()
+	err := g.Wait()
+	if err != nil {
+		return nil, err
+	}
+	return zonesInstanceTemplates, nil
 }
 
 // createInstanceGroups creates an instance group in each zone, for the cluster
@@ -1541,7 +1585,7 @@ func waitForGroupStability(l *logger.Logger, project, groupName string, zones []
 // individual instances.
 func (p *Provider) Create(
 	l *logger.Logger, names []string, opts vm.CreateOpts, vmProviderOpts vm.ProviderOpts,
-) error {
+) (vm.List, error) {
 	providerOpts := vmProviderOpts.(*ProviderOpts)
 	project := p.GetProject()
 	var gcJob bool
@@ -1557,7 +1601,7 @@ func (p *Provider) Create(
 	}
 	if providerOpts.Managed {
 		if err := checkSDKVersion("450.0.0" /* minVersion */, "required by managed instance groups"); err != nil {
-			return err
+			return nil, err
 		}
 	}
 
@@ -1566,15 +1610,15 @@ func (p *Provider) Create(
 		defer cleanUpFn()
 	}
 	if err != nil {
-		return err
+		return nil, err
 	}
 	zones, err := computeZones(opts, providerOpts)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	labels, err := computeLabelsArg(opts, providerOpts)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	// Work out in which zones VMs should be created.
@@ -1587,6 +1631,8 @@ func (p *Provider) Create(
 	}
 	usedZones := maps.Keys(zoneToHostNames)
 
+	var vmList vm.List
+	var vmListMutex syncutil.Mutex
 	switch {
 	case providerOpts.Managed:
 		zoneToInstanceArgs := make(map[string][]string)
@@ -1597,7 +1643,7 @@ func (p *Provider) Create(
 		// for those zones to use spot instances.
 		if len(providerOpts.ManagedSpotZones) > 0 {
 			if providerOpts.UseSpot {
-				return errors.Newf("Use either --%[1]s-use-spot or --%[1]s-managed-spot-zones, not both", ProviderName)
+				return nil, errors.Newf("Use either --%[1]s-use-spot or --%[1]s-managed-spot-zones, not both", ProviderName)
 			}
 			spotProviderOpts := *providerOpts
 			spotProviderOpts.UseSpot = true
@@ -1606,23 +1652,23 @@ func (p *Provider) Create(
 				defer spotCleanUpFn()
 			}
 			if err != nil {
-				return err
+				return nil, err
 			}
 			for _, zone := range providerOpts.ManagedSpotZones {
 				if _, ok := zoneToInstanceArgs[zone]; !ok {
-					return errors.Newf("the managed spot zone %q is not in the list of zones for the cluster", zone)
+					return nil, errors.Newf("the managed spot zone %q is not in the list of zones for the cluster", zone)
 				}
 				zoneToInstanceArgs[zone] = spotInstanceArgs
 			}
 		}
 
-		err = createInstanceTemplates(l, opts.ClusterName, zoneToInstanceArgs, labels)
+		zonesInstanceTemplates, err := createInstanceTemplates(l, opts.ClusterName, zoneToInstanceArgs, labels)
 		if err != nil {
-			return err
+			return nil, err
 		}
 		err = createInstanceGroups(l, project, opts.ClusterName, usedZones, opts)
 		if err != nil {
-			return err
+			return nil, err
 		}
 
 		groupName := instanceGroupName(opts.ClusterName)
@@ -1648,27 +1694,43 @@ func (p *Provider) Create(
 		}
 		err = g.Wait()
 		if err != nil {
-			return err
+			return nil, err
 		}
 		err = waitForGroupStability(l, project, groupName, usedZones)
 		if err != nil {
-			return err
+			return nil, err
 		}
+
+		// Now that the instance-group is stable,
+		// fetch the list of instances in the managed instance group.
+		vmList, err = getManagedInstanceGroupVMs(
+			l, project, groupName, zonesInstanceTemplates, p.publicDomain,
+		)
+		if err != nil {
+			return nil, err
+		}
+
 	default:
 		var g errgroup.Group
-		createArgs := []string{"compute", "instances", "create", "--subnet", "default"}
+		createArgs := []string{"compute", "instances", "create", "--subnet", "default", "--format", "json"}
 		createArgs = append(createArgs, "--labels", labels)
 		createArgs = append(createArgs, instanceArgs...)
 
 		l.Printf("Creating %d instances, distributed across [%s]", len(names), strings.Join(usedZones, ", "))
 		for zone, zoneHosts := range zoneToHostNames {
-			argsWithZone := append(createArgs[:len(createArgs):len(createArgs)], "--zone", zone)
+			argsWithZone := append(createArgs, "--zone", zone)
 			argsWithZone = append(argsWithZone, zoneHosts...)
 			g.Go(func() error {
-				cmd := exec.Command("gcloud", argsWithZone...)
-				output, err := cmd.CombinedOutput()
+				var instances []jsonVM
+				err := runJSONCommand(argsWithZone, &instances)
 				if err != nil {
-					return errors.Wrapf(err, "Command: gcloud %s\nOutput: %s", argsWithZone, output)
+					return errors.Wrapf(err, "Command: gcloud %s", argsWithZone)
+				}
+				vmListMutex.Lock()
+				defer vmListMutex.Unlock()
+				for _, i := range instances {
+					v := i.toVM(project, p.publicDomain)
+					vmList = append(vmList, *v)
 				}
 				return nil
 			})
@@ -1676,10 +1738,10 @@ func (p *Provider) Create(
 		}
 		err = g.Wait()
 		if err != nil {
-			return err
+			return nil, err
 		}
 	}
-	return propagateDiskLabels(l, project, labels, zoneToHostNames, opts.SSDOpts.UseLocalSSD)
+	return vmList, propagateDiskLabels(l, project, labels, zoneToHostNames, opts.SSDOpts.UseLocalSSD)
 }
 
 // computeGrowDistribution computes the distribution of new nodes across the
@@ -1742,16 +1804,18 @@ func (p *Provider) Shrink(l *logger.Logger, vmsToDelete vm.List, clusterName str
 	return waitForGroupStability(l, project, groupName, maps.Keys(vmZones))
 }
 
-func (p *Provider) Grow(l *logger.Logger, vms vm.List, clusterName string, names []string) error {
+func (p *Provider) Grow(
+	l *logger.Logger, vms vm.List, clusterName string, names []string,
+) (vm.List, error) {
 	if !isManaged(vms) {
-		return errors.New("growing is only supported for managed instance groups")
+		return nil, errors.New("growing is only supported for managed instance groups")
 	}
 
 	project := vms[0].Project
 	groupName := instanceGroupName(clusterName)
 	groups, err := listManagedInstanceGroups(project, groupName)
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	newNodeCount := len(names)
@@ -1761,6 +1825,7 @@ func (p *Provider) Grow(l *logger.Logger, vms vm.List, clusterName string, names
 	addCounts := computeGrowDistribution(groups, newNodeCount)
 
 	zoneToHostNames := make(map[string][]string)
+	addedVms := make(map[string]bool)
 	var g errgroup.Group
 	for idx, group := range groups {
 		addCount := addCounts[idx]
@@ -1769,10 +1834,9 @@ func (p *Provider) Grow(l *logger.Logger, vms vm.List, clusterName string, names
 		}
 		createArgs := []string{"compute", "instance-groups", "managed", "create-instance", "--zone", group.Zone, groupName}
 		for i := 0; i < addCount; i++ {
-			name := names[0]
-			names = names[1:]
-			argsWithName := append(createArgs[:len(createArgs):len(createArgs)], []string{"--instance", name}...)
-			zoneToHostNames[group.Zone] = append(zoneToHostNames[group.Zone], name)
+			addedVms[names[i]] = true
+			argsWithName := append(createArgs[:len(createArgs):len(createArgs)], []string{"--instance", names[i]}...)
+			zoneToHostNames[group.Zone] = append(zoneToHostNames[group.Zone], names[i])
 			g.Go(func() error {
 				cmd := exec.Command("gcloud", argsWithName...)
 				output, err := cmd.CombinedOutput()
@@ -1786,12 +1850,36 @@ func (p *Provider) Grow(l *logger.Logger, vms vm.List, clusterName string, names
 
 	err = g.Wait()
 	if err != nil {
-		return err
+		return nil, err
 	}
 
 	err = waitForGroupStability(l, project, groupName, maps.Keys(zoneToHostNames))
 	if err != nil {
-		return err
+		return nil, err
+	}
+
+	// Fetch instance templates for the cluster to get required information to build VMs list.
+	zoneToInstanceTemplates := make(map[string]jsonInstanceTemplate)
+	templates, err := listInstanceTemplates(project, clusterName)
+	if err != nil {
+		return nil, err
+	}
+	for _, t := range templates {
+		zoneToInstanceTemplates[t.getZone()] = t
+	}
+
+	// Fetch the list of instances in the managed instance group.
+	vmList, err := getManagedInstanceGroupVMs(l, project, groupName, zoneToInstanceTemplates, p.publicDomain)
+	if err != nil {
+		return nil, err
+	}
+
+	// We only want to return the new VMs.
+	var addedVmList vm.List
+	for _, v := range vmList {
+		if _, ok := addedVms[v.Name]; ok {
+			addedVmList = append(addedVmList, v)
+		}
 	}
 
 	var labelsJoined string
@@ -1801,7 +1889,12 @@ func (p *Provider) Grow(l *logger.Logger, vms vm.List, clusterName string, names
 		}
 		labelsJoined += fmt.Sprintf("%s=%s", key, value)
 	}
-	return propagateDiskLabels(l, project, labelsJoined, zoneToHostNames, len(vms[0].LocalDisks) != 0)
+	err = propagateDiskLabels(l, project, labelsJoined, zoneToHostNames, len(vms[0].LocalDisks) != 0)
+	if err != nil {
+		return nil, err
+	}
+
+	return addedVmList, nil
 }
 
 type jsonBackendService struct {
@@ -2335,25 +2428,232 @@ func propagateDiskLabels(
 type jsonInstanceTemplate struct {
 	Name       string `json:"name"`
 	Properties struct {
-		Labels map[string]string `json:"labels"`
+		Disks             []jsonInstanceTemplateDisk
+		Labels            map[string]string `json:"labels"`
+		MachineType       string            `json:"machineType"`
+		NetworkInterfaces []struct {
+			Name    string `json:"name"`
+			Network string `json:"network"`
+		} `json:"networkInterfaces"`
+		Scheduling struct {
+			AutomaticRestart  bool   `json:"automaticRestart"`
+			OnHostMaintenance string `json:"onHostMaintenance"`
+			Preemptible       bool   `json:"preemptible"`
+			ProvisioningModel string `json:"provisioningModel"`
+		}
 	} `json:"properties"`
+}
+
+func (t *jsonInstanceTemplate) getZone() string {
+	namePrefix := instanceTemplateNamePrefix(t.Properties.Labels[vm.TagCluster])
+	return strings.TrimPrefix(t.Name, namePrefix)
+}
+
+type jsonInstanceTemplateDisk struct {
+	AutoDelete       bool   `json:"autoDelete"`
+	Boot             bool   `json:"boot"`
+	DeviceName       string `json:"deviceName"`
+	Index            int    `json:"index"`
+	InitializeParams struct {
+		DiskSizeGb  string            `json:"diskSizeGb"`
+		DiskType    string            `json:"diskType"`
+		Labels      map[string]string `json:"labels"`
+		SourceImage string            `json:"sourceImage"`
+	} `json:"initializeParams"`
+	Mode string `json:"mode"`
+	Type string `json:"type"`
+}
+
+// toVolume converts a jsonInstanceTemplateDisk to a vm.Volume.
+// This function does a job very similar to &attachDiskCmdDisk{}.toVolume(),
+// but a lot of information are coming from a different place, which makes it
+// hard to unify the two functions.
+func (d *jsonInstanceTemplateDisk) toVolume(vmName, zone string) (*vm.Volume, VolumeType, error) {
+	// We fail silently here because the disk size is not always set
+	// (e.g. in case of scratch disks).
+	diskSize, _ := strconv.Atoi(d.InitializeParams.DiskSizeGb)
+
+	// This is a scratch disk.
+	if d.InitializeParams.DiskType == "SCRATCH" {
+		return &vm.Volume{
+			Size:               diskSize,
+			ProviderVolumeType: "local-ssd",
+		}, VolumeTypeLocalSSD, nil
+	}
+
+	volType := VolumeTypePersistent
+	if d.Boot {
+		volType = VolumeTypeBoot
+	}
+
+	diskName := vmName
+	if d.Index > 0 {
+		diskName = fmt.Sprintf("%s-%d", vmName, d.Index)
+	}
+
+	vol := vm.Volume{
+		Name: diskName,
+		Zone: zone,
+		Size: diskSize,
+		// Unfortunately, the attachedDisk struct does not return the actual type
+		// (standard or ssd) of the persistent disk. We assume `pd_ssd` as those
+		// are common and is a worst case scenario for cost computation.
+		ProviderVolumeType: "pd-ssd",
+		ProviderResourceID: diskName,
+	}
+
+	return &vol, volType, nil
 }
 
 // listInstanceTemplates returns a list of instance templates for a given
 // project.
-func listInstanceTemplates(project string) ([]jsonInstanceTemplate, error) {
+func listInstanceTemplates(project, clusterFilter string) ([]jsonInstanceTemplate, error) {
 	args := []string{"compute", "instance-templates", "list", "--project", project, "--format", "json"}
 	var templates []jsonInstanceTemplate
 	if err := runJSONCommand(args, &templates); err != nil {
 		return nil, err
 	}
-	return templates, nil
+
+	if clusterFilter == "" {
+		return templates, nil
+	}
+
+	var filteredTemplates []jsonInstanceTemplate
+	for _, t := range templates {
+		if t.Properties.Labels[vm.TagCluster] != clusterFilter {
+			continue
+		}
+
+		filteredTemplates = append(filteredTemplates, t)
+	}
+	return filteredTemplates, nil
 }
 
 type jsonManagedInstanceGroup struct {
 	Name string `json:"name"`
 	Zone string `json:"zone"`
 	Size int    `json:"size"`
+}
+
+// managedInstanceGroupInstance represents the struct gcloud returns
+// when listing instances of a managed instance group.
+type managedInstanceGroupInstance struct {
+	CurrentAction                   string
+	Id                              string
+	Instance                        string
+	InstanceStatus                  string
+	Name                            string
+	PreservedStateFromConfig        PreservedState
+	PreservedStateFromPolicy        PreservedState
+	PropertiesFromFlexibilityPolicy struct {
+		MachineType string
+	}
+	Version struct {
+		InstanceTemplate string
+		Name             string
+	}
+}
+type PreservedState struct {
+	Disks       map[string]*PreservedStatePreservedDisk
+	ExternalIPs map[string]*PreservedStatePreservedNetworkIp
+	InternalIPs map[string]*PreservedStatePreservedNetworkIp
+	Metadata    map[string]string
+}
+type PreservedStatePreservedDisk struct {
+	AutoDelete string
+	Mode       string
+	Source     string
+}
+type PreservedStatePreservedNetworkIp struct {
+	AutoDelete string
+	IpAddress  struct {
+		Address string
+		Literal string
+	}
+}
+
+// toVM converts a managed instance group instance to a vm.VM struct
+// based on data found in both the instance and the instance template.
+// TODO(ludo): arch and CPU platform are not available at this time,
+// so arch is derived from the VM tags. They should be inferred from
+// the machine type instead.
+func (j *managedInstanceGroupInstance) toVM(
+	project, zone string, instanceTemplate jsonInstanceTemplate, dnsDomain string,
+) *vm.VM {
+
+	var err error
+	var vmErrors []error
+
+	remoteUser := config.SharedUser
+	if !config.UseSharedUser {
+		// N.B. gcloud uses the local username to log into instances rather
+		// than the username on the authenticated Google account but we set
+		// up the shared user at cluster creation time. Allow use of the
+		// local username if requested.
+		remoteUser = config.OSUser.Username
+	}
+
+	// Check "lifetime" label.
+	var lifetime time.Duration
+	if lifetimeStr, ok := instanceTemplate.Properties.Labels[vm.TagLifetime]; ok {
+		if lifetime, err = time.ParseDuration(lifetimeStr); err != nil {
+			vmErrors = append(vmErrors, vm.ErrNoExpiration)
+		}
+	} else {
+		vmErrors = append(vmErrors, vm.ErrNoExpiration)
+	}
+
+	var arch vm.CPUArch
+	var cpuPlatform string
+	if instanceTemplate.Properties.Labels[vm.TagArch] != "" {
+		arch = vm.CPUArch(instanceTemplate.Properties.Labels[vm.TagArch])
+	}
+
+	var volumes []vm.Volume
+	var bootVolume vm.Volume
+	var localDisks []vm.Volume
+	for _, disk := range instanceTemplate.Properties.Disks {
+		vol, volType, err := disk.toVolume(j.Name, zone)
+		if err != nil {
+			vmErrors = append(vmErrors, err)
+			continue
+		}
+
+		switch volType {
+		case VolumeTypeLocalSSD:
+			localDisks = append(localDisks, *vol)
+		case VolumeTypeBoot:
+			bootVolume = *vol
+		default:
+			volumes = append(volumes, *vol)
+		}
+	}
+
+	return &vm.VM{
+		Name:                   j.Name,
+		CreatedAt:              timeutil.Now(),
+		DNS:                    fmt.Sprintf("%s.%s.%s", j.Name, zone, project),
+		Lifetime:               lifetime,
+		Preemptible:            instanceTemplate.Properties.Scheduling.Preemptible,
+		Labels:                 instanceTemplate.Properties.Labels,
+		PrivateIP:              j.PreservedStateFromPolicy.InternalIPs["nic0"].IpAddress.Literal,
+		Provider:               ProviderName,
+		DNSProvider:            ProviderName,
+		ProviderID:             lastComponent(j.Instance),
+		PublicIP:               j.PreservedStateFromPolicy.ExternalIPs["nic0"].IpAddress.Literal,
+		PublicDNS:              fmt.Sprintf("%s.%s", j.Name, dnsDomain),
+		RemoteUser:             remoteUser,
+		VPC:                    lastComponent(instanceTemplate.Properties.NetworkInterfaces[0].Network),
+		MachineType:            instanceTemplate.Properties.MachineType,
+		Zone:                   zone,
+		Project:                project,
+		NonBootAttachedVolumes: volumes,
+		BootVolume:             bootVolume,
+		LocalDisks:             localDisks,
+		Errors:                 vmErrors,
+		CPUArch:                arch,
+		CPUFamily:              cpuPlatform,
+	}
 }
 
 // listManagedInstanceGroups returns a list of managed instance groups for a
@@ -2367,6 +2667,54 @@ func listManagedInstanceGroups(project, groupName string) ([]jsonManagedInstance
 		return nil, err
 	}
 	return groups, nil
+}
+
+// getManagedInstanceGroupVMs returns a list of VMs for a given instance group.
+// The instance group may exist in multiple zones with the same name, so the
+// function gathers instances across all zones. The instance templates are used
+// to determine the zones to query and the extra properties of the VMs.
+func getManagedInstanceGroupVMs(
+	l *logger.Logger,
+	project, groupName string,
+	instanceTemplates map[string]jsonInstanceTemplate,
+	dnsDomain string,
+) (vm.List, error) {
+
+	zones := maps.Keys(instanceTemplates)
+
+	var vmList vm.List
+	var vmListMutex syncutil.Mutex
+	listArgs := []string{
+		"compute", "instance-groups", "managed", "list-instances", groupName,
+		"--project", project, "--format", "json",
+	}
+	g := ui.NewDefaultSpinnerGroup(l,
+		fmt.Sprintf("gathering instances created across zones [%s]", strings.Join(zones, ", ")),
+		len(zones),
+	)
+	for _, zone := range zones {
+		g.Go(func() error {
+			var zoneInstances []managedInstanceGroupInstance
+			argsWithZone := append(listArgs, "--zone", zone)
+			err := runJSONCommand(argsWithZone, &zoneInstances)
+			if err != nil {
+				return err
+			}
+			vmListMutex.Lock()
+			defer vmListMutex.Unlock()
+			for _, i := range zoneInstances {
+				v := i.toVM(project, zone, instanceTemplates[zone], dnsDomain)
+				vmList = append(vmList, *v)
+			}
+			return nil
+		})
+	}
+	err := g.Wait()
+	if err != nil {
+		return nil, err
+	}
+
+	return vmList, nil
 }
 
 // deleteInstanceTemplate deletes the instance template for the cluster.
@@ -2448,15 +2796,11 @@ func (p *Provider) deleteManaged(l *logger.Logger, vms vm.List) error {
 	// deleted.
 	g = errgroup.Group{}
 	for cluster, project := range clusterProjectMap {
-		templates, err := listInstanceTemplates(project)
+		templates, err := listInstanceTemplates(project, cluster)
 		if err != nil {
 			return err
 		}
 		for _, template := range templates {
-			// Only delete templates that are part of the cluster.
-			if template.Properties.Labels[vm.TagCluster] != cluster {
-				continue
-			}
 			g.Go(func() error {
 				return deleteInstanceTemplate(project, template.Name)
 			})
@@ -2581,9 +2925,6 @@ func (p *Provider) FindActiveAccount(l *logger.Logger) (string, error) {
 
 // List queries gcloud to produce a list of VM info objects.
 func (p *Provider) List(l *logger.Logger, opts vm.ListOptions) (vm.List, error) {
-	if opts.IncludeVolumes {
-		l.Printf("WARN: --include-volumes is disabled; attached disks info will be partial")
-	}
 
 	templatesInUse := make(map[string]map[string]struct{})
 	var vms vm.List
@@ -2594,34 +2935,6 @@ func (p *Provider) List(l *logger.Logger, opts vm.ListOptions) (vm.List, error) 
 		jsonVMS := make([]jsonVM, 0)
 		if err := runJSONCommand(args, &jsonVMS); err != nil {
 			return nil, err
-		}
-
-		userVMToDetailedDisk := make(map[string][]describeVolumeCommandResponse)
-		if opts.IncludeVolumes {
-			var jsonVMSelfLinks []string
-			for _, jsonVM := range jsonVMS {
-				jsonVMSelfLinks = append(jsonVMSelfLinks, jsonVM.SelfLink)
-			}
-
-			args = []string{
-				"compute",
-				"disks",
-				"list",
-				"--project", prj,
-				"--format", "json",
-				"--filter", "users:(" + strings.Join(jsonVMSelfLinks, ",") + ")",
-			}
-
-			var disks []describeVolumeCommandResponse
-			if err := runJSONCommand(args, &disks); err != nil {
-				return nil, err
-			}
-
-			for _, d := range disks {
-				for _, u := range d.Users {
-					userVMToDetailedDisk[u] = append(userVMToDetailedDisk[u], d)
-				}
-			}
 		}
 
 		// Find all instance templates that are currently in use.
@@ -2640,15 +2953,7 @@ func (p *Provider) List(l *logger.Logger, opts vm.ListOptions) (vm.List, error) 
 
 		// Now, convert the json payload into our common VM type
 		for _, jsonVM := range jsonVMS {
-			defaultOpts := p.CreateProviderOpts().(*ProviderOpts)
-			disks := userVMToDetailedDisk[jsonVM.SelfLink]
-
-			if len(disks) == 0 {
-				// Since `--include-volumes` is disabled, we convert attachDiskCmdDisk to describeVolumeCommandResponse.
-				// The former is a subset of the latter. Some information like `Labels` will be missing.
-				disks = toDescribeVolumeCommandResponse(jsonVM.Disks, jsonVM.Zone)
-			}
-			vms = append(vms, *jsonVM.toVM(prj, disks, defaultOpts, p.publicDomain))
+			vms = append(vms, *jsonVM.toVM(prj, p.publicDomain))
 		}
 	}
 
@@ -2663,7 +2968,7 @@ func (p *Provider) List(l *logger.Logger, opts vm.ListOptions) (vm.List, error) 
 			if projTemplatesInUse == nil {
 				projTemplatesInUse = make(map[string]struct{})
 			}
-			templates, err := listInstanceTemplates(prj)
+			templates, err := listInstanceTemplates(prj, "" /* clusterFilter */)
 			if err != nil {
 				return nil, err
 			}
@@ -2708,42 +3013,6 @@ func (p *Provider) List(l *logger.Logger, opts vm.ListOptions) (vm.List, error) 
 	}
 
 	return vms, nil
-}
-
-// Convert attachDiskCmdDisk to describeVolumeCommandResponse and link via SelfLink, Source.
-func toDescribeVolumeCommandResponse(
-	disks []attachDiskCmdDisk, zone string,
-) []describeVolumeCommandResponse {
-	res := make([]describeVolumeCommandResponse, 0, len(disks))
-
-	diskType := func(s string) string {
-		if s == "PERSISTENT" {
-			// Unfortunately, we don't know if it's a pd-ssd or pd-standard. We assume pd_ssd since those are common.
-			return "pd-ssd"
-		}
-		return "unknown"
-	}
-
-	for _, d := range disks {
-		if d.Source == "" && d.Type == "SCRATCH" {
-			// Skip scratch disks.
-			continue
-		}
-		res = append(res, describeVolumeCommandResponse{
-			// TODO(irfansharif): Use of the device name here is wrong -- it's
-			// ends up being things like "persistent-disk-1" but in other, more
-			// correct uses, it's "irfansharif-snapshot-0001-1". In fact, this
-			// whole transformation from attachDiskCmdDisk to
-			// describeVolumeCommandResponse if funky. Use something like
-			// (Provider).ListVolumes instead.
-			Name:     d.DeviceName,
-			SelfLink: d.Source,
-			SizeGB:   d.DiskSizeGB,
-			Type:     diskType(d.Type),
-			Zone:     zone,
-		})
-	}
-	return res
 }
 
 // populateCostPerHour adds an approximate cost per hour to each VM in the list,
@@ -2920,6 +3189,23 @@ func (p *Provider) ProjectActive(project string) bool {
 func lastComponent(url string) string {
 	s := strings.Split(url, "/")
 	return s[len(s)-1]
+}
+
+// zoneFromSelfLink splits a GCE self link and returns the zone. This is used
+// because some fields in GCE APIs are defined using URLs like:
+//
+//	"https://www.googleapis.com/compute/v1/projects/cockroach-shared/zones/us-east1-b/machineTypes/n2-standard-16"
+//
+// We want to extract the "us-east1-b" part, which is the zone.
+func zoneFromSelfLink(selfLink string) string {
+	substr := "zones/"
+	idx := strings.Index(selfLink, substr)
+	if idx == -1 {
+		return ""
+	}
+	selfLink = selfLink[idx+len(substr):]
+	s := strings.Split(selfLink, "/")
+	return s[0]
 }
 
 // checkSDKVersion checks that the gcloud SDK version is at least minVersion.

--- a/pkg/roachprod/vm/vm.go
+++ b/pkg/roachprod/vm/vm.go
@@ -474,8 +474,8 @@ type Provider interface {
 	// ConfigSSH takes a list of zones and configures SSH for machines in those
 	// zones for the given provider.
 	ConfigSSH(l *logger.Logger, zones []string) error
-	Create(l *logger.Logger, names []string, opts CreateOpts, providerOpts ProviderOpts) error
-	Grow(l *logger.Logger, vms List, clusterName string, names []string) error
+	Create(l *logger.Logger, names []string, opts CreateOpts, providerOpts ProviderOpts) (List, error)
+	Grow(l *logger.Logger, vms List, clusterName string, names []string) (List, error)
 	Shrink(l *logger.Logger, vmsToRemove List, clusterName string) error
 	Reset(l *logger.Logger, vms List) error
 	Delete(l *logger.Logger, vms List) error


### PR DESCRIPTION
Backport 1/1 commits from #137956.

/cc @cockroachdb/release

---

A few commands that alter a single cluster were forcing a sync of all clusters across all Cloud providers after execution in order to refresh `roachprod`'s local cache. While this behavior limits the possibility of a cache drift, it can lead to many issues (as described in #130082).

By updating the `Provider{}` interface, this patch forces its implementations to return an updated `vm.List` argument when creating or modifying a cluster. This allows to directly update the local cache without having to sync from the Cloud providers again. As most of the commands executed to alter a cluster already return the information required to update the cache, this also reduces the number of API calls to the Cloud providers.

The following commands have been updated:
  - create
  - destroy
  - extend
  - grow
  - shrink

Epic: none
Release note: None

---

Release justification: Test only change
