### PR TITLE
sqlstats: set session meta fields directly on sqlstats.RecordedTxnStats

### DIFF
--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -4356,8 +4356,9 @@ func (ex *connExecutor) recordTransactionFinish(
 		// TODO(107318): add qos
 		// TODO(107318): add asoftime or ishistorical
 		// TODO(107318): add readonly
-		SessionData: ex.sessionData(),
-		TxnErr:      txnErr,
+		TxnErr:         txnErr,
+		Application:    ex.applicationName.Load().(string),
+		UserNormalized: ex.sessionData().User().Normalized(),
 	}
 
 	if ex.server.cfg.TestingKnobs.OnRecordTxnFinish != nil {

--- a/pkg/sql/exec_log.go
+++ b/pkg/sql/exec_log.go
@@ -471,8 +471,8 @@ func (p *planner) logTransaction(
 
 	*sampledTxn = eventpb.SampledTransaction{
 		SkippedTransactions:      int64(skippedTransactions),
-		User:                     txnStats.SessionData.SessionUser().Normalized(),
-		ApplicationName:          txnStats.SessionData.ApplicationName,
+		User:                     txnStats.UserNormalized,
+		ApplicationName:          txnStats.Application,
 		TxnCounter:               uint32(txnCounter),
 		SessionID:                txnStats.SessionID.String(),
 		TransactionID:            txnStats.TransactionID.String(),

--- a/pkg/sql/instrumentation_test.go
+++ b/pkg/sql/instrumentation_test.go
@@ -215,7 +215,7 @@ func TestSampledStatsCollectionOnNewFingerprint(t *testing.T) {
 				OnRecordTxnFinish: func(isInternal bool, _ *sessionphase.Times, stmt string, txnStats sqlstats.RecordedTxnStats) {
 					// We won't run into a race here because we'll only observe
 					// txns from a single connection.
-					if txnStats.SessionData.ApplicationName == testApp {
+					if txnStats.Application == testApp {
 						if strings.Contains(stmt, `SET application_name`) {
 							return
 						}

--- a/pkg/sql/sqlstats/BUILD.bazel
+++ b/pkg/sql/sqlstats/BUILD.bazel
@@ -20,7 +20,6 @@ go_library(
         "//pkg/sql/clusterunique",
         "//pkg/sql/execstats",
         "//pkg/sql/sem/tree",
-        "//pkg/sql/sessiondata",
         "//pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil",
         "//pkg/util/log",
         "//pkg/util/metric",

--- a/pkg/sql/sqlstats/insights/util.go
+++ b/pkg/sql/sqlstats/insights/util.go
@@ -36,12 +36,6 @@ func MakeTxnInsight(value sqlstats.RecordedTxnStats) *Transaction {
 		status = Transaction_Completed
 	}
 
-	var user, appName string
-	if value.SessionData != nil {
-		user = value.SessionData.User().Normalized()
-		appName = value.SessionData.ApplicationName
-	}
-
 	insight := &Transaction{
 		ID:              value.TransactionID,
 		FingerprintID:   value.FingerprintID,
@@ -50,8 +44,8 @@ func MakeTxnInsight(value sqlstats.RecordedTxnStats) *Transaction {
 		Contention:      &value.ExecStats.ContentionTime,
 		StartTime:       value.StartTime,
 		EndTime:         value.EndTime,
-		User:            user,
-		ApplicationName: appName,
+		User:            value.UserNormalized,
+		ApplicationName: value.Application,
 		RowsRead:        value.RowsRead,
 		RowsWritten:     value.RowsWritten,
 		RetryCount:      value.RetryCount,

--- a/pkg/sql/sqlstats/sslocal/BUILD.bazel
+++ b/pkg/sql/sqlstats/sslocal/BUILD.bazel
@@ -63,7 +63,6 @@ go_test(
         "//pkg/sql/sem/catconstants",
         "//pkg/sql/sem/tree",
         "//pkg/sql/sessiondata",
-        "//pkg/sql/sessiondatapb",
         "//pkg/sql/sessionphase",
         "//pkg/sql/sqlstats",
         "//pkg/sql/sqlstats/insights",

--- a/pkg/sql/sqlstats/ssprovider.go
+++ b/pkg/sql/sqlstats/ssprovider.go
@@ -17,7 +17,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/clusterunique"
 	"github.com/cockroachdb/cockroach/pkg/sql/execstats"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
-	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 )
 
@@ -119,8 +118,10 @@ type RecordedTxnStats struct {
 	RowsWritten             int64
 	BytesRead               int64
 	Priority                roachpb.UserPriority
-	SessionData             *sessiondata.SessionData
 	TxnErr                  error
+	Application             string
+	// Normalized user name.
+	UserNormalized string
 }
 
 // SSDrainer is the interface for draining or resetting sql stats.


### PR DESCRIPTION
This commit replaces the SessionData pointer field on sqlstas.RecordedTxnStats with direct Application and UserNormalized fields for simpler access to session metadata.

Epic: none
Release note: None