### PR TITLE
vecindex: store metadata struct in Partition

### DIFF
--- a/pkg/sql/vecindex/cspann/commontest/storetests.go
+++ b/pkg/sql/vecindex/cspann/commontest/storetests.go
@@ -199,8 +199,10 @@ func (suite *StoreTestSuite) TestNonRootPartition() {
 		quantizedSet := suite.quantizer.Quantize(&suite.workspace, vectors)
 		childKeys := []cspann.ChildKey{partitionKey1, partitionKey2}
 		valueBytes := []cspann.ValueBytes{valueBytes1, valueBytes2}
+		metadata := cspann.PartitionMetadata{
+			Level: cspann.SecondLevel, Centroid: quantizedSet.GetCentroid()}
 		partition := cspann.NewPartition(
-			suite.quantizer, quantizedSet, childKeys, valueBytes, cspann.SecondLevel)
+			metadata, suite.quantizer, quantizedSet, childKeys, valueBytes)
 
 		partitionKey, err := tx.InsertPartition(suite.ctx, treeKey, partition)
 		suite.NoError(err)
@@ -458,8 +460,10 @@ func (suite *StoreTestSuite) insertLeafPartition(store TestStore, treeID int) cs
 	quantizedSet := suite.quantizer.Quantize(&suite.workspace, vectors)
 	childKeys := []cspann.ChildKey{primaryKey1, primaryKey2, primaryKey3}
 	valueBytes := []cspann.ValueBytes{valueBytes1, valueBytes2, valueBytes3}
+	metadata := cspann.PartitionMetadata{
+		Level: cspann.LeafLevel, Centroid: quantizedSet.GetCentroid()}
 	partition := cspann.NewPartition(
-		suite.quantizer, quantizedSet, childKeys, valueBytes, cspann.LeafLevel)
+		metadata, suite.quantizer, quantizedSet, childKeys, valueBytes)
 
 	partitionKey, err := tx.InsertPartition(suite.ctx, treeKey, partition)
 	suite.NoError(err)
@@ -600,14 +604,16 @@ func (suite *StoreTestSuite) setRootPartition(store TestStore, treeID int) {
 	quantizedSet := suite.rootQuantizer.Quantize(&suite.workspace, vectors)
 	childKeys := []cspann.ChildKey{partitionKey1, partitionKey2}
 	valueBytes := []cspann.ValueBytes{valueBytes1, valueBytes2}
+	metadata := cspann.PartitionMetadata{
+		Level: cspann.SecondLevel, Centroid: quantizedSet.GetCentroid()}
 	newRoot := cspann.NewPartition(
-		suite.rootQuantizer, quantizedSet, childKeys, valueBytes, cspann.SecondLevel)
+		metadata, suite.rootQuantizer, quantizedSet, childKeys, valueBytes)
 
 	err := tx.SetRootPartition(suite.ctx, treeKey, newRoot)
 	suite.NoError(err)
 
 	// Check partition metadata.
-	metadata, err := tx.GetPartitionMetadata(suite.ctx, treeKey, cspann.RootKey, false /* forUpdate */)
+	metadata, err = tx.GetPartitionMetadata(suite.ctx, treeKey, cspann.RootKey, false /* forUpdate */)
 	suite.NoError(err)
 	CheckPartitionMetadata(suite.T(), metadata, cspann.SecondLevel, centroid)
 

--- a/pkg/sql/vecindex/cspann/fixup_worker_test.go
+++ b/pkg/sql/vecindex/cspann/fixup_worker_test.go
@@ -34,7 +34,9 @@ func TestSplitPartitionData(t *testing.T) {
 	}, 2)
 	quantizedSet := quantizer.Quantize(&workspace, vectors)
 
+	metadata := PartitionMetadata{Level: 1, Centroid: quantizedSet.GetCentroid()}
 	splitPartition := NewPartition(
+		metadata,
 		quantizer,
 		quantizedSet,
 		[]ChildKey{
@@ -48,8 +50,7 @@ func TestSplitPartitionData(t *testing.T) {
 		},
 		[]ValueBytes{
 			{1, 2}, {3, 4}, {5, 6}, {7, 8}, {9, 10}, {11, 12}, {13, 14},
-		},
-		1)
+		})
 
 	validate := func(split *splitData, offsets []uint64) {
 		require.Equal(t, splitPartition.Level(), split.Partition.Level())

--- a/pkg/sql/vecindex/cspann/memstore/memstore.go
+++ b/pkg/sql/vecindex/cspann/memstore/memstore.go
@@ -485,8 +485,10 @@ func Load(data []byte) (*Store, error) {
 			quantizedSet = partitionProto.UnQuantized
 		}
 
-		memPart.lock.partition = cspann.NewPartition(quantizer, quantizedSet,
-			partitionProto.ChildKeys, partitionProto.ValueBytes, partitionProto.Level)
+		metadata := cspann.PartitionMetadata{
+			Level: partitionProto.Level, Centroid: quantizedSet.GetCentroid()}
+		memPart.lock.partition = cspann.NewPartition(metadata, quantizer, quantizedSet,
+			partitionProto.ChildKeys, partitionProto.ValueBytes)
 
 		inMemStore.mu.partitions[memPart.key] = memPart
 	}

