### PR TITLE
sql: fix recent regression in EXPLAIN ANALYZE

### DIFF
--- a/pkg/backup/backup_compaction_test.go
+++ b/pkg/backup/backup_compaction_test.go
@@ -428,6 +428,8 @@ func TestScheduledBackupCompaction(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
+	skip.WithIssue(t, 143394, "flaky test")
+
 	ctx := context.Background()
 	th, cleanup := newTestHelper(t)
 	defer cleanup()

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain_analyze
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain_analyze
@@ -82,3 +82,112 @@ vectorized: true
   estimated row count: 10 (missing stats)
   table: privileges@privileges_path_user_id_key
   spans: /"vtable/crdb_internal/tables"-/"vtable/crdb_internal/tables"/PrefixEnd
+
+# Regression test for not showing the execution statistics that correspond to
+# scans of the virtual tables.
+query T
+EXPLAIN ANALYZE SHOW TABLES;
+----
+planning time: 10µs
+execution time: 100µs
+distribution: <hidden>
+vectorized: <hidden>
+plan type: custom
+maximum memory usage: <hidden>
+network usage: <hidden>
+regions: <hidden>
+isolation level: serializable
+priority: normal
+quality of service: regular
+·
+• sort
+│ sql nodes: <hidden>
+│ regions: <hidden>
+│ actual row count: 1
+│ estimated max memory allocated: 0 B
+│ order: +nspname,+relname
+│
+└── • render
+    │
+    └── • hash join (left outer)
+        │ sql nodes: <hidden>
+        │ regions: <hidden>
+        │ actual row count: 1
+        │ estimated max memory allocated: 0 B
+        │ equality: (column80) = (table_id)
+        │
+        ├── • render
+        │   │
+        │   └── • hash join (left outer)
+        │       │ sql nodes: <hidden>
+        │       │ regions: <hidden>
+        │       │ actual row count: 1
+        │       │ estimated max memory allocated: 0 B
+        │       │ equality: (column62) = (table_id)
+        │       │ right cols are key
+        │       │
+        │       ├── • render
+        │       │   │
+        │       │   └── • hash join (right outer)
+        │       │       │ sql nodes: <hidden>
+        │       │       │ regions: <hidden>
+        │       │       │ actual row count: 1
+        │       │       │ estimated max memory allocated: 0 B
+        │       │       │ equality: (oid) = (relowner)
+        │       │       │
+        │       │       ├── • virtual table
+        │       │       │     sql nodes: <hidden>
+        │       │       │     regions: <hidden>
+        │       │       │     actual row count: 4
+        │       │       │     table: pg_roles@primary
+        │       │       │
+        │       │       └── • hash join
+        │       │           │ sql nodes: <hidden>
+        │       │           │ regions: <hidden>
+        │       │           │ actual row count: 1
+        │       │           │ estimated max memory allocated: 0 B
+        │       │           │ equality: (oid) = (relnamespace)
+        │       │           │
+        │       │           ├── • filter
+        │       │           │   │ sql nodes: <hidden>
+        │       │           │   │ regions: <hidden>
+        │       │           │   │ actual row count: 1
+        │       │           │   │ filter: nspname NOT IN ('crdb_internal', 'information_schema', __more1_10__, 'pg_extension')
+        │       │           │   │
+        │       │           │   └── • virtual table
+        │       │           │         sql nodes: <hidden>
+        │       │           │         regions: <hidden>
+        │       │           │         actual row count: 5
+        │       │           │         table: pg_namespace@primary
+        │       │           │
+        │       │           └── • filter
+        │       │               │ sql nodes: <hidden>
+        │       │               │ regions: <hidden>
+        │       │               │ actual row count: 330
+        │       │               │ filter: relkind IN ('S', 'm', __more1_10__, 'v')
+        │       │               │
+        │       │               └── • virtual table
+        │       │                     sql nodes: <hidden>
+        │       │                     regions: <hidden>
+        │       │                     actual row count: 362
+        │       │                     table: pg_class@primary
+        │       │
+        │       └── • distinct
+        │           │ sql nodes: <hidden>
+        │           │ regions: <hidden>
+        │           │ actual row count: 330
+        │           │ estimated max memory allocated: 0 B
+        │           │ distinct on: table_id
+        │           │
+        │           └── • virtual table
+        │                 sql nodes: <hidden>
+        │                 regions: <hidden>
+        │                 actual row count: 330
+        │                 table: table_row_statistics@primary
+        │
+        └── • virtual table
+              sql nodes: <hidden>
+              regions: <hidden>
+              actual row count: 1
+              table: tables@tables_database_name_idx (partial index)
+              spans: [/'test' - /'test']


### PR DESCRIPTION
This commit fixes a regression in EXPLAIN ANALYZE output recently added in 44da781bbe493dedcdb2674d6433a6d862c8b3ae. Before that change we always performed the association of the current planNode with the last stage of the physical plan, and after that change we started doing the association only when a new stage is added. However, this resulted in missing associations when a particular planNode didn't result in a new stage of the physical plan (for example, renderNode is handled as a projection by adjusting PostProcessSpec of already existing stage). As a result, we could lose the ability to associate execution statistics to some nodes in EXPLAIN ANALYZE output.

This is now fixed by bringing back the unconditional call to associate the current planNode with the last stage of the physical plan, even if a new stage isn't added. This required teaching `associateNodeWithComponents` to "swallow" duplicate associations and make them no-ops (otherwise, we would double-count statistics in some cases).

Epic: None
Release note: None