### PR TITLE
sql: always update rows in merging indexes

### DIFF
--- a/pkg/sql/backfill/BUILD.bazel
+++ b/pkg/sql/backfill/BUILD.bazel
@@ -11,6 +11,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/base",
+        "//pkg/clusterversion",
         "//pkg/keys",
         "//pkg/kv",
         "//pkg/kv/kvpb",

--- a/pkg/sql/backfill/mvcc_index_merger.go
+++ b/pkg/sql/backfill/mvcc_index_merger.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
@@ -92,11 +93,12 @@ type keyBatch struct {
 // IndexBackfillMerger is a processor that merges entries from the corresponding
 // temporary index to a new index.
 type IndexBackfillMerger struct {
-	processorID    int32
-	spec           execinfrapb.IndexBackfillMergerSpec
-	desc           catalog.TableDescriptor
-	flowCtx        *execinfra.FlowCtx
-	muBoundAccount muBoundAccount
+	processorID         int32
+	spec                execinfrapb.IndexBackfillMergerSpec
+	desc                catalog.TableDescriptor
+	skipNewerTimestamps bool
+	flowCtx             *execinfra.FlowCtx
+	muBoundAccount      muBoundAccount
 }
 
 // OutputTypes is always nil.
@@ -115,6 +117,10 @@ const indexBackfillMergeProgressReportInterval = 10 * time.Second
 func (ibm *IndexBackfillMerger) Run(ctx context.Context, output execinfra.RowReceiver) {
 	opName := "IndexBackfillMerger"
 	ctx = logtags.AddTag(ctx, opName, int(ibm.spec.Table.ID))
+	// Starting 25.2 we can skip newer timestamps in the temporary index because
+	// of new logic to always write values to the newly created index during
+	// the merge process.
+	ibm.skipNewerTimestamps = ibm.flowCtx.Cfg.Settings.Version.IsActive(ctx, clusterversion.V25_2)
 	ctx, span := execinfra.ProcessorSpan(ctx, ibm.flowCtx, opName, ibm.processorID)
 	defer span.Finish()
 	// This method blocks until all worker goroutines exit, so it's safe to
@@ -488,7 +494,8 @@ func (ibm *IndexBackfillMerger) constructMergeBatch(
 		}
 		// If the timestamp we are looking at is after the merge timestamp,
 		// then no work needs to be done for this row.
-		if !sourceKV.Value.Timestamp.LessEq(ibm.spec.MergeTimestamp) {
+		if ibm.skipNewerTimestamps &&
+			!sourceKV.Value.Timestamp.LessEq(ibm.spec.MergeTimestamp) {
 			batch.markKeyAsSkipped(sourceOffset)
 			keysToSkip++
 			continue

--- a/pkg/sql/mvcc_backfiller_test.go
+++ b/pkg/sql/mvcc_backfiller_test.go
@@ -853,7 +853,7 @@ func TestIndexOverwritesChunksDuringMerge(t *testing.T) {
 	var mu syncutil.Mutex
 	var iteration = 0
 	// Upserts rows in the table. If sampleData is false,
-	// then all rows are updated. Otherwise, 1 in 4 rouws are
+	// then all rows are updated. Otherwise, 1 in 4 rows are
 	// updated.
 	writeMore = func(sampleData bool) error {
 		const rowsPerWrite = 500

--- a/pkg/sql/schemachanger/BUILD.bazel
+++ b/pkg/sql/schemachanger/BUILD.bazel
@@ -48,6 +48,7 @@ go_test(
         "//pkg/security/securitytest",
         "//pkg/server",
         "//pkg/sql",
+        "//pkg/sql/backfill",
         "//pkg/sql/catalog",
         "//pkg/sql/catalog/desctestutils",
         "//pkg/sql/execinfra",

--- a/pkg/sql/testdata/index_mutations/merging
+++ b/pkg/sql/testdata/index_mutations/merging
@@ -105,6 +105,7 @@ UPDATE tpfp SET b = b - 1
 ----
 Scan /Table/107/{1-2} lock Exclusive (Block, Unreplicated)
 Put /Table/107/1/3/0 -> /TUPLE/2:2:Int/1/1:3:Bytes/foo
+Put /Table/107/2/"foo"/0 -> /BYTES/0x8b
 
 # Update a row that matches the partial index before and after, and the index
 # entry changes.
@@ -183,7 +184,13 @@ UPDATE tifp SET b = ARRAY[1, 2, 2, NULL, 4, 4]
 ----
 Scan /Table/109/{1-2} lock Exclusive (Block, Unreplicated)
 Put /Table/109/1/1/0 -> /TUPLE/2:2:Array/ARRAY[1,2,2,NULL,4,4]
+Del /Table/109/2/NULL/1/0
+Del /Table/109/2/1/1/0
+Del /Table/109/2/2/1/0
 Del /Table/109/2/3/1/0
+Put /Table/109/2/NULL/1/0 -> /BYTES/
+Put /Table/109/2/1/1/0 -> /BYTES/
+Put /Table/109/2/2/1/0 -> /BYTES/
 Put /Table/109/2/4/1/0 -> /BYTES/
 
 # ---------------------------------------------------------


### PR DESCRIPTION
Previously, when an index was merging we would optimize updates to avoid writing duplicate values. Once we added optimizations inside the MVCC merge to skip rows in the temporary index with newer timestamps we started noticing failures. This was because of the following scenario:

1) An index starts a backfill with data from t
2) An update modifies rows to set some value A in a column, this
   gets captured by the temporary index.
3) The backfill completes and the index is now merging.
4) An update modifies the same rows to set some value A, this update
   always gets captured by the temporary index, giving it a new newer
   timestamp. The new index that is being merged ignores the updates,
   because the primary index already has the same values.
5) During the merge we skip over value A because of the optimization
   introduced in #142768

To address this, this patch treats merging indexes like temporary indexes and always forces any updates into them. This acts as a transient state to ensure that any newer updates are guaranteed to hit both the temporary and  secondary index. Additionally, the index merger optimization is version gated, so that the queries changes are guaranteed to be there to make things safe.

Fixes: #143116