### PR TITLE
amazon: wrap kms credential provider in cache

### DIFF
--- a/pkg/cloud/amazon/aws_kms.go
+++ b/pkg/cloud/amazon/aws_kms.go
@@ -206,7 +206,7 @@ func MakeAWSKMS(ctx context.Context, uri string, env cloud.KMSEnv) (cloud.KMS, e
 				}
 			})
 			intermediateCreds := stscreds.NewAssumeRoleProvider(client, delegateProvider.roleARN, withExternalID(delegateProvider.externalID))
-			cfg.Credentials = intermediateCreds
+			cfg.Credentials = aws.NewCredentialsCache(intermediateCreds)
 		}
 
 		client := sts.NewFromConfig(cfg, func(options *sts.Options) {
@@ -215,7 +215,7 @@ func MakeAWSKMS(ctx context.Context, uri string, env cloud.KMSEnv) (cloud.KMS, e
 			}
 		})
 		creds := stscreds.NewAssumeRoleProvider(client, kmsURIParams.roleProvider.roleARN, withExternalID(kmsURIParams.roleProvider.externalID))
-		cfg.Credentials = creds
+		cfg.Credentials = aws.NewCredentialsCache(creds)
 	}
 
 	reuse := reuseKMSSession.Get(&env.ClusterSettings().SV)


### PR DESCRIPTION
In the same spirit as #142434, we need to wrap the kms credential provider in a cache to prevent throttling from the STS endpoints.

Epic: none

Release note (bug fix): prevents users of AWS KMS + ASSUME ROLE from having their STS requests get throttled.