### PR TITLE
builtins,eval: fix `width_bucket()` and `power()` edge cases to match postgres

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -1157,7 +1157,7 @@ available replica will error.</p>
 </span></td><td>Leakproof</td></tr>
 <tr><td><a name="fnv64a"></a><code>fnv64a(<a href="string.html">string</a>...) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>Calculates the 64-bit FNV-1a hash value of a set of values.</p>
 </span></td><td>Leakproof</td></tr>
-<tr><td><a name="width_bucket"></a><code>width_bucket(operand: <a href="decimal.html">decimal</a>, b1: <a href="decimal.html">decimal</a>, b2: <a href="decimal.html">decimal</a>, count: <a href="int.html">int</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>return the bucket number to which operand would be assigned in a histogram having count equal-width buckets spanning the range b1 to b2.</p>
+<tr><td><a name="width_bucket"></a><code>width_bucket(operand: <a href="decimal.html">decimal</a>, b1: <a href="decimal.html">decimal</a>, b2: <a href="decimal.html">decimal</a>, count: <a href="int.html">int</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>return the bucket number to which operand would be assigned in a histogram having count equal-width buckets spanning the range b1 to b2. Returns 0 or count+1 for an input outside that range.</p>
 </span></td><td>Immutable</td></tr>
 <tr><td><a name="width_bucket"></a><code>width_bucket(operand: <a href="int.html">int</a>, b1: <a href="int.html">int</a>, b2: <a href="int.html">int</a>, count: <a href="int.html">int</a>) &rarr; <a href="int.html">int</a></code></td><td><span class="funcdesc"><p>return the bucket number to which operand would be assigned in a histogram having count equal-width buckets spanning the range b1 to b2.</p>
 </span></td><td>Immutable</td></tr>

--- a/pkg/sql/colexec/colexecproj/proj_non_const_ops.eg.go
+++ b/pkg/sql/colexec/colexecproj/proj_non_const_ops.eg.go
@@ -18914,7 +18914,7 @@ func (p projPowDecimalInt16Op) Next() coldata.Batch {
 
 							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							if _, err := tree.DecimalCtx.Pow(&projCol[i], &arg1, &tmpDec); err != nil {
+							if err := eval.DecimalPow(tree.DecimalCtx, &projCol[i], &arg1, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -18938,7 +18938,7 @@ func (p projPowDecimalInt16Op) Next() coldata.Batch {
 
 							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							if _, err := tree.DecimalCtx.Pow(&projCol[i], &arg1, &tmpDec); err != nil {
+							if err := eval.DecimalPow(tree.DecimalCtx, &projCol[i], &arg1, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -18958,7 +18958,7 @@ func (p projPowDecimalInt16Op) Next() coldata.Batch {
 
 						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg2))
-						if _, err := tree.DecimalCtx.Pow(&projCol[i], &arg1, &tmpDec); err != nil {
+						if err := eval.DecimalPow(tree.DecimalCtx, &projCol[i], &arg1, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -18978,7 +18978,7 @@ func (p projPowDecimalInt16Op) Next() coldata.Batch {
 
 						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg2))
-						if _, err := tree.DecimalCtx.Pow(&projCol[i], &arg1, &tmpDec); err != nil {
+						if err := eval.DecimalPow(tree.DecimalCtx, &projCol[i], &arg1, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -19024,7 +19024,7 @@ func (p projPowDecimalInt32Op) Next() coldata.Batch {
 
 							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							if _, err := tree.DecimalCtx.Pow(&projCol[i], &arg1, &tmpDec); err != nil {
+							if err := eval.DecimalPow(tree.DecimalCtx, &projCol[i], &arg1, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -19048,7 +19048,7 @@ func (p projPowDecimalInt32Op) Next() coldata.Batch {
 
 							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							if _, err := tree.DecimalCtx.Pow(&projCol[i], &arg1, &tmpDec); err != nil {
+							if err := eval.DecimalPow(tree.DecimalCtx, &projCol[i], &arg1, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -19068,7 +19068,7 @@ func (p projPowDecimalInt32Op) Next() coldata.Batch {
 
 						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg2))
-						if _, err := tree.DecimalCtx.Pow(&projCol[i], &arg1, &tmpDec); err != nil {
+						if err := eval.DecimalPow(tree.DecimalCtx, &projCol[i], &arg1, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -19088,7 +19088,7 @@ func (p projPowDecimalInt32Op) Next() coldata.Batch {
 
 						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg2))
-						if _, err := tree.DecimalCtx.Pow(&projCol[i], &arg1, &tmpDec); err != nil {
+						if err := eval.DecimalPow(tree.DecimalCtx, &projCol[i], &arg1, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -19134,7 +19134,7 @@ func (p projPowDecimalInt64Op) Next() coldata.Batch {
 
 							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							if _, err := tree.DecimalCtx.Pow(&projCol[i], &arg1, &tmpDec); err != nil {
+							if err := eval.DecimalPow(tree.DecimalCtx, &projCol[i], &arg1, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -19158,7 +19158,7 @@ func (p projPowDecimalInt64Op) Next() coldata.Batch {
 
 							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg2))
-							if _, err := tree.DecimalCtx.Pow(&projCol[i], &arg1, &tmpDec); err != nil {
+							if err := eval.DecimalPow(tree.DecimalCtx, &projCol[i], &arg1, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -19178,7 +19178,7 @@ func (p projPowDecimalInt64Op) Next() coldata.Batch {
 
 						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg2))
-						if _, err := tree.DecimalCtx.Pow(&projCol[i], &arg1, &tmpDec); err != nil {
+						if err := eval.DecimalPow(tree.DecimalCtx, &projCol[i], &arg1, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -19198,7 +19198,7 @@ func (p projPowDecimalInt64Op) Next() coldata.Batch {
 
 						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg2))
-						if _, err := tree.DecimalCtx.Pow(&projCol[i], &arg1, &tmpDec); err != nil {
+						if err := eval.DecimalPow(tree.DecimalCtx, &projCol[i], &arg1, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -19242,7 +19242,7 @@ func (p projPowDecimalDecimalOp) Next() coldata.Batch {
 
 						{
 
-							_, err := tree.DecimalCtx.Pow(&projCol[i], &arg1, &arg2)
+							err := eval.DecimalPow(tree.DecimalCtx, &projCol[i], &arg1, &arg2)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -19266,7 +19266,7 @@ func (p projPowDecimalDecimalOp) Next() coldata.Batch {
 
 						{
 
-							_, err := tree.DecimalCtx.Pow(&projCol[i], &arg1, &arg2)
+							err := eval.DecimalPow(tree.DecimalCtx, &projCol[i], &arg1, &arg2)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -19286,7 +19286,7 @@ func (p projPowDecimalDecimalOp) Next() coldata.Batch {
 
 					{
 
-						_, err := tree.DecimalCtx.Pow(&projCol[i], &arg1, &arg2)
+						err := eval.DecimalPow(tree.DecimalCtx, &projCol[i], &arg1, &arg2)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -19306,7 +19306,7 @@ func (p projPowDecimalDecimalOp) Next() coldata.Batch {
 
 					{
 
-						_, err := tree.DecimalCtx.Pow(&projCol[i], &arg1, &arg2)
+						err := eval.DecimalPow(tree.DecimalCtx, &projCol[i], &arg1, &arg2)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -19354,7 +19354,7 @@ func (p projPowInt16Int16Op) Next() coldata.Batch {
 							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg1)))
 							rightTmpDec.SetInt64(int64(int64(arg2)))
-							if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
+							if err := eval.DecimalPow(tree.DecimalCtx, &leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 							resultInt, err := leftTmpDec.Int64()
@@ -19383,7 +19383,7 @@ func (p projPowInt16Int16Op) Next() coldata.Batch {
 							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg1)))
 							rightTmpDec.SetInt64(int64(int64(arg2)))
-							if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
+							if err := eval.DecimalPow(tree.DecimalCtx, &leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 							resultInt, err := leftTmpDec.Int64()
@@ -19408,7 +19408,7 @@ func (p projPowInt16Int16Op) Next() coldata.Batch {
 						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg1)))
 						rightTmpDec.SetInt64(int64(int64(arg2)))
-						if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
+						if err := eval.DecimalPow(tree.DecimalCtx, &leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 						resultInt, err := leftTmpDec.Int64()
@@ -19433,7 +19433,7 @@ func (p projPowInt16Int16Op) Next() coldata.Batch {
 						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg1)))
 						rightTmpDec.SetInt64(int64(int64(arg2)))
-						if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
+						if err := eval.DecimalPow(tree.DecimalCtx, &leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 						resultInt, err := leftTmpDec.Int64()
@@ -19484,7 +19484,7 @@ func (p projPowInt16Int32Op) Next() coldata.Batch {
 							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg1)))
 							rightTmpDec.SetInt64(int64(int64(arg2)))
-							if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
+							if err := eval.DecimalPow(tree.DecimalCtx, &leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 							resultInt, err := leftTmpDec.Int64()
@@ -19513,7 +19513,7 @@ func (p projPowInt16Int32Op) Next() coldata.Batch {
 							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg1)))
 							rightTmpDec.SetInt64(int64(int64(arg2)))
-							if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
+							if err := eval.DecimalPow(tree.DecimalCtx, &leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 							resultInt, err := leftTmpDec.Int64()
@@ -19538,7 +19538,7 @@ func (p projPowInt16Int32Op) Next() coldata.Batch {
 						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg1)))
 						rightTmpDec.SetInt64(int64(int64(arg2)))
-						if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
+						if err := eval.DecimalPow(tree.DecimalCtx, &leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 						resultInt, err := leftTmpDec.Int64()
@@ -19563,7 +19563,7 @@ func (p projPowInt16Int32Op) Next() coldata.Batch {
 						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg1)))
 						rightTmpDec.SetInt64(int64(int64(arg2)))
-						if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
+						if err := eval.DecimalPow(tree.DecimalCtx, &leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 						resultInt, err := leftTmpDec.Int64()
@@ -19614,7 +19614,7 @@ func (p projPowInt16Int64Op) Next() coldata.Batch {
 							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg1)))
 							rightTmpDec.SetInt64(int64(int64(arg2)))
-							if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
+							if err := eval.DecimalPow(tree.DecimalCtx, &leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 							resultInt, err := leftTmpDec.Int64()
@@ -19643,7 +19643,7 @@ func (p projPowInt16Int64Op) Next() coldata.Batch {
 							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg1)))
 							rightTmpDec.SetInt64(int64(int64(arg2)))
-							if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
+							if err := eval.DecimalPow(tree.DecimalCtx, &leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 							resultInt, err := leftTmpDec.Int64()
@@ -19668,7 +19668,7 @@ func (p projPowInt16Int64Op) Next() coldata.Batch {
 						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg1)))
 						rightTmpDec.SetInt64(int64(int64(arg2)))
-						if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
+						if err := eval.DecimalPow(tree.DecimalCtx, &leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 						resultInt, err := leftTmpDec.Int64()
@@ -19693,7 +19693,7 @@ func (p projPowInt16Int64Op) Next() coldata.Batch {
 						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg1)))
 						rightTmpDec.SetInt64(int64(int64(arg2)))
-						if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
+						if err := eval.DecimalPow(tree.DecimalCtx, &leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 						resultInt, err := leftTmpDec.Int64()
@@ -19744,7 +19744,7 @@ func (p projPowInt16DecimalOp) Next() coldata.Batch {
 
 							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							_, err := tree.DecimalCtx.Pow(&projCol[i], &tmpDec, &arg2)
+							err := eval.DecimalPow(tree.DecimalCtx, &projCol[i], &tmpDec, &arg2)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -19770,7 +19770,7 @@ func (p projPowInt16DecimalOp) Next() coldata.Batch {
 
 							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							_, err := tree.DecimalCtx.Pow(&projCol[i], &tmpDec, &arg2)
+							err := eval.DecimalPow(tree.DecimalCtx, &projCol[i], &tmpDec, &arg2)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -19792,7 +19792,7 @@ func (p projPowInt16DecimalOp) Next() coldata.Batch {
 
 						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg1))
-						_, err := tree.DecimalCtx.Pow(&projCol[i], &tmpDec, &arg2)
+						err := eval.DecimalPow(tree.DecimalCtx, &projCol[i], &tmpDec, &arg2)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -19814,7 +19814,7 @@ func (p projPowInt16DecimalOp) Next() coldata.Batch {
 
 						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg1))
-						_, err := tree.DecimalCtx.Pow(&projCol[i], &tmpDec, &arg2)
+						err := eval.DecimalPow(tree.DecimalCtx, &projCol[i], &tmpDec, &arg2)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -19862,7 +19862,7 @@ func (p projPowInt32Int16Op) Next() coldata.Batch {
 							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg1)))
 							rightTmpDec.SetInt64(int64(int64(arg2)))
-							if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
+							if err := eval.DecimalPow(tree.DecimalCtx, &leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 							resultInt, err := leftTmpDec.Int64()
@@ -19891,7 +19891,7 @@ func (p projPowInt32Int16Op) Next() coldata.Batch {
 							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg1)))
 							rightTmpDec.SetInt64(int64(int64(arg2)))
-							if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
+							if err := eval.DecimalPow(tree.DecimalCtx, &leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 							resultInt, err := leftTmpDec.Int64()
@@ -19916,7 +19916,7 @@ func (p projPowInt32Int16Op) Next() coldata.Batch {
 						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg1)))
 						rightTmpDec.SetInt64(int64(int64(arg2)))
-						if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
+						if err := eval.DecimalPow(tree.DecimalCtx, &leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 						resultInt, err := leftTmpDec.Int64()
@@ -19941,7 +19941,7 @@ func (p projPowInt32Int16Op) Next() coldata.Batch {
 						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg1)))
 						rightTmpDec.SetInt64(int64(int64(arg2)))
-						if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
+						if err := eval.DecimalPow(tree.DecimalCtx, &leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 						resultInt, err := leftTmpDec.Int64()
@@ -19992,7 +19992,7 @@ func (p projPowInt32Int32Op) Next() coldata.Batch {
 							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg1)))
 							rightTmpDec.SetInt64(int64(int64(arg2)))
-							if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
+							if err := eval.DecimalPow(tree.DecimalCtx, &leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 							resultInt, err := leftTmpDec.Int64()
@@ -20021,7 +20021,7 @@ func (p projPowInt32Int32Op) Next() coldata.Batch {
 							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg1)))
 							rightTmpDec.SetInt64(int64(int64(arg2)))
-							if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
+							if err := eval.DecimalPow(tree.DecimalCtx, &leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 							resultInt, err := leftTmpDec.Int64()
@@ -20046,7 +20046,7 @@ func (p projPowInt32Int32Op) Next() coldata.Batch {
 						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg1)))
 						rightTmpDec.SetInt64(int64(int64(arg2)))
-						if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
+						if err := eval.DecimalPow(tree.DecimalCtx, &leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 						resultInt, err := leftTmpDec.Int64()
@@ -20071,7 +20071,7 @@ func (p projPowInt32Int32Op) Next() coldata.Batch {
 						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg1)))
 						rightTmpDec.SetInt64(int64(int64(arg2)))
-						if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
+						if err := eval.DecimalPow(tree.DecimalCtx, &leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 						resultInt, err := leftTmpDec.Int64()
@@ -20122,7 +20122,7 @@ func (p projPowInt32Int64Op) Next() coldata.Batch {
 							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg1)))
 							rightTmpDec.SetInt64(int64(int64(arg2)))
-							if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
+							if err := eval.DecimalPow(tree.DecimalCtx, &leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 							resultInt, err := leftTmpDec.Int64()
@@ -20151,7 +20151,7 @@ func (p projPowInt32Int64Op) Next() coldata.Batch {
 							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg1)))
 							rightTmpDec.SetInt64(int64(int64(arg2)))
-							if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
+							if err := eval.DecimalPow(tree.DecimalCtx, &leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 							resultInt, err := leftTmpDec.Int64()
@@ -20176,7 +20176,7 @@ func (p projPowInt32Int64Op) Next() coldata.Batch {
 						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg1)))
 						rightTmpDec.SetInt64(int64(int64(arg2)))
-						if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
+						if err := eval.DecimalPow(tree.DecimalCtx, &leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 						resultInt, err := leftTmpDec.Int64()
@@ -20201,7 +20201,7 @@ func (p projPowInt32Int64Op) Next() coldata.Batch {
 						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg1)))
 						rightTmpDec.SetInt64(int64(int64(arg2)))
-						if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
+						if err := eval.DecimalPow(tree.DecimalCtx, &leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 						resultInt, err := leftTmpDec.Int64()
@@ -20252,7 +20252,7 @@ func (p projPowInt32DecimalOp) Next() coldata.Batch {
 
 							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							_, err := tree.DecimalCtx.Pow(&projCol[i], &tmpDec, &arg2)
+							err := eval.DecimalPow(tree.DecimalCtx, &projCol[i], &tmpDec, &arg2)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -20278,7 +20278,7 @@ func (p projPowInt32DecimalOp) Next() coldata.Batch {
 
 							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							_, err := tree.DecimalCtx.Pow(&projCol[i], &tmpDec, &arg2)
+							err := eval.DecimalPow(tree.DecimalCtx, &projCol[i], &tmpDec, &arg2)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -20300,7 +20300,7 @@ func (p projPowInt32DecimalOp) Next() coldata.Batch {
 
 						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg1))
-						_, err := tree.DecimalCtx.Pow(&projCol[i], &tmpDec, &arg2)
+						err := eval.DecimalPow(tree.DecimalCtx, &projCol[i], &tmpDec, &arg2)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -20322,7 +20322,7 @@ func (p projPowInt32DecimalOp) Next() coldata.Batch {
 
 						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg1))
-						_, err := tree.DecimalCtx.Pow(&projCol[i], &tmpDec, &arg2)
+						err := eval.DecimalPow(tree.DecimalCtx, &projCol[i], &tmpDec, &arg2)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -20370,7 +20370,7 @@ func (p projPowInt64Int16Op) Next() coldata.Batch {
 							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg1)))
 							rightTmpDec.SetInt64(int64(int64(arg2)))
-							if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
+							if err := eval.DecimalPow(tree.DecimalCtx, &leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 							resultInt, err := leftTmpDec.Int64()
@@ -20399,7 +20399,7 @@ func (p projPowInt64Int16Op) Next() coldata.Batch {
 							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg1)))
 							rightTmpDec.SetInt64(int64(int64(arg2)))
-							if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
+							if err := eval.DecimalPow(tree.DecimalCtx, &leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 							resultInt, err := leftTmpDec.Int64()
@@ -20424,7 +20424,7 @@ func (p projPowInt64Int16Op) Next() coldata.Batch {
 						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg1)))
 						rightTmpDec.SetInt64(int64(int64(arg2)))
-						if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
+						if err := eval.DecimalPow(tree.DecimalCtx, &leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 						resultInt, err := leftTmpDec.Int64()
@@ -20449,7 +20449,7 @@ func (p projPowInt64Int16Op) Next() coldata.Batch {
 						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg1)))
 						rightTmpDec.SetInt64(int64(int64(arg2)))
-						if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
+						if err := eval.DecimalPow(tree.DecimalCtx, &leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 						resultInt, err := leftTmpDec.Int64()
@@ -20500,7 +20500,7 @@ func (p projPowInt64Int32Op) Next() coldata.Batch {
 							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg1)))
 							rightTmpDec.SetInt64(int64(int64(arg2)))
-							if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
+							if err := eval.DecimalPow(tree.DecimalCtx, &leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 							resultInt, err := leftTmpDec.Int64()
@@ -20529,7 +20529,7 @@ func (p projPowInt64Int32Op) Next() coldata.Batch {
 							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg1)))
 							rightTmpDec.SetInt64(int64(int64(arg2)))
-							if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
+							if err := eval.DecimalPow(tree.DecimalCtx, &leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 							resultInt, err := leftTmpDec.Int64()
@@ -20554,7 +20554,7 @@ func (p projPowInt64Int32Op) Next() coldata.Batch {
 						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg1)))
 						rightTmpDec.SetInt64(int64(int64(arg2)))
