### PR TITLE
release-25.1: external catalog: support rewriting table names in IngestExternalCatalog

### DIFF
--- a/pkg/crosscluster/logical/create_logical_replication_stmt.go
+++ b/pkg/crosscluster/logical/create_logical_replication_stmt.go
@@ -435,7 +435,11 @@ func doLDRPlan(
 			ingestedCatalog externalpb.ExternalCatalog
 		)
 		if details.CreateTable {
-			ingestedCatalog, err = externalcatalog.IngestExternalCatalog(ctx, execCfg, user, srcExternalCatalog, txn, txn.Descriptors(), resolvedDestObjects.ParentDatabaseID, resolvedDestObjects.ParentSchemaID, true /* setOffline */)
+			ingestingTableNames := make([]string, len(resolvedDestObjects.TableNames))
+			for i := range resolvedDestObjects.TableNames {
+				ingestingTableNames[i] = resolvedDestObjects.TableNames[i].Table()
+			}
+			ingestedCatalog, err = externalcatalog.IngestExternalCatalog(ctx, execCfg, user, srcExternalCatalog, txn, txn.Descriptors(), resolvedDestObjects.ParentDatabaseID, resolvedDestObjects.ParentSchemaID, true /* setOffline */, ingestingTableNames)
 			if err != nil {
 				return err
 			}

--- a/pkg/crosscluster/logical/logical_replication_job_test.go
+++ b/pkg/crosscluster/logical/logical_replication_job_test.go
@@ -493,6 +493,20 @@ func TestCreateTables(t *testing.T) {
 		sqlF.QueryRow(t, "CREATE LOGICAL REPLICATION STREAM FROM TABLE tab ON $1 INTO TABLE tab WITH PARENT = '124'", fURL.String()).Scan(&jobIDDiff)
 		require.NotEqual(t, jobID, jobIDDiff)
 	})
+	t.Run("dest table rename", func(t *testing.T) {
+		sqlA.Exec(t, "CREATE DATABASE g")
+		sqlG := sqlutils.MakeSQLRunner(srv.SQLConn(t, serverutils.DBName("g")))
+		gURL := replicationtestutils.GetExternalConnectionURI(t, srv, srv, serverutils.DBName("g"))
+
+		sqlG.Exec(t, "CREATE TABLE tab (pk int primary key, payload string)")
+
+		var jobID jobspb.JobID
+		// use create logically replicated table syntax
+		sqlG.QueryRow(t, "CREATE LOGICALLY REPLICATED TABLE tab2 FROM TABLE tab ON $1 WITH UNIDIRECTIONAL", gURL.String()).Scan(&jobID)
+		WaitUntilReplicatedTime(t, srv.Clock().Now(), sqlG, jobID)
+		// check that tab2 is empty
+		sqlG.CheckQueryResults(t, "SELECT * FROM tab2", [][]string{})
+	})
 }
 
 // TestLogicalStreamIngestionAdvancePTS tests that the producer side pts advances

