### PR TITLE
kvcoord: support BATCH_RESPONSE scan format with buffered writes

### DIFF
--- a/pkg/kv/kvclient/kvcoord/BUILD.bazel
+++ b/pkg/kv/kvclient/kvcoord/BUILD.bazel
@@ -62,6 +62,7 @@ go_library(
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",
         "//pkg/storage/enginepb",
+        "//pkg/storage/mvccencoding",
         "//pkg/storage/mvcceval",
         "//pkg/util",
         "//pkg/util/admission/admissionpb",

--- a/pkg/kv/kvclient/kvcoord/BUILD.bazel
+++ b/pkg/kv/kvclient/kvcoord/BUILD.bazel
@@ -207,6 +207,7 @@ go_test(
         "//pkg/sql/pgwire/pgerror",
         "//pkg/storage",
         "//pkg/storage/enginepb",
+        "//pkg/storage/mvccencoding",
         "//pkg/testutils",
         "//pkg/testutils/datapathutils",
         "//pkg/testutils/kvclientutils",

--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_write_buffer.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_write_buffer.go
@@ -7,12 +7,14 @@ package kvcoord
 
 import (
 	"context"
+	"encoding/binary"
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/lock"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/storage/mvccencoding"
 	"github.com/cockroachdb/cockroach/pkg/storage/mvcceval"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
@@ -531,10 +533,6 @@ func (twb *txnWriteBuffer) mergeWithScanResp(
 		return nil, errors.AssertionFailedf("unexpectedly called mergeWithScanResp on a ScanRequest " +
 			"with COL_BATCH_RESPONSE scan format")
 	}
-	if req.ScanFormat == kvpb.BATCH_RESPONSE {
-		// TODO(arul): See pebbleResults.put for how this should be done.
-		return nil, errors.AssertionFailedf("unimplemented")
-	}
 
 	respIter := newScanRespIter(req, resp)
 	// First, calculate the size of the merged response. This then allows us to
@@ -559,10 +557,6 @@ func (twb *txnWriteBuffer) mergeWithReverseScanResp(
 		return nil, errors.AssertionFailedf("unexpectedly called mergeWithReverseScanResp on a " +
 			"ReverseScanRequest with COL_BATCH_RESPONSE scan format")
 	}
-	if req.ScanFormat == kvpb.BATCH_RESPONSE {
-		// TODO(arul): See pebbleResults.put for how this should be done.
-		return nil, errors.AssertionFailedf("unimplemented")
-	}
 
 	respIter := newReverseScanRespIter(req, resp)
 	// First, calculate the size of the merged response. This then allows us to
@@ -581,6 +575,9 @@ func (twb *txnWriteBuffer) mergeWithReverseScanResp(
 // by iterating over both, in-order[1], and calling the appropriate accept
 // function, based on which KV pair should be preferred[2] by the combined
 // response.
+//
+// Note that acceptBuffer and acceptResp functions should not advance the
+// iterator. acceptResp will only be called when respIter is in valid state.
 //
 // [1] Forward or reverse order, depending on the direction of the scan.
 // [2] See inline comments for more details on what "preferred" means.
@@ -999,20 +996,72 @@ func (bw *bufferedWrite) toRequest() kvpb.RequestUnion {
 	return ru
 }
 
+// getKey reads the key for the next KV from a slice of BatchResponses field of
+// {,Reverse}ScanResponse. The KV is encoded in the following format:
+//
+//	<lenValue:Uint32><lenKey:Uint32><Key><Value>
+//
+// Furthermore, MVCC timestamp might be included in the suffix of <Key> part, so
+// we need to split it away.
+//
+// The method assumes that the encoding is valid.
+func getKey(br []byte) []byte {
+	lenKey := int(binary.LittleEndian.Uint32(br[4:8]))
+	key, _, _ := enginepb.SplitMVCCKey(br[8 : 8+lenKey])
+	return key
+}
+
+// getFirstKVLength returns the number of bytes used to encode the first KV from
+// the given slice (which is assumed to have come from BatchResponses field of
+// {,Reverse}ScanResponse).
+func getFirstKVLength(br []byte) int {
+	// See comment on getKey for more details.
+	lenValue := int(binary.LittleEndian.Uint32(br[0:4]))
+	lenKey := int(binary.LittleEndian.Uint32(br[4:8]))
+	return 8 + lenKey + lenValue
+}
+
+// encKVLength returns the number of bytes that will be required to encode the
+// given key/value pair as well as just encoding length of the key (including
+// the timestamp).
+func encKVLength(key roachpb.Key, value *roachpb.Value) (lenKV, lenKey int) {
+	// See comment on getKey for more details.
+	lenKey = mvccencoding.EncodedMVCCKeyLength(key, value.Timestamp)
+	lenKV = 8 + lenKey + len(value.RawBytes)
+	return lenKV, lenKey
+}
+
+// appendKV appends the given key/value pair to the provided slice. It is
+// assumed that the slice already has enough capacity. The updated slice is
+// returned.
+func appendKV(toAppend []byte, key roachpb.Key, value *roachpb.Value) []byte {
+	lenKV, lenKey := encKVLength(key, value)
+	buf := toAppend[len(toAppend) : len(toAppend)+lenKV]
+	binary.LittleEndian.PutUint32(buf[0:4], uint32(len(value.RawBytes)))
+	binary.LittleEndian.PutUint32(buf[4:8], uint32(lenKey))
+	mvccencoding.EncodeMVCCKeyToBufSized(buf[8:8+lenKey], key, value.Timestamp, lenKey)
+	copy(buf[8+lenKey:], value.RawBytes)
+	return toAppend[:len(toAppend)+lenKV]
+}
+
 // respIter is an iterator over a scan or reverse scan response returned by
 // the KV layer.
 type respIter struct {
 	// One and only one of scanReq/reverseScanReq should ever be set.
 	scanReq        *kvpb.ScanRequest
 	reverseScanReq *kvpb.ReverseScanRequest
-	// scanFormat indicates the ScanFormat of the request. Only KEY_VALUES is
-	// supported right now.
+	// scanFormat indicates the ScanFormat of the request. Only KEY_VALUES and
+	// BATCH_RESPONSE are supported right now.
 	scanFormat kvpb.ScanFormat
 
 	// rows is the Rows field of the corresponding response.
 	//
 	// Only set with KEY_VALUES scan format.
 	rows []roachpb.KeyValue
+	// batchResponses is the BatchResponses field of the corresponding response.
+	//
+	// Only set with BATCH_RESPONSE scan format.
+	batchResponses [][]byte
 
 	// Fields below will be modified when advancing the iterator.
 
@@ -1020,18 +1069,30 @@ type respIter struct {
 	//
 	// Used in the KEY_VALUES scan format.
 	rowsIndex int
+	// brIndex and brOffset describe the current position within BatchResponses
+	// field of the response. The next KV starts at
+	// batchResponses[brIndex][brOffset]. When the end of the slice is reached,
+	// brIndex is incremented and brOffset is reset to 0.
+	//
+	// Additionally, brIndex controls which BatchResponses[i] slice KVs are
+	// being written into when merging the response with the buffered writes.
+	//
+	// Used in the BATCH_RESPONSE scan format.
+	brIndex  int
+	brOffset int
 }
 
 // newScanRespIter constructs and returns a new iterator to iterate over a
 // ScanRequest/Response.
 func newScanRespIter(req *kvpb.ScanRequest, resp *kvpb.ScanResponse) *respIter {
-	if req.ScanFormat != kvpb.KEY_VALUES {
+	if req.ScanFormat != kvpb.KEY_VALUES && req.ScanFormat != kvpb.BATCH_RESPONSE {
 		panic("unexpected")
 	}
 	return &respIter{
-		scanReq:    req,
-		scanFormat: req.ScanFormat,
-		rows:       resp.Rows,
+		scanReq:        req,
+		scanFormat:     req.ScanFormat,
+		rows:           resp.Rows,
+		batchResponses: resp.BatchResponses,
 	}
 }
 
@@ -1040,27 +1101,42 @@ func newScanRespIter(req *kvpb.ScanRequest, resp *kvpb.ScanResponse) *respIter {
 func newReverseScanRespIter(
 	req *kvpb.ReverseScanRequest, resp *kvpb.ReverseScanResponse,
 ) *respIter {
-	if req.ScanFormat != kvpb.KEY_VALUES {
+	if req.ScanFormat != kvpb.KEY_VALUES && req.ScanFormat != kvpb.BATCH_RESPONSE {
 		panic("unexpected")
 	}
 	return &respIter{
 		reverseScanReq: req,
 		scanFormat:     req.ScanFormat,
 		rows:           resp.Rows,
+		batchResponses: resp.BatchResponses,
 	}
 }
 
 // peekKey returns the key at the current iterator position.
+//
+// peekKey should only be called if the iterator is in valid state (i.e.
+// valid() returned true).
 func (s *respIter) peekKey() roachpb.Key {
 	if s.scanFormat == kvpb.KEY_VALUES {
 		return s.rows[s.rowsIndex].Key
 	}
-	panic("unexpected")
+	return getKey(s.batchResponses[s.brIndex][s.brOffset:])
 }
 
 // next moves the iterator forward.
+//
+// next should only be called if the iterator is in valid state (i.e. valid()
+// returned true).
 func (s *respIter) next() {
-	s.rowsIndex++
+	if s.scanFormat == kvpb.KEY_VALUES {
+		s.rowsIndex++
+		return
+	}
+	s.brOffset += getFirstKVLength(s.batchResponses[s.brIndex][s.brOffset:])
+	if s.brOffset >= len(s.batchResponses[s.brIndex]) {
+		s.brIndex++
+		s.brOffset = 0
+	}
 }
 
 // valid returns whether the iterator is (still) positioned to a valid index.
@@ -1068,12 +1144,14 @@ func (s *respIter) valid() bool {
 	if s.scanFormat == kvpb.KEY_VALUES {
 		return s.rowsIndex < len(s.rows)
 	}
-	panic("unexpected")
+	return s.brIndex < len(s.batchResponses)
 }
 
 // reset re-positions the iterator to the beginning of the response.
 func (s *respIter) reset() {
 	s.rowsIndex = 0
+	s.brIndex = 0
+	s.brOffset = 0
 }
 
 // startKey returns the start key of the request in response to which the
@@ -1110,18 +1188,51 @@ type respSizeHelper struct {
 	// field of the merged {,Reverse}ScanResponse when KEY_VALUES scan format is
 	// used.
 	rowsSize int
+	// batchResponseSize tracks the lengths of each []byte that we'll include in
+	// the BatchResponses field of the merged {,Reverse}ScanResponse when
+	// BATCH_RESPONSE scan format is used.
+	//
+	// At the moment, we'll rely on the "structure" produced by the server
+	// meaning that we'll "inject" the buffered KVs into responses from the
+	// server while maintaining the "layering" of slices. In the extreme case
+	// when the server produced an empty response this means that we'll include
+	// all buffered KVs in a single slice.
+	// TODO(yuzefovich): add better sizing heuristic which will allow for faster
+	// garbage collection of already processed KVs by the SQL layer.
+	//
+	// Length of this slice is always 1 greater than the length of the
+	// BatchResponses field from the server response in order to include a
+	// "spill-over" slice - this is done to accommodate any buffered writes
+	// after the server response is fully processed.
+	batchResponseSize []int
 }
 
 func makeRespSizeHelper(it *respIter) respSizeHelper {
-	return respSizeHelper{it: it}
+	h := respSizeHelper{it: it}
+	if it.scanFormat == kvpb.BATCH_RESPONSE {
+		h.batchResponseSize = make([]int, len(it.batchResponses)+1)
+	}
+	return h
 }
 
-func (h *respSizeHelper) acceptBuffer(roachpb.Key, *roachpb.Value) {
-	h.rowsSize++
+func (h *respSizeHelper) acceptBuffer(key roachpb.Key, value *roachpb.Value) {
+	if h.it.scanFormat == kvpb.KEY_VALUES {
+		h.rowsSize++
+		return
+	}
+	lenKV, _ := encKVLength(key, value)
+	// Note that this will always be in bounds even when h.it is no longer
+	// valid (due to the "spill-over" slice).
+	h.batchResponseSize[h.it.brIndex] += lenKV
 }
 
 func (h *respSizeHelper) acceptResp() {
-	h.rowsSize++
+	if h.it.scanFormat == kvpb.KEY_VALUES {
+		h.rowsSize++
+		return
+	}
+	br := h.it.batchResponses[h.it.brIndex][h.it.brOffset:]
+	h.batchResponseSize[h.it.brIndex] += getFirstKVLength(br)
 }
 
 // respMerger encapsulates state to combine a {,Reverse}ScanResponse, returned
@@ -1141,23 +1252,40 @@ type respMerger struct {
 	// rowsIdx tracks the position within rows slice of the response to be
 	// populated next.
 	rowsIdx int
+
+	// batchResponses is the BatchResponses field of the corresponding response.
+	// The merged response will be accumulated here first before being injected
+	// into one of the response structs.
+	//
+	// Only populated with BATCH_RESPONSE scan format.
+	//
+	// Note that unlike for rows, we don't have any position tracking in this
+	// struct for batchResponses -- this is because we reuse respIter.brIndex to
+	// indicate which []byte to write into.
+	batchResponses [][]byte
 }
 
 // makeRespMerger constructs and returns a new respMerger.
 func makeRespMerger(serverSideRespIter *respIter, h respSizeHelper) respMerger {
-	if serverSideRespIter.scanFormat != kvpb.KEY_VALUES {
-		panic("unexpected")
-	}
-	return respMerger{
+	m := respMerger{
 		serverRespIter: serverSideRespIter,
-		rows:           make([]roachpb.KeyValue, h.rowsSize),
 	}
+	if serverSideRespIter.scanFormat == kvpb.KEY_VALUES {
+		m.rows = make([]roachpb.KeyValue, h.rowsSize)
+	} else {
+		m.batchResponses = make([][]byte, len(h.batchResponseSize))
+		for i, size := range h.batchResponseSize {
+			m.batchResponses[i] = make([]byte, 0, size)
+		}
+	}
+	return m
 }
 
 // acceptKV takes a key and a value (presumably from the write buffer) and adds
 // it to the result set.
 func (m *respMerger) acceptKV(key roachpb.Key, value *roachpb.Value) {
-	if m.serverRespIter.scanFormat == kvpb.KEY_VALUES {
+	it := m.serverRespIter
+	if it.scanFormat == kvpb.KEY_VALUES {
 		m.rows[m.rowsIdx] = roachpb.KeyValue{
 			Key:   key,
 			Value: *value,
@@ -1165,21 +1293,23 @@ func (m *respMerger) acceptKV(key roachpb.Key, value *roachpb.Value) {
 		m.rowsIdx++
 		return
 	}
-	panic("unexpected")
+	// Note that this will always be in bounds even when the server resp
+	// iterator is no longer valid (due to the "spill-over" slice).
+	m.batchResponses[it.brIndex] = appendKV(m.batchResponses[it.brIndex], key, value)
 }
 
 // acceptServerResp accepts the current server response and adds it to the
 // result set.
-//
-// Note that the iterator is not moved forward after accepting the response; the
-// responsibility of doing so, if desired, is the caller's.
 func (m *respMerger) acceptServerResp() {
-	if m.serverRespIter.scanFormat == kvpb.KEY_VALUES {
-		m.rows[m.rowsIdx] = m.serverRespIter.rows[m.serverRespIter.rowsIndex]
+	it := m.serverRespIter
+	if it.scanFormat == kvpb.KEY_VALUES {
+		m.rows[m.rowsIdx] = it.rows[it.rowsIndex]
 		m.rowsIdx++
 		return
 	}
-	panic("unexpected")
+	br := it.batchResponses[it.brIndex][it.brOffset:]
+	toAppend := br[:getFirstKVLength(br)]
+	m.batchResponses[it.brIndex] = append(m.batchResponses[it.brIndex], toAppend...)
 }
 
 // toScanResp populates a copy of the given response with the final merged
@@ -1193,8 +1323,19 @@ func (m *respMerger) toScanResp(resp *kvpb.ScanResponse) *kvpb.ScanResponse {
 		assertTrue(m.rowsIdx == len(m.rows), "did not fill in all rows; did we miscount?")
 		result.Rows = m.rows
 		return result
+	} else {
+		// If we've done everything correctly, then each BatchResponses[i] slice
+		// should've been filled up to capacity.
+		for _, br := range m.batchResponses {
+			assertTrue(len(br) == cap(br), "incorrect calculation of BatchResponses[i] slice capacity")
+		}
+		if lastIdx := len(m.batchResponses) - 1; lastIdx > 0 && len(m.batchResponses[lastIdx]) == 0 {
+			// If we didn't use the "spill-over" slice, then remove it.
+			m.batchResponses = m.batchResponses[:lastIdx]
+		}
+		result.BatchResponses = m.batchResponses
+		return result
 	}
-	panic("unexpected")
 }
 
 // toReverseScanResp populates a copy of the given response with the final
@@ -1208,8 +1349,19 @@ func (m *respMerger) toReverseScanResp(resp *kvpb.ReverseScanResponse) *kvpb.Rev
 		assertTrue(m.rowsIdx == len(m.rows), "did not fill in all rows; did we miscount?")
 		result.Rows = m.rows
 		return result
+	} else {
+		// If we've done everything correctly, then each BatchResponses[i] slice
+		// should've been filled up to capacity.
+		for _, br := range m.batchResponses {
+			assertTrue(len(br) == cap(br), "incorrect calculation of BatchResponses[i] slice capacity")
+		}
+		if lastIdx := len(m.batchResponses) - 1; lastIdx > 0 && len(m.batchResponses[lastIdx]) == 0 {
+			// If we didn't use the "spill-over" slice, then remove it.
+			m.batchResponses = m.batchResponses[:lastIdx]
+		}
+		result.BatchResponses = m.batchResponses
+		return result
 	}
-	panic("unexpected")
 }
 
 // assertTrue panics with a message if the supplied condition isn't true.

--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_write_buffer.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_write_buffer.go
@@ -554,10 +554,10 @@ func (twb *txnWriteBuffer) mergeWithScanResp(
 	return rm.toScanResp(), nil
 }
 
-// mergeWithScanResp takes a ReverseScanRequest, that was sent to the KV layer,
-// and the response returned by the KV layer, and merges it with any writes that
-// were buffered by the transaction to correctly uphold read-your-own-write
-// semantics.
+// mergeWithReverseScanResp takes a ReverseScanRequest, that was sent to the KV
+// layer, and the response returned by the KV layer, and merges it with any
+// writes that were buffered by the transaction to correctly uphold
+// read-your-own-write semantics.
 func (twb *txnWriteBuffer) mergeWithReverseScanResp(
 	req *kvpb.ReverseScanRequest, resp *kvpb.ReverseScanResponse,
 ) (*kvpb.ReverseScanResponse, error) {
@@ -1020,16 +1020,23 @@ type respIter struct {
 	scanResp        *kvpb.ScanResponse
 	reverseScanReq  *kvpb.ReverseScanRequest
 	reverseScanResp *kvpb.ReverseScanResponse
-	index           int
+	// scanFormat indicates the ScanFormat of the request. Only KEY_VALUES is
+	// supported right now.
+	scanFormat kvpb.ScanFormat
+
+	rowsIndex int
 }
 
 // newScanRespIter constructs and returns a new iterator to iterate over a
 // ScanRequest/Response.
 func newScanRespIter(req *kvpb.ScanRequest, resp *kvpb.ScanResponse) *respIter {
+	if req.ScanFormat != kvpb.KEY_VALUES {
+		panic("unexpected")
+	}
 	return &respIter{
-		scanReq:  req,
-		scanResp: resp,
-		index:    0,
+		scanReq:    req,
+		scanResp:   resp,
+		scanFormat: req.ScanFormat,
 	}
 }
 
@@ -1038,128 +1045,73 @@ func newScanRespIter(req *kvpb.ScanRequest, resp *kvpb.ScanResponse) *respIter {
 func newReverseScanRespIter(
 	req *kvpb.ReverseScanRequest, resp *kvpb.ReverseScanResponse,
 ) *respIter {
+	if req.ScanFormat != kvpb.KEY_VALUES {
+		panic("unexpected")
+	}
 	return &respIter{
 		reverseScanReq:  req,
 		reverseScanResp: resp,
-		index:           0,
+		scanFormat:      req.ScanFormat,
 	}
 }
 
 // peekKey returns the key at the current iterator position.
 func (s *respIter) peekKey() roachpb.Key {
-	switch s.method() {
-	case kvpb.Scan:
-		switch s.scanFormat() {
-		case kvpb.KEY_VALUES:
-			return s.scanResp.Rows[s.index].Key
-		default:
-			panic("unexpected")
+	if s.scanFormat == kvpb.KEY_VALUES {
+		if s.scanReq != nil {
+			return s.scanResp.Rows[s.rowsIndex].Key
 		}
-
-	case kvpb.ReverseScan:
-		switch s.scanFormat() {
-		case kvpb.KEY_VALUES:
-			return s.reverseScanResp.Rows[s.index].Key
-		default:
-			panic("unexpected")
-		}
-	default:
-		panic("unexpected")
+		return s.reverseScanResp.Rows[s.rowsIndex].Key
 	}
+	panic("unexpected")
 }
 
 // next moves the iterator forward.
 func (s *respIter) next() {
-	s.index++
+	s.rowsIndex++
 }
 
 // valid returns whether the iterator is (still) positioned to a valid index.
 func (s *respIter) valid() bool {
-	switch s.method() {
-	case kvpb.Scan:
-		switch s.scanFormat() {
-		case kvpb.KEY_VALUES:
-			return s.index < len(s.scanResp.Rows)
-		default:
-			panic("unexpected")
+	if s.scanFormat == kvpb.KEY_VALUES {
+		if s.scanReq != nil {
+			return s.rowsIndex < len(s.scanResp.Rows)
 		}
-	case kvpb.ReverseScan:
-		switch s.scanFormat() {
-		case kvpb.KEY_VALUES:
-			return s.index < len(s.reverseScanResp.Rows)
-		default:
-			panic("unexpected")
-		}
-	default:
-		panic("unexpected")
+		return s.rowsIndex < len(s.reverseScanResp.Rows)
 	}
+	panic("unexpected")
 }
 
 // reset re-positions the iterator to the beginning of the response.
 func (s *respIter) reset() {
-	s.index = 0
-}
-
-// scanFormat returns the scan format of the request/response.
-func (s *respIter) scanFormat() kvpb.ScanFormat {
-	switch s.method() {
-	case kvpb.Scan:
-		return s.scanReq.ScanFormat
-	case kvpb.ReverseScan:
-		return s.reverseScanReq.ScanFormat
-	default:
-		panic("unexpected")
-	}
+	s.rowsIndex = 0
 }
 
 // startKey returns the start key of the request in response to which the
 // iterator was created.
 func (s *respIter) startKey() roachpb.Key {
-	switch s.method() {
-	case kvpb.Scan:
+	if s.scanReq != nil {
 		return s.scanReq.Key
-	case kvpb.ReverseScan:
-		return s.reverseScanReq.Key
-	default:
-		panic("unexpected")
 	}
+	return s.reverseScanReq.Key
 }
 
 // endKey returns the end key of the request in response to which the iterator
 // was created.
 func (s *respIter) endKey() roachpb.Key {
-	switch s.method() {
-	case kvpb.Scan:
+	if s.scanReq != nil {
 		return s.scanReq.EndKey
-	case kvpb.ReverseScan:
-		return s.reverseScanReq.EndKey
-	default:
-		panic("unexpected")
 	}
+	return s.reverseScanReq.EndKey
 }
 
 // seq returns the sequence number of the request in response to which the
 // iterator was created.
 func (s *respIter) seq() enginepb.TxnSeq {
-	switch s.method() {
-	case kvpb.Scan:
+	if s.scanReq != nil {
 		return s.scanReq.Sequence
-	case kvpb.ReverseScan:
-		return s.reverseScanReq.Sequence
-	default:
-		panic("unexpected")
 	}
-}
-
-func (s *respIter) method() kvpb.Method {
-	switch {
-	case s.scanReq != nil:
-		return kvpb.Scan
-	case s.reverseScanReq != nil:
-		return kvpb.ReverseScan
-	default:
-		panic("unexpected")
-	}
+	return s.reverseScanReq.Sequence
 }
 
 // respMerger encapsulates state to combine a {,Reverse}ScanResponse, returned
@@ -1172,66 +1124,56 @@ type respMerger struct {
 	// reverseScanResp; the other field should be nil.
 	scanResp        *kvpb.ScanResponse
 	reverseScanResp *kvpb.ReverseScanResponse
-	respIdx         int
+
+	// rowsIdx tracks the position within Rows slice of the response to be
+	// populated next.
+	rowsIdx int
 }
 
 // makeRespMerger constructs and returns a new respMerger.
 func makeRespMerger(serverSideRespIter *respIter, size int) respMerger {
 	m := respMerger{
 		serverRespIter: serverSideRespIter,
-		respIdx:        0,
 	}
-	switch serverSideRespIter.method() {
-	case kvpb.Scan:
+	if serverSideRespIter.scanReq != nil {
 		resp := serverSideRespIter.scanResp.ShallowCopy().(*kvpb.ScanResponse)
-		switch serverSideRespIter.scanFormat() {
-		case kvpb.KEY_VALUES:
+		if serverSideRespIter.scanFormat == kvpb.KEY_VALUES {
 			resp.Rows = make([]roachpb.KeyValue, size)
-		default:
+		} else {
 			panic("unexpected")
 		}
 		m.scanResp = resp
-	case kvpb.ReverseScan:
-		resp := serverSideRespIter.reverseScanResp.ShallowCopy().(*kvpb.ReverseScanResponse)
-		switch serverSideRespIter.scanFormat() {
-		case kvpb.KEY_VALUES:
-			resp.Rows = make([]roachpb.KeyValue, size)
-		default:
-			panic("unexpected")
-		}
-		m.reverseScanResp = resp
-	default:
+		return m
+	}
+	resp := serverSideRespIter.reverseScanResp.ShallowCopy().(*kvpb.ReverseScanResponse)
+	if serverSideRespIter.scanFormat == kvpb.KEY_VALUES {
+		resp.Rows = make([]roachpb.KeyValue, size)
+	} else {
 		panic("unexpected")
 	}
+	m.reverseScanResp = resp
 	return m
 }
 
 // acceptKV takes a key and a value (presumably from the write buffer) and adds
 // it to the result set.
 func (m *respMerger) acceptKV(key roachpb.Key, value *roachpb.Value) {
-	switch m.serverRespIter.method() {
-	case kvpb.Scan:
-		switch m.serverRespIter.scanFormat() {
-		case kvpb.KEY_VALUES:
-			m.scanResp.Rows[m.respIdx] = roachpb.KeyValue{
+	if m.serverRespIter.scanFormat == kvpb.KEY_VALUES {
+		if m.serverRespIter.scanReq != nil {
+			m.scanResp.Rows[m.rowsIdx] = roachpb.KeyValue{
 				Key:   key,
 				Value: *value,
 			}
-		default:
-			panic("unexpected")
-		}
-	case kvpb.ReverseScan:
-		switch m.serverRespIter.scanFormat() {
-		case kvpb.KEY_VALUES:
-			m.reverseScanResp.Rows[m.respIdx] = roachpb.KeyValue{
+		} else {
+			m.reverseScanResp.Rows[m.rowsIdx] = roachpb.KeyValue{
 				Key:   key,
 				Value: *value,
 			}
-		default:
-			panic("unexpected")
 		}
+		m.rowsIdx++
+		return
 	}
-	m.respIdx++
+	panic("unexpected")
 }
 
 // acceptServerResp accepts the current server response and adds it to the
@@ -1240,52 +1182,39 @@ func (m *respMerger) acceptKV(key roachpb.Key, value *roachpb.Value) {
 // Note that the iterator is not moved forward after accepting the response; the
 // responsibility of doing so, if desired, is the caller's.
 func (m *respMerger) acceptServerResp() {
-	switch m.serverRespIter.method() {
-	case kvpb.Scan:
-		switch m.serverRespIter.scanFormat() {
-		case kvpb.KEY_VALUES:
-			m.scanResp.Rows[m.respIdx] = m.serverRespIter.scanResp.Rows[m.serverRespIter.index]
-		default:
-			panic("unexpected")
+	if m.serverRespIter.scanFormat == kvpb.KEY_VALUES {
+		if m.serverRespIter.scanReq != nil {
+			m.scanResp.Rows[m.rowsIdx] = m.serverRespIter.scanResp.Rows[m.serverRespIter.rowsIndex]
+		} else {
+			m.reverseScanResp.Rows[m.rowsIdx] = m.serverRespIter.reverseScanResp.Rows[m.serverRespIter.rowsIndex]
 		}
-	case kvpb.ReverseScan:
-		switch m.serverRespIter.scanFormat() {
-		case kvpb.KEY_VALUES:
-			m.reverseScanResp.Rows[m.respIdx] = m.serverRespIter.reverseScanResp.Rows[m.serverRespIter.index]
-		default:
-			panic("unexpected")
-		}
-	default:
-		panic("unexpected")
+		m.rowsIdx++
+		return
 	}
-	m.respIdx++
+	panic("unexpected")
 }
 
 // toScanResp returns the final merged ScanResponse.
 func (m *respMerger) toScanResp() *kvpb.ScanResponse {
-	assertTrue(m.serverRespIter.method() == kvpb.Scan, "weren't accumulating a scan resp")
+	assertTrue(m.serverRespIter.scanReq != nil, "weren't accumulating a scan resp")
 	// If we've done everything correctly, resIdx == len(response rows).
-	switch m.serverRespIter.scanFormat() {
-	case kvpb.KEY_VALUES:
-		assertTrue(m.respIdx == len(m.scanResp.Rows), "did not fill in all rows; did we miscount?")
-	default:
-		panic("unexpected")
+	if m.serverRespIter.scanFormat == kvpb.KEY_VALUES {
+		assertTrue(m.rowsIdx == len(m.scanResp.Rows), "did not fill in all rows; did we miscount?")
+		return m.scanResp
 	}
-	return m.scanResp
+	panic("unexpected")
 }
 
 // toReverseScanResp returns the final merged ReverseScanResponse.
 func (m *respMerger) toReverseScanResp() *kvpb.ReverseScanResponse {
-	assertTrue(m.serverRespIter.method() == kvpb.ReverseScan,
-		"weren't accumulating a reverse scan resp")
+	assertTrue(m.serverRespIter.scanReq == nil, "weren't accumulating a reverse scan resp")
 	// If we've done everything correctly, resIdx == len(response rows).
-	switch m.serverRespIter.scanFormat() {
-	case kvpb.KEY_VALUES:
-		assertTrue(m.respIdx == len(m.reverseScanResp.Rows), "did not fill in all rows; did we miscount?")
-	default:
-		panic("unexpected")
+	if m.serverRespIter.scanFormat == kvpb.KEY_VALUES {
+		assertTrue(m.rowsIdx == len(m.reverseScanResp.Rows), "did not fill in all rows; did we miscount?")
+		return m.reverseScanResp
 	}
-	return m.reverseScanResp
+	panic("unexpected")
+
 }
 
 // assertTrue panics with a message if the supplied condition isn't true.

--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_write_buffer.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_write_buffer.go
@@ -538,20 +538,14 @@ func (twb *txnWriteBuffer) mergeWithScanResp(
 
 	respIter := newScanRespIter(req, resp)
 	// First, calculate the size of the merged response. This then allows us to
-	// exactly pre-allocate the response slice when constructing the
-	// respMerger.
-	respSize := 0
-	twb.mergeBufferAndResp(
-		respIter,
-		func(roachpb.Key, *roachpb.Value) { respSize++ },
-		func() { respSize++ },
-		false, /* reverse */
-	)
+	// exactly pre-allocate the response slice when constructing the respMerger.
+	h := makeRespSizeHelper(respIter)
+	twb.mergeBufferAndResp(respIter, h.acceptBuffer, h.acceptResp, false /* reverse */)
 
 	respIter.reset()
-	rm := makeRespMerger(respIter, respSize)
+	rm := makeRespMerger(respIter, h)
 	twb.mergeBufferAndResp(respIter, rm.acceptKV, rm.acceptServerResp, false /* reverse */)
-	return rm.toScanResp(), nil
+	return rm.toScanResp(resp), nil
 }
 
 // mergeWithReverseScanResp takes a ReverseScanRequest, that was sent to the KV
@@ -572,20 +566,14 @@ func (twb *txnWriteBuffer) mergeWithReverseScanResp(
 
 	respIter := newReverseScanRespIter(req, resp)
 	// First, calculate the size of the merged response. This then allows us to
-	// exactly pre-allocate the response slice when constructing the
-	// respMerger.
-	respSize := 0
-	twb.mergeBufferAndResp(
-		respIter,
-		func(roachpb.Key, *roachpb.Value) { respSize++ },
-		func() { respSize++ },
-		true, /* reverse */
-	)
+	// exactly pre-allocate the response slice when constructing the respMerger.
+	h := makeRespSizeHelper(respIter)
+	twb.mergeBufferAndResp(respIter, h.acceptBuffer, h.acceptResp, true /* reverse */)
 
 	respIter.reset()
-	rm := makeRespMerger(respIter, respSize)
+	rm := makeRespMerger(respIter, h)
 	twb.mergeBufferAndResp(respIter, rm.acceptKV, rm.acceptServerResp, true /* reverse */)
-	return rm.toReverseScanResp(), nil
+	return rm.toReverseScanResp(resp), nil
 }
 
 // mergeBufferAndScanResp merges (think the merge step from merge sort) the
@@ -1014,16 +1002,23 @@ func (bw *bufferedWrite) toRequest() kvpb.RequestUnion {
 // respIter is an iterator over a scan or reverse scan response returned by
 // the KV layer.
 type respIter struct {
-	// One and only one of scanReq/reverseScanReq (and by extension,
-	// scanResp/reverseScanResp) should ever be set.
-	scanReq         *kvpb.ScanRequest
-	scanResp        *kvpb.ScanResponse
-	reverseScanReq  *kvpb.ReverseScanRequest
-	reverseScanResp *kvpb.ReverseScanResponse
+	// One and only one of scanReq/reverseScanReq should ever be set.
+	scanReq        *kvpb.ScanRequest
+	reverseScanReq *kvpb.ReverseScanRequest
 	// scanFormat indicates the ScanFormat of the request. Only KEY_VALUES is
 	// supported right now.
 	scanFormat kvpb.ScanFormat
 
+	// rows is the Rows field of the corresponding response.
+	//
+	// Only set with KEY_VALUES scan format.
+	rows []roachpb.KeyValue
+
+	// Fields below will be modified when advancing the iterator.
+
+	// rowsIndex is the current index into Rows field of the response.
+	//
+	// Used in the KEY_VALUES scan format.
 	rowsIndex int
 }
 
@@ -1035,8 +1030,8 @@ func newScanRespIter(req *kvpb.ScanRequest, resp *kvpb.ScanResponse) *respIter {
 	}
 	return &respIter{
 		scanReq:    req,
-		scanResp:   resp,
 		scanFormat: req.ScanFormat,
+		rows:       resp.Rows,
 	}
 }
 
@@ -1049,19 +1044,16 @@ func newReverseScanRespIter(
 		panic("unexpected")
 	}
 	return &respIter{
-		reverseScanReq:  req,
-		reverseScanResp: resp,
-		scanFormat:      req.ScanFormat,
+		reverseScanReq: req,
+		scanFormat:     req.ScanFormat,
+		rows:           resp.Rows,
 	}
 }
 
 // peekKey returns the key at the current iterator position.
 func (s *respIter) peekKey() roachpb.Key {
 	if s.scanFormat == kvpb.KEY_VALUES {
-		if s.scanReq != nil {
-			return s.scanResp.Rows[s.rowsIndex].Key
-		}
-		return s.reverseScanResp.Rows[s.rowsIndex].Key
+		return s.rows[s.rowsIndex].Key
 	}
 	panic("unexpected")
 }
@@ -1074,10 +1066,7 @@ func (s *respIter) next() {
 // valid returns whether the iterator is (still) positioned to a valid index.
 func (s *respIter) valid() bool {
 	if s.scanFormat == kvpb.KEY_VALUES {
-		if s.scanReq != nil {
-			return s.rowsIndex < len(s.scanResp.Rows)
-		}
-		return s.rowsIndex < len(s.reverseScanResp.Rows)
+		return s.rowsIndex < len(s.rows)
 	}
 	panic("unexpected")
 }
@@ -1114,61 +1103,64 @@ func (s *respIter) seq() enginepb.TxnSeq {
 	return s.reverseScanReq.Sequence
 }
 
+type respSizeHelper struct {
+	it *respIter
+
+	// rowsSize tracks the total number of KVs that we'll include in the Rows
+	// field of the merged {,Reverse}ScanResponse when KEY_VALUES scan format is
+	// used.
+	rowsSize int
+}
+
+func makeRespSizeHelper(it *respIter) respSizeHelper {
+	return respSizeHelper{it: it}
+}
+
+func (h *respSizeHelper) acceptBuffer(roachpb.Key, *roachpb.Value) {
+	h.rowsSize++
+}
+
+func (h *respSizeHelper) acceptResp() {
+	h.rowsSize++
+}
+
 // respMerger encapsulates state to combine a {,Reverse}ScanResponse, returned
 // by the KV layer, with any overlapping buffered writes to correctly uphold
 // read-your-own-write semantics. It can be used to accumulate a response when
 // merging a {,Reverse}ScanResponse with buffered writes.
 type respMerger struct {
 	serverRespIter *respIter
-	// We should only ever be accumulating either one of scanResp or
-	// reverseScanResp; the other field should be nil.
-	scanResp        *kvpb.ScanResponse
-	reverseScanResp *kvpb.ReverseScanResponse
 
-	// rowsIdx tracks the position within Rows slice of the response to be
+	// rows is the Rows field of the corresponding response. The merged response
+	// will be accumulated here first before being injected into one of the
+	// response structs.
+	//
+	// Only populated with KEY_VALUES scan format.
+	rows []roachpb.KeyValue
+
+	// rowsIdx tracks the position within rows slice of the response to be
 	// populated next.
 	rowsIdx int
 }
 
 // makeRespMerger constructs and returns a new respMerger.
-func makeRespMerger(serverSideRespIter *respIter, size int) respMerger {
-	m := respMerger{
-		serverRespIter: serverSideRespIter,
-	}
-	if serverSideRespIter.scanReq != nil {
-		resp := serverSideRespIter.scanResp.ShallowCopy().(*kvpb.ScanResponse)
-		if serverSideRespIter.scanFormat == kvpb.KEY_VALUES {
-			resp.Rows = make([]roachpb.KeyValue, size)
-		} else {
-			panic("unexpected")
-		}
-		m.scanResp = resp
-		return m
-	}
-	resp := serverSideRespIter.reverseScanResp.ShallowCopy().(*kvpb.ReverseScanResponse)
-	if serverSideRespIter.scanFormat == kvpb.KEY_VALUES {
-		resp.Rows = make([]roachpb.KeyValue, size)
-	} else {
+func makeRespMerger(serverSideRespIter *respIter, h respSizeHelper) respMerger {
+	if serverSideRespIter.scanFormat != kvpb.KEY_VALUES {
 		panic("unexpected")
 	}
-	m.reverseScanResp = resp
-	return m
+	return respMerger{
+		serverRespIter: serverSideRespIter,
+		rows:           make([]roachpb.KeyValue, h.rowsSize),
+	}
 }
 
 // acceptKV takes a key and a value (presumably from the write buffer) and adds
 // it to the result set.
 func (m *respMerger) acceptKV(key roachpb.Key, value *roachpb.Value) {
 	if m.serverRespIter.scanFormat == kvpb.KEY_VALUES {
-		if m.serverRespIter.scanReq != nil {
-			m.scanResp.Rows[m.rowsIdx] = roachpb.KeyValue{
-				Key:   key,
-				Value: *value,
-			}
-		} else {
-			m.reverseScanResp.Rows[m.rowsIdx] = roachpb.KeyValue{
-				Key:   key,
-				Value: *value,
-			}
+		m.rows[m.rowsIdx] = roachpb.KeyValue{
+			Key:   key,
+			Value: *value,
 		}
 		m.rowsIdx++
 		return
@@ -1183,38 +1175,41 @@ func (m *respMerger) acceptKV(key roachpb.Key, value *roachpb.Value) {
 // responsibility of doing so, if desired, is the caller's.
 func (m *respMerger) acceptServerResp() {
 	if m.serverRespIter.scanFormat == kvpb.KEY_VALUES {
-		if m.serverRespIter.scanReq != nil {
-			m.scanResp.Rows[m.rowsIdx] = m.serverRespIter.scanResp.Rows[m.serverRespIter.rowsIndex]
-		} else {
-			m.reverseScanResp.Rows[m.rowsIdx] = m.serverRespIter.reverseScanResp.Rows[m.serverRespIter.rowsIndex]
-		}
+		m.rows[m.rowsIdx] = m.serverRespIter.rows[m.serverRespIter.rowsIndex]
 		m.rowsIdx++
 		return
 	}
 	panic("unexpected")
 }
 
-// toScanResp returns the final merged ScanResponse.
-func (m *respMerger) toScanResp() *kvpb.ScanResponse {
+// toScanResp populates a copy of the given response with the final merged
+// state.
+func (m *respMerger) toScanResp(resp *kvpb.ScanResponse) *kvpb.ScanResponse {
 	assertTrue(m.serverRespIter.scanReq != nil, "weren't accumulating a scan resp")
-	// If we've done everything correctly, resIdx == len(response rows).
+	// TODO(yuzefovich): we need to update NumKeys and NumBytes.
+	result := resp.ShallowCopy().(*kvpb.ScanResponse)
 	if m.serverRespIter.scanFormat == kvpb.KEY_VALUES {
-		assertTrue(m.rowsIdx == len(m.scanResp.Rows), "did not fill in all rows; did we miscount?")
-		return m.scanResp
+		// If we've done everything correctly, resIdx == len(response rows).
+		assertTrue(m.rowsIdx == len(m.rows), "did not fill in all rows; did we miscount?")
+		result.Rows = m.rows
+		return result
 	}
 	panic("unexpected")
 }
 
-// toReverseScanResp returns the final merged ReverseScanResponse.
-func (m *respMerger) toReverseScanResp() *kvpb.ReverseScanResponse {
+// toReverseScanResp populates a copy of the given response with the final
+// merged state.
+func (m *respMerger) toReverseScanResp(resp *kvpb.ReverseScanResponse) *kvpb.ReverseScanResponse {
 	assertTrue(m.serverRespIter.scanReq == nil, "weren't accumulating a reverse scan resp")
-	// If we've done everything correctly, resIdx == len(response rows).
+	// TODO(yuzefovich): we need to update NumKeys and NumBytes.
+	result := resp.ShallowCopy().(*kvpb.ReverseScanResponse)
 	if m.serverRespIter.scanFormat == kvpb.KEY_VALUES {
-		assertTrue(m.rowsIdx == len(m.reverseScanResp.Rows), "did not fill in all rows; did we miscount?")
-		return m.reverseScanResp
+		// If we've done everything correctly, resIdx == len(response rows).
+		assertTrue(m.rowsIdx == len(m.rows), "did not fill in all rows; did we miscount?")
+		result.Rows = m.rows
+		return result
 	}
 	panic("unexpected")
-
 }
 
 // assertTrue panics with a message if the supplied condition isn't true.

--- a/pkg/kv/kvclient/kvcoord/txn_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/tscache"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/kvclientutils"
@@ -1709,6 +1710,19 @@ func TestTxnBufferedWritesOverlappingScan(t *testing.T) {
 	s := createTestDB(t)
 	defer s.Stop()
 
+	extractKVs := func(rows []roachpb.KeyValue, batchResponses [][]byte) []roachpb.KeyValue {
+		if rows != nil {
+			return rows
+		}
+		var kvs []roachpb.KeyValue
+		err := storage.MVCCScanDecodeKeyValues(batchResponses, func(key storage.MVCCKey, rawBytes []byte) error {
+			kvs = append(kvs, roachpb.KeyValue{Key: key.Key, Value: roachpb.Value{RawBytes: rawBytes}})
+			return nil
+		})
+		require.NoError(t, err)
+		return kvs
+	}
+
 	testutils.RunTrueAndFalse(t, "reverse", func(t *testing.T, reverse bool) {
 		makeKV := func(key []byte, val []byte) roachpb.KeyValue {
 			return roachpb.KeyValue{Key: key, Value: roachpb.Value{RawBytes: val}}
@@ -1799,6 +1813,14 @@ func TestTxnBufferedWritesOverlappingScan(t *testing.T) {
 					},
 				},
 				{
+					// Entirely within the buffer and the server response is empty.
+					key:    keyB,
+					endKey: keyC,
+					expRes: []roachpb.KeyValue{
+						makeKV(keyB, valueTxn),
+					},
+				},
+				{
 					// End key is present in the buffer, but isn't returned because the scan
 					// is exclusive.
 					key:    keyA,
@@ -1834,27 +1856,55 @@ func TestTxnBufferedWritesOverlappingScan(t *testing.T) {
 					},
 				},
 			} {
-				var res []kv.KeyValue
-				var err error
-				if reverse {
-					res, err = txn.ReverseScan(ctx, tc.key, tc.endKey, 0 /* maxRows */)
-					require.NoError(t, err)
-				} else {
-					res, err = txn.Scan(ctx, tc.key, tc.endKey, 0 /* maxRows */)
-					require.NoError(t, err)
-				}
-				if reverse {
-					// Reverse the expected result.
-					sort.Slice(tc.expRes, func(i, j int) bool {
-						return bytes.Compare(tc.expRes[i].Key, tc.expRes[j].Key) > 0
-					})
-				}
-				require.Len(t, res, len(tc.expRes), "failed %d", i)
-				for i, exp := range tc.expRes {
-					require.Equal(t, exp.Key, res[i].Key, "failed %d", i)
-					val, err := res[i].Value.GetBytes()
-					require.NoError(t, err)
-					require.Equal(t, exp.Value.RawBytes, val)
+				for _, sf := range []kvpb.ScanFormat{
+					kvpb.KEY_VALUES,
+					kvpb.BATCH_RESPONSE,
+				} {
+					var req kvpb.Request
+					if reverse {
+						req = &kvpb.ReverseScanRequest{
+							RequestHeader: kvpb.RequestHeader{
+								Key:    tc.key,
+								EndKey: tc.endKey,
+							},
+							ScanFormat: sf,
+						}
+					} else {
+						req = &kvpb.ScanRequest{
+							RequestHeader: kvpb.RequestHeader{
+								Key:    tc.key,
+								EndKey: tc.endKey,
+							},
+							ScanFormat: sf,
+						}
+					}
+					b := txn.NewBatch()
+					b.AddRawRequest(req)
+					require.NoError(t, txn.Run(ctx, b))
+					br := b.RawResponse()
+
+					require.Equal(t, 1, len(br.Responses))
+					var kvs []roachpb.KeyValue
+					if reverse {
+						rsr := br.Responses[0].GetInner().(*kvpb.ReverseScanResponse)
+						kvs = extractKVs(rsr.Rows, rsr.BatchResponses)
+					} else {
+						sr := br.Responses[0].GetInner().(*kvpb.ScanResponse)
+						kvs = extractKVs(sr.Rows, sr.BatchResponses)
+					}
+					if reverse {
+						// Reverse the expected result.
+						sort.Slice(tc.expRes, func(i, j int) bool {
+							return bytes.Compare(tc.expRes[i].Key, tc.expRes[j].Key) > 0
+						})
+					}
+					require.Len(t, kvs, len(tc.expRes), "failed %d", i)
+					for i, exp := range tc.expRes {
+						require.Equal(t, exp.Key, kvs[i].Key, "failed %d", i)
+						val, err := kvs[i].Value.GetBytes()
+						require.NoError(t, err)
+						require.Equal(t, exp.Value.RawBytes, val)
+					}
 				}
 			}
 			return nil


### PR DESCRIPTION
This PR contains several commits that add support for BATCH_RESPONSE scan format of Scan and ReverseScan requests to the buffered writes interceptor. It refactors the existing logic for KEY_VALUES format to make it more extensible, and then maintains the same "hierarchy" of `[][]byte` slices in the response. It also fixes `NumKeys` and `NumBytes` fields of the merged response. See each commit for more details.

Fixes: #141743