### PR TITLE
CODEOWNERS: mark pkg/sql/syntheticprivilege* as owned by Foundations

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -103,6 +103,9 @@
 /pkg/sql/tests/rsg_test.go   @cockroachdb/sql-foundations
 /pkg/sql/ttl                 @cockroachdb/sql-foundations
 
+/pkg/sql/syntheticprivilege/      @cockroachdb/sql-foundations
+/pkg/sql/syntheticprivilegecache/ @cockroachdb/sql-foundations
+
 /pkg/ccl/schemachangerccl/   @cockroachdb/sql-foundations
 /pkg/sql/catalog/            @cockroachdb/sql-foundations
 /pkg/sql/catalog/multiregion @cockroachdb/sql-foundations


### PR DESCRIPTION
Informs: #143183
Epic: None
Release note: None