### PR TITLE
roachtest/mixedversion: remove cluster setting mutator for `kv.snapshot_receiver.excise.enabled`

### DIFF
--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/planner.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/planner.go
@@ -227,11 +227,6 @@ var planMutators = []mutator{
 		clusterSettingMinimumVersion("v23.2.0"),
 	),
 	newClusterSettingMutator(
-		"kv.snapshot_receiver.excise.enabled",
-		[]bool{true, false},
-		clusterSettingMinimumVersion("v23.2.0"),
-	),
-	newClusterSettingMutator(
 		"storage.sstable.compression_algorithm",
 		[]string{"snappy", "zstd"},
 		clusterSettingMinimumVersion("v24.1.0-alpha.0"),

--- a/pkg/cmd/roachtest/tests/mixed_version_backup.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_backup.go
@@ -2684,7 +2684,6 @@ func registerBackupMixedVersion(r registry.Registry) {
 				// of concurrent steps.
 				mixedversion.DisableMutators(
 					mixedversion.ClusterSettingMutator("kv.expiration_leases_only.enabled"),
-					mixedversion.ClusterSettingMutator("kv.snapshot_receiver.excise.enabled"),
 					mixedversion.ClusterSettingMutator("storage.ingest_split.enabled"),
 					mixedversion.ClusterSettingMutator("storage.sstable.compression_algorithm"),
 				),

--- a/pkg/workload/kv/BUILD.bazel
+++ b/pkg/workload/kv/BUILD.bazel
@@ -2,7 +2,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "kv",
-    srcs = ["kv.go"],
+    srcs = [
+        "kv.go",
+        "zipfian.go",
+    ],
     importpath = "github.com/cockroachdb/cockroach/pkg/workload/kv",
     visibility = ["//visibility:public"],
     deps = [

--- a/pkg/workload/kv/zipfian.go
+++ b/pkg/workload/kv/zipfian.go
@@ -1,0 +1,91 @@
+// Copyright 2019 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+// Copyright 2009 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// W.Hormann, G.Derflinger:
+// "Rejection-Inversion to Generate Variates
+// from Monotone Discrete Distributions"
+// http://eeyore.wu-wien.ac.at/papers/96-04-04.wh-der.ps.gz
+
+package kv
+
+import (
+	"math"
+	"math/rand"
+)
+
+// A zipf generates Zipf distributed variates.
+// This was added here from math/rand so we could
+// have the Zipfian distribution give us a deterministic
+// result based on the read key so we don't read missing
+// entries.
+//
+// Our changes involve being supplied with
+// a seeded rand object during the time of retrieval instead
+// of a rand object during creation.
+type zipf struct {
+	imax         float64
+	v            float64
+	q            float64
+	s            float64
+	oneminusQ    float64
+	oneminusQinv float64
+	hxm          float64
+	hx0minusHxm  float64
+}
+
+func (z *zipf) h(x float64) float64 {
+	return math.Exp(z.oneminusQ*math.Log(z.v+x)) * z.oneminusQinv
+}
+
+func (z *zipf) hinv(x float64) float64 {
+	return math.Exp(z.oneminusQinv*math.Log(z.oneminusQ*x)) - z.v
+}
+
+// newZipf returns a Zipf variate generator.
+// The generator generates values k ∈ [0, imax]
+// such that P(k) is proportional to (v + k) ** (-s).
+// Requirements: s > 1 and v >= 1.
+func newZipf(s float64, v float64, imax uint64) *zipf {
+	z := new(zipf)
+	if s <= 1.0 || v < 1 {
+		return nil
+	}
+	z.imax = float64(imax)
+	z.v = v
+	z.q = s
+	z.oneminusQ = 1.0 - z.q
+	z.oneminusQinv = 1.0 / z.oneminusQ
+	z.hxm = z.h(z.imax + 0.5)
+	z.hx0minusHxm = z.h(0.5) - math.Exp(math.Log(z.v)*(-z.q)) - z.hxm
+	z.s = 1 - z.hinv(z.h(1.5)-math.Exp(-z.q*math.Log(z.v+1.0)))
+	return z
+}
+
+// Uint64 returns a value drawn from the Zipf distribution described
+// by the Zipf object.
+func (z *zipf) Uint64(random *rand.Rand) uint64 {
+	if z == nil {
+		panic("rand: nil Zipf")
+	}
+	k := 0.0
+
+	for {
+		r := random.Float64() // r in [0.0, 1.0]
+		ur := z.hxm + r*z.hx0minusHxm
+		x := z.hinv(ur)
+		k = math.Floor(x + 0.5)
+		if k-x <= z.s {
+			break
+		}
+		if ur >= z.h(k+0.5)-math.Exp(-math.Log(k+z.v)*z.q) {
+			break
+		}
+	}
+	return uint64(int64(k))
+}


### PR DESCRIPTION
The cluster setting `kv.snapshot_receiver.excise.enabled`
was removed in [1]. As a quick workaround, let's remove
the corresponding cluster setting mutator.

Subsequent PR will revisit the general problem of how
to deal with retired cluster settings.

[1] https://github.com/cockroachdb/cockroach/pull/142651

Epic: none
Release note: None