### PR TITLE
server: don't output jemalloc stats during purge

### DIFF
--- a/pkg/server/status/runtime_jemalloc.go
+++ b/pkg/server/status/runtime_jemalloc.go
@@ -217,7 +217,8 @@ func jemallocMaybePurge(
 		return
 	}
 
-	C.jemalloc_stats_print_abbreviated()
+	// TODO(Edward): output to logs, not stderr.
+	// C.jemalloc_stats_print_abbreviated()
 	res, err := C.jemalloc_purge()
 	if err != nil || res != 0 {
 		log.Warningf(ctx, "jemalloc purging failed: %v (res=%d)", err, int(res))


### PR DESCRIPTION
This shows up in a very annoying way during `cockroach demo`.

Epic: none
Release note: None