### PR TITLE
jsonpath/eval: fix edge case with unwrapping an empty array

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/jsonb_path_query
+++ b/pkg/sql/logictest/testdata/logic_test/jsonb_path_query
@@ -108,6 +108,9 @@ SELECT jsonb_path_query(data, 'strict $.aa.aaa.aaaa') FROM a
 query empty
 SELECT jsonb_path_query('{}', '$.a')
 
+query empty
+SELECT jsonb_path_query('[]', '$.a')
+
 statement ok
 CREATE TABLE b (j JSONB)
 

--- a/pkg/util/jsonpath/eval/eval.go
+++ b/pkg/util/jsonpath/eval/eval.go
@@ -143,6 +143,11 @@ func (ctx *jsonpathCtx) executeAnyItem(
 	}
 	var agg []json.JSON
 	for _, item := range childItems {
+		// The case when this will happen is if jsonValue is an empty array,
+		// in which case we just skip the evaluation.
+		if item.Len() == 0 {
+			continue
+		}
 		if item.Len() != 1 {
 			return nil, errors.AssertionFailedf("unexpected path length")
 		}


### PR DESCRIPTION
This commit fixes an edge case with unwrapping an empty array in `executeAnyItem`. When the input json array is empty, unwrapping it with `AllPathsWithDepth` will result in an array of size 1, with the sole element being an empty array, thus violating the invariant that we will have one element in the array. Instead of hitting the assertion, we skip the rest of the loop.

Fixes: #143370
Epic: None
Release note: None