### PR TITLE
release-25.1: multiregion: fix replicas leak out of configured regions

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region
@@ -398,15 +398,15 @@ CREATE TABLE public.regional_primary_region_table (
 query TT
 SHOW ZONE CONFIGURATION FOR TABLE regional_primary_region_table
 ----
-DATABASE multi_region_test_db  ALTER DATABASE multi_region_test_db CONFIGURE ZONE USING
-                                 range_min_bytes = 134217728,
-                                 range_max_bytes = 536870912,
-                                 gc.ttlseconds = 14400,
-                                 num_replicas = 5,
-                                 num_voters = 5,
-                                 constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                                 voter_constraints = '{+region=ca-central-1: 2}',
-                                 lease_preferences = '[[+region=ca-central-1]]'
+TABLE regional_primary_region_table  ALTER TABLE regional_primary_region_table CONFIGURE ZONE USING
+                                       range_min_bytes = 134217728,
+                                       range_max_bytes = 536870912,
+                                       gc.ttlseconds = 14400,
+                                       num_replicas = 5,
+                                       num_voters = 5,
+                                       constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                       voter_constraints = '{+region=ca-central-1: 2}',
+                                       lease_preferences = '[[+region=ca-central-1]]'
 
 statement error cannot set PARTITION BY on a table in a multi-region enabled database
 ALTER TABLE regional_primary_region_table PARTITION BY LIST (id) (
@@ -433,15 +433,15 @@ CREATE TABLE public.regional_implicit_primary_region_table (
 query TT
 SHOW ZONE CONFIGURATION FOR TABLE regional_implicit_primary_region_table
 ----
-DATABASE multi_region_test_db  ALTER DATABASE multi_region_test_db CONFIGURE ZONE USING
-                                 range_min_bytes = 134217728,
-                                 range_max_bytes = 536870912,
-                                 gc.ttlseconds = 14400,
-                                 num_replicas = 5,
-                                 num_voters = 5,
-                                 constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                                 voter_constraints = '{+region=ca-central-1: 2}',
-                                 lease_preferences = '[[+region=ca-central-1]]'
+TABLE regional_implicit_primary_region_table  ALTER TABLE regional_implicit_primary_region_table CONFIGURE ZONE USING
+                                                range_min_bytes = 134217728,
+                                                range_max_bytes = 536870912,
+                                                gc.ttlseconds = 14400,
+                                                num_replicas = 5,
+                                                num_voters = 5,
+                                                constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                                voter_constraints = '{+region=ca-central-1: 2}',
+                                                lease_preferences = '[[+region=ca-central-1]]'
 
 statement ok
 CREATE TABLE "regional_us-east-1_table" (a int) LOCALITY REGIONAL BY TABLE IN "us-east-1"
@@ -464,7 +464,7 @@ TABLE "regional_us-east-1_table"  ALTER TABLE "regional_us-east-1_table" CONFIGU
                                     gc.ttlseconds = 14400,
                                     num_replicas = 5,
                                     num_voters = 5,
-                                    constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                    constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 1}',
                                     voter_constraints = '{+region=us-east-1: 2}',
                                     lease_preferences = '[[+region=us-east-1]]'
 
@@ -919,15 +919,15 @@ DATABASE alter_survive_db  ALTER DATABASE alter_survive_db CONFIGURE ZONE USING
 query TT
 SHOW ZONE CONFIGURATION FOR TABLE t_no_locality
 ----
-DATABASE alter_survive_db  ALTER DATABASE alter_survive_db CONFIGURE ZONE USING
-                             range_min_bytes = 134217728,
-                             range_max_bytes = 536870912,
-                             gc.ttlseconds = 14400,
-                             num_replicas = 5,
-                             num_voters = 5,
-                             constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                             voter_constraints = '{+region=ca-central-1: 2}',
-                             lease_preferences = '[[+region=ca-central-1]]'
+TABLE t_no_locality  ALTER TABLE t_no_locality CONFIGURE ZONE USING
+                       range_min_bytes = 134217728,
+                       range_max_bytes = 536870912,
+                       gc.ttlseconds = 14400,
+                       num_replicas = 5,
+                       num_voters = 5,
+                       constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                       voter_constraints = '{+region=ca-central-1: 2}',
+                       lease_preferences = '[[+region=ca-central-1]]'
 
 query TT
 SHOW ZONE CONFIGURATION FOR TABLE t_global

--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_survival_goal
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_survival_goal
@@ -37,6 +37,28 @@ SELECT get_db_survival_goal()
 (system,)
 
 statement ok
+create table alter_survive_db.t();
+
+# When SURVIVE REGION FAILURE is set with 3 regions we must set 5 constraints for 5 replicas.
+# This query shows 5 total constraints, where 1 voter constraint is also a normal constraint.
+query TT nosort,colnames
+show zone configuration for table alter_survive_db.t
+----
+target                           raw_config_sql
+TABLE alter_survive_db.public.t  ALTER TABLE alter_survive_db.public.t CONFIGURE ZONE USING
+                                   range_min_bytes = 134217728,
+                                   range_max_bytes = 536870912,
+                                   gc.ttlseconds = 14400,
+                                   num_replicas = 5,
+                                   num_voters = 5,
+                                   constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                   voter_constraints = '{+region=ca-central-1: 2}',
+                                   lease_preferences = '[[+region=ca-central-1]]'
+
+statement ok
+drop table alter_survive_db.t;
+
+statement ok
 ALTER DATABASE alter_survive_db SURVIVE ZONE FAILURE;
 
 query T nosort

--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_zone_config_extensions
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_zone_config_extensions
@@ -38,15 +38,15 @@ DATABASE "mr-zone-configs"  ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USIN
 query TT
 SHOW ZONE CONFIGURATION FOR TABLE tbl
 ----
-DATABASE "mr-zone-configs"  ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USING
-                              range_min_bytes = 134217728,
-                              range_max_bytes = 536870912,
-                              gc.ttlseconds = 14400,
-                              num_replicas = 5,
-                              num_voters = 5,
-                              constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                              voter_constraints = '{+region=ca-central-1: 2}',
-                              lease_preferences = '[[+region=ca-central-1]]'
+TABLE tbl  ALTER TABLE tbl CONFIGURE ZONE USING
+             range_min_bytes = 134217728,
+             range_max_bytes = 536870912,
+             gc.ttlseconds = 14400,
+             num_replicas = 5,
+             num_voters = 5,
+             constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 1}',
+             voter_constraints = '{+region=ca-central-1: 2}',
+             lease_preferences = '[[+region=ca-central-1]]'
 
 
 # REGIONAL zone config extensions.
@@ -70,15 +70,15 @@ DATABASE "mr-zone-configs"  ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USIN
 query TT
 SHOW ZONE CONFIGURATION FOR TABLE tbl
 ----
-DATABASE "mr-zone-configs"  ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USING
-                              range_min_bytes = 134217728,
-                              range_max_bytes = 536870912,
-                              gc.ttlseconds = 14400,
-                              num_replicas = 9,
-                              num_voters = 5,
-                              constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                              voter_constraints = '{+region=ca-central-1: 2}',
-                              lease_preferences = '[[+region=ca-central-1]]'
+TABLE tbl  ALTER TABLE tbl CONFIGURE ZONE USING
+             range_min_bytes = 134217728,
+             range_max_bytes = 536870912,
+             gc.ttlseconds = 14400,
+             num_replicas = 9,
+             num_voters = 5,
+             constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 1}',
+             voter_constraints = '{+region=ca-central-1: 2}',
+             lease_preferences = '[[+region=ca-central-1]]'
 
 
 # REGIONAL IN zone config extensions.
