### PR TITLE
rangefeed: de-flake TestRangefeedCatchupStarvation

### DIFF
--- a/pkg/kv/kvclient/rangefeed/rangefeed_external_test.go
+++ b/pkg/kv/kvclient/rangefeed/rangefeed_external_test.go
@@ -1923,10 +1923,14 @@ func TestRangefeedCatchupStarvation(t *testing.T) {
 		f, err := rangefeed.NewFactory(s.AppStopper(), db, s.ClusterSettings(), nil)
 		require.NoError(t, err)
 
-		blocked := make(chan struct{})
+		blocked := make(chan struct{}, 1)
 		r1, err := f.RangeFeed(ctx, "consumer-1-rf-1", []roachpb.Span{span}, ts,
 			func(ctx context.Context, value *kvpb.RangeFeedValue) {
-				blocked <- struct{}{}
+				select {
+				case blocked <- struct{}{}:
+				default:
+					// We can hit this case on retries.
+				}
 				<-ctx.Done()
 			},
 			rangefeed.WithConsumerID(1),


### PR DESCRIPTION
It installed a callback that would send to a channel to signal that it was
blocked, but it could do this sending more than once but the channel was not
buffered and only read once. This resulted in a deadlock.

The fix is to make the channel 1-buffered and to skip sending if it is full.

Closes #143163.

Epic: none
Release note: None
