### PR TITLE
builtins: add jsonb_path_query

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -1262,6 +1262,25 @@ available replica will error.</p>
 </span></td><td>Stable</td></tr></tbody>
 </table>
 
+### Jsonpath functions
+
+<table>
+<thead><tr><th>Function &rarr; Returns</th><th>Description</th><th>Volatility</th></tr></thead>
+<tbody>
+<tr><td><a name="jsonb_path_query"></a><code>jsonb_path_query(target: jsonb, path: jsonpath) &rarr; jsonb</code></td><td><span class="funcdesc"><p>Returns all JSON items returned by the JSON path for the specified JSON value.</p>
+</span></td><td>Immutable</td></tr>
+<tr><td><a name="jsonb_path_query"></a><code>jsonb_path_query(target: jsonb, path: jsonpath, vars: jsonb) &rarr; jsonb</code></td><td><span class="funcdesc"><p>Returns all JSON items returned by the JSON path for the specified JSON value.
+The vars argument must be a JSON object, and its fields provide named values
+to be substituted into the jsonpath expression.</p>
+</span></td><td>Immutable</td></tr>
+<tr><td><a name="jsonb_path_query"></a><code>jsonb_path_query(target: jsonb, path: jsonpath, vars: jsonb, silent: <a href="bool.html">bool</a>) &rarr; jsonb</code></td><td><span class="funcdesc"><p>Returns all JSON items returned by the JSON path for the specified JSON value.
+The vars argument must be a JSON object, and its fields provide named values
+to be substituted into the jsonpath expression. If the silent argument is true,
+the function suppresses the following errors: missing object field or array
+element, unexpected JSON item type, datetime and numeric errors.</p>
+</span></td><td>Immutable</td></tr></tbody>
+</table>
+
 ### Multi-region functions
 
 <table>

