### PR TITLE
vecindex: do not create root partition metadata until first split

### DIFF
--- a/pkg/sql/vecindex/cspann/commontest/storetests.go
+++ b/pkg/sql/vecindex/cspann/commontest/storetests.go
@@ -405,12 +405,8 @@ func (suite *StoreTestSuite) testEmptyOrMissingRoot(
 	suite.Run("try to remove vector from "+desc, func() {
 		metadata, err := tx.RemoveFromPartition(
 			suite.ctx, treeKey, cspann.RootKey, cspann.ChildKey{KeyBytes: cspann.KeyBytes{1, 2, 3}})
-		if isMissing {
-			suite.ErrorIs(err, cspann.ErrPartitionNotFound)
-		} else {
-			suite.NoError(err)
-			CheckPartitionMetadata(suite.T(), metadata, cspann.LeafLevel, vector.T{0, 0}, 0)
-		}
+		suite.NoError(err)
+		CheckPartitionMetadata(suite.T(), metadata, cspann.LeafLevel, vector.T{0, 0}, 0)
 	})
 }
 


### PR DESCRIPTION
A recent PR lazily creates root partition metadata when a vector is first added to a K-means tree. However, due to default stepping behavior in SQL, this partition is not visible to the transaction. This PR addresses that by waiting to create the root partition metadata until the background fixup processor splits the root partition. Until that happens, the missing root metadata is inferred, since the level must equal LeafLevel and the centroid is always the empty vector.

Epic: CRDB-42943

Release note: None