### PR TITLE
release-25.1: scripts: update bump-pebble.sh to use crl-release-25.1

### DIFF
--- a/scripts/bump-pebble.sh
+++ b/scripts/bump-pebble.sh
@@ -12,7 +12,7 @@
 # in build/teamcity/cockroach/nightlies to use `@crl-release-xy.z` instead of
 # `@master`.
 BRANCH=release-25.1
-PEBBLE_BRANCH=master
+PEBBLE_BRANCH=crl-release-25.1
 
 # This script may be used to produce a branch bumping the Pebble version. The
 # storage team bumps CockroachDB's Pebble dependency frequently, and this script


### PR DESCRIPTION
Epic: none
Release note: none
Release justification: non-production code changes