### PR TITLE
release: sign MacOS ARM64 binaries on Linux

### DIFF
--- a/build/teamcity/internal/cockroach/release/publish/sign_staged_macos_release_on_linux.sh
+++ b/build/teamcity/internal/cockroach/release/publish/sign_staged_macos_release_on_linux.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+
+# Copyright 2023 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
+set -xeuo pipefail
+
+dir="$(dirname $(dirname $(dirname $(dirname $(dirname $(dirname "${0}"))))))"
+source "$dir/teamcity-support.sh"  # For log_into_gcloud
+
+curr_dir=$(pwd)
+
+remove_files_on_exit() {
+  rm -f "$curr_dir/.google-credentials.json"
+  rm -f "$curr_dir/.secrets"
+}
+trap remove_files_on_exit EXIT
+
+# By default, set dry-run variables
+google_credentials="$GCS_CREDENTIALS_DEV"
+gcs_staged_bucket="cockroach-release-artifacts-staged-dryrun"
+version=$(grep -v "^#" "$dir/../pkg/build/version.txt" | head -n1)
+
+# override dev defaults with production values
+if [[ -z "${DRY_RUN}" ]] ; then
+  echo "Setting production variable values"
+  google_credentials="$GCS_CREDENTIALS_PROD"
+  gcs_staged_bucket="cockroach-release-artifacts-staged-prod"
+fi
+
+log_into_gcloud
+
+mkdir -p .secrets
+gcloud secrets versions access latest --secret=apple-signing-cert | base64 -d > "$curr_dir/.secrets/cert.p12"
+gcloud secrets versions access latest --secret=apple-signing-cert-password > "$curr_dir/.secrets/cert.pass"
+gcloud secrets versions access latest --secret=appstoreconnect-api-key > "$curr_dir/.secrets/api_key.json"
+
+mkdir -p artifacts
+cd artifacts
+
+for product in cockroach cockroach-sql; do
+  # TODO: add Intel binaries too.
+  for platform in darwin-11.0-arm64; do
+    base=${product}-${version}.${platform}
+    unsigned_base=${product}-${version}.${platform}.unsigned
+    unsigned_file=${unsigned_base}.tgz
+    target=${base}.tgz
+
+    gsutil cp "gs://$gcs_staged_bucket/$unsigned_file" "$unsigned_file"
+    gsutil cp "gs://$gcs_staged_bucket/$unsigned_file.sha256sum" "$unsigned_file.sha256sum"
+
+    shasum --algorithm 256 --check "$unsigned_file.sha256sum"
+
+    tar -xf "$unsigned_file"
+    mv "$unsigned_base" "$base"
+
+    rcodesign sign \
+      --p12-file "$curr_dir/.secrets/cert.p12" --p12-password-file "$curr_dir/.secrets/cert.pass" \
+      --code-signature-flags runtime \
+      "$base/$product"
+    tar -czf "$target" "$base"
+
+    zip crl.zip "$base/$product"
+    rcodesign notary-submit \
+      --api-key-file "$curr_dir/.secrets/api_key.json" \
+      --wait \
+      crl.zip
+
+    rm -rf "$base" "$unsigned_file" "$unsigned_file.sha256sum" crl.zip
+
+    shasum --algorithm 256 "$target" > "$target.sha256sum"
+    gsutil cp "$target" "gs://$gcs_staged_bucket/$target"
+    gsutil cp "$target.sha256sum" "gs://$gcs_staged_bucket/$target.sha256sum"
+
+  done
+done


### PR DESCRIPTION
Previously, we used MacOS agents to sign the binaries. Managing these agents was not convenient.

This PR uses `rcodesign` to sign and notarize the MacOS ARM64 binaries.

Part of: DEVINF-1406
Release note: None