### PR TITLE
Revert "storeliveness,kvserver: optimize store liveness sleep"

### DIFF
--- a/pkg/kv/kvserver/replica_metrics.go
+++ b/pkg/kv/kvserver/replica_metrics.go
@@ -76,9 +76,9 @@ func (r *Replica) Metrics(
 	vitalityMap livenesspb.NodeVitalityMap,
 	clusterNodes int,
 ) ReplicaMetrics {
-	r.store.quiescence.Lock()
-	_, ticking := r.store.quiescence.unquiescedOrAwake[r.RangeID]
-	r.store.quiescence.Unlock()
+	r.store.unquiescedOrAwakeReplicas.Lock()
+	_, ticking := r.store.unquiescedOrAwakeReplicas.m[r.RangeID]
+	r.store.unquiescedOrAwakeReplicas.Unlock()
 
 	latchMetrics := r.concMgr.LatchMetrics()
 	lockTableMetrics := r.concMgr.LockTableMetrics()

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -681,7 +681,7 @@ func (r *Replica) stepRaftGroupRaftMuLocked(req *kvserverpb.RaftMessageRequest) 
 			wakeLeader := hasLeader && !fromLeader
 			r.maybeUnquiesceLocked(wakeLeader, false /* mayCampaign */)
 		}
-		r.maybeWakeUpReplicaMuLocked()
+		r.maybeWakeUpRMuLocked()
 
 		{
 			// Update the lastUpdateTimes map, unless configured not to by a testing

--- a/pkg/kv/kvserver/replica_raft_quiesce.go
+++ b/pkg/kv/kvserver/replica_raft_quiesce.go
@@ -39,9 +39,9 @@ func (r *Replica) quiesceLocked(ctx context.Context, lagging laggingReplicaSet) 
 		}
 		r.mu.quiescent = true
 		r.mu.laggingFollowersOnQuiesce = lagging
-		r.store.quiescence.Lock()
-		delete(r.store.quiescence.unquiescedOrAwake, r.RangeID)
-		r.store.quiescence.Unlock()
+		r.store.unquiescedOrAwakeReplicas.Lock()
+		delete(r.store.unquiescedOrAwakeReplicas.m, r.RangeID)
+		r.store.unquiescedOrAwakeReplicas.Unlock()
 	} else if log.V(4) {
 		log.Infof(ctx, "r%d already quiesced", r.RangeID)
 	}
@@ -82,9 +82,9 @@ func (r *Replica) maybeUnquiesceLocked(wakeLeader, mayCampaign bool) bool {
 	}
 	r.mu.quiescent = false
 	r.mu.laggingFollowersOnQuiesce = nil
