### PR TITLE
sql: Add getSchemaForCreate smart dispatcher to fix temporary schema …

### DIFF
--- a/pkg/sql/create_type.go
+++ b/pkg/sql/create_type.go
@@ -140,13 +140,17 @@ func getCreateTypeParams(
 			return nil, sqlerrors.NewTypeAlreadyExistsError(name.String())
 		}
 	}
+
 	// Get the ID of the schema the type is being created in.
 	dbID := db.GetID()
-	schema, err = p.getNonTemporarySchemaForCreate(ctx, db, name.Schema())
+
+	// Use the smart dispatcher to get the appropriate schema
+	schema, err = p.getSchemaForCreate(ctx, db, name.Schema())
 	if err != nil {
 		return nil, err
 	}
 
+	// The rest of the function remains unchanged
 	// Check permissions on the schema.
 	if err := p.canCreateOnSchema(
 		ctx, schema.GetID(), dbID, p.User(), skipCheckPublicSchema); err != nil {


### PR DESCRIPTION
…handling #142780

Fix an issue in getCreateTypeParams where temporary schemas were incorrectly handled by always calling getNonTemporarySchemaForCreate() regardless of schema type. This introduces a new dispatcher function getSchemaForCreate that properly handles all schema kinds, including temporary schemas.

The fix ensures that when creating types in temporary schemas, we use the temporary schema mechanism rather than treating them as regular schemas, which prevents errors during type creation operations.

Jira issue: CRDB-48510