### PR TITLE
rac2: introduce tokenCounterMu

### DIFF
--- a/pkg/kv/kvserver/kvflowcontrol/rac2/token_counter.go
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/token_counter.go
@@ -181,6 +181,43 @@ func (f TokenType) SafeFormat(p redact.SafePrinter, _ rune) {
 	}
 }
 
+// Wrapper type to give mutex contention events in mutex profiles a leaf frame
+// that references tokenCounterMu. This makes it easier to look at contention
+// on this mutex specifically.
+type tokenCounterMu syncutil.RWMutex
+
+func (mu *tokenCounterMu) Lock() {
+	(*syncutil.RWMutex)(mu).Lock()
+}
+
+func (mu *tokenCounterMu) TryLock() {
+	(*syncutil.RWMutex)(mu).TryLock()
+}
+
+func (mu *tokenCounterMu) Unlock() {
+	(*syncutil.RWMutex)(mu).Unlock()
+}
+
+func (mu *tokenCounterMu) RLock() {
+	(*syncutil.RWMutex)(mu).RLock()
+}
+
+func (mu *tokenCounterMu) TryRLock() {
+	(*syncutil.RWMutex)(mu).TryRLock()
+}
+
+func (mu *tokenCounterMu) RUnlock() {
+	(*syncutil.RWMutex)(mu).RUnlock()
+}
+
+func (mu *tokenCounterMu) AssertHeld() {
+	(*syncutil.RWMutex)(mu).AssertHeld()
+}
+
+func (mu *tokenCounterMu) AssertRHeld() {
+	(*syncutil.RWMutex)(mu).AssertRHeld()
+}
+
 // tokenCounter holds flow tokens for {regular,elastic} traffic over a
 // kvflowcontrol.Stream. It's used to synchronize handoff between threads
 // returning and waiting for flow tokens.
@@ -194,7 +231,7 @@ type tokenCounter struct {
 	tokenType TokenType
 
 	mu struct {
-		syncutil.RWMutex
+		tokenCounterMu
 
 		counters [admissionpb.NumWorkClasses]tokenCounterPerWorkClass
 	}


### PR DESCRIPTION
This gives the mutex acquisitions a dedicated call frame which helps look for only this mutex in mutex profiles.

This follows the same pattern that we already apply for ReplicaMutex.

Epic: CRDB-42584
Release note: None