### PR TITLE
slstorage: reduce allocations in `(*Storage).isAlive`

### DIFF
--- a/pkg/sql/sqlliveness/slstorage/slstorage.go
+++ b/pkg/sql/sqlliveness/slstorage/slstorage.go
@@ -213,11 +213,12 @@ func (s *Storage) isAlive(
 		if !s.mu.started {
 			return false, false, singleflight.Future{}, sqlliveness.NotStartedError
 		}
-		if _, ok := s.mu.deadSessions.Get(sid); ok {
+		sidKey := any(sid)
+		if _, ok := s.mu.deadSessions.Get(sidKey); ok {
 			s.metrics.IsAliveCacheHits.Inc(1)
 			return false, false, singleflight.Future{}, nil
 		}
-		if expiration, ok := s.mu.liveSessions.Get(sid); ok {
+		if expiration, ok := s.mu.liveSessions.Get(sidKey); ok {
 			expiration := expiration.(hlc.Timestamp)
 			// The record exists and is valid.
 			if s.clock.Now().Less(expiration) {


### PR DESCRIPTION
Using a session ID as a key in an `cache.UnorderedCache` requires the
key to be boxed as an `interface{}`, requiring an allocation. This
commit combines two of these allocations into one.

Epic: None
Release note: None
