### PR TITLE
dev: add `whoownsit` to dev build targets

### DIFF
--- a/pkg/cmd/dev/build.go
+++ b/pkg/cmd/dev/build.go
@@ -108,6 +108,7 @@ var buildTargetMapping = map[string]string{
 	"sql-bootstrap-data":   "//pkg/cmd/sql-bootstrap-data:sql-bootstrap-data",
 	"staticcheck":          "@co_honnef_go_tools//cmd/staticcheck:staticcheck",
 	"tests":                "//pkg:all_tests",
+	"whoownsit":            "//pkg/cmd/whoownsit:whoownsit",
 	"workload":             "//pkg/cmd/workload:workload",
 }
 


### PR DESCRIPTION
This utility displays file ownership locally without requiring the creation of a PR.

Release note: none
Epic: none