### PR TITLE
changefeedccl: update TestChangefeedLaggingSpanCheckpointing

### DIFF
--- a/pkg/ccl/changefeedccl/helpers_test.go
+++ b/pkg/ccl/changefeedccl/helpers_test.go
@@ -11,6 +11,7 @@ import (
 	gosql "database/sql"
 	gojson "encoding/json"
 	"fmt"
+	"maps"
 	"math"
 	"math/rand"
 	"net/url"
@@ -868,7 +869,7 @@ func loadCheckpoint(t *testing.T, progress jobspb.Progress) *jobspb.TimestampSpa
 	if spanLevelCheckpoint.IsEmpty() {
 		return nil
 	}
-	t.Logf("found checkpoint: %#v", spanLevelCheckpoint)
+	t.Logf("found checkpoint: %v", maps.Collect(spanLevelCheckpoint.All()))
 	return spanLevelCheckpoint
 }
 

--- a/pkg/ccl/changefeedccl/kvfeed/physical_kv_feed.go
+++ b/pkg/ccl/changefeedccl/kvfeed/physical_kv_feed.go
@@ -99,12 +99,17 @@ func (p rangefeedFactory) Run(ctx context.Context, sink kvevent.Writer, cfg rang
 	if cfg.RangeObserver != nil {
 		rfOpts = append(rfOpts, kvcoord.WithRangeObserver(cfg.RangeObserver))
 	}
-	rfOpts = append(rfOpts, kvcoord.WithConsumerID(cfg.ConsumerID))
+	if cfg.ConsumerID != 0 {
+		rfOpts = append(rfOpts, kvcoord.WithConsumerID(cfg.ConsumerID))
+	}
 	if len(cfg.Knobs.RangefeedOptions) != 0 {
 		rfOpts = append(rfOpts, cfg.Knobs.RangefeedOptions...)
 	}
 
 	g.GoCtx(func(ctx context.Context) error {
+		if cfg.Knobs.OnRangeFeedStart != nil {
+			cfg.Knobs.OnRangeFeedStart(cfg.Spans)
+		}
 		return p(ctx, cfg.Spans, eventCh, rfOpts...)
 	})
 	return g.Wait()


### PR DESCRIPTION
This patch updates `TestChangefeedLaggingSpanCheckpointing` to ensure
we checkpoint spans at at least two different timestamps.

This patch also fixes the issue where the `OnRangeFeedStart` kvfeed
testing knob was not being invoked in production code.

Informs #137692
Fixes #143377

Release note: None