### PR TITLE
kv: use origin timestamp to validate lww semantics

### DIFF
--- a/pkg/kv/BUILD.bazel
+++ b/pkg/kv/BUILD.bazel
@@ -51,6 +51,7 @@ go_test(
         "admission_test.go",
         "client_test.go",
         "db_test.go",
+        "kv_client_lww_test.go",
         "main_test.go",
         "range_lookup_test.go",
         "txn_external_test.go",

--- a/pkg/kv/kv_client_lww_test.go
+++ b/pkg/kv/kv_client_lww_test.go
@@ -1,0 +1,355 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package kv_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/require"
+)
+
+// unwrapConditionFailedError unwraps an error into a kvpb.ConditionFailedError.
+// It fails the test if there is no error or if the error cannot be unwrapped
+// into the expected type.
+func unwrapConditionFailedError(t *testing.T, err error) *kvpb.ConditionFailedError {
+	t.Helper()
+	require.Error(t, err, "expected an error")
+
+	var conditionFailedErr *kvpb.ConditionFailedError
+	require.True(t, errors.As(err, &conditionFailedErr),
+		"expected error to unwrap to *kvpb.ConditionFailedError, got: %v", err)
+
+	return conditionFailedErr
+}
+
+func TestDeleteWithOriginTimestamp(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	s, _, db := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(context.Background())
+
+	ctx := context.Background()
+	key := roachpb.Key("lww-test-key")
+	value := []byte("value")
+
+	// Put a value with the current timestamp.
+	require.NoError(t, db.Put(ctx, key, value))
+
+	// Get the current timestamp to use as a reference.
+	gr, err := db.Get(ctx, key)
+	require.NoError(t, err)
+	currentTS := gr.Value.Timestamp
+
+	// Helper function to attempt a delete with a specific origin timestamp
+	attemptDelete := func(ts hlc.Timestamp) error {
+		b := &kv.Batch{}
+		b.Del(key)
+		b.Header.WriteOptions = &kvpb.WriteOptions{
+			OriginTimestamp: ts,
+		}
+		return db.Run(ctx, b)
+	}
+
+	t.Run("OlderTimestamp", func(t *testing.T) {
+		// Delete with an origin timestamp older than the mvcc timestamp should fail
+		err := attemptDelete(currentTS.Prev())
+		condErr := unwrapConditionFailedError(t, err)
+		require.False(t, condErr.OriginTimestampOlderThan.IsEmpty(), "expected OriginTimestampOlderThan to be set")
+		require.Equal(t, currentTS, condErr.OriginTimestampOlderThan, "expected OriginTimestampOlderThan to match current timestamp")
+
+		// Verify the original value still exists
+		gr, err := db.Get(ctx, key)
+		require.NoError(t, err)
+		require.NotNil(t, gr.Value, "expected value to exist")
+		require.Equal(t, value, gr.ValueBytes(), "value should match what was put")
+	})
+
+	t.Run("NewerTimestamp", func(t *testing.T) {
+		// Delete with an origin timestamp newer than the mvcc timestamp should succeed
+		err := attemptDelete(currentTS.Next())
+		require.NoError(t, err)
+
+		// Verify the value was deleted
+		gr, err := db.Get(ctx, key)
+		require.NoError(t, err)
+		require.Nil(t, gr.Value, "expected value to be deleted")
+	})
+}
+
+func TestDelRangeWithOriginTimestamp(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	s, _, db := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(context.Background())
+
+	ctx := context.Background()
+
+	// Setup test data once for all subtests
+	keys := []roachpb.Key{
+		roachpb.Key("lww-delrange-a"),
+		roachpb.Key("lww-delrange-b"),
+		roachpb.Key("lww-delrange-c"),
+	}
+	startKey := keys[0]
+	endKey := keys[len(keys)-1].Next()
+	value := []byte("value")
+
+	// Put values for all keys
+	for _, key := range keys {
+		require.NoError(t, db.Put(ctx, key, value))
+	}
+
+	// Get the current timestamp to use as a reference
+	gr, err := db.Get(ctx, keys[2])
+	require.NoError(t, err)
+	currentTS := gr.Value.Timestamp
+
+	t.Run("OlderTimestamp", func(t *testing.T) {
+		// DelRange with an origin timestamp older than the mvcc timestamp should fail
+		b := &kv.Batch{}
+		b.DelRange(startKey, endKey, false)
+		b.Header.WriteOptions = &kvpb.WriteOptions{
+			OriginTimestamp: currentTS.Prev(),
+		}
+		err := db.Run(ctx, b)
+		condErr := unwrapConditionFailedError(t, err)
+		require.False(t, condErr.OriginTimestampOlderThan.IsEmpty(), "expected OriginTimestampOlderThan to be set")
+		require.Equal(t, currentTS, condErr.OriginTimestampOlderThan, "expected OriginTimestampOlderThan to match current timestamp")
+
+		// Verify the original values still exist
+		for _, key := range keys {
+			gr, err := db.Get(ctx, key)
+			require.NoError(t, err)
+			require.NotNil(t, gr.Value, "expected value to exist at %s", key)
+			require.Equal(t, value, gr.ValueBytes(), "value should match what was put")
+		}
+	})
+
+	t.Run("NewerTimestamp", func(t *testing.T) {
+		// Delete the range with the newer timestamp
+		b := &kv.Batch{}
+		b.DelRange(startKey, endKey, false)
+		b.Header.WriteOptions = &kvpb.WriteOptions{
+			OriginTimestamp: currentTS.Next(),
+		}
+		err := db.Run(ctx, b)
+		require.NoError(t, err, "unexpected error when deleting range with newer origin timestamp")
+
+		// Verify all values were deleted
+		for _, key := range keys {
+			gr, err := db.Get(ctx, key)
+			require.NoError(t, err)
+			require.Nil(t, gr.Value, "expected value to be deleted at %s", key)
+		}
+	})
+}
+
+func TestPutWithOriginTimestamp(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	s, _, db := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(context.Background())
+
+	ctx := context.Background()
+	key := roachpb.Key("lww-put-test-key")
+	value1 := []byte("value1")
+	value2 := []byte("value2")
+
+	// Put a value with the current timestamp.
+	require.NoError(t, db.Put(ctx, key, value1))
+
+	// Get the current timestamp to use as a reference.
+	gr, err := db.Get(ctx, key)
+	require.NoError(t, err)
+	currentTS := gr.Value.Timestamp
+
+	// Helper function to attempt a put with a specific origin timestamp
+	attemptPut := func(ts hlc.Timestamp, value []byte) error {
+		b := &kv.Batch{}
+		b.Put(key, value)
+		b.Header.WriteOptions = &kvpb.WriteOptions{
+			OriginTimestamp: ts,
+		}
+		return db.Run(ctx, b)
+	}
+
+	t.Run("OlderTimestamp", func(t *testing.T) {
+		// Put with an origin timestamp older than the mvcc timestamp should fail
+		olderTS := currentTS.Prev()
+		err := attemptPut(olderTS, value2)
+		condErr := unwrapConditionFailedError(t, err)
+		require.False(t, condErr.OriginTimestampOlderThan.IsEmpty(), "expected OriginTimestampOlderThan to be set")
+		require.Equal(t, currentTS, condErr.OriginTimestampOlderThan, "expected OriginTimestampOlderThan to match current timestamp")
+
+		// Verify the original value still exists
+		gr, err := db.Get(ctx, key)
+		require.NoError(t, err)
+		require.NotNil(t, gr.Value, "expected value to exist")
+		require.Equal(t, value1, gr.ValueBytes(), "value should match expected")
+	})
+
+	t.Run("NewerTimestamp", func(t *testing.T) {
+		// Put with an origin timestamp newer than the mvcc timestamp should succeed
+		newerTS := currentTS.Next()
+		err := attemptPut(newerTS, value2)
+		require.NoError(t, err, "unexpected error when putting with newer origin timestamp")
+
+		// Verify the value was updated
+		gr, err := db.Get(ctx, key)
+		require.NoError(t, err)
+		require.NotNil(t, gr.Value, "expected value to exist")
+		require.Equal(t, value2, gr.ValueBytes(), "value should match expected")
+
+		// Get the new timestamp
+		gr, err = db.Get(ctx, key)
+		require.NoError(t, err)
+		updatedTS := gr.Value.Timestamp
+
+		// Try to put with an even newer timestamp
+		newestValue := []byte("newest-value")
+		newestTS := updatedTS.Next()
+		err = attemptPut(newestTS, newestValue)
+		require.NoError(t, err, "unexpected error when putting with newest origin timestamp")
+
+		// Verify the newest value was written
+		gr, err = db.Get(ctx, key)
+		require.NoError(t, err)
+		require.NotNil(t, gr.Value, "expected value to exist")
+		require.Equal(t, newestValue, gr.ValueBytes(), "value should match new value")
+	})
+}
+
+func TestCPutWithOriginTimestamp(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	s, _, db := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(context.Background())
+
+	ctx := context.Background()
+	key := roachpb.Key("lww-cput-test-key")
+	initialValue := []byte("initial")
+	newValue := []byte("new-value")
+	wrongExpectedValue := []byte("wrong-expected")
+
+	// Put a value with the current timestamp.
+	require.NoError(t, db.Put(ctx, key, initialValue))
+
+	// Get the current timestamp to use as a reference.
+	gr, err := db.Get(ctx, key)
+	require.NoError(t, err)
+	currentTS := gr.Value.Timestamp
+
+	// Helper function to attempt a conditional put with a specific origin timestamp
+	attemptCPut := func(ts hlc.Timestamp, expectedValue, newValue []byte) error {
+		b := &kv.Batch{}
+		b.CPut(key, newValue, expectedValue)
+		b.Header.WriteOptions = &kvpb.WriteOptions{
+			OriginTimestamp: ts,
+		}
+		return db.Run(ctx, b)
+	}
+
+	t.Run("ConditionFailsAndLWWFails", func(t *testing.T) {
+		// Both the condition fails (wrong expected value) and the origin timestamp is older
+		olderTS := currentTS.Prev()
+		err := attemptCPut(olderTS, wrongExpectedValue, newValue)
+		condErr := unwrapConditionFailedError(t, err)
+
+		// The error should indicate the origin timestamp is older
+		require.False(t, condErr.OriginTimestampOlderThan.IsEmpty(), "expected OriginTimestampOlderThan to be set")
+		require.Equal(t, currentTS, condErr.OriginTimestampOlderThan, "expected OriginTimestampOlderThan to match current timestamp")
+
+		// Verify the original value still exists
+		gr, err := db.Get(ctx, key)
+		require.NoError(t, err)
+		require.NotNil(t, gr.Value, "expected value to exist")
+		require.Equal(t, initialValue, gr.ValueBytes(), "value should match initial value")
+	})
+
+	t.Run("ConditionPassesButLWWFails", func(t *testing.T) {
+		// The condition passes (correct expected value) but the origin timestamp is older
+		olderTS := currentTS.Prev()
+		err := attemptCPut(olderTS, initialValue, newValue)
+		condErr := unwrapConditionFailedError(t, err)
+
+		// The error should indicate the origin timestamp is older
+		require.False(t, condErr.OriginTimestampOlderThan.IsEmpty(), "expected OriginTimestampOlderThan to be set")
+		require.Equal(t, currentTS, condErr.OriginTimestampOlderThan, "expected OriginTimestampOlderThan to match current timestamp")
+
+		// Verify the original value still exists
+		gr, err := db.Get(ctx, key)
+		require.NoError(t, err)
+		require.NotNil(t, gr.Value, "expected value to exist")
+		require.Equal(t, initialValue, gr.ValueBytes(), "value should match initial value")
+	})
+
+	t.Run("ConditionFailsButLWWPasses", func(t *testing.T) {
+		// The condition fails (wrong expected value) but the origin timestamp is newer
+		newerTS := currentTS.Next()
+		err := attemptCPut(newerTS, wrongExpectedValue, newValue)
+		condErr := unwrapConditionFailedError(t, err)
+
+		// The error should indicate the condition failed but not that the timestamp is older
+		require.True(t, condErr.OriginTimestampOlderThan.IsEmpty(), "expected OriginTimestampOlderThan to be empty")
+		require.NotNil(t, condErr.ActualValue, "expected ActualValue to be set")
+
+		// Verify the original value still exists
+		gr, err := db.Get(ctx, key)
+		require.NoError(t, err)
+		require.NotNil(t, gr.Value, "expected value to exist")
+		require.Equal(t, initialValue, gr.ValueBytes(), "value should match initial value")
+	})
+
+	t.Run("BothConditionAndLWWPass", func(t *testing.T) {
+		// Create a new key for this test to avoid interference from previous test cases
+		successKey := roachpb.Key("lww-cput-success-key")
+
+		// Put an initial value
+		require.NoError(t, db.Put(ctx, successKey, initialValue))
+
+		// Get the current value and timestamp
+		gr, err := db.Get(ctx, successKey)
+		require.NoError(t, err)
+		require.NotNil(t, gr.Value)
+		currentValue := gr.Value.TagAndDataBytes()
+		currentTS := gr.Value.Timestamp
+
+		// Both the condition passes and the origin timestamp is newer
+		newerTS := currentTS.Next()
+
+		// Use a helper function to perform the CPut with the current value
+		cputErr := func() error {
+			b := &kv.Batch{}
+			b.CPut(successKey, newValue, currentValue)
+			b.Header.WriteOptions = &kvpb.WriteOptions{
+				OriginTimestamp: newerTS,
+			}
+			return db.Run(ctx, b)
+		}()
+
+		require.NoError(t, cputErr, "unexpected error when both condition and timestamp are valid")
+
+		// Verify the value was updated
+		gr, err = db.Get(ctx, successKey)
+		require.NoError(t, err)
+		require.NotNil(t, gr.Value, "expected value to exist")
+		require.Equal(t, newValue, gr.ValueBytes(), "value should match new value")
+	})
+}

