### PR TITLE
sql: increase tenant testing coverage

### DIFF
--- a/pkg/base/test_server_args.go
+++ b/pkg/base/test_server_args.go
@@ -526,6 +526,19 @@ func TestIsForStuffThatShouldWorkWithSharedProcessModeButDoesntYet(
 //
 // It should link to a github issue with label C-investigation.
 func TestSkippedForExternalModeDueToPerformance(issueNumber int) DefaultTestTenantOptions {
+	return testSkippedForExternalProcessMode(issueNumber)
+}
+
+// TestDoesNotWorkWithExternalProcessMode disables selecting the external
+// process virtual cluster for tests that are not functional in that mode and
+// require further investigation. Any test using this function should reference
+// a GitHub issue tagged with "C-investigation" describing the underlying
+// problem.
+func TestDoesNotWorkWithExternalProcessMode(issueNumber int) DefaultTestTenantOptions {
+	return testSkippedForExternalProcessMode(issueNumber)
+}
+
+func testSkippedForExternalProcessMode(issueNumber int) DefaultTestTenantOptions {
 	return DefaultTestTenantOptions{
 		testBehavior:           ttSharedProcess,
 		allowAdditionalTenants: true,

--- a/pkg/sql/mvcc_backfiller_test.go
+++ b/pkg/sql/mvcc_backfiller_test.go
@@ -555,7 +555,7 @@ func TestIndexBackfillMergeTxnRetry(t *testing.T) {
 		additionalRowsForMerge = 10
 	)
 
-	params, _ := createTestServerParams()
+	params, _ := createTestServerParamsAllowTenants()
 	params.Knobs = base.TestingKnobs{
 		SQLSchemaChanger: &sql.SchemaChangerTestingKnobs{
 			// Ensure that the temp index has work to do.
@@ -597,6 +597,7 @@ func TestIndexBackfillMergeTxnRetry(t *testing.T) {
 	var err error
 	scratch, err = s.ScratchRange()
 	require.NoError(t, err)
+	scratch = append(s.Codec().TenantPrefix(), scratch...)
 
 	if _, err := sqlDB.Exec(`
 SET use_declarative_schema_changer='off';

--- a/pkg/sql/unsplit_range_test.go
+++ b/pkg/sql/unsplit_range_test.go
@@ -12,6 +12,7 @@ import (
 	"errors"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
@@ -269,7 +270,8 @@ func TestUnsplitRanges(t *testing.T) {
 
 	ctx := context.Background()
 	run := func(t *testing.T, tc testCase) {
-		params, _ := createTestServerParams()
+		params, _ := createTestServerParamsAllowTenants()
+		params.DefaultTestTenant = base.TestDoesNotWorkWithExternalProcessMode(142388)
 		params.Knobs.JobsTestingKnobs = jobs.NewTestingKnobsWithShortIntervals()
 		params.Knobs.GCJob = &sql.GCJobTestingKnobs{
 			SkipWaitingForMVCCGC: true,


### PR DESCRIPTION
`` sql: increase tenant testing coverage for `jobs_profiler_execution_details_test` ``


`` sql: increase tenant testing coverage for `mvcc_backfiller_test` ``


`` sql: increase tenant testing coverage for `txn_restart_test` ``


`` sql: enable shared-process mode tenant testing for `TestUnsplitRanges` ``

I opened issue #142388 to track the work for enabling external-process mode
testing, as it turned out to be a non-trivial effort.

Informs: #140446
Epic: CRDB-48564
Release note: None
