### PR TITLE
release-24.3: sql: display retry count and time for EXPLAIN ANALYZE

### DIFF
--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -600,6 +600,9 @@ func (ex *connExecutor) execStmtInOpenState(
 
 	// For pausable portal, the instrumentation helper needs to be set up only
 	// when the portal is executed for the first time.
+	//
+	// This goroutine is the only one that can modify txnState.mu.priority and
+	// txnState.mu.autoRetryCounter, so we don't need to get a mutex here.
 	if !isPausablePortal() || portal.pauseInfo.execStmtInOpenState.ihWrapper == nil {
 		ctx = ih.Setup(
 			ctx, ex.server.cfg, ex.statsCollector, p, ex.stmtDiagnosticsRecorder,
@@ -608,6 +611,7 @@ func (ex *connExecutor) execStmtInOpenState(
 			// txnState.mu.priority, so we don't need to get a mutex here.
 			ex.state.mu.priority,
 			ex.extraTxnState.shouldCollectTxnExecutionStats,
+			ex.state.mu.autoRetryCounter,
 		)
 	} else {
 		ctx = portal.pauseInfo.execStmtInOpenState.ihWrapper.ctx

--- a/pkg/sql/instrumentation.go
+++ b/pkg/sql/instrumentation.go
@@ -213,6 +213,9 @@ type instrumentationHelper struct {
 	// stats scanned by this query.
 	nanosSinceStatsForecasted time.Duration
 
+	// retryCount is the number of times the transaction was retried.
+	retryCount uint64
+
 	// joinTypeCounts records the number of times each type of logical join was
 	// used in the query.
 	joinTypeCounts map[descpb.JoinType]int
@@ -422,10 +425,12 @@ func (ih *instrumentationHelper) Setup(
 	implicitTxn bool,
 	txnPriority roachpb.UserPriority,
 	collectTxnExecStats bool,
+	retryCount int32,
 ) (newCtx context.Context) {
 	ih.fingerprint = fingerprint
 	ih.implicitTxn = implicitTxn
 	ih.txnPriority = txnPriority
+	ih.retryCount = uint64(retryCount)
 	ih.codec = cfg.Codec
 	ih.origCtx = ctx
 	ih.evalCtx = p.EvalContext()
@@ -855,6 +860,8 @@ func (ih *instrumentationHelper) emitExplainAnalyzePlanToOutputBuilder(
 	ob.AddDistribution(ih.distribution.String())
 	ob.AddVectorized(ih.vectorized)
 	ob.AddPlanType(ih.generic, ih.optimized)
+	ob.AddRetryCount(ih.retryCount)
+	ob.AddRetryTime(phaseTimes.GetTransactionRetryLatency())
 
 	if queryStats != nil {
 		if queryStats.KVRowsRead != 0 {

--- a/pkg/sql/opt/exec/explain/output.go
+++ b/pkg/sql/opt/exec/explain/output.go
@@ -373,6 +373,22 @@ func (ob *OutputBuilder) AddContentionTime(contentionTime time.Duration) {
 	)
 }
 
+// AddRetryCount adds a top-level retry-count field. Cannot be called while
+// inside a node.
+func (ob *OutputBuilder) AddRetryCount(count uint64) {
+	if !ob.flags.Deflake.HasAny(DeflakeVolatile) && count > 0 {
+		ob.AddTopLevelField("number of transaction retries", string(humanizeutil.Count(count)))
+	}
+}
+
+// AddRetryTime adds a top-level statement retry time field. Cannot be called
+// while inside a node.
+func (ob *OutputBuilder) AddRetryTime(delta time.Duration) {
+	if !ob.flags.Deflake.HasAny(DeflakeVolatile) && delta > 0 {
+		ob.AddTopLevelField("time spent retrying the transaction", string(humanizeutil.Duration(delta)))
+	}
+}
+
 // AddMaxMemUsage adds a top-level field for the memory used by the query.
 func (ob *OutputBuilder) AddMaxMemUsage(bytes int64) {
 	ob.AddFlakyTopLevelField(

--- a/pkg/sql/opt/exec/explain/output_test.go
+++ b/pkg/sql/opt/exec/explain/output_test.go
@@ -345,3 +345,35 @@ func TestContentionTimeOnWrites(t *testing.T) {
 	// Meat of the test - verify that the contention was reported.
 	require.True(t, foundContention)
 }
+
+func TestRetryFields(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	s, conn, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(ctx)
+
+	sqlDB := sqlutils.MakeSQLRunner(conn)
+	sqlDB.Exec(t, "CREATE SEQUENCE s")
+
+	retryCountRE := regexp.MustCompile(`number of transaction retries: (\d+)`)
+	retryTimeRE := regexp.MustCompile(`time spent retrying the transaction: (\d+)[µsm]+`)
+	queryMatchRE := func(query string) bool {
+		rows, err := conn.QueryContext(ctx, query)
+		assert.NoError(t, err)
+		var foundCount, foundTime bool
+		for rows.Next() {
+			var res string
+			assert.NoError(t, rows.Scan(&res))
+			if matches := retryCountRE.FindStringSubmatch(res); len(matches) > 0 {
+				foundCount = true
+			}
+			if matches := retryTimeRE.FindStringSubmatch(res); len(matches) > 0 {
+				foundTime = true
+			}
+		}
+		return foundCount && foundTime
+	}
+	assert.True(t, queryMatchRE("EXPLAIN ANALYZE SELECT IF(nextval('s')<=3, crdb_internal.force_retry('1h'::INTERVAL), 0)"))
+}


### PR DESCRIPTION
Backport 1/1 commits from #142692.

/cc @cockroachdb/release

---

This commit adds two new top-level fields to the plan output of `EXPLAIN ANALYZE` displaying the number of transaction retries and cumulative time spent due to the retries. This will help make retries more visible when debugging poor performance via statement bundle.

Fixes #142674

Release note (sql change): EXPLAIN ANALYZE statements now display the number of transaction retries and time spent retrying as part of the plan output.

---

Release justification: observability improvement