### PR TITLE
tree: change routine overload resolution to use Oids

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/drop_function
+++ b/pkg/sql/logictest/testdata/logic_test/drop_function
@@ -397,3 +397,11 @@ CREATE FUNCTION f_bit(c BIT(0)) RETURNS INT LANGUAGE SQL AS 'SELECT 1'
 
 statement ok
 DROP FUNCTION f_bit(BIT(2))
+
+# Regression test for #142886 - we should be able to drop a function by
+# specifying the input type but without type width.
+statement ok
+CREATE FUNCTION f142886(p VARCHAR(10)) RETURNS INT LANGUAGE SQL AS $$ SELECT 0; $$;
+
+statement ok
+DROP FUNCTION f142886(VARCHAR);

--- a/pkg/sql/logictest/testdata/logic_test/drop_procedure
+++ b/pkg/sql/logictest/testdata/logic_test/drop_procedure
@@ -193,3 +193,11 @@ statement ok
 DROP PROCEDURE p114677(t114677);
 
 subtest end
+
+# Regression test for #142886 - we should be able to drop a procedure by
+# specifying the input type but without type width.
+statement ok
+CREATE PROCEDURE p142886(p VARCHAR(10)) LANGUAGE SQL AS $$ SELECT 0; $$;
+
+statement ok
+DROP PROCEDURE p142886(VARCHAR);

--- a/pkg/sql/logictest/testdata/logic_test/procedure
+++ b/pkg/sql/logictest/testdata/logic_test/procedure
@@ -543,3 +543,14 @@ CALL withdraw(17, 100.0, NULL);
 statement ok
 DROP PROCEDURE withdraw;
 DROP TABLE bank;
+
+# Regression test for #142886 - we should not be able to create an overload that
+# differs only in the type width of the input type.
+statement ok
+CREATE PROCEDURE p142886(p VARCHAR(10)) LANGUAGE SQL AS $$ SELECT 0; $$;
+
+statement error pgcode 42723 function "p142886" already exists with same argument types
+CREATE PROCEDURE p142886(p VARCHAR(100)) LANGUAGE SQL AS $$ SELECT 0; $$;
+
+statement ok
+DROP PROCEDURE p142886;

--- a/pkg/sql/logictest/testdata/logic_test/udf
+++ b/pkg/sql/logictest/testdata/logic_test/udf
@@ -1004,3 +1004,14 @@ PREPARE p AS SELECT f($1::REGCLASS::INT)
 
 statement ok
 EXECUTE p(10)
+
+# Regression test for #142886 - we should not be able to create an overload that
+# differs only in the type width of the input type.
+statement ok
+CREATE FUNCTION f142886(p VARCHAR(10)) RETURNS INT LANGUAGE SQL AS $$ SELECT 0; $$;
+
+statement error pgcode 42723 function "f142886" already exists with same argument types
+CREATE FUNCTION f142886(p VARCHAR(100)) RETURNS INT LANGUAGE SQL AS $$ SELECT 0; $$;
+
+statement ok
+DROP FUNCTION f142886;

