### PR TITLE
builtins: move test to `heavy` pool when run under `race`

### DIFF
--- a/pkg/sql/sem/builtins/BUILD.bazel
+++ b/pkg/sql/sem/builtins/BUILD.bazel
@@ -179,7 +179,7 @@ go_test(
     data = glob(["testdata/**"]),
     embed = [":builtins"],
     exec_properties = select({
-        "//build/toolchains:is_heavy": {"test.Pool": "large"},
+        "//build/toolchains:is_heavy": {"test.Pool": "heavy"},
         "//conditions:default": {"test.Pool": "default"},
     }),
     deps = [


### PR DESCRIPTION
We've seen this OOM.

Epic: none
Release note: None