### PR TITLE
row, sql: implement mutations on vector indexes

### DIFF
--- a/pkg/crosscluster/logical/lww_kv_processor.go
+++ b/pkg/crosscluster/logical/lww_kv_processor.go
@@ -476,13 +476,15 @@ func (p *kvTableWriter) insertRow(ctx context.Context, b *kv.Batch, after cdceve
 
 	var ph row.PartialIndexUpdateHelper
 	// TODO(dt): support partial indexes.
+	var vh row.VectorIndexUpdateHelper
+	// TODO(mw5h, drewk): support vector indexes.
 	oth := &row.OriginTimestampCPutHelper{
 		OriginTimestamp: after.MvccTimestamp,
 		// TODO(ssd): We should choose this based by comparing the cluster IDs of the source
 		// and destination clusters.
 		// ShouldWinTie: true,
 	}
-	return p.ri.InsertRow(ctx, &row.KVBatchAdapter{Batch: b}, p.newVals, ph, oth, row.CPutOp, false /* traceKV */)
+	return p.ri.InsertRow(ctx, &row.KVBatchAdapter{Batch: b}, p.newVals, ph, vh, oth, row.CPutOp, false /* traceKV */)
 }
 
 func (p *kvTableWriter) updateRow(
@@ -497,13 +499,15 @@ func (p *kvTableWriter) updateRow(
 
 	var ph row.PartialIndexUpdateHelper
 	// TODO(dt): support partial indexes.
+	var vh row.VectorIndexUpdateHelper
+	// TODO(mw5h, drewk): support vector indexes.
 	oth := &row.OriginTimestampCPutHelper{
 		OriginTimestamp: after.MvccTimestamp,
 		// TODO(ssd): We should choose this based by comparing the cluster IDs of the source
 		// and destination clusters.
 		// ShouldWinTie: true,
 	}
-	_, err := p.ru.UpdateRow(ctx, b, p.oldVals, p.newVals, ph, oth, false)
+	_, err := p.ru.UpdateRow(ctx, b, p.oldVals, p.newVals, ph, vh, oth, false)
 	return err
 }
 
@@ -516,6 +520,8 @@ func (p *kvTableWriter) deleteRow(
 
 	var ph row.PartialIndexUpdateHelper
 	// TODO(dt): support partial indexes.
+	var vh row.VectorIndexUpdateHelper
+	// TODO(mw5h, drewk): support vector indexes.
 	oth := &row.OriginTimestampCPutHelper{
 		PreviousWasDeleted: before.IsDeleted(),
 		OriginTimestamp:    after.MvccTimestamp,
@@ -524,7 +530,7 @@ func (p *kvTableWriter) deleteRow(
 		// ShouldWinTie: true,
 	}
 
-	return p.rd.DeleteRow(ctx, b, p.oldVals, ph, oth, false)
+	return p.rd.DeleteRow(ctx, b, p.oldVals, ph, vh, oth, false)
 }
 
 func (p *kvTableWriter) fillOld(vals cdcevent.Row) error {

--- a/pkg/sql/backfill/backfill.go
+++ b/pkg/sql/backfill/backfill.go
@@ -398,12 +398,13 @@ func (cb *ColumnBackfiller) RunColumnBackfillChunk(
 		}
 		copy(oldValues, fetchedValues)
 
-		// No existing secondary indexes will be updated by adding or dropping a
-		// column. It is safe to use an empty PartialIndexUpdateHelper in this
-		// case.
+		// No existing secondary indexes will be updated by adding or dropping a column.
+		// It is safe to use an empty PartialIndexUpdateHelper and
+		// VectorIndexUpdateHelper in this case.
 		var pm row.PartialIndexUpdateHelper
+		var vh row.VectorIndexUpdateHelper
 		if _, err := ru.UpdateRow(
-			ctx, b, oldValues, updateValues, pm, nil, traceKV,
+			ctx, b, oldValues, updateValues, pm, vh, nil, traceKV,
 		); err != nil {
 			return roachpb.Key{}, err
 		}

--- a/pkg/sql/colenc/encode.go
+++ b/pkg/sql/colenc/encode.go
@@ -432,6 +432,11 @@ func (b *BatchEncoder) encodeSecondaryIndex(ctx context.Context, ind catalog.Ind
 		// Since the inverted indexes generate multiple keys per row just handle them
 		// separately.
 		return b.encodeInvertedSecondaryIndex(ctx, ind, kys, b.extraKeys)
+	} else if ind.GetType() == idxtype.VECTOR {
+		// TODO(mw5h, drewk): Implement encoding for vector indexes. This is complicated
+		// by vector indexes needing output from the mutation search operator, which will
+		// need to be plumbed through to the encoder.
+		return errors.AssertionFailedf("vector indexes not supported")
 	} else {
 		keyAndSuffixCols := b.rh.TableDesc.IndexFetchSpecKeyAndSuffixColumns(ind)
 		keyCols := keyAndSuffixCols[:ind.NumKeyColumns()]

--- a/pkg/sql/colenc/encode_test.go
+++ b/pkg/sql/colenc/encode_test.go
@@ -606,8 +606,9 @@ func buildRowKVs(
 	}
 	p := &capturePutter{}
 	var pm row.PartialIndexUpdateHelper
+	var vh row.VectorIndexUpdateHelper
 	for _, d := range datums {
-		if err := inserter.InsertRow(context.Background(), p, d, pm, nil, row.CPutOp, true /* traceKV */); err != nil {
+		if err := inserter.InsertRow(context.Background(), p, d, pm, vh, nil, row.CPutOp, true /* traceKV */); err != nil {
 			return kvs{}, err
 		}
 	}

--- a/pkg/sql/copy_from.go
+++ b/pkg/sql/copy_from.go
@@ -418,6 +418,10 @@ func (c *copyMachine) canSupportVectorized(table catalog.TableDescriptor) bool {
 	if c.p.SessionData().VectorizeMode == sessiondatapb.VectorizeOff {
 		return false
 	}
+	// Columnar vector index encoding is not yet supported.
+	if len(table.VectorIndexes()) > 0 {
+		return false
+	}
 	// Vectorized COPY doesn't support foreign key checks, no reason it couldn't
 	// but it doesn't work right now because we don't have the ability to
 	// hold the results in a bufferNode. We wouldn't want to enable it

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -612,11 +612,12 @@ func (n *createTableNode) startExec(params runParams) error {
 				// Populate the buffer.
 				copy(rowBuffer, n.input.Values())
 
-				// CREATE TABLE AS does not copy indexes from the input table.
-				// An empty row.PartialIndexUpdateHelper is used here because
-				// there are no indexes, partial or otherwise, to update.
+				// CREATE TABLE AS does not copy indexes from the input table. Empty
+				// partial and vector index helpers are used here because there are no
+				// indexes, partial, vector, or otherwise, to update.
 				var pm row.PartialIndexUpdateHelper
-				if err := ti.row(params.ctx, rowBuffer, pm, params.extendedEvalCtx.Tracing.KVTracingEnabled()); err != nil {
+				var vh row.VectorIndexUpdateHelper
+				if err := ti.row(params.ctx, rowBuffer, pm, vh, params.extendedEvalCtx.Tracing.KVTracingEnabled()); err != nil {
 					return err
 				}
 			}

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -4622,7 +4622,8 @@ func (dsp *DistSQLPlanner) planVectorMutationSearch(
 		suffixKeyColumnOrdinals[i] = uint32(p.PlanToStreamColMap[col])
 	}
 	keyAndSuffixCols := planInfo.table.IndexFetchSpecKeyAndSuffixColumns(planInfo.index)
-	prefixKeyCols := keyAndSuffixCols[planInfo.index.NumKeyColumns()-1:]
+	// Prefix cols do not include the vector column, which is the last key column.
+	prefixKeyCols := keyAndSuffixCols[:planInfo.index.NumKeyColumns()-1]
 	suffixKeyCols := keyAndSuffixCols[planInfo.index.NumKeyColumns():]
 	spec := &execinfrapb.VectorMutationSearchSpec{
 		PrefixKeyColumnOrdinals:  prefixKeyColumnOrdinals,

--- a/pkg/sql/opt/exec/execbuilder/testdata/vector_mutation
+++ b/pkg/sql/opt/exec/execbuilder/testdata/vector_mutation
@@ -1,0 +1,83 @@
+# LogicTest: local
+
+statement ok
+CREATE TABLE exec_test (
+  id INT PRIMARY KEY,
+  user_id INT,
+  data STRING COLLATE en_US_u_ks_level2,
+  encoding VECTOR(3),
+  VECTOR INDEX simple (encoding),
+  VECTOR INDEX prefix (user_id, encoding),
+  VECTOR INDEX composite_prefix (data, encoding),
+  FAMILY fam_id_uid_d_enc (id, user_id, data, encoding)
+)
+
+statement ok
+CREATE INDEX ON exec_test (user_id) WHERE user_id >= 10 AND user_id <= 20
+
+query T kvtrace(redactbytes)
+INSERT INTO exec_test VALUES (1, 1, 'foo', '[1, 2, 3]'), (2, 10, 'bar', '[4, 5, 6]'), (3, 15, 'baz', '[7, 8, 9]')
+----
+CPut /Table/106/1/1/0 -> /TUPLE/2:2:Int/1/1:3:Bytes/foo/
+CPut /Table/106/2/1/1/0 -> /BYTES/:redacted:
+CPut /Table/106/3/1/1/1/0 -> /BYTES/:redacted:
+CPut /Table/106/4/"\x16\x84\x17q\x17q\x00\x00\x00 \x00 \x00 "/1/1/0 -> /BYTES/:redacted:
+CPut /Table/106/1/2/0 -> /TUPLE/2:2:Int/10/1:3:Bytes/bar/
+CPut /Table/106/2/1/2/0 -> /BYTES/:redacted:
+CPut /Table/106/3/10/1/2/0 -> /BYTES/:redacted:
+CPut /Table/106/4/"\x16\x05\x15\xef\x17\xbd\x00\x00\x00 \x00 \x00 "/1/2/0 -> /BYTES/:redacted:
+CPut /Table/106/5/10/2/0 -> /BYTES/
+CPut /Table/106/1/3/0 -> /TUPLE/2:2:Int/15/1:3:Bytes/baz/
+CPut /Table/106/2/1/3/0 -> /BYTES/:redacted:
+CPut /Table/106/3/15/1/3/0 -> /BYTES/:redacted:
+CPut /Table/106/4/"\x16\x05\x15\xef\x18\x95\x00\x00\x00 \x00 \x00 "/1/3/0 -> /BYTES/:redacted:
+CPut /Table/106/5/15/3/0 -> /BYTES/
+
+query T kvtrace(redactbytes)
+UPSERT INTO exec_test VALUES (2, 10, 'bar', '[6, 5, 4]'), (4, 20, 'qux', '[10, 11, 12]')
+----
+Scan /Table/106/1/2/0, /Table/106/1/4/0
+Put /Table/106/1/2/0 -> /TUPLE/2:2:Int/10/1:3:Bytes/bar/
+Del (locking) /Table/106/2/1/2/0
+CPut /Table/106/2/1/2/0 -> /BYTES/:redacted:
+Del (locking) /Table/106/3/10/1/2/0
+CPut /Table/106/3/10/1/2/0 -> /BYTES/:redacted:
+Del (locking) /Table/106/4/"\x16\x05\x15\xef\x17\xbd\x00\x00\x00 \x00 \x00 "/1/2/0
+CPut /Table/106/4/"\x16\x05\x15\xef\x17\xbd\x00\x00\x00 \x00 \x00 "/1/2/0 -> /BYTES/:redacted:
+CPut /Table/106/1/4/0 -> /TUPLE/2:2:Int/20/1:3:Bytes/qux/
+CPut /Table/106/2/1/4/0 -> /BYTES/:redacted:
+CPut /Table/106/3/20/1/4/0 -> /BYTES/:redacted:
+CPut /Table/106/4/"\x17\xab\x186\x18{\x00\x00\x00 \x00 \x00 "/1/4/0 -> /BYTES/:redacted:
+CPut /Table/106/5/20/4/0 -> /BYTES/
+
+query T kvtrace(redactbytes)
+UPDATE exec_test SET encoding = '[3, 2, 1]' WHERE id = 1
+----
+Scan /Table/106/1/1/0
+Put /Table/106/1/1/0 -> /TUPLE/2:2:Int/1/1:3:Bytes/foo/
+Del (locking) /Table/106/2/1/1/0
+CPut /Table/106/2/1/1/0 -> /BYTES/:redacted:
+Del (locking) /Table/106/3/1/1/1/0
+CPut /Table/106/3/1/1/1/0 -> /BYTES/:redacted:
+Del (locking) /Table/106/4/"\x16\x84\x17q\x17q\x00\x00\x00 \x00 \x00 "/1/1/0
+CPut /Table/106/4/"\x16\x84\x17q\x17q\x00\x00\x00 \x00 \x00 "/1/1/0 -> /BYTES/:redacted:
+
+query T kvtrace(redactbytes)
+UPDATE exec_test SET data = 'fooo' WHERE user_id = 15;
+----
+Scan /Table/106/5/1{5-6}
+Scan /Table/106/1/3/0
+Put /Table/106/1/3/0 -> /TUPLE/2:2:Int/15/1:3:Bytes/fooo/
+Del (locking) /Table/106/4/"\x16\x05\x15\xef\x18\x95\x00\x00\x00 \x00 \x00 "/1/3/0
+CPut /Table/106/4/"\x16\x84\x17q\x17q\x17q\x00\x00\x00 \x00 \x00 \x00 "/1/3/0 -> /BYTES/:redacted:
+
+query T kvtrace
+DELETE FROM exec_test WHERE user_id = 10
+----
+Scan /Table/106/5/1{0-1}
+Scan /Table/106/1/2/0
+Del /Table/106/2/1/2/0
+Del /Table/106/3/10/1/2/0
+Del /Table/106/4/"\x16\x05\x15\xef\x17\xbd\x00\x00\x00 \x00 \x00 "/1/2/0
+Del /Table/106/5/10/2/0
+Del (locking) /Table/106/1/2/0

--- a/pkg/sql/opt/exec/execbuilder/tests/local/generated_test.go
+++ b/pkg/sql/opt/exec/execbuilder/tests/local/generated_test.go
@@ -687,6 +687,13 @@ func TestExecBuild_values(
 	runExecBuildLogicTest(t, "values")
 }
 
+func TestExecBuild_vector_mutation(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runExecBuildLogicTest(t, "vector_mutation")
+}
+
 func TestExecBuild_vector_search(
 	t *testing.T,
 ) {

--- a/pkg/sql/row/BUILD.bazel
+++ b/pkg/sql/row/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "row_converter.go",
         "truncate.go",
         "updater.go",
+        "vector_index.go",
         "writer.go",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/row",

--- a/pkg/sql/row/deleter.go
+++ b/pkg/sql/row/deleter.go
@@ -133,6 +133,7 @@ func (rd *Deleter) DeleteRow(
 	batch *kv.Batch,
 	values []tree.Datum,
 	pm PartialIndexUpdateHelper,
+	vh VectorIndexUpdateHelper,
 	oth *OriginTimestampCPutHelper,
 	traceKV bool,
 ) error {
@@ -154,7 +155,7 @@ func (rd *Deleter) DeleteRow(
 			index,
 			rd.FetchColIDtoRowIndex,
 			values,
-			rowenc.EmptyVectorIndexEncodingHelper,
+			vh.GetDel(),
 			true, /* includeEmpty */
 		)
 		if err != nil {

--- a/pkg/sql/row/helper.go
+++ b/pkg/sql/row/helper.go
@@ -156,6 +156,7 @@ func (rh *RowHelper) encodeIndexes(
 	ctx context.Context,
 	colIDtoRowPosition catalog.TableColMap,
 	values []tree.Datum,
+	vh rowenc.VectorIndexEncodingHelper,
 	ignoreIndexes intsets.Fast,
 	includeEmpty bool,
 ) (
@@ -167,7 +168,9 @@ func (rh *RowHelper) encodeIndexes(
 	if err != nil {
 		return nil, nil, err
 	}
-	secondaryIndexEntries, err = rh.encodeSecondaryIndexes(ctx, colIDtoRowPosition, values, ignoreIndexes, includeEmpty)
+	secondaryIndexEntries, err = rh.encodeSecondaryIndexes(
+		ctx, colIDtoRowPosition, values, vh, ignoreIndexes, includeEmpty,
+	)
 	if err != nil {
 		return nil, nil, err
 	}
@@ -310,6 +313,7 @@ func (rh *RowHelper) encodeSecondaryIndexes(
 	ctx context.Context,
 	colIDtoRowPosition catalog.TableColMap,
 	values []tree.Datum,
+	vh rowenc.VectorIndexEncodingHelper,
 	ignoreIndexes intsets.Fast,
 	includeEmpty bool,
 ) (secondaryIndexEntries map[catalog.Index][]rowenc.IndexEntry, err error) {
@@ -332,7 +336,7 @@ func (rh *RowHelper) encodeSecondaryIndexes(
 				index,
 				colIDtoRowPosition,
 				values,
-				rowenc.EmptyVectorIndexEncodingHelper,
+				vh,
 				includeEmpty,
 			)
 			if err != nil {

--- a/pkg/sql/row/inserter.go
+++ b/pkg/sql/row/inserter.go
@@ -170,6 +170,7 @@ func (ri *Inserter) InsertRow(
 	b Putter,
 	values []tree.Datum,
 	pm PartialIndexUpdateHelper,
+	vh VectorIndexUpdateHelper,
 	oth *OriginTimestampCPutHelper,
 	kvOp KVInsertOp,
 	traceKV bool,
@@ -191,7 +192,7 @@ func (ri *Inserter) InsertRow(
 	// We don't want to insert empty k/v's like this, so we
 	// set includeEmpty to false.
 	primaryIndexKey, secondaryIndexEntries, err := ri.Helper.encodeIndexes(
-		ctx, ri.InsertColIDtoRowIndex, values, pm.IgnoreForPut, false, /* includeEmpty */
+		ctx, ri.InsertColIDtoRowIndex, values, vh.GetPut(), pm.IgnoreForPut, false, /* includeEmpty */
 	)
 	if err != nil {
 		return err

--- a/pkg/sql/row/row_converter.go
+++ b/pkg/sql/row/row_converter.go
@@ -578,11 +578,16 @@ func (c *DatumRowConverter) Row(ctx context.Context, sourceID int32, rowIndex in
 		c.EvalCtx.PopIVarContainer()
 	}
 
+	// TODO(mw5h, drewk): call into the vector index library to determine the partitions
+	// to update.
+	var vh VectorIndexUpdateHelper
+
 	if err := c.ri.InsertRow(
 		ctx,
 		c.kvInserter,
 		insertRow,
 		pm,
+		vh,
 		nil, /* OriginTimestampCPutHelper */
 		PutOp,
 		false, /* traceKV */

--- a/pkg/sql/row/vector_index.go
+++ b/pkg/sql/row/vector_index.go
@@ -1,0 +1,112 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package row
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+)
+
+// VectorIndexUpdateHelper keeps track of the information needed to encode put
+// and del operations on vector indexes.
+//
+// Forward and inverted indexes produce the index encoding directly from the
+// value itself. Vector indexes, however, require a vector search to determine
+// which partition "owns" the vector. The partition is not stored as a table
+// column, and an indexed vector can move to a new partition in the background
+// via index maintenance operations.
+//
+// For an index put operation, VectorIndexUpdateHelper stores the key of the
+// partition to be updated for each vector index on the table, as well as the
+// quantized vector. For an index del, it stores only the partition key. It can
+// handle both put and del operations simultaneously (e.g. for an UPDATE).
+type VectorIndexUpdateHelper struct {
+	// PutPartitionKeys indicates the target vector index partitions for an index
+	// put operation. Null values indicate a no-op.
+	PutPartitionKeys map[descpb.IndexID]tree.Datum
+	// PutQuantizedVecs contains the quantized and encoded vectors that will be
+	// used as the values for the index put operations. An entry should only be
+	// null if the corresponding partition key is null.
+	PutQuantizedVecs map[descpb.IndexID]tree.Datum
+	// PutPartitionKeys indicates the target vector index partitions for an index
+	// del operation. Null values indicate a no-op.
+	DelPartitionKeys map[descpb.IndexID]tree.Datum
+}
+
+func (vm *VectorIndexUpdateHelper) GetPut() rowenc.VectorIndexEncodingHelper {
+	return rowenc.VectorIndexEncodingHelper{
+		PartitionKeys: vm.PutPartitionKeys,
+		QuantizedVecs: vm.PutQuantizedVecs,
+	}
+}
+
+func (vm *VectorIndexUpdateHelper) GetDel() rowenc.VectorIndexEncodingHelper {
+	return rowenc.VectorIndexEncodingHelper{PartitionKeys: vm.DelPartitionKeys}
+}
+
+// InitForPut initializes a VectorIndexUpdateHelper to track vector index
+// partitions and quantized vectors for use in encoding index puts. It can be
+// used in conjunction with InitForDel to handle both put and del operations.
+func (vm *VectorIndexUpdateHelper) InitForPut(
+	putPartitionKeys, putQuantizedVecs tree.Datums, tabDesc catalog.TableDescriptor,
+) {
+	// Clear the Put maps to remove entries from previous iterations.
+	clear(vm.PutPartitionKeys)
+	clear(vm.PutQuantizedVecs)
+	vm.initImpl(putPartitionKeys, putQuantizedVecs, nil /* delPartitionKeys */, tabDesc)
+}
+
+// InitForDel initializes a VectorIndexUpdateHelper to track vector index
+// partitions for use in encoding index deletes. It can be used in conjunction
+// with InitForPut to handle both put and del operations.
+func (vm *VectorIndexUpdateHelper) InitForDel(
+	delPartitionKeys tree.Datums, tabDesc catalog.TableDescriptor,
+) {
+	// Clear the Del map to remove entries from previous iterations.
+	clear(vm.DelPartitionKeys)
+	vm.initImpl(nil /* putPartitionKeys */, nil /* putQuantizedVecs */, delPartitionKeys, tabDesc)
+}
+
+func (vm *VectorIndexUpdateHelper) initImpl(
+	putPartitionKeys, putQuantizedVecs, delPartitionKeys tree.Datums, tabDesc catalog.TableDescriptor,
+) {
+	valIdx := 0
+	for _, idx := range tabDesc.VectorIndexes() {
+		// Retrieve the partition key value, if it exists.
+		if valIdx < len(putPartitionKeys) {
+			if vm.PutPartitionKeys == nil {
+				vm.PutPartitionKeys = make(map[descpb.IndexID]tree.Datum)
+			}
+			if putPartitionKeys[valIdx] != tree.DNull {
+				vm.PutPartitionKeys[idx.GetID()] = putPartitionKeys[valIdx]
+			}
+		}
+
+		// Retrieve the quantized vector, if it exists.
+		if valIdx < len(putQuantizedVecs) {
+			if vm.PutQuantizedVecs == nil {
+				vm.PutQuantizedVecs = make(map[descpb.IndexID]tree.Datum)
+			}
+			if putQuantizedVecs[valIdx] != tree.DNull {
+				vm.PutQuantizedVecs[idx.GetID()] = putQuantizedVecs[valIdx]
+			}
+		}
+
+		// Retrieve the partition key value for delete, if it exists.
+		if valIdx < len(delPartitionKeys) {
+			if vm.DelPartitionKeys == nil {
+				vm.DelPartitionKeys = make(map[descpb.IndexID]tree.Datum)
+			}
+			if delPartitionKeys[valIdx] != tree.DNull {
+				vm.DelPartitionKeys[idx.GetID()] = delPartitionKeys[valIdx]
+			}
+		}
+
+		valIdx++
+	}
+}

--- a/pkg/sql/rowenc/index_encoding.go
+++ b/pkg/sql/rowenc/index_encoding.go
@@ -1449,6 +1449,7 @@ func encodeSecondaryIndexWithKeyPrefix(
 
 		if tableDesc.NumFamilies() == 1 ||
 			secondaryIndex.GetType() == idxtype.INVERTED ||
+			secondaryIndex.GetType() == idxtype.VECTOR ||
 			secondaryIndex.GetVersion() == descpb.BaseIndexFormatVersion {
 			// We do all computation that affects indexes with families in a separate
 			// code path to avoid performance regression for tables without column

--- a/pkg/sql/rowexec/vector_search.go
+++ b/pkg/sql/rowexec/vector_search.go
@@ -205,7 +205,7 @@ func newVectorMutationSearchProcessor(
 		prefixKeyColOrds:  spec.PrefixKeyColumnOrdinals,
 		prefixKeyCols:     spec.PrefixKeyColumns,
 		queryVectorColOrd: int(spec.QueryVectorColumnOrdinal),
-		suffixKeyColOrds:  spec.PrefixKeyColumnOrdinals,
+		suffixKeyColOrds:  spec.SuffixKeyColumnOrdinals,
 		suffixKeyCols:     spec.SuffixKeyColumns,
 		isIndexPut:        spec.IsIndexPut,
 	}

--- a/pkg/sql/tablewriter_delete.go
+++ b/pkg/sql/tablewriter_delete.go
@@ -39,15 +39,24 @@ func (td *tableDeleter) init(_ context.Context, txn *kv.Txn, evalCtx *eval.Conte
 // to avoid updating when performing row modification. This is necessary
 // because not all rows are indexed by partial indexes.
 //
+// The VectorIndexUpdateHelper is used to determine which partitions to update
+// in each vector index. This is necessary because these values are not part
+// of the table, and are materialized only for the purpose of updating vector
+// indexes.
+//
 // The traceKV parameter determines whether the individual K/V operations
 // should be logged to the context. We use a separate argument here instead
 // of a Value field on the context because Value access in context.Context
 // is rather expensive.
 func (td *tableDeleter) row(
-	ctx context.Context, values tree.Datums, pm row.PartialIndexUpdateHelper, traceKV bool,
+	ctx context.Context,
+	values tree.Datums,
+	pm row.PartialIndexUpdateHelper,
+	vh row.VectorIndexUpdateHelper,
+	traceKV bool,
 ) error {
 	td.currentBatchSize++
-	return td.rd.DeleteRow(ctx, td.b, values, pm, nil, traceKV)
+	return td.rd.DeleteRow(ctx, td.b, values, pm, vh, nil, traceKV)
 }
 
 // deleteIndex runs the kv operations necessary to delete all kv entries in the

--- a/pkg/sql/tablewriter_insert.go
+++ b/pkg/sql/tablewriter_insert.go
@@ -34,15 +34,24 @@ func (ti *tableInserter) init(_ context.Context, txn *kv.Txn, evalCtx *eval.Cont
 // to avoid updating when performing row modification. This is necessary
 // because not all rows are indexed by partial indexes.
 //
+// The VectorIndexUpdateHelper is used to determine which partitions to update
+// in each vector index and supply the quantized vectors to add to the
+// partitions. This is necessary because these values are not part of the table,
+// and are materialized only for the purpose of updating vector indexes.
+//
 // The traceKV parameter determines whether the individual K/V operations
 // should be logged to the context. We use a separate argument here instead
 // of a Value field on the context because Value access in context.Context
 // is rather expensive.
 func (ti *tableInserter) row(
-	ctx context.Context, values tree.Datums, pm row.PartialIndexUpdateHelper, traceKV bool,
+	ctx context.Context,
+	values tree.Datums,
+	pm row.PartialIndexUpdateHelper,
+	vh row.VectorIndexUpdateHelper,
+	traceKV bool,
 ) error {
 	ti.currentBatchSize++
-	return ti.ri.InsertRow(ctx, &ti.putter, values, pm, nil, row.CPutOp, traceKV)
+	return ti.ri.InsertRow(ctx, &ti.putter, values, pm, vh, nil, row.CPutOp, traceKV)
 }
 
 // tableDesc returns the TableDescriptor for the table that the tableInserter

--- a/pkg/sql/tablewriter_update.go
+++ b/pkg/sql/tablewriter_update.go
@@ -34,6 +34,11 @@ func (tu *tableUpdater) init(_ context.Context, txn *kv.Txn, evalCtx *eval.Conte
 // to avoid updating when performing row modification. This is necessary
 // because not all rows are indexed by partial indexes.
 //
+// The VectorIndexUpdateHelper is used to determine which partitions to update
+// in each vector index and supply the quantized vectors to add to the
+// partitions. This is necessary because these values are not part of the table,
+// and are materialized only for the purpose of updating vector indexes.
+//
 // The traceKV parameter determines whether the individual K/V operations
 // should be logged to the context. We use a separate argument here instead
 // of a Value field on the context because Value access in context.Context
@@ -42,10 +47,11 @@ func (tu *tableUpdater) rowForUpdate(
 	ctx context.Context,
 	oldValues, updateValues tree.Datums,
 	pm row.PartialIndexUpdateHelper,
+	vh row.VectorIndexUpdateHelper,
 	traceKV bool,
 ) (tree.Datums, error) {
 	tu.currentBatchSize++
-	return tu.ru.UpdateRow(ctx, tu.b, oldValues, updateValues, pm, nil, traceKV)
+	return tu.ru.UpdateRow(ctx, tu.b, oldValues, updateValues, pm, vh, nil, traceKV)
 }
 
 // tableDesc returns the TableDescriptor for the table that the tableUpdater

--- a/pkg/sql/vecindex/BUILD.bazel
+++ b/pkg/sql/vecindex/BUILD.bazel
@@ -24,6 +24,7 @@ go_library(
         "//pkg/sql/vecindex/cspann/quantize",
         "//pkg/sql/vecindex/vecpb",
         "//pkg/sql/vecindex/vecstore",
+        "//pkg/util/buildutil",
         "//pkg/util/log",
         "//pkg/util/metric",
         "//pkg/util/stop",

--- a/pkg/sql/vecindex/manager.go
+++ b/pkg/sql/vecindex/manager.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/vecindex/cspann/quantize"
 	"github.com/cockroachdb/cockroach/pkg/sql/vecindex/vecpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/vecindex/vecstore"
+	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
@@ -196,6 +197,13 @@ func (m *Manager) getVecConfig(
 	config := idxDesc.GetVecConfig()
 	if config.Dims <= 0 {
 		return vecpb.Config{}, errInvalidVecConfig
+	}
+	// TODO(mw5h, drewk): this should be a session setting in create index rather
+	// than an override like this.
+	if buildutil.CrdbTestBuild {
+		// This is a test build, so let's use a fixed seed for the random projection to
+		// avoid test flakes.
+		config.Seed = 0xdeadcafe
 	}
 	return config, nil
 }


### PR DESCRIPTION
This patch plumbs the output of the vector search operators into rowenc for encoding into vector indexes. The output of these vector search operators is included in the row values for mutation operators after partial index values and are plumbed into a new vector index update helper, which tracks the column values until they're needed by rowenc.

While we're here, we homogonize how
pkg/sql/{delete,insert,update,upsert}.go consume row values, hopefully improving legibility.

Epic: CRDB-42943
Release note: None