### PR TITLE
roachprod: add ebpf_exporter scraping

### DIFF
--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -852,6 +852,10 @@ func updatePrometheusTargets(
 						Target:       fmt.Sprintf("%s:%d", nodeIP, vm.NodeExporterPort),
 						CustomLabels: createLabels(nodeID, v, "node_exporter", !c.Secure),
 					},
+					{
+						Target:       fmt.Sprintf("%s:%d", nodeIP, vm.EbpfExporterPort),
+						CustomLabels: createLabels(nodeID, v, "ebpf_exporter", !c.Secure),
+					},
 				}
 			}
 			nodeIPPorts[nodeID] = append(
@@ -909,10 +913,18 @@ func createLabels(nodeID int, v vm.VM, job string, insecure bool) map[string]str
 		}
 	case "node_exporter":
 		labels["__metrics_path__"] = vm.NodeExporterMetricsPath
-		// node exporter is always scraped over http
+		// node_exporter is always scraped over http
 		labels["__scheme__"] = "http"
 
 		// Node ID is exposed by cockroachdb metrics, we add it to node_exporter
+		labels["node_id"] = strconv.Itoa(nodeID)
+
+	case "ebpf_exporter":
+		labels["__metrics_path__"] = vm.EbpfExporterMetricsPath
+		// ebpf_exporter is always scraped over http
+		labels["__scheme__"] = "http"
+
+		// Node ID is exposed by cockroachdb metrics, we add it to ebpf_exporter
 		labels["node_id"] = strconv.Itoa(nodeID)
 	}
 

--- a/pkg/roachprod/vm/aws/support.go
+++ b/pkg/roachprod/vm/aws/support.go
@@ -163,6 +163,7 @@ setup_disks
 {{ template "fips_utils" . }}
 {{ template "ssh_utils" . }}
 {{ template "node_exporter" . }}
