### PR TITLE
kvserver: clean up and fix truncations

### DIFF
--- a/pkg/kv/kvserver/kvserverpb/proposer_kv.go
+++ b/pkg/kv/kvserver/kvserverpb/proposer_kv.go
@@ -107,3 +107,14 @@ func (r *ReplicatedEvalResult) GetRaftTruncatedState() *RaftTruncatedState {
 	}
 	return r.State.TruncatedState
 }
+
+// DiscardRaftTruncation discards the RaftTruncatedState and the associated
+// metadata from this ReplicatedEvalResult.
+func (r *ReplicatedEvalResult) DiscardRaftTruncation() {
+	if r.State != nil {
+		r.State.TruncatedState = nil
+	}
+	r.RaftTruncatedState = nil
+	r.RaftLogDelta = 0
+	r.RaftExpectedFirstIndex = 0
+}

--- a/pkg/kv/kvserver/raft_log_queue.go
+++ b/pkg/kv/kvserver/raft_log_queue.go
@@ -19,7 +19,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/raft/tracker"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
-	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/spanconfig"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
@@ -724,10 +723,4 @@ func (*raftLogQueue) purgatoryChan() <-chan time.Time {
 
 func (*raftLogQueue) updateChan() <-chan time.Time {
 	return nil
-}
-
-func isLooselyCoupledRaftLogTruncationEnabled(
-	ctx context.Context, settings *cluster.Settings,
-) bool {
-	return looselyCoupledTruncationEnabled.Get(&settings.SV)
 }

--- a/pkg/kv/kvserver/raft_log_truncator.go
+++ b/pkg/kv/kvserver/raft_log_truncator.go
@@ -540,7 +540,7 @@ func (t *raftLogTruncator) tryEnactTruncations(
 	batch := t.store.getEngine().NewUnindexedBatch()
 	defer batch.Close()
 	if err := handleTruncatedStateBelowRaftPreApply(ctx, truncState,
-		&pendingTruncs.mu.truncs[enactIndex].RaftTruncatedState,
+		pendingTruncs.mu.truncs[enactIndex].RaftTruncatedState,
 		stateLoader.StateLoader, batch,
 	); err != nil {
 		log.Errorf(ctx, "while attempting to truncate raft log: %+v", err)

--- a/pkg/kv/kvserver/raft_log_truncator.go
+++ b/pkg/kv/kvserver/raft_log_truncator.go
@@ -563,6 +563,9 @@ func (t *raftLogTruncator) tryEnactTruncations(
 	// sync=false since we don't need a guarantee that the truncation is
 	// durable. Loss of a truncation means we have more of the suffix of the
 	// raft log, which does not affect correctness.
+	// TODO(pav-kv): there is a bug here. When a truncation removes sideloaded
+	// entries, there must be a log engine sync preceding the file removals. This
+	// is the same issue as #38566 and #113135 in the tightly-coupled stack.
 	if err := batch.Commit(false /* sync */); err != nil {
 		log.Errorf(ctx, "while committing batch to truncate raft log: %+v", err)
 		pendingTruncs.reset()

--- a/pkg/kv/kvserver/raft_truncator_replica.go
+++ b/pkg/kv/kvserver/raft_truncator_replica.go
@@ -30,8 +30,7 @@ func (r *raftTruncatorReplica) getTruncatedState() kvserverpb.RaftTruncatedState
 }
 
 func (r *raftTruncatorReplica) handleTruncationResult(ctx context.Context, pt pendingTruncation) {
-	(*Replica)(r).handleTruncatedStateResultRaftMuLocked(ctx, pt.RaftTruncatedState,
-		pt.expectedFirstIndex, pt.logDeltaBytes, pt.isDeltaTrusted)
+	(*Replica)(r).handleTruncatedStateResultRaftMuLocked(ctx, pt)
 }
 
 func (r *raftTruncatorReplica) getPendingTruncs() *pendingLogTruncations {

--- a/pkg/kv/kvserver/replica_app_batch.go
+++ b/pkg/kv/kvserver/replica_app_batch.go
@@ -526,12 +526,7 @@ func (b *replicaAppBatch) stageTruncation(
 	if !apply || discard {
 		// The truncated state was discarded, or we are queuing a pending
 		// truncation, so make sure we don't apply it to our in-memory state.
-		if res.State != nil {
-			res.State.TruncatedState = nil
-		}
-		res.RaftTruncatedState = nil
-		res.RaftLogDelta = 0
-		res.RaftExpectedFirstIndex = 0
+		res.DiscardRaftTruncation()
 	}
 	return nil
 }

--- a/pkg/kv/kvserver/replica_app_batch.go
+++ b/pkg/kv/kvserver/replica_app_batch.go
@@ -412,81 +412,8 @@ func (b *replicaAppBatch) runPostAddTriggersReplicaOnly(
 	}
 
 	if truncatedState := res.GetRaftTruncatedState(); truncatedState != nil {
-		var err error
-		// Typically one should not be checking the cluster version below raft,
-		// since it can cause state machine divergence. However, this check is
-		// only for deciding how to truncate the raft log, which is not part of
-		// the state machine. Also, we will eventually eliminate this check by
-		// only supporting loosely coupled truncation.
-		looselyCoupledTruncation := isLooselyCoupledRaftLogTruncationEnabled(ctx, b.r.ClusterSettings())
-		// In addition to cluster version and cluster settings, we also apply
-		// immediately if RaftExpectedFirstIndex is not populated (see comment in
-		// that proto).
-		//
-		// In the release following LooselyCoupledRaftLogTruncation, we will
-		// retire the strongly coupled path. It is possible that some replica
-		// still has a truncation sitting in a raft log that never populated
-		// RaftExpectedFirstIndex, which will be interpreted as 0. When applying
-		// it, the loosely coupled code will mark the log size as untrusted and
-		// will recompute the size. This has no correctness impact, so we are not
-		// going to bother with a long-running migration.
-		apply := !looselyCoupledTruncation || res.RaftExpectedFirstIndex == 0
-		if apply {
-			if apply, err = handleTruncatedStateBelowRaftPreApply(
-				ctx, b.truncState, truncatedState,
-				b.r.raftMu.stateLoader.StateLoader, b.batch,
-			); err != nil {
-				return errors.Wrap(err, "unable to handle truncated state")
-			}
-		} else {
-			b.r.store.raftTruncator.addPendingTruncation(
-				ctx, (*raftTruncatorReplica)(b.r), *truncatedState, res.RaftExpectedFirstIndex,
-				res.RaftLogDelta)
-		}
-		if apply {
-			// This truncation command will apply synchronously in this batch.
-			// Determine if there are any sideloaded entries that will be removed as a
-			// side effect.
-			//
-			// We must sync state machine batch application if the command removes any
-			// sideloaded log entries. Not doing so can lead to losing the entries.
-			// See the usage of changeTruncatesSideloadedFiles flag at the other end.
-			//
-			// We only need to check sideloaded entries in this path. The loosely
-			// coupled truncation mechanism in the other branch already ensures
-			// enacting truncations only after state machine synced.
-			if entries, size, err := b.r.raftMu.sideloaded.Stats(ctx, kvpb.RaftSpan{
-				After: b.truncState.Index, Last: truncatedState.Index,
-			}); err != nil {
-				return errors.Wrap(err, "failed searching for sideloaded entries")
-			} else if entries != 0 {
-				b.changeTruncatesSideloadedFiles = true
-				b.truncatedSideloadedSize = size
-			}
-		} else {
-			// The truncated state was discarded, or we are queuing a pending
-			// truncation, so make sure we don't apply it to our in-memory state.
-			if res.State != nil {
-				res.State.TruncatedState = nil
-			}
-			res.RaftTruncatedState = nil
-			res.RaftLogDelta = 0
-			res.RaftExpectedFirstIndex = 0
-			if !looselyCoupledTruncation {
-				// TODO(ajwerner): consider moving this code.
-				// We received a truncation that doesn't apply to us, so we know that
-				// there's a leaseholder out there with a log that has earlier entries
-				// than ours. That leader also guided our log size computations by
-				// giving us RaftLogDeltas for past truncations, and this was likely
-				// off. Mark our Raft log size is not trustworthy so that, assuming
-				// we step up as leader at some point in the future, we recompute
-				// our numbers.
-				// TODO(sumeer): this code will be deleted when there is no
-				// !looselyCoupledTruncation code path.
-				b.r.mu.Lock()
-				b.r.shMu.raftLogSizeTrusted = false
-				b.r.mu.Unlock()
-			}
+		if err := b.stageTruncation(ctx, res); err != nil {
+			return err
 		}
 	}
 
@@ -544,6 +471,92 @@ func (b *replicaAppBatch) runPostAddTriggersReplicaOnly(
 		log.Fatalf(ctx, "non-nil logical op log with nil write batch: %v", cmd.Cmd)
 	}
 
+	return nil
+}
+
+// stageTruncation stages the raft log truncation command. It prepares the
+// truncation to happen immediately if tightly coupled truncations are used, or
+// queues the truncation into the loosely coupled machinery otherwise.
+func (b *replicaAppBatch) stageTruncation(
+	ctx context.Context, res *kvserverpb.ReplicatedEvalResult,
+) error {
+	truncatedState := res.GetRaftTruncatedState() // NB: not nil
+	var err error
+	// Typically one should not be checking the cluster version below raft,
+	// since it can cause state machine divergence. However, this check is
+	// only for deciding how to truncate the raft log, which is not part of
+	// the state machine. Also, we will eventually eliminate this check by
+	// only supporting loosely coupled truncation.
+	looselyCoupledTruncation := isLooselyCoupledRaftLogTruncationEnabled(ctx, b.r.ClusterSettings())
+	// In addition to cluster version and cluster settings, we also apply
+	// immediately if RaftExpectedFirstIndex is not populated (see comment in
+	// that proto).
+	//
+	// In the release following LooselyCoupledRaftLogTruncation, we will
+	// retire the strongly coupled path. It is possible that some replica
+	// still has a truncation sitting in a raft log that never populated
+	// RaftExpectedFirstIndex, which will be interpreted as 0. When applying
+	// it, the loosely coupled code will mark the log size as untrusted and
+	// will recompute the size. This has no correctness impact, so we are not
+	// going to bother with a long-running migration.
+	apply := !looselyCoupledTruncation || res.RaftExpectedFirstIndex == 0
+	if apply {
+		if apply, err = handleTruncatedStateBelowRaftPreApply(
+			ctx, b.truncState, truncatedState,
+			b.r.raftMu.stateLoader.StateLoader, b.batch,
+		); err != nil {
+			return errors.Wrap(err, "unable to handle truncated state")
+		}
+	} else {
+		b.r.store.raftTruncator.addPendingTruncation(
+			ctx, (*raftTruncatorReplica)(b.r), *truncatedState, res.RaftExpectedFirstIndex,
+			res.RaftLogDelta)
+	}
+	if apply {
+		// This truncation command will apply synchronously in this batch.
+		// Determine if there are any sideloaded entries that will be removed as a
+		// side effect.
+		//
+		// We must sync state machine batch application if the command removes any
+		// sideloaded log entries. Not doing so can lead to losing the entries.
+		// See the usage of changeTruncatesSideloadedFiles flag at the other end.
+		//
+		// We only need to check sideloaded entries in this path. The loosely
+		// coupled truncation mechanism in the other branch already ensures
+		// enacting truncations only after state machine synced.
+		if entries, size, err := b.r.raftMu.sideloaded.Stats(ctx, kvpb.RaftSpan{
+			After: b.truncState.Index, Last: truncatedState.Index,
+		}); err != nil {
+			return errors.Wrap(err, "failed searching for sideloaded entries")
+		} else if entries != 0 {
+			b.changeTruncatesSideloadedFiles = true
+			b.truncatedSideloadedSize = size
+		}
+	} else {
+		// The truncated state was discarded, or we are queuing a pending
+		// truncation, so make sure we don't apply it to our in-memory state.
+		if res.State != nil {
+			res.State.TruncatedState = nil
+		}
+		res.RaftTruncatedState = nil
+		res.RaftLogDelta = 0
+		res.RaftExpectedFirstIndex = 0
+		if !looselyCoupledTruncation {
+			// TODO(ajwerner): consider moving this code.
+			// We received a truncation that doesn't apply to us, so we know that
+			// there's a leaseholder out there with a log that has earlier entries
+			// than ours. That leader also guided our log size computations by
+			// giving us RaftLogDeltas for past truncations, and this was likely
+			// off. Mark our Raft log size is not trustworthy so that, assuming
+			// we step up as leader at some point in the future, we recompute
+			// our numbers.
+			// TODO(sumeer): this code will be deleted when there is no
+			// !looselyCoupledTruncation code path.
+			b.r.mu.Lock()
+			b.r.shMu.raftLogSizeTrusted = false
+			b.r.mu.Unlock()
+		}
+	}
 	return nil
 }
 

--- a/pkg/kv/kvserver/replica_app_batch.go
+++ b/pkg/kv/kvserver/replica_app_batch.go
@@ -500,7 +500,7 @@ func (b *replicaAppBatch) stageTruncation(
 		// This truncation will apply synchronously in this batch. Stage the
 		// write into the batch, and compute metadata used after applying it.
 		if err := handleTruncatedStateBelowRaftPreApply(
-			ctx, b.truncState, truncatedState,
+			ctx, b.truncState, *truncatedState,
 			b.r.raftMu.stateLoader.StateLoader, b.batch,
 		); err != nil {
 			return errors.Wrap(err, "unable to handle truncated state")

--- a/pkg/kv/kvserver/replica_app_batch.go
+++ b/pkg/kv/kvserver/replica_app_batch.go
@@ -484,7 +484,7 @@ func (b *replicaAppBatch) stageTruncation(
 	var err error
 	// Use loosely-coupled truncations if configured by the setting. Otherwise,
 	// perform a tightly-coupled truncation, i.e. apply it immediately.
-	looselyCoupledTruncation := isLooselyCoupledRaftLogTruncationEnabled(ctx, b.r.ClusterSettings())
+	looselyCoupledTruncation := looselyCoupledTruncationEnabled.Get(&b.r.ClusterSettings().SV)
 	// We also apply immediately if RaftExpectedFirstIndex is not populated (see
 	// comment in that proto). It is possible that a replica still has a
 	// truncation sitting in the raft log that never populated this field.

--- a/pkg/kv/kvserver/replica_application_result.go
+++ b/pkg/kv/kvserver/replica_application_result.go
@@ -510,8 +510,7 @@ func (r *Replica) handleTruncatedStateResultRaftMuLocked(
 	// v22.1 that added it, when all truncations were strongly coupled. It is not
 	// safe to consider the log size delta trusted in this case. Conveniently,
 	// this doesn't need any special casing.
-	expectedFirstIndexWasAccurate := r.shMu.raftTruncState.Index+1 == pt.expectedFirstIndex
-	isRaftLogTruncationDeltaTrusted := pt.isDeltaTrusted && expectedFirstIndexWasAccurate
+	isDeltaTrusted := pt.isDeltaTrusted && r.shMu.raftTruncState.Index+1 == pt.expectedFirstIndex
 
 	// TODO(#132114, #131063): updating the truncated state after the storage
 	// writes leads to a necessity of the ErrCompacted handling in raft, when
@@ -520,8 +519,7 @@ func (r *Replica) handleTruncatedStateResultRaftMuLocked(
 	// is truncated "logically" first, and then physically under raftMu.
 	r.mu.Lock()
 	r.shMu.raftTruncState = pt.RaftTruncatedState
-	r.handleRaftLogDeltaResultRaftMuLockedReplicaMuLocked(
-		pt.logDeltaBytes, isRaftLogTruncationDeltaTrusted)
+	r.handleRaftLogDeltaResultRaftMuLockedReplicaMuLocked(pt.logDeltaBytes, isDeltaTrusted)
 	r.mu.Unlock()
 
 	// Clear any entries in the Raft log entry cache for this range up

--- a/pkg/kv/kvserver/replica_application_result.go
+++ b/pkg/kv/kvserver/replica_application_result.go
@@ -502,27 +502,16 @@ func (r *Replica) handleLeaseResult(
 // log truncation command. It updates the in-memory state of the Replica with
 // the new RaftTruncatedState and log size delta, and removes obsolete entries
 // from the raft log cache and sideloaded storage.
-//
-// The isDeltaTrusted flag specifies whether the raftLogDelta has been correctly
-// computed. The loosely coupled truncations stack sets it to false if, for
-// example, it failed to account for the sideloaded entries. The tightly coupled
-// truncations have correct stats.
-//
-// TODO(pav-kv): simplify this.
 func (r *Replica) handleTruncatedStateResultRaftMuLocked(
-	ctx context.Context,
-	t kvserverpb.RaftTruncatedState,
-	expectedFirstIndexPreTruncation kvpb.RaftIndex,
-	raftLogDelta int64,
-	isDeltaTrusted bool,
+	ctx context.Context, pt pendingTruncation,
 ) {
 	r.raftMu.AssertHeld()
 	// NB: The expected first index can be zero if this proposal is from before
 	// v22.1 that added it, when all truncations were strongly coupled. It is not
 	// safe to consider the log size delta trusted in this case. Conveniently,
 	// this doesn't need any special casing.
-	expectedFirstIndexWasAccurate := r.shMu.raftTruncState.Index+1 == expectedFirstIndexPreTruncation
-	isRaftLogTruncationDeltaTrusted := isDeltaTrusted && expectedFirstIndexWasAccurate
+	expectedFirstIndexWasAccurate := r.shMu.raftTruncState.Index+1 == pt.expectedFirstIndex
+	isRaftLogTruncationDeltaTrusted := pt.isDeltaTrusted && expectedFirstIndexWasAccurate
 
 	// TODO(#132114, #131063): updating the truncated state after the storage
 	// writes leads to a necessity of the ErrCompacted handling in raft, when
@@ -530,9 +519,9 @@ func (r *Replica) handleTruncatedStateResultRaftMuLocked(
 	// the truncated state is updated first. The semantics would be that the log
 	// is truncated "logically" first, and then physically under raftMu.
 	r.mu.Lock()
-	r.shMu.raftTruncState = t
+	r.shMu.raftTruncState = pt.RaftTruncatedState
 	r.handleRaftLogDeltaResultRaftMuLockedReplicaMuLocked(
-		raftLogDelta, isRaftLogTruncationDeltaTrusted)
+		pt.logDeltaBytes, isRaftLogTruncationDeltaTrusted)
 	r.mu.Unlock()
 
 	// Clear any entries in the Raft log entry cache for this range up
@@ -542,13 +531,13 @@ func (r *Replica) handleTruncatedStateResultRaftMuLocked(
 	// log reads under Replica.mu (from within RawNode) may temporarily return
 	// cached entries that are already removed from storage. It appears as if the
 	// read is performed right before the truncation batch was written.
-	r.store.raftEntryCache.Clear(r.RangeID, t.Index)
+	r.store.raftEntryCache.Clear(r.RangeID, pt.Index)
 
 	// Truncate the sideloaded storage. This is safe because the new truncated
 	// state is already synced. If it wasn't, a crash right after removing the
 	// sideloaded entries could result in missing entries in the log.
-	log.Eventf(ctx, "truncating sideloaded storage up to (and including) index %d", t.Index)
-	if err := r.raftMu.sideloaded.TruncateTo(ctx, t.Index); err != nil {
+	log.Eventf(ctx, "truncating sideloaded storage up to (and including) index %d", pt.Index)
+	if err := r.raftMu.sideloaded.TruncateTo(ctx, pt.Index); err != nil {
 		// We don't *have* to remove these entries for correctness. Log a loud
 		// error, but keep humming along.
 		log.Errorf(ctx, "while removing sideloaded files during log truncation: %+v", err)

--- a/pkg/kv/kvserver/replica_application_result.go
+++ b/pkg/kv/kvserver/replica_application_result.go
@@ -517,11 +517,11 @@ func (r *Replica) handleTruncatedStateResultRaftMuLocked(
 	isDeltaTrusted bool,
 ) {
 	r.raftMu.AssertHeld()
-	// NB: The expected first index is zero if this proposal is from before v22.1
-	// that added it, when all truncations were strongly coupled.
-	// TODO(pav-kv): remove the zero check after any below-raft migration.
-	expectedFirstIndexWasAccurate := expectedFirstIndexPreTruncation == 0 ||
-		r.shMu.raftTruncState.Index+1 == expectedFirstIndexPreTruncation
+	// NB: The expected first index can be zero if this proposal is from before
+	// v22.1 that added it, when all truncations were strongly coupled. It is not
+	// safe to consider the log size delta trusted in this case. Conveniently,
+	// this doesn't need any special casing.
+	expectedFirstIndexWasAccurate := r.shMu.raftTruncState.Index+1 == expectedFirstIndexPreTruncation
 	isRaftLogTruncationDeltaTrusted := isDeltaTrusted && expectedFirstIndexWasAccurate
 
 	// TODO(#132114, #131063): updating the truncated state after the storage

--- a/pkg/kv/kvserver/replica_application_state_machine.go
+++ b/pkg/kv/kvserver/replica_application_state_machine.go
@@ -329,9 +329,12 @@ func (sm *replicaStateMachine) handleNonTrivialReplicatedEvalResult(
 	if truncState != nil {
 		// The size delta in the proposal is accurate, but does not account for the
 		// sideloaded entries, so we fix it up.
-		logDelta := rResult.RaftLogDelta - sm.batch.truncatedSideloadedSize
-		sm.r.handleTruncatedStateResultRaftMuLocked(ctx, *truncState,
-			rResult.RaftExpectedFirstIndex, logDelta, true /* isDeltaTrusted */)
+		sm.r.handleTruncatedStateResultRaftMuLocked(ctx, pendingTruncation{
+			RaftTruncatedState: *truncState,
+			expectedFirstIndex: rResult.RaftExpectedFirstIndex,
+			logDeltaBytes:      rResult.RaftLogDelta - sm.batch.truncatedSideloadedSize,
+			isDeltaTrusted:     true,
+		})
 		rResult.RaftLogDelta = 0
 		rResult.RaftExpectedFirstIndex = 0
 	}

--- a/pkg/kv/kvserver/replica_application_state_machine.go
+++ b/pkg/kv/kvserver/replica_application_state_machine.go
@@ -289,24 +289,11 @@ func (sm *replicaStateMachine) handleNonTrivialReplicatedEvalResult(
 		log.Fatalf(ctx, "zero-value ReplicatedEvalResult passed to handleNonTrivialReplicatedEvalResult")
 	}
 
-	truncState := rResult.RaftTruncatedState
-	if truncState != nil {
-		rResult.RaftTruncatedState = nil
-	}
-
 	if rResult.State != nil {
 		if newLease := rResult.State.Lease; newLease != nil {
 			sm.r.handleLeaseResult(ctx, newLease, rResult.PriorReadSummary)
 			rResult.State.Lease = nil
 			rResult.PriorReadSummary = nil
-		}
-
-		if newTruncState := rResult.State.TruncatedState; newTruncState != nil {
-			if truncState != nil {
-				log.Fatalf(ctx, "double RaftTruncatedState in ReplicatedEvalResult")
-			}
-			truncState = newTruncState
-			rResult.State.TruncatedState = nil
 		}
 
 		if newVersion := rResult.State.Version; newVersion != nil {
@@ -326,7 +313,7 @@ func (sm *replicaStateMachine) handleNonTrivialReplicatedEvalResult(
 
 	// TODO(#93248): the strongly coupled truncation code will be removed once the
 	// loosely coupled truncations are the default.
-	if truncState != nil {
+	if truncState := rResult.GetRaftTruncatedState(); truncState != nil {
 		// The size delta in the proposal is accurate, but does not account for the
 		// sideloaded entries, so we fix it up.
 		sm.r.handleTruncatedStateResultRaftMuLocked(ctx, pendingTruncation{
@@ -335,8 +322,7 @@ func (sm *replicaStateMachine) handleNonTrivialReplicatedEvalResult(
 			logDeltaBytes:      rResult.RaftLogDelta - sm.batch.truncatedSideloadedSize,
 			isDeltaTrusted:     true,
 		})
-		rResult.RaftLogDelta = 0
-		rResult.RaftExpectedFirstIndex = 0
+		rResult.DiscardRaftTruncation()
 	}
 
 	// The rest of the actions are "nontrivial" and may have large effects on the

--- a/pkg/kv/kvserver/replica_application_state_machine.go
+++ b/pkg/kv/kvserver/replica_application_state_machine.go
@@ -327,11 +327,8 @@ func (sm *replicaStateMachine) handleNonTrivialReplicatedEvalResult(
 	// TODO(#93248): the strongly coupled truncation code will be removed once the
 	// loosely coupled truncations are the default.
 	if truncState != nil {
-		// NB: The RaftExpectedFirstIndex field is zero if this proposal is from
-		// before v22.1 that added it, when all truncations were strongly coupled.
-		// The delta in these historical proposals is accurate, but does not account
-		// for the sideloaded entries.
-		// TODO(pav-kv): remove the zero clause after any below-raft migration.
+		// The size delta in the proposal is accurate, but does not account for the
+		// sideloaded entries, so we fix it up.
 		logDelta := rResult.RaftLogDelta - sm.batch.truncatedSideloadedSize
 		sm.r.handleTruncatedStateResultRaftMuLocked(ctx, *truncState,
 			rResult.RaftExpectedFirstIndex, logDelta, true /* isDeltaTrusted */)

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -3052,7 +3052,7 @@ func (r *Replica) acquireMergeLock(
 func handleTruncatedStateBelowRaftPreApply(
 	ctx context.Context,
 	prev kvserverpb.RaftTruncatedState,
-	next *kvserverpb.RaftTruncatedState,
+	next kvserverpb.RaftTruncatedState,
 	loader logstore.StateLoader,
 	readWriter storage.ReadWriter,
 ) error {

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -3051,13 +3051,12 @@ func (r *Replica) acquireMergeLock(
 // snapshot.
 func handleTruncatedStateBelowRaftPreApply(
 	ctx context.Context,
-	currentTruncatedState kvserverpb.RaftTruncatedState,
-	suggestedTruncatedState *kvserverpb.RaftTruncatedState,
+	prev kvserverpb.RaftTruncatedState,
+	next *kvserverpb.RaftTruncatedState,
 	loader logstore.StateLoader,
 	readWriter storage.ReadWriter,
 ) (_apply bool, _ error) {
-	return logstore.Compact(ctx, currentTruncatedState, suggestedTruncatedState,
-		loader, readWriter)
+	return logstore.Compact(ctx, prev, next, loader, readWriter)
 }
 
 // shouldCampaignAfterConfChange returns true if the current replica should

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -3055,7 +3055,7 @@ func handleTruncatedStateBelowRaftPreApply(
 	next *kvserverpb.RaftTruncatedState,
 	loader logstore.StateLoader,
 	readWriter storage.ReadWriter,
-) (_apply bool, _ error) {
+) error {
 	return logstore.Compact(ctx, prev, next, loader, readWriter)
 }
 

--- a/pkg/kv/kvserver/replica_raft_truncation_test.go
+++ b/pkg/kv/kvserver/replica_raft_truncation_test.go
@@ -73,7 +73,7 @@ func TestHandleTruncatedStateBelowRaft(t *testing.T) {
 				d.ScanArgs(t, "index", &index)
 				d.ScanArgs(t, "term", &term)
 
-				suggestedTruncatedState := &kvserverpb.RaftTruncatedState{
+				suggestedTruncatedState := kvserverpb.RaftTruncatedState{
 					Index: kvpb.RaftIndex(index),
 					Term:  kvpb.RaftTerm(term),
 				}

--- a/pkg/kv/kvserver/replica_raft_truncation_test.go
+++ b/pkg/kv/kvserver/replica_raft_truncation_test.go
@@ -98,9 +98,9 @@ func TestHandleTruncatedStateBelowRaft(t *testing.T) {
 				}
 
 				// Apply truncation.
-				apply, err := handleTruncatedStateBelowRaftPreApply(ctx, currentTruncatedState, suggestedTruncatedState, loader, eng)
-				require.NoError(t, err)
-				fmt.Fprintf(&buf, "apply: %t\n", apply)
+				require.NoError(t, handleTruncatedStateBelowRaftPreApply(
+					ctx, currentTruncatedState, suggestedTruncatedState, loader, eng,
+				))
 
 				// Check the truncated state.
 				key := keys.RaftTruncatedStateKey(rangeID)

--- a/pkg/kv/kvserver/testdata/truncated_state/truncated_state
+++ b/pkg/kv/kvserver/testdata/truncated_state/truncated_state
@@ -7,29 +7,23 @@ prev index=100 term=9
 
 handle index=150 term=9
 ----
-apply: true
 state: /Local/RangeID/12/u/RaftTruncatedState -> index=150 term=9
 head: /Local/RangeID/12/u/RaftLog/logIndex:151
 
 # Simulate another truncation that moves forward.
-
 handle index=170 term=9
 ----
-apply: true
 state: /Local/RangeID/12/u/RaftTruncatedState -> index=170 term=9
 head: /Local/RangeID/12/u/RaftLog/logIndex:171
 
 # ... and one that moves backwards and should not take effect.
-
 handle index=150 term=9
 ----
-apply: false
 state: /Local/RangeID/12/u/RaftTruncatedState -> index=170 term=9
 head: /Local/RangeID/12/u/RaftLog/logIndex:171
 
 # A huge truncation (beyond raftLogTruncationClearRangeThreshold) also works.
 handle index=12345678901234567890 term=9
 ----
-apply: true
 state: /Local/RangeID/12/u/RaftTruncatedState -> index=12345678901234567890 term=9
 head: /Local/RangeID/12/u/RaftLog/logIndex:12345678901234567891

--- a/pkg/roachpb/data.go
+++ b/pkg/roachpb/data.go
@@ -517,6 +517,15 @@ func (v *Value) SetBytes(b []byte) {
 	v.setTag(ValueType_BYTES)
 }
 
+// AllocBytes allocates space for a BYTES value of the given size and clears the
+// checksum. The caller must populate the returned slice with exactly the same
+// number of bytes.
+func (v *Value) AllocBytes(size int) []byte {
+	v.ensureRawBytes(headerSize + size)
+	v.setTag(ValueType_BYTES)
+	return v.RawBytes[headerSize:]
+}
+
 // SetTagAndData copies the bytes and tag field to the receiver and clears the
 // checksum. As opposed to SetBytes, b is assumed to contain the tag too, not
 // just the data.


### PR DESCRIPTION
This PR further iterates on the raft log truncations stack code, and makes it cleaner. It also fixes a bug in log size maintenance.

The `RaftExpectedFirstIndex == 0` case now renders in distrusting the log size delta. Example scenario where the bug would previously occur:

- leader’s log is `(20, 80]`
- follower’s log is `(50, 80]` (e.g. it was inited from a snapshot)
- leader proposes a truncation <= `70`, with `sizeDelta = -size(20,70]`
- the follower does apply it, and does `raftLogSize += delta`
- the follower’s size is inaccurate (even though it believes otherwise)

Epic: none
Release note: none