### PR TITLE
blobfixture: make concurrently delete objects

### DIFF
--- a/pkg/roachprod/blobfixture/BUILD.bazel
+++ b/pkg/roachprod/blobfixture/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
         "//pkg/cloud",
         "//pkg/roachprod/logger",
         "//pkg/settings/cluster",
+        "//pkg/util/ctxgroup",
         "//pkg/util/ioctx",
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",


### PR DESCRIPTION
Previously, the blobfixture GC would delete objects one at a time. Now, it uses the producer+consumer pattern to delete ten blobs concurrently.

Release note: none
Fixes: #142646