### PR TITLE
kvserver: actually test lock replication on merge

### DIFF
--- a/pkg/kv/kvnemesis/BUILD.bazel
+++ b/pkg/kv/kvnemesis/BUILD.bazel
@@ -30,6 +30,7 @@ go_library(
         "//pkg/kv/kvserver/concurrency/isolation",
         "//pkg/kv/kvserver/concurrency/lock",
         "//pkg/kv/kvserver/liveness",
+        "//pkg/kv/kvtestutils",
         "//pkg/roachpb",
         "//pkg/settings/cluster",
         "//pkg/sql/catalog/bootstrap",

--- a/pkg/kv/kvnemesis/env.go
+++ b/pkg/kv/kvnemesis/env.go
@@ -9,12 +9,11 @@ import (
 	"context"
 	gosql "database/sql"
 	"fmt"
-	"regexp"
 	"time"
 
 	"github.com/cockroachdb/cockroach-go/v2/crdb"
 	"github.com/cockroachdb/cockroach/pkg/config/zonepb"
-	kvpb "github.com/cockroachdb/cockroach/pkg/kv/kvpb"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvtestutils"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/errors"
@@ -46,53 +45,7 @@ func (e *Env) anyNode() *gosql.DB {
 // as a list of errors. RANGE_CONSISTENT_STATS_ESTIMATED is considered a
 // success, since stats estimates are fine (if unfortunate).
 func (e *Env) CheckConsistency(ctx context.Context, span roachpb.Span) []error {
-	rows, err := e.anyNode().QueryContext(ctx, fmt.Sprintf(`
-		SELECT range_id, start_key_pretty, status, detail
-		FROM crdb_internal.check_consistency(false, b'\x%x', b'\x%x')
-		ORDER BY range_id ASC`,
-		span.Key, span.EndKey,
-	))
-	if err != nil {
-		return []error{err}
-	}
-	defer rows.Close()
-
-	var failures []error
-	for rows.Next() {
-		var rangeID int
-		var key, status, detail string
-		if err := rows.Scan(&rangeID, &key, &status, &detail); err != nil {
-			return []error{err}
-		}
-		// NB: There's a known issue that can result in a 10-byte discrepancy in
-		// SysBytes. See:
-		// https://github.com/cockroachdb/cockroach/issues/93896
-		//
-		// This isn't critical, so we ignore such discrepancies.
-		if status == kvpb.CheckConsistencyResponse_RANGE_CONSISTENT_STATS_INCORRECT.String() {
-			m := regexp.MustCompile(`.*\ndelta \(stats-computed\): \{(.*)\}`).FindStringSubmatch(detail)
-			if len(m) > 1 {
-				delta := m[1]
-				// Strip out LastUpdateNanos and all zero-valued fields.
-				delta = regexp.MustCompile(`LastUpdateNanos:\d+`).ReplaceAllString(delta, "")
-				delta = regexp.MustCompile(`\S+:0\b`).ReplaceAllString(delta, "")
-				if regexp.MustCompile(`^\s*SysBytes:-?10\s*$`).MatchString(delta) {
-					continue
-				}
-			}
-		}
-		switch status {
-		case kvpb.CheckConsistencyResponse_RANGE_INDETERMINATE.String():
-			// Can't do anything, so let it slide.
-		case kvpb.CheckConsistencyResponse_RANGE_CONSISTENT.String():
-			// Good.
-		case kvpb.CheckConsistencyResponse_RANGE_CONSISTENT_STATS_ESTIMATED.String():
-			// Ok.
-		default:
-			failures = append(failures, errors.Errorf("range %d (%s) %s:\n%s", rangeID, key, status, detail))
-		}
-	}
-	return failures
+	return kvtestutils.CheckConsistency(ctx, e.anyNode(), span)
 }
 
 // SetClosedTimestampInterval sets the kv.closed_timestamp.target_duration

--- a/pkg/kv/kvtestutils/BUILD.bazel
+++ b/pkg/kv/kvtestutils/BUILD.bazel
@@ -2,14 +2,22 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "kvtestutils",
-    testonly = 1,
-    srcs = ["test_utils.go"],
+    # This package can become testonly when kvnemesis tests are moved
+    # into a test package.
+    # testonly = 1,
+    srcs = [
+        "consistency.go",
+        "test_utils.go",
+    ],
     importpath = "github.com/cockroachdb/cockroach/pkg/kv/kvtestutils",
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/kv/kvbase",
-        "//pkg/testutils",
+        "//pkg/kv/kvpb",
+        "//pkg/roachpb",
+        "//pkg/sql/pgwire/pgerror",
         "//pkg/util/tracing",
         "//pkg/util/tracing/tracingpb",
+        "@com_github_cockroachdb_errors//:errors",
     ],
 )

--- a/pkg/kv/kvtestutils/consistency.go
+++ b/pkg/kv/kvtestutils/consistency.go
@@ -1,0 +1,76 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+//
+
+package kvtestutils
+
+import (
+	"context"
+	gosql "database/sql"
+	"fmt"
+	"regexp"
+
+	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/errors"
+)
+
+type querier interface {
+	QueryContext(ctx context.Context, query string, args ...interface{}) (*gosql.Rows, error)
+}
+
+// CheckConsistency runs a consistency check on all ranges in the given span,
+// primarily to verify that MVCC stats are accurate. Any failures are returned
+// as a list of errors. RANGE_CONSISTENT_STATS_ESTIMATED is considered a
+// success, since stats estimates are fine (if unfortunate).
+func CheckConsistency(ctx context.Context, db querier, span roachpb.Span) []error {
+	rows, err := db.QueryContext(ctx, fmt.Sprintf(`
+		SELECT range_id, start_key_pretty, status, detail
+		FROM crdb_internal.check_consistency(false, b'\x%x', b'\x%x')
+		ORDER BY range_id ASC`,
+		span.Key, span.EndKey,
+	))
+	if err != nil {
+		return []error{err}
+	}
+	defer rows.Close()
+
+	var failures []error
+	for rows.Next() {
+		var rangeID int
+		var key, status, detail string
+		if err := rows.Scan(&rangeID, &key, &status, &detail); err != nil {
+			return []error{err}
+		}
+		// NB: There's a known issue that can result in a 10-byte discrepancy in
+		// SysBytes. See:
+		// https://github.com/cockroachdb/cockroach/issues/93896
+		//
+		// This isn't critical, so we ignore such discrepancies.
+		if status == kvpb.CheckConsistencyResponse_RANGE_CONSISTENT_STATS_INCORRECT.String() {
+			m := regexp.MustCompile(`.*\ndelta \(stats-computed\): \{(.*)\}`).FindStringSubmatch(detail)
+			if len(m) > 1 {
+				delta := m[1]
+				// Strip out LastUpdateNanos and all zero-valued fields.
+				delta = regexp.MustCompile(`LastUpdateNanos:\d+`).ReplaceAllString(delta, "")
+				delta = regexp.MustCompile(`\S+:0\b`).ReplaceAllString(delta, "")
+				if regexp.MustCompile(`^\s*SysBytes:-?10\s*$`).MatchString(delta) {
+					continue
+				}
+			}
+		}
+		switch status {
+		case kvpb.CheckConsistencyResponse_RANGE_INDETERMINATE.String():
+			// Can't do anything, so let it slide.
+		case kvpb.CheckConsistencyResponse_RANGE_CONSISTENT.String():
+			// Good.
+		case kvpb.CheckConsistencyResponse_RANGE_CONSISTENT_STATS_ESTIMATED.String():
+			// Ok.
+		default:
+			failures = append(failures, errors.Errorf("range %d (%s) %s:\n%s", rangeID, key, status, detail))
+		}
+	}
+	return failures
+}


### PR DESCRIPTION
We modified this test during review and I made a mistake that meant that it always passed because they key being locked wasn't actually in the range being merged.

Here, I fixed that and along they way also make sure that we run the consistency checker on the range after merging.

Epic: none
Release note: None