### PR TITLE
raft: separate out ElectionJitterTicks from ElectionTick

### DIFF
--- a/pkg/base/config_test.go
+++ b/pkg/base/config_test.go
@@ -34,14 +34,15 @@ func TestDefaultRaftConfig(t *testing.T) {
 	nodeActive, nodeRenewal := cfg.NodeLivenessDurations()
 	storeActive, storeRenewal := cfg.StoreLivenessDurations()
 	raftElectionTimeout := cfg.RaftElectionTimeout()
+	raftElectionJitter := cfg.RaftTickInterval * time.Duration(cfg.RaftElectionTimeoutJitterTicks)
 	raftReproposalTimeout := cfg.RaftTickInterval * time.Duration(cfg.RaftReproposalTimeoutTicks)
 	raftHeartbeatInterval := cfg.RaftTickInterval * time.Duration(cfg.RaftHeartbeatIntervalTicks)
-
 	{
 		var s string
 		s += spew.Sdump(cfg)
 		s += fmt.Sprintf("RaftHeartbeatInterval: %s\n", raftHeartbeatInterval)
 		s += fmt.Sprintf("RaftElectionTimeout: %s\n", raftElectionTimeout)
+		s += fmt.Sprintf("RaftElectionJitter: %s\n", raftElectionJitter)
 		s += fmt.Sprintf("RaftReproposalTimeout: %s\n", raftReproposalTimeout)
 		s += fmt.Sprintf("RangeLeaseDurations: active=%s renewal=%s\n", leaseActive, leaseRenewal)
 		s += fmt.Sprintf("RangeLeaseAcquireTimeout: %s\n", cfg.RangeLeaseAcquireTimeout())
@@ -53,9 +54,8 @@ func TestDefaultRaftConfig(t *testing.T) {
 
 	// Generate and assert the derived recovery intervals.
 	const (
-		minRTT                = 10 * time.Millisecond
-		maxRTT                = 400 * time.Millisecond // max GCP inter-region RTT is ~350ms
-		maxElectionMultiplier = 2
+		minRTT = 10 * time.Millisecond
+		maxRTT = 400 * time.Millisecond // max GCP inter-region RTT is ~350ms
 		// TODO(nvanbenschoten): don't hardcode this values, separate from the
 		// hardcoded value in storeliveness/config.go.
 		storeLivenessWithdrawalInterval = 100 * time.Millisecond
@@ -94,9 +94,9 @@ func TestDefaultRaftConfig(t *testing.T) {
 			0,
 		},
 		{
-			fmt.Sprintf("Election timeout (random 1x-%dx timeout)", maxElectionMultiplier),
+			"Election timeout (timeout + random election jitter)",
 			raftElectionTimeout,
-			maxElectionMultiplier * raftElectionTimeout,
+			raftElectionTimeout + raftElectionJitter,
 		},
 		{
 			"Election (3x RTT: prevote, vote, append)",
@@ -165,9 +165,9 @@ func TestDefaultRaftConfig(t *testing.T) {
 			storeLivenessWithdrawalInterval,
 		},
 		{
-			fmt.Sprintf("Raft election timeout jitter (random 0x-%dx timeout)", maxElectionMultiplier-1),
+			"Raft election timeout jitter (random election jitter)",
 			0,
-			(maxElectionMultiplier - 1) * raftElectionTimeout,
+			raftElectionJitter,
 		},
 		{
 			"Election (3x RTT: prevote, vote, append)",

--- a/pkg/base/testdata/raft_config
+++ b/pkg/base/testdata/raft_config
@@ -3,6 +3,7 @@ echo
 (base.RaftConfig) {
  RaftTickInterval: (time.Duration) 500ms,
  RaftElectionTimeoutTicks: (int64) 4,
+ RaftElectionTimeoutJitterTicks: (int64) 4,
  RaftReproposalTimeoutTicks: (int64) 6,
  RaftHeartbeatIntervalTicks: (int64) 2,
  StoreLivenessHeartbeatInterval: (time.Duration) 1s,
@@ -21,6 +22,7 @@ echo
 }
 RaftHeartbeatInterval: 1s
 RaftElectionTimeout: 2s
+RaftElectionJitter: 2s
 RaftReproposalTimeout: 3s
 RangeLeaseDurations: active=6s renewal=3s
 RangeLeaseAcquireTimeout: 4s

--- a/pkg/base/testdata/raft_config_recovery
+++ b/pkg/base/testdata/raft_config_recovery
@@ -4,7 +4,7 @@ echo
 ----
 // Raft election (fortification disabled):
 // - Heartbeat offset (0-1 heartbeat interval)                [-1.00s - 0.00s]
-// - Election timeout (random 1x-2x timeout)                  [ 2.00s - 4.00s]
+// - Election timeout (timeout + random election jitter)      [ 2.00s - 4.00s]
 // - Election (3x RTT: prevote, vote, append)                 [ 0.03s - 1.20s]
 // Total latency                                              [ 1.03s - 5.20s]
 //
@@ -25,7 +25,7 @@ echo
 // - Store Liveness heartbeat offset (0-1 heartbeat interval) [-1.00s - 0.00s]
 // - Store Liveness expiration (constant)                     [ 3.00s - 3.00s]
 // - Store Liveness withdrawal (0-1 withdrawal interval)      [ 0.00s - 0.10s]
-// - Raft election timeout jitter (random 0x-1x timeout)      [ 0.00s - 2.00s]
+// - Raft election timeout jitter (random election jitter)    [ 0.00s - 2.00s]
 // - Election (3x RTT: prevote, vote, append)                 [ 0.03s - 1.20s]
 // - Lease acquisition (1x RTT: append)                       [ 0.01s - 0.40s]
 // Total latency                                              [ 2.04s - 6.70s]

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -383,6 +383,7 @@ func testStoreConfig(clock *hlc.Clock, version roachpb.Version) StoreConfig {
 	// time in tests.
 	sc.RaftHeartbeatIntervalTicks = 1
 	sc.RaftElectionTimeoutTicks = 3
+	sc.RaftElectionTimeoutJitterTicks = 3
 	sc.RaftReproposalTimeoutTicks = 5
 	sc.RaftTickInterval = 100 * time.Millisecond
 	sc.SetDefaults(1 /* numStores */)
@@ -406,6 +407,7 @@ func newRaftConfig(
 		Applied:                     uint64(appliedIndex),
 		AsyncStorageWrites:          true,
 		ElectionTick:                storeCfg.RaftElectionTimeoutTicks,
+		ElectionJitterTick:          storeCfg.RaftElectionTimeoutJitterTicks,
 		HeartbeatTick:               storeCfg.RaftHeartbeatIntervalTicks,
 		MaxUncommittedEntriesSize:   storeCfg.RaftMaxUncommittedEntriesSize,
 		MaxCommittedSizePerReady:    storeCfg.RaftMaxCommittedSizePerReady,
@@ -1384,8 +1386,9 @@ func (sc *StoreConfig) Valid() bool {
 	return sc.Clock != nil && sc.Transport != nil &&
 		sc.RaftTickInterval != 0 && sc.RaftHeartbeatIntervalTicks > 0 &&
 		sc.RaftElectionTimeoutTicks > 0 && sc.RaftReproposalTimeoutTicks > 0 &&
-		sc.RaftSchedulerConcurrency > 0 && sc.RaftSchedulerConcurrencyPriority > 0 &&
-		sc.RaftSchedulerShardSize > 0 && sc.ScanInterval >= 0 && sc.AmbientCtx.Tracer != nil &&
+		sc.RaftElectionTimeoutJitterTicks > 0 && sc.RaftSchedulerConcurrency > 0 &&
+		sc.RaftSchedulerConcurrencyPriority > 0 && sc.RaftSchedulerShardSize > 0 &&
+		sc.ScanInterval >= 0 && sc.AmbientCtx.Tracer != nil &&
 		sc.RangeFeedSchedulerConcurrency > 0 && sc.RangeFeedSchedulerShardSize > 0
 }
 

--- a/pkg/raft/node_test.go
+++ b/pkg/raft/node_test.go
@@ -292,15 +292,16 @@ func TestNodeStart(t *testing.T) {
 	}
 	storage := NewMemoryStorage()
 	c := &Config{
-		ID:              1,
-		ElectionTick:    10,
-		HeartbeatTick:   1,
-		Storage:         storage,
-		MaxSizePerMsg:   noLimit,
-		MaxInflightMsgs: 256,
-		StoreLiveness:   raftstoreliveness.AlwaysLive{},
-		CRDBVersion:     cluster.MakeTestingClusterSettings().Version,
-		Metrics:         NewMetrics(),
+		ID:                 1,
+		ElectionTick:       10,
+		ElectionJitterTick: 10,
+		HeartbeatTick:      1,
+		Storage:            storage,
+		MaxSizePerMsg:      noLimit,
+		MaxInflightMsgs:    256,
+		StoreLiveness:      raftstoreliveness.AlwaysLive{},
+		CRDBVersion:        cluster.MakeTestingClusterSettings().Version,
+		Metrics:            NewMetrics(),
 	}
 
 	rn, err := NewRawNode(c)
@@ -357,15 +358,16 @@ func TestNodeRestart(t *testing.T) {
 	require.NoError(t, storage.SetHardState(st))
 	require.NoError(t, storage.Append(entries))
 	c := &Config{
-		ID:              1,
-		ElectionTick:    10,
-		HeartbeatTick:   1,
-		Storage:         storage,
-		MaxSizePerMsg:   noLimit,
-		MaxInflightMsgs: 256,
-		StoreLiveness:   raftstoreliveness.AlwaysLive{},
-		CRDBVersion:     cluster.MakeTestingClusterSettings().Version,
-		Metrics:         NewMetrics(),
+		ID:                 1,
+		ElectionTick:       10,
+		ElectionJitterTick: 10,
+		HeartbeatTick:      1,
+		Storage:            storage,
+		MaxSizePerMsg:      noLimit,
+		MaxInflightMsgs:    256,
+		StoreLiveness:      raftstoreliveness.AlwaysLive{},
+		CRDBVersion:        cluster.MakeTestingClusterSettings().Version,
+		Metrics:            NewMetrics(),
 	}
 	rn, err := NewRawNode(c)
 	require.NoError(t, err)
@@ -406,15 +408,16 @@ func TestNodeRestartFromSnapshot(t *testing.T) {
 	require.NoError(t, s.ApplySnapshot(snap))
 	require.NoError(t, s.Append(entries))
 	c := &Config{
-		ID:              1,
-		ElectionTick:    10,
-		HeartbeatTick:   1,
-		Storage:         s,
-		MaxSizePerMsg:   noLimit,
-		MaxInflightMsgs: 256,
-		StoreLiveness:   raftstoreliveness.AlwaysLive{},
-		CRDBVersion:     cluster.MakeTestingClusterSettings().Version,
-		Metrics:         NewMetrics(),
+		ID:                 1,
+		ElectionTick:       10,
+		ElectionJitterTick: 10,
+		HeartbeatTick:      1,
+		Storage:            s,
+		MaxSizePerMsg:      noLimit,
+		MaxInflightMsgs:    256,
+		StoreLiveness:      raftstoreliveness.AlwaysLive{},
+		CRDBVersion:        cluster.MakeTestingClusterSettings().Version,
+		Metrics:            NewMetrics(),
 	}
 	rn, err := NewRawNode(c)
 	require.NoError(t, err)
@@ -429,15 +432,16 @@ func TestNodeRestartFromSnapshot(t *testing.T) {
 func TestNodeAdvance(t *testing.T) {
 	storage := newTestMemoryStorage(withPeers(1))
 	c := &Config{
-		ID:              1,
-		ElectionTick:    10,
-		HeartbeatTick:   1,
-		Storage:         storage,
-		MaxSizePerMsg:   noLimit,
-		MaxInflightMsgs: 256,
-		StoreLiveness:   raftstoreliveness.AlwaysLive{},
-		CRDBVersion:     cluster.MakeTestingClusterSettings().Version,
-		Metrics:         NewMetrics(),
+		ID:                 1,
+		ElectionTick:       10,
+		ElectionJitterTick: 10,
+		HeartbeatTick:      1,
+		Storage:            storage,
+		MaxSizePerMsg:      noLimit,
+		MaxInflightMsgs:    256,
+		StoreLiveness:      raftstoreliveness.AlwaysLive{},
+		CRDBVersion:        cluster.MakeTestingClusterSettings().Version,
+		Metrics:            NewMetrics(),
 	}
 	rn, err := NewRawNode(c)
 	require.NoError(t, err)

--- a/pkg/raft/raft_paper_test.go
+++ b/pkg/raft/raft_paper_test.go
@@ -180,7 +180,7 @@ func testNonleaderStartElection(t *testing.T, state pb.StateType) {
 		r.becomeCandidate()
 	}
 
-	for i := int64(1); i < 2*et; i++ {
+	for i := int64(1); i <= r.randomizedElectionTimeout; i++ {
 		r.tick()
 	}
 	r.advanceMessagesAfterAppend()
@@ -309,6 +309,7 @@ func TestCandidateElectionTimeoutRandomized(t *testing.T) {
 func testNonleaderElectionTimeoutRandomized(t *testing.T, state pb.StateType) {
 	et := int64(10)
 	r := newTestRaft(1, et, 1, newTestMemoryStorage(withPeers(1, 2, 3)))
+	r.electionTimeoutJitter = et
 	timeouts := make(map[int64]bool)
 	for round := int64(0); round < 50*et; round++ {
 		switch state {
@@ -712,7 +713,7 @@ func TestVoteRequest(t *testing.T) {
 		})
 		r.readMessages()
 
-		for i := int64(1); i < r.electionTimeout*2; i++ {
+		for i := int64(1); i <= r.randomizedElectionTimeout; i++ {
 			r.tickElection()
 		}
 

--- a/pkg/raft/rafttest/interaction_env.go
+++ b/pkg/raft/rafttest/interaction_env.go
@@ -100,10 +100,11 @@ type Storage interface {
 // must be set for each node using the stub as a template.
 func raftConfigStub() raft.Config {
 	return raft.Config{
-		ElectionTick:    3,
-		HeartbeatTick:   1,
-		MaxSizePerMsg:   math.MaxUint64,
-		MaxInflightMsgs: math.MaxInt32,
+		ElectionTick:       3,
+		ElectionJitterTick: 3,
+		HeartbeatTick:      1,
+		MaxSizePerMsg:      math.MaxUint64,
+		MaxInflightMsgs:    math.MaxInt32,
 	}
 }
 

--- a/pkg/raft/rafttest/node.go
+++ b/pkg/raft/rafttest/node.go
@@ -50,6 +50,7 @@ func startNode(id raftpb.PeerID, peers []raft.Peer, iface iface) *node {
 	c := &raft.Config{
 		ID:                        id,
 		ElectionTick:              50,
+		ElectionJitterTick:        50,
 		HeartbeatTick:             1,
 		Storage:                   st,
 		MaxSizePerMsg:             1024 * 1024,
@@ -211,6 +212,7 @@ func (n *node) restart() {
 	c := &raft.Config{
 		ID:                        n.id,
 		ElectionTick:              10,
+		ElectionJitterTick:        10,
 		HeartbeatTick:             1,
 		Storage:                   n.storage,
 		MaxSizePerMsg:             1024 * 1024,


### PR DESCRIPTION
Instead of always randomly campaigning in the interval: [RaftElectionTimeoutTicks, 2*RaftElectionTimeoutTicks), this commit adds the ability to campaign in the interval:
[RaftElectionTimeoutTicks, RaftElectionTimeoutTicks+RaftElectionTimeoutJitter). This adds more flexibility if in the future we decide to double the number of ticks, but we don't want to double the number of ticks per election.

Fixes: #133576

Release note: None