### PR TITLE
raft: StateProbe on store liveness disconnects

### DIFF
--- a/pkg/raft/testdata/lagging_commit_no_store_liveness_support.txt
+++ b/pkg/raft/testdata/lagging_commit_no_store_liveness_support.txt
@@ -153,13 +153,19 @@ Ready MustSync=true:
 HardState Term:1 Vote:1 Commit:13 Lead:1 LeadEpoch:2
 Messages:
 1->3 MsgFortifyLeader Term:1 Log:0/0
-1->3 MsgApp Term:1 Log:1/13 Commit:13
+1->3 MsgApp Term:1 Log:1/11 Commit:13 Entries:[
+  1/12 EntryNormal "data1"
+  1/13 EntryNormal "data2"
+]
 
 stabilize
 ----
 > 3 receiving messages
   1->3 MsgFortifyLeader Term:1 Log:0/0
-  1->3 MsgApp Term:1 Log:1/13 Commit:13
+  1->3 MsgApp Term:1 Log:1/11 Commit:13 Entries:[
+    1/12 EntryNormal "data1"
+    1/13 EntryNormal "data2"
+  ]
 > 3 handling Ready
   Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:13 Lead:1 LeadEpoch:2

--- a/pkg/raft/testdata/refortification_basic.txt
+++ b/pkg/raft/testdata/refortification_basic.txt
@@ -178,15 +178,19 @@ stabilize
   Ready MustSync=false:
   Messages:
   1->3 MsgFortifyLeader Term:1 Log:0/0
+  1->3 MsgApp Term:1 Log:1/3 Commit:3
 > 3 receiving messages
   1->3 MsgFortifyLeader Term:1 Log:0/0
+  1->3 MsgApp Term:1 Log:1/3 Commit:3
 > 3 handling Ready
   Ready MustSync=true:
   HardState Term:1 Vote:1 Commit:3 Lead:1 LeadEpoch:3
   Messages:
   3->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:3
+  3->1 MsgAppResp Term:1 Log:0/3 Commit:3
 > 1 receiving messages
   3->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:3
+  3->1 MsgAppResp Term:1 Log:0/3 Commit:3
 
 # If the follower supports the leader at an older epoch, the leader will try
 # to refortify it on the next heartbeat timeout.


### PR DESCRIPTION
This makes a replication flow transition from `StateReplicate` to `StateProbe` if the leader loses store liveness support of the peer's store.

Replaces #140979
Epic: none
Release note: none