### PR TITLE
release-24.1: upgrademanager: skip TestPrecondition under race

### DIFF
--- a/pkg/upgrade/upgrademanager/manager_external_test.go
+++ b/pkg/upgrade/upgrademanager/manager_external_test.go
@@ -660,6 +660,7 @@ func TestPrecondition(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	skip.UnderStress(t, "flaky")
+	skip.UnderRace(t, "flaky")
 
 	// Start by running v0. We want the precondition of v1 to prevent
 	// us from reaching v1 (or v2). We want the precondition to not be


### PR DESCRIPTION
Backport 1/1 commits from #142301 on behalf of @rail.

/cc @cockroachdb/release

----

This test has been flaky under race.

Fixes: #143194
Release note: None

----

Release justification: test-only changes