### PR TITLE
sql/schemachanger: avoid retries on invalid expressions during backfills

### DIFF
--- a/pkg/sql/backfill/BUILD.bazel
+++ b/pkg/sql/backfill/BUILD.bazel
@@ -31,6 +31,7 @@ go_library(
         "//pkg/sql/row",
         "//pkg/sql/rowenc",
         "//pkg/sql/rowinfra",
+        "//pkg/sql/schemachanger/scerrors",
         "//pkg/sql/sem/catid",
         "//pkg/sql/sem/eval",
         "//pkg/sql/sem/idxtype",

--- a/pkg/sql/backfill/backfill.go
+++ b/pkg/sql/backfill/backfill.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/row"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowinfra"
+	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scerrors"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/catid"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/idxtype"
@@ -912,6 +913,12 @@ func (ib *IndexBackfiller) BuildIndexEntriesChunk(
 					// Cannot use expressions that depend on the transaction of the
 					// evaluation context as the default value for backfill.
 					err = pgerror.WithCandidateCode(err, pgcode.FeatureNotSupported)
+				}
+				// Explicitly mark with user errors for codes that we know
+				// cannot be retried.
+				if code := pgerror.GetPGCode(err); code == pgcode.FeatureNotSupported ||
+					code == pgcode.InvalidParameterValue {
+					return scerrors.SchemaChangerUserError(err)
 				}
 				return err
 			}

--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -4462,3 +4462,20 @@ ALTER TABLE alter_table_alter_primary_key_duplicate_storage_params_a
   WITH (bucket_count=30, bucket_count=20);
 
 subtest end
+
+
+# Regression test for #141352, which would previously happen
+# when adding a column with an invalid geometry expression.
+subtest alter_table_add_column_with_invalid_geometry_expression
+
+
+statement ok
+CREATE TABLE alter_table_add_column_with_invalid_geometry_expression (
+  id INT PRIMARY KEY
+);
+INSERT INTO alter_table_add_column_with_invalid_geometry_expression VALUES (1);
+
+statement error pgcode 22023 pq: failed to construct index entries during backfill: error parsing EWKB: unexpected EOF
+ALTER TABLE alter_table_add_column_with_invalid_geometry_expression ADD COLUMN geom GEOMETRY NULL DEFAULT x'001a'
+
+subtest end

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -214,6 +214,12 @@ func IsPermanentSchemaChangeError(err error) bool {
 		return true
 	}
 
+	// Any error with a schema changer user error wrapper on it should not be
+	// retried.
+	if scerrors.HasSchemaChangerUserError(err) {
+		return true
+	}
+
 	if grpcutil.IsClosedConnection(err) {
 		return false
 	}

--- a/pkg/sql/schemachanger/scerrors/errors.go
+++ b/pkg/sql/schemachanger/scerrors/errors.go
@@ -207,7 +207,9 @@ func (e *schemaChangerUserError) SafeFormatError(p errors.Printer) (next error) 
 }
 
 func (e *schemaChangerUserError) Error() string {
-	return fmt.Sprintf("schema change operation encountered an error: %v", e.err)
+	// We don't want to print the schemaChangerUserError wrapper in the error,
+	// this only serves as a marker to the declarative schema changer to surface.
+	return fmt.Sprintf("%v", e.err)
 }
 
 func (e *schemaChangerUserError) Unwrap() error {


### PR DESCRIPTION
Currently, the schema changer uses a white list to determine which errors to be retired, which in some cases use a text comparison. Unfortunately, when we parse expressions their text can appear in the error and cause errors to be erroneously retried for backfills. To address this, this patch explicitly wraps errors from eval.Expr with SchemaChangerUserError to block retries.

Fixes: #141352

Release note (bug fix): Invalid default expressions could cause backfilling schema changes to retry forever