### PR TITLE
release-25.1: Revert "raft: match MsgFortifyLeaderResp to MsgHeartbeatResp"

### DIFF
--- a/pkg/raft/raft.go
+++ b/pkg/raft/raft.go
@@ -2099,15 +2099,8 @@ func stepLeader(r *raft, m pb.Message) error {
 		}
 
 	case pb.MsgFortifyLeaderResp:
+		pr.RecentActive = true
 		r.handleFortifyResp(m)
-		// We do the same as we do when receiving a MsgHeartbeatResp.
-		// NB: We ignore self-addressed messages as we don't send MsgApp to
-		// ourselves.
-		if m.From != r.id {
-			pr.RecentActive = true
-			pr.MsgAppProbesPaused = false
-			r.maybeSendAppend(m.From)
-		}
 
 	case pb.MsgHeartbeatResp:
 		pr.RecentActive = true

--- a/pkg/raft/testdata/async_storage_writes.txt
+++ b/pkg/raft/testdata/async_storage_writes.txt
@@ -170,19 +170,15 @@ stabilize
   CommittedEntries:
   1/11 EntryNormal ""
   Messages:
-  1->2 MsgApp Term:1 Log:1/10 Commit:10 Entries:[1/11 EntryNormal ""]
   1->2 MsgApp Term:1 Log:1/11 Commit:11
-  1->3 MsgApp Term:1 Log:1/10 Commit:11 Entries:[1/11 EntryNormal ""]
   1->3 MsgApp Term:1 Log:1/11 Commit:11
   1->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:11 Vote:1 Lead:1 LeadEpoch:1
   1->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[1/11 EntryNormal ""] Responses:[
     ApplyThread->1 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/11 EntryNormal ""]
   ]
 > 2 receiving messages
-  1->2 MsgApp Term:1 Log:1/10 Commit:10 Entries:[1/11 EntryNormal ""]
   1->2 MsgApp Term:1 Log:1/11 Commit:11
 > 3 receiving messages
-  1->3 MsgApp Term:1 Log:1/10 Commit:11 Entries:[1/11 EntryNormal ""]
   1->3 MsgApp Term:1 Log:1/11 Commit:11
 > 1 processing append thread
   Processing:
@@ -200,7 +196,6 @@ stabilize
   1/11 EntryNormal ""
   Messages:
   2->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:11 Vote:1 Lead:1 LeadEpoch:1 Responses:[
-    2->1 MsgAppResp Term:1 Log:0/11 Commit:10
     2->1 MsgAppResp Term:1 Log:0/11 Commit:11
   ]
   2->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[1/11 EntryNormal ""] Responses:[
@@ -214,7 +209,6 @@ stabilize
   Messages:
   3->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:11 Vote:1 Lead:1 LeadEpoch:1 Responses:[
     3->1 MsgAppResp Term:1 Log:0/11 Commit:11
-    3->1 MsgAppResp Term:1 Log:0/11 Commit:11
   ]
   3->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[1/11 EntryNormal ""] Responses:[
     ApplyThread->3 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/11 EntryNormal ""]
@@ -225,13 +219,11 @@ stabilize
   Processing:
   2->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:11 Vote:1 Lead:1 LeadEpoch:1
   Responses:
-  2->1 MsgAppResp Term:1 Log:0/11 Commit:10
   2->1 MsgAppResp Term:1 Log:0/11 Commit:11
 > 3 processing append thread
   Processing:
   3->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:11 Vote:1 Lead:1 LeadEpoch:1
   Responses:
-  3->1 MsgAppResp Term:1 Log:0/11 Commit:11
   3->1 MsgAppResp Term:1 Log:0/11 Commit:11
 > 2 processing apply thread
   Processing:
@@ -244,9 +236,7 @@ stabilize
   Responses:
   ApplyThread->3 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/11 EntryNormal ""]
 > 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/11 Commit:10
   2->1 MsgAppResp Term:1 Log:0/11 Commit:11
-  3->1 MsgAppResp Term:1 Log:0/11 Commit:11
   3->1 MsgAppResp Term:1 Log:0/11 Commit:11
 > 2 receiving messages
   ApplyThread->2 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/11 EntryNormal ""]

--- a/pkg/raft/testdata/campaign.txt
+++ b/pkg/raft/testdata/campaign.txt
@@ -102,15 +102,11 @@ stabilize
   CommittedEntries:
   1/3 EntryNormal ""
   Messages:
-  1->2 MsgApp Term:1 Log:1/2 Commit:2 Entries:[1/3 EntryNormal ""]
   1->2 MsgApp Term:1 Log:1/3 Commit:3
-  1->3 MsgApp Term:1 Log:1/2 Commit:3 Entries:[1/3 EntryNormal ""]
   1->3 MsgApp Term:1 Log:1/3 Commit:3
 > 2 receiving messages
-  1->2 MsgApp Term:1 Log:1/2 Commit:2 Entries:[1/3 EntryNormal ""]
   1->2 MsgApp Term:1 Log:1/3 Commit:3
 > 3 receiving messages
-  1->3 MsgApp Term:1 Log:1/2 Commit:3 Entries:[1/3 EntryNormal ""]
   1->3 MsgApp Term:1 Log:1/3 Commit:3
 > 2 handling Ready
   Ready MustSync=true:
@@ -118,7 +114,6 @@ stabilize
   CommittedEntries:
   1/3 EntryNormal ""
   Messages:
-  2->1 MsgAppResp Term:1 Log:0/3 Commit:2
   2->1 MsgAppResp Term:1 Log:0/3 Commit:3
 > 3 handling Ready
   Ready MustSync=true:
@@ -127,9 +122,6 @@ stabilize
   1/3 EntryNormal ""
   Messages:
   3->1 MsgAppResp Term:1 Log:0/3 Commit:3
-  3->1 MsgAppResp Term:1 Log:0/3 Commit:3
 > 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/3 Commit:2
   2->1 MsgAppResp Term:1 Log:0/3 Commit:3
-  3->1 MsgAppResp Term:1 Log:0/3 Commit:3
   3->1 MsgAppResp Term:1 Log:0/3 Commit:3

--- a/pkg/raft/testdata/campaign_learner_must_vote.txt
+++ b/pkg/raft/testdata/campaign_learner_must_vote.txt
@@ -128,14 +128,11 @@ stabilize 2 3
 > 2 handling Ready
   Ready MustSync=false:
   Messages:
-  2->3 MsgApp Term:2 Log:1/4 Commit:4 Entries:[2/5 EntryNormal ""]
   2->3 MsgApp Term:2 Log:1/3 Commit:4 Entries:[
     1/4 EntryConfChangeV2 v3
     2/5 EntryNormal ""
   ]
 > 3 receiving messages
