### PR TITLE
util/mon: reduce monitor-related allocations

### DIFF
--- a/pkg/backup/backup_test.go
+++ b/pkg/backup/backup_test.go
@@ -8370,7 +8370,7 @@ func TestReadBackupManifestMemoryMonitoring(t *testing.T) {
 	require.NoError(t, err)
 
 	m := mon.NewMonitor(mon.Options{
-		Name:     mon.MakeMonitorName("test-monitor"),
+		Name:     mon.MakeName("test-monitor"),
 		Settings: st,
 	})
 	m.Start(ctx, nil, mon.NewStandaloneBudget(128<<20))

--- a/pkg/backup/backuputils/memory_backed_quota_pool.go
+++ b/pkg/backup/backuputils/memory_backed_quota_pool.go
@@ -40,7 +40,7 @@ func NewMemoryBackedQuotaPool(
 	}
 
 	if m != nil {
-		q.mon = mon.NewMonitorInheritWithLimitAndStringName(name, limit, m, false /* longLiving */)
+		q.mon = mon.NewMonitorInheritWithLimit(mon.MakeName(name), limit, m, false /* longLiving */)
 		q.mon.StartNoReserved(ctx, m)
 		mem := q.mon.MakeBoundAccount()
 		q.mem = &mem

--- a/pkg/backup/backuputils/memory_backed_quota_pool.go
+++ b/pkg/backup/backuputils/memory_backed_quota_pool.go
@@ -40,7 +40,7 @@ func NewMemoryBackedQuotaPool(
 	}
 
 	if m != nil {
-		q.mon = mon.NewMonitorInheritWithLimit(name, limit, m, false /* longLiving */)
+		q.mon = mon.NewMonitorInheritWithLimitAndStringName(name, limit, m, false /* longLiving */)
 		q.mon.StartNoReserved(ctx, m)
 		mem := q.mon.MakeBoundAccount()
 		q.mem = &mem

--- a/pkg/backup/backuputils/memory_backed_quota_pool_test.go
+++ b/pkg/backup/backuputils/memory_backed_quota_pool_test.go
@@ -21,7 +21,7 @@ import (
 
 func getMemoryMonitor(limit int64) *mon.BytesMonitor {
 	return mon.NewMonitor(mon.Options{
-		Name:      mon.MakeMonitorName("test-mon"),
+		Name:      mon.MakeName("test-mon"),
 		Limit:     limit,
 		Increment: 1,
 		Settings:  cluster.MakeTestingClusterSettings(),

--- a/pkg/backup/restore_data_processor_test.go
+++ b/pkg/backup/restore_data_processor_test.go
@@ -270,7 +270,7 @@ func runTestIngest(t *testing.T, init func(*cluster.Settings)) {
 			Settings: s.ClusterSettings(),
 			Codec:    s.Codec(),
 			BackupMonitor: mon.NewUnlimitedMonitor(ctx, mon.Options{
-				Name:     mon.MakeMonitorName("test"),
+				Name:     mon.MakeName("test"),
 				Settings: s.ClusterSettings(),
 			}),
 			BulkSenderLimiter: limit.MakeConcurrentRequestLimiter("test", math.MaxInt),

--- a/pkg/base/config.go
+++ b/pkg/base/config.go
@@ -947,11 +947,11 @@ func InheritTempStorageConfig(
 func newTempStorageConfig(
 	ctx context.Context, st *cluster.Settings, inMemory bool, useStore StoreSpec, maxSizeBytes int64,
 ) TempStorageConfig {
-	var monitorName mon.MonitorName
+	var monitorName mon.Name
 	if inMemory {
-		monitorName = mon.MakeMonitorName("in-mem temp storage")
+		monitorName = mon.MakeName("in-mem temp storage")
 	} else {
-		monitorName = mon.MakeMonitorName("temp disk storage")
+		monitorName = mon.MakeName("temp disk storage")
 	}
 	monitor := mon.NewMonitor(mon.Options{
 		Name:      monitorName,

--- a/pkg/base/test_server_args.go
+++ b/pkg/base/test_server_args.go
@@ -591,7 +591,7 @@ func DefaultTestTempStorageConfigWithSize(
 	st *cluster.Settings, maxSizeBytes int64,
 ) TempStorageConfig {
 	monitor := mon.NewMonitor(mon.Options{
-		Name:      mon.MakeMonitorName("in-mem temp storage"),
+		Name:      mon.MakeName("in-mem temp storage"),
 		Res:       mon.DiskResource,
 		Increment: 1024 * 1024,
 		Settings:  st,

--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -195,7 +195,7 @@ func newChangeAggregatorProcessor(
 		}
 	}()
 
-	memMonitor := execinfra.NewMonitorWithStringName(ctx, flowCtx.Mon, "changeagg-mem")
+	memMonitor := execinfra.NewMonitor(ctx, flowCtx.Mon, mon.MakeName("changeagg-mem"))
 	ca := &changeAggregator{
 		spec:              spec,
 		memAcc:            memMonitor.MakeBoundAccount(),
@@ -1193,7 +1193,7 @@ func newChangeFrontierProcessor(
 	input execinfra.RowSource,
 	post *execinfrapb.PostProcessSpec,
 ) (execinfra.Processor, error) {
-	memMonitor := execinfra.NewMonitorWithStringName(ctx, flowCtx.Mon, "changefntr-mem")
+	memMonitor := execinfra.NewMonitor(ctx, flowCtx.Mon, mon.MakeName("changefntr-mem"))
 
 	cf := &changeFrontier{
 		// We might modify the ChangefeedState field in the eval.Context, so we

--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -195,7 +195,7 @@ func newChangeAggregatorProcessor(
 		}
 	}()
 
-	memMonitor := execinfra.NewMonitor(ctx, flowCtx.Mon, "changeagg-mem")
+	memMonitor := execinfra.NewMonitorWithStringName(ctx, flowCtx.Mon, "changeagg-mem")
 	ca := &changeAggregator{
 		spec:              spec,
 		memAcc:            memMonitor.MakeBoundAccount(),
@@ -444,7 +444,7 @@ func (ca *changeAggregator) startKVFeed(
 	opts changefeedbase.StatementOptions,
 ) (kvevent.Reader, chan struct{}, chan error, error) {
 	cfg := ca.FlowCtx.Cfg
-	kvFeedMemMon := mon.NewMonitorInheritWithLimit("kvFeed", memLimit, parentMemMon, false /* longLiving */)
+	kvFeedMemMon := mon.NewMonitorInheritWithLimitAndStringName("kvFeed", memLimit, parentMemMon, false /* longLiving */)
 	kvFeedMemMon.StartNoReserved(ctx, parentMemMon)
 	buf := kvevent.NewThrottlingBuffer(
 		kvevent.NewMemBuffer(kvFeedMemMon.MakeBoundAccount(), &cfg.Settings.SV, &ca.metrics.KVFeedMetrics.AggregatorBufferMetricsWithCompat),
@@ -1193,7 +1193,7 @@ func newChangeFrontierProcessor(
 	input execinfra.RowSource,
 	post *execinfrapb.PostProcessSpec,
 ) (execinfra.Processor, error) {
-	memMonitor := execinfra.NewMonitor(ctx, flowCtx.Mon, "changefntr-mem")
+	memMonitor := execinfra.NewMonitorWithStringName(ctx, flowCtx.Mon, "changefntr-mem")
 
 	cf := &changeFrontier{
 		// We might modify the ChangefeedState field in the eval.Context, so we

--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -444,7 +444,7 @@ func (ca *changeAggregator) startKVFeed(
 	opts changefeedbase.StatementOptions,
 ) (kvevent.Reader, chan struct{}, chan error, error) {
 	cfg := ca.FlowCtx.Cfg
-	kvFeedMemMon := mon.NewMonitorInheritWithLimitAndStringName("kvFeed", memLimit, parentMemMon, false /* longLiving */)
+	kvFeedMemMon := mon.NewMonitorInheritWithLimit(mon.MakeName("kvFeed"), memLimit, parentMemMon, false /* longLiving */)
 	kvFeedMemMon.StartNoReserved(ctx, parentMemMon)
 	buf := kvevent.NewThrottlingBuffer(
 		kvevent.NewMemBuffer(kvFeedMemMon.MakeBoundAccount(), &cfg.Settings.SV, &ca.metrics.KVFeedMetrics.AggregatorBufferMetricsWithCompat),

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -9330,7 +9330,7 @@ func TestChangefeedPredicateWithSchemaChange(t *testing.T) {
 
 func startMonitorWithBudget(budget int64) *mon.BytesMonitor {
 	mm := mon.NewMonitor(mon.Options{
-		Name:      mon.MakeMonitorName("test-mm"),
+		Name:      mon.MakeName("test-mm"),
 		Limit:     budget,
 		Increment: 128, /* small allocation increment */
 		Settings:  cluster.MakeTestingClusterSettings(),

--- a/pkg/ccl/changefeedccl/kvevent/blocking_buffer_test.go
+++ b/pkg/ccl/changefeedccl/kvevent/blocking_buffer_test.go
@@ -68,7 +68,7 @@ func makeRangeFeedEvent(rnd *rand.Rand, valSize int, prevValSize int) *kvpb.Rang
 
 func getBoundAccountWithBudget(budget int64) (account mon.BoundAccount, cleanup func()) {
 	mm := mon.NewMonitor(mon.Options{
-		Name:      mon.MakeMonitorName("test-mm"),
+		Name:      mon.MakeName("test-mm"),
 		Limit:     budget,
 		Increment: 128, /* small allocation increment */
 		Settings:  cluster.MakeTestingClusterSettings(),

--- a/pkg/ccl/changefeedccl/kvfeed/kv_feed_test.go
+++ b/pkg/ccl/changefeedccl/kvfeed/kv_feed_test.go
@@ -120,7 +120,7 @@ func TestKVFeed(t *testing.T) {
 	runTest := func(t *testing.T, tc testCase) {
 		settings := cluster.MakeTestingClusterSettings()
 		mm := mon.NewUnlimitedMonitor(context.Background(), mon.Options{
-			Name:     mon.MakeMonitorName("test"),
+			Name:     mon.MakeName("test"),
 			Settings: settings,
 		})
 		metrics := kvevent.MakeMetrics(time.Minute)

--- a/pkg/kv/bulk/kv_buf_test.go
+++ b/pkg/kv/bulk/kv_buf_test.go
@@ -51,10 +51,10 @@ func TestKvBuf(t *testing.T) {
 	src, totalSize := makeTestData(50000)
 
 	ctx := context.Background()
-	noneMonitor := mon.NewMonitor(mon.Options{Name: mon.MakeMonitorName("none")})
+	noneMonitor := mon.NewMonitor(mon.Options{Name: mon.MakeName("none")})
 	noneMonitor.StartNoReserved(ctx, nil /* pool */)
 	none := noneMonitor.MakeEarmarkedBoundAccount()
-	lots := mon.NewUnlimitedMonitor(ctx, mon.Options{Name: mon.MakeMonitorName("lots")}).
+	lots := mon.NewUnlimitedMonitor(ctx, mon.Options{Name: mon.MakeName("lots")}).
 		MakeEarmarkedBoundAccount()
 
 	// Write everything to our buf.

--- a/pkg/kv/bulk/sst_batcher_test.go
+++ b/pkg/kv/bulk/sst_batcher_test.go
@@ -49,7 +49,7 @@ func TestDuplicateHandling(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
 
-	mem := mon.NewUnlimitedMonitor(ctx, mon.Options{Name: mon.MakeMonitorName("lots")})
+	mem := mon.NewUnlimitedMonitor(ctx, mon.Options{Name: mon.MakeName("lots")})
 	reqs := limit.MakeConcurrentRequestLimiter("reqs", 1000)
 	s, _, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(ctx)
@@ -310,7 +310,7 @@ func runTestImport(t *testing.T, batchSizeValue int64) {
 			))
 
 			ts := hlc.Timestamp{WallTime: 100}
-			mem := mon.NewUnlimitedMonitor(ctx, mon.Options{Name: mon.MakeMonitorName("lots")})
+			mem := mon.NewUnlimitedMonitor(ctx, mon.Options{Name: mon.MakeName("lots")})
 			reqs := limit.MakeConcurrentRequestLimiter("reqs", 1000)
 			b, err := bulk.MakeBulkAdder(
 				ctx, kvDB, mockCache, s.ClusterSettings(), ts,
@@ -376,7 +376,7 @@ func TestImportEpochIngestion(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
 
-	mem := mon.NewUnlimitedMonitor(ctx, mon.Options{Name: mon.MakeMonitorName("lots")})
+	mem := mon.NewUnlimitedMonitor(ctx, mon.Options{Name: mon.MakeName("lots")})
 	reqs := limit.MakeConcurrentRequestLimiter("reqs", 1000)
 	s, _, kvDB := serverutils.StartServer(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(ctx)

--- a/pkg/kv/kvclient/kvstreamer/results_buffer_test.go
+++ b/pkg/kv/kvclient/kvstreamer/results_buffer_test.go
@@ -44,7 +44,7 @@ func TestInOrderResultsBuffer(t *testing.T) {
 	require.NoError(t, err)
 	defer tempEngine.Close()
 	memMonitor := mon.NewMonitor(mon.Options{
-		Name:     mon.MakeMonitorName("test-mem"),
+		Name:     mon.MakeName("test-mem"),
 		Res:      mon.MemoryResource,
 		Settings: st,
 	})
@@ -52,7 +52,7 @@ func TestInOrderResultsBuffer(t *testing.T) {
 	defer memMonitor.Stop(ctx)
 	memAcc := memMonitor.MakeBoundAccount()
 	diskMonitor := mon.NewMonitor(mon.Options{
-		Name:     mon.MakeMonitorName("test-disk"),
+		Name:     mon.MakeName("test-disk"),
 		Res:      mon.DiskResource,
 		Settings: st,
 	})

--- a/pkg/kv/kvclient/kvstreamer/streamer_accounting_test.go
+++ b/pkg/kv/kvclient/kvstreamer/streamer_accounting_test.go
@@ -65,7 +65,7 @@ func TestStreamerMemoryAccounting(t *testing.T) {
 	}
 
 	monitor := mon.NewMonitor(mon.Options{
-		Name:     mon.MakeMonitorName("streamer"),
+		Name:     mon.MakeName("streamer"),
 		Settings: cluster.MakeTestingClusterSettings(),
 	})
 	monitor.Start(ctx, nil /* pool */, mon.NewStandaloneBudget(math.MaxInt64))

--- a/pkg/kv/kvclient/kvstreamer/streamer_test.go
+++ b/pkg/kv/kvclient/kvstreamer/streamer_test.go
@@ -196,7 +196,7 @@ func TestStreamerBudgetErrorInEnqueue(t *testing.T) {
 	// Imitate a root SQL memory monitor with 1MiB size.
 	const rootPoolSize = 1 << 20 /* 1MiB */
 	rootMemMonitor := mon.NewMonitor(mon.Options{
-		Name:     mon.MakeMonitorName("root"),
+		Name:     mon.MakeName("root"),
 		Settings: cluster.MakeTestingClusterSettings(),
 	})
 	rootMemMonitor.Start(ctx, nil /* pool */, mon.NewStandaloneBudget(rootPoolSize))

--- a/pkg/kv/kvclient/rangefeed/db_adapter_external_test.go
+++ b/pkg/kv/kvclient/rangefeed/db_adapter_external_test.go
@@ -34,7 +34,7 @@ import (
 
 func startMonitorWithBudget(budget int64) *mon.BytesMonitor {
 	mm := mon.NewMonitor(mon.Options{
-		Name:      mon.MakeMonitorName("test-mm"),
+		Name:      mon.MakeName("test-mm"),
 		Limit:     budget,
 		Increment: 128, /* small allocation increment */
 		Settings:  cluster.MakeTestingClusterSettings(),

--- a/pkg/kv/kvserver/rangefeed/budget.go
+++ b/pkg/kv/kvserver/rangefeed/budget.go
@@ -322,14 +322,14 @@ func NewBudgetFactory(ctx context.Context, config BudgetFactoryConfig) *BudgetFa
 		return nil
 	}
 	metrics := NewFeedBudgetMetrics(config.histogramWindowInterval)
-	systemRangeMonitor := mon.NewMonitorInheritWithLimit(
+	systemRangeMonitor := mon.NewMonitorInheritWithLimitAndStringName(
 		"rangefeed-system-monitor", systemRangeFeedBudget, config.rootMon, true, /* longLiving */
 	)
 	systemRangeMonitor.SetMetrics(metrics.SystemBytesCount, nil /* maxHist */)
 	systemRangeMonitor.Start(ctx, config.rootMon,
 		mon.NewStandaloneBudget(systemRangeFeedBudget))
 
-	rangeFeedPoolMonitor := mon.NewMonitorInheritWithLimit(
+	rangeFeedPoolMonitor := mon.NewMonitorInheritWithLimitAndStringName(
 		"rangefeed-monitor", config.totalRangeFeedBudget, config.rootMon, true, /* longLiving */
 	)
 	rangeFeedPoolMonitor.SetMetrics(metrics.SharedBytesCount, nil /* maxHist */)

--- a/pkg/kv/kvserver/rangefeed/budget.go
+++ b/pkg/kv/kvserver/rangefeed/budget.go
@@ -322,15 +322,17 @@ func NewBudgetFactory(ctx context.Context, config BudgetFactoryConfig) *BudgetFa
 		return nil
 	}
 	metrics := NewFeedBudgetMetrics(config.histogramWindowInterval)
-	systemRangeMonitor := mon.NewMonitorInheritWithLimitAndStringName(
-		"rangefeed-system-monitor", systemRangeFeedBudget, config.rootMon, true, /* longLiving */
+	systemRangeMonitor := mon.NewMonitorInheritWithLimit(
+		mon.MakeName("rangefeed-system-monitor"), systemRangeFeedBudget, config.rootMon,
+		true, /* longLiving */
 	)
 	systemRangeMonitor.SetMetrics(metrics.SystemBytesCount, nil /* maxHist */)
 	systemRangeMonitor.Start(ctx, config.rootMon,
 		mon.NewStandaloneBudget(systemRangeFeedBudget))
 
-	rangeFeedPoolMonitor := mon.NewMonitorInheritWithLimitAndStringName(
-		"rangefeed-monitor", config.totalRangeFeedBudget, config.rootMon, true, /* longLiving */
+	rangeFeedPoolMonitor := mon.NewMonitorInheritWithLimit(
+		mon.MakeName("rangefeed-monitor"), config.totalRangeFeedBudget, config.rootMon,
+		true, /* longLiving */
 	)
 	rangeFeedPoolMonitor.SetMetrics(metrics.SharedBytesCount, nil /* maxHist */)
 	rangeFeedPoolMonitor.StartNoReserved(ctx, config.rootMon)

--- a/pkg/kv/kvserver/rangefeed/budget_test.go
+++ b/pkg/kv/kvserver/rangefeed/budget_test.go
@@ -17,7 +17,7 @@ import (
 
 func getMemoryMonitor(s *cluster.Settings) *mon.BytesMonitor {
 	return mon.NewMonitor(mon.Options{
-		Name:      mon.MakeMonitorName("rangefeed"),
+		Name:      mon.MakeName("rangefeed"),
 		Increment: 1,
 		Settings:  s,
 	})

--- a/pkg/kv/kvserver/rangefeed/event_queue_test.go
+++ b/pkg/kv/kvserver/rangefeed/event_queue_test.go
@@ -135,7 +135,7 @@ func TestEventQueue(t *testing.T) {
 		ctx := context.Background()
 		s := cluster.MakeTestingClusterSettings()
 		m := mon.NewMonitor(mon.Options{
-			Name:      mon.MakeMonitorName("rangefeed"),
+			Name:      mon.MakeName("rangefeed"),
 			Increment: 1,
 			Settings:  s,
 		})

--- a/pkg/kv/kvserver/rangefeed/processor_test.go
+++ b/pkg/kv/kvserver/rangefeed/processor_test.go
@@ -1100,7 +1100,7 @@ func TestBudgetReleaseOnProcessorStop(t *testing.T) {
 	testutils.RunValues(t, "feed type", testTypes, func(t *testing.T, rt rangefeedTestType) {
 		s := cluster.MakeTestingClusterSettings()
 		m := mon.NewMonitor(mon.Options{
-			Name:      mon.MakeMonitorName("rangefeed"),
+			Name:      mon.MakeName("rangefeed"),
 			Res:       mon.MemoryResource,
 			Increment: 1,
 			Limit:     math.MaxInt64,

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -1552,7 +1552,7 @@ func NewStore(
 	s.replRankingsByTenant = NewReplicaRankingsMap()
 
 	s.raftRecvQueues.mon = mon.NewUnlimitedMonitor(ctx, mon.Options{
-		Name:     mon.MakeMonitorName("raft-receive-queue"),
+		Name:     mon.MakeName("raft-receive-queue"),
 		CurCount: s.metrics.RaftRcvdQueuedBytes,
 		Settings: cfg.Settings,
 	})

--- a/pkg/kv/kvserver/store_raft_test.go
+++ b/pkg/kv/kvserver/store_raft_test.go
@@ -41,7 +41,7 @@ func TestRaftReceiveQueue(t *testing.T) {
 	st := cluster.MakeTestingClusterSettings()
 	g := metric.NewGauge(metric.Metadata{})
 	m := mon.NewUnlimitedMonitor(context.Background(), mon.Options{
-		Name:     mon.MakeMonitorName("test"),
+		Name:     mon.MakeName("test"),
 		CurCount: g,
 		Settings: st,
 	})
@@ -234,7 +234,7 @@ func TestRaftReceiveQueuesEnforceMaxLenConcurrency(t *testing.T) {
 	st := cluster.MakeTestingClusterSettings()
 	g := metric.NewGauge(metric.Metadata{})
 	m := mon.NewUnlimitedMonitor(context.Background(), mon.Options{
-		Name:     mon.MakeMonitorName("test"),
+		Name:     mon.MakeName("test"),
 		CurCount: g,
 		Settings: st,
 	})
@@ -297,7 +297,7 @@ func TestRaftReceiveQueuesEnforceMaxLen(t *testing.T) {
 	st := cluster.MakeTestingClusterSettings()
 	g := metric.NewGauge(metric.Metadata{})
 	m := mon.NewUnlimitedMonitor(context.Background(), mon.Options{
-		Name:     mon.MakeMonitorName("test"),
+		Name:     mon.MakeName("test"),
 		CurCount: g,
 		Settings: st,
 	})

--- a/pkg/kv/kvserver/ts_maintenance_queue.go
+++ b/pkg/kv/kvserver/ts_maintenance_queue.go
@@ -92,7 +92,7 @@ func newTimeSeriesMaintenanceQueue(
 		replicaCountFn: store.ReplicaCount,
 		db:             db,
 		mem: mon.NewUnlimitedMonitor(context.Background(), mon.Options{
-			Name:     mon.MakeMonitorName("timeseries-maintenance-queue"),
+			Name:     mon.MakeName("timeseries-maintenance-queue"),
 			Settings: store.cfg.Settings,
 		}),
 	}

--- a/pkg/kv/kvserver/ts_maintenance_queue_test.go
+++ b/pkg/kv/kvserver/ts_maintenance_queue_test.go
@@ -282,7 +282,7 @@ func TestTimeSeriesMaintenanceQueueServer(t *testing.T) {
 	}
 
 	memMon := mon.NewMonitor(mon.Options{
-		Name:     mon.MakeMonitorName("test"),
+		Name:     mon.MakeName("test"),
 		Settings: cluster.MakeTestingClusterSettings(),
 	})
 	memMon.Start(context.Background(), nil /* pool */, mon.NewStandaloneBudget(math.MaxInt64))

--- a/pkg/security/clientcert/cert_expiry_cache.go
+++ b/pkg/security/clientcert/cert_expiry_cache.go
@@ -97,7 +97,7 @@ func NewClientCertExpirationCache(
 			c.mu.acc.Shrink(ctx, int64(unsafe.Sizeof(*metrics)))
 		},
 	})
-	c.mon = mon.NewMonitorInheritWithLimit(
+	c.mon = mon.NewMonitorInheritWithLimitAndStringName(
 		"client-expiration-cache", 0 /* limit */, parentMon, true, /* longLiving */
 	)
 	c.mu.acc = c.mon.MakeBoundAccount()

--- a/pkg/security/clientcert/cert_expiry_cache.go
+++ b/pkg/security/clientcert/cert_expiry_cache.go
@@ -97,8 +97,8 @@ func NewClientCertExpirationCache(
 			c.mu.acc.Shrink(ctx, int64(unsafe.Sizeof(*metrics)))
 		},
 	})
-	c.mon = mon.NewMonitorInheritWithLimitAndStringName(
-		"client-expiration-cache", 0 /* limit */, parentMon, true, /* longLiving */
+	c.mon = mon.NewMonitorInheritWithLimit(
+		mon.MakeName("client-expiration-cache"), 0 /* limit */, parentMon, true, /* longLiving */
 	)
 	c.mu.acc = c.mon.MakeBoundAccount()
 	c.mon.StartNoReserved(ctx, parentMon)

--- a/pkg/security/clientcert/cert_expiry_cache_test.go
+++ b/pkg/security/clientcert/cert_expiry_cache_test.go
@@ -276,7 +276,7 @@ func newCache(
 	defer stopper.Stop(ctx)
 	clientcert.ClientCertExpirationCacheCapacity.Override(ctx, &st.SV, int64(capacity))
 	parentMon := mon.NewUnlimitedMonitor(ctx, mon.Options{
-		Name:     mon.MakeMonitorName("test"),
+		Name:     mon.MakeName("test"),
 		Settings: st,
 	})
 	cache := clientcert.NewClientCertExpirationCache(ctx, st, stopper, clock, parentMon)

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -229,7 +229,7 @@ func newAdminServer(
 	// TODO(knz): We do not limit memory usage by admin operations
 	// yet. Is this wise?
 	server.memMonitor = mon.NewUnlimitedMonitor(context.Background(), mon.Options{
-		Name:     mon.MakeMonitorName("admin"),
+		Name:     mon.MakeName("admin"),
 		Settings: cs,
 	})
 	return server

--- a/pkg/server/profiler/memory_monitoring_profiler_test.go
+++ b/pkg/server/profiler/memory_monitoring_profiler_test.go
@@ -27,7 +27,7 @@ func addMonitor(
 	reservedBytes int64,
 ) *mon.BytesMonitor {
 	m := mon.NewMonitor(mon.Options{
-		Name:      mon.MakeMonitorName(name),
+		Name:      mon.MakeName(name),
 		Increment: 1,
 		Settings:  st,
 	})

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -719,8 +719,9 @@ func NewServer(cfg Config, stopper *stop.Stopper) (serverctl.ServerStartupInterf
 		histogramWindowInterval: cfg.HistogramWindowInterval(),
 		settings:                cfg.Settings,
 	})
-	kvMemoryMonitor := mon.NewMonitorInheritWithLimitAndStringName(
-		"kv-mem", 0 /* limit */, sqlMonitorAndMetrics.rootSQLMemoryMonitor, true, /* longLiving */
+	kvMemoryMonitor := mon.NewMonitorInheritWithLimit(
+		mon.MakeName("kv-mem"), 0 /* limit */, sqlMonitorAndMetrics.rootSQLMemoryMonitor,
+		true, /* longLiving */
 	)
 	kvMemoryMonitor.StartNoReserved(ctx, sqlMonitorAndMetrics.rootSQLMemoryMonitor)
 	rangeFeedBudgetFactory := serverrangefeed.NewBudgetFactory(

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -719,7 +719,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (serverctl.ServerStartupInterf
 		histogramWindowInterval: cfg.HistogramWindowInterval(),
 		settings:                cfg.Settings,
 	})
-	kvMemoryMonitor := mon.NewMonitorInheritWithLimit(
+	kvMemoryMonitor := mon.NewMonitorInheritWithLimitAndStringName(
 		"kv-mem", 0 /* limit */, sqlMonitorAndMetrics.rootSQLMemoryMonitor, true, /* longLiving */
 	)
 	kvMemoryMonitor.StartNoReserved(ctx, sqlMonitorAndMetrics.rootSQLMemoryMonitor)

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -688,8 +688,8 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 	// bulkMemoryMonitor is the parent to all child SQL monitors tracking bulk
 	// operations (IMPORT, index backfill). It is itself a child of the
 	// ParentMemoryMonitor.
-	bulkMemoryMonitor := mon.NewMonitorInheritWithLimitAndStringName(
-		"bulk-mon", 0 /* limit */, rootSQLMemoryMonitor, true, /* longLiving */
+	bulkMemoryMonitor := mon.NewMonitorInheritWithLimit(
+		mon.MakeName("bulk-mon"), 0 /* limit */, rootSQLMemoryMonitor, true, /* longLiving */
 	)
 	bulkMetrics := bulk.MakeBulkMetrics(cfg.HistogramWindowInterval())
 	cfg.registry.AddMetricStruct(bulkMetrics)
@@ -701,8 +701,8 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 	backupMemoryMonitor := execinfra.NewMonitor(ctx, bulkMemoryMonitor, mon.MakeName("backup-mon"))
 	backupMemoryMonitor.MarkLongLiving()
 
-	changefeedMemoryMonitor := mon.NewMonitorInheritWithLimitAndStringName(
-		"changefeed-mon", 0 /* limit */, rootSQLMemoryMonitor, true, /* longLiving */
+	changefeedMemoryMonitor := mon.NewMonitorInheritWithLimit(
+		mon.MakeName("changefeed-mon"), 0 /* limit */, rootSQLMemoryMonitor, true, /* longLiving */
 	)
 	if jobs.MakeChangefeedMemoryMetricsHook != nil {
 		changefeedCurCount, changefeedMaxHist := jobs.MakeChangefeedMemoryMetricsHook(cfg.HistogramWindowInterval())
@@ -710,8 +710,8 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 	}
 	changefeedMemoryMonitor.StartNoReserved(ctx, rootSQLMemoryMonitor)
 
-	serverCacheMemoryMonitor := mon.NewMonitorInheritWithLimitAndStringName(
-		"server-cache-mon", 0 /* limit */, rootSQLMemoryMonitor, true, /* longLiving */
+	serverCacheMemoryMonitor := mon.NewMonitorInheritWithLimit(
+		mon.MakeName("server-cache-mon"), 0 /* limit */, rootSQLMemoryMonitor, true, /* longLiving */
 	)
 	serverCacheMemoryMonitor.StartNoReserved(ctx, rootSQLMemoryMonitor)
 

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -440,7 +440,7 @@ var vmoduleSetting = settings.RegisterStringSetting(
 func newRootSQLMemoryMonitor(opts monitorAndMetricsOptions) monitorAndMetrics {
 	rootSQLMetrics := sql.MakeBaseMemMetrics("root", opts.histogramWindowInterval)
 	rootSQLMemoryMonitor := mon.NewMonitor(mon.Options{
-		Name:     mon.MakeMonitorName("root"),
+		Name:     mon.MakeName("root"),
 		CurCount: rootSQLMetrics.CurBytesCount,
 		MaxHist:  rootSQLMetrics.MaxBytesHist,
 		Settings: opts.settings,
@@ -1187,7 +1187,7 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 	// returning the memory allocated to internalDBMonitor since the
 	// parent monitor is being closed anyway.
 	internalDBMonitor := mon.NewMonitor(mon.Options{
-		Name:       mon.MakeMonitorName("internal sql executor"),
+		Name:       mon.MakeName("internal sql executor"),
 		CurCount:   internalMemMetrics.CurBytesCount,
 		MaxHist:    internalMemMetrics.MaxBytesHist,
 		Settings:   cfg.Settings,

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -696,9 +696,9 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 	bulkMemoryMonitor.SetMetrics(bulkMetrics.CurBytesCount, bulkMetrics.MaxBytesHist)
 	bulkMemoryMonitor.StartNoReserved(ctx, rootSQLMemoryMonitor)
 
-	backfillMemoryMonitor := execinfra.NewMonitorWithStringName(ctx, bulkMemoryMonitor, "backfill-mon")
+	backfillMemoryMonitor := execinfra.NewMonitor(ctx, bulkMemoryMonitor, mon.MakeName("backfill-mon"))
 	backfillMemoryMonitor.MarkLongLiving()
-	backupMemoryMonitor := execinfra.NewMonitorWithStringName(ctx, bulkMemoryMonitor, "backup-mon")
+	backupMemoryMonitor := execinfra.NewMonitor(ctx, bulkMemoryMonitor, mon.MakeName("backup-mon"))
 	backupMemoryMonitor.MarkLongLiving()
 
 	changefeedMemoryMonitor := mon.NewMonitorInheritWithLimitAndStringName(
@@ -842,7 +842,7 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 		) (kvserverbase.BulkAdder, error) {
 			// Attach a child memory monitor to enable control over the BulkAdder's
 			// memory usage.
-			bulkMon := execinfra.NewMonitorWithStringName(ctx, bulkMemoryMonitor, "bulk-adder-monitor")
+			bulkMon := execinfra.NewMonitor(ctx, bulkMemoryMonitor, mon.MakeName("bulk-adder-monitor"))
 			return bulk.MakeBulkAdder(ctx, db, cfg.distSender.RangeDescriptorCache(), cfg.Settings, ts, opts, bulkMon, bulkSenderLimiter)
 		},
 

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -2877,7 +2877,8 @@ func columnBackfillInTxn(
 	}
 	var columnBackfillerMon *mon.BytesMonitor
 	if evalCtx.Planner.Mon() != nil {
-		columnBackfillerMon = execinfra.NewMonitorWithStringName(ctx, evalCtx.Planner.Mon(), "local-column-backfill-mon")
+		columnBackfillerMon = execinfra.NewMonitor(ctx, evalCtx.Planner.Mon(),
+			mon.MakeName("local-column-backfill-mon"))
 	}
 
 	rowMetrics := execCfg.GetRowMetrics(evalCtx.SessionData().Internal)
@@ -2920,7 +2921,8 @@ func indexBackfillInTxn(
 ) error {
 	var indexBackfillerMon *mon.BytesMonitor
 	if evalCtx.Planner.Mon() != nil {
-		indexBackfillerMon = execinfra.NewMonitorWithStringName(ctx, evalCtx.Planner.Mon(), "local-index-backfill-mon")
+		indexBackfillerMon = execinfra.NewMonitor(ctx, evalCtx.Planner.Mon(),
+			mon.MakeName("local-index-backfill-mon"))
 	}
 
 	var backfiller backfill.IndexBackfiller

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -2877,7 +2877,7 @@ func columnBackfillInTxn(
 	}
 	var columnBackfillerMon *mon.BytesMonitor
 	if evalCtx.Planner.Mon() != nil {
-		columnBackfillerMon = execinfra.NewMonitor(ctx, evalCtx.Planner.Mon(), "local-column-backfill-mon")
+		columnBackfillerMon = execinfra.NewMonitorWithStringName(ctx, evalCtx.Planner.Mon(), "local-column-backfill-mon")
 	}
 
 	rowMetrics := execCfg.GetRowMetrics(evalCtx.SessionData().Internal)
@@ -2920,7 +2920,7 @@ func indexBackfillInTxn(
 ) error {
 	var indexBackfillerMon *mon.BytesMonitor
 	if evalCtx.Planner.Mon() != nil {
-		indexBackfillerMon = execinfra.NewMonitor(ctx, evalCtx.Planner.Mon(), "local-index-backfill-mon")
+		indexBackfillerMon = execinfra.NewMonitorWithStringName(ctx, evalCtx.Planner.Mon(), "local-index-backfill-mon")
 	}
 
 	var backfiller backfill.IndexBackfiller

--- a/pkg/sql/backfill/mvcc_index_merger.go
+++ b/pkg/sql/backfill/mvcc_index_merger.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/intsets"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/logtags"
@@ -125,7 +126,8 @@ func (ibm *IndexBackfillMerger) Run(ctx context.Context, output execinfra.RowRec
 	defer span.Finish()
 	// This method blocks until all worker goroutines exit, so it's safe to
 	// close memory monitoring infra in defers.
-	mergerMon := execinfra.NewMonitorWithStringName(ctx, ibm.flowCtx.Cfg.BackfillerMonitor, "index-backfiller-merger-mon")
+	mergerMon := execinfra.NewMonitor(ctx, ibm.flowCtx.Cfg.BackfillerMonitor,
+		mon.MakeName("index-backfiller-merger-mon"))
 	defer mergerMon.Stop(ctx)
 	ibm.muBoundAccount.boundAccount = mergerMon.MakeBoundAccount()
 	defer func() {

--- a/pkg/sql/backfill/mvcc_index_merger.go
+++ b/pkg/sql/backfill/mvcc_index_merger.go
@@ -125,7 +125,7 @@ func (ibm *IndexBackfillMerger) Run(ctx context.Context, output execinfra.RowRec
 	defer span.Finish()
 	// This method blocks until all worker goroutines exit, so it's safe to
 	// close memory monitoring infra in defers.
-	mergerMon := execinfra.NewMonitor(ctx, ibm.flowCtx.Cfg.BackfillerMonitor, "index-backfiller-merger-mon")
+	mergerMon := execinfra.NewMonitorWithStringName(ctx, ibm.flowCtx.Cfg.BackfillerMonitor, "index-backfiller-merger-mon")
 	defer mergerMon.Stop(ctx)
 	ibm.muBoundAccount.boundAccount = mergerMon.MakeBoundAccount()
 	defer func() {

--- a/pkg/sql/buffer_util.go
+++ b/pkg/sql/buffer_util.go
@@ -83,13 +83,13 @@ func (c *rowContainerHelper) InitWithParentMon(
 	// Fix it.
 	c.memMonitor = execinfra.NewLimitedMonitorNoFlowCtx(
 		ctx, parent, distSQLCfg, evalContext.SessionData(),
-		opName+"-limited",
+		mon.MakeMonitorName(opName).WithSuffix("limited"),
 	)
 	c.unlimitedMemMonitor = execinfra.NewMonitor(
-		ctx, parent, opName+"-unlimited",
+		ctx, parent, mon.MakeMonitorName(opName).WithSuffix("unlimited"),
 	)
 	c.diskMonitor = execinfra.NewMonitor(
-		ctx, distSQLCfg.ParentDiskMonitor, opName+"-disk",
+		ctx, distSQLCfg.ParentDiskMonitor, mon.MakeMonitorName(opName).WithSuffix("disk"),
 	)
 	c.rows = &rowcontainer.DiskBackedRowContainer{}
 	c.rows.Init(
@@ -108,13 +108,13 @@ func (c *rowContainerHelper) initMonitors(
 	// Fix it.
 	c.memMonitor = execinfra.NewLimitedMonitorNoFlowCtx(
 		ctx, evalContext.Planner.Mon(), distSQLCfg, evalContext.SessionData(),
-		opName+"-limited",
+		mon.MakeMonitorName(opName).WithSuffix("limited"),
 	)
 	c.unlimitedMemMonitor = execinfra.NewMonitor(
-		ctx, evalContext.Planner.Mon(), opName+"-unlimited",
+		ctx, evalContext.Planner.Mon(), mon.MakeMonitorName(opName).WithSuffix("unlimited"),
 	)
 	c.diskMonitor = execinfra.NewMonitor(
-		ctx, distSQLCfg.ParentDiskMonitor, opName+"-disk",
+		ctx, distSQLCfg.ParentDiskMonitor, mon.MakeMonitorName(opName).WithSuffix("disk"),
 	)
 }
 

--- a/pkg/sql/buffer_util.go
+++ b/pkg/sql/buffer_util.go
@@ -83,13 +83,13 @@ func (c *rowContainerHelper) InitWithParentMon(
 	// Fix it.
 	c.memMonitor = execinfra.NewLimitedMonitorNoFlowCtx(
 		ctx, parent, distSQLCfg, evalContext.SessionData(),
-		mon.MakeMonitorName(opName).Limited(),
+		mon.MakeName(opName).Limited(),
 	)
 	c.unlimitedMemMonitor = execinfra.NewMonitor(
-		ctx, parent, mon.MakeMonitorName(opName).Unlimited(),
+		ctx, parent, mon.MakeName(opName).Unlimited(),
 	)
 	c.diskMonitor = execinfra.NewMonitor(
-		ctx, distSQLCfg.ParentDiskMonitor, mon.MakeMonitorName(opName).Disk(),
+		ctx, distSQLCfg.ParentDiskMonitor, mon.MakeName(opName).Disk(),
 	)
 	c.rows = &rowcontainer.DiskBackedRowContainer{}
 	c.rows.Init(
@@ -108,13 +108,13 @@ func (c *rowContainerHelper) initMonitors(
 	// Fix it.
 	c.memMonitor = execinfra.NewLimitedMonitorNoFlowCtx(
 		ctx, evalContext.Planner.Mon(), distSQLCfg, evalContext.SessionData(),
-		mon.MakeMonitorName(opName).Limited(),
+		mon.MakeName(opName).Limited(),
 	)
 	c.unlimitedMemMonitor = execinfra.NewMonitor(
-		ctx, evalContext.Planner.Mon(), mon.MakeMonitorName(opName).Unlimited(),
+		ctx, evalContext.Planner.Mon(), mon.MakeName(opName).Unlimited(),
 	)
 	c.diskMonitor = execinfra.NewMonitor(
-		ctx, distSQLCfg.ParentDiskMonitor, mon.MakeMonitorName(opName).Disk(),
+		ctx, distSQLCfg.ParentDiskMonitor, mon.MakeName(opName).Disk(),
 	)
 }
 

--- a/pkg/sql/buffer_util.go
+++ b/pkg/sql/buffer_util.go
@@ -83,13 +83,13 @@ func (c *rowContainerHelper) InitWithParentMon(
 	// Fix it.
 	c.memMonitor = execinfra.NewLimitedMonitorNoFlowCtx(
 		ctx, parent, distSQLCfg, evalContext.SessionData(),
-		mon.MakeMonitorName(opName).WithSuffix("limited"),
+		mon.MakeMonitorName(opName).Limited(),
 	)
 	c.unlimitedMemMonitor = execinfra.NewMonitor(
-		ctx, parent, mon.MakeMonitorName(opName).WithSuffix("unlimited"),
+		ctx, parent, mon.MakeMonitorName(opName).Unlimited(),
 	)
 	c.diskMonitor = execinfra.NewMonitor(
-		ctx, distSQLCfg.ParentDiskMonitor, mon.MakeMonitorName(opName).WithSuffix("disk"),
+		ctx, distSQLCfg.ParentDiskMonitor, mon.MakeMonitorName(opName).Disk(),
 	)
 	c.rows = &rowcontainer.DiskBackedRowContainer{}
 	c.rows.Init(
@@ -108,13 +108,13 @@ func (c *rowContainerHelper) initMonitors(
 	// Fix it.
 	c.memMonitor = execinfra.NewLimitedMonitorNoFlowCtx(
 		ctx, evalContext.Planner.Mon(), distSQLCfg, evalContext.SessionData(),
-		mon.MakeMonitorName(opName).WithSuffix("limited"),
+		mon.MakeMonitorName(opName).Limited(),
 	)
 	c.unlimitedMemMonitor = execinfra.NewMonitor(
-		ctx, evalContext.Planner.Mon(), mon.MakeMonitorName(opName).WithSuffix("unlimited"),
+		ctx, evalContext.Planner.Mon(), mon.MakeMonitorName(opName).Unlimited(),
 	)
 	c.diskMonitor = execinfra.NewMonitor(
-		ctx, distSQLCfg.ParentDiskMonitor, mon.MakeMonitorName(opName).WithSuffix("disk"),
+		ctx, distSQLCfg.ParentDiskMonitor, mon.MakeMonitorName(opName).Disk(),
 	)
 }
 

--- a/pkg/sql/cacheutil/cache_test.go
+++ b/pkg/sql/cacheutil/cache_test.go
@@ -21,7 +21,7 @@ import (
 func TestCache(t *testing.T) {
 	st := cluster.MakeTestingClusterSettings()
 	memoryMonitor := mon.NewMonitor(mon.Options{
-		Name:     mon.MakeMonitorName("test-mem"),
+		Name:     mon.MakeName("test-mem"),
 		Settings: st,
 	})
 	stopper := &stop.Stopper{}

--- a/pkg/sql/catalog/descs/collection_test.go
+++ b/pkg/sql/catalog/descs/collection_test.go
@@ -598,7 +598,7 @@ func TestCollectionProperlyUsesMemoryMonitoring(t *testing.T) {
 
 	// Create a monitor to be used to track memory usage in a Collection.
 	monitor := mon.NewMonitor(mon.Options{
-		Name:     mon.MakeMonitorName("test_monitor"),
+		Name:     mon.MakeName("test_monitor"),
 		Settings: cluster.MakeTestingClusterSettings(),
 	})
 
@@ -1239,7 +1239,7 @@ func TestDescriptorErrorWrap(t *testing.T) {
 	tdb.Exec(t, `CREATE TABLE db.schema.table()`)
 
 	monitor := mon.NewMonitor(mon.Options{
-		Name:     mon.MakeMonitorName("test_monitor"),
+		Name:     mon.MakeName("test_monitor"),
 		Settings: cluster.MakeTestingClusterSettings(),
 	})
 	monitor.Start(ctx, nil, mon.NewStandaloneBudget(1))

--- a/pkg/sql/catalog/descs/factory.go
+++ b/pkg/sql/catalog/descs/factory.go
@@ -84,7 +84,7 @@ func NewCollectionFactory(
 		spanConfigSplitter: spanConfigSplitter,
 		spanConfigLimiter:  spanConfigLimiter,
 		defaultMonitor: mon.NewUnlimitedMonitor(ctx, mon.Options{
-			Name:     mon.MakeMonitorName("CollectionFactoryDefaultUnlimitedMonitor"),
+			Name:     mon.MakeName("CollectionFactoryDefaultUnlimitedMonitor"),
 			Settings: settings,
 		}),
 		defaultDescriptorSessionDataProvider: defaultDescriptorSessionDataProvider,

--- a/pkg/sql/closed_session_cache.go
+++ b/pkg/sql/closed_session_cache.go
@@ -70,8 +70,8 @@ type ClosedSessionCache struct {
 func NewClosedSessionCache(
 	st *cluster.Settings, parentMon *mon.BytesMonitor, timeSrc timeSource,
 ) *ClosedSessionCache {
-	monitor := mon.NewMonitorInheritWithLimitAndStringName(
-		"closed-session-cache", 0 /* limit */, parentMon, true, /* longLiving */
+	monitor := mon.NewMonitorInheritWithLimit(
+		mon.MakeName("closed-session-cache"), 0 /* limit */, parentMon, true, /* longLiving */
 	)
 
 	c := &ClosedSessionCache{st: st, timeSrc: timeSrc}

--- a/pkg/sql/closed_session_cache.go
+++ b/pkg/sql/closed_session_cache.go
@@ -70,7 +70,7 @@ type ClosedSessionCache struct {
 func NewClosedSessionCache(
 	st *cluster.Settings, parentMon *mon.BytesMonitor, timeSrc timeSource,
 ) *ClosedSessionCache {
-	monitor := mon.NewMonitorInheritWithLimit(
+	monitor := mon.NewMonitorInheritWithLimitAndStringName(
 		"closed-session-cache", 0 /* limit */, parentMon, true, /* longLiving */
 	)
 

--- a/pkg/sql/closed_session_cache_test.go
+++ b/pkg/sql/closed_session_cache_test.go
@@ -46,7 +46,7 @@ func TestSessionCacheBasic(t *testing.T) {
 
 				st := &cluster.Settings{}
 				monitor := mon.NewUnlimitedMonitor(ctx, mon.Options{
-					Name:     mon.MakeMonitorName("test"),
+					Name:     mon.MakeName("test"),
 					Settings: st,
 				})
 				cache = NewClosedSessionCache(st, monitor, time.Now)

--- a/pkg/sql/colcontainer/diskqueue_test.go
+++ b/pkg/sql/colcontainer/diskqueue_test.go
@@ -191,7 +191,8 @@ func TestDiskQueueCloseOnErr(t *testing.T) {
 		t.Run(fmt.Sprintf("diskLimit=%s", humanizeutil.IBytes(diskLimit)), func(t *testing.T) {
 			serverCfg := &execinfra.ServerConfig{}
 			serverCfg.TestingKnobs.MemoryLimitBytes = diskLimit
-			diskMon := execinfra.NewLimitedMonitorNoFlowCtx(ctx, testDiskMonitor, serverCfg, nil /* sd */, "test-disk")
+			diskMon := execinfra.NewLimitedMonitorNoFlowCtx(ctx, testDiskMonitor, serverCfg,
+				nil /* sd */, mon.MakeMonitorName("test-disk"))
 			defer diskMon.Stop(ctx)
 			diskAcc := diskMon.MakeBoundAccount()
 			defer diskAcc.Close(ctx)

--- a/pkg/sql/colcontainer/diskqueue_test.go
+++ b/pkg/sql/colcontainer/diskqueue_test.go
@@ -192,7 +192,7 @@ func TestDiskQueueCloseOnErr(t *testing.T) {
 			serverCfg := &execinfra.ServerConfig{}
 			serverCfg.TestingKnobs.MemoryLimitBytes = diskLimit
 			diskMon := execinfra.NewLimitedMonitorNoFlowCtx(ctx, testDiskMonitor, serverCfg,
-				nil /* sd */, mon.MakeMonitorName("test-disk"))
+				nil /* sd */, mon.MakeName("test-disk"))
 			defer diskMon.Stop(ctx)
 			diskAcc := diskMon.MakeBoundAccount()
 			defer diskAcc.Close(ctx)

--- a/pkg/sql/colexec/colbuilder/execplan.go
+++ b/pkg/sql/colexec/colbuilder/execplan.go
@@ -344,7 +344,7 @@ func createDiskBackedSort(
 	diskBackedReuseMode colexecop.BufferingOpReuseMode,
 ) colexecop.Operator {
 	var (
-		sorterMemMonitorName mon.MonitorName
+		sorterMemMonitorName mon.Name
 		inMemorySorter       colexecop.Operator
 	)
 	if len(ordering.Columns) == int(matchLen) {
@@ -645,7 +645,7 @@ func makeNewHashJoinerArgs(
 	opName redact.SafeString,
 	core *execinfrapb.HashJoinerSpec,
 	factory coldata.ColumnFactory,
-) (colexecjoin.NewHashJoinerArgs, mon.MonitorName) {
+) (colexecjoin.NewHashJoinerArgs, mon.Name) {
 	hashJoinerMemAccount, hashJoinerMemMonitorName := args.MonitorRegistry.CreateMemAccountForSpillStrategy(
 		ctx, flowCtx, opName, args.Spec.ProcessorID,
 	)
@@ -679,7 +679,7 @@ func makeNewHashAggregatorArgs(
 	opName redact.SafeString,
 	newAggArgs *colexecagg.NewAggregatorArgs,
 	factory coldata.ColumnFactory,
-) (*colexecagg.NewHashAggregatorArgs, *colexecutils.NewSpillingQueueArgs, mon.MonitorName) {
+) (*colexecagg.NewHashAggregatorArgs, *colexecutils.NewSpillingQueueArgs, mon.Name) {
 	// We will divide the available memory equally between the two usages - the
 	// hash aggregation itself and the input tuples tracking.
 	totalMemLimit := execinfra.GetWorkMemLimit(flowCtx)
@@ -1208,7 +1208,7 @@ func NewColOperator(
 				} else {
 					diskSpiller := colexecdisk.NewTwoInputDiskSpiller(
 						inputs[0].Root, inputs[1].Root, inMemoryHashJoiner.(colexecop.BufferingInMemoryOperator),
-						[]mon.MonitorName{hashJoinerMemMonitorName},
+						[]mon.Name{hashJoinerMemMonitorName},
 						func(inputOne, inputTwo colexecop.Operator) colexecop.Operator {
 							opName := redact.SafeString("external-hash-joiner")
 							accounts := args.MonitorRegistry.CreateUnlimitedMemAccounts(
@@ -1375,7 +1375,7 @@ func NewColOperator(
 			evalCtx.SingleDatumAggMemAccount = ehaMemAccount
 			diskSpiller := colexecdisk.NewTwoInputDiskSpiller(
 				inputs[0].Root, inputs[1].Root, hgj,
-				[]mon.MonitorName{hashJoinerMemMonitorName, hashAggregatorMemMonitorName},
+				[]mon.Name{hashJoinerMemMonitorName, hashAggregatorMemMonitorName},
 				func(inputOne, inputTwo colexecop.Operator) colexecop.Operator {
 					// When we spill to disk, we just use a combo of an external
 					// hash join followed by an external hash aggregation.

--- a/pkg/sql/colexec/colbuilder/execplan.go
+++ b/pkg/sql/colexec/colbuilder/execplan.go
@@ -344,7 +344,7 @@ func createDiskBackedSort(
 	diskBackedReuseMode colexecop.BufferingOpReuseMode,
 ) colexecop.Operator {
 	var (
-		sorterMemMonitorName redact.SafeString
+		sorterMemMonitorName mon.MonitorName
 		inMemorySorter       colexecop.Operator
 	)
 	if len(ordering.Columns) == int(matchLen) {
@@ -645,7 +645,7 @@ func makeNewHashJoinerArgs(
 	opName redact.SafeString,
 	core *execinfrapb.HashJoinerSpec,
 	factory coldata.ColumnFactory,
-) (colexecjoin.NewHashJoinerArgs, redact.SafeString) {
+) (colexecjoin.NewHashJoinerArgs, mon.MonitorName) {
 	hashJoinerMemAccount, hashJoinerMemMonitorName := args.MonitorRegistry.CreateMemAccountForSpillStrategy(
 		ctx, flowCtx, opName, args.Spec.ProcessorID,
 	)
@@ -679,7 +679,7 @@ func makeNewHashAggregatorArgs(
 	opName redact.SafeString,
 	newAggArgs *colexecagg.NewAggregatorArgs,
 	factory coldata.ColumnFactory,
-) (*colexecagg.NewHashAggregatorArgs, *colexecutils.NewSpillingQueueArgs, redact.SafeString) {
+) (*colexecagg.NewHashAggregatorArgs, *colexecutils.NewSpillingQueueArgs, mon.MonitorName) {
 	// We will divide the available memory equally between the two usages - the
 	// hash aggregation itself and the input tuples tracking.
 	totalMemLimit := execinfra.GetWorkMemLimit(flowCtx)
@@ -724,7 +724,8 @@ func makeNewHashAggregatorArgs(
 			DiskQueueCfg:       args.DiskQueueCfg,
 			FDSemaphore:        args.FDSemaphore,
 			DiskAcc: args.MonitorRegistry.CreateDiskAccount(
-				ctx, flowCtx, hashAggregatorMemMonitorName+"-spilling-queue", args.Spec.ProcessorID,
+				// TODO(mgartner): Do not convert the name to a string.
+				ctx, flowCtx, redact.SafeString(hashAggregatorMemMonitorName.String())+"-spilling-queue", args.Spec.ProcessorID,
 			),
 			DiskQueueMemAcc: accounts[4],
 		},
@@ -1207,7 +1208,7 @@ func NewColOperator(
 				} else {
 					diskSpiller := colexecdisk.NewTwoInputDiskSpiller(
 						inputs[0].Root, inputs[1].Root, inMemoryHashJoiner.(colexecop.BufferingInMemoryOperator),
-						[]redact.SafeString{hashJoinerMemMonitorName},
+						[]mon.MonitorName{hashJoinerMemMonitorName},
 						func(inputOne, inputTwo colexecop.Operator) colexecop.Operator {
 							opName := redact.SafeString("external-hash-joiner")
 							accounts := args.MonitorRegistry.CreateUnlimitedMemAccounts(
@@ -1374,7 +1375,7 @@ func NewColOperator(
 			evalCtx.SingleDatumAggMemAccount = ehaMemAccount
 			diskSpiller := colexecdisk.NewTwoInputDiskSpiller(
 				inputs[0].Root, inputs[1].Root, hgj,
-				[]redact.SafeString{hashJoinerMemMonitorName, hashAggregatorMemMonitorName},
+				[]mon.MonitorName{hashJoinerMemMonitorName, hashAggregatorMemMonitorName},
 				func(inputOne, inputTwo colexecop.Operator) colexecop.Operator {
 					// When we spill to disk, we just use a combo of an external
 					// hash join followed by an external hash aggregation.

--- a/pkg/sql/colexec/colexecargs/monitor_registry.go
+++ b/pkg/sql/colexec/colexecargs/monitor_registry.go
@@ -167,9 +167,10 @@ func (r *MonitorRegistry) createUnlimitedMemAccountsLocked(
 	)
 	r.monitors = append(r.monitors, bufferingOpUnlimitedMemMonitor)
 	oldLen := len(r.accounts)
-	for i := 0; i < numAccounts; i++ {
-		acc := bufferingOpUnlimitedMemMonitor.MakeBoundAccount()
-		r.accounts = append(r.accounts, &acc)
+	newAccounts := make([]mon.BoundAccount, numAccounts)
+	for i := range newAccounts {
+		newAccounts[i] = bufferingOpUnlimitedMemMonitor.MakeBoundAccount()
+		r.accounts = append(r.accounts, &newAccounts[i])
 	}
 	return bufferingOpUnlimitedMemMonitor, r.accounts[oldLen:len(r.accounts)]
 }

--- a/pkg/sql/colexec/colexecargs/monitor_registry.go
+++ b/pkg/sql/colexec/colexecargs/monitor_registry.go
@@ -47,7 +47,7 @@ func (r *MonitorRegistry) getMemMonitorNameLocked(
 	opName redact.SafeString, processorID int32,
 ) mon.MonitorName {
 	r.mu.AssertHeld()
-	return mon.MakeMonitorName(opName).WithProcessorID(processorID).WithInt(int32(len(r.monitors)))
+	return mon.MakeMonitorName(opName).WithID(processorID).WithInt(uint16(len(r.monitors)))
 }
 
 // CreateMemAccountForSpillStrategy instantiates a memory monitor and a memory

--- a/pkg/sql/colexec/colexecdisk/disk_spiller.go
+++ b/pkg/sql/colexec/colexecdisk/disk_spiller.go
@@ -80,7 +80,7 @@ import (
 func NewOneInputDiskSpiller(
 	input colexecop.Operator,
 	inMemoryOp colexecop.BufferingInMemoryOperator,
-	inMemoryMemMonitorName mon.MonitorName,
+	inMemoryMemMonitorName mon.Name,
 	diskBackedOpConstructor func(input colexecop.Operator) colexecop.Operator,
 	diskBackedReuseMode colexecop.BufferingOpReuseMode,
 	spillingCallbackFn func(),
@@ -170,7 +170,7 @@ func (d *oneInputDiskSpiller) constructDiskBackedOp() colexecop.Operator {
 func NewTwoInputDiskSpiller(
 	inputOne, inputTwo colexecop.Operator,
 	inMemoryOp colexecop.BufferingInMemoryOperator,
-	inMemoryMemMonitorNames []mon.MonitorName,
+	inMemoryMemMonitorNames []mon.Name,
 	diskBackedOpConstructor func(inputOne, inputTwo colexecop.Operator) colexecop.Operator,
 	spillingCallbackFn func(),
 ) colexecop.ClosableOperator {

--- a/pkg/sql/colexec/colexecdisk/disk_spiller.go
+++ b/pkg/sql/colexec/colexecdisk/disk_spiller.go
@@ -15,8 +15,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra/execopnode"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlerrors"
 	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
+	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/errors"
-	"github.com/cockroachdb/redact"
 )
 
 // oneInputDiskSpiller is an Operator that manages the fallback from a one
@@ -80,7 +80,7 @@ import (
 func NewOneInputDiskSpiller(
 	input colexecop.Operator,
 	inMemoryOp colexecop.BufferingInMemoryOperator,
-	inMemoryMemMonitorName redact.SafeString,
+	inMemoryMemMonitorName mon.MonitorName,
 	diskBackedOpConstructor func(input colexecop.Operator) colexecop.Operator,
 	diskBackedReuseMode colexecop.BufferingOpReuseMode,
 	spillingCallbackFn func(),
@@ -90,9 +90,10 @@ func NewOneInputDiskSpiller(
 		diskBackedReuseMode:     diskBackedReuseMode,
 	}
 	op.diskSpillerBase = diskSpillerBase{
-		inputs:                  []colexecop.Operator{input},
-		inMemoryOp:              inMemoryOp,
-		inMemoryMemMonitorNames: []string{string(inMemoryMemMonitorName)},
+		inputs:     []colexecop.Operator{input},
+		inMemoryOp: inMemoryOp,
+		// TODO(mgartner): Do not convert the name to a string.
+		inMemoryMemMonitorNames: []string{inMemoryMemMonitorName.String()},
 		diskBackedOpConstructor: op.constructDiskBackedOp,
 		spillingCallbackFn:      spillingCallbackFn,
 	}
@@ -169,7 +170,7 @@ func (d *oneInputDiskSpiller) constructDiskBackedOp() colexecop.Operator {
 func NewTwoInputDiskSpiller(
 	inputOne, inputTwo colexecop.Operator,
 	inMemoryOp colexecop.BufferingInMemoryOperator,
-	inMemoryMemMonitorNames []redact.SafeString,
+	inMemoryMemMonitorNames []mon.MonitorName,
 	diskBackedOpConstructor func(inputOne, inputTwo colexecop.Operator) colexecop.Operator,
 	spillingCallbackFn func(),
 ) colexecop.ClosableOperator {
@@ -178,7 +179,8 @@ func NewTwoInputDiskSpiller(
 	}
 	names := make([]string, len(inMemoryMemMonitorNames))
 	for i := range names {
-		names[i] = string(inMemoryMemMonitorNames[i])
+		// TODO(mgartner): Do not convert the names to strings.
+		names[i] = inMemoryMemMonitorNames[i].String()
 	}
 	op.diskSpillerBase = diskSpillerBase{
 		inputs:                  []colexecop.Operator{inputOne, inputTwo},

--- a/pkg/sql/colfetcher/cfetcher_wrapper.go
+++ b/pkg/sql/colfetcher/cfetcher_wrapper.go
@@ -245,7 +245,7 @@ func newCFetcherWrapper(
 	// the cFetcherWrapper is responsible for performing the correct accounting
 	// against the memory account provided by the caller.
 	detachedFetcherMon := mon.NewMonitor(mon.Options{
-		Name:     mon.MakeMonitorName("cfetcher-wrapper-detached-monitor"),
+		Name:     mon.MakeName("cfetcher-wrapper-detached-monitor"),
 		Settings: st,
 	})
 	detachedFetcherMon.Start(ctx, nil /* pool */, mon.NewStandaloneBudget(math.MaxInt64))

--- a/pkg/sql/colflow/draining_test.go
+++ b/pkg/sql/colflow/draining_test.go
@@ -36,7 +36,7 @@ func TestDrainingAfterRemoteError(t *testing.T) {
 	// This ensures that the query will run into "out of temporary storage"
 	// error.
 	diskMonitor := mon.NewMonitor(mon.Options{
-		Name:     mon.MakeMonitorName("test-disk"),
+		Name:     mon.MakeName("test-disk"),
 		Res:      mon.DiskResource,
 		Settings: st,
 	})

--- a/pkg/sql/colflow/vectorized_flow.go
+++ b/pkg/sql/colflow/vectorized_flow.go
@@ -793,7 +793,7 @@ func (s *vectorizedFlowCreator) setupRouter(
 		sb.WriteString(s.StreamID.String())
 	}
 	streamIDs := redact.SafeString(sb.String())
-	mmName := mon.MakeMonitorName("hash-router-[" + streamIDs + "]")
+	mmName := mon.MakeName("hash-router-[" + streamIDs + "]")
 
 	numOutputs := len(output.Streams)
 	// We need to create two memory accounts for each output (one for the

--- a/pkg/sql/colflow/vectorized_flow.go
+++ b/pkg/sql/colflow/vectorized_flow.go
@@ -793,7 +793,7 @@ func (s *vectorizedFlowCreator) setupRouter(
 		sb.WriteString(s.StreamID.String())
 	}
 	streamIDs := redact.SafeString(sb.String())
-	mmName := "hash-router-[" + streamIDs + "]"
+	mmName := mon.MakeMonitorName("hash-router-[" + streamIDs + "]")
 
 	numOutputs := len(output.Streams)
 	// We need to create two memory accounts for each output (one for the

--- a/pkg/sql/colflow/vectorized_flow_space_test.go
+++ b/pkg/sql/colflow/vectorized_flow_space_test.go
@@ -74,7 +74,7 @@ func TestVectorizeInternalMemorySpaceError(t *testing.T) {
 					sources = append(sources, colexecutils.NewFixedNumTuplesNoInputOp(testAllocator, 0 /* numTuples */, nil /* opToInitialize */))
 				}
 				memMon := mon.NewMonitor(mon.Options{
-					Name:     mon.MakeMonitorName("MemoryMonitor"),
+					Name:     mon.MakeName("MemoryMonitor"),
 					Settings: st,
 				})
 				if success {
@@ -204,7 +204,7 @@ func TestVectorizeAllocatorSpaceError(t *testing.T) {
 					sources = append(sources, colexecop.NewRepeatableBatchSource(testAllocator, batch, typs))
 				}
 				memMon := mon.NewMonitor(mon.Options{
-					Name:     mon.MakeMonitorName("MemoryMonitor"),
+					Name:     mon.MakeName("MemoryMonitor"),
 					Settings: st,
 				})
 				flowCtx.Cfg.TestingKnobs = execinfra.TestingKnobs{}

--- a/pkg/sql/colmem/BUILD.bazel
+++ b/pkg/sql/colmem/BUILD.bazel
@@ -47,7 +47,6 @@ go_test(
         "//pkg/util/mon",
         "//pkg/util/randutil",
         "@com_github_cockroachdb_errors//:errors",
-        "@com_github_cockroachdb_redact//:redact",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/sql/colmem/adjust_memory_usage_test.go
+++ b/pkg/sql/colmem/adjust_memory_usage_test.go
@@ -36,7 +36,7 @@ func TestAdjustMemoryUsage(t *testing.T) {
 
 	limitedMemMonitorName := "test-limited"
 	limit := int64(100000)
-	limitedMemMonitor := mon.NewMonitorInheritWithLimit(
+	limitedMemMonitor := mon.NewMonitorInheritWithLimitAndStringName(
 		redact.SafeString(limitedMemMonitorName), limit, unlimitedMemMonitor, false, /* longLiving */
 	)
 	limitedMemMonitor.StartNoReserved(ctx, unlimitedMemMonitor)

--- a/pkg/sql/colmem/adjust_memory_usage_test.go
+++ b/pkg/sql/colmem/adjust_memory_usage_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
-	"github.com/cockroachdb/redact"
 	"github.com/stretchr/testify/require"
 )
 
@@ -34,10 +33,10 @@ func TestAdjustMemoryUsage(t *testing.T) {
 	unlimitedMemAcc := unlimitedMemMonitor.MakeBoundAccount()
 	defer unlimitedMemAcc.Close(ctx)
 
-	limitedMemMonitorName := "test-limited"
+	limitedMemMonitorName := mon.MakeName("test-limited")
 	limit := int64(100000)
-	limitedMemMonitor := mon.NewMonitorInheritWithLimitAndStringName(
-		redact.SafeString(limitedMemMonitorName), limit, unlimitedMemMonitor, false, /* longLiving */
+	limitedMemMonitor := mon.NewMonitorInheritWithLimit(
+		limitedMemMonitorName, limit, unlimitedMemMonitor, false, /* longLiving */
 	)
 	limitedMemMonitor.StartNoReserved(ctx, unlimitedMemMonitor)
 	defer limitedMemMonitor.Stop(ctx)
@@ -57,7 +56,7 @@ func TestAdjustMemoryUsage(t *testing.T) {
 	// unlimited account has not been grown.
 	err := colexecerror.CatchVectorizedRuntimeError(func() { allocator.AdjustMemoryUsage(limit) })
 	require.NotNil(t, err)
-	require.True(t, strings.Contains(err.Error(), limitedMemMonitorName))
+	require.True(t, strings.Contains(err.Error(), limitedMemMonitorName.String()))
 	require.Equal(t, limit/2, limitedMemAcc.Used())
 	require.Zero(t, unlimitedMemAcc.Used())
 
@@ -65,7 +64,7 @@ func TestAdjustMemoryUsage(t *testing.T) {
 	// unlimited account has been grown.
 	err = colexecerror.CatchVectorizedRuntimeError(func() { allocator.AdjustMemoryUsageAfterAllocation(limit) })
 	require.NotNil(t, err)
-	require.True(t, strings.Contains(err.Error(), limitedMemMonitorName))
+	require.True(t, strings.Contains(err.Error(), limitedMemMonitorName.String()))
 	require.Equal(t, limit/2, limitedMemAcc.Used())
 	require.Equal(t, limit, unlimitedMemAcc.Used())
 
@@ -73,7 +72,7 @@ func TestAdjustMemoryUsage(t *testing.T) {
 	// it cannot be grown.
 	err = colexecerror.CatchVectorizedRuntimeError(func() { allocator.AdjustMemoryUsageAfterAllocation(math.MaxInt64) })
 	require.NotNil(t, err)
-	require.False(t, strings.Contains(err.Error(), limitedMemMonitorName))
+	require.False(t, strings.Contains(err.Error(), limitedMemMonitorName.String()))
 	require.Equal(t, limit/2, limitedMemAcc.Used())
 	require.Equal(t, limit, unlimitedMemAcc.Used())
 

--- a/pkg/sql/colmem/allocator_test.go
+++ b/pkg/sql/colmem/allocator_test.go
@@ -42,7 +42,7 @@ func getAllocator(increment int64) (_ *colmem.Allocator, _ *mon.BoundAccount, cl
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettings()
 	testMemMonitor := mon.NewMonitor(mon.Options{
-		Name:      mon.MakeMonitorName("test-mem"),
+		Name:      mon.MakeName("test-mem"),
 		Increment: increment,
 		Settings:  st,
 	})

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -1083,19 +1083,19 @@ func (s *Server) newConnExecutor(
 	// Create the various monitors.
 	// The session monitors are started in activate().
 	sessionRootMon := mon.NewMonitor(mon.Options{
-		Name:     mon.MakeMonitorName("session root"),
+		Name:     mon.MakeName("session root"),
 		CurCount: memMetrics.CurBytesCount,
 		MaxHist:  memMetrics.MaxBytesHist,
 		Settings: s.cfg.Settings,
 	})
 	sessionMon := mon.NewMonitor(mon.Options{
-		Name:     mon.MakeMonitorName("session"),
+		Name:     mon.MakeName("session"),
 		CurCount: memMetrics.SessionCurBytesCount,
 		MaxHist:  memMetrics.SessionMaxBytesHist,
 		Settings: s.cfg.Settings,
 	})
 	sessionPreparedMon := mon.NewMonitor(mon.Options{
-		Name:      mon.MakeMonitorName("session prepared statements"),
+		Name:      mon.MakeName("session prepared statements"),
 		CurCount:  memMetrics.SessionPreparedCurBytesCount,
 		MaxHist:   memMetrics.SessionPreparedMaxBytesHist,
 		Increment: 1024,
@@ -1103,7 +1103,7 @@ func (s *Server) newConnExecutor(
 	})
 	// The txn monitor is started in txnState.resetForNewSQLTxn().
 	txnMon := mon.NewMonitor(mon.Options{
-		Name:     mon.MakeMonitorName("txn"),
+		Name:     mon.MakeName("txn"),
 		CurCount: memMetrics.TxnCurBytesCount,
 		MaxHist:  memMetrics.TxnMaxBytesHist,
 		Settings: s.cfg.Settings,

--- a/pkg/sql/conn_executor_internal_test.go
+++ b/pkg/sql/conn_executor_internal_test.go
@@ -287,7 +287,7 @@ func startConnExecutor(
 	defer tempEngine.Close()
 	ambientCtx := log.MakeTestingAmbientCtxWithNewTracer()
 	pool := mon.NewUnlimitedMonitor(ctx, mon.Options{
-		Name:     mon.MakeMonitorName("test"),
+		Name:     mon.MakeName("test"),
 		Settings: st,
 	})
 	// This pool should never be Stop()ed because, if the test is failing, memory

--- a/pkg/sql/copy_from.go
+++ b/pkg/sql/copy_from.go
@@ -522,7 +522,7 @@ func (c *copyMachine) initMonitoring(ctx context.Context, parentMon *mon.BytesMo
 	// Create a monitor for the COPY command so it can be tracked separate from transaction or session.
 	memMetrics := &MemoryMetrics{}
 	c.copyMon = mon.NewMonitor(mon.Options{
-		Name:     mon.MakeMonitorName("copy"),
+		Name:     mon.MakeName("copy"),
 		CurCount: memMetrics.CurBytesCount,
 		MaxHist:  memMetrics.MaxBytesHist,
 		Settings: c.p.ExecCfg().Settings,

--- a/pkg/sql/delete_preserving_index_test.go
+++ b/pkg/sql/delete_preserving_index_test.go
@@ -624,7 +624,7 @@ func TestMergeProcessor(t *testing.T) {
 		execCfg := server.ExecutorConfig().(sql.ExecutorConfig)
 		evalCtx := eval.Context{Settings: settings, Codec: codec}
 		mm := mon.NewUnlimitedMonitor(ctx, mon.Options{
-			Name:     mon.MakeMonitorName("MemoryMonitor"),
+			Name:     mon.MakeName("MemoryMonitor"),
 			Settings: settings,
 		})
 		flowCtx := execinfra.FlowCtx{

--- a/pkg/sql/distsql/server.go
+++ b/pkg/sql/distsql/server.go
@@ -245,7 +245,7 @@ func (ds *ServerImpl) setupFlow(
 		Settings: ds.Settings,
 	})
 	monitor.Start(ctx, parentMonitor, reserved)
-	diskMonitor = execinfra.NewMonitor(ctx, ds.ParentDiskMonitor, "flow-disk-monitor")
+	diskMonitor = execinfra.NewMonitorWithStringName(ctx, ds.ParentDiskMonitor, "flow-disk-monitor")
 
 	makeLeaf := func(ctx context.Context) (*kv.Txn, error) {
 		tis := req.LeafTxnInputState

--- a/pkg/sql/distsql/server.go
+++ b/pkg/sql/distsql/server.go
@@ -239,7 +239,7 @@ func (ds *ServerImpl) setupFlow(
 	}
 
 	monitor = mon.NewMonitor(mon.Options{
-		Name:     mon.MakeMonitorNameWithID("flow ", req.Flow.FlowID.Short()),
+		Name:     mon.MakeMonitorName("flow").WithUUID(req.Flow.FlowID.Short()),
 		CurCount: ds.Metrics.CurBytesCount,
 		MaxHist:  ds.Metrics.MaxBytesHist,
 		Settings: ds.Settings,

--- a/pkg/sql/distsql/server.go
+++ b/pkg/sql/distsql/server.go
@@ -77,7 +77,7 @@ func NewServer(
 		flowRegistry:      flowinfra.NewFlowRegistry(),
 		remoteFlowRunner:  remoteFlowRunner,
 		memMonitor: mon.NewMonitor(mon.Options{
-			Name: mon.MakeMonitorName("distsql"),
+			Name: mon.MakeName("distsql"),
 			// Note that we don't use 'sql.mem.distsql.*' metrics here since
 			// that would double count them with the 'flow' monitor in
 			// setupFlow.
@@ -239,7 +239,7 @@ func (ds *ServerImpl) setupFlow(
 	}
 
 	monitor = mon.NewMonitor(mon.Options{
-		Name:     mon.MakeMonitorName("flow").WithUUID(req.Flow.FlowID.Short()),
+		Name:     mon.MakeName("flow").WithUUID(req.Flow.FlowID.Short()),
 		CurCount: ds.Metrics.CurBytesCount,
 		MaxHist:  ds.Metrics.MaxBytesHist,
 		Settings: ds.Settings,

--- a/pkg/sql/distsql/server.go
+++ b/pkg/sql/distsql/server.go
@@ -245,7 +245,7 @@ func (ds *ServerImpl) setupFlow(
 		Settings: ds.Settings,
 	})
 	monitor.Start(ctx, parentMonitor, reserved)
-	diskMonitor = execinfra.NewMonitorWithStringName(ctx, ds.ParentDiskMonitor, "flow-disk-monitor")
+	diskMonitor = execinfra.NewMonitor(ctx, ds.ParentDiskMonitor, mon.MakeName("flow-disk-monitor"))
 
 	makeLeaf := func(ctx context.Context) (*kv.Txn, error) {
 		tis := req.LeafTxnInputState

--- a/pkg/sql/execinfra/processorsbase.go
+++ b/pkg/sql/execinfra/processorsbase.go
@@ -993,7 +993,8 @@ func NewLimitedMonitorWithLowerBound(
 	if memoryLimit < minMemoryLimit {
 		memoryLimit = minMemoryLimit
 	}
-	limitedMon := mon.NewMonitorInheritWithLimitAndStringName(name, memoryLimit, flowCtx.Mon, false /* longLiving */)
+	limitedMon := mon.NewMonitorInheritWithLimit(mon.MakeName(name), memoryLimit, flowCtx.Mon,
+		false /* longLiving */)
 	limitedMon.StartNoReserved(ctx, flowCtx.Mon)
 	return limitedMon
 }

--- a/pkg/sql/execinfra/processorsbase.go
+++ b/pkg/sql/execinfra/processorsbase.go
@@ -969,16 +969,6 @@ func NewMonitor(ctx context.Context, parent *mon.BytesMonitor, name mon.Name) *m
 	return monitor
 }
 
-// NewMonitorWithStringName is the same as NewMonitor but accepts a string name.
-// Deprecated: NewMonitor should be used instead.
-func NewMonitorWithStringName(
-	ctx context.Context, parent *mon.BytesMonitor, name redact.SafeString,
-) *mon.BytesMonitor {
-	monitor := mon.NewMonitorInheritWithLimitAndStringName(name, 0 /* limit */, parent, false /* longLiving */)
-	monitor.StartNoReserved(ctx, parent)
-	return monitor
-}
-
 // NewLimitedMonitor is a utility function used by processors to create a new
 // limited memory monitor with the given name and start it. The returned monitor
 // must be closed. The limit is determined by SessionData.WorkMemLimit (stored

--- a/pkg/sql/execinfra/processorsbase.go
+++ b/pkg/sql/execinfra/processorsbase.go
@@ -963,9 +963,7 @@ func (pb *ProcessorBaseNoHelper) ConsumerClosed() {
 // NewMonitor is a utility function used by processors to create a new
 // memory monitor with the given name and start it. The returned monitor must
 // be closed.
-func NewMonitor(
-	ctx context.Context, parent *mon.BytesMonitor, name mon.MonitorName,
-) *mon.BytesMonitor {
+func NewMonitor(ctx context.Context, parent *mon.BytesMonitor, name mon.Name) *mon.BytesMonitor {
 	monitor := mon.NewMonitorInheritWithLimit(name, 0 /* limit */, parent, false /* longLiving */)
 	monitor.StartNoReserved(ctx, parent)
 	return monitor
@@ -988,7 +986,7 @@ func NewMonitorWithStringName(
 // ServerConfig.TestingKnobs.ForceDiskSpill is set or
 // ServerConfig.TestingKnobs.MemoryLimitBytes if not.
 func NewLimitedMonitor(
-	ctx context.Context, parent *mon.BytesMonitor, flowCtx *FlowCtx, name mon.MonitorName,
+	ctx context.Context, parent *mon.BytesMonitor, flowCtx *FlowCtx, name mon.Name,
 ) *mon.BytesMonitor {
 	limitedMon := mon.NewMonitorInheritWithLimit(name, GetWorkMemLimit(flowCtx), parent, false /* longLiving */)
 	limitedMon.StartNoReserved(ctx, parent)
@@ -1017,7 +1015,7 @@ func NewLimitedMonitorNoFlowCtx(
 	parent *mon.BytesMonitor,
 	config *ServerConfig,
 	sd *sessiondata.SessionData,
-	name mon.MonitorName,
+	name mon.Name,
 ) *mon.BytesMonitor {
 	// Create a fake FlowCtx populating only the required fields.
 	flowCtx := &FlowCtx{

--- a/pkg/sql/execinfra/testutils.go
+++ b/pkg/sql/execinfra/testutils.go
@@ -82,7 +82,7 @@ func (r *RepeatableRowSource) ConsumerClosed() {}
 // moved).
 func NewTestMemMonitor(ctx context.Context, st *cluster.Settings) *mon.BytesMonitor {
 	memMonitor := mon.NewMonitor(mon.Options{
-		Name:     mon.MakeMonitorName("test-mem"),
+		Name:     mon.MakeName("test-mem"),
 		Settings: st,
 	})
 	memMonitor.Start(ctx, nil, mon.NewStandaloneBudget(math.MaxInt64))
@@ -93,7 +93,7 @@ func NewTestMemMonitor(ctx context.Context, st *cluster.Settings) *mon.BytesMoni
 // tests.
 func NewTestDiskMonitor(ctx context.Context, st *cluster.Settings) *mon.BytesMonitor {
 	diskMonitor := mon.NewMonitor(mon.Options{
-		Name:     mon.MakeMonitorName("test-disk"),
+		Name:     mon.MakeName("test-disk"),
 		Res:      mon.DiskResource,
 		Settings: st,
 	})

--- a/pkg/sql/explain_vec.go
+++ b/pkg/sql/explain_vec.go
@@ -87,7 +87,7 @@ func (n *explainVecNode) startExec(params runParams) error {
 
 func newFlowCtxForExplainPurposes(ctx context.Context, p *planner) *execinfra.FlowCtx {
 	monitor := mon.NewMonitor(mon.Options{
-		Name:     mon.MakeMonitorName("explain"),
+		Name:     mon.MakeName("explain"),
 		Settings: p.execCfg.Settings,
 	})
 	// Note that we do not use planner's monitor here in order to not link any

--- a/pkg/sql/importer/exportparquet_test.go
+++ b/pkg/sql/importer/exportparquet_test.go
@@ -392,7 +392,7 @@ func TestMemoryMonitor(t *testing.T) {
 	// Arrange for a small memory budget.
 	budget := int64(4096)
 	mm := mon.NewMonitor(mon.Options{
-		Name:      mon.MakeMonitorName("test-mm"),
+		Name:      mon.MakeName("test-mm"),
 		Limit:     budget,
 		Increment: 128, /* small allocation increment */
 		Settings:  cluster.MakeTestingClusterSettings(),

--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -181,7 +181,7 @@ func MakeInternalExecutorMemMonitor(
 	memMetrics MemoryMetrics, settings *cluster.Settings,
 ) *mon.BytesMonitor {
 	return mon.NewMonitor(mon.Options{
-		Name:       mon.MakeMonitorName("internal SQL executor"),
+		Name:       mon.MakeName("internal SQL executor"),
 		CurCount:   memMetrics.CurBytesCount,
 		MaxHist:    memMetrics.MaxBytesHist,
 		Settings:   settings,

--- a/pkg/sql/pgwire/pre_serve.go
+++ b/pkg/sql/pgwire/pre_serve.go
@@ -139,7 +139,7 @@ func NewPreServeConnHandler(
 		getTLSConfig:             getTLSConfig,
 
 		tenantIndependentConnMonitor: mon.NewMonitor(mon.Options{
-			Name:       mon.MakeMonitorName("pre-conn"),
+			Name:       mon.MakeName("pre-conn"),
 			CurCount:   metrics.PreServeCurBytes,
 			MaxHist:    metrics.PreServeMaxBytes,
 			Increment:  int64(connReservationBatchSize) * baseSQLMemoryBudget,

--- a/pkg/sql/pgwire/server.go
+++ b/pkg/sql/pgwire/server.go
@@ -434,7 +434,7 @@ func MakeServer(
 		},
 	}
 	server.sqlMemoryPool = mon.NewMonitor(mon.Options{
-		Name: mon.MakeMonitorName("sql"),
+		Name: mon.MakeName("sql"),
 		// Note that we don't report metrics on this monitor. The reason for this is
 		// that we report metrics on the sum of all the child monitors of this pool.
 		// This monitor is the "main sql" monitor. It's a child of the root memory
@@ -450,7 +450,7 @@ func MakeServer(
 	server.SQLServer = sql.NewServer(executorConfig, server.sqlMemoryPool)
 
 	server.tenantSpecificConnMonitor = mon.NewMonitor(mon.Options{
-		Name:       mon.MakeMonitorName("conn"),
+		Name:       mon.MakeName("conn"),
 		CurCount:   server.tenantMetrics.ConnMemMetrics.CurBytesCount,
 		MaxHist:    server.tenantMetrics.ConnMemMetrics.MaxBytesHist,
 		Increment:  int64(connReservationBatchSize) * baseSQLMemoryBudget,

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -402,7 +402,7 @@ func newInternalPlanner(
 	}
 
 	plannerMon := mon.NewMonitor(mon.Options{
-		Name:     mon.MakeMonitorName("internal-planner." + opName),
+		Name:     mon.MakeName("internal-planner." + opName),
 		CurCount: memMetrics.CurBytesCount,
 		MaxHist:  memMetrics.MaxBytesHist,
 		Settings: execCfg.Settings,

--- a/pkg/sql/row/fetcher.go
+++ b/pkg/sql/row/fetcher.go
@@ -358,7 +358,7 @@ func (rf *Fetcher) Init(ctx context.Context, args FetcherInitArgs) error {
 	rf.args = args
 
 	if args.MemMonitor != nil {
-		rf.mon = mon.NewMonitorInheritWithLimit(
+		rf.mon = mon.NewMonitorInheritWithLimitAndStringName(
 			"fetcher-mem", 0 /* limit */, args.MemMonitor, false, /* longLiving */
 		)
 		rf.mon.StartNoReserved(ctx, args.MemMonitor)

--- a/pkg/sql/row/fetcher.go
+++ b/pkg/sql/row/fetcher.go
@@ -358,8 +358,8 @@ func (rf *Fetcher) Init(ctx context.Context, args FetcherInitArgs) error {
 	rf.args = args
 
 	if args.MemMonitor != nil {
-		rf.mon = mon.NewMonitorInheritWithLimitAndStringName(
-			"fetcher-mem", 0 /* limit */, args.MemMonitor, false, /* longLiving */
+		rf.mon = mon.NewMonitorInheritWithLimit(
+			mon.MakeName("fetcher-mem"), 0 /* limit */, args.MemMonitor, false, /* longLiving */
 		)
 		rf.mon.StartNoReserved(ctx, args.MemMonitor)
 		memAcc := rf.mon.MakeBoundAccount()

--- a/pkg/sql/row/fetcher_test.go
+++ b/pkg/sql/row/fetcher_test.go
@@ -347,7 +347,7 @@ func TestRowFetcherMemoryLimits(t *testing.T) {
 	// we can test whether scans of wide tables are prevented if
 	// we have insufficient memory to do them.
 	memMon := mon.NewMonitor(mon.Options{
-		Name:     mon.MakeMonitorName("test"),
+		Name:     mon.MakeName("test"),
 		Settings: settings,
 	})
 	memMon.Start(ctx, nil, mon.NewStandaloneBudget(1<<20))

--- a/pkg/sql/rowcontainer/disk_row_container_test.go
+++ b/pkg/sql/rowcontainer/disk_row_container_test.go
@@ -94,21 +94,21 @@ func compareRowToEncRow(
 
 func getMemoryMonitor(st *cluster.Settings) *mon.BytesMonitor {
 	return mon.NewMonitor(mon.Options{
-		Name:     mon.MakeMonitorName("test-mem"),
+		Name:     mon.MakeName("test-mem"),
 		Settings: st,
 	})
 }
 
 func getUnlimitedMemoryMonitor(st *cluster.Settings) *mon.BytesMonitor {
 	return mon.NewUnlimitedMonitor(context.Background(), mon.Options{
-		Name:     mon.MakeMonitorName("test-mem"),
+		Name:     mon.MakeName("test-mem"),
 		Settings: st,
 	})
 }
 
 func getDiskMonitor(st *cluster.Settings) *mon.BytesMonitor {
 	return mon.NewMonitor(mon.Options{
-		Name:     mon.MakeMonitorName("test-disk"),
+		Name:     mon.MakeName("test-disk"),
 		Res:      mon.DiskResource,
 		Settings: st,
 	})

--- a/pkg/sql/rowexec/aggregator.go
+++ b/pkg/sql/rowexec/aggregator.go
@@ -94,7 +94,7 @@ func (ag *aggregatorBase) init(
 	post *execinfrapb.PostProcessSpec,
 	trailingMetaCallback func() []execinfrapb.ProducerMetadata,
 ) error {
-	memMonitor := execinfra.NewMonitor(ctx, flowCtx.Mon, "aggregator-mem")
+	memMonitor := execinfra.NewMonitorWithStringName(ctx, flowCtx.Mon, "aggregator-mem")
 	if execstats.ShouldCollectStats(ctx, flowCtx.CollectStats) {
 		input = newInputStatCollector(input)
 		ag.ExecStatsForTrace = ag.execStatsForTrace

--- a/pkg/sql/rowexec/aggregator.go
+++ b/pkg/sql/rowexec/aggregator.go
@@ -94,7 +94,7 @@ func (ag *aggregatorBase) init(
 	post *execinfrapb.PostProcessSpec,
 	trailingMetaCallback func() []execinfrapb.ProducerMetadata,
 ) error {
-	memMonitor := execinfra.NewMonitorWithStringName(ctx, flowCtx.Mon, "aggregator-mem")
+	memMonitor := execinfra.NewMonitor(ctx, flowCtx.Mon, mon.MakeName("aggregator-mem"))
 	if execstats.ShouldCollectStats(ctx, flowCtx.CollectStats) {
 		input = newInputStatCollector(input)
 		ag.ExecStatsForTrace = ag.execStatsForTrace

--- a/pkg/sql/rowexec/columnbackfiller.go
+++ b/pkg/sql/rowexec/columnbackfiller.go
@@ -59,7 +59,7 @@ func newColumnBackfiller(
 	processorID int32,
 	spec execinfrapb.BackfillerSpec,
 ) (*columnBackfiller, error) {
-	columnBackfillerMon := execinfra.NewMonitor(
+	columnBackfillerMon := execinfra.NewMonitorWithStringName(
 		ctx, flowCtx.Cfg.BackfillerMonitor, "column-backfill-mon",
 	)
 	cb := &columnBackfiller{

--- a/pkg/sql/rowexec/columnbackfiller.go
+++ b/pkg/sql/rowexec/columnbackfiller.go
@@ -25,6 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/admission/admissionpb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/logtags"
@@ -59,8 +60,8 @@ func newColumnBackfiller(
 	processorID int32,
 	spec execinfrapb.BackfillerSpec,
 ) (*columnBackfiller, error) {
-	columnBackfillerMon := execinfra.NewMonitorWithStringName(
-		ctx, flowCtx.Cfg.BackfillerMonitor, "column-backfill-mon",
+	columnBackfillerMon := execinfra.NewMonitor(
+		ctx, flowCtx.Cfg.BackfillerMonitor, mon.MakeName("column-backfill-mon"),
 	)
 	cb := &columnBackfiller{
 		desc:        flowCtx.TableDescriptor(ctx, &spec.Table),

--- a/pkg/sql/rowexec/distinct.go
+++ b/pkg/sql/rowexec/distinct.go
@@ -93,7 +93,7 @@ func newDistinct(
 		}
 	}
 
-	memMonitor := execinfra.NewMonitor(ctx, flowCtx.Mon, "distinct-mem")
+	memMonitor := execinfra.NewMonitorWithStringName(ctx, flowCtx.Mon, "distinct-mem")
 	d := &distinct{
 		input:            input,
 		memAcc:           memMonitor.MakeBoundAccount(),

--- a/pkg/sql/rowexec/distinct.go
+++ b/pkg/sql/rowexec/distinct.go
@@ -93,7 +93,7 @@ func newDistinct(
 		}
 	}
 
-	memMonitor := execinfra.NewMonitorWithStringName(ctx, flowCtx.Mon, "distinct-mem")
+	memMonitor := execinfra.NewMonitor(ctx, flowCtx.Mon, mon.MakeName("distinct-mem"))
 	d := &distinct{
 		input:            input,
 		memAcc:           memMonitor.MakeBoundAccount(),

--- a/pkg/sql/rowexec/hashjoiner.go
+++ b/pkg/sql/rowexec/hashjoiner.go
@@ -148,11 +148,11 @@ func newHashJoiner(
 	// Limit the memory use by creating a child monitor with a hard limit.
 	// The hashJoiner will overflow to disk if this limit is not enough.
 	h.MemMonitor = execinfra.NewLimitedMonitor(ctx, flowCtx.Mon, flowCtx,
-		mon.MakeMonitorName("hashjoiner").Limited())
+		mon.MakeName("hashjoiner").Limited())
 	h.unlimitedMemMonitor = execinfra.NewMonitor(ctx, flowCtx.Mon,
-		mon.MakeMonitorName("hashjoiner").Unlimited())
+		mon.MakeName("hashjoiner").Unlimited())
 	h.diskMonitor = execinfra.NewMonitor(ctx, flowCtx.DiskMonitor,
-		mon.MakeMonitorName("hashjoiner").Disk())
+		mon.MakeName("hashjoiner").Disk())
 	h.hashTable = rowcontainer.NewHashDiskBackedRowContainer(
 		h.FlowCtx.EvalCtx, h.MemMonitor, h.unlimitedMemMonitor, h.diskMonitor, h.FlowCtx.Cfg.TempStorage,
 	)

--- a/pkg/sql/rowexec/hashjoiner.go
+++ b/pkg/sql/rowexec/hashjoiner.go
@@ -147,12 +147,10 @@ func newHashJoiner(
 
 	// Limit the memory use by creating a child monitor with a hard limit.
 	// The hashJoiner will overflow to disk if this limit is not enough.
-	h.MemMonitor = execinfra.NewLimitedMonitor(ctx, flowCtx.Mon, flowCtx,
-		mon.MakeName("hashjoiner").Limited())
-	h.unlimitedMemMonitor = execinfra.NewMonitor(ctx, flowCtx.Mon,
-		mon.MakeName("hashjoiner").Unlimited())
-	h.diskMonitor = execinfra.NewMonitor(ctx, flowCtx.DiskMonitor,
-		mon.MakeName("hashjoiner").Disk())
+	mn := mon.MakeName("hashjoiner")
+	h.MemMonitor = execinfra.NewLimitedMonitor(ctx, flowCtx.Mon, flowCtx, mn.Limited())
+	h.unlimitedMemMonitor = execinfra.NewMonitor(ctx, flowCtx.Mon, mn.Unlimited())
+	h.diskMonitor = execinfra.NewMonitor(ctx, flowCtx.DiskMonitor, mn.Disk())
 	h.hashTable = rowcontainer.NewHashDiskBackedRowContainer(
 		h.FlowCtx.EvalCtx, h.MemMonitor, h.unlimitedMemMonitor, h.diskMonitor, h.FlowCtx.Cfg.TempStorage,
 	)

--- a/pkg/sql/rowexec/hashjoiner.go
+++ b/pkg/sql/rowexec/hashjoiner.go
@@ -148,11 +148,11 @@ func newHashJoiner(
 	// Limit the memory use by creating a child monitor with a hard limit.
 	// The hashJoiner will overflow to disk if this limit is not enough.
 	h.MemMonitor = execinfra.NewLimitedMonitor(ctx, flowCtx.Mon, flowCtx,
-		mon.MakeMonitorName("hashjoiner").WithSuffix("limited"))
+		mon.MakeMonitorName("hashjoiner").Limited())
 	h.unlimitedMemMonitor = execinfra.NewMonitor(ctx, flowCtx.Mon,
-		mon.MakeMonitorName("hashjoiner").WithSuffix("unlimited"))
+		mon.MakeMonitorName("hashjoiner").Unlimited())
 	h.diskMonitor = execinfra.NewMonitor(ctx, flowCtx.DiskMonitor,
-		mon.MakeMonitorName("hashjoiner").WithSuffix("disk"))
+		mon.MakeMonitorName("hashjoiner").Disk())
 	h.hashTable = rowcontainer.NewHashDiskBackedRowContainer(
 		h.FlowCtx.EvalCtx, h.MemMonitor, h.unlimitedMemMonitor, h.diskMonitor, h.FlowCtx.Cfg.TempStorage,
 	)

--- a/pkg/sql/rowexec/hashjoiner.go
+++ b/pkg/sql/rowexec/hashjoiner.go
@@ -147,9 +147,12 @@ func newHashJoiner(
 
 	// Limit the memory use by creating a child monitor with a hard limit.
 	// The hashJoiner will overflow to disk if this limit is not enough.
-	h.MemMonitor = execinfra.NewLimitedMonitor(ctx, flowCtx.Mon, flowCtx, "hashjoiner-limited")
-	h.unlimitedMemMonitor = execinfra.NewMonitor(ctx, flowCtx.Mon, "hashjoiner-unlimited")
-	h.diskMonitor = execinfra.NewMonitor(ctx, flowCtx.DiskMonitor, "hashjoiner-disk")
+	h.MemMonitor = execinfra.NewLimitedMonitor(ctx, flowCtx.Mon, flowCtx,
+		mon.MakeMonitorName("hashjoiner").WithSuffix("limited"))
+	h.unlimitedMemMonitor = execinfra.NewMonitor(ctx, flowCtx.Mon,
+		mon.MakeMonitorName("hashjoiner").WithSuffix("unlimited"))
+	h.diskMonitor = execinfra.NewMonitor(ctx, flowCtx.DiskMonitor,
+		mon.MakeMonitorName("hashjoiner").WithSuffix("disk"))
 	h.hashTable = rowcontainer.NewHashDiskBackedRowContainer(
 		h.FlowCtx.EvalCtx, h.MemMonitor, h.unlimitedMemMonitor, h.diskMonitor, h.FlowCtx.Cfg.TempStorage,
 	)

--- a/pkg/sql/rowexec/indexbackfiller.go
+++ b/pkg/sql/rowexec/indexbackfiller.go
@@ -83,7 +83,7 @@ func newIndexBackfiller(
 	processorID int32,
 	spec execinfrapb.BackfillerSpec,
 ) (*indexBackfiller, error) {
-	indexBackfillerMon := execinfra.NewMonitor(ctx, flowCtx.Cfg.BackfillerMonitor,
+	indexBackfillerMon := execinfra.NewMonitorWithStringName(ctx, flowCtx.Cfg.BackfillerMonitor,
 		"index-backfill-mon")
 	ib := &indexBackfiller{
 		desc:        flowCtx.TableDescriptor(ctx, &spec.Table),

--- a/pkg/sql/rowexec/indexbackfiller.go
+++ b/pkg/sql/rowexec/indexbackfiller.go
@@ -26,6 +26,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -83,8 +84,8 @@ func newIndexBackfiller(
 	processorID int32,
 	spec execinfrapb.BackfillerSpec,
 ) (*indexBackfiller, error) {
-	indexBackfillerMon := execinfra.NewMonitorWithStringName(ctx, flowCtx.Cfg.BackfillerMonitor,
-		"index-backfill-mon")
+	indexBackfillerMon := execinfra.NewMonitor(ctx, flowCtx.Cfg.BackfillerMonitor,
+		mon.MakeName("index-backfill-mon"))
 	ib := &indexBackfiller{
 		desc:        flowCtx.TableDescriptor(ctx, &spec.Table),
 		spec:        spec,

--- a/pkg/sql/rowexec/inverted_filterer.go
+++ b/pkg/sql/rowexec/inverted_filterer.go
@@ -111,9 +111,12 @@ func newInvertedFilterer(
 	}
 
 	// Initialize memory monitor and row container for input rows.
-	ifr.MemMonitor = execinfra.NewLimitedMonitor(ctx, flowCtx.Mon, flowCtx, "inverted-filterer-limited")
-	ifr.unlimitedMemMonitor = execinfra.NewMonitor(ctx, flowCtx.Mon, "inverted-filterer-unlimited")
-	ifr.diskMonitor = execinfra.NewMonitor(ctx, flowCtx.DiskMonitor, "inverted-filterer-disk")
+	ifr.MemMonitor = execinfra.NewLimitedMonitor(ctx, flowCtx.Mon, flowCtx,
+		mon.MakeMonitorName("inverted-filterer").WithSuffix("limited"))
+	ifr.unlimitedMemMonitor = execinfra.NewMonitor(ctx, flowCtx.Mon,
+		mon.MakeMonitorName("inverted-filterer").WithSuffix("unlimited"))
+	ifr.diskMonitor = execinfra.NewMonitor(ctx, flowCtx.DiskMonitor,
+		mon.MakeMonitorName("inverted-filterer").WithSuffix("disk"))
 	ifr.rc = rowcontainer.NewDiskBackedNumberedRowContainer(
 		true, /* deDup */
 		rcColTypes,

--- a/pkg/sql/rowexec/inverted_filterer.go
+++ b/pkg/sql/rowexec/inverted_filterer.go
@@ -111,12 +111,10 @@ func newInvertedFilterer(
 	}
 
 	// Initialize memory monitor and row container for input rows.
-	ifr.MemMonitor = execinfra.NewLimitedMonitor(ctx, flowCtx.Mon, flowCtx,
-		mon.MakeName("inverted-filterer").Limited())
-	ifr.unlimitedMemMonitor = execinfra.NewMonitor(ctx, flowCtx.Mon,
-		mon.MakeName("inverted-filterer").Unlimited())
-	ifr.diskMonitor = execinfra.NewMonitor(ctx, flowCtx.DiskMonitor,
-		mon.MakeName("inverted-filterer").Disk())
+	mn := mon.MakeName("inverted-filterer")
+	ifr.MemMonitor = execinfra.NewLimitedMonitor(ctx, flowCtx.Mon, flowCtx, mn.Limited())
+	ifr.unlimitedMemMonitor = execinfra.NewMonitor(ctx, flowCtx.Mon, mn.Unlimited())
+	ifr.diskMonitor = execinfra.NewMonitor(ctx, flowCtx.DiskMonitor, mn.Disk())
 	ifr.rc = rowcontainer.NewDiskBackedNumberedRowContainer(
 		true, /* deDup */
 		rcColTypes,

--- a/pkg/sql/rowexec/inverted_filterer.go
+++ b/pkg/sql/rowexec/inverted_filterer.go
@@ -112,11 +112,11 @@ func newInvertedFilterer(
 
 	// Initialize memory monitor and row container for input rows.
 	ifr.MemMonitor = execinfra.NewLimitedMonitor(ctx, flowCtx.Mon, flowCtx,
-		mon.MakeMonitorName("inverted-filterer").WithSuffix("limited"))
+		mon.MakeMonitorName("inverted-filterer").Limited())
 	ifr.unlimitedMemMonitor = execinfra.NewMonitor(ctx, flowCtx.Mon,
-		mon.MakeMonitorName("inverted-filterer").WithSuffix("unlimited"))
+		mon.MakeMonitorName("inverted-filterer").Unlimited())
 	ifr.diskMonitor = execinfra.NewMonitor(ctx, flowCtx.DiskMonitor,
-		mon.MakeMonitorName("inverted-filterer").WithSuffix("disk"))
+		mon.MakeMonitorName("inverted-filterer").Disk())
 	ifr.rc = rowcontainer.NewDiskBackedNumberedRowContainer(
 		true, /* deDup */
 		rcColTypes,

--- a/pkg/sql/rowexec/inverted_filterer.go
+++ b/pkg/sql/rowexec/inverted_filterer.go
@@ -112,11 +112,11 @@ func newInvertedFilterer(
 
 	// Initialize memory monitor and row container for input rows.
 	ifr.MemMonitor = execinfra.NewLimitedMonitor(ctx, flowCtx.Mon, flowCtx,
-		mon.MakeMonitorName("inverted-filterer").Limited())
+		mon.MakeName("inverted-filterer").Limited())
 	ifr.unlimitedMemMonitor = execinfra.NewMonitor(ctx, flowCtx.Mon,
-		mon.MakeMonitorName("inverted-filterer").Unlimited())
+		mon.MakeName("inverted-filterer").Unlimited())
 	ifr.diskMonitor = execinfra.NewMonitor(ctx, flowCtx.DiskMonitor,
-		mon.MakeMonitorName("inverted-filterer").Disk())
+		mon.MakeName("inverted-filterer").Disk())
 	ifr.rc = rowcontainer.NewDiskBackedNumberedRowContainer(
 		true, /* deDup */
 		rcColTypes,

--- a/pkg/sql/rowexec/inverted_joiner.go
+++ b/pkg/sql/rowexec/inverted_joiner.go
@@ -321,9 +321,12 @@ func newInvertedJoiner(
 	ij.spanBuilder.InitWithFetchSpec(flowCtx.EvalCtx, flowCtx.Codec(), &ij.fetchSpec)
 
 	// Initialize memory monitors and row container for index rows.
-	ij.MemMonitor = execinfra.NewLimitedMonitor(ctx, flowCtx.Mon, flowCtx, "invertedjoiner-limited")
-	ij.unlimitedMemMonitor = execinfra.NewMonitor(ctx, flowCtx.Mon, "invertedjoiner-unlimited")
-	ij.diskMonitor = execinfra.NewMonitor(ctx, flowCtx.DiskMonitor, "invertedjoiner-disk")
+	ij.MemMonitor = execinfra.NewLimitedMonitor(ctx, flowCtx.Mon, flowCtx,
+		mon.MakeMonitorName("invertedjoiner").WithSuffix("limited"))
+	ij.unlimitedMemMonitor = execinfra.NewMonitor(ctx, flowCtx.Mon,
+		mon.MakeMonitorName("invertedjoiner").WithSuffix("unlimited"))
+	ij.diskMonitor = execinfra.NewMonitor(ctx, flowCtx.DiskMonitor,
+		mon.MakeMonitorName("invertedjoiner").WithSuffix("disk"))
 	ij.indexRows = rowcontainer.NewDiskBackedNumberedRowContainer(
 		true, /* deDup */
 		rightColTypes,

--- a/pkg/sql/rowexec/inverted_joiner.go
+++ b/pkg/sql/rowexec/inverted_joiner.go
@@ -322,11 +322,11 @@ func newInvertedJoiner(
 
 	// Initialize memory monitors and row container for index rows.
 	ij.MemMonitor = execinfra.NewLimitedMonitor(ctx, flowCtx.Mon, flowCtx,
-		mon.MakeMonitorName("invertedjoiner").WithSuffix("limited"))
+		mon.MakeMonitorName("invertedjoiner").Limited())
 	ij.unlimitedMemMonitor = execinfra.NewMonitor(ctx, flowCtx.Mon,
-		mon.MakeMonitorName("invertedjoiner").WithSuffix("unlimited"))
+		mon.MakeMonitorName("invertedjoiner").Unlimited())
 	ij.diskMonitor = execinfra.NewMonitor(ctx, flowCtx.DiskMonitor,
-		mon.MakeMonitorName("invertedjoiner").WithSuffix("disk"))
+		mon.MakeMonitorName("invertedjoiner").Disk())
 	ij.indexRows = rowcontainer.NewDiskBackedNumberedRowContainer(
 		true, /* deDup */
 		rightColTypes,

--- a/pkg/sql/rowexec/inverted_joiner.go
+++ b/pkg/sql/rowexec/inverted_joiner.go
@@ -322,11 +322,11 @@ func newInvertedJoiner(
 
 	// Initialize memory monitors and row container for index rows.
 	ij.MemMonitor = execinfra.NewLimitedMonitor(ctx, flowCtx.Mon, flowCtx,
-		mon.MakeMonitorName("invertedjoiner").Limited())
+		mon.MakeName("invertedjoiner").Limited())
 	ij.unlimitedMemMonitor = execinfra.NewMonitor(ctx, flowCtx.Mon,
-		mon.MakeMonitorName("invertedjoiner").Unlimited())
+		mon.MakeName("invertedjoiner").Unlimited())
 	ij.diskMonitor = execinfra.NewMonitor(ctx, flowCtx.DiskMonitor,
-		mon.MakeMonitorName("invertedjoiner").Disk())
+		mon.MakeName("invertedjoiner").Disk())
 	ij.indexRows = rowcontainer.NewDiskBackedNumberedRowContainer(
 		true, /* deDup */
 		rightColTypes,

--- a/pkg/sql/rowexec/joinreader.go
+++ b/pkg/sql/rowexec/joinreader.go
@@ -513,8 +513,9 @@ func newJoinReader(
 		streamerBudgetLimit := memoryLimit - 3*jr.batchSizeBytes
 		// We need to use an unlimited monitor for the streamer's budget since
 		// the streamer itself is responsible for staying under the limit.
-		jr.streamerInfo.unlimitedMemMonitor = mon.NewMonitorInheritWithLimitAndStringName(
-			"joinreader-streamer-unlimited" /* name */, math.MaxInt64, flowCtx.Mon, false, /* longLiving */
+		jr.streamerInfo.unlimitedMemMonitor = mon.NewMonitorInheritWithLimit(
+			mon.MakeName("joinreader-streamer").Unlimited(), math.MaxInt64, flowCtx.Mon,
+			false, /* longLiving */
 		)
 		jr.streamerInfo.unlimitedMemMonitor.StartNoReserved(ctx, flowCtx.Mon)
 		jr.streamerInfo.budgetAcc = jr.streamerInfo.unlimitedMemMonitor.MakeBoundAccount()

--- a/pkg/sql/rowexec/joinreader.go
+++ b/pkg/sql/rowexec/joinreader.go
@@ -513,7 +513,7 @@ func newJoinReader(
 		streamerBudgetLimit := memoryLimit - 3*jr.batchSizeBytes
 		// We need to use an unlimited monitor for the streamer's budget since
 		// the streamer itself is responsible for staying under the limit.
-		jr.streamerInfo.unlimitedMemMonitor = mon.NewMonitorInheritWithLimit(
+		jr.streamerInfo.unlimitedMemMonitor = mon.NewMonitorInheritWithLimitAndStringName(
 			"joinreader-streamer-unlimited" /* name */, math.MaxInt64, flowCtx.Mon, false, /* longLiving */
 		)
 		jr.streamerInfo.unlimitedMemMonitor.StartNoReserved(ctx, flowCtx.Mon)
@@ -547,7 +547,7 @@ func newJoinReader(
 		var diskBuffer kvstreamer.ResultDiskBuffer
 		if jr.streamerInfo.maintainOrdering {
 			diskBufferMemAcc := jr.streamerInfo.unlimitedMemMonitor.MakeBoundAccount()
-			jr.streamerInfo.diskMonitor = execinfra.NewMonitor(
+			jr.streamerInfo.diskMonitor = execinfra.NewMonitorWithStringName(
 				ctx, jr.FlowCtx.DiskMonitor, "streamer-disk", /* name */
 			)
 			diskBuffer = rowcontainer.NewKVStreamerResultDiskBuffer(
@@ -729,13 +729,16 @@ func (jr *joinReader) initJoinReaderStrategy(
 	// joinReader will overflow to disk if this limit is not enough.
 	limit := execinfra.GetWorkMemLimit(flowCtx)
 	// Initialize memory monitors and row container for looked up rows.
-	jr.limitedMemMonitor = execinfra.NewLimitedMonitor(ctx, jr.MemMonitor, flowCtx, "joinreader-limited")
+	jr.limitedMemMonitor = execinfra.NewLimitedMonitor(ctx, jr.MemMonitor, flowCtx,
+		mon.MakeMonitorName("joinreader").WithSuffix("limited"))
 	// We want to make sure that if the disk-backed container is spilled to
 	// disk, it releases all of the memory reservations, so we make the
 	// corresponding memory monitor not hold on to any bytes.
 	jr.limitedMemMonitor.RelinquishAllOnReleaseBytes()
-	jr.unlimitedMemMonitor = execinfra.NewMonitor(ctx, flowCtx.Mon, "joinreader-unlimited")
-	jr.diskMonitor = execinfra.NewMonitor(ctx, flowCtx.DiskMonitor, "joinreader-disk")
+	jr.unlimitedMemMonitor = execinfra.NewMonitor(ctx, flowCtx.Mon,
+		mon.MakeMonitorName("joinreader").WithSuffix("unlimited"))
+	jr.diskMonitor = execinfra.NewMonitor(ctx, flowCtx.DiskMonitor,
+		mon.MakeMonitorName("joinreader").WithSuffix("disk"))
 	drc := rowcontainer.NewDiskBackedNumberedRowContainer(
 		false, /* deDup */
 		typs,

--- a/pkg/sql/rowexec/joinreader.go
+++ b/pkg/sql/rowexec/joinreader.go
@@ -730,15 +730,15 @@ func (jr *joinReader) initJoinReaderStrategy(
 	limit := execinfra.GetWorkMemLimit(flowCtx)
 	// Initialize memory monitors and row container for looked up rows.
 	jr.limitedMemMonitor = execinfra.NewLimitedMonitor(ctx, jr.MemMonitor, flowCtx,
-		mon.MakeMonitorName("joinreader").WithSuffix("limited"))
+		mon.MakeMonitorName("joinreader").Limited())
 	// We want to make sure that if the disk-backed container is spilled to
 	// disk, it releases all of the memory reservations, so we make the
 	// corresponding memory monitor not hold on to any bytes.
 	jr.limitedMemMonitor.RelinquishAllOnReleaseBytes()
 	jr.unlimitedMemMonitor = execinfra.NewMonitor(ctx, flowCtx.Mon,
-		mon.MakeMonitorName("joinreader").WithSuffix("unlimited"))
+		mon.MakeMonitorName("joinreader").Unlimited())
 	jr.diskMonitor = execinfra.NewMonitor(ctx, flowCtx.DiskMonitor,
-		mon.MakeMonitorName("joinreader").WithSuffix("disk"))
+		mon.MakeMonitorName("joinreader").Disk())
 	drc := rowcontainer.NewDiskBackedNumberedRowContainer(
 		false, /* deDup */
 		typs,

--- a/pkg/sql/rowexec/joinreader.go
+++ b/pkg/sql/rowexec/joinreader.go
@@ -730,15 +730,15 @@ func (jr *joinReader) initJoinReaderStrategy(
 	limit := execinfra.GetWorkMemLimit(flowCtx)
 	// Initialize memory monitors and row container for looked up rows.
 	jr.limitedMemMonitor = execinfra.NewLimitedMonitor(ctx, jr.MemMonitor, flowCtx,
-		mon.MakeMonitorName("joinreader").Limited())
+		mon.MakeName("joinreader").Limited())
 	// We want to make sure that if the disk-backed container is spilled to
 	// disk, it releases all of the memory reservations, so we make the
 	// corresponding memory monitor not hold on to any bytes.
 	jr.limitedMemMonitor.RelinquishAllOnReleaseBytes()
 	jr.unlimitedMemMonitor = execinfra.NewMonitor(ctx, flowCtx.Mon,
-		mon.MakeMonitorName("joinreader").Unlimited())
+		mon.MakeName("joinreader").Unlimited())
 	jr.diskMonitor = execinfra.NewMonitor(ctx, flowCtx.DiskMonitor,
-		mon.MakeMonitorName("joinreader").Disk())
+		mon.MakeName("joinreader").Disk())
 	drc := rowcontainer.NewDiskBackedNumberedRowContainer(
 		false, /* deDup */
 		typs,

--- a/pkg/sql/rowexec/mergejoiner.go
+++ b/pkg/sql/rowexec/mergejoiner.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/rowinfra"
 	"github.com/cockroachdb/cockroach/pkg/util/cancelchecker"
 	"github.com/cockroachdb/cockroach/pkg/util/intsets"
+	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/optional"
 	"github.com/cockroachdb/errors"
 )
@@ -82,7 +83,7 @@ func newMergeJoiner(
 		return nil, err
 	}
 
-	m.MemMonitor = execinfra.NewMonitorWithStringName(ctx, flowCtx.Mon, "mergejoiner-mem")
+	m.MemMonitor = execinfra.NewMonitor(ctx, flowCtx.Mon, mon.MakeName("mergejoiner-mem"))
 
 	var err error
 	m.streamMerger, err = makeStreamMerger(

--- a/pkg/sql/rowexec/mergejoiner.go
+++ b/pkg/sql/rowexec/mergejoiner.go
@@ -82,7 +82,7 @@ func newMergeJoiner(
 		return nil, err
 	}
 
-	m.MemMonitor = execinfra.NewMonitor(ctx, flowCtx.Mon, "mergejoiner-mem")
+	m.MemMonitor = execinfra.NewMonitorWithStringName(ctx, flowCtx.Mon, "mergejoiner-mem")
 
 	var err error
 	m.streamMerger, err = makeStreamMerger(

--- a/pkg/sql/rowexec/sorter.go
+++ b/pkg/sql/rowexec/sorter.go
@@ -57,7 +57,7 @@ func (s *sorterBase) init(
 	// Limit the memory use by creating a child monitor with a hard limit.
 	// The processor will overflow to disk if this limit is not enough.
 	memMonitor := execinfra.NewLimitedMonitor(ctx, flowCtx.Mon, flowCtx,
-		mon.MakeMonitorName(processorName).WithSuffix("limited"))
+		mon.MakeMonitorName(processorName).Limited())
 	if err := s.ProcessorBase.Init(
 		ctx, self, post, input.OutputTypes(), flowCtx, processorID, memMonitor, opts,
 	); err != nil {
@@ -65,8 +65,10 @@ func (s *sorterBase) init(
 		return err
 	}
 
-	s.unlimitedMemMonitor = execinfra.NewMonitorWithStringName(ctx, flowCtx.Mon, processorName+"-unlimited")
-	s.diskMonitor = execinfra.NewMonitorWithStringName(ctx, flowCtx.DiskMonitor, processorName+"-disk")
+	s.unlimitedMemMonitor = execinfra.NewMonitor(ctx, flowCtx.Mon,
+		mon.MakeMonitorName(processorName).Unlimited())
+	s.diskMonitor = execinfra.NewMonitor(ctx, flowCtx.DiskMonitor,
+		mon.MakeMonitorName(processorName).Disk())
 	rc := rowcontainer.DiskBackedRowContainer{}
 	rc.Init(
 		ordering,

--- a/pkg/sql/rowexec/sorter.go
+++ b/pkg/sql/rowexec/sorter.go
@@ -56,7 +56,8 @@ func (s *sorterBase) init(
 
 	// Limit the memory use by creating a child monitor with a hard limit.
 	// The processor will overflow to disk if this limit is not enough.
-	memMonitor := execinfra.NewLimitedMonitor(ctx, flowCtx.Mon, flowCtx, processorName+"-limited")
+	memMonitor := execinfra.NewLimitedMonitor(ctx, flowCtx.Mon, flowCtx,
+		mon.MakeMonitorName(processorName).WithSuffix("limited"))
 	if err := s.ProcessorBase.Init(
 		ctx, self, post, input.OutputTypes(), flowCtx, processorID, memMonitor, opts,
 	); err != nil {
@@ -64,8 +65,8 @@ func (s *sorterBase) init(
 		return err
 	}
 
-	s.unlimitedMemMonitor = execinfra.NewMonitor(ctx, flowCtx.Mon, processorName+"-unlimited")
-	s.diskMonitor = execinfra.NewMonitor(ctx, flowCtx.DiskMonitor, processorName+"-disk")
+	s.unlimitedMemMonitor = execinfra.NewMonitorWithStringName(ctx, flowCtx.Mon, processorName+"-unlimited")
+	s.diskMonitor = execinfra.NewMonitorWithStringName(ctx, flowCtx.DiskMonitor, processorName+"-disk")
 	rc := rowcontainer.DiskBackedRowContainer{}
 	rc.Init(
 		ordering,

--- a/pkg/sql/rowexec/sorter.go
+++ b/pkg/sql/rowexec/sorter.go
@@ -57,7 +57,7 @@ func (s *sorterBase) init(
 	// Limit the memory use by creating a child monitor with a hard limit.
 	// The processor will overflow to disk if this limit is not enough.
 	memMonitor := execinfra.NewLimitedMonitor(ctx, flowCtx.Mon, flowCtx,
-		mon.MakeMonitorName(processorName).Limited())
+		mon.MakeName(processorName).Limited())
 	if err := s.ProcessorBase.Init(
 		ctx, self, post, input.OutputTypes(), flowCtx, processorID, memMonitor, opts,
 	); err != nil {
@@ -66,9 +66,9 @@ func (s *sorterBase) init(
 	}
 
 	s.unlimitedMemMonitor = execinfra.NewMonitor(ctx, flowCtx.Mon,
-		mon.MakeMonitorName(processorName).Unlimited())
+		mon.MakeName(processorName).Unlimited())
 	s.diskMonitor = execinfra.NewMonitor(ctx, flowCtx.DiskMonitor,
-		mon.MakeMonitorName(processorName).Disk())
+		mon.MakeName(processorName).Disk())
 	rc := rowcontainer.DiskBackedRowContainer{}
 	rc.Init(
 		ordering,

--- a/pkg/sql/rowexec/sorter.go
+++ b/pkg/sql/rowexec/sorter.go
@@ -56,8 +56,8 @@ func (s *sorterBase) init(
 
 	// Limit the memory use by creating a child monitor with a hard limit.
 	// The processor will overflow to disk if this limit is not enough.
-	memMonitor := execinfra.NewLimitedMonitor(ctx, flowCtx.Mon, flowCtx,
-		mon.MakeName(processorName).Limited())
+	mn := mon.MakeName(processorName)
+	memMonitor := execinfra.NewLimitedMonitor(ctx, flowCtx.Mon, flowCtx, mn.Limited())
 	if err := s.ProcessorBase.Init(
 		ctx, self, post, input.OutputTypes(), flowCtx, processorID, memMonitor, opts,
 	); err != nil {
@@ -65,10 +65,8 @@ func (s *sorterBase) init(
 		return err
 	}
 
-	s.unlimitedMemMonitor = execinfra.NewMonitor(ctx, flowCtx.Mon,
-		mon.MakeName(processorName).Unlimited())
-	s.diskMonitor = execinfra.NewMonitor(ctx, flowCtx.DiskMonitor,
-		mon.MakeName(processorName).Disk())
+	s.unlimitedMemMonitor = execinfra.NewMonitor(ctx, flowCtx.Mon, mn.Unlimited())
+	s.diskMonitor = execinfra.NewMonitor(ctx, flowCtx.DiskMonitor, mn.Disk())
 	rc := rowcontainer.DiskBackedRowContainer{}
 	rc.Init(
 		ordering,

--- a/pkg/sql/rowexec/windower.go
+++ b/pkg/sql/rowexec/windower.go
@@ -173,8 +173,9 @@ func newWindower(
 		return nil, err
 	}
 
-	w.unlimitedMemMonitor = execinfra.NewMonitorWithStringName(ctx, flowCtx.Mon, "windower-unlimited")
-	w.diskMonitor = execinfra.NewMonitorWithStringName(ctx, flowCtx.DiskMonitor, "windower-disk")
+	mn := mon.MakeName("windower")
+	w.unlimitedMemMonitor = execinfra.NewMonitor(ctx, flowCtx.Mon, mn.Unlimited())
+	w.diskMonitor = execinfra.NewMonitor(ctx, flowCtx.DiskMonitor, mn.Disk())
 	w.allRowsPartitioned = rowcontainer.NewHashDiskBackedRowContainer(
 		w.evalCtx, w.MemMonitor, w.unlimitedMemMonitor, w.diskMonitor, flowCtx.Cfg.TempStorage,
 	)

--- a/pkg/sql/rowexec/windower.go
+++ b/pkg/sql/rowexec/windower.go
@@ -173,8 +173,8 @@ func newWindower(
 		return nil, err
 	}
 
-	w.unlimitedMemMonitor = execinfra.NewMonitor(ctx, flowCtx.Mon, "windower-unlimited")
-	w.diskMonitor = execinfra.NewMonitor(ctx, flowCtx.DiskMonitor, "windower-disk")
+	w.unlimitedMemMonitor = execinfra.NewMonitorWithStringName(ctx, flowCtx.Mon, "windower-unlimited")
+	w.diskMonitor = execinfra.NewMonitorWithStringName(ctx, flowCtx.DiskMonitor, "windower-disk")
 	w.allRowsPartitioned = rowcontainer.NewHashDiskBackedRowContainer(
 		w.evalCtx, w.MemMonitor, w.unlimitedMemMonitor, w.diskMonitor, flowCtx.Cfg.TempStorage,
 	)

--- a/pkg/sql/rowexec/windower_test.go
+++ b/pkg/sql/rowexec/windower_test.go
@@ -36,7 +36,7 @@ func TestWindowerAccountingForResults(t *testing.T) {
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettings()
 	monitor := mon.NewMonitor(mon.Options{
-		Name:      mon.MakeMonitorName("test-monitor"),
+		Name:      mon.MakeName("test-monitor"),
 		Limit:     100000,
 		Increment: 5000,
 		Settings:  st,

--- a/pkg/sql/rowflow/BUILD.bazel
+++ b/pkg/sql/rowflow/BUILD.bazel
@@ -29,7 +29,6 @@ go_library(
         "//pkg/util/tracing",
         "//pkg/util/tracing/tracingpb",
         "@com_github_cockroachdb_errors//:errors",
-        "@com_github_cockroachdb_redact//:redact",
         "@io_opentelemetry_go_otel//attribute",
     ],
 )

--- a/pkg/sql/rowflow/routers_test.go
+++ b/pkg/sql/rowflow/routers_test.go
@@ -784,7 +784,7 @@ func TestRouterDiskSpill(t *testing.T) {
 	// rowContainer. This is a bytes value that will ensure we fall back to disk
 	// but use memory for at least a couple of rows.
 	monitor := mon.NewMonitor(mon.Options{
-		Name:      mon.MakeMonitorName("test-monitor"),
+		Name:      mon.MakeName("test-monitor"),
 		Limit:     (numRows - routerRowBufSize) / 2,
 		Increment: 1,
 		Settings:  st,

--- a/pkg/sql/rowflow/row_based_flow.go
+++ b/pkg/sql/rowflow/row_based_flow.go
@@ -463,12 +463,12 @@ func (f *rowBasedFlow) setupRouter(
 	for i := range spec.Streams {
 		memoryMonitors[i] = execinfra.NewLimitedMonitor(
 			ctx, f.Mon, &f.FlowCtx,
-			"router-limited-"+redact.SafeString(spec.Streams[i].StreamID.String()),
+			mon.MakeMonitorName("router-limited-"+redact.SafeString(spec.Streams[i].StreamID.String())),
 		)
-		unlimitedMemMonitors[i] = execinfra.NewMonitor(
+		unlimitedMemMonitors[i] = execinfra.NewMonitorWithStringName(
 			ctx, f.Mon, "router-unlimited-"+redact.SafeString(spec.Streams[i].StreamID.String()),
 		)
-		diskMonitors[i] = execinfra.NewMonitor(
+		diskMonitors[i] = execinfra.NewMonitorWithStringName(
 			ctx, f.DiskMonitor,
 			"router-disk-"+redact.SafeString(spec.Streams[i].StreamID.String()),
 		)

--- a/pkg/sql/rowflow/row_based_flow.go
+++ b/pkg/sql/rowflow/row_based_flow.go
@@ -463,7 +463,7 @@ func (f *rowBasedFlow) setupRouter(
 	for i := range spec.Streams {
 		memoryMonitors[i] = execinfra.NewLimitedMonitor(
 			ctx, f.Mon, &f.FlowCtx,
-			mon.MakeMonitorName("router-limited-"+redact.SafeString(spec.Streams[i].StreamID.String())),
+			mon.MakeName("router-limited-"+redact.SafeString(spec.Streams[i].StreamID.String())),
 		)
 		unlimitedMemMonitors[i] = execinfra.NewMonitorWithStringName(
 			ctx, f.Mon, "router-unlimited-"+redact.SafeString(spec.Streams[i].StreamID.String()),

--- a/pkg/sql/schemachanger/scbuild/builder_test.go
+++ b/pkg/sql/schemachanger/scbuild/builder_test.go
@@ -313,7 +313,7 @@ func TestBuildIsMemoryMonitored(t *testing.T) {
 	tdb.Exec(t, `use system;`)
 
 	monitor := mon.NewMonitor(mon.Options{
-		Name:     mon.MakeMonitorName("test-sc-build-mon"),
+		Name:     mon.MakeName("test-sc-build-mon"),
 		Settings: s.ClusterSettings(),
 	})
 	monitor.Start(ctx, nil, mon.NewStandaloneBudget(5*1024*1024 /* 5MiB */))

--- a/pkg/sql/schemachanger/scplan/plan_test.go
+++ b/pkg/sql/schemachanger/scplan/plan_test.go
@@ -274,7 +274,7 @@ func TestExplainPlanIsMemoryMonitored(t *testing.T) {
 	})
 
 	monitor := mon.NewMonitor(mon.Options{
-		Name:     mon.MakeMonitorName("test-sc-plan-mon"),
+		Name:     mon.MakeName("test-sc-plan-mon"),
 		Settings: tt.ClusterSettings(),
 	})
 	monitor.Start(ctx, nil, mon.NewStandaloneBudget(5.243e+6 /* 5MiB */))

--- a/pkg/sql/sem/builtins/show_create_all_tables_builtin_test.go
+++ b/pkg/sql/sem/builtins/show_create_all_tables_builtin_test.go
@@ -22,7 +22,7 @@ func TestTopologicalSort(t *testing.T) {
 
 	ctx := context.Background()
 	monitor := mon.NewMonitor(mon.Options{
-		Name:     mon.MakeMonitorName("test-mem"),
+		Name:     mon.MakeName("test-mem"),
 		Settings: cluster.MakeTestingClusterSettings(),
 	})
 	monitor.Start(ctx, nil, mon.NewStandaloneBudget(math.MaxInt64))

--- a/pkg/sql/sem/eval/context.go
+++ b/pkg/sql/sem/eval/context.go
@@ -432,7 +432,7 @@ func (ec *Context) MustGetPlaceholderValue(ctx context.Context, p *tree.Placehol
 // MakeTestingEvalContext returns an EvalContext that includes a MemoryMonitor.
 func MakeTestingEvalContext(st *cluster.Settings) Context {
 	monitor := mon.NewMonitor(mon.Options{
-		Name:     mon.MakeMonitorName("test-monitor"),
+		Name:     mon.MakeName("test-monitor"),
 		Settings: st,
 	})
 	return MakeTestingEvalContextWithMon(st, monitor)

--- a/pkg/sql/sqlstats/sslocal/sql_stats.go
+++ b/pkg/sql/sqlstats/sslocal/sql_stats.go
@@ -58,7 +58,7 @@ func newSQLStats(
 	knobs *sqlstats.TestingKnobs,
 ) *SQLStats {
 	monitor := mon.NewMonitor(mon.Options{
-		Name:       mon.MakeMonitorName("SQLStats"),
+		Name:       mon.MakeName("SQLStats"),
 		CurCount:   curMemBytesCount,
 		MaxHist:    maxMemBytesHist,
 		Settings:   st,

--- a/pkg/sql/sqlstats/sslocal/sql_stats_test.go
+++ b/pkg/sql/sqlstats/sslocal/sql_stats_test.go
@@ -440,7 +440,7 @@ func TestExplicitTxnFingerprintAccounting(t *testing.T) {
 
 	st := cluster.MakeTestingClusterSettings()
 	monitor := mon.NewUnlimitedMonitor(ctx, mon.Options{
-		Name:     mon.MakeMonitorName("test"),
+		Name:     mon.MakeName("test"),
 		Settings: st,
 	})
 
@@ -551,7 +551,7 @@ func TestAssociatingStmtStatsWithTxnFingerprint(t *testing.T) {
 	st := cluster.MakeTestingClusterSettings()
 	updater := st.MakeUpdater()
 	monitor := mon.NewUnlimitedMonitor(ctx, mon.Options{
-		Name:     mon.MakeMonitorName("test"),
+		Name:     mon.MakeName("test"),
 		Settings: st,
 	})
 
@@ -2043,7 +2043,7 @@ func BenchmarkSqlStatsDrain(b *testing.B) {
 func createNewSqlStats() *sslocal.SQLStats {
 	st := cluster.MakeTestingClusterSettings()
 	monitor := mon.NewUnlimitedMonitor(context.Background(), mon.Options{
-		Name:     mon.MakeMonitorName("test"),
+		Name:     mon.MakeName("test"),
 		Settings: st,
 	})
 	sqlstats.MaxMemSQLStatsStmtFingerprints.Override(context.Background(), &st.SV, 100000)

--- a/pkg/sql/sqlstats/ssmemstorage/ss_mem_writer_test.go
+++ b/pkg/sql/sqlstats/ssmemstorage/ss_mem_writer_test.go
@@ -276,7 +276,7 @@ func testMonitor(
 	ctx context.Context, name redact.SafeString, settings *cluster.Settings,
 ) *mon.BytesMonitor {
 	return mon.NewUnlimitedMonitor(ctx, mon.Options{
-		Name:     mon.MakeMonitorName(name),
+		Name:     mon.MakeName(name),
 		Settings: settings,
 	})
 }

--- a/pkg/sql/stats/row_sampling_test.go
+++ b/pkg/sql/stats/row_sampling_test.go
@@ -107,7 +107,7 @@ func TestSampleReservoir(t *testing.T) {
 			for _, mem := range []int64{1 << 8, 1 << 10, 1 << 12} {
 				t.Run(fmt.Sprintf("n=%d/k=%d/mem=%d", n, k, mem), func(t *testing.T) {
 					monitor := mon.NewMonitor(mon.Options{
-						Name:      mon.MakeMonitorName("test-monitor"),
+						Name:      mon.MakeName("test-monitor"),
 						Limit:     mem,
 						Increment: 1,
 						Settings:  st,
@@ -201,7 +201,7 @@ func TestSampleReservoirMemAccounting(t *testing.T) {
 		{getStringDatum(maxBytesPerSample), getStringDatum(0)}, // rank 1
 	}
 	monitor := mon.NewMonitor(mon.Options{
-		Name:      mon.MakeMonitorName("test-monitor"),
+		Name:      mon.MakeName("test-monitor"),
 		Limit:     memLimit,
 		Increment: 1,
 		Settings:  st,

--- a/pkg/sql/txn_state_test.go
+++ b/pkg/sql/txn_state_test.go
@@ -60,7 +60,7 @@ func makeTestContext(stopper *stop.Stopper) testContext {
 		clock:  clock,
 		mockDB: kv.NewDB(ambient, factory, clock, stopper),
 		mon: mon.NewMonitor(mon.Options{
-			Name:     mon.MakeMonitorName("test root mon"),
+			Name:     mon.MakeName("test root mon"),
 			Settings: settings,
 		}),
 		tracer:   ambient.Tracer,
@@ -75,7 +75,7 @@ func (tc *testContext) createOpenState(typ txnType) (fsm.State, *txnState) {
 	ctx := tracing.ContextWithSpan(tc.ctx, sp)
 
 	txnStateMon := mon.NewMonitor(mon.Options{
-		Name:     mon.MakeMonitorName("test mon"),
+		Name:     mon.MakeName("test mon"),
 		Settings: cluster.MakeTestingClusterSettings(),
 	})
 	txnStateMon.StartNoReserved(tc.ctx, tc.mon)
@@ -117,7 +117,7 @@ func (tc *testContext) createCommitWaitState() (fsm.State, *txnState, error) {
 
 func (tc *testContext) createNoTxnState() (fsm.State, *txnState) {
 	txnStateMon := mon.NewMonitor(mon.Options{
-		Name:     mon.MakeMonitorName("test mon"),
+		Name:     mon.MakeName("test mon"),
 		Settings: cluster.MakeTestingClusterSettings(),
 	})
 	ts := txnState{mon: txnStateMon, connCtx: tc.ctx}

--- a/pkg/storage/col_mvcc.go
+++ b/pkg/storage/col_mvcc.go
@@ -440,7 +440,7 @@ func mvccScanToCols(
 		// If we don't have the monitor, then we create a "fake" one that is not
 		// connected to the memory accounting system.
 		monitor = mon.NewMonitor(mon.Options{
-			Name:     mon.MakeMonitorName("mvcc-scan-to-cols"),
+			Name:     mon.MakeName("mvcc-scan-to-cols"),
 			Settings: st,
 		})
 		monitor.Start(ctx, nil /* pool */, mon.NewStandaloneBudget(math.MaxInt64))

--- a/pkg/storage/pebble_mvcc_scanner_test.go
+++ b/pkg/storage/pebble_mvcc_scanner_test.go
@@ -183,7 +183,7 @@ func scannerWithAccount(
 	ctx context.Context, st *cluster.Settings, scanner *pebbleMVCCScanner, limitBytes int64,
 ) (cleanup func()) {
 	m := mon.NewMonitor(mon.Options{
-		Name:      mon.MakeMonitorName("test"),
+		Name:      mon.MakeName("test"),
 		Increment: 1,
 		Settings:  st,
 	})

--- a/pkg/ts/db_test.go
+++ b/pkg/ts/db_test.go
@@ -74,11 +74,11 @@ type testModelRunner struct {
 func newTestModelRunner(t *testing.T) testModelRunner {
 	st := cluster.MakeTestingClusterSettings()
 	workerMonitor := mon.NewUnlimitedMonitor(context.Background(), mon.Options{
-		Name:     mon.MakeMonitorName("timeseries-test-worker"),
+		Name:     mon.MakeName("timeseries-test-worker"),
 		Settings: st,
 	})
 	resultMonitor := mon.NewUnlimitedMonitor(context.Background(), mon.Options{
-		Name:     mon.MakeMonitorName("timeseries-test-result"),
+		Name:     mon.MakeName("timeseries-test-result"),
 		Settings: st,
 	})
 	return testModelRunner{

--- a/pkg/ts/query_test.go
+++ b/pkg/ts/query_test.go
@@ -396,7 +396,7 @@ func TestQueryWorkerMemoryConstraint(t *testing.T) {
 		{
 			// Swap model's memory monitor in order to adjust allocation size.
 			adjustedMon := mon.NewMonitor(mon.Options{
-				Name:      mon.MakeMonitorName("timeseries-test-worker-adjusted"),
+				Name:      mon.MakeName("timeseries-test-worker-adjusted"),
 				Increment: 1,
 				Settings:  cluster.MakeTestingClusterSettings(),
 			})
@@ -469,7 +469,7 @@ func TestQueryWorkerMemoryMonitor(t *testing.T) {
 		// Create a limited bytes monitor.
 		memoryBudget := int64(100 * 1024)
 		limitedMon := mon.NewMonitor(mon.Options{
-			Name:      mon.MakeMonitorName("timeseries-test-limited"),
+			Name:      mon.MakeName("timeseries-test-limited"),
 			Limit:     memoryBudget,
 			Increment: 100,
 			Settings:  cluster.MakeTestingClusterSettings(),

--- a/pkg/ts/rollup_test.go
+++ b/pkg/ts/rollup_test.go
@@ -267,7 +267,7 @@ func TestRollupMemoryConstraint(t *testing.T) {
 	// Construct a memory monitor that will be used to measure the high-water
 	// mark of memory usage for the rollup process.
 	adjustedMon := mon.NewMonitor(mon.Options{
-		Name:      mon.MakeMonitorName("timeseries-test-worker-adjusted"),
+		Name:      mon.MakeName("timeseries-test-worker-adjusted"),
 		Increment: 1,
 		Settings:  cluster.MakeTestingClusterSettings(),
 	})

--- a/pkg/ts/server.go
+++ b/pkg/ts/server.go
@@ -184,14 +184,14 @@ func MakeServer(
 		db:             db,
 		stopper:        stopper,
 		nodeCountFn:    nodeCountFn,
-		workerMemMonitor: mon.NewMonitorInheritWithLimitAndStringName(
-			"timeseries-workers",
+		workerMemMonitor: mon.NewMonitorInheritWithLimit(
+			mon.MakeName("timeseries-workers"),
 			queryMemoryMax*2,
 			memoryMonitor,
 			true, /* longLiving */
 		),
-		resultMemMonitor: mon.NewMonitorInheritWithLimitAndStringName(
-			"timeseries-results",
+		resultMemMonitor: mon.NewMonitorInheritWithLimit(
+			mon.MakeName("timeseries-results"),
 			math.MaxInt64,
 			memoryMonitor,
 			true, /* longLiving */

--- a/pkg/ts/server.go
+++ b/pkg/ts/server.go
@@ -184,13 +184,13 @@ func MakeServer(
 		db:             db,
 		stopper:        stopper,
 		nodeCountFn:    nodeCountFn,
-		workerMemMonitor: mon.NewMonitorInheritWithLimit(
+		workerMemMonitor: mon.NewMonitorInheritWithLimitAndStringName(
 			"timeseries-workers",
 			queryMemoryMax*2,
 			memoryMonitor,
 			true, /* longLiving */
 		),
-		resultMemMonitor: mon.NewMonitorInheritWithLimit(
+		resultMemMonitor: mon.NewMonitorInheritWithLimitAndStringName(
 			"timeseries-results",
 			math.MaxInt64,
 			memoryMonitor,

--- a/pkg/util/mon/bytes_usage.go
+++ b/pkg/util/mon/bytes_usage.go
@@ -531,14 +531,14 @@ func NewMonitor(args Options) *BytesMonitor {
 // those chunks would be reported as used by pool while downstream monitors will
 // not.
 func NewMonitorInheritWithLimit(
-	name redact.SafeString, limit int64, m *BytesMonitor, longLiving bool,
+	name MonitorName, limit int64, m *BytesMonitor, longLiving bool,
 ) *BytesMonitor {
 	res := MemoryResource
 	if m.mu.tracksDisk {
 		res = DiskResource
 	}
 	return NewMonitor(Options{
-		Name:       MakeMonitorName(name),
+		Name:       name,
 		Res:        res,
 		Limit:      limit,
 		CurCount:   nil, // CurCount is not inherited as we don't want to double count allocations
@@ -547,6 +547,15 @@ func NewMonitorInheritWithLimit(
 		Settings:   m.settings,
 		LongLiving: longLiving,
 	})
+}
+
+// NewMonitorInheritWithLimitAndStringName is the same as
+// NewMonitorInheritWithLimit but accept a string name.
+// Deprecated: NewMonitorInheritWithLimit should be used instead.
+func NewMonitorInheritWithLimitAndStringName(
+	name redact.SafeString, limit int64, m *BytesMonitor, longLiving bool,
+) *BytesMonitor {
+	return NewMonitorInheritWithLimit(MakeMonitorName(name), limit, m, longLiving)
 }
 
 func (mm *BytesMonitor) MarkAsRootSQLMonitor() {

--- a/pkg/util/mon/bytes_usage.go
+++ b/pkg/util/mon/bytes_usage.go
@@ -595,15 +595,6 @@ func NewMonitorInheritWithLimit(
 	})
 }
 
-// NewMonitorInheritWithLimitAndStringName is the same as
-// NewMonitorInheritWithLimit but accept a string name.
-// Deprecated: NewMonitorInheritWithLimit should be used instead.
-func NewMonitorInheritWithLimitAndStringName(
-	name redact.SafeString, limit int64, m *BytesMonitor, longLiving bool,
-) *BytesMonitor {
-	return NewMonitorInheritWithLimit(MakeName(name), limit, m, longLiving)
-}
-
 func (mm *BytesMonitor) MarkAsRootSQLMonitor() {
 	if mm.mu.tracksDisk {
 		panic(errors.AssertionFailedf("root SQL memory monitor cannot track disk resources"))

--- a/pkg/util/mon/bytes_usage.go
+++ b/pkg/util/mon/bytes_usage.go
@@ -278,34 +278,34 @@ type BytesMonitor struct {
 }
 
 // MonitorName is used to identify monitors in logging messages. It consists of
-// a string name and an optional ID.
+// a string prefix and an optional uuid.Short.
 type MonitorName struct {
-	name redact.SafeString
-	id   uuid.Short
+	prefix redact.SafeString
+	uuid   uuid.Short
 }
 
-// MakeMonitorName constructs a MonitorName with the given name.
-func MakeMonitorName(name redact.SafeString) MonitorName {
-	return MonitorName{name: name}
+// MakeMonitorName constructs a MonitorName with the given prefix.
+func MakeMonitorName(prefix redact.SafeString) MonitorName {
+	return MonitorName{prefix: prefix}
 }
 
-// MakeMonitorNameWithID constructs a MonitorName with the given name and
+// MakeMonitorNameWithID constructs a MonitorName with the given prefix and
 // ID.
-func MakeMonitorNameWithID(name redact.SafeString, id uuid.Short) MonitorName {
-	return MonitorName{name: name, id: id}
+func MakeMonitorNameWithID(prefix redact.SafeString, uuid uuid.Short) MonitorName {
+	return MonitorName{prefix: prefix, uuid: uuid}
 }
 
-// String returns the monitor name as a string.
+// String returns the monitor prefix as a string.
 func (mn MonitorName) String() string {
 	return redact.StringWithoutMarkers(mn)
 }
 
 // SafeFormat implements the redact.SafeFormatter interface.
 func (mn MonitorName) SafeFormat(w redact.SafePrinter, r rune) {
-	w.SafeString(mn.name)
+	w.SafeString(mn.prefix)
 	var nullShort uuid.Short
-	if mn.id != nullShort {
-		w.SafeString(redact.SafeString(mn.id.String()))
+	if mn.uuid != nullShort {
+		w.SafeString(redact.SafeString(mn.uuid.String()))
 	}
 }
 
@@ -621,7 +621,7 @@ func (mm *BytesMonitor) Stop(ctx context.Context) {
 	mm.doStop(ctx, true)
 }
 
-// Name returns the name of the monitor.
+// Name returns the prefix of the monitor.
 func (mm *BytesMonitor) Name() MonitorName {
 	return mm.name
 }

--- a/pkg/util/mon/bytes_usage.go
+++ b/pkg/util/mon/bytes_usage.go
@@ -247,7 +247,7 @@ type BytesMonitor struct {
 	}
 
 	// name identifies this monitor in logging messages.
-	name MonitorName
+	name Name
 
 	// reserved indicates how many bytes were already reserved for this
 	// monitor before it was instantiated. Allocations registered to
@@ -278,7 +278,8 @@ type BytesMonitor struct {
 	settings *cluster.Settings
 }
 
-// MonitorName is used to identify monitors in logging messages. It consists of:
+// Name is used to identify monitors in logging messages and populate the
+// crdb_internal.node_memory_monitors virtual table. It consists of:
 //
 //   - a string prefix
 //   - an optional int32 id or uuid.Short
@@ -286,98 +287,98 @@ type BytesMonitor struct {
 //   - an optional uint16
 //
 // When printed, the fields are separated by "-", if present.
-type MonitorName struct {
+type Name struct {
 	prefix redact.SafeString
 	// id contains either an int32 or a uuid.Short, depending on the value of
 	// the uuid boolean.
 	id     int32
 	uuid   bool
-	suffix monitorNameSuffix
+	suffix nameSuffix
 	i      uint16
 }
 
-// monitorNameSuffix is an enum the represents one of a finite list of possible
+// nameSuffix is an enum the represents one of a finite list of possible
 // monitor name suffixes.
-type monitorNameSuffix uint8
+type nameSuffix uint8
 
 const (
-	monitorNameSuffixNone monitorNameSuffix = iota
-	monitorNameSuffixLimited
-	monitorNameSuffixUnlimited
-	monitorNameSuffixDisk
+	nameSuffixNone nameSuffix = iota
+	nameSuffixLimited
+	nameSuffixUnlimited
+	nameSuffixDisk
 )
 
-func (mns monitorNameSuffix) safeString() redact.SafeString {
+func (mns nameSuffix) safeString() redact.SafeString {
 	switch mns {
-	case monitorNameSuffixLimited:
+	case nameSuffixLimited:
 		return "limited"
-	case monitorNameSuffixUnlimited:
+	case nameSuffixUnlimited:
 		return "unlimited"
-	case monitorNameSuffixDisk:
+	case nameSuffixDisk:
 		return "disk"
 	default:
 		return "unknown-suffix"
 	}
 }
 
-// MakeMonitorName constructs a MonitorName with the given prefix.
-func MakeMonitorName(prefix redact.SafeString) MonitorName {
-	return MonitorName{prefix: prefix}
+// MakeName constructs a Name with the given prefix.
+func MakeName(prefix redact.SafeString) Name {
+	return Name{prefix: prefix}
 }
 
-// WithID returns a new MonitorName with the given ID attached. A previously set
+// WithID returns a new Name with the given ID attached. A previously set
 // UUID is cleared.
-func (mn MonitorName) WithID(id int32) MonitorName {
+func (mn Name) WithID(id int32) Name {
 	mn.id = id
 	mn.uuid = false
 	return mn
 }
 
-// WithUUID returns a new MonitorName with the given uuid.Short attached.
+// WithUUID returns a new Name with the given uuid.Short attached.
 // A previously set ID is cleared.
-func (mn MonitorName) WithUUID(uuid uuid.Short) MonitorName {
+func (mn Name) WithUUID(uuid uuid.Short) Name {
 	mn.id = uuid.ToInt32()
 	mn.uuid = true
 	return mn
 }
 
 // Limited sets the suffix to "limited".
-func (mn MonitorName) Limited() MonitorName {
-	mn.suffix = monitorNameSuffixLimited
+func (mn Name) Limited() Name {
+	mn.suffix = nameSuffixLimited
 	return mn
 }
 
 // Unlimited sets the suffix to "unlimited".
-func (mn MonitorName) Unlimited() MonitorName {
-	mn.suffix = monitorNameSuffixUnlimited
+func (mn Name) Unlimited() Name {
+	mn.suffix = nameSuffixUnlimited
 	return mn
 }
 
 // Disk sets the suffix to "disk".
-func (mn MonitorName) Disk() MonitorName {
-	mn.suffix = monitorNameSuffixDisk
+func (mn Name) Disk() Name {
+	mn.suffix = nameSuffixDisk
 	return mn
 }
 
-// WithSuffix returns a new MonitorName with the given suffix attached.
-func (mn MonitorName) WithSuffix(suffix monitorNameSuffix) MonitorName {
+// WithSuffix returns a new Name with the given suffix attached.
+func (mn Name) WithSuffix(suffix nameSuffix) Name {
 	mn.suffix = suffix
 	return mn
 }
 
-// WithInt returns a new MonitorName with the given integer attached.
-func (mn MonitorName) WithInt(i uint16) MonitorName {
+// WithInt returns a new Name with the given integer attached.
+func (mn Name) WithInt(i uint16) Name {
 	mn.i = i
 	return mn
 }
 
 // String returns the monitor prefix as a string.
-func (mn MonitorName) String() string {
+func (mn Name) String() string {
 	return redact.StringWithoutMarkers(mn)
 }
 
 // SafeFormat implements the redact.SafeFormatter interface.
-func (mn MonitorName) SafeFormat(w redact.SafePrinter, r rune) {
+func (mn Name) SafeFormat(w redact.SafePrinter, r rune) {
 	w.SafeString(mn.prefix)
 	if mn.id != 0 {
 		w.SafeString("-")
@@ -389,7 +390,7 @@ func (mn MonitorName) SafeFormat(w redact.SafePrinter, r rune) {
 			w.SafeString(redact.SafeString(strconv.Itoa(int(mn.id))))
 		}
 	}
-	if mn.suffix != monitorNameSuffixNone {
+	if mn.suffix != nameSuffixNone {
 		w.SafeString("-")
 		w.SafeString(mn.suffix.safeString())
 	}
@@ -428,7 +429,7 @@ type MonitorState struct {
 	// root.
 	Level int
 	// Name is the name of the monitor.
-	Name MonitorName
+	Name Name
 	// ID is the "id" of the monitor (its address converted to int64).
 	ID int64
 	// ParentID is the "id" of the parent monitor (parent's address converted to
@@ -528,7 +529,7 @@ var DefaultPoolAllocationSize = envutil.EnvOrDefaultInt64("COCKROACH_ALLOCATION_
 type Options struct {
 	// Name is used to annotate log messages, can be used to distinguish
 	// monitors.
-	Name MonitorName
+	Name Name
 	// Res specifies what kind of resource the monitor is tracking allocations
 	// for (e.g. memory or disk). If unset, MemoryResource is assumed.
 	Res   Resource
@@ -576,7 +577,7 @@ func NewMonitor(args Options) *BytesMonitor {
 // those chunks would be reported as used by pool while downstream monitors will
 // not.
 func NewMonitorInheritWithLimit(
-	name MonitorName, limit int64, m *BytesMonitor, longLiving bool,
+	name Name, limit int64, m *BytesMonitor, longLiving bool,
 ) *BytesMonitor {
 	res := MemoryResource
 	if m.mu.tracksDisk {
@@ -600,7 +601,7 @@ func NewMonitorInheritWithLimit(
 func NewMonitorInheritWithLimitAndStringName(
 	name redact.SafeString, limit int64, m *BytesMonitor, longLiving bool,
 ) *BytesMonitor {
-	return NewMonitorInheritWithLimit(MakeMonitorName(name), limit, m, longLiving)
+	return NewMonitorInheritWithLimit(MakeName(name), limit, m, longLiving)
 }
 
 func (mm *BytesMonitor) MarkAsRootSQLMonitor() {
@@ -712,7 +713,7 @@ func (mm *BytesMonitor) Stop(ctx context.Context) {
 }
 
 // Name returns the prefix of the monitor.
-func (mm *BytesMonitor) Name() MonitorName {
+func (mm *BytesMonitor) Name() Name {
 	return mm.name
 }
 

--- a/pkg/util/mon/bytes_usage.go
+++ b/pkg/util/mon/bytes_usage.go
@@ -360,17 +360,8 @@ const (
 	expectedAccountSize = 24
 )
 
-func init() {
-	monitorSize := unsafe.Sizeof(BytesMonitor{})
-	if !util.RaceEnabled {
-		if monitorSize != expectedMonitorSize {
-			panic(errors.AssertionFailedf("expected monitor size to be %d, found %d", expectedMonitorSize, monitorSize))
-		}
-	}
-	if accountSize := unsafe.Sizeof(BoundAccount{}); accountSize != expectedAccountSize {
-		panic(errors.AssertionFailedf("expected account size to be %d, found %d", expectedAccountSize, accountSize))
-	}
-}
+var _ [0]struct{} = [expectedMonitorSize - unsafe.Sizeof(BytesMonitor{})]struct{}{}
+var _ [0]struct{} = [expectedAccountSize - unsafe.Sizeof(BoundAccount{})]struct{}{}
 
 // enableMonitorTreeTrackingEnvVar indicates whether tracking of all children of
 // a BytesMonitor (which is what powers TraverseTree) is enabled.

--- a/pkg/util/mon/bytes_usage_test.go
+++ b/pkg/util/mon/bytes_usage_test.go
@@ -374,7 +374,7 @@ func TestMultiSharedGauge(t *testing.T) {
 	})
 	parent.Start(ctx, nil, NewStandaloneBudget(100000))
 
-	child := NewMonitorInheritWithLimitAndStringName("child", 20000, parent, false /* longLiving */)
+	child := NewMonitorInheritWithLimit(MakeName("child"), 20000, parent, false /* longLiving */)
 	child.StartNoReserved(ctx, parent)
 
 	acc := child.MakeBoundAccount()

--- a/pkg/util/mon/bytes_usage_test.go
+++ b/pkg/util/mon/bytes_usage_test.go
@@ -144,7 +144,7 @@ func TestMemoryAllocations(t *testing.T) {
 	}
 
 	for _, max := range maxs {
-		pool = getMonitorEx(ctx, st, "test" /* name */, nil /* parent */, max /* reservedBytes */)
+		pool = getMonitorEx(ctx, st, "test" /* prefix */, nil /* parent */, max /* reservedBytes */)
 
 		for _, hf := range hysteresisFactors {
 			maxAllocatedButUnusedBlocks = hf
@@ -226,7 +226,7 @@ func TestBoundAccount(t *testing.T) {
 
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettings()
-	m := getMonitorEx(ctx, st, "test" /* name */, nil /* parent */, 100 /* reservedBytes */)
+	m := getMonitorEx(ctx, st, "test" /* prefix */, nil /* parent */, 100 /* reservedBytes */)
 	m.poolAllocationSize = 1
 	maxAllocatedButUnusedBlocks = 1
 
@@ -285,7 +285,7 @@ func TestBytesMonitor(t *testing.T) {
 
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettings()
-	m := getMonitorEx(ctx, st, "test" /* name */, nil /* parent */, 100 /* reservedBytes */)
+	m := getMonitorEx(ctx, st, "test" /* prefix */, nil /* parent */, 100 /* reservedBytes */)
 	maxAllocatedButUnusedBlocks = 1
 
 	if err := m.reserveBytes(ctx, 10); err != nil {
@@ -387,7 +387,7 @@ func TestReservedAccountCleared(t *testing.T) {
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettings()
 
-	root := getMonitor(ctx, st, "root" /* name */, nil /* parent */)
+	root := getMonitor(ctx, st, "root" /* prefix */, nil /* parent */)
 	root.RelinquishAllOnReleaseBytes()
 
 	// Pre-reserve a budget of 100 bytes.

--- a/pkg/util/mon/bytes_usage_test.go
+++ b/pkg/util/mon/bytes_usage_test.go
@@ -47,7 +47,7 @@ func TestMemoryAllocations(t *testing.T) {
 	var paramHeader func()
 
 	m := NewMonitor(Options{
-		Name:     MakeMonitorName("test"),
+		Name:     MakeName("test"),
 		Settings: st,
 	})
 	m.StartNoReserved(ctx, nil /* pool */)
@@ -158,7 +158,7 @@ func TestMemoryAllocations(t *testing.T) {
 					// We start with a fresh monitor for every set of
 					// parameters.
 					m = NewMonitor(Options{
-						Name:      MakeMonitorName("test"),
+						Name:      MakeName("test"),
 						Increment: pa,
 						Settings:  st,
 					})
@@ -318,7 +318,7 @@ func TestBytesMonitor(t *testing.T) {
 	}
 
 	limitedMonitor := NewMonitor(Options{
-		Name:      MakeMonitorName("testlimit"),
+		Name:      MakeName("testlimit"),
 		Limit:     10,
 		Increment: 1,
 		Settings:  cluster.MakeTestingClusterSettings(),
@@ -343,7 +343,7 @@ func TestMemoryAllocationEdgeCases(t *testing.T) {
 	ctx := context.Background()
 	st := cluster.MakeTestingClusterSettings()
 	m := NewMonitor(Options{
-		Name:      MakeMonitorName("test"),
+		Name:      MakeName("test"),
 		Increment: 1e9,
 		Settings:  st,
 	})
@@ -367,7 +367,7 @@ func TestMultiSharedGauge(t *testing.T) {
 	minAllocation := int64(1000)
 
 	parent := NewMonitor(Options{
-		Name:      MakeMonitorName("root"),
+		Name:      MakeName("root"),
 		CurCount:  resourceGauge,
 		Increment: minAllocation,
 		Settings:  cluster.MakeTestingClusterSettings(),
@@ -395,7 +395,7 @@ func TestReservedAccountCleared(t *testing.T) {
 	require.NoError(t, reserved.Grow(ctx, 100))
 
 	m := NewMonitor(Options{
-		Name:      MakeMonitorName("test"),
+		Name:      MakeName("test"),
 		Increment: 1,
 		Settings:  st,
 	})
@@ -432,7 +432,7 @@ func getMonitorEx(
 	reservedBytes int64,
 ) *BytesMonitor {
 	m := NewMonitor(Options{
-		Name:      MakeMonitorName(name),
+		Name:      MakeName(name),
 		Increment: 1,
 		Settings:  st,
 	})
@@ -614,7 +614,7 @@ func TestBytesMonitorNoDeadlocks(t *testing.T) {
 func BenchmarkBoundAccountGrow(b *testing.B) {
 	ctx := context.Background()
 	m := NewMonitor(Options{
-		Name:      MakeMonitorName("test"),
+		Name:      MakeName("test"),
 		Increment: 1e9,
 		Settings:  cluster.MakeTestingClusterSettings(),
 	})
@@ -676,7 +676,7 @@ func TestLimit(t *testing.T) {
 	st := cluster.MakeTestingClusterSettings()
 
 	m := NewMonitor(Options{
-		Name:     MakeMonitorName("test"),
+		Name:     MakeName("test"),
 		Settings: st,
 	})
 
@@ -689,7 +689,7 @@ func TestLimit(t *testing.T) {
 	m.Stop(ctx)
 
 	m2 := NewMonitor(Options{
-		Name:     MakeMonitorName("test"),
+		Name:     MakeName("test"),
 		Settings: st,
 	})
 

--- a/pkg/util/mon/bytes_usage_test.go
+++ b/pkg/util/mon/bytes_usage_test.go
@@ -374,7 +374,7 @@ func TestMultiSharedGauge(t *testing.T) {
 	})
 	parent.Start(ctx, nil, NewStandaloneBudget(100000))
 
-	child := NewMonitorInheritWithLimit("child", 20000, parent, false /* longLiving */)
+	child := NewMonitorInheritWithLimitAndStringName("child", 20000, parent, false /* longLiving */)
 	child.StartNoReserved(ctx, parent)
 
 	acc := child.MakeBoundAccount()

--- a/pkg/util/uuid/uuid_wrapper.go
+++ b/pkg/util/uuid/uuid_wrapper.go
@@ -39,6 +39,16 @@ func (s Short) String() string {
 	return string(b[:])
 }
 
+// ToInt32 returns an int32 representation of the abbreviated UUID.
+func (s Short) ToInt32() int32 {
+	return int32(binary.BigEndian.Uint32(s.b[:]))
+}
+
+// FromInt32 sets the abbreviated UUID from an int32.
+func (s *Short) FromInt32(i int32) {
+	binary.BigEndian.PutUint32(s.b[:], uint32(i))
+}
+
 // Short returns an abbreviated version of the UUID containing the first four
 // bytes.
 func (u UUID) Short() Short {

--- a/pkg/util/uuid/uuid_wrapper.go
+++ b/pkg/util/uuid/uuid_wrapper.go
@@ -21,6 +21,7 @@ const (
 	shortStrSize = 8
 )
 
+// Short is an abbreviated version of a UUID containing the first four bytes.
 type Short struct {
 	b [shortSize]byte
 }


### PR DESCRIPTION
#### util/mon: rename fields of MonitorName

Release note: None

#### util/uuid: add comment to uuid.Short

Release note: None

#### util/mon: add fields to MonitorName

The `processorID`, `suffix`, and `i` fields will be used in future
commits to reduce allocations related to MonitorNames.

Release note: None

#### util/mon: compile-time checks for size of BytesMonitor and BoundAccount

Release note: None

#### sql: use mon.MonitorName in more places

Using structured `mon.MonitorName` objects reduces allocations of
strings in some cases. This commit doesn't replace all usages of string
monitor names - there are myriad such usages. We can iteratively chip
away at them in future commits.

Release note: None

#### util/mon: reduce size of MonitorName

The size of `MonitorName` has been reduced by replacing the string
suffix with a suffix enum.

Release note: None

#### util/mon: further reduce the size of MonitorName

The size of `MonitorName` has been reduced by using the same 4 bytes to
store either the `int32` processor ID or the `uuid.Short`, and by
reducing the optional integer suffix from an `int32` to `uint16`, which
should be sufficient in all cases.

Release note: None

#### util/mon: rename MonitorName to Name

Release note: None

#### util/mon: remove deprecated NewMonitorWithStringName

All usages of the deprecated NewMonitorWithStringName function have been
replaced with NewMonitor, and the former has been removed.

Release note: None

#### util/mon: remove deprecated NewMonitorInheritWithLimitAndStringName

All usages of the deprecated NewMonitorInheritWithLimitAndStringName
function have been replaced with NewMonitorInheritWithLimit, and the
former has been removed.

Release note: None

#### colexec: batch allocations of BoundAccount

Allocations of `BoundAccount`s in `createUnlimitedMemAccountsLocked` are
now batched into a single allocation.

Release note: None

#### sql/rowflow: refactor monitor name

The monitor names created in `(*rowBasedFlow).setupRouter` now use
`(*mon.Name).WithID` to add the stream ID to the name instead of
allocating a new string.

Epic: None
Release note: None
