### PR TITLE
schemachanger: ensure table zcfg validation inherits correctly

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/zone_config_inheritance
+++ b/pkg/ccl/logictestccl/testdata/logic_test/zone_config_inheritance
@@ -1,0 +1,70 @@
+# LogicTest: 5node
+
+statement ok
+CREATE DATABASE d;
+
+statement ok
+CREATE TABLE d.t (
+    i INT NOT NULL,
+    INDEX idx (i) PARTITION BY LIST (i) (
+        PARTITION p1 VALUES IN (1, 5)
+    )
+);
+
+# Ensure objects inherit from its direct parent correctly; since we are
+# exercising num_voters/num_replicas changes, we also test that validation
+# of zone configs inherits properly.
+statement error pq: could not validate zone config: num_voters cannot be greater than num_replicas
+ALTER DATABASE d CONFIGURE ZONE USING num_voters = 6;
+
+statement ok
+ALTER RANGE default CONFIGURE ZONE USING num_replicas = 7;
+
+# Database direct-inheritance checks.
+statement ok
+ALTER DATABASE d CONFIGURE ZONE USING num_voters = 6;
+
+query I
+SELECT regexp_extract(raw_config_sql, 'num_replicas = (\d+)')::INT
+FROM [SHOW ZONE CONFIGURATION FOR DATABASE d];
+----
+7
+
+statement ok
+ALTER DATABASE d CONFIGURE ZONE USING num_replicas = 7;
+
+# Table direct-inheritance checks.
+statement ok
+ALTER TABLE d.t CONFIGURE ZONE USING num_voters = 6;
+
+query I
+SELECT regexp_extract(raw_config_sql, 'num_replicas = (\d+)')::INT
+FROM [SHOW ZONE CONFIGURATION FOR TABLE d.t];
+----
+7
+
+statement ok
+ALTER TABLE d.t CONFIGURE ZONE USING num_replicas = 7;
+
+# Index direct-inheritance checks.
+statement ok
+ALTER INDEX d.t@idx CONFIGURE ZONE USING num_voters = 6;
+
+query I
+SELECT regexp_extract(raw_config_sql, 'num_replicas = (\d+)')::INT
+FROM [SHOW ZONE CONFIGURATION FOR INDEX d.t@idx];
+----
+7
+
+statement ok
+ALTER INDEX d.t@idx CONFIGURE ZONE USING num_replicas = 7;
+
+# Partition direct-inheritance checks.
+statement ok
+ALTER TABLE d.t CONFIGURE ZONE USING num_voters = 6;
+
+query I
+SELECT regexp_extract(raw_config_sql, 'num_replicas = (\d+)')::INT
+FROM [SHOW ZONE CONFIGURATION FOR PARTITION p1 OF INDEX d.t@idx];
+----
+7

--- a/pkg/ccl/logictestccl/tests/5node/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/5node/BUILD.bazel
@@ -12,7 +12,7 @@ go_test(
         "//build/toolchains:is_heavy": {"test.Pool": "heavy"},
         "//conditions:default": {"test.Pool": "large"},
     }),
-    shard_count = 5,
+    shard_count = 6,
     tags = ["cpu:3"],
     deps = [
         "//pkg/base",

--- a/pkg/ccl/logictestccl/tests/5node/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/5node/generated_test.go
@@ -109,3 +109,10 @@ func TestCCLLogic_zone(
 	defer leaktest.AfterTest(t)()
 	runCCLLogicTest(t, "zone")
 }
+
+func TestCCLLogic_zone_config_inheritance(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "zone_config_inheritance")
+}

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/configure_zone.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/configure_zone.go
@@ -173,7 +173,9 @@ func astToZoneConfigObject(b BuildCtx, n *tree.SetZoneConfig) (zoneConfigObject,
 	if tableID == catid.InvalidDescID {
 		return nil, errors.AssertionFailedf("tableID not found for table %s", tblName)
 	}
-	tzo := tableZoneConfigObj{tableID: tableID}
+	dbID := b.QueryByID(tableID).FilterNamespace().MustGetOneElement().DatabaseID
+	dbzco := databaseZoneConfigObj{databaseID: dbID}
+	tzo := tableZoneConfigObj{tableID: tableID, databaseZoneConfigObj: dbzco}
 
 	// We are a table object.
 	if zs.TargetsTable() && !zs.TargetsIndex() && !zs.TargetsPartition() {


### PR DESCRIPTION
This patch ensures that we don't skip inheriting from the database during a table-level zone config validation by populating the database parent properly.

Epic: none
Fixes: #142283

Release note (bug fix): Fixed a bug where during validation of a table-level zone config, inherited values were incorrectly populated from the default range instead of from the parent database.