### PR TITLE
kvserver: pull out the smear into its own file

### DIFF
--- a/pkg/kv/kvserver/BUILD.bazel
+++ b/pkg/kv/kvserver/BUILD.bazel
@@ -108,6 +108,7 @@ go_library(
         "stores_base.go",
         "stores_server.go",
         "stores_store_liveness.go",
+        "task_pacer.go",
         "testing_knobs.go",
         "ts_maintenance_queue.go",
         ":gen-refreshraftreason-stringer",  # keep
@@ -378,6 +379,7 @@ go_test(
         "store_replica_btree_test.go",
         "store_test.go",
         "stores_test.go",
+        "task_pacer_test.go",
         "testutils_test.go",
         "ts_maintenance_queue_test.go",
         "txn_recovery_integration_test.go",

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -2577,18 +2577,19 @@ func (s *Store) startRangefeedUpdater(ctx context.Context) {
 		//   the rate of processing in accordance with the time remaining until the
 		//   refresh interval ends.
 		conf := newRangeFeedUpdaterConf(s.cfg.Settings)
+		pacer := NewTaskPacer(conf)
 		for {
 			// Configuration may have changed between runs, load it unconditionally.
 			// This will block until an "active" configuration exists, i.e. a one with
 			// non-zero refresh and smear intervals.
-			refresh, smear, err := conf.wait(ctx)
+			err := conf.wait(ctx)
 			if err != nil {
 				return // context canceled
 			}
 			// Aim to complete this run in exactly refresh interval.
 			now := timeutil.Now()
-			deadline := now.Add(refresh)
-			var waitErr error
+			pacer.StartTask(now)
+
 			// We're about to perform one work cycle, where we go through all replicas
 			// that have an active rangefeed on them and update them with the current
 			// closed timestamp for their range. While doing so, we'll keep track of
@@ -2597,13 +2598,14 @@ func (s *Store) startRangefeedUpdater(ctx context.Context) {
 			// some metrics when the work cycle completes.
 			var earliestClosedTS hlc.Timestamp
 			var numExcessivelyLaggingClosedTS int64
-
+			var waitErr error
 			for work, startAt := updateRangeIDs(), now; len(work) != 0; {
 				if waitErr = wait(ctx, startAt, conf.changed); waitErr != nil {
 					// NB: a configuration change abandons the update loop
 					break
 				}
-				todo, by := rangeFeedUpdaterPace(timeutil.Now(), deadline, smear, len(work))
+
+				todo, by := pacer.Pace(timeutil.Now(), len(work))
 				for _, id := range work[:todo] {
 					if r := s.GetReplicaIfExists(id); r != nil {
 						cts := r.GetCurrentClosedTimestamp(ctx)
@@ -2619,17 +2621,21 @@ func (s *Store) startRangefeedUpdater(ctx context.Context) {
 				startAt = by
 			}
 			if waitErr == nil {
-				waitErr = wait(ctx, deadline, conf.changed) // wait out any remaining time
+				waitErr = wait(ctx, pacer.GetDeadline(), conf.changed) // wait out any remaining time
 			}
 			// NB: an errInterrupted means this run was interrupted by relevant
 			// cluster setting changes. In this case we abandon the current run, and
 			// start a new one immediately by looping around.
 			//
 			// TODO(pavelkalinnikov): honour config changes without interrupting the
-			// run, as rangeFeedUpdaterPace makes this algorithm adaptive.
+			// run, as rangeFeedUpdaterPace makes this algorithm adaptive. This could
+			// also simplify the task_pacer code as we could use one function for
+			// waiting. The wait function could also be integrated into the Pace
+			// function.
 			if waitErr != nil && !errors.Is(waitErr, errInterrupted) {
 				return // context canceled
 			}
+
 			// We've successfully finished one work cycle where we went through all
 			// replicas that had an active rangefeed on them; update metrics.
 			if !earliestClosedTS.IsEmpty() {

--- a/pkg/kv/kvserver/store_rangefeed.go
+++ b/pkg/kv/kvserver/store_rangefeed.go
@@ -15,6 +15,7 @@ import (
 
 // rangeFeedUpdaterConf provides configuration for the rangefeed updater job,
 // and allows watching for when it is updated.
+// rangeFeedUpdaterConf Implements the taskPacerConfig interface.
 type rangeFeedUpdaterConf struct {
 	settings *cluster.Settings
 	changed  <-chan struct{}
@@ -36,63 +37,39 @@ func newRangeFeedUpdaterConf(st *cluster.Settings) rangeFeedUpdaterConf {
 	return rangeFeedUpdaterConf{settings: st, changed: confCh}
 }
 
-// get returns a pair of (refresh interval, smear interval) which determines
-// pacing of the rangefeed closed timestamp updater job.
-func (r rangeFeedUpdaterConf) get() (time.Duration, time.Duration) {
-	refresh := RangeFeedRefreshInterval.Get(&r.settings.SV)
-	if refresh <= 0 {
-		refresh = closedts.SideTransportCloseInterval.Get(&r.settings.SV)
-	}
-	if refresh <= 0 {
-		return 0, 0
-	}
-	smear := RangeFeedSmearInterval.Get(&r.settings.SV)
-	if smear <= 0 || smear > refresh {
-		smear = refresh
-	}
-	return refresh, smear
-}
-
 // wait blocks until it receives a valid rangefeed closed timestamp pacing
 // configuration, and returns it.
-func (r rangeFeedUpdaterConf) wait(ctx context.Context) (time.Duration, time.Duration, error) {
+func (r rangeFeedUpdaterConf) wait(ctx context.Context) error {
 	for {
-		if refresh, sched := r.get(); refresh != 0 && sched != 0 {
-			return refresh, sched, nil
+		refresh := r.getRefresh()
+		smear := r.getSmear()
+		if refresh != 0 && smear != 0 {
+			return nil
 		}
 		select {
 		case <-r.changed:
 			// Loop back around and check if the config is good now.
 		case <-ctx.Done():
-			return 0, 0, ctx.Err()
+			return ctx.Err()
 		}
 	}
 }
 
-// rangeFeedUpdaterPace returns the number of work items to do (out of workLeft)
-// within a quantum of time, and a suggested deadline for completing this work.
-// It assumes that work can be done at constant speed and uniformly fill the
-// remaining time between now and the deadline.
-//
-// See TestRangeFeedUpdaterPace for an example of how this function can/should
-// be used for scheduling work.
-func rangeFeedUpdaterPace(
-	now, deadline time.Time, quantum time.Duration, workLeft int,
-) (todo int, by time.Time) {
-	timeLeft := deadline.Sub(now)
-	if workLeft <= 0 || timeLeft <= 0 { // ran out of work or time
-		return workLeft, now
-	} else if timeLeft <= quantum { // time is running out
-		return workLeft, deadline
+// getRefresh returns the refresh interval for the rangefeed updater.
+func (r rangeFeedUpdaterConf) getRefresh() time.Duration {
+	refresh := RangeFeedRefreshInterval.Get(&r.settings.SV)
+	if refresh <= 0 {
+		refresh = closedts.SideTransportCloseInterval.Get(&r.settings.SV)
 	}
-	// Otherwise, we have workLeft >= 1, and at least a full quantum of time.
-	// Assume we can complete work at uniform speed.
-	todo = int(float64(workLeft) * quantum.Seconds() / timeLeft.Seconds())
-	by = now.Add(quantum)
-	if todo > workLeft { // should never happen, but just in case float64 has quirks
-		return workLeft, by
-	} else if todo == 0 {
-		return 1, by // always do some work
+	return refresh
+}
+
+// getSmear returns the smear interval for the rangefeed updater.
+func (r rangeFeedUpdaterConf) getSmear() time.Duration {
+	refresh := r.getRefresh()
+	smear := RangeFeedSmearInterval.Get(&r.settings.SV)
+	if smear <= 0 || smear > refresh {
+		smear = refresh
 	}
-	return todo, by
+	return smear
 }

--- a/pkg/kv/kvserver/store_rangefeed_test.go
+++ b/pkg/kv/kvserver/store_rangefeed_test.go
@@ -15,7 +15,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
-	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -96,137 +95,18 @@ func TestRangeFeedUpdaterConf(t *testing.T) {
 			if len(tc.updates) != 0 {
 				<-conf.changed // we must observe an update, otherwise the test times out
 			}
-			refresh, smear := conf.get()
+			refresh, smear := conf.getRefresh(), conf.getSmear()
 			assert.Equal(t, tc.want, [...]time.Duration{refresh, smear})
 
 			ctx, cancel := context.WithTimeout(ctx, time.Millisecond)
 			defer cancel()
-			var err error
-			refresh, smear, err = conf.wait(ctx)
+			err := conf.wait(ctx)
 			require.ErrorIs(t, err, tc.waitErr)
 			if tc.waitErr != nil {
 				return
 			}
+			refresh, smear = conf.getRefresh(), conf.getSmear()
 			assert.Equal(t, tc.want, [...]time.Duration{refresh, smear})
-		})
-	}
-}
-
-func TestRangeFeedUpdaterPace(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
-
-	for _, tc := range []struct {
-		desc string
-
-		deadline time.Duration   // deadline for completing the run
-		smear    time.Duration   // the wake-up interval
-		work     int             // the number of items to process
-		durs     []time.Duration // actual durations of each wake-up
-
-		wantWork []int           // expected work planned on each wake-up
-		wantBy   []time.Duration // expected "due by" time for each wake-up
-		wantDone time.Duration   // expected total duration of the run
-	}{{
-		desc:     "no-smearing",
-		deadline: 200, smear: 200, work: 1234,
-		durs:     []time.Duration{55},
-		wantWork: []int{1234},
-		wantBy:   []time.Duration{200},
-		wantDone: 55,
-	}, {
-		desc:     "within-schedule",
-		deadline: 200, smear: 50, work: 123,
-		durs:     []time.Duration{10, 5, 50, 20},
-		wantWork: []int{30, 31, 31, 31},
-		wantBy:   []time.Duration{50, 100, 150, 200},
-		wantDone: 170,
-	}, {
-		desc:     "uneven-steps",
-		deadline: 200, smear: 60, work: 123,
-		durs:     []time.Duration{33, 44, 55, 11},
-		wantWork: []int{36, 37, 37, 13},
-		wantBy:   []time.Duration{60, 120, 180, 200},
-		wantDone: 191,
-	}, {
-		desc:     "within-schedule-with-jitter",
-		deadline: 200, smear: 50, work: 123,
-		durs:     []time.Duration{51, 49, 53, 48},
-		wantWork: []int{30, 31, 31, 31},
-		wantBy:   []time.Duration{50, 101, 151, 200},
-		wantDone: 202,
-	}, {
-		desc:     "with-temporary-delays",
-		deadline: 100, smear: 10, work: 1000,
-		durs:     []time.Duration{10, 20, 20, 30, 10, 10}, // caught up by t=100
-		wantWork: []int{100, 100, 114, 137, 274, 275},
-		wantBy:   []time.Duration{10, 20, 40, 60, 90, 100},
-		wantDone: 100,
-	}, {
-		desc:     "with-delays-past-deadline",
-		deadline: 200, smear: 50, work: 123,
-		durs:     []time.Duration{78, 102, 53}, // longer than 200
-		wantWork: []int{30, 38, 55},
-		wantBy:   []time.Duration{50, 128, 200},
-		wantDone: 233,
-	}, {
-		desc:     "small-work-with-jitter",
-		deadline: 200, smear: 2, work: 5,
-		durs:     []time.Duration{2, 3, 3, 1, 2},
-		wantWork: []int{1, 1, 1, 1, 1},
-		wantBy:   []time.Duration{2, 4, 7, 10, 12},
-		wantDone: 12,
-	}, {
-		desc:     "no-work",
-		deadline: 200, smear: 2, work: 0,
-		durs:     []time.Duration{0},
-		wantWork: []int{},
-		wantBy:   []time.Duration{},
-		wantDone: 0,
-	}, {
-		desc:     "in-one-go",
-		deadline: 222, smear: 222, work: 2135,
-		durs:     []time.Duration{123},
-		wantWork: []int{2135},
-		wantBy:   []time.Duration{222},
-		wantDone: 123,
-	}, {
-		desc:     "not-enough-time",
-		deadline: 10, smear: 2, work: 900000,
-		durs:     []time.Duration{500, 10000},
-		wantWork: []int{180000, 720000},
-		wantBy:   []time.Duration{2, 500},
-		wantDone: 10500,
-	},
-	} {
-		t.Run(tc.desc, func(t *testing.T) {
-			durs := tc.durs
-			gotWork := make([]int, 0, len(tc.wantWork))
-			gotBy := make([]time.Duration, 0, len(tc.wantBy))
-
-			start := timeutil.Unix(946684800, 0) // Jan 1, 2000
-			now := start
-			deadline := now.Add(tc.deadline)
-			for work, startAt := tc.work, now; work != 0; {
-				if startAt.After(now) { // imitate waiting
-					now = startAt
-				}
-				todo, by := rangeFeedUpdaterPace(now, deadline, tc.smear, work)
-				gotWork = append(gotWork, todo)
-				gotBy = append(gotBy, by.Sub(start))
-
-				// Imitate work and time passage during this work.
-				work -= todo
-				require.NotEmpty(t, durs)
-				now = now.Add(durs[0])
-				durs = durs[1:]
-
-				startAt = by
-			}
-
-			assert.Equal(t, tc.wantWork, gotWork)
-			assert.Equal(t, tc.wantBy, gotBy)
-			assert.Equal(t, tc.wantDone, now.Sub(start))
 		})
 	}
 }

--- a/pkg/kv/kvserver/task_pacer.go
+++ b/pkg/kv/kvserver/task_pacer.go
@@ -1,0 +1,67 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package kvserver
+
+import "time"
+
+// taskPacerConfig is the interface for the configuration of a taskPacer.
+type taskPacerConfig interface {
+	// getRefresh returns the interval between tasks.
+	getRefresh() time.Duration
+
+	// getSmear returns the interval between batches inside a task.
+	getSmear() time.Duration
+}
+
+// taskPacer controls the pacing of tasks to prevent overloading the system.
+type taskPacer struct {
+	// taskStartTime is the time at which the task started.
+	taskStartTime time.Time
+	// conf is the configuration for the taskPacer.
+	conf taskPacerConfig
+}
+
+func NewTaskPacer(conf taskPacerConfig) *taskPacer {
+	return &taskPacer{
+		conf: conf,
+	}
+}
+
+func (tp *taskPacer) StartTask(now time.Time) {
+	tp.taskStartTime = now
+}
+
+// Pace returns the amount of work that should be done and the time by which it
+// should be done.
+// See the test TestTaskPacer for examples of how to use this method.
+func (tp *taskPacer) Pace(now time.Time, workLeft int) (todo int, by time.Time) {
+	deadline := tp.GetDeadline()
+	timeLeft := deadline.Sub(now)
+	quantum := tp.conf.getSmear()
+	if workLeft <= 0 || timeLeft <= 0 { // ran out of work or time
+		return workLeft, now
+	} else if quantum <= 0 { // smearing is disabled
+		return workLeft, deadline
+	} else if timeLeft <= quantum { // time is running out
+		return workLeft, deadline
+	}
+	// Otherwise, we have workLeft >= 1, and at least a full quantum of time.
+	// Assume we can complete work at uniform speed.
+	todo = int(float64(workLeft) * quantum.Seconds() / timeLeft.Seconds())
+	by = now.Add(quantum)
+	if todo > workLeft { // should never happen, but just in case float64 has quirks
+		return workLeft, by
+	} else if todo == 0 {
+		return 1, by // always do some work
+	}
+	return todo, by
+}
+
+// GetDeadline returns the time at which the current batch of work should be
+// done.
+func (tp *taskPacer) GetDeadline() time.Time {
+	return tp.taskStartTime.Add(tp.conf.getRefresh())
+}

--- a/pkg/kv/kvserver/task_pacer_test.go
+++ b/pkg/kv/kvserver/task_pacer_test.go
@@ -1,0 +1,278 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package kvserver
+
+import (
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// MockTaskPacerConfig is a test implementation of a task pacer configuration.
+type MockTaskPacerConfig struct {
+	// refresh is the interval between task batches
+	refresh time.Duration
+	// smear is the interval between task batches
+	smear time.Duration
+}
+
+func newMockTaskPacerConfig(refresh, smear time.Duration) *MockTaskPacerConfig {
+	return &MockTaskPacerConfig{
+		refresh: refresh,
+		smear:   smear,
+	}
+}
+
+func (tp *MockTaskPacerConfig) getRefresh() time.Duration {
+	return tp.refresh
+}
+
+func (tp *MockTaskPacerConfig) getSmear() time.Duration {
+	return tp.smear
+}
+
+func TestTaskPacer(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	for _, tc := range []struct {
+		desc string
+
+		deadline time.Duration   // deadline for completing the run
+		smear    time.Duration   // the wake-up interval
+		work     int             // the number of items to process
+		durs     []time.Duration // actual durations of each wake-up
+
+		wantWork []int           // expected work planned on each wake-up
+		wantBy   []time.Duration // expected "due by" time for each wake-up
+		wantDone time.Duration   // expected total duration of the run
+	}{{
+		desc:     "no-smearing",
+		deadline: 200, smear: 200, work: 1234,
+		durs:     []time.Duration{55},
+		wantWork: []int{1234},
+		wantBy:   []time.Duration{200},
+		wantDone: 55,
+	}, {
+		// If smear is set to 0, the taskPacer should not smear the work over
+		// time.
+		desc:     "zero-smear",
+		deadline: 200, smear: 0, work: 1234,
+		durs:     []time.Duration{55},
+		wantWork: []int{1234},
+		wantBy:   []time.Duration{200},
+		wantDone: 55,
+	}, {
+		desc:     "within-schedule",
+		deadline: 200, smear: 50, work: 123,
+		durs:     []time.Duration{10, 5, 50, 20},
+		wantWork: []int{30, 31, 31, 31},
+		wantBy:   []time.Duration{50, 100, 150, 200},
+		wantDone: 170,
+	}, {
+		desc:     "uneven-steps",
+		deadline: 200, smear: 60, work: 123,
+		durs:     []time.Duration{33, 44, 55, 11},
+		wantWork: []int{36, 37, 37, 13},
+		wantBy:   []time.Duration{60, 120, 180, 200},
+		wantDone: 191,
+	}, {
+		desc:     "within-schedule-with-jitter",
+		deadline: 200, smear: 50, work: 123,
+		durs:     []time.Duration{51, 49, 53, 48},
+		wantWork: []int{30, 31, 31, 31},
+		wantBy:   []time.Duration{50, 101, 151, 200},
+		wantDone: 202,
+	}, {
+		desc:     "with-temporary-delays",
+		deadline: 100, smear: 10, work: 1000,
+		durs:     []time.Duration{10, 20, 20, 30, 10, 10}, // caught up by t=100
+		wantWork: []int{100, 100, 114, 137, 274, 275},
+		wantBy:   []time.Duration{10, 20, 40, 60, 90, 100},
+		wantDone: 100,
+	}, {
+		desc:     "with-delays-past-deadline",
+		deadline: 200, smear: 50, work: 123,
+		durs:     []time.Duration{78, 102, 53}, // longer than 200
+		wantWork: []int{30, 38, 55},
+		wantBy:   []time.Duration{50, 128, 200},
+		wantDone: 233,
+	}, {
+		desc:     "small-work-with-jitter",
+		deadline: 200, smear: 2, work: 5,
+		durs:     []time.Duration{2, 3, 3, 1, 2},
+		wantWork: []int{1, 1, 1, 1, 1},
+		wantBy:   []time.Duration{2, 4, 7, 10, 12},
+		wantDone: 12,
+	}, {
+		desc:     "no-work",
+		deadline: 200, smear: 2, work: 0,
+		durs:     []time.Duration{0},
+		wantWork: []int{},
+		wantBy:   []time.Duration{},
+		wantDone: 0,
+	}, {
+		desc:     "in-one-go",
+		deadline: 222, smear: 222, work: 2135,
+		durs:     []time.Duration{123},
+		wantWork: []int{2135},
+		wantBy:   []time.Duration{222},
+		wantDone: 123,
+	}, {
+		desc:     "not-enough-time",
+		deadline: 10, smear: 2, work: 900000,
+		durs:     []time.Duration{500, 10000},
+		wantWork: []int{180000, 720000},
+		wantBy:   []time.Duration{2, 500},
+		wantDone: 10500,
+	},
+	} {
+		t.Run(tc.desc, func(t *testing.T) {
+			durs := tc.durs
+			gotWork := make([]int, 0, len(tc.wantWork))
+			gotBy := make([]time.Duration, 0, len(tc.wantBy))
+
+			start := timeutil.Unix(946684800, 0) // Jan 1, 2000
+			now := start
+
+			conf := newMockTaskPacerConfig(tc.deadline, tc.smear)
+			pacer := NewTaskPacer(conf)
+			pacer.StartTask(now)
+
+			for work, startAt := tc.work, now; work != 0; {
+				if startAt.After(now) { // imitate waiting
+					now = startAt
+				}
+				todo, by := pacer.Pace(now, work)
+				gotWork = append(gotWork, todo)
+				gotBy = append(gotBy, by.Sub(start))
+
+				// Imitate work and time passage during this work.
+				work -= todo
+				require.NotEmpty(t, durs)
+				now = now.Add(durs[0])
+				durs = durs[1:]
+
+				startAt = by
+			}
+
+			assert.Equal(t, tc.wantWork, gotWork)
+			assert.Equal(t, tc.wantBy, gotBy)
+			assert.Equal(t, tc.wantDone, now.Sub(start))
+		})
+	}
+}
+
+// TestTaskPacerAccommodatesConfChanges tests that the taskPacer can accommodate
+// changing the refresh and the smear intervals mid-run.
+func TestTaskPacerAccommodatesConfChanges(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	for _, tc := range []struct {
+		desc string
+
+		refreshes []time.Duration // deadline for completing the run
+		smears    []time.Duration // the wake-up interval
+		work      int             // the number of items to process
+		durs      []time.Duration // actual durations of each wake-up
+
+		wantWork []int           // expected work planned on each wake-up
+		wantBy   []time.Duration // expected "due by" time for each wake-up
+		wantDone time.Duration   // expected total duration of the run
+	}{{
+		desc:      "constant",
+		refreshes: []time.Duration{200, 200, 200, 200},
+		smears:    []time.Duration{50, 50, 50, 50},
+		work:      123,
+		durs:      []time.Duration{5, 5, 5, 5},
+		wantWork:  []int{30, 31, 31, 31},
+		wantBy:    []time.Duration{50, 100, 150, 200},
+		wantDone:  155,
+	}, {
+		desc:      "decrease-refresh",
+		refreshes: []time.Duration{200, 100},
+		smears:    []time.Duration{50, 50},
+		work:      123,
+		durs:      []time.Duration{5, 5},
+		wantWork:  []int{30, 93},
+		wantBy:    []time.Duration{50, 100},
+		wantDone:  55,
+	}, {
+		desc:      "increase-refresh",
+		refreshes: []time.Duration{200, 400, 400, 400, 400, 400, 400, 400},
+		smears:    []time.Duration{50, 50, 50, 50, 50, 50, 50, 50},
+		work:      123,
+		durs:      []time.Duration{5, 5, 5, 5, 5, 5, 5, 5},
+		wantWork:  []int{30, 13, 13, 13, 13, 13, 14, 14},
+		wantBy:    []time.Duration{50, 100, 150, 200, 250, 300, 350, 400},
+		wantDone:  355,
+	}, {
+		desc:      "decrease-smear",
+		refreshes: []time.Duration{200, 200, 200, 200, 200, 200, 200},
+		smears:    []time.Duration{50, 25, 25, 25, 25, 25, 25},
+		work:      123,
+		durs:      []time.Duration{5, 5, 5, 5, 5, 5, 5},
+		wantWork:  []int{30, 15, 15, 15, 16, 16, 16},
+		wantBy:    []time.Duration{50, 75, 100, 125, 150, 175, 200},
+		wantDone:  180,
+	}, {
+		desc:      "increase-smear",
+		refreshes: []time.Duration{200, 200, 200},
+		smears:    []time.Duration{50, 100, 100},
+		work:      123,
+		durs:      []time.Duration{5, 5, 5},
+		wantWork:  []int{30, 62, 31},
+		wantBy:    []time.Duration{50, 150, 200},
+		wantDone:  155,
+	}} {
+		t.Run(tc.desc, func(t *testing.T) {
+			durs := tc.durs
+			gotWork := make([]int, 0, len(tc.wantWork))
+			gotBy := make([]time.Duration, 0, len(tc.wantBy))
+
+			start := timeutil.Unix(946684800, 0) // Jan 1, 2000
+			now := start
+
+			conf := newMockTaskPacerConfig(tc.refreshes[0], tc.smears[0])
+			pacer := NewTaskPacer(conf)
+			pacer.StartTask(now)
+
+			index := 0
+			for work, startAt := tc.work, now; work != 0; {
+
+				conf.refresh = tc.refreshes[index]
+				conf.smear = tc.smears[index]
+
+				if startAt.After(now) { // imitate waiting
+					now = startAt
+				}
+				todo, by := pacer.Pace(now, work)
+				gotWork = append(gotWork, todo)
+				gotBy = append(gotBy, by.Sub(start))
+
+				// Imitate work and time passage during this work.
+				work -= todo
+				require.NotEmpty(t, durs)
+				now = now.Add(durs[0])
+				durs = durs[1:]
+
+				startAt = by
+				index++
+			}
+
+			assert.Equal(t, tc.wantWork, gotWork)
+			assert.Equal(t, tc.wantBy, gotBy)
+			assert.Equal(t, tc.wantDone, now.Sub(start))
+		})
+	}
+
+}


### PR DESCRIPTION
This commit abstract the rangefeed task pacer into its own file. This will be used to also pace the Raft ticks over the tick interval.

References: #142330

Release note: None