### PR TITLE
changefeedccl: write new span-level checkpoint during ALTER CHANGEFEED

### DIFF
--- a/pkg/ccl/changefeedccl/alter_changefeed_test.go
+++ b/pkg/ccl/changefeedccl/alter_changefeed_test.go
@@ -233,6 +233,89 @@ func TestAlterChangefeedAddTarget(t *testing.T) {
 	cdcTest(t, testFn, feedTestEnterpriseSinks, feedTestNoExternalConnection)
 }
 
+// TestAlterChangefeedAddTargetAfterInitialScan tests adding a new target
+// after the changefeed has already completed its initial scan.
+func TestAlterChangefeedAddTargetAfterInitialScan(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	testutils.RunValues(t, "initial_scan", []string{"yes", "no", "only"}, func(t *testing.T, initialScan string) {
+		testFn := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
+			sqlDB := sqlutils.MakeSQLRunner(s.DB)
+			sqlDB.Exec(t, `CREATE TABLE foo (a INT PRIMARY KEY)`)
+			sqlDB.Exec(t, `CREATE TABLE bar (a INT PRIMARY KEY, b INT)`)
+
+			testFeed := feed(t, f, `CREATE CHANGEFEED FOR foo`)
+			defer closeFeed(t, testFeed)
+
+			feed, ok := testFeed.(cdctest.EnterpriseTestFeed)
+			require.True(t, ok)
+
+			checkHighwaterAdvance := func(ts hlc.Timestamp) func() error {
+				return func() error {
+					hw, err := feed.HighWaterMark()
+					if err != nil {
+						return err
+					}
+					if hw.After(ts) {
+						return nil
+					}
+					return errors.Newf("waiting for highwater to advance past %s", ts)
+				}
+			}
+
+			// Insert and update row into new table after changefeed was already created.
+			sqlDB.Exec(t, `INSERT INTO bar VALUES(2, 2)`)
+			sqlDB.Exec(t, `UPDATE bar SET b = 9 WHERE a = 2`)
+
+			var tsStr string
+			sqlDB.QueryRow(t, `INSERT INTO foo VALUES(1) RETURNING cluster_logical_timestamp()`).Scan(&tsStr)
+			assertPayloads(t, testFeed, []string{
+				`foo: [1]->{"after": {"a": 1}}`,
+			})
+			ts := parseTimeToHLC(t, tsStr)
+			testutils.SucceedsSoon(t, checkHighwaterAdvance(ts))
+
+			sqlDB.Exec(t, `PAUSE JOB $1`, feed.JobID())
+			waitForJobState(sqlDB, t, feed.JobID(), `paused`)
+
+			sqlDB.Exec(t, fmt.Sprintf(`ALTER CHANGEFEED %d ADD bar WITH initial_scan = '%s'`, feed.JobID(), initialScan))
+
+			sqlDB.Exec(t, `RESUME JOB $1`, feed.JobID())
+			waitForJobState(sqlDB, t, feed.JobID(), `running`)
+
+			// Updates for the new table only start at the changefeed's current
+			// highwater at the time of the ALTER CHANGEFEED.
+			switch initialScan {
+			case "yes":
+				assertPayloads(t, testFeed, []string{
+					// There is no `bar: [2]->{"after": {"a": 2, "b": 2}}` message
+					// because it was inserted before the highwater.
+					`bar: [2]->{"after": {"a": 2, "b": 9}}`,
+				})
+			case "only":
+				// Strangely, when initial_scan = 'only', we don't do an initial
+				// scan unless the original changefeed was initial_scan = 'only'.
+			case "no":
+			default:
+				t.Fatalf("unknown initial scan type %q", initialScan)
+			}
+
+			sqlDB.QueryRow(t, `INSERT INTO foo VALUES(2)`)
+			assertPayloads(t, testFeed, []string{
+				`foo: [2]->{"after": {"a": 2}}`,
+			})
+
+			sqlDB.Exec(t, `UPDATE bar SET b = 25 WHERE a = 2`)
+			assertPayloads(t, testFeed, []string{
+				`bar: [2]->{"after": {"a": 2, "b": 25}}`,
+			})
+		}
+
+		cdcTest(t, testFn, feedTestEnterpriseSinks, feedTestNoExternalConnection)
+	})
+}
+
 func TestAlterChangefeedAddTargetFamily(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)

