### PR TITLE
kvserver,db-console: enable leader lease quiescence by default

### DIFF
--- a/pkg/kv/kvserver/replica_store_liveness_sleep.go
+++ b/pkg/kv/kvserver/replica_store_liveness_sleep.go
@@ -9,7 +9,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
-	"github.com/cockroachdb/cockroach/pkg/util/metamorphic"
 )
 
 // RaftStoreLivenessQuiescenceEnabled controls whether store liveness quiescence
@@ -18,9 +17,7 @@ var RaftStoreLivenessQuiescenceEnabled = settings.RegisterBoolSetting(
 	settings.SystemOnly,
 	"kv.raft.store_liveness.quiescence.enabled",
 	"controls whether store liveness quiescence is enabled",
-	metamorphic.ConstantWithTestChoice("kv.raft.store_liveness.quiescence.enabled",
-		false, /* defaultValue */
-		true /* otherValues */),
+	true,
 )
 
 // goToSleepAfterTicks is the number of Raft ticks after which a follower can

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/replication.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/replication.tsx
@@ -207,7 +207,14 @@ export default function (props: GraphDashboardProps) {
     >
       <Axis label="replicas">
         <Metric name="cr.store.replicas" title="Replicas" />
-        <Metric name="cr.store.replicas.quiescent" title="Quiescent" />
+        <Metric
+          name="cr.store.replicas.quiescent"
+          title="Epoch Lease Quiescent"
+        />
+        <Metric
+          name="cr.store.replicas.asleep"
+          title="Leader Lease Quiescent"
+        />
       </Axis>
     </LineGraph>,
 


### PR DESCRIPTION
This commit enables leader lease quiescence by default and adds the new quiesced replicas metric to the Replication DB console dashboard.

Part of: #133885

Release note (ui change): The Replica Quiescence graph on the Replication dashboard in the DB Console Metrics now displays the number of replicas quiesced with leader leases.