@@ -107,15 +107,15 @@ DATABASE "mr-zone-configs"  ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USIN
 query TT
 SHOW ZONE CONFIGURATION FOR TABLE tbl
 ----
-DATABASE "mr-zone-configs"  ALTER DATABASE "mr-zone-configs" CONFIGURE ZONE USING
-                              range_min_bytes = 134217728,
-                              range_max_bytes = 536870912,
-                              gc.ttlseconds = 14400,
-                              num_replicas = 9,
-                              num_voters = 5,
-                              constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
-                              voter_constraints = '{+region=ca-central-1: 2}',
-                              lease_preferences = '[[+region=ca-central-1], [+region=ap-southeast-2]]'
+TABLE tbl  ALTER TABLE tbl CONFIGURE ZONE USING
+             range_min_bytes = 134217728,
+             range_max_bytes = 536870912,
+             gc.ttlseconds = 14400,
+             num_replicas = 9,
+             num_voters = 5,
+             constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 1}',
+             voter_constraints = '{+region=ca-central-1: 2}',
+             lease_preferences = '[[+region=ca-central-1], [+region=ap-southeast-2]]'
 
 statement ok
 ALTER TABLE tbl SET LOCALITY REGIONAL IN "ca-central-1"
@@ -129,7 +129,7 @@ TABLE tbl  ALTER TABLE tbl CONFIGURE ZONE USING
              gc.ttlseconds = 14400,
              num_replicas = 9,
              num_voters = 5,
-             constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+             constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 1}',
              voter_constraints = '{+region=ca-central-1: 2}',
              lease_preferences = '[[+region=ca-central-1], [+region=ap-southeast-2]]'
 
@@ -145,7 +145,7 @@ TABLE tbl  ALTER TABLE tbl CONFIGURE ZONE USING
              gc.ttlseconds = 14400,
              num_replicas = 9,
              num_voters = 5,
-             constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+             constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 2, +region=us-east-1: 1}',
              voter_constraints = '{+region=ap-southeast-2: 2}',
              lease_preferences = '[[+region=ap-southeast-2], [+region=us-east-1]]'
 
@@ -161,7 +161,7 @@ TABLE tbl  ALTER TABLE tbl CONFIGURE ZONE USING
              gc.ttlseconds = 14400,
              num_replicas = 9,
              num_voters = 5,
-             constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+             constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 1}',
              voter_constraints = '{+region=us-east-1: 2}',
              lease_preferences = '[[+region=us-east-1]]'
 

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
@@ -117,9 +117,9 @@ query TTT
 SELECT zone_config, index_name, partition_name FROM [SHOW PARTITIONS FROM TABLE regional_by_row_table_explicit_crdb_region_column]
 ORDER BY partition_name, index_name
 ----
-num_voters = 5,\nvoter_constraints = '{+region=ap-southeast-2: 2}',\nlease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row_table_explicit_crdb_region_column@regional_by_row_table_explicit_crdb_region_column_pkey  ap-southeast-2
-num_voters = 5,\nvoter_constraints = '{+region=ca-central-1: 2}',\nlease_preferences = '[[+region=ca-central-1]]'      regional_by_row_table_explicit_crdb_region_column@regional_by_row_table_explicit_crdb_region_column_pkey  ca-central-1
-num_voters = 5,\nvoter_constraints = '{+region=us-east-1: 2}',\nlease_preferences = '[[+region=us-east-1]]'            regional_by_row_table_explicit_crdb_region_column@regional_by_row_table_explicit_crdb_region_column_pkey  us-east-1
+num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 2, +region=us-east-1: 1}',\nvoter_constraints = '{+region=ap-southeast-2: 2}',\nlease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row_table_explicit_crdb_region_column@regional_by_row_table_explicit_crdb_region_column_pkey  ap-southeast-2
+num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 1}',\nvoter_constraints = '{+region=ca-central-1: 2}',\nlease_preferences = '[[+region=ca-central-1]]'      regional_by_row_table_explicit_crdb_region_column@regional_by_row_table_explicit_crdb_region_column_pkey  ca-central-1
+num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 1}',\nvoter_constraints = '{+region=us-east-1: 2}',\nlease_preferences = '[[+region=us-east-1]]'            regional_by_row_table_explicit_crdb_region_column@regional_by_row_table_explicit_crdb_region_column_pkey  us-east-1
 
 query TT
 SHOW ZONE CONFIGURATION FROM TABLE regional_by_row_table_explicit_crdb_region_column
@@ -188,18 +188,18 @@ query TTT
 SELECT zone_config, index_name, partition_name FROM [SHOW PARTITIONS FROM TABLE regional_by_row_table]
 ORDER BY partition_name, index_name
 ----
