### PR TITLE
memo: avoid encoding jsonpath in `IsDatumEqual`

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/jsonpath
+++ b/pkg/sql/logictest/testdata/logic_test/jsonpath
@@ -84,6 +84,22 @@ SELECT '$'::JSONPATH AS col ORDER BY col DESC NULLS FIRST;
 statement error pgcode 42883 could not identify an ordering operator for type jsonpath
 SELECT '$'::JSONPATH ORDER BY 1 ASC;
 
+statement ok
+CREATE TABLE t (k INT PRIMARY KEY);
+
+statement ok
+INSERT INTO t VALUES (0);
+
+query T
+SELECT bpchar('$."a1"[*]':::JSONPATH::JSONPATH)::BPCHAR FROM t ORDER BY 1 NULLS LAST;
+----
+$."a1"[*]
+
+query T
+SELECT bpchar('$.   abc    [*]':::JSONPATH::JSONPATH)::BPCHAR FROM t ORDER BY 1 NULLS LAST;
+----
+$."abc"[*]
+
 ## When we allow table creation
 
 # statement ok

--- a/pkg/sql/opt/memo/interner.go
+++ b/pkg/sql/opt/memo/interner.go
@@ -909,6 +909,10 @@ func (h *hasher) IsDatumEqual(l, r tree.Datum) bool {
 			return false
 		}
 		return len(lt.Array) != 0 || h.IsTypeEqual(ltyp, rtyp)
+	case *tree.DJsonpath:
+		// TODO(normanchenn): Workaround until we allow jsonpath encoding.
+		rt := r.(*tree.DJsonpath)
+		return h.IsStringEqual(string(*lt), string(*rt))
 	default:
 		h.bytes, h.bytes3 = encodeDatum(h.bytes[:0], l, h.bytes3[:0])
 		h.bytes2, h.bytes3 = encodeDatum(h.bytes2[:0], r, h.bytes3[:0])


### PR DESCRIPTION
This commit adds a workaround to address a roachtest failure where encoding jsonpath is not supported. Now, in `IsDatumEqual`, `tree.DJsonpath` values are converted to and compared as strings.

Fixes: #142949
Epic: None
Release note: None