### PR TITLE
Revert "Merge #140979"

### DIFF
--- a/pkg/kv/kvserver/helpers_test.go
+++ b/pkg/kv/kvserver/helpers_test.go
@@ -415,7 +415,7 @@ func (r *Replica) NumPendingProposals() int64 {
 	return r.numPendingProposalsRLocked()
 }
 
-func (r *Replica) LastUpdateTimes() map[roachpb.ReplicaID]lastReplicaUpdateTime {
+func (r *Replica) LastUpdateTimes() map[roachpb.ReplicaID]time.Time {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 	return maps.Clone(r.mu.lastUpdateTimes)

--- a/pkg/kv/kvserver/raft_log_queue_test.go
+++ b/pkg/kv/kvserver/raft_log_queue_test.go
@@ -370,10 +370,10 @@ func TestUpdateRaftStatusActivity(t *testing.T) {
 		{
 			replicas: []roachpb.ReplicaDescriptor{{ReplicaID: 1}, {ReplicaID: 2}, {ReplicaID: 3}},
 			prs:      []tracker.Progress{{RecentActive: false}, {RecentActive: true}},
-			lastUpdate: map[roachpb.ReplicaID]lastReplicaUpdateTime{
-				1: {update: now.Add(-1 * inactivityThreashold / 2)},
-				2: {update: now.Add(-1 - inactivityThreashold)},
-				3: {update: now},
+			lastUpdate: map[roachpb.ReplicaID]time.Time{
+				1: now.Add(-1 * inactivityThreashold / 2),
+				2: now.Add(-1 - inactivityThreashold),
+				3: now,
 			},
 			now: now,
 

--- a/pkg/kv/kvserver/replica_proposal_quota.go
+++ b/pkg/kv/kvserver/replica_proposal_quota.go
@@ -147,7 +147,7 @@ func (r *Replica) updateProposalQuotaRaftMuLocked(
 	shouldInitQuotaPool := false
 	if r.mu.leaderID != lastLeaderID {
 		if r.replicaID == r.mu.leaderID {
-			r.mu.lastUpdateTimes = make(map[roachpb.ReplicaID]lastReplicaUpdateTime)
+			r.mu.lastUpdateTimes = make(map[roachpb.ReplicaID]time.Time)
 			r.mu.lastUpdateTimes.updateOnBecomeLeader(r.shMu.state.Desc.Replicas().Descriptors(), now)
 			r.mu.replicaFlowControlIntegration.onBecameLeader(ctx)
 			r.mu.lastProposalAtTicks = r.mu.ticks // delay imminent quiescence

--- a/pkg/kv/kvserver/replica_raft_test.go
+++ b/pkg/kv/kvserver/replica_raft_test.go
@@ -51,24 +51,12 @@ func TestLastUpdateTimesMap(t *testing.T) {
 	t2 := t1.Add(time.Second)
 	m.update(3, t1)
 	m.update(1, t2)
-
-	upd := func(t time.Time, unreachable bool) lastReplicaUpdateTime {
-		return lastReplicaUpdateTime{update: t, unreachable: unreachable}
-	}
-	assert.EqualValues(t, map[roachpb.ReplicaID]lastReplicaUpdateTime{
-		1: upd(t2, false),
-		3: upd(t1, false),
-	}, m)
-
+	assert.EqualValues(t, map[roachpb.ReplicaID]time.Time{1: t2, 3: t1}, m)
 	descs := []roachpb.ReplicaDescriptor{{ReplicaID: 1}, {ReplicaID: 2}, {ReplicaID: 3}, {ReplicaID: 4}}
+
 	t3 := t2.Add(time.Second)
 	m.updateOnBecomeLeader(descs, t3)
-	assert.EqualValues(t, map[roachpb.ReplicaID]lastReplicaUpdateTime{
-		1: upd(t3, false),
-		2: upd(t3, false),
-		3: upd(t3, false),
-		4: upd(t3, false),
-	}, m)
+	assert.EqualValues(t, map[roachpb.ReplicaID]time.Time{1: t3, 2: t3, 3: t3, 4: t3}, m)
 
 	t4 := t3.Add(time.Second)
 	descs = append(descs, []roachpb.ReplicaDescriptor{{ReplicaID: 5}, {ReplicaID: 6}}...)
@@ -82,20 +70,13 @@ func TestLastUpdateTimesMap(t *testing.T) {
 		7: {State: tracker.StateReplicate}, // ignored, not in descs
 	}
 	m.updateOnUnquiesce(descs, prs, t4)
-	assert.EqualValues(t, map[roachpb.ReplicaID]lastReplicaUpdateTime{
-		1: upd(t4, false),
-		2: upd(t3, false),
-		3: upd(t3, false),
-		4: upd(t3, false),
-		6: upd(t4, false),
+	assert.EqualValues(t, map[roachpb.ReplicaID]time.Time{
+		1: t4,
+		2: t3,
+		3: t3,
+		4: t3,
+		6: t4,
 	}, m)
-
-	assert.True(t, m.updateUnreachable(4))
-	assert.False(t, m.updateUnreachable(4))
-	assert.Equal(t, upd(t3, true), m[4])
-	m.update(4, t4)
-	assert.Equal(t, upd(t4, false), m[4])
-	assert.True(t, m.updateUnreachable(4))
 }
 
 func Test_handleRaftReadyStats_SafeFormat(t *testing.T) {


### PR DESCRIPTION
This commit reverts #140979. Need to move this functionality to raft, or at least the else-case of the following condition requires extra scrutiny:

```golang
if storeClockTimestamp.ToTimestamp().LessEq(curExp) {} else {}
```

Store liveness can return zero expiration timestamp, which triggers the else case. We don't want to always report this as an unreachable node, especially in cases when the store liveness hasn't been given the opportunity to connect just yet.

Epic: none
Release note: none