### PR TITLE
release-23.2: workload/npgsql: ignore flaky test Failed_transaction_on_close_with_custom_timeout

### DIFF
--- a/pkg/cmd/roachtest/tests/npgsql_blocklist.go
+++ b/pkg/cmd/roachtest/tests/npgsql_blocklist.go
@@ -709,5 +709,6 @@ var npgsqlBlocklist = blocklist{
 }
 
 var npgsqlIgnoreList = blocklist{
-	`Npgsql.Tests.TransactionTests(Multiplexing).Failed_transaction_on_close_with_custom_timeout`: "flaky",
+	`Npgsql.Tests.TransactionTests(NonMultiplexing).Failed_transaction_on_close_with_custom_timeout`: "flaky",
+	`Npgsql.Tests.TransactionTests(Multiplexing).Failed_transaction_on_close_with_custom_timeout`:    "flaky",
 }


### PR DESCRIPTION
Backport 1/1 commits from #142728.

/cc @cockroachdb/release

---

The test Failed_transaction_on_close_with_custom_timeout has been observed to fail intermittently. To improve test stability, we are adding it to the ignore list.

Closes #142455

Epic: none
Release note: none
Release justification: test-only change
