### PR TITLE
sql/schemachanger: support ALTER POLICY DDL

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/row_level_security
+++ b/pkg/sql/logictest/testdata/logic_test/row_level_security
@@ -1280,6 +1280,124 @@ DROP FUNCTION my_non_sec_definer_reader_function;
 statement ok
 DROP TABLE sensitive_data_table CASCADE;
 
+subtest alter_policy
+
+statement ok
+CREATE TABLE alter_policy_table (c1 INT NOT NULL PRIMARY KEY, c2 TEXT, FAMILY (c1, c2));
+
+statement ok
+ALTER TABLE alter_policy_table ENABLE ROW LEVEL SECURITY, FORCE ROW LEVEL SECURITY;
+
+statement ok
+CREATE ROLE alter_policy_role;
+
+statement ok
+CREATE ROLE aux1;
+
+statement ok
+CREATE USER aux2;
+
+statement ok
+CREATE SEQUENCE seq1;
+
+statement ok
+GRANT ALL ON seq1 TO alter_policy_role;
+
+statement ok
+ALTER TABLE alter_policy_table OWNER TO alter_policy_role;
+
+statement ok
+SET ROLE alter_policy_role;
+
+statement ok
+CREATE POLICY p ON alter_policy_table FOR INSERT WITH CHECK (false);
+
+statement error pq: new row violates row-level security policy for table "alter_policy_table"
+INSERT INTO alter_policy_table VALUES (1, 'one'), (2, 'two'), (3, 'three');
+
+statement error pq: only WITH CHECK expression allowed for INSERT
+ALTER POLICY p ON alter_policy_table USING (true);
+
+statement ok
+ALTER POLICY p ON alter_policy_table WITH CHECK (nextval('seq1') < 10000);
+
+statement ok
+INSERT INTO alter_policy_table VALUES (1, 'one'), (2, 'two'), (3, 'three');
+
+query I
+SELECT c1 FROM alter_policy_table ORDER BY c1;
+----
+
+statement ok
+ALTER POLICY p ON alter_policy_table RENAME TO p_ins;
+
+statement ok
+CREATE POLICY p ON alter_policy_table FOR SELECT TO aux1 USING (c1 > 0);
+
+query I
+SELECT c1 FROM alter_policy_table ORDER BY c1;
+----
+
+statement error pq: policy "p_sel" for table "alter_policy_table" does not exist
+ALTER POLICY p_sel ON alter_policy_table WITH CHECK (true);
+
+statement error pq: WITH CHECK cannot be applied to SELECT or DELETE
+ALTER POLICY p ON alter_policy_table WITH CHECK (true);
+
+statement ok
+ALTER POLICY p ON alter_policy_table TO alter_policy_role,aux1,aux2 USING (c1 != 1);
+
+query I
+SELECT c1 FROM alter_policy_table ORDER BY c1;
+----
+2
+3
+
+statement ok
+ALTER POLICY p ON alter_policy_table RENAME TO p_sel;
+
+query TT
+SHOW CREATE TABLE alter_policy_table;
+----
+alter_policy_table  CREATE TABLE public.alter_policy_table (
+                      c1 INT8 NOT NULL,
+                      c2 STRING NULL,
+                      CONSTRAINT alter_policy_table_pkey PRIMARY KEY (c1 ASC),
+                      FAMILY fam_0_c1_c2 (c1, c2)
+                    );
+                    ALTER TABLE public.alter_policy_table ENABLE ROW LEVEL SECURITY, FORCE ROW LEVEL SECURITY;
+                    CREATE POLICY p_ins ON public.alter_policy_table AS PERMISSIVE FOR INSERT TO public WITH CHECK (nextval('public.seq1'::REGCLASS) < 10000:::INT8);
+                    CREATE POLICY p_sel ON public.alter_policy_table AS PERMISSIVE FOR SELECT TO aux1, alter_policy_role, aux2 USING (c1 != 1:::INT8)
+
+# TODO(143358): Include roles in the SHOW POLICIES output.
+query TTTTT colnames
+SELECT name,cmd,type,using_expr,with_check_expr
+FROM [SHOW POLICIES FOR alter_policy_table]
+ORDER BY name DESC;
+----
+name   cmd     type        using_expr      with_check_expr
+p_sel  SELECT  permissive  c1 != 1:::INT8  ·
+p_ins  INSERT  permissive  ·               nextval('public.seq1'::REGCLASS) < 10000:::INT8
+
+statement ok
+SET ROLE root;
+
+statement error pq: cannot drop sequence seq1 because other objects depend on it
+DROP SEQUENCE seq1;
+
+# Change the policy so there isn't a dependency on seq1 anymore.
+statement ok
+ALTER POLICY p_ins ON alter_policy_table WITH CHECK (true);
+
+statement ok
+DROP SEQUENCE seq1;
+
+statement ok
+DROP TABLE alter_policy_table;
+
+statement ok
+DROP ROLE alter_policy_role, aux1, aux2;
+
 # Verify that you need to be the table owner to do any of the RLS DDLs
 subtest table_owner_and_rls_ddl
 
@@ -1313,14 +1431,14 @@ DROP POLICY p1 on table_owner_test;
 statement ok
 CREATE POLICY new_p1 on table_owner_test;
 
-statement error pq: unimplemented: ALTER POLICY is not yet implemented
+statement ok
 ALTER POLICY new_p1 on table_owner_test RENAME TO p1;
 
-statement error pq: unimplemented: ALTER POLICY is not yet implemented
+statement ok
 ALTER POLICY p1 on table_owner_test RENAME TO new_p1;
 
-statement error pq: unimplemented: ALTER POLICY is not yet implemented
-ALTER POLICY p1 on table_owner_test USING (true);
+statement ok
+ALTER POLICY new_p1 on table_owner_test USING (true);
 
 statement ok
 SET ROLE nontab_owner;
@@ -1337,10 +1455,10 @@ CREATE POLICY p2 on table_owner_test;
 statement error pq: must be owner of relation table_owner_test
 DROP POLICY new_p1 on table_owner_test;
 
-statement error pq: unimplemented: ALTER POLICY is not yet implemented
+statement error pq: must be owner of relation table_owner_test
 ALTER POLICY new_p1 on table_owner_test WITH CHECK (true);
 
