### PR TITLE
kvserver: return early from maybeTransferRaftLeadershipToLeaseholder

### DIFF
--- a/pkg/kv/kvserver/helpers_test.go
+++ b/pkg/kv/kvserver/helpers_test.go
@@ -708,3 +708,8 @@ func (r *Replica) SupportFromEnabled() bool {
 func RaftFortificationEnabledForRangeID(fracEnabled float64, rangeID roachpb.RangeID) bool {
 	return raftFortificationEnabledForRangeID(fracEnabled, rangeID)
 }
+
+// ProcessTick exports processTick for use in tests.
+func (s *Store) ProcessTick(ctx context.Context, rangeID roachpb.RangeID) {
+	s.processTick(ctx, rangeID)
+}

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -2707,12 +2707,23 @@ func (r *Replica) maybeTransferRaftLeadershipToLeaseholderLocked(
 	if r.store.TestingKnobs().DisableLeaderFollowsLeaseholder {
 		return
 	}
-	raftStatus := r.mu.internalRaftGroup.SparseStatus()
+	raftStatus := r.mu.internalRaftGroup.BasicStatus()
+
+	// Return early if we are not the leader, or if we are already the
+	// leaseholder. This is a short circuit fast-path for
+	// shouldTransferRaftLeadershipToLeaseholderLocked(), but the same checks are
+	// also handled there.
+	if raftStatus.RaftState != raftpb.StateLeader ||
+		leaseStatus.OwnedBy(r.store.StoreID()) {
+		return
+	}
+
+	lhReplicaID := raftpb.PeerID(leaseStatus.Lease.Replica.ReplicaID)
 	leaseAcquisitionPending := r.mu.pendingLeaseRequest.AcquisitionInProgress()
 	ok := shouldTransferRaftLeadershipToLeaseholderLocked(
-		raftStatus, leaseStatus, leaseAcquisitionPending, r.StoreID(), r.store.IsDraining())
+		raftStatus, r.mu.internalRaftGroup.ReplicaProgress(lhReplicaID), leaseStatus,
+		leaseAcquisitionPending, r.StoreID(), r.store.IsDraining())
 	if ok {
-		lhReplicaID := raftpb.PeerID(leaseStatus.Lease.Replica.ReplicaID)
 		log.VEventf(ctx, 1, "transferring raft leadership to replica ID %v", lhReplicaID)
 		r.store.metrics.RangeRaftLeaderTransfers.Inc(1)
 		r.mu.internalRaftGroup.TransferLeader(lhReplicaID)
@@ -2720,7 +2731,8 @@ func (r *Replica) maybeTransferRaftLeadershipToLeaseholderLocked(
 }
 
 func shouldTransferRaftLeadershipToLeaseholderLocked(
-	raftStatus raft.SparseStatus,
+	raftStatus raft.BasicStatus,
+	lhProgress *tracker.Progress,
 	leaseStatus kvserverpb.LeaseStatus,
 	leaseAcquisitionPending bool,
 	storeID roachpb.StoreID,
@@ -2772,9 +2784,7 @@ func shouldTransferRaftLeadershipToLeaseholderLocked(
 	}
 
 	// Otherwise, only transfer if the leaseholder is caught up on the raft log.
-	lhReplicaID := raftpb.PeerID(leaseStatus.Lease.Replica.ReplicaID)
-	lhProgress, ok := raftStatus.Progress[lhReplicaID]
-	lhCaughtUp := ok && lhProgress.Match >= raftStatus.Commit
+	lhCaughtUp := lhProgress != nil && lhProgress.Match >= raftStatus.Commit
 	return lhCaughtUp
 }
 

--- a/pkg/raft/rawnode.go
+++ b/pkg/raft/rawnode.go
@@ -600,6 +600,12 @@ func (rn *RawNode) SparseStatus() SparseStatus {
 	return getSparseStatus(rn.raft)
 }
 
+// ReplicaProgress returns the progress for the replica with the given ID.
+// It returns nil if the replica is not being tracked.
+func (rn *RawNode) ReplicaProgress(id pb.PeerID) *tracker.Progress {
+	return getReplicaProgress(rn.raft, id)
+}
+
 // SupportingFortifiedLeader indicates if this peer supports a fortified leader.
 func (rn *RawNode) SupportingFortifiedLeader() bool {
 	return rn.raft.supportingFortifiedLeader()

--- a/pkg/raft/status.go
+++ b/pkg/raft/status.go
@@ -74,6 +74,12 @@ func withProgress(r *raft, visitor func(id pb.PeerID, typ ProgressType, pr track
 	})
 }
 
+// getReplicaProgress returns the progress for the replica with the given ID.
+// It returns nil if the replica is not being tracked.
+func getReplicaProgress(r *raft, id pb.PeerID) *tracker.Progress {
+	return r.trk.Progress(id)
+}
+
 func getProgressCopy(r *raft) map[pb.PeerID]tracker.Progress {
 	m := make(map[pb.PeerID]tracker.Progress, r.trk.Len())
 	r.trk.Visit(func(id pb.PeerID, pr *tracker.Progress) {


### PR DESCRIPTION
This commit returns early if we are already the leaseholder when calling
maybeTransferRaftLeadershipToLeaseholderLocked. This saves getting the
Raft sparse status (which is not light) in the normal case where the
leader is the leaseholder. Also, instead of getting the whole sparse
status, it gets the basic status + the progress of the leaseholder.

Benchmark results:
```
name                           old time/op    new time/op    delta
LeaderTickWithLeaderLeases-12    1.03µs ± 3%    0.77µs ± 2%   -25.73%  (p=0.000 n=19+17)

name                           old alloc/op   new alloc/op   delta
LeaderTickWithLeaderLeases-12      757B ± 0%        3B ±45%   -99.64%  (p=0.000 n=20+20)

name                           old allocs/op  new allocs/op  delta
LeaderTickWithLeaderLeases-12      2.00 ± 0%      0.00       -100.00%  (p=0.000 n=20+20)
```
References: #142329

Release note: None