### PR TITLE
sql: enforce SELECT policies for UPDATE/DELETE

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/row_level_security
+++ b/pkg/sql/logictest/testdata/logic_test/row_level_security
@@ -2054,6 +2054,295 @@ DROP TABLE multip;
 statement ok
 DROP USER multi_user;
 
-subtest multiple_insert_policies
+# This is another test for multiple policies. But the focus here is how multiple
+# policies are applied when they apply for other commands. For example, having
+# a policy that applies to SELECT and a policy that applies to DELETE.
+subtest multi_policies_multi_cmd
+
+statement ok
+create table r1 (c1 int);
+
+statement ok
+alter table r1 enable row level security;
+
+statement ok
+insert into r1 values (0),(1),(2),(3),(4),(5),(22);
+
+statement ok
+create policy sel1 on r1 for select using (c1 % 2 = 0);
+
+statement ok
+create policy upd1 on r1 for update using (c1 between 0 and 20);
+
+statement ok
+create user r1_user;
+
+statement ok
+grant all on r1 to r1_user;
+
+statement ok
+set role r1_user;
+
+# UPDATE should only apply to the combination of both policies.
+statement ok
+update r1 set c1 = c1 ;
+
+query I rowsort
+update r1 set c1 = c1 returning c1;
+----
+0
+2
+4
+
+statement error pq: new row violates row-level security policy for table "r1"
+update r1 set c1 = c1 + 1;
+
+statement error pq: new row violates row-level security policy for table "r1"
+update r1 set c1 = c1 + 1 where c1 between 1 and 3;
+
+statement ok
+update r1 set c1 = c1 + 2 where c1 between 1 and 10;
+
+query I rowsort
+update r1 set c1 = c1 + 2 where c1 between 1 and 10 returning c1;
+----
+6
+8
+
+query I
+update r1 set c1 = c1 + 2 where c1 > 20 returning c1;
+----
+
+query I rowsort
+SELECT * FROM r1;
+----
+0
+6
+8
+22
+
+statement ok
+SET ROLE root;
+
+query I rowsort
+SELECT * FROM r1;
+----
+0
+1
+3
+5
+6
+8
+22
+
+statement ok
+DROP TABLE r1;
+
+# Do another test of select and update policies, but use simple expressions and
+# try out different combinations of those expressions.
+statement ok
+CREATE TABLE cnt (counter INT);
+
+statement ok
+INSERT INTO cnt VALUES (1);
+
+statement ok
+GRANT ALL ON cnt TO r1_user;
+
+statement ok
+ALTER TABLE cnt ENABLE ROW LEVEL SECURITY, FORCE ROW LEVEL SECURITY;
+
+statement ok
+ALTER TABLE cnt OWNER TO r1_user;
+
+statement ok
+SET ROLE r1_user;
+
+statement ok
+CREATE POLICY upd1 ON cnt FOR UPDATE USING (true);
+
+# Only an UPDATE policy and no SELECT policy. Nothing is updated.
+query I
+UPDATE cnt SET counter = counter + 1 RETURNING counter;
+----
+
+# Now create only a SELECT policy. Same behaviour as before.
+statement ok
+DROP POLICY upd1 ON cnt;
+
+statement ok
+CREATE POLICY sel1 ON cnt FOR SELECT USING (true);
+
+query I
+SELECT * FROM cnt;
+----
+1
+
+# Any locking modes on the query will cause the UPDATE policies to be applied,
+# which will filter out the row.
+query I
+SELECT * FROM cnt FOR UPDATE;
+----
+
+
+query I
+SELECT * FROM cnt FOR SHARE;
+----
+
+
+let $cnt_oid
+SELECT 'cnt'::REGCLASS::OID;
+
+query I
+SELECT * FROM [$cnt_oid as t];
+----
+1
+
+query I
+SELECT * FROM [$cnt_oid as t] FOR UPDATE;
+----
+
+query I
+SELECT * FROM [$cnt_oid as t] FOR SHARE;
+----
+
+# Update with a SELECT policy but no UPDATE policy. Nothing should be returned.
+query I
+UPDATE cnt SET counter = counter + 1 RETURNING counter;
+----
+
+# Now add a SELECT policy, but it still filters everything out.
+statement ok
+CREATE POLICY upd1 ON cnt FOR UPDATE USING (false);
+
+# Same as before, no update occurs because the reading of existing rows filters
+# everything out.
+query I
+UPDATE cnt SET counter = counter + 1 RETURNING counter;
+----
+
+# Now replace the UPDATE policy with one that allows everything.
+statement ok
+DROP POLICY upd1 ON cnt;
+
+statement ok
+CREATE POLICY upd1 ON cnt FOR UPDATE USING (true);
+
+query I
+UPDATE cnt SET counter = counter + 1 RETURNING counter;
+----
+2
+
+# Update the UPDATE policy so that it allows old rows but blocks all new rows.
+statement ok
+DROP POLICY upd1 ON cnt;
+
+statement ok
+CREATE POLICY upd1 ON cnt FOR UPDATE USING (true) WITH CHECK (false);
+
+# We are able to read the row but cannot write a new row as it violates the
+# update policy.
+statement error pq: new row violates row-level security policy for table "cnt"
+UPDATE cnt SET counter = counter + 1 RETURNING counter;
+
+# Verify that select policy (true) with no delete policy will not delete anything.
+query I
+delete from cnt where counter is not null returning counter;
+----
+
+statement ok
+delete from cnt;
+
+query I
+select counter from cnt;
+----
+2
+
+# Now change the select policy to be always false, and delete policy to be always true.
+statement ok
+DROP POLICY sel1 ON cnt;
+
+statement ok
+CREATE POLICY sel1 ON cnt FOR SELECT USING (false);
+
+statement ok
+CREATE POLICY del1 ON cnt FOR DELETE USING (true);
+
+query I
+delete from cnt where counter > 0 returning counter;
+----
+
+statement ok
+delete from cnt;
+
+statement ok
+ALTER TABLE cnt NO FORCE ROW LEVEL SECURITY;
+
+query I
+SELECT counter FROM cnt;
+----
+2
+
+# Drop the select policy entirely. It should be no different than a deny-all select policy.
+statement ok
+DROP POLICY sel1 ON cnt;
+
+statement ok
+ALTER TABLE cnt FORCE ROW LEVEL SECURITY;
+
+query I
+delete from cnt where counter > 0 returning counter;
+----
+
+statement ok
+delete from cnt;
+
+statement ok
+ALTER TABLE cnt NO FORCE ROW LEVEL SECURITY;
+
+query I
+SELECT counter FROM cnt;
+----
+2
+
+statement ok
+ALTER TABLE cnt FORCE ROW LEVEL SECURITY;
+
+# Now change the select policy to always return true, and delete policy to always return false.
+statement ok
+DROP POLICY del1 ON cnt;
+
+statement ok
+CREATE POLICY sel1 ON cnt FOR SELECT USING (true);
+
+statement ok
+CREATE POLICY del1 ON cnt FOR DELETE USING (false);
+
+query I
+DELETE FROM cnt WHERE counter > 0 RETURNING counter;
+----
+
+statement ok
+DELETE FROM cnt;
+
+statement ok
+ALTER TABLE cnt NO FORCE ROW LEVEL SECURITY;
+
+query I
+SELECT counter FROM cnt;
+----
+2
+
+statement ok
+ALTER TABLE cnt NO FORCE ROW LEVEL SECURITY;
+
+statement ok
+SET ROLE root
+
+statement ok
+DROP TABLE cnt;
+
+statement ok
+DROP USER r1_user;
 
 subtest end

