### PR TITLE
opt: add rule to eliminate subquery wrapper around UDF calls

### DIFF
--- a/pkg/bench/rttanalysis/testdata/benchmark_expectations
+++ b/pkg/bench/rttanalysis/testdata/benchmark_expectations
@@ -127,7 +127,7 @@ exp,benchmark
 15,Truncate/truncate_2_column_2_rows
 0,UDFResolution/select_from_udf
 2,UseManyRoles/use_2_roles
-0,UseManyRoles/use_50_roles
+2,UseManyRoles/use_50_roles
 1,VirtualTableQueries/select_crdb_internal.invalid_objects_with_1_fk
 1,VirtualTableQueries/select_crdb_internal.tables_with_1_fk
 5,VirtualTableQueries/virtual_table_cache_with_point_lookups

--- a/pkg/sql/opt/memo/testdata/logprops/tail-calls
+++ b/pkg/sql/opt/memo/testdata/logprops/tail-calls
@@ -584,29 +584,21 @@ values
                                │    ├── gt
                                │    │    ├── function: random
                                │    │    └── const: 0.5
-                               │    └── subquery
+                               │    └── udf: nested
                                │         ├── tail-call
-                               │         └── values
-                               │              └── tuple
-                               │                   └── udf: nested
-                               │                        ├── tail-call
-                               │                        └── body
-                               │                             └── values
-                               │                                  └── tuple
-                               │                                       └── const: 1
-                               └── subquery
+                               │         └── body
+                               │              └── values
+                               │                   └── tuple
+                               │                        └── const: 1
+                               └── udf: nested_arg
                                     ├── tail-call
-                                    └── values
-                                         └── tuple
-                                              └── udf: nested_arg
-                                                   ├── tail-call
-                                                   ├── args
-                                                   │    └── variable: x
-                                                   ├── params: x
-                                                   └── body
-                                                        └── values
-                                                             └── tuple
-                                                                  └── variable: x
+                                    ├── args
+                                    │    └── variable: x
+                                    ├── params: x
+                                    └── body
+                                         └── values
+                                              └── tuple
+                                                   └── variable: x
 
 # Tail-call reachable from both branches of an IF statement.
 exec-ddl
@@ -747,16 +739,12 @@ values
                                                    │                        │    ├── eq
                                                    │                        │    │    ├── variable: i
                                                    │                        │    │    └── const: 5
-                                                   │                        │    └── subquery
+                                                   │                        │    └── udf: nested
                                                    │                        │         ├── tail-call
-                                                   │                        │         └── values
-                                                   │                        │              └── tuple
-                                                   │                        │                   └── udf: nested
-                                                   │                        │                        ├── tail-call
-                                                   │                        │                        └── body
-                                                   │                        │                             └── values
-                                                   │                        │                                  └── tuple
-                                                   │                        │                                       └── const: 1
+                                                   │                        │         └── body
+                                                   │                        │              └── values
+                                                   │                        │                   └── tuple
+                                                   │                        │                        └── const: 1
                                                    │                        └── subquery
                                                    │                             ├── tail-call
                                                    │                             └── values
@@ -770,44 +758,36 @@ values
                                                    │                                                 │              ├── variable: i
                                                    │                                                 │              └── const: 1
                                                    │                                                 └── projections
-                                                   │                                                      └── subquery
+                                                   │                                                      └── udf: stmt_loop_5
                                                    │                                                           ├── tail-call
-                                                   │                                                           └── values
-                                                   │                                                                └── tuple
-                                                   │                                                                     └── udf: stmt_loop_5
-                                                   │                                                                          ├── tail-call
-                                                   │                                                                          ├── args
-                                                   │                                                                          │    └── variable: i
-                                                   │                                                                          └── recursive-call
-                                                   └── subquery
+                                                   │                                                           ├── args
+                                                   │                                                           │    └── variable: i
+                                                   │                                                           └── recursive-call
+                                                   └── udf: loop_exit_1
                                                         ├── tail-call
