### PR TITLE
raftentry: include last index in Cache.Clear()

### DIFF
--- a/pkg/kv/kvserver/raftentry/cache.go
+++ b/pkg/kv/kvserver/raftentry/cache.go
@@ -193,7 +193,7 @@ func (c *Cache) Add(id roachpb.RangeID, ents []raftpb.Entry, truncate bool) {
 	c.recordUpdate(p, bytesAdded-bytesRemoved, bytesGuessed, entriesAdded-entriesRemoved)
 }
 
-// Clear removes all entries on the given range with index less than hi.
+// Clear removes all entries on the given range with index <= hi.
 func (c *Cache) Clear(id roachpb.RangeID, hi kvpb.RaftIndex) {
 	c.mu.Lock()
 	p := c.getPartLocked(id, false /* create */, false /* recordUse */)

--- a/pkg/kv/kvserver/raftentry/ring_buffer.go
+++ b/pkg/kv/kvserver/raftentry/ring_buffer.go
@@ -33,7 +33,7 @@ func (b *ringBuf) add(ents []raftpb.Entry) (addedBytes, addedEntries int32) {
 	if it := last(b); it.valid(b) && kvpb.RaftIndex(ents[0].Index) > it.index(b)+1 {
 		// If ents is non-contiguous and later than the currently cached range then
 		// remove the current entries and add ents in their place.
-		removedBytes, removedEntries := b.clearTo(it.index(b) + 1)
+		removedBytes, removedEntries := b.clearTo(it.index(b))
 		addedBytes, addedEntries = -1*removedBytes, -1*removedEntries
 	}
 	before, after, ok := computeExtension(b, kvpb.RaftIndex(ents[0].Index), kvpb.RaftIndex(ents[len(ents)-1].Index))
@@ -97,27 +97,22 @@ func (b *ringBuf) truncateFrom(lo kvpb.RaftIndex) (removedBytes, removedEntries 
 	return removedBytes, removedEntries
 }
 
-// clearTo clears all entries from the ringBuf with index less than hi. The
+// clearTo clears all entries from the ringBuf with index <= hi. The
 // method returns the aggregate size and count of entries removed.
 func (b *ringBuf) clearTo(hi kvpb.RaftIndex) (removedBytes, removedEntries int32) {
-	// TODO(pav-kv): since hi is not inclusive, this should be hi <= firstIndex.
 	if b.len == 0 || hi < first(b).index(b) {
 		return
 	}
 	it := first(b)
 	ok := it.valid(b) // true
-	firstIndex := it.index(b)
-	for ok && it.index(b) < hi {
+	for ok && it.index(b) <= hi {
 		removedBytes += int32(it.entry(b).Size())
 		removedEntries++
 		it.clear(b)
 		it, ok = it.next(b)
 	}
-	offset := int(hi - firstIndex)
-	if offset > b.len {
-		offset = b.len
-	}
-	b.len = b.len - offset
+	offset := int(removedEntries)
+	b.len -= offset
 	b.head = (b.head + offset) % len(b.buf)
 	if b.len < (len(b.buf) / shrinkThreshold) {
 		realloc(b, 0, b.len)

--- a/pkg/kv/kvserver/raftentry/ring_buffer.go
+++ b/pkg/kv/kvserver/raftentry/ring_buffer.go
@@ -100,6 +100,7 @@ func (b *ringBuf) truncateFrom(lo kvpb.RaftIndex) (removedBytes, removedEntries 
 // clearTo clears all entries from the ringBuf with index less than hi. The
 // method returns the aggregate size and count of entries removed.
 func (b *ringBuf) clearTo(hi kvpb.RaftIndex) (removedBytes, removedEntries int32) {
+	// TODO(pav-kv): since hi is not inclusive, this should be hi <= firstIndex.
 	if b.len == 0 || hi < first(b).index(b) {
 		return
 	}

--- a/pkg/kv/kvserver/raftentry/ring_buffer_test.go
+++ b/pkg/kv/kvserver/raftentry/ring_buffer_test.go
@@ -52,7 +52,7 @@ func TestRingBuffer_Add(t *testing.T) {
 	}
 
 	{
-		rb, re := b.clearTo(3)
+		rb, re := b.clearTo(2)
 		eq(t, b, 3, 4, 5, 6)
 		require.EqualValues(t, rb, 2*size)
 		require.EqualValues(t, re, 2)
@@ -173,17 +173,19 @@ func TestRingBuffer_TruncateFrom(t *testing.T) {
 
 func TestRingBuffer_ClearTo(t *testing.T) {
 	b := &ringBuf{}
-	b.clearTo(100)
+	b.clearTo(99)
 	eq(t, b)
 	b.add(newEntries(10, 20, 9))
 	eq(t, b, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19)
-	b.clearTo(10)
+	b.clearTo(8)
 	eq(t, b, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19)
-	b.clearTo(11)
+	b.clearTo(9)
+	eq(t, b, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19)
+	b.clearTo(10)
 	eq(t, b, 11, 12, 13, 14, 15, 16, 17, 18, 19)
-	b.clearTo(17)
+	b.clearTo(16)
 	eq(t, b, 17, 18, 19)
-	b.clearTo(100)
+	b.clearTo(99)
 	eq(t, b)
 }
 

--- a/pkg/kv/kvserver/replica_application_result.go
+++ b/pkg/kv/kvserver/replica_application_result.go
@@ -509,9 +509,9 @@ func (r *Replica) handleTruncatedStateResult(
 	r.shMu.raftTruncState = *t
 	r.mu.Unlock()
 
-	// Clear any entries in the Raft log entry cache for this range up
-	// to and including the most recently truncated index.
-	r.store.raftEntryCache.Clear(r.RangeID, t.Index+1)
+	// Clear any entries in the Raft log entry cache for this range up to and
+	// including the most recently truncated index.
+	r.store.raftEntryCache.Clear(r.RangeID, t.Index)
 
 	// Truncate the sideloaded storage. This is safe only if the new truncated
 	// state is durably stored on disk, i.e. synced.

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -7498,7 +7498,7 @@ func TestEntries(t *testing.T) {
 			// Case 19: lo and hi are available, but entry cache evicted.
 			{lo: indexes[5], hi: indexes[9], expResultCount: 4, expCacheCount: 0, setup: func() {
 				// Manually evict cache for the first 10 log entries.
-				repl.store.raftEntryCache.Clear(rangeID, indexes[9]+1)
+				repl.store.raftEntryCache.Clear(rangeID, indexes[9])
 				indexes = append(indexes, populateLogs(10, 40)...)
 			}},
 			// Case 20: lo and hi are available, entry cache evicted and hi available in cache.


### PR DESCRIPTION
This commit converts `Clear`/`clearTo` methods of the raft entry cache to include the last entry. This is typically called in the context of knowing the new truncated/compacted index, so it's good to avoid the extra +1 in the call.

This commit also fixes an off-by-one error in `clearTo` check. It wasn't a bug, but the method was doing more work than necessary in the case when the truncated prefix was touching the first index in the cache.

Epic: none
Release note: none