### PR TITLE
changefeedccl: increase random queries generated in changefeed test

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -1262,7 +1262,7 @@ func TestChangefeedRandomExpressions(t *testing.T) {
 		require.NoError(t, err)
 		defer queryGen.Close()
 		numNonTrivialTestRuns := 0
-		n := 100
+		n := 150
 		whereClausesChecked := make(map[string]struct{}, n)
 		for i := 0; i < n; i++ {
 			query := queryGen.Generate()
@@ -1345,7 +1345,7 @@ func TestChangefeedRandomExpressions(t *testing.T) {
 			}
 			numNonTrivialTestRuns++
 		}
-		require.Greater(t, numNonTrivialTestRuns, 1)
+		require.Greater(t, numNonTrivialTestRuns, 0, "Expected >0 predicates to be nontrivial out of %d attempts", n)
 		t.Logf("%d predicates checked: all had the same result in SELECT and CHANGEFEED", numNonTrivialTestRuns)
 
 	}


### PR DESCRIPTION
This change increases the number of attempts at testing a non-trivial query by 50% and now checks that there is at least 1 non-trivial test in order to reduce flakiness.

Epic: none
Fixes: #142383

Release note: none