### PR TITLE
server: enable tenant testing for TestSSLEnforcement

### DIFF
--- a/pkg/server/authserver/authentication_test.go
+++ b/pkg/server/authserver/authentication_test.go
@@ -167,12 +167,6 @@ func TestSSLEnforcement(t *testing.T) {
 		{ts.URLPrefix, insecureContext, http.StatusTemporaryRedirect},
 	} {
 		t.Run(tc.path, func(t *testing.T) {
-			if tc.path == apiconstants.StatusPrefix+"nodes" && srv.TenantController().StartedDefaultTestTenant() {
-				// TODO(multitenant): The /_status/nodes endpoint should be
-				// available subject to a tenant capability.
-				skip.WithIssue(t, 110009)
-			}
-
 			client, err := tc.ctx.GetHTTPClient()
 			if err != nil {
 				t.Fatal(err)


### PR DESCRIPTION
Now that `/_status/nodes` is available to secondary tenants (thanks to #131644), we can flip on tenant testing for TestSSLEnforcement.

Fixes: #110009
Epic: CRDB-38968
Release note: none