-						if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
+						if err := eval.DecimalPow(tree.DecimalCtx, &leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 						resultInt, err := leftTmpDec.Int64()
@@ -20579,7 +20579,7 @@ func (p projPowInt64Int32Op) Next() coldata.Batch {
 						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg1)))
 						rightTmpDec.SetInt64(int64(int64(arg2)))
-						if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
+						if err := eval.DecimalPow(tree.DecimalCtx, &leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 						resultInt, err := leftTmpDec.Int64()
@@ -20630,7 +20630,7 @@ func (p projPowInt64Int64Op) Next() coldata.Batch {
 							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg1)))
 							rightTmpDec.SetInt64(int64(int64(arg2)))
-							if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
+							if err := eval.DecimalPow(tree.DecimalCtx, &leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 							resultInt, err := leftTmpDec.Int64()
@@ -20659,7 +20659,7 @@ func (p projPowInt64Int64Op) Next() coldata.Batch {
 							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg1)))
 							rightTmpDec.SetInt64(int64(int64(arg2)))
-							if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
+							if err := eval.DecimalPow(tree.DecimalCtx, &leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 							resultInt, err := leftTmpDec.Int64()
@@ -20684,7 +20684,7 @@ func (p projPowInt64Int64Op) Next() coldata.Batch {
 						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg1)))
 						rightTmpDec.SetInt64(int64(int64(arg2)))
-						if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
+						if err := eval.DecimalPow(tree.DecimalCtx, &leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 						resultInt, err := leftTmpDec.Int64()
@@ -20709,7 +20709,7 @@ func (p projPowInt64Int64Op) Next() coldata.Batch {
 						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg1)))
 						rightTmpDec.SetInt64(int64(int64(arg2)))
-						if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
+						if err := eval.DecimalPow(tree.DecimalCtx, &leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 						resultInt, err := leftTmpDec.Int64()
@@ -20760,7 +20760,7 @@ func (p projPowInt64DecimalOp) Next() coldata.Batch {
 
 							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							_, err := tree.DecimalCtx.Pow(&projCol[i], &tmpDec, &arg2)
+							err := eval.DecimalPow(tree.DecimalCtx, &projCol[i], &tmpDec, &arg2)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -20786,7 +20786,7 @@ func (p projPowInt64DecimalOp) Next() coldata.Batch {
 
 							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg1))
-							_, err := tree.DecimalCtx.Pow(&projCol[i], &tmpDec, &arg2)
+							err := eval.DecimalPow(tree.DecimalCtx, &projCol[i], &tmpDec, &arg2)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -20808,7 +20808,7 @@ func (p projPowInt64DecimalOp) Next() coldata.Batch {
 
 						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg1))
-						_, err := tree.DecimalCtx.Pow(&projCol[i], &tmpDec, &arg2)
+						err := eval.DecimalPow(tree.DecimalCtx, &projCol[i], &tmpDec, &arg2)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -20830,7 +20830,7 @@ func (p projPowInt64DecimalOp) Next() coldata.Batch {
 
 						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg1))
-						_, err := tree.DecimalCtx.Pow(&projCol[i], &tmpDec, &arg2)
+						err := eval.DecimalPow(tree.DecimalCtx, &projCol[i], &tmpDec, &arg2)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}

