### PR TITLE
release-25.1: scbuild: clean up logic for finding temporary indexes

### DIFF
--- a/pkg/sql/schemachanger/scpb/elements.proto
+++ b/pkg/sql/schemachanger/scpb/elements.proto
@@ -301,7 +301,11 @@ message Index {
   // TODO(postamar): try to get rid of these altogether
   //  Perhaps move these to the target metadata instead?
   bool is_concurrently = 20;
+  // SourceIndexID refers back to the primary index for which a secondary index
+  // was created.
   uint32 source_index_id = 21 [(gogoproto.customname) = "SourceIndexID", (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/sql/sem/catid.IndexID"];
+  // TemporaryIndexID refers to the temporary index that was created while this
+  // index is being backfilled.
   uint32 temporary_index_id = 22 [(gogoproto.customname) = "TemporaryIndexID", (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/sql/sem/catid.IndexID"];
 
   cockroach.geo.geoindex.Config geo_config = 24 [(gogoproto.nullable) = true];


### PR DESCRIPTION
Backport 1/1 commits from #143089.

/cc @cockroachdb/release

Release justification: fixing a latent bug in an internal function

---

The previous logic assumed that a temporary index could be linked to its corresponding index that is getting backfilled by using the SourceIndexID field. However, that field always refers back to the primary index.  This meant that the function would work correctly for primary indexes, but not for secondary indexes.

There was no bug, since the function is currently only used for primary indexes. Since we want to start using it for secondary indexes too, we need this change.

While doing this, I added comments to the fields to clarify.

I plan to backport this to 25.1 for the purposes of keeping the code sync'd between branches, and since it's a contained change.

Epic: CRDB-31329
Release note: None
