### PR TITLE
roachtest: disable metamorphism for import-cancellation

### DIFF
--- a/pkg/cmd/roachtest/tests/import_cancellation.go
+++ b/pkg/cmd/roachtest/tests/import_cancellation.go
@@ -40,6 +40,9 @@ func registerImportCancellation(r registry.Registry) {
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runImportCancellation(ctx, t, c)
 		},
+		// Disable metamorphic variables as otherwise TPCH queries might take
+		// extremely long time to complete.
+		CockroachBinary: registry.StandardCockroach,
 	})
 }
 


### PR DESCRIPTION
We just saw a timeout of `import-cancellation` roachtest where TPCH queries were taking extremely long (on the order of an hour) time to complete. I think this was due to the unlucky choice of some metamorphic variables, so let's hard-code that this test requires standard cockroach binary.

Fixes: #142538.

Release note: None