### PR TITLE
aggmetric: replace btree with UnorderedCache

### DIFF
--- a/pkg/util/metric/aggmetric/BUILD.bazel
+++ b/pkg/util/metric/aggmetric/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/util/metric/aggmetric",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/util/cache",
         "//pkg/util/metric",
         "//pkg/util/metric/tick",
         "//pkg/util/syncutil",

--- a/pkg/util/metric/aggmetric/agg_metric.go
+++ b/pkg/util/metric/aggmetric/agg_metric.go
@@ -11,10 +11,10 @@ package aggmetric
 import (
 	"strings"
 
+	"github.com/cockroachdb/cockroach/pkg/util/cache"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/errors"
-	"github.com/google/btree"
 	io_prometheus_client "github.com/prometheus/client_model/go"
 )
 
@@ -62,14 +62,21 @@ func (b Builder) Histogram(opts metric.HistogramOptions) *AggHistogram {
 type childSet struct {
 	labels []string
 	mu     struct {
+		// TODO(arjunmahishi): this should probably be RWMutex. Because in some
+		// places, we are just reading the cache.
 		syncutil.Mutex
-		tree *btree.BTree
+		children *cache.UnorderedCache
 	}
 }
 
 func (cs *childSet) init(labels []string) {
 	cs.labels = labels
-	cs.mu.tree = btree.New(8)
+	cs.mu.children = cache.NewUnorderedCache(cache.Config{
+		Policy: cache.CacheLRU,
+		ShouldEvict: func(size int, key, value interface{}) bool {
+			return size > 2000 // TODO: make this configurable
+		},
+	})
 }
 
 func (cs *childSet) Each(
@@ -77,8 +84,8 @@ func (cs *childSet) Each(
 ) {
 	cs.mu.Lock()
 	defer cs.mu.Unlock()
-	cs.mu.tree.Ascend(func(item btree.Item) (wantMore bool) {
-		cm := item.(childMetric)
+	cs.mu.children.Do(func(e *cache.Entry) {
+		cm := e.Value.(childMetric)
 		pm := cm.ToPrometheusMetric()
 		childLabels := make([]*io_prometheus_client.LabelPair, 0, len(labels)+len(cs.labels))
 		childLabels = append(childLabels, labels...)
@@ -91,17 +98,6 @@ func (cs *childSet) Each(
 		}
 		pm.Label = childLabels
 		f(pm)
-		return true
-	})
-}
-
-// apply applies the given applyFn to every item in the childSet
-func (cs *childSet) apply(applyFn func(item btree.Item)) {
-	cs.mu.Lock()
-	defer cs.mu.Unlock()
-	cs.mu.tree.Ascend(func(item btree.Item) bool {
-		applyFn(item)
-		return true
 	})
 }
 
@@ -114,24 +110,43 @@ func (cs *childSet) add(metric childMetric) {
 	}
 	cs.mu.Lock()
 	defer cs.mu.Unlock()
-	if cs.mu.tree.Has(metric) {
+
+	key := metricKey(lvs...)
+	if _, ok := cs.mu.children.Get(key); ok {
 		panic(errors.AssertionFailedf("child %v already exists", metric.labelValues()))
 	}
-	cs.mu.tree.ReplaceOrInsert(metric)
+	cs.mu.children.Add(key, metric)
+}
+
+func (cs *childSet) get(labelVals ...string) (childMetric, bool) {
+	cs.mu.Lock()
+	defer cs.mu.Unlock()
+
+	if v, ok := cs.mu.children.Get(metricKey(labelVals...)); ok {
+		return v.(childMetric), true
+	}
+
+	return nil, false
 }
 
 func (cs *childSet) remove(metric childMetric) {
 	cs.mu.Lock()
 	defer cs.mu.Unlock()
-	if existing := cs.mu.tree.Delete(metric); existing == nil {
-		panic(errors.AssertionFailedf(
-			"child %v does not exists", metric.labelValues()))
+
+	key := metricKey(metric.labelValues()...)
+	if _, ok := cs.mu.children.Get(key); ok {
+		cs.mu.children.Del(key)
+		return
 	}
+	panic(errors.AssertionFailedf("child %v does not exists", metric.labelValues()))
+}
+
+type MetricItem interface {
+	labelValuer
 }
 
 type childMetric interface {
-	btree.Item
-	labelValuer
+	MetricItem
 	ToPrometheusMetric() *io_prometheus_client.Metric
 }
 
@@ -143,16 +158,14 @@ type labelValuesSlice []string
 
 func (lv *labelValuesSlice) labelValues() []string { return []string(*lv) }
 
-func (lv *labelValuesSlice) Less(o btree.Item) bool {
-	ov := o.(labelValuer).labelValues()
-	if len(ov) != len(*lv) {
-		panic(errors.AssertionFailedf("mismatch in label values lengths %v vs %v",
-			ov, *lv))
-	}
-	for i := range ov {
-		if cmp := strings.Compare((*lv)[i], ov[i]); cmp != 0 {
-			return cmp < 0
-		}
-	}
-	return false // eq
+func metricKey(labels ...string) string {
+	return strings.Join(labels, ",")
+}
+
+func (cs *childSet) apply(applyFn func(item MetricItem)) {
+	cs.mu.Lock()
+	defer cs.mu.Unlock()
+	cs.mu.children.Do(func(e *cache.Entry) {
+		applyFn(e.Value.(MetricItem))
+	})
 }

--- a/pkg/util/metric/aggmetric/counter.go
+++ b/pkg/util/metric/aggmetric/counter.go
@@ -9,6 +9,7 @@ import (
 	"sync/atomic"
 
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
+	"github.com/cockroachdb/errors"
 	"github.com/gogo/protobuf/proto"
 	io_prometheus_client "github.com/prometheus/client_model/go"
 )
@@ -80,6 +81,26 @@ func (c *AggCounter) AddChild(labelVals ...string) *Counter {
 	}
 	c.add(child)
 	return child
+}
+
+// Inc increments the counter value by i for the given label values. If a
+// counter with the given label values doesn't exist yet, it creates a new
+// counter and increments it. Panics if the number of label values doesn't
+// match the number of labels defined for this counter.
+func (c *AggCounter) Inc(i int64, labelVals ...string) {
+	if len(c.labels) != len(labelVals) {
+		panic(errors.AssertionFailedf(
+			"cannot increment child with %d label values %v to a metric with %d labels %v",
+			len(labelVals), labelVals, len(c.labels), c.labels))
+	}
+
+	if child, ok := c.get(labelVals...); ok {
+		child.(*Counter).Inc(i)
+		return
+	}
+
+	child := c.AddChild(labelVals...)
+	child.Inc(i)
 }
 
 // Counter is a child of a AggCounter. When it is incremented, so too is the

--- a/pkg/util/metric/aggmetric/gauge.go
+++ b/pkg/util/metric/aggmetric/gauge.go
@@ -9,9 +9,9 @@ import (
 	"math"
 	"sync/atomic"
 
+	"github.com/cockroachdb/cockroach/pkg/util/cache"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/gogo/protobuf/proto"
-	"github.com/google/btree"
 	io_prometheus_client "github.com/prometheus/client_model/go"
 )
 
@@ -46,10 +46,9 @@ func NewFunctionalGauge(
 		values := make([]int64, 0)
 		g.childSet.mu.Lock()
 		defer g.childSet.mu.Unlock()
-		g.childSet.mu.tree.Ascend(func(item btree.Item) (wantMore bool) {
-			cg := item.(*Gauge)
+		g.childSet.mu.children.Do(func(e *cache.Entry) {
+			cg := e.Value.(*Gauge)
 			values = append(values, cg.Value())
-			return true
 		})
 		return f(values)
 	}

--- a/pkg/util/metric/aggmetric/histogram.go
+++ b/pkg/util/metric/aggmetric/histogram.go
@@ -13,7 +13,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
-	"github.com/google/btree"
 	prometheusgo "github.com/prometheus/client_model/go"
 )
 
@@ -78,7 +77,7 @@ func NewHistogram(opts metric.HistogramOptions, childLabels ...string) *AggHisto
 			// Atomically rotate the histogram window for the
 			// parent histogram, and all the child histograms.
 			a.h.Tick()
-			a.childSet.apply(func(childItem btree.Item) {
+			a.childSet.apply(func(childItem MetricItem) {
 				childHist, ok := childItem.(*Histogram)
 				if !ok {
 					panic(errors.AssertionFailedf(


### PR DESCRIPTION
Currently, Agg metrics internally use btree to store the label set of metrics. But we are not actually using any of the btree specific features like range queries or ordered iteration. We are only adding, deleting, looking up exact keys and iterating over all the keys. A hash map based data structure is a better fit for this use case. This commit replaces the btree with an UnorderedCache.

This UnorderedCache is configured with an LRU based eviction policy and sets a max size limit on the number of items stored in the cache. This will also help us manage the cardinality of the metrics.

Release note: none