--- a/pkg/sql/opt/exec/explain/testdata/row_level_security
+++ b/pkg/sql/opt/exec/explain/testdata/row_level_security
@@ -181,6 +181,10 @@ exec-ddl
 ALTER TABLE writer ENABLE ROW LEVEL SECURITY;
 ----
 
+exec-ddl
+CREATE POLICY p_select ON writer FOR SELECT USING (true);
+----
+
 plan
 INSERT INTO writer VALUES (0, 'zero')
 ----
@@ -244,7 +248,7 @@ UPDATE writer SET key = key * 10;
 │ table: writer
 │ set: key
 │ auto commit
-│ policies: row-level security enabled, no policies applied.
+│ policies: p_select
 │
 └── • render
     │
@@ -266,7 +270,7 @@ UPDATE writer SET key = key * 11;
 │ table: writer
 │ set: key
 │ auto commit
-│ policies: p_update1, p_update2
+│ policies: p_select, p_update1, p_update2
 │
 └── • render
     │
@@ -274,7 +278,7 @@ UPDATE writer SET key = key * 11;
           table: writer@writer_pkey
           spans: 1+ spans
           locking strength: for update
-          policies: p_update1
+          policies: p_select, p_update1
 
 plan
 UPDATE writer SET key = key * 15 WHERE value = 'some-val' or value = 'other-val';
