### PR TITLE
ui: refactor jobs detail page to functional components

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/api/jobsApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/jobsApi.ts
@@ -4,8 +4,10 @@
 // included in the /LICENSE file.
 
 import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
+import long from "long";
+import { SWRConfiguration } from "swr";
 
-import { propsToQueryString } from "../util";
+import { propsToQueryString, useSwrWithClusterId } from "../util";
 
 import { fetchData } from "./fetchData";
 
@@ -47,9 +49,19 @@ export const getJobs = (
   );
 };
 
-export const getJob = (
-  req: JobRequest,
-): Promise<cockroach.server.serverpb.JobResponse> => {
+export function useJobDetails(jobId: long, opts: SWRConfiguration = {}) {
+  return useSwrWithClusterId<JobResponse>(
+    { name: "jobDetailsById", jobId },
+    () => getJob({ job_id: jobId }),
+    {
+      revalidateOnFocus: false,
+      revalidateOnReconnect: false,
+      ...opts,
+    },
+  );
+}
+
+export const getJob = (req: JobRequest): Promise<JobResponse> => {
   return fetchData(
     cockroach.server.serverpb.JobResponse,
     `${JOBS_PATH}/${req.job_id}`,

--- a/pkg/ui/workspaces/cluster-ui/src/jobs/jobDetailsPage/jobDetails.spec.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/jobs/jobDetailsPage/jobDetails.spec.tsx
@@ -1,0 +1,117 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+import "@testing-library/jest-dom";
+import { configureStore } from "@reduxjs/toolkit";
+import { render, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import * as H from "history";
+import Long from "long";
+import React from "react";
+import { Provider } from "react-redux";
+import { MemoryRouter } from "react-router";
+
+import * as jobApi from "src/api/jobsApi";
+import { CockroachCloudContext } from "src/contexts";
+
+import { JOB_STATUS_RUNNING, JOB_STATUS_SUCCEEDED } from "../util";
+
+import { JobDetailsPropsV2, JobDetailsV2 } from "./jobDetails";
+
+const mockGetJob = (jobStatus: string | null) => {
+  jest.spyOn(jobApi, "getJob").mockResolvedValue({
+    id: Long.fromNumber(1),
+    status: jobStatus,
+    running_status: "test running status",
+    type: "test job type",
+    statement: "test job statement",
+    description: "test job description",
+    username: "test user",
+    descriptor_ids: [],
+    fraction_completed: jobStatus === JOB_STATUS_SUCCEEDED ? 1 : 0.5,
+    error: "",
+    highwater_decimal: "1",
+    execution_failures: [],
+    coordinator_id: Long.fromNumber(1),
+    messages: [],
+    num_runs: Long.fromNumber(1),
+  });
+};
+
+const mockFetchExecutionDetailFiles = jest.fn().mockResolvedValue({
+  files: ["file1", "file2"],
+});
+
+const mockCollectExecutionDetails = jest.fn().mockImplementation(() => {
+  mockFetchExecutionDetailFiles.mockResolvedValue({
+    files: ["file1", "file2", "file3"],
+  });
+  return Promise.resolve({ req_resp: true });
+});
+
+const createJobDetailsPageProps = (): JobDetailsPropsV2 => {
+  const history = H.createHashHistory();
+  return {
+    adminRoleSelector: jest.fn().mockReturnValue(true),
+    refreshUserSQLRoles: jest.fn(),
+    onFetchExecutionDetailFiles: mockFetchExecutionDetailFiles,
+    onCollectExecutionDetails: mockCollectExecutionDetails,
+    onDownloadExecutionFile: jest.fn(),
+    history: history,
+    location: history.location,
+    match: {
+      url: "",
+      path: history.location.pathname,
+      isExact: false,
+      params: { id: "1" },
+    },
+  };
+};
+
+describe("JobDetailsV2", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+    jest.useRealTimers();
+  });
+
+  const renderPage = () => {
+    const store = configureStore({
+      reducer: {
+        noop: (state = {}) => state,
+      },
+    });
+    return render(
+      <Provider store={store}>
+        <CockroachCloudContext.Provider value={false}>
+          <MemoryRouter>
+            <JobDetailsV2 {...createJobDetailsPageProps()} />
+          </MemoryRouter>
+        </CockroachCloudContext.Provider>
+      </Provider>,
+    );
+  };
+
+  it("refreshes job details periodically", async () => {
+    jest.useFakeTimers();
+    mockGetJob(JOB_STATUS_RUNNING);
+    const { getByText } = renderPage();
+    await waitFor(() => getByText("50.0%"));
+    mockGetJob(JOB_STATUS_SUCCEEDED);
+    jest.advanceTimersByTime(10 * 1000);
+    await waitFor(() => getByText(JOB_STATUS_SUCCEEDED));
+  });
+
+  it("refetches execution files after collection", async () => {
+    mockGetJob(JOB_STATUS_SUCCEEDED);
+    const { getByText, queryByText } = renderPage();
+    await waitFor(() => getByText(JOB_STATUS_SUCCEEDED));
+    userEvent.click(getByText("Advanced Debugging"));
+    await waitFor(() => getByText("file1"));
+    getByText("file2");
+    expect(queryByText("file3")).toBeNull();
+    userEvent.click(getByText("Request Execution Details"));
+    await waitFor(() => getByText("file3"));
+  });
+});

--- a/pkg/ui/workspaces/cluster-ui/src/jobs/jobDetailsPage/jobDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/jobs/jobDetailsPage/jobDetails.tsx
@@ -6,13 +6,20 @@ import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
 import { ArrowLeft } from "@cockroachlabs/icons";
 import { Col, Row, Tabs } from "antd";
 import classNames from "classnames/bind";
-import Long from "long";
+import long from "long";
 import moment from "moment-timezone";
-import React, { useContext } from "react";
+import React, {
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
 import Helmet from "react-helmet";
+import { Selector, useSelector } from "react-redux";
 import { RouteComponentProps } from "react-router-dom";
 
-import { JobRequest, JobResponse } from "src/api/jobsApi";
+import { JobRequest, JobResponse, useJobDetails } from "src/api/jobsApi";
 import { Button } from "src/button";
 import { commonStyles } from "src/common";
 import { CockroachCloudContext } from "src/contexts";
@@ -36,6 +43,8 @@ import {
 } from "src/util";
 
 import {
+  CollectExecutionDetailsRequest,
+  CollectExecutionDetailsResponse,
   GetJobProfilerExecutionDetailRequest,
   GetJobProfilerExecutionDetailResponse,
   ListJobProfilerExecutionDetailsRequest,
@@ -43,9 +52,10 @@ import {
   RequestState,
 } from "../../api";
 import { Timestamp } from "../../timestamp";
-import { isTerminalState } from "../util/jobOptions";
+import { isTerminalState } from "../util";
 
 import { JobProfilerView } from "./jobProfilerView";
+import OverviewTabContent from "./overviewTab";
 
 type JobMessage = JobResponse["messages"][number];
 
@@ -58,6 +68,144 @@ enum TabKeysEnum {
   OVERVIEW = "Overview",
   PROFILER = "Advanced Debugging",
 }
+
+export interface JobDetailsPropsV2<AppState = unknown>
+  extends RouteComponentProps {
+  refreshUserSQLRoles: () => void;
+  onFetchExecutionDetailFiles: (
+    req: ListJobProfilerExecutionDetailsRequest,
+  ) => Promise<ListJobProfilerExecutionDetailsResponse>;
+  onCollectExecutionDetails: (
+    req: CollectExecutionDetailsRequest,
+  ) => Promise<CollectExecutionDetailsResponse>;
+  onDownloadExecutionFile: (
+    req: GetJobProfilerExecutionDetailRequest,
+  ) => Promise<GetJobProfilerExecutionDetailResponse>;
+  adminRoleSelector: Selector<AppState, UIConfigState["hasAdminRole"]>;
+}
+
+export function JobDetailsV2<AppState = unknown>({
+  history,
+  match,
+  refreshUserSQLRoles,
+  onFetchExecutionDetailFiles,
+  onCollectExecutionDetails,
+  onDownloadExecutionFile,
+  adminRoleSelector,
+}: JobDetailsPropsV2<AppState>): React.ReactElement {
+  const ccContext = useContext(CockroachCloudContext);
+  const hasAdminRole = useSelector(adminRoleSelector);
+  const jobId = useMemo(
+    () => long.fromString(getMatchParamByName(match, idAttr)),
+    [match],
+  );
+  const [jobTerminal, setJobTerminal] = useState(false);
+  const {
+    data: job,
+    error,
+    isLoading,
+  } = useJobDetails(jobId, {
+    refreshInterval: 10 * 1000,
+    keepPreviousData: true,
+    isPaused: () => jobTerminal,
+  });
+  const searchParams = useMemo(() => {
+    return new URLSearchParams(history.location.search);
+  }, [history.location.search]);
+  const [currentTab, setCurrentTab] = React.useState<string>(
+    searchParams.get("tab") || "overview",
+  );
+  const onTabChange = useCallback(
+    (tabId: string): void => {
+      searchParams.set("tab", tabId);
+      setCurrentTab(tabId);
+      history.replace({
+        ...history.location,
+        search: searchParams.toString(),
+      });
+    },
+    [history, searchParams],
+  );
+  useEffect(() => {
+    refreshUserSQLRoles();
+  }, [refreshUserSQLRoles]);
+  useEffect(() => {
+    if (job) {
+      setJobTerminal(isTerminalState(job.status));
+    }
+  }, [job]);
+
+  return (
+    <div className={jobCx("job-details")}>
+      <Helmet title={"Details | Job"} />
+      <div className={jobCx("section page--header")}>
+        <Button
+          onClick={() => history.goBack()}
+          type="unstyled-link"
+          size="small"
+          icon={<ArrowLeft fontSize={"10px"} />}
+          iconPosition="left"
+          className={commonStyles("small-margin")}
+        >
+          Jobs
+        </Button>
+        <h3 className={jobCx("page--header__title")}>{`Job ID: ${jobId}`}</h3>
+      </div>
+      <section className={jobCx("section section--container")}>
+        <Loading
+          loading={isLoading}
+          page={"job details"}
+          error={error}
+          render={() => (
+            <>
+              <section className={cardCx("summary-card")}>
+                <Row gutter={24}>
+                  <Col className="gutter-row" span={24}>
+                    <SqlBox
+                      value={job?.description ?? "Job not found."}
+                      size={SqlBoxSize.CUSTOM}
+                      format={true}
+                    />
+                  </Col>
+                </Row>
+              </section>
+              <Tabs
+                className={commonStyles("cockroach--tabs")}
+                defaultActiveKey={TabKeysEnum.OVERVIEW}
+                onChange={onTabChange}
+                activeKey={currentTab}
+                items={[
+                  {
+                    key: "overview",
+                    label: TabKeysEnum.OVERVIEW,
+                    children: <OverviewTabContent job={job} />,
+                  },
+                  !ccContext &&
+                    hasAdminRole && {
+                      key: "profiler",
+                      label: TabKeysEnum.PROFILER,
+                      children: (
+                        <JobProfilerView
+                          jobID={jobId}
+                          onFetchExecutionDetailFiles={
+                            onFetchExecutionDetailFiles
+                          }
+                          onCollectExecutionDetails={onCollectExecutionDetails}
+                          onDownloadExecutionFile={onDownloadExecutionFile}
+                        />
+                      ),
+                    },
+                ]}
+              />
+            </>
+          )}
+        />
+      </section>
+    </div>
+  );
+}
+
+// DEPRECATED: Remove once ported over to Cockroach Cloud.
 
 export interface JobDetailsStateProps {
   jobRequest: RequestState<JobResponse>;
@@ -75,7 +223,7 @@ export interface JobDetailsDispatchProps {
   refreshExecutionDetailFiles: (
     req: ListJobProfilerExecutionDetailsRequest,
   ) => void;
-  onRequestExecutionDetails: (jobID: Long) => void;
+  onRequestExecutionDetails: (jobID: long) => void;
   refreshUserSQLRoles: () => void;
 }
 
@@ -109,7 +257,7 @@ export class JobDetails extends React.Component<
 
     this.props.refreshJob(
       new cockroach.server.serverpb.JobRequest({
-        job_id: Long.fromString(getMatchParamByName(this.props.match, idAttr)),
+        job_id: long.fromString(getMatchParamByName(this.props.match, idAttr)),
       }),
     );
   }
@@ -130,27 +278,6 @@ export class JobDetails extends React.Component<
   }
 
   prevPage = (): void => this.props.history.goBack();
-
-  renderProfilerTabContent = (
-    job: cockroach.server.serverpb.JobResponse,
-  ): React.ReactElement => {
-    const id = job?.id;
-    return (
-      <JobProfilerView
-        jobID={id}
-        executionDetailFilesResponse={
-          this.props.jobProfilerExecutionDetailFilesResponse
-        }
-        refreshExecutionDetailFiles={this.props.refreshExecutionDetailFiles}
-        lastUpdated={this.props.jobProfilerLastUpdated}
-        isDataValid={this.props.jobProfilerDataIsValid}
-        onDownloadExecutionFileClicked={
-          this.props.onDownloadExecutionFileClicked
-        }
-        onRequestExecutionDetails={this.props.onRequestExecutionDetails}
-      />
-    );
-  };
 
   renderOverviewTabContent = (job: JobResponse): React.ReactElement => {
     if (!job) {
@@ -338,15 +465,6 @@ export class JobDetails extends React.Component<
                   <TabPane tab={TabKeysEnum.OVERVIEW} key="overview">
                     {this.renderOverviewTabContent(job)}
                   </TabPane>
-                  {!useContext(CockroachCloudContext) &&
-                    this.props.hasAdminRole && (
-                      <TabPane
-                        tab={TabKeysEnum.PROFILER}
-                        key="advancedDebugging"
-                      >
-                        {this.renderProfilerTabContent(job)}
-                      </TabPane>
-                    )}
                 </Tabs>
               </>
             )}

--- a/pkg/ui/workspaces/cluster-ui/src/jobs/jobDetailsPage/jobProfilerView.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/jobs/jobDetailsPage/jobProfilerView.tsx
@@ -9,11 +9,11 @@ import { Space } from "antd";
 import classNames from "classnames";
 import classnames from "classnames/bind";
 import long from "long";
-import moment from "moment-timezone";
-import React, { useCallback, useEffect, useMemo, useState } from "react";
+import React, { useState } from "react";
 
-import { RequestState } from "src/api";
 import {
+  CollectExecutionDetailsRequest,
+  CollectExecutionDetailsResponse,
   GetJobProfilerExecutionDetailRequest,
   GetJobProfilerExecutionDetailResponse,
   ListJobProfilerExecutionDetailsRequest,
@@ -24,40 +24,101 @@ import { EmptyTable } from "src/empty";
 import { ColumnDescriptor, SortSetting, SortedTable } from "src/sortedtable";
 import { SummaryCard, SummaryCardItem } from "src/summaryCard";
 import summaryCardStyles from "src/summaryCard/summaryCard.module.scss";
-import { useScheduleFunction } from "src/util/hooks";
+import {
+  useSwrMutationWithClusterId,
+  useSwrWithClusterId,
+} from "src/util/hooks";
 
 import styles from "./jobProfilerView.module.scss";
 
 const cardCx = classNames.bind(summaryCardStyles);
 const cx = classnames.bind(styles);
 
-export type JobProfilerStateProps = {
+export interface JobProfilerViewProps {
   jobID: long;
-  executionDetailFilesResponse: RequestState<ListJobProfilerExecutionDetailsResponse>;
-  lastUpdated: moment.Moment;
-  isDataValid: boolean;
-  onDownloadExecutionFileClicked: (
+  onFetchExecutionDetailFiles: (
+    req: ListJobProfilerExecutionDetailsRequest,
+  ) => Promise<ListJobProfilerExecutionDetailsResponse>;
+  onCollectExecutionDetails: (
+    req: CollectExecutionDetailsRequest,
+  ) => Promise<CollectExecutionDetailsResponse>;
+  onDownloadExecutionFile: (
     req: GetJobProfilerExecutionDetailRequest,
   ) => Promise<GetJobProfilerExecutionDetailResponse>;
-};
+}
 
-export type JobProfilerDispatchProps = {
-  refreshExecutionDetailFiles: (
-    req: ListJobProfilerExecutionDetailsRequest,
-  ) => void;
-  onRequestExecutionDetails: (jobID: long) => void;
-};
+export function JobProfilerView({
+  jobID,
+  onFetchExecutionDetailFiles,
+  onCollectExecutionDetails,
+  onDownloadExecutionFile,
+}: JobProfilerViewProps): React.ReactElement {
+  const { data: detailFiles, mutate: refreshFiles } = useSwrWithClusterId(
+    { name: "jobProfilerExecutionFiles", jobID },
+    () => onFetchExecutionDetailFiles({ job_id: jobID }),
+    {
+      refreshInterval: 10 * 1000, // 10s polling interval
+    },
+  );
+  const { trigger } = useSwrMutationWithClusterId(
+    { name: "collectExecutionDetails", jobID },
+    async () => {
+      const resp = await onCollectExecutionDetails({ job_id: jobID });
+      if (resp.req_resp) {
+        refreshFiles();
+      }
+    },
+  );
 
-export type JobProfilerViewProps = JobProfilerStateProps &
-  JobProfilerDispatchProps;
+  const columns = makeJobProfilerViewColumns(jobID, onDownloadExecutionFile);
+  const [sortSetting, setSortSetting] = useState<SortSetting>({
+    ascending: true,
+    columnTitle: "executionDetailFiles",
+  });
+  const onChangeSortSetting = (ss: SortSetting): void => {
+    setSortSetting(ss);
+  };
 
-export function extractFileExtension(filename: string): string {
+  // This URL results in a cluster-wide CPU profile to be collected for 5
+  // seconds. We set `tagfocus` (tf) to only view the samples corresponding to
+  // this job's execution.
+  const url = `debug/pprof/ui/cpu?node=all&seconds=5&labels=true&tf=job.*${jobID}`;
+  return (
+    <Space direction="vertical" size="middle" className={cx("full-width")}>
+      <SummaryCard className={cardCx("summary-card")}>
+        <SummaryCardItem
+          label="Cluster-wide CPU Profile"
+          value={<a href={url}>Profile</a>}
+        />
+        <InlineAlert
+          intent="warning"
+          title="This operation buffers profiles in memory for all the nodes in the cluster and can result in increased memory usage."
+        />
+      </SummaryCard>
+      <Space direction="vertical" align="end" className={cx("full-width")}>
+        <Button intent="secondary" onClick={trigger}>
+          Request Execution Details
+        </Button>
+      </Space>
+      <SortedTable
+        data={detailFiles?.files}
+        columns={columns}
+        tableWrapperClassName={cx("sorted-table")}
+        sortSetting={sortSetting}
+        onChangeSortSetting={onChangeSortSetting}
+        renderNoResult={<EmptyTable title="No execution detail files found." />}
+      />
+    </Space>
+  );
+}
+
+function extractFileExtension(filename: string): string {
   const parts = filename.split(".");
   // The extension is the last part after the last dot (if it exists).
   return parts.length > 1 ? parts[parts.length - 1] : "";
 }
 
-export function getContentTypeForFile(filename: string): string {
+function getContentTypeForFile(filename: string): string {
   const extension = extractFileExtension(filename);
   switch (extension) {
     case "txt":
@@ -71,8 +132,8 @@ export function getContentTypeForFile(filename: string): string {
   }
 }
 
-export function makeJobProfilerViewColumns(
-  jobID: Long,
+function makeJobProfilerViewColumns(
+  jobID: long,
   onDownloadExecutionFileClicked: (
     req: GetJobProfilerExecutionDetailRequest,
   ) => Promise<GetJobProfilerExecutionDetailResponse>,
@@ -157,82 +218,3 @@ export function makeJobProfilerViewColumns(
     },
   ];
 }
-
-export const JobProfilerView: React.FC<JobProfilerViewProps> = ({
-  jobID,
-  executionDetailFilesResponse,
-  lastUpdated,
-  isDataValid,
-  onDownloadExecutionFileClicked,
-  refreshExecutionDetailFiles,
-  onRequestExecutionDetails,
-}: JobProfilerViewProps) => {
-  const columns = makeJobProfilerViewColumns(
-    jobID,
-    onDownloadExecutionFileClicked,
-  );
-  const [sortSetting, setSortSetting] = useState<SortSetting>({
-    ascending: true,
-    columnTitle: "executionDetailFiles",
-  });
-  const req = useMemo(
-    () =>
-      new cockroach.server.serverpb.ListJobProfilerExecutionDetailsRequest({
-        job_id: jobID,
-      }),
-    [jobID],
-  );
-  const refresh = useCallback(() => {
-    refreshExecutionDetailFiles(req);
-  }, [refreshExecutionDetailFiles, req]);
-  const [refetch] = useScheduleFunction(
-    refresh,
-    true,
-    10 * 1000, // 10s polling interval
-    lastUpdated,
-  );
-  useEffect(() => {
-    if (!isDataValid) refetch();
-  }, [isDataValid, refetch]);
-
-  const onChangeSortSetting = (ss: SortSetting): void => {
-    setSortSetting(ss);
-  };
-
-  // This URL results in a cluster-wide CPU profile to be collected for 5
-  // seconds. We set `tagfocus` (tf) to only view the samples corresponding to
-  // this job's execution.
-  const url = `debug/pprof/ui/cpu?node=all&seconds=5&labels=true&tf=job.*${jobID}`;
-  return (
-    <Space direction="vertical" size="middle" className={cx("full-width")}>
-      <SummaryCard className={cardCx("summary-card")}>
-        <SummaryCardItem
-          label="Cluster-wide CPU Profile"
-          value={<a href={url}>Profile</a>}
-        />
-        <InlineAlert
-          intent="warning"
-          title="This operation buffers profiles in memory for all the nodes in the cluster and can result in increased memory usage."
-        />
-      </SummaryCard>
-      <Space direction="vertical" align="end" className={cx("full-width")}>
-        <Button
-          intent="secondary"
-          onClick={() => {
-            onRequestExecutionDetails(jobID);
-          }}
-        >
-          Request Execution Details
-        </Button>
-      </Space>
-      <SortedTable
-        data={executionDetailFilesResponse.data?.files}
-        columns={columns}
-        tableWrapperClassName={cx("sorted-table")}
-        sortSetting={sortSetting}
-        onChangeSortSetting={onChangeSortSetting}
-        renderNoResult={<EmptyTable title="No execution detail files found." />}
-      />
-    </Space>
-  );
-};

--- a/pkg/ui/workspaces/cluster-ui/src/jobs/jobDetailsPage/overviewTab.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/jobs/jobDetailsPage/overviewTab.tsx
@@ -1,0 +1,146 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+//
+import { Col, Row } from "antd";
+import classNames from "classnames/bind";
+import React from "react";
+
+import { JobResponse } from "src/api/jobsApi";
+import { EmptyTable } from "src/empty";
+import jobStyles from "src/jobs/jobs.module.scss";
+import { SortedTable } from "src/sortedtable";
+import { SummaryCard, SummaryCardItem } from "src/summaryCard";
+import summaryCardStyles from "src/summaryCard/summaryCard.module.scss";
+import { Text, TextTypes } from "src/text";
+import {
+  DATE_WITH_SECONDS_FORMAT,
+  DATE_WITH_SECONDS_FORMAT_24_TZ,
+  TimestampToMoment,
+} from "src/util";
+
+import { Timestamp } from "../../timestamp";
+import { HighwaterTimestamp, JobStatusCell } from "../util";
+
+type JobMessage = JobResponse["messages"][number];
+const cardCx = classNames.bind(summaryCardStyles);
+const jobCx = classNames.bind(jobStyles);
+
+interface OverviewTabContentProps {
+  job: JobResponse | null;
+}
+
+export default function OverviewTabContent({
+  job,
+}: OverviewTabContentProps): React.ReactElement {
+  if (!job) {
+    return null;
+  }
+
+  return (
+    <Row gutter={24}>
+      <Col className="gutter-row" span={8}>
+        <Text textType={TextTypes.Heading5} className={jobCx("details-header")}>
+          Details
+        </Text>
+        <SummaryCard className={cardCx("summary-card")}>
+          <SummaryCardItem
+            label="Status"
+            value={
+              <JobStatusCell job={job} lineWidth={1.5} hideDuration={true} />
+            }
+          />
+          <SummaryCardItem
+            label="Creation Time"
+            value={
+              <Timestamp
+                time={TimestampToMoment(job.created, null)}
+                format={DATE_WITH_SECONDS_FORMAT_24_TZ}
+              />
+            }
+          />
+          {job.modified && (
+            <SummaryCardItem
+              label="Last Modified Time"
+              value={
+                <Timestamp
+                  time={TimestampToMoment(job.modified, null)}
+                  format={DATE_WITH_SECONDS_FORMAT_24_TZ}
+                />
+              }
+            />
+          )}
+          {job.finished && (
+            <SummaryCardItem
+              label="Completed Time"
+              value={
+                <Timestamp
+                  time={TimestampToMoment(job.finished, null)}
+                  format={DATE_WITH_SECONDS_FORMAT_24_TZ}
+                />
+              }
+            />
+          )}
+          <SummaryCardItem label="User Name" value={job.username} />
+          {job.highwater_timestamp && (
+            <SummaryCardItem
+              label="High-water Timestamp"
+              value={
+                <HighwaterTimestamp
+                  timestamp={job.highwater_timestamp}
+                  decimalString={job.highwater_decimal}
+                />
+              }
+            />
+          )}
+          <SummaryCardItem
+            label="Coordinator Node"
+            value={
+              job.coordinator_id.isZero() ? "-" : job.coordinator_id.toString()
+            }
+          />
+        </SummaryCard>
+      </Col>
+      <Col className="gutter-row" span={16}>
+        <Text textType={TextTypes.Heading5} className={jobCx("details-header")}>
+          Events
+        </Text>
+        <SummaryCard className={jobCx("messages-card")}>
+          <SortedTable
+            data={job.messages}
+            columns={messageColumns}
+            tableWrapperClassName={jobCx("job-messages", "sorted-table")}
+            renderNoResult={<EmptyTable title="No messages recorded." />}
+          />
+        </SummaryCard>
+      </Col>
+    </Row>
+  );
+}
+
+const messageColumns = [
+  {
+    name: "timestamp",
+    title: "When",
+    hideTitleUnderline: true,
+    cell: (x: JobMessage) => (
+      <Timestamp
+        time={TimestampToMoment(x.timestamp, null)}
+        format={DATE_WITH_SECONDS_FORMAT}
+      />
+    ),
+  },
+  {
+    name: "kind",
+    title: "Kind",
+    hideTitleUnderline: true,
+    cell: (x: JobMessage) => x.kind,
+  },
+  {
+    name: "message",
+    title: "Message",
+    hideTitleUnderline: true,
+    cell: (x: JobMessage) => <p className={jobCx("message")}>{x.message}</p>,
+  },
+];

--- a/pkg/ui/workspaces/cluster-ui/src/util/hooks.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/util/hooks.ts
@@ -8,6 +8,7 @@ import { useEffect, useCallback, useRef, useContext } from "react";
 import useSWR, { SWRConfiguration, SWRResponse } from "swr";
 import { Arguments, Fetcher } from "swr/_internal";
 import useSWRImmutable from "swr/immutable";
+import useSWRMutation, { SWRMutationConfiguration } from "swr/mutation";
 
 import { ClusterDetailsContext } from "../contexts";
 
@@ -168,4 +169,27 @@ export const useSwrImmutableWithClusterId = <
 ): SWRResponse<Data, Error, SWROptions> => {
   const keyWithClusterId = useSwrKeyWithClusterId(key) as SWRKey;
   return useSWRImmutable(keyWithClusterId, fetcher, config);
+};
+
+/**
+ * useSwrMutationWithClusterId is a wrapper around useSWRMutation that adds the cluster id to the key.
+ *
+ * @param key The key, in combination with the clusterId, that will be used for useSWRMutation.
+ * @param fetcher The fetcher to be called by useSWRMutation.
+ * @param config the config to be provided to useSWRMutation.
+ */
+export const useSwrMutationWithClusterId = <
+  Data = any,
+  Error = any,
+  SWRKey = Arguments,
+  SWROptions extends
+    | SWRMutationConfiguration<Data, Error, SWRKey>
+    | undefined = SWRMutationConfiguration<Data, Error, SWRKey> | undefined,
+>(
+  key: SWRKey,
+  fetcher: Fetcher<Data, SWRKey> | null,
+  config?: SWROptions,
+) => {
+  const keyWithClusterId = useSwrKeyWithClusterId(key) as SWRKey;
+  return useSWRMutation(keyWithClusterId, fetcher, config);
 };

--- a/pkg/ui/workspaces/db-console/src/views/jobs/jobDetails.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/jobs/jobDetails.tsx
@@ -2,62 +2,35 @@
 //
 // Use of this software is governed by the CockroachDB Software License
 // included in the /LICENSE file.
-import {
-  JobDetails,
-  JobDetailsStateProps,
-  selectID,
-  api as clusterUiApi,
-} from "@cockroachlabs/cluster-ui";
-import long from "long";
-import { connect } from "react-redux";
+import { api as clusterUiApi, JobDetailsV2 } from "@cockroachlabs/cluster-ui";
+import React from "react";
+import { useDispatch, useStore } from "react-redux";
+import { StaticContext } from "react-router";
 import { RouteComponentProps, withRouter } from "react-router-dom";
 
-import { collectExecutionDetailsAction } from "oss/src/redux/jobs/jobsActions";
-import {
-  createSelectorForKeyedCachedDataField,
-  refreshListExecutionDetailFiles,
-  refreshJob,
-  refreshUserSQLRoles,
-} from "src/redux/apiReducers";
-import { AdminUIState, AppDispatch } from "src/redux/state";
+import { refreshUserSQLRoles } from "src/redux/apiReducers";
 import { selectHasAdminRole } from "src/redux/user";
-import { ListJobProfilerExecutionDetailsResponseMessage } from "src/util/api";
-
-const selectJob = createSelectorForKeyedCachedDataField("job", selectID);
-const selectExecutionDetailFiles =
-  createSelectorForKeyedCachedDataField<ListJobProfilerExecutionDetailsResponseMessage>(
-    "jobProfiler",
-    selectID,
-  );
-const mapStateToProps = (
-  state: AdminUIState,
-  props: RouteComponentProps,
-): JobDetailsStateProps => {
-  const jobID = selectID(state, props);
-  return {
-    jobRequest: selectJob(state, props),
-    jobProfilerExecutionDetailFilesResponse: selectExecutionDetailFiles(
-      state,
-      props,
-    ),
-    jobProfilerLastUpdated: state.cachedData.jobProfiler[jobID]?.setAt,
-    jobProfilerDataIsValid: state.cachedData.jobProfiler[jobID]?.valid,
-    onDownloadExecutionFileClicked: clusterUiApi.getExecutionDetailFile,
-    hasAdminRole: selectHasAdminRole(state),
-  };
-};
-
-const mapDispatchToProps = {
-  refreshJob,
-  refreshExecutionDetailFiles: refreshListExecutionDetailFiles,
-  onRequestExecutionDetails: (jobID: long) => {
-    return (dispatch: AppDispatch) => {
-      dispatch(collectExecutionDetailsAction({ job_id: jobID }));
-    };
-  },
-  refreshUserSQLRoles: refreshUserSQLRoles,
-};
+import { listExecutionDetailFiles } from "src/util/api";
 
 export default withRouter(
-  connect(mapStateToProps, mapDispatchToProps)(JobDetails),
+  (
+    props: React.PropsWithChildren<
+      RouteComponentProps<any, StaticContext, unknown>
+    >,
+  ) => {
+    const store = useStore();
+    const dispatch = useDispatch();
+    return (
+      <JobDetailsV2
+        {...props}
+        refreshUserSQLRoles={() =>
+          refreshUserSQLRoles()(dispatch, store.getState, undefined)
+        }
+        onFetchExecutionDetailFiles={listExecutionDetailFiles}
+        onCollectExecutionDetails={clusterUiApi.collectExecutionDetails}
+        onDownloadExecutionFile={clusterUiApi.getExecutionDetailFile}
+        adminRoleSelector={selectHasAdminRole}
+      />
+    );
+  },
 );


### PR DESCRIPTION
This commit refactors the job details page to use React functional components and hooks. It also begins some work on moving the job details API fetch out of the global state and into local `useSWR` hooks.

Epic: none

Release note: None