### PR TITLE
sql: add test for session migration with DECLARE CURSOR

### DIFF
--- a/pkg/sql/conn_executor_prepare.go
+++ b/pkg/sql/conn_executor_prepare.go
@@ -285,9 +285,9 @@ func (ex *connExecutor) prepare(
 		if origin != PreparedStatementOriginSessionMigration {
 			return nil, err
 		} else {
-			f := tree.NewFmtCtx(tree.FmtMarkRedactionNode | tree.FmtSimple)
+			f := tree.NewFmtCtx(tree.FmtMarkRedactionNode | tree.FmtOmitNameRedaction | tree.FmtSimple)
 			f.FormatNode(stmt.AST)
-			redactableStmt := redact.SafeString(f.CloseAndGetString())
+			redactableStmt := redact.RedactableString(f.CloseAndGetString())
 			log.Warningf(ctx, "could not prepare statement during session migration (%s): %v", redactableStmt, err)
 		}
 	}

--- a/pkg/sql/testdata/session_migration/prepared_statements
+++ b/pkg/sql/testdata/session_migration/prepared_statements
@@ -62,6 +62,29 @@ query
 SELECT * FROM t2
 ----
 
+exec
+BEGIN
+----
+
+# Test for preparing a DECLARE CURSOR statement. We have observed errors in
+# some cases; see https://github.com/cockroachdb/cockroach/issues/136518.
+
+wire_prepare s_declare_cursor
+DECLARE c CURSOR FOR WITH cte AS (SELECT b FROM t2 WHERE a = $1) SELECT * FROM cte
+----
+
+wire_exec s_declare_cursor 1
+----
+
+query
+FETCH 1 FROM c
+----
+
+exec
+COMMIT
+----
+
+
 let $x
 SELECT encode(crdb_internal.serialize_session(), 'hex')
 ----
@@ -124,6 +147,22 @@ wire_query s5
 wire_query s6 0
 ----
 1 cat
+
+exec
+BEGIN
+----
+
+wire_exec s_declare_cursor 1
+----
+
+query
+FETCH 1 FROM c
+----
+cat
+
+exec
+COMMIT
+----
 
 reset
 ----


### PR DESCRIPTION
We have observed issues wiht preparing statements like this in our SLI dashboard. This test does not fully repro the problem, but adding this test could still be useful to prevent further regressions.

While doing this, I fixed the redaction for the warning that is logged if a statement can't be prepared.

informs https://github.com/cockroachdb/cockroach/issues/136518
Release note: None