-  2->3 MsgApp Term:2 Log:1/4 Commit:4 Entries:[2/5 EntryNormal ""]
-  DEBUG 3 [logterm: 0, index: 4] rejected MsgApp [logterm: 1, index: 4] from 2
   2->3 MsgApp Term:2 Log:1/3 Commit:4 Entries:[
     1/4 EntryConfChangeV2 v3
     2/5 EntryNormal ""
@@ -149,12 +146,9 @@ stabilize 2 3
   CommittedEntries:
   1/4 EntryConfChangeV2 v3
   Messages:
-  3->2 MsgAppResp Term:2 Log:1/4 Rejected (Hint: 3) Commit:3
   3->2 MsgAppResp Term:2 Log:0/5 Commit:4
   INFO 3 switched to configuration voters=(1 2 3)
 > 2 receiving messages
-  3->2 MsgAppResp Term:2 Log:1/4 Rejected (Hint: 3) Commit:3
-  DEBUG 2 received MsgAppResp(rejected, hint: (index 3, term 1)) from 3 for index 4
   3->2 MsgAppResp Term:2 Log:0/5 Commit:4
 > 2 handling Ready
   Ready MustSync=true:

--- a/pkg/raft/testdata/confchange_fortification_safety.txt
+++ b/pkg/raft/testdata/confchange_fortification_safety.txt
@@ -166,21 +166,12 @@ stabilize 1 4
 > 1 handling Ready
   Ready MustSync=false:
   Messages:
-  1->4 MsgApp Term:1 Log:1/3 Commit:4 Entries:[
-    1/4 EntryConfChangeV2 v4
-    1/5 EntryNormal ""
-  ]
   1->4 MsgApp Term:1 Log:1/2 Commit:4 Entries:[
     1/3 EntryNormal ""
     1/4 EntryConfChangeV2 v4
     1/5 EntryNormal ""
   ]
 > 4 receiving messages
-  1->4 MsgApp Term:1 Log:1/3 Commit:4 Entries:[
-    1/4 EntryConfChangeV2 v4
-    1/5 EntryNormal ""
-  ]
-  DEBUG 4 [logterm: 0, index: 3] rejected MsgApp [logterm: 1, index: 3] from 1
   1->4 MsgApp Term:1 Log:1/2 Commit:4 Entries:[
     1/3 EntryNormal ""
     1/4 EntryConfChangeV2 v4
@@ -197,12 +188,9 @@ stabilize 1 4
   1/3 EntryNormal ""
   1/4 EntryConfChangeV2 v4
   Messages:
-  4->1 MsgAppResp Term:1 Log:1/3 Rejected (Hint: 2) Commit:2
   4->1 MsgAppResp Term:1 Log:0/5 Commit:4
   INFO 4 switched to configuration voters=(1 2 3 4)
 > 1 receiving messages
-  4->1 MsgAppResp Term:1 Log:1/3 Rejected (Hint: 2) Commit:2
-  DEBUG 1 received MsgAppResp(rejected, hint: (index 2, term 1)) from 4 for index 3
   4->1 MsgAppResp Term:1 Log:0/5 Commit:4
 
 store-liveness

--- a/pkg/raft/testdata/confchange_v1_add_single.txt
+++ b/pkg/raft/testdata/confchange_v1_add_single.txt
@@ -83,12 +83,9 @@ stabilize
 > 1 handling Ready
   Ready MustSync=false:
   Messages:
-  1->2 MsgApp Term:1 Log:1/3 Commit:4 Entries:[1/4 EntryConfChange v2]
   1->2 MsgSnap Term:1 Log:0/0
     Snapshot: Index:4 Term:1 ConfState:Voters:[1 2] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
 > 2 receiving messages
-  1->2 MsgApp Term:1 Log:1/3 Commit:4 Entries:[1/4 EntryConfChange v2]
-  DEBUG 2 [logterm: 0, index: 3] rejected MsgApp [logterm: 1, index: 3] from 1
   1->2 MsgSnap Term:1 Log:0/0
     Snapshot: Index:4 Term:1 ConfState:Voters:[1 2] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
   INFO log [committed=0, applied=0, applying=0, unstable.offset=1, unstable.offsetInProgress=1, len(unstable.Entries)=0] starts to restore snapshot [index: 4, term: 1]
@@ -100,10 +97,7 @@ stabilize
   HardState Term:1 Commit:4 Lead:1 LeadEpoch:1
   Snapshot Index:4 Term:1 ConfState:Voters:[1 2] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
   Messages:
-  2->1 MsgAppResp Term:1 Log:0/3 Rejected (Hint: 0)
   2->1 MsgAppResp Term:1 Log:0/4 Commit:4
 > 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/3 Rejected (Hint: 0)
-  DEBUG 1 received MsgAppResp(rejected, hint: (index 0, term 0)) from 2 for index 3
   2->1 MsgAppResp Term:1 Log:0/4 Commit:4
   DEBUG 1 recovered from needing snapshot, resumed sending replication messages to 2 [StateSnapshot match=4 next=5 sentCommit=4 matchCommit=4 paused pendingSnap=4]

--- a/pkg/raft/testdata/confchange_v2_add_double_auto.txt
+++ b/pkg/raft/testdata/confchange_v2_add_double_auto.txt
@@ -109,18 +109,9 @@ stabilize 1 2
 > 1 handling Ready
   Ready MustSync=false:
   Messages:
-  1->2 MsgApp Term:1 Log:1/3 Commit:4 Entries:[
-    1/4 EntryConfChangeV2 v2 v3
-    1/5 EntryNormal ""
-  ]
   1->2 MsgSnap Term:1 Log:0/0
     Snapshot: Index:4 Term:1 ConfState:Voters:[1 2 3] VotersOutgoing:[1] Learners:[] LearnersNext:[] AutoLeave:true
 > 2 receiving messages
-  1->2 MsgApp Term:1 Log:1/3 Commit:4 Entries:[
-    1/4 EntryConfChangeV2 v2 v3
-    1/5 EntryNormal ""
-  ]
-  DEBUG 2 [logterm: 0, index: 3] rejected MsgApp [logterm: 1, index: 3] from 1
   1->2 MsgSnap Term:1 Log:0/0
     Snapshot: Index:4 Term:1 ConfState:Voters:[1 2 3] VotersOutgoing:[1] Learners:[] LearnersNext:[] AutoLeave:true
   INFO log [committed=0, applied=0, applying=0, unstable.offset=1, unstable.offsetInProgress=1, len(unstable.Entries)=0] starts to restore snapshot [index: 4, term: 1]
@@ -132,11 +123,8 @@ stabilize 1 2
   HardState Term:1 Commit:4 Lead:1 LeadEpoch:1
   Snapshot Index:4 Term:1 ConfState:Voters:[1 2 3] VotersOutgoing:[1] Learners:[] LearnersNext:[] AutoLeave:true
   Messages:
-  2->1 MsgAppResp Term:1 Log:0/3 Rejected (Hint: 0)
   2->1 MsgAppResp Term:1 Log:0/4 Commit:4
 > 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/3 Rejected (Hint: 0)
-  DEBUG 1 received MsgAppResp(rejected, hint: (index 0, term 0)) from 2 for index 3
   2->1 MsgAppResp Term:1 Log:0/4 Commit:4
   DEBUG 1 recovered from needing snapshot, resumed sending replication messages to 2 [StateSnapshot match=4 next=5 sentCommit=4 matchCommit=4 paused pendingSnap=4]
 > 1 handling Ready
@@ -242,20 +230,9 @@ stabilize 1 3
 > 1 handling Ready
   Ready MustSync=false:
   Messages:
-  1->3 MsgApp Term:1 Log:1/3 Commit:6 Entries:[
-    1/4 EntryConfChangeV2 v2 v3
-    1/5 EntryNormal ""
-    1/6 EntryConfChangeV2
-  ]
   1->3 MsgSnap Term:1 Log:0/0
     Snapshot: Index:6 Term:1 ConfState:Voters:[1 2 3] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
 > 3 receiving messages
-  1->3 MsgApp Term:1 Log:1/3 Commit:6 Entries:[
-    1/4 EntryConfChangeV2 v2 v3
-    1/5 EntryNormal ""
-    1/6 EntryConfChangeV2
-  ]
-  DEBUG 3 [logterm: 0, index: 3] rejected MsgApp [logterm: 1, index: 3] from 1
   1->3 MsgSnap Term:1 Log:0/0
     Snapshot: Index:6 Term:1 ConfState:Voters:[1 2 3] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
   INFO log [committed=0, applied=0, applying=0, unstable.offset=1, unstable.offsetInProgress=1, len(unstable.Entries)=0] starts to restore snapshot [index: 6, term: 1]
@@ -267,11 +244,8 @@ stabilize 1 3
   HardState Term:1 Commit:6 Lead:1 LeadEpoch:1
   Snapshot Index:6 Term:1 ConfState:Voters:[1 2 3] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
   Messages:
-  3->1 MsgAppResp Term:1 Log:0/3 Rejected (Hint: 0)
   3->1 MsgAppResp Term:1 Log:0/6 Commit:6
 > 1 receiving messages
-  3->1 MsgAppResp Term:1 Log:0/3 Rejected (Hint: 0)
-  DEBUG 1 received MsgAppResp(rejected, hint: (index 0, term 0)) from 3 for index 3
   3->1 MsgAppResp Term:1 Log:0/6 Commit:6
   DEBUG 1 recovered from needing snapshot, resumed sending replication messages to 3 [StateSnapshot match=6 next=7 sentCommit=6 matchCommit=6 paused pendingSnap=6]
 

--- a/pkg/raft/testdata/confchange_v2_add_single_auto.txt
+++ b/pkg/raft/testdata/confchange_v2_add_single_auto.txt
@@ -84,12 +84,9 @@ stabilize
 > 1 handling Ready
   Ready MustSync=false:
   Messages:
-  1->2 MsgApp Term:1 Log:1/3 Commit:4 Entries:[1/4 EntryConfChangeV2 v2]
   1->2 MsgSnap Term:1 Log:0/0
     Snapshot: Index:4 Term:1 ConfState:Voters:[1 2] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
 > 2 receiving messages
-  1->2 MsgApp Term:1 Log:1/3 Commit:4 Entries:[1/4 EntryConfChangeV2 v2]
-  DEBUG 2 [logterm: 0, index: 3] rejected MsgApp [logterm: 1, index: 3] from 1
   1->2 MsgSnap Term:1 Log:0/0
     Snapshot: Index:4 Term:1 ConfState:Voters:[1 2] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
   INFO log [committed=0, applied=0, applying=0, unstable.offset=1, unstable.offsetInProgress=1, len(unstable.Entries)=0] starts to restore snapshot [index: 4, term: 1]
@@ -101,10 +98,7 @@ stabilize
   HardState Term:1 Commit:4 Lead:1 LeadEpoch:1
   Snapshot Index:4 Term:1 ConfState:Voters:[1 2] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
   Messages:
-  2->1 MsgAppResp Term:1 Log:0/3 Rejected (Hint: 0)
   2->1 MsgAppResp Term:1 Log:0/4 Commit:4
 > 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/3 Rejected (Hint: 0)
-  DEBUG 1 received MsgAppResp(rejected, hint: (index 0, term 0)) from 2 for index 3
   2->1 MsgAppResp Term:1 Log:0/4 Commit:4
   DEBUG 1 recovered from needing snapshot, resumed sending replication messages to 2 [StateSnapshot match=4 next=5 sentCommit=4 matchCommit=4 paused pendingSnap=4]

--- a/pkg/raft/testdata/confchange_v2_add_single_explicit.txt
+++ b/pkg/raft/testdata/confchange_v2_add_single_explicit.txt
@@ -84,12 +84,9 @@ stabilize 1 2
 > 1 handling Ready
   Ready MustSync=false:
   Messages:
-  1->2 MsgApp Term:1 Log:1/3 Commit:4 Entries:[1/4 EntryConfChangeV2 v2]
   1->2 MsgSnap Term:1 Log:0/0
     Snapshot: Index:4 Term:1 ConfState:Voters:[1 2] VotersOutgoing:[1] Learners:[] LearnersNext:[] AutoLeave:false
 > 2 receiving messages
-  1->2 MsgApp Term:1 Log:1/3 Commit:4 Entries:[1/4 EntryConfChangeV2 v2]
-  DEBUG 2 [logterm: 0, index: 3] rejected MsgApp [logterm: 1, index: 3] from 1
   1->2 MsgSnap Term:1 Log:0/0
     Snapshot: Index:4 Term:1 ConfState:Voters:[1 2] VotersOutgoing:[1] Learners:[] LearnersNext:[] AutoLeave:false
   INFO log [committed=0, applied=0, applying=0, unstable.offset=1, unstable.offsetInProgress=1, len(unstable.Entries)=0] starts to restore snapshot [index: 4, term: 1]
@@ -101,11 +98,8 @@ stabilize 1 2
   HardState Term:1 Commit:4 Lead:1 LeadEpoch:1
   Snapshot Index:4 Term:1 ConfState:Voters:[1 2] VotersOutgoing:[1] Learners:[] LearnersNext:[] AutoLeave:false
   Messages:
-  2->1 MsgAppResp Term:1 Log:0/3 Rejected (Hint: 0)
   2->1 MsgAppResp Term:1 Log:0/4 Commit:4
 > 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/3 Rejected (Hint: 0)
-  DEBUG 1 received MsgAppResp(rejected, hint: (index 0, term 0)) from 2 for index 3
   2->1 MsgAppResp Term:1 Log:0/4 Commit:4
   DEBUG 1 recovered from needing snapshot, resumed sending replication messages to 2 [StateSnapshot match=4 next=5 sentCommit=4 matchCommit=4 paused pendingSnap=4]
 

--- a/pkg/raft/testdata/confchange_v2_add_single_implicit.txt
+++ b/pkg/raft/testdata/confchange_v2_add_single_implicit.txt
@@ -128,21 +128,12 @@ stabilize
   1/5 EntryConfChangeV2
   Messages:
   1->2 MsgApp Term:1 Log:1/5 Commit:5
-  1->3 MsgApp Term:1 Log:1/3 Commit:5 Entries:[
-    1/4 EntryConfChangeV2 v3
-    1/5 EntryConfChangeV2
-  ]
   1->3 MsgSnap Term:1 Log:0/0
     Snapshot: Index:4 Term:1 ConfState:Voters:[1 2 3] VotersOutgoing:[1 2] Learners:[] LearnersNext:[] AutoLeave:true
   INFO 1 switched to configuration voters=(1 2 3)
 > 2 receiving messages
   1->2 MsgApp Term:1 Log:1/5 Commit:5
 > 3 receiving messages
-  1->3 MsgApp Term:1 Log:1/3 Commit:5 Entries:[
-    1/4 EntryConfChangeV2 v3
-    1/5 EntryConfChangeV2
-  ]
-  DEBUG 3 [logterm: 0, index: 3] rejected MsgApp [logterm: 1, index: 3] from 1
   1->3 MsgSnap Term:1 Log:0/0
     Snapshot: Index:4 Term:1 ConfState:Voters:[1 2 3] VotersOutgoing:[1 2] Learners:[] LearnersNext:[] AutoLeave:true
   INFO log [committed=0, applied=0, applying=0, unstable.offset=1, unstable.offsetInProgress=1, len(unstable.Entries)=0] starts to restore snapshot [index: 4, term: 1]
@@ -162,12 +153,9 @@ stabilize
   HardState Term:1 Commit:4 Lead:1 LeadEpoch:1
   Snapshot Index:4 Term:1 ConfState:Voters:[1 2 3] VotersOutgoing:[1 2] Learners:[] LearnersNext:[] AutoLeave:true
   Messages:
-  3->1 MsgAppResp Term:1 Log:0/3 Rejected (Hint: 0)
   3->1 MsgAppResp Term:1 Log:0/4 Commit:4
 > 1 receiving messages
   2->1 MsgAppResp Term:1 Log:0/5 Commit:5
-  3->1 MsgAppResp Term:1 Log:0/3 Rejected (Hint: 0)
-  DEBUG 1 received MsgAppResp(rejected, hint: (index 0, term 0)) from 3 for index 3
   3->1 MsgAppResp Term:1 Log:0/4 Commit:4
   DEBUG 1 recovered from needing snapshot, resumed sending replication messages to 3 [StateSnapshot match=4 next=5 sentCommit=4 matchCommit=4 paused pendingSnap=4]
 > 1 handling Ready

--- a/pkg/raft/testdata/de_fortification_basic.txt
+++ b/pkg/raft/testdata/de_fortification_basic.txt
@@ -210,7 +210,6 @@ stabilize
   CommittedEntries:
   1/3 EntryNormal ""
   Messages:
-  1->2 MsgApp Term:1 Log:1/2 Commit:2 Entries:[1/3 EntryNormal ""]
   1->2 MsgApp Term:1 Log:1/3 Commit:3
   1->3 MsgApp Term:1 Log:1/3 Commit:3
   1->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:3 Vote:1 Lead:1 LeadEpoch:3
@@ -218,7 +217,6 @@ stabilize
     ApplyThread->1 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/3 EntryNormal ""]
   ]
 > 2 receiving messages
