### PR TITLE
builtins: add jsonb_path_exists

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -1267,6 +1267,19 @@ available replica will error.</p>
 <table>
 <thead><tr><th>Function &rarr; Returns</th><th>Description</th><th>Volatility</th></tr></thead>
 <tbody>
+<tr><td><a name="jsonb_path_exists"></a><code>jsonb_path_exists(target: jsonb, path: jsonpath) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Checks whether the JSON path returns any item for the specified JSON value.</p>
+</span></td><td>Immutable</td></tr>
+<tr><td><a name="jsonb_path_exists"></a><code>jsonb_path_exists(target: jsonb, path: jsonpath, vars: jsonb) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Checks whether the JSON path returns any item for the specified JSON value.
+The vars argument must be a JSON object, and its fields provide named
+values to be substituted into the jsonpath expression.</p>
+</span></td><td>Immutable</td></tr>
+<tr><td><a name="jsonb_path_exists"></a><code>jsonb_path_exists(target: jsonb, path: jsonpath, vars: jsonb, silent: <a href="bool.html">bool</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Checks whether the JSON path returns any item for the specified JSON value.
+The vars argument must be a JSON object, and its fields provide named
+values to be substituted into the jsonpath expression. If the silent
+argument is true, the function suppresses the following errors:
+missing object field or array element, unexpected JSON item type,
+datetime and numeric errors.</p>
+</span></td><td>Immutable</td></tr>
 <tr><td><a name="jsonb_path_query"></a><code>jsonb_path_query(target: jsonb, path: jsonpath) &rarr; jsonb</code></td><td><span class="funcdesc"><p>Returns all JSON items returned by the JSON path for the specified JSON value.</p>
 </span></td><td>Immutable</td></tr>
 <tr><td><a name="jsonb_path_query"></a><code>jsonb_path_query(target: jsonb, path: jsonpath, vars: jsonb) &rarr; jsonb</code></td><td><span class="funcdesc"><p>Returns all JSON items returned by the JSON path for the specified JSON value.

--- a/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
@@ -1156,6 +1156,20 @@ func TestTenantLogic_json_index(
 	runLogicTest(t, "json_index")
 }
 
+func TestTenantLogic_jsonb_path_exists(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "jsonb_path_exists")
+}
+
+func TestTenantLogic_jsonb_path_query(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "jsonb_path_query")
+}
+
 func TestTenantLogic_jsonpath(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/local-read-committed/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/local-read-committed/generated_test.go
@@ -1161,6 +1161,20 @@ func TestReadCommittedLogic_json_index(
 	runLogicTest(t, "json_index")
 }
 
+func TestReadCommittedLogic_jsonb_path_exists(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "jsonb_path_exists")
+}
+
+func TestReadCommittedLogic_jsonb_path_query(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "jsonb_path_query")
+}
+
 func TestReadCommittedLogic_jsonpath(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/local-repeatable-read/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/local-repeatable-read/generated_test.go
@@ -1154,6 +1154,20 @@ func TestRepeatableReadLogic_json_index(
 	runLogicTest(t, "json_index")
 }
 
+func TestRepeatableReadLogic_jsonb_path_exists(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "jsonb_path_exists")
+}
+
+func TestRepeatableReadLogic_jsonb_path_query(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "jsonb_path_query")
+}
+
 func TestRepeatableReadLogic_jsonpath(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/testdata/logic_test/jsonb_path_exists
+++ b/pkg/sql/logictest/testdata/logic_test/jsonb_path_exists
@@ -1,0 +1,39 @@
+# LogicTest: !local-mixed-24.3 !local-mixed-25.1
+
+query B
+SELECT jsonb_path_exists('{}', '$');
+----
+true
+
+query B
+SELECT jsonb_path_exists('{}', '$.a');
+----
+false
+
+statement error pgcode 2203A JSON object does not contain key "a"
+SELECT jsonb_path_exists('{}', 'strict $.a');
+
+query B
+SELECT jsonb_path_exists('{"a": "b"}', '$.a');
+----
+true
+
+query B
+SELECT jsonb_path_exists('{"A": "b"}', '$.a');
+----
+false
+
+query B
+SELECT jsonb_path_exists('[{"a": 1}]', 'false');
+----
+true
+
+query B
+SELECT jsonb_path_exists('[{"a": 1}, {"a": 2}, 3]', 'lax $[*].a', '{}', false);
+----
+true
+
+query B
+SELECT jsonb_path_exists('[{"a": 1}, {"a": 2}, 3]', 'lax $[*].a', '{}', true);
+----
+true

--- a/pkg/sql/logictest/testdata/logic_test/jsonb_path_query
+++ b/pkg/sql/logictest/testdata/logic_test/jsonb_path_query
@@ -1,4 +1,4 @@
-# LogicTest: local
+# LogicTest: !local-mixed-24.3 !local-mixed-25.1
 
 query T
 SELECT jsonb_path_query('{}', '$')

--- a/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
@@ -1123,6 +1123,20 @@ func TestLogic_json_index(
 	runLogicTest(t, "json_index")
 }
 
+func TestLogic_jsonb_path_exists(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "jsonb_path_exists")
+}
+
+func TestLogic_jsonb_path_query(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "jsonb_path_query")
+}
+
 func TestLogic_jsonpath(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
@@ -1123,6 +1123,20 @@ func TestLogic_json_index(
 	runLogicTest(t, "json_index")
 }
 
+func TestLogic_jsonb_path_exists(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "jsonb_path_exists")
+}
+
+func TestLogic_jsonb_path_query(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "jsonb_path_query")
+}
+
 func TestLogic_jsonpath(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist/generated_test.go
@@ -1130,6 +1130,20 @@ func TestLogic_json_index(
 	runLogicTest(t, "json_index")
 }
 
+func TestLogic_jsonb_path_exists(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "jsonb_path_exists")
+}
+
+func TestLogic_jsonb_path_query(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "jsonb_path_query")
+}
+
 func TestLogic_jsonpath(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-legacy-schema-changer/generated_test.go
+++ b/pkg/sql/logictest/tests/local-legacy-schema-changer/generated_test.go
@@ -1102,6 +1102,20 @@ func TestLogic_json_index(
 	runLogicTest(t, "json_index")
 }
 
+func TestLogic_jsonb_path_exists(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "jsonb_path_exists")
+}
+
+func TestLogic_jsonb_path_query(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "jsonb_path_query")
+}
+
 func TestLogic_jsonpath(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/local-vec-off/generated_test.go
@@ -1137,6 +1137,20 @@ func TestLogic_json_index(
 	runLogicTest(t, "json_index")
 }
 
+func TestLogic_jsonb_path_exists(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "jsonb_path_exists")
+}
+
+func TestLogic_jsonb_path_query(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "jsonb_path_query")
+}
+
 func TestLogic_jsonpath(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local/generated_test.go
+++ b/pkg/sql/logictest/tests/local/generated_test.go
@@ -1256,6 +1256,13 @@ func TestLogic_json_index(
 	runLogicTest(t, "json_index")
 }
 
+func TestLogic_jsonb_path_exists(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "jsonb_path_exists")
+}
+
 func TestLogic_jsonb_path_query(
 	t *testing.T,
 ) {

--- a/pkg/sql/sem/builtins/fixed_oids.go
+++ b/pkg/sql/sem/builtins/fixed_oids.go
@@ -2649,6 +2649,9 @@ var builtinOidsArray = []string{
 	2686: `jsonb_path_query(target: jsonb, path: jsonpath, vars: jsonb) -> jsonb`,
 	2687: `jsonb_path_query(target: jsonb, path: jsonpath, vars: jsonb, silent: bool) -> jsonb`,
 	2688: `crdb_internal.backup_compaction(backup_stmt: string, start_time: decimal, end_time: decimal) -> int`,
+	2689: `jsonb_path_exists(target: jsonb, path: jsonpath) -> bool`,
+	2690: `jsonb_path_exists(target: jsonb, path: jsonpath, vars: jsonb) -> bool`,
+	2691: `jsonb_path_exists(target: jsonb, path: jsonpath, vars: jsonb, silent: bool) -> bool`,
 }
 
 var builtinOidsBySignature map[string]oid.Oid

--- a/pkg/util/jsonpath/eval/eval.go
+++ b/pkg/util/jsonpath/eval/eval.go
@@ -55,6 +55,16 @@ func JsonpathQuery(
 	return res, nil
 }
 
+func JsonpathExists(
+	target tree.DJSON, path tree.DJsonpath, vars tree.DJSON, silent tree.DBool,
+) (tree.DBool, error) {
+	j, err := JsonpathQuery(target, path, vars, silent)
+	if err != nil {
+		return false, err
+	}
+	return len(j) > 0, nil
+}
+
 func (ctx *jsonpathCtx) eval(
 	jsonPath jsonpath.Path, jsonValue json.JSON, unwrap bool,
 ) ([]json.JSON, error) {


### PR DESCRIPTION
This commit adds the `jsonb_path_exists` function, which wraps `jsonb_path_query` and returns a boolean - whether the query returned any items or not.

Epic: None
Release note (sql change): Add the `jsonb_path_exists` function, which takes in a JSON object and Jsonpath query, and returns whether the query returned any items.