### PR TITLE
sql: fix maybeAdjustVirtualIndexScanForExplain in an edge case

### DIFF
--- a/pkg/sql/virtual_schema.go
+++ b/pkg/sql/virtual_schema.go
@@ -326,7 +326,10 @@ func (t virtualSchemaTable) preferIndexOverGenerator(
 func maybeAdjustVirtualIndexScanForExplain(
 	ctx context.Context, evalCtx *eval.Context, index cat.Index, params exec.ScanParams,
 ) (_ cat.Index, _ exec.ScanParams, extraAttribute string) {
-	idx := index.(*optVirtualIndex)
+	idx, ok := index.(*optVirtualIndex)
+	if !ok {
+		return idx, params, extraAttribute
+	}
 	if idx.idx != nil && idx.idx.GetID() != 1 && params.IndexConstraint != nil {
 		// If we picked the virtual index, check that we can actually use it.
 		spans := params.IndexConstraint.Spans


### PR DESCRIPTION
We just got a report where this function was called on `explain.unknownIndex` rather than `*optVirtualIndex` which led to an internal error, so this commit fixes the problem by doing the type cast safely.

I'm a bit puzzled about how this could have happened and how to come up with a reproduction though. This method is called only on virtual tables, so it means that we had a plan gist for a plan in which we scanned a virtual index of a virtual table such that the virtual index has been dropped since the gist was created. Perhaps it happened in the mixed version cluster where the gist was generated on the newer binary and then we attempted to decode it on the older one (although I didn't find a new virtual index that we added in 25.1). Another possibility is that the virtual table as a whole is not found on the binary where we're decoding the plan gist on, but `maybeAdjustVirtualIndexScanForExplain` is only present on 25.1+ versions, so we were decoding on the newest possible release). Thus, there is no regression test, but the fix is simple.

Fixes: #142989.

Release note: None