### PR TITLE
optbuilder: disallow `ORDER BY` on jsonpath columns

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/jsonpath
+++ b/pkg/sql/logictest/testdata/logic_test/jsonpath
@@ -78,6 +78,12 @@ SELECT '$.ABC[*].DEF.GHI[*]'::JSONPATH
 ----
 $."ABC"[*]."DEF"."GHI"[*]
 
+statement error pgcode 42883 could not identify an ordering operator for type jsonpath
+SELECT '$'::JSONPATH AS col ORDER BY col DESC NULLS FIRST;
+
+statement error pgcode 42883 could not identify an ordering operator for type jsonpath
+SELECT '$'::JSONPATH ORDER BY 1 ASC;
+
 ## When we allow table creation
 
 # statement ok

--- a/pkg/sql/opt/optbuilder/orderby.go
+++ b/pkg/sql/opt/optbuilder/orderby.go
@@ -331,5 +331,8 @@ func ensureColumnOrderable(e tree.TypedExpr) {
 	switch typ.Family() {
 	case types.TSQueryFamily, types.TSVectorFamily, types.PGVectorFamily:
 		panic(unimplementedWithIssueDetailf(92165, "", "can't order by column type %s", typ.SQLString()))
+	case types.JsonpathFamily:
+		panic(pgerror.Newf(pgcode.UndefinedFunction, "could not identify an ordering operator for type jsonpath"))
+
 	}
 }


### PR DESCRIPTION
Previously, `ORDER BY` statements on jsonpath columns would be allowed, but postgres does not allow it. This fix disables this ability, and returns the same error message and code as postgres.

Epic: None
Fixes: #142600
Release note: None