### PR TITLE
changefeedccl: warn user when creating changefeed with an older cursor

### DIFF
--- a/pkg/ccl/changefeedccl/testing_knobs.go
+++ b/pkg/ccl/changefeedccl/testing_knobs.go
@@ -108,6 +108,9 @@ type TestingKnobs struct {
 
 	// WrapTelemetryLogger is used to wrap the periodic telemetry logger in tests.
 	WrapTelemetryLogger func(logger telemetryLogger) telemetryLogger
+
+	// OverrideCursorAge is used to change how old a cursor is. Returns time in nanoseconds.
+	OverrideCursorAge func() int64
 }
 
 // ModuleTestingKnobs is part of the base.ModuleTestingKnobs interface.


### PR DESCRIPTION
changefeedccl: warn user when creating changefeed
with an older cursor

Older but valid cursors can cause changefeeds to lag behind a lot.
To ensure that customers are not accidentally using a cursor that's too
old, we now provide a warning if the provided cursor is older than 5
hours. This warning would not show if the changefeed option is
initial_scan='only' as the changefeed would never lag behind with
this option.

The warning looks like:
NOTICE: the provided cursor is 7 hours old; older cursors can result in 
increased changefeed latency

Resolves #124290
Epic: CRDB-32401

Release note (general): Provide a warning when creating an enterprise
changefeed with a cursor older than 5 hours