-                                                        └── values
-                                                             └── tuple
-                                                                  └── udf: loop_exit_1
-                                                                       ├── tail-call
-                                                                       ├── args
-                                                                       │    └── variable: i
-                                                                       ├── params: i
-                                                                       └── body
-                                                                            └── values
-                                                                                 └── tuple
-                                                                                      └── udf: _end_of_function_2
-                                                                                           ├── tail-call
-                                                                                           ├── args
-                                                                                           │    └── variable: i
-                                                                                           ├── params: i
-                                                                                           └── body
-                                                                                                ├── values
-                                                                                                │    └── tuple
-                                                                                                │         └── function: crdb_internal.plpgsql_raise
-                                                                                                │              ├── const: 'ERROR'
-                                                                                                │              ├── const: 'control reached end of function without RETURN'
-                                                                                                │              ├── const: ''
-                                                                                                │              ├── const: ''
-                                                                                                │              └── const: '2F005'
-                                                                                                └── values
-                                                                                                     └── tuple
-                                                                                                          └── null
+                                                        ├── args
+                                                        │    └── variable: i
+                                                        ├── params: i
+                                                        └── body
+                                                             └── values
+                                                                  └── tuple
+                                                                       └── udf: _end_of_function_2
+                                                                            ├── tail-call
+                                                                            ├── args
+                                                                            │    └── variable: i
+                                                                            ├── params: i
+                                                                            └── body
+                                                                                 ├── values
+                                                                                 │    └── tuple
+                                                                                 │         └── function: crdb_internal.plpgsql_raise
+                                                                                 │              ├── const: 'ERROR'
+                                                                                 │              ├── const: 'control reached end of function without RETURN'
+                                                                                 │              ├── const: ''
+                                                                                 │              ├── const: ''
+                                                                                 │              └── const: '2F005'
+                                                                                 └── values
+                                                                                      └── tuple
+                                                                                           └── null
 
 # Tail-call within nested PL/pgSQL blocks.
 exec-ddl
@@ -855,47 +835,39 @@ values
                                                    │    ├── lt
                                                    │    │    ├── function: random
                                                    │    │    └── const: 0.5
-                                                   │    └── subquery
+                                                   │    └── udf: nested
                                                    │         ├── tail-call
-                                                   │         └── values
-                                                   │              └── tuple
-                                                   │                   └── udf: nested
-                                                   │                        ├── tail-call
-                                                   │                        └── body
-                                                   │                             └── values
-                                                   │                                  └── tuple
-                                                   │                                       └── const: 1
-                                                   └── subquery
+                                                   │         └── body
+                                                   │              └── values
+                                                   │                   └── tuple
+                                                   │                        └── const: 1
+                                                   └── udf: stmt_if_7
                                                         ├── tail-call
-                                                        └── values
-                                                             └── tuple
-                                                                  └── udf: stmt_if_7
-                                                                       ├── tail-call
-                                                                       └── body
-                                                                            └── values
-                                                                                 └── tuple
-                                                                                      └── udf: _stmt_raise_9
-                                                                                           ├── tail-call
-                                                                                           └── body
-                                                                                                ├── values
-                                                                                                │    └── tuple
-                                                                                                │         └── function: crdb_internal.plpgsql_raise
-                                                                                                │              ├── const: 'NOTICE'
-                                                                                                │              ├── const: 'bar'
-                                                                                                │              ├── const: ''
-                                                                                                │              ├── const: ''
-                                                                                                │              └── const: '00000'
-                                                                                                └── values
-                                                                                                     └── tuple
-                                                                                                          └── udf: nested_arg
-                                                                                                               ├── tail-call
-                                                                                                               ├── args
-                                                                                                               │    └── const: 100
-                                                                                                               ├── params: x
-                                                                                                               └── body
-                                                                                                                    └── values
-                                                                                                                         └── tuple
-                                                                                                                              └── variable: x
+                                                        └── body
+                                                             └── values
+                                                                  └── tuple
+                                                                       └── udf: _stmt_raise_9
+                                                                            ├── tail-call
+                                                                            └── body
+                                                                                 ├── values
+                                                                                 │    └── tuple
+                                                                                 │         └── function: crdb_internal.plpgsql_raise
+                                                                                 │              ├── const: 'NOTICE'
+                                                                                 │              ├── const: 'bar'
+                                                                                 │              ├── const: ''
+                                                                                 │              ├── const: ''
+                                                                                 │              └── const: '00000'
+                                                                                 └── values
+                                                                                      └── tuple
+                                                                                           └── udf: nested_arg
+                                                                                                ├── tail-call
+                                                                                                ├── args
+                                                                                                │    └── const: 100
+                                                                                                ├── params: x
+                                                                                                └── body
+                                                                                                     └── values
+                                                                                                          └── tuple
+                                                                                                               └── variable: x
 
 # Tail-call within an exception handler.
 exec-ddl

