### PR TITLE
cli: add node attributes to node status

### DIFF
--- a/pkg/cli/node.go
+++ b/pkg/cli/node.go
@@ -89,6 +89,7 @@ var baseNodeColumnHeaders = []string{
 	"started_at",
 	"updated_at",
 	"locality",
+	"attrs",
 	"is_available",
 	"is_live",
 }
@@ -168,6 +169,7 @@ func runStatusNodeInner(
             started_at,
 			updated_at,
 			locality,
+			attrs,
             CASE WHEN split_part(expiration,',',1)::decimal > now()::decimal
                  THEN true
                  ELSE false


### PR DESCRIPTION
This change add node attributes to the node status endpoint.

Without:
```bash
 ./cockroach node status --insecure
  id |         address               |        sql_address            |     build           |         started_at                   |            updated_at          	     | locality | is_available | is_live
-----+-------------------------------+-------------------------------+---------------------+--------------------------------------+--------------------------------------+----------+--------------+----------
   1 | Brams-MacBook-Pro.local:26257 | Brams-MacBook-Pro.local:26257 | v25.2.0-alpha.1-dev | 2025-03-20 17:59:58.470609 +0000 UTC | 2025-03-20 18:03:19.492982 +0000 UTC |      	| true         | true
```

With:
```bash
 ./cockroach node status --insecure
  id |         address               |        sql_address            |     build           |         started_at                   |            updated_at          	     | locality |  	    attrs      | is_available | is_live
-----+-------------------------------+-------------------------------+---------------------+--------------------------------------+--------------------------------------+----------+------------------+--------------+----------
   1 | Brams-MacBook-Pro.local:26257 | Brams-MacBook-Pro.local:26257 | v25.2.0-alpha.1-dev | 2025-03-20 17:59:58.470609 +0000 UTC | 2025-03-20 18:03:19.492982 +0000 UTC |      	| [attrs on node]  | true         | true
```

This helps with complex setups in which one might use the node attributes in conjuction with zone configs. That they are not currently present seems like an oversight.

Part of: https://cockroachlabs.atlassian.net/browse/TREQ-955
Part of: https://cockroachlabs.atlassian.net/browse/FEB-78

Release note (cli change): Node attributes (attrs) will now appear in the node status cli command.