--- a/pkg/kv/kvpb/api.proto
+++ b/pkg/kv/kvpb/api.proto
@@ -347,29 +347,8 @@ message ConditionalPutRequest {
   // the use of this value with transactions.
   bool inline = 7;
 
-  // OriginTimestamp, if set, indicates that the ConditionalPut should
-  // only succeed if the provided timestamp is greater than the
-  // OriginTimestamp field in the MVCCValueHeader of the existing
-  // value (if the value has a non-zero OriginTimestamp) or the MVCC
-  // timestamp of the existing value. If there is no existing value,
-  // the timestamp check succeeds.
-  //
-  // The conditional put request will only succeed if this timestamp
-  // comparison is successful and the expected bytes matches the
-  // actual bytes.
-  //
-  // On success, this timestamp will also be stored in the
-  // OriginTimestamp field of the the MVCCValueHeader for the newly
-  // written value.
-  //
-  // In the proposed use case, the OriginTimestamp is the MVCC version
-  // timestamp of the row on the source cluster and the semantics lead
-  // to idempotent last-write-wins semantics against the "original
-  // MVCC timestamp" of the value on the destination, which is its
-  // MVCC timestamp or, if set, the OriginTimestamp (reflecting that
-  // this value originated from the source cluster).
-  //
-  // Used by logical data replication.
+  // OriginTimestamp is deprecated. If set, it must be equal to the
+  // OriginTimestamp in the batch's WriteOptions.
   util.hlc.Timestamp origin_timestamp = 8 [(gogoproto.nullable) = false];
 
   reserved 9;
@@ -2997,9 +2976,26 @@ message Header {
 
 message WriteOptions {
   uint32 origin_id = 1[(gogoproto.customname) = "OriginID"];
-  // OriginTimestamp is bound to the MVCCValueHeader of written key in the
-  // batch. Note that a kv client cannot set this if they use CPut's origin
-  // timestamp arg.
+  // OriginTimestamp is used by logical data replication. It is the MVCC
+  // timestamp of the row in the source cluster.
+  //
+  // If set the write will only succeed if the provided timestamp is greater than
+  // the OriginTimestamp field in the MVCCValueHeader of the existing value (if
+  // the value has a non-zero OriginTimestamp) or the MVCC timestamp of the
+  // existing value. If there is no existing value, the timestamp check succeeds.
+	//
+	// The origin_timestamp header is only handled by the put, cput, delete, and
+	// range delete commands.
+  //
+  // On success, this timestamp will also be stored in the
+  // OriginTimestamp field of the the MVCCValueHeader for the newly
+  // written value.
+  //
+  // In LDR, the OriginTimestamp is the MVCC version timestamp of the row on the
+  // source cluster and the semantics leads to idempotent last-write-wins
+  // semantics against the "original" MVCC timestamp of the value on the
+  // destination, which is its MVCC timestamp or, if set, the OriginTimestamp
+  // (reflecting that this value originated from the source cluster).
   util.hlc.Timestamp origin_timestamp = 2 [(gogoproto.nullable) = false];
 }
 

--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -410,11 +410,13 @@ func (v *optionalValue) ToPointer() *roachpb.Value {
 	return &cpy
 }
 
-func (v *optionalValue) isOriginTimestampWinner(
-	proposedTS hlc.Timestamp, inclusive bool,
-) (bool, hlc.Timestamp) {
+func (v *optionalValue) checkOriginTimestamp(originTimestamp hlc.Timestamp) error {
 	if !v.exists {
-		return true, hlc.Timestamp{}
+		return nil
+	}
+
+	if !originTimestamp.IsSet() {
+		return nil
 	}
 
 	existTS := v.Value.Timestamp
@@ -422,7 +424,33 @@ func (v *optionalValue) isOriginTimestampWinner(
 		existTS = v.MVCCValueHeader.OriginTimestamp
 	}
 
-	return existTS.Less(proposedTS) || (inclusive && existTS.Equal(proposedTS)), existTS
+	// TODO(jeffswenson): add support for handling ties. The KV LDR writer
+	// originally had a ShouldWinOriginTimestampTie field, but it was removed
+	// due to an issue with replays. ShouldWinOriginTimestampTie was set
+	// unconditionally if the replicating cluster had a larger origin cluster
+	// id.
+	//
+	// There are two problems with this:
+	// 1. When replaying replicated writes, the replicated writes will win LWW
+	// vs themselves, which is undesirable because it writes duplicate KVs which
+	// is slow and wastes storage until the duplicate KVs are cleaned up by GC.
+	// 2. It doesn't implement semantics correctly in the case of three way
+	// replication.
+	//
+	// For now, LDR is going to ignore the possibility of ties. A tie will only
+	// occur if there are racing updates to the same row in two different
+	// clusters at the same nanosecond.
+	//
+	// The proper fix for this is to pass the source cluster and local cluster
+	// id to checkOriginTimestamp. That lets us correctly implement cross
+	// cluster ties while allowing a replicated write to lose ties against
+	// itself.
+	if originTimestamp.LessEq(existTS) {
+		return &kvpb.ConditionFailedError{
+			OriginTimestampOlderThan: existTS,
+		}
+	}
+	return nil
 }
 
 // isSysLocal returns whether the key is system-local.
@@ -1927,6 +1955,7 @@ func MVCCPut(
 	// key we can utilize a blind put to avoid reading any existing value.
 	var iter MVCCIterator
 	var ltScanner *lockTableKeyScanner
+	var valueFn func(existVal optionalValue) (roachpb.Value, error)
 	blind := opts.Stats == nil && timestamp.IsEmpty()
 	if !blind {
 		var err error
@@ -1952,8 +1981,16 @@ func MVCCPut(
 			}
 			defer ltScanner.close()
 		}
+		if !opts.OriginTimestamp.IsEmpty() {
+			valueFn = func(existVal optionalValue) (roachpb.Value, error) {
+				if err := existVal.checkOriginTimestamp(opts.OriginTimestamp); err != nil {
+					return roachpb.Value{}, err
+				}
+				return value, nil
+			}
+		}
 	}
-	return mvccPutUsingIter(ctx, rw, iter, ltScanner, key, timestamp, value, nil, opts)
+	return mvccPutUsingIter(ctx, rw, iter, ltScanner, key, timestamp, value, valueFn, opts)
 }
 
 // MVCCBlindPut is a fast-path of MVCCPut. See the MVCCPut comments for details
@@ -2019,9 +2056,18 @@ func MVCCDelete(
 	buf := newPutBuffer()
 	defer buf.release()
 
+	var valueFn func(existVal optionalValue) (roachpb.Value, error)
+	if !opts.OriginTimestamp.IsEmpty() {
+		valueFn = func(existVal optionalValue) (roachpb.Value, error) {
+			if err := existVal.checkOriginTimestamp(opts.OriginTimestamp); err != nil {
+				return roachpb.Value{}, err
+			}
+			return noValue, nil
+		}
+	}
 	// TODO(yuzefovich): can we avoid the put if the key does not exist?
 	return mvccPutInternal(
-		ctx, rw, iter, ltScanner, key, timestamp, noValue, buf, nil, opts)
+		ctx, rw, iter, ltScanner, key, timestamp, noValue, buf, valueFn, opts)
 }
 
 var noValue = roachpb.Value{}
@@ -2893,12 +2939,6 @@ type ConditionalPutWriteOptions struct {
 	MVCCWriteOptions
 
 	AllowIfDoesNotExist CPutMissingBehavior
-	// OriginTimestamp, if set, indicates that the caller wants to put the
-	// value only if any existing key is older than this timestamp.
-	//
-	// See the comment on the OriginTimestamp field of
-	// kvpb.ConditionalPutRequest for more details.
-	OriginTimestamp hlc.Timestamp
 }
 
 // MVCCConditionalPut sets the value for a specified key only if the expected
@@ -3018,40 +3058,17 @@ func mvccConditionalPutUsingIter(
 		}
 	}
 