--- a/pkg/sql/opt/norm/rules/scalar.opt
+++ b/pkg/sql/opt/norm/rules/scalar.opt
@@ -273,13 +273,20 @@ $input
 =>
 (Exists $input $existsPrivate)
 
-# EliminateConstValuesSubquery replaces a subquery with a constant value if the
+# EliminateConstValueSubquery replaces a subquery with a constant value if the
 # subquery's input is a single-row, single-column Values expression with a
 # constant value.
 [EliminateConstValueSubquery, Normalize]
 (Subquery (Values [ (Tuple [ $value:(Const) ]) ]))
 =>
 $value
+
+# EliminateUDFCallSubquery replaces a subquery with a udf call if the subquery's
+# input is a single-row, single-column Values expression with a udf call.
+[EliminateUDFCallSubquery, Normalize]
+(Subquery (Values [ (Tuple [ $udf:(UDFCall) ]) ]))
+=>
+$udf
 
 # SimplifyCaseWhenConstValue removes branches known to not match. Any
 # branch known to match is used as the ELSE and further WHEN conditions

--- a/pkg/sql/opt/norm/testdata/rules/routine
+++ b/pkg/sql/opt/norm/testdata/rules/routine
@@ -40,93 +40,74 @@ call
                           │    │    ├── function: pg_sleep
                           │    │    │    └── const: 0.1
                           │    │    └── null
-                          │    └── subquery
+                          │    └── udf: _stmt_raise_2
                           │         ├── tail-call
-                          │         └── values
-                          │              ├── columns: "_stmt_raise_2":7
-                          │              ├── outer: (1)
-                          │              ├── cardinality: [1 - 1]
-                          │              ├── volatile
-                          │              ├── key: ()
-                          │              ├── fd: ()-->(7)
-                          │              └── tuple
-                          │                   └── udf: _stmt_raise_2
-                          │                        ├── tail-call
-                          │                        ├── args
-                          │                        │    └── variable: x:1
-                          │                        ├── params: x:4
-                          │                        └── body
-                          │                             ├── values
-                          │                             │    ├── columns: stmt_raise_3:5
-                          │                             │    ├── outer: (4)
-                          │                             │    ├── cardinality: [1 - 1]
-                          │                             │    ├── volatile
-                          │                             │    ├── key: ()
-                          │                             │    ├── fd: ()-->(5)
-                          │                             │    └── tuple
-                          │                             │         └── function: crdb_internal.plpgsql_raise
-                          │                             │              ├── const: 'NOTICE'
-                          │                             │              ├── concat
-                          │                             │              │    ├── concat
-                          │                             │              │    │    ├── const: 'foo '
-                          │                             │              │    │    └── coalesce
-                          │                             │              │    │         ├── cast: STRING
-                          │                             │              │    │         │    └── variable: x:4
-                          │                             │              │    │         └── const: '<NULL>'
-                          │                             │              │    └── const: ''
-                          │                             │              ├── const: ''
-                          │                             │              ├── const: ''
-                          │                             │              └── const: '00000'
+                          │         ├── args
+                          │         │    └── variable: x:1
+                          │         ├── params: x:4
+                          │         └── body
+                          │              ├── values
+                          │              │    ├── columns: stmt_raise_3:5
+                          │              │    ├── outer: (4)
+                          │              │    ├── cardinality: [1 - 1]
+                          │              │    ├── volatile
+                          │              │    ├── key: ()
+                          │              │    ├── fd: ()-->(5)
+                          │              │    └── tuple
+                          │              │         └── function: crdb_internal.plpgsql_raise
+                          │              │              ├── const: 'NOTICE'
+                          │              │              ├── concat
+                          │              │              │    ├── concat
+                          │              │              │    │    ├── const: 'foo '
+                          │              │              │    │    └── coalesce
+                          │              │              │    │         ├── cast: STRING
+                          │              │              │    │         │    └── variable: x:4
+                          │              │              │    │         └── const: '<NULL>'
+                          │              │              │    └── const: ''
+                          │              │              ├── const: ''
+                          │              │              ├── const: ''
+                          │              │              └── const: '00000'
+                          │              └── values
+                          │                   ├── columns: stmt_if_1:6
+                          │                   ├── cardinality: [1 - 1]
+                          │                   ├── key: ()
+                          │                   ├── fd: ()-->(6)
+                          │                   └── tuple
+                          │                        └── subquery
+                          │                             ├── tail-call
                           │                             └── values
