### PR TITLE
cloud/amazon: add option to skip checksums

### DIFF
--- a/pkg/cloud/amazon/s3_storage_test.go
+++ b/pkg/cloud/amazon/s3_storage_test.go
@@ -167,6 +167,22 @@ func TestPutS3(t *testing.T) {
 				cloudtestutils.CheckExportStore(t, info)
 			})
 
+			t.Run("skip-checksums", func(t *testing.T) {
+				if locked {
+					skip.IgnoreLint(t, "object-locked buckets do not support skipping checksums")
+				}
+				skipIfNoDefaultConfig(t, ctx)
+				info := cloudtestutils.StoreInfo{
+					URI: fmt.Sprintf(
+						"s3://%s/%s-%d?%s=%s&%s=true",
+						bucket, "backup-test-skip-checksums", testID,
+						cloud.AuthParam, cloud.AuthParamImplicit, AWSSkipChecksumParam,
+					),
+					User: user,
+				}
+				cloudtestutils.CheckExportStore(t, info)
+			})
+
 			t.Run("server-side-encryption-invalid-params", func(t *testing.T) {
 				skipIfNoDefaultConfig(t, ctx)
 				// Unsupported server side encryption option.
@@ -357,6 +373,7 @@ func TestPutS3Endpoint(t *testing.T) {
 		}
 		cloudtestutils.CheckExportStore(t, info)
 	})
+
 	t.Run("use-path-style", func(t *testing.T) {
 		// EngFlow machines have no internet access, and queries even to localhost will time out.
 		// So this test is skipped above.

--- a/pkg/cloud/cloudpb/external_storage.proto
+++ b/pkg/cloud/cloudpb/external_storage.proto
@@ -63,6 +63,7 @@ message ExternalStorage {
     string temp_token = 5;
     string endpoint = 6;
     bool use_path_style=16;
+    bool skip_checksum=17;
     string region = 7;
     string auth = 8;
     string server_enc_mode  = 9;
@@ -91,7 +92,10 @@ message ExternalStorage {
     // role chain. These roles will be assumed in the order they appear in the
     // list so that the role specified in AssumeRoleProvider can be assumed.
     repeated AssumeRoleProvider delegate_role_providers = 15 [(gogoproto.nullable) = false];
+
+    // Next ID: 18;
   }
+  
   message GCS {
     string bucket = 1;
     string prefix = 2;


### PR DESCRIPTION
Our files (SSTs) often have internal checksums anyway, and we have ecplicit checksum files for those that don't that are cloud agnostic, so we do not generally need the extra checksums in s3-specific metadata. Computing them has non-zero cost as well, so users may wish to disable them. Indeed, we almost did so by default a couple years ago before realizing that they are required by the S3 API if certain other features, like object locking, are enabled. So while some users may not be able to or want to disable them, e.g. if they're using object locking, we can provide the option to do so to those who would want it. This may also be useful to users of certain s3-like storage services that have different compatibility with different checksums.

Release note: none.
Epic: none.