### PR TITLE
pkg/cmd/roachtest: Use revision history in backup/restore roachtest

### DIFF
--- a/pkg/cmd/roachtest/operations/backup_restore.go
+++ b/pkg/cmd/roachtest/operations/backup_restore.go
@@ -78,20 +78,26 @@ outer:
 	bucket := fmt.Sprintf("gs://%s/operation-backup-restore/%d/?AUTH=implicit", testutils.BackupTestingBucket(), timeutil.Now().UnixNano())
 
 	backupTS := hlc.Timestamp{WallTime: timeutil.Now().Add(-10 * time.Second).UTC().UnixNano()}
-	_, err = conn.ExecContext(ctx, fmt.Sprintf("BACKUP DATABASE %s INTO '%s' AS OF SYSTEM TIME '%s'", dbName, bucket, backupTS.AsOfSystemTime()))
-	if err != nil {
-		o.Fatal(err)
-	}
 
 	if !online {
+		_, err = conn.ExecContext(ctx, fmt.Sprintf("BACKUP DATABASE %s INTO '%s' AS OF SYSTEM TIME '%s' WITH revision_history", dbName, bucket, backupTS.AsOfSystemTime()))
+		if err != nil {
+			o.Fatal(err)
+		}
 		for i := range 24 {
 			o.Status(fmt.Sprintf("backing up db %s (incremental layer %d)", dbName, i))
 			// Update backupTS to match the latest layer.
 			backupTS = hlc.Timestamp{WallTime: timeutil.Now().Add(-10 * time.Second).UTC().UnixNano()}
-			_, err = conn.ExecContext(ctx, fmt.Sprintf("BACKUP DATABASE %s INTO LATEST IN '%s' AS OF SYSTEM TIME '%s'", dbName, bucket, backupTS.AsOfSystemTime()))
+			_, err = conn.ExecContext(ctx, fmt.Sprintf("BACKUP DATABASE %s INTO LATEST IN '%s' AS OF SYSTEM TIME '%s' WITH revision_history", dbName, bucket, backupTS.AsOfSystemTime()))
 			if err != nil {
 				o.Fatal(err)
 			}
+		}
+	} else {
+		// Revision history doesn't work with online restore.
+		_, err = conn.ExecContext(ctx, fmt.Sprintf("BACKUP DATABASE %s INTO '%s' AS OF SYSTEM TIME '%s'", dbName, bucket, backupTS.AsOfSystemTime()))
+		if err != nil {
+			o.Fatal(err)
 		}
 	}
 


### PR DESCRIPTION
Many of our customers use this feature, so our roachtests should focus on this mode too.

Epic: none
Release note: None