-                          │                                  ├── columns: stmt_if_1:6
+                          │                                  ├── columns: "_implicit_return":3
                           │                                  ├── cardinality: [1 - 1]
                           │                                  ├── key: ()
-                          │                                  ├── fd: ()-->(6)
+                          │                                  ├── fd: ()-->(3)
                           │                                  └── tuple
-                          │                                       └── subquery
-                          │                                            ├── tail-call
-                          │                                            └── values
-                          │                                                 ├── columns: "_implicit_return":3
-                          │                                                 ├── cardinality: [1 - 1]
-                          │                                                 ├── key: ()
-                          │                                                 ├── fd: ()-->(3)
-                          │                                                 └── tuple
-                          │                                                      └── null
-                          └── subquery
+                          │                                       └── null
+                          └── udf: _stmt_exec_4
                                ├── tail-call
-                               └── values
-                                    ├── columns: "_stmt_exec_4":11
-                                    ├── outer: (1)
-                                    ├── cardinality: [1 - 1]
-                                    ├── key: ()
-                                    ├── fd: ()-->(11)
-                                    └── tuple
-                                         └── udf: _stmt_exec_4
-                                              ├── tail-call
-                                              ├── args
-                                              │    └── variable: x:1
-                                              ├── params: x:8
-                                              └── body
-                                                   ├── values
-                                                   │    ├── columns: x:9
-                                                   │    ├── outer: (8)
-                                                   │    ├── cardinality: [1 - 1]
-                                                   │    ├── key: ()
-                                                   │    ├── fd: ()-->(9)
-                                                   │    └── tuple
-                                                   │         └── variable: x:8
+                               ├── args
+                               │    └── variable: x:1
+                               ├── params: x:8
+                               └── body
+                                    ├── values
+                                    │    ├── columns: x:9
+                                    │    ├── outer: (8)
+                                    │    ├── cardinality: [1 - 1]
+                                    │    ├── key: ()
+                                    │    ├── fd: ()-->(9)
+                                    │    └── tuple
+                                    │         └── variable: x:8
+                                    └── values
+                                         ├── columns: stmt_if_1:10
+                                         ├── cardinality: [1 - 1]
+                                         ├── key: ()
+                                         ├── fd: ()-->(10)
+                                         └── tuple
+                                              └── subquery
+                                                   ├── tail-call
                                                    └── values
-                                                        ├── columns: stmt_if_1:10
+                                                        ├── columns: "_implicit_return":3
                                                         ├── cardinality: [1 - 1]
                                                         ├── key: ()
-                                                        ├── fd: ()-->(10)
+                                                        ├── fd: ()-->(3)
                                                         └── tuple
-                                                             └── subquery
-                                                                  ├── tail-call
-                                                                  └── values
-                                                                       ├── columns: "_implicit_return":3
-                                                                       ├── cardinality: [1 - 1]
-                                                                       ├── key: ()
-                                                                       ├── fd: ()-->(3)
-                                                                       └── tuple
-                                                                            └── null
+                                                             └── null

--- a/pkg/sql/opt/norm/testdata/rules/scalar
+++ b/pkg/sql/opt/norm/testdata/rules/scalar
@@ -1025,6 +1025,250 @@ values
                 ├── fd: ()-->(1)
                 └── (gen_random_uuid(),)
 
