### PR TITLE
metric: add static labels to metric metadata

### DIFF
--- a/pkg/ccl/multitenantccl/tenantcostclient/tenant_side_test.go
+++ b/pkg/ccl/multitenantccl/tenantcostclient/tenant_side_test.go
@@ -647,7 +647,7 @@ func (ts *testState) metrics(*testing.T, *datadriven.TestData, cmdArgs) string {
 					if !ok {
 						return
 					}
-					promIter.Each(it.GetLabels(), func(m *prometheusgo.Metric) {
+					promIter.Each(it.GetLabels(false /* useStaticLabels */), func(m *prometheusgo.Metric) {
 						childMetrics += fmt.Sprintf("%s{", typ.GetName())
 						for i, l := range m.Label {
 							if i > 0 {

--- a/pkg/ccl/sqlproxyccl/server.go
+++ b/pkg/ccl/sqlproxyccl/server.go
@@ -149,7 +149,7 @@ func (s *Server) handleVars(w http.ResponseWriter, r *http.Request) {
 	contentType := expfmt.Negotiate(r.Header)
 	w.Header().Set(httputil.ContentTypeHeader, string(contentType))
 	scrape := func(pm *metric.PrometheusExporter) {
-		pm.ScrapeRegistry(s.metricsRegistry, true /* includeChildMetrics*/, true /* includeAggregateMetrics */)
+		pm.ScrapeRegistry(s.metricsRegistry, metric.WithIncludeChildMetrics(true), metric.WithIncludeAggregateMetrics(true))
 	}
 	if err := s.prometheusExporter.ScrapeAndPrintAsText(w, contentType, scrape); err != nil {
 		log.Errorf(r.Context(), "%v", err)

--- a/pkg/kv/kvserver/client_tenant_test.go
+++ b/pkg/kv/kvserver/client_tenant_test.go
@@ -99,7 +99,7 @@ func TestTenantsStorageMetricsOnSplit(t *testing.T) {
 		})
 		ex := metric.MakePrometheusExporter()
 		scrape := func(ex *metric.PrometheusExporter) {
-			ex.ScrapeRegistry(store.Registry(), true /* includeChildMetrics */, true)
+			ex.ScrapeRegistry(store.Registry(), metric.WithIncludeChildMetrics(true), metric.WithIncludeAggregateMetrics(true))
 		}
 		var in bytes.Buffer
 		if err := ex.ScrapeAndPrintAsText(&in, expfmt.FmtText, scrape); err != nil {

--- a/pkg/server/load_endpoint.go
+++ b/pkg/server/load_endpoint.go
@@ -89,7 +89,7 @@ func newLoadEndpoint(
 
 // Exporter for the load vars that are provided only by the load handler.
 func (le *loadEndpoint) scrapeLoadVarsIntoPrometheus(pm *metric.PrometheusExporter) {
-	pm.ScrapeRegistry(le.registry, true, true)
+	pm.ScrapeRegistry(le.registry, metric.WithIncludeChildMetrics(true), metric.WithIncludeAggregateMetrics(true))
 }
 
 // Handler responsible for serving the instant values of selected

--- a/pkg/server/status/recorder.go
+++ b/pkg/server/status/recorder.go
@@ -346,15 +346,15 @@ func (mr *MetricsRecorder) ScrapeIntoPrometheus(pm *metric.PrometheusExporter) {
 	}
 	includeChildMetrics := ChildMetricsEnabled.Get(&mr.settings.SV)
 	includeAggregateMetrics := includeAggregateMetricsEnabled.Get(&mr.settings.SV)
-	pm.ScrapeRegistry(mr.mu.nodeRegistry, includeChildMetrics, includeAggregateMetrics)
-	pm.ScrapeRegistry(mr.mu.appRegistry, includeChildMetrics, includeAggregateMetrics)
-	pm.ScrapeRegistry(mr.mu.logRegistry, includeChildMetrics, includeAggregateMetrics)
-	pm.ScrapeRegistry(mr.mu.sysRegistry, includeChildMetrics, includeAggregateMetrics)
+	pm.ScrapeRegistry(mr.mu.nodeRegistry, metric.WithIncludeChildMetrics(includeChildMetrics), metric.WithIncludeAggregateMetrics(includeAggregateMetrics))
+	pm.ScrapeRegistry(mr.mu.appRegistry, metric.WithIncludeChildMetrics(includeChildMetrics), metric.WithIncludeAggregateMetrics(includeAggregateMetrics))
+	pm.ScrapeRegistry(mr.mu.logRegistry, metric.WithIncludeChildMetrics(includeChildMetrics), metric.WithIncludeAggregateMetrics(includeAggregateMetrics))
+	pm.ScrapeRegistry(mr.mu.sysRegistry, metric.WithIncludeChildMetrics(includeChildMetrics), metric.WithIncludeAggregateMetrics(includeAggregateMetrics))
 	for _, reg := range mr.mu.storeRegistries {
-		pm.ScrapeRegistry(reg, includeChildMetrics, includeAggregateMetrics)
+		pm.ScrapeRegistry(reg, metric.WithIncludeChildMetrics(includeChildMetrics), metric.WithIncludeAggregateMetrics(includeAggregateMetrics))
 	}
 	for _, tenantRegistry := range mr.mu.tenantRegistries {
-		pm.ScrapeRegistry(tenantRegistry, includeChildMetrics, includeAggregateMetrics)
+		pm.ScrapeRegistry(tenantRegistry, metric.WithIncludeChildMetrics(includeChildMetrics), metric.WithIncludeAggregateMetrics(includeAggregateMetrics))
 	}
 }
 
@@ -808,7 +808,7 @@ func (rr registryRecorder) recordChild(
 			return
 		}
 		m := prom.ToPrometheusMetric()
-		m.Label = append(labels, prom.GetLabels()...)
+		m.Label = append(labels, prom.GetLabels(false /* useStaticLabels */)...)
 
 		processChildMetric := func(metric *prometheusgo.Metric) {
 			found := false

--- a/pkg/sql/mvcc_statistics_update_job_test.go
+++ b/pkg/sql/mvcc_statistics_update_job_test.go
@@ -127,7 +127,7 @@ func TestTenantGlobalAggregatedLivebytes(t *testing.T) {
 			&in,
 			expfmt.FmtText,
 			func(ex *metric.PrometheusExporter) {
-				ex.ScrapeRegistry(r, true /* includeChildMetrics */, true)
+				ex.ScrapeRegistry(r, metric.WithIncludeChildMetrics(true), metric.WithIncludeAggregateMetrics(true))
 			},
 		)
 		require.NoError(t, err)

--- a/pkg/testutils/metrictestutils/metrics_text.go
+++ b/pkg/testutils/metrictestutils/metrics_text.go
@@ -21,7 +21,7 @@ import (
 func GetMetricsText(registry *metric.Registry, re *regexp.Regexp) (string, error) {
 	ex := metric.MakePrometheusExporter()
 	scrape := func(ex *metric.PrometheusExporter) {
-		ex.ScrapeRegistry(registry, true /* includeChildMetrics */, true)
+		ex.ScrapeRegistry(registry, metric.WithIncludeChildMetrics(true), metric.WithIncludeAggregateMetrics(true))
 	}
 	var in bytes.Buffer
 	if err := ex.ScrapeAndPrintAsText(&in, expfmt.FmtText, scrape); err != nil {

--- a/pkg/util/metric/BUILD.bazel
+++ b/pkg/util/metric/BUILD.bazel
@@ -62,12 +62,14 @@ go_test(
         "//pkg/util/buildutil",
         "//pkg/util/log",
         "//pkg/util/randutil",
+        "@com_github_gogo_protobuf//proto",
         "@com_github_kr_pretty//:pretty",
         "@com_github_prometheus_client_golang//prometheus",
         "@com_github_prometheus_client_model//go",
         "@com_github_prometheus_common//expfmt",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
+        "@org_golang_google_protobuf//proto",
     ],
 )
 

--- a/pkg/util/metric/aggmetric/agg_metric_test.go
+++ b/pkg/util/metric/aggmetric/agg_metric_test.go
@@ -35,7 +35,7 @@ func TestExcludeAggregateMetrics(t *testing.T) {
 	// Flipping the includeAggregateMetrics flag should have no effect.
 	testutils.RunTrueAndFalse(t, "includeChildMetrics=false,includeAggregateMetrics", func(t *testing.T, includeAggregateMetrics bool) {
 		pe := metric.MakePrometheusExporter()
-		pe.ScrapeRegistry(r, false, includeAggregateMetrics)
+		pe.ScrapeRegistry(r, metric.WithIncludeChildMetrics(false), metric.WithIncludeAggregateMetrics(includeAggregateMetrics))
 		families, err := pe.Gather()
 		require.NoError(t, err)
 		require.Equal(t, 1, len(families))
@@ -46,7 +46,7 @@ func TestExcludeAggregateMetrics(t *testing.T) {
 
 	testutils.RunTrueAndFalse(t, "includeChildMetrics=true,includeAggregateMetrics", func(t *testing.T, includeAggregateMetrics bool) {
 		pe := metric.MakePrometheusExporter()
-		pe.ScrapeRegistry(r, true, includeAggregateMetrics)
+		pe.ScrapeRegistry(r, metric.WithIncludeChildMetrics(true), metric.WithIncludeAggregateMetrics(includeAggregateMetrics))
 		families, err := pe.Gather()
 		require.NoError(t, err)
 		require.Equal(t, 1, len(families))
@@ -355,7 +355,7 @@ func WritePrometheusMetricsFunc(r *metric.Registry) func(t *testing.T) string {
 		var in bytes.Buffer
 		ex := metric.MakePrometheusExporter()
 		scrape := func(ex *metric.PrometheusExporter) {
-			ex.ScrapeRegistry(r, true /* includeChildMetrics */, true)
+			ex.ScrapeRegistry(r, metric.WithIncludeChildMetrics(true), metric.WithIncludeAggregateMetrics(true))
 		}
 		require.NoError(t, ex.ScrapeAndPrintAsText(&in, expfmt.FmtText, scrape))
 		var lines []string

--- a/pkg/util/metric/aggmetric/counter.go
+++ b/pkg/util/metric/aggmetric/counter.go
@@ -37,6 +37,9 @@ func NewCounter(metadata metric.Metadata, childLabels ...string) *AggCounter {
 // GetName is part of the metric.Iterable interface.
 func (c *AggCounter) GetName() string { return c.g.GetName() }
 
+// GetLabeledName is part of the metric.Iterable interface.
+func (c *AggCounter) GetLabeledName() string { return c.g.GetLabeledName() }
+
 // GetHelp is part of the metric.Iterable interface.
 func (c *AggCounter) GetHelp() string { return c.g.GetHelp() }
 
@@ -58,8 +61,8 @@ func (c *AggCounter) GetType() *io_prometheus_client.MetricType {
 }
 
 // GetLabels is part of the metric.PrometheusExportable interface.
-func (c *AggCounter) GetLabels() []*io_prometheus_client.LabelPair {
-	return c.g.GetLabels()
+func (c *AggCounter) GetLabels(useStaticLabels bool) []*io_prometheus_client.LabelPair {
+	return c.g.GetLabels(useStaticLabels)
 }
 
 // ToPrometheusMetric is part of the metric.PrometheusExportable interface.
@@ -176,6 +179,9 @@ func NewCounterFloat64(metadata metric.Metadata, childLabels ...string) *AggCoun
 // GetName is part of the metric.Iterable interface.
 func (c *AggCounterFloat64) GetName() string { return c.g.GetName() }
 
+// GetLabeledName is part of the metric.Iterable interface.
+func (c *AggCounterFloat64) GetLabeledName() string { return c.g.GetLabeledName() }
+
 // GetHelp is part of the metric.Iterable interface.
 func (c *AggCounterFloat64) GetHelp() string { return c.g.GetHelp() }
 
@@ -197,8 +203,8 @@ func (c *AggCounterFloat64) GetType() *io_prometheus_client.MetricType {
 }
 
 // GetLabels is part of the metric.PrometheusExportable interface.
-func (c *AggCounterFloat64) GetLabels() []*io_prometheus_client.LabelPair {
-	return c.g.GetLabels()
+func (c *AggCounterFloat64) GetLabels(useStaticLabels bool) []*io_prometheus_client.LabelPair {
+	return c.g.GetLabels(useStaticLabels)
 }
 
 // ToPrometheusMetric is part of the metric.PrometheusExportable interface.

--- a/pkg/util/metric/aggmetric/counter_test.go
+++ b/pkg/util/metric/aggmetric/counter_test.go
@@ -30,7 +30,7 @@ func TestAggCounter(t *testing.T) {
 		var in bytes.Buffer
 		ex := metric.MakePrometheusExporter()
 		scrape := func(ex *metric.PrometheusExporter) {
-			ex.ScrapeRegistry(r, true /* includeChildMetrics */, true)
+			ex.ScrapeRegistry(r, metric.WithIncludeChildMetrics(true), metric.WithIncludeAggregateMetrics(true))
 		}
 		require.NoError(t, ex.ScrapeAndPrintAsText(&in, expfmt.FmtText, scrape))
 		var lines []string

--- a/pkg/util/metric/aggmetric/gauge.go
+++ b/pkg/util/metric/aggmetric/gauge.go
@@ -60,6 +60,9 @@ func NewFunctionalGauge(
 // GetName is part of the metric.Iterable interface.
 func (g *AggGauge) GetName() string { return g.g.GetName() }
 
+// GetLabeledName is part of the metric.Iterable interface.
+func (g *AggGauge) GetLabeledName() string { return g.g.GetLabeledName() }
+
 // GetHelp is part of the metric.Iterable interface.
 func (g *AggGauge) GetHelp() string { return g.g.GetHelp() }
 
@@ -81,8 +84,8 @@ func (g *AggGauge) GetType() *io_prometheus_client.MetricType {
 }
 
 // GetLabels is part of the metric.PrometheusExportable interface.
-func (g *AggGauge) GetLabels() []*io_prometheus_client.LabelPair {
-	return g.g.GetLabels()
+func (g *AggGauge) GetLabels(useStaticLabels bool) []*io_prometheus_client.LabelPair {
+	return g.g.GetLabels(useStaticLabels)
 }
 
 // ToPrometheusMetric is part of the metric.PrometheusExportable interface.
@@ -262,6 +265,9 @@ func NewGaugeFloat64(metadata metric.Metadata, childLabels ...string) *AggGaugeF
 // GetName is part of the metric.Iterable interface.
 func (g *AggGaugeFloat64) GetName() string { return g.g.GetName() }
 
+// GetLabeledName is part of the metric.Iterable interface.
+func (g *AggGaugeFloat64) GetLabeledName() string { return g.g.GetLabeledName() }
+
 // GetHelp is part of the metric.Iterable interface.
 func (g *AggGaugeFloat64) GetHelp() string { return g.g.GetHelp() }
 
@@ -283,8 +289,8 @@ func (g *AggGaugeFloat64) GetType() *io_prometheus_client.MetricType {
 }
 
 // GetLabels is part of the metric.PrometheusExportable interface.
-func (g *AggGaugeFloat64) GetLabels() []*io_prometheus_client.LabelPair {
-	return g.g.GetLabels()
+func (g *AggGaugeFloat64) GetLabels(useStaticLabels bool) []*io_prometheus_client.LabelPair {
+	return g.g.GetLabels(useStaticLabels)
 }
 
 // ToPrometheusMetric is part of the metric.PrometheusExportable interface.

--- a/pkg/util/metric/aggmetric/gauge_test.go
+++ b/pkg/util/metric/aggmetric/gauge_test.go
@@ -65,7 +65,7 @@ func TestAggGaugeMethods(t *testing.T) {
 		var in bytes.Buffer
 		ex := metric.MakePrometheusExporter()
 		scrape := func(ex *metric.PrometheusExporter) {
-			ex.ScrapeRegistry(r, true /* includeChildMetrics */, true)
+			ex.ScrapeRegistry(r, metric.WithIncludeChildMetrics(true), metric.WithIncludeAggregateMetrics(true))
 		}
 		require.NoError(t, ex.ScrapeAndPrintAsText(&in, expfmt.FmtText, scrape))
 		var lines []string

--- a/pkg/util/metric/aggmetric/histogram.go
+++ b/pkg/util/metric/aggmetric/histogram.go
@@ -94,6 +94,9 @@ func NewHistogram(opts metric.HistogramOptions, childLabels ...string) *AggHisto
 // GetName is part of the metric.Iterable interface.
 func (a *AggHistogram) GetName() string { return a.h.GetName() }
 
+// GetLabeledName is part of the metric.Iterable interface.
+func (a *AggHistogram) GetLabeledName() string { return a.h.GetLabeledName() }
+
 // GetHelp is part of the metric.Iterable interface.
 func (a *AggHistogram) GetHelp() string { return a.h.GetHelp() }
 
@@ -132,8 +135,8 @@ func (a *AggHistogram) GetType() *prometheusgo.MetricType {
 }
 
 // GetLabels is part of the metric.PrometheusExportable interface.
-func (a *AggHistogram) GetLabels() []*prometheusgo.LabelPair {
-	return a.h.GetLabels()
+func (a *AggHistogram) GetLabels(useStaticLabels bool) []*prometheusgo.LabelPair {
+	return a.h.GetLabels(useStaticLabels)
 }
 
 // ToPrometheusMetric is part of the metric.PrometheusExportable interface.

--- a/pkg/util/metric/aggmetric/histogram_test.go
+++ b/pkg/util/metric/aggmetric/histogram_test.go
@@ -31,7 +31,7 @@ func TestAggHistogram(t *testing.T) {
 		var in bytes.Buffer
 		ex := metric.MakePrometheusExporter()
 		scrape := func(ex *metric.PrometheusExporter) {
-			ex.ScrapeRegistry(r, true /* includeChildMetrics */, true)
+			ex.ScrapeRegistry(r, metric.WithIncludeChildMetrics(true), metric.WithIncludeAggregateMetrics(true))
 		}
 		require.NoError(t, ex.ScrapeAndPrintAsText(&in, expfmt.FmtText, scrape))
 		var lines []string

--- a/pkg/util/metric/metric.proto
+++ b/pkg/util/metric/metric.proto
@@ -50,10 +50,17 @@ enum Unit {
 // each metric object. It's used to export information about the
 // metric to Prometheus and for Admin UI charts.
 message Metadata {
+  // name is the name of the metric as if it was unlabeled. Set this to ensure
+  // it gets recorded in TSDB.
   required string name = 1 [(gogoproto.nullable) = false];
   required string help = 2 [(gogoproto.nullable) = false];
   required string measurement = 3 [(gogoproto.nullable) = false];
   required Unit unit = 4 [(gogoproto.nullable) = false];
   optional io.prometheus.client.MetricType metricType = 5 [(gogoproto.nullable) = false];
   repeated LabelPair labels = 6;
+
+  // if a labeled_name is provided, it will be output in the /metrics endpoint
+  // with the corresponding static labels.
+  required string labeled_name = 8 [(gogoproto.nullable) = false];
+  repeated LabelPair static_labels = 7;
 }

--- a/pkg/util/metric/prometheus_exporter_test.go
+++ b/pkg/util/metric/prometheus_exporter_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/gogo/protobuf/proto"
 	"github.com/prometheus/common/expfmt"
 	"github.com/stretchr/testify/require"
 )
@@ -48,8 +49,8 @@ func TestPrometheusExporter(t *testing.T) {
 	pe := MakePrometheusExporter()
 	const includeChildMetrics = false
 	const includeAggregateMetrics = true
-	pe.ScrapeRegistry(r1, includeChildMetrics, includeAggregateMetrics)
-	pe.ScrapeRegistry(r2, includeChildMetrics, includeAggregateMetrics)
+	pe.ScrapeRegistry(r1, WithIncludeChildMetrics(includeChildMetrics), WithIncludeAggregateMetrics(includeAggregateMetrics))
+	pe.ScrapeRegistry(r2, WithIncludeChildMetrics(includeChildMetrics), WithIncludeAggregateMetrics(includeAggregateMetrics))
 
 	type metricLabels map[string]string
 	type family struct {
@@ -142,8 +143,8 @@ func TestPrometheusExporter(t *testing.T) {
 	// Remove a metric, followed by a call to scrape and Gather. Results should
 	// only include metrics with data points.
 	r2.RemoveMetric(c2Dup)
-	pe.ScrapeRegistry(r1, includeChildMetrics, includeAggregateMetrics)
-	pe.ScrapeRegistry(r2, includeChildMetrics, includeAggregateMetrics)
+	pe.ScrapeRegistry(r1, WithIncludeChildMetrics(includeChildMetrics), WithIncludeAggregateMetrics(includeAggregateMetrics))
+	pe.ScrapeRegistry(r2, WithIncludeChildMetrics(includeChildMetrics), WithIncludeAggregateMetrics(includeAggregateMetrics))
 	families, err = pe.Gather()
 	if err != nil {
 		t.Errorf("unexpected error from Gather(): %v", err)
@@ -158,7 +159,7 @@ func TestPrometheusExporter(t *testing.T) {
 	var buf bytes.Buffer
 	pe = MakePrometheusExporter()
 	err = pe.ScrapeAndPrintAsText(&buf, expfmt.FmtText, func(exporter *PrometheusExporter) {
-		exporter.ScrapeRegistry(r1, true, includeAggregateMetrics)
+		exporter.ScrapeRegistry(r1, WithIncludeChildMetrics(true), WithIncludeAggregateMetrics(includeAggregateMetrics))
 	})
 	require.NoError(t, err)
 	output := buf.String()
@@ -174,7 +175,7 @@ func TestPrometheusExporter(t *testing.T) {
 	buf.Reset()
 	r1.RemoveMetric(g1Dup)
 	err = pe.ScrapeAndPrintAsText(&buf, expfmt.FmtText, func(exporter *PrometheusExporter) {
-		exporter.ScrapeRegistry(r1, true, includeAggregateMetrics)
+		exporter.ScrapeRegistry(r1, WithIncludeChildMetrics(true), WithIncludeAggregateMetrics(includeAggregateMetrics))
 	})
 	require.NoError(t, err)
 	output = buf.String()
@@ -210,7 +211,7 @@ func TestPrometheusExporterNativeHistogram(t *testing.T) {
 	// Print metrics as proto text, since native histograms aren't yet supported.
 	// in the prometheus text exposition format.
 	err := pe.ScrapeAndPrintAsText(&buf, expfmt.FmtProtoText, func(exporter *PrometheusExporter) {
-		exporter.ScrapeRegistry(r, false, true)
+		exporter.ScrapeRegistry(r, WithIncludeChildMetrics(false), WithIncludeAggregateMetrics(true))
 	})
 	require.NoError(t, err)
 	output := buf.String()
@@ -220,9 +221,112 @@ func TestPrometheusExporterNativeHistogram(t *testing.T) {
 	buf.Reset()
 	r.RemoveMetric(histogram)
 	err = pe.ScrapeAndPrintAsText(&buf, expfmt.FmtProtoText, func(exporter *PrometheusExporter) {
-		exporter.ScrapeRegistry(r, false, true)
+		exporter.ScrapeRegistry(r, WithIncludeChildMetrics(false), WithIncludeAggregateMetrics(true))
 	})
 	require.NoError(t, err)
 	output = buf.String()
 	require.Empty(t, output)
+}
+
+func TestPrometheusExporterStaticLabels(t *testing.T) {
+	tests := []struct {
+		name            string
+		useStaticLabels bool
+		metricMetadata  Metadata
+		expectedOutput  string
+	}{
+		{
+			name:            "no static labels requested",
+			useStaticLabels: false,
+			metricMetadata: Metadata{
+				Name:        "test.metric.static.value",
+				Help:        "Test metric",
+				LabeledName: "test.metric",
+				StaticLabels: []*LabelPair{
+					{Name: proto.String("static"), Value: proto.String("value")},
+				},
+			},
+			expectedOutput: "test_metric_static_value 0",
+		},
+		{
+			name:            "with static labels",
+			useStaticLabels: true,
+			metricMetadata: Metadata{
+				Name:        "test.metric.static.value",
+				Help:        "Test metric",
+				LabeledName: "test.metric",
+				StaticLabels: []*LabelPair{
+					{Name: proto.String("static"), Value: proto.String("value")},
+				},
+			},
+			expectedOutput: "test_metric{static=\"value\"} 0",
+		},
+		{
+			name:            "with both static and dynamic labels",
+			useStaticLabels: true,
+			metricMetadata: Metadata{
+				Name:        "test.metric.static.value",
+				Help:        "Test metric",
+				LabeledName: "test.metric",
+				StaticLabels: []*LabelPair{
+					{Name: proto.String("static"), Value: proto.String("value")},
+				},
+				Labels: []*LabelPair{
+					{Name: proto.String("dynamic"), Value: proto.String("value")},
+				},
+			},
+			expectedOutput: "test_metric{static=\"value\",dynamic=\"value\"} 0",
+		},
+		{
+			name:            "with both static and dynamic labels only output dynamic",
+			useStaticLabels: false,
+			metricMetadata: Metadata{
+				Name:        "test.metric.static.value",
+				Help:        "Test metric",
+				LabeledName: "test.metric",
+				StaticLabels: []*LabelPair{
+					{Name: proto.String("static"), Value: proto.String("value")},
+				},
+				Labels: []*LabelPair{
+					{Name: proto.String("dynamic"), Value: proto.String("value")},
+				},
+			},
+			expectedOutput: "test_metric_static_value{dynamic=\"value\"} 0",
+		},
+		{
+			name:            "legacy metric with static label output should remain the same",
+			useStaticLabels: true,
+			metricMetadata: Metadata{
+				Name: "test.metric.static.value",
+				Help: "Test metric",
+				Labels: []*LabelPair{
+					{Name: proto.String("dynamic"), Value: proto.String("value")},
+				},
+			},
+			expectedOutput: "test_metric_static_value{dynamic=\"value\"} 0",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			// Create a registry with a test metric
+			r := NewRegistry()
+			gauge := NewGauge(tc.metricMetadata)
+			r.AddMetric(gauge)
+
+			// Create exporter and scrape registry
+			pe := MakePrometheusExporter()
+
+			// Test the text output format
+			var buf bytes.Buffer
+			err := pe.ScrapeAndPrintAsText(&buf, expfmt.FmtText, func(exporter *PrometheusExporter) {
+				exporter.ScrapeRegistry(r, WithUseStaticLabels(tc.useStaticLabels))
+			})
+			require.NoError(t, err)
+
+			// Verify the text output matches expected format
+			output := buf.String()
+			require.Contains(t, output, tc.expectedOutput, "expected metric output not found")
+		})
+	}
 }


### PR DESCRIPTION
Previously, it was not possible to emit metrics with static labels that were known at startup. Labels would need to be dynamically added after `Metadata` was constructed. This made it difficult to define groups of metrics with the same name but different labels.

This commit adds two new fields to the `metric.Metadata` struct, which are meant to enable a backwards-compatible transition to labeled metrics from today's definitions which reify the label values into the metric name.

The Prometheus export code is modified to accept a flag that governs whether static labels are requested. If so, the labeled name of the metric be used if available.

A future PR will add a `/metrics` endpoint that is like `/_status/ vars` except that it will emit the static label version of metrics when they have those definitions available.

Part of: #142570

Release note: None