### PR TITLE
pkg/cloud/amazon: add caching to final s3 credential in chain

### DIFF
--- a/pkg/cloud/amazon/s3_storage.go
+++ b/pkg/cloud/amazon/s3_storage.go
@@ -616,8 +616,8 @@ func (s *s3Storage) newClient(ctx context.Context) (s3Client, string, error) {
 			}
 		})
 
-		creds := stscreds.NewAssumeRoleProvider(client, s.opts.assumeRoleProvider.roleARN, withExternalID(s.opts.assumeRoleProvider.externalID))
-		cfg.Credentials = creds
+		finalCreds := stscreds.NewAssumeRoleProvider(client, s.opts.assumeRoleProvider.roleARN, withExternalID(s.opts.assumeRoleProvider.externalID))
+		cfg.Credentials = aws.NewCredentialsCache(finalCreds)
 	}
 
 	region := s.opts.region


### PR DESCRIPTION
May address observations of STS throttling in the wild.

[Cloud unit tests here.](https://teamcity.cockroachdb.com/buildConfiguration/Cockroach_Nightlies_CloudUnitTests/19024809?hideProblemsFromDependencies=false&hideTestsFromDependencies=false)