### PR TITLE
logical: add support for using new crud statements

### DIFF
--- a/pkg/crosscluster/logical/BUILD.bazel
+++ b/pkg/crosscluster/logical/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
         "purgatory.go",
         "range_stats.go",
         "replication_statements.go",
+        "sql_row_writer.go",
         "tombstone_updater.go",
         "udf_row_processor.go",
     ],
@@ -121,6 +122,7 @@ go_test(
         "purgatory_test.go",
         "range_stats_test.go",
         "replication_statements_test.go",
+        "sql_row_writer_test.go",
         "udf_row_processor_test.go",
     ],
     data = glob(["testdata/**"]) + [

--- a/pkg/crosscluster/logical/replication_statements_test.go
+++ b/pkg/crosscluster/logical/replication_statements_test.go
@@ -66,10 +66,10 @@ func TestReplicationStatements(t *testing.T) {
 				require.NoError(t, err)
 
 				// Test preparing the statement to ensure it is valid SQL.
-				_, err = sqlDB.Exec(fmt.Sprintf("PREPARE stmt_%d AS %s", rand.Int(), insertStmt.String()))
+				_, err = sqlDB.Exec(fmt.Sprintf("PREPARE stmt_%d AS %s", rand.Int(), insertStmt.SQL))
 				require.NoError(t, err)
 
-				return insertStmt.String()
+				return insertStmt.SQL
 			case "show-update":
 				var tableName string
 				d.ScanArgs(t, "table", &tableName)
@@ -80,10 +80,10 @@ func TestReplicationStatements(t *testing.T) {
 				require.NoError(t, err)
 
 				// Test preparing the statement to ensure it is valid SQL.
-				_, err = sqlDB.Exec(fmt.Sprintf("PREPARE stmt_%d AS %s", rand.Int(), updateStmt.String()))
+				_, err = sqlDB.Exec(fmt.Sprintf("PREPARE stmt_%d AS %s", rand.Int(), updateStmt.SQL))
 				require.NoError(t, err)
 
-				return updateStmt.String()
+				return updateStmt.SQL
 			case "show-delete":
 				var tableName string
 				d.ScanArgs(t, "table", &tableName)
@@ -94,10 +94,10 @@ func TestReplicationStatements(t *testing.T) {
 				require.NoError(t, err)
 
 				// Test preparing the statement to ensure it is valid SQL.
-				_, err = sqlDB.Exec(fmt.Sprintf("PREPARE stmt_%d AS %s", rand.Int(), deleteStmt.String()))
+				_, err = sqlDB.Exec(fmt.Sprintf("PREPARE stmt_%d AS %s", rand.Int(), deleteStmt.SQL))
 				require.NoError(t, err)
 
-				return deleteStmt.String()
+				return deleteStmt.SQL
 			default:
 				return "unknown command: " + d.Cmd
 			}

--- a/pkg/crosscluster/logical/sql_row_writer.go
+++ b/pkg/crosscluster/logical/sql_row_writer.go
@@ -1,0 +1,159 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package logical
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
+	"github.com/cockroachdb/cockroach/pkg/sql/isql"
+	"github.com/cockroachdb/cockroach/pkg/sql/parser/statements"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/errors"
+)
+
+// errStalePreviousValue is returned if the row supplied to UpdateRow,
+// UpdateTombstone, or DeleteRow does not match the value in the local
+// database.
+var errStalePreviousValue = errors.New("stale previous value")
+
+// sqlRowWriter is configured to write rows to a specific table and descriptor
+// version.
+type sqlRowWriter struct {
+	insert statements.Statement[tree.Statement]
+	update statements.Statement[tree.Statement]
+	delete statements.Statement[tree.Statement]
+
+	scratchDatums []any
+	columns       []string
+}
+
+func (s *sqlRowWriter) getExecutorOverride(
+	originTimestamp hlc.Timestamp,
+) sessiondata.InternalExecutorOverride {
+	session := ieOverrideBase
+	session.OriginTimestampForLogicalDataReplication = originTimestamp
+	return session
+}
+
+// DeleteRow deletes a row from the table. It returns errStalePreviousValue
+// if the oldRow argument does not match the value in the local database.
+func (s *sqlRowWriter) DeleteRow(
+	ctx context.Context, txn isql.Txn, originTimestamp hlc.Timestamp, oldRow tree.Datums,
+) error {
+	s.scratchDatums = s.scratchDatums[:0]
+
+	for _, d := range oldRow {
+		s.scratchDatums = append(s.scratchDatums, d)
+	}
+
+	rowsAffected, err := txn.ExecParsed(ctx, "replicated-delete", txn.KV(),
+		s.getExecutorOverride(originTimestamp),
+		s.delete,
+		s.scratchDatums...,
+	)
+	if err != nil {
+		return err
+	}
+	if rowsAffected != 1 {
+		return errStalePreviousValue
+	}
+	return nil
+}
+
+// InsertRow inserts a row into the table. It will return an error if the row
+// already exists.
+func (s *sqlRowWriter) InsertRow(
+	ctx context.Context, txn isql.Txn, originTimestamp hlc.Timestamp, row tree.Datums,
+) error {
+	s.scratchDatums = s.scratchDatums[:0]
+	for _, d := range row {
+		s.scratchDatums = append(s.scratchDatums, d)
+	}
+	rowsImpacted, err := txn.ExecParsed(ctx, "replicated-insert", txn.KV(),
+		s.getExecutorOverride(originTimestamp),
+		s.insert,
+		s.scratchDatums...,
+	)
+	if err != nil {
+		return err
+	}
+	if rowsImpacted != 1 {
+		return errors.AssertionFailedf("expected 1 row impacted, got %d", rowsImpacted)
+	}
+	return nil
+}
+
+// UpdateRow updates a row in the table. It returns errStalePreviousValue
+// if the oldRow argument does not match the value in the local database.
+func (s *sqlRowWriter) UpdateRow(
+	ctx context.Context,
+	txn isql.Txn,
+	originTimestamp hlc.Timestamp,
+	oldRow tree.Datums,
+	newRow tree.Datums,
+) error {
+	s.scratchDatums = s.scratchDatums[:0]
+
+	for _, d := range oldRow {
+		s.scratchDatums = append(s.scratchDatums, d)
+	}
+	for _, d := range newRow {
+		s.scratchDatums = append(s.scratchDatums, d)
+	}
+
+	rowsAffected, err := txn.ExecParsed(ctx, "replicated-update", txn.KV(),
+		s.getExecutorOverride(originTimestamp),
+		s.update,
+		s.scratchDatums...,
+	)
+	if err != nil {
+		return err
+	}
+	if rowsAffected != 1 {
+		return errStalePreviousValue
+	}
+	return err
+}
+
+func newSQLRowWriter(table catalog.TableDescriptor) (*sqlRowWriter, error) {
+	physicalColumns := getPhysicalColumns(table)
+	columns := make([]string, len(physicalColumns))
+	for i, col := range physicalColumns {
+		columns[i] = col.GetName()
+	}
+
+	// TODO(jeffswenson): figure out how to manage prepared statements and
+	// transactions in an internal executor. The original plan was to prepare
+	// statements on initialization then reuse them, but the internal executor
+	// is scoped to a single transaction and I couldn't figure out how to
+	// maintain prepared statements across different instances of the internal
+	// executor.
+
+	insert, err := newInsertStatement(table)
+	if err != nil {
+		return nil, err
+	}
+
+	update, err := newUpdateStatement(table)
+	if err != nil {
+		return nil, err
+	}
+
+	delete, err := newDeleteStatement(table)
+	if err != nil {
+		return nil, err
+	}
+
+	return &sqlRowWriter{
+		insert:  insert,
+		update:  update,
+		delete:  delete,
+		columns: columns,
+	}, nil
+}

--- a/pkg/crosscluster/logical/sql_row_writer_test.go
+++ b/pkg/crosscluster/logical/sql_row_writer_test.go
@@ -1,0 +1,94 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package logical
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/cdctest"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
+	"github.com/cockroachdb/cockroach/pkg/sql/isql"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/stretchr/testify/require"
+)
+
+func makeTestRow(t *testing.T, _ catalog.TableDescriptor, id int64, name string) tree.Datums {
+	t.Helper()
+	return tree.Datums{
+		tree.NewDInt(tree.DInt(id)),
+		tree.NewDString(name),
+		tree.DNull,
+	}
+}
+
+func TestSQLRowWriter(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+	s, db, _ := serverutils.StartSlimServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(ctx)
+
+	sqlDB := sqlutils.MakeSQLRunner(db)
+	internalDB := s.InternalDB().(isql.DB)
+
+	// Create a test table
+	sqlDB.Exec(t, `
+		CREATE TABLE test_table (
+			id INT PRIMARY KEY,
+			name STRING,
+			is_always_null STRING
+		)
+	`)
+
+	// Create a row writer
+	desc := cdctest.GetHydratedTableDescriptor(t, s.ApplicationLayer().ExecutorConfig(), "test_table")
+	writer, err := newSQLRowWriter(desc)
+	require.NoError(t, err)
+
+	// Test InsertRow
+	insertRow := makeTestRow(t, desc, 1, "test")
+	require.NoError(t, internalDB.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
+		return writer.InsertRow(ctx, txn, s.Clock().Now(), insertRow)
+	}))
+	require.Equal(t,
+		[][]string{{"1", "test", "NULL"}},
+		sqlDB.QueryStr(t, "SELECT id, name, is_always_null FROM test_table WHERE id = 1"))
+
+	// Test UpdateRow
+	updateRow := makeTestRow(t, desc, 1, "updated")
+	require.NoError(t, internalDB.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
+		return writer.UpdateRow(ctx, txn, s.Clock().Now(), insertRow, updateRow)
+	}))
+	require.Equal(t,
+		[][]string{{"1", "updated", "NULL"}},
+		sqlDB.QueryStr(t, "SELECT id, name, is_always_null FROM test_table WHERE id = 1"))
+
+	// Test UpdateRow with stale previous value
+	staleRow := makeTestRow(t, desc, 1, "test") // Using old value
+	err = internalDB.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
+		return writer.UpdateRow(ctx, txn, s.Clock().Now(), staleRow, updateRow)
+	})
+	require.ErrorIs(t, err, errStalePreviousValue)
+
+	// Test DeleteRow
+	require.NoError(t, internalDB.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
+		return writer.DeleteRow(ctx, txn, s.Clock().Now(), updateRow)
+	}))
+	require.Equal(t,
+		[][]string{},
+		sqlDB.QueryStr(t, "SELECT id, name, is_always_null FROM test_table WHERE id = 1"))
+
+	// Test DeleteRow with stale value
+	err = internalDB.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
+		return writer.DeleteRow(ctx, txn, s.Clock().Now(), staleRow)
+	})
+	require.ErrorIs(t, err, errStalePreviousValue)
+}


### PR DESCRIPTION
This change adds a functions that call the new LDR INSERT/UPDATE/DELETE statements based on a decoded row from a replication stream.

Release note: none
Epic: CRDB-48647