+
+# --------------------------------------------------
+# EliminateUDFCallSubquery
+# --------------------------------------------------
+
+exec-ddl
+CREATE FUNCTION f1(i INT) RETURNS INT AS $$
+  SELECT i
+$$ LANGUAGE SQL
+----
+
+opt expect=EliminateUDFCallSubquery format=show-scalars
+SELECT (VALUES (f1(0)))
+----
+values
+ ├── columns: column1:4
+ ├── cardinality: [1 - 1]
+ ├── volatile
+ ├── key: ()
+ ├── fd: ()-->(4)
+ └── tuple
+      └── udf: f1
+           ├── args
+           │    └── const: 0
+           ├── params: i:1
+           └── body
+                └── values
+                     ├── columns: i:2
+                     ├── outer: (1)
+                     ├── cardinality: [1 - 1]
+                     ├── key: ()
+                     ├── fd: ()-->(2)
+                     └── tuple
+                          └── variable: i:1
+
+
+opt expect=EliminateUDFCallSubquery format=show-scalars
+SELECT (SELECT f1(0))
+----
+values
+ ├── columns: f1:4
+ ├── cardinality: [1 - 1]
+ ├── volatile
+ ├── key: ()
+ ├── fd: ()-->(4)
+ └── tuple
+      └── udf: f1
+           ├── args
+           │    └── const: 0
+           ├── params: i:1
+           └── body
+                └── values
+                     ├── columns: i:2
+                     ├── outer: (1)
+                     ├── cardinality: [1 - 1]
+                     ├── key: ()
+                     ├── fd: ()-->(2)
+                     └── tuple
+                          └── variable: i:1
+
+opt expect=EliminateUDFCallSubquery format=show-scalars
+SELECT (SELECT v FROM (VALUES (f1(0))) AS v(v))
+----
+values
+ ├── columns: v:4
+ ├── cardinality: [1 - 1]
+ ├── volatile
+ ├── key: ()
+ ├── fd: ()-->(4)
+ └── tuple
+      └── udf: f1
+           ├── args
+           │    └── const: 0
+           ├── params: i:1
+           └── body
+                └── values
+                     ├── columns: i:2
+                     ├── outer: (1)
+                     ├── cardinality: [1 - 1]
+                     ├── key: ()
+                     ├── fd: ()-->(2)
+                     └── tuple
+                          └── variable: i:1
+
+
+# Cannot eliminate multi-row values subquery.
+opt expect-not=EliminateUDFCallSubquery format=show-scalars
+SELECT (VALUES (f1(0)), (f1(1)))
+----
+values
+ ├── columns: column1:6
+ ├── cardinality: [1 - 1]
+ ├── volatile
+ ├── key: ()
+ ├── fd: ()-->(6)
+ └── tuple
+      └── subquery
+           └── max1-row
+                ├── columns: column1:5
+                ├── error: "more than one row returned by a subquery used as an expression"
+                ├── cardinality: [1 - 1]
+                ├── volatile
+                ├── key: ()
+                ├── fd: ()-->(5)
+                └── values
+                     ├── columns: column1:5
+                     ├── cardinality: [2 - 2]
+                     ├── volatile
+                     ├── tuple
+                     │    └── udf: f1
+                     │         ├── args
+                     │         │    └── const: 0
+                     │         ├── params: i:1
+                     │         └── body
+                     │              └── values
+                     │                   ├── columns: i:2
+                     │                   ├── outer: (1)
+                     │                   ├── cardinality: [1 - 1]
+                     │                   ├── key: ()
+                     │                   ├── fd: ()-->(2)
+                     │                   └── tuple
+                     │                        └── variable: i:1
+                     └── tuple
+                          └── udf: f1
+                               ├── args
+                               │    └── const: 1
+                               ├── params: i:3
+                               └── body
+                                    └── values
+                                         ├── columns: i:4
+                                         ├── outer: (3)
+                                         ├── cardinality: [1 - 1]
+                                         ├── key: ()
+                                         ├── fd: ()-->(4)
+                                         └── tuple
+                                              └── variable: i:3
+
+# Cannot eliminate multi-column values subquery.
+opt expect-not=EliminateUDFCallSubquery format=show-scalars
+SELECT (f1(0), f1(1)) = (SELECT f1(0), f1(1))
+----
+values
+ ├── columns: "?column?":12
+ ├── cardinality: [1 - 1]
+ ├── volatile
+ ├── key: ()
+ ├── fd: ()-->(12)
+ └── tuple
+      └── eq
+           ├── tuple
+           │    ├── udf: f1
+           │    │    ├── args
+           │    │    │    └── const: 0
+           │    │    ├── params: i:7
+           │    │    └── body
+           │    │         └── values
+           │    │              ├── columns: i:8
+           │    │              ├── outer: (7)
+           │    │              ├── cardinality: [1 - 1]
+           │    │              ├── key: ()
+           │    │              ├── fd: ()-->(8)
+           │    │              └── tuple
+           │    │                   └── variable: i:7
+           │    └── udf: f1
+           │         ├── args
+           │         │    └── const: 1
+           │         ├── params: i:9
+           │         └── body
+           │              └── values
+           │                   ├── columns: i:10
+           │                   ├── outer: (9)
+           │                   ├── cardinality: [1 - 1]
+           │                   ├── key: ()
+           │                   ├── fd: ()-->(10)
+           │                   └── tuple
+           │                        └── variable: i:9
+           └── subquery
+                └── project
+                     ├── columns: column11:11
+                     ├── cardinality: [1 - 1]
+                     ├── volatile
+                     ├── key: ()
+                     ├── fd: ()-->(11)
+                     ├── values
+                     │    ├── columns: f1:3 f1:6
+                     │    ├── cardinality: [1 - 1]
+                     │    ├── volatile
+                     │    ├── key: ()
+                     │    ├── fd: ()-->(3,6)
+                     │    └── tuple
+                     │         ├── udf: f1
+                     │         │    ├── args
+                     │         │    │    └── const: 0
+                     │         │    ├── params: i:1
+                     │         │    └── body
+                     │         │         └── values
+                     │         │              ├── columns: i:2
+                     │         │              ├── outer: (1)
+                     │         │              ├── cardinality: [1 - 1]
+                     │         │              ├── key: ()
+                     │         │              ├── fd: ()-->(2)
+                     │         │              └── tuple
+                     │         │                   └── variable: i:1
+                     │         └── udf: f1
+                     │              ├── args
+                     │              │    └── const: 1
+                     │              ├── params: i:4
+                     │              └── body
+                     │                   └── values
+                     │                        ├── columns: i:5
+                     │                        ├── outer: (4)
+                     │                        ├── cardinality: [1 - 1]
+                     │                        ├── key: ()
+                     │                        ├── fd: ()-->(5)
+                     │                        └── tuple
+                     │                             └── variable: i:4
+                     └── projections
+                          └── tuple [as=column11:11, outer=(3,6)]
+                               ├── variable: f1:3
+                               └── variable: f1:6
+
+
+# Cannot eliminate non-udf call subquery.
+opt expect-not=EliminateUDFCallSubquery format=show-scalars
+SELECT (SELECT gen_random_uuid())
+----
+values
+ ├── columns: gen_random_uuid:2
+ ├── cardinality: [1 - 1]
+ ├── volatile
+ ├── key: ()
+ ├── fd: ()-->(2)
+ └── tuple
+      └── subquery
+           └── values
+                ├── columns: gen_random_uuid:1
+                ├── cardinality: [1 - 1]
+                ├── volatile
+                ├── key: ()
+                ├── fd: ()-->(1)
+                └── tuple
+                     └── function: gen_random_uuid
+
+
 # --------------------------------------------------
 # SimplifyCaseWhenConstValue
 # --------------------------------------------------

