### PR TITLE
all: use tenant name scoped client certs for auth

### DIFF
--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -667,7 +667,6 @@ func init() {
 		if cmd == createClientCertCmd {
 			cliflagcfg.VarFlag(f, &tenantIDSetter{tenantIDs: &certCtx.tenantScope}, cliflags.TenantScope)
 			cliflagcfg.VarFlag(f, &tenantNameSetter{tenantNames: &certCtx.tenantNameScope}, cliflags.TenantScopeByNames)
-			_ = f.MarkHidden(cliflags.TenantScopeByNames.Name)
 
 			// PKCS8 key format is only available for the client cert command.
 			cliflagcfg.BoolFlag(f, &certCtx.generatePKCS8Key, cliflags.GeneratePKCS8Key)

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -667,6 +667,7 @@ func init() {
 		if cmd == createClientCertCmd {
 			cliflagcfg.VarFlag(f, &tenantIDSetter{tenantIDs: &certCtx.tenantScope}, cliflags.TenantScope)
 			cliflagcfg.VarFlag(f, &tenantNameSetter{tenantNames: &certCtx.tenantNameScope}, cliflags.TenantScopeByNames)
+			_ = f.MarkDeprecated(cliflags.TenantScope.Name, fmt.Sprintf("use %s instead", cliflags.TenantScopeByNames.Name))
 
 			// PKCS8 key format is only available for the client cert command.
 			cliflagcfg.BoolFlag(f, &certCtx.generatePKCS8Key, cliflags.GeneratePKCS8Key)

--- a/pkg/rpc/auth_test.go
+++ b/pkg/rpc/auth_test.go
@@ -132,7 +132,7 @@ func TestAuthenticateTenant(t *testing.T) {
 		{systemID: stid, ous: nil, commonName: "root"},
 		{systemID: stid, ous: nil, commonName: "node"},
 		{systemID: stid, ous: nil, commonName: "root", tenantScope: 10,
-			expErr: `need root or node client cert to perform RPCs on this server \(this is tenant system; cert is valid for "root" on tenant 10\)`},
+			expErr: `need root or node client cert to perform RPCs on this server \(this is tenant system; cert is valid for "root" on tenantID 10\)`},
 		{systemID: tenTen, ous: correctOU, commonName: "10", expTenID: roachpb.TenantID{}},
 		{systemID: tenTen, ous: correctOU, commonName: "123", expErr: `client tenant identity \(123\) does not match server`},
 		{systemID: tenTen, ous: correctOU, commonName: "1", expErr: `invalid tenant ID 1 in Common Name \(CN\)`},

--- a/pkg/rpc/context.go
+++ b/pkg/rpc/context.go
@@ -302,7 +302,8 @@ func (c *Context) StoreLivenessWithdrawalGracePeriod() time.Duration {
 // ContextOptions are passed to NewContext to set up a new *Context.
 // All pointer fields and TenantID are required.
 type ContextOptions struct {
-	TenantID roachpb.TenantID
+	TenantID   roachpb.TenantID
+	TenantName roachpb.TenantName
 
 	Clock                  hlc.WallClock
 	ToleratedOffset        time.Duration

--- a/pkg/security/auth_test.go
+++ b/pkg/security/auth_test.go
@@ -506,12 +506,13 @@ func TestAuthenticationHook(t *testing.T) {
 				tc.insecure,
 				makeFakeTLSState(t, tc.tlsSpec),
 				tc.tenantID,
+				"",
 				nil, /* certManager */
 				roleSubject,
 				tc.subjectRequired,
 			)
 			if (err == nil) != tc.buildHookSuccess {
-				t.Fatalf("expected success=%t, got err=%v", tc.buildHookSuccess, err)
+				t.Fatalf("expected success=%t, got err=%v expected err=%s", tc.buildHookSuccess, err, tc.expectedErr)
 			}
 			if err != nil {
 				require.Regexp(t, tc.expectedErr, err.Error())
@@ -519,7 +520,7 @@ func TestAuthenticationHook(t *testing.T) {
 			}
 			err = hook(ctx, tc.username, true /* clientConnection */)
 			if (err == nil) != tc.publicHookSuccess {
-				t.Fatalf("expected success=%t, got err=%v", tc.publicHookSuccess, err)
+				t.Fatalf("expected success=%t, got err=%v expected err=%s", tc.publicHookSuccess, err, tc.expectedErr)
 			}
 			if err != nil {
 				require.Regexp(t, tc.expectedErr, err.Error())
@@ -527,7 +528,7 @@ func TestAuthenticationHook(t *testing.T) {
 			}
 			err = hook(ctx, tc.username, false /* clientConnection */)
 			if (err == nil) != tc.privateHookSuccess {
-				t.Fatalf("expected success=%t, got err=%v", tc.privateHookSuccess, err)
+				t.Fatalf("expected success=%t, got err=%v, expected err=%s", tc.privateHookSuccess, err, tc.expectedErr)
 			}
 			if err != nil {
 				require.Regexp(t, tc.expectedErr, err.Error())

--- a/pkg/server/server_controller_new_server.go
+++ b/pkg/server/server_controller_new_server.go
@@ -69,7 +69,8 @@ func (s *topLevelServer) newTenantServer(
 		return nil, err
 	}
 
-	baseCfg, sqlCfg, err := s.makeSharedProcessTenantConfig(ctx, tenantID, portStartHint, tenantStopper, testArgs.Settings)
+	baseCfg, sqlCfg, err := s.makeSharedProcessTenantConfig(ctx, tenantID, tenantNameContainer.Get(), portStartHint,
+		tenantStopper, testArgs.Settings)
 	if err != nil {
 		return nil, err
 	}
@@ -146,6 +147,7 @@ func newTenantServerInternal(
 func (s *topLevelServer) makeSharedProcessTenantConfig(
 	ctx context.Context,
 	tenantID roachpb.TenantID,
+	tenantName roachpb.TenantName,
 	portStartHint int,
 	stopper *stop.Stopper,
 	testSettings *cluster.Settings,
@@ -164,7 +166,8 @@ func (s *topLevelServer) makeSharedProcessTenantConfig(
 		st.SV.TestingCopyForVirtualCluster(&testSettings.SV)
 	}
 
-	baseCfg, sqlCfg, err := makeSharedProcessTenantServerConfig(ctx, tenantID, portStartHint, parentCfg, localServerInfo, st, stopper, s.recorder)
+	baseCfg, sqlCfg, err := makeSharedProcessTenantServerConfig(ctx, tenantID, tenantName, portStartHint, parentCfg,
+		localServerInfo, st, stopper, s.recorder)
 	if err != nil {
 		return BaseConfig{}, SQLConfig{}, err
 	}
@@ -176,6 +179,7 @@ func (s *topLevelServer) makeSharedProcessTenantConfig(
 func makeSharedProcessTenantServerConfig(
 	ctx context.Context,
 	tenantID roachpb.TenantID,
+	tenantName roachpb.TenantName,
 	portStartHint int,
 	kvServerCfg Config,
 	kvServerInfo LocalKVServerInfo,
@@ -324,7 +328,7 @@ func makeSharedProcessTenantServerConfig(
 		}
 	}
 
-	sqlCfg = MakeSQLConfig(tenantID, tempStorageCfg)
+	sqlCfg = MakeSQLConfig(tenantID, tenantName, tempStorageCfg)
 	baseCfg.ExternalIODirConfig = kvServerCfg.BaseConfig.ExternalIODirConfig
 
 	baseCfg.ExternalIODir = kvServerCfg.BaseConfig.ExternalIODir

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -1475,6 +1475,7 @@ func (s *SQLServer) preStart(
 		// from KV (or elsewhere).
 		if entry, _ := s.tenantConnect.TenantInfo(); entry.Name != "" {
 			s.cfg.idProvider.SetTenantName(entry.Name)
+			s.execCfg.RPCContext.TenantName = entry.Name
 			s.execCfg.VirtualClusterName = entry.Name
 		}
 		if err := s.startCheckService(ctx, stopper); err != nil {

--- a/pkg/server/tenant.go
+++ b/pkg/server/tenant.go
@@ -1114,6 +1114,7 @@ func makeTenantSQLServerArgs(
 
 	rpcCtxOpts := rpc.ServerContextOptionsFromBaseConfig(baseCfg.Config)
 	rpcCtxOpts.TenantID = sqlCfg.TenantID
+	rpcCtxOpts.TenantName = sqlCfg.TenantName
 	rpcCtxOpts.UseNodeAuth = sqlCfg.LocalKVServerInfo != nil
 	rpcCtxOpts.NodeID = baseCfg.IDContainer
 	rpcCtxOpts.StorageClusterID = baseCfg.ClusterIDContainer

--- a/pkg/server/tenant_delayed_id_set_test.go
+++ b/pkg/server/tenant_delayed_id_set_test.go
@@ -52,7 +52,7 @@ func TestStartTenantWithDelayedID(t *testing.T) {
 	st := cluster.MakeTestingClusterSettings()
 	baseCfg := makeTestBaseConfig(st, s.Stopper().Tracer())
 	require.Equal(t, roachpb.Locality{}, baseCfg.Locality)
-	sqlCfg := makeTestSQLConfig(st, roachpb.TenantID{})
+	sqlCfg := makeTestSQLConfig(st, roachpb.TenantID{}, "")
 	sqlCfg.TenantLoopbackAddr = s.AdvRPCAddr()
 
 	var tenantIDSet, listenerReady sync.WaitGroup

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -88,7 +88,8 @@ func makeTestConfig(st *cluster.Settings, tr *tracing.Tracer) Config {
 	return Config{
 		BaseConfig: makeTestBaseConfig(st, tr),
 		KVConfig:   makeTestKVConfig(),
-		SQLConfig:  makeTestSQLConfig(st, roachpb.SystemTenantID),
+		SQLConfig: makeTestSQLConfig(st, roachpb.SystemTenantID,
+			roachpb.TenantName(roachpb.SystemTenantID.String())),
 	}
 }
 
@@ -125,8 +126,10 @@ func makeTestKVConfig() KVConfig {
 	return kvCfg
 }
 
-func makeTestSQLConfig(st *cluster.Settings, tenID roachpb.TenantID) SQLConfig {
-	return MakeSQLConfig(tenID, base.DefaultTestTempStorageConfig(st))
+func makeTestSQLConfig(
+	st *cluster.Settings, tenID roachpb.TenantID, tenName roachpb.TenantName,
+) SQLConfig {
+	return MakeSQLConfig(tenID, tenName, base.DefaultTestTempStorageConfig(st))
 }
 
 func initTraceDir(dir string) error {
@@ -1714,7 +1717,7 @@ func (ts *testServer) StartTenant(
 		st = cluster.MakeTestingClusterSettings()
 	}
 
-	sqlCfg := makeTestSQLConfig(st, params.TenantID)
+	sqlCfg := makeTestSQLConfig(st, params.TenantID, params.TenantName)
 	sqlCfg.TenantLoopbackAddr = ts.AdvRPCAddr()
 	if params.MemoryPoolSize != 0 {
 		sqlCfg.MemoryPoolSize = params.MemoryPoolSize

--- a/pkg/sql/pgwire/auth_methods.go
+++ b/pkg/sql/pgwire/auth_methods.go
@@ -449,6 +449,7 @@ func authCert(
 			false, /*insecure*/
 			&tlsState,
 			execCfg.RPCContext.TenantID,
+			execCfg.RPCContext.TenantName,
 			cm,
 			roleSubject,
 			security.ClientCertSubjectRequired.Get(&execCfg.Settings.SV),


### PR DESCRIPTION
Improve user experience for tenant-scoped client certificate generation

Previously, users generated tenant-scoped client certificates using the `--tenant-scope` flag, which required specifying a list of tenant IDs. This approach was inconvenient, as users needed to know and manually provide tenant IDs.

This PR introduces the `--tenant-name-scope` flag, allowing users to specify tenant names instead of IDs when generating tenant-scoped client certificates. Since users typically interact with tenants by name rather than ID, this change enhances usability and provides a more intuitive experience.

`--tenant-name-scope` flag deprecates `--tenant-scope` flag and eventually replaces it.

--- 

So far, users use to generate client certs with tenant scope as follows:
```
$COCKROACH_HOME/cockroach cert create-client \
	--certs-dir=$HOME/.cockroach-certs \
	--tenant-scope=4 \
	--ca-key=$HOME/.cockroach-certs/ca-key.pem test
```

Tenant scopes are added to the certs using SAN extensions:
```
└─▪ openssl x509 -in ~/.cockroach-certs/client.test.crt -text | grep URI
                URI:crdb://tenant/4/user/test
```

After this change users can generate client certs with tenant scope as follows:
```
$COCKROACH_HOME/cockroach cert create-client \
	--certs-dir=$HOME/.cockroach-certs \
	--tenant-name-scope=test \
	--ca-key=$HOME/.cockroach-certs/ca-key.pem test
```

Tenant scopes are added to the certs using SAN extensions. Notice that the URI is different from tenant ID URI. 
```
└─▪ openssl x509 -in ~/.cockroach-certs/client.test.crt -text | grep URI
                URI:crdb://tenant-name/test/user/test
```

To be backward compatible, we continue to support `--tenant-scope` and eventually remove its support. 

Users can also mix and match tenant ID and tenant name scopes as follows:
```
$COCKROACH_HOME/cockroach cert create-client \
	--certs-dir=$HOME/.cockroach-certs \
	--tenant-scope=3 \
	--tenant-name-scope=test \
	--ca-key=$HOME/.cockroach-certs/ca-key.pem test
```

Tenant scopes added to the certs:
```
└─▪ openssl x509 -in ~/.cockroach-certs/client.test.crt -text | grep URI
                URI:crdb://tenant/3/user/test, URI:crdb://tenant-name/test/user/test
```

Epic: [CRDB-39093](https://cockroachlabs.atlassian.net/browse/CRDB-39093)
Informs: https://github.com/cockroachdb/cockroach/issues/105340
Release note: Added a new `--tenant-name-scope` flag to the `cockroach cert create-client` command, allowing the generation of tenant-scoped client certificates using tenant names. Previously, these certificates were created using tenant IDs.