### PR TITLE
roachtest: remove old excise setting in admission control test

### DIFF
--- a/pkg/cmd/roachtest/tests/admission_control_snapshot_overload_io.go
+++ b/pkg/cmd/roachtest/tests/admission_control_snapshot_overload_io.go
@@ -131,11 +131,7 @@ func runAdmissionControlSnapshotOverloadIO(
 	{
 		// Defensive, since admission control is enabled by default.
 		roachtestutil.SetAdmissionControl(ctx, t, c, true)
-		// Ensure ingest splits and excises are enabled. (Enabled by default in v24.1+)
-		if _, err := db.ExecContext(
-			ctx, "SET CLUSTER SETTING kv.snapshot_receiver.excise.enabled = 'true'"); err != nil {
-			t.Fatalf("failed to set kv.snapshot_receiver.excise.enabled: %v", err)
-		}
+		// Ensure ingest splits are enabled. (Enabled by default in v24.1+)
 		if _, err := db.ExecContext(
 			ctx, "SET CLUSTER SETTING storage.ingest_split.enabled = 'true'"); err != nil {
 			t.Fatalf("failed to set storage.ingest_split.enabled: %v", err)


### PR DESCRIPTION
The setting is now always on (#142651).

Test runs weekly, so it hasn't failed yet (as of time of writing)

Epic: CRDB-46488
Release note: None