### PR TITLE
workload: fix max ops

### DIFF
--- a/pkg/workload/cli/run.go
+++ b/pkg/workload/cli/run.go
@@ -553,8 +553,8 @@ func runRun(gen workload.Generator, urls []string, dbName string) error {
 	workersCtx, cancelWorkers := context.WithCancel(ctx)
 	defer cancelWorkers()
 
-	// implements the --duration and --ramp timeouts
-	if *duration+*ramp > 0 {
+	// implement the --duration timeout
+	if *duration > 0 {
 		workersCtx, cancelWorkers = context.WithTimeout(workersCtx, *duration+*ramp)
 	}
 


### PR DESCRIPTION
This change fixes a bug introduced by #142258, that removed the done check when waiting for the worker / op functions to finish. This is fixed by cancelling the context when all operations / workers have finished as it was previously.

Fixes: #142553

Epic: None
Release note: None