### PR TITLE
release-25.1: schemachanger: update subzone configs with new indexID from backfill

### DIFF
--- a/pkg/ccl/schemachangerccl/ccl_generated_test.go
+++ b/pkg/ccl/schemachangerccl/ccl_generated_test.go
@@ -15,6 +15,13 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
 
+func TestBackupRollbacks_ccl_add_column_subzones(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_subzones"
+	sctest.BackupRollbacks(t, path, MultiRegionTestClusterFactory{})
+}
+
 func TestBackupRollbacks_ccl_alter_index_configure_zone(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -104,6 +111,13 @@ func TestBackupRollbacks_ccl_drop_trigger(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	const path = "pkg/ccl/schemachangerccl/testdata/end_to_end/drop_trigger"
 	sctest.BackupRollbacks(t, path, MultiRegionTestClusterFactory{})
+}
+
+func TestBackupRollbacksMixedVersion_ccl_add_column_subzones(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_subzones"
+	sctest.BackupRollbacksMixedVersion(t, path, MultiRegionTestClusterFactory{})
 }
 
 func TestBackupRollbacksMixedVersion_ccl_alter_index_configure_zone(t *testing.T) {
@@ -197,6 +211,13 @@ func TestBackupRollbacksMixedVersion_ccl_drop_trigger(t *testing.T) {
 	sctest.BackupRollbacksMixedVersion(t, path, MultiRegionTestClusterFactory{})
 }
 
+func TestBackupSuccess_ccl_add_column_subzones(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_subzones"
+	sctest.BackupSuccess(t, path, MultiRegionTestClusterFactory{})
+}
+
 func TestBackupSuccess_ccl_alter_index_configure_zone(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -286,6 +307,13 @@ func TestBackupSuccess_ccl_drop_trigger(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	const path = "pkg/ccl/schemachangerccl/testdata/end_to_end/drop_trigger"
 	sctest.BackupSuccess(t, path, MultiRegionTestClusterFactory{})
+}
+
+func TestBackupSuccessMixedVersion_ccl_add_column_subzones(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_subzones"
+	sctest.BackupSuccessMixedVersion(t, path, MultiRegionTestClusterFactory{})
 }
 
 func TestBackupSuccessMixedVersion_ccl_alter_index_configure_zone(t *testing.T) {
@@ -379,6 +407,13 @@ func TestBackupSuccessMixedVersion_ccl_drop_trigger(t *testing.T) {
 	sctest.BackupSuccessMixedVersion(t, path, MultiRegionTestClusterFactory{})
 }
 
+func TestEndToEndSideEffects_ccl_add_column_subzones(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_subzones"
+	sctest.EndToEndSideEffects(t, path, MultiRegionTestClusterFactory{})
+}
+
 func TestEndToEndSideEffects_ccl_alter_index_configure_zone(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -468,6 +503,13 @@ func TestEndToEndSideEffects_ccl_drop_trigger(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	const path = "pkg/ccl/schemachangerccl/testdata/end_to_end/drop_trigger"
 	sctest.EndToEndSideEffects(t, path, MultiRegionTestClusterFactory{})
+}
+
+func TestExecuteWithDMLInjection_ccl_add_column_subzones(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_subzones"
+	sctest.ExecuteWithDMLInjection(t, path, MultiRegionTestClusterFactory{})
 }
 
 func TestExecuteWithDMLInjection_ccl_alter_index_configure_zone(t *testing.T) {
@@ -561,6 +603,13 @@ func TestExecuteWithDMLInjection_ccl_drop_trigger(t *testing.T) {
 	sctest.ExecuteWithDMLInjection(t, path, MultiRegionTestClusterFactory{})
 }
 
+func TestGenerateSchemaChangeCorpus_ccl_add_column_subzones(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_subzones"
+	sctest.GenerateSchemaChangeCorpus(t, path, MultiRegionTestClusterFactory{})
+}
+
 func TestGenerateSchemaChangeCorpus_ccl_alter_index_configure_zone(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -650,6 +699,13 @@ func TestGenerateSchemaChangeCorpus_ccl_drop_trigger(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	const path = "pkg/ccl/schemachangerccl/testdata/end_to_end/drop_trigger"
 	sctest.GenerateSchemaChangeCorpus(t, path, MultiRegionTestClusterFactory{})
+}
+
+func TestPause_ccl_add_column_subzones(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_subzones"
+	sctest.Pause(t, path, MultiRegionTestClusterFactory{})
 }
 
 func TestPause_ccl_alter_index_configure_zone(t *testing.T) {
@@ -743,6 +799,13 @@ func TestPause_ccl_drop_trigger(t *testing.T) {
 	sctest.Pause(t, path, MultiRegionTestClusterFactory{})
 }
 
+func TestPauseMixedVersion_ccl_add_column_subzones(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_subzones"
+	sctest.PauseMixedVersion(t, path, MultiRegionTestClusterFactory{})
+}
+
 func TestPauseMixedVersion_ccl_alter_index_configure_zone(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -832,6 +895,13 @@ func TestPauseMixedVersion_ccl_drop_trigger(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	const path = "pkg/ccl/schemachangerccl/testdata/end_to_end/drop_trigger"
 	sctest.PauseMixedVersion(t, path, MultiRegionTestClusterFactory{})
+}
+
+func TestRollback_ccl_add_column_subzones(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_subzones"
+	sctest.Rollback(t, path, MultiRegionTestClusterFactory{})
 }
 
 func TestRollback_ccl_alter_index_configure_zone(t *testing.T) {

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_subzones/add_column_subzones.definition
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_subzones/add_column_subzones.definition
@@ -1,0 +1,29 @@
+setup
+CREATE TABLE t (
+  k INT PRIMARY KEY,
+  V STRING
+);
+----
+
+stage-exec phase=PostCommitPhase stage=:
+INSERT INTO t VALUES ($stageKey);
+INSERT INTO t VALUES ($stageKey * -1);
+DELETE FROM t WHERE k = $stageKey;
+----
+
+stage-query phase=PostCommitPhase stage=:
+SELECT (
+    SELECT count(DISTINCT (subzone->>'indexId')::INT)
+    FROM jsonb_array_elements(crdb_internal.pb_to_json('cockroach.config.zonepb.ZoneConfig',config)->'subzones') AS subzone
+    WHERE (subzone->>'indexId')::INT IN (1, 2, 3)
+) = 3
+FROM system.zones
+WHERE id = 't'::regclass::oid;
+----
+true
+
+test
+ALTER INDEX t@t_pkey CONFIGURE ZONE USING gc.ttlseconds = 1;
+ALTER TABLE t CONFIGURE ZONE USING gc.ttlseconds = 1;
+ALTER TABLE t ADD COLUMN w TEXT NOT NULL DEFAULT 's';
+----

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_subzones/add_column_subzones.side_effects
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_subzones/add_column_subzones.side_effects
@@ -1,0 +1,707 @@
+/* setup */
+CREATE TABLE t (
+  k INT PRIMARY KEY,
+  V STRING
+);
+----
+...
++object {100 101 t} -> 104
+
+/* test */
+ALTER INDEX t@t_pkey CONFIGURE ZONE USING gc.ttlseconds = 1;
+ALTER TABLE t CONFIGURE ZONE USING gc.ttlseconds = 1;
+ALTER TABLE t ADD COLUMN w TEXT NOT NULL DEFAULT 's';
+----
+begin transaction #1
+# begin StatementPhase
+checking for feature: CONFIGURE ZONE
+write *eventpb.SetZoneConfig to event log:
+  config:
+    options:
+    - '"gc.ttlseconds" = 1'
+    target: INDEX defaultdb.public.t@t_pkey
+  resolvedOldConfig: 'range_min_bytes:134217728 range_max_bytes:536870912 gc:<ttl_seconds:14400 > num_replicas:5 inherited_constraints:false null_voter_constraints_is_empty:true inherited_lease_preferences:false '
+  sql:
+    descriptorId: 104
+    statement: ALTER INDEX ‹defaultdb›.‹public›.‹t›@‹t_pkey› CONFIGURE ZONE USING ‹"gc.ttlseconds"› = ‹1›
+    tag: CONFIGURE ZONE
+    user: root
+## StatementPhase stage 1 of 1 with 1 MutationType op
+upsert zone config for #104
+checking for feature: CONFIGURE ZONE
+write *eventpb.SetZoneConfig to event log:
+  config:
+    options:
+    - '"gc.ttlseconds" = 1'
+    target: TABLE defaultdb.public.t
+  resolvedOldConfig: 'range_min_bytes:134217728 range_max_bytes:536870912 gc:<ttl_seconds:14400 > num_replicas:5 inherited_constraints:false null_voter_constraints_is_empty:true inherited_lease_preferences:false subzones:<index_id:1 partition_name:"" config:<range_min_bytes:134217728 range_max_bytes:536870912 gc:<ttl_seconds:1 > num_replicas:5 inherited_constraints:false null_voter_constraints_is_empty:true inherited_lease_preferences:false > > '
+  sql:
+    descriptorId: 104
+    statement: ALTER TABLE ‹defaultdb›.‹public›.‹t› CONFIGURE ZONE USING ‹"gc.ttlseconds"› = ‹1›
+    tag: CONFIGURE ZONE
+    user: root
+## StatementPhase stage 1 of 1 with 1 MutationType op
+upsert zone config for #104
+checking for feature: ALTER TABLE
+increment telemetry for sql.schema.alter_table
+increment telemetry for sql.schema.alter_table.add_column
+increment telemetry for sql.schema.qualifcation.default_expr
+increment telemetry for sql.schema.new_column_type.string
+write *eventpb.AlterTable to event log:
+  mutationId: 1
+  sql:
+    descriptorId: 104
+    statement: ALTER TABLE ‹defaultdb›.‹public›.‹t› ADD COLUMN ‹w› STRING NOT NULL DEFAULT ‹'s'›
+    tag: ALTER TABLE
+    user: root
+  tableName: defaultdb.public.t
+## StatementPhase stage 1 of 1 with 13 MutationType ops
+upsert descriptor #104
+  ...
+       - 1
+       - 2
+  +    - 3
+       columnNames:
+       - k
+       - v
+  +    - w
+       defaultColumnId: 2
+       name: primary
+  ...
+     id: 104
+     modificationTime: {}
+  +  mutations:
+  +  - column:
+  +      defaultExpr: '''s'':::STRING'
+  +      id: 3
+  +      name: w
+  +      nullable: true
+  +      type:
+  +        family: StringFamily
+  +        oid: 25
+  +    direction: ADD
+  +    mutationId: 1
+  +    state: DELETE_ONLY
+  +  - direction: ADD
+  +    index:
+  +      constraintId: 2
+  +      createdExplicitly: true
+  +      encodingType: 1
+  +      foreignKey: {}
+  +      geoConfig: {}
+  +      id: 2
+  +      interleave: {}
+  +      keyColumnDirections:
+  +      - ASC
+  +      keyColumnIds:
+  +      - 1
+  +      keyColumnNames:
+  +      - k
+  +      name: crdb_internal_index_2_name_placeholder
+  +      partitioning: {}
+  +      sharded: {}
+  +      storeColumnIds:
+  +      - 2
+  +      - 3
+  +      storeColumnNames:
+  +      - v
+  +      - w
+  +      unique: true
+  +      version: 4
+  +    mutationId: 1
+  +    state: BACKFILLING
+  +  - direction: ADD
+  +    index:
+  +      constraintId: 3
+  +      createdExplicitly: true
+  +      encodingType: 1
+  +      foreignKey: {}
+  +      geoConfig: {}
+  +      id: 3
+  +      interleave: {}
+  +      keyColumnDirections:
+  +      - ASC
+  +      keyColumnIds:
+  +      - 1
+  +      keyColumnNames:
+  +      - k
+  +      name: crdb_internal_index_3_name_placeholder
+  +      partitioning: {}
+  +      sharded: {}
+  +      storeColumnIds:
+  +      - 2
+  +      - 3
+  +      storeColumnNames:
+  +      - v
+  +      - w
+  +      unique: true
+  +      useDeletePreservingEncoding: true
+  +      version: 4
+  +    mutationId: 1
+  +    state: DELETE_ONLY
+     name: t
+  -  nextColumnId: 3
+  -  nextConstraintId: 2
+  +  nextColumnId: 4
+  +  nextConstraintId: 4
+     nextFamilyId: 1
+  -  nextIndexId: 2
+  +  nextIndexId: 4
+     nextMutationId: 1
+     parentId: 100
+  ...
+       time: {}
+     unexposedParentSchemaId: 101
+  -  version: "1"
+  +  version: "2"
+upsert zone config for #104
+# end StatementPhase
+# begin PreCommitPhase
+## PreCommitPhase stage 1 of 2 with 1 MutationType op
+undo all catalog changes within txn #1
+persist all catalog changes to storage
+## PreCommitPhase stage 2 of 2 with 19 MutationType ops
+upsert descriptor #104
+  ...
+     createAsOfTime:
+       wallTime: "1640995200000000000"
+  +  declarativeSchemaChangerState:
+  +    authorization:
+  +      userName: root
+  +    currentStatuses: <redacted>
+  +    jobId: "1"
+  +    nameMapping:
+  +      columns:
+  +        "1": k
+  +        "2": v
+  +        "3": w
+  +        "4294967292": crdb_internal_origin_timestamp
+  +        "4294967293": crdb_internal_origin_id
+  +        "4294967294": tableoid
+  +        "4294967295": crdb_internal_mvcc_timestamp
+  +      families:
+  +        "0": primary
+  +      id: 104
+  +      indexes:
+  +        "2": t_pkey
+  +      name: t
+  +    relevantStatements:
+  +    - statement:
+  +        redactedStatement: ALTER INDEX ‹defaultdb›.‹public›.‹t›@‹t_pkey› CONFIGURE ZONE USING ‹"gc.ttlseconds"› = ‹1›
+  +        statement: ALTER INDEX t@t_pkey CONFIGURE ZONE USING "gc.ttlseconds" = 1
+  +        statementTag: CONFIGURE ZONE
+  +    - statement:
+  +        redactedStatement: ALTER TABLE ‹defaultdb›.‹public›.‹t› CONFIGURE ZONE USING ‹"gc.ttlseconds"› = ‹1›
+  +        statement: ALTER TABLE t CONFIGURE ZONE USING "gc.ttlseconds" = 1
+  +        statementTag: CONFIGURE ZONE
+  +      statementRank: 1
+  +    - statement:
+  +        redactedStatement: ALTER TABLE ‹defaultdb›.‹public›.‹t› ADD COLUMN ‹w› STRING NOT NULL DEFAULT ‹'s'›
+  +        statement: ALTER TABLE t ADD COLUMN w STRING NOT NULL DEFAULT 's'
+  +        statementTag: ALTER TABLE
+  +      statementRank: 2
+  +    revertible: true
+  +    targetRanks: <redacted>
+  +    targets: <redacted>
+     families:
+     - columnIds:
+       - 1
+       - 2
+  +    - 3
+       columnNames:
+       - k
+       - v
+  +    - w
+       defaultColumnId: 2
+       name: primary
+  ...
+     id: 104
+     modificationTime: {}
+  +  mutations:
+  +  - column:
+  +      defaultExpr: '''s'':::STRING'
+  +      id: 3
+  +      name: w
+  +      nullable: true
+  +      type:
+  +        family: StringFamily
+  +        oid: 25
+  +    direction: ADD
+  +    mutationId: 1
+  +    state: DELETE_ONLY
+  +  - direction: ADD
+  +    index:
+  +      constraintId: 2
+  +      createdExplicitly: true
+  +      encodingType: 1
+  +      foreignKey: {}
+  +      geoConfig: {}
+  +      id: 2
+  +      interleave: {}
+  +      keyColumnDirections:
+  +      - ASC
+  +      keyColumnIds:
+  +      - 1
+  +      keyColumnNames:
+  +      - k
+  +      name: crdb_internal_index_2_name_placeholder
+  +      partitioning: {}
+  +      sharded: {}
+  +      storeColumnIds:
+  +      - 2
+  +      - 3
+  +      storeColumnNames:
+  +      - v
+  +      - w
+  +      unique: true
+  +      version: 4
+  +    mutationId: 1
+  +    state: BACKFILLING
+  +  - direction: ADD
+  +    index:
+  +      constraintId: 3
+  +      createdExplicitly: true
+  +      encodingType: 1
+  +      foreignKey: {}
+  +      geoConfig: {}
+  +      id: 3
+  +      interleave: {}
+  +      keyColumnDirections:
+  +      - ASC
+  +      keyColumnIds:
+  +      - 1
+  +      keyColumnNames:
+  +      - k
+  +      name: crdb_internal_index_3_name_placeholder
+  +      partitioning: {}
+  +      sharded: {}
+  +      storeColumnIds:
+  +      - 2
+  +      - 3
+  +      storeColumnNames:
+  +      - v
+  +      - w
+  +      unique: true
+  +      useDeletePreservingEncoding: true
+  +      version: 4
+  +    mutationId: 1
+  +    state: DELETE_ONLY
+     name: t
+  -  nextColumnId: 3
+  -  nextConstraintId: 2
+  +  nextColumnId: 4
+  +  nextConstraintId: 4
+     nextFamilyId: 1
+  -  nextIndexId: 2
+  +  nextIndexId: 4
+     nextMutationId: 1
+     parentId: 100
+  ...
+       time: {}
+     unexposedParentSchemaId: 101
+  -  version: "1"
+  +  version: "2"
+upsert zone config for #104
+persist all catalog changes to storage
+create job #1 (non-cancelable: false): "ALTER INDEX defaultdb.public.t@t_pkey CONFIGURE ZONE USING \"gc.ttlseconds\" = 1; ALTER TABLE defaultdb.public.t CONFIGURE ZONE USING \"gc.ttlseconds\" = 1; ALTER TABLE defaultdb.public.t ADD COLUMN w STRING NOT NULL DEFAULT 's'"
+  descriptor IDs: [104]
+# end PreCommitPhase
+commit transaction #1
+notified job registry to adopt jobs: [1]
+# begin PostCommitPhase
+begin transaction #2
+commit transaction #2
+begin transaction #3
+## PostCommitPhase stage 1 of 7 with 5 MutationType ops
+upsert descriptor #104
+   table:
+  +  checks:
+  +  - columnIds:
+  +    - 3
+  +    expr: w IS NOT NULL
+  +    isNonNullConstraint: true
+  +    name: w_auto_not_null
+  +    validity: Validating
+     columns:
+     - id: 1
+  ...
+       direction: ADD
+       mutationId: 1
+  -    state: DELETE_ONLY
+  +    state: WRITE_ONLY
+     - direction: ADD
+       index:
+  ...
+         version: 4
+       mutationId: 1
+  -    state: DELETE_ONLY
+  +    state: WRITE_ONLY
+  +  - constraint:
+  +      check:
+  +        columnIds:
+  +        - 3
+  +        expr: w IS NOT NULL
+  +        isNonNullConstraint: true
+  +        name: w_auto_not_null
+  +        validity: Validating
+  +      constraintType: NOT_NULL
+  +      foreignKey: {}
+  +      name: w_auto_not_null
+  +      notNullColumn: 3
+  +      uniqueWithoutIndexConstraint: {}
+  +    direction: ADD
+  +    mutationId: 1
+  +    state: WRITE_ONLY
+     name: t
+     nextColumnId: 4
+  ...
+       time: {}
+     unexposedParentSchemaId: 101
+  -  version: "2"
+  +  version: "3"
+persist all catalog changes to storage
+update progress of schema change job #1: "PostCommitPhase stage 2 of 7 with 1 BackfillType op pending"
+commit transaction #3
+begin transaction #4
+## PostCommitPhase stage 2 of 7 with 1 BackfillType op
+backfill indexes [2] from index #1 in table #104
+commit transaction #4
+begin transaction #5
+## PostCommitPhase stage 3 of 7 with 3 MutationType ops
+upsert descriptor #104
+  ...
+         version: 4
+       mutationId: 1
+  -    state: BACKFILLING
+  +    state: DELETE_ONLY
+     - direction: ADD
+       index:
+  ...
+       time: {}
+     unexposedParentSchemaId: 101
+  -  version: "3"
+  +  version: "4"
+persist all catalog changes to storage
+update progress of schema change job #1: "PostCommitPhase stage 4 of 7 with 1 MutationType op pending"
+commit transaction #5
+begin transaction #6
+## PostCommitPhase stage 4 of 7 with 3 MutationType ops
+upsert descriptor #104
+  ...
+         version: 4
+       mutationId: 1
+  -    state: DELETE_ONLY
+  +    state: MERGING
+     - direction: ADD
+       index:
+  ...
+       time: {}
+     unexposedParentSchemaId: 101
+  -  version: "4"
+  +  version: "5"
+persist all catalog changes to storage
+update progress of schema change job #1: "PostCommitPhase stage 5 of 7 with 1 BackfillType op pending"
+commit transaction #6
+begin transaction #7
+## PostCommitPhase stage 5 of 7 with 1 BackfillType op
+merge temporary indexes [3] into backfilled indexes [2] in table #104
+commit transaction #7
+begin transaction #8
+## PostCommitPhase stage 6 of 7 with 4 MutationType ops
+upsert descriptor #104
+  ...
+         version: 4
+       mutationId: 1
+  -    state: MERGING
+  -  - direction: ADD
+  +    state: WRITE_ONLY
+  +  - direction: DROP
+       index:
+         constraintId: 3
+  ...
+         version: 4
+       mutationId: 1
+  -    state: WRITE_ONLY
+  +    state: DELETE_ONLY
+     - constraint:
+         check:
+  ...
+       time: {}
+     unexposedParentSchemaId: 101
+  -  version: "5"
+  +  version: "6"
+persist all catalog changes to storage
+update progress of schema change job #1: "PostCommitPhase stage 7 of 7 with 2 ValidationType ops pending"
+commit transaction #8
+begin transaction #9
+## PostCommitPhase stage 7 of 7 with 2 ValidationType ops
+validate forward indexes [2] in table #104
+validate CHECK constraint w_auto_not_null in table #104
+commit transaction #9
+begin transaction #10
+## PostCommitNonRevertiblePhase stage 1 of 3 with 13 MutationType ops
+upsert descriptor #104
+   table:
+  -  checks:
+  -  - columnIds:
+  -    - 3
+  -    expr: w IS NOT NULL
+  -    isNonNullConstraint: true
+  -    name: w_auto_not_null
+  -    validity: Validating
+  +  checks: []
+     columns:
+     - id: 1
+  ...
+         family: StringFamily
+         oid: 25
+  +  - defaultExpr: '''s'':::STRING'
+  +    id: 3
+  +    name: w
+  +    type:
+  +      family: StringFamily
+  +      oid: 25
+     createAsOfTime:
+       wallTime: "1640995200000000000"
+  ...
+           statementTag: ALTER TABLE
+         statementRank: 2
+  -    revertible: true
+       targetRanks: <redacted>
+       targets: <redacted>
+  ...
+     modificationTime: {}
+     mutations:
+  -  - column:
+  -      defaultExpr: '''s'':::STRING'
+  -      id: 3
+  -      name: w
+  -      nullable: true
+  -      type:
+  -        family: StringFamily
+  -        oid: 25
+  -    direction: ADD
+  -    mutationId: 1
+  -    state: WRITE_ONLY
+  -  - direction: ADD
+  -    index:
+  -      constraintId: 2
+  -      createdExplicitly: true
+  -      encodingType: 1
+  -      foreignKey: {}
+  -      geoConfig: {}
+  -      id: 2
+  -      interleave: {}
+  -      keyColumnDirections:
+  -      - ASC
+  -      keyColumnIds:
+  -      - 1
+  -      keyColumnNames:
+  -      - k
+  -      name: crdb_internal_index_2_name_placeholder
+  -      partitioning: {}
+  -      sharded: {}
+  -      storeColumnIds:
+  -      - 2
+  -      - 3
+  -      storeColumnNames:
+  -      - v
+  -      - w
+  -      unique: true
+  -      version: 4
+  -    mutationId: 1
+  -    state: WRITE_ONLY
+     - direction: DROP
+       index:
+  -      constraintId: 3
+  -      createdExplicitly: true
+  +      constraintId: 1
+  +      createdAtNanos: "1640995200000000000"
+         encodingType: 1
+         foreignKey: {}
+         geoConfig: {}
+  -      id: 3
+  +      id: 1
+         interleave: {}
+         keyColumnDirections:
+  ...
+         keyColumnNames:
+         - k
+  -      name: crdb_internal_index_3_name_placeholder
+  +      name: crdb_internal_index_1_name_placeholder
+         partitioning: {}
+         sharded: {}
+         storeColumnIds:
+         - 2
+  -      - 3
+         storeColumnNames:
+         - v
+  -      - w
+         unique: true
+  -      useDeletePreservingEncoding: true
+         version: 4
+       mutationId: 1
+  -    state: DELETE_ONLY
+  -  - constraint:
+  -      check:
+  -        columnIds:
+  -        - 3
+  -        expr: w IS NOT NULL
+  -        isNonNullConstraint: true
+  -        name: w_auto_not_null
+  -        validity: Validating
+  -      constraintType: NOT_NULL
+  -      foreignKey: {}
+  -      name: w_auto_not_null
+  -      notNullColumn: 3
+  -      uniqueWithoutIndexConstraint: {}
+  -    direction: ADD
+  -    mutationId: 1
+       state: WRITE_ONLY
+     name: t
+  ...
+     parentId: 100
+     primaryIndex:
+  -    constraintId: 1
+  -    createdAtNanos: "1640995200000000000"
+  +    constraintId: 2
+  +    createdExplicitly: true
+       encodingType: 1
+       foreignKey: {}
+       geoConfig: {}
+  -    id: 1
+  +    id: 2
+       interleave: {}
+       keyColumnDirections:
+  ...
+       storeColumnIds:
+       - 2
+  +    - 3
+       storeColumnNames:
+       - v
+  +    - w
+       unique: true
+       version: 4
+  ...
+       time: {}
+     unexposedParentSchemaId: 101
+  -  version: "6"
+  +  version: "7"
+persist all catalog changes to storage
+adding table for stats refresh: 104
+update progress of schema change job #1: "PostCommitNonRevertiblePhase stage 2 of 3 with 3 MutationType ops pending"
+set schema change job #1 to non-cancellable
+commit transaction #10
+begin transaction #11
+## PostCommitNonRevertiblePhase stage 2 of 3 with 5 MutationType ops
+upsert descriptor #104
+  ...
+         version: 4
+       mutationId: 1
+  -    state: WRITE_ONLY
+  +    state: DELETE_ONLY
+     name: t
+     nextColumnId: 4
+  ...
+       time: {}
+     unexposedParentSchemaId: 101
+  -  version: "7"
+  +  version: "8"
+persist all catalog changes to storage
+update progress of schema change job #1: "PostCommitNonRevertiblePhase stage 3 of 3 with 3 MutationType ops pending"
+commit transaction #11
+begin transaction #12
+## PostCommitNonRevertiblePhase stage 3 of 3 with 5 MutationType ops
+upsert descriptor #104
+  ...
+     createAsOfTime:
+       wallTime: "1640995200000000000"
+  -  declarativeSchemaChangerState:
+  -    authorization:
+  -      userName: root
+  -    currentStatuses: <redacted>
+  -    jobId: "1"
+  -    nameMapping:
+  -      columns:
+  -        "1": k
+  -        "2": v
+  -        "3": w
+  -        "4294967292": crdb_internal_origin_timestamp
+  -        "4294967293": crdb_internal_origin_id
+  -        "4294967294": tableoid
+  -        "4294967295": crdb_internal_mvcc_timestamp
+  -      families:
+  -        "0": primary
+  -      id: 104
+  -      indexes:
+  -        "2": t_pkey
+  -      name: t
+  -    relevantStatements:
+  -    - statement:
+  -        redactedStatement: ALTER INDEX ‹defaultdb›.‹public›.‹t›@‹t_pkey› CONFIGURE ZONE USING ‹"gc.ttlseconds"› = ‹1›
+  -        statement: ALTER INDEX t@t_pkey CONFIGURE ZONE USING "gc.ttlseconds" = 1
+  -        statementTag: CONFIGURE ZONE
+  -    - statement:
+  -        redactedStatement: ALTER TABLE ‹defaultdb›.‹public›.‹t› CONFIGURE ZONE USING ‹"gc.ttlseconds"› = ‹1›
+  -        statement: ALTER TABLE t CONFIGURE ZONE USING "gc.ttlseconds" = 1
+  -        statementTag: CONFIGURE ZONE
+  -      statementRank: 1
+  -    - statement:
+  -        redactedStatement: ALTER TABLE ‹defaultdb›.‹public›.‹t› ADD COLUMN ‹w› STRING NOT NULL DEFAULT ‹'s'›
+  -        statement: ALTER TABLE t ADD COLUMN w STRING NOT NULL DEFAULT 's'
+  -        statementTag: ALTER TABLE
+  -      statementRank: 2
+  -    targetRanks: <redacted>
+  -    targets: <redacted>
+     families:
+     - columnIds:
+  ...
+     id: 104
+     modificationTime: {}
+  -  mutations:
+  -  - direction: DROP
+  -    index:
+  -      constraintId: 1
+  -      createdAtNanos: "1640995200000000000"
+  -      encodingType: 1
+  -      foreignKey: {}
+  -      geoConfig: {}
+  -      id: 1
+  -      interleave: {}
+  -      keyColumnDirections:
+  -      - ASC
+  -      keyColumnIds:
+  -      - 1
+  -      keyColumnNames:
+  -      - k
+  -      name: crdb_internal_index_1_name_placeholder
+  -      partitioning: {}
+  -      sharded: {}
+  -      storeColumnIds:
+  -      - 2
+  -      storeColumnNames:
+  -      - v
+  -      unique: true
+  -      version: 4
+  -    mutationId: 1
+  -    state: DELETE_ONLY
+  +  mutations: []
+     name: t
+     nextColumnId: 4
+  ...
+       time: {}
+     unexposedParentSchemaId: 101
+  -  version: "8"
+  +  version: "9"
+persist all catalog changes to storage
+create job #2 (non-cancelable: true): "GC for ALTER TABLE defaultdb.public.t ADD COLUMN w STRING NOT NULL DEFAULT 's'"
+  descriptor IDs: [104]
+update progress of schema change job #1: "all stages completed"
+set schema change job #1 to non-cancellable
+updated schema change job #1 descriptor IDs to []
+write *eventpb.FinishSchemaChange to event log:
+  sc:
+    descriptorId: 104
+commit transaction #12
+notified job registry to adopt jobs: [2]
+# end PostCommitPhase

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_subzones/add_column_subzones__rollback_1_of_7.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_subzones/add_column_subzones__rollback_1_of_7.explain
@@ -1,0 +1,49 @@
+/* setup */
+CREATE TABLE t (
+  k INT PRIMARY KEY,
+  V STRING
+);
+
+/* test */
+ALTER INDEX t@t_pkey CONFIGURE ZONE USING gc.ttlseconds = 1;
+ALTER TABLE t CONFIGURE ZONE USING gc.ttlseconds = 1;
+ALTER TABLE t ADD COLUMN w TEXT NOT NULL DEFAULT 's';
+EXPLAIN (DDL) rollback at post-commit stage 1 of 7;
+----
+Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN w STRING NOT NULL DEFAULT ‹'s'›; following ALTER INDEX defaultdb.public.t@t_pkey CONFIGURE ZONE USING "gc.ttlseconds" = ‹1›; ALTER TABLE defaultdb.public.t CONFIGURE ZONE USING "gc.ttlseconds" = ‹1›;
+ └── PostCommitNonRevertiblePhase
+      └── Stage 1 of 1 in PostCommitNonRevertiblePhase
+           ├── 16 elements transitioning toward ABSENT
+           │    ├── PUBLIC        → ABSENT IndexZoneConfig:{DescID: 104 (t), IndexID: 1 (t_pkey+), SeqNum: 1}
+           │    ├── PUBLIC        → ABSENT TableZoneConfig:{DescID: 104 (t), SeqNum: 1}
+           │    ├── DELETE_ONLY   → ABSENT Column:{DescID: 104 (t), ColumnID: 3 (w-)}
+           │    ├── PUBLIC        → ABSENT ColumnName:{DescID: 104 (t), Name: "w", ColumnID: 3 (w-)}
+           │    ├── PUBLIC        → ABSENT ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 3 (w-), TypeName: "STRING"}
+           │    ├── PUBLIC        → ABSENT ColumnDefaultExpression:{DescID: 104 (t), ColumnID: 3 (w-), Expr: 's':::STRING}
+           │    ├── BACKFILL_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 2 (t_pkey-), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1 (t_pkey+)}
+           │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 1 (k), IndexID: 2 (t_pkey-)}
+           │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 2 (v), IndexID: 2 (t_pkey-)}
+           │    ├── PUBLIC        → ABSENT IndexData:{DescID: 104 (t), IndexID: 2 (t_pkey-)}
+           │    ├── DELETE_ONLY   → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 3, ConstraintID: 3, SourceIndexID: 1 (t_pkey+)}
+           │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 1 (k), IndexID: 3}
+           │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 2 (v), IndexID: 3}
+           │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 3 (w-), IndexID: 2 (t_pkey-)}
+           │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 3 (w-), IndexID: 3}
+           │    └── PUBLIC        → ABSENT TableZoneConfig:{DescID: 104 (t), SeqNum: 2}
+           └── 16 Mutation operations
+                ├── DiscardTableZoneConfig {"TableID":104}
+                ├── SetColumnName {"ColumnID":3,"Name":"crdb_internal_co...","TableID":104}
+                ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"TableID":104}
+                ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":2,"Kind":2,"TableID":104}
+                ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":104}
+                ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"Kind":2,"TableID":104}
+                ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":2,"Kind":2,"Ordinal":1,"TableID":104}
+                ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":3,"Kind":2,"Ordinal":1,"TableID":104}
+                ├── DiscardTableZoneConfig {"TableID":104}
+                ├── RemoveColumnDefaultExpression {"ColumnID":3,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":2,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":2,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":3,"TableID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_subzones/add_column_subzones__rollback_2_of_7.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_subzones/add_column_subzones__rollback_2_of_7.explain
@@ -1,0 +1,62 @@
+/* setup */
+CREATE TABLE t (
+  k INT PRIMARY KEY,
+  V STRING
+);
+
+/* test */
+ALTER INDEX t@t_pkey CONFIGURE ZONE USING gc.ttlseconds = 1;
+ALTER TABLE t CONFIGURE ZONE USING gc.ttlseconds = 1;
+ALTER TABLE t ADD COLUMN w TEXT NOT NULL DEFAULT 's';
+EXPLAIN (DDL) rollback at post-commit stage 2 of 7;
+----
+Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN w STRING NOT NULL DEFAULT ‹'s'›; following ALTER INDEX defaultdb.public.t@t_pkey CONFIGURE ZONE USING "gc.ttlseconds" = ‹1›; ALTER TABLE defaultdb.public.t CONFIGURE ZONE USING "gc.ttlseconds" = ‹1›;
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 14 elements transitioning toward ABSENT
+      │    │    ├── PUBLIC        → ABSENT      IndexZoneConfig:{DescID: 104 (t), IndexID: 1 (t_pkey+), SeqNum: 1}
+      │    │    ├── PUBLIC        → ABSENT      TableZoneConfig:{DescID: 104 (t), SeqNum: 1}
+      │    │    ├── WRITE_ONLY    → DELETE_ONLY Column:{DescID: 104 (t), ColumnID: 3 (w-)}
+      │    │    ├── PUBLIC        → ABSENT      ColumnName:{DescID: 104 (t), Name: "w", ColumnID: 3 (w-)}
+      │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 2 (t_pkey-), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (k), IndexID: 2 (t_pkey-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (v), IndexID: 2 (t_pkey-)}
+      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 3, ConstraintID: 3, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (k), IndexID: 3}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (v), IndexID: 3}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (w-), IndexID: 2 (t_pkey-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (w-), IndexID: 3}
+      │    │    ├── WRITE_ONLY    → ABSENT      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (w-), IndexID: 2 (t_pkey-)}
+      │    │    └── PUBLIC        → ABSENT      TableZoneConfig:{DescID: 104 (t), SeqNum: 2}
+      │    └── 15 Mutation operations
+      │         ├── DiscardTableZoneConfig {"TableID":104}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":3,"TableID":104}
+      │         ├── SetColumnName {"ColumnID":3,"Name":"crdb_internal_co...","TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":2,"Kind":2,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":3,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":2,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":3,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── DiscardTableZoneConfig {"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":2,"TableID":104}
+      │         ├── RemoveColumnNotNull {"ColumnID":3,"TableID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 6 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 104 (t), ColumnID: 3 (w-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 3 (w-), TypeName: "STRING"}
+           │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 104 (t), ColumnID: 3 (w-), Expr: 's':::STRING}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 2 (t_pkey-)}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 3, ConstraintID: 3, SourceIndexID: 1 (t_pkey+)}
+           │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 3}
+           └── 7 Mutation operations
+                ├── RemoveColumnDefaultExpression {"ColumnID":3,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":2,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":3,"TableID":104}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":3,"TableID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_subzones/add_column_subzones__rollback_3_of_7.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_subzones/add_column_subzones__rollback_3_of_7.explain
@@ -1,0 +1,62 @@
+/* setup */
+CREATE TABLE t (
+  k INT PRIMARY KEY,
+  V STRING
+);
+
+/* test */
+ALTER INDEX t@t_pkey CONFIGURE ZONE USING gc.ttlseconds = 1;
+ALTER TABLE t CONFIGURE ZONE USING gc.ttlseconds = 1;
+ALTER TABLE t ADD COLUMN w TEXT NOT NULL DEFAULT 's';
+EXPLAIN (DDL) rollback at post-commit stage 3 of 7;
+----
+Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN w STRING NOT NULL DEFAULT ‹'s'›; following ALTER INDEX defaultdb.public.t@t_pkey CONFIGURE ZONE USING "gc.ttlseconds" = ‹1›; ALTER TABLE defaultdb.public.t CONFIGURE ZONE USING "gc.ttlseconds" = ‹1›;
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 14 elements transitioning toward ABSENT
+      │    │    ├── PUBLIC        → ABSENT      IndexZoneConfig:{DescID: 104 (t), IndexID: 1 (t_pkey+), SeqNum: 1}
+      │    │    ├── PUBLIC        → ABSENT      TableZoneConfig:{DescID: 104 (t), SeqNum: 1}
+      │    │    ├── WRITE_ONLY    → DELETE_ONLY Column:{DescID: 104 (t), ColumnID: 3 (w-)}
+      │    │    ├── PUBLIC        → ABSENT      ColumnName:{DescID: 104 (t), Name: "w", ColumnID: 3 (w-)}
+      │    │    ├── BACKFILL_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 2 (t_pkey-), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (k), IndexID: 2 (t_pkey-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (v), IndexID: 2 (t_pkey-)}
+      │    │    ├── WRITE_ONLY    → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 3, ConstraintID: 3, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (k), IndexID: 3}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (v), IndexID: 3}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (w-), IndexID: 2 (t_pkey-)}
+      │    │    ├── PUBLIC        → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (w-), IndexID: 3}
+      │    │    ├── WRITE_ONLY    → ABSENT      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (w-), IndexID: 2 (t_pkey-)}
+      │    │    └── PUBLIC        → ABSENT      TableZoneConfig:{DescID: 104 (t), SeqNum: 2}
+      │    └── 15 Mutation operations
+      │         ├── DiscardTableZoneConfig {"TableID":104}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":3,"TableID":104}
+      │         ├── SetColumnName {"ColumnID":3,"Name":"crdb_internal_co...","TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":2,"Kind":2,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":3,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":2,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":3,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── DiscardTableZoneConfig {"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":2,"TableID":104}
+      │         ├── RemoveColumnNotNull {"ColumnID":3,"TableID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 6 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 104 (t), ColumnID: 3 (w-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 3 (w-), TypeName: "STRING"}
+           │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 104 (t), ColumnID: 3 (w-), Expr: 's':::STRING}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 2 (t_pkey-)}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 3, ConstraintID: 3, SourceIndexID: 1 (t_pkey+)}
+           │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 3}
+           └── 7 Mutation operations
+                ├── RemoveColumnDefaultExpression {"ColumnID":3,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":2,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":3,"TableID":104}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":3,"TableID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_subzones/add_column_subzones__rollback_4_of_7.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_subzones/add_column_subzones__rollback_4_of_7.explain
@@ -1,0 +1,62 @@
+/* setup */
+CREATE TABLE t (
+  k INT PRIMARY KEY,
+  V STRING
+);
+
+/* test */
+ALTER INDEX t@t_pkey CONFIGURE ZONE USING gc.ttlseconds = 1;
+ALTER TABLE t CONFIGURE ZONE USING gc.ttlseconds = 1;
+ALTER TABLE t ADD COLUMN w TEXT NOT NULL DEFAULT 's';
+EXPLAIN (DDL) rollback at post-commit stage 4 of 7;
+----
+Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN w STRING NOT NULL DEFAULT ‹'s'›; following ALTER INDEX defaultdb.public.t@t_pkey CONFIGURE ZONE USING "gc.ttlseconds" = ‹1›; ALTER TABLE defaultdb.public.t CONFIGURE ZONE USING "gc.ttlseconds" = ‹1›;
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 14 elements transitioning toward ABSENT
+      │    │    ├── PUBLIC      → ABSENT      IndexZoneConfig:{DescID: 104 (t), IndexID: 1 (t_pkey+), SeqNum: 1}
+      │    │    ├── PUBLIC      → ABSENT      TableZoneConfig:{DescID: 104 (t), SeqNum: 1}
+      │    │    ├── WRITE_ONLY  → DELETE_ONLY Column:{DescID: 104 (t), ColumnID: 3 (w-)}
+      │    │    ├── PUBLIC      → ABSENT      ColumnName:{DescID: 104 (t), Name: "w", ColumnID: 3 (w-)}
+      │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 104 (t), IndexID: 2 (t_pkey-), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (k), IndexID: 2 (t_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (v), IndexID: 2 (t_pkey-)}
+      │    │    ├── WRITE_ONLY  → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 3, ConstraintID: 3, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (k), IndexID: 3}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (v), IndexID: 3}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (w-), IndexID: 2 (t_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (w-), IndexID: 3}
+      │    │    ├── WRITE_ONLY  → ABSENT      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (w-), IndexID: 2 (t_pkey-)}
+      │    │    └── PUBLIC      → ABSENT      TableZoneConfig:{DescID: 104 (t), SeqNum: 2}
+      │    └── 15 Mutation operations
+      │         ├── DiscardTableZoneConfig {"TableID":104}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":3,"TableID":104}
+      │         ├── SetColumnName {"ColumnID":3,"Name":"crdb_internal_co...","TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":2,"Kind":2,"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":3,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":2,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":3,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── DiscardTableZoneConfig {"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":2,"TableID":104}
+      │         ├── RemoveColumnNotNull {"ColumnID":3,"TableID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 6 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 104 (t), ColumnID: 3 (w-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 3 (w-), TypeName: "STRING"}
+           │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 104 (t), ColumnID: 3 (w-), Expr: 's':::STRING}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 2 (t_pkey-)}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 3, ConstraintID: 3, SourceIndexID: 1 (t_pkey+)}
+           │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 3}
+           └── 7 Mutation operations
+                ├── RemoveColumnDefaultExpression {"ColumnID":3,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":2,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":3,"TableID":104}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":3,"TableID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_subzones/add_column_subzones__rollback_5_of_7.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_subzones/add_column_subzones__rollback_5_of_7.explain
@@ -1,0 +1,64 @@
+/* setup */
+CREATE TABLE t (
+  k INT PRIMARY KEY,
+  V STRING
+);
+
+/* test */
+ALTER INDEX t@t_pkey CONFIGURE ZONE USING gc.ttlseconds = 1;
+ALTER TABLE t CONFIGURE ZONE USING gc.ttlseconds = 1;
+ALTER TABLE t ADD COLUMN w TEXT NOT NULL DEFAULT 's';
+EXPLAIN (DDL) rollback at post-commit stage 5 of 7;
+----
+Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN w STRING NOT NULL DEFAULT ‹'s'›; following ALTER INDEX defaultdb.public.t@t_pkey CONFIGURE ZONE USING "gc.ttlseconds" = ‹1›; ALTER TABLE defaultdb.public.t CONFIGURE ZONE USING "gc.ttlseconds" = ‹1›;
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 14 elements transitioning toward ABSENT
+      │    │    ├── PUBLIC     → ABSENT      IndexZoneConfig:{DescID: 104 (t), IndexID: 1 (t_pkey+), SeqNum: 1}
+      │    │    ├── PUBLIC     → ABSENT      TableZoneConfig:{DescID: 104 (t), SeqNum: 1}
+      │    │    ├── WRITE_ONLY → DELETE_ONLY Column:{DescID: 104 (t), ColumnID: 3 (w-)}
+      │    │    ├── PUBLIC     → ABSENT      ColumnName:{DescID: 104 (t), Name: "w", ColumnID: 3 (w-)}
+      │    │    ├── MERGE_ONLY → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 2 (t_pkey-), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (k), IndexID: 2 (t_pkey-)}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (v), IndexID: 2 (t_pkey-)}
+      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 3, ConstraintID: 3, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (k), IndexID: 3}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (v), IndexID: 3}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (w-), IndexID: 2 (t_pkey-)}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (w-), IndexID: 3}
+      │    │    ├── WRITE_ONLY → ABSENT      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (w-), IndexID: 2 (t_pkey-)}
+      │    │    └── PUBLIC     → ABSENT      TableZoneConfig:{DescID: 104 (t), SeqNum: 2}
+      │    └── 15 Mutation operations
+      │         ├── DiscardTableZoneConfig {"TableID":104}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":3,"TableID":104}
+      │         ├── SetColumnName {"ColumnID":3,"Name":"crdb_internal_co...","TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":3,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":3,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── DiscardTableZoneConfig {"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":2,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":2,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnNotNull {"ColumnID":3,"TableID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 7 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 104 (t), ColumnID: 3 (w-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 3 (w-), TypeName: "STRING"}
+           │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 104 (t), ColumnID: 3 (w-), Expr: 's':::STRING}
+           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 2 (t_pkey-), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1 (t_pkey+)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 2 (t_pkey-)}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 3, ConstraintID: 3, SourceIndexID: 1 (t_pkey+)}
+           │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 3}
+           └── 8 Mutation operations
+                ├── RemoveColumnDefaultExpression {"ColumnID":3,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":2,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":2,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":3,"TableID":104}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":3,"TableID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_subzones/add_column_subzones__rollback_6_of_7.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_subzones/add_column_subzones__rollback_6_of_7.explain
@@ -1,0 +1,64 @@
+/* setup */
+CREATE TABLE t (
+  k INT PRIMARY KEY,
+  V STRING
+);
+
+/* test */
+ALTER INDEX t@t_pkey CONFIGURE ZONE USING gc.ttlseconds = 1;
+ALTER TABLE t CONFIGURE ZONE USING gc.ttlseconds = 1;
+ALTER TABLE t ADD COLUMN w TEXT NOT NULL DEFAULT 's';
+EXPLAIN (DDL) rollback at post-commit stage 6 of 7;
+----
+Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN w STRING NOT NULL DEFAULT ‹'s'›; following ALTER INDEX defaultdb.public.t@t_pkey CONFIGURE ZONE USING "gc.ttlseconds" = ‹1›; ALTER TABLE defaultdb.public.t CONFIGURE ZONE USING "gc.ttlseconds" = ‹1›;
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 14 elements transitioning toward ABSENT
+      │    │    ├── PUBLIC     → ABSENT      IndexZoneConfig:{DescID: 104 (t), IndexID: 1 (t_pkey+), SeqNum: 1}
+      │    │    ├── PUBLIC     → ABSENT      TableZoneConfig:{DescID: 104 (t), SeqNum: 1}
+      │    │    ├── WRITE_ONLY → DELETE_ONLY Column:{DescID: 104 (t), ColumnID: 3 (w-)}
+      │    │    ├── PUBLIC     → ABSENT      ColumnName:{DescID: 104 (t), Name: "w", ColumnID: 3 (w-)}
+      │    │    ├── MERGE_ONLY → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 2 (t_pkey-), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (k), IndexID: 2 (t_pkey-)}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (v), IndexID: 2 (t_pkey-)}
+      │    │    ├── WRITE_ONLY → DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 3, ConstraintID: 3, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (k), IndexID: 3}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (v), IndexID: 3}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (w-), IndexID: 2 (t_pkey-)}
+      │    │    ├── PUBLIC     → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (w-), IndexID: 3}
+      │    │    ├── WRITE_ONLY → ABSENT      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (w-), IndexID: 2 (t_pkey-)}
+      │    │    └── PUBLIC     → ABSENT      TableZoneConfig:{DescID: 104 (t), SeqNum: 2}
+      │    └── 15 Mutation operations
+      │         ├── DiscardTableZoneConfig {"TableID":104}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":3,"TableID":104}
+      │         ├── SetColumnName {"ColumnID":3,"Name":"crdb_internal_co...","TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":3,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":3,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── DiscardTableZoneConfig {"TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":2,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":2,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnNotNull {"ColumnID":3,"TableID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 7 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 104 (t), ColumnID: 3 (w-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 3 (w-), TypeName: "STRING"}
+           │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 104 (t), ColumnID: 3 (w-), Expr: 's':::STRING}
+           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 2 (t_pkey-), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1 (t_pkey+)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 2 (t_pkey-)}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 3, ConstraintID: 3, SourceIndexID: 1 (t_pkey+)}
+           │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 3}
+           └── 8 Mutation operations
+                ├── RemoveColumnDefaultExpression {"ColumnID":3,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":2,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":2,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":3,"TableID":104}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":3,"TableID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_subzones/add_column_subzones__rollback_7_of_7.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_subzones/add_column_subzones__rollback_7_of_7.explain
@@ -1,0 +1,62 @@
+/* setup */
+CREATE TABLE t (
+  k INT PRIMARY KEY,
+  V STRING
+);
+
+/* test */
+ALTER INDEX t@t_pkey CONFIGURE ZONE USING gc.ttlseconds = 1;
+ALTER TABLE t CONFIGURE ZONE USING gc.ttlseconds = 1;
+ALTER TABLE t ADD COLUMN w TEXT NOT NULL DEFAULT 's';
+EXPLAIN (DDL) rollback at post-commit stage 7 of 7;
+----
+Schema change plan for rolling back ALTER TABLE defaultdb.public.t ADD COLUMN w STRING NOT NULL DEFAULT ‹'s'›; following ALTER INDEX defaultdb.public.t@t_pkey CONFIGURE ZONE USING "gc.ttlseconds" = ‹1›; ALTER TABLE defaultdb.public.t CONFIGURE ZONE USING "gc.ttlseconds" = ‹1›;
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 14 elements transitioning toward ABSENT
+      │    │    ├── PUBLIC                → ABSENT      IndexZoneConfig:{DescID: 104 (t), IndexID: 1 (t_pkey+), SeqNum: 1}
+      │    │    ├── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 104 (t), SeqNum: 1}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 104 (t), ColumnID: 3 (w-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 104 (t), Name: "w", ColumnID: 3 (w-)}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 2 (t_pkey-), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (k), IndexID: 2 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (v), IndexID: 2 (t_pkey-)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 104 (t), IndexID: 3, ConstraintID: 3, SourceIndexID: 1 (t_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (k), IndexID: 3}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (v), IndexID: 3}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (w-), IndexID: 2 (t_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 3 (w-), IndexID: 3}
+      │    │    ├── WRITE_ONLY            → ABSENT      ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (w-), IndexID: 2 (t_pkey-)}
+      │    │    └── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 104 (t), SeqNum: 2}
+      │    └── 15 Mutation operations
+      │         ├── DiscardTableZoneConfig {"TableID":104}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":3,"TableID":104}
+      │         ├── SetColumnName {"ColumnID":3,"Name":"crdb_internal_co...","TableID":104}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":2,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":2,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":3,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── DiscardTableZoneConfig {"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
+      │         ├── RemoveColumnNotNull {"ColumnID":3,"TableID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 6 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 104 (t), ColumnID: 3 (w-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 3 (w-), TypeName: "STRING"}
+           │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 104 (t), ColumnID: 3 (w-), Expr: 's':::STRING}
+           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 2 (t_pkey-), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1 (t_pkey+)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 2 (t_pkey-)}
+           │    └── PUBLIC      → ABSENT IndexData:{DescID: 104 (t), IndexID: 3}
+           └── 7 Mutation operations
+                ├── RemoveColumnDefaultExpression {"ColumnID":3,"TableID":104}
+                ├── MakeIndexAbsent {"IndexID":2,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":2,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":3,"TableID":104}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":3,"TableID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_subzones/add_column_subzones__statement_1_of_3.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_subzones/add_column_subzones__statement_1_of_3.explain
@@ -1,0 +1,27 @@
+/* setup */
+CREATE TABLE t (
+  k INT PRIMARY KEY,
+  V STRING
+);
+
+/* test */
+EXPLAIN (DDL) ALTER INDEX t@t_pkey CONFIGURE ZONE USING gc.ttlseconds = 1;
+----
+Schema change plan for ALTER INDEX ‹defaultdb›.‹public›.‹t›@‹t_pkey› CONFIGURE ZONE USING ‹"gc.ttlseconds"› = ‹1›;
+ ├── StatementPhase
+ │    └── Stage 1 of 1 in StatementPhase
+ │         ├── 1 element transitioning toward PUBLIC
+ │         │    └── ABSENT → PUBLIC IndexZoneConfig:{DescID: 104 (t), IndexID: 1 (t_pkey), SeqNum: 1}
+ │         └── 1 Mutation operation
+ │              └── AddIndexZoneConfig {"SubzoneIndexToDelete":-1,"TableID":104}
+ └── PreCommitPhase
+      ├── Stage 1 of 2 in PreCommitPhase
+      │    ├── 1 element transitioning toward PUBLIC
+      │    │    └── PUBLIC → ABSENT IndexZoneConfig:{DescID: 104 (t), IndexID: 1 (t_pkey), SeqNum: 1}
+      │    └── 1 Mutation operation
+      │         └── UndoAllInTxnImmediateMutationOpSideEffects
+      └── Stage 2 of 2 in PreCommitPhase
+           ├── 1 element transitioning toward PUBLIC
+           │    └── ABSENT → PUBLIC IndexZoneConfig:{DescID: 104 (t), IndexID: 1 (t_pkey), SeqNum: 1}
+           └── 1 Mutation operation
+                └── AddIndexZoneConfig {"SubzoneIndexToDelete":-1,"TableID":104}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_subzones/add_column_subzones__statement_1_of_3.explain_shape
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_subzones/add_column_subzones__statement_1_of_3.explain_shape
@@ -1,0 +1,11 @@
+/* setup */
+CREATE TABLE t (
+  k INT PRIMARY KEY,
+  V STRING
+);
+
+/* test */
+EXPLAIN (DDL, SHAPE) ALTER INDEX t@t_pkey CONFIGURE ZONE USING gc.ttlseconds = 1;
+----
+Schema change plan for ALTER INDEX ‹defaultdb›.‹public›.‹t›@‹t_pkey› CONFIGURE ZONE USING ‹"gc.ttlseconds"› = ‹1›;
+ └── execute 1 system table mutations transaction

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_subzones/add_column_subzones__statement_2_of_3.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_subzones/add_column_subzones__statement_2_of_3.explain
@@ -1,0 +1,31 @@
+/* setup */
+CREATE TABLE t (
+  k INT PRIMARY KEY,
+  V STRING
+);
+
+/* test */
+ALTER INDEX t@t_pkey CONFIGURE ZONE USING gc.ttlseconds = 1;
+EXPLAIN (DDL) ALTER TABLE t CONFIGURE ZONE USING gc.ttlseconds = 1;
+----
+Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› CONFIGURE ZONE USING ‹"gc.ttlseconds"› = ‹1›; following ALTER INDEX ‹defaultdb›.‹public›.‹t›@‹t_pkey› CONFIGURE ZONE USING ‹"gc.ttlseconds"› = ‹1›;
+ ├── StatementPhase
+ │    └── Stage 1 of 1 in StatementPhase
+ │         ├── 1 element transitioning toward PUBLIC
+ │         │    └── ABSENT → PUBLIC TableZoneConfig:{DescID: 104 (t), SeqNum: 1}
+ │         └── 1 Mutation operation
+ │              └── AddTableZoneConfig {"TableID":104}
+ └── PreCommitPhase
+      ├── Stage 1 of 2 in PreCommitPhase
+      │    ├── 2 elements transitioning toward PUBLIC
+      │    │    ├── PUBLIC → ABSENT IndexZoneConfig:{DescID: 104 (t), IndexID: 1 (t_pkey), SeqNum: 1}
+      │    │    └── PUBLIC → ABSENT TableZoneConfig:{DescID: 104 (t), SeqNum: 1}
+      │    └── 1 Mutation operation
+      │         └── UndoAllInTxnImmediateMutationOpSideEffects
+      └── Stage 2 of 2 in PreCommitPhase
+           ├── 2 elements transitioning toward PUBLIC
+           │    ├── ABSENT → PUBLIC IndexZoneConfig:{DescID: 104 (t), IndexID: 1 (t_pkey), SeqNum: 1}
+           │    └── ABSENT → PUBLIC TableZoneConfig:{DescID: 104 (t), SeqNum: 1}
+           └── 2 Mutation operations
+                ├── AddIndexZoneConfig {"SubzoneIndexToDelete":-1,"TableID":104}
+                └── AddTableZoneConfig {"TableID":104}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_subzones/add_column_subzones__statement_2_of_3.explain_shape
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_subzones/add_column_subzones__statement_2_of_3.explain_shape
@@ -1,0 +1,12 @@
+/* setup */
+CREATE TABLE t (
+  k INT PRIMARY KEY,
+  V STRING
+);
+
+/* test */
+ALTER INDEX t@t_pkey CONFIGURE ZONE USING gc.ttlseconds = 1;
+EXPLAIN (DDL, SHAPE) ALTER TABLE t CONFIGURE ZONE USING gc.ttlseconds = 1;
+----
+Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› CONFIGURE ZONE USING ‹"gc.ttlseconds"› = ‹1›; following ALTER INDEX ‹defaultdb›.‹public›.‹t›@‹t_pkey› CONFIGURE ZONE USING ‹"gc.ttlseconds"› = ‹1›;
+ └── execute 1 system table mutations transaction

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_subzones/add_column_subzones__statement_3_of_3.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_subzones/add_column_subzones__statement_3_of_3.explain
@@ -1,0 +1,212 @@
+/* setup */
+CREATE TABLE t (
+  k INT PRIMARY KEY,
+  V STRING
+);
+
+/* test */
+ALTER INDEX t@t_pkey CONFIGURE ZONE USING gc.ttlseconds = 1;
+ALTER TABLE t CONFIGURE ZONE USING gc.ttlseconds = 1;
+EXPLAIN (DDL) ALTER TABLE t ADD COLUMN w TEXT NOT NULL DEFAULT 's';
+----
+Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ADD COLUMN ‹w› STRING NOT NULL DEFAULT ‹'s'›; following ALTER INDEX ‹defaultdb›.‹public›.‹t›@‹t_pkey› CONFIGURE ZONE USING ‹"gc.ttlseconds"› = ‹1›; ALTER TABLE ‹defaultdb›.‹public›.‹t› CONFIGURE ZONE USING ‹"gc.ttlseconds"› = ‹1›;
+ ├── StatementPhase
+ │    └── Stage 1 of 1 in StatementPhase
+ │         ├── 10 elements transitioning toward PUBLIC
+ │         │    ├── ABSENT → DELETE_ONLY   Column:{DescID: 104 (t), ColumnID: 3 (w+)}
+ │         │    ├── ABSENT → PUBLIC        ColumnName:{DescID: 104 (t), Name: "w", ColumnID: 3 (w+)}
+ │         │    ├── ABSENT → PUBLIC        ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 3 (w+), TypeName: "STRING"}
+ │         │    ├── ABSENT → PUBLIC        ColumnDefaultExpression:{DescID: 104 (t), ColumnID: 3 (w+), Expr: 's':::STRING}
+ │         │    ├── ABSENT → BACKFILL_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 2 (t_pkey+), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1 (t_pkey-)}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 1 (k), IndexID: 2 (t_pkey+)}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 2 (v), IndexID: 2 (t_pkey+)}
+ │         │    ├── ABSENT → PUBLIC        IndexData:{DescID: 104 (t), IndexID: 2 (t_pkey+)}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 3 (w+), IndexID: 2 (t_pkey+)}
+ │         │    └── ABSENT → PUBLIC        TableZoneConfig:{DescID: 104 (t), SeqNum: 2}
+ │         ├── 4 elements transitioning toward TRANSIENT_ABSENT
+ │         │    ├── ABSENT → DELETE_ONLY   TemporaryIndex:{DescID: 104 (t), IndexID: 3, ConstraintID: 3, SourceIndexID: 1 (t_pkey-)}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 1 (k), IndexID: 3}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 2 (v), IndexID: 3}
+ │         │    └── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 3 (w+), IndexID: 3}
+ │         └── 13 Mutation operations
+ │              ├── MakeAbsentColumnDeleteOnly {"Column":{"ColumnID":3,"TableID":104}}
+ │              ├── SetColumnName {"ColumnID":3,"Name":"w","TableID":104}
+ │              ├── UpsertColumnType {"ColumnType":{"ColumnID":3,"TableID":104}}
+ │              ├── AddColumnDefaultExpression {"Default":{"ColumnID":3,"TableID":104}}
+ │              ├── MakeAbsentIndexBackfilling {"Index":{"ConstraintID":2,"IndexID":2,"IsUnique":true,"SourceIndexID":1,"TableID":104,"TemporaryIndexID":3}}
+ │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":2,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":2,"Kind":2,"TableID":104}
+ │              ├── MakeAbsentTempIndexDeleteOnly {"Index":{"ConstraintID":3,"IndexID":3,"IsUnique":true,"SourceIndexID":1,"TableID":104}}
+ │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":3,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":3,"Kind":2,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":3,"IndexID":2,"Kind":2,"Ordinal":1,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":3,"IndexID":3,"Kind":2,"Ordinal":1,"TableID":104}
+ │              └── AddTableZoneConfig {"TableID":104}
+ ├── PreCommitPhase
+ │    ├── Stage 1 of 2 in PreCommitPhase
+ │    │    ├── 12 elements transitioning toward PUBLIC
+ │    │    │    ├── PUBLIC        → ABSENT IndexZoneConfig:{DescID: 104 (t), IndexID: 1 (t_pkey-), SeqNum: 1}
+ │    │    │    ├── PUBLIC        → ABSENT TableZoneConfig:{DescID: 104 (t), SeqNum: 1}
+ │    │    │    ├── DELETE_ONLY   → ABSENT Column:{DescID: 104 (t), ColumnID: 3 (w+)}
+ │    │    │    ├── PUBLIC        → ABSENT ColumnName:{DescID: 104 (t), Name: "w", ColumnID: 3 (w+)}
+ │    │    │    ├── PUBLIC        → ABSENT ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 3 (w+), TypeName: "STRING"}
+ │    │    │    ├── PUBLIC        → ABSENT ColumnDefaultExpression:{DescID: 104 (t), ColumnID: 3 (w+), Expr: 's':::STRING}
+ │    │    │    ├── BACKFILL_ONLY → ABSENT PrimaryIndex:{DescID: 104 (t), IndexID: 2 (t_pkey+), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1 (t_pkey-)}
+ │    │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 1 (k), IndexID: 2 (t_pkey+)}
+ │    │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 2 (v), IndexID: 2 (t_pkey+)}
+ │    │    │    ├── PUBLIC        → ABSENT IndexData:{DescID: 104 (t), IndexID: 2 (t_pkey+)}
+ │    │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 3 (w+), IndexID: 2 (t_pkey+)}
+ │    │    │    └── PUBLIC        → ABSENT TableZoneConfig:{DescID: 104 (t), SeqNum: 2}
+ │    │    ├── 4 elements transitioning toward TRANSIENT_ABSENT
+ │    │    │    ├── DELETE_ONLY   → ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 3, ConstraintID: 3, SourceIndexID: 1 (t_pkey-)}
+ │    │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 1 (k), IndexID: 3}
+ │    │    │    ├── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 2 (v), IndexID: 3}
+ │    │    │    └── PUBLIC        → ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 3 (w+), IndexID: 3}
+ │    │    └── 1 Mutation operation
+ │    │         └── UndoAllInTxnImmediateMutationOpSideEffects
+ │    └── Stage 2 of 2 in PreCommitPhase
+ │         ├── 12 elements transitioning toward PUBLIC
+ │         │    ├── ABSENT → PUBLIC        IndexZoneConfig:{DescID: 104 (t), IndexID: 1 (t_pkey-), SeqNum: 1}
+ │         │    ├── ABSENT → PUBLIC        TableZoneConfig:{DescID: 104 (t), SeqNum: 1}
+ │         │    ├── ABSENT → DELETE_ONLY   Column:{DescID: 104 (t), ColumnID: 3 (w+)}
+ │         │    ├── ABSENT → PUBLIC        ColumnName:{DescID: 104 (t), Name: "w", ColumnID: 3 (w+)}
+ │         │    ├── ABSENT → PUBLIC        ColumnType:{DescID: 104 (t), ColumnFamilyID: 0 (primary), ColumnID: 3 (w+), TypeName: "STRING"}
+ │         │    ├── ABSENT → PUBLIC        ColumnDefaultExpression:{DescID: 104 (t), ColumnID: 3 (w+), Expr: 's':::STRING}
+ │         │    ├── ABSENT → BACKFILL_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 2 (t_pkey+), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1 (t_pkey-)}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 1 (k), IndexID: 2 (t_pkey+)}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 2 (v), IndexID: 2 (t_pkey+)}
+ │         │    ├── ABSENT → PUBLIC        IndexData:{DescID: 104 (t), IndexID: 2 (t_pkey+)}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 3 (w+), IndexID: 2 (t_pkey+)}
+ │         │    └── ABSENT → PUBLIC        TableZoneConfig:{DescID: 104 (t), SeqNum: 2}
+ │         ├── 4 elements transitioning toward TRANSIENT_ABSENT
+ │         │    ├── ABSENT → DELETE_ONLY   TemporaryIndex:{DescID: 104 (t), IndexID: 3, ConstraintID: 3, SourceIndexID: 1 (t_pkey-)}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 1 (k), IndexID: 3}
+ │         │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 2 (v), IndexID: 3}
+ │         │    └── ABSENT → PUBLIC        IndexColumn:{DescID: 104 (t), ColumnID: 3 (w+), IndexID: 3}
+ │         └── 19 Mutation operations
+ │              ├── AddIndexZoneConfig {"SubzoneIndexToDelete":-1,"TableID":104}
+ │              ├── AddTableZoneConfig {"TableID":104}
+ │              ├── MakeAbsentColumnDeleteOnly {"Column":{"ColumnID":3,"TableID":104}}
+ │              ├── SetColumnName {"ColumnID":3,"Name":"w","TableID":104}
+ │              ├── UpsertColumnType {"ColumnType":{"ColumnID":3,"TableID":104}}
+ │              ├── AddColumnDefaultExpression {"Default":{"ColumnID":3,"TableID":104}}
+ │              ├── MakeAbsentIndexBackfilling {"Index":{"ConstraintID":2,"IndexID":2,"IsUnique":true,"SourceIndexID":1,"TableID":104,"TemporaryIndexID":3}}
+ │              ├── MaybeAddSplitForIndex {"IndexID":2,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":2,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":2,"Kind":2,"TableID":104}
+ │              ├── MakeAbsentTempIndexDeleteOnly {"Index":{"ConstraintID":3,"IndexID":3,"IsUnique":true,"SourceIndexID":1,"TableID":104}}
+ │              ├── MaybeAddSplitForIndex {"IndexID":3,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":3,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":3,"Kind":2,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":3,"IndexID":2,"Kind":2,"Ordinal":1,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":3,"IndexID":3,"Kind":2,"Ordinal":1,"TableID":104}
+ │              ├── AddTableZoneConfig {"TableID":104}
+ │              ├── SetJobStateOnDescriptor {"DescriptorID":104,"Initialize":true}
+ │              └── CreateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
+ ├── PostCommitPhase
+ │    ├── Stage 1 of 7 in PostCommitPhase
+ │    │    ├── 2 elements transitioning toward PUBLIC
+ │    │    │    ├── DELETE_ONLY → WRITE_ONLY Column:{DescID: 104 (t), ColumnID: 3 (w+)}
+ │    │    │    └── ABSENT      → WRITE_ONLY ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (w+), IndexID: 2 (t_pkey+)}
+ │    │    ├── 2 elements transitioning toward TRANSIENT_ABSENT
+ │    │    │    ├── DELETE_ONLY → WRITE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 3, ConstraintID: 3, SourceIndexID: 1 (t_pkey-)}
+ │    │    │    └── ABSENT      → PUBLIC     IndexData:{DescID: 104 (t), IndexID: 3}
+ │    │    └── 5 Mutation operations
+ │    │         ├── MakeDeleteOnlyColumnWriteOnly {"ColumnID":3,"TableID":104}
+ │    │         ├── MakeDeleteOnlyIndexWriteOnly {"IndexID":3,"TableID":104}
+ │    │         ├── MakeAbsentColumnNotNullWriteOnly {"ColumnID":3,"TableID":104}
+ │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+ │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
+ │    ├── Stage 2 of 7 in PostCommitPhase
+ │    │    ├── 1 element transitioning toward PUBLIC
+ │    │    │    └── BACKFILL_ONLY → BACKFILLED PrimaryIndex:{DescID: 104 (t), IndexID: 2 (t_pkey+), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1 (t_pkey-)}
+ │    │    └── 1 Backfill operation
+ │    │         └── BackfillIndex {"IndexID":2,"SourceIndexID":1,"TableID":104}
+ │    ├── Stage 3 of 7 in PostCommitPhase
+ │    │    ├── 1 element transitioning toward PUBLIC
+ │    │    │    └── BACKFILLED → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 2 (t_pkey+), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1 (t_pkey-)}
+ │    │    └── 3 Mutation operations
+ │    │         ├── MakeBackfillingIndexDeleteOnly {"IndexID":2,"TableID":104}
+ │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+ │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
+ │    ├── Stage 4 of 7 in PostCommitPhase
+ │    │    ├── 1 element transitioning toward PUBLIC
+ │    │    │    └── DELETE_ONLY → MERGE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 2 (t_pkey+), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1 (t_pkey-)}
+ │    │    └── 3 Mutation operations
+ │    │         ├── MakeBackfilledIndexMerging {"IndexID":2,"TableID":104}
+ │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+ │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
+ │    ├── Stage 5 of 7 in PostCommitPhase
+ │    │    ├── 1 element transitioning toward PUBLIC
+ │    │    │    └── MERGE_ONLY → MERGED PrimaryIndex:{DescID: 104 (t), IndexID: 2 (t_pkey+), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1 (t_pkey-)}
+ │    │    └── 1 Backfill operation
+ │    │         └── MergeIndex {"BackfilledIndexID":2,"TableID":104,"TemporaryIndexID":3}
+ │    ├── Stage 6 of 7 in PostCommitPhase
+ │    │    ├── 1 element transitioning toward PUBLIC
+ │    │    │    └── MERGED     → WRITE_ONLY            PrimaryIndex:{DescID: 104 (t), IndexID: 2 (t_pkey+), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1 (t_pkey-)}
+ │    │    ├── 1 element transitioning toward TRANSIENT_ABSENT
+ │    │    │    └── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 104 (t), IndexID: 3, ConstraintID: 3, SourceIndexID: 1 (t_pkey-)}
+ │    │    └── 4 Mutation operations
+ │    │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":3,"TableID":104}
+ │    │         ├── MakeMergedIndexWriteOnly {"IndexID":2,"TableID":104}
+ │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+ │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
+ │    └── Stage 7 of 7 in PostCommitPhase
+ │         ├── 2 elements transitioning toward PUBLIC
+ │         │    ├── WRITE_ONLY → VALIDATED PrimaryIndex:{DescID: 104 (t), IndexID: 2 (t_pkey+), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1 (t_pkey-)}
+ │         │    └── WRITE_ONLY → VALIDATED ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (w+), IndexID: 2 (t_pkey+)}
+ │         └── 2 Validation operations
+ │              ├── ValidateIndex {"IndexID":2,"TableID":104}
+ │              └── ValidateColumnNotNull {"ColumnID":3,"IndexIDForValidation":2,"TableID":104}
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 4 elements transitioning toward PUBLIC
+      │    │    ├── WRITE_ONLY            → PUBLIC           Column:{DescID: 104 (t), ColumnID: 3 (w+)}
+      │    │    ├── VALIDATED             → PUBLIC           PrimaryIndex:{DescID: 104 (t), IndexID: 2 (t_pkey+), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1 (t_pkey-)}
+      │    │    ├── ABSENT                → PUBLIC           IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 2 (t_pkey+)}
+      │    │    └── VALIDATED             → PUBLIC           ColumnNotNull:{DescID: 104 (t), ColumnID: 3 (w+), IndexID: 2 (t_pkey+)}
+      │    ├── 4 elements transitioning toward TRANSIENT_ABSENT
+      │    │    ├── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT TemporaryIndex:{DescID: 104 (t), IndexID: 3, ConstraintID: 3, SourceIndexID: 1 (t_pkey-)}
+      │    │    ├── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 1 (k), IndexID: 3}
+      │    │    ├── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 2 (v), IndexID: 3}
+      │    │    └── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 104 (t), ColumnID: 3 (w+), IndexID: 3}
+      │    ├── 2 elements transitioning toward ABSENT
+      │    │    ├── PUBLIC                → VALIDATED        PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey-), ConstraintID: 1}
+      │    │    └── PUBLIC                → ABSENT           IndexName:{DescID: 104 (t), Name: "t_pkey", IndexID: 1 (t_pkey-)}
+      │    └── 13 Mutation operations
+      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":1,"TableID":104}
+      │         ├── SetIndexName {"IndexID":1,"Name":"crdb_internal_in...","TableID":104}
+      │         ├── SetIndexName {"IndexID":2,"Name":"t_pkey","TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":3,"Kind":2,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":3,"Kind":2,"Ordinal":1,"TableID":104}
+      │         ├── MakeValidatedColumnNotNullPublic {"ColumnID":3,"TableID":104}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":2,"TableID":104}
+      │         ├── MakeIndexAbsent {"IndexID":3,"TableID":104}
+      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":3,"TableID":104}
+      │         ├── RefreshStats {"TableID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 3 elements transitioning toward ABSENT
+      │    │    ├── PUBLIC    → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 1 (k), IndexID: 1 (t_pkey-)}
+      │    │    ├── PUBLIC    → ABSENT      IndexColumn:{DescID: 104 (t), ColumnID: 2 (v), IndexID: 1 (t_pkey-)}
+      │    │    └── VALIDATED → DELETE_ONLY PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey-), ConstraintID: 1}
+      │    └── 5 Mutation operations
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":1,"TableID":104}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":1,"Kind":2,"TableID":104}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 3 of 3 in PostCommitNonRevertiblePhase
+           ├── 1 element transitioning toward TRANSIENT_ABSENT
+           │    └── PUBLIC      → TRANSIENT_ABSENT IndexData:{DescID: 104 (t), IndexID: 3}
+           ├── 2 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY → ABSENT           PrimaryIndex:{DescID: 104 (t), IndexID: 1 (t_pkey-), ConstraintID: 1}
+           │    └── PUBLIC      → ABSENT           IndexData:{DescID: 104 (t), IndexID: 1 (t_pkey-)}
+           └── 5 Mutation operations
+                ├── MakeIndexAbsent {"IndexID":1,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":1,"TableID":104}
+                ├── CreateGCJobForIndex {"IndexID":3,"TableID":104}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":104}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_subzones/add_column_subzones__statement_3_of_3.explain_shape
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_subzones/add_column_subzones__statement_3_of_3.explain_shape
@@ -1,0 +1,22 @@
+/* setup */
+CREATE TABLE t (
+  k INT PRIMARY KEY,
+  V STRING
+);
+
+/* test */
+ALTER INDEX t@t_pkey CONFIGURE ZONE USING gc.ttlseconds = 1;
+ALTER TABLE t CONFIGURE ZONE USING gc.ttlseconds = 1;
+EXPLAIN (DDL, SHAPE) ALTER TABLE t ADD COLUMN w TEXT NOT NULL DEFAULT 's';
+----
+Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ADD COLUMN ‹w› STRING NOT NULL DEFAULT ‹'s'›; following ALTER INDEX ‹defaultdb›.‹public›.‹t›@‹t_pkey› CONFIGURE ZONE USING ‹"gc.ttlseconds"› = ‹1›; ALTER TABLE ‹defaultdb›.‹public›.‹t› CONFIGURE ZONE USING ‹"gc.ttlseconds"› = ‹1›;
+ ├── execute 2 system table mutations transactions
+ ├── backfill using primary index t_pkey- in relation t
+ │    └── into t_pkey+ (k; v, w+)
+ ├── execute 2 system table mutations transactions
+ ├── merge temporary indexes into backfilled indexes in relation t
+ │    └── from t@[3] into t_pkey+
+ ├── execute 1 system table mutations transaction
+ ├── validate UNIQUE constraint backed by index t_pkey+ in relation t
+ ├── validate NOT NULL constraint on column w+ in index t_pkey+ in relation t
+ └── execute 3 system table mutations transactions

--- a/pkg/sql/logictest/testdata/logic_test/zone_config
+++ b/pkg/sql/logictest/testdata/logic_test/zone_config
@@ -531,3 +531,69 @@ statement ok
 RESET use_declarative_schema_changer;
 
 subtest end
+
+# Ensure that index ID changes due to a backfill have a properly corresponding
+# zone config.
+subtest backfill_idx_id
+
+statement ok
+CREATE TABLE foo(i int);
+
+statement ok
+ALTER INDEX foo@foo_pkey CONFIGURE ZONE USING gc.ttlseconds=90;
+
+statement ok
+ALTER TABLE foo ADD COLUMN j INT NOT NULL DEFAULT 42;
+
+# Here, we can see that although the index ID changed, our corresponding
+# subzone config has an entry for our new index; along with a corres. subzone
+# span.
+skipif config local-mixed-24.3 local-legacy-schema-changer
+query B colnames
+WITH subzones AS (
+    SELECT
+        json_array_elements(
+            crdb_internal.pb_to_json('cockroach.config.zonepb.ZoneConfig', config) -> 'subzones'
+        ) AS config
+    FROM system.zones
+    WHERE id = 'foo'::REGCLASS::OID
+),
+subzone_indexes AS (
+    SELECT
+        (config -> 'indexId')::INT AS indexID
+    FROM subzones
+),
+primary_index AS (
+    SELECT
+        (crdb_internal.pb_to_json(
+            'cockroach.sql.sqlbase.Descriptor',
+            descriptor
+        )->'table'->'primaryIndex'->>'id')::INT AS primaryID
+    FROM system.descriptor
+    WHERE id = 'foo'::regclass::oid
+)
+SELECT EXISTS (
+    SELECT 1
+    FROM primary_index, subzone_indexes
+    WHERE primaryID = indexID
+) AS match_found;
+----
+match_found
+true
+
+skipif config local-mixed-24.3 local-legacy-schema-changer
+query B
+WITH subzone_spans AS (
+    SELECT json_array_elements(crdb_internal.pb_to_json('cockroach.config.zonepb.ZoneConfig', config) -> 'subzoneSpans') ->> 'key' AS key
+    FROM system.zones
+    WHERE id = 'foo'::REGCLASS::OID
+)
+SELECT EXISTS (
+    SELECT 1
+    FROM subzone_spans
+    WHERE crdb_internal.pretty_key(decode(key, 'base64'), 0) = '/2'
+) AS exists;
+----
+true
+
+subtest end

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table.go
@@ -185,29 +185,43 @@ func disallowDroppingPrimaryIndexReferencedInUDFOrView(
 
 // maybeRewriteTempIDsInPrimaryIndexes is part of the post-processing
 // invoked at the end of building each ALTER TABLE statement to replace temporary
-// IDs with real, actual IDs.
+// IDs with real, actual IDs. If any replaced temporary IDs had any subzone
+// configs, we also ensure those references get updated.
 func maybeRewriteTempIDsInPrimaryIndexes(b BuildCtx, tableID catid.DescID) {
 	chain := getPrimaryIndexChain(b, tableID)
+	hasRewrittenPrimaryID := false
 	for i, spec := range chain.allPrimaryIndexSpecs(nonNilPrimaryIndexSpecSelector) {
 		if i == 0 {
 			continue
 		}
-		maybeRewriteIndexAndConstraintID(b, tableID, spec.primary.IndexID, spec.primary.ConstraintID)
+		hasRewrittenPrimaryID = maybeRewriteIndexAndConstraintID(b, tableID, spec.primary.IndexID, spec.primary.ConstraintID)
 		tempIndexSpec := chain.mustGetIndexSpecByID(spec.primary.TemporaryIndexID)
 		maybeRewriteIndexAndConstraintID(b, tableID, tempIndexSpec.temporary.IndexID, tempIndexSpec.temporary.ConstraintID)
 	}
 	chain.validate()
+	currPrimaryIndexID := getCurrentPrimaryIndexID(b, tableID)
+	hasZoneCfgRefs := hasSubzonesForIndex(b, tableID, currPrimaryIndexID)
+	if hasRewrittenPrimaryID && hasZoneCfgRefs {
+		if err := configureZoneConfigForNewIndexBackfill(b, tableID, currPrimaryIndexID); err != nil {
+			panic(errors.Wrapf(
+				err,
+				"error while updating zone config refs for indexID %d of tableID %d",
+				currPrimaryIndexID,
+				tableID))
+		}
+	}
 }
 
-// maybeRewriteIndexAndConstraintID attempts to replace index which currently has
-// a temporary index ID `indexID` with an actual index ID. It also updates
-// all elements that references this index with the actual index ID.
+// maybeRewriteIndexAndConstraintID attempts to replace index which currently
+// has a temporary index ID `indexID` with an actual index ID. It also updates
+// all elements that references this index with the actual index ID. It returns
+// a boolean indicating if any work has been done.
 func maybeRewriteIndexAndConstraintID(
 	b BuildCtx, tableID catid.DescID, indexID catid.IndexID, constraintID catid.ConstraintID,
-) {
+) bool {
 	if indexID < catid.IndexID(TableTentativeIdsStart) || constraintID < catid.ConstraintID(TableTentativeIdsStart) {
 		// Nothing to do if it's already an actual index ID.
-		return
+		return false
 	}
 
 	actualIndexID := b.NextTableIndexID(tableID)
@@ -228,6 +242,7 @@ func maybeRewriteIndexAndConstraintID(
 			return nil
 		})
 	})
