### PR TITLE
roachprod-microbench: affinity logic

### DIFF
--- a/pkg/cmd/roachprod-microbench/executor.go
+++ b/pkg/cmd/roachprod-microbench/executor.go
@@ -337,26 +337,30 @@ func (e *executor) executeBenchmarks() error {
 		if e.shellCommand != "" {
 			runCommand = fmt.Sprintf("%s && %s", e.shellCommand, runCommand)
 		}
-		commandGroup := make([]cluster.RemoteCommand, 0)
 		// Weave the commands between binaries and iterations.
-		for i := 0; i < e.iterations; i++ {
+		for range e.iterations {
+			iterationGroup := make([]cluster.RemoteCommand, 0)
 			for key, bin := range e.binaries {
 				shellCommand := fmt.Sprintf(`"cd %s/%s/bin && %s"`, bin, bench.pkg, runCommand)
 				command := cluster.RemoteCommand{
 					Args:     []string{"sh", "-c", shellCommand},
 					Metadata: benchmarkKey{bench, key},
 				}
-				commandGroup = append(commandGroup, command)
+				iterationGroup = append(iterationGroup, command)
 			}
-		}
-		if e.affinity {
-			commands = append(commands, commandGroup)
-		} else {
-			// When affinity is disabled, commands & single iterations can run on any
-			// node. This has the benefit of not having stragglers, but the downside
-			// of possibly introducing noise.
-			for _, command := range commandGroup {
-				commands = append(commands, []cluster.RemoteCommand{command})
+
+			if e.affinity {
+				// When affinity is enabled, each iteration runs as a group with binaries interleaved.
+				// This means all binaries for a single iteration will run together on the same node,
+				// but different iterations can run on different nodes.
+				commands = append(commands, iterationGroup)
+			} else {
+				// When affinity is disabled, each command runs individually on any available node.
+				// This has the benefit of not having stragglers, but the downside of possibly
+				// introducing noise due to different node characteristics.
+				for _, command := range iterationGroup {
+					commands = append(commands, []cluster.RemoteCommand{command})
+				}
 			}
 		}
 	}

--- a/pkg/cmd/roachprod-microbench/executor.go
+++ b/pkg/cmd/roachprod-microbench/executor.go
@@ -125,6 +125,7 @@ func defaultExecutorConfig() executorConfig {
 		iterations:   1,
 		lenient:      true,
 		recoverable:  true,
+		affinity:     true,
 	}
 }
 

--- a/pkg/cmd/roachprod-microbench/main.go
+++ b/pkg/cmd/roachprod-microbench/main.go
@@ -113,7 +113,7 @@ func makeRunCommand() *cobra.Command {
 	cmd.Flags().StringSliceVar(&config.ignorePackageList, "ignore-package", []string{}, "packages to completely exclude from listing or execution'")
 	cmd.Flags().IntVar(&config.iterations, "iterations", config.iterations, "number of iterations to run each benchmark")
 	cmd.Flags().BoolVar(&config.lenient, "lenient", config.lenient, "tolerate errors while running benchmarks")
-	cmd.Flags().BoolVar(&config.affinity, "affinity", config.affinity, "run benchmarks with iterations and binaries having affinity to the same node, only applies when more than one archive is specified")
+	cmd.Flags().BoolVar(&config.affinity, "affinity", config.affinity, "run benchmarks with each iteration's binaries having affinity to the same node, while different iterations can run on different nodes")
 	cmd.Flags().BoolVar(&config.quiet, "quiet", config.quiet, "suppress roachprod progress output")
 	cmd.Flags().BoolVar(&config.recoverable, "recoverable", config.recoverable, "VMs are able to recover from transient failures (e.g., running spot instances on a MIG in GCE)")
 	return cmd


### PR DESCRIPTION
Previously, affinity determined whether all binaries for a benchmark were run on the same node. This tended to cause long tails and stragglers, and was disabled by default.

Affinity mode is now more granular, allowing each interleaved iteration to run on any node. This reduces the risk of a node being overloaded with long benchmarks. The distribution of results may vary more due to node-specific performance characteristics, but since at least one interleaved iteration pair is run per node, we should be able to maintain a good distribution.

Affinity is now enabled by default.

Epic: None
Release note: None