--- a/pkg/sql/opt/optbuilder/testdata/udf_plpgsql
+++ b/pkg/sql/opt/optbuilder/testdata/udf_plpgsql
@@ -7013,106 +7013,91 @@ values
                                                    │    ├── le
                                                    │    │    ├── variable: "_loop_counter":14
                                                    │    │    └── variable: "_loop_upper":12
-                                                   │    └── subquery
+                                                   │    └── udf: _stmt_raise_9
                                                    │         ├── tail-call
-                                                   │         └── values
-                                                   │              ├── columns: "_stmt_raise_9":33
-                                                   │              └── tuple
-                                                   │                   └── udf: _stmt_raise_9
-                                                   │                        ├── tail-call
-                                                   │                        ├── args
-                                                   │                        │    ├── variable: i:10
-                                                   │                        │    ├── variable: "_loop_lower":11
-                                                   │                        │    ├── variable: "_loop_upper":12
-                                                   │                        │    ├── variable: "_loop_step":13
-                                                   │                        │    └── variable: "_loop_counter":14
-                                                   │                        ├── params: i:26 "_loop_lower":27 "_loop_upper":28 "_loop_step":29 "_loop_counter":30
-                                                   │                        └── body
-                                                   │                             ├── values
-                                                   │                             │    ├── columns: stmt_raise_10:31
-                                                   │                             │    └── tuple
-                                                   │                             │         └── function: crdb_internal.plpgsql_raise
-                                                   │                             │              ├── const: 'NOTICE'
-                                                   │                             │              ├── concat
-                                                   │                             │              │    ├── concat
-                                                   │                             │              │    │    ├── const: 'i: '
-                                                   │                             │              │    │    └── coalesce
-                                                   │                             │              │    │         ├── cast: STRING
-                                                   │                             │              │    │         │    └── variable: i:26
-                                                   │                             │              │    │         └── const: '<NULL>'
-                                                   │                             │              │    └── const: ''
-                                                   │                             │              ├── const: ''
-                                                   │                             │              ├── const: ''
-                                                   │                             │              └── const: '00000'
-                                                   │                             └── values
-                                                   │                                  ├── columns: stmt_if_8:32
-                                                   │                                  └── tuple
-                                                   │                                       └── subquery
-                                                   │                                            ├── tail-call
-                                                   │                                            └── values
-                                                   │                                                 ├── columns: stmt_loop_inc_7:25
-                                                   │                                                 └── tuple
-                                                   │                                                      └── udf: stmt_loop_inc_7
-                                                   │                                                           ├── tail-call
-                                                   │                                                           ├── args
-                                                   │                                                           │    ├── variable: i:26
-                                                   │                                                           │    ├── variable: "_loop_lower":27
-                                                   │                                                           │    ├── variable: "_loop_upper":28
-                                                   │                                                           │    ├── variable: "_loop_step":29
-                                                   │                                                           │    └── variable: "_loop_counter":30
-                                                   │                                                           ├── params: i:15 "_loop_lower":16 "_loop_upper":17 "_loop_step":18 "_loop_counter":19
-                                                   │                                                           └── body
-                                                   │                                                                └── project
-                                                   │                                                                     ├── columns: stmt_loop_6:38
-                                                   │                                                                     ├── barrier
-                                                   │                                                                     │    ├── columns: "_loop_counter":36 i:37
-                                                   │                                                                     │    └── project
-                                                   │                                                                     │         ├── columns: i:37 "_loop_counter":36
-                                                   │                                                                     │         ├── values
-                                                   │                                                                     │         │    ├── columns: "_loop_counter":36
-                                                   │                                                                     │         │    └── tuple
-                                                   │                                                                     │         │         └── plus
-                                                   │                                                                     │         │              ├── variable: "_loop_counter":19
-                                                   │                                                                     │         │              └── variable: "_loop_step":18
-                                                   │                                                                     │         └── projections
-                                                   │                                                                     │              └── variable: "_loop_counter":36 [as=i:37]
-                                                   │                                                                     └── projections
-                                                   │                                                                          └── udf: stmt_loop_6 [as=stmt_loop_6:38]
-                                                   │                                                                               ├── tail-call
-                                                   │                                                                               ├── args
-                                                   │                                                                               │    ├── variable: i:37
-                                                   │                                                                               │    ├── variable: "_loop_lower":16
-                                                   │                                                                               │    ├── variable: "_loop_upper":17
-                                                   │                                                                               │    ├── variable: "_loop_step":18
-                                                   │                                                                               │    └── variable: "_loop_counter":36
-                                                   │                                                                               └── recursive-call
-                                                   └── subquery
+                                                   │         ├── args
+                                                   │         │    ├── variable: i:10
+                                                   │         │    ├── variable: "_loop_lower":11
+                                                   │         │    ├── variable: "_loop_upper":12
+                                                   │         │    ├── variable: "_loop_step":13
+                                                   │         │    └── variable: "_loop_counter":14
+                                                   │         ├── params: i:26 "_loop_lower":27 "_loop_upper":28 "_loop_step":29 "_loop_counter":30
+                                                   │         └── body
+                                                   │              ├── values
+                                                   │              │    ├── columns: stmt_raise_10:31
+                                                   │              │    └── tuple
+                                                   │              │         └── function: crdb_internal.plpgsql_raise
+                                                   │              │              ├── const: 'NOTICE'
+                                                   │              │              ├── concat
+                                                   │              │              │    ├── concat
+                                                   │              │              │    │    ├── const: 'i: '
+                                                   │              │              │    │    └── coalesce
+                                                   │              │              │    │         ├── cast: STRING
+                                                   │              │              │    │         │    └── variable: i:26
+                                                   │              │              │    │         └── const: '<NULL>'
+                                                   │              │              │    └── const: ''
+                                                   │              │              ├── const: ''
+                                                   │              │              ├── const: ''
+                                                   │              │              └── const: '00000'
+                                                   │              └── values
+                                                   │                   ├── columns: stmt_if_8:32
+                                                   │                   └── tuple
+                                                   │                        └── udf: stmt_loop_inc_7
+                                                   │                             ├── tail-call
+                                                   │                             ├── args
+                                                   │                             │    ├── variable: i:26
+                                                   │                             │    ├── variable: "_loop_lower":27
+                                                   │                             │    ├── variable: "_loop_upper":28
+                                                   │                             │    ├── variable: "_loop_step":29
+                                                   │                             │    └── variable: "_loop_counter":30
+                                                   │                             ├── params: i:15 "_loop_lower":16 "_loop_upper":17 "_loop_step":18 "_loop_counter":19
+                                                   │                             └── body
+                                                   │                                  └── project
+                                                   │                                       ├── columns: stmt_loop_6:38
+                                                   │                                       ├── barrier
+                                                   │                                       │    ├── columns: "_loop_counter":36 i:37
+                                                   │                                       │    └── project
+                                                   │                                       │         ├── columns: i:37 "_loop_counter":36
+                                                   │                                       │         ├── values
+                                                   │                                       │         │    ├── columns: "_loop_counter":36
+                                                   │                                       │         │    └── tuple
+                                                   │                                       │         │         └── plus
+                                                   │                                       │         │              ├── variable: "_loop_counter":19
+                                                   │                                       │         │              └── variable: "_loop_step":18
+                                                   │                                       │         └── projections
+                                                   │                                       │              └── variable: "_loop_counter":36 [as=i:37]
+                                                   │                                       └── projections
+                                                   │                                            └── udf: stmt_loop_6 [as=stmt_loop_6:38]
+                                                   │                                                 ├── tail-call
+                                                   │                                                 ├── args
+                                                   │                                                 │    ├── variable: i:37
+                                                   │                                                 │    ├── variable: "_loop_lower":16
+                                                   │                                                 │    ├── variable: "_loop_upper":17
+                                                   │                                                 │    ├── variable: "_loop_step":18
+                                                   │                                                 │    └── variable: "_loop_counter":36
+                                                   │                                                 └── recursive-call
+                                                   └── udf: loop_exit_1
                                                         ├── tail-call