--- a/pkg/sql/sem/tree/function_definition.go
+++ b/pkg/sql/sem/tree/function_definition.go
@@ -336,7 +336,7 @@ func (fd *ResolvedFunctionDefinition) MatchOverload(
 		//
 		// First, apply regular postgres resolution approach of using only
 		// the input types.
-		if ol.params().MatchIdentical(paramTypes) {
+		if ol.params().MatchOid(paramTypes) {
 			return true
 		}
 		if tryDefaultExprs && len(ol.defaultExprs()) > 0 {
@@ -346,7 +346,7 @@ func (fd *ResolvedFunctionDefinition) MatchOverload(
 				numOmittedExprs := len(inputTypes) - len(paramTypes)
 				if numOmittedExprs > 0 && numOmittedExprs <= len(inputTypes) {
 					inputTypes = inputTypes[:len(inputTypes)-numOmittedExprs]
-					if inputTypes.MatchIdentical(paramTypes) {
+					if inputTypes.MatchOid(paramTypes) {
 						return true
 					}
 				}
@@ -373,7 +373,7 @@ func (fd *ResolvedFunctionDefinition) MatchOverload(
 				allParams[i] = ParamType{Typ: ol.Types.GetAt(i - outParamsSeen)}
 			}
 		}
-		match := allParams.MatchIdentical(allParamTypes)
+		match := allParams.MatchOid(allParamTypes)
 		if firstMatchParamTypes == nil && match {
 			firstMatchParamTypes = allParamTypes
 		}

--- a/pkg/sql/sem/tree/overload.go
+++ b/pkg/sql/sem/tree/overload.go
@@ -424,16 +424,16 @@ func GetParamsAndReturnType(impl overloadImpl) (TypeList, ReturnTyper) {
 type TypeList interface {
 	// Match checks if all types in the TypeList match the corresponding elements in types.
 	Match(types []*types.T) bool
-	// MatchIdentical is similar to match but checks that the types are identical matches,
-	// instead of equivalent matches. See types.T.Equivalent and types.T.Identical.
-	MatchIdentical(types []*types.T) bool
+	// MatchOid is similar to match but checks that the types have the same
+	// Oids, instead of being equivalent (in types.T.Equivalent sense) matches.
+	MatchOid(types []*types.T) bool
 	// MatchAt checks if the parameter type at index i of the TypeList matches type typ.
 	// In all implementations, types.Null will match with each parameter type, allowing
 	// NULL values to be used as arguments.
 	MatchAt(typ *types.T, i int) bool
-	// MatchAtIdentical is similar to MatchAt but checks that the type at index i of
-	// the Typelist is identical to typ.
-	MatchAtIdentical(typ *types.T, i int) bool
+	// MatchAtOid is similar to MatchAt but checks that the Oid of the type at
+	// index i of the Typelist is the same as the Oid of typ.
+	MatchAtOid(typ *types.T, i int) bool
 	// MatchLen checks that the TypeList can support l parameters.
 	MatchLen(l int) bool
 	// GetAt returns the type at the given index in the TypeList, or nil if the TypeList
@@ -474,12 +474,12 @@ func (p ParamTypes) Match(types []*types.T) bool {
 }
 
 // MatchIdentical is part of the TypeList interface.
-func (p ParamTypes) MatchIdentical(types []*types.T) bool {
+func (p ParamTypes) MatchOid(types []*types.T) bool {
 	if len(types) != len(p) {
 		return false
 	}
 	for i := range types {
-		if !p.MatchAtIdentical(types[i], i) {
+		if !p.MatchAtOid(types[i], i) {
 			return false
 		}
 	}
@@ -500,15 +500,8 @@ func (p ParamTypes) MatchAt(typ *types.T, i int) bool {
 }
 
 // MatchAtIdentical is part of the TypeList interface.
-func (p ParamTypes) MatchAtIdentical(typ *types.T, i int) bool {
-	return i < len(p) && (typ.Family() == types.UnknownFamily ||
-		p[i].Typ.Identical(typ) ||
-		// Special case for CHAR, CHAR(N), and BPCHAR which are not "identical"
-		// but have the same OID. See #129007.
-		(p[i].Typ.Oid() == oid.T_bpchar && typ.Oid() == oid.T_bpchar) ||
-		// Special case for BIT, BIT(N), and BIT(0) which are not "identical"
-		// but have the same OID. See #132944.
-		(p[i].Typ.Oid() == oid.T_bit && typ.Oid() == oid.T_bit))
+func (p ParamTypes) MatchAtOid(typ *types.T, i int) bool {
+	return i < len(p) && (typ.Family() == types.UnknownFamily || p[i].Typ.Oid() == typ.Oid())
 }
 
 // MatchLen is part of the TypeList interface.
@@ -580,7 +573,7 @@ func (HomogeneousType) Match(types []*types.T) bool {
 }
 
 // MatchIdentical is part of the TypeList interface.
-func (HomogeneousType) MatchIdentical(types []*types.T) bool {
+func (HomogeneousType) MatchOid(types []*types.T) bool {
 	return true
 }
 
@@ -590,7 +583,7 @@ func (HomogeneousType) MatchAt(typ *types.T, i int) bool {
 }
 
 // MatchAtIdentical is part of the TypeList interface.
-func (HomogeneousType) MatchAtIdentical(typ *types.T, i int) bool {
+func (HomogeneousType) MatchAtOid(typ *types.T, i int) bool {
 	return true
 }
 
@@ -637,7 +630,7 @@ func (v VariadicType) Match(types []*types.T) bool {
 }
 
 // MatchIdentical is part of the TypeList interface.
-func (VariadicType) MatchIdentical(types []*types.T) bool {
+func (VariadicType) MatchOid(types []*types.T) bool {
 	return true
 }
 
@@ -651,7 +644,7 @@ func (v VariadicType) MatchAt(typ *types.T, i int) bool {
 
 // MatchAtIdentical is part of the TypeList interface.
 // TODO(mgartner): This will be incorrect once we add support for variadic UDFs
-func (VariadicType) MatchAtIdentical(typ *types.T, i int) bool {
+func (VariadicType) MatchAtOid(typ *types.T, i int) bool {
 	return true
 }
 

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -3522,7 +3522,7 @@ func getMostSignificantOverload(
 		for k, idx := range oImpls {
 			candidate := overloads[idx]
 			srcParams := candidate.params()
-			matches := srcParams.MatchIdentical(allArgTypes)
+			matches := srcParams.MatchOid(allArgTypes)
 			if !matches {
 				routineType, outParamOrdinals, _ := candidate.outParamInfo()
 				defaultExprs := candidate.defaultExprs()
@@ -3565,7 +3565,7 @@ func getMostSignificantOverload(
 						ovInputTypes = ovInputTypes[:len(ovInputTypes)-numOmittedExprs]
 					}
 				}
-				matches = ovInputTypes.MatchIdentical(inputTypes)
+				matches = ovInputTypes.MatchOid(inputTypes)
 			}
 			if matches {
 				if foundMatch {


### PR DESCRIPTION
This commit attempts to bring overload resolution closer to how postgres behaves. Previously, we used `types.T.Identical` when matching type signatures, and this commit switches to comparing Oids instead.

Fixes: #142886.

Release note (bug fix): CockroachDB could previously perform the routine overload resolution incorrectly in some cases and this is now fixed. E.g., it allowed creation of two routines where signatures only differed in the type width (i.e. `f(p VARCHAR(1))` and `f(p VARCHAR(2))` would be allowed which is not allowed in PG) - this in turn would require a precise type cast when invoking it. Relatedly, when dropping a routine we previously required precise types too unlike PG which is more lenient (in the example above `DROP FUNCTION f(VARCHAR)` previously wouldn't have worked). The bug has been present since 23.1 version.