### PR TITLE
release-24.3: backup: fix backupAndRestore test helper search for backup job query

### DIFF
--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -914,7 +914,7 @@ func backupAndRestore(
 
 		found := false
 		stmt := `
-SELECT payload FROM "".crdb_internal.system_jobs ORDER BY created DESC LIMIT 10
+SELECT payload FROM "".crdb_internal.system_jobs WHERE job_type = 'BACKUP' ORDER BY created DESC LIMIT 10
 `
 		rows := sqlDB.Query(t, stmt)
 		for rows.Next() {


### PR DESCRIPTION
Backport 1/1 commits from #142611.

/cc @cockroachdb/release

---

The `backupAndRestore` test helper creates a backup job and searches the `crdb_internal.system_jobs` table for a backup job. However, because the query does not filter on the job type and also limits the query to 10 results, occasionally the `AUTO CREATE STATS` job will populate the table, hiding the backup job. As a result, some tests will flake, reporting that no backup job exists in the job rows.

Fixes: #141562 #140287

Release note: None

---

Release justification: Test only change to fix test flakiness.
