### PR TITLE
sql: support multiple RLS policies on a table

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/row_level_security
+++ b/pkg/sql/logictest/testdata/logic_test/row_level_security
@@ -1677,4 +1677,162 @@ DROP FUNCTION al_only;
 statement ok
 DROP SEQUENCE seq1;
 
+subtest multiple_policies
+
+statement ok
+CREATE TABLE multip (key INT NOT NULL, value TEXT, FAMILY (key,value));
+
+statement ok
+ALTER TABLE multip ENABLE ROW LEVEL SECURITY;
+
+# The policies will be combined as: (or1 || or2 || or3) && and1 && and2
+statement ok
+CREATE POLICY or1 ON multip AS PERMISSIVE USING (key = 1);
+
+statement ok
+CREATE POLICY or2 ON multip AS PERMISSIVE USING (key = 2);
+
+statement ok
+CREATE POLICY or3 ON multip AS PERMISSIVE USING (key = 3);
+
+statement ok
+CREATE POLICY and1 ON multip AS RESTRICTIVE USING (value not like '%sensitive%')
+
+statement ok
+CREATE POLICY and2 ON multip AS RESTRICTIVE USING (value not like '%confidential%')
+
+statement ok
+INSERT INTO multip VALUES
+ (0, 'key out of bounds'),
+ (1, 'okay'),
+ (1, 'sensitive - filtered out'),
+ (2, 'okay'),
+ (2, 'confidential - filtered out'),
+ (3, 'okay'),
+ (2, 'sensitive - filtered out'),
+ (4, 'key out of bounds'),
+ (4, 'confidential');
+
+statement ok
+CREATE USER multi_user;
+
+statement ok
+GRANT ALL ON multip TO multi_user;
+
+statement ok
+SET ROLE multi_user;
+
+query IT
+select * from multip ORDER BY key, value;
+----
+1  okay
+2  okay
+3  okay
+
+query IT
+select * from multip where key >= 0 ORDER BY key, value;
+----
+1  okay
+2  okay
+3  okay
+
+statement ok
+SET ROLE root
+
+# Ensure that if only a restrictive policy exists that all rows will be rejected
+# regardless of the policy expression.
+statement ok
+DROP POLICY or1 ON multip;
+
+statement ok
+DROP POLICY or2 ON multip;
+
+statement ok
+DROP POLICY or3 ON multip;
+
+statement ok
+SET ROLE multi_user;
+
+query TT
+SHOW CREATE multip;
+----
+multip  CREATE TABLE public.multip (
+          key INT8 NOT NULL,
+          value STRING NULL,
+          rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+          CONSTRAINT multip_pkey PRIMARY KEY (rowid ASC),
+          FAMILY fam_0_key_value_rowid (key, value, rowid)
+        );
+        ALTER TABLE public.multip ENABLE ROW LEVEL SECURITY;
+        CREATE POLICY and1 ON public.multip AS RESTRICTIVE FOR ALL TO public USING (value NOT LIKE '%sensitive%':::STRING);
+        CREATE POLICY and2 ON public.multip AS RESTRICTIVE FOR ALL TO public USING (value NOT LIKE '%confidential%':::STRING)
+
+query IT
+select * from multip ORDER BY key, value;
+----
+
+statement ok
+SET ROLE root;
+
+# Setup to verify the write policies.
+statement ok
+TRUNCATE TABLE multip;
+
+statement ok
+CREATE POLICY or1 ON multip AS PERMISSIVE USING (key = 1);
+
+statement ok
+CREATE POLICY or2 ON multip AS PERMISSIVE USING (key = 2);
+
+statement ok
+CREATE POLICY or3 ON multip AS PERMISSIVE USING (key = 3);
+
+statement ok
+SET ROLE multi_user;
+
+statement error pq: new row violates row-level security policy for table "multip"
+INSERT INTO multip VALUES (0, 'key out of bounds');
+
+statement ok
+INSERT INTO multip VALUES (1, 'okay');
+
+statement error pq: new row violates row-level security policy for table "multip"
+INSERT INTO multip VALUES (1, 'sensitive - filtered out');
+
+statement ok
+INSERT INTO multip VALUES (2, 'okay')
+
+statement error pq: new row violates row-level security policy for table "multip"
+INSERT INTO multip VALUES (2, 'confidential - filtered out')
+
+statement ok
+INSERT INTO multip VALUES (3, 'okay')
+
+statement error pq: new row violates row-level security policy for table "multip"
+INSERT INTO multip VALUES (2, 'sensitive - filtered out')
+
+statement error pq: new row violates row-level security policy for table "multip"
+INSERT INTO multip VALUES (4, 'key out of bounds')
+
+statement error pq: new row violates row-level security policy for table "multip"
+INSERT INTO multip VALUES (4, 'confidential');
+
+statement ok
+SET ROLE root;
+
+query IT
+select * FROM multip ORDER BY key, value;
+----
+1  okay
+2  okay
+3  okay
+
+statement ok
+DROP TABLE multip;
+
+statement ok
+DROP USER multi_user;
+
+subtest multiple_insert_policies
+
 subtest end

