### PR TITLE
release-25.1: sql,backfill: avoid holding a protected timestamp during the backfill

### DIFF
--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -1011,8 +1011,6 @@ func (sc *SchemaChanger) distIndexBackfill(
 		log.Infof(ctx, "writing at persisted safe write time %v...", writeAsOf)
 	}
 
-	readAsOf := sc.clock.Now()
-
 	var p *PhysicalPlan
 	var evalCtx extendedEvalContext
 	var planCtx *PlanningCtx
@@ -1044,7 +1042,7 @@ func (sc *SchemaChanger) distIndexBackfill(
 		)
 		indexBatchSize := indexBackfillBatchSize.Get(&sc.execCfg.Settings.SV)
 		chunkSize := sc.getChunkSize(indexBatchSize)
-		spec, err := initIndexBackfillerSpec(*tableDesc.TableDesc(), writeAsOf, readAsOf, writeAtRequestTimestamp, chunkSize, addedIndexes)
+		spec, err := initIndexBackfillerSpec(*tableDesc.TableDesc(), writeAsOf, writeAtRequestTimestamp, chunkSize, addedIndexes)
 		if err != nil {
 			return err
 		}

--- a/pkg/sql/distsql_plan_backfill.go
+++ b/pkg/sql/distsql_plan_backfill.go
@@ -40,7 +40,7 @@ func initColumnBackfillerSpec(
 
 func initIndexBackfillerSpec(
 	desc descpb.TableDescriptor,
-	writeAsOf, readAsOf hlc.Timestamp,
+	writeAsOf hlc.Timestamp,
 	writeAtBatchTimestamp bool,
 	chunkSize int64,
 	indexesToBackfill []descpb.IndexID,
@@ -49,7 +49,6 @@ func initIndexBackfillerSpec(
 		Table:                 desc,
 		WriteAsOf:             writeAsOf,
 		WriteAtBatchTimestamp: writeAtBatchTimestamp,
-		ReadAsOf:              readAsOf,
 		Type:                  execinfrapb.BackfillerSpec_Index,
 		ChunkSize:             chunkSize,
 		IndexesToBackfill:     indexesToBackfill,

--- a/pkg/sql/execinfrapb/processors_bulk_io.proto
+++ b/pkg/sql/execinfrapb/processors_bulk_io.proto
@@ -64,9 +64,9 @@ message BackfillerSpec {
   optional uint64 update_chunk_size_threshold_bytes = 14 [(gogoproto.nullable) = false];
 
   // WriteAsOf is the time that the backfill entries should be written.
-  // Note: Older nodes may also use this as the read time instead of readAsOf.
   optional util.hlc.Timestamp writeAsOf = 7 [(gogoproto.nullable) = false];
   // The timestamp to perform index backfill historical scans at.
+  // This is only used by the column backfiller.
   optional util.hlc.Timestamp readAsOf = 9 [(gogoproto.nullable) = false];
 
   // IndexesToBackfill is the set of indexes to backfill. This is populated only

--- a/pkg/sql/index_backfiller.go
+++ b/pkg/sql/index_backfiller.go
@@ -182,7 +182,7 @@ func (ib *IndexBackfillPlanner) plan(
 		chunkSize := indexBackfillBatchSize.Get(&ib.execCfg.Settings.SV)
 		const writeAtRequestTimestamp = true
 		spec, err := initIndexBackfillerSpec(
-			*td.TableDesc(), writeAsOf, readAsOf, writeAtRequestTimestamp, chunkSize,
+			*td.TableDesc(), writeAsOf, writeAtRequestTimestamp, chunkSize,
 			indexesToBackfill,
 		)
 		if err != nil {

--- a/pkg/sql/index_backfiller.go
+++ b/pkg/sql/index_backfiller.go
@@ -23,7 +23,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/admission/admissionpb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
-	"github.com/cockroachdb/errors"
 )
 
 // IndexBackfillPlanner holds dependencies for an index backfiller
@@ -68,19 +67,6 @@ func (ib *IndexBackfillPlanner) BackfillIndexes(
 	job *jobs.Job,
 	descriptor catalog.TableDescriptor,
 ) (retErr error) {
-	// Potentially install a protected timestamp before the GC interval is hit,
-	// which can help avoid transaction retry errors, with shorter GC intervals.
-	protectedTimestampCleaner := ib.execCfg.ProtectedTimestampManager.TryToProtectBeforeGC(ctx,
-		job,
-		descriptor,
-		progress.MinimumWriteTimestamp)
-	defer func() {
-		cleanupError := protectedTimestampCleaner(ctx)
-		if cleanupError != nil {
-			retErr = errors.CombineErrors(retErr, cleanupError)
-		}
-	}()
-
 	var completed = struct {
 		syncutil.Mutex
 		g roachpb.SpanGroup

--- a/pkg/sql/rowexec/indexbackfiller.go
+++ b/pkg/sql/rowexec/indexbackfiller.go
@@ -135,12 +135,16 @@ func (ib *indexBackfiller) constructIndexEntries(
 		todo := ib.spec.Spans[i]
 		for todo.Key != nil {
 			startKey := todo.Key
-			readAsOf := ib.spec.ReadAsOf
-			if readAsOf.IsEmpty() { // old gateway
+			// Pick an arbitrary timestamp close to now as the read timestamp for the
+			// backfill. It's safe to use this timestamp to read even if we've
+			// partially backfilled at an earlier timestamp because other writing
+			// transactions have been writing at the appropriate timestamps
+			// in-between.
+			readAsOf := ib.flowCtx.Cfg.DB.KV().Clock().Now().AddDuration(-30 * time.Second)
+			if readAsOf.Less(ib.spec.WriteAsOf) {
 				readAsOf = ib.spec.WriteAsOf
 			}
-			todo.Key, entries, memUsedBuildingBatch, err = ib.buildIndexEntryBatch(ctx, todo,
-				readAsOf)
+			todo.Key, entries, memUsedBuildingBatch, err = ib.buildIndexEntryBatch(ctx, todo, readAsOf)
 			if err != nil {
 				return err
 			}

--- a/pkg/sql/rowexec/indexbackfiller.go
+++ b/pkg/sql/rowexec/indexbackfiller.go
@@ -193,7 +193,7 @@ func (ib *indexBackfiller) ingestIndexEntries(
 		MinBufferSize:            minBufferSize,
 		MaxBufferSize:            maxBufferSize,
 		SkipDuplicates:           ib.ContainsInvertedIndex(),
-		BatchTimestamp:           ib.spec.ReadAsOf,
+		BatchTimestamp:           ib.spec.WriteAsOf,
 		InitialSplitsIfUnordered: int(ib.spec.InitialSplits),
 		WriteAtBatchTimestamp:    ib.spec.WriteAtBatchTimestamp,
 	}

--- a/pkg/sql/schema_changer_test.go
+++ b/pkg/sql/schema_changer_test.go
@@ -4084,6 +4084,7 @@ func TestIndexBackfillAfterGC(t *testing.T) {
 	var tc serverutils.TestClusterInterface
 	ctx := context.Background()
 	var gcAt hlc.Timestamp
+	shouldRunGC := atomic.Bool{}
 	runGC := func(sp roachpb.Span) error {
 		if tc == nil {
 			return nil
@@ -4104,9 +4105,8 @@ func TestIndexBackfillAfterGC(t *testing.T) {
 	params.Knobs = base.TestingKnobs{
 		DistSQL: &execinfra.TestingKnobs{
 			RunBeforeBackfillChunk: func(sp roachpb.Span) error {
-				if fn := runGC; fn != nil {
-					runGC = nil
-					return fn(sp)
+				if shouldRunGC.Swap(false) {
+					return runGC(sp)
 				}
 				return nil
 			},
@@ -4120,29 +4120,45 @@ func TestIndexBackfillAfterGC(t *testing.T) {
 	db := tc.ServerConn(0)
 	kvDB := tc.Server(0).DB()
 	codec := tc.Server(0).ApplicationLayer().Codec()
+	db.SetMaxOpenConns(1)
 	sqlDB := sqlutils.MakeSQLRunner(db)
-
-	sqlDB.Exec(t, "SET use_declarative_schema_changer='off'")
 	sqlDB.Exec(t, `CREATE DATABASE t`)
-	sqlDB.Exec(t, `CREATE TABLE t.test (k INT PRIMARY KEY, v INT, pi DECIMAL DEFAULT (DECIMAL '3.14'))`)
-	sqlDB.Exec(t, `INSERT INTO t.test VALUES (1, 1)`)
-	if _, err := db.Exec(`CREATE UNIQUE INDEX index_created_in_test ON t.test (v)`); err != nil {
-		t.Fatal(err)
-	}
 
-	if err := sqltestutils.CheckTableKeyCount(context.Background(), kvDB, codec, 2, 0); err != nil {
-		t.Fatal(err)
-	}
+	testutils.RunTrueAndFalse(t, "useDeclarative", func(t *testing.T, useDeclarative bool) {
+		writeTSFromJob := "p->'schemaChange'->'writeTimestamp'->>'wallTime'"
+		indexName := "index_created_in_test_legacy"
+		sqlDB.Exec(t, "SET use_declarative_schema_changer='off'")
+		if useDeclarative {
+			writeTSFromJob = "p->'newSchemaChange'->'backfillProgress'->0->'writeTimestamp'->>'wallTime'"
+			indexName = "index_created_in_test_declarative"
+			sqlDB.Exec(t, "SET use_declarative_schema_changer='on'")
+		}
+		sqlDB.Exec(t, "DROP TABLE IF EXISTS t.test")
+		sqlDB.Exec(t, `CREATE TABLE t.test (k INT PRIMARY KEY, v INT, pi DECIMAL DEFAULT (DECIMAL '3.14'))`)
+		sqlDB.Exec(t, `INSERT INTO t.test VALUES (1, 1)`)
 
-	got := sqlDB.QueryStr(t, `
-		SELECT p->'schemaChange'->'writeTimestamp'->>'wallTime' < $1, jsonb_pretty(p)
+		shouldRunGC.Store(true)
+		if _, err := db.Exec(
+			fmt.Sprintf(`CREATE UNIQUE INDEX %s ON t.test (v)`, indexName),
+		); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := sqltestutils.CheckTableKeyCount(context.Background(), kvDB, codec, 2, 0); err != nil {
+			t.Fatal(err)
+		}
+
+		got := sqlDB.QueryStr(t, fmt.Sprintf(`
+		SELECT %s < $1, jsonb_pretty(p)
 		FROM (SELECT crdb_internal.pb_to_json('cockroach.sql.jobs.jobspb.Payload', payload) AS p FROM crdb_internal.system_jobs)
-		WHERE p->>'description' LIKE 'CREATE UNIQUE INDEX index_created_in_test%'`,
-		gcAt.WallTime,
-	)[0]
-	if got[0] != "true" {
-		t.Fatalf("expected write-ts < gc time. details: %s", got[1])
-	}
+		WHERE p->>'description' LIKE 'CREATE UNIQUE INDEX %s%%'`, writeTSFromJob, indexName),
+			gcAt.WallTime,
+		)[0]
+		if got[0] != "true" {
+			t.Fatalf("expected write-ts < gc time (%d). details: %s", gcAt.WallTime, got[1])
+		}
+
+	})
 }
 
 // TestAddComputedColumn verifies that while a column backfill is happening

--- a/pkg/sql/schemachanger/scexec/exec_backfill.go
+++ b/pkg/sql/schemachanger/scexec/exec_backfill.go
@@ -44,23 +44,6 @@ func executeBackfillOps(ctx context.Context, deps Dependencies, execute []scop.O
 		if errors.HasType(err, (*kvpb.InsufficientSpaceError)(nil)) {
 			return jobs.MarkPauseRequestError(errors.UnwrapAll(err))
 		}
-		if errors.HasType(err, (*kvpb.BatchTimestampBeforeGCError)(nil)) {
-			// We will not ever move the timestamp forward so this will fail forever.
-			// Mark as a permanent error.
-			if scerrors.HasSchemaChangerUserError(err) {
-				// We need to unwrap this so that the PermanentJobError is marked
-				// at the correct level.
-				err = scerrors.UnwrapSchemaChangerUserError(err)
-			}
-			return scerrors.SchemaChangerUserError(
-				jobs.MarkAsPermanentJobError(
-					errors.Wrap(
-						err,
-						"unable to retry backfill since fixed timestamp is before the GC timestamp",
-					),
-				),
-			)
-		}
 		return err
 	}
 	return nil


### PR DESCRIPTION
Backport 4/4 commits from #143451.

/cc @cockroachdb/release

Release justification: fix undesirable behavior that was backported to 25.1 (https://github.com/cockroachdb/cockroach/pull/139251)

---

### sql,rowexec: use WriteTS as timestamp for AddSSTable in backfill

PR cockroachdb#64023 made it so we use the backfill's read TS as the batch TS for
the AddSSTable operation. Simultaneously with that change, cockroachdb#63945 was
being worked on, which made it so that we use a fixed _write_ timestamp
for the keys that are backfilled. This write timestamp is the actual
minimum lower bound timestamp for the backfill operation, and the read
timstamp is allowed to change, so it makes more sense to use the write
timestamp for the AddSSTable operation. Looking at the diffs in the PRs
makes it seem pretty likely that this was just missed as part of a
trivial branch skew.

This commit does not cause any behavior change, since at the time of
writing, the read timestamp and write timestamp are always identical for
the backfill.

Release note: None

### sql,backfill: choose new read timestamp when backfill job is resumed

When cockroachdb#73861 got merged, we seem to have accidentally made it so the index
backfiller will never select a new read timestamp. That is contrary to
the goals of cockroachdb#63945, where we initially added the ability to advance the
read timestamp forward.

This mistake is why we were seeing behavior where a GC threshold error
would cause the backfill to retry infinitely (which in turn led us to treat
as a permanent error in cockroachdb#139203, which was something we never should have
done). We never noticed the bug because when CREATE INDEX was added to the
declarative schema changer in cockroachdb#92128, we turned off the declarative schema
changer in the test that would have caught this (i.e. TestIndexBackfillAfterGC).

This commit makes it so we choose a current timestamp as the read
timestamp when planning the backfill, and fixes up that test to show
that this works for index backfills in the declarative schema changer.

Release note (bug fix): Fixed a bug where a GC threshold error (which
appears as "batch timestamp must be after replica GC threshold ...")
could cause a schema change that backfills data to fail. Now, the error
will cause the backfill to be retried at a higher timestamp to avoid the
error.

### sql, backfill: use a current timestamp to scan each chunk of the source index

There's no need for the backfill to use a fixed read timestamp for the
entire job. Instead, each chunk of the original index that needs to be
scanned can use a current timestamp. This allows us to remove all the
logic for adding protected timestamps for the backfill.

Release note (performance improvement): Schema changes that require
data to be backfilled no longer hold a protected timestamp for the
entire duration of the backfill, which means there is less overhead
caused by MVCC garbage collection after the backfill completes.

### sql: stop setting readAsOf in index backfiller

As of the parent commit, this is unused by the index backfiller.

Release note: None

---

fixes https://github.com/cockroachdb/cockroach/issues/140629
informs https://github.com/cockroachdb/cockroach/issues/142339
informs https://github.com/cockroachdb/cockroach/issues/142117
informs https://github.com/cockroachdb/cockroach/issues/141773
