### PR TITLE
dev: command-line tools are sufficient

### DIFF
--- a/dev
+++ b/dev
@@ -8,7 +8,7 @@ fi
 set -euo pipefail
 
 # Bump this counter to force rebuilding `dev` on all machines.
-DEV_VERSION=109
+DEV_VERSION=110
 
 THIS_DIR=$(cd "$(dirname "$0")" && pwd)
 BINARY_DIR=$THIS_DIR/bin/dev-versions

--- a/pkg/cmd/dev/doctor.go
+++ b/pkg/cmd/dev/doctor.go
@@ -30,7 +30,7 @@ const (
 	// doctorStatusVersion is the current "version" of the status checks
 	// performed by `dev doctor``. Increasing it will force doctor to be re-run
 	// before other dev commands can be run.
-	doctorStatusVersion = 10
+	doctorStatusVersion = 11
 
 	noCacheFlag     = "no-cache"
 	interactiveFlag = "interactive"
@@ -143,17 +143,13 @@ var allDoctorChecks = []doctorCheck{
 			if runtime.GOOS != "darwin" {
 				return ""
 			}
-			stdout, err := d.exec.CommandContextSilent(ctx, "/usr/bin/xcodebuild", "-version")
+			stdout, err := d.exec.CommandContextSilent(ctx, "/usr/bin/xcode-select", "-p")
 			if err != nil {
-				log.Println("Failed to run `/usr/bin/xcodebuild -version`.")
+				log.Println("Failed to run `/usr/bin/xcode-select -p`.")
 				stdoutStr := strings.TrimSpace(string(stdout))
 				printStdoutAndErr(stdoutStr, err)
-				return `You must have a full installation of XCode to build with Bazel.
-A command-line tools instance does not suffice.
-Please perform the following steps:
-  1. Install XCode from the App Store.
-  2. Launch Xcode.app at least once to perform one-time initialization of developer tools.
-  3. Run ` + "`xcode-select -switch /Applications/Xcode.app/`."
+				return `You must have the XCode command-line tools installed (if not a full installation of XCode) to build with Bazel.
+Please run ` + "`xcode-select --install`."
 			}
 			return ""
 		},


### PR DESCRIPTION
Things have changed and the command-line tools are sufficient for building with Bazel these days. Update the `doctor` check accordingly.

Epic: CRDB-17171
Release note: None