### PR TITLE
sqlstats: gracefully handle flush async task error

### DIFF
--- a/pkg/sql/sqlstats/persistedsqlstats/flush.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/flush.go
@@ -200,6 +200,8 @@ func (s *PersistedSQLStats) flush(
 	})
 	if err != nil {
 		log.Warningf(ctx, "failed to execute sql-stmt-stats-flush task, %s", err.Error())
+		wg.Done()
+		return
 	}
 
 	err = stopper.RunAsyncTask(ctx, "sql-txn-stats-flush", func(ctx context.Context) {
@@ -211,6 +213,8 @@ func (s *PersistedSQLStats) flush(
 	})
 	if err != nil {
 		log.Warningf(ctx, "failed to execute sql-txn-stats-flush task, %s", err.Error())
+		wg.Done()
+		return
 	}
 
 	wg.Wait()


### PR DESCRIPTION
sql stats flush could stuck waiting on the waitgroup used so synchronize the flushing of statement and
transaction statistics. In the case where a flush is started and a node is shutdown, it is possible for one of the async tasks to never start, causing the flush to wait forever.

To fix, wait.Done() is called when the either go routine flushing errors. This was the logic that existed prior to sql stats flushed being refactored (See #140673).

Resolves: #142074
Epic: None
Release note: none