### PR TITLE
roachtest: attachToExistingCluster doesn't populate the cloud field

### DIFF
--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -128,12 +128,7 @@ type testRunner struct {
 	stopper *stop.Stopper
 
 	config struct {
-		// skipClusterValidationOnAttach skips validation on existing clusters that
-		// the registry uses for running tests.
-		skipClusterValidationOnAttach bool
-		// skipClusterStopOnAttach skips stopping existing clusters that
-		// the registry uses for running tests. It implies skipClusterWipeOnAttach.
-		skipClusterStopOnAttach bool
+		// Skips wiping the cluster unless roachtestflags.ClusterWipe is set.
 		skipClusterWipeOnAttach bool
 		// disableIssue disables posting GitHub issues for test failures.
 		disableIssue bool
@@ -495,7 +490,9 @@ func generateRunID(cOpts clustersOpt) string {
 	return fmt.Sprintf("%s-%s", cOpts.user, cOpts.clusterID)
 }
 
-func (r *testRunner) allocateCluster(
+// If clustersOpt.clusterName is empty, create a fresh cluster; otherwise, attempt to attach to the existing cluster.
+// If the existing cluster isn't found, we fall back to creating a new cluster. Otherwise, we bail out with an error.
+func (r *testRunner) allocateOrAttachToCluster(
 	ctx context.Context,
 	clusterFactory *clusterFactory,
 	clustersOpt clustersOpt,
@@ -523,22 +520,23 @@ func (r *testRunner) allocateCluster(
 		}
 		defer clusterL.Close()
 		opt := attachOpt{
-			skipValidation: r.config.skipClusterValidationOnAttach,
-			skipStop:       r.config.skipClusterStopOnAttach,
-			skipWipe:       r.config.skipClusterWipeOnAttach,
+			skipWipe: r.config.skipClusterWipeOnAttach,
 		}
 		// TODO(srosenberg): we need to think about validation here. Attaching to an incompatible cluster, e.g.,
 		// using arm64 AMI with amd64 binary, would result in obscure errors. The test runner ensures compatibility
 		// during cluster reuse, whereas attachment via CLI (e.g., via roachprod) does not.
 		lopt.l.PrintfCtx(ctx, "Attaching to existing cluster %s for test %s", existingClusterName, t.Name)
-		c, err := attachToExistingCluster(ctx, existingClusterName, clusterL, t.Cluster, opt, r.cr)
-		if err == nil {
+		if c, err := attachToExistingCluster(ctx, existingClusterName, clusterL, t.Cluster, opt, r.cr); err != nil {
+			// If the cluster is not found, we fall through to create a new cluster. Otherwise, we bail out.
+			if errors.Is(err, errClusterNotFound) {
+				lopt.l.PrintfCtx(ctx, "Error attaching to existing cluster %s: %s", existingClusterName, err)
+			} else {
+				return nil, nil, err
+			}
+		} else {
 			// Pretend pre-existing's cluster architecture matches the desired one; see the above TODO wrt validation.
 			c.arch = arch
 			return c, nil, nil
-		}
-		if !errors.Is(err, errClusterNotFound) {
-			return nil, nil, err
 		}
 		// Fall through to create new cluster with name override.
 		lopt.l.PrintfCtx(
@@ -763,7 +761,7 @@ func (r *testRunner) runWorker(
 			// Create a new cluster if can't reuse or reuse attempt failed.
 			// N.B. non-reusable cluster would have been destroyed above.
 			wStatus.SetTest(nil /* test */, testToRun)
-			c, vmCreateOpts, clusterCreateErr = r.allocateCluster(
+			c, vmCreateOpts, clusterCreateErr = r.allocateOrAttachToCluster(
 				ctx, clusterFactory, clustersOpt, lopt,
 				testToRun.spec, arch, wStatus)
 


### PR DESCRIPTION
Previously, `attachToExistingCluster` would not set the cloud spec. of `clusterImpl`, resulting in panic in [1]. As of this change, we set it to the actual cloud provider, unless validation is disabled; in that case, the cloud field is set to `spec.AnyCloud`.

[1] https://github.com/cockroachdb/cockroach/pull/142447

Epic: none
Fixes: #136998
Release note: None