### PR TITLE
kvserver: better obs in TestTxnReadWithinUncertaintyIntervalAfterRangeMerge

### DIFF
--- a/pkg/kv/kvpb/BUILD.bazel
+++ b/pkg/kv/kvpb/BUILD.bazel
@@ -78,6 +78,7 @@ go_test(
         "//pkg/roachpb",
         "//pkg/storage/enginepb",
         "//pkg/testutils/echotest",
+        "//pkg/testutils/skip",
         "//pkg/util/buildutil",
         "//pkg/util/encoding",
         "//pkg/util/hlc",

--- a/pkg/kv/kvpb/batch_test.go
+++ b/pkg/kv/kvpb/batch_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/lock"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/kr/pretty"
 	"github.com/stretchr/testify/require"
@@ -554,6 +555,7 @@ func TestRefreshSpanIterateSkipLocked(t *testing.T) {
 }
 
 func TestResponseKeyIterate(t *testing.T) {
+	skip.UnderNonTestBuild(t) // some assertions that are checked are only returned in test builds
 	keyA, keyB := roachpb.Key("a"), roachpb.Key("b")
 	keyC, keyD := roachpb.Key("c"), roachpb.Key("d")
 


### PR DESCRIPTION
Closes #143260.

This is a complex test with a rare failure mode. Trace all of the relevant operations so that we can meaningfully engage with it.

Epic: none
Release note: none