### PR TITLE
release-25.1: sql: avoid dangling role reference in default privileges

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/drop_role_with_default_privileges
+++ b/pkg/sql/logictest/testdata/logic_test/drop_role_with_default_privileges
@@ -183,3 +183,23 @@ statement ok
 DROP USER IF EXISTS a_user_that_does_not_exist;
 
 subtest end
+
+# Verify that a granting default privileges to the same role the defaults are
+# being defined for has no undesirable side effect.
+subtest default_priv_granted_to_self
+
+statement ok
+CREATE ROLE self_referencing_role
+
+statement ok
+ALTER DEFAULT PRIVILEGES FOR ROLE self_referencing_role GRANT INSERT ON TABLES TO self_referencing_role
+
+statement ok
+DROP ROLE self_referencing_role
+
+query I
+SELECT count(*) FROM crdb_internal.invalid_objects
+----
+0
+
+subtest end


### PR DESCRIPTION
Backport 1/1 commits from #143287 on behalf of @rafiss.

/cc @cockroachdb/release

----

fixes https://github.com/cockroachdb/cockroach/issues/142777
Release note (bug fix): Fixed a bug that could leave behind a dangling reference to a dropped role if that role had default privileges granted to itself. The bug was caused by defining privileges such as: `ALTER DEFAULT PRIVILEGES FOR ROLE self_referencing_role GRANT INSERT ON TABLES TO self_referencing_role`

----

Release justification: bug fix