### PR TITLE
changefeedccl: add support for diff option to enriched envelope

### DIFF
--- a/pkg/ccl/changefeedccl/changefeedbase/options.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/options.go
@@ -1012,10 +1012,15 @@ type Filters struct {
 
 // GetFilters returns a populated Filters.
 func (s StatementOptions) GetFilters() Filters {
+	envelopeType := s.m[OptEnvelope]
 	_, withDiff := s.m[OptDiff]
 	_, withIgnoreDisableChangefeedReplication := s.m[OptIgnoreDisableChangefeedReplication]
 	return Filters{
-		WithDiff:      withDiff,
+		// Feeds using the enriched envelope need their kvfeed to send the previous
+		// version of a row even when the `diff` changefeed option is not set
+		// in order to populate the `op` field. The use this data to differentiate
+		// between inserts and updates.
+		WithDiff:      withDiff || envelopeType == string(OptEnvelopeEnriched),
 		WithFiltering: !withIgnoreDisableChangefeedReplication,
 	}
 }

--- a/pkg/ccl/changefeedccl/encoder_json.go
+++ b/pkg/ccl/changefeedccl/encoder_json.go
@@ -621,7 +621,6 @@ func (e *jsonEncoder) makeValueSchema(updated, prev cdcevent.Row) (json.JSON, er
 		source, _ = ptr(e.enrichedEnvelopeSourceProvider.KafkaConnectJSONSchema(), nil)
 	}
 
-	// NOTE: this is option (2) cc @rohan-joshi
 	if e.keyInValue {
 		keyInValue, err = ptr(kcjsonschema.NewSchemaFromIterator(updated.ForEachKeyColumn(), fmt.Sprintf("%s.key", sqlName)))
 		if err != nil {
@@ -649,6 +648,9 @@ func (e *jsonEncoder) initEnrichedEnvelope(ctx context.Context) error {
 	}
 
 	payloadKeys := []string{"after", "op", "ts_ns"}
+	if e.beforeField {
+		payloadKeys = append(payloadKeys, "before")
+	}
 	if e.keyInValue {
 		payloadKeys = append(payloadKeys, "key")
 	}
@@ -678,8 +680,22 @@ func (e *jsonEncoder) initEnrichedEnvelope(ctx context.Context) error {
 			return nil, err
 		}
 
+		if e.beforeField {
+			var before json.JSON
+			if prev.IsInitialized() && !prev.IsDeleted() {
+				before, err = e.versionEncoder(prev.EventDescriptor, true).rowAsGoNative(ctx, prev, emitDeletedRowAsNull, nil)
+				if err != nil {
+					return nil, err
+				}
+			} else {
+				before = json.NullJSONValue
+			}
+
+			if err := payloadBuilder.Set("before", before); err != nil {
+				return nil, err
+			}
+		}
 		if e.keyInValue {
-			// NOTE: this is option (2) cc @rohan-joshi
 			if err := ve.encodeKeyInValue(ctx, updated, payloadBuilder, true); err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
This change allows the user to add a before field to
enriched changefeed messages if the diff option is
specified. Even when the diff option is not specified
this change allows us to correctly populate the "op"
field as an update when appropriate.

Fixes: https://github.com/cockroachdb/cockroach/issues/139662

Epic: [CRDB-8665](https://cockroachlabs.atlassian.net/browse/CRDB-8665)

Release note: None