### PR TITLE
backup: add panic log in restoreDataProcessor

### DIFF
--- a/pkg/backup/restore_data_processor.go
+++ b/pkg/backup/restore_data_processor.go
@@ -191,6 +191,14 @@ func (rd *restoreDataProcessor) Start(ctx context.Context) {
 
 	ctx, cancel := context.WithCancel(ctx)
 	rd.cancelWorkersAndWait = func() {
+		defer func() {
+			// A panic here will not have a useful stack trace. If the panic is an
+			// error that contains a stack trace, we want those full details.
+			// TODO(jeffswenson): improve panic recovery more generally.
+			if p := recover(); p != nil {
+				panic(fmt.Sprintf("restore worker hit panic: %+v", p))
+			}
+		}()
 		cancel()
 		_ = rd.phaseGroup.Wait()
 	}


### PR DESCRIPTION
A test is causing a panic being emitted by `Wait()`, but the original
stack trace of the panic does not show up in logs. Add a Fatalf that
should print the full details of the underlying panic.

Informs: #141606
Release note: None