### PR TITLE
kv, sql: allow configuration of max retry limit; use it for some operations

### DIFF
--- a/pkg/kv/db_test.go
+++ b/pkg/kv/db_test.go
@@ -949,34 +949,43 @@ func testDBTxnRetryLimit(t *testing.T, isoLevel isolation.Level) {
 	defer s.Stopper().Stop(ctx)
 
 	// Configure a low retry limit.
-	const maxRetries = 7
-	const maxAttempts = maxRetries + 1
-	kv.MaxInternalTxnAutoRetries.Override(ctx, &s.ClusterSettings().SV, maxRetries)
-
-	// Run the txn, aborting it on each attempt.
-	attempts := 0
-	err := db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
-		attempts++
-		require.NoError(t, txn.SetIsoLevel(isoLevel))
-		require.NoError(t, txn.Put(ctx, "a", "1"))
-
-		{
-			// High priority txn - will abort the other txn each attempt.
-			hpTxn := kv.NewTxn(ctx, db, 0)
-			require.NoError(t, hpTxn.SetUserPriority(roachpb.MaxUserPriority))
-			require.NoError(t, hpTxn.Put(ctx, "a", "hp txn"))
-			require.NoError(t, hpTxn.Commit(ctx))
+	const maxRetriesSetting = 7
+	const maxRetriesExplicit = 4
+	kv.MaxInternalTxnAutoRetries.Override(ctx, &s.ClusterSettings().SV, maxRetriesSetting)
+	testutils.RunTrueAndFalse(t, "explicitRetryLimit", func(t *testing.T, explicitRetryLimit bool) {
+		maxAttempts := maxRetriesSetting + 1
+		if explicitRetryLimit {
+			maxAttempts = maxRetriesExplicit + 1
 		}
 
-		// Read, so that we'll get a retryable error.
-		_, err := txn.Get(ctx, "a")
+		// Run the txn, aborting it on each attempt.
+		attempts := 0
+		err := db.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
+			if explicitRetryLimit {
+				txn.SetMaxAutoRetries(maxRetriesExplicit)
+			}
+			attempts++
+			require.NoError(t, txn.SetIsoLevel(isoLevel))
+			require.NoError(t, txn.Put(ctx, "a", "1"))
+
+			{
+				// High priority txn - will abort the other txn each attempt.
+				hpTxn := kv.NewTxn(ctx, db, 0)
+				require.NoError(t, hpTxn.SetUserPriority(roachpb.MaxUserPriority))
+				require.NoError(t, hpTxn.Put(ctx, "a", "hp txn"))
+				require.NoError(t, hpTxn.Commit(ctx))
+			}
+
+			// Read, so that we'll get a retryable error.
+			_, err := txn.Get(ctx, "a")
+			require.Error(t, err)
+			require.IsType(t, &kvpb.TransactionRetryWithProtoRefreshError{}, err)
+			return err
+		})
 		require.Error(t, err)
-		require.IsType(t, &kvpb.TransactionRetryWithProtoRefreshError{}, err)
-		return err
+		require.Regexp(t, "Terminating retry loop and returning error", err)
+		require.Equal(t, maxAttempts, attempts)
 	})
-	require.Error(t, err)
-	require.Regexp(t, "Terminating retry loop and returning error", err)
-	require.Equal(t, maxAttempts, attempts)
 }
 
 func TestPreservingSteppingOnSenderReplacement(t *testing.T) {

--- a/pkg/sql/ttl/ttljob/BUILD.bazel
+++ b/pkg/sql/ttl/ttljob/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "//pkg/roachpb",
         "//pkg/security/username",
         "//pkg/server/telemetry",
+        "//pkg/settings",
         "//pkg/settings/cluster",
         "//pkg/sql",
         "//pkg/sql/catalog",

--- a/pkg/upgrade/upgrades/first_upgrade.go
+++ b/pkg/upgrade/upgrades/first_upgrade.go
@@ -86,6 +86,10 @@ func upgradeDescriptors(
 		descBatch := idsToRewrite[currentIdx:min(currentIdx+batchSize, len(idsToRewrite))]
 		err := timeutil.RunWithTimeout(ctx, "repair-post-deserialization", repairBatchTimeLimit, func(ctx context.Context) error {
 			return d.DB.DescsTxn(ctx, func(ctx context.Context, txn descs.Txn) error {
+				// We explicitly specify a low retry limit because this operation is
+				// wrapped with its own retry function that will also take care of
+				// adjusting the batch size on each retry.
+				txn.KV().SetMaxAutoRetries(10)
 				if batchSize <= HighPriBatchSize {
 					if err := txn.KV().SetUserPriority(roachpb.MaxUserPriority); err != nil {
 						return err
@@ -216,6 +220,10 @@ WHERE
 			var rowsUpdated tree.DInt
 			err := timeutil.RunWithTimeout(ctx, "descriptor-repair", repairBatchTimeLimit, func(ctx context.Context) error {
 				return d.DB.DescsTxn(ctx, func(ctx context.Context, txn descs.Txn) error {
+					// We explicitly specify a low retry limit because this operation is
+					// wrapped with its own retry function that will also take care of
+					// adjusting the batch size on each retry.
+					txn.KV().SetMaxAutoRetries(10)
 					if batchSize <= HighPriBatchSize {
 						if err = txn.KV().SetUserPriority(roachpb.MaxUserPriority); err != nil {
 							return err


### PR DESCRIPTION
79219f705fc76eae5753ea5e28b7077dfacfd213 added a cluster setting that limits the maximum number of times a transaction will be retried internally in the KV layer.

This patch adds more configurability by adding a function that can configure the max retry limit for a specific transaction. If nothing is set this way, the limit falls back to using the cluster setting.

As part of this, an error message was tweaked to no longer mention the cluster setting. Since the setting was internal anyway, it makes more sense not to mention its name.

Finally, the new max retry function is used in a few places that already have its own retry logic to retry a transaction with a smaller batch size. This should help reduce latency of these batch operations.

fixes https://github.com/cockroachdb/cockroach/issues/142491
Release note (performance improvement): Index backfills and row-level-TTL deletions that encounter transaction contention will now be retried with smaller batch sizes more quickly, which reduces the latency of these jobs under high contention workloads.