### PR TITLE
release-25.1: sql: fix check to determine if declarative schema changer can be used

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/triggers
+++ b/pkg/ccl/logictestccl/testdata/logic_test/triggers
@@ -4080,4 +4080,67 @@ DROP FUNCTION update_listing_balance ;
 statement ok
 drop table listings_balance cascade;
 
+# Test that CREATE and DROP TRIGGER work when sent in a statement batch.
+
+subtest create_drop_in_batch_statement
+
+statement ok
+CREATE TABLE tab_141810 (
+  id  INT PRIMARY KEY,
+  a   INT,
+  b   INT
+);
+CREATE OR REPLACE FUNCTION func_141810() RETURNS TRIGGER LANGUAGE PLpgSQL AS $$
+  BEGIN
+    IF TG_OP = 'INSERT' THEN
+      NEW.a := 1;
+    END IF;
+    NEW.b := 2;
+    RETURN NEW;
+  END;
+$$;
+CREATE TRIGGER trg_141810
+  BEFORE INSERT OR UPDATE ON tab_141810
+  FOR EACH ROW
+  EXECUTE FUNCTION func_141810();
+INSERT INTO tab_141810 (id) VALUES (1);
+DROP TRIGGER trg_141810 ON tab_141810;
+INSERT INTO tab_141810 (id) VALUES (2);
+
+query III
+SELECT id, a, b FROM tab_141810 ORDER BY id
+----
+1  1     2
+2  NULL  NULL
+
+# Test that CREATE and DROP TRIGGER work in a prepared statement.
+
+subtest create_drop_prepared
+
+statement ok
+PREPARE foo AS CREATE TRIGGER trg_141810 BEFORE INSERT ON tab_141810 FOR EACH ROW EXECUTE FUNCTION func_141810();
+
+statement ok
+EXECUTE foo;
+
+statement ok
+INSERT INTO tab_141810 VALUES (3);
+
+statement ok
+PREPARE bar AS DROP TRIGGER trg_141810 ON tab_141810;
+
+statement ok
+EXECUTE bar;
+
+statement ok
+INSERT INTO tab_141810 VALUES (4);
+
+query III
+SELECT id, a, b FROM tab_141810 ORDER BY id
+----
+1  1     2
+2  NULL  NULL
+3  1     2
+4  NULL  NULL
+
 subtest end

--- a/pkg/ccl/multiregionccl/region_test.go
+++ b/pkg/ccl/multiregionccl/region_test.go
@@ -314,8 +314,13 @@ func TestRegionAddDropEnclosingRegionalByRowOps(t *testing.T) {
 		expectedIndexes []string
 	}{
 		{
-			name:            "create-rbr-table",
-			op:              `DROP TABLE IF EXISTS db.rbr; CREATE TABLE db.rbr() LOCALITY REGIONAL BY ROW`,
+			name: "create-rbr-table",
+			op: `
+BEGIN;
+SET LOCAL autocommit_before_ddl = false;
+DROP TABLE IF EXISTS db.rbr;
+CREATE TABLE db.rbr() LOCALITY REGIONAL BY ROW;
+COMMIT;`,
 			expectedIndexes: []string{"rbr@rbr_pkey"},
 		},
 	}

