### PR TITLE
upgrademanager: skip TestPrecondition under race

### DIFF
--- a/pkg/upgrade/upgrademanager/manager_external_test.go
+++ b/pkg/upgrade/upgrademanager/manager_external_test.go
@@ -692,6 +692,7 @@ func TestPrecondition(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	skip.UnderStress(t, "flaky")
+	skip.UnderRace(t, "flaky")
 
 	// Start by running v0. We want the precondition of v1 to prevent
 	// us from reaching v1 (or v2). We want the precondition to not be


### PR DESCRIPTION
This test has been flaky under race.

Fixes: #140350
Release note: None