### PR TITLE
catalog/lease: reduce contention during lease acquistion.

### DIFF
--- a/pkg/sql/catalog/lease/descriptor_set.go
+++ b/pkg/sql/catalog/lease/descriptor_set.go
@@ -106,12 +106,10 @@ func (l *descriptorSet) findPreviousToExpire(dropped bool) *descriptorVersionSta
 		// avoid expiring.
 		return nil
 	}
-	exp.mu.Lock()
-	defer exp.mu.Unlock()
 	// If the refcount has hit zero then this version will be cleaned up
-	// automatically. If an expiration time is already setup, then this
-	// version has already been expired.
-	if exp.mu.refcount == 0 || !exp.mu.expiration.IsEmpty() {
+	// automatically. The expiration time is non-nil only if a version has
+	// been expired or is considered stale.
+	if exp.refcount.Load() == 0 || (exp.expiration.Load() != nil) {
 		return nil
 	}
 	return exp

--- a/pkg/sql/catalog/lease/helpers_test.go
+++ b/pkg/sql/catalog/lease/helpers_test.go
@@ -114,11 +114,7 @@ func (m *Manager) ExpireLeases(clock *hlc.Clock) {
 	defer m.names.mu.Unlock()
 	_ = m.names.descriptors.IterateByID(func(entry catalog.NameEntry) error {
 		desc := entry.(*descriptorVersionState)
-		desc.mu.Lock()
-		defer desc.mu.Unlock()
-		desc.mu.expiration = past
-		// Wipe the session as if this is an expired version
-		desc.mu.session = nil
+		desc.expiration.Store(&past)
 		return nil
 	})
 }

--- a/pkg/sql/catalog/lease/lease.go
+++ b/pkg/sql/catalog/lease/lease.go
@@ -1117,6 +1117,10 @@ type Manager struct {
 	// waitForInit used when the lease manager is starting up prevent leases from
 	// being acquired before the range feed.
 	waitForInit chan struct{}
+
+	// initComplete is a fast check to confirm that initialization is complete, since
+	// performance testing showed select on the waitForInit channel can be expensive.
+	initComplete atomic.Bool
 }
 
 const leaseConcurrencyLimit = 5
@@ -1552,6 +1556,9 @@ func (m *Manager) isDescriptorStateEmpty(id descpb.ID) bool {
 
 // maybeWaitForInit waits for the lease manager to startup.
 func (m *Manager) maybeWaitForInit() {
+	if m.initComplete.Load() {
+		return
+	}
 	select {
 	case <-m.waitForInit:
 	case <-m.stopper.ShouldQuiesce():
@@ -1579,6 +1586,7 @@ func (m *Manager) StartRefreshLeasesTask(ctx context.Context, s *stop.Stopper, d
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	defer close(m.waitForInit)
+	defer m.initComplete.Swap(true)
 	m.watchForUpdates(ctx)
 	_ = s.RunAsyncTask(ctx, "refresh-leases", func(ctx context.Context) {
 		for {
@@ -2286,6 +2294,7 @@ func (m *Manager) TestingMarkInit() {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	close(m.waitForInit)
+	m.initComplete.Swap(true)
 }
 
 // deleteOrphanedLeasesFromStaleSession deletes leases from sessions that are

--- a/pkg/sql/catalog/lease/name_cache.go
+++ b/pkg/sql/catalog/lease/name_cache.go
@@ -75,12 +75,15 @@ func (c *nameCache) get(
 	}
 
 	// Expired descriptor. Don't hand it out.
-	if desc.hasExpiredLocked(ctx, timestamp) {
+	if desc.hasExpired(ctx, timestamp) {
 		return nil, hlc.Timestamp{}
 	}
 
-	desc.incRefCountLocked(ctx, expensiveLogEnabled)
-	return desc, desc.mu.expiration
+	desc.incRefCount(ctx, expensiveLogEnabled)
+	if exp := desc.expiration.Load(); exp != nil {
+		return desc, *exp
+	}
+	return desc, hlc.Timestamp{}
 }
 
 func (c *nameCache) insert(ctx context.Context, desc *descriptorVersionState) {


### PR DESCRIPTION
This patch makes the following changes to help improve the performance of descriptor lease acquisition:

1. Adds a multi-threaded benchmark (AcquireLeaseConcurrent) for acquiring and releasing lease, so we can objectively measure improvements to the leasing fast path (i.e. when a lease is already cached).
2. Removes mutexes from common fields used for acquiring leases, such as the expiration, session ID, and reference count.
3. The WaitForInit check inside the lease manager can be expensive since select on a channel needs a mutex, so an atomic is introduced as a short circuit after initialization is complete.
4. The sqlliveness session mutable state only consists of an expiration, so we can replace this field with an atomic. This reduces contention for session based leasing, since multiple readers may need to check expirations concurrently.

With these changes we see the following improvement on the microbenchmark for leasing:
```
old:  1f19a34 catalog/lease: add BenchmarkAcquireLeaseConcurrent
new:  2ca363d sqlliveness: remove mutex from session
args: benchdiff "./pkg/sql/catalog/lease" "-b" "-r" "BenchmarkAcquireLeaseConcurrent" "--count" "10" "--old=1f19a3427d7cd240bae293a3fd6209d854390d7c"

name                                   old time/op    new time/op    delta
AcquireLeaseConcurrent/threads=32-10      711ns ± 9%     361ns ± 8%   -49.28%  (p=0.000 n=10+10)
AcquireLeaseConcurrent/threads=64-10      722ns ± 7%     370ns ± 8%   -48.76%  (p=0.000 n=9+10)
AcquireLeaseConcurrent/threads=8-10       660ns ±12%     339ns ±10%   -48.65%  (p=0.000 n=10+9)
AcquireLeaseConcurrent/threads=128-10     728ns ± 8%     376ns ± 8%   -48.38%  (p=0.000 n=10+10)
AcquireLeaseConcurrent/threads=16-10      679ns ±10%     351ns ±11%   -48.31%  (p=0.000 n=10+10)
AcquireLeaseConcurrent/threads=4-10       629ns ± 7%     331ns ±15%   -47.33%  (p=0.000 n=9+10)
AcquireLeaseConcurrent/threads=2-10       575ns ± 6%     306ns ± 4%   -46.78%  (p=0.000 n=10+8)
AcquireLeaseConcurrent/threads=1-10       488ns ± 8%     287ns ± 9%   -41.20%  (p=0.000 n=10+10)

name                                   old alloc/op   new alloc/op   delta
AcquireLeaseConcurrent/threads=32-10     6.20B ±110%     0.00B       -100.00%  (p=0.033 n=10+10)
AcquireLeaseConcurrent/threads=1-10       2.00B ± 0%     1.00B ± 0%   -50.00%  (p=0.000 n=9+10)
AcquireLeaseConcurrent/threads=2-10       0.00B          0.00B           ~     (all equal)
AcquireLeaseConcurrent/threads=4-10       0.00B          0.00B           ~     (all equal)
AcquireLeaseConcurrent/threads=16-10      0.00B          0.00B           ~     (all equal)
AcquireLeaseConcurrent/threads=128-10     0.00B          0.00B           ~     (all equal)
AcquireLeaseConcurrent/threads=8-10       0.00B          1.00B ± 0%     +Inf%  (p=0.000 n=10+8)
AcquireLeaseConcurrent/threads=64-10      0.00B          6.75B ±11%     +Inf%  (p=0.000 n=8+8)

name                                   old allocs/op  new allocs/op  delta
AcquireLeaseConcurrent/threads=1-10        0.00           0.00           ~     (all equal)
AcquireLeaseConcurrent/threads=2-10        0.00           0.00           ~     (all equal)
AcquireLeaseConcurrent/threads=4-10        0.00           0.00           ~     (all equal)
AcquireLeaseConcurrent/threads=8-10        0.00           0.00           ~     (all equal)
AcquireLeaseConcurrent/threads=16-10       0.00           0.00           ~     (all equal)
AcquireLeaseConcurrent/threads=32-10       0.00           0.00           ~     (all equal)
AcquireLeaseConcurrent/threads=64-10       0.00           0.00           ~     (all equal)
AcquireLeaseConcurrent/threads=128-10      0.00           0.00           ~     (all equal)
```


Fixes: #139166 