-	r.store.quiescence.Lock()
-	r.store.quiescence.unquiescedOrAwake[r.RangeID] = struct{}{}
-	r.store.quiescence.Unlock()
+	r.store.unquiescedOrAwakeReplicas.Lock()
+	r.store.unquiescedOrAwakeReplicas.m[r.RangeID] = struct{}{}
+	r.store.unquiescedOrAwakeReplicas.Unlock()
 
 	st := r.raftSparseStatusRLocked()
 	if st.RaftState == raftpb.StateLeader {

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -1084,19 +1084,10 @@ type Store struct {
 		replicaPlaceholders map[roachpb.RangeID]*ReplicaPlaceholder
 	}
 
-	// quiescence stores quiesced/asleep and unquiesced/awake replicas.
-	quiescence struct {
-		// Replica.mu > quiescence; i.e. if acquiring both mutexes, acquire
-		// Replica.mu first.
+	// The unquiesced or awake subset of replicas.
+	unquiescedOrAwakeReplicas struct {
 		syncutil.Mutex
-		// unquiescedOrAwake is the set of unquiesced or awake ranges; the Raft
-		// scheduler iterates over this set to schedule replicas for Raft ticks.
-		unquiescedOrAwake map[roachpb.RangeID]struct{}
-		// asleepByLeaderStore is a map from a store ID to the set of asleep
-		// replicas that have a leader on that store; it is used to easily locate
-		// all replicas that need to be awakened when the local store withdraws
-		// store liveness support for a remote store (the leader's store).
-		asleepByLeaderStore map[roachpb.StoreID]map[*Replica]struct{}
+		m map[roachpb.RangeID]struct{}
 	}
 
 	// The subset of replicas with active rangefeeds.
@@ -1618,10 +1609,9 @@ func NewStore(
 	s.mu.uninitReplicas = map[roachpb.RangeID]*Replica{}
 	s.mu.Unlock()
 
-	s.quiescence.Lock()
-	s.quiescence.unquiescedOrAwake = map[roachpb.RangeID]struct{}{}
-	s.quiescence.asleepByLeaderStore = map[roachpb.StoreID]map[*Replica]struct{}{}
-	s.quiescence.Unlock()
+	s.unquiescedOrAwakeReplicas.Lock()
+	s.unquiescedOrAwakeReplicas.m = map[roachpb.RangeID]struct{}{}
+	s.unquiescedOrAwakeReplicas.Unlock()
 
 	s.rangefeedReplicas.Lock()
 	s.rangefeedReplicas.m = map[roachpb.RangeID]int64{}

--- a/pkg/kv/kvserver/store_remove_replica.go
+++ b/pkg/kv/kvserver/store_remove_replica.go
@@ -132,9 +132,6 @@ func (s *Store) removeInitializedReplicaRaftMuLocked(
 				repDesc.ReplicaID, nextReplicaID)
 		}
 
-		// Remove the replica from the quiescence data structures.
-		rep.maybeRemoveAsleepReplicaFromQuiescenceStateReplicaMuLocked()
-
 		// Sanity checks passed. Mark the replica as removed before deleting data.
 		rep.mu.destroyStatus.Set(kvpb.NewRangeNotFoundError(rep.RangeID, rep.StoreID()),
 			destroyReasonRemoved)
@@ -300,9 +297,9 @@ func (s *Store) removeUninitializedReplicaRaftMuLocked(
 // store.mu must be held.
 func (s *Store) unlinkReplicaByRangeIDLocked(ctx context.Context, rangeID roachpb.RangeID) {
 	s.mu.AssertHeld()
-	s.quiescence.Lock()
-	delete(s.quiescence.unquiescedOrAwake, rangeID)
-	s.quiescence.Unlock()
+	s.unquiescedOrAwakeReplicas.Lock()
+	delete(s.unquiescedOrAwakeReplicas.m, rangeID)
+	s.unquiescedOrAwakeReplicas.Unlock()
 	delete(s.mu.uninitReplicas, rangeID)
 	s.mu.replicasByRangeID.Delete(rangeID)
 	s.unregisterLeaseholderByID(ctx, rangeID)

--- a/pkg/kv/kvserver/storeliveness/fabric.go
+++ b/pkg/kv/kvserver/storeliveness/fabric.go
@@ -67,7 +67,7 @@ type Fabric interface {
 	// liveness). The replica may need to help elect a new leader.
 	//
 	// Returns the set of stores for which support was withdrawn.
-	RegisterSupportWithdrawalCallback(func(storeIDs []roachpb.StoreID))
+	RegisterSupportWithdrawalCallback(func(storeIDs map[roachpb.StoreID]struct{}))
 }
 
 // InspectFabric is an interface that exposes all in-memory support state for a

--- a/pkg/kv/kvserver/storeliveness/support_manager.go
+++ b/pkg/kv/kvserver/storeliveness/support_manager.go
@@ -49,7 +49,7 @@ type SupportManager struct {
 	receiveQueue          receiveQueue
 	storesToAdd           storesToAdd
 	minWithdrawalTS       hlc.Timestamp
-	withdrawalCallback    func([]roachpb.StoreID)
+	withdrawalCallback    func(map[roachpb.StoreID]struct{})
 	supporterStateHandler *supporterStateHandler
 	requesterStateHandler *requesterStateHandler
 	metrics               *SupportManagerMetrics
@@ -155,7 +155,7 @@ func (sm *SupportManager) SupportFrom(id slpb.StoreIdent) (slpb.Epoch, hlc.Times
 
 // RegisterSupportWithdrawalCallback implements the Fabric interface and
 // registers a callback to be invoked on each support withdrawal.
-func (sm *SupportManager) RegisterSupportWithdrawalCallback(cb func([]roachpb.StoreID)) {
+func (sm *SupportManager) RegisterSupportWithdrawalCallback(cb func(map[roachpb.StoreID]struct{})) {
 	sm.withdrawalCallback = cb
 }
 

--- a/pkg/kv/kvserver/storeliveness/support_manager_test.go
+++ b/pkg/kv/kvserver/storeliveness/support_manager_test.go
@@ -124,9 +124,10 @@ func TestSupportManagerProvidesSupport(t *testing.T) {
 	clock := hlc.NewClockForTesting(manual)
 	sender := &testMessageSender{}
 	sm := NewSupportManager(store, engine, options, settings, stopper, clock, sender, nil)
-	cb := func(supportWithdrawn []roachpb.StoreID) {
+	cb := func(supportWithdrawn map[roachpb.StoreID]struct{}) {
 		require.Equal(t, 1, len(supportWithdrawn))
-		require.Equal(t, roachpb.StoreID(2), supportWithdrawn[0])
+		_, ok := supportWithdrawn[roachpb.StoreID(2)]
+		require.True(t, ok)
 	}
 	sm.RegisterSupportWithdrawalCallback(cb)
 	require.NoError(t, sm.Start(ctx))


### PR DESCRIPTION
This reverts commit d7a3355114a5be55603df7aacdb0e1b9d1fdf8ce.

This optimization introduced a data race in the store liveness sleep mechanism: `supportWithdrawnCallback` was reading from the `quiescence` struct without acquiring a lock. This is a consequence of the optimization's inherent lock inversion in accessing the `quiescence.asleepByLeaderStore` map: when waking a replica up due to an incoming Raft message (or when checking to fall asleep), `Replica.mu` is already held, and `quiescence.mu` needs to be acquired; when waking a replica up due to store liveness support withdrawal, `quiescence.mu` needs to be acquired before we can even know which replcas' `Replica.mu`'s to lock. To avoid this situation, we'd need to rethink the need for `quiescence.asleepByLeaderStore` or completely reverse the lock acquisition order (i.e. always `quiescence.mu` before `Replica.mu`).

Part of: #140476

Release note: None