+	return true
 }
 
 // maybeDropRedundantPrimaryIndexes is part of the post-processing invoked at

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/helpers.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/helpers.go
@@ -1867,3 +1867,15 @@ func failIfSafeUpdates(b BuildCtx, n tree.NodeFormatter) {
 		)
 	}
 }
+
+func hasSubzonesForIndex(b BuildCtx, tableID descpb.ID, indexID catid.IndexID) bool {
+	numIdxSubzones := b.QueryByID(tableID).FilterIndexZoneConfig().
+		Filter(func(_ scpb.Status, _ scpb.TargetStatus, e *scpb.IndexZoneConfig) bool {
+			return e.IndexID == indexID
+		}).Size()
+	numPartSubzones := b.QueryByID(tableID).FilterPartitionZoneConfig().
+		Filter(func(_ scpb.Status, _ scpb.TargetStatus, e *scpb.PartitionZoneConfig) bool {
+			return e.IndexID == indexID
+		}).Size()
+	return numIdxSubzones > 0 || numPartSubzones > 0
+}

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/zone_config_helpers.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/zone_config_helpers.go
@@ -784,33 +784,36 @@ func generateSubzoneSpans(
 	a := &tree.DatumAlloc{}
 	var indexCovering covering.Covering
 	var partitionCoverings []covering.Covering
-	var err error
-	b.QueryByID(tableID).FilterIndexName().NotToAbsent().ForEach(
-		func(_ scpb.Status, _ scpb.TargetStatus, e *scpb.IndexName) {
-			_, indexSubzoneExists := subzoneIndexByIndexID[e.IndexID]
-			if indexSubzoneExists {
-				prefix := roachpb.Key(rowenc.MakeIndexKeyPrefix(b.Codec(), tableID, e.IndexID))
-				idxSpan := roachpb.Span{Key: prefix, EndKey: prefix.PrefixEnd()}
-				// Each index starts with a unique prefix, so (from a precedence
-				// perspective) it's safe to append them all together.
-				indexCovering = append(indexCovering, covering.Range{
-					Start: idxSpan.Key, End: idxSpan.EndKey,
-					Payload: zonepb.Subzone{IndexID: uint32(e.IndexID)},
-				})
-			}
-			var emptyPrefix []tree.Datum
-			index := mustRetrieveIndexColumnElements(b, tableID, e.IndexID)
-			partitioning := mustRetrievePartitioningFromIndexPartitioning(b, tableID, e.IndexID)
-			var indexPartitionCoverings []covering.Covering
-			indexPartitionCoverings, err = indexCoveringsForPartitioning(
-				b, a, tableID, e.IndexID, index, partitioning, subzoneIndexByPartition, emptyPrefix)
-			if err != nil {
-				return
-			}
-			partitionCoverings = append(partitionCoverings, indexPartitionCoverings...)
+	var indexes []catid.IndexID
+	b.QueryByID(tableID).FilterIndexName().
+		ForEach(func(_ scpb.Status, _ scpb.TargetStatus, e *scpb.IndexName) {
+			indexes = append(indexes, e.IndexID)
 		})
-	if err != nil {
-		return nil, err
+	b.QueryByID(tableID).FilterTemporaryIndex().Transient().
+		ForEach(func(_ scpb.Status, _ scpb.TargetStatus, e *scpb.TemporaryIndex) {
+			indexes = append(indexes, e.IndexID)
+		})
+	for _, idxID := range indexes {
+		_, indexSubzoneExists := subzoneIndexByIndexID[idxID]
+		if indexSubzoneExists {
+			prefix := roachpb.Key(rowenc.MakeIndexKeyPrefix(b.Codec(), tableID, idxID))
+			idxSpan := roachpb.Span{Key: prefix, EndKey: prefix.PrefixEnd()}
+			// Each index starts with a unique prefix, so (from a precedence
+			// perspective) it's safe to append them all together.
+			indexCovering = append(indexCovering, covering.Range{
+				Start: idxSpan.Key, End: idxSpan.EndKey,
+				Payload: zonepb.Subzone{IndexID: uint32(idxID)},
+			})
+		}
+		var emptyPrefix []tree.Datum
+		index := mustRetrieveIndexColumnElements(b, tableID, idxID)
+		partitioning := mustRetrievePartitioningFromIndexPartitioning(b, tableID, idxID)
+		indexPartitionCoverings, err := indexCoveringsForPartitioning(
+			b, a, tableID, idxID, index, partitioning, subzoneIndexByPartition, emptyPrefix)
+		if err != nil {
+			return nil, err
+		}
+		partitionCoverings = append(partitionCoverings, indexPartitionCoverings...)
 	}
 
 	// OverlapCoveringMerge returns the payloads for any coverings that overlap
@@ -1337,4 +1340,68 @@ func constructSideEffectPartitionElem(
 		OldIdxRef:     oldSubzoneIdx,
 	}
 	return elem
+}
+
+// getMostRecentTableZoneCfg returns the most recent table (denoted by
+// highest seqNum) zone config for the given tableID (if any exist).
+//
+// N.B. Adding a new zone config element entails adding a new element where the
+// seqNum is 1 greater than the most recent zone config element. This helps
+// ensure zone config changes are applied in the correct order during explicit
+// transactions.
+func getMostRecentTableZoneCfg(b BuildCtx, tableID catid.DescID) *scpb.TableZoneConfig {
+	maxSeq := uint32(0)
+	var tzo *scpb.TableZoneConfig
+	b.QueryByID(tableID).FilterTableZoneConfig().
+		ForEach(func(status scpb.Status, targetStatus scpb.TargetStatus, elem *scpb.TableZoneConfig) {
+			if elem.SeqNum >= maxSeq {
+				maxSeq = elem.SeqNum
+				tzo = elem
+			}
+		})
+	return tzo
+}
+
+// configureZoneConfigForNewIndexBackfill will ensure that current subzone
+// configs for the given index on tableID are updated to the newIndexID.
+func configureZoneConfigForNewIndexBackfill(
+	b BuildCtx, tableID catid.DescID, oldIndexID catid.IndexID,
+) error {
+	mostRecentTableZoneConfig := getMostRecentTableZoneCfg(b, tableID)
+	if mostRecentTableZoneConfig == nil {
+		return errors.AssertionFailedf("attempting to modify subzone configs for indexID %d"+
+			" on tableID %d that does not a zone config set", oldIndexID, tableID)
+	}
+	tempIndex := b.QueryByID(tableID).FilterTemporaryIndex().
+		Filter(func(current scpb.Status, target scpb.TargetStatus, e *scpb.TemporaryIndex) bool {
+			return target == scpb.Transient && e.SourceIndexID == oldIndexID
+		}).MustGetZeroOrOneElement()
+	newIndex := getLatestPrimaryIndex(b, tableID)
+	newIndexesForBackfill := []catid.IndexID{tempIndex.IndexID, newIndex.IndexID}
+	newZoneConfig := *mostRecentTableZoneConfig.ZoneConfig
+	newSubzones := make([]zonepb.Subzone, 0)
+	newSubzones = append(newSubzones, newZoneConfig.Subzones...)
+	// For the indexes we will use as a part of the backfill, ensure we copy
+	// over each subzone config from the old index to the backfill-related ones.
+	for _, idxToAdd := range newIndexesForBackfill {
+		for _, subzone := range newZoneConfig.Subzones {
+			if subzone.IndexID == uint32(oldIndexID) {
+				subzone.IndexID = uint32(idxToAdd)
+			}
+			newSubzones = append(newSubzones, subzone)
+		}
+	}
+	newZoneConfig.Subzones = newSubzones
+	var err error
+	newZoneConfig.SubzoneSpans, err = generateSubzoneSpans(b, tableID, newZoneConfig.Subzones)
+	if err != nil {
+		return err
+	}
+	tzc := &scpb.TableZoneConfig{
+		TableID:    tableID,
+		ZoneConfig: &newZoneConfig,
+		SeqNum:     mostRecentTableZoneConfig.SeqNum + 1,
+	}
+	b.Add(tzc)
+	return nil
 }

--- a/pkg/sql/schemachanger/scdeps/exec_deps.go
+++ b/pkg/sql/schemachanger/scdeps/exec_deps.go
@@ -258,7 +258,8 @@ func (d *txnDeps) UpdateZoneConfig(ctx context.Context, id descpb.ID, zc *zonepb
 	return d.descsCollection.WriteZoneConfigToBatch(ctx, d.kvTrace, d.getOrCreateBatch(), id, newZc)
 }
 
-// UpdateSubzoneConfig implements the scexec.Catalog interface.
+// UpdateSubzoneConfig implements the scexec.Catalog interface. Note that this
+// function does not add the subzone config to uncommitted.
 func (d *txnDeps) UpdateSubzoneConfig(
 	ctx context.Context,
 	parentZone catalog.ZoneConfig,


### PR DESCRIPTION
Backport 1/1 commits from #141800.

/cc @cockroachdb/release

---

This patch ensures that we update references to any index
ID that changes in a table's zone config (due to an index backfill).

Epic: none
Fixes: https://github.com/cockroachdb/cockroach/issues/141789

Release note (bug fix): Fixed a bug where replication controls on
indexes and partitions would not get properly updated during an index
backfill (in the [Declarative Schema Changer](https://www.cockroachlabs.com/docs/stable/online-schema-changes#declarative-schema-changer)) to its new ID; effectively
discarding the replication controls set on it before the backfill.

---

Release justification: high-priority bug fix