@@ -283,7 +287,7 @@ UPDATE writer SET key = key * 15 WHERE value = 'some-val' or value = 'other-val'
 │ table: writer
 │ set: key
 │ auto commit
-│ policies: p_update1, p_update2
+│ policies: p_select, p_update1, p_update2
 │
 └── • render
     │
@@ -293,7 +297,7 @@ UPDATE writer SET key = key * 15 WHERE value = 'some-val' or value = 'other-val'
         └── • scan
               table: writer@writer_pkey
               spans: 1+ spans
-              policies: p_update1
+              policies: p_select, p_update1
 
 plan
 UPDATE writer SET value = 'updated' WHERE key between 1 and 100;
@@ -302,7 +306,7 @@ UPDATE writer SET value = 'updated' WHERE key between 1 and 100;
 │ table: writer
 │ set: value
 │ auto commit
-│ policies: p_update1, p_update2
+│ policies: p_select, p_update1, p_update2
 │
 └── • render
     │
@@ -310,7 +314,7 @@ UPDATE writer SET value = 'updated' WHERE key between 1 and 100;
           table: writer@writer_pkey
           spans: 1+ spans
           locking strength: for update
-          policies: p_update1
+          policies: p_select, p_update1
 
 plan
 UPDATE writer SET value = value WHERE key = 5;
@@ -319,7 +323,7 @@ UPDATE writer SET value = value WHERE key = 5;
 │ table: writer
 │ set: value
 │ auto commit
-│ policies: p_update1, p_update2
+│ policies: p_select, p_update1, p_update2
 │
 └── • render
     │
@@ -327,7 +331,7 @@ UPDATE writer SET value = value WHERE key = 5;
           table: writer@writer_pkey
           spans: 1+ spans
           locking strength: for update
-          policies: p_update1
+          policies: p_select, p_update1
 
 # Show policy information for delete
 # ----------------------------------------------------------------------
@@ -353,7 +357,7 @@ DELETE FROM writer WHERE key = 1;
   from: writer
   auto commit
   spans: 1+ spans
-  policies: p_delete
+  policies: p_select, p_delete
 
 plan
 DELETE FROM writer WHERE value = 'some-val' or value = 'other-val';
@@ -368,7 +372,7 @@ DELETE FROM writer WHERE value = 'some-val' or value = 'other-val';
     └── • scan
           table: writer@writer_pkey
           spans: 1+ spans
-          policies: p_delete
+          policies: p_select, p_delete
 
 # Show that policies are exempt when the table owner queries the table, unless
 # the FORCE option is used.

--- a/pkg/sql/opt/optbuilder/testdata/row_level_security
+++ b/pkg/sql/opt/optbuilder/testdata/row_level_security
@@ -41,7 +41,7 @@ project
       └── filters
            └── false
 
-# Add a policy with a USING expression to see that a SELECT fill include that
+# Add a policy with a USING expression to see that a SELECT will include that
 # expression in its filter.
 
 exec-ddl
@@ -64,7 +64,7 @@ exec-ddl
 DROP POLICY p1 on t1;
 ----
 
-# Verify that a policy for SELECT isn't used for UPDATE.
+# Verify that having only a SELECT policy will prevent an UPDATE.
 
 exec-ddl
 CREATE POLICY p1 on t1 FOR SELECT USING (c1 % 2 = 0);
@@ -97,7 +97,7 @@ update t1
       │    └── projections
       │         └── c1:7 * 2 [as=c1_new:13]
       └── projections
