### PR TITLE
roachtest: enable table stats histograms in sysbench

### DIFF
--- a/pkg/cmd/roachtest/tests/sysbench.go
+++ b/pkg/cmd/roachtest/tests/sysbench.go
@@ -277,7 +277,6 @@ func registerSysbench(r registry.Registry) {
 					`set cluster setting sql.stats.flush.enabled = false`,
 					`set cluster setting sql.metrics.statement_details.enabled = false`,
 					`set cluster setting kv.split_queue.enabled = false`,
-					`set cluster setting sql.stats.histogram_collection.enabled = false`,
 					`set cluster setting kv.consistency_queue.enabled = false`,
 				},
 				useDRPC: true,


### PR DESCRIPTION
#### roachtest: enable table stats histograms in sysbench

After merging a handful of optimizations for table histogram collection
and usage, I no longer measure any benefit from disabling their
collection with sysbench.

Here are the results of 6 10-minute runs with histograms disabled:

    Run 20250320_173820 - QPS: 23657.98
    Run 20250320_175819 - QPS: 23478.55
    Run 20250320_181745 - QPS: 22835.62
    Run 20250320_183704 - QPS: 23422.88
    Run 20250320_185602 - QPS: 23850.45
    Run 20250320_191501 - QPS: 22873.06
    Mean: 23353.09
    Median: 23450.71
    Standard Deviation: 378.40

And here are the results with histograms enabled:

    Run 20250320_153907 - QPS: 23173.45
    Run 20250320_155759 - QPS: 24112.82
    Run 20250320_161641 - QPS: 23904.91
    Run 20250320_163530 - QPS: 23599.34
    Run 20250320_165439 - QPS: 24183.21
    Run 20250320_171324 - QPS: 22982.28
    Mean: 23659.33
    Median: 23752.12
    Standard Deviation: 454.32
    Coefficient of variance: .0191

In this case, the mean QPS is 1.3% higher with histograms enabled,
likely due to typical variance.

Fixes #137780

Release note: None
