### PR TITLE
sql/copy: validate RLS policies for COPY FROM

### DIFF
--- a/pkg/sql/copy/copy_test.go
+++ b/pkg/sql/copy/copy_test.go
@@ -218,6 +218,9 @@ func TestDataDriven(t *testing.T) {
 								err = conn.Exec(ctx, fmt.Sprintf(`SET COPY_FROM_ATOMIC_ENABLED='%s'`, atomic))
 								require.NoError(t, err)
 
+								err = conn.Exec(ctx, `SET enable_row_level_security=on`)
+								require.NoError(t, err)
+
 								datadriven.RunTest(t, path, func(t *testing.T, d *datadriven.TestData) string {
 									return doTest(t, d, conn)
 								})

--- a/pkg/sql/copy/testdata/copy_from
+++ b/pkg/sql/copy/testdata/copy_from
@@ -759,3 +759,86 @@ CPut /Table/<>/1/2/0 -> /TUPLE/2:2:Bytes/succeed
 CPut /Table/<>/1/2/1/1 -> /INT/1
 CPut /Table/<>/2/"running"/1/0 -> /BYTES/
 CPut /Table/<>/2/"running"/1/1/1 -> /TUPLE/3:3:Int/3
+
+# Ensure RLS policies are applied for COPY FROM
+exec-ddl
+CREATE TABLE rls_table (id INT NOT NULL PRIMARY KEY, val TEXT);
+----
+
+exec-ddl
+CREATE ROLE copier
+----
+
+exec-ddl
+ALTER TABLE rls_table OWNER TO copier;
+----
+
+exec-ddl
+SET ROLE copier
+----
+
+exec-ddl
+ALTER TABLE rls_table ENABLE ROW LEVEL SECURITY, FORCE ROW LEVEL SECURITY;
+----
+
+# Deny all
+copy-from-error
+COPY rls_table FROM STDIN WITH CSV
+1,"one"
+2,"two"
+----
+ERROR: new row violates row-level security policy for table "rls_table" (SQLSTATE 42501)
+
+exec-ddl
+CREATE POLICY p_ins ON rls_table FOR INSERT WITH CHECK (id > 10);
+----
+
+exec-ddl
+CREATE POLICY p_sel ON rls_table FOR SELECT USING (true);
+----
+
+# Deny some
+copy-from-error
+COPY rls_table FROM STDIN WITH CSV
+20,"twenty"
+4,"four (violates rls policy)"
+----
+ERROR: new row violates row-level security policy for table "rls_table" (SQLSTATE 42501)
+
+query
+SELECT * FROM rls_table ORDER BY id
+----
+
+# Deny none
+copy-from
+COPY rls_table FROM STDIN WITH CSV
+20,"twenty"
+24,"twenty-four"
+----
+2
+
+query
+SELECT * FROM rls_table ORDER BY id
+----
+20|twenty
+24|twenty-four
+
+# Owner with force can insert rows that would have violated policies
+exec-ddl
+ALTER TABLE rls_table NO FORCE ROW LEVEL SECURITY
+----
+
+copy-from
+COPY rls_table FROM STDIN WITH CSV
+28,"twenty-eight"
+4,"four (violates rls policy, but okay because inserted by owner and force is off)"
+----
+2
+
+query
+SELECT * FROM rls_table ORDER BY id
+----
+4|four (violates rls policy, but okay because inserted by owner and force is off)
+20|twenty
+24|twenty-four
+28|twenty-eight

--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -251,19 +251,6 @@ import (
 //    Completes a pending statement with the provided name, validating its
 //    results as expected per the given options to "statement async <name>...".
 //
-//  - copy,copy-error
-//    Runs a COPY FROM STDIN statement, because of the separate data chunk it requires
-//    special logictest support. Format is:
-//      copy
-//      COPY <table> FROM STDIN;
-//      <blankline>
-//      COPY DATA
-//      ----
-//      <NUMROWS>
-//
-//    copy-error is just like copy but an error is expected and results should be error
-//    string.
-//
 //  - query <typestring> <options> <label>
 //    Runs the query that follows and verifies the results (specified after the
 //    query and a ---- separator). Example:


### PR DESCRIPTION
COPY FROM goes through the optbuilder, applying any applicable row-level security (RLS) policies. This commit adds tests to ensure that RLS policies are correctly enforced for COPY FROM.

Additionally, a stale comment in logic.go has been removed. The COPY FROM tests originally resided in logic tests before being moved to the sql/copy package.

Closes #136807

Epic: CRDB-45203
Release note: none