### PR TITLE
kvserver,raft: reduce leader lease logging

### DIFF
--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -2220,7 +2220,9 @@ func (r *Replica) maybeMarkReplicaUnavailableInLeaderlessWatcher(
 			err := errors.Errorf("have been leaderless for %.2fs, setting the "+
 				"leaderless watcher replica's state as unavailable",
 				durationSinceLeaderless.Seconds())
-			log.Warningf(ctx, "%s", err)
+			if log.ExpensiveLogEnabled(ctx, 1) {
+				log.VEventf(ctx, 1, "%s", err)
+			}
 			r.LeaderlessWatcher.mu.unavailable = true
 		}
 	}

--- a/pkg/kv/kvserver/replica_store_liveness.go
+++ b/pkg/kv/kvserver/replica_store_liveness.go
@@ -63,7 +63,9 @@ func (r *replicaRLockedStoreLiveness) SupportFor(replicaID raftpb.PeerID) (raftp
 	storeID, ok := r.getStoreIdent(replicaID)
 	if !ok {
 		ctx := r.AnnotateCtx(context.TODO())
-		log.Warningf(ctx, "store not found for replica %d in SupportFor", replicaID)
+		if log.ExpensiveLogEnabled(ctx, 1) {
+			log.VEventf(ctx, 1, "store not found for replica %d in SupportFor", replicaID)
+		}
 		return 0, false
 	}
 	epoch, ok := r.store.storeLiveness.SupportFor(storeID)
@@ -77,7 +79,9 @@ func (r *replicaRLockedStoreLiveness) SupportFrom(
 	storeID, ok := r.getStoreIdent(replicaID)
 	if !ok {
 		ctx := r.AnnotateCtx(context.TODO())
-		log.Warningf(ctx, "store not found for replica %d in SupportFrom", replicaID)
+		if log.ExpensiveLogEnabled(ctx, 1) {
+			log.VEventf(ctx, 1, "store not found for replica %d in SupportFrom", replicaID)
+		}
 		return 0, hlc.Timestamp{}
 	}
 	epoch, exp := r.store.storeLiveness.SupportFrom(storeID)

--- a/pkg/raft/raft.go
+++ b/pkg/raft/raft.go
@@ -2356,7 +2356,7 @@ func (r *raft) checkQuorumActive() {
 		r.logger.Debugf("%x does not have store liveness support from a quorum of peers", r.id)
 	}
 	if !quorumActiveByHeartbeats && !quorumActiveByFortification {
-		r.logger.Warningf("%x stepped down to follower since quorum is not active", r.id)
+		r.logger.Infof("%x stepped down to follower since quorum is not active", r.id)
 		r.becomeFollower(r.Term, None)
 	}
 	// Mark everyone (but ourselves) as inactive in preparation for the next

--- a/pkg/raft/testdata/de_fortification_checkquorum.txt
+++ b/pkg/raft/testdata/de_fortification_checkquorum.txt
@@ -68,7 +68,7 @@ INFO 1 leader at term 1 does not support itself in the liveness fabric
 INFO 1 leader at term 1 does not support itself in the liveness fabric
 DEBUG 1 has not received messages from a quorum of peers in the last election timeout
 DEBUG 1 does not have store liveness support from a quorum of peers
-WARN 1 stepped down to follower since quorum is not active
+INFO 1 stepped down to follower since quorum is not active
 DEBUG 1 setting election elapsed to start from 3 ticks after store liveness support expired
 INFO 1 became follower at term 1
 DEBUG 1 reset election elapsed to 0
@@ -232,7 +232,7 @@ INFO 2 leader at term 2 does not support itself in the liveness fabric
 INFO 2 leader at term 2 does not support itself in the liveness fabric
 DEBUG 2 has not received messages from a quorum of peers in the last election timeout
 DEBUG 2 does not have store liveness support from a quorum of peers
-WARN 2 stepped down to follower since quorum is not active
+INFO 2 stepped down to follower since quorum is not active
 DEBUG 2 setting election elapsed to start from 3 ticks after store liveness support expired
 INFO 2 became follower at term 2
 DEBUG 2 reset election elapsed to 0

--- a/pkg/raft/testdata/fortification_checkquorum.txt
+++ b/pkg/raft/testdata/fortification_checkquorum.txt
@@ -84,7 +84,7 @@ INFO 1 leader at term 1 does not support itself in the liveness fabric
 INFO 1 leader at term 1 does not support itself in the liveness fabric
 DEBUG 1 has not received messages from a quorum of peers in the last election timeout
 DEBUG 1 does not have store liveness support from a quorum of peers
-WARN 1 stepped down to follower since quorum is not active
+INFO 1 stepped down to follower since quorum is not active
 DEBUG 1 setting election elapsed to start from 3 ticks after store liveness support expired
 INFO 1 became follower at term 1
 DEBUG 1 reset election elapsed to 0

--- a/pkg/raft/testdata/liveness_recovered_after_temporary_loss_of_quorum.txt
+++ b/pkg/raft/testdata/liveness_recovered_after_temporary_loss_of_quorum.txt
@@ -65,7 +65,7 @@ tick-election 1
 ----
 INFO 1 leader at term 1 does not support itself in the liveness fabric
 INFO 1 leader at term 1 does not support itself in the liveness fabric
-WARN 1 stepped down to follower since quorum is not active
+INFO 1 stepped down to follower since quorum is not active
 INFO 1 became follower at term 1
 
 stabilize


### PR DESCRIPTION
Under some circumstances (e.g. successive splitting, overload), certain Raft and store liveness logging is excessive and might appear worrisome even though it is harmless or expected.

This commit pushes some of that logging to a higher verbosity.

Fixes: #141854

Release note: None