### PR TITLE
upgrades: skip creating defaultdb/postgres dbs during PCR reader tenant startup

### DIFF
--- a/pkg/upgrade/upgrades/permanent_maybe_setup_pcr_reader.go
+++ b/pkg/upgrade/upgrades/permanent_maybe_setup_pcr_reader.go
@@ -23,7 +23,7 @@ func maybeSetupPCRStandbyReader(
 	if d.TenantInfoAccessor == nil {
 		return nil
 	}
-	id, ts, err := d.TenantInfoAccessor.ReadFromTenantInfo(ctx)
+	id, ts, err := readerTenantInfo(ctx, d)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Informs #142960
Informs: #141592

Release note: none