### PR TITLE
kvserver: untangle shared/external snap streaming logic

### DIFF
--- a/pkg/kv/kvserver/kv_snapshot_strategy.go
+++ b/pkg/kv/kvserver/kv_snapshot_strategy.go
@@ -645,6 +645,12 @@ func (kvSS *kvBatchSnapshotStrategy) Send(
 					kvs-kvsBefore,
 				)
 			}
+			// TODO(tbg): the shared and external visitors never flush, so at this
+			// point the receiver hasn't gotten any shared/external SST references
+			// sent to it. This implies that an explicit transition is unnecessary
+			// and we can remove this.
+			//
+			// See: https://github.com/cockroachdb/cockroach/issues/142673
 			transitionFromSharedToRegularReplicate = true
 			err = rditer.IterateReplicaKeySpans(ctx, snap.State.Desc, snap.EngineSnap, true, /* replicatedOnly */
 				rditer.ReplicatedSpansUserOnly, iterateRKSpansVisitor)

--- a/pkg/kv/kvserver/kv_snapshot_strategy.go
+++ b/pkg/kv/kvserver/kv_snapshot_strategy.go
@@ -186,11 +186,16 @@ func (kvSS *kvBatchSnapshotStrategy) Receive(
 			return noSnap, sendSnapshotError(snapshotCtx, s, stream, err)
 		}
 		if req.TransitionFromSharedToRegularReplicate {
-			doExcise = false
 			sharedSSTs = nil
 			externalSSTs = nil
-			if err := msstw.addClearForMVCCSpan(); err != nil {
-				return noSnap, errors.Wrap(err, "adding tombstone for last span")
+			if !doExcise {
+				// TODO(tbg): this is dead code. We always excise if there is
+				// initially any chance of shared/external SSTs, and never
+				// opt out of that.
+				if err := msstw.addClearForMVCCSpan(); err != nil {
+					return noSnap, errors.Wrap(err, "adding tombstone for last span")
+				}
+				return noSnap, errors.AssertionFailedf("unexpected TransitionFromSharedToRegularReplicate without excising")
 			}
 		}
 

--- a/pkg/kv/kvserver/kv_snapshot_strategy.go
+++ b/pkg/kv/kvserver/kv_snapshot_strategy.go
@@ -300,42 +300,39 @@ func (kvSS *kvBatchSnapshotStrategy) Receive(
 			}
 			timingTag.stop("sst")
 		}
