### PR TITLE
wip: kvserver: change ReplicaMutex to RBMutex

### DIFF
--- a/DEPS.bzl
+++ b/DEPS.bzl
@@ -7953,6 +7953,16 @@ def go_deps():
         ],
     )
     go_repository(
+        name = "com_github_puzpuzpuz_xsync_v3",
+        build_file_proto_mode = "disable_global",
+        importpath = "github.com/puzpuzpuz/xsync/v3",
+        sha256 = "f7fcd1eeb1bc96bc497dc0bca05ed0d64d194fdb1a73460dd42cd2bc42ae00e6",
+        strip_prefix = "github.com/puzpuzpuz/xsync/v3@v3.5.1",
+        urls = [
+            "https://storage.googleapis.com/cockroach-godeps/gomod/github.com/puzpuzpuz/xsync/v3/com_github_puzpuzpuz_xsync_v3-v3.5.1.zip",
+        ],
+    )
+    go_repository(
         name = "com_github_rcrowley_go_metrics",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/rcrowley/go-metrics",

--- a/build/bazelutil/distdir_files.bzl
+++ b/build/bazelutil/distdir_files.bzl
@@ -934,6 +934,7 @@ DISTDIR_FILES = {
     "https://storage.googleapis.com/cockroach-godeps/gomod/github.com/prometheus/statsd_exporter/com_github_prometheus_statsd_exporter-v0.21.0.zip": "aa848ade6fb019df4f7992808a1d6aa48d6b8276017970af4aabc1bd337c2dc3",
     "https://storage.googleapis.com/cockroach-godeps/gomod/github.com/pseudomuto/protoc-gen-doc/com_github_pseudomuto_protoc_gen_doc-v1.3.2.zip": "ecf627d6f5b4e55d4844dda45612cbd152f0bc4dbe2ba182c7bc3ad1dc63ce5f",
     "https://storage.googleapis.com/cockroach-godeps/gomod/github.com/pseudomuto/protokit/com_github_pseudomuto_protokit-v0.2.0.zip": "16d5fe0f6ac5bebbf9f2f05fde72f28bbf05bb18baef045b9ae79c2585f4e127",
+    "https://storage.googleapis.com/cockroach-godeps/gomod/github.com/puzpuzpuz/xsync/v3/com_github_puzpuzpuz_xsync_v3-v3.5.1.zip": "f7fcd1eeb1bc96bc497dc0bca05ed0d64d194fdb1a73460dd42cd2bc42ae00e6",
     "https://storage.googleapis.com/cockroach-godeps/gomod/github.com/rcrowley/go-metrics/com_github_rcrowley_go_metrics-v0.0.0-20201227073835-cf1acfcdf475.zip": "e4dbd20c185cb05019fd7d4a361266bd5d182938f49fd9577df4d12c16dc81c3",
     "https://storage.googleapis.com/cockroach-godeps/gomod/github.com/remyoudompheng/bigfft/com_github_remyoudompheng_bigfft-v0.0.0-20230129092748-24d4a6f8daec.zip": "9be16c32c384d55d0f7bd7b03f1ff1e9a4e4b91b000f0aa87a567a01b9b82398",
     "https://storage.googleapis.com/cockroach-godeps/gomod/github.com/retailnext/hllpp/com_github_retailnext_hllpp-v1.0.1-0.20180308014038-101a6d2f8b52.zip": "7863938cb01dfe9d4495df3c6608bedceec2d1195da05612f3c1b0e27d37729d",

--- a/go.mod
+++ b/go.mod
@@ -225,6 +225,7 @@ require (
 	github.com/prometheus/common v0.42.0
 	github.com/prometheus/prometheus v1.8.2-0.20210914090109-37468d88dce8
 	github.com/pseudomuto/protoc-gen-doc v1.3.2
+	github.com/puzpuzpuz/xsync/v3 v3.5.1
 	github.com/rcrowley/go-metrics v0.0.0-20201227073835-cf1acfcdf475
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/rs/dnscache v0.0.0-20230804202142-fc85eb664529

--- a/go.sum
+++ b/go.sum
@@ -2133,6 +2133,8 @@ github.com/pseudomuto/protoc-gen-doc v1.3.2 h1:61vWZuxYa8D7Rn4h+2dgoTNqnluBmJya2
 github.com/pseudomuto/protoc-gen-doc v1.3.2/go.mod h1:y5+P6n3iGrbKG+9O04V5ld71in3v/bX88wUwgt+U8EA=
 github.com/pseudomuto/protokit v0.2.0 h1:hlnBDcy3YEDXH7kc9gV+NLaN0cDzhDvD1s7Y6FZ8RpM=
 github.com/pseudomuto/protokit v0.2.0/go.mod h1:2PdH30hxVHsup8KpBTOXTBeMVhJZVio3Q8ViKSAXT0Q=
+github.com/puzpuzpuz/xsync/v3 v3.5.1 h1:GJYJZwO6IdxN/IKbneznS6yPkVC+c3zyY/j19c++5Fg=
+github.com/puzpuzpuz/xsync/v3 v3.5.1/go.mod h1:VjzYrABPabuM4KyBh1Ftq6u8nhwY5tBPKP9jpmh0nnA=
 github.com/rcrowley/go-metrics v0.0.0-20181016184325-3113b8401b8a/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rcrowley/go-metrics v0.0.0-20190826022208-cac0b30c2563/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=
 github.com/rcrowley/go-metrics v0.0.0-20200313005456-10cdbea86bc0/go.mod h1:bCqnVzQkZxMG4s8nGwiZ5l3QUCyqpo9Y+/ZMZ9VjZe4=

--- a/pkg/kv/kvserver/helpers_test.go
+++ b/pkg/kv/kvserver/helpers_test.go
@@ -314,8 +314,8 @@ func (r *Replica) Breaker() *circuit.Breaker {
 func (r *Replica) AssertState(ctx context.Context, reader storage.Reader) {
 	r.raftMu.Lock()
 	defer r.raftMu.Unlock()
-	r.mu.RLock()
-	defer r.mu.RUnlock()
+	token := r.mu.RLock()
+	defer r.mu.RUnlock(token)
 	r.assertStateRaftMuLockedReplicaMuRLocked(ctx, reader)
 }
 
@@ -336,8 +336,8 @@ func (r *Replica) RaftReportUnreachable(id roachpb.ReplicaID) error {
 
 // LastAssignedLeaseIndexRLocked returns the last assigned lease index.
 func (r *Replica) LastAssignedLeaseIndex() kvpb.LeaseAppliedIndex {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
+	token := r.mu.RLock()
+	defer r.mu.RUnlock(token)
 	return r.mu.proposalBuf.LastAssignedLeaseIndexRLocked()
 }
 
@@ -410,22 +410,22 @@ func (r *Replica) QuotaReleaseQueueLen() int {
 }
 
 func (r *Replica) NumPendingProposals() int64 {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
+	token := r.mu.RLock()
+	defer r.mu.RUnlock(token)
 	return r.numPendingProposalsRLocked()
 }
 
 func (r *Replica) LastUpdateTimes() map[roachpb.ReplicaID]time.Time {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
+	token := r.mu.RLock()
+	defer r.mu.RUnlock(token)
 	return maps.Clone(r.mu.lastUpdateTimes)
 }
 
 func (r *Replica) IsFollowerActiveSince(
 	followerID roachpb.ReplicaID, now time.Time, threshold time.Duration,
 ) bool {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
+	token := r.mu.RLock()
+	defer r.mu.RUnlock(token)
 	return r.mu.lastUpdateTimes.isFollowerActiveSince(followerID, now, threshold)
 }
 
@@ -447,16 +447,16 @@ func (r *Replica) ShouldBackpressureWrites(_ context.Context) bool {
 // GetRaftLogSize returns the approximate raft log size and whether it is
 // trustworthy.. See r.mu.raftLogSize for details.
 func (r *Replica) GetRaftLogSize() (int64, bool) {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
+	token := r.mu.RLock()
+	defer r.mu.RUnlock(token)
 	return r.shMu.raftLogSize, r.shMu.raftLogSizeTrusted
 }
 
 // GetCachedLastTerm returns the cached last term value. May return
 // invalidLastTerm if the cache is not set.
 func (r *Replica) GetCachedLastTerm() kvpb.RaftTerm {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
+	token := r.mu.RLock()
+	defer r.mu.RUnlock(token)
 	return r.shMu.lastTermNotDurable
 }
 
@@ -469,8 +469,8 @@ func (r *Replica) SideloadedRaftMuLocked() logstore.SideloadStorage {
 // LargestPreviousMaxRangeSizeBytes returns the in-memory value used to mitigate
 // backpressure when the zone.RangeMaxBytes is decreased.
 func (r *Replica) LargestPreviousMaxRangeSizeBytes() int64 {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
+	token := r.mu.RLock()
+	defer r.mu.RUnlock(token)
 	return r.mu.largestPreviousMaxRangeSizeBytes
 }
 
@@ -589,16 +589,16 @@ func (r *Replica) MaybeUnquiesceAndPropose() (bool, error) {
 }
 
 func (r *Replica) ReadCachedProtectedTS() (readAt, earliestProtectionTimestamp hlc.Timestamp) {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
+	token := r.mu.RLock()
+	defer r.mu.RUnlock(token)
 	return r.mu.cachedProtectedTS.readAt, r.mu.cachedProtectedTS.earliestProtectionTimestamp
 }
 
 // ClosedTimestampPolicy returns the closed timestamp policy of the range, which
 // is updated asynchronously through gossip of zone configurations.
 func (r *Replica) ClosedTimestampPolicy() roachpb.RangeClosedTimestampPolicy {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
+	token := r.mu.RLock()
+	defer r.mu.RUnlock(token)
 	return r.closedTimestampPolicyRLocked()
 }
 

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/range_controller.go
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/range_controller.go
@@ -537,11 +537,11 @@ type ProbeToCloseTimerScheduler interface {
 // production code.
 type ReplicaMutexAsserter struct {
 	RaftMu    *syncutil.Mutex
-	ReplicaMu *syncutil.RWMutex
+	ReplicaMu *syncutil.RBMutex
 }
 
 func MakeReplicaMutexAsserter(
-	raftMu *syncutil.Mutex, replicaMu *syncutil.RWMutex,
+	raftMu *syncutil.Mutex, replicaMu *syncutil.RBMutex,
 ) ReplicaMutexAsserter {
 	return ReplicaMutexAsserter{
 		RaftMu:    raftMu,

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/range_controller_test.go
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/range_controller_test.go
@@ -337,7 +337,7 @@ func (s *testingRCState) maybeSetInitialTokens(r testingRange) {
 
 func makeTestMutexAsserter() ReplicaMutexAsserter {
 	var raftMu syncutil.Mutex
-	var replicaMu syncutil.RWMutex
+	var replicaMu syncutil.RBMutex
 	return MakeReplicaMutexAsserter(&raftMu, &replicaMu)
 }
 

--- a/pkg/kv/kvserver/kvflowcontrol/replica_rac2/processor_test.go
+++ b/pkg/kv/kvserver/kvflowcontrol/replica_rac2/processor_test.go
@@ -253,7 +253,7 @@ func (c *testRangeController) StatusRaftMuLocked() serverpb.RACStatus {
 
 func makeTestMutexAsserter() rac2.ReplicaMutexAsserter {
 	var raftMu syncutil.Mutex
-	var replicaMu syncutil.RWMutex
+	var replicaMu syncutil.RBMutex
 	return rac2.MakeReplicaMutexAsserter(&raftMu, &replicaMu)
 }
 

--- a/pkg/kv/kvserver/kvserverbase/stores.go
+++ b/pkg/kv/kvserver/kvserverbase/stores.go
@@ -37,7 +37,7 @@ type Store interface {
 	// GetReplicaMutexForTesting returns the mutex of the replica with the given
 	// range ID, or nil if no replica was found. This is used for testing.
 	// Returns a syncutil.RWMutex rather than ReplicaMutex to avoid import cycles.
-	GetReplicaMutexForTesting(rangeID roachpb.RangeID) *syncutil.RWMutex
+	GetReplicaMutexForTesting(rangeID roachpb.RangeID) *syncutil.RBMutex
 }
 
 // UnsupportedStoresIterator is a StoresIterator that only returns "unsupported"

--- a/pkg/kv/kvserver/mvcc_gc_queue.go
+++ b/pkg/kv/kvserver/mvcc_gc_queue.go
@@ -302,10 +302,10 @@ func makeMVCCGCQueueScore(
 	gcTTL time.Duration,
 	canAdvanceGCThreshold bool,
 ) mvccGCQueueScore {
-	repl.mu.RLock()
+	token := repl.mu.RLock()
 	ms := *repl.shMu.state.Stats
 	hint := *repl.shMu.state.GCHint
-	repl.mu.RUnlock()
+	repl.mu.RUnlock(token)
 
 	if repl.store.cfg.TestingKnobs.DisableLastProcessedCheck {
 		lastGC = hlc.Timestamp{}

--- a/pkg/kv/kvserver/mvcc_gc_queue_test.go
+++ b/pkg/kv/kvserver/mvcc_gc_queue_test.go
@@ -1240,9 +1240,9 @@ func TestMVCCGCQueueTransactionTable(t *testing.T) {
 	batch := tc.engine.NewSnapshot()
 	defer batch.Close()
 	tc.repl.raftMu.Lock()
-	tc.repl.mu.RLock()
+	token := tc.repl.mu.RLock()
 	tc.repl.assertStateRaftMuLockedReplicaMuRLocked(ctx, batch) // check that in-mem and on-disk state were updated
-	tc.repl.mu.RUnlock()
+	tc.repl.mu.RUnlock(token)
 	tc.repl.raftMu.Unlock()
 }
 

--- a/pkg/kv/kvserver/raft.go
+++ b/pkg/kv/kvserver/raft.go
@@ -264,13 +264,13 @@ func extractIDs(ids []kvserverbase.CmdIDKey, ents []raftpb.Entry) []kvserverbase
 // command which corresponds to an id in ids.
 func traceProposals(r *Replica, ids []kvserverbase.CmdIDKey, event string) {
 	ctxs := make([]context.Context, 0, len(ids))
-	r.mu.RLock()
+	token := r.mu.RLock()
 	for _, id := range ids {
 		if prop, ok := r.mu.proposals[id]; ok {
 			ctxs = append(ctxs, prop.Context())
 		}
 	}
-	r.mu.RUnlock()
+	r.mu.RUnlock(token)
 	for _, ctx := range ctxs {
 		log.Eventf(ctx, "%v", event)
 	}

--- a/pkg/kv/kvserver/raft_log_queue_test.go
+++ b/pkg/kv/kvserver/raft_log_queue_test.go
@@ -828,8 +828,8 @@ func TestTruncateLogRecompute(t *testing.T) {
 	repl := tc.store.LookupReplica(keys.MustAddr(key))
 
 	trusted := func() bool {
-		repl.mu.RLock()
-		defer repl.mu.RUnlock()
+		token := repl.mu.RLock()
+		defer repl.mu.RUnlock(token)
 		return repl.shMu.raftLogSizeTrusted
 	}
 

--- a/pkg/kv/kvserver/replica_application_state_machine_test.go
+++ b/pkg/kv/kvserver/replica_application_state_machine_test.go
@@ -430,9 +430,9 @@ func TestReplicaStateMachineEphemeralAppBatchRejection(t *testing.T) {
 
 	sm := r.getStateMachine()
 
-	r.mu.RLock()
+	token := r.mu.RLock()
 	raftAppliedIndex := r.shMu.state.RaftAppliedIndex
-	r.mu.RUnlock()
+	r.mu.RUnlock(token)
 
 	descWriteRepr := func(v string) (kvpb.Request, []byte) {
 		b := tc.store.TODOEngine().NewBatch()

--- a/pkg/kv/kvserver/replica_backpressure.go
+++ b/pkg/kv/kvserver/replica_backpressure.go
@@ -152,8 +152,8 @@ func (r *Replica) signallerForBatch(ba *kvpb.BatchRequest) signaller {
 // further explanation). It ensures that writes are always backpressured if the
 // range's size is already larger than the absolute maximum we'll allow.
 func (r *Replica) shouldBackpressureWrites() bool {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
+	token := r.mu.RLock()
+	defer r.mu.RUnlock(token)
 
 	// Check if the current range's size is already over the absolute maximum
 	// we'll allow. Don't bother with any multipliers/byte tolerance calculations

--- a/pkg/kv/kvserver/replica_command.go
+++ b/pkg/kv/kvserver/replica_command.go
@@ -2965,10 +2965,10 @@ func (r *Replica) sendSnapshotUsingDelegate(
 		r.reportSnapshotStatus(ctx, recipient.ReplicaID, retErr)
 	}()
 
-	r.mu.RLock()
+	token := r.mu.RLock()
 	sender, err := r.getReplicaDescriptorRLocked()
 	_, destPaused := r.mu.pausedFollowers[recipient.ReplicaID]
-	r.mu.RUnlock()
+	r.mu.RUnlock(token)
 
 	if err != nil {
 		return err
@@ -3142,10 +3142,10 @@ func (r *Replica) validateSnapshotDelegationRequest(
 	// Check the raft applied state index and term to determine if this replica
 	// is not too far behind the leaseholder. If the delegate is too far behind
 	// that is also needs a snapshot, then any snapshot it sends will be useless.
-	r.mu.RLock()
+	token := r.mu.RLock()
 	replIdx := r.shMu.state.RaftAppliedIndex + 1
 	status := r.raftBasicStatusRLocked()
-	r.mu.RUnlock()
+	r.mu.RUnlock(token)
 
 	if status.Empty() {
 		// This code path is sometimes hit during scatter for replicas that haven't

--- a/pkg/kv/kvserver/replica_follower_read.go
+++ b/pkg/kv/kvserver/replica_follower_read.go
@@ -162,7 +162,7 @@ func (r *Replica) getCurrentClosedTimestampLocked(
 // GetCurrentClosedTimestamp returns the current maximum closed timestamp for
 // this range.
 func (r *Replica) GetCurrentClosedTimestamp(ctx context.Context) hlc.Timestamp {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
+	token := r.mu.RLock()
+	defer r.mu.RUnlock(token)
 	return r.getCurrentClosedTimestampLocked(ctx, hlc.Timestamp{} /* sufficient */)
 }

--- a/pkg/kv/kvserver/replica_follower_read_test.go
+++ b/pkg/kv/kvserver/replica_follower_read_test.go
@@ -92,8 +92,8 @@ func TestCanServeFollowerRead(t *testing.T) {
 			ba.Header = kvpb.Header{Txn: &txn}
 			ba.Add(&gArgs)
 			r := tc.repl
-			r.mu.RLock()
-			defer r.mu.RUnlock()
+			token := r.mu.RLock()
+			defer r.mu.RUnlock(token)
 			require.Equal(t, test.expCanServeFollowerRead, r.canServeFollowerReadRLocked(ctx, ba))
 		})
 	}

--- a/pkg/kv/kvserver/replica_init.go
+++ b/pkg/kv/kvserver/replica_init.go
@@ -267,7 +267,7 @@ func newUninitializedReplicaWithoutRaftGroup(
 		ReplicaID:         r.replicaID,
 		ReplicaForTesting: (*replicaForRACv2)(r),
 		ReplicaMutexAsserter: rac2.MakeReplicaMutexAsserter(
-			&r.raftMu.Mutex, (*syncutil.RWMutex)(&r.mu.ReplicaMutex)),
+			&r.raftMu.Mutex, (*syncutil.RBMutex)(&r.mu.ReplicaMutex)),
 		RaftScheduler:          r.store.scheduler,
 		AdmittedPiggybacker:    r.store.cfg.KVFlowAdmittedPiggybacker,
 		ACWorkQueue:            r.store.cfg.KVAdmissionController,
@@ -414,8 +414,8 @@ func (r *Replica) IsInitialized() bool {
 // TenantID returns the associated tenant ID and a boolean to indicate that it
 // is valid. It will be invalid only if the replica is not initialized.
 func (r *Replica) TenantID() (roachpb.TenantID, bool) {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
+	token := r.mu.RLock()
+	defer r.mu.RUnlock(token)
 	return r.getTenantIDRLocked()
 }
 

--- a/pkg/kv/kvserver/replica_metrics.go
+++ b/pkg/kv/kvserver/replica_metrics.go
@@ -87,7 +87,7 @@ func (r *Replica) Metrics(
 	nodeAttrs := r.store.nodeDesc.Attrs
 	nodeLocality := r.store.nodeDesc.Locality
 
-	r.mu.RLock()
+	token := r.mu.RLock()
 
 	var qpUsed, qpCap int64
 	if q := r.mu.proposalQuota; q != nil {
@@ -124,7 +124,7 @@ func (r *Replica) Metrics(
 		slowRaftProposalCount:    r.mu.slowProposalCount,
 	}
 
-	r.mu.RUnlock()
+	r.mu.RUnlock(token)
 
 	return calcReplicaMetrics(input)
 }

--- a/pkg/kv/kvserver/replica_proposal_buf_test.go
+++ b/pkg/kv/kvserver/replica_proposal_buf_test.go
@@ -45,7 +45,7 @@ import (
 
 // testProposer is a testing implementation of proposer.
 type testProposer struct {
-	syncutil.RWMutex
+	syncutil.RBMutex
 	clock      *hlc.Clock
 	ds         destroyStatus
 	ci         kvpb.RaftIndex
@@ -136,11 +136,11 @@ func (t *testProposerRaft) Campaign() error {
 }
 
 func (t *testProposer) locker() sync.Locker {
-	return &t.RWMutex
+	return &t.RBMutex
 }
 
-func (t *testProposer) rlocker() sync.Locker {
-	return t.RWMutex.RLocker()
+func (t *testProposer) rlocker() syncutil.RBLocker {
+	return t.RBMutex.RLocker()
 }
 func (t *testProposer) flowControlHandle(ctx context.Context) kvflowcontrol.Handle {
 	return &testFlowTokenHandle{}

--- a/pkg/kv/kvserver/replica_proposal_quota.go
+++ b/pkg/kv/kvserver/replica_proposal_quota.go
@@ -41,10 +41,10 @@ func (r *Replica) maybeAcquireProposalQuota(
 		return nil, nil
 	}
 
-	r.mu.RLock()
+	token := r.mu.RLock()
 	enabled := r.getQuotaPoolEnabledRLocked(ctx)
 	quotaPool := r.mu.proposalQuota
-	r.mu.RUnlock()
+	r.mu.RUnlock(token)
 
 	if !enabled {
 		return nil, nil

--- a/pkg/kv/kvserver/replica_protected_timestamp.go
+++ b/pkg/kv/kvserver/replica_protected_timestamp.go
@@ -117,8 +117,8 @@ func (r *Replica) checkProtectedTimestampsForGC(
 	// record.
 	var read cachedProtectedTimestampState
 	defer r.maybeUpdateCachedProtectedTS(&read)
-	r.mu.RLock()
-	defer r.mu.RUnlock()
+	token := r.mu.RLock()
+	defer r.mu.RUnlock(token)
 	defer read.clearIfNotNewer(r.mu.cachedProtectedTS)
 
 	oldThreshold = *r.shMu.state.GCThreshold

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -2055,7 +2055,7 @@ func (r *Replica) sendRaftMessage(
 ) {
 	lastToReplica, lastFromReplica := r.getLastReplicaDescriptors()
 
-	r.mu.RLock()
+	token := r.mu.RLock()
 	traced := r.mu.raftTracer.MaybeTrace(msg)
 	fromReplica, fromErr := r.getReplicaDescriptorByIDRLocked(roachpb.ReplicaID(msg.From), lastToReplica)
 	toReplica, toErr := r.getReplicaDescriptorByIDRLocked(roachpb.ReplicaID(msg.To), lastFromReplica)
@@ -2077,7 +2077,7 @@ func (r *Replica) sendRaftMessage(
 			}
 		})
 	}
-	r.mu.RUnlock()
+	r.mu.RUnlock(token)
 
 	if fromErr != nil {
 		log.Warningf(ctx, "failed to look up sender replica %d in r%d while sending %s: %s",
@@ -2336,8 +2336,8 @@ func (r *Replica) errOnOutstandingLearnerSnapshotInflight() error {
 func (r *Replica) hasOutstandingSnapshotInFlightToStore(
 	storeID roachpb.StoreID, initialOnly bool,
 ) ([]snapTruncationInfo, bool) {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
+	token := r.mu.RLock()
+	defer r.mu.RUnlock(token)
 	sl, idx := r.getSnapshotLogTruncationConstraintsRLocked(storeID, initialOnly)
 	return sl, idx > 0
 }

--- a/pkg/kv/kvserver/replica_raft_quiesce.go
+++ b/pkg/kv/kvserver/replica_raft_quiesce.go
@@ -51,7 +51,7 @@ func (r *Replica) quiesceLocked(ctx context.Context, lagging laggingReplicaSet) 
 // unquiesced, returning true in that case. See maybeUnquiesceLocked() for
 // details.
 func (r *Replica) maybeUnquiesce(ctx context.Context, wakeLeader, mayCampaign bool) bool {
-	r.mu.TracedLock(ctx)
+	r.mu.Lock()
 	defer r.mu.Unlock()
 	return r.maybeUnquiesceLocked(wakeLeader, mayCampaign)
 }

--- a/pkg/kv/kvserver/replica_raftlog.go
+++ b/pkg/kv/kvserver/replica_raftlog.go
@@ -145,8 +145,8 @@ func (r *Replica) raftLastIndexRLocked() kvpb.RaftIndex {
 // GetLastIndex returns the index of the last entry in the raft log.
 // Requires that r.mu is not held.
 func (r *Replica) GetLastIndex() kvpb.RaftIndex {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
+	token := r.mu.RLock()
+	defer r.mu.RUnlock(token)
 	return r.raftLastIndexRLocked()
 }
 
@@ -164,8 +164,8 @@ func (r *Replica) raftCompactedIndexRLocked() kvpb.RaftIndex {
 // GetCompactedIndex returns the compacted index of the raft log.
 // Requires that r.mu is not held.
 func (r *Replica) GetCompactedIndex() kvpb.RaftIndex {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
+	token := r.mu.RLock()
+	defer r.mu.RUnlock(token)
 	return r.raftCompactedIndexRLocked()
 }
 

--- a/pkg/kv/kvserver/replica_raftstorage.go
+++ b/pkg/kv/kvserver/replica_raftstorage.go
@@ -140,8 +140,8 @@ func (r *replicaRaftStorage) InitialState() (raftpb.HardState, raftpb.ConfState,
 
 // GetLeaseAppliedIndex returns the lease index of the last applied command.
 func (r *Replica) GetLeaseAppliedIndex() kvpb.LeaseAppliedIndex {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
+	token := r.mu.RLock()
+	defer r.mu.RUnlock(token)
 	return r.shMu.state.LeaseAppliedIndex
 }
 
@@ -762,9 +762,9 @@ func (r *Replica) applySnapshot(
 	// after the application of the snapshot. Do so under a read lock, as this
 	// operation can be expensive. This is safe, as we hold the Replica.raftMu
 	// across both Replica.mu critical sections.
-	r.mu.RLock()
+	token := r.mu.RLock()
 	r.assertStateRaftMuLockedReplicaMuRLocked(ctx, r.store.TODOEngine())
-	r.mu.RUnlock()
+	r.mu.RUnlock(token)
 
 	// The rangefeed processor is listening for the logical ops attached to
 	// each raft command. These will be lost during a snapshot, so disconnect

--- a/pkg/kv/kvserver/replica_range_lease.go
+++ b/pkg/kv/kvserver/replica_range_lease.go
@@ -731,8 +731,8 @@ func (r *Replica) CurrentLeaseStatus(ctx context.Context) kvserverpb.LeaseStatus
 func (r *Replica) LeaseStatusAt(
 	ctx context.Context, now hlc.ClockTimestamp,
 ) kvserverpb.LeaseStatus {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
+	token := r.mu.RLock()
+	defer r.mu.RUnlock(token)
 	return r.leaseStatusAtRLocked(ctx, now)
 }
 
@@ -773,8 +773,8 @@ func (r *Replica) leaseStatusForRequestRLocked(
 // but returns the status of the current lease and ownership at the
 // specified point in time.
 func (r *Replica) OwnsValidLease(ctx context.Context, now hlc.ClockTimestamp) bool {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
+	token := r.mu.RLock()
+	defer r.mu.RUnlock(token)
 	return r.ownsValidLeaseRLocked(ctx, now)
 }
 
@@ -1037,8 +1037,8 @@ func (r *Replica) AdminTransferLease(
 
 // GetLease returns the lease and, if available, the proposed next lease.
 func (r *Replica) GetLease() (roachpb.Lease, roachpb.Lease) {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
+	token := r.mu.RLock()
+	defer r.mu.RUnlock(token)
 	return r.getLeaseRLocked()
 }
 
@@ -1199,8 +1199,8 @@ func (r *Replica) leaseGoodToGoForStatusRLocked(
 func (r *Replica) leaseGoodToGo(
 	ctx context.Context, now hlc.ClockTimestamp, reqTS hlc.Timestamp,
 ) (kvserverpb.LeaseStatus, error) {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
+	token := r.mu.RLock()
+	defer r.mu.RUnlock(token)
 	return r.leaseGoodToGoRLocked(ctx, now, reqTS)
 }
 
@@ -1559,8 +1559,8 @@ func (r *Replica) maybeSwitchLeaseType(ctx context.Context) *kvpb.Error {
 
 // HasCorrectLeaseType returns true if the lease type is correct for this replica.
 func (r *Replica) HasCorrectLeaseType(lease roachpb.Lease) bool {
-	r.mu.RLock()
-	defer r.mu.RUnlock()
+	token := r.mu.RLock()
+	defer r.mu.RUnlock(token)
 	return r.hasCorrectLeaseTypeRLocked(lease)
 }
 

--- a/pkg/kv/kvserver/replica_rangefeed.go
+++ b/pkg/kv/kvserver/replica_rangefeed.go
@@ -348,8 +348,8 @@ func (r *Replica) RangeFeed(
 }
 
 func (r *Replica) getRangefeedProcessorAndFilter() (rangefeed.Processor, *rangefeed.Filter) {
-	r.rangefeedMu.RLock()
-	defer r.rangefeedMu.RUnlock()
+	token := r.rangefeedMu.RLock()
+	defer r.rangefeedMu.RUnlock(token)
 	return r.rangefeedMu.proc, r.rangefeedMu.opFilter
 }
 

--- a/pkg/kv/kvserver/replica_read.go
+++ b/pkg/kv/kvserver/replica_read.go
@@ -46,8 +46,8 @@ func (r *Replica) executeReadOnlyBatch(
 	_ *kvadmission.StoreWriteBytes,
 	pErr *kvpb.Error,
 ) {
-	r.readOnlyCmdMu.RLock()
-	defer r.readOnlyCmdMu.RUnlock()
+	token := r.readOnlyCmdMu.RLock()
+	defer r.readOnlyCmdMu.RUnlock(token)
 
 	// Verify that the batch can be executed.
 	st, err := r.checkExecutionCanProceedBeforeStorageSnapshot(ctx, ba, g)

--- a/pkg/kv/kvserver/replica_send.go
+++ b/pkg/kv/kvserver/replica_send.go
@@ -1104,10 +1104,10 @@ func (r *Replica) collectSpans(
 	_ error,
 ) {
 	latchSpans, lockSpans = spanset.New(), lockspanset.New()
-	r.mu.RLock()
+	token := r.mu.RLock()
 	desc := r.descRLocked()
 	liveCount := r.shMu.state.Stats.LiveCount
-	r.mu.RUnlock()
+	r.mu.RUnlock(token)
 	// TODO(bdarnell): need to make this less global when local
 	// latches are used more heavily. For example, a split will
 	// have a large read-only span but also a write (see #10084).

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -304,9 +304,9 @@ func (tc *testContext) addBogusReplicaToRangeDesc(
 
 	tc.repl.raftMu.Lock()
 	tc.repl.setDescRaftMuLocked(ctx, &newDesc)
-	tc.repl.mu.RLock()
+	token := tc.repl.mu.RLock()
 	tc.repl.assertStateRaftMuLockedReplicaMuRLocked(ctx, tc.engine)
-	tc.repl.mu.RUnlock()
+	tc.repl.mu.RUnlock(token)
 	tc.repl.raftMu.Unlock()
 	return newReplica, nil
 }
@@ -856,13 +856,13 @@ func TestLeaseReplicaNotInDesc(t *testing.T) {
 			},
 		},
 	}
-	tc.repl.mu.RLock()
+	token := tc.repl.mu.RLock()
 	fr := kvserverbase.CheckForcedErr(
 		ctx, raftlog.MakeCmdIDKey(), &raftCmd, false, /* isLocal */
 		&tc.repl.shMu.state,
 	)
 	pErr := fr.ForcedError
-	tc.repl.mu.RUnlock()
+	tc.repl.mu.RUnlock(token)
 	if _, isErr := pErr.GetDetail().(*kvpb.LeaseRejectedError); !isErr {
 		t.Fatal(pErr)
 	} else if !testutils.IsPError(pErr, "replica not part of range") {
@@ -6678,9 +6678,9 @@ func TestAppliedIndex(t *testing.T) {
 			t.Errorf("expected %d, got %d", sum, reply.NewValue)
 		}
 
-		tc.repl.mu.RLock()
+		token := tc.repl.mu.RLock()
 		newAppliedIndex := tc.repl.shMu.state.RaftAppliedIndex
-		tc.repl.mu.RUnlock()
+		tc.repl.mu.RUnlock(token)
 		if newAppliedIndex <= appliedIndex {
 			t.Errorf("appliedIndex did not advance. Was %d, now %d", appliedIndex, newAppliedIndex)
 		}
@@ -7925,12 +7925,12 @@ func TestReplicaRetryRaftProposal(t *testing.T) {
 
 	// Set the max lease index to that of the recently applied write.
 	// Two requests can't have the same lease applied index.
-	tc.repl.mu.RLock()
+	token := tc.repl.mu.RLock()
 	wrongLeaseIndex = tc.repl.shMu.state.LeaseAppliedIndex
 	if wrongLeaseIndex < 1 {
 		t.Fatal("committed a few batches, but still at lease index zero")
 	}
-	tc.repl.mu.RUnlock()
+	tc.repl.mu.RUnlock(token)
 
 	log.Infof(ctx, "test begins")
 
@@ -8139,8 +8139,8 @@ func TestReplicaBurstPendingCommandsAndRepropose(t *testing.T) {
 		t.Fatalf("expected indexes %v, got %v", origIndexes, seenCmds)
 	}
 
-	tc.repl.mu.RLock()
-	defer tc.repl.mu.RUnlock()
+	token := tc.repl.mu.RLock()
+	defer tc.repl.mu.RUnlock(token)
 	if tc.repl.hasPendingProposalsRLocked() {
 		t.Fatal("still pending commands")
 	}

--- a/pkg/kv/kvserver/replica_write.go
+++ b/pkg/kv/kvserver/replica_write.go
@@ -106,10 +106,10 @@ func (r *Replica) executeWriteBatch(
 	// Raft execution, use the local. Upon unlocking, the local must be zeroed
 	// out.
 	readOnlyCmdMu := &r.readOnlyCmdMu
-	readOnlyCmdMu.RLock()
+	token := readOnlyCmdMu.RLock()
 	defer func() {
 		if readOnlyCmdMu != nil {
-			readOnlyCmdMu.RUnlock()
+			readOnlyCmdMu.RUnlock(token)
 		}
 	}()
 
@@ -189,7 +189,7 @@ func (r *Replica) executeWriteBatch(
 	if pErr != nil {
 		if cErr, ok := pErr.GetDetail().(*kvpb.ReplicaCorruptionError); ok {
 			// Need to unlock here because setCorruptRaftMuLock needs readOnlyCmdMu not held.
-			readOnlyCmdMu.RUnlock()
+			readOnlyCmdMu.RUnlock(token)
 			readOnlyCmdMu = nil
 
 			r.raftMu.Lock()
@@ -203,7 +203,7 @@ func (r *Replica) executeWriteBatch(
 
 	// We are done with pre-Raft evaluation at this point, and have to release the
 	// read-only command lock to avoid deadlocks during Raft evaluation.
-	readOnlyCmdMu.RUnlock()
+	readOnlyCmdMu.RUnlock(token)
 	readOnlyCmdMu = nil
 
 	// If the command was accepted by raft, wait for the range to apply it.

--- a/pkg/kv/kvserver/split_delay_helper.go
+++ b/pkg/kv/kvserver/split_delay_helper.go
@@ -29,7 +29,7 @@ type splitDelayHelper Replica
 
 func (sdh *splitDelayHelper) RaftStatus(ctx context.Context) (roachpb.RangeID, *raft.Status) {
 	r := (*Replica)(sdh)
-	r.mu.RLock()
+	token := r.mu.RLock()
 	raftStatus := r.raftStatusRLocked()
 	if raftStatus != nil {
 		updateRaftProgressFromActivity(
@@ -39,7 +39,7 @@ func (sdh *splitDelayHelper) RaftStatus(ctx context.Context) (roachpb.RangeID, *
 			},
 		)
 	}
-	r.mu.RUnlock()
+	r.mu.RUnlock(token)
 	return r.RangeID, raftStatus
 }
 

--- a/pkg/kv/kvserver/split_trigger_helper.go
+++ b/pkg/kv/kvserver/split_trigger_helper.go
@@ -22,10 +22,10 @@ type replicaMsgAppDropper Replica
 
 func (rd *replicaMsgAppDropper) Args() (initialized bool, age time.Duration) {
 	r := (*Replica)(rd)
-	r.mu.RLock()
+	token := r.mu.RLock()
 	initialized = r.IsInitialized()
 	creationTime := r.creationTime
-	r.mu.RUnlock()
+	r.mu.RUnlock(token)
 	age = timeutil.Since(creationTime)
 	return initialized, age
 }

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -564,10 +564,10 @@ func (rs *storeReplicaVisitor) Visit(visitor func(*Replica) bool) {
 		// destroyed once we return errors from mutexes (#9190). After all, it
 		// can still happen with this code.
 		rs.visited++
-		repl.mu.RLock()
+		token := repl.mu.RLock()
 		destroyed := repl.mu.destroyStatus
 		initialized := repl.IsInitialized()
-		repl.mu.RUnlock()
+		repl.mu.RUnlock(token)
 		if initialized && destroyed.IsAlive() && !visitor(repl) {
 			break
 		}

--- a/pkg/kv/kvserver/store_snapshot.go
+++ b/pkg/kv/kvserver/store_snapshot.go
@@ -347,11 +347,11 @@ func (s *Store) canAcceptSnapshotLocked(
 	// commits, and cannot have been replicaGC'ed yet (see replicaGCQueue.process).
 	existingRepl.raftMu.AssertHeld()
 
-	existingRepl.mu.RLock()
+	token := existingRepl.mu.RLock()
 	existingDesc := existingRepl.shMu.state.Desc
 	existingIsInitialized := existingDesc.IsInitialized()
 	existingDestroyStatus := existingRepl.mu.destroyStatus
-	existingRepl.mu.RUnlock()
+	existingRepl.mu.RUnlock(token)
 
 	if existingIsInitialized {
 		// Regular Raft snapshots can't be refused at this point,

--- a/pkg/kv/kvserver/store_split.go
+++ b/pkg/kv/kvserver/store_split.go
@@ -221,10 +221,10 @@ func prepareRightReplicaForSplit(
 	// was not able to use its current lease because of a restart or lease
 	// transfer, the RHS will also not be able to. minValidObservedTS ensures that
 	// the bounds for uncertainty interval are preserved.
-	r.mu.RLock()
+	token := r.mu.RLock()
 	minLeaseProposedTS := r.mu.minLeaseProposedTS
 	minValidObservedTS := r.mu.minValidObservedTimestamp
-	r.mu.RUnlock()
+	r.mu.RUnlock(token)
 
 	// If the RHS replica of the split is not removed, then it has been obtained
 	// (and its raftMu acquired) in Replica.acquireSplitLock.

--- a/pkg/kv/kvserver/store_test.go
+++ b/pkg/kv/kvserver/store_test.go
@@ -773,9 +773,9 @@ func TestStoreRemoveReplicaDestroy(t *testing.T) {
 	})
 	require.Equal(t, errRemoved, err)
 
-	repl1.mu.RLock()
+	token := repl1.mu.RLock()
 	expErr := repl1.mu.destroyStatus.err
-	repl1.mu.RUnlock()
+	repl1.mu.RUnlock(token)
 
 	if expErr == nil {
 		t.Fatal("replica was not marked as destroyed")

--- a/pkg/kv/kvserver/stores_base.go
+++ b/pkg/kv/kvserver/stores_base.go
@@ -87,10 +87,10 @@ func (s *baseStore) SetQueueActive(active bool, queue string) error {
 }
 
 // GetReplicaMutexForTesting is part of kvserverbase.Store.
-func (s *baseStore) GetReplicaMutexForTesting(rangeID roachpb.RangeID) *syncutil.RWMutex {
+func (s *baseStore) GetReplicaMutexForTesting(rangeID roachpb.RangeID) *syncutil.RBMutex {
 	store := (*Store)(s)
 	if repl := store.GetReplicaIfExists(rangeID); repl != nil {
-		return (*syncutil.RWMutex)(repl.GetMutexForTesting())
+		return (*syncutil.RBMutex)(repl.GetMutexForTesting())
 	}
 	return nil
 }

--- a/pkg/kv/kvserver/stores_server.go
+++ b/pkg/kv/kvserver/stores_server.go
@@ -86,9 +86,9 @@ func (is Server) WaitForApplication(
 			if err != nil {
 				return err
 			}
-			repl.mu.RLock()
+			token := repl.mu.RLock()
 			leaseAppliedIndex := repl.shMu.state.LeaseAppliedIndex
-			repl.mu.RUnlock()
+			repl.mu.RUnlock(token)
 			if leaseAppliedIndex >= req.LeaseIndex {
 				// For performance reasons, we don't sync to disk when
 				// applying raft commands. This means that if a node restarts

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -6978,7 +6978,7 @@ SELECT
 				rangeID := roachpb.RangeID(*args[0].(*tree.DInt))
 				lock := *args[1].(*tree.DBool)
 
-				var replicaMu *syncutil.RWMutex
+				var replicaMu *syncutil.RBMutex
 				if err := evalCtx.KVStoresIterator.ForEachStore(func(store kvserverbase.Store) error {
 					if replicaMu == nil {
 						replicaMu = store.GetReplicaMutexForTesting(rangeID)

--- a/pkg/util/syncutil/BUILD.bazel
+++ b/pkg/util/syncutil/BUILD.bazel
@@ -32,5 +32,9 @@ go_test(
         "set_test.go",
     ],
     embed = [":syncutil"],
-    deps = ["@com_github_stretchr_testify//require"],
+    deps = [
+        "@com_github_cockroachdb_crlib//crtime",
+        "@com_github_stretchr_testify//require",
+        "@org_golang_x_sync//errgroup",
+    ],
 )

--- a/pkg/util/syncutil/BUILD.bazel
+++ b/pkg/util/syncutil/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/util/syncutil",
     visibility = ["//visibility:public"],
     deps = [
+        "@com_github_puzpuzpuz_xsync_v3//:xsync",
         "@com_github_sasha_s_go_deadlock//:go-deadlock",  # keep
     ],
 )

--- a/pkg/util/syncutil/map_bench_test.go
+++ b/pkg/util/syncutil/map_bench_test.go
@@ -340,7 +340,7 @@ func BenchmarkMutex(b *testing.B) {
 				b.Run(fmt.Sprintf("threads=%d", numThreads), func(b *testing.B) {
 					var rWaitTime, wWaitTime atomic.Int64
 					for i := 0; i < b.N; i++ {
-						var mu RBMutex
+						var mu RWMutex
 						g := errgroup.Group{}
 						g.SetLimit(numThreads)
 
@@ -358,10 +358,10 @@ func BenchmarkMutex(b *testing.B) {
 									time.Sleep(writeHoldTimeMs)
 									mu.Unlock()
 								} else {
-									token := mu.RLock()
+									mu.RLock()
 									rWaitTime.Add(int64(now.Elapsed()))
 									time.Sleep(readHoldTimeMs)
-									mu.RUnlock(token)
+									mu.RUnlock()
 								}
 								return nil
 							})

--- a/pkg/util/syncutil/mutex_deadlock.go
+++ b/pkg/util/syncutil/mutex_deadlock.go
@@ -64,6 +64,23 @@ type RBMutex struct {
 	xsync.RBMutex
 }
 
+// RLock locks rb for reading and returns a reader token. The
+// token must be used in the later RUnlock call.
+//
+// Should not be used for recursive read locking; a blocked Lock
+// call excludes new readers from acquiring the lock.
+func (rb *RBMutex) RLock() *RToken {
+	return (*RToken)(rb.RBMutex.RLock())
+}
+
+// RUnlock undoes a single RLock call. A reader token obtained from
+// the RLock call must be provided. RUnlock does not affect other
+// simultaneous readers. A panic is raised if m is not locked for
+// reading on entry to RUnlock.
+func (rb *RBMutex) RUnlock(token *RToken) {
+	rb.RBMutex.RUnlock((*xsync.RToken)(token))
+}
+
 // AssertHeld may panic if the mutex is not locked for writing (but it is not
 // required to do so). Functions which require that their callers hold a
 // particular lock may use this to enforce this requirement more directly than

--- a/pkg/util/syncutil/mutex_deadlock.go
+++ b/pkg/util/syncutil/mutex_deadlock.go
@@ -10,6 +10,7 @@ package syncutil
 import (
 	"time"
 
+	"github.com/puzpuzpuz/xsync/v3"
 	deadlock "github.com/sasha-s/go-deadlock"
 )
 
@@ -56,3 +57,32 @@ func (rw *RWMutex) TryLock() bool {
 func (rw *RWMutex) TryRLock() bool {
 	return false
 }
+
+// A RBMutex is a reader biased reader/writer mutual exclusion lock.
+// It behaves the same in deadlock builds and non-deadlock builds.
+type RBMutex struct {
+	xsync.RBMutex
+}
+
+// AssertHeld may panic if the mutex is not locked for writing (but it is not
+// required to do so). Functions which require that their callers hold a
+// particular lock may use this to enforce this requirement more directly than
+// relying on the race detector.
+//
+// Note that we do not require the exclusive lock to be held by any particular
+// thread, just that some thread holds the lock. This is both more efficient
+// and allows for rare cases where a mutex is locked in one thread and used in
+// another.
+func (rb *RBMutex) AssertHeld() {}
+
+// AssertRHeld may panic if the mutex is not locked for reading (but it is not
+// required to do so). If the mutex is locked for writing, it is also considered
+// to be locked for reading. Functions which require that their callers hold a
+// particular lock may use this to enforce this requirement more directly than
+// relying on the race detector.
+//
+// Note that we do not require the shared lock to be held by any particular
+// thread, just that some thread holds the lock. This is both more efficient
+// and allows for rare cases where a mutex is locked in one thread and used in
+// another.
+func (rb *RBMutex) AssertRHeld() {}

--- a/pkg/util/syncutil/mutex_sync.go
+++ b/pkg/util/syncutil/mutex_sync.go
@@ -7,7 +7,11 @@
 
 package syncutil
 
-import "sync"
+import (
+	"sync"
+
+	"github.com/puzpuzpuz/xsync/v3"
+)
 
 // DeadlockEnabled is true if the deadlock detector is enabled.
 const DeadlockEnabled = false
@@ -57,3 +61,31 @@ func (rw *RWMutex) AssertHeld() {
 // another.
 func (rw *RWMutex) AssertRHeld() {
 }
+
+// A RBMutex is a reader biased reader/writer mutual exclusion lock.
+type RBMutex struct {
+	xsync.RBMutex
+}
+
+// AssertHeld may panic if the mutex is not locked for writing (but it is not
+// required to do so). Functions which require that their callers hold a
+// particular lock may use this to enforce this requirement more directly than
+// relying on the race detector.
+//
+// Note that we do not require the exclusive lock to be held by any particular
+// thread, just that some thread holds the lock. This is both more efficient
+// and allows for rare cases where a mutex is locked in one thread and used in
+// another.
+func (rb *RBMutex) AssertHeld() {}
+
+// AssertRHeld may panic if the mutex is not locked for reading (but it is not
+// required to do so). If the mutex is locked for writing, it is also considered
+// to be locked for reading. Functions which require that their callers hold a
+// particular lock may use this to enforce this requirement more directly than
+// relying on the race detector.
+//
+// Note that we do not require the shared lock to be held by any particular
+// thread, just that some thread holds the lock. This is both more efficient
+// and allows for rare cases where a mutex is locked in one thread and used in
+// another.
+func (rb *RBMutex) AssertRHeld() {}

--- a/pkg/util/syncutil/mutex_sync_race.go
+++ b/pkg/util/syncutil/mutex_sync_race.go
@@ -156,6 +156,23 @@ type RBMutex struct {
 	rLocked int32 // updated atomically
 }
 
+// RLock locks rb for reading and returns a reader token. The
+// token must be used in the later RUnlock call.
+//
+// Should not be used for recursive read locking; a blocked Lock
+// call excludes new readers from acquiring the lock.
+func (rb *RBMutex) RLock() *RToken {
+	return (*RToken)(rb.RBMutex.RLock())
+}
+
+// RUnlock undoes a single RLock call. A reader token obtained from
+// the RLock call must be provided. RUnlock does not affect other
+// simultaneous readers. A panic is raised if m is not locked for
+// reading on entry to RUnlock.
+func (rb *RBMutex) RUnlock(token *RToken) {
+	rb.RBMutex.RUnlock((*xsync.RToken)(token))
+}
+
 // AssertHeld may panic if the mutex is not locked for writing (but it is not
 // required to do so). Functions which require that their callers hold a
 // particular lock may use this to enforce this requirement more directly than


### PR DESCRIPTION
### go.mod, syncutil: add xsync.RBMutex dependency

xsync.RBMutex has a few differences from the syncutil.RWMutex algorithm
which could improve performance for read-heavy access:
- Fast path for readers which avoids contention on a single counter.
- A different fairness algorithm that biases more towards readers.

###  kvserver: stop using TracedLock in Replica.maybeUnquiesce

Not sure if we'll be able to merge this, but this is to make it easier
to test out RBMutex.

###  wip: kvserver: change ReplicaMutex to RBMutex

RBMutex is biased more towards readers, so could help when there is
heavy read contention.

This usage is being changed since it appeared in a mutex profile
captured by BenchmarkParallelSysbench.

There are two notable changes that are not mechanical:
- The sync.Cond used in the replica proposal buffer was replaced with a
  channel. We can't use sync.Cond since it needs to be associated with
  a sync.Locker. and we don't have one since RBMutex does not implement
  that interface.
- The allocateIndex function of the proposal buffer sometimes needs to
  flush the buffer, which involves upgrading a shared lock to an
  exclusive lock, then downgrading it back after flushing. To support
  this, I had to make this function return the new token that can be
  used by the caller of allocateIndex to release the shared lock.

### storage: use RBMutex to protect stats

informs https://github.com/cockroachdb/cockroach/issues/142625
informs https://github.com/cockroachdb/cockroach/issues/142621
Release note: None