### PR TITLE
kvclient: use buffered write when evaluating ConditionalPut 

### DIFF
--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_write_buffer.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_write_buffer.go
@@ -345,10 +345,21 @@ func (twb *txnWriteBuffer) applyTransformations(
 		req := ru.GetInner()
 		switch t := req.(type) {
 		case *kvpb.ConditionalPutRequest:
+			var resp kvpb.ResponseUnion
+			val, served := twb.maybeServeRead(t.Key, t.Sequence)
+			if served {
+				// TODO(ssd): If we tracked locked information here, we could avoid the
+				// locking Get below.
+				log.VEventf(ctx, 2, "serving read portion of %s on key %s from the buffer", t.Method(), t.Key)
+				resp.MustSetInner(&kvpb.GetResponse{
+					Value: val,
+				})
+			}
 			ts = append(ts, transformation{
 				stripped:    false,
 				index:       i,
 				origRequest: req,
+				resp:        resp,
 			})
 			getReq := &kvpb.GetRequest{
 				RequestHeader: kvpb.RequestHeader{
@@ -363,8 +374,6 @@ func (twb *txnWriteBuffer) applyTransformations(
 			// Send a locking Get request to the KV layer; we'll evaluate the
 			// condition locally based on the response.
 			baRemote.Requests = append(baRemote.Requests, getReqU)
-			// TODO(arul): We're not handling the case where this Get needs to
-			// be served locally from the buffer yet.
 
 		case *kvpb.PutRequest:
 			// If the MustAcquireExclusiveLock flag is set on the Put, then we need to
@@ -811,7 +820,16 @@ func (t transformation) toResp(
 		if twb.testingOverrideCPutEvalFn != nil {
 			evalFn = twb.testingOverrideCPutEvalFn
 		}
-		getResp := br.GetInner().(*kvpb.GetResponse)
+
+		var getResp *kvpb.GetResponse
+		if bufResp := t.resp.GetGet(); bufResp != nil {
+			// If we served the response out of the buffer, we don't care what came
+			// back from KV.
+			getResp = bufResp
+		} else {
+			getResp = br.GetInner().(*kvpb.GetResponse)
+		}
+
 		condFailedErr := evalFn(
 			req.ExpBytes,
 			getResp.Value,

--- a/pkg/sql/logictest/testdata/logic_test/buffered_writes
+++ b/pkg/sql/logictest/testdata/logic_test/buffered_writes
@@ -60,3 +60,25 @@ DELETE FROM t1 WHERE pk = 1
 
 statement ok
 COMMIT
+
+subtest delete_then_insert
+
+statement ok
+INSERT INTO t1 VALUES (1,1)
+
+statement ok
+BEGIN
+
+statement count 1
+DELETE FROM t1 WHERE pk = 1
+
+statement ok
+INSERT INTO t1 VALUES (1,1)
+
+statement ok
+COMMIT
+
+query II
+SELECT * FROM t1
+----
+1 1


### PR DESCRIPTION
When evaluating a ConditionalPutRequest, the condition needs to be
evaluated against any buffered writes.

It should be possible to elide the locking Get completely if the
buffered key was already locked, but we don't yet track that
information in the write buffer.

Epic: none
Release note: None