### PR TITLE
sqlstats: move mem account Clear back to freeLocked

### DIFF
--- a/pkg/sql/sqlstats/ssmemstorage/ss_mem_storage.go
+++ b/pkg/sql/sqlstats/ssmemstorage/ss_mem_storage.go
@@ -600,14 +600,13 @@ func (s *Container) clearLocked(ctx context.Context) {
 // presumed to be no longer in use and its actual allocated memory will
 // eventually be GC'd.
 func (s *Container) Free(ctx context.Context) {
-	s.acc.Clear(ctx)
-
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	s.freeLocked(ctx)
 }
 
 func (s *Container) freeLocked(ctx context.Context) {
+	s.acc.Clear(ctx)
 	if s.uniqueServerCount != nil {
 		s.uniqueServerCount.freeByCnt(int64(len(s.mu.stmts)), int64(len(s.mu.txns)))
 	}

--- a/pkg/sql/sqlstats/ssmemstorage/ss_mem_writer_test.go
+++ b/pkg/sql/sqlstats/ssmemstorage/ss_mem_writer_test.go
@@ -7,6 +7,7 @@ package ssmemstorage
 
 import (
 	"context"
+	"math"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
@@ -74,4 +75,113 @@ func testMonitor(
 		Name:     mon.MakeMonitorName(name),
 		Settings: settings,
 	})
+}
+
+// TestContainerMemoryAccounting verifies that the memory account is properly
+// cleared after calling Clear and Free methods.
+func TestContainerMemoryAccountClearing(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	st := cluster.MakeTestingClusterSettings()
+
+	memMonitor := testMonitor(ctx, "test-mem", st)
+	memMonitor.Start(ctx, nil, mon.NewStandaloneBudget(math.MaxInt64))
+	defer memMonitor.Stop(ctx)
+
+	// Create a container with the memory monitor.
+	container := New(st, nil, memMonitor, "test-app", nil)
+
+	// Create statement keys
+	stmt1Key := appstatspb.StatementStatisticsKey{
+		Query:                    "SELECT * FROM table1",
+		ImplicitTxn:              true,
+		Database:                 "testdb",
+		TransactionFingerprintID: appstatspb.TransactionFingerprintID(100),
+	}
+	stmt1Stats := sqlstats.RecordedStmtStats{
+		FingerprintID: appstatspb.StmtFingerprintID(1),
+	}
+
+	stmt2Key := appstatspb.StatementStatisticsKey{
+		Query:                    "SELECT * FROM table2",
+		ImplicitTxn:              true,
+		Database:                 "testdb",
+		TransactionFingerprintID: appstatspb.TransactionFingerprintID(100),
+	}
+	stmt2Stats := sqlstats.RecordedStmtStats{
+		FingerprintID: appstatspb.StmtFingerprintID(2),
+	}
+
+	// Record statements to allocate memory.
+	err := container.RecordStatement(ctx, stmt1Key, stmt1Stats)
+	require.NoError(t, err)
+
+	err = container.RecordStatement(ctx, stmt2Key, stmt2Stats)
+	require.NoError(t, err)
+
+	// Record a transaction to allocate more memory.
+	txnKey := appstatspb.TransactionFingerprintID(100)
+	txnStats := sqlstats.RecordedTxnStats{}
+
+	err = container.RecordTransaction(ctx, txnKey, txnStats)
+	require.NoError(t, err)
+
+	// Verify memory is allocated
+	memUsedBefore := container.acc.Used()
+	require.Greater(t, memUsedBefore, int64(0), "Expected memory to be allocated")
+
+	// Test Clear method
+	container.Clear(ctx)
+
+	// Verify memory account is cleared after Clear().
+	memUsedAfterClear := container.acc.Used()
+	require.Equal(t, int64(0), memUsedAfterClear, "Memory account should be cleared after Clear")
+
+	// Add more statements to allocate memory again.
+	stmt3Key := appstatspb.StatementStatisticsKey{
+		Query:                    "SELECT * FROM table3",
+		ImplicitTxn:              true,
+		Database:                 "testdb",
+		TransactionFingerprintID: appstatspb.TransactionFingerprintID(100),
+	}
+	stmt3Stats := sqlstats.RecordedStmtStats{
+		FingerprintID: appstatspb.StmtFingerprintID(3),
+	}
+
+	err = container.RecordStatement(ctx, stmt3Key, stmt3Stats)
+	require.NoError(t, err)
+
+	// Verify memory is allocated again
+	memUsedAfterRealloc := container.acc.Used()
+	require.Greater(t, memUsedAfterRealloc, int64(0), "Expected memory to be allocated again")
+
+	// Ensure Free() clears the memory account.
+	container.Free(ctx)
+
+	// Verify memory account is cleared after Free().
+	memUsedAfterFree := container.acc.Used()
+	require.Equal(t, int64(0), memUsedAfterFree, "Memory account should be cleared after Free")
+
+	// Verify that the container can still be used after Free
+	// by adding more statements.
+	stmt4Key := appstatspb.StatementStatisticsKey{
+		Query:                    "SELECT * FROM table4",
+		ImplicitTxn:              true,
+		Database:                 "testdb",
+		TransactionFingerprintID: appstatspb.TransactionFingerprintID(100),
+	}
+	stmt4Stats := sqlstats.RecordedStmtStats{
+		FingerprintID: appstatspb.StmtFingerprintID(4),
+	}
+
+	err = container.RecordStatement(ctx, stmt4Key, stmt4Stats)
+	require.NoError(t, err)
+
+	// Verify memory is allocated again
+	memUsedAfterFreeThenRealloc := container.acc.Used()
+	require.Greater(t, memUsedAfterFreeThenRealloc, int64(0), "Expected memory to be allocated after Free")
+
+	container.Clear(ctx)
 }


### PR DESCRIPTION
Previously we moved the Clear on the mem account from `freeLocked` to `Free` after swapping to the conc. safe mem account. However this move was unsafe as `freeLocked` is called from `Clear`.

Release note: None
Fixes: #142734