### PR TITLE
roachprod-microbench: failure groups

### DIFF
--- a/pkg/cmd/roachprod-microbench/cluster/BUILD.bazel
+++ b/pkg/cmd/roachprod-microbench/cluster/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "//pkg/roachprod/errors",
         "//pkg/roachprod/install",
         "//pkg/roachprod/logger",
+        "//pkg/util/syncutil",
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",
     ],

--- a/pkg/cmd/roachprod-microbench/executor.go
+++ b/pkg/cmd/roachprod-microbench/executor.go
@@ -13,6 +13,7 @@ import (
 	"path"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
 	"time"
 
@@ -254,6 +255,58 @@ func (e *executor) listRemotePackages(log *logger.Logger, dir string) ([]string,
 	return packages, nil
 }
 
+func (e *executor) generateBenchmarkCommands(
+	benchmarks []benchmark,
+) ([][]cluster.RemoteCommand, error) {
+	// Generate commands for running benchmarks.
+	commands := make([][]cluster.RemoteCommand, 0)
+
+	// Sort the binary keys to ensure a deterministic order.
+	binaryKeys := maps.Keys(e.binaries)
+	sort.Strings(binaryKeys)
+
+	// Generate the commands for each benchmark binary.
+	for _, bench := range benchmarks {
+		runCommand := fmt.Sprintf("./run.sh %s -test.benchmem -test.bench=^%s$ -test.run=^$ -test.v",
+			strings.Join(e.testArgs, " "), bench.name)
+		if e.timeout != "" {
+			runCommand = fmt.Sprintf("timeout -k 30s %s %s", e.timeout, runCommand)
+		}
+		if e.shellCommand != "" {
+			runCommand = fmt.Sprintf("%s && %s", e.shellCommand, runCommand)
+		}
+
+		benchmarkCommands := make([]cluster.RemoteCommand, 0, len(e.binaries))
+		for _, key := range binaryKeys {
+			bin := e.binaries[key]
+			shellCommand := fmt.Sprintf(`"cd %s/%s/bin && %s"`, bin, bench.pkg, runCommand)
+			command := cluster.RemoteCommand{
+				Args:     []string{"sh", "-c", shellCommand},
+				Metadata: benchmarkKey{bench, key},
+			}
+			benchmarkCommands = append(benchmarkCommands, command)
+		}
+
+		// If affinity is enabled, add all commands for a benchmark together.
+		// Otherwise, split commands for each binary.
+		if e.affinity {
+			commands = append(commands, benchmarkCommands)
+		} else {
+			for _, cmd := range benchmarkCommands {
+				commands = append(commands, []cluster.RemoteCommand{cmd})
+			}
+		}
+	}
+
+	// Expand the commands for the number of iterations requested.
+	expandedCommands := make([][]cluster.RemoteCommand, 0)
+	for range e.iterations {
+		expandedCommands = append(expandedCommands, commands...)
+	}
+
+	return expandedCommands, nil
+}
+
 // executeBenchmarks executes the microbenchmarks on the remote cluster. Reports
 // containing the microbenchmark results for each package are stored in the log
 // output directory. Microbenchmark failures are recorded in separate log files,
@@ -305,6 +358,12 @@ func (e *executor) executeBenchmarks() error {
 		return errors.New("no packages containing benchmarks found")
 	}
 
+	// Generate commands for running benchmarks.
+	commands, err := e.generateBenchmarkCommands(benchmarks)
+	if err != nil {
+		return err
+	}
+
 	// Create reports for each key, binary combination.
 	reporters := make(map[string]*report)
 	defer func() {
@@ -324,45 +383,6 @@ func (e *executor) executeBenchmarks() error {
 		reporters[key] = report
 		if err != nil {
 			return err
-		}
-	}
-
-	// Generate commands for running benchmarks.
-	commands := make([][]cluster.RemoteCommand, 0)
-	for _, bench := range benchmarks {
-		runCommand := fmt.Sprintf("./run.sh %s -test.benchmem -test.bench=^%s$ -test.run=^$ -test.v",
-			strings.Join(e.testArgs, " "), bench.name)
-		if e.timeout != "" {
-			runCommand = fmt.Sprintf("timeout -k 30s %s %s", e.timeout, runCommand)
-		}
-		if e.shellCommand != "" {
-			runCommand = fmt.Sprintf("%s && %s", e.shellCommand, runCommand)
-		}
-		// Weave the commands between binaries and iterations.
-		for range e.iterations {
-			iterationGroup := make([]cluster.RemoteCommand, 0)
-			for key, bin := range e.binaries {
-				shellCommand := fmt.Sprintf(`"cd %s/%s/bin && %s"`, bin, bench.pkg, runCommand)
-				command := cluster.RemoteCommand{
-					Args:     []string{"sh", "-c", shellCommand},
-					Metadata: benchmarkKey{bench, key},
-				}
-				iterationGroup = append(iterationGroup, command)
-			}
-
-			if e.affinity {
-				// When affinity is enabled, each iteration runs as a group with binaries interleaved.
-				// This means all binaries for a single iteration will run together on the same node,
-				// but different iterations can run on different nodes.
-				commands = append(commands, iterationGroup)
-			} else {
-				// When affinity is disabled, each command runs individually on any available node.
-				// This has the benefit of not having stragglers, but the downside of possibly
-				// introducing noise due to different node characteristics.
-				for _, command := range iterationGroup {
-					commands = append(commands, []cluster.RemoteCommand{command})
-				}
-			}
 		}
 	}
 

--- a/pkg/cmd/roachprod-microbench/executor_test.go
+++ b/pkg/cmd/roachprod-microbench/executor_test.go
@@ -8,11 +8,14 @@ package main
 import (
 	"fmt"
 	"path"
+	"strconv"
+	"strings"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachprod-microbench/parser"
 	"github.com/cockroachdb/cockroach/pkg/testutils/datapathutils"
 	"github.com/cockroachdb/datadriven"
+	"github.com/stretchr/testify/require"
 )
 
 func TestExtractBenchmarkResultsDataDriven(t *testing.T) {
@@ -24,5 +27,71 @@ func TestExtractBenchmarkResultsDataDriven(t *testing.T) {
 		result := parser.ExtractBenchmarkResults(d.Input)
 		output := fmt.Sprintf("%v", result)
 		return output
+	})
+}
+
+func TestGenerateBenchmarkCommandsDataDriven(t *testing.T) {
+	ddFilePath := path.Join(datapathutils.TestDataPath(t), "generate_commands.txt")
+	datadriven.RunTest(t, ddFilePath, func(t *testing.T, d *datadriven.TestData) string {
+		if d.Cmd != "generate" {
+			d.Fatalf(t, "unknown command %s", d.Cmd)
+		}
+
+		// Parse test configuration
+		config := defaultExecutorConfig()
+		for _, arg := range d.CmdArgs {
+			switch arg.Key {
+			case "iterations":
+				var err error
+				config.iterations, err = strconv.Atoi(arg.Vals[0])
+				require.NoError(t, err)
+			case "affinity":
+				config.affinity = arg.Vals[0] == "true"
+			case "binaries":
+				binaries := make(map[string]string)
+				for _, name := range arg.Vals {
+					binaries[name] = name
+				}
+				config.binaries = binaries
+			default:
+				t.Fatalf("unknown flag %s", arg.Key)
+			}
+		}
+
+		// Create executor with the config
+		e, err := newExecutor(config)
+		require.NoError(t, err)
+
+		// Parse benchmark input
+		var benchmarks []benchmark
+		for _, line := range strings.Split(d.Input, "\n") {
+			line = strings.TrimSpace(line)
+			if line == "" {
+				continue
+			}
+			parts := strings.Split(line, " ")
+			require.Len(t, parts, 2, "benchmark format should be 'pkg name'")
+			benchmarks = append(benchmarks, benchmark{
+				pkg:  parts[0],
+				name: parts[1],
+			})
+		}
+
+		// Generate commands
+		commands, err := e.generateBenchmarkCommands(benchmarks)
+		require.NoError(t, err)
+
+		// Format output
+		var output strings.Builder
+		for i, cmdGroup := range commands {
+			fmt.Fprintf(&output, "Command Group %d:\n", i+1)
+			for _, cmd := range cmdGroup {
+				metadata := cmd.Metadata.(benchmarkKey)
+				fmt.Fprintf(&output, "\tPackage: %s\n", metadata.pkg)
+				fmt.Fprintf(&output, "\tBenchmark: %s\n", metadata.name)
+				fmt.Fprintf(&output, "\tBinary Key: %s\n", metadata.key)
+			}
+		}
+		return output.String()
 	})
 }

--- a/pkg/cmd/roachprod-microbench/testdata/generate_commands.txt
+++ b/pkg/cmd/roachprod-microbench/testdata/generate_commands.txt
@@ -1,0 +1,99 @@
+# Test with default configuration (affinity=true, iterations=1)
+generate
+pkg1 BenchmarkTest1
+pkg2 BenchmarkTest2
+----
+Command Group 1:
+	Package: pkg1
+	Benchmark: BenchmarkTest1
+	Binary Key: experiment
+Command Group 2:
+	Package: pkg2
+	Benchmark: BenchmarkTest2
+	Binary Key: experiment
+
+# Test with multiple iterations (affinity=true, iterations=2)
+generate iterations=2
+pkg1 BenchmarkTest1
+----
+Command Group 1:
+	Package: pkg1
+	Benchmark: BenchmarkTest1
+	Binary Key: experiment
+Command Group 2:
+	Package: pkg1
+	Benchmark: BenchmarkTest1
+	Binary Key: experiment
+
+# Test with affinity disabled (affinity=false, iterations=1)
+generate affinity=false
+pkg1 BenchmarkTest1
+pkg2 BenchmarkTest2
+----
+Command Group 1:
+	Package: pkg1
+	Benchmark: BenchmarkTest1
+	Binary Key: experiment
+Command Group 2:
+	Package: pkg2
+	Benchmark: BenchmarkTest2
+	Binary Key: experiment
+
+# Test with multiple binaries (affinity=true, iterations=1)
+generate binaries=(baseline, experiment)
+pkg1 BenchmarkTest1
+----
+Command Group 1:
+	Package: pkg1
+	Benchmark: BenchmarkTest1
+	Binary Key: baseline
+	Package: pkg1
+	Benchmark: BenchmarkTest1
+	Binary Key: experiment
+
+# Test with multiple binaries and affinity disabled (affinity=false, iterations=1)
+generate binaries=(baseline, experiment) affinity=false
+pkg1 BenchmarkTest1
+----
+Command Group 1:
+	Package: pkg1
+	Benchmark: BenchmarkTest1
+	Binary Key: baseline
+Command Group 2:
+	Package: pkg1
+	Benchmark: BenchmarkTest1
+	Binary Key: experiment
+
+# Test with multiple iterations, multiple binaries, and multiple benchmarks (affinity=true)
+generate iterations=2 binaries=(baseline, experiment)
+pkg1 BenchmarkTest1
+pkg2 BenchmarkTest2
+----
+Command Group 1:
+	Package: pkg1
+	Benchmark: BenchmarkTest1
+	Binary Key: baseline
+	Package: pkg1
+	Benchmark: BenchmarkTest1
+	Binary Key: experiment
+Command Group 2:
+	Package: pkg2
+	Benchmark: BenchmarkTest2
+	Binary Key: baseline
+	Package: pkg2
+	Benchmark: BenchmarkTest2
+	Binary Key: experiment
+Command Group 3:
+	Package: pkg1
+	Benchmark: BenchmarkTest1
+	Binary Key: baseline
+	Package: pkg1
+	Benchmark: BenchmarkTest1
+	Binary Key: experiment
+Command Group 4:
+	Package: pkg2
+	Benchmark: BenchmarkTest2
+	Binary Key: baseline
+	Package: pkg2
+	Benchmark: BenchmarkTest2
+	Binary Key: experiment


### PR DESCRIPTION
This PR improves the execution of microbenchmarks in two key ways:

1. Reorders benchmark execution to run all first iterations before second iterations:
   - Previously: Each benchmark would run all its iterations before moving to the next benchmark
   - Now: Runs the first iteration of all benchmarks, then the second iteration of all benchmarks, etc.
   - This allows early detection of failing benchmarks and cancellation of remaining iterations

2. Introduces group-based failure handling:
   - Adds GroupID to RemoteCommand to identify commands that are part of the same logical group
   - When a command fails with a non-transient error, all other commands in the same group are cancelled
   - Prevents redundant execution of iterations that would fail for the same reason
   - This is particularly important for GitHub issue reporting, as we'll only see the first failure of an iteration rather than repeated identical failures

Epic: None
Release note: None