### PR TITLE
scbuild: clean up logic for finding temporary indexes

### DIFF
--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/zone_config_helpers.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/zone_config_helpers.go
@@ -1243,11 +1243,24 @@ func prepareZoneConfig(
 func isCorrespondingTemporaryIndex(
 	b BuildCtx, tableID catid.DescID, idx catid.IndexID, otherIdx catid.IndexID,
 ) bool {
-	maybeCorresponding := b.QueryByID(tableID).FilterTemporaryIndex().
-		Filter(func(_ scpb.Status, _ scpb.TargetStatus, e *scpb.TemporaryIndex) bool {
-			return idx == e.TemporaryIndexID && e.TemporaryIndexID == otherIdx+1
-		}).MustGetZeroOrOneElement()
-	return maybeCorresponding != nil
+	tmpIndexes := b.QueryByID(tableID).FilterTemporaryIndex().
+		Filter(func(_ scpb.Status, _ scpb.TargetStatus, tmpIndex *scpb.TemporaryIndex) bool {
+			return tmpIndex.IndexID == idx
+		}).Elements()
+	for _, tmpIndex := range tmpIndexes {
+		foundPrimary := b.QueryByID(tableID).FilterPrimaryIndex().
+			Filter(func(_ scpb.Status, _ scpb.TargetStatus, primaryIndex *scpb.PrimaryIndex) bool {
+				return primaryIndex.TemporaryIndexID == tmpIndex.IndexID && primaryIndex.IndexID == otherIdx
+			}).Size() > 0
+		foundSecondary := b.QueryByID(tableID).FilterSecondaryIndex().
+			Filter(func(_ scpb.Status, _ scpb.TargetStatus, secondaryIndex *scpb.SecondaryIndex) bool {
+				return secondaryIndex.TemporaryIndexID == tmpIndex.IndexID && secondaryIndex.IndexID == otherIdx
+			}).Size() > 0
+		if foundPrimary || foundSecondary {
+			return true
+		}
+	}
+	return false
 }
 
 // findCorrespondingTemporaryIndexByID finds the temporary index that
@@ -1258,10 +1271,27 @@ func isCorrespondingTemporaryIndex(
 func findCorrespondingTemporaryIndexByID(
 	b BuildCtx, tableID catid.DescID, indexID catid.IndexID,
 ) *scpb.TemporaryIndex {
-	return b.QueryByID(tableID).FilterTemporaryIndex().
-		Filter(func(_ scpb.Status, _ scpb.TargetStatus, e *scpb.TemporaryIndex) bool {
-			return e.SourceIndexID == indexID
+	primaryIdx := b.QueryByID(tableID).FilterPrimaryIndex().
+		Filter(func(_ scpb.Status, _ scpb.TargetStatus, primaryIndex *scpb.PrimaryIndex) bool {
+			return primaryIndex.IndexID == indexID
 		}).MustGetZeroOrOneElement()
+	if primaryIdx != nil {
+		return b.QueryByID(tableID).FilterTemporaryIndex().
+			Filter(func(_ scpb.Status, _ scpb.TargetStatus, e *scpb.TemporaryIndex) bool {
+				return e.IndexID == primaryIdx.TemporaryIndexID
+			}).MustGetZeroOrOneElement()
+	}
+	secondaryIdx := b.QueryByID(tableID).FilterSecondaryIndex().
+		Filter(func(_ scpb.Status, _ scpb.TargetStatus, secondaryIndex *scpb.SecondaryIndex) bool {
+			return secondaryIndex.IndexID == indexID
+		}).MustGetZeroOrOneElement()
+	if secondaryIdx != nil {
+		return b.QueryByID(tableID).FilterTemporaryIndex().
+			Filter(func(_ scpb.Status, _ scpb.TargetStatus, e *scpb.TemporaryIndex) bool {
+				return e.IndexID == secondaryIdx.TemporaryIndexID
+			}).MustGetZeroOrOneElement()
+	}
+	return nil
 }
 
 // getSubzoneSpansWithIdx groups each subzone span by their subzoneIndexes
@@ -1388,11 +1418,8 @@ func configureZoneConfigForNewIndexBackfill(
 		return errors.AssertionFailedf("attempting to modify subzone configs for indexID %d"+
 			" on tableID %d that does not a zone config set", oldIndexID, tableID)
 	}
-	tempIndex := b.QueryByID(tableID).FilterTemporaryIndex().
-		Filter(func(current scpb.Status, target scpb.TargetStatus, e *scpb.TemporaryIndex) bool {
-			return target == scpb.Transient && e.SourceIndexID == oldIndexID
-		}).MustGetZeroOrOneElement()
 	newIndex := getLatestPrimaryIndex(b, tableID)
+	tempIndex := findCorrespondingTemporaryIndexByID(b, tableID, newIndex.IndexID)
 	newIndexesForBackfill := []catid.IndexID{tempIndex.IndexID, newIndex.IndexID}
 	newZoneConfig := *mostRecentTableZoneConfig.ZoneConfig
 	newSubzones := make([]zonepb.Subzone, 0)

--- a/pkg/sql/schemachanger/scpb/elements.proto
+++ b/pkg/sql/schemachanger/scpb/elements.proto
@@ -311,7 +311,11 @@ message Index {
   // TODO(postamar): try to get rid of these altogether
   //  Perhaps move these to the target metadata instead?
   bool is_concurrently = 20;
+  // SourceIndexID refers back to the primary index for which a secondary index
+  // was created.
   uint32 source_index_id = 21 [(gogoproto.customname) = "SourceIndexID", (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/sql/sem/catid.IndexID"];
+  // TemporaryIndexID refers to the temporary index that was created while this
+  // index is being backfilled.
   uint32 temporary_index_id = 22 [(gogoproto.customname) = "TemporaryIndexID", (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/sql/sem/catid.IndexID"];
 
   cockroach.geo.geoindex.Config geo_config = 24 [(gogoproto.nullable) = true];


### PR DESCRIPTION
The previous logic assumed that a temporary index could be linked to its corresponding index that is getting backfilled by using the SourceIndexID field. However, that field always refers back to the primary index.  This meant that the function would work correctly for primary indexes, but not for secondary indexes.

There was no bug, since the function is currently only used for primary indexes. Since we want to start using it for secondary indexes too, we need this change.

While doing this, I added comments to the fields to clarify.

I plan to backport this to 25.1 for the purposes of keeping the code sync'd between branches, and since it's a contained change.

Epic: CRDB-31329
Release note: None