### PR TITLE
jsonpath: add predicate evaluation (comparison, logical operators)

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/jsonb_path_query
+++ b/pkg/sql/logictest/testdata/logic_test/jsonb_path_query
@@ -578,6 +578,41 @@ SELECT jsonb_path_query('{"a": [1, 3]}', 'strict $.a == 2');
 ----
 null
 
+query T
+SELECT jsonb_path_query('{"a": 5, "b": 10}', '$.a == 5 && $.b == 10');
+----
+true
+
+query T
+SELECT jsonb_path_query('{"a": 5, "b": 10}', '$.a == 5 && $.b == 5');
+----
+false
+
+query T
+SELECT jsonb_path_query('{"a": 5, "b": 10}', '$.a == 5 || $.b == 5');
+----
+true
+
+query T
+SELECT jsonb_path_query('{"a": 5, "b": 10}', '$.a == 1 || $.b == 1');
+----
+false
+
+query T
+SELECT jsonb_path_query('{"a": 5}', '!($.a == 1)');
+----
+true
+
+query T
+SELECT jsonb_path_query('{"a": 5}', '!($.a == 5)');
+----
+false
+
+query T
+SELECT jsonb_path_query('{"a": 5, "b": 10}', '(1.5 > 1.2 && (!($.a == 1) || $.b == 1))');
+----
+true
+
 # select jsonb_path_query('[1, 2, 3, 4, 5]', '$[-1]');
 # select jsonb_path_query('[1, 2, 3, 4, 5]', 'strict $[-1]');
 