+{{ template "ebpf_exporter" . }}
 
 sudo touch {{ .OSInitializedFile }}
 `

--- a/pkg/roachprod/vm/aws/testdata/startup_script
+++ b/pkg/roachprod/vm/aws/testdata/startup_script
@@ -282,14 +282,37 @@ mkdir -p ${DEFAULT_USER_HOME}/node_exporter && curl -fsSL \
 	tar zxv --strip-components 1 -C ${DEFAULT_USER_HOME}/node_exporter \
 	&& chown -R 1000:1000 ${DEFAULT_USER_HOME}/node_exporter
 
-sudo iptables -A INPUT -s 127.0.0.1,10.0.0.0/8,prometheus.testeng.crdb.io -p tcp --dport 9100 -j ACCEPT
+export SCRAPING_PUBLIC_IPS=$(dig +short prometheus.testeng.crdb.io | awk '{printf "%s%s",sep,$0; sep=","} END {print ""}')
+sudo iptables -A INPUT -s 127.0.0.1,10.0.0.0/8,${SCRAPING_PUBLIC_IPS} -p tcp --dport 9100 -j ACCEPT
 sudo iptables -A INPUT -p tcp --dport 9100 -j DROP
 (
-	chown -R 1000:1000 ${DEFAULT_USER_HOME}/node_exporter && \
 	cd ${DEFAULT_USER_HOME}/node_exporter && \
 	sudo systemd-run --unit node_exporter --same-dir \
 		./node_exporter --collector.systemd --collector.interrupts --collector.processes \
 		--web.listen-address=":9100" \
+		--web.telemetry-path="/metrics"
+)
+
+
+
+# Add and start ebpf_exporter, only authorize scrapping from internal network.
+export ARCH=$(dpkg --print-architecture)
+export DEFAULT_USER_HOME="/home/$(id -nu 1000)"
+mkdir -p ${DEFAULT_USER_HOME}/ebpf_exporter && curl -fsSL \
+	https://storage.googleapis.com/cockroach-test-artifacts/prometheus/ebpf_exporter-2.4.2.linux-${ARCH}.tar.gz |
+	tar zxv --strip-components 1 -C ${DEFAULT_USER_HOME}/ebpf_exporter \
+	&& chown -R 1000:1000 ${DEFAULT_USER_HOME}/ebpf_exporter
+
+export SCRAPING_PUBLIC_IPS=$(dig +short prometheus.testeng.crdb.io | awk '{printf "%s%s",sep,$0; sep=","} END {print ""}')
+sudo iptables -A INPUT -s 127.0.0.1,10.0.0.0/8,${SCRAPING_PUBLIC_IPS} -p tcp --dport 9435 -j ACCEPT
+sudo iptables -A INPUT -p tcp --dport 9435 -j DROP
+(
+	cd ${DEFAULT_USER_HOME}/ebpf_exporter && \
+	sudo systemd-run --unit ebpf_exporter --same-dir \
+		./ebpf_exporter \
+		--config.dir=examples \
+		--config.names=biolatency,timers,sched-trace,syscalls,uprobe \
+		--web.listen-address=":9435" \
 		--web.telemetry-path="/metrics"
 )
 

--- a/pkg/roachprod/vm/azure/testdata/startup_script
+++ b/pkg/roachprod/vm/azure/testdata/startup_script
@@ -221,13 +221,36 @@ mkdir -p ${DEFAULT_USER_HOME}/node_exporter && curl -fsSL \
 	tar zxv --strip-components 1 -C ${DEFAULT_USER_HOME}/node_exporter \
 	&& chown -R 1000:1000 ${DEFAULT_USER_HOME}/node_exporter
 
-sudo iptables -A INPUT -s 127.0.0.1,10.0.0.0/8,prometheus.testeng.crdb.io -p tcp --dport 0 -j ACCEPT
+export SCRAPING_PUBLIC_IPS=$(dig +short prometheus.testeng.crdb.io | awk '{printf "%s%s",sep,$0; sep=","} END {print ""}')
+sudo iptables -A INPUT -s 127.0.0.1,10.0.0.0/8,${SCRAPING_PUBLIC_IPS} -p tcp --dport 0 -j ACCEPT
 sudo iptables -A INPUT -p tcp --dport 0 -j DROP
 (
-	chown -R 1000:1000 ${DEFAULT_USER_HOME}/node_exporter && \
 	cd ${DEFAULT_USER_HOME}/node_exporter && \
 	sudo systemd-run --unit node_exporter --same-dir \
 		./node_exporter --collector.systemd --collector.interrupts --collector.processes \
+		--web.listen-address=":0" \
+		--web.telemetry-path="/metrics"
+)
+
+
+
+# Add and start ebpf_exporter, only authorize scrapping from internal network.
+export ARCH=$(dpkg --print-architecture)
+export DEFAULT_USER_HOME="/home/$(id -nu 1000)"
+mkdir -p ${DEFAULT_USER_HOME}/ebpf_exporter && curl -fsSL \
+	https://storage.googleapis.com/cockroach-test-artifacts/prometheus/ebpf_exporter-2.4.2.linux-${ARCH}.tar.gz |
+	tar zxv --strip-components 1 -C ${DEFAULT_USER_HOME}/ebpf_exporter \
+	&& chown -R 1000:1000 ${DEFAULT_USER_HOME}/ebpf_exporter
+
+export SCRAPING_PUBLIC_IPS=$(dig +short prometheus.testeng.crdb.io | awk '{printf "%s%s",sep,$0; sep=","} END {print ""}')
+sudo iptables -A INPUT -s 127.0.0.1,10.0.0.0/8,${SCRAPING_PUBLIC_IPS} -p tcp --dport 0 -j ACCEPT
+sudo iptables -A INPUT -p tcp --dport 0 -j DROP
+(
+	cd ${DEFAULT_USER_HOME}/ebpf_exporter && \
+	sudo systemd-run --unit ebpf_exporter --same-dir \
+		./ebpf_exporter \
+		--config.dir=examples \
+		--config.names=biolatency,timers,sched-trace,syscalls,uprobe \
 		--web.listen-address=":0" \
 		--web.telemetry-path="/metrics"
 )

--- a/pkg/roachprod/vm/azure/utils.go
+++ b/pkg/roachprod/vm/azure/utils.go
@@ -86,6 +86,7 @@ echo $ts_dev_id | sudo tee /sys/bus/vmbus/drivers/hv_utils/unbind
 {{ template "fips_utils" . }}
 {{ template "ssh_utils" . }}
 {{ template "node_exporter" . }}
+{{ template "ebpf_exporter" . }}
 
 sudo touch {{ .OSInitializedFile }}
 `

