### PR TITLE
jsonpath: add arithmetic evaluation

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/jsonb_path_query
+++ b/pkg/sql/logictest/testdata/logic_test/jsonb_path_query
@@ -701,13 +701,72 @@ SELECT jsonb_path_query('{"a": [[[[[[{"b": 1}]]]]]]}', '$.a ? (@.b == 1)');
 query empty
 SELECT jsonb_path_query('{"a": [[[{"b": 1}], [{"b": 2}]]]}', '$.a ? (@.b == 1)');
 
+query T
+SELECT jsonb_path_query('{}', '1 + 2');
+----
+3
+
+query T
+SELECT jsonb_path_query('{}', '1 - 2');
+----
+-1
+
+query T
+SELECT jsonb_path_query('{}', '1 * 2');
+----
+2
+
+query T
+SELECT jsonb_path_query('{}', '1 / 2');
+----
+0.50000000000000000000
+
+query T
+SELECT jsonb_path_query('{}', '3 % 2');
+----
+1
+
+query T
+SELECT jsonb_path_query('{"a": 4, "b": 5}', '$.a + $.b');
+----
+9
+
+query T
+SELECT jsonb_path_query('{"a": 4, "b": 5, "c": [9, 8, 7]}', '$.c[0] + $.c[1]');
+----
+17
+
+query T
+SELECT jsonb_path_query('{"a": 4, "b": 5, "c": [9, 8, 7]}', '$.c[$.b - $.a]');
+----
+8
+
+query T
+SELECT jsonb_path_query('{"a": 4, "b": 5, "c": [9, 8, 7]}', '$.c[$.b - $.a] + $var', '{"var": 10}');
+----
+18
+
+statement error pgcode 22012 pq: division by zero
+SELECT jsonb_path_query('{}', '1 / 0');
+
+statement error pgcode 22038 pq: left operand of jsonpath operator / is not a single numeric value
+SELECT jsonb_path_query('[1, 2]', '$[*] / 2');
+
+statement error pgcode 22038 pq: right operand of jsonpath operator \+ is not a single numeric value
+SELECT jsonb_path_query('[1, 2]', '2 + $[*]');
+
+statement error pgcode 22038 pq: left operand of jsonpath operator / is not a single numeric value
+SELECT jsonb_path_query('{"a": "hello"}', '$.a / 2');
+
+statement error pgcode 22038 pq: right operand of jsonpath operator \+ is not a single numeric value
+SELECT jsonb_path_query('{"a": null}', '2 + $.a');
+
 # when string literals are supported
 # query T rowsort
 # SELECT jsonb_path_query('{"data": [{"val": "a", "num": 1}, {"val": "b", "num": 2}, {"val": "a", "num": 3}]}'::jsonb, '$.data ? (@.val == "a")'::jsonpath);
 # ----
 # {"num": 1, "val": "a"}
 # {"num": 3, "val": "a"}
-
 # select jsonb_path_query('[1, 2, 3, 4, 5]', '$[-1]');
 # select jsonb_path_query('[1, 2, 3, 4, 5]', 'strict $[-1]');
 

--- a/pkg/util/jsonpath/eval/BUILD.bazel
+++ b/pkg/util/jsonpath/eval/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "//pkg/util/json",
         "//pkg/util/jsonpath",
         "//pkg/util/jsonpath/parser",
+        "@com_github_cockroachdb_apd_v3//:apd",
         "@com_github_cockroachdb_errors//:errors",
     ],
 )