--- a/pkg/sql/vecindex/cspann/memstore/memstore_txn.go
+++ b/pkg/sql/vecindex/cspann/memstore/memstore_txn.go
@@ -199,7 +199,7 @@ func (tx *memTxn) GetPartitionMetadata(
 	}
 	defer memPart.lock.ReleaseShared()
 
-	return memPart.lock.partition.Metadata(), nil
+	return *memPart.lock.partition.Metadata(), nil
 }
 
 // AddToPartition implements the Txn interface.

--- a/pkg/sql/vecindex/cspann/partition_test.go
+++ b/pkg/sql/vecindex/cspann/partition_test.go
@@ -42,7 +42,8 @@ func TestPartition(t *testing.T) {
 	quantizedSet := quantizer.Quantize(&workspace, vectors)
 	childKeys := []ChildKey{childKey10, childKey20, childKey30}
 	valueBytes := []ValueBytes{valueBytes10, valueBytes20, valueBytes30, valueBytes40}
-	partition := NewPartition(quantizer, quantizedSet, childKeys, valueBytes, Level(1))
+	metadata := PartitionMetadata{Level: 1, Centroid: quantizedSet.GetCentroid()}
+	partition := NewPartition(metadata, quantizer, quantizedSet, childKeys, valueBytes)
 	require.True(t, partition.Add(&workspace, vector.T{4, 3}, childKey40, valueBytes40))
 
 	// Add vector and expect its value to be updated.
@@ -114,7 +115,7 @@ func roundResults(results SearchResults, prec int) SearchResults {
 }
 
 func checkPartitionMetadata(
-	t *testing.T, metadata PartitionMetadata, level Level, centroid vector.T,
+	t *testing.T, metadata *PartitionMetadata, level Level, centroid vector.T,
 ) {
 	require.Equal(t, level, metadata.Level)
 	require.Equal(t, []float32(centroid), testutils.RoundFloats(metadata.Centroid, 2))

--- a/pkg/sql/vecindex/cspann/split_data.go
+++ b/pkg/sql/vecindex/cspann/split_data.go
@@ -39,7 +39,8 @@ func (s *splitData) Init(
 	s.Vectors = vectors
 	s.OldCentroidDistances = oldCentroidDistances
 	quantizedSet := quantizer.Quantize(w, s.Vectors)
-	s.Partition = NewPartition(quantizer, quantizedSet, childKeys, valueBytes, level)
+	metadata := PartitionMetadata{Level: level, Centroid: quantizedSet.GetCentroid()}
+	s.Partition = NewPartition(metadata, quantizer, quantizedSet, childKeys, valueBytes)
 }
 
 // ReplaceWithLast removes the vector at the given offset in the set, replacing

--- a/pkg/sql/vecindex/vecencoding/encoding_test.go
+++ b/pkg/sql/vecindex/vecencoding/encoding_test.go
@@ -68,7 +68,8 @@ func testEncodeDecodeRoundTripImpl(t *testing.T, rnd *rand.Rand, set vector.Set)
 						}
 						valueBytes[i] = randutil.RandBytes(rnd, 10)
 					}
-					originalPartition := cspann.NewPartition(quantizer, quantizedSet, childKeys, valueBytes, level)
+					metadata := cspann.PartitionMetadata{Level: level, Centroid: quantizedSet.GetCentroid()}
+					originalPartition := cspann.NewPartition(metadata, quantizer, quantizedSet, childKeys, valueBytes)
 
 					// Encode the partition.
 					encMetadata, err := vecencoding.EncodePartitionMetadata(level, quantizedSet.GetCentroid())
@@ -124,8 +125,9 @@ func testEncodeDecodeRoundTripImpl(t *testing.T, rnd *rand.Rand, set vector.Set)
 						require.Equal(t, trailingData, testutils.NormalizeSlice(remainder))
 					}
 
+					metadata = cspann.PartitionMetadata{Level: decodedLevel, Centroid: decodedCentroid}
 					decodedPartition := cspann.NewPartition(
-						quantizer, decodedSet, childKeys, valueBytes, decodedLevel)
+						metadata, quantizer, decodedSet, childKeys, valueBytes)
 					testingAssertPartitionsEqual(t, originalPartition, decodedPartition)
 				})
 			}

--- a/pkg/sql/vecindex/vecstore/store_txn.go
+++ b/pkg/sql/vecindex/vecstore/store_txn.go
@@ -203,7 +203,7 @@ func (tx *Txn) decodePartition(
 	}
 
 	return cspann.NewPartition(
-		codec.quantizer, codec.getVectorSet(), tx.tmpChildKeys, tx.tmpValueBytes, metadata.Level), nil
+		metadata, codec.quantizer, codec.getVectorSet(), tx.tmpChildKeys, tx.tmpValueBytes), nil
 }
 
 // GetPartition is part of the cspann.Txn interface. Read the partition


### PR DESCRIPTION
Previously, we lazily created PartitionMetadata when it was needed by the Partition. However, soon we will add more metadata fields and so this commit embeds PartitionMetadata in the Partition struct. Now, rather than lazily constructing it, a reference to the embedded PartitionMetadata can be returned.

Epic: CRDB-42943

Release note: None