### PR TITLE
rpc: add `system-db` back to gossip subscription allowlist

### DIFF
--- a/pkg/rpc/auth_tenant.go
+++ b/pkg/rpc/auth_tenant.go
@@ -300,6 +300,9 @@ var gossipSubscriptionPatternAllowlist = []string{
 	"cluster-id",
 	"node:.*",
 	"store:.*",
+	// This "system-db" exception can be removed once we fully remove
+	// gossip.KeyDeprecatedSystemConfig from the gossip network.
+	"system-db",
 }
 
 // authTenantRanges authorizes the provided tenant to invoke the


### PR DESCRIPTION
This was removed overly-eagerly in b606fd4722f. We still need it since the KeyDeprecatedSystemConfig key can still be gossipped in a mixed version cluster. Removing it from this allowlist causes noisy warning logs.

Epic: None
Informs: #141849
Release note: None