--- a/pkg/util/jsonpath/eval/eval.go
+++ b/pkg/util/jsonpath/eval/eval.go
@@ -90,7 +90,7 @@ func (ctx *jsonpathCtx) eval(
 		if err != nil {
 			return nil, err
 		}
-		return convertFromBool(res), nil
+		return []json.JSON{res}, nil
 	case jsonpath.Filter:
 		return ctx.evalFilter(path, jsonValue, unwrap)
 	default:

--- a/pkg/util/jsonpath/eval/operation.go
+++ b/pkg/util/jsonpath/eval/operation.go
@@ -6,6 +6,10 @@
 package eval
 
 import (
+	"github.com/cockroachdb/apd/v3"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/util/json"
 	"github.com/cockroachdb/cockroach/pkg/util/jsonpath"
 	"github.com/cockroachdb/errors"
@@ -28,14 +32,14 @@ func isBool(j json.JSON) bool {
 	}
 }
 
-func convertFromBool(b jsonpathBool) []json.JSON {
+func convertFromBool(b jsonpathBool) json.JSON {
 	switch b {
 	case jsonpathBoolTrue:
-		return []json.JSON{json.TrueJSONValue}
+		return json.TrueJSONValue
 	case jsonpathBoolFalse:
-		return []json.JSON{json.FalseJSONValue}
+		return json.FalseJSONValue
 	case jsonpathBoolUnknown:
-		return []json.JSON{json.NullJSONValue}
+		return json.NullJSONValue
 	default:
 		panic(errors.AssertionFailedf("unhandled jsonpath boolean type"))
 	}
@@ -54,22 +58,25 @@ func convertToBool(j json.JSON) jsonpathBool {
 
 func (ctx *jsonpathCtx) evalOperation(
 	op jsonpath.Operation, jsonValue json.JSON,
-) (jsonpathBool, error) {
+) (json.JSON, error) {
 	switch op.Type {
 	case jsonpath.OpLogicalAnd, jsonpath.OpLogicalOr, jsonpath.OpLogicalNot:
 		res, err := ctx.evalLogical(op, jsonValue)
 		if err != nil {
-			return jsonpathBoolUnknown, err
+			return convertFromBool(jsonpathBoolUnknown), err
 		}
-		return res, nil
+		return convertFromBool(res), nil
 	case jsonpath.OpCompEqual, jsonpath.OpCompNotEqual,
 		jsonpath.OpCompLess, jsonpath.OpCompLessEqual,
 		jsonpath.OpCompGreater, jsonpath.OpCompGreaterEqual:
 		res, err := ctx.evalComparison(op, jsonValue, true /* unwrapRight */)
 		if err != nil {
-			return jsonpathBoolUnknown, err
+			return convertFromBool(jsonpathBoolUnknown), err
 		}
-		return res, nil
+		return convertFromBool(res), nil
+	case jsonpath.OpAdd, jsonpath.OpSub, jsonpath.OpMult,
+		jsonpath.OpDiv, jsonpath.OpMod:
+		return ctx.evalArithmetic(op, jsonValue)
 	default:
 		panic(errors.AssertionFailedf("unhandled operation type"))
 	}
@@ -233,4 +240,55 @@ func execComparison(l, r json.JSON, op jsonpath.OperationType) (jsonpathBool, er
 		return jsonpathBoolTrue, nil
 	}
 	return jsonpathBoolFalse, nil
+}
+
+func (ctx *jsonpathCtx) evalArithmetic(
+	op jsonpath.Operation, jsonValue json.JSON,
+) (json.JSON, error) {
+	left, err := ctx.evalAndUnwrapResult(op.Left, jsonValue, true /* unwrap */)
+	if err != nil {
+		return nil, err
+	}
+	right, err := ctx.evalAndUnwrapResult(op.Right, jsonValue, true /* unwrap */)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(left) != 1 || left[0].Type() != json.NumberJSONType {
+		return nil, pgerror.Newf(pgcode.SingletonSQLJSONItemRequired,
+			"left operand of jsonpath operator %s is not a single numeric value",
+			jsonpath.OperationTypeStrings[op.Type])
+	}
+	if len(right) != 1 || right[0].Type() != json.NumberJSONType {
+		return nil, pgerror.Newf(pgcode.SingletonSQLJSONItemRequired,
+			"right operand of jsonpath operator %s is not a single numeric value",
+			jsonpath.OperationTypeStrings[op.Type])
+	}
+
+	leftNum, _ := left[0].AsDecimal()
+	rightNum, _ := right[0].AsDecimal()
+	var res apd.Decimal
+	var cond apd.Condition
+	switch op.Type {
+	case jsonpath.OpAdd:
+		_, err = tree.DecimalCtx.Add(&res, leftNum, rightNum)
+	case jsonpath.OpSub:
+		_, err = tree.DecimalCtx.Sub(&res, leftNum, rightNum)
+	case jsonpath.OpMult:
+		_, err = tree.DecimalCtx.Mul(&res, leftNum, rightNum)
+	case jsonpath.OpDiv:
+		cond, err = tree.DecimalCtx.Quo(&res, leftNum, rightNum)
+		// Division by zero or 0 / 0.
+		if cond.DivisionByZero() || cond.DivisionUndefined() {
+			return nil, tree.ErrDivByZero
+		}
+	case jsonpath.OpMod:
+		_, err = tree.DecimalCtx.Rem(&res, leftNum, rightNum)
+	default:
+		panic(errors.AssertionFailedf("unhandled jsonpath arithmetic type"))
+	}
+	if err != nil {
+		return nil, err
+	}
+	return json.FromDecimal(res), nil
 }

--- a/pkg/util/jsonpath/operation.go
+++ b/pkg/util/jsonpath/operation.go
@@ -19,9 +19,14 @@ const (
 	OpLogicalAnd
 	OpLogicalOr
 	OpLogicalNot
+	OpAdd
+	OpSub
+	OpMult
+	OpDiv
+	OpMod
 )
 
-var operationTypeStrings = map[OperationType]string{
+var OperationTypeStrings = map[OperationType]string{
 	OpCompEqual:        "==",
 	OpCompNotEqual:     "!=",
 	OpCompLess:         "<",
@@ -31,6 +36,11 @@ var operationTypeStrings = map[OperationType]string{
 	OpLogicalAnd:       "&&",
 	OpLogicalOr:        "||",
 	OpLogicalNot:       "!",
+	OpAdd:              "+",
+	OpSub:              "-",
+	OpMult:             "*",
+	OpDiv:              "/",
+	OpMod:              "%",
 }
 
 type Operation struct {
@@ -46,7 +56,7 @@ func (o Operation) String() string {
 	// 1 == 1 && 1 != 1, postgres will output (1 == 1 && 1 != 1), but we output
 	// ((1 == 1) && (1 != 1)).
 	if o.Type == OpLogicalNot {
-		return fmt.Sprintf("%s(%s)", operationTypeStrings[o.Type], o.Left)
+		return fmt.Sprintf("%s(%s)", OperationTypeStrings[o.Type], o.Left)
 	}
-	return fmt.Sprintf("(%s %s %s)", o.Left, operationTypeStrings[o.Type], o.Right)
+	return fmt.Sprintf("(%s %s %s)", o.Left, OperationTypeStrings[o.Type], o.Right)
 }

--- a/pkg/util/jsonpath/parser/jsonpath.y
+++ b/pkg/util/jsonpath/parser/jsonpath.y
@@ -194,6 +194,9 @@ func unaryOp(op jsonpath.OperationType, left jsonpath.Path) jsonpath.Operation {
 %left AND
 %right NOT
 
+%left '+' '-'
+%left '*' '/' '%'
+
 %%
 
 jsonpath:
@@ -235,6 +238,31 @@ expr:
   {
     $$.val = jsonpath.Paths($1.pathArr())
   }
+| '(' expr ')'
+  {
+    $$.val = $2.path()
+  }
+| expr '+' expr
+  {
+    $$.val = binaryOp(jsonpath.OpAdd, $1.path(), $3.path())
+  }
+| expr '-' expr
+  {
+    $$.val = binaryOp(jsonpath.OpSub, $1.path(), $3.path())
+  }
+| expr '*' expr
+  {
+    $$.val = binaryOp(jsonpath.OpMult, $1.path(), $3.path())
+  }
+| expr '/' expr
+  {
+    $$.val = binaryOp(jsonpath.OpDiv, $1.path(), $3.path())
+  }
+| expr '%' expr
+  {
+    $$.val = binaryOp(jsonpath.OpMod, $1.path(), $3.path())
+  }
+// TODO(normanchenn): add unary + and -.
 ;
 
 accessor_expr:

--- a/pkg/util/jsonpath/parser/testdata/jsonpath
+++ b/pkg/util/jsonpath/parser/testdata/jsonpath
@@ -363,6 +363,61 @@ $.a[*] ? (@.b > 100 || (@.c < 100))
 ----
 $."a"[*]?(((@."b" > 100) || (@."c" < 100))) -- normalized!
 
+parse
+1 + 1
+----
+(1 + 1) -- normalized!
+
+parse
+1 + 1 * 2
+----
+(1 + (1 * 2)) -- normalized!
+
+parse
+1 + 2 - 3 * 4 / 5 % 6
+----
+((1 + 2) - (((3 * 4) / 5) % 6)) -- normalized!
+
+parse
+(1 + 2) * (3 - 4) / 5
+----
+(((1 + 2) * (3 - 4)) / 5) -- normalized!
+
+parse
+1 * 2 + 3 * 4
+----
+((1 * 2) + (3 * 4)) -- normalized!
+
+parse
+1 + 2 * (3 - 4) / (5 + 6) - 7 % 8
+----
+((1 + ((2 * (3 - 4)) / (5 + 6))) - (7 % 8)) -- normalized!
+
+parse
+1 * (2 + 3) - 4 / (5 - 6) % 7
+----
+((1 * (2 + 3)) - ((4 / (5 - 6)) % 7)) -- normalized!
+
+parse
+((1 + 2) * 3) - (4 % 5) * 6
+----
+(((1 + 2) * 3) - ((4 % 5) * 6)) -- normalized!
+
+parse
+1 + 2 - 3 + 4 - 5
+----
+((((1 + 2) - 3) + 4) - 5) -- normalized!
+
+parse
+$.c[$.b - $.a]
+----
+$."c"[($."b" - $."a")] -- normalized!
+
+parse
+$.c[$.b - $.a to $.d - $.b]
+----
+$."c"[($."b" - $."a") to ($."d" - $."b")] -- normalized!
+
 # postgres allows floats as array indexes
 # parse
 # $.abc[1.0]


### PR DESCRIPTION
This commit adds functionality to evaluate arithmetic expressions within jsonpath queries. Addition, subtraction, multiplication, division and modulo operators are now supported, which use the `apd` library to do the calculations.

Closes: #143242 
Epic: None
Release note (sql change): Add support for addition, subtraction, multiplication, division and modulo operators within jsonpath queries.