### PR TITLE
workload: remove `workload` label from openmetrics

### DIFF
--- a/pkg/workload/cli/run.go
+++ b/pkg/workload/cli/run.go
@@ -687,8 +687,6 @@ func maybeInitAndCreateExporter(gen workload.Generator) (exporter.Exporter, *os.
 			}
 			labels[strings.TrimSpace(parts[0])] = strings.TrimSpace(parts[1])
 		}
-		// Append workload generator name as a tag
-		labels["workload"] = gen.Meta().Name
 		openMetricsExporter := exporter.OpenMetricsExporter{}
 		openMetricsExporter.SetLabels(&labels)
 		metricsExporter = &openMetricsExporter


### PR DESCRIPTION
workload label was added to the openmetrics exporter earlier. This is not needed and only increases the file size, hence removing it.

Epic: none

Release note: None