### PR TITLE
raft: ignore setting the lead field from a MsgDeFortify at current term

### DIFF
--- a/pkg/raft/raft.go
+++ b/pkg/raft/raft.go
@@ -2258,11 +2258,11 @@ func stepCandidate(r *raft, m pb.Message) error {
 
 func stepFollower(r *raft, m pb.Message) error {
 	if IsMsgFromLeader(m.Type) {
-		r.setLead(m.From)
 		if m.Type != pb.MsgDeFortifyLeader {
 			// If we receive any message from the leader except a MsgDeFortifyLeader,
 			// we know that the leader is still alive and still acting as the leader,
 			// so reset the election timer.
+			r.setLead(m.From)
 			r.electionElapsed = 0
 		}
 	}

--- a/pkg/raft/testdata/liveness_impacted_after_temporary_loss_of_quorum.txt
+++ b/pkg/raft/testdata/liveness_impacted_after_temporary_loss_of_quorum.txt
@@ -1,0 +1,182 @@
+# This test ensures that if there is a temporary blip that causes loss of
+# quorum, the liveness of the raft group is restored once the blip is fixed.
+# Right now, there is a bug where no peer will be able to become a leader, and
+# liveness could be stalled indefinitely.
+
+log-level none
+----
+ok
+
+add-nodes 2 voters=(1,2) index=10 checkquorum=true prevote=true
+----
+ok
+
+campaign 1
+----
+ok
+
+stabilize
+----
+ok
+
+# Fix the randomized election timeout to be one tick-election.
+set-randomized-election-timeout 1 timeout=3
+----
+ok
+
+set-randomized-election-timeout 2 timeout=3
+----
+ok
+
+log-level info
+----
+ok
+
+# Propose a data entry to peer 1. This makes it have the longest log.
+propose 1 data1
+----
+ok
+
+stabilize 1
+----
+> 1 handling Ready
+  Ready MustSync=true:
+  Entries:
+  1/12 EntryNormal "data1"
+  Messages:
+  1->2 MsgApp Term:1 Log:1/11 Commit:11 Entries:[1/12 EntryNormal "data1"]
+
+# Peer 2 has a temporary blip.
+deliver-msgs drop=(2)
+----
+dropped: 1->2 MsgApp Term:1 Log:1/11 Commit:11 Entries:[1/12 EntryNormal "data1"]
+
+# Peer 1's support will eventually expire.
+support-expired 1
+----
+ok
+
+# Peer 1 should detect that it no longer has a quorum and step down.
+tick-election 1
+----
+INFO 1 leader at term 1 does not support itself in the liveness fabric
+INFO 1 leader at term 1 does not support itself in the liveness fabric
+INFO 1 leader at term 1 does not support itself in the liveness fabric
+
+tick-election 1
+----
+INFO 1 leader at term 1 does not support itself in the liveness fabric
+INFO 1 leader at term 1 does not support itself in the liveness fabric
+WARN 1 stepped down to follower since quorum is not active
+INFO 1 became follower at term 1
+
+stabilize
+----
+> 1 handling Ready
+  Ready MustSync=true:
+  State:StateFollower
+  HardState Term:1 Vote:1 Commit:11 Lead:0 LeadEpoch:0
+  Messages:
+  1->2 MsgDeFortifyLeader Term:1 Log:0/0
+> 2 receiving messages
+  1->2 MsgDeFortifyLeader Term:1 Log:0/0
+> 2 handling Ready
+  Ready MustSync=true:
+  HardState Term:1 Vote:1 Commit:11 Lead:1 LeadEpoch:0
+  
+# Fix the network blip.
+support-expired 1 reset
+----
+ok
+
+# Note that at this point, the quorum is active, and it should be possible for
+# both peers to campaign. However, only peer 1 can actually win the election
+# since it has the longer log.
+tick-election 2
+----
+INFO 2 is starting a new election at term 1
+INFO 2 became pre-candidate at term 1
+INFO 2 [logterm: 1, index: 11] sent MsgPreVote request to 1 at term 1
+
+stabilize
+----
+> 2 handling Ready
+  Ready MustSync=true:
+  State:StatePreCandidate
+  HardState Term:1 Vote:1 Commit:11 Lead:0 LeadEpoch:0
+  Messages:
+  2->1 MsgPreVote Term:2 Log:1/11
+  INFO 2 received MsgPreVoteResp from 2 at term 1
+  INFO 2 has received 1 MsgPreVoteResp votes and 0 vote rejections
+> 1 receiving messages
+  2->1 MsgPreVote Term:2 Log:1/11
+  INFO 1 [logterm: 1, index: 12, vote: 1] rejected MsgPreVote from 2 [logterm: 1, index: 11] at term 1
+> 1 handling Ready
+  Ready MustSync=false:
+  Messages:
+  1->2 MsgPreVoteResp Term:1 Log:0/0 Rejected (Hint: 0)
+> 2 receiving messages
+  1->2 MsgPreVoteResp Term:1 Log:0/0 Rejected (Hint: 0)
+  INFO 2 received MsgPreVoteResp rejection from 1 at term 1
+  INFO 2 has received 1 MsgPreVoteResp votes and 1 vote rejections
+  INFO 2 became follower at term 1
+> 2 handling Ready
+  Ready MustSync=false:
+  State:StateFollower
+  
+# Note that both peers have successfully forgotten the leader for term 1.
+raft-state
+----
+1: StateFollower (Voter) Term:1 Lead:0 LeadEpoch:0
+2: StateFollower (Voter) Term:1 Lead:0 LeadEpoch:0
+
+# The leader will keep trying to broadcast a MsgDeFortifyLeader until it
+# hears about a new term that got committed at a higher term.
+send-de-fortify 1 2
+----
+ok
+
+stabilize
+----
+> 1 handling Ready
+  Ready MustSync=false:
+  Messages:
+  1->2 MsgDeFortifyLeader Term:1 Log:0/0
+> 2 receiving messages
+  1->2 MsgDeFortifyLeader Term:1 Log:0/0
+> 2 handling Ready
+  Ready MustSync=true:
+  HardState Term:1 Vote:1 Commit:11 Lead:1 LeadEpoch:0
+
+# Fix the randomized election timeout to be one tick-election.
+set-randomized-election-timeout 1 timeout=3
+----
+ok
+
+tick-election 1
+----
+INFO 1 is starting a new election at term 1
+INFO 1 became pre-candidate at term 1
+INFO 1 [logterm: 1, index: 12] sent MsgPreVote request to 2 at term 1
+
+stabilize
+----
+> 1 handling Ready
+  Ready MustSync=false:
+  State:StatePreCandidate
+  Messages:
+  1->2 MsgPreVote Term:2 Log:1/12
+  INFO 1 received MsgPreVoteResp from 1 at term 1
+  INFO 1 has received 1 MsgPreVoteResp votes and 0 vote rejections
+> 2 receiving messages
+  1->2 MsgPreVote Term:2 Log:1/12
+  INFO 2 [logterm: 1, index: 11, vote: 1] ignored MsgPreVote from 1 [logterm: 1, index: 12] at term 1: recently received communication from leader (remaining ticks: 3)
+  
+# At this point we saw that both peers attempted to campaign, but non of them
+# succeeded. Peer 1's request got rejected because 2 recently heard from 1
+# when receiving the MsgDefortifyLeader request.
+# Note that now 2 thinks that 1 is the leader for term 1, even though it isn't.
+raft-state
+----
+1: StatePreCandidate (Voter) Term:1 Lead:0 LeadEpoch:0
+2: StateFollower (Voter) Term:1 Lead:1 LeadEpoch:0

--- a/pkg/raft/testdata/liveness_recovered_after_temporary_loss_of_quorum.txt
+++ b/pkg/raft/testdata/liveness_recovered_after_temporary_loss_of_quorum.txt
@@ -1,7 +1,5 @@
 # This test ensures that if there is a temporary blip that causes loss of
 # quorum, the liveness of the raft group is restored once the blip is fixed.
-# Right now, there is a bug where no peer will be able to become a leader, and
-# liveness could be stalled indefinitely.
 
 log-level none
 ----
@@ -144,9 +142,6 @@ stabilize
   1->2 MsgDeFortifyLeader Term:1 Log:0/0
 > 2 receiving messages
   1->2 MsgDeFortifyLeader Term:1 Log:0/0
-> 2 handling Ready
-  Ready MustSync=true:
-  HardState Term:1 Vote:1 Commit:11 Lead:1 LeadEpoch:0
 
 # Fix the randomized election timeout to be one tick-election.
 set-randomized-election-timeout 1 timeout=3
@@ -170,13 +165,104 @@ stabilize
   INFO 1 has received 1 MsgPreVoteResp votes and 0 vote rejections
 > 2 receiving messages
   1->2 MsgPreVote Term:2 Log:1/12
-  INFO 2 [logterm: 1, index: 11, vote: 1] ignored MsgPreVote from 1 [logterm: 1, index: 12] at term 1: recently received communication from leader (remaining ticks: 3)
-  
-# At this point we saw that both peers attempted to campaign, but non of them
-# succeeded. Peer 1's request got rejected because 2 recently heard from 1
-# when receiving the MsgDefortifyLeader request.
-# Note that now 2 thinks that 1 is the leader for term 1, even though it isn't.
+  INFO 2 [logterm: 1, index: 11, vote: 1] cast MsgPreVote for 1 [logterm: 1, index: 12] at term 1
+> 2 handling Ready
+  Ready MustSync=false:
+  Messages:
+  2->1 MsgPreVoteResp Term:2 Log:0/0
+> 1 receiving messages
+  2->1 MsgPreVoteResp Term:2 Log:0/0
+  INFO 1 received MsgPreVoteResp from 2 at term 1
+  INFO 1 has received 2 MsgPreVoteResp votes and 0 vote rejections
+  INFO 1 became candidate at term 2
+  INFO 1 [logterm: 1, index: 12] sent MsgVote request to 2 at term 2
+> 1 handling Ready
+  Ready MustSync=true:
+  State:StateCandidate
+  HardState Term:2 Vote:1 Commit:11 Lead:0 LeadEpoch:0
+  Messages:
+  1->2 MsgVote Term:2 Log:1/12
+  INFO 1 received MsgVoteResp from 1 at term 2
+  INFO 1 has received 1 MsgVoteResp votes and 0 vote rejections
+> 2 receiving messages
+  1->2 MsgVote Term:2 Log:1/12
+  INFO 2 [term: 1] received a MsgVote message with higher term from 1 [term: 2], advancing term
+  INFO 2 became follower at term 2
+  INFO 2 [logterm: 1, index: 11, vote: 0] cast MsgVote for 1 [logterm: 1, index: 12] at term 2
+> 2 handling Ready
+  Ready MustSync=true:
+  HardState Term:2 Vote:1 Commit:11 Lead:0 LeadEpoch:0
+  Messages:
+  2->1 MsgVoteResp Term:2 Log:0/0
+> 1 receiving messages
+  2->1 MsgVoteResp Term:2 Log:0/0
+  INFO 1 received MsgVoteResp from 2 at term 2
+  INFO 1 has received 2 MsgVoteResp votes and 0 vote rejections
+  INFO 1 became leader at term 2
+> 1 handling Ready
+  Ready MustSync=true:
+  State:StateLeader
+  HardState Term:2 Vote:1 Commit:11 Lead:1 LeadEpoch:1
+  Entries:
+  2/13 EntryNormal ""
+  Messages:
+  1->2 MsgFortifyLeader Term:2 Log:0/0
+  1->2 MsgApp Term:2 Log:1/12 Commit:11 Entries:[2/13 EntryNormal ""]
+> 2 receiving messages
+  1->2 MsgFortifyLeader Term:2 Log:0/0
+  1->2 MsgApp Term:2 Log:1/12 Commit:11 Entries:[2/13 EntryNormal ""]
+> 2 handling Ready
+  Ready MustSync=true:
+  HardState Term:2 Vote:1 Commit:11 Lead:1 LeadEpoch:1
+  Messages:
+  2->1 MsgFortifyLeaderResp Term:2 Log:0/0 LeadEpoch:1
+  2->1 MsgAppResp Term:2 Log:1/12 Rejected (Hint: 11) Commit:11
+> 1 receiving messages
+  2->1 MsgFortifyLeaderResp Term:2 Log:0/0 LeadEpoch:1
+  2->1 MsgAppResp Term:2 Log:1/12 Rejected (Hint: 11) Commit:11
+> 1 handling Ready
+  Ready MustSync=false:
+  Messages:
+  1->2 MsgApp Term:2 Log:1/11 Commit:11 Entries:[
+    1/12 EntryNormal "data1"
+    2/13 EntryNormal ""
+  ]
+> 2 receiving messages
+  1->2 MsgApp Term:2 Log:1/11 Commit:11 Entries:[
+    1/12 EntryNormal "data1"
+    2/13 EntryNormal ""
+  ]
+> 2 handling Ready
+  Ready MustSync=true:
+  Entries:
+  1/12 EntryNormal "data1"
+  2/13 EntryNormal ""
+  Messages:
+  2->1 MsgAppResp Term:2 Log:0/13 Commit:11
+> 1 receiving messages
+  2->1 MsgAppResp Term:2 Log:0/13 Commit:11
+> 1 handling Ready
+  Ready MustSync=true:
+  HardState Term:2 Vote:1 Commit:13 Lead:1 LeadEpoch:1
+  CommittedEntries:
+  1/12 EntryNormal "data1"
+  2/13 EntryNormal ""
+  Messages:
+  1->2 MsgApp Term:2 Log:2/13 Commit:13
+> 2 receiving messages
+  1->2 MsgApp Term:2 Log:2/13 Commit:13
+> 2 handling Ready
+  Ready MustSync=true:
+  HardState Term:2 Vote:1 Commit:13 Lead:1 LeadEpoch:1
+  CommittedEntries:
+  1/12 EntryNormal "data1"
+  2/13 EntryNormal ""
+  Messages:
+  2->1 MsgAppResp Term:2 Log:0/13 Commit:13
+> 1 receiving messages
+  2->1 MsgAppResp Term:2 Log:0/13 Commit:13
+
 raft-state
 ----
-1: StatePreCandidate (Voter) Term:1 Lead:0 LeadEpoch:0
-2: StateFollower (Voter) Term:1 Lead:1 LeadEpoch:0
+1: StateLeader (Voter) Term:2 Lead:1 LeadEpoch:1
+2: StateFollower (Voter) Term:2 Lead:1 LeadEpoch:1


### PR DESCRIPTION
When receiving a MsgDeFortifyLeader at the same term as we are, we
should not set the lead field to the sender. Mainly for two reasons:

1) By definition, a MsgDeFortifyLeader is sent by an ex-leader until it
hears of a new committed term. If we forgot the leader at the current
term, we shouldn't remember it since we are using the fact that
lead==None to indicate that this replica has been leaderless for
some time. Read the leaderlessWatcher for more details.

2) This could lead to a situation where no replica can win an election
as it could require votes from some replicas that still know who think
they know leader is (due to MsgDefortifyLeader), and that have recently
campaigned and lost, which reset the electionElapsed to 0. Meaning that
this replica is in a heartbeat lease, and will reject MsgVotes.

Fixes: #142994

Release note: None