--- a/pkg/roachprod/vm/gce/testdata/startup_script
+++ b/pkg/roachprod/vm/gce/testdata/startup_script
@@ -288,14 +288,37 @@ mkdir -p ${DEFAULT_USER_HOME}/node_exporter && curl -fsSL \
 	tar zxv --strip-components 1 -C ${DEFAULT_USER_HOME}/node_exporter \
 	&& chown -R 1000:1000 ${DEFAULT_USER_HOME}/node_exporter
 
-sudo iptables -A INPUT -s 127.0.0.1,10.0.0.0/8,prometheus.testeng.crdb.io -p tcp --dport 9100 -j ACCEPT
+export SCRAPING_PUBLIC_IPS=$(dig +short prometheus.testeng.crdb.io | awk '{printf "%s%s",sep,$0; sep=","} END {print ""}')
+sudo iptables -A INPUT -s 127.0.0.1,10.0.0.0/8,${SCRAPING_PUBLIC_IPS} -p tcp --dport 9100 -j ACCEPT
 sudo iptables -A INPUT -p tcp --dport 9100 -j DROP
 (
-	chown -R 1000:1000 ${DEFAULT_USER_HOME}/node_exporter && \
 	cd ${DEFAULT_USER_HOME}/node_exporter && \
 	sudo systemd-run --unit node_exporter --same-dir \
 		./node_exporter --collector.systemd --collector.interrupts --collector.processes \
 		--web.listen-address=":9100" \
+		--web.telemetry-path="/metrics"
+)
+
+
+
+# Add and start ebpf_exporter, only authorize scrapping from internal network.
+export ARCH=$(dpkg --print-architecture)
+export DEFAULT_USER_HOME="/home/$(id -nu 1000)"
+mkdir -p ${DEFAULT_USER_HOME}/ebpf_exporter && curl -fsSL \
+	https://storage.googleapis.com/cockroach-test-artifacts/prometheus/ebpf_exporter-2.4.2.linux-${ARCH}.tar.gz |
+	tar zxv --strip-components 1 -C ${DEFAULT_USER_HOME}/ebpf_exporter \
+	&& chown -R 1000:1000 ${DEFAULT_USER_HOME}/ebpf_exporter
+
+export SCRAPING_PUBLIC_IPS=$(dig +short prometheus.testeng.crdb.io | awk '{printf "%s%s",sep,$0; sep=","} END {print ""}')
+sudo iptables -A INPUT -s 127.0.0.1,10.0.0.0/8,${SCRAPING_PUBLIC_IPS} -p tcp --dport 9435 -j ACCEPT
+sudo iptables -A INPUT -p tcp --dport 9435 -j DROP
+(
+	cd ${DEFAULT_USER_HOME}/ebpf_exporter && \
+	sudo systemd-run --unit ebpf_exporter --same-dir \
+		./ebpf_exporter \
+		--config.dir=examples \
+		--config.names=biolatency,timers,sched-trace,syscalls,uprobe \
+		--web.listen-address=":9435" \
 		--web.telemetry-path="/metrics"
 )
 

--- a/pkg/roachprod/vm/gce/utils.go
+++ b/pkg/roachprod/vm/gce/utils.go
@@ -171,6 +171,7 @@ setup_disks true
 {{ template "fips_utils" . }}
 {{ template "ssh_utils" . }}
 {{ template "node_exporter" . }}
+{{ template "ebpf_exporter" .}}
 
 sudo touch {{ .OSInitializedFile }}
 `


### PR DESCRIPTION
Previously, testeng observability was scraping CRDB and node_exporter metrics.

This PR adds ebpf_exporter scraping with the following configurations:
- biolatency
- timers
- sched-trace
- syscalls
- uprobe

Epic: none
Release note: None