### PR TITLE
vecindex: lazily create root partition metadata

### DIFF
--- a/pkg/sql/vecindex/vecstore/BUILD.bazel
+++ b/pkg/sql/vecindex/vecstore/BUILD.bazel
@@ -45,6 +45,7 @@ go_test(
     deps = [
         "//pkg/base",
         "//pkg/keys",
+        "//pkg/kv",
         "//pkg/kv/kvpb",
         "//pkg/security/securityassets",
         "//pkg/security/securitytest",


### PR DESCRIPTION
When preparing to update a K-means tree, we check its root partition metadata. If that does not yet exist, we will create it using a CPut operation and then acquire a SHARED lock that prevents a background split operation until the transaction ends.

Epic: CRDB-42943

Release note: None