### PR TITLE
cloud/amazon/s3: Add caching to STS credentials

### DIFF
--- a/pkg/cloud/amazon/s3_storage.go
+++ b/pkg/cloud/amazon/s3_storage.go
@@ -617,6 +617,9 @@ func (s *s3Storage) newClient(ctx context.Context) (s3Client, string, error) {
 		})
 
 		creds := stscreds.NewAssumeRoleProvider(client, s.opts.assumeRoleProvider.roleARN, withExternalID(s.opts.assumeRoleProvider.externalID))
+		// NOTE: It's critical to wrap all credentials in a CredentialCache to
+		// prevent DDoS'ing STS API endpoints:
+		// https://pkg.go.dev/github.com/aws/aws-sdk-go-v2/aws#CredentialsCache
 		cfg.Credentials = aws.NewCredentialsCache(creds)
 	}
 

--- a/pkg/cloud/amazon/s3_storage.go
+++ b/pkg/cloud/amazon/s3_storage.go
@@ -617,7 +617,7 @@ func (s *s3Storage) newClient(ctx context.Context) (s3Client, string, error) {
 		})
 
 		creds := stscreds.NewAssumeRoleProvider(client, s.opts.assumeRoleProvider.roleARN, withExternalID(s.opts.assumeRoleProvider.externalID))
-		cfg.Credentials = creds
+		cfg.Credentials = aws.NewCredentialsCache(creds)
 	}
 
 	region := s.opts.region


### PR DESCRIPTION
Add missing credential cache for stscreds instance.

Fixes: zd-25965
Epic: none
Release note: Improve S3 credential caching for STS credentials