### PR TITLE
server: add tenant descriptors to hot ranges page

### DIFF
--- a/docs/generated/http/full.md
+++ b/docs/generated/http/full.md
@@ -3646,6 +3646,7 @@ HotRange message describes a single hot range, ie its QPS, node ID it belongs to
 | databases | [string](#cockroach.server.serverpb.HotRangesResponseV2-string) | repeated | Databases for the range. | [reserved](#support-status) |
 | tables | [string](#cockroach.server.serverpb.HotRangesResponseV2-string) | repeated | Tables for the range | [reserved](#support-status) |
 | indexes | [string](#cockroach.server.serverpb.HotRangesResponseV2-string) | repeated | Indexes for the range | [reserved](#support-status) |
+| desc | [cockroach.roachpb.RangeDescriptor](#cockroach.server.serverpb.HotRangesResponseV2-cockroach.roachpb.RangeDescriptor) |  | Range Descriptor for the range | [reserved](#support-status) |
 
 
 

--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -515,6 +515,7 @@ go_test(
         "//pkg/kv/kvclient/kvtenant",
         "//pkg/kv/kvpb",
         "//pkg/kv/kvserver",
+        "//pkg/kv/kvserver/allocator/plan",
         "//pkg/kv/kvserver/closedts",
         "//pkg/kv/kvserver/kvserverpb",
         "//pkg/kv/kvserver/kvstorage",

--- a/pkg/server/serverpb/status.proto
+++ b/pkg/server/serverpb/status.proto
@@ -1444,6 +1444,8 @@ message HotRangesResponseV2 {
     repeated string tables = 17;
     // Indexes for the range
     repeated string indexes = 18;
+    // Range Descriptor for the range
+    cockroach.roachpb.RangeDescriptor desc = 19;
 
     // previously used for database, table, and index name
     reserved 4 to 6;


### PR DESCRIPTION
server: add tenant descriptors to hot ranges page

This may be a case of the "this never worked, but nobody has ever noticed". For multi-tenant deployments, when we call to collect the hot ranges, the calls go through this pathway to collect descriptors.

```
statusServer -> tenantConnect -> systemStatusServer -> distSQL
```

The problem with this is that when the call reaches the systemStatusServer, it has lost the ability to interface with the tenant catalog, and so it attempts to read the tenant system descriptors from the system system descriptors and comes up empty.

This change introduces tenant descriptor hydration at the first step of the process, in the statusServer, if it is being made for a non-system tenant.

Epic: none
Fixes: CRDB-48137

Release note (bug fix): fixes situation when databases, tables and indexes do not appear in the hot ranges page.