### PR TITLE
roachtest: "large" cluster tweaks

### DIFF
--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -1753,8 +1753,11 @@ func (r *testRunner) collectArtifacts(
 		if err := c.FetchPebbleCheckpoints(ctx, t.L()); err != nil {
 			t.L().Printf("failed to fetch Pebble checkpoints: %s", err)
 		}
-		if err := c.FetchTimeseriesData(ctx, t.L()); err != nil {
-			t.L().Printf("failed to fetch timeseries data: %s", err)
+		// Bypass the collection of timeseries data for "large" clusters.
+		if c.spec.NodeCount < 30 {
+			if err := c.FetchTimeseriesData(ctx, t.L()); err != nil {
+				t.L().Printf("failed to fetch timeseries data: %s", err)
+			}
 		}
 		if err := c.FetchDebugZip(ctx, t.L(), "debug.zip"); err != nil {
 			t.L().Printf("failed to collect zip: %s", err)

--- a/pkg/cmd/roachtest/tests/mixed_version_multi_region.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_multi_region.go
@@ -36,7 +36,7 @@ func registerMultiRegionMixedVersion(r registry.Registry) {
 	}
 
 	const (
-		nodesPerRegion = 20
+		nodesPerRegion = 13
 		// These values are somewhat arbitrary: currently, they are
 		// sufficient to keep the cluster relatively busy (CPU utilization
 		// varying from 10-60%). In the future, these values might be
@@ -75,7 +75,7 @@ func registerMultiRegionMixedVersion(r registry.Registry) {
 				mixedversion.NeverUseFixtures,
 				// Allow migrations to run for a longer period of time due to
 				// added latency and cluster size.
-				mixedversion.UpgradeTimeout(1*time.Hour),
+				mixedversion.UpgradeTimeout(2*time.Hour),
 				// There are known issues upgrading from older patch releases
 				// in MR clusters (e.g., #113908), so use the latest patch
 				// releases to avoid flakes.


### PR DESCRIPTION
While triaging recent failures of the
_weekly_ `multi-region/mixed-version`,
we observed that the 1h upgrade timeout
was exceeded, potentially due to [1].
We also observed that 10m wasn't sufficient
to construct `debug.zip`.

Thus, we bump the upgrade timeout to 2h and
`FetchDebugZip` to 20m. We also reduce the
cluster size from 80 nodes down to 52, in
hope of stabilizing it. Finally, we skip
`FetchTimeSeries` since we have no direct
use for it, and it has non-negligible overhead.

[1] https://github.com/cockroachdb/cockroach/pull/141420

Informs: https://github.com/cockroachdb/cockroach/issues/121455
Epic: none
Release note: None