### PR TITLE
metamorphic: support override of boolean choices

### DIFF
--- a/pkg/util/metamorphic/constants.go
+++ b/pkg/util/metamorphic/constants.go
@@ -189,6 +189,8 @@ func parseChoice[T any](s string) (any, error) {
 		return strconv.ParseFloat(s, 32)
 	case float64:
 		return strconv.ParseFloat(s, 64)
+	case bool:
+		return strconv.ParseBool(s)
 	default:
 		panic(fmt.Sprintf("unable to parse %T", zero))
 	}


### PR DESCRIPTION
Some packages use ConstantWithTestChoice rather than ConstantWithTestBool. The parseChoice function didn't have a case for bool so you couldn't override such constants. Now you can.

Epic: none
Release note: None