### PR TITLE
ui: add DurationMillis axis type

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/graphs/bargraph/plugins.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/graphs/bargraph/plugins.ts
@@ -92,6 +92,8 @@ function getFormattedValue(value: number, yAxisUnits: AxisUnits): string {
       return Bytes(value);
     case AxisUnits.Duration:
       return Duration(value);
+    case AxisUnits.DurationMillis:
+      return Duration(value);
     case AxisUnits.Percentage:
       return Percentage(value, 1);
     default:

--- a/pkg/ui/workspaces/cluster-ui/src/graphs/utils/domain.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/graphs/utils/domain.ts
@@ -37,6 +37,10 @@ export enum AxisUnits {
    * Units are percentages expressed as fractional values of 1 (1.0 = 100%).
    */
   Percentage,
+  /**
+   * DurationMillis are durations expressed in nanoseconds, but which force the max Y-axis to be at least 1000000.
+   */
+  DurationMillis,
 }
 
 // The number of ticks to display on a Y axis.
@@ -320,6 +324,11 @@ export function calculateYAxisDomain(
       return ComputeDurationAxisDomain(yExtent);
     case AxisUnits.Percentage:
       return ComputePercentageAxisDomain(yExtent[0], yExtent[1]);
+    case AxisUnits.DurationMillis:
+      return ComputeDurationAxisDomain([
+        min(allDatapoints),
+        max([max(allDatapoints), 1000000]),
+      ]);
     default:
       return ComputeCountAxisDomain(yExtent);
   }

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/overload.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/overload.tsx
@@ -138,7 +138,7 @@ export default function (props: GraphDashboardProps) {
       showMetricsInTooltip={true}
       tooltip={`The 99th percentile latency of requests waiting in the various Admission Control CPU queues.`}
     >
-      <Axis units={AxisUnits.Duration} label="Delay Duration">
+      <Axis units={AxisUnits.DurationMillis} label="Delay Duration">
         {nodeIDs.map(nid => (
           <>
             <Metric
@@ -174,7 +174,7 @@ export default function (props: GraphDashboardProps) {
       showMetricsInTooltip={true}
       tooltip={`The 99th percentile latency of requests waiting in the Admission Control store queue.`}
     >
-      <Axis units={AxisUnits.Duration} label="Write Delay Duration">
+      <Axis units={AxisUnits.DurationMillis} label="Write Delay Duration">
         {storeMetrics(
           {
             name: "cr.store.admission.wait_durations.kv-stores-p99",
@@ -203,7 +203,7 @@ export default function (props: GraphDashboardProps) {
       showMetricsInTooltip={true}
       tooltip={`The 99th percentile latency of requests waiting in the Admission Control elastic CPU queue.`}
     >
-      <Axis units={AxisUnits.Duration} label="Delay Duration">
+      <Axis units={AxisUnits.DurationMillis} label="Delay Duration">
         {nodeIDs.map(nid => (
           <>
             <Metric
@@ -225,7 +225,7 @@ export default function (props: GraphDashboardProps) {
       showMetricsInTooltip={true}
       tooltip={`The 99th percentile latency of requests waiting in the Replication Admission Control queue. This metric is indicative of store overload on replicas.`}
     >
-      <Axis units={AxisUnits.Duration} label="Flow Token Wait Duration">
+      <Axis units={AxisUnits.DurationMillis} label="Flow Token Wait Duration">
         {nodeIDs.map(nid => (
           <>
             <Metric


### PR DESCRIPTION
This can help reduce alarm on some AC dashboards because the spikes should be ignored

Release note: None