### PR TITLE
build: upgrade bazel to 7.6.0

### DIFF
--- a/.bazelversion
+++ b/.bazelversion
@@ -1,1 +1,1 @@
-cockroachdb/7.2.1
+cockroachdb/7.6.0


### PR DESCRIPTION
7.2.1 has a remote-execution related bug which should be fixed in this version.

Epic: none
Release note: None