-                                                        └── values
-                                                             ├── columns: loop_exit_1:34
-                                                             └── tuple
-                                                                  └── udf: loop_exit_1
-                                                                       ├── tail-call
-                                                                       └── body
-                                                                            └── values
-                                                                                 ├── columns: "_stmt_raise_2":3
-                                                                                 └── tuple
-                                                                                      └── udf: _stmt_raise_2
-                                                                                           ├── tail-call
-                                                                                           └── body
-                                                                                                ├── values
-                                                                                                │    ├── columns: stmt_raise_3:1
-                                                                                                │    └── tuple
-                                                                                                │         └── function: crdb_internal.plpgsql_raise
-                                                                                                │              ├── const: 'NOTICE'
-                                                                                                │              ├── const: 'DONE'
-                                                                                                │              ├── const: ''
-                                                                                                │              ├── const: ''
-                                                                                                │              └── const: '00000'
-                                                                                                └── values
-                                                                                                     ├── columns: stmt_return_4:2!null
-                                                                                                     └── tuple
-                                                                                                          └── const: 0
+                                                        └── body
+                                                             └── values
+                                                                  ├── columns: "_stmt_raise_2":3
+                                                                  └── tuple
+                                                                       └── udf: _stmt_raise_2
+                                                                            ├── tail-call
+                                                                            └── body
+                                                                                 ├── values
+                                                                                 │    ├── columns: stmt_raise_3:1
+                                                                                 │    └── tuple
+                                                                                 │         └── function: crdb_internal.plpgsql_raise
+                                                                                 │              ├── const: 'NOTICE'
+                                                                                 │              ├── const: 'DONE'
+                                                                                 │              ├── const: ''
+                                                                                 │              ├── const: ''
+                                                                                 │              └── const: '00000'
+                                                                                 └── values
+                                                                                      ├── columns: stmt_return_4:2!null
+                                                                                      └── tuple
+                                                                                           └── const: 0
 
 # DO statements execute a PL/pgSQL code block inline. This is effectively an
 # anonymous function with no arguments.


### PR DESCRIPTION
This commit adds a new normalization rule `EliminateUDFCallSubquery` that removes unnecessary subquery wrappers around UDF calls when they appear in single row and single column Values expressions.

Informs: #143299
Epic: None
Release note: None