### PR TITLE
sql: improve hint message for large scan errors

### DIFF
--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -3322,7 +3322,7 @@ func (ex *connExecutor) makeExecPlan(
 					pgerror.Newf(pgcode.TooManyRows,
 						"query `%s` contains a full table/index scan which is explicitly disallowed",
 						planner.stmt.SQL),
-					"try overriding the `disallow_full_table_scans` or increasing the `large_full_scan_rows` cluster/session settings",
+					"to permit this scan, set disallow_full_table_scans to false or increase the large_full_scan_rows threshold",
 				)
 			}
 		}

--- a/pkg/sql/logictest/testdata/logic_test/select
+++ b/pkg/sql/logictest/testdata/logic_test/select
@@ -783,7 +783,7 @@ SET disallow_full_table_scans = true;
 statement error pq: query `SELECT \* FROM t_disallow_scans` contains a full table/index scan which is explicitly disallowed
 SELECT * FROM t_disallow_scans
 
-statement error pq: index "b_idx" cannot be used for this query\nHINT: try overriding the `disallow_full_table_scans`
+statement error pq: index "b_idx" cannot be used for this query\nHINT: to permit this scan, set disallow_full_table_scans to false or increase the large_full_scan_rows threshold
 SELECT * FROM t_disallow_scans@b_idx
 
 # Full scans of partial indexes are allowed.
@@ -823,7 +823,7 @@ ALTER TABLE t_disallow_scans INJECT STATISTICS '[
 statement error pq: query `SELECT \* FROM t_disallow_scans` contains a full table/index scan which is explicitly disallowed
 SELECT * FROM t_disallow_scans
 
-statement error pq: index "b_idx" cannot be used for this query\nHINT: try overriding the `disallow_full_table_scans`
+statement error pq: index "b_idx" cannot be used for this query\nHINT: to permit this scan, set disallow_full_table_scans to false or increase the large_full_scan_rows threshold to at least 4
 SELECT * FROM t_disallow_scans@b_idx
 
 # Full scans of virtual tables are still allowed with this setting (#123783).
@@ -835,7 +835,7 @@ SELECT * FROM crdb_internal.jobs
 
 # Tests for 'large_full_scan_rows'.
 statement ok
-SET large_full_scan_rows = 1000
+SET large_full_scan_rows = 4
 
 # These queries succeed because the full table/index scans aren't considered
 # "large".
@@ -851,7 +851,13 @@ SET large_full_scan_rows = 2
 statement error pq: query `SELECT \* FROM t_disallow_scans` contains a full table/index scan which is explicitly disallowed
 SELECT * FROM t_disallow_scans
 
-statement error pq: index "b_idx" cannot be used for this query\nHINT: try overriding the `disallow_full_table_scans`
+statement error pq: index "b_idx" cannot be used for this query\nHINT: to permit this scan, set disallow_full_table_scans to false or increase the large_full_scan_rows threshold to at least 4
+SELECT * FROM t_disallow_scans@b_idx
+
+statement ok
+SET large_full_scan_rows = 3
+
+statement error pq: query `.*` contains a full table\/index scan which is explicitly disallowed\nHINT: to permit this scan, set disallow_full_table_scans to false or increase the large_full_scan_rows threshold
 SELECT * FROM t_disallow_scans@b_idx
 
 # Cleanup


### PR DESCRIPTION
This change updates the hint message displayed when large scans are disallowed. Previously, the hint was somewhat vague in guiding users on how to address the error. The updated message provides clearer instructions. Additionally, if table statistics are available, the hint now includes the recommended large_full_scan_rows setting.

The related issue suggested modifying the error text itself, but I chose to keep it unchanged for conciseness and clarity, focusing instead on improving the hint message. The original error was triggered by an internal query, but this is no longer a concern since the error is now only returned for external queries.

Epic: none
Release note: none
Closes #136743