-num_voters = 5,\nvoter_constraints = '{+region=ap-southeast-2: 2}',\nlease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row_table@regional_by_row_table_a_idx  ap-southeast-2
-num_voters = 5,\nvoter_constraints = '{+region=ap-southeast-2: 2}',\nlease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row_table@regional_by_row_table_b_key  ap-southeast-2
-num_voters = 5,\nvoter_constraints = '{+region=ap-southeast-2: 2}',\nlease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row_table@regional_by_row_table_j_idx  ap-southeast-2
-num_voters = 5,\nvoter_constraints = '{+region=ap-southeast-2: 2}',\nlease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row_table@regional_by_row_table_pkey   ap-southeast-2
-num_voters = 5,\nvoter_constraints = '{+region=ca-central-1: 2}',\nlease_preferences = '[[+region=ca-central-1]]'      regional_by_row_table@regional_by_row_table_a_idx  ca-central-1
-num_voters = 5,\nvoter_constraints = '{+region=ca-central-1: 2}',\nlease_preferences = '[[+region=ca-central-1]]'      regional_by_row_table@regional_by_row_table_b_key  ca-central-1
-num_voters = 5,\nvoter_constraints = '{+region=ca-central-1: 2}',\nlease_preferences = '[[+region=ca-central-1]]'      regional_by_row_table@regional_by_row_table_j_idx  ca-central-1
-num_voters = 5,\nvoter_constraints = '{+region=ca-central-1: 2}',\nlease_preferences = '[[+region=ca-central-1]]'      regional_by_row_table@regional_by_row_table_pkey   ca-central-1
-num_voters = 5,\nvoter_constraints = '{+region=us-east-1: 2}',\nlease_preferences = '[[+region=us-east-1]]'            regional_by_row_table@regional_by_row_table_a_idx  us-east-1
-num_voters = 5,\nvoter_constraints = '{+region=us-east-1: 2}',\nlease_preferences = '[[+region=us-east-1]]'            regional_by_row_table@regional_by_row_table_b_key  us-east-1
-num_voters = 5,\nvoter_constraints = '{+region=us-east-1: 2}',\nlease_preferences = '[[+region=us-east-1]]'            regional_by_row_table@regional_by_row_table_j_idx  us-east-1
-num_voters = 5,\nvoter_constraints = '{+region=us-east-1: 2}',\nlease_preferences = '[[+region=us-east-1]]'            regional_by_row_table@regional_by_row_table_pkey   us-east-1
+num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 2, +region=us-east-1: 1}',\nvoter_constraints = '{+region=ap-southeast-2: 2}',\nlease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row_table@regional_by_row_table_a_idx  ap-southeast-2
+num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 2, +region=us-east-1: 1}',\nvoter_constraints = '{+region=ap-southeast-2: 2}',\nlease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row_table@regional_by_row_table_b_key  ap-southeast-2
+num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 2, +region=us-east-1: 1}',\nvoter_constraints = '{+region=ap-southeast-2: 2}',\nlease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row_table@regional_by_row_table_j_idx  ap-southeast-2
+num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 2, +region=us-east-1: 1}',\nvoter_constraints = '{+region=ap-southeast-2: 2}',\nlease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row_table@regional_by_row_table_pkey   ap-southeast-2
+num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 1}',\nvoter_constraints = '{+region=ca-central-1: 2}',\nlease_preferences = '[[+region=ca-central-1]]'      regional_by_row_table@regional_by_row_table_a_idx  ca-central-1
+num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 1}',\nvoter_constraints = '{+region=ca-central-1: 2}',\nlease_preferences = '[[+region=ca-central-1]]'      regional_by_row_table@regional_by_row_table_b_key  ca-central-1
+num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 1}',\nvoter_constraints = '{+region=ca-central-1: 2}',\nlease_preferences = '[[+region=ca-central-1]]'      regional_by_row_table@regional_by_row_table_j_idx  ca-central-1
+num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 1}',\nvoter_constraints = '{+region=ca-central-1: 2}',\nlease_preferences = '[[+region=ca-central-1]]'      regional_by_row_table@regional_by_row_table_pkey   ca-central-1
+num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 1}',\nvoter_constraints = '{+region=us-east-1: 2}',\nlease_preferences = '[[+region=us-east-1]]'            regional_by_row_table@regional_by_row_table_a_idx  us-east-1
+num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 1}',\nvoter_constraints = '{+region=us-east-1: 2}',\nlease_preferences = '[[+region=us-east-1]]'            regional_by_row_table@regional_by_row_table_b_key  us-east-1
+num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 1}',\nvoter_constraints = '{+region=us-east-1: 2}',\nlease_preferences = '[[+region=us-east-1]]'            regional_by_row_table@regional_by_row_table_j_idx  us-east-1
+num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 1}',\nvoter_constraints = '{+region=us-east-1: 2}',\nlease_preferences = '[[+region=us-east-1]]'            regional_by_row_table@regional_by_row_table_pkey   us-east-1
 
 query TT
 SHOW ZONE CONFIGURATION FROM TABLE regional_by_row_table
@@ -308,21 +308,21 @@ query TTT
 SELECT zone_config, index_name, partition_name FROM [SHOW PARTITIONS FROM TABLE regional_by_row_table]
 ORDER BY partition_name, index_name
 ----
-num_voters = 5,\nvoter_constraints = '{+region=ap-southeast-2: 2}',\nlease_preferences = '[[+region=ap-southeast-2]]'             regional_by_row_table@regional_by_row_table_a_idx           ap-southeast-2
-num_voters = 5,\nvoter_constraints = '{+region=ap-southeast-2: 2}',\nlease_preferences = '[[+region=ap-southeast-2]]'             regional_by_row_table@regional_by_row_table_b_key           ap-southeast-2
-num_voters = 5,\nvoter_constraints = '{+region=ap-southeast-2: 2}',\nlease_preferences = '[[+region=ap-southeast-2]]'             regional_by_row_table@regional_by_row_table_j_idx           ap-southeast-2
-num_voters = 5,\nvoter_constraints = '{+region=ap-southeast-2: 2}',\nlease_preferences = '[[+region=ap-southeast-2]]'             regional_by_row_table@regional_by_row_table_pkey            ap-southeast-2
-num_voters = 5,\nvoter_constraints = '{+region=ap-southeast-2: 2}',\nlease_preferences = '[[+region=ap-southeast-2]]'             regional_by_row_table@regional_by_row_table_unique_col_key  ap-southeast-2
-num_voters = 5,\nvoter_constraints = '{+region=ca-central-1: 2}',\nlease_preferences = '[[+region=ca-central-1]]'                 regional_by_row_table@regional_by_row_table_a_idx           ca-central-1
-num_voters = 5,\nvoter_constraints = '{+region=ca-central-1: 2}',\nlease_preferences = '[[+region=ca-central-1]]'                 regional_by_row_table@regional_by_row_table_b_key           ca-central-1
-num_voters = 5,\nvoter_constraints = '{+region=ca-central-1: 2}',\nlease_preferences = '[[+region=ca-central-1]]'                 regional_by_row_table@regional_by_row_table_j_idx           ca-central-1
-num_voters = 5,\nvoter_constraints = '{+region=ca-central-1: 2}',\nlease_preferences = '[[+region=ca-central-1]]'                 regional_by_row_table@regional_by_row_table_pkey            ca-central-1
-num_voters = 5,\nvoter_constraints = '{+region=ca-central-1: 2}',\nlease_preferences = '[[+region=ca-central-1]]'                 regional_by_row_table@regional_by_row_table_unique_col_key  ca-central-1
-gc.ttlseconds = 10,\nnum_voters = 5,\nvoter_constraints = '{+region=us-east-1: 2}',\nlease_preferences = '[[+region=us-east-1]]'  regional_by_row_table@regional_by_row_table_a_idx           us-east-1
-num_voters = 5,\nvoter_constraints = '{+region=us-east-1: 2}',\nlease_preferences = '[[+region=us-east-1]]'                       regional_by_row_table@regional_by_row_table_b_key           us-east-1
-num_voters = 5,\nvoter_constraints = '{+region=us-east-1: 2}',\nlease_preferences = '[[+region=us-east-1]]'                       regional_by_row_table@regional_by_row_table_j_idx           us-east-1
-num_voters = 5,\nvoter_constraints = '{+region=us-east-1: 2}',\nlease_preferences = '[[+region=us-east-1]]'                       regional_by_row_table@regional_by_row_table_pkey            us-east-1
-num_voters = 5,\nvoter_constraints = '{+region=us-east-1: 2}',\nlease_preferences = '[[+region=us-east-1]]'                       regional_by_row_table@regional_by_row_table_unique_col_key  us-east-1
+num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 2, +region=us-east-1: 1}',\nvoter_constraints = '{+region=ap-southeast-2: 2}',\nlease_preferences = '[[+region=ap-southeast-2]]'             regional_by_row_table@regional_by_row_table_a_idx           ap-southeast-2
+num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 2, +region=us-east-1: 1}',\nvoter_constraints = '{+region=ap-southeast-2: 2}',\nlease_preferences = '[[+region=ap-southeast-2]]'             regional_by_row_table@regional_by_row_table_b_key           ap-southeast-2
+num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 2, +region=us-east-1: 1}',\nvoter_constraints = '{+region=ap-southeast-2: 2}',\nlease_preferences = '[[+region=ap-southeast-2]]'             regional_by_row_table@regional_by_row_table_j_idx           ap-southeast-2
+num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 2, +region=us-east-1: 1}',\nvoter_constraints = '{+region=ap-southeast-2: 2}',\nlease_preferences = '[[+region=ap-southeast-2]]'             regional_by_row_table@regional_by_row_table_pkey            ap-southeast-2
+num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 2, +region=us-east-1: 1}',\nvoter_constraints = '{+region=ap-southeast-2: 2}',\nlease_preferences = '[[+region=ap-southeast-2]]'             regional_by_row_table@regional_by_row_table_unique_col_key  ap-southeast-2
+num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 1}',\nvoter_constraints = '{+region=ca-central-1: 2}',\nlease_preferences = '[[+region=ca-central-1]]'                 regional_by_row_table@regional_by_row_table_a_idx           ca-central-1
+num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 1}',\nvoter_constraints = '{+region=ca-central-1: 2}',\nlease_preferences = '[[+region=ca-central-1]]'                 regional_by_row_table@regional_by_row_table_b_key           ca-central-1
+num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 1}',\nvoter_constraints = '{+region=ca-central-1: 2}',\nlease_preferences = '[[+region=ca-central-1]]'                 regional_by_row_table@regional_by_row_table_j_idx           ca-central-1
+num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 1}',\nvoter_constraints = '{+region=ca-central-1: 2}',\nlease_preferences = '[[+region=ca-central-1]]'                 regional_by_row_table@regional_by_row_table_pkey            ca-central-1
+num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 1}',\nvoter_constraints = '{+region=ca-central-1: 2}',\nlease_preferences = '[[+region=ca-central-1]]'                 regional_by_row_table@regional_by_row_table_unique_col_key  ca-central-1
+gc.ttlseconds = 10,\nnum_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 1}',\nvoter_constraints = '{+region=us-east-1: 2}',\nlease_preferences = '[[+region=us-east-1]]'  regional_by_row_table@regional_by_row_table_a_idx           us-east-1
+num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 1}',\nvoter_constraints = '{+region=us-east-1: 2}',\nlease_preferences = '[[+region=us-east-1]]'                       regional_by_row_table@regional_by_row_table_b_key           us-east-1
+num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 1}',\nvoter_constraints = '{+region=us-east-1: 2}',\nlease_preferences = '[[+region=us-east-1]]'                       regional_by_row_table@regional_by_row_table_j_idx           us-east-1
+num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 1}',\nvoter_constraints = '{+region=us-east-1: 2}',\nlease_preferences = '[[+region=us-east-1]]'                       regional_by_row_table@regional_by_row_table_pkey            us-east-1
+num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 1}',\nvoter_constraints = '{+region=us-east-1: 2}',\nlease_preferences = '[[+region=us-east-1]]'                       regional_by_row_table@regional_by_row_table_unique_col_key  us-east-1
 
 statement ok
 ALTER TABLE regional_by_row_table DROP COLUMN unique_col
