### PR TITLE
jsonpath: add `like_regex`, string and null scalars

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/jsonb_path_query
+++ b/pkg/sql/logictest/testdata/logic_test/jsonb_path_query
@@ -785,6 +785,29 @@ SELECT jsonb_path_query('{"data": [{"val": "a", "num": 1}, {"val": "b", "num": 2
 {"num": 1, "val": "a"}
 {"num": 3, "val": "a"}
 
+query T
+SELECT jsonb_path_query('{}', 'null == null');
+----
+true
+
+query T
+SELECT jsonb_path_query('{}', 'null != null');
+----
+false
+
+query T
+SELECT jsonb_path_query('{}', 'null != 1');
+----
+true
+
+query T
+SELECT jsonb_path_query('{}', 'null <= "null"');
+----
+false
+
+statement error pgcode 22038 pq: left operand of jsonpath operator \% is not a single numeric value
+SELECT jsonb_path_query('{}', 'null % 1');
+
 # select jsonb_path_query('[1, 2, 3, 4, 5]', '$[-1]');
 # select jsonb_path_query('[1, 2, 3, 4, 5]', 'strict $[-1]');
 

--- a/pkg/sql/logictest/testdata/logic_test/jsonb_path_query
+++ b/pkg/sql/logictest/testdata/logic_test/jsonb_path_query
@@ -1,6 +1,11 @@
 # LogicTest: !local-mixed-24.3 !local-mixed-25.1
 
 query T
+SELECT jsonb_path_query('"\\"', '$ ? (@ like_regex "^\\\\$")');
+----
+"\\"
+
+query T
 SELECT jsonb_path_query('{}', '$')
 ----
 {}
@@ -807,6 +812,107 @@ false
 
 statement error pgcode 22038 pq: left operand of jsonpath operator \% is not a single numeric value
 SELECT jsonb_path_query('{}', 'null % 1');
+
+query T
+SELECT jsonb_path_query('{}', 'null like_regex "^he.*$"');
+----
+null
+
+query T
+SELECT jsonb_path_query('{}', '"hello" like_regex "^he.*$"');
+----
+true
+
+query T
+SELECT jsonb_path_query('{}', '"ahello" like_regex "^he.*$"');
+----
+false
+
+query T
+SELECT jsonb_path_query('{"a": "e"}', '$.a ? (@ like_regex "^[aeiou]")');
+----
+"e"
+
+query T
+SELECT jsonb_path_query('{"a": {"b": "e"}}', '$.a ? (@.b like_regex "^[aeiou]")');
+----
+{"b": "e"}
+
+query empty
+SELECT jsonb_path_query('{"a": {"b": "r"}}', '$.a ? (@.b like_regex "^[aeiou]")');
+
+query T rowsort
+SELECT jsonb_path_query('["apple", "banana", "orange", "umbrella", "grape"]', 'strict $[*] ? (@ like_regex "^[aeiou]")');
+----
+"apple"
+"orange"
+"umbrella"
+
+query T rowsort
+SELECT jsonb_path_query('[{"balance": "987_650", "name": "a"}, {"balance": "987_424", "name": "b"}, {"balance": "100", "name": "c"}]', '$[*] ? (@.balance like_regex "987_.*").balance');
+----
+"987_650"
+"987_424"
+
+query T
+SELECT jsonb_path_query('{"ab\\c": "hello"}', '$."ab\\c"');
+----
+"hello"
+
+query empty
+SELECT jsonb_path_query('"a\nb"', '$ ? (@ like_regex "^.*$")');
+
+query T
+SELECT jsonb_path_query('"\\"', '$ ? (@ like_regex "^\\\\$")');
+----
+"\\"
+
+query T
+SELECT jsonb_path_query('"\\\\"', '$ ? (@ like_regex "^\\\\\\\\$")');
+----
+"\\\\"
+
+query T
+SELECT jsonb_path_query('{"paths": ["C:\\Program Files", "D:\\Data"]}', '$.paths[*] ? (@ like_regex "^[A-Z]:\\\\[A-Za-z]+$")');
+----
+"D:\\Data"
+
+query T rowsort
+SELECT jsonb_path_query('{"paths": ["C:\\Program Files (x86)\\", "D:\\My Documents\\", "E:\\Test!@#$"]}', '$.paths[*] ? (@ like_regex "^[A-Z]:\\\\.*\\\\$")');
+----
+"C:\\Program Files (x86)\\"
+"D:\\My Documents\\"
+
+query T rowsort
+SELECT jsonb_path_query('{"urls": ["http:\/\/example.com", "https:\/\/test.com\/path"]}', '$.urls[*] ? (@ like_regex "^https?:\/\/.*\.com")');
+----
+"http://example.com"
+"https://test.com/path"
+
+query T rowsort
+SELECT jsonb_path_query('{"mixed": ["C:/path\\to/file", "D:\\path/to\\file"]}', '$.mixed[*] ? (@ like_regex "^[A-Z]:[/\\\\].*")');
+----
+"C:/path\\to/file"
+"D:\\path/to\\file"
+
+query T rowsort
+SELECT jsonb_path_query('["a+b", "a*b", "a?b", "a.b", "a[b]", "a{b}"]', '$[*] ? (@ like_regex "^a[\\+\\*\\?\\.]b$|^a\\[b\\]$|^a\\{b\\}$")');
+----
+"a+b"
+"a*b"
+"a?b"
+"a.b"
+"a[b]"
+"a{b}"
+
+query T rowsort
+SELECT jsonb_path_query('[null, 1, "abc", "abd", "aBdC", "abdacb", "babc", "adc\nabc", "ab\nadc"]', 'lax $[*] ? (@ like_regex "^ab.*c")');
+----
+"abc"
+"abdacb"
+
+# TODO(normanchenn): support scanning identQuote within regex.
+# SELECT jsonb_path_query('"He said \"Hello\\World!\""', '$ ? (@ like_regex ".*\"H.*\\\\.*!.*\".*")');
 
 # select jsonb_path_query('[1, 2, 3, 4, 5]', '$[-1]');
 # select jsonb_path_query('[1, 2, 3, 4, 5]', 'strict $[-1]');

--- a/pkg/sql/logictest/testdata/logic_test/jsonb_path_query
+++ b/pkg/sql/logictest/testdata/logic_test/jsonb_path_query
@@ -761,12 +761,30 @@ SELECT jsonb_path_query('{"a": "hello"}', '$.a / 2');
 statement error pgcode 22038 pq: right operand of jsonpath operator \+ is not a single numeric value
 SELECT jsonb_path_query('{"a": null}', '2 + $.a');
 
-# when string literals are supported
-# query T rowsort
-# SELECT jsonb_path_query('{"data": [{"val": "a", "num": 1}, {"val": "b", "num": 2}, {"val": "a", "num": 3}]}'::jsonb, '$.data ? (@.val == "a")'::jsonpath);
-# ----
-# {"num": 1, "val": "a"}
-# {"num": 3, "val": "a"}
+query T
+SELECT jsonb_path_query('{}', '"a" == "b"');
+----
+false
+
+query T
+SELECT jsonb_path_query('{}', '"a" < "b"');
+----
+true
+
+query T
+SELECT jsonb_path_query('{}', '"a" > "b"');
+----
+false
+
+statement error pgcode 22038 pq: left operand of jsonpath operator \+ is not a single numeric value
+SELECT jsonb_path_query('{}', '"a" + "b"');
+
+query T rowsort
+SELECT jsonb_path_query('{"data": [{"val": "a", "num": 1}, {"val": "b", "num": 2}, {"val": "a", "num": 3}]}', '$.data ? (@.val == "a")');
+----
+{"num": 1, "val": "a"}
+{"num": 3, "val": "a"}
+
 # select jsonb_path_query('[1, 2, 3, 4, 5]', '$[-1]');
 # select jsonb_path_query('[1, 2, 3, 4, 5]', 'strict $[-1]');
 

--- a/pkg/sql/scanner/jsonpath_scan.go
+++ b/pkg/sql/scanner/jsonpath_scan.go
@@ -27,7 +27,7 @@ func (s *JSONPathScanner) Scan(lval ScanSymType) {
 	switch ch {
 	case '$':
 		// Root path ($)
-		if s.peek() == '.' || s.peek() == eof || s.peek() == ' ' || s.peek() == '[' || s.peek() == ')' {
+		if s.peek() == '.' || s.peek() == eof || s.peek() == ' ' || s.peek() == '[' || s.peek() == ')' || s.peek() == '?' {
 			lval.SetID(lexbase.ROOT)
 			return
 		}
@@ -46,7 +46,17 @@ func (s *JSONPathScanner) Scan(lval ScanSymType) {
 		return
 	case identQuote:
 		// "[^"]"
-		if s.scanString(lval, identQuote, false /* allowEscapes */, true /* requireUTF8 */) {
+		// When scanning string literals for like_regex patterns, we need to
+		// consider how to handle escape characters similarly to Postgres.
+		// See: https://www.postgresql.org/docs/current/functions-json.html#JSONPATH-REGULAR-EXPRESSIONS,
+		// "any backslashes you want to use in the regular expression must be doubled".
+		//
+		// With allowEscapes == true,
+		//  - String literal input "^\\$" is scanned as "^\\$" (one escaped backslash)
+		//  - This matches the behaviour of Postgres.
+		// With allowEscapes == false,
+		//  - String literal input "^\\$" is scanned as "^\\\\$" (two escaped backslashes)
+		if s.scanString(lval, identQuote, true /* allowEscapes */, true /* requireUTF8 */) {
 			lval.SetID(lexbase.STRING)
 		}
 		return

--- a/pkg/sql/scanner/jsonpath_scan.go
+++ b/pkg/sql/scanner/jsonpath_scan.go
@@ -47,7 +47,7 @@ func (s *JSONPathScanner) Scan(lval ScanSymType) {
 	case identQuote:
 		// "[^"]"
 		if s.scanString(lval, identQuote, false /* allowEscapes */, true /* requireUTF8 */) {
-			lval.SetID(lexbase.IDENT)
+			lval.SetID(lexbase.STRING)
 		}
 		return
 	case '=':

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -12180,7 +12180,9 @@ func makeTimestampStatementBuiltinOverload(withOutputTZ bool, withInputTZ bool) 
 	}
 }
 
-func makeJsonpathExists(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
+func makeJsonpathExists(
+	_ context.Context, evalCtx *eval.Context, args tree.Datums,
+) (tree.Datum, error) {
 	target := tree.MustBeDJSON(args[0])
 	path := tree.MustBeDJsonpath(args[1])
 	vars := tree.EmptyDJSON
@@ -12191,7 +12193,7 @@ func makeJsonpathExists(_ context.Context, _ *eval.Context, args tree.Datums) (t
 	if len(args) > 3 {
 		silent = tree.MustBeDBool(args[3])
 	}
-	exists, err := jsonpath.JsonpathExists(target, path, vars, silent)
+	exists, err := jsonpath.JsonpathExists(evalCtx, target, path, vars, silent)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/util/jsonpath/eval/BUILD.bazel
+++ b/pkg/util/jsonpath/eval/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
     deps = [
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",
+        "//pkg/sql/sem/eval",
         "//pkg/sql/sem/tree",
         "//pkg/util/errorutil/unimplemented",
         "//pkg/util/json",

--- a/pkg/util/jsonpath/eval/operation.go
+++ b/pkg/util/jsonpath/eval/operation.go
@@ -69,7 +69,7 @@ func (ctx *jsonpathCtx) evalOperation(
 	case jsonpath.OpCompEqual, jsonpath.OpCompNotEqual,
 		jsonpath.OpCompLess, jsonpath.OpCompLessEqual,
 		jsonpath.OpCompGreater, jsonpath.OpCompGreaterEqual:
-		res, err := ctx.evalComparison(op, jsonValue, true /* unwrapRight */)
+		res, err := ctx.evalComparison(op, jsonValue)
 		if err != nil {
 			return convertFromBool(jsonpathBoolUnknown), err
 		}
@@ -77,9 +77,56 @@ func (ctx *jsonpathCtx) evalOperation(
 	case jsonpath.OpAdd, jsonpath.OpSub, jsonpath.OpMult,
 		jsonpath.OpDiv, jsonpath.OpMod:
 		return ctx.evalArithmetic(op, jsonValue)
+	case jsonpath.OpLikeRegex:
+		res, err := ctx.evalRegex(op, jsonValue)
+		if err != nil {
+			return convertFromBool(jsonpathBoolUnknown), err
+		}
+		return convertFromBool(res), nil
 	default:
 		panic(errors.AssertionFailedf("unhandled operation type"))
 	}
+}
+
+func (ctx *jsonpathCtx) evalRegex(
+	op jsonpath.Operation, jsonValue json.JSON,
+) (jsonpathBool, error) {
+	l, err := ctx.evalAndUnwrapResult(op.Left, jsonValue, true /* unwrap */)
+	if err != nil {
+		return jsonpathBoolUnknown, err
+	}
+	if len(l) != 1 {
+		return jsonpathBoolUnknown, errors.AssertionFailedf("left is not a single string")
+	}
+	if l[0].Type() != json.StringJSONType {
+		return jsonpathBoolUnknown, nil
+	}
+	// AsText() provides the correct string representation for regex pattern
+	// matching by returning raw characters instead of their escaped JSON string
+	// representations.
+	//
+	// Examples:
+	// - For a JSON string with a backslash ("\\"): AsText() returns two
+	//   backslashes ("\\"), while String() returns "\"\\\\\"" (two escaped
+	//   backslashes enclosed in quotes).
+	// - For a JSON string with a newline ("\n"): AsText() returns an actual
+	//   newline character ("\n"), while String() returns "\"\\n\"" (an escaped
+	//   backslash and 'n' enclosed in quotes)
+	text, err := l[0].AsText()
+	if err != nil {
+		return jsonpathBoolUnknown, err
+	}
+
+	regexOp := op.Right.(jsonpath.Regex)
+	r, err := ctx.evalCtx.ReCache.GetRegexp(regexOp)
+	if err != nil {
+		return jsonpathBoolUnknown, err
+	}
+	res := r.MatchString(*text)
+	if !res {
+		return jsonpathBoolFalse, nil
+	}
+	return jsonpathBoolTrue, nil
 }
 
 func (ctx *jsonpathCtx) evalLogical(
@@ -143,17 +190,14 @@ func (ctx *jsonpathCtx) evalLogical(
 // right paths satisfy the condition. In strict mode, even if a pair has been
 // found, all pairs need to be checked for errors.
 func (ctx *jsonpathCtx) evalComparison(
-	op jsonpath.Operation, jsonValue json.JSON, unwrapRight bool,
+	op jsonpath.Operation, jsonValue json.JSON,
 ) (jsonpathBool, error) {
-	// The left argument results are always auto-unwrapped.
+	// The left and right argument results are always auto-unwrapped.
 	left, err := ctx.evalAndUnwrapResult(op.Left, jsonValue, true /* unwrap */)
 	if err != nil {
 		return jsonpathBoolUnknown, err
 	}
-	// The right argument results are conditionally unwrapped. Currently, it is
-	// always unwrapped, but in the future for operations like like_regex, we
-	// don't want to unwrap the right argument.
-	right, err := ctx.evalAndUnwrapResult(op.Right, jsonValue, unwrapRight)
+	right, err := ctx.evalAndUnwrapResult(op.Right, jsonValue, true /* unwrap */)
 	if err != nil {
 		return jsonpathBoolUnknown, err
 	}

--- a/pkg/util/jsonpath/expr.go
+++ b/pkg/util/jsonpath/expr.go
@@ -108,3 +108,24 @@ type Current struct{}
 var _ Path = Current{}
 
 func (c Current) String() string { return "@" }
+
+type Regex struct {
+	Regex string
+	// Flags are currently not used.
+	Flags string
+}
+
+var _ Path = Regex{}
+
+func (r Regex) String() string {
+	if r.Flags == "" {
+		return fmt.Sprintf("%q", r.Regex)
+	}
+	return fmt.Sprintf("%q flag %q", r.Regex, r.Flags)
+}
+
+var _ tree.RegexpCacheKey = Regex{}
+
+func (r Regex) Pattern() (string, error) {
+	return r.Regex, nil
+}

--- a/pkg/util/jsonpath/operation.go
+++ b/pkg/util/jsonpath/operation.go
@@ -24,6 +24,7 @@ const (
 	OpMult
 	OpDiv
 	OpMod
+	OpLikeRegex
 )
 
 var OperationTypeStrings = map[OperationType]string{
@@ -41,6 +42,7 @@ var OperationTypeStrings = map[OperationType]string{
 	OpMult:             "*",
 	OpDiv:              "/",
 	OpMod:              "%",
+	OpLikeRegex:        "like_regex",
 }
 
 type Operation struct {

--- a/pkg/util/jsonpath/parser/jsonpath.y
+++ b/pkg/util/jsonpath/parser/jsonpath.y
@@ -172,6 +172,7 @@ func unaryOp(op jsonpath.OperationType, left jsonpath.Path) jsonpath.Operation {
 %token <str> CURRENT
 
 %token <str> STRING
+%token <str> NULL
 
 %type <jsonpath.Jsonpath> jsonpath
 %type <jsonpath.Path> expr_or_predicate
@@ -453,7 +454,10 @@ scalar_value:
   {
     $$.val = jsonpath.Scalar{Type: jsonpath.ScalarString, Value: json.FromString($1)}
   }
-// TODO(normanchenn): support null.
+| NULL
+  {
+    $$.val = jsonpath.Scalar{Type: jsonpath.ScalarNull, Value: json.NullJSONValue}
+  }
 ;
 
 any_identifier:
@@ -465,6 +469,7 @@ any_identifier:
 unreserved_keyword:
   FALSE
 | LAX
+| NULL
 | STRICT
 | TO
 | TRUE

--- a/pkg/util/jsonpath/parser/jsonpath.y
+++ b/pkg/util/jsonpath/parser/jsonpath.y
@@ -174,6 +174,9 @@ func unaryOp(op jsonpath.OperationType, left jsonpath.Path) jsonpath.Operation {
 %token <str> STRING
 %token <str> NULL
 
+%token <str> LIKE_REGEX
+%token <str> FLAG
+
 %type <jsonpath.Jsonpath> jsonpath
 %type <jsonpath.Path> expr_or_predicate
 %type <jsonpath.Path> expr
@@ -381,6 +384,16 @@ predicate:
   {
     $$.val = unaryOp(jsonpath.OpLogicalNot, $2.path())
   }
+| expr LIKE_REGEX STRING
+  {
+    regex := jsonpath.Regex{Regex: $3}
+    $$.val = binaryOp(jsonpath.OpLikeRegex, $1.path(), regex)
+  }
+| expr LIKE_REGEX STRING FLAG STRING
+  {
+    // TODO(normanchenn): implement regex flags.
+    return unimplemented(jsonpathlex, "regex with flags")
+  }
 ;
 
 delimited_predicate:
@@ -468,7 +481,9 @@ any_identifier:
 
 unreserved_keyword:
   FALSE
+| FLAG
 | LAX
+| LIKE_REGEX
 | NULL
 | STRICT
 | TO

--- a/pkg/util/jsonpath/parser/jsonpath.y
+++ b/pkg/util/jsonpath/parser/jsonpath.y
@@ -171,6 +171,8 @@ func unaryOp(op jsonpath.OperationType, left jsonpath.Path) jsonpath.Operation {
 
 %token <str> CURRENT
 
+%token <str> STRING
+
 %type <jsonpath.Jsonpath> jsonpath
 %type <jsonpath.Path> expr_or_predicate
 %type <jsonpath.Path> expr
@@ -447,20 +449,22 @@ scalar_value:
   {
     $$.val = jsonpath.Scalar{Type: jsonpath.ScalarBool, Value: json.FromBool(false)}
   }
-// TODO(normanchenn): support strings, null.
+| STRING
+  {
+    $$.val = jsonpath.Scalar{Type: jsonpath.ScalarString, Value: json.FromString($1)}
+  }
+// TODO(normanchenn): support null.
 ;
 
 any_identifier:
   IDENT
+| STRING
 | unreserved_keyword
 ;
 
 unreserved_keyword:
-  AND
-| FALSE
+  FALSE
 | LAX
-| NOT
-| OR
 | STRICT
 | TO
 | TRUE

--- a/pkg/util/jsonpath/parser/testdata/jsonpath
+++ b/pkg/util/jsonpath/parser/testdata/jsonpath
@@ -454,6 +454,11 @@ DETAIL: source SQL:
 !null
  ^
 
+parse
+$.a ? (@.b like_regex "^[aeiou]")
+----
+$."a"?((@."b" like_regex "^[aeiou]")) -- normalized!
+
 # postgres allows floats as array indexes
 # parse
 # $.abc[1.0]

--- a/pkg/util/jsonpath/parser/testdata/jsonpath
+++ b/pkg/util/jsonpath/parser/testdata/jsonpath
@@ -418,6 +418,24 @@ $.c[$.b - $.a to $.d - $.b]
 ----
 $."c"[($."b" - $."a") to ($."d" - $."b")] -- normalized!
 
+parse
+"hello" == "hello"
+----
+("hello" == "hello") -- normalized!
+
+parse
+$.a ? (@.b == "string")
+----
+$."a"?((@."b" == "string")) -- normalized!
+
+error
+"a" && "b"
+----
+at or near "&": syntax error
+DETAIL: source SQL:
+"a" && "b"
+    ^
+
 # postgres allows floats as array indexes
 # parse
 # $.abc[1.0]

--- a/pkg/util/jsonpath/parser/testdata/jsonpath
+++ b/pkg/util/jsonpath/parser/testdata/jsonpath
@@ -436,6 +436,24 @@ DETAIL: source SQL:
 "a" && "b"
     ^
 
+parse
+null == null
+----
+(null == null) -- normalized!
+
+parse
+null + null
+----
+(null + null) -- normalized!
+
+error
+!null
+----
+at or near "null": syntax error
+DETAIL: source SQL:
+!null
+ ^
+
 # postgres allows floats as array indexes
 # parse
 # $.abc[1.0]


### PR DESCRIPTION
#### jsonpath/parser: add support for string scalars

This commit adds string scalars, enabling string comparisons within
jsonpath queries.

Epic: None
Release note (sql change): Support string comparisons within jsonpath
queries.

#### jsonpath/parser: add support for null scalars.

This commit adds null scalars, enabling null comparisons within jsonpath
queries.

Epic: None
Release note (sql change): Support null comparisons within jsonpath
queries.

#### jsonpath: add `like_regex` support

This commit add `like_regex` predicate evaluation support. Flags for
`like_regex` are not supported yet.

Informs: #143243
Epic: None
Release note (sql change): Add `like_regex` predicate evaluation support
for jsonpath queries. Flags for `like_regex` are not supported yet.