### PR TITLE
kvserver/closedts: auto-tune closed ts

### DIFF
--- a/pkg/ccl/multiregionccl/BUILD.bazel
+++ b/pkg/ccl/multiregionccl/BUILD.bazel
@@ -61,6 +61,8 @@ go_test(
         "//pkg/kv/kvpb",
         "//pkg/kv/kvserver",
         "//pkg/kv/kvserver/allocator/allocatorimpl",
+        "//pkg/kv/kvserver/closedts",
+        "//pkg/kv/kvserver/closedts/ctpb",
         "//pkg/roachpb",
         "//pkg/rpc",
         "//pkg/security/securityassets",

--- a/pkg/ccl/multiregionccl/multiregion_test.go
+++ b/pkg/ccl/multiregionccl/multiregion_test.go
@@ -6,14 +6,23 @@
 package multiregionccl_test
 
 import (
+	"context"
 	"testing"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/ccl"
 	"github.com/cockroachdb/cockroach/pkg/ccl/multiregionccl/multiregionccltestutils"
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/closedts"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/closedts/ctpb"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 )
 
@@ -149,4 +158,105 @@ func TestGlobalReadsAfterEnterpriseDisabled(t *testing.T) {
 	// Can unset global_reads with enterprise license disabled.
 	_, err = sqlDB.Exec(`ALTER TABLE t2 CONFIGURE ZONE USING global_reads = false`)
 	require.NoError(t, err)
+}
+
+// This test verifies closed timestamp policy behavior with and without the
+// auto-tuning. With the auto-tuning enabled, we expect latency-based policies
+// on global tables. Without it, no latency-based policies should exist.
+func TestReplicaClosedTSPolicyWithPolicyRefresher(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+	st := cluster.MakeTestingClusterSettings()
+
+	// Helper function to check if a policy is a newly introduced latency-based policy.
+	isLatencyBasedPolicy := func(policy ctpb.RangeClosedTimestampPolicy) bool {
+		return policy >= ctpb.LEAD_FOR_GLOBAL_READS_LATENCY_LESS_THAN_20MS &&
+			policy <= ctpb.LEAD_FOR_GLOBAL_READS_LATENCY_EQUAL_OR_GREATER_THAN_300MS
+	}
+
+	// Set small intervals for faster testing.
+	closedts.LeadForGlobalReadsAutoTuneEnabled.Override(ctx, &st.SV, true)
+	closedts.RangeClosedTimestampPolicyRefreshInterval.Override(ctx, &st.SV, 5*time.Millisecond)
+	closedts.RangeClosedTimestampPolicyLatencyRefreshInterval.Override(ctx, &st.SV, 5*time.Millisecond)
+
+	// Create a multi-region cluster with manual replication.
+	numServers := 3
+	tc, sqlDB, cleanup := multiregionccltestutils.TestingCreateMultiRegionCluster(
+		t, numServers, base.TestingKnobs{}, multiregionccltestutils.WithReplicationMode(base.ReplicationManual),
+		multiregionccltestutils.WithSettings(st),
+	)
+	defer cleanup()
+
+	// Create a multi-region database and global table.
+	_, err := sqlDB.Exec(`CREATE DATABASE t PRIMARY REGION "us-east1" REGIONS "us-east2", "us-east3"`)
+	require.NoError(t, err)
+	_, err = sqlDB.Exec(`CREATE TABLE t.test_table (k INT PRIMARY KEY) LOCALITY GLOBAL`)
+	require.NoError(t, err)
+
+	// Look up the table ID and get its key prefix.
+	var tableID uint32
+	err = sqlDB.QueryRow(`SELECT id from system.namespace WHERE name='test_table'`).Scan(&tableID)
+	require.NoError(t, err)
+	tablePrefix := keys.MustAddr(keys.SystemSQLCodec.TablePrefix(tableID))
+	// Split the range at the table prefix and replicate it across all nodes.
+	tc.SplitRangeOrFatal(t, tablePrefix.AsRawKey())
+	tc.AddVotersOrFatal(t, tablePrefix.AsRawKey(), tc.Target(1), tc.Target(2))
+
+	// Get the store and replica for testing.
+	store := tc.GetFirstStoreFromServer(t, 0)
+	replica := store.LookupReplica(roachpb.RKey(tablePrefix.AsRawKey()))
+	require.NotNil(t, replica)
+
+	// Wait for the closed timestamp policies to stabilize and verify the
+	// expected behavior.
+	testutils.SucceedsSoon(t, func() error {
+		snapshot := store.GetStoreConfig().ClosedTimestampSender.GetSnapshot()
+		if len(snapshot.ClosedTimestamps) != int(ctpb.MAX_CLOSED_TIMESTAMP_POLICY) {
+			return errors.Errorf("expected %d closed timestamps, got %d",
+				ctpb.MAX_CLOSED_TIMESTAMP_POLICY, len(snapshot.ClosedTimestamps))
+		}
+
+		// Ensure there are ranges to check.
+		if len(snapshot.AddedOrUpdated) == 0 {
+			return errors.Errorf("no ranges")
+		}
+
+		// With policy refresher enabled: expect to find latency-based policy.
+		for _, policy := range snapshot.AddedOrUpdated {
+			if policy.RangeID != replica.GetRangeID() {
+				continue
+			}
+			if isLatencyBasedPolicy(policy.Policy) {
+				return nil
+			}
+		}
+		return errors.Errorf("no ranges with latency based policy")
+	})
+
+	// Without policy refresher: expect to NOT find latency-based policy.
+	_, err = sqlDB.Exec(`SET CLUSTER SETTING kv.closed_timestamp.lead_for_global_reads_auto_tune.enabled = false`)
+	require.NoError(t, err)
+
+	// Wait for policy refresher to disable and verify no latency-based policies exist.
+	testutils.SucceedsSoon(t, func() error {
+		snapshot := store.GetStoreConfig().ClosedTimestampSender.GetSnapshot()
+		if len(snapshot.ClosedTimestamps) != int(ctpb.MAX_CLOSED_TIMESTAMP_POLICY) {
+			return errors.Errorf("expected %d closed timestamps, got %d",
+				ctpb.MAX_CLOSED_TIMESTAMP_POLICY, len(snapshot.ClosedTimestamps))
+		}
+
+		// Ensure there are ranges to check.
+		if len(snapshot.AddedOrUpdated) == 0 {
+			return errors.Errorf("no ranges")
+		}
+
+		// Verify no latency-based policies remain.
+		for _, policy := range snapshot.AddedOrUpdated {
+			if isLatencyBasedPolicy(policy.Policy) {
+				return errors.Errorf("range %d has latency based policy %s", policy.RangeID, policy.Policy)
+			}
+		}
+		return nil
+	})
 }

--- a/pkg/kv/kvserver/closedts/BUILD.bazel
+++ b/pkg/kv/kvserver/closedts/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "closedts",
     srcs = [
         "policy.go",
+        "policy_calculation.go",
         "setting.go",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/kv/kvserver/closedts",
@@ -17,7 +18,10 @@ go_library(
 
 go_test(
     name = "closedts_test",
-    srcs = ["policy_test.go"],
+    srcs = [
+        "policy_calculation_test.go",
+        "policy_test.go",
+    ],
     embed = [":closedts"],
     deps = [
         "//pkg/kv/kvserver/closedts/ctpb",

--- a/pkg/kv/kvserver/closedts/ctpb/service.proto
+++ b/pkg/kv/kvserver/closedts/ctpb/service.proto
@@ -36,10 +36,29 @@ enum RangeClosedTimestampPolicy {
   // configured to lead present time such that all followers of the range are
   // able to serve consistent, present time reads.
   //
-  // Lead policy for global reads with no locality information.
+  // Lead policy for global reads with no locality information. It uses a
+  // hardcoded network latency 150ms by default.
   LEAD_FOR_GLOBAL_READS_WITH_NO_LATENCY_INFO = 1;
+  // Lead policy for ranges with global reads policy. The following policies are
+  // selected based on max leaseholder-to-follower latency.
+  LEAD_FOR_GLOBAL_READS_LATENCY_LESS_THAN_20MS = 2;  // [0,20)ms
+  LEAD_FOR_GLOBAL_READS_LATENCY_LESS_THAN_40MS = 3;  // [20,40)ms
+  LEAD_FOR_GLOBAL_READS_LATENCY_LESS_THAN_60MS = 4;  // [40,60)ms
+  LEAD_FOR_GLOBAL_READS_LATENCY_LESS_THAN_80MS = 5;  // [60,80)ms
+  LEAD_FOR_GLOBAL_READS_LATENCY_LESS_THAN_100MS = 6;  // [80,100)ms
+  LEAD_FOR_GLOBAL_READS_LATENCY_LESS_THAN_120MS = 7;  // [100,120)ms
+  LEAD_FOR_GLOBAL_READS_LATENCY_LESS_THAN_140MS = 8;  // [120,140)ms
+  LEAD_FOR_GLOBAL_READS_LATENCY_LESS_THAN_160MS = 9;  // [140,160)ms
+  LEAD_FOR_GLOBAL_READS_LATENCY_LESS_THAN_180MS = 10; // [160,180)ms
+  LEAD_FOR_GLOBAL_READS_LATENCY_LESS_THAN_200MS = 11; // [180,200)ms
+  LEAD_FOR_GLOBAL_READS_LATENCY_LESS_THAN_220MS = 12; // [200,220)ms
+  LEAD_FOR_GLOBAL_READS_LATENCY_LESS_THAN_240MS = 13; // [220,240)ms
+  LEAD_FOR_GLOBAL_READS_LATENCY_LESS_THAN_260MS = 14; // [240,260)ms
+  LEAD_FOR_GLOBAL_READS_LATENCY_LESS_THAN_280MS = 15; // [260,280)ms
+  LEAD_FOR_GLOBAL_READS_LATENCY_LESS_THAN_300MS = 16; // [280,300)ms
+  LEAD_FOR_GLOBAL_READS_LATENCY_EQUAL_OR_GREATER_THAN_300MS = 17; // >=300ms
   // Sentinel value for slice sizing.
-  MAX_CLOSED_TIMESTAMP_POLICY = 2;
+  MAX_CLOSED_TIMESTAMP_POLICY = 18;
 }
 
 // Update contains information about (the advancement of) closed timestamps for

--- a/pkg/kv/kvserver/closedts/policy.go
+++ b/pkg/kv/kvserver/closedts/policy.go
@@ -14,6 +14,7 @@ import (
 
 const (
 	DefaultMaxNetworkRTT = 150 * time.Millisecond
+	closedTimestampPolicyBucketWidth = 20 * time.Millisecond
 )
 
 // computeLeadTimeForGlobalReads calculates how far ahead of the current time a
@@ -108,17 +109,18 @@ func TargetForPolicy(
 	policy ctpb.RangeClosedTimestampPolicy,
 ) hlc.Timestamp {
 	var targetOffsetTime time.Duration
-	switch policy {
-	case ctpb.LAG_BY_CLUSTER_SETTING:
+	switch {
+	case policy == ctpb.LAG_BY_CLUSTER_SETTING:
 		// Simple calculation: lag now by desired duration.
 		targetOffsetTime = -lagTargetDuration
-	case ctpb.LEAD_FOR_GLOBAL_READS_WITH_NO_LATENCY_INFO:
+	case policy >= ctpb.LEAD_FOR_GLOBAL_READS_WITH_NO_LATENCY_INFO &&
+		policy <= ctpb.LEAD_FOR_GLOBAL_READS_LATENCY_EQUAL_OR_GREATER_THAN_300MS:
 		// Override entirely with cluster setting, if necessary.
 		if leadTargetOverride != 0 {
 			targetOffsetTime = leadTargetOverride
 			break
 		}
-		targetOffsetTime = computeLeadTimeForGlobalReads(DefaultMaxNetworkRTT,
+		targetOffsetTime = computeLeadTimeForGlobalReads(computeNetworkRTTBasedOnPolicy(policy),
 			maxClockOffset, sideTransportCloseInterval)
 	default:
 		panic("unexpected RangeClosedTimestampPolicy")

--- a/pkg/kv/kvserver/closedts/policy.go
+++ b/pkg/kv/kvserver/closedts/policy.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	DefaultMaxNetworkRTT = 150 * time.Millisecond
+	DefaultMaxNetworkRTT             = 150 * time.Millisecond
 	closedTimestampPolicyBucketWidth = 20 * time.Millisecond
 )
 

--- a/pkg/kv/kvserver/closedts/policy_calculation.go
+++ b/pkg/kv/kvserver/closedts/policy_calculation.go
@@ -1,0 +1,31 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package closedts
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/closedts/ctpb"
+)
+
+// computeNetworkRTTBasedOnPolicy converts a closed timestamp policy to an estimated
+// network RTT.
+func computeNetworkRTTBasedOnPolicy(policy ctpb.RangeClosedTimestampPolicy) time.Duration {
+	switch {
+	case policy == ctpb.LEAD_FOR_GLOBAL_READS_WITH_NO_LATENCY_INFO:
+		// If no latency info is available, return the default max RTT.
+		return DefaultMaxNetworkRTT
+	case policy >= ctpb.LEAD_FOR_GLOBAL_READS_LATENCY_LESS_THAN_20MS &&
+		policy <= ctpb.LEAD_FOR_GLOBAL_READS_LATENCY_EQUAL_OR_GREATER_THAN_300MS:
+		// For known latency buckets, we return the midpoint RTT for the bucket.
+		// The midpointRTT for bucket N is (N+0.5)*interval.
+		bucket := int(policy) - int(ctpb.LEAD_FOR_GLOBAL_READS_WITH_NO_LATENCY_INFO) - 1
+		return time.Duration((float64(bucket) + 0.5) * float64(closedTimestampPolicyBucketWidth.Nanoseconds()))
+	default:
+		panic(fmt.Sprintf("unknown closed timestamp policy: %s", policy))
+	}
+}

--- a/pkg/kv/kvserver/closedts/policy_calculation.go
+++ b/pkg/kv/kvserver/closedts/policy_calculation.go
@@ -7,10 +7,28 @@ package closedts
 
 import (
 	"fmt"
+	"math"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/closedts/ctpb"
 )
+
+// FindBucketBasedOnNetworkRTT maps a network RTT to a closed timestamp policy
+// bucket.
+func FindBucketBasedOnNetworkRTT(networkRTT time.Duration) ctpb.RangeClosedTimestampPolicy {
+	// If maxLatency is negative (i.e. no peer latency is provided), return
+	// LEAD_FOR_GLOBAL_READS_WITH_NO_LATENCY_INFO
+	if networkRTT < 0 {
+		return ctpb.LEAD_FOR_GLOBAL_READS_WITH_NO_LATENCY_INFO
+	}
+	if networkRTT >= 300*time.Millisecond {
+		return ctpb.LEAD_FOR_GLOBAL_READS_LATENCY_EQUAL_OR_GREATER_THAN_300MS
+	}
+	// Divide RTT by policy interval, add 1 for zero-based indexing, and offset by
+	// the base policy enum value.
+	bucketNum := int32(math.Floor(float64(networkRTT)/float64(closedTimestampPolicyBucketWidth))) + 1
+	return ctpb.RangeClosedTimestampPolicy(bucketNum + int32(ctpb.LEAD_FOR_GLOBAL_READS_WITH_NO_LATENCY_INFO))
+}
 
 // computeNetworkRTTBasedOnPolicy converts a closed timestamp policy to an estimated
 // network RTT.

--- a/pkg/kv/kvserver/closedts/policy_calculation_test.go
+++ b/pkg/kv/kvserver/closedts/policy_calculation_test.go
@@ -354,6 +354,12 @@ func TestNetworkRTTAndPolicyCalculations(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
+			// Test RTT -> Policy conversion.
+			policy := FindBucketBasedOnNetworkRTT(tc.networkRTT)
+			require.Equal(t, tc.expectedPolicy, policy,
+				"expected policy %v for RTT %v, got %v",
+				tc.expectedPolicy, tc.networkRTT, policy)
+
 			// Test Policy -> RTT conversion.
 			rtt := computeNetworkRTTBasedOnPolicy(policy)
 			require.Equal(t, tc.expectedRTT, rtt,

--- a/pkg/kv/kvserver/closedts/policy_calculation_test.go
+++ b/pkg/kv/kvserver/closedts/policy_calculation_test.go
@@ -1,0 +1,364 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package closedts
+
+import (
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/closedts/ctpb"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/stretchr/testify/require"
+)
+
+// TestNetworkRTTAndPolicyCalculations tests the conversion between network
+// RTT and closed timestamp policy.
+func TestNetworkRTTAndPolicyCalculations(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	testCases := []struct {
+		name           string
+		networkRTT     time.Duration
+		expectedPolicy ctpb.RangeClosedTimestampPolicy
+		expectedRTT    time.Duration
+	}{
+		{
+			name:           "negative latency",
+			networkRTT:     -10 * time.Millisecond,
+			expectedPolicy: ctpb.LEAD_FOR_GLOBAL_READS_WITH_NO_LATENCY_INFO,
+			expectedRTT:    DefaultMaxNetworkRTT, // default RTT for no latency info
+		},
+		{
+			name:           "negative latency",
+			networkRTT:     -50 * time.Millisecond,
+			expectedPolicy: ctpb.LEAD_FOR_GLOBAL_READS_WITH_NO_LATENCY_INFO,
+			expectedRTT:    DefaultMaxNetworkRTT, // default RTT for no latency info
+		},
+		// 0-20ms bucket
+		{
+			name:           "zero latency",
+			networkRTT:     0,
+			expectedPolicy: ctpb.LEAD_FOR_GLOBAL_READS_LATENCY_LESS_THAN_20MS,
+			expectedRTT:    10 * time.Millisecond,
+		},
+		{
+			name:           "0-20ms bucket low",
+			networkRTT:     1 * time.Millisecond,
+			expectedPolicy: ctpb.LEAD_FOR_GLOBAL_READS_LATENCY_LESS_THAN_20MS,
+			expectedRTT:    10 * time.Millisecond,
+		},
+		{
+			name:           "0-20ms bucket mid",
+			networkRTT:     10 * time.Millisecond,
+			expectedPolicy: ctpb.LEAD_FOR_GLOBAL_READS_LATENCY_LESS_THAN_20MS,
+			expectedRTT:    10 * time.Millisecond,
+		},
+		{
+			name: "high-end bucket boundary",
+			// 19.999999999ms in nanoseconds
+			networkRTT:     19*time.Millisecond + 999*time.Microsecond,
+			expectedPolicy: ctpb.LEAD_FOR_GLOBAL_READS_LATENCY_LESS_THAN_20MS,
+			expectedRTT:    10 * time.Millisecond,
+		},
+		// 20-40ms bucket
+		{
+			name:           "20-40ms bucket low",
+			networkRTT:     20 * time.Millisecond,
+			expectedPolicy: ctpb.LEAD_FOR_GLOBAL_READS_LATENCY_LESS_THAN_40MS,
+			expectedRTT:    30 * time.Millisecond,
+		},
+		{
+			name:           "20-40ms bucket mid",
+			networkRTT:     30 * time.Millisecond,
+			expectedPolicy: ctpb.LEAD_FOR_GLOBAL_READS_LATENCY_LESS_THAN_40MS,
+			expectedRTT:    30 * time.Millisecond,
+		},
+		{
+			name:           "20-40ms bucket high",
+			networkRTT:     39 * time.Millisecond,
+			expectedPolicy: ctpb.LEAD_FOR_GLOBAL_READS_LATENCY_LESS_THAN_40MS,
+			expectedRTT:    30 * time.Millisecond,
+		},
+		// 40-60ms bucket
+		{
+			name:           "40-60ms bucket low",
+			networkRTT:     40 * time.Millisecond,
+			expectedPolicy: ctpb.LEAD_FOR_GLOBAL_READS_LATENCY_LESS_THAN_60MS,
+			expectedRTT:    50 * time.Millisecond,
+		},
+		{
+			name:           "40-60ms bucket mid",
+			networkRTT:     50 * time.Millisecond,
+			expectedPolicy: ctpb.LEAD_FOR_GLOBAL_READS_LATENCY_LESS_THAN_60MS,
+			expectedRTT:    50 * time.Millisecond,
+		},
+		{
+			name:           "40-60ms bucket high",
+			networkRTT:     59 * time.Millisecond,
+			expectedPolicy: ctpb.LEAD_FOR_GLOBAL_READS_LATENCY_LESS_THAN_60MS,
+			expectedRTT:    50 * time.Millisecond,
+		},
+		// 60-80ms bucket
+		{
+			name:           "60-80ms bucket low",
+			networkRTT:     60 * time.Millisecond,
+			expectedPolicy: ctpb.LEAD_FOR_GLOBAL_READS_LATENCY_LESS_THAN_80MS,
+			expectedRTT:    70 * time.Millisecond,
+		},
+		{
+			name:           "60-80ms bucket mid",
+			networkRTT:     70 * time.Millisecond,
+			expectedPolicy: ctpb.LEAD_FOR_GLOBAL_READS_LATENCY_LESS_THAN_80MS,
+			expectedRTT:    70 * time.Millisecond,
+		},
+		{
+			name:           "60-80ms bucket high",
+			networkRTT:     79 * time.Millisecond,
+			expectedPolicy: ctpb.LEAD_FOR_GLOBAL_READS_LATENCY_LESS_THAN_80MS,
+			expectedRTT:    70 * time.Millisecond,
+		},
+		// 80-100ms bucket
+		{
+			name:           "80-100ms bucket low",
+			networkRTT:     80 * time.Millisecond,
+			expectedPolicy: ctpb.LEAD_FOR_GLOBAL_READS_LATENCY_LESS_THAN_100MS,
+			expectedRTT:    90 * time.Millisecond,
+		},
+		{
+			name:           "80-100ms bucket mid",
+			networkRTT:     90 * time.Millisecond,
+			expectedPolicy: ctpb.LEAD_FOR_GLOBAL_READS_LATENCY_LESS_THAN_100MS,
+			expectedRTT:    90 * time.Millisecond,
+		},
+		{
+			name:           "80-100ms bucket high",
+			networkRTT:     99 * time.Millisecond,
+			expectedPolicy: ctpb.LEAD_FOR_GLOBAL_READS_LATENCY_LESS_THAN_100MS,
+			expectedRTT:    90 * time.Millisecond,
+		},
+		// 100-120ms bucket
+		{
+			name:           "100-120ms bucket low",
+			networkRTT:     100 * time.Millisecond,
+			expectedPolicy: ctpb.LEAD_FOR_GLOBAL_READS_LATENCY_LESS_THAN_120MS,
+			expectedRTT:    110 * time.Millisecond,
+		},
+		{
+			name:           "100-120ms bucket mid",
+			networkRTT:     110 * time.Millisecond,
+			expectedPolicy: ctpb.LEAD_FOR_GLOBAL_READS_LATENCY_LESS_THAN_120MS,
+			expectedRTT:    110 * time.Millisecond,
+		},
+		{
+			name:           "100-120ms bucket high",
+			networkRTT:     119 * time.Millisecond,
+			expectedPolicy: ctpb.LEAD_FOR_GLOBAL_READS_LATENCY_LESS_THAN_120MS,
+			expectedRTT:    110 * time.Millisecond,
+		},
+		// 120-140ms bucket
+		{
+			name:           "120-140ms bucket low",
+			networkRTT:     120 * time.Millisecond,
+			expectedPolicy: ctpb.LEAD_FOR_GLOBAL_READS_LATENCY_LESS_THAN_140MS,
+			expectedRTT:    130 * time.Millisecond,
+		},
+		{
+			name:           "120-140ms bucket mid",
+			networkRTT:     130 * time.Millisecond,
+			expectedPolicy: ctpb.LEAD_FOR_GLOBAL_READS_LATENCY_LESS_THAN_140MS,
+			expectedRTT:    130 * time.Millisecond,
+		},
+		{
+			name:           "120-140ms bucket high",
+			networkRTT:     139 * time.Millisecond,
+			expectedPolicy: ctpb.LEAD_FOR_GLOBAL_READS_LATENCY_LESS_THAN_140MS,
+			expectedRTT:    130 * time.Millisecond,
+		},
+		// 140-160ms bucket
+		{
+			name:           "140-160ms bucket low",
+			networkRTT:     140 * time.Millisecond,
+			expectedPolicy: ctpb.LEAD_FOR_GLOBAL_READS_LATENCY_LESS_THAN_160MS,
+			expectedRTT:    150 * time.Millisecond,
+		},
+		{
+			name:           "140-160ms bucket mid",
+			networkRTT:     150 * time.Millisecond,
+			expectedPolicy: ctpb.LEAD_FOR_GLOBAL_READS_LATENCY_LESS_THAN_160MS,
+			expectedRTT:    150 * time.Millisecond,
+		},
+		{
+			name:           "140-160ms bucket high",
+			networkRTT:     159 * time.Millisecond,
+			expectedPolicy: ctpb.LEAD_FOR_GLOBAL_READS_LATENCY_LESS_THAN_160MS,
+			expectedRTT:    150 * time.Millisecond,
+		},
+		// 160-180ms bucket
+		{
+			name:           "160-180ms bucket low",
+			networkRTT:     160 * time.Millisecond,
+			expectedPolicy: ctpb.LEAD_FOR_GLOBAL_READS_LATENCY_LESS_THAN_180MS,
+			expectedRTT:    170 * time.Millisecond,
+		},
+		{
+			name:           "160-180ms bucket mid",
+			networkRTT:     170 * time.Millisecond,
+			expectedPolicy: ctpb.LEAD_FOR_GLOBAL_READS_LATENCY_LESS_THAN_180MS,
+			expectedRTT:    170 * time.Millisecond,
+		},
+		{
+			name:           "160-180ms bucket high",
+			networkRTT:     179 * time.Millisecond,
+			expectedPolicy: ctpb.LEAD_FOR_GLOBAL_READS_LATENCY_LESS_THAN_180MS,
+			expectedRTT:    170 * time.Millisecond,
+		},
+		// 180-200ms bucket
+		{
+			name:           "180-200ms bucket low",
+			networkRTT:     180 * time.Millisecond,
+			expectedPolicy: ctpb.LEAD_FOR_GLOBAL_READS_LATENCY_LESS_THAN_200MS,
+			expectedRTT:    190 * time.Millisecond,
+		},
+		{
+			name:           "180-200ms bucket mid",
+			networkRTT:     190 * time.Millisecond,
+			expectedPolicy: ctpb.LEAD_FOR_GLOBAL_READS_LATENCY_LESS_THAN_200MS,
+			expectedRTT:    190 * time.Millisecond,
+		},
+		{
+			name:           "180-200ms bucket high",
+			networkRTT:     199 * time.Millisecond,
+			expectedPolicy: ctpb.LEAD_FOR_GLOBAL_READS_LATENCY_LESS_THAN_200MS,
+			expectedRTT:    190 * time.Millisecond,
+		},
+		// 200-220ms bucket
+		{
+			name:           "200-220ms bucket low",
+			networkRTT:     200 * time.Millisecond,
+			expectedPolicy: ctpb.LEAD_FOR_GLOBAL_READS_LATENCY_LESS_THAN_220MS,
+			expectedRTT:    210 * time.Millisecond,
+		},
+		{
+			name:           "200-220ms bucket mid",
+			networkRTT:     210 * time.Millisecond,
+			expectedPolicy: ctpb.LEAD_FOR_GLOBAL_READS_LATENCY_LESS_THAN_220MS,
+			expectedRTT:    210 * time.Millisecond,
+		},
+		{
+			name:           "200-220ms bucket high",
+			networkRTT:     219 * time.Millisecond,
+			expectedPolicy: ctpb.LEAD_FOR_GLOBAL_READS_LATENCY_LESS_THAN_220MS,
+			expectedRTT:    210 * time.Millisecond,
+		},
+		// 220-240ms bucket
+		{
+			name:           "220-240ms bucket low",
+			networkRTT:     220 * time.Millisecond,
+			expectedPolicy: ctpb.LEAD_FOR_GLOBAL_READS_LATENCY_LESS_THAN_240MS,
+			expectedRTT:    230 * time.Millisecond,
+		},
+		{
+			name:           "220-240ms bucket mid",
+			networkRTT:     230 * time.Millisecond,
+			expectedPolicy: ctpb.LEAD_FOR_GLOBAL_READS_LATENCY_LESS_THAN_240MS,
+			expectedRTT:    230 * time.Millisecond,
+		},
+		{
+			name:           "220-240ms bucket high",
+			networkRTT:     239 * time.Millisecond,
+			expectedPolicy: ctpb.LEAD_FOR_GLOBAL_READS_LATENCY_LESS_THAN_240MS,
+			expectedRTT:    230 * time.Millisecond,
+		},
+		// 240-260ms bucket
+		{
+			name:           "240-260ms bucket low",
+			networkRTT:     240 * time.Millisecond,
+			expectedPolicy: ctpb.LEAD_FOR_GLOBAL_READS_LATENCY_LESS_THAN_260MS,
+			expectedRTT:    250 * time.Millisecond,
+		},
+		{
+			name:           "240-260ms bucket mid",
+			networkRTT:     250 * time.Millisecond,
+			expectedPolicy: ctpb.LEAD_FOR_GLOBAL_READS_LATENCY_LESS_THAN_260MS,
+			expectedRTT:    250 * time.Millisecond,
+		},
+		{
+			name:           "240-260ms bucket high",
+			networkRTT:     259 * time.Millisecond,
+			expectedPolicy: ctpb.LEAD_FOR_GLOBAL_READS_LATENCY_LESS_THAN_260MS,
+			expectedRTT:    250 * time.Millisecond,
+		},
+		// 260-280ms bucket
+		{
+			name:           "260-280ms bucket low",
+			networkRTT:     260 * time.Millisecond,
+			expectedPolicy: ctpb.LEAD_FOR_GLOBAL_READS_LATENCY_LESS_THAN_280MS,
+			expectedRTT:    270 * time.Millisecond,
+		},
+		{
+			name:           "260-280ms bucket mid",
+			networkRTT:     270 * time.Millisecond,
+			expectedPolicy: ctpb.LEAD_FOR_GLOBAL_READS_LATENCY_LESS_THAN_280MS,
+			expectedRTT:    270 * time.Millisecond,
+		},
+		{
+			name:           "260-280ms bucket high",
+			networkRTT:     279 * time.Millisecond,
+			expectedPolicy: ctpb.LEAD_FOR_GLOBAL_READS_LATENCY_LESS_THAN_280MS,
+			expectedRTT:    270 * time.Millisecond,
+		},
+		// 280-300ms bucket
+		{
+			name:           "280-300ms bucket low",
+			networkRTT:     280 * time.Millisecond,
+			expectedPolicy: ctpb.LEAD_FOR_GLOBAL_READS_LATENCY_LESS_THAN_300MS,
+			expectedRTT:    290 * time.Millisecond,
+		},
+		{
+			name:           "280-300ms bucket mid",
+			networkRTT:     290 * time.Millisecond,
+			expectedPolicy: ctpb.LEAD_FOR_GLOBAL_READS_LATENCY_LESS_THAN_300MS,
+			expectedRTT:    290 * time.Millisecond,
+		},
+		{
+			name:           "just below 300ms",
+			networkRTT:     299 * time.Millisecond,
+			expectedPolicy: ctpb.LEAD_FOR_GLOBAL_READS_LATENCY_LESS_THAN_300MS,
+			expectedRTT:    290 * time.Millisecond,
+		},
+		// >=300ms bucket
+		{
+			name:           "exactly 300ms",
+			networkRTT:     300 * time.Millisecond,
+			expectedPolicy: ctpb.LEAD_FOR_GLOBAL_READS_LATENCY_EQUAL_OR_GREATER_THAN_300MS,
+			expectedRTT:    310 * time.Millisecond,
+		},
+		{
+			name:           ">=300ms bucket mid",
+			networkRTT:     350 * time.Millisecond,
+			expectedPolicy: ctpb.LEAD_FOR_GLOBAL_READS_LATENCY_EQUAL_OR_GREATER_THAN_300MS,
+			expectedRTT:    310 * time.Millisecond,
+		},
+		{
+			name:           ">=300ms bucket high",
+			networkRTT:     400 * time.Millisecond,
+			expectedPolicy: ctpb.LEAD_FOR_GLOBAL_READS_LATENCY_EQUAL_OR_GREATER_THAN_300MS,
+			expectedRTT:    310 * time.Millisecond,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Test Policy -> RTT conversion.
+			rtt := computeNetworkRTTBasedOnPolicy(policy)
+			require.Equal(t, tc.expectedRTT, rtt,
+				"expected RTT %v for policy %v, got %v",
+				tc.expectedRTT, policy, rtt)
+		})
+	}
+}

--- a/pkg/kv/kvserver/closedts/sidetransport/BUILD.bazel
+++ b/pkg/kv/kvserver/closedts/sidetransport/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/base",
+        "//pkg/clusterversion",
         "//pkg/kv/kvpb",
         "//pkg/kv/kvserver/closedts",
         "//pkg/kv/kvserver/closedts/ctpb",
@@ -45,6 +46,7 @@ go_test(
         "//pkg/kv/kvpb",
         "//pkg/kv/kvserver/closedts",
         "//pkg/kv/kvserver/closedts/ctpb",
+        "//pkg/kv/kvserver/closedts/policyrefresher",
         "//pkg/roachpb",
         "//pkg/rpc",
         "//pkg/settings/cluster",

--- a/pkg/kv/kvserver/closedts/sidetransport/sender.go
+++ b/pkg/kv/kvserver/closedts/sidetransport/sender.go
@@ -18,6 +18,7 @@ import (
 	"sync/atomic"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/closedts"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/closedts/ctpb"
@@ -306,6 +307,17 @@ func (s *Sender) UnregisterLeaseholder(
 	}
 }
 
+// maxClosedTimestampPolicy returns the distinct number of closed timestamp
+// policies for which the side transport should send updates.
+func (s *Sender) maxClosedTimestampPolicy() int {
+	if s.st.Version.IsActive(context.TODO(), clusterversion.V25_2) {
+		return int(ctpb.MAX_CLOSED_TIMESTAMP_POLICY)
+	}
+	// If the cluster is not fully upgraded, only look at closed timestamps
+	// policies without considering locality info.
+	return int(roachpb.MAX_CLOSED_TIMESTAMP_POLICY)
+}
+
 func (s *Sender) publish(ctx context.Context) hlc.ClockTimestamp {
 	s.trackedMu.Lock()
 	defer s.trackedMu.Unlock()
@@ -314,7 +326,7 @@ func (s *Sender) publish(ctx context.Context) hlc.ClockTimestamp {
 	// TODO(wenyihu6): a cluster version check is needed here once we add new
 	// policies to ctpb.RangeClosedTimestampPolicies that do not have a
 	// corresponding roachpb.RangeClosedTimestampPolicy.
-	numPolicies := int(roachpb.MAX_CLOSED_TIMESTAMP_POLICY)
+	numPolicies := s.maxClosedTimestampPolicy()
 	s.trackedMu.lastClosed = make(map[ctpb.RangeClosedTimestampPolicy]hlc.Timestamp, numPolicies)
 	msg := &ctpb.Update{
 		NodeID:           s.nodeID,

--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/allocator/allocatorimpl"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/allocator/plan"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/batcheval"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/closedts"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/closedts/ctpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/gc"
@@ -1338,11 +1339,8 @@ func (r *Replica) closedTimestampPolicyRLocked() ctpb.RangeClosedTimestampPolicy
 }
 
 // RefreshPolicy updates the replica's cached closed timestamp policy based on
-// its span configuration. Note that the given map can be nil.
-//
-// TODO(wenyihu6): update this function to consult the supplied map and
-// clarify what happens when the map is nil
-func (r *Replica) RefreshPolicy(_ map[roachpb.NodeID]time.Duration) {
+// span configurations and provided node latencies.
+func (r *Replica) RefreshPolicy(latencies map[roachpb.NodeID]time.Duration) {
 	policy := func() ctpb.RangeClosedTimestampPolicy {
 		desc, conf := r.DescAndSpanConfig()
 		// The node liveness range ignores zone configs and always uses a
@@ -1356,7 +1354,26 @@ func (r *Replica) RefreshPolicy(_ map[roachpb.NodeID]time.Duration) {
 		if !conf.GlobalReads {
 			return ctpb.LAG_BY_CLUSTER_SETTING
 		}
-		return ctpb.LEAD_FOR_GLOBAL_READS_WITH_NO_LATENCY_INFO
+		// If the provided map is nil, the policy will be
+		// LEAD_FOR_GLOBAL_READS_WITH_NO_LATENCY_INFO. The latency will be hardcoded
+		// to closedts.DefaultMaxNetworkRTT in closed timestamp calculation.
+		if latencies == nil {
+			return ctpb.LEAD_FOR_GLOBAL_READS_WITH_NO_LATENCY_INFO
+		}
+
+		// For ranges serving global reads, determine the maximum
+		// leaseholder-to-peer replica using the provided map and set an appropriate
+		// policy bucket. This then controls how far in the future timestamps will
+		// be closed for the range.
+		maxLatency := time.Duration(-1)
+		for _, peer := range r.shMu.state.Desc.InternalReplicas {
+			peerLatency := closedts.DefaultMaxNetworkRTT
+			if latency, ok := latencies[peer.NodeID]; ok {
+				peerLatency = latency
+			}
+			maxLatency = max(maxLatency, peerLatency)
+		}
+		return closedts.FindBucketBasedOnNetworkRTT(maxLatency)
 	}
 	r.cachedClosedTimestampPolicy.Store(int32(policy()))
 }

--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -1310,10 +1310,11 @@ func (r *Replica) descRLocked() *roachpb.RangeDescriptor {
 func toClientClosedTsPolicy(
 	policy ctpb.RangeClosedTimestampPolicy,
 ) roachpb.RangeClosedTimestampPolicy {
-	switch policy {
-	case ctpb.LAG_BY_CLUSTER_SETTING:
+	switch {
+	case policy == ctpb.LAG_BY_CLUSTER_SETTING:
 		return roachpb.LAG_BY_CLUSTER_SETTING
-	case ctpb.LEAD_FOR_GLOBAL_READS_WITH_NO_LATENCY_INFO:
+	case policy >= ctpb.LEAD_FOR_GLOBAL_READS_WITH_NO_LATENCY_INFO &&
+		policy <= ctpb.LEAD_FOR_GLOBAL_READS_LATENCY_EQUAL_OR_GREATER_THAN_300MS:
 		return roachpb.LEAD_FOR_GLOBAL_READS
 	default:
 		panic(fmt.Sprintf("unknown policy locality %s", policy))

--- a/pkg/kv/kvserver/replica_closedts_test.go
+++ b/pkg/kv/kvserver/replica_closedts_test.go
@@ -1107,3 +1107,97 @@ func TestClosedTimestampPolicyRefreshIntervalOnLeaseTransfers(t *testing.T) {
 		return nil
 	})
 }
+
+// TestRefreshPolicy tests the RefreshPolicy method of the Replica struct. This
+// test focuses on the latency based closed timestamp policies. Other part of the
+// logic is tested above.
+func TestRefreshPolicyWithVariousLatencies(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	tc := testcluster.StartTestCluster(t, 3, base.TestClusterArgs{})
+	defer tc.Stopper().Stop(ctx)
+
+	// Create a scratch range.
+	scratchKey := tc.ScratchRange(t)
+	store := tc.GetFirstStoreFromServer(t, 0)
+	repl := store.LookupReplica(roachpb.RKey(scratchKey))
+	require.NotNil(t, repl)
+	repl.SetSpanConfig(roachpb.SpanConfig{GlobalReads: true}, roachpb.Span{Key: scratchKey})
+
+	// Define test cases with different latency scenarios.
+	testCases := []struct {
+		name           string
+		latencies      map[roachpb.NodeID]time.Duration
+		expectedPolicy ctpb.RangeClosedTimestampPolicy
+	}{
+		{
+			name: "all replicas with low latencies",
+			latencies: map[roachpb.NodeID]time.Duration{
+				tc.Target(0).NodeID: 10 * time.Millisecond,
+				tc.Target(1).NodeID: 15 * time.Millisecond,
+				tc.Target(2).NodeID: 20 * time.Millisecond,
+			},
+			expectedPolicy: closedts.FindBucketBasedOnNetworkRTT(20 * time.Millisecond),
+		},
+		{
+			name: "one replica with high latency",
+			latencies: map[roachpb.NodeID]time.Duration{
+				tc.Target(0).NodeID: 10 * time.Millisecond,
+				tc.Target(1).NodeID: 15 * time.Millisecond,
+				tc.Target(2).NodeID: 300 * time.Millisecond,
+			},
+			expectedPolicy: closedts.FindBucketBasedOnNetworkRTT(300 * time.Millisecond),
+		},
+		{
+			name: "some replicas missing",
+			latencies: map[roachpb.NodeID]time.Duration{
+				tc.Target(0).NodeID: 10 * time.Millisecond,
+				// tc.Target(1,2).NodeID is missing.
+			},
+			expectedPolicy: closedts.FindBucketBasedOnNetworkRTT(closedts.DefaultMaxNetworkRTT),
+		},
+		{
+			name:           "nil latencies",
+			latencies:      nil,
+			expectedPolicy: ctpb.LEAD_FOR_GLOBAL_READS_WITH_NO_LATENCY_INFO,
+		},
+		{
+			name: "one nil, others low",
+			latencies: map[roachpb.NodeID]time.Duration{
+				tc.Target(0).NodeID: 10 * time.Millisecond,
+				tc.Target(1).NodeID: 15 * time.Millisecond,
+				// tc.Target(2).NodeID is missing.
+			},
+			expectedPolicy: closedts.FindBucketBasedOnNetworkRTT(closedts.DefaultMaxNetworkRTT),
+		},
+		{
+			name: "two nil, one high",
+			latencies: map[roachpb.NodeID]time.Duration{
+				tc.Target(2).NodeID: 300 * time.Millisecond,
+				// tc.Target(0,1).NodeID are missing.
+			},
+			expectedPolicy: closedts.FindBucketBasedOnNetworkRTT(300 * time.Millisecond),
+		},
+		{
+			name: "two nil, one low",
+			latencies: map[roachpb.NodeID]time.Duration{
+				tc.Target(2).NodeID: 10 * time.Millisecond,
+				// tc.Target(0,1).NodeID are missing.
+			},
+			expectedPolicy: closedts.FindBucketBasedOnNetworkRTT(closedts.DefaultMaxNetworkRTT),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Refresh the policy with the current test case's latencies map.
+			repl.RefreshPolicy(tc.latencies)
+
+			// Verify the policy is set correctly.
+			actualPolicy := repl.GetCachedClosedTimestampPolicyForTesting()
+			require.Equal(t, tc.expectedPolicy, actualPolicy, "expected policy %v, got %v", tc.expectedPolicy, actualPolicy)
+		})
+	}
+}

--- a/pkg/kv/txn.go
+++ b/pkg/kv/txn.go
@@ -941,6 +941,10 @@ func (txn *Txn) DeadlineLikelySufficient() bool {
 		lagTargetDuration := closedts.TargetDuration.Get(sv)
 		leadTargetOverride := closedts.LeadForGlobalReadsOverride.Get(sv)
 		sideTransportCloseInterval := closedts.SideTransportCloseInterval.Get(sv)
+		// Pass the DefaultMaxNetworkRTT regardless of leadTargetAutoTune because we
+		// don't have a good way to estimate the network RTT here. We choose to be
+		// more conservative as this is just for an optimization if the deadline is
+		// far in the future. Missing the optimization is not a big deal.
 		return closedts.TargetForPolicy(now, maxClockOffset,
 			lagTargetDuration, leadTargetOverride, sideTransportCloseInterval,
 			ctpb.LEAD_FOR_GLOBAL_READS_WITH_NO_LATENCY_INFO).Add(int64(time.Second), 0)


### PR DESCRIPTION

**kvserver/closedts: add latency based closed timestamp policies**

This patch adds latency based closed timestamp policies to
ctpb.LatencyBasedRangeClosedTimestampPolicy.

Part of: #59680
Release note: none

---

**kvserver/closedts: auto-tune closed ts**

For global table ranges, we aim to ensure follower replicas can serve
present-time reads by calculating a target closed timestamp that leads the
current time (using the `LEAD_FOR_GLOBAL_READS` policy). The goal of this
estimation is to be confident that by the time that all follower have received
this closed timestamp, it's greater than the present time, so they can serve
reads without redirecting to the leaseholder. Note that this is an estimated
goal, not the exact lead time. It is still possible that some follower nodes are
really behind.

Calculation:

```
raft_propagation_time = max_network_rtt*1.5 + raft_overhead(20ms)
side_propagation_time = max_network_rtt*0.5 + side_transport_close_interval(200ms by default)
closed_ts_propagation = max(raft_propagation_time,side_propagation_time)
closed_ts_at_sender = now(sender’s current clock) + maxClockOffset(500ms by
default) + buffer (25ms) + closed_ts_propagation
```

Currently, `max_network_rtt` is hardcoded at 150ms, leading to a default 800ms
lead.

Problems with the current implementation:

Tuning trade-offs: A higher lead timestamp leads to high commit wait times,
which inturn impacts write latency. A lower lead timestamp may result in a
closed timestamp that lags present time, causing follower replicas to redirect,
which inturn impacts read latency.

Cluster wide setting: kv.closed_timestamp.lead_for_global_reads_override only
applies to the entire cluster, not per range. For geographically distant
replicas, a short lead time may not be enough for full application. However,
increasing the lead time cluster wide can harm write performance for replicas
that are close together and don’t require as much time to replicate.

This commit adds newly added latency based policies to the side transport
senders.

For side transport senders, nodes create a map of closed timestamps for each
policy without consulting leaseholders. Senders pass this map to leaseholders,
who decide whether to "bump" their closed timestamp and which policy to use.
Senders then send this information to receivers to opt in ranges and pick the
closed timestamps based on the policies ranges opt in.

Currently, side transport senders create only two policies, offering limited
control over closed timestamps based on range specific latencies. The new design
introduces 16 additional policies, each representing a different network latency
bucket ranges fall under. Instead of relying on a hardcoded 150ms latency for
closed timestamp calculations, ranges will now use the appropriate bucket
based on its observed network conditions.

Periodically, the policy refresher iterates over all leaseholders on a node,
updating cached closed timestamp policies based on the observed latency between
the leaseholder replica and the furthest replica. This policy is then used by
side transport and by raft side closed timestamp computation.

Instead of using the hardcoded 150ms network roundtrip latency, a more
dynamic latency would be used based on the latency based closed
timestamp policy the range holds.

kv.closed_timestamp.lead_for_global_reads_auto_tune.enabled can now be used
to auto-tune the lead time that global table ranges use to publish
close timestamps. The kv.closed_timestamp.lead_for_global_reads_override
cluster setting takes precedence over this one. If auto-tuning is disabled or
no data is observed, the system falls back to a hardcoded computed lead time.

Resolves: #59680
Release note: none