@@ -488,7 +488,7 @@ PARTITION "ap-southeast-2" OF INDEX regional_by_row_table@regional_by_row_table_
                                                                                         gc.ttlseconds = 14400,
                                                                                         num_replicas = 5,
                                                                                         num_voters = 5,
-                                                                                        constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                                                                        constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 2, +region=us-east-1: 1}',
                                                                                         voter_constraints = '{+region=ap-southeast-2: 2}',
                                                                                         lease_preferences = '[[+region=ap-southeast-2]]'
 
@@ -501,7 +501,7 @@ PARTITION "ap-southeast-2" OF INDEX regional_by_row_table@regional_by_row_table_
                                                                                           gc.ttlseconds = 14400,
                                                                                           num_replicas = 5,
                                                                                           num_voters = 5,
-                                                                                          constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                                                                          constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 2, +region=us-east-1: 1}',
                                                                                           voter_constraints = '{+region=ap-southeast-2: 2}',
                                                                                           lease_preferences = '[[+region=ap-southeast-2]]'
 
@@ -514,7 +514,7 @@ PARTITION "ap-southeast-2" OF INDEX regional_by_row_table@unique_b_a  ALTER PART
                                                                         gc.ttlseconds = 14400,
                                                                         num_replicas = 5,
                                                                         num_voters = 5,
-                                                                        constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                                                        constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 2, +region=us-east-1: 1}',
                                                                         voter_constraints = '{+region=ap-southeast-2: 2}',
                                                                         lease_preferences = '[[+region=ap-southeast-2]]'
 
@@ -579,15 +579,15 @@ query TTT
 SELECT zone_config, index_name, partition_name FROM [SHOW PARTITIONS FROM TABLE regional_by_row_table_as]
 ORDER BY partition_name, index_name
 ----
-num_voters = 5,\nvoter_constraints = '{+region=ap-southeast-2: 2}',\nlease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row_table_as@regional_by_row_table_as_a_idx  ap-southeast-2
-num_voters = 5,\nvoter_constraints = '{+region=ap-southeast-2: 2}',\nlease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row_table_as@regional_by_row_table_as_b_key  ap-southeast-2
-num_voters = 5,\nvoter_constraints = '{+region=ap-southeast-2: 2}',\nlease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row_table_as@regional_by_row_table_as_pkey   ap-southeast-2
-num_voters = 5,\nvoter_constraints = '{+region=ca-central-1: 2}',\nlease_preferences = '[[+region=ca-central-1]]'      regional_by_row_table_as@regional_by_row_table_as_a_idx  ca-central-1
-num_voters = 5,\nvoter_constraints = '{+region=ca-central-1: 2}',\nlease_preferences = '[[+region=ca-central-1]]'      regional_by_row_table_as@regional_by_row_table_as_b_key  ca-central-1
-num_voters = 5,\nvoter_constraints = '{+region=ca-central-1: 2}',\nlease_preferences = '[[+region=ca-central-1]]'      regional_by_row_table_as@regional_by_row_table_as_pkey   ca-central-1
-num_voters = 5,\nvoter_constraints = '{+region=us-east-1: 2}',\nlease_preferences = '[[+region=us-east-1]]'            regional_by_row_table_as@regional_by_row_table_as_a_idx  us-east-1
-num_voters = 5,\nvoter_constraints = '{+region=us-east-1: 2}',\nlease_preferences = '[[+region=us-east-1]]'            regional_by_row_table_as@regional_by_row_table_as_b_key  us-east-1
-num_voters = 5,\nvoter_constraints = '{+region=us-east-1: 2}',\nlease_preferences = '[[+region=us-east-1]]'            regional_by_row_table_as@regional_by_row_table_as_pkey   us-east-1
+num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 2, +region=us-east-1: 1}',\nvoter_constraints = '{+region=ap-southeast-2: 2}',\nlease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row_table_as@regional_by_row_table_as_a_idx  ap-southeast-2
+num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 2, +region=us-east-1: 1}',\nvoter_constraints = '{+region=ap-southeast-2: 2}',\nlease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row_table_as@regional_by_row_table_as_b_key  ap-southeast-2
+num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 2, +region=us-east-1: 1}',\nvoter_constraints = '{+region=ap-southeast-2: 2}',\nlease_preferences = '[[+region=ap-southeast-2]]'  regional_by_row_table_as@regional_by_row_table_as_pkey   ap-southeast-2
+num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 1}',\nvoter_constraints = '{+region=ca-central-1: 2}',\nlease_preferences = '[[+region=ca-central-1]]'      regional_by_row_table_as@regional_by_row_table_as_a_idx  ca-central-1
+num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 1}',\nvoter_constraints = '{+region=ca-central-1: 2}',\nlease_preferences = '[[+region=ca-central-1]]'      regional_by_row_table_as@regional_by_row_table_as_b_key  ca-central-1
+num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 1}',\nvoter_constraints = '{+region=ca-central-1: 2}',\nlease_preferences = '[[+region=ca-central-1]]'      regional_by_row_table_as@regional_by_row_table_as_pkey   ca-central-1
+num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 1}',\nvoter_constraints = '{+region=us-east-1: 2}',\nlease_preferences = '[[+region=us-east-1]]'            regional_by_row_table_as@regional_by_row_table_as_a_idx  us-east-1
+num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 1}',\nvoter_constraints = '{+region=us-east-1: 2}',\nlease_preferences = '[[+region=us-east-1]]'            regional_by_row_table_as@regional_by_row_table_as_b_key  us-east-1
+num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 1}',\nvoter_constraints = '{+region=us-east-1: 2}',\nlease_preferences = '[[+region=us-east-1]]'            regional_by_row_table_as@regional_by_row_table_as_pkey   us-east-1
 
 query TT
 SHOW ZONE CONFIGURATION FROM TABLE regional_by_row_table_as
