### PR TITLE
sql: honour FORCE option for RLS-enabled tables

### DIFF
--- a/pkg/sql/authorization.go
+++ b/pkg/sql/authorization.go
@@ -408,8 +408,13 @@ func isOwner(
 func (p *planner) HasOwnership(
 	ctx context.Context, privilegeObject privilege.Object,
 ) (bool, error) {
-	user := p.SessionData().User()
+	return p.UserHasOwnership(ctx, privilegeObject, p.SessionData().User())
+}
 
+// UserHasOwnership implements the AuthorizationAccessor interface.
+func (p *planner) UserHasOwnership(
+	ctx context.Context, privilegeObject privilege.Object, user username.SQLUsername,
+) (bool, error) {
 	return p.checkRolePredicate(ctx, user, func(role username.SQLUsername) (bool, error) {
 		return isOwner(ctx, p, privilegeObject, role)
 	})

--- a/pkg/sql/logictest/testdata/logic_test/row_level_security
+++ b/pkg/sql/logictest/testdata/logic_test/row_level_security
@@ -1236,6 +1236,227 @@ DROP FUNCTION my_non_sec_definer_reader_function;
 statement ok
 DROP TABLE sensitive_data_table CASCADE;
 
+subtest force
+
+statement ok
+CREATE USER forcer;
+
+statement ok
+CREATE USER funuser;
+
+statement ok
+GRANT CREATE ON DATABASE db1 TO forcer;
+
+statement ok
+set role forcer;
+
+statement ok
+CREATE TABLE force_check (c1 INT NOT NULL PRIMARY KEY, c2 TEXT);
+
+statement ok
+INSERT INTO force_check VALUES (10, 'ten'), (20, 'twenty'), (50, 'fifty')
+
+statement ok
+CREATE FUNCTION access_large_c2_as_session_user() RETURNS TABLE(ID INT)
+LANGUAGE SQL AS
+$$
+ SELECT c1 FROM force_check WHERE length(c2) > 3
+$$;
+
+statement ok
+CREATE FUNCTION access_large_c2_as_forcer() RETURNS TABLE(ID INT)
+LANGUAGE SQL AS
+$$
+ SELECT c1 FROM force_check WHERE length(c2) > 3
+$$ SECURITY DEFINER;
+
+statement ok
+CREATE FUNCTION insert_policy_violation_as_session_user(c1 INT) RETURNS TABLE(id INT, description TEXT)
+LANGUAGE SQL AS
+$$
+ INSERT INTO force_check VALUES (c1, 't - violated col value') RETURNING c1, c2
+$$;
+
+statement ok
+CREATE FUNCTION insert_policy_violation_as_forcer(c1 INT) RETURNS TABLE(id INT, description TEXT)
+LANGUAGE SQL AS
+$$
+ INSERT INTO force_check VALUES (c1, 't - violated col value') RETURNING c1, c2
+$$ SECURITY DEFINER;
+
+statement ok
+ALTER TABLE force_check ENABLE ROW LEVEL SECURITY, FORCE ROW LEVEL SECURITY;
+
+statement ok
+CREATE POLICY p_sel ON force_check TO forcer, funuser USING (c2 not like 't%');
+
+# Should see only part of the rows because we are the table owner with FORCE on.
+# We use different queries, all showing the same results, so that the query cache
+# has multiple statements. We will retry the exact same SQL later once RLS
+# settings have changed. I label each query (e.g. q1) so it can be easily
+# found when its reused in this subtest.
+#
+# q1
+query IT
+SELECT c1, c2 FROM force_check ORDER BY c1;
+----
+50 fifty
+
+# q2
+query IT
+SELECT c1, c2 FROM force_check WHERE c1 > 0 ORDER BY c1;
+----
+50 fifty
+
+statement error pq: new row violates row-level security policy for table "force_check"
+INSERT INTO force_check VALUES (30, 'thirty')
+
+# Verify the admin can still see everything
+statement ok
+SET ROLE root
+
+# q1 - show that query reuse doesn't occur for different user
+query IT
+SELECT c1, c2 FROM force_check ORDER BY c1;
+----
+10 ten
+20 twenty
+50 fifty
+
+statement ok
+INSERT INTO force_check VALUES (33, 'thirty-three')
+
+statement ok
+SET ROLE forcer;
+
+# Turn off force to ensure we can see everything again.
+statement ok
+ALTER TABLE force_check NO FORCE ROW LEVEL SECURITY;
+
+statement ok
+INSERT INTO force_check VALUES (30, 'thirty')
+
+# q2 - should not reuse because table version since last use
+query IT
+SELECT c1, c2 FROM force_check WHERE c1 > 0 ORDER BY c1;
+----
+10 ten
+20 twenty
+30 thirty
+33 thirty-three
+50 fifty
+
+# Transfer ownership of force_check back to the root and attempt query from cache.
+statement ok
+SET ROLE root
+
+statement ok
+ALTER TABLE force_check OWNER TO root;
+
+statement ok
+GRANT ALL ON force_check TO forcer;
+
+statement ok
+SET ROLE forcer;
+
+# q2 - should not be reused due to an ownership change, which has resulted in a
+# new table version since its last use
+query IT
+SELECT c1, c2 FROM force_check WHERE c1 > 0 ORDER BY c1;
+----
+50 fifty
+
+# Turn on force again, but it shouldn't matter because we aren't the owner anymore
+statement ok
+ALTER TABLE force_check FORCE ROW LEVEL SECURITY;
+
+# q2 - should not reuse because table version change
+query IT
+SELECT c1, c2 FROM force_check WHERE c1 > 0 ORDER BY c1;
+----
+50 fifty
+
+statement error pq: new row violates row-level security policy for table "force_check"
+INSERT INTO force_check VALUES (34, 'thirty-four')
+
+# Transfer back to forcer and access table via functions as 'funuser'
+statement ok
+SET ROLE root
+
+statement ok
+ALTER TABLE force_check OWNER TO forcer;
+
+statement ok
+GRANT ALL ON force_check TO funuser;
+
+statement ok
+SET ROLE funuser;
+
+# Since FORCE is enabled, the policies will apply both to the session user and
+# when running the function as the security definer (forcer). Therefore, we
+# expect the same filtered result in both cases.
+
+query I
+select * from access_large_c2_as_session_user();
+----
+50
+
+query I
+select * from access_large_c2_as_forcer();
+----
+50
+
+# Similar for functions that add new rows
+
+statement error pq: new row violates row-level security policy for table "force_check"
+SELECT insert_policy_violation_as_session_user(110);
+
+statement error pq: new row violates row-level security policy for table "force_check"
+SELECT insert_policy_violation_as_forcer(111);
+
+# Turn off FORCE and retry function access as funuser
+statement ok
+SET ROLE forcer;
+
+statement ok
+ALTER TABLE force_check NO FORCE ROW LEVEL SECURITY;
+
+statement ok
+SET ROLE funuser;
+
+# FORCE is now off. When run as funuser, the result should remain the same as
+# before. However, when running the function as forcer, policies will not be
+# applied since forcer is the table owner and is exempt from policy enforcement.
+
+query I
+select * from access_large_c2_as_session_user();
+----
+50
+
+query I rowsort
+select * from access_large_c2_as_forcer();
+----
+20
+30
+33
+50
+
+# Similar for functions that add new rows
+
+statement error pq: new row violates row-level security policy for table "force_check"
+SELECT insert_policy_violation_as_session_user(111);
+
+query IT
+SELECT * FROM insert_policy_violation_as_forcer(112);
+----
+112  t - violated col value
+
+statement ok
+SET ROLE root
+
+statement ok
+DROP TABLE force_check CASCADE;
+
 subtest truncate
 
 statement ok

--- a/pkg/sql/opt/cat/catalog.go
+++ b/pkg/sql/opt/cat/catalog.go
@@ -271,4 +271,7 @@ type Catalog interface {
 	// GetRoutineOwner returns the username.SQLUsername of the routine's
 	// (specified by routineOid) owner.
 	GetRoutineOwner(ctx context.Context, routineOid oid.Oid) (username.SQLUsername, error)
+
+	// IsOwner returns true if user is the owner of the object o
+	IsOwner(ctx context.Context, o Object, user username.SQLUsername) (bool, error)
 }

--- a/pkg/sql/opt/cat/table.go
+++ b/pkg/sql/opt/cat/table.go
@@ -188,6 +188,10 @@ type Table interface {
 	// IsRowLevelSecurityEnabled is true if policies should be applied during the query.
 	IsRowLevelSecurityEnabled() bool
 
+	// IsRowLevelSecurityForced is true if row-level security policies should be
+	// applied to the table owner.
+	IsRowLevelSecurityForced() bool
+
 	// Policies returns all the policies defined for this table.
 	Policies() *Policies
 }

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -460,15 +460,15 @@ func (b *Builder) maybeAnnotatePolicyInfo(node exec.Node, e memo.RelExpr) {
 		// Helper to annotate a node for the given table ID.
 		annotateNodeForTable := func(tabID opt.TableID, applyFilterExpr bool) {
 			// Pull out the policy information for the table the node was built for.
-			policies, found := rlsMeta.PoliciesApplied[tabID]
+			policiesApplied, found := rlsMeta.PoliciesApplied[tabID]
 			if found {
 				val := exec.RLSPoliciesApplied{
-					PoliciesSkippedForRole: rlsMeta.HasAdminRole,
+					PoliciesSkippedForRole: rlsMeta.HasAdminRole || policiesApplied.NoForceExempt,
 				}
 				if applyFilterExpr {
-					val.Policies = policies.Filter
+					val.Policies = policiesApplied.Filter
 				} else {
-					val.Policies = policies.Check
+					val.Policies = policiesApplied.Check
 				}
 				ef.AnnotateNode(node, exec.PolicyInfoID, &val)
 			}

--- a/pkg/sql/opt/exec/explain/plan_gist_factory.go
+++ b/pkg/sql/opt/exec/explain/plan_gist_factory.go
@@ -666,6 +666,9 @@ func (u *unknownTable) Trigger(i int) cat.Trigger {
 // IsRowLevelSecurityEnabled is part of the cat.Table interface
 func (u *unknownTable) IsRowLevelSecurityEnabled() bool { return false }
 
+// IsRowLevelSecurityForced is part of the cat.Table interface
+func (u *unknownTable) IsRowLevelSecurityForced() bool { return false }
+
 // Policies is part of the cat.Table interface.
 func (u *unknownTable) Policies() *cat.Policies { return nil }
 

--- a/pkg/sql/opt/exec/explain/testdata/row_level_security
+++ b/pkg/sql/opt/exec/explain/testdata/row_level_security
@@ -369,3 +369,51 @@ DELETE FROM writer WHERE value = 'some-val' or value = 'other-val';
           table: writer@writer_pkey
           spans: 1+ spans
           policies: p_delete
+
+# Show that policies are exempt when the table owner queries the table, unless
+# the FORCE option is used.
+# ----------------------------------------------------------------------
+
+exec-ddl
+ALTER TABLE t1 OWNER TO rls_accessor
+----
+
+plan
+select count(*) from t1,t2 where t1.c1 = t2.c1;
+----
+• group (scalar)
+│
+└── • hash join
+    │ equality: (c1) = (c1)
+    │
+    ├── • scan
+    │     table: t1@t1_pkey
+    │     spans: FULL SCAN
+    │     policies: exempt for role
+    │
+    └── • scan
+          table: t2@t2_pkey
+          spans: FULL SCAN
+          policies: t2_pol_1
+
+exec-ddl
+ALTER TABLE t1 FORCE ROW LEVEL SECURITY
+----
+
+plan
+select count(*) from t1,t2 where t1.c1 = t2.c1;
+----
+• group (scalar)
+│
+└── • hash join
+    │ equality: (c1) = (c1)
+    │
+    ├── • scan
+    │     table: t1@t1_pkey
+    │     spans: FULL SCAN
+    │     policies: policy 1, p2, p3, r1, r2
+    │
+    └── • scan
+          table: t2@t2_pkey
+          spans: FULL SCAN
+          policies: t2_pol_1

--- a/pkg/sql/opt/memo/memo_test.go
+++ b/pkg/sql/opt/memo/memo_test.go
@@ -633,7 +633,8 @@ func TestMemoIsStale(t *testing.T) {
 	notStale()
 
 	// User changes (with RLS)
-	o.Memo().Metadata().SetRLSEnabled(evalCtx.SessionData().User(), true /* admin */, 1 /* tableID */)
+	o.Memo().Metadata().SetRLSEnabled(evalCtx.SessionData().User(), true, /* admin */
+		1 /* tableID */, false /* isTableOwnerAndNotForced */)
 	notStale()
 	evalCtx.SessionData().UserProto = newUser
 	stale()

--- a/pkg/sql/opt/metadata.go
+++ b/pkg/sql/opt/metadata.go
@@ -1185,9 +1185,11 @@ func (md *Metadata) TestingPrivileges() map[cat.StableID]privilegeBitmap {
 
 // SetRLSEnabled will update the metadata to indicate we came across a table
 // that had row-level security enabled.
-func (md *Metadata) SetRLSEnabled(user username.SQLUsername, isAdmin bool, tableID TableID) {
+func (md *Metadata) SetRLSEnabled(
+	user username.SQLUsername, isAdmin bool, tableID TableID, isTableOwnerAndNotForced bool,
+) {
 	md.rlsMeta.MaybeInit(user, isAdmin)
-	md.rlsMeta.AddTableUse(tableID)
+	md.rlsMeta.AddTableUse(tableID, isTableOwnerAndNotForced)
 }
 
 // ClearRLSEnabled will clear out the initialized state for the rls meta. This

--- a/pkg/sql/opt/optbuilder/testdata/row_level_security
+++ b/pkg/sql/opt/optbuilder/testdata/row_level_security
@@ -721,3 +721,102 @@ update t1_explicit_pk
       │         └── now() [as=c3_new:11]
       └── projections
            └── (((((c1:6 = 1) OR (c1:6 = 2)) OR (c1:6 = 3)) OR (c1:6 = 4)) AND ((c1:6 % 2) = 0)) AND ((c1:6 % 3) = 0) [as=rls:12]
+
+# Show that the owner, who is not admin, is exempt from policies unless FORCE
+# option is set.
+
+exec-ddl
+ALTER TABLE t1 OWNER TO fred;
+----
+
+exec-ddl
+CREATE POLICY p_read on t1 FOR SELECT TO fred USING (c2 != 'out of policy');
+----
+
+exec-ddl
+CREATE POLICY p_write on t1 FOR INSERT TO fred WITH CHECK (c3 >= '2025-01-01');
+----
+
+# Show that querying and inserting into the table won't have the policy filter.
+build
+SELECT c1 FROM t1 where C1 between 0 and 9;
+----
+project
+ ├── columns: c1:1!null
+ └── select
+      ├── columns: c1:1!null c2:2 c3:3 rowid:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+      ├── scan t1
+      │    └── columns: c1:1 c2:2 c3:3 rowid:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+      └── filters
+           └── (c1:1 >= 0) AND (c1:1 <= 9)
+
+build
+INSERT INTO t1(c1) VALUES (23);
+----
+insert t1
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├── column1:7 => c1:1
+ │    ├── c2_default:8 => c2:2
+ │    ├── c3_default:9 => c3:3
+ │    └── rowid_default:10 => rowid:4
+ ├── check columns: rls:11
+ └── project
+      ├── columns: rls:11!null column1:7!null c2_default:8 c3_default:9 rowid_default:10
+      ├── project
+      │    ├── columns: c2_default:8 c3_default:9 rowid_default:10 column1:7!null
+      │    ├── values
+      │    │    ├── columns: column1:7!null
+      │    │    └── (23,)
+      │    └── projections
+      │         ├── NULL::STRING [as=c2_default:8]
+      │         ├── NULL::DATE [as=c3_default:9]
+      │         └── unique_rowid() [as=rowid_default:10]
+      └── projections
+           └── true [as=rls:11]
+
+exec-ddl
+ALTER TABLE t1 FORCE ROW LEVEL SECURITY
+----
+
+# Repeat the above DML, but this time with FORCE enabled. The policies will show up.
+build
+SELECT c1 FROM t1 where C1 between 0 and 9;
+----
+project
+ ├── columns: c1:1!null
+ └── select
+      ├── columns: c1:1!null c2:2!null c3:3 rowid:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+      ├── select
+      │    ├── columns: c1:1 c2:2!null c3:3 rowid:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+      │    ├── scan t1
+      │    │    └── columns: c1:1 c2:2 c3:3 rowid:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+      │    └── filters
+      │         └── c2:2 != 'out of policy'
+      └── filters
+           └── (c1:1 >= 0) AND (c1:1 <= 9)
+
+build
+INSERT INTO t1(c1) VALUES (23);
+----
+insert t1
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├── column1:7 => c1:1
+ │    ├── c2_default:8 => c2:2
+ │    ├── c3_default:9 => c3:3
+ │    └── rowid_default:10 => rowid:4
+ ├── check columns: rls:11
+ └── project
+      ├── columns: rls:11 column1:7!null c2_default:8 c3_default:9 rowid_default:10
+      ├── project
+      │    ├── columns: c2_default:8 c3_default:9 rowid_default:10 column1:7!null
+      │    ├── values
+      │    │    ├── columns: column1:7!null
+      │    │    └── (23,)
+      │    └── projections
+      │         ├── NULL::STRING [as=c2_default:8]
+      │         ├── NULL::DATE [as=c3_default:9]
+      │         └── unique_rowid() [as=rowid_default:10]
+      └── projections
+           └── c3_default:9 >= '2025-01-01' [as=rls:11]

--- a/pkg/sql/opt/row_level_security.go
+++ b/pkg/sql/opt/row_level_security.go
@@ -54,11 +54,12 @@ func (r *RowLevelSecurityMeta) Clear() {
 // AddTableUse indicates that an RLS-enabled table was encountered while
 // building the query plan. If any policies are in use, they will be added
 // via the AddPolicyUse call.
-func (r *RowLevelSecurityMeta) AddTableUse(tableID TableID) {
+func (r *RowLevelSecurityMeta) AddTableUse(tableID TableID, isTableOwnerAndNotForced bool) {
 	if _, found := r.PoliciesApplied[tableID]; !found {
 		r.PoliciesApplied[tableID] = PoliciesApplied{
-			Filter: PolicyIDSet{},
-			Check:  PolicyIDSet{},
+			NoForceExempt: isTableOwnerAndNotForced,
+			Filter:        PolicyIDSet{},
+			Check:         PolicyIDSet{},
 		}
 	}
 }
@@ -83,6 +84,9 @@ func (r *RowLevelSecurityMeta) AddPoliciesUsed(
 
 // PoliciesApplied stores the set of policies that were applied to a table.
 type PoliciesApplied struct {
+	// NoForceExempt is true if the policies were exempt because they were the
+	// table owner and force RLS wasn't set.
+	NoForceExempt bool
 	// Filter is the set of policy IDs that were applied to filter out existing
 	// rows. The USING expression in each policy is used to derive the filter.
 	Filter PolicyIDSet
@@ -94,8 +98,9 @@ type PoliciesApplied struct {
 
 func (p *PoliciesApplied) Copy() PoliciesApplied {
 	return PoliciesApplied{
-		Filter: p.Filter.Copy(),
-		Check:  p.Check.Copy(),
+		NoForceExempt: p.NoForceExempt,
+		Filter:        p.Filter.Copy(),
+		Check:         p.Check.Copy(),
 	}
 }
 

--- a/pkg/sql/opt/testutils/testcat/create_table.go
+++ b/pkg/sql/opt/testutils/testcat/create_table.go
@@ -511,6 +511,7 @@ func (tc *Catalog) CreateTableAs(name tree.TableName, columns []cat.Column) *Tab
 
 	tab.Columns = append(tab.Columns, rowid)
 	tab.addPrimaryColumnIndex("rowid")
+	tab.Owner = tc.currentUser
 
 	// Add the new table to the catalog.
 	tc.AddTable(tab)

--- a/pkg/sql/schemachanger/scbuild/dependencies.go
+++ b/pkg/sql/schemachanger/scbuild/dependencies.go
@@ -200,6 +200,9 @@ type AuthorizationAccessor interface {
 	// of, has ownership privilege of the desc.
 	HasOwnership(ctx context.Context, privilegeObject privilege.Object) (bool, error)
 
+	// UserHasOwnership is like HasOwnership but allows you to specify the owner.
+	UserHasOwnership(ctx context.Context, privilegeObject privilege.Object, user username.SQLUsername) (bool, error)
+
 	// CheckPrivilegeForUser verifies that `user` has `privilege` on `descriptor`.
 	CheckPrivilegeForUser(
 		ctx context.Context, privilegeObject privilege.Object, privilege privilege.Kind, user username.SQLUsername,

--- a/pkg/sql/schemachanger/scdeps/sctestdeps/test_deps.go
+++ b/pkg/sql/schemachanger/scdeps/sctestdeps/test_deps.go
@@ -184,6 +184,13 @@ func (s *TestState) HasOwnership(
 	return true, nil
 }
 
+// UserHasOwnership implements the scbuild.AuthorizationAccessor interface.
+func (s *TestState) UserHasOwnership(
+	context.Context, privilege.Object, username.SQLUsername,
+) (bool, error) {
+	return true, nil
+}
+
 // HasPrivilege implements the scbuild.AuthorizationAccessor interface.
 func (s *TestState) HasPrivilege(
 	ctx context.Context,


### PR DESCRIPTION
This change implements the logic for the FORCE ROW LEVEL SECURITY option on tables with row-level security (RLS) enabled.

By default, table owners are exempt from RLS policies. However, when the FORCE option is set, policies apply to table owners as well. This behavior can be configured via ALTER TABLE ... FORCE ROW LEVEL SECURITY, which was previously introduced.

With this change, when building the plan we now correctly checks the FORCE setting when evaluating RLS policies. If FORCE is enabled, policies apply even when the current user is the table owner.

Additionally, updates to the test catalog allow modifying table ownership (ALTER TABLE ... OWNER) and toggling the FORCE ROW LEVEL SECURITY option, enabling tests to verify behavior changes when FORCE is on or off.

Epic: CRDB-45203
Release note: None
Closes: #138844