### PR TITLE
server: ensure health alerts always use a ttl

### DIFF
--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -1051,7 +1051,7 @@ func (n *Node) initializeAdditionalStores(ctx context.Context, engines []storage
 
 	// Write a new status summary after all stores have been initialized; this
 	// helps the UI remain responsive when new nodes are added.
-	if err := n.writeNodeStatus(ctx, 0 /* alertTTL */, false /* mustExist */); err != nil {
+	if err := n.writeNodeStatus(ctx, false /* mustExist */); err != nil {
 		log.Warningf(ctx, "error writing node summary after store bootstrap: %s", err)
 	}
 
@@ -1487,7 +1487,7 @@ func (n *Node) startWriteNodeStatus(frequency time.Duration) error {
 	if err := startup.RunIdempotentWithRetry(ctx,
 		n.stopper.ShouldQuiesce(),
 		"kv write node status", func(ctx context.Context) error {
-			return n.writeNodeStatus(ctx, 0 /* alertTTL */, false /* mustExist */)
+			return n.writeNodeStatus(ctx, false /* mustExist */)
 		}); err != nil {
 		return errors.Wrap(err, "error recording initial status summaries")
 	}
@@ -1500,17 +1500,12 @@ func (n *Node) startWriteNodeStatus(frequency time.Duration) error {
 			for {
 				select {
 				case <-ticker.C:
-					// Use an alertTTL of twice the ticker frequency. This makes sure that
-					// alerts don't disappear and reappear spuriously while at the same
-					// time ensuring that an alert doesn't linger for too long after having
-					// resolved.
-					//
 					// The status key must already exist, to avoid race conditions
 					// during decommissioning of this node. Decommissioning may be
 					// carried out by a different node, so this avoids resurrecting
 					// the status entry after the decommissioner has removed it.
 					// See Server.Decommission().
-					if err := n.writeNodeStatus(ctx, 2*frequency, true /* mustExist */); err != nil {
+					if err := n.writeNodeStatus(ctx, true /* mustExist */); err != nil {
 						log.Warningf(ctx, "error recording status summaries: %s", err)
 					}
 				case <-n.stopper.ShouldQuiesce():
@@ -1524,7 +1519,7 @@ func (n *Node) startWriteNodeStatus(frequency time.Duration) error {
 // NodeStatusRecorder and persists them to the cockroach data store.
 // If mustExist is true the status key must already exist and must
 // not change during writing -- if false, the status is always written.
-func (n *Node) writeNodeStatus(ctx context.Context, alertTTL time.Duration, mustExist bool) error {
+func (n *Node) writeNodeStatus(ctx context.Context, mustExist bool) error {
 	if n.suppressNodeStatus.Load() {
 		return nil
 	}
@@ -1548,7 +1543,7 @@ func (n *Node) writeNodeStatus(ctx context.Context, alertTTL time.Duration, must
 				log.Warningf(ctx, "health alerts detected: %+v", result)
 			}
 			if err := n.storeCfg.Gossip.AddInfoProto(
-				gossip.MakeNodeHealthAlertKey(n.Descriptor.NodeID), &result, alertTTL,
+				gossip.MakeNodeHealthAlertKey(n.Descriptor.NodeID), &result, 2*base.DefaultMetricsSampleInterval, /* ttl */
 			); err != nil {
 				log.Warningf(ctx, "unable to gossip health alerts: %+v", result)
 			}

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -1936,7 +1936,7 @@ func (ts *testServer) SetReadyFn(fn func(bool)) {
 
 // WriteSummaries implements the serverutils.StorageLayerInterface.
 func (ts *testServer) WriteSummaries() error {
-	return ts.node.writeNodeStatus(context.TODO(), time.Hour, false)
+	return ts.node.writeNodeStatus(context.TODO(), false)
 }
 
 // UpdateChecker implements the serverutils.StorageLayerInterface.


### PR DESCRIPTION
Fixes an issue where health alerts could persist indefinitely in gossip
when a zero TTL was specified during node startup or initial status
write. This caused stale alerts to appear in crdb_internal.gossip_alerts
from long-removed nodes.

Modified writeNodeStatus to always use
2*base.DefaultMetricsSampleInterval, ensuring alerts eventually expire
from gossip.

Fixes https://github.com/cockroachdb/cockroach/issues/128793

Release note (bug fix): Fixed an issue where removed nodes could leave
persistent entries in crdb_internal.gossip_alerts.