### PR TITLE
span: refactor iterator methods on span.Frontier

### DIFF
--- a/pkg/backup/restore_span_covering_test.go
+++ b/pkg/backup/restore_span_covering_test.go
@@ -176,16 +176,14 @@ func checkRestoreCovering(
 		var last roachpb.Key
 		for i, b := range backups {
 			var coveredLater bool
-			introducedSpanFrontier.Entries(func(s roachpb.Span,
-				ts hlc.Timestamp) (done spanUtils.OpResult) {
+			for s, ts := range introducedSpanFrontier.Entries() {
 				if span.Overlaps(s) {
 					if b.EndTime.Less(ts) {
 						coveredLater = true
 					}
-					return spanUtils.StopMatch
+					break
 				}
-				return spanUtils.ContinueMatch
-			})
+			}
 			if coveredLater {
 				// Skip spans that were later re-introduced. See makeSimpleImportSpans
 				// for explanation.

--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -799,14 +799,13 @@ func (ca *changeAggregator) computeTrailingMetadata(meta *execinfrapb.Changefeed
 	}
 
 	// Build out the list of frontier spans.
-	ca.frontier.Entries(func(r roachpb.Span, ts hlc.Timestamp) (done span.OpResult) {
+	for sp, ts := range ca.frontier.Entries() {
 		meta.Checkpoint = append(meta.Checkpoint,
 			execinfrapb.ChangefeedMeta_FrontierSpan{
-				Span:      r,
+				Span:      sp,
 				Timestamp: ts,
 			})
-		return span.ContinueMatch
-	})
+	}
 }
 
 // tick is the workhorse behind Next(). It retrieves the next event from
@@ -1937,17 +1936,12 @@ func frontierIsBehind(frontier hlc.Timestamp, sv *settings.Values) bool {
 	return timeutil.Since(frontier.GoTime()) > slownessThreshold(sv)
 }
 
-type behindSpanFrontier interface {
-	Frontier() hlc.Timestamp
-	PeekFrontierSpan() roachpb.Span
-}
-
 // Potentially log the most behind span in the frontier for debugging if the
 // frontier is behind
 func maybeLogBehindSpan(
 	ctx context.Context,
 	description string,
-	frontier behindSpanFrontier,
+	frontier span.Frontier,
 	frontierChanged bool,
 	sv *settings.Values,
 ) {

--- a/pkg/ccl/changefeedccl/changefeed_processors_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors_test.go
@@ -13,7 +13,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
-	"github.com/cockroachdb/cockroach/pkg/util/span"
 	"github.com/stretchr/testify/require"
 )
 
@@ -278,10 +277,9 @@ func TestSetupSpansAndFrontierWithNewSpec(t *testing.T) {
 			_, err := ca.setupSpansAndFrontier()
 			require.NoError(t, err)
 			actualFrontierSpan := checkpointSpans{}
-			ca.frontier.Entries(func(sp roachpb.Span, ts hlc.Timestamp) span.OpResult {
+			for sp, ts := range ca.frontier.Entries() {
 				actualFrontierSpan = append(actualFrontierSpan, checkpointSpan{span: sp, ts: ts})
-				return span.ContinueMatch
-			})
+			}
 
 			require.Equal(t, tc.expectedFrontierSpan, actualFrontierSpan)
 			require.Equal(t, tc.expectedFrontierTs, ca.frontier.Frontier())

--- a/pkg/ccl/changefeedccl/checkpoint/checkpoint_test.go
+++ b/pkg/ccl/changefeedccl/checkpoint/checkpoint_test.go
@@ -238,10 +238,9 @@ func TestCheckpointRestore(t *testing.T) {
 			require.NoError(t, err)
 
 			actualFrontierSpans := checkpointSpans{}
-			actualFrontier.Entries(func(sp roachpb.Span, ts hlc.Timestamp) span.OpResult {
+			for sp, ts := range actualFrontier.Entries() {
 				actualFrontierSpans = append(actualFrontierSpans, checkpointSpan{span: sp, ts: ts})
-				return span.ContinueMatch
-			})
+			}
 
 			expectedFrontierSpans := checkpointSpans{}
 			expectedFrontier, err := span.MakeFrontierAt(tc.initialHighWater, tc.trackedSpans...)
@@ -250,10 +249,9 @@ func TestCheckpointRestore(t *testing.T) {
 				_, err = expectedFrontier.Forward(s.span, s.ts)
 				require.NoError(t, err)
 			}
-			expectedFrontier.Entries(func(sp roachpb.Span, ts hlc.Timestamp) span.OpResult {
+			for sp, ts := range expectedFrontier.Entries() {
 				expectedFrontierSpans = append(expectedFrontierSpans, checkpointSpan{span: sp, ts: ts})
-				return span.ContinueMatch
-			})
+			}
 			require.Equal(t, expectedFrontierSpans, actualFrontierSpans)
 		})
 	}
@@ -318,10 +316,9 @@ func TestCheckpointMakeRestoreRoundTrip(t *testing.T) {
 				restoredFrontier, err := span.MakeFrontierAt(tc.frontier, tc.trackedSpans...)
 				require.NoError(t, err)
 				require.NoError(t, checkpoint.Restore(restoredFrontier, cp))
-				restoredFrontier.Entries(func(sp roachpb.Span, ts hlc.Timestamp) (done span.OpResult) {
+				for sp, ts := range restoredFrontier.Entries() {
 					spans = append(spans, checkpointSpan{span: sp, ts: ts})
-					return span.ContinueMatch
-				})
+				}
 				return spans
 			}()
 

--- a/pkg/ccl/changefeedccl/kvfeed/kv_feed.go
+++ b/pkg/ccl/changefeedccl/kvfeed/kv_feed.go
@@ -599,10 +599,9 @@ func (f *kvFeed) runUntilTableEvent(ctx context.Context, resumeFrontier span.Fro
 	}
 
 	var stps []kvcoord.SpanTimePair
-	resumeFrontier.Entries(func(s roachpb.Span, ts hlc.Timestamp) (done span.OpResult) {
+	for s, ts := range resumeFrontier.Entries() {
 		stps = append(stps, kvcoord.SpanTimePair{Span: s, StartAfter: ts})
-		return span.ContinueMatch
-	})
+	}
 
 	g := ctxgroup.WithContext(ctx)
 	physicalCfg := rangeFeedConfig{

--- a/pkg/ccl/changefeedccl/kvfeed/kv_feed.go
+++ b/pkg/ccl/changefeedccl/kvfeed/kv_feed.go
@@ -747,12 +747,11 @@ func copyFromSourceToDestUntilTableEvent(
 		// finding the minimum timestamp of its subspans in the frontier.
 		spanFrontier = func(sp roachpb.Span) hlc.Timestamp {
 			minTs := hlc.MaxTimestamp
-			frontier.SpanEntries(sp, func(_ roachpb.Span, ts hlc.Timestamp) (done span.OpResult) {
+			for _, ts := range frontier.SpanEntries(sp) {
 				if ts.Less(minTs) {
 					minTs = ts
 				}
-				return span.ContinueMatch
-			})
+			}
 			if minTs == hlc.MaxTimestamp {
 				return hlc.Timestamp{}
 			}

--- a/pkg/ccl/changefeedccl/kvfeed/kv_feed_test.go
+++ b/pkg/ccl/changefeedccl/kvfeed/kv_feed_test.go
@@ -782,10 +782,9 @@ func TestFrontierQuantization(t *testing.T) {
 				_, err := frontier.Forward(e.Checkpoint.Span, e.Checkpoint.ResolvedTS)
 				require.NoError(t, err)
 			}
-			frontier.Entries(func(sp roachpb.Span, ts hlc.Timestamp) span.OpResult {
+			for sp, ts := range frontier.Entries() {
 				t.Logf("span: %v, ts: %v\n", sp, ts)
-				return false
-			})
+			}
 			require.Equal(t, tc.expectedFrontierEntries, frontier.Len())
 			require.Equal(t, tc.expectedFrontier, frontier.Frontier())
 		})

--- a/pkg/ccl/changefeedccl/resolvedspan/frontier.go
+++ b/pkg/ccl/changefeedccl/resolvedspan/frontier.go
@@ -179,7 +179,7 @@ func (f *CoordinatorFrontier) All() iter.Seq[jobspb.ResolvedSpan] {
 func (f *CoordinatorFrontier) MakeCheckpoint(
 	maxBytes int64, metrics *checkpoint.Metrics,
 ) *jobspb.TimestampSpansMap {
-	return checkpoint.Make(f.Frontier(), f.Spans(), maxBytes, metrics)
+	return checkpoint.Make(f.Frontier(), f.Entries(), maxBytes, metrics)
 }
 
 // spanFrontier is a type alias to make it possible to embed and forward calls
@@ -323,7 +323,7 @@ func (f *resolvedSpanFrontier) HasLaggingSpans(sv *settings.Values) bool {
 // All returns an iterator over the resolved spans in the frontier.
 func (f *resolvedSpanFrontier) All() iter.Seq[jobspb.ResolvedSpan] {
 	return func(yield func(jobspb.ResolvedSpan) bool) {
-		for sp, ts := range f.spanFrontier.All() {
+		for sp, ts := range f.spanFrontier.Entries() {
 			var boundaryType jobspb.ResolvedSpan_BoundaryType
 			if ok, bt := f.boundary.At(ts); ok {
 				boundaryType = bt
@@ -337,11 +337,6 @@ func (f *resolvedSpanFrontier) All() iter.Seq[jobspb.ResolvedSpan] {
 			}
 		}
 	}
-}
-
-// Spans returns an iterator over the spans in the frontier.
-func (f *resolvedSpanFrontier) Spans() iter.Seq2[roachpb.Span, hlc.Timestamp] {
-	return f.spanFrontier.All()
 }
 
 // resolvedSpanBoundary encapsulates a resolved span boundary, which is

--- a/pkg/crosscluster/logical/logical_replication_job.go
+++ b/pkg/crosscluster/logical/logical_replication_job.go
@@ -798,10 +798,9 @@ func (rh *rowHandler) handleRow(ctx context.Context, row tree.Datums) error {
 	}
 
 	frontierResolvedSpans := make([]jobspb.ResolvedSpan, 0)
-	rh.frontier.Entries(func(sp roachpb.Span, ts hlc.Timestamp) (done span.OpResult) {
+	for sp, ts := range rh.frontier.Entries() {
 		frontierResolvedSpans = append(frontierResolvedSpans, jobspb.ResolvedSpan{Span: sp, Timestamp: ts})
-		return span.ContinueMatch
-	})
+	}
 
 	rh.lastPartitionUpdate = timeutil.Now()
 	log.VInfof(ctx, 2, "persisting replicated time of %s", replicatedTime.GoTime())

--- a/pkg/crosscluster/physical/replication_execution_details.go
+++ b/pkg/crosscluster/physical/replication_execution_details.go
@@ -15,7 +15,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
-	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/isql"
@@ -69,7 +68,7 @@ func constructSpanFrontierExecutionDetailsWithFrontier(
 	res := make([]frontierExecutionDetails, 0)
 	for _, spec := range partitionSpecs.Specs {
 		for _, sp := range spec.Spans {
-			f.SpanEntries(sp, func(r roachpb.Span, timestamp hlc.Timestamp) (done span.OpResult) {
+			for r, timestamp := range f.SpanEntries(sp) {
 				res = append(res, frontierExecutionDetails{
 					srcInstanceID:  spec.SrcInstanceID,
 					destInstanceID: spec.DestInstanceID,
@@ -77,8 +76,7 @@ func constructSpanFrontierExecutionDetailsWithFrontier(
 					frontierTS:     timestamp,
 					behindBy:       humanizeutil.Duration(now.Sub(timestamp.GoTime())),
 				})
-				return span.ContinueMatch
-			})
+			}
 		}
 
 		// Sort res on the basis of srcInstanceID, destInstanceID.

--- a/pkg/crosscluster/physical/stream_ingestion_frontier_processor.go
+++ b/pkg/crosscluster/physical/stream_ingestion_frontier_processor.go
@@ -319,10 +319,9 @@ func (sf *streamIngestionFrontier) maybeUpdateProgress() error {
 	jobID := jobspb.JobID(sf.spec.JobID)
 
 	frontierResolvedSpans := make([]jobspb.ResolvedSpan, 0)
-	f.Entries(func(sp roachpb.Span, ts hlc.Timestamp) (done span.OpResult) {
+	for sp, ts := range f.Entries() {
 		frontierResolvedSpans = append(frontierResolvedSpans, jobspb.ResolvedSpan{Span: sp, Timestamp: ts})
-		return span.ContinueMatch
-	})
+	}
 
 	replicatedTime := f.Frontier()
 	sf.lastPartitionUpdate = timeutil.Now()
@@ -415,10 +414,9 @@ func (sf *streamIngestionFrontier) maybePersistFrontierEntries() error {
 	jobID := jobspb.JobID(sf.spec.JobID)
 
 	frontierEntries := &execinfrapb.FrontierEntries{ResolvedSpans: make([]jobspb.ResolvedSpan, 0)}
-	f.Entries(func(sp roachpb.Span, ts hlc.Timestamp) (done span.OpResult) {
+	for sp, ts := range f.Entries() {
 		frontierEntries.ResolvedSpans = append(frontierEntries.ResolvedSpans, jobspb.ResolvedSpan{Span: sp, Timestamp: ts})
-		return span.ContinueMatch
-	})
+	}
 
 	frontierBytes, err := protoutil.Marshal(frontierEntries)
 	if err != nil {

--- a/pkg/crosscluster/physical/stream_ingestion_processor.go
+++ b/pkg/crosscluster/physical/stream_ingestion_processor.go
@@ -1249,12 +1249,11 @@ func (sip *streamIngestionProcessor) flush() error {
 	sip.buffer = getBuffer()
 
 	checkpoint := &jobspb.ResolvedSpans{ResolvedSpans: make([]jobspb.ResolvedSpan, 0, sip.frontier.Len())}
-	sip.frontier.Entries(func(sp roachpb.Span, ts hlc.Timestamp) span.OpResult {
+	for sp, ts := range sip.frontier.Entries() {
 		if !ts.IsEmpty() {
 			checkpoint.ResolvedSpans = append(checkpoint.ResolvedSpans, jobspb.ResolvedSpan{Span: sp, Timestamp: ts})
 		}
-		return span.ContinueMatch
-	})
+	}
 
 	select {
 	case sip.flushCh <- flushableBuffer{

--- a/pkg/crosscluster/physical/stream_ingestion_processor_test.go
+++ b/pkg/crosscluster/physical/stream_ingestion_processor_test.go
@@ -352,10 +352,10 @@ func TestStreamIngestionProcessor(t *testing.T) {
 			if token == string(p2) {
 				sp = p2Span
 			}
-			clientStartTimes.SpanEntries(sp, func(s roachpb.Span, t hlc.Timestamp) (done span.OpResult) {
+			for _, t := range clientStartTimes.SpanEntries(sp) {
 				lastClientStart[token] = t
-				return span.StopMatch
-			})
+				break
+			}
 		}}
 		out, err := runStreamIngestionProcessor(ctx, t, registry, db,
 			topology, initialScanTimestamp, checkpoint, tenantRekey, mockClient,

--- a/pkg/crosscluster/producer/event_stream.go
+++ b/pkg/crosscluster/producer/event_stream.go
@@ -330,10 +330,9 @@ func (s *eventStream) sendCheckpoint(ctx context.Context, frontier rangefeed.Vis
 	}
 
 	spans := make([]jobspb.ResolvedSpan, 0, s.lastCheckpointLen)
-	frontier.Entries(func(sp roachpb.Span, ts hlc.Timestamp) (done span.OpResult) {
+	for sp, ts := range frontier.Entries() {
 		spans = append(spans, jobspb.ResolvedSpan{Span: sp, Timestamp: ts})
-		return span.ContinueMatch
-	})
+	}
 	s.lastCheckpointLen = len(spans)
 
 	s.seqNum++

--- a/pkg/crosscluster/producer/range_stats.go
+++ b/pkg/crosscluster/producer/range_stats.go
@@ -13,7 +13,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/repstream/streampb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
-	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/rangedesc"
 	"github.com/cockroachdb/cockroach/pkg/util/span"
@@ -98,18 +97,15 @@ func computeRangeStats(
 				EndKey: lazyIterator.CurRangeDescriptor().EndKey.AsRawKey(),
 			}
 			stats.RangeCount += 1
-			frontier.SpanEntries(
-				rangeSpan,
-				func(_ roachpb.Span, timestamp hlc.Timestamp) span.OpResult {
-					if timestamp.IsEmpty() {
-						stats.ScanningRangeCount += 1
-						return span.StopMatch
-					} else if now.Sub(timestamp.GoTime()) > laggingSpanThreshold {
-						stats.LaggingRangeCount += 1
-						return span.StopMatch
-					}
-					return span.ContinueMatch
-				})
+			for _, timestamp := range frontier.SpanEntries(rangeSpan) {
+				if timestamp.IsEmpty() {
+					stats.ScanningRangeCount += 1
+					break
+				} else if now.Sub(timestamp.GoTime()) > laggingSpanThreshold {
+					stats.LaggingRangeCount += 1
+					break
+				}
+			}
 		}
 		if lazyIterator.Error() != nil {
 			return streampb.StreamEvent_RangeStats{}, err

--- a/pkg/crosscluster/streamclient/partitioned_stream_client.go
+++ b/pkg/crosscluster/streamclient/partitioned_stream_client.go
@@ -254,10 +254,9 @@ func (p *partitionedStreamClient) Subscribe(
 	sps.InitialScanTimestamp = initialScanTime
 	if previousReplicatedTimes != nil {
 		sps.PreviousReplicatedTimestamp = previousReplicatedTimes.Frontier()
-		previousReplicatedTimes.Entries(func(s roachpb.Span, t hlc.Timestamp) (done span.OpResult) {
+		for s, t := range previousReplicatedTimes.Entries() {
 			sps.Progress = append(sps.Progress, jobspb.ResolvedSpan{Span: s, Timestamp: t})
-			return span.ContinueMatch
-		})
+		}
 	}
 	sps.Spans = sourcePartition.Spans
 	sps.ConsumerNode = consumerNode

--- a/pkg/kv/kvclient/rangefeed/config.go
+++ b/pkg/kv/kvclient/rangefeed/config.go
@@ -7,6 +7,7 @@ package rangefeed
 
 import (
 	"context"
+	"iter"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
@@ -14,7 +15,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
-	"github.com/cockroachdb/cockroach/pkg/util/span"
 )
 
 // Option configures a RangeFeed.
@@ -280,7 +280,7 @@ func WithOnFrontierAdvance(f OnFrontierAdvance) Option {
 // VisitableFrontier is the subset of the span.Frontier interface required to
 // inspect the content of the frontier.
 type VisitableFrontier interface {
-	Entries(span.Operation)
+	Entries() iter.Seq2[roachpb.Span, hlc.Timestamp]
 }
 
 // FrontierSpanVisitor is called when the frontier is updated by a checkpoint,

--- a/pkg/kv/kvclient/rangefeed/db_adapter.go
+++ b/pkg/kv/kvclient/rangefeed/db_adapter.go
@@ -90,16 +90,14 @@ func (dbc *dbAdapter) RangeFeedFromFrontier(
 	opts ...kvcoord.RangeFeedOption,
 ) error {
 	timedSpans := make([]kvcoord.SpanTimePair, 0, frontier.Len())
-	frontier.Entries(
-		func(sp roachpb.Span, ts hlc.Timestamp) (done span.OpResult) {
-			timedSpans = append(timedSpans, kvcoord.SpanTimePair{
-				// Clone the span as the rangefeed progress tracker will manipulate the
-				// original frontier.
-				Span:       sp.Clone(),
-				StartAfter: ts,
-			})
-			return false
+	for sp, ts := range frontier.Entries() {
+		timedSpans = append(timedSpans, kvcoord.SpanTimePair{
+			// Clone the span as the rangefeed progress tracker will manipulate the
+			// original frontier.
+			Span:       sp.Clone(),
+			StartAfter: ts,
 		})
+	}
 	return dbc.distSender.RangeFeed(ctx, timedSpans, eventC, opts...)
 }
 

--- a/pkg/kv/kvclient/rangefeed/rangefeed.go
+++ b/pkg/kv/kvclient/rangefeed/rangefeed.go
@@ -230,10 +230,9 @@ func (f *RangeFeed) start(
 
 	// Frontier merges and de-dups passed in spans.  So, use frontier to initialize
 	// sorted list of spans.
-	frontier.Entries(func(sp roachpb.Span, _ hlc.Timestamp) (done span.OpResult) {
+	for sp := range frontier.Entries() {
 		f.spans = append(f.spans, sp)
-		return span.ContinueMatch
-	})
+	}
 
 	runWithFrontier := func(ctx context.Context) {
 		if ownsFrontier {
@@ -259,17 +258,16 @@ func (f *RangeFeed) start(
 		f.spansDebugStr = frontier.PeekFrontierSpan().String()
 	} else {
 		var buf strings.Builder
-		frontier.Entries(func(sp roachpb.Span, _ hlc.Timestamp) span.OpResult {
+		for sp := range frontier.Entries() {
 			if buf.Len() > 0 {
 				buf.WriteString(", ")
 			}
 			buf.WriteString(sp.String())
 			if buf.Len() >= 400 {
 				fmt.Fprintf(&buf, "… [%d spans]", l)
-				return span.StopMatch
+				break
 			}
-			return span.ContinueMatch
-		})
+		}
 		f.spansDebugStr = buf.String()
 	}
 

--- a/pkg/kv/kvclient/rangefeed/rangefeed_mock_test.go
+++ b/pkg/kv/kvclient/rangefeed/rangefeed_mock_test.go
@@ -450,12 +450,11 @@ func TestRangeFeedMock(t *testing.T) {
 
 		getSpanTimestamp := func(frontier span.Frontier, given roachpb.Span) hlc.Timestamp {
 			maxTS := hlc.MinTimestamp
-			frontier.SpanEntries(given, func(sp roachpb.Span, ts hlc.Timestamp) (done span.OpResult) {
+			for _, ts := range frontier.SpanEntries(given) {
 				if maxTS.Less(ts) {
 					maxTS = ts
 				}
-				return span.ContinueMatch
-			})
+			}
 			return maxTS
 		}
 
@@ -516,10 +515,9 @@ func TestRangeFeedMock(t *testing.T) {
 
 			onCheckpoint := func(ctx context.Context, checkpoint *kvpb.RangeFeedCheckpoint) {
 				// Ensure the checkpoint timestamp is always greater than the initial timestamp.
-				initFrontier.SpanEntries(checkpoint.Span, func(sp roachpb.Span, ts hlc.Timestamp) (done span.OpResult) {
+				for _, ts := range initFrontier.SpanEntries(checkpoint.Span) {
 					require.True(t, ts.Less(checkpoint.ResolvedTS), "checkpoint %s", checkpoint)
-					return span.ContinueMatch
-				})
+				}
 				observedUpdates++
 			}
 

--- a/pkg/kv/kvclient/rangefeed/rangefeed_mock_test.go
+++ b/pkg/kv/kvclient/rangefeed/rangefeed_mock_test.go
@@ -508,11 +508,10 @@ func TestRangeFeedMock(t *testing.T) {
 			initFrontier, err := span.MakeFrontier(fullSpan)
 			require.NoError(t, err)
 
-			externalFrontier.Entries(func(sp roachpb.Span, ts hlc.Timestamp) (done span.OpResult) {
+			for sp, ts := range externalFrontier.Entries() {
 				_, err := initFrontier.Forward(sp, ts)
 				require.NoError(t, err)
-				return span.ContinueMatch
-			})
+			}
 			require.NoError(t, err)
 
 			onCheckpoint := func(ctx context.Context, checkpoint *kvpb.RangeFeedCheckpoint) {

--- a/pkg/kv/kvclient/rangefeed/scanner.go
+++ b/pkg/kv/kvclient/rangefeed/scanner.go
@@ -93,12 +93,11 @@ func (f *RangeFeed) runInitialScan(
 	for r.Next() {
 		// Figure out what spans are left to scan.
 		toScan = toScan[:0]
-		frontier.Entries(func(sp roachpb.Span, ts hlc.Timestamp) (done span.OpResult) {
+		for sp, ts := range frontier.Entries() {
 			if ts.IsEmpty() || ts.Less(f.initialTimestamp) {
 				toScan = append(toScan, sp)
 			}
-			return span.ContinueMatch
-		})
+		}
 
 		// Scan the spans.
 		if len(toScan) > 0 {

--- a/pkg/util/span/frontier.go
+++ b/pkg/util/span/frontier.go
@@ -54,8 +54,8 @@ type Frontier interface {
 	// Updates to the frontier are restricted until iteration is stopped.
 	Entries() iter.Seq2[roachpb.Span, hlc.Timestamp]
 
-	// SpanEntries invokes op for each sub-span of the specified span with the
-	// timestamp as observed by this frontier.
+	// SpanEntries returns an iterator over the entries in the frontier that are
+	// sub-spans of the specified span.
 	//
 	// Time
 	// 5|      .b__c               .
@@ -72,9 +72,8 @@ type Frontier interface {
 	//
 	// Note: neither [a-b) nor [m, q) will be emitted since they do not intersect with the spans
 	// tracked by this frontier.
-	// The fn may not mutate this frontier while iterating.
-	// TODO(yang): Change this function to return an iterator.
-	SpanEntries(span roachpb.Span, op Operation)
+	// Updates to the frontier are restricted until iteration is stopped.
+	SpanEntries(span roachpb.Span) iter.Seq2[roachpb.Span, hlc.Timestamp]
 
 	// Len returns the number of spans tracked by the frontier.
 	Len() int
@@ -82,21 +81,6 @@ type Frontier interface {
 	// String returns string representation of this fFrontier.
 	String() string
 }
-
-// OpResult is the result of the Operation callback.
-type OpResult bool
-
-const (
-	// ContinueMatch signals DoMatching should continue.
-	ContinueMatch OpResult = false
-	// StopMatch signals DoMatching should stop.
-	StopMatch OpResult = true
-)
-
-// An Operation is a function that operates on a frontier spans. If done is returned true, the
-// Operation is indicating that no further work needs to be done and so the DoMatching function
-// should traverse no further.
-type Operation func(roachpb.Span, hlc.Timestamp) (done OpResult)
 
 func newBtreeFrontier() Frontier {
 	return &btreeFrontier{}
@@ -572,48 +556,33 @@ func (f *btreeFrontier) Entries() iter.Seq2[roachpb.Span, hlc.Timestamp] {
 	}
 }
 
-// SpanEntries invokes op for each sub-span of the specified span with the
-// timestamp as observed by this frontier.
-//
-// Time
-// 5|      .b__c               .
-// 4|      .             h__k  .
-// 3|      .      e__f         .
-// 1 ---a----------------------m---q-- Frontier
-//
-//	|___________span___________|
-//
-// In the above example, frontier tracks [b, m) and the current frontier
-// timestamp is 1.  SpanEntries for span [a-q) will invoke op with:
-//
-//	([b-c), 5), ([c-e), 1), ([e-f), 3], ([f, h], 1) ([h, k), 4), ([k, m), 1).
-//
-// Note: neither [a-b) nor [m, q) will be emitted since they do not intersect with the spans
-// tracked by this frontier.
-func (f *btreeFrontier) SpanEntries(span roachpb.Span, op Operation) {
-	defer f.disallowMutations()()
+// SpanEntries implements Frontier.
+func (f *btreeFrontier) SpanEntries(span roachpb.Span) iter.Seq2[roachpb.Span, hlc.Timestamp] {
+	return func(yield func(roachpb.Span, hlc.Timestamp) bool) {
+		defer f.disallowMutations()()
 
-	todoRange := newSearchKey(span.Key, span.EndKey)
-	defer putFrontierEntry(todoRange)
+		todoRange := newSearchKey(span.Key, span.EndKey)
+		defer putFrontierEntry(todoRange)
 
-	it := f.tree.MakeIter()
-	for it.FirstOverlap(todoRange); it.Valid(); it.NextOverlap(todoRange) {
-		e := it.Cur()
+		it := f.tree.MakeIter()
+		for it.FirstOverlap(todoRange); it.Valid(); it.NextOverlap(todoRange) {
+			e := it.Cur()
 
-		// Skip untracked portion.
-		if todoRange.Start.Compare(e.Start) < 0 {
-			todoRange.Start = e.Start
+			// Skip untracked portion.
+			if todoRange.Start.Compare(e.Start) < 0 {
+				todoRange.Start = e.Start
+			}
+
+			end := e.End
+			if e.End.Compare(todoRange.End) > 0 {
+				end = todoRange.End
+			}
+
+			if !yield(roachpb.Span{Key: todoRange.Start, EndKey: end}, e.ts) {
+				return
+			}
+			todoRange.Start = end
 		}
-
-		end := e.End
-		if e.End.Compare(todoRange.End) > 0 {
-			end = todoRange.End
-		}
-
-		if op(roachpb.Span{Key: todoRange.Start, EndKey: end}, e.ts) == StopMatch {
-			return
-		}
-		todoRange.Start = end
 	}
 }
 
@@ -815,10 +784,9 @@ func spanDifference(s roachpb.Span, f Frontier) []roachpb.Span {
 	var sg roachpb.SpanGroup
 	sg.Add(s)
 
-	f.SpanEntries(s, func(overlap roachpb.Span, ts hlc.Timestamp) (done OpResult) {
+	for overlap := range f.SpanEntries(s) {
 		sg.Sub(overlap)
-		return false
-	})
+	}
 
 	return sg.Slice()
 }
@@ -879,10 +847,16 @@ func (f *concurrentFrontier) Entries() iter.Seq2[roachpb.Span, hlc.Timestamp] {
 }
 
 // SpanEntries implements Frontier.
-func (f *concurrentFrontier) SpanEntries(span roachpb.Span, op Operation) {
+func (f *concurrentFrontier) SpanEntries(span roachpb.Span) iter.Seq2[roachpb.Span, hlc.Timestamp] {
 	f.Lock()
-	defer f.Unlock()
-	f.f.SpanEntries(span, op)
+	return func(yield func(roachpb.Span, hlc.Timestamp) bool) {
+		defer f.Unlock()
+		for sp, ts := range f.f.SpanEntries(span) {
+			if !yield(sp, ts) {
+				return
+			}
+		}
+	}
 }
 
 // Len implements Frontier.

--- a/pkg/util/span/frontier.go
+++ b/pkg/util/span/frontier.go
@@ -50,11 +50,9 @@ type Frontier interface {
 	// but it will prevent frontier nodes from being efficiently re-used.
 	Release()
 
-	// Entries invokes the given callback with the current timestamp for each
-	// component span in the tracked span set.
-	// The fn may not mutate this frontier while iterating.
-	// TODO(yang): Delete this function and replace usages with All.
-	Entries(fn Operation)
+	// Entries returns an iterator over the entries in the frontier.
+	// Updates to the frontier are restricted until iteration is stopped.
+	Entries() iter.Seq2[roachpb.Span, hlc.Timestamp]
 
 	// SpanEntries invokes op for each sub-span of the specified span with the
 	// timestamp as observed by this frontier.
@@ -75,6 +73,7 @@ type Frontier interface {
 	// Note: neither [a-b) nor [m, q) will be emitted since they do not intersect with the spans
 	// tracked by this frontier.
 	// The fn may not mutate this frontier while iterating.
+	// TODO(yang): Change this function to return an iterator.
 	SpanEntries(span roachpb.Span, op Operation)
 
 	// Len returns the number of spans tracked by the frontier.
@@ -82,10 +81,6 @@ type Frontier interface {
 
 	// String returns string representation of this fFrontier.
 	String() string
-
-	// All returns an iterator over the entries in the frontier.
-	// Updates to the frontier are restricted until iteration is stopped.
-	All() iter.Seq2[roachpb.Span, hlc.Timestamp]
 }
 
 // OpResult is the result of the Operation callback.
@@ -563,15 +558,16 @@ func (f *btreeFrontier) disallowMutations() func() {
 	}
 }
 
-// Entries invokes the given callback with the current timestamp for each
-// component span in the tracked span set.
-func (f *btreeFrontier) Entries(fn Operation) {
-	defer f.disallowMutations()()
+// Entries implements Frontier.
+func (f *btreeFrontier) Entries() iter.Seq2[roachpb.Span, hlc.Timestamp] {
+	return func(yield func(roachpb.Span, hlc.Timestamp) bool) {
+		defer f.disallowMutations()()
 
-	it := f.tree.MakeIter()
-	for it.First(); it.Valid(); it.Next() {
-		if fn(it.Cur().span(), it.Cur().ts) == StopMatch {
-			break
+		it := f.tree.MakeIter()
+		for it.First(); it.Valid(); it.Next() {
+			if !yield(it.Cur().span(), it.Cur().ts) {
+				return
+			}
 		}
 	}
 }
@@ -634,20 +630,6 @@ func (f *btreeFrontier) String() string {
 		buf.WriteString(it.Cur().String())
 	}
 	return buf.String()
-}
-
-// All implements Frontier.
-func (f *btreeFrontier) All() iter.Seq2[roachpb.Span, hlc.Timestamp] {
-	return func(yield func(roachpb.Span, hlc.Timestamp) bool) {
-		defer f.disallowMutations()()
-
-		it := f.tree.MakeIter()
-		for it.First(); it.Valid(); it.Next() {
-			if !yield(it.Cur().span(), it.Cur().ts) {
-				return
-			}
-		}
-	}
 }
 
 // Len implements Frontier.
@@ -884,10 +866,16 @@ func (f *concurrentFrontier) Release() {
 }
 
 // Entries implements Frontier.
-func (f *concurrentFrontier) Entries(fn Operation) {
+func (f *concurrentFrontier) Entries() iter.Seq2[roachpb.Span, hlc.Timestamp] {
 	f.Lock()
-	defer f.Unlock()
-	f.f.Entries(fn)
+	return func(yield func(roachpb.Span, hlc.Timestamp) bool) {
+		defer f.Unlock()
+		for sp, ts := range f.f.Entries() {
+			if !yield(sp, ts) {
+				return
+			}
+		}
+	}
 }
 
 // SpanEntries implements Frontier.
@@ -909,11 +897,4 @@ func (f *concurrentFrontier) String() string {
 	f.Lock()
 	defer f.Unlock()
 	return f.f.String()
-}
-
-// All implements Frontier.
-func (f *concurrentFrontier) All() iter.Seq2[roachpb.Span, hlc.Timestamp] {
-	f.Lock()
-	defer f.Unlock()
-	return f.f.All()
 }

--- a/pkg/util/span/frontier_test.go
+++ b/pkg/util/span/frontier_test.go
@@ -320,13 +320,12 @@ func TestSpanEntries(t *testing.T) {
 
 	spanEntries := func(f Frontier, sp roachpb.Span) string {
 		var buf strings.Builder
-		f.SpanEntries(sp, func(s roachpb.Span, ts hlc.Timestamp) OpResult {
+		for s, ts := range f.SpanEntries(sp) {
 			if buf.Len() != 0 {
 				buf.WriteString(` `)
 			}
 			fmt.Fprintf(&buf, `%s@%d`, s, ts.WallTime)
-			return ContinueMatch
-		})
+		}
 		return buf.String()
 	}
 

--- a/pkg/util/span/frontier_test.go
+++ b/pkg/util/span/frontier_test.go
@@ -24,13 +24,12 @@ import (
 
 func entriesStr(f Frontier) string {
 	var buf strings.Builder
-	f.Entries(func(sp roachpb.Span, ts hlc.Timestamp) OpResult {
+	for sp, ts := range f.Entries() {
 		if buf.Len() != 0 {
 			buf.WriteString(` `)
 		}
 		fmt.Fprintf(&buf, `%s@%d`, sp, ts.WallTime)
-		return ContinueMatch
-	})
+	}
 	return buf.String()
 }
 


### PR DESCRIPTION
**span: change Frontier.Entries to return an iterator**

This patch is a pure refactoring change to make span.Frontier's
Entries method return an iterator instead of accepting a
span.Operation function.

Release note: None

---

**span: change Frontier.SpanEntries to return an iterator**

This patch is a pure refactoring change to make span.Frontier's
SpanEntries method return an iterator instead of accepting a
span.Operation function.

Release note: None

---

Epic: None