### PR TITLE
release-25.1: crosscluster/physical: actually spin up reader tenant on failback

### DIFF
--- a/pkg/crosscluster/physical/standby_read_ts_poller_job_test.go
+++ b/pkg/crosscluster/physical/standby_read_ts_poller_job_test.go
@@ -12,21 +12,15 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/crosscluster/replicationtestutils"
 	"github.com/cockroachdb/cockroach/pkg/crosscluster/replicationutils"
-	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
-	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/jobutils"
-	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
-	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
-	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
@@ -57,31 +51,68 @@ func TestStandbyReadTSPollerJob(t *testing.T) {
 	require.NotNil(t, readerTenantID)
 
 	readerTenantName := fmt.Sprintf("%s-readonly", args.DestTenantName)
-	c.ConnectToReaderTenant(ctx, readerTenantID, readerTenantName, 0)
+	c.ConnectToReaderTenant(ctx, readerTenantID, readerTenantName)
 
-	c.SrcTenantSQL.Exec(t, `
+	defaultDBQuery := `
 USE defaultdb;
 CREATE TABLE a (i INT PRIMARY KEY);
 INSERT INTO a VALUES (1);
-`)
-	waitForPollerJobToStart(t, c, ingestionJobID)
-	observeValueInReaderTenant(t, c)
+`
+
+	c.SrcTenantSQL.Exec(t, defaultDBQuery)
+	waitForPollerJobToStartDest(t, c, ingestionJobID)
+	observeValueInReaderTenant(t, c.ReaderTenantSQL)
+
+	// Failback and setup stanby reader tenant on the og source.
+	{
+		c.Cutover(ctx, producerJobID, ingestionJobID, srcTime.GoTime(), false)
+		defer c.StartDestTenant(ctx, nil, 0)()
+
+		destPgURL, cleanupSinkCert := sqlutils.PGUrl(t, c.DestSysServer.AdvSQLAddr(), t.Name(), url.User(username.RootUser))
+		defer cleanupSinkCert()
+
+		c.SrcSysSQL.Exec(t, fmt.Sprintf("ALTER VIRTUAL CLUSTER '%s' STOP SERVICE", c.Args.SrcTenantName))
+		waitUntilTenantServerStopped(t, c.SrcSysServer, string(c.Args.SrcTenantName))
+
+		c.SrcSysSQL.Exec(c.T,
+			`ALTER TENANT $1 START REPLICATION OF $2 ON $3 WITH READ VIRTUAL CLUSTER`,
+			c.Args.SrcTenantName, c.Args.DestTenantName, destPgURL.String())
+
+		_, failbackJobID := replicationtestutils.GetStreamJobIds(t, ctx, c.SrcSysSQL, c.Args.SrcTenantName)
+		now := c.SrcCluster.Servers[0].Clock().Now()
+		replicationtestutils.WaitUntilReplicatedTime(c.T, now, c.SrcSysSQL, jobspb.JobID(failbackJobID))
+		stats := replicationutils.TestingGetStreamIngestionStatsFromReplicationJob(t, ctx, c.SrcSysSQL, failbackJobID)
+		srcReaderTenantID := stats.IngestionDetails.ReadTenantID
+		require.NotNil(t, srcReaderTenantID)
+
+		// We cutover the dest tenant to a time bfore we created table a, so lets
+		// created it again and observe it in the new reader tenant.
+		c.DestTenantSQL.Exec(t, defaultDBQuery)
+
+		srcReaderTenantName := fmt.Sprintf("%s-readonly", c.Args.SrcTenantName)
+		srcReaderSQL := sqlutils.MakeSQLRunner(replicationtestutils.SetupReaderTenant(ctx, t, srcReaderTenantID, srcReaderTenantName, c.SrcCluster, c.SrcSysSQL))
+		waitForPollerJobToStart(t, srcReaderSQL)
+
+		var numTables int
+		srcReaderSQL.QueryRow(t, `SELECT count(*) FROM [SHOW TABLES]`).Scan(&numTables)
+		observeValueInReaderTenant(t, srcReaderSQL)
+	}
 }
 
-func observeValueInReaderTenant(t *testing.T, c *replicationtestutils.TenantStreamingClusters) {
+func observeValueInReaderTenant(t *testing.T, readerSQL *sqlutils.SQLRunner) {
 	now := timeutil.Now()
 	// Verify that updates have been replicated to reader tenant. This may take a
 	// second as the historical timestamp these AOST queries run needs to advance.
 	testutils.SucceedsSoon(t, func() error {
 		var numTables int
-		c.ReaderTenantSQL.QueryRow(t, `SELECT count(*) FROM [SHOW TABLES]`).Scan(&numTables)
+		readerSQL.QueryRow(t, `SELECT count(*) FROM [SHOW TABLES]`).Scan(&numTables)
 
 		if numTables != 1 {
 			return errors.Errorf("expected 1 table to be present in reader tenant, but got %d instead", numTables)
 		}
 
 		var actualQueryResult int
-		c.ReaderTenantSQL.QueryRow(t, `SELECT * FROM a`).Scan(&actualQueryResult)
+		readerSQL.QueryRow(t, `SELECT * FROM a`).Scan(&actualQueryResult)
 		if actualQueryResult != 1 {
 			return errors.Newf("expected %d to be replicated to table {a} in reader tenant, received %d instead",
 				1, actualQueryResult)
@@ -91,7 +122,7 @@ func observeValueInReaderTenant(t *testing.T, c *replicationtestutils.TenantStre
 	t.Logf("waited for %s for updates to reflect in reader tenant", timeutil.Since(now))
 }
 
-func waitForPollerJobToStart(
+func waitForPollerJobToStartDest(
 	t *testing.T, c *replicationtestutils.TenantStreamingClusters, ingestionJobID int,
 ) {
 	// TODO(annezhu): we really should be waiting for the AOST timestamp on the
@@ -101,9 +132,13 @@ func waitForPollerJobToStart(
 	srcTime := c.SrcCluster.Server(0).Clock().Now()
 	c.WaitUntilReplicatedTime(srcTime, jobspb.JobID(ingestionJobID))
 
+	waitForPollerJobToStart(t, c.ReaderTenantSQL)
+}
+
+func waitForPollerJobToStart(t *testing.T, readerSQL *sqlutils.SQLRunner) {
 	testutils.SucceedsSoon(t, func() error {
 		var numJobs int
-		c.ReaderTenantSQL.QueryRow(t, `
+		readerSQL.QueryRow(t, `
 SELECT count(*)
 FROM crdb_internal.jobs 
 WHERE job_type = 'STANDBY READ TS POLLER';
@@ -115,126 +150,12 @@ WHERE job_type = 'STANDBY READ TS POLLER';
 		return nil
 	})
 	var jobID jobspb.JobID
-	c.ReaderTenantSQL.QueryRow(t, `
+	readerSQL.QueryRow(t, `
 SELECT job_id
 FROM crdb_internal.jobs 
 WHERE job_type = 'STANDBY READ TS POLLER'
 `).Scan(&jobID)
-	jobutils.WaitForJobToRun(t, c.ReaderTenantSQL, jobID)
-}
-
-func TestFastFailbackWithReaderTenant(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
-	ctx := context.Background()
-
-	skip.UnderRace(t, "test takes ~5 minutes under race")
-
-	serverA, aDB, _ := serverutils.StartServer(t, base.TestServerArgs{
-		DefaultTestTenant: base.TestControlsTenantsExplicitly,
-		Knobs: base.TestingKnobs{
-			JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
-		},
-	})
-	defer serverA.Stopper().Stop(ctx)
-	serverB, bDB, _ := serverutils.StartServer(t, base.TestServerArgs{
-		DefaultTestTenant: base.TestControlsTenantsExplicitly,
-		Knobs: base.TestingKnobs{
-			JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
-		},
-	})
-	defer serverB.Stopper().Stop(ctx)
-
-	sqlA := sqlutils.MakeSQLRunner(aDB)
-	sqlB := sqlutils.MakeSQLRunner(bDB)
-
-	serverAURL, cleanupURLA := sqlutils.PGUrl(t, serverA.SQLAddr(), t.Name(), url.User(username.RootUser))
-	defer cleanupURLA()
-	serverBURL, cleanupURLB := sqlutils.PGUrl(t, serverB.SQLAddr(), t.Name(), url.User(username.RootUser))
-	defer cleanupURLB()
-
-	for _, s := range []string{
-		"SET CLUSTER SETTING kv.rangefeed.enabled = true",
-		"SET CLUSTER SETTING kv.rangefeed.closed_timestamp_refresh_interval = '200ms'",
-		"SET CLUSTER SETTING kv.closed_timestamp.target_duration = '100ms'",
-		"SET CLUSTER SETTING kv.closed_timestamp.side_transport_interval = '50ms'",
-
-		"SET CLUSTER SETTING physical_replication.consumer.heartbeat_frequency = '1s'",
-		"SET CLUSTER SETTING physical_replication.consumer.job_checkpoint_frequency = '100ms'",
-		"SET CLUSTER SETTING physical_replication.consumer.minimum_flush_interval = '10ms'",
-		"SET CLUSTER SETTING physical_replication.consumer.failover_signal_poll_interval = '100ms'",
-		"SET CLUSTER SETTING spanconfig.reconciliation_job.checkpoint_interval = '100ms'",
-	} {
-		sqlA.Exec(t, s)
-		sqlB.Exec(t, s)
-	}
-
-	t.Logf("creating tenant f")
-	sqlA.Exec(t, "CREATE VIRTUAL CLUSTER f")
-	sqlA.Exec(t, "ALTER VIRTUAL CLUSTER f START SERVICE SHARED")
-
-	t.Logf("starting replication f->g")
-	sqlB.Exec(t, "CREATE VIRTUAL CLUSTER g FROM REPLICATION OF f ON $1 WITH READ VIRTUAL CLUSTER", serverAURL.String())
-
-	// Verify that reader tenant has been created for g
-	waitForReaderTenant(t, sqlB, "g-readonly")
-
-	// FAILOVER
-	_, consumerGJobID := replicationtestutils.GetStreamJobIds(t, ctx, sqlB, roachpb.TenantName("g"))
-	var ts1 string
-	sqlA.QueryRow(t, "SELECT cluster_logical_timestamp()").Scan(&ts1)
-
-	rng, _ := randutil.NewPseudoRand()
-	if rng.Intn(2) == 0 {
-		t.Logf("waiting for g@%s", ts1)
-		replicationtestutils.WaitUntilReplicatedTime(t,
-			replicationtestutils.DecimalTimeToHLC(t, ts1),
-			sqlB,
-			jobspb.JobID(consumerGJobID))
-
-		t.Logf("completing replication on g@%s", ts1)
-		sqlB.Exec(t, fmt.Sprintf("ALTER VIRTUAL CLUSTER g COMPLETE REPLICATION TO SYSTEM TIME '%s'", ts1))
-	} else {
-		t.Log("waiting for initial scan on g")
-		replicationtestutils.WaitUntilStartTimeReached(t, sqlB, jobspb.JobID(consumerGJobID))
-		t.Log("completing replication on g to latest")
-		sqlB.Exec(t, "ALTER VIRTUAL CLUSTER g COMPLETE REPLICATION TO LATEST")
-	}
-	jobutils.WaitForJobToSucceed(t, sqlB, jobspb.JobID(consumerGJobID))
-
-	sqlB.Exec(t, "ALTER VIRTUAL CLUSTER g START SERVICE SHARED")
-	var ts2 string
-	sqlA.QueryRow(t, "SELECT cluster_logical_timestamp()").Scan(&ts2)
-
-	sqlA.Exec(t, "ALTER VIRTUAL CLUSTER f STOP SERVICE")
-	waitUntilTenantServerStopped(t, serverA.SystemLayer(), "f")
-	t.Logf("starting replication g->f")
-	sqlA.Exec(t, "ALTER VIRTUAL CLUSTER f START REPLICATION OF g ON $1 WITH READ VIRTUAL CLUSTER", serverBURL.String())
-	_, consumerFJobID := replicationtestutils.GetStreamJobIds(t, ctx, sqlA, roachpb.TenantName("f"))
-	t.Logf("waiting for f@%s", ts2)
-	replicationtestutils.WaitUntilReplicatedTime(t,
-		replicationtestutils.DecimalTimeToHLC(t, ts2),
-		sqlA,
-		jobspb.JobID(consumerFJobID))
-
-	// Verify that reader tenant has been created for f
-	waitForReaderTenant(t, sqlA, "f-readonly")
-}
-
-func waitForReaderTenant(t *testing.T, db *sqlutils.SQLRunner, tenantName string) {
-	testutils.SucceedsSoon(t, func() error {
-		var numTenants int
-		db.QueryRow(t, `
-SELECT count(*)
-FROM system.tenants
-WHERE name = $1
-`, tenantName).Scan(&numTenants)
-
-		if numTenants != 1 {
-			return errors.Errorf("expected 1 tenant, got %d", numTenants)
-		}
-		return nil
-	})
+	jobutils.WaitForJobToRun(t, readerSQL, jobID)
 }
 
 func TestReaderTenantCutover(t *testing.T) {
@@ -261,7 +182,7 @@ func TestReaderTenantCutover(t *testing.T) {
 		require.NotNil(t, readerTenantID)
 
 		readerTenantName := fmt.Sprintf("%s-readonly", args.DestTenantName)
-		c.ConnectToReaderTenant(ctx, readerTenantID, readerTenantName, 0)
+		c.ConnectToReaderTenant(ctx, readerTenantID, readerTenantName)
 
 		c.SrcTenantSQL.Exec(t, `
 USE defaultdb;
@@ -269,12 +190,12 @@ CREATE TABLE a (i INT PRIMARY KEY);
 INSERT INTO a VALUES (1);
 `)
 
-		waitForPollerJobToStart(t, c, ingestionJobID)
+		waitForPollerJobToStartDest(t, c, ingestionJobID)
 		if cutoverToLatest {
-			observeValueInReaderTenant(t, c)
+			observeValueInReaderTenant(t, c.ReaderTenantSQL)
 			c.Cutover(ctx, producerJobID, ingestionJobID, time.Time{}, false)
 			jobutils.WaitForJobToSucceed(t, c.DestSysSQL, jobspb.JobID(ingestionJobID))
-			observeValueInReaderTenant(t, c)
+			observeValueInReaderTenant(t, c.ReaderTenantSQL)
 		} else {
 			c.Cutover(ctx, producerJobID, ingestionJobID, c.SrcCluster.Server(0).Clock().Now().GoTime(), false)
 			waitToRemoveTenant(t, c.DestSysSQL, readerTenantName)

--- a/pkg/crosscluster/physical/stream_ingestion_frontier_processor.go
+++ b/pkg/crosscluster/physical/stream_ingestion_frontier_processor.go
@@ -73,6 +73,8 @@ type streamIngestionFrontier struct {
 	// source cluster can begin garbage collection.
 	heartbeatTime hlc.Timestamp
 
+	readerTenantActivated bool
+
 	lastPartitionUpdate time.Time
 	lastFrontierDump    time.Time
 
@@ -360,14 +362,20 @@ func (sf *streamIngestionFrontier) maybeUpdateProgress() error {
 			return errors.AssertionFailedf("expected replication job to have a protected timestamp " +
 				"record over the destination tenant's keyspan")
 		}
-		// Only set up the reader tenant once during PCR: when PCR finishes the initial
-		// scan and persists a replicated time for the first time.
-		if replicationDetails.ReadTenantID.IsSet() && sf.replicatedTimeAtStart.IsEmpty() && replicatedTime.IsSet() {
+		// Attempt to activate the reader tenant on the first persisted update of
+		// the flow. If the reader tenant is already active, this will be a no-op.
+		//
+		// NB: we do not have enough persisted state to read the tenant key space
+		// only once during the whole replication stream process, so instead, we
+		// check once per flow.
+		firstProgressOfFlow := sf.replicatedTimeAtStart.Less(replicatedTime)
+		if replicationDetails.ReadTenantID.IsSet() && firstProgressOfFlow && !sf.readerTenantActivated {
 			readerToActivate := replicationDetails.ReadTenantID
-			err := sf.activateReaderTenant(ctx, txn, readerToActivate)
+			err := sf.maybeActivateReaderTenant(ctx, txn, readerToActivate)
 			if err != nil {
 				return err
 			}
+			sf.readerTenantActivated = true
 		}
 
 		ptp := sf.FlowCtx.Cfg.ProtectedTimestampProvider.WithTxn(txn)
@@ -476,12 +484,15 @@ func (sf *streamIngestionFrontier) handleLaggingNodeError(ctx context.Context, e
 	}
 }
 
-func (sf *streamIngestionFrontier) activateReaderTenant(
+func (sf *streamIngestionFrontier) maybeActivateReaderTenant(
 	ctx context.Context, txn isql.Txn, readerToActivate roachpb.TenantID,
 ) error {
 	info, err := sql.GetTenantRecordByID(ctx, txn, readerToActivate, sf.FlowCtx.Cfg.Settings)
 	if err != nil {
 		return err
+	}
+	if info.DataState == mtinfopb.DataStateReady {
+		return nil
 	}
 
 	info.DataState = mtinfopb.DataStateReady

--- a/pkg/crosscluster/replicationtestutils/testutils.go
+++ b/pkg/crosscluster/replicationtestutils/testutils.go
@@ -127,9 +127,7 @@ type TenantStreamingClusters struct {
 	DestTenantConn *gosql.DB
 	DestTenantSQL  *sqlutils.SQLRunner
 
-	ReaderTenantServer serverutils.ApplicationLayerInterface
-	ReaderTenantConn   *gosql.DB
-	ReaderTenantSQL    *sqlutils.SQLRunner
+	ReaderTenantSQL *sqlutils.SQLRunner
 
 	Rng *rand.Rand
 }
@@ -206,30 +204,41 @@ func (c *TenantStreamingClusters) StartDestTenant(
 	}
 }
 
-// ConnectToReaderTenant should be invoked when a PCR job has reader tenant enabled
-// and is in running state to open a connection to the standby reader tenant.
-func (c *TenantStreamingClusters) ConnectToReaderTenant(
-	ctx context.Context, tenantID roachpb.TenantID, tenantName string, server int,
-) {
-	var err error
-	c.ReaderTenantServer, c.ReaderTenantConn, err = c.DestCluster.Server(server).TenantController().StartSharedProcessTenant(ctx, base.TestSharedProcessTenantArgs{
+func SetupReaderTenant(
+	ctx context.Context,
+	t *testing.T,
+	tenantID roachpb.TenantID,
+	tenantName string,
+	cluster *testcluster.TestCluster,
+	sysSQL *sqlutils.SQLRunner,
+) *gosql.DB {
+	_, _, err := cluster.Server(0).TenantController().StartSharedProcessTenant(ctx, base.TestSharedProcessTenantArgs{
 		TenantID:    tenantID,
 		TenantName:  roachpb.TenantName(tenantName),
 		UseDatabase: "defaultdb",
 	})
-	c.DestSysSQL.Exec(c.T, `ALTER TENANT $1 SET CLUSTER SETTING jobs.registry.interval.adopt = '1s'`, tenantName)
-	c.DestSysSQL.Exec(c.T, `ALTER TENANT $1 SET CLUSTER SETTING bulkio.stream_ingestion.standby_read_ts_poll_interval = '500ms'`, tenantName)
+	require.NoError(t, err)
+	sysSQL.Exec(t, `ALTER TENANT $1 SET CLUSTER SETTING jobs.registry.interval.adopt = '1s'`, tenantName)
+	sysSQL.Exec(t, `ALTER TENANT $1 SET CLUSTER SETTING bulkio.stream_ingestion.standby_read_ts_poll_interval = '500ms'`, tenantName)
 
 	// Attempt to keep the reader tenant's historical aost close to the present.
-	c.DestSysSQL.Exec(c.T, `ALTER TENANT $1 SET CLUSTER SETTING kv.closed_timestamp.target_duration = '100ms'`, tenantName)
-	c.DestSysSQL.Exec(c.T, `ALTER TENANT $1 SET CLUSTER SETTING kv.rangefeed.closed_timestamp_refresh_interval = '200ms'`, tenantName)
-	c.DestSysSQL.Exec(c.T, `ALTER TENANT $1 SET CLUSTER SETTING kv.closed_timestamp.side_transport_interval = '50ms'`, tenantName)
-
-	require.NoError(c.T, err)
-	c.ReaderTenantConn = c.DestCluster.Server(server).SystemLayer().SQLConn(c.T,
+	sysSQL.Exec(t, `ALTER TENANT $1 SET CLUSTER SETTING kv.closed_timestamp.target_duration = '100ms'`, tenantName)
+	sysSQL.Exec(t, `ALTER TENANT $1 SET CLUSTER SETTING kv.rangefeed.closed_timestamp_refresh_interval = '200ms'`, tenantName)
+	sysSQL.Exec(t, `ALTER TENANT $1 SET CLUSTER SETTING kv.closed_timestamp.side_transport_interval = '50ms'`, tenantName)
+	readerConn := cluster.Server(0).SystemLayer().SQLConn(t,
 		serverutils.DBName("cluster:"+tenantName+"/defaultdb"))
-	c.ReaderTenantSQL = sqlutils.MakeSQLRunner(c.ReaderTenantConn)
-	testutils.SucceedsSoon(c.T, func() error { return c.ReaderTenantConn.Ping() })
+	testutils.SucceedsSoon(t, func() error { return readerConn.Ping() })
+	return readerConn
+}
+
+// ConnectToReaderTenant should be invoked when a PCR job has reader tenant enabled
+// and is in running state to open a connection to the standby reader tenant.
+func (c *TenantStreamingClusters) ConnectToReaderTenant(
+	ctx context.Context, tenantID roachpb.TenantID, tenantName string,
+) {
+	readerConn := SetupReaderTenant(ctx, c.T, tenantID, tenantName, c.DestCluster, c.DestSysSQL)
+	c.ReaderTenantSQL = sqlutils.MakeSQLRunner(readerConn)
+
 }
 
 // CompareResult compares the results of query on the primary and standby


### PR DESCRIPTION
Backport 1/1 commits from #143072.

/cc @cockroachdb/release

---

Previously, the stream ingestion frontier processor failed to activate the reader tenant on the first progress update if the replication stream began from a cursor. This patch fixes this bug.

Epic: none

Release note (bug fix): the reader virtual cluster now starts if the user begins a replication stream from a cursor via ALTER VIRTUAL CLUSTER foo START REPLICATION OF baz ON pgurl WITH READ VIRTUAL CLUSTER.

Release justification: low risk bug fix
