### PR TITLE
roachpb: simplify locality comparison logic

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender.go
@@ -3146,15 +3146,7 @@ func (ds *DistSender) getLocalityComparison(
 		log.VEventf(ctx, 5, "failed to perform look up for node descriptor %v", err)
 		return roachpb.LocalityComparisonType_UNDEFINED
 	}
-
-	comparisonResult, regionValid, zoneValid := gatewayNodeDesc.Locality.CompareWithLocality(destinationNodeDesc.Locality)
-	if !regionValid {
-		log.VInfof(ctx, 5, "unable to determine if the given nodes are cross region")
-	}
-	if !zoneValid {
-		log.VInfof(ctx, 5, "unable to determine if the given nodes are cross zone")
-	}
-	return comparisonResult
+	return gatewayNodeDesc.Locality.Compare(destinationNodeDesc.Locality)
 }
 
 func (ds *DistSender) maybeIncrementErrCounters(br *kvpb.BatchResponse, err error) {

--- a/pkg/kv/kvserver/replica_command.go
+++ b/pkg/kv/kvserver/replica_command.go
@@ -3357,7 +3357,7 @@ func (r *Replica) followerSendSnapshot(
 	sent := func() {
 		r.store.metrics.RangeSnapshotsGenerated.Inc(1)
 	}
-	comparisonResult := r.store.getLocalityComparison(ctx, req.CoordinatorReplica.NodeID,
+	comparisonResult := r.store.getLocalityComparison(req.CoordinatorReplica.NodeID,
 		req.RecipientReplica.NodeID)
 
 	recordBytesSent := func(inc int64) {

--- a/pkg/kv/kvserver/store_raft.go
+++ b/pkg/kv/kvserver/store_raft.go
@@ -328,7 +328,7 @@ func (s *Store) uncoalesceBeats(
 func (s *Store) HandleRaftRequest(
 	ctx context.Context, req *kvserverpb.RaftMessageRequest, respStream RaftMessageResponseStream,
 ) *kvpb.Error {
-	comparisonResult := s.getLocalityComparison(ctx, req.FromReplica.NodeID, req.ToReplica.NodeID)
+	comparisonResult := s.getLocalityComparison(req.FromReplica.NodeID, req.ToReplica.NodeID)
 	s.metrics.updateCrossLocalityMetricsOnIncomingRaftMsg(comparisonResult, int64(req.Size()))
 	// NB: unlike the other two IncomingRaftMessageHandler methods implemented by
 	// Store, this one doesn't need to directly run through a Stopper task because
@@ -389,7 +389,7 @@ func (s *Store) HandleRaftUncoalescedRequest(
 func (s *Store) HandleRaftRequestSent(
 	ctx context.Context, fromNodeID roachpb.NodeID, toNodeID roachpb.NodeID, msgSize int64,
 ) {
-	comparisonResult := s.getLocalityComparison(ctx, fromNodeID, toNodeID)
+	comparisonResult := s.getLocalityComparison(fromNodeID, toNodeID)
 	s.metrics.updateCrossLocalityMetricsOnOutgoingRaftMsg(comparisonResult, msgSize)
 }
 

--- a/pkg/kv/kvserver/store_snapshot.go
+++ b/pkg/kv/kvserver/store_snapshot.go
@@ -1558,18 +1558,11 @@ func (s *Store) checkSnapshotOverlapLocked(
 // comparison result between their corresponding nodes. This result indicates
 // whether the two nodes are located in different regions or zones.
 func (s *Store) getLocalityComparison(
-	ctx context.Context, fromNodeID roachpb.NodeID, toNodeID roachpb.NodeID,
+	fromNodeID roachpb.NodeID, toNodeID roachpb.NodeID,
 ) roachpb.LocalityComparisonType {
 	firstLocality := s.cfg.StorePool.GetNodeLocality(fromNodeID)
 	secLocality := s.cfg.StorePool.GetNodeLocality(toNodeID)
-	comparisonResult, regionValid, zoneValid := firstLocality.CompareWithLocality(secLocality)
-	if !regionValid {
-		log.VEventf(ctx, 5, "unable to determine if the given nodes are cross region")
-	}
-	if !zoneValid {
-		log.VEventf(ctx, 5, "unable to determine if the given nodes are cross zone")
-	}
-	return comparisonResult
+	return firstLocality.Compare(secLocality)
 }
 
 // receiveSnapshot receives an incoming snapshot via a pre-opened GRPC stream.
@@ -1676,8 +1669,8 @@ func (s *Store) receiveSnapshot(
 		log.Infof(ctx, "accepted snapshot reservation for r%d", header.State.Desc.RangeID)
 	}
 
-	comparisonResult := s.getLocalityComparison(ctx,
-		header.RaftMessageRequest.FromReplica.NodeID, header.RaftMessageRequest.ToReplica.NodeID)
+	comparisonResult := s.getLocalityComparison(header.RaftMessageRequest.FromReplica.NodeID,
+		header.RaftMessageRequest.ToReplica.NodeID)
 
 	recordBytesReceived := func(inc int64) {
 		s.metrics.RangeSnapshotRcvdBytes.Inc(inc)

--- a/pkg/roachpb/metadata.go
+++ b/pkg/roachpb/metadata.go
@@ -630,16 +630,13 @@ func (l Locality) Matches(filter Locality) (bool, Tier) {
 	return true, Tier{}
 }
 
-// getFirstRegionFirstZone iterates through the locality tiers and returns
-// multiple values containing:
-// 1. The value of the first encountered "region" tier.
-// 2. A boolean indicating whether the "region" tier key was found.
-// 3,4. The key and the value of the first encountered "zone" tier.
-// 5. A boolean indicating whether the "zone" tier key was found.
+// getFirstRegionFirstZone returns the first region and zone values found in the locality tiers.
+// Returns:
+// - First region value and whether region was found.
+// - First zone value and whether zone was found.
 func (l Locality) getFirstRegionFirstZone() (
 	firstRegionValue string,
 	hasRegion bool,
-	firstZoneKey string,
 	firstZoneValue string,
 	hasZone bool,
 ) {
@@ -655,65 +652,59 @@ func (l Locality) getFirstRegionFirstZone() (
 			}
 		case "zone", "availability-zone", "az":
 			if !hasZone {
-				firstZoneKey, firstZoneValue = tier.Key, tier.Value
+				firstZoneValue = tier.Value
 				hasZone = true
 			}
 		}
 	}
-	return firstRegionValue, hasRegion, firstZoneKey, firstZoneValue, hasZone
+	return firstRegionValue, hasRegion, firstZoneValue, hasZone
 }
 
-// CompareWithLocality returns the comparison result between this and the
-// provided other locality along with any lookup errors. Possible errors include
-// 1. if either locality does not have a "region" tier key. 2. if either
-// locality does not have a "zone" tier key or if the first "zone" tier keys
-// used by two localities are different.
+// Compare compares two localities based on their region and zone tiers.
 //
-// Limitation:
-// - It is unfortunate that the tier key is hardcoded here. Ideally, we would
-// prefer a more robust way to look up node locality regions and zones.
-// - Although it is technically possible for users to use  “az”, “zone”,
-// “availability-zone” as tier keys within a single locality, it can cause
-// confusion when choosing the zone tier values for cross-zone comparison. In
-// such cases, we would want to return an error. Ideally, both localities would
-// be checked thoroughly for duplicate zone tier keys and key mismatches.
-// However, due to frequent invocation of this function, we prefer to terminate
-// the check after examining the first encountered zone tier key-value pairs.
+// Returns:
+//   - UNDEFINED if neither region nor zone tiers exist in both localities.
+//   - CROSS_REGION if regions exist in both and differ.
+//   - SAME_REGION_CROSS_ZONE if zones exist in both and differ.
+//   - SAME_REGION_SAME_ZONE if regions/zones match or partial matches exist.
+//     Partial matches occur when only one locality has a region but zones match,
+//     or only one has a zone but regions match.
 //
-// Note: it is intentional here to perform multiple locality tiers comparison in
-// a single function to avoid overhead. If you are adding additional locality
-// tiers comparisons, it is recommended to handle them within one tier list
-// iteration.
-func (l Locality) CompareWithLocality(
-	other Locality,
-) (_ LocalityComparisonType, regionValid bool, zoneValid bool) {
-	firstRegionValue, hasRegion, firstZoneKey, firstZone, hasZone := l.getFirstRegionFirstZone()
-	firstRegionValueOther, hasRegionOther, firstZoneKeyOther, firstZoneOther, hasZoneOther := other.getFirstRegionFirstZone()
+// Limitations:
+// - Region and zone keys are hardcoded.
+// - Only first matching zone tier is considered.
+// - Assume at most one region/zone tier per locality.
+//
+// All comparisons are done in a single pass for performance.
+func (l Locality) Compare(other Locality) LocalityComparisonType {
+	// Get region and zone information for both localities.
+	thisRegion, hasThisRegion, thisZone, hasThisZone := l.getFirstRegionFirstZone()
+	otherRegion, hasOtherRegion, otherZone, hasOtherZone := other.getFirstRegionFirstZone()
 
-	isCrossRegion := firstRegionValue != firstRegionValueOther
-	isCrossZone := firstZone != firstZoneOther
+	// Check if we have valid region and zone information to compare.
+	hasValidRegions := hasThisRegion && hasOtherRegion
+	hasValidZones := hasThisZone && hasOtherZone
 
-	if !hasRegion || !hasRegionOther {
-		isCrossRegion = false
-	} else {
-		regionValid = true
+	// Return UNDEFINED if we lack both region and zone information.
+	if !hasValidRegions && !hasValidZones {
+		return LocalityComparisonType_UNDEFINED
 	}
 
-	if (!hasZone || !hasZoneOther) || (firstZoneKey != firstZoneKeyOther) {
-		isCrossZone = false
-	} else {
-		zoneValid = true
+	// Return CROSS_REGION if regions differ.
+	if hasValidRegions && thisRegion != otherRegion {
+		return LocalityComparisonType_CROSS_REGION
 	}
 
-	if isCrossRegion {
-		return LocalityComparisonType_CROSS_REGION, regionValid, zoneValid
-	} else {
-		if isCrossZone {
-			return LocalityComparisonType_SAME_REGION_CROSS_ZONE, regionValid, zoneValid
-		} else {
-			return LocalityComparisonType_SAME_REGION_SAME_ZONE, regionValid, zoneValid
-		}
+	// Return SAME_REGION_CROSS_ZONE if zones differ but regions match.
+	if hasValidZones && thisZone != otherZone {
+		return LocalityComparisonType_SAME_REGION_CROSS_ZONE
 	}
+
+	// Return SAME_REGION_SAME_ZONE for matching or partial matches. Partial
+	// matches occur when only one locality has a region but zones match, or only
+	// one has a zone, but regions match. In the case of partial matches, the
+	// locality with the missing information is considered to be more local.
+	return LocalityComparisonType_SAME_REGION_SAME_ZONE
 }
 
 // SharedPrefix returns the number of this locality's tiers which match those of

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -1808,20 +1808,12 @@ func (n *Node) getLocalityComparison(
 	}
 	gatewayNodeDesc, err := gossip.GetNodeDescriptor(gatewayNodeID)
 	if err != nil {
-		log.VInfof(ctx, 2,
+		log.VInfof(ctx, 5,
 			"failed to perform look up for node descriptor %v", err)
 		return roachpb.LocalityComparisonType_UNDEFINED
 	}
 
-	comparisonResult, regionValid, zoneValid := n.Descriptor.Locality.CompareWithLocality(gatewayNodeDesc.Locality)
-	if !regionValid {
-		log.VInfof(ctx, 5, "unable to determine if the given nodes are cross region")
-	}
-	if !zoneValid {
-		log.VInfof(ctx, 5, "unable to determine if the given nodes are cross zone")
-	}
-
-	return comparisonResult
+	return n.Descriptor.Locality.Compare(gatewayNodeDesc.Locality)
 }
 
 // incrementBatchCounters increments counters to track the batch and composite


### PR DESCRIPTION
Previous, locality.CompareWithLocality was too complex since it was trying to
return detailed region and zone validation states to help callers print error
messages. Usually, the caller doesn't actually care about these details since
this is just for metrics and only enabled at log V(5).

This commit refactors the code so that it simply returns UNDEFINED if the
localities are invalid or incomplete. The new Compare method maintains the same
correctness guarantees for what the caller actually cares about.

Epic: none
Release note: none