### PR TITLE
kvclient: respect MustAcquireExclusiveLock in txnWriteBuffer

### DIFF
--- a/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
@@ -337,6 +337,13 @@ func TestTenantLogic_bpchar(
 	runLogicTest(t, "bpchar")
 }
 
+func TestTenantLogic_buffered_writes(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "buffered_writes")
+}
+
 func TestTenantLogic_builtin_function(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/local-read-committed/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/local-read-committed/generated_test.go
@@ -335,6 +335,13 @@ func TestReadCommittedLogic_bpchar(
 	runLogicTest(t, "bpchar")
 }
 
+func TestReadCommittedLogic_buffered_writes(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "buffered_writes")
+}
+
 func TestReadCommittedLogic_builtin_function(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/local-repeatable-read/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/local-repeatable-read/generated_test.go
@@ -335,6 +335,13 @@ func TestRepeatableReadLogic_bpchar(
 	runLogicTest(t, "bpchar")
 }
 
+func TestRepeatableReadLogic_buffered_writes(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "buffered_writes")
+}
+
 func TestRepeatableReadLogic_builtin_function(
 	t *testing.T,
 ) {

--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_write_buffer.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_write_buffer.go
@@ -144,7 +144,7 @@ func (twb *txnWriteBuffer) SendLocked(
 		// anything to KV.
 		br := ba.CreateReply()
 		for i, t := range ts {
-			br.Responses[i], pErr = t.toResp(twb, kvpb.ResponseUnion{}, ba.Txn)
+			br.Responses[i], pErr = t.toResp(ctx, twb, kvpb.ResponseUnion{}, ba.Txn)
 			if pErr != nil {
 				return nil, pErr
 			}
@@ -310,8 +310,9 @@ func (twb *txnWriteBuffer) closeLocked() {}
 //
 // Some examples of transformations include:
 //
-// 1. Blind writes (Put/Delete requests) are stripped from the batch and
-// buffered locally.
+// 1. Blind writes (Put/Delete requests) are buffered locally. When they the
+// original request has MustAcquireExclusiveLock set, a locking Get is used to
+// acquire the lock.
 // 2. Point reads (Get requests) are served from the buffer and stripped from
 // the batch iff the key has seen a buffered write.
 // 3. Scans are always sent to the KV layer, but if the key span being scanned
@@ -364,15 +365,28 @@ func (twb *txnWriteBuffer) applyTransformations(
 			// be served locally from the buffer yet.
 
 		case *kvpb.PutRequest:
+			// If the MustAcquireExclusiveLock flag is set on the Put, then we need to
+			// add a locking Get to the BatchRequest, including if the key doesn't
+			// exist.
+			if t.MustAcquireExclusiveLock {
+				// TODO(yuzefovich,ssd): ensure that we elide the lock acquisition
+				// whenever possible (e.g. blind UPSERT in an implicit txn).
+				var getReqU kvpb.RequestUnion
+				getReqU.MustSetInner(&kvpb.GetRequest{
+					RequestHeader: kvpb.RequestHeader{
+						Key:      t.Key,
+						Sequence: t.Sequence,
+					},
+					LockNonExisting:    true,
+					KeyLockingStrength: lock.Exclusive,
+				})
+				baRemote.Requests = append(baRemote.Requests, getReqU)
+			}
+
 			var ru kvpb.ResponseUnion
 			ru.MustSetInner(&kvpb.PutResponse{})
-			// TODO(yuzefovich): if MustAcquireExclusiveLock flag is set on the
-			// Put, then we need to add a locking Get to the BatchRequest,
-			// including if the key doesn't exist (#139232).
-			// TODO(yuzefovich): ensure that we elide the lock acquisition
-			// whenever possible (e.g. blind UPSERT in an implicit txn).
 			ts = append(ts, transformation{
-				stripped:    true,
+				stripped:    !t.MustAcquireExclusiveLock,
 				index:       i,
 				origRequest: req,
 				resp:        ru,
@@ -380,15 +394,30 @@ func (twb *txnWriteBuffer) applyTransformations(
 			twb.addToBuffer(t.Key, t.Value, t.Sequence)
 
 		case *kvpb.DeleteRequest:
+			// If MustAcquireExclusiveLock flag is set on the DeleteRequest, then we
+			// need to add a locking Get to the BatchRequest, including if the key
+			// doesn't exist.
+			if t.MustAcquireExclusiveLock {
+				// TODO(ssd): ensure that we elide the lock acquisition
+				// whenever possible.
+				var getReqU kvpb.RequestUnion
+				getReqU.MustSetInner(&kvpb.GetRequest{
+					RequestHeader: kvpb.RequestHeader{
+						Key:      t.Key,
+						Sequence: t.Sequence,
+					},
+					LockNonExisting:    true,
+					KeyLockingStrength: lock.Exclusive,
+				})
+				baRemote.Requests = append(baRemote.Requests, getReqU)
+			}
+
 			var ru kvpb.ResponseUnion
 			ru.MustSetInner(&kvpb.DeleteResponse{
-				// TODO(yuzefovich): if MustAcquireExclusiveLock flag is set on
-				// the Del, then we need to add a locking Get to the
-				// BatchRequest, including if the key doesn't exist (#139232).
 				FoundKey: false,
 			})
 			ts = append(ts, transformation{
-				stripped:    true,
+				stripped:    !t.MustAcquireExclusiveLock,
 				index:       i,
 				origRequest: req,
 				resp:        ru,
@@ -717,13 +746,13 @@ func (twb *txnWriteBuffer) mergeResponseWithTransformations(
 				// we received a response for it, which then needs to be combined with
 				// what's in the write buffer.
 				resp := br.Responses[0]
-				mergedResps[i], pErr = ts[0].toResp(twb, resp, br.Txn)
+				mergedResps[i], pErr = ts[0].toResp(ctx, twb, resp, br.Txn)
 				if pErr != nil {
 					return nil, pErr
 				}
 				br.Responses = br.Responses[1:]
 			} else {
-				mergedResps[i], pErr = ts[0].toResp(twb, kvpb.ResponseUnion{}, br.Txn)
+				mergedResps[i], pErr = ts[0].toResp(ctx, twb, kvpb.ResponseUnion{}, br.Txn)
 				if pErr != nil {
 					return nil, pErr
 				}
@@ -763,27 +792,26 @@ type transformation struct {
 // toResp returns the response that should be added to the batch response as
 // a result of applying the transformation.
 func (t transformation) toResp(
-	twb *txnWriteBuffer, br kvpb.ResponseUnion, txn *roachpb.Transaction,
+	ctx context.Context, twb *txnWriteBuffer, br kvpb.ResponseUnion, txn *roachpb.Transaction,
 ) (kvpb.ResponseUnion, *kvpb.Error) {
 	if t.stripped {
 		return t.resp, nil
 	}
 
 	var ru kvpb.ResponseUnion
-	switch t.origRequest.(type) {
+	switch req := t.origRequest.(type) {
 	case *kvpb.ConditionalPutRequest:
 		// Evaluate the condition.
 		evalFn := mvcceval.MaybeConditionFailedError
 		if twb.testingOverrideCPutEvalFn != nil {
 			evalFn = twb.testingOverrideCPutEvalFn
 		}
-		cputReq := t.origRequest.(*kvpb.ConditionalPutRequest)
 		getResp := br.GetInner().(*kvpb.GetResponse)
 		condFailedErr := evalFn(
-			cputReq.ExpBytes,
+			req.ExpBytes,
 			getResp.Value,
 			getResp.Value.IsPresent(),
-			cputReq.AllowIfDoesNotExist,
+			req.AllowIfDoesNotExist,
 		)
 		if condFailedErr != nil {
 			pErr := kvpb.NewErrorWithTxn(condFailedErr, txn)
@@ -792,21 +820,25 @@ func (t transformation) toResp(
 		}
 		// The condition was satisfied; buffer a Put, and return a synthesized
 		// response.
-		twb.addToBuffer(cputReq.Key, cputReq.Value, cputReq.Sequence)
+		twb.addToBuffer(req.Key, req.Value, req.Sequence)
 		ru.MustSetInner(&kvpb.ConditionalPutResponse{})
 
 	case *kvpb.PutRequest:
 		ru = t.resp
 
 	case *kvpb.DeleteRequest:
+		getResp := br.GetInner().(*kvpb.GetResponse)
 		ru = t.resp
+		if log.ExpensiveLogEnabled(ctx, 2) {
+			log.Eventf(ctx, "synthesizing DeleteResponse from GetResponse: %#v", getResp)
+		}
+		ru.GetDelete().FoundKey = getResp.Value.IsPresent()
 
 	case *kvpb.GetRequest:
 		// Get requests must be served from the local buffer if a transaction
 		// performed a previous write to the key being read. However, Get requests
 		// must be sent to the KV layer (i.e. not be stripped) iff they are locking
 		// in nature.
-		req := t.origRequest.(*kvpb.GetRequest)
 		assertTrue(t.stripped == (req.KeyLockingStrength == lock.None),
 			"Get requests should either be stripped or be locking")
 		ru = t.resp

--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_write_buffer_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_write_buffer_test.go
@@ -1100,3 +1100,74 @@ func TestTxnWriteBufferDecomposesConditionalPutsExpectingNoRow(t *testing.T) {
 	require.Len(t, br.Responses, 1)
 	require.IsType(t, &kvpb.EndTxnResponse{}, br.Responses[0].GetInner())
 }
+
+// TestTxnWriteBufferRespectsMustAcquireExclusiveLock verifies that Put and
+// Delete requests that have the MustAcquireExclusiveLock are decomposed into a
+// locking Get and a buffered write.
+func TestTxnWriteBufferRespectsMustAcquireExclusiveLock(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+	twb, mockSender := makeMockTxnWriteBuffer()
+
+	txn := makeTxnProto()
+	txn.Sequence = 10
+	keyA := roachpb.Key("a")
+	keyB := roachpb.Key("b")
+	val := "val"
+
+	// Blindly write to keys A and B.
+	ba := &kvpb.BatchRequest{}
+	ba.Header = kvpb.Header{Txn: &txn}
+	delA := delArgs(keyA, txn.Sequence)
+	putB := putArgs(keyB, val, txn.Sequence)
+
+	ba.Add(delA)
+	ba.Add(putB)
+
+	mockSender.MockSend(func(ba *kvpb.BatchRequest) (*kvpb.BatchResponse, *kvpb.Error) {
+		require.Len(t, ba.Requests, 2)
+		require.IsType(t, &kvpb.GetRequest{}, ba.Requests[0].GetInner())
+		getReq := ba.Requests[0].GetInner().(*kvpb.GetRequest)
+		require.Equal(t, keyA, getReq.Key)
+		require.Equal(t, txn.Sequence, getReq.Sequence)
+		require.Equal(t, lock.Exclusive, getReq.KeyLockingStrength)
+		require.True(t, getReq.LockNonExisting)
+
+		require.IsType(t, &kvpb.GetRequest{}, ba.Requests[1].GetInner())
+		getReq = ba.Requests[1].GetInner().(*kvpb.GetRequest)
+		require.Equal(t, keyB, getReq.Key)
+		require.Equal(t, txn.Sequence, getReq.Sequence)
+		require.Equal(t, lock.Exclusive, getReq.KeyLockingStrength)
+		require.True(t, getReq.LockNonExisting)
+		return ba.CreateReply(), nil
+	})
+
+	br, pErr := twb.SendLocked(ctx, ba)
+	require.Nil(t, pErr)
+	require.NotNil(t, br)
+
+	// Lastly, commit the transaction.
+	ba = &kvpb.BatchRequest{}
+	ba.Header = kvpb.Header{Txn: &txn}
+	ba.Add(&kvpb.EndTxnRequest{Commit: true})
+
+	mockSender.MockSend(func(ba *kvpb.BatchRequest) (*kvpb.BatchResponse, *kvpb.Error) {
+		require.Len(t, ba.Requests, 3)
+		require.IsType(t, &kvpb.DeleteRequest{}, ba.Requests[0].GetInner())
+		require.IsType(t, &kvpb.PutRequest{}, ba.Requests[1].GetInner())
+		require.IsType(t, &kvpb.EndTxnRequest{}, ba.Requests[2].GetInner())
+		br = ba.CreateReply()
+		br.Txn = ba.Txn
+		return br, nil
+	})
+
+	br, pErr = twb.SendLocked(ctx, ba)
+	require.Nil(t, pErr)
+	require.NotNil(t, br)
+
+	// Even though we may have flushed the buffer, responses from the blind writes should
+	// not be returned.
+	require.Len(t, br.Responses, 1)
+	require.IsType(t, &kvpb.EndTxnResponse{}, br.Responses[0].GetInner())
+}

--- a/pkg/sql/logictest/testdata/logic_test/buffered_writes
+++ b/pkg/sql/logictest/testdata/logic_test/buffered_writes
@@ -1,0 +1,23 @@
+
+subtest point_delete
+
+statement ok
+SET kv_transaction_buffered_writes_enabled=true
+
+statement ok
+CREATE TABLE t1 (pk int primary key, v int)
+
+statement ok
+INSERT INTO t1 VALUES (1,1)
+
+statement ok
+BEGIN
+
+statement count 1
+DELETE FROM t1 WHERE pk = 1
+
+statement count 0
+DELETE FROM t1 WHERE pk = 3
+
+statement ok
+COMMIT

--- a/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
@@ -290,6 +290,13 @@ func TestLogic_bpchar(
 	runLogicTest(t, "bpchar")
 }
 
+func TestLogic_buffered_writes(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "buffered_writes")
+}
+
 func TestLogic_builtin_function(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
@@ -290,6 +290,13 @@ func TestLogic_bpchar(
 	runLogicTest(t, "bpchar")
 }
 
+func TestLogic_buffered_writes(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "buffered_writes")
+}
+
 func TestLogic_builtin_function(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist/generated_test.go
@@ -290,6 +290,13 @@ func TestLogic_bpchar(
 	runLogicTest(t, "bpchar")
 }
 
+func TestLogic_buffered_writes(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "buffered_writes")
+}
+
 func TestLogic_builtin_function(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-legacy-schema-changer/generated_test.go
+++ b/pkg/sql/logictest/tests/local-legacy-schema-changer/generated_test.go
@@ -283,6 +283,13 @@ func TestLogic_bpchar(
 	runLogicTest(t, "bpchar")
 }
 
+func TestLogic_buffered_writes(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "buffered_writes")
+}
+
 func TestLogic_builtin_function(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-mixed-24.3/generated_test.go
+++ b/pkg/sql/logictest/tests/local-mixed-24.3/generated_test.go
@@ -290,6 +290,13 @@ func TestLogic_bpchar(
 	runLogicTest(t, "bpchar")
 }
 
+func TestLogic_buffered_writes(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "buffered_writes")
+}
+
 func TestLogic_builtin_function(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-mixed-25.1/generated_test.go
+++ b/pkg/sql/logictest/tests/local-mixed-25.1/generated_test.go
@@ -290,6 +290,13 @@ func TestLogic_bpchar(
 	runLogicTest(t, "bpchar")
 }
 
+func TestLogic_buffered_writes(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "buffered_writes")
+}
+
 func TestLogic_builtin_function(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/local-vec-off/generated_test.go
@@ -290,6 +290,13 @@ func TestLogic_bpchar(
 	runLogicTest(t, "bpchar")
 }
 
+func TestLogic_buffered_writes(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "buffered_writes")
+}
+
 func TestLogic_builtin_function(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local/generated_test.go
+++ b/pkg/sql/logictest/tests/local/generated_test.go
@@ -290,6 +290,13 @@ func TestLogic_bpchar(
 	runLogicTest(t, "bpchar")
 }
 
+func TestLogic_buffered_writes(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "buffered_writes")
+}
+
 func TestLogic_builtin_function(
 	t *testing.T,
 ) {


### PR DESCRIPTION
SQL signals to KV that a Put or Delete is expected to lock the given key via the flag MustAcquireExclusiveLock.

In the txnWriteBuffer, we obey that command by sending a locking GetRequest and buffering the corresponding write operation.

Epic: none

Release note: None