### PR TITLE
vecindex: remove VectorsPerPartition stat

### DIFF
--- a/pkg/sql/vecindex/cspann/cspann.proto
+++ b/pkg/sql/vecindex/cspann/cspann.proto
@@ -42,10 +42,7 @@ message IndexStats {
   // NumPartitions tracks the total number of partitions in the index. Unlike
   // the other statistics, this number is exact rather than an estimate.
   int64 num_partitions = 1;
-  // VectorsPerPartition is the estimated average number of vectors in each
-  // partition.
-  double vectors_per_partition = 2;
   // CVStats is a list of statistics for each non-leaf level of the K-means
   // tree that determine how many partitions to search at each level.
-  repeated CVStats c_v_stats = 3 [(gogoproto.nullable) = false];
+  repeated CVStats c_v_stats = 2 [(gogoproto.nullable) = false];
 }

--- a/pkg/sql/vecindex/cspann/cspannpb.go
+++ b/pkg/sql/vecindex/cspann/cspannpb.go
@@ -16,17 +16,16 @@ import (
 // not affect the other.
 func (s *IndexStats) Clone() IndexStats {
 	return IndexStats{
-		NumPartitions:       s.NumPartitions,
-		VectorsPerPartition: s.VectorsPerPartition,
-		CVStats:             slices.Clone(s.CVStats),
+		NumPartitions: s.NumPartitions,
+		CVStats:       slices.Clone(s.CVStats),
 	}
 }
 
 // String returns a human-readable representation of the index stats.
 func (s *IndexStats) String() string {
 	var buf bytes.Buffer
-	buf.WriteString(fmt.Sprintf("%d levels, %d partitions, %.2f vectors/partition.\n",
-		len(s.CVStats)+1, s.NumPartitions, s.VectorsPerPartition))
+	buf.WriteString(fmt.Sprintf("%d levels, %d partitions.\n",
+		len(s.CVStats)+1, s.NumPartitions))
 	buf.WriteString("CV stats:\n")
 	for i, cvstats := range s.CVStats {
 		stdev := math.Sqrt(cvstats.Variance)

--- a/pkg/sql/vecindex/cspann/cspannpb_test.go
+++ b/pkg/sql/vecindex/cspann/cspannpb_test.go
@@ -21,20 +21,19 @@ func TestIndexStats(t *testing.T) {
 	// Empty stats.
 	stats := IndexStats{}
 	require.Equal(t, strings.TrimSpace(`
-1 levels, 0 partitions, 0.00 vectors/partition.
+1 levels, 0 partitions.
 CV stats:
 `), strings.TrimSpace(stats.String()))
 
 	stats = IndexStats{
-		NumPartitions:       100,
-		VectorsPerPartition: 32.59,
+		NumPartitions: 100,
 		CVStats: []CVStats{
 			{Mean: 10.12, Variance: 2.13},
 			{Mean: 18.42, Variance: 3.87},
 		},
 	}
 	require.Equal(t, strings.TrimSpace(`
-3 levels, 100 partitions, 32.59 vectors/partition.
+3 levels, 100 partitions.
 CV stats:
   level 2 - mean: 10.1200, stdev: 1.4595
   level 3 - mean: 18.4200, stdev: 1.9672
@@ -43,20 +42,19 @@ CV stats:
 	// Clone method.
 	cloned := stats.Clone()
 	stats.NumPartitions = 50
-	stats.VectorsPerPartition = 16
 	stats.CVStats[0].Mean = 100
 	stats.CVStats[1].Variance = 100
 
 	// Ensure that original and clone can be updated independently.
 	require.Equal(t, strings.TrimSpace(`
-3 levels, 50 partitions, 16.00 vectors/partition.
+3 levels, 50 partitions.
 CV stats:
   level 2 - mean: 100.0000, stdev: 1.4595
   level 3 - mean: 18.4200, stdev: 10.0000
 `), strings.TrimSpace(stats.String()))
 
 	require.Equal(t, strings.TrimSpace(`
-3 levels, 100 partitions, 32.59 vectors/partition.
+3 levels, 100 partitions.
 CV stats:
   level 2 - mean: 10.1200, stdev: 1.4595
   level 3 - mean: 18.4200, stdev: 1.9672

--- a/pkg/sql/vecindex/cspann/index_stats_test.go
+++ b/pkg/sql/vecindex/cspann/index_stats_test.go
@@ -29,7 +29,7 @@ func TestStatsManager(t *testing.T) {
 
 	var stats statsManager
 	require.NoError(t, stats.Init(ctx, mergeStats))
-	require.Equal(t, "1 levels, 1 partitions, 0.00 vectors/partition.\nCV stats:\n", stats.Format())
+	require.Equal(t, "1 levels, 1 partitions.\nCV stats:\n", stats.Format())
 	require.True(t, skippedMerge)
 
 	// Get zero, negative, positive z-scores.
@@ -60,7 +60,7 @@ func TestStatsManager(t *testing.T) {
 
 	// Format stats.
 	require.Equal(t,
-		"3 levels, 1 partitions, 0.00 vectors/partition.\n"+
+		"3 levels, 1 partitions.\n"+
 			"CV stats:\n"+
 			"  level 2 - mean: 0.4987, stdev: 0.2960\n"+
 			"  level 3 - mean: 0.5000, stdev: 0.0000\n", stats.Format())

--- a/pkg/sql/vecindex/cspann/memstore/memstore.go
+++ b/pkg/sql/vecindex/cspann/memstore/memstore.go
@@ -331,7 +331,6 @@ func (s *Store) MergeStats(ctx context.Context, stats *cspann.IndexStats, skipMe
 
 	// Update incoming stats with global stats.
 	stats.NumPartitions = s.mu.stats.NumPartitions
-	stats.VectorsPerPartition = s.mu.stats.VectorsPerPartition
 
 	extra := len(s.mu.stats.CVStats) - len(stats.CVStats)
 	if extra > 0 {
@@ -533,21 +532,6 @@ func (s *Store) tickLocked() uint64 {
 func (s *Store) updatedStructureLocked(tx *memTxn) {
 	tx.updated = true
 	tx.current = s.tickLocked()
-}
-
-// reportPartitionSizeLocked updates the vectors per partition statistic. It is
-// called with the count of vectors in a partition when a partition is inserted
-// or updated.
-// NOTE: Callers must have locked the s.mu mutex.
-func (s *Store) reportPartitionSizeLocked(count int) {
-	if s.mu.stats.VectorsPerPartition == 0 {
-		// Use first value if this is the first update.
-		s.mu.stats.VectorsPerPartition = float64(count)
-	} else {
-		// Calculate exponential moving average.
-		s.mu.stats.VectorsPerPartition = (1 - storeStatsAlpha) * s.mu.stats.VectorsPerPartition
-		s.mu.stats.VectorsPerPartition += storeStatsAlpha * float64(count)
-	}
 }
 
 // getPartition returns a partition by its key, or ErrPartitionNotFound if no

--- a/pkg/sql/vecindex/cspann/memstore/memstore_test.go
+++ b/pkg/sql/vecindex/cspann/memstore/memstore_test.go
@@ -204,7 +204,6 @@ func TestInMemoryStoreUpdateStats(t *testing.T) {
 	err = store.MergeStats(ctx, &stats, false /* skipMerge */)
 	require.NoError(t, err)
 	require.Equal(t, int64(1), stats.NumPartitions)
-	require.Equal(t, float64(1.05), stats.VectorsPerPartition)
 	require.Equal(t, []cspann.CVStats{}, stats.CVStats)
 
 	// Upsert new root partition with higher level and check stats.
@@ -219,7 +218,6 @@ func TestInMemoryStoreUpdateStats(t *testing.T) {
 	err = store.MergeStats(ctx, &stats, false /* skipMerge */)
 	require.NoError(t, err)
 	require.Equal(t, int64(1), stats.NumPartitions)
-	require.Equal(t, float64(1.0975), stats.VectorsPerPartition)
 	require.Equal(t, []cspann.CVStats{{Mean: 2.5, Variance: 0}, {Mean: 1, Variance: 0}}, roundCVStats(stats.CVStats))
 
 	// Insert new partition with lower level and check stats.
@@ -235,7 +233,6 @@ func TestInMemoryStoreUpdateStats(t *testing.T) {
 	err = store.MergeStats(ctx, &stats, false /* skipMerge */)
 	require.NoError(t, err)
 	require.Equal(t, int64(2), stats.NumPartitions)
-	require.Equal(t, float64(1.0926), scalar.Round(stats.VectorsPerPartition, 4))
 	require.Equal(t, []cspann.CVStats{
 		{Mean: 2.775, Variance: 0.1}, {Mean: 1.25, Variance: 0.05}}, roundCVStats(stats.CVStats))
 
@@ -248,7 +245,6 @@ func TestInMemoryStoreUpdateStats(t *testing.T) {
 	err = store.MergeStats(ctx, &stats, false /* skipMerge */)
 	require.NoError(t, err)
 	require.Equal(t, int64(2), stats.NumPartitions)
-	require.Equal(t, float64(1.1380), scalar.Round(stats.VectorsPerPartition, 4))
 	require.Equal(t, []cspann.CVStats{
 		{Mean: 2.7863, Variance: 0.145}, {Mean: 1.2625, Variance: 0.0725}}, roundCVStats(stats.CVStats))
 
@@ -260,7 +256,6 @@ func TestInMemoryStoreUpdateStats(t *testing.T) {
 	err = store.MergeStats(ctx, &stats, false /* skipMerge */)
 	require.NoError(t, err)
 	require.Equal(t, int64(2), stats.NumPartitions)
-	require.Equal(t, float64(1.1311), scalar.Round(stats.VectorsPerPartition, 4))
 	require.Equal(t, []cspann.CVStats{
 		{Mean: 2.8969, Variance: 0.2378}, {Mean: 1.3494, Variance: 0.1439}}, roundCVStats(stats.CVStats))
 
@@ -269,7 +264,6 @@ func TestInMemoryStoreUpdateStats(t *testing.T) {
 	err = store.MergeStats(ctx, &stats, true /* skipMerge */)
 	require.NoError(t, err)
 	require.Equal(t, int64(2), stats.NumPartitions)
-	require.Equal(t, float64(1.1311), scalar.Round(stats.VectorsPerPartition, 4))
 	require.Equal(t, []cspann.CVStats{
 		{Mean: 2.8969, Variance: 0.2378}, {Mean: 1.3494, Variance: 0.1439}}, roundCVStats(stats.CVStats))
 }
@@ -326,9 +320,8 @@ func TestInMemoryStoreMarshalling(t *testing.T) {
 		string([]byte{3, 4}): {12, 13},
 	}
 	store.mu.stats = cspann.IndexStats{
-		NumPartitions:       2,
-		VectorsPerPartition: 100,
-		CVStats:             []cspann.CVStats{{Mean: 0.5, Variance: 0.25}},
+		NumPartitions: 2,
+		CVStats:       []cspann.CVStats{{Mean: 0.5, Variance: 0.25}},
 	}
 
 	// Round-trip the data.
@@ -349,7 +342,6 @@ func TestInMemoryStoreMarshalling(t *testing.T) {
 	require.Equal(t, cspann.PartitionKey(100), store2.mu.nextKey)
 	require.Len(t, store2.mu.vectors, 2)
 	require.Equal(t, vector.T{12, 13}, store2.mu.vectors[string([]byte{3, 4})])
-	require.Equal(t, float64(100), store2.mu.stats.VectorsPerPartition)
 	require.Equal(t, int64(42), store2.seed)
 }
 

--- a/pkg/sql/vecindex/cspann/memstore/memstore_txn.go
+++ b/pkg/sql/vecindex/cspann/memstore/memstore_txn.go
@@ -103,8 +103,6 @@ func (tx *memTxn) SetRootPartition(
 	tx.store.mu.Lock()
 	defer tx.store.mu.Unlock()
 
-	tx.store.reportPartitionSizeLocked(partition.Count())
-
 	// Grow or shrink CVStats slice if a new level is being added or removed.
 	expectedLevels := int(partition.Level() - 1)
 	if expectedLevels > len(tx.store.mu.stats.CVStats) {
@@ -142,7 +140,6 @@ func (tx *memTxn) InsertPartition(
 
 	// Update stats.
 	tx.store.mu.stats.NumPartitions++
-	tx.store.reportPartitionSizeLocked(partition.Count())
 
 	tx.store.updatedStructureLocked(tx)
 	return partitionKey, nil
@@ -236,7 +233,6 @@ func (tx *memTxn) AddToPartition(
 	if partition.Add(&tx.workspace, vec, childKey, valueBytes) {
 		tx.store.mu.Lock()
 		defer tx.store.mu.Unlock()
-		tx.store.reportPartitionSizeLocked(partition.Count())
 		memPart.count.Add(1)
 	}
 
@@ -274,7 +270,6 @@ func (tx *memTxn) RemoveFromPartition(
 	if partition.ReplaceWithLastByKey(childKey) {
 		tx.store.mu.Lock()
 		defer tx.store.mu.Unlock()
-		tx.store.reportPartitionSizeLocked(partition.Count())
 		memPart.count.Add(-1)
 	}
 

--- a/pkg/sql/vecindex/cspann/testdata/search-features.ddt
+++ b/pkg/sql/vecindex/cspann/testdata/search-features.ddt
@@ -4,7 +4,7 @@
 new-index dims=512 min-partition-size=4 max-partition-size=16 quality-samples=8 beam-size=4 load-features=1000 hide-tree
 ----
 Created index with 1000 vectors with 512 dimensions.
-3 levels, 95 partitions, 11.28 vectors/partition.
+3 levels, 95 partitions.
 CV stats:
   level 2 - mean: 0.1294, stdev: 0.0425
   level 3 - mean: 0.1162, stdev: 0.0421


### PR DESCRIPTION
In order to make implementing MergeStats easier, as well as making the refactoring of split/merge easier, this commit removes the VectorsPerPartition stat. This is not used for anything critical. We can add it back later on if we decide it's useful.

Epic: CRDB-42943

Release note: None