### PR TITLE
release-25.1: release: decrease log level for preflight check

### DIFF
--- a/build/teamcity/internal/cockroach/release/publish/publish-redhat-release.sh
+++ b/build/teamcity/internal/cockroach/release/publish/publish-redhat-release.sh
@@ -77,7 +77,7 @@ mkdir -p artifacts
 docker run \
   --rm \
   --security-opt=label=disable \
-  --env PFLT_LOGLEVEL=trace \
+  --env PFLT_LOGLEVEL=error \
   --env PFLT_ARTIFACTS=/artifacts \
   --env PFLT_LOGFILE=/artifacts/preflight.log \
   --env PFLT_CERTIFICATION_PROJECT_ID="$rhel_project_id" \


### PR DESCRIPTION
Backport 1/1 commits from #143286 on behalf of @rail.

/cc @cockroachdb/release

----

Previously, the preflight check was logging at the trace level, which created a huge log file, what caused the API server to reject submissions due to the log file size. At the same time, the catalog still showed the image as published, which was misleading. This commit reduce the log level to error.

Release note: none
Epic: none


----

Release justification: release automation changes