### PR TITLE
raft: distinguish LogSlice and LeadSlice

### DIFF
--- a/pkg/kv/kvserver/kvflowcontrol/rac2/range_controller.go
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/range_controller.go
@@ -166,7 +166,7 @@ type RaftInterface interface {
 	//
 	// If it returns true, all the entries in the slice are in the message, and
 	// Next is advanced to be equal to end.
-	SendMsgAppRaftMuLocked(replicaID roachpb.ReplicaID, slice raft.LogSlice) (raftpb.Message, bool)
+	SendMsgAppRaftMuLocked(replicaID roachpb.ReplicaID, slice raft.LeadSlice) (raftpb.Message, bool)
 }
 
 // RaftMsgAppMode specifies how Raft (at the leader) generates MsgApps. In
@@ -2630,7 +2630,7 @@ func (rs *replicaState) scheduledRaftMuLocked(
 	// replication AC in pull mode, and a send-queue forms, and these entries
 	// are > 4KiB, we will empty the send-queue one entry at a time.
 	// Specifically, we will only deduct 4KiB of tokens, since the approx size
-	// of the send-queue will be zero. Then we will call LogSlice with
+	// of the send-queue will be zero. Then we will call LeadSlice with
 	// maxSize=4KiB, which will return one entry. And then we will repeat. If
 	// this is a real problem, we can fix this by keeping track of not just the
 	// preciseSizeSum of tokens needed, but also the size sum of these entries.
@@ -2648,7 +2648,7 @@ func (rs *replicaState) scheduledRaftMuLocked(
 	// and elastic work, and MsgAppPull mode, in which case the total size of
 	// entries not subject to flow control will be tiny. We of course return the
 	// unused tokens for entries not subject to flow control.
-	slice, err := logSnapshot.LogSlice(
+	slice, err := logSnapshot.LeadSlice(
 		rss.mu.sendQueue.indexToSend-1, rss.mu.sendQueue.nextRaftIndex-1, uint64(bytesToSend))
 	var msg raftpb.Message
 	if err == nil {
@@ -2904,7 +2904,7 @@ func (rss *replicaSendStream) handleReadyEntriesRaftMuAndStreamLocked(
 	if n := len(event.sendingEntries); n > 0 && event.mode == MsgAppPull {
 		// NB: this will not do IO since everything here is in the unstable log
 		// (see raft.LogSnapshot.unstable).
-		slice, err := event.logSnapshot.LogSlice(
+		slice, err := event.logSnapshot.LeadSlice(
 			event.sendingEntries[0].id.index-1, event.sendingEntries[n-1].id.index, infinityEntryIndex)
 		if err != nil {
 			return false, err
@@ -2935,7 +2935,7 @@ func (rss *replicaSendStream) handleReadyEntriesRaftMuAndStreamLocked(
 	return transitionedSendQState, nil
 }
 
-func (rss *replicaSendStream) updateInflightRaftMuAndStreamLocked(ls raft.LogSlice) {
+func (rss *replicaSendStream) updateInflightRaftMuAndStreamLocked(ls raft.LeadSlice) {
 	rss.parent.parent.opts.ReplicaMutexAsserter.RaftMuAssertHeld()
 	rss.mu.AssertHeld()
 	entries := ls.Entries()

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/range_controller_test.go
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/range_controller_test.go
@@ -490,7 +490,7 @@ func (r *testingRCRange) logSnapshot() raft.LogSnapshot {
 }
 
 func (r *testingRCRange) SendMsgAppRaftMuLocked(
-	replicaID roachpb.ReplicaID, ls raft.LogSlice,
+	replicaID roachpb.ReplicaID, ls raft.LeadSlice,
 ) (raftpb.Message, bool) {
 	// TODO(pav-kv): populate the message correctly.
 	// TODO(pav-kv): use the real RawNode instead of fakes.

--- a/pkg/kv/kvserver/kvflowcontrol/replica_rac2/processor_test.go
+++ b/pkg/kv/kvserver/kvflowcontrol/replica_rac2/processor_test.go
@@ -87,7 +87,7 @@ func (rn *testRaftNode) SendPingRaftMuLocked(to roachpb.ReplicaID) bool {
 }
 
 func (rn *testRaftNode) SendMsgAppRaftMuLocked(
-	_ roachpb.ReplicaID, _ raft.LogSlice,
+	_ roachpb.ReplicaID, _ raft.LeadSlice,
 ) (raftpb.Message, bool) {
 	panic("unimplemented")
 }

--- a/pkg/kv/kvserver/kvflowcontrol/replica_rac2/raft_node.go
+++ b/pkg/kv/kvserver/kvflowcontrol/replica_rac2/raft_node.go
@@ -68,7 +68,7 @@ func (rn raftNodeForRACv2) SendPingRaftMuLocked(to roachpb.ReplicaID) bool {
 
 // SendMsgAppRaftMuLocked implements rac2.RaftInterface.
 func (rn raftNodeForRACv2) SendMsgAppRaftMuLocked(
-	replicaID roachpb.ReplicaID, ls raft.LogSlice,
+	replicaID roachpb.ReplicaID, ls raft.LeadSlice,
 ) (raftpb.Message, bool) {
 	rn.r.MuLock()
 	defer rn.r.MuUnlock()

--- a/pkg/raft/bootstrap.go
+++ b/pkg/raft/bootstrap.go
@@ -46,7 +46,10 @@ func (rn *RawNode) Bootstrap(peers []Peer) error {
 	// TODO(tbg): remove StartNode and give the application the right tools to
 	// bootstrap the initial membership in a cleaner way.
 	rn.raft.becomeFollower(1, None)
-	app := LeadSlice{term: 1, entries: make([]pb.Entry, 0, len(peers))}
+	app := LeadSlice{
+		term:     1,
+		LogSlice: LogSlice{entries: make([]pb.Entry, 0, len(peers))},
+	}
 	for i, peer := range peers {
 		cc := pb.ConfChange{Type: pb.ConfChangeAddNode, NodeID: peer.ID, Context: peer.Context}
 		data, err := cc.Marshal()

--- a/pkg/raft/bootstrap.go
+++ b/pkg/raft/bootstrap.go
@@ -46,7 +46,7 @@ func (rn *RawNode) Bootstrap(peers []Peer) error {
 	// TODO(tbg): remove StartNode and give the application the right tools to
 	// bootstrap the initial membership in a cleaner way.
 	rn.raft.becomeFollower(1, None)
-	app := LogSlice{term: 1, entries: make([]pb.Entry, 0, len(peers))}
+	app := LeadSlice{term: 1, entries: make([]pb.Entry, 0, len(peers))}
 	for i, peer := range peers {
 		cc := pb.ConfChange{Type: pb.ConfChangeAddNode, NodeID: peer.ID, Context: peer.Context}
 		data, err := cc.Marshal()

--- a/pkg/raft/log.go
+++ b/pkg/raft/log.go
@@ -41,7 +41,7 @@ type LogSnapshot struct {
 	// storage contains the stable log entries.
 	storage LogStorage
 	// unstable contains the unstable log entries.
-	unstable LogSlice
+	unstable LeadSlice
 	// logger gives access to logging errors.
 	logger raftlogger.Logger
 }
@@ -155,7 +155,7 @@ func (l *raftLog) accTerm() uint64 {
 // the log (so this log slice is insufficient to make our log consistent with
 // the leader log), the slice is out of bounds (appending it would introduce a
 // gap), or a.term is outdated.
-func (l *raftLog) maybeAppend(a LogSlice) bool {
+func (l *raftLog) maybeAppend(a LeadSlice) bool {
 	match, ok := l.match(a)
 	if !ok {
 		return false
@@ -179,7 +179,7 @@ func (l *raftLog) maybeAppend(a LogSlice) bool {
 //
 // Returns false if the operation can not be done: entry a.prev does not match
 // the lastEntryID of this log, or a.term is outdated.
-func (l *raftLog) append(a LogSlice) bool {
+func (l *raftLog) append(a LeadSlice) bool {
 	return l.unstable.append(a)
 }
 
@@ -191,8 +191,8 @@ func (l *raftLog) append(a LogSlice) bool {
 //
 // All the entries up to the returned index are already present in the log, and
 // do not need to be rewritten. The caller can safely fast-forward the appended
-// LogSlice to this index.
-func (l *raftLog) match(s LogSlice) (uint64, bool) {
+// LeadSlice to this index.
+func (l *raftLog) match(s LeadSlice) (uint64, bool) {
 	if !l.matchTerm(s.prev) {
 		return 0, false
 	}
@@ -551,23 +551,23 @@ func (l *raftLog) slice(lo, hi uint64, maxSize entryEncodingSize) ([]pb.Entry, e
 	return l.snap(l.storage).slice(lo, hi, maxSize)
 }
 
-// LogSlice returns a valid log slice for a prefix of the (lo, hi] log index
+// LeadSlice returns a valid log slice for a prefix of the (lo, hi] log index
 // interval, with the total entries size not exceeding maxSize.
 //
 // Returns at least one entry if the interval contains any. The maxSize can only
 // be exceeded if the first entry (lo+1) is larger.
-func (l LogSnapshot) LogSlice(lo, hi uint64, maxSize uint64) (LogSlice, error) {
+func (l LogSnapshot) LeadSlice(lo, hi uint64, maxSize uint64) (LeadSlice, error) {
 	prevTerm, err := l.term(lo)
 	if err != nil {
 		// The log is probably compacted at index > lo (err == ErrCompacted), or it
 		// can be a custom storage error.
-		return LogSlice{}, err
+		return LeadSlice{}, err
 	}
 	ents, err := l.slice(lo, hi, entryEncodingSize(maxSize))
 	if err != nil {
-		return LogSlice{}, err
+		return LeadSlice{}, err
 	}
-	return LogSlice{
+	return LeadSlice{
 		term:    l.unstable.term,
 		prev:    entryID{term: prevTerm, index: lo},
 		entries: ents,
@@ -662,7 +662,7 @@ func (l *raftLog) snap(storage LogStorage) LogSnapshot {
 	return LogSnapshot{
 		first:    l.firstIndex(),
 		storage:  storage,
-		unstable: l.unstable.LogSlice,
+		unstable: l.unstable.LeadSlice,
 		logger:   l.logger,
 	}
 }

--- a/pkg/raft/log.go
+++ b/pkg/raft/log.go
@@ -162,7 +162,7 @@ func (l *raftLog) maybeAppend(a LeadSlice) bool {
 	}
 	// Fast-forward the appended log slice to the last matching entry.
 	// NB: a.prev.index <= match <= a.lastIndex(), so the call is safe.
-	a = a.forward(match)
+	a.LogSlice = a.forward(match)
 
 	if len(a.entries) == 0 {
 		// TODO(pav-kv): remove this clause and handle it in unstable. The log slice
@@ -568,12 +568,15 @@ func (l LogSnapshot) LeadSlice(lo, hi uint64, maxSize uint64) (LeadSlice, error)
 		return LeadSlice{}, err
 	}
 	return LeadSlice{
-		term:    l.unstable.term,
-		prev:    entryID{term: prevTerm, index: lo},
-		entries: ents,
+		term: l.unstable.term,
+		LogSlice: LogSlice{
+			prev:    entryID{term: prevTerm, index: lo},
+			entries: ents,
+		},
 	}, nil
 }
 
+// TODO(pav-kv): return LogSlice.
 func (l LogSnapshot) slice(lo, hi uint64, maxSize entryEncodingSize) ([]pb.Entry, error) {
 	if err := l.mustCheckOutOfBounds(lo, hi); err != nil {
 		return nil, err

--- a/pkg/raft/log_test.go
+++ b/pkg/raft/log_test.go
@@ -955,9 +955,11 @@ func (id entryID) append(terms ...uint64) LeadSlice {
 		term = terms[ln-1]
 	}
 	ls := LeadSlice{
-		term:    term,
-		prev:    id,
-		entries: index(id.index + 1).terms(terms...),
+		term: term,
+		LogSlice: LogSlice{
+			prev:    id,
+			entries: index(id.index + 1).terms(terms...),
+		},
 	}
 	if err := ls.valid(); err != nil {
 		panic(err)

--- a/pkg/raft/log_test.go
+++ b/pkg/raft/log_test.go
@@ -33,7 +33,7 @@ func TestMatch(t *testing.T) {
 		ids[i] = entryID{term: init.termAt(uint64(i)), index: uint64(i)}
 	}
 	for _, tt := range []struct {
-		sl    LogSlice
+		sl    LeadSlice
 		notOk bool
 		want  uint64
 	}{
@@ -42,7 +42,7 @@ func TestMatch(t *testing.T) {
 		{sl: entryID{term: 4, index: 1}.append(4, 4), notOk: true},
 		{sl: entryID{term: 5, index: 2}.append(5, 6), notOk: true},
 		// no conflict, empty slice
-		{sl: LogSlice{}, want: 0},
+		{sl: LeadSlice{}, want: 0},
 		// no conflict
 		{sl: ids[0].append(1, 2, 3), want: 3},
 		{sl: ids[1].append(2, 3), want: 3},
@@ -75,7 +75,7 @@ func TestFindConflictByTerm(t *testing.T) {
 	noSnap := entryID{}
 	snap10 := entryID{term: 3, index: 10}
 	for _, tt := range []struct {
-		sl    LogSlice
+		sl    LeadSlice
 		index uint64
 		term  uint64
 		want  uint64
@@ -155,12 +155,12 @@ func TestIsUpToDate(t *testing.T) {
 func TestAppend(t *testing.T) {
 	init := entryID{}.append(1, 2, 2)
 	for _, tt := range []struct {
-		app   LogSlice
-		want  LogSlice
+		app   LeadSlice
+		want  LeadSlice
 		notOk bool
 	}{
 		// appends not at the end of the log
-		{app: LogSlice{}, notOk: true},
+		{app: LeadSlice{}, notOk: true},
 		{app: entryID{term: 1, index: 1}.append(3), notOk: true},
 		{app: entryID{term: 2, index: 4}.append(3), notOk: true},
 		// appends at the end of the log
@@ -204,7 +204,7 @@ func TestLogMaybeAppend(t *testing.T) {
 	commit := uint64(1)
 
 	for _, tt := range []struct {
-		app   LogSlice
+		app   LeadSlice
 		want  []pb.Entry
 		notOk bool
 		panic bool
@@ -222,7 +222,7 @@ func TestLogMaybeAppend(t *testing.T) {
 		{app: last.append(4), want: index(1).terms(1, 2, 3, 4)},
 		{app: last.append(4, 4), want: index(1).terms(1, 2, 3, 4, 4)},
 		// appends from before the end of the log
-		{app: LogSlice{}, want: init.entries},
+		{app: LeadSlice{}, want: init.entries},
 		{app: entryID{term: 1, index: 1}.append(4), want: index(1).terms(1, 4)},
 		{app: entryID{term: 1, index: 1}.append(4, 4), want: index(1).terms(1, 4, 4)},
 		{app: entryID{term: 2, index: 2}.append(4), want: index(1).terms(1, 2, 4)},
@@ -507,7 +507,7 @@ func TestAppliedTo(t *testing.T) {
 // the entries correctly, before and after making them stable.
 func TestNextUnstableEnts(t *testing.T) {
 	init := entryID{}.append(1, 2)
-	for _, tt := range []LogSlice{
+	for _, tt := range []LeadSlice{
 		init.lastEntryID().append(),
 		init.lastEntryID().append(2, 2),
 		init.lastEntryID().append(3, 4, 5, 6),
@@ -590,7 +590,7 @@ func TestStableToWithSnap(t *testing.T) {
 	snapID := entryID{term: 2, index: 5}
 	snap := pb.Snapshot{Metadata: pb.SnapshotMetadata{Term: snapID.term, Index: snapID.index}}
 	for _, tt := range []struct {
-		sl   LogSlice
+		sl   LeadSlice
 		to   LogMark
 		want uint64 // prev.index
 	}{
@@ -946,15 +946,15 @@ func (i index) terms(terms ...uint64) []pb.Entry {
 	return entries
 }
 
-// append generates a valid LogSlice of entries appended after the given entry
+// append generates a valid LeadSlice of entries appended after the given entry
 // ID, at indices [id.index+1, id.index+len(terms)], with the given terms of
 // each entry. Terms must be >= id.term, and non-decreasing.
-func (id entryID) append(terms ...uint64) LogSlice {
+func (id entryID) append(terms ...uint64) LeadSlice {
 	term := id.term
 	if ln := len(terms); ln != 0 {
 		term = terms[ln-1]
 	}
-	ls := LogSlice{
+	ls := LeadSlice{
 		term:    term,
 		prev:    id,
 		entries: index(id.index + 1).terms(terms...),

--- a/pkg/raft/log_test.go
+++ b/pkg/raft/log_test.go
@@ -786,7 +786,7 @@ func TestSlice(t *testing.T) {
 	halfe := pb.Entry{Index: half, Term: half}
 
 	entries := func(lo, hi uint64) []pb.Entry { // (lo, hi]
-		return index(lo+1).termRange(lo+1, hi+1)
+		return index(lo + 1).terms(intRange(lo+1, hi+1)...)
 	}
 
 	storage := NewMemoryStorage()
@@ -871,7 +871,7 @@ func TestScan(t *testing.T) {
 	last := offset + num
 	half := offset + num/2
 	entries := func(from, to uint64) []pb.Entry {
-		return index(from).termRange(from, to)
+		return index(from).terms(intRange(from, to)...)
 	}
 	entrySize := entsSize(entries(half, half+1))
 
@@ -944,13 +944,6 @@ func (i index) terms(terms ...uint64) []pb.Entry {
 		index++
 	}
 	return entries
-}
-
-// termRange generates a slice of to-from entries, at consecutive indices
-// starting from i, and consecutive terms in [from, to).
-// TODO(pav-kv): remove.
-func (i index) termRange(from, to uint64) []pb.Entry {
-	return i.terms(intRange(from, to)...)
 }
 
 // append generates a valid LogSlice of entries appended after the given entry

--- a/pkg/raft/log_unstable.go
+++ b/pkg/raft/log_unstable.go
@@ -26,14 +26,14 @@ import (
 // "log" can be represented by a snapshot, and/or a contiguous slice of entries.
 //
 // The possible states:
-//  1. Both the snapshot and the entries LogSlice are empty. This means the log
-//     is fully in Storage. The LogSlice.prev is the lastEntryID of the log.
-//  2. The snapshot is empty, and the LogSlice is non-empty. The state up to
-//     (including) LogSlice.prev is in Storage, and the LogSlice is pending.
-//  3. The snapshot is non-empty, and the LogSlice is empty. The snapshot
+//  1. Both the snapshot and the entries LeadSlice are empty. This means the log
+//     is fully in Storage. The LeadSlice.prev is the lastEntryID of the log.
+//  2. The snapshot is empty, and the LeadSlice is non-empty. The state up to
+//     (including) LeadSlice.prev is in Storage, and the LeadSlice is pending.
+//  3. The snapshot is non-empty, and the LeadSlice is empty. The snapshot
 //     overrides the entire log in Storage.
-//  4. Both the snapshot and LogSlice are non-empty. The snapshot immediately
-//     precedes the entries, i.e. LogSlice.prev == snapshot.lastEntryID. This
+//  4. Both the snapshot and LeadSlice are non-empty. The snapshot immediately
+//     precedes the entries, i.e. LeadSlice.prev == snapshot.lastEntryID. This
 //     state overrides the entire log in Storage.
 //
 // The type serves two roles. First, it holds on to the latest snapshot / log
@@ -50,7 +50,7 @@ import (
 // no strict requirement on the order of acknowledgement delivery.
 //
 // TODO(pav-kv): describe the order requirements in more detail when accTerm
-// (LogSlice.term) is integrated into the protocol.
+// (LeadSlice.term) is integrated into the protocol.
 //
 // Note that the in-memory prefix of the log can contain entries at indices less
 // than Storage.LastIndex(). This means that the next write to storage might
@@ -64,31 +64,31 @@ type unstable struct {
 	// snapshot is the pending unstable snapshot, if any.
 	//
 	// Invariant: snapshot == nil ==> !snapshotInProgress
-	// Invariant: snapshot != nil ==> snapshot.lastEntryID == LogSlice.prev
+	// Invariant: snapshot != nil ==> snapshot.lastEntryID == LeadSlice.prev
 	//
 	// The last invariant enforces the order of handling a situation when there is
 	// both a snapshot and entries. The snapshot write must be acknowledged first,
-	// before entries are acknowledged and the LogSlice moves forward.
+	// before entries are acknowledged and the LeadSlice moves forward.
 	snapshot *pb.Snapshot
 
-	// LogSlice is the suffix of the raft log that is not yet written to storage.
+	// LeadSlice is the suffix of the raft log that is not yet written to storage.
 	// If all the entries are written, or covered by the pending snapshot, then
-	// LogSlice.entries is empty.
+	// LeadSlice.entries is empty.
 	//
-	// Invariant: snapshot != nil ==> LogSlice.prev == snapshot.lastEntryID
-	// Invariant: snapshot == nil ==> LogSlice.prev is in Storage
-	// Invariant: LogSlice.lastEntryID() is the end of the log at all times
+	// Invariant: snapshot != nil ==> LeadSlice.prev == snapshot.lastEntryID
+	// Invariant: snapshot == nil ==> LeadSlice.prev is in Storage
+	// Invariant: LeadSlice.lastEntryID() is the end of the log at all times
 	//
-	// Invariant: LogSlice.term, a.k.a. the "last accepted term", is the term of
+	// Invariant: LeadSlice.term, a.k.a. the "last accepted term", is the term of
 	// the leader whose append (either entries or snapshot) we accepted last. Our
 	// state is consistent with the leader log at this term.
-	LogSlice
+	LeadSlice
 
 	// snapshotInProgress is true if the snapshot is being written to storage.
 	//
 	// Invariant: snapshotInProgress ==> snapshot != nil
 	snapshotInProgress bool
-	// entryInProgress is the index of the last entry in LogSlice already present
+	// entryInProgress is the index of the last entry in LeadSlice already present
 	// in, or being written to storage.
 	//
 	// Invariant: prev.index <= entryInProgress <= lastIndex()
@@ -103,7 +103,7 @@ type unstable struct {
 }
 
 func newUnstable(last entryID, logger raftlogger.Logger) unstable {
-	// To initialize the last accepted term (LogSlice.term) correctly, we make
+	// To initialize the last accepted term (LeadSlice.term) correctly, we make
 	// sure its invariant is true: the log is a prefix of the term's leader's log.
 	// This can be achieved by conservatively initializing to the term of the last
 	// log entry.
@@ -119,7 +119,7 @@ func newUnstable(last entryID, logger raftlogger.Logger) unstable {
 	// leader Term) gives us more information about the log, and then allows
 	// bumping its commit index sooner than when the next MsgApp arrives.
 	return unstable{
-		LogSlice:        LogSlice{term: last.term, prev: last},
+		LeadSlice:       LeadSlice{term: last.term, prev: last},
 		entryInProgress: last.index,
 		logger:          logger,
 	}
@@ -190,7 +190,7 @@ func (u *unstable) stableTo(mark LogMark) {
 		u.logger.Panicf("mark %+v acked earlier than the snapshot(in-progress=%t): %s",
 			mark, u.snapshotInProgress, DescribeSnapshot(*u.snapshot))
 	}
-	u.LogSlice = u.forward(mark.Index)
+	u.LeadSlice = u.forward(mark.Index)
 	// TODO(pav-kv): why can mark.index overtake u.entryInProgress? Probably bugs
 	// in tests using the log writes incorrectly, e.g. TestLeaderStartReplication
 	// takes nextUnstableEnts() without acceptInProgress().
@@ -246,7 +246,7 @@ func (u *unstable) restore(s snapshot) bool {
 	term := max(u.term, s.term)
 
 	u.snapshot = &s.snap
-	u.LogSlice = LogSlice{term: term, prev: s.lastEntryID()}
+	u.LeadSlice = LeadSlice{term: term, prev: s.lastEntryID()}
 	u.snapshotInProgress = false
 	u.entryInProgress = u.prev.index
 	return true
@@ -254,7 +254,7 @@ func (u *unstable) restore(s snapshot) bool {
 
 // append adds the given log slice to the end of the log. Returns false if this
 // can not be done.
-func (u *unstable) append(a LogSlice) bool {
+func (u *unstable) append(a LeadSlice) bool {
 	if a.term < u.term {
 		return false // append from an outdated log
 	} else if a.prev != u.lastEntryID() {
@@ -265,7 +265,7 @@ func (u *unstable) append(a LogSlice) bool {
 	return true
 }
 
-func (u *unstable) truncateAndAppend(a LogSlice) bool {
+func (u *unstable) truncateAndAppend(a LeadSlice) bool {
 	if a.term < u.term {
 		return false // append from an outdated log
 	}
@@ -307,7 +307,7 @@ func (u *unstable) truncateAndAppend(a LogSlice) bool {
 	// Truncate the log and append new entries. Regress the entryInProgress mark
 	// to reflect that the truncated entries are no longer considered in progress.
 	if a.prev.index <= u.prev.index {
-		u.LogSlice = a // replace the entire LogSlice with the latest append
+		u.LeadSlice = a // replace the entire LeadSlice with the latest append
 		// TODO(pav-kv): clean up the logging message. It will change all datadriven
 		// test outputs, so do it in a contained PR.
 		u.logger.Infof("replace the unstable entries from index %d", a.prev.index+1)

--- a/pkg/raft/node_test.go
+++ b/pkg/raft/node_test.go
@@ -810,7 +810,7 @@ func TestNodeCommitPaginationAfterRestart(t *testing.T) {
 		entries[i] = ent
 		size += uint64(ent.Size())
 	}
-	s.ls = LogSlice{term: 1, entries: entries}
+	s.ls = LeadSlice{term: 1, entries: entries}
 
 	cfg := newTestConfig(1, 10, 1, s)
 	// Set a MaxSizePerMsg that would suggest to Raft that the last committed entry should

--- a/pkg/raft/node_test.go
+++ b/pkg/raft/node_test.go
@@ -810,7 +810,7 @@ func TestNodeCommitPaginationAfterRestart(t *testing.T) {
 		entries[i] = ent
 		size += uint64(ent.Size())
 	}
-	s.ls = LeadSlice{term: 1, entries: entries}
+	s.ls = LogSlice{entries: entries}
 
 	cfg := newTestConfig(1, 10, 1, s)
 	// Set a MaxSizePerMsg that would suggest to Raft that the last committed entry should

--- a/pkg/raft/raft_test.go
+++ b/pkg/raft/raft_test.go
@@ -1065,8 +1065,7 @@ func TestCandidateConcede(t *testing.T) {
 	assert.Equal(t, pb.StateFollower, a.state)
 	assert.Equal(t, uint64(1), a.Term)
 
-	wantLog := ltoa(newLog(&MemoryStorage{ls: LeadSlice{
-		term:    1,
+	wantLog := ltoa(newLog(&MemoryStorage{ls: LogSlice{
 		entries: []pb.Entry{{Index: 1, Term: 1}, {Index: 2, Term: 1, Data: data}},
 	}}, nil))
 	for i, p := range tt.peers {
@@ -1134,10 +1133,7 @@ func testOldMessages(t *testing.T, storeLivenessEnabled bool) {
 
 	ents := index(1).terms(1, 2, 3, 3)
 	ents[3].Data = []byte("somedata")
-	ilog := newLog(&MemoryStorage{ls: LeadSlice{
-		term:    3,
-		entries: ents,
-	}}, nil)
+	ilog := newLog(&MemoryStorage{ls: LogSlice{entries: ents}}, nil)
 	base := ltoa(ilog)
 	for i, p := range tt.peers {
 		if sm, ok := p.(*raft); ok {
@@ -1186,8 +1182,7 @@ func TestProposal(t *testing.T) {
 
 		wantLog := newLog(NewMemoryStorage(), raftlogger.RaftLogger)
 		if tt.success {
-			wantLog = newLog(&MemoryStorage{ls: LeadSlice{
-				term:    2,
+			wantLog = newLog(&MemoryStorage{ls: LogSlice{
 				entries: []pb.Entry{{Index: 1, Term: 1}, {Index: 2, Term: 1, Data: data}},
 			}}, nil)
 		}
@@ -1218,8 +1213,7 @@ func TestProposalByProxy(t *testing.T) {
 		// propose via follower
 		tt.send(pb.Message{From: 2, To: 2, Type: pb.MsgProp, Entries: []pb.Entry{{Data: []byte("somedata")}}})
 
-		wantLog := newLog(&MemoryStorage{ls: LeadSlice{
-			term:    1,
+		wantLog := newLog(&MemoryStorage{ls: LogSlice{
 			entries: []pb.Entry{{Index: 1, Term: 1}, {Index: 2, Term: 1, Data: data}},
 		}}, nil)
 		base := ltoa(wantLog)
@@ -1649,8 +1643,7 @@ func testRecvMsgVote(t *testing.T, msgType pb.MessageType) {
 			sm.step = stepLeader
 		}
 		sm.Vote = tt.voteFor
-		sm.raftLog = newLog(&MemoryStorage{ls: LeadSlice{
-			term:    2,
+		sm.raftLog = newLog(&MemoryStorage{ls: LogSlice{
 			entries: index(1).terms(2, 2),
 		}}, nil)
 
@@ -2754,8 +2747,7 @@ func TestRecvMsgBeat(t *testing.T) {
 
 	for i, tt := range tests {
 		sm := newTestRaft(1, 10, 1, newTestMemoryStorage(withPeers(1, 2, 3)))
-		sm.raftLog = newLog(&MemoryStorage{ls: LeadSlice{
-			term:    1,
+		sm.raftLog = newLog(&MemoryStorage{ls: LogSlice{
 			entries: index(1).terms(1, 1),
 		}}, nil)
 		sm.Term = 1

--- a/pkg/raft/raft_test.go
+++ b/pkg/raft/raft_test.go
@@ -1065,7 +1065,7 @@ func TestCandidateConcede(t *testing.T) {
 	assert.Equal(t, pb.StateFollower, a.state)
 	assert.Equal(t, uint64(1), a.Term)
 
-	wantLog := ltoa(newLog(&MemoryStorage{ls: LogSlice{
+	wantLog := ltoa(newLog(&MemoryStorage{ls: LeadSlice{
 		term:    1,
 		entries: []pb.Entry{{Index: 1, Term: 1}, {Index: 2, Term: 1, Data: data}},
 	}}, nil))
@@ -1134,7 +1134,7 @@ func testOldMessages(t *testing.T, storeLivenessEnabled bool) {
 
 	ents := index(1).terms(1, 2, 3, 3)
 	ents[3].Data = []byte("somedata")
-	ilog := newLog(&MemoryStorage{ls: LogSlice{
+	ilog := newLog(&MemoryStorage{ls: LeadSlice{
 		term:    3,
 		entries: ents,
 	}}, nil)
@@ -1186,7 +1186,7 @@ func TestProposal(t *testing.T) {
 
 		wantLog := newLog(NewMemoryStorage(), raftlogger.RaftLogger)
 		if tt.success {
-			wantLog = newLog(&MemoryStorage{ls: LogSlice{
+			wantLog = newLog(&MemoryStorage{ls: LeadSlice{
 				term:    2,
 				entries: []pb.Entry{{Index: 1, Term: 1}, {Index: 2, Term: 1, Data: data}},
 			}}, nil)
@@ -1218,7 +1218,7 @@ func TestProposalByProxy(t *testing.T) {
 		// propose via follower
 		tt.send(pb.Message{From: 2, To: 2, Type: pb.MsgProp, Entries: []pb.Entry{{Data: []byte("somedata")}}})
 
-		wantLog := newLog(&MemoryStorage{ls: LogSlice{
+		wantLog := newLog(&MemoryStorage{ls: LeadSlice{
 			term:    1,
 			entries: []pb.Entry{{Index: 1, Term: 1}, {Index: 2, Term: 1, Data: data}},
 		}}, nil)
@@ -1649,7 +1649,7 @@ func testRecvMsgVote(t *testing.T, msgType pb.MessageType) {
 			sm.step = stepLeader
 		}
 		sm.Vote = tt.voteFor
-		sm.raftLog = newLog(&MemoryStorage{ls: LogSlice{
+		sm.raftLog = newLog(&MemoryStorage{ls: LeadSlice{
 			term:    2,
 			entries: index(1).terms(2, 2),
 		}}, nil)
@@ -2754,7 +2754,7 @@ func TestRecvMsgBeat(t *testing.T) {
 
 	for i, tt := range tests {
 		sm := newTestRaft(1, 10, 1, newTestMemoryStorage(withPeers(1, 2, 3)))
-		sm.raftLog = newLog(&MemoryStorage{ls: LogSlice{
+		sm.raftLog = newLog(&MemoryStorage{ls: LeadSlice{
 			term:    1,
 			entries: index(1).terms(1, 1),
 		}}, nil)

--- a/pkg/raft/rafttest/interaction_env_handler_send_msgapp.go
+++ b/pkg/raft/rafttest/interaction_env_handler_send_msgapp.go
@@ -40,7 +40,7 @@ func (env *InteractionEnv) handleSendMsgApp(t *testing.T, d datadriven.TestData)
 func (env *InteractionEnv) SendMsgApp(from int, to pb.PeerID, lo, hi uint64) error {
 	rn := env.Nodes[from].RawNode
 	snap := rn.LogSnapshot()
-	ls, err := snap.LogSlice(lo, hi, math.MaxUint64)
+	ls, err := snap.LeadSlice(lo, hi, math.MaxUint64)
 	if err != nil {
 		return err
 	}

--- a/pkg/raft/rawnode.go
+++ b/pkg/raft/rawnode.go
@@ -206,7 +206,7 @@ func (rn *RawNode) LogSnapshot() LogSnapshot {
 //   - the first slice index matches the Next index to send to this peer
 //
 // Returns false if the message can not be sent.
-func (rn *RawNode) SendMsgApp(to pb.PeerID, slice LogSlice) (pb.Message, bool) {
+func (rn *RawNode) SendMsgApp(to pb.PeerID, slice LeadSlice) (pb.Message, bool) {
 	return rn.raft.maybePrepareMsgApp(to, slice)
 }
 

--- a/pkg/raft/rawnode_test.go
+++ b/pkg/raft/rawnode_test.go
@@ -551,7 +551,7 @@ func TestRawNodeStart(t *testing.T) {
 	}
 
 	storage := NewMemoryStorage()
-	storage.ls = LeadSlice{term: 1, prev: entryID{index: 1, term: 1}}
+	storage.ls = LogSlice{prev: entryID{index: 1, term: 1}}
 
 	// TODO(tbg): this is a first prototype of what bootstrapping could look
 	// like (without the annoying faux ConfChanges). We want to persist a
@@ -770,7 +770,7 @@ func TestRawNodeCommitPaginationAfterRestart(t *testing.T) {
 		entries[i] = ent
 		size += uint64(ent.Size())
 	}
-	s.ls = LeadSlice{term: 1, entries: entries}
+	s.ls = LogSlice{entries: entries}
 
 	cfg := newTestConfig(1, 10, 1, s)
 	// Set a MaxSizePerMsg that would suggest to Raft that the last committed entry should

--- a/pkg/raft/rawnode_test.go
+++ b/pkg/raft/rawnode_test.go
@@ -551,7 +551,7 @@ func TestRawNodeStart(t *testing.T) {
 	}
 
 	storage := NewMemoryStorage()
-	storage.ls = LogSlice{term: 1, prev: entryID{index: 1, term: 1}}
+	storage.ls = LeadSlice{term: 1, prev: entryID{index: 1, term: 1}}
 
 	// TODO(tbg): this is a first prototype of what bootstrapping could look
 	// like (without the annoying faux ConfChanges). We want to persist a
@@ -770,7 +770,7 @@ func TestRawNodeCommitPaginationAfterRestart(t *testing.T) {
 		entries[i] = ent
 		size += uint64(ent.Size())
 	}
-	s.ls = LogSlice{term: 1, entries: entries}
+	s.ls = LeadSlice{term: 1, entries: entries}
 
 	cfg := newTestConfig(1, 10, 1, s)
 	// Set a MaxSizePerMsg that would suggest to Raft that the last committed entry should

--- a/pkg/raft/storage.go
+++ b/pkg/raft/storage.go
@@ -90,8 +90,8 @@ type LogStorage interface {
 	// FirstIndex still returns the snapshot index + 1, yet the first log entry at
 	// this index is not available.
 	//
-	// TODO(pav-kv): replace this with a Prev() method equivalent to LogSlice's
-	// prev field. The log storage is just a storage-backed LogSlice.
+	// TODO(pav-kv): replace this with a Prev() method equivalent to LeadSlice's
+	// prev field. The log storage is just a storage-backed LeadSlice.
 	FirstIndex() uint64
 
 	// LogSnapshot returns an immutable point-in-time log storage snapshot.
@@ -148,11 +148,11 @@ type MemoryStorage struct {
 
 	// ls contains the log entries.
 	//
-	// TODO(pav-kv): the term field of the LogSlice is conservatively populated
-	// to be the last entry term, to keep the LogSlice valid. But it must be
+	// TODO(pav-kv): the term field of the LeadSlice is conservatively populated
+	// to be the last entry term, to keep the LeadSlice valid. But it must be
 	// sourced from the upper layer's last accepted term (which is >= the last
 	// entry term).
-	ls LogSlice
+	ls LeadSlice
 
 	callStats inMemStorageCallStats
 }
@@ -261,7 +261,7 @@ func (ms *MemoryStorage) ApplySnapshot(snap pb.Snapshot) error {
 	}
 	ms.snapshot = snap
 	// TODO(pav-kv): the term must be the last accepted term passed in.
-	ms.ls = LogSlice{term: id.term, prev: id}
+	ms.ls = LeadSlice{term: id.term, prev: id}
 	return nil
 }
 
@@ -306,7 +306,7 @@ func (ms *MemoryStorage) Compact(index uint64) error {
 
 // Append the new entries to storage.
 //
-// TODO(pav-kv): pass in a LogSlice which carries correctness semantics.
+// TODO(pav-kv): pass in a LeadSlice which carries correctness semantics.
 func (ms *MemoryStorage) Append(entries []pb.Entry) error {
 	if len(entries) == 0 {
 		return nil

--- a/pkg/raft/storage_test.go
+++ b/pkg/raft/storage_test.go
@@ -27,7 +27,7 @@ import (
 
 func TestStorageTerm(t *testing.T) {
 	prev3 := entryID{index: 3, term: 3}
-	ls := prev3.append(4, 5)
+	ls := prev3.append(4, 5).LogSlice
 	tests := []struct {
 		i uint64
 
@@ -59,7 +59,7 @@ func TestStorageTerm(t *testing.T) {
 
 func TestStorageEntries(t *testing.T) {
 	prev3 := entryID{index: 3, term: 3}
-	ls := prev3.append(4, 5, 6)
+	ls := prev3.append(4, 5, 6).LogSlice
 	ents := ls.entries
 	tests := []struct {
 		lo, hi, maxsize uint64
@@ -94,21 +94,21 @@ func TestStorageEntries(t *testing.T) {
 }
 
 func TestStorageLastIndex(t *testing.T) {
-	s := &MemoryStorage{ls: entryID{index: 3, term: 3}.append(4, 5)}
+	s := &MemoryStorage{ls: entryID{index: 3, term: 3}.append(4, 5).LogSlice}
 	require.Equal(t, uint64(5), s.LastIndex())
 	require.NoError(t, s.Append(index(6).terms(5)))
 	require.Equal(t, uint64(6), s.LastIndex())
 }
 
 func TestStorageFirstIndex(t *testing.T) {
-	s := &MemoryStorage{ls: entryID{index: 3, term: 3}.append(4, 5)}
+	s := &MemoryStorage{ls: entryID{index: 3, term: 3}.append(4, 5).LogSlice}
 	require.Equal(t, uint64(4), s.FirstIndex())
 	require.NoError(t, s.Compact(4))
 	require.Equal(t, uint64(5), s.FirstIndex())
 }
 
 func TestStorageCompact(t *testing.T) {
-	ls := entryID{index: 3, term: 3}.append(4, 5)
+	ls := entryID{index: 3, term: 3}.append(4, 5).LogSlice
 	tests := []struct {
 		i uint64
 
@@ -135,7 +135,7 @@ func TestStorageCompact(t *testing.T) {
 }
 
 func TestStorageCreateSnapshot(t *testing.T) {
-	ls := entryID{index: 3, term: 3}.append(4, 5)
+	ls := entryID{index: 3, term: 3}.append(4, 5).LogSlice
 	cs := &pb.ConfState{Voters: []pb.PeerID{1, 2, 3}}
 	data := []byte("data")
 
@@ -160,7 +160,7 @@ func TestStorageCreateSnapshot(t *testing.T) {
 }
 
 func TestStorageAppend(t *testing.T) {
-	ls := entryID{index: 3, term: 3}.append(4, 5)
+	ls := entryID{index: 3, term: 3}.append(4, 5).LogSlice
 	tests := []struct {
 		entries []pb.Entry
 

--- a/pkg/raft/types_test.go
+++ b/pkg/raft/types_test.go
@@ -42,7 +42,7 @@ func TestEntryID(t *testing.T) {
 	}
 }
 
-func TestLogSlice(t *testing.T) {
+func TestLeadSlice(t *testing.T) {
 	id := func(index, term uint64) entryID {
 		return entryID{term: term, index: index}
 	}
@@ -84,7 +84,7 @@ func TestLogSlice(t *testing.T) {
 		{term: 10, prev: id(12, 2), entries: []pb.Entry{e(13, 2), e(14, 3)}, last: id(14, 3)},
 	} {
 		t.Run("", func(t *testing.T) {
-			s := LeadSlice{term: tt.term, prev: tt.prev, entries: tt.entries}
+			s := LeadSlice{term: tt.term, LogSlice: LogSlice{prev: tt.prev, entries: tt.entries}}
 			require.Equal(t, tt.notOk, s.valid() != nil)
 			if tt.notOk {
 				return
@@ -106,20 +106,19 @@ func TestLogSliceForward(t *testing.T) {
 	id := func(index, term uint64) entryID {
 		return entryID{term: term, index: index}
 	}
-	ls := func(prev entryID, terms ...uint64) LeadSlice {
+	ls := func(prev entryID, terms ...uint64) LogSlice {
 		empty := make([]pb.Entry, 0) // hack to canonicalize empty slices
-		return LeadSlice{
-			term:    8,
+		return LogSlice{
 			prev:    prev,
 			entries: append(empty, index(prev.index+1).terms(terms...)...),
 		}
 	}
 	for _, tt := range []struct {
-		ls   LeadSlice
+		ls   LogSlice
 		to   uint64
-		want LeadSlice
+		want LogSlice
 	}{
-		{ls: LeadSlice{}, to: 0, want: LeadSlice{}},
+		{ls: LogSlice{}, to: 0, want: LogSlice{}},
 		{ls: ls(id(5, 1)), to: 5, want: ls(id(5, 1))},
 		{ls: ls(id(10, 3), 3, 4, 5), to: 10, want: ls(id(10, 3), 3, 4, 5)},
 		{ls: ls(id(10, 3), 3, 4, 5), to: 11, want: ls(id(11, 3), 4, 5)},

--- a/pkg/raft/types_test.go
+++ b/pkg/raft/types_test.go
@@ -84,7 +84,7 @@ func TestLogSlice(t *testing.T) {
 		{term: 10, prev: id(12, 2), entries: []pb.Entry{e(13, 2), e(14, 3)}, last: id(14, 3)},
 	} {
 		t.Run("", func(t *testing.T) {
-			s := LogSlice{term: tt.term, prev: tt.prev, entries: tt.entries}
+			s := LeadSlice{term: tt.term, prev: tt.prev, entries: tt.entries}
 			require.Equal(t, tt.notOk, s.valid() != nil)
 			if tt.notOk {
 				return
@@ -106,20 +106,20 @@ func TestLogSliceForward(t *testing.T) {
 	id := func(index, term uint64) entryID {
 		return entryID{term: term, index: index}
 	}
-	ls := func(prev entryID, terms ...uint64) LogSlice {
+	ls := func(prev entryID, terms ...uint64) LeadSlice {
 		empty := make([]pb.Entry, 0) // hack to canonicalize empty slices
-		return LogSlice{
+		return LeadSlice{
 			term:    8,
 			prev:    prev,
 			entries: append(empty, index(prev.index+1).terms(terms...)...),
 		}
 	}
 	for _, tt := range []struct {
-		ls   LogSlice
+		ls   LeadSlice
 		to   uint64
-		want LogSlice
+		want LeadSlice
 	}{
-		{ls: LogSlice{}, to: 0, want: LogSlice{}},
+		{ls: LeadSlice{}, to: 0, want: LeadSlice{}},
 		{ls: ls(id(5, 1)), to: 5, want: ls(id(5, 1))},
 		{ls: ls(id(10, 3), 3, 4, 5), to: 10, want: ls(id(10, 3), 3, 4, 5)},
 		{ls: ls(id(10, 3), 3, 4, 5), to: 11, want: ls(id(11, 3), 4, 5)},


### PR DESCRIPTION
This PR splits the `LogSlice` type into two: `LogSlice` and `LeadSlice`. The `LogSlice` can contain any well-formed slice of a raft log. The `LeadSlice` ties a `LogSlice` to a leader term, and gives the additional guarantee that the log slice is consistent with a particular leader's log.

A few TODOs in `MemoryStorage` are resolved because the `MemoryStorage` is not a `LeadSlice`.

Epic: none
Release note: none