-  1->2 MsgApp Term:1 Log:1/2 Commit:2 Entries:[1/3 EntryNormal ""]
   1->2 MsgApp Term:1 Log:1/3 Commit:3
 > 3 receiving messages
   1->3 MsgApp Term:1 Log:1/3 Commit:3
@@ -238,7 +236,6 @@ stabilize
   1/3 EntryNormal ""
   Messages:
   2->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:3 Vote:1 Lead:1 LeadEpoch:3 Responses:[
-    2->1 MsgAppResp Term:1 Log:0/3 Commit:2
     2->1 MsgAppResp Term:1 Log:0/3 Commit:3
   ]
   2->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[1/3 EntryNormal ""] Responses:[
@@ -262,7 +259,6 @@ stabilize
   Processing:
   2->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:3 Vote:1 Lead:1 LeadEpoch:3
   Responses:
-  2->1 MsgAppResp Term:1 Log:0/3 Commit:2
   2->1 MsgAppResp Term:1 Log:0/3 Commit:3
 > 3 processing append thread
   Processing:
@@ -280,7 +276,6 @@ stabilize
   Responses:
   ApplyThread->3 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/3 EntryNormal ""]
 > 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/3 Commit:2
   2->1 MsgAppResp Term:1 Log:0/3 Commit:3
   3->1 MsgAppResp Term:1 Log:0/3 Commit:3
 > 2 receiving messages
@@ -546,19 +541,15 @@ stabilize
   CommittedEntries:
   2/4 EntryNormal ""
   Messages:
-  2->1 MsgApp Term:2 Log:1/3 Commit:3 Entries:[2/4 EntryNormal ""]
   2->1 MsgApp Term:2 Log:2/4 Commit:4
-  2->3 MsgApp Term:2 Log:1/3 Commit:4 Entries:[2/4 EntryNormal ""]
   2->3 MsgApp Term:2 Log:2/4 Commit:4
   2->AppendThread MsgStorageAppend Term:2 Log:0/0 Commit:4 Vote:2 Lead:2 LeadEpoch:1
   2->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[2/4 EntryNormal ""] Responses:[
     ApplyThread->2 MsgStorageApplyResp Term:0 Log:0/0 Entries:[2/4 EntryNormal ""]
   ]
 > 1 receiving messages
-  2->1 MsgApp Term:2 Log:1/3 Commit:3 Entries:[2/4 EntryNormal ""]
   2->1 MsgApp Term:2 Log:2/4 Commit:4
 > 3 receiving messages
-  2->3 MsgApp Term:2 Log:1/3 Commit:4 Entries:[2/4 EntryNormal ""]
   2->3 MsgApp Term:2 Log:2/4 Commit:4
 > 2 processing append thread
   Processing:
