### PR TITLE
urlcheck: skip for pre-release and customized versions

### DIFF
--- a/pkg/build/info.go
+++ b/pkg/build/info.go
@@ -225,3 +225,8 @@ func TestingOverrideVersion(v string) func() {
 func MakeIssueURL(issue int) string {
 	return fmt.Sprintf("https://go.crdb.dev/issue-v/%d/%s", issue, VersionForURLs())
 }
+
+// ParsedVersion returns the parsed version.txt.
+func ParsedVersion() *version.Version {
+	return parsedVersionTxt
+}

--- a/pkg/testutils/lint/BUILD.bazel
+++ b/pkg/testutils/lint/BUILD.bazel
@@ -35,6 +35,7 @@ go_test(
     ],
     visibility = ["//build/bazelutil:__subpackages__"],
     deps = [
+        "//pkg/build",
         "//pkg/build/bazel",
         "//pkg/cmd/urlcheck/lib/urlcheck",
         "//pkg/internal/codeowners",

--- a/pkg/testutils/lint/nightly_lint_test.go
+++ b/pkg/testutils/lint/nightly_lint_test.go
@@ -13,6 +13,7 @@ import (
 	"os/exec"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/build"
 	"github.com/cockroachdb/cockroach/pkg/cmd/urlcheck/lib/urlcheck"
 	sqlparser "github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
@@ -24,6 +25,9 @@ func TestNightlyLint(t *testing.T) {
 	// TestHelpURLs checks that all help texts have a valid documentation URL.
 	t.Run("TestHelpURLs", func(t *testing.T) {
 		skip.UnderShort(t)
+		if build.ParsedVersion().IsPrerelease() || build.ParsedVersion().IsCustomOrNightlyBuild() {
+			skip.IgnoreLint(t, "pre-release or customized build")
+		}
 		if pkgSpecified {
 			skip.IgnoreLint(t, "PKG specified")
 		}


### PR DESCRIPTION
Previously, the urllint tool would use the production URLs for alphas and betas. The current SLA is to have the final URLs ready only for the GA version.

This commit makes the test skipped for pre-release and customized versions.


Release note: none
Fixes: #142883