### PR TITLE
upgrades: mark missing job error as permanent

### DIFF
--- a/pkg/upgrade/upgrades/v25_1_add_jobs_tables.go
+++ b/pkg/upgrade/upgrades/v25_1_add_jobs_tables.go
@@ -170,7 +170,7 @@ func backfillJobsTablesAndColumns(
 				// owner to an empty string) and continuing so that the upgrade
 				// completes.
 				if row == nil {
-					return errors.Newf("job %d missing from crdb_internal.jobs", id)
+					return jobs.MarkAsPermanentJobError(errors.Newf("job %d missing from crdb_internal.jobs", id))
 				}
 
 				// Update the job row.


### PR DESCRIPTION
Otherwise the jobs system just silently retries the job without indicating why it cannot succeed, causing 'set cluster setting version' to just hang forever. With the error marked as permanent, it immediately fails with a message identifying the problem allowing it to be fixed and then the finalization retried by the user once the corrupted jobs are addressed.

Release note: none.
Epic: none.