### PR TITLE
raft: remove unused Ready.MustSync

### DIFF
--- a/pkg/kv/kvserver/raft.go
+++ b/pkg/kv/kvserver/raft.go
@@ -179,7 +179,7 @@ func logRaftReady(ctx context.Context, ready raft.Ready) {
 		fmt.Fprintf(&buf, "  Outgoing Message[%d]: %.200s\n",
 			i, raft.DescribeMessage(m, raftEntryFormatter))
 	}
-	log.Infof(ctx, "raft ready (must-sync=%t)\n%s", ready.MustSync, buf.String())
+	log.Infof(ctx, "raft ready\n%s", buf.String())
 }
 
 func raftEntryFormatter(data []byte) string {

--- a/pkg/raft/node.go
+++ b/pkg/raft/node.go
@@ -94,13 +94,6 @@ type Ready struct {
 	// If it contains a MsgSnap message, the application MUST report back to raft
 	// when the snapshot has been received or has failed by calling ReportSnapshot.
 	Messages []pb.Message
-
-	// MustSync indicates whether the HardState and Entries must be durably
-	// written to disk or if a non-durable write is permissible.
-	//
-	// TODO(pav-kv): This flag isn't used at the moment, and the user code
-	// determines MustSync from the content of Messages. Make the API explicit.
-	MustSync bool
 }
 
 func isHardStateEqual(a, b pb.HardState) bool {

--- a/pkg/raft/node_test.go
+++ b/pkg/raft/node_test.go
@@ -275,19 +275,16 @@ func TestNodeStart(t *testing.T) {
 			CommittedEntries: []raftpb.Entry{
 				{Type: raftpb.EntryConfChange, Term: 1, Index: 1, Data: ccdata},
 			},
-			MustSync: true,
 		},
 		{
 			HardState:        raftpb.HardState{Term: 2, Commit: 2, Vote: 1, Lead: 1, LeadEpoch: 1},
 			Entries:          []raftpb.Entry{{Term: 2, Index: 3, Data: []byte("foo")}},
 			CommittedEntries: []raftpb.Entry{{Term: 2, Index: 2, Data: nil}},
-			MustSync:         true,
 		},
 		{
 			HardState:        raftpb.HardState{Term: 2, Commit: 3, Vote: 1, Lead: 1, LeadEpoch: 1},
 			Entries:          nil,
 			CommittedEntries: []raftpb.Entry{{Term: 2, Index: 3, Data: []byte("foo")}},
-			MustSync:         true,
 		},
 	}
 	storage := NewMemoryStorage()
@@ -355,8 +352,6 @@ func TestNodeRestart(t *testing.T) {
 		HardState: raftpb.HardState{},
 		// commit up to index commit index in st
 		CommittedEntries: entries[:st.Commit],
-		// MustSync is false because no HardState or new entries are provided.
-		MustSync: false,
 	}
 
 	storage := NewMemoryStorage()
@@ -405,9 +400,6 @@ func TestNodeRestartFromSnapshot(t *testing.T) {
 		HardState: raftpb.HardState{},
 		// commit up to index commit index in st
 		CommittedEntries: entries,
-		// MustSync is only true when there is a new HardState or new entries;
-		// neither is the case here.
-		MustSync: false,
 	}
 
 	s := NewMemoryStorage()

--- a/pkg/raft/rawnode.go
+++ b/pkg/raft/rawnode.go
@@ -240,7 +240,6 @@ func (rn *RawNode) Ready() Ready {
 	// TODO(pav-kv): remove "accept" methods down the stack, since we now accept
 	// all updates unconditionally.
 	r.raftLog.acceptUnstable()
-	rd.MustSync = MustSync(hardSt, prevHardSt, len(rd.Entries))
 
 	allowUnstable := rn.applyUnstableEntries()
 	if r.raftLog.hasNextCommittedEnts(allowUnstable) {
@@ -260,23 +259,6 @@ func (rn *RawNode) Ready() Ready {
 	r.msgsAfterAppend = nil
 
 	return rd
-}
-
-// MustSync returns true if the hard state and count of Raft entries indicate
-// that a synchronous write to persistent storage is required.
-//
-// TODO(pav-kv): MustSync isn't used, because all writes are asynchronous.
-// Remove this, or repurpose it to fit the asynchronous writes API.
-func MustSync(st, prevst pb.HardState, entsnum int) bool {
-	// Persistent state on all servers:
-	// (Updated on stable storage before responding to RPCs)
-	// currentTerm
-	// currentLead
-	// currentLeadEpoch
-	// votedFor
-	// log entries[]
-	return entsnum != 0 || st.Vote != prevst.Vote || st.Term != prevst.Term ||
-		st.Lead != prevst.Lead || st.LeadEpoch != prevst.LeadEpoch || st.Commit != prevst.Commit
 }
 
 func needStorageAppendMsg(r *raft, rd Ready) bool {

--- a/pkg/raft/rawnode_test.go
+++ b/pkg/raft/rawnode_test.go
@@ -547,7 +547,6 @@ func TestRawNodeStart(t *testing.T) {
 		HardState:        pb.HardState{Term: 1, Commit: 3, Vote: 1, Lead: 1, LeadEpoch: 1},
 		Entries:          nil, // emitted & checked in intermediate Ready cycle
 		CommittedEntries: entries,
-		MustSync:         true, // because we are advancing the commit index
 	}
 
 	storage := NewMemoryStorage()
@@ -613,7 +612,6 @@ func TestRawNodeStart(t *testing.T) {
 	require.True(t, rawNode.HasReady())
 	rd = rawNode.Ready()
 	require.Empty(t, rd.Entries)
-	require.True(t, rd.MustSync)
 	rawNode.AdvanceHack(rd)
 
 	rd.SoftState, want.SoftState = nil, nil
@@ -634,7 +632,6 @@ func TestRawNodeRestart(t *testing.T) {
 		HardState: emptyState, // no HardState is emitted because there was no change
 		// commit up to commit index in st
 		CommittedEntries: entries[:st.Commit],
-		MustSync:         false,
 	}
 
 	storage := newTestMemoryStorage(withPeers(1, 2))
@@ -697,7 +694,6 @@ func TestRawNodeRestartFromSnapshot(t *testing.T) {
 		HardState: emptyState,
 		// commit up to commit index in st
 		CommittedEntries: entries,
-		MustSync:         false,
 	}
 
 	s := NewMemoryStorage()

--- a/pkg/raft/testdata/async_storage_writes.txt
+++ b/pkg/raft/testdata/async_storage_writes.txt
@@ -26,7 +26,7 @@ INFO 1 [logterm: 1, index: 10] sent MsgVote request to 3 at term 1
 stabilize
 ----
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   State:StateCandidate
   HardState Term:1 Vote:1 Commit:10 Lead:0 LeadEpoch:0
   Messages:
@@ -53,14 +53,14 @@ stabilize
   Responses:
   1->1 MsgVoteResp Term:1 Log:0/0
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:10 Lead:0 LeadEpoch:0
   Messages:
   2->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:10 Vote:1 Responses:[
     2->1 MsgVoteResp Term:1 Log:0/0
   ]
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:10 Lead:0 LeadEpoch:0
   Messages:
   3->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:10 Vote:1 Responses:[
@@ -87,7 +87,7 @@ stabilize
   INFO 1 became leader at term 1
   3->1 MsgVoteResp Term:1 Log:0/0
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   State:StateLeader
   HardState Term:1 Vote:1 Commit:10 Lead:1 LeadEpoch:1
   Entries:
@@ -116,7 +116,7 @@ stabilize
   1->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:1
   AppendThread->1 MsgStorageAppendResp Term:0 Log:1/11
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:10 Lead:1 LeadEpoch:1
   Entries:
   1/11 EntryNormal ""
@@ -127,7 +127,7 @@ stabilize
     AppendThread->2 MsgStorageAppendResp Term:0 Log:1/11
   ]
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:10 Lead:1 LeadEpoch:1
   Entries:
   1/11 EntryNormal ""
@@ -165,7 +165,7 @@ stabilize
 > 3 receiving messages
   AppendThread->3 MsgStorageAppendResp Term:0 Log:1/11
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:11 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/11 EntryNormal ""
@@ -190,7 +190,7 @@ stabilize
   Responses:
   ApplyThread->1 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/11 EntryNormal ""]
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:11 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/11 EntryNormal ""
@@ -202,7 +202,7 @@ stabilize
     ApplyThread->2 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/11 EntryNormal ""]
   ]
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:11 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/11 EntryNormal ""
@@ -250,7 +250,7 @@ ok
 process-ready 1 2 3
 ----
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   Entries:
   1/12 EntryNormal "prop_1"
   Messages:
@@ -281,7 +281,7 @@ process-ready 1 2 3
 > 1 handling Ready
   <empty Ready>
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   Entries:
   1/12 EntryNormal "prop_1"
   Messages:
@@ -290,7 +290,7 @@ process-ready 1 2 3
     AppendThread->2 MsgStorageAppendResp Term:0 Log:1/12
   ]
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   Entries:
   1/12 EntryNormal "prop_1"
   Messages:
@@ -306,7 +306,7 @@ ok
 process-ready 1 2 3
 ----
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   Entries:
   1/13 EntryNormal "prop_2"
   Messages:
@@ -331,7 +331,7 @@ process-ready 1 2 3
 > 1 handling Ready
   <empty Ready>
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   Entries:
   1/13 EntryNormal "prop_2"
   Messages:
@@ -340,7 +340,7 @@ process-ready 1 2 3
     AppendThread->2 MsgStorageAppendResp Term:0 Log:1/13
   ]
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   Entries:
   1/13 EntryNormal "prop_2"
   Messages:
@@ -392,7 +392,7 @@ ok
 process-ready 1 2 3
 ----
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:12 Lead:1 LeadEpoch:1
   Entries:
   1/14 EntryNormal "prop_3"
@@ -427,7 +427,7 @@ process-ready 1 2 3
 > 1 handling Ready
   <empty Ready>
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:12 Lead:1 LeadEpoch:1
   Entries:
   1/14 EntryNormal "prop_3"
@@ -443,7 +443,7 @@ process-ready 1 2 3
     ApplyThread->2 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/12 EntryNormal "prop_1"]
   ]
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:12 Lead:1 LeadEpoch:1
   Entries:
   1/14 EntryNormal "prop_3"
@@ -496,7 +496,7 @@ ok
 process-ready 1 2 3
 ----
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:13 Lead:1 LeadEpoch:1
   Entries:
   1/15 EntryNormal "prop_4"
@@ -531,7 +531,7 @@ process-ready 1 2 3
 > 1 handling Ready
   <empty Ready>
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:13 Lead:1 LeadEpoch:1
   Entries:
   1/15 EntryNormal "prop_4"
@@ -547,7 +547,7 @@ process-ready 1 2 3
     ApplyThread->2 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/13 EntryNormal "prop_2"]
   ]
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:13 Lead:1 LeadEpoch:1
   Entries:
   1/15 EntryNormal "prop_4"
@@ -621,7 +621,7 @@ ApplyThread->3 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/12 EntryNormal "pro
 process-ready 1 2 3
 ----
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:14 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/14 EntryNormal "prop_3"
@@ -647,7 +647,7 @@ process-ready 1 2 3
 > 1 handling Ready
   <empty Ready>
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:14 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/14 EntryNormal "prop_3"
@@ -659,7 +659,7 @@ process-ready 1 2 3
     ApplyThread->2 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/14 EntryNormal "prop_3"]
   ]
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:14 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/14 EntryNormal "prop_3"
@@ -729,7 +729,7 @@ ApplyThread->3 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/13 EntryNormal "pro
 process-ready 1 2 3
 ----
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:15 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/15 EntryNormal "prop_4"
@@ -755,7 +755,7 @@ process-ready 1 2 3
 > 1 handling Ready
   <empty Ready>
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:15 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/15 EntryNormal "prop_4"
@@ -767,7 +767,7 @@ process-ready 1 2 3
     ApplyThread->2 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/15 EntryNormal "prop_4"]
   ]
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:15 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/15 EntryNormal "prop_4"

--- a/pkg/raft/testdata/async_storage_writes_append_aba_race.txt
+++ b/pkg/raft/testdata/async_storage_writes_append_aba_race.txt
@@ -32,7 +32,7 @@ ok
 
 process-ready 2
 ----
-Ready MustSync=true:
+Ready:
 Entries:
 1/12 EntryNormal "init_prop"
 Messages:
