### PR TITLE
sql/delegate: fix SHOW POLICIES to properly display roles

### DIFF
--- a/pkg/sql/delegate/show_policies.go
+++ b/pkg/sql/delegate/show_policies.go
@@ -25,14 +25,15 @@ func (d *delegator) delegateShowPolicies(stmt *tree.ShowPolicies) (tree.Statemen
 			array_agg(
 					CASE 
 							WHEN role_id.uid = 0 THEN 'public'
-							ELSE u.usename
+							ELSE r.rolname
 					END
+					ORDER BY r.rolname
 			) AS roles,
 			COALESCE(p.polqual::text, '') AS using_expr,
 			COALESCE(p.polwithcheck::text, '') AS with_check_expr
 			FROM pg_policy p
 			LEFT JOIN LATERAL unnest(p.polroles) AS role_id(uid) ON true
-			LEFT JOIN pg_catalog.pg_user u ON u.usesysid = role_id.uid
+			LEFT JOIN pg_catalog.pg_roles r ON r.oid = role_id.uid
 			WHERE p.polrelid = %[6]d
 			GROUP BY p.polname, p.polcmd, p.polpermissive, p.polqual, p.polwithcheck`
 

--- a/pkg/sql/logictest/testdata/logic_test/row_level_security
+++ b/pkg/sql/logictest/testdata/logic_test/row_level_security
@@ -175,7 +175,6 @@ query TTTTTT colnames,rowsort
 SHOW POLICIES FOR multi_pol_tab1
 ----
 name     cmd     type         roles                using_expr  with_check_expr
-policy8  ALL     permissive   {papa_roach,public}  ·           ·
 policy1  ALL     permissive   {public}             ·           ·
 policy2  ALL     restrictive  {public}             ·           ·
 policy3  ALL     permissive   {public}             ·           ·
@@ -183,6 +182,7 @@ policy4  INSERT  permissive   {public}             ·           ·
 policy5  UPDATE  permissive   {public}             ·           ·
 policy6  DELETE  permissive   {public}             ·           ·
 policy7  SELECT  permissive   {public}             ·           ·
+policy8  ALL     permissive   {public,papa_roach}  ·           ·
 
 statement ok
 CREATE TABLE multi_pol_tab2 (c1 INT NOT NULL PRIMARY KEY)
@@ -1369,15 +1369,14 @@ alter_policy_table  CREATE TABLE public.alter_policy_table (
                     CREATE POLICY p_ins ON public.alter_policy_table AS PERMISSIVE FOR INSERT TO public WITH CHECK (nextval('public.seq1'::REGCLASS) < 10000:::INT8);
                     CREATE POLICY p_sel ON public.alter_policy_table AS PERMISSIVE FOR SELECT TO aux1, alter_policy_role, aux2 USING (c1 != 1:::INT8)
 
-# TODO(143358): Include roles in the SHOW POLICIES output.
-query TTTTT colnames
-SELECT name,cmd,type,using_expr,with_check_expr
+query TTTTTT colnames
+SELECT name,cmd,type,roles,using_expr,with_check_expr
 FROM [SHOW POLICIES FOR alter_policy_table]
 ORDER BY name DESC;
 ----
-name   cmd     type        using_expr      with_check_expr
-p_sel  SELECT  permissive  c1 != 1:::INT8  ·
-p_ins  INSERT  permissive  ·               nextval('public.seq1'::REGCLASS) < 10000:::INT8
+name   cmd     type        roles                          using_expr      with_check_expr
+p_sel  SELECT  permissive  {alter_policy_role,aux1,aux2}  c1 != 1:::INT8  ·
+p_ins  INSERT  permissive  {public}                       ·               nextval('public.seq1'::REGCLASS) < 10000:::INT8
 
 statement ok
 SET ROLE root;
@@ -2567,7 +2566,7 @@ CREATE POLICY p1 ON rls_disabled USING (true);
 statement ok
 ALTER TABLE rls_disabled DISABLE ROW LEVEL SECURITY;
 
-query TTTTTT colnames,rowsort
+query TTTTTT colnames
 SHOW POLICIES FOR rls_disabled;
 ----
 name  cmd  type        roles     using_expr  with_check_expr
@@ -2580,10 +2579,9 @@ CREATE TABLE no_policies (id INT PRIMARY KEY);
 statement ok
 ALTER TABLE no_policies ENABLE ROW LEVEL SECURITY;
 
-query TTTTTT colnames,rowsort
+query TTTTTT
 SHOW POLICIES FOR no_policies;
 ----
-name  cmd  type  roles  using_expr  with_check_expr
 
 # This is another test for multiple policies. But the focus here is how multiple
 # policies are applied when they apply for other commands. For example, having
@@ -2866,5 +2864,67 @@ DROP TABLE cnt;
 
 statement ok
 DROP USER r1_user;
+
+subtest show_policies_roles_and_users
+
+statement ok
+CREATE ROLE test_role1;
+
+statement ok
+CREATE ROLE test_role2;
+
+statement ok
+CREATE USER test_user1;
+
+statement ok
+CREATE USER test_user2;
+
+statement ok
+CREATE TABLE policy_roles_test (id INT PRIMARY KEY, val TEXT);
+
+statement ok
+CREATE POLICY mixed_policy ON policy_roles_test TO test_role1, test_user1, test_role2, test_user2;
+
+query TTTTTT colnames
+SHOW POLICIES FOR policy_roles_test
+----
+name          cmd  type        roles                                          using_expr  with_check_expr
+mixed_policy  ALL  permissive  {test_role1,test_role2,test_user1,test_user2}  ·           ·
+
+statement ok
+CREATE POLICY users_only_policy ON policy_roles_test TO test_user1, test_user2;
+
+query TTTTTT colnames,rowsort
+SHOW POLICIES FOR policy_roles_test
+----
+name               cmd  type        roles                                          using_expr  with_check_expr
+mixed_policy       ALL  permissive  {test_role1,test_role2,test_user1,test_user2}  ·           ·
+users_only_policy  ALL  permissive  {test_user1,test_user2}                        ·           ·
+
+statement ok
+CREATE POLICY roles_only_policy ON policy_roles_test TO test_role1, test_role2;
+
+query TTTTTT colnames,rowsort
+SHOW POLICIES FOR policy_roles_test
+----
+name               cmd  type        roles                                          using_expr  with_check_expr
+mixed_policy       ALL  permissive  {test_role1,test_role2,test_user1,test_user2}  ·           ·
+roles_only_policy  ALL  permissive  {test_role1,test_role2}                        ·           ·
+users_only_policy  ALL  permissive  {test_user1,test_user2}                        ·           ·
+
+statement ok
+DROP TABLE policy_roles_test;
+
+statement ok
+DROP USER test_user1;
+
+statement ok
+DROP USER test_user2;
+
+statement ok
+DROP ROLE test_role1;
+
+statement ok
+DROP ROLE test_role2;
 
 subtest end


### PR DESCRIPTION
The SHOW POLICIES command was not correctly displaying roles for policies. When users were created and added to a policy, they would show up as NULL in the output. This was caused by using pg_catalog.pg_user in the join, which only contains users, not roles.

The fix changes the query to join with pg_catalog.pg_roles instead, which contains information for both users and roles. This ensures all roles and users are properly displayed in the SHOW POLICIES output.

Added a test to verify that roles, users, and mixed policies all display correctly.

Fixes: #143358
Epic: CRDB-11724
Release note: none