### PR TITLE
sql/schemachanger: require table ownership for RLS DDL operations

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/row_level_security
+++ b/pkg/sql/logictest/testdata/logic_test/row_level_security
@@ -324,6 +324,9 @@ statement ok
 GRANT ALL ON db1.* to john;
 
 statement ok
+ALTER TABLE target OWNER TO john;
+
+statement ok
 GRANT SYSTEM MODIFYCLUSTERSETTING TO testuser;
 
 user testuser
@@ -1236,6 +1239,78 @@ DROP FUNCTION my_non_sec_definer_reader_function;
 statement ok
 DROP TABLE sensitive_data_table CASCADE;
 
+# Verify that you need to be the table owner to do any of the RLS DDLs
+subtest table_owner_and_rls_ddl
+
+statement ok
+CREATE USER tab_owner;
+
+statement ok
+CREATE USER nontab_owner;
+
+statement ok
+CREATE TABLE table_owner_test ();
+
+statement ok
+ALTER TABLE table_owner_test OWNER TO tab_owner;
+
+statement ok
+GRANT ALL ON table_owner_test TO nontab_owner;
+
+statement ok
+SET ROLE tab_owner;
+
+statement ok
+ALTER TABLE table_owner_test ENABLE ROW LEVEL SECURITY, FORCE ROW LEVEL SECURITY;
+
+statement ok
+CREATE POLICY p1 on table_owner_test;
+
+statement ok
+DROP POLICY p1 on table_owner_test;
+
+statement ok
+CREATE POLICY new_p1 on table_owner_test;
+
+statement error pq: unimplemented: ALTER POLICY is not yet implemented
+ALTER POLICY new_p1 on table_owner_test RENAME TO p1;
+
+statement error pq: unimplemented: ALTER POLICY is not yet implemented
+ALTER POLICY p1 on table_owner_test RENAME TO new_p1;
+
+statement error pq: unimplemented: ALTER POLICY is not yet implemented
+ALTER POLICY p1 on table_owner_test USING (true);
+
+statement ok
+SET ROLE nontab_owner;
+
+statement error pq: must be owner of relation table_owner_test
+ALTER TABLE table_owner_test DISABLE ROW LEVEL SECURITY;
+
+statement error pq: must be owner of relation table_owner_test
+ALTER TABLE table_owner_test NO FORCE ROW LEVEL SECURITY;
+
+statement error pq: must be owner of relation table_owner_test
+CREATE POLICY p2 on table_owner_test;
+
+statement error pq: must be owner of relation table_owner_test
+DROP POLICY new_p1 on table_owner_test;
+
+statement error pq: unimplemented: ALTER POLICY is not yet implemented
+ALTER POLICY new_p1 on table_owner_test WITH CHECK (true);
+
+statement error pq: unimplemented: ALTER POLICY is not yet implemented
+ALTER POLICY new_p1 on table_owner_test RENAME TO p1;
+
+statement ok
+SET ROLE root
+
+statement ok
+DROP TABLE table_owner_test;
+
+statement ok
+DROP ROLE nontab_owner, tab_owner;
+
 subtest force
 
 statement ok
@@ -1366,9 +1441,15 @@ SELECT c1, c2 FROM force_check WHERE c1 > 0 ORDER BY c1;
 ----
 50 fifty
 
+statement ok
+SET ROLE root;
+
 # Turn on force again, but it shouldn't matter because we aren't the owner anymore
 statement ok
 ALTER TABLE force_check FORCE ROW LEVEL SECURITY;
+
+statement ok
+SET ROLE forcer;
 
 # q2 - should not reuse because table version change
 query IT

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_set_rls_mode.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_set_rls_mode.go
@@ -19,6 +19,13 @@ func alterTableSetRLSMode(
 ) {
 	failIfRLSIsNotEnabled(b)
 
+	// The table is already known to exist, and we would have checked for
+	// the CREATE privilege. However, changing the RLS mode is different,
+	// as it can only be done by the table owner.
+	_ = b.ResolveTable(tn.ToUnresolvedObjectName(), ResolveParams{
+		RequireOwnership: true,
+	})
+
 	switch n.Mode {
 	case tree.TableRLSEnable:
 		b.Add(&scpb.RowLevelSecurityEnabled{

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/create_policy.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/create_policy.go
@@ -31,7 +31,7 @@ func CreatePolicy(b BuildCtx, n *tree.CreatePolicy) {
 	b.IncrementSchemaChangeCreateCounter("policy")
 
 	tableElems := b.ResolveTable(n.TableName, ResolveParams{
-		RequiredPrivilege: privilege.CREATE,
+		RequireOwnership: true,
 	})
 	panicIfSchemaChangeIsDisallowed(tableElems, n)
 	tbl := tableElems.FilterTable().MustGetOneElement()


### PR DESCRIPTION
Previously, executing row-level security (RLS) DDL statements (e.g., CREATE POLICY, DROP POLICY) required only the CREATE privilege. This change updates the requirement so that only the table owner can perform these operations, aligning with postgres' behaviour.

Closes #143080

Epic: CRDB-45203
Release note: none