### PR TITLE
sql: display retry count and time for EXPLAIN ANALYZE

### DIFF
--- a/pkg/sql/opt/exec/explain/output.go
+++ b/pkg/sql/opt/exec/explain/output.go
@@ -373,6 +373,22 @@ func (ob *OutputBuilder) AddContentionTime(contentionTime time.Duration) {
 	)
 }
 
+// AddRetryCount adds a top-level retry-count field. Cannot be called while
+// inside a node.
+func (ob *OutputBuilder) AddRetryCount(count uint64) {
+	if !ob.flags.Deflake.HasAny(DeflakeVolatile) && count > 0 {
+		ob.AddTopLevelField("number of transaction retries", string(humanizeutil.Count(count)))
+	}
+}
+
+// AddRetryTime adds a top-level statement retry time field. Cannot be called
+// while inside a node.
+func (ob *OutputBuilder) AddRetryTime(delta time.Duration) {
+	if !ob.flags.Deflake.HasAny(DeflakeVolatile) && delta > 0 {
+		ob.AddTopLevelField("time spent retrying the transaction", string(humanizeutil.Duration(delta)))
+	}
+}
+
 // AddMaxMemUsage adds a top-level field for the memory used by the query.
 func (ob *OutputBuilder) AddMaxMemUsage(bytes int64) {
 	ob.AddFlakyTopLevelField(


### PR DESCRIPTION
This commit adds two new top-level fields to the plan output of `EXPLAIN ANALYZE` displaying the number of transaction retries and cumulative time spent due to the retries. This will help make retries more visible when debugging poor performance via statement bundle.

Fixes #142674

Release note (sql change): EXPLAIN ANALYZE statements now display the number of transaction retries and time spent retrying as part of the plan output.