@@ -642,7 +642,7 @@ PARTITION "us-east-1" OF TABLE t_regional_by_row  ALTER PARTITION "us-east-1" OF
                                                     gc.ttlseconds = 14400,
                                                     num_replicas = 5,
                                                     num_voters = 5,
-                                                    constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                                    constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 1}',
                                                     voter_constraints = '{+region=us-east-1: 2}',
                                                     lease_preferences = '[[+region=us-east-1]]'
 
@@ -650,17 +650,17 @@ query TTT
 SELECT zone_config, index_name, partition_name FROM [SHOW PARTITIONS FROM TABLE t_regional_by_row]
 ORDER BY partition_name, index_name
 ----
-num_voters = 5,\nvoter_constraints = '{+region=ap-southeast-2: 2}',\nlease_preferences = '[[+region=ap-southeast-2]]'  t_regional_by_row@t_regional_by_row_pkey  ap-southeast-2
-num_voters = 5,\nvoter_constraints = '{+region=ca-central-1: 2}',\nlease_preferences = '[[+region=ca-central-1]]'      t_regional_by_row@t_regional_by_row_pkey  ca-central-1
-num_voters = 5,\nvoter_constraints = '{+region=us-east-1: 2}',\nlease_preferences = '[[+region=us-east-1]]'            t_regional_by_row@t_regional_by_row_pkey  us-east-1
+num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 2, +region=us-east-1: 1}',\nvoter_constraints = '{+region=ap-southeast-2: 2}',\nlease_preferences = '[[+region=ap-southeast-2]]'  t_regional_by_row@t_regional_by_row_pkey  ap-southeast-2
+num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 1}',\nvoter_constraints = '{+region=ca-central-1: 2}',\nlease_preferences = '[[+region=ca-central-1]]'      t_regional_by_row@t_regional_by_row_pkey  ca-central-1
+num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 1}',\nvoter_constraints = '{+region=us-east-1: 2}',\nlease_preferences = '[[+region=us-east-1]]'            t_regional_by_row@t_regional_by_row_pkey  us-east-1
 
 query TTT
 SELECT zone_config, index_name, partition_name FROM [SHOW PARTITIONS FROM TABLE t_regional_by_row]
 ORDER BY partition_name, index_name
 ----
-num_voters = 5,\nvoter_constraints = '{+region=ap-southeast-2: 2}',\nlease_preferences = '[[+region=ap-southeast-2]]'  t_regional_by_row@t_regional_by_row_pkey  ap-southeast-2
-num_voters = 5,\nvoter_constraints = '{+region=ca-central-1: 2}',\nlease_preferences = '[[+region=ca-central-1]]'      t_regional_by_row@t_regional_by_row_pkey  ca-central-1
-num_voters = 5,\nvoter_constraints = '{+region=us-east-1: 2}',\nlease_preferences = '[[+region=us-east-1]]'            t_regional_by_row@t_regional_by_row_pkey  us-east-1
+num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 2, +region=us-east-1: 1}',\nvoter_constraints = '{+region=ap-southeast-2: 2}',\nlease_preferences = '[[+region=ap-southeast-2]]'  t_regional_by_row@t_regional_by_row_pkey  ap-southeast-2
+num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 1}',\nvoter_constraints = '{+region=ca-central-1: 2}',\nlease_preferences = '[[+region=ca-central-1]]'      t_regional_by_row@t_regional_by_row_pkey  ca-central-1
+num_replicas = 5,\nnum_voters = 5,\nconstraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 1}',\nvoter_constraints = '{+region=us-east-1: 2}',\nlease_preferences = '[[+region=us-east-1]]'            t_regional_by_row@t_regional_by_row_pkey  us-east-1
 
 query TT
 SHOW ZONE CONFIGURATION FROM TABLE t_regional_by_row

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_query_behavior
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_query_behavior
@@ -68,7 +68,7 @@ TABLE regional_by_row_table
  │         │    └── ZONE
  │         │         ├── replica constraints
  │         │         │    ├── 1 replicas: [+region=ap-southeast-2]
- │         │         │    ├── 1 replicas: [+region=ca-central-1]
+ │         │         │    ├── 2 replicas: [+region=ca-central-1]
  │         │         │    └── 1 replicas: [+region=us-east-1]
  │         │         ├── voter constraints: [+region=ap-southeast-2]
  │         │         └── lease preference: [+region=ap-southeast-2]
@@ -77,7 +77,7 @@ TABLE regional_by_row_table
  │         │    │    └── ('ca-central-1')
  │         │    └── ZONE
  │         │         ├── replica constraints
- │         │         │    ├── 1 replicas: [+region=ap-southeast-2]
+ │         │         │    ├── 2 replicas: [+region=ap-southeast-2]
  │         │         │    ├── 1 replicas: [+region=ca-central-1]
  │         │         │    └── 1 replicas: [+region=us-east-1]
  │         │         ├── voter constraints: [+region=ca-central-1]
@@ -87,7 +87,7 @@ TABLE regional_by_row_table
  │              │    └── ('us-east-1')
  │              └── ZONE
  │                   ├── replica constraints
- │                   │    ├── 1 replicas: [+region=ap-southeast-2]
+ │                   │    ├── 2 replicas: [+region=ap-southeast-2]
  │                   │    ├── 1 replicas: [+region=ca-central-1]
  │                   │    └── 1 replicas: [+region=us-east-1]
  │                   ├── voter constraints: [+region=us-east-1]
@@ -110,7 +110,7 @@ TABLE regional_by_row_table
  │         │    └── ZONE
  │         │         ├── replica constraints
  │         │         │    ├── 1 replicas: [+region=ap-southeast-2]
