### PR TITLE
kvserver: eliminate FirstIndex

### DIFF
--- a/pkg/kv/kvpb/data.go
+++ b/pkg/kv/kvpb/data.go
@@ -200,3 +200,19 @@ type RaftIndex uint64
 
 // SafeValue implements the redact.SafeValue interface.
 func (s RaftIndex) SafeValue() {}
+
+// RaftSpan represents a (begin, end] span of indices in a raft log. The choice
+// of excluding the left bound and including the right bound is deliberate and
+// principled. When working with raft logs, it almost always helps to avoid
+// off-by-one errors and risk of integer underflow.
+type RaftSpan struct {
+	// After is the left bound of the log indices span. Exclusive.
+	After RaftIndex
+	// Last is the right bound of the log indices span. Inclusive.
+	Last RaftIndex
+}
+
+// Contains returns true iff the given index is within the span.
+func (s RaftSpan) Contains(index RaftIndex) bool {
+	return index > s.After && index <= s.Last
+}

--- a/pkg/kv/kvserver/allocator/allocatorimpl/allocator.go
+++ b/pkg/kv/kvserver/allocator/allocatorimpl/allocator.go
@@ -2015,7 +2015,7 @@ func (a *Allocator) ValidLeaseTargets(
 	leaseRepl interface {
 		StoreID() roachpb.StoreID
 		RaftStatus() *raft.Status
-		GetFirstIndex() kvpb.RaftIndex
+		GetCompactedIndex() kvpb.RaftIndex
 		SendStreamStats(*rac2.RangeSendStreamStats)
 	},
 	opts allocator.TransferLeaseOptions,
@@ -2079,7 +2079,7 @@ func (a *Allocator) ValidLeaseTargets(
 		}
 
 		candidates = append(validSnapshotCandidates, excludeReplicasInNeedOfSnapshots(
-			ctx, status, leaseRepl.GetFirstIndex(), candidates)...)
+			ctx, status, leaseRepl.GetCompactedIndex()+1, candidates)...)
 		candidates = excludeReplicasInNeedOfCatchup(
 			ctx, leaseRepl.SendStreamStats, candidates)
 	}
@@ -2189,7 +2189,7 @@ func (a *Allocator) LeaseholderShouldMoveDueToPreferences(
 	leaseRepl interface {
 		StoreID() roachpb.StoreID
 		RaftStatus() *raft.Status
-		GetFirstIndex() kvpb.RaftIndex
+		GetCompactedIndex() kvpb.RaftIndex
 		SendStreamStats(*rac2.RangeSendStreamStats)
 	},
 	allExistingReplicas []roachpb.ReplicaDescriptor,
@@ -2222,7 +2222,7 @@ func (a *Allocator) LeaseholderShouldMoveDueToPreferences(
 	preferred := a.PreferredLeaseholders(storePool, conf, candidates)
 	if exclReplsInNeedOfSnapshots {
 		preferred = excludeReplicasInNeedOfSnapshots(
-			ctx, leaseRepl.RaftStatus(), leaseRepl.GetFirstIndex(), preferred)
+			ctx, leaseRepl.RaftStatus(), leaseRepl.GetCompactedIndex()+1, preferred)
 		preferred = excludeReplicasInNeedOfCatchup(
 			ctx, leaseRepl.SendStreamStats, preferred)
 	}
@@ -2282,7 +2282,7 @@ func (a *Allocator) TransferLeaseTarget(
 		StoreID() roachpb.StoreID
 		GetRangeID() roachpb.RangeID
 		RaftStatus() *raft.Status
-		GetFirstIndex() kvpb.RaftIndex
+		GetCompactedIndex() kvpb.RaftIndex
 		SendStreamStats(*rac2.RangeSendStreamStats)
 	},
 	usageInfo allocator.RangeUsageInfo,
@@ -2651,7 +2651,7 @@ func (a *Allocator) ShouldTransferLease(
 	leaseRepl interface {
 		StoreID() roachpb.StoreID
 		RaftStatus() *raft.Status
-		GetFirstIndex() kvpb.RaftIndex
+		GetCompactedIndex() kvpb.RaftIndex
 		SendStreamStats(*rac2.RangeSendStreamStats)
 	},
 	usageInfo allocator.RangeUsageInfo,

--- a/pkg/kv/kvserver/allocator/allocatorimpl/allocator.go
+++ b/pkg/kv/kvserver/allocator/allocatorimpl/allocator.go
@@ -2079,7 +2079,7 @@ func (a *Allocator) ValidLeaseTargets(
 		}
 
 		candidates = append(validSnapshotCandidates, excludeReplicasInNeedOfSnapshots(
-			ctx, status, leaseRepl.GetCompactedIndex()+1, candidates)...)
+			ctx, status, leaseRepl.GetCompactedIndex(), candidates)...)
 		candidates = excludeReplicasInNeedOfCatchup(
 			ctx, leaseRepl.SendStreamStats, candidates)
 	}
@@ -2222,7 +2222,7 @@ func (a *Allocator) LeaseholderShouldMoveDueToPreferences(
 	preferred := a.PreferredLeaseholders(storePool, conf, candidates)
 	if exclReplsInNeedOfSnapshots {
 		preferred = excludeReplicasInNeedOfSnapshots(
-			ctx, leaseRepl.RaftStatus(), leaseRepl.GetCompactedIndex()+1, preferred)
+			ctx, leaseRepl.RaftStatus(), leaseRepl.GetCompactedIndex(), preferred)
 		preferred = excludeReplicasInNeedOfCatchup(
 			ctx, leaseRepl.SendStreamStats, preferred)
 	}
