### PR TITLE
kvserver: use correct tracer in a test

### DIFF
--- a/pkg/kv/kvserver/client_replica_test.go
+++ b/pkg/kv/kvserver/client_replica_test.go
@@ -1022,7 +1022,7 @@ func TestTxnReadWithinUncertaintyIntervalAfterRangeMerge(t *testing.T) {
 		// Write the data from a different transaction to establish the time for the
 		// key as 10 ns in the future.
 		{
-			ctx, fagrs := tracing.ContextWithRecordingSpan(ctx, tc.Servers[0].Tracer(), "keyC-write")
+			ctx, fagrs := tracing.ContextWithRecordingSpan(ctx, tc.Servers[2].Tracer(), "keyC-write")
 			resp, pErr := kv.SendWrapped(ctx, tc.Servers[2].DistSenderI().(kv.Sender), putArgs(keyC, []byte("value")))
 			rec := fagrs()
 			require.Nil(t, pErr, "%v", rec)
@@ -1042,7 +1042,7 @@ func TestTxnReadWithinUncertaintyIntervalAfterRangeMerge(t *testing.T) {
 
 		// Simulate a read which will cause the observed time to be set to now.
 		{
-			ctx, fagrs := tracing.ContextWithRecordingSpan(ctx, tc.Servers[0].Tracer(), "txn1-keyA-get")
+			ctx, fagrs := tracing.ContextWithRecordingSpan(ctx, tc.Servers[1].Tracer(), "txn1-keyA-get")
 			resp, pErr := kv.SendWrappedWith(ctx, tc.Servers[1].DistSenderI().(kv.Sender), kvpb.Header{Txn: &txn}, getArgs(keyA))
 			rec := fagrs()
 			require.Nil(t, pErr, "%v", rec)


### PR DESCRIPTION
Fixes #143270, which would previously crash ~immediately under stress.

Epic: none
Release note: None