### PR TITLE
roachtest: fix panic while getting cloud info for debug clusters

### DIFF
--- a/pkg/cmd/roachtest/roachtestutil/metric_utils.go
+++ b/pkg/cmd/roachtest/roachtestutil/metric_utils.go
@@ -128,9 +128,15 @@ func GetOpenmetricsLabelMap(
 ) map[string]string {
 	defaultMap := map[string]string{
 		"test-run-id": t.GetRunId(),
-		"cloud":       c.Cloud().String(),
 		"owner":       t.Owner(),
 		"test":        t.Name(),
+	}
+
+	// With --cluster flag, the cloud field in cluster spec is not populated.
+	// To avoid panic, we check and only then add the cloud label
+	// Since --cluster is not used in nightlies, this is not an issue.
+	if cloud := c.Cloud(); cloud.IsSet() {
+		defaultMap["cloud"] = cloud.String()
 	}
 
 	if roachtestflags.OpenmetricsLabels != "" {


### PR DESCRIPTION
`sysbench` started failing with the following error

```
 Wraps: (4) monitor user task failed: recovered panic: invalid cloud
 .
 .
 github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil.GetOpenmetricsLabelMap
 |   |         pkg/cmd/roachtest/roachtestutil/metric_utils.go:131

```
Since this was a debug cluster, the cloud info is not populated. To
avoid further issues, this change adds a nil check

Epic: none

Release note: None