### PR TITLE
changefeedccl: improve create changefeed error message

### DIFF
--- a/pkg/ccl/changefeedccl/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/BUILD.bazel
@@ -78,6 +78,7 @@ go_library(
         "//pkg/keys",
         "//pkg/kv",
         "//pkg/kv/kvclient/kvcoord",
+        "//pkg/kv/kvpb",
         "//pkg/kv/kvserver",
         "//pkg/kv/kvserver/closedts",
         "//pkg/kv/kvserver/protectedts",

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/protectedts"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/protectedts/ptpb"
@@ -329,6 +330,14 @@ func changefeedPlanHook(
 		err := rowFn(ctx, resultsCh)
 		if err != nil {
 			logChangefeedFailedTelemetryDuringStartup(ctx, description, failureTypeForStartupError(err))
+			var e *kvpb.BatchTimestampBeforeGCError
+			if errors.As(err, &e) && opts.HasStartCursor() {
+				err = errors.Wrapf(err,
+					"could not create changefeed: cursor %s is older than the GC threshold %d",
+					opts.GetCursor(), e.Threshold.WallTime)
+				err = errors.WithHint(err,
+					"use a more recent cursor")
+			}
 		}
 		return err
 	}


### PR DESCRIPTION
Prevously if a user creates a changefeed with a cursor before the GC threshold they'd see

ERROR: failed to resolve targets in the CHANGEFEED stmt: batch timestamp 1541199412.324189000,0 must be after replica GC threshold 1740696773.366361000,0 (r9: /Table/{5-6})
HINT: do the targets exist at the specified cursor time 1541199412.324189000,0?

Now they'd see
ERROR: could not create changefeed: cursor 1741759425000000000 is older than the GC threshold 1741966895145639000: batch timestamp 1741759425.000000000,0 must be after replica GC threshold 1741966895.145639000,0 (r165: /Table/10{6-7})
HINT: use a more recent cursor

Resolves https://github.com/cockroachdb/cockroach/issues/137317

Release note (general): Improve the wording of error message when creating a changefeed with a cursor older than GC threshold.