### PR TITLE
cli: log more error context on startup

### DIFF
--- a/pkg/cli/clierror/check.go
+++ b/pkg/cli/clierror/check.go
@@ -27,6 +27,11 @@ func CheckAndMaybeLog(
 		severity = ec.GetSeverity()
 		cause = ec.Unwrap()
 	}
-	logger(context.Background(), severity, "%v", cause)
+	format := "%v"
+	// For assertions, we want to see the full stack trace.
+	if errors.HasAssertionFailure(err) {
+		format = "%+v"
+	}
+	logger(context.Background(), severity, format, cause)
 	return err
 }


### PR DESCRIPTION
When checking for CLI errors, we now use `%+v` when logging to include additional context.  For example, if the error wraps a stack, the stack trace will now be part of the log output.  This provides better debugging information, particularly for issues like #135273.

Closes #142627

Release note: none