### PR TITLE
kvserver: document rangedel problems in snapshot receive path

### DIFF
--- a/pkg/ccl/storageccl/engineccl/shared_storage.go
+++ b/pkg/ccl/storageccl/engineccl/shared_storage.go
@@ -36,6 +36,12 @@ func configureForSharedStorage(opts *pebble.Options, remoteStorage remote.Storag
 // over a range's user key span; IterateReplicaKeySpans must be called to
 // iterate over the other key spans.
 //
+// If this method returns pebble.ErrInvalidSkipSharedIteration, only the
+// shared external visitors may have been invoked. In particular, no
+// local data has been visited yet.
+// The above contract appears true for the current implementation of this
+// method, but is likely untested.
+//
 // Must use a reader with consistent iterators.
 func iterateReplicaKeySpansShared(
 	ctx context.Context,

--- a/pkg/kv/kvserver/kv_snapshot_strategy.go
+++ b/pkg/kv/kvserver/kv_snapshot_strategy.go
@@ -120,7 +120,35 @@ func (kvSS *kvBatchSnapshotStrategy) Receive(
 
 	// TODO(aaditya): Remove once we support flushableIngests for shared and
 	// external files in the engine.
+
+	// TODO(tbg): skipClearForMVCCSpan should equal `doExcise`, but there appear
+	// to be bugs in this code as demonstrated by
+	// TestRaftSnapshotsWithMVCCRangeKeysEverywhere failing with the proposed
+	// change:
+	//
+	// * panic: failed to put range key in sst: pebble: spans must be added in order: /Local/RangeID/75/r":a"/0,0 > /Local/RangeID/75/r""/0,0
+	// ^- we added the ":a" key first, now we're trying to add the r"" key.
+	//
+	// My basic understanding of this failure mode is:
+	// - first, a range del covering the range-local replicated key span `/Range/75/{r-s}` is added in (msstw.initSST)
+	// - the fragmenter's start key is now `/Range/75/r`.
+	// - when the `/Range/75/r/{:a-:z}` rangedel, is handled, it enters through `msstw.PutRangeKey`
+	//    - since  `skipClearForMVCCSpan` is set, this does not update the fragmenter.
+	//    - the range deletion is added to the current SST.
+	// - when the first key >= `/Range/75/r` is added, `msstw.finalizeSST` flushes
+	//   the fragmenter to the current SST.
+	// - we hit the above error, since the SST already contains the rangedel
+	//   starting at `/Range/75/r:a` and we're not attempting to add a rangedel
+	//   `/Range/75/r` with smaller start key.
+	//
+	// The crucial problem is skipping the fragmenter. This seems to have to do with
+	// wanting to allow callers to use `skipClearForMVCCSpan`, but this is going to
+	// be dead code.
+	//
+	// Another note: CI passes when this is unconditionally set to `false`,
+	// indicating that we have poor coverage of the shared and external code paths.
 	skipClearForMVCCSpan := doExcise && (header.SharedReplicate || header.ExternalReplicate)
+
 	// The last key range is the user key span.
 	localRanges := keyRanges[:len(keyRanges)-1]
 	mvccRange := keyRanges[len(keyRanges)-1]

--- a/pkg/kv/kvserver/rditer/replica_data_iter.go
+++ b/pkg/kv/kvserver/rditer/replica_data_iter.go
@@ -448,6 +448,9 @@ func IterateReplicaKeySpans(
 // IterateReplicaKeySpansShared is a shared-replicate version of
 // IterateReplicaKeySpans. See definitions of this method for how it is
 // implemented.
+//
+// The impl of this method along with a comment is in
+// engineccl/shared_storage.go.
 var IterateReplicaKeySpansShared func(
 	ctx context.Context,
 	desc *roachpb.RangeDescriptor,


### PR DESCRIPTION
We ~always add a rangedel to the MVCC span even when excising.
Trying to change that (we should add the rangedel only when
not excising, but in practice we ~always excise), I hit upon
issues that stem from bypassing the range key fragmenter.

This commit documents the issue. I think I have a fix for
it, but I'm trying to keep the PRs manageable. The fix
will revolve around removing the case which motivated
the fragmenter bypass in the first place, namely the
method `addClearForMVCCSpan`, which is connected to
transitioning out of the excise path.

Extracted from #142476.

Epic: CRDB-46488
Release note: None
