### PR TITLE
syncutil: replace RWMutex with Mutex

### DIFF
--- a/pkg/util/syncutil/mutex_sync_race.go
+++ b/pkg/util/syncutil/mutex_sync_race.go
@@ -57,8 +57,10 @@ func (m *Mutex) AssertHeld() {
 }
 
 // An RWMutex is a reader/writer mutual exclusion lock.
+// NOTE: Due to https://github.com/golang/go/issues/17973, this implementation
+// has the behavior of a normal Mutex.
 type RWMutex struct {
-	mu      sync.RWMutex
+	mu      sync.Mutex
 	wLocked int32 // updated atomically
 	rLocked int32 // updated atomically
 }
@@ -84,25 +86,28 @@ func (rw *RWMutex) Unlock() {
 	rw.mu.Unlock()
 }
 
-// RLock locks m for reading.
+// RLock locks rw for reading. It is identical to Lock in the current
+// implementation.
 func (rw *RWMutex) RLock() {
-	rw.mu.RLock()
+	rw.mu.Lock()
 	atomic.AddInt32(&rw.rLocked, 1)
 }
 
 // TryRLock tries to lock rw for reading and reports whether it succeeded.
+// It is identical to TryLock in the current implementation.
 func (rw *RWMutex) TryRLock() bool {
-	if !rw.mu.TryRLock() {
+	if !rw.mu.TryLock() {
 		return false
 	}
 	atomic.AddInt32(&rw.rLocked, 1)
 	return true
 }
 
-// RUnlock undoes a single RLock call.
+// RUnlock undoes a single RLock call. It is identical to Lock in the current
+// implementation.
 func (rw *RWMutex) RUnlock() {
 	atomic.AddInt32(&rw.rLocked, -1)
-	rw.mu.RUnlock()
+	rw.mu.Unlock()
 }
 
 // RLocker returns a Locker interface that implements


### PR DESCRIPTION
`sync.RWMutex` has poor performance as the number of CPUs increases.
This patch changes our own syncutil.RWMutex implementation so that it
delegates to sync.Mutex instead. Although this prevents multiple readers
from accessing the mutex at the same time, it still improves results on
end-to-end benchmarks since the algorithm is more efficient.

```
Sysbench/SQL/1node_remote/oltp_begin_commit-24     156µs ±11%     147µs ± 3%   -5.74%  (p=0.002 n=15+13)
Sysbench/KV/3node/oltp_point_select-24            94.1µs ±12%    89.7µs ± 7%   -4.66%  (p=0.033 n=15+14)
Sysbench/KV/3node/oltp_begin_commit-24            1.53µs ± 9%    1.46µs ± 9%   -4.49%  (p=0.000 n=13+13)
Sysbench/SQL/3node/oltp_point_select-24            470µs ± 4%     458µs ± 2%   -2.55%  (p=0.000 n=15+15)
Sysbench/SQL/1node_local/oltp_read_only-24        5.39ms ± 1%    5.27ms ± 2%   -2.23%  (p=0.000 n=15+15)
Sysbench/SQL/1node_remote/oltp_read_only-24       6.99ms ± 2%    6.85ms ± 3%   -2.03%  (p=0.001 n=15+15)
Sysbench/SQL/1node_remote/oltp_point_select-24     455µs ± 3%     446µs ± 3%   -1.96%  (p=0.002 n=14+15)
Sysbench/KV/1node_local/oltp_read_write-24        2.47ms ± 2%    2.43ms ± 3%   -1.83%  (p=0.002 n=15+15)
Sysbench/SQL/1node_local/oltp_read_write-24       8.47ms ± 2%    8.32ms ± 2%   -1.80%  (p=0.001 n=15+15)
Sysbench/SQL/1node_remote/oltp_read_write-24      10.7ms ± 3%    10.5ms ± 3%   -1.75%  (p=0.003 n=15+15)
Sysbench/SQL/3node/oltp_read_only-24              7.08ms ± 2%    6.96ms ± 3%   -1.73%  (p=0.001 n=15+15)
Sysbench/SQL/1node_local/oltp_write_only-24       3.17ms ± 3%    3.12ms ± 3%   -1.64%  (p=0.004 n=15+15)
Sysbench/SQL/3node/oltp_read_write-24             11.0ms ± 2%    10.8ms ± 2%   -1.63%  (p=0.001 n=15+15)
Sysbench/KV/1node_remote/oltp_write_only-24       2.06ms ± 3%    2.02ms ± 3%   -1.62%  (p=0.009 n=15+15)
Sysbench/KV/1node_remote/oltp_read_only-24        2.19ms ± 2%    2.15ms ± 3%   -1.61%  (p=0.010 n=15+15)
Sysbench/SQL/1node_remote/oltp_write_only-24      3.78ms ± 2%    3.73ms ± 3%   -1.43%  (p=0.008 n=15+15)
Sysbench/KV/3node/oltp_write_only-24              2.42ms ± 2%    2.39ms ± 3%   -1.38%  (p=0.019 n=15+15)
Sysbench/SQL/3node/oltp_write_only-24             3.95ms ± 2%    3.89ms ± 3%   -1.34%  (p=0.010 n=15+15)
Sysbench/KV/1node_local/oltp_write_only-24        1.45ms ± 3%    1.43ms ± 3%   -1.16%  (p=0.041 n=15+15)
Sysbench/KV/3node/oltp_read_only-24               2.25ms ± 2%    2.23ms ± 2%   -0.93%  (p=0.025 n=15+13)
Sysbench/SQL/1node_local/oltp_point_select-24      361µs ± 3%     357µs ± 4%     ~     (p=0.161 n=15+15)
Sysbench/SQL/1node_local/oltp_begin_commit-24      152µs ±13%     154µs ± 9%     ~     (p=0.267 n=15+15)
Sysbench/SQL/3node/oltp_begin_commit-24            156µs ±10%     153µs ± 6%     ~     (p=0.285 n=15+15)
Sysbench/KV/1node_local/oltp_read_only-24          770µs ± 3%     762µs ± 3%     ~     (p=0.234 n=15+14)
Sysbench/KV/1node_local/oltp_point_select-24      33.6µs ± 5%    33.2µs ± 4%     ~     (p=0.186 n=14+15)
Sysbench/KV/1node_local/oltp_begin_commit-24      1.45µs ± 3%    1.44µs ± 4%     ~     (p=0.372 n=15+15)
Sysbench/KV/1node_remote/oltp_read_write-24       4.55ms ± 3%    4.49ms ± 3%     ~     (p=0.081 n=15+15)
Sysbench/KV/1node_remote/oltp_point_select-24     88.5µs ±10%    86.6µs ±15%     ~     (p=0.250 n=15+15)
Sysbench/KV/1node_remote/oltp_begin_commit-24     1.42µs ± 4%    1.41µs ± 2%     ~     (p=0.109 n=15+14)
Sysbench/KV/3node/oltp_read_write-24              4.99ms ± 3%    4.94ms ± 2%     ~     (p=0.061 n=15+15)


name                                            old alloc/op   new alloc/op   delta
Sysbench/SQL/3node/oltp_begin_commit-24           13.3kB ±37%    11.0kB ± 2%  -17.28%  (p=0.000 n=15+13)
Sysbench/SQL/1node_local/oltp_point_select-24     26.3kB ± 1%    24.0kB ± 4%   -8.69%  (p=0.000 n=14+13)
Sysbench/SQL/3node/oltp_write_only-24             1.14MB ± 2%    1.10MB ± 0%   -3.39%  (p=0.000 n=15+15)
Sysbench/SQL/3node/oltp_read_write-24             2.32MB ± 1%    2.27MB ± 0%   -1.90%  (p=0.000 n=15+15)
Sysbench/SQL/1node_remote/oltp_write_only-24       538kB ± 1%     530kB ± 3%   -1.48%  (p=0.002 n=14+15)
Sysbench/SQL/1node_local/oltp_write_only-24        479kB ± 3%     474kB ± 3%   -0.93%  (p=0.002 n=15+15)
Sysbench/KV/3node/oltp_write_only-24               766kB ± 0%     765kB ± 0%   -0.18%  (p=0.002 n=13+14)
Sysbench/SQL/1node_local/oltp_read_only-24         809kB ± 0%     808kB ± 0%   -0.17%  (p=0.022 n=13+12)
Sysbench/KV/1node_local/oltp_begin_commit-24      2.77kB ± 0%    2.76kB ± 0%   -0.14%  (p=0.002 n=13+14)
Sysbench/SQL/1node_local/oltp_begin_commit-24     11.6kB ±15%    11.7kB ±13%     ~     (p=0.345 n=15+15)
Sysbench/SQL/1node_remote/oltp_read_only-24       1.12MB ± 1%    1.12MB ± 1%     ~     (p=0.345 n=15+15)
Sysbench/SQL/1node_remote/oltp_read_write-24      1.65MB ± 1%    1.64MB ± 1%     ~     (p=0.512 n=15+15)
Sysbench/SQL/3node/oltp_read_only-24              1.20MB ± 2%    1.19MB ± 3%     ~     (p=0.116 n=15+15)
Sysbench/KV/1node_local/oltp_read_only-24          257kB ± 0%     257kB ± 0%     ~     (p=0.905 n=13+14)
Sysbench/KV/1node_local/oltp_write_only-24         260kB ± 0%     260kB ± 0%     ~     (p=0.874 n=14+14)
Sysbench/KV/1node_local/oltp_read_write-24         518kB ± 0%     518kB ± 0%     ~     (p=0.559 n=15+15)
Sysbench/KV/1node_local/oltp_point_select-24      4.69kB ± 0%    4.69kB ± 0%     ~     (p=0.569 n=14+15)
Sysbench/KV/1node_remote/oltp_read_only-24         650kB ± 0%     650kB ± 0%     ~     (p=0.250 n=15+15)
Sysbench/KV/1node_remote/oltp_write_only-24        322kB ± 0%     322kB ± 0%     ~     (p=0.650 n=13+15)
Sysbench/KV/1node_remote/oltp_read_write-24        976kB ± 0%     975kB ± 0%     ~     (p=0.100 n=15+15)
Sysbench/KV/1node_remote/oltp_point_select-24     6.66kB ± 3%    6.64kB ± 3%     ~     (p=0.559 n=15+15)
Sysbench/KV/1node_remote/oltp_begin_commit-24     2.76kB ± 0%    2.76kB ± 0%     ~     (p=0.166 n=15+15)
Sysbench/KV/3node/oltp_read_only-24                674kB ± 0%     675kB ± 0%     ~     (p=0.051 n=15+14)
Sysbench/KV/3node/oltp_read_write-24              1.45MB ± 0%    1.45MB ± 0%     ~     (p=0.305 n=15+15)
Sysbench/KV/3node/oltp_point_select-24            7.78kB ± 2%    7.80kB ± 2%     ~     (p=0.820 n=11+13)
Sysbench/KV/3node/oltp_begin_commit-24            2.83kB ± 1%    2.83kB ± 0%     ~     (p=0.904 n=13+12)
Sysbench/SQL/1node_remote/oltp_point_select-24    26.9kB ± 1%    27.0kB ± 1%   +0.33%  (p=0.012 n=15+14)
Sysbench/SQL/1node_remote/oltp_begin_commit-24    10.7kB ± 0%    10.7kB ± 1%   +0.63%  (p=0.000 n=15+15)
Sysbench/SQL/1node_local/oltp_read_write-24       1.27MB ± 1%    1.28MB ± 0%   +0.64%  (p=0.006 n=15+12)
Sysbench/SQL/3node/oltp_point_select-24           34.0kB ±14%    63.1kB ±43%  +85.32%  (p=0.000 n=14+15)


Sysbench/SQL/3node/oltp_begin_commit-24             87.9 ±42%      69.1 ± 2%  -21.31%  (p=0.000 n=15+14)
Sysbench/SQL/1node_local/oltp_point_select-24        205 ± 1%       188 ± 4%   -8.55%  (p=0.000 n=15+13)
Sysbench/SQL/1node_local/oltp_write_only-24        2.68k ± 0%     2.66k ± 0%   -0.59%  (p=0.000 n=12+14)
Sysbench/SQL/1node_remote/oltp_write_only-24       3.47k ± 0%     3.46k ± 0%   -0.31%  (p=0.000 n=15+14)
Sysbench/SQL/1node_local/oltp_read_only-24         3.64k ± 0%     3.63k ± 0%   -0.25%  (p=0.020 n=15+15)
Sysbench/KV/1node_local/oltp_read_write-24         1.87k ± 0%     1.87k ± 0%   -0.06%  (p=0.016 n=15+14)
Sysbench/SQL/1node_local/oltp_read_write-24        6.20k ± 0%     6.21k ± 0%     ~     (p=0.054 n=15+15)
Sysbench/SQL/1node_local/oltp_begin_commit-24       74.1 ±16%      74.8 ±15%     ~     (p=0.508 n=15+15)
Sysbench/SQL/1node_remote/oltp_read_write-24       7.62k ± 0%     7.62k ± 0%     ~     (p=0.213 n=14+15)
Sysbench/SQL/3node/oltp_read_only-24               4.48k ± 2%     4.48k ± 2%     ~     (p=0.976 n=15+15)
Sysbench/SQL/3node/oltp_read_write-24              10.2k ± 1%     10.2k ± 0%     ~     (p=0.736 n=15+15)
Sysbench/KV/1node_local/oltp_read_only-24            436 ± 0%       436 ± 0%     ~     (all equal)
Sysbench/KV/1node_local/oltp_write_only-24         1.41k ± 0%     1.41k ± 0%     ~     (p=0.957 n=11+14)
Sysbench/KV/1node_local/oltp_point_select-24        23.0 ± 0%      23.0 ± 0%     ~     (all equal)
Sysbench/KV/1node_local/oltp_begin_commit-24        6.00 ± 0%      6.00 ± 0%     ~     (all equal)
Sysbench/KV/1node_remote/oltp_read_only-24         1.78k ± 0%     1.78k ± 0%     ~     (all equal)
Sysbench/KV/1node_remote/oltp_write_only-24        2.25k ± 0%     2.25k ± 0%     ~     (p=0.912 n=14+15)
Sysbench/KV/1node_remote/oltp_read_write-24        4.09k ± 0%     4.09k ± 0%     ~     (p=0.117 n=15+15)
Sysbench/KV/1node_remote/oltp_point_select-24       53.5 ± 1%      53.5 ± 1%     ~     (p=1.000 n=15+15)
Sysbench/KV/1node_remote/oltp_begin_commit-24       6.00 ± 0%      6.00 ± 0%     ~     (all equal)
Sysbench/KV/3node/oltp_read_only-24                1.90k ± 0%     1.90k ± 0%     ~     (p=0.874 n=14+13)
Sysbench/KV/3node/oltp_write_only-24               4.47k ± 0%     4.46k ± 0%     ~     (p=0.350 n=15+15)
Sysbench/KV/3node/oltp_read_write-24               6.48k ± 0%     6.48k ± 0%     ~     (p=0.340 n=15+15)
Sysbench/KV/3node/oltp_point_select-24              55.8 ± 1%      56.0 ± 0%     ~     (p=0.399 n=11+13)
Sysbench/KV/3node/oltp_begin_commit-24              6.00 ± 0%      6.00 ± 0%     ~     (all equal)
Sysbench/SQL/1node_remote/oltp_read_only-24        4.20k ± 0%     4.21k ± 1%   +0.26%  (p=0.015 n=13+15)
Sysbench/SQL/1node_remote/oltp_point_select-24       223 ± 0%       224 ± 0%   +0.27%  (p=0.002 n=12+15)
Sysbench/SQL/3node/oltp_write_only-24              5.78k ± 1%     5.81k ± 0%   +0.53%  (p=0.019 n=15+14)
Sysbench/SQL/1node_remote/oltp_begin_commit-24      67.0 ± 0%      67.5 ± 2%   +0.80%  (p=0.006 n=15+15)
Sysbench/SQL/3node/oltp_point_select-24              278 ±14%       314 ± 0%  +13.06%  (p=0.001 n=15+13)
```

Epic: CRDB-42584
Release note: None