### PR TITLE
sql: remove enable_row_level_security feature gate

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -393,7 +393,6 @@ func TestRLSBlocking(t *testing.T) {
 	testFn := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
 		sqlDB := sqlutils.MakeSQLRunner(s.DB)
 		sqlDB.Exec(t, `CREATE TABLE rls (a INT PRIMARY KEY, b STRING)`)
-		sqlDB.Exec(t, `SET enable_row_level_security = on`)
 		sqlDB.Exec(t, `INSERT INTO rls VALUES (0, 'initial')`)
 		sqlDB.Exec(t, `INSERT INTO rls VALUES (1, 'second')`)
 

--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning
@@ -414,9 +414,6 @@ ok1  CREATE TABLE public.ok1 (
 subtest partition_with_rls
 
 statement ok
-set enable_row_level_security=on;
-
-statement ok
 ALTER TABLE ok1 ENABLE ROW LEVEL SECURITY;
 
 statement ok
@@ -445,9 +442,6 @@ DROP POLICY test_policy ON ok1;
 
 statement ok
 ALTER TABLE ok1 DISABLE ROW LEVEL SECURITY;
-
-statement ok
-set enable_row_level_security=off;
 
 subtest end
 

--- a/pkg/cmd/roachtest/testdata/pg_regress/equivclass.diffs
+++ b/pkg/cmd/roachtest/testdata/pg_regress/equivclass.diffs
@@ -658,7 +658,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/equivclass.out --
  explain (costs off)
    select * from ec1,
      (select ff + 1 as x from
-@@ -362,92 +525,110 @@
+@@ -362,92 +525,108 @@
       union all
       select ff + 4 as x from ec1) as ss1
    where ss1.x = ec1.f1 and ec1.ff = 42::int8;
@@ -714,9 +714,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/equivclass.out --
  alter table ec1 enable row level security;
 +ERROR:  relation "ec1" does not exist
  create policy p1 on ec1 using (f1 < '5'::int8alias1);
-+ERROR:  unimplemented: row-level security is not yet implemented
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/73596/_version_
++ERROR:  relation "ec1" does not exist
  create user regress_user_ectest;
  grant select on ec0 to regress_user_ectest;
  grant select on ec1 to regress_user_ectest;

--- a/pkg/cmd/roachtest/testdata/pg_regress/event_trigger.diffs
+++ b/pkg/cmd/roachtest/testdata/pg_regress/event_trigger.diffs
@@ -914,7 +914,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/event_trigger.out
  CREATE TABLE event_trigger_test (a integer, b text);
  CREATE OR REPLACE FUNCTION start_command()
  RETURNS event_trigger AS $$
-@@ -563,37 +780,58 @@
+@@ -563,37 +780,46 @@
  RAISE NOTICE '% - ddl_command_start', tg_tag;
  END;
  $$ LANGUAGE plpgsql;
@@ -957,32 +957,20 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/event_trigger.out
  CREATE POLICY p1 ON event_trigger_test USING (FALSE);
 -NOTICE:  CREATE POLICY - ddl_command_start
 -NOTICE:  CREATE POLICY - ddl_command_end
-+ERROR:  unimplemented: row-level security is not yet implemented
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/73596/_version_
  ALTER POLICY p1 ON event_trigger_test USING (TRUE);
 -NOTICE:  ALTER POLICY - ddl_command_start
 -NOTICE:  ALTER POLICY - ddl_command_end
-+ERROR:  unimplemented: ALTER POLICY is not yet implemented
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/136997/_version_
  ALTER POLICY p1 ON event_trigger_test RENAME TO p2;
 -NOTICE:  ALTER POLICY - ddl_command_start
 -NOTICE:  ALTER POLICY - ddl_command_end
-+ERROR:  unimplemented: ALTER POLICY is not yet implemented
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/136996/_version_
  DROP POLICY p2 ON event_trigger_test;
 -NOTICE:  DROP POLICY - ddl_command_start
 -NOTICE:  DROP POLICY - sql_drop
 -NOTICE:  DROP POLICY - ddl_command_end
-+ERROR:  unimplemented: row-level security is not yet implemented
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/73596/_version_
  -- Check the object addresses of all the event triggers.
  SELECT
      e.evtname,
-@@ -604,13 +842,22 @@
+@@ -604,13 +830,22 @@
      LATERAL pg_identify_object_as_address('pg_event_trigger'::regclass, e.oid, 0) as b,
      LATERAL pg_get_object_address(b.type, b.object_names, b.object_args) as a
    ORDER BY e.evtname;

--- a/pkg/cmd/roachtest/testdata/pg_regress/merge.diffs
+++ b/pkg/cmd/roachtest/testdata/pg_regress/merge.diffs
@@ -2008,7 +2008,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/merge.out --label
  ROLLBACK;
  -- try updating the partition key column
  BEGIN;
-@@ -1732,64 +1690,102 @@
+@@ -1732,64 +1690,100 @@
      UPDATE SET tid = tid + 1, balance = balance + delta, val = val || ' updated by merge'
    WHEN NOT MATCHED THEN
      INSERT VALUES (sid, delta, 'inserted by merge');
@@ -2045,9 +2045,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/merge.out --label
  ALTER TABLE pa_target FORCE ROW LEVEL SECURITY;
 +ERROR:  relation "pa_target" does not exist
  CREATE POLICY pa_target_pol ON pa_target USING (tid != 0);
-+ERROR:  unimplemented: row-level security is not yet implemented
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/73596/_version_
++ERROR:  relation "pa_target" does not exist
  MERGE INTO pa_target t
    USING pa_source s
    ON t.tid = s.sid AND t.tid IN (1,2,3,4)
@@ -2130,7 +2128,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/merge.out --label
  -- try simple MERGE
  BEGIN;
  MERGE INTO pa_target t
-@@ -1799,91 +1795,78 @@
+@@ -1799,91 +1793,78 @@
      UPDATE SET balance = balance + delta, val = val || ' updated by merge'
    WHEN NOT MATCHED THEN
      INSERT VALUES (slogts::timestamp, sid, delta, 'inserted by merge');
@@ -2262,7 +2260,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/merge.out --label
  INSERT INTO cj_source1 VALUES (1, 10, 100);
  INSERT INTO cj_source1 VALUES (1, 20, 200);
  INSERT INTO cj_source1 VALUES (2, 20, 300);
-@@ -1898,6 +1881,10 @@
+@@ -1898,6 +1879,10 @@
  ON t.tid = sid1
  WHEN NOT MATCHED THEN
  	INSERT VALUES (sid1, delta, sval);
@@ -2273,7 +2271,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/merge.out --label
  -- try accessing columns from either side of the source join
  MERGE INTO cj_target t
  USING cj_source2 s2
-@@ -1907,6 +1894,10 @@
+@@ -1907,6 +1892,10 @@
  	INSERT VALUES (sid2, delta, sval)
  WHEN MATCHED THEN
  	DELETE;
@@ -2284,7 +2282,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/merge.out --label
  -- some simple expressions in INSERT targetlist
  MERGE INTO cj_target t
  USING cj_source2 s2
-@@ -1916,20 +1907,24 @@
+@@ -1916,20 +1905,24 @@
  	INSERT VALUES (sid2, delta + scat, sval)
  WHEN MATCHED THEN
  	UPDATE SET val = val || ' updated by merge';
@@ -2316,7 +2314,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/merge.out --label
  
  -- try it with an outer join and PlaceHolderVar
  MERGE INTO cj_target t
-@@ -1938,19 +1933,14 @@
+@@ -1938,19 +1931,14 @@
  ON t.tid = fj.scat
  WHEN NOT MATCHED THEN
  	INSERT (tid, balance, val) VALUES (fj.scat, fj.delta, fj.phv);
@@ -2343,7 +2341,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/merge.out --label
  
  ALTER TABLE cj_source1 RENAME COLUMN sid1 TO sid;
  ALTER TABLE cj_source2 RENAME COLUMN sid2 TO sid;
-@@ -1961,10 +1951,15 @@
+@@ -1961,10 +1949,15 @@
  ON t.tid = s1.sid
  WHEN NOT MATCHED THEN
  	INSERT VALUES (s2.sid, delta, sval);
@@ -2359,7 +2357,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/merge.out --label
  MERGE INTO fs_target t
  USING generate_series(1,100,1) AS id
  ON t.a = id
-@@ -1972,6 +1967,10 @@
+@@ -1972,6 +1965,10 @@
  	UPDATE SET b = b + id
  WHEN NOT MATCHED THEN
  	INSERT VALUES (id, -1);
@@ -2370,7 +2368,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/merge.out --label
  MERGE INTO fs_target t
  USING generate_series(1,100,2) AS id
  ON t.a = id
-@@ -1979,10 +1978,14 @@
+@@ -1979,10 +1976,14 @@
  	UPDATE SET b = b + id, c = 'updated '|| id.*::text
  WHEN NOT MATCHED THEN
  	INSERT VALUES (id, -1, 'inserted ' || id.*::text);
@@ -2386,7 +2384,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/merge.out --label
  (1 row)
  
  DROP TABLE fs_target;
-@@ -1995,12 +1998,29 @@
+@@ -1995,12 +1996,29 @@
      peaktemp        int,
      unitsales       int
  ) WITH (autovacuum_enabled=off);
@@ -2416,7 +2414,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/merge.out --label
  CREATE TABLE measurement_y2007m01 (
      filler          text,
      peaktemp        int,
-@@ -2009,8 +2029,14 @@
+@@ -2009,8 +2027,14 @@
      unitsales       int
      CHECK ( logdate >= DATE '2007-01-01' AND logdate < DATE '2007-02-01')
  ) WITH (autovacuum_enabled=off);
@@ -2431,7 +2429,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/merge.out --label
  INSERT INTO measurement VALUES (0, '2005-07-21', 5, 15);
  CREATE OR REPLACE FUNCTION measurement_insert_trigger()
  RETURNS TRIGGER AS $$
-@@ -2034,6 +2060,7 @@
+@@ -2034,6 +2058,7 @@
  CREATE TRIGGER insert_measurement_trigger
      BEFORE INSERT ON measurement
      FOR EACH ROW EXECUTE PROCEDURE measurement_insert_trigger();
@@ -2439,7 +2437,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/merge.out --label
  INSERT INTO measurement VALUES (1, '2006-02-10', 35, 10);
  INSERT INTO measurement VALUES (1, '2006-02-16', 45, 20);
  INSERT INTO measurement VALUES (1, '2006-03-17', 25, 10);
-@@ -2041,18 +2068,19 @@
+@@ -2041,18 +2066,19 @@
  INSERT INTO measurement VALUES (1, '2007-01-15', 10, 10);
  INSERT INTO measurement VALUES (1, '2007-01-17', 10, 10);
  SELECT tableoid::regclass, * FROM measurement ORDER BY city_id, logdate;
@@ -2468,7 +2466,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/merge.out --label
  INSERT INTO new_measurement VALUES (0, '2005-07-21', 25, 20);
  INSERT INTO new_measurement VALUES (1, '2006-03-01', 20, 10);
  INSERT INTO new_measurement VALUES (1, '2006-02-16', 50, 10);
-@@ -2072,25 +2100,12 @@
+@@ -2072,25 +2098,12 @@
  WHEN NOT MATCHED THEN INSERT
       (city_id, logdate, peaktemp, unitsales)
     VALUES (city_id, logdate, peaktemp, unitsales);
@@ -2499,7 +2497,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/merge.out --label
  ROLLBACK;
  MERGE into measurement m
   USING new_measurement nm ON
-@@ -2102,56 +2117,64 @@
+@@ -2102,56 +2115,64 @@
  WHEN NOT MATCHED THEN INSERT
       (city_id, logdate, peaktemp, unitsales)
     VALUES (city_id, logdate, peaktemp, unitsales);

--- a/pkg/cmd/roachtest/testdata/pg_regress/object_address.diffs
+++ b/pkg/cmd/roachtest/testdata/pg_regress/object_address.diffs
@@ -1,7 +1,7 @@
 diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/object_address.out --label=/mnt/data1/postgres/src/test/regress/results/object_address.out /mnt/data1/postgres/src/test/regress/expected/object_address.out /mnt/data1/postgres/src/test/regress/results/object_address.out
 --- /mnt/data1/postgres/src/test/regress/expected/object_address.out
 +++ /mnt/data1/postgres/src/test/regress/results/object_address.out
-@@ -10,32 +10,144 @@
+@@ -10,32 +10,141 @@
  CREATE SCHEMA addr_nsp;
  SET search_path TO 'addr_nsp';
  CREATE FOREIGN DATA WRAPPER addr_fdw;
@@ -117,9 +117,6 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/object_address.ou
  CREATE FUNCTION addr_nsp.trig() RETURNS TRIGGER LANGUAGE plpgsql AS $$ BEGIN END; $$;
  CREATE TRIGGER t BEFORE INSERT ON addr_nsp.gentable FOR EACH ROW EXECUTE PROCEDURE addr_nsp.trig();
  CREATE POLICY genpol ON addr_nsp.gentable;
-+ERROR:  unimplemented: row-level security is not yet implemented
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/73596/_version_
  CREATE PROCEDURE addr_nsp.proc(int4) LANGUAGE SQL AS $$ $$;
  CREATE SERVER "integer" FOREIGN DATA WRAPPER addr_fdw;
 +ERROR:  at or near "integer": syntax error: unimplemented: this syntax
@@ -146,7 +143,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/object_address.ou
  ALTER DEFAULT PRIVILEGES FOR ROLE regress_addr_user IN SCHEMA public GRANT ALL ON TABLES TO regress_addr_user;
  ALTER DEFAULT PRIVILEGES FOR ROLE regress_addr_user REVOKE DELETE ON TABLES FROM regress_addr_user;
  -- this transform would be quite unsafe to leave lying around,
-@@ -43,22 +155,75 @@
+@@ -43,22 +152,75 @@
  CREATE TRANSFORM FOR int LANGUAGE SQL (
      FROM SQL WITH FUNCTION prsd_lextype(internal),
      TO SQL WITH FUNCTION int4recv(internal));
@@ -227,7 +224,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/object_address.ou
  -- unrecognized object types
  DO $$
  DECLARE
-@@ -75,21 +240,33 @@
+@@ -75,21 +237,33 @@
      END LOOP;
  END;
  $$;
@@ -271,7 +268,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/object_address.ou
  DO $$
  DECLARE
      objtype text;
-@@ -123,265 +300,81 @@
+@@ -123,265 +297,81 @@
      END LOOP;
  END;
  $$;
@@ -584,7 +581,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/object_address.ou
  -- Make sure that NULL handling is correct.
  \pset null 'NULL'
  -- Temporarily disable fancy output, so as future additions never create
-@@ -455,86 +448,86 @@
+@@ -455,86 +445,86 @@
       pg_identify_object_as_address(classid, objid, objsubid) AS ioa (typ, nms, args),
       pg_get_object_address(typ, nms, ioa.args) AS addr2
  ORDER BY addr1.classid, addr1.objid, addr1.objsubid;
@@ -741,7 +738,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/object_address.ou
  --
  -- Checks for invalid objects
  --
-@@ -592,47 +585,6 @@
+@@ -592,47 +582,6 @@
           AS descr
  FROM objects
  ORDER BY objects.classid, objects.objid, objects.objsubid;

--- a/pkg/cmd/roachtest/testdata/pg_regress/rowsecurity.diffs
+++ b/pkg/cmd/roachtest/testdata/pg_regress/rowsecurity.diffs
@@ -44,19 +44,11 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  CREATE TABLE uaccount (
      pguser      name primary key,
      seclv       int
-@@ -73,426 +99,299 @@
-     ( 9, 22, 1, 'regress_rls_dave', 'awesome science fiction'),
-     (10, 33, 2, 'regress_rls_dave', 'awesome technology book');
- ALTER TABLE document ENABLE ROW LEVEL SECURITY;
-+ERROR:  unimplemented: row-level security is not yet implemented
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/73596/_version_
+@@ -76,13 +102,15 @@
  -- user's security level must be higher than or equal to document's
  CREATE POLICY p1 ON document AS PERMISSIVE
      USING (dlevel <= (SELECT seclv FROM uaccount WHERE pguser = current_user));
-+ERROR:  unimplemented: row-level security is not yet implemented
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/73596/_version_
++ERROR:  column "seclv" does not exist
  -- try to create a policy of bogus type
  CREATE POLICY p1 ON document AS UGLY
      USING (dlevel <= (SELECT seclv FROM uaccount WHERE pguser = current_user));
@@ -72,18 +64,9 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  -- but Dave isn't allowed to anything at cid 50 or above
  -- this is to make sure that we sort the policies by name first
  -- when applying WITH CHECK, a later INSERT by Dave should fail due
- -- to p1r first
- CREATE POLICY p2r ON document AS RESTRICTIVE TO regress_rls_dave
-     USING (cid <> 44 AND cid < 50);
-+ERROR:  unimplemented: row-level security is not yet implemented
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/73596/_version_
- -- and Dave isn't allowed to see manga documents
+@@ -93,354 +121,162 @@
  CREATE POLICY p1r ON document AS RESTRICTIVE TO regress_rls_dave
      USING (cid <> 44);
-+ERROR:  unimplemented: row-level security is not yet implemented
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/73596/_version_
  \dp
 -                                                                  Access privileges
 -       Schema       |   Name   | Type  |              Access privileges              | Column privileges |                  Policies                  
@@ -421,16 +404,11 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  -- only owner can change policies
  ALTER POLICY p1 ON document USING (true);    --fail
 -ERROR:  must be owner of table document
-+ERROR:  unimplemented: ALTER POLICY is not yet implemented
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/136997/_version_
++ERROR:  policy "p1" for table "document" does not exist
  DROP POLICY p1 ON document;                  --fail
 -ERROR:  must be owner of relation document
--SET SESSION AUTHORIZATION regress_rls_alice;
-+ERROR:  unimplemented: row-level security is not yet implemented
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/73596/_version_
-+SET SESSION AUTHORIZATION regress_rls_alice;
++ERROR:  policy "p1" for table "document" does not exist
+ SET SESSION AUTHORIZATION regress_rls_alice;
 +ERROR:  at or near "regress_rls_alice": syntax error: unimplemented: this syntax
 +DETAIL:  source SQL:
 +SET SESSION AUTHORIZATION regress_rls_alice
@@ -438,9 +416,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 +HINT:  You have attempted to use a feature that is not yet implemented.
 +See: https://go.crdb.dev/issue-v/40283/_version_
  ALTER POLICY p1 ON document USING (dauthor = current_user);
-+ERROR:  unimplemented: ALTER POLICY is not yet implemented
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/136997/_version_
++ERROR:  policy "p1" for table "document" does not exist
  -- viewpoint from regress_rls_bob again
  SET SESSION AUTHORIZATION regress_rls_bob;
 +ERROR:  at or near "regress_rls_bob": syntax error: unimplemented: this syntax
@@ -551,14 +527,8 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  CREATE POLICY p2 ON category
      USING (CASE WHEN current_user = 'regress_rls_bob' THEN cid IN (11, 33)
             WHEN current_user = 'regress_rls_carol' THEN cid IN (22, 44)
-            ELSE false END);
-+ERROR:  unimplemented: row-level security is not yet implemented
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/73596/_version_
+@@ -448,51 +284,91 @@
  ALTER TABLE category ENABLE ROW LEVEL SECURITY;
-+ERROR:  unimplemented: row-level security is not yet implemented
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/73596/_version_
  -- cannot delete PK referenced by invisible FK
  SET SESSION AUTHORIZATION regress_rls_bob;
 +ERROR:  at or near "regress_rls_bob": syntax error: unimplemented: this syntax
@@ -673,7 +643,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
     1 |  11 |      1 | regress_rls_bob   | my first novel
     2 |  11 |      2 | regress_rls_bob   | my second novel
     3 |  22 |      2 | regress_rls_bob   | my science fiction
-@@ -503,8 +402,9 @@
+@@ -503,8 +379,9 @@
     8 |  44 |      1 | regress_rls_carol | great manga
     9 |  22 |      1 | regress_rls_dave  | awesome science fiction
    10 |  33 |      2 | regress_rls_dave  | awesome technology book
@@ -685,7 +655,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  
  SELECT * FROM category;
   cid |      cname      
-@@ -517,10 +417,15 @@
+@@ -517,10 +394,15 @@
  
  -- database superuser does bypass RLS policy when disabled
  RESET SESSION AUTHORIZATION;
@@ -703,7 +673,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
     1 |  11 |      1 | regress_rls_bob   | my first novel
     2 |  11 |      2 | regress_rls_bob   | my second novel
     3 |  22 |      2 | regress_rls_bob   | my science fiction
-@@ -531,8 +436,9 @@
+@@ -531,8 +413,9 @@
     8 |  44 |      1 | regress_rls_carol | great manga
     9 |  22 |      1 | regress_rls_dave  | awesome science fiction
    10 |  33 |      2 | regress_rls_dave  | awesome technology book
@@ -715,7 +685,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  
  SELECT * FROM category;
   cid |      cname      
-@@ -545,10 +451,16 @@
+@@ -545,10 +428,16 @@
  
  -- database non-superuser with bypass privilege can bypass RLS policy when disabled
  SET SESSION AUTHORIZATION regress_rls_exempt_user;
@@ -734,7 +704,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
     1 |  11 |      1 | regress_rls_bob   | my first novel
     2 |  11 |      2 | regress_rls_bob   | my second novel
     3 |  22 |      2 | regress_rls_bob   | my science fiction
-@@ -559,8 +471,9 @@
+@@ -559,8 +448,9 @@
     8 |  44 |      1 | regress_rls_carol | great manga
     9 |  22 |      1 | regress_rls_dave  | awesome science fiction
    10 |  33 |      2 | regress_rls_dave  | awesome technology book
@@ -746,7 +716,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  
  SELECT * FROM category;
   cid |      cname      
-@@ -573,10 +486,16 @@
+@@ -573,10 +463,16 @@
  
  -- RLS policy does not apply to table owner when RLS enabled.
  SET SESSION AUTHORIZATION regress_rls_alice;
@@ -765,7 +735,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
     1 |  11 |      1 | regress_rls_bob   | my first novel
     2 |  11 |      2 | regress_rls_bob   | my second novel
     3 |  22 |      2 | regress_rls_bob   | my science fiction
-@@ -587,8 +506,9 @@
+@@ -587,8 +483,9 @@
     8 |  44 |      1 | regress_rls_carol | great manga
     9 |  22 |      1 | regress_rls_dave  | awesome science fiction
    10 |  33 |      2 | regress_rls_dave  | awesome technology book
@@ -777,7 +747,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  
  SELECT * FROM category;
   cid |      cname      
-@@ -601,10 +521,16 @@
+@@ -601,10 +498,16 @@
  
  -- RLS policy does not apply to table owner when RLS disabled.
  SET SESSION AUTHORIZATION regress_rls_alice;
@@ -796,7 +766,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
     1 |  11 |      1 | regress_rls_bob   | my first novel
     2 |  11 |      2 | regress_rls_bob   | my second novel
     3 |  22 |      2 | regress_rls_bob   | my science fiction
-@@ -615,8 +541,9 @@
+@@ -615,8 +518,9 @@
     8 |  44 |      1 | regress_rls_carol | great manga
     9 |  22 |      1 | regress_rls_dave  | awesome science fiction
    10 |  33 |      2 | regress_rls_dave  | awesome technology book
@@ -808,7 +778,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  
  SELECT * FROM category;
   cid |      cname      
-@@ -631,278 +558,210 @@
+@@ -631,278 +535,205 @@
  -- Table inheritance and RLS policy
  --
  SET SESSION AUTHORIZATION regress_rls_alice;
@@ -885,13 +855,8 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 +301	1	xxx	X
 +^
  CREATE POLICY p2 ON t2 FOR ALL TO PUBLIC USING (a % 2 = 1); -- be odd number
-+ERROR:  unimplemented: row-level security is not yet implemented
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/73596/_version_
++ERROR:  relation "t2" does not exist
  ALTER TABLE t1 ENABLE ROW LEVEL SECURITY;
-+ERROR:  unimplemented: row-level security is not yet implemented
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/73596/_version_
  ALTER TABLE t2 ENABLE ROW LEVEL SECURITY;
 +ERROR:  relation "t2" does not exist
  SET SESSION AUTHORIZATION regress_rls_bob;
@@ -1238,7 +1203,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  CREATE TABLE part_document (
      did         int,
      cid         int,
-@@ -910,14 +769,44 @@
+@@ -910,14 +741,44 @@
      dauthor     name,
      dtitle      text
  ) PARTITION BY RANGE (cid);
@@ -1283,7 +1248,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  INSERT INTO part_document VALUES
      ( 1, 11, 1, 'regress_rls_bob', 'my first novel'),
      ( 2, 11, 2, 'regress_rls_bob', 'my second novel'),
-@@ -929,1067 +818,919 @@
+@@ -929,1067 +790,844 @@
      ( 8, 55, 2, 'regress_rls_carol', 'great satire'),
      ( 9, 11, 1, 'regress_rls_dave', 'awesome science fiction'),
      (10, 99, 2, 'regress_rls_dave', 'awesome technology book');
@@ -1294,15 +1259,11 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  -- user's security level must be higher than or equal to document's
  CREATE POLICY pp1 ON part_document AS PERMISSIVE
      USING (dlevel <= (SELECT seclv FROM uaccount WHERE pguser = current_user));
-+ERROR:  unimplemented: row-level security is not yet implemented
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/73596/_version_
++ERROR:  relation "part_document" does not exist
  -- Dave is only allowed to see cid < 55
  CREATE POLICY pp1r ON part_document AS RESTRICTIVE TO regress_rls_dave
      USING (cid < 55);
-+ERROR:  unimplemented: row-level security is not yet implemented
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/73596/_version_
++ERROR:  relation "part_document" does not exist
  \d+ part_document
 -                    Partitioned table "regress_rls_schema.part_document"
 - Column  |  Type   | Collation | Nullable | Default | Storage  | Stats target | Description 
@@ -1536,9 +1497,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 +ERROR:  relation "part_document_satire" does not exist
  CREATE POLICY pp3 ON part_document_satire AS RESTRICTIVE
      USING (cid < 55);
-+ERROR:  unimplemented: row-level security is not yet implemented
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/73596/_version_
++ERROR:  relation "part_document_satire" does not exist
  -- This should fail with RLS violation now.
  SET SESSION AUTHORIZATION regress_rls_dave;
 +ERROR:  at or near "regress_rls_dave": syntax error: unimplemented: this syntax
@@ -1647,16 +1606,11 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  -- only owner can change policies
  ALTER POLICY pp1 ON part_document USING (true);    --fail
 -ERROR:  must be owner of table part_document
-+ERROR:  unimplemented: ALTER POLICY is not yet implemented
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/136997/_version_
++ERROR:  relation "part_document" does not exist
  DROP POLICY pp1 ON part_document;                  --fail
 -ERROR:  must be owner of relation part_document
--SET SESSION AUTHORIZATION regress_rls_alice;
-+ERROR:  unimplemented: row-level security is not yet implemented
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/73596/_version_
-+SET SESSION AUTHORIZATION regress_rls_alice;
++ERROR:  relation "part_document" does not exist
+ SET SESSION AUTHORIZATION regress_rls_alice;
 +ERROR:  at or near "regress_rls_alice": syntax error: unimplemented: this syntax
 +DETAIL:  source SQL:
 +SET SESSION AUTHORIZATION regress_rls_alice
@@ -1664,9 +1618,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 +HINT:  You have attempted to use a feature that is not yet implemented.
 +See: https://go.crdb.dev/issue-v/40283/_version_
  ALTER POLICY pp1 ON part_document USING (dauthor = current_user);
-+ERROR:  unimplemented: ALTER POLICY is not yet implemented
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/136997/_version_
++ERROR:  relation "part_document" does not exist
  -- viewpoint from regress_rls_bob again
  SET SESSION AUTHORIZATION regress_rls_bob;
 +ERROR:  at or near "regress_rls_bob": syntax error: unimplemented: this syntax
@@ -1858,11 +1810,8 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  SET row_security TO ON;
  CREATE POLICY pp3 ON part_document AS RESTRICTIVE
      USING ((SELECT dlevel <= seclv FROM uaccount WHERE pguser = current_user));
--SET SESSION AUTHORIZATION regress_rls_carol;
-+ERROR:  unimplemented: row-level security is not yet implemented
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/73596/_version_
-+SET SESSION AUTHORIZATION regress_rls_carol;
++ERROR:  relation "part_document" does not exist
+ SET SESSION AUTHORIZATION regress_rls_carol;
 +ERROR:  at or near "regress_rls_carol": syntax error: unimplemented: this syntax
 +DETAIL:  source SQL:
 +SET SESSION AUTHORIZATION regress_rls_carol
@@ -1886,9 +1835,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  CREATE POLICY d1 ON dependent FOR ALL
      TO PUBLIC
      USING (x = (SELECT d.x FROM dependee d WHERE d.y = y));
-+ERROR:  unimplemented: row-level security is not yet implemented
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/73596/_version_
++ERROR:  no data source matches prefix: d in this context
  DROP TABLE dependee; -- Should fail without CASCADE due to dependency on row security qual?
 -ERROR:  cannot drop table dependee because other objects depend on it
 -DETAIL:  policy d1 on table dependent depends on table dependee
@@ -1920,15 +1867,9 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 +See: https://go.crdb.dev/issue-v/40283/_version_
  CREATE TABLE rec1 (x integer, y integer);
  CREATE POLICY r1 ON rec1 USING (x = (SELECT r.x FROM rec1 r WHERE y = r.y));
-+ERROR:  unimplemented: row-level security is not yet implemented
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/73596/_version_
++ERROR:  no data source matches prefix: r in this context
  ALTER TABLE rec1 ENABLE ROW LEVEL SECURITY;
--SET SESSION AUTHORIZATION regress_rls_bob;
-+ERROR:  unimplemented: row-level security is not yet implemented
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/73596/_version_
-+SET SESSION AUTHORIZATION regress_rls_bob;
+ SET SESSION AUTHORIZATION regress_rls_bob;
 +ERROR:  at or near "regress_rls_bob": syntax error: unimplemented: this syntax
 +DETAIL:  source SQL:
 +SET SESSION AUTHORIZATION regress_rls_bob
@@ -1953,19 +1894,11 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 +See: https://go.crdb.dev/issue-v/40283/_version_
  CREATE TABLE rec2 (a integer, b integer);
  ALTER POLICY r1 ON rec1 USING (x = (SELECT a FROM rec2 WHERE b = y));
-+ERROR:  unimplemented: ALTER POLICY is not yet implemented
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/136997/_version_
++ERROR:  policy "r1" for table "rec1" does not exist
  CREATE POLICY r2 ON rec2 USING (a = (SELECT x FROM rec1 WHERE y = b));
-+ERROR:  unimplemented: row-level security is not yet implemented
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/73596/_version_
++ERROR:  column "x" does not exist
  ALTER TABLE rec2 ENABLE ROW LEVEL SECURITY;
--SET SESSION AUTHORIZATION regress_rls_bob;
-+ERROR:  unimplemented: row-level security is not yet implemented
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/73596/_version_
-+SET SESSION AUTHORIZATION regress_rls_bob;
+ SET SESSION AUTHORIZATION regress_rls_bob;
 +ERROR:  at or near "regress_rls_bob": syntax error: unimplemented: this syntax
 +DETAIL:  source SQL:
 +SET SESSION AUTHORIZATION regress_rls_bob
@@ -1998,15 +1931,10 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 +HINT:  You have attempted to use a feature that is not yet implemented.
 +See: https://go.crdb.dev/issue-v/40283/_version_
  ALTER POLICY r1 ON rec1 USING (x = (SELECT a FROM rec2v WHERE b = y));
-+ERROR:  unimplemented: ALTER POLICY is not yet implemented
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/136997/_version_
++ERROR:  policy "r1" for table "rec1" does not exist
  ALTER POLICY r2 ON rec2 USING (a = (SELECT x FROM rec1v WHERE y = b));
--SET SESSION AUTHORIZATION regress_rls_bob;
-+ERROR:  unimplemented: ALTER POLICY is not yet implemented
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/136997/_version_
-+SET SESSION AUTHORIZATION regress_rls_bob;
++ERROR:  policy "r2" for table "rec2" does not exist
+ SET SESSION AUTHORIZATION regress_rls_bob;
 +ERROR:  at or near "regress_rls_bob": syntax error: unimplemented: this syntax
 +DETAIL:  source SQL:
 +SET SESSION AUTHORIZATION regress_rls_bob
@@ -2054,15 +1982,10 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 +HINT:  You have attempted to use a feature that is not yet implemented.
 +See: https://go.crdb.dev/issue-v/40283/_version_
  CREATE POLICY r1 ON rec1 USING (x = (SELECT a FROM rec2v WHERE b = y));
-+ERROR:  unimplemented: row-level security is not yet implemented
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/73596/_version_
++ERROR:  column "a" does not exist
  CREATE POLICY r2 ON rec2 USING (a = (SELECT x FROM rec1v WHERE y = b));
--SET SESSION AUTHORIZATION regress_rls_bob;
-+ERROR:  unimplemented: row-level security is not yet implemented
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/73596/_version_
-+SET SESSION AUTHORIZATION regress_rls_bob;
++ERROR:  column "x" does not exist
+ SET SESSION AUTHORIZATION regress_rls_bob;
 +ERROR:  at or near "regress_rls_bob": syntax error: unimplemented: this syntax
 +DETAIL:  source SQL:
 +SET SESSION AUTHORIZATION regress_rls_bob
@@ -2093,27 +2016,14 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 +ERROR:  unknown function: public.fipshash()
  GRANT SELECT ON s1, s2 TO regress_rls_bob;
  CREATE POLICY p1 ON s1 USING (a in (select x from s2 where y like '%2f%'));
-+ERROR:  unimplemented: row-level security is not yet implemented
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/73596/_version_
++ERROR:  column "x" does not exist
  CREATE POLICY p2 ON s2 USING (x in (select a from s1 where b like '%22%'));
-+ERROR:  unimplemented: row-level security is not yet implemented
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/73596/_version_
++ERROR:  column "a" does not exist
  CREATE POLICY p3 ON s1 FOR INSERT WITH CHECK (a = (SELECT a FROM s1));
-+ERROR:  unimplemented: row-level security is not yet implemented
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/73596/_version_
++ERROR:  variable sub-expressions are not allowed in POLICY WITH CHECK
  ALTER TABLE s1 ENABLE ROW LEVEL SECURITY;
-+ERROR:  unimplemented: row-level security is not yet implemented
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/73596/_version_
  ALTER TABLE s2 ENABLE ROW LEVEL SECURITY;
--SET SESSION AUTHORIZATION regress_rls_bob;
-+ERROR:  unimplemented: row-level security is not yet implemented
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/73596/_version_
-+SET SESSION AUTHORIZATION regress_rls_bob;
+ SET SESSION AUTHORIZATION regress_rls_bob;
 +ERROR:  at or near "regress_rls_bob": syntax error: unimplemented: this syntax
 +DETAIL:  source SQL:
 +SET SESSION AUTHORIZATION regress_rls_bob
@@ -2134,15 +2044,10 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 +HINT:  You have attempted to use a feature that is not yet implemented.
 +See: https://go.crdb.dev/issue-v/40283/_version_
  DROP POLICY p3 on s1;
-+ERROR:  unimplemented: row-level security is not yet implemented
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/73596/_version_
++ERROR:  policy "p3" for table "s1" does not exist
  ALTER POLICY p2 ON s2 USING (x % 2 = 0);
--SET SESSION AUTHORIZATION regress_rls_bob;
-+ERROR:  unimplemented: ALTER POLICY is not yet implemented
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/136997/_version_
-+SET SESSION AUTHORIZATION regress_rls_bob;
++ERROR:  policy "p2" for table "s2" does not exist
+ SET SESSION AUTHORIZATION regress_rls_bob;
 +ERROR:  at or near "regress_rls_bob": syntax error: unimplemented: this syntax
 +DETAIL:  source SQL:
 +SET SESSION AUTHORIZATION regress_rls_bob
@@ -2181,11 +2086,8 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 +HINT:  You have attempted to use a feature that is not yet implemented.
 +See: https://go.crdb.dev/issue-v/40283/_version_
  ALTER POLICY p1 ON s1 USING (a in (select x from v2)); -- using VIEW in RLS policy
--SET SESSION AUTHORIZATION regress_rls_bob;
-+ERROR:  unimplemented: ALTER POLICY is not yet implemented
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/136997/_version_
-+SET SESSION AUTHORIZATION regress_rls_bob;
++ERROR:  policy "p1" for table "s1" does not exist
+ SET SESSION AUTHORIZATION regress_rls_bob;
 +ERROR:  at or near "regress_rls_bob": syntax error: unimplemented: this syntax
 +DETAIL:  source SQL:
 +SET SESSION AUTHORIZATION regress_rls_bob
@@ -2252,11 +2154,8 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 +HINT:  You have attempted to use a feature that is not yet implemented.
 +See: https://go.crdb.dev/issue-v/40283/_version_
  ALTER POLICY p2 ON s2 USING (x in (select a from s1 where b like '%d2%'));
--SET SESSION AUTHORIZATION regress_rls_bob;
-+ERROR:  unimplemented: ALTER POLICY is not yet implemented
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/136997/_version_
-+SET SESSION AUTHORIZATION regress_rls_bob;
++ERROR:  policy "p2" for table "s2" does not exist
+ SET SESSION AUTHORIZATION regress_rls_bob;
 +ERROR:  at or near "regress_rls_bob": syntax error: unimplemented: this syntax
 +DETAIL:  source SQL:
 +SET SESSION AUTHORIZATION regress_rls_bob
@@ -2806,13 +2705,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  INSERT INTO b1 (SELECT x, public.fipshash(x::text) FROM generate_series(-10,10) x);
 +ERROR:  unknown function: public.fipshash()
  CREATE POLICY p1 ON b1 USING (a % 2 = 0);
-+ERROR:  unimplemented: row-level security is not yet implemented
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/73596/_version_
  ALTER TABLE b1 ENABLE ROW LEVEL SECURITY;
-+ERROR:  unimplemented: row-level security is not yet implemented
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/73596/_version_
  GRANT ALL ON b1 TO regress_rls_bob;
  SET SESSION AUTHORIZATION regress_rls_bob;
 +ERROR:  at or near "regress_rls_bob": syntax error: unimplemented: this syntax
@@ -2953,29 +2846,15 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 +HINT:  You have attempted to use a feature that is not yet implemented.
 +See: https://go.crdb.dev/issue-v/40283/_version_
  DROP POLICY p1 ON document;
-+ERROR:  unimplemented: row-level security is not yet implemented
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/73596/_version_
++ERROR:  policy "p1" for table "document" does not exist
  DROP POLICY p1r ON document;
-+ERROR:  unimplemented: row-level security is not yet implemented
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/73596/_version_
  CREATE POLICY p1 ON document FOR SELECT USING (true);
-+ERROR:  unimplemented: row-level security is not yet implemented
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/73596/_version_
  CREATE POLICY p2 ON document FOR INSERT WITH CHECK (dauthor = current_user);
-+ERROR:  unimplemented: row-level security is not yet implemented
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/73596/_version_
  CREATE POLICY p3 ON document FOR UPDATE
    USING (cid = (SELECT cid from category WHERE cname = 'novel'))
    WITH CHECK (dauthor = current_user);
--SET SESSION AUTHORIZATION regress_rls_bob;
-+ERROR:  unimplemented: row-level security is not yet implemented
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/73596/_version_
-+SET SESSION AUTHORIZATION regress_rls_bob;
++ERROR:  column "cname" does not exist
+ SET SESSION AUTHORIZATION regress_rls_bob;
 +ERROR:  at or near "regress_rls_bob": syntax error: unimplemented: this syntax
 +DETAIL:  source SQL:
 +SET SESSION AUTHORIZATION regress_rls_bob
@@ -2985,7 +2864,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  -- Exists...
  SELECT * FROM document WHERE did = 2;
   did | cid | dlevel |     dauthor     |     dtitle      
-@@ -2001,7 +1742,6 @@
+@@ -2001,7 +1639,6 @@
  -- alternative UPDATE path happens to be taken):
  INSERT INTO document VALUES (2, (SELECT cid from category WHERE cname = 'novel'), 1, 'regress_rls_carol', 'my first novel')
      ON CONFLICT (did) DO UPDATE SET dtitle = EXCLUDED.dtitle, dauthor = EXCLUDED.dauthor;
@@ -2993,7 +2872,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  -- Violates USING qual for UPDATE policy p3.
  --
  -- UPDATE path is taken, but UPDATE fails purely because *existing* row to be
-@@ -2010,14 +1750,13 @@
+@@ -2010,14 +1647,13 @@
  INSERT INTO document VALUES (33, 22, 1, 'regress_rls_bob', 'okay science fiction'); -- preparation for next statement
  INSERT INTO document VALUES (33, (SELECT cid from category WHERE cname = 'novel'), 1, 'regress_rls_bob', 'Some novel, replaces sci-fi') -- takes UPDATE path
      ON CONFLICT (did) DO UPDATE SET dtitle = EXCLUDED.dtitle;
@@ -3011,7 +2890,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  (1 row)
  
  -- Fine (we INSERT, so "cid = 33" ("technology") isn't evaluated):
-@@ -2041,7 +1780,11 @@
+@@ -2041,7 +1677,11 @@
  -- passing quals:
  INSERT INTO document VALUES (78, (SELECT cid from category WHERE cname = 'novel'), 1, 'regress_rls_bob', 'some technology novel')
      ON CONFLICT (did) DO UPDATE SET dtitle = EXCLUDED.dtitle, cid = 33 RETURNING *;
@@ -3024,7 +2903,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  -- Don't fail just because INSERT doesn't satisfy WITH CHECK option that
  -- originated as a barrier/USING() qual from the UPDATE.  Note that the UPDATE
  -- path *isn't* taken, and so UPDATE-related policy does not apply:
-@@ -2058,15 +1801,43 @@
+@@ -2058,15 +1698,33 @@
  -- irrelevant, in fact.
  INSERT INTO document VALUES (79, (SELECT cid from category WHERE cname = 'technology'), 1, 'regress_rls_bob', 'technology book, can only insert')
      ON CONFLICT (did) DO UPDATE SET dtitle = EXCLUDED.dtitle RETURNING *;
@@ -3043,24 +2922,13 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 +HINT:  You have attempted to use a feature that is not yet implemented.
 +See: https://go.crdb.dev/issue-v/40283/_version_
  DROP POLICY p1 ON document;
-+ERROR:  unimplemented: row-level security is not yet implemented
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/73596/_version_
  DROP POLICY p2 ON document;
-+ERROR:  unimplemented: row-level security is not yet implemented
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/73596/_version_
  DROP POLICY p3 ON document;
-+ERROR:  unimplemented: row-level security is not yet implemented
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/73596/_version_
++ERROR:  policy "p3" for table "document" does not exist
  CREATE POLICY p3_with_default ON document FOR UPDATE
    USING (cid = (SELECT cid from category WHERE cname = 'novel'));
--SET SESSION AUTHORIZATION regress_rls_bob;
-+ERROR:  unimplemented: row-level security is not yet implemented
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/73596/_version_
-+SET SESSION AUTHORIZATION regress_rls_bob;
++ERROR:  column "cname" does not exist
+ SET SESSION AUTHORIZATION regress_rls_bob;
 +ERROR:  at or near "regress_rls_bob": syntax error: unimplemented: this syntax
 +DETAIL:  source SQL:
 +SET SESSION AUTHORIZATION regress_rls_bob
@@ -3070,7 +2938,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  -- Just because WCO-style enforcement of USING quals occurs with
  -- existing/target tuple does not mean that the implementation can be allowed
  -- to fail to also enforce this qual against the final tuple appended to
-@@ -2080,16 +1851,33 @@
+@@ -2080,16 +1738,31 @@
  -- UPDATE to make this fail:
  INSERT INTO document VALUES (79, (SELECT cid from category WHERE cname = 'technology'), 1, 'regress_rls_bob', 'technology book, can only insert')
      ON CONFLICT (did) DO UPDATE SET dtitle = EXCLUDED.dtitle RETURNING *;
@@ -3100,21 +2968,16 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 +HINT:  You have attempted to use a feature that is not yet implemented.
 +See: https://go.crdb.dev/issue-v/40283/_version_
  DROP POLICY p3_with_default ON document;
-+ERROR:  unimplemented: row-level security is not yet implemented
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/73596/_version_
++ERROR:  policy "p3_with_default" for table "document" does not exist
  --
  -- Test ALL policies with ON CONFLICT DO UPDATE (much the same as existing UPDATE
  -- tests)
-@@ -2097,76 +1885,121 @@
+@@ -2097,25 +1770,35 @@
  CREATE POLICY p3_with_all ON document FOR ALL
    USING (cid = (SELECT cid from category WHERE cname = 'novel'))
    WITH CHECK (dauthor = current_user);
--SET SESSION AUTHORIZATION regress_rls_bob;
-+ERROR:  unimplemented: row-level security is not yet implemented
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/73596/_version_
-+SET SESSION AUTHORIZATION regress_rls_bob;
++ERROR:  column "cname" does not exist
+ SET SESSION AUTHORIZATION regress_rls_bob;
 +ERROR:  at or near "regress_rls_bob": syntax error: unimplemented: this syntax
 +DETAIL:  source SQL:
 +SET SESSION AUTHORIZATION regress_rls_bob
@@ -3144,33 +3007,19 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 +              ^
 +HINT:  try \h RESET
  DROP POLICY p3_with_all ON document;
-+ERROR:  unimplemented: row-level security is not yet implemented
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/73596/_version_
++ERROR:  policy "p3_with_all" for table "document" does not exist
  ALTER TABLE document ADD COLUMN dnotes text DEFAULT '';
  -- all documents are readable
  CREATE POLICY p1 ON document FOR SELECT USING (true);
-+ERROR:  unimplemented: row-level security is not yet implemented
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/73596/_version_
- -- one may insert documents only authored by them
- CREATE POLICY p2 ON document FOR INSERT WITH CHECK (dauthor = current_user);
-+ERROR:  unimplemented: row-level security is not yet implemented
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/73596/_version_
- -- one may only update documents in 'novel' category and new dlevel must be > 0
+@@ -2125,48 +1808,69 @@
  CREATE POLICY p3 ON document FOR UPDATE
    USING (cid = (SELECT cid from category WHERE cname = 'novel'))
    WITH CHECK (dlevel > 0);
-+ERROR:  unimplemented: row-level security is not yet implemented
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/73596/_version_
++ERROR:  column "cname" does not exist
  -- one may only delete documents in 'manga' category
  CREATE POLICY p4 ON document FOR DELETE
    USING (cid = (SELECT cid from category WHERE cname = 'manga'));
-+ERROR:  unimplemented: row-level security is not yet implemented
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/73596/_version_
++ERROR:  column "cname" does not exist
  SELECT * FROM document;
   did | cid | dlevel |      dauthor      |              dtitle              | dnotes 
  -----+-----+--------+-------------------+----------------------------------+--------
@@ -3239,7 +3088,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  -- There is a MATCH for did = 3, but UPDATE's USING qual does not allow
  -- updating an item in category 'science fiction'
  MERGE INTO document d
-@@ -2174,7 +2007,10 @@
+@@ -2174,7 +1878,10 @@
  ON did = s.sdid
  WHEN MATCHED THEN
  	UPDATE SET dnotes = dnotes || ' notes added by merge ';
@@ -3251,7 +3100,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  -- The same thing with DELETE action, but fails again because no permissions
  -- to delete items in 'science fiction' category that did 3 belongs to.
  MERGE INTO document d
-@@ -2182,7 +2018,10 @@
+@@ -2182,7 +1889,10 @@
  ON did = s.sdid
  WHEN MATCHED THEN
  	DELETE;
@@ -3263,7 +3112,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  -- Document with did 4 belongs to 'manga' category which is allowed for
  -- deletion. But this fails because the UPDATE action is matched first and
  -- UPDATE policy does not allow updation in the category.
-@@ -2193,7 +2032,10 @@
+@@ -2193,7 +1903,10 @@
  	UPDATE SET dnotes = dnotes || ' notes added by merge '
  WHEN MATCHED THEN
  	DELETE;
@@ -3275,7 +3124,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  -- UPDATE action is not matched this time because of the WHEN qual.
  -- DELETE still fails because role regress_rls_bob does not have SELECT
  -- privileges on 'manga' category row in the category table.
-@@ -2204,7 +2046,10 @@
+@@ -2204,7 +1917,10 @@
  	UPDATE SET dnotes = dnotes || ' notes added by merge '
  WHEN MATCHED THEN
  	DELETE;
@@ -3287,7 +3136,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  -- OK if DELETE is replaced with DO NOTHING
  MERGE INTO document d
  USING (SELECT 4 as sdid) s
-@@ -2213,16 +2058,31 @@
+@@ -2213,16 +1929,31 @@
  	UPDATE SET dnotes = dnotes || ' notes added by merge '
  WHEN MATCHED THEN
  	DO NOTHING;
@@ -3321,7 +3170,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  MERGE INTO document d
  USING (SELECT 4 as sdid) s
  ON did = s.sdid
-@@ -2230,9 +2090,24 @@
+@@ -2230,9 +1961,24 @@
  	UPDATE SET dnotes = dnotes || ' notes added by merge '
  WHEN MATCHED THEN
  	DELETE;
@@ -3347,7 +3196,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  -- Try INSERT action. This fails because we are trying to insert
  -- dauthor = regress_rls_dave and INSERT's WITH CHECK does not allow
  -- that
-@@ -2243,7 +2118,10 @@
+@@ -2243,7 +1989,10 @@
  	DELETE
  WHEN NOT MATCHED THEN
  	INSERT VALUES (12, 11, 1, 'regress_rls_dave', 'another novel');
@@ -3359,7 +3208,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  -- This should be fine
  MERGE INTO document d
  USING (SELECT 12 as sdid) s
-@@ -2252,6 +2130,10 @@
+@@ -2252,6 +2001,10 @@
  	DELETE
  WHEN NOT MATCHED THEN
  	INSERT VALUES (12, 11, 1, 'regress_rls_bob', 'another novel');
@@ -3370,7 +3219,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  -- ok
  MERGE INTO document d
  USING (SELECT 1 as sdid) s
-@@ -2260,13 +2142,34 @@
+@@ -2260,13 +2013,29 @@
  	UPDATE SET dnotes = dnotes || ' notes added by merge4 '
  WHEN NOT MATCHED THEN
  	INSERT VALUES (12, 11, 1, 'regress_rls_bob', 'another novel');
@@ -3387,16 +3236,10 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 +              ^
 +HINT:  try \h RESET
  DROP POLICY p1 ON document;
-+ERROR:  unimplemented: row-level security is not yet implemented
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/73596/_version_
  CREATE POLICY p1 ON document FOR SELECT
    USING (cid = (SELECT cid from category WHERE cname = 'novel'));
--SET SESSION AUTHORIZATION regress_rls_bob;
-+ERROR:  unimplemented: row-level security is not yet implemented
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/73596/_version_
-+SET SESSION AUTHORIZATION regress_rls_bob;
++ERROR:  column "cname" does not exist
+ SET SESSION AUTHORIZATION regress_rls_bob;
 +ERROR:  at or near "regress_rls_bob": syntax error: unimplemented: this syntax
 +DETAIL:  source SQL:
 +SET SESSION AUTHORIZATION regress_rls_bob
@@ -3406,7 +3249,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  -- MERGE can no longer see the matching row and hence attempts the
  -- NOT MATCHED action, which results in unique key violation
  MERGE INTO document d
-@@ -2276,7 +2179,10 @@
+@@ -2276,7 +2045,10 @@
  	UPDATE SET dnotes = dnotes || ' notes added by merge5 '
  WHEN NOT MATCHED THEN
  	INSERT VALUES (12, 11, 1, 'regress_rls_bob', 'another novel');
@@ -3418,7 +3261,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  -- UPDATE action fails if new row is not visible
  MERGE INTO document d
  USING (SELECT 1 as sdid) s
-@@ -2284,7 +2190,10 @@
+@@ -2284,7 +2056,10 @@
  WHEN MATCHED THEN
  	UPDATE SET dnotes = dnotes || ' notes added by merge6 ',
  			   cid = (SELECT cid from category WHERE cname = 'technology');
@@ -3430,7 +3273,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  -- but OK if new row is visible
  MERGE INTO document d
  USING (SELECT 1 as sdid) s
-@@ -2292,6 +2201,10 @@
+@@ -2292,6 +2067,10 @@
  WHEN MATCHED THEN
  	UPDATE SET dnotes = dnotes || ' notes added by merge7 ',
  			   cid = (SELECT cid from category WHERE cname = 'novel');
@@ -3441,7 +3284,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  -- OK to insert a new row that is not visible
  MERGE INTO document d
  USING (SELECT 13 as sdid) s
-@@ -2300,35 +2213,54 @@
+@@ -2300,35 +2079,52 @@
  	UPDATE SET dnotes = dnotes || ' notes added by merge8 '
  WHEN NOT MATCHED THEN
  	INSERT VALUES (13, 44, 1, 'regress_rls_bob', 'new manga');
@@ -3458,9 +3301,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  -- drop the restrictive SELECT policy so that we can look at the
  -- final state of the table
  DROP POLICY p1 ON document;
-+ERROR:  unimplemented: row-level security is not yet implemented
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/73596/_version_
++ERROR:  policy "p1" for table "document" does not exist
  -- Just check everything went per plan
  SELECT * FROM document;
 - did | cid | dlevel |      dauthor      |              dtitle              |                                            dnotes                                            
@@ -3505,23 +3346,10 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  CREATE TABLE z1 (a int, b text);
  CREATE TABLE z2 (a int, b text);
  GRANT SELECT ON z1,z2 TO regress_rls_group1, regress_rls_group2,
-@@ -2339,582 +2271,654 @@
-     (3, 'ccc'),
-     (4, 'dad');
- CREATE POLICY p1 ON z1 TO regress_rls_group1 USING (a % 2 = 0);
-+ERROR:  unimplemented: row-level security is not yet implemented
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/73596/_version_
+@@ -2342,579 +2138,636 @@
  CREATE POLICY p2 ON z1 TO regress_rls_group2 USING (a % 2 = 1);
-+ERROR:  unimplemented: row-level security is not yet implemented
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/73596/_version_
  ALTER TABLE z1 ENABLE ROW LEVEL SECURITY;
--SET SESSION AUTHORIZATION regress_rls_bob;
-+ERROR:  unimplemented: row-level security is not yet implemented
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/73596/_version_
-+SET SESSION AUTHORIZATION regress_rls_bob;
+ SET SESSION AUTHORIZATION regress_rls_bob;
 +ERROR:  at or near "regress_rls_bob": syntax error: unimplemented: this syntax
 +DETAIL:  source SQL:
 +SET SESSION AUTHORIZATION regress_rls_bob
@@ -4045,9 +3873,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  CREATE TABLE z1_blacklist (a int);
  INSERT INTO z1_blacklist VALUES (3), (4);
  CREATE POLICY p3 ON z1 AS RESTRICTIVE USING (a NOT IN (SELECT a FROM z1_blacklist));
-+ERROR:  unimplemented: row-level security is not yet implemented
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/73596/_version_
++ERROR:  must be owner of relation z1
  -- Query as role that is not owner of table but is owner of view without permissions.
  SET SESSION AUTHORIZATION regress_rls_bob;
 +ERROR:  at or near "regress_rls_bob": syntax error: unimplemented: this syntax
@@ -4162,11 +3988,8 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 +See: https://go.crdb.dev/issue-v/40283/_version_
  REVOKE SELECT ON z1_blacklist FROM regress_rls_bob;
  DROP POLICY p3 ON z1;
--SET SESSION AUTHORIZATION regress_rls_bob;
-+ERROR:  unimplemented: row-level security is not yet implemented
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/73596/_version_
-+SET SESSION AUTHORIZATION regress_rls_bob;
++ERROR:  must be owner of relation z1
+ SET SESSION AUTHORIZATION regress_rls_bob;
 +ERROR:  at or near "regress_rls_bob": syntax error: unimplemented: this syntax
 +DETAIL:  source SQL:
 +SET SESSION AUTHORIZATION regress_rls_bob
@@ -4417,9 +4240,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 +HINT:  You have attempted to use a feature that is not yet implemented.
 +See: https://go.crdb.dev/issue-v/40283/_version_
  CREATE POLICY p3 ON z1 AS RESTRICTIVE USING (a NOT IN (SELECT a FROM z1_blacklist));
-+ERROR:  unimplemented: row-level security is not yet implemented
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/73596/_version_
++ERROR:  must be owner of relation z1
  -- Query as role that is not owner of table but is owner of view without permissions.
  SET SESSION AUTHORIZATION regress_rls_bob;
 +ERROR:  at or near "regress_rls_bob": syntax error: unimplemented: this syntax
@@ -4573,35 +4394,10 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  CREATE TABLE x1 (a int, b text, c text);
  GRANT ALL ON x1 TO PUBLIC;
  INSERT INTO x1 VALUES
-@@ -2927,516 +2931,402 @@
-     (7, 'fgh', 'regress_rls_carol'),
-     (8, 'fgh', 'regress_rls_carol');
- CREATE POLICY p0 ON x1 FOR ALL USING (c = current_user);
-+ERROR:  unimplemented: row-level security is not yet implemented
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/73596/_version_
- CREATE POLICY p1 ON x1 FOR SELECT USING (a % 2 = 0);
-+ERROR:  unimplemented: row-level security is not yet implemented
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/73596/_version_
- CREATE POLICY p2 ON x1 FOR INSERT WITH CHECK (a % 2 = 1);
-+ERROR:  unimplemented: row-level security is not yet implemented
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/73596/_version_
- CREATE POLICY p3 ON x1 FOR UPDATE USING (a % 2 = 0);
-+ERROR:  unimplemented: row-level security is not yet implemented
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/73596/_version_
+@@ -2933,103 +2786,46 @@
  CREATE POLICY p4 ON x1 FOR DELETE USING (a < 8);
-+ERROR:  unimplemented: row-level security is not yet implemented
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/73596/_version_
  ALTER TABLE x1 ENABLE ROW LEVEL SECURITY;
--SET SESSION AUTHORIZATION regress_rls_bob;
-+ERROR:  unimplemented: row-level security is not yet implemented
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/73596/_version_
-+SET SESSION AUTHORIZATION regress_rls_bob;
+ SET SESSION AUTHORIZATION regress_rls_bob;
 +ERROR:  at or near "regress_rls_bob": syntax error: unimplemented: this syntax
 +DETAIL:  source SQL:
 +SET SESSION AUTHORIZATION regress_rls_bob
@@ -4719,32 +4515,14 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  CREATE TABLE y2 (a int, b text);
  GRANT ALL ON y1, y2 TO regress_rls_bob;
  CREATE POLICY p1 ON y1 FOR ALL USING (a % 2 = 0);
-+ERROR:  unimplemented: row-level security is not yet implemented
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/73596/_version_
  CREATE POLICY p2 ON y1 FOR SELECT USING (a > 2);
-+ERROR:  unimplemented: row-level security is not yet implemented
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/73596/_version_
  CREATE POLICY p1 ON y1 FOR SELECT USING (a % 2 = 1);  --fail
 -ERROR:  policy "p1" for table "y1" already exists
-+ERROR:  unimplemented: row-level security is not yet implemented
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/73596/_version_
++ERROR:  policy with name "p1" already exists on table "y1"
  CREATE POLICY p1 ON y2 FOR ALL USING (a % 2 = 0);  --OK
-+ERROR:  unimplemented: row-level security is not yet implemented
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/73596/_version_
  ALTER TABLE y1 ENABLE ROW LEVEL SECURITY;
-+ERROR:  unimplemented: row-level security is not yet implemented
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/73596/_version_
  ALTER TABLE y2 ENABLE ROW LEVEL SECURITY;
-+ERROR:  unimplemented: row-level security is not yet implemented
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/73596/_version_
- --
- -- Expression structure with SBV
+@@ -3038,188 +2834,121 @@
  --
  -- Create view as table owner.  RLS should NOT be applied.
  SET SESSION AUTHORIZATION regress_rls_alice;
@@ -4817,15 +4595,8 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  INSERT INTO y2 (SELECT x, public.fipshash(x::text) FROM generate_series(0,20) x);
 +ERROR:  unknown function: public.fipshash()
  CREATE POLICY p2 ON y2 USING (a % 3 = 0);
-+ERROR:  unimplemented: row-level security is not yet implemented
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/73596/_version_
  CREATE POLICY p3 ON y2 USING (a % 4 = 0);
--SET SESSION AUTHORIZATION regress_rls_bob;
-+ERROR:  unimplemented: row-level security is not yet implemented
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/73596/_version_
-+SET SESSION AUTHORIZATION regress_rls_bob;
+ SET SESSION AUTHORIZATION regress_rls_bob;
 +ERROR:  at or near "regress_rls_bob": syntax error: unimplemented: this syntax
 +DETAIL:  source SQL:
 +SET SESSION AUTHORIZATION regress_rls_bob
@@ -5016,19 +4787,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  CREATE TABLE t1 (a integer);
  GRANT SELECT ON t1 TO regress_rls_bob, regress_rls_carol;
  CREATE POLICY p1 ON t1 TO regress_rls_bob USING ((a % 2) = 0);
-+ERROR:  unimplemented: row-level security is not yet implemented
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/73596/_version_
- CREATE POLICY p2 ON t1 TO regress_rls_carol USING ((a % 4) = 0);
-+ERROR:  unimplemented: row-level security is not yet implemented
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/73596/_version_
- ALTER TABLE t1 ENABLE ROW LEVEL SECURITY;
-+ERROR:  unimplemented: row-level security is not yet implemented
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/73596/_version_
- -- Prepare as regress_rls_bob
- SET ROLE regress_rls_bob;
+@@ -3230,112 +2959,85 @@
  PREPARE role_inval AS SELECT * FROM t1;
  -- Check plan
  EXPLAIN (COSTS OFF) EXECUTE role_inval;
@@ -5087,9 +4846,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  CREATE TABLE t1 (a integer, b text);
 +ERROR:  relation "root.regress_rls_schema.t1" already exists
  CREATE POLICY p1 ON t1 USING (a % 2 = 0);
-+ERROR:  unimplemented: row-level security is not yet implemented
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/73596/_version_
++ERROR:  must be owner of relation t1
  ALTER TABLE t1 ENABLE ROW LEVEL SECURITY;
 +ERROR:  must be owner of table t1 or have CREATE privilege on table t1
  GRANT ALL ON t1 TO regress_rls_bob;
@@ -5187,32 +4944,30 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 +HINT:  try \h RESET
  ALTER POLICY p1 ON t1 RENAME TO p1; --fail
 -ERROR:  policy "p1" for table "t1" already exists
-+ERROR:  unimplemented: ALTER POLICY is not yet implemented
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/136996/_version_
++ERROR:  must be owner of relation t1
  SELECT polname, relname
      FROM pg_policy pol
      JOIN pg_class pc ON (pc.oid = pol.polrelid)
-     WHERE relname = 't1';
+@@ -3343,95 +3045,74 @@
   polname | relname 
  ---------+---------
-- p1      | t1
+  p1      | t1
 -(1 row)
-+(0 rows)
++ p2      | t1
++(2 rows)
  
  ALTER POLICY p1 ON t1 RENAME TO p2; --ok
-+ERROR:  unimplemented: ALTER POLICY is not yet implemented
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/136996/_version_
++ERROR:  must be owner of relation t1
  SELECT polname, relname
      FROM pg_policy pol
      JOIN pg_class pc ON (pc.oid = pol.polrelid)
      WHERE relname = 't1';
   polname | relname 
  ---------+---------
-- p2      | t1
++ p1      | t1
+  p2      | t1
 -(1 row)
-+(0 rows)
++(2 rows)
  
  --
  -- Check INSERT SELECT
@@ -5328,18 +5083,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  CREATE TABLE blog (id integer, author text, post text);
  CREATE TABLE comment (blog_id integer, message text);
  GRANT ALL ON blog, comment TO regress_rls_bob;
- CREATE POLICY blog_1 ON blog USING (id % 2 = 0);
-+ERROR:  unimplemented: row-level security is not yet implemented
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/73596/_version_
- ALTER TABLE blog ENABLE ROW LEVEL SECURITY;
-+ERROR:  unimplemented: row-level security is not yet implemented
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/73596/_version_
- INSERT INTO blog VALUES
-     (1, 'alice', 'blog #1'),
-     (2, 'bob', 'blog #1'),
-@@ -3451,1097 +3341,412 @@
+@@ -3451,1097 +3132,392 @@
      (4, 'insane!'),
      (2, 'who did it?');
  SET SESSION AUTHORIZATION regress_rls_bob;
@@ -5384,15 +5128,8 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 +HINT:  You have attempted to use a feature that is not yet implemented.
 +See: https://go.crdb.dev/issue-v/40283/_version_
  CREATE POLICY comment_1 ON comment USING (blog_id < 4);
-+ERROR:  unimplemented: row-level security is not yet implemented
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/73596/_version_
  ALTER TABLE comment ENABLE ROW LEVEL SECURITY;
--SET SESSION AUTHORIZATION regress_rls_bob;
-+ERROR:  unimplemented: row-level security is not yet implemented
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/73596/_version_
-+SET SESSION AUTHORIZATION regress_rls_bob;
+ SET SESSION AUTHORIZATION regress_rls_bob;
 +ERROR:  at or near "regress_rls_bob": syntax error: unimplemented: this syntax
 +DETAIL:  source SQL:
 +SET SESSION AUTHORIZATION regress_rls_bob
@@ -5442,9 +5179,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 +              ^
 +HINT:  try \h RESET
  DROP POLICY p2 ON t1;
-+ERROR:  unimplemented: row-level security is not yet implemented
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/73596/_version_
++ERROR:  must be owner of relation t1
  ALTER TABLE t1 OWNER TO regress_rls_alice;
 +ERROR:  must be owner of table t1
  -- Check that default deny does not apply to superuser.
@@ -5613,13 +5348,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 +ERROR:  relation "copy_t" does not exist
  CREATE TABLE copy_t (a integer, b text);
  CREATE POLICY p1 ON copy_t USING (a % 2 = 0);
-+ERROR:  unimplemented: row-level security is not yet implemented
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/73596/_version_
  ALTER TABLE copy_t ENABLE ROW LEVEL SECURITY;
-+ERROR:  unimplemented: row-level security is not yet implemented
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/73596/_version_
  GRANT ALL ON copy_t TO regress_rls_bob, regress_rls_exempt_user;
 +ERROR:  role/user "regress_rls_exempt_user" does not exist
  INSERT INTO copy_t (SELECT x, public.fipshash(x::text) FROM generate_series(0,10) x);
@@ -5734,13 +5463,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  SET row_security TO ON;
  CREATE TABLE copy_rel_to (a integer, b text);
  CREATE POLICY p1 ON copy_rel_to USING (a % 2 = 0);
-+ERROR:  unimplemented: row-level security is not yet implemented
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/73596/_version_
  ALTER TABLE copy_rel_to ENABLE ROW LEVEL SECURITY;
-+ERROR:  unimplemented: row-level security is not yet implemented
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/73596/_version_
  GRANT ALL ON copy_rel_to TO regress_rls_bob, regress_rls_exempt_user;
 +ERROR:  role/user "regress_rls_exempt_user" does not exist
  INSERT INTO copy_rel_to VALUES (1, public.fipshash('1'));

--- a/pkg/cmd/roachtest/testdata/pg_regress/stats_ext.diffs
+++ b/pkg/cmd/roachtest/testdata/pg_regress/stats_ext.diffs
@@ -4074,7 +4074,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/stats_ext.out --l
  DROP TABLE expr_stats_incompatible_test;
  -- Permission tests. Users should not be able to see specific data values in
  -- the extended statistics, if they lack permission to see those values in
-@@ -3088,205 +2141,511 @@
+@@ -3088,205 +2141,508 @@
       SELECT mod(i,5), mod(i,10) FROM generate_series(1,100) s(i);
  CREATE STATISTICS tststats.priv_test_stats (mcv) ON a, b
    FROM tststats.priv_test_tbl;
@@ -4651,9 +4651,6 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/stats_ext.out --l
 +              ^
 +HINT:  try \h RESET
  ALTER TABLE tststats.priv_test_tbl ENABLE ROW LEVEL SECURITY;
-+ERROR:  unimplemented: row-level security is not yet implemented
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/73596/_version_
  GRANT SELECT, DELETE ON tststats.priv_test_tbl TO regress_stats_user1;
  -- Should now have direct table access, but see nothing and leak nothing
  SET SESSION AUTHORIZATION regress_stats_user1;

--- a/pkg/cmd/roachtest/testdata/pg_regress/update.diffs
+++ b/pkg/cmd/roachtest/testdata/pg_regress/update.diffs
@@ -583,7 +583,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/update.out --labe
  -- Don't drop trans_updatetrig yet. It is required below.
  -- Test with transition tuple conversion happening for rows moved into the
  -- new partition. This requires a trigger that references transition table
-@@ -545,74 +521,84 @@
+@@ -545,74 +521,80 @@
  END $$ language plpgsql;
  CREATE TRIGGER trig_c1_100 BEFORE UPDATE OR INSERT ON part_c_1_100
     FOR EACH ROW EXECUTE PROCEDURE func_parted_mod_b();
@@ -671,13 +671,9 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/update.out --labe
  GRANT ALL ON range_parted, mintab TO regress_range_parted_user;
 +ERROR:  cannot get the privileges on the grant targets: cannot determine the target type of the GRANT statement: relation "range_parted" does not exist
  CREATE POLICY seeall ON range_parted AS PERMISSIVE FOR SELECT USING (true);
-+ERROR:  unimplemented: row-level security is not yet implemented
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/73596/_version_
++ERROR:  relation "range_parted" does not exist
  CREATE POLICY policy_range_parted ON range_parted for UPDATE USING (true) WITH CHECK (c % 2 = 0);
-+ERROR:  unimplemented: row-level security is not yet implemented
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/73596/_version_
++ERROR:  relation "range_parted" does not exist
  :init_range_parted;
 +ERROR:  relation "range_parted" does not exist
 +ERROR:  relation "range_parted" does not exist
@@ -702,7 +698,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/update.out --labe
  -- Create a trigger on part_d_1_15
  CREATE FUNCTION func_d_1_15() RETURNS trigger AS $$
  BEGIN
-@@ -621,61 +607,154 @@
+@@ -621,61 +603,144 @@
  END $$ LANGUAGE plpgsql;
  CREATE TRIGGER trig_d_1_15 BEFORE INSERT ON part_d_1_15
     FOR EACH ROW EXECUTE PROCEDURE func_d_1_15();
@@ -767,9 +763,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/update.out --labe
  CREATE POLICY policy_range_parted_subplan on range_parted
      AS RESTRICTIVE for UPDATE USING (true)
      WITH CHECK ((SELECT range_parted.c <= c1 FROM mintab));
-+ERROR:  unimplemented: row-level security is not yet implemented
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/73596/_version_
++ERROR:  relation "range_parted" does not exist
  SET SESSION AUTHORIZATION regress_range_parted_user;
 +ERROR:  at or near "regress_range_parted_user": syntax error: unimplemented: this syntax
 +DETAIL:  source SQL:
@@ -796,9 +790,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/update.out --labe
 +ERROR:  relation "range_parted" does not exist
  CREATE POLICY policy_range_parted_wholerow on range_parted AS RESTRICTIVE for UPDATE USING (true)
     WITH CHECK (range_parted = row('b', 10, 112, 1, NULL)::range_parted);
-+ERROR:  unimplemented: row-level security is not yet implemented
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/73596/_version_
++ERROR:  relation "range_parted" does not exist
  SET SESSION AUTHORIZATION regress_range_parted_user;
 +ERROR:  at or near "regress_range_parted_user": syntax error: unimplemented: this syntax
 +DETAIL:  source SQL:
@@ -837,17 +829,11 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/update.out --labe
 +              ^
 +HINT:  try \h RESET
  DROP POLICY policy_range_parted ON range_parted;
-+ERROR:  unimplemented: row-level security is not yet implemented
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/73596/_version_
++ERROR:  relation "range_parted" does not exist
  DROP POLICY policy_range_parted_subplan ON range_parted;
-+ERROR:  unimplemented: row-level security is not yet implemented
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/73596/_version_
++ERROR:  relation "range_parted" does not exist
  DROP POLICY policy_range_parted_wholerow ON range_parted;
-+ERROR:  unimplemented: row-level security is not yet implemented
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/73596/_version_
++ERROR:  relation "range_parted" does not exist
  REVOKE ALL ON range_parted, mintab FROM regress_range_parted_user;
 +ERROR:  cannot get the privileges on the grant targets: cannot determine the target type of the GRANT statement: relation "range_parted" does not exist
  DROP USER regress_range_parted_user;
@@ -860,7 +846,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/update.out --labe
  CREATE FUNCTION trigfunc() returns trigger language plpgsql as
  $$
    begin
-@@ -687,235 +766,271 @@
+@@ -687,235 +752,271 @@
  -- Triggers on root partition
  CREATE TRIGGER parent_delete_trig
    AFTER DELETE ON range_parted for each statement execute procedure trigfunc();
@@ -1235,7 +1221,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/update.out --labe
  -- Test the case where BR UPDATE triggers change the partition key.
  CREATE FUNCTION func_parted_mod_b() returns trigger as $$
  BEGIN
-@@ -925,26 +1040,13 @@
+@@ -925,26 +1026,13 @@
  CREATE TRIGGER parted_mod_b before update on sub_part1
     for each row execute procedure func_parted_mod_b();
  SELECT tableoid::regclass::text, * FROM list_parted ORDER BY 1, 2, 3, 4;
@@ -1265,7 +1251,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/update.out --labe
  DROP TRIGGER parted_mod_b ON sub_part1;
  -- If BR DELETE trigger prevented DELETE from happening, we should also skip
  -- the INSERT if that delete is part of UPDATE=>DELETE+INSERT.
-@@ -956,28 +1058,15 @@
+@@ -956,28 +1044,15 @@
  CREATE TRIGGER trig_skip_delete before delete on sub_part2
     for each row execute procedure func_parted_mod_b();
  UPDATE list_parted set b = 1 WHERE c = 70;
@@ -1298,7 +1284,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/update.out --labe
  DROP FUNCTION func_parted_mod_b();
  -- UPDATE partition-key with FROM clause. If join produces multiple output
  -- rows for the same row to be modified, we should tuple-route the row only
-@@ -985,44 +1074,93 @@
+@@ -985,44 +1060,93 @@
  CREATE TABLE non_parted (id int);
  INSERT into non_parted VALUES (1), (1), (1), (2), (2), (2), (3), (3), (3);
  UPDATE list_parted t1 set a = 2 FROM non_parted t2 WHERE t1.a = t2.id and a = 1;

--- a/pkg/sql/copy/copy_test.go
+++ b/pkg/sql/copy/copy_test.go
@@ -218,9 +218,6 @@ func TestDataDriven(t *testing.T) {
 								err = conn.Exec(ctx, fmt.Sprintf(`SET COPY_FROM_ATOMIC_ENABLED='%s'`, atomic))
 								require.NoError(t, err)
 
-								err = conn.Exec(ctx, `SET enable_row_level_security=on`)
-								require.NoError(t, err)
-
 								datadriven.RunTest(t, path, func(t *testing.T, d *datadriven.TestData) string {
 									return doTest(t, d, conn)
 								})

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -3645,10 +3645,6 @@ func (m *sessionDataMutator) SetAlterColumnTypeGeneral(val bool) {
 	m.data.AlterColumnTypeGeneralEnabled = val
 }
 
-func (m *sessionDataMutator) SetRowLevelSecurity(val bool) {
-	m.data.RowLevelSecurityEnabled = val
-}
-
 func (m *sessionDataMutator) SetEnableSuperRegions(val bool) {
 	m.data.EnableSuperRegions = val
 }

--- a/pkg/sql/logictest/testdata/logic_test/row_level_security
+++ b/pkg/sql/logictest/testdata/logic_test/row_level_security
@@ -14,14 +14,6 @@ USE db1;
 statement ok
 GRANT ADMIN to testuser;
 
-statement ok
-SET enable_row_level_security = on;
-
-query T
-show session enable_row_level_security;
-----
-on
-
 subtest create_drop_sanity
 
 statement ok
@@ -371,9 +363,6 @@ GRANT SYSTEM MODIFYCLUSTERSETTING TO testuser;
 user testuser
 
 statement ok
-SET enable_row_level_security = on;
-
-statement ok
 USE db1;
 
 statement ok
@@ -397,9 +386,6 @@ target  CREATE TABLE public.target (
         CREATE POLICY pol ON public.target AS PERMISSIVE FOR ALL TO john, testuser
 
 user root
-
-statement ok
-SET enable_row_level_security = on;
 
 statement ok
 USE db1;

--- a/pkg/sql/schemachanger/dml_injection_test.go
+++ b/pkg/sql/schemachanger/dml_injection_test.go
@@ -443,7 +443,6 @@ func TestAlterTableDMLInjection(t *testing.T) {
 		{
 			desc: "alter policy name",
 			setup: []string{
-				"SET enable_row_level_security=on",
 				"CREATE POLICY p ON tbl FOR SELECT USING (val > 0)",
 				"ALTER TABLE tbl ENABLE ROW LEVEL SECURITY, FORCE ROW LEVEL SECURITY",
 				"CREATE USER foo",
@@ -455,7 +454,6 @@ func TestAlterTableDMLInjection(t *testing.T) {
 		{
 			desc: "alter policy using expression",
 			setup: []string{
-				"SET enable_row_level_security=on",
 				"CREATE POLICY p ON tbl FOR SELECT USING (val > 0)",
 				"ALTER TABLE tbl ENABLE ROW LEVEL SECURITY, FORCE ROW LEVEL SECURITY",
 				"CREATE USER foo",

--- a/pkg/sql/schemachanger/scbuild/builder_test.go
+++ b/pkg/sql/schemachanger/scbuild/builder_test.go
@@ -97,7 +97,6 @@ func TestBuildDataDriven(t *testing.T) {
 										sd.NewSchemaChangerMode = sessiondatapb.UseNewSchemaChangerUnsafeAlways
 										sd.ApplicationName = ""
 										sd.EnableUniqueWithoutIndexConstraints = true
-										sd.RowLevelSecurityEnabled = true
 										sd.SerialNormalizationMode = localData.SerialNormalizationMode
 									},
 								),

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/BUILD.bazel
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/BUILD.bazel
@@ -110,7 +110,6 @@ go_library(
         "//pkg/sql/types",
         "//pkg/sql/vecindex/vecpb",
         "//pkg/util/encoding",
-        "//pkg/util/envutil",
         "//pkg/util/errorutil/unimplemented",
         "//pkg/util/log/eventpb",
         "//pkg/util/log/logpb",

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_policy.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_policy.go
@@ -12,7 +12,6 @@ import (
 
 // AlterPolicy implements ALTER POLICY.
 func AlterPolicy(b BuildCtx, n *tree.AlterPolicy) {
-	failIfRLSIsNotEnabled(b)
 	b.IncrementSchemaChangeAlterCounter("policy")
 
 	tableElems := b.ResolveTable(n.TableName, ResolveParams{

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_set_rls_mode.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_set_rls_mode.go
@@ -17,8 +17,6 @@ func alterTableSetRLSMode(
 	stmt tree.Statement,
 	n *tree.AlterTableSetRLSMode,
 ) {
-	failIfRLSIsNotEnabled(b)
-
 	// The table is already known to exist, and we would have checked for
 	// the CREATE privilege. However, changing the RLS mode is different,
 	// as it can only be done by the table owner.

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/create_policy.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/create_policy.go
@@ -28,7 +28,6 @@ import (
 
 // CreatePolicy implements CREATE POLICY.
 func CreatePolicy(b BuildCtx, n *tree.CreatePolicy) {
-	failIfRLSIsNotEnabled(b)
 	b.IncrementSchemaChangeCreateCounter("policy")
 
 	tableElems := b.ResolveTable(n.TableName, ResolveParams{

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/drop_policy.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/drop_policy.go
@@ -13,7 +13,6 @@ import (
 
 // DropPolicy implements DROP POLICY.
 func DropPolicy(b BuildCtx, n *tree.DropPolicy) {
-	failIfRLSIsNotEnabled(b)
 	noticeSender := b.EvalCtx().ClientNoticeSender
 	tableElems := b.ResolveTable(n.TableName, ResolveParams{
 		IsExistenceOptional: n.IfExists,

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/helpers.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/helpers.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"sort"
 
-	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catenumpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
@@ -28,8 +27,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlclustersettings"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlerrors"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
-	"github.com/cockroachdb/cockroach/pkg/util/envutil"
-	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/redact"
@@ -1825,23 +1822,6 @@ func mustRetrievePartitioningFromIndexPartitioning(
 		partition = tabledesc.NewPartitioning(&idxPart.PartitioningDescriptor)
 	}
 	return partition
-}
-
-// enableRLSEnvVar is true if row-level security is enabled. This override is a
-// convenience for dev as it allows you to set an environment variable and not
-// have to worry about changing a local setting each time. This should be removed
-// once RLS is enabled by default.
-var enableRLSEnvVar = envutil.EnvOrDefaultBool("COCKROACH_ENABLE_ROW_LEVEL_SECURITY", false)
-
-// failIfRLSIsNotEnabled will fail if row-level security is not active
-func failIfRLSIsNotEnabled(b BuildCtx) {
-	if enableRLSEnvVar {
-		return
-	}
-	if !b.SessionData().RowLevelSecurityEnabled ||
-		!b.EvalCtx().Settings.Version.ActiveVersion(b).IsActive(clusterversion.V25_1) {
-		panic(unimplemented.NewWithIssue(73596, "row-level security is not yet implemented"))
-	}
 }
 
 // failIfSafeUpdates checks if the sql_safe_updates is present, and if so, it

--- a/pkg/sql/schemachanger/scbuild/testdata/alter_policy
+++ b/pkg/sql/schemachanger/scbuild/testdata/alter_policy
@@ -1,5 +1,4 @@
 setup
-SET enable_row_level_security = true;
 CREATE TABLE defaultdb.foo (i INT PRIMARY KEY);
 CREATE USER fred;
 CREATE USER george;

--- a/pkg/sql/schemachanger/scbuild/testdata/alter_table_row_level_security
+++ b/pkg/sql/schemachanger/scbuild/testdata/alter_table_row_level_security
@@ -1,5 +1,4 @@
 setup
-set enable_row_level_security=on;
 CREATE DATABASE db1;
 CREATE SCHEMA db1.sc1;
 CREATE TABLE db1.sc1.t1 (

--- a/pkg/sql/schemachanger/scbuild/testdata/drop_policy
+++ b/pkg/sql/schemachanger/scbuild/testdata/drop_policy
@@ -1,5 +1,4 @@
 setup
-SET enable_row_level_security = true;
 CREATE FUNCTION is_valid(n INT) returns bool as $$ begin return n < 10; end; $$ language plpgsql;
 CREATE TABLE defaultdb.foo (i INT PRIMARY KEY);
 CREATE USER fred;

--- a/pkg/sql/schemachanger/scdeps/sctestutils/sctestutils.go
+++ b/pkg/sql/schemachanger/scdeps/sctestutils/sctestutils.go
@@ -87,7 +87,6 @@ func WithBuilderDependenciesFromTestServer(
 	planner.SessionData().NewSchemaChangerMode = sessiondatapb.UseNewSchemaChangerUnsafe
 	planner.SessionData().EnableUniqueWithoutIndexConstraints = true
 	planner.SessionData().AlterColumnTypeGeneralEnabled = true
-	planner.SessionData().RowLevelSecurityEnabled = true
 	fn(scdeps.NewBuilderDependencies(
 		execCfg.NodeInfo.LogicalClusterID(),
 		execCfg.Codec,

--- a/pkg/sql/schemachanger/scplan/testdata/alter_policy
+++ b/pkg/sql/schemachanger/scplan/testdata/alter_policy
@@ -1,5 +1,4 @@
 setup
-SET enable_row_level_security=on;
 CREATE TYPE pt AS (x int, y int);
 CREATE TABLE t1 (tenant_id uuid, c1 pt, c2 text);
 CREATE SEQUENCE seq1;

--- a/pkg/sql/schemachanger/scplan/testdata/alter_table_row_level_security
+++ b/pkg/sql/schemachanger/scplan/testdata/alter_table_row_level_security
@@ -1,5 +1,4 @@
 setup
-set enable_row_level_security=on;
 CREATE DATABASE db1;
 CREATE SCHEMA db1.sc1;
 CREATE TABLE db1.sc1.t1 (

--- a/pkg/sql/schemachanger/scplan/testdata/drop_policy
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_policy
@@ -4,7 +4,6 @@ CREATE TABLE t1 (tenant_id uuid, c1 pt, c2 text);
 CREATE SEQUENCE seq1;
 CREATE USER user1;
 CREATE USER user2;
-SET enable_row_level_security=on;
 CREATE TYPE greeting AS ENUM('hi', 'howdy', 'hello');
 CREATE FUNCTION is_valid(n INT) returns bool as $$ begin return n < 10; end; $$ language plpgsql;
 CREATE FUNCTION is_even(n INT) returns bool as $$ begin return n % 2 = 0; end; $$ language plpgsql;

--- a/pkg/sql/schemachanger/sctest/end_to_end.go
+++ b/pkg/sql/schemachanger/sctest/end_to_end.go
@@ -140,7 +140,6 @@ func EndToEndSideEffects(t *testing.T, relTestCaseDir string, factory TestServer
 						sd.TempTablesEnabled = true
 						sd.ApplicationName = ""
 						sd.EnableUniqueWithoutIndexConstraints = true // this allows `ADD UNIQUE WITHOUT INDEX` in the testing suite.
-						sd.RowLevelSecurityEnabled = true
 						sd.SerialNormalizationMode = localData.SerialNormalizationMode
 					})),
 					sctestdeps.WithTestingKnobs(&scexec.TestingKnobs{

--- a/pkg/sql/schemachanger/sctest/framework.go
+++ b/pkg/sql/schemachanger/sctest/framework.go
@@ -880,9 +880,6 @@ func executeSchemaChangeTxn(
 			_, err = conn.ExecContext(
 				ctx, "SET experimental_enable_temp_tables=true",
 			)
-			_, err = conn.ExecContext(
-				ctx, "SET enable_row_level_security=true",
-			)
 			if err != nil {
 				return err
 			}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_disable_row_level_security/alter_table_disable_row_level_security.definition
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_disable_row_level_security/alter_table_disable_row_level_security.definition
@@ -1,6 +1,5 @@
 setup
 CREATE TABLE roaches();
-set enable_row_level_security = on;
 ALTER TABLE roaches ENABLE ROW LEVEL SECURITY;
 ----
 

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_disable_row_level_security/alter_table_disable_row_level_security.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_disable_row_level_security/alter_table_disable_row_level_security.explain
@@ -1,6 +1,5 @@
 /* setup */
 CREATE TABLE roaches();
-set enable_row_level_security = on;
 ALTER TABLE roaches ENABLE ROW LEVEL SECURITY;
 
 /* test */

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_disable_row_level_security/alter_table_disable_row_level_security.explain_shape
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_disable_row_level_security/alter_table_disable_row_level_security.explain_shape
@@ -1,6 +1,5 @@
 /* setup */
 CREATE TABLE roaches();
-set enable_row_level_security = on;
 ALTER TABLE roaches ENABLE ROW LEVEL SECURITY;
 
 /* test */

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_disable_row_level_security/alter_table_disable_row_level_security.side_effects
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_disable_row_level_security/alter_table_disable_row_level_security.side_effects
@@ -1,6 +1,5 @@
 /* setup */
 CREATE TABLE roaches();
-set enable_row_level_security = on;
 ALTER TABLE roaches ENABLE ROW LEVEL SECURITY;
 ----
 ...

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_force_row_level_security/alter_table_force_row_level_security.definition
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_force_row_level_security/alter_table_force_row_level_security.definition
@@ -1,6 +1,5 @@
 setup
 CREATE TABLE roaches();
-set enable_row_level_security = on;
 ALTER TABLE roaches ENABLE ROW LEVEL SECURITY;
 ALTER TABLE roaches FORCE ROW LEVEL SECURITY;
 ----

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_force_row_level_security/alter_table_force_row_level_security.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_force_row_level_security/alter_table_force_row_level_security.explain
@@ -1,6 +1,5 @@
 /* setup */
 CREATE TABLE roaches();
-set enable_row_level_security = on;
 ALTER TABLE roaches ENABLE ROW LEVEL SECURITY;
 ALTER TABLE roaches FORCE ROW LEVEL SECURITY;
 

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_force_row_level_security/alter_table_force_row_level_security.explain_shape
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_force_row_level_security/alter_table_force_row_level_security.explain_shape
@@ -1,6 +1,5 @@
 /* setup */
 CREATE TABLE roaches();
-set enable_row_level_security = on;
 ALTER TABLE roaches ENABLE ROW LEVEL SECURITY;
 ALTER TABLE roaches FORCE ROW LEVEL SECURITY;
 

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_force_row_level_security/alter_table_force_row_level_security.side_effects
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_force_row_level_security/alter_table_force_row_level_security.side_effects
@@ -1,6 +1,5 @@
 /* setup */
 CREATE TABLE roaches();
-set enable_row_level_security = on;
 ALTER TABLE roaches ENABLE ROW LEVEL SECURITY;
 ALTER TABLE roaches FORCE ROW LEVEL SECURITY;
 ----

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_no_force_row_level_security/alter_table_no_force_row_level_security.definition
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_no_force_row_level_security/alter_table_no_force_row_level_security.definition
@@ -1,6 +1,5 @@
 setup
 CREATE TABLE roaches();
-set enable_row_level_security = on;
 ALTER TABLE roaches ENABLE ROW LEVEL SECURITY;
 ----
 

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_no_force_row_level_security/alter_table_no_force_row_level_security.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_no_force_row_level_security/alter_table_no_force_row_level_security.explain
@@ -1,6 +1,5 @@
 /* setup */
 CREATE TABLE roaches();
-set enable_row_level_security = on;
 ALTER TABLE roaches ENABLE ROW LEVEL SECURITY;
 
 /* test */

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_no_force_row_level_security/alter_table_no_force_row_level_security.explain_shape
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_no_force_row_level_security/alter_table_no_force_row_level_security.explain_shape
@@ -1,6 +1,5 @@
 /* setup */
 CREATE TABLE roaches();
-set enable_row_level_security = on;
 ALTER TABLE roaches ENABLE ROW LEVEL SECURITY;
 
 /* test */

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_no_force_row_level_security/alter_table_no_force_row_level_security.side_effects
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_no_force_row_level_security/alter_table_no_force_row_level_security.side_effects
@@ -1,6 +1,5 @@
 /* setup */
 CREATE TABLE roaches();
-set enable_row_level_security = on;
 ALTER TABLE roaches ENABLE ROW LEVEL SECURITY;
 ----
 ...

--- a/pkg/sql/schemachanger/testdata/end_to_end/drop_policy/drop_policy.definition
+++ b/pkg/sql/schemachanger/testdata/end_to_end/drop_policy/drop_policy.definition
@@ -2,7 +2,6 @@ setup
 CREATE TABLE t1 (tenant_id uuid, c1 int);
 CREATE USER user1;
 CREATE USER user2;
-SET enable_row_level_security = true;
 CREATE POLICY "policy 1" on t1 AS PERMISSIVE FOR ALL TO PUBLIC USING (true);
 CREATE POLICY "policy 2" on t1 AS PERMISSIVE FOR INSERT TO user1,user2 WITH CHECK (true);
 ----

--- a/pkg/sql/schemachanger/testdata/end_to_end/drop_policy/drop_policy.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/drop_policy/drop_policy.explain
@@ -2,7 +2,6 @@
 CREATE TABLE t1 (tenant_id uuid, c1 int);
 CREATE USER user1;
 CREATE USER user2;
-SET enable_row_level_security = true;
 CREATE POLICY "policy 1" on t1 AS PERMISSIVE FOR ALL TO PUBLIC USING (true);
 CREATE POLICY "policy 2" on t1 AS PERMISSIVE FOR INSERT TO user1,user2 WITH CHECK (true);
 

--- a/pkg/sql/schemachanger/testdata/end_to_end/drop_policy/drop_policy.explain_shape
+++ b/pkg/sql/schemachanger/testdata/end_to_end/drop_policy/drop_policy.explain_shape
@@ -2,7 +2,6 @@
 CREATE TABLE t1 (tenant_id uuid, c1 int);
 CREATE USER user1;
 CREATE USER user2;
-SET enable_row_level_security = true;
 CREATE POLICY "policy 1" on t1 AS PERMISSIVE FOR ALL TO PUBLIC USING (true);
 CREATE POLICY "policy 2" on t1 AS PERMISSIVE FOR INSERT TO user1,user2 WITH CHECK (true);
 

--- a/pkg/sql/schemachanger/testdata/end_to_end/drop_policy/drop_policy.side_effects
+++ b/pkg/sql/schemachanger/testdata/end_to_end/drop_policy/drop_policy.side_effects
@@ -2,7 +2,6 @@
 CREATE TABLE t1 (tenant_id uuid, c1 int);
 CREATE USER user1;
 CREATE USER user2;
-SET enable_row_level_security = true;
 CREATE POLICY "policy 1" on t1 AS PERMISSIVE FOR ALL TO PUBLIC USING (true);
 CREATE POLICY "policy 2" on t1 AS PERMISSIVE FOR INSERT TO user1,user2 WITH CHECK (true);
 ----

--- a/pkg/sql/sessiondatapb/local_only_session_data.proto
+++ b/pkg/sql/sessiondatapb/local_only_session_data.proto
@@ -589,8 +589,7 @@ message LocalOnlySessionData {
   // AvoidFullTableScansInMutations indicates whether mutation queries that plan
   // full table scans should be avoided.
   bool avoid_full_table_scans_in_mutations = 151;
-  // RowLevelSecurityEnabled indicates whether row level security is enabled
-  bool row_level_security_enabled = 152;
+  reserved 152;
   // CatalogDigestStalenessCheckEnabled is used to enable using the catalog
   // digest information to do fast memo checks.
   bool catalog_digest_staleness_check_enabled = 153;

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -2006,24 +2006,6 @@ var varGen = map[string]sessionVar{
 		},
 	},
 
-	// CockroachDB extension.
-	`enable_row_level_security`: {
-		Hidden:       true,
-		GetStringVal: makePostgresBoolGetStringValFn(`enable_row_level_security`),
-		Set: func(_ context.Context, m sessionDataMutator, s string) error {
-			b, err := paramparse.ParseBoolVar("enable_row_level_security", s)
-			if err != nil {
-				return err
-			}
-			m.SetRowLevelSecurity(b)
-			return nil
-		},
-		Get: func(evalCtx *extendedEvalContext, _ *kv.Txn) (string, error) {
-			return formatBoolAsPostgresSetting(evalCtx.SessionData().RowLevelSecurityEnabled), nil
-		},
-		GlobalDefault: globalFalse,
-	},
-
 	// TODO(rytaft): remove this once unique without index constraints are fully
 	// supported.
 	`experimental_enable_unique_without_index_constraints`: {


### PR DESCRIPTION
Row-level security (RLS) was initially introduced behind a feature gate in v25.1 to enable incremental development. With the feature nearing completion—pending only #141998—this commit removes the enable_row_level_security feature gate. This change makes RLS generally available without requiring the feature to be explicitly enabled.

Informs: #137122
Epic: CRDB-11724

Release note: None