### PR TITLE
changefeedccl: fix key_in_value handling in enriched envelopes

### DIFF
--- a/pkg/ccl/changefeedccl/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/BUILD.bazel
@@ -235,6 +235,7 @@ go_test(
         "//pkg/ccl/changefeedccl/changefeedbase",
         "//pkg/ccl/changefeedccl/changefeedpb",
         "//pkg/ccl/changefeedccl/checkpoint",
+        "//pkg/ccl/changefeedccl/kcjsonschema",
         "//pkg/ccl/changefeedccl/kvevent",
         "//pkg/ccl/changefeedccl/mocks",
         "//pkg/ccl/changefeedccl/resolvedspan",

--- a/pkg/ccl/changefeedccl/kcjsonschema/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/kcjsonschema/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
     deps = [
         "//pkg/ccl/changefeedccl/cdcevent",
         "//pkg/ccl/changefeedccl/changefeedbase",
+        "//pkg/geo",
         "//pkg/sql/types",
         "//pkg/util/json",
         "@com_github_cockroachdb_errors//:errors",
@@ -20,7 +21,6 @@ go_test(
     embed = [":kcjsonschema"],
     deps = [
         "//pkg/ccl/changefeedccl/cdcevent",
-        "//pkg/geo",
         "//pkg/keys",
         "//pkg/settings/cluster",
         "//pkg/sql/catalog",
@@ -43,7 +43,6 @@ go_test(
         "//pkg/util/randutil",
         "//pkg/util/timeutil",
         "@com_github_pkg_errors//:errors",
-        "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
     ],
 )


### PR DESCRIPTION
The interaction between key_in_value and
enriched_properties=schema is interesting -- with
the latter, keys include an inline schema
`{"schema": .., "payload": ..}`, but we don't want
to include a schema in the message value, so we
include the value portion of the key (`.payload`)
instead. In this case `(value).payload.key` now equals `(key).payload.`

Fixes: #142607

Release note: None