### PR TITLE
pkg/backup: simplify backup error messages

### DIFF
--- a/pkg/backup/backup_processor_planning.go
+++ b/pkg/backup/backup_processor_planning.go
@@ -24,7 +24,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
-	"github.com/cockroachdb/errors"
 )
 
 func distBackupPlanSpecs(
@@ -80,8 +79,8 @@ func distBackupPlanSpecs(
 
 		encryption.Key, err = kms.Decrypt(ctx, encryption.KMSInfo.EncryptedDataKey)
 		if err != nil {
-			return nil, errors.Wrap(err,
-				"failed to decrypt data key before starting BackupDataProcessor")
+			log.Error(ctx, "failed to decrypt data key before starting BackupDataProcessor")
+			return nil, err
 		}
 	}
 	// Wrap the relevant BackupEncryptionOptions to be used by the Backup

--- a/pkg/backup/backup_test.go
+++ b/pkg/backup/backup_test.go
@@ -2078,7 +2078,7 @@ table_name from [SHOW TABLES FROM restore] ORDER BY schema_name, table_name`, tc
 		{
 			// We have to qualify the table correctly to back it up. d.tb1 resolves
 			// to d.public.tb1.
-			sqlDB.ExpectErr(t, `pq: failed to resolve targets specified in the BACKUP stmt: table "d.tb1" does not exist`, `BACKUP TABLE d.tb1 INTO 'nodelocal://1/test/'`)
+			sqlDB.ExpectErr(t, `pq: table "d.tb1" does not exist`, `BACKUP TABLE d.tb1 INTO 'nodelocal://1/test/'`)
 			// Backup tb1.
 			sqlDB.Exec(t, `BACKUP TABLE d.sc.tb1 INTO 'nodelocal://1/test/'`)
 			// Create a new database to restore into. This restore should restore the
@@ -7561,7 +7561,7 @@ func TestBackupExportRequestTimeout(t *testing.T) {
 	// should hang. The timeout should save us in this case.
 	_, err := sqlSessions[1].DB.ExecContext(ctx, "BACKUP TABLE data.bank INTO 'nodelocal://1/timeout'")
 	require.Regexp(t,
-		`running distributed backup to export.*/Table/\d+/.*\: context deadline exceeded`,
+		`pq: KV storage layer did not respond to BACKUP within timeout: node may be overloaded`,
 		err.Error())
 }
 

--- a/pkg/backup/testdata/backup-restore/backup-dropped-descriptors
+++ b/pkg/backup/testdata/backup-restore/backup-dropped-descriptors
@@ -41,7 +41,7 @@ SELECT orig->'database'->'name', orig->'database'->'state' FROM tbls WHERE id = 
 exec-sql
 BACKUP DATABASE d INTO 'nodelocal://1/dropped-database';
 ----
-pq: failed to resolve targets specified in the BACKUP stmt: database "d" does not exist, or invalid RESTORE timestamp: supplied backups do not cover requested time
+pq: database "d" does not exist, or invalid RESTORE timestamp: supplied backups do not cover requested time
 
 # A cluster backup should succeed but should ignore the dropped database
 # and table descriptors.

--- a/pkg/backup/testdata/backup-restore/backup-dropped-descriptors-declarative
+++ b/pkg/backup/testdata/backup-restore/backup-dropped-descriptors-declarative
@@ -42,7 +42,7 @@ SELECT orig->'database'->'name', orig->'database'->'state' FROM tbls WHERE id = 
 exec-sql
 BACKUP DATABASE dd INTO 'nodelocal://1/dropped-database';
 ----
-pq: failed to resolve targets specified in the BACKUP stmt: database "dd" does not exist, or invalid RESTORE timestamp: supplied backups do not cover requested time
+pq: database "dd" does not exist, or invalid RESTORE timestamp: supplied backups do not cover requested time
 
 # A cluster backup should succeed.
 exec-sql

--- a/pkg/backup/testdata/backup-restore/backup-permissions
+++ b/pkg/backup/testdata/backup-restore/backup-permissions
@@ -46,7 +46,7 @@ REVOKE ADMIN FROM testuser
 exec-sql user=testuser
 BACKUP INTO 'userfile:///test-nonroot-cluster';
 ----
-pq: only users with the admin role or the BACKUP system privilege are allowed to perform full cluster backups: user testuser does not have BACKUP system privilege
+pq: user testuser does not have BACKUP system privilege
 
 # Grant system backup privilege and re-run the backup.
 exec-sql

--- a/pkg/backup/testdata/backup-restore/backup-permissions-deprecated
+++ b/pkg/backup/testdata/backup-restore/backup-permissions-deprecated
@@ -61,7 +61,7 @@ CREATE USER testuser
 exec-sql user=testuser
 BACKUP INTO 'nodelocal://1/test2'
 ----
-pq: only users with the admin role or the BACKUP system privilege are allowed to perform full cluster backups: user testuser does not have BACKUP system privilege
+pq: user testuser does not have BACKUP system privilege
 
 # Database backup as a non-admin user should have CONNECT on database and SELECT on tables.
 exec-sql user=testuser

--- a/pkg/backup/testdata/backup-restore/schedule-privileges
+++ b/pkg/backup/testdata/backup-restore/schedule-privileges
@@ -54,7 +54,7 @@ REVOKE ADMIN FROM testuser;
 exec-sql user=testuser
 CREATE SCHEDULE foocluster FOR BACKUP INTO 'external://foo/cluster' RECURRING '@hourly';
 ----
-pq: failed to dry run backup: only users with the admin role or the BACKUP system privilege are allowed to perform full cluster backups: user testuser does not have BACKUP system privilege
+pq: failed to dry run backup: user testuser does not have BACKUP system privilege
 
 exec-sql user=testuser
 CREATE SCHEDULE foodb FOR BACKUP DATABASE foo INTO 'external://foo/database' RECURRING '@hourly';

--- a/pkg/backup/testdata/backup-restore/temp-tables
+++ b/pkg/backup/testdata/backup-restore/temp-tables
@@ -35,7 +35,7 @@ public
 exec-sql
 BACKUP TABLE temp_table INTO 'nodelocal://1/temp_table_backup'
 ----
-pq: failed to resolve targets specified in the BACKUP stmt: table "temp_table" does not exist, or invalid RESTORE timestamp: supplied backups do not cover requested time
+pq: table "temp_table" does not exist, or invalid RESTORE timestamp: supplied backups do not cover requested time
 
 exec-sql
 BACKUP DATABASE d1 INTO 'nodelocal://1/d1_backup/'


### PR DESCRIPTION
Remove calls to errors.Wrap to simplify and shorten backup-related errors.

Release note (enterprise change): Shorten some error messages in backup for clarity.