### PR TITLE
release-25.1: scbuild: clean up unneeded subzones after index swap

### DIFF
--- a/pkg/ccl/schemachangerccl/BUILD.bazel
+++ b/pkg/ccl/schemachangerccl/BUILD.bazel
@@ -43,6 +43,8 @@ go_test(
         "//pkg/sql/schemachanger/sctest",
         "//pkg/testutils/datapathutils",
         "//pkg/testutils/serverutils",
+        "//pkg/testutils/skip",
+        "//pkg/testutils/sqlutils",
         "//pkg/testutils/testcluster",
         "//pkg/util/leaktest",
         "//pkg/util/log",

--- a/pkg/ccl/schemachangerccl/schemachanger_ccl_test.go
+++ b/pkg/ccl/schemachangerccl/schemachanger_ccl_test.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	gosql "database/sql"
 	"testing"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/ccl/multiregionccl/multiregionccltestutils"
@@ -19,6 +20,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/sctest"
 	"github.com/cockroachdb/cockroach/pkg/testutils/datapathutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
@@ -80,4 +83,169 @@ func TestDecomposeToElements(t *testing.T) {
 		datapathutils.TestDataPath(t, "decomp"),
 		MultiRegionTestClusterFactory{},
 	)
+}
+
+func TestSubzonesRemovedByGCAfterIndexSwap(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	skip.UnderDeadlock(t, "timing dependent")
+	skip.UnderRace(t, "timing dependent")
+
+	ctx := context.Background()
+	s, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(ctx)
+
+	systemConn := s.SystemLayer().SQLConn(t)
+	systemRunner := sqlutils.MakeSQLRunner(systemConn)
+	systemRunner.Exec(t, "SET CLUSTER SETTING sql.gc_job.wait_for_gc.interval = '5s';")
+
+	runner := sqlutils.MakeSQLRunner(sqlDB)
+	runner.Exec(t, `
+CREATE TABLE person (
+    name STRING,
+    country STRING,
+    birth_date DATE,
+    INDEX (birth_date),
+    PRIMARY KEY (country, birth_date, name)
+)
+    PARTITION BY LIST (country) (
+            PARTITION australia
+                VALUES IN ('AU', 'NZ')
+                PARTITION BY RANGE (birth_date)
+                    (
+                        PARTITION old_au VALUES FROM (minvalue) TO ('1995-01-01'),
+                        PARTITION yung_au VALUES FROM ('1995-01-01') TO (maxvalue)
+                    ),
+            PARTITION north_america
+                VALUES IN ('US', 'CA')
+                PARTITION BY RANGE (birth_date)
+                    (
+                        PARTITION old_na VALUES FROM (minvalue) TO ('1995-01-01'),
+                        PARTITION yung_na VALUES FROM ('1995-01-01') TO (maxvalue)
+                    ),
+            PARTITION default
+                VALUES IN (default)
+        );`)
+
+	subzonesQuery := `
+	WITH subzone_json AS (
+	  SELECT
+	    value AS config,
+	    ordinality AS array_index
+	  FROM system.zones,
+	       LATERAL json_array_elements(
+	         crdb_internal.pb_to_json('cockroach.config.zonepb.ZoneConfig', config) -> 'subzones'
+	       ) WITH ORDINALITY
+	  WHERE id = 'person'::REGCLASS::OID
+	),
+	subzones AS (
+		SELECT
+			(config->'indexId')::INT index_id,
+			(config->>'partitionName')::TEXT partition_name,
+			(config->'config'->'gc'->'ttlSeconds')::INT AS ttl_seconds,
+			array_index - 1 AS array_index
+		FROM subzone_json
+	),
+	subzone_span_json AS (
+		SELECT json_array_elements(crdb_internal.pb_to_json('cockroach.config.zonepb.ZoneConfig', config) -> 'subzoneSpans') AS subzone_span
+		FROM system.zones
+		WHERE id = 'person'::REGCLASS::OID
+	),
+	subzone_spans AS (
+		SELECT
+			crdb_internal.pretty_key(decode(subzone_span->>'key', 'base64'), 0) AS start_key,
+			crdb_internal.pretty_key(decode(subzone_span->>'endKey', 'base64'), 0) AS end_key,
+			COALESCE((subzone_span->>'subzoneIndex')::INT, 0) AS subzone_index
+		FROM subzone_span_json
+	)
+	SELECT
+		subzones.index_id,
+		subzones.partition_name,
+		subzones.ttl_seconds,
+		subzone_spans.start_key,
+		subzone_spans.end_key
+	FROM subzones
+	LEFT JOIN subzone_spans ON subzones.array_index = subzone_spans.subzone_index
+	ORDER BY 3, 1, 2, 4, 5;`
+
+	runner.Exec(t, `ALTER PARTITION north_america OF TABLE person CONFIGURE ZONE USING gc.ttlseconds = 4;`)
+	runner.Exec(t, `ALTER PARTITION old_au OF TABLE person CONFIGURE ZONE USING gc.ttlseconds = 5;`)
+	runner.Exec(t, `ALTER PARTITION yung_au OF TABLE person CONFIGURE ZONE USING gc.ttlseconds = 6;`)
+	runner.Exec(t, `ALTER INDEX person@person_pkey CONFIGURE ZONE USING gc.ttlseconds = 7;`)
+	runner.Exec(t, `ALTER INDEX person@person_birth_date_idx CONFIGURE ZONE USING gc.ttlseconds = 8;`)
+
+	runner.CheckQueryResults(t, subzonesQuery, [][]string{
+		{"1", "north_america", "4", `/1/"CA"`, "NULL"},
+		{"1", "north_america", "4", `/1/"US"`, "NULL"},
+		{"1", "old_au", "5", `/1/"AU"`, `/1/"AU"/9131`},
+		{"1", "old_au", "5", `/1/"NZ"`, `/1/"NZ"/9131`},
+		{"1", "yung_au", "6", `/1/"AU"/9131`, `/1/"AU"/PrefixEnd`},
+		{"1", "yung_au", "6", `/1/"NZ"/9131`, `/1/"NZ"/PrefixEnd`},
+		{"1", "NULL", "7", "/1", `/1/"AU"`},
+		{"1", "NULL", "7", `/1/"AU"/PrefixEnd`, `/1/"CA"`},
+		{"1", "NULL", "7", `/1/"CA"/PrefixEnd`, `/1/"NZ"`},
+		{"1", "NULL", "7", `/1/"NZ"/PrefixEnd`, `/1/"US"`},
+		{"1", "NULL", "7", `/1/"US"/PrefixEnd`, "/2"},
+		{"2", "NULL", "8", "/2", "NULL"},
+	})
+
+	// Cause a primary key change.
+	runner.Exec(t, `ALTER TABLE person ADD COLUMN new_col INT DEFAULT 0;`)
+
+	// Right after the primary key change, the subzones for the old index and
+	// temporary index should still be present.
+	runner.CheckQueryResults(t, subzonesQuery, [][]string{
+		{"1", "north_america", "4", `/1/"CA"`, "NULL"},
+		{"1", "north_america", "4", `/1/"US"`, "NULL"},
+		{"3", "north_america", "4", `/3/"CA"`, "NULL"},
+		{"3", "north_america", "4", `/3/"US"`, "NULL"},
+		{"4", "north_america", "4", `/4/"CA"`, "NULL"},
+		{"4", "north_america", "4", `/4/"US"`, "NULL"},
+		{"1", "old_au", "5", `/1/"AU"`, `/1/"AU"/9131`},
+		{"1", "old_au", "5", `/1/"NZ"`, `/1/"NZ"/9131`},
+		{"3", "old_au", "5", `/3/"AU"`, `/3/"AU"/9131`},
+		{"3", "old_au", "5", `/3/"NZ"`, `/3/"NZ"/9131`},
+		{"4", "old_au", "5", `/4/"AU"`, `/4/"AU"/9131`},
+		{"4", "old_au", "5", `/4/"NZ"`, `/4/"NZ"/9131`},
+		{"1", "yung_au", "6", `/1/"AU"/9131`, `/1/"AU"/PrefixEnd`},
+		{"1", "yung_au", "6", `/1/"NZ"/9131`, `/1/"NZ"/PrefixEnd`},
+		{"3", "yung_au", "6", `/3/"AU"/9131`, `/3/"AU"/PrefixEnd`},
+		{"3", "yung_au", "6", `/3/"NZ"/9131`, `/3/"NZ"/PrefixEnd`},
+		{"4", "yung_au", "6", `/4/"AU"/9131`, `/4/"AU"/PrefixEnd`},
+		{"4", "yung_au", "6", `/4/"NZ"/9131`, `/4/"NZ"/PrefixEnd`},
+		{"1", "NULL", "7", "/1", `/1/"AU"`},
+		{"1", "NULL", "7", `/1/"AU"/PrefixEnd`, `/1/"CA"`},
+		{"1", "NULL", "7", `/1/"CA"/PrefixEnd`, `/1/"NZ"`},
+		{"1", "NULL", "7", `/1/"NZ"/PrefixEnd`, `/1/"US"`},
+		{"1", "NULL", "7", `/1/"US"/PrefixEnd`, "/2"},
+		{"3", "NULL", "7", "/3", `/3/"AU"`},
+		{"3", "NULL", "7", `/3/"AU"/PrefixEnd`, `/3/"CA"`},
+		{"3", "NULL", "7", `/3/"CA"/PrefixEnd`, `/3/"NZ"`},
+		{"3", "NULL", "7", `/3/"NZ"/PrefixEnd`, `/3/"US"`},
+		{"3", "NULL", "7", `/3/"US"/PrefixEnd`, "/4"},
+		{"4", "NULL", "7", "/4", `/4/"AU"`},
+		{"4", "NULL", "7", `/4/"AU"/PrefixEnd`, `/4/"CA"`},
+		{"4", "NULL", "7", `/4/"CA"/PrefixEnd`, `/4/"NZ"`},
+		{"4", "NULL", "7", `/4/"NZ"/PrefixEnd`, `/4/"US"`},
+		{"4", "NULL", "7", `/4/"US"/PrefixEnd`, "/5"},
+		{"2", "NULL", "8", "/2", "NULL"},
+	})
+
+	// Keep retrying until the old index and temporary index are removed by the GC job.
+	runner.SucceedsSoonDuration = 12 * time.Second
+	runner.CheckQueryResultsRetry(t, subzonesQuery, [][]string{
+		{"3", "north_america", "4", `/3/"CA"`, "NULL"},
+		{"3", "north_america", "4", `/3/"US"`, "NULL"},
+		{"3", "old_au", "5", `/3/"AU"`, `/3/"AU"/9131`},
+		{"3", "old_au", "5", `/3/"NZ"`, `/3/"NZ"/9131`},
+		{"3", "yung_au", "6", `/3/"AU"/9131`, `/3/"AU"/PrefixEnd`},
+		{"3", "yung_au", "6", `/3/"NZ"/9131`, `/3/"NZ"/PrefixEnd`},
+		{"3", "NULL", "7", "/3", `/3/"AU"`},
+		{"3", "NULL", "7", `/3/"AU"/PrefixEnd`, `/3/"CA"`},
+		{"3", "NULL", "7", `/3/"CA"/PrefixEnd`, `/3/"NZ"`},
+		{"3", "NULL", "7", `/3/"NZ"/PrefixEnd`, `/3/"US"`},
+		{"3", "NULL", "7", `/3/"US"/PrefixEnd`, "/4"},
+		{"2", "NULL", "8", "/2", "NULL"},
+	})
 }