-statement error pq: unimplemented: ALTER POLICY is not yet implemented
+statement error pq: must be owner of relation table_owner_test
 ALTER POLICY new_p1 on table_owner_test RENAME TO p1;
 
 statement ok
@@ -2634,12 +2752,9 @@ query I
 UPDATE cnt SET counter = counter + 1 RETURNING counter;
 ----
 
-# Now replace the UPDATE policy with one that allows everything.
+# Now alter the UPDATE policy with one that allows everything.
 statement ok
-DROP POLICY upd1 ON cnt;
-
-statement ok
-CREATE POLICY upd1 ON cnt FOR UPDATE USING (true);
+ALTER POLICY upd1 ON cnt USING (true);
 
 query I
 UPDATE cnt SET counter = counter + 1 RETURNING counter;
@@ -2648,10 +2763,7 @@ UPDATE cnt SET counter = counter + 1 RETURNING counter;
 
 # Update the UPDATE policy so that it allows old rows but blocks all new rows.
 statement ok
-DROP POLICY upd1 ON cnt;
-
-statement ok
-CREATE POLICY upd1 ON cnt FOR UPDATE USING (true) WITH CHECK (false);
+ALTER POLICY upd1 ON cnt USING (true) WITH CHECK (false);
 
 # We are able to read the row but cannot write a new row as it violates the
 # update policy.
@@ -2673,10 +2785,7 @@ select counter from cnt;
 
 # Now change the select policy to be always false, and delete policy to be always true.
 statement ok
-DROP POLICY sel1 ON cnt;
-
-statement ok
-CREATE POLICY sel1 ON cnt FOR SELECT USING (false);
+ALTER POLICY sel1 ON cnt USING (false);
 
 statement ok
 CREATE POLICY del1 ON cnt FOR DELETE USING (true);

