### PR TITLE
release-24.1: cli: actually drain after decommission

### DIFF
--- a/pkg/cli/node.go
+++ b/pkg/cli/node.go
@@ -597,8 +597,8 @@ func runDecommissionNodeImpl(
 			for _, targetNode := range nodeIDs {
 				if targetNode == localNodeID {
 					// Skip the draining step for the node serving the request, if it is a target node.
-					log.Warningf(ctx,
-						"skipping drain step for node n%d; it is decommissioning and serving the request",
+					_, _ = fmt.Fprintf(stderr,
+						"skipping drain step for node n%d; it is decommissioning and serving the request\n",
 						localNodeID,
 					)
 					continue

--- a/pkg/cmd/roachtest/tests/decommission.go
+++ b/pkg/cmd/roachtest/tests/decommission.go
@@ -1055,7 +1055,7 @@ func runDecommissionDrains(ctx context.Context, t test.Test, c cluster.Cluster) 
 			return err
 		}
 
-		// Check to see if the node has been drained.
+		// Check to see if the node has been drained or decommissioned.
 		// If not, queries should not fail.
 		if err = run(decommNodeDB, `SHOW DATABASES`); err != nil {
 			if strings.Contains(err.Error(), "not accepting clients") { // drained

--- a/pkg/cmd/roachtest/tests/decommission.go
+++ b/pkg/cmd/roachtest/tests/decommission.go
@@ -1020,10 +1020,6 @@ func runDecommissionDrains(ctx context.Context, t test.Test, c cluster.Cluster) 
 		require.NoError(t, err)
 	}
 
-	// Connect to node 4 (the target node of the decommission).
-	decommNodeDB := c.Conn(ctx, t.L(), decommNodeID)
-	defer decommNodeDB.Close()
-
 	// Decommission node 4 and poll its status during the decommission.
 	var (
 		maxAttempts = 50
@@ -1057,6 +1053,9 @@ func runDecommissionDrains(ctx context.Context, t test.Test, c cluster.Cluster) 
 
 		// Check to see if the node has been drained or decommissioned.
 		// If not, queries should not fail.
+		// Connect to node 4 (the target node of the decommission).
+		decommNodeDB := c.Conn(ctx, t.L(), decommNodeID)
+		defer decommNodeDB.Close()
 		if err = run(decommNodeDB, `SHOW DATABASES`); err != nil {
 			if strings.Contains(err.Error(), "not accepting clients") { // drained
 				return nil

--- a/pkg/cmd/roachtest/tests/decommission.go
+++ b/pkg/cmd/roachtest/tests/decommission.go
@@ -74,17 +74,25 @@ func registerDecommission(r registry.Registry) {
 	}
 	{
 		numNodes := 4
-		r.Add(registry.TestSpec{
-			Name:             "decommission/drains",
-			Owner:            registry.OwnerKV,
-			Cluster:          r.MakeClusterSpec(numNodes),
-			CompatibleClouds: registry.AllExceptAWS,
-			Suites:           registry.Suites(registry.Nightly),
-			Leases:           registry.MetamorphicLeases,
-			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
-				runDecommissionDrains(ctx, t, c)
-			},
-		})
+		for _, dead := range []bool{false, true} {
+			name := "decommission/drains"
+			if dead {
+				name += "/dead"
+			} else {
+				name += "/alive"
+			}
+			r.Add(registry.TestSpec{
+				Name:             name,
+				Owner:            registry.OwnerKV,
+				Cluster:          r.MakeClusterSpec(numNodes),
+				CompatibleClouds: registry.AllExceptAWS,
+				Suites:           registry.Suites(registry.Weekly),
+				Leases:           registry.MetamorphicLeases,
+				Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+					runDecommissionDrains(ctx, t, c, dead)
+				},
+			})
+		}
 	}
 	{
 		numNodes := 6
@@ -990,7 +998,7 @@ func runDecommissionRandomized(ctx context.Context, t test.Test, c cluster.Clust
 // the end of decommissioning. The test cluster contains 4 nodes and the fourth
 // node is decommissioned. While the decommissioning node has open SQL
 // connections, queries should never fail.
-func runDecommissionDrains(ctx context.Context, t test.Test, c cluster.Cluster) {
+func runDecommissionDrains(ctx context.Context, t test.Test, c cluster.Cluster, dead bool) {
 	var (
 		numNodes     = 4
 		pinnedNodeID = 1
@@ -1031,16 +1039,25 @@ func runDecommissionDrains(ctx context.Context, t test.Test, c cluster.Cluster) 
 		// The expected output of decommission while the node is about to be drained/is draining.
 		expReplicasTransferred = [][]string{
 			decommissionHeader,
-			{strconv.Itoa(decommNodeID), "true|false", "0", "true", "decommissioning", "false", "ready", "0"},
+			{strconv.Itoa(decommNodeID), "true|false", "0", "true", "decommissioning", "false", ".*", "0"},
 			decommissionFooter,
 		}
 		// The expected output of decommission once the node is finally marked as "decommissioned."
 		expDecommissioned = [][]string{
 			decommissionHeader,
-			{strconv.Itoa(decommNodeID), "true|false", "0", "true", "decommissioned", "false", "ready", "0"},
+			{strconv.Itoa(decommNodeID), "true|false", "0", "true", "decommissioned", "false", ".*", "0"},
 			decommissionFooter,
 		}
 	)
+	if dead {
+		t.Status(fmt.Sprintf("stopping node %d and waiting for it to be recognized as dead", decommNodeID))
+		c.Stop(ctx, t.L(), option.DefaultStopOpts(), decommNode)
+		// This should reliably result in the node being perceived as non-live from
+		// this point on. If the node were still "down but live" when decommission
+		// finishes, we'd try to drain a live node and get an error (since it can't
+		// be reached any more).
+		time.Sleep(15 * time.Second)
+	}
 	t.Status(fmt.Sprintf("decommissioning node %d", decommNodeID))
 	e := retry.WithMaxAttempts(ctx, retryOpts, maxAttempts, func() error {
 		o, err := h.decommission(ctx, decommNode, pinnedNodeID, "--wait=none", "--format=csv")
@@ -1051,14 +1068,22 @@ func runDecommissionDrains(ctx context.Context, t test.Test, c cluster.Cluster) 
 			return err
 		}
 
+		// When the target node is dead in this test configuration, the draining
+		// step is moot. If the target node is alive, the last decommission
+		// invocation should have drained it, which we verify below.
+
+		if dead {
+			return nil
+		}
+
 		// Check to see if the node has been drained or decommissioned.
 		// If not, queries should not fail.
 		// Connect to node 4 (the target node of the decommission).
 		decommNodeDB := c.Conn(ctx, t.L(), decommNodeID)
 		defer decommNodeDB.Close()
 		if err = run(decommNodeDB, `SHOW DATABASES`); err != nil {
-			if strings.Contains(err.Error(), "not accepting clients") { // drained
-				return nil
+			if strings.Contains(err.Error(), "not accepting clients") {
+				return nil // success (drained)
 			}
 			t.Fatal(err)
 		}


### PR DESCRIPTION
Backport 6/6 commits from #138732.

/cc @cockroachdb/release

Release justification: bug fix for customer impact

---

I do not know how this was ever supposed to work, but the old code can not have
been intentional: it created a drain client but then did not consume from it.
This had the effect of kicking off the drain, but ~immediately cancelling the
context on the goroutine carrying it out on the decommissioning node. This PR
actually waits for the drain to complete.

There is a related issue here, though. You can't drain a node that isn't live,
so attempting to decommission a node that's down will fail on the drain step.
This is certainly true as of this PR, but should have been true before as well.

Our docs[^1] do not mention this rather large caveat at all, and it seems
strange anyway; if the node is down why would you let the failing drain get in
the way.  Really the code ought to distinguish between the case of a live and
dead node and react accordingly - this is not something this PR achieves.

Fixes https://github.com/cockroachdb/cockroach/issues/138265.
Fixes https://github.com/cockroachdb/cockroach/issues/137240.

[^1]: https://www.cockroachlabs.com/docs/v24.3/node-shutdown?filters=decommission#remove-nodes
Epic: none
Release note (ops change): the `node decommission` cli command now waits
until the target node is drained before marking it as fully
decommissioned. Previously, it would start drain but not wait, leaving
the target node briefly in a state where it would be unable to
communicate with the cluster but would still accept client requests
(which would then hang or hit unexpected errors).