--- a/pkg/sql/logictest/testdata/logic_test/zone_config
+++ b/pkg/sql/logictest/testdata/logic_test/zone_config
@@ -546,10 +546,10 @@ statement ok
 ALTER TABLE foo ADD COLUMN j INT NOT NULL DEFAULT 42;
 
 # Here, we can see that although the index ID changed, our corresponding
-# subzone config has an entry for our new index; along with a corres. subzone
-# span.
+# subzone config has an entry for our new index, along with a corresponding
+# subzone span.
 skipif config local-mixed-24.3 local-legacy-schema-changer
-query B colnames
+statement ok
 WITH subzones AS (
     SELECT
         json_array_elements(
@@ -571,29 +571,56 @@ primary_index AS (
         )->'table'->'primaryIndex'->>'id')::INT AS primaryID
     FROM system.descriptor
     WHERE id = 'foo'::regclass::oid
+),
+index_ids_match AS (
+  SELECT EXISTS (
+      SELECT 1
+      FROM primary_index, subzone_indexes
+      WHERE primaryID = indexID
+  ) AS match_found
 )
-SELECT EXISTS (
-    SELECT 1
-    FROM primary_index, subzone_indexes
-    WHERE primaryID = indexID
-) AS match_found;
+SELECT crdb_internal.force_error('', 'expected IDs to match')
+FROM index_ids_match WHERE match_found = false;
+
+# The new primary index should have a subzone. The old primary index and the
+# temporary index also have a subzone, and those will be cleaned up later by the
+# schema change GC job.
+skipif config local-mixed-24.3 local-legacy-schema-changer
+query I
+WITH subzones AS (
+    SELECT
+        json_array_elements(
+            crdb_internal.pb_to_json('cockroach.config.zonepb.ZoneConfig', config) -> 'subzones'
+        ) AS config
+    FROM system.zones
+    WHERE id = 'foo'::REGCLASS::OID
+),
+subzone_indexes AS (
+    SELECT
+        (config -> 'indexId')::INT AS indexID
+    FROM subzones
+)
+SELECT indexID
+FROM subzone_indexes
+ORDER BY indexID;
 ----
