### PR TITLE
kvserver: update raft log stats with trunc state

### DIFF
--- a/pkg/kv/kvserver/logstore/logstore.go
+++ b/pkg/kv/kvserver/logstore/logstore.go
@@ -591,7 +591,7 @@ func (s *LogStore) ComputeSize(ctx context.Context) (int64, error) {
 	if err != nil {
 		return 0, err
 	}
-	totalSideloaded, err := s.Sideload.BytesIfTruncatedFromTo(ctx, kvpb.RaftSpan{Last: math.MaxUint64})
+	_, totalSideloaded, err := s.Sideload.Stats(ctx, kvpb.RaftSpan{Last: math.MaxUint64})
 	if err != nil {
 		return 0, err
 	}

--- a/pkg/kv/kvserver/logstore/sideload.go
+++ b/pkg/kv/kvserver/logstore/sideload.go
@@ -44,16 +44,13 @@ type SideloadStorage interface {
 	Purge(_ context.Context, index kvpb.RaftIndex, term kvpb.RaftTerm) (int64, error)
 	// Clear files that may have been written by this SideloadStorage.
 	Clear(context.Context) error
-	// HasAnyEntry returns whether there is any entry in the given log span.
-	HasAnyEntry(_ context.Context, _ kvpb.RaftSpan) (bool, error)
 	// TruncateTo removes all files belonging to an index <= the given index.
 	// Returns the number of bytes freed, or an error.
+	// TODO(pav-kv): don't need to count the bytes anymore.
 	TruncateTo(_ context.Context, index kvpb.RaftIndex) (freed int64, _ error)
-	// BytesIfTruncatedFromTo returns the number of bytes that would be freed, if
-	// one were to truncate the given (from, to] log span.
-	// TODO(pav-kv): merge this with HasAnyEntry into a single "stats" call. The
-	// truncation path needs both anyway.
-	BytesIfTruncatedFromTo(_ context.Context, _ kvpb.RaftSpan) (freed int64, _ error)
+	// Stats returns the number and the total size of the sideloaded entries in
+	// the given log span.
+	Stats(_ context.Context, _ kvpb.RaftSpan) (entries uint64, size int64, _ error)
 	// Returns an absolute path to the file that Get() would return the contents
 	// of. Does not check whether the file actually exists.
 	Filename(_ context.Context, index kvpb.RaftIndex, term kvpb.RaftTerm) (string, error)

--- a/pkg/kv/kvserver/logstore/sideload.go
+++ b/pkg/kv/kvserver/logstore/sideload.go
@@ -45,9 +45,7 @@ type SideloadStorage interface {
 	// Clear files that may have been written by this SideloadStorage.
 	Clear(context.Context) error
 	// TruncateTo removes all files belonging to an index <= the given index.
-	// Returns the number of bytes freed, or an error.
-	// TODO(pav-kv): don't need to count the bytes anymore.
-	TruncateTo(_ context.Context, index kvpb.RaftIndex) (freed int64, _ error)
+	TruncateTo(_ context.Context, index kvpb.RaftIndex) error
 	// Stats returns the number and the total size of the sideloaded entries in
 	// the given log span.
 	Stats(_ context.Context, _ kvpb.RaftSpan) (entries uint64, size int64, _ error)

--- a/pkg/kv/kvserver/logstore/sideload_disk.go
+++ b/pkg/kv/kvserver/logstore/sideload_disk.go
@@ -188,15 +188,7 @@ func (ss *DiskSideloadStorage) Clear(_ context.Context) error {
 func (ss *DiskSideloadStorage) TruncateTo(
 	ctx context.Context, lastIndex kvpb.RaftIndex,
 ) (bytesFreed int64, _ error) {
-	return ss.possiblyTruncateTo(ctx, kvpb.RaftSpan{
-		After: 0, Last: lastIndex,
-	}, true /* doTruncate */)
-}
-
-// Helper for truncation or byte calculation for (from, to].
-func (ss *DiskSideloadStorage) possiblyTruncateTo(
-	ctx context.Context, span kvpb.RaftSpan, doTruncate bool,
-) (bytesFreed int64, _ error) {
+	span := kvpb.RaftSpan{Last: lastIndex}
 	deletedAll := true
 	if err := ss.forEach(ctx, func(index kvpb.RaftIndex, filename string) (bool, error) {
 		if !span.Contains(index) {
@@ -204,13 +196,7 @@ func (ss *DiskSideloadStorage) possiblyTruncateTo(
 			return true, nil
 		}
 		// index is in (span.After, span.Last].
-		var fileSize int64
-		var err error
-		if doTruncate {
-			fileSize, err = ss.purgeFile(ctx, filename)
-		} else {
-			fileSize, err = ss.fileSize(filename)
-		}
+		fileSize, err := ss.purgeFile(ctx, filename)
 		if err != nil {
 			return false, err
 		}
@@ -220,7 +206,7 @@ func (ss *DiskSideloadStorage) possiblyTruncateTo(
 		return 0, err
 	}
 
-	if deletedAll && doTruncate {
+	if deletedAll {
 		// The directory may not exist, or it may exist and have been empty.
 		// Not worth trying to figure out which one, just try to delete.
 		err := ss.eng.Env().Remove(ss.dir)
@@ -234,27 +220,25 @@ func (ss *DiskSideloadStorage) possiblyTruncateTo(
 	return bytesFreed, nil
 }
 
-// HasAnyEntry implements SideloadStorage.
-func (ss *DiskSideloadStorage) HasAnyEntry(ctx context.Context, span kvpb.RaftSpan) (bool, error) {
-	// Find any file at index in (from, to].
-	found := false
-	if err := ss.forEach(ctx, func(index kvpb.RaftIndex, _ string) (bool, error) {
-		if span.Contains(index) {
-			found = true
-			return false, nil // stop the iteration
+// Stats implements SideloadStorage.
+func (ss *DiskSideloadStorage) Stats(
+	ctx context.Context, span kvpb.RaftSpan,
+) (entries uint64, size int64, _ error) {
+	if err := ss.forEach(ctx, func(index kvpb.RaftIndex, filename string) (bool, error) {
+		if !span.Contains(index) {
+			return true, nil // skip
 		}
+		entries++
+		fileSize, err := ss.fileSize(filename)
+		if err != nil {
+			return false, err
+		}
+		size += fileSize
 		return true, nil
 	}); err != nil {
-		return false, err
+		return 0, 0, err
 	}
-	return found, nil
-}
-
-// BytesIfTruncatedFromTo implements SideloadStorage.
-func (ss *DiskSideloadStorage) BytesIfTruncatedFromTo(
-	ctx context.Context, span kvpb.RaftSpan,
-) (freed int64, _ error) {
-	return ss.possiblyTruncateTo(ctx, span, false /* doTruncate */)
+	return entries, size, nil
 }
 
 // forEach runs the given visit function for each file in the sideloaded storage

--- a/pkg/kv/kvserver/raft_truncator_replica.go
+++ b/pkg/kv/kvserver/raft_truncator_replica.go
@@ -30,7 +30,7 @@ func (r *raftTruncatorReplica) getTruncatedState() kvserverpb.RaftTruncatedState
 }
 
 func (r *raftTruncatorReplica) handleTruncationResult(ctx context.Context, pt pendingTruncation) {
-	(*Replica)(r).handleTruncatedStateResult(ctx, pt.RaftTruncatedState,
+	(*Replica)(r).handleTruncatedStateResultRaftMuLocked(ctx, pt.RaftTruncatedState,
 		pt.expectedFirstIndex, pt.logDeltaBytes, pt.isDeltaTrusted)
 }
 

--- a/pkg/kv/kvserver/raft_truncator_replica.go
+++ b/pkg/kv/kvserver/raft_truncator_replica.go
@@ -41,7 +41,8 @@ func (r *raftTruncatorReplica) getPendingTruncs() *pendingLogTruncations {
 func (r *raftTruncatorReplica) sideloadedBytesIfTruncatedFromTo(
 	ctx context.Context, span kvpb.RaftSpan,
 ) (freed int64, err error) {
-	return r.raftMu.sideloaded.BytesIfTruncatedFromTo(ctx, span)
+	_, freed, err = r.raftMu.sideloaded.Stats(ctx, span)
+	return freed, err
 }
 
 func (r *raftTruncatorReplica) getStateLoader() stateloader.StateLoader {

--- a/pkg/kv/kvserver/raft_truncator_replica.go
+++ b/pkg/kv/kvserver/raft_truncator_replica.go
@@ -30,7 +30,7 @@ func (r *raftTruncatorReplica) getTruncatedState() kvserverpb.RaftTruncatedState
 }
 
 func (r *raftTruncatorReplica) handleTruncationResult(ctx context.Context, pt pendingTruncation) {
-	(*Replica)(r).handleTruncatedStateResult(ctx, &pt.RaftTruncatedState,
+	(*Replica)(r).handleTruncatedStateResult(ctx, pt.RaftTruncatedState,
 		pt.expectedFirstIndex, pt.logDeltaBytes, pt.isDeltaTrusted, true /* sideloadIncluded */)
 }
 

--- a/pkg/kv/kvserver/raft_truncator_replica.go
+++ b/pkg/kv/kvserver/raft_truncator_replica.go
@@ -29,18 +29,9 @@ func (r *raftTruncatorReplica) getTruncatedState() kvserverpb.RaftTruncatedState
 	return r.shMu.raftTruncState
 }
 
-func (r *raftTruncatorReplica) setTruncatedStateAndSideEffects(
-	ctx context.Context,
-	trunc *kvserverpb.RaftTruncatedState,
-	expectedFirstIndexPreTruncation kvpb.RaftIndex,
-) (expectedFirstIndexWasAccurate bool) {
-	_, expectedFirstIndexAccurate := (*Replica)(r).handleTruncatedStateResult(
-		ctx, trunc, expectedFirstIndexPreTruncation)
-	return expectedFirstIndexAccurate
-}
-
-func (r *raftTruncatorReplica) setTruncationDeltaAndTrusted(deltaBytes int64, isDeltaTrusted bool) {
-	(*Replica)(r).handleRaftLogDeltaResult(deltaBytes, isDeltaTrusted)
+func (r *raftTruncatorReplica) handleTruncationResult(ctx context.Context, pt pendingTruncation) {
+	(*Replica)(r).handleTruncatedStateResult(ctx, &pt.RaftTruncatedState,
+		pt.expectedFirstIndex, pt.logDeltaBytes, pt.isDeltaTrusted, true /* sideloadIncluded */)
 }
 
 func (r *raftTruncatorReplica) getPendingTruncs() *pendingLogTruncations {

--- a/pkg/kv/kvserver/raft_truncator_replica.go
+++ b/pkg/kv/kvserver/raft_truncator_replica.go
@@ -40,22 +40,7 @@ func (r *raftTruncatorReplica) setTruncatedStateAndSideEffects(
 }
 
 func (r *raftTruncatorReplica) setTruncationDeltaAndTrusted(deltaBytes int64, isDeltaTrusted bool) {
-	r.raftMu.AssertHeld()
-	r.mu.Lock()
-	defer r.mu.Unlock()
-	r.shMu.raftLogSize += deltaBytes
-	r.shMu.raftLogLastCheckSize += deltaBytes
-	// Ensure raftLog{,LastCheck}Size is not negative since it isn't persisted
-	// between server restarts.
-	if r.shMu.raftLogSize < 0 {
-		r.shMu.raftLogSize = 0
-	}
-	if r.shMu.raftLogLastCheckSize < 0 {
-		r.shMu.raftLogLastCheckSize = 0
-	}
-	if !isDeltaTrusted {
-		r.shMu.raftLogSizeTrusted = false
-	}
+	(*Replica)(r).handleRaftLogDeltaResult(deltaBytes, isDeltaTrusted)
 }
 
 func (r *raftTruncatorReplica) getPendingTruncs() *pendingLogTruncations {

--- a/pkg/kv/kvserver/raft_truncator_replica.go
+++ b/pkg/kv/kvserver/raft_truncator_replica.go
@@ -31,7 +31,7 @@ func (r *raftTruncatorReplica) getTruncatedState() kvserverpb.RaftTruncatedState
 
 func (r *raftTruncatorReplica) handleTruncationResult(ctx context.Context, pt pendingTruncation) {
 	(*Replica)(r).handleTruncatedStateResult(ctx, pt.RaftTruncatedState,
-		pt.expectedFirstIndex, pt.logDeltaBytes, pt.isDeltaTrusted, true /* sideloadIncluded */)
+		pt.expectedFirstIndex, pt.logDeltaBytes, pt.isDeltaTrusted)
 }
 
 func (r *raftTruncatorReplica) getPendingTruncs() *pendingLogTruncations {

--- a/pkg/kv/kvserver/replica_app_batch.go
+++ b/pkg/kv/kvserver/replica_app_batch.go
@@ -64,6 +64,11 @@ type replicaAppBatch struct {
 	// sideloaded storage file. Such commands may apply side effects only after
 	// their application to state machine is synced.
 	changeTruncatesSideloadedFiles bool
+	// truncatedSideloadedSize is set when changeTruncatesSideloadedFiles is true,
+	// and contains the total size of the removed sideloaded entry files.
+	// TODO(pav-kv): make a type for the truncation-related parameters.
+	// Potentially, can use the pendingTruncation type here.
+	truncatedSideloadedSize int64
 
 	start                   time.Time // time at NewBatch()
 	followerStoreWriteBytes kvadmission.FollowerStoreWriteBytes
@@ -450,12 +455,13 @@ func (b *replicaAppBatch) runPostAddTriggersReplicaOnly(
 			// We only need to check sideloaded entries in this path. The loosely
 			// coupled truncation mechanism in the other branch already ensures
 			// enacting truncations only after state machine synced.
-			if entries, _, err := b.r.raftMu.sideloaded.Stats(ctx, kvpb.RaftSpan{
+			if entries, size, err := b.r.raftMu.sideloaded.Stats(ctx, kvpb.RaftSpan{
 				After: b.truncState.Index, Last: truncatedState.Index,
 			}); err != nil {
 				return errors.Wrap(err, "failed searching for sideloaded entries")
 			} else if entries != 0 {
 				b.changeTruncatesSideloadedFiles = true
+				b.truncatedSideloadedSize = size
 			}
 		} else {
 			// The truncated state was discarded, or we are queuing a pending

--- a/pkg/kv/kvserver/replica_app_batch.go
+++ b/pkg/kv/kvserver/replica_app_batch.go
@@ -450,11 +450,11 @@ func (b *replicaAppBatch) runPostAddTriggersReplicaOnly(
 			// We only need to check sideloaded entries in this path. The loosely
 			// coupled truncation mechanism in the other branch already ensures
 			// enacting truncations only after state machine synced.
-			if has, err := b.r.raftMu.sideloaded.HasAnyEntry(ctx, kvpb.RaftSpan{
+			if entries, _, err := b.r.raftMu.sideloaded.Stats(ctx, kvpb.RaftSpan{
 				After: b.truncState.Index, Last: truncatedState.Index,
 			}); err != nil {
 				return errors.Wrap(err, "failed searching for sideloaded entries")
-			} else if has {
+			} else if entries != 0 {
 				b.changeTruncatesSideloadedFiles = true
 			}
 		} else {

--- a/pkg/kv/kvserver/replica_application_result.go
+++ b/pkg/kv/kvserver/replica_application_result.go
@@ -498,6 +498,19 @@ func (r *Replica) handleLeaseResult(
 		assertNoLeaseJump)
 }
 
+// handleTruncatedStateResult is a post-apply handler for the raft log
+// truncation command. It updates the in-memory state of the Replica with the
+// new RaftTruncatedState, and removes obsolete entries from the raft log cache
+// and sideloaded storage.
+//
+// The truncation is finalized by the handleRaftLogDeltaResult method below,
+// which updates the raft log size using the computed delta. The reason for
+// having two separate methods is that the handling is different between the
+// tightly and loosely coupled truncation stacks. The latter computes the log
+// size delta when preparing the truncation, while the former only evaluates a
+// partial delta and accounts for the sideloaded files size when applying.
+//
+// TODO(pav-kv): simplify this.
 func (r *Replica) handleTruncatedStateResult(
 	ctx context.Context,
 	t *kvserverpb.RaftTruncatedState,
@@ -545,6 +558,27 @@ func (r *Replica) handleTruncatedStateResult(
 	// TODO(#136416): If a crash occurs before the files are durably removed,
 	// there will be dangling files at the next start. Clean them up at startup.
 	return -size, expectedFirstIndexWasAccurate
+}
+
+// TODO(pav-kv): update the stats in the same Replica.mu section with the
+// truncated state update.
+func (r *Replica) handleRaftLogDeltaResult(delta int64, isDeltaTrusted bool) {
+	r.raftMu.AssertHeld()
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.shMu.raftLogSize += delta
+	r.shMu.raftLogLastCheckSize += delta
+	// Ensure raftLog{,LastCheck}Size is not negative since it isn't persisted
+	// between server restarts.
+	if r.shMu.raftLogSize < 0 {
+		r.shMu.raftLogSize = 0
+	}
+	if r.shMu.raftLogLastCheckSize < 0 {
+		r.shMu.raftLogLastCheckSize = 0
+	}
+	if !isDeltaTrusted {
+		r.shMu.raftLogSizeTrusted = false
+	}
 }
 
 func (r *Replica) handleGCThresholdResult(ctx context.Context, thresh *hlc.Timestamp) {
@@ -625,9 +659,4 @@ func (r *Replica) handleChangeReplicasResult(
 	}
 
 	return true
-}
-
-// TODO(sumeer): remove method when all truncation is loosely coupled.
-func (r *Replica) handleRaftLogDeltaResult(ctx context.Context, delta int64, isDeltaTrusted bool) {
-	(*raftTruncatorReplica)(r).setTruncationDeltaAndTrusted(delta, isDeltaTrusted)
 }

--- a/pkg/kv/kvserver/replica_application_result.go
+++ b/pkg/kv/kvserver/replica_application_result.go
@@ -500,25 +500,34 @@ func (r *Replica) handleLeaseResult(
 
 // handleTruncatedStateResult is a post-apply handler for the raft log
 // truncation command. It updates the in-memory state of the Replica with the
-// new RaftTruncatedState, and removes obsolete entries from the raft log cache
-// and sideloaded storage.
+// new RaftTruncatedState and log size delta, and removes obsolete entries from
+// the raft log cache and sideloaded storage.
 //
-// The truncation is finalized by the handleRaftLogDeltaResult method below,
-// which updates the raft log size using the computed delta. The reason for
-// having two separate methods is that the handling is different between the
-// tightly and loosely coupled truncation stacks. The latter computes the log
-// size delta when preparing the truncation, while the former only evaluates a
-// partial delta and accounts for the sideloaded files size when applying.
+// The sideloadIncluded flag specifies whether the raftLogDelta already includes
+// the total size of the sideloaded entries. It is true in loosely coupled
+// truncations stack, and false in the tightly coupled stack.
+//
+// The isDeltaTrusted flag specifies whether the raftLogDelta has been correctly
+// computed. The loosely coupled truncations stack sets it to false if, for
+// example, it failed to account for the sideloaded entries. The tightly coupled
+// truncations have correct stats (but excluding the sideloaded entries).
 //
 // TODO(pav-kv): simplify this.
 func (r *Replica) handleTruncatedStateResult(
 	ctx context.Context,
 	t *kvserverpb.RaftTruncatedState,
 	expectedFirstIndexPreTruncation kvpb.RaftIndex,
-) (raftLogDelta int64, expectedFirstIndexWasAccurate bool) {
+	raftLogDelta int64,
+	isDeltaTrusted bool,
+	sideloadIncluded bool,
+) {
 	r.raftMu.AssertHeld()
-	expectedFirstIndexWasAccurate =
+	// NB: The expected first index is zero if this proposal is from before v22.1
+	// that added it, when all truncations were strongly coupled.
+	// TODO(pav-kv): remove the zero check after any below-raft migration.
+	expectedFirstIndexWasAccurate := expectedFirstIndexPreTruncation == 0 ||
 		r.shMu.raftTruncState.Index+1 == expectedFirstIndexPreTruncation
+	isRaftLogTruncationDeltaTrusted := isDeltaTrusted && expectedFirstIndexWasAccurate
 
 	// TODO(pav-kv): we are updating the truncation state, but leaving the raft
 	// log size at the previous value and update it in a different Replica.mu
@@ -557,7 +566,10 @@ func (r *Replica) handleTruncatedStateResult(
 	// reasons.
 	// TODO(#136416): If a crash occurs before the files are durably removed,
 	// there will be dangling files at the next start. Clean them up at startup.
-	return -size, expectedFirstIndexWasAccurate
+	if !sideloadIncluded {
+		raftLogDelta -= size
+	}
+	r.handleRaftLogDeltaResult(raftLogDelta, isRaftLogTruncationDeltaTrusted)
 }
 
 // TODO(pav-kv): update the stats in the same Replica.mu section with the

--- a/pkg/kv/kvserver/replica_application_result.go
+++ b/pkg/kv/kvserver/replica_application_result.go
@@ -515,7 +515,7 @@ func (r *Replica) handleLeaseResult(
 // TODO(pav-kv): simplify this.
 func (r *Replica) handleTruncatedStateResult(
 	ctx context.Context,
-	t *kvserverpb.RaftTruncatedState,
+	t kvserverpb.RaftTruncatedState,
 	expectedFirstIndexPreTruncation kvpb.RaftIndex,
 	raftLogDelta int64,
 	isDeltaTrusted bool,
@@ -540,7 +540,7 @@ func (r *Replica) handleTruncatedStateResult(
 	// the truncated state is updated first. The semantics would be that the log
 	// is truncated "logically" first, and then physically under raftMu.
 	r.mu.Lock()
-	r.shMu.raftTruncState = *t
+	r.shMu.raftTruncState = t
 	r.mu.Unlock()
 
 	// Clear any entries in the Raft log entry cache for this range up

--- a/pkg/kv/kvserver/replica_application_result.go
+++ b/pkg/kv/kvserver/replica_application_result.go
@@ -503,9 +503,10 @@ func (r *Replica) handleTruncatedStateResult(
 	t *kvserverpb.RaftTruncatedState,
 	expectedFirstIndexPreTruncation kvpb.RaftIndex,
 ) (raftLogDelta int64, expectedFirstIndexWasAccurate bool) {
-	r.mu.Lock()
+	r.raftMu.AssertHeld()
 	expectedFirstIndexWasAccurate =
 		r.shMu.raftTruncState.Index+1 == expectedFirstIndexPreTruncation
+	r.mu.Lock()
 	r.shMu.raftTruncState = *t
 	r.mu.Unlock()
 

--- a/pkg/kv/kvserver/replica_application_state_machine.go
+++ b/pkg/kv/kvserver/replica_application_state_machine.go
@@ -338,7 +338,7 @@ func (sm *replicaStateMachine) handleNonTrivialReplicatedEvalResult(
 		// The proposer hasn't included the sideloaded entries into the delta. We
 		// counted these above, and combine the deltas.
 		raftLogDelta += rResult.RaftLogDelta
-		sm.r.handleRaftLogDeltaResult(ctx, raftLogDelta, isRaftLogTruncationDeltaTrusted)
+		sm.r.handleRaftLogDeltaResult(raftLogDelta, isRaftLogTruncationDeltaTrusted)
 
 		rResult.RaftLogDelta = 0
 		rResult.RaftExpectedFirstIndex = 0

--- a/pkg/kv/kvserver/replica_application_state_machine.go
+++ b/pkg/kv/kvserver/replica_application_state_machine.go
@@ -331,7 +331,7 @@ func (sm *replicaStateMachine) handleNonTrivialReplicatedEvalResult(
 		// The delta in these historical proposals is accurate, but does not account
 		// for the sideloaded entries.
 		// TODO(pav-kv): remove the zero clause after any below-raft migration.
-		sm.r.handleTruncatedStateResult(ctx, truncState, rResult.RaftExpectedFirstIndex,
+		sm.r.handleTruncatedStateResult(ctx, *truncState, rResult.RaftExpectedFirstIndex,
 			rResult.RaftLogDelta, true /* isDeltaTrusted */, false /* sideloadIncluded */)
 		rResult.RaftLogDelta = 0
 		rResult.RaftExpectedFirstIndex = 0

--- a/pkg/kv/kvserver/replica_application_state_machine.go
+++ b/pkg/kv/kvserver/replica_application_state_machine.go
@@ -333,8 +333,8 @@ func (sm *replicaStateMachine) handleNonTrivialReplicatedEvalResult(
 		// for the sideloaded entries.
 		// TODO(pav-kv): remove the zero clause after any below-raft migration.
 		logDelta := rResult.RaftLogDelta - sm.batch.truncatedSideloadedSize
-		sm.r.handleTruncatedStateResult(ctx, *truncState, rResult.RaftExpectedFirstIndex,
-			logDelta, true /* isDeltaTrusted */)
+		sm.r.handleTruncatedStateResultRaftMuLocked(ctx, *truncState,
+			rResult.RaftExpectedFirstIndex, logDelta, true /* isDeltaTrusted */)
 		rResult.RaftLogDelta = 0
 		rResult.RaftExpectedFirstIndex = 0
 	}

--- a/pkg/kv/kvserver/replica_application_state_machine.go
+++ b/pkg/kv/kvserver/replica_application_state_machine.go
@@ -326,20 +326,13 @@ func (sm *replicaStateMachine) handleNonTrivialReplicatedEvalResult(
 	// TODO(#93248): the strongly coupled truncation code will be removed once the
 	// loosely coupled truncations are the default.
 	if truncState != nil {
-		// NB: raftLogDelta reflects removals of any sideloaded entries.
-		raftLogDelta, expectedFirstIndexWasAccurate := sm.r.handleTruncatedStateResult(
-			ctx, truncState, rResult.RaftExpectedFirstIndex)
 		// NB: The RaftExpectedFirstIndex field is zero if this proposal is from
 		// before v22.1 that added it, when all truncations were strongly coupled.
-		// The delta in these historical proposals is thus accurate.
-		// TODO(pav-kv): remove the zero check after any below-raft migration.
-		isRaftLogTruncationDeltaTrusted := expectedFirstIndexWasAccurate ||
-			rResult.RaftExpectedFirstIndex == 0
-		// The proposer hasn't included the sideloaded entries into the delta. We
-		// counted these above, and combine the deltas.
-		raftLogDelta += rResult.RaftLogDelta
-		sm.r.handleRaftLogDeltaResult(raftLogDelta, isRaftLogTruncationDeltaTrusted)
-
+		// The delta in these historical proposals is accurate, but does not account
+		// for the sideloaded entries.
+		// TODO(pav-kv): remove the zero clause after any below-raft migration.
+		sm.r.handleTruncatedStateResult(ctx, truncState, rResult.RaftExpectedFirstIndex,
+			rResult.RaftLogDelta, true /* isDeltaTrusted */, false /* sideloadIncluded */)
 		rResult.RaftLogDelta = 0
 		rResult.RaftExpectedFirstIndex = 0
 	}


### PR DESCRIPTION
This PR iterates on the raft log truncation code, and makes it more consolidated.

It also fixes one bug: the log size update is now done in the same `Replica.mu` critical section with the `RaftTruncatedState` update. This is achieved by moving the truncated files size computation from post-apply to pre-apply stage. The latter change bears no performance implications because the pre-apply stage already reads from FS when determining whether a truncation affects any sideloaded entries.

Epic: none
Release note: none