### PR TITLE
sql: remove `createTestServerParams`

### DIFF
--- a/pkg/sql/index_mutation_test.go
+++ b/pkg/sql/index_mutation_test.go
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
@@ -35,7 +36,8 @@ func TestIndexMutationKVOps(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
 
-	params, _ := createTestServerParams()
+	params, _ := createTestServerParamsAllowTenants()
+	params.DefaultTestTenant = base.TestDoesNotWorkWithSecondaryTenantsButWeDontKnowWhyYet(143114)
 	// Decrease the adopt loop interval so that retries happen quickly.
 	params.Knobs.JobsTestingKnobs = jobs.NewTestingKnobsWithShortIntervals()
 	params.Knobs.SQLEvalContext = &eval.TestingKnobs{

--- a/pkg/sql/server_params_test.go
+++ b/pkg/sql/server_params_test.go
@@ -17,6 +17,7 @@ import (
 // enables some EndTxn sanity checking and installs a flexible
 // TestingEvalFilter.
 // TODO(andrei): this function is not used consistently by SQL tests.
+// TODO(ssd,shubham): Rename this to `createTestServerParams`
 func createTestServerParamsAllowTenants() (base.TestServerArgs, *tests.CommandFilters) {
 	var cmdFilters tests.CommandFilters
 	params := base.TestServerArgs{}
@@ -27,17 +28,4 @@ func createTestServerParamsAllowTenants() (base.TestServerArgs, *tests.CommandFi
 		},
 	}
 	return params, &cmdFilters
-}
-
-// createTestServerParams creates a set of params suitable for SQL
-// tests with randomized tenant testing disabled. New tests should
-// prefer createTestServerParamsAllowTenants(). See
-// createTestServerParamsAllowTenants for additional details.
-//
-// TODO(ssd): Rename this and createTestServerParamsAllowTenants once
-// disabling tenant testing is less common than enabling it.
-func createTestServerParams() (base.TestServerArgs, *tests.CommandFilters) {
-	params, cmdFilters := createTestServerParamsAllowTenants()
-	params.DefaultTestTenant = base.TODOTestTenantDisabled
-	return params, cmdFilters
 }


### PR DESCRIPTION
The only remaining use of `createTestServerParams` was in `TestIndexMutationKVOps`, but that test is really something the SQL queries team better suited to handle. So, I swapped it out for `createTestServerParamsAllowTenants` and override `DefaultTestTenant` with an appropriate one (tracked in #143114).

Now that's taken care of, `createTestServerParams` is fully gone—one less way for test authors to accidentally skip running tests with tenants.

Next step: we should rename `createTestServerParamsAllowTenants` back to `createTestServerParams` to keep things tidy.

Closes: #140446
Epic: CRDB-48564
Release note: none