--- a/pkg/sql/logictest/testdata/logic_test/jsonb_path_query
+++ b/pkg/sql/logictest/testdata/logic_test/jsonb_path_query
@@ -353,6 +353,231 @@ SELECT jsonb_path_query('{}', '$varBool', '{"varInt": 1, "varFloat": 2.3, "varSt
 ----
 true
 
+query T
+SELECT jsonb_path_query('{}', '1 < 1');
+----
+false
+
+query T
+SELECT jsonb_path_query('{}', '1 <= 1');
+----
+true
+
+query T
+SELECT jsonb_path_query('{}', '1 > 1');
+----
+false
+
+query T
+SELECT jsonb_path_query('{}', '1 >= 1');
+----
+true
+
+query T
+SELECT jsonb_path_query('{}', '1 != 1');
+----
+false
+
+query T
+SELECT jsonb_path_query('{}', '1 == 1');
+----
+true
+
+query T
+SELECT jsonb_path_query('{}', '(true < false)');
+----
+false
+
+query T
+SELECT jsonb_path_query('{}', '((true <= false))');
+----
+false
+
+query T
+SELECT jsonb_path_query('{}', '(((true > false)))');
+----
+true
+
+query T
+SELECT jsonb_path_query('{}', 'true >= false');
+----
+true
+
+query T
+SELECT jsonb_path_query('{}', 'true != false');
+----
+true
+
+query T
+SELECT jsonb_path_query('{}', 'true == false');
+----
+false
+
+query T
+SELECT jsonb_path_query('{}', '$ < 1');
+----
+null
+
+query T
+SELECT jsonb_path_query('{}', '$ == $');
+----
+null
+
+query T
+SELECT jsonb_path_query('{}', '1 < 2');
+----
+true
+
+query T
+SELECT jsonb_path_query('{}', '1 <= 2');
+----
+true
+
+query T
+SELECT jsonb_path_query('{}', '2 > 1');
+----
+true
+
+query T
+SELECT jsonb_path_query('{}', '2 >= 1');
+----
+true
+
+query T
+SELECT jsonb_path_query('{}', '1 == 2');
+----
+false
+
+query T
+SELECT jsonb_path_query('{}', '1 != 2');
+----
+true
+
+query T
+SELECT jsonb_path_query('{}', '((1 < 2))');
+----
+true
+
+query T
+SELECT jsonb_path_query('{}', '((2 > 1))');
+----
+true
+
+query T
+SELECT jsonb_path_query('{}', '1.5 > 1');
+----
+true
+
+query T
+SELECT jsonb_path_query('{}', '1.5 < 2');
+----
+true
+
+query T
+SELECT jsonb_path_query('{}', '1.5 == 1.5');
+----
+true
+
+query T
+SELECT jsonb_path_query('{}', '1.5 != 1.5');
+----
+false
+
+query T
+SELECT jsonb_path_query('{}', '1.0 == 1.0000');
+----
+true
+
+query T
+SELECT jsonb_path_query('{}', '$var == $var2', '{"var": 1, "var2": 1}');
+----
+true
+
+query T
+SELECT jsonb_path_query('{}', '$var != $var2', '{"var": 1, "var2": 1}');
+----
+false
+
+query T
+SELECT jsonb_path_query('{}', '$var < $var2', '{"var": 1, "var2": 2}');
+----
+true
+
+query T
+SELECT jsonb_path_query('{}', '$var <= $var2', '{"var": 1, "var2": 2}');
+----
+true
+
+query T
+SELECT jsonb_path_query('{}', '$var > $var2', '{"var": 1, "var2": 2}');
+----
+false
+
+query T
+SELECT jsonb_path_query('{}', '$var >= $var2', '{"var": 1, "var2": 2}');
+----
+false
+
+query T
+SELECT jsonb_path_query('{"a": {"b": 5}}', '$.a.b > 3');
+----
+true
+
+query T
+SELECT jsonb_path_query('{"a": {"b": 5}}', '$.a.b <= 3');
+----
+false
+
+query T
+SELECT jsonb_path_query('{"arr": [1,2,3,4]}', '$.arr[0] == 1');
+----
+true
+
+query T
+SELECT jsonb_path_query('{"arr": [1,2,3,4]}', '$.arr[3] >= 4');
+----
+true
+
+query T
+SELECT jsonb_path_query('{"a": {"b": [10,20,30]}}', '$.a.b[1] < $.a.b[2]');
+----
+true
+
+query T
+SELECT jsonb_path_query('{"x": 5, "y": 5}', '$.x == $.y');
+----
+true
+
+query T
+SELECT jsonb_path_query('{"vals": [{"a": 1}, {"a": 2}]}', '$.vals[0].a != $.vals[1].a');
+----
+true
+
+query T
+SELECT jsonb_path_query('{"outer": {"inner": {"val": 100}}}', '$.outer.inner.val >= 100');
+----
+true
+
+query T
+SELECT jsonb_path_query('{"a": [2, 3]}', '$.a == 2');
+----
+true
+
+query T
+SELECT jsonb_path_query('{"a": [1, 3]}', '$.a == 2');
+----
+false
+
+query T
+SELECT jsonb_path_query('{"a": [2, 3]}', 'strict $.a == 2');
+----
+null
+
+query T
+SELECT jsonb_path_query('{"a": [1, 3]}', 'strict $.a == 2');
+----
+null
+
 # select jsonb_path_query('[1, 2, 3, 4, 5]', '$[-1]');
 # select jsonb_path_query('[1, 2, 3, 4, 5]', 'strict $[-1]');
 

--- a/pkg/sql/scanner/jsonpath_scan.go
+++ b/pkg/sql/scanner/jsonpath_scan.go
@@ -27,7 +27,8 @@ func (s *JSONPathScanner) Scan(lval ScanSymType) {
 	switch ch {
 	case '$':
 		// Root path ($)
-		if s.peek() == '.' || s.peek() == eof || s.peek() == ' ' || s.peek() == '[' {
+		if s.peek() == '.' || s.peek() == eof || s.peek() == ' ' || s.peek() == '[' || s.peek() == ')' {
+			lval.SetID(lexbase.ROOT)
 			return
 		}
 
@@ -48,6 +49,36 @@ func (s *JSONPathScanner) Scan(lval ScanSymType) {
 		if s.scanString(lval, identQuote, false /* allowEscapes */, true /* requireUTF8 */) {
 			lval.SetID(lexbase.IDENT)
 		}
+		return
+	case '=':
+		if s.peek() == '=' { // ==
+			s.pos++
+			lval.SetID(lexbase.EQUAL)
+			return
+		}
+		return
+	case '!':
+		if s.peek() == '=' { // !=
+			s.pos++
+			lval.SetID(lexbase.NOT_EQUAL)
+			return
+		}
+		return
+	case '>':
+		if s.peek() == '=' { // >=
+			s.pos++
+			lval.SetID(lexbase.GREATER_EQUAL)
+			return
+		}
+		lval.SetID(lexbase.GREATER)
+		return
+	case '<':
+		if s.peek() == '=' { // <=
+			s.pos++
+			lval.SetID(lexbase.LESS_EQUAL)
+			return
+		}
+		lval.SetID(lexbase.LESS)
 		return
 	default:
 		if sqllexbase.IsDigit(ch) {

--- a/pkg/sql/scanner/jsonpath_scan.go
+++ b/pkg/sql/scanner/jsonpath_scan.go
@@ -63,6 +63,7 @@ func (s *JSONPathScanner) Scan(lval ScanSymType) {
 			lval.SetID(lexbase.NOT_EQUAL)
 			return
 		}
+		lval.SetID(lexbase.NOT)
 		return
 	case '>':
 		if s.peek() == '=' { // >=
@@ -79,6 +80,20 @@ func (s *JSONPathScanner) Scan(lval ScanSymType) {
 			return
 		}
 		lval.SetID(lexbase.LESS)
+		return
+	case '&':
+		if s.peek() == '&' { // &&
+			s.pos++
+			lval.SetID(lexbase.AND)
+			return
+		}
+		return
+	case '|':
+		if s.peek() == '|' { // ||
+			s.pos++
+			lval.SetID(lexbase.OR)
+			return
+		}
 		return
 	default:
 		if sqllexbase.IsDigit(ch) {

--- a/pkg/util/jsonpath/BUILD.bazel
+++ b/pkg/util/jsonpath/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "jsonpath",
     srcs = [
         "expr.go",
+        "operation.go",
         "scalar.go",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/util/jsonpath",

--- a/pkg/util/jsonpath/eval/BUILD.bazel
+++ b/pkg/util/jsonpath/eval/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
         "array.go",
         "eval.go",
         "key.go",
+        "operation.go",
         "scalar.go",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/util/jsonpath/eval",

--- a/pkg/util/jsonpath/eval/operation.go
+++ b/pkg/util/jsonpath/eval/operation.go
@@ -6,7 +6,6 @@
 package eval
 
 import (
-	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/util/json"
 	"github.com/cockroachdb/cockroach/pkg/util/jsonpath"
 	"github.com/cockroachdb/errors"
@@ -20,8 +19,8 @@ const (
 	jsonpathBoolUnknown
 )
 
-func isBool(j tree.DJSON) bool {
-	switch j.JSON.Type() {
+func isBool(j json.JSON) bool {
+	switch j.Type() {
 	case json.TrueJSONType, json.FalseJSONType:
 		return true
 	default:
@@ -29,14 +28,14 @@ func isBool(j tree.DJSON) bool {
 	}
 }
 
-func convertFromBool(b jsonpathBool) []tree.DJSON {
+func convertFromBool(b jsonpathBool) []json.JSON {
 	switch b {
 	case jsonpathBoolTrue:
-		return []tree.DJSON{{JSON: json.TrueJSONValue}}
+		return []json.JSON{json.TrueJSONValue}
 	case jsonpathBoolFalse:
-		return []tree.DJSON{{JSON: json.FalseJSONValue}}
+		return []json.JSON{json.FalseJSONValue}
 	case jsonpathBoolUnknown:
-		return []tree.DJSON{{JSON: json.NullJSONValue}}
+		return []json.JSON{json.NullJSONValue}
 	default:
 		panic(errors.AssertionFailedf("unhandled jsonpath boolean type"))
 	}
@@ -54,8 +53,8 @@ func convertToBool(j json.JSON) jsonpathBool {
 }
 
 func (ctx *jsonpathCtx) evalOperation(
-	p jsonpath.Operation, current []tree.DJSON,
-) ([]tree.DJSON, error) {
+	p jsonpath.Operation, current []json.JSON,
+) ([]json.JSON, error) {
 	switch p.Type {
 	case jsonpath.OpLogicalAnd, jsonpath.OpLogicalOr, jsonpath.OpLogicalNot:
 		res, err := ctx.evalLogical(p, current)
@@ -77,7 +76,7 @@ func (ctx *jsonpathCtx) evalOperation(
 }
 
 func (ctx *jsonpathCtx) evalLogical(
-	op jsonpath.Operation, current []tree.DJSON,
+	op jsonpath.Operation, current []json.JSON,
 ) (jsonpathBool, error) {
 	left, err := ctx.eval(op.Left, current)
 	if err != nil {
@@ -87,7 +86,7 @@ func (ctx *jsonpathCtx) evalLogical(
 	if len(left) != 1 || !isBool(left[0]) {
 		return jsonpathBoolUnknown, errors.AssertionFailedf("left is not a boolean")
 	}
-	leftBool := convertToBool(left[0].JSON)
+	leftBool := convertToBool(left[0])
 	switch op.Type {
 	case jsonpath.OpLogicalAnd:
 		if leftBool == jsonpathBoolFalse {
@@ -117,7 +116,7 @@ func (ctx *jsonpathCtx) evalLogical(
 	if len(right) != 1 || !isBool(right[0]) {
 		return jsonpathBoolUnknown, errors.AssertionFailedf("right is not a boolean")
 	}
-	rightBool := convertToBool(right[0].JSON)
+	rightBool := convertToBool(right[0])
 
 	switch op.Type {
 	case jsonpath.OpLogicalAnd:
@@ -140,7 +139,7 @@ func (ctx *jsonpathCtx) evalLogical(
 // right paths satisfy the condition. In strict mode, even if a pair has been
 // found, all pairs need to be checked for errors.
 func (ctx *jsonpathCtx) evalComparison(
-	p jsonpath.Operation, current []tree.DJSON,
+	p jsonpath.Operation, current []json.JSON,
 ) (jsonpathBool, error) {
 	left, err := ctx.evalAndUnwrap(p.Left, current)
 	if err != nil {
@@ -182,11 +181,11 @@ func (ctx *jsonpathCtx) evalComparison(
 	return jsonpathBoolFalse, nil
 }
 
-func execComparison(l, r tree.DJSON, op jsonpath.OperationType) (jsonpathBool, error) {
-	if l.JSON.Type() != r.JSON.Type() && !(isBool(l) && isBool(r)) {
+func execComparison(l, r json.JSON, op jsonpath.OperationType) (jsonpathBool, error) {
+	if l.Type() != r.Type() && !(isBool(l) && isBool(r)) {
 		// Inequality comparison of nulls to non-nulls is true. Everything else
 		// is false.
-		if l.JSON.Type() == json.NullJSONType || r.JSON.Type() == json.NullJSONType {
+		if l.Type() == json.NullJSONType || r.Type() == json.NullJSONType {
 			if op == jsonpath.OpCompNotEqual {
 				return jsonpathBoolTrue, nil
 			}
@@ -198,10 +197,10 @@ func execComparison(l, r tree.DJSON, op jsonpath.OperationType) (jsonpathBool, e
 
 	var cmp int
 	var err error
-	switch l.JSON.Type() {
+	switch l.Type() {
 	case json.NullJSONType, json.TrueJSONType, json.FalseJSONType,
 		json.NumberJSONType, json.StringJSONType:
-		cmp, err = l.JSON.Compare(r.JSON)
+		cmp, err = l.Compare(r)
 		if err != nil {
 			return jsonpathBoolUnknown, err
 		}

--- a/pkg/util/jsonpath/eval/operation.go
+++ b/pkg/util/jsonpath/eval/operation.go
@@ -1,0 +1,171 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package eval
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/util/json"
+	"github.com/cockroachdb/cockroach/pkg/util/jsonpath"
+	"github.com/cockroachdb/errors"
+)
+
+type jsonpathBool int
+
+const (
+	jsonpathBoolTrue jsonpathBool = iota
+	jsonpathBoolFalse
+	jsonpathBoolUnknown
+)
+
+func isBool(j tree.DJSON) bool {
+	switch j.JSON.Type() {
+	case json.TrueJSONType, json.FalseJSONType:
+		return true
+	default:
+		return false
+	}
+}
+
+func convertFromBool(b jsonpathBool) []tree.DJSON {
+	switch b {
+	case jsonpathBoolTrue:
+		return []tree.DJSON{{JSON: json.TrueJSONValue}}
+	case jsonpathBoolFalse:
+		return []tree.DJSON{{JSON: json.FalseJSONValue}}
+	case jsonpathBoolUnknown:
+		return []tree.DJSON{{JSON: json.NullJSONValue}}
+	default:
+		panic(errors.AssertionFailedf("unhandled jsonpath boolean type"))
+	}
+}
+
+func convertToBool(j json.JSON) jsonpathBool {
+	b, ok := j.AsBool()
+	if !ok {
+		return jsonpathBoolUnknown
+	}
+	if b {
+		return jsonpathBoolTrue
+	}
+	return jsonpathBoolFalse
+}
+
+func (ctx *jsonpathCtx) evalOperation(
+	p jsonpath.Operation, current []tree.DJSON,
+) ([]tree.DJSON, error) {
+	switch p.Type {
+	case jsonpath.OpCompEqual, jsonpath.OpCompNotEqual,
+		jsonpath.OpCompLess, jsonpath.OpCompLessEqual,
+		jsonpath.OpCompGreater, jsonpath.OpCompGreaterEqual:
+		res, err := ctx.evalComparison(p, current)
+		if err != nil {
+			return nil, err
+		}
+		return convertFromBool(res), nil
+	default:
+		panic(errors.AssertionFailedf("unhandled operation type"))
+	}
+}
+
+// evalComparison evaluates a comparison operation predicate. Predicates have
+// existence semantics. True is returned if any pair of items from the left and
+// right paths satisfy the condition. In strict mode, even if a pair has been
+// found, all pairs need to be checked for errors.
+func (ctx *jsonpathCtx) evalComparison(
+	p jsonpath.Operation, current []tree.DJSON,
+) (jsonpathBool, error) {
+	left, err := ctx.evalAndUnwrap(p.Left, current)
+	if err != nil {
+		return jsonpathBoolUnknown, err
+	}
+	right, err := ctx.evalAndUnwrap(p.Right, current)
+	if err != nil {
+		return jsonpathBoolUnknown, err
+	}
+
+	errored := false
+	found := false
+	for _, l := range left {
+		for _, r := range right {
+			res, err := execComparison(l, r, p.Type)
+			if err != nil {
+				return jsonpathBoolUnknown, err
+			}
+			if res == jsonpathBoolUnknown {
+				if ctx.strict {
+					return jsonpathBoolUnknown, nil
+				}
+				errored = true
+			} else if res == jsonpathBoolTrue {
+				if !ctx.strict {
+					return jsonpathBoolTrue, nil
+				}
+				found = true
+			}
+		}
+	}
+	if found {
+		return jsonpathBoolTrue, nil
+	}
+	// Lax mode.
+	if errored {
+		return jsonpathBoolUnknown, nil
+	}
+	return jsonpathBoolFalse, nil
+}
+
+func execComparison(l, r tree.DJSON, op jsonpath.OperationType) (jsonpathBool, error) {
+	if l.JSON.Type() != r.JSON.Type() && !(isBool(l) && isBool(r)) {
+		// Inequality comparison of nulls to non-nulls is true. Everything else
+		// is false.
+		if l.JSON.Type() == json.NullJSONType || r.JSON.Type() == json.NullJSONType {
+			if op == jsonpath.OpCompNotEqual {
+				return jsonpathBoolTrue, nil
+			}
+			return jsonpathBoolFalse, nil
+		}
+		// Non-null items of different types are not comparable.
+		return jsonpathBoolUnknown, nil
+	}
+
+	var cmp int
+	var err error
+	switch l.JSON.Type() {
+	case json.NullJSONType, json.TrueJSONType, json.FalseJSONType,
+		json.NumberJSONType, json.StringJSONType:
+		cmp, err = l.JSON.Compare(r.JSON)
+		if err != nil {
+			return jsonpathBoolUnknown, err
+		}
+	case json.ArrayJSONType, json.ObjectJSONType:
+		// Don't evaluate non-scalar types.
+		return jsonpathBoolUnknown, nil
+	default:
+		panic(errors.AssertionFailedf("unhandled json type"))
+	}
+
+	var res bool
+	switch op {
+	case jsonpath.OpCompEqual:
+		res = cmp == 0
+	case jsonpath.OpCompNotEqual:
+		res = cmp != 0
+	case jsonpath.OpCompLess:
+		res = cmp < 0
+	case jsonpath.OpCompLessEqual:
+		res = cmp <= 0
+	case jsonpath.OpCompGreater:
+		res = cmp > 0
+	case jsonpath.OpCompGreaterEqual:
+		res = cmp >= 0
+	default:
+		panic(errors.AssertionFailedf("unhandled jsonpath comparison type"))
+	}
+	if res {
+		return jsonpathBoolTrue, nil
+	}
+	return jsonpathBoolFalse, nil
+}

--- a/pkg/util/jsonpath/eval/scalar.go
+++ b/pkg/util/jsonpath/eval/scalar.go
@@ -8,20 +8,20 @@ package eval
 import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
-	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/util/json"
 	"github.com/cockroachdb/cockroach/pkg/util/jsonpath"
 )
 
-func (ctx *jsonpathCtx) resolveScalar(s jsonpath.Scalar) (tree.DJSON, error) {
+func (ctx *jsonpathCtx) resolveScalar(s jsonpath.Scalar) (json.JSON, error) {
 	if s.Type == jsonpath.ScalarVariable {
 		val, err := ctx.vars.FetchValKey(s.Variable)
 		if err != nil {
-			return tree.DJSON{}, err
+			return nil, err
 		}
 		if val == nil {
-			return tree.DJSON{}, pgerror.Newf(pgcode.UndefinedObject, "could not find jsonpath variable %q", s.Variable)
+			return nil, pgerror.Newf(pgcode.UndefinedObject, "could not find jsonpath variable %q", s.Variable)
 		}
-		return *ctx.a.NewDJSON(tree.DJSON{JSON: val}), nil
+		return val, nil
 	}
-	return *ctx.a.NewDJSON(tree.DJSON{JSON: s.Value}), nil
+	return s.Value, nil
 }

--- a/pkg/util/jsonpath/operation.go
+++ b/pkg/util/jsonpath/operation.go
@@ -1,0 +1,40 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package jsonpath
+
+import "fmt"
+
+type OperationType int
+
+const (
+	OpCompEqual OperationType = iota
+	OpCompNotEqual
+	OpCompLess
+	OpCompLessEqual
+	OpCompGreater
+	OpCompGreaterEqual
+)
+
+var operationTypeStrings = map[OperationType]string{
+	OpCompEqual:        "==",
+	OpCompNotEqual:     "!=",
+	OpCompLess:         "<",
+	OpCompLessEqual:    "<=",
+	OpCompGreater:      ">",
+	OpCompGreaterEqual: ">=",
+}
+
+type Operation struct {
+	Type  OperationType
+	Left  Path
+	Right Path
+}
+
+var _ Path = Operation{}
+
+func (o Operation) String() string {
+	return fmt.Sprintf("(%s %s %s)", o.Left, operationTypeStrings[o.Type], o.Right)
+}

--- a/pkg/util/jsonpath/operation.go
+++ b/pkg/util/jsonpath/operation.go
@@ -16,6 +16,9 @@ const (
 	OpCompLessEqual
 	OpCompGreater
 	OpCompGreaterEqual
+	OpLogicalAnd
+	OpLogicalOr
+	OpLogicalNot
 )
 
 var operationTypeStrings = map[OperationType]string{
@@ -25,6 +28,9 @@ var operationTypeStrings = map[OperationType]string{
 	OpCompLessEqual:    "<=",
 	OpCompGreater:      ">",
 	OpCompGreaterEqual: ">=",
+	OpLogicalAnd:       "&&",
+	OpLogicalOr:        "||",
+	OpLogicalNot:       "!",
 }
 
 type Operation struct {
@@ -36,5 +42,11 @@ type Operation struct {
 var _ Path = Operation{}
 
 func (o Operation) String() string {
+	// TODO(normanchenn): Fix recursive brackets. When there is a operation like
+	// 1 == 1 && 1 != 1, postgres will output (1 == 1 && 1 != 1), but we output
+	// ((1 == 1) && (1 != 1)).
+	if o.Type == OpLogicalNot {
+		return fmt.Sprintf("%s(%s)", operationTypeStrings[o.Type], o.Left)
+	}
 	return fmt.Sprintf("(%s %s %s)", o.Left, operationTypeStrings[o.Type], o.Right)
 }

--- a/pkg/util/jsonpath/parser/testdata/jsonpath
+++ b/pkg/util/jsonpath/parser/testdata/jsonpath
@@ -262,6 +262,76 @@ $[false]
 ----
 $[false]
 
+parse
+1 < 1
+----
+(1 < 1) -- normalized!
+
+parse
+1 <= 1
+----
+(1 <= 1) -- normalized!
+
+parse
+1 > 1
+----
+(1 > 1) -- normalized!
+
+parse
+1 >= 1
+----
+(1 >= 1) -- normalized!
+
+parse
+1 != 1
+----
+(1 != 1) -- normalized!
+
+parse
+1 == 1
+----
+(1 == 1) -- normalized!
+
+parse
+((true < false))
+----
+(true < false) -- normalized!
+
+parse
+((true <= false))
+----
+(true <= false) -- normalized!
+
+parse
+((true > false))
+----
+(true > false) -- normalized!
+
+parse
+((true >= false))
+----
+(true >= false) -- normalized!
+
+parse
+((true != false))
+----
+(true != false) -- normalized!
+
+parse
+((true == false))
+----
+(true == false) -- normalized!
+
+parse
+$ < 1
+----
+($ < 1) -- normalized!
+
+parse
+$ == $
+----
+($ == $) -- normalized!
+
 # postgres allows floats as array indexes
 # parse
 # $.abc[1.0]

--- a/pkg/util/jsonpath/parser/testdata/jsonpath
+++ b/pkg/util/jsonpath/parser/testdata/jsonpath
@@ -332,6 +332,16 @@ $ == $
 ----
 ($ == $) -- normalized!
 
+parse
+1 == 1 && 1 != 1
+----
+((1 == 1) && (1 != 1)) -- normalized!
+
+parse
+1 == 1 || 1 != 1
+----
+((1 == 1) || (1 != 1)) -- normalized!
+
 # postgres allows floats as array indexes
 # parse
 # $.abc[1.0]


### PR DESCRIPTION
#### jsonpath: add comparison operations

This commit adds the framework for handling predicate evaluation and
adds functionality to evaluate and compare the values of expressions.
Specifically, the following operations are added: `==`, `!=`, `<`,
`<=`, `>`, `>=`, which resolve into json true, false, or null.

Informs: #142608
Epic: None
Release note (sql change): Add predicate support with comparison
operator evaluation for jsonpath queries. (ex. `SELECT
jsonb_path_query('{}', 1 < 2)`)

#### jsonpath: add logical operators

This commit adds logical operators to predicate evaluation.
Specifically, logical AND (&&), OR (||), and NOT (!) are added.

Informs: #142608
Epic: None
Release note (sql change): Add logical operators to jsonpath predicate
evaluation. (ex. `SELECT jsonb_path_query('{}', '1 < 2 && 3 >= 2')`)

#### jsonpath/eval: use `json.JSON` instead of `tree.DJSON`

Previously during jsonpath evaluation, a slice of `tree.DJSON` would be
made every `eval` call. This is unnecessary, since the evaluation only
uses the underlying `json.JSON`.

Epic: None
Release note: None