### PR TITLE
execbuilder: fix recently added flake

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_join_geospatial
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_join_geospatial
@@ -15,7 +15,8 @@ CREATE TABLE rtable(
   geom geometry,
   rk2 string,
   PRIMARY KEY (rk1, rk2),
-  INVERTED INDEX geom_index(geom)
+  INVERTED INDEX geom_index(geom),
+  FAMILY (rk1, rk2, geom)
 )
 
 query T


### PR DESCRIPTION
In just merged f6038a10bb13d6aff0c22c3e0da91c794ef432f6 we added EXPLAIN ANALYZE output, but that output can differ slightly based on the column family mutation done by the logic test framework (namely, with multiple column families the streamer requires the disk buffer, so `max sql temp disk usage` line would show up). This commit fixes this flakiness by hard-coding single column family for the lookup table.

Fixes: #143176.

Release note: None