--- a/pkg/ccl/changefeedccl/alter_changefeed_test.go
+++ b/pkg/ccl/changefeedccl/alter_changefeed_test.go
@@ -1524,7 +1524,7 @@ func TestAlterChangefeedInitialScan(t *testing.T) {
 			sqlDB.Exec(t, fmt.Sprintf(`RESUME JOB %d`, feed.JobID()))
 			waitForJobState(sqlDB, t, feed.JobID(), `running`)
 
-			expectPayloads := (initialScanOption == "initial_scan = 'yes'" || initialScanOption == "initial_scan")
+			expectPayloads := initialScanOption == "initial_scan = 'yes'" || initialScanOption == "initial_scan"
 			if expectPayloads {
 				assertPayloads(t, testFeed, []string{
 					`bar: [1]->{"after": {"a": 1}}`,
@@ -1543,8 +1543,10 @@ func TestAlterChangefeedInitialScan(t *testing.T) {
 	for _, initialScanOpt := range []string{
 		"initial_scan = 'yes'",
 		"initial_scan = 'no'",
+		"initial_scan = 'only'",
 		"initial_scan",
-		"no_initial_scan"} {
+		"no_initial_scan",
+	} {
 		cdcTest(t, testFn(initialScanOpt), feedTestForceSink("kafka"), feedTestNoExternalConnection)
 	}
 }

--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -8,7 +8,9 @@ package changefeedccl
 import (
 	"context"
 	"fmt"
+	"iter"
 	"math/rand"
+	"slices"
 	"sync"
 	"time"
 
@@ -929,15 +931,9 @@ func (ca *changeAggregator) flushFrontier() error {
 	}
 
 	// Iterate frontier spans and build a list of spans to emit.
-	var batch jobspb.ResolvedSpans
-	ca.frontier.EntriesWithBoundaryType(func(s roachpb.Span, ts hlc.Timestamp, boundaryType jobspb.ResolvedSpan_BoundaryType) (done span.OpResult) {
-		batch.ResolvedSpans = append(batch.ResolvedSpans, jobspb.ResolvedSpan{
-			Span:         s,
-			Timestamp:    ts,
-			BoundaryType: boundaryType,
-		})
-		return span.ContinueMatch
-	})
+	batch := jobspb.ResolvedSpans{
+		ResolvedSpans: slices.Collect(ca.frontier.All()),
+	}
 	return ca.emitResolved(batch)
 }
 
@@ -1103,6 +1099,18 @@ func (cs *cachedState) SetCheckpoint(checkpoint *jobspb.TimestampSpansMap) {
 	// copy of the checkpoint is only used in-memory on a coordinator node that
 	// knows about the new field.
 	cs.progress.Details.(*jobspb.Progress_Changefeed).Changefeed.SpanLevelCheckpoint = checkpoint
+}
+
+// AggregatorFrontierSpans returns an iterator over the spans in the aggregator
+// frontier collected during shutdown.
+func (cs *cachedState) AggregatorFrontierSpans() iter.Seq2[roachpb.Span, hlc.Timestamp] {
+	return func(yield func(roachpb.Span, hlc.Timestamp) bool) {
+		for _, entry := range cs.aggregatorFrontier {
+			if !yield(entry.Span, entry.Timestamp) {
+				return
+			}
+		}
+	}
 }
 
 func newJobState(
@@ -1927,12 +1935,17 @@ func frontierIsBehind(frontier hlc.Timestamp, sv *settings.Values) bool {
 	return timeutil.Since(frontier.GoTime()) > slownessThreshold(sv)
 }
 
+type behindSpanFrontier interface {
+	Frontier() hlc.Timestamp
+	PeekFrontierSpan() roachpb.Span
+}
+
 // Potentially log the most behind span in the frontier for debugging if the
 // frontier is behind
 func maybeLogBehindSpan(
 	ctx context.Context,
 	description string,
-	frontier span.Frontier,
+	frontier behindSpanFrontier,
 	frontierChanged bool,
 	sv *settings.Values,
 ) {

--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -610,7 +610,7 @@ func (ca *changeAggregator) setupSpansAndFrontier() (spans []roachpb.Span, err e
 	// can ignore it from this point on.
 	if !ca.spec.Checkpoint.IsEmpty() {
 		if ca.spec.SpanLevelCheckpoint != nil {
-			return nil, errors.New("both legacy and current checkpoint set on change aggregator spec")
+			return nil, errors.AssertionFailedf("both legacy and current checkpoint set on change aggregator spec")
 		}
 
 		// This conversion undoes an unnecessary conversion when the spec

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -1516,8 +1516,8 @@ func reconcileJobStateWithLocalState(
 		return err
 	}
 	// Advance frontier based on the information received from the aggregators.
-	for _, s := range localState.aggregatorFrontier {
-		_, err := sf.Forward(s.Span, s.Timestamp)
+	for sp, ts := range localState.AggregatorFrontierSpans() {
+		_, err := sf.Forward(sp, ts)
 		if err != nil {
 			return err
 		}
@@ -1526,11 +1526,7 @@ func reconcileJobStateWithLocalState(
 	maxBytes := changefeedbase.SpanCheckpointMaxBytes.Get(&execCfg.Settings.SV)
 	checkpoint := checkpoint.Make(
 		sf.Frontier(),
-		func(forEachSpan span.Operation) {
-			for _, fs := range localState.aggregatorFrontier {
-				forEachSpan(fs.Span, fs.Timestamp)
-			}
-		},
+		localState.AggregatorFrontierSpans(),
 		maxBytes,
 		nil, /* metrics */
 	)

--- a/pkg/ccl/changefeedccl/changefeedbase/options.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/options.go
@@ -1159,6 +1159,11 @@ func (s StatementOptions) SetDefaultEnvelope(t EnvelopeType) {
 	}
 }
 
+// Unset unsets an option.
+func (s StatementOptions) Unset(opt string) {
+	delete(s.m, opt)
+}
+
 // GetOnError validates and returns the desired behavior when a non-retriable error is encountered.
 func (s StatementOptions) GetOnError() (OnErrorType, error) {
 	v, err := s.getEnumValue(OptOnError)

--- a/pkg/ccl/changefeedccl/checkpoint/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/checkpoint/BUILD.bazel
@@ -15,7 +15,6 @@ go_library(
         "//pkg/util/hlc",
         "//pkg/util/metric",
         "//pkg/util/metric/aggmetric",
-        "//pkg/util/span",
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",
     ],

--- a/pkg/ccl/changefeedccl/resolvedspan/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/resolvedspan/BUILD.bazel
@@ -32,7 +32,6 @@ go_test(
         "//pkg/util/hlc",
         "//pkg/util/leaktest",
         "//pkg/util/log",
-        "//pkg/util/span",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_stretchr_testify//require",
     ],


### PR DESCRIPTION
This patch starts writing the new span-level checkpoint during ALTER
CHANGEFEED on 25.2+ clusters.

Fixes #140509

Release note: None