### PR TITLE
sql: assorted generic query plan improvements

### DIFF
--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -288,6 +288,9 @@ import (
 //        place of actual results.
 //
 //    Options are comma separated strings from the following:
+//      - match(<regexp>): returned rows with string representations that do not
+//            satisfy the given regexp are excluded from the test output. This
+//            is useful for condensing the output of EXPLAIN ANALYZE queries.
 //      - nosort: sorts neither the returned or expected rows. Skips the
 //            flakiness check that forces either rowsort, valuesort,
 //            partialsort, or an ORDER BY clause to be present.
@@ -908,6 +911,9 @@ type logicQuery struct {
 	colNames bool
 	// some tests require the output to match modulo sorting.
 	sorter logicSorter
+	// match filters result rows such that only rows that have at least one
+	// column matching the regexp are included.
+	match *regexp.Regexp
 	// noSort is true if the nosort option was explicitly provided in the test.
 	noSort bool
 	// empty indicates whether the result is expected to be empty (i.e. 0 rows
@@ -2855,6 +2861,18 @@ func (t *logicTest) processSubtest(
 							continue
 						}
 
+						if strings.HasPrefix(opt, "match(") && strings.HasSuffix(opt, ")") {
+							s := opt
+							s = strings.TrimPrefix(s, "match(")
+							s = strings.TrimSuffix(s, ")")
+							var err error
+							query.match, err = regexp.Compile(s)
+							if err != nil {
+								return errors.Errorf("%s: invalid match regexp: %s", query.pos, opt)
+							}
+							continue
+						}
+
 						switch opt {
 						case "nosort":
 							query.sorter = nil
@@ -3727,6 +3745,22 @@ func (t *logicTest) finishExecQuery(query logicQuery, rows *gosql.Rows, err erro
 				if err := rows.Scan(vals...); err != nil {
 					return err
 				}
+
+				if query.match != nil {
+					// Exclude rows that don't match the regexp.
+					match := false
+					for _, v := range vals {
+						val := *v.(*interface{})
+						if val != nil && query.match.MatchString(fmt.Sprint(val)) {
+							match = true
+							break
+						}
+					}
+					if !match {
+						continue
+					}
+				}
+
 				rowCount++
 				for i, v := range vals {
 					colT := query.colTypes[i]

--- a/pkg/sql/logictest/testdata/logic_test/generic
+++ b/pkg/sql/logictest/testdata/logic_test/generic
@@ -320,6 +320,41 @@ plan type: generic, reused
 statement ok
 DEALLOCATE p
 
+statement ok
+SET plan_cache_mode = auto
+
+statement ok
+ALTER TABLE g INJECT STATISTICS '[
+  {
+    "columns": ["k"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 0,
+    "distinct_count": 0,
+    "avg_size": 1
+  }
+]';
+
+statement ok
+PREPARE p AS
+UPDATE t SET b = 0 WHERE a IN ($1, $2) AND b > $3
+
+statement ok
+EXECUTE p(1, 10, 100);
+EXECUTE p(1, 10, 100);
+EXECUTE p(1, 10, 100);
+EXECUTE p(1, 10, 100);
+EXECUTE p(1, 10, 100);
+
+# The generic query plan is not chosen because it has a full table scan on a
+# mutating table, while the custom plan does not.
+query T match((plan\stype|FULL\sSCAN))
+EXPLAIN ANALYZE EXECUTE p(1, 10, 100)
+----
+plan type: custom
+
+statement ok
+DEALLOCATE p
+
 # Regression test for #132963. Do not cache non-reusable plans.
 statement ok
 SET plan_cache_mode = auto

--- a/pkg/sql/logictest/testdata/logic_test/generic
+++ b/pkg/sql/logictest/testdata/logic_test/generic
@@ -36,108 +36,20 @@ PREPARE p AS SELECT * FROM t WHERE a = 1 AND b = 2 AND c = 3
 
 # An ideal generic plan can be built during PREPARE for queries with no
 # placeholders nor stable expressions.
-query T
+query T match(plan\stype)
 EXPLAIN ANALYZE EXECUTE p
 ----
-planning time: 10µs
-execution time: 100µs
-distribution: <hidden>
-vectorized: <hidden>
 plan type: generic, reused
-maximum memory usage: <hidden>
-network usage: <hidden>
-regions: <hidden>
-isolation level: serializable
-priority: normal
-quality of service: regular
-·
-• filter
-│ sql nodes: <hidden>
-│ regions: <hidden>
-│ actual row count: 0
-│ filter: (b = 2) AND (c = 3)
-│
-└── • index join (streamer)
-    │ sql nodes: <hidden>
-    │ regions: <hidden>
-    │ actual row count: 0
-    │ KV time: 0µs
-    │ KV contention time: 0µs
-    │ KV rows decoded: 0
-    │ KV bytes read: 0 B
-    │ KV gRPC calls: 0
-    │ estimated max memory allocated: 0 B
-    │ estimated max sql temp disk usage: 0 B
-    │ table: t@t_pkey
-    │
-    └── • scan
-          sql nodes: <hidden>
-          kv nodes: <hidden>
-          regions: <hidden>
-          actual row count: 0
-          KV time: 0µs
-          KV contention time: 0µs
-          KV rows decoded: 0
-          KV bytes read: 0 B
-          KV gRPC calls: 0
-          estimated max memory allocated: 0 B
-          missing stats
-          table: t@t_a_idx
-          spans: [/1 - /1]
 
 statement ok
 SET plan_cache_mode = force_custom_plan
 
 # The ideal generic plan is reused even when forcing a custom plan because it
 # will always be optimal.
-query T
+query T match(plan\stype)
 EXPLAIN ANALYZE EXECUTE p
 ----
-planning time: 10µs
-execution time: 100µs
-distribution: <hidden>
-vectorized: <hidden>
 plan type: generic, reused
-maximum memory usage: <hidden>
-network usage: <hidden>
-regions: <hidden>
-isolation level: serializable
-priority: normal
-quality of service: regular
-·
-• filter
-│ sql nodes: <hidden>
-│ regions: <hidden>
-│ actual row count: 0
-│ filter: (b = 2) AND (c = 3)
-│
-└── • index join (streamer)
-    │ sql nodes: <hidden>
-    │ regions: <hidden>
-    │ actual row count: 0
-    │ KV time: 0µs
-    │ KV contention time: 0µs
-    │ KV rows decoded: 0
-    │ KV bytes read: 0 B
-    │ KV gRPC calls: 0
-    │ estimated max memory allocated: 0 B
-    │ estimated max sql temp disk usage: 0 B
-    │ table: t@t_pkey
-    │
-    └── • scan
-          sql nodes: <hidden>
-          kv nodes: <hidden>
-          regions: <hidden>
-          actual row count: 0
-          KV time: 0µs
-          KV contention time: 0µs
-          KV rows decoded: 0
-          KV bytes read: 0 B
-          KV gRPC calls: 0
-          estimated max memory allocated: 0 B
-          missing stats
-          table: t@t_a_idx
-          spans: [/1 - /1]
 
 statement ok
 DEALLOCATE p
@@ -147,108 +59,20 @@ statement ok
 PREPARE p AS SELECT * FROM t WHERE a = 1 AND b = 2 AND c = 3
 
 # Execute it once with plan_cache_mode set to force_custom_plan.
-query T
+query T match(plan\stype)
 EXPLAIN ANALYZE EXECUTE p
 ----
-planning time: 10µs
-execution time: 100µs
-distribution: <hidden>
-vectorized: <hidden>
 plan type: generic, reused
-maximum memory usage: <hidden>
-network usage: <hidden>
-regions: <hidden>
-isolation level: serializable
-priority: normal
-quality of service: regular
-·
-• filter
-│ sql nodes: <hidden>
-│ regions: <hidden>
-│ actual row count: 0
-│ filter: (b = 2) AND (c = 3)
-│
-└── • index join (streamer)
-    │ sql nodes: <hidden>
-    │ regions: <hidden>
-    │ actual row count: 0
-    │ KV time: 0µs
-    │ KV contention time: 0µs
-    │ KV rows decoded: 0
-    │ KV bytes read: 0 B
-    │ KV gRPC calls: 0
-    │ estimated max memory allocated: 0 B
-    │ estimated max sql temp disk usage: 0 B
-    │ table: t@t_pkey
-    │
-    └── • scan
-          sql nodes: <hidden>
-          kv nodes: <hidden>
-          regions: <hidden>
-          actual row count: 0
-          KV time: 0µs
-          KV contention time: 0µs
-          KV rows decoded: 0
-          KV bytes read: 0 B
-          KV gRPC calls: 0
-          estimated max memory allocated: 0 B
-          missing stats
-          table: t@t_a_idx
-          spans: [/1 - /1]
 
 statement ok
 SET plan_cache_mode = force_generic_plan
 
 # The plan is an ideal generic plan (it has no placeholders), so it can be
 # reused with plan_cache_mode set to force_generic_plan.
-query T
+query T match(plan\stype)
 EXPLAIN ANALYZE EXECUTE p
 ----
-planning time: 10µs
-execution time: 100µs
-distribution: <hidden>
-vectorized: <hidden>
 plan type: generic, reused
-maximum memory usage: <hidden>
-network usage: <hidden>
-regions: <hidden>
-isolation level: serializable
-priority: normal
-quality of service: regular
-·
-• filter
-│ sql nodes: <hidden>
-│ regions: <hidden>
-│ actual row count: 0
-│ filter: (b = 2) AND (c = 3)
-│
-└── • index join (streamer)
-    │ sql nodes: <hidden>
-    │ regions: <hidden>
-    │ actual row count: 0
-    │ KV time: 0µs
-    │ KV contention time: 0µs
-    │ KV rows decoded: 0
-    │ KV bytes read: 0 B
-    │ KV gRPC calls: 0
-    │ estimated max memory allocated: 0 B
-    │ estimated max sql temp disk usage: 0 B
-    │ table: t@t_pkey
-    │
-    └── • scan
-          sql nodes: <hidden>
-          kv nodes: <hidden>
-          regions: <hidden>
-          actual row count: 0
-          KV time: 0µs
-          KV contention time: 0µs
-          KV rows decoded: 0
-          KV bytes read: 0 B
-          KV gRPC calls: 0
-          estimated max memory allocated: 0 B
-          missing stats
-          table: t@t_a_idx
-          spans: [/1 - /1]
 
 statement ok
 DEALLOCATE p
@@ -258,70 +82,20 @@ PREPARE p AS SELECT * FROM t WHERE k = $1
 
 # An ideal generic plan can be built during PREPARE when the placeholder
 # fast-path can be used.
-query T
+query T match(plan\stype)
 EXPLAIN ANALYZE EXECUTE p(33)
 ----
-planning time: 10µs
-execution time: 100µs
-distribution: <hidden>
-vectorized: <hidden>
 plan type: generic, reused
-maximum memory usage: <hidden>
-network usage: <hidden>
-regions: <hidden>
-isolation level: serializable
-priority: normal
-quality of service: regular
-·
-• scan
-  sql nodes: <hidden>
-  kv nodes: <hidden>
-  regions: <hidden>
-  actual row count: 0
-  KV time: 0µs
-  KV contention time: 0µs
-  KV rows decoded: 0
-  KV bytes read: 0 B
-  KV gRPC calls: 0
-  estimated max memory allocated: 0 B
-  missing stats
-  table: t@t_pkey
-  spans: [/33 - /33]
 
 statement ok
 SET plan_cache_mode = force_custom_plan
 
 # The ideal generic plan is reused even when forcing a custom plan because it
 # will always be optimal.
-query T
+query T match(plan\stype)
 EXPLAIN ANALYZE EXECUTE p(33)
 ----
-planning time: 10µs
-execution time: 100µs
-distribution: <hidden>
-vectorized: <hidden>
 plan type: generic, reused
-maximum memory usage: <hidden>
-network usage: <hidden>
-regions: <hidden>
-isolation level: serializable
-priority: normal
-quality of service: regular
-·
-• scan
-  sql nodes: <hidden>
-  kv nodes: <hidden>
-  regions: <hidden>
-  actual row count: 0
-  KV time: 0µs
-  KV contention time: 0µs
-  KV rows decoded: 0
-  KV bytes read: 0 B
-  KV gRPC calls: 0
-  estimated max memory allocated: 0 B
-  missing stats
-  table: t@t_pkey
-  spans: [/33 - /33]
 
 statement ok
 SET plan_cache_mode = force_generic_plan
@@ -333,159 +107,25 @@ statement ok
 PREPARE p AS SELECT * FROM t WHERE a = $1 AND c = $2
 
 # A simple generic plan can be built during EXECUTE.
-query T
+query T match(plan\stype)
 EXPLAIN ANALYZE EXECUTE p(1, 2)
 ----
-planning time: 10µs
-execution time: 100µs
-distribution: <hidden>
-vectorized: <hidden>
 plan type: generic, re-optimized
-maximum memory usage: <hidden>
-network usage: <hidden>
-regions: <hidden>
-isolation level: serializable
-priority: normal
-quality of service: regular
-·
-• lookup join
-│ sql nodes: <hidden>
-│ regions: <hidden>
-│ actual row count: 0
-│ KV time: 0µs
-│ KV contention time: 0µs
-│ KV rows decoded: 0
-│ KV bytes read: 0 B
-│ KV gRPC calls: 0
-│ estimated max memory allocated: 0 B
-│ table: t@t_pkey
-│ equality: (k) = (k)
-│ equality cols are key
-│ pred: c = "$2"
-│
-└── • lookup join
-    │ sql nodes: <hidden>
-    │ kv nodes: <hidden>
-    │ regions: <hidden>
-    │ actual row count: 0
-    │ KV time: 0µs
-    │ KV contention time: 0µs
-    │ KV rows decoded: 0
-    │ KV bytes read: 0 B
-    │ KV gRPC calls: 0
-    │ estimated max memory allocated: 0 B
-    │ table: t@t_a_idx
-    │ equality: ($1) = (a)
-    │
-    └── • values
-          sql nodes: <hidden>
-          regions: <hidden>
-          actual row count: 1
-          size: 2 columns, 1 row
 
 # The generic plan can be reused with different placeholder values.
-query T
+query T match(plan\stype)
 EXPLAIN ANALYZE EXECUTE p(11, 22)
 ----
-planning time: 10µs
-execution time: 100µs
-distribution: <hidden>
-vectorized: <hidden>
 plan type: generic, reused
-maximum memory usage: <hidden>
-network usage: <hidden>
-regions: <hidden>
-isolation level: serializable
-priority: normal
-quality of service: regular
-·
-• lookup join
-│ sql nodes: <hidden>
-│ regions: <hidden>
-│ actual row count: 0
-│ KV time: 0µs
-│ KV contention time: 0µs
-│ KV rows decoded: 0
-│ KV bytes read: 0 B
-│ KV gRPC calls: 0
-│ estimated max memory allocated: 0 B
-│ table: t@t_pkey
-│ equality: (k) = (k)
-│ equality cols are key
-│ pred: c = "$2"
-│
-└── • lookup join
-    │ sql nodes: <hidden>
-    │ kv nodes: <hidden>
-    │ regions: <hidden>
-    │ actual row count: 0
-    │ KV time: 0µs
-    │ KV contention time: 0µs
-    │ KV rows decoded: 0
-    │ KV bytes read: 0 B
-    │ KV gRPC calls: 0
-    │ estimated max memory allocated: 0 B
-    │ table: t@t_a_idx
-    │ equality: ($1) = (a)
-    │
-    └── • values
-          sql nodes: <hidden>
-          regions: <hidden>
-          actual row count: 1
-          size: 2 columns, 1 row
 
 statement ok
 SET plan_cache_mode = force_custom_plan
 
 # The generic plan is not reused when forcing a custom plan.
-query T
+query T match(plan\stype)
 EXPLAIN ANALYZE EXECUTE p(1, 2)
 ----
-planning time: 10µs
-execution time: 100µs
-distribution: <hidden>
-vectorized: <hidden>
 plan type: custom
-maximum memory usage: <hidden>
-network usage: <hidden>
-regions: <hidden>
-isolation level: serializable
-priority: normal
-quality of service: regular
-·
-• filter
-│ sql nodes: <hidden>
-│ regions: <hidden>
-│ actual row count: 0
-│ filter: c = 2
-│
-└── • index join (streamer)
-    │ sql nodes: <hidden>
-    │ regions: <hidden>
-    │ actual row count: 0
-    │ KV time: 0µs
-    │ KV contention time: 0µs
-    │ KV rows decoded: 0
-    │ KV bytes read: 0 B
-    │ KV gRPC calls: 0
-    │ estimated max memory allocated: 0 B
-    │ estimated max sql temp disk usage: 0 B
-    │ table: t@t_pkey
-    │
-    └── • scan
-          sql nodes: <hidden>
-          kv nodes: <hidden>
-          regions: <hidden>
-          actual row count: 0
-          KV time: 0µs
-          KV contention time: 0µs
-          KV rows decoded: 0
-          KV bytes read: 0 B
-          KV gRPC calls: 0
-          estimated max memory allocated: 0 B
-          missing stats
-          table: t@t_a_idx
-          spans: [/1 - /1]
 
 statement ok
 SET plan_cache_mode = force_generic_plan
@@ -497,104 +137,16 @@ statement ok
 PREPARE p AS SELECT * FROM t WHERE t = now()
 
 # A generic plan with a stable expression.
-query T
+query T match(plan\stype)
 EXPLAIN ANALYZE EXECUTE p
 ----
-planning time: 10µs
-execution time: 100µs
-distribution: <hidden>
-vectorized: <hidden>
 plan type: generic, re-optimized
-maximum memory usage: <hidden>
-network usage: <hidden>
-regions: <hidden>
-isolation level: serializable
-priority: normal
-quality of service: regular
-·
-• lookup join
-│ sql nodes: <hidden>
-│ regions: <hidden>
-│ actual row count: 0
-│ KV time: 0µs
-│ KV contention time: 0µs
-│ KV rows decoded: 0
-│ KV bytes read: 0 B
-│ KV gRPC calls: 0
-│ estimated max memory allocated: 0 B
-│ table: t@t_pkey
-│ equality: (k) = (k)
-│ equality cols are key
-│
-└── • lookup join
-    │ sql nodes: <hidden>
-    │ kv nodes: <hidden>
-    │ regions: <hidden>
-    │ actual row count: 0
-    │ KV time: 0µs
-    │ KV contention time: 0µs
-    │ KV rows decoded: 0
-    │ KV bytes read: 0 B
-    │ KV gRPC calls: 0
-    │ estimated max memory allocated: 0 B
-    │ table: t@t_t_idx
-    │ equality: (column11) = (t)
-    │
-    └── • values
-          sql nodes: <hidden>
-          regions: <hidden>
-          actual row count: 1
-          size: 1 column, 1 row
 
 # The generic plan can be reused.
-query T
+query T match(plan\stype)
 EXPLAIN ANALYZE EXECUTE p
 ----
-planning time: 10µs
-execution time: 100µs
-distribution: <hidden>
-vectorized: <hidden>
 plan type: generic, reused
-maximum memory usage: <hidden>
-network usage: <hidden>
-regions: <hidden>
-isolation level: serializable
-priority: normal
-quality of service: regular
-·
-• lookup join
-│ sql nodes: <hidden>
-│ regions: <hidden>
-│ actual row count: 0
-│ KV time: 0µs
-│ KV contention time: 0µs
-│ KV rows decoded: 0
-│ KV bytes read: 0 B
-│ KV gRPC calls: 0
-│ estimated max memory allocated: 0 B
-│ table: t@t_pkey
-│ equality: (k) = (k)
-│ equality cols are key
-│
-└── • lookup join
-    │ sql nodes: <hidden>
-    │ kv nodes: <hidden>
-    │ regions: <hidden>
-    │ actual row count: 0
-    │ KV time: 0µs
-    │ KV contention time: 0µs
-    │ KV rows decoded: 0
-    │ KV bytes read: 0 B
-    │ KV gRPC calls: 0
-    │ estimated max memory allocated: 0 B
-    │ table: t@t_t_idx
-    │ equality: (column11) = (t)
-    │
-    └── • values
-          sql nodes: <hidden>
-          regions: <hidden>
-          actual row count: 1
-          size: 1 column, 1 row
 
 statement ok
 DEALLOCATE p
@@ -603,41 +155,10 @@ statement ok
 PREPARE p AS SELECT k FROM t WHERE s LIKE $1
 
 # A suboptimal generic query plan is chosen if it is forced.
-query T
+query T match(plan\stype)
 EXPLAIN ANALYZE EXECUTE p('foo%')
 ----
-planning time: 10µs
-execution time: 100µs
-distribution: <hidden>
-vectorized: <hidden>
 plan type: generic, re-optimized
-maximum memory usage: <hidden>
-network usage: <hidden>
-regions: <hidden>
-isolation level: serializable
-priority: normal
-quality of service: regular
-·
-• filter
-│ sql nodes: <hidden>
-│ regions: <hidden>
-│ actual row count: 0
-│ filter: s LIKE 'foo%'
-│
-└── • scan
-      sql nodes: <hidden>
-      kv nodes: <hidden>
-      regions: <hidden>
-      actual row count: 0
-      KV time: 0µs
-      KV contention time: 0µs
-      KV rows decoded: 0
-      KV bytes read: 0 B
-      KV gRPC calls: 0
-      estimated max memory allocated: 0 B
-      missing stats
-      table: t@t_s_idx
-      spans: (/NULL - ]
 
 statement ok
 DEALLOCATE p
@@ -646,81 +167,19 @@ statement ok
 PREPARE p AS SELECT k FROM t WHERE c = $1
 
 # A simple generic plan.
-query T
+query T match(plan\stype)
 EXPLAIN ANALYZE EXECUTE p(1)
 ----
-planning time: 10µs
-execution time: 100µs
-distribution: <hidden>
-vectorized: <hidden>
 plan type: generic, re-optimized
-maximum memory usage: <hidden>
-network usage: <hidden>
-regions: <hidden>
-isolation level: serializable
-priority: normal
-quality of service: regular
-·
-• filter
-│ sql nodes: <hidden>
-│ regions: <hidden>
-│ actual row count: 0
-│ filter: c = 1
-│
-└── • scan
-      sql nodes: <hidden>
-      kv nodes: <hidden>
-      regions: <hidden>
-      actual row count: 0
-      KV time: 0µs
-      KV contention time: 0µs
-      KV rows decoded: 0
-      KV bytes read: 0 B
-      KV gRPC calls: 0
-      estimated max memory allocated: 0 B
-      missing stats
-      table: t@t_pkey
-      spans: FULL SCAN
 
 statement ok
 ALTER TABLE t ADD COLUMN z INT
 
 # A schema change invalidates the generic plan, and it must be re-optimized.
-query T
+query T match(plan\stype)
 EXPLAIN ANALYZE EXECUTE p(1)
 ----
-planning time: 10µs
-execution time: 100µs
-distribution: <hidden>
-vectorized: <hidden>
 plan type: generic, re-optimized
-maximum memory usage: <hidden>
-network usage: <hidden>
-regions: <hidden>
-isolation level: serializable
-priority: normal
-quality of service: regular
-·
-• filter
-│ sql nodes: <hidden>
-│ regions: <hidden>
-│ actual row count: 0
-│ filter: c = 1
-│
-└── • scan
-      sql nodes: <hidden>
-      kv nodes: <hidden>
-      regions: <hidden>
-      actual row count: 0
-      KV time: 0µs
-      KV contention time: 0µs
-      KV rows decoded: 0
-      KV bytes read: 0 B
-      KV gRPC calls: 0
-      estimated max memory allocated: 0 B
-      missing stats
-      table: t@t_pkey
-      spans: FULL SCAN
 
 statement ok
 DEALLOCATE p
@@ -735,54 +194,10 @@ statement ok
 PREPARE p AS SELECT * FROM t WHERE a = 1 AND b = 2 AND c = 3
 
 # An ideal generic plan is used immediately with plan_cache_mode=auto.
-query T
+query T match(plan\stype)
 EXPLAIN ANALYZE EXECUTE p
 ----
-planning time: 10µs
-execution time: 100µs
-distribution: <hidden>
-vectorized: <hidden>
 plan type: generic, reused
-maximum memory usage: <hidden>
-network usage: <hidden>
-regions: <hidden>
-isolation level: serializable
-priority: normal
-quality of service: regular
-·
-• filter
-│ sql nodes: <hidden>
-│ regions: <hidden>
-│ actual row count: 0
-│ filter: (b = 2) AND (c = 3)
-│
-└── • index join (streamer)
-    │ sql nodes: <hidden>
-    │ regions: <hidden>
-    │ actual row count: 0
-    │ KV time: 0µs
-    │ KV contention time: 0µs
-    │ KV rows decoded: 0
-    │ KV bytes read: 0 B
-    │ KV gRPC calls: 0
-    │ estimated max memory allocated: 0 B
-    │ estimated max sql temp disk usage: 0 B
-    │ table: t@t_pkey
-    │
-    └── • scan
-          sql nodes: <hidden>
-          kv nodes: <hidden>
-          regions: <hidden>
-          actual row count: 0
-          KV time: 0µs
-          KV contention time: 0µs
-          KV rows decoded: 0
-          KV bytes read: 0 B
-          KV gRPC calls: 0
-          estimated max memory allocated: 0 B
-          missing stats
-          table: t@t_a_idx
-          spans: [/1 - /1]
 
 statement ok
 DEALLOCATE p
@@ -800,54 +215,10 @@ EXECUTE p(10000, 20000);
 # On the sixth execution a generic query plan will be generated. The cost of the
 # generic plan is more than the average cost of the five custom plans (plus some
 # overhead cost of optimization), so the custom plan is chosen.
-query T
+query T match(plan\stype)
 EXPLAIN ANALYZE EXECUTE p(10000, 20000)
 ----
-planning time: 10µs
-execution time: 100µs
-distribution: <hidden>
-vectorized: <hidden>
 plan type: custom
-maximum memory usage: <hidden>
-network usage: <hidden>
-regions: <hidden>
-isolation level: serializable
-priority: normal
-quality of service: regular
-·
-• filter
-│ sql nodes: <hidden>
-│ regions: <hidden>
-│ actual row count: 0
-│ filter: c = 20000
-│
-└── • index join (streamer)
-    │ sql nodes: <hidden>
-    │ regions: <hidden>
-    │ actual row count: 0
-    │ KV time: 0µs
-    │ KV contention time: 0µs
-    │ KV rows decoded: 0
-    │ KV bytes read: 0 B
-    │ KV gRPC calls: 0
-    │ estimated max memory allocated: 0 B
-    │ estimated max sql temp disk usage: 0 B
-    │ table: t@t_pkey
-    │
-    └── • scan
-          sql nodes: <hidden>
-          kv nodes: <hidden>
-          regions: <hidden>
-          actual row count: 0
-          KV time: 0µs
-          KV contention time: 0µs
-          KV rows decoded: 0
-          KV bytes read: 0 B
-          KV gRPC calls: 0
-          estimated max memory allocated: 0 B
-          missing stats
-          table: t@t_a_idx
-          spans: [/10000 - /10000]
 
 statement ok
 DEALLOCATE p
@@ -867,236 +238,24 @@ EXECUTE p(100, 200);
 EXECUTE p(1000, 2000);
 
 # The first five executions will use a custom plan. This is the fifth.
-query T
+query T match(plan\stype)
 EXPLAIN ANALYZE EXECUTE p(10000, 20000)
 ----
-planning time: 10µs
-execution time: 100µs
-distribution: <hidden>
-vectorized: <hidden>
 plan type: custom
-maximum memory usage: <hidden>
-network usage: <hidden>
-regions: <hidden>
-isolation level: serializable
-priority: normal
-quality of service: regular
-·
-• lookup join (streamer)
-│ sql nodes: <hidden>
-│ regions: <hidden>
-│ actual row count: 0
-│ KV time: 0µs
-│ KV contention time: 0µs
-│ KV rows decoded: 0
-│ KV bytes read: 0 B
-│ KV gRPC calls: 0
-│ estimated max memory allocated: 0 B
-│ table: g@g_a_b_idx
-│ equality: (k) = (a)
-│
-└── • lookup join (streamer)
-    │ sql nodes: <hidden>
-    │ regions: <hidden>
-    │ actual row count: 0
-    │ KV time: 0µs
-    │ KV contention time: 0µs
-    │ KV rows decoded: 0
-    │ KV bytes read: 0 B
-    │ KV gRPC calls: 0
-    │ estimated max memory allocated: 0 B
-    │ table: c@c_a_idx
-    │ equality: (k) = (a)
-    │
-    └── • filter
-        │ sql nodes: <hidden>
-        │ regions: <hidden>
-        │ actual row count: 0
-        │ filter: c = 20000
-        │
-        └── • index join (streamer)
-            │ sql nodes: <hidden>
-            │ regions: <hidden>
-            │ actual row count: 0
-            │ KV time: 0µs
-            │ KV contention time: 0µs
-            │ KV rows decoded: 0
-            │ KV bytes read: 0 B
-            │ KV gRPC calls: 0
-            │ estimated max memory allocated: 0 B
-            │ estimated max sql temp disk usage: 0 B
-            │ table: t@t_pkey
-            │
-            └── • scan
-                  sql nodes: <hidden>
-                  kv nodes: <hidden>
-                  regions: <hidden>
-                  actual row count: 0
-                  KV time: 0µs
-                  KV contention time: 0µs
-                  KV rows decoded: 0
-                  KV bytes read: 0 B
-                  KV gRPC calls: 0
-                  estimated max memory allocated: 0 B
-                  missing stats
-                  table: t@t_a_idx
-                  spans: [/10000 - /10000]
 
 # On the sixth execution a generic query plan will be generated. The cost of the
 # generic plan is less than the average cost of the five custom plans (plus some
 # overhead cost of optimization), so the generic plan is chosen.
-query T
+query T match(plan\stype)
 EXPLAIN ANALYZE EXECUTE p(10000, 20000)
 ----
-planning time: 10µs
-execution time: 100µs
-distribution: <hidden>
-vectorized: <hidden>
 plan type: generic, re-optimized
-maximum memory usage: <hidden>
-network usage: <hidden>
-regions: <hidden>
-isolation level: serializable
-priority: normal
-quality of service: regular
-·
-• lookup join
-│ sql nodes: <hidden>
-│ regions: <hidden>
-│ actual row count: 0
-│ KV time: 0µs
-│ KV contention time: 0µs
-│ KV rows decoded: 0
-│ KV bytes read: 0 B
-│ KV gRPC calls: 0
-│ estimated max memory allocated: 0 B
-│ table: g@g_a_b_idx
-│ equality: (k) = (a)
-│
-└── • lookup join
-    │ sql nodes: <hidden>
-    │ regions: <hidden>
-    │ actual row count: 0
-    │ KV time: 0µs
-    │ KV contention time: 0µs
-    │ KV rows decoded: 0
-    │ KV bytes read: 0 B
-    │ KV gRPC calls: 0
-    │ estimated max memory allocated: 0 B
-    │ table: c@c_a_idx
-    │ equality: (k) = (a)
-    │
-    └── • lookup join
-        │ sql nodes: <hidden>
-        │ regions: <hidden>
-        │ actual row count: 0
-        │ KV time: 0µs
-        │ KV contention time: 0µs
-        │ KV rows decoded: 0
-        │ KV bytes read: 0 B
-        │ KV gRPC calls: 0
-        │ estimated max memory allocated: 0 B
-        │ table: t@t_pkey
-        │ equality: (k) = (k)
-        │ equality cols are key
-        │ pred: c = "$2"
-        │
-        └── • lookup join
-            │ sql nodes: <hidden>
-            │ kv nodes: <hidden>
-            │ regions: <hidden>
-            │ actual row count: 0
-            │ KV time: 0µs
-            │ KV contention time: 0µs
-            │ KV rows decoded: 0
-            │ KV bytes read: 0 B
-            │ KV gRPC calls: 0
-            │ estimated max memory allocated: 0 B
-            │ table: t@t_a_idx
-            │ equality: ($1) = (a)
-            │
-            └── • values
-                  sql nodes: <hidden>
-                  regions: <hidden>
-                  actual row count: 1
-                  size: 2 columns, 1 row
 
 # On the seventh execution the generic plan is reused.
-query T
+query T match(plan\stype)
 EXPLAIN ANALYZE EXECUTE p(10000, 20000)
 ----
-planning time: 10µs
-execution time: 100µs
-distribution: <hidden>
-vectorized: <hidden>
 plan type: generic, reused
-maximum memory usage: <hidden>
-network usage: <hidden>
-regions: <hidden>
-isolation level: serializable
-priority: normal
-quality of service: regular
-·
-• lookup join
-│ sql nodes: <hidden>
-│ regions: <hidden>
-│ actual row count: 0
-│ KV time: 0µs
-│ KV contention time: 0µs
-│ KV rows decoded: 0
-│ KV bytes read: 0 B
-│ KV gRPC calls: 0
-│ estimated max memory allocated: 0 B
-│ table: g@g_a_b_idx
-│ equality: (k) = (a)
-│
-└── • lookup join
-    │ sql nodes: <hidden>
-    │ regions: <hidden>
-    │ actual row count: 0
-    │ KV time: 0µs
-    │ KV contention time: 0µs
-    │ KV rows decoded: 0
-    │ KV bytes read: 0 B
-    │ KV gRPC calls: 0
-    │ estimated max memory allocated: 0 B
-    │ table: c@c_a_idx
-    │ equality: (k) = (a)
-    │
-    └── • lookup join
-        │ sql nodes: <hidden>
-        │ regions: <hidden>
-        │ actual row count: 0
-        │ KV time: 0µs
-        │ KV contention time: 0µs
-        │ KV rows decoded: 0
-        │ KV bytes read: 0 B
-        │ KV gRPC calls: 0
-        │ estimated max memory allocated: 0 B
-        │ table: t@t_pkey
-        │ equality: (k) = (k)
-        │ equality cols are key
-        │ pred: c = "$2"
-        │
-        └── • lookup join
-            │ sql nodes: <hidden>
-            │ kv nodes: <hidden>
-            │ regions: <hidden>
-            │ actual row count: 0
-            │ KV time: 0µs
-            │ KV contention time: 0µs
-            │ KV rows decoded: 0
-            │ KV bytes read: 0 B
-            │ KV gRPC calls: 0
-            │ estimated max memory allocated: 0 B
-            │ table: t@t_a_idx
-            │ equality: ($1) = (a)
-            │
-            └── • values
-                  sql nodes: <hidden>
-                  regions: <hidden>
-                  actual row count: 1
-                  size: 2 columns, 1 row
 
 statement ok
 DEALLOCATE p
@@ -1115,79 +274,19 @@ EXECUTE p(10000);
 
 # The generic plan is generated on the sixth execution, but is more expensive
 # than the average custom plan.
-query T
+query T match(plan\stype)
 EXPLAIN ANALYZE EXECUTE p(10)
 ----
-planning time: 10µs
-execution time: 100µs
-distribution: <hidden>
-vectorized: <hidden>
 plan type: custom
-maximum memory usage: <hidden>
-network usage: <hidden>
-regions: <hidden>
-isolation level: serializable
-priority: normal
-quality of service: regular
-·
-• scan
-  sql nodes: <hidden>
-  kv nodes: <hidden>
-  regions: <hidden>
-  actual row count: 0
-  KV time: 0µs
-  KV contention time: 0µs
-  KV rows decoded: 0
-  KV bytes read: 0 B
-  KV gRPC calls: 0
-  estimated max memory allocated: 0 B
-  missing stats
-  table: g@g_a_b_idx
-  spans: [/10 - /10]
-  limit: 10
 
 statement ok
 SET plan_cache_mode = force_generic_plan
 
 # The generic plan previously generated is reused when forcing a generic plan.
-query T
+query T match(plan\stype)
 EXPLAIN ANALYZE EXECUTE p(10)
 ----
-planning time: 10µs
-execution time: 100µs
-distribution: <hidden>
-vectorized: <hidden>
 plan type: generic, reused
-maximum memory usage: <hidden>
-network usage: <hidden>
-regions: <hidden>
-isolation level: serializable
-priority: normal
-quality of service: regular
-·
-• limit
-│ count: 10
-│
-└── • lookup join
-    │ sql nodes: <hidden>
-    │ kv nodes: <hidden>
-    │ regions: <hidden>
-    │ actual row count: 0
-    │ KV time: 0µs
-    │ KV contention time: 0µs
-    │ KV rows decoded: 0
-    │ KV bytes read: 0 B
-    │ KV gRPC calls: 0
-    │ estimated max memory allocated: 0 B
-    │ estimated max sql temp disk usage: 0 B
-    │ table: g@g_a_b_idx
-    │ equality: ($1) = (a)
-    │
-    └── • values
-          sql nodes: <hidden>
-          regions: <hidden>
-          actual row count: 1
-          size: 1 column, 1 row
 
 statement ok
 DEALLOCATE p
@@ -1235,35 +334,10 @@ SET plan_cache_mode = force_custom_plan;
 statement ok
 PREPARE p AS SELECT k FROM t135151 WHERE a = $1 AND b = $2;
 
-query T
+query T match(plan\stype)
 EXPLAIN ANALYZE EXECUTE p(1, 2);
 ----
-planning time: 10µs
-execution time: 100µs
-distribution: <hidden>
-vectorized: <hidden>
 plan type: generic, reused
-maximum memory usage: <hidden>
-network usage: <hidden>
-regions: <hidden>
-isolation level: serializable
-priority: normal
-quality of service: regular
-·
-• scan
-  sql nodes: <hidden>
-  kv nodes: <hidden>
-  regions: <hidden>
-  actual row count: 0
-  KV time: 0µs
-  KV contention time: 0µs
-  KV rows decoded: 0
-  KV bytes read: 0 B
-  KV gRPC calls: 0
-  estimated max memory allocated: 0 B
-  missing stats
-  table: t135151@t135151_a_b_idx
-  spans: [/1/2 - /1/2]
 
 statement ok
 ALTER TABLE t135151 INJECT STATISTICS '[
@@ -1283,32 +357,7 @@ ALTER TABLE t135151 INJECT STATISTICS '[
   }
 ]';
 
-query T
+query T match(plan\stype)
 EXPLAIN ANALYZE EXECUTE p(1, 2);
 ----
-planning time: 10µs
-execution time: 100µs
-distribution: <hidden>
-vectorized: <hidden>
 plan type: custom
-maximum memory usage: <hidden>
-network usage: <hidden>
-regions: <hidden>
-isolation level: serializable
-priority: normal
-quality of service: regular
-·
-• scan
-  sql nodes: <hidden>
-  kv nodes: <hidden>
-  regions: <hidden>
-  actual row count: 0
-  KV time: 0µs
-  KV contention time: 0µs
-  KV rows decoded: 0
-  KV bytes read: 0 B
-  KV gRPC calls: 0
-  estimated max memory allocated: 0 B
-  estimated row count: 100 (1.0% of the table; stats collected <hidden> ago)
-  table: t135151@t135151_a_b_idx
-  spans: [/1/2 - /1/2]

--- a/pkg/sql/logictest/testdata/logic_test/generic
+++ b/pkg/sql/logictest/testdata/logic_test/generic
@@ -355,6 +355,51 @@ plan type: custom
 statement ok
 DEALLOCATE p
 
+statement ok
+PREPARE p AS
+SELECT * FROM g WHERE a IN ($1, $2) AND b > $3
+
+statement ok
+EXECUTE p(1, 10, 100);
+EXECUTE p(1, 10, 100);
+EXECUTE p(1, 10, 100);
+EXECUTE p(1, 10, 100);
+EXECUTE p(1, 10, 100);
+
+# The generic query plan is not chosen because it has a full table scan, while
+# the custom plan does not.
+query T match((plan\stype|FULL\sSCAN))
+EXPLAIN ANALYZE EXECUTE p(1, 10, 100)
+----
+plan type: custom
+
+statement ok
+DEALLOCATE p
+
+statement ok
+PREPARE p AS
+SELECT * FROM g
+UNION ALL
+SELECT * FROM g WHERE a IN ($1, $2) AND b > $3
+
+statement ok
+EXECUTE p(1, 10, 100);
+EXECUTE p(1, 10, 100);
+EXECUTE p(1, 10, 100);
+EXECUTE p(1, 10, 100);
+EXECUTE p(1, 10, 100);
+
+# The generic query plan is not chosen because it has two full table scans,
+# while the custom plan has only one.
+query T match((plan\stype|FULL\sSCAN))
+EXPLAIN ANALYZE EXECUTE p(1, 10, 100)
+----
+plan type: custom
+│     spans: FULL SCAN
+
+statement ok
+DEALLOCATE p
+
 # Regression test for #132963. Do not cache non-reusable plans.
 statement ok
 SET plan_cache_mode = auto

--- a/pkg/sql/logictest/testdata/logic_test/generic
+++ b/pkg/sql/logictest/testdata/logic_test/generic
@@ -226,7 +226,7 @@ DEALLOCATE p
 # Now use a more complex query that could have multiple join orderings.
 statement ok
 PREPARE p AS
-SELECT * FROM t
+SELECT t.k, c.k, g.k FROM t
 JOIN c ON t.k = c.a
 JOIN g ON c.k = g.a
 WHERE t.a = $1 AND t.c = $2
@@ -254,6 +254,35 @@ plan type: generic, re-optimized
 # On the seventh execution the generic plan is reused.
 query T match(plan\stype)
 EXPLAIN ANALYZE EXECUTE p(10000, 20000)
+----
+plan type: generic, reused
+
+statement ok
+ALTER TABLE t ADD COLUMN z INT
+
+# If a schema change occurs, the cost of both plans is reset, so the custom plan
+# is used for at least 5 executions.
+query T match(plan\stype)
+EXPLAIN ANALYZE EXECUTE p(1, 2)
+----
+plan type: custom
+
+statement ok
+EXECUTE p(1, 2);
+EXECUTE p(10, 20);
+EXECUTE p(100, 200);
+EXECUTE p(1000, 2000);
+
+# On the sixth execution after the schema change a generic plan is built and
+# used.
+query T match(plan\stype)
+EXPLAIN ANALYZE EXECUTE p(1, 2)
+----
+plan type: generic, re-optimized
+
+# On the seventh execution after the schema change the generic plan is reused.
+query T match(plan\stype)
+EXPLAIN ANALYZE EXECUTE p(1, 2)
 ----
 plan type: generic, reused
 

--- a/pkg/sql/opt/memo/cost.go
+++ b/pkg/sql/opt/memo/cost.go
@@ -13,6 +13,14 @@ import "math"
 type Cost struct {
 	C     float64
 	Flags CostFlags
+
+	// aux is auxiliary information within a cost that does not affect how the
+	// cost is compared to other costs with Less.
+	aux struct {
+		// fullScanCount is the number of full table or index scans in a
+		// sub-plan, up to 255.
+		fullScanCount uint8
+	}
 }
 
 // MaxCost is the maximum possible estimated cost. It's used to suppress memo
@@ -49,6 +57,26 @@ func (c Cost) Less(other Cost) bool {
 func (c *Cost) Add(other Cost) {
 	c.C += other.C
 	c.Flags.Add(other.Flags)
+	if c.aux.fullScanCount > math.MaxUint8-other.aux.fullScanCount {
+		// Avoid overflow.
+		c.aux.fullScanCount = math.MaxUint8
+	} else {
+		c.aux.fullScanCount += other.aux.fullScanCount
+	}
+}
+
+// FullScanCount returns the number of full scans in the cost.
+func (c Cost) FullScanCount() uint8 {
+	return c.aux.fullScanCount
+}
+
+// IncrFullScanCount increments that auxiliary full scan count within c.
+func (c *Cost) IncrFullScanCount() {
+	if c.aux.fullScanCount == math.MaxUint8 {
+		// Avoid overflow.
+		return
+	}
+	c.aux.fullScanCount++
 }
 
 // CostFlags contains flags that penalize the cost of an operator.

--- a/pkg/sql/opt/memo/cost_test.go
+++ b/pkg/sql/opt/memo/cost_test.go
@@ -7,6 +7,10 @@ package memo
 
 import "testing"
 
+type testAux struct {
+	fullScanCount uint8
+}
+
 func TestCostLess(t *testing.T) {
 	testCases := []struct {
 		left, right Cost
@@ -33,6 +37,8 @@ func TestCostLess(t *testing.T) {
 		{Cost{C: 1.0, Flags: CostFlags{HugeCostPenalty: true}}, MaxCost, true},
 		{Cost{C: 2.0, Flags: CostFlags{}}, Cost{C: 1.0, Flags: CostFlags{UnboundedCardinality: true}}, true},
 		{Cost{C: 1.0, Flags: CostFlags{UnboundedCardinality: true}}, Cost{C: 2.0, Flags: CostFlags{}}, false},
+		// Auxiliary information should not affect the comparison.
+		{Cost{C: 1.0, aux: testAux{0}}, Cost{C: 1.0, aux: testAux{1}}, false},
 	}
 	for _, tc := range testCases {
 		if tc.left.Less(tc.right) != tc.expected {
@@ -51,6 +57,8 @@ func TestCostAdd(t *testing.T) {
 		{Cost{C: 1.5}, Cost{C: 2.5}, Cost{C: 4.0}},
 		{Cost{C: 1.0, Flags: CostFlags{FullScanPenalty: true}}, Cost{C: 2.0}, Cost{C: 3.0, Flags: CostFlags{FullScanPenalty: true}}},
 		{Cost{C: 1.0}, Cost{C: 2.0, Flags: CostFlags{HugeCostPenalty: true}}, Cost{C: 3.0, Flags: CostFlags{HugeCostPenalty: true}}},
+		{Cost{C: 1.0, aux: testAux{1}}, Cost{C: 1.0, aux: testAux{2}}, Cost{C: 2.0, aux: testAux{3}}},
+		{Cost{C: 1.0, aux: testAux{200}}, Cost{C: 1.0, aux: testAux{100}}, Cost{C: 2.0, aux: testAux{255}}},
 	}
 	for _, tc := range testCases {
 		tc.left.Add(tc.right)

--- a/pkg/sql/opt/memo/cost_test.go
+++ b/pkg/sql/opt/memo/cost_test.go
@@ -3,40 +3,36 @@
 // Use of this software is governed by the CockroachDB Software License
 // included in the /LICENSE file.
 
-package memo_test
+package memo
 
-import (
-	"testing"
-
-	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
-)
+import "testing"
 
 func TestCostLess(t *testing.T) {
 	testCases := []struct {
-		left, right memo.Cost
+		left, right Cost
 		expected    bool
 	}{
-		{memo.Cost{C: 0.0}, memo.Cost{C: 1.0}, true},
-		{memo.Cost{C: 0.0}, memo.Cost{C: 1e-20}, true},
-		{memo.Cost{C: 0.0}, memo.Cost{C: 0.0}, false},
-		{memo.Cost{C: 1.0}, memo.Cost{C: 0.0}, false},
-		{memo.Cost{C: 1e-20}, memo.Cost{C: 1.0000000000001e-20}, false},
-		{memo.Cost{C: 1e-20}, memo.Cost{C: 1.000001e-20}, true},
-		{memo.Cost{C: 1}, memo.Cost{C: 1.00000000000001}, false},
-		{memo.Cost{C: 1}, memo.Cost{C: 1.00000001}, true},
-		{memo.Cost{C: 1000}, memo.Cost{C: 1000.00000000001}, false},
-		{memo.Cost{C: 1000}, memo.Cost{C: 1000.00001}, true},
-		{memo.Cost{C: 1.0, Flags: memo.CostFlags{FullScanPenalty: true}}, memo.Cost{C: 1.0}, false},
-		{memo.Cost{C: 1.0}, memo.Cost{C: 1.0, Flags: memo.CostFlags{HugeCostPenalty: true}}, true},
-		{memo.Cost{C: 1.0, Flags: memo.CostFlags{FullScanPenalty: true, HugeCostPenalty: true}}, memo.Cost{C: 1.0}, false},
-		{memo.Cost{C: 1.0, Flags: memo.CostFlags{FullScanPenalty: true}}, memo.Cost{C: 1.0, Flags: memo.CostFlags{HugeCostPenalty: true}}, true},
-		{memo.MaxCost, memo.Cost{C: 1.0}, false},
-		{memo.Cost{C: 0.0}, memo.MaxCost, true},
-		{memo.MaxCost, memo.MaxCost, false},
-		{memo.MaxCost, memo.Cost{C: 1.0, Flags: memo.CostFlags{FullScanPenalty: true}}, false},
-		{memo.Cost{C: 1.0, Flags: memo.CostFlags{HugeCostPenalty: true}}, memo.MaxCost, true},
-		{memo.Cost{C: 2.0, Flags: memo.CostFlags{}}, memo.Cost{C: 1.0, Flags: memo.CostFlags{UnboundedCardinality: true}}, true},
-		{memo.Cost{C: 1.0, Flags: memo.CostFlags{UnboundedCardinality: true}}, memo.Cost{C: 2.0, Flags: memo.CostFlags{}}, false},
+		{Cost{C: 0.0}, Cost{C: 1.0}, true},
+		{Cost{C: 0.0}, Cost{C: 1e-20}, true},
+		{Cost{C: 0.0}, Cost{C: 0.0}, false},
+		{Cost{C: 1.0}, Cost{C: 0.0}, false},
+		{Cost{C: 1e-20}, Cost{C: 1.0000000000001e-20}, false},
+		{Cost{C: 1e-20}, Cost{C: 1.000001e-20}, true},
+		{Cost{C: 1}, Cost{C: 1.00000000000001}, false},
+		{Cost{C: 1}, Cost{C: 1.00000001}, true},
+		{Cost{C: 1000}, Cost{C: 1000.00000000001}, false},
+		{Cost{C: 1000}, Cost{C: 1000.00001}, true},
+		{Cost{C: 1.0, Flags: CostFlags{FullScanPenalty: true}}, Cost{C: 1.0}, false},
+		{Cost{C: 1.0}, Cost{C: 1.0, Flags: CostFlags{HugeCostPenalty: true}}, true},
+		{Cost{C: 1.0, Flags: CostFlags{FullScanPenalty: true, HugeCostPenalty: true}}, Cost{C: 1.0}, false},
+		{Cost{C: 1.0, Flags: CostFlags{FullScanPenalty: true}}, Cost{C: 1.0, Flags: CostFlags{HugeCostPenalty: true}}, true},
+		{MaxCost, Cost{C: 1.0}, false},
+		{Cost{C: 0.0}, MaxCost, true},
+		{MaxCost, MaxCost, false},
+		{MaxCost, Cost{C: 1.0, Flags: CostFlags{FullScanPenalty: true}}, false},
+		{Cost{C: 1.0, Flags: CostFlags{HugeCostPenalty: true}}, MaxCost, true},
+		{Cost{C: 2.0, Flags: CostFlags{}}, Cost{C: 1.0, Flags: CostFlags{UnboundedCardinality: true}}, true},
+		{Cost{C: 1.0, Flags: CostFlags{UnboundedCardinality: true}}, Cost{C: 2.0, Flags: CostFlags{}}, false},
 	}
 	for _, tc := range testCases {
 		if tc.left.Less(tc.right) != tc.expected {
@@ -47,14 +43,14 @@ func TestCostLess(t *testing.T) {
 
 func TestCostAdd(t *testing.T) {
 	testCases := []struct {
-		left, right, expected memo.Cost
+		left, right, expected Cost
 	}{
-		{memo.Cost{C: 1.0}, memo.Cost{C: 2.0}, memo.Cost{C: 3.0}},
-		{memo.Cost{C: 0.0}, memo.Cost{C: 0.0}, memo.Cost{C: 0.0}},
-		{memo.Cost{C: -1.0}, memo.Cost{C: 1.0}, memo.Cost{C: 0.0}},
-		{memo.Cost{C: 1.5}, memo.Cost{C: 2.5}, memo.Cost{C: 4.0}},
-		{memo.Cost{C: 1.0, Flags: memo.CostFlags{FullScanPenalty: true}}, memo.Cost{C: 2.0}, memo.Cost{C: 3.0, Flags: memo.CostFlags{FullScanPenalty: true}}},
-		{memo.Cost{C: 1.0}, memo.Cost{C: 2.0, Flags: memo.CostFlags{HugeCostPenalty: true}}, memo.Cost{C: 3.0, Flags: memo.CostFlags{HugeCostPenalty: true}}},
+		{Cost{C: 1.0}, Cost{C: 2.0}, Cost{C: 3.0}},
+		{Cost{C: 0.0}, Cost{C: 0.0}, Cost{C: 0.0}},
+		{Cost{C: -1.0}, Cost{C: 1.0}, Cost{C: 0.0}},
+		{Cost{C: 1.5}, Cost{C: 2.5}, Cost{C: 4.0}},
+		{Cost{C: 1.0, Flags: CostFlags{FullScanPenalty: true}}, Cost{C: 2.0}, Cost{C: 3.0, Flags: CostFlags{FullScanPenalty: true}}},
+		{Cost{C: 1.0}, Cost{C: 2.0, Flags: CostFlags{HugeCostPenalty: true}}, Cost{C: 3.0, Flags: CostFlags{HugeCostPenalty: true}}},
 	}
 	for _, tc := range testCases {
 		tc.left.Add(tc.right)
@@ -66,16 +62,16 @@ func TestCostAdd(t *testing.T) {
 
 func TestCostFlagsLess(t *testing.T) {
 	testCases := []struct {
-		left, right memo.CostFlags
+		left, right CostFlags
 		expected    bool
 	}{
-		{memo.CostFlags{FullScanPenalty: false, HugeCostPenalty: false}, memo.CostFlags{FullScanPenalty: true, HugeCostPenalty: true}, true},
-		{memo.CostFlags{FullScanPenalty: true, HugeCostPenalty: true}, memo.CostFlags{FullScanPenalty: false, HugeCostPenalty: false}, false},
-		{memo.CostFlags{FullScanPenalty: true, HugeCostPenalty: true}, memo.CostFlags{FullScanPenalty: true, HugeCostPenalty: true}, false},
-		{memo.CostFlags{FullScanPenalty: false}, memo.CostFlags{FullScanPenalty: true}, true},
-		{memo.CostFlags{HugeCostPenalty: false}, memo.CostFlags{HugeCostPenalty: true}, true},
-		{memo.CostFlags{UnboundedCardinality: false}, memo.CostFlags{UnboundedCardinality: true}, true},
-		{memo.CostFlags{UnboundedCardinality: true}, memo.CostFlags{UnboundedCardinality: false}, false},
+		{CostFlags{FullScanPenalty: false, HugeCostPenalty: false}, CostFlags{FullScanPenalty: true, HugeCostPenalty: true}, true},
+		{CostFlags{FullScanPenalty: true, HugeCostPenalty: true}, CostFlags{FullScanPenalty: false, HugeCostPenalty: false}, false},
+		{CostFlags{FullScanPenalty: true, HugeCostPenalty: true}, CostFlags{FullScanPenalty: true, HugeCostPenalty: true}, false},
+		{CostFlags{FullScanPenalty: false}, CostFlags{FullScanPenalty: true}, true},
+		{CostFlags{HugeCostPenalty: false}, CostFlags{HugeCostPenalty: true}, true},
+		{CostFlags{UnboundedCardinality: false}, CostFlags{UnboundedCardinality: true}, true},
+		{CostFlags{UnboundedCardinality: true}, CostFlags{UnboundedCardinality: false}, false},
 	}
 	for _, tc := range testCases {
 		if tc.left.Less(tc.right) != tc.expected {
@@ -86,13 +82,13 @@ func TestCostFlagsLess(t *testing.T) {
 
 func TestCostFlagsAdd(t *testing.T) {
 	testCases := []struct {
-		left, right, expected memo.CostFlags
+		left, right, expected CostFlags
 	}{
-		{memo.CostFlags{FullScanPenalty: false, HugeCostPenalty: false}, memo.CostFlags{FullScanPenalty: true, HugeCostPenalty: true}, memo.CostFlags{FullScanPenalty: true, HugeCostPenalty: true}},
-		{memo.CostFlags{FullScanPenalty: true, HugeCostPenalty: true}, memo.CostFlags{FullScanPenalty: false, HugeCostPenalty: false}, memo.CostFlags{FullScanPenalty: true, HugeCostPenalty: true}},
-		{memo.CostFlags{FullScanPenalty: false}, memo.CostFlags{FullScanPenalty: true}, memo.CostFlags{FullScanPenalty: true}},
-		{memo.CostFlags{HugeCostPenalty: false}, memo.CostFlags{HugeCostPenalty: true}, memo.CostFlags{HugeCostPenalty: true}},
-		{memo.CostFlags{FullScanPenalty: true, HugeCostPenalty: false}, memo.CostFlags{FullScanPenalty: false, HugeCostPenalty: true}, memo.CostFlags{FullScanPenalty: true, HugeCostPenalty: true}},
+		{CostFlags{FullScanPenalty: false, HugeCostPenalty: false}, CostFlags{FullScanPenalty: true, HugeCostPenalty: true}, CostFlags{FullScanPenalty: true, HugeCostPenalty: true}},
+		{CostFlags{FullScanPenalty: true, HugeCostPenalty: true}, CostFlags{FullScanPenalty: false, HugeCostPenalty: false}, CostFlags{FullScanPenalty: true, HugeCostPenalty: true}},
+		{CostFlags{FullScanPenalty: false}, CostFlags{FullScanPenalty: true}, CostFlags{FullScanPenalty: true}},
+		{CostFlags{HugeCostPenalty: false}, CostFlags{HugeCostPenalty: true}, CostFlags{HugeCostPenalty: true}},
+		{CostFlags{FullScanPenalty: true, HugeCostPenalty: false}, CostFlags{FullScanPenalty: false, HugeCostPenalty: true}, CostFlags{FullScanPenalty: true, HugeCostPenalty: true}},
 	}
 	for _, tc := range testCases {
 		tc.left.Add(tc.right)

--- a/pkg/sql/opt/xform/coster.go
+++ b/pkg/sql/opt/xform/coster.go
@@ -890,9 +890,12 @@ func (c *coster) computeScanCost(scan *memo.ScanExpr, required *physical.Require
 	extraCost := c.distributionCost(regionsAccessed)
 	cost.Add(extraCost)
 
-	// Apply a penalty for a full scan if needed.
-	if scan.Flags.AvoidFullScan && isFullScan {
-		cost.Flags.FullScanPenalty = true
+	if isFullScan {
+		cost.IncrFullScanCount()
+		if scan.Flags.AvoidFullScan {
+			// Apply a penalty for a full scan if needed.
+			cost.Flags.FullScanPenalty = true
+		}
 	}
 
 	return cost

--- a/pkg/sql/prepared_stmt.go
+++ b/pkg/sql/prepared_stmt.go
@@ -181,13 +181,9 @@ func (p *planCosts) AvgCustom() memo.Cost {
 	return sum
 }
 
-// ClearGeneric clears the generic cost.
-func (p *planCosts) ClearGeneric() {
+// Reset clears any previously set costs.
+func (p *planCosts) Reset() {
 	p.generic = memo.Cost{C: 0}
-}
-
-// ClearCustom clears any previously added custom costs.
-func (p *planCosts) ClearCustom() {
 	p.custom.nextIdx = 0
 	p.custom.length = 0
 }

--- a/pkg/sql/prepared_stmt_test.go
+++ b/pkg/sql/prepared_stmt_test.go
@@ -32,7 +32,7 @@ func TestPlanCosts(t *testing.T) {
 	}
 	var pc planCosts
 	for _, tc := range testCases {
-		pc.ClearCustom()
+		pc.Reset()
 		for _, cost := range tc.input {
 			pc.AddCustom(memo.Cost{C: cost})
 		}

--- a/pkg/sql/prepared_stmt_test.go
+++ b/pkg/sql/prepared_stmt_test.go
@@ -40,8 +40,8 @@ func TestPlanCosts(t *testing.T) {
 			t.Errorf("expected Len() to be %d, got %d", tc.expectedNum, pc.NumCustom())
 		}
 		expectedAvgCost := memo.Cost{C: tc.expectedAvg}
-		if pc.AvgCustom() != expectedAvgCost {
-			t.Errorf("expected Avg() to be %f, got %f", tc.expectedAvg, pc.AvgCustom().C)
+		if pc.avgCustom() != expectedAvgCost {
+			t.Errorf("expected Avg() to be %f, got %f", tc.expectedAvg, pc.avgCustom().C)
 		}
 	}
 }


### PR DESCRIPTION
#### sql/logictest: add match option to query directive

The `match(<regexp>)` option is now supported for the `query` test
directive. Any rows that do not have a column value with a string
representation matching `<regexp>` will be excluded in the result.

This option is useful for `EXPLAIN` queries which cannot be included in
square-bracket subqueries which could normally be used to filter result
rows, e.g., `SELECT * FROM [EXPLAIN ...] WHERE ...`.

Release note: None

#### sql/logictest: simplify generic query plan tests

The `generic` test file has been simplified using the `match` option of
the `query` directive.

Release note: None

#### sql: reset generic and custom plan costs if either is stale

If either of the prebuilt generic or custom memos are stale, the costs
for both are cleared and the decision to use a custom or generic plan
for a prepared statement is reset. This ensures that we do not compare
costs of generic and custom plans based on different stats or schema
versions.

Fixes #132968
Informs #127826

Release note: None

#### sql: consider cost flags when choosing generic or custom plans

Cost flags are now considered when choosing between generic or custom
query plans.

Fixes #127826

Release note: None

#### opt: move Cost tests to memo package

Unit tests for the `Cost` type have been moved from the `memo_test`
package to the `memo` package.

Release note: None

#### sql: do not prefer generic plans with more full scans than custom plans

Under `plan_cache_mode=auto`, a generic query plan is not chosen if it
has more full scans than any of the 5 custom plans previously created.
This heuristic will help avoid choosing suboptimal generic query plans.
If a generic query plan has more full scans than some custom plan, then
the cost of re-optimization is likely worth it to try to avoid the full
scan.

Informs #137018
Informs #136975

Release note: None
