### PR TITLE
server: rolling restart planning endpoint

### DIFF
--- a/docs/generated/http/full.md
+++ b/docs/generated/http/full.md
@@ -5586,6 +5586,52 @@ show throttling warnings and alerts in DB Console.
 
 
 
+## NodeFaultToleranceStatus
+
+
+
+NodeFaultToleranceStatus indicates whether it's safe to terminate a
+node, and what that node's neighbor nodes are in the replication graph
+
+Support status: [reserved](#support-status)
+
+#### Request Parameters
+
+
+
+
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| node_id | [string](#cockroach.server.serverpb.NodeFaultToleranceRequest-string) |  |  | [reserved](#support-status) |
+
+
+
+
+
+
+
+#### Response Parameters
+
+
+
+
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| can_terminate | [bool](#cockroach.server.serverpb.NodeFaultToleranceResponse-bool) |  |  | [reserved](#support-status) |
+| neighbors | [int32](#cockroach.server.serverpb.NodeFaultToleranceResponse-int32) | repeated |  | [reserved](#support-status) |
+
+
+
+
+
+
+
 ## Users
 
 `GET /_admin/v1/users`

--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -387,6 +387,7 @@ go_library(
         "@org_golang_google_grpc//metadata",
         "@org_golang_google_grpc//status",
         "@org_golang_x_exp//maps",
+        "@org_golang_x_time//rate",
     ] + select({
         "@io_bazel_rules_go//go/platform:aix": [
             "@org_golang_x_sys//unix",

--- a/pkg/server/api_v2.go
+++ b/pkg/server/api_v2.go
@@ -29,7 +29,9 @@ package server
 import (
 	"context"
 	"fmt"
+	"math"
 	"net/http"
+	"sort"
 	"strconv"
 
 	"github.com/cockroachdb/cockroach/pkg/kv"
@@ -63,6 +65,7 @@ type ApiV2System interface {
 	restartSafetyCheck(w http.ResponseWriter, r *http.Request)
 	listNodes(w http.ResponseWriter, r *http.Request)
 	listNodeRanges(w http.ResponseWriter, r *http.Request)
+	planDrain(w http.ResponseWriter, r *http.Request)
 }
 
 type apiV2ServerOpts struct {
@@ -187,6 +190,7 @@ func registerRoutes(
 		{"ranges/hot/", a.listHotRanges, true, authserver.ViewClusterMetadataRole, false},
 		{"ranges/{range_id:[0-9]+}/", a.listRange, true, authserver.ViewClusterMetadataRole, false},
 		{"health/restart_safety/", systemRoutes.restartSafetyCheck, false, authserver.RegularRole, false},
+		{"drain/plan/", systemRoutes.planDrain, true, authserver.ViewClusterMetadataRole, false},
 		{"health/", systemRoutes.health, false, authserver.RegularRole, false},
 		{"users/", a.listUsers, true, authserver.RegularRole, false},
 		{"events/", a.listEvents, true, authserver.ViewClusterMetadataRole, false},
@@ -562,6 +566,252 @@ func checkRestartSafe(
 		return nil
 	})
 	return res, err
+}
+
+func (a *apiV2Server) planDrain(w http.ResponseWriter, r *http.Request) {
+	apiutil.WriteJSONResponse(r.Context(), w, http.StatusNotImplemented, nil)
+}
+
+func (a *apiV2SystemServer) planDrain(w http.ResponseWriter, r *http.Request) {
+	ctx := r.Context()
+	ctx = authserver.ForwardHTTPAuthInfoToRPCCalls(ctx, r)
+
+	// get the nodes we've already handled
+	nodeStrs, ok := r.URL.Query()["doneNodes"]
+	doneNodes := make(map[roachpb.NodeID]struct{})
+	if ok && len(nodeStrs) > 0 {
+		for _, nodeStr := range nodeStrs {
+			nID, err := strconv.Atoi(nodeStr)
+			if err != nil {
+				apiutil.WriteJSONResponse(ctx, w, http.StatusBadRequest, fmt.Errorf("invalid node ID: %s", nodeStr))
+				return
+			}
+
+			doneNodes[roachpb.NodeID(nID)] = struct{}{}
+		}
+	}
+
+	// parse the capacityTarget
+	capacityTarget := 0.0
+	capTargetStr := r.URL.Query().Get("capacityTarget")
+	if capTargetStr != "" {
+		var err error
+		capacityTarget, err = strconv.ParseFloat(capTargetStr, 64)
+		if err != nil {
+			apiutil.WriteJSONResponse(ctx, w, http.StatusBadRequest, fmt.Errorf("invalid capacityTarget: %s", capTargetStr))
+			return
+		}
+	}
+
+	batch, moreBatches, err := planRollingRestart(ctx, doneNodes, capacityTarget, a.systemStatus)
+	if err != nil {
+		apiutil.WriteJSONResponse(ctx, w, http.StatusInternalServerError, err)
+		return
+	}
+
+	resp := &serverpb.DrainPlanBatch{
+		DrainCohort: batch,
+		MoreBatches: moreBatches,
+	}
+
+	apiutil.WriteJSONResponse(ctx, w, http.StatusOK, resp)
+}
+
+// planRollingRestart is an iterator over nodes. It produces nodes in batches. To be included in the next batch, a
+// node must have healthy ranges, and none of its ranges can overlap any other node in the batch. Due to changes in
+// range allocation, or outages that impact range health, each node in the batch should be checked for drain safety
+// before being drained.
+//
+// In a large cluster with several localities, it's likely that the batch will consist of nodes in one locality, due
+// to the range overlap constraints. This is not guaranteed, but the goal here is to enable safe parallel draining and
+// restart operations on a running cluster, within capacity constraints.
+//
+// `doneNodes` is the set of nodes that should not be considered, presumably because they've already been restarted.
+// `capacityTarget` impacts the size of the batch. We assume that the cluster needs this much capacity to continue
+// without disruption, and limit the size of the batch to `totalNodes * (1.0 - capacityTarget)`. capacityTarget must be
+// less than 1.0. Targets less than 0.66 are treated as 0.8, since taking down more than a third of the cluster is
+// definitely a bad idea. That said, the minimum batch size limit is 1.
+//
+// The returned batch may be empty, or could be less than the batch size limit, if range health restricts it.
+// It's assumed that calls to this method will be well-separated in time. Don't poll in a tight loop; wait long enough
+// for cluster conditions to change before checking again.
+//
+// Since an empty batch does not indicate the end of iteration, there's a separate moreBatches return value.
+func planRollingRestart(
+	ctx context.Context,
+	doneNodes map[roachpb.NodeID]struct{},
+	capacityTarget float64,
+	systemStatus *systemStatusServer,
+) (batch []*roachpb.NodeDescriptor, moreBatches bool, err error) {
+	if capacityTarget >= 1.0 {
+		return nil, false, fmt.Errorf("capacity target must be less than 1.0")
+	}
+	if capacityTarget < 0.66 {
+		capacityTarget = 0.8
+	}
+
+	totalNodes := systemStatus.storePool.ClusterNodeCount()
+	nodesPerRound := int(math.Floor(float64(totalNodes) * (1.0 - capacityTarget)))
+	if nodesPerRound < 1 {
+		nodesPerRound = 1
+	}
+
+	nodeVitality := systemStatus.nodeLiveness.ScanNodeVitalityFromCache()
+
+	// track a set of ranges that are problematic, either because they're under-replicated, or about to be.
+	problemRanges := make(map[roachpb.RangeID]struct{})
+	// start with all live-and-not-draining nodes as candidates
+	candidateNodes := make(map[roachpb.NodeID]struct{})
+	for nID, nv := range nodeVitality {
+		if nv.IsLive(livenesspb.AdminHealthCheck) {
+			// node is available and not draining
+			candidateNodes[nID] = struct{}{}
+		} else if nv.IsDecommissioned() || nv.IsDecommissioning() {
+			// remove decommissioned nodes from done nodes, as we don't count them among the totalNodes
+			delete(doneNodes, nID)
+
+			if totalNodes == len(doneNodes) {
+				// Apparently the last candidate for the rolling restart got decommissioned instead
+				return nil, false, nil
+			}
+		} else if nv.IsDraining() {
+			// count draining nodes against the disruption budget
+			nodesPerRound -= 1
+			if nodesPerRound < 1 {
+				// We're already using our disruption budget to drain nodes
+				return nil, true, nil
+			}
+
+			// If the node is already draining, consider its ranges to be problemRanges
+			rr, err := systemStatus.Ranges(ctx, &serverpb.RangesRequest{
+				NodeId: strconv.Itoa(int(nID)),
+			})
+			if err != nil {
+				return nil, false, err
+			}
+
+			for _, r := range rr.Ranges {
+				problemRanges[r.State.Desc.RangeID] = struct{}{}
+			}
+		}
+	}
+
+	candidateToRanges := make(map[roachpb.NodeID][]roachpb.RangeID)
+	for nID := range candidateNodes {
+		rr, err := systemStatus.Ranges(ctx, &serverpb.RangesRequest{
+			NodeId: strconv.Itoa(int(nID)),
+		})
+		if err != nil {
+			return nil, false, err
+		}
+
+		var rangeIDs []roachpb.RangeID
+		// check the ranges on the node for problems
+		for _, r := range rr.Ranges {
+			rangeID := r.State.Desc.RangeID
+			rangeIDs = append(rangeIDs, rangeID)
+			_, marked := problemRanges[rangeID]
+
+			if marked {
+				delete(candidateNodes, nID)
+				continue
+			}
+
+			if r.Problems.Underreplicated || r.Problems.Unavailable {
+				problemRanges[rangeID] = struct{}{}
+				delete(candidateNodes, nID)
+			}
+		}
+
+		// at this point, if nID is still a candidate, it has no ranges that are under-replicated, or already draining
+		_, isDone := doneNodes[nID]
+		if _, ok := candidateNodes[nID]; ok && !isDone {
+			candidateToRanges[nID] = rangeIDs
+		}
+	}
+
+	// Fetch the node metadata for all the surviving candidates
+	candidateNodeDescs := make([]roachpb.NodeDescriptor, 0, len(candidateToRanges))
+	for nID := range candidateToRanges {
+		nodeStr := strconv.Itoa(int(nID))
+		node, err := systemStatus.Node(ctx, &serverpb.NodeRequest{
+			NodeId: nodeStr,
+			Redact: false,
+		})
+		if err != nil {
+			return nil, false, err
+		}
+
+		candidateNodeDescs = append(candidateNodeDescs, node.Desc)
+	}
+
+	// Sort candidates by node locality, so that we tend to succeed at finding large, disjoint groups of nodes
+	sort.Slice(candidateNodeDescs, func(i, j int) bool {
+		// compare by locality, then nodeID
+		l := candidateNodeDescs[i].Locality.Tiers
+		r := candidateNodeDescs[j].Locality.Tiers
+
+		for k, lt := range l {
+			if k < len(r) {
+				// less if key is less
+				if lt.Key < r[k].Key {
+					return true
+				} else if lt.Key > r[k].Key {
+					return false
+				}
+
+				// less if value is less
+				if lt.Value < r[k].Value {
+					return true
+				} else if lt.Value > r[k].Value {
+					return false
+				}
+			} else {
+				// greater if r is shorter and everything matches up to here
+				return false
+			}
+		}
+
+		if len(l) < len(r) {
+			// less if l is shorter and the kv pairs match
+			return true
+		}
+
+		// nodeID as a tie breaker
+		return candidateNodeDescs[i].NodeID < candidateNodeDescs[j].NodeID
+	})
+
+	// go through the candidates, and return the first ones that are disjoint.
+	toRestart := make([]*roachpb.NodeDescriptor, 0, nodesPerRound)
+	for _, node := range candidateNodeDescs {
+		nID := node.NodeID
+		rangeIDs := candidateToRanges[nID]
+
+		stillOk := true
+		for _, rID := range rangeIDs {
+			if _, ok := problemRanges[rID]; ok {
+				stillOk = false
+				break
+			}
+		}
+		if stillOk {
+			// node doesn't share ranges with any nodes already in the toRestart list
+			// add it to the list, then mark its ranges as problems so subsequent list elements will also be disjoint with it
+			toRestart = append(toRestart, &node)
+
+			for _, rID := range rangeIDs {
+				problemRanges[rID] = struct{}{}
+			}
+		}
+
+		if len(toRestart) >= nodesPerRound {
+			break
+		}
+	}
+
+	moreBatches = len(toRestart)+len(doneNodes) < totalNodes
+
+	return toRestart, moreBatches, nil
 }
 
 // # Get metric recording and alerting rule templates

--- a/pkg/server/api_v2.go
+++ b/pkg/server/api_v2.go
@@ -609,8 +609,8 @@ func (a *apiV2SystemServer) planDrain(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	resp := &serverpb.DrainPlanBatch{
-		DrainCohort: batch,
+	resp := &serverpb.RestartPlanBatch{
+		Batch:       batch,
 		MoreBatches: moreBatches,
 	}
 

--- a/pkg/server/api_v2.go
+++ b/pkg/server/api_v2.go
@@ -651,7 +651,11 @@ func planRollingRestart(
 	}
 
 	totalNodes := systemStatus.storePool.ClusterNodeCount()
-	nodesPerRound := int(math.Floor(float64(totalNodes) * (1.0 - capacityTarget)))
+	// due to floating-point rounding error, 1.0-0.8 < 0.2, so we end up a whole node short of our target.
+	// a fudge factor of about 1 in a million is sufficient to correct the error, and small enough to be
+	// insignificant
+	const fudgeFactor float64 = 1.0 / (1024.0 * 1024.0)
+	nodesPerRound := int(math.Floor(float64(totalNodes) * (1.0 - capacityTarget + fudgeFactor)))
 	if nodesPerRound < 1 {
 		nodesPerRound = 1
 	}

--- a/pkg/server/api_v2_test.go
+++ b/pkg/server/api_v2_test.go
@@ -267,23 +267,23 @@ func TestPlanDrain(t *testing.T) {
 
 		// Check if the response was a 200.
 		require.Equal(t, 200, resp.StatusCode)
-		// Check if an unmarshal into the (empty) DrainPlanBatch struct works.
-		var batchResult serverpb.DrainPlanBatch
+		// Check if an unmarshal into the (empty) RestartPlanBatch struct works.
+		var batchResult serverpb.RestartPlanBatch
 		require.NoError(t, json.NewDecoder(resp.Body).Decode(&batchResult))
 		require.NoError(t, resp.Body.Close())
 
 		// Check that the drain cohort is non-empty (which is expected here, since we're not actually downing any nodes)
 		// NB: In a real client, an empty cohort should just cause you to sleep for like 30s and check again.
-		require.Greater(t, len(batchResult.DrainCohort), 0)
+		require.Greater(t, len(batchResult.Batch), 0)
 		// Check that we're not exceeding our disruption budget
 		disruptionBudget := (1.0 - capacityTarget) * nodeCount
-		require.LessOrEqual(t, len(batchResult.DrainCohort), int(disruptionBudget))
-		t.Logf("Cohort size %d", len(batchResult.DrainCohort))
+		require.LessOrEqual(t, len(batchResult.Batch), int(disruptionBudget))
+		t.Logf("Cohort size %d", len(batchResult.Batch))
 
 		// NB: In a real operations orchestrator, this is where you go drain and restart the nodes in
-		// batchResult.DrainCohort in parallel
+		// batchResult.Batch in parallel
 
-		for _, toDrain := range batchResult.DrainCohort {
+		for _, toDrain := range batchResult.Batch {
 			_, ok := doneNodes[toDrain.NodeID]
 			// Check that we're not repeating any nodes that are already done
 			require.False(t, ok, "repeated drain node %d", toDrain.NodeID)

--- a/pkg/server/api_v2_test.go
+++ b/pkg/server/api_v2_test.go
@@ -213,7 +213,7 @@ func TestRestartSafetyV2(t *testing.T) {
 	require.NoError(t, json.Unmarshal(bodyBytes, &response))
 }
 
-func TestPlanDrain(t *testing.T) {
+func TestPlanRestart(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 

--- a/pkg/server/api_v2_test.go
+++ b/pkg/server/api_v2_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness/livenesspb"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server/apiconstants"
 	"github.com/cockroachdb/cockroach/pkg/server/authserver"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
@@ -210,6 +211,95 @@ func TestRestartSafetyV2(t *testing.T) {
 
 	require.Equal(t, 200, resp.StatusCode, "expected 200: %s", string(bodyBytes))
 	require.NoError(t, json.Unmarshal(bodyBytes, &response))
+}
+
+func TestPlanDrain(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	// locality config to put 25 nodes in 5 localities
+	locs := []string{"a", "b", "c", "d", "e"}
+	const nodeCount = 25
+	args := base.TestClusterArgs{}
+	args.ServerArgsPerNode = make(map[int]base.TestServerArgs)
+	for i := 0; i < nodeCount; i++ {
+		args.ServerArgsPerNode[i] = base.TestServerArgs{
+			Locality: roachpb.Locality{
+				Tiers: []roachpb.Tier{
+					{
+						Key:   "region",
+						Value: "test",
+					},
+					{
+						Key:   "zone",
+						Value: locs[i%len(locs)],
+					},
+				},
+			},
+		}
+	}
+	testCluster := serverutils.StartCluster(t, nodeCount, args)
+	ctx := context.Background()
+	defer testCluster.Stopper().Stop(ctx)
+
+	ts1 := testCluster.Server(0)
+
+	client, err := ts1.GetAdminHTTPClient()
+	require.NoError(t, err)
+
+	const capacityTarget = 0.75
+	doneNodes := map[roachpb.NodeID]struct{}{}
+	moreBatches := true
+	for moreBatches {
+		url := ts1.AdminURL().WithPath(apiconstants.APIV2Path + "drain/plan/")
+		query := url.Query()
+		query.Add("capacityTarget", fmt.Sprintf("%f", capacityTarget))
+		for nodeID := range doneNodes {
+			query.Add("doneNodes", strconv.Itoa(int(nodeID)))
+		}
+		url.RawQuery = query.Encode()
+
+		req, err := http.NewRequest("GET", url.String(), nil)
+		require.NoError(t, err)
+		resp, err := client.Do(req)
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+
+		// Check if the response was a 200.
+		require.Equal(t, 200, resp.StatusCode)
+		// Check if an unmarshal into the (empty) DrainPlanBatch struct works.
+		var batchResult serverpb.DrainPlanBatch
+		require.NoError(t, json.NewDecoder(resp.Body).Decode(&batchResult))
+		require.NoError(t, resp.Body.Close())
+
+		// Check that the drain cohort is non-empty (which is expected here, since we're not actually downing any nodes)
+		// NB: In a real client, an empty cohort should just cause you to sleep for like 30s and check again.
+		require.Greater(t, len(batchResult.DrainCohort), 0)
+		// Check that we're not exceeding our disruption budget
+		disruptionBudget := (1.0 - capacityTarget) * nodeCount
+		require.LessOrEqual(t, len(batchResult.DrainCohort), int(disruptionBudget))
+		t.Logf("Cohort size %d", len(batchResult.DrainCohort))
+
+		// NB: In a real operations orchestrator, this is where you go drain and restart the nodes in
+		// batchResult.DrainCohort in parallel
+
+		for _, toDrain := range batchResult.DrainCohort {
+			_, ok := doneNodes[toDrain.NodeID]
+			// Check that we're not repeating any nodes that are already done
+			require.False(t, ok, "repeated drain node %d", toDrain.NodeID)
+
+			doneNodes[toDrain.NodeID] = struct{}{}
+		}
+
+		// Check the more flag
+		if len(doneNodes) < nodeCount {
+			require.True(t, batchResult.MoreBatches)
+		} else {
+			require.False(t, batchResult.MoreBatches)
+		}
+
+		moreBatches = batchResult.MoreBatches
+	}
 }
 
 // TestRulesV2 tests the /api/v2/rules endpoint to ensure it

--- a/pkg/server/serverpb/admin.proto
+++ b/pkg/server/serverpb/admin.proto
@@ -650,8 +650,8 @@ message HealthRequest {
 message HealthResponse {
 }
 
-message DrainPlanBatch {
-  repeated roachpb.NodeDescriptor drainCohort = 1;
+message RestartPlanBatch {
+  repeated roachpb.NodeDescriptor batch = 1;
   bool moreBatches = 2;
 }
 

--- a/pkg/server/serverpb/admin.proto
+++ b/pkg/server/serverpb/admin.proto
@@ -650,6 +650,11 @@ message HealthRequest {
 message HealthResponse {
 }
 
+message DrainPlanBatch {
+  repeated roachpb.NodeDescriptor drainCohort = 1;
+  bool moreBatches = 2;
+}
+
 // LivenessRequest requests liveness data for all nodes on the cluster.
 message LivenessRequest {
 }

--- a/pkg/server/serverpb/admin.proto
+++ b/pkg/server/serverpb/admin.proto
@@ -652,7 +652,7 @@ message HealthResponse {
 
 message RestartPlanBatch {
   repeated roachpb.NodeDescriptor batch = 1;
-  bool moreBatches = 2;
+  bool more_batches = 2;
 }
 
 // LivenessRequest requests liveness data for all nodes on the cluster.

--- a/pkg/server/serverpb/status.proto
+++ b/pkg/server/serverpb/status.proto
@@ -2157,6 +2157,15 @@ message GetThrottlingMetadataRequest {
   string node_id = 1 [(gogoproto.customname) = "NodeID"];
 }
 
+message NodeFaultToleranceRequest {
+  string node_id = 1 [(gogoproto.customname) = "NodeID"];
+}
+
+message NodeFaultToleranceResponse {
+  bool can_terminate = 1;
+  repeated int32 neighbors = 2;
+}
+
 // GetThrottlingMetadataResponse contains all information necessary to
 // show throttling warnings and alerts in DB Console.
 message GetThrottlingMetadataResponse {
@@ -2690,4 +2699,8 @@ service Status {
       get: "/_status/throttling"
     };
   }
+
+  // NodeFaultToleranceStatus indicates whether it's safe to terminate a
+  // node, and what that node's neighbor nodes are in the replication graph
+  rpc NodeFaultToleranceStatus(NodeFaultToleranceRequest) returns (NodeFaultToleranceResponse) {}
 }


### PR DESCRIPTION
Iterates over groups of nodes that can be drained and restarted in parallel without creating unavailability.

Epic: none
Part of: https://cockroachlabs.atlassian.net/browse/TREQ-929

Release node (ops change):
The drain planning endpoint aids in efficient rolling restarts by examining replica placement and range health, and identifying non-overlapping nodes that can be drained and restarted without creating unavailability. It also respects cluster capacity constraints.