--- a/pkg/sql/opt/exec/explain/emit.go
+++ b/pkg/sql/opt/exec/explain/emit.go
@@ -1404,14 +1404,14 @@ func (e *emitter) emitPolicies(ob *OutputBuilder, table cat.Table, n *Node) {
 	} else {
 		var sb strings.Builder
 		policies := table.Policies()
-		// TODO(136742): Add support for restrictive policies.
-		for i := range policies.Permissive {
-			policy := policies.Permissive[i]
-			if applied.Policies.Contains(policy.ID) {
-				if sb.Len() > 0 {
-					sb.WriteString(", ")
+		for _, grp := range [][]cat.Policy{policies.Permissive, policies.Restrictive} {
+			for _, policy := range grp {
+				if applied.Policies.Contains(policy.ID) {
+					if sb.Len() > 0 {
+						sb.WriteString(", ")
+					}
+					sb.WriteString(policy.Name.Normalize())
 				}
-				sb.WriteString(policy.Name.Normalize())
 			}
 		}
 		ob.AddField("policies", sb.String())

--- a/pkg/sql/opt/exec/explain/testdata/row_level_security
+++ b/pkg/sql/opt/exec/explain/testdata/row_level_security
@@ -137,15 +137,13 @@ exec-ddl
 CREATE POLICY r2 on t1 AS RESTRICTIVE USING (true);
 ----
 
-# TODO(136742): We currently only support at most one permissive policy. Update
-# this when we support multiple and restrictive policies.
 plan
 select * from t1
 ----
 • scan
   table: t1@t1_pkey
   spans: FULL SCAN
-  policies: policy 1
+  policies: policy 1, p2, p3, r1, r2
 
 # Show policy information where an index scan is used for one table
 # ----------------------------------------------------------------------
@@ -162,7 +160,7 @@ select t1.c1 from t1, t2 where t1.c1 = t2.c1 and t1.c1 = 1;
 ├── • scan
 │     table: t1@t1_idx
 │     spans: 1+ spans
-│     policies: policy 1
+│     policies: policy 1, p2, p3, r1, r2
 │
 └── • filter
     │ filter: c1 = _
@@ -268,7 +266,7 @@ UPDATE writer SET key = key * 11;
 │ table: writer
 │ set: key
 │ auto commit
-│ policies: p_update1
+│ policies: p_update1, p_update2
 │
 └── • render
     │
@@ -285,7 +283,7 @@ UPDATE writer SET key = key * 15 WHERE value = 'some-val' or value = 'other-val'
 │ table: writer
 │ set: key
 │ auto commit
-│ policies: p_update1
+│ policies: p_update1, p_update2
 │
 └── • render
     │
@@ -304,7 +302,7 @@ UPDATE writer SET value = 'updated' WHERE key between 1 and 100;
 │ table: writer
 │ set: value
 │ auto commit
-│ policies: p_update1
+│ policies: p_update1, p_update2
 │
 └── • render
     │
@@ -321,7 +319,7 @@ UPDATE writer SET value = value WHERE key = 5;
 │ table: writer
 │ set: value
 │ auto commit
-│ policies: p_update1
+│ policies: p_update1, p_update2
 │
 └── • render
     │

--- a/pkg/sql/opt/optbuilder/testdata/row_level_security
+++ b/pkg/sql/opt/optbuilder/testdata/row_level_security
@@ -624,3 +624,100 @@ upsert t1_explicit_pk
       │         └── CASE WHEN c1:9 IS NULL THEN column3:8 ELSE c3:11 END [as=upsert_c3:17]
       └── projections
            └── upsert_c3:17 != '2023-05-02' [as=rls:18]
+
+exec-ddl
+DROP POLICY p_insert ON t1_explicit_pk;
+----
+
+exec-ddl
+DROP POLICY p_update ON t1_explicit_pk;
+----
+
+# Verify multiple policies on a table
+
+exec-ddl
+CREATE POLICY p1 ON t1_explicit_pk AS PERMISSIVE USING (c1 = 1);
+----
+
+exec-ddl
+CREATE POLICY p2 ON t1_explicit_pk AS PERMISSIVE USING (c1 = 2);
+----
+
+exec-ddl
+CREATE POLICY p3 ON t1_explicit_pk AS PERMISSIVE USING (c1 = 3);
+----
+
+exec-ddl
+CREATE POLICY p4 ON t1_explicit_pk AS PERMISSIVE USING (c1 = 4);
+----
+
+exec-ddl
+CREATE POLICY p5 ON t1_explicit_pk AS RESTRICTIVE USING (c1 % 2 = 0);
+----
+
+exec-ddl
+CREATE POLICY p6 ON t1_explicit_pk AS RESTRICTIVE USING (c1 % 3 = 0);
+----
+
+build
+SELECT c2 FROM t1_explicit_pk WHERE c3 >= '2025-01-01';
+----
+project
+ ├── columns: c2:2
+ └── select
+      ├── columns: c1:1!null c2:2 c3:3!null crdb_internal_mvcc_timestamp:4 tableoid:5
+      ├── select
+      │    ├── columns: c1:1!null c2:2 c3:3 crdb_internal_mvcc_timestamp:4 tableoid:5
+      │    ├── scan t1_explicit_pk
+      │    │    └── columns: c1:1!null c2:2 c3:3 crdb_internal_mvcc_timestamp:4 tableoid:5
+      │    └── filters
+      │         └── (((((c1:1 = 1) OR (c1:1 = 2)) OR (c1:1 = 3)) OR (c1:1 = 4)) AND ((c1:1 % 2) = 0)) AND ((c1:1 % 3) = 0)
+      └── filters
+           └── c3:3 >= '2025-01-01'
+
+build
+INSERT INTO t1_explicit_pk VALUES (8, 'eight', '2002-05-04');
+----
+insert t1_explicit_pk
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├── column1:6 => c1:1
+ │    ├── column2:7 => c2:2
+ │    └── column3:8 => c3:3
+ ├── check columns: rls:9
+ └── project
+      ├── columns: rls:9!null column1:6!null column2:7!null column3:8!null
+      ├── values
+      │    ├── columns: column1:6!null column2:7!null column3:8!null
+      │    └── (8, 'eight', '2002-05-04')
+      └── projections
+           └── (((((column1:6 = 1) OR (column1:6 = 2)) OR (column1:6 = 3)) OR (column1:6 = 4)) AND ((column1:6 % 2) = 0)) AND ((column1:6 % 3) = 0) [as=rls:9]
+
+build
+UPDATE t1_explicit_pk SET c3 = now() WHERE c1 = 18;
+----
+update t1_explicit_pk
+ ├── columns: <none>
+ ├── fetch columns: c1:6 c2:7 c3:8
+ ├── update-mapping:
+ │    └── c3_new:11 => c3:3
+ ├── check columns: rls:12
+ └── project
+      ├── columns: rls:12!null c1:6!null c2:7 c3:8 crdb_internal_mvcc_timestamp:9 tableoid:10 c3_new:11
+      ├── project
+      │    ├── columns: c3_new:11 c1:6!null c2:7 c3:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+      │    ├── select
+      │    │    ├── columns: c1:6!null c2:7 c3:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+      │    │    ├── select
+      │    │    │    ├── columns: c1:6!null c2:7 c3:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+      │    │    │    ├── scan t1_explicit_pk
+      │    │    │    │    ├── columns: c1:6!null c2:7 c3:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+      │    │    │    │    └── flags: avoid-full-scan
+      │    │    │    └── filters
+      │    │    │         └── (((((c1:6 = 1) OR (c1:6 = 2)) OR (c1:6 = 3)) OR (c1:6 = 4)) AND ((c1:6 % 2) = 0)) AND ((c1:6 % 3) = 0)
+      │    │    └── filters
+      │    │         └── c1:6 = 18
+      │    └── projections
+      │         └── now() [as=c3_new:11]
+      └── projections
+           └── (((((c1:6 = 1) OR (c1:6 = 2)) OR (c1:6 = 3)) OR (c1:6 = 4)) AND ((c1:6 % 2) = 0)) AND ((c1:6 % 3) = 0) [as=rls:12]


### PR DESCRIPTION
Previously, row-level security (RLS) tables only ever enforced one policy. This change allows multiple policies to be applied.

When multiple policies exist, their type determines how they are combined:
- Permissive policies are combined using OR
- Restrictive policies are combined using AND
- At least one permissive policy is required; otherwise, the table is treated as deny-all (all rows are filtered out, or all new rows are rejected).

The change affects both the filtering of existing rows (USING expression) and constraints on new rows (WITH CHECK expression).

Epic: CRDB-45203
Release note: none
Informs #136742