### PR TITLE
kvserver: tighten up truncation heuristics

### DIFF
--- a/pkg/kv/kvserver/raft_log_queue.go
+++ b/pkg/kv/kvserver/raft_log_queue.go
@@ -522,7 +522,7 @@ func computeTruncateDecision(input truncateDecisionInput) truncateDecision {
 	//
 	// TODO(pav-kv): source everything from raft.LogSnapshot, and there will be no
 	// discrepancy between commit index and last index.
-	decision.ProtectIndex(decision.CommitIndex, truncatableIndexChosenViaCommitIndex)
+	decision.ProtectIndex(decision.CommitIndex+1, truncatableIndexChosenViaCommitIndex)
 
 	for _, progress := range input.RaftStatus.Progress {
 		// Snapshots are expensive, so we try our best to avoid truncating past
@@ -609,7 +609,7 @@ func computeTruncateDecision(input truncateDecisionInput) truncateDecision {
 	//         FirstIndex    <= LastIndex                                    (0)
 	//         NewFirstIndex >= FirstIndex                                   (1)
 	//         NewFirstIndex <= LastIndex                                    (2)
-	//         NewFirstIndex <= CommitIndex                                  (3)
+	//         NewFirstIndex <= CommitIndex + 1                              (3)
 	//
 	// (1) asserts that we're not regressing our FirstIndex
 	// (2) asserts that our we don't truncate past the last index we can
@@ -633,7 +633,7 @@ func computeTruncateDecision(input truncateDecisionInput) truncateDecision {
 	logIndexValid := logEmpty ||
 		(decision.NewFirstIndex >= input.FirstIndex) && (decision.NewFirstIndex <= input.LastIndex)
 	commitIndexValid := noCommittedEntries ||
-		(decision.NewFirstIndex <= decision.CommitIndex)
+		(decision.NewFirstIndex <= decision.CommitIndex+1)
 	valid := logIndexValid && commitIndexValid
 	if !valid {
 		err := fmt.Sprintf("invalid truncation decision: output = %d, input: [%d, %d], commit idx = %d",

--- a/pkg/kv/kvserver/raft_log_queue.go
+++ b/pkg/kv/kvserver/raft_log_queue.go
@@ -679,11 +679,11 @@ func (rlq *raftLogQueue) shouldQueueImpl(
 		return true, !decision.Input.LogSizeTrusted, float64(decision.Input.LogSize)
 	}
 	if decision.Input.LogSizeTrusted ||
-		decision.Input.LastIndex == decision.Input.FirstIndex {
+		decision.Input.FirstIndex > decision.Input.LastIndex {
 
 		return false, false, 0
 	}
-	// We have a nonempty log (first index != last index) and can't vouch that
+	// We have a nonempty log (first index <= last index) and can't vouch that
 	// the bytes in the log are known. Queue the replica; processing it will
 	// force a recomputation. For the priority, we have to pick one as we
 	// usually use the log size which is not available here. Going half-way

--- a/pkg/kv/kvserver/raft_log_queue_test.go
+++ b/pkg/kv/kvserver/raft_log_queue_test.go
@@ -97,7 +97,7 @@ func TestComputeTruncateDecision(t *testing.T) {
 			// We're not truncating anything, but one follower is already cut off. There's no pending
 			// snapshot so we shouldn't be causing any additional snapshots.
 			2, []uint64{1, 5, 5}, 100, 2, 2, 0,
-			"should truncate: false [truncate 0 entries to first index 2 (chosen via: first index)]",
+			"should truncate: false [truncate 0 entries to first index 2 (chosen via: last index)]",
 		},
 		{
 			// The happy case.
@@ -119,18 +119,18 @@ func TestComputeTruncateDecision(t *testing.T) {
 		{
 			// Log is below target size, so respecting the slowest follower.
 			3, []uint64{1, 2, 3, 4}, 100, 1, 5, 0,
-			"should truncate: false [truncate 0 entries to first index 1 (chosen via: followers)]",
+			"should truncate: false [truncate 1 entries to first index 2 (chosen via: followers)]",
 		},
 		{
 			// Truncating since local log starts at 2. One follower is already cut off without a pending
 			// snapshot.
 			2, []uint64{1, 2, 3, 4}, 100, 2, 2, 0,
-			"should truncate: false [truncate 0 entries to first index 2 (chosen via: first index)]",
+			"should truncate: false [truncate 0 entries to first index 2 (chosen via: last index)]",
 		},
 		// Don't truncate off active followers, even if over targetSize.
 		{
-			3, []uint64{1, 3, 3, 4}, 2000, 1, 3, 0,
-			"should truncate: false [truncate 0 entries to first index 1 (chosen via: followers); log too large (2.0 KiB > 1000 B)]",
+			3, []uint64{1, 3, 3, 4}, 2000, 2, 3, 0,
+			"should truncate: false [truncate 0 entries to first index 2 (chosen via: followers); log too large (2.0 KiB > 1000 B)]",
 		},
 		// Don't truncate away pending snapshot, even when log too large.
 		{
@@ -139,7 +139,7 @@ func TestComputeTruncateDecision(t *testing.T) {
 		},
 		{
 			3, []uint64{1, 3, 3, 4}, 2000, 2, 3, 0,
-			"should truncate: false [truncate 0 entries to first index 2 (chosen via: first index); log too large (2.0 KiB > 1000 B)]",
+			"should truncate: false [truncate 0 entries to first index 2 (chosen via: followers); log too large (2.0 KiB > 1000 B)]",
 		},
 		{
 			3, []uint64{1, 3, 3, 4}, 2000, 3, 3, 0,
@@ -235,7 +235,7 @@ func TestComputeTruncateDecisionProgressStatusProbe(t *testing.T) {
 		},
 		true: {
 			true:  "should truncate: false [truncate 0 entries to first index 10 (chosen via: probing follower); log too large (2.0 KiB > 1.0 KiB)]",
-			false: "should truncate: true [truncate 190 entries to first index 200 (chosen via: followers); log too large (2.0 KiB > 1.0 KiB)]",
+			false: "should truncate: true [truncate 191 entries to first index 201 (chosen via: followers); log too large (2.0 KiB > 1.0 KiB)]",
 		},
 	}
 

--- a/pkg/kv/kvserver/raft_log_queue_test.go
+++ b/pkg/kv/kvserver/raft_log_queue_test.go
@@ -152,8 +152,8 @@ func TestComputeTruncateDecision(t *testing.T) {
 		},
 		// Never truncate past the commit index.
 		{
-			3, []uint64{3, 3, 6}, 100, 2, 7, 0,
-			"should truncate: false [truncate 1 entries to first index 3 (chosen via: commit)]",
+			3, []uint64{4, 4, 6}, 100, 2, 7, 0,
+			"should truncate: false [truncate 2 entries to first index 4 (chosen via: commit)]",
 		},
 		// Never truncate past the last index.
 		{

--- a/pkg/kv/kvserver/raft_log_queue_test.go
+++ b/pkg/kv/kvserver/raft_log_queue_test.go
@@ -806,12 +806,12 @@ func TestRaftLogQueueShouldQueueRecompute(t *testing.T) {
 	_ = rlq
 
 	// NB: Cases for which decision.ShouldTruncate() is true are tested in
-	// TestComputeTruncateDecision, so here the decision itself is never
-	// positive.
+	// TestComputeTruncateDecision, so here the decision itself is never positive.
 	var decision truncateDecision
 	decision.Input.LogSizeTrusted = true
 	decision.Input.LogSize = 12
 	decision.Input.MaxLogSize = 1000
+	decision.Input.FirstIndex = 1 // LastIndex == 0, so it's an empty log
 
 	verify := func(shouldQ bool, recompute bool, prio float64) {
 		t.Helper()
@@ -835,7 +835,7 @@ func TestRaftLogQueueShouldQueueRecompute(t *testing.T) {
 
 	// Check all boxes except that log is empty.
 	decision = golden
-	decision.Input.LastIndex = decision.Input.FirstIndex
+	decision.Input.LastIndex = decision.Input.FirstIndex - 1
 	verify(false, false, 0)
 }
 

--- a/pkg/kv/kvserver/raft_log_queue_test.go
+++ b/pkg/kv/kvserver/raft_log_queue_test.go
@@ -108,13 +108,13 @@ func TestComputeTruncateDecision(t *testing.T) {
 			// No truncation, but the outstanding snapshot is made obsolete by the truncation. However
 			// it was already obsolete before. (This example is also not one you could manufacture in
 			// a real system).
-			2, []uint64{5, 5, 5}, 100, 2, 2, 1,
-			"should truncate: false [truncate 0 entries to first index 2 (chosen via: first index)]",
+			3, []uint64{5, 5, 5}, 100, 3, 3, 1,
+			"should truncate: false [truncate 0 entries to first index 3 (chosen via: first index)]",
 		},
 		{
 			// Respecting the pending snapshot.
 			5, []uint64{5, 5, 5}, 100, 2, 5, 3,
-			"should truncate: false [truncate 1 entries to first index 3 (chosen via: pending snapshot)]",
+			"should truncate: false [truncate 2 entries to first index 4 (chosen via: pending snapshot)]",
 		},
 		{
 			// Log is below target size, so respecting the slowest follower.
@@ -135,7 +135,7 @@ func TestComputeTruncateDecision(t *testing.T) {
 		// Don't truncate away pending snapshot, even when log too large.
 		{
 			100, []uint64{100, 100}, 2000, 1, 100, 50,
-			"should truncate: false [truncate 49 entries to first index 50 (chosen via: pending snapshot); log too large (2.0 KiB > 1000 B)]",
+			"should truncate: false [truncate 50 entries to first index 51 (chosen via: pending snapshot); log too large (2.0 KiB > 1000 B)]",
 		},
 		{
 			3, []uint64{1, 3, 3, 4}, 2000, 2, 3, 0,
@@ -148,7 +148,7 @@ func TestComputeTruncateDecision(t *testing.T) {
 		// Respecting the pending snapshot.
 		{
 			7, []uint64{4}, 2000, 1, 7, 1,
-			"should truncate: false [truncate 0 entries to first index 1 (chosen via: pending snapshot); log too large (2.0 KiB > 1000 B)]",
+			"should truncate: false [truncate 1 entries to first index 2 (chosen via: pending snapshot); log too large (2.0 KiB > 1000 B)]",
 		},
 		// Never truncate past the commit index.
 		{
@@ -162,8 +162,8 @@ func TestComputeTruncateDecision(t *testing.T) {
 		},
 		// Never truncate "before the first index".
 		{
-			3, []uint64{5}, 100, 2, 3, 1,
-			"should truncate: false [truncate 0 entries to first index 2 (chosen via: first index)]",
+			4, []uint64{5}, 100, 3, 4, 1,
+			"should truncate: false [truncate 0 entries to first index 3 (chosen via: first index)]",
 		},
 	}
 	for i, c := range testCases {
@@ -320,8 +320,8 @@ func TestTruncateDecisionNumSnapshots(t *testing.T) {
 
 	decision := truncateDecision{Input: truncateDecisionInput{RaftStatus: status}}
 	assert.Equal(t, 0, decision.raftSnapshotsForIndex(10))
-	assert.Equal(t, 1, decision.raftSnapshotsForIndex(11))
-	assert.Equal(t, 3, decision.raftSnapshotsForIndex(12))
+	assert.Equal(t, 0, decision.raftSnapshotsForIndex(11))
+	assert.Equal(t, 1, decision.raftSnapshotsForIndex(12))
 	assert.Equal(t, 3, decision.raftSnapshotsForIndex(13))
 }
 


### PR DESCRIPTION
There are a bunch of +- 1 "errors" in `computeTruncateDecision` which result in under-truncating. For example, the last log entry was never truncated. This PR fixes all these cases.

This also contributes to how much of the raft log is flushed from memtables. The fact that the last entry was never truncated means there would often be at least 1 non-trivial entry to flush (in addition to the latest truncation command itself).

Epic: none
Release note: none