### PR TITLE
release-24.1: upgradeccl: Fix TenantAutoUpgradeTest flake

### DIFF
--- a/pkg/ccl/kvccl/kvtenantccl/upgradeccl/BUILD.bazel
+++ b/pkg/ccl/kvccl/kvtenantccl/upgradeccl/BUILD.bazel
@@ -30,7 +30,6 @@ go_test(
         "//pkg/testutils/sqlutils",
         "//pkg/upgrade",
         "//pkg/upgrade/upgradebase",
-        "//pkg/util",
         "//pkg/util/leaktest",
         "//pkg/util/log",
         "//pkg/util/randutil",

--- a/pkg/ccl/kvccl/kvtenantccl/upgradeccl/tenant_upgrade_test.go
+++ b/pkg/ccl/kvccl/kvtenantccl/upgradeccl/tenant_upgrade_test.go
@@ -27,7 +27,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/upgrade"
 	"github.com/cockroachdb/cockroach/pkg/upgrade/upgradebase"
-	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
@@ -219,7 +218,9 @@ func TestTenantAutoUpgrade(t *testing.T) {
 		UpgradeTo roachpb.Version
 	}
 	succeedsSoon := 20 * time.Second
-	if util.RaceEnabled || skip.Stress() {
+
+	// Test is slower under race, deadlock or stress, so increase timeout.
+	if skip.Duress() {
 		succeedsSoon = 60 * time.Second
 	}
 	// Wait for auto upgrade status to be received by the testing knob.


### PR DESCRIPTION
This PR increases the timeout for the test when the test is under duress (test is run with race, stress or deadlock enabled). Previously, the increased timeout only applied when run under race or stress. This case is extended to deadlock as the test likely runs slower under deadlock too resulting in an occassional timeout.

Fixes: https://github.com/cockroachdb/cockroach/issues/127564
Epic: none

Release note: None
Release justification: Test only change