@@ -3033,12 +3033,12 @@ func FilterBehindReplicas(
 func excludeReplicasInNeedOfSnapshots(
 	ctx context.Context,
 	st *raft.Status,
-	firstIndex kvpb.RaftIndex,
+	compacted kvpb.RaftIndex,
 	replicas []roachpb.ReplicaDescriptor,
 ) []roachpb.ReplicaDescriptor {
 	filled := 0
 	for _, repl := range replicas {
-		snapStatus := raftutil.ReplicaMayNeedSnapshot(st, firstIndex, repl.ReplicaID)
+		snapStatus := raftutil.ReplicaMayNeedSnapshot(st, compacted, repl.ReplicaID)
 		if snapStatus != raftutil.NoSnapshotNeeded {
 			log.KvDistribution.VEventf(
 				ctx,

--- a/pkg/kv/kvserver/allocator/allocatorimpl/allocator_test.go
+++ b/pkg/kv/kvserver/allocator/allocatorimpl/allocator_test.go
@@ -1928,7 +1928,7 @@ func (r *mockRepl) RaftStatus() *raft.Status {
 	return raftStatus
 }
 
-func (r *mockRepl) GetFirstIndex() kvpb.RaftIndex {
+func (r *mockRepl) GetCompactedIndex() kvpb.RaftIndex {
 	return 0
 }
 

--- a/pkg/kv/kvserver/allocator/plan/replicate.go
+++ b/pkg/kv/kvserver/allocator/plan/replicate.go
@@ -97,7 +97,7 @@ type AllocatorReplica interface {
 	LeaseCheckReplica
 	RangeUsageInfo() allocator.RangeUsageInfo
 	RaftStatus() *raft.Status
-	GetFirstIndex() kvpb.RaftIndex
+	GetCompactedIndex() kvpb.RaftIndex
 	LastReplicaAdded() (roachpb.ReplicaID, time.Time)
 	StoreID() roachpb.StoreID
 	GetRangeID() roachpb.RangeID

--- a/pkg/kv/kvserver/asim/queue/allocator_replica.go
+++ b/pkg/kv/kvserver/asim/queue/allocator_replica.go
@@ -135,12 +135,11 @@ func (sr *SimulatorReplica) RaftStatus() *raft.Status {
 	return sr.state.RaftStatus(sr.rng.RangeID(), sr.repl.StoreID())
 }
 
-// GetFirstIndex returns the index of the first entry in the replica's Raft
-// log.
-func (sr *SimulatorReplica) GetFirstIndex() kvpb.RaftIndex {
-	// TODO(kvoli): We always return 2 here as RaftStatus is unimplemented. When
+// GetCompactedIndex returns the compacted index of the raft log.
+func (sr *SimulatorReplica) GetCompactedIndex() kvpb.RaftIndex {
+	// TODO(kvoli): We always return 1 here as RaftStatus is unimplemented. When
 	// it is implemented, this may become variable.
-	return 2
+	return 1
 }
 
 func (sr *SimulatorReplica) SpanConfig() (*roachpb.SpanConfig, error) {

--- a/pkg/kv/kvserver/asim/storerebalancer/candidate_replica.go
+++ b/pkg/kv/kvserver/asim/storerebalancer/candidate_replica.go
@@ -65,12 +65,11 @@ func (sr *simulatorReplica) RaftStatus() *raft.Status {
 	return sr.state.RaftStatus(sr.rng.RangeID(), sr.repl.StoreID())
 }
 
-// GetFirstIndex returns the index of the first entry in the replica's Raft
-// log.
-func (sr *simulatorReplica) GetFirstIndex() kvpb.RaftIndex {
-	// TODO(kvoli): We always return 2 here as RaftStatus is unimplemented.
+// GetCompactedIndex returns the compacted index of the raft log.
+func (sr *simulatorReplica) GetCompactedIndex() kvpb.RaftIndex {
+	// TODO(kvoli): We always return 1 here as RaftStatus is unimplemented.
 	// When it is implmeneted, this may become variable.
-	return 2
+	return 1
 }
 
 // LoadSpanConfig returns the authoritative range descriptor as well

--- a/pkg/kv/kvserver/batcheval/cmd_truncate_log.go
+++ b/pkg/kv/kvserver/batcheval/cmd_truncate_log.go
@@ -65,7 +65,9 @@ func TruncateLog(
 	//
 	// TODO(tbg): think about synthesizing a valid term. Can we use the next
 	// existing entry's term?
-	firstIndex := cArgs.EvalCtx.GetFirstIndex()
+	// TODO(pav-kv): some day, make args.Index an inclusive compaction index, and
+	// eliminate the remaining +-1 arithmetics.
+	firstIndex := cArgs.EvalCtx.GetCompactedIndex() + 1
 	if firstIndex >= args.Index {
 		if log.V(3) {
 			log.Infof(ctx, "attempting to truncate previously truncated raft log. FirstIndex:%d, TruncateFrom:%d",

--- a/pkg/kv/kvserver/batcheval/cmd_truncate_log_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_truncate_log_test.go
@@ -58,9 +58,9 @@ func TestTruncateLog(t *testing.T) {
 
 	ctx := context.Background()
 	const (
-		rangeID    = 12
-		term       = 10
-		firstIndex = 100
+		rangeID        = 12
+		term           = 10
+		compactedIndex = 99
 	)
 
 	st := cluster.MakeTestingClusterSettings()
@@ -68,14 +68,14 @@ func TestTruncateLog(t *testing.T) {
 		ClusterSettings: st,
 		Desc:            &roachpb.RangeDescriptor{RangeID: rangeID},
 		Term:            term,
-		FirstIndex:      firstIndex,
+		CompactedIndex:  compactedIndex,
 	}
 
 	eng := storage.NewDefaultInMemForTesting()
 	defer eng.Close()
 
 	truncState := kvserverpb.RaftTruncatedState{
-		Index: firstIndex + 1,
+		Index: compactedIndex + 2,
 		Term:  term,
 	}
 
@@ -84,7 +84,7 @@ func TestTruncateLog(t *testing.T) {
 	// Send a truncation request.
 	req := kvpb.TruncateLogRequest{
 		RangeID: rangeID,
-		Index:   firstIndex + 7,
+		Index:   compactedIndex + 8,
 	}
 	cArgs := CommandArgs{
 		EvalCtx: evalCtx.EvalContext(),

--- a/pkg/kv/kvserver/batcheval/eval_context.go
+++ b/pkg/kv/kvserver/batcheval/eval_context.go
@@ -59,7 +59,7 @@ type EvalContext interface {
 	GetNodeLocality() roachpb.Locality
 
 	IsFirstRange() bool
-	GetFirstIndex() kvpb.RaftIndex
+	GetCompactedIndex() kvpb.RaftIndex
 	GetTerm(index kvpb.RaftIndex) (kvpb.RaftTerm, error)
 	GetLeaseAppliedIndex() kvpb.LeaseAppliedIndex
 
@@ -174,7 +174,7 @@ type MockEvalCtx struct {
 	AbortSpan              *abortspan.AbortSpan
 	GCThreshold            hlc.Timestamp
 	Term                   kvpb.RaftTerm
-	FirstIndex             kvpb.RaftIndex
+	CompactedIndex         kvpb.RaftIndex
 	CanCreateTxnRecordFn   func() (bool, kvpb.TransactionAbortedReason)
 	MinTxnCommitTSFn       func() hlc.Timestamp
 	LastReplicaGCTimestamp hlc.Timestamp
@@ -238,8 +238,8 @@ func (m *mockEvalCtxImpl) GetRangeID() roachpb.RangeID {
 func (m *mockEvalCtxImpl) IsFirstRange() bool {
 	panic("unimplemented")
 }
-func (m *mockEvalCtxImpl) GetFirstIndex() kvpb.RaftIndex {
-	return m.FirstIndex
+func (m *mockEvalCtxImpl) GetCompactedIndex() kvpb.RaftIndex {
+	return m.CompactedIndex
 }
 func (m *mockEvalCtxImpl) GetTerm(kvpb.RaftIndex) (kvpb.RaftTerm, error) {
 	return m.Term, nil

--- a/pkg/kv/kvserver/client_merge_test.go
+++ b/pkg/kv/kvserver/client_merge_test.go
@@ -4142,7 +4142,7 @@ func TestStoreRangeMergeRaftSnapshot(t *testing.T) {
 		index := repl.GetLastIndex()
 		truncArgs := &kvpb.TruncateLogRequest{
 			RequestHeader: kvpb.RequestHeader{Key: keyA},
-			Index:         index,
+			Index:         index + 1,
 			RangeID:       repl.RangeID,
 		}
 		if _, err := kv.SendWrapped(ctx, distSender, truncArgs); err != nil {

--- a/pkg/kv/kvserver/client_merge_test.go
+++ b/pkg/kv/kvserver/client_merge_test.go
@@ -760,8 +760,7 @@ func mergeCheckingTimestampCaches(
 					// Loosely-coupled truncation requires an engine flush to advance
 					// guaranteed durability.
 					require.NoError(t, r.Store().TODOEngine().Flush())
-					firstIndex := r.GetFirstIndex()
-					if firstIndex < truncIndex {
+					if firstIndex := r.GetCompactedIndex() + 1; firstIndex < truncIndex {
 						return errors.Errorf("truncate not applied, %d < %d", firstIndex, truncIndex)
 					}
 				}

--- a/pkg/kv/kvserver/client_raft_epoch_leases_test.go
+++ b/pkg/kv/kvserver/client_raft_epoch_leases_test.go
@@ -653,7 +653,7 @@ func TestSnapshotAfterTruncationWithUncommittedTailEpochLeases(t *testing.T) {
 		}
 		return nil
 	})
-	waitForTruncationForTesting(t, newLeaderRepl, index+1)
+	waitForTruncationForTesting(t, newLeaderRepl, index)
 
 	snapsMetric := tc.GetFirstStoreFromServer(t, partStore).Metrics().RangeSnapshotsAppliedByVoters
 	snapsBefore := snapsMetric.Count()

--- a/pkg/kv/kvserver/client_raft_test.go
+++ b/pkg/kv/kvserver/client_raft_test.go
@@ -838,12 +838,12 @@ func TestSnapshotAfterTruncation(t *testing.T) {
 	}
 }
 
-func waitForTruncationForTesting(t *testing.T, r *kvserver.Replica, newFirstIndex kvpb.RaftIndex) {
+func waitForTruncationForTesting(t *testing.T, r *kvserver.Replica, compacted kvpb.RaftIndex) {
 	testutils.SucceedsSoon(t, func() error {
 		// Flush the engine to advance durability, which triggers truncation.
 		require.NoError(t, r.Store().TODOEngine().Flush())
-		if firstIndex := r.GetCompactedIndex() + 1; firstIndex != newFirstIndex {
-			return errors.Errorf("expected firstIndex == %d, got %d", newFirstIndex, firstIndex)
+		if index := r.GetCompactedIndex(); index != compacted {
+			return errors.Errorf("expected compacted index == %d, got %d", compacted, index)
 		}
 		return nil
 	})
@@ -1023,7 +1023,7 @@ func TestSnapshotAfterTruncationWithUncommittedTail(t *testing.T) {
 		}
 		return nil
 	})
-	waitForTruncationForTesting(t, newLeaderRepl, index+1)
+	waitForTruncationForTesting(t, newLeaderRepl, index)
 
 	snapsMetric := tc.GetFirstStoreFromServer(t, partStore).Metrics().RangeSnapshotsAppliedByVoters
 	snapsBefore := snapsMetric.Count()

--- a/pkg/kv/kvserver/client_raft_test.go
+++ b/pkg/kv/kvserver/client_raft_test.go
@@ -842,7 +842,7 @@ func waitForTruncationForTesting(t *testing.T, r *kvserver.Replica, newFirstInde
 	testutils.SucceedsSoon(t, func() error {
 		// Flush the engine to advance durability, which triggers truncation.
 		require.NoError(t, r.Store().TODOEngine().Flush())
-		if firstIndex := r.GetFirstIndex(); firstIndex != newFirstIndex {
+		if firstIndex := r.GetCompactedIndex() + 1; firstIndex != newFirstIndex {
 			return errors.Errorf("expected firstIndex == %d, got %d", newFirstIndex, firstIndex)
 		}
 		return nil

--- a/pkg/kv/kvserver/leases/build.go
+++ b/pkg/kv/kvserver/leases/build.go
@@ -111,8 +111,8 @@ type BuildInput struct {
 	MinLeaseProposedTS hlc.ClockTimestamp
 
 	// Information about raft.
-	RaftStatus     *raft.Status
-	RaftFirstIndex kvpb.RaftIndex
+	RaftStatus    *raft.Status
+	RaftCompacted kvpb.RaftIndex
 
 	// Information about the previous lease.
 	PrevLease roachpb.Lease
@@ -254,7 +254,7 @@ func (i BuildInput) toVerifyInput() VerifyInput {
 		LocalReplicaID:     i.LocalReplicaID,
 		Desc:               i.Desc,
 		RaftStatus:         i.RaftStatus,
-		RaftFirstIndex:     i.RaftFirstIndex,
+		RaftFirstIndex:     i.RaftCompacted + 1, // TODO(pav-kv): propagate "compacted"
 		PrevLease:          i.PrevLease,
 		PrevLeaseExpired:   i.PrevLeaseExpired,
 		NextLeaseHolder:    i.NextLeaseHolder,

--- a/pkg/kv/kvserver/leases/build.go
+++ b/pkg/kv/kvserver/leases/build.go
@@ -254,7 +254,7 @@ func (i BuildInput) toVerifyInput() VerifyInput {
 		LocalReplicaID:     i.LocalReplicaID,
 		Desc:               i.Desc,
 		RaftStatus:         i.RaftStatus,
-		RaftFirstIndex:     i.RaftCompacted + 1, // TODO(pav-kv): propagate "compacted"
+		RaftCompacted:      i.RaftCompacted,
 		PrevLease:          i.PrevLease,
 		PrevLeaseExpired:   i.PrevLeaseExpired,
 		NextLeaseHolder:    i.NextLeaseHolder,

--- a/pkg/kv/kvserver/leases/build_test.go
+++ b/pkg/kv/kvserver/leases/build_test.go
@@ -1195,7 +1195,7 @@ func TestInputToVerifyInput(t *testing.T) {
 		LocalReplicaID: 1,
 		Desc:           &roachpb.RangeDescriptor{},
 		RaftStatus:     &raft.Status{},
-		RaftFirstIndex: 1,
+		RaftCompacted:  1,
 		PrevLease: roachpb.Lease{
 			Start:      cts,
 			Expiration: &ts,

--- a/pkg/kv/kvserver/leases/verify.go
+++ b/pkg/kv/kvserver/leases/verify.go
@@ -28,8 +28,8 @@ type VerifyInput struct {
 	Desc           *roachpb.RangeDescriptor
 
 	// Information about raft.
-	RaftStatus     *raft.Status
-	RaftFirstIndex kvpb.RaftIndex
+	RaftStatus    *raft.Status
+	RaftCompacted kvpb.RaftIndex
 
 	// Information about the previous lease.
 	PrevLease        roachpb.Lease
@@ -296,7 +296,8 @@ func verifyTransfer(ctx context.Context, st Settings, i VerifyInput) error {
 	if i.BypassSafetyChecks {
 		return nil
 	}
-	snapStatus := raftutil.ReplicaMayNeedSnapshot(i.RaftStatus, i.RaftFirstIndex, i.NextLeaseHolder.ReplicaID)
+	// TODO(pav-kv): propagate "compacted" down the stack.
+	snapStatus := raftutil.ReplicaMayNeedSnapshot(i.RaftStatus, i.RaftCompacted+1, i.NextLeaseHolder.ReplicaID)
 	if snapStatus != raftutil.NoSnapshotNeeded {
 		log.VEventf(ctx, 2, "not initiating lease transfer because the target %s may "+
 			"need a snapshot: %s", i.NextLeaseHolder, snapStatus)

--- a/pkg/kv/kvserver/leases/verify.go
+++ b/pkg/kv/kvserver/leases/verify.go
@@ -296,8 +296,7 @@ func verifyTransfer(ctx context.Context, st Settings, i VerifyInput) error {
 	if i.BypassSafetyChecks {
 		return nil
 	}
-	// TODO(pav-kv): propagate "compacted" down the stack.
-	snapStatus := raftutil.ReplicaMayNeedSnapshot(i.RaftStatus, i.RaftCompacted+1, i.NextLeaseHolder.ReplicaID)
+	snapStatus := raftutil.ReplicaMayNeedSnapshot(i.RaftStatus, i.RaftCompacted, i.NextLeaseHolder.ReplicaID)
 	if snapStatus != raftutil.NoSnapshotNeeded {
 		log.VEventf(ctx, 2, "not initiating lease transfer because the target %s may "+
 			"need a snapshot: %s", i.NextLeaseHolder, snapStatus)

--- a/pkg/kv/kvserver/leases/verify_test.go
+++ b/pkg/kv/kvserver/leases/verify_test.go
@@ -69,7 +69,7 @@ func TestVerify(t *testing.T) {
 				LocalReplicaID: repl1.ReplicaID,
 				Desc:           &descCpy,
 				RaftStatus:     makeRaftStatus(repl1.ReplicaID, raftpb.StateLeader),
-				RaftFirstIndex: 5,
+				RaftCompacted:  4,
 				PrevLease: roachpb.Lease{
 					Replica:  repl2,
 					Epoch:    2,
@@ -219,7 +219,7 @@ func TestVerify(t *testing.T) {
 	})
 
 	t.Run("transfer", func(t *testing.T) {
-		const repl1RaftFirstIndex = 5
+		const compactedIndex = 4
 		defaultInput := func() VerifyInput {
 			descCpy := desc
 			descCpy.InternalReplicas = append([]roachpb.ReplicaDescriptor(nil), desc.InternalReplicas...)
@@ -228,7 +228,7 @@ func TestVerify(t *testing.T) {
 				LocalReplicaID: repl1.ReplicaID,
 				Desc:           &descCpy,
 				RaftStatus:     nil, // set below
-				RaftFirstIndex: repl1RaftFirstIndex,
+				RaftCompacted:  compactedIndex,
 				PrevLease: roachpb.Lease{
 					Replica:  repl1,
 					Epoch:    2,
@@ -249,7 +249,7 @@ func TestVerify(t *testing.T) {
 			in := defaultInput()
 			in.RaftStatus = makeRaftStatus(repl1.ReplicaID, raftpb.StateLeader)
 			in.RaftStatus.Progress = map[raftpb.PeerID]rafttracker.Progress{
-				raftpb.PeerID(repl1.ReplicaID): {State: rafttracker.StateReplicate, Match: uint64(in.RaftFirstIndex)},
+				raftpb.PeerID(repl1.ReplicaID): {State: rafttracker.StateReplicate, Match: uint64(in.RaftCompacted)},
 			}
 			if targetState != noTargetState {
 				in.RaftStatus.Progress[raftpb.PeerID(repl2.ReplicaID)] = rafttracker.Progress{
@@ -293,17 +293,17 @@ func TestVerify(t *testing.T) {
 			},
 			{
 				name:   "leader, target state replicate, match+1 < firstIndex",
-				input:  defaultLeaderInput(rafttracker.StateReplicate, repl1RaftFirstIndex-2),
+				input:  defaultLeaderInput(rafttracker.StateReplicate, compactedIndex-1),
 				expErr: leaseTransferErrPrefix + raftutil.ReplicaMatchBelowLeadersFirstIndex.String(),
 			},
 			{
 				name:   "leader, target state replicate, match+1 == firstIndex",
-				input:  defaultLeaderInput(rafttracker.StateReplicate, repl1RaftFirstIndex-1),
+				input:  defaultLeaderInput(rafttracker.StateReplicate, compactedIndex),
 				expErr: ``,
 			},
 			{
 				name:   "leader, target state replicate, match+1 > firstIndex",
-				input:  defaultLeaderInput(rafttracker.StateReplicate, repl1RaftFirstIndex),
+				input:  defaultLeaderInput(rafttracker.StateReplicate, compactedIndex+1),
 				expErr: ``,
 			},
 		})

--- a/pkg/kv/kvserver/logstore/logstore.go
+++ b/pkg/kv/kvserver/logstore/logstore.go
@@ -590,7 +590,7 @@ func (s *LogStore) ComputeSize(ctx context.Context) (int64, error) {
 	if err != nil {
 		return 0, err
 	}
-	// The remaining bytes if one were to truncate [0, 0) gives us the total
+	// The remaining bytes if one were to truncate (0, 0] gives us the total
 	// number of bytes in sideloaded files.
 	_, totalSideloaded, err := s.Sideload.BytesIfTruncatedFromTo(ctx, 0, 0)
 	if err != nil {

--- a/pkg/kv/kvserver/logstore/logstore.go
+++ b/pkg/kv/kvserver/logstore/logstore.go
@@ -592,7 +592,7 @@ func (s *LogStore) ComputeSize(ctx context.Context) (int64, error) {
 	}
 	// The remaining bytes if one were to truncate (0, 0] gives us the total
 	// number of bytes in sideloaded files.
-	_, totalSideloaded, err := s.Sideload.BytesIfTruncatedFromTo(ctx, 0, 0)
+	_, totalSideloaded, err := s.Sideload.BytesIfTruncatedFromTo(ctx, kvpb.RaftSpan{})
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/kv/kvserver/logstore/sideload.go
+++ b/pkg/kv/kvserver/logstore/sideload.go
@@ -44,16 +44,16 @@ type SideloadStorage interface {
 	Purge(_ context.Context, index kvpb.RaftIndex, term kvpb.RaftTerm) (int64, error)
 	// Clear files that may have been written by this SideloadStorage.
 	Clear(context.Context) error
-	// HasAnyEntry returns whether there is any entry in (from, to].
-	HasAnyEntry(_ context.Context, from, to kvpb.RaftIndex) (bool, error)
+	// HasAnyEntry returns whether there is any entry in the given log span.
+	HasAnyEntry(_ context.Context, _ kvpb.RaftSpan) (bool, error)
 	// TruncateTo removes all files belonging to an index <= the given index.
 	// Returns the number of bytes freed, the number of bytes in files that
 	// remain, or an error.
 	TruncateTo(_ context.Context, index kvpb.RaftIndex) (freed, retained int64, _ error)
-	// BytesIfTruncatedFromTo returns the number of bytes that would be freed,
-	// if one were to truncate (from, to]. Additionally, it returns the number
-	// of bytes that would be retained > to.
-	BytesIfTruncatedFromTo(_ context.Context, from kvpb.RaftIndex, to kvpb.RaftIndex) (freed, retained int64, _ error)
+	// BytesIfTruncatedFromTo returns the number of bytes that would be freed, if
+	// one were to truncate the given (from, to] log span. Additionally, it
+	// returns the number of bytes that would be retained > to.
+	BytesIfTruncatedFromTo(_ context.Context, _ kvpb.RaftSpan) (freed, retained int64, _ error)
 	// Returns an absolute path to the file that Get() would return the contents
 	// of. Does not check whether the file actually exists.
 	Filename(_ context.Context, index kvpb.RaftIndex, term kvpb.RaftTerm) (string, error)

--- a/pkg/kv/kvserver/logstore/sideload.go
+++ b/pkg/kv/kvserver/logstore/sideload.go
@@ -44,15 +44,15 @@ type SideloadStorage interface {
 	Purge(_ context.Context, index kvpb.RaftIndex, term kvpb.RaftTerm) (int64, error)
 	// Clear files that may have been written by this SideloadStorage.
 	Clear(context.Context) error
-	// HasAnyEntry returns whether there is any entry in [from, to).
+	// HasAnyEntry returns whether there is any entry in (from, to].
 	HasAnyEntry(_ context.Context, from, to kvpb.RaftIndex) (bool, error)
-	// TruncateTo removes all files belonging to an index strictly smaller than
-	// the given one. Returns the number of bytes freed, the number of bytes in
-	// files that remain, or an error.
+	// TruncateTo removes all files belonging to an index <= the given index.
+	// Returns the number of bytes freed, the number of bytes in files that
+	// remain, or an error.
 	TruncateTo(_ context.Context, index kvpb.RaftIndex) (freed, retained int64, _ error)
 	// BytesIfTruncatedFromTo returns the number of bytes that would be freed,
-	// if one were to truncate [from, to). Additionally, it returns the number
-	// of bytes that would be retained >= to.
+	// if one were to truncate (from, to]. Additionally, it returns the number
+	// of bytes that would be retained > to.
 	BytesIfTruncatedFromTo(_ context.Context, from kvpb.RaftIndex, to kvpb.RaftIndex) (freed, retained int64, _ error)
 	// Returns an absolute path to the file that Get() would return the contents
 	// of. Does not check whether the file actually exists.

--- a/pkg/kv/kvserver/logstore/sideload_disk.go
+++ b/pkg/kv/kvserver/logstore/sideload_disk.go
@@ -188,16 +188,18 @@ func (ss *DiskSideloadStorage) Clear(_ context.Context) error {
 func (ss *DiskSideloadStorage) TruncateTo(
 	ctx context.Context, lastIndex kvpb.RaftIndex,
 ) (bytesFreed, bytesRetained int64, _ error) {
-	return ss.possiblyTruncateTo(ctx, 0, lastIndex, true /* doTruncate */)
+	return ss.possiblyTruncateTo(ctx, kvpb.RaftSpan{
+		After: 0, Last: lastIndex,
+	}, true /* doTruncate */)
 }
 
 // Helper for truncation or byte calculation for (from, to].
 func (ss *DiskSideloadStorage) possiblyTruncateTo(
-	ctx context.Context, from kvpb.RaftIndex, to kvpb.RaftIndex, doTruncate bool,
+	ctx context.Context, span kvpb.RaftSpan, doTruncate bool,
 ) (bytesFreed, bytesRetained int64, _ error) {
 	deletedAll := true
 	if err := ss.forEach(ctx, func(index kvpb.RaftIndex, filename string) (bool, error) {
-		if index > to {
+		if index > span.Last {
 			size, err := ss.fileSize(filename)
 			if err != nil {
 				return false, err
@@ -206,11 +208,11 @@ func (ss *DiskSideloadStorage) possiblyTruncateTo(
 			deletedAll = false
 			return true, nil
 		}
-		if index <= from {
+		if index <= span.After {
 			// TODO(pav-kv): these files may never be removed. Clean them up.
 			return true, nil
 		}
-		// index is in (from, to]
+		// index is in (span.After, span.Last].
 		var fileSize int64
 		var err error
 		if doTruncate {
@@ -242,13 +244,11 @@ func (ss *DiskSideloadStorage) possiblyTruncateTo(
 }
 
 // HasAnyEntry implements SideloadStorage.
-func (ss *DiskSideloadStorage) HasAnyEntry(
-	ctx context.Context, from, to kvpb.RaftIndex,
-) (bool, error) {
+func (ss *DiskSideloadStorage) HasAnyEntry(ctx context.Context, span kvpb.RaftSpan) (bool, error) {
 	// Find any file at index in (from, to].
 	found := false
 	if err := ss.forEach(ctx, func(index kvpb.RaftIndex, _ string) (bool, error) {
-		if index > from && index <= to {
+		if span.Contains(index) {
 			found = true
 			return false, nil // stop the iteration
 		}
@@ -261,9 +261,9 @@ func (ss *DiskSideloadStorage) HasAnyEntry(
 
 // BytesIfTruncatedFromTo implements SideloadStorage.
 func (ss *DiskSideloadStorage) BytesIfTruncatedFromTo(
-	ctx context.Context, from kvpb.RaftIndex, to kvpb.RaftIndex,
+	ctx context.Context, span kvpb.RaftSpan,
 ) (freed, retained int64, _ error) {
-	return ss.possiblyTruncateTo(ctx, from, to, false /* doTruncate */)
+	return ss.possiblyTruncateTo(ctx, span, false /* doTruncate */)
 }
 
 // forEach runs the given visit function for each file in the sideloaded storage

--- a/pkg/kv/kvserver/logstore/sideload_test.go
+++ b/pkg/kv/kvserver/logstore/sideload_test.go
@@ -167,7 +167,7 @@ func testSideloadingSideloadedStorage(t *testing.T, eng storage.Engine) {
 		{
 			err: nil,
 			fun: func() error {
-				_, _, err := ss.TruncateTo(ctx, 123)
+				_, _, err := ss.TruncateTo(ctx, 122)
 				return err
 			},
 		},
@@ -220,30 +220,30 @@ func testSideloadingSideloadedStorage(t *testing.T, eng storage.Engine) {
 	assertExists(true)
 
 	for n := range payloads {
-		freed, retained, err := ss.BytesIfTruncatedFromTo(ctx, 0, payloads[n])
+		index := payloads[n] // (0, index] + (index, ...]
+		freed, retained, err := ss.BytesIfTruncatedFromTo(ctx, 0, index)
 		require.NoError(t, err)
 		freedWhatWasRetained, retainedNothing, err :=
-			ss.BytesIfTruncatedFromTo(ctx, payloads[n], math.MaxUint64)
+			ss.BytesIfTruncatedFromTo(ctx, index, math.MaxUint64)
 		require.NoError(t, err)
 		require.Zero(t, retainedNothing)
 		require.Equal(t, freedWhatWasRetained, retained)
-		// Truncate indexes < payloads[n] (payloads is sorted in increasing order).
-		freedByTruncateTo, retainedByTruncateTo, err := ss.TruncateTo(ctx, payloads[n])
+		// Truncate indexes <= payloads[n] (payloads is sorted in increasing order).
+		freedByTruncateTo, retainedByTruncateTo, err := ss.TruncateTo(ctx, index)
 		if err != nil {
 			t.Fatalf("%d: %+v", n, err)
 		}
 		require.Equal(t, freedByTruncateTo, freed)
 		require.Equal(t, retainedByTruncateTo, retained)
-		// Index payloads[n] and above are still there (truncation is exclusive)
-		// at both terms.
+		// Indexes > payloads[n] are still there at both terms.
 		for _, term := range []kvpb.RaftTerm{lowTerm, highTerm} {
-			for _, i := range payloads[n:] {
+			for _, i := range payloads[n+1:] {
 				if _, err := ss.Get(ctx, i, term); err != nil {
 					t.Fatalf("%d.%d: %+v", n, i, err)
 				}
 			}
-			// Indexes below are gone.
-			for _, i := range payloads[:n] {
+			// Indexes <= payloads[n] are gone.
+			for _, i := range payloads[:n+1] {
 				if _, err := ss.Get(ctx, i, term); !errors.Is(err, errSideloadedFileNotFound) {
 					t.Fatalf("%d.%d: %+v", n, i, err)
 				}
@@ -299,12 +299,12 @@ func testSideloadingSideloadedStorage(t *testing.T, eng storage.Engine) {
 			from, to kvpb.RaftIndex
 			want     bool
 		}{
-			{from: 0, to: 3, want: false}, // 3 is excluded
-			{from: 0, to: 4, want: true},  // but included if to == 4
-			{from: 3, to: 5, want: true},  // 3 is included
-			{from: 4, to: 5, want: false},
-			{from: 50, to: 60, want: false},
-			{from: 1, to: 10, want: true},
+			{from: 0, to: 2, want: false}, // 2 is included
+			{from: 0, to: 3, want: true},  // but included if to == 3
+			{from: 2, to: 4, want: true},  // 2 is excluded
+			{from: 3, to: 4, want: false},
+			{from: 49, to: 59, want: false},
+			{from: 0, to: 9, want: true},
 		} {
 			found, err := ss.HasAnyEntry(ctx, check.from, check.to)
 			require.NoError(t, err)
@@ -328,11 +328,11 @@ func testSideloadingSideloadedStorage(t *testing.T, eng storage.Engine) {
 
 	// Sanity check that we can call BytesIfTruncatedFromTo and TruncateTo
 	// without the directory existing.
-	freed, retained, err := ss.BytesIfTruncatedFromTo(ctx, 0, 1)
+	freed, retained, err := ss.BytesIfTruncatedFromTo(ctx, 0, 0)
 	require.NoError(t, err)
 	require.Zero(t, freed)
 	require.Zero(t, retained)
-	freed, retained, err = ss.TruncateTo(ctx, 1)
+	freed, retained, err = ss.TruncateTo(ctx, 0)
 	require.NoError(t, err)
 	require.Zero(t, freed)
 	require.Zero(t, retained)

--- a/pkg/kv/kvserver/raft_log_queue.go
+++ b/pkg/kv/kvserver/raft_log_queue.go
@@ -274,9 +274,9 @@ func newTruncateDecision(ctx context.Context, r *Replica) (truncateDecision, err
 	// will become false and we will recompute the size -- so this cannot cause
 	// an indefinite delay in recomputation.
 	logSizeTrusted := r.shMu.raftLogSizeTrusted
-	firstIndex := r.raftCompactedIndexRLocked() + 1 // TODO(pav-kv): use "compacted" indexing
+	compIndex := r.raftCompactedIndexRLocked()
 	r.mu.RUnlock()
-	firstIndex = r.pendingLogTruncations.computePostTruncFirstIndex(firstIndex)
+	compIndex = r.pendingLogTruncations.nextCompactedIndex(compIndex)
 
 	if raftStatus == nil {
 		if log.V(6) {
@@ -310,7 +310,7 @@ func newTruncateDecision(ctx context.Context, r *Replica) (truncateDecision, err
 		LogSize:              raftLogSize,
 		MaxLogSize:           targetSize,
 		LogSizeTrusted:       logSizeTrusted,
-		FirstIndex:           firstIndex,
+		FirstIndex:           compIndex + 1, // TODO(pav-kv): use "compacted" directly
 		LastIndex:            lastIndex,
 		PendingSnapshotIndex: pendingSnapshotIndex,
 	}

--- a/pkg/kv/kvserver/raft_log_queue_test.go
+++ b/pkg/kv/kvserver/raft_log_queue_test.go
@@ -84,91 +84,91 @@ func TestComputeTruncateDecision(t *testing.T) {
 		{
 			// Nothing to truncate.
 			1, []uint64{1, 1}, 100, 2, 1, 0,
-			"should truncate: false [truncate 0 entries to first index 2 (chosen via: last index)]",
+			"should truncate: false [truncate 0 entries to compacted index 1 (chosen via: last index)]",
 		},
 		{
 			// Truncate the latest entry.
 			1, []uint64{1, 2}, 100, 1, 1, 0,
-			"should truncate: false [truncate 1 entries to first index 2 (chosen via: last index)]",
+			"should truncate: false [truncate 1 entries to compacted index 1 (chosen via: last index)]",
 		},
 		{
 			// Nothing to truncate on this replica, though a quorum elsewhere has more progress.
 			// NB this couldn't happen if we're truly the Raft leader, unless we appended to our
 			// own log asynchronously.
 			1, []uint64{1, 5, 5}, 100, 2, 1, 0,
-			"should truncate: false [truncate 0 entries to first index 2 (chosen via: last index)]",
+			"should truncate: false [truncate 0 entries to compacted index 1 (chosen via: last index)]",
 		},
 		{
 			// We're not truncating anything, but one follower is already cut off. There's no pending
 			// snapshot so we shouldn't be causing any additional snapshots.
 			2, []uint64{1, 5, 5}, 100, 2, 2, 0,
-			"should truncate: false [truncate 0 entries to first index 2 (chosen via: followers)]",
+			"should truncate: false [truncate 0 entries to compacted index 1 (chosen via: followers)]",
 		},
 		{
 			// The happy case.
 			5, []uint64{5, 5, 5}, 100, 2, 5, 0,
-			"should truncate: false [truncate 4 entries to first index 6 (chosen via: last index)]",
+			"should truncate: false [truncate 4 entries to compacted index 5 (chosen via: last index)]",
 		},
 		{
 			// No truncation, but the outstanding snapshot is made obsolete by the truncation. However
 			// it was already obsolete before. (This example is also not one you could manufacture in
 			// a real system).
 			3, []uint64{5, 5, 5}, 100, 3, 3, 1,
-			"should truncate: false [truncate 0 entries to first index 3 (chosen via: first index)]",
+			"should truncate: false [truncate 0 entries to compacted index 2 (chosen via: first index)]",
 		},
 		{
 			// Respecting the pending snapshot.
 			5, []uint64{5, 5, 5}, 100, 2, 5, 3,
-			"should truncate: false [truncate 2 entries to first index 4 (chosen via: pending snapshot)]",
+			"should truncate: false [truncate 2 entries to compacted index 3 (chosen via: pending snapshot)]",
 		},
 		{
 			// Log is below target size, so respecting the slowest follower.
 			3, []uint64{1, 2, 3, 4}, 100, 1, 5, 0,
-			"should truncate: false [truncate 1 entries to first index 2 (chosen via: followers)]",
+			"should truncate: false [truncate 1 entries to compacted index 1 (chosen via: followers)]",
 		},
 		{
 			// Truncating since local log starts at 3. One follower is already cut off
 			// without a pending snapshot.
 			3, []uint64{1, 3, 3, 4}, 100, 3, 3, 0,
-			"should truncate: false [truncate 0 entries to first index 3 (chosen via: first index)]",
+			"should truncate: false [truncate 0 entries to compacted index 2 (chosen via: first index)]",
 		},
 		// Don't truncate off active followers, even if over targetSize.
 		{
 			3, []uint64{1, 3, 3, 4}, 2000, 2, 3, 0,
-			"should truncate: false [truncate 0 entries to first index 2 (chosen via: followers); log too large (2.0 KiB > 1000 B)]",
+			"should truncate: false [truncate 0 entries to compacted index 1 (chosen via: followers); log too large (2.0 KiB > 1000 B)]",
 		},
 		// Don't truncate away pending snapshot, even when log too large.
 		{
 			100, []uint64{100, 100}, 2000, 1, 100, 50,
-			"should truncate: false [truncate 50 entries to first index 51 (chosen via: pending snapshot); log too large (2.0 KiB > 1000 B)]",
+			"should truncate: false [truncate 50 entries to compacted index 50 (chosen via: pending snapshot); log too large (2.0 KiB > 1000 B)]",
 		},
 		{
 			3, []uint64{1, 3, 3, 4}, 2000, 2, 3, 0,
-			"should truncate: false [truncate 0 entries to first index 2 (chosen via: followers); log too large (2.0 KiB > 1000 B)]",
+			"should truncate: false [truncate 0 entries to compacted index 1 (chosen via: followers); log too large (2.0 KiB > 1000 B)]",
 		},
 		{
 			3, []uint64{1, 3, 3, 4}, 2000, 3, 3, 0,
-			"should truncate: false [truncate 0 entries to first index 3 (chosen via: first index); log too large (2.0 KiB > 1000 B)]",
+			"should truncate: false [truncate 0 entries to compacted index 2 (chosen via: first index); log too large (2.0 KiB > 1000 B)]",
 		},
 		// Respecting the pending snapshot.
 		{
 			7, []uint64{4}, 2000, 1, 7, 1,
-			"should truncate: false [truncate 1 entries to first index 2 (chosen via: pending snapshot); log too large (2.0 KiB > 1000 B)]",
+			"should truncate: false [truncate 1 entries to compacted index 1 (chosen via: pending snapshot); log too large (2.0 KiB > 1000 B)]",
 		},
 		// Never truncate past the commit index.
 		{
 			3, []uint64{4, 4, 6}, 100, 2, 7, 0,
-			"should truncate: false [truncate 2 entries to first index 4 (chosen via: commit)]",
+			"should truncate: false [truncate 2 entries to compacted index 3 (chosen via: commit)]",
 		},
 		// Never truncate past the last index.
 		{
 			3, []uint64{5}, 100, 1, 3, 0,
-			"should truncate: false [truncate 3 entries to first index 4 (chosen via: last index)]",
+			"should truncate: false [truncate 3 entries to compacted index 3 (chosen via: last index)]",
 		},
 		// Never truncate "before the first index".
 		{
 			4, []uint64{5}, 100, 3, 4, 1,
-			"should truncate: false [truncate 0 entries to first index 3 (chosen via: first index)]",
+			"should truncate: false [truncate 0 entries to compacted index 2 (chosen via: first index)]",
 		},
 	}
 	for i, c := range testCases {
@@ -211,8 +211,9 @@ func TestComputeTruncateDecision(t *testing.T) {
 			assert.Equal(t, decision.ShouldTruncate(), prio != 0)
 			input.LogSizeTrusted = false
 			input.RaftStatus.RaftState = raftpb.StateLeader
-			if input.LastIndex <= input.FirstIndex() {
-				input.LastIndex = input.FirstIndex() + 1
+			if input.LastIndex <= input.CompIndex+1 {
+				// TODO(pav-kv): what does this clause mean?
+				input.LastIndex = input.CompIndex + 2
 			}
 			decision = computeTruncateDecision(input)
 			should, recompute, prio = (*raftLogQueue)(nil).shouldQueueImpl(ctx, decision)
@@ -235,12 +236,12 @@ func TestComputeTruncateDecisionProgressStatusProbe(t *testing.T) {
 	// the truncation threshold.
 	exp := map[bool]map[bool]string{ // (tooLarge, active)
 		false: {
-			true:  "should truncate: false [truncate 0 entries to first index 10 (chosen via: probing follower)]",
-			false: "should truncate: false [truncate 0 entries to first index 10 (chosen via: first index)]",
+			true:  "should truncate: false [truncate 0 entries to compacted index 9 (chosen via: probing follower)]",
+			false: "should truncate: false [truncate 0 entries to compacted index 9 (chosen via: first index)]",
 		},
 		true: {
-			true:  "should truncate: false [truncate 0 entries to first index 10 (chosen via: probing follower); log too large (2.0 KiB > 1.0 KiB)]",
-			false: "should truncate: true [truncate 191 entries to first index 201 (chosen via: followers); log too large (2.0 KiB > 1.0 KiB)]",
+			true:  "should truncate: false [truncate 0 entries to compacted index 9 (chosen via: probing follower); log too large (2.0 KiB > 1.0 KiB)]",
+			false: "should truncate: true [truncate 191 entries to compacted index 200 (chosen via: followers); log too large (2.0 KiB > 1.0 KiB)]",
 		},
 	}
 
@@ -303,7 +304,7 @@ func TestTruncateDecisionZeroValue(t *testing.T) {
 	assert.False(t, decision.ShouldTruncate())
 	assert.Zero(t, decision.NumNewRaftSnapshots())
 	assert.Zero(t, decision.NumTruncatableIndexes())
-	assert.Equal(t, "should truncate: false [truncate 0 entries to first index 1 (chosen via: ); log size untrusted]", decision.String())
+	assert.Equal(t, "should truncate: false [truncate 0 entries to compacted index 0 (chosen via: ); log size untrusted]", decision.String())
 }
 
 func TestTruncateDecisionNumSnapshots(t *testing.T) {
@@ -468,7 +469,8 @@ func TestNewTruncateDecision(t *testing.T) {
 		if err != nil {
 			return 0, 0, 0, err
 		}
-		return d.Input.FirstIndex(), d.NumTruncatableIndexes(), d.NewFirstIndex(), nil
+		// TODO(pav-kv): clean up the caller to use compacted indices.
+		return d.Input.CompIndex + 1, d.NumTruncatableIndexes(), d.NewCompIndex + 1, nil
 	}
 
 	aFirst, aTruncatable, aOldest, err := getIndexes()
@@ -833,7 +835,7 @@ func TestRaftLogQueueShouldQueueRecompute(t *testing.T) {
 
 	// Check all boxes except that log is empty.
 	decision = golden
-	decision.Input.LastIndex = decision.Input.FirstIndex() - 1
+	decision.Input.LastIndex = decision.Input.CompIndex
 	verify(false, false, 0)
 }
 

--- a/pkg/kv/kvserver/raft_log_queue_test.go
+++ b/pkg/kv/kvserver/raft_log_queue_test.go
@@ -53,7 +53,7 @@ func TestShouldTruncate(t *testing.T) {
 			var d truncateDecision
 			d.Input.LogSize = c.raftLogSize
 			d.Input.CompIndex = 122
-			d.NewFirstIndex = d.Input.FirstIndex() + c.truncatableIndexes
+			d.NewCompIndex = d.Input.CompIndex + c.truncatableIndexes
 			v := d.ShouldTruncate()
 			if c.expected != v {
 				t.Fatalf("expected %v, but found %v", c.expected, v)
@@ -303,7 +303,7 @@ func TestTruncateDecisionZeroValue(t *testing.T) {
 	assert.False(t, decision.ShouldTruncate())
 	assert.Zero(t, decision.NumNewRaftSnapshots())
 	assert.Zero(t, decision.NumTruncatableIndexes())
-	assert.Equal(t, "should truncate: false [truncate 0 entries to first index 0 (chosen via: ); log size untrusted]", decision.String())
+	assert.Equal(t, "should truncate: false [truncate 0 entries to first index 1 (chosen via: ); log size untrusted]", decision.String())
 }
 
 func TestTruncateDecisionNumSnapshots(t *testing.T) {
@@ -468,7 +468,7 @@ func TestNewTruncateDecision(t *testing.T) {
 		if err != nil {
 			return 0, 0, 0, err
 		}
-		return d.Input.FirstIndex(), d.NumTruncatableIndexes(), d.NewFirstIndex, nil
+		return d.Input.FirstIndex(), d.NumTruncatableIndexes(), d.NewFirstIndex(), nil
 	}
 
 	aFirst, aTruncatable, aOldest, err := getIndexes()

--- a/pkg/kv/kvserver/raft_log_queue_test.go
+++ b/pkg/kv/kvserver/raft_log_queue_test.go
@@ -324,10 +324,10 @@ func TestTruncateDecisionNumSnapshots(t *testing.T) {
 	}
 
 	decision := truncateDecision{Input: truncateDecisionInput{RaftStatus: status}}
+	assert.Equal(t, 0, decision.raftSnapshotsForIndex(9))
 	assert.Equal(t, 0, decision.raftSnapshotsForIndex(10))
-	assert.Equal(t, 0, decision.raftSnapshotsForIndex(11))
-	assert.Equal(t, 1, decision.raftSnapshotsForIndex(12))
-	assert.Equal(t, 3, decision.raftSnapshotsForIndex(13))
+	assert.Equal(t, 1, decision.raftSnapshotsForIndex(11))
+	assert.Equal(t, 3, decision.raftSnapshotsForIndex(12))
 }
 
 func verifyLogSizeInSync(t *testing.T, r *Replica) {

--- a/pkg/kv/kvserver/raft_log_truncator.go
+++ b/pkg/kv/kvserver/raft_log_truncator.go
@@ -86,18 +86,15 @@ func (p *pendingLogTruncations) computePostTruncLogSize(raftLogSize int64) int64
 	return raftLogSize
 }
 
-// computePostTruncFirstIndex computes the first log index that is not
-// truncated, under the pretense that the pending truncations have been
-// enacted.
-func (p *pendingLogTruncations) computePostTruncFirstIndex(
-	firstIndex kvpb.RaftIndex,
-) kvpb.RaftIndex {
+// nextCompactedIndex computes the new compacted index, under the pretense
+// that all pending truncations have been enacted.
+func (p *pendingLogTruncations) nextCompactedIndex(compIndex kvpb.RaftIndex) kvpb.RaftIndex {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	p.iterateLocked(func(_ int, trunc pendingTruncation) {
-		firstIndex = max(firstIndex, trunc.compactedIndex()+1)
+		compIndex = max(compIndex, trunc.compactedIndex())
 	})
-	return firstIndex
+	return compIndex
 }
 
 func (p *pendingLogTruncations) isEmptyLocked() bool {

--- a/pkg/kv/kvserver/raft_log_truncator.go
+++ b/pkg/kv/kvserver/raft_log_truncator.go
@@ -256,7 +256,7 @@ type replicaForTruncator interface {
 	// Returns the sideloaded bytes that would be freed if we were to truncate
 	// (from, to].
 	sideloadedBytesIfTruncatedFromTo(
-		_ context.Context, from, to kvpb.RaftIndex) (freed int64, _ error)
+		_ context.Context, _ kvpb.RaftSpan) (freed int64, _ error)
 	getStateLoader() stateloader.StateLoader
 	// NB: Setting the persistent raft state is via the Engine exposed by
 	// storeForTruncator.
@@ -318,8 +318,9 @@ func (t *raftLogTruncator) addPendingTruncation(
 	// In the common case of alreadyTruncIndex+1 == raftExpectedFirstIndex, the
 	// computation returns the same result regardless of which is plugged in as
 	// the lower bound.
-	sideloadedFreed, err := r.sideloadedBytesIfTruncatedFromTo(
-		ctx, alreadyTruncIndex, pendingTrunc.compactedIndex())
+	sideloadedFreed, err := r.sideloadedBytesIfTruncatedFromTo(ctx, kvpb.RaftSpan{
+		After: alreadyTruncIndex, Last: pendingTrunc.compactedIndex(),
+	})
 	if err != nil {
 		// Log a loud error since we need to continue enqueuing the truncation.
 		log.Errorf(ctx, "while computing size of sideloaded files to truncate: %+v", err)

--- a/pkg/kv/kvserver/raft_log_truncator.go
+++ b/pkg/kv/kvserver/raft_log_truncator.go
@@ -254,7 +254,7 @@ type replicaForTruncator interface {
 	// the return value by additionally acquiring pendingLogTruncations.mu.
 	getPendingTruncs() *pendingLogTruncations
 	// Returns the sideloaded bytes that would be freed if we were to truncate
-	// [from, to).
+	// (from, to].
 	sideloadedBytesIfTruncatedFromTo(
 		_ context.Context, from, to kvpb.RaftIndex) (freed int64, _ error)
 	getStateLoader() stateloader.StateLoader
@@ -319,7 +319,7 @@ func (t *raftLogTruncator) addPendingTruncation(
 	// computation returns the same result regardless of which is plugged in as
 	// the lower bound.
 	sideloadedFreed, err := r.sideloadedBytesIfTruncatedFromTo(
-		ctx, alreadyTruncIndex+1, pendingTrunc.compactedIndex()+1)
+		ctx, alreadyTruncIndex, pendingTrunc.compactedIndex())
 	if err != nil {
 		// Log a loud error since we need to continue enqueuing the truncation.
 		log.Errorf(ctx, "while computing size of sideloaded files to truncate: %+v", err)

--- a/pkg/kv/kvserver/raft_log_truncator_test.go
+++ b/pkg/kv/kvserver/raft_log_truncator_test.go
@@ -44,7 +44,7 @@ func TestPendingLogTruncations(t *testing.T) {
 	require.Equal(t, 2, truncs.capacity())
 	require.True(t, truncs.isEmptyLocked())
 	require.EqualValues(t, 55, truncs.computePostTruncLogSize(55))
-	require.EqualValues(t, 5, truncs.computePostTruncFirstIndex(5))
+	require.EqualValues(t, 4, truncs.nextCompactedIndex(4))
 
 	// One pending truncation.
 	truncs.mu.truncs[0].logDeltaBytes = -50
@@ -60,11 +60,11 @@ func TestPendingLogTruncations(t *testing.T) {
 	// Added -50 and bumped up to 0.
 	require.EqualValues(t, 0, truncs.computePostTruncLogSize(45))
 	// Advances to Index+1.
-	require.EqualValues(t, 21, truncs.computePostTruncFirstIndex(5))
-	require.EqualValues(t, 21, truncs.computePostTruncFirstIndex(20))
+	require.EqualValues(t, 20, truncs.nextCompactedIndex(4))
+	require.EqualValues(t, 20, truncs.nextCompactedIndex(19))
 	// Does not advance.
-	require.EqualValues(t, 21, truncs.computePostTruncFirstIndex(21))
-	require.EqualValues(t, 30, truncs.computePostTruncFirstIndex(30))
+	require.EqualValues(t, 20, truncs.nextCompactedIndex(20))
+	require.EqualValues(t, 29, truncs.nextCompactedIndex(29))
 
 	// Two pending truncations.
 	truncs.mu.truncs[1].logDeltaBytes = -70
@@ -83,11 +83,11 @@ func TestPendingLogTruncations(t *testing.T) {
 	// Added -120 and bumped up to 0.
 	require.EqualValues(t, 0, truncs.computePostTruncLogSize(115))
 	// Advances to Index+1 of second entry.
-	require.EqualValues(t, 31, truncs.computePostTruncFirstIndex(5))
-	require.EqualValues(t, 31, truncs.computePostTruncFirstIndex(30))
+	require.EqualValues(t, 30, truncs.nextCompactedIndex(4))
+	require.EqualValues(t, 30, truncs.nextCompactedIndex(29))
 	// Does not advance.
-	require.EqualValues(t, 31, truncs.computePostTruncFirstIndex(31))
-	require.EqualValues(t, 40, truncs.computePostTruncFirstIndex(40))
+	require.EqualValues(t, 30, truncs.nextCompactedIndex(30))
+	require.EqualValues(t, 39, truncs.nextCompactedIndex(39))
 
 	// Pop first.
 	last := truncs.mu.truncs[1]

--- a/pkg/kv/kvserver/raft_log_truncator_test.go
+++ b/pkg/kv/kvserver/raft_log_truncator_test.go
@@ -146,9 +146,10 @@ func (r *replicaTruncatorTest) setTruncationDeltaAndTrusted(deltaBytes int64, is
 }
 
 func (r *replicaTruncatorTest) sideloadedBytesIfTruncatedFromTo(
-	_ context.Context, from, to kvpb.RaftIndex,
+	_ context.Context, span kvpb.RaftSpan,
 ) (freed int64, _ error) {
-	fmt.Fprintf(r.buf, "r%d.sideloadedBytesIfTruncatedFromTo(%d, %d)\n", r.rangeID, from, to)
+	fmt.Fprintf(r.buf, "r%d.sideloadedBytesIfTruncatedFromTo(%d, %d)\n",
+		r.rangeID, span.After, span.Last)
 	return r.sideloadedFreed, r.sideloadedErr
 }
 

--- a/pkg/kv/kvserver/raft_truncator_replica.go
+++ b/pkg/kv/kvserver/raft_truncator_replica.go
@@ -63,9 +63,9 @@ func (r *raftTruncatorReplica) getPendingTruncs() *pendingLogTruncations {
 }
 
 func (r *raftTruncatorReplica) sideloadedBytesIfTruncatedFromTo(
-	ctx context.Context, from, to kvpb.RaftIndex,
+	ctx context.Context, span kvpb.RaftSpan,
 ) (freed int64, err error) {
-	freed, _, err = r.raftMu.sideloaded.BytesIfTruncatedFromTo(ctx, from, to)
+	freed, _, err = r.raftMu.sideloaded.BytesIfTruncatedFromTo(ctx, span)
 	return freed, err
 }
 

--- a/pkg/kv/kvserver/raftutil/util.go
+++ b/pkg/kv/kvserver/raftutil/util.go
@@ -125,7 +125,7 @@ func (s ReplicaNeedsSnapshotStatus) String() string {
 // indicates that our local replica is not the raft leader, we pessimistically
 // assume that replicaID may need a snapshot.
 func ReplicaMayNeedSnapshot(
-	st *raft.Status, firstIndex kvpb.RaftIndex, replicaID roachpb.ReplicaID,
+	st *raft.Status, compacted kvpb.RaftIndex, replicaID roachpb.ReplicaID,
 ) ReplicaNeedsSnapshotStatus {
 	if st == nil {
 		// Testing only.
@@ -155,7 +155,7 @@ func ReplicaMayNeedSnapshot(
 	default:
 		panic("unknown tracker.StateType")
 	}
-	if kvpb.RaftIndex(progress.Match+1) < firstIndex {
+	if kvpb.RaftIndex(progress.Match) < compacted {
 		// Even if the follower is in StateReplicate, it could have been cut off
 		// from the log by a recent log truncation that hasn't been recognized yet
 		// by raft. Confirm that this is not the case.

--- a/pkg/kv/kvserver/raftutil/util_test.go
+++ b/pkg/kv/kvserver/raftutil/util_test.go
@@ -113,7 +113,7 @@ func TestReplicaIsBehind(t *testing.T) {
 }
 
 func TestReplicaMayNeedSnapshot(t *testing.T) {
-	const firstIndex = 10
+	const compactedIndex = 9
 	const replicaID = 3
 	makeStatus := func(f func(*raft.Status)) *raft.Status {
 		st := new(raft.Status)
@@ -197,7 +197,7 @@ func TestReplicaMayNeedSnapshot(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			require.Equal(t, tt.expect, ReplicaMayNeedSnapshot(tt.st, firstIndex, replicaID))
+			require.Equal(t, tt.expect, ReplicaMayNeedSnapshot(tt.st, compactedIndex, replicaID))
 		})
 	}
 }

--- a/pkg/kv/kvserver/replica_app_batch.go
+++ b/pkg/kv/kvserver/replica_app_batch.go
@@ -450,9 +450,9 @@ func (b *replicaAppBatch) runPostAddTriggersReplicaOnly(
 			// We only need to check sideloaded entries in this path. The loosely
 			// coupled truncation mechanism in the other branch already ensures
 			// enacting truncations only after state machine synced.
-			if has, err := b.r.raftMu.sideloaded.HasAnyEntry(
-				ctx, b.truncState.Index, truncatedState.Index, // (begin, end]
-			); err != nil {
+			if has, err := b.r.raftMu.sideloaded.HasAnyEntry(ctx, kvpb.RaftSpan{
+				After: b.truncState.Index, Last: truncatedState.Index,
+			}); err != nil {
 				return errors.Wrap(err, "failed searching for sideloaded entries")
 			} else if has {
 				b.changeTruncatesSideloadedFiles = true

--- a/pkg/kv/kvserver/replica_app_batch.go
+++ b/pkg/kv/kvserver/replica_app_batch.go
@@ -451,7 +451,7 @@ func (b *replicaAppBatch) runPostAddTriggersReplicaOnly(
 			// coupled truncation mechanism in the other branch already ensures
 			// enacting truncations only after state machine synced.
 			if has, err := b.r.raftMu.sideloaded.HasAnyEntry(
-				ctx, b.truncState.Index, truncatedState.Index+1, // include end Index
+				ctx, b.truncState.Index, truncatedState.Index, // (begin, end]
 			); err != nil {
 				return errors.Wrap(err, "failed searching for sideloaded entries")
 			} else if has {

--- a/pkg/kv/kvserver/replica_application_result.go
+++ b/pkg/kv/kvserver/replica_application_result.go
@@ -521,7 +521,7 @@ func (r *Replica) handleTruncatedStateResult(
 	// handleTruncatedStateResult, stop calculating the size of the removed
 	// files and the remaining files.
 	log.Eventf(ctx, "truncating sideloaded storage up to (and including) index %d", t.Index)
-	size, _, err := r.raftMu.sideloaded.TruncateTo(ctx, t.Index+1)
+	size, _, err := r.raftMu.sideloaded.TruncateTo(ctx, t.Index)
 	if err != nil {
 		// We don't *have* to remove these entries for correctness. Log a
 		// loud error, but keep humming along.

--- a/pkg/kv/kvserver/replica_eval_context_span.go
+++ b/pkg/kv/kvserver/replica_eval_context_span.go
@@ -80,9 +80,9 @@ func (rec *SpanSetReplicaEvalContext) GetNodeLocality() roachpb.Locality {
 	return rec.i.GetNodeLocality()
 }
 
-// GetFirstIndex returns the first index.
-func (rec *SpanSetReplicaEvalContext) GetFirstIndex() kvpb.RaftIndex {
-	return rec.i.GetFirstIndex()
+// GetCompactedIndex returns the compacted index of the raft log.
+func (rec *SpanSetReplicaEvalContext) GetCompactedIndex() kvpb.RaftIndex {
+	return rec.i.GetCompactedIndex()
 }
 
 // GetTerm returns the term for the given index in the Raft log.

--- a/pkg/kv/kvserver/replica_proposal_buf.go
+++ b/pkg/kv/kvserver/replica_proposal_buf.go
@@ -1273,7 +1273,7 @@ func (rp *replicaProposer) verifyLeaseRequestSafetyRLocked(
 		LocalReplicaID:     r.ReplicaID(),
 		Desc:               r.descRLocked(),
 		RaftStatus:         &raftStatus,
-		RaftFirstIndex:     r.raftCompactedIndexRLocked() + 1, // TODO(pav-kv): use "compacted" indexing
+		RaftCompacted:      r.raftCompactedIndexRLocked(),
 		PrevLease:          prevLease,
 		PrevLeaseExpired:   !r.ownsValidLeaseRLocked(ctx, r.Clock().NowAsClockTimestamp()),
 		NextLeaseHolder:    nextLease.Replica,

--- a/pkg/kv/kvserver/replica_raftlog.go
+++ b/pkg/kv/kvserver/replica_raftlog.go
@@ -161,14 +161,12 @@ func (r *Replica) raftCompactedIndexRLocked() kvpb.RaftIndex {
 	return r.shMu.raftTruncState.Index
 }
 
-// GetFirstIndex returns the index of the first entry in the raft log.
+// GetCompactedIndex returns the compacted index of the raft log.
 // Requires that r.mu is not held.
-//
-// TODO(pav-kv): use the "compacted" indexing scheme.
-func (r *Replica) GetFirstIndex() kvpb.RaftIndex {
+func (r *Replica) GetCompactedIndex() kvpb.RaftIndex {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	return r.raftCompactedIndexRLocked() + 1
+	return r.raftCompactedIndexRLocked()
 }
 
 // LogSnapshot returns an immutable point-in-time snapshot of the log storage.

--- a/pkg/kv/kvserver/replica_range_lease.go
+++ b/pkg/kv/kvserver/replica_range_lease.go
@@ -377,7 +377,7 @@ func (p *pendingLeaseRequest) InitOrJoinRequest(
 		Now:                   status.Now,
 		MinLeaseProposedTS:    p.repl.mu.minLeaseProposedTS,
 		RaftStatus:            raftStatus,
-		RaftFirstIndex:        p.repl.raftCompactedIndexRLocked() + 1, // TODO(pav-kv): "compacted" indexing
+		RaftCompacted:         p.repl.raftCompactedIndexRLocked(),
 		PrevLease:             status.Lease,
 		PrevLeaseNodeLiveness: status.Liveness,
 		PrevLeaseExpired:      status.IsExpired(),

--- a/pkg/kv/kvserver/replica_rangefeed_test.go
+++ b/pkg/kv/kvserver/replica_rangefeed_test.go
@@ -1054,7 +1054,7 @@ func TestReplicaRangefeedErrors(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			waitForTruncationForTesting(t, repl, index+1)
+			waitForTruncationForTesting(t, repl, index)
 		}
 
 		// Remove the partition. Snapshot should follow.

--- a/pkg/kv/kvserver/replica_rankings.go
+++ b/pkg/kv/kvserver/replica_rankings.go
@@ -38,9 +38,8 @@ type CandidateReplica interface {
 	// RaftStatus returns the current raft status of the replica. It returns
 	// nil if the Raft group has not been initialized yet.
 	RaftStatus() *raft.Status
-	// GetFirstIndex returns the index of the first entry in the replica's Raft
-	// log.
-	GetFirstIndex() kvpb.RaftIndex
+	// GetCompactedIndex returns the compacted index of the raft log.
+	GetCompactedIndex() kvpb.RaftIndex
 	// LoadSpanConfig returns the span config for the replica or an error if it can't
 	// be determined.
 	LoadSpanConfig(context.Context) (*roachpb.SpanConfig, error)

--- a/pkg/kv/kvserver/testdata/raft_log_truncator
+++ b/pkg/kv/kvserver/testdata/raft_log_truncator
@@ -28,7 +28,7 @@ add-pending-truncation id=1 first-index=16 trunc-index=22 delta-bytes=-20 sidelo
 ----
 r1.getPendingTruncs
 r1.getTruncatedState
-r1.sideloadedBytesIfTruncatedFromTo(21, 23)
+r1.sideloadedBytesIfTruncatedFromTo(20, 22)
 truncator ranges: 1
 
 print-replica-state id=1
@@ -69,7 +69,7 @@ add-pending-truncation id=2 first-index=21 trunc-index=22 delta-bytes=-20 sidelo
 ----
 r2.getPendingTruncs
 r2.getTruncatedState
-r2.sideloadedBytesIfTruncatedFromTo(21, 23)
+r2.sideloadedBytesIfTruncatedFromTo(20, 22)
 truncator ranges: 1, 2, 13
 
 print-replica-state id=2
@@ -189,7 +189,7 @@ add-pending-truncation id=2 first-index=21 trunc-index=24 delta-bytes=-20 sidelo
 ----
 r2.getPendingTruncs
 r2.getTruncatedState
-r2.sideloadedBytesIfTruncatedFromTo(23, 25)
+r2.sideloadedBytesIfTruncatedFromTo(22, 24)
 truncator ranges: 2
 
 print-replica-state id=2
@@ -226,14 +226,14 @@ add-pending-truncation id=2 first-index=25 trunc-index=26 delta-bytes=-20 sidelo
 ----
 r2.getPendingTruncs
 r2.getTruncatedState
-r2.sideloadedBytesIfTruncatedFromTo(25, 27)
+r2.sideloadedBytesIfTruncatedFromTo(24, 26)
 truncator ranges: 2
 
 add-pending-truncation id=2 first-index=27 trunc-index=28 delta-bytes=-20 sideloaded-bytes=10
 ----
 r2.getPendingTruncs
 r2.getTruncatedState
-r2.sideloadedBytesIfTruncatedFromTo(27, 29)
+r2.sideloadedBytesIfTruncatedFromTo(26, 28)
 truncator ranges: 2
 
 print-replica-state id=2
@@ -247,7 +247,7 @@ add-pending-truncation id=2 first-index=28 trunc-index=29 delta-bytes=-20 sidelo
 ----
 r2.getPendingTruncs
 r2.getTruncatedState
-r2.sideloadedBytesIfTruncatedFromTo(29, 30)
+r2.sideloadedBytesIfTruncatedFromTo(28, 29)
 truncator ranges: 2
 
 # The last two pending truncations are merged and since they overlap,
@@ -291,7 +291,7 @@ add-pending-truncation id=2 first-index=30 trunc-index=31 delta-bytes=-20 sidelo
 ----
 r2.getPendingTruncs
 r2.getTruncatedState
-r2.sideloadedBytesIfTruncatedFromTo(30, 32)
+r2.sideloadedBytesIfTruncatedFromTo(29, 31)
 truncator ranges: 2
 
 print-replica-state id=2
@@ -340,14 +340,14 @@ add-pending-truncation id=2 first-index=32 trunc-index=32 delta-bytes=-20 sidelo
 ----
 r2.getPendingTruncs
 r2.getTruncatedState
-r2.sideloadedBytesIfTruncatedFromTo(32, 33)
+r2.sideloadedBytesIfTruncatedFromTo(31, 32)
 truncator ranges: 2
 
 add-pending-truncation id=2 first-index=33 trunc-index=33 delta-bytes=-20 sideloaded-bytes=10
 ----
 r2.getPendingTruncs
 r2.getTruncatedState
-r2.sideloadedBytesIfTruncatedFromTo(33, 34)
+r2.sideloadedBytesIfTruncatedFromTo(32, 33)
 truncator ranges: 2
 
 print-replica-state id=2
@@ -361,7 +361,7 @@ add-pending-truncation id=2 first-index=34 trunc-index=34 delta-bytes=-20 sidelo
 ----
 r2.getPendingTruncs
 r2.getTruncatedState
-r2.sideloadedBytesIfTruncatedFromTo(34, 35)
+r2.sideloadedBytesIfTruncatedFromTo(33, 34)
 truncator ranges: 2
 
 # Because of the error, the delta for the merged truncation is not trusted.
@@ -416,14 +416,14 @@ add-pending-truncation id=3 first-index=21 trunc-index=22 delta-bytes=-20 sidelo
 ----
 r3.getPendingTruncs
 r3.getTruncatedState
-r3.sideloadedBytesIfTruncatedFromTo(21, 23)
+r3.sideloadedBytesIfTruncatedFromTo(20, 22)
 truncator ranges: 3
 
 add-pending-truncation id=3 first-index=23 trunc-index=24 delta-bytes=-20 sideloaded-bytes=10
 ----
 r3.getPendingTruncs
 r3.getTruncatedState
-r3.sideloadedBytesIfTruncatedFromTo(23, 25)
+r3.sideloadedBytesIfTruncatedFromTo(22, 24)
 truncator ranges: 3
 
 print-replica-state id=3


### PR DESCRIPTION
Before this PR, `kvserver` extensively used the raft log `FirstIndex` as a first-class citizen. The idea was that `[FirstIndex, LastIndex]` describes a log slice. There were a few problems with it:

- `FirstIndex` is not intuitively defined for empty log slices: `FirstIndex == LastIndex + 1`.
- It was easy to confuse `FirstIndex` with `TruncatedState.Index` which are one index apart.

So, there are 3 key positions in the raft log:

1. `TruncatedState.Index / CompactedIndex`
2. `FirstIndex == CompactedIndex + 1`
3. `LastIndex`

Overall, this led to off-by-one semi-bugs like ones fixed in #142827, and +-1 arithmetics in a bunch of places. It is especially unfortunate to have a `FirstIndex` and needing to do `FirstIndex - 1` because one is never sure whether that underflows. It has to be explicitly noted / checked that `FirstIndex >= 1`.

---

This PR eliminates most uses of `FirstIndex` as a concept (leaving only 2/3 concepts in place), and converts the code to use `Compacted` index. The one remaining place that still uses `FirstIndex` notation is the log truncation evaluation code and protocol - but it's well isolated and can be migrated from at some point as a drive-by.

The `Compacted` index is more intuitive:

- Empty slice is `Compacted == LastIndex`
- Slice length is `LastIndex - Compacted`
- Invariants are like `Committed >= Compacted` rather than `Committed >= FirstIndex-1`
- Etc

---

Epic: none
Release note: none