### PR TITLE
kvserver: fix durability bug in loosely coupled truncs

### DIFF
--- a/pkg/kv/kvserver/raft_log_truncator.go
+++ b/pkg/kv/kvserver/raft_log_truncator.go
@@ -164,9 +164,21 @@ type pendingTruncation struct {
 	isDeltaTrusted bool
 }
 
-func (pt *pendingTruncation) compactedIndex() kvpb.RaftIndex {
+func (pt pendingTruncation) compactedIndex() kvpb.RaftIndex {
 	// Reminder: RaftTruncatedState.Index is inclusive.
 	return pt.Index
+}
+
+// merge returns the result of merging this pendingTruncation with the one that
+// precedes it.
+func (pt pendingTruncation) merge(prev pendingTruncation) pendingTruncation {
+	res := prev
+	res.RaftTruncatedState = pt.RaftTruncatedState
+	res.logDeltaBytes += pt.logDeltaBytes
+	if !pt.isDeltaTrusted || prev.compactedIndex()+1 != pt.expectedFirstIndex {
+		res.isDeltaTrusted = false
+	}
+	return res
 }
 
 // raftLogTruncator is responsible for actually enacting truncations.
@@ -319,13 +331,7 @@ func (t *raftLogTruncator) addPendingTruncation(
 	if mergeWithPending {
 		// Merge the existing entry into the new one.
 		// No need to acquire pendingTruncs.mu for read in this case.
-		pendingTrunc.isDeltaTrusted = pendingTrunc.isDeltaTrusted &&
-			pendingTruncs.mu.truncs[pos].isDeltaTrusted
-		if pendingTruncs.mu.truncs[pos].compactedIndex()+1 != pendingTrunc.expectedFirstIndex {
-			pendingTrunc.isDeltaTrusted = false
-		}
-		pendingTrunc.logDeltaBytes += pendingTruncs.mu.truncs[pos].logDeltaBytes
-		pendingTrunc.expectedFirstIndex = pendingTruncs.mu.truncs[pos].expectedFirstIndex
+		pendingTrunc = pendingTrunc.merge(pendingTruncs.mu.truncs[pos])
 	}
 	pendingTruncs.mu.Lock()
 	// Install the new pending truncation.

--- a/pkg/kv/kvserver/raft_log_truncator.go
+++ b/pkg/kv/kvserver/raft_log_truncator.go
@@ -89,7 +89,7 @@ func (p *pendingLogTruncations) nextCompactedIndex(compIndex kvpb.RaftIndex) kvp
 	p.mu.Lock()
 	defer p.mu.Unlock()
 	p.iterateLocked(func(_ int, trunc pendingTruncation) {
-		compIndex = max(compIndex, trunc.compactedIndex())
+		compIndex = max(compIndex, trunc.Index)
 	})
 	return compIndex
 }
@@ -167,11 +167,6 @@ type pendingTruncation struct {
 	hasSideloaded bool
 }
 
-func (pt pendingTruncation) compactedIndex() kvpb.RaftIndex {
-	// Reminder: RaftTruncatedState.Index is inclusive.
-	return pt.Index
-}
-
 // merge returns the result of merging this pendingTruncation with the one that
 // precedes it.
 func (pt pendingTruncation) merge(prev pendingTruncation) pendingTruncation {
@@ -179,7 +174,7 @@ func (pt pendingTruncation) merge(prev pendingTruncation) pendingTruncation {
 	res.RaftTruncatedState = pt.RaftTruncatedState
 	res.logDeltaBytes += pt.logDeltaBytes
 	res.hasSideloaded = prev.hasSideloaded || pt.hasSideloaded
-	if !pt.isDeltaTrusted || prev.compactedIndex()+1 != pt.expectedFirstIndex {
+	if !pt.isDeltaTrusted || prev.Index+1 != pt.expectedFirstIndex {
 		res.isDeltaTrusted = false
 	}
 	return res
@@ -324,7 +319,7 @@ func (t *raftLogTruncator) addPendingTruncation(
 	// computation returns the same result regardless of which is plugged in as
 	// the lower bound.
 	if entries, size, err := r.sideloadedStats(ctx, kvpb.RaftSpan{
-		After: alreadyTruncIndex, Last: pendingTrunc.compactedIndex(),
+		After: alreadyTruncIndex, Last: pendingTrunc.Index,
 	}); err != nil {
 		// Log a loud error since we need to continue enqueuing the truncation.
 		log.Errorf(ctx, "while computing size of sideloaded files to truncate: %+v", err)

--- a/pkg/kv/kvserver/raft_log_truncator.go
+++ b/pkg/kv/kvserver/raft_log_truncator.go
@@ -137,6 +137,7 @@ func (p *pendingLogTruncations) capacity() int {
 	return len(p.mu.truncs)
 }
 
+// TODO(pav-kv): refresh this struct comments.
 type pendingTruncation struct {
 	// The pending truncation will truncate entries up to
 	// RaftTruncatedState.Index, inclusive.
@@ -147,12 +148,11 @@ type pendingTruncation struct {
 	// originates in ReplicatedEvalResult, where it is accurate.
 	// There are two reasons isDeltaTrusted could be considered false here:
 	// - The original "accurate" delta does not account for sideloaded files. It
-	//   is adjusted on this replica using
-	//   SideloadStorage.BytesIfTruncatedFromTo, but it is possible that the
-	//   truncated state of this replica is already > expectedFirstIndex. We
-	//   don't actually set isDeltaTrusted=false for this case since we will
-	//   change Replica.raftLogSizeTrusted to false after enacting this
-	//   truncation.
+	//   is adjusted on this replica using SideloadStorage.Stats, but it is
+	//   possible that the truncated state of this replica is already >
+	//   expectedFirstIndex. We don't actually set isDeltaTrusted=false for this
+	//   case since we will change Replica.raftLogSizeTrusted to false after
+	//   enacting this truncation.
 	// - We merge pendingTruncation entries in the pendingTruncations struct. We
 	//   are making an effort to have consecutive TruncateLogRequests provide us
 	//   stats for index intervals that are adjacent and non-overlapping, but
@@ -162,6 +162,9 @@ type pendingTruncation struct {
 	// ReplicatedEvalResult.RaftLogDelta, this is <= 0.
 	logDeltaBytes  int64
 	isDeltaTrusted bool
+	// hasSideloaded is true if the truncated interval contains at least one
+	// sideloaded entry.
+	hasSideloaded bool
 }
 
 func (pt pendingTruncation) compactedIndex() kvpb.RaftIndex {
@@ -175,6 +178,7 @@ func (pt pendingTruncation) merge(prev pendingTruncation) pendingTruncation {
 	res := prev
 	res.RaftTruncatedState = pt.RaftTruncatedState
 	res.logDeltaBytes += pt.logDeltaBytes
+	res.hasSideloaded = prev.hasSideloaded || pt.hasSideloaded
 	if !pt.isDeltaTrusted || prev.compactedIndex()+1 != pt.expectedFirstIndex {
 		res.isDeltaTrusted = false
 	}
@@ -256,8 +260,8 @@ type replicaForTruncator interface {
 	getPendingTruncs() *pendingLogTruncations
 	// Returns the sideloaded bytes that would be freed if we were to truncate
 	// (from, to].
-	sideloadedBytesIfTruncatedFromTo(
-		_ context.Context, _ kvpb.RaftSpan) (freed int64, _ error)
+	sideloadedStats(
+		_ context.Context, _ kvpb.RaftSpan) (entries uint64, size int64, _ error)
 	getStateLoader() stateloader.StateLoader
 	// NB: Setting the persistent raft state is via the Engine exposed by
 	// storeForTruncator.
@@ -319,15 +323,16 @@ func (t *raftLogTruncator) addPendingTruncation(
 	// In the common case of alreadyTruncIndex+1 == raftExpectedFirstIndex, the
 	// computation returns the same result regardless of which is plugged in as
 	// the lower bound.
-	sideloadedFreed, err := r.sideloadedBytesIfTruncatedFromTo(ctx, kvpb.RaftSpan{
+	if entries, size, err := r.sideloadedStats(ctx, kvpb.RaftSpan{
 		After: alreadyTruncIndex, Last: pendingTrunc.compactedIndex(),
-	})
-	if err != nil {
+	}); err != nil {
 		// Log a loud error since we need to continue enqueuing the truncation.
 		log.Errorf(ctx, "while computing size of sideloaded files to truncate: %+v", err)
 		pendingTrunc.isDeltaTrusted = false
+	} else if entries != 0 {
+		pendingTrunc.logDeltaBytes -= size
+		pendingTrunc.hasSideloaded = true
 	}
-	pendingTrunc.logDeltaBytes -= sideloadedFreed
 	if mergeWithPending {
 		// Merge the existing entry into the new one.
 		// No need to acquire pendingTruncs.mu for read in this case.
@@ -553,13 +558,14 @@ func (t *raftLogTruncator) tryEnactTruncations(
 		pendingTruncs.reset()
 		return
 	}
-	// sync=false since we don't need a guarantee that the truncation is
-	// durable. Loss of a truncation means we have more of the suffix of the
-	// raft log, which does not affect correctness.
-	// TODO(pav-kv): there is a bug here. When a truncation removes sideloaded
-	// entries, there must be a log engine sync preceding the file removals. This
-	// is the same issue as #38566 and #113135 in the tightly-coupled stack.
-	if err := batch.Commit(false /* sync */); err != nil {
+	// Most of the time, sync=false since we don't need a guarantee that the
+	// truncation is durable. Loss of a truncation means we have more of the
+	// suffix of the raft log, which does not affect correctness.
+	//
+	// If the truncated log interval contains sideloaded entries, we need to sync
+	// so that the subsequent removals from the sideloaded storage are safe.
+	sync := pendingTruncs.mu.truncs[enactIndex].hasSideloaded
+	if err := batch.Commit(sync); err != nil {
 		log.Errorf(ctx, "while committing batch to truncate raft log: %+v", err)
 		pendingTruncs.reset()
 		return

--- a/pkg/kv/kvserver/raft_log_truncator_test.go
+++ b/pkg/kv/kvserver/raft_log_truncator_test.go
@@ -389,3 +389,53 @@ func printTruncatorState(t *testing.T, buf *strings.Builder, truncator *raftLogT
 		prefixStr = ", "
 	}
 }
+
+func (pt pendingTruncation) delta(delta int64, trusted bool) pendingTruncation {
+	pt.logDeltaBytes = delta
+	pt.isDeltaTrusted = trusted
+	return pt
+}
+
+func TestPendingTruncationMerge(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	pt := func(from, to, term uint64) pendingTruncation {
+		return pendingTruncation{
+			RaftTruncatedState: kvserverpb.RaftTruncatedState{
+				Index: kvpb.RaftIndex(to),
+				Term:  kvpb.RaftTerm(term),
+			},
+			expectedFirstIndex: kvpb.RaftIndex(from + 1),
+		}
+	}
+	for _, tt := range []struct {
+		prev pendingTruncation
+		next pendingTruncation
+		want pendingTruncation
+	}{{
+		prev: pt(100, 200, 10).delta(1024, true),
+		next: pt(200, 300, 11).delta(1024, true),
+		want: pt(100, 300, 11).delta(2048, true),
+	}, {
+		prev: pt(100, 200, 10).delta(1024, false),
+		next: pt(200, 300, 11).delta(1024, true),
+		want: pt(100, 300, 11).delta(2048, false),
+	}, {
+		prev: pt(100, 200, 10).delta(1024, true),
+		next: pt(200, 300, 11).delta(1024, false),
+		want: pt(100, 300, 11).delta(2048, false),
+	}, {
+		prev: pt(100, 200, 10).delta(1024, true),
+		next: pt(150, 300, 11).delta(2048, true),
+		want: pt(100, 300, 11).delta(3072, false),
+	}, {
+		prev: pt(100, 200, 10).delta(1024, false),
+		next: pt(250, 400, 11).delta(2048, true),
+		want: pt(100, 400, 11).delta(3072, false),
+	}} {
+		t.Run("", func(t *testing.T) {
+			require.Equal(t, tt.want, tt.next.merge(tt.prev))
+		})
+	}
+}

--- a/pkg/kv/kvserver/raft_truncator_replica.go
+++ b/pkg/kv/kvserver/raft_truncator_replica.go
@@ -37,11 +37,10 @@ func (r *raftTruncatorReplica) getPendingTruncs() *pendingLogTruncations {
 	return &r.pendingLogTruncations
 }
 
-func (r *raftTruncatorReplica) sideloadedBytesIfTruncatedFromTo(
+func (r *raftTruncatorReplica) sideloadedStats(
 	ctx context.Context, span kvpb.RaftSpan,
-) (freed int64, err error) {
-	_, freed, err = r.raftMu.sideloaded.Stats(ctx, span)
-	return freed, err
+) (entries uint64, freed int64, err error) {
+	return r.raftMu.sideloaded.Stats(ctx, span)
 }
 
 func (r *raftTruncatorReplica) getStateLoader() stateloader.StateLoader {

--- a/pkg/kv/kvserver/replica_application_state_machine.go
+++ b/pkg/kv/kvserver/replica_application_state_machine.go
@@ -321,6 +321,7 @@ func (sm *replicaStateMachine) handleNonTrivialReplicatedEvalResult(
 			expectedFirstIndex: rResult.RaftExpectedFirstIndex,
 			logDeltaBytes:      rResult.RaftLogDelta - sm.batch.truncatedSideloadedSize,
 			isDeltaTrusted:     true,
+			hasSideloaded:      false, // unused, but listed here for completeness
 		})
 		rResult.DiscardRaftTruncation()
 	}

--- a/pkg/kv/kvserver/testdata/raft_log_truncator
+++ b/pkg/kv/kvserver/testdata/raft_log_truncator
@@ -28,14 +28,14 @@ add-pending-truncation id=1 first-index=16 trunc-index=22 delta-bytes=-20 sidelo
 ----
 r1.getPendingTruncs
 r1.getTruncatedState
-r1.sideloadedBytesIfTruncatedFromTo(20, 22)
+r1.sideloadedStats(20, 22)
 truncator ranges: 1
 
 print-replica-state id=1
 ----
 truncIndex: 20
 pending:
- {RaftTruncatedState:{Index:22 Term:0} expectedFirstIndex:16 logDeltaBytes:-30 isDeltaTrusted:true}
+ {RaftTruncatedState:{Index:22 Term:0} expectedFirstIndex:16 logDeltaBytes:-30 isDeltaTrusted:true hasSideloaded:true}
 
 # The durability advanced, but we haven't updated the RaftAppliedIndex, so the
 # pending truncation cannot be enacted.
@@ -52,7 +52,7 @@ print-replica-state id=1
 ----
 truncIndex: 20
 pending:
- {RaftTruncatedState:{Index:22 Term:0} expectedFirstIndex:16 logDeltaBytes:-30 isDeltaTrusted:true}
+ {RaftTruncatedState:{Index:22 Term:0} expectedFirstIndex:16 logDeltaBytes:-30 isDeltaTrusted:true hasSideloaded:true}
 
 # Queue another non-existent replica, to be annoying.
 add-replica-to-truncator id=13
@@ -69,14 +69,14 @@ add-pending-truncation id=2 first-index=21 trunc-index=22 delta-bytes=-20 sidelo
 ----
 r2.getPendingTruncs
 r2.getTruncatedState
-r2.sideloadedBytesIfTruncatedFromTo(20, 22)
+r2.sideloadedStats(20, 22)
 truncator ranges: 1, 2, 13
 
 print-replica-state id=2
 ----
 truncIndex: 20
 pending:
- {RaftTruncatedState:{Index:22 Term:0} expectedFirstIndex:21 logDeltaBytes:-30 isDeltaTrusted:true}
+ {RaftTruncatedState:{Index:22 Term:0} expectedFirstIndex:21 logDeltaBytes:-30 isDeltaTrusted:true hasSideloaded:true}
 
 # Update the RaftAppliedIndex of replica 1 to equal the index of the pending
 # truncation.
@@ -119,7 +119,7 @@ print-replica-state id=2
 ----
 truncIndex: 20
 pending:
- {RaftTruncatedState:{Index:22 Term:0} expectedFirstIndex:21 logDeltaBytes:-30 isDeltaTrusted:true}
+ {RaftTruncatedState:{Index:22 Term:0} expectedFirstIndex:21 logDeltaBytes:-30 isDeltaTrusted:true hasSideloaded:true}
 
 print-engine-state id=2
 ----
@@ -146,7 +146,7 @@ print-replica-state id=2
 ----
 truncIndex: 20
 pending:
- {RaftTruncatedState:{Index:22 Term:0} expectedFirstIndex:21 logDeltaBytes:-30 isDeltaTrusted:true}
+ {RaftTruncatedState:{Index:22 Term:0} expectedFirstIndex:21 logDeltaBytes:-30 isDeltaTrusted:true hasSideloaded:true}
 
 print-engine-state id=2
 ----
@@ -189,14 +189,14 @@ add-pending-truncation id=2 first-index=21 trunc-index=24 delta-bytes=-20 sidelo
 ----
 r2.getPendingTruncs
 r2.getTruncatedState
-r2.sideloadedBytesIfTruncatedFromTo(22, 24)
+r2.sideloadedStats(22, 24)
 truncator ranges: 2
 
 print-replica-state id=2
 ----
 truncIndex: 22
 pending:
- {RaftTruncatedState:{Index:24 Term:0} expectedFirstIndex:21 logDeltaBytes:-30 isDeltaTrusted:true}
+ {RaftTruncatedState:{Index:24 Term:0} expectedFirstIndex:21 logDeltaBytes:-30 isDeltaTrusted:true hasSideloaded:true}
 
 # Enact the truncation. Note the isDeltaTrusted is false.
 durability-advanced
@@ -226,28 +226,28 @@ add-pending-truncation id=2 first-index=25 trunc-index=26 delta-bytes=-20 sidelo
 ----
 r2.getPendingTruncs
 r2.getTruncatedState
-r2.sideloadedBytesIfTruncatedFromTo(24, 26)
+r2.sideloadedStats(24, 26)
 truncator ranges: 2
 
 add-pending-truncation id=2 first-index=27 trunc-index=28 delta-bytes=-20 sideloaded-bytes=10
 ----
 r2.getPendingTruncs
 r2.getTruncatedState
-r2.sideloadedBytesIfTruncatedFromTo(26, 28)
+r2.sideloadedStats(26, 28)
 truncator ranges: 2
 
 print-replica-state id=2
 ----
 truncIndex: 24
 pending:
- {RaftTruncatedState:{Index:26 Term:0} expectedFirstIndex:25 logDeltaBytes:-30 isDeltaTrusted:true}
- {RaftTruncatedState:{Index:28 Term:0} expectedFirstIndex:27 logDeltaBytes:-30 isDeltaTrusted:true}
+ {RaftTruncatedState:{Index:26 Term:0} expectedFirstIndex:25 logDeltaBytes:-30 isDeltaTrusted:true hasSideloaded:true}
+ {RaftTruncatedState:{Index:28 Term:0} expectedFirstIndex:27 logDeltaBytes:-30 isDeltaTrusted:true hasSideloaded:true}
 
 add-pending-truncation id=2 first-index=28 trunc-index=29 delta-bytes=-20 sideloaded-bytes=10
 ----
 r2.getPendingTruncs
 r2.getTruncatedState
-r2.sideloadedBytesIfTruncatedFromTo(28, 29)
+r2.sideloadedStats(28, 29)
 truncator ranges: 2
 
 # The last two pending truncations are merged and since they overlap,
@@ -256,8 +256,8 @@ print-replica-state id=2
 ----
 truncIndex: 24
 pending:
- {RaftTruncatedState:{Index:26 Term:0} expectedFirstIndex:25 logDeltaBytes:-30 isDeltaTrusted:true}
- {RaftTruncatedState:{Index:29 Term:0} expectedFirstIndex:27 logDeltaBytes:-60 isDeltaTrusted:false}
+ {RaftTruncatedState:{Index:26 Term:0} expectedFirstIndex:25 logDeltaBytes:-30 isDeltaTrusted:true hasSideloaded:true}
+ {RaftTruncatedState:{Index:29 Term:0} expectedFirstIndex:27 logDeltaBytes:-60 isDeltaTrusted:false hasSideloaded:true}
 
 # Advance RaftAppliedIndex enough to enact the first but not the second.
 write-raft-applied-index id=2 raft-applied-index=27
@@ -278,7 +278,7 @@ print-replica-state id=2
 ----
 truncIndex: 26
 pending:
- {RaftTruncatedState:{Index:29 Term:0} expectedFirstIndex:27 logDeltaBytes:-60 isDeltaTrusted:false}
+ {RaftTruncatedState:{Index:29 Term:0} expectedFirstIndex:27 logDeltaBytes:-60 isDeltaTrusted:false hasSideloaded:true}
 
 print-engine-state id=2
 ----
@@ -291,15 +291,15 @@ add-pending-truncation id=2 first-index=30 trunc-index=31 delta-bytes=-20 sidelo
 ----
 r2.getPendingTruncs
 r2.getTruncatedState
-r2.sideloadedBytesIfTruncatedFromTo(29, 31)
+r2.sideloadedStats(29, 31)
 truncator ranges: 2
 
 print-replica-state id=2
 ----
 truncIndex: 26
 pending:
- {RaftTruncatedState:{Index:29 Term:0} expectedFirstIndex:27 logDeltaBytes:-60 isDeltaTrusted:false}
- {RaftTruncatedState:{Index:31 Term:0} expectedFirstIndex:30 logDeltaBytes:-30 isDeltaTrusted:true}
+ {RaftTruncatedState:{Index:29 Term:0} expectedFirstIndex:27 logDeltaBytes:-60 isDeltaTrusted:false hasSideloaded:true}
+ {RaftTruncatedState:{Index:31 Term:0} expectedFirstIndex:30 logDeltaBytes:-30 isDeltaTrusted:true hasSideloaded:true}
 
 # Advance RaftAppliedIndex enough to enact both.
 write-raft-applied-index id=2 raft-applied-index=31
@@ -340,28 +340,28 @@ add-pending-truncation id=2 first-index=32 trunc-index=32 delta-bytes=-20 sidelo
 ----
 r2.getPendingTruncs
 r2.getTruncatedState
-r2.sideloadedBytesIfTruncatedFromTo(31, 32)
+r2.sideloadedStats(31, 32)
 truncator ranges: 2
 
 add-pending-truncation id=2 first-index=33 trunc-index=33 delta-bytes=-20 sideloaded-bytes=10
 ----
 r2.getPendingTruncs
 r2.getTruncatedState
-r2.sideloadedBytesIfTruncatedFromTo(32, 33)
+r2.sideloadedStats(32, 33)
 truncator ranges: 2
 
 print-replica-state id=2
 ----
 truncIndex: 31
 pending:
- {RaftTruncatedState:{Index:32 Term:0} expectedFirstIndex:32 logDeltaBytes:-30 isDeltaTrusted:true}
- {RaftTruncatedState:{Index:33 Term:0} expectedFirstIndex:33 logDeltaBytes:-30 isDeltaTrusted:true}
+ {RaftTruncatedState:{Index:32 Term:0} expectedFirstIndex:32 logDeltaBytes:-30 isDeltaTrusted:true hasSideloaded:true}
+ {RaftTruncatedState:{Index:33 Term:0} expectedFirstIndex:33 logDeltaBytes:-30 isDeltaTrusted:true hasSideloaded:true}
 
 add-pending-truncation id=2 first-index=34 trunc-index=34 delta-bytes=-20 sideloaded-bytes=10 sideloaded-err=true
 ----
 r2.getPendingTruncs
 r2.getTruncatedState
-r2.sideloadedBytesIfTruncatedFromTo(33, 34)
+r2.sideloadedStats(33, 34)
 truncator ranges: 2
 
 # Because of the error, the delta for the merged truncation is not trusted.
@@ -369,8 +369,8 @@ print-replica-state id=2
 ----
 truncIndex: 31
 pending:
- {RaftTruncatedState:{Index:32 Term:0} expectedFirstIndex:32 logDeltaBytes:-30 isDeltaTrusted:true}
- {RaftTruncatedState:{Index:34 Term:0} expectedFirstIndex:33 logDeltaBytes:-60 isDeltaTrusted:false}
+ {RaftTruncatedState:{Index:32 Term:0} expectedFirstIndex:32 logDeltaBytes:-30 isDeltaTrusted:true hasSideloaded:true}
+ {RaftTruncatedState:{Index:34 Term:0} expectedFirstIndex:33 logDeltaBytes:-50 isDeltaTrusted:false hasSideloaded:true}
 
 # Advance RaftAppliedIndex enough to enact all.
 write-raft-applied-index id=2 raft-applied-index=34
@@ -385,7 +385,7 @@ r2.getStateLoader
 r2.setTruncatedStateAndSideEffects(..., expectedFirstIndex:32) => trusted:true
 r2.setTruncationDeltaAndTrusted(delta:-30, trusted:true)
 r2.setTruncatedStateAndSideEffects(..., expectedFirstIndex:33) => trusted:true
-r2.setTruncationDeltaAndTrusted(delta:-60, trusted:false)
+r2.setTruncationDeltaAndTrusted(delta:-50, trusted:false)
 releaseReplica(2)
 truncator ranges:
 
@@ -416,22 +416,22 @@ add-pending-truncation id=3 first-index=21 trunc-index=22 delta-bytes=-20 sidelo
 ----
 r3.getPendingTruncs
 r3.getTruncatedState
-r3.sideloadedBytesIfTruncatedFromTo(20, 22)
+r3.sideloadedStats(20, 22)
 truncator ranges: 3
 
 add-pending-truncation id=3 first-index=23 trunc-index=24 delta-bytes=-20 sideloaded-bytes=10
 ----
 r3.getPendingTruncs
 r3.getTruncatedState
-r3.sideloadedBytesIfTruncatedFromTo(22, 24)
+r3.sideloadedStats(22, 24)
 truncator ranges: 3
 
 print-replica-state id=3
 ----
 truncIndex: 20
 pending:
- {RaftTruncatedState:{Index:22 Term:0} expectedFirstIndex:21 logDeltaBytes:-30 isDeltaTrusted:true}
- {RaftTruncatedState:{Index:24 Term:0} expectedFirstIndex:23 logDeltaBytes:-30 isDeltaTrusted:true}
+ {RaftTruncatedState:{Index:22 Term:0} expectedFirstIndex:21 logDeltaBytes:-30 isDeltaTrusted:true hasSideloaded:true}
+ {RaftTruncatedState:{Index:24 Term:0} expectedFirstIndex:23 logDeltaBytes:-30 isDeltaTrusted:true hasSideloaded:true}
 
 # Move RaftAppliedState enough to allow first truncation, but don't flush that
 # change.
@@ -452,8 +452,8 @@ print-replica-state id=3
 ----
 truncIndex: 20
 pending:
- {RaftTruncatedState:{Index:22 Term:0} expectedFirstIndex:21 logDeltaBytes:-30 isDeltaTrusted:true}
- {RaftTruncatedState:{Index:24 Term:0} expectedFirstIndex:23 logDeltaBytes:-30 isDeltaTrusted:true}
+ {RaftTruncatedState:{Index:22 Term:0} expectedFirstIndex:21 logDeltaBytes:-30 isDeltaTrusted:true hasSideloaded:true}
+ {RaftTruncatedState:{Index:24 Term:0} expectedFirstIndex:23 logDeltaBytes:-30 isDeltaTrusted:true hasSideloaded:true}
 
 print-engine-state id=3
 ----
@@ -482,7 +482,7 @@ print-replica-state id=3
 ----
 truncIndex: 22
 pending:
- {RaftTruncatedState:{Index:24 Term:0} expectedFirstIndex:23 logDeltaBytes:-30 isDeltaTrusted:true}
+ {RaftTruncatedState:{Index:24 Term:0} expectedFirstIndex:23 logDeltaBytes:-30 isDeltaTrusted:true hasSideloaded:true}
 
 print-engine-state id=3
 ----


### PR DESCRIPTION
This PR fixes a bug equivalent to the one we had in tightly coupled truncations stack. The log engine is now synced when applying a truncation that removes sideloaded entries. Not doing so could result in a log with missing entries, and crashes when the leader attempts to replicate such a log.

Related to #38566, #113135, #114191