### PR TITLE
security: change client cert expiration caching eviction policy

### DIFF
--- a/pkg/security/BUILD.bazel
+++ b/pkg/security/BUILD.bazel
@@ -40,6 +40,7 @@ go_library(
         "//pkg/util/log/severity",
         "//pkg/util/metric",
         "//pkg/util/metric/aggmetric",
+        "//pkg/util/mon",
         "//pkg/util/quotapool",
         "//pkg/util/randutil",
         "//pkg/util/stop",

--- a/pkg/security/auth.go
+++ b/pkg/security/auth.go
@@ -356,6 +356,7 @@ func UserAuthCertHook(
 				certManager.MaybeUpsertClientExpiration(
 					ctx,
 					systemIdentity,
+					peerCert.SerialNumber.String(),
 					peerCert.NotAfter.Unix(),
 				)
 			}

--- a/pkg/security/clientcert/BUILD.bazel
+++ b/pkg/security/clientcert/BUILD.bazel
@@ -8,7 +8,6 @@ go_library(
     deps = [
         "//pkg/settings",
         "//pkg/settings/cluster",
-        "//pkg/util/cache",
         "//pkg/util/log",
         "//pkg/util/metric/aggmetric",
         "//pkg/util/mon",

--- a/pkg/security/clientcert/cert_expiry_cache.go
+++ b/pkg/security/clientcert/cert_expiry_cache.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
-	"github.com/cockroachdb/cockroach/pkg/util/cache"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/metric/aggmetric"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
@@ -34,10 +33,19 @@ var ClientCertExpirationCacheCapacity = settings.RegisterIntSetting(
 	1000,
 	settings.WithPublic)
 
-type clientCertExpirationMetrics struct {
-	expiration *aggmetric.Gauge
-	ttl        *aggmetric.Gauge
+// certInfo holds information about a certificate, including its expiration
+// time and the last time it was seen.
+type certInfo struct {
+	expiration int64
+	last_seen  time.Time
 }
+
+// CacheTTL is an overridable duration for when certificates should be evicted.
+var CacheTTL = 24 * time.Hour
+
+// The size of the cache and the certInfo struct. To be used for memory tracking.
+var GaugeSize = int64(unsafe.Sizeof(aggmetric.AggGauge{}))
+var CertInfoSize = int64(unsafe.Sizeof(certInfo{}))
 
 // ClientCertExpirationCache contains a cache of gauge objects keyed by
 // SQL username strings. It is a FIFO cache that stores gauges valued by
@@ -47,8 +55,10 @@ type ClientCertExpirationCache struct {
 		// NB: Cannot be a RWMutex for Get because UnorderedCache.Get manipulates
 		// an internal hashmap.
 		syncutil.Mutex
-		cache *cache.UnorderedCache
-		acc   mon.BoundAccount
+		cache             map[string]map[string]certInfo
+		acc               mon.BoundAccount
+		expirationMetrics *aggmetric.AggGauge
+		ttlMetrics        *aggmetric.AggGauge
 	}
 	settings *cluster.Settings
 	stopper  *stop.Stopper
@@ -63,9 +73,13 @@ func NewClientCertExpirationCache(
 	stopper *stop.Stopper,
 	timeSrc timeutil.TimeSource,
 	parentMon *mon.BytesMonitor,
+	expirationMetrics *aggmetric.AggGauge,
+	ttlMetrics *aggmetric.AggGauge,
 ) *ClientCertExpirationCache {
 	c := &ClientCertExpirationCache{settings: st}
 	c.stopper = stopper
+	c.mu.expirationMetrics = expirationMetrics
+	c.mu.ttlMetrics = ttlMetrics
 
 	switch timeSrc := timeSrc.(type) {
 	case *timeutil.DefaultTimeSource, *timeutil.ManualTime:
@@ -74,29 +88,7 @@ func NewClientCertExpirationCache(
 		c.timeSrc = &timeutil.DefaultTimeSource{}
 	}
 
-	c.mu.cache = cache.NewUnorderedCache(cache.Config{
-		Policy: cache.CacheFIFO,
-		ShouldEvict: func(size int, _, value interface{}) bool {
-			var capacity int64
-			settingCapacity := ClientCertExpirationCacheCapacity.Get(&st.SV)
-			if settingCapacity < CacheCapacityMax {
-				capacity = settingCapacity
-			} else {
-				capacity = CacheCapacityMax
-			}
-			return int64(size) > capacity
-		},
-		OnEvictedEntry: func(entry *cache.Entry) {
-			metrics := entry.Value.(*clientCertExpirationMetrics)
-			// The child metric will continue to report into the parent metric even
-			// after unlinking, so we also reset it to 0.
-			metrics.expiration.Update(0)
-			metrics.expiration.Unlink()
-			metrics.ttl.Update(0)
-			metrics.ttl.Unlink()
-			c.mu.acc.Shrink(ctx, int64(unsafe.Sizeof(*metrics)))
-		},
-	})
+	c.mu.cache = make(map[string]map[string]certInfo)
 	c.mon = mon.NewMonitorInheritWithLimit(
 		"client-expiration-cache", 0 /* limit */, parentMon, true, /* longLiving */
 	)
@@ -116,54 +108,42 @@ func NewClientCertExpirationCache(
 
 // GetTTL retrieves seconds till cert expiration for the given username, if it exists.
 // A TTL of 0 indicates an entry was not found.
-func (c *ClientCertExpirationCache) GetTTL(key string) (int64, bool) {
+func (c *ClientCertExpirationCache) GetTTL(user string) int64 {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	value, ok := c.mu.cache.Get(key)
-	if !ok {
-		return 0, ok
+
+	expiration := c.getExpirationLocked(user)
+	ttl := expiration - c.timeNow()
+
+	if ttl > 0 {
+		return ttl
+	} else {
+		return 0
 	}
-	// If the metrics has already been reached, remove the entry and indicate
-	// that the entry was not found.
-	metrics := value.(*clientCertExpirationMetrics)
-	if metrics.expiration.Value() < c.timeNow() {
-		c.mu.cache.Del(key)
-		return 0, false
-	}
-	return metrics.ttl.Value(), ok
 }
 
 // GetExpiration retrieves the cert expiration for the given username, if it exists.
 // An expiration of 0 indicates an entry was not found.
-func (c *ClientCertExpirationCache) GetExpiration(key string) (int64, bool) {
+func (c *ClientCertExpirationCache) GetExpiration(user string) int64 {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	value, ok := c.mu.cache.Get(key)
-	if !ok {
-		return 0, ok
-	}
-	// If the metrics has already been reached, remove the entry and indicate
-	// that the entry was not found.
-	metrics := value.(*clientCertExpirationMetrics)
-	if metrics.expiration.Value() < c.timeNow() {
-		c.mu.cache.Del(key)
-		return 0, false
-	}
-	return metrics.expiration.Value(), ok
+
+	return c.getExpirationLocked(user)
 }
 
-// ttlFunc returns a function function which takes a time,
-// if the time is past returns 0, otherwise returns the number
-// of seconds until that timestamp
-func ttlFunc(now func() int64, exp int64) func() int64 {
-	return func() int64 {
-		ttl := exp - now()
-		if ttl > 0 {
-			return ttl
-		} else {
-			return 0
+func (c *ClientCertExpirationCache) getExpirationLocked(user string) int64 {
+	if certs, ok := c.mu.cache[user]; ok {
+		// compute the earliest expiration time.
+		var minExpiration int64
+		for _, cert := range certs {
+			if minExpiration == 0 || cert.expiration < minExpiration {
+				minExpiration = cert.expiration
+			}
 		}
+
+		return minExpiration
 	}
+	return 0
 }
 
 // MaybeUpsert may update or insert a client cert expiration gauge for a
@@ -171,32 +151,35 @@ func ttlFunc(now func() int64, exp int64) func() int64 {
 // old expiration is after the new expiration. This ensures that the cache
 // maintains the minimum expiration for each user.
 func (c *ClientCertExpirationCache) MaybeUpsert(
-	ctx context.Context,
-	key string,
-	newExpiry int64,
-	parentExpirationGauge *aggmetric.AggGauge,
-	parentTTLGauge *aggmetric.AggGauge,
+	ctx context.Context, user string, serial string, newExpiry int64,
 ) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	value, ok := c.mu.cache.Get(key)
-	if !ok {
-		err := c.mu.acc.Grow(ctx, int64(unsafe.Sizeof(clientCertExpirationMetrics{})))
-		if err == nil {
-			// Only create new gauges for expirations in the future.
-			if newExpiry > c.timeNow() {
-				expiration := parentExpirationGauge.AddChild(key)
-				expiration.Update(newExpiry)
-				ttl := parentTTLGauge.AddFunctionalChild(ttlFunc(c.timeNow, newExpiry), key)
-				c.mu.cache.Add(key, &clientCertExpirationMetrics{expiration, ttl})
-			}
-		} else {
+	// if the user is not in the cache, add them, and add their expiration to a gauge.
+	if _, ok := c.mu.cache[user]; !ok {
+		err := c.mu.acc.Grow(ctx, 2*GaugeSize)
+		if err != nil {
 			log.Ops.Warningf(ctx, "no memory available to cache cert expiry: %v", err)
+			return
 		}
-	} else if metrics := value.(*clientCertExpirationMetrics); newExpiry < metrics.expiration.Value() || metrics.expiration.Value() == 0 {
-		metrics.expiration.Update(newExpiry)
-		metrics.ttl.UpdateFn(ttlFunc(c.timeNow, newExpiry))
+		c.mu.cache[user] = map[string]certInfo{}
+		c.mu.expirationMetrics.AddFunctionalChild(func() int64 { return c.GetExpiration(user) }, user)
+		c.mu.ttlMetrics.AddFunctionalChild(func() int64 { return c.GetTTL(user) }, user)
+
+	}
+
+	err := c.mu.acc.Grow(ctx, CertInfoSize)
+	if err != nil {
+		log.Warningf(ctx, "no memory available to cache cert expiry: %v", err)
+		c.evictLocked(ctx, user, serial)
+	}
+
+	// insert / update the certificate expiration time.
+	certs := c.mu.cache[user]
+	certs[serial] = certInfo{
+		expiration: newExpiry,
+		last_seen:  timeutil.Unix(c.timeNow(), 0),
 	}
 }
 
@@ -204,14 +187,20 @@ func (c *ClientCertExpirationCache) MaybeUpsert(
 func (c *ClientCertExpirationCache) Clear() {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	c.mu.cache.Clear()
+
+	for user, certs := range c.mu.cache {
+		for serial := range certs {
+			c.evictLocked(context.Background(), user, serial)
+		}
+	}
 }
 
 // Len returns the number of cert expirations in the cache.
 func (c *ClientCertExpirationCache) Len() int {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	return c.mu.cache.Len()
+
+	return len(c.mu.cache)
 }
 
 // timeNow returns the current time depending on the time source of the cache.
@@ -220,6 +209,14 @@ func (c *ClientCertExpirationCache) timeNow() int64 {
 		return timeSrc.Now().Unix()
 	}
 	return timeutil.Now().Unix()
+}
+
+// timeSince returns the current time depending on the time source of the cache.
+func (c *ClientCertExpirationCache) timeSince(t time.Time) time.Duration {
+	if timeSrc, ok := c.timeSrc.(timeutil.TimeSource); ok {
+		return timeSrc.Since(t)
+	}
+	return timeutil.Since(t)
 }
 
 // startPurgePastExpirations runs an infinite loop in a goroutine which
@@ -237,7 +234,7 @@ func (c *ClientCertExpirationCache) startPurgePastExpirations(ctx context.Contex
 			select {
 			case <-timer.C:
 				timer.Read = true
-				c.PurgePastExpirations()
+				c.Purge(ctx)
 			case <-c.stopper.ShouldQuiesce():
 				return
 			case <-ctx.Done():
@@ -248,22 +245,37 @@ func (c *ClientCertExpirationCache) startPurgePastExpirations(ctx context.Contex
 	)
 }
 
-// PurgePastExpirations removes entries associated with expiration values that
-// have already passed. This helps ensure that the cache contains gauges
-// with expiration values in the future only.
-func (c *ClientCertExpirationCache) PurgePastExpirations() {
+// Purge removes any certificates which have not been seen in the last 24 hours.
+func (c *ClientCertExpirationCache) Purge(ctx context.Context) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	var deleteEntryKeys []interface{}
-	now := c.timeNow()
-	c.mu.cache.Do(func(entry *cache.Entry) {
-		metrics := entry.Value.(*clientCertExpirationMetrics)
-		if metrics.expiration.Value() <= now {
-			deleteEntryKeys = append(deleteEntryKeys, entry.Key)
+
+	for user, certs := range c.mu.cache {
+		for serial, cert := range certs {
+			if c.timeSince(cert.last_seen) >= CacheTTL {
+				c.evictLocked(ctx, user, serial)
+			}
 		}
-	})
-	for _, key := range deleteEntryKeys {
-		c.mu.cache.Del(key)
+	}
+}
+
+func (c *ClientCertExpirationCache) Account() *mon.BoundAccount {
+	return &c.mu.acc
+}
+
+// evictLocked is a utility function for removing a specific certificate from the
+// cache and removing the corresponding user if they have no more certificates.
+func (c *ClientCertExpirationCache) evictLocked(ctx context.Context, user, serial string) {
+	c.mu.acc.Shrink(ctx, CertInfoSize)
+	delete(c.mu.cache[user], serial)
+
+	// if there are no more certificates for the user, remove the user from the cache.
+	// and remove their corresponding gauge.
+	if len(c.mu.cache[user]) == 0 {
+		delete(c.mu.cache, user)
+		c.mu.acc.Shrink(ctx, 2*GaugeSize)
+		c.mu.expirationMetrics.RemoveChild(user)
+		c.mu.ttlMetrics.RemoveChild(user)
 	}
 }
 

--- a/pkg/security/clientcert/cert_expiry_cache_test.go
+++ b/pkg/security/clientcert/cert_expiry_cache_test.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/security/clientcert"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
@@ -22,102 +23,104 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestEntryCache(t *testing.T) {
-	defer leaktest.AfterTest(t)()
+var defaultSerial = "1"
+var secondarySerial = "2"
 
-	const (
-		fooUser  = "foo"
-		barUser  = "bar"
-		blahUser = "blah"
-		fakeUser = "fake"
-
-		laterExpiration  = int64(1684359292)
-		closerExpiration = int64(1584359292)
-	)
-
+func setup(t *testing.T) (context.Context, *timeutil.ManualTime, *stop.Stopper, func()) {
 	ctx := context.Background()
+	stopper := stop.NewStopper()
 
-	timesource := timeutil.NewManualTime(timeutil.Unix(0, 123))
-	// Create a cache with a capacity of 3.
-	cache, expMetric, ttlMetric := newCache(
-		ctx,
-		&cluster.Settings{},
-		3, /* capacity */
-		timesource,
-	)
+	clock := timeutil.NewManualTime(timeutil.Now())
+	leaktestChecker := leaktest.AfterTest(t)
+
+	teardown := func() {
+		stopper.Stop(ctx)
+		leaktestChecker()
+	}
+
+	return ctx, clock, stopper, teardown
+}
+
+func metricsHasUser(metrics *aggmetric.AggGauge, user string) bool {
+	has := false
+	metrics.Each([]*io_prometheus_client.LabelPair{}, func(metric *io_prometheus_client.Metric) {
+		if metric.GetLabel()[0].GetValue() == user {
+			has = true
+		}
+	})
+	return has
+}
+
+func assertMetricsHasUser(
+	t *testing.T, expiration *aggmetric.AggGauge, ttl *aggmetric.AggGauge, user string,
+) {
+	if !metricsHasUser(expiration, user) {
+		t.Fatal("expiration metrics does not contain user", user)
+	}
+	if !metricsHasUser(ttl, user) {
+		t.Fatal("ttl metrics does not contain user", user)
+	}
+}
+
+func assertMetricsMissingUser(
+	t *testing.T, expiration *aggmetric.AggGauge, ttl *aggmetric.AggGauge, user string,
+) {
+	if metricsHasUser(expiration, user) {
+		t.Fatal("expiration metrics does not contain user", user)
+	}
+	if metricsHasUser(ttl, user) {
+		t.Fatal("ttl metrics does not contain user", user)
+	}
+}
+
+func TestEntryCache(t *testing.T) {
+	ctx, clock, stopper, teardown := setup(t)
+	defer teardown()
+
+	fooUser := "foo"
+	barUser := "bar"
+	fakeUser := "fake"
+
+	laterExpiration := timeutil.Now().Add(100 * time.Second).Unix()
+	closerExpiration := timeutil.Now().Unix()
+
+	cache := newCache(ctx, clock, stopper)
 	require.Equal(t, 0, cache.Len())
 
 	// Verify insert.
-	cache.MaybeUpsert(ctx, fooUser, laterExpiration, expMetric, ttlMetric)
+	cache.MaybeUpsert(ctx, fooUser, defaultSerial, laterExpiration)
 	require.Equal(t, 1, cache.Len())
 
 	// Verify update.
-	cache.MaybeUpsert(ctx, fooUser, closerExpiration, expMetric, ttlMetric)
+	cache.MaybeUpsert(ctx, fooUser, defaultSerial, closerExpiration)
 	require.Equal(t, 1, cache.Len())
 
 	// Verify retrieval.
-	expiration, found := cache.GetExpiration(fooUser)
-	require.Equal(t, true, found)
+	expiration := cache.GetExpiration(fooUser)
 	require.Equal(t, closerExpiration, expiration)
 
 	// Verify the cache retains the minimum expiration for a user, assuming no
 	// eviction.
-	cache.MaybeUpsert(ctx, barUser, closerExpiration, expMetric, ttlMetric)
+	cache.MaybeUpsert(ctx, barUser, defaultSerial, closerExpiration)
 	require.Equal(t, 2, cache.Len())
-	cache.MaybeUpsert(ctx, barUser, laterExpiration, expMetric, ttlMetric)
+	cache.MaybeUpsert(ctx, barUser, secondarySerial, laterExpiration)
 	require.Equal(t, 2, cache.Len())
-	expiration, found = cache.GetExpiration(barUser)
-	require.Equal(t, true, found)
+	expiration = cache.GetExpiration(barUser)
 	require.Equal(t, closerExpiration, expiration)
 
 	// Verify indication of absence for non-existent values.
-	expiration, found = cache.GetExpiration(fakeUser)
-	require.Equal(t, false, found)
+	expiration = cache.GetExpiration(fakeUser)
 	require.Equal(t, int64(0), expiration)
-
-	// Verify eviction when the capacity is exceeded.
-	cache.MaybeUpsert(ctx, blahUser, laterExpiration, expMetric, ttlMetric)
-	require.Equal(t, 3, cache.Len())
-	cache.MaybeUpsert(ctx, fakeUser, closerExpiration, expMetric, ttlMetric)
-	require.Equal(t, 3, cache.Len())
-	_, found = cache.GetExpiration(fooUser)
-	require.Equal(t, false, found)
-	_, found = cache.GetExpiration(barUser)
-	require.Equal(t, true, found)
-
-	// Verify previous entries can be inserted after the cache is cleared.
-	cache.Clear()
-	require.Equal(t, 0, cache.Len())
-	_, found = cache.GetExpiration(fooUser)
-	require.Equal(t, false, found)
-	_, found = cache.GetExpiration(barUser)
-	require.Equal(t, false, found)
-	cache.MaybeUpsert(ctx, fooUser, laterExpiration, expMetric, ttlMetric)
-	require.Equal(t, 1, cache.Len())
-	cache.MaybeUpsert(ctx, barUser, laterExpiration, expMetric, ttlMetric)
-	require.Equal(t, 2, cache.Len())
-	expiration, found = cache.GetExpiration(fooUser)
-	require.Equal(t, true, found)
-	require.Equal(t, laterExpiration, expiration)
-	expiration, found = cache.GetExpiration(barUser)
-	require.Equal(t, true, found)
-	require.Equal(t, laterExpiration, expiration)
-
-	// Verify expirations in the past cannot be inserted into the cache.
-	cache.Clear()
-	cache.MaybeUpsert(ctx, fooUser, int64(0), expMetric, ttlMetric)
-	require.Equal(t, 0, cache.Len())
 
 	// Verify value of TTL metrics
 	cache.Clear()
-	timesource.AdvanceTo(timeutil.Unix(closerExpiration+20, 0))
-	cache.MaybeUpsert(ctx, fooUser, closerExpiration, expMetric, ttlMetric)
-	cache.MaybeUpsert(ctx, barUser, laterExpiration, expMetric, ttlMetric)
-	ttl, found := cache.GetTTL(fooUser)
-	require.Equal(t, false, found)
+	when := timeutil.Unix(closerExpiration+20, 0)
+	clock.AdvanceTo(when)
+	cache.MaybeUpsert(ctx, fooUser, defaultSerial, closerExpiration)
+	cache.MaybeUpsert(ctx, barUser, defaultSerial, laterExpiration)
+	ttl := cache.GetTTL(fooUser)
 	require.Equal(t, int64(0), ttl)
-	ttl, found = cache.GetTTL(barUser)
-	require.Equal(t, true, found)
+	ttl = cache.GetTTL(barUser)
 	require.Equal(t, laterExpiration-(closerExpiration+20), ttl)
 }
 
@@ -125,7 +128,8 @@ func TestEntryCache(t *testing.T) {
 // when entries are inserted and updated. It checks that the cache length and
 // expiration times are properly updated and reflected in the metrics.
 func TestCacheMetricsSync(t *testing.T) {
-	defer leaktest.AfterTest(t)()
+	ctx, clock, stopper, teardown := setup(t)
+	defer teardown()
 
 	findChildMetric := func(metrics *aggmetric.AggGauge, childName string) *io_prometheus_client.Metric {
 		var result *io_prometheus_client.Metric
@@ -137,100 +141,94 @@ func TestCacheMetricsSync(t *testing.T) {
 		return result
 	}
 
-	const (
-		fooUser = "foo"
+	fooUser := "foo"
 
-		laterExpiration  = int64(1684359292)
-		closerExpiration = int64(1584359292)
-	)
+	laterExpiration := timeutil.Now().Add(100 * time.Second).Unix()
+	closerExpiration := timeutil.Now().Unix()
+	clock.Backwards(time.Second * time.Duration(clock.Now().Unix()))
 
-	ctx := context.Background()
-
-	timesource := timeutil.NewManualTime(timeutil.Unix(0, 123))
-	// Create a cache with a capacity of 3.
-	cache, expMetric, ttlMetric := newCache(
-		ctx,
-		&cluster.Settings{},
-		3, /* capacity */
-		timesource,
-	)
+	cache, expMetric, ttlMetric := newCacheAndMetrics(ctx, clock, stopper)
 	require.Equal(t, 0, cache.Len())
 
 	// insert.
-	cache.MaybeUpsert(ctx, fooUser, laterExpiration, expMetric, ttlMetric)
+	cache.MaybeUpsert(ctx, fooUser, defaultSerial, laterExpiration)
 	// update.
-	cache.MaybeUpsert(ctx, fooUser, closerExpiration, expMetric, ttlMetric)
+	cache.MaybeUpsert(ctx, fooUser, defaultSerial, closerExpiration)
 
-	metricFloat := *(findChildMetric(expMetric, fooUser).Gauge.Value)
-	expiration, found := cache.GetExpiration(fooUser)
+	expFloat := *(findChildMetric(expMetric, fooUser).Gauge.Value)
+	expiration := cache.GetExpiration(fooUser)
+	ttlFloat := *(findChildMetric(ttlMetric, fooUser).Gauge.Value)
+	ttl := cache.GetTTL(fooUser)
 
 	// verify that both the cache and metric are in sync.
-	require.Equal(t, true, found)
 	require.Equal(t, closerExpiration, expiration)
-	require.Equal(t, closerExpiration, int64(metricFloat))
+	require.Equal(t, closerExpiration, int64(expFloat))
+	require.Equal(t, closerExpiration, ttl)
+	require.Equal(t, closerExpiration, int64(ttlFloat))
 }
 
-func TestPurgePastEntries(t *testing.T) {
-	defer leaktest.AfterTest(t)()
+func TestPurge(t *testing.T) {
+	ctx, clock, stopper, teardown := setup(t)
+	defer teardown()
 
-	const (
-		fooUser  = "foo"
-		barUser  = "bar"
-		blahUser = "blah"
-		bazUser  = "baz"
+	t.Run("Purge empty cache", func(t *testing.T) {
+		cache := newCache(ctx, clock, stopper)
+		// nothing scary happens.
+		cache.Purge(ctx)
+	})
 
-		pastExpiration1  = int64(1000000000)
-		pastExpiration2  = int64(2000000000)
-		futureExpiration = int64(3000000000)
-	)
+	t.Run("Purge when no certificates are evictable", func(t *testing.T) {
+		cache, expirationMetrics, ttlMetrics := newCacheAndMetrics(ctx, clock, stopper)
+		cache.MaybeUpsert(ctx, "user1", "serial1", 100)
+		cache.Purge(ctx)
+		require.Equal(t, int64(100), cache.GetExpiration("user1"))
+		assertMetricsHasUser(t, expirationMetrics, ttlMetrics, "user1")
+	})
 
-	ctx := context.Background()
+	t.Run("Purge last certificate for a user", func(t *testing.T) {
+		cache, expirationMetrics, ttlMetrics := newCacheAndMetrics(ctx, clock, stopper)
+		cache.MaybeUpsert(ctx, "user1", "serial1", 100)
+		clock.Advance(time.Minute)
+		cache.Purge(ctx)
+		require.Equal(t, int64(0), cache.GetExpiration("user1"))
+		assertMetricsMissingUser(t, expirationMetrics, ttlMetrics, "user1")
+	})
 
-	// Create a cache with a capacity of 4.
-	clock := timeutil.NewManualTime(timeutil.Unix(0, 123))
-	cache, expMetric, ttlMetric := newCache(ctx, &cluster.Settings{}, 4 /* capacity */, clock)
+	t.Run("Purge not the last certificate for a user", func(t *testing.T) {
+		cache, expirationMetrics, ttlMetrics := newCacheAndMetrics(ctx, clock, stopper)
+		cache.MaybeUpsert(ctx, "user1", "serial1", 100)
+		clock.Advance(time.Minute)
+		cache.MaybeUpsert(ctx, "user1", "serial2", 120)
+		cache.Purge(ctx)
+		require.Equal(t, int64(120), cache.GetExpiration("user1"))
+		assertMetricsHasUser(t, expirationMetrics, ttlMetrics, "user1")
+	})
 
-	// Insert entries that we expect to be cleaned up after advancing in time.
-	cache.MaybeUpsert(ctx, fooUser, pastExpiration1, expMetric, ttlMetric)
-	cache.MaybeUpsert(ctx, barUser, pastExpiration2, expMetric, ttlMetric)
-	cache.MaybeUpsert(ctx, blahUser, pastExpiration2, expMetric, ttlMetric)
-	// Insert an entry that should NOT be removed after advancing in time
-	// because it is still in the future.
-	cache.MaybeUpsert(ctx, bazUser, futureExpiration, expMetric, ttlMetric)
-	require.Equal(t, 4, cache.Len())
+	t.Run("Purge certificates for multiple users", func(t *testing.T) {
+		// In this test, user1 will have two certificates, and user2 will have one.
+		// One certificate for each user will be purged, and therefore user1 will
+		// be the only user "left" in the cache.
+		cache, expirationMetrics, ttlMetrics := newCacheAndMetrics(ctx, clock, stopper)
+		cache.MaybeUpsert(ctx, "user1", "serial1", 100)
+		cache.MaybeUpsert(ctx, "user2", "serial2", 65)
+		clock.Advance(time.Minute)
+		cache.MaybeUpsert(ctx, "user1", "serial3", 150)
+		cache.Purge(ctx)
 
-	// Advance time so that expirations have been reached already.
-	clock.AdvanceTo(timeutil.Unix(2000000000, 123))
-
-	// Verify an expiration from the past cannot be retrieved. Confirm it has
-	// been removed after the attempt as well.
-	_, found := cache.GetExpiration(fooUser)
-	require.Equal(t, false, found)
-	require.Equal(t, 3, cache.Len())
-
-	// Verify that when the cache gets cleaned of the past expirations.
-	// Confirm that expirations in the future do not get removed.
-	cache.PurgePastExpirations()
-	require.Equal(t, 1, cache.Len())
-	_, found = cache.GetExpiration(bazUser)
-	require.Equal(t, true, found)
+		// verify that user 1 still exists, but user2 is gone.
+		require.Equal(t, int64(150), cache.GetExpiration("user1"))
+		assertMetricsHasUser(t, expirationMetrics, ttlMetrics, "user1")
+		require.Equal(t, int64(0), cache.GetExpiration("user2"))
+		assertMetricsMissingUser(t, expirationMetrics, ttlMetrics, "user2")
+	})
 }
 
 // TestConcurrentUpdates ensures that concurrent updates do not race with each
 // other.
 func TestConcurrentUpdates(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-
-	ctx := context.Background()
-	st := &cluster.Settings{}
-
-	// Create a cache with a large capacity.
-	cache, expMetric, ttlMetric := newCache(
-		ctx,
-		st,
-		10000, /* capacity */
-		timeutil.NewManualTime(timeutil.Unix(0, 123)),
-	)
+	ctx, clock, stopper, teardown := setup(t)
+	defer teardown()
+	cache := newCache(ctx, clock, stopper)
 
 	var (
 		user       = "testUser"
@@ -244,7 +242,7 @@ func TestConcurrentUpdates(t *testing.T) {
 	for i := 0; i < N; i++ {
 		go func(i int) {
 			if i%2 == 1 {
-				cache.MaybeUpsert(ctx, user, expiration, expMetric, ttlMetric)
+				cache.MaybeUpsert(ctx, user, defaultSerial, expiration)
 			} else {
 				cache.Clear()
 			}
@@ -255,30 +253,248 @@ func TestConcurrentUpdates(t *testing.T) {
 	cache.Clear()
 }
 
+func TestUpsert(t *testing.T) {
+	ctx, clock, stopper, teardown := setup(t)
+	defer teardown()
+	cache, expirationMetrics, ttlMetrics := newCacheAndMetrics(ctx, clock, stopper)
+
+	// check no users in cache.
+	require.Equal(t, int64(0), cache.GetExpiration("user1"))
+	assertMetricsMissingUser(t, expirationMetrics, ttlMetrics, "user1")
+	require.Equal(t, int64(0), cache.GetExpiration("user2"))
+	assertMetricsMissingUser(t, expirationMetrics, ttlMetrics, "user2")
+
+	cache.MaybeUpsert(ctx, "user1", "serial1", 100)
+
+	// check user1 in cache.
+	require.Equal(t, int64(100), cache.GetExpiration("user1"))
+	assertMetricsHasUser(t, expirationMetrics, ttlMetrics, "user1")
+	// check user 2 not in the cache.
+	require.Equal(t, int64(0), cache.GetExpiration("user2"))
+	assertMetricsMissingUser(t, expirationMetrics, ttlMetrics, "user2")
+
+	cache.MaybeUpsert(ctx, "user2", "serial2", 90)
+
+	// check both in cache now.
+	require.Equal(t, int64(100), cache.GetExpiration("user1"))
+	assertMetricsHasUser(t, expirationMetrics, ttlMetrics, "user1")
+	require.Equal(t, int64(90), cache.GetExpiration("user2"))
+	assertMetricsHasUser(t, expirationMetrics, ttlMetrics, "user2")
+}
+
+func TestClear(t *testing.T) {
+	ctx, clock, stopper, teardown := setup(t)
+	defer teardown()
+	cache, expirationMetrics, ttlMetrics := newCacheAndMetrics(ctx, clock, stopper)
+
+	// Set up a user with multiple expired certificates.
+	cache.MaybeUpsert(ctx, "user1", "serial1", 5)
+	cache.MaybeUpsert(ctx, "user1", "serial2", 10)
+	// Set up a user with a single expired, and one unexpired ceritificate.
+	cache.MaybeUpsert(ctx, "user2", "serial3", 15)
+	// Set up a user with a single expired certificate.
+	cache.MaybeUpsert(ctx, "user3", "serial4", 20)
+
+	clock.Advance(time.Minute)
+
+	// user2's unexpired certificate.
+	cache.MaybeUpsert(ctx, "user2", "serial5", 25)
+
+	// Set up a user with no expired certificates.
+	cache.MaybeUpsert(ctx, "user4", "serial6", 30)
+
+	// Verify initial state
+	assertMetricsHasUser(t, expirationMetrics, ttlMetrics, "user1")
+	require.Equal(t, int64(5), cache.GetExpiration("user1"))
+	assertMetricsHasUser(t, expirationMetrics, ttlMetrics, "user2")
+	require.Equal(t, int64(15), cache.GetExpiration("user2"))
+	assertMetricsHasUser(t, expirationMetrics, ttlMetrics, "user3")
+	require.Equal(t, int64(20), cache.GetExpiration("user3"))
+	assertMetricsHasUser(t, expirationMetrics, ttlMetrics, "user4")
+	require.Equal(t, int64(30), cache.GetExpiration("user4"))
+	// check for a user who will be added after the clear call.
+	assertMetricsMissingUser(t, expirationMetrics, ttlMetrics, "user5")
+	require.Equal(t, int64(0), cache.GetExpiration("user5"))
+	// check for a user who is not in the cache.
+	assertMetricsMissingUser(t, expirationMetrics, ttlMetrics, "user6")
+	require.Equal(t, int64(0), cache.GetExpiration("user6"))
+
+	// Clear all certificates
+	cache.Clear()
+
+	cache.MaybeUpsert(ctx, "user5", "serial7", 35)
+
+	// Verify final state - all users should be removed
+	assertMetricsMissingUser(t, expirationMetrics, ttlMetrics, "user1")
+	require.Equal(t, int64(0), cache.GetExpiration("user1"))
+	assertMetricsMissingUser(t, expirationMetrics, ttlMetrics, "user2")
+	require.Equal(t, int64(0), cache.GetExpiration("user2"))
+	assertMetricsMissingUser(t, expirationMetrics, ttlMetrics, "user3")
+	require.Equal(t, int64(0), cache.GetExpiration("user3"))
+	assertMetricsMissingUser(t, expirationMetrics, ttlMetrics, "user4")
+	require.Equal(t, int64(0), cache.GetExpiration("user4"))
+	// nothing changes for a user who has never been seen.
+	assertMetricsMissingUser(t, expirationMetrics, ttlMetrics, "user6")
+	require.Equal(t, int64(0), cache.GetExpiration("user6"))
+
+	// user5 should be the only one in the cache.
+	assertMetricsHasUser(t, expirationMetrics, ttlMetrics, "user5")
+	require.Equal(t, int64(35), cache.GetExpiration("user5"))
+}
+
+func TestAllocationTracking(t *testing.T) {
+	ctx, clock, stopper, teardown := setup(t)
+	defer teardown()
+
+	var certInfoSize, gaugeSize = clientcert.CertInfoSize, clientcert.GaugeSize
+
+	t.Run("starts at zero", func(t *testing.T) {
+		account := newCache(ctx, clock, stopper).Account()
+		// verify no usage to start
+		require.Equal(t, int64(0), account.Used())
+	})
+
+	t.Run("increases two gauge and num certs per user", func(t *testing.T) {
+		cache := newCache(ctx, clock, stopper)
+		account := cache.Account()
+		cache.MaybeUpsert(ctx, "user1", "serial1", 100)
+		cache.MaybeUpsert(ctx, "user1", "serial2", 120)
+		cache.MaybeUpsert(ctx, "user2", "serial3", 65)
+		cache.MaybeUpsert(ctx, "user2", "serial4", 75)
+		require.Equal(t, (4*certInfoSize)+(4*gaugeSize), account.Used())
+	})
+
+	t.Run("Purge removes the gauges and cert allocations correctly", func(t *testing.T) {
+		cache := newCache(ctx, clock, stopper)
+		account := cache.Account()
+		cache.MaybeUpsert(ctx, "user1", "serial1", 100)
+		cache.MaybeUpsert(ctx, "user1", "serial2", 120)
+		cache.MaybeUpsert(ctx, "user2", "serial3", 65)
+		clock.Advance(time.Minute)
+		cache.Purge(ctx)
+		cache.MaybeUpsert(ctx, "user2", "serial4", 75)
+		require.Equal(t, certInfoSize+(2*gaugeSize), account.Used())
+	})
+
+	t.Run("Clear also removes the gauges and cert allocations correctly", func(t *testing.T) {
+		cache := newCache(ctx, clock, stopper)
+		account := cache.Account()
+		cache.MaybeUpsert(ctx, "user1", "serial1", 100)
+		cache.MaybeUpsert(ctx, "user1", "serial2", 120)
+		cache.MaybeUpsert(ctx, "user2", "serial3", 65)
+		cache.MaybeUpsert(ctx, "user2", "serial4", 75)
+		cache.Clear()
+		require.Equal(t, int64(0), account.Used())
+	})
+}
+
+func TestGetExpiration(t *testing.T) {
+	ctx, clock, stopper, teardown := setup(t)
+	defer teardown()
+
+	t.Run("basic test", func(t *testing.T) {
+		cache := newCache(ctx, clock, stopper)
+		cache.MaybeUpsert(ctx, "user1", "serial1", 100)
+		require.Equal(t, int64(100), cache.GetExpiration("user1"))
+	})
+
+	// This should work, but it's unlikely this is a possible use case.
+	t.Run("update existing certificate", func(t *testing.T) {
+		cache := newCache(ctx, clock, stopper)
+		cache.MaybeUpsert(ctx, "user1", "serial1", 100)
+		cache.MaybeUpsert(ctx, "user1", "serial1", 90)
+		require.Equal(t, int64(90), cache.GetExpiration("user1"))
+	})
+
+	t.Run("multiple certs for a single user", func(t *testing.T) {
+		cache := newCache(ctx, clock, stopper)
+		cache.MaybeUpsert(ctx, "user1", "serial1", 120)
+		cache.MaybeUpsert(ctx, "user1", "serial2", 80)
+		// verify that the lowest expiration is chosen.
+		require.Equal(t, int64(80), cache.GetExpiration("user1"))
+
+		// verify that when last inserted doesn't matter.
+		cache.MaybeUpsert(ctx, "user1", "serial3", 100)
+		require.Equal(t, int64(80), cache.GetExpiration("user1"))
+	})
+
+	t.Run("multiple users", func(t *testing.T) {
+		cache := newCache(ctx, clock, stopper)
+		cache.MaybeUpsert(ctx, "user1", "serial1", 80)
+		cache.MaybeUpsert(ctx, "user2", "serial2", 120)
+		cache.MaybeUpsert(ctx, "user3", "serial3", 60)
+
+		require.Equal(t, int64(80), cache.GetExpiration("user1"))
+		require.Equal(t, int64(120), cache.GetExpiration("user2"))
+		require.Equal(t, int64(60), cache.GetExpiration("user3"))
+	})
+
+	t.Run("returns nothing when the certificates are purged", func(t *testing.T) {
+		cache := newCache(ctx, clock, stopper)
+		cache.MaybeUpsert(ctx, "user1", "serial1", 100)
+		clock.Advance(time.Minute)
+		cache.Purge(ctx)
+		require.Equal(t, int64(0), cache.GetExpiration("user1"))
+	})
+}
+
+func TestGetTTL(t *testing.T) {
+	ctx, _, stopper, teardown := setup(t)
+	defer teardown()
+
+	t.Run("reports ttl based on expiration", func(t *testing.T) {
+		manClock := timeutil.NewManualTime(time.Unix(50, 0))
+		cache := newCache(ctx, manClock, stopper)
+
+		cache.MaybeUpsert(ctx, "user1", "serial1", 100)
+
+		require.Equal(t, int64(50), cache.GetTTL("user1"))
+	})
+
+	t.Run("negative ttls get clamped to 0", func(t *testing.T) {
+		manClock := timeutil.NewManualTime(time.Unix(50, 0))
+		cache := newCache(ctx, manClock, stopper)
+		cache.MaybeUpsert(ctx, "user1", "serial1", 49)
+
+		require.Equal(t, int64(0), cache.GetTTL("user1"))
+	})
+}
+
 func BenchmarkCertExpirationCacheInsert(b *testing.B) {
 	ctx := context.Background()
-	st := &cluster.Settings{}
 	clock := timeutil.NewManualTime(timeutil.Unix(0, 123))
-	cache, expMetric, ttlMetric := newCache(ctx, st, 1000 /* capacity */, clock)
+	stopper := stop.NewStopper()
+	defer stopper.Stop(ctx)
+	cache := newCache(ctx, clock, stopper)
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		cache.MaybeUpsert(ctx, "foo", clock.Now().Unix(), expMetric, ttlMetric)
-		cache.MaybeUpsert(ctx, "bar", clock.Now().Unix(), expMetric, ttlMetric)
-		cache.MaybeUpsert(ctx, "blah", clock.Now().Unix(), expMetric, ttlMetric)
+		cache.MaybeUpsert(ctx, "foo", defaultSerial, clock.Now().Unix())
+		cache.MaybeUpsert(ctx, "bar", defaultSerial, clock.Now().Unix())
+		cache.MaybeUpsert(ctx, "blah", defaultSerial, clock.Now().Unix())
 	}
 }
 
 func newCache(
-	ctx context.Context, st *cluster.Settings, capacity int, clock *timeutil.ManualTime,
+	ctx context.Context, clock *timeutil.ManualTime, stopper *stop.Stopper,
+) *clientcert.ClientCertExpirationCache {
+	cache, _, _ := newCacheAndMetrics(ctx, clock, stopper)
+	return cache
+}
+
+func newCacheAndMetrics(
+	ctx context.Context, clock *timeutil.ManualTime, stopper *stop.Stopper,
 ) (*clientcert.ClientCertExpirationCache, *aggmetric.AggGauge, *aggmetric.AggGauge) {
-	stopper := stop.NewStopper()
-	defer stopper.Stop(ctx)
-	clientcert.ClientCertExpirationCacheCapacity.Override(ctx, &st.SV, int64(capacity))
+	st := &cluster.Settings{}
 	parentMon := mon.NewUnlimitedMonitor(ctx, mon.Options{
 		Name:     mon.MakeMonitorName("test"),
 		Settings: st,
 	})
-	cache := clientcert.NewClientCertExpirationCache(ctx, st, stopper, clock, parentMon)
-	return cache, aggmetric.MakeBuilder("user").Gauge(metric.Metadata{}), aggmetric.MakeBuilder("user").Gauge(metric.Metadata{})
+
+	clientcert.CacheTTL = time.Minute
+
+	expirationMetrics := aggmetric.MakeBuilder("user").Gauge(metric.Metadata{})
+	ttlMetrics := aggmetric.MakeBuilder("user").Gauge(metric.Metadata{})
+	cache := clientcert.NewClientCertExpirationCache(ctx, st, stopper, clock, parentMon, expirationMetrics, ttlMetrics)
+	return cache, expirationMetrics, ttlMetrics
 }

--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -170,7 +170,6 @@ go_library(
         "//pkg/scheduledjobs",
         "//pkg/security",
         "//pkg/security/certnames",
-        "//pkg/security/clientcert",
         "//pkg/security/clientsecopts",
         "//pkg/security/username",
         "//pkg/server/apiconstants",

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -48,7 +48,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/rpc/nodedialer"
 	"github.com/cockroachdb/cockroach/pkg/scheduledjobs"
-	"github.com/cockroachdb/cockroach/pkg/security/clientcert"
 	"github.com/cockroachdb/cockroach/pkg/security/clientsecopts"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/server/diagnostics"
@@ -957,9 +956,7 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 			return nil, errors.Wrap(err, "initializing certificate manager")
 		}
 		certMgr.RegisterExpirationCache(
-			clientcert.NewClientCertExpirationCache(
-				ctx, cfg.Settings, cfg.stopper, &timeutil.DefaultTimeSource{}, rootSQLMemoryMonitor,
-			),
+			ctx, cfg.Settings, cfg.stopper, &timeutil.DefaultTimeSource{}, rootSQLMemoryMonitor,
 		)
 	}
 

--- a/pkg/util/metric/aggmetric/counter.go
+++ b/pkg/util/metric/aggmetric/counter.go
@@ -106,6 +106,13 @@ func (c *AggCounter) Inc(i int64, labelVals ...string) {
 	child.Inc(i)
 }
 
+// RemoveChild removes a Gauge from this AggGauge. This method panics if a Gauge
+// does not exist for this set of labelVals.
+func (g *AggCounter) RemoveChild(labelVals ...string) {
+	key := &Counter{labelValuesSlice: labelValuesSlice(labelVals)}
+	g.remove(key)
+}
+
 // Counter is a child of a AggCounter. When it is incremented, so too is the
 // parent. When metrics are collected by prometheus, each of the children will
 // appear with a distinct label, however, when cockroach internally collects

--- a/pkg/util/metric/aggmetric/gauge.go
+++ b/pkg/util/metric/aggmetric/gauge.go
@@ -163,6 +163,13 @@ func (g *AggGauge) getOrCreateChild(labelVals ...string) *Gauge {
 	return child
 }
 
+// RemoveChild removes a Gauge from this AggGauge. This method panics if a Gauge
+// does not exist for this set of labelVals.
+func (g *AggGauge) RemoveChild(labelVals ...string) {
+	key := &Gauge{labelValuesSlice: labelValuesSlice(labelVals)}
+	g.remove(key)
+}
+
 // Gauge is a child of a AggGauge. When it is incremented or decremented, so
 // too is the parent. When metrics are collected by prometheus, each of the
 // children will appear with a distinct label, however, when cockroach

--- a/pkg/util/metric/aggmetric/histogram.go
+++ b/pkg/util/metric/aggmetric/histogram.go
@@ -141,7 +141,7 @@ func (a *AggHistogram) ToPrometheusMetric() *prometheusgo.Metric {
 	return a.h.ToPrometheusMetric()
 }
 
-// AddChild adds a Counter to this AggCounter. This method panics if a Counter
+// AddChild adds a Counter to this AggHistogram. This method panics if a Counter
 // already exists for this set of labelVals.
 func (a *AggHistogram) AddChild(labelVals ...string) *Histogram {
 	child := &Histogram{
@@ -175,6 +175,13 @@ func (a *AggHistogram) RecordValue(v int64, labelVals ...string) {
 	// Otherwise, create a new child and update it.
 	child := a.AddChild(labelVals...)
 	child.RecordValue(v)
+}
+
+// RemoveChild removes a Gauge from this AggGauge. This method panics if a Gauge
+// does not exist for this set of labelVals.
+func (g *AggHistogram) RemoveChild(labelVals ...string) {
+	key := &Histogram{labelValuesSlice: labelValuesSlice(labelVals)}
+	g.remove(key)
 }
 
 // Histogram is a child of a AggHistogram. When values are recorded, so too is the


### PR DESCRIPTION
security: change client cert expiration caching eviction policy

Previously, we cached and emitted metrics for client certificates indefinitely or until they expired. However, this strategy ignores the case where a team rotates their certificates, discontinuing to use soon-to-expire ones, in which crdb would continue to report on their expiration.

This change modifies the caching behavior so that eviction from the cache is based on last usage. It does a few additional things here:
 - Supports the removal of child metrics by key.
 - Removes the `server.client_cert_expiration_cache.capacity` cluster setting.
 - Adds a shared utility for adding jitter.
 - Moves caching and metrics reporting from a single cache to two caches, one for expiration, one for ttl.

Fixes: #142686
Epic: CRDB-40209

Release note (ops change): Cluster setting
`server.client_cert_expiration_cache.capacity` removed. Metrics `security.certificate.expiration.client` and `security.certificate.ttl.client` now report lowest value seen for user in last 24h.