- │         │         │    ├── 1 replicas: [+region=ca-central-1]
+ │         │         │    ├── 2 replicas: [+region=ca-central-1]
  │         │         │    └── 1 replicas: [+region=us-east-1]
  │         │         ├── voter constraints: [+region=ap-southeast-2]
  │         │         └── lease preference: [+region=ap-southeast-2]
@@ -119,7 +119,7 @@ TABLE regional_by_row_table
  │         │    │    └── ('ca-central-1')
  │         │    └── ZONE
  │         │         ├── replica constraints
- │         │         │    ├── 1 replicas: [+region=ap-southeast-2]
+ │         │         │    ├── 2 replicas: [+region=ap-southeast-2]
  │         │         │    ├── 1 replicas: [+region=ca-central-1]
  │         │         │    └── 1 replicas: [+region=us-east-1]
  │         │         ├── voter constraints: [+region=ca-central-1]
@@ -129,7 +129,7 @@ TABLE regional_by_row_table
  │              │    └── ('us-east-1')
  │              └── ZONE
  │                   ├── replica constraints
- │                   │    ├── 1 replicas: [+region=ap-southeast-2]
+ │                   │    ├── 2 replicas: [+region=ap-southeast-2]
  │                   │    ├── 1 replicas: [+region=ca-central-1]
  │                   │    └── 1 replicas: [+region=us-east-1]
  │                   ├── voter constraints: [+region=us-east-1]
@@ -152,7 +152,7 @@ TABLE regional_by_row_table
  │         │    └── ZONE
  │         │         ├── replica constraints
  │         │         │    ├── 1 replicas: [+region=ap-southeast-2]
- │         │         │    ├── 1 replicas: [+region=ca-central-1]
+ │         │         │    ├── 2 replicas: [+region=ca-central-1]
  │         │         │    └── 1 replicas: [+region=us-east-1]
  │         │         ├── voter constraints: [+region=ap-southeast-2]
  │         │         └── lease preference: [+region=ap-southeast-2]
@@ -161,7 +161,7 @@ TABLE regional_by_row_table
  │         │    │    └── ('ca-central-1')
  │         │    └── ZONE
  │         │         ├── replica constraints
- │         │         │    ├── 1 replicas: [+region=ap-southeast-2]
+ │         │         │    ├── 2 replicas: [+region=ap-southeast-2]
  │         │         │    ├── 1 replicas: [+region=ca-central-1]
  │         │         │    └── 1 replicas: [+region=us-east-1]
  │         │         ├── voter constraints: [+region=ca-central-1]
@@ -171,7 +171,7 @@ TABLE regional_by_row_table
  │              │    └── ('us-east-1')
  │              └── ZONE
  │                   ├── replica constraints
- │                   │    ├── 1 replicas: [+region=ap-southeast-2]
+ │                   │    ├── 2 replicas: [+region=ap-southeast-2]
  │                   │    ├── 1 replicas: [+region=ca-central-1]
  │                   │    └── 1 replicas: [+region=us-east-1]
  │                   ├── voter constraints: [+region=us-east-1]
@@ -194,7 +194,7 @@ TABLE regional_by_row_table
  │         │    └── ZONE
  │         │         ├── replica constraints
  │         │         │    ├── 1 replicas: [+region=ap-southeast-2]
- │         │         │    ├── 1 replicas: [+region=ca-central-1]
+ │         │         │    ├── 2 replicas: [+region=ca-central-1]
  │         │         │    └── 1 replicas: [+region=us-east-1]
  │         │         ├── voter constraints: [+region=ap-southeast-2]
  │         │         └── lease preference: [+region=ap-southeast-2]
@@ -203,7 +203,7 @@ TABLE regional_by_row_table
  │         │    │    └── ('ca-central-1')
  │         │    └── ZONE
  │         │         ├── replica constraints
- │         │         │    ├── 1 replicas: [+region=ap-southeast-2]
+ │         │         │    ├── 2 replicas: [+region=ap-southeast-2]
  │         │         │    ├── 1 replicas: [+region=ca-central-1]
  │         │         │    └── 1 replicas: [+region=us-east-1]
  │         │         ├── voter constraints: [+region=ca-central-1]
@@ -213,7 +213,7 @@ TABLE regional_by_row_table
  │              │    └── ('us-east-1')
  │              └── ZONE
  │                   ├── replica constraints
- │                   │    ├── 1 replicas: [+region=ap-southeast-2]
+ │                   │    ├── 2 replicas: [+region=ap-southeast-2]
  │                   │    ├── 1 replicas: [+region=ca-central-1]
  │                   │    └── 1 replicas: [+region=us-east-1]
  │                   ├── voter constraints: [+region=us-east-1]

--- a/pkg/ccl/logictestccl/testdata/logic_test/secondary_region
+++ b/pkg/ccl/logictestccl/testdata/logic_test/secondary_region
@@ -212,7 +212,7 @@ TABLE db.public.rbt_in_primary  ALTER TABLE db.public.rbt_in_primary CONFIGURE Z
                                   gc.ttlseconds = 14400,
                                   num_replicas = 5,
                                   num_voters = 5,
-                                  constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                  constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 2, +region=us-east-1: 1}',
                                   voter_constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 2}',
                                   lease_preferences = '[[+region=ap-southeast-2], [+region=ca-central-1]]'
 
@@ -225,7 +225,7 @@ TABLE db.public.rbt_in_us_east  ALTER TABLE db.public.rbt_in_us_east CONFIGURE Z
                                   gc.ttlseconds = 14400,
                                   num_replicas = 5,
                                   num_voters = 5,
-                                  constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                  constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 1}',
                                   voter_constraints = '{+region=ca-central-1: 2, +region=us-east-1: 2}',
                                   lease_preferences = '[[+region=us-east-1], [+region=ca-central-1]]'
 
@@ -238,7 +238,7 @@ TABLE db.public.rbt_in_ca_central  ALTER TABLE db.public.rbt_in_ca_central CONFI
                                      gc.ttlseconds = 14400,
                                      num_replicas = 5,
                                      num_voters = 5,
-                                     constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                     constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 1}',
                                      voter_constraints = '{+region=ca-central-1: 2}',
                                      lease_preferences = '[[+region=ca-central-1]]'
 
@@ -252,7 +252,7 @@ PARTITION "us-east-1" OF TABLE db.public.rbr  ALTER PARTITION "us-east-1" OF TAB
                                                 gc.ttlseconds = 14400,
                                                 num_replicas = 5,
                                                 num_voters = 5,
-                                                constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                                constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 1}',
                                                 voter_constraints = '{+region=ca-central-1: 2, +region=us-east-1: 2}',
                                                 lease_preferences = '[[+region=us-east-1], [+region=ca-central-1]]'
 
@@ -265,7 +265,7 @@ PARTITION "ap-southeast-2" OF TABLE db.public.rbr  ALTER PARTITION "ap-southeast
                                                      gc.ttlseconds = 14400,
                                                      num_replicas = 5,
                                                      num_voters = 5,