-match_found
-true
+1
+2
+3
 
 skipif config local-mixed-24.3 local-legacy-schema-changer
-query B
+query T
 WITH subzone_spans AS (
     SELECT json_array_elements(crdb_internal.pb_to_json('cockroach.config.zonepb.ZoneConfig', config) -> 'subzoneSpans') ->> 'key' AS key
     FROM system.zones
     WHERE id = 'foo'::REGCLASS::OID
 )
-SELECT EXISTS (
-    SELECT 1
-    FROM subzone_spans
-    WHERE crdb_internal.pretty_key(decode(key, 'base64'), 0) = '/2'
-) AS exists;
+SELECT crdb_internal.pretty_key(decode(key, 'base64'), 0)
+FROM subzone_spans
+ORDER BY 1
 ----
-true
+/1
+/2
+/3
 
 subtest end

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table.go
@@ -200,12 +200,11 @@ func maybeRewriteTempIDsInPrimaryIndexes(b BuildCtx, tableID catid.DescID) {
 	}
 	chain.validate()
 	currPrimaryIndexID := getCurrentPrimaryIndexID(b, tableID)
-	hasZoneCfgRefs := hasSubzonesForIndex(b, tableID, currPrimaryIndexID)
-	if hasRewrittenPrimaryID && hasZoneCfgRefs {
+	if hasRewrittenPrimaryID {
 		if err := configureZoneConfigForNewIndexBackfill(b, tableID, currPrimaryIndexID); err != nil {
 			panic(errors.Wrapf(
 				err,
-				"error while updating zone config refs for indexID %d of tableID %d",
+				"error while updating zone configs for indexID %d of tableID %d",
 				currPrimaryIndexID,
 				tableID))
 		}

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/zone_config_helpers.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/zone_config_helpers.go
@@ -1342,14 +1342,14 @@ func constructSideEffectPartitionElem(
 	return elem
 }
 
-// getMostRecentTableZoneCfg returns the most recent table (denoted by
+// getMostRecentTableZoneConfig returns the most recent table (denoted by
 // highest seqNum) zone config for the given tableID (if any exist).
 //
 // N.B. Adding a new zone config element entails adding a new element where the
 // seqNum is 1 greater than the most recent zone config element. This helps
 // ensure zone config changes are applied in the correct order during explicit
 // transactions.
-func getMostRecentTableZoneCfg(b BuildCtx, tableID catid.DescID) *scpb.TableZoneConfig {
+func getMostRecentTableZoneConfig(b BuildCtx, tableID catid.DescID) *scpb.TableZoneConfig {
 	maxSeq := uint32(0)
 	var tzo *scpb.TableZoneConfig
 	b.QueryByID(tableID).FilterTableZoneConfig().
@@ -1367,7 +1367,11 @@ func getMostRecentTableZoneCfg(b BuildCtx, tableID catid.DescID) *scpb.TableZone
 func configureZoneConfigForNewIndexBackfill(
 	b BuildCtx, tableID catid.DescID, oldIndexID catid.IndexID,
 ) error {
-	mostRecentTableZoneConfig := getMostRecentTableZoneCfg(b, tableID)
+	// Short-circuit if there are no subzones for the old index.
+	if !hasSubzonesForIndex(b, tableID, oldIndexID) {
+		return nil
+	}
+	mostRecentTableZoneConfig := getMostRecentTableZoneConfig(b, tableID)
 	if mostRecentTableZoneConfig == nil {
 		return errors.AssertionFailedf("attempting to modify subzone configs for indexID %d"+
 			" on tableID %d that does not a zone config set", oldIndexID, tableID)
@@ -1383,12 +1387,15 @@ func configureZoneConfigForNewIndexBackfill(
 	newSubzones = append(newSubzones, newZoneConfig.Subzones...)
 	// For the indexes we will use as a part of the backfill, ensure we copy
 	// over each subzone config from the old index to the backfill-related ones.
+	// NOTE: The subzones for the old index and temporary index will eventually
+	// be removed by the schema change GC job, but we need them to be present
+	// for the duration of this schema change.
 	for _, idxToAdd := range newIndexesForBackfill {
 		for _, subzone := range newZoneConfig.Subzones {
 			if subzone.IndexID == uint32(oldIndexID) {
 				subzone.IndexID = uint32(idxToAdd)
+				newSubzones = append(newSubzones, subzone)
 			}
-			newSubzones = append(newSubzones, subzone)
 		}
 	}
 	newZoneConfig.Subzones = newSubzones


### PR DESCRIPTION
Backport 1/1 commits from #142952.

/cc @cockroachdb/release

Release justification: bug fix

---

6a122ed6788 added logic to update the subzone configs with the new index
IDs after an index backfill and swap. However, it created duplicate
entries for the old index's subzones.

This patch fixes that. While I was looking at the code I added a test to
verify that the old and temporary indexes eventually have their subzones
cleaned up by the GC job.

Epic: CRDB-43532
Release note: None