@@ -576,7 +567,6 @@ stabilize
   2/4 EntryNormal ""
   Messages:
   1->AppendThread MsgStorageAppend Term:2 Log:0/0 Commit:4 Vote:2 Lead:2 LeadEpoch:1 Responses:[
-    1->2 MsgAppResp Term:2 Log:0/4 Commit:3
     1->2 MsgAppResp Term:2 Log:0/4 Commit:4
   ]
   1->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[2/4 EntryNormal ""] Responses:[
@@ -590,7 +580,6 @@ stabilize
   Messages:
   3->AppendThread MsgStorageAppend Term:2 Log:0/0 Commit:4 Vote:2 Lead:2 LeadEpoch:1 Responses:[
     3->2 MsgAppResp Term:2 Log:0/4 Commit:4
-    3->2 MsgAppResp Term:2 Log:0/4 Commit:4
   ]
   3->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[2/4 EntryNormal ""] Responses:[
     ApplyThread->3 MsgStorageApplyResp Term:0 Log:0/0 Entries:[2/4 EntryNormal ""]
@@ -601,13 +590,11 @@ stabilize
   Processing:
   1->AppendThread MsgStorageAppend Term:2 Log:0/0 Commit:4 Vote:2 Lead:2 LeadEpoch:1
   Responses:
-  1->2 MsgAppResp Term:2 Log:0/4 Commit:3
   1->2 MsgAppResp Term:2 Log:0/4 Commit:4
 > 3 processing append thread
   Processing:
   3->AppendThread MsgStorageAppend Term:2 Log:0/0 Commit:4 Vote:2 Lead:2 LeadEpoch:1
   Responses:
-  3->2 MsgAppResp Term:2 Log:0/4 Commit:4
   3->2 MsgAppResp Term:2 Log:0/4 Commit:4
 > 1 processing apply thread
   Processing:
@@ -622,9 +609,7 @@ stabilize
 > 1 receiving messages
   ApplyThread->1 MsgStorageApplyResp Term:0 Log:0/0 Entries:[2/4 EntryNormal ""]
 > 2 receiving messages
-  1->2 MsgAppResp Term:2 Log:0/4 Commit:3
   1->2 MsgAppResp Term:2 Log:0/4 Commit:4
-  3->2 MsgAppResp Term:2 Log:0/4 Commit:4
   3->2 MsgAppResp Term:2 Log:0/4 Commit:4
 > 3 receiving messages
   ApplyThread->3 MsgStorageApplyResp Term:0 Log:0/0 Entries:[2/4 EntryNormal ""]
@@ -830,19 +815,15 @@ stabilize
   CommittedEntries:
   3/5 EntryNormal ""
   Messages:
-  3->1 MsgApp Term:3 Log:2/4 Commit:4 Entries:[3/5 EntryNormal ""]
   3->1 MsgApp Term:3 Log:3/5 Commit:5
-  3->2 MsgApp Term:3 Log:2/4 Commit:5 Entries:[3/5 EntryNormal ""]
   3->2 MsgApp Term:3 Log:3/5 Commit:5
   3->AppendThread MsgStorageAppend Term:3 Log:0/0 Commit:5 Vote:3 Lead:3 LeadEpoch:1
   3->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[3/5 EntryNormal ""] Responses:[
     ApplyThread->3 MsgStorageApplyResp Term:0 Log:0/0 Entries:[3/5 EntryNormal ""]
   ]
 > 1 receiving messages
-  3->1 MsgApp Term:3 Log:2/4 Commit:4 Entries:[3/5 EntryNormal ""]
   3->1 MsgApp Term:3 Log:3/5 Commit:5
 > 2 receiving messages
-  3->2 MsgApp Term:3 Log:2/4 Commit:5 Entries:[3/5 EntryNormal ""]
   3->2 MsgApp Term:3 Log:3/5 Commit:5
 > 3 processing append thread
   Processing:
@@ -860,7 +841,6 @@ stabilize
   3/5 EntryNormal ""
   Messages:
   1->AppendThread MsgStorageAppend Term:3 Log:0/0 Commit:5 Lead:3 LeadEpoch:1 Responses:[
-    1->3 MsgAppResp Term:3 Log:0/5 Commit:4
     1->3 MsgAppResp Term:3 Log:0/5 Commit:5
   ]
   1->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[3/5 EntryNormal ""] Responses:[
@@ -874,7 +854,6 @@ stabilize
   Messages:
   2->AppendThread MsgStorageAppend Term:3 Log:0/0 Commit:5 Vote:3 Lead:3 LeadEpoch:1 Responses:[
     2->3 MsgAppResp Term:3 Log:0/5 Commit:5
-    2->3 MsgAppResp Term:3 Log:0/5 Commit:5
   ]
   2->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[3/5 EntryNormal ""] Responses:[
     ApplyThread->2 MsgStorageApplyResp Term:0 Log:0/0 Entries:[3/5 EntryNormal ""]
@@ -885,13 +864,11 @@ stabilize
   Processing:
   1->AppendThread MsgStorageAppend Term:3 Log:0/0 Commit:5 Lead:3 LeadEpoch:1
   Responses:
-  1->3 MsgAppResp Term:3 Log:0/5 Commit:4
   1->3 MsgAppResp Term:3 Log:0/5 Commit:5
 > 2 processing append thread
   Processing:
   2->AppendThread MsgStorageAppend Term:3 Log:0/0 Commit:5 Vote:3 Lead:3 LeadEpoch:1
   Responses:
-  2->3 MsgAppResp Term:3 Log:0/5 Commit:5
   2->3 MsgAppResp Term:3 Log:0/5 Commit:5
 > 1 processing apply thread
   Processing:
@@ -908,9 +885,7 @@ stabilize
 > 2 receiving messages
   ApplyThread->2 MsgStorageApplyResp Term:0 Log:0/0 Entries:[3/5 EntryNormal ""]
 > 3 receiving messages
-  1->3 MsgAppResp Term:3 Log:0/5 Commit:4
   1->3 MsgAppResp Term:3 Log:0/5 Commit:5
-  2->3 MsgAppResp Term:3 Log:0/5 Commit:5
   2->3 MsgAppResp Term:3 Log:0/5 Commit:5
 
 raft-state
@@ -1118,19 +1093,15 @@ stabilize
   CommittedEntries:
   4/6 EntryNormal ""
   Messages:
-  2->1 MsgApp Term:4 Log:3/5 Commit:5 Entries:[4/6 EntryNormal ""]
   2->1 MsgApp Term:4 Log:4/6 Commit:6
-  2->3 MsgApp Term:4 Log:3/5 Commit:6 Entries:[4/6 EntryNormal ""]
   2->3 MsgApp Term:4 Log:4/6 Commit:6
   2->AppendThread MsgStorageAppend Term:4 Log:0/0 Commit:6 Vote:2 Lead:2 LeadEpoch:1
   2->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[4/6 EntryNormal ""] Responses:[
     ApplyThread->2 MsgStorageApplyResp Term:0 Log:0/0 Entries:[4/6 EntryNormal ""]
   ]
 > 1 receiving messages
-  2->1 MsgApp Term:4 Log:3/5 Commit:5 Entries:[4/6 EntryNormal ""]
   2->1 MsgApp Term:4 Log:4/6 Commit:6
 > 3 receiving messages
-  2->3 MsgApp Term:4 Log:3/5 Commit:6 Entries:[4/6 EntryNormal ""]
   2->3 MsgApp Term:4 Log:4/6 Commit:6
 > 2 processing append thread
   Processing:
@@ -1148,7 +1119,6 @@ stabilize
   4/6 EntryNormal ""
   Messages:
   1->AppendThread MsgStorageAppend Term:4 Log:0/0 Commit:6 Vote:2 Lead:2 LeadEpoch:1 Responses:[
-    1->2 MsgAppResp Term:4 Log:0/6 Commit:5
     1->2 MsgAppResp Term:4 Log:0/6 Commit:6
   ]
   1->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[4/6 EntryNormal ""] Responses:[
@@ -1162,7 +1132,6 @@ stabilize
   Messages:
   3->AppendThread MsgStorageAppend Term:4 Log:0/0 Commit:6 Vote:2 Lead:2 LeadEpoch:1 Responses:[
     3->2 MsgAppResp Term:4 Log:0/6 Commit:6
-    3->2 MsgAppResp Term:4 Log:0/6 Commit:6
   ]
   3->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[4/6 EntryNormal ""] Responses:[
     ApplyThread->3 MsgStorageApplyResp Term:0 Log:0/0 Entries:[4/6 EntryNormal ""]
@@ -1173,13 +1142,11 @@ stabilize
   Processing:
   1->AppendThread MsgStorageAppend Term:4 Log:0/0 Commit:6 Vote:2 Lead:2 LeadEpoch:1
   Responses:
-  1->2 MsgAppResp Term:4 Log:0/6 Commit:5
   1->2 MsgAppResp Term:4 Log:0/6 Commit:6
 > 3 processing append thread
   Processing:
   3->AppendThread MsgStorageAppend Term:4 Log:0/0 Commit:6 Vote:2 Lead:2 LeadEpoch:1
   Responses:
-  3->2 MsgAppResp Term:4 Log:0/6 Commit:6
   3->2 MsgAppResp Term:4 Log:0/6 Commit:6
 > 1 processing apply thread
   Processing:
@@ -1194,9 +1161,7 @@ stabilize
 > 1 receiving messages
   ApplyThread->1 MsgStorageApplyResp Term:0 Log:0/0 Entries:[4/6 EntryNormal ""]
 > 2 receiving messages
-  1->2 MsgAppResp Term:4 Log:0/6 Commit:5
   1->2 MsgAppResp Term:4 Log:0/6 Commit:6
-  3->2 MsgAppResp Term:4 Log:0/6 Commit:6
   3->2 MsgAppResp Term:4 Log:0/6 Commit:6
 > 3 receiving messages
   ApplyThread->3 MsgStorageApplyResp Term:0 Log:0/0 Entries:[4/6 EntryNormal ""]
@@ -1394,7 +1359,6 @@ stabilize
   CommittedEntries:
   5/7 EntryNormal ""
   Messages:
-  1->2 MsgApp Term:5 Log:4/6 Commit:6 Entries:[5/7 EntryNormal ""]
   1->2 MsgApp Term:5 Log:5/7 Commit:7
   1->3 MsgApp Term:5 Log:5/7 Commit:7
   1->AppendThread MsgStorageAppend Term:5 Log:0/0 Commit:7 Vote:1 Lead:1 LeadEpoch:3
@@ -1402,7 +1366,6 @@ stabilize
     ApplyThread->1 MsgStorageApplyResp Term:0 Log:0/0 Entries:[5/7 EntryNormal ""]
   ]
 > 2 receiving messages
-  1->2 MsgApp Term:5 Log:4/6 Commit:6 Entries:[5/7 EntryNormal ""]
   1->2 MsgApp Term:5 Log:5/7 Commit:7
 > 3 receiving messages
   1->3 MsgApp Term:5 Log:5/7 Commit:7
@@ -1422,7 +1385,6 @@ stabilize
   5/7 EntryNormal ""
   Messages:
   2->AppendThread MsgStorageAppend Term:5 Log:0/0 Commit:7 Vote:1 Lead:1 LeadEpoch:3 Responses:[
-    2->1 MsgAppResp Term:5 Log:0/7 Commit:6
     2->1 MsgAppResp Term:5 Log:0/7 Commit:7
   ]
   2->ApplyThread MsgStorageApply Term:0 Log:0/0 Entries:[5/7 EntryNormal ""] Responses:[
@@ -1446,7 +1408,6 @@ stabilize
   Processing:
   2->AppendThread MsgStorageAppend Term:5 Log:0/0 Commit:7 Vote:1 Lead:1 LeadEpoch:3
   Responses:
-  2->1 MsgAppResp Term:5 Log:0/7 Commit:6
   2->1 MsgAppResp Term:5 Log:0/7 Commit:7
 > 3 processing append thread
   Processing:
@@ -1464,7 +1425,6 @@ stabilize
   Responses:
   ApplyThread->3 MsgStorageApplyResp Term:0 Log:0/0 Entries:[5/7 EntryNormal ""]
 > 1 receiving messages
-  2->1 MsgAppResp Term:5 Log:0/7 Commit:6
   2->1 MsgAppResp Term:5 Log:0/7 Commit:7
   3->1 MsgAppResp Term:5 Log:0/7 Commit:7
 > 2 receiving messages

--- a/pkg/raft/testdata/de_fortification_checkquorum.txt
+++ b/pkg/raft/testdata/de_fortification_checkquorum.txt
@@ -344,10 +344,8 @@ stabilize 1 3
   CommittedEntries:
   3/13 EntryNormal ""
   Messages:
-  3->1 MsgApp Term:3 Log:2/12 Commit:12 Entries:[3/13 EntryNormal ""]
   3->1 MsgApp Term:3 Log:3/13 Commit:13
 > 1 receiving messages
-  3->1 MsgApp Term:3 Log:2/12 Commit:12 Entries:[3/13 EntryNormal ""]
   3->1 MsgApp Term:3 Log:3/13 Commit:13
 > 1 handling Ready
   Ready MustSync=true:
@@ -355,10 +353,8 @@ stabilize 1 3
   CommittedEntries:
   3/13 EntryNormal ""
   Messages:
-  1->3 MsgAppResp Term:3 Log:0/13 Commit:12
   1->3 MsgAppResp Term:3 Log:0/13 Commit:13
 > 3 receiving messages
-  1->3 MsgAppResp Term:3 Log:0/13 Commit:12
   1->3 MsgAppResp Term:3 Log:0/13 Commit:13
 
 deliver-msgs drop=(2)
@@ -454,18 +450,6 @@ stabilize
   2->3 MsgDeFortifyLeader Term:2 Log:0/0
   INFO 3 [term: 3] ignored a MsgDeFortifyLeader message with lower term from 2 [term: 2]
   2->3 MsgFortifyLeaderResp Term:3 Log:0/0 LeadEpoch:1
-  2->3 MsgAppResp Term:3 Log:0/13 Commit:13
-> 3 handling Ready
-  Ready MustSync=false:
-  Messages:
-  3->2 MsgApp Term:3 Log:2/12 Commit:13 Entries:[3/13 EntryNormal ""]
-> 2 receiving messages
-  3->2 MsgApp Term:3 Log:2/12 Commit:13 Entries:[3/13 EntryNormal ""]
-> 2 handling Ready
-  Ready MustSync=false:
-  Messages:
-  2->3 MsgAppResp Term:3 Log:0/13 Commit:13
-> 3 receiving messages
   2->3 MsgAppResp Term:3 Log:0/13 Commit:13
 
 raft-state

--- a/pkg/raft/testdata/fortification_basic.txt
+++ b/pkg/raft/testdata/fortification_basic.txt
@@ -189,18 +189,14 @@ stabilize
   CommittedEntries:
   1/3 EntryNormal ""
   Messages:
-  1->2 MsgApp Term:1 Log:1/2 Commit:2 Entries:[1/3 EntryNormal ""]
   1->2 MsgApp Term:1 Log:1/3 Commit:3
   1->3 MsgApp Term:1 Log:1/3 Commit:3
-  1->4 MsgApp Term:1 Log:1/2 Commit:3 Entries:[1/3 EntryNormal ""]
   1->4 MsgApp Term:1 Log:1/3 Commit:3
 > 2 receiving messages
-  1->2 MsgApp Term:1 Log:1/2 Commit:2 Entries:[1/3 EntryNormal ""]
   1->2 MsgApp Term:1 Log:1/3 Commit:3
 > 3 receiving messages
   1->3 MsgApp Term:1 Log:1/3 Commit:3
 > 4 receiving messages
-  1->4 MsgApp Term:1 Log:1/2 Commit:3 Entries:[1/3 EntryNormal ""]
   1->4 MsgApp Term:1 Log:1/3 Commit:3
 > 2 handling Ready
   Ready MustSync=true:
@@ -208,7 +204,6 @@ stabilize
   CommittedEntries:
   1/3 EntryNormal ""
   Messages:
-  2->1 MsgAppResp Term:1 Log:0/3 Commit:2
   2->1 MsgAppResp Term:1 Log:0/3 Commit:3
 > 3 handling Ready
   Ready MustSync=true:
@@ -224,10 +219,7 @@ stabilize
   1/3 EntryNormal ""
   Messages:
   4->1 MsgAppResp Term:1 Log:0/3 Commit:3
-  4->1 MsgAppResp Term:1 Log:0/3 Commit:3
 > 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/3 Commit:2
   2->1 MsgAppResp Term:1 Log:0/3 Commit:3
   3->1 MsgAppResp Term:1 Log:0/3 Commit:3
-  4->1 MsgAppResp Term:1 Log:0/3 Commit:3
   4->1 MsgAppResp Term:1 Log:0/3 Commit:3

--- a/pkg/raft/testdata/fortification_followers_dont_call_election_prevote.txt
+++ b/pkg/raft/testdata/fortification_followers_dont_call_election_prevote.txt
@@ -140,15 +140,11 @@ stabilize
   CommittedEntries:
   1/11 EntryNormal ""
   Messages:
-  1->2 MsgApp Term:1 Log:1/10 Commit:10 Entries:[1/11 EntryNormal ""]
   1->2 MsgApp Term:1 Log:1/11 Commit:11
-  1->3 MsgApp Term:1 Log:1/10 Commit:11 Entries:[1/11 EntryNormal ""]
   1->3 MsgApp Term:1 Log:1/11 Commit:11
 > 2 receiving messages
-  1->2 MsgApp Term:1 Log:1/10 Commit:10 Entries:[1/11 EntryNormal ""]
   1->2 MsgApp Term:1 Log:1/11 Commit:11
 > 3 receiving messages
-  1->3 MsgApp Term:1 Log:1/10 Commit:11 Entries:[1/11 EntryNormal ""]
   1->3 MsgApp Term:1 Log:1/11 Commit:11
 > 2 handling Ready
   Ready MustSync=true:
@@ -156,7 +152,6 @@ stabilize
   CommittedEntries:
   1/11 EntryNormal ""
   Messages:
-  2->1 MsgAppResp Term:1 Log:0/11 Commit:10
   2->1 MsgAppResp Term:1 Log:0/11 Commit:11
 > 3 handling Ready
   Ready MustSync=true:
@@ -165,11 +160,8 @@ stabilize
   1/11 EntryNormal ""
   Messages:
   3->1 MsgAppResp Term:1 Log:0/11 Commit:11
-  3->1 MsgAppResp Term:1 Log:0/11 Commit:11
 > 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/11 Commit:10
   2->1 MsgAppResp Term:1 Log:0/11 Commit:11
-  3->1 MsgAppResp Term:1 Log:0/11 Commit:11
   3->1 MsgAppResp Term:1 Log:0/11 Commit:11
 
 store-liveness

--- a/pkg/raft/testdata/fortification_followers_dont_prevote.txt
+++ b/pkg/raft/testdata/fortification_followers_dont_prevote.txt
@@ -140,15 +140,11 @@ stabilize
   CommittedEntries:
   1/11 EntryNormal ""
   Messages:
-  1->2 MsgApp Term:1 Log:1/10 Commit:10 Entries:[1/11 EntryNormal ""]
   1->2 MsgApp Term:1 Log:1/11 Commit:11
-  1->3 MsgApp Term:1 Log:1/10 Commit:11 Entries:[1/11 EntryNormal ""]
   1->3 MsgApp Term:1 Log:1/11 Commit:11
 > 2 receiving messages
-  1->2 MsgApp Term:1 Log:1/10 Commit:10 Entries:[1/11 EntryNormal ""]
   1->2 MsgApp Term:1 Log:1/11 Commit:11
 > 3 receiving messages
-  1->3 MsgApp Term:1 Log:1/10 Commit:11 Entries:[1/11 EntryNormal ""]
   1->3 MsgApp Term:1 Log:1/11 Commit:11
 > 2 handling Ready
   Ready MustSync=true:
@@ -156,7 +152,6 @@ stabilize
   CommittedEntries:
   1/11 EntryNormal ""
   Messages:
-  2->1 MsgAppResp Term:1 Log:0/11 Commit:10
   2->1 MsgAppResp Term:1 Log:0/11 Commit:11
 > 3 handling Ready
   Ready MustSync=true:
@@ -165,11 +160,8 @@ stabilize
   1/11 EntryNormal ""
   Messages:
   3->1 MsgAppResp Term:1 Log:0/11 Commit:11
-  3->1 MsgAppResp Term:1 Log:0/11 Commit:11
 > 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/11 Commit:10
   2->1 MsgAppResp Term:1 Log:0/11 Commit:11
-  3->1 MsgAppResp Term:1 Log:0/11 Commit:11
   3->1 MsgAppResp Term:1 Log:0/11 Commit:11
 
 withdraw-support 2 1
@@ -333,15 +325,11 @@ stabilize
   CommittedEntries:
   2/12 EntryNormal ""
   Messages:
-  2->1 MsgApp Term:2 Log:1/11 Commit:11 Entries:[2/12 EntryNormal ""]
   2->1 MsgApp Term:2 Log:2/12 Commit:12
-  2->3 MsgApp Term:2 Log:1/11 Commit:12 Entries:[2/12 EntryNormal ""]
   2->3 MsgApp Term:2 Log:2/12 Commit:12
 > 1 receiving messages
-  2->1 MsgApp Term:2 Log:1/11 Commit:11 Entries:[2/12 EntryNormal ""]
   2->1 MsgApp Term:2 Log:2/12 Commit:12
 > 3 receiving messages
-  2->3 MsgApp Term:2 Log:1/11 Commit:12 Entries:[2/12 EntryNormal ""]
   2->3 MsgApp Term:2 Log:2/12 Commit:12
 > 1 handling Ready
   Ready MustSync=true:
@@ -349,7 +337,6 @@ stabilize
   CommittedEntries:
   2/12 EntryNormal ""
   Messages:
-  1->2 MsgAppResp Term:2 Log:0/12 Commit:11
   1->2 MsgAppResp Term:2 Log:0/12 Commit:12
 > 3 handling Ready
   Ready MustSync=true:
@@ -358,11 +345,8 @@ stabilize
   2/12 EntryNormal ""
   Messages:
   3->2 MsgAppResp Term:2 Log:0/12 Commit:12
-  3->2 MsgAppResp Term:2 Log:0/12 Commit:12
 > 2 receiving messages
-  1->2 MsgAppResp Term:2 Log:0/12 Commit:11
   1->2 MsgAppResp Term:2 Log:0/12 Commit:12
-  3->2 MsgAppResp Term:2 Log:0/12 Commit:12
   3->2 MsgAppResp Term:2 Log:0/12 Commit:12
 
 raft-state
@@ -605,15 +589,11 @@ stabilize
   CommittedEntries:
   3/13 EntryNormal ""
   Messages:
-  2->1 MsgApp Term:3 Log:2/12 Commit:12 Entries:[3/13 EntryNormal ""]
   2->1 MsgApp Term:3 Log:3/13 Commit:13
-  2->3 MsgApp Term:3 Log:2/12 Commit:13 Entries:[3/13 EntryNormal ""]
   2->3 MsgApp Term:3 Log:3/13 Commit:13
 > 1 receiving messages
-  2->1 MsgApp Term:3 Log:2/12 Commit:12 Entries:[3/13 EntryNormal ""]
   2->1 MsgApp Term:3 Log:3/13 Commit:13
 > 3 receiving messages
-  2->3 MsgApp Term:3 Log:2/12 Commit:13 Entries:[3/13 EntryNormal ""]
   2->3 MsgApp Term:3 Log:3/13 Commit:13
 > 1 handling Ready
   Ready MustSync=true:
@@ -621,7 +601,6 @@ stabilize
   CommittedEntries:
   3/13 EntryNormal ""
   Messages:
-  1->2 MsgAppResp Term:3 Log:0/13 Commit:12
   1->2 MsgAppResp Term:3 Log:0/13 Commit:13
 > 3 handling Ready
   Ready MustSync=true:
@@ -630,11 +609,8 @@ stabilize
   3/13 EntryNormal ""
   Messages:
   3->2 MsgAppResp Term:3 Log:0/13 Commit:13
-  3->2 MsgAppResp Term:3 Log:0/13 Commit:13
 > 2 receiving messages
-  1->2 MsgAppResp Term:3 Log:0/13 Commit:12
   1->2 MsgAppResp Term:3 Log:0/13 Commit:13
-  3->2 MsgAppResp Term:3 Log:0/13 Commit:13
   3->2 MsgAppResp Term:3 Log:0/13 Commit:13
 
 raft-state

--- a/pkg/raft/testdata/fortification_leader_does_not_support_itself.txt
+++ b/pkg/raft/testdata/fortification_leader_does_not_support_itself.txt
@@ -135,15 +135,11 @@ stabilize
   CommittedEntries:
   1/3 EntryNormal ""
   Messages:
-  1->2 MsgApp Term:1 Log:1/2 Commit:2 Entries:[1/3 EntryNormal ""]
   1->2 MsgApp Term:1 Log:1/3 Commit:3
-  1->3 MsgApp Term:1 Log:1/2 Commit:3 Entries:[1/3 EntryNormal ""]
   1->3 MsgApp Term:1 Log:1/3 Commit:3
 > 2 receiving messages
-  1->2 MsgApp Term:1 Log:1/2 Commit:2 Entries:[1/3 EntryNormal ""]
   1->2 MsgApp Term:1 Log:1/3 Commit:3
 > 3 receiving messages
-  1->3 MsgApp Term:1 Log:1/2 Commit:3 Entries:[1/3 EntryNormal ""]
   1->3 MsgApp Term:1 Log:1/3 Commit:3
 > 2 handling Ready
   Ready MustSync=true:
@@ -151,7 +147,6 @@ stabilize
   CommittedEntries:
   1/3 EntryNormal ""
   Messages:
-  2->1 MsgAppResp Term:1 Log:0/3 Commit:2
   2->1 MsgAppResp Term:1 Log:0/3 Commit:3
 > 3 handling Ready
   Ready MustSync=true:
@@ -160,11 +155,8 @@ stabilize
   1/3 EntryNormal ""
   Messages:
   3->1 MsgAppResp Term:1 Log:0/3 Commit:3
-  3->1 MsgAppResp Term:1 Log:0/3 Commit:3
 > 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/3 Commit:2
   2->1 MsgAppResp Term:1 Log:0/3 Commit:3
-  3->1 MsgAppResp Term:1 Log:0/3 Commit:3
   3->1 MsgAppResp Term:1 Log:0/3 Commit:3
 
 # TODO(arul): Consider adding a directive for the leader's support tracker and

--- a/pkg/raft/testdata/fortification_support_tracking.txt
+++ b/pkg/raft/testdata/fortification_support_tracking.txt
@@ -113,12 +113,10 @@ stabilize
   1/11 EntryNormal ""
   Messages:
   1->2 MsgApp Term:1 Log:1/11 Commit:11
-  1->3 MsgApp Term:1 Log:1/10 Commit:11 Entries:[1/11 EntryNormal ""]
   1->3 MsgApp Term:1 Log:1/11 Commit:11
 > 2 receiving messages
   1->2 MsgApp Term:1 Log:1/11 Commit:11
 > 3 receiving messages
-  1->3 MsgApp Term:1 Log:1/10 Commit:11 Entries:[1/11 EntryNormal ""]
   1->3 MsgApp Term:1 Log:1/11 Commit:11
 > 2 handling Ready
   Ready MustSync=true:
@@ -134,10 +132,8 @@ stabilize
   1/11 EntryNormal ""
   Messages:
   3->1 MsgAppResp Term:1 Log:0/11 Commit:11
-  3->1 MsgAppResp Term:1 Log:0/11 Commit:11
 > 1 receiving messages
   2->1 MsgAppResp Term:1 Log:0/11 Commit:11
-  3->1 MsgAppResp Term:1 Log:0/11 Commit:11
   3->1 MsgAppResp Term:1 Log:0/11 Commit:11
 
 print-fortification-state 1
@@ -260,15 +256,11 @@ stabilize
   CommittedEntries:
   2/12 EntryNormal ""
   Messages:
-  2->1 MsgApp Term:2 Log:1/11 Commit:11 Entries:[2/12 EntryNormal ""]
   2->1 MsgApp Term:2 Log:2/12 Commit:12
-  2->3 MsgApp Term:2 Log:1/11 Commit:12 Entries:[2/12 EntryNormal ""]
   2->3 MsgApp Term:2 Log:2/12 Commit:12
 > 1 receiving messages
-  2->1 MsgApp Term:2 Log:1/11 Commit:11 Entries:[2/12 EntryNormal ""]
   2->1 MsgApp Term:2 Log:2/12 Commit:12
 > 3 receiving messages
-  2->3 MsgApp Term:2 Log:1/11 Commit:12 Entries:[2/12 EntryNormal ""]
   2->3 MsgApp Term:2 Log:2/12 Commit:12
 > 1 handling Ready
   Ready MustSync=true:
@@ -276,7 +268,6 @@ stabilize
   CommittedEntries:
   2/12 EntryNormal ""
   Messages:
-  1->2 MsgAppResp Term:2 Log:0/12 Commit:11
   1->2 MsgAppResp Term:2 Log:0/12 Commit:12
 > 3 handling Ready
   Ready MustSync=true:
@@ -285,11 +276,8 @@ stabilize
   2/12 EntryNormal ""
   Messages:
   3->2 MsgAppResp Term:2 Log:0/12 Commit:12
-  3->2 MsgAppResp Term:2 Log:0/12 Commit:12
 > 2 receiving messages
-  1->2 MsgAppResp Term:2 Log:0/12 Commit:11
   1->2 MsgAppResp Term:2 Log:0/12 Commit:12
-  3->2 MsgAppResp Term:2 Log:0/12 Commit:12
   3->2 MsgAppResp Term:2 Log:0/12 Commit:12
 
 print-fortification-state 2

--- a/pkg/raft/testdata/lagging_commit_no_store_liveness_support.txt
+++ b/pkg/raft/testdata/lagging_commit_no_store_liveness_support.txt
@@ -172,15 +172,3 @@ stabilize
 > 1 receiving messages
   3->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:2
   3->1 MsgAppResp Term:1 Log:0/13 Commit:13
-> 1 handling Ready
-  Ready MustSync=false:
-  Messages:
-  1->3 MsgApp Term:1 Log:1/13 Commit:13
-> 3 receiving messages
-  1->3 MsgApp Term:1 Log:1/13 Commit:13
-> 3 handling Ready
-  Ready MustSync=false:
-  Messages:
-  3->1 MsgAppResp Term:1 Log:0/13 Commit:13
-> 1 receiving messages
-  3->1 MsgAppResp Term:1 Log:0/13 Commit:13

--- a/pkg/raft/testdata/leader_step_down_stranded_peer.txt
+++ b/pkg/raft/testdata/leader_step_down_stranded_peer.txt
@@ -169,10 +169,8 @@ stabilize 1 2
   CommittedEntries:
   1/11 EntryNormal ""
   Messages:
-  1->2 MsgApp Term:1 Log:1/10 Commit:10 Entries:[1/11 EntryNormal ""]
   1->2 MsgApp Term:1 Log:1/11 Commit:11
 > 2 receiving messages
-  1->2 MsgApp Term:1 Log:1/10 Commit:10 Entries:[1/11 EntryNormal ""]
   1->2 MsgApp Term:1 Log:1/11 Commit:11
 > 2 handling Ready
   Ready MustSync=true:
@@ -180,10 +178,8 @@ stabilize 1 2
   CommittedEntries:
   1/11 EntryNormal ""
   Messages:
-  2->1 MsgAppResp Term:1 Log:0/11 Commit:10
   2->1 MsgAppResp Term:1 Log:0/11 Commit:11
 > 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/11 Commit:10
   2->1 MsgAppResp Term:1 Log:0/11 Commit:11
 
 deliver-msgs drop=(3)
@@ -351,19 +347,14 @@ stabilize
   CommittedEntries:
   4/12 EntryNormal ""
   Messages:
-  1->2 MsgApp Term:4 Log:1/11 Commit:11 Entries:[4/12 EntryNormal ""]
   1->2 MsgApp Term:4 Log:4/12 Commit:12
-  1->3 MsgApp Term:4 Log:1/11 Commit:12 Entries:[4/12 EntryNormal ""]
   1->3 MsgApp Term:4 Log:1/10 Commit:12 Entries:[
     1/11 EntryNormal ""
     4/12 EntryNormal ""
   ]
 > 2 receiving messages
-  1->2 MsgApp Term:4 Log:1/11 Commit:11 Entries:[4/12 EntryNormal ""]
   1->2 MsgApp Term:4 Log:4/12 Commit:12
 > 3 receiving messages
-  1->3 MsgApp Term:4 Log:1/11 Commit:12 Entries:[4/12 EntryNormal ""]
-  DEBUG 3 [logterm: 0, index: 11] rejected MsgApp [logterm: 1, index: 11] from 1
   1->3 MsgApp Term:4 Log:1/10 Commit:12 Entries:[
     1/11 EntryNormal ""
     4/12 EntryNormal ""
@@ -374,7 +365,6 @@ stabilize
   CommittedEntries:
   4/12 EntryNormal ""
   Messages:
-  2->1 MsgAppResp Term:4 Log:0/12 Commit:11
   2->1 MsgAppResp Term:4 Log:0/12 Commit:12
 > 3 handling Ready
   Ready MustSync=true:
@@ -386,13 +376,9 @@ stabilize
   1/11 EntryNormal ""
   4/12 EntryNormal ""
   Messages:
-  3->1 MsgAppResp Term:4 Log:1/11 Rejected (Hint: 10) Commit:10
   3->1 MsgAppResp Term:4 Log:0/12 Commit:12
 > 1 receiving messages
-  2->1 MsgAppResp Term:4 Log:0/12 Commit:11
   2->1 MsgAppResp Term:4 Log:0/12 Commit:12
-  3->1 MsgAppResp Term:4 Log:1/11 Rejected (Hint: 10) Commit:10
-  DEBUG 1 received MsgAppResp(rejected, hint: (index 10, term 1)) from 3 for index 11
   3->1 MsgAppResp Term:4 Log:0/12 Commit:12
 
 raft-state

--- a/pkg/raft/testdata/leader_step_down_stranded_peer_prevote.txt
+++ b/pkg/raft/testdata/leader_step_down_stranded_peer_prevote.txt
@@ -287,10 +287,8 @@ stabilize 1 2
   CommittedEntries:
   1/11 EntryNormal ""
   Messages:
-  1->2 MsgApp Term:1 Log:1/10 Commit:10 Entries:[1/11 EntryNormal ""]
   1->2 MsgApp Term:1 Log:1/11 Commit:11
 > 2 receiving messages
-  1->2 MsgApp Term:1 Log:1/10 Commit:10 Entries:[1/11 EntryNormal ""]
   1->2 MsgApp Term:1 Log:1/11 Commit:11
 > 2 handling Ready
   Ready MustSync=true:
@@ -298,10 +296,8 @@ stabilize 1 2
   CommittedEntries:
   1/11 EntryNormal ""
   Messages:
-  2->1 MsgAppResp Term:1 Log:0/11 Commit:10
   2->1 MsgAppResp Term:1 Log:0/11 Commit:11
 > 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/11 Commit:10
   2->1 MsgAppResp Term:1 Log:0/11 Commit:11
 
 deliver-msgs drop=(3)
@@ -495,19 +491,14 @@ stabilize
   CommittedEntries:
   4/12 EntryNormal ""
   Messages:
-  1->2 MsgApp Term:4 Log:1/11 Commit:11 Entries:[4/12 EntryNormal ""]
   1->2 MsgApp Term:4 Log:4/12 Commit:12
-  1->3 MsgApp Term:4 Log:1/11 Commit:12 Entries:[4/12 EntryNormal ""]
   1->3 MsgApp Term:4 Log:1/10 Commit:12 Entries:[
     1/11 EntryNormal ""
     4/12 EntryNormal ""
   ]
 > 2 receiving messages
-  1->2 MsgApp Term:4 Log:1/11 Commit:11 Entries:[4/12 EntryNormal ""]
   1->2 MsgApp Term:4 Log:4/12 Commit:12
 > 3 receiving messages
-  1->3 MsgApp Term:4 Log:1/11 Commit:12 Entries:[4/12 EntryNormal ""]
-  DEBUG 3 [logterm: 0, index: 11] rejected MsgApp [logterm: 1, index: 11] from 1
   1->3 MsgApp Term:4 Log:1/10 Commit:12 Entries:[
     1/11 EntryNormal ""
     4/12 EntryNormal ""
@@ -518,7 +509,6 @@ stabilize
   CommittedEntries:
   4/12 EntryNormal ""
   Messages:
-  2->1 MsgAppResp Term:4 Log:0/12 Commit:11
   2->1 MsgAppResp Term:4 Log:0/12 Commit:12
 > 3 handling Ready
   Ready MustSync=true:
@@ -530,13 +520,9 @@ stabilize
   1/11 EntryNormal ""
   4/12 EntryNormal ""
   Messages:
-  3->1 MsgAppResp Term:4 Log:1/11 Rejected (Hint: 10) Commit:10
   3->1 MsgAppResp Term:4 Log:0/12 Commit:12
 > 1 receiving messages
-  2->1 MsgAppResp Term:4 Log:0/12 Commit:11
   2->1 MsgAppResp Term:4 Log:0/12 Commit:12
-  3->1 MsgAppResp Term:4 Log:1/11 Rejected (Hint: 10) Commit:10
-  DEBUG 1 received MsgAppResp(rejected, hint: (index 10, term 1)) from 3 for index 11
   3->1 MsgAppResp Term:4 Log:0/12 Commit:12
 
 raft-state

--- a/pkg/raft/testdata/prevote.txt
+++ b/pkg/raft/testdata/prevote.txt
@@ -282,15 +282,11 @@ stabilize
   CommittedEntries:
   2/13 EntryNormal ""
   Messages:
-  2->1 MsgApp Term:2 Log:1/12 Commit:12 Entries:[2/13 EntryNormal ""]
   2->1 MsgApp Term:2 Log:2/13 Commit:13
-  2->3 MsgApp Term:2 Log:1/12 Commit:13 Entries:[2/13 EntryNormal ""]
   2->3 MsgApp Term:2 Log:2/13 Commit:13
 > 1 receiving messages
-  2->1 MsgApp Term:2 Log:1/12 Commit:12 Entries:[2/13 EntryNormal ""]
   2->1 MsgApp Term:2 Log:2/13 Commit:13
 > 3 receiving messages
-  2->3 MsgApp Term:2 Log:1/12 Commit:13 Entries:[2/13 EntryNormal ""]
   2->3 MsgApp Term:2 Log:2/13 Commit:13
 > 1 handling Ready
   Ready MustSync=true:
@@ -298,7 +294,6 @@ stabilize
   CommittedEntries:
   2/13 EntryNormal ""
   Messages:
-  1->2 MsgAppResp Term:2 Log:0/13 Commit:12
   1->2 MsgAppResp Term:2 Log:0/13 Commit:13
 > 3 handling Ready
   Ready MustSync=true:
@@ -307,9 +302,6 @@ stabilize
   2/13 EntryNormal ""
   Messages:
   3->2 MsgAppResp Term:2 Log:0/13 Commit:13
-  3->2 MsgAppResp Term:2 Log:0/13 Commit:13
 > 2 receiving messages
-  1->2 MsgAppResp Term:2 Log:0/13 Commit:12
   1->2 MsgAppResp Term:2 Log:0/13 Commit:13
-  3->2 MsgAppResp Term:2 Log:0/13 Commit:13
   3->2 MsgAppResp Term:2 Log:0/13 Commit:13

--- a/pkg/raft/testdata/prevote_checkquorum.txt
+++ b/pkg/raft/testdata/prevote_checkquorum.txt
@@ -192,15 +192,11 @@ stabilize
   CommittedEntries:
   2/12 EntryNormal ""
   Messages:
-  3->1 MsgApp Term:2 Log:1/11 Commit:11 Entries:[2/12 EntryNormal ""]
   3->1 MsgApp Term:2 Log:2/12 Commit:12
-  3->2 MsgApp Term:2 Log:1/11 Commit:12 Entries:[2/12 EntryNormal ""]
   3->2 MsgApp Term:2 Log:2/12 Commit:12
 > 1 receiving messages
-  3->1 MsgApp Term:2 Log:1/11 Commit:11 Entries:[2/12 EntryNormal ""]
   3->1 MsgApp Term:2 Log:2/12 Commit:12
 > 2 receiving messages
-  3->2 MsgApp Term:2 Log:1/11 Commit:12 Entries:[2/12 EntryNormal ""]
   3->2 MsgApp Term:2 Log:2/12 Commit:12
 > 1 handling Ready
   Ready MustSync=true:
@@ -208,7 +204,6 @@ stabilize
   CommittedEntries:
   2/12 EntryNormal ""
   Messages:
-  1->3 MsgAppResp Term:2 Log:0/12 Commit:11
   1->3 MsgAppResp Term:2 Log:0/12 Commit:12
 > 2 handling Ready
   Ready MustSync=true:
@@ -217,11 +212,8 @@ stabilize
   2/12 EntryNormal ""
   Messages:
   2->3 MsgAppResp Term:2 Log:0/12 Commit:12
-  2->3 MsgAppResp Term:2 Log:0/12 Commit:12
 > 3 receiving messages
-  1->3 MsgAppResp Term:2 Log:0/12 Commit:11
   1->3 MsgAppResp Term:2 Log:0/12 Commit:12
-  2->3 MsgAppResp Term:2 Log:0/12 Commit:12
   2->3 MsgAppResp Term:2 Log:0/12 Commit:12
 
 withdraw-support 1 3
@@ -396,15 +388,11 @@ stabilize
   CommittedEntries:
   3/13 EntryNormal ""
   Messages:
-  2->1 MsgApp Term:3 Log:2/12 Commit:12 Entries:[3/13 EntryNormal ""]
   2->1 MsgApp Term:3 Log:3/13 Commit:13
-  2->3 MsgApp Term:3 Log:2/12 Commit:13 Entries:[3/13 EntryNormal ""]
   2->3 MsgApp Term:3 Log:3/13 Commit:13
 > 1 receiving messages
-  2->1 MsgApp Term:3 Log:2/12 Commit:12 Entries:[3/13 EntryNormal ""]
   2->1 MsgApp Term:3 Log:3/13 Commit:13
 > 3 receiving messages
-  2->3 MsgApp Term:3 Log:2/12 Commit:13 Entries:[3/13 EntryNormal ""]
   2->3 MsgApp Term:3 Log:3/13 Commit:13
 > 1 handling Ready
   Ready MustSync=true:
@@ -412,7 +400,6 @@ stabilize
   CommittedEntries:
   3/13 EntryNormal ""
   Messages:
-  1->2 MsgAppResp Term:3 Log:0/13 Commit:12
   1->2 MsgAppResp Term:3 Log:0/13 Commit:13
 > 3 handling Ready
   Ready MustSync=true:
@@ -421,9 +408,6 @@ stabilize
   3/13 EntryNormal ""
   Messages:
   3->2 MsgAppResp Term:3 Log:0/13 Commit:13
-  3->2 MsgAppResp Term:3 Log:0/13 Commit:13
 > 2 receiving messages
-  1->2 MsgAppResp Term:3 Log:0/13 Commit:12
   1->2 MsgAppResp Term:3 Log:0/13 Commit:13
-  3->2 MsgAppResp Term:3 Log:0/13 Commit:13
   3->2 MsgAppResp Term:3 Log:0/13 Commit:13

--- a/pkg/raft/testdata/probe_and_replicate.txt
+++ b/pkg/raft/testdata/probe_and_replicate.txt
@@ -580,13 +580,11 @@ stabilize 1 2
 > 1 handling Ready
   Ready MustSync=false:
   Messages:
-  1->2 MsgApp Term:8 Log:6/20 Commit:18 Entries:[8/21 EntryNormal ""]
   1->2 MsgApp Term:8 Log:6/19 Commit:18 Entries:[
     6/20 EntryNormal "prop_6_20"
     8/21 EntryNormal ""
   ]
 > 2 receiving messages
-  1->2 MsgApp Term:8 Log:6/20 Commit:18 Entries:[8/21 EntryNormal ""]
   1->2 MsgApp Term:8 Log:6/19 Commit:18 Entries:[
     6/20 EntryNormal "prop_6_20"
     8/21 EntryNormal ""
@@ -597,10 +595,8 @@ stabilize 1 2
   6/20 EntryNormal "prop_6_20"
   8/21 EntryNormal ""
   Messages:
-  2->1 MsgAppResp Term:8 Log:6/20 Rejected (Hint: 19) Commit:18
   2->1 MsgAppResp Term:8 Log:0/21 Commit:18
 > 1 receiving messages
-  2->1 MsgAppResp Term:8 Log:6/20 Rejected (Hint: 19) Commit:18
   2->1 MsgAppResp Term:8 Log:0/21 Commit:18
 
 stabilize 1 3
@@ -620,7 +616,6 @@ stabilize 1 3
 > 1 handling Ready
   Ready MustSync=false:
   Messages:
-  1->3 MsgApp Term:8 Log:6/20 Commit:18 Entries:[8/21 EntryNormal ""]
   1->3 MsgApp Term:8 Log:4/14 Commit:18 Entries:[
     4/15 EntryNormal "prop_4_15"
     5/16 EntryNormal ""
@@ -631,7 +626,6 @@ stabilize 1 3
     8/21 EntryNormal ""
   ]
 > 3 receiving messages
-  1->3 MsgApp Term:8 Log:6/20 Commit:18 Entries:[8/21 EntryNormal ""]
   1->3 MsgApp Term:8 Log:4/14 Commit:18 Entries:[
     4/15 EntryNormal "prop_4_15"
     5/16 EntryNormal ""
@@ -658,10 +652,8 @@ stabilize 1 3
   5/17 EntryNormal "prop_5_17"
   6/18 EntryNormal ""
   Messages:
-  3->1 MsgAppResp Term:8 Log:4/20 Rejected (Hint: 14) Commit:14
   3->1 MsgAppResp Term:8 Log:0/21 Commit:18
 > 1 receiving messages
-  3->1 MsgAppResp Term:8 Log:4/20 Rejected (Hint: 14) Commit:14
   3->1 MsgAppResp Term:8 Log:0/21 Commit:18
 
 stabilize 1 4
@@ -690,12 +682,10 @@ stabilize 1 4
   6/20 EntryNormal "prop_6_20"
   8/21 EntryNormal ""
   Messages:
-  1->4 MsgApp Term:8 Log:6/20 Commit:18 Entries:[8/21 EntryNormal ""]
   1->2 MsgApp Term:8 Log:8/21 Commit:21
   1->3 MsgApp Term:8 Log:8/21 Commit:21
   1->4 MsgApp Term:8 Log:8/21 Commit:21
 > 4 receiving messages
-  1->4 MsgApp Term:8 Log:6/20 Commit:18 Entries:[8/21 EntryNormal ""]
   1->4 MsgApp Term:8 Log:8/21 Commit:21
 > 4 handling Ready
   Ready MustSync=true:
@@ -705,10 +695,8 @@ stabilize 1 4
   6/20 EntryNormal "prop_6_20"
   8/21 EntryNormal ""
   Messages:
-  4->1 MsgAppResp Term:8 Log:0/21 Commit:18
   4->1 MsgAppResp Term:8 Log:0/21 Commit:21
 > 1 receiving messages
-  4->1 MsgAppResp Term:8 Log:0/21 Commit:18
   4->1 MsgAppResp Term:8 Log:0/21 Commit:21
 
 stabilize 1 5
@@ -728,14 +716,12 @@ stabilize 1 5
 > 1 handling Ready
   Ready MustSync=false:
   Messages:
-  1->5 MsgApp Term:8 Log:6/20 Commit:21 Entries:[8/21 EntryNormal ""]
   1->5 MsgApp Term:8 Log:6/18 Commit:21 Entries:[
     6/19 EntryNormal "prop_6_19"
     6/20 EntryNormal "prop_6_20"
     8/21 EntryNormal ""
   ]
 > 5 receiving messages
-  1->5 MsgApp Term:8 Log:6/20 Commit:21 Entries:[8/21 EntryNormal ""]
   1->5 MsgApp Term:8 Log:6/18 Commit:21 Entries:[
     6/19 EntryNormal "prop_6_19"
     6/20 EntryNormal "prop_6_20"
@@ -755,10 +741,8 @@ stabilize 1 5
   6/20 EntryNormal "prop_6_20"
   8/21 EntryNormal ""
   Messages:
-  5->1 MsgAppResp Term:8 Log:6/20 Rejected (Hint: 18) Commit:18
   5->1 MsgAppResp Term:8 Log:0/21 Commit:21
 > 1 receiving messages
-  5->1 MsgAppResp Term:8 Log:6/20 Rejected (Hint: 18) Commit:18
   5->1 MsgAppResp Term:8 Log:0/21 Commit:21
 
 stabilize 1 6
@@ -778,7 +762,6 @@ stabilize 1 6
 > 1 handling Ready
   Ready MustSync=false:
   Messages:
-  1->6 MsgApp Term:8 Log:6/20 Commit:21 Entries:[8/21 EntryNormal ""]
   1->6 MsgApp Term:8 Log:4/15 Commit:21 Entries:[
     5/16 EntryNormal ""
     5/17 EntryNormal "prop_5_17"
@@ -788,7 +771,6 @@ stabilize 1 6
     8/21 EntryNormal ""
   ]
 > 6 receiving messages
-  1->6 MsgApp Term:8 Log:6/20 Commit:21 Entries:[8/21 EntryNormal ""]
   1->6 MsgApp Term:8 Log:4/15 Commit:21 Entries:[
     5/16 EntryNormal ""
     5/17 EntryNormal "prop_5_17"
@@ -817,8 +799,6 @@ stabilize 1 6
   6/20 EntryNormal "prop_6_20"
   8/21 EntryNormal ""
   Messages:
-  6->1 MsgAppResp Term:8 Log:4/20 Rejected (Hint: 17) Commit:15
   6->1 MsgAppResp Term:8 Log:0/21 Commit:21
 > 1 receiving messages
-  6->1 MsgAppResp Term:8 Log:4/20 Rejected (Hint: 17) Commit:15
   6->1 MsgAppResp Term:8 Log:0/21 Commit:21

--- a/pkg/raft/testdata/refortification_basic.txt
+++ b/pkg/raft/testdata/refortification_basic.txt
@@ -125,11 +125,9 @@ stabilize
   CommittedEntries:
   1/3 EntryNormal ""
   Messages:
-  1->2 MsgApp Term:1 Log:1/2 Commit:2 Entries:[1/3 EntryNormal ""]
   1->2 MsgApp Term:1 Log:1/3 Commit:3
   1->3 MsgApp Term:1 Log:1/3 Commit:3
 > 2 receiving messages
-  1->2 MsgApp Term:1 Log:1/2 Commit:2 Entries:[1/3 EntryNormal ""]
   1->2 MsgApp Term:1 Log:1/3 Commit:3
 > 3 receiving messages
   1->3 MsgApp Term:1 Log:1/3 Commit:3
@@ -139,7 +137,6 @@ stabilize
   CommittedEntries:
   1/3 EntryNormal ""
   Messages:
-  2->1 MsgAppResp Term:1 Log:0/3 Commit:2
   2->1 MsgAppResp Term:1 Log:0/3 Commit:3
 > 3 handling Ready
   Ready MustSync=true:
@@ -149,7 +146,6 @@ stabilize
   Messages:
   3->1 MsgAppResp Term:1 Log:0/3 Commit:3
 > 1 receiving messages
-  2->1 MsgAppResp Term:1 Log:0/3 Commit:2
   2->1 MsgAppResp Term:1 Log:0/3 Commit:3
   3->1 MsgAppResp Term:1 Log:0/3 Commit:3
 

--- a/pkg/raft/testdata/snapshot_new_term.txt
+++ b/pkg/raft/testdata/snapshot_new_term.txt
@@ -108,10 +108,8 @@ stabilize 1 2
   CommittedEntries:
   2/12 EntryNormal ""
   Messages:
-  2->1 MsgApp Term:2 Log:1/11 Commit:11 Entries:[2/12 EntryNormal ""]
   2->1 MsgApp Term:2 Log:2/12 Commit:12
 > 1 receiving messages
-  2->1 MsgApp Term:2 Log:1/11 Commit:11 Entries:[2/12 EntryNormal ""]
   2->1 MsgApp Term:2 Log:2/12 Commit:12
 > 1 handling Ready
   Ready MustSync=true:
@@ -119,10 +117,8 @@ stabilize 1 2
   CommittedEntries:
   2/12 EntryNormal ""
   Messages:
-  1->2 MsgAppResp Term:2 Log:0/12 Commit:11
   1->2 MsgAppResp Term:2 Log:0/12 Commit:12
 > 2 receiving messages
-  1->2 MsgAppResp Term:2 Log:0/12 Commit:11
   1->2 MsgAppResp Term:2 Log:0/12 Commit:12
 
 # Drop inflight messages to 3.

--- a/pkg/raft/testdata/snapshot_succeed_via_app_resp.txt
+++ b/pkg/raft/testdata/snapshot_succeed_via_app_resp.txt
@@ -86,13 +86,18 @@ stabilize 1
 ----
 > 1 receiving messages
   3->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:1
-  DEBUG 1 [firstindex: 12, commit: 11] sent snapshot[index: 11, term: 1] to 3 [StateProbe match=0 next=11 sentCommit=10 matchCommit=0]
-  DEBUG 1 paused sending replication messages to 3 [StateSnapshot match=0 next=12 sentCommit=11 matchCommit=0 paused pendingSnap=11]
-> 1 handling Ready
-  Ready MustSync=false:
-  Messages:
-  1->3 MsgSnap Term:1 Log:0/0
-    Snapshot: Index:11 Term:1 ConfState:Voters:[1 2 3] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
+
+tick-heartbeat 1
+----
+DEBUG 1 [firstindex: 12, commit: 11] sent snapshot[index: 11, term: 1] to 3 [StateProbe match=0 next=11 sentCommit=10 matchCommit=0]
+DEBUG 1 paused sending replication messages to 3 [StateSnapshot match=0 next=12 sentCommit=11 matchCommit=0 paused pendingSnap=11]
+
+process-ready 1
+----
+Ready MustSync=false:
+Messages:
+1->3 MsgSnap Term:1 Log:0/0
+  Snapshot: Index:11 Term:1 ConfState:Voters:[1 2 3] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
 
 status 1
 ----

--- a/pkg/raft/testdata/transfer-leadership.txt
+++ b/pkg/raft/testdata/transfer-leadership.txt
@@ -134,15 +134,11 @@ stabilize
   CommittedEntries:
   2/12 EntryNormal ""
   Messages:
-  2->1 MsgApp Term:2 Log:1/11 Commit:11 Entries:[2/12 EntryNormal ""]
   2->1 MsgApp Term:2 Log:2/12 Commit:12
-  2->3 MsgApp Term:2 Log:1/11 Commit:12 Entries:[2/12 EntryNormal ""]
   2->3 MsgApp Term:2 Log:2/12 Commit:12
 > 1 receiving messages
-  2->1 MsgApp Term:2 Log:1/11 Commit:11 Entries:[2/12 EntryNormal ""]
   2->1 MsgApp Term:2 Log:2/12 Commit:12
 > 3 receiving messages
-  2->3 MsgApp Term:2 Log:1/11 Commit:12 Entries:[2/12 EntryNormal ""]
   2->3 MsgApp Term:2 Log:2/12 Commit:12
 > 1 handling Ready
   Ready MustSync=true:
@@ -150,7 +146,6 @@ stabilize
   CommittedEntries:
   2/12 EntryNormal ""
   Messages:
-  1->2 MsgAppResp Term:2 Log:0/12 Commit:11
   1->2 MsgAppResp Term:2 Log:0/12 Commit:12
 > 3 handling Ready
   Ready MustSync=true:
@@ -159,11 +154,8 @@ stabilize
   2/12 EntryNormal ""
   Messages:
   3->2 MsgAppResp Term:2 Log:0/12 Commit:12
-  3->2 MsgAppResp Term:2 Log:0/12 Commit:12
 > 2 receiving messages
-  1->2 MsgAppResp Term:2 Log:0/12 Commit:11
   1->2 MsgAppResp Term:2 Log:0/12 Commit:12
-  3->2 MsgAppResp Term:2 Log:0/12 Commit:12
   3->2 MsgAppResp Term:2 Log:0/12 Commit:12
 
 # Withdraw support for 3 and transfer leadership to it.


### PR DESCRIPTION
Backport 1/1 commits from #142654.

/cc @cockroachdb/release

---

This reverts commit bf1955c introduced in #132703, with modifications: we still set `RecentActive` flag on fortification response, like with all other `Resp` messages.

If we are in `StateProbe`, we do a `MsgApp` once per heartbeat (or quicker when we get an accept/reject and adjust the flow). When we switch to `StateReplicate`, we replicate eagerly. The replication flow is self-sufficient, and has its own "heartbeating" mechanism that superseded `MsgHeartbeat`.

Nudging the replication on `MsgLeaderFortifyResp` introduces interference with the normal replication flow. In particular, it induces an unnecessary/duplicate `MsgApp` probe as observed in #142652 and https://github.com/cockroachdb/cockroach/issues/140516#issuecomment-2644135153. It probably also happens in production, because the `MsgLeaderFortify/MsgApp(Resp)` messages are sent in a particular order, and raft transport mostly preserves this order.

Upon winning election, the leader sends out probes and fortification requests simultaneously. The fortification responses are racing with probe responses, and usually it happens that the fortification overtakes the `MsgAppResp` because of the order in which they are sent. This causes a non-empty `MsgApp` which duplicates the entries that are about to be sent anyway after switch to `StateReplicate`.

Epic: none
Release note: none
Release justification: performance-related fix