### PR TITLE
sql: avoid merging keys unnecessarily during index backfills

### DIFF
--- a/pkg/sql/backfill/mvcc_index_merger.go
+++ b/pkg/sql/backfill/mvcc_index_merger.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/admission/admissionpb"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/intsets"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/errors"
@@ -70,7 +71,11 @@ var indexBackfillMergeNumWorkers = settings.RegisterIntSetting(
 type keyBatch struct {
 	sourceKeys    []roachpb.Key
 	processedKeys int
-	batchSize     int
+	// batchSize the size of the current batches being used.
+	batchSize int
+	// keysToSkip is the set of keys that can be safely skipped,
+	// because we noticed a newer timestamp on them.
+	keysToSkip intsets.Fast
 }
 
 // IndexBackfillMerger is a processor that merges entries from the corresponding
@@ -345,18 +350,27 @@ func (ibm *IndexBackfillMerger) merge(
 	destPrefix := rowenc.MakeIndexKeyPrefix(codec, table.GetID(), destinationID)
 
 	batch := &keyBatch{sourceKeys: sourceKeys}
-
 	err := retryWithReducedBatchWhenAutoRetryLimitExceeded(ctx, batch,
 		func(ctx context.Context, keys []roachpb.Key) error {
 			return ibm.flowCtx.Cfg.DB.Txn(ctx, func(
 				ctx context.Context, txn isql.Txn,
-			) error {
+			) (err error) {
+				if knobs, ok := ibm.flowCtx.Cfg.TestingKnobs.IndexBackfillMergerTestingKnobs.(*IndexBackfillMergerTestingKnobs); ok {
+					if knobs != nil && knobs.RunBeforeMergeTxn != nil {
+						if err := knobs.RunBeforeMergeTxn(ctx, txn.KV(), keys, batch.keysToSkip.Len()); err != nil {
+							return err
+						}
+					}
+				}
+
 				var deletedCount int
+				var keysToSkipCount int
 				txn.KV().AddCommitTrigger(func(ctx context.Context) {
 					commitTs, _ := txn.KV().CommitTimestamp()
-					log.VInfof(ctx, 2, "merged batch of %d keys (%d deletes) (span: %s) (commit timestamp: %s)",
+					log.VInfof(ctx, 2, "merged batch of %d keys (%d deletes, %d skipped) (span: %s) (commit timestamp: %s)",
 						len(keys),
 						deletedCount,
+						keysToSkipCount,
 						sourceSpan,
 						commitTs,
 					)
@@ -365,15 +379,15 @@ func (ibm *IndexBackfillMerger) merge(
 					return nil
 				}
 
-				wb, memUsedInMerge, deletedKeys, err := ibm.constructMergeBatch(
-					ctx, txn.KV(), keys, sourcePrefix, destPrefix,
+				wb, memUsedInMerge, deletedKeys, keysToSkip, err := ibm.constructMergeBatch(
+					ctx, txn.KV(), keys, sourcePrefix, destPrefix, batch,
 				)
-				if err != nil {
+				if err != nil || wb == nil {
 					return err
 				}
-
 				defer ibm.shrinkBoundAccount(ctx, memUsedInMerge)
 				deletedCount = deletedKeys
+				keysToSkipCount = keysToSkip
 				if err := txn.KV().Run(ctx, wb); err != nil {
 					return err
 				}
@@ -399,13 +413,26 @@ func (ibm *IndexBackfillMerger) constructMergeBatch(
 	sourceKeys []roachpb.Key,
 	sourcePrefix []byte,
 	destPrefix []byte,
-) (*kv.Batch, int64, int, error) {
+	batch *keyBatch,
+) (*kv.Batch, int64, int, int, error) {
+	var keysToSkip int
+	var keysAdded int
 	rb := txn.NewBatch()
 	for i := range sourceKeys {
+		if batch.isKeySkipped(i) {
+			keysToSkip++
+			continue
+		}
 		rb.Get(sourceKeys[i])
+		keysAdded++
+	}
+	// All of the keys in this batch are skipped, so nothing
+	// to fetch.
+	if keysAdded == 0 {
+		return nil, 0, 0, keysToSkip, nil
 	}
 	if err := txn.Run(ctx, rb); err != nil {
-		return nil, 0, 0, err
+		return nil, 0, 0, 0, err
 	}
 
 	// We acquire the bound account lock for the entirety of the merge batch
@@ -418,11 +445,11 @@ func (ibm *IndexBackfillMerger) constructMergeBatch(
 		// Since the source index is delete-preserving, reading the latest value for
 		// a key that has existed in the past should always return a value.
 		if rb.Results[i].Rows[0].Value == nil {
-			return nil, 0, 0, errors.AssertionFailedf("expected value to be present in temp index for key=%s", rb.Results[i].Rows[0].Key)
+			return nil, 0, 0, 0, errors.AssertionFailedf("expected value to be present in temp index for key=%s", rb.Results[i].Rows[0].Key)
 		}
 		rowMem := int64(len(rb.Results[i].Rows[0].Key)) + int64(len(rb.Results[i].Rows[0].Value.RawBytes))
 		if err := ibm.muBoundAccount.boundAccount.Grow(ctx, rowMem); err != nil {
-			return nil, 0, 0, errors.Wrap(err, "failed to allocate space to read latest keys from temp index")
+			return nil, 0, 0, 0, errors.Wrap(err, "failed to allocate space to read latest keys from temp index")
 		}
 		memUsedInMerge += rowMem
 	}
@@ -431,24 +458,36 @@ func (ibm *IndexBackfillMerger) constructMergeBatch(
 	destKey := make([]byte, len(destPrefix))
 	var deletedCount int
 	wb := txn.NewBatch()
-	for i := range rb.Results {
+	resultOffset := 0
+	for sourceOffset := range sourceKeys {
+		if batch.isKeySkipped(sourceOffset) {
+			continue
+		}
+		i := resultOffset
+		resultOffset++
 		sourceKV := &rb.Results[i].Rows[0]
 		if len(sourceKV.Key) < prefixLen {
-			return nil, 0, 0, errors.Errorf("key for index entry %v does not start with prefix %v", sourceKV, sourcePrefix)
+			return nil, 0, 0, 0, errors.Errorf("key for index entry %v does not start with prefix %v", sourceKV, sourcePrefix)
 		}
-
+		// If the timestamp we are looking at is after the merge timestamp,
+		// then no work needs to be done for this row.
+		if !sourceKV.Value.Timestamp.LessEq(ibm.spec.MergeTimestamp) {
+			batch.markKeyAsSkipped(sourceOffset)
+			keysToSkip++
+			continue
+		}
 		destKey = destKey[:0]
 		destKey = append(destKey, destPrefix...)
 		destKey = append(destKey, sourceKV.Key[prefixLen:]...)
 
 		mergedEntry, deleted, err := mergeEntry(sourceKV, destKey)
 		if err != nil {
-			return nil, 0, 0, err
+			return nil, 0, 0, 0, err
 		}
 
 		entryBytes := mergedEntryBytes(mergedEntry, deleted)
 		if err := ibm.muBoundAccount.boundAccount.Grow(ctx, entryBytes); err != nil {
-			return nil, 0, 0, errors.Wrap(err, "failed to allocate space to merge entry from temp index")
+			return nil, 0, 0, 0, errors.Wrap(err, "failed to allocate space to merge entry from temp index")
 		}
 		memUsedInMerge += entryBytes
 		if deleted {
@@ -459,7 +498,7 @@ func (ibm *IndexBackfillMerger) constructMergeBatch(
 		}
 	}
 
-	return wb, memUsedInMerge, deletedCount, nil
+	return wb, memUsedInMerge, deletedCount, keysToSkip, nil
 }
 
 func mergedEntryBytes(entry *kv.KeyValue, deleted bool) int64 {
@@ -536,6 +575,8 @@ type IndexBackfillMergerTestingKnobs struct {
 	// RunAfterScanChunk is called once after a chunk has been successfully scanned.
 	RunAfterScanChunk func()
 
+	RunBeforeMergeTxn func(ctx context.Context, txn *kv.Txn, sourceKeys []roachpb.Key, keysToSkipCount int) error
+
 	RunDuringMergeTxn func(ctx context.Context, txn *kv.Txn, startKey roachpb.Key, endKey roachpb.Key) error
 
 	// PushesProgressEveryChunk forces the process to push the merge process after
@@ -601,6 +642,16 @@ func (k *keyBatch) getKeysForNextBatch() []roachpb.Key {
 	}
 	batchEnd := min(k.processedKeys+k.batchSize, len(k.sourceKeys))
 	return k.sourceKeys[k.processedKeys:batchEnd]
+}
+
+// markKeyAsSkipped marks that a key in the batch can be skipped.
+func (k *keyBatch) markKeyAsSkipped(keyIdx int) {
+	k.keysToSkip.Add(keyIdx + k.processedKeys)
+}
+
+// isKeySkipped returns true if a key in the batch can be skipped.
+func (k *keyBatch) isKeySkipped(keyIdx int) bool {
+	return k.keysToSkip.Contains(keyIdx + k.processedKeys)
 }
 
 // setLastBatchComplete is a helper for when we successfully merged the last


### PR DESCRIPTION
Previously, index backfills merged all keys between a temporary index and the newly backfilled index. This caused unnecessary contention, as only rows written before the merge needed to be rewritten to the new primary index. This patch modifies the index merger to skip rows modified after the merge started. This reduces contention and accelerates index creation under write-heavy workloads.

Fixes: #142767

Release note (bug fix): Index backfills unnecessarily merged new data written to an index, which could lead to extra contention.