### PR TITLE
wip: prototype of "compiled factories"

### DIFF
--- a/pkg/sql/exec_factory_util.go
+++ b/pkg/sql/exec_factory_util.go
@@ -21,7 +21,6 @@ import (
 )
 
 func constructPlan(
-	planner *planner,
 	root exec.Node,
 	subqueries []exec.Subquery,
 	cascades, triggers []exec.PostQuery,

--- a/pkg/sql/opt/exec/BUILD.bazel
+++ b/pkg/sql/opt/exec/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
     deps = [
         "//pkg/sql/catalog/colinfo",
         "//pkg/sql/catalog/descpb",  # keep
+        "//pkg/sql/idxusage",
         "//pkg/sql/inverted",
         "//pkg/sql/opt",  # keep
         "//pkg/sql/opt/cat",
@@ -21,6 +22,7 @@ go_library(
         "//pkg/sql/types",
         "//pkg/util/intsets",
         "//pkg/util/optional",
+        "@com_github_cockroachdb_errors//:errors",
     ],
 )
 

--- a/pkg/sql/opt/exec/explain/emit.go
+++ b/pkg/sql/opt/exec/explain/emit.go
@@ -293,6 +293,9 @@ func (e *emitter) nodeName(n *Node) (name string, _ error) {
 		}
 		return "scan", nil
 
+	case placeholderScanOp:
+		return "placeholder-scan", nil
+
 	case valuesOp:
 		a := n.args.(*valuesArgs)
 		switch {
@@ -706,6 +709,10 @@ func (e *emitter) emitNodeAttributes(ctx context.Context, evalCtx *eval.Context,
 		}
 		e.emitLockingPolicy(a.Params.Locking)
 		e.emitPolicies(ob, a.Table, n)
+
+	case placeholderScanOp:
+		// a := n.args.(*placeholderScanArgs)
+		e.emitPolicies(ob, nil, n)
 
 	case valuesOp:
 		a := n.args.(*valuesArgs)

--- a/pkg/sql/opt/exec/explain/explain_factory.go
+++ b/pkg/sql/opt/exec/explain/explain_factory.go
@@ -34,6 +34,17 @@ func (f *Factory) Ctx() context.Context {
 	return f.wrappedFactory.Ctx()
 }
 
+// EnableCompilation implements the Factory interface.
+func (f *Factory) EnableCompilation() {}
+
+// DisableCompilation implements the Factory interface.
+func (f *Factory) DisableCompilation() {}
+
+// Compiled implements the Factory interface.
+func (f *Factory) Compiled() exec.CompiledPlan {
+	return nil
+}
+
 // Node in a plan tree; records the operation and arguments passed to the
 // factory method and provides access to the corresponding exec.Node (produced
 // by the wrapped factory).

--- a/pkg/sql/opt/exec/explain/plan_gist_factory.go
+++ b/pkg/sql/opt/exec/explain/plan_gist_factory.go
@@ -34,7 +34,8 @@ import (
 )
 
 func init() {
-	if numOperators != 65 {
+	// TODO
+	if numOperators != 66 {
 		// This error occurs when an operator has been added or removed in
 		// pkg/sql/opt/exec/explain/factory.opt. If an operator is added at the
 		// end of factory.opt, simply adjust the hardcoded value above. If an
@@ -105,6 +106,21 @@ var _ exec.Factory = &PlanGistFactory{}
 // Ctx implements the Factory interface.
 func (f *PlanGistFactory) Ctx() context.Context {
 	return f.wrappedFactory.Ctx()
+}
+
+// EnableCompilation implements the Factory interface.
+func (f *PlanGistFactory) EnableCompilation() {
+	f.wrappedFactory.EnableCompilation()
+}
+
+// DisableCompilation implements the Factory interface.
+func (f *PlanGistFactory) DisableCompilation() {
+	f.wrappedFactory.DisableCompilation()
+}
+
+// Compiled implements the Factory interface.
+func (f *PlanGistFactory) Compiled() exec.CompiledPlan {
+	return f.wrappedFactory.Compiled()
 }
 
 // writeAndHash writes an arbitrary slice of bytes to the buffer and hashes each

--- a/pkg/sql/opt/exec/explain/result_columns.go
+++ b/pkg/sql/opt/exec/explain/result_columns.go
@@ -62,6 +62,10 @@ func getResultColumns(
 		a := args.(*scanArgs)
 		return tableColumns(a.Table, a.Params.NeededCols), nil
 
+	case placeholderScanOp:
+		a := args.(*placeholderScanArgs)
+		return tableColumns(a.Table, a.Params.NeededCols), nil
+
 	case indexJoinOp:
 		a := args.(*indexJoinArgs)
 		return tableColumns(a.Table, a.TableCols), nil

--- a/pkg/sql/opt/exec/factory.opt
+++ b/pkg/sql/opt/exec/factory.opt
@@ -7,6 +7,16 @@ define Scan {
     ReqOrdering exec.OutputOrdering
 }
 
+# PlaceholderScan runs a constrained scan of a specified index of a table with
+# some placeholders that are not known during optimization. Span contains a
+# constant datums and placeholders the correspond to a prefix of the index key
+# columns.
+define PlaceholderScan {
+    Table cat.Table
+    Index cat.Index
+    Params exec.PlaceholderScanParams
+}
+
 define Values {
     Rows [][]tree.TypedExpr
     Columns colinfo.ResultColumns

--- a/pkg/sql/opt/optgen/cmd/optgen/exec_factory_gen.go
+++ b/pkg/sql/opt/optgen/cmd/optgen/exec_factory_gen.go
@@ -41,7 +41,7 @@ func (g *execFactoryGen) generate(compiled *lang.CompiledExpr, w io.Writer) {
 }
 
 func (g *execFactoryGen) genExecFactory() {
-	g.w.write("// Factory defines the interface for building an execution plan, which consists\n")
+	g.w.write("// factory defines the interface for building an execution plan, which consists\n")
 	g.w.write("// of a tree of execution nodes (currently a sql.planNode tree).\n")
 	g.w.write("//\n")
 	g.w.write("// The tree is always built bottom-up. The Construct methods either construct\n")
@@ -57,7 +57,7 @@ func (g *execFactoryGen) genExecFactory() {
 	g.w.write("//\n")
 	g.w.write("// The TypedExprs passed to these functions refer to columns of the input node\n")
 	g.w.write("// via IndexedVars.\n")
-	g.w.nest("type Factory interface {\n")
+	g.w.nest("type factory interface {\n")
 	g.w.writeIndent("// ConstructPlan creates a plan enclosing the given plan and (optionally)\n")
 	g.w.writeIndent("// subqueries, cascades, and checks.\n")
 	g.w.writeIndent("//\n")
@@ -109,7 +109,7 @@ func (g *execFactoryGen) genStubFactory() {
 	g.w.write("// StubFactory is a do-nothing implementation of Factory, used for testing.\n")
 	g.w.write("type StubFactory struct{}\n")
 	g.w.write("\n")
-	g.w.write("var _ Factory = StubFactory{}\n")
+	g.w.write("var _ factory = StubFactory{}\n")
 	g.w.write("\n")
 	g.w.nestIndent("func (StubFactory) ConstructPlan(\n")
 	g.w.writeIndent("root Node,\n")

--- a/pkg/sql/opt/xform/rules/generic.opt
+++ b/pkg/sql/opt/xform/rules/generic.opt
@@ -56,3 +56,28 @@
     []
     (OutputCols (Root))
 )
+
+# TODO: For the prototype:
+# 1. Move constraint building to the distsql/exec factory constructors.
+# 2. Build closures over immutable planning data in constructors and reuse them
+#    for PlaceholderScans, Updates, Deletes, maybe others?
+# 3. Benchmark the gains.
+#
+# TODO: For productions:
+# 1. We need to actually cost these PlaceholderScans now. Maybe they can have
+# the same cost as the lookup join, but like a little bit less?
+# TODO: Check for empty on filters here?
+[ConvertParameterizedJoinToPlaceholderScan, Explore]
+(LookupJoin
+    $values:(Values [ (Tuple $row:[ ... ]) ]) &
+        (Let
+            ($span $private $ok):(PlaceholderScanSpanAndPrivate
+                (Root)
+                $values
+                $row
+            )
+            $ok
+        )
+)
+=>
+(PlaceholderScan $span $private)

--- a/pkg/sql/plan_opt.go
+++ b/pkg/sql/plan_opt.go
@@ -910,18 +910,41 @@ func (opc *optPlanningCtx) runExecBuilder(
 	}
 	var bld *execbuilder.Builder
 	if !planTop.instrumentation.ShouldBuildExplainPlan() {
-		bld = execbuilder.New(
-			ctx, f, &opc.optimizer, mem, opc.catalog, mem.RootExpr(),
-			semaCtx, evalCtx, allowAutoCommit, statements.IsANSIDML(stmt.AST),
-		)
-		if disableTelemetryAndPlanGists {
-			bld.DisableTelemetry()
+		prep := opc.p.stmt.Prepared
+		a := opc.p.SessionData().ApplicationName == "marcus"
+		_ = a
+		isGeneric := prep != nil && prep.GenericMemo == mem
+		if isGeneric && prep.CompiledPlan != nil {
+			plan, err := prep.CompiledPlan(
+				ctx, opc.p.EvalContext(), opc.p.extendedEvalCtx.indexUsageStats,
+			)
+			if err != nil {
+				return err
+			}
+			result = plan.(*planComponents)
+		} else {
+			compile := isGeneric && !opc.p.SessionData().Internal
+			if compile {
+				f.EnableCompilation()
+			}
+			bld = execbuilder.New(
+				ctx, f, &opc.optimizer, mem, opc.catalog, mem.RootExpr(),
+				semaCtx, evalCtx, allowAutoCommit, statements.IsANSIDML(stmt.AST),
+			)
+			if disableTelemetryAndPlanGists {
+				bld.DisableTelemetry()
+			}
+			plan, err := bld.Build()
+			if err != nil {
+				return err
+			}
+			if compile {
+				// Save the compiled plan.
+				prep.CompiledPlan = f.Compiled()
+				f.DisableCompilation()
+			}
+			result = plan.(*planComponents)
 		}
-		plan, err := bld.Build()
-		if err != nil {
-			return err
-		}
-		result = plan.(*planComponents)
 	} else {
 		// Create an explain factory and record the explain.Plan.
 		explainFactory := explain.NewFactory(f, semaCtx, evalCtx)
@@ -940,15 +963,16 @@ func (opc *optPlanningCtx) runExecBuilder(
 		result = explainPlan.WrappedPlan.(*planComponents)
 		planTop.instrumentation.RecordExplainPlan(explainPlan)
 	}
-	planTop.instrumentation.maxFullScanRows = bld.MaxFullScanRows
-	planTop.instrumentation.totalScanRows = bld.TotalScanRows
-	planTop.instrumentation.totalScanRowsWithoutForecasts = bld.TotalScanRowsWithoutForecasts
-	planTop.instrumentation.nanosSinceStatsCollected = bld.NanosSinceStatsCollected
-	planTop.instrumentation.nanosSinceStatsForecasted = bld.NanosSinceStatsForecasted
-	planTop.instrumentation.joinTypeCounts = bld.JoinTypeCounts
-	planTop.instrumentation.joinAlgorithmCounts = bld.JoinAlgorithmCounts
-	planTop.instrumentation.scanCounts = bld.ScanCounts
-	planTop.instrumentation.indexesUsed = bld.IndexesUsed
+	// TODO: Need to figure out what to do with this shit...
+	// planTop.instrumentation.maxFullScanRows = bld.MaxFullScanRows
+	// planTop.instrumentation.totalScanRows = bld.TotalScanRows
+	// planTop.instrumentation.totalScanRowsWithoutForecasts = bld.TotalScanRowsWithoutForecasts
+	// planTop.instrumentation.nanosSinceStatsCollected = bld.NanosSinceStatsCollected
+	// planTop.instrumentation.nanosSinceStatsForecasted = bld.NanosSinceStatsForecasted
+	// planTop.instrumentation.joinTypeCounts = bld.JoinTypeCounts
+	// planTop.instrumentation.joinAlgorithmCounts = bld.JoinAlgorithmCounts
+	// planTop.instrumentation.scanCounts = bld.ScanCounts
+	// planTop.instrumentation.indexesUsed = bld.IndexesUsed
 
 	if opc.gf.Initialized() {
 		planTop.instrumentation.planGist = opc.gf.PlanGist()

--- a/pkg/sql/prepared_stmt.go
+++ b/pkg/sql/prepared_stmt.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/appstatspb"
 	"github.com/cockroachdb/cockroach/pkg/sql/clusterunique"
 	"github.com/cockroachdb/cockroach/pkg/sql/flowinfra"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/exec"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgwirebase"
 	"github.com/cockroachdb/cockroach/pkg/sql/querycache"
@@ -56,7 +57,8 @@ type PreparedStatement struct {
 
 	// GenericMemo, if present, is a fully-optimized memo that can be executed
 	// as-is.
-	GenericMemo *memo.Memo
+	GenericMemo  *memo.Memo
+	CompiledPlan exec.CompiledPlan
 
 	// IdealGenericPlan is true if GenericMemo is guaranteed to be optimal
 	// across all executions of the prepared statement. Ideal generic plans are

--- a/pkg/sql/scan.go
+++ b/pkg/sql/scan.go
@@ -121,7 +121,8 @@ func (cfg scanColumnsConfig) assertValidReqOrdering(reqOrdering exec.OutputOrder
 	return nil
 }
 
-func (p *planner) Scan() *scanNode {
+// NewScanNode returns an empty scanNode.
+func NewScanNode() *scanNode {
 	n := scanNodePool.Get().(*scanNode)
 	return n
 }


### PR DESCRIPTION
This prototype memoizes repeated work when converting an optimized memo into a
physical plan. Placeholder scans now have their own constructors in exec
factories, allowing constraint building, which depends on placeholder values, to
move from the execbuild phase to the constructor phase. As a result, the
execbuild phase does not need to be repeated for each execution of placeholder
scan.

Data structures that do not depend on placeholder values can be reused across
executions of the same placeholder scan. These objects are cached in a closure
which is invoked on future executions to create an exec plan without creating or
invoking execbuilder or the factories directly. I'm calling these closures
"compiled factories" (naming is not yet consistent in this prototype).

The end-to-end benchmarks show the potential speedup and reduction in
allocations for a simple kv read.

```
name                                     old time/op    new time/op    delta
EndToEnd/kv-read/vectorize=on/Simple        164µs ± 2%     163µs ± 2%    ~     (p=0.565 n=20+20)
EndToEnd/kv-read/vectorize=on/Prepared      114µs ± 5%     109µs ± 3%  -4.59%  (p=0.000 n=20+20)
EndToEnd/kv-read/vectorize=off/Simple       178µs ± 4%     178µs ± 2%    ~     (p=0.892 n=20+17)
EndToEnd/kv-read/vectorize=off/Prepared     114µs ± 5%     107µs ± 6%  -5.68%  (p=0.000 n=20+19)

name                                     old alloc/op   new alloc/op   delta
EndToEnd/kv-read/vectorize=on/Simple       30.4kB ± 4%    31.6kB ± 5%  +3.87%  (p=0.000 n=17+19)
EndToEnd/kv-read/vectorize=on/Prepared     19.4kB ± 4%    18.6kB ± 5%  -4.33%  (p=0.000 n=16+16)
EndToEnd/kv-read/vectorize=off/Simple      31.2kB ± 0%    32.2kB ± 0%  +3.34%  (p=0.000 n=18+17)
EndToEnd/kv-read/vectorize=off/Prepared    20.3kB ± 0%    19.5kB ± 0%  -4.08%  (p=0.000 n=16+19)

name                                     old allocs/op  new allocs/op  delta
EndToEnd/kv-read/vectorize=on/Simple          248 ± 1%       249 ± 0%  +0.32%  (p=0.000 n=16+17)
EndToEnd/kv-read/vectorize=on/Prepared        171 ± 1%       157 ± 1%  -8.14%  (p=0.000 n=17+16)
EndToEnd/kv-read/vectorize=off/Simple         242 ± 0%       242 ± 0%  +0.31%  (p=0.000 n=18+17)
EndToEnd/kv-read/vectorize=off/Prepared       164 ± 0%       150 ± 0%  -8.54%  (p=0.000 n=16+16)
```

This prototype also explores a method for utilizing placeholder scans in generic
query plans that don't hit the placeholder fast-path. It does this by adding an
exploration rule to transform simple parameterized lookup joins into placeholder
scans. There are still some wrinkles to iron out, e.g., costing, but I believe
this shows that there is a pragmatic path for supporting compiled factories of
other types of generic query plans. 

Below are some implementation notesfor myself th
Below is a rough map of the steps to productionize this prototype:

#### A. Make placeholder scans a first-class type in exec factories

1. Create a placeholder scan private.
2. Create a placeholder exec params struct.
3. Add placeholder constructor to factories.
4. Move constraint building from execbuilder to factories.
5. Make sure EXPLAIN works.
6. Make sure plan gists work.

#### B. Simple compiled factories for placeholder scans

1. Add simple compilation API to factories.
2. Solve the instrumentation problem.
3. Remove planner from constructPlan.
4. Figure out how to correctly handle codec in a compiled factory.
5. Make NewScanNode a static function.
6. Ensure compilation is only attempted once per generic memo.

#### C. Convert parameterized lookup joins to placeholder scans

1. Add locking to placeholder scan.
2. Add more robust mechanism for unsupported nodes in compiled factories.
3. Add exploration rule to convert parameterized lookup join to placeholder
scan.
4. Add costing for placeholder scans. Maybe this can be really simple for now,
like reuse the cost of the lookup join?

#### D. Support compiled factories for more operators 

1. Project
2. Update
3. Delete
4. Insert?
