### PR TITLE
execinfra: make procState redact-safe

### DIFF
--- a/pkg/sql/execinfra/BUILD.bazel
+++ b/pkg/sql/execinfra/BUILD.bazel
@@ -77,6 +77,7 @@ go_library(
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_pebble//vfs",
         "@com_github_cockroachdb_redact//:redact",
+        "@com_github_cockroachdb_redact//interfaces",
         "@com_github_marusama_semaphore//:semaphore",
         "@io_opentelemetry_go_otel//attribute",
         "@org_golang_google_grpc//:grpc",

--- a/pkg/sql/execinfra/processorsbase.go
+++ b/pkg/sql/execinfra/processorsbase.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/redact"
+	"github.com/cockroachdb/redact/interfaces"
 	"go.opentelemetry.io/otel/attribute"
 )
 
@@ -444,6 +445,21 @@ func (pb *ProcessorBase) Reset() {
 // states are relevant when the processor is using the draining utilities in
 // ProcessorBase.
 type procState int
+
+func (i procState) SafeFormat(s interfaces.SafePrinter, verb rune) {
+	switch i {
+	case StateRunning:
+		s.Print("StateRunning")
+	case StateDraining:
+		s.Print("StateDraining")
+	case StateTrailingMeta:
+		s.Print("StateTrailingMeta")
+	case StateExhausted:
+		s.Print("StateExhausted")
+	}
+}
+
+var _ redact.SafeFormatter = procState(0)
 
 //go:generate stringer -type=procState
 const (


### PR DESCRIPTION
We've seen a few sentry issues where it'd be nice to have the processor state unredacted to help understanding how the issue happened.

Fixes: #142966.

Release note: None