### PR TITLE
kvserver: replace hightly contended RWMutexes with Mutex

### DIFF
--- a/pkg/kv/kvclient/rangecache/range_cache_test.go
+++ b/pkg/kv/kvclient/rangecache/range_cache_test.go
@@ -1050,7 +1050,7 @@ func TestRangeCacheClearOverlapping(t *testing.T) {
 
 	require.True(t, clearOlderOverlapping(ctx, cache, &bToMaxDesc))
 	cache.addEntryLocked(&cacheEntry{desc: bToMaxDesc})
-	ce, _ := cache.getCachedRLocked(ctx, roachpb.RKey("b"), false)
+	ce, _ := cache.getCachedLocked(ctx, roachpb.RKey("b"), false)
 	require.Equal(t, bToMaxDesc, ce.desc)
 
 	// Add default descriptor back which should remove two split descriptors.
@@ -1060,7 +1060,7 @@ func TestRangeCacheClearOverlapping(t *testing.T) {
 	require.True(t, clearOlderOverlapping(ctx, cache, &defDescCpy))
 	cache.addEntryLocked(&cacheEntry{desc: defDescCpy})
 	for _, key := range []roachpb.RKey{roachpb.RKey("a"), roachpb.RKey("b")} {
-		ce, _ = cache.getCachedRLocked(ctx, key, false)
+		ce, _ = cache.getCachedLocked(ctx, key, false)
 		require.Equal(t, defDescCpy, ce.desc)
 	}
 
@@ -1073,7 +1073,7 @@ func TestRangeCacheClearOverlapping(t *testing.T) {
 	}
 	require.True(t, clearOlderOverlapping(ctx, cache, &bToCDesc))
 	cache.addEntryLocked(&cacheEntry{desc: bToCDesc})
-	ce, _ = cache.getCachedRLocked(ctx, roachpb.RKey("c"), true)
+	ce, _ = cache.getCachedLocked(ctx, roachpb.RKey("c"), true)
 	require.Equal(t, bToCDesc, ce.desc)
 
 	curGeneration++
@@ -1084,7 +1084,7 @@ func TestRangeCacheClearOverlapping(t *testing.T) {
 	}
 	require.True(t, clearOlderOverlapping(ctx, cache, aToBDesc))
 	cache.addEntryLocked(ce)
-	ce, _ = cache.getCachedRLocked(ctx, roachpb.RKey("c"), true)
+	ce, _ = cache.getCachedLocked(ctx, roachpb.RKey("c"), true)
 	require.Equal(t, bToCDesc, ce.desc)
 }
 
@@ -1340,9 +1340,9 @@ func TestGetCachedRangeDescriptorInverted(t *testing.T) {
 
 	for _, test := range testCases {
 		t.Run("", func(t *testing.T) {
-			cache.rangeCache.RLock()
-			targetRange, _ := cache.getCachedRLocked(ctx, test.queryKey, true /* inverted */)
-			cache.rangeCache.RUnlock()
+			cache.rangeCache.Lock()
+			targetRange, _ := cache.getCachedLocked(ctx, test.queryKey, true /* inverted */)
+			cache.rangeCache.Unlock()
 
 			if !test.rng.IsInitialized() {
 				require.Nil(t, targetRange)

--- a/pkg/kv/kvserver/allocator/storepool/store_pool.go
+++ b/pkg/kv/kvserver/allocator/storepool/store_pool.go
@@ -337,7 +337,7 @@ type StorePool struct {
 	// storeDetails.
 	// NB: Exported for use in tests and allocator simulator.
 	DetailsMu struct {
-		syncutil.RWMutex
+		syncutil.Mutex
 		StoreDetails map[roachpb.StoreID]*StoreDetail
 	}
 	localitiesMu struct {
@@ -403,8 +403,8 @@ func (sp *StorePool) SafeFormat(w redact.SafePrinter, _ rune) {
 }
 
 func (sp *StorePool) statusString(nl NodeLivenessFunc) redact.RedactableString {
-	sp.DetailsMu.RLock()
-	defer sp.DetailsMu.RUnlock()
+	sp.DetailsMu.Lock()
+	defer sp.DetailsMu.Unlock()
 
 	ids := make(roachpb.StoreIDSlice, 0, len(sp.DetailsMu.StoreDetails))
 	for id := range sp.DetailsMu.StoreDetails {
@@ -649,8 +649,8 @@ func newStoreDetail() *StoreDetail {
 // Stores without descriptor (a node that didn't come up yet after a cluster
 // restart) will not be part of the returned set.
 func (sp *StorePool) GetStores() map[roachpb.StoreID]roachpb.StoreDescriptor {
-	sp.DetailsMu.RLock()
-	defer sp.DetailsMu.RUnlock()
+	sp.DetailsMu.Lock()
+	defer sp.DetailsMu.Unlock()
 	stores := make(map[roachpb.StoreID]roachpb.StoreDescriptor, len(sp.DetailsMu.StoreDetails))
 	for _, s := range sp.DetailsMu.StoreDetails {
 		if s.Desc != nil {
@@ -681,8 +681,8 @@ func (sp *StorePool) GetStoreDetailLocked(storeID roachpb.StoreID) *StoreDetail 
 // GetStoreDescriptor returns the latest store descriptor for the given
 // storeID.
 func (sp *StorePool) GetStoreDescriptor(storeID roachpb.StoreID) (roachpb.StoreDescriptor, bool) {
-	sp.DetailsMu.RLock()
-	defer sp.DetailsMu.RUnlock()
+	sp.DetailsMu.Lock()
+	defer sp.DetailsMu.Unlock()
 
 	if detail, ok := sp.DetailsMu.StoreDetails[storeID]; ok && detail.Desc != nil {
 		return *detail.Desc, true

--- a/pkg/kv/kvserver/allocator/storepool/store_pool_test.go
+++ b/pkg/kv/kvserver/allocator/storepool/store_pool_test.go
@@ -57,19 +57,19 @@ func TestStorePoolGossipUpdate(t *testing.T) {
 	defer stopper.Stop(ctx)
 	sg := gossiputil.NewStoreGossiper(g)
 
-	sp.DetailsMu.RLock()
+	sp.DetailsMu.Lock()
 	if _, ok := sp.DetailsMu.StoreDetails[2]; ok {
 		t.Fatalf("store 2 is already in the pool's store list")
 	}
-	sp.DetailsMu.RUnlock()
+	sp.DetailsMu.Unlock()
 
 	sg.GossipStores(uniqueStore, t)
 
-	sp.DetailsMu.RLock()
+	sp.DetailsMu.Lock()
 	if _, ok := sp.DetailsMu.StoreDetails[2]; !ok {
 		t.Fatalf("store 2 isn't in the pool's store list")
 	}
-	sp.DetailsMu.RUnlock()
+	sp.DetailsMu.Unlock()
 }
 
 // verifyStoreList ensures that the returned list of stores is correct.

--- a/pkg/kv/kvserver/helpers_test.go
+++ b/pkg/kv/kvserver/helpers_test.go
@@ -314,8 +314,8 @@ func (r *Replica) Breaker() *circuit.Breaker {
 func (r *Replica) AssertState(ctx context.Context, reader storage.Reader) {
 	r.raftMu.Lock()
 	defer r.raftMu.Unlock()
-	r.mu.RLock()
-	defer r.mu.RUnlock()
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	r.assertStateRaftMuLockedReplicaMuRLocked(ctx, reader)
 }
 
@@ -336,8 +336,8 @@ func (r *Replica) RaftReportUnreachable(id roachpb.ReplicaID) error {
 
 // LastAssignedLeaseIndexRLocked returns the last assigned lease index.
 func (r *Replica) LastAssignedLeaseIndex() kvpb.LeaseAppliedIndex {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	return r.mu.proposalBuf.LastAssignedLeaseIndexRLocked()
 }
 
@@ -410,22 +410,22 @@ func (r *Replica) QuotaReleaseQueueLen() int {
 }
 
 func (r *Replica) NumPendingProposals() int64 {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	return r.numPendingProposalsRLocked()
 }
 
 func (r *Replica) LastUpdateTimes() map[roachpb.ReplicaID]lastReplicaUpdateTime {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	return maps.Clone(r.mu.lastUpdateTimes)
 }
 
 func (r *Replica) IsFollowerActiveSince(
 	followerID roachpb.ReplicaID, now time.Time, threshold time.Duration,
 ) bool {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	return r.mu.lastUpdateTimes.isFollowerActiveSince(followerID, now, threshold)
 }
 
@@ -447,16 +447,16 @@ func (r *Replica) ShouldBackpressureWrites(_ context.Context) bool {
 // GetRaftLogSize returns the approximate raft log size and whether it is
 // trustworthy.. See r.mu.raftLogSize for details.
 func (r *Replica) GetRaftLogSize() (int64, bool) {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	return r.shMu.raftLogSize, r.shMu.raftLogSizeTrusted
 }
 
 // GetCachedLastTerm returns the cached last term value. May return
 // invalidLastTerm if the cache is not set.
 func (r *Replica) GetCachedLastTerm() kvpb.RaftTerm {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	return r.shMu.lastTermNotDurable
 }
 
@@ -469,8 +469,8 @@ func (r *Replica) SideloadedRaftMuLocked() logstore.SideloadStorage {
 // LargestPreviousMaxRangeSizeBytes returns the in-memory value used to mitigate
 // backpressure when the zone.RangeMaxBytes is decreased.
 func (r *Replica) LargestPreviousMaxRangeSizeBytes() int64 {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	return r.mu.largestPreviousMaxRangeSizeBytes
 }
 
@@ -589,16 +589,16 @@ func (r *Replica) MaybeUnquiesceAndPropose() (bool, error) {
 }
 
 func (r *Replica) ReadCachedProtectedTS() (readAt, earliestProtectionTimestamp hlc.Timestamp) {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	return r.mu.cachedProtectedTS.readAt, r.mu.cachedProtectedTS.earliestProtectionTimestamp
 }
 
 // ClosedTimestampPolicy returns the closed timestamp policy of the range, which
 // is updated asynchronously through gossip of zone configurations.
 func (r *Replica) ClosedTimestampPolicy() roachpb.RangeClosedTimestampPolicy {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	return r.closedTimestampPolicyRLocked()
 }
 

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/range_controller.go
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/range_controller.go
@@ -537,11 +537,11 @@ type ProbeToCloseTimerScheduler interface {
 // production code.
 type ReplicaMutexAsserter struct {
 	RaftMu    *syncutil.Mutex
-	ReplicaMu *syncutil.RWMutex
+	ReplicaMu *syncutil.Mutex
 }
 
 func MakeReplicaMutexAsserter(
-	raftMu *syncutil.Mutex, replicaMu *syncutil.RWMutex,
+	raftMu *syncutil.Mutex, replicaMu *syncutil.Mutex,
 ) ReplicaMutexAsserter {
 	return ReplicaMutexAsserter{
 		RaftMu:    raftMu,

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/token_counter.go
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/token_counter.go
@@ -194,7 +194,7 @@ type tokenCounter struct {
 	tokenType TokenType
 
 	mu struct {
-		syncutil.RWMutex
+		syncutil.Mutex
 
 		counters [admissionpb.NumWorkClasses]tokenCounterPerWorkClass
 	}
@@ -256,8 +256,8 @@ func (t *tokenCounter) String() string {
 
 // SafeFormat implements the redact.SafeFormatter interface.
 func (t *tokenCounter) SafeFormat(w redact.SafePrinter, _ rune) {
-	t.mu.RLock()
-	defer t.mu.RUnlock()
+	t.mu.Lock()
+	defer t.mu.Unlock()
 	w.Printf("reg=%v/%v ela=%v/%v",
 		t.mu.counters[admissionpb.RegularWorkClass].tokens,
 		t.mu.counters[admissionpb.RegularWorkClass].limit,
@@ -271,8 +271,8 @@ func (t *tokenCounter) Stream() kvflowcontrol.Stream {
 }
 
 func (t *tokenCounter) tokensPerWorkClass() tokensPerWorkClass {
-	t.mu.RLock()
-	defer t.mu.RUnlock()
+	t.mu.Lock()
+	defer t.mu.Unlock()
 	return tokensPerWorkClass{
 		regular: t.tokensLocked(admissionpb.RegularWorkClass),
 		elastic: t.tokensLocked(admissionpb.ElasticWorkClass),
@@ -280,8 +280,8 @@ func (t *tokenCounter) tokensPerWorkClass() tokensPerWorkClass {
 }
 
 func (t *tokenCounter) tokens(wc admissionpb.WorkClass) kvflowcontrol.Tokens {
-	t.mu.RLock()
-	defer t.mu.RUnlock()
+	t.mu.Lock()
+	defer t.mu.Unlock()
 	return t.tokensLocked(wc)
 }
 
@@ -290,8 +290,8 @@ func (t *tokenCounter) tokensLocked(wc admissionpb.WorkClass) kvflowcontrol.Toke
 }
 
 func (t *tokenCounter) limit(wc admissionpb.WorkClass) kvflowcontrol.Tokens {
-	t.mu.RLock()
-	defer t.mu.RUnlock()
+	t.mu.Lock()
+	defer t.mu.Unlock()
 	return t.mu.counters[wc].limit
 }
 

--- a/pkg/kv/kvserver/kvserverbase/stores.go
+++ b/pkg/kv/kvserver/kvserverbase/stores.go
@@ -37,7 +37,7 @@ type Store interface {
 	// GetReplicaMutexForTesting returns the mutex of the replica with the given
 	// range ID, or nil if no replica was found. This is used for testing.
 	// Returns a syncutil.RWMutex rather than ReplicaMutex to avoid import cycles.
-	GetReplicaMutexForTesting(rangeID roachpb.RangeID) *syncutil.RWMutex
+	GetReplicaMutexForTesting(rangeID roachpb.RangeID) *syncutil.Mutex
 }
 
 // UnsupportedStoresIterator is a StoresIterator that only returns "unsupported"

--- a/pkg/kv/kvserver/mvcc_gc_queue.go
+++ b/pkg/kv/kvserver/mvcc_gc_queue.go
@@ -293,10 +293,10 @@ func makeMVCCGCQueueScore(
 	gcTTL time.Duration,
 	canAdvanceGCThreshold bool,
 ) mvccGCQueueScore {
-	repl.mu.RLock()
+	repl.mu.Lock()
 	ms := *repl.shMu.state.Stats
 	hint := *repl.shMu.state.GCHint
-	repl.mu.RUnlock()
+	repl.mu.Unlock()
 
 	if repl.store.cfg.TestingKnobs.DisableLastProcessedCheck {
 		lastGC = hlc.Timestamp{}

--- a/pkg/kv/kvserver/mvcc_gc_queue_test.go
+++ b/pkg/kv/kvserver/mvcc_gc_queue_test.go
@@ -1242,9 +1242,9 @@ func TestMVCCGCQueueTransactionTable(t *testing.T) {
 	batch := tc.engine.NewSnapshot()
 	defer batch.Close()
 	tc.repl.raftMu.Lock()
-	tc.repl.mu.RLock()
+	tc.repl.mu.Lock()
 	tc.repl.assertStateRaftMuLockedReplicaMuRLocked(ctx, batch) // check that in-mem and on-disk state were updated
-	tc.repl.mu.RUnlock()
+	tc.repl.mu.Unlock()
 	tc.repl.raftMu.Unlock()
 }
 

--- a/pkg/kv/kvserver/raft.go
+++ b/pkg/kv/kvserver/raft.go
@@ -264,13 +264,13 @@ func extractIDs(ids []kvserverbase.CmdIDKey, ents []raftpb.Entry) []kvserverbase
 // command which corresponds to an id in ids.
 func traceProposals(r *Replica, ids []kvserverbase.CmdIDKey, event string) {
 	ctxs := make([]context.Context, 0, len(ids))
-	r.mu.RLock()
+	r.mu.Lock()
 	for _, id := range ids {
 		if prop, ok := r.mu.proposals[id]; ok {
 			ctxs = append(ctxs, prop.Context())
 		}
 	}
-	r.mu.RUnlock()
+	r.mu.Unlock()
 	for _, ctx := range ctxs {
 		log.Eventf(ctx, "%v", event)
 	}

--- a/pkg/kv/kvserver/raft_log_queue.go
+++ b/pkg/kv/kvserver/raft_log_queue.go
@@ -242,7 +242,7 @@ func newTruncateDecision(ctx context.Context, r *Replica) (truncateDecision, err
 	rangeID := r.RangeID
 	now := timeutil.Now()
 
-	r.mu.RLock()
+	r.mu.Lock()
 	raftLogSize := r.pendingLogTruncations.computePostTruncLogSize(r.shMu.raftLogSize)
 	// A "cooperative" truncation (i.e. one that does not cut off followers from
 	// the log) takes place whenever there are more than
@@ -275,7 +275,7 @@ func newTruncateDecision(ctx context.Context, r *Replica) (truncateDecision, err
 	// an indefinite delay in recomputation.
 	logSizeTrusted := r.shMu.raftLogSizeTrusted
 	firstIndex := r.raftFirstIndexRLocked()
-	r.mu.RUnlock()
+	r.mu.Unlock()
 	firstIndex = r.pendingLogTruncations.computePostTruncFirstIndex(firstIndex)
 
 	if raftStatus == nil {
@@ -293,7 +293,7 @@ func newTruncateDecision(ctx context.Context, r *Replica) (truncateDecision, err
 
 	// For all our followers, overwrite the RecentActive field with our own
 	// activity check.
-	r.mu.RLock()
+	r.mu.Lock()
 	log.Eventf(ctx, "raft status before lastUpdateTimes check: %+v", raftStatus.Progress)
 	log.Eventf(ctx, "lastUpdateTimes: %+v", r.mu.lastUpdateTimes)
 	updateRaftProgressFromActivity(
@@ -303,7 +303,7 @@ func newTruncateDecision(ctx context.Context, r *Replica) (truncateDecision, err
 		},
 	)
 	log.Eventf(ctx, "raft status after lastUpdateTimes check: %+v", raftStatus.Progress)
-	r.mu.RUnlock()
+	r.mu.Unlock()
 
 	input := truncateDecisionInput{
 		RaftStatus:           *raftStatus,

--- a/pkg/kv/kvserver/raft_log_queue_test.go
+++ b/pkg/kv/kvserver/raft_log_queue_test.go
@@ -853,8 +853,8 @@ func TestTruncateLogRecompute(t *testing.T) {
 	repl := tc.store.LookupReplica(keys.MustAddr(key))
 
 	trusted := func() bool {
-		repl.mu.RLock()
-		defer repl.mu.RUnlock()
+		repl.mu.Lock()
+		defer repl.mu.Unlock()
 		return repl.shMu.raftLogSizeTrusted
 	}
 

--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -8,7 +8,6 @@ package kvserver
 import (
 	"context"
 	"slices"
-	"sync"
 	"sync/atomic"
 	"time"
 
@@ -176,44 +175,24 @@ func (c *atomicConnectionClass) set(cc rpc.ConnectionClass) {
 	atomic.StoreUint32((*uint32)(c), uint32(cc))
 }
 
-// ReplicaMutex is an RWMutex. It has its own type to make it easier to look for
+// ReplicaMutex is a Mutex. It has its own type to make it easier to look for
 // usages specific to the replica mutex.
-type ReplicaMutex syncutil.RWMutex
+type ReplicaMutex syncutil.Mutex
 
 func (mu *ReplicaMutex) Lock() {
-	(*syncutil.RWMutex)(mu).Lock()
+	(*syncutil.Mutex)(mu).Lock()
 }
 
 func (mu *ReplicaMutex) TracedLock(ctx context.Context) {
-	(*syncutil.RWMutex)(mu).TracedLock(ctx)
+	(*syncutil.Mutex)(mu).TracedLock(ctx)
 }
 
 func (mu *ReplicaMutex) Unlock() {
-	(*syncutil.RWMutex)(mu).Unlock()
-}
-
-func (mu *ReplicaMutex) RLock() {
-	(*syncutil.RWMutex)(mu).RLock()
-}
-
-func (mu *ReplicaMutex) TracedRLock(ctx context.Context) {
-	(*syncutil.RWMutex)(mu).TracedRLock(ctx)
+	(*syncutil.Mutex)(mu).Unlock()
 }
 
 func (mu *ReplicaMutex) AssertHeld() {
-	(*syncutil.RWMutex)(mu).AssertHeld()
-}
-
-func (mu *ReplicaMutex) AssertRHeld() {
-	(*syncutil.RWMutex)(mu).AssertRHeld()
-}
-
-func (mu *ReplicaMutex) RUnlock() {
-	(*syncutil.RWMutex)(mu).RUnlock()
-}
-
-func (mu *ReplicaMutex) RLocker() sync.Locker {
-	return (*syncutil.RWMutex)(mu).RLocker()
+	(*syncutil.Mutex)(mu).AssertHeld()
 }
 
 // A Replica is a contiguous keyspace with writes managed via an
@@ -1060,15 +1039,15 @@ func (r *Replica) cleanupFailedProposalLocked(p *ProposalData) {
 
 // GetMinBytes gets the replica's minimum byte threshold.
 func (r *Replica) GetMinBytes(_ context.Context) int64 {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	return r.mu.conf.RangeMinBytes
 }
 
 // GetMaxBytes gets the replica's maximum byte threshold.
 func (r *Replica) GetMaxBytes(_ context.Context) int64 {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	return r.mu.conf.RangeMaxBytes
 }
 
@@ -1154,8 +1133,8 @@ func (r *Replica) HasExternalBytes() (bool, error) {
 // IsScratchRange returns true if this is range is a scratch range (i.e.
 // overlaps with the scratch span and has a start key <= keys.ScratchRangeMin).
 func (r *Replica) IsScratchRange() bool {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	return r.isScratchRangeRLocked()
 }
 
@@ -1174,8 +1153,8 @@ func (r *Replica) IsFirstRange() bool {
 // IsDestroyed returns a non-nil error if the replica has been destroyed
 // and the reason if it has.
 func (r *Replica) IsDestroyed() (DestroyReason, error) {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	return r.isDestroyedRLocked()
 }
 
@@ -1185,23 +1164,23 @@ func (r *Replica) isDestroyedRLocked() (DestroyReason, error) {
 
 // IsQuiescent returns whether the replica is quiescent or not.
 func (r *Replica) IsQuiescent() bool {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	return r.mu.quiescent
 }
 
 // IsAsleep returns whether the replica is asleep or not.
 func (r *Replica) IsAsleep() bool {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	return r.mu.asleep
 }
 
 // DescAndSpanConfig returns the authoritative range descriptor as well
 // as the span config for the replica.
 func (r *Replica) DescAndSpanConfig() (*roachpb.RangeDescriptor, *roachpb.SpanConfig) {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	// This method is being removed shortly. We can't pass out a pointer to the
 	// underlying replica's SpanConfig.
 	conf := r.mu.conf
@@ -1210,8 +1189,8 @@ func (r *Replica) DescAndSpanConfig() (*roachpb.RangeDescriptor, *roachpb.SpanCo
 
 // LoadSpanConfig loads the authoritative span config for the replica.
 func (r *Replica) LoadSpanConfig(_ context.Context) (*roachpb.SpanConfig, error) {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	// This method is being removed shortly. We can't pass out a pointer to the
 	// underlying replica's SpanConfig.
 	conf := r.mu.conf
@@ -1221,13 +1200,13 @@ func (r *Replica) LoadSpanConfig(_ context.Context) (*roachpb.SpanConfig, error)
 // Desc returns the authoritative range descriptor, acquiring a replica lock in
 // the process.
 func (r *Replica) Desc() *roachpb.RangeDescriptor {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	return r.shMu.state.Desc
 }
 
 func (r *Replica) descRLocked() *roachpb.RangeDescriptor {
-	r.mu.AssertRHeld()
+	r.mu.AssertHeld()
 	return r.shMu.state.Desc
 }
 
@@ -1301,23 +1280,23 @@ func (r *Replica) GetRangeID() roachpb.RangeID {
 
 // GetGCThreshold returns the GC threshold.
 func (r *Replica) GetGCThreshold() hlc.Timestamp {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	return *r.shMu.state.GCThreshold
 }
 
 // GetGCHint returns the GC hint.
 func (r *Replica) GetGCHint() roachpb.GCHint {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	return *r.shMu.state.GCHint
 }
 
 // ExcludeDataFromBackup returns whether the replica is to be excluded from a
 // backup.
 func (r *Replica) ExcludeDataFromBackup(ctx context.Context, sp roachpb.Span) (bool, error) {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	return r.entireSpanExcludedFromBackupRLocked(ctx, sp)
 }
 
@@ -1354,8 +1333,8 @@ func (r *Replica) entireSpanExcludedFromBackupRLocked(
 
 // Version returns the replica version.
 func (r *Replica) Version() roachpb.Version {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	if r.shMu.state.Version == nil {
 		// We introduced replica versions in v21.1 to service long-running
 		// migrations. For replicas that were instantiated pre-21.1, it's
@@ -1380,8 +1359,8 @@ func (r *Replica) Version() roachpb.Version {
 
 // GetRangeInfo atomically reads the range's current range info.
 func (r *Replica) GetRangeInfo(ctx context.Context) roachpb.RangeInfo {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	desc := r.descRLocked()
 	l, _ /* nextLease */ := r.getLeaseRLocked()
 	closedts := r.closedTimestampPolicyRLocked()
@@ -1453,8 +1432,8 @@ func (r *Replica) getImpliedGCThresholdRLocked(
 }
 
 func (r *Replica) isRangefeedEnabled() (ret bool) {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
+	r.mu.Lock()
+	defer r.mu.Unlock()
 
 	return r.isRangefeedEnabledRLocked()
 }
@@ -1496,8 +1475,8 @@ func maxReplicaIDOfAny(desc *roachpb.RangeDescriptor) roachpb.ReplicaID {
 // LastReplicaAdded returns the ID of the most recently added replica and the
 // time at which it was added.
 func (r *Replica) LastReplicaAdded() (roachpb.ReplicaID, time.Time) {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	return r.mu.lastReplicaAdded, r.mu.lastReplicaAddedTime
 }
 
@@ -1505,8 +1484,8 @@ func (r *Replica) LastReplicaAdded() (roachpb.ReplicaID, time.Time) {
 // descriptor. Returns a *RangeNotFoundError if the replica is not found.
 // No other errors are returned.
 func (r *Replica) GetReplicaDescriptor() (roachpb.ReplicaDescriptor, error) {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	return r.getReplicaDescriptorRLocked()
 }
 
@@ -1521,8 +1500,8 @@ func (r *Replica) getReplicaDescriptorRLocked() (roachpb.ReplicaDescriptor, erro
 }
 
 func (r *Replica) getMergeCompleteCh() chan struct{} {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	return r.getMergeCompleteChRLocked()
 }
 
@@ -1558,8 +1537,8 @@ func (r *Replica) getLastReplicaDescriptors() (to, from roachpb.ReplicaDescripto
 // This accessor is thread-safe, but provides no guarantees about its
 // synchronization with any concurrent writes.
 func (r *Replica) GetMVCCStats() enginepb.MVCCStats {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	return *r.shMu.state.Stats
 }
 
@@ -1669,16 +1648,16 @@ func (r *Replica) setQueueLastProcessed(
 // RaftStatus returns the current raft status of the replica. It returns nil
 // if the Raft group has not been initialized yet.
 func (r *Replica) RaftStatus() *raft.Status {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	return r.raftStatusRLocked()
 }
 
 // RaftBasicStatus returns the current raft basic status of the replica. An empty
 // BasicStatus is returned if the Raft group hasn't been initialized.
 func (r *Replica) RaftBasicStatus() raft.BasicStatus {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	return r.raftBasicStatusRLocked()
 }
 
@@ -1745,8 +1724,8 @@ func (r *Replica) State(ctx context.Context) kvserverpb.RangeInfo {
 	// it's best to keep it out of the Replica.mu critical section.
 	ri.RangefeedRegistrations = int64(r.numRangefeedRegistrations())
 
-	r.mu.RLock()
-	defer r.mu.RUnlock()
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	ri.ReplicaState = *(protoutil.Clone(&r.shMu.state)).(*kvserverpb.ReplicaState)
 	// TODO(#97613): add a dedicated TruncatedState field to RangeInfo when the
 	// TruncatedState field is removed from ReplicaState. We can't do it right now
@@ -1903,8 +1882,8 @@ func (r *Replica) checkExecutionCanProceedBeforeStorageSnapshot(
 		return kvserverpb.LeaseStatus{}, err
 	}
 
-	r.mu.RLock()
-	defer r.mu.RUnlock()
+	r.mu.Lock()
+	defer r.mu.Unlock()
 
 	// Has the replica been initialized?
 	// NB: this should have already been checked in Store.Send, so we don't need
@@ -1969,8 +1948,8 @@ func (r *Replica) checkExecutionCanProceedAfterStorageSnapshot(
 		return err
 	}
 
-	r.mu.RLock()
-	defer r.mu.RUnlock()
+	r.mu.Lock()
+	defer r.mu.Unlock()
 
 	// Ensure the request is entirely contained within the range's key bounds
 	// (even) after the storage engine has been pinned by the iterator. Given we
@@ -2067,8 +2046,8 @@ func (r *Replica) checkExecutionCanProceedForRangeFeed(
 	ctx context.Context, rSpan roachpb.RSpan, ts hlc.Timestamp,
 ) error {
 	now := r.Clock().NowAsClockTimestamp()
-	r.mu.RLock()
-	defer r.mu.RUnlock()
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	status := r.leaseStatusForRequestRLocked(ctx, now, ts)
 	if _, err := r.isDestroyedRLocked(); err != nil {
 		return err
@@ -2617,8 +2596,8 @@ func (r *Replica) HasOutstandingLearnerSnapshotInFlightForTesting() bool {
 func (r *Replica) ReadProtectedTimestampsForTesting(ctx context.Context) (err error) {
 	var ts cachedProtectedTimestampState
 	defer r.maybeUpdateCachedProtectedTS(&ts)
-	r.mu.RLock()
-	defer r.mu.RUnlock()
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	ts, err = r.readProtectedTimestampsRLocked(ctx)
 	return err
 }

--- a/pkg/kv/kvserver/replica_application_state_machine.go
+++ b/pkg/kv/kvserver/replica_application_state_machine.go
@@ -141,13 +141,13 @@ func (sm *replicaStateMachine) NewBatch() apply.Batch {
 	b.r = r
 	b.applyStats = &sm.applyStats
 	b.batch = r.store.TODOEngine().NewBatch()
-	r.mu.RLock()
+	r.mu.Lock()
 	b.state = r.shMu.state
 	b.truncState = r.shMu.raftTruncState
 	b.state.Stats = &sm.stats
 	*b.state.Stats = *r.shMu.state.Stats
 	b.closedTimestampSetter = r.mu.closedTimestampSetter
-	r.mu.RUnlock()
+	r.mu.Unlock()
 	b.start = timeutil.Now()
 	return b
 }
@@ -199,11 +199,11 @@ func (sm *replicaStateMachine) ApplySideEffects(
 		if shouldAssert {
 			// Assert that the on-disk state doesn't diverge from the in-memory
 			// state as a result of the side effects.
-			sm.r.mu.RLock()
+			sm.r.mu.Lock()
 			// TODO(sep-raft-log): either check only statemachine invariants or
 			// pass both engines in.
 			sm.r.assertStateRaftMuLockedReplicaMuRLocked(ctx, sm.r.store.TODOEngine())
-			sm.r.mu.RUnlock()
+			sm.r.mu.Unlock()
 			sm.applyStats.stateAssertions++
 		}
 	} else if res := cmd.ReplicatedResult(); !res.IsZero() {

--- a/pkg/kv/kvserver/replica_application_state_machine_test.go
+++ b/pkg/kv/kvserver/replica_application_state_machine_test.go
@@ -430,9 +430,9 @@ func TestReplicaStateMachineEphemeralAppBatchRejection(t *testing.T) {
 
 	sm := r.getStateMachine()
 
-	r.mu.RLock()
+	r.mu.Lock()
 	raftAppliedIndex := r.shMu.state.RaftAppliedIndex
-	r.mu.RUnlock()
+	r.mu.Unlock()
 
 	descWriteRepr := func(v string) (kvpb.Request, []byte) {
 		b := tc.store.TODOEngine().NewBatch()

--- a/pkg/kv/kvserver/replica_backpressure.go
+++ b/pkg/kv/kvserver/replica_backpressure.go
@@ -141,8 +141,8 @@ func (r *Replica) signallerForBatch(ba *kvpb.BatchRequest) signaller {
 // further explanation). It ensures that writes are always backpressured if the
 // range's size is already larger than the absolute maximum we'll allow.
 func (r *Replica) shouldBackpressureWrites() bool {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
+	r.mu.Lock()
+	defer r.mu.Unlock()
 
 	// Check if the current range's size is already over the absolute maximum
 	// we'll allow. Don't bother with any multipliers/byte tolerance calculations

--- a/pkg/kv/kvserver/replica_command.go
+++ b/pkg/kv/kvserver/replica_command.go
@@ -2965,10 +2965,10 @@ func (r *Replica) sendSnapshotUsingDelegate(
 		r.reportSnapshotStatus(ctx, recipient.ReplicaID, retErr)
 	}()
 
-	r.mu.RLock()
+	r.mu.Lock()
 	sender, err := r.getReplicaDescriptorRLocked()
 	_, destPaused := r.mu.pausedFollowers[recipient.ReplicaID]
-	r.mu.RUnlock()
+	r.mu.Unlock()
 
 	if err != nil {
 		return err
@@ -3142,10 +3142,10 @@ func (r *Replica) validateSnapshotDelegationRequest(
 	// Check the raft applied state index and term to determine if this replica
 	// is not too far behind the leaseholder. If the delegate is too far behind
 	// that is also needs a snapshot, then any snapshot it sends will be useless.
-	r.mu.RLock()
+	r.mu.Lock()
 	replIdx := r.shMu.state.RaftAppliedIndex + 1
 	status := r.raftBasicStatusRLocked()
-	r.mu.RUnlock()
+	r.mu.Unlock()
 
 	if status.Empty() {
 		// This code path is sometimes hit during scatter for replicas that haven't

--- a/pkg/kv/kvserver/replica_follower_read.go
+++ b/pkg/kv/kvserver/replica_follower_read.go
@@ -162,7 +162,7 @@ func (r *Replica) getCurrentClosedTimestampLocked(
 // GetCurrentClosedTimestamp returns the current maximum closed timestamp for
 // this range.
 func (r *Replica) GetCurrentClosedTimestamp(ctx context.Context) hlc.Timestamp {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	return r.getCurrentClosedTimestampLocked(ctx, hlc.Timestamp{} /* sufficient */)
 }

--- a/pkg/kv/kvserver/replica_follower_read_test.go
+++ b/pkg/kv/kvserver/replica_follower_read_test.go
@@ -92,8 +92,8 @@ func TestCanServeFollowerRead(t *testing.T) {
 			ba.Header = kvpb.Header{Txn: &txn}
 			ba.Add(&gArgs)
 			r := tc.repl
-			r.mu.RLock()
-			defer r.mu.RUnlock()
+			r.mu.Lock()
+			defer r.mu.Unlock()
 			require.Equal(t, test.expCanServeFollowerRead, r.canServeFollowerReadRLocked(ctx, ba))
 		})
 	}

--- a/pkg/kv/kvserver/replica_init.go
+++ b/pkg/kv/kvserver/replica_init.go
@@ -266,7 +266,7 @@ func newUninitializedReplicaWithoutRaftGroup(
 		ReplicaID:         r.replicaID,
 		ReplicaForTesting: (*replicaForRACv2)(r),
 		ReplicaMutexAsserter: rac2.MakeReplicaMutexAsserter(
-			&r.raftMu.Mutex, (*syncutil.RWMutex)(&r.mu.ReplicaMutex)),
+			&r.raftMu.Mutex, (*syncutil.Mutex)(&r.mu.ReplicaMutex)),
 		RaftScheduler:          r.store.scheduler,
 		AdmittedPiggybacker:    r.store.cfg.KVFlowAdmittedPiggybacker,
 		ACWorkQueue:            r.store.cfg.KVAdmissionController,
@@ -413,8 +413,8 @@ func (r *Replica) IsInitialized() bool {
 // TenantID returns the associated tenant ID and a boolean to indicate that it
 // is valid. It will be invalid only if the replica is not initialized.
 func (r *Replica) TenantID() (roachpb.TenantID, bool) {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	return r.getTenantIDRLocked()
 }
 

--- a/pkg/kv/kvserver/replica_metrics.go
+++ b/pkg/kv/kvserver/replica_metrics.go
@@ -87,7 +87,7 @@ func (r *Replica) Metrics(
 	nodeAttrs := r.store.nodeDesc.Attrs
 	nodeLocality := r.store.nodeDesc.Locality
 
-	r.mu.RLock()
+	r.mu.Lock()
 
 	var qpUsed, qpCap int64
 	if q := r.mu.proposalQuota; q != nil {
@@ -124,7 +124,7 @@ func (r *Replica) Metrics(
 		slowRaftProposalCount:    r.mu.slowProposalCount,
 	}
 
-	r.mu.RUnlock()
+	r.mu.Unlock()
 
 	return calcReplicaMetrics(input)
 }

--- a/pkg/kv/kvserver/replica_proposal_buf_test.go
+++ b/pkg/kv/kvserver/replica_proposal_buf_test.go
@@ -139,9 +139,6 @@ func (t *testProposer) locker() sync.Locker {
 	return &t.RWMutex
 }
 
-func (t *testProposer) rlocker() sync.Locker {
-	return t.RWMutex.RLocker()
-}
 func (t *testProposer) flowControlHandle(ctx context.Context) kvflowcontrol.Handle {
 	return &testFlowTokenHandle{}
 }

--- a/pkg/kv/kvserver/replica_proposal_quota.go
+++ b/pkg/kv/kvserver/replica_proposal_quota.go
@@ -41,10 +41,10 @@ func (r *Replica) maybeAcquireProposalQuota(
 		return nil, nil
 	}
 
-	r.mu.RLock()
+	r.mu.Lock()
 	enabled := r.getQuotaPoolEnabledRLocked(ctx)
 	quotaPool := r.mu.proposalQuota
-	r.mu.RUnlock()
+	r.mu.Unlock()
 
 	if !enabled {
 		return nil, nil

--- a/pkg/kv/kvserver/replica_protected_timestamp.go
+++ b/pkg/kv/kvserver/replica_protected_timestamp.go
@@ -117,8 +117,8 @@ func (r *Replica) checkProtectedTimestampsForGC(
 	// record.
 	var read cachedProtectedTimestampState
 	defer r.maybeUpdateCachedProtectedTS(&read)
-	r.mu.RLock()
-	defer r.mu.RUnlock()
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	defer read.clearIfNotNewer(r.mu.cachedProtectedTS)
 
 	oldThreshold = *r.shMu.state.GCThreshold

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -2034,7 +2034,7 @@ func (r *Replica) sendRaftMessage(
 ) {
 	lastToReplica, lastFromReplica := r.getLastReplicaDescriptors()
 
-	r.mu.RLock()
+	r.mu.Lock()
 	traced := r.mu.raftTracer.MaybeTrace(msg)
 	fromReplica, fromErr := r.getReplicaDescriptorByIDRLocked(roachpb.ReplicaID(msg.From), lastToReplica)
 	toReplica, toErr := r.getReplicaDescriptorByIDRLocked(roachpb.ReplicaID(msg.To), lastFromReplica)
@@ -2056,7 +2056,7 @@ func (r *Replica) sendRaftMessage(
 			}
 		})
 	}
-	r.mu.RUnlock()
+	r.mu.Unlock()
 
 	if fromErr != nil {
 		log.Warningf(ctx, "failed to look up sender replica %d in r%d while sending %s: %s",
@@ -2272,8 +2272,8 @@ func (r *Replica) errOnOutstandingLearnerSnapshotInflight() error {
 func (r *Replica) hasOutstandingSnapshotInFlightToStore(
 	storeID roachpb.StoreID, initialOnly bool,
 ) ([]snapTruncationInfo, bool) {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	sl, idx := r.getSnapshotLogTruncationConstraintsRLocked(storeID, initialOnly)
 	return sl, idx > 0
 }

--- a/pkg/kv/kvserver/replica_raftlog.go
+++ b/pkg/kv/kvserver/replica_raftlog.go
@@ -145,8 +145,8 @@ func (r *Replica) raftLastIndexRLocked() kvpb.RaftIndex {
 // GetLastIndex returns the index of the last entry in the raft log.
 // Requires that r.mu is not held.
 func (r *Replica) GetLastIndex() kvpb.RaftIndex {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	return r.raftLastIndexRLocked()
 }
 
@@ -164,8 +164,8 @@ func (r *Replica) raftFirstIndexRLocked() kvpb.RaftIndex {
 // GetFirstIndex returns the index of the first entry in the raft log.
 // Requires that r.mu is not held.
 func (r *Replica) GetFirstIndex() kvpb.RaftIndex {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	return r.raftFirstIndexRLocked()
 }
 
@@ -176,7 +176,7 @@ func (r *Replica) GetFirstIndex() kvpb.RaftIndex {
 // returned snapshot.
 func (r *replicaLogStorage) LogSnapshot() raft.LogStorageSnapshot {
 	r.raftMu.AssertHeld()
-	r.mu.AssertRHeld()
+	r.mu.AssertHeld()
 	return (*replicaRaftMuLogSnap)(r)
 }
 

--- a/pkg/kv/kvserver/replica_raftstorage.go
+++ b/pkg/kv/kvserver/replica_raftstorage.go
@@ -140,8 +140,8 @@ func (r *replicaRaftStorage) InitialState() (raftpb.HardState, raftpb.ConfState,
 
 // GetLeaseAppliedIndex returns the lease index of the last applied command.
 func (r *Replica) GetLeaseAppliedIndex() kvpb.LeaseAppliedIndex {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	return r.shMu.state.LeaseAppliedIndex
 }
 
@@ -785,9 +785,9 @@ func (r *Replica) applySnapshot(
 	// after the application of the snapshot. Do so under a read lock, as this
 	// operation can be expensive. This is safe, as we hold the Replica.raftMu
 	// across both Replica.mu critical sections.
-	r.mu.RLock()
+	r.mu.Lock()
 	r.assertStateRaftMuLockedReplicaMuRLocked(ctx, r.store.TODOEngine())
-	r.mu.RUnlock()
+	r.mu.Unlock()
 
 	// The rangefeed processor is listening for the logical ops attached to
 	// each raft command. These will be lost during a snapshot, so disconnect

--- a/pkg/kv/kvserver/replica_range_lease.go
+++ b/pkg/kv/kvserver/replica_range_lease.go
@@ -731,8 +731,8 @@ func (r *Replica) CurrentLeaseStatus(ctx context.Context) kvserverpb.LeaseStatus
 func (r *Replica) LeaseStatusAt(
 	ctx context.Context, now hlc.ClockTimestamp,
 ) kvserverpb.LeaseStatus {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	return r.leaseStatusAtRLocked(ctx, now)
 }
 
@@ -773,8 +773,8 @@ func (r *Replica) leaseStatusForRequestRLocked(
 // but returns the status of the current lease and ownership at the
 // specified point in time.
 func (r *Replica) OwnsValidLease(ctx context.Context, now hlc.ClockTimestamp) bool {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	return r.ownsValidLeaseRLocked(ctx, now)
 }
 
@@ -1037,8 +1037,8 @@ func (r *Replica) AdminTransferLease(
 
 // GetLease returns the lease and, if available, the proposed next lease.
 func (r *Replica) GetLease() (roachpb.Lease, roachpb.Lease) {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	return r.getLeaseRLocked()
 }
 
@@ -1199,8 +1199,8 @@ func (r *Replica) leaseGoodToGoForStatusRLocked(
 func (r *Replica) leaseGoodToGo(
 	ctx context.Context, now hlc.ClockTimestamp, reqTS hlc.Timestamp,
 ) (kvserverpb.LeaseStatus, error) {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	return r.leaseGoodToGoRLocked(ctx, now, reqTS)
 }
 
@@ -1559,8 +1559,8 @@ func (r *Replica) maybeSwitchLeaseType(ctx context.Context) *kvpb.Error {
 
 // HasCorrectLeaseType returns true if the lease type is correct for this replica.
 func (r *Replica) HasCorrectLeaseType(lease roachpb.Lease) bool {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
+	r.mu.Lock()
+	defer r.mu.Unlock()
 	return r.hasCorrectLeaseTypeRLocked(lease)
 }
 

--- a/pkg/kv/kvserver/replica_send.go
+++ b/pkg/kv/kvserver/replica_send.go
@@ -1104,10 +1104,10 @@ func (r *Replica) collectSpans(
 	_ error,
 ) {
 	latchSpans, lockSpans = spanset.New(), lockspanset.New()
-	r.mu.RLock()
+	r.mu.Lock()
 	desc := r.descRLocked()
 	liveCount := r.shMu.state.Stats.LiveCount
-	r.mu.RUnlock()
+	r.mu.Unlock()
 	// TODO(bdarnell): need to make this less global when local
 	// latches are used more heavily. For example, a split will
 	// have a large read-only span but also a write (see #10084).

--- a/pkg/kv/kvserver/replica_store_liveness.go
+++ b/pkg/kv/kvserver/replica_store_liveness.go
@@ -50,7 +50,7 @@ var _ raftstoreliveness.StoreLiveness = (*replicaRLockedStoreLiveness)(nil)
 func (r *replicaRLockedStoreLiveness) getStoreIdent(
 	replicaID raftpb.PeerID,
 ) (slpb.StoreIdent, bool) {
-	r.mu.AssertRHeld()
+	r.mu.AssertHeld()
 	desc, ok := r.shMu.state.Desc.GetReplicaDescriptorByID(roachpb.ReplicaID(replicaID))
 	if !ok {
 		return slpb.StoreIdent{}, false

--- a/pkg/kv/kvserver/split_delay_helper.go
+++ b/pkg/kv/kvserver/split_delay_helper.go
@@ -29,7 +29,7 @@ type splitDelayHelper Replica
 
 func (sdh *splitDelayHelper) RaftStatus(ctx context.Context) (roachpb.RangeID, *raft.Status) {
 	r := (*Replica)(sdh)
-	r.mu.RLock()
+	r.mu.Lock()
 	raftStatus := r.raftStatusRLocked()
 	if raftStatus != nil {
 		updateRaftProgressFromActivity(
@@ -39,7 +39,7 @@ func (sdh *splitDelayHelper) RaftStatus(ctx context.Context) (roachpb.RangeID, *
 			},
 		)
 	}
-	r.mu.RUnlock()
+	r.mu.Unlock()
 	return r.RangeID, raftStatus
 }
 

--- a/pkg/kv/kvserver/split_trigger_helper.go
+++ b/pkg/kv/kvserver/split_trigger_helper.go
@@ -22,10 +22,10 @@ type replicaMsgAppDropper Replica
 
 func (rd *replicaMsgAppDropper) Args() (initialized bool, age time.Duration) {
 	r := (*Replica)(rd)
-	r.mu.RLock()
+	r.mu.Lock()
 	initialized = r.IsInitialized()
 	creationTime := r.creationTime
-	r.mu.RUnlock()
+	r.mu.Unlock()
 	age = timeutil.Since(creationTime)
 	return initialized, age
 }

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -564,10 +564,10 @@ func (rs *storeReplicaVisitor) Visit(visitor func(*Replica) bool) {
 		// destroyed once we return errors from mutexes (#9190). After all, it
 		// can still happen with this code.
 		rs.visited++
-		repl.mu.RLock()
+		repl.mu.Lock()
 		destroyed := repl.mu.destroyStatus
 		initialized := repl.IsInitialized()
-		repl.mu.RUnlock()
+		repl.mu.Unlock()
 		if initialized && destroyed.IsAlive() && !visitor(repl) {
 			break
 		}

--- a/pkg/kv/kvserver/store_raft.go
+++ b/pkg/kv/kvserver/store_raft.go
@@ -803,10 +803,10 @@ func (s *Store) nodeIsLiveCallback(l livenesspb.Liveness) {
 	s.updateLivenessMap()
 
 	s.mu.replicasByRangeID.Range(func(_ roachpb.RangeID, r *Replica) bool {
-		r.mu.RLock()
+		r.mu.Lock()
 		quiescent := r.mu.quiescent
 		lagging := r.mu.laggingFollowersOnQuiesce
-		r.mu.RUnlock()
+		r.mu.Unlock()
 		if quiescent && lagging.MemberStale(l) {
 			r.maybeUnquiesce(ctx, false /* wakeLeader */, false /* mayCampaign */) // already leader
 		}

--- a/pkg/kv/kvserver/store_snapshot.go
+++ b/pkg/kv/kvserver/store_snapshot.go
@@ -347,11 +347,11 @@ func (s *Store) canAcceptSnapshotLocked(
 	// commits, and cannot have been replicaGC'ed yet (see replicaGCQueue.process).
 	existingRepl.raftMu.AssertHeld()
 
-	existingRepl.mu.RLock()
+	existingRepl.mu.Lock()
 	existingDesc := existingRepl.shMu.state.Desc
 	existingIsInitialized := existingDesc.IsInitialized()
 	existingDestroyStatus := existingRepl.mu.destroyStatus
-	existingRepl.mu.RUnlock()
+	existingRepl.mu.Unlock()
 
 	if existingIsInitialized {
 		// Regular Raft snapshots can't be refused at this point,

--- a/pkg/kv/kvserver/store_split.go
+++ b/pkg/kv/kvserver/store_split.go
@@ -221,10 +221,10 @@ func prepareRightReplicaForSplit(
 	// was not able to use its current lease because of a restart or lease
 	// transfer, the RHS will also not be able to. minValidObservedTS ensures that
 	// the bounds for uncertainty interval are preserved.
-	r.mu.RLock()
+	r.mu.Lock()
 	minLeaseProposedTS := r.mu.minLeaseProposedTS
 	minValidObservedTS := r.mu.minValidObservedTimestamp
-	r.mu.RUnlock()
+	r.mu.Unlock()
 
 	// If the RHS replica of the split is not removed, then it has been obtained
 	// (and its raftMu acquired) in Replica.acquireSplitLock.

--- a/pkg/kv/kvserver/store_test.go
+++ b/pkg/kv/kvserver/store_test.go
@@ -765,9 +765,9 @@ func TestStoreRemoveReplicaDestroy(t *testing.T) {
 	})
 	require.Equal(t, errRemoved, err)
 
-	repl1.mu.RLock()
+	repl1.mu.Lock()
 	expErr := repl1.mu.destroyStatus.err
-	repl1.mu.RUnlock()
+	repl1.mu.Unlock()
 
 	if expErr == nil {
 		t.Fatal("replica was not marked as destroyed")

--- a/pkg/kv/kvserver/stores_base.go
+++ b/pkg/kv/kvserver/stores_base.go
@@ -87,10 +87,10 @@ func (s *baseStore) SetQueueActive(active bool, queue string) error {
 }
 
 // GetReplicaMutexForTesting is part of kvserverbase.Store.
-func (s *baseStore) GetReplicaMutexForTesting(rangeID roachpb.RangeID) *syncutil.RWMutex {
+func (s *baseStore) GetReplicaMutexForTesting(rangeID roachpb.RangeID) *syncutil.Mutex {
 	store := (*Store)(s)
 	if repl := store.GetReplicaIfExists(rangeID); repl != nil {
-		return (*syncutil.RWMutex)(repl.GetMutexForTesting())
+		return (*syncutil.Mutex)(repl.GetMutexForTesting())
 	}
 	return nil
 }

--- a/pkg/kv/kvserver/stores_server.go
+++ b/pkg/kv/kvserver/stores_server.go
@@ -86,9 +86,9 @@ func (is Server) WaitForApplication(
 			if err != nil {
 				return err
 			}
-			repl.mu.RLock()
+			repl.mu.Lock()
 			leaseAppliedIndex := repl.shMu.state.LeaseAppliedIndex
-			repl.mu.RUnlock()
+			repl.mu.Unlock()
 			if leaseAppliedIndex >= req.LeaseIndex {
 				// For performance reasons, we don't sync to disk when
 				// applying raft commands. This means that if a node restarts

--- a/pkg/kv/kvserver/tscache/interval_skl.go
+++ b/pkg/kv/kvserver/tscache/interval_skl.go
@@ -142,7 +142,7 @@ type intervalSkl struct {
 	// lock is acquired by the Add and Lookup operations. The write lock is
 	// acquired only when the pages are rotated. Since that is very rare, the
 	// vast majority of operations can proceed without blocking.
-	rotMutex syncutil.RWMutex
+	rotMutex syncutil.Mutex
 
 	// The following fields are used to enforce a minimum retention window on
 	// all timestamp intervals. intervalSkl promises to retain all timestamp
@@ -293,10 +293,10 @@ func (s *intervalSkl) AddRange(
 func (s *intervalSkl) addRange(
 	ctx context.Context, from, to []byte, opt rangeOptions, val cacheValue,
 ) *sklPage {
-	// Acquire the rotation mutex read lock so that the page will not be rotated
+	// Acquire the rotation mutex lock so that the page will not be rotated
 	// while add or lookup operations are in progress.
-	s.rotMutex.TracedRLock(ctx)
-	defer s.rotMutex.RUnlock()
+	s.rotMutex.TracedLock(ctx)
+	defer s.rotMutex.Unlock()
 
 	// If floor ts is >= requested timestamp, then no need to perform a search or
 	// add any records.
@@ -431,7 +431,7 @@ func (s *intervalSkl) maximumPageSize() uint32 {
 // timestamp, in order to guarantee that timestamp lookups never return decreasing
 // values.
 func (s *intervalSkl) rotatePages(ctx context.Context, filledPage *sklPage) {
-	// Acquire the rotation mutex write lock to lock the entire intervalSkl.
+	// Acquire the rotation mutex lock to lock the entire intervalSkl.
 	s.rotMutex.TracedLock(ctx)
 	defer s.rotMutex.Unlock()
 
@@ -507,10 +507,10 @@ func (s *intervalSkl) LookupTimestampRange(
 		panic("from and to keys cannot be nil")
 	}
 
-	// Acquire the rotation mutex read lock so that the page will not be rotated
+	// Acquire the rotation mutex lock so that the page will not be rotated
 	// while add or lookup operations are in progress.
-	s.rotMutex.TracedRLock(ctx)
-	defer s.rotMutex.RUnlock()
+	s.rotMutex.TracedLock(ctx)
+	defer s.rotMutex.Unlock()
 
 	// Iterate over the pages, performing the lookup on each and remembering the
 	// maximum value we've seen so far.
@@ -569,10 +569,10 @@ func (s *intervalSkl) Serialize(ctx context.Context, from, to []byte) rspb.Segme
 // serializePages returns a serialized representation of each of the
 // intervalSkl's pages over the interval spanning from start to end.
 func (s *intervalSkl) serializePages(ctx context.Context, from, to []byte) []rspb.Segment {
-	// Acquire the rotation mutex read lock so that the page will not be rotated
+	// Acquire the rotation mutex lock so that the page will not be rotated
 	// while serialize operations are in progress.
-	s.rotMutex.TracedRLock(ctx)
-	defer s.rotMutex.RUnlock()
+	s.rotMutex.TracedLock(ctx)
+	defer s.rotMutex.Unlock()
 
 	// Iterate over the pages, serializing each and merging as we go.
 	segs := make([]rspb.Segment, 0, s.pages.Len())
@@ -587,8 +587,8 @@ func (s *intervalSkl) serializePages(ctx context.Context, from, to []byte) []rsp
 
 // FloorTS returns the receiver's floor timestamp.
 func (s *intervalSkl) FloorTS() hlc.Timestamp {
-	s.rotMutex.RLock()
-	defer s.rotMutex.RUnlock()
+	s.rotMutex.Lock()
+	defer s.rotMutex.Unlock()
 	return s.floorTS
 }
 

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -6936,7 +6936,7 @@ SELECT
 				rangeID := roachpb.RangeID(*args[0].(*tree.DInt))
 				lock := *args[1].(*tree.DBool)
 
-				var replicaMu *syncutil.RWMutex
+				var replicaMu *syncutil.Mutex
 				if err := evalCtx.KVStoresIterator.ForEachStore(func(store kvserverbase.Store) error {
 					if replicaMu == nil {
 						replicaMu = store.GetReplicaMutexForTesting(rangeID)

--- a/pkg/util/admission/work_queue.go
+++ b/pkg/util/admission/work_queue.go
@@ -1899,7 +1899,7 @@ type StoreWorkQueue struct {
 	granters [admissionpb.NumWorkClasses]granterWithStoreReplicatedWorkAdmitted
 	coordMu  *syncutil.Mutex
 	mu       struct {
-		syncutil.RWMutex
+		syncutil.Mutex
 		// estimates is used to determine how many tokens are deducted at-admit
 		// time for each request. It's not used for replication admission
 		// control (below-raft) where we do know the size of the write being
@@ -1965,8 +1965,8 @@ func (q *StoreWorkQueue) Admit(
 		// [1]: This happens asynchronously -- i.e. we may have already returned
 		//      from StoreWorkQueue.Admit().
 		info.RequestedCount = func() int64 {
-			q.mu.RLock()
-			defer q.mu.RUnlock()
+			q.mu.Lock()
+			defer q.mu.Unlock()
 			return q.mu.estimates.writeTokens
 		}()
 	}
@@ -2230,8 +2230,8 @@ func (q *StoreWorkQueue) close() {
 }
 
 func (q *StoreWorkQueue) getStoreAdmissionStats() storeAdmissionStats {
-	q.mu.RLock()
-	defer q.mu.RUnlock()
+	q.mu.Lock()
+	defer q.mu.Unlock()
 	return q.mu.stats
 }
 


### PR DESCRIPTION
RWMutex may not always be the best choice, as it:
- scales poorly with larger CPU counts.
- is unfair to read lockers, which may cause reads to get queued for longer, then cause a thundering herd.

The mutexes that were changed in this patch were identified as highly
contended by the profile captured in https://github.com/cockroachdb/cockroach/issues/142621.

Using this PR to experiment if changing them helps.

Release note: None