### PR TITLE
kv: pass `Lease` by pointer in `leases.StatusInput`

### DIFF
--- a/pkg/kv/kvserver/leases/status.go
+++ b/pkg/kv/kvserver/leases/status.go
@@ -34,7 +34,7 @@ type StatusInput struct {
 	RequestTs hlc.Timestamp
 
 	// The lease to evaluate.
-	Lease roachpb.Lease
+	Lease *roachpb.Lease
 }
 
 // Status returns a lease status. The lease status is linked to the desire to
@@ -100,7 +100,7 @@ type StatusInput struct {
 func Status(ctx context.Context, nl NodeLiveness, i StatusInput) kvserverpb.LeaseStatus {
 	lease := i.Lease
 	status := kvserverpb.LeaseStatus{
-		Lease: lease,
+		Lease: *lease,
 		// NOTE: it would not be correct to accept either only the request time
 		// or only the current time in this method, we need both. We need the
 		// request time to determine whether the current lease can serve a given

--- a/pkg/kv/kvserver/leases/status_test.go
+++ b/pkg/kv/kvserver/leases/status_test.go
@@ -192,7 +192,7 @@ func TestStatus(t *testing.T) {
 				MinValidObservedTs: hlc.ClockTimestamp{},
 				RaftStatus:         tc.raftStatus,
 				RequestTs:          tc.reqTS,
-				Lease:              tc.lease,
+				Lease:              &tc.lease,
 			}
 
 			got := Status(context.Background(), nl, in)

--- a/pkg/kv/kvserver/replica_range_lease.go
+++ b/pkg/kv/kvserver/replica_range_lease.go
@@ -757,7 +757,7 @@ func (r *Replica) leaseStatusForRequestRLocked(
 		MinProposedTs:      r.mu.minLeaseProposedTS,
 		MinValidObservedTs: r.mu.minValidObservedTimestamp,
 		RequestTs:          reqTS,
-		Lease:              *r.shMu.state.Lease,
+		Lease:              r.shMu.state.Lease,
 	}
 
 	if in.Lease.Type() == roachpb.LeaseLeader {


### PR DESCRIPTION
The `Lease` struct is 112 bytes, which is reasonably large. Copying it into `leases.StatusInput` (line `replica_range_lease.go:759`) showed up in CPU profiles on the telemetry, where its use of `runtime.duffcopy` was responsible for about 1% of total system CPU time.

```
----------------------------------------------------------+-------------
                                             0.28s 84.85% |   github.com/cockroachdb/cockroach/pkg/kv/kvserver.(*Replica).leaseStatusForRequestRLocked pkg/kv/kvserver/replica_range_lease.go:759
                                             0.05s 15.15% |   github.com/cockroachdb/cockroach/pkg/kv/kvserver.(*pendingLeaseRequest).AcquisitionInProgress pkg/kv/kvserver/replica_range_lease.go:276
     0.33s  0.92%  0.92%      0.33s  0.92%                | runtime.duffcopy src/runtime/duff_amd64.s:393
----------------------------------------------------------+-------------
                                             0.04s 44.44% |   github.com/cockroachdb/cockroach/pkg/kv/kvserver.RRAccumulatorByTenant.AddReplica pkg/kv/kvserver/replica_rankings.go:282
                                             0.02s 22.22% |   github.com/cockroachdb/cockroach/pkg/kv/kvserver.(*Replica).leaseStatusForRequestRLocked pkg/kv/kvserver/replica_range_lease.go:759
                                             0.01s 11.11% |   github.com/cockroachdb/cockroach/pkg/kv/kvserver.(*Store).Capacity.func1 pkg/kv/kvserver/store.go:3172
                                             0.01s 11.11% |   github.com/cockroachdb/cockroach/pkg/raft.(*RawNode).LogSnapshot pkg/raft/rawnode.go:194
                                             0.01s 11.11% |   github.com/cockroachdb/cockroach/pkg/raft.getBasicStatus pkg/raft/status.go:104
     0.09s  0.25%  1.17%      0.09s  0.25%                | runtime.duffcopy src/runtime/duff_amd64.s:403
----------------------------------------------------------+-------------
                                             0.04s 50.00% |   github.com/cockroachdb/cockroach/pkg/kv/kvserver.(*pendingLeaseRequest).AcquisitionInProgress pkg/kv/kvserver/replica_range_lease.go:276
                                             0.01s 12.50% |   github.com/cockroachdb/cockroach/pkg/kv/kvserver.(*Replica).Metrics pkg/kv/kvserver/replica_metrics.go:99
                                             0.01s 12.50% |   github.com/cockroachdb/cockroach/pkg/kv/kvserver.(*Replica).leaseStatusForRequestRLocked pkg/kv/kvserver/replica_range_lease.go:759
                                             0.01s 12.50% |   github.com/cockroachdb/cockroach/pkg/kv/kvserver.(*pendingLeaseRequest).TransferInProgress pkg/kv/kvserver/replica_range_lease.go:297
                                             0.01s 12.50% |   github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb.LeaseStatus.Expiration pkg/kv/kvserver/kvserverpb/lease_status.go:32
     0.08s  0.22%  1.39%      0.08s  0.22%                | runtime.duffcopy src/runtime/duff_amd64.s:398
----------------------------------------------------------+-------------
                                             0.03s 50.00% |   github.com/cockroachdb/cockroach/pkg/kv/kvserver.(*Replica).leaseStatusForRequestRLocked pkg/kv/kvserver/replica_range_lease.go:759
                                             0.01s 16.67% |   github.com/cockroachdb/cockroach/pkg/kv/kvserver.(*Store).processReady pkg/kv/kvserver/store_raft.go:736
                                             0.01s 16.67% |   github.com/cockroachdb/cockroach/pkg/raft.getBasicStatus pkg/raft/status.go:104
                                             0.01s 16.67% |   github.com/cockroachdb/pebble.(*levelIter).init external/com_github_cockroachdb_pebble/level_iter.go:181
     0.06s  0.17%  1.56%      0.06s  0.17%                | runtime.duffcopy src/runtime/duff_amd64.s:423
```

<img width="1728" alt="Screenshot 2025-03-06 at 5 08 53 PM" src="https://github.com/user-attachments/assets/ca23a1a8-7d8a-4ad5-adfc-87fd019758a3" />

This commit avoids the unnecessary copy by passing the `Lease` by pointer.

Epic: None
Release note: None