### PR TITLE
explain: fix decoding plan gist with CALL stmts

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/explain_gist
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain_gist
@@ -212,3 +212,9 @@ query T
 SELECT crdb_internal.decode_external_plan_gist('Aifvzn5p':::STRING)
 ----
 • create view
+
+# Regression test for hitting an internal error on CALL expressions (#143211).
+query T nosort
+SELECT crdb_internal.decode_external_plan_gist('Aj0=':::STRING)
+----
+• call

--- a/pkg/sql/opt/exec/explain/emit.go
+++ b/pkg/sql/opt/exec/explain/emit.go
@@ -1172,7 +1172,14 @@ func (e *emitter) emitNodeAttributes(ctx context.Context, evalCtx *eval.Context,
 
 	case callOp:
 		a := n.args.(*callArgs)
-		ob.Expr("procedure", a.Proc, nil /* columns */)
+		if a.Proc != nil {
+			// Unlike other expressions, we store Proc as *tree.RoutineExpr, so
+			// the nil value in Proc is different from the nil value that is
+			// checked in Expr:
+			//  (*tree.RoutineExpr)(nil)  vs (tree.TypedExpr)(nil)
+			// so we need an explicit nil check.
+			ob.Expr("procedure", a.Proc, nil /* columns */)
+		}
 
 	case simpleProjectOp,
 		serializingProjectOp,


### PR DESCRIPTION
Previously we'd hit a nil pointer error when trying to print `Proc` argument when it is `nil`. The problem is that it is stored as `*tree.RoutineExpr`, and `(*tree.RoutineExpr)(nil)` is different from `(tree.TypedExpr)(nil)` that we check for (and short-circuit on) in the `Expr` call.

I have an idea for how we could've caught this, but it'll be done in a separate commit.

Fixes: #143211.

Release note (bug fix): CockroachDB would previously encounter an internal error when decoding plan gists of the plans with CALL statements. The bug has been present since 23.2 version and is now fixed.