### PR TITLE
crosscluster/producer: allow table level auth for REPLICATIONSOURCE

### DIFF
--- a/pkg/crosscluster/logical/logical_replication_job.go
+++ b/pkg/crosscluster/logical/logical_replication_job.go
@@ -488,6 +488,7 @@ func (p *logicalReplicationPlanner) generatePlanImpl(
 		// During an offline initial scan, we need to replicate the whole table, not
 		// just the primary keys.
 		UseTableSpan: payload.CreateTable && progress.ReplicatedTime.IsEmpty(),
+		StreamID:     streampb.StreamID(payload.StreamID),
 	}
 	for _, pair := range payload.ReplicationPairs {
 		req.TableIDs = append(req.TableIDs, pair.SrcDescriptorID)

--- a/pkg/crosscluster/producer/replication_manager.go
+++ b/pkg/crosscluster/producer/replication_manager.go
@@ -450,12 +450,30 @@ func (r *replicationStreamManagerImpl) AuthorizeViaJob(
 	return nil
 }
 
-func (r *replicationStreamManagerImpl) AuthorizeViaReplicationPriv(ctx context.Context) error {
-	err := r.evalCtx.SessionAccessor.CheckPrivilege(ctx,
-		syntheticprivilege.GlobalPrivilegeObject,
-		privilege.REPLICATIONSOURCE)
+// AuthorizeViaReplicationPriv ensures the user has the REPLICATIONSOUCE privilege. If tableNames is passed, then table level auth is tried.
+func (r *replicationStreamManagerImpl) AuthorizeViaReplicationPriv(
+	ctx context.Context, tableNames ...string,
+) (err error) {
 
-	if pgerror.GetPGCode(err) == pgcode.InsufficientPrivilege {
+	authorize := func() error {
+		// First try fast path for system level priv.
+		err = r.evalCtx.SessionAccessor.CheckPrivilege(ctx,
+			syntheticprivilege.GlobalPrivilegeObject,
+			privilege.REPLICATIONSOURCE)
+		if err == nil {
+			return nil
+		} else if pgerror.GetPGCode(err) != pgcode.InsufficientPrivilege {
+			return err
+		}
+		if len(tableNames) != 0 {
+			err = replicationutils.AuthorizeTableLevelPriv(ctx, r.resolver, r.evalCtx.SessionAccessor, privilege.REPLICATIONSOURCE, tableNames)
+			if err == nil {
+				return nil
+			} else if pgerror.GetPGCode(err) != pgcode.InsufficientPrivilege {
+				return err
+			}
+		}
+
 		// Fallback to legacy REPLICATION priv.
 		if fallbackErr := r.evalCtx.SessionAccessor.CheckPrivilege(ctx,
 			syntheticprivilege.GlobalPrivilegeObject,
@@ -465,10 +483,12 @@ func (r *replicationStreamManagerImpl) AuthorizeViaReplicationPriv(ctx context.C
 			// the deprecated REPLICATION priv.
 			return err
 		}
-	} else if err != nil {
-		return err
+		return nil
 	}
 
+	if err = authorize(); err != nil {
+		return err
+	}
 	r.authorized = true
 	return nil
 }

--- a/pkg/crosscluster/replicationutils/utils.go
+++ b/pkg/crosscluster/replicationutils/utils.go
@@ -347,6 +347,10 @@ func AuthorizeTableLevelPriv(
 			return err
 		}
 		lookupFlags := tree.ObjectLookupFlags{
+			// TODO(msbutler): for reasons beyond my paygrade, to grab offline
+			// descriptors, we need to also pass RequireMutable.
+			RequireMutable:       true,
+			IncludeOffline:       true,
 			Required:             true,
 			DesiredObjectKind:    tree.TableObject,
 			DesiredTableDescKind: tree.ResolveRequireTableDesc,

--- a/pkg/repstream/streampb/stream.proto
+++ b/pkg/repstream/streampb/stream.proto
@@ -170,6 +170,7 @@ message LogicalReplicationPlanRequest {
     // PlanAsOf is the time as of which the plan should be produced.
     util.hlc.Timestamp plan_as_of = 2 [(gogoproto.nullable) = false];
     bool use_table_span = 3;
+    int64 stream_id = 4 [(gogoproto.customname) = "StreamID", (gogoproto.casttype) = "StreamID"];
 }
 
 // SourcePartition contains per partition information for a replication plan.

--- a/pkg/sql/sem/builtins/replication_builtins.go
+++ b/pkg/sql/sem/builtins/replication_builtins.go
@@ -511,7 +511,14 @@ var replicationBuiltins = map[string]builtinDefinition{
 				if err := protoutil.Unmarshal(reqBytes, &req); err != nil {
 					return nil, err
 				}
-				if err := mgr.AuthorizeViaReplicationPriv(ctx); err != nil {
+				if req.StreamID != 0 {
+					if err := mgr.AuthorizeViaJob(ctx, req.StreamID); err != nil {
+						return nil, err
+					}
+					// Auth via replication priv exists to ensure a user that planned their
+					// job pre 25.2, which will not send a stream id, can still plan their
+					// distsql flow.
+				} else if err := mgr.AuthorizeViaReplicationPriv(ctx); err != nil {
 					return nil, err
 				}
 

--- a/pkg/sql/sem/builtins/replication_builtins.go
+++ b/pkg/sql/sem/builtins/replication_builtins.go
@@ -553,13 +553,13 @@ var replicationBuiltins = map[string]builtinDefinition{
 				if err != nil {
 					return nil, err
 				}
-				if err := mgr.AuthorizeViaReplicationPriv(ctx); err != nil {
-					return nil, err
-				}
 				reqBytes := []byte(tree.MustBeDBytes(args[0]))
 				req := streampb.ReplicationProducerRequest{}
 				if err := protoutil.Unmarshal(reqBytes, &req); err != nil {
 					return nil, err
+				}
+				if err := mgr.AuthorizeViaReplicationPriv(ctx, req.TableNames...); err != nil {
+					return nil, errors.Wrapf(err, "failed to auth")
 				}
 
 				spec, err := mgr.StartReplicationStreamForTables(ctx, req)

--- a/pkg/sql/sem/eval/context.go
+++ b/pkg/sql/sem/eval/context.go
@@ -934,7 +934,7 @@ type ReplicationStreamManager interface {
 	) (streampb.ReplicationProducerSpec, error)
 
 	AuthorizeViaJob(ctx context.Context, streamID streampb.StreamID) error
-	AuthorizeViaReplicationPriv(ctx context.Context) error
+	AuthorizeViaReplicationPriv(ctx context.Context, tableNames ...string) error
 }
 
 // StreamIngestManager represents a collection of APIs that streaming replication supports


### PR DESCRIPTION
Epic: none

Release note (ops change): previously, the user provided in the source URI in
the LDR stream required the REPLICATIONSOURCE priv at the system level. With
this change, the user only needs this priv on the source tables (i.e. a table
level priv).