-		if len(req.SharedTables) > 0 && doExcise {
-			for i := range req.SharedTables {
-				sst := req.SharedTables[i]
-				pbToInternalKey := func(k *kvserverpb.SnapshotRequest_SharedTable_InternalKey) pebble.InternalKey {
-					return pebble.InternalKey{UserKey: k.UserKey, Trailer: pebble.InternalKeyTrailer(k.Trailer)}
-				}
-				sharedSSTs = append(sharedSSTs, pebble.SharedSSTMeta{
-					Backing:          stubBackingHandle{sst.Backing},
-					Smallest:         pbToInternalKey(sst.Smallest),
-					Largest:          pbToInternalKey(sst.Largest),
-					SmallestRangeKey: pbToInternalKey(sst.SmallestRangeKey),
-					LargestRangeKey:  pbToInternalKey(sst.LargestRangeKey),
-					SmallestPointKey: pbToInternalKey(sst.SmallestPointKey),
-					LargestPointKey:  pbToInternalKey(sst.LargestPointKey),
-					Level:            uint8(sst.Level),
-					Size:             sst.Size_,
-				})
+
+		for i := range req.SharedTables {
+			sst := req.SharedTables[i]
+			pbToInternalKey := func(k *kvserverpb.SnapshotRequest_SharedTable_InternalKey) pebble.InternalKey {
+				return pebble.InternalKey{UserKey: k.UserKey, Trailer: pebble.InternalKeyTrailer(k.Trailer)}
 			}
+			sharedSSTs = append(sharedSSTs, pebble.SharedSSTMeta{
+				Backing:          stubBackingHandle{sst.Backing},
+				Smallest:         pbToInternalKey(sst.Smallest),
+				Largest:          pbToInternalKey(sst.Largest),
+				SmallestRangeKey: pbToInternalKey(sst.SmallestRangeKey),
+				LargestRangeKey:  pbToInternalKey(sst.LargestRangeKey),
+				SmallestPointKey: pbToInternalKey(sst.SmallestPointKey),
+				LargestPointKey:  pbToInternalKey(sst.LargestPointKey),
+				Level:            uint8(sst.Level),
+				Size:             sst.Size_,
+			})
 		}
-		if len(req.ExternalTables) > 0 && doExcise {
-			for i := range req.ExternalTables {
-				sst := req.ExternalTables[i]
-				externalSSTs = append(externalSSTs, pebble.ExternalFile{
-					Locator:           remote.Locator(sst.Locator),
-					ObjName:           sst.ObjectName,
-					StartKey:          sst.StartKey,
-					EndKey:            sst.EndKey,
-					EndKeyIsInclusive: sst.EndKeyIsInclusive,
-					HasPointKey:       sst.HasPointKey,
-					HasRangeKey:       sst.HasRangeKey,
-					SyntheticPrefix:   sst.SyntheticPrefix,
-					SyntheticSuffix:   sst.SyntheticSuffix,
-					Level:             uint8(sst.Level),
-					Size:              sst.Size_,
-				})
-			}
+		for i := range req.ExternalTables {
+			sst := req.ExternalTables[i]
+			externalSSTs = append(externalSSTs, pebble.ExternalFile{
+				Locator:           remote.Locator(sst.Locator),
+				ObjName:           sst.ObjectName,
+				StartKey:          sst.StartKey,
+				EndKey:            sst.EndKey,
+				EndKeyIsInclusive: sst.EndKeyIsInclusive,
+				HasPointKey:       sst.HasPointKey,
+				HasRangeKey:       sst.HasRangeKey,
+				SyntheticPrefix:   sst.SyntheticPrefix,
+				SyntheticSuffix:   sst.SyntheticSuffix,
+				Level:             uint8(sst.Level),
+				Size:              sst.Size_,
+			})
 		}
 		if req.Final {
 			// We finished receiving all batches and log entries. It's possible that

--- a/pkg/kv/kvserver/kv_snapshot_strategy.go
+++ b/pkg/kv/kvserver/kv_snapshot_strategy.go
@@ -236,14 +236,14 @@ func (kvSS *kvBatchSnapshotStrategy) Receive(
 						return noSnap, errors.Wrapf(err, "writing sst for raft snapshot")
 					}
 				case pebble.InternalKeyKindDelete, pebble.InternalKeyKindDeleteSized:
-					if !doExcise {
+					if !header.SharedReplicate {
 						return noSnap, errors.AssertionFailedf("unexpected batch entry key kind %d", batchReader.KeyKind())
 					}
 					if err := msstw.PutInternalPointKey(ctx, batchReader.Key(), batchReader.KeyKind(), nil); err != nil {
 						return noSnap, errors.Wrapf(err, "writing sst for raft snapshot")
 					}
 				case pebble.InternalKeyKindRangeDelete:
-					if !doExcise {
+					if !header.SharedReplicate {
 						return noSnap, errors.AssertionFailedf("unexpected batch entry key kind %d", batchReader.KeyKind())
 					}
 					start := batchReader.Key()
@@ -256,7 +256,7 @@ func (kvSS *kvBatchSnapshotStrategy) Receive(
 					}
 
 				case pebble.InternalKeyKindRangeKeyUnset, pebble.InternalKeyKindRangeKeyDelete:
-					if !doExcise {
+					if !header.SharedReplicate {
 						return noSnap, errors.AssertionFailedf("unexpected batch entry key kind %d", batchReader.KeyKind())
 					}
 					start := batchReader.Key()

--- a/pkg/kv/kvserver/multi_sst_writer.go
+++ b/pkg/kv/kvserver/multi_sst_writer.go
@@ -377,9 +377,6 @@ func decodeRangeStartEnd(
 }
 
 func (msstw *multiSSTWriter) PutInternalRangeDelete(ctx context.Context, start, end []byte) error {
-	if !msstw.skipClearForMVCCSpan {
-		panic("can only add internal range deletes to multiSSTWriter if skipClearForMVCCSpan is true")
-	}
 	decodedStart, decodedEnd, err := decodeRangeStartEnd(start, end)
 	if err != nil {
 		return err
@@ -398,9 +395,6 @@ func (msstw *multiSSTWriter) PutInternalRangeDelete(ctx context.Context, start, 
 func (msstw *multiSSTWriter) PutInternalRangeKey(
 	ctx context.Context, start, end []byte, key rangekey.Key,
 ) error {
-	if !msstw.skipClearForMVCCSpan {
-		panic("can only add internal range deletes to multiSSTWriter if skipClearForMVCCSpan is true")
-	}
 	decodedStart, decodedEnd, err := decodeRangeStartEnd(start, end)
 	if err != nil {
 		return err


### PR DESCRIPTION
This made my head hurt. For the full discovery story, go [here].

If a snapshot may possibly reference external/shared SSTs (i.e. ones not local to the sending node), we avoid putting a range deletion into the addressable portion of the state machine snapshot (i.e. the bulk of the snapshot).

Instead, we require that this snapshot is ingested with an accompanying excise span. However, if we later realize that we cannot actually send shared/external SSTs, we were forcibly _disabling_ excise ingestion (even if it was used for all other snapshots). I believe this was written this way before excise became the default, but now it explicitly steered us into a legacy path. This then awkwardly necessitated sending a message to the recipient to please quickly add a range deletion to the main state machine SSTable:

```
// if req.TransitionFromSharedToRegularReplicate received:
if err := msstw.addClearForMVCCSpan(); err != nil {
  return noSnap, errors.Wrap(err, "adding tombstone for last span")
}
```

Then, the sender would stream the addressable state machine data, this time without relying on external/shared SSTs.

CockroachDB has routinely ingested every snapshot on the excise path since 24.1, and falling into the legacy path here causes complexity, namely the aforementioned call to `addClearForMVCCSpan`. We would like to remove non-excise snapshots altogether (see https://github.com/cockroachdb/cockroach/pull/142651). This PR keeps us on the excise path if we were initially on it.

This turns addClearForMVCCSpan into "obviously" dead code. I'll leave it around for now, since it's used in a unit test and I'd like to tackle it separately.

----

There was also the general question on how this transition path worked. Since the ingested SSTs have to have nonoverlapping bounds (and SSTs must be
sorted), this "transition path" only makes sense no MVCC keys had been streamed yet. Looking at
the code, this is far from obvious. It does appear to be true, though, so an
assertion has been added.
It's worth noting that SST references (shared/external) may have been sent, as the visitor may have seen some of them. So we can't remove the transition path entirely. We could, however, if we buffered up the 

----

The resulting story is now much simpler and makes sense to me:

- Snapshots that have any chance of referencing external/shared SSTs use excise, and don't leave that path.
- They may fall back to not using external/shared SSTs. Since we know haven't streamed any keys or values we from the MVCC span yet by the time we discover this (though we may have told the recipient about some SST references), we send the recipient a "transition" message.
- the only effect of receiving this message is clearing out the slice of external SST references.
- after that, we're effectively on the "regular" snapshot path (with excise).

[here]: https://cockroachlabs.slack.com/archives/CAC6K3SLU/p1741356670269679

Epic: CRDB-46488
Release note: none