### PR TITLE
sql: enforce failure on NULLs in RLS WITH CHECK expressions

### DIFF
--- a/pkg/sql/catalog/table_elements.go
+++ b/pkg/sql/catalog/table_elements.go
@@ -564,6 +564,10 @@ type CheckConstraintValidator interface {
 	// IsRLSConstraint returns true iff ths check constraint is the synthethic one
 	// to enforce row-level security policies.
 	IsRLSConstraint() bool
+
+	// IsCheckFailed returns true if the constraint was violated based on the
+	// input given.
+	IsCheckFailed(boolVal, isNull bool) bool
 }
 
 // ForeignKeyConstraint is an interface around a check constraint.

--- a/pkg/sql/check.go
+++ b/pkg/sql/check.go
@@ -867,7 +867,7 @@ func checkMutationInput(
 
 		if res, err := tree.GetBool(checkVals[colIdx]); err != nil {
 			return err
-		} else if !res && checkVals[colIdx] != tree.DNull {
+		} else if checks[i].IsCheckFailed(res == tree.DBool(true), checkVals[colIdx] == tree.DNull) {
 			return row.CheckFailed(ctx, evalCtx, semaCtx, sessionData, tabDesc, checks[i])
 		}
 		colIdx++

--- a/pkg/sql/colexec/insert.go
+++ b/pkg/sql/colexec/insert.go
@@ -211,7 +211,7 @@ func (v *vectorInserter) checkMutationInput(ctx context.Context, b coldata.Batch
 		bools := vec.Bool()
 		nulls := vec.Nulls()
 		for r := 0; r < b.Length(); r++ {
-			if !bools[r] && !nulls.NullAt(r) {
+			if ch.IsCheckFailed(bools[r], nulls.NullAt(r)) {
 				return row.CheckFailed(ctx, v.flowCtx.EvalCtx, v.semaCtx, v.flowCtx.EvalCtx.SessionData(), v.desc, ch)
 			}
 		}

--- a/pkg/sql/logictest/testdata/logic_test/row_level_security
+++ b/pkg/sql/logictest/testdata/logic_test/row_level_security
@@ -1754,7 +1754,7 @@ GRANT ALL on rlsInsert TO buck;
 
 # Sanity that the admin can insert anything
 statement ok
-INSERT INTO rlsInsert VALUES (1, 'first', '2012-06-30');
+INSERT INTO rlsInsert VALUES (1, 'first', '2012-06-30'),(0, 'zero', NULL);
 
 statement ok
 SET ROLE buck;
@@ -1769,6 +1769,10 @@ INSERT INTO rlsInsert VALUES (3, 'third', '2012-07-08');
 # Violates policy because date is in 2012.
 statement error pq: new row violates row-level security policy for table "rlsinsert"
 INSERT INTO rlsInsert SELECT c1 + 5, c2, c3 FROM rlsInsert;
+
+# Violates policy because date is NULL
+statement error pq: new row violates row-level security policy for table "rlsinsert"
+INSERT INTO rlsInsert VALUES (4, 'four', NULL)
 
 statement ok
 INSERT INTO rlsInsert SELECT c1 + 5, c2, c3 FROM rlsInsert WHERE c3 not between '2012-01-01' and '2012-12-31';
@@ -1803,6 +1807,7 @@ INSERT INTO rlsInsert VALUES (4, 'fourth', '2022-10-08');
 query I
 select c1 from rlsInsert ORDER BY c1;
 ----
+0
 1
 2
 7


### PR DESCRIPTION
Previously, row-level security (RLS) WITH CHECK constraints treated NULL values similarly to standard CHECK constraints, allowing NULL results to pass. This behavior was inconsistent with postgres and introduced potential security loopholes.

This change ensures that NULL results cause the constraint to fail.

Closes #143125

Epic: CRDB-45203
Release note: none