### PR TITLE
roachtest: set cdc/mixed-versions maxUpgrades to 2

### DIFF
--- a/pkg/cmd/roachtest/tests/mixed_version_cdc.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_cdc.go
@@ -446,9 +446,6 @@ func runCDCMixedVersions(ctx context.Context, t test.Test, c cluster.Cluster) {
 		ctx, t, t.L(), c, tester.crdbNodes,
 		// Multi-tenant deployments are currently unsupported. See #127378.
 		mixedversion.EnabledDeploymentModes(mixedversion.SystemOnlyDeployment),
-		// We limit the number of upgrades to be performed in the test run because
-		// the test takes a significant amount of time to complete.
-		mixedversion.MaxUpgrades(3),
 	)
 
 	cleanupKafka := tester.StartKafka(t, c)


### PR DESCRIPTION
Commit 195397ceec3052a0cd9130e9854bd72c2b0bb331 set the maxUpgrades of this test to 3 in order to limit the run time. However, on release-23.2, the default maxUpgrades is already 2 in order to respect the minSupportedVersion of 22.2.

As a result, the potential run time of this test actually increased, as the test can now generate plans starting at 22.1. A side effect of this is that the test would sometimes fail attempting to connect with the -cluster flag, which is not supported on v22.1.

Fixes: https://github.com/cockroachdb/cockroach/issues/137667
Release Justification: Test only change
Release note: none