### PR TITLE
server: include nice, irq, softirq in host cpu calculation 

### DIFF
--- a/pkg/server/status/BUILD.bazel
+++ b/pkg/server/status/BUILD.bazel
@@ -159,6 +159,7 @@ go_test(
         "//pkg/testutils/serverutils",
         "//pkg/ts/tspb",
         "//pkg/ts/tsutil",
+        "//pkg/util/hlc",
         "//pkg/util/leaktest",
         "//pkg/util/log",
         "//pkg/util/log/eventpb",


### PR DESCRIPTION
Previously, our measure of host CPU usage was limited to adding up
counters for `user` and `system` time which matches the counters that
we record for the process-specific cpu usage.

However, this sum omitted additional counters on the host-side
that provide a more complete picture of CPU usage which led to
undercounting in many scenarios. In particular, we observed that
high network usage leads to an increase in `softirq` counters on the
host-side as the OS does more work on the TCP layer. This would lead
to a host CPU percentage that was **below** the process CPU percentage
which led to confusion.

This change adds the `irq` and `softirq` counters to the host CPU
measurement, as well as `nice`. This eliminates the underreporting
that was previously observed.

The additional fields in the `cpu.TimesStat` struct provided by
`gopsutil` that are not included in the host CPU calculation are:
- `Idle`, `Iowait`: these represent time when the CPU is not doing work
- `Steal`: this represents time "stolen" by other operating systems in
a virtualized environment. This would not be considered CPU consumed
by the "host".
- `Guest`, `GuestNice`: these represent user time spent in virtualized
environments. This is captured in `User` and `Nice` already.

As far as virtualized environments like Docker are concerned, the host
CPU consumption is measured with respect to the container itself.
Within the container, the `/proc` filesystem represents that
container's CPU.

There are no additional counters available on the process-side, only
`user` and `system`.

Resolves: https://github.com/cockroachdb/cockroach/issues/122349

Release note (ops change): the metric that measures host cpu,
`sys.cpu.host.combined.percent-normalized` has been updated to include
additional counters to provide a correct measurement and reduce
underreporting host cpu. This metric now includes time spent
processing hardware and software interrupts (irq, softirq) as well as
nice time which represents low priority user mode activity.