### PR TITLE
release-24.1: sql/schemachanger: fix create sequence schema version bump

### DIFF
--- a/pkg/sql/schemachanger/scexec/scmutationexec/references.go
+++ b/pkg/sql/schemachanger/scexec/scmutationexec/references.go
@@ -604,17 +604,16 @@ func updateBackReferencesInRelation(
 }
 
 func (i *immediateVisitor) SetObjectParentID(ctx context.Context, op scop.SetObjectParentID) error {
-	sc, err := i.checkOutSchema(ctx, op.ObjParent.SchemaID)
-	if err != nil {
-		return err
-	}
-
 	obj, err := i.checkOutDescriptor(ctx, op.ObjParent.ChildObjectID)
 	if err != nil {
 		return err
 	}
 	switch t := obj.(type) {
 	case *funcdesc.Mutable:
+		sc, err := i.checkOutSchema(ctx, op.ObjParent.SchemaID)
+		if err != nil {
+			return err
+		}
 		if t.ParentSchemaID != descpb.InvalidID {
 			sc.RemoveFunction(t.GetName(), t.GetID())
 		}

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_complex/create_complex.side_effects
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_complex/create_complex.side_effects
@@ -237,8 +237,6 @@ upsert descriptor #108
   +    start: "32"
   +  unexposedParentSchemaId: 106
   +  version: "1"
-upsert descriptor #106
-  ...
 # end StatementPhase
 # begin PreCommitPhase
 ## PreCommitPhase stage 1 of 2 with 1 MutationType op

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_function/create_function.side_effects
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_function/create_function.side_effects
@@ -109,8 +109,8 @@ upsert descriptor #101
   ...
          withGrantOption: "2"
        version: 3
-  -  version: "2"
-  +  version: "3"
+  -  version: "1"
+  +  version: "2"
 upsert descriptor #104
   ...
        - 1
@@ -252,8 +252,8 @@ upsert descriptor #101
   ...
          withGrantOption: "2"
        version: 3
-  -  version: "2"
-  +  version: "3"
+  -  version: "1"
+  +  version: "2"
 upsert descriptor #104
   ...
        - 1

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_function_calling_function/create_function_calling_function.side_effects
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_function_calling_function/create_function_calling_function.side_effects
@@ -110,8 +110,8 @@ upsert descriptor #101
   ...
          withGrantOption: "2"
        version: 3
-  -  version: "4"
-  +  version: "5"
+  -  version: "3"
+  +  version: "4"
 upsert descriptor #107
   ...
      - 110
@@ -221,8 +221,8 @@ upsert descriptor #101
   ...
          withGrantOption: "2"
        version: 3
-  -  version: "4"
-  +  version: "5"
+  -  version: "3"
+  +  version: "4"
 upsert descriptor #107
   ...
      - 110

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_sequence/create_sequence.side_effects
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_sequence/create_sequence.side_effects
@@ -79,12 +79,6 @@ upsert descriptor #104
   +    start: "32"
   +  unexposedParentSchemaId: 101
   +  version: "1"
-upsert descriptor #101
-  ...
-         withGrantOption: "2"
-       version: 3
-  -  version: "1"
-  +  version: "2"
 # end StatementPhase
 # begin PreCommitPhase
 ## PreCommitPhase stage 1 of 2 with 1 MutationType op
@@ -154,12 +148,6 @@ upsert descriptor #104
   +    start: "32"
   +  unexposedParentSchemaId: 101
   +  version: "1"
-upsert descriptor #101
-  ...
-         withGrantOption: "2"
-       version: 3
-  -  version: "1"
-  +  version: "2"
 persist all catalog changes to storage
 # end PreCommitPhase
 commit transaction #1

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_sequence_add_column/create_sequence_add_column.side_effects
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_sequence_add_column/create_sequence_add_column.side_effects
@@ -82,12 +82,6 @@ upsert descriptor #105
   +    start: "32"
   +  unexposedParentSchemaId: 101
   +  version: "1"
-upsert descriptor #101
-  ...
-         withGrantOption: "2"
-       version: 3
-  -  version: "1"
-  +  version: "2"
 checking for feature: ALTER TABLE
 increment telemetry for sql.schema.alter_table
 increment telemetry for sql.schema.alter_table.add_column
@@ -306,12 +300,6 @@ upsert descriptor #105
   +  state: ADD
   +  unexposedParentSchemaId: 101
   +  version: "1"
-upsert descriptor #101
-  ...
-         withGrantOption: "2"
-       version: 3
-  -  version: "1"
-  +  version: "2"
 upsert descriptor #104
   ...
      createAsOfTime:

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_sequence_drop_sequence/create_sequence_drop_sequence.side_effects
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_sequence_drop_sequence/create_sequence_drop_sequence.side_effects
@@ -80,12 +80,6 @@ upsert descriptor #104
   +    start: "32"
   +  unexposedParentSchemaId: 101
   +  version: "1"
-upsert descriptor #101
-  ...
-         withGrantOption: "2"
-       version: 3
-  -  version: "1"
-  +  version: "2"
 checking for feature: DROP SEQUENCE
 increment telemetry for sql.schema.drop_sequence
 write *eventpb.DropSequence to event log:

--- a/pkg/sql/schemachanger/testdata/end_to_end/drop_function/drop_function.side_effects
+++ b/pkg/sql/schemachanger/testdata/end_to_end/drop_function/drop_function.side_effects
@@ -61,8 +61,8 @@ upsert descriptor #101
   ...
          withGrantOption: "2"
        version: 3
-  -  version: "3"
-  +  version: "4"
+  -  version: "2"
+  +  version: "3"
 upsert descriptor #104
   ...
        - 1
@@ -165,8 +165,8 @@ upsert descriptor #101
   ...
          withGrantOption: "2"
        version: 3
-  -  version: "3"
-  +  version: "4"
+  -  version: "2"
+  +  version: "3"
 upsert descriptor #104
   ...
      createAsOfTime:


### PR DESCRIPTION
Previously, when creating a sequence in the declarative schema changer, we would incorrectly bump up the schema versions. This would happen because we would check out the schema descriptor, even if it didn't need to be updated. To address this, this patch only checks out the schema descriptor for functions.

Fixes: #142606
Release note (bug fix): CREATE SEQUENCE without other concurrent DDL operations could hit retry error because of the schema being incorrectly modified.
Release justification: low risk fix that addresses issues with concurrent DDL when executing CREATE SEQUENCE