### PR TITLE
jsonpath: refactor scalar types to reuse JSON primitives

### DIFF
--- a/pkg/sql/scanner/jsonpath_scan.go
+++ b/pkg/sql/scanner/jsonpath_scan.go
@@ -27,7 +27,7 @@ func (s *JSONPathScanner) Scan(lval ScanSymType) {
 	switch ch {
 	case '$':
 		// Root path ($.)
-		if s.peek() == '.' || s.peek() == eof || s.peek() == ' ' {
+		if s.peek() == '.' || s.peek() == eof || s.peek() == ' ' || s.peek() == '[' {
 			return
 		}
 

--- a/pkg/util/jsonpath/BUILD.bazel
+++ b/pkg/util/jsonpath/BUILD.bazel
@@ -5,5 +5,8 @@ go_library(
     srcs = ["expr.go"],
     importpath = "github.com/cockroachdb/cockroach/pkg/util/jsonpath",
     visibility = ["//visibility:public"],
-    deps = ["//pkg/sql/sem/tree"],
+    deps = [
+        "//pkg/sql/sem/tree",
+        "//pkg/util/json",
+    ],
 )

--- a/pkg/util/jsonpath/parser/BUILD.bazel
+++ b/pkg/util/jsonpath/parser/BUILD.bazel
@@ -41,6 +41,7 @@ go_library(
         "//pkg/sql/scanner",
         "//pkg/sql/sem/tree",
         "//pkg/util/errorutil/unimplemented",
+        "//pkg/util/json",  # keep
         "//pkg/util/jsonpath",
         "@com_github_cockroachdb_errors//:errors",
     ],

--- a/pkg/util/jsonpath/parser/testdata/jsonpath
+++ b/pkg/util/jsonpath/parser/testdata/jsonpath
@@ -26,6 +26,11 @@ $.abc
 $."abc" -- normalized!
 
 parse
+$."abc-def"."abc_def"
+----
+$."abc-def"."abc_def"
+
+parse
 $.a.b.c.d.e.f.g.h.i.j.k.l.m.n.o.p.q.r.s.t.u.v.w.x.y.z
 ----
 $."a"."b"."c"."d"."e"."f"."g"."h"."i"."j"."k"."l"."m"."n"."o"."p"."q"."r"."s"."t"."u"."v"."w"."x"."y"."z" -- normalized!
@@ -232,6 +237,16 @@ $.abc[  1    to    3   , 4 to 3, 5  , 9     to 7]
 ----
 $."abc"[1 to 3,4 to 3,5,9 to 7] -- normalized!
 
+parse
+$[1]
+----
+$[1]
+
+parse
+$[$var]
+----
+$[$"var"] -- normalized!
+
 # postgres allows floats as array indexes
 # parse
 # $.abc[1.0]
@@ -260,5 +275,21 @@ $."abc"[1 to 3,4 to 3,5,9 to 7] -- normalized!
 # ----
 
 # parse
+# $[1.999999999999999]
+# ----
+
+# parse
 # $.1a
+# ----
+
+# parse
+# $[true]
+# ----
+
+# parse
+# $[false]
+# ----
+
+# parse
+# $[null]
 # ----


### PR DESCRIPTION
**jsonpath: refactor scalar types to reuse JSON primitives**

Previously, array indexes in jsonpath were represented with a custom
Numeric type. This commit creates a unified Scalar type that supports
integers and variables, and will be able to support strings, bools,
null, etc. in the future, and leverages existing JSON primitive
infrastructure to maintain the values.

Epic: None
Release note: None