### PR TITLE
vecindex: check partition size in fixup processor

### DIFF
--- a/pkg/sql/vecindex/BUILD.bazel
+++ b/pkg/sql/vecindex/BUILD.bazel
@@ -39,8 +39,9 @@ go_test(
     srcs = [
         "manager_test.go",
         "searcher_test.go",
+        "vecindex_test.go",
     ],
-    data = glob(["testdata/**"]),
+    data = ["//pkg/sql/vecindex/cspann:features_10000"],
     embed = [":vecindex"],
     deps = [
         "//pkg/base",
@@ -63,6 +64,7 @@ go_test(
         "//pkg/sql/types",
         "//pkg/sql/vecindex/cspann",
         "//pkg/sql/vecindex/cspann/quantize",
+        "//pkg/sql/vecindex/cspann/testutils",
         "//pkg/sql/vecindex/vecpb",
         "//pkg/sql/vecindex/vecstore",
         "//pkg/testutils/serverutils",

--- a/pkg/sql/vecindex/cspann/BUILD.bazel
+++ b/pkg/sql/vecindex/cspann/BUILD.bazel
@@ -3,9 +3,9 @@ load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 filegroup(
-    name = "testdata",
-    srcs = glob(["testdata/**"]),
-    visibility = ["//pkg/sql/vecindex/cspann:__subpackages__"],
+    name = "features_10000",
+    srcs = glob(["testdata/features_10000.gob"]),
+    visibility = ["//visibility:public"],
 )
 
 go_library(
@@ -55,7 +55,7 @@ go_test(
         "partition_test.go",
         "search_set_test.go",
     ],
-    data = ["//pkg/sql/vecindex/cspann:testdata"],
+    data = glob(["testdata/**"]),
     embed = [":cspann"],
     deps = [
         "//pkg/sql/vecindex/cspann/commontest",

--- a/pkg/sql/vecindex/cspann/commontest/utils.go
+++ b/pkg/sql/vecindex/cspann/commontest/utils.go
@@ -18,11 +18,24 @@ import (
 
 // CheckPartitionMetadata tests the correctness of the given metadata's fields.
 func CheckPartitionMetadata(
-	t *testing.T, metadata cspann.PartitionMetadata, level cspann.Level, centroid vector.T, count int,
+	t *testing.T, metadata cspann.PartitionMetadata, level cspann.Level, centroid vector.T,
 ) {
 	require.Equal(t, level, metadata.Level)
 	require.Equal(t, []float32(centroid), testutils.RoundFloats(metadata.Centroid, 2))
-	require.Equal(t, count, metadata.Count)
+}
+
+// CheckPartitionCount tests the size of a partition.
+func CheckPartitionCount(
+	ctx context.Context,
+	t *testing.T,
+	store cspann.Store,
+	treeKey cspann.TreeKey,
+	partitionKey cspann.PartitionKey,
+	expectedCount int,
+) {
+	count, err := store.EstimatePartitionCount(ctx, treeKey, partitionKey)
+	require.NoError(t, err)
+	require.Equal(t, expectedCount, count)
 }
 
 // BeginTransaction starts a new transaction for the given store and returns it.

--- a/pkg/sql/vecindex/cspann/fixup_processor.go
+++ b/pkg/sql/vecindex/cspann/fixup_processor.go
@@ -23,9 +23,9 @@ import (
 type fixupType int
 
 const (
-	// splitOrMergeFixup is a fixup that includes the key of a partition to
-	// split or merge as well as the key of its parent partition (if it exists).
-	// Whether a partition is split or merged depends on its size.
+	// splitOrMergeFixup is a fixup that includes the key of a partition that
+	// may need to be split or merged, as well as the key of its parent partition
+	// (if it exists). Whether a partition is split or merged depends on its size.
 	splitOrMergeFixup fixupType = iota + 1
 	// vectorDeleteFixup is a fixup that includes the primary key of a vector to
 	// delete from the index, as well as the key of the partition that contains
@@ -266,20 +266,9 @@ func (fp *FixupProcessor) DelayInsertOrDelete(ctx context.Context) error {
 	return nil
 }
 
-// AddSplit enqueues a split fixup for later processing.
-func (fp *FixupProcessor) AddSplit(
-	ctx context.Context, treeKey TreeKey, parentPartitionKey PartitionKey, partitionKey PartitionKey,
-) {
-	fp.addFixup(ctx, fixup{
-		TreeKey:            treeKey,
-		Type:               splitOrMergeFixup,
-		ParentPartitionKey: parentPartitionKey,
-		PartitionKey:       partitionKey,
-	})
-}
-
-// AddMerge enqueues a merge fixup for later processing.
-func (fp *FixupProcessor) AddMerge(
+// AddSplitOrMergeCheck enqueues a fixup to check whether a split or merge is
+// needed for the given partition.
+func (fp *FixupProcessor) AddSplitOrMergeCheck(
 	ctx context.Context, treeKey TreeKey, parentPartitionKey PartitionKey, partitionKey PartitionKey,
 ) {
 	fp.addFixup(ctx, fixup{

--- a/pkg/sql/vecindex/cspann/fixup_worker.go
+++ b/pkg/sql/vecindex/cspann/fixup_worker.go
@@ -105,6 +105,18 @@ func (fw *fixupWorker) Start(ctx context.Context) {
 func (fw *fixupWorker) splitOrMergePartition(
 	ctx context.Context, parentPartitionKey PartitionKey, partitionKey PartitionKey,
 ) (err error) {
+	// Do a quick, inconsistent scan of the partition, in order to see if it may
+	// need to be split or merged.
+	count, err := fw.index.store.EstimatePartitionCount(ctx, fw.treeKey, partitionKey)
+	if err != nil {
+		return errors.Wrapf(err, "counting vectors in partition %d", partitionKey)
+	}
+	split := count > fw.index.options.MaxPartitionSize
+	merge := partitionKey != RootKey && count < fw.index.options.MinPartitionSize
+	if !split && !merge {
+		return nil
+	}
+
 	// Run the split or merge within a transaction.
 	fw.txn, err = fw.index.store.BeginTransaction(ctx)
 	if err != nil {
@@ -128,9 +140,10 @@ func (fw *fixupWorker) splitOrMergePartition(
 		return errors.Wrapf(err, "getting partition %d to split or merge", partitionKey)
 	}
 
-	// Don't split or merge the partition if its size is within bounds.
-	split := partition.Count() > fw.index.options.MaxPartitionSize
-	merge := partition.Count() < fw.index.options.MinPartitionSize
+	// Re-check the size of the partition now that it's locked, using a consistent
+	// scan, so that we are not acting based on stale information.
+	split = partition.Count() > fw.index.options.MaxPartitionSize
+	merge = partitionKey != RootKey && partition.Count() < fw.index.options.MinPartitionSize
 	if !split && !merge {
 		log.VEventf(ctx, 2, "partition %d size is within bounds, do not split or merge", partitionKey)
 		return nil
@@ -213,14 +226,14 @@ func (fw *fixupWorker) splitPartition(
 				partitionKey, parentPartitionKey)
 		}
 
-		metadata, err := fw.index.removeFromPartition(
-			ctx, fw.txn, fw.treeKey, parentPartitionKey, childKey)
+		err := fw.index.removeFromPartition(ctx, fw.txn, fw.treeKey, parentPartitionKey, childKey)
 		if err != nil {
 			return errors.Wrapf(err, "removing splitting partition %d from its parent %d",
 				partitionKey, parentPartitionKey)
 		}
 
-		if metadata.Count != 0 {
+		// Only attempt to move vectors if there are siblings.
+		if parentPartition.Count() > 1 {
 			// Move any vectors to sibling partitions that have closer centroids.
 			// Lazily get parent vectors only if they're actually needed.
 			var parentVectors vector.Set
@@ -474,8 +487,8 @@ func (fw *fixupWorker) moveVectorsToSiblings(
 		// there instead.
 		childKey := split.Partition.ChildKeys()[i]
 		valueBytes := split.Partition.ValueBytes()[i]
-		err = fw.index.addToPartition(ctx, fw.txn, fw.treeKey,
-			parentPartitionKey, siblingPartitionKey, vector, childKey, valueBytes)
+		err = fw.index.addToPartition(
+			ctx, fw.txn, fw.treeKey, siblingPartitionKey, vector, childKey, valueBytes)
 		if err != nil {
 			return errors.Wrapf(err, "moving vector to partition %d", siblingPartitionKey)
 		}
@@ -503,6 +516,11 @@ func (fw *fixupWorker) linkNearbyVectors(
 	idxCtx.options = SearchOptions{ReturnVectors: true}
 	idxCtx.level = partition.Level()
 	idxCtx.randomized = partition.Centroid()
+
+	// Ensure that the search never returns the last remaining vector in a
+	// non-leaf partition, in order to avoid moving it and creating an empty
+	// non-leaf partition, which is not allowed by a balanced K-means tree.
+	idxCtx.ignoreLonelyVector = partition.Level() != LeafLevel
 
 	// Don't link more vectors than the number of remaining slots in the split
 	// partition, to avoid triggering another split.
@@ -542,23 +560,11 @@ func (fw *fixupWorker) linkNearbyVectors(
 		}
 
 		// Remove the vector from the other partition.
-		metadata, err := fw.index.removeFromPartition(
+		err = fw.index.removeFromPartition(
 			ctx, fw.txn, fw.treeKey, result.ParentPartitionKey, result.ChildKey)
 		if err != nil {
 			return errors.Wrapf(err, "removing vector from nearby partition %d during split of %d",
 				result.ParentPartitionKey, oldPartitionKey)
-		}
-		if metadata.Count == 0 && partition.Level() > LeafLevel {
-			// Removing the vector will result in an empty non-leaf partition, which
-			// is not allowed, as the K-means tree would not be fully balanced. Add
-			// the vector back to the partition. This is a very rare case and that
-			// partition is likely to be merged away regardless.
-			_, err = fw.txn.AddToPartition(
-				ctx, fw.treeKey, result.ParentPartitionKey, vector, result.ChildKey, result.ValueBytes)
-			if err != nil {
-				return errors.Wrapf(err, "adding vector to splitting partition %d", oldPartitionKey)
-			}
-			continue
 		}
 
 		// Add the vector to the split partition.
@@ -627,7 +633,7 @@ func (fw *fixupWorker) mergePartition(
 			partitionKey, parentPartitionKey)
 		return nil
 	}
-	_, err = fw.index.removeFromPartition(ctx, fw.txn, fw.treeKey, parentPartitionKey, childKey)
+	err = fw.index.removeFromPartition(ctx, fw.txn, fw.treeKey, parentPartitionKey, childKey)
 	if err != nil {
 		return errors.Wrapf(err, "remove partition %d from parent partition %d",
 			partitionKey, parentPartitionKey)
@@ -687,7 +693,7 @@ func (fw *fixupWorker) deleteVector(
 		return nil
 	}
 
-	_, err = fw.index.removeFromPartition(ctx, fw.txn, fw.treeKey, partitionKey, childKey)
+	err = fw.index.removeFromPartition(ctx, fw.txn, fw.treeKey, partitionKey, childKey)
 	if errors.Is(err, ErrPartitionNotFound) {
 		log.VEventf(ctx, 2, "partition %d no longer exists, do not delete vector", partitionKey)
 		return nil

--- a/pkg/sql/vecindex/cspann/index_test.go
+++ b/pkg/sql/vecindex/cspann/index_test.go
@@ -79,7 +79,7 @@ func TestIndex(t *testing.T) {
 			case "delete":
 				return state.Delete(d)
 
-			case "force-split", "force-merge":
+			case "force-split-or-merge":
 				return state.ForceSplitOrMerge(d)
 
 			case "recall":
@@ -475,10 +475,8 @@ func (s *testState) ForceSplitOrMerge(d *datadriven.TestData) string {
 		}
 	}
 
-	if d.Cmd == "force-split" {
-		s.Index.ForceSplit(s.Ctx, treeKey, parentPartitionKey, partitionKey)
-	} else {
-		s.Index.ForceMerge(s.Ctx, treeKey, parentPartitionKey, partitionKey)
+	if d.Cmd == "force-split-or-merge" {
+		s.Index.ForceSplitOrMerge(s.Ctx, treeKey, parentPartitionKey, partitionKey)
 	}
 
 	// Ensure the fixup runs.

--- a/pkg/sql/vecindex/cspann/memstore/memstore_test.go
+++ b/pkg/sql/vecindex/cspann/memstore/memstore_test.go
@@ -129,7 +129,7 @@ func TestInMemoryStoreConcurrency(t *testing.T) {
 		defer commontest.CommitTransaction(ctx, t, store, txn)
 
 		// Ensure the root partition has been created.
-		_, err := txn.AddToPartition(
+		err := txn.AddToPartition(
 			ctx, treeKey, cspann.RootKey, vector.T{10, 10}, childKey1, valueBytes1)
 		require.NoError(t, err)
 
@@ -161,8 +161,7 @@ func TestInMemoryStoreConcurrency(t *testing.T) {
 		// Add vector to root partition after yielding to the background goroutine.
 		// The add should always happen before the background search.
 		runtime.Gosched()
-		_, err = txn.AddToPartition(
-			ctx, treeKey, cspann.RootKey, vector.T{3, 4}, childKey2, valueBytes2)
+		err = txn.AddToPartition(ctx, treeKey, cspann.RootKey, vector.T{3, 4}, childKey2, valueBytes2)
 		require.NoError(t, err)
 	}()
 
@@ -192,9 +191,9 @@ func TestInMemoryStoreUpdateStats(t *testing.T) {
 	valueBytes30 := cspann.ValueBytes{5, 6}
 	valueBytes40 := cspann.ValueBytes{7, 8}
 
-	_, err := txn.AddToPartition(ctx, treeKey, cspann.RootKey, vector.T{1, 2}, childKey10, valueBytes10)
+	err := txn.AddToPartition(ctx, treeKey, cspann.RootKey, vector.T{1, 2}, childKey10, valueBytes10)
 	require.NoError(t, err)
-	_, err = txn.AddToPartition(ctx, treeKey, cspann.RootKey, vector.T{3, 4}, childKey20, valueBytes20)
+	err = txn.AddToPartition(ctx, treeKey, cspann.RootKey, vector.T{3, 4}, childKey20, valueBytes20)
 	require.NoError(t, err)
 
 	// Update stats.
@@ -236,7 +235,7 @@ func TestInMemoryStoreUpdateStats(t *testing.T) {
 		{Mean: 2.775, Variance: 0.1}, {Mean: 1.25, Variance: 0.05}}, roundCVStats(stats.CVStats))
 
 	// Add vector to partition and check stats.
-	_, err = txn.AddToPartition(ctx, treeKey, partitionKey, vector.T{7, 8}, childKey40, valueBytes40)
+	err = txn.AddToPartition(ctx, treeKey, partitionKey, vector.T{7, 8}, childKey40, valueBytes40)
 	require.NoError(t, err)
 
 	stats.CVStats = []cspann.CVStats{{Mean: 3, Variance: 1}, {Mean: 1.5, Variance: 0.5}}
@@ -248,7 +247,7 @@ func TestInMemoryStoreUpdateStats(t *testing.T) {
 		{Mean: 2.7863, Variance: 0.145}, {Mean: 1.2625, Variance: 0.0725}}, roundCVStats(stats.CVStats))
 
 	// Remove vector from partition and check stats.
-	_, err = txn.RemoveFromPartition(ctx, treeKey, partitionKey, childKey30)
+	err = txn.RemoveFromPartition(ctx, treeKey, partitionKey, childKey30)
 	require.NoError(t, err)
 
 	stats.CVStats = []cspann.CVStats{{Mean: 5, Variance: 2}, {Mean: 3, Variance: 1.5}}

--- a/pkg/sql/vecindex/cspann/partition.go
+++ b/pkg/sql/vecindex/cspann/partition.go
@@ -100,7 +100,6 @@ func (p *Partition) Metadata() PartitionMetadata {
 	return PartitionMetadata{
 		Level:    p.Level(),
 		Centroid: p.quantizedSet.GetCentroid(),
-		Count:    p.Count(),
 	}
 }
 

--- a/pkg/sql/vecindex/cspann/partition_test.go
+++ b/pkg/sql/vecindex/cspann/partition_test.go
@@ -52,7 +52,7 @@ func TestPartition(t *testing.T) {
 	require.Equal(t, []ChildKey{childKey10, childKey40, childKey30, childKey20}, partition.ChildKeys())
 	require.Equal(t, []ValueBytes{valueBytes10, valueBytes40, valueBytes30, valueBytes20b}, partition.ValueBytes())
 	require.Equal(t, []float32{4, 3.33}, testutils.RoundFloats(partition.Centroid(), 2))
-	checkPartitionMetadata(t, partition.Metadata(), Level(1), vector.T{4, 3.33}, 4)
+	checkPartitionMetadata(t, partition.Metadata(), Level(1), vector.T{4, 3.33})
 
 	// Ensure that cloning does not disturb anything.
 	cloned := partition.Clone()
@@ -99,7 +99,7 @@ func TestPartition(t *testing.T) {
 	cloned.Quantizer().EstimateSquaredDistances(
 		&workspace, cloned.QuantizedSet(), vector.T{3, 4}, squaredDistances, errorBounds)
 	require.Equal(t, []float32{8, 2, 13, 85, 34}, squaredDistances)
-	checkPartitionMetadata(t, cloned.Metadata(), Level(1), vector.T{4, 3.33}, 5)
+	checkPartitionMetadata(t, cloned.Metadata(), Level(1), vector.T{4, 3.33})
 }
 
 func roundResults(results SearchResults, prec int) SearchResults {
@@ -114,9 +114,8 @@ func roundResults(results SearchResults, prec int) SearchResults {
 }
 
 func checkPartitionMetadata(
-	t *testing.T, metadata PartitionMetadata, level Level, centroid vector.T, count int,
+	t *testing.T, metadata PartitionMetadata, level Level, centroid vector.T,
 ) {
 	require.Equal(t, level, metadata.Level)
 	require.Equal(t, []float32(centroid), testutils.RoundFloats(metadata.Centroid, 2))
-	require.Equal(t, count, metadata.Count)
 }

--- a/pkg/sql/vecindex/cspann/quantize/BUILD.bazel
+++ b/pkg/sql/vecindex/cspann/quantize/BUILD.bazel
@@ -54,7 +54,7 @@ go_test(
         "unquantizedpb_test.go",
         "unquantizer_test.go",
     ],
-    data = ["//pkg/sql/vecindex/cspann:testdata"],
+    data = ["//pkg/sql/vecindex/cspann:features_10000"],
     embed = [":quantize"],
     deps = [
         "//pkg/sql/vecindex/cspann/testutils",

--- a/pkg/sql/vecindex/cspann/search_set.go
+++ b/pkg/sql/vecindex/cspann/search_set.go
@@ -201,6 +201,18 @@ type SearchSet struct {
 	extraResults searchResultHeap
 }
 
+// RemoveResults removes all results that are in the given parent partition.
+func (ss *SearchSet) RemoveResults(parentPartitionKey PartitionKey) {
+	// Remove all results, and then add back all but excluded results.
+	results := ss.PopUnsortedResults()
+	for i := range results {
+		res := &results[i]
+		if res.ParentPartitionKey != parentPartitionKey {
+			ss.Add(res)
+		}
+	}
+}
+
 // Add includes a new candidate in the search set. If set limits have been
 // reached, then the candidate with the farthest distance will be discarded.
 func (ss *SearchSet) Add(candidate *SearchResult) {

--- a/pkg/sql/vecindex/cspann/search_set_test.go
+++ b/pkg/sql/vecindex/cspann/search_set_test.go
@@ -148,4 +148,14 @@ func TestSearchSet(t *testing.T) {
 	otherSet = SearchSet{MaxResults: 2, MatchKey: []byte{60}}
 	otherSet.AddAll(SearchResults{result1, result2, result3, result4, result5, result6, result7})
 	require.Equal(t, SearchResults{result6}, otherSet.PopResults())
+
+	// Remove results.
+	searchSet = SearchSet{MaxResults: 4, MaxExtraResults: 2}
+	searchSet.AddAll(SearchResults{result1, result2, result3, result4, result5, result6})
+	searchSet.RemoveResults(100)
+	require.Equal(t, SearchResults{result3, result4, result6, result2, result5}, searchSet.PopResults())
+
+	searchSet.AddAll(SearchResults{result1, result2, result3, result4, result5, result6})
+	searchSet.RemoveResults(200)
+	require.Equal(t, SearchResults{result3, result1, result4, result6, result5}, searchSet.PopResults())
 }

--- a/pkg/sql/vecindex/cspann/testdata/merge.ddt
+++ b/pkg/sql/vecindex/cspann/testdata/merge.ddt
@@ -401,7 +401,7 @@ vec5: (1, 5)
     ├───• vec2 (3, 9)
     └───• vec5 (1, 5)
 
-force-merge partition-key=2 parent-partition-key=1
+force-split-or-merge partition-key=2 parent-partition-key=1
 ----
 • 1 (1.3333, 4.1667)
 │
@@ -416,7 +416,7 @@ force-merge partition-key=2 parent-partition-key=1
     ├───• vec2 (3, 9)
     └───• vec5 (1, 5)
 
-force-merge partition-key=3 parent-partition-key=2
+force-split-or-merge partition-key=3 parent-partition-key=2
 ----
 • 1 (1.3333, 4.1667)
 │

--- a/pkg/sql/vecindex/cspann/testdata/metrics.ddt
+++ b/pkg/sql/vecindex/cspann/testdata/metrics.ddt
@@ -35,8 +35,8 @@ vec9: (5, 2)
 metrics
 ----
 2 successful splits
-2 fixups added to queue
-2 fixups processed
+5 fixups added to queue
+5 fixups processed
 
 # Delete vector from primary index, but not from secondary index.
 delete not-found
@@ -73,5 +73,5 @@ vec4: 17 (centroid=1.25)
 metrics
 ----
 2 successful splits
-3 fixups added to queue
-3 fixups processed
+6 fixups added to queue
+6 fixups processed

--- a/pkg/sql/vecindex/cspann/testdata/search-features.ddt
+++ b/pkg/sql/vecindex/cspann/testdata/search-features.ddt
@@ -1,117 +1,117 @@
-# Load 500 512-dimension features and search them. Use small partition size to
+# Load 1000 512-dimension features and search them. Use small partition size to
 # ensure a deeper tree.
 
 new-index dims=512 min-partition-size=4 max-partition-size=16 quality-samples=8 beam-size=4 load-features=1000 hide-tree
 ----
 Created index with 1000 vectors with 512 dimensions.
-3 levels, 92 partitions, 12.57 vectors/partition.
+3 levels, 95 partitions, 11.28 vectors/partition.
 CV stats:
-  level 2 - mean: 0.1301, stdev: 0.0335
-  level 3 - mean: 0.1568, stdev: 0.0161
+  level 2 - mean: 0.1294, stdev: 0.0425
+  level 3 - mean: 0.1162, stdev: 0.0421
 
 # Search with small beam size.
 search max-results=1 use-feature=5000 beam-size=1
 ----
-vec356: 0.5976 (centroid=0.5)
-23 leaf vectors, 47 vectors, 3 full vectors, 4 partitions
+vec704: 0.7916 (centroid=0.53)
+16 leaf vectors, 33 vectors, 5 full vectors, 4 partitions
 
 # Search for additional results.
 search max-results=6 use-feature=5000 beam-size=1
 ----
-vec356: 0.5976 (centroid=0.5)
-vec309: 0.7311 (centroid=0.52)
-vec979: 0.8066 (centroid=0.6)
-vec133: 0.8381 (centroid=0.51)
-vec527: 0.845 (centroid=0.38)
-vec50: 0.8542 (centroid=0.55)
-23 leaf vectors, 47 vectors, 18 full vectors, 4 partitions
+vec704: 0.7916 (centroid=0.53)
+vec637: 0.8039 (centroid=0.46)
+vec879: 0.8291 (centroid=0.64)
+vec199: 0.8304 (centroid=0.54)
+vec483: 0.8465 (centroid=0.48)
+vec994: 0.8608 (centroid=0.59)
+16 leaf vectors, 33 vectors, 13 full vectors, 4 partitions
 
 # Use a larger beam size.
 search max-results=6 use-feature=5000 beam-size=4
 ----
-vec356: 0.5976 (centroid=0.5)
-vec302: 0.6601 (centroid=0.55)
-vec329: 0.6871 (centroid=0.62)
+vec356: 0.5976 (centroid=0.52)
+vec302: 0.6601 (centroid=0.49)
+vec329: 0.6871 (centroid=0.69)
 vec386: 0.7301 (centroid=0.67)
-vec309: 0.7311 (centroid=0.52)
+vec309: 0.7311 (centroid=0.54)
 vec117: 0.7576 (centroid=0.49)
-95 leaf vectors, 149 vectors, 22 full vectors, 13 partitions
+90 leaf vectors, 139 vectors, 19 full vectors, 13 partitions
 
 # Turn off re-ranking, which results in increased inaccuracy.
 search max-results=6 use-feature=5000 beam-size=4 skip-rerank
 ----
-vec302: 0.5957 ±0.04 (centroid=0.55)
-vec356: 0.6234 ±0.03 (centroid=0.5)
+vec356: 0.6301 ±0.03 (centroid=0.52)
+vec302: 0.6695 ±0.03 (centroid=0.49)
 vec386: 0.6868 ±0.04 (centroid=0.67)
-vec329: 0.6988 ±0.04 (centroid=0.62)
-vec11: 0.7207 ±0.04 (centroid=0.6)
+vec329: 0.6883 ±0.05 (centroid=0.69)
+vec387: 0.7257 ±0.04 (centroid=0.57)
 vec117: 0.7295 ±0.03 (centroid=0.49)
-95 leaf vectors, 149 vectors, 0 full vectors, 13 partitions
+90 leaf vectors, 139 vectors, 0 full vectors, 13 partitions
 
 # Return top 25 results with large beam size.
 search max-results=25 use-feature=5000 beam-size=16
 ----
-vec771: 0.5624 (centroid=0.65)
-vec356: 0.5976 (centroid=0.5)
-vec640: 0.6525 (centroid=0.58)
-vec302: 0.6601 (centroid=0.55)
-vec329: 0.6871 (centroid=0.62)
+vec771: 0.5624 (centroid=0.67)
+vec356: 0.5976 (centroid=0.52)
+vec640: 0.6525 (centroid=0.52)
+vec302: 0.6601 (centroid=0.49)
+vec329: 0.6871 (centroid=0.69)
 vec95: 0.7008 (centroid=0.65)
 vec249: 0.7268 (centroid=0.48)
 vec386: 0.7301 (centroid=0.67)
-vec309: 0.7311 (centroid=0.52)
+vec309: 0.7311 (centroid=0.54)
 vec117: 0.7576 (centroid=0.49)
 vec25: 0.761 (centroid=0.49)
-vec859: 0.7708 (centroid=0.64)
+vec872: 0.7707 (centroid=0.59)
 vec240: 0.7723 (centroid=0.67)
-vec347: 0.7745 (centroid=0.54)
-vec11: 0.777 (centroid=0.6)
+vec347: 0.7745 (centroid=0.68)
+vec11: 0.777 (centroid=0.53)
 vec340: 0.7858 (centroid=0.66)
-vec239: 0.7878 (centroid=0.51)
-vec704: 0.7916 (centroid=0.63)
-vec220: 0.7957 (centroid=0.39)
+vec239: 0.7878 (centroid=0.45)
+vec704: 0.7916 (centroid=0.53)
+vec423: 0.7956 (centroid=0.53)
+vec220: 0.7957 (centroid=0.43)
 vec848: 0.7958 (centroid=0.51)
-vec387: 0.8038 (centroid=0.52)
-vec637: 0.8039 (centroid=0.52)
+vec387: 0.8038 (centroid=0.57)
+vec637: 0.8039 (centroid=0.46)
 vec410: 0.8062 (centroid=0.58)
-vec979: 0.8066 (centroid=0.6)
-vec457: 0.8084 (centroid=0.42)
-391 leaf vectors, 485 vectors, 82 full vectors, 41 partitions
+vec979: 0.8066 (centroid=0.61)
+372 leaf vectors, 469 vectors, 87 full vectors, 42 partitions
 
 # Search for an "easy" result, where adaptive search inspects less partitions.
 recall topk=20 use-feature=8601 beam-size=4
 ----
-40.00% recall@20
-49.00 leaf vectors, 64.00 vectors, 28.00 full vectors, 6.00 partitions
+70.00% recall@20
+26.00 leaf vectors, 45.00 vectors, 26.00 full vectors, 4.00 partitions
 
 # Search for a "hard" result, where adaptive search inspects more partitions.
 recall topk=20 use-feature=2717 beam-size=4
 ----
-50.00% recall@20
-116.00 leaf vectors, 168.00 vectors, 50.00 full vectors, 13.00 partitions
+35.00% recall@20
+103.00 leaf vectors, 145.00 vectors, 46.00 full vectors, 13.00 partitions
 
 # Test recall at different beam sizes.
 recall topk=10 beam-size=2 samples=50
 ----
-47.20% recall@10
-34.46 leaf vectors, 60.54 vectors, 18.06 full vectors, 5.42 partitions
+39.20% recall@10
+30.26 leaf vectors, 52.98 vectors, 16.64 full vectors, 5.06 partitions
 
 recall topk=10 beam-size=4 samples=50
 ----
-66.40% recall@10
-73.50 leaf vectors, 114.00 vectors, 22.48 full vectors, 9.98 partitions
+59.60% recall@10
+63.40 leaf vectors, 95.72 vectors, 20.92 full vectors, 8.94 partitions
 
 recall topk=10 beam-size=8 samples=50
 ----
-84.00% recall@10
-147.94 leaf vectors, 216.26 vectors, 26.22 full vectors, 18.98 partitions
+78.40% recall@10
+142.32 leaf vectors, 192.82 vectors, 26.20 full vectors, 17.76 partitions
 
 recall topk=10 beam-size=16 samples=50
 ----
-93.40% recall@10
-294.30 leaf vectors, 376.50 vectors, 29.68 full vectors, 32.72 partitions
+93.60% recall@10
+292.12 leaf vectors, 368.62 vectors, 30.52 full vectors, 33.10 partitions
 
 recall topk=10 beam-size=32 samples=50
 ----
-98.80% recall@10
-582.06 leaf vectors, 676.06 vectors, 31.44 full vectors, 58.54 partitions
+98.40% recall@10
+578.32 leaf vectors, 673.14 vectors, 32.86 full vectors, 59.68 partitions

--- a/pkg/sql/vecindex/cspann/testdata/search-for-delete.ddt
+++ b/pkg/sql/vecindex/cspann/testdata/search-for-delete.ddt
@@ -41,14 +41,14 @@ vec13: (1, 7)
     ├───• 5 (6.5, 4.5)
     │   │
     │   ├───• vec7 (6, 5)
-    │   ├───• vec2 (7, 4)
-    │   └───• vec8 (8, 3)
+    │   └───• vec2 (7, 4)
     │
     └───• 3 (3.3333, 2)
         │
         ├───• vec3 (4, 3)
         ├───• vec5 (5, 1)
-        └───• vec1 (1, 2)
+        ├───• vec1 (1, 2)
+        └───• vec8 (8, 3)
 
 # Search for vector that exists.
 search-for-delete
@@ -103,14 +103,14 @@ vec1
     ├───• 5 (6.5, 4.5)
     │   │
     │   ├───• vec7 (6, 5)
-    │   ├───• vec2 (7, 4)
-    │   └───• vec8 (8, 3)
+    │   └───• vec2 (7, 4)
     │
     └───• 3 (3.3333, 2)
         │
         ├───• vec3 (4, 3)
         ├───• vec5 (5, 1)
-        └───• vec1 (MISSING)
+        ├───• vec1 (MISSING)
+        └───• vec8 (8, 3)
 
 # Try to find the missing vector. Since it's in the index, it should be found,
 # even though it's missing from the primary index.
@@ -148,11 +148,11 @@ format-tree
     ├───• 5 (6.5, 4.5)
     │   │
     │   ├───• vec7 (6, 5)
-    │   ├───• vec2 (7, 4)
-    │   └───• vec8 (8, 3)
+    │   └───• vec2 (7, 4)
     │
     └───• 3 (3.3333, 2)
         │
         ├───• vec3 (4, 3)
         ├───• vec5 (5, 1)
-        └───• vec1 (MISSING)
+        ├───• vec1 (MISSING)
+        └───• vec8 (8, 3)

--- a/pkg/sql/vecindex/cspann/testdata/search.ddt
+++ b/pkg/sql/vecindex/cspann/testdata/search.ddt
@@ -58,14 +58,14 @@ vec13: (6, 2)
 │   ├───• vec5 (1, 11)
 │   └───• vec9 (2, 8)
 │
-├───• 6 (0.3333, 3)
+├───• 6 (0, 3.5)
 │   │
 │   ├───• vec10 (0, 3)
 │   ├───• vec7 (0, 4)
-│   ├───• vec1 (1, 2)
-│   └───• vec11 (1, 1)
+│   ├───• vec11 (1, 1)
+│   └───• vec1 (1, 2)
 │
-└───• 7 (5.5, 3.5)
+└───• 7 (5.3333, 3.6667)
     │
     ├───• vec3 (4, 3)
     ├───• vec2 (7, 4)
@@ -76,17 +76,17 @@ vec13: (6, 2)
 search max-results=2 beam-size=1
 (1, 6)
 ----
-vec7: 5 (centroid=1.05)
-vec10: 10 (centroid=0.33)
+vec7: 5 (centroid=0.5)
+vec10: 10 (centroid=0.5)
 4 leaf vectors, 8 vectors, 4 full vectors, 2 partitions
 
 # Search for closest vectors with beam-size=2.
 search max-results=2 beam-size=2
 (1, 6)
 ----
-vec7: 5 (centroid=1.05)
+vec7: 5 (centroid=0.5)
 vec9: 5 (centroid=3.67)
-8 leaf vectors, 12 vectors, 6 full vectors, 3 partitions
+8 leaf vectors, 12 vectors, 7 full vectors, 3 partitions
 
 # ----------
 # Search tree with only duplicate vectors.

--- a/pkg/sql/vecindex/cspann/testdata/split.ddt
+++ b/pkg/sql/vecindex/cspann/testdata/split.ddt
@@ -151,15 +151,15 @@ vec9: (3, 4)
 │
 ├───• 3 (0, 0)
 │   │
-│   ├───• vec1 (-2, -2)
-│   └───• vec2 (0, 0)
+│   ├───• vec3 (2, 2)
+│   ├───• vec2 (0, 0)
+│   └───• vec1 (-2, -2)
 │
 ├───• 4 (3.6667, 3.6667)
 │   │
 │   ├───• vec9 (3, 4)
 │   ├───• vec8 (4, 3)
-│   ├───• vec4 (4, 4)
-│   └───• vec3 (2, 2)
+│   └───• vec4 (4, 4)
 │
 └───• 5 (5.3333, 5.3333)
     │
@@ -205,8 +205,7 @@ vec8: (4, 4)
 │   │
 │   ├───• vec6 (1, -2)
 │   ├───• vec5 (-1, -2)
-│   ├───• vec4 (0, -2)
-│   └───• vec1 (0, 0)
+│   └───• vec4 (0, -2)
 │
 ├───• 4 (-2.5, 2.5)
 │   │
@@ -215,8 +214,9 @@ vec8: (4, 4)
 │
 └───• 5 (1.6667, 1.6667)
     │
-    ├───• vec8 (4, 4)
-    └───• vec3 (1, 1)
+    ├───• vec1 (0, 0)
+    ├───• vec3 (1, 1)
+    └───• vec8 (4, 4)
 
 # ----------
 # Test splits in the presence of dangling vectors.
@@ -372,7 +372,7 @@ vec5: (2, 2)
     ├───• vec4 (4, 3)
     └───• vec5 (2, 2)
 
-force-split partition-key=3
+force-split-or-merge partition-key=3
 ----
 • 1 (1.25, 4.75)
 │
@@ -412,7 +412,7 @@ vec9: (1, 1)
     └───• vec9 (1, 1)
 
 # Even split partition is greater than max-partition-size.
-force-split partition-key=3 parent-partition-key=2
+force-split-or-merge partition-key=3 parent-partition-key=2
 ----
 • 1 (1.25, 4.75)
 │

--- a/pkg/sql/vecindex/cspann/testdata/tree-key.ddt
+++ b/pkg/sql/vecindex/cspann/testdata/tree-key.ddt
@@ -63,7 +63,7 @@ vec6
     └───• vec5 (14, 1)
 
 # Merge partition in tree #2.
-force-merge partition-key=3 parent-partition-key=1 tree=2
+force-split-or-merge partition-key=3 parent-partition-key=1 tree=2
 ----
 • 1 (4.5, 4.0833)
 │

--- a/pkg/sql/vecindex/manager_test.go
+++ b/pkg/sql/vecindex/manager_test.go
@@ -152,7 +152,7 @@ func TestVectorManager(t *testing.T) {
 	t.Run("test metrics", func(t *testing.T) {
 		idx, err := vectorMgr.Get(ctx, catid.DescID(140), 2)
 		require.NoError(t, err)
-		idx.ForceSplit(ctx, nil, 0, cspann.RootKey)
+		idx.ForceSplitOrMerge(ctx, nil, 0, cspann.RootKey)
 
 		metrics := vectorMgr.Metrics().(*vecindex.Metrics)
 		require.Equal(t, int64(1), metrics.FixupsAdded.Count())

--- a/pkg/sql/vecindex/searcher_test.go
+++ b/pkg/sql/vecindex/searcher_test.go
@@ -95,7 +95,7 @@ func TestSearcher(t *testing.T) {
 		keyBytes := keys.MakeFamilyKey(encoding.EncodeVarintAscending([]byte{}, key), 0 /* famID */)
 		randomizedVec := make(vector.T, len(vec))
 		idx.RandomizeVector(vec, randomizedVec)
-		_, err = mutator.txn.AddToPartition(ctx, cspann.TreeKey(prefix), partitionKey,
+		err = mutator.txn.AddToPartition(ctx, cspann.TreeKey(prefix), partitionKey,
 			randomizedVec, cspann.ChildKey{KeyBytes: keyBytes}, val)
 		require.NoError(t, err)
 		return randomizedVec

--- a/pkg/sql/vecindex/vecindex_test.go
+++ b/pkg/sql/vecindex/vecindex_test.go
@@ -1,0 +1,103 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package vecindex_test
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/sql/vecindex/cspann/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/vector"
+)
+
+// TestVecindexConcurrency builds an index on multiple goroutines, with
+// background splits and merges enabled.
+func TestVecindexConcurrency(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	srv, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	runner := sqlutils.MakeSQLRunner(sqlDB)
+	defer srv.Stopper().Stop(ctx)
+
+	// Construct the table.
+	runner.Exec(t, "CREATE TABLE t (id INT PRIMARY KEY, v VECTOR(512), VECTOR INDEX (v))")
+
+	// Load features.
+	vectors := testutils.LoadFeatures(t, 100)
+
+	for i := 0; i < 1; i++ {
+		buildIndex(ctx, t, runner, vectors)
+	}
+}
+
+func buildIndex(ctx context.Context, t *testing.T, runner *sqlutils.SQLRunner, vectors vector.Set) {
+	var insertCount atomic.Uint64
+
+	// Insert block of vectors within the scope of a transaction.
+	insertBlock := func(start, end int) {
+		var valuesClause strings.Builder
+		args := make([]interface{}, (end-start)*2)
+		for i := start; i < end; i++ {
+			argOffset := i - start
+			if argOffset > 0 {
+				valuesClause.WriteString(", ")
+			}
+			valuesClause.WriteString(fmt.Sprintf("($%d, $%d)", argOffset*2+1, argOffset*2+2))
+			args[argOffset*2] = i
+			args[argOffset*2+1] = vectors.At(i).String()
+		}
+
+		// Execute the batch insert.
+		query := fmt.Sprintf("INSERT INTO t (id, v) VALUES %s", valuesClause.String())
+		runner.Exec(t, query, args...)
+
+		insertCount.Add(uint64(end - start))
+	}
+
+	// Insert vectors into the store on multiple goroutines.
+	var wait sync.WaitGroup
+	// TODO(andyk): replace with runtime.GOMAXPROCS(-1) once contention is solved.
+	procs := 1
+	countPerProc := (vectors.Count + procs) / procs
+	const blockSize = 1
+	for i := 0; i < vectors.Count; i += countPerProc {
+		end := min(i+countPerProc, vectors.Count)
+		wait.Add(1)
+		go func(start, end int) {
+			defer wait.Done()
+
+			// Break vector group into individual transactions that each insert a
+			// block of vectors.
+			for j := start; j < end; j += blockSize {
+				insertBlock(j, min(j+blockSize, end))
+			}
+		}(i, end)
+	}
+
+	for int(insertCount.Load()) < vectors.Count {
+		time.Sleep(time.Second)
+		log.Infof(ctx, "inserted %d vectors", insertCount.Load())
+	}
+
+	wait.Wait()
+
+	// Fail on foreground goroutine if any background goroutines failed.
+	if t.Failed() {
+		t.FailNow()
+	}
+}

--- a/pkg/sql/vecindex/vecstore/BUILD.bazel
+++ b/pkg/sql/vecindex/vecstore/BUILD.bazel
@@ -45,6 +45,7 @@ go_test(
     deps = [
         "//pkg/base",
         "//pkg/keys",
+        "//pkg/kv/kvpb",
         "//pkg/security/securityassets",
         "//pkg/security/securitytest",
         "//pkg/server",

--- a/pkg/sql/vecindex/vecstore/store_test.go
+++ b/pkg/sql/vecindex/vecstore/store_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catenumpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
@@ -132,6 +133,9 @@ func TestStore(t *testing.T) {
 			vCol.GetID(),
 		)
 		require.NoError(t, err)
+
+		// Use CONSISTENT reads to ensure test is deterministic.
+		store.SetMinimumConsistency(kvpb.CONSISTENT)
 
 		return &testStore{Store: store, usePrefix: usePrefix, runner: runner}
 	}


### PR DESCRIPTION
Previously, we checked the size of a partition after adding or removing a vector to/from it. The main reason for doing this was to decide whether the partition needed to be split or merged. However, this added to the contention footprint of the user's transaction. This commit moves the partition size check to the background processor, as part of the SplitOrMergeFixup, and makes the size scan INCONSISTENT. While this can return stale data, it's OK if a split or merge gets delayed because of that. If the inconsistent check indicates that a split or merge may be necessary, we run a consistent scan to ensure that it's really necessary.

Besides being used to check for splits/merges, the partition size scan was used to ensure that we don't create an unbalanced K-means tree by moving the last vector of a non-root partition to a sibling partition. Now that RemoveFromPartition no longer returns a count, we instead use a new "skipLonelyVector" option when searching. This option stops the search from returning any vectors that are last in their partition, which prevents the creation of empty non-root partitions.

Epic: CRDB-42943

Release note: None