### PR TITLE
sql: refactor PlanCDCExpression

### DIFF
--- a/pkg/sql/distsql_plan_changefeed.go
+++ b/pkg/sql/distsql_plan_changefeed.go
@@ -125,10 +125,14 @@ func PlanCDCExpression(
 		return cdcPlan, err
 	}
 
+	// The top node contains the list of columns to return.
+	presentation := planColumns(p.curPlan.main.planNode)
+	if len(presentation) == 0 {
+		return cdcPlan, errors.AssertionFailedf("unable to determine result columns")
+	}
+
 	// Walk the plan, perform sanity checks and extract information we need.
 	var spans roachpb.Spans
-	var presentation colinfo.ResultColumns
-
 	if err := walkPlan(ctx, p.curPlan.main.planNode, planObserver{
 		enterNode: func(ctx context.Context, nodeName string, plan planNode) (bool, error) {
 			switch n := plan.(type) {
@@ -147,12 +151,6 @@ func PlanCDCExpression(
 				return false, errors.Newf(
 					"changefeed expression %s does not match any rows", tree.AsString(cdcExpr))
 			}
-
-			// Because the walk is top down, the top node is the node containing the
-			// list of columns to return.
-			if len(presentation) == 0 {
-				presentation = planColumns(plan)
-			}
 			return true, nil
 		},
 	}); err != nil {
@@ -162,10 +160,6 @@ func PlanCDCExpression(
 	if len(spans) == 0 {
 		// Should have been handled by the zeroNode check above.
 		return cdcPlan, errors.AssertionFailedf("expected at least 1 span to scan")
-	}
-
-	if len(presentation) == 0 {
-		return cdcPlan, errors.AssertionFailedf("unable to determine result columns")
 	}
 
 	if len(p.curPlan.subqueryPlans) > 0 || len(p.curPlan.cascades) > 0 ||

--- a/pkg/sql/distsql_plan_changefeed.go
+++ b/pkg/sql/distsql_plan_changefeed.go
@@ -133,27 +133,39 @@ func PlanCDCExpression(
 
 	// Walk the plan, perform sanity checks and extract information we need.
 	var spans roachpb.Spans
-	if err := walkPlan(ctx, p.curPlan.main.planNode, planObserver{
-		enterNode: func(ctx context.Context, nodeName string, plan planNode) (bool, error) {
-			switch n := plan.(type) {
-			case *scanNode:
-				// Collect spans we wanted to scan.  The select statement used for this
-				// plan should result in a single table scan of primary index span.
-				if len(spans) > 0 {
-					return false, errors.AssertionFailedf("unexpected multiple primary index scan operations")
-				}
-				if n.index.GetID() != n.desc.GetPrimaryIndexID() {
-					return false, errors.AssertionFailedf(
-						"expect scan of primary index, found scan of %d", n.index.GetID())
-				}
-				spans = n.spans
-			case *zeroNode:
-				return false, errors.Newf(
-					"changefeed expression %s does not match any rows", tree.AsString(cdcExpr))
+	var validatePlanAndCollectSpans func(p planNode) error
+	validatePlanAndCollectSpans = func(p planNode) error {
+		switch n := p.(type) {
+		case *scanNode:
+			// Collect spans we wanted to scan. The select statement used for
+			// this plan should result in a single table scan of primary index
+			// span.
+			if len(spans) > 0 {
+				return errors.AssertionFailedf("unexpected multiple primary index scan operations")
 			}
-			return true, nil
-		},
-	}); err != nil {
+			if n.index.GetID() != n.desc.GetPrimaryIndexID() {
+				return errors.AssertionFailedf(
+					"expect scan of primary index, found scan of %d", n.index.GetID())
+			}
+			spans = n.spans
+		case *zeroNode:
+			return errors.Newf(
+				"changefeed expression %s does not match any rows", tree.AsString(cdcExpr))
+		default:
+			// Recurse into input nodes.
+			for i, n := 0, p.InputCount(); i < n; i++ {
+				input, err := p.Input(i)
+				if err != nil {
+					return err
+				}
+				if err = validatePlanAndCollectSpans(input); err != nil {
+					return err
+				}
+			}
+		}
+		return nil
+	}
+	if err := validatePlanAndCollectSpans(p.curPlan.main.planNode); err != nil {
 		return cdcPlan, err
 	}
 


### PR DESCRIPTION
#### sql: collect CDC presentation outside of plan walker

The column presentation of the top node is collected to determine the
output columns for the CDC expression. There is no need to do this
within the plan node walker, so it has been moved outside.

Release note: None

#### sql: use InputCount and Input planNode methods to walk CDC plans

The `Input` and `InputCount` methods of the `planNode` interface are now
used to walk plan node trees of CDC expressions. This continues the
effort to deprecate and remove the plan node walkers (see #137620 for
more details on the motivation for this).

Epic: None
Release note: None

#### sql: refactor return statements in PlanCDCExpression

The `return` statements for error cases now explicitly return an empty
`CDCExpressionPlan` for clarity.

Release note: None
