### PR TITLE
privchecker: remove no longer used method

### DIFF
--- a/pkg/server/privchecker/api.go
+++ b/pkg/server/privchecker/api.go
@@ -40,7 +40,6 @@ type CheckerForRPCHandlers interface {
 	RequireViewActivityPermission(ctx context.Context) error
 
 	RequireViewActivityOrViewActivityRedactedPermission(ctx context.Context) error
-	RequireViewClusterSettingOrModifyClusterSettingPermission(ctx context.Context) error
 	RequireViewActivityAndNoViewActivityRedactedPermission(ctx context.Context) error
 	RequireViewClusterMetadataPermission(ctx context.Context) error
 	RequireRepairClusterPermission(ctx context.Context) error

--- a/pkg/server/privchecker/privchecker.go
+++ b/pkg/server/privchecker/privchecker.go
@@ -88,36 +88,6 @@ func (c *adminPrivilegeChecker) RequireViewActivityOrViewActivityRedactedPermiss
 		roleoption.VIEWACTIVITY, roleoption.VIEWACTIVITYREDACTED)
 }
 
-// RequireViewClusterSettingOrModifyClusterSettingPermission's error return is a gRPC error.
-func (c *adminPrivilegeChecker) RequireViewClusterSettingOrModifyClusterSettingPermission(
-	ctx context.Context,
-) (err error) {
-	userName, isAdmin, err := c.GetUserAndRole(ctx)
-	if err != nil {
-		return srverrors.ServerError(ctx, err)
-	}
-	if isAdmin {
-		return nil
-	}
-	hasView, err := c.HasPrivilegeOrRoleOption(ctx, userName, privilege.VIEWCLUSTERSETTING)
-	if err != nil {
-		return srverrors.ServerError(ctx, err)
-	}
-	if hasView {
-		return nil
-	}
-	hasModify, err := c.HasPrivilegeOrRoleOption(ctx, userName, privilege.MODIFYCLUSTERSETTING)
-	if err != nil {
-		return srverrors.ServerError(ctx, err)
-	}
-	if hasModify {
-		return nil
-	}
-	return grpcstatus.Errorf(
-		codes.PermissionDenied, "this operation requires the %s or %s system privileges",
-		privilege.VIEWCLUSTERSETTING.DisplayName(), privilege.MODIFYCLUSTERSETTING.DisplayName())
-}
-
 // RequireViewActivityAndNoViewActivityRedactedPermission requires
 // that the user have the VIEWACTIVITY role, but does not have the
 // VIEWACTIVITYREDACTED role. This function's error return is a gRPC


### PR DESCRIPTION
`RequireViewClusterSettingOrModifyClusterSettingPermission` is no longer used as of 852e4ea0756545208d63485ffca566262535898f. (Noticed this while looking at a related code.)

Epic: None
Release note: None