### PR TITLE
raft: replace FirstIndex() with Compacted()

### DIFF
--- a/pkg/kv/kvserver/asim/state/impl.go
+++ b/pkg/kv/kvserver/asim/state/impl.go
@@ -1207,7 +1207,7 @@ func (s *state) RaftStatus(rangeID RangeID, storeID StoreID) *raft.Status {
 	status.Commit = 2
 	// TODO(kvoli): A replica is never behind on their raft log, this should
 	// change to enable testing this scenario where replicas fall behind. e.g.
-	// FirstIndex on all replicas will return 2.
+	// Compacted on all replicas will return 1.
 	for _, replica := range rng.replicas {
 		status.Progress[raftpb.PeerID(replica.ReplicaID())] = tracker.Progress{
 			Match: 2,

--- a/pkg/kv/kvserver/client_raft_test.go
+++ b/pkg/kv/kvserver/client_raft_test.go
@@ -841,9 +841,7 @@ func waitForTruncationForTesting(t *testing.T, r *kvserver.Replica, newFirstInde
 	testutils.SucceedsSoon(t, func() error {
 		// Flush the engine to advance durability, which triggers truncation.
 		require.NoError(t, r.Store().TODOEngine().Flush())
-		// FirstIndex has changed.
-		firstIndex := r.GetFirstIndex()
-		if firstIndex != newFirstIndex {
+		if firstIndex := r.GetFirstIndex(); firstIndex != newFirstIndex {
 			return errors.Errorf("expected firstIndex == %d, got %d", newFirstIndex, firstIndex)
 		}
 		return nil

--- a/pkg/kv/kvserver/logstore/logstore.go
+++ b/pkg/kv/kvserver/logstore/logstore.go
@@ -601,7 +601,7 @@ func (s *LogStore) ComputeSize(ctx context.Context) (int64, error) {
 
 // LoadTerm returns the term of the entry at the given index for the specified
 // range. The result is loaded from the storage engine if it's not in the cache.
-// The valid range for index is [FirstIndex-1, LastIndex].
+// The valid range for index is [Compacted, LastIndex].
 //
 // There are 3 cases for when the term is not found: (1) the index has been
 // compacted away, (2) index > LastIndex, or (3) there is a gap in the log. In
@@ -675,7 +675,7 @@ func LoadTerm(
 // entries. The size of the returned entries does not exceed maxSize, unless the
 // first entry exceeds the limit (in which case it is returned regardless).
 //
-// The valid range for lo/hi is: FirstIndex <= lo <= hi <= LastIndex+1.
+// The valid range for lo/hi is: Compacted < lo <= hi <= LastIndex+1.
 //
 // There are 3 cases for when an entry is not found: (1) the lo index has been
 // compacted away, (2) hi > LastIndex+1, or (3) there is a gap in the log. In

--- a/pkg/kv/kvserver/raft_log_queue.go
+++ b/pkg/kv/kvserver/raft_log_queue.go
@@ -274,7 +274,7 @@ func newTruncateDecision(ctx context.Context, r *Replica) (truncateDecision, err
 	// will become false and we will recompute the size -- so this cannot cause
 	// an indefinite delay in recomputation.
 	logSizeTrusted := r.shMu.raftLogSizeTrusted
-	firstIndex := r.raftFirstIndexRLocked()
+	firstIndex := r.raftCompactedIndexRLocked() + 1 // TODO(pav-kv): use "compacted" indexing
 	r.mu.RUnlock()
 	firstIndex = r.pendingLogTruncations.computePostTruncFirstIndex(firstIndex)
 

--- a/pkg/kv/kvserver/raft_log_queue_test.go
+++ b/pkg/kv/kvserver/raft_log_queue_test.go
@@ -687,7 +687,7 @@ func TestSnapshotLogTruncationConstraints(t *testing.T) {
 }
 
 // TestTruncateLog verifies that the TruncateLog command removes a
-// prefix of the raft logs (modifying FirstIndex() and making them
+// prefix of the raft logs (modifying Compacted() and making them
 // inaccessible via Entries()).
 func TestTruncateLog(t *testing.T) {
 	defer leaktest.AfterTest(t)()
@@ -909,8 +909,7 @@ func waitForTruncationForTesting(
 			require.NoError(t, r.store.TODOEngine().Flush())
 		}
 		// FirstIndex should have changed.
-		firstIndex := r.GetFirstIndex()
-		if firstIndex != newFirstIndex {
+		if firstIndex := r.GetFirstIndex(); firstIndex != newFirstIndex {
 			return errors.Errorf("expected firstIndex == %d, got %d", newFirstIndex, firstIndex)
 		}
 		// Some low-level tests also look at the raftEntryCache or sideloaded

--- a/pkg/kv/kvserver/replica_proposal_buf.go
+++ b/pkg/kv/kvserver/replica_proposal_buf.go
@@ -1273,7 +1273,7 @@ func (rp *replicaProposer) verifyLeaseRequestSafetyRLocked(
 		LocalReplicaID:     r.ReplicaID(),
 		Desc:               r.descRLocked(),
 		RaftStatus:         &raftStatus,
-		RaftFirstIndex:     r.raftFirstIndexRLocked(),
+		RaftFirstIndex:     r.raftCompactedIndexRLocked() + 1, // TODO(pav-kv): use "compacted" indexing
 		PrevLease:          prevLease,
 		PrevLeaseExpired:   !r.ownsValidLeaseRLocked(ctx, r.Clock().NowAsClockTimestamp()),
 		NextLeaseHolder:    nextLease.Replica,

--- a/pkg/kv/kvserver/replica_range_lease.go
+++ b/pkg/kv/kvserver/replica_range_lease.go
@@ -377,7 +377,7 @@ func (p *pendingLeaseRequest) InitOrJoinRequest(
 		Now:                   status.Now,
 		MinLeaseProposedTS:    p.repl.mu.minLeaseProposedTS,
 		RaftStatus:            raftStatus,
-		RaftFirstIndex:        p.repl.raftFirstIndexRLocked(),
+		RaftFirstIndex:        p.repl.raftCompactedIndexRLocked() + 1, // TODO(pav-kv): "compacted" indexing
 		PrevLease:             status.Lease,
 		PrevLeaseNodeLiveness: status.Liveness,
 		PrevLeaseExpired:      status.IsExpired(),

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -7547,6 +7547,7 @@ func TestEntries(t *testing.T) {
 	})
 }
 
+// TODO(pav-kv): this test belongs to logstore. And requires a cleanup.
 func TestTerm(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -7587,7 +7588,7 @@ func TestTerm(t *testing.T) {
 		repl.mu.Lock()
 		defer repl.mu.Unlock()
 
-		firstIndex := repl.raftFirstIndexRLocked()
+		firstIndex := repl.raftCompactedIndexRLocked() + 1
 		if firstIndex != indexes[5] {
 			t.Fatalf("expected firstIndex %d to be %d", firstIndex, indexes[4])
 		}
@@ -7600,7 +7601,6 @@ func TestTerm(t *testing.T) {
 			t.Errorf("expected ErrCompacted, got %s", err)
 		}
 
-		// FirstIndex-1 should return the term of firstIndex.
 		firstIndexTerm, err := tc.repl.raftTermLocked(firstIndex)
 		if err != nil {
 			t.Errorf("expect no error, got %s", err)

--- a/pkg/raft/log.go
+++ b/pkg/raft/log.go
@@ -36,8 +36,8 @@ import (
 // This gives the application direct control on resource allocation, and
 // flexibility to do raft log IO without blocking RawNode operation.
 type LogSnapshot struct {
-	// first is the first available log index.
-	first uint64
+	// compacted is the compacted log index.
+	compacted uint64
 	// storage contains the stable log entries.
 	storage LogStorage
 	// unstable contains the unstable log entries.
@@ -353,11 +353,11 @@ func (l *raftLog) snapshot() (pb.Snapshot, error) {
 	return l.storage.Snapshot()
 }
 
-func (l *raftLog) firstIndex() uint64 {
-	if i, ok := l.unstable.maybeFirstIndex(); ok {
-		return i
+func (l *raftLog) compacted() uint64 {
+	if index, ok := l.unstable.maybeCompacted(); ok {
+		return index
 	}
-	return l.storage.Compacted() + 1 // TODO(pav-kv): use "compacted" up the stack
+	return l.storage.Compacted()
 }
 
 func (l *raftLog) lastIndex() uint64 {
@@ -445,7 +445,7 @@ func (l LogSnapshot) term(index uint64) (uint64, error) {
 		return 0, ErrUnavailable
 	} else if index >= l.unstable.prev.index {
 		return l.unstable.termAt(index), nil
-	} else if index+1 < l.first {
+	} else if index < l.compacted {
 		return 0, ErrCompacted
 	}
 
@@ -479,7 +479,7 @@ func (l *raftLog) entries(after uint64, maxSize entryEncodingSize) ([]pb.Entry, 
 
 // allEntries returns all entries in the log. For testing only.
 func (l *raftLog) allEntries() []pb.Entry {
-	ents, err := l.entries(l.firstIndex()-1, noLimit)
+	ents, err := l.entries(l.compacted(), noLimit)
 	if err == nil {
 		return ents
 	}
@@ -640,15 +640,15 @@ func (l LogSnapshot) slice(lo, hi uint64, maxSize entryEncodingSize) ([]pb.Entry
 }
 
 // mustCheckOutOfBounds checks that the (lo, hi] interval is within the bounds
-// of this raft log: l.firstIndex()-1 <= lo <= hi <= l.lastIndex().
+// of this raft log: l.compacted() <= lo <= hi <= l.lastIndex().
 func (l LogSnapshot) mustCheckOutOfBounds(lo, hi uint64) error {
 	if lo > hi {
 		l.logger.Panicf("invalid slice %d > %d", lo, hi)
 	}
-	if fi := l.first; lo+1 < fi {
+	if ci := l.compacted; lo < ci {
 		return ErrCompacted
 	} else if li := l.unstable.lastIndex(); hi > li {
-		l.logger.Panicf("slice(%d,%d] out of bound [%d,%d]", lo, hi, fi, li)
+		l.logger.Panicf("slice(%d,%d] out of bound (%d,%d]", lo, hi, ci, li)
 	}
 	return nil
 }
@@ -668,9 +668,9 @@ func (l *raftLog) zeroTermOnOutOfBounds(t uint64, err error) uint64 {
 // read from while the underlying storage is not mutated.
 func (l *raftLog) snap(storage LogStorage) LogSnapshot {
 	return LogSnapshot{
-		first:    l.firstIndex(),
-		storage:  storage,
-		unstable: l.unstable.LeadSlice,
-		logger:   l.logger,
+		compacted: l.compacted(),
+		storage:   storage,
+		unstable:  l.unstable.LeadSlice,
+		logger:    l.logger,
 	}
 }

--- a/pkg/raft/log_test.go
+++ b/pkg/raft/log_test.go
@@ -670,7 +670,7 @@ func TestLogRestore(t *testing.T) {
 	raftLog := newLog(storage, raftlogger.DiscardLogger)
 
 	require.Zero(t, len(raftLog.allEntries()))
-	require.Equal(t, index+1, raftLog.firstIndex())
+	require.Equal(t, index, raftLog.compacted())
 	require.Equal(t, index, raftLog.committed)
 	require.Equal(t, index, raftLog.unstable.prev.index)
 	require.Equal(t, term, mustTerm(raftLog.term(index)))

--- a/pkg/raft/log_unstable.go
+++ b/pkg/raft/log_unstable.go
@@ -125,11 +125,10 @@ func newUnstable(last entryID, logger raftlogger.Logger) unstable {
 	}
 }
 
-// maybeFirstIndex returns the index of the first possible entry in entries
-// if it has a snapshot.
-func (u *unstable) maybeFirstIndex() (uint64, bool) {
+// maybeCompacted returns the pending compacted index if there is a snapshot.
+func (u *unstable) maybeCompacted() (uint64, bool) {
 	if u.snapshot != nil {
-		return u.snapshot.Metadata.Index + 1, true
+		return u.snapshot.Metadata.Index, true
 	}
 	return 0, false
 }

--- a/pkg/raft/log_unstable_test.go
+++ b/pkg/raft/log_unstable_test.go
@@ -50,7 +50,7 @@ func (u *unstable) checkInvariants(t testing.TB) {
 	}
 }
 
-func TestUnstableMaybeFirstIndex(t *testing.T) {
+func TestUnstableMaybeCompacted(t *testing.T) {
 	prev4 := entryID{term: 1, index: 4}
 	snap4 := &pb.Snapshot{Metadata: pb.SnapshotMetadata{Index: 4, Term: 1}}
 	for _, tt := range []struct {
@@ -72,18 +72,18 @@ func TestUnstableMaybeFirstIndex(t *testing.T) {
 		// has snapshot
 		{
 			prev4.append(1), snap4,
-			true, 5,
+			true, 4,
 		},
 		{
 			prev4.append(), snap4,
-			true, 5,
+			true, 4,
 		},
 	} {
 		t.Run("", func(t *testing.T) {
 			u := newUnstableForTesting(tt.ls, tt.snap)
 			u.checkInvariants(t)
 
-			index, ok := u.maybeFirstIndex()
+			index, ok := u.maybeCompacted()
 			require.Equal(t, tt.wok, ok)
 			require.Equal(t, tt.windex, index)
 		})

--- a/pkg/raft/raft.go
+++ b/pkg/raft/raft.go
@@ -787,7 +787,7 @@ func (r *raft) maybeSendSnapshot(to pb.PeerID, pr *tracker.Progress) bool {
 	}
 	sindex, sterm := snapshot.Metadata.Index, snapshot.Metadata.Term
 	r.logger.Debugf("%x [firstindex: %d, commit: %d] sent snapshot[index: %d, term: %d] to %x [%s]",
-		r.id, r.raftLog.firstIndex(), r.raftLog.committed, sindex, sterm, to, pr)
+		r.id, r.raftLog.compacted()+1, r.raftLog.committed, sindex, sterm, to, pr)
 	r.becomeSnapshot(pr, sindex)
 	r.logger.Debugf("%x paused sending replication messages to %x [%s]", r.id, to, pr)
 
@@ -2081,7 +2081,7 @@ func stepLeader(r *raft, m pb.Message) error {
 				switch {
 				case pr.State == tracker.StateProbe:
 					r.becomeReplicate(pr)
-				case pr.State == tracker.StateSnapshot && pr.Match+1 >= r.raftLog.firstIndex():
+				case pr.State == tracker.StateSnapshot && pr.Match >= r.raftLog.compacted():
 					// Note that we don't take into account PendingSnapshot to
 					// enter this branch. No matter at which index a snapshot
 					// was actually applied, as long as this allows catching up

--- a/pkg/raft/raft_snap_test.go
+++ b/pkg/raft/raft_snap_test.go
@@ -45,7 +45,7 @@ func TestSendingSnapshotSetPendingSnapshot(t *testing.T) {
 
 	// force set the next of node 2, so that
 	// node 2 needs a snapshot
-	sm.trk.Progress(2).Next = sm.raftLog.firstIndex()
+	sm.trk.Progress(2).Next = sm.raftLog.compacted() + 1
 
 	sm.Step(pb.Message{From: 2, To: 1, Type: pb.MsgAppResp, Index: sm.trk.Progress(2).Next - 1, Reject: true})
 	if sm.trk.Progress(2).PendingSnapshot != 11 {

--- a/pkg/raft/raft_test.go
+++ b/pkg/raft/raft_test.go
@@ -3172,7 +3172,7 @@ func TestProvideSnap(t *testing.T) {
 	sm.becomeLeader()
 
 	// force set the next of node 2, so that node 2 needs a snapshot
-	sm.trk.Progress(2).Next = sm.raftLog.firstIndex()
+	sm.trk.Progress(2).Next = sm.raftLog.compacted() + 1
 	sm.Step(pb.Message{From: 2, To: 1, Type: pb.MsgAppResp, Index: sm.trk.Progress(2).Next - 1, Reject: true})
 
 	msgs := sm.readMessages()
@@ -3201,7 +3201,7 @@ func TestIgnoreProvidingSnap(t *testing.T) {
 
 	// force set the next of node 2, so that node 2 needs a snapshot
 	// change node 2 to be inactive, expect node 1 ignore sending snapshot to 2
-	sm.trk.Progress(2).Next = sm.raftLog.firstIndex() - 1
+	sm.trk.Progress(2).Next = sm.raftLog.compacted()
 	sm.trk.Progress(2).RecentActive = false
 
 	sm.Step(pb.Message{From: 1, To: 1, Type: pb.MsgProp, Entries: []pb.Entry{{Data: []byte("somedata")}}})

--- a/pkg/raft/rafttest/interaction_env.go
+++ b/pkg/raft/rafttest/interaction_env.go
@@ -91,7 +91,7 @@ type Storage interface {
 	raft.Storage
 	SetHardState(state pb.HardState) error
 	ApplySnapshot(pb.Snapshot) error
-	Compact(newFirstIndex uint64) error
+	Compact(index uint64) error
 	Append([]pb.Entry) error
 }
 

--- a/pkg/raft/rafttest/interaction_env_handler_add_nodes.go
+++ b/pkg/raft/rafttest/interaction_env_handler_add_nodes.go
@@ -127,12 +127,12 @@ func (env *InteractionEnv) AddNodes(n int, cfg raft.Config, snap pb.Snapshot) er
 			if err := s.ApplySnapshot(snap); err != nil {
 				return err
 			}
-			fi := s.FirstIndex()
+			ci := s.Compacted()
 			// At the time of writing and for *MemoryStorage, applying a
 			// snapshot also truncates appropriately, but this would change with
 			// other storage engines potentially.
-			if exp := snap.Metadata.Index + 1; fi != exp {
-				return fmt.Errorf("failed to establish first index %d; got %d", exp, fi)
+			if exp := snap.Metadata.Index; ci != exp {
+				return fmt.Errorf("failed to establish compacted index %d; got %d", exp, ci)
 			}
 		}
 		cfg := cfg // fork the config stub

--- a/pkg/raft/rafttest/interaction_env_handler_compact.go
+++ b/pkg/raft/rafttest/interaction_env_handler_compact.go
@@ -1,3 +1,6 @@
+// This code has been modified from its original form by The Cockroach Authors.
+// All modifications are Copyright 2025 The Cockroach Authors.
+//
 // Copyright 2019 The etcd Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -23,17 +26,16 @@ import (
 
 func (env *InteractionEnv) handleCompact(t *testing.T, d datadriven.TestData) error {
 	idx := firstAsNodeIdx(t, d)
-	newFirstIndex, err := strconv.ParseUint(d.CmdArgs[1].Key, 10, 64)
+	index, err := strconv.ParseUint(d.CmdArgs[1].Key, 10, 64)
 	if err != nil {
 		return err
 	}
-	return env.Compact(idx, newFirstIndex)
+	return env.Compact(idx, index)
 }
 
-// Compact truncates the log on the node at index idx so that the supplied new
-// first index results.
-func (env *InteractionEnv) Compact(idx int, newFirstIndex uint64) error {
-	if err := env.Nodes[idx].Compact(newFirstIndex); err != nil {
+// Compact compacts the given node's log to the supplied log index (inclusive).
+func (env *InteractionEnv) Compact(idx int, index uint64) error {
+	if err := env.Nodes[idx].Compact(index); err != nil {
 		return err
 	}
 	return env.RaftLog(idx)

--- a/pkg/raft/rafttest/interaction_env_handler_raft_log.go
+++ b/pkg/raft/rafttest/interaction_env_handler_raft_log.go
@@ -34,14 +34,15 @@ func (env *InteractionEnv) handleRaftLog(t *testing.T, d datadriven.TestData) er
 // RaftLog pretty prints the raft log to the output buffer.
 func (env *InteractionEnv) RaftLog(idx int) error {
 	s := env.Nodes[idx].Storage
-	fi, li := s.FirstIndex(), s.LastIndex()
-	if li < fi {
+	ci, li := s.Compacted(), s.LastIndex()
+	if li <= ci {
 		// TODO(tbg): this is what MemoryStorage returns, but unclear if it's
 		// the "correct" thing to do.
-		fmt.Fprintf(env.Output, "log is empty: first index=%d, last index=%d", fi, li)
+		fmt.Fprintf(env.Output, "log is empty: compacted index=%d, last index=%d", ci, li)
 		return nil
 	}
-	ents, err := s.Entries(fi, li+1, math.MaxUint64)
+	// TODO(pav-kv): convert Entries() to the (begin, end] addressing.
+	ents, err := s.Entries(ci+1, li+1, math.MaxUint64)
 	if err != nil {
 		return err
 	}

--- a/pkg/raft/rawnode_test.go
+++ b/pkg/raft/rawnode_test.go
@@ -570,11 +570,11 @@ func TestRawNodeStart(t *testing.T) {
 	}
 	bootstrap := func(storage appenderStorage, cs pb.ConfState) error {
 		require.NotEmpty(t, cs.Voters, "no voters specified")
-		fi, li := storage.FirstIndex(), storage.LastIndex()
-		require.GreaterOrEqual(t, fi, uint64(2), "FirstIndex >= 2 is prerequisite for bootstrap")
-		require.Equal(t, fi, li+1, "the log must be empty")
+		ci, li := storage.Compacted(), storage.LastIndex()
+		require.GreaterOrEqual(t, ci, uint64(1), "Compacted >= 1 is prerequisite for bootstrap")
+		require.Equal(t, ci, li, "the log must be empty")
 
-		entries, err := storage.Entries(fi, li+1, math.MaxUint64)
+		entries, err := storage.Entries(ci+1, li+1, math.MaxUint64)
 		require.NoError(t, err)
 		require.Empty(t, entries, "should not have been able to load any entries")
 
@@ -1109,7 +1109,7 @@ func benchmarkRawNodeImpl(b *testing.B, peers ...pb.PeerID) {
 		b.Fatalf("did not apply everything: %d < %d", applied, b.N)
 	}
 	b.ReportAllocs()
-	b.ReportMetric(float64(s.callStats.firstIndex)/float64(b.N), "firstIndex/op")
+	b.ReportMetric(float64(s.callStats.compacted)/float64(b.N), "compacted/op")
 	b.ReportMetric(float64(s.callStats.lastIndex)/float64(b.N), "lastIndex/op")
 	b.ReportMetric(float64(s.callStats.term)/float64(b.N), "term/op")
 	b.ReportMetric(float64(numReady)/float64(b.N), "ready/op")

--- a/pkg/raft/storage.go
+++ b/pkg/raft/storage.go
@@ -75,24 +75,24 @@ type LogStorage interface {
 	Entries(lo, hi, maxSize uint64) ([]pb.Entry, error)
 
 	// Term returns the term of the entry at the given index, which must be in the
-	// valid range: [FirstIndex()-1, LastIndex()]. The term of the entry before
-	// FirstIndex is retained for matching purposes even though the rest of that
-	// entry may not be available.
+	// valid range: [Compacted(), LastIndex()]. The term of the Compacted() entry
+	// is retained for matching purposes even though the rest of that entry is not
+	// available.
 	Term(index uint64) (uint64, error)
 	// LastIndex returns the index of the last entry in the log.
 	// TODO(pav-kv): replace this with LastEntryID() which never fails.
 	LastIndex() uint64
-	// FirstIndex returns the index of the first log entry that is possibly
-	// available via Entries. Older entries have been incorporated into the
-	// StateStorage.Snapshot.
+	// Compacted returns the index of the last compacted log entry. If storage
+	// only contains the dummy entry or initial snapshot then Compacted() returns
+	// the snapshot index.
 	//
-	// If storage only contains the dummy entry or initial snapshot then
-	// FirstIndex still returns the snapshot index + 1, yet the first log entry at
-	// this index is not available.
+	// Entries at indices <= Compacted() have been committed and incorporated into
+	// StateStorage.Snapshot, and are no longer available via Entries() calls.
+	// Note that some entries > Compacted() may have been already applied too.
 	//
-	// TODO(pav-kv): replace this with a Prev() method equivalent to LeadSlice's
-	// prev field. The log storage is just a storage-backed LeadSlice.
-	FirstIndex() uint64
+	// TODO(pav-kv): replace this with a Prev() method equivalent to LogSlice's
+	// prev field. The log storage is just a storage-backed LogSlice.
+	Compacted() uint64
 
 	// LogSnapshot returns an immutable point-in-time log storage snapshot.
 	LogSnapshot() LogStorageSnapshot
@@ -131,7 +131,7 @@ type Storage interface {
 }
 
 type inMemStorageCallStats struct {
-	initialState, firstIndex, lastIndex, entries, term, snapshot int
+	initialState, compacted, lastIndex, entries, term, snapshot int
 }
 
 // MemoryStorage implements the Storage interface backed by an in-memory slice.
@@ -211,12 +211,12 @@ func (ms *MemoryStorage) LastIndex() uint64 {
 	return ms.ls.lastIndex()
 }
 
-// FirstIndex implements the Storage interface.
-func (ms *MemoryStorage) FirstIndex() uint64 {
+// Compacted implements the Storage interface.
+func (ms *MemoryStorage) Compacted() uint64 {
 	ms.Lock()
 	defer ms.Unlock()
-	ms.callStats.firstIndex++
-	return ms.ls.prev.index + 1
+	ms.callStats.compacted++
+	return ms.ls.prev.index
 }
 
 // LogSnapshot implements the LogStorage interface.
@@ -331,7 +331,7 @@ func (ms *MemoryStorage) Append(entries []pb.Entry) error {
 func MakeLogSnapshot(ms *MemoryStorage) LogSnapshot {
 	ls := ms.ls.forward(ms.ls.lastIndex())
 	return LogSnapshot{
-		first:    ms.FirstIndex(),
+		first:    ms.Compacted() + 1, // TODO(pav-kv): use "compacted" scheme
 		storage:  ms.LogSnapshot(),
 		unstable: LeadSlice{term: ls.lastEntryID().term, LogSlice: ls},
 		logger:   raftlogger.DiscardLogger,

--- a/pkg/raft/storage.go
+++ b/pkg/raft/storage.go
@@ -331,9 +331,9 @@ func (ms *MemoryStorage) Append(entries []pb.Entry) error {
 func MakeLogSnapshot(ms *MemoryStorage) LogSnapshot {
 	ls := ms.ls.forward(ms.ls.lastIndex())
 	return LogSnapshot{
-		first:    ms.Compacted() + 1, // TODO(pav-kv): use "compacted" scheme
-		storage:  ms.LogSnapshot(),
-		unstable: LeadSlice{term: ls.lastEntryID().term, LogSlice: ls},
-		logger:   raftlogger.DiscardLogger,
+		compacted: ms.Compacted(),
+		storage:   ms.LogSnapshot(),
+		unstable:  LeadSlice{term: ls.lastEntryID().term, LogSlice: ls},
+		logger:    raftlogger.DiscardLogger,
 	}
 }

--- a/pkg/raft/storage_test.go
+++ b/pkg/raft/storage_test.go
@@ -100,11 +100,11 @@ func TestStorageLastIndex(t *testing.T) {
 	require.Equal(t, uint64(6), s.LastIndex())
 }
 
-func TestStorageFirstIndex(t *testing.T) {
+func TestStorageCompacted(t *testing.T) {
 	s := &MemoryStorage{ls: entryID{index: 3, term: 3}.append(4, 5).LogSlice}
-	require.Equal(t, uint64(4), s.FirstIndex())
+	require.Equal(t, uint64(3), s.Compacted())
 	require.NoError(t, s.Compact(4))
-	require.Equal(t, uint64(5), s.FirstIndex())
+	require.Equal(t, uint64(4), s.Compacted())
 }
 
 func TestStorageCompact(t *testing.T) {
@@ -236,9 +236,9 @@ func TestStorageLogSnapshot(t *testing.T) {
 	snap := s.LogSnapshot()
 	// The snapshot must be immutable regardless of mutations on the storage.
 	check := func() {
-		require.Equal(t, uint64(1), snap.FirstIndex())
+		require.Equal(t, uint64(0), snap.Compacted())
 		require.Equal(t, uint64(3), snap.LastIndex())
-		entries, err := snap.Entries(snap.FirstIndex(), snap.LastIndex()+1, math.MaxUint64)
+		entries, err := snap.Entries(1, 4, math.MaxUint64)
 		require.NoError(t, err)
 		require.Equal(t, index(1).terms(1, 2, 3), entries)
 	}

--- a/pkg/raft/testdata/snapshot_sent_and_leadership_change.txt
+++ b/pkg/raft/testdata/snapshot_sent_and_leadership_change.txt
@@ -152,7 +152,7 @@ stabilize 3
 # 3 has applied the snapshot
 raft-log 3
 ----
-log is empty: first index=16, last index=15
+log is empty: compacted index=15, last index=15
 
 # Do compaction on 2
 compact 2 15

--- a/pkg/raft/testdata/snapshot_succeed_via_app_resp_behind.txt
+++ b/pkg/raft/testdata/snapshot_succeed_via_app_resp_behind.txt
@@ -54,7 +54,7 @@ status 1
 
 raft-log 3
 ----
-log is empty: first index=6, last index=5
+log is empty: compacted index=5, last index=5
 
 # Send a manual snapshot from 1 to 3, which will be at index 11. This snapshot
 # does not move 3 to StateSnapshot.


### PR DESCRIPTION
The "first index" notation is error-prone, and requires `firstIndex-1` in a bunch of places, where we are never sure whether it would lead to an underflow.

It is also confusing to see `FirstIndex` > `LastIndex`, when the log is empty. One bound should be inclusive, another exclusive.

When working with raft logs, it is almost always beneficial to use the addressing scheme like `(begin, end]` rather than the other way around. The `Compacted()` index is the exclusive "begin" of a raft log.

Epic: none
Release note: none