--- a/pkg/sql/schemachanger/dml_injection_test.go
+++ b/pkg/sql/schemachanger/dml_injection_test.go
@@ -417,6 +417,30 @@ func TestAlterTableDMLInjection(t *testing.T) {
 			schemaChange: "DROP INDEX idx",
 		},
 		{
+			desc: "alter policy name",
+			setup: []string{
+				"SET enable_row_level_security=on",
+				"CREATE POLICY p ON tbl FOR SELECT USING (val > 0)",
+				"ALTER TABLE tbl ENABLE ROW LEVEL SECURITY, FORCE ROW LEVEL SECURITY",
+				"CREATE USER foo",
+				"ALTER TABLE tbl OWNER TO foo",
+				"SET ROLE foo",
+			},
+			schemaChange: "ALTER POLICY p ON tbl RENAME TO policy_1",
+		},
+		{
+			desc: "alter policy using expression",
+			setup: []string{
+				"SET enable_row_level_security=on",
+				"CREATE POLICY p ON tbl FOR SELECT USING (val > 0)",
+				"ALTER TABLE tbl ENABLE ROW LEVEL SECURITY, FORCE ROW LEVEL SECURITY",
+				"CREATE USER foo",
+				"ALTER TABLE tbl OWNER TO foo",
+				"SET ROLE foo",
+			},
+			schemaChange: "ALTER POLICY p ON tbl USING (val > -10)",
+		},
+		{
 			desc: "drop column with index using hash cascade",
 			setup: []string{
 				"ALTER TABLE tbl ADD COLUMN i INT NOT NULL DEFAULT 1",

--- a/pkg/sql/schemachanger/scbuild/testdata/alter_policy
+++ b/pkg/sql/schemachanger/scbuild/testdata/alter_policy
@@ -1,0 +1,109 @@
+setup
+SET enable_row_level_security = true;
+CREATE TABLE defaultdb.foo (i INT PRIMARY KEY);
+CREATE USER fred;
+CREATE USER george;
+CREATE FUNCTION is_valid(n INT) returns bool as $$ begin return n < 10; end; $$ language plpgsql;
+CREATE SEQUENCE seq1;
+CREATE POLICY p on defaultdb.foo USING (nextval('seq1') < 50);
+----
+
+build
+ALTER POLICY p ON defaultdb.foo RENAME TO policy_1;
+----
+- [[IndexData:{DescID: 104, IndexID: 1}, PUBLIC], PUBLIC]
+  {indexId: 1, tableId: 104}
+- [[PolicyName:{DescID: 104, Name: p, PolicyID: 1}, ABSENT], PUBLIC]
+  {name: p, policyId: 1, tableId: 104}
+- [[TableData:{DescID: 104, ReferencedDescID: 100}, PUBLIC], PUBLIC]
+  {databaseId: 100, tableId: 104}
+- [[PolicyName:{DescID: 104, Name: policy_1, PolicyID: 1}, PUBLIC], ABSENT]
+  {name: policy_1, policyId: 1, tableId: 104}
+
+build
+ALTER POLICY p ON defaultdb.foo TO fred,george;
+----
+- [[IndexData:{DescID: 104, IndexID: 1}, PUBLIC], PUBLIC]
+  {indexId: 1, tableId: 104}
+- [[PolicyRole:{DescID: 104, Name: public, PolicyID: 1}, ABSENT], PUBLIC]
+  {policyId: 1, roleName: public, tableId: 104}
+- [[TableData:{DescID: 104, ReferencedDescID: 100}, PUBLIC], PUBLIC]
+  {databaseId: 100, tableId: 104}
+- [[PolicyRole:{DescID: 104, Name: fred, PolicyID: 1}, PUBLIC], ABSENT]
+  {policyId: 1, roleName: fred, tableId: 104}
+- [[PolicyRole:{DescID: 104, Name: george, PolicyID: 1}, PUBLIC], ABSENT]
+  {policyId: 1, roleName: george, tableId: 104}
+
+build
+ALTER POLICY p ON defaultdb.foo TO george USING (is_valid(i)) WITH CHECK (nextval('seq1') < 10000);
+----
+- [[IndexData:{DescID: 104, IndexID: 1}, PUBLIC], PUBLIC]
+  {indexId: 1, tableId: 104}
+- [[PolicyRole:{DescID: 104, Name: public, PolicyID: 1}, ABSENT], PUBLIC]
+  {policyId: 1, roleName: public, tableId: 104}
+- [[PolicyUsingExpr:{DescID: 104, Expr: nextval(106:::REGCLASS) < 50:::INT8, PolicyID: 1}, ABSENT], PUBLIC]
+  {expr: 'nextval(106:::REGCLASS) < 50:::INT8', policyId: 1, tableId: 104, usesSequenceIds: [106]}
+- [[PolicyDeps:{DescID: 104, ReferencedSequenceIDs: [106], PolicyID: 1}, ABSENT], PUBLIC]
+  {policyId: 1, tableId: 104, usesRelationIds: [106]}
+- [[TableData:{DescID: 104, ReferencedDescID: 100}, PUBLIC], PUBLIC]
+  {databaseId: 100, tableId: 104}
+- [[PolicyRole:{DescID: 104, Name: george, PolicyID: 1}, PUBLIC], ABSENT]
+  {policyId: 1, roleName: george, tableId: 104}
+- [[PolicyUsingExpr:{DescID: 104, Expr: [FUNCTION 100105](i), PolicyID: 1}, PUBLIC], ABSENT]
+  {expr: '[FUNCTION 100105](i)', policyId: 1, referencedColumnIds: [1], tableId: 104, usesFunctionIds: [105]}
+- [[PolicyWithCheckExpr:{DescID: 104, Expr: nextval(106:::REGCLASS) < 10000:::INT8, PolicyID: 1}, PUBLIC], ABSENT]
+  {expr: 'nextval(106:::REGCLASS) < 10000:::INT8', policyId: 1, tableId: 104, usesSequenceIds: [106]}
+- [[PolicyDeps:{DescID: 104, ReferencedSequenceIDs: [106], ReferencedFunctionIDs: [105], PolicyID: 1}, PUBLIC], ABSENT]
+  {policyId: 1, tableId: 104, usesFunctionIds: [105], usesRelationIds: [106]}
+
+build
+ALTER POLICY p ON defaultdb.foo TO fred USING (is_valid(i));
+----
+- [[IndexData:{DescID: 104, IndexID: 1}, PUBLIC], PUBLIC]
+  {indexId: 1, tableId: 104}
+- [[PolicyRole:{DescID: 104, Name: public, PolicyID: 1}, ABSENT], PUBLIC]
+  {policyId: 1, roleName: public, tableId: 104}
+- [[PolicyUsingExpr:{DescID: 104, Expr: nextval(106:::REGCLASS) < 50:::INT8, PolicyID: 1}, ABSENT], PUBLIC]
+  {expr: 'nextval(106:::REGCLASS) < 50:::INT8', policyId: 1, tableId: 104, usesSequenceIds: [106]}
+- [[PolicyDeps:{DescID: 104, ReferencedSequenceIDs: [106], PolicyID: 1}, ABSENT], PUBLIC]
+  {policyId: 1, tableId: 104, usesRelationIds: [106]}
+- [[TableData:{DescID: 104, ReferencedDescID: 100}, PUBLIC], PUBLIC]
+  {databaseId: 100, tableId: 104}
+- [[PolicyRole:{DescID: 104, Name: fred, PolicyID: 1}, PUBLIC], ABSENT]
+  {policyId: 1, roleName: fred, tableId: 104}
+- [[PolicyUsingExpr:{DescID: 104, Expr: [FUNCTION 100105](i), PolicyID: 1}, PUBLIC], ABSENT]
+  {expr: '[FUNCTION 100105](i)', policyId: 1, referencedColumnIds: [1], tableId: 104, usesFunctionIds: [105]}
+- [[PolicyDeps:{DescID: 104, ReferencedFunctionIDs: [105], PolicyID: 1}, PUBLIC], ABSENT]
+  {policyId: 1, tableId: 104, usesFunctionIds: [105]}
+
+build
+ALTER POLICY p ON defaultdb.foo TO fred WITH CHECK (true);
+----
+- [[IndexData:{DescID: 104, IndexID: 1}, PUBLIC], PUBLIC]
+  {indexId: 1, tableId: 104}
+- [[PolicyRole:{DescID: 104, Name: public, PolicyID: 1}, ABSENT], PUBLIC]
+  {policyId: 1, roleName: public, tableId: 104}
+- [[TableData:{DescID: 104, ReferencedDescID: 100}, PUBLIC], PUBLIC]
+  {databaseId: 100, tableId: 104}
+- [[PolicyRole:{DescID: 104, Name: fred, PolicyID: 1}, PUBLIC], ABSENT]
+  {policyId: 1, roleName: fred, tableId: 104}
+- [[PolicyWithCheckExpr:{DescID: 104, Expr: true, PolicyID: 1}, PUBLIC], ABSENT]
+  {expr: "true", policyId: 1, tableId: 104}
+
+build
+ALTER POLICY p ON defaultdb.foo USING (i > 0) WITH CHECK (is_valid(i));
+----
+- [[IndexData:{DescID: 104, IndexID: 1}, PUBLIC], PUBLIC]
+  {indexId: 1, tableId: 104}
+- [[PolicyUsingExpr:{DescID: 104, Expr: nextval(106:::REGCLASS) < 50:::INT8, PolicyID: 1}, ABSENT], PUBLIC]
+  {expr: 'nextval(106:::REGCLASS) < 50:::INT8', policyId: 1, tableId: 104, usesSequenceIds: [106]}
+- [[PolicyDeps:{DescID: 104, ReferencedSequenceIDs: [106], PolicyID: 1}, ABSENT], PUBLIC]
+  {policyId: 1, tableId: 104, usesRelationIds: [106]}
+- [[TableData:{DescID: 104, ReferencedDescID: 100}, PUBLIC], PUBLIC]
+  {databaseId: 100, tableId: 104}
+- [[PolicyUsingExpr:{DescID: 104, Expr: i > 0:::INT8, PolicyID: 1}, PUBLIC], ABSENT]
+  {expr: 'i > 0:::INT8', policyId: 1, referencedColumnIds: [1], tableId: 104}
+- [[PolicyWithCheckExpr:{DescID: 104, Expr: [FUNCTION 100105](i), PolicyID: 1}, PUBLIC], ABSENT]
+  {expr: '[FUNCTION 100105](i)', policyId: 1, referencedColumnIds: [1], tableId: 104, usesFunctionIds: [105]}
+- [[PolicyDeps:{DescID: 104, ReferencedFunctionIDs: [105], PolicyID: 1}, PUBLIC], ABSENT]
+  {policyId: 1, tableId: 104, usesFunctionIds: [105]}

--- a/pkg/sql/schemachanger/scplan/testdata/alter_policy
+++ b/pkg/sql/schemachanger/scplan/testdata/alter_policy
@@ -1,0 +1,500 @@
+setup
+SET enable_row_level_security=on;
+CREATE TYPE pt AS (x int, y int);
+CREATE TABLE t1 (tenant_id uuid, c1 pt, c2 text);
+CREATE SEQUENCE seq1;
+CREATE USER user1;
+CREATE USER user2;
+CREATE TYPE greeting AS ENUM('hi', 'howdy', 'hello');
+CREATE FUNCTION is_valid(n INT) returns bool as $$ begin return n < 10; end; $$ language plpgsql;
+CREATE FUNCTION is_even(n INT) returns bool as $$ begin return n % 2 = 0; end; $$ language plpgsql;
+CREATE POLICY p on t1 AS PERMISSIVE FOR UPDATE TO public USING (tenant_id = '01538898-f55c-44db-a306-89078e2c430e' AND (c1).x > 0) WITH CHECK (nextval('seq1') < 10);
+----
+
+ops
+ALTER POLICY p ON t1 RENAME TO "policy 1";
+----
+StatementPhase stage 1 of 1 with 2 MutationType ops
+  transitions:
+    [[PolicyName:{DescID: 106, Name: p, PolicyID: 1}, ABSENT], PUBLIC] -> ABSENT
+    [[PolicyName:{DescID: 106, Name: policy 1, PolicyID: 1}, PUBLIC], ABSENT] -> PUBLIC
+  ops:
+    *scop.SetPolicyName
+      Name: crdb_internal_policy_1_name_placeholder
+      PolicyID: 1
+      TableID: 106
+    *scop.SetPolicyName
+      Name: policy 1
+      PolicyID: 1
+      TableID: 106
+PreCommitPhase stage 1 of 2 with 1 MutationType op
+  transitions:
+    [[PolicyName:{DescID: 106, Name: p, PolicyID: 1}, ABSENT], ABSENT] -> PUBLIC
+    [[PolicyName:{DescID: 106, Name: policy 1, PolicyID: 1}, PUBLIC], PUBLIC] -> ABSENT
+  ops:
+    *scop.UndoAllInTxnImmediateMutationOpSideEffects
+      {}
+PreCommitPhase stage 2 of 2 with 2 MutationType ops
+  transitions:
+    [[PolicyName:{DescID: 106, Name: p, PolicyID: 1}, ABSENT], PUBLIC] -> ABSENT
+    [[PolicyName:{DescID: 106, Name: policy 1, PolicyID: 1}, PUBLIC], ABSENT] -> PUBLIC
+  ops:
+    *scop.SetPolicyName
+      Name: crdb_internal_policy_1_name_placeholder
+      PolicyID: 1
+      TableID: 106
+    *scop.SetPolicyName
+      Name: policy 1
+      PolicyID: 1
+      TableID: 106
+
+ops
+ALTER POLICY p ON t1 TO user1, user2, public;
+----
+StatementPhase stage 1 of 1 with 2 MutationType ops
+  transitions:
+    [[PolicyRole:{DescID: 106, Name: user1, PolicyID: 1}, PUBLIC], ABSENT] -> PUBLIC
+    [[PolicyRole:{DescID: 106, Name: user2, PolicyID: 1}, PUBLIC], ABSENT] -> PUBLIC
+  ops:
+    *scop.AddPolicyRole
+      Role:
+        PolicyID: 1
+        RoleName: user1
+        TableID: 106
+    *scop.AddPolicyRole
+      Role:
+        PolicyID: 1
+        RoleName: user2
+        TableID: 106
+PreCommitPhase stage 1 of 2 with 1 MutationType op
+  transitions:
+    [[PolicyRole:{DescID: 106, Name: user1, PolicyID: 1}, PUBLIC], PUBLIC] -> ABSENT
+    [[PolicyRole:{DescID: 106, Name: user2, PolicyID: 1}, PUBLIC], PUBLIC] -> ABSENT
+  ops:
+    *scop.UndoAllInTxnImmediateMutationOpSideEffects
+      {}
+PreCommitPhase stage 2 of 2 with 2 MutationType ops
+  transitions:
+    [[PolicyRole:{DescID: 106, Name: user1, PolicyID: 1}, PUBLIC], ABSENT] -> PUBLIC
+    [[PolicyRole:{DescID: 106, Name: user2, PolicyID: 1}, PUBLIC], ABSENT] -> PUBLIC
+  ops:
+    *scop.AddPolicyRole
+      Role:
+        PolicyID: 1
+        RoleName: user1
+        TableID: 106
+    *scop.AddPolicyRole
+      Role:
+        PolicyID: 1
+        RoleName: user2
+        TableID: 106
+
+ops
+ALTER POLICY p ON t1 USING (true);
+----
+StatementPhase stage 1 of 1 with 2 MutationType ops
+  transitions:
+    [[PolicyUsingExpr:{DescID: 106, Expr: (tenant_id = '01538898-f55c-44db-a306-89078e2c430e':::UUID) AND ((c1).x > 0:::INT8), PolicyID: 1}, ABSENT], PUBLIC] -> ABSENT
+    [[PolicyUsingExpr:{DescID: 106, Expr: true, PolicyID: 1}, PUBLIC], ABSENT] -> PUBLIC
+  ops:
+    *scop.SetPolicyUsingExpression
+      PolicyID: 1
+      TableID: 106
+    *scop.SetPolicyUsingExpression
+      Expr: "true"
+      PolicyID: 1
+      TableID: 106
+PreCommitPhase stage 1 of 2 with 1 MutationType op
+  transitions:
+    [[PolicyUsingExpr:{DescID: 106, Expr: (tenant_id = '01538898-f55c-44db-a306-89078e2c430e':::UUID) AND ((c1).x > 0:::INT8), PolicyID: 1}, ABSENT], ABSENT] -> PUBLIC
+    [[PolicyUsingExpr:{DescID: 106, Expr: true, PolicyID: 1}, PUBLIC], PUBLIC] -> ABSENT
+  ops:
+    *scop.UndoAllInTxnImmediateMutationOpSideEffects
+      {}
+PreCommitPhase stage 2 of 2 with 2 MutationType ops
+  transitions:
+    [[PolicyUsingExpr:{DescID: 106, Expr: (tenant_id = '01538898-f55c-44db-a306-89078e2c430e':::UUID) AND ((c1).x > 0:::INT8), PolicyID: 1}, ABSENT], PUBLIC] -> ABSENT
+    [[PolicyUsingExpr:{DescID: 106, Expr: true, PolicyID: 1}, PUBLIC], ABSENT] -> PUBLIC
+  ops:
+    *scop.SetPolicyUsingExpression
+      PolicyID: 1
+      TableID: 106
+    *scop.SetPolicyUsingExpression
+      Expr: "true"
+      PolicyID: 1
+      TableID: 106
+
+ops
+ALTER POLICY p ON t1 USING (true) WITH CHECK (false);
+----
+StatementPhase stage 1 of 1 with 6 MutationType ops
+  transitions:
+    [[PolicyUsingExpr:{DescID: 106, Expr: (tenant_id = '01538898-f55c-44db-a306-89078e2c430e':::UUID) AND ((c1).x > 0:::INT8), PolicyID: 1}, ABSENT], PUBLIC] -> ABSENT
+    [[PolicyWithCheckExpr:{DescID: 106, Expr: nextval(107:::REGCLASS) < 10:::INT8, PolicyID: 1}, ABSENT], PUBLIC] -> ABSENT
+    [[PolicyDeps:{DescID: 106, ReferencedSequenceIDs: [107], PolicyID: 1}, ABSENT], PUBLIC] -> ABSENT
+    [[PolicyUsingExpr:{DescID: 106, Expr: true, PolicyID: 1}, PUBLIC], ABSENT] -> PUBLIC
+    [[PolicyWithCheckExpr:{DescID: 106, Expr: false, PolicyID: 1}, PUBLIC], ABSENT] -> PUBLIC
+    [[PolicyDeps:{DescID: 106, PolicyID: 1}, PUBLIC], ABSENT] -> PUBLIC
+  ops:
+    *scop.SetPolicyUsingExpression
+      PolicyID: 1
+      TableID: 106
+    *scop.SetPolicyWithCheckExpression
+      PolicyID: 1
+      TableID: 106
+    *scop.UpdateTableBackReferencesInSequences
+      BackReferencedTableID: 106
+      SequenceIDs:
+      - 107
+    *scop.SetPolicyUsingExpression
+      Expr: "true"
+      PolicyID: 1
+      TableID: 106
+    *scop.SetPolicyWithCheckExpression
+      Expr: "false"
+      PolicyID: 1
+      TableID: 106
+    *scop.SetPolicyForwardReferences
+      Deps:
+        PolicyID: 1
+        TableID: 106
+PreCommitPhase stage 1 of 2 with 1 MutationType op
+  transitions:
+    [[PolicyUsingExpr:{DescID: 106, Expr: (tenant_id = '01538898-f55c-44db-a306-89078e2c430e':::UUID) AND ((c1).x > 0:::INT8), PolicyID: 1}, ABSENT], ABSENT] -> PUBLIC
+    [[PolicyWithCheckExpr:{DescID: 106, Expr: nextval(107:::REGCLASS) < 10:::INT8, PolicyID: 1}, ABSENT], ABSENT] -> PUBLIC
+    [[PolicyDeps:{DescID: 106, ReferencedSequenceIDs: [107], PolicyID: 1}, ABSENT], ABSENT] -> PUBLIC
+    [[PolicyUsingExpr:{DescID: 106, Expr: true, PolicyID: 1}, PUBLIC], PUBLIC] -> ABSENT
+    [[PolicyWithCheckExpr:{DescID: 106, Expr: false, PolicyID: 1}, PUBLIC], PUBLIC] -> ABSENT
+    [[PolicyDeps:{DescID: 106, PolicyID: 1}, PUBLIC], PUBLIC] -> ABSENT
+  ops:
+    *scop.UndoAllInTxnImmediateMutationOpSideEffects
+      {}
+PreCommitPhase stage 2 of 2 with 6 MutationType ops
+  transitions:
+    [[PolicyUsingExpr:{DescID: 106, Expr: (tenant_id = '01538898-f55c-44db-a306-89078e2c430e':::UUID) AND ((c1).x > 0:::INT8), PolicyID: 1}, ABSENT], PUBLIC] -> ABSENT
+    [[PolicyWithCheckExpr:{DescID: 106, Expr: nextval(107:::REGCLASS) < 10:::INT8, PolicyID: 1}, ABSENT], PUBLIC] -> ABSENT
+    [[PolicyDeps:{DescID: 106, ReferencedSequenceIDs: [107], PolicyID: 1}, ABSENT], PUBLIC] -> ABSENT
+    [[PolicyUsingExpr:{DescID: 106, Expr: true, PolicyID: 1}, PUBLIC], ABSENT] -> PUBLIC
+    [[PolicyWithCheckExpr:{DescID: 106, Expr: false, PolicyID: 1}, PUBLIC], ABSENT] -> PUBLIC
+    [[PolicyDeps:{DescID: 106, PolicyID: 1}, PUBLIC], ABSENT] -> PUBLIC
+  ops:
+    *scop.SetPolicyUsingExpression
+      PolicyID: 1
+      TableID: 106
+    *scop.SetPolicyWithCheckExpression
+      PolicyID: 1
+      TableID: 106
+    *scop.UpdateTableBackReferencesInSequences
+      BackReferencedTableID: 106
+      SequenceIDs:
+      - 107
+    *scop.SetPolicyUsingExpression
+      Expr: "true"
+      PolicyID: 1
+      TableID: 106
+    *scop.SetPolicyWithCheckExpression
+      Expr: "false"
+      PolicyID: 1
+      TableID: 106
+    *scop.SetPolicyForwardReferences
+      Deps:
+        PolicyID: 1
+        TableID: 106
+
+ops
+ALTER POLICY p ON t1 USING (is_valid((c1).x)) WITH CHECK (true);
+----
+StatementPhase stage 1 of 1 with 7 MutationType ops
+  transitions:
+    [[PolicyUsingExpr:{DescID: 106, Expr: (tenant_id = '01538898-f55c-44db-a306-89078e2c430e':::UUID) AND ((c1).x > 0:::INT8), PolicyID: 1}, ABSENT], PUBLIC] -> ABSENT
+    [[PolicyWithCheckExpr:{DescID: 106, Expr: nextval(107:::REGCLASS) < 10:::INT8, PolicyID: 1}, ABSENT], PUBLIC] -> ABSENT
+    [[PolicyDeps:{DescID: 106, ReferencedSequenceIDs: [107], PolicyID: 1}, ABSENT], PUBLIC] -> ABSENT
+    [[PolicyUsingExpr:{DescID: 106, Expr: [FUNCTION 100110]((c1).x), PolicyID: 1}, PUBLIC], ABSENT] -> PUBLIC
+    [[PolicyWithCheckExpr:{DescID: 106, Expr: true, PolicyID: 1}, PUBLIC], ABSENT] -> PUBLIC
+    [[PolicyDeps:{DescID: 106, ReferencedFunctionIDs: [110], PolicyID: 1}, PUBLIC], ABSENT] -> PUBLIC
+  ops:
+    *scop.SetPolicyUsingExpression
+      PolicyID: 1
+      TableID: 106
+    *scop.SetPolicyWithCheckExpression
+      PolicyID: 1
+      TableID: 106
+    *scop.UpdateTableBackReferencesInSequences
+      BackReferencedTableID: 106
+      SequenceIDs:
+      - 107
+    *scop.SetPolicyUsingExpression
+      ColumnIDs:
+      - 2
+      Expr: '[FUNCTION 100110]((c1).x)'
+      PolicyID: 1
+      TableID: 106
+    *scop.SetPolicyWithCheckExpression
+      Expr: "true"
+      PolicyID: 1
+      TableID: 106
+    *scop.SetPolicyForwardReferences
+      Deps:
+        PolicyID: 1
+        TableID: 106
+        UsesFunctionIDs:
+        - 110
+    *scop.AddPolicyBackReferenceInFunctions
+      BackReferencedPolicyID: 1
+      BackReferencedTableID: 106
+      FunctionIDs:
+      - 110
+PreCommitPhase stage 1 of 2 with 1 MutationType op
+  transitions:
+    [[PolicyUsingExpr:{DescID: 106, Expr: (tenant_id = '01538898-f55c-44db-a306-89078e2c430e':::UUID) AND ((c1).x > 0:::INT8), PolicyID: 1}, ABSENT], ABSENT] -> PUBLIC
+    [[PolicyWithCheckExpr:{DescID: 106, Expr: nextval(107:::REGCLASS) < 10:::INT8, PolicyID: 1}, ABSENT], ABSENT] -> PUBLIC
+    [[PolicyDeps:{DescID: 106, ReferencedSequenceIDs: [107], PolicyID: 1}, ABSENT], ABSENT] -> PUBLIC
+    [[PolicyUsingExpr:{DescID: 106, Expr: [FUNCTION 100110]((c1).x), PolicyID: 1}, PUBLIC], PUBLIC] -> ABSENT
+    [[PolicyWithCheckExpr:{DescID: 106, Expr: true, PolicyID: 1}, PUBLIC], PUBLIC] -> ABSENT
+    [[PolicyDeps:{DescID: 106, ReferencedFunctionIDs: [110], PolicyID: 1}, PUBLIC], PUBLIC] -> ABSENT
+  ops:
+    *scop.UndoAllInTxnImmediateMutationOpSideEffects
+      {}
+PreCommitPhase stage 2 of 2 with 7 MutationType ops
+  transitions:
+    [[PolicyUsingExpr:{DescID: 106, Expr: (tenant_id = '01538898-f55c-44db-a306-89078e2c430e':::UUID) AND ((c1).x > 0:::INT8), PolicyID: 1}, ABSENT], PUBLIC] -> ABSENT
+    [[PolicyWithCheckExpr:{DescID: 106, Expr: nextval(107:::REGCLASS) < 10:::INT8, PolicyID: 1}, ABSENT], PUBLIC] -> ABSENT
+    [[PolicyDeps:{DescID: 106, ReferencedSequenceIDs: [107], PolicyID: 1}, ABSENT], PUBLIC] -> ABSENT
+    [[PolicyUsingExpr:{DescID: 106, Expr: [FUNCTION 100110]((c1).x), PolicyID: 1}, PUBLIC], ABSENT] -> PUBLIC
+    [[PolicyWithCheckExpr:{DescID: 106, Expr: true, PolicyID: 1}, PUBLIC], ABSENT] -> PUBLIC
+    [[PolicyDeps:{DescID: 106, ReferencedFunctionIDs: [110], PolicyID: 1}, PUBLIC], ABSENT] -> PUBLIC
+  ops:
+    *scop.SetPolicyUsingExpression
+      PolicyID: 1
+      TableID: 106
+    *scop.SetPolicyWithCheckExpression
+      PolicyID: 1
+      TableID: 106
+    *scop.UpdateTableBackReferencesInSequences
+      BackReferencedTableID: 106
+      SequenceIDs:
+      - 107
+    *scop.SetPolicyUsingExpression
+      ColumnIDs:
+      - 2
+      Expr: '[FUNCTION 100110]((c1).x)'
+      PolicyID: 1
+      TableID: 106
+    *scop.SetPolicyWithCheckExpression
+      Expr: "true"
+      PolicyID: 1
+      TableID: 106
+    *scop.SetPolicyForwardReferences
+      Deps:
+        PolicyID: 1
+        TableID: 106
+        UsesFunctionIDs:
+        - 110
+    *scop.AddPolicyBackReferenceInFunctions
+      BackReferencedPolicyID: 1
+      BackReferencedTableID: 106
+      FunctionIDs:
+      - 110
+
+ops
+ALTER POLICY p ON t1 USING (is_valid((c1).x)) WITH CHECK (is_even((c1).y) and c2 not like '%stuff%');
+----
+StatementPhase stage 1 of 1 with 7 MutationType ops
+  transitions:
+    [[PolicyUsingExpr:{DescID: 106, Expr: (tenant_id = '01538898-f55c-44db-a306-89078e2c430e':::UUID) AND ((c1).x > 0:::INT8), PolicyID: 1}, ABSENT], PUBLIC] -> ABSENT
+    [[PolicyWithCheckExpr:{DescID: 106, Expr: nextval(107:::REGCLASS) < 10:::INT8, PolicyID: 1}, ABSENT], PUBLIC] -> ABSENT
+    [[PolicyDeps:{DescID: 106, ReferencedSequenceIDs: [107], PolicyID: 1}, ABSENT], PUBLIC] -> ABSENT
+    [[PolicyUsingExpr:{DescID: 106, Expr: [FUNCTION 100110]((c1).x), PolicyID: 1}, PUBLIC], ABSENT] -> PUBLIC
+    [[PolicyWithCheckExpr:{DescID: 106, Expr: [FUNCTION 100111]((c1).y) AND (c2 NOT LIKE '%stuff%':::STRING), PolicyID: 1}, PUBLIC], ABSENT] -> PUBLIC
+    [[PolicyDeps:{DescID: 106, ReferencedFunctionIDs: [110 111], PolicyID: 1}, PUBLIC], ABSENT] -> PUBLIC
+  ops:
+    *scop.SetPolicyUsingExpression
+      PolicyID: 1
+      TableID: 106
+    *scop.SetPolicyWithCheckExpression
+      PolicyID: 1
+      TableID: 106
+    *scop.UpdateTableBackReferencesInSequences
+      BackReferencedTableID: 106
+      SequenceIDs:
+      - 107
+    *scop.SetPolicyUsingExpression
+      ColumnIDs:
+      - 2
+      Expr: '[FUNCTION 100110]((c1).x)'
+      PolicyID: 1
+      TableID: 106
+    *scop.SetPolicyWithCheckExpression
+      ColumnIDs:
+      - 2
+      - 3
+      Expr: '[FUNCTION 100111]((c1).y) AND (c2 NOT LIKE ''%stuff%'':::STRING)'
+      PolicyID: 1
+      TableID: 106
+    *scop.SetPolicyForwardReferences
+      Deps:
+        PolicyID: 1
+        TableID: 106
+        UsesFunctionIDs:
+        - 110
+        - 111
+    *scop.AddPolicyBackReferenceInFunctions
+      BackReferencedPolicyID: 1
+      BackReferencedTableID: 106
+      FunctionIDs:
+      - 110
+      - 111
+PreCommitPhase stage 1 of 2 with 1 MutationType op
+  transitions:
+    [[PolicyUsingExpr:{DescID: 106, Expr: (tenant_id = '01538898-f55c-44db-a306-89078e2c430e':::UUID) AND ((c1).x > 0:::INT8), PolicyID: 1}, ABSENT], ABSENT] -> PUBLIC
+    [[PolicyWithCheckExpr:{DescID: 106, Expr: nextval(107:::REGCLASS) < 10:::INT8, PolicyID: 1}, ABSENT], ABSENT] -> PUBLIC
+    [[PolicyDeps:{DescID: 106, ReferencedSequenceIDs: [107], PolicyID: 1}, ABSENT], ABSENT] -> PUBLIC
+    [[PolicyUsingExpr:{DescID: 106, Expr: [FUNCTION 100110]((c1).x), PolicyID: 1}, PUBLIC], PUBLIC] -> ABSENT
+    [[PolicyWithCheckExpr:{DescID: 106, Expr: [FUNCTION 100111]((c1).y) AND (c2 NOT LIKE '%stuff%':::STRING), PolicyID: 1}, PUBLIC], PUBLIC] -> ABSENT
+    [[PolicyDeps:{DescID: 106, ReferencedFunctionIDs: [110 111], PolicyID: 1}, PUBLIC], PUBLIC] -> ABSENT
+  ops:
+    *scop.UndoAllInTxnImmediateMutationOpSideEffects
+      {}
+PreCommitPhase stage 2 of 2 with 7 MutationType ops
+  transitions:
+    [[PolicyUsingExpr:{DescID: 106, Expr: (tenant_id = '01538898-f55c-44db-a306-89078e2c430e':::UUID) AND ((c1).x > 0:::INT8), PolicyID: 1}, ABSENT], PUBLIC] -> ABSENT
+    [[PolicyWithCheckExpr:{DescID: 106, Expr: nextval(107:::REGCLASS) < 10:::INT8, PolicyID: 1}, ABSENT], PUBLIC] -> ABSENT
+    [[PolicyDeps:{DescID: 106, ReferencedSequenceIDs: [107], PolicyID: 1}, ABSENT], PUBLIC] -> ABSENT
+    [[PolicyUsingExpr:{DescID: 106, Expr: [FUNCTION 100110]((c1).x), PolicyID: 1}, PUBLIC], ABSENT] -> PUBLIC
+    [[PolicyWithCheckExpr:{DescID: 106, Expr: [FUNCTION 100111]((c1).y) AND (c2 NOT LIKE '%stuff%':::STRING), PolicyID: 1}, PUBLIC], ABSENT] -> PUBLIC
+    [[PolicyDeps:{DescID: 106, ReferencedFunctionIDs: [110 111], PolicyID: 1}, PUBLIC], ABSENT] -> PUBLIC
+  ops:
+    *scop.SetPolicyUsingExpression
+      PolicyID: 1
+      TableID: 106
+    *scop.SetPolicyWithCheckExpression
+      PolicyID: 1
+      TableID: 106
+    *scop.UpdateTableBackReferencesInSequences
+      BackReferencedTableID: 106
+      SequenceIDs:
+      - 107
+    *scop.SetPolicyUsingExpression
+      ColumnIDs:
+      - 2
+      Expr: '[FUNCTION 100110]((c1).x)'
+      PolicyID: 1
+      TableID: 106
+    *scop.SetPolicyWithCheckExpression
+      ColumnIDs:
+      - 2
+      - 3
+      Expr: '[FUNCTION 100111]((c1).y) AND (c2 NOT LIKE ''%stuff%'':::STRING)'
+      PolicyID: 1
+      TableID: 106
+    *scop.SetPolicyForwardReferences
+      Deps:
+        PolicyID: 1
+        TableID: 106
+        UsesFunctionIDs:
+        - 110
+        - 111
+    *scop.AddPolicyBackReferenceInFunctions
+      BackReferencedPolicyID: 1
+      BackReferencedTableID: 106
+      FunctionIDs:
+      - 110
+      - 111
+
+ops
+ALTER POLICY p ON t1 USING (c2::greeting = 'hello'::greeting) WITH CHECK (true);
+---
+----
+StatementPhase stage 1 of 1 with 7 MutationType ops
+  transitions:
+    [[PolicyUsingExpr:{DescID: 106, Expr: (tenant_id = '01538898-f55c-44db-a306-89078e2c430e':::UUID) AND ((c1).x > 0:::INT8), PolicyID: 1}, ABSENT], PUBLIC] -> ABSENT
+    [[PolicyWithCheckExpr:{DescID: 106, Expr: nextval(107:::REGCLASS) < 10:::INT8, PolicyID: 1}, ABSENT], PUBLIC] -> ABSENT
+    [[PolicyDeps:{DescID: 106, ReferencedSequenceIDs: [107], PolicyID: 1}, ABSENT], PUBLIC] -> ABSENT
+    [[PolicyUsingExpr:{DescID: 106, Expr: c2::@100108 = b'\xc0':::@100108, PolicyID: 1}, PUBLIC], ABSENT] -> PUBLIC
+    [[PolicyWithCheckExpr:{DescID: 106, Expr: true, PolicyID: 1}, PUBLIC], ABSENT] -> PUBLIC
+    [[PolicyDeps:{DescID: 106, ReferencedTypeIDs: [108 109], PolicyID: 1}, PUBLIC], ABSENT] -> PUBLIC
+  ops:
+    *scop.SetPolicyUsingExpression
+      PolicyID: 1
+      TableID: 106
+    *scop.SetPolicyWithCheckExpression
+      PolicyID: 1
+      TableID: 106
+    *scop.UpdateTableBackReferencesInSequences
+      BackReferencedTableID: 106
+      SequenceIDs:
+      - 107
+    *scop.SetPolicyUsingExpression
+      ColumnIDs:
+      - 3
+      Expr: c2::@100108 = b'\xc0':::@100108
+      PolicyID: 1
+      TableID: 106
+    *scop.SetPolicyWithCheckExpression
+      Expr: "true"
+      PolicyID: 1
+      TableID: 106
+    *scop.SetPolicyForwardReferences
+      Deps:
+        PolicyID: 1
+        TableID: 106
+        UsesTypeIDs:
+        - 108
+        - 109
+    *scop.UpdateTableBackReferencesInTypes
+      BackReferencedTableID: 106
+      TypeIDs:
+      - 108
+      - 109
+PreCommitPhase stage 1 of 2 with 1 MutationType op
+  transitions:
+    [[PolicyUsingExpr:{DescID: 106, Expr: (tenant_id = '01538898-f55c-44db-a306-89078e2c430e':::UUID) AND ((c1).x > 0:::INT8), PolicyID: 1}, ABSENT], ABSENT] -> PUBLIC
+    [[PolicyWithCheckExpr:{DescID: 106, Expr: nextval(107:::REGCLASS) < 10:::INT8, PolicyID: 1}, ABSENT], ABSENT] -> PUBLIC
+    [[PolicyDeps:{DescID: 106, ReferencedSequenceIDs: [107], PolicyID: 1}, ABSENT], ABSENT] -> PUBLIC
+    [[PolicyUsingExpr:{DescID: 106, Expr: c2::@100108 = b'\xc0':::@100108, PolicyID: 1}, PUBLIC], PUBLIC] -> ABSENT
+    [[PolicyWithCheckExpr:{DescID: 106, Expr: true, PolicyID: 1}, PUBLIC], PUBLIC] -> ABSENT
+    [[PolicyDeps:{DescID: 106, ReferencedTypeIDs: [108 109], PolicyID: 1}, PUBLIC], PUBLIC] -> ABSENT
+  ops:
+    *scop.UndoAllInTxnImmediateMutationOpSideEffects
+      {}
+PreCommitPhase stage 2 of 2 with 7 MutationType ops
+  transitions:
+    [[PolicyUsingExpr:{DescID: 106, Expr: (tenant_id = '01538898-f55c-44db-a306-89078e2c430e':::UUID) AND ((c1).x > 0:::INT8), PolicyID: 1}, ABSENT], PUBLIC] -> ABSENT
+    [[PolicyWithCheckExpr:{DescID: 106, Expr: nextval(107:::REGCLASS) < 10:::INT8, PolicyID: 1}, ABSENT], PUBLIC] -> ABSENT
+    [[PolicyDeps:{DescID: 106, ReferencedSequenceIDs: [107], PolicyID: 1}, ABSENT], PUBLIC] -> ABSENT
+    [[PolicyUsingExpr:{DescID: 106, Expr: c2::@100108 = b'\xc0':::@100108, PolicyID: 1}, PUBLIC], ABSENT] -> PUBLIC
+    [[PolicyWithCheckExpr:{DescID: 106, Expr: true, PolicyID: 1}, PUBLIC], ABSENT] -> PUBLIC
+    [[PolicyDeps:{DescID: 106, ReferencedTypeIDs: [108 109], PolicyID: 1}, PUBLIC], ABSENT] -> PUBLIC
+  ops:
+    *scop.SetPolicyUsingExpression
+      PolicyID: 1
+      TableID: 106
+    *scop.SetPolicyWithCheckExpression
+      PolicyID: 1
+      TableID: 106
+    *scop.UpdateTableBackReferencesInSequences
+      BackReferencedTableID: 106
+      SequenceIDs:
+      - 107
+    *scop.SetPolicyUsingExpression
+      ColumnIDs:
+      - 3
+      Expr: c2::@100108 = b'\xc0':::@100108
+      PolicyID: 1
+      TableID: 106
+    *scop.SetPolicyWithCheckExpression
+      Expr: "true"
+      PolicyID: 1
+      TableID: 106
+    *scop.SetPolicyForwardReferences
+      Deps:
+        PolicyID: 1
+        TableID: 106
+        UsesTypeIDs:
+        - 108
+        - 109
+    *scop.UpdateTableBackReferencesInTypes
+      BackReferencedTableID: 106
+      TypeIDs:
+      - 108
+      - 109


### PR DESCRIPTION
Previously, attempts to execute ALTER POLICY DDL statements failed with an unimplemented error.

This change enables support for ALTER POLICY by leveraging the existing policy-related scpb elements, which already accounted for alteration scenarios.

Closes #136996
Closes #136997

Epic: CRDB-11724
Release note: none