### PR TITLE
roachtest: detect sysbench crashes when preparing workload

### DIFF
--- a/pkg/cmd/roachtest/roachtestutil/utils.go
+++ b/pkg/cmd/roachtest/roachtestutil/utils.go
@@ -279,3 +279,12 @@ func PortLatency(
 	}
 	return time.Duration(avgRTT * float64(time.Second)), nil
 }
+
+// PrefixCmdOutputWithTimestamp wraps a remote command such that it pipes
+// stdout and stderr through awk and prepends the timestamp. Can be used to aid
+// debugging long-running commands that don't already prefix output with timestamps.
+func PrefixCmdOutputWithTimestamp(cmd string) string {
+	// Don't prefix blank lines with timestamps.
+	awkCmd := `awk 'NF { cmd="date +\"%H:%M:%S\""; cmd | getline ts; close(cmd); print ts ":", $0; next } { print }'`
+	return fmt.Sprintf(`bash -c '%s' 2>&1 |`, cmd) + awkCmd
+}


### PR DESCRIPTION
Sysbench is known to flake with crashes. Previously, we would detect these crashes when running the workload and pass the run to avoid noise.

This change now does the same when preparing the workload as well. It also skips the test instead of passing the test. This makes it easier to identify tests that actually ran to completion and has consequences for test selection.

We also add a small helper to prefix sysbench output with timestamps, this should aid debugging.

Fixes: https://github.com/cockroachdb/cockroach/issues/141981
Informs: https://github.com/cockroachdb/cockroach/issues/140799
Release note: none