### PR TITLE
kvserver: deflake TestLeaderlessWatcherInit

### DIFF
--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -15423,7 +15423,7 @@ func TestLeaderlessWatcherInit(t *testing.T) {
 	defer repl.LeaderlessWatcher.mu.RUnlock()
 
 	// Initially, the leaderWatcher doesn't consider the replica as unavailable.
-	require.False(t, repl.LeaderlessWatcher.IsUnavailable())
+	require.False(t, repl.LeaderlessWatcher.mu.unavailable)
 
 	// The leaderless timestamp is not set.
 	require.Equal(t, time.Time{}, repl.LeaderlessWatcher.mu.leaderlessTimestamp)


### PR DESCRIPTION
The test used to fail under deadlock build since it used to acquire the read mutex recursively. This commit fixes that.

Fixes: #142888

Release note: None