### PR TITLE
vecindex: fix race caused by reusing centroid memory

### DIFF
--- a/pkg/sql/vecindex/cspann/quantize/quantize.proto
+++ b/pkg/sql/vecindex/cspann/quantize/quantize.proto
@@ -35,6 +35,7 @@ message RaBitQuantizedVectorSet {
   // Centroid is the average of vectors in the set, representing its "center of
   // mass". Note that the centroid is computed when a vector set is created and
   // is not updated when vectors are added or removed.
+  // NOTE: The centroid should be treated as immutable.
   repeated float centroid = 1;
   // Codes is a set of RaBitQ quantization codes, with one code per quantized
   // vector in the set.
@@ -58,6 +59,7 @@ message UnQuantizedVectorSet {
   // Centroid is the average of vectors in the set, representing its "center of
   // mass". Note that the centroid is computed when a vector set is created and
   // is not updated when vectors are added or removed.
+  // NOTE: The centroid should be treated as immutable.
   repeated float centroid = 1;
   // CentroidDistances is a slice of the exact distances of the vectors in the
   // set from the centroid.

--- a/pkg/sql/vecindex/cspann/quantize/quantizer.go
+++ b/pkg/sql/vecindex/cspann/quantize/quantizer.go
@@ -85,6 +85,8 @@ type QuantizedVectorSet interface {
 	Clone() QuantizedVectorSet
 
 	// Clear removes all the elements of the vector set so that it may be reused.
-	// The new centroid is copied over the existing centroid.
+	// The new centroid replaces the existing centroid.
+	// NOTE: Centroids are immutable, so the existing centroid should be replaced
+	// rather than having its memory overwritten.
 	Clear(centroid vector.T)
 }

--- a/pkg/sql/vecindex/cspann/quantize/rabitqpb.go
+++ b/pkg/sql/vecindex/cspann/quantize/rabitqpb.go
@@ -138,7 +138,7 @@ func (vs *RaBitQuantizedVectorSet) ReplaceWithLast(offset int) {
 // Clone implements the QuantizedVectorSet interface.
 func (vs *RaBitQuantizedVectorSet) Clone() QuantizedVectorSet {
 	return &RaBitQuantizedVectorSet{
-		Centroid:          slices.Clone(vs.Centroid),
+		Centroid:          vs.Centroid, // Centroid is immutable
 		Codes:             vs.Codes.Clone(),
 		CodeCounts:        slices.Clone(vs.CodeCounts),
 		CentroidDistances: slices.Clone(vs.CentroidDistances),
@@ -161,7 +161,8 @@ func (vs *RaBitQuantizedVectorSet) Clear(centroid vector.T) {
 		// RaBitQCodeSet.Clear takes care of scribbling memory for vs.Codes.
 	}
 
-	copy(vs.Centroid, centroid)
+	// vs.Centroid is immutable, so do not try to reuse its memory.
+	vs.Centroid = centroid
 	vs.Codes.Clear()
 	vs.CodeCounts = vs.CodeCounts[:0]
 	vs.CentroidDistances = vs.CentroidDistances[:0]

--- a/pkg/sql/vecindex/cspann/quantize/rabitqpb_test.go
+++ b/pkg/sql/vecindex/cspann/quantize/rabitqpb_test.go
@@ -77,7 +77,6 @@ func TestRaBitQuantizedVectorSet(t *testing.T) {
 	// Ensure that cloning does not disturb anything.
 	cloned := quantizedSet.Clone().(*RaBitQuantizedVectorSet)
 	copy(cloned.Codes.At(0), []uint64{10, 20, 30})
-	cloned.Centroid[0] = 10
 	cloned.CodeCounts[0] = 10
 	cloned.CentroidDistances[0] = 10
 	cloned.DotProducts[0] = 10
@@ -97,7 +96,7 @@ func TestRaBitQuantizedVectorSet(t *testing.T) {
 	require.Equal(t, float32(4.56), quantizedSet.DotProducts[2])
 
 	// Check that clone is unaffected.
-	require.Equal(t, []float32{10, 2, 3}, cloned.Centroid)
+	require.Equal(t, []float32{1, 2, 3}, cloned.Centroid)
 	require.Equal(t, RaBitQCodeSet{Count: 1, Width: 3, Data: []uint64{10, 20, 30}}, cloned.Codes)
 	require.Equal(t, []uint32{10}, cloned.CodeCounts)
 	require.Equal(t, []float32{10}, cloned.CentroidDistances)

--- a/pkg/sql/vecindex/cspann/quantize/unquantizedpb.go
+++ b/pkg/sql/vecindex/cspann/quantize/unquantizedpb.go
@@ -30,7 +30,7 @@ func (vs *UnQuantizedVectorSet) GetCentroidDistances() []float32 {
 // Clone implements the QuantizedVectorSet interface.
 func (vs *UnQuantizedVectorSet) Clone() QuantizedVectorSet {
 	return &UnQuantizedVectorSet{
-		Centroid:          slices.Clone(vs.Centroid),
+		Centroid:          vs.Centroid, // Centroid is immutable
 		CentroidDistances: slices.Clone(vs.CentroidDistances),
 		Vectors:           vs.Vectors.Clone(),
 	}
@@ -38,7 +38,8 @@ func (vs *UnQuantizedVectorSet) Clone() QuantizedVectorSet {
 
 // Clear implements the QuantizedVectorSet interface.
 func (vs *UnQuantizedVectorSet) Clear(centroid vector.T) {
-	copy(vs.Centroid, centroid)
+	// vs.Centroid is immutable, so do not try to reuse its memory.
+	vs.Centroid = centroid
 	vs.CentroidDistances = vs.CentroidDistances[:0]
 	vs.Vectors.Clear()
 }

--- a/pkg/sql/vecindex/cspann/quantize/unquantizedpb_test.go
+++ b/pkg/sql/vecindex/cspann/quantize/unquantizedpb_test.go
@@ -33,7 +33,6 @@ func TestUnQuantizedVectorSet(t *testing.T) {
 
 	// Ensure that cloning does not disturb anything.
 	cloned := quantizedSet.Clone().(*UnQuantizedVectorSet)
-	cloned.Centroid[0] = 10
 	cloned.CentroidDistances[0] = 10
 	copy(cloned.Vectors.At(0), vector.T{0, 0})
 	cloned.ReplaceWithLast(1)
@@ -49,7 +48,7 @@ func TestUnQuantizedVectorSet(t *testing.T) {
 	require.Equal(t, []float32{5, 25, 181, 113}, testutils.RoundFloats(distances, 4))
 
 	// Check that clone is unaffected.
-	require.Equal(t, []float32{10, 2}, cloned.Centroid)
+	require.Equal(t, []float32{4, 2}, cloned.Centroid)
 	require.Equal(t, []float32{10, 9.43, 4.12, 6.71}, testutils.RoundFloats(cloned.CentroidDistances, 2))
 	require.Equal(t, vector.Set{Dims: 2, Count: 4, Data: []float32{0, 0, 9, 10, 5, 6, 7, 8}}, cloned.Vectors)
 }


### PR DESCRIPTION
The race detector is failing due to QuantizedVectorSet.Clear implementations attempting to reuse centroid memory. This commit changes Clear to treat the centroid as immutable, replacing it rather than overwriting its memory. This fits better with the existing GetCentroid method, which already specifies that the centroid is immutable. It enables sharing of centroids, such as sharing the zero-valued centroid across root partitions in multiple K-means trees in an index.

Epic: CRDB-42943

Release note: None