### PR TITLE
backup: fix backupAndRestore test helper search for backup job query

### DIFF
--- a/pkg/backup/backup_test.go
+++ b/pkg/backup/backup_test.go
@@ -912,7 +912,7 @@ func backupAndRestore(
 
 		found := false
 		stmt := `
-SELECT payload FROM "".crdb_internal.system_jobs ORDER BY created DESC LIMIT 10
+SELECT payload FROM "".crdb_internal.system_jobs WHERE job_type = 'BACKUP' ORDER BY created DESC LIMIT 10
 `
 		rows := sqlDB.Query(t, stmt)
 		for rows.Next() {


### PR DESCRIPTION
The `backupAndRestore` test helper creates a backup job and searches the `crdb_internal.system_jobs` table for a backup job. However, because the query does not filter on the job type and also limits the query to 10 results, occasionally the `AUTO CREATE STATS` job will populate the table, hiding the backup job. As a result, some tests will flake, reporting that no backup job exists in the job rows.

Fixes: #141562 #140287

Release note: None