### PR TITLE
security: fix test failure due to leaked goroutine

### DIFF
--- a/pkg/util/leaktest/leaktest.go
+++ b/pkg/util/leaktest/leaktest.go
@@ -63,6 +63,7 @@ func interestingGoroutines() map[int64]string {
 			// TODO(pritesh-lahoti): Revisit this once Go is updated to 1.23, as this seems to have been
 			// fixed: https://github.com/golang/go/pull/62227.
 			strings.Contains(stack, "net/http.(*persistConn).addTLS") ||
+			strings.Contains(stack, "crypto/tls.(*Conn).handshakeContext") ||
 			// Seems to be gccgo specific.
 			(runtime.Compiler == "gccgo" && strings.Contains(stack, "testing.T.Parallel")) ||
 			// Ignore intentionally long-running logging goroutines that live for the


### PR DESCRIPTION
We have been seeing intermittent test failures for TestUseCerts. These failures have been due to a leaked goroutine that establishes a TLS handshake. The change is to ignore this goroutine while checking for leaked goroutines.

Fixes: #142448
Epic: CRDB-48341

Release note: None