### PR TITLE
kvclient/rangefeed: add useBufferedSender=true for rangefeedTestType

### DIFF
--- a/pkg/kv/kvclient/rangefeed/rangefeed_external_test.go
+++ b/pkg/kv/kvclient/rangefeed/rangefeed_external_test.go
@@ -68,6 +68,9 @@ var feedTypes = []rangefeedTestType{
 	{
 		useBufferedSender: false,
 	},
+	{
+		useBufferedSender: true,
+	},
 }
 
 // TestRangeFeedIntegration is a basic integration test demonstrating all of


### PR DESCRIPTION
Previously, rangefeedTestType only included useBufferedSender=false. This patch
extends the tests by adding useBufferedSender=true as well. It will override the
cluster setting kvserver.RangefeedUseBufferedSender as true during testing. Note
that the framework for overriding this cluster setting already exists.

Epic: none
Release note: none