### PR TITLE
server: fix NPE from HotRangesV2 API

### DIFF
--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -2881,10 +2881,11 @@ func (s *systemStatusServer) HotRangesV2(
 		}
 		if local {
 			resp, err := s.localHotRanges(ctx, tenantID, requestedNodeID)
-			response.Ranges = append(response.Ranges, resp.Ranges...)
 			if err != nil {
-				response.ErrorsByNodeID[requestedNodeID] = err.Error()
+				return nil, err
 			}
+
+			response.Ranges = append(response.Ranges, resp.Ranges...)
 			return response, nil
 		}
 		requestedNodes = []roachpb.NodeID{requestedNodeID}


### PR DESCRIPTION
Fixes a bug where HotRangesV2 is throwing an NPE when localHotRanges returns an error.

Fixes: #142908
Epic: none
Release note: none