### PR TITLE
schemachangerccl: use heavy pool

### DIFF
--- a/pkg/ccl/schemachangerccl/BUILD.bazel
+++ b/pkg/ccl/schemachangerccl/BUILD.bazel
@@ -27,7 +27,7 @@ go_test(
         "//pkg/sql/schemachanger:end_to_end_testdata",
     ],
     embed = [":schemachangerccl"],
-    exec_properties = {"test.Pool": "large"},
+    exec_properties = {"test.Pool": "heavy"},
     shard_count = 48,
     tags = ["cpu:3"],
     deps = [


### PR DESCRIPTION
This test package has been timing out. It runs pretty expensive tests, so using the heavy pool should help.

fixes https://github.com/cockroachdb/cockroach/issues/141742
fixes https://github.com/cockroachdb/cockroach/issues/141744
Release note: None