-           └── false [as=rls:14]
+           └── ((c1_new:13 % 2) = 0) AND false [as=rls:14]
 
 exec-ddl
 CREATE POLICY p2 on t1 FOR UPDATE USING (c1 < 100);
@@ -124,15 +124,15 @@ update t1
       │    │    │    │    ├── columns: c1:7 c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
       │    │    │    │    └── flags: avoid-full-scan
       │    │    │    └── filters
-      │    │    │         └── c1:7 < 100
+      │    │    │         └── ((c1:7 % 2) = 0) AND (c1:7 < 100)
       │    │    └── filters
       │    │         └── c1:7 > 0
       │    └── projections
       │         └── c1:7 * 2 [as=c1_new:13]
       └── projections
-           └── c1_new:13 < 100 [as=rls:14]
+           └── ((c1_new:13 % 2) = 0) AND (c1_new:13 < 100) [as=rls:14]
 
-# Verify a DELETE won't use policies for SELECT or UPDATE.
+# Verify a DELETE won't use policies for UPDATE.
 
 build
 DELETE FROM T1 WHERE c1 BETWEEN 0 AND 20;
@@ -170,7 +170,7 @@ delete t1
       │    │    ├── columns: c1:7 c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
       │    │    └── flags: avoid-full-scan
       │    └── filters
-      │         └── (c1:7 >= 8) AND (c1:7 <= 12)
+      │         └── ((c1:7 % 2) = 0) AND ((c1:7 >= 8) AND (c1:7 <= 12))
       └── filters
            └── (c1:7 >= 0) AND (c1:7 <= 20)
 
@@ -357,11 +357,11 @@ update t1
       │    │    │    ├── columns: c1:7 c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
       │    │    │    └── flags: avoid-full-scan
       │    │    └── filters
-      │    │         └── (c2:8 = 'Hello, World') OR (c3:9 = '2024-12-24')
+      │    │         └── (true OR ((c2:8 = 'Hello, World') OR (c3:9 = '2024-12-24'))) AND ((c2:8 = 'Hello, World') OR (c3:9 = '2024-12-24'))
       │    └── projections
       │         └── 'new val' [as=c2_new:13]
       └── projections
-           └── (c2_new:13 = 'Hello, World') OR (c3:9 = '2024-12-24') [as=rls:14]
+           └── (true OR ((c2_new:13 = 'Hello, World') OR (c3:9 = '2024-12-24'))) AND ((c2_new:13 = 'Hello, World') OR (c3:9 = '2024-12-24')) [as=rls:14]
 
 # Verify insert and update code path when no policy applies to role.
 
@@ -417,7 +417,7 @@ update t1
       │    └── projections
       │         └── 'new val' [as=c2_new:13]
       └── projections
-           └── false [as=rls:14]
+           └── true AND false [as=rls:14]
 
 # Verify that an INSERT ... SELECT statement applies the RLS check constraint
 # and uses different policies for the SELECT and INSERT portions of the query.
@@ -474,6 +474,10 @@ DROP POLICY p_insert on t1;
 # the column itself is not being modified.
 
 exec-ddl
+CREATE POLICY p_select on t1 FOR SELECT USING (true);
+----
+
+exec-ddl
 CREATE POLICY p_update on t1 FOR UPDATE USING (c3 in ('2025-01-01', '2024-12-31')) WITH CHECK (c2 like '%');
 ----
 
@@ -496,11 +500,38 @@ update t1
       │    │    │    ├── columns: c1:7 c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
       │    │    │    └── flags: avoid-full-scan
       │    │    └── filters
-      │    │         └── c3:9 IN ('2025-01-01', '2024-12-31')
+      │    │         └── true AND (c3:9 IN ('2025-01-01', '2024-12-31'))
       │    └── projections
       │         └── c1:7 + 1 [as=c1_new:13]
       └── projections
