### PR TITLE
sql: fix TestListProfilerExecutionDetails

### DIFF
--- a/pkg/sql/jobs_profiler_execution_details_test.go
+++ b/pkg/sql/jobs_profiler_execution_details_test.go
@@ -399,7 +399,9 @@ func TestListProfilerExecutionDetails(t *testing.T) {
 			if s.DeploymentMode().IsExternal() {
 				expectedCount--
 			}
-			require.Len(t, files, expectedCount)
+			if len(files) != expectedCount {
+				return errors.Newf("expected %d files, got %d: %v", expectedCount, len(files), files)
+			}
 			return nil
 		})
 
@@ -418,7 +420,9 @@ func TestListProfilerExecutionDetails(t *testing.T) {
 			if s.DeploymentMode().IsExternal() {
 				expectedCount = 8
 			}
-			require.Len(t, files, expectedCount)
+			if len(files) != expectedCount {
+				return errors.Newf("expected %d files, got %d: %v", expectedCount, len(files), files)
+			}
 			return nil
 		})
 		patterns = []string{


### PR DESCRIPTION
In #142391, a bug was introduced in the test where `testutils.SucceedSoon`'s closure used `require.Len` instead of returning an error, causing the test to fail if slice length doesn't match without retrying. This assertion has been reverted to the `if` statement that returns an error instead.

Fixes: #143082
Release note: none
Epic: none