### PR TITLE
server: don't override leader fortification setting in test

### DIFF
--- a/pkg/server/testserver_test.go
+++ b/pkg/server/testserver_test.go
@@ -10,7 +10,6 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
-	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -49,9 +48,6 @@ func BenchmarkTestServerStartup(b *testing.B) {
 						},
 					},
 				}
-				// Disable leader fortification as it currently causes large variability in runtime.
-				kvserver.RaftLeaderFortificationFractionEnabled.Override(context.Background(), &args.Settings.SV, 0.0)
-
 				s := serverutils.StartServerOnly(b, args)
 				s.Stopper().Stop(context.Background())
 			}
@@ -77,8 +73,6 @@ func TestServerStartup(t *testing.T) {
 			DefaultTestTenant: tc.tenantOpt,
 			Settings:          cluster.MakeTestingClusterSettings(),
 		}
-		// Disable leader fortification as it currently causes large variability in runtime.
-		kvserver.RaftLeaderFortificationFractionEnabled.Override(context.Background(), &args.Settings.SV, 0.0)
 
 		t.Run(tc.name, func(t *testing.T) {
 			testutils.RunTrueAndFalse(t, "slim", func(t *testing.T, useSlimServer bool) {


### PR DESCRIPTION
Since 1 is the default value now, we should have this benchmark test with that value in order to accurately measure how long testserver startup takes.

Turns out using leader leases is actually faster anyway (thanks to #142150):
```
old:  2bcbd41 Merge #142209
new:  c66b30b server: don't override leader fortification settin
args: benchdiff "--old" "2bcbd41ad3b" "--new" "c66b30b7bc6" "./pkg/server" "-r" "BenchmarkTestServerStartup" "-c" "10" "-b"

name                                   old time/op    new time/op    delta
TestServerStartup/ExternalTenant-10       221ms ±16%     140ms ± 8%  -36.56%  (p=0.000 n=10+9)
TestServerStartup/SystemTenantOnly-10     222ms ± 8%     143ms ±13%  -35.69%  (p=0.000 n=9+10)
TestServerStartup/SharedTenant-10         209ms ±23%     144ms ±10%  -31.29%  (p=0.000 n=10+9)

name                                   old alloc/op   new alloc/op   delta
TestServerStartup/SharedTenant-10         117MB ± 1%     117MB ± 1%     ~     (p=0.720 n=9+10)
TestServerStartup/ExternalTenant-10       118MB ± 1%     117MB ± 1%     ~     (p=0.133 n=9+10)
TestServerStartup/SystemTenantOnly-10     118MB ± 1%     118MB ± 1%     ~     (p=0.211 n=10+9)

name                                   old allocs/op  new allocs/op  delta
TestServerStartup/SystemTenantOnly-10      701k ± 0%      709k ± 0%   +1.17%  (p=0.000 n=10+10)
TestServerStartup/ExternalTenant-10        701k ± 0%      709k ± 0%   +1.19%  (p=0.000 n=10+9)
TestServerStartup/SharedTenant-10          700k ± 0%      709k ± 0%   +1.25%  (p=0.000 n=10+10)
```

Epic: None
Release note: None