--- a/pkg/ccl/spanconfigccl/spanconfigreconcilerccl/datadriven_test.go
+++ b/pkg/ccl/spanconfigccl/spanconfigreconcilerccl/datadriven_test.go
@@ -150,7 +150,7 @@ func TestDataDriven(t *testing.T) {
 				// Run under an explicit transaction -- we rely on having a
 				// single timestamp for the statements (see
 				// tenant.TimestampAfterLastSQLChange) for ordering guarantees.
-				tenant.Exec(fmt.Sprintf("BEGIN; %s; COMMIT;", d.Input))
+				tenant.Exec(fmt.Sprintf("BEGIN; SET LOCAL autocommit_before_ddl = false; %s; COMMIT;", d.Input))
 
 			case "query-sql":
 				rows := tenant.Query(d.Input)

--- a/pkg/sql/logictest/testdata/logic_test/show_create
+++ b/pkg/sql/logictest/testdata/logic_test/show_create
@@ -76,10 +76,19 @@ c  CREATE TABLE public.c (
 statement ok
 ALTER TABLE c VALIDATE CONSTRAINT check_b;
 ALTER TABLE c VALIDATE CONSTRAINT fk_a;
-ALTER TABLE c VALIDATE CONSTRAINT unique_a;
 ALTER TABLE c VALIDATE CONSTRAINT unique_b;
 ALTER TABLE c VALIDATE CONSTRAINT unique_a_b;
 ALTER TABLE c VALIDATE CONSTRAINT unique_b_partial;
+
+skipif config local-legacy-schema-changer
+statement error constraint "unique_a" of relation "test.public.c" is not a foreign key, check, or unique without index constraint
+ALTER TABLE c VALIDATE CONSTRAINT unique_a;
+
+# The legacy schema changer is more permissive and allows this VALIDATE
+# statement even though it doesn't do anything.
+onlyif config local-legacy-schema-changer
+statement ok
+ALTER TABLE c VALIDATE CONSTRAINT unique_a;
 
 query TT
 SHOW CREATE c

--- a/pkg/sql/opt/exec/execbuilder/testdata/show_trace
+++ b/pkg/sql/opt/exec/execbuilder/testdata/show_trace
@@ -43,7 +43,12 @@ SELECT $$
 $$
 
 statement ok
-SET tracing = on,kv,results; CREATE DATABASE t; SET tracing = off
+BEGIN;
+SET LOCAL autocommit_before_ddl = false;
+SET tracing = on,kv,results;
+CREATE DATABASE t;
+SET tracing = off;
+COMMIT;
 
 # Check the KV trace; we need to remove the eventlog entry and
 # internal queries since the timestamp is non-deterministic.
@@ -59,7 +64,12 @@ sql query        rows affected: 0
 
 # More KV operations.
 statement ok
-SET tracing = on,kv,results; CREATE TABLE t.kv(k INT PRIMARY KEY, v INT, FAMILY "primary" (k, v)); SET tracing = off
+BEGIN;
+SET LOCAL autocommit_before_ddl = false;
+SET tracing = on,kv,results;
+CREATE TABLE t.kv(k INT PRIMARY KEY, v INT, FAMILY "primary" (k, v));
+SET tracing = off;
+COMMIT;
 
 query TT
 $trace_query
@@ -75,7 +85,12 @@ sql query     rows affected: 0
 # timestamp index, and we can't use (non-deterministic) timestamp
 # values in expected values.
 statement ok
-SET tracing = on,kv,results; CREATE UNIQUE INDEX woo ON t.kv(v); SET tracing = off
+BEGIN;
+SET LOCAL autocommit_before_ddl = false;
+SET tracing = on,kv,results;
+CREATE UNIQUE INDEX woo ON t.kv(v);
+SET tracing = off;
+COMMIT;
 
 query TT
 $trace_query

--- a/pkg/sql/pgwire/testdata/pgtest/schema_changes_implicit_txn
+++ b/pkg/sql/pgwire/testdata/pgtest/schema_changes_implicit_txn
@@ -110,4 +110,81 @@ ReadyForQuery
 {"Type":"CommandComplete","CommandTag":"DROP TABLE"}
 {"Type":"ReadyForQuery","TxStatus":"T"}
 
+send
+Query {"String": "COMMIT"}
+----
+
+until noncrdb_only
+ReadyForQuery
+----
+{"Type":"CommandComplete","CommandTag":"COMMIT"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+until crdb_only
+ReadyForQuery
+----
+{"Severity":"WARNING","SeverityUnlocalized":"WARNING","Code":"25P01","Message":"there is no transaction in progress","Detail":"","Hint":"","Position":0,"InternalPosition":0,"InternalQuery":"","Where":"","SchemaName":"","TableName":"","ColumnName":"","DataTypeName":"","ConstraintName":"","File":"exec_util.go","Line":0,"Routine":"init","UnknownFields":null}
+{"Type":"CommandComplete","CommandTag":"COMMIT"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+subtest end
+
+# Verify that CREATE and DROP TRIGGER statements can be prepared. These
+# statements are only implemented in the declarative schema changer, so this
+# tests the logic that determines if the schema change is supported by the
+# declarative schema changer.
+subtest triggers
+
+send
+Query {"String": "DROP TABLE IF EXISTS t141810;"}
+Query {"String": "DROP FUNCTION IF EXISTS f141810;"}
+Query {"String": "CREATE TABLE t141810 (x INT, y INT);"}
+Query {"String": "CREATE FUNCTION f141810() RETURNS TRIGGER LANGUAGE PLpgSQL AS $$ BEGIN RAISE NOTICE 'HERE'; RETURN NEW; END $$;"}
+----
+
+until ignore=NoticeResponse
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+ReadyForQuery
+----
+{"Type":"CommandComplete","CommandTag":"DROP TABLE"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+{"Type":"CommandComplete","CommandTag":"DROP FUNCTION"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+{"Type":"CommandComplete","CommandTag":"CREATE TABLE"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+{"Type":"CommandComplete","CommandTag":"CREATE FUNCTION"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+send
+Parse {"Query": "CREATE TRIGGER tr141810 BEFORE INSERT ON t141810 FOR EACH ROW EXECUTE FUNCTION f141810();"}
+Bind
+Execute
+Sync
+----
+
+until
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"BindComplete"}
+{"Type":"CommandComplete","CommandTag":"CREATE TRIGGER"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+send
+Parse {"Query": "DROP TRIGGER tr141810 ON t141810;"}
+Bind
+Execute
+Sync
+----
+
+until
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"BindComplete"}
+{"Type":"CommandComplete","CommandTag":"DROP TRIGGER"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
 subtest end

--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -6560,6 +6560,7 @@ ALTER TABLE t ADD CHECK (i > 0);
 				`
 SET sql_safe_updates = false;
 BEGIN;
+SET LOCAL autocommit_before_ddl = false;
 ALTER TABLE t DROP COLUMN j;
 INSERT INTO t VALUES(-5);
 DELETE FROM t WHERE i=-5;

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/create_index.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/create_index.go
@@ -160,10 +160,6 @@ func CreateIndex(b BuildCtx, n *tree.CreateIndex) {
 		if n.Unique {
 			panic(pgerror.New(pgcode.InvalidSQLStatementName, "inverted indexes can't be unique"))
 		}
-		b.IncrementSchemaChangeIndexCounter("inverted")
-		if len(n.Columns) > 1 {
-			b.IncrementSchemaChangeIndexCounter("multi_column_inverted")
-		}
 	}
 
 	// Assign the ID here, since we may have added columns
@@ -180,6 +176,14 @@ func CreateIndex(b BuildCtx, n *tree.CreateIndex) {
 	// Picks up any geoconfig parameters, hash sharded one are
 	// picked independently.
 	maybeApplyStorageParameters(b, n, &idxSpec)
+
+	if n.Inverted {
+		b.IncrementSchemaChangeIndexCounter("inverted")
+		if len(n.Columns) > 1 {
+			b.IncrementSchemaChangeIndexCounter("multi_column_inverted")
+		}
+	}
+
 	// Assign the secondary constraint ID now, since we may have added a check
 	// constraint earlier.
 	if idxSpec.secondary.IsUnique {

--- a/pkg/sql/schemachanger/schemachanger_test.go
+++ b/pkg/sql/schemachanger/schemachanger_test.go
@@ -303,17 +303,17 @@ func TestDropJobCancelable(t *testing.T) {
 	}{
 		{
 			"simple drop sequence",
-			"BEGIN;DROP SEQUENCE db.sq1; END;",
+			"BEGIN; SET LOCAL autocommit_before_ddl = false; DROP SEQUENCE db.sq1; END;",
 			false,
 		},
 		{
 			"simple drop view",
-			"BEGIN;DROP VIEW db.v1; END;",
+			"BEGIN; SET LOCAL autocommit_before_ddl = false; DROP VIEW db.v1; END;",
 			false,
 		},
 		{
 			"simple drop table",
-			"BEGIN;DROP TABLE db.t1 CASCADE; END;",
+			"BEGIN; SET LOCAL autocommit_before_ddl = false; DROP TABLE db.t1 CASCADE; END;",
 			false,
 		},
 	}

--- a/pkg/sql/testdata/telemetry/index
+++ b/pkg/sql/testdata/telemetry/index
@@ -130,7 +130,6 @@ sql.schema.partial_inverted_index
 # invalid.
 feature-usage
 CREATE INVERTED INDEX err ON d (i, j) WHERE i;
-CREATE INVERTED INDEX err ON g4 (i, geom) WHERE i
 ----
 error: pq: expected INDEX PREDICATE expression to have type bool, but 'i' has type int
 

--- a/pkg/sql/tests/autocommit_extended_protocol_test.go
+++ b/pkg/sql/tests/autocommit_extended_protocol_test.go
@@ -124,7 +124,7 @@ func TestInsertFastPathDisableDDLExtendedProtocol(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, 1, c, "expected 1 row, got %d", c)
 	// Verify that a job was created for the create index.
-	err = db.QueryRow("SELECT count(*) FROM  [SHOW JOBS] WHERE job_type ='SCHEMA CHANGE' AND description LIKE 'CREATE INDEX idx%' LIMIT 1").Scan(&c)
+	err = db.QueryRow("SELECT count(*) FROM  [SHOW JOBS] WHERE job_type ='NEW SCHEMA CHANGE' AND description LIKE 'CREATE INDEX idx%' LIMIT 1").Scan(&c)
 	require.NoError(t, err)
 	require.Equal(t, 1, c, "expected 1 row, got %d", c)
 }


### PR DESCRIPTION
Backport 2/2 commits from #142202.

/cc @cockroachdb/release

Release justification: bug fix

---

fixes https://github.com/cockroachdb/cockroach/issues/141810
Release note (bug fix): Fixed a bug that would prevent CREATE TRIGGER and DROP TRIGGER statements from working if the autocommit_before_ddl setting was enabled, and if the statement was either sent as a prepared statement or as part of a batch of multiple statements.