--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -2589,6 +2589,7 @@ GO_TARGETS = [
     "//pkg/util/json:json",
     "//pkg/util/json:json_test",
     "//pkg/util/jsonbytes:jsonbytes",
+    "//pkg/util/jsonpath/eval:eval",
     "//pkg/util/jsonpath/parser/lexbase:lexbase",
     "//pkg/util/jsonpath/parser:parser",
     "//pkg/util/jsonpath/parser:parser_test",

--- a/pkg/sql/logictest/testdata/logic_test/jsonb_path_query
+++ b/pkg/sql/logictest/testdata/logic_test/jsonb_path_query
@@ -1,0 +1,304 @@
+# LogicTest: local
+
+query T
+SELECT jsonb_path_query('{"a": "hello"}', '$.a[0 to 0]');
+----
+"hello"
+
+query T
+SELECT jsonb_path_query('{}', '$')
+----
+{}
+
+statement error pgcode 2203A JSON object does not contain key "a"
+SELECT jsonb_path_query('{}', 'strict $.a')
+
+query T
+SELECT jsonb_path_query('{"a": "b"}', '$')
+----
+{"a": "b"}
+
+query T
+SELECT jsonb_path_query('{"a": ["b", true, false, null]}', '$')
+----
+{"a": ["b", true, false, null]}
+
+# WITH a AS (
+#     SELECT '{
+#         "a": {
+#             "aa": {
+#                 "aaa": "s1",
+#                 "aab": 123,
+#                 "aac": true,
+#                 "aad": false,
+#                 "aae": null,
+#                 "aaf": [1, 2, 3],
+#                 "aag": {
+#                     "aaga": "s2"
+#                 }
+#             },
+#             "ab": "s3"
+#         },
+#         "b": "s4",
+#         "c": [
+#             {"ca": "s5"},
+#             {"ca": "s6"},
+#             1,
+#             true,
+#         ],
+#         "d": 123.45,
+#     }'::JSONB AS data
+# )
+
+statement ok
+CREATE TABLE a AS SELECT '{"a": {"aa": {"aaa": "s1", "aab": 123, "aac": true, "aad": false, "aae": null, "aaf": [1, 2, 3], "aag": {"aaga": "s2"}}, "ab": "s3"}, "b": "s4", "c": [{"ca": "s5"}, {"ca": "s6"}, 1, true], "d": 123.45}'::JSONB AS data
+
+query T
+SELECT jsonb_path_query(data, '$.a.aa.aaa') FROM a
+----
+"s1"
+
+query T
+SELECT jsonb_path_query(data, '$.a.aa.aab') FROM a
+----
+123
+
+query T
+SELECT jsonb_path_query(data, '$.a.aa.aac') FROM a
+----
+true
+
+query T
+SELECT jsonb_path_query(data, '$.a.aa.aad') FROM a
+----
+false
+
+query T
+SELECT jsonb_path_query(data, '$.a.aa.aae') FROM a
+----
+null
+
+query T
+SELECT jsonb_path_query(data, '$.a.aa.aaf') FROM a
+----
+[1, 2, 3]
+
+query T
+SELECT jsonb_path_query(data, '$.a.aa.aag') FROM a
+----
+{"aaga": "s2"}
+
+query T
+SELECT jsonb_path_query(data, '$.c') FROM a
+----
+[{"ca": "s5"}, {"ca": "s6"}, 1, true]
+
+query T
+SELECT jsonb_path_query(data, '$.d') FROM a
+----
+123.45
+
+query T rowsort
+SELECT jsonb_path_query(data, '$.c[*].ca') FROM a
+----
+"s5"
+"s6"
+
+statement error pgcode 2203A JSON object does not contain key "aa"
+SELECT jsonb_path_query(data, 'strict $.aa') FROM a
+
+statement error pgcode 2203A JSON object does not contain key "aa"
+SELECT jsonb_path_query(data, 'strict $.aa.aaa.aaaa') FROM a
+
+query empty
+SELECT jsonb_path_query('{}', '$.a')
+
+
+statement ok
+CREATE TABLE b (j JSONB)
+
+statement ok
+INSERT INTO b VALUES ('{"a": [1, 2, 3], "b": "hello"}'), ('{"a": false}')
+
+query T rowsort
+SELECT jsonb_path_query(j, '$.a') FROM b
+----
+[1, 2, 3]
+false
+
+query T
+SELECT jsonb_path_query(j, '$.b') FROM b
+----
+"hello"
+
+query T rowsort
+SELECT jsonb_path_query('{"a": [1, 2, {"b": [4, 5]}, null, [true, false]]}', '$.a[*]')
+----
+1
+2
+{"b": [4, 5]}
+null
+[true, false]
+
+query T rowsort
+SELECT jsonb_path_query('{"a": [1, 2, {"b": [{"c": true}, {"c": false}]}, null, [true, false], {"b": [{"c": 0.1}, {"d": null}, {"c": 10}]}]}', '$.a[*].b[*].c')
+----
+true
+false
+0.1
+10
+
+query T
+SELECT jsonb_path_query('{"a": [1]}', '$.a', '{}');
+----
+[1]
+
+statement error pgcode 22023 "vars" argument is not an object
+SELECT jsonb_path_query('{"a": [1]}', '$.a', '[]');
+
+query T
+SELECT jsonb_path_query('{"a": [1]}', '$.b', '{}', false);
+----
+
+query T
+SELECT jsonb_path_query('{"a": [1]}', '$.b', '{}', true);
+----
+
+statement error pgcode 2203A JSON object does not contain key "b"
+SELECT jsonb_path_query('{"a": [1]}', 'strict $.b', '{}', false);
+
+query T
+SELECT jsonb_path_query('{"a": [1]}', 'strict $.b', '{}', true);
+----
+
+
+query T rowsort
+SELECT jsonb_path_query('{"a": {"b": [1, 2, 3]}}', '$.a[*].b[*]');
+----
+1
+2
+3
+
+statement error pgcode 22039 jsonpath wildcard array accessor can only be applied to an array
+SELECT jsonb_path_query('{"a": {"b": [1, 2, 3]}}', 'strict $.a[*].b[*]');
+
+query T
+SELECT jsonb_path_query('{"a": [1, 2, 3, 4, 5]}', '$.a[0]');
+----
+1
+
+query T rowsort
+SELECT jsonb_path_query('[1, 2, 3, 4, 5]', '$[1 to 3, 2, 1 to 3]');
+----
+2
+3
+4
+3
+2
+3
+4
+
+query empty
+SELECT jsonb_path_query('[1, 2, 3, 4, 5]', '$[3 to 1]');
+
+
+query T rowsort
+SELECT jsonb_path_query('[1, 2, 3, 4, 5]', '$[4 to 4]');
+----
+5
+
+query T rowsort
+SELECT jsonb_path_query('{"a": [[5, 4], [7, 6], [6, 7], [10], []]}', '$.a[*][0]');
+----
+5
+7
+6
+10
+
+statement error pgcode 22033 jsonpath array subscript is out of bounds
+SELECT jsonb_path_query('{"a": [[5, 4], [7, 6], [6, 7], [10], []]}', 'strict $.a[*][0]');
+
+query T rowsort
+SELECT jsonb_path_query('{"a": [{}, [5, 4], [7, 6], [6, 7], [10], []]}', '$.a[*][0]');
+----
+{}
+5
+7
+6
+10
+
+statement error pgcode 22039 jsonpath array accessor can only be applied to an array
+SELECT jsonb_path_query('{"a": [{}, [5, 4], [7, 6], [6, 7], [10], []]}', 'strict $.a[*][0]');
+
+query T rowsort
+SELECT jsonb_path_query('{"a": ["hello", [5, 4], [7, 6], [6, 7], [10], []]}', '$.a[*][0]');
+----
+"hello"
+5
+7
+6
+10
+
+query T rowsort
+SELECT jsonb_path_query('{"a": ["hello", [5, 4], [7, 6], [6, 7], [10], []]}', '$.a[*][1]');
+----
+4
+6
+7
+
+statement error pgcode 22039 jsonpath array accessor can only be applied to an array
+SELECT jsonb_path_query('{"a": "hello"}', 'strict $.a[1 to 3]');
+
+statement error pgcode 22039 jsonpath array accessor can only be applied to an array
+SELECT jsonb_path_query('{"a": [1, 2, 3, 4, 5]}', 'strict $[3 to 1]');
+
+query empty
+SELECT jsonb_path_query('{"a": [1, 2, 3]}', '$.a.b');
+
+
+statement error pgcode 2203A jsonpath member accessor can only be applied to an object
+SELECT jsonb_path_query('{"a": [1, 2, 3]}', 'strict $.a.b');
+
+query T
+SELECT jsonb_path_query('[1, 2, 3, 4, 5]', '$[1]');
+----
+2
+
+query T
+SELECT jsonb_path_query('{"a": [10, 9, 8, 7]}', '$.a[$varInt]', '{"varInt": 1, "varFloat": 2.3, "varString": "a", "varBool": true, "varNull": null}')
+----
+9
+
+# TODO(normanchenn): this will be changed after floats are supported.
+statement error pgcode 22033 jsonpath array subscript is not a single numeric value
+SELECT jsonb_path_query('{"a": [10, 9, 8, 7]}', '$.a[$varFloat]', '{"varInt": 1, "varFloat": 2.3, "varString": "a", "varBool": true, "varNull": null}')
+
+statement error pgcode 22033 jsonpath array subscript is not a single numeric value
+SELECT jsonb_path_query('{"a": [10, 9, 8, 7]}', '$.a[$varString]', '{"varInt": 1, "varFloat": 2.3, "varString": "a", "varBool": true, "varNull": null}')
+
+statement error pgcode 22033 jsonpath array subscript is not a single numeric value
+SELECT jsonb_path_query('{"a": [10, 9, 8, 7]}', '$.a[$varBool]', '{"varInt": 1, "varFloat": 2.3, "varString": "a", "varBool": true, "varNull": null}')
+
+statement error pgcode 22033 jsonpath array subscript is not a single numeric value
+SELECT jsonb_path_query('{"a": [10, 9, 8, 7]}', '$.a[$varNull]', '{"varInt": 1, "varFloat": 2.3, "varString": "a", "varBool": true, "varNull": null}')
+
+query T
+SELECT jsonb_path_query('{"foo": [{"bar": "value"}]}', '$.foo.bar');
+----
+"value"
+
+query T rowsort
+SELECT jsonb_path_query('{"foo": [{"bar": "value"}, {"bar": "value2"}, {"baz": "value3"}]}', '$.foo.bar');
+----
+"value"
+"value2"
+
+statement error pgcode 2203A jsonpath member accessor can only be applied to an object
+SELECT jsonb_path_query('{"foo": [{"bar": "value"}, {"bar": "value2"}]}', 'strict $.foo.bar');
+
+# select jsonb_path_query('[1, 2, 3, 4, 5]', '$[-1]');
+# select jsonb_path_query('[1, 2, 3, 4, 5]', 'strict $[-1]');
+
+# interesting functionality
+# select jsonb_path_query('{"a": [1, 2], "b": "hello"}', '$.a ? ($.b == "hello") ');
+# select jsonb_path_query('{"a": [1, 2], "b": "hello"}', '$.a');

--- a/pkg/sql/logictest/tests/local/generated_test.go
+++ b/pkg/sql/logictest/tests/local/generated_test.go
@@ -1256,6 +1256,13 @@ func TestLogic_json_index(
 	runLogicTest(t, "json_index")
 }
 
+func TestLogic_jsonb_path_query(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "jsonb_path_query")
+}
+
 func TestLogic_jsonpath(
 	t *testing.T,
 ) {

--- a/pkg/sql/pgwire/pgcode/codes.go
+++ b/pkg/sql/pgwire/pgcode/codes.go
@@ -124,6 +124,9 @@ var (
 	InvalidXMLContent                     = MakeCode("2200N")
 	InvalidXMLComment                     = MakeCode("2200S")
 	InvalidXMLProcessingInstruction       = MakeCode("2200T")
+	ArraySubscriptOutOfBounds             = MakeCode("22033")
+	WildcardOnNonArray                    = MakeCode("22039")
+	KeyNotInJSON                          = MakeCode("2203A")
 	// Section: Class 23 - Integrity Constraint Violation
 	IntegrityConstraintViolation = MakeCode("23000")
 	RestrictViolation            = MakeCode("23001")

--- a/pkg/sql/sem/builtins/BUILD.bazel
+++ b/pkg/sql/sem/builtins/BUILD.bazel
@@ -114,6 +114,7 @@ go_library(
         "//pkg/util/intsets",
         "//pkg/util/ipaddr",
         "//pkg/util/json",
+        "//pkg/util/jsonpath/eval",
         "//pkg/util/log",
         "//pkg/util/mon",
         "//pkg/util/pretty",

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -4141,7 +4141,6 @@ value if you rely on the HLC for accuracy.`,
 	"jsonb_path_exists_opr":  makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 22513, Category: builtinconstants.CategoryJsonpath}),
 	"jsonb_path_match":       makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 22513, Category: builtinconstants.CategoryJsonpath}),
 	"jsonb_path_match_opr":   makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 22513, Category: builtinconstants.CategoryJsonpath}),
-	"jsonb_path_query":       makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 22513, Category: builtinconstants.CategoryJsonpath}),
 	"jsonb_path_query_array": makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 22513, Category: builtinconstants.CategoryJsonpath}),
 	"jsonb_path_query_first": makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 22513, Category: builtinconstants.CategoryJsonpath}),
 

--- a/pkg/sql/sem/builtins/fixed_oids.go
+++ b/pkg/sql/sem/builtins/fixed_oids.go
@@ -2645,6 +2645,9 @@ var builtinOidsArray = []string{
 	2682: `char(jsonpath: jsonpath) -> "char"`,
 	2683: `substring_index(input: string, delim: string, count: int) -> string`,
 	2684: `crdb_internal.sql_liveness_is_alive(session_id: bytes, is_sync: bool) -> bool`,
+	2685: `jsonb_path_query(target: jsonb, path: jsonpath) -> jsonb`,
+	2686: `jsonb_path_query(target: jsonb, path: jsonpath, vars: jsonb) -> jsonb`,
+	2687: `jsonb_path_query(target: jsonb, path: jsonpath, vars: jsonb, silent: bool) -> jsonb`,
 }
 
 var builtinOidsBySignature map[string]oid.Oid

--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -96,6 +96,9 @@ var (
 
 	// ValidateJSONPath is injected from pkg/util/jsonpath/parser/parse.go.
 	ValidateJSONPath func(string) (string, error)
+
+	// EmptyDJSON is an empty JSON object.
+	EmptyDJSON = *NewDJSON(json.EmptyJSONValue)
 )
 
 // CompareContext represents the dependencies used to evaluate comparisons
@@ -3969,6 +3972,30 @@ func ParseDJsonpath(s string) (Datum, error) {
 		return nil, MakeParseError(s, types.Jsonpath, err)
 	}
 	return NewDJsonpath(jp), nil
+}
+
+// AsDJsonpath attempts to retrieve a *DJsonpath from an Expr, returning a *DJsonpath and
+// a flag signifying whether the assertion was successful. The function should
+// be used instead of direct type assertions wherever a *DJsonpath wrapped by a
+// *DOidWrapper is possible.
+func AsDJsonpath(e Expr) (*DJsonpath, bool) {
+	switch t := e.(type) {
+	case *DJsonpath:
+		return t, true
+	case *DOidWrapper:
+		return AsDJsonpath(t.Wrapped)
+	}
+	return nil, false
+}
+
+// MustBeDJsonpath attempts to retrieve a DJsonpath from an Expr, panicking if the
+// assertion fails.
+func MustBeDJsonpath(e Expr) DJsonpath {
+	i, ok := AsDJsonpath(e)
+	if !ok {
+		panic(errors.AssertionFailedf("expected *DJsonpath, found %T", e))
+	}
+	return *i
 }
 
 // DJSON is the JSON Datum.

--- a/pkg/util/json/json.go
+++ b/pkg/util/json/json.go
@@ -236,6 +236,8 @@ type JSON interface {
 	HasContainerLeaf() (bool, error)
 }
 
+var EmptyJSONValue = NewObjectBuilder(0).Build()
+
 type jsonTrue struct{}
 
 // TrueJSONValue is JSON `true`

--- a/pkg/util/jsonpath/eval/BUILD.bazel
+++ b/pkg/util/jsonpath/eval/BUILD.bazel
@@ -1,0 +1,18 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "eval",
+    srcs = ["eval.go"],
+    importpath = "github.com/cockroachdb/cockroach/pkg/util/jsonpath/eval",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/sql/pgwire/pgcode",
+        "//pkg/sql/pgwire/pgerror",
+        "//pkg/sql/sem/tree",
+        "//pkg/util/errorutil/unimplemented",
+        "//pkg/util/json",
+        "//pkg/util/jsonpath",
+        "//pkg/util/jsonpath/parser",
+        "@com_github_cockroachdb_errors//:errors",
+    ],
+)

--- a/pkg/util/jsonpath/eval/eval.go
+++ b/pkg/util/jsonpath/eval/eval.go
@@ -1,0 +1,270 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package eval
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
+	"github.com/cockroachdb/cockroach/pkg/util/json"
+	"github.com/cockroachdb/cockroach/pkg/util/jsonpath"
+	"github.com/cockroachdb/cockroach/pkg/util/jsonpath/parser"
+	"github.com/cockroachdb/errors"
+)
+
+var errUnimplemented = unimplemented.NewWithIssue(22513, "unimplemented")
+var errInternal = errors.New("internal error")
+
+type jsonpathCtx struct {
+	// Root of the given JSON object ($). We store this because we will need to
+	// support queries with multiple root elements (ex. $.a ? ($.b == "hello").
+	root   tree.DJSON
+	vars   tree.DJSON
+	strict bool
+	a      tree.DatumAlloc
+}
+
+func JsonpathQuery(
+	target tree.DJSON, path tree.DJsonpath, vars tree.DJSON, silent tree.DBool,
+) ([]tree.DJSON, error) {
+	parsedPath, err := parser.Parse(string(path))
+	if err != nil {
+		return []tree.DJSON{}, err
+	}
+	expr := parsedPath.AST
+
+	ctx := &jsonpathCtx{
+		root:   target,
+		vars:   vars,
+		strict: expr.Strict,
+	}
+
+	// When silent is true, overwrite the strict mode.
+	if bool(silent) {
+		ctx.strict = false
+	}
+
+	res, err := ctx.eval(expr.Path, []tree.DJSON{target})
+	if err != nil {
+		return nil, err
+	}
+	return res, nil
+}
+
+func (ctx *jsonpathCtx) eval(jp jsonpath.Path, current []tree.DJSON) ([]tree.DJSON, error) {
+	switch p := jp.(type) {
+	case jsonpath.Paths:
+		// Evaluate each path within the path list, update the current JSON
+		// object after each evaluation.
+		for _, path := range p {
+			results, err := ctx.eval(path, current)
+			if err != nil {
+				return nil, err
+			}
+			current = results
+		}
+		return current, nil
+	case jsonpath.Root:
+		return []tree.DJSON{ctx.root}, nil
+	case jsonpath.Key:
+		var agg []tree.DJSON
+		for _, res := range current {
+			if res.JSON.Type() == json.ObjectJSONType {
+				val, err := res.JSON.FetchValKey(string(p))
+				if err != nil {
+					return nil, err
+				}
+				if val == nil {
+					if ctx.strict {
+						return nil, pgerror.Newf(pgcode.KeyNotInJSON, "JSON object does not contain key %q", string(p))
+					}
+					continue
+				}
+				agg = append(agg, *ctx.a.NewDJSON(tree.DJSON{JSON: val}))
+			} else if !ctx.strict && res.JSON.Type() == json.ArrayJSONType {
+				arr, ok := res.JSON.AsArray()
+				if !ok {
+					return nil, errors.AssertionFailedf("array expected")
+				}
+				for _, elem := range arr {
+					results, err := ctx.eval(p, []tree.DJSON{*ctx.a.NewDJSON(tree.DJSON{JSON: elem})})
+					if err != nil {
+						return nil, err
+					}
+					agg = append(agg, results...)
+				}
+			} else if ctx.strict {
+				return nil, pgerror.Newf(pgcode.KeyNotInJSON, "jsonpath member accessor can only be applied to an object")
+			}
+		}
+		return agg, nil
+	case jsonpath.Wildcard:
+		var agg []tree.DJSON
+		for _, res := range current {
+			if res.JSON.Type() == json.ArrayJSONType {
+				paths, err := json.AllPathsWithDepth(res.JSON, 1)
+				if err != nil {
+					return nil, err
+				}
+				for _, path := range paths {
+					if path.Len() != 1 {
+						return nil, errors.AssertionFailedf("unexpected path length")
+					}
+					unwrapped, err := path.FetchValIdx(0)
+					if err != nil {
+						return nil, err
+					}
+					if unwrapped == nil {
+						return nil, errors.AssertionFailedf("unwrapping json element")
+					}
+					agg = append(agg, *ctx.a.NewDJSON(tree.DJSON{JSON: unwrapped}))
+				}
+			} else if !ctx.strict {
+				agg = append(agg, res)
+			} else {
+				return nil, pgerror.Newf(pgcode.WildcardOnNonArray, "jsonpath wildcard array accessor can only be applied to an array")
+			}
+		}
+		return agg, nil
+	case jsonpath.ArrayList:
+		var agg []tree.DJSON
+		for _, path := range p {
+			// path should be ArrayIndex or ArrayIndexRange.
+			results, err := ctx.eval(path, current)
+			if err != nil {
+				return nil, err
+			}
+			// Aggregate results of each array index accessor.
+			agg = append(agg, results...)
+		}
+		return agg, nil
+	case jsonpath.ArrayIndex:
+		var agg []tree.DJSON
+		idx, err := ctx.resolveArrayIndex(jsonpath.Scalar(p))
+		if err != nil {
+			return nil, err
+		}
+		for _, res := range current {
+			if ctx.strict && res.JSON.Type() != json.ArrayJSONType {
+				return nil, pgerror.Newf(pgcode.WildcardOnNonArray, "jsonpath array accessor can only be applied to an array")
+			}
+			djson, err := ctx.getJSONArrayValueAtIndex(res, idx)
+			if err != nil {
+				return nil, err
+			}
+			if djson == nil {
+				continue
+			}
+			agg = append(agg, *djson)
+		}
+		return agg, nil
+	case jsonpath.ArrayIndexRange:
+		var agg []tree.DJSON
+		start, err := ctx.resolveArrayIndex(jsonpath.Scalar(p.Start))
+		if err != nil {
+			return nil, err
+		}
+		end, err := ctx.resolveArrayIndex(jsonpath.Scalar(p.End))
+		if err != nil {
+			return nil, err
+		}
+		for _, res := range current {
+			// Return array errors here before checking range bounds.
+			if ctx.strict && res.JSON.Type() != json.ArrayJSONType {
+				return nil, pgerror.Newf(pgcode.WildcardOnNonArray, "jsonpath array accessor can only be applied to an array")
+			}
+			if ctx.strict && start > end {
+				return nil, pgerror.Newf(pgcode.ArraySubscriptOutOfBounds, "jsonpath array subscript is out of bounds")
+			}
+			for i := start; i <= end; i++ {
+				djson, err := ctx.getJSONArrayValueAtIndex(res, i)
+				if err != nil {
+					return nil, err
+				}
+				if djson == nil {
+					continue
+				}
+				agg = append(agg, *djson)
+			}
+		}
+		return agg, nil
+	case jsonpath.Scalar:
+		return nil, errors.AssertionFailedf("scalar evaluation shouldn't occur")
+	default:
+		return nil, errUnimplemented
+	}
+}
+
+func (ctx *jsonpathCtx) resolveArrayIndex(s jsonpath.Scalar) (int, error) {
+	// TODO(normanchenn): support floats.
+	if s.Type == jsonpath.ScalarFloat {
+		return 0, errors.AssertionFailedf("floats not supported yet")
+	}
+	resolved, err := ctx.resolveScalar(s)
+	if err != nil {
+		return 0, err
+	}
+	i, err := asInt(resolved)
+	if err != nil {
+		return 0, pgerror.Newf(pgcode.ArraySubscriptOutOfBounds, "jsonpath array subscript is not a single numeric value")
+	}
+	return i, nil
+}
+
+func (ctx *jsonpathCtx) resolveScalar(s jsonpath.Scalar) (tree.DJSON, error) {
+	if s.Type == jsonpath.ScalarVariable {
+		val, err := ctx.vars.FetchValKey(s.Variable)
+		if err != nil {
+			return tree.DJSON{}, err
+		}
+		if val == nil {
+			return tree.DJSON{}, pgerror.Newf(pgcode.UndefinedObject, "could not find jsonpath variable %q", s.Variable)
+		}
+		return *ctx.a.NewDJSON(tree.DJSON{JSON: val}), nil
+	}
+	return *ctx.a.NewDJSON(tree.DJSON{JSON: s.Value}), nil
+}
+
+func asInt(j tree.DJSON) (int, error) {
+	d, ok := j.JSON.AsDecimal()
+	if !ok {
+		return 0, errInternal
+	}
+	i64, err := d.Int64()
+	if err != nil {
+		return 0, err
+	}
+	return int(i64), nil
+}
+
+func (ctx *jsonpathCtx) getJSONArrayValueAtIndex(res tree.DJSON, index int) (*tree.DJSON, error) {
+	if ctx.strict && res.JSON.Type() != json.ArrayJSONType {
+		return nil, pgerror.Newf(pgcode.WildcardOnNonArray, "jsonpath array accessor can only be applied to an array")
+	} else if res.JSON.Type() != json.ArrayJSONType {
+		if index == 0 {
+			return &res, nil
+		}
+		return nil, nil
+	}
+
+	if ctx.strict && index >= res.JSON.Len() {
+		return nil, pgerror.Newf(pgcode.ArraySubscriptOutOfBounds, "jsonpath array subscript is out of bounds")
+	}
+	if index < 0 {
+		// Shouldn't happen, not supported in parser.
+		return nil, errors.AssertionFailedf("negative array index")
+	}
+
+	val, err := res.JSON.FetchValIdx(index)
+	if err != nil {
+		return nil, err
+	}
+	if val == nil {
+		return nil, nil
+	}
+	return ctx.a.NewDJSON(tree.DJSON{JSON: val}), nil
+}


### PR DESCRIPTION
Previously, the `jsonpath` data type and parser were created and integrated with each other. This PR adds the `jsonb_path_query` function and a new `pkg/util/jsonpath/eval` package, adding an evaluation engine for jsonpath queries.

Informs: #22513.
Epic: None

Release note (sql change): Add the `jsonb_path_query` function, which takes in a JSON object and a Jsonpath query, and returns the resulting JSON object.