-           └── c2:8 LIKE '%' [as=rls:14]
+           └── true AND (c2:8 LIKE '%') [as=rls:14]
+
+# Show that SELECT with the locking clauses causes the UPDATE policies to be applied.
+build
+SELECT c2 FROM t1 FOR SHARE
+----
+project
+ ├── columns: c2:2
+ └── select
+      ├── columns: c1:1 c2:2 c3:3!null rowid:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+      ├── scan t1
+      │    ├── columns: c1:1 c2:2 c3:3 rowid:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+      │    └── locking: for-share
+      └── filters
+           └── true AND (c3:3 IN ('2025-01-01', '2024-12-31'))
+
+build
+SELECT c3 FROM t1 FOR UPDATE
+----
+project
+ ├── columns: c3:3!null
+ └── select
+      ├── columns: c1:1 c2:2 c3:3!null rowid:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+      ├── scan t1
+      │    ├── columns: c1:1 c2:2 c3:3 rowid:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+      │    └── locking: for-update
+      └── filters
+           └── true AND (c3:3 IN ('2025-01-01', '2024-12-31'))
 
 exec-ddl
 DROP POLICY p_update on t1;
@@ -714,13 +745,13 @@ update t1_explicit_pk
       │    │    │    │    ├── columns: c1:6!null c2:7 c3:8 crdb_internal_mvcc_timestamp:9 tableoid:10
       │    │    │    │    └── flags: avoid-full-scan
       │    │    │    └── filters
-      │    │    │         └── (((((c1:6 = 1) OR (c1:6 = 2)) OR (c1:6 = 3)) OR (c1:6 = 4)) AND ((c1:6 % 2) = 0)) AND ((c1:6 % 3) = 0)
+      │    │    │         └── ((((((c1:6 = 1) OR (c1:6 = 2)) OR (c1:6 = 3)) OR (c1:6 = 4)) AND ((c1:6 % 2) = 0)) AND ((c1:6 % 3) = 0)) AND ((((((c1:6 = 1) OR (c1:6 = 2)) OR (c1:6 = 3)) OR (c1:6 = 4)) AND ((c1:6 % 2) = 0)) AND ((c1:6 % 3) = 0))
       │    │    └── filters
       │    │         └── c1:6 = 18
       │    └── projections
       │         └── now() [as=c3_new:11]
       └── projections
-           └── (((((c1:6 = 1) OR (c1:6 = 2)) OR (c1:6 = 3)) OR (c1:6 = 4)) AND ((c1:6 % 2) = 0)) AND ((c1:6 % 3) = 0) [as=rls:12]
+           └── ((((((c1:6 = 1) OR (c1:6 = 2)) OR (c1:6 = 3)) OR (c1:6 = 4)) AND ((c1:6 % 2) = 0)) AND ((c1:6 % 3) = 0)) AND ((((((c1:6 = 1) OR (c1:6 = 2)) OR (c1:6 = 3)) OR (c1:6 = 4)) AND ((c1:6 % 2) = 0)) AND ((c1:6 % 3) = 0)) [as=rls:12]
 
 # Show that the owner, who is not admin, is exempt from policies unless FORCE
 # option is set.
@@ -786,13 +817,13 @@ SELECT c1 FROM t1 where C1 between 0 and 9;
 project
  ├── columns: c1:1!null
  └── select
-      ├── columns: c1:1!null c2:2!null c3:3 rowid:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+      ├── columns: c1:1!null c2:2 c3:3 rowid:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
       ├── select
-      │    ├── columns: c1:1 c2:2!null c3:3 rowid:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+      │    ├── columns: c1:1 c2:2 c3:3 rowid:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
       │    ├── scan t1
       │    │    └── columns: c1:1 c2:2 c3:3 rowid:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
       │    └── filters
-      │         └── c2:2 != 'out of policy'
+      │         └── true OR (c2:2 != 'out of policy')
       └── filters
            └── (c1:1 >= 0) AND (c1:1 <= 9)
 


### PR DESCRIPTION
To align with postgres behavior, SELECT policies should be applied in specific cases:
- For DELETE statements, apply SELECT policies as filters.
- For UPDATE statements:
  - Apply SELECT policies as filters when selecting existing rows.
  - Apply SELECT policies as check constraints for new rows.

Additionally, when a SELECT query includes locking clauses (e.g., SELECT ... FOR UPDATE|SHARE), UPDATE policies should also be applied.

For more details on the postgres behaviour, see this: https://www.postgresql.org/docs/17/sql-createpolicy.html#SQL-CREATEPOLICY-UPDATE

Closes #136742 

Epic: CRDB-45203
Release note: none