### PR TITLE
crosscluster: handle lww condition failures

### DIFF
--- a/pkg/crosscluster/logical/lww_row_processor_test.go
+++ b/pkg/crosscluster/logical/lww_row_processor_test.go
@@ -459,9 +459,6 @@ func TestLWWConflictResolution(t *testing.T) {
 				runner.CheckQueryResults(t, fmt.Sprintf("SELECT * from %s", tableNameDst), expectedRows)
 			})
 			t.Run("cross-cluster-local-delete", func(t *testing.T) {
-				if !useKVProc {
-					skip.IgnoreLint(t, "local delete ordering is not handled correctly by the SQL processor")
-				}
 				tableNameDst, rp, encoder := setup(t, useKVProc)
 
 				runner.Exec(t, fmt.Sprintf("INSERT INTO %s VALUES ($1, $2)", tableNameDst), row1...)
@@ -507,9 +504,6 @@ func TestLWWConflictResolution(t *testing.T) {
 				runner.CheckQueryResults(t, fmt.Sprintf("SELECT * from %s", tableNameDst), expectedRows)
 			})
 			t.Run("remote-delete-after-local-delete", func(t *testing.T) {
-				if !useKVProc {
-					skip.IgnoreLint(t, "local delete ordering is not handled correctly by the SQL processor")
-				}
 				tableNameDst, rp, encoder := setup(t, useKVProc)
 
 				runner.Exec(t, fmt.Sprintf("INSERT INTO %s VALUES ($1, $2)", tableNameDst), row1...)

--- a/pkg/sql/row/errors.go
+++ b/pkg/sql/row/errors.go
@@ -41,6 +41,11 @@ func ConvertBatchError(ctx context.Context, tableDesc catalog.TableDescriptor, b
 		)
 
 	case *kvpb.ConditionFailedError:
+		if !v.OriginTimestampOlderThan.IsEmpty() {
+			// NOTE: we return the go error here because this error should never be
+			// communicated to pgwire. It's exposed for the LDR writer.
+			return origPErr.GoError()
+		}
 		if origPErr.Index == nil {
 			break
 		}


### PR DESCRIPTION
This change aims to correct the SQL writer's LWW semantics, enabling the
retirement of the KV writer. If the SQL writer observes the condition
failed error's introduced by https://github.com/cockroachdb/cockroach/pull/143100, it will drop the row as a LWW
loss. This closes a LWW bug where an old replicated write can overwrite
a recent local tombstone.

The first two commits in this PR are from:
* https://github.com/cockroachdb/cockroach/pull/143096
* https://github.com/cockroachdb/cockroach/pull/143100

Release note: none
Epic: [CRDB-48647](https://cockroachlabs.atlassian.net/browse/CRDB-48647)