-	var valueFn func(existVal optionalValue) (roachpb.Value, error)
-	if opts.OriginTimestamp.IsEmpty() {
-		valueFn = func(actualValue optionalValue) (roachpb.Value, error) {
-			if err := maybeConditionFailedError(expBytes, actualValue, bool(opts.AllowIfDoesNotExist)); err != nil {
-				return roachpb.Value{}, err
-			}
-			return value, nil
+	valueFn := func(actualValue optionalValue) (roachpb.Value, error) {
+		if err := actualValue.checkOriginTimestamp(opts.OriginTimestamp); err != nil {
+			return roachpb.Value{}, err
 		}
-	} else {
-		valueFn = func(existVal optionalValue) (roachpb.Value, error) {
-			originTSWinner, existTS := existVal.isOriginTimestampWinner(opts.OriginTimestamp, false)
-			if !originTSWinner {
-				return roachpb.Value{}, &kvpb.ConditionFailedError{
-					OriginTimestampOlderThan: existTS,
-				}
-			}
-
-			// We are the OriginTimestamp comparison winner. We
-			// check the expected bytes because a mismatch implies
-			// that the caller may have produced other commands with
-			// outdated data.
-			if err := maybeConditionFailedError(expBytes, existVal, false); err != nil {
+		if err := maybeConditionFailedError(expBytes, actualValue, bool(opts.AllowIfDoesNotExist)); err != nil {
+			if !opts.OriginTimestamp.IsEmpty() {
 				err.HadNewerOriginTimestamp = true
-				return roachpb.Value{}, err
 			}
-			return value, nil
+			return roachpb.Value{}, err
 		}
-
-		// TODO(ssd): We set the OriginTimestamp on our write
-		// options to the originTimestamp passed to us. We
-		// don't assert they are the same yet because it is
-		// still unclear how exactly we want to manage this in
-		// the long run.
-		opts.MVCCWriteOptions.OriginTimestamp = opts.OriginTimestamp
+		return value, nil
 	}
 
 	return mvccPutUsingIter(ctx, writer, iter, ltScanner, key, timestamp, noValue, valueFn, opts.MVCCWriteOptions)
@@ -3773,11 +3790,21 @@ func MVCCDeleteRange(
 	buf := newPutBuffer()
 	defer buf.release()
 
+	var valueFn func(existVal optionalValue) (roachpb.Value, error)
+	if !opts.OriginTimestamp.IsEmpty() {
+		valueFn = func(existVal optionalValue) (roachpb.Value, error) {
+			if err := existVal.checkOriginTimestamp(opts.OriginTimestamp); err != nil {
+				return roachpb.Value{}, err
+			}
+			return noValue, nil
+		}
+	}
+
 	var keys []roachpb.Key
 	var acqs []roachpb.LockAcquisition
 	for i, kv := range res.KVs {
 		_, acq, err := mvccPutInternal(
-			ctx, rw, iter, ltScanner, kv.Key, timestamp, noValue, buf, nil, opts,
+			ctx, rw, iter, ltScanner, kv.Key, timestamp, noValue, buf, valueFn, opts,
 		)
 		if err != nil {
 			return nil, nil, 0, nil, err

--- a/pkg/storage/testdata/mvcc_histories/delete_range_with_origin_timestamps
+++ b/pkg/storage/testdata/mvcc_histories/delete_range_with_origin_timestamps
@@ -1,0 +1,46 @@
+run ok
+with v=abc
+  put k=a ts=1
+  put k=b ts=1
+  put k=c ts=3
+----
+>> at end:
+data: "a"/1.000000000,0 -> /BYTES/abc
+data: "b"/1.000000000,0 -> /BYTES/abc
+data: "c"/3.000000000,0 -> /BYTES/abc
+
+run error
+del_range k=c end=d ts=4 origin_ts=2
+----
+>> at end:
+data: "a"/1.000000000,0 -> /BYTES/abc
+data: "b"/1.000000000,0 -> /BYTES/abc
+data: "c"/3.000000000,0 -> /BYTES/abc
+error: (*kvpb.ConditionFailedError:) OriginTimestamp older than 3.000000000,0
+
+run ok
+del_range k=a end=c ts=5 origin_ts=2
+----
+del_range: "a"-"c" -> deleted 2 key(s)
+>> at end:
+data: "a"/5.000000000,0 -> {originTs=2.000000000,0}/<empty>
+data: "a"/1.000000000,0 -> /BYTES/abc
+data: "b"/5.000000000,0 -> {originTs=2.000000000,0}/<empty>
+data: "b"/1.000000000,0 -> /BYTES/abc
+data: "c"/3.000000000,0 -> /BYTES/abc
+
+# NOTE: there is a subtle behavior demonstrated by this test. Delete range does
+# not advance the origin ts if the key was already deleted. This is okay
+# because the SQL writer will issue a CPUT to update the origin timestamp
+# assigned to the primary key.
+run ok
+del_range k=a end=d ts=6 origin_ts=4
+----
+del_range: "a"-"d" -> deleted 1 key(s)
+>> at end:
+data: "a"/5.000000000,0 -> {originTs=2.000000000,0}/<empty>
+data: "a"/1.000000000,0 -> /BYTES/abc
+data: "b"/5.000000000,0 -> {originTs=2.000000000,0}/<empty>
+data: "b"/1.000000000,0 -> /BYTES/abc
+data: "c"/6.000000000,0 -> {originTs=4.000000000,0}/<empty>
+data: "c"/3.000000000,0 -> /BYTES/abc

--- a/pkg/storage/testdata/mvcc_histories/delete_with_origin_timestamp
+++ b/pkg/storage/testdata/mvcc_histories/delete_with_origin_timestamp
@@ -1,0 +1,43 @@
+run ok
+put k=a v=wow ts=3
+----
+>> at end:
+data: "a"/3.000000000,0 -> /BYTES/wow
+
+# deleting with a younger origin time should lose LWW
+run error
+del k=a ts=4 origin_ts=2
+----
+>> at end:
+data: "a"/3.000000000,0 -> /BYTES/wow
+error: (*kvpb.ConditionFailedError:) OriginTimestamp older than 3.000000000,0
+
+run ok
+del k=a ts=5 origin_ts=4
+----
+del: "a": found key true
+>> at end:
+data: "a"/5.000000000,0 -> {originTs=4.000000000,0}/<empty>
+data: "a"/3.000000000,0 -> /BYTES/wow
+
+# it should be possible to write over an existing tombstone with a newer origin
+# timestamp
+run ok
+del k=a ts=6 origin_ts=5
+----
+del: "a": found key false
+>> at end:
+data: "a"/6.000000000,0 -> {originTs=5.000000000,0}/<empty>
+data: "a"/5.000000000,0 -> {originTs=4.000000000,0}/<empty>
+data: "a"/3.000000000,0 -> /BYTES/wow
+
+# it is possible to write a tombstone for a value that does not exist locally
+run ok
+del k=notfound ts=7 origin_ts=5
+----
+del: "notfound": found key false
+>> at end:
+data: "a"/6.000000000,0 -> {originTs=5.000000000,0}/<empty>
+data: "a"/5.000000000,0 -> {originTs=4.000000000,0}/<empty>
+data: "a"/3.000000000,0 -> /BYTES/wow
+data: "notfound"/7.000000000,0 -> {originTs=5.000000000,0}/<empty>

--- a/pkg/storage/testdata/mvcc_histories/put_with_origin_timestamp
+++ b/pkg/storage/testdata/mvcc_histories/put_with_origin_timestamp
@@ -1,0 +1,20 @@
+run ok
+put k=a v=wow ts=3
+----
+>> at end:
+data: "a"/3.000000000,0 -> /BYTES/wow
+
+# put with a younger origin time should lose LWW
+run error
+put k=a v=wow ts=4 origin_ts=2
+----
+>> at end:
+data: "a"/3.000000000,0 -> /BYTES/wow
+error: (*kvpb.ConditionFailedError:) OriginTimestamp older than 3.000000000,0
+
+run ok
+put k=a v=wow ts=5 origin_ts=4
+----
+>> at end:
+data: "a"/5.000000000,0 -> {originTs=4.000000000,0}/BYTES/wow
+data: "a"/3.000000000,0 -> /BYTES/wow


### PR DESCRIPTION
The PR updates the implementation of put, cput, delete, and range delete
to return an error if a replicated write with an origin timestamp would
overwrite a value with a more recent origin or MVCC timestamp.

No explicit version checks are included. In a mixed-version environment,
a SQL writer running 25.1 and writing to a 25.2 KV server will encounter
"condition failed" errors if an insert would overwrite a tombstone and
retry the write until it is upgraded or the LDR PTS ages out. This is
acceptable, as LDR remains in preview and the SQL writer is neither the
default nor the recommended writer.

Release note: none
Epic: [CRDB-48647](https://cockroachlabs.atlassian.net/browse/CRDB-48647)