### PR TITLE
roachprod: enable `PanicOnAssertions`

### DIFF
--- a/pkg/roachprod/install/cockroach.go
+++ b/pkg/roachprod/install/cockroach.go
@@ -1392,6 +1392,9 @@ func (c *SyncedCluster) generateClusterSettingCmd(
 	clusterSettings := map[string]string{
 		"cluster.organization": "Cockroach Labs - Production Testing",
 		"enterprise.license":   license,
+		// N.B. We now enable `PanicOnAssertions` for all roachprod clusters.
+		// (See https://github.com/cockroachdb/cockroach/issues/136858)
+		"debug.panic_on_failed_assertions.enabled": "true",
 	}
 	for name, value := range c.ClusterSettings.ClusterSettings {
 		clusterSettings[name] = value


### PR DESCRIPTION
`PanicOnAssertions` (or `debug.panic_on_failed_assertions.enabled"`) cluster setting is disabled by default. Since `roachprod`, and by extension, `roachtest` are inherently used for testing rather than production environments, we enable `PanicOnAssertions` unconditionally. Thus, `logcrash.ReportOrPanic` will now cause the node to `panic`.

Resolves: https://github.com/cockroachdb/cockroach/issues/136858
Epic: none
Release note: None