### PR TITLE
release-25.1: roachtest/mixedversion: allow registering hooks during cluster startup

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -681,6 +681,11 @@ type clusterImpl struct {
 	// debugging service.
 	sideEyeClient *sideeyeclient.SideEyeClient
 
+	// preStartHooks contains registered preStartHook(s).
+	preStartHooks []install.PreStartHook
+	// preStartVirtualClusterHooks contains registered preStartVirtualClusterHook(s).
+	preStartVirtualClusterHooks []install.PreStartHook
+
 	// State that can be accessed concurrently (in particular, read from the UI
 	// HTML generator).
 	mu struct {
@@ -2168,6 +2173,7 @@ func (c *clusterImpl) StartE(
 
 	clusterSettingsOpts := c.configureClusterSettingOptions(c.clusterSettings, settings)
 
+	startOpts.RoachprodOpts.PreStartHooks = append(startOpts.RoachprodOpts.PreStartHooks, c.preStartHooks...)
 	if err := roachprod.Start(ctx, l, c.MakeNodes(opts...), startOpts.RoachprodOpts, clusterSettingsOpts...); err != nil {
 		return err
 	}
@@ -2244,6 +2250,7 @@ func (c *clusterImpl) StartServiceForVirtualClusterE(
 	if len(startOpts.SeparateProcessNodes) > 0 {
 		startOpts.RoachprodOpts.VirtualClusterLocation = c.MakeNodes(startOpts.SeparateProcessNodes)
 	}
+	startOpts.RoachprodOpts.PreStartHooks = append(startOpts.RoachprodOpts.PreStartHooks, c.preStartVirtualClusterHooks...)
 	if err := roachprod.StartServiceForVirtualCluster(
 		ctx, l, c.MakeNodes(storageCluster), startOpts.RoachprodOpts, clusterSettingsOpts...,
 	); err != nil {
@@ -3345,4 +3352,24 @@ func (c *clusterImpl) GetHostErrorVMs(ctx context.Context, l *logger.Logger) ([]
 		allHostErrorVMs = append(allHostErrorVMs, hostErrorVMS...)
 	}
 	return allHostErrorVMs, nil
+}
+
+// RegisterClusterHook registers a hook to be run at a certain point as defined
+// by option.ClusterHookType. This exposes a way for test writers to run code
+// in between certain steps normally orchestrated by the framework, e.g. running
+// some workload during cluster init that depends on knowing connection info.
+func (c *clusterImpl) RegisterClusterHook(
+	hookName string,
+	hookType option.ClusterHookType,
+	timeout time.Duration,
+	fn func(context.Context) error,
+) {
+	switch hookType {
+	case option.PreStartHook:
+		c.preStartHooks = append(c.preStartHooks, install.PreStartHook{Name: hookName, Fn: fn, Timeout: timeout})
+	case option.PreStartVirtualClusterHook:
+		c.preStartVirtualClusterHooks = append(c.preStartVirtualClusterHooks, install.PreStartHook{Name: hookName, Fn: fn, Timeout: timeout})
+	default:
+		panic(fmt.Sprintf("unknown test hook type %v", hookType))
+	}
 }

--- a/pkg/cmd/roachtest/cluster/cluster_interface.go
+++ b/pkg/cmd/roachtest/cluster/cluster_interface.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	gosql "database/sql"
 	"os"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachprod/grafana"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
@@ -210,4 +211,6 @@ type Cluster interface {
 
 	// CaptureSideEyeSnapshot triggers a side-eye snapshot if side-eye is enabled in the enviroment.
 	CaptureSideEyeSnapshot(ctx context.Context) string
+
+	RegisterClusterHook(hookName string, hookType option.ClusterHookType, timeout time.Duration, hook func(context.Context) error)
 }

--- a/pkg/cmd/roachtest/clusterstats/mock_cluster_generated_test.go
+++ b/pkg/cmd/roachtest/clusterstats/mock_cluster_generated_test.go
@@ -9,6 +9,7 @@ import (
 	sql "database/sql"
 	fs "io/fs"
 	reflect "reflect"
+	time "time"
 
 	grafana "github.com/cockroachdb/cockroach/pkg/cmd/roachprod/grafana"
 	cluster "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
@@ -724,6 +725,18 @@ func (m *MockCluster) Reformat(arg0 context.Context, arg1 *logger.Logger, arg2 o
 func (mr *MockClusterMockRecorder) Reformat(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Reformat", reflect.TypeOf((*MockCluster)(nil).Reformat), arg0, arg1, arg2, arg3)
+}
+
+// RegisterClusterHook mocks base method.
+func (m *MockCluster) RegisterClusterHook(arg0 string, arg1 option.ClusterHookType, arg2 time.Duration, arg3 func(context.Context) error) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "RegisterClusterHook", arg0, arg1, arg2, arg3)
+}
+
+// RegisterClusterHook indicates an expected call of RegisterClusterHook.
+func (mr *MockClusterMockRecorder) RegisterClusterHook(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RegisterClusterHook", reflect.TypeOf((*MockCluster)(nil).RegisterClusterHook), arg0, arg1, arg2, arg3)
 }
 
 // Run mocks base method.

--- a/pkg/cmd/roachtest/option/options.go
+++ b/pkg/cmd/roachtest/option/options.go
@@ -268,3 +268,15 @@ func Graceful(gracePeriodSeconds int) func(interface{}) {
 func WithNodes(nodes NodeListOption) install.RunOptions {
 	return install.WithNodes(nodes.InstallNodes())
 }
+
+// ClusterHookType represents when an install.PreStartHook should be run.
+type ClusterHookType int
+
+const (
+	// PreStartHook is a func run after service registration occurs in StartE but before
+	// the cluster is actually started. This can be useful if we want to run some code
+	// during CRDB startup that is dependent on knowing the service registration info.
+	PreStartHook ClusterHookType = iota
+	// PreStartVirtualClusterHook is similar to preStartHook but for virtual clusters.
+	PreStartVirtualClusterHook
+)

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/mixedversion.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/mixedversion.go
@@ -96,6 +96,7 @@ import (
 
 const (
 	logPrefix                  = "mixed-version-test"
+	beforeClusterStartLabel    = "run before cluster start hooks"
 	startupLabel               = "run startup hooks"
 	backgroundLabel            = "start background hooks"
 	mixedVersionLabel          = "run mixed-version hooks"
@@ -311,6 +312,7 @@ type (
 	// testHooks groups hooks associated with a mixed-version test in
 	// its different stages: startup, mixed-version, and after-test.
 	testHooks struct {
+		beforeClusterStart    hooks
 		startup               hooks
 		background            hooks
 		mixedVersion          hooks
@@ -694,6 +696,18 @@ func (t *Test) InMixedVersion(desc string, fn stepFunc) {
 	}
 
 	t.hooks.AddMixedVersion(versionUpgradeHook{name: desc, predicate: predicate, fn: fn})
+}
+
+// BeforeClusterStart registers a callback that is run before cluster
+// initialization. In the case of multitenant deployments, hooks
+// will be run for both the system and tenant cluster startup. If
+// only one of the two is desired, the caller can check the upgrade
+// stage.
+func (t *Test) BeforeClusterStart(desc string, fn stepFunc) {
+	// Since the callbacks here are only referenced in the setup steps
+	// of the planner, there is no need to have a predicate function
+	// gating them.
+	t.hooks.AddBeforeClusterStart(versionUpgradeHook{name: desc, fn: fn})
 }
 
 // OnStartup registers a callback that is run once the cluster is
@@ -1227,6 +1241,10 @@ func (h hooks) AsSteps(prng *rand.Rand, testContext *Context, stopChans []should
 	return steps
 }
 
+func (th *testHooks) AddBeforeClusterStart(hook versionUpgradeHook) {
+	th.beforeClusterStart = append(th.beforeClusterStart, hook)
+}
+
 func (th *testHooks) AddStartup(hook versionUpgradeHook) {
 	th.startup = append(th.startup, hook)
 }
@@ -1241,6 +1259,10 @@ func (th *testHooks) AddMixedVersion(hook versionUpgradeHook) {
 
 func (th *testHooks) AddAfterUpgradeFinalized(hook versionUpgradeHook) {
 	th.afterUpgradeFinalized = append(th.afterUpgradeFinalized, hook)
+}
+
+func (th *testHooks) BeforeClusterStartSteps(testContext *Context, rng *rand.Rand) []testStep {
+	return th.beforeClusterStart.AsSteps(rng, testContext, nil)
 }
 
 func (th *testHooks) StartupSteps(testContext *Context, rng *rand.Rand) []testStep {

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/planner.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/planner.go
@@ -557,6 +557,11 @@ func (p *testPlanner) systemSetupSteps() []testStep {
 	}
 
 	setupContext := p.nonUpgradeContext(initialVersion, SystemSetupStage)
+
+	clusterStartHooks := p.hooks.BeforeClusterStartSteps(setupContext, p.prng)
+	if len(clusterStartHooks) > 0 {
+		steps = append(steps, p.concurrently(beforeClusterStartLabel, clusterStartHooks)...)
+	}
 	return append(steps,
 		p.newSingleStepWithContext(setupContext, startStep{
 			version:            initialVersion,
@@ -579,6 +584,7 @@ func (p *testPlanner) systemSetupSteps() []testStep {
 // passed is the version in which the tenant is created.
 func (p *testPlanner) tenantSetupSteps(v *clusterupgrade.Version) []testStep {
 	setupContext := p.nonUpgradeContext(v, TenantSetupStage)
+	var steps []testStep
 	shouldGrantCapabilities := p.deploymentMode == SeparateProcessDeployment ||
 		(p.deploymentMode == SharedProcessDeployment && !v.AtLeast(TenantsAndSystemAlignedSettingsVersion))
 
@@ -598,11 +604,15 @@ func (p *testPlanner) tenantSetupSteps(v *clusterupgrade.Version) []testStep {
 		}
 	}
 
+	clusterStartHooks := p.hooks.BeforeClusterStartSteps(setupContext, p.prng)
+	if len(clusterStartHooks) > 0 {
+		steps = append(steps, p.concurrently(beforeClusterStartLabel, clusterStartHooks)...)
+	}
 	// We are creating a virtual cluster: we first create it, then wait
 	// for the cluster version to match the expected version, then set
 	// it as the default cluster, and finally give it all capabilities
 	// if necessary.
-	steps := []testStep{
+	steps = append(steps,
 		p.newSingleStepWithContext(setupContext, startStep),
 		p.newSingleStepWithContext(setupContext, waitForStableClusterVersionStep{
 			nodes:              p.currentContext.Tenant.Descriptor.Nodes,
@@ -610,7 +620,7 @@ func (p *testPlanner) tenantSetupSteps(v *clusterupgrade.Version) []testStep {
 			desiredVersion:     versionToClusterVersion(v),
 			virtualClusterName: p.tenantName(),
 		}),
-	}
+	)
 
 	// We only use the 'default tenant' cluster setting in
 	// shared-process deployments. For separate-process deployments, we

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/planner_test.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/planner_test.go
@@ -113,6 +113,8 @@ func TestTestPlanner(t *testing.T) {
 				}
 			case "mixed-version-test":
 				mvt = createDataDrivenMixedVersionTest(t, d.CmdArgs)
+			case "before-cluster-start":
+				mvt.BeforeClusterStart(d.CmdArgs[0].Vals[0], dummyHook)
 			case "on-startup":
 				mvt.OnStartup(d.CmdArgs[0].Vals[0], dummyHook)
 			case "in-mixed-version":

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/testdata/planner/concurrent_before_cluster_start
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/testdata/planner/concurrent_before_cluster_start
@@ -1,0 +1,78 @@
+# Test that BeforeClusterStart hooks run concurrently
+
+mixed-version-test deployment_mode=separate-process
+----
+ok
+
+before-cluster-start name=(init 1)
+----
+ok
+
+before-cluster-start name=(init 2)
+----
+ok
+
+before-cluster-start name=(init 3)
+----
+ok
+
+plan debug=true
+----
+Seed:               12345
+Upgrades:           v24.2.2 → <current>
+Deployment mode:    separate-process
+Plan:
+├── install fixtures for version "v24.2.2" (1) [stage=system:system-setup;tenant:system-setup]
+├── run before cluster start hooks concurrently
+│   ├── run "init 1", after 0s delay (2) [stage=system:system-setup;tenant:system-setup]
+│   ├── run "init 2", after 30s delay (3) [stage=system:system-setup;tenant:system-setup]
+│   └── run "init 3", after 3m0s delay (4) [stage=system:system-setup;tenant:system-setup]
+├── start cluster at version "v24.2.2" (5) [stage=system:system-setup;tenant:system-setup]
+├── wait for all nodes (:1-4) to acknowledge cluster version '24.2' on system tenant (6) [stage=system:system-setup;tenant:system-setup]
+├── run before cluster start hooks concurrently
+│   ├── run "init 1", after 500ms delay (7) [stage=system:tenant-setup;tenant:tenant-setup]
+│   ├── run "init 2", after 5s delay (8) [stage=system:tenant-setup;tenant:tenant-setup]
+│   └── run "init 3", after 0s delay (9) [stage=system:tenant-setup;tenant:tenant-setup]
+├── start separate process virtual cluster mixed-version-tenant-zngg5 with binary version v24.2.2 (10) [stage=system:tenant-setup;tenant:tenant-setup]
+├── wait for all nodes (:1-4) to acknowledge cluster version '24.2' on mixed-version-tenant-zngg5 tenant (11) [stage=system:tenant-setup;tenant:tenant-setup]
+├── set cluster setting "spanconfig.tenant_limit" to '50000' on mixed-version-tenant-zngg5 tenant (12) [stage=system:tenant-setup;tenant:tenant-setup]
+├── disable KV and tenant(SQL) rate limiter on mixed-version-tenant-zngg5 tenant (13) [stage=system:tenant-setup;tenant:tenant-setup]
+├── set cluster setting "server.secondary_tenants.authorization.mode" to 'allow-all' on system tenant (14) [stage=system:tenant-setup;tenant:tenant-setup]
+└── upgrade cluster from "v24.2.2" to "<current>"
+   ├── upgrade storage cluster
+   │   ├── prevent auto-upgrades on system tenant by setting `preserve_downgrade_option` (15) [stage=system:init;tenant:upgrading-system]
+   │   ├── upgrade nodes :1-4 from "v24.2.2" to "<current>"
+   │   │   ├── restart system server on node 1 with binary version <current> (16) [stage=system:temporary-upgrade;tenant:upgrading-system]
+   │   │   ├── restart system server on node 2 with binary version <current> (17) [stage=system:temporary-upgrade;tenant:upgrading-system]
+   │   │   ├── restart system server on node 4 with binary version <current> (18) [stage=system:temporary-upgrade;tenant:upgrading-system]
+   │   │   └── restart system server on node 3 with binary version <current> (19) [stage=system:temporary-upgrade;tenant:upgrading-system]
+   │   ├── downgrade nodes :1-4 from "<current>" to "v24.2.2"
+   │   │   ├── restart system server on node 2 with binary version v24.2.2 (20) [stage=system:rollback-upgrade;tenant:upgrading-system]
+   │   │   ├── restart system server on node 4 with binary version v24.2.2 (21) [stage=system:rollback-upgrade;tenant:upgrading-system]
+   │   │   ├── restart system server on node 1 with binary version v24.2.2 (22) [stage=system:rollback-upgrade;tenant:upgrading-system]
+   │   │   └── restart system server on node 3 with binary version v24.2.2 (23) [stage=system:rollback-upgrade;tenant:upgrading-system]
+   │   ├── upgrade nodes :1-4 from "v24.2.2" to "<current>"
+   │   │   ├── restart system server on node 3 with binary version <current> (24) [stage=system:last-upgrade;tenant:upgrading-system]
+   │   │   ├── restart system server on node 4 with binary version <current> (25) [stage=system:last-upgrade;tenant:upgrading-system]
+   │   │   ├── restart system server on node 2 with binary version <current> (26) [stage=system:last-upgrade;tenant:upgrading-system]
+   │   │   └── restart system server on node 1 with binary version <current> (27) [stage=system:last-upgrade;tenant:upgrading-system]
+   │   ├── allow upgrade to happen on system tenant by resetting `preserve_downgrade_option` (28) [stage=system:running-upgrade-migrations;tenant:upgrading-system,finalizing]
+   │   └── wait for all nodes (:1-4) to acknowledge cluster version <current> on system tenant (29) [stage=system:running-upgrade-migrations;tenant:upgrading-system,finalizing]
+   └── upgrade tenant
+      ├── upgrade nodes :1-4 from "v24.2.2" to "<current>"
+      │   ├── restart mixed-version-tenant-zngg5 server on node 3 with binary version <current> (30) [stage=system:upgrading-tenant;tenant:temporary-upgrade]
+      │   ├── restart mixed-version-tenant-zngg5 server on node 2 with binary version <current> (31) [stage=system:upgrading-tenant;tenant:temporary-upgrade]
+      │   ├── restart mixed-version-tenant-zngg5 server on node 1 with binary version <current> (32) [stage=system:upgrading-tenant;tenant:temporary-upgrade]
+      │   └── restart mixed-version-tenant-zngg5 server on node 4 with binary version <current> (33) [stage=system:upgrading-tenant;tenant:temporary-upgrade]
+      ├── downgrade nodes :1-4 from "<current>" to "v24.2.2"
+      │   ├── restart mixed-version-tenant-zngg5 server on node 3 with binary version v24.2.2 (34) [stage=system:upgrading-tenant;tenant:rollback-upgrade]
+      │   ├── restart mixed-version-tenant-zngg5 server on node 1 with binary version v24.2.2 (35) [stage=system:upgrading-tenant;tenant:rollback-upgrade]
+      │   ├── restart mixed-version-tenant-zngg5 server on node 2 with binary version v24.2.2 (36) [stage=system:upgrading-tenant;tenant:rollback-upgrade]
+      │   └── restart mixed-version-tenant-zngg5 server on node 4 with binary version v24.2.2 (37) [stage=system:upgrading-tenant;tenant:rollback-upgrade]
+      ├── upgrade nodes :1-4 from "v24.2.2" to "<current>"
+      │   ├── restart mixed-version-tenant-zngg5 server on node 2 with binary version <current> (38) [stage=system:upgrading-tenant;tenant:last-upgrade]
+      │   ├── restart mixed-version-tenant-zngg5 server on node 3 with binary version <current> (39) [stage=system:upgrading-tenant;tenant:last-upgrade]
+      │   ├── restart mixed-version-tenant-zngg5 server on node 4 with binary version <current> (40) [stage=system:upgrading-tenant;tenant:last-upgrade]
+      │   └── restart mixed-version-tenant-zngg5 server on node 1 with binary version <current> (41) [stage=system:upgrading-tenant;tenant:last-upgrade]
+      ├── set `version` to <current> on mixed-version-tenant-zngg5 tenant (42) [stage=system:upgrading-tenant;tenant:running-upgrade-migrations,finalizing]
+      └── wait for all nodes (:1-4) to acknowledge cluster version <current> on mixed-version-tenant-zngg5 tenant (43) [stage=system:upgrading-tenant;tenant:running-upgrade-migrations,finalizing]

--- a/pkg/cmd/roachtest/tests/versionupgrade.go
+++ b/pkg/cmd/roachtest/tests/versionupgrade.go
@@ -10,6 +10,7 @@ import (
 	gosql "database/sql"
 	"fmt"
 	"math/rand"
+	"sync"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
@@ -18,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil/clusterupgrade"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil/mixedversion"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil/task"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
@@ -26,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/ts/tspb"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/version"
+	"github.com/cockroachdb/errors"
 )
 
 type versionFeatureTest struct {
@@ -327,18 +330,19 @@ func runHTTPRestart(ctx context.Context, t test.Test, c cluster.Cluster) {
 		}},
 	}
 
-	httpCall := func(ctx context.Context, node int, l *logger.Logger, useSystemTenant bool) {
-		logEvery := roachtestutil.Every(1 * time.Second)
-		var clientOpts []func(opts *roachtestutil.RoachtestHTTPOptions)
-		var urlOpts []option.OptionFunc
-		if useSystemTenant {
-			clientOpts = append(clientOpts, roachtestutil.VirtualCluster(install.SystemInterfaceName))
-			urlOpts = append(urlOpts, option.VirtualClusterName(install.SystemInterfaceName))
-		}
-		client := roachtestutil.DefaultHTTPClient(c, l, clientOpts...)
-		adminUrls, err := c.ExternalAdminUIAddr(ctx, l, c.Node(node), urlOpts...)
+	httpCall := func(ctx context.Context, node int, l *logger.Logger, virtualClusterName string) error {
+		// We expect lots of requests to fail, e.g. during a node restart.
+		// Use a quiet logger to keep the test log output clean.
+		loggerName := fmt.Sprintf("n%d-%s-http-requests", node, virtualClusterName)
+		httpLogger, err := l.ChildLogger(loggerName, logger.QuietStdout)
 		if err != nil {
-			t.Fatal(err)
+			return err
+		}
+
+		client := roachtestutil.DefaultHTTPClient(c, httpLogger, roachtestutil.VirtualCluster(virtualClusterName))
+		adminUrls, err := c.ExternalAdminUIAddr(ctx, httpLogger, c.Node(node), option.VirtualClusterName(virtualClusterName))
+		if err != nil {
+			return err
 		}
 		url := "https://" + adminUrls[0] + "/ts/query"
 		l.Printf("Sending requests to %s", url)
@@ -350,31 +354,65 @@ func runHTTPRestart(ctx context.Context, t test.Test, c cluster.Cluster) {
 			select {
 			case <-ctx.Done():
 				if !reqSuccess {
-					t.Fatalf("n%d: No successful http requests made.", node)
+					return errors.Newf("n%d: No successful http requests made.", node)
 				}
-				return
+				return nil
 			default:
 			}
 			if err := client.PostProtobuf(ctx, url, &httpReq, &response); err != nil {
-				if logEvery.ShouldLog() {
-					l.Printf("n%d: Error posting protobuf: %s", node, err)
-				}
+				httpLogger.Printf("n%d: Error posting protobuf: %s", node, err)
 				continue
 			}
 			reqSuccess = true
 		}
 	}
 
-	for _, n := range c.CRDBNodes() {
-		mvt.BackgroundFunc("HTTP requests to system tenant", func(ctx context.Context, l *logger.Logger, rng *rand.Rand, h *mixedversion.Helper) error {
-			httpCall(ctx, n, l, true /* useSystemTenant */)
-			return nil
+	// We want to make a ton of requests to the cluster as soon as the HTTP
+	// routes are registered. However, we don't know which UI ports will be
+	// used until service registration happens. Since the roachprod framework
+	// implicitly runs service registration when a node is started, we need to
+	// use cluster hooks to know when we can start making requests. The ports
+	// shouldn't change after they are set, so waiting once is adequate.
+	var systemOnce, tenantOnce sync.Once
+	var systemRegisteredCh = make(chan struct{})
+	var tenantRegisteredCh = make(chan struct{})
+	c.RegisterClusterHook("mark system service registration as complete", option.PreStartHook, time.Minute, func(ctx context.Context) error {
+		systemOnce.Do(func() {
+			close(systemRegisteredCh)
 		})
-		mvt.BackgroundFunc("HTTP requests to secondary tenant", func(ctx context.Context, l *logger.Logger, rng *rand.Rand, h *mixedversion.Helper) error {
-			if h.DeploymentMode() == mixedversion.SystemOnlyDeployment {
+		return nil
+	})
+	c.RegisterClusterHook("mark tenant service registration as complete", option.PreStartVirtualClusterHook, time.Minute, func(ctx context.Context) error {
+		tenantOnce.Do(func() {
+			close(tenantRegisteredCh)
+		})
+		return nil
+	})
+
+	for _, n := range c.CRDBNodes() {
+		mvt.BeforeClusterStart(fmt.Sprintf("HTTP requests to n%d", n), func(ctx context.Context, l *logger.Logger, rng *rand.Rand, h *mixedversion.Helper) error {
+			if h.Context().Stage == mixedversion.SystemSetupStage {
+				h.Go(func(ctx context.Context, l *logger.Logger) error {
+					select {
+					case <-ctx.Done():
+						return ctx.Err()
+					case <-systemRegisteredCh:
+						l.Printf("System tenant service registration complete, starting HTTP requests in background")
+					}
+					return httpCall(ctx, n, l, install.SystemInterfaceName)
+				}, task.Name(fmt.Sprintf("HTTP requests to system tenant on n%d", n)))
 				return nil
 			}
-			httpCall(ctx, n, l, false /* useSystemTenant */)
+
+			h.Go(func(ctx context.Context, l *logger.Logger) error {
+				select {
+				case <-ctx.Done():
+					return ctx.Err()
+				case <-tenantRegisteredCh:
+					l.Printf("Secondary tenant service registration complete, starting HTTP requests in background")
+				}
+				return httpCall(ctx, n, l, h.Tenant.Descriptor.Name)
+			}, task.Name(fmt.Sprintf("HTTP requests to secondary tenant on n%d", n)))
 			return nil
 		})
 	}

--- a/pkg/roachprod/install/BUILD.bazel
+++ b/pkg/roachprod/install/BUILD.bazel
@@ -40,6 +40,7 @@ go_library(
         "//pkg/roachprod/vm/gce",
         "//pkg/roachprod/vm/local",
         "//pkg/testutils",
+        "//pkg/util/debugutil",
         "//pkg/util/intsets",
         "//pkg/util/log",
         "//pkg/util/retry",

--- a/pkg/roachprod/install/cockroach.go
+++ b/pkg/roachprod/install/cockroach.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachprod/ssh"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/vm/gce"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/util/debugutil"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -149,6 +150,10 @@ type StartOpts struct {
 	// EnableFluentSink determines whether to enable the fluent-servers attribute
 	// in the CockroachDB logging configuration.
 	EnableFluentSink bool
+
+	// PreStartHooks are hooks that are run after service registration has occurred,
+	// but before starting the cockroach process.
+	PreStartHooks []PreStartHook
 }
 
 func (s *StartOpts) IsVirtualCluster() bool {
@@ -412,6 +417,16 @@ func (c *SyncedCluster) Start(ctx context.Context, l *logger.Logger, startOpts S
 		}, "\n"))
 		startOpts.SQLPort = config.DefaultSQLPort
 		startOpts.AdminUIPort = config.DefaultAdminUIPort
+	}
+
+	for _, hook := range startOpts.PreStartHooks {
+		hookCtx, cancel := context.WithTimeout(ctx, hook.Timeout)
+		l.Printf("running pre-start hook: %s", hook.Name)
+		err := panicAsError(hookCtx, l, hook.Fn)
+		cancel()
+		if err != nil {
+			return err
+		}
 	}
 
 	if startOpts.IsVirtualCluster() {
@@ -1624,4 +1639,32 @@ func getEnvVars() []string {
 // this workaround and just log the constants once when the cluster is started.
 func SuppressMetamorphicConstantsEnvVar() string {
 	return config.DisableMetamorphicTestingEnvVar
+}
+
+// PreStartHook is a hook that is run locally after service registration has completed
+// but before any cockroach processes have started in the cluster.
+type PreStartHook struct {
+	Name    string
+	Fn      func(context.Context) error
+	Timeout time.Duration
+}
+
+// logPanicToErr logs the panic stack trace and returns an error with the
+// panic message.
+func panicAsError(
+	ctx context.Context, l *logger.Logger, f func(context.Context) error,
+) (retErr error) {
+	defer func() {
+		if r := recover(); r != nil {
+			retErr = logPanicToErr(l, r)
+		}
+	}()
+	return f(ctx)
+}
+
+// logPanicToErr logs the panic stack trace and returns an error with the
+// panic message.
+func logPanicToErr(l *logger.Logger, r interface{}) error {
+	l.Printf("panic stack trace:\n%s", debugutil.Stack())
+	return fmt.Errorf("panic (stack trace above): %v", r)
 }


### PR DESCRIPTION
Backport 2/2 commits from #142146.

/cc @cockroachdb/release

---

Occasionally, a roachtest will want to run some code between two steps normally orchestrated by the roachtest framework, e.g. after service registration so we know connection info but before cockroach init. This change introduces a cluster hook API which allow roachtests to run code at points normally outside of their scope of control

Additionally, mixed version tests can now register hooks that will be run concurrently with cluster startup. 

With the above two changes, the http-register-routes test has been modified so it will make http requests the first time the cluster is started. Previously, it would not be able to do so until the first upgrade, missing out on an entire upgrade worth of coverage.

Fixes: https://github.com/cockroachdb/cockroach/issues/138750

----

Release Justification: test only change
