### PR TITLE
vecindex: improve Index.Format method

### DIFF
--- a/pkg/sql/vecindex/cspann/BUILD.bazel
+++ b/pkg/sql/vecindex/cspann/BUILD.bazel
@@ -37,6 +37,7 @@ go_library(
         "//pkg/util/num32",
         "//pkg/util/stop",
         "//pkg/util/syncutil",
+        "//pkg/util/timeutil",
         "//pkg/util/vector",
         "@com_github_cockroachdb_crlib//crtime",
         "@com_github_cockroachdb_errors//:errors",

--- a/pkg/sql/vecindex/cspann/commontest/BUILD.bazel
+++ b/pkg/sql/vecindex/cspann/commontest/BUILD.bazel
@@ -14,7 +14,6 @@ go_library(
         "//pkg/sql/vecindex/cspann/testutils",
         "//pkg/sql/vecindex/cspann/workspace",
         "//pkg/util/num32",
-        "//pkg/util/timeutil",
         "//pkg/util/vector",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_stretchr_testify//require",

--- a/pkg/sql/vecindex/cspann/fixup_worker.go
+++ b/pkg/sql/vecindex/cspann/fixup_worker.go
@@ -309,7 +309,10 @@ func (fw *fixupWorker) splitPartition(
 		}
 		valueBytes := make([]ValueBytes, 2)
 		rootMetadata := PartitionMetadata{
-			Level: partition.Level() + 1, Centroid: quantizedSet.GetCentroid()}
+			Level:        partition.Level() + 1,
+			Centroid:     quantizedSet.GetCentroid(),
+			StateDetails: MakeReadyDetails(),
+		}
 		rootPartition := NewPartition(
 			rootMetadata, fw.index.rootQuantizer, quantizedSet, childKeys, valueBytes)
 		if err = fw.txn.SetRootPartition(ctx, fw.treeKey, rootPartition); err != nil {
@@ -623,7 +626,11 @@ func (fw *fixupWorker) mergePartition(
 			return errors.AssertionFailedf("only root partition can have zero vectors")
 		}
 		quantizedSet := fw.index.rootQuantizer.Quantize(&fw.workspace, vectors)
-		metadata := PartitionMetadata{Level: partition.Level(), Centroid: quantizedSet.GetCentroid()}
+		metadata := PartitionMetadata{
+			Level:        partition.Level(),
+			Centroid:     quantizedSet.GetCentroid(),
+			StateDetails: MakeReadyDetails(),
+		}
 		rootPartition := NewPartition(
 			metadata, fw.index.rootQuantizer, quantizedSet, partition.ChildKeys(), partition.ValueBytes())
 		if err = fw.txn.SetRootPartition(ctx, fw.treeKey, rootPartition); err != nil {

--- a/pkg/sql/vecindex/cspann/memstore/BUILD.bazel
+++ b/pkg/sql/vecindex/cspann/memstore/BUILD.bazel
@@ -20,7 +20,6 @@ go_library(
         "//pkg/util/container/list",
         "//pkg/util/protoutil",
         "//pkg/util/syncutil",
-        "//pkg/util/timeutil",
         "//pkg/util/vector",
         "@com_github_cockroachdb_errors//:errors",
     ],

--- a/pkg/sql/vecindex/cspann/memstore/memstore_test.go
+++ b/pkg/sql/vecindex/cspann/memstore/memstore_test.go
@@ -216,7 +216,10 @@ func TestInMemoryStoreUpdateStats(t *testing.T) {
 	oldRoot, err := txn.GetPartition(ctx, treeKey, cspann.RootKey)
 	require.NoError(t, err)
 	metadata := cspann.PartitionMetadata{
-		Level: 3, Centroid: oldRoot.QuantizedSet().GetCentroid()}
+		Level:        3,
+		Centroid:     oldRoot.QuantizedSet().GetCentroid(),
+		StateDetails: cspann.MakeReadyDetails(),
+	}
 	newRoot := cspann.NewPartition(metadata, oldRoot.Quantizer(), oldRoot.QuantizedSet(),
 		oldRoot.ChildKeys(), oldRoot.ValueBytes())
 	require.NoError(t, txn.SetRootPartition(ctx, treeKey, newRoot))
@@ -229,7 +232,11 @@ func TestInMemoryStoreUpdateStats(t *testing.T) {
 	// Insert new partition with lower level and check stats.
 	vectors := vector.MakeSetFromRawData([]float32{5, 6}, 2)
 	quantizedSet := quantizer.Quantize(&workspace, vectors)
-	metadata = cspann.PartitionMetadata{Level: 2, Centroid: quantizedSet.GetCentroid()}
+	metadata = cspann.PartitionMetadata{
+		Level:        2,
+		Centroid:     quantizedSet.GetCentroid(),
+		StateDetails: cspann.MakeReadyDetails(),
+	}
 	partition := cspann.NewPartition(metadata, quantizer, quantizedSet,
 		[]cspann.ChildKey{childKey30}, []cspann.ValueBytes{valueBytes30})
 	partitionKey, err := txn.InsertPartition(ctx, treeKey, partition)
@@ -286,7 +293,7 @@ func TestInMemoryStoreMarshalling(t *testing.T) {
 
 	memPart := &memPartition{}
 	memPart.lock.partition = cspann.NewPartition(
-		cspann.PartitionMetadata{Level: 1, Centroid: centroid},
+		cspann.PartitionMetadata{Level: 1, Centroid: centroid, StateDetails: cspann.MakeReadyDetails()},
 		unquantizer,
 		&quantize.UnQuantizedVectorSet{
 			Centroid:          centroid,
@@ -304,7 +311,7 @@ func TestInMemoryStoreMarshalling(t *testing.T) {
 
 	memPart = &memPartition{}
 	memPart.lock.partition = cspann.NewPartition(
-		cspann.PartitionMetadata{Level: 2, Centroid: centroid},
+		cspann.PartitionMetadata{Level: 2, Centroid: centroid, StateDetails: cspann.MakeReadyDetails()},
 		raBitQuantizer,
 		&quantize.UnQuantizedVectorSet{
 			Centroid:          centroid,

--- a/pkg/sql/vecindex/cspann/split_data.go
+++ b/pkg/sql/vecindex/cspann/split_data.go
@@ -39,7 +39,11 @@ func (s *splitData) Init(
 	s.Vectors = vectors
 	s.OldCentroidDistances = oldCentroidDistances
 	quantizedSet := quantizer.Quantize(w, s.Vectors)
-	metadata := PartitionMetadata{Level: level, Centroid: quantizedSet.GetCentroid()}
+	metadata := PartitionMetadata{
+		Level:        level,
+		Centroid:     quantizedSet.GetCentroid(),
+		StateDetails: MakeReadyDetails(),
+	}
 	s.Partition = NewPartition(metadata, quantizer, quantizedSet, childKeys, valueBytes)
 }
 

--- a/pkg/sql/vecindex/cspann/store.go
+++ b/pkg/sql/vecindex/cspann/store.go
@@ -169,9 +169,8 @@ type Store interface {
 // Txn implementations are not thread-safe.
 type Txn interface {
 	// GetPartition returns the partition identified by the given key, or
-	// ErrPartitionNotFound if the key cannot be found. The returned partition
-	// can be modified by the caller in the scope of the transaction with a
-	// guarantee it won't be changed by other agents.
+	// ErrPartitionNotFound if the key cannot be found. The returned partition's
+	// memory is owned by the caller - it can be modified as needed.
 	GetPartition(ctx context.Context, treeKey TreeKey, partitionKey PartitionKey) (*Partition, error)
 
 	// SetRootPartition makes the given partition the root partition in the store.
@@ -246,6 +245,9 @@ type Txn interface {
 	// by the given child keys and stores them in "refs". If a vector has been
 	// deleted, then its corresponding reference will be set to nil. If a
 	// partition cannot be found, GetFullVectors returns ErrPartitionNotFound.
+	//
+	// NOTE: The caller takes ownership of any vector memory returned in "refs".
+	// The Store implementation should not try to use it after returning it.
 	//
 	// TODO(andyk): what if the row exists but the vector column is NULL? Right
 	// now, this whole library expects vectors passed to it to be non-nil and have

--- a/pkg/sql/vecindex/vecencoding/encoding_test.go
+++ b/pkg/sql/vecindex/vecencoding/encoding_test.go
@@ -68,7 +68,11 @@ func testEncodeDecodeRoundTripImpl(t *testing.T, rnd *rand.Rand, set vector.Set)
 						}
 						valueBytes[i] = randutil.RandBytes(rnd, 10)
 					}
-					metadata := cspann.PartitionMetadata{Level: level, Centroid: quantizedSet.GetCentroid()}
+					metadata := cspann.PartitionMetadata{
+						Level:        level,
+						Centroid:     quantizedSet.GetCentroid(),
+						StateDetails: cspann.MakeReadyDetails(),
+					}
 					originalPartition := cspann.NewPartition(metadata, quantizer, quantizedSet, childKeys, valueBytes)
 
 					// Encode the partition.
@@ -125,7 +129,11 @@ func testEncodeDecodeRoundTripImpl(t *testing.T, rnd *rand.Rand, set vector.Set)
 						require.Equal(t, trailingData, testutils.NormalizeSlice(remainder))
 					}
 
-					metadata = cspann.PartitionMetadata{Level: decodedLevel, Centroid: decodedCentroid}
+					metadata = cspann.PartitionMetadata{
+						Level:        decodedLevel,
+						Centroid:     decodedCentroid,
+						StateDetails: cspann.MakeReadyDetails(),
+					}
 					decodedPartition := cspann.NewPartition(
 						metadata, quantizer, decodedSet, childKeys, valueBytes)
 					testingAssertPartitionsEqual(t, originalPartition, decodedPartition)

--- a/pkg/sql/vecindex/vecstore/store_txn.go
+++ b/pkg/sql/vecindex/vecstore/store_txn.go
@@ -607,7 +607,11 @@ func (tx *Txn) createRootPartition(
 	ctx context.Context, metadataKey roachpb.Key,
 ) (cspann.PartitionMetadata, error) {
 	b := tx.kv.NewBatch()
-	metadata := cspann.PartitionMetadata{Level: cspann.LeafLevel, Centroid: tx.store.emptyVec}
+	metadata := cspann.PartitionMetadata{
+		Level:        cspann.LeafLevel,
+		Centroid:     tx.store.emptyVec,
+		StateDetails: cspann.MakeReadyDetails(),
+	}
 	encoded, err := vecencoding.EncodePartitionMetadata(metadata.Level, metadata.Centroid)
 	if err != nil {
 		return cspann.PartitionMetadata{}, err
@@ -664,7 +668,11 @@ func (tx *Txn) getMetadataFromKVResult(
 		}
 
 		// Construct synthetic metadata.
-		metadata := cspann.PartitionMetadata{Level: cspann.LeafLevel, Centroid: tx.store.emptyVec}
+		metadata := cspann.PartitionMetadata{
+			Level:        cspann.LeafLevel,
+			Centroid:     tx.store.emptyVec,
+			StateDetails: cspann.MakeReadyDetails(),
+		}
 		return metadata, nil
 	}
 
@@ -674,7 +682,11 @@ func (tx *Txn) getMetadataFromKVResult(
 	}
 
 	// Return the metadata.
-	return cspann.PartitionMetadata{Level: level, Centroid: centroid}, nil
+	return cspann.PartitionMetadata{
+		Level:        level,
+		Centroid:     centroid,
+		StateDetails: cspann.MakeReadyDetails(),
+	}, nil
 }
 
 // calculateMetaKeyLen returns the length of the metadata partition key.


### PR DESCRIPTION
Now that we have a non-transactional Store.TryGetPartition method, use it in Index.Format. The Format method is used in testing/debugging, and doesn't need to be transactional. Removing its dependence on GetPartition will eventually allow us to remove that method entirely.

Also begin showing partition state if it is not Ready. This will be needed as we begin using other states. Update all the places where we create partition metadata to set the state so that Format shows expected results.

Epic: CRDB-42943

Release note: None