-                                                     constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                                     constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 2, +region=us-east-1: 1}',
                                                      voter_constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 2}',
                                                      lease_preferences = '[[+region=ap-southeast-2], [+region=ca-central-1]]'
 
@@ -278,7 +278,7 @@ PARTITION "ca-central-1" OF TABLE db.public.rbr  ALTER PARTITION "ca-central-1" 
                                                    gc.ttlseconds = 14400,
                                                    num_replicas = 5,
                                                    num_voters = 5,
-                                                   constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                                   constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 1}',
                                                    voter_constraints = '{+region=ca-central-1: 2}',
                                                    lease_preferences = '[[+region=ca-central-1]]'
 
@@ -312,7 +312,7 @@ TABLE db.public.rbt_in_us_east  ALTER TABLE db.public.rbt_in_us_east CONFIGURE Z
                                   gc.ttlseconds = 14400,
                                   num_replicas = 5,
                                   num_voters = 5,
-                                  constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                  constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 1}',
                                   voter_constraints = '{+region=ca-central-1: 2, +region=us-east-1: 2}',
                                   lease_preferences = '[[+region=us-east-1], [+region=ca-central-1]]'
 
@@ -325,7 +325,7 @@ TABLE db.public.rbt_in_ca_central  ALTER TABLE db.public.rbt_in_ca_central CONFI
                                      gc.ttlseconds = 14400,
                                      num_replicas = 5,
                                      num_voters = 5,
-                                     constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                     constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 1}',
                                      voter_constraints = '{+region=ca-central-1: 2}',
                                      lease_preferences = '[[+region=ca-central-1]]'
 
@@ -339,7 +339,7 @@ PARTITION "us-east-1" OF TABLE db.public.rbr  ALTER PARTITION "us-east-1" OF TAB
                                                 gc.ttlseconds = 14400,
                                                 num_replicas = 5,
                                                 num_voters = 5,
-                                                constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                                constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 1}',
                                                 voter_constraints = '{+region=ca-central-1: 2, +region=us-east-1: 2}',
                                                 lease_preferences = '[[+region=us-east-1], [+region=ca-central-1]]'
 
@@ -352,7 +352,7 @@ PARTITION "ap-southeast-2" OF TABLE db.public.rbr  ALTER PARTITION "ap-southeast
                                                      gc.ttlseconds = 14400,
                                                      num_replicas = 5,
                                                      num_voters = 5,
-                                                     constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                                     constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 2, +region=us-east-1: 1}',
                                                      voter_constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 2}',
                                                      lease_preferences = '[[+region=ap-southeast-2], [+region=ca-central-1]]'
 
@@ -365,7 +365,7 @@ PARTITION "ca-central-1" OF TABLE db.public.rbr  ALTER PARTITION "ca-central-1" 
                                                    gc.ttlseconds = 14400,
                                                    num_replicas = 5,
                                                    num_voters = 5,
-                                                   constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                                   constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 1}',
                                                    voter_constraints = '{+region=ca-central-1: 2}',
                                                    lease_preferences = '[[+region=ca-central-1]]'
 
@@ -397,7 +397,7 @@ TABLE db.public.rbt_in_us_east  ALTER TABLE db.public.rbt_in_us_east CONFIGURE Z
                                   gc.ttlseconds = 14400,
                                   num_replicas = 5,
                                   num_voters = 5,
-                                  constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                  constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 1}',
                                   voter_constraints = '{+region=us-east-1: 2}',
                                   lease_preferences = '[[+region=us-east-1]]'
 
@@ -410,7 +410,7 @@ PARTITION "ap-southeast-2" OF TABLE db.public.rbr  ALTER PARTITION "ap-southeast
                                                      gc.ttlseconds = 14400,
                                                      num_replicas = 5,
                                                      num_voters = 5,
-                                                     constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                                     constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 2, +region=us-east-1: 1}',
                                                      voter_constraints = '{+region=ap-southeast-2: 2}',
                                                      lease_preferences = '[[+region=ap-southeast-2]]'
 
@@ -423,7 +423,7 @@ PARTITION "ca-central-1" OF TABLE db.public.rbr  ALTER PARTITION "ca-central-1" 
                                                    gc.ttlseconds = 14400,
                                                    num_replicas = 5,
                                                    num_voters = 5,
-                                                   constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                                   constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 1}',
                                                    voter_constraints = '{+region=ca-central-1: 2}',
                                                    lease_preferences = '[[+region=ca-central-1]]'
 

--- a/pkg/ccl/schemachangerccl/testdata/decomp/multiregion
+++ b/pkg/ccl/schemachangerccl/testdata/decomp/multiregion
@@ -874,10 +874,25 @@ ElementState:
     seqNum: 0
     tableId: 109
     zoneConfig:
-      constraints: []
+      constraints:
+      - constraints:
+        - key: region
+          type: REQUIRED
+          value: us-east1
+        numReplicas: 2
+      - constraints:
+        - key: region
+          type: REQUIRED
+          value: us-east2
+        numReplicas: 1
+      - constraints:
+        - key: region
+          type: REQUIRED
+          value: us-east3
+        numReplicas: 1
       gc: null
       globalReads: null
-      inheritedConstraints: true
+      inheritedConstraints: false
       inheritedLeasePreferences: false
       leasePreferences:
       - constraints:
@@ -885,7 +900,7 @@ ElementState:
           type: REQUIRED
           value: us-east2
       nullVoterConstraintsIsEmpty: true
-      numReplicas: null
+      numReplicas: 5
       numVoters: 5
       rangeMaxBytes: null
       rangeMinBytes: null
@@ -1360,10 +1375,25 @@ ElementState:
     seqNum: 0
     subzone:
       config:
-        constraints: []
+        constraints:
+        - constraints:
+          - key: region
+            type: REQUIRED
+            value: us-east1
+          numReplicas: 1
+        - constraints:
+          - key: region
+            type: REQUIRED
+            value: us-east2
+          numReplicas: 2
+        - constraints:
+          - key: region
+            type: REQUIRED
+            value: us-east3
+          numReplicas: 1
         gc: null
         globalReads: null
-        inheritedConstraints: true
+        inheritedConstraints: false
         inheritedLeasePreferences: false
         leasePreferences:
         - constraints:
@@ -1371,7 +1401,7 @@ ElementState:
             type: REQUIRED
             value: us-east1
         nullVoterConstraintsIsEmpty: true
-        numReplicas: null
+        numReplicas: 5
         numVoters: 5
         rangeMaxBytes: null
         rangeMinBytes: null
@@ -1398,10 +1428,25 @@ ElementState:
     seqNum: 0
     subzone:
       config:
-        constraints: []
+        constraints:
+        - constraints:
+          - key: region
+            type: REQUIRED
+            value: us-east1
+          numReplicas: 2
+        - constraints:
+          - key: region
+            type: REQUIRED
+            value: us-east2
+          numReplicas: 1
+        - constraints:
+          - key: region
+            type: REQUIRED
+            value: us-east3
+          numReplicas: 1
         gc: null
         globalReads: null
-        inheritedConstraints: true
+        inheritedConstraints: false
         inheritedLeasePreferences: false
         leasePreferences:
         - constraints:
@@ -1409,7 +1454,7 @@ ElementState:
             type: REQUIRED
             value: us-east2
         nullVoterConstraintsIsEmpty: true
-        numReplicas: null
+        numReplicas: 5
         numVoters: 5
         rangeMaxBytes: null
         rangeMinBytes: null
@@ -1436,10 +1481,25 @@ ElementState:
     seqNum: 0
     subzone:
       config:
-        constraints: []
+        constraints:
+        - constraints:
+          - key: region
+            type: REQUIRED
+            value: us-east1
+          numReplicas: 2
+        - constraints:
+          - key: region
+            type: REQUIRED
+            value: us-east2
+          numReplicas: 1
+        - constraints:
+          - key: region
+            type: REQUIRED
+            value: us-east3
+          numReplicas: 1
         gc: null
         globalReads: null
-        inheritedConstraints: true
+        inheritedConstraints: false
         inheritedLeasePreferences: false
         leasePreferences:
         - constraints:
@@ -1447,7 +1507,7 @@ ElementState:
             type: REQUIRED
             value: us-east3
         nullVoterConstraintsIsEmpty: true
-        numReplicas: null
+        numReplicas: 5
         numVoters: 5
         rangeMaxBytes: null
         rangeMinBytes: null
@@ -1532,10 +1592,25 @@ ElementState:
         subzoneIndex: 2
       subzones:
       - config:
-          constraints: []
+          constraints:
+          - constraints:
+            - key: region
+              type: REQUIRED
+              value: us-east1
+            numReplicas: 1
+          - constraints:
+            - key: region
+              type: REQUIRED
+              value: us-east2
+            numReplicas: 2
+          - constraints:
+            - key: region
+              type: REQUIRED
+              value: us-east3
+            numReplicas: 1
           gc: null
           globalReads: null
-          inheritedConstraints: true
+          inheritedConstraints: false
           inheritedLeasePreferences: false
           leasePreferences:
           - constraints:
@@ -1543,7 +1618,7 @@ ElementState:
               type: REQUIRED
               value: us-east1
           nullVoterConstraintsIsEmpty: true
-          numReplicas: null
+          numReplicas: 5
           numVoters: 5
           rangeMaxBytes: null
           rangeMinBytes: null
@@ -1558,10 +1633,25 @@ ElementState:
         indexId: 1
         partitionName: us-east1
       - config:
-          constraints: []
+          constraints:
+          - constraints:
+            - key: region
+              type: REQUIRED
+              value: us-east1
+            numReplicas: 2
+          - constraints:
+            - key: region
+              type: REQUIRED
+              value: us-east2
+            numReplicas: 1
+          - constraints:
+            - key: region
+              type: REQUIRED
+              value: us-east3
+            numReplicas: 1
           gc: null
           globalReads: null
-          inheritedConstraints: true
+          inheritedConstraints: false
           inheritedLeasePreferences: false
           leasePreferences:
           - constraints:
@@ -1569,7 +1659,7 @@ ElementState:
               type: REQUIRED
               value: us-east2
           nullVoterConstraintsIsEmpty: true
-          numReplicas: null
+          numReplicas: 5
           numVoters: 5
           rangeMaxBytes: null
           rangeMinBytes: null
@@ -1584,10 +1674,25 @@ ElementState:
         indexId: 1
         partitionName: us-east2
       - config:
-          constraints: []
+          constraints:
+          - constraints:
+            - key: region
+              type: REQUIRED
+              value: us-east1
+            numReplicas: 2
+          - constraints:
+            - key: region
+              type: REQUIRED
+              value: us-east2
+            numReplicas: 1
+          - constraints:
+            - key: region
+              type: REQUIRED
+              value: us-east3
+            numReplicas: 1
           gc: null
           globalReads: null
-          inheritedConstraints: true
+          inheritedConstraints: false
           inheritedLeasePreferences: false
           leasePreferences:
           - constraints:
@@ -1595,7 +1700,7 @@ ElementState:
               type: REQUIRED
               value: us-east3
           nullVoterConstraintsIsEmpty: true
-          numReplicas: null
+          numReplicas: 5
           numVoters: 5
           rangeMaxBytes: null
           rangeMinBytes: null

--- a/pkg/sql/alter_database.go
+++ b/pkg/sql/alter_database.go
@@ -2011,7 +2011,7 @@ func (n *alterDatabaseSecondaryRegion) startExec(params runParams) error {
 	}
 
 	regions, ok := prevRegionConfig.GetSuperRegionRegionsForRegion(prevRegionConfig.PrimaryRegion())
-	if !ok && prevRegionConfig.IsMemberOfExplicitSuperRegion(catpb.RegionName(n.n.SecondaryRegion)) {
+	if !ok && prevRegionConfig.IsMemberOfSuperRegion(catpb.RegionName(n.n.SecondaryRegion)) {
 		return pgerror.New(pgcode.InvalidDatabaseDefinition,
 			"the secondary region can not be in a super region, unless the primary is also "+
 				"within a super region",

--- a/pkg/sql/region_util.go
+++ b/pkg/sql/region_util.go
@@ -257,7 +257,7 @@ func zoneConfigForMultiRegionPartition(
 	numVoters, numReplicas := getNumVotersAndNumReplicas(regionConfig)
 	zc.NumVoters = &numVoters
 
-	if regionConfig.IsMemberOfExplicitSuperRegion(partitionRegion) {
+	if regionConfig.IsMemberOfSuperRegion(partitionRegion) {
 		err := addConstraintsForSuperRegion(&zc, regionConfig, partitionRegion)
 		if err != nil {
 			return zonepb.ZoneConfig{}, err
@@ -575,7 +575,7 @@ func zoneConfigForMultiRegionTable(
 		if l.RegionalByTable.Region != nil {
 			affinityRegion = *l.RegionalByTable.Region
 		}
-		if l.RegionalByTable.Region == nil && !regionConfig.IsMemberOfExplicitSuperRegion(affinityRegion) {
+		if l.RegionalByTable.Region == nil && !regionConfig.IsMemberOfSuperRegion(affinityRegion) {
 			// If we don't have an explicit affinity region, use the same
 			// configuration as the database and return a blank zcfg here.
 			return zc, nil
@@ -584,7 +584,7 @@ func zoneConfigForMultiRegionTable(
 		numVoters, numReplicas := getNumVotersAndNumReplicas(regionConfig)
 		zc.NumVoters = &numVoters
 
-		if regionConfig.IsMemberOfExplicitSuperRegion(affinityRegion) {
+		if regionConfig.IsMemberOfSuperRegion(affinityRegion) {
 			err := addConstraintsForSuperRegion(&zc, regionConfig, affinityRegion)
 			if err != nil {
 				return zonepb.ZoneConfig{}, err


### PR DESCRIPTION
Backport 1/1 commits from #142838.

/cc @cockroachdb/release

---

When running in a virtual cluster, setting SURVIVE REGION FAILURE on a database, data can leak out of the configured regions. The data can end up in any region that is known to the host cluster. The fix is to implicitly create and apply a super region when SURVIVE_REGION_FAILURE is set and we are using 3 regions.

Fixes: #141623
Release note (bug fix): Fixed a bug which would send a replica outside of a tenant known region, when SURVIVE REGION FAILURE was set and we configured exactly 3 regions.

Release justification: Bug fix.