--- a/pkg/sql/colexec/colexecprojconst/proj_const_left_ops.eg.go
+++ b/pkg/sql/colexec/colexecprojconst/proj_const_left_ops.eg.go
@@ -17515,7 +17515,7 @@ func (p projPowDecimalConstInt16Op) Next() coldata.Batch {
 
 							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							if _, err := tree.DecimalCtx.Pow(&projCol[i], &p.constArg, &tmpDec); err != nil {
+							if err := eval.DecimalPow(tree.DecimalCtx, &projCol[i], &p.constArg, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -17535,7 +17535,7 @@ func (p projPowDecimalConstInt16Op) Next() coldata.Batch {
 
 							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							if _, err := tree.DecimalCtx.Pow(&projCol[i], &p.constArg, &tmpDec); err != nil {
+							if err := eval.DecimalPow(tree.DecimalCtx, &projCol[i], &p.constArg, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -17554,7 +17554,7 @@ func (p projPowDecimalConstInt16Op) Next() coldata.Batch {
 
 						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg))
-						if _, err := tree.DecimalCtx.Pow(&projCol[i], &p.constArg, &tmpDec); err != nil {
+						if err := eval.DecimalPow(tree.DecimalCtx, &projCol[i], &p.constArg, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -17571,7 +17571,7 @@ func (p projPowDecimalConstInt16Op) Next() coldata.Batch {
 
 						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg))
-						if _, err := tree.DecimalCtx.Pow(&projCol[i], &p.constArg, &tmpDec); err != nil {
+						if err := eval.DecimalPow(tree.DecimalCtx, &projCol[i], &p.constArg, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -17617,7 +17617,7 @@ func (p projPowDecimalConstInt32Op) Next() coldata.Batch {
 
 							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							if _, err := tree.DecimalCtx.Pow(&projCol[i], &p.constArg, &tmpDec); err != nil {
+							if err := eval.DecimalPow(tree.DecimalCtx, &projCol[i], &p.constArg, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -17637,7 +17637,7 @@ func (p projPowDecimalConstInt32Op) Next() coldata.Batch {
 
 							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							if _, err := tree.DecimalCtx.Pow(&projCol[i], &p.constArg, &tmpDec); err != nil {
+							if err := eval.DecimalPow(tree.DecimalCtx, &projCol[i], &p.constArg, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -17656,7 +17656,7 @@ func (p projPowDecimalConstInt32Op) Next() coldata.Batch {
 
 						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg))
-						if _, err := tree.DecimalCtx.Pow(&projCol[i], &p.constArg, &tmpDec); err != nil {
+						if err := eval.DecimalPow(tree.DecimalCtx, &projCol[i], &p.constArg, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -17673,7 +17673,7 @@ func (p projPowDecimalConstInt32Op) Next() coldata.Batch {
 
 						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg))
-						if _, err := tree.DecimalCtx.Pow(&projCol[i], &p.constArg, &tmpDec); err != nil {
+						if err := eval.DecimalPow(tree.DecimalCtx, &projCol[i], &p.constArg, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -17719,7 +17719,7 @@ func (p projPowDecimalConstInt64Op) Next() coldata.Batch {
 
 							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							if _, err := tree.DecimalCtx.Pow(&projCol[i], &p.constArg, &tmpDec); err != nil {
+							if err := eval.DecimalPow(tree.DecimalCtx, &projCol[i], &p.constArg, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -17739,7 +17739,7 @@ func (p projPowDecimalConstInt64Op) Next() coldata.Batch {
 
 							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							if _, err := tree.DecimalCtx.Pow(&projCol[i], &p.constArg, &tmpDec); err != nil {
+							if err := eval.DecimalPow(tree.DecimalCtx, &projCol[i], &p.constArg, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -17758,7 +17758,7 @@ func (p projPowDecimalConstInt64Op) Next() coldata.Batch {
 
 						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg))
-						if _, err := tree.DecimalCtx.Pow(&projCol[i], &p.constArg, &tmpDec); err != nil {
+						if err := eval.DecimalPow(tree.DecimalCtx, &projCol[i], &p.constArg, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -17775,7 +17775,7 @@ func (p projPowDecimalConstInt64Op) Next() coldata.Batch {
 
 						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg))
-						if _, err := tree.DecimalCtx.Pow(&projCol[i], &p.constArg, &tmpDec); err != nil {
+						if err := eval.DecimalPow(tree.DecimalCtx, &projCol[i], &p.constArg, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -17819,7 +17819,7 @@ func (p projPowDecimalConstDecimalOp) Next() coldata.Batch {
 
 						{
 
-							_, err := tree.DecimalCtx.Pow(&projCol[i], &p.constArg, &arg)
+							err := eval.DecimalPow(tree.DecimalCtx, &projCol[i], &p.constArg, &arg)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -17839,7 +17839,7 @@ func (p projPowDecimalConstDecimalOp) Next() coldata.Batch {
 
 						{
 
-							_, err := tree.DecimalCtx.Pow(&projCol[i], &p.constArg, &arg)
+							err := eval.DecimalPow(tree.DecimalCtx, &projCol[i], &p.constArg, &arg)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -17858,7 +17858,7 @@ func (p projPowDecimalConstDecimalOp) Next() coldata.Batch {
 
 					{
 
-						_, err := tree.DecimalCtx.Pow(&projCol[i], &p.constArg, &arg)
+						err := eval.DecimalPow(tree.DecimalCtx, &projCol[i], &p.constArg, &arg)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -17875,7 +17875,7 @@ func (p projPowDecimalConstDecimalOp) Next() coldata.Batch {
 
 					{
 
-						_, err := tree.DecimalCtx.Pow(&projCol[i], &p.constArg, &arg)
+						err := eval.DecimalPow(tree.DecimalCtx, &projCol[i], &p.constArg, &arg)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -17923,7 +17923,7 @@ func (p projPowInt16ConstInt16Op) Next() coldata.Batch {
 							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(p.constArg)))
 							rightTmpDec.SetInt64(int64(int64(arg)))
-							if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
+							if err := eval.DecimalPow(tree.DecimalCtx, &leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 							resultInt, err := leftTmpDec.Int64()
@@ -17948,7 +17948,7 @@ func (p projPowInt16ConstInt16Op) Next() coldata.Batch {
 							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(p.constArg)))
 							rightTmpDec.SetInt64(int64(int64(arg)))
-							if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
+							if err := eval.DecimalPow(tree.DecimalCtx, &leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 							resultInt, err := leftTmpDec.Int64()
@@ -17972,7 +17972,7 @@ func (p projPowInt16ConstInt16Op) Next() coldata.Batch {
 						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(p.constArg)))
 						rightTmpDec.SetInt64(int64(int64(arg)))
-						if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
+						if err := eval.DecimalPow(tree.DecimalCtx, &leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 						resultInt, err := leftTmpDec.Int64()
@@ -17994,7 +17994,7 @@ func (p projPowInt16ConstInt16Op) Next() coldata.Batch {
 						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(p.constArg)))
 						rightTmpDec.SetInt64(int64(int64(arg)))
-						if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
+						if err := eval.DecimalPow(tree.DecimalCtx, &leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 						resultInt, err := leftTmpDec.Int64()
@@ -18045,7 +18045,7 @@ func (p projPowInt16ConstInt32Op) Next() coldata.Batch {
 							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(p.constArg)))
 							rightTmpDec.SetInt64(int64(int64(arg)))
-							if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
+							if err := eval.DecimalPow(tree.DecimalCtx, &leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 							resultInt, err := leftTmpDec.Int64()
@@ -18070,7 +18070,7 @@ func (p projPowInt16ConstInt32Op) Next() coldata.Batch {
 							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(p.constArg)))
 							rightTmpDec.SetInt64(int64(int64(arg)))
-							if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
+							if err := eval.DecimalPow(tree.DecimalCtx, &leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 							resultInt, err := leftTmpDec.Int64()
@@ -18094,7 +18094,7 @@ func (p projPowInt16ConstInt32Op) Next() coldata.Batch {
 						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(p.constArg)))
 						rightTmpDec.SetInt64(int64(int64(arg)))
-						if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
+						if err := eval.DecimalPow(tree.DecimalCtx, &leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 						resultInt, err := leftTmpDec.Int64()
@@ -18116,7 +18116,7 @@ func (p projPowInt16ConstInt32Op) Next() coldata.Batch {
 						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(p.constArg)))
 						rightTmpDec.SetInt64(int64(int64(arg)))
-						if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
+						if err := eval.DecimalPow(tree.DecimalCtx, &leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 						resultInt, err := leftTmpDec.Int64()
@@ -18167,7 +18167,7 @@ func (p projPowInt16ConstInt64Op) Next() coldata.Batch {
 							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(p.constArg)))
 							rightTmpDec.SetInt64(int64(int64(arg)))
-							if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
+							if err := eval.DecimalPow(tree.DecimalCtx, &leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 							resultInt, err := leftTmpDec.Int64()
@@ -18192,7 +18192,7 @@ func (p projPowInt16ConstInt64Op) Next() coldata.Batch {
 							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(p.constArg)))
 							rightTmpDec.SetInt64(int64(int64(arg)))
-							if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
+							if err := eval.DecimalPow(tree.DecimalCtx, &leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 							resultInt, err := leftTmpDec.Int64()
@@ -18216,7 +18216,7 @@ func (p projPowInt16ConstInt64Op) Next() coldata.Batch {
 						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(p.constArg)))
 						rightTmpDec.SetInt64(int64(int64(arg)))
-						if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
+						if err := eval.DecimalPow(tree.DecimalCtx, &leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 						resultInt, err := leftTmpDec.Int64()
@@ -18238,7 +18238,7 @@ func (p projPowInt16ConstInt64Op) Next() coldata.Batch {
 						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(p.constArg)))
 						rightTmpDec.SetInt64(int64(int64(arg)))
-						if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
+						if err := eval.DecimalPow(tree.DecimalCtx, &leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 						resultInt, err := leftTmpDec.Int64()
@@ -18289,7 +18289,7 @@ func (p projPowInt16ConstDecimalOp) Next() coldata.Batch {
 
 							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							_, err := tree.DecimalCtx.Pow(&projCol[i], &tmpDec, &arg)
+							err := eval.DecimalPow(tree.DecimalCtx, &projCol[i], &tmpDec, &arg)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -18311,7 +18311,7 @@ func (p projPowInt16ConstDecimalOp) Next() coldata.Batch {
 
 							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							_, err := tree.DecimalCtx.Pow(&projCol[i], &tmpDec, &arg)
+							err := eval.DecimalPow(tree.DecimalCtx, &projCol[i], &tmpDec, &arg)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -18332,7 +18332,7 @@ func (p projPowInt16ConstDecimalOp) Next() coldata.Batch {
 
 						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(p.constArg))
-						_, err := tree.DecimalCtx.Pow(&projCol[i], &tmpDec, &arg)
+						err := eval.DecimalPow(tree.DecimalCtx, &projCol[i], &tmpDec, &arg)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -18351,7 +18351,7 @@ func (p projPowInt16ConstDecimalOp) Next() coldata.Batch {
 
 						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(p.constArg))
-						_, err := tree.DecimalCtx.Pow(&projCol[i], &tmpDec, &arg)
+						err := eval.DecimalPow(tree.DecimalCtx, &projCol[i], &tmpDec, &arg)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -18399,7 +18399,7 @@ func (p projPowInt32ConstInt16Op) Next() coldata.Batch {
 							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(p.constArg)))
 							rightTmpDec.SetInt64(int64(int64(arg)))
-							if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
+							if err := eval.DecimalPow(tree.DecimalCtx, &leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 							resultInt, err := leftTmpDec.Int64()
@@ -18424,7 +18424,7 @@ func (p projPowInt32ConstInt16Op) Next() coldata.Batch {
 							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(p.constArg)))
 							rightTmpDec.SetInt64(int64(int64(arg)))
-							if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
+							if err := eval.DecimalPow(tree.DecimalCtx, &leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 							resultInt, err := leftTmpDec.Int64()
@@ -18448,7 +18448,7 @@ func (p projPowInt32ConstInt16Op) Next() coldata.Batch {
 						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(p.constArg)))
 						rightTmpDec.SetInt64(int64(int64(arg)))
-						if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
+						if err := eval.DecimalPow(tree.DecimalCtx, &leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 						resultInt, err := leftTmpDec.Int64()
@@ -18470,7 +18470,7 @@ func (p projPowInt32ConstInt16Op) Next() coldata.Batch {
 						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(p.constArg)))
 						rightTmpDec.SetInt64(int64(int64(arg)))
-						if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
+						if err := eval.DecimalPow(tree.DecimalCtx, &leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 						resultInt, err := leftTmpDec.Int64()
@@ -18521,7 +18521,7 @@ func (p projPowInt32ConstInt32Op) Next() coldata.Batch {
 							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(p.constArg)))
 							rightTmpDec.SetInt64(int64(int64(arg)))
-							if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
+							if err := eval.DecimalPow(tree.DecimalCtx, &leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 							resultInt, err := leftTmpDec.Int64()
@@ -18546,7 +18546,7 @@ func (p projPowInt32ConstInt32Op) Next() coldata.Batch {
 							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(p.constArg)))
 							rightTmpDec.SetInt64(int64(int64(arg)))
-							if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
+							if err := eval.DecimalPow(tree.DecimalCtx, &leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 							resultInt, err := leftTmpDec.Int64()
@@ -18570,7 +18570,7 @@ func (p projPowInt32ConstInt32Op) Next() coldata.Batch {
 						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(p.constArg)))
 						rightTmpDec.SetInt64(int64(int64(arg)))
-						if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
+						if err := eval.DecimalPow(tree.DecimalCtx, &leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 						resultInt, err := leftTmpDec.Int64()
@@ -18592,7 +18592,7 @@ func (p projPowInt32ConstInt32Op) Next() coldata.Batch {
 						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(p.constArg)))
 						rightTmpDec.SetInt64(int64(int64(arg)))
-						if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
+						if err := eval.DecimalPow(tree.DecimalCtx, &leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 						resultInt, err := leftTmpDec.Int64()
@@ -18643,7 +18643,7 @@ func (p projPowInt32ConstInt64Op) Next() coldata.Batch {
 							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(p.constArg)))
 							rightTmpDec.SetInt64(int64(int64(arg)))
-							if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
+							if err := eval.DecimalPow(tree.DecimalCtx, &leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 							resultInt, err := leftTmpDec.Int64()
@@ -18668,7 +18668,7 @@ func (p projPowInt32ConstInt64Op) Next() coldata.Batch {
 							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(p.constArg)))
 							rightTmpDec.SetInt64(int64(int64(arg)))
-							if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
+							if err := eval.DecimalPow(tree.DecimalCtx, &leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 							resultInt, err := leftTmpDec.Int64()
@@ -18692,7 +18692,7 @@ func (p projPowInt32ConstInt64Op) Next() coldata.Batch {
 						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(p.constArg)))
 						rightTmpDec.SetInt64(int64(int64(arg)))
-						if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
+						if err := eval.DecimalPow(tree.DecimalCtx, &leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 						resultInt, err := leftTmpDec.Int64()
@@ -18714,7 +18714,7 @@ func (p projPowInt32ConstInt64Op) Next() coldata.Batch {
 						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(p.constArg)))
 						rightTmpDec.SetInt64(int64(int64(arg)))
-						if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
+						if err := eval.DecimalPow(tree.DecimalCtx, &leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 						resultInt, err := leftTmpDec.Int64()
@@ -18765,7 +18765,7 @@ func (p projPowInt32ConstDecimalOp) Next() coldata.Batch {
 
 							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							_, err := tree.DecimalCtx.Pow(&projCol[i], &tmpDec, &arg)
+							err := eval.DecimalPow(tree.DecimalCtx, &projCol[i], &tmpDec, &arg)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -18787,7 +18787,7 @@ func (p projPowInt32ConstDecimalOp) Next() coldata.Batch {
 
 							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							_, err := tree.DecimalCtx.Pow(&projCol[i], &tmpDec, &arg)
+							err := eval.DecimalPow(tree.DecimalCtx, &projCol[i], &tmpDec, &arg)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -18808,7 +18808,7 @@ func (p projPowInt32ConstDecimalOp) Next() coldata.Batch {
 
 						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(p.constArg))
-						_, err := tree.DecimalCtx.Pow(&projCol[i], &tmpDec, &arg)
+						err := eval.DecimalPow(tree.DecimalCtx, &projCol[i], &tmpDec, &arg)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -18827,7 +18827,7 @@ func (p projPowInt32ConstDecimalOp) Next() coldata.Batch {
 
 						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(p.constArg))
-						_, err := tree.DecimalCtx.Pow(&projCol[i], &tmpDec, &arg)
+						err := eval.DecimalPow(tree.DecimalCtx, &projCol[i], &tmpDec, &arg)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -18875,7 +18875,7 @@ func (p projPowInt64ConstInt16Op) Next() coldata.Batch {
 							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(p.constArg)))
 							rightTmpDec.SetInt64(int64(int64(arg)))
-							if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
+							if err := eval.DecimalPow(tree.DecimalCtx, &leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 							resultInt, err := leftTmpDec.Int64()
@@ -18900,7 +18900,7 @@ func (p projPowInt64ConstInt16Op) Next() coldata.Batch {
 							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(p.constArg)))
 							rightTmpDec.SetInt64(int64(int64(arg)))
-							if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
+							if err := eval.DecimalPow(tree.DecimalCtx, &leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 							resultInt, err := leftTmpDec.Int64()
@@ -18924,7 +18924,7 @@ func (p projPowInt64ConstInt16Op) Next() coldata.Batch {
 						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(p.constArg)))
 						rightTmpDec.SetInt64(int64(int64(arg)))
-						if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
+						if err := eval.DecimalPow(tree.DecimalCtx, &leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 						resultInt, err := leftTmpDec.Int64()
@@ -18946,7 +18946,7 @@ func (p projPowInt64ConstInt16Op) Next() coldata.Batch {
 						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(p.constArg)))
 						rightTmpDec.SetInt64(int64(int64(arg)))
-						if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
+						if err := eval.DecimalPow(tree.DecimalCtx, &leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 						resultInt, err := leftTmpDec.Int64()
@@ -18997,7 +18997,7 @@ func (p projPowInt64ConstInt32Op) Next() coldata.Batch {
 							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(p.constArg)))
 							rightTmpDec.SetInt64(int64(int64(arg)))
-							if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
+							if err := eval.DecimalPow(tree.DecimalCtx, &leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 							resultInt, err := leftTmpDec.Int64()
@@ -19022,7 +19022,7 @@ func (p projPowInt64ConstInt32Op) Next() coldata.Batch {
 							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(p.constArg)))
 							rightTmpDec.SetInt64(int64(int64(arg)))
-							if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
+							if err := eval.DecimalPow(tree.DecimalCtx, &leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 							resultInt, err := leftTmpDec.Int64()
@@ -19046,7 +19046,7 @@ func (p projPowInt64ConstInt32Op) Next() coldata.Batch {
 						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(p.constArg)))
 						rightTmpDec.SetInt64(int64(int64(arg)))
-						if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
+						if err := eval.DecimalPow(tree.DecimalCtx, &leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 						resultInt, err := leftTmpDec.Int64()
@@ -19068,7 +19068,7 @@ func (p projPowInt64ConstInt32Op) Next() coldata.Batch {
 						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(p.constArg)))
 						rightTmpDec.SetInt64(int64(int64(arg)))
-						if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
+						if err := eval.DecimalPow(tree.DecimalCtx, &leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 						resultInt, err := leftTmpDec.Int64()
@@ -19119,7 +19119,7 @@ func (p projPowInt64ConstInt64Op) Next() coldata.Batch {
 							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(p.constArg)))
 							rightTmpDec.SetInt64(int64(int64(arg)))
-							if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
+							if err := eval.DecimalPow(tree.DecimalCtx, &leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 							resultInt, err := leftTmpDec.Int64()
@@ -19144,7 +19144,7 @@ func (p projPowInt64ConstInt64Op) Next() coldata.Batch {
 							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(p.constArg)))
 							rightTmpDec.SetInt64(int64(int64(arg)))
-							if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
+							if err := eval.DecimalPow(tree.DecimalCtx, &leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 							resultInt, err := leftTmpDec.Int64()
@@ -19168,7 +19168,7 @@ func (p projPowInt64ConstInt64Op) Next() coldata.Batch {
 						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(p.constArg)))
 						rightTmpDec.SetInt64(int64(int64(arg)))
-						if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
+						if err := eval.DecimalPow(tree.DecimalCtx, &leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 						resultInt, err := leftTmpDec.Int64()
@@ -19190,7 +19190,7 @@ func (p projPowInt64ConstInt64Op) Next() coldata.Batch {
 						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(p.constArg)))
 						rightTmpDec.SetInt64(int64(int64(arg)))
-						if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
+						if err := eval.DecimalPow(tree.DecimalCtx, &leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 						resultInt, err := leftTmpDec.Int64()
@@ -19241,7 +19241,7 @@ func (p projPowInt64ConstDecimalOp) Next() coldata.Batch {
 
 							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							_, err := tree.DecimalCtx.Pow(&projCol[i], &tmpDec, &arg)
+							err := eval.DecimalPow(tree.DecimalCtx, &projCol[i], &tmpDec, &arg)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -19263,7 +19263,7 @@ func (p projPowInt64ConstDecimalOp) Next() coldata.Batch {
 
 							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							_, err := tree.DecimalCtx.Pow(&projCol[i], &tmpDec, &arg)
+							err := eval.DecimalPow(tree.DecimalCtx, &projCol[i], &tmpDec, &arg)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -19284,7 +19284,7 @@ func (p projPowInt64ConstDecimalOp) Next() coldata.Batch {
 
 						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(p.constArg))
-						_, err := tree.DecimalCtx.Pow(&projCol[i], &tmpDec, &arg)
+						err := eval.DecimalPow(tree.DecimalCtx, &projCol[i], &tmpDec, &arg)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -19303,7 +19303,7 @@ func (p projPowInt64ConstDecimalOp) Next() coldata.Batch {
 
 						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(p.constArg))
-						_, err := tree.DecimalCtx.Pow(&projCol[i], &tmpDec, &arg)
+						err := eval.DecimalPow(tree.DecimalCtx, &projCol[i], &tmpDec, &arg)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}

--- a/pkg/sql/colexec/colexecprojconst/proj_const_right_ops.eg.go
+++ b/pkg/sql/colexec/colexecprojconst/proj_const_right_ops.eg.go
@@ -17524,7 +17524,7 @@ func (p projPowDecimalInt16ConstOp) Next() coldata.Batch {
 
 							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							if _, err := tree.DecimalCtx.Pow(&projCol[i], &arg, &tmpDec); err != nil {
+							if err := eval.DecimalPow(tree.DecimalCtx, &projCol[i], &arg, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -17544,7 +17544,7 @@ func (p projPowDecimalInt16ConstOp) Next() coldata.Batch {
 
 							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							if _, err := tree.DecimalCtx.Pow(&projCol[i], &arg, &tmpDec); err != nil {
+							if err := eval.DecimalPow(tree.DecimalCtx, &projCol[i], &arg, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -17563,7 +17563,7 @@ func (p projPowDecimalInt16ConstOp) Next() coldata.Batch {
 
 						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(p.constArg))
-						if _, err := tree.DecimalCtx.Pow(&projCol[i], &arg, &tmpDec); err != nil {
+						if err := eval.DecimalPow(tree.DecimalCtx, &projCol[i], &arg, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -17580,7 +17580,7 @@ func (p projPowDecimalInt16ConstOp) Next() coldata.Batch {
 
 						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(p.constArg))
-						if _, err := tree.DecimalCtx.Pow(&projCol[i], &arg, &tmpDec); err != nil {
+						if err := eval.DecimalPow(tree.DecimalCtx, &projCol[i], &arg, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -17626,7 +17626,7 @@ func (p projPowDecimalInt32ConstOp) Next() coldata.Batch {
 
 							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							if _, err := tree.DecimalCtx.Pow(&projCol[i], &arg, &tmpDec); err != nil {
+							if err := eval.DecimalPow(tree.DecimalCtx, &projCol[i], &arg, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -17646,7 +17646,7 @@ func (p projPowDecimalInt32ConstOp) Next() coldata.Batch {
 
 							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							if _, err := tree.DecimalCtx.Pow(&projCol[i], &arg, &tmpDec); err != nil {
+							if err := eval.DecimalPow(tree.DecimalCtx, &projCol[i], &arg, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -17665,7 +17665,7 @@ func (p projPowDecimalInt32ConstOp) Next() coldata.Batch {
 
 						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(p.constArg))
-						if _, err := tree.DecimalCtx.Pow(&projCol[i], &arg, &tmpDec); err != nil {
+						if err := eval.DecimalPow(tree.DecimalCtx, &projCol[i], &arg, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -17682,7 +17682,7 @@ func (p projPowDecimalInt32ConstOp) Next() coldata.Batch {
 
 						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(p.constArg))
-						if _, err := tree.DecimalCtx.Pow(&projCol[i], &arg, &tmpDec); err != nil {
+						if err := eval.DecimalPow(tree.DecimalCtx, &projCol[i], &arg, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -17728,7 +17728,7 @@ func (p projPowDecimalInt64ConstOp) Next() coldata.Batch {
 
 							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							if _, err := tree.DecimalCtx.Pow(&projCol[i], &arg, &tmpDec); err != nil {
+							if err := eval.DecimalPow(tree.DecimalCtx, &projCol[i], &arg, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -17748,7 +17748,7 @@ func (p projPowDecimalInt64ConstOp) Next() coldata.Batch {
 
 							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(p.constArg))
-							if _, err := tree.DecimalCtx.Pow(&projCol[i], &arg, &tmpDec); err != nil {
+							if err := eval.DecimalPow(tree.DecimalCtx, &projCol[i], &arg, &tmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 						}
@@ -17767,7 +17767,7 @@ func (p projPowDecimalInt64ConstOp) Next() coldata.Batch {
 
 						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(p.constArg))
-						if _, err := tree.DecimalCtx.Pow(&projCol[i], &arg, &tmpDec); err != nil {
+						if err := eval.DecimalPow(tree.DecimalCtx, &projCol[i], &arg, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -17784,7 +17784,7 @@ func (p projPowDecimalInt64ConstOp) Next() coldata.Batch {
 
 						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(p.constArg))
-						if _, err := tree.DecimalCtx.Pow(&projCol[i], &arg, &tmpDec); err != nil {
+						if err := eval.DecimalPow(tree.DecimalCtx, &projCol[i], &arg, &tmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 					}
@@ -17828,7 +17828,7 @@ func (p projPowDecimalDecimalConstOp) Next() coldata.Batch {
 
 						{
 
-							_, err := tree.DecimalCtx.Pow(&projCol[i], &arg, &p.constArg)
+							err := eval.DecimalPow(tree.DecimalCtx, &projCol[i], &arg, &p.constArg)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -17848,7 +17848,7 @@ func (p projPowDecimalDecimalConstOp) Next() coldata.Batch {
 
 						{
 
-							_, err := tree.DecimalCtx.Pow(&projCol[i], &arg, &p.constArg)
+							err := eval.DecimalPow(tree.DecimalCtx, &projCol[i], &arg, &p.constArg)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -17867,7 +17867,7 @@ func (p projPowDecimalDecimalConstOp) Next() coldata.Batch {
 
 					{
 
-						_, err := tree.DecimalCtx.Pow(&projCol[i], &arg, &p.constArg)
+						err := eval.DecimalPow(tree.DecimalCtx, &projCol[i], &arg, &p.constArg)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -17884,7 +17884,7 @@ func (p projPowDecimalDecimalConstOp) Next() coldata.Batch {
 
 					{
 
-						_, err := tree.DecimalCtx.Pow(&projCol[i], &arg, &p.constArg)
+						err := eval.DecimalPow(tree.DecimalCtx, &projCol[i], &arg, &p.constArg)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -17932,7 +17932,7 @@ func (p projPowInt16Int16ConstOp) Next() coldata.Batch {
 							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg)))
 							rightTmpDec.SetInt64(int64(int64(p.constArg)))
-							if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
+							if err := eval.DecimalPow(tree.DecimalCtx, &leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 							resultInt, err := leftTmpDec.Int64()
@@ -17957,7 +17957,7 @@ func (p projPowInt16Int16ConstOp) Next() coldata.Batch {
 							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg)))
 							rightTmpDec.SetInt64(int64(int64(p.constArg)))
-							if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
+							if err := eval.DecimalPow(tree.DecimalCtx, &leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 							resultInt, err := leftTmpDec.Int64()
@@ -17981,7 +17981,7 @@ func (p projPowInt16Int16ConstOp) Next() coldata.Batch {
 						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg)))
 						rightTmpDec.SetInt64(int64(int64(p.constArg)))
-						if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
+						if err := eval.DecimalPow(tree.DecimalCtx, &leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 						resultInt, err := leftTmpDec.Int64()
@@ -18003,7 +18003,7 @@ func (p projPowInt16Int16ConstOp) Next() coldata.Batch {
 						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg)))
 						rightTmpDec.SetInt64(int64(int64(p.constArg)))
-						if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
+						if err := eval.DecimalPow(tree.DecimalCtx, &leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 						resultInt, err := leftTmpDec.Int64()
@@ -18054,7 +18054,7 @@ func (p projPowInt16Int32ConstOp) Next() coldata.Batch {
 							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg)))
 							rightTmpDec.SetInt64(int64(int64(p.constArg)))
-							if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
+							if err := eval.DecimalPow(tree.DecimalCtx, &leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 							resultInt, err := leftTmpDec.Int64()
@@ -18079,7 +18079,7 @@ func (p projPowInt16Int32ConstOp) Next() coldata.Batch {
 							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg)))
 							rightTmpDec.SetInt64(int64(int64(p.constArg)))
-							if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
+							if err := eval.DecimalPow(tree.DecimalCtx, &leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 							resultInt, err := leftTmpDec.Int64()
@@ -18103,7 +18103,7 @@ func (p projPowInt16Int32ConstOp) Next() coldata.Batch {
 						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg)))
 						rightTmpDec.SetInt64(int64(int64(p.constArg)))
-						if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
+						if err := eval.DecimalPow(tree.DecimalCtx, &leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 						resultInt, err := leftTmpDec.Int64()
@@ -18125,7 +18125,7 @@ func (p projPowInt16Int32ConstOp) Next() coldata.Batch {
 						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg)))
 						rightTmpDec.SetInt64(int64(int64(p.constArg)))
-						if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
+						if err := eval.DecimalPow(tree.DecimalCtx, &leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 						resultInt, err := leftTmpDec.Int64()
@@ -18176,7 +18176,7 @@ func (p projPowInt16Int64ConstOp) Next() coldata.Batch {
 							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg)))
 							rightTmpDec.SetInt64(int64(int64(p.constArg)))
-							if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
+							if err := eval.DecimalPow(tree.DecimalCtx, &leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 							resultInt, err := leftTmpDec.Int64()
@@ -18201,7 +18201,7 @@ func (p projPowInt16Int64ConstOp) Next() coldata.Batch {
 							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg)))
 							rightTmpDec.SetInt64(int64(int64(p.constArg)))
-							if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
+							if err := eval.DecimalPow(tree.DecimalCtx, &leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 							resultInt, err := leftTmpDec.Int64()
@@ -18225,7 +18225,7 @@ func (p projPowInt16Int64ConstOp) Next() coldata.Batch {
 						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg)))
 						rightTmpDec.SetInt64(int64(int64(p.constArg)))
-						if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
+						if err := eval.DecimalPow(tree.DecimalCtx, &leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 						resultInt, err := leftTmpDec.Int64()
@@ -18247,7 +18247,7 @@ func (p projPowInt16Int64ConstOp) Next() coldata.Batch {
 						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg)))
 						rightTmpDec.SetInt64(int64(int64(p.constArg)))
-						if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
+						if err := eval.DecimalPow(tree.DecimalCtx, &leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 						resultInt, err := leftTmpDec.Int64()
@@ -18298,7 +18298,7 @@ func (p projPowInt16DecimalConstOp) Next() coldata.Batch {
 
 							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							_, err := tree.DecimalCtx.Pow(&projCol[i], &tmpDec, &p.constArg)
+							err := eval.DecimalPow(tree.DecimalCtx, &projCol[i], &tmpDec, &p.constArg)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -18320,7 +18320,7 @@ func (p projPowInt16DecimalConstOp) Next() coldata.Batch {
 
 							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							_, err := tree.DecimalCtx.Pow(&projCol[i], &tmpDec, &p.constArg)
+							err := eval.DecimalPow(tree.DecimalCtx, &projCol[i], &tmpDec, &p.constArg)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -18341,7 +18341,7 @@ func (p projPowInt16DecimalConstOp) Next() coldata.Batch {
 
 						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg))
-						_, err := tree.DecimalCtx.Pow(&projCol[i], &tmpDec, &p.constArg)
+						err := eval.DecimalPow(tree.DecimalCtx, &projCol[i], &tmpDec, &p.constArg)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -18360,7 +18360,7 @@ func (p projPowInt16DecimalConstOp) Next() coldata.Batch {
 
 						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg))
-						_, err := tree.DecimalCtx.Pow(&projCol[i], &tmpDec, &p.constArg)
+						err := eval.DecimalPow(tree.DecimalCtx, &projCol[i], &tmpDec, &p.constArg)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -18408,7 +18408,7 @@ func (p projPowInt32Int16ConstOp) Next() coldata.Batch {
 							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg)))
 							rightTmpDec.SetInt64(int64(int64(p.constArg)))
-							if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
+							if err := eval.DecimalPow(tree.DecimalCtx, &leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 							resultInt, err := leftTmpDec.Int64()
@@ -18433,7 +18433,7 @@ func (p projPowInt32Int16ConstOp) Next() coldata.Batch {
 							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg)))
 							rightTmpDec.SetInt64(int64(int64(p.constArg)))
-							if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
+							if err := eval.DecimalPow(tree.DecimalCtx, &leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 							resultInt, err := leftTmpDec.Int64()
@@ -18457,7 +18457,7 @@ func (p projPowInt32Int16ConstOp) Next() coldata.Batch {
 						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg)))
 						rightTmpDec.SetInt64(int64(int64(p.constArg)))
-						if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
+						if err := eval.DecimalPow(tree.DecimalCtx, &leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 						resultInt, err := leftTmpDec.Int64()
@@ -18479,7 +18479,7 @@ func (p projPowInt32Int16ConstOp) Next() coldata.Batch {
 						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg)))
 						rightTmpDec.SetInt64(int64(int64(p.constArg)))
-						if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
+						if err := eval.DecimalPow(tree.DecimalCtx, &leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 						resultInt, err := leftTmpDec.Int64()
@@ -18530,7 +18530,7 @@ func (p projPowInt32Int32ConstOp) Next() coldata.Batch {
 							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg)))
 							rightTmpDec.SetInt64(int64(int64(p.constArg)))
-							if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
+							if err := eval.DecimalPow(tree.DecimalCtx, &leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 							resultInt, err := leftTmpDec.Int64()
@@ -18555,7 +18555,7 @@ func (p projPowInt32Int32ConstOp) Next() coldata.Batch {
 							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg)))
 							rightTmpDec.SetInt64(int64(int64(p.constArg)))
-							if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
+							if err := eval.DecimalPow(tree.DecimalCtx, &leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 							resultInt, err := leftTmpDec.Int64()
@@ -18579,7 +18579,7 @@ func (p projPowInt32Int32ConstOp) Next() coldata.Batch {
 						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg)))
 						rightTmpDec.SetInt64(int64(int64(p.constArg)))
-						if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
+						if err := eval.DecimalPow(tree.DecimalCtx, &leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 						resultInt, err := leftTmpDec.Int64()
@@ -18601,7 +18601,7 @@ func (p projPowInt32Int32ConstOp) Next() coldata.Batch {
 						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg)))
 						rightTmpDec.SetInt64(int64(int64(p.constArg)))
-						if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
+						if err := eval.DecimalPow(tree.DecimalCtx, &leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 						resultInt, err := leftTmpDec.Int64()
@@ -18652,7 +18652,7 @@ func (p projPowInt32Int64ConstOp) Next() coldata.Batch {
 							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg)))
 							rightTmpDec.SetInt64(int64(int64(p.constArg)))
-							if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
+							if err := eval.DecimalPow(tree.DecimalCtx, &leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 							resultInt, err := leftTmpDec.Int64()
@@ -18677,7 +18677,7 @@ func (p projPowInt32Int64ConstOp) Next() coldata.Batch {
 							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg)))
 							rightTmpDec.SetInt64(int64(int64(p.constArg)))
-							if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
+							if err := eval.DecimalPow(tree.DecimalCtx, &leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 							resultInt, err := leftTmpDec.Int64()
@@ -18701,7 +18701,7 @@ func (p projPowInt32Int64ConstOp) Next() coldata.Batch {
 						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg)))
 						rightTmpDec.SetInt64(int64(int64(p.constArg)))
-						if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
+						if err := eval.DecimalPow(tree.DecimalCtx, &leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 						resultInt, err := leftTmpDec.Int64()
@@ -18723,7 +18723,7 @@ func (p projPowInt32Int64ConstOp) Next() coldata.Batch {
 						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg)))
 						rightTmpDec.SetInt64(int64(int64(p.constArg)))
-						if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
+						if err := eval.DecimalPow(tree.DecimalCtx, &leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 						resultInt, err := leftTmpDec.Int64()
@@ -18774,7 +18774,7 @@ func (p projPowInt32DecimalConstOp) Next() coldata.Batch {
 
 							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							_, err := tree.DecimalCtx.Pow(&projCol[i], &tmpDec, &p.constArg)
+							err := eval.DecimalPow(tree.DecimalCtx, &projCol[i], &tmpDec, &p.constArg)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -18796,7 +18796,7 @@ func (p projPowInt32DecimalConstOp) Next() coldata.Batch {
 
 							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							_, err := tree.DecimalCtx.Pow(&projCol[i], &tmpDec, &p.constArg)
+							err := eval.DecimalPow(tree.DecimalCtx, &projCol[i], &tmpDec, &p.constArg)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -18817,7 +18817,7 @@ func (p projPowInt32DecimalConstOp) Next() coldata.Batch {
 
 						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg))
-						_, err := tree.DecimalCtx.Pow(&projCol[i], &tmpDec, &p.constArg)
+						err := eval.DecimalPow(tree.DecimalCtx, &projCol[i], &tmpDec, &p.constArg)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -18836,7 +18836,7 @@ func (p projPowInt32DecimalConstOp) Next() coldata.Batch {
 
 						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg))
-						_, err := tree.DecimalCtx.Pow(&projCol[i], &tmpDec, &p.constArg)
+						err := eval.DecimalPow(tree.DecimalCtx, &projCol[i], &tmpDec, &p.constArg)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -18884,7 +18884,7 @@ func (p projPowInt64Int16ConstOp) Next() coldata.Batch {
 							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg)))
 							rightTmpDec.SetInt64(int64(int64(p.constArg)))
-							if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
+							if err := eval.DecimalPow(tree.DecimalCtx, &leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 							resultInt, err := leftTmpDec.Int64()
@@ -18909,7 +18909,7 @@ func (p projPowInt64Int16ConstOp) Next() coldata.Batch {
 							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg)))
 							rightTmpDec.SetInt64(int64(int64(p.constArg)))
-							if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
+							if err := eval.DecimalPow(tree.DecimalCtx, &leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 							resultInt, err := leftTmpDec.Int64()
@@ -18933,7 +18933,7 @@ func (p projPowInt64Int16ConstOp) Next() coldata.Batch {
 						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg)))
 						rightTmpDec.SetInt64(int64(int64(p.constArg)))
-						if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
+						if err := eval.DecimalPow(tree.DecimalCtx, &leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 						resultInt, err := leftTmpDec.Int64()
@@ -18955,7 +18955,7 @@ func (p projPowInt64Int16ConstOp) Next() coldata.Batch {
 						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg)))
 						rightTmpDec.SetInt64(int64(int64(p.constArg)))
-						if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
+						if err := eval.DecimalPow(tree.DecimalCtx, &leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 						resultInt, err := leftTmpDec.Int64()
@@ -19006,7 +19006,7 @@ func (p projPowInt64Int32ConstOp) Next() coldata.Batch {
 							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg)))
 							rightTmpDec.SetInt64(int64(int64(p.constArg)))
-							if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
+							if err := eval.DecimalPow(tree.DecimalCtx, &leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 							resultInt, err := leftTmpDec.Int64()
@@ -19031,7 +19031,7 @@ func (p projPowInt64Int32ConstOp) Next() coldata.Batch {
 							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg)))
 							rightTmpDec.SetInt64(int64(int64(p.constArg)))
-							if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
+							if err := eval.DecimalPow(tree.DecimalCtx, &leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 							resultInt, err := leftTmpDec.Int64()
@@ -19055,7 +19055,7 @@ func (p projPowInt64Int32ConstOp) Next() coldata.Batch {
 						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg)))
 						rightTmpDec.SetInt64(int64(int64(p.constArg)))
-						if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
+						if err := eval.DecimalPow(tree.DecimalCtx, &leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 						resultInt, err := leftTmpDec.Int64()
@@ -19077,7 +19077,7 @@ func (p projPowInt64Int32ConstOp) Next() coldata.Batch {
 						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg)))
 						rightTmpDec.SetInt64(int64(int64(p.constArg)))
-						if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
+						if err := eval.DecimalPow(tree.DecimalCtx, &leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 						resultInt, err := leftTmpDec.Int64()
@@ -19128,7 +19128,7 @@ func (p projPowInt64Int64ConstOp) Next() coldata.Batch {
 							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg)))
 							rightTmpDec.SetInt64(int64(int64(p.constArg)))
-							if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
+							if err := eval.DecimalPow(tree.DecimalCtx, &leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 							resultInt, err := leftTmpDec.Int64()
@@ -19153,7 +19153,7 @@ func (p projPowInt64Int64ConstOp) Next() coldata.Batch {
 							var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 							leftTmpDec.SetInt64(int64(int64(arg)))
 							rightTmpDec.SetInt64(int64(int64(p.constArg)))
-							if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
+							if err := eval.DecimalPow(tree.DecimalCtx, &leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 								colexecerror.ExpectedError(err)
 							}
 							resultInt, err := leftTmpDec.Int64()
@@ -19177,7 +19177,7 @@ func (p projPowInt64Int64ConstOp) Next() coldata.Batch {
 						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg)))
 						rightTmpDec.SetInt64(int64(int64(p.constArg)))
-						if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
+						if err := eval.DecimalPow(tree.DecimalCtx, &leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 						resultInt, err := leftTmpDec.Int64()
@@ -19199,7 +19199,7 @@ func (p projPowInt64Int64ConstOp) Next() coldata.Batch {
 						var leftTmpDec, rightTmpDec apd.Decimal //gcassert:noescape
 						leftTmpDec.SetInt64(int64(int64(arg)))
 						rightTmpDec.SetInt64(int64(int64(p.constArg)))
-						if _, err := tree.DecimalCtx.Pow(&leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
+						if err := eval.DecimalPow(tree.DecimalCtx, &leftTmpDec, &leftTmpDec, &rightTmpDec); err != nil {
 							colexecerror.ExpectedError(err)
 						}
 						resultInt, err := leftTmpDec.Int64()
@@ -19250,7 +19250,7 @@ func (p projPowInt64DecimalConstOp) Next() coldata.Batch {
 
 							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							_, err := tree.DecimalCtx.Pow(&projCol[i], &tmpDec, &p.constArg)
+							err := eval.DecimalPow(tree.DecimalCtx, &projCol[i], &tmpDec, &p.constArg)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -19272,7 +19272,7 @@ func (p projPowInt64DecimalConstOp) Next() coldata.Batch {
 
 							var tmpDec apd.Decimal //gcassert:noescape
 							tmpDec.SetInt64(int64(arg))
-							_, err := tree.DecimalCtx.Pow(&projCol[i], &tmpDec, &p.constArg)
+							err := eval.DecimalPow(tree.DecimalCtx, &projCol[i], &tmpDec, &p.constArg)
 							if err != nil {
 								colexecerror.ExpectedError(err)
 							}
@@ -19293,7 +19293,7 @@ func (p projPowInt64DecimalConstOp) Next() coldata.Batch {
 
 						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg))
-						_, err := tree.DecimalCtx.Pow(&projCol[i], &tmpDec, &p.constArg)
+						err := eval.DecimalPow(tree.DecimalCtx, &projCol[i], &tmpDec, &p.constArg)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}
@@ -19312,7 +19312,7 @@ func (p projPowInt64DecimalConstOp) Next() coldata.Batch {
 
 						var tmpDec apd.Decimal //gcassert:noescape
 						tmpDec.SetInt64(int64(arg))
-						_, err := tree.DecimalCtx.Pow(&projCol[i], &tmpDec, &p.constArg)
+						err := eval.DecimalPow(tree.DecimalCtx, &projCol[i], &tmpDec, &p.constArg)
 						if err != nil {
 							colexecerror.ExpectedError(err)
 						}

--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -1115,14 +1115,13 @@ SELECT pow(0::int, 3::int), pow(3::int, 0::int), pow(-3::int, 0::int)
 ----
 0 1 1
 
-statement error integer out of range
+statement error pgcode 2201F zero raised to a negative power is undefined
 SELECT pow(0::int, -3::int)
 
-# TODO(mjibson): This uses the decimal implementation internally, which
-# returns NaN, hence the below error. However postgres returns 1 for this,
-# which we should probably match.
-statement error integer out of range
+query I
 SELECT pow(0::int, 0::int)
+----
+1
 
 query RRR
 SELECT pow(-3.0::float, 2.0), power(3.0::float, 2.0), pow(5.0::decimal, 2.0)
@@ -1134,16 +1133,11 @@ SELECT pow(CAST (pi() AS DECIMAL), DECIMAL '2.0')
 ----
 9.8696044010893571205
 
-query R
+statement error pgcode 2201F zero raised to a negative power is undefined
 SELECT power(0::decimal, -1)
-----
-Infinity
 
-# TODO(mjibson): Postgres returns an error for this.
-query R
+statement error pgcode 2201F a negative number raised to a non-integer power yields a complex result
 SELECT power(-1, -.1)
-----
-NaN
 
 query RR
 SELECT radians(-45.0), radians(45.0)

--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -2739,6 +2739,20 @@ SELECT width_bucket(1, array[]::int[]);
 ----
 0
 
+query I
+SELECT width_bucket('Infinity'::numeric, 1, 10, 10);
+----
+11
+
+query I
+SELECT width_bucket('-Infinity'::numeric, 1, 10, 10);
+----
+0
+
+statement error pgcode 2201G pq: width_bucket\(\): operand, lower bound, and upper bound cannot be NaN
+SELECT width_bucket('NaN', 3.0, 4.0, 888);
+
+
 # Sanity check pg_type_is_visible.
 query BBB
 SELECT pg_type_is_visible('int'::regtype), pg_type_is_visible(NULL), pg_type_is_visible(99999)

--- a/pkg/sql/logictest/testdata/logic_test/decimal
+++ b/pkg/sql/logictest/testdata/logic_test/decimal
@@ -564,13 +564,15 @@ SELECT 'NaN'::numeric::int2
 statement error integer out of range
 SELECT '-Infinity'::numeric::int8
 
-statement error operand, lower bound, and upper bound cannot be infinity
+query I
 SELECT width_bucket('inf', 3.0, 4.0, 888)
+----
+889
 
-statement error operand, lower bound, and upper bound cannot be infinity
+statement error pgcode 2201G pq: width_bucket\(\): lower and upper bounds must be finite
 SELECT width_bucket(2.0, 3.0, '-inf', 888)
 
-statement error operand, lower bound, and upper bound cannot be infinity
+statement error pgcode 2201G pq: width_bucket\(\): lower and upper bounds must be finite
 SELECT width_bucket(0, '-inf', 4.0, 888)
 
 query RRR

--- a/pkg/sql/sem/builtins/math_builtins.go
+++ b/pkg/sql/sem/builtins/math_builtins.go
@@ -666,7 +666,7 @@ func powImpls() builtinDefinition {
 		}, "Calculates `x`^`y`.", volatility.Immutable),
 		decimalOverload2("x", "y", func(x, y *apd.Decimal) (tree.Datum, error) {
 			dd := &tree.DDecimal{}
-			_, err := tree.DecimalCtx.Pow(&dd.Decimal, x, y)
+			err := eval.DecimalPow(tree.DecimalCtx, &dd.Decimal, x, y)
 			return dd, err
 		}, "Calculates `x`^`y`.", volatility.Immutable),
 		tree.Overload{

--- a/pkg/sql/sem/builtins/math_builtins.go
+++ b/pkg/sql/sem/builtins/math_builtins.go
@@ -564,17 +564,30 @@ var mathBuiltins = map[string]builtinDefinition{
 				operand, _ := args[0].(*tree.DDecimal).Float64()
 				b1, _ := args[1].(*tree.DDecimal).Float64()
 				b2, _ := args[2].(*tree.DDecimal).Float64()
-				if math.IsInf(operand, 0) || math.IsInf(b1, 0) || math.IsInf(b2, 0) {
+				count := int(tree.MustBeDInt(args[3]))
+				// See postgres/src/backend/utils/adp/numeric.c:width_bucket_numeric.
+				if math.IsNaN(operand) || math.IsNaN(b1) || math.IsNaN(b2) {
 					return nil, pgerror.New(
-						pgcode.InvalidParameterValue,
-						"operand, lower bound, and upper bound cannot be infinity",
+						pgcode.InvalidArgumentForWidthBucketFunction,
+						"operand, lower bound, and upper bound cannot be NaN",
 					)
 				}
-				count := int(tree.MustBeDInt(args[3]))
+				if math.IsInf(b1, 0) || math.IsInf(b2, 0) {
+					return nil, pgerror.New(
+						pgcode.InvalidArgumentForWidthBucketFunction,
+						"lower and upper bounds must be finite",
+					)
+				}
+				if math.IsInf(operand, 1) {
+					return tree.NewDInt(tree.DInt(count + 1)), nil
+				}
+				if math.IsInf(operand, -1) {
+					return tree.NewDInt(tree.DInt(0)), nil
+				}
 				return tree.NewDInt(tree.DInt(widthBucket(operand, b1, b2, count))), nil
 			},
 			Info: "return the bucket number to which operand would be assigned in a histogram having count " +
-				"equal-width buckets spanning the range b1 to b2.",
+				"equal-width buckets spanning the range b1 to b2. Returns 0 or count+1 for an input outside that range.",
 			Volatility: volatility.Immutable,
 		},
 		tree.Overload{

--- a/pkg/sql/sem/eval/binary_op.go
+++ b/pkg/sql/sem/eval/binary_op.go
@@ -1493,7 +1493,7 @@ func (e *evaluator) EvalPowDecimalIntOp(
 	r := tree.MustBeDInt(right)
 	dd := &tree.DDecimal{}
 	dd.SetInt64(int64(r))
-	_, err := tree.DecimalCtx.Pow(&dd.Decimal, l, &dd.Decimal)
+	err := DecimalPow(tree.DecimalCtx, &dd.Decimal, l, &dd.Decimal)
 	return dd, err
 }
 
@@ -1503,7 +1503,7 @@ func (e *evaluator) EvalPowDecimalOp(
 	l := &left.(*tree.DDecimal).Decimal
 	r := &right.(*tree.DDecimal).Decimal
 	dd := &tree.DDecimal{}
-	_, err := tree.DecimalCtx.Pow(&dd.Decimal, l, r)
+	err := DecimalPow(tree.DecimalCtx, &dd.Decimal, l, r)
 	return dd, err
 }
 
@@ -1521,7 +1521,7 @@ func (e *evaluator) EvalPowIntDecimalOp(
 	r := &right.(*tree.DDecimal).Decimal
 	dd := &tree.DDecimal{}
 	dd.SetInt64(int64(l))
-	_, err := tree.DecimalCtx.Pow(&dd.Decimal, &dd.Decimal, r)
+	err := DecimalPow(tree.DecimalCtx, &dd.Decimal, &dd.Decimal, r)
 	return dd, err
 }
 

--- a/pkg/sql/sem/eval/math.go
+++ b/pkg/sql/sem/eval/math.go
@@ -9,14 +9,29 @@ import (
 	"math"
 
 	"github.com/cockroachdb/apd/v3"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+)
+
+var (
+	errZeroToNegativePower       = pgerror.New(pgcode.InvalidArgumentForPowerFunction, "zero raised to a negative power is undefined")
+	errNegativeToNonIntegerPower = pgerror.New(pgcode.InvalidArgumentForPowerFunction, "a negative number raised to a non-integer power yields a complex result")
+
+	zero   = apd.New(0, 0)
+	one    = apd.New(1, 0)
+	negOne = apd.New(-1, 0)
+	posInf = &apd.Decimal{
+		Form:     apd.Infinite,
+		Negative: false,
+	}
 )
 
 // IntPow computes the value of x^y.
 func IntPow(x, y tree.DInt) (*tree.DInt, error) {
 	xd := apd.New(int64(x), 0)
 	yd := apd.New(int64(y), 0)
-	_, err := tree.DecimalCtx.Pow(xd, xd, yd)
+	err := DecimalPow(tree.DecimalCtx, xd, xd, yd)
 	if err != nil {
 		return nil, err
 	}
@@ -25,6 +40,25 @@ func IntPow(x, y tree.DInt) (*tree.DInt, error) {
 		return nil, tree.ErrIntOutOfRange
 	}
 	return tree.NewDInt(tree.DInt(i)), nil
+}
+
+// DecimalPow wraps apd.Context.Pow() as a helper function and handles special
+// cases that apd.Context.Pow() does not. See handlePowEdgeCases for details.
+func DecimalPow(ctx *apd.Context, d, x, y *apd.Decimal) error {
+	e, err := handlePowEdgeCases(x, y)
+	if err != nil {
+		return err
+	}
+	if e != nil {
+		d.Set(e)
+		return nil
+	}
+	// TODO(normanchenn): do something with the condition.
+	_, err = ctx.Pow(d, x, y)
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 // Sqrt returns the square root of x.
@@ -55,4 +89,105 @@ func DecimalCbrt(x *apd.Decimal) (*tree.DDecimal, error) {
 	dd := &tree.DDecimal{}
 	_, err := tree.DecimalCtx.Cbrt(&dd.Decimal, x)
 	return dd, err
+}
+
+func isOne(d *apd.Decimal) bool {
+	return d.Cmp(one) == 0
+}
+
+func isNegOne(d *apd.Decimal) bool {
+	return d.Cmp(negOne) == 0
+}
+
+func isNotInteger(d *apd.Decimal) bool {
+	var frac apd.Decimal
+	d.Modf(nil, &frac)
+	return !frac.IsZero()
+}
+
+func isAbsUnderOne(d *apd.Decimal) bool {
+	var abs apd.Decimal
+	abs.Abs(d)
+	return abs.Cmp(one) == -1
+}
+
+// handlePowEdgeCases validates and handles special cases for power function arguments
+// according to Postgres behavior. This function implements special case handling
+// in places that differ from the General Decimal Arithmetic spec used by apd. The
+// implementation follows postgres/src/backend/utils/adt/numeric.c:numeric_power,
+// which adheres to the POSIX pow(3) spec.
+// Special cases handled here:
+// - NaN ^ 0 = 1
+// - 1 ^ NaN = 1
+// - 0 ^ negative = error
+// - negative ^ non-integer = error
+// - any ^ 0 = 1 (including 0^0)
+// - |x| < 1 cases with (+/-) infinite y
+// - |x| > 1 cases with (+/-) infinite y
+// - -infinity ^ negative = 0
+func handlePowEdgeCases(x, y *apd.Decimal) (*apd.Decimal, error) {
+	// NaN ^ 0 = 1.
+	if x.Form == apd.NaN && y.IsZero() {
+		return one, nil
+	}
+	// 1 ^ NaN = 1.
+	if isOne(x) && y.Form == apd.NaN {
+		return one, nil
+	}
+
+	// Zero raised to a negative power is undefined.
+	if x.IsZero() && y.Sign() == -1 {
+		return nil, errZeroToNegativePower
+	}
+	// A negative number raised to a non-integer power yields a complex result.
+	if x.Sign() == -1 && isNotInteger(y) {
+		return nil, errNegativeToNonIntegerPower
+	}
+
+	// For x = 1 and any value of y, 1.0 shall be returned.
+	if isOne(x) {
+		return one, nil
+	}
+
+	// For any value of x and y is 0, 1.0 shall be returned.
+	// apd.Context.Pow() would return NaN for 0 ^ 0.
+	if y.IsZero() {
+		return one, nil
+	}
+
+	// If x is 0 and y is positive, 0 shall be returned. This is handled in apd.
+
+	// If x is -1 and y is (+/-)Inf, 1.0 shall be returned.
+	if isNegOne(x) && y.Form == apd.Infinite {
+		return one, nil
+	}
+
+	// If |x| < 1 and y is -Inf, +Inf is returned.
+	if isAbsUnderOne(x) && y.Negative && y.Form == apd.Infinite {
+		return posInf, nil
+	}
+	// If |x| < 1 and y is +Inf, +0 shall be returned.
+	if isAbsUnderOne(x) && !y.Negative && y.Form == apd.Infinite {
+		return zero, nil
+	}
+	// If |x| > 1 and y is -Inf, +0 shall be returned.
+	if !isAbsUnderOne(x) && y.Negative && y.Form == apd.Infinite {
+		return zero, nil
+	}
+	// If |x| > 1 and y is +Inf, +Inf shall be returned.
+	if !isAbsUnderOne(x) && !y.Negative && y.Form == apd.Infinite {
+		return posInf, nil
+	}
+
+	// If x is +Inf and y < 0, 0 shall be returned. This is handled in apd.
+	// If x is +Inf and y > 0, +Inf shall be returned. This is handled in apd.
+
+	// If x is -Inf and y < 0, 0 shall be returned.
+	if x.Negative && x.Form == apd.Infinite && y.Negative {
+		return zero, nil
+	}
+
+	// If x is -Inf and y > 0 and y is odd, -Inf shall be returned. This is handled in apd.
+	// If x is -Inf and y > 0 and y is even, +Inf shall be returned. This is handled in apd.
+	return nil, nil
 }

--- a/pkg/sql/sem/eval/testdata/eval/infinity
+++ b/pkg/sql/sem/eval/testdata/eval/infinity
@@ -1,8 +1,3 @@
-eval
-power(0::decimal, -1)
-----
-Infinity
-
 # Infinities
 
 eval

--- a/pkg/sql/sem/eval/testdata/eval/power
+++ b/pkg/sql/sem/eval/testdata/eval/power
@@ -1,0 +1,422 @@
+# This file contains tests for special cases for the power function as described
+# in https://github.com/cockroachdb/cockroach/issues/114872. Additionally, there
+# was more changes to be made as the apd library follows a different spec than
+# postgres. More details can be found in pkg/sql/sem/builtins/math_builtins.go:handlePowEdgeCases.
+
+# NaN ^ 0 = 1.
+eval
+power('NaN'::numeric, '0'::numeric)
+----
+1
+
+eval
+'NaN'::numeric ^ 0
+----
+1
+
+# 1 ^ NaN = 1.
+eval
+power('1'::numeric, 'NaN')
+----
+1
+
+eval
+1 ^ 'NaN'::numeric
+----
+1
+
+# Zero raised to a negative power is undefined.
+eval
+power('0'::numeric, '-1')
+----
+power(): zero raised to a negative power is undefined
+
+eval
+'0'::numeric ^ -1
+----
+zero raised to a negative power is undefined
+
+eval
+power('0'::numeric, '-0.0001')
+----
+power(): zero raised to a negative power is undefined
+
+eval
+'0'::numeric ^ -0.0001
+----
+zero raised to a negative power is undefined
+
+eval
+power('0'::numeric, '-Inf'::numeric)
+----
+power(): zero raised to a negative power is undefined
+
+eval
+'0'::numeric ^ '-Inf'::numeric
+----
+zero raised to a negative power is undefined
+
+# A negative number raised to a non-integer power yields a complex result.
+eval
+power('-2'::numeric, '-1.5')
+----
+power(): a negative number raised to a non-integer power yields a complex result
+
+eval
+'-2'::numeric ^ '-1.5'
+----
+a negative number raised to a non-integer power yields a complex result
+
+eval
+power('-0.0001'::numeric, '3.3')
+----
+power(): a negative number raised to a non-integer power yields a complex result
+
+eval
+'-0.0001'::numeric ^ '3.3'
+----
+a negative number raised to a non-integer power yields a complex result
+
+eval
+power('-Inf'::numeric, '4.5')
+----
+power(): a negative number raised to a non-integer power yields a complex result
+
+eval
+'-Inf'::numeric ^ '4.5'
+----
+a negative number raised to a non-integer power yields a complex result
+
+# For x = 1 and any value of y, 1.0 shall be returned.
+eval
+power('1'::numeric, 'Inf'::numeric)
+----
+1
+
+eval
+'1'::numeric ^ 'Inf'::numeric
+----
+1
+
+eval
+power('1'::numeric, '-Inf'::numeric)
+----
+1
+
+eval
+'1'::numeric ^ '-Inf'::numeric
+----
+1
+
+eval
+power('1'::numeric, '0.0001'::numeric)
+----
+1
+
+eval
+'1'::numeric ^ '0.0001'::numeric
+----
+1
+
+eval
+power('1'::numeric, '-0.0001'::numeric)
+----
+1
+
+eval
+'1'::numeric ^ '-0.0001'::numeric
+----
+1
+
+# For any value of x and y is 0, 1.0 shall be returned.
+# apd.Context.Pow() would return NaN for 0 ^ 0.
+eval
+power('0'::numeric, '0'::numeric)
+----
+1
+
+eval
+'0'::numeric ^ '0'::numeric
+----
+1
+
+eval
+power('0.0001'::numeric, '0'::numeric)
+----
+1
+
+eval
+'0.0001'::numeric ^ '0'::numeric
+----
+1
+
+eval
+power('-0.0001'::numeric, '0'::numeric)
+----
+1
+
+eval
+'-0.0001'::numeric ^ '0'::numeric
+----
+1
+
+eval
+power('Inf'::numeric, '0'::numeric)
+----
+1
+
+eval
+'Inf'::numeric ^ '0'::numeric
+----
+1
+
+eval
+power('-Inf'::numeric, '0'::numeric)
+----
+1
+
+eval
+'-Inf'::numeric ^ '0'::numeric
+----
+1
+
+# If x is 0 and y is positive, 0 shall be returned. This is handled in apd.
+eval
+power('0'::numeric, '0.0001'::numeric)
+----
+0
+
+eval
+'0'::numeric ^ '0.0001'::numeric
+----
+0
+
+eval
+power('0'::numeric, 'Inf'::numeric)
+----
+0
+
+eval
+'0'::numeric ^ 'Inf'::numeric
+----
+0
+
+# If x is -1 and y is (+/-)Inf, 1.0 shall be returned.
+eval
+power('-1'::numeric, 'Inf'::numeric)
+----
+1
+
+eval
+'-1'::numeric ^ 'Inf'::numeric
+----
+1
+
+eval
+power('-1'::numeric, '-Inf'::numeric)
+----
+1
+
+eval
+'-1'::numeric ^ '-Inf'::numeric
+----
+1
+
+# If |x| < 1 and y is -Inf, +Inf is returned.
+eval
+power('0.999'::numeric, '-Inf'::numeric)
+----
+Infinity
+
+eval
+'0.999'::numeric ^ '-Inf'::numeric
+----
+Infinity
+
+eval
+power('-0.999'::numeric, '-Inf'::numeric)
+----
+Infinity
+
+eval
+'-0.999'::numeric ^ '-Inf'::numeric
+----
+Infinity
+
+# If |x| < 1 and y is +Inf, +0 shall be returned.
+eval
+power('0.999'::numeric, 'Inf'::numeric)
+----
+0
+
+eval
+'0.999'::numeric ^ 'Inf'::numeric
+----
+0
+
+eval
+power('-0.999'::numeric, 'Inf'::numeric)
+----
+0
+
+eval
+'-0.999'::numeric ^ 'Inf'::numeric
+----
+0
+
+# If |x| > 1 and y is -Inf, +0 shall be returned.
+eval
+power('1.001'::numeric, '-Inf'::numeric)
+----
+0
+
+eval
+'1.001'::numeric ^ '-Inf'::numeric
+----
+0
+
+eval
+power('-1.001'::numeric, '-Inf'::numeric)
+----
+0
+
+eval
+'-1.001'::numeric ^ '-Inf'::numeric
+----
+0
+
+eval
+power('-2'::numeric, '-Inf'::numeric)
+----
+0
+
+eval
+'-2'::numeric ^ '-Inf'::numeric
+----
+0
+
+# If |x| > 1 and y is +Inf, +Inf shall be returned.
+eval
+power('1.001'::numeric, 'Inf'::numeric)
+----
+Infinity
+
+eval
+'1.001'::numeric ^ 'Inf'::numeric
+----
+Infinity
+
+eval
+power('-1.001'::numeric, 'Inf'::numeric)
+----
+Infinity
+
+eval
+'-1.001'::numeric ^ 'Inf'::numeric
+----
+Infinity
+
+eval
+power('-2'::numeric, 'Inf'::numeric)
+----
+Infinity
+
+eval
+'-2'::numeric ^ 'Inf'::numeric
+----
+Infinity
+
+# If x is +Inf and y < 0, 0 shall be returned. This is handled in apd.
+eval
+power('Inf'::numeric, '-0.0001'::numeric)
+----
+0
+
+eval
+'Inf'::numeric ^ '-0.0001'::numeric
+----
+0
+
+eval
+power('Inf'::numeric, '-Inf'::numeric)
+----
+0
+
+eval
+'Inf'::numeric ^ '-Inf'::numeric
+----
+0
+
+# If x is +Inf and y > 0, +Inf shall be returned. This is handled in apd.
+eval
+power('Inf'::numeric, '0.0001'::numeric)
+----
+Infinity
+
+eval
+'Inf'::numeric ^ '0.0001'::numeric
+----
+Infinity
+
+eval
+power('Inf'::numeric, 'Inf'::numeric)
+----
+Infinity
+
+eval
+'Inf'::numeric ^ 'Inf'::numeric
+----
+Infinity
+
+# If x is -Inf and y < 0, 0 shall be returned.
+eval
+power('-Inf'::numeric, '-Inf'::numeric)
+----
+0
+
+eval
+'-Inf'::numeric ^ '-Inf'::numeric
+----
+0
+
+# If x is -Inf and y > 0 and y is odd, -Inf shall be returned. This is handled in apd.
+# If x is -Inf and y > 0 and y is even, +Inf shall be returned. This is handled in apd.
+eval
+power('-Inf'::numeric, '1'::numeric)
+----
+-Infinity
+
+eval
+'-Inf'::numeric ^ '1'::numeric
+----
+-Infinity
+
+eval
+power('-Inf'::numeric, '2'::numeric)
+----
+Infinity
+
+eval
+'-Inf'::numeric ^ '2'::numeric
+----
+Infinity
+
+eval
+power('-Inf'::numeric, 'Inf'::numeric)
+----
+Infinity
+
+eval
+'-Inf'::numeric ^ 'Inf'::numeric
+----
+Infinity
+
+eval
+power('-Inf'::numeric, '-Inf'::numeric)
+----
+0
+
+eval
+'-Inf'::numeric ^ '-Inf'::numeric
+----
+0


### PR DESCRIPTION
#### builtins: fix `width_bucket()` edge cases to match postgres

This commit fixes some edge cases in the `width_bucket()` function to
match postgres behaviour:
- Return count + 1 for a positive infinity operand.
- Return 0 for a negative infinity operand.
- Update error codes and messages.

Informs #114872
Epic: None
Release note (sql change): Update edge cases in the `width_bucket()`
function to return count + 1 for a positive infinity operand, and
0 for a negative infinity operand, instead of an error.

#### sql/sem/eval: implement postgres `power()` and `^` edge cases

This commit adds special case handling for `power()` and `^` operations
to match postgres behaviour. The internal apd package implements the
General Decimal Arithmetic specification, while postgres follows the POSIX
pow(3) spec. This commit adds a function to handle special cases, and a
wrapper around `apd.Context.Pow()` that calls the handler.

Special cases handled:
- NaN ^ 0 = 1. This used to return NaN.
- 1 ^ NaN = 1. This used to return NaN.
- 0 ^ negative = error. This used to return Infinity.
- negative ^ non-integer = error. This used to return NaN.
- any ^ 0 = 1 (including 0^0). 0^0 used to return NaN.
- |x| < 1 cases with (+/-) infinite y. These used to return 1.
- |x| > 1 cases with (+/-) infinite y. These used to return 1.
- -infinity ^ negative = 0.

Informs #114872
Epic: None
Release note (sql change): Implement various
`power()` and `^` edge cases to match postgres behaviour.

Release note (backward-incompatible change): Implement various
`power()` and `^` edge cases to match postgres behaviour. Some expressions
that previously returned NaN now return specific numbers, some expressions
that previously returned Infinity or NaN now return errors, and some
expressions with infinite exponents now return different results.