--- a/pkg/sql/catalog/externalcatalog/external_catalog_test.go
+++ b/pkg/sql/catalog/externalcatalog/external_catalog_test.go
@@ -101,17 +101,19 @@ func TestExtractIngestExternalCatalog(t *testing.T) {
 	defaultdbID, defaultdbpublicID := getDatabaseSchemaIDs("defaultdb")
 
 	t.Run("basic", func(t *testing.T) {
-		ingestableCatalog, err := extractCatalog("db1.sc1.tab1", "db1.sc1.tab2")
+		tableNames := []string{"db1.sc1.tab1", "db1.sc1.tab2"}
+		ingestedTableNames := []string{"tab1", "tab2_rename"}
+		ingestableCatalog, err := extractCatalog(tableNames...)
 		require.NoError(t, err)
 		require.Equal(t, 2, len(ingestableCatalog.Tables))
 
 		var written externalpb.ExternalCatalog
 		require.NoError(t, sql.TestingDescsTxn(ctx, srv, func(ctx context.Context, txn isql.Txn, col *descs.Collection) error {
-			written, err = IngestExternalCatalog(ctx, &execCfg, sqlUser, ingestableCatalog, txn, col, defaultdbID, defaultdbpublicID, false)
+			written, err = IngestExternalCatalog(ctx, &execCfg, sqlUser, ingestableCatalog, txn, col, defaultdbID, defaultdbpublicID, false, ingestedTableNames)
 			return err
 		}))
 		require.Equal(t, 2, len(written.Tables))
-		sqlDB.CheckQueryResults(t, "SELECT schema_name,table_name FROM [SHOW TABLES]", [][]string{{"public", "tab1"}, {"public", "tab2"}})
+		sqlDB.CheckQueryResults(t, "SELECT schema_name,table_name FROM [SHOW TABLES]", [][]string{{"public", "tab1"}, {"public", "tab2_rename"}})
 
 		require.NoError(t, sql.TestingDescsTxn(ctx, srv, func(ctx context.Context, txn isql.Txn, col *descs.Collection) error {
 			return DropIngestedExternalCatalog(ctx, &execCfg, sqlUser, written, txn, srv.JobRegistry().(*jobs.Registry), col, "test gc")
@@ -128,7 +130,7 @@ func TestExtractIngestExternalCatalog(t *testing.T) {
 				[][]string{{"succeeded"}},
 			)
 		} else {
-			sqlDB.CheckQueryResults(t, "SELECT name FROM crdb_internal.tables WHERE state = 'DROP'", [][]string{{"tab1"}, {"tab2"}})
+			sqlDB.CheckQueryResults(t, "SELECT name FROM crdb_internal.tables WHERE state = 'DROP'", [][]string{{"tab1"}, {"tab2_rename"}})
 		}
 	})
 
@@ -145,7 +147,7 @@ func TestExtractIngestExternalCatalog(t *testing.T) {
 		// an error.
 		require.ErrorContains(t,
 			sql.TestingDescsTxn(ctx, srv, func(ctx context.Context, txn isql.Txn, col *descs.Collection) error {
-				_, err = IngestExternalCatalog(ctx, &execCfg, sqlUser, udtCatalog, txn, col, defaultdbID, defaultdbpublicID, false)
+				_, err = IngestExternalCatalog(ctx, &execCfg, sqlUser, udtCatalog, txn, col, defaultdbID, defaultdbpublicID, false, []string{"data"})
 				return err
 			}),
 			"cross database type references are not supported",
@@ -160,14 +162,14 @@ func TestExtractIngestExternalCatalog(t *testing.T) {
 		sadCatalog, err := extractCatalog("db1.sc1.tab3")
 		require.NoError(t, err)
 		require.ErrorContains(t, sql.TestingDescsTxn(ctx, srv, func(ctx context.Context, txn isql.Txn, col *descs.Collection) error {
-			_, err := IngestExternalCatalog(ctx, &execCfg, sqlUser, sadCatalog, txn, col, defaultdbID, defaultdbpublicID, false)
+			_, err := IngestExternalCatalog(ctx, &execCfg, sqlUser, sadCatalog, txn, col, defaultdbID, defaultdbpublicID, false, []string{"tab3"})
 			return err
 		}), "invalid outbound foreign key")
 
 		anotherSadCatalog, err := extractCatalog("db1.sc1.tab2")
 		require.NoError(t, err)
 		require.ErrorContains(t, sql.TestingDescsTxn(ctx, srv, func(ctx context.Context, txn isql.Txn, col *descs.Collection) error {
-			_, err := IngestExternalCatalog(ctx, &execCfg, sqlUser, anotherSadCatalog, txn, col, defaultdbID, defaultdbpublicID, false)
+			_, err := IngestExternalCatalog(ctx, &execCfg, sqlUser, anotherSadCatalog, txn, col, defaultdbID, defaultdbpublicID, false, []string{"tab2"})
 			return err
 		}), "invalid inbound foreign key")
 	})


### PR DESCRIPTION
Backport 1/1 commits from #142235.

/cc @cockroachdb/release

---

Informs: #142107

Release note (bugfix): previously the CREATE LOGICALLY REPLICATED syntax would always create the destination side table with the source side name, instead of the user provided name. This patch ensures the user provided name is used.

Release Justification: low risk bug fix
