### PR TITLE
kvserver: deflake TestSplitBurstWithSlowFollower

### DIFF
--- a/pkg/kv/kvserver/client_split_burst_test.go
+++ b/pkg/kv/kvserver/client_split_burst_test.go
@@ -160,9 +160,9 @@ func TestSplitBurstWithSlowFollower(t *testing.T) {
 		// even though there is a slow follower, `splitDelayHelper` isn't interested in
 		// delaying this here (which would imply that it's trying to check that every-
 		// one is "caught up").
-		// We set a 100s timeout so that below we can assert that `splitDelayHelper`
+		// We set a 200s timeout so that below we can assert that `splitDelayHelper`
 		// isn't somehow forcing us to wait here.
-		infiniteDelay := 100 * time.Second
+		infiniteDelay := 200 * time.Second
 		sbt := setupSplitBurstTest(t, infiniteDelay)
 		defer sbt.Stopper().Stop(ctx)
 


### PR DESCRIPTION
We saw a couple of instances where this test ran for more than what the test considers infinite delay (100s). When this happens, it's fair game for a split to get applied, which breaks the 0 splits got applied at a slow follower test assertion. Double what "infinite" means to this test.

Closes https://github.com/cockroachdb/cockroach/issues/142525

Release note: None