### PR TITLE
colexec: add warm-up to BenchmarkAllSpooler

### DIFF
--- a/pkg/sql/colexec/sort_test.go
+++ b/pkg/sql/colexec/sort_test.go
@@ -413,6 +413,13 @@ func BenchmarkAllSpooler(b *testing.B) {
 						col[j] = rng.Int63() % int64((i*1024)+1)
 					}
 				}
+				// Warm up.
+				for n := 0; n < 250; n++ {
+					source := colexectestutils.NewFiniteBatchSource(testAllocator, batch, typs, nBatches)
+					allSpooler := newAllSpooler(testAllocator, source, typs)
+					allSpooler.init(ctx)
+					allSpooler.spool()
+				}
 				b.ResetTimer()
 				for n := 0; n < b.N; n++ {
 					source := colexectestutils.NewFiniteBatchSource(testAllocator, batch, typs, nBatches)


### PR DESCRIPTION
Prior to this commit the first run of `BenchmarkAllSpooler` was nearly
twice as slow as subsequent runs. This is fixed by adding some warm-up
iterations before resetting the benchmark timer.

Before:

```
AllSpooler/rows=262144/cols=2  3748956 ns/op 1118.79 MB/s
AllSpooler/rows=262144/cols=2  1995039 ns/op 2102.37 MB/s
AllSpooler/rows=262144/cols=2  2137415 ns/op 1962.33 MB/s
AllSpooler/rows=262144/cols=2  2011513 ns/op 2085.15 MB/s
AllSpooler/rows=262144/cols=2  2084128 ns/op 2012.50 MB/s
```

After:

```
AllSpooler/rows=262144/cols=2  2194850 ns/op  1910.98 MB/s
AllSpooler/rows=262144/cols=2  2032961 ns/op  2063.15 MB/s
AllSpooler/rows=262144/cols=2  2089076 ns/op  2007.73 MB/s
AllSpooler/rows=262144/cols=2  1845962 ns/op  2272.15 MB/s
AllSpooler/rows=262144/cols=2  1924038 ns/op  2179.95 MB/s
```

Epic: None
Release note: None
