### PR TITLE
scripts: update check-pebble-dep.sh releases

### DIFF
--- a/scripts/check-pebble-dep.sh
+++ b/scripts/check-pebble-dep.sh
@@ -9,7 +9,7 @@
 set -euo pipefail
 #set -x
 
-RELEASES="23.1 23.2 24.1 24.2 24.3 master"
+RELEASES="23.2 24.1 24.3 25.1 master"
 
 for REL in $RELEASES; do
   if [ "$REL" == "master" ]; then


### PR DESCRIPTION
Update the set of releases checked by the check-pebble-dep.sh to drop 23.1 and 24.2 (both have reached end-of-life) and add 25.1.

Epic: none
Release note: none