### PR TITLE
changefeedccl: add retry to TestChangefeedFailOnTableOffline

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -5195,7 +5195,7 @@ func TestChangefeedFailOnTableOffline(t *testing.T) {
 		// Start an import job which will immediately pause after ingestion
 		sqlDB.Exec(t, "SET CLUSTER SETTING jobs.debug.pausepoints = 'import.after_ingest';")
 		go func() {
-			sqlDB.ExpectErrWithTimeout(t, `pause point`, `IMPORT INTO for_import CSV DATA ($1);`, dataSrv.URL)
+			sqlDB.ExpectErrWithRetry(t, `pause point`, `IMPORT INTO for_import CSV DATA ($1);`, `result is ambiguous`, dataSrv.URL)
 		}()
 		sqlDB.CheckQueryResultsRetry(
 			t,

--- a/pkg/testutils/sqlutils/BUILD.bazel
+++ b/pkg/testutils/sqlutils/BUILD.bazel
@@ -29,6 +29,7 @@ go_library(
         "//pkg/sql/sem/tree",
         "//pkg/testutils",
         "//pkg/util/protoutil",
+        "//pkg/util/retry",
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_cockroach_go_v2//crdb",
         "@com_github_cockroachdb_errors//:errors",


### PR DESCRIPTION
Previously, this TestChangefeedFailOnTableOffline test could fail if the import attempt failed with "result is ambiguous". This error should be retried. This should reduce this source of flakiness for that test.

Fixes: #142033
Release note: None