### PR TITLE
kvclient: decompose CPut requests in the txnWriteBuffer

### DIFF
--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -2383,6 +2383,7 @@ GO_TARGETS = [
     "//pkg/storage/metamorphic:metamorphic",
     "//pkg/storage/metamorphic:metamorphic_test",
     "//pkg/storage/mvccencoding:mvccencoding",
+    "//pkg/storage/mvcceval:mvcceval",
     "//pkg/storage/pebbleiter:pebbleiter",
     "//pkg/storage/pebbleiter:pebbleiter_test",
     "//pkg/storage/storagepb:storagepb",

--- a/pkg/kv/kvclient/kvcoord/BUILD.bazel
+++ b/pkg/kv/kvclient/kvcoord/BUILD.bazel
@@ -62,6 +62,7 @@ go_library(
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",
         "//pkg/storage/enginepb",
+        "//pkg/storage/mvcceval",
         "//pkg/util",
         "//pkg/util/admission/admissionpb",
         "//pkg/util/buildutil",

--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_write_buffer.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_write_buffer.go
@@ -347,13 +347,12 @@ func (twb *txnWriteBuffer) applyTransformations(
 				index:       i,
 				origRequest: req,
 			})
-			// TODO(arul,ssd): Once we are able to acquire locks on non-existing keys,
-			// we'll need that here in cases where the CPut expects no value to exist.
 			getReq := &kvpb.GetRequest{
 				RequestHeader: kvpb.RequestHeader{
 					Key:      t.Key,
 					Sequence: t.Sequence,
 				},
+				LockNonExisting:    len(t.ExpBytes) == 0 || t.AllowIfDoesNotExist,
 				KeyLockingStrength: lock.Exclusive,
 			}
 			var getReqU kvpb.RequestUnion

--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_write_buffer.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_write_buffer.go
@@ -13,6 +13,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/storage/mvcceval"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
 )
@@ -114,11 +115,15 @@ type txnWriteBuffer struct {
 	bufferIDAlloc uint64
 
 	wrapped lockedSender
+
+	// testingOverrideCPutEvalFn is used to mock the evaluation function for
+	// conditional puts. Intended only for tests.
+	testingOverrideCPutEvalFn func(expBytes []byte, actVal *roachpb.Value, actValPresent bool, allowNoExisting bool) *kvpb.ConditionFailedError
 }
 
 func (twb *txnWriteBuffer) SendLocked(
 	ctx context.Context, ba *kvpb.BatchRequest,
-) (*kvpb.BatchResponse, *kvpb.Error) {
+) (_ *kvpb.BatchResponse, pErr *kvpb.Error) {
 	if !twb.enabled {
 		return twb.wrapped.SendLocked(ctx, ba)
 	}
@@ -138,11 +143,10 @@ func (twb *txnWriteBuffer) SendLocked(
 		// left with an empty batch after applying transformations, eschew sending
 		// anything to KV.
 		br := ba.CreateReply()
-		var err error
 		for i, t := range ts {
-			br.Responses[i], err = t.toResp(twb, kvpb.ResponseUnion{})
-			if err != nil {
-				return nil, kvpb.NewError(err)
+			br.Responses[i], pErr = t.toResp(twb, kvpb.ResponseUnion{}, ba.Txn)
+			if pErr != nil {
+				return nil, pErr
 			}
 		}
 		return br, nil
@@ -153,11 +157,7 @@ func (twb *txnWriteBuffer) SendLocked(
 		return nil, twb.adjustError(ctx, transformedBa, ts, pErr)
 	}
 
-	resp, err := twb.mergeResponseWithTransformations(ctx, ts, br)
-	if err != nil {
-		return nil, kvpb.NewError(err)
-	}
-	return resp, nil
+	return twb.mergeResponseWithTransformations(ctx, ts, br)
 }
 
 // adjustError adjusts the provided error based on the transformations made by
@@ -321,6 +321,9 @@ func (twb *txnWriteBuffer) closeLocked() {}
 // their response needs to be merged with any buffered writes. The only
 // difference is the direction in which the buffer is iterated when doing the
 // merge. As a result, they're also collected as tranformations.
+// 5. Conditional Puts are decomposed into a locking Get followed by a Put. The
+// Put is buffered locally if the condition evaluates successfully using the
+// Get's response. Otherwise, a ConditionFailedError is returned.
 //
 // TODO(arul): Augment this comment as these expand.
 func (twb *txnWriteBuffer) applyTransformations(
@@ -338,6 +341,29 @@ func (twb *txnWriteBuffer) applyTransformations(
 	for i, ru := range ba.Requests {
 		req := ru.GetInner()
 		switch t := req.(type) {
+		case *kvpb.ConditionalPutRequest:
+			ts = append(ts, transformation{
+				stripped:    false,
+				index:       i,
+				origRequest: req,
+			})
+			// TODO(arul,ssd): Once we are able to acquire locks on non-existing keys,
+			// we'll need that here in cases where the CPut expects no value to exist.
+			getReq := &kvpb.GetRequest{
+				RequestHeader: kvpb.RequestHeader{
+					Key:      t.Key,
+					Sequence: t.Sequence,
+				},
+				KeyLockingStrength: lock.Exclusive,
+			}
+			var getReqU kvpb.RequestUnion
+			getReqU.MustSetInner(getReq)
+			// Send a locking Get request to the KV layer; we'll evaluate the
+			// condition locally based on the response.
+			baRemote.Requests = append(baRemote.Requests, getReqU)
+			// TODO(arul): We're not handling the case where this Get needs to
+			// be served locally from the buffer yet.
+
 		case *kvpb.PutRequest:
 			var ru kvpb.ResponseUnion
 			ru.MustSetInner(&kvpb.PutResponse{})
@@ -670,7 +696,7 @@ func (twb *txnWriteBuffer) mergeBufferAndResp(
 // oblivious to its decision to buffer any writes.
 func (twb *txnWriteBuffer) mergeResponseWithTransformations(
 	ctx context.Context, ts transformations, br *kvpb.BatchResponse,
-) (_ *kvpb.BatchResponse, err error) {
+) (_ *kvpb.BatchResponse, pErr *kvpb.Error) {
 	if ts.Empty() && br == nil {
 		log.Fatal(ctx, "unexpectedly found no transformations and no batch response")
 	} else if ts.Empty() {
@@ -692,15 +718,15 @@ func (twb *txnWriteBuffer) mergeResponseWithTransformations(
 				// we received a response for it, which then needs to be combined with
 				// what's in the write buffer.
 				resp := br.Responses[0]
-				mergedResps[i], err = ts[0].toResp(twb, resp)
-				if err != nil {
-					return nil, err
+				mergedResps[i], pErr = ts[0].toResp(twb, resp, br.Txn)
+				if pErr != nil {
+					return nil, pErr
 				}
 				br.Responses = br.Responses[1:]
 			} else {
-				mergedResps[i], err = ts[0].toResp(twb, kvpb.ResponseUnion{})
-				if err != nil {
-					return nil, err
+				mergedResps[i], pErr = ts[0].toResp(twb, kvpb.ResponseUnion{}, br.Txn)
+				if pErr != nil {
+					return nil, pErr
 				}
 			}
 
@@ -738,18 +764,44 @@ type transformation struct {
 // toResp returns the response that should be added to the batch response as
 // a result of applying the transformation.
 func (t transformation) toResp(
-	twb *txnWriteBuffer, br kvpb.ResponseUnion,
-) (kvpb.ResponseUnion, error) {
+	twb *txnWriteBuffer, br kvpb.ResponseUnion, txn *roachpb.Transaction,
+) (kvpb.ResponseUnion, *kvpb.Error) {
 	if t.stripped {
 		return t.resp, nil
 	}
 
 	var ru kvpb.ResponseUnion
 	switch t.origRequest.(type) {
+	case *kvpb.ConditionalPutRequest:
+		// Evaluate the condition.
+		evalFn := mvcceval.MaybeConditionFailedError
+		if twb.testingOverrideCPutEvalFn != nil {
+			evalFn = twb.testingOverrideCPutEvalFn
+		}
+		cputReq := t.origRequest.(*kvpb.ConditionalPutRequest)
+		getResp := br.GetInner().(*kvpb.GetResponse)
+		condFailedErr := evalFn(
+			cputReq.ExpBytes,
+			getResp.Value,
+			getResp.Value.IsPresent(),
+			cputReq.AllowIfDoesNotExist,
+		)
+		if condFailedErr != nil {
+			pErr := kvpb.NewErrorWithTxn(condFailedErr, txn)
+			pErr.SetErrorIndex(int32(t.index))
+			return kvpb.ResponseUnion{}, pErr
+		}
+		// The condition was satisfied; buffer a Put, and return a synthesized
+		// response.
+		twb.addToBuffer(cputReq.Key, cputReq.Value, cputReq.Sequence)
+		ru.MustSetInner(&kvpb.ConditionalPutResponse{})
+
 	case *kvpb.PutRequest:
 		ru = t.resp
+
 	case *kvpb.DeleteRequest:
 		ru = t.resp
+
 	case *kvpb.GetRequest:
 		// Get requests must be served from the local buffer if a transaction
 		// performed a previous write to the key being read. However, Get requests
@@ -759,20 +811,22 @@ func (t transformation) toResp(
 		assertTrue(t.stripped == (req.KeyLockingStrength == lock.None),
 			"Get requests should either be stripped or be locking")
 		ru = t.resp
+
 	case *kvpb.ScanRequest:
 		scanResp, err := twb.mergeWithScanResp(
 			t.origRequest.(*kvpb.ScanRequest), br.GetInner().(*kvpb.ScanResponse),
 		)
 		if err != nil {
-			return kvpb.ResponseUnion{}, err
+			return kvpb.ResponseUnion{}, kvpb.NewError(err)
 		}
 		ru.MustSetInner(scanResp)
+
 	case *kvpb.ReverseScanRequest:
 		reverseScanResp, err := twb.mergeWithReverseScanResp(
 			t.origRequest.(*kvpb.ReverseScanRequest), br.GetInner().(*kvpb.ReverseScanResponse),
 		)
 		if err != nil {
-			return kvpb.ResponseUnion{}, err
+			return kvpb.ResponseUnion{}, kvpb.NewError(err)
 		}
 		ru.MustSetInner(reverseScanResp)
 

--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_write_buffer_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_write_buffer_test.go
@@ -36,6 +36,16 @@ func putArgs(key roachpb.Key, value string, seq enginepb.TxnSeq) *kvpb.PutReques
 	}
 }
 
+func cputArgs(
+	key roachpb.Key, value string, expValue string, seq enginepb.TxnSeq,
+) *kvpb.ConditionalPutRequest {
+	return &kvpb.ConditionalPutRequest{
+		RequestHeader: kvpb.RequestHeader{Key: key, Sequence: seq},
+		Value:         roachpb.MakeValueFromString(value),
+		ExpBytes:      []byte(expValue),
+	}
+}
+
 func delArgs(key roachpb.Key, seq enginepb.TxnSeq) *kvpb.DeleteRequest {
 	return &kvpb.DeleteRequest{
 		RequestHeader: kvpb.RequestHeader{Key: key, Sequence: seq},
@@ -858,7 +868,7 @@ func TestTxnWriteBufferLockingGetRequests(t *testing.T) {
 	keyA := roachpb.Key("a")
 	valA := "val"
 
-	// Blindly write to keys A.
+	// Blindly write to key A.
 	ba := &kvpb.BatchRequest{}
 	ba.Header = kvpb.Header{Txn: &txn}
 	putA := putArgs(keyA, valA, txn.Sequence)
@@ -947,4 +957,85 @@ func TestTxnWriteBufferLockingGetRequests(t *testing.T) {
 	// not be returned.
 	require.Len(t, br.Responses, 1)
 	require.IsType(t, &kvpb.EndTxnResponse{}, br.Responses[0].GetInner())
+}
+
+// TestTxnWriteBufferDecomposesConditionalPuts verifies that conditional puts
+// are decomposed into a locking Get, which is sent to KV, and a Put, which is
+// buffered locally. Additionally, we also test that the Put is only buffered, and
+// flushed to KV, if the condition evaluates successfully.
+func TestTxnWriteBufferDecomposesConditionalPuts(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+	twb, mockSender := makeMockTxnWriteBuffer()
+
+	testutils.RunTrueAndFalse(t, "condEvalSuccessful", func(t *testing.T, condEvalSuccessful bool) {
+		twb.testingOverrideCPutEvalFn = func(expBytes []byte, actVal *roachpb.Value, actValPresent bool, allowNoExisting bool) *kvpb.ConditionFailedError {
+			if condEvalSuccessful {
+				return nil
+			}
+			return &kvpb.ConditionFailedError{}
+		}
+
+		txn := makeTxnProto()
+		txn.Sequence = 10
+		keyA := roachpb.Key("a")
+		valA := "val"
+
+		// Blindly write to keys A.
+		ba := &kvpb.BatchRequest{}
+		ba.Header = kvpb.Header{Txn: &txn}
+		cputA := cputArgs(keyA, valA, valA, txn.Sequence)
+		ba.Add(cputA)
+
+		mockSender.MockSend(func(ba *kvpb.BatchRequest) (*kvpb.BatchResponse, *kvpb.Error) {
+			require.Len(t, ba.Requests, 1)
+			require.IsType(t, &kvpb.GetRequest{}, ba.Requests[0].GetInner())
+			getReq := ba.Requests[0].GetInner().(*kvpb.GetRequest)
+			require.Equal(t, keyA, getReq.Key)
+			require.Equal(t, txn.Sequence, getReq.Sequence)
+			require.Equal(t, lock.Exclusive, getReq.KeyLockingStrength)
+
+			return ba.CreateReply(), nil
+		})
+
+		br, pErr := twb.SendLocked(ctx, ba)
+		if condEvalSuccessful {
+			require.Nil(t, pErr)
+			require.NotNil(t, br)
+		} else {
+			require.NotNil(t, pErr)
+			require.IsType(t, &kvpb.ConditionFailedError{}, pErr.GoError())
+		}
+
+		// Lastly, commit the transaction. A put should only be flushed if the condition
+		// evaluated successfully.
+		ba = &kvpb.BatchRequest{}
+		ba.Header = kvpb.Header{Txn: &txn}
+		ba.Add(&kvpb.EndTxnRequest{Commit: true})
+
+		mockSender.MockSend(func(ba *kvpb.BatchRequest) (*kvpb.BatchResponse, *kvpb.Error) {
+			if condEvalSuccessful {
+				require.Len(t, ba.Requests, 2)
+				require.IsType(t, &kvpb.PutRequest{}, ba.Requests[0].GetInner())
+				require.IsType(t, &kvpb.EndTxnRequest{}, ba.Requests[1].GetInner())
+			} else {
+				require.Len(t, ba.Requests, 1)
+				require.IsType(t, &kvpb.EndTxnRequest{}, ba.Requests[0].GetInner())
+			}
+
+			br = ba.CreateReply()
+			br.Txn = ba.Txn
+			return br, nil
+		})
+
+		br, pErr = twb.SendLocked(ctx, ba)
+		require.Nil(t, pErr)
+		require.NotNil(t, br)
+
+		// Even though we may have flushed the buffer, responses from the blind writes should
+		// not be returned.
+		require.Len(t, br.Responses, 1)
+		require.IsType(t, &kvpb.EndTxnResponse{}, br.Responses[0].GetInner())
+	})
 }

--- a/pkg/storage/BUILD.bazel
+++ b/pkg/storage/BUILD.bazel
@@ -67,6 +67,7 @@ go_library(
         "//pkg/storage/enginepb",
         "//pkg/storage/fs",
         "//pkg/storage/mvccencoding",
+        "//pkg/storage/mvcceval",
         "//pkg/storage/pebbleiter",
         "//pkg/storage/storagepb",
         "//pkg/util",

--- a/pkg/storage/mvcceval/BUILD.bazel
+++ b/pkg/storage/mvcceval/BUILD.bazel
@@ -1,0 +1,12 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "mvcceval",
+    srcs = ["eval.go"],
+    importpath = "github.com/cockroachdb/cockroach/pkg/storage/mvcceval",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/kv/kvpb",
+        "//pkg/roachpb",
+    ],
+)

--- a/pkg/storage/mvcceval/eval.go
+++ b/pkg/storage/mvcceval/eval.go
@@ -1,0 +1,35 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package mvcceval
+
+import (
+	"bytes"
+
+	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+)
+
+// MaybeConditionFailedError returns a non-nil ConditionFailedError if the
+// expected value does not match the actual value. If allowNoExisting is true,
+// then a non-existent actual value is allowed even when expected-value is
+// non-empty.
+func MaybeConditionFailedError(
+	expBytes []byte, actVal *roachpb.Value, actValPresent bool, allowNoExisting bool,
+) *kvpb.ConditionFailedError {
+	expValPresent := len(expBytes) != 0
+	if expValPresent && actValPresent {
+		if !bytes.Equal(expBytes, actVal.TagAndDataBytes()) {
+			return &kvpb.ConditionFailedError{
+				ActualValue: actVal,
+			}
+		}
+	} else if expValPresent != actValPresent && (actValPresent || !allowNoExisting) {
+		return &kvpb.ConditionFailedError{
+			ActualValue: actVal,
+		}
+	}
+	return nil
+}


### PR DESCRIPTION
This patch decomposes CPut requests, which are read-write in nature, into a read half and a write half. This is done by sending a (Exclusive) locking Get request to KV, followed by the evaluation of the CPut conditional on the client. If successful, the associated write is buffered on the client. Subsequently, at flush time, this buffered write will be converted to a Put request.

If the conditional evaluation isn't successful, an ConditionFailedError is returned back. The layers above should be oblivious to this transformation in the txnWriteBuffer; so the ConditionFailedError looks exactly like it would if it were generated by the server.

This patch mostly takes care of the linked issue. There'll be two more small patches to tie up loose ends once this merges:
1. We'll want to do something similar for InitPut requests, even though SQL no longer uses these.
2. We'll want to handle cases where the read half needs to be served out of the buffer.

Informs https://github.com/cockroachdb/cockroach/issues/139055

Release note: None