@@ -60,7 +60,7 @@ dropped: 2->7 MsgApp Term:1 Log:1/11 Commit:11 Entries:[1/12 EntryNormal "init_p
 
 process-ready 1
 ----
-Ready MustSync=true:
+Ready:
 Entries:
 1/12 EntryNormal "init_prop"
 Messages:
@@ -95,7 +95,7 @@ INFO 3 [logterm: 1, index: 11] sent MsgVote request to 7 at term 2
 
 process-ready 3
 ----
-Ready MustSync=true:
+Ready:
 State:StateCandidate
 HardState Term:2 Vote:3 Commit:11 Lead:0 LeadEpoch:0
 Messages:
@@ -127,21 +127,21 @@ INFO 6 [logterm: 1, index: 11, vote: 0] cast MsgVote for 3 [logterm: 1, index: 1
 process-ready 4 5 6
 ----
 > 4 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:2 Vote:3 Commit:11 Lead:0 LeadEpoch:0
   Messages:
   4->AppendThread MsgStorageAppend Term:2 Log:0/0 Commit:11 Vote:3 Responses:[
     4->3 MsgVoteResp Term:2 Log:0/0
   ]
 > 5 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:2 Vote:3 Commit:11 Lead:0 LeadEpoch:0
   Messages:
   5->AppendThread MsgStorageAppend Term:2 Log:0/0 Commit:11 Vote:3 Responses:[
     5->3 MsgVoteResp Term:2 Log:0/0
   ]
 > 6 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:2 Vote:3 Commit:11 Lead:0 LeadEpoch:0
   Messages:
   6->AppendThread MsgStorageAppend Term:2 Log:0/0 Commit:11 Vote:3 Responses:[
@@ -194,7 +194,7 @@ INFO 3 became leader at term 2
 
 process-ready 3
 ----
-Ready MustSync=true:
+Ready:
 State:StateLeader
 HardState Term:2 Vote:3 Commit:11 Lead:3 LeadEpoch:1
 Entries:
@@ -243,7 +243,7 @@ dropped: 3->7 MsgApp Term:2 Log:1/11 Commit:11 Entries:[2/12 EntryNormal ""]
 
 process-ready 1
 ----
-Ready MustSync=true:
+Ready:
 HardState Term:2 Commit:11 Lead:3 LeadEpoch:1
 Entries:
 2/12 EntryNormal ""
@@ -270,7 +270,7 @@ INFO 4 [logterm: 1, index: 11] sent MsgVote request to 7 at term 3
 
 process-ready 4
 ----
-Ready MustSync=true:
+Ready:
 State:StateCandidate
 HardState Term:3 Vote:4 Commit:11 Lead:0 LeadEpoch:0
 Messages:
@@ -302,21 +302,21 @@ INFO 7 [logterm: 1, index: 11, vote: 0] cast MsgVote for 4 [logterm: 1, index: 1
 process-ready 5 6 7
 ----
 > 5 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:3 Vote:4 Commit:11 Lead:0 LeadEpoch:0
   Messages:
   5->AppendThread MsgStorageAppend Term:3 Log:0/0 Commit:11 Vote:4 Responses:[
     5->4 MsgVoteResp Term:3 Log:0/0
   ]
 > 6 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:3 Vote:4 Commit:11 Lead:0 LeadEpoch:0
   Messages:
   6->AppendThread MsgStorageAppend Term:3 Log:0/0 Commit:11 Vote:4 Responses:[
     6->4 MsgVoteResp Term:3 Log:0/0
   ]
 > 7 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:3 Vote:4 Commit:11 Lead:0 LeadEpoch:0
   Messages:
   7->AppendThread MsgStorageAppend Term:3 Log:0/0 Commit:11 Vote:4 Responses:[
@@ -364,7 +364,7 @@ INFO 4 became leader at term 3
 
 process-ready 4
 ----
-Ready MustSync=true:
+Ready:
 State:StateLeader
 HardState Term:3 Vote:4 Commit:11 Lead:4 LeadEpoch:1
 Entries:
@@ -406,7 +406,7 @@ ok
 
 process-ready 4
 ----
-Ready MustSync=false:
+Ready:
 Messages:
 4->1 MsgFortifyLeader Term:3 Log:0/0
 4->2 MsgFortifyLeader Term:3 Log:0/0
@@ -435,7 +435,7 @@ INFO replace the unstable entries from index 12
 
 process-ready 1
 ----
-Ready MustSync=true:
+Ready:
 HardState Term:3 Commit:11 Lead:4 LeadEpoch:1
 Entries:
 3/12 EntryNormal ""

--- a/pkg/raft/testdata/campaign.txt
+++ b/pkg/raft/testdata/campaign.txt
@@ -24,7 +24,7 @@ INFO 1 [logterm: 1, index: 2] sent MsgVote request to 3 at term 1
 stabilize
 ----
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   State:StateCandidate
   HardState Term:1 Vote:1 Commit:2 Lead:0 LeadEpoch:0
   Messages:
@@ -43,12 +43,12 @@ stabilize
   INFO 3 became follower at term 1
   INFO 3 [logterm: 1, index: 2, vote: 0] cast MsgVote for 1 [logterm: 1, index: 2] at term 1
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:2 Lead:0 LeadEpoch:0
   Messages:
   2->1 MsgVoteResp Term:1 Log:0/0
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:2 Lead:0 LeadEpoch:0
   Messages:
   3->1 MsgVoteResp Term:1 Log:0/0
@@ -59,7 +59,7 @@ stabilize
   INFO 1 became leader at term 1
   3->1 MsgVoteResp Term:1 Log:0/0
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   State:StateLeader
   HardState Term:1 Vote:1 Commit:2 Lead:1 LeadEpoch:1
   Entries:
@@ -76,7 +76,7 @@ stabilize
   1->3 MsgFortifyLeader Term:1 Log:0/0
   1->3 MsgApp Term:1 Log:1/2 Commit:2 Entries:[1/3 EntryNormal ""]
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:2 Lead:1 LeadEpoch:1
   Entries:
   1/3 EntryNormal ""
@@ -84,7 +84,7 @@ stabilize
   2->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:1
   2->1 MsgAppResp Term:1 Log:0/3 Commit:2
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:2 Lead:1 LeadEpoch:1
   Entries:
   1/3 EntryNormal ""
@@ -97,7 +97,7 @@ stabilize
   3->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:1
   3->1 MsgAppResp Term:1 Log:0/3 Commit:2
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:3 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/3 EntryNormal ""
@@ -109,14 +109,14 @@ stabilize
 > 3 receiving messages
   1->3 MsgApp Term:1 Log:1/3 Commit:3
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:3 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/3 EntryNormal ""
   Messages:
   2->1 MsgAppResp Term:1 Log:0/3 Commit:3
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:3 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/3 EntryNormal ""

--- a/pkg/raft/testdata/campaign_learner_must_vote.txt
+++ b/pkg/raft/testdata/campaign_learner_must_vote.txt
@@ -64,7 +64,7 @@ INFO 2 [logterm: 1, index: 4] sent MsgVote request to 3 at term 2
 # Send out the MsgVote requests.
 process-ready 2
 ----
-Ready MustSync=true:
+Ready:
 State:StateCandidate
 HardState Term:2 Vote:2 Commit:4 Lead:0 LeadEpoch:0
 Messages:
@@ -87,7 +87,7 @@ stabilize 3
   DEBUG 3 reset election elapsed to 0
   INFO 3 [logterm: 1, index: 3, vote: 0] cast MsgVote for 2 [logterm: 1, index: 4] at term 2
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:2 Vote:2 Commit:3 Lead:0 LeadEpoch:0
   Messages:
   3->2 MsgVoteResp Term:2 Log:0/0
@@ -100,7 +100,7 @@ stabilize 2 3
   INFO 2 has received 2 MsgVoteResp votes and 0 vote rejections
   INFO 2 became leader at term 2
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   State:StateLeader
   HardState Term:2 Vote:2 Commit:4 Lead:2 LeadEpoch:1
   Entries:
@@ -115,7 +115,7 @@ stabilize 2 3
   2->3 MsgApp Term:2 Log:1/4 Commit:4 Entries:[2/5 EntryNormal ""]
   DEBUG 3 [logterm: 0, index: 4] rejected MsgApp [logterm: 1, index: 4] from 2
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:2 Vote:2 Commit:3 Lead:2 LeadEpoch:1
   Messages:
   3->2 MsgFortifyLeaderResp Term:2 Log:0/0 LeadEpoch:1
@@ -126,7 +126,7 @@ stabilize 2 3
   DEBUG 2 received MsgAppResp(rejected, hint: (index 3, term 1)) from 3 for index 4
   DEBUG 2 decreased progress of 3 to [StateProbe match=0 next=4 sentCommit=3 matchCommit=3]
 > 2 handling Ready
-  Ready MustSync=false:
+  Ready:
   Messages:
   2->3 MsgApp Term:2 Log:1/3 Commit:4 Entries:[
     1/4 EntryConfChangeV2 v3
@@ -138,7 +138,7 @@ stabilize 2 3
     2/5 EntryNormal ""
   ]
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:2 Vote:2 Commit:4 Lead:2 LeadEpoch:1
   Entries:
   1/4 EntryConfChangeV2 v3
@@ -151,7 +151,7 @@ stabilize 2 3
 > 2 receiving messages
   3->2 MsgAppResp Term:2 Log:0/5 Commit:4
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:2 Vote:2 Commit:5 Lead:2 LeadEpoch:1
   CommittedEntries:
   2/5 EntryNormal ""
@@ -160,7 +160,7 @@ stabilize 2 3
 > 3 receiving messages
   2->3 MsgApp Term:2 Log:2/5 Commit:5
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:2 Vote:2 Commit:5 Lead:2 LeadEpoch:1
   CommittedEntries:
   2/5 EntryNormal ""

--- a/pkg/raft/testdata/campaign_single_voter.txt
+++ b/pkg/raft/testdata/campaign_single_voter.txt
@@ -25,7 +25,7 @@ INFO 1 became candidate at term 1
 stabilize
 ----
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   State:StateCandidate
   HardState Term:1 Vote:1 Commit:2 Lead:0 LeadEpoch:0
   INFO 1 received MsgVoteResp from 1 at term 1
@@ -33,13 +33,13 @@ stabilize
   INFO 1 became leader at term 1
   INFO 1 leader at term 1 does not support itself in the liveness fabric
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   State:StateLeader
   HardState Term:1 Vote:1 Commit:2 Lead:1 LeadEpoch:0
   Entries:
   1/3 EntryNormal ""
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:3 Lead:1 LeadEpoch:0
   CommittedEntries:
   1/3 EntryNormal ""

--- a/pkg/raft/testdata/confchange_disable_validation.txt
+++ b/pkg/raft/testdata/confchange_disable_validation.txt
@@ -49,22 +49,22 @@ ok
 stabilize 1
 ----
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   Entries:
   1/4 EntryNormal "foo"
   1/5 EntryConfChangeV2 l2 l3
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:5 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/4 EntryNormal "foo"
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready:
   CommittedEntries:
   1/5 EntryConfChangeV2 l2 l3
   INFO 1 switched to configuration voters=(1)&&(1) learners=(2 3)
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready:
   Messages:
   1->2 MsgFortifyLeader Term:1 Log:0/0
   1->3 MsgFortifyLeader Term:1 Log:0/0
@@ -81,7 +81,7 @@ ok
 # The new config change is appended to the log.
 process-ready 1
 ----
-Ready MustSync=true:
+Ready:
 Entries:
 1/6 EntryConfChangeV2 l4
 

--- a/pkg/raft/testdata/confchange_drop_if_unapplied.txt
+++ b/pkg/raft/testdata/confchange_drop_if_unapplied.txt
@@ -40,7 +40,7 @@ ok
 # The first config change gets appended.
 process-ready 1
 ----
-Ready MustSync=true:
+Ready:
 Entries:
 1/4 EntryConfChangeV2 l2 l3
 
@@ -55,7 +55,7 @@ INFO 1 ignoring conf change {ConfChangeTransitionAuto [{ConfChangeAddLearnerNode
 stabilize 1
 ----
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:4 Lead:1 LeadEpoch:1
   Entries:
   1/5 EntryNormal ""
@@ -63,7 +63,7 @@ stabilize 1
   1/4 EntryConfChangeV2 l2 l3
   INFO 1 switched to configuration voters=(1)&&(1) learners=(2 3)
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:5 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/5 EntryNormal ""

--- a/pkg/raft/testdata/confchange_fortification_safety.txt
+++ b/pkg/raft/testdata/confchange_fortification_safety.txt
@@ -51,7 +51,7 @@ ok
 stabilize 1 2 3
 ----
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   Entries:
   1/4 EntryConfChangeV2 v4
   Messages:
@@ -62,13 +62,13 @@ stabilize 1 2 3
 > 3 receiving messages
   1->3 MsgApp Term:1 Log:1/3 Commit:3 Entries:[1/4 EntryConfChangeV2 v4]
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   Entries:
   1/4 EntryConfChangeV2 v4
   Messages:
   2->1 MsgAppResp Term:1 Log:0/4 Commit:3
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   Entries:
   1/4 EntryConfChangeV2 v4
   Messages:
@@ -77,7 +77,7 @@ stabilize 1 2 3
   2->1 MsgAppResp Term:1 Log:0/4 Commit:3
   3->1 MsgAppResp Term:1 Log:0/4 Commit:3
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:4 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/4 EntryConfChangeV2 v4
@@ -90,12 +90,12 @@ stabilize 1 2 3
 > 3 receiving messages
   1->3 MsgApp Term:1 Log:1/4 Commit:4
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready:
   Messages:
   1->4 MsgFortifyLeader Term:1 Log:0/0
   1->4 MsgApp Term:1 Log:1/3 Commit:4 Entries:[1/4 EntryConfChangeV2 v4]
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:4 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/4 EntryConfChangeV2 v4
@@ -103,7 +103,7 @@ stabilize 1 2 3
   2->1 MsgAppResp Term:1 Log:0/4 Commit:4
   INFO 2 switched to configuration voters=(1 2 3 4)
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:4 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/4 EntryConfChangeV2 v4
@@ -139,7 +139,7 @@ INFO 1 ignoring conf change {ConfChangeTransitionAuto [{ConfChangeRemoveNode 2} 
 stabilize 1 4
 ----
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   Entries:
   1/5 EntryNormal ""
   Messages:
@@ -153,7 +153,7 @@ stabilize 1 4
   1->4 MsgApp Term:1 Log:1/3 Commit:4 Entries:[1/4 EntryConfChangeV2 v4]
   DEBUG 4 [logterm: 0, index: 3] rejected MsgApp [logterm: 1, index: 3] from 1
 > 4 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Commit:2 Lead:1 LeadEpoch:1
   Messages:
   4->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:1
@@ -164,7 +164,7 @@ stabilize 1 4
   DEBUG 1 received MsgAppResp(rejected, hint: (index 2, term 1)) from 4 for index 3
   DEBUG 1 decreased progress of 4 to [StateProbe match=0 next=3 sentCommit=2 matchCommit=2]
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready:
   Messages:
   1->4 MsgApp Term:1 Log:1/2 Commit:4 Entries:[
     1/3 EntryNormal ""
@@ -178,7 +178,7 @@ stabilize 1 4
     1/5 EntryNormal ""
   ]
 > 4 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Commit:4 Lead:1 LeadEpoch:1
   Entries:
   1/3 EntryNormal ""
@@ -217,7 +217,7 @@ ok
 stabilize
 ----
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   Entries:
   1/6 EntryConfChangeV2 r2 l2
   Messages:
@@ -233,7 +233,7 @@ stabilize
 > 4 receiving messages
   1->4 MsgApp Term:1 Log:1/5 Commit:4 Entries:[1/6 EntryConfChangeV2 r2 l2]
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   Entries:
   1/5 EntryNormal ""
   1/6 EntryConfChangeV2 r2 l2
@@ -241,7 +241,7 @@ stabilize
   2->1 MsgAppResp Term:1 Log:0/5 Commit:4
   2->1 MsgAppResp Term:1 Log:0/6 Commit:4
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   Entries:
   1/5 EntryNormal ""
   1/6 EntryConfChangeV2 r2 l2
@@ -249,7 +249,7 @@ stabilize
   3->1 MsgAppResp Term:1 Log:0/5 Commit:4
   3->1 MsgAppResp Term:1 Log:0/6 Commit:4
 > 4 handling Ready
-  Ready MustSync=true:
+  Ready:
   Entries:
   1/6 EntryConfChangeV2 r2 l2
   Messages:
@@ -261,7 +261,7 @@ stabilize
   3->1 MsgAppResp Term:1 Log:0/6 Commit:4
   4->1 MsgAppResp Term:1 Log:0/6 Commit:4
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:6 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/5 EntryNormal ""
@@ -285,7 +285,7 @@ stabilize
   1->4 MsgApp Term:1 Log:1/6 Commit:5
   1->4 MsgApp Term:1 Log:1/6 Commit:6
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   Entries:
   1/7 EntryConfChangeV2
   Messages:
@@ -293,7 +293,7 @@ stabilize
   1->3 MsgApp Term:1 Log:1/6 Commit:6 Entries:[1/7 EntryConfChangeV2]
   1->4 MsgApp Term:1 Log:1/6 Commit:6 Entries:[1/7 EntryConfChangeV2]
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:6 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/5 EntryNormal ""
@@ -303,7 +303,7 @@ stabilize
   2->1 MsgAppResp Term:1 Log:0/6 Commit:6
   INFO 2 switched to configuration voters=(1 3 4)&&(1 2 3 4) learners_next=(2) autoleave
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:6 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/5 EntryNormal ""
@@ -313,7 +313,7 @@ stabilize
   3->1 MsgAppResp Term:1 Log:0/6 Commit:6
   INFO 3 switched to configuration voters=(1 3 4)&&(1 2 3 4) learners_next=(2) autoleave
 > 4 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Commit:6 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/5 EntryNormal ""
@@ -336,19 +336,19 @@ stabilize
 > 4 receiving messages
   1->4 MsgApp Term:1 Log:1/6 Commit:6 Entries:[1/7 EntryConfChangeV2]
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   Entries:
   1/7 EntryConfChangeV2
   Messages:
   2->1 MsgAppResp Term:1 Log:0/7 Commit:6
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   Entries:
   1/7 EntryConfChangeV2
   Messages:
   3->1 MsgAppResp Term:1 Log:0/7 Commit:6
 > 4 handling Ready
-  Ready MustSync=true:
+  Ready:
   Entries:
   1/7 EntryConfChangeV2
   Messages:
@@ -358,7 +358,7 @@ stabilize
   3->1 MsgAppResp Term:1 Log:0/7 Commit:6
   4->1 MsgAppResp Term:1 Log:0/7 Commit:6
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:7 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/7 EntryConfChangeV2
@@ -374,7 +374,7 @@ stabilize
 > 4 receiving messages
   1->4 MsgApp Term:1 Log:1/7 Commit:7
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:7 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/7 EntryConfChangeV2
@@ -382,7 +382,7 @@ stabilize
   2->1 MsgAppResp Term:1 Log:0/7 Commit:7
   INFO 2 switched to configuration voters=(1 3 4) learners=(2)
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:7 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/7 EntryConfChangeV2
@@ -390,7 +390,7 @@ stabilize
   3->1 MsgAppResp Term:1 Log:0/7 Commit:7
   INFO 3 switched to configuration voters=(1 3 4) learners=(2)
 > 4 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Commit:7 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/7 EntryConfChangeV2

--- a/pkg/raft/testdata/confchange_v1_add_single.txt
+++ b/pkg/raft/testdata/confchange_v1_add_single.txt
@@ -15,7 +15,7 @@ INFO 1 became candidate at term 1
 
 process-ready 1
 ----
-Ready MustSync=true:
+Ready:
 State:StateCandidate
 HardState Term:1 Vote:1 Commit:2 Lead:0 LeadEpoch:0
 INFO 1 received MsgVoteResp from 1 at term 1
@@ -42,21 +42,21 @@ INFO newRaft 2 [peers: [], term: 0, commit: 0, applied: 0, lastindex: 0, lastter
 stabilize
 ----
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   State:StateLeader
   HardState Term:1 Vote:1 Commit:2 Lead:1 LeadEpoch:1
   Entries:
   1/3 EntryNormal ""
   1/4 EntryConfChange v2
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:4 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/3 EntryNormal ""
   1/4 EntryConfChange v2
   INFO 1 switched to configuration voters=(1 2)
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready:
   Messages:
   1->2 MsgFortifyLeader Term:1 Log:0/0
   1->2 MsgApp Term:1 Log:1/3 Commit:4 Entries:[1/4 EntryConfChange v2]
@@ -68,7 +68,7 @@ stabilize
   1->2 MsgApp Term:1 Log:1/3 Commit:4 Entries:[1/4 EntryConfChange v2]
   DEBUG 2 [logterm: 0, index: 3] rejected MsgApp [logterm: 1, index: 3] from 1
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Commit:0 Lead:1 LeadEpoch:1
   Messages:
   2->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:1
@@ -81,7 +81,7 @@ stabilize
   DEBUG 1 [firstindex: 3, commit: 4] sent snapshot[index: 4, term: 1] to 2 [StateProbe match=0 next=1 sentCommit=0 matchCommit=0]
   DEBUG 1 paused sending replication messages to 2 [StateSnapshot match=0 next=5 sentCommit=4 matchCommit=0 paused pendingSnap=4]
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready:
   Messages:
   1->2 MsgSnap Term:1 Log:0/0
     Snapshot: Index:4 Term:1 ConfState:Voters:[1 2] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
@@ -93,7 +93,7 @@ stabilize
   INFO 2 [commit: 4, lastindex: 4, lastterm: 1] restored snapshot [index: 4, term: 1]
   INFO 2 [commit: 4] restored snapshot [index: 4, term: 1]
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Commit:4 Lead:1 LeadEpoch:1
   Snapshot Index:4 Term:1 ConfState:Voters:[1 2] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
   Messages:

--- a/pkg/raft/testdata/confchange_v1_remove_leader.txt
+++ b/pkg/raft/testdata/confchange_v1_remove_leader.txt
@@ -68,7 +68,7 @@ ok
 # Send out the corresponding appends.
 process-ready 1
 ----
-Ready MustSync=true:
+Ready:
 Entries:
 1/6 EntryConfChangeV2
 1/7 EntryNormal "foo"
@@ -89,7 +89,7 @@ stabilize 2 3
   1->3 MsgApp Term:1 Log:1/5 Commit:5 Entries:[1/6 EntryConfChangeV2]
   1->3 MsgApp Term:1 Log:1/6 Commit:5 Entries:[1/7 EntryNormal "foo"]
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   Entries:
   1/6 EntryConfChangeV2
   1/7 EntryNormal "foo"
@@ -97,7 +97,7 @@ stabilize 2 3
   2->1 MsgAppResp Term:1 Log:0/6 Commit:5
   2->1 MsgAppResp Term:1 Log:0/7 Commit:5
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   Entries:
   1/6 EntryConfChangeV2
   1/7 EntryNormal "foo"
@@ -115,7 +115,7 @@ ok
 stabilize 1
 ----
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   Entries:
   1/8 EntryNormal "bar"
   Messages:
@@ -127,7 +127,7 @@ stabilize 1
   3->1 MsgAppResp Term:1 Log:0/6 Commit:5
   3->1 MsgAppResp Term:1 Log:0/7 Commit:5
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:7 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/6 EntryConfChangeV2
@@ -142,7 +142,7 @@ stabilize 1
   INFO 1 became follower at term 1
   DEBUG 1 reset election elapsed to 0
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   State:StateFollower
   HardState Term:1 Vote:1 Commit:7 Lead:0 LeadEpoch:0
 
@@ -160,7 +160,7 @@ stabilize 2
   1->2 MsgApp Term:1 Log:1/8 Commit:6
   1->2 MsgApp Term:1 Log:1/8 Commit:7
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:7 Lead:1 LeadEpoch:1
   Entries:
   1/8 EntryNormal "bar"
@@ -189,7 +189,7 @@ stabilize
   1->3 MsgApp Term:1 Log:1/8 Commit:6
   1->3 MsgApp Term:1 Log:1/8 Commit:7
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:7 Lead:1 LeadEpoch:1
   Entries:
   1/8 EntryNormal "bar"

--- a/pkg/raft/testdata/confchange_v2_add_double_auto.txt
+++ b/pkg/raft/testdata/confchange_v2_add_double_auto.txt
@@ -17,7 +17,7 @@ INFO 1 became candidate at term 1
 
 process-ready 1
 ----
-Ready MustSync=true:
+Ready:
 State:StateCandidate
 HardState Term:1 Vote:1 Commit:2 Lead:0 LeadEpoch:0
 INFO 1 received MsgVoteResp from 1 at term 1
@@ -44,7 +44,7 @@ INFO newRaft 3 [peers: [], term: 0, commit: 0, applied: 0, lastindex: 0, lastter
 # Process n1 once, so that it can append the entry.
 process-ready 1
 ----
-Ready MustSync=true:
+Ready:
 State:StateLeader
 HardState Term:1 Vote:1 Commit:2 Lead:1 LeadEpoch:1
 Entries:
@@ -57,7 +57,7 @@ Entries:
 # it has to since we're carrying out two additions at once.
 process-ready 1
 ----
-Ready MustSync=true:
+Ready:
 HardState Term:1 Vote:1 Commit:4 Lead:1 LeadEpoch:1
 CommittedEntries:
 1/3 EntryNormal ""
@@ -70,7 +70,7 @@ INFO initiating automatic transition out of joint configuration voters=(1 2 3)&&
 stabilize 1
 ----
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   Entries:
   1/5 EntryNormal ""
   Messages:
@@ -94,7 +94,7 @@ stabilize 1 2
   1->2 MsgApp Term:1 Log:1/3 Commit:4 Entries:[1/4 EntryConfChangeV2 v2 v3]
   DEBUG 2 [logterm: 0, index: 3] rejected MsgApp [logterm: 1, index: 3] from 1
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Commit:0 Lead:1 LeadEpoch:1
   Messages:
   2->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:1
@@ -107,7 +107,7 @@ stabilize 1 2
   DEBUG 1 [firstindex: 3, commit: 4] sent snapshot[index: 4, term: 1] to 2 [StateProbe match=0 next=1 sentCommit=0 matchCommit=0]
   DEBUG 1 paused sending replication messages to 2 [StateSnapshot match=0 next=5 sentCommit=4 matchCommit=0 paused pendingSnap=4]
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready:
   Messages:
   1->2 MsgSnap Term:1 Log:0/0
     Snapshot: Index:4 Term:1 ConfState:Voters:[1 2 3] VotersOutgoing:[1] Learners:[] LearnersNext:[] AutoLeave:true
@@ -119,7 +119,7 @@ stabilize 1 2
   INFO 2 [commit: 4, lastindex: 4, lastterm: 1] restored snapshot [index: 4, term: 1]
   INFO 2 [commit: 4] restored snapshot [index: 4, term: 1]
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Commit:4 Lead:1 LeadEpoch:1
   Snapshot Index:4 Term:1 ConfState:Voters:[1 2 3] VotersOutgoing:[1] Learners:[] LearnersNext:[] AutoLeave:true
   Messages:
@@ -128,13 +128,13 @@ stabilize 1 2
   2->1 MsgAppResp Term:1 Log:0/4 Commit:4
   DEBUG 1 recovered from needing snapshot, resumed sending replication messages to 2 [StateSnapshot match=4 next=5 sentCommit=4 matchCommit=4 paused pendingSnap=4]
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready:
   Messages:
   1->2 MsgApp Term:1 Log:1/4 Commit:4 Entries:[1/5 EntryNormal ""]
 > 2 receiving messages
   1->2 MsgApp Term:1 Log:1/4 Commit:4 Entries:[1/5 EntryNormal ""]
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   Entries:
   1/5 EntryNormal ""
   Messages:
@@ -142,7 +142,7 @@ stabilize 1 2
 > 1 receiving messages
   2->1 MsgAppResp Term:1 Log:0/5 Commit:4
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:5 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/5 EntryNormal ""
@@ -152,13 +152,13 @@ stabilize 1 2
 > 2 receiving messages
   1->2 MsgApp Term:1 Log:1/5 Commit:5
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   Entries:
   1/6 EntryConfChangeV2
   Messages:
   1->2 MsgApp Term:1 Log:1/5 Commit:5 Entries:[1/6 EntryConfChangeV2]
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Commit:5 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/5 EntryNormal ""
@@ -169,7 +169,7 @@ stabilize 1 2
 > 2 receiving messages
   1->2 MsgApp Term:1 Log:1/5 Commit:5 Entries:[1/6 EntryConfChangeV2]
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   Entries:
   1/6 EntryConfChangeV2
   Messages:
@@ -177,7 +177,7 @@ stabilize 1 2
 > 1 receiving messages
   2->1 MsgAppResp Term:1 Log:0/6 Commit:5
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:6 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/6 EntryConfChangeV2
@@ -187,11 +187,11 @@ stabilize 1 2
 > 2 receiving messages
   1->2 MsgApp Term:1 Log:1/6 Commit:6
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready:
   Messages:
   1->3 MsgFortifyLeader Term:1 Log:0/0
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Commit:6 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/6 EntryConfChangeV2
@@ -213,7 +213,7 @@ stabilize 1 3
   DEBUG 3 [logterm: 0, index: 3] rejected MsgApp [logterm: 1, index: 3] from 1
   1->3 MsgFortifyLeader Term:1 Log:0/0
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Commit:0 Lead:1 LeadEpoch:1
   Messages:
   3->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:1
@@ -228,7 +228,7 @@ stabilize 1 3
   DEBUG 1 paused sending replication messages to 3 [StateSnapshot match=0 next=7 sentCommit=6 matchCommit=0 paused pendingSnap=6]
   3->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:1
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready:
   Messages:
   1->3 MsgSnap Term:1 Log:0/0
     Snapshot: Index:6 Term:1 ConfState:Voters:[1 2 3] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
@@ -240,7 +240,7 @@ stabilize 1 3
   INFO 3 [commit: 6, lastindex: 6, lastterm: 1] restored snapshot [index: 6, term: 1]
   INFO 3 [commit: 6] restored snapshot [index: 6, term: 1]
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Commit:6 Lead:1 LeadEpoch:1
   Snapshot Index:6 Term:1 ConfState:Voters:[1 2 3] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
   Messages:
@@ -266,7 +266,7 @@ ok
 stabilize 1
 ----
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   Entries:
   1/7 EntryConfChangeV2 r2 r3 l2 l3
   Messages:
@@ -281,13 +281,13 @@ stabilize 2 3
 > 3 receiving messages
   1->3 MsgApp Term:1 Log:1/6 Commit:6 Entries:[1/7 EntryConfChangeV2 r2 r3 l2 l3]
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   Entries:
   1/7 EntryConfChangeV2 r2 r3 l2 l3
   Messages:
   2->1 MsgAppResp Term:1 Log:0/7 Commit:6
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   Entries:
   1/7 EntryConfChangeV2 r2 r3 l2 l3
   Messages:
@@ -309,7 +309,7 @@ ok
 stabilize 1
 ----
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   Entries:
   1/8 EntryNormal "foo"
   1/9 EntryNormal "bar"
@@ -322,7 +322,7 @@ stabilize 1
   2->1 MsgAppResp Term:1 Log:0/7 Commit:6
   3->1 MsgAppResp Term:1 Log:0/7 Commit:6
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:7 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/7 EntryConfChangeV2 r2 r3 l2 l3
@@ -332,7 +332,7 @@ stabilize 1
   INFO 1 switched to configuration voters=(1)&&(1 2 3) learners_next=(2 3) autoleave
   INFO initiating automatic transition out of joint configuration voters=(1)&&(1 2 3) learners_next=(2 3) autoleave
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   Entries:
   1/10 EntryConfChangeV2
   Messages:
@@ -353,7 +353,7 @@ stabilize 2 3
   1->3 MsgApp Term:1 Log:1/9 Commit:7
   1->3 MsgApp Term:1 Log:1/9 Commit:7 Entries:[1/10 EntryConfChangeV2]
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Commit:7 Lead:1 LeadEpoch:1
   Entries:
   1/8 EntryNormal "foo"
@@ -368,7 +368,7 @@ stabilize 2 3
   2->1 MsgAppResp Term:1 Log:0/10 Commit:7
   INFO 2 switched to configuration voters=(1)&&(1 2 3) learners_next=(2 3) autoleave
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Commit:7 Lead:1 LeadEpoch:1
   Entries:
   1/8 EntryNormal "foo"
@@ -398,7 +398,7 @@ stabilize
   3->1 MsgAppResp Term:1 Log:0/9 Commit:7
   3->1 MsgAppResp Term:1 Log:0/10 Commit:7
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:10 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/8 EntryNormal "foo"
@@ -421,7 +421,7 @@ stabilize
   1->3 MsgApp Term:1 Log:1/10 Commit:9
   1->3 MsgApp Term:1 Log:1/10 Commit:10
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Commit:10 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/8 EntryNormal "foo"
@@ -433,7 +433,7 @@ stabilize
   2->1 MsgAppResp Term:1 Log:0/10 Commit:10
   INFO 2 switched to configuration voters=(1) learners=(2 3)
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Commit:10 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/8 EntryNormal "foo"

--- a/pkg/raft/testdata/confchange_v2_add_single_auto.txt
+++ b/pkg/raft/testdata/confchange_v2_add_single_auto.txt
@@ -17,7 +17,7 @@ INFO 1 became candidate at term 1
 
 process-ready 1
 ----
-Ready MustSync=true:
+Ready:
 State:StateCandidate
 HardState Term:1 Vote:1 Commit:2 Lead:0 LeadEpoch:0
 INFO 1 received MsgVoteResp from 1 at term 1
@@ -43,21 +43,21 @@ INFO newRaft 2 [peers: [], term: 0, commit: 0, applied: 0, lastindex: 0, lastter
 stabilize
 ----
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   State:StateLeader
   HardState Term:1 Vote:1 Commit:2 Lead:1 LeadEpoch:1
   Entries:
   1/3 EntryNormal ""
   1/4 EntryConfChangeV2 v2
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:4 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/3 EntryNormal ""
   1/4 EntryConfChangeV2 v2
   INFO 1 switched to configuration voters=(1 2)
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready:
   Messages:
   1->2 MsgFortifyLeader Term:1 Log:0/0
   1->2 MsgApp Term:1 Log:1/3 Commit:4 Entries:[1/4 EntryConfChangeV2 v2]
@@ -69,7 +69,7 @@ stabilize
   1->2 MsgApp Term:1 Log:1/3 Commit:4 Entries:[1/4 EntryConfChangeV2 v2]
   DEBUG 2 [logterm: 0, index: 3] rejected MsgApp [logterm: 1, index: 3] from 1
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Commit:0 Lead:1 LeadEpoch:1
   Messages:
   2->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:1
@@ -82,7 +82,7 @@ stabilize
   DEBUG 1 [firstindex: 3, commit: 4] sent snapshot[index: 4, term: 1] to 2 [StateProbe match=0 next=1 sentCommit=0 matchCommit=0]
   DEBUG 1 paused sending replication messages to 2 [StateSnapshot match=0 next=5 sentCommit=4 matchCommit=0 paused pendingSnap=4]
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready:
   Messages:
   1->2 MsgSnap Term:1 Log:0/0
     Snapshot: Index:4 Term:1 ConfState:Voters:[1 2] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
@@ -94,7 +94,7 @@ stabilize
   INFO 2 [commit: 4, lastindex: 4, lastterm: 1] restored snapshot [index: 4, term: 1]
   INFO 2 [commit: 4] restored snapshot [index: 4, term: 1]
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Commit:4 Lead:1 LeadEpoch:1
   Snapshot Index:4 Term:1 ConfState:Voters:[1 2] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
   Messages:

--- a/pkg/raft/testdata/confchange_v2_add_single_explicit.txt
+++ b/pkg/raft/testdata/confchange_v2_add_single_explicit.txt
@@ -17,7 +17,7 @@ INFO 1 became candidate at term 1
 
 process-ready 1
 ----
-Ready MustSync=true:
+Ready:
 State:StateCandidate
 HardState Term:1 Vote:1 Commit:2 Lead:0 LeadEpoch:0
 INFO 1 received MsgVoteResp from 1 at term 1
@@ -43,21 +43,21 @@ INFO newRaft 2 [peers: [], term: 0, commit: 0, applied: 0, lastindex: 0, lastter
 stabilize 1 2
 ----
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   State:StateLeader
   HardState Term:1 Vote:1 Commit:2 Lead:1 LeadEpoch:1
   Entries:
   1/3 EntryNormal ""
   1/4 EntryConfChangeV2 v2
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:4 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/3 EntryNormal ""
   1/4 EntryConfChangeV2 v2
   INFO 1 switched to configuration voters=(1 2)&&(1)
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready:
   Messages:
   1->2 MsgFortifyLeader Term:1 Log:0/0
   1->2 MsgApp Term:1 Log:1/3 Commit:4 Entries:[1/4 EntryConfChangeV2 v2]
@@ -69,7 +69,7 @@ stabilize 1 2
   1->2 MsgApp Term:1 Log:1/3 Commit:4 Entries:[1/4 EntryConfChangeV2 v2]
   DEBUG 2 [logterm: 0, index: 3] rejected MsgApp [logterm: 1, index: 3] from 1
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Commit:0 Lead:1 LeadEpoch:1
   Messages:
   2->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:1
@@ -82,7 +82,7 @@ stabilize 1 2
   DEBUG 1 [firstindex: 3, commit: 4] sent snapshot[index: 4, term: 1] to 2 [StateProbe match=0 next=1 sentCommit=0 matchCommit=0]
   DEBUG 1 paused sending replication messages to 2 [StateSnapshot match=0 next=5 sentCommit=4 matchCommit=0 paused pendingSnap=4]
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready:
   Messages:
   1->2 MsgSnap Term:1 Log:0/0
     Snapshot: Index:4 Term:1 ConfState:Voters:[1 2] VotersOutgoing:[1] Learners:[] LearnersNext:[] AutoLeave:false
@@ -94,7 +94,7 @@ stabilize 1 2
   INFO 2 [commit: 4, lastindex: 4, lastterm: 1] restored snapshot [index: 4, term: 1]
   INFO 2 [commit: 4] restored snapshot [index: 4, term: 1]
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Commit:4 Lead:1 LeadEpoch:1
   Snapshot Index:4 Term:1 ConfState:Voters:[1 2] VotersOutgoing:[1] Learners:[] LearnersNext:[] AutoLeave:false
   Messages:
@@ -120,7 +120,7 @@ ok
 stabilize
 ----
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   Entries:
   1/5 EntryNormal ""
   1/6 EntryConfChangeV2
@@ -131,7 +131,7 @@ stabilize
   1->2 MsgApp Term:1 Log:1/4 Commit:4 Entries:[1/5 EntryNormal ""]
   1->2 MsgApp Term:1 Log:1/5 Commit:4 Entries:[1/6 EntryConfChangeV2]
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   Entries:
   1/5 EntryNormal ""
   1/6 EntryConfChangeV2
@@ -142,7 +142,7 @@ stabilize
   2->1 MsgAppResp Term:1 Log:0/5 Commit:4
   2->1 MsgAppResp Term:1 Log:0/6 Commit:4
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:6 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/5 EntryNormal ""
@@ -155,7 +155,7 @@ stabilize
   1->2 MsgApp Term:1 Log:1/6 Commit:5
   1->2 MsgApp Term:1 Log:1/6 Commit:6
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Commit:6 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/5 EntryNormal ""
@@ -177,7 +177,7 @@ INFO 1 ignoring conf change {ConfChangeTransitionAuto [] []} at config voters=(1
 stabilize
 ----
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   Entries:
   1/7 EntryNormal ""
   Messages:
@@ -185,7 +185,7 @@ stabilize
 > 2 receiving messages
   1->2 MsgApp Term:1 Log:1/6 Commit:6 Entries:[1/7 EntryNormal ""]
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   Entries:
   1/7 EntryNormal ""
   Messages:
@@ -193,7 +193,7 @@ stabilize
 > 1 receiving messages
   2->1 MsgAppResp Term:1 Log:0/7 Commit:6
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:7 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/7 EntryNormal ""
@@ -202,7 +202,7 @@ stabilize
 > 2 receiving messages
   1->2 MsgApp Term:1 Log:1/7 Commit:7
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Commit:7 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/7 EntryNormal ""

--- a/pkg/raft/testdata/confchange_v2_add_single_implicit.txt
+++ b/pkg/raft/testdata/confchange_v2_add_single_implicit.txt
@@ -48,7 +48,7 @@ INFO newRaft 3 [peers: [], term: 0, commit: 0, applied: 0, lastindex: 0, lastter
 stabilize
 ----
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   Entries:
   1/4 EntryConfChangeV2 v3
   Messages:
@@ -56,7 +56,7 @@ stabilize
 > 2 receiving messages
   1->2 MsgApp Term:1 Log:1/3 Commit:3 Entries:[1/4 EntryConfChangeV2 v3]
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   Entries:
   1/4 EntryConfChangeV2 v3
   Messages:
@@ -64,7 +64,7 @@ stabilize
 > 1 receiving messages
   2->1 MsgAppResp Term:1 Log:0/4 Commit:3
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:4 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/4 EntryConfChangeV2 v3
@@ -75,7 +75,7 @@ stabilize
 > 2 receiving messages
   1->2 MsgApp Term:1 Log:1/4 Commit:4
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   Entries:
   1/5 EntryConfChangeV2
   Messages:
@@ -83,7 +83,7 @@ stabilize
   1->3 MsgApp Term:1 Log:1/3 Commit:4 Entries:[1/4 EntryConfChangeV2 v3]
   1->2 MsgApp Term:1 Log:1/4 Commit:4 Entries:[1/5 EntryConfChangeV2]
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:4 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/4 EntryConfChangeV2 v3
@@ -102,13 +102,13 @@ stabilize
   1->3 MsgApp Term:1 Log:1/3 Commit:4 Entries:[1/4 EntryConfChangeV2 v3]
   DEBUG 3 [logterm: 0, index: 3] rejected MsgApp [logterm: 1, index: 3] from 1
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   Entries:
   1/5 EntryConfChangeV2
   Messages:
   2->1 MsgAppResp Term:1 Log:0/5 Commit:4
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Commit:0 Lead:1 LeadEpoch:1
   Messages:
   3->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:1
@@ -122,7 +122,7 @@ stabilize
   DEBUG 1 [firstindex: 3, commit: 5] sent snapshot[index: 4, term: 1] to 3 [StateProbe match=0 next=1 sentCommit=0 matchCommit=0]
   DEBUG 1 paused sending replication messages to 3 [StateSnapshot match=0 next=5 sentCommit=4 matchCommit=0 paused pendingSnap=4]
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:5 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/5 EntryConfChangeV2
@@ -141,7 +141,7 @@ stabilize
   INFO 3 [commit: 4, lastindex: 4, lastterm: 1] restored snapshot [index: 4, term: 1]
   INFO 3 [commit: 4] restored snapshot [index: 4, term: 1]
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:5 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/5 EntryConfChangeV2
@@ -149,7 +149,7 @@ stabilize
   2->1 MsgAppResp Term:1 Log:0/5 Commit:5
   INFO 2 switched to configuration voters=(1 2 3)
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Commit:4 Lead:1 LeadEpoch:1
   Snapshot Index:4 Term:1 ConfState:Voters:[1 2 3] VotersOutgoing:[1 2] Learners:[] LearnersNext:[] AutoLeave:true
   Messages:
@@ -159,13 +159,13 @@ stabilize
   3->1 MsgAppResp Term:1 Log:0/4 Commit:4
   DEBUG 1 recovered from needing snapshot, resumed sending replication messages to 3 [StateSnapshot match=4 next=5 sentCommit=4 matchCommit=4 paused pendingSnap=4]
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready:
   Messages:
   1->3 MsgApp Term:1 Log:1/4 Commit:5 Entries:[1/5 EntryConfChangeV2]
 > 3 receiving messages
   1->3 MsgApp Term:1 Log:1/4 Commit:5 Entries:[1/5 EntryConfChangeV2]
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Commit:5 Lead:1 LeadEpoch:1
   Entries:
   1/5 EntryConfChangeV2

--- a/pkg/raft/testdata/confchange_v2_replace_leader.txt
+++ b/pkg/raft/testdata/confchange_v2_replace_leader.txt
@@ -69,13 +69,13 @@ ok
 stabilize
 ----
 > 4 handling Ready
-  Ready MustSync=false:
+  Ready:
   Messages:
   4->1 MsgProp Term:0 Log:0/0 Entries:[0/0 EntryConfChangeV2]
 > 1 receiving messages
   4->1 MsgProp Term:0 Log:0/0 Entries:[0/0 EntryConfChangeV2]
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   Entries:
   1/5 EntryConfChangeV2
   Messages:
@@ -89,19 +89,19 @@ stabilize
 > 4 receiving messages
   1->4 MsgApp Term:1 Log:1/4 Commit:4 Entries:[1/5 EntryConfChangeV2]
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   Entries:
   1/5 EntryConfChangeV2
   Messages:
   2->1 MsgAppResp Term:1 Log:0/5 Commit:4
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   Entries:
   1/5 EntryConfChangeV2
   Messages:
   3->1 MsgAppResp Term:1 Log:0/5 Commit:4
 > 4 handling Ready
-  Ready MustSync=true:
+  Ready:
   Entries:
   1/5 EntryConfChangeV2
   Messages:
@@ -111,7 +111,7 @@ stabilize
   3->1 MsgAppResp Term:1 Log:0/5 Commit:4
   4->1 MsgAppResp Term:1 Log:0/5 Commit:4
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:5 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/5 EntryConfChangeV2
@@ -128,11 +128,11 @@ stabilize
 > 4 receiving messages
   1->4 MsgApp Term:1 Log:1/5 Commit:5
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   State:StateFollower
   HardState Term:1 Vote:1 Commit:5 Lead:0 LeadEpoch:0
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:5 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/5 EntryConfChangeV2
@@ -140,7 +140,7 @@ stabilize
   2->1 MsgAppResp Term:1 Log:0/5 Commit:5
   INFO 2 switched to configuration voters=(2 3 4) learners=(1)
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:5 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/5 EntryConfChangeV2
@@ -148,7 +148,7 @@ stabilize
   3->1 MsgAppResp Term:1 Log:0/5 Commit:5
   INFO 3 switched to configuration voters=(2 3 4) learners=(1)
 > 4 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Commit:5 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/5 EntryConfChangeV2
@@ -189,7 +189,7 @@ ok
 stabilize log-level=debug
 ----
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready:
   Messages:
   1->2 MsgDeFortifyLeader Term:1 Log:0/0
   1->3 MsgDeFortifyLeader Term:1 Log:0/0
@@ -204,13 +204,13 @@ stabilize log-level=debug
   1->4 MsgDeFortifyLeader Term:1 Log:0/0
   DEBUG 4 setting election elapsed to start from 3 ticks after store liveness support expired
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:5 Lead:1 LeadEpoch:0
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:5 Lead:1 LeadEpoch:0
 > 4 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Commit:5 Lead:1 LeadEpoch:0
 
 

--- a/pkg/raft/testdata/de_fortification_basic.txt
+++ b/pkg/raft/testdata/de_fortification_basic.txt
@@ -71,7 +71,7 @@ INFO 1 [logterm: 1, index: 2] sent MsgVote request to 3 at term 1
 stabilize
 ----
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   State:StateCandidate
   HardState Term:1 Vote:1 Commit:2 Lead:0 LeadEpoch:0
   Messages:
@@ -98,14 +98,14 @@ stabilize
   Responses:
   1->1 MsgVoteResp Term:1 Log:0/0
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:2 Lead:0 LeadEpoch:0
   Messages:
   2->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:2 Vote:1 Responses:[
     2->1 MsgVoteResp Term:1 Log:0/0
   ]
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:2 Lead:0 LeadEpoch:0
   Messages:
   3->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:2 Vote:1 Responses:[
@@ -132,7 +132,7 @@ stabilize
   INFO 1 became leader at term 1
   3->1 MsgVoteResp Term:1 Log:0/0
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   State:StateLeader
   HardState Term:1 Vote:1 Commit:2 Lead:1 LeadEpoch:3
   Entries:
@@ -159,7 +159,7 @@ stabilize
   1->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:3
   AppendThread->1 MsgStorageAppendResp Term:0 Log:1/3
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:2 Lead:1 LeadEpoch:3
   Entries:
   1/3 EntryNormal ""
@@ -170,7 +170,7 @@ stabilize
     AppendThread->2 MsgStorageAppendResp Term:0 Log:1/3
   ]
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:2 Lead:1 LeadEpoch:0
   Entries:
   1/3 EntryNormal ""
@@ -205,7 +205,7 @@ stabilize
 > 3 receiving messages
   AppendThread->3 MsgStorageAppendResp Term:0 Log:1/3
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:3 Lead:1 LeadEpoch:3
   CommittedEntries:
   1/3 EntryNormal ""
@@ -230,7 +230,7 @@ stabilize
   Responses:
   ApplyThread->1 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/3 EntryNormal ""]
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:3 Lead:1 LeadEpoch:3
   CommittedEntries:
   1/3 EntryNormal ""
@@ -242,7 +242,7 @@ stabilize
     ApplyThread->2 MsgStorageApplyResp Term:0 Log:0/0 Entries:[1/3 EntryNormal ""]
   ]
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:3 Lead:1 LeadEpoch:0
   CommittedEntries:
   1/3 EntryNormal ""
@@ -311,7 +311,7 @@ ok
 stabilize
 ----
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   State:StateFollower
   HardState Term:1 Vote:1 Commit:3 Lead:0 LeadEpoch:0
   Messages:
@@ -329,7 +329,7 @@ stabilize
   1->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:3 Vote:1
   Responses:
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:3 Lead:1 LeadEpoch:0
   Messages:
   2->AppendThread MsgStorageAppend Term:1 Log:0/0 Commit:3 Vote:1 Lead:1
@@ -366,7 +366,7 @@ ok
 stabilize
 ----
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready:
   Messages:
   1->2 MsgDeFortifyLeader Term:1 Log:0/0
 > 2 receiving messages
@@ -397,7 +397,7 @@ INFO 2 [logterm: 1, index: 3] sent MsgVote request to 3 at term 2
 stabilize
 ----
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   State:StateCandidate
   HardState Term:2 Vote:2 Commit:3 Lead:0 LeadEpoch:0
   Messages:
@@ -424,14 +424,14 @@ stabilize
   Responses:
   2->2 MsgVoteResp Term:2 Log:0/0
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:2 Vote:2 Commit:3 Lead:0 LeadEpoch:0
   Messages:
   1->AppendThread MsgStorageAppend Term:2 Log:0/0 Commit:3 Vote:2 Responses:[
     1->2 MsgVoteResp Term:2 Log:0/0
   ]
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:2 Vote:2 Commit:3 Lead:0 LeadEpoch:0
   Messages:
   3->AppendThread MsgStorageAppend Term:2 Log:0/0 Commit:3 Vote:2 Responses:[
@@ -458,7 +458,7 @@ stabilize
   INFO 2 became leader at term 2
   3->2 MsgVoteResp Term:2 Log:0/0
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   State:StateLeader
   HardState Term:2 Vote:2 Commit:3 Lead:2 LeadEpoch:1
   Entries:
@@ -487,7 +487,7 @@ stabilize
   2->2 MsgFortifyLeaderResp Term:2 Log:0/0 LeadEpoch:1
   AppendThread->2 MsgStorageAppendResp Term:0 Log:2/4
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:2 Vote:2 Commit:3 Lead:2 LeadEpoch:1
   Entries:
   2/4 EntryNormal ""
@@ -498,7 +498,7 @@ stabilize
     AppendThread->1 MsgStorageAppendResp Term:0 Log:2/4
   ]
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:2 Vote:2 Commit:3 Lead:2 LeadEpoch:1
   Entries:
   2/4 EntryNormal ""
@@ -536,7 +536,7 @@ stabilize
 > 3 receiving messages
   AppendThread->3 MsgStorageAppendResp Term:0 Log:2/4
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:2 Vote:2 Commit:4 Lead:2 LeadEpoch:1
   CommittedEntries:
   2/4 EntryNormal ""
@@ -561,7 +561,7 @@ stabilize
   Responses:
   ApplyThread->2 MsgStorageApplyResp Term:0 Log:0/0 Entries:[2/4 EntryNormal ""]
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:2 Vote:2 Commit:4 Lead:2 LeadEpoch:1
   CommittedEntries:
   2/4 EntryNormal ""
@@ -573,7 +573,7 @@ stabilize
     ApplyThread->1 MsgStorageApplyResp Term:0 Log:0/0 Entries:[2/4 EntryNormal ""]
   ]
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:2 Vote:2 Commit:4 Lead:2 LeadEpoch:1
   CommittedEntries:
   2/4 EntryNormal ""
@@ -641,7 +641,7 @@ ok
 stabilize
 ----
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   State:StateFollower
   HardState Term:2 Vote:2 Commit:4 Lead:0 LeadEpoch:0
   Messages:
@@ -655,7 +655,7 @@ stabilize
   2->AppendThread MsgStorageAppend Term:2 Log:0/0 Commit:4 Vote:2
   Responses:
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:2 Vote:2 Commit:4 Lead:2 LeadEpoch:0
   Messages:
   3->AppendThread MsgStorageAppend Term:2 Log:0/0 Commit:4 Vote:2 Lead:2
@@ -683,7 +683,7 @@ INFO 3 [logterm: 2, index: 4] sent MsgVote request to 2 at term 3
 stabilize
 ----
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   State:StateCandidate
   HardState Term:3 Vote:3 Commit:4 Lead:0 LeadEpoch:0
   Messages:
@@ -707,7 +707,7 @@ stabilize
   Responses:
   3->3 MsgVoteResp Term:3 Log:0/0
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:3 Vote:3 Commit:4 Lead:0 LeadEpoch:0
   Messages:
   2->AppendThread MsgStorageAppend Term:3 Log:0/0 Commit:4 Vote:3 Responses:[
@@ -728,7 +728,7 @@ stabilize
   INFO 3 has received 2 MsgVoteResp votes and 0 vote rejections
   INFO 3 became leader at term 3
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   State:StateLeader
   HardState Term:3 Vote:3 Commit:4 Lead:3 LeadEpoch:1
   Entries:
@@ -761,7 +761,7 @@ stabilize
   3->3 MsgFortifyLeaderResp Term:3 Log:0/0 LeadEpoch:1
   AppendThread->3 MsgStorageAppendResp Term:0 Log:3/5
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:3 Commit:4 Lead:3 LeadEpoch:1
   Entries:
   3/5 EntryNormal ""
@@ -772,7 +772,7 @@ stabilize
     AppendThread->1 MsgStorageAppendResp Term:0 Log:3/5
   ]
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:3 Vote:3 Commit:4 Lead:3 LeadEpoch:1
   Entries:
   3/5 EntryNormal ""
@@ -810,7 +810,7 @@ stabilize
   2->3 MsgFortifyLeaderResp Term:3 Log:0/0 LeadEpoch:1
   2->3 MsgAppResp Term:3 Log:0/5 Commit:4
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:3 Vote:3 Commit:5 Lead:3 LeadEpoch:1
   CommittedEntries:
   3/5 EntryNormal ""
@@ -835,7 +835,7 @@ stabilize
   Responses:
   ApplyThread->3 MsgStorageApplyResp Term:0 Log:0/0 Entries:[3/5 EntryNormal ""]
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:3 Commit:5 Lead:3 LeadEpoch:1
   CommittedEntries:
   3/5 EntryNormal ""
@@ -847,7 +847,7 @@ stabilize
     ApplyThread->1 MsgStorageApplyResp Term:0 Log:0/0 Entries:[3/5 EntryNormal ""]
   ]
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:3 Vote:3 Commit:5 Lead:3 LeadEpoch:1
   CommittedEntries:
   3/5 EntryNormal ""
@@ -916,7 +916,7 @@ ok
 stabilize
 ----
 > 2 handling Ready
-  Ready MustSync=false:
+  Ready:
   Messages:
   2->1 MsgDeFortifyLeader Term:2 Log:0/0
   2->3 MsgDeFortifyLeader Term:2 Log:0/0
@@ -946,7 +946,7 @@ INFO 2 [logterm: 3, index: 5] sent MsgVote request to 3 at term 4
 stabilize
 ----
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   State:StateCandidate
   HardState Term:4 Vote:2 Commit:5 Lead:0 LeadEpoch:0
   Messages:
@@ -975,14 +975,14 @@ stabilize
   Responses:
   2->2 MsgVoteResp Term:4 Log:0/0
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:4 Vote:2 Commit:5 Lead:0 LeadEpoch:0
   Messages:
   1->AppendThread MsgStorageAppend Term:4 Log:0/0 Commit:5 Vote:2 Responses:[
     1->2 MsgVoteResp Term:4 Log:0/0
   ]
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   State:StateFollower
   HardState Term:4 Vote:2 Commit:5 Lead:0 LeadEpoch:0
   Messages:
@@ -1010,7 +1010,7 @@ stabilize
   INFO 2 became leader at term 4
   3->2 MsgVoteResp Term:4 Log:0/0
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   State:StateLeader
   HardState Term:4 Vote:2 Commit:5 Lead:2 LeadEpoch:1
   Entries:
@@ -1039,7 +1039,7 @@ stabilize
   2->2 MsgFortifyLeaderResp Term:4 Log:0/0 LeadEpoch:1
   AppendThread->2 MsgStorageAppendResp Term:0 Log:4/6
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:4 Vote:2 Commit:5 Lead:2 LeadEpoch:1
   Entries:
   4/6 EntryNormal ""
@@ -1050,7 +1050,7 @@ stabilize
     AppendThread->1 MsgStorageAppendResp Term:0 Log:4/6
   ]
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:4 Vote:2 Commit:5 Lead:2 LeadEpoch:1
   Entries:
   4/6 EntryNormal ""
@@ -1088,7 +1088,7 @@ stabilize
 > 3 receiving messages
   AppendThread->3 MsgStorageAppendResp Term:0 Log:4/6
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:4 Vote:2 Commit:6 Lead:2 LeadEpoch:1
   CommittedEntries:
   4/6 EntryNormal ""
@@ -1113,7 +1113,7 @@ stabilize
   Responses:
   ApplyThread->2 MsgStorageApplyResp Term:0 Log:0/0 Entries:[4/6 EntryNormal ""]
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:4 Vote:2 Commit:6 Lead:2 LeadEpoch:1
   CommittedEntries:
   4/6 EntryNormal ""
@@ -1125,7 +1125,7 @@ stabilize
     ApplyThread->1 MsgStorageApplyResp Term:0 Log:0/0 Entries:[4/6 EntryNormal ""]
   ]
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:4 Vote:2 Commit:6 Lead:2 LeadEpoch:1
   CommittedEntries:
   4/6 EntryNormal ""
@@ -1193,7 +1193,7 @@ ok
 stabilize
 ----
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   State:StateFollower
   HardState Term:4 Vote:2 Commit:6 Lead:0 LeadEpoch:0
   Messages:
@@ -1207,7 +1207,7 @@ stabilize
   2->AppendThread MsgStorageAppend Term:4 Log:0/0 Commit:6 Vote:2
   Responses:
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:4 Vote:2 Commit:6 Lead:2 LeadEpoch:0
   Messages:
   1->AppendThread MsgStorageAppend Term:4 Log:0/0 Commit:6 Vote:2 Lead:2
@@ -1232,7 +1232,7 @@ INFO 1 [logterm: 4, index: 6] sent MsgVote request to 3 at term 5
 stabilize
 ----
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   State:StateCandidate
   HardState Term:5 Vote:1 Commit:6 Lead:0 LeadEpoch:0
   Messages:
@@ -1256,7 +1256,7 @@ stabilize
   Responses:
   1->1 MsgVoteResp Term:5 Log:0/0
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:5 Vote:1 Commit:6 Lead:0 LeadEpoch:0
   Messages:
   2->AppendThread MsgStorageAppend Term:5 Log:0/0 Commit:6 Vote:1 Responses:[
@@ -1277,7 +1277,7 @@ stabilize
   INFO 1 has received 2 MsgVoteResp votes and 0 vote rejections
   INFO 1 became leader at term 5
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   State:StateLeader
   HardState Term:5 Vote:1 Commit:6 Lead:1 LeadEpoch:3
   Entries:
@@ -1308,7 +1308,7 @@ stabilize
   1->1 MsgFortifyLeaderResp Term:5 Log:0/0 LeadEpoch:3
   AppendThread->1 MsgStorageAppendResp Term:0 Log:5/7
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:5 Vote:1 Commit:6 Lead:1 LeadEpoch:3
   Entries:
   5/7 EntryNormal ""
@@ -1319,7 +1319,7 @@ stabilize
     AppendThread->2 MsgStorageAppendResp Term:0 Log:5/7
   ]
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:5 Commit:6 Lead:1 LeadEpoch:0
   Entries:
   5/7 EntryNormal ""
@@ -1354,7 +1354,7 @@ stabilize
 > 3 receiving messages
   AppendThread->3 MsgStorageAppendResp Term:0 Log:5/7
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:5 Vote:1 Commit:7 Lead:1 LeadEpoch:3
   CommittedEntries:
   5/7 EntryNormal ""
@@ -1379,7 +1379,7 @@ stabilize
   Responses:
   ApplyThread->1 MsgStorageApplyResp Term:0 Log:0/0 Entries:[5/7 EntryNormal ""]
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:5 Vote:1 Commit:7 Lead:1 LeadEpoch:3
   CommittedEntries:
   5/7 EntryNormal ""
@@ -1391,7 +1391,7 @@ stabilize
     ApplyThread->2 MsgStorageApplyResp Term:0 Log:0/0 Entries:[5/7 EntryNormal ""]
   ]
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:5 Commit:7 Lead:1 LeadEpoch:0
   CommittedEntries:
   5/7 EntryNormal ""
@@ -1446,7 +1446,7 @@ ok
 stabilize
 ----
 > 2 handling Ready
-  Ready MustSync=false:
+  Ready:
   Messages:
   2->1 MsgDeFortifyLeader Term:4 Log:0/0
 > 1 receiving messages

--- a/pkg/raft/testdata/de_fortification_checkquorum.txt
+++ b/pkg/raft/testdata/de_fortification_checkquorum.txt
@@ -95,7 +95,7 @@ raft-state 1
 stabilize
 ----
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   State:StateFollower
   HardState Term:1 Vote:1 Commit:11 Lead:0 LeadEpoch:0
   Messages:
@@ -126,10 +126,10 @@ stabilize
   1->3 MsgDeFortifyLeader Term:1 Log:0/0
   DEBUG 3 is not fortifying 1; de-fortification is a no-op
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:11 Lead:1 LeadEpoch:0
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:11 Lead:1 LeadEpoch:0
 
 # All peers have been de-fortified successfully.
@@ -149,7 +149,7 @@ ok
 stabilize
 ----
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready:
   Messages:
   1->2 MsgDeFortifyLeader Term:1 Log:0/0
   1->3 MsgDeFortifyLeader Term:1 Log:0/0
@@ -256,7 +256,7 @@ INFO 3 [logterm: 2, index: 12] sent MsgPreVote request to 2 at term 2
 stabilize 3
 ----
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   State:StatePreCandidate
   HardState Term:2 Vote:2 Commit:12 Lead:0 LeadEpoch:0
   Messages:
@@ -272,13 +272,13 @@ dropped: 3->2 MsgPreVote Term:3 Log:2/12
 stabilize 1 3
 ----
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:2 Vote:2 Commit:12 Lead:2 LeadEpoch:0
 > 1 receiving messages
   3->1 MsgPreVote Term:3 Log:2/12
   INFO 1 [logterm: 2, index: 12, vote: 2] cast MsgPreVote for 3 [logterm: 2, index: 12] at term 2
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready:
   Messages:
   1->3 MsgPreVoteResp Term:3 Log:0/0
 > 3 receiving messages
@@ -289,7 +289,7 @@ stabilize 1 3
   INFO 3 [logterm: 2, index: 12] sent MsgVote request to 1 at term 3
   INFO 3 [logterm: 2, index: 12] sent MsgVote request to 2 at term 3
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   State:StateCandidate
   HardState Term:3 Vote:3 Commit:12 Lead:0 LeadEpoch:0
   Messages:
@@ -304,7 +304,7 @@ stabilize 1 3
   DEBUG 1 reset election elapsed to 0
   INFO 1 [logterm: 2, index: 12, vote: 0] cast MsgVote for 3 [logterm: 2, index: 12] at term 3
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:3 Vote:3 Commit:12 Lead:0 LeadEpoch:0
   Messages:
   1->3 MsgVoteResp Term:3 Log:0/0
@@ -314,7 +314,7 @@ stabilize 1 3
   INFO 3 has received 2 MsgVoteResp votes and 0 vote rejections
   INFO 3 became leader at term 3
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   State:StateLeader
   HardState Term:3 Vote:3 Commit:12 Lead:3 LeadEpoch:1
   Entries:
@@ -328,7 +328,7 @@ stabilize 1 3
   3->1 MsgFortifyLeader Term:3 Log:0/0
   3->1 MsgApp Term:3 Log:2/12 Commit:12 Entries:[3/13 EntryNormal ""]
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:3 Vote:3 Commit:12 Lead:3 LeadEpoch:1
   Entries:
   3/13 EntryNormal ""
@@ -339,7 +339,7 @@ stabilize 1 3
   1->3 MsgFortifyLeaderResp Term:3 Log:0/0 LeadEpoch:1
   1->3 MsgAppResp Term:3 Log:0/13 Commit:12
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:3 Vote:3 Commit:13 Lead:3 LeadEpoch:1
   CommittedEntries:
   3/13 EntryNormal ""
@@ -348,7 +348,7 @@ stabilize 1 3
 > 1 receiving messages
   3->1 MsgApp Term:3 Log:3/13 Commit:13
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:3 Vote:3 Commit:13 Lead:3 LeadEpoch:1
   CommittedEntries:
   3/13 EntryNormal ""
@@ -394,7 +394,7 @@ ok
 stabilize
 ----
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   State:StateFollower
   HardState Term:2 Vote:2 Commit:12 Lead:0 LeadEpoch:0
   Messages:
@@ -421,7 +421,7 @@ ok
 stabilize
 ----
 > 3 handling Ready
-  Ready MustSync=false:
+  Ready:
   Messages:
   3->2 MsgFortifyLeader Term:3 Log:0/0
   3->2 MsgApp Term:3 Log:2/12 Commit:13 Entries:[3/13 EntryNormal ""]
@@ -432,7 +432,7 @@ stabilize
   DEBUG 2 reset election elapsed to 0
   3->2 MsgApp Term:3 Log:2/12 Commit:13 Entries:[3/13 EntryNormal ""]
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:3 Commit:13 Lead:3 LeadEpoch:1
   Entries:
   3/13 EntryNormal ""

--- a/pkg/raft/testdata/forget_leader.txt
+++ b/pkg/raft/testdata/forget_leader.txt
@@ -118,28 +118,28 @@ ok
 stabilize
 ----
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:11 Lead:1 LeadEpoch:2
   Messages:
   1->2 MsgFortifyLeader Term:1 Log:0/0
   1->4 MsgFortifyLeader Term:1 Log:0/0
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:11 Lead:0 LeadEpoch:0
 > 4 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Commit:11 Lead:0 LeadEpoch:0
 > 2 receiving messages
   1->2 MsgFortifyLeader Term:1 Log:0/0
 > 4 receiving messages
   1->4 MsgFortifyLeader Term:1 Log:0/0
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:11 Lead:1 LeadEpoch:2
   Messages:
   2->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:2
 > 4 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Commit:11 Lead:1 LeadEpoch:2
   Messages:
   4->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:2

--- a/pkg/raft/testdata/forget_leader_prevote_checkquorum.txt
+++ b/pkg/raft/testdata/forget_leader_prevote_checkquorum.txt
@@ -41,7 +41,7 @@ INFO 3 [logterm: 1, index: 11] sent MsgPreVote request to 2 at term 1
 stabilize 3
 ----
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   State:StatePreCandidate
   HardState Term:1 Vote:1 Commit:11 Lead:0 LeadEpoch:0
   Messages:
@@ -72,7 +72,7 @@ ok
 stabilize
 ----
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:11 Lead:1 LeadEpoch:2
   Messages:
   1->3 MsgFortifyLeader Term:1 Log:0/0
@@ -81,7 +81,7 @@ stabilize
   INFO 3 became follower at term 1
   DEBUG 3 reset election elapsed to 0
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   State:StateFollower
   HardState Term:1 Vote:1 Commit:11 Lead:1 LeadEpoch:2
   Messages:
@@ -137,7 +137,7 @@ INFO 3 [logterm: 1, index: 11] sent MsgPreVote request to 2 at term 1
 stabilize 3
 ----
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   State:StatePreCandidate
   HardState Term:1 Vote:1 Commit:11 Lead:0 LeadEpoch:0
   Messages:
@@ -149,13 +149,13 @@ stabilize 3
 stabilize 2
 ----
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:11 Lead:0 LeadEpoch:0
 > 2 receiving messages
   3->2 MsgPreVote Term:2 Log:1/11
   INFO 2 [logterm: 1, index: 11, vote: 1] cast MsgPreVote for 3 [logterm: 1, index: 11] at term 1
 > 2 handling Ready
-  Ready MustSync=false:
+  Ready:
   Messages:
   2->3 MsgPreVoteResp Term:2 Log:0/0
 
@@ -169,7 +169,7 @@ stabilize 3
   INFO 3 [logterm: 1, index: 11] sent MsgVote request to 1 at term 2
   INFO 3 [logterm: 1, index: 11] sent MsgVote request to 2 at term 2
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   State:StateCandidate
   HardState Term:2 Vote:3 Commit:11 Lead:0 LeadEpoch:0
   Messages:
@@ -197,7 +197,7 @@ ok
 stabilize 3
 ----
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   Entries:
   2/13 EntryNormal "prop_1"
   Messages:
@@ -209,7 +209,7 @@ stabilize 2
 > 2 receiving messages
   3->2 MsgApp Term:2 Log:2/12 Commit:12 Entries:[2/13 EntryNormal "prop_1"]
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   Entries:
   2/13 EntryNormal "prop_1"
   Messages:
@@ -260,7 +260,7 @@ INFO 1 [logterm: 2, index: 12] sent MsgPreVote request to 3 at term 2
 
 process-ready 1
 ----
-Ready MustSync=true:
+Ready:
 State:StatePreCandidate
 HardState Term:2 Commit:12 Lead:0 LeadEpoch:0
 Messages:
@@ -272,13 +272,13 @@ INFO 1 has received 1 MsgPreVoteResp votes and 0 vote rejections
 stabilize 2
 ----
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:2 Vote:3 Commit:12 Lead:0 LeadEpoch:0
 > 2 receiving messages
   1->2 MsgPreVote Term:3 Log:2/12
   INFO 2 [logterm: 2, index: 13, vote: 3] rejected MsgPreVote from 1 [logterm: 2, index: 12] at term 2
 > 2 handling Ready
-  Ready MustSync=false:
+  Ready:
   Messages:
   2->1 MsgPreVoteResp Term:2 Log:0/0 Rejected (Hint: 0)
 

--- a/pkg/raft/testdata/fortification_basic.txt
+++ b/pkg/raft/testdata/fortification_basic.txt
@@ -65,7 +65,7 @@ withdraw-support 3 1
 stabilize 1
 ----
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   State:StateCandidate
   HardState Term:1 Vote:1 Commit:2 Lead:0 LeadEpoch:0
   Messages:
@@ -93,17 +93,17 @@ stabilize 2 3 4
   INFO 4 became follower at term 1
   INFO 4 [logterm: 1, index: 2, vote: 0] cast MsgVote for 1 [logterm: 1, index: 2] at term 1
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:2 Lead:0 LeadEpoch:0
   Messages:
   2->1 MsgVoteResp Term:1 Log:0/0
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:2 Lead:0 LeadEpoch:0
   Messages:
   3->1 MsgVoteResp Term:1 Log:0/0
 > 4 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:2 Lead:0 LeadEpoch:0
   Messages:
   4->1 MsgVoteResp Term:1 Log:0/0
@@ -122,7 +122,7 @@ stabilize 1
   INFO 1 became leader at term 1
   4->1 MsgVoteResp Term:1 Log:0/0
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   State:StateLeader
   HardState Term:1 Vote:1 Commit:2 Lead:1 LeadEpoch:3
   Entries:
@@ -155,7 +155,7 @@ stabilize
   1->4 MsgFortifyLeader Term:1 Log:0/0
   1->4 MsgApp Term:1 Log:1/2 Commit:2 Entries:[1/3 EntryNormal ""]
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:2 Lead:1 LeadEpoch:2
   Entries:
   1/3 EntryNormal ""
@@ -163,14 +163,14 @@ stabilize
   2->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:2
   2->1 MsgAppResp Term:1 Log:0/3 Commit:2
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:2 Lead:1 LeadEpoch:0
   Entries:
   1/3 EntryNormal ""
   Messages:
   3->1 MsgAppResp Term:1 Log:0/3 Commit:2
 > 4 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:2 Lead:1 LeadEpoch:0
   Entries:
   1/3 EntryNormal ""
@@ -184,7 +184,7 @@ stabilize
   4->1 MsgFortifyLeaderResp Term:1 Log:0/0 Rejected (Hint: 0)
   4->1 MsgAppResp Term:1 Log:0/3 Commit:2
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:3 Lead:1 LeadEpoch:3
   CommittedEntries:
   1/3 EntryNormal ""
@@ -199,21 +199,21 @@ stabilize
 > 4 receiving messages
   1->4 MsgApp Term:1 Log:1/3 Commit:3
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:3 Lead:1 LeadEpoch:2
   CommittedEntries:
   1/3 EntryNormal ""
   Messages:
   2->1 MsgAppResp Term:1 Log:0/3 Commit:3
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:3 Lead:1 LeadEpoch:0
   CommittedEntries:
   1/3 EntryNormal ""
   Messages:
   3->1 MsgAppResp Term:1 Log:0/3 Commit:3
 > 4 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:3 Lead:1 LeadEpoch:0
   CommittedEntries:
   1/3 EntryNormal ""

--- a/pkg/raft/testdata/fortification_followers_dont_call_election_prevote.txt
+++ b/pkg/raft/testdata/fortification_followers_dont_call_election_prevote.txt
@@ -30,7 +30,7 @@ INFO 1 [logterm: 1, index: 10] sent MsgPreVote request to 3 at term 0
 stabilize
 ----
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready:
   State:StatePreCandidate
   Messages:
   1->2 MsgPreVote Term:1 Log:1/10
@@ -44,11 +44,11 @@ stabilize
   1->3 MsgPreVote Term:1 Log:1/10
   INFO 3 [logterm: 1, index: 10, vote: 0] cast MsgPreVote for 1 [logterm: 1, index: 10] at term 0
 > 2 handling Ready
-  Ready MustSync=false:
+  Ready:
   Messages:
   2->1 MsgPreVoteResp Term:1 Log:0/0
 > 3 handling Ready
-  Ready MustSync=false:
+  Ready:
   Messages:
   3->1 MsgPreVoteResp Term:1 Log:0/0
 > 1 receiving messages
@@ -60,7 +60,7 @@ stabilize
   INFO 1 [logterm: 1, index: 10] sent MsgVote request to 3 at term 1
   3->1 MsgPreVoteResp Term:1 Log:0/0
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   State:StateCandidate
   HardState Term:1 Vote:1 Commit:10 Lead:0 LeadEpoch:0
   Messages:
@@ -81,12 +81,12 @@ stabilize
   DEBUG 3 reset election elapsed to 0
   INFO 3 [logterm: 1, index: 10, vote: 0] cast MsgVote for 1 [logterm: 1, index: 10] at term 1
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:10 Lead:0 LeadEpoch:0
   Messages:
   2->1 MsgVoteResp Term:1 Log:0/0
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:10 Lead:0 LeadEpoch:0
   Messages:
   3->1 MsgVoteResp Term:1 Log:0/0
@@ -97,7 +97,7 @@ stabilize
   INFO 1 became leader at term 1
   3->1 MsgVoteResp Term:1 Log:0/0
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   State:StateLeader
   HardState Term:1 Vote:1 Commit:10 Lead:1 LeadEpoch:1
   Entries:
@@ -114,7 +114,7 @@ stabilize
   1->3 MsgFortifyLeader Term:1 Log:0/0
   1->3 MsgApp Term:1 Log:1/10 Commit:10 Entries:[1/11 EntryNormal ""]
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:10 Lead:1 LeadEpoch:1
   Entries:
   1/11 EntryNormal ""
@@ -122,7 +122,7 @@ stabilize
   2->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:1
   2->1 MsgAppResp Term:1 Log:0/11 Commit:10
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:10 Lead:1 LeadEpoch:1
   Entries:
   1/11 EntryNormal ""
@@ -135,7 +135,7 @@ stabilize
   3->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:1
   3->1 MsgAppResp Term:1 Log:0/11 Commit:10
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:11 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/11 EntryNormal ""
@@ -147,14 +147,14 @@ stabilize
 > 3 receiving messages
   1->3 MsgApp Term:1 Log:1/11 Commit:11
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:11 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/11 EntryNormal ""
   Messages:
   2->1 MsgAppResp Term:1 Log:0/11 Commit:11
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:11 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/11 EntryNormal ""

--- a/pkg/raft/testdata/fortification_followers_dont_prevote.txt
+++ b/pkg/raft/testdata/fortification_followers_dont_prevote.txt
@@ -30,7 +30,7 @@ INFO 1 [logterm: 1, index: 10] sent MsgPreVote request to 3 at term 0
 stabilize
 ----
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready:
   State:StatePreCandidate
   Messages:
   1->2 MsgPreVote Term:1 Log:1/10
@@ -44,11 +44,11 @@ stabilize
   1->3 MsgPreVote Term:1 Log:1/10
   INFO 3 [logterm: 1, index: 10, vote: 0] cast MsgPreVote for 1 [logterm: 1, index: 10] at term 0
 > 2 handling Ready
-  Ready MustSync=false:
+  Ready:
   Messages:
   2->1 MsgPreVoteResp Term:1 Log:0/0
 > 3 handling Ready
-  Ready MustSync=false:
+  Ready:
   Messages:
   3->1 MsgPreVoteResp Term:1 Log:0/0
 > 1 receiving messages
@@ -60,7 +60,7 @@ stabilize
   INFO 1 [logterm: 1, index: 10] sent MsgVote request to 3 at term 1
   3->1 MsgPreVoteResp Term:1 Log:0/0
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   State:StateCandidate
   HardState Term:1 Vote:1 Commit:10 Lead:0 LeadEpoch:0
   Messages:
@@ -81,12 +81,12 @@ stabilize
   DEBUG 3 reset election elapsed to 0
   INFO 3 [logterm: 1, index: 10, vote: 0] cast MsgVote for 1 [logterm: 1, index: 10] at term 1
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:10 Lead:0 LeadEpoch:0
   Messages:
   2->1 MsgVoteResp Term:1 Log:0/0
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:10 Lead:0 LeadEpoch:0
   Messages:
   3->1 MsgVoteResp Term:1 Log:0/0
@@ -97,7 +97,7 @@ stabilize
   INFO 1 became leader at term 1
   3->1 MsgVoteResp Term:1 Log:0/0
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   State:StateLeader
   HardState Term:1 Vote:1 Commit:10 Lead:1 LeadEpoch:1
   Entries:
@@ -114,7 +114,7 @@ stabilize
   1->3 MsgFortifyLeader Term:1 Log:0/0
   1->3 MsgApp Term:1 Log:1/10 Commit:10 Entries:[1/11 EntryNormal ""]
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:10 Lead:1 LeadEpoch:1
   Entries:
   1/11 EntryNormal ""
@@ -122,7 +122,7 @@ stabilize
   2->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:1
   2->1 MsgAppResp Term:1 Log:0/11 Commit:10
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:10 Lead:1 LeadEpoch:1
   Entries:
   1/11 EntryNormal ""
@@ -135,7 +135,7 @@ stabilize
   3->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:1
   3->1 MsgAppResp Term:1 Log:0/11 Commit:10
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:11 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/11 EntryNormal ""
@@ -147,14 +147,14 @@ stabilize
 > 3 receiving messages
   1->3 MsgApp Term:1 Log:1/11 Commit:11
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:11 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/11 EntryNormal ""
   Messages:
   2->1 MsgAppResp Term:1 Log:0/11 Commit:11
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:11 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/11 EntryNormal ""
@@ -183,7 +183,7 @@ INFO 2 [logterm: 1, index: 11] sent MsgPreVote request to 3 at term 1
 stabilize
 ----
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   State:StatePreCandidate
   HardState Term:1 Vote:1 Commit:11 Lead:0 LeadEpoch:0
   Messages:
@@ -223,7 +223,7 @@ INFO 2 [logterm: 1, index: 11] sent MsgPreVote request to 3 at term 1
 stabilize
 ----
 > 2 handling Ready
-  Ready MustSync=false:
+  Ready:
   Messages:
   2->1 MsgPreVote Term:2 Log:1/11
   2->3 MsgPreVote Term:2 Log:1/11
@@ -237,7 +237,7 @@ stabilize
   DEBUG 3 setting election elapsed to start from 3 ticks after store liveness support expired
   INFO 3 [logterm: 1, index: 11, vote: 1] cast MsgPreVote for 2 [logterm: 1, index: 11] at term 1
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:11 Lead:1 LeadEpoch:0
   Messages:
   3->2 MsgPreVoteResp Term:2 Log:0/0
@@ -249,7 +249,7 @@ stabilize
   INFO 2 [logterm: 1, index: 11] sent MsgVote request to 1 at term 2
   INFO 2 [logterm: 1, index: 11] sent MsgVote request to 3 at term 2
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   State:StateCandidate
   HardState Term:2 Vote:2 Commit:11 Lead:0 LeadEpoch:0
   Messages:
@@ -267,7 +267,7 @@ stabilize
   DEBUG 3 reset election elapsed to 0
   INFO 3 [logterm: 1, index: 11, vote: 0] cast MsgVote for 2 [logterm: 1, index: 11] at term 2
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:2 Vote:2 Commit:11 Lead:0 LeadEpoch:0
   Messages:
   3->2 MsgVoteResp Term:2 Log:0/0
@@ -277,7 +277,7 @@ stabilize
   INFO 2 has received 2 MsgVoteResp votes and 0 vote rejections
   INFO 2 became leader at term 2
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   State:StateLeader
   HardState Term:2 Vote:2 Commit:11 Lead:2 LeadEpoch:1
   Entries:
@@ -298,7 +298,7 @@ stabilize
   2->3 MsgFortifyLeader Term:2 Log:0/0
   2->3 MsgApp Term:2 Log:1/11 Commit:11 Entries:[2/12 EntryNormal ""]
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   State:StateFollower
   HardState Term:2 Commit:11 Lead:2 LeadEpoch:1
   Entries:
@@ -307,7 +307,7 @@ stabilize
   1->2 MsgFortifyLeaderResp Term:2 Log:0/0 LeadEpoch:1
   1->2 MsgAppResp Term:2 Log:0/12 Commit:11
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:2 Vote:2 Commit:11 Lead:2 LeadEpoch:1
   Entries:
   2/12 EntryNormal ""
@@ -320,7 +320,7 @@ stabilize
   3->2 MsgFortifyLeaderResp Term:2 Log:0/0 LeadEpoch:1
   3->2 MsgAppResp Term:2 Log:0/12 Commit:11
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:2 Vote:2 Commit:12 Lead:2 LeadEpoch:1
   CommittedEntries:
   2/12 EntryNormal ""
@@ -332,14 +332,14 @@ stabilize
 > 3 receiving messages
   2->3 MsgApp Term:2 Log:2/12 Commit:12
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:2 Commit:12 Lead:2 LeadEpoch:1
   CommittedEntries:
   2/12 EntryNormal ""
   Messages:
   1->2 MsgAppResp Term:2 Log:0/12 Commit:12
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:2 Vote:2 Commit:12 Lead:2 LeadEpoch:1
   CommittedEntries:
   2/12 EntryNormal ""
@@ -386,7 +386,7 @@ INFO 2 [logterm: 2, index: 12] sent MsgPreVote request to 3 at term 2
 stabilize
 ----
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   State:StatePreCandidate
   HardState Term:2 Vote:2 Commit:12 Lead:0 LeadEpoch:0
   Messages:
@@ -433,7 +433,7 @@ ok
 stabilize
 ----
 > 2 handling Ready
-  Ready MustSync=false:
+  Ready:
   Messages:
   2->1 MsgDeFortifyLeader Term:2 Log:0/0
   2->3 MsgDeFortifyLeader Term:2 Log:0/0
@@ -444,10 +444,10 @@ stabilize
   2->3 MsgDeFortifyLeader Term:2 Log:0/0
   DEBUG 3 setting election elapsed to start from 3 ticks after store liveness support expired
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:2 Commit:12 Lead:2 LeadEpoch:0
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:2 Vote:2 Commit:12 Lead:2 LeadEpoch:0
 
 # At this point, 2 can campaign and win the election. Reset store liveness by
@@ -480,7 +480,7 @@ INFO 2 [logterm: 2, index: 12] sent MsgPreVote request to 3 at term 2
 stabilize
 ----
 > 2 handling Ready
-  Ready MustSync=false:
+  Ready:
   Messages:
   2->1 MsgPreVote Term:3 Log:2/12
   2->3 MsgPreVote Term:3 Log:2/12
@@ -493,11 +493,11 @@ stabilize
   2->3 MsgPreVote Term:3 Log:2/12
   INFO 3 [logterm: 2, index: 12, vote: 2] cast MsgPreVote for 2 [logterm: 2, index: 12] at term 2
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready:
   Messages:
   1->2 MsgPreVoteResp Term:3 Log:0/0
 > 3 handling Ready
-  Ready MustSync=false:
+  Ready:
   Messages:
   3->2 MsgPreVoteResp Term:3 Log:0/0
 > 2 receiving messages
@@ -509,7 +509,7 @@ stabilize
   INFO 2 [logterm: 2, index: 12] sent MsgVote request to 3 at term 3
   3->2 MsgPreVoteResp Term:3 Log:0/0
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   State:StateCandidate
   HardState Term:3 Vote:2 Commit:12 Lead:0 LeadEpoch:0
   Messages:
@@ -530,12 +530,12 @@ stabilize
   DEBUG 3 reset election elapsed to 0
   INFO 3 [logterm: 2, index: 12, vote: 0] cast MsgVote for 2 [logterm: 2, index: 12] at term 3
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:3 Vote:2 Commit:12 Lead:0 LeadEpoch:0
   Messages:
   1->2 MsgVoteResp Term:3 Log:0/0
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:3 Vote:2 Commit:12 Lead:0 LeadEpoch:0
   Messages:
   3->2 MsgVoteResp Term:3 Log:0/0
@@ -546,7 +546,7 @@ stabilize
   INFO 2 became leader at term 3
   3->2 MsgVoteResp Term:3 Log:0/0
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   State:StateLeader
   HardState Term:3 Vote:2 Commit:12 Lead:2 LeadEpoch:3
   Entries:
@@ -563,7 +563,7 @@ stabilize
   2->3 MsgFortifyLeader Term:3 Log:0/0
   2->3 MsgApp Term:3 Log:2/12 Commit:12 Entries:[3/13 EntryNormal ""]
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:3 Vote:2 Commit:12 Lead:2 LeadEpoch:2
   Entries:
   3/13 EntryNormal ""
@@ -571,7 +571,7 @@ stabilize
   1->2 MsgFortifyLeaderResp Term:3 Log:0/0 LeadEpoch:2
   1->2 MsgAppResp Term:3 Log:0/13 Commit:12
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:3 Vote:2 Commit:12 Lead:2 LeadEpoch:2
   Entries:
   3/13 EntryNormal ""
@@ -584,7 +584,7 @@ stabilize
   3->2 MsgFortifyLeaderResp Term:3 Log:0/0 LeadEpoch:2
   3->2 MsgAppResp Term:3 Log:0/13 Commit:12
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:3 Vote:2 Commit:13 Lead:2 LeadEpoch:3
   CommittedEntries:
   3/13 EntryNormal ""
@@ -596,14 +596,14 @@ stabilize
 > 3 receiving messages
   2->3 MsgApp Term:3 Log:3/13 Commit:13
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:3 Vote:2 Commit:13 Lead:2 LeadEpoch:2
   CommittedEntries:
   3/13 EntryNormal ""
   Messages:
   1->2 MsgAppResp Term:3 Log:0/13 Commit:13
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:3 Vote:2 Commit:13 Lead:2 LeadEpoch:2
   CommittedEntries:
   3/13 EntryNormal ""

--- a/pkg/raft/testdata/fortification_leader_does_not_support_itself.txt
+++ b/pkg/raft/testdata/fortification_leader_does_not_support_itself.txt
@@ -56,7 +56,7 @@ INFO 1 [logterm: 1, index: 2] sent MsgVote request to 3 at term 1
 stabilize
 ----
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   State:StateCandidate
   HardState Term:1 Vote:1 Commit:2 Lead:0 LeadEpoch:0
   Messages:
@@ -75,12 +75,12 @@ stabilize
   INFO 3 became follower at term 1
   INFO 3 [logterm: 1, index: 2, vote: 0] cast MsgVote for 1 [logterm: 1, index: 2] at term 1
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:2 Lead:0 LeadEpoch:0
   Messages:
   2->1 MsgVoteResp Term:1 Log:0/0
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:2 Lead:0 LeadEpoch:0
   Messages:
   3->1 MsgVoteResp Term:1 Log:0/0
@@ -92,7 +92,7 @@ stabilize
   INFO 1 leader at term 1 does not support itself in the liveness fabric
   3->1 MsgVoteResp Term:1 Log:0/0
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   State:StateLeader
   HardState Term:1 Vote:1 Commit:2 Lead:1 LeadEpoch:0
   Entries:
@@ -109,7 +109,7 @@ stabilize
   1->3 MsgFortifyLeader Term:1 Log:0/0
   1->3 MsgApp Term:1 Log:1/2 Commit:2 Entries:[1/3 EntryNormal ""]
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:2 Lead:1 LeadEpoch:3
   Entries:
   1/3 EntryNormal ""
@@ -117,7 +117,7 @@ stabilize
   2->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:3
   2->1 MsgAppResp Term:1 Log:0/3 Commit:2
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:2 Lead:1 LeadEpoch:2
   Entries:
   1/3 EntryNormal ""
@@ -130,7 +130,7 @@ stabilize
   3->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:2
   3->1 MsgAppResp Term:1 Log:0/3 Commit:2
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:3 Lead:1 LeadEpoch:0
   CommittedEntries:
   1/3 EntryNormal ""
@@ -142,14 +142,14 @@ stabilize
 > 3 receiving messages
   1->3 MsgApp Term:1 Log:1/3 Commit:3
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:3 Lead:1 LeadEpoch:3
   CommittedEntries:
   1/3 EntryNormal ""
   Messages:
   2->1 MsgAppResp Term:1 Log:0/3 Commit:3
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:3 Lead:1 LeadEpoch:2
   CommittedEntries:
   1/3 EntryNormal ""

--- a/pkg/raft/testdata/fortification_support_tracking.txt
+++ b/pkg/raft/testdata/fortification_support_tracking.txt
@@ -36,7 +36,7 @@ INFO 1 [logterm: 1, index: 10] sent MsgVote request to 3 at term 1
 stabilize
 ----
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   State:StateCandidate
   HardState Term:1 Vote:1 Commit:10 Lead:0 LeadEpoch:0
   Messages:
@@ -57,12 +57,12 @@ stabilize
   DEBUG 3 reset election elapsed to 0
   INFO 3 [logterm: 1, index: 10, vote: 0] cast MsgVote for 1 [logterm: 1, index: 10] at term 1
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:10 Lead:0 LeadEpoch:0
   Messages:
   2->1 MsgVoteResp Term:1 Log:0/0
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:10 Lead:0 LeadEpoch:0
   Messages:
   3->1 MsgVoteResp Term:1 Log:0/0
@@ -73,7 +73,7 @@ stabilize
   INFO 1 became leader at term 1
   3->1 MsgVoteResp Term:1 Log:0/0
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   State:StateLeader
   HardState Term:1 Vote:1 Commit:10 Lead:1 LeadEpoch:1
   Entries:
@@ -88,14 +88,14 @@ stabilize
   1->3 MsgFortifyLeader Term:1 Log:0/0
   1->3 MsgApp Term:1 Log:1/10 Commit:10 Entries:[1/11 EntryNormal ""]
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:10 Lead:1 LeadEpoch:0
   Entries:
   1/11 EntryNormal ""
   Messages:
   2->1 MsgAppResp Term:1 Log:0/11 Commit:10
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:10 Lead:1 LeadEpoch:1
   Entries:
   1/11 EntryNormal ""
@@ -107,7 +107,7 @@ stabilize
   3->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:1
   3->1 MsgAppResp Term:1 Log:0/11 Commit:10
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:11 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/11 EntryNormal ""
@@ -119,14 +119,14 @@ stabilize
 > 3 receiving messages
   1->3 MsgApp Term:1 Log:1/11 Commit:11
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:11 Lead:1 LeadEpoch:0
   CommittedEntries:
   1/11 EntryNormal ""
   Messages:
   2->1 MsgAppResp Term:1 Log:0/11 Commit:11
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:11 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/11 EntryNormal ""
@@ -179,7 +179,7 @@ INFO 2 [logterm: 1, index: 11] sent MsgVote request to 3 at term 2
 stabilize
 ----
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   State:StateCandidate
   HardState Term:2 Vote:2 Commit:11 Lead:0 LeadEpoch:0
   Messages:
@@ -198,7 +198,7 @@ stabilize
   DEBUG 3 reset election elapsed to 0
   INFO 3 [logterm: 1, index: 11, vote: 0] cast MsgVote for 2 [logterm: 1, index: 11] at term 2
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:2 Vote:2 Commit:11 Lead:0 LeadEpoch:0
   Messages:
   3->2 MsgVoteResp Term:2 Log:0/0
@@ -208,7 +208,7 @@ stabilize
   INFO 2 has received 2 MsgVoteResp votes and 0 vote rejections
   INFO 2 became leader at term 2
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   State:StateLeader
   HardState Term:2 Vote:2 Commit:11 Lead:2 LeadEpoch:3
   Entries:
@@ -229,7 +229,7 @@ stabilize
   2->3 MsgFortifyLeader Term:2 Log:0/0
   2->3 MsgApp Term:2 Log:1/11 Commit:11 Entries:[2/12 EntryNormal ""]
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   State:StateFollower
   HardState Term:2 Commit:11 Lead:2 LeadEpoch:2
   Entries:
@@ -238,7 +238,7 @@ stabilize
   1->2 MsgFortifyLeaderResp Term:2 Log:0/0 LeadEpoch:2
   1->2 MsgAppResp Term:2 Log:0/12 Commit:11
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:2 Vote:2 Commit:11 Lead:2 LeadEpoch:3
   Entries:
   2/12 EntryNormal ""
@@ -251,7 +251,7 @@ stabilize
   3->2 MsgFortifyLeaderResp Term:2 Log:0/0 LeadEpoch:3
   3->2 MsgAppResp Term:2 Log:0/12 Commit:11
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:2 Vote:2 Commit:12 Lead:2 LeadEpoch:3
   CommittedEntries:
   2/12 EntryNormal ""
@@ -263,14 +263,14 @@ stabilize
 > 3 receiving messages
   2->3 MsgApp Term:2 Log:2/12 Commit:12
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:2 Commit:12 Lead:2 LeadEpoch:2
   CommittedEntries:
   2/12 EntryNormal ""
   Messages:
   1->2 MsgAppResp Term:2 Log:0/12 Commit:12
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:2 Vote:2 Commit:12 Lead:2 LeadEpoch:3
   CommittedEntries:
   2/12 EntryNormal ""

--- a/pkg/raft/testdata/heartbeat_timeout_recovers_from_probing.txt
+++ b/pkg/raft/testdata/heartbeat_timeout_recovers_from_probing.txt
@@ -51,13 +51,13 @@ ok
 stabilize
 ----
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready:
   Messages:
   1->2 MsgApp Term:1 Log:1/11 Commit:11
 > 2 receiving messages
   1->2 MsgApp Term:1 Log:1/11 Commit:11
 > 2 handling Ready
-  Ready MustSync=false:
+  Ready:
   Messages:
   2->1 MsgAppResp Term:1 Log:0/11 Commit:11
 > 1 receiving messages

--- a/pkg/raft/testdata/lagging_commit.txt
+++ b/pkg/raft/testdata/lagging_commit.txt
@@ -46,7 +46,7 @@ deliver-msgs 2 3
 
 process-ready 3
 ----
-Ready MustSync=true:
+Ready:
 Entries:
 1/12 EntryNormal "data1"
 1/13 EntryNormal "data2"
@@ -66,7 +66,7 @@ dropped: 3->1 MsgAppResp Term:1 Log:0/13 Commit:11
 stabilize 1 2
 ----
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   Entries:
   1/12 EntryNormal "data1"
   1/13 EntryNormal "data2"
@@ -77,7 +77,7 @@ stabilize 1 2
   2->1 MsgAppResp Term:1 Log:0/12 Commit:11
   2->1 MsgAppResp Term:1 Log:0/13 Commit:11
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:13 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/12 EntryNormal "data1"
@@ -91,7 +91,7 @@ stabilize 1 2
   1->2 MsgApp Term:1 Log:1/13 Commit:12
   1->2 MsgApp Term:1 Log:1/13 Commit:13
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:13 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/12 EntryNormal "data1"
@@ -130,7 +130,7 @@ ok
 # to fix that.
 process-ready 1
 ----
-Ready MustSync=false:
+Ready:
 Messages:
 1->3 MsgApp Term:1 Log:1/13 Commit:13
 
@@ -146,7 +146,7 @@ stabilize 1 3
 > 3 receiving messages
   1->3 MsgApp Term:1 Log:1/13 Commit:13
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:13 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/12 EntryNormal "data1"

--- a/pkg/raft/testdata/lagging_commit_no_store_liveness_support.txt
+++ b/pkg/raft/testdata/lagging_commit_no_store_liveness_support.txt
@@ -47,7 +47,7 @@ deliver-msgs 2 3
 
 process-ready 3
 ----
-Ready MustSync=true:
+Ready:
 Entries:
 1/12 EntryNormal "data1"
 1/13 EntryNormal "data2"
@@ -67,7 +67,7 @@ dropped: 3->1 MsgAppResp Term:1 Log:0/13 Commit:11
 stabilize 1 2
 ----
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   Entries:
   1/12 EntryNormal "data1"
   1/13 EntryNormal "data2"
@@ -78,7 +78,7 @@ stabilize 1 2
   2->1 MsgAppResp Term:1 Log:0/12 Commit:11
   2->1 MsgAppResp Term:1 Log:0/13 Commit:11
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:13 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/12 EntryNormal "data1"
@@ -92,7 +92,7 @@ stabilize 1 2
   1->2 MsgApp Term:1 Log:1/13 Commit:12
   1->2 MsgApp Term:1 Log:1/13 Commit:13
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:13 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/12 EntryNormal "data1"
@@ -149,7 +149,7 @@ ok
 
 process-ready 1
 ----
-Ready MustSync=true:
+Ready:
 HardState Term:1 Vote:1 Commit:13 Lead:1 LeadEpoch:2
 Messages:
 1->3 MsgFortifyLeader Term:1 Log:0/0
@@ -161,7 +161,7 @@ stabilize
   1->3 MsgFortifyLeader Term:1 Log:0/0
   1->3 MsgApp Term:1 Log:1/13 Commit:13
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:13 Lead:1 LeadEpoch:2
   CommittedEntries:
   1/12 EntryNormal "data1"

--- a/pkg/raft/testdata/lazy_replication.txt
+++ b/pkg/raft/testdata/lazy_replication.txt
@@ -37,7 +37,7 @@ ok
 stabilize
 ----
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   Entries:
   1/12 EntryNormal "data-1"
   1/13 EntryNormal "data-2"
@@ -72,14 +72,14 @@ stabilize
 > 3 receiving messages
   1->3 MsgApp Term:1 Log:1/11 Commit:11 Entries:[1/12 EntryNormal "data-1"]
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   Entries:
   1/12 EntryNormal "data-1"
   1/13 EntryNormal "data-2"
   Messages:
   2->1 MsgAppResp Term:1 Log:0/13 Commit:11
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   Entries:
   1/12 EntryNormal "data-1"
   Messages:
@@ -88,7 +88,7 @@ stabilize
   2->1 MsgAppResp Term:1 Log:0/13 Commit:11
   3->1 MsgAppResp Term:1 Log:0/12 Commit:11
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:13 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/12 EntryNormal "data-1"
@@ -101,7 +101,7 @@ stabilize
 > 3 receiving messages
   1->3 MsgApp Term:1 Log:1/12 Commit:13
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:13 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/12 EntryNormal "data-1"
@@ -109,7 +109,7 @@ stabilize
   Messages:
   2->1 MsgAppResp Term:1 Log:0/13 Commit:13
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:12 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/12 EntryNormal "data-1"
@@ -136,7 +136,7 @@ stabilize
 > 3 receiving messages
   1->3 MsgApp Term:1 Log:1/12 Commit:13 Entries:[1/13 EntryNormal "data-2"]
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:13 Lead:1 LeadEpoch:1
   Entries:
   1/13 EntryNormal "data-2"
@@ -165,7 +165,7 @@ ok
 stabilize
 ----
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   Entries:
   1/14 EntryNormal "data-3"
 
@@ -177,7 +177,7 @@ ok
 stabilize
 ----
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready:
   Messages:
   1->2 MsgApp Term:1 Log:1/13 Commit:13 Entries:[1/14 EntryNormal "data-3"]
   1->3 MsgApp Term:1 Log:1/13 Commit:13 Entries:[1/14 EntryNormal "data-3"]
@@ -186,13 +186,13 @@ stabilize
 > 3 receiving messages
   1->3 MsgApp Term:1 Log:1/13 Commit:13 Entries:[1/14 EntryNormal "data-3"]
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   Entries:
   1/14 EntryNormal "data-3"
   Messages:
   2->1 MsgAppResp Term:1 Log:0/14 Commit:13
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   Entries:
   1/14 EntryNormal "data-3"
   Messages:
@@ -201,7 +201,7 @@ stabilize
   2->1 MsgAppResp Term:1 Log:0/14 Commit:13
   3->1 MsgAppResp Term:1 Log:0/14 Commit:13
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:14 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/14 EntryNormal "data-3"
@@ -213,14 +213,14 @@ stabilize
 > 3 receiving messages
   1->3 MsgApp Term:1 Log:1/14 Commit:14
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:14 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/14 EntryNormal "data-3"
   Messages:
   2->1 MsgAppResp Term:1 Log:0/14 Commit:14
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:14 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/14 EntryNormal "data-3"
@@ -245,7 +245,7 @@ ok
 stabilize
 ----
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   Entries:
   1/15 EntryNormal "data-4"
   Messages:
@@ -256,13 +256,13 @@ stabilize
 > 3 receiving messages
   1->3 MsgApp Term:1 Log:1/14 Commit:14 Entries:[1/15 EntryNormal "data-4"]
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   Entries:
   1/15 EntryNormal "data-4"
   Messages:
   2->1 MsgAppResp Term:1 Log:0/15 Commit:14
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   Entries:
   1/15 EntryNormal "data-4"
   Messages:
@@ -271,7 +271,7 @@ stabilize
   2->1 MsgAppResp Term:1 Log:0/15 Commit:14
   3->1 MsgAppResp Term:1 Log:0/15 Commit:14
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:15 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/15 EntryNormal "data-4"
@@ -283,14 +283,14 @@ stabilize
 > 3 receiving messages
   1->3 MsgApp Term:1 Log:1/15 Commit:15
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:15 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/15 EntryNormal "data-4"
   Messages:
   2->1 MsgAppResp Term:1 Log:0/15 Commit:15
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:15 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/15 EntryNormal "data-4"
@@ -308,6 +308,6 @@ ok
 stabilize
 ----
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   Entries:
   1/16 EntryNormal "data-5"

--- a/pkg/raft/testdata/leader_step_down_stranded_peer.txt
+++ b/pkg/raft/testdata/leader_step_down_stranded_peer.txt
@@ -30,7 +30,7 @@ INFO 3 [logterm: 1, index: 10] sent MsgVote request to 2 at term 1
 stabilize 3
 ----
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   State:StateCandidate
   HardState Term:1 Vote:3 Commit:10 Lead:0 LeadEpoch:0
   Messages:
@@ -55,7 +55,7 @@ INFO 3 [logterm: 1, index: 10] sent MsgVote request to 2 at term 2
 stabilize 3
 ----
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:2 Vote:3 Commit:10 Lead:0 LeadEpoch:0
   Messages:
   3->1 MsgVote Term:2 Log:1/10
@@ -77,7 +77,7 @@ INFO 3 [logterm: 1, index: 10] sent MsgVote request to 2 at term 3
 stabilize 3
 ----
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:3 Vote:3 Commit:10 Lead:0 LeadEpoch:0
   Messages:
   3->1 MsgVote Term:3 Log:1/10
@@ -114,7 +114,7 @@ INFO 1 [logterm: 1, index: 10] sent MsgVote request to 3 at term 1
 stabilize 1 2
 ----
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   State:StateCandidate
   HardState Term:1 Vote:1 Commit:10 Lead:0 LeadEpoch:0
   Messages:
@@ -129,7 +129,7 @@ stabilize 1 2
   DEBUG 2 reset election elapsed to 0
   INFO 2 [logterm: 1, index: 10, vote: 0] cast MsgVote for 1 [logterm: 1, index: 10] at term 1
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:10 Lead:0 LeadEpoch:0
   Messages:
   2->1 MsgVoteResp Term:1 Log:0/0
@@ -139,7 +139,7 @@ stabilize 1 2
   INFO 1 has received 2 MsgVoteResp votes and 0 vote rejections
   INFO 1 became leader at term 1
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   State:StateLeader
   HardState Term:1 Vote:1 Commit:10 Lead:1 LeadEpoch:1
   Entries:
@@ -153,7 +153,7 @@ stabilize 1 2
   1->2 MsgFortifyLeader Term:1 Log:0/0
   1->2 MsgApp Term:1 Log:1/10 Commit:10 Entries:[1/11 EntryNormal ""]
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:10 Lead:1 LeadEpoch:1
   Entries:
   1/11 EntryNormal ""
@@ -164,7 +164,7 @@ stabilize 1 2
   2->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:1
   2->1 MsgAppResp Term:1 Log:0/11 Commit:10
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:11 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/11 EntryNormal ""
@@ -173,7 +173,7 @@ stabilize 1 2
 > 2 receiving messages
   1->2 MsgApp Term:1 Log:1/11 Commit:11
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:11 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/11 EntryNormal ""
@@ -206,7 +206,7 @@ ok
 stabilize 1 3
 ----
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready:
   Messages:
   1->3 MsgFortifyLeader Term:1 Log:0/0
   1->3 MsgApp Term:1 Log:1/10 Commit:11 Entries:[1/11 EntryNormal ""]
@@ -214,7 +214,7 @@ stabilize 1 3
   1->3 MsgFortifyLeader Term:1 Log:0/0
   1->3 MsgApp Term:1 Log:1/10 Commit:11 Entries:[1/11 EntryNormal ""]
 > 3 handling Ready
-  Ready MustSync=false:
+  Ready:
   Messages:
   3->1 MsgAppResp Term:3 Log:0/0
   3->1 MsgAppResp Term:3 Log:0/0
@@ -259,7 +259,7 @@ INFO 1 [logterm: 1, index: 11] sent MsgVote request to 3 at term 4
 stabilize
 ----
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   State:StateCandidate
   HardState Term:4 Vote:1 Commit:11 Lead:0 LeadEpoch:0
   Messages:
@@ -286,12 +286,12 @@ stabilize
   DEBUG 3 reset election elapsed to 0
   INFO 3 [logterm: 1, index: 10, vote: 0] cast MsgVote for 1 [logterm: 1, index: 11] at term 4
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:4 Vote:1 Commit:11 Lead:0 LeadEpoch:0
   Messages:
   2->1 MsgVoteResp Term:4 Log:0/0
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   State:StateFollower
   HardState Term:4 Vote:1 Commit:10 Lead:0 LeadEpoch:0
   Messages:
@@ -303,7 +303,7 @@ stabilize
   INFO 1 became leader at term 4
   3->1 MsgVoteResp Term:4 Log:0/0
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   State:StateLeader
   HardState Term:4 Vote:1 Commit:11 Lead:1 LeadEpoch:1
   Entries:
@@ -321,7 +321,7 @@ stabilize
   1->3 MsgApp Term:4 Log:1/11 Commit:11 Entries:[4/12 EntryNormal ""]
   DEBUG 3 [logterm: 0, index: 11] rejected MsgApp [logterm: 1, index: 11] from 1
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:4 Vote:1 Commit:11 Lead:1 LeadEpoch:1
   Entries:
   4/12 EntryNormal ""
@@ -329,7 +329,7 @@ stabilize
   2->1 MsgFortifyLeaderResp Term:4 Log:0/0 LeadEpoch:1
   2->1 MsgAppResp Term:4 Log:0/12 Commit:11
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:4 Vote:1 Commit:10 Lead:1 LeadEpoch:1
   Messages:
   3->1 MsgFortifyLeaderResp Term:4 Log:0/0 LeadEpoch:1
@@ -342,7 +342,7 @@ stabilize
   DEBUG 1 received MsgAppResp(rejected, hint: (index 10, term 1)) from 3 for index 11
   DEBUG 1 decreased progress of 3 to [StateProbe match=0 next=11 sentCommit=10 matchCommit=10]
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:4 Vote:1 Commit:12 Lead:1 LeadEpoch:1
   CommittedEntries:
   4/12 EntryNormal ""
@@ -360,14 +360,14 @@ stabilize
     4/12 EntryNormal ""
   ]
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:4 Vote:1 Commit:12 Lead:1 LeadEpoch:1
   CommittedEntries:
   4/12 EntryNormal ""
   Messages:
   2->1 MsgAppResp Term:4 Log:0/12 Commit:12
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:4 Vote:1 Commit:12 Lead:1 LeadEpoch:1
   Entries:
   1/11 EntryNormal ""

--- a/pkg/raft/testdata/leader_step_down_stranded_peer_prevote.txt
+++ b/pkg/raft/testdata/leader_step_down_stranded_peer_prevote.txt
@@ -31,7 +31,7 @@ INFO 3 [logterm: 1, index: 10] sent MsgPreVote request to 2 at term 0
 stabilize 3
 ----
 > 3 handling Ready
-  Ready MustSync=false:
+  Ready:
   State:StatePreCandidate
   Messages:
   3->1 MsgPreVote Term:1 Log:1/10
@@ -45,7 +45,7 @@ stabilize 2
   3->2 MsgPreVote Term:1 Log:1/10
   INFO 2 [logterm: 1, index: 10, vote: 0] cast MsgPreVote for 3 [logterm: 1, index: 10] at term 0
 > 2 handling Ready
-  Ready MustSync=false:
+  Ready:
   Messages:
   2->3 MsgPreVoteResp Term:1 Log:0/0
 
@@ -59,7 +59,7 @@ stabilize 3
   INFO 3 [logterm: 1, index: 10] sent MsgVote request to 1 at term 1
   INFO 3 [logterm: 1, index: 10] sent MsgVote request to 2 at term 1
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   State:StateCandidate
   HardState Term:1 Vote:3 Commit:10 Lead:0 LeadEpoch:0
   Messages:
@@ -88,7 +88,7 @@ INFO 3 [logterm: 1, index: 10] sent MsgPreVote request to 2 at term 1
 stabilize 3
 ----
 > 3 handling Ready
-  Ready MustSync=false:
+  Ready:
   State:StatePreCandidate
   Messages:
   3->1 MsgPreVote Term:2 Log:1/10
@@ -102,7 +102,7 @@ stabilize 2
   3->2 MsgPreVote Term:2 Log:1/10
   INFO 2 [logterm: 1, index: 10, vote: 0] cast MsgPreVote for 3 [logterm: 1, index: 10] at term 0
 > 2 handling Ready
-  Ready MustSync=false:
+  Ready:
   Messages:
   2->3 MsgPreVoteResp Term:2 Log:0/0
 
@@ -116,7 +116,7 @@ stabilize 3
   INFO 3 [logterm: 1, index: 10] sent MsgVote request to 1 at term 2
   INFO 3 [logterm: 1, index: 10] sent MsgVote request to 2 at term 2
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   State:StateCandidate
   HardState Term:2 Vote:3 Commit:10 Lead:0 LeadEpoch:0
   Messages:
@@ -143,7 +143,7 @@ INFO 3 [logterm: 1, index: 10] sent MsgPreVote request to 2 at term 2
 stabilize 3
 ----
 > 3 handling Ready
-  Ready MustSync=false:
+  Ready:
   State:StatePreCandidate
   Messages:
   3->1 MsgPreVote Term:3 Log:1/10
@@ -157,7 +157,7 @@ stabilize 2
   3->2 MsgPreVote Term:3 Log:1/10
   INFO 2 [logterm: 1, index: 10, vote: 0] cast MsgPreVote for 3 [logterm: 1, index: 10] at term 0
 > 2 handling Ready
-  Ready MustSync=false:
+  Ready:
   Messages:
   2->3 MsgPreVoteResp Term:3 Log:0/0
 
@@ -171,7 +171,7 @@ stabilize 3
   INFO 3 [logterm: 1, index: 10] sent MsgVote request to 1 at term 3
   INFO 3 [logterm: 1, index: 10] sent MsgVote request to 2 at term 3
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   State:StateCandidate
   HardState Term:3 Vote:3 Commit:10 Lead:0 LeadEpoch:0
   Messages:
@@ -210,7 +210,7 @@ INFO 1 [logterm: 1, index: 10] sent MsgPreVote request to 3 at term 0
 stabilize 1 2
 ----
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready:
   State:StatePreCandidate
   Messages:
   1->2 MsgPreVote Term:1 Log:1/10
@@ -221,7 +221,7 @@ stabilize 1 2
   1->2 MsgPreVote Term:1 Log:1/10
   INFO 2 [logterm: 1, index: 10, vote: 0] cast MsgPreVote for 1 [logterm: 1, index: 10] at term 0
 > 2 handling Ready
-  Ready MustSync=false:
+  Ready:
   Messages:
   2->1 MsgPreVoteResp Term:1 Log:0/0
 > 1 receiving messages
@@ -232,7 +232,7 @@ stabilize 1 2
   INFO 1 [logterm: 1, index: 10] sent MsgVote request to 2 at term 1
   INFO 1 [logterm: 1, index: 10] sent MsgVote request to 3 at term 1
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   State:StateCandidate
   HardState Term:1 Vote:1 Commit:10 Lead:0 LeadEpoch:0
   Messages:
@@ -247,7 +247,7 @@ stabilize 1 2
   DEBUG 2 reset election elapsed to 0
   INFO 2 [logterm: 1, index: 10, vote: 0] cast MsgVote for 1 [logterm: 1, index: 10] at term 1
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:10 Lead:0 LeadEpoch:0
   Messages:
   2->1 MsgVoteResp Term:1 Log:0/0
@@ -257,7 +257,7 @@ stabilize 1 2
   INFO 1 has received 2 MsgVoteResp votes and 0 vote rejections
   INFO 1 became leader at term 1
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   State:StateLeader
   HardState Term:1 Vote:1 Commit:10 Lead:1 LeadEpoch:1
   Entries:
@@ -271,7 +271,7 @@ stabilize 1 2
   1->2 MsgFortifyLeader Term:1 Log:0/0
   1->2 MsgApp Term:1 Log:1/10 Commit:10 Entries:[1/11 EntryNormal ""]
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:10 Lead:1 LeadEpoch:1
   Entries:
   1/11 EntryNormal ""
@@ -282,7 +282,7 @@ stabilize 1 2
   2->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:1
   2->1 MsgAppResp Term:1 Log:0/11 Commit:10
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:11 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/11 EntryNormal ""
@@ -291,7 +291,7 @@ stabilize 1 2
 > 2 receiving messages
   1->2 MsgApp Term:1 Log:1/11 Commit:11
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:11 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/11 EntryNormal ""
@@ -325,7 +325,7 @@ ok
 stabilize 1 3
 ----
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready:
   Messages:
   1->3 MsgFortifyLeader Term:1 Log:0/0
   1->3 MsgApp Term:1 Log:1/10 Commit:11 Entries:[1/11 EntryNormal ""]
@@ -333,7 +333,7 @@ stabilize 1 3
   1->3 MsgFortifyLeader Term:1 Log:0/0
   1->3 MsgApp Term:1 Log:1/10 Commit:11 Entries:[1/11 EntryNormal ""]
 > 3 handling Ready
-  Ready MustSync=false:
+  Ready:
   Messages:
   3->1 MsgAppResp Term:3 Log:0/0
   3->1 MsgAppResp Term:3 Log:0/0
@@ -371,7 +371,7 @@ INFO 1 [logterm: 1, index: 11] sent MsgPreVote request to 3 at term 3
 stabilize
 ----
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   State:StatePreCandidate
   HardState Term:3 Commit:11 Lead:0 LeadEpoch:0
   Messages:
@@ -392,12 +392,12 @@ stabilize
   1->3 MsgPreVote Term:4 Log:1/11
   INFO 3 [logterm: 1, index: 10, vote: 3] cast MsgPreVote for 1 [logterm: 1, index: 11] at term 3
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:11 Lead:1 LeadEpoch:0
   Messages:
   2->1 MsgPreVoteResp Term:4 Log:0/0
 > 3 handling Ready
-  Ready MustSync=false:
+  Ready:
   Messages:
   3->1 MsgPreVoteResp Term:4 Log:0/0
 > 1 receiving messages
@@ -409,7 +409,7 @@ stabilize
   INFO 1 [logterm: 1, index: 11] sent MsgVote request to 3 at term 4
   3->1 MsgPreVoteResp Term:4 Log:0/0
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   State:StateCandidate
   HardState Term:4 Vote:1 Commit:11 Lead:0 LeadEpoch:0
   Messages:
@@ -430,12 +430,12 @@ stabilize
   DEBUG 3 reset election elapsed to 0
   INFO 3 [logterm: 1, index: 10, vote: 0] cast MsgVote for 1 [logterm: 1, index: 11] at term 4
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:4 Vote:1 Commit:11 Lead:0 LeadEpoch:0
   Messages:
   2->1 MsgVoteResp Term:4 Log:0/0
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   State:StateFollower
   HardState Term:4 Vote:1 Commit:10 Lead:0 LeadEpoch:0
   Messages:
@@ -447,7 +447,7 @@ stabilize
   INFO 1 became leader at term 4
   3->1 MsgVoteResp Term:4 Log:0/0
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   State:StateLeader
   HardState Term:4 Vote:1 Commit:11 Lead:1 LeadEpoch:1
   Entries:
@@ -465,7 +465,7 @@ stabilize
   1->3 MsgApp Term:4 Log:1/11 Commit:11 Entries:[4/12 EntryNormal ""]
   DEBUG 3 [logterm: 0, index: 11] rejected MsgApp [logterm: 1, index: 11] from 1
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:4 Vote:1 Commit:11 Lead:1 LeadEpoch:1
   Entries:
   4/12 EntryNormal ""
@@ -473,7 +473,7 @@ stabilize
   2->1 MsgFortifyLeaderResp Term:4 Log:0/0 LeadEpoch:1
   2->1 MsgAppResp Term:4 Log:0/12 Commit:11
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:4 Vote:1 Commit:10 Lead:1 LeadEpoch:1
   Messages:
   3->1 MsgFortifyLeaderResp Term:4 Log:0/0 LeadEpoch:1
@@ -486,7 +486,7 @@ stabilize
   DEBUG 1 received MsgAppResp(rejected, hint: (index 10, term 1)) from 3 for index 11
   DEBUG 1 decreased progress of 3 to [StateProbe match=0 next=11 sentCommit=10 matchCommit=10]
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:4 Vote:1 Commit:12 Lead:1 LeadEpoch:1
   CommittedEntries:
   4/12 EntryNormal ""
@@ -504,14 +504,14 @@ stabilize
     4/12 EntryNormal ""
   ]
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:4 Vote:1 Commit:12 Lead:1 LeadEpoch:1
   CommittedEntries:
   4/12 EntryNormal ""
   Messages:
   2->1 MsgAppResp Term:4 Log:0/12 Commit:12
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:4 Vote:1 Commit:12 Lead:1 LeadEpoch:1
   Entries:
   1/11 EntryNormal ""

--- a/pkg/raft/testdata/liveness_recovered_after_temporary_loss_of_quorum.txt
+++ b/pkg/raft/testdata/liveness_recovered_after_temporary_loss_of_quorum.txt
@@ -38,7 +38,7 @@ ok
 stabilize 1
 ----
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   Entries:
   1/12 EntryNormal "data1"
   Messages:
@@ -71,7 +71,7 @@ INFO 1 became follower at term 1
 stabilize
 ----
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   State:StateFollower
   HardState Term:1 Vote:1 Commit:11 Lead:0 LeadEpoch:0
   Messages:
@@ -79,7 +79,7 @@ stabilize
 > 2 receiving messages
   1->2 MsgDeFortifyLeader Term:1 Log:0/0
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:11 Lead:1 LeadEpoch:0
 
 # Fix the network blip.
@@ -99,7 +99,7 @@ INFO 2 [logterm: 1, index: 11] sent MsgPreVote request to 1 at term 1
 stabilize
 ----
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   State:StatePreCandidate
   HardState Term:1 Vote:1 Commit:11 Lead:0 LeadEpoch:0
   Messages:
@@ -110,7 +110,7 @@ stabilize
   2->1 MsgPreVote Term:2 Log:1/11
   INFO 1 [logterm: 1, index: 12, vote: 1] rejected MsgPreVote from 2 [logterm: 1, index: 11] at term 1
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready:
   Messages:
   1->2 MsgPreVoteResp Term:1 Log:0/0 Rejected (Hint: 0)
 > 2 receiving messages
@@ -119,7 +119,7 @@ stabilize
   INFO 2 has received 1 MsgPreVoteResp votes and 1 vote rejections
   INFO 2 became follower at term 1
 > 2 handling Ready
-  Ready MustSync=false:
+  Ready:
   State:StateFollower
 
 # Note that both peers have successfully forgotten the leader for term 1.
@@ -137,7 +137,7 @@ ok
 stabilize
 ----
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready:
   Messages:
   1->2 MsgDeFortifyLeader Term:1 Log:0/0
 > 2 receiving messages
@@ -157,7 +157,7 @@ INFO 1 [logterm: 1, index: 12] sent MsgPreVote request to 2 at term 1
 stabilize
 ----
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready:
   State:StatePreCandidate
   Messages:
   1->2 MsgPreVote Term:2 Log:1/12
@@ -167,7 +167,7 @@ stabilize
   1->2 MsgPreVote Term:2 Log:1/12
   INFO 2 [logterm: 1, index: 11, vote: 1] cast MsgPreVote for 1 [logterm: 1, index: 12] at term 1
 > 2 handling Ready
-  Ready MustSync=false:
+  Ready:
   Messages:
   2->1 MsgPreVoteResp Term:2 Log:0/0
 > 1 receiving messages
@@ -177,7 +177,7 @@ stabilize
   INFO 1 became candidate at term 2
   INFO 1 [logterm: 1, index: 12] sent MsgVote request to 2 at term 2
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   State:StateCandidate
   HardState Term:2 Vote:1 Commit:11 Lead:0 LeadEpoch:0
   Messages:
@@ -190,7 +190,7 @@ stabilize
   INFO 2 became follower at term 2
   INFO 2 [logterm: 1, index: 11, vote: 0] cast MsgVote for 1 [logterm: 1, index: 12] at term 2
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:2 Vote:1 Commit:11 Lead:0 LeadEpoch:0
   Messages:
   2->1 MsgVoteResp Term:2 Log:0/0
@@ -200,7 +200,7 @@ stabilize
   INFO 1 has received 2 MsgVoteResp votes and 0 vote rejections
   INFO 1 became leader at term 2
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   State:StateLeader
   HardState Term:2 Vote:1 Commit:11 Lead:1 LeadEpoch:1
   Entries:
@@ -212,7 +212,7 @@ stabilize
   1->2 MsgFortifyLeader Term:2 Log:0/0
   1->2 MsgApp Term:2 Log:1/12 Commit:11 Entries:[2/13 EntryNormal ""]
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:2 Vote:1 Commit:11 Lead:1 LeadEpoch:1
   Messages:
   2->1 MsgFortifyLeaderResp Term:2 Log:0/0 LeadEpoch:1
@@ -221,7 +221,7 @@ stabilize
   2->1 MsgFortifyLeaderResp Term:2 Log:0/0 LeadEpoch:1
   2->1 MsgAppResp Term:2 Log:1/12 Rejected (Hint: 11) Commit:11
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready:
   Messages:
   1->2 MsgApp Term:2 Log:1/11 Commit:11 Entries:[
     1/12 EntryNormal "data1"
@@ -233,7 +233,7 @@ stabilize
     2/13 EntryNormal ""
   ]
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   Entries:
   1/12 EntryNormal "data1"
   2/13 EntryNormal ""
@@ -242,7 +242,7 @@ stabilize
 > 1 receiving messages
   2->1 MsgAppResp Term:2 Log:0/13 Commit:11
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:2 Vote:1 Commit:13 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/12 EntryNormal "data1"
@@ -252,7 +252,7 @@ stabilize
 > 2 receiving messages
   1->2 MsgApp Term:2 Log:2/13 Commit:13
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:2 Vote:1 Commit:13 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/12 EntryNormal "data1"

--- a/pkg/raft/testdata/msg_app_commit_index.txt
+++ b/pkg/raft/testdata/msg_app_commit_index.txt
@@ -46,7 +46,7 @@ deliver-msgs 2 3
 
 process-ready 3
 ----
-Ready MustSync=true:
+Ready:
 Entries:
 1/12 EntryNormal "data1"
 1/13 EntryNormal "data2"
@@ -59,7 +59,7 @@ Messages:
 stabilize 1 2
 ----
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   Entries:
   1/12 EntryNormal "data1"
   1/13 EntryNormal "data2"
@@ -72,7 +72,7 @@ stabilize 1 2
   2->1 MsgAppResp Term:1 Log:0/12 Commit:11
   2->1 MsgAppResp Term:1 Log:0/13 Commit:11
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:13 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/12 EntryNormal "data1"
@@ -86,7 +86,7 @@ stabilize 1 2
   1->2 MsgApp Term:1 Log:1/13 Commit:12
   1->2 MsgApp Term:1 Log:1/13 Commit:13
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:13 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/12 EntryNormal "data1"
@@ -120,7 +120,7 @@ ok
 
 process-ready 1
 ----
-Ready MustSync=false:
+Ready:
 Messages:
 1->3 MsgApp Term:1 Log:1/13 Commit:13
 
@@ -132,7 +132,7 @@ stabilize 1 2 3
 > 3 receiving messages
   1->3 MsgApp Term:1 Log:1/13 Commit:13
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:13 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/12 EntryNormal "data1"

--- a/pkg/raft/testdata/prevote.txt
+++ b/pkg/raft/testdata/prevote.txt
@@ -32,7 +32,7 @@ ok
 
 process-ready 1
 ----
-Ready MustSync=true:
+Ready:
 Entries:
 1/12 EntryNormal "prop_1"
 Messages:
@@ -45,7 +45,7 @@ deliver-msgs 2
 
 process-ready 2
 ----
-Ready MustSync=true:
+Ready:
 Entries:
 1/12 EntryNormal "prop_1"
 Messages:
@@ -89,7 +89,7 @@ INFO 3 [logterm: 1, index: 11] sent MsgPreVote request to 2 at term 1
 
 process-ready 3
 ----
-Ready MustSync=true:
+Ready:
 State:StatePreCandidate
 HardState Term:1 Vote:1 Commit:11 Lead:0 LeadEpoch:0
 Messages:
@@ -113,7 +113,7 @@ INFO 2 [logterm: 1, index: 12, vote: 1] rejected MsgPreVote from 3 [logterm: 1, 
 stabilize
 ----
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:12 Lead:1 LeadEpoch:0
   CommittedEntries:
   1/12 EntryNormal "prop_1"
@@ -122,7 +122,7 @@ stabilize
   1->3 MsgApp Term:1 Log:1/12 Commit:12
   1->3 MsgPreVoteResp Term:1 Log:0/0 Rejected (Hint: 0)
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:11 Lead:1 LeadEpoch:0
   Messages:
   2->3 MsgPreVoteResp Term:1 Log:0/0 Rejected (Hint: 0)
@@ -136,14 +136,14 @@ stabilize
   1->3 MsgPreVoteResp Term:1 Log:0/0 Rejected (Hint: 0)
   2->3 MsgPreVoteResp Term:1 Log:0/0 Rejected (Hint: 0)
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:12 Lead:1 LeadEpoch:0
   CommittedEntries:
   1/12 EntryNormal "prop_1"
   Messages:
   2->1 MsgAppResp Term:1 Log:0/12 Commit:12
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   State:StateFollower
   HardState Term:1 Vote:1 Commit:12 Lead:1 LeadEpoch:0
   Entries:
@@ -170,7 +170,7 @@ INFO 2 [logterm: 1, index: 12] sent MsgPreVote request to 3 at term 1
 stabilize
 ----
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   State:StatePreCandidate
   HardState Term:1 Vote:1 Commit:12 Lead:0 LeadEpoch:0
   Messages:
@@ -185,11 +185,11 @@ stabilize
   2->3 MsgPreVote Term:2 Log:1/12
   INFO 3 [logterm: 1, index: 12, vote: 1] cast MsgPreVote for 2 [logterm: 1, index: 12] at term 1
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready:
   Messages:
   1->2 MsgPreVoteResp Term:2 Log:0/0
 > 3 handling Ready
-  Ready MustSync=false:
+  Ready:
   Messages:
   3->2 MsgPreVoteResp Term:2 Log:0/0
 > 2 receiving messages
@@ -201,7 +201,7 @@ stabilize
   INFO 2 [logterm: 1, index: 12] sent MsgVote request to 3 at term 2
   3->2 MsgPreVoteResp Term:2 Log:0/0
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   State:StateCandidate
   HardState Term:2 Vote:2 Commit:12 Lead:0 LeadEpoch:0
   Messages:
@@ -222,13 +222,13 @@ stabilize
   DEBUG 3 reset election elapsed to 0
   INFO 3 [logterm: 1, index: 12, vote: 0] cast MsgVote for 2 [logterm: 1, index: 12] at term 2
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   State:StateFollower
   HardState Term:2 Vote:2 Commit:12 Lead:0 LeadEpoch:0
   Messages:
   1->2 MsgVoteResp Term:2 Log:0/0
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:2 Vote:2 Commit:12 Lead:0 LeadEpoch:0
   Messages:
   3->2 MsgVoteResp Term:2 Log:0/0
@@ -239,7 +239,7 @@ stabilize
   INFO 2 became leader at term 2
   3->2 MsgVoteResp Term:2 Log:0/0
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   State:StateLeader
   HardState Term:2 Vote:2 Commit:12 Lead:2 LeadEpoch:1
   Entries:
@@ -256,7 +256,7 @@ stabilize
   2->3 MsgFortifyLeader Term:2 Log:0/0
   2->3 MsgApp Term:2 Log:1/12 Commit:12 Entries:[2/13 EntryNormal ""]
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:2 Vote:2 Commit:12 Lead:2 LeadEpoch:1
   Entries:
   2/13 EntryNormal ""
@@ -264,7 +264,7 @@ stabilize
   1->2 MsgFortifyLeaderResp Term:2 Log:0/0 LeadEpoch:1
   1->2 MsgAppResp Term:2 Log:0/13 Commit:12
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:2 Vote:2 Commit:12 Lead:2 LeadEpoch:1
   Entries:
   2/13 EntryNormal ""
@@ -277,7 +277,7 @@ stabilize
   3->2 MsgFortifyLeaderResp Term:2 Log:0/0 LeadEpoch:1
   3->2 MsgAppResp Term:2 Log:0/13 Commit:12
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:2 Vote:2 Commit:13 Lead:2 LeadEpoch:1
   CommittedEntries:
   2/13 EntryNormal ""
@@ -289,14 +289,14 @@ stabilize
 > 3 receiving messages
   2->3 MsgApp Term:2 Log:2/13 Commit:13
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:2 Vote:2 Commit:13 Lead:2 LeadEpoch:1
   CommittedEntries:
   2/13 EntryNormal ""
   Messages:
   1->2 MsgAppResp Term:2 Log:0/13 Commit:13
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:2 Vote:2 Commit:13 Lead:2 LeadEpoch:1
   CommittedEntries:
   2/13 EntryNormal ""

--- a/pkg/raft/testdata/prevote_checkquorum.txt
+++ b/pkg/raft/testdata/prevote_checkquorum.txt
@@ -41,7 +41,7 @@ INFO 2 [logterm: 1, index: 11] sent MsgPreVote request to 3 at term 1
 stabilize
 ----
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   State:StatePreCandidate
   HardState Term:1 Vote:1 Commit:11 Lead:0 LeadEpoch:0
   Messages:
@@ -82,7 +82,7 @@ INFO 3 [logterm: 1, index: 11] sent MsgPreVote request to 2 at term 1
 
 process-ready 3
 ----
-Ready MustSync=true:
+Ready:
 State:StatePreCandidate
 HardState Term:1 Vote:1 Commit:11 Lead:0 LeadEpoch:0
 Messages:
@@ -98,7 +98,7 @@ INFO 2 [logterm: 1, index: 11, vote: 1] cast MsgPreVote for 3 [logterm: 1, index
 
 process-ready 2
 ----
-Ready MustSync=false:
+Ready:
 Messages:
 2->3 MsgPreVoteResp Term:2 Log:0/0
 
@@ -115,7 +115,7 @@ stabilize
   INFO 3 [logterm: 1, index: 11] sent MsgVote request to 1 at term 2
   INFO 3 [logterm: 1, index: 11] sent MsgVote request to 2 at term 2
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   State:StateCandidate
   HardState Term:2 Vote:3 Commit:11 Lead:0 LeadEpoch:0
   Messages:
@@ -133,7 +133,7 @@ stabilize
   DEBUG 2 reset election elapsed to 0
   INFO 2 [logterm: 1, index: 11, vote: 0] cast MsgVote for 3 [logterm: 1, index: 11] at term 2
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   State:StateFollower
   HardState Term:2 Vote:3 Commit:11 Lead:0 LeadEpoch:0
   Messages:
@@ -144,7 +144,7 @@ stabilize
   INFO 3 has received 2 MsgVoteResp votes and 0 vote rejections
   INFO 3 became leader at term 2
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   State:StateLeader
   HardState Term:2 Vote:3 Commit:11 Lead:3 LeadEpoch:1
   Entries:
@@ -165,7 +165,7 @@ stabilize
   3->2 MsgFortifyLeader Term:2 Log:0/0
   3->2 MsgApp Term:2 Log:1/11 Commit:11 Entries:[2/12 EntryNormal ""]
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   State:StateFollower
   HardState Term:2 Commit:11 Lead:3 LeadEpoch:1
   Entries:
@@ -174,7 +174,7 @@ stabilize
   1->3 MsgFortifyLeaderResp Term:2 Log:0/0 LeadEpoch:1
   1->3 MsgAppResp Term:2 Log:0/12 Commit:11
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:2 Vote:3 Commit:11 Lead:3 LeadEpoch:1
   Entries:
   2/12 EntryNormal ""
@@ -187,7 +187,7 @@ stabilize
   2->3 MsgFortifyLeaderResp Term:2 Log:0/0 LeadEpoch:1
   2->3 MsgAppResp Term:2 Log:0/12 Commit:11
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:2 Vote:3 Commit:12 Lead:3 LeadEpoch:1
   CommittedEntries:
   2/12 EntryNormal ""
@@ -199,14 +199,14 @@ stabilize
 > 2 receiving messages
   3->2 MsgApp Term:2 Log:2/12 Commit:12
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:2 Commit:12 Lead:3 LeadEpoch:1
   CommittedEntries:
   2/12 EntryNormal ""
   Messages:
   1->3 MsgAppResp Term:2 Log:0/12 Commit:12
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:2 Vote:3 Commit:12 Lead:3 LeadEpoch:1
   CommittedEntries:
   2/12 EntryNormal ""
@@ -253,7 +253,7 @@ INFO 1 [logterm: 2, index: 12] sent MsgPreVote request to 3 at term 2
 stabilize
 ----
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   State:StatePreCandidate
   HardState Term:2 Commit:12 Lead:0 LeadEpoch:0
   Messages:
@@ -285,7 +285,7 @@ INFO 2 [logterm: 2, index: 12] sent MsgPreVote request to 3 at term 2
 stabilize
 ----
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   State:StatePreCandidate
   HardState Term:2 Vote:3 Commit:12 Lead:0 LeadEpoch:0
   Messages:
@@ -300,7 +300,7 @@ stabilize
   2->3 MsgPreVote Term:3 Log:2/12
   INFO 3 [logterm: 2, index: 12, vote: 3] ignored MsgPreVote from 2 [logterm: 2, index: 12] at term 2: supporting fortified leader 3 at epoch 1
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready:
   Messages:
   1->2 MsgPreVoteResp Term:3 Log:0/0
 > 2 receiving messages
@@ -311,7 +311,7 @@ stabilize
   INFO 2 [logterm: 2, index: 12] sent MsgVote request to 1 at term 3
   INFO 2 [logterm: 2, index: 12] sent MsgVote request to 3 at term 3
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   State:StateCandidate
   HardState Term:3 Vote:2 Commit:12 Lead:0 LeadEpoch:0
   Messages:
@@ -329,7 +329,7 @@ stabilize
   2->3 MsgVote Term:3 Log:2/12
   INFO 3 [logterm: 2, index: 12, vote: 3] ignored MsgVote from 2 [logterm: 2, index: 12] at term 2: supporting fortified leader 3 at epoch 1
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   State:StateFollower
   HardState Term:3 Vote:2 Commit:12 Lead:0 LeadEpoch:0
   Messages:
@@ -340,7 +340,7 @@ stabilize
   INFO 2 has received 2 MsgVoteResp votes and 0 vote rejections
   INFO 2 became leader at term 3
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   State:StateLeader
   HardState Term:3 Vote:2 Commit:12 Lead:2 LeadEpoch:1
   Entries:
@@ -361,7 +361,7 @@ stabilize
   DEBUG 3 reset election elapsed to 0
   2->3 MsgApp Term:3 Log:2/12 Commit:12 Entries:[3/13 EntryNormal ""]
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:3 Vote:2 Commit:12 Lead:2 LeadEpoch:1
   Entries:
   3/13 EntryNormal ""
@@ -369,7 +369,7 @@ stabilize
   1->2 MsgFortifyLeaderResp Term:3 Log:0/0 LeadEpoch:1
   1->2 MsgAppResp Term:3 Log:0/13 Commit:12
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   State:StateFollower
   HardState Term:3 Commit:12 Lead:2 LeadEpoch:1
   Entries:
@@ -383,7 +383,7 @@ stabilize
   3->2 MsgFortifyLeaderResp Term:3 Log:0/0 LeadEpoch:1
   3->2 MsgAppResp Term:3 Log:0/13 Commit:12
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:3 Vote:2 Commit:13 Lead:2 LeadEpoch:1
   CommittedEntries:
   3/13 EntryNormal ""
@@ -395,14 +395,14 @@ stabilize
 > 3 receiving messages
   2->3 MsgApp Term:3 Log:3/13 Commit:13
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:3 Vote:2 Commit:13 Lead:2 LeadEpoch:1
   CommittedEntries:
   3/13 EntryNormal ""
   Messages:
   1->2 MsgAppResp Term:3 Log:0/13 Commit:13
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:3 Commit:13 Lead:2 LeadEpoch:1
   CommittedEntries:
   3/13 EntryNormal ""

--- a/pkg/raft/testdata/probe_and_replicate.txt
+++ b/pkg/raft/testdata/probe_and_replicate.txt
@@ -402,7 +402,7 @@ INFO 1 [logterm: 6, index: 20] sent MsgVote request to 7 at term 8
 stabilize 1
 ----
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   State:StateCandidate
   HardState Term:8 Vote:1 Commit:18 Lead:0 LeadEpoch:0
   Messages:
@@ -448,23 +448,23 @@ stabilize 2 3 4 5 6 7
   INFO 7 became follower at term 8
   INFO 7 [logterm: 3, index: 21, vote: 0] cast MsgVote for 1 [logterm: 6, index: 20] at term 8
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:8 Vote:1 Commit:18 Lead:0 LeadEpoch:0
   Messages:
   2->1 MsgVoteResp Term:8 Log:0/0
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:8 Vote:1 Commit:14 Lead:0 LeadEpoch:0
   Messages:
   3->1 MsgVoteResp Term:8 Log:0/0
 > 4 handling Ready
-  Ready MustSync=true:
+  Ready:
   State:StateFollower
   HardState Term:8 Commit:18 Lead:0 LeadEpoch:0
   Messages:
   4->1 MsgVoteResp Term:8 Log:0/0 Rejected (Hint: 0)
 > 5 handling Ready
-  Ready MustSync=true:
+  Ready:
   State:StateFollower
   HardState Term:8 Commit:18 Lead:0 LeadEpoch:0
   Messages:
@@ -476,12 +476,12 @@ stabilize 2 3 4 5 6 7
   5->7 MsgDeFortifyLeader Term:7 Log:0/0
   5->1 MsgVoteResp Term:8 Log:0/0 Rejected (Hint: 0)
 > 6 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:8 Vote:1 Commit:15 Lead:0 LeadEpoch:0
   Messages:
   6->1 MsgVoteResp Term:8 Log:0/0
 > 7 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:8 Vote:1 Commit:13 Lead:0 LeadEpoch:0
   Messages:
   7->1 MsgDeFortifyLeader Term:3 Log:0/0
@@ -543,7 +543,7 @@ stabilize 1
   INFO 1 [term: 8] ignored a MsgDeFortifyLeader message with lower term from 7 [term: 3]
   7->1 MsgVoteResp Term:8 Log:0/0
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   State:StateLeader
   HardState Term:8 Vote:1 Commit:18 Lead:1 LeadEpoch:2
   Entries:
@@ -569,7 +569,7 @@ stabilize 1 2
   1->2 MsgFortifyLeader Term:8 Log:0/0
   1->2 MsgApp Term:8 Log:6/20 Commit:18 Entries:[8/21 EntryNormal ""]
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:8 Vote:1 Commit:18 Lead:1 LeadEpoch:2
   Messages:
   2->1 MsgFortifyLeaderResp Term:8 Log:0/0 LeadEpoch:2
@@ -578,7 +578,7 @@ stabilize 1 2
   2->1 MsgFortifyLeaderResp Term:8 Log:0/0 LeadEpoch:2
   2->1 MsgAppResp Term:8 Log:6/20 Rejected (Hint: 19) Commit:18
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready:
   Messages:
   1->2 MsgApp Term:8 Log:6/19 Commit:18 Entries:[
     6/20 EntryNormal "prop_6_20"
@@ -590,7 +590,7 @@ stabilize 1 2
     8/21 EntryNormal ""
   ]
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   Entries:
   6/20 EntryNormal "prop_6_20"
   8/21 EntryNormal ""
@@ -605,7 +605,7 @@ stabilize 1 3
   1->3 MsgFortifyLeader Term:8 Log:0/0
   1->3 MsgApp Term:8 Log:6/20 Commit:18 Entries:[8/21 EntryNormal ""]
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:8 Vote:1 Commit:14 Lead:1 LeadEpoch:2
   Messages:
   3->1 MsgFortifyLeaderResp Term:8 Log:0/0 LeadEpoch:2
@@ -614,7 +614,7 @@ stabilize 1 3
   3->1 MsgFortifyLeaderResp Term:8 Log:0/0 LeadEpoch:2
   3->1 MsgAppResp Term:8 Log:4/20 Rejected (Hint: 14) Commit:14
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready:
   Messages:
   1->3 MsgApp Term:8 Log:4/14 Commit:18 Entries:[
     4/15 EntryNormal "prop_4_15"
@@ -636,7 +636,7 @@ stabilize 1 3
     8/21 EntryNormal ""
   ]
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:8 Vote:1 Commit:18 Lead:1 LeadEpoch:2
   Entries:
   4/15 EntryNormal "prop_4_15"
@@ -664,7 +664,7 @@ stabilize 1 4
   INFO found conflict at index 21 [existing term: 6, conflicting term: 8]
   INFO replace the unstable entries from index 21
 > 4 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:8 Commit:18 Lead:1 LeadEpoch:2
   Entries:
   8/21 EntryNormal ""
@@ -675,7 +675,7 @@ stabilize 1 4
   4->1 MsgFortifyLeaderResp Term:8 Log:0/0 LeadEpoch:2
   4->1 MsgAppResp Term:8 Log:0/21 Commit:18
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:8 Vote:1 Commit:21 Lead:1 LeadEpoch:2
   CommittedEntries:
   6/19 EntryNormal "prop_6_19"
@@ -688,7 +688,7 @@ stabilize 1 4
 > 4 receiving messages
   1->4 MsgApp Term:8 Log:8/21 Commit:21
 > 4 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:8 Commit:21 Lead:1 LeadEpoch:2
   CommittedEntries:
   6/19 EntryNormal "prop_6_19"
@@ -705,7 +705,7 @@ stabilize 1 5
   1->5 MsgFortifyLeader Term:8 Log:0/0
   1->5 MsgApp Term:8 Log:6/20 Commit:18 Entries:[8/21 EntryNormal ""]
 > 5 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:8 Commit:18 Lead:1 LeadEpoch:2
   Messages:
   5->1 MsgFortifyLeaderResp Term:8 Log:0/0 LeadEpoch:2
@@ -714,7 +714,7 @@ stabilize 1 5
   5->1 MsgFortifyLeaderResp Term:8 Log:0/0 LeadEpoch:2
   5->1 MsgAppResp Term:8 Log:6/20 Rejected (Hint: 18) Commit:18
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready:
   Messages:
   1->5 MsgApp Term:8 Log:6/18 Commit:21 Entries:[
     6/19 EntryNormal "prop_6_19"
@@ -730,7 +730,7 @@ stabilize 1 5
   INFO found conflict at index 19 [existing term: 7, conflicting term: 6]
   INFO replace the unstable entries from index 19
 > 5 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:8 Commit:21 Lead:1 LeadEpoch:2
   Entries:
   6/19 EntryNormal "prop_6_19"
@@ -751,7 +751,7 @@ stabilize 1 6
   1->6 MsgFortifyLeader Term:8 Log:0/0
   1->6 MsgApp Term:8 Log:6/20 Commit:18 Entries:[8/21 EntryNormal ""]
 > 6 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:8 Vote:1 Commit:15 Lead:1 LeadEpoch:2
   Messages:
   6->1 MsgFortifyLeaderResp Term:8 Log:0/0 LeadEpoch:2
@@ -760,7 +760,7 @@ stabilize 1 6
   6->1 MsgFortifyLeaderResp Term:8 Log:0/0 LeadEpoch:2
   6->1 MsgAppResp Term:8 Log:4/20 Rejected (Hint: 17) Commit:15
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready:
   Messages:
   1->6 MsgApp Term:8 Log:4/15 Commit:21 Entries:[
     5/16 EntryNormal ""
@@ -782,7 +782,7 @@ stabilize 1 6
   INFO found conflict at index 16 [existing term: 4, conflicting term: 5]
   INFO replace the unstable entries from index 16
 > 6 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:8 Vote:1 Commit:21 Lead:1 LeadEpoch:2
   Entries:
   5/16 EntryNormal ""

--- a/pkg/raft/testdata/refortification_basic.txt
+++ b/pkg/raft/testdata/refortification_basic.txt
@@ -51,7 +51,7 @@ INFO 1 [logterm: 1, index: 2] sent MsgVote request to 3 at term 1
 stabilize
 ----
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   State:StateCandidate
   HardState Term:1 Vote:1 Commit:2 Lead:0 LeadEpoch:0
   Messages:
@@ -70,12 +70,12 @@ stabilize
   INFO 3 became follower at term 1
   INFO 3 [logterm: 1, index: 2, vote: 0] cast MsgVote for 1 [logterm: 1, index: 2] at term 1
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:2 Lead:0 LeadEpoch:0
   Messages:
   2->1 MsgVoteResp Term:1 Log:0/0
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:2 Lead:0 LeadEpoch:0
   Messages:
   3->1 MsgVoteResp Term:1 Log:0/0
@@ -86,7 +86,7 @@ stabilize
   INFO 1 became leader at term 1
   3->1 MsgVoteResp Term:1 Log:0/0
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   State:StateLeader
   HardState Term:1 Vote:1 Commit:2 Lead:1 LeadEpoch:3
   Entries:
@@ -101,7 +101,7 @@ stabilize
 > 3 receiving messages
   1->3 MsgApp Term:1 Log:1/2 Commit:2 Entries:[1/3 EntryNormal ""]
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:2 Lead:1 LeadEpoch:2
   Entries:
   1/3 EntryNormal ""
@@ -109,7 +109,7 @@ stabilize
   2->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:2
   2->1 MsgAppResp Term:1 Log:0/3 Commit:2
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:2 Lead:1 LeadEpoch:0
   Entries:
   1/3 EntryNormal ""
@@ -120,7 +120,7 @@ stabilize
   2->1 MsgAppResp Term:1 Log:0/3 Commit:2
   3->1 MsgAppResp Term:1 Log:0/3 Commit:2
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:3 Lead:1 LeadEpoch:3
   CommittedEntries:
   1/3 EntryNormal ""
@@ -132,14 +132,14 @@ stabilize
 > 3 receiving messages
   1->3 MsgApp Term:1 Log:1/3 Commit:3
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:3 Lead:1 LeadEpoch:2
   CommittedEntries:
   1/3 EntryNormal ""
   Messages:
   2->1 MsgAppResp Term:1 Log:0/3 Commit:3
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:3 Lead:1 LeadEpoch:0
   CommittedEntries:
   1/3 EntryNormal ""
@@ -175,13 +175,13 @@ ok
 stabilize
 ----
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready:
   Messages:
   1->3 MsgFortifyLeader Term:1 Log:0/0
 > 3 receiving messages
   1->3 MsgFortifyLeader Term:1 Log:0/0
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:3 Lead:1 LeadEpoch:3
   Messages:
   3->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:3
@@ -204,7 +204,7 @@ ok
 stabilize
 ----
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:3 Lead:1 LeadEpoch:4
   Messages:
   1->2 MsgFortifyLeader Term:1 Log:0/0
@@ -214,12 +214,12 @@ stabilize
 > 3 receiving messages
   1->3 MsgFortifyLeader Term:1 Log:0/0
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:3 Lead:1 LeadEpoch:3
   Messages:
   2->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:3
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:3 Lead:1 LeadEpoch:4
   Messages:
   3->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:4

--- a/pkg/raft/testdata/replicate_pause.txt
+++ b/pkg/raft/testdata/replicate_pause.txt
@@ -131,7 +131,7 @@ ok
 stabilize 1
 ----
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready:
   Messages:
   1->3 MsgApp Term:1 Log:1/14 Commit:17
 
@@ -142,7 +142,7 @@ stabilize 2 3
   1->3 MsgApp Term:1 Log:1/14 Commit:17
   DEBUG 3 [logterm: 0, index: 14] rejected MsgApp [logterm: 1, index: 14] from 1
 > 3 handling Ready
-  Ready MustSync=false:
+  Ready:
   Messages:
   3->1 MsgAppResp Term:1 Log:1/14 Rejected (Hint: 11) Commit:11
 
@@ -154,7 +154,7 @@ stabilize 1
   DEBUG 1 received MsgAppResp(rejected, hint: (index 11, term 1)) from 3 for index 14
   DEBUG 1 decreased progress of 3 to [StateReplicate match=11 next=12 sentCommit=11 matchCommit=11 paused inflight=3[full]]
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready:
   Messages:
   1->3 MsgApp Term:1 Log:1/11 Commit:17 Entries:[
     1/12 EntryNormal "prop_1_12"
@@ -177,7 +177,7 @@ stabilize 1 3
     1/17 EntryNormal "prop_1_17"
   ]
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:17 Lead:1 LeadEpoch:1
   Entries:
   1/12 EntryNormal "prop_1_12"

--- a/pkg/raft/testdata/single_node.txt
+++ b/pkg/raft/testdata/single_node.txt
@@ -16,20 +16,20 @@ INFO 1 became candidate at term 1
 stabilize
 ----
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   State:StateCandidate
   HardState Term:1 Vote:1 Commit:3 Lead:0 LeadEpoch:0
   INFO 1 received MsgVoteResp from 1 at term 1
   INFO 1 has received 1 MsgVoteResp votes and 0 vote rejections
   INFO 1 became leader at term 1
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   State:StateLeader
   HardState Term:1 Vote:1 Commit:3 Lead:1 LeadEpoch:1
   Entries:
   1/4 EntryNormal ""
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:4 Lead:1 LeadEpoch:1
   CommittedEntries:
   1/4 EntryNormal ""

--- a/pkg/raft/testdata/slow_follower_after_compaction.txt
+++ b/pkg/raft/testdata/slow_follower_after_compaction.txt
@@ -107,7 +107,7 @@ DEBUG 1 paused sending replication messages to 3 [StateSnapshot match=14 next=19
 stabilize
 ----
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready:
   Messages:
   1->3 MsgSnap Term:1 Log:0/0
     Snapshot: Index:18 Term:1 ConfState:Voters:[1 2 3] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
@@ -119,7 +119,7 @@ stabilize
   INFO 3 [commit: 18, lastindex: 18, lastterm: 1] restored snapshot [index: 18, term: 1]
   INFO 3 [commit: 18] restored snapshot [index: 18, term: 1]
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:18 Lead:1 LeadEpoch:1
   Snapshot Index:18 Term:1 ConfState:Voters:[1 2 3] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
   Messages:

--- a/pkg/raft/testdata/snapshot_new_term.txt
+++ b/pkg/raft/testdata/snapshot_new_term.txt
@@ -40,7 +40,7 @@ DEBUG 1 reset election elapsed to 0
 stabilize 1 2
 ----
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   State:StateFollower
   HardState Term:1 Vote:1 Commit:11 Lead:0 LeadEpoch:0
   Messages:
@@ -53,7 +53,7 @@ stabilize 1 2
   INFO 2 [logterm: 1, index: 11] sent MsgVote request to 1 at term 2
   INFO 2 [logterm: 1, index: 11] sent MsgVote request to 3 at term 2
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   State:StateCandidate
   HardState Term:2 Vote:2 Commit:11 Lead:0 LeadEpoch:0
   Messages:
@@ -68,7 +68,7 @@ stabilize 1 2
   DEBUG 1 reset election elapsed to 0
   INFO 1 [logterm: 1, index: 11, vote: 0] cast MsgVote for 2 [logterm: 1, index: 11] at term 2
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:2 Vote:2 Commit:11 Lead:0 LeadEpoch:0
   Messages:
   1->2 MsgVoteResp Term:2 Log:0/0
@@ -78,7 +78,7 @@ stabilize 1 2
   INFO 2 has received 2 MsgVoteResp votes and 0 vote rejections
   INFO 2 became leader at term 2
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   State:StateLeader
   HardState Term:2 Vote:2 Commit:11 Lead:2 LeadEpoch:1
   Entries:
@@ -92,7 +92,7 @@ stabilize 1 2
   2->1 MsgFortifyLeader Term:2 Log:0/0
   2->1 MsgApp Term:2 Log:1/11 Commit:11 Entries:[2/12 EntryNormal ""]
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:2 Vote:2 Commit:11 Lead:2 LeadEpoch:1
   Entries:
   2/12 EntryNormal ""
@@ -103,7 +103,7 @@ stabilize 1 2
   1->2 MsgFortifyLeaderResp Term:2 Log:0/0 LeadEpoch:1
   1->2 MsgAppResp Term:2 Log:0/12 Commit:11
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:2 Vote:2 Commit:12 Lead:2 LeadEpoch:1
   CommittedEntries:
   2/12 EntryNormal ""
@@ -112,7 +112,7 @@ stabilize 1 2
 > 1 receiving messages
   2->1 MsgApp Term:2 Log:2/12 Commit:12
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:2 Vote:2 Commit:12 Lead:2 LeadEpoch:1
   CommittedEntries:
   2/12 EntryNormal ""
@@ -148,7 +148,7 @@ stabilize
   INFO 3 [commit: 12, lastindex: 12, lastterm: 2] restored snapshot [index: 12, term: 2]
   INFO 3 [commit: 12] restored snapshot [index: 12, term: 2]
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:2 Commit:12 Lead:0 LeadEpoch:0
   Snapshot Index:12 Term:2 ConfState:Voters:[1 2 3] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
   Messages:

--- a/pkg/raft/testdata/snapshot_sent_and_leadership_change.txt
+++ b/pkg/raft/testdata/snapshot_sent_and_leadership_change.txt
@@ -131,7 +131,7 @@ INFO 3 [commit: 15] restored snapshot [index: 15, term: 1]
 stabilize 3
 ----
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:2 Commit:15 Lead:2 LeadEpoch:0
   Snapshot Index:15 Term:1 ConfState:Voters:[1 2 3] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
   Messages:
@@ -143,7 +143,7 @@ stabilize 3
   INFO 3 [logterm: 1, index: 15, vote: 0] rejected MsgVote from 2 [logterm: 1, index: 15] at term 2
   2->3 MsgFortifyLeader Term:2 Log:0/0
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:2 Commit:15 Lead:2 LeadEpoch:1
   Messages:
   3->2 MsgVoteResp Term:2 Log:0/0 Rejected (Hint: 0)
@@ -182,7 +182,7 @@ stabilize 2
   3->2 MsgVoteResp Term:2 Log:0/0 Rejected (Hint: 0)
   3->2 MsgFortifyLeaderResp Term:2 Log:0/0 LeadEpoch:1
 > 2 handling Ready
-  Ready MustSync=false:
+  Ready:
   Messages:
   2->3 MsgSnap Term:2 Log:0/0
     Snapshot: Index:16 Term:2 ConfState:Voters:[1 2 3] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false

--- a/pkg/raft/testdata/snapshot_succeed_via_app_resp.txt
+++ b/pkg/raft/testdata/snapshot_succeed_via_app_resp.txt
@@ -64,7 +64,7 @@ DEBUG ignore sending snapshot to 3 since it is not recently active
 
 process-ready 1
 ----
-Ready MustSync=false:
+Ready:
 Messages:
 1->3 MsgFortifyLeader Term:1 Log:0/0
 
@@ -77,7 +77,7 @@ stabilize 3
   INFO 3 became follower at term 1
   DEBUG 3 reset election elapsed to 0
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Commit:0 Lead:1 LeadEpoch:1
   Messages:
   3->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:1
@@ -94,7 +94,7 @@ DEBUG 1 paused sending replication messages to 3 [StateSnapshot match=0 next=12 
 
 process-ready 1
 ----
-Ready MustSync=false:
+Ready:
 Messages:
 1->3 MsgSnap Term:1 Log:0/0
   Snapshot: Index:11 Term:1 ConfState:Voters:[1 2 3] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
@@ -119,7 +119,7 @@ stabilize 3
   INFO 3 [commit: 11, lastindex: 11, lastterm: 1] restored snapshot [index: 11, term: 1]
   INFO 3 [commit: 11] restored snapshot [index: 11, term: 1]
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Commit:11 Lead:1 LeadEpoch:1
   Snapshot Index:11 Term:1 ConfState:Voters:[1 2 3] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
   Messages:

--- a/pkg/raft/testdata/snapshot_succeed_via_app_resp_behind.txt
+++ b/pkg/raft/testdata/snapshot_succeed_via_app_resp_behind.txt
@@ -99,7 +99,7 @@ DEBUG 3 [logterm: 0, index: 10] rejected MsgApp [logterm: 1, index: 10] from 1
 # PendingSnapshot=lastIndex=12.
 process-ready 3
 ----
-Ready MustSync=true:
+Ready:
 HardState Term:1 Vote:1 Commit:5 Lead:1 LeadEpoch:0
 Messages:
 3->1 MsgAppResp Term:1 Log:1/10 Rejected (Hint: 5) Commit:5
@@ -127,7 +127,7 @@ stabilize 1
   DEBUG 1 [firstindex: 11, commit: 12] sent snapshot[index: 12, term: 1] to 3 [StateProbe match=0 next=6 sentCommit=5 matchCommit=5]
   DEBUG 1 paused sending replication messages to 3 [StateSnapshot match=0 next=13 sentCommit=12 matchCommit=5 paused pendingSnap=12]
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready:
   Messages:
   1->3 MsgSnap Term:1 Log:0/0
     Snapshot: Index:12 Term:1 ConfState:Voters:[1 2 3] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
@@ -143,7 +143,7 @@ dropped: 1->3 MsgSnap Term:1 Log:0/0
 stabilize 3
 ----
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:1 Vote:1 Commit:11 Lead:1 LeadEpoch:1
   Snapshot Index:11 Term:1 ConfState:Voters:[1 2 3] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
   Messages:
@@ -157,7 +157,7 @@ stabilize 1
   3->1 MsgAppResp Term:1 Log:0/11 Commit:11
   DEBUG 1 recovered from needing snapshot, resumed sending replication messages to 3 [StateSnapshot match=11 next=13 sentCommit=12 matchCommit=11 paused pendingSnap=12]
 > 1 handling Ready
-  Ready MustSync=false:
+  Ready:
   Messages:
   1->3 MsgApp Term:1 Log:1/11 Commit:12 Entries:[1/12 EntryNormal "\"foo\""]
 

--- a/pkg/raft/testdata/transfer-leadership.txt
+++ b/pkg/raft/testdata/transfer-leadership.txt
@@ -40,7 +40,7 @@ DEBUG 1 reset election elapsed to 0
 stabilize
 ----
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   State:StateFollower
   HardState Term:1 Vote:1 Commit:11 Lead:0 LeadEpoch:0
   Messages:
@@ -53,7 +53,7 @@ stabilize
   INFO 2 [logterm: 1, index: 11] sent MsgVote request to 1 at term 2
   INFO 2 [logterm: 1, index: 11] sent MsgVote request to 3 at term 2
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   State:StateCandidate
   HardState Term:2 Vote:2 Commit:11 Lead:0 LeadEpoch:0
   Messages:
@@ -75,12 +75,12 @@ stabilize
   DEBUG 3 reset election elapsed to 0
   INFO 3 [logterm: 1, index: 11, vote: 0] cast MsgVote for 2 [logterm: 1, index: 11] at term 2
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:2 Vote:2 Commit:11 Lead:0 LeadEpoch:0
   Messages:
   1->2 MsgVoteResp Term:2 Log:0/0
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:2 Vote:2 Commit:11 Lead:0 LeadEpoch:0
   Messages:
   3->2 MsgVoteResp Term:2 Log:0/0
@@ -91,7 +91,7 @@ stabilize
   INFO 2 became leader at term 2
   3->2 MsgVoteResp Term:2 Log:0/0
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   State:StateLeader
   HardState Term:2 Vote:2 Commit:11 Lead:2 LeadEpoch:1
   Entries:
@@ -108,7 +108,7 @@ stabilize
   2->3 MsgFortifyLeader Term:2 Log:0/0
   2->3 MsgApp Term:2 Log:1/11 Commit:11 Entries:[2/12 EntryNormal ""]
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:2 Vote:2 Commit:11 Lead:2 LeadEpoch:1
   Entries:
   2/12 EntryNormal ""
@@ -116,7 +116,7 @@ stabilize
   1->2 MsgFortifyLeaderResp Term:2 Log:0/0 LeadEpoch:1
   1->2 MsgAppResp Term:2 Log:0/12 Commit:11
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:2 Vote:2 Commit:11 Lead:2 LeadEpoch:1
   Entries:
   2/12 EntryNormal ""
@@ -129,7 +129,7 @@ stabilize
   3->2 MsgFortifyLeaderResp Term:2 Log:0/0 LeadEpoch:1
   3->2 MsgAppResp Term:2 Log:0/12 Commit:11
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:2 Vote:2 Commit:12 Lead:2 LeadEpoch:1
   CommittedEntries:
   2/12 EntryNormal ""
@@ -141,14 +141,14 @@ stabilize
 > 3 receiving messages
   2->3 MsgApp Term:2 Log:2/12 Commit:12
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:2 Vote:2 Commit:12 Lead:2 LeadEpoch:1
   CommittedEntries:
   2/12 EntryNormal ""
   Messages:
   1->2 MsgAppResp Term:2 Log:0/12 Commit:12
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:2 Vote:2 Commit:12 Lead:2 LeadEpoch:1
   CommittedEntries:
   2/12 EntryNormal ""
@@ -193,7 +193,7 @@ DEBUG 2 reset election elapsed to 0
 stabilize
 ----
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   State:StateFollower
   HardState Term:2 Vote:2 Commit:12 Lead:0 LeadEpoch:0
   Messages:
@@ -206,7 +206,7 @@ stabilize
   INFO 3 [logterm: 2, index: 12] sent MsgVote request to 1 at term 3
   INFO 3 [logterm: 2, index: 12] sent MsgVote request to 2 at term 3
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   State:StateCandidate
   HardState Term:3 Vote:3 Commit:12 Lead:0 LeadEpoch:0
   Messages:
@@ -228,12 +228,12 @@ stabilize
   DEBUG 2 reset election elapsed to 0
   INFO 2 [logterm: 2, index: 12, vote: 0] cast MsgVote for 3 [logterm: 2, index: 12] at term 3
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:3 Vote:3 Commit:12 Lead:0 LeadEpoch:0
   Messages:
   1->3 MsgVoteResp Term:3 Log:0/0
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:3 Vote:3 Commit:12 Lead:0 LeadEpoch:0
   Messages:
   2->3 MsgVoteResp Term:3 Log:0/0
@@ -244,7 +244,7 @@ stabilize
   INFO 3 became leader at term 3
   2->3 MsgVoteResp Term:3 Log:0/0
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   State:StateLeader
   HardState Term:3 Vote:3 Commit:12 Lead:3 LeadEpoch:1
   Entries:
@@ -257,14 +257,14 @@ stabilize
 > 2 receiving messages
   3->2 MsgApp Term:3 Log:2/12 Commit:12 Entries:[3/13 EntryNormal ""]
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:3 Vote:3 Commit:12 Lead:3 LeadEpoch:0
   Entries:
   3/13 EntryNormal ""
   Messages:
   1->3 MsgAppResp Term:3 Log:0/13 Commit:12
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:3 Vote:3 Commit:12 Lead:3 LeadEpoch:0
   Entries:
   3/13 EntryNormal ""
@@ -274,7 +274,7 @@ stabilize
   1->3 MsgAppResp Term:3 Log:0/13 Commit:12
   2->3 MsgAppResp Term:3 Log:0/13 Commit:12
 > 3 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:3 Vote:3 Commit:13 Lead:3 LeadEpoch:1
   CommittedEntries:
   3/13 EntryNormal ""
@@ -286,14 +286,14 @@ stabilize
 > 2 receiving messages
   3->2 MsgApp Term:3 Log:3/13 Commit:13
 > 1 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:3 Vote:3 Commit:13 Lead:3 LeadEpoch:0
   CommittedEntries:
   3/13 EntryNormal ""
   Messages:
   1->3 MsgAppResp Term:3 Log:0/13 Commit:13
 > 2 handling Ready
-  Ready MustSync=true:
+  Ready:
   HardState Term:3 Vote:3 Commit:13 Lead:3 LeadEpoch:0
   CommittedEntries:
   3/13 EntryNormal ""

--- a/pkg/raft/util.go
+++ b/pkg/raft/util.go
@@ -183,7 +183,7 @@ func DescribeReady(rd Ready, f EntryFormatter) string {
 		}
 	}
 	if buf.Len() > 0 {
-		return fmt.Sprintf("Ready MustSync=%t:\n%s", rd.MustSync, buf.String())
+		return fmt.Sprintf("Ready:\n%s", buf.String())
 	}
 	return "<empty Ready>"
 }


### PR DESCRIPTION
This commit removes the unused and mildly confusing `MustSync` flag of the `Ready` struct. At the moment, the "must sync" signal is defined as `len(MsgStorageAppend.Responses) != 0`. We may later revisit making this explicit again.

Another reason why we don't want `MustSync` in the `Ready` struct is that it's purely a log storage protocol thing, so it's logically part of the `MsgStorageAppend` protocol, or one that will replace it.

Part of #124440