### PR TITLE
build: undo change to build `amd64` in `v3` mode

### DIFF
--- a/build/toolchains/BUILD.bazel
+++ b/build/toolchains/BUILD.bazel
@@ -28,7 +28,6 @@ toolchain(
 platform(
     name = "cross_linux",
     constraint_values = [
-        "@io_bazel_rules_go//go/constraints/amd64:v3",
         "@platforms//os:linux",
         "@platforms//cpu:x86_64",
     ],


### PR DESCRIPTION
This was an accident.

Epic: none
Release note: None