### PR TITLE
wip: very crude prototype of "compiled plans" + pkLookup planNode + new execution path

### DIFF
--- a/pkg/kv/kvclient/kvcoord/txn_coord_sender.go
+++ b/pkg/kv/kvclient/kvcoord/txn_coord_sender.go
@@ -235,7 +235,7 @@ func newRootTxnCoordSender(
 		log.Fatalf(context.TODO(), "cannot initialize root txn with seq != 0: %s", txn)
 	}
 
-	tcs := &TxnCoordSender{
+	tcs := &TxnCoordSender{ // TODO: 0.7% of allocations
 		typ:                   kv.RootTxn,
 		TxnCoordSenderFactory: tcf,
 	}

--- a/pkg/kv/txn.go
+++ b/pkg/kv/txn.go
@@ -222,7 +222,7 @@ func NewTxnFromProto(
 		proto.UpdateObservedTimestamp(gatewayNodeID, now)
 	}
 
-	txn := &Txn{db: db, typ: typ, gatewayNodeID: gatewayNodeID}
+	txn := &Txn{db: db, typ: typ, gatewayNodeID: gatewayNodeID} // TODO: 0.7% of allocations.
 	txn.mu.ID = proto.ID
 	txn.mu.userPriority = roachpb.NormalUserPriority
 	txn.mu.sender = db.factory.RootTransactionalSender(proto, txn.mu.userPriority)
@@ -866,7 +866,7 @@ func (txn *Txn) commit(ctx context.Context) error {
 	// will be subject to admission control, and the zero CreateTime will give
 	// it preference within the tenant.
 	et := endTxnReq(true, txn.deadline())
-	ba := &kvpb.BatchRequest{Requests: et.unionArr[:]}
+	ba := &kvpb.BatchRequest{Requests: et.unionArr[:]} // TODO: This is 0.6% of allocations
 	_, pErr := txn.Send(ctx, ba)
 	return pErr.GoError()
 }
@@ -1088,7 +1088,7 @@ type endTxnReqAlloc struct {
 }
 
 func endTxnReq(commit bool, deadline hlc.Timestamp) *endTxnReqAlloc {
-	alloc := new(endTxnReqAlloc)
+	alloc := new(endTxnReqAlloc) // TODO: This is 0.7% of allocations.
 	alloc.req.Commit = commit
 	alloc.req.Deadline = deadline
 	alloc.union.EndTxn = &alloc.req

--- a/pkg/roachpb/data.go
+++ b/pkg/roachpb/data.go
@@ -1601,7 +1601,7 @@ func (t *Transaction) UpdateObservedTimestamp(nodeID NodeID, timestamp hlc.Clock
 	// Fast path optimization for either no observed timestamps or
 	// exactly one, for the same nodeID as we're updating.
 	if l := len(t.ObservedTimestamps); l == 0 {
-		t.ObservedTimestamps = []ObservedTimestamp{{NodeID: nodeID, Timestamp: timestamp}}
+		t.ObservedTimestamps = []ObservedTimestamp{{NodeID: nodeID, Timestamp: timestamp}} // TODO: 0.6% of allocations
 		return
 	} else if l == 1 && t.ObservedTimestamps[0].NodeID == nodeID {
 		if timestamp.Less(t.ObservedTimestamps[0].Timestamp) {

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -2856,7 +2856,7 @@ func (ex *connExecutor) setTxnRewindPos(ctx context.Context, pos CmdPos) error {
 	ex.extraTxnState.txnRewindPos = pos
 	ex.stmtBuf.Ltrim(ctx, pos)
 	ex.extraTxnState.rewindPosSnapshot.savepoints = ex.extraTxnState.savepoints.clone()
-	ex.extraTxnState.rewindPosSnapshot.sessionDataStack = ex.sessionDataStack.Clone()
+	ex.extraTxnState.rewindPosSnapshot.sessionDataStack = ex.sessionDataStack.Clone() // TODO: This is indirectly 7% of allocations.
 	return ex.commitPrepStmtNamespace(ctx)
 }
 
@@ -4786,7 +4786,7 @@ func withPlanGist(ctx context.Context, gist string) context.Context {
 	if gist == "" {
 		return ctx
 	}
-	return ctxutil.WithFastValue(ctx, contextPlanGistKey, gist)
+	return ctxutil.WithFastValue(ctx, contextPlanGistKey, gist) // TODO: This is 1.5% of allocations, some here (I think to box gist) and some indirectly.
 }
 
 func planGistFromCtx(ctx context.Context) string {

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -3525,7 +3525,7 @@ func (ex *connExecutor) beginTransactionTimestampsAndReadMode(
 		if ex.executorType == executorTypeExec {
 			// Check if a PCR reader catalog timestamp is set, which
 			// will cause to turn all txns into system time queries.
-			if newTS := ex.GetPCRReaderTimestamp(); !newTS.IsEmpty() {
+			if newTS := ex.GetPCRReaderTimestamp(); !newTS.IsEmpty() { // TODO: This is 0.7% of allocations.
 				return tree.ReadOnly, now, &newTS, nil
 			}
 		}
@@ -3681,12 +3681,12 @@ func (ex *connExecutor) beginImplicitTxn(
 	// an AOST clause. In these cases the clause is evaluated and applied
 	// when the command is evaluated again.
 	noBeginStmt := (*tree.BeginTransaction)(nil)
-	mode, sqlTs, historicalTs, err := ex.beginTransactionTimestampsAndReadMode(ctx, noBeginStmt)
+	mode, sqlTs, historicalTs, err := ex.beginTransactionTimestampsAndReadMode(ctx, noBeginStmt) // TODO: This is 1.5% of allocations.
 	if err != nil {
 		return ex.makeErrEvent(err, ast)
 	}
 	return eventStartImplicitTxn,
-		makeEventTxnStartPayload(
+		makeEventTxnStartPayload( // TODO: This is 0.7% of allocations (somewhere in this return expression).
 			ex.txnPriorityWithSessionDefault(tree.UnspecifiedUserPriority),
 			mode,
 			sqlTs,

--- a/pkg/sql/distsql_spec_exec_factory.go
+++ b/pkg/sql/distsql_spec_exec_factory.go
@@ -80,6 +80,27 @@ func newDistSQLSpecExecFactory(
 	return e
 }
 
+// Ctx implements the Factory interface.
+func (e *distSQLSpecExecFactory) Ctx() context.Context {
+	return e.ctx
+}
+
+// EnableCompilation implements the Factory interface.
+func (e *distSQLSpecExecFactory) EnableCompilation() {}
+
+// DisableCompilation implements the Factory interface.
+func (e *distSQLSpecExecFactory) DisableCompilation() {}
+
+// Compiled implements the Factory interface.
+func (e *distSQLSpecExecFactory) Compiled() exec.CompiledPlan {
+	return nil
+}
+
+// CompiledPlan implements the Factory interface.
+func (e *distSQLSpecExecFactory) CompiledPlan() exec.Node {
+	return nil
+}
+
 func (e *distSQLSpecExecFactory) getPlanCtx(recommendation distRecommendation) *PlanningCtx {
 	distribute := false
 	if e.singleTenant && e.planningMode != distSQLLocalOnlyPlanning {
@@ -360,9 +381,107 @@ func (e *distSQLSpecExecFactory) ConstructScan(
 	return makePlanMaybePhysical(p, nil /* planNodesToClose */), err
 }
 
-// Ctx implements the Factory interface.
-func (e *distSQLSpecExecFactory) Ctx() context.Context {
-	return e.ctx
+// ConstructPlaceholderScan implements exec.Factory interface by combining the
+// logic that performs scanNode creation of execFactory.ConstructScan and
+// physical planning of table readers of DistSQLPlanner.createTableReaders.
+func (e *distSQLSpecExecFactory) ConstructPlaceholderScan(
+	table cat.Table, index cat.Index, params exec.PlaceholderScanParams,
+) (exec.Node, error) {
+	if table.IsVirtualTable() {
+		// TODO: Assertion failure.
+	}
+
+	// Although we don't yet recommend distributing plans where soft limits
+	// propagate to scan nodes because we don't have infrastructure to only
+	// plan for a few ranges at a time, the propagation of the soft limits
+	// to scan nodes has been added in 20.1 release, so to keep the
+	// previous behavior we continue to ignore the soft limits for now.
+	// TODO(yuzefovich): pay attention to the soft limits.
+	recommendation := canDistribute
+	planCtx := e.getPlanCtx(recommendation)
+	p := planCtx.NewPhysicalPlan()
+
+	// Phase 1: set up all necessary infrastructure for table reader planning
+	// below. This phase is equivalent to what execFactory.ConstructScan does.
+	tabDesc := table.(*optTable).desc
+	idx := index.(*optIndex).idx
+	// colCfg := makeScanColumnsConfig(table, params.NeededCols)
+
+	var sb span.Builder
+	sb.InitAllowingExternalRowData(e.planner.EvalContext(), e.planner.ExecCfg().Codec, tabDesc, idx)
+
+	cols := make([]catalog.Column, 0, params.NeededCols.Len())
+	allCols := tabDesc.AllColumns()
+	for ord, ok := params.NeededCols.Next(0); ok; ord, ok = params.NeededCols.Next(ord + 1) {
+		cols = append(cols, allCols[ord])
+	}
+	columnIDs := make([]descpb.ColumnID, len(cols))
+	for i := range cols {
+		columnIDs[i] = cols[i].GetID()
+	}
+
+	p.ResultColumns = colinfo.ResultColumnsFromColumns(tabDesc.GetID(), cols)
+
+	var c constraint.Constraint
+	params.InitConstraint(e.ctx, e.planner.EvalContext(), &c)
+
+	var spans roachpb.Spans
+	var err error
+	splitter := span.MakeSplitter(tabDesc, idx, params.NeededCols)
+	spans, err = sb.SpansFromConstraint(&c, splitter)
+	if err != nil {
+		return nil, err
+	}
+
+	// Phase 2: perform the table reader planning. This phase is equivalent to
+	// what DistSQLPlanner.createTableReaders does.
+	trSpec := physicalplan.NewTableReaderSpec()
+	*trSpec = execinfrapb.TableReaderSpec{
+		Reverse:                         false,
+		TableDescriptorModificationTime: tabDesc.GetModificationTime(),
+	}
+	if err := rowenc.InitIndexFetchSpec(&trSpec.FetchSpec, e.planner.ExecCfg().Codec, tabDesc, idx, columnIDs); err != nil {
+		return nil, err
+	}
+	// trSpec.LockingStrength = descpb.ToScanLockingStrength(params.Locking.Strength)
+	// trSpec.LockingWaitPolicy = descpb.ToScanLockingWaitPolicy(params.Locking.WaitPolicy)
+	// trSpec.LockingDurability = descpb.ToScanLockingDurability(params.Locking.Durability)
+	// if trSpec.LockingStrength != descpb.ScanLockingStrength_FOR_NONE {
+	// 	// Scans that are performing row-level locking cannot currently be
+	// 	// distributed because their locks would not be propagated back to
+	// 	// the root transaction coordinator.
+	// 	// TODO(nvanbenschoten): lift this restriction.
+	// 	recommendation = cannotDistribute
+	// }
+
+	// Note that we don't do anything about the possible filter here since we
+	// don't know yet whether we will have it. ConstructFilter is responsible
+	// for pushing the filter down into the post-processing stage of this scan.
+	post := execinfrapb.PostProcessSpec{}
+	// if params.HardLimit != 0 {
+	// 	post.Limit = uint64(params.HardLimit)
+	// } else if params.SoftLimit != 0 {
+	// 	trSpec.LimitHint = params.SoftLimit
+	// }
+
+	err = e.dsp.planTableReaders(
+		e.ctx,
+		e.getPlanCtx(recommendation),
+		p,
+		&tableReaderPlanningInfo{
+			spec:        trSpec,
+			post:        post,
+			desc:        tabDesc,
+			spans:       spans,
+			reverse:     false,
+			parallelize: false,
+			// TODO: Need estimated row count.
+			// estimatedRowCount: params.EstimatedRowCount,
+			reqOrdering: nil,
+		},
+	)
+
+	return makePlanMaybePhysical(p, nil /* planNodesToClose */), err
 }
 
 // checkExprsAndMaybeMergeLastStage is a helper method that returns a
@@ -1296,7 +1415,7 @@ func (e *distSQLSpecExecFactory) ConstructPlan(
 	} else {
 		p.physPlan.onClose = e.planCtx.getCleanupFunc()
 	}
-	return constructPlan(e.planner, root, subqueries, cascades, triggers, checks, rootRowCount, flags)
+	return constructPlan(root, subqueries, cascades, triggers, checks, rootRowCount, flags)
 }
 
 func (e *distSQLSpecExecFactory) ConstructExplainOpt(

--- a/pkg/sql/exec_factory_util.go
+++ b/pkg/sql/exec_factory_util.go
@@ -21,7 +21,6 @@ import (
 )
 
 func constructPlan(
-	planner *planner,
 	root exec.Node,
 	subqueries []exec.Subquery,
 	cascades, triggers []exec.PostQuery,

--- a/pkg/sql/opt/exec/BUILD.bazel
+++ b/pkg/sql/opt/exec/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
     deps = [
         "//pkg/sql/catalog/colinfo",
         "//pkg/sql/catalog/descpb",  # keep
+        "//pkg/sql/idxusage",
         "//pkg/sql/inverted",
         "//pkg/sql/opt",  # keep
         "//pkg/sql/opt/cat",
@@ -21,6 +22,7 @@ go_library(
         "//pkg/sql/types",
         "//pkg/util/intsets",
         "//pkg/util/optional",
+        "@com_github_cockroachdb_errors//:errors",
     ],
 )
 

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -32,7 +32,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/builtins/builtinsregistry"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/catconstants"
-	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/idxtype"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree/treewindow"
@@ -973,7 +972,7 @@ func (b *Builder) buildPlaceholderScan(
 	scan *memo.PlaceholderScanExpr,
 ) (_ execPlan, outputCols colOrdMap, err error) {
 	if scan.Constraint != nil || scan.InvertedConstraint != nil {
-		return execPlan{}, colOrdMap{}, errors.AssertionFailedf("PlaceholderScan cannot have constraints")
+		return execPlan{}, colOrdMap{}, errors.AssertionFailedf("placeholder scan cannot have constraints")
 	}
 
 	md := b.mem.Metadata()
@@ -990,48 +989,36 @@ func (b *Builder) buildPlaceholderScan(
 	}
 	var columns constraint.Columns
 	columns.Init(spanColumns)
-	keyCtx := constraint.MakeKeyContext(b.ctx, &columns, b.evalCtx)
 
-	values := make([]tree.Datum, len(scan.Span))
+	values := make([]tree.TypedExpr, len(scan.Span))
 	for i, expr := range scan.Span {
 		// The expression is either a placeholder or a constant.
 		if p, ok := expr.(*memo.PlaceholderExpr); ok {
-			val, err := eval.Expr(b.ctx, b.evalCtx, p.Value)
-			if err != nil {
-				return execPlan{}, colOrdMap{}, err
-			}
-			values[i] = val
+			values[i] = p.Value
 		} else {
 			values[i] = memo.ExtractConstDatum(expr)
 		}
 	}
-
-	key := constraint.MakeCompositeKey(values...)
-	var span constraint.Span
-	span.Init(key, constraint.IncludeBoundary, key, constraint.IncludeBoundary)
-	var spans constraint.Spans
-	spans.InitSingleSpan(&span)
-
-	var c constraint.Constraint
-	c.Init(&keyCtx, &spans)
-
-	private := scan.ScanPrivate
-	private.SetConstraint(b.ctx, b.evalCtx, &c)
+	pkPointLookup := idx.Ordinal() == cat.PrimaryIndex && len(values) == idx.KeyColumnCount()
 
 	var params exec.ScanParams
-	params, outputCols, err = b.scanParams(tab, &private, scan.Relational(), scan.RequiredPhysical())
+	params, outputCols, err = b.scanParams(tab, &scan.ScanPrivate, scan.Relational(), scan.RequiredPhysical())
 	if err != nil {
 		return execPlan{}, colOrdMap{}, err
 	}
-	reqOrdering, err := reqOrdering(scan, outputCols)
-	if err != nil {
-		return execPlan{}, colOrdMap{}, err
+	if !scan.ProvidedPhysical().Ordering.Empty() {
+		return execPlan{}, colOrdMap{},
+			errors.AssertionFailedf("placeholder scan does not support required orderings")
 	}
-	root, err := b.factory.ConstructScan(
+	root, err := b.factory.ConstructPlaceholderScan(
 		tab,
 		tab.Index(scan.Index),
-		params,
-		reqOrdering,
+		exec.PlaceholderScanParams{
+			NeededCols:    params.NeededCols,
+			SpanValues:    values,
+			SpanColumns:   columns,
+			PKPointLookup: pkPointLookup,
+		},
 	)
 	if err != nil {
 		return execPlan{}, colOrdMap{}, err

--- a/pkg/sql/opt/exec/explain/emit.go
+++ b/pkg/sql/opt/exec/explain/emit.go
@@ -294,6 +294,9 @@ func (e *emitter) nodeName(n *Node) (name string, _ error) {
 		}
 		return "scan", nil
 
+	case placeholderScanOp:
+		return "placeholder-scan", nil
+
 	case valuesOp:
 		a := n.args.(*valuesArgs)
 		switch {
@@ -717,6 +720,10 @@ func (e *emitter) emitNodeAttributes(ctx context.Context, evalCtx *eval.Context,
 		}
 		e.emitLockingPolicy(a.Params.Locking)
 		e.emitPolicies(ob, a.Table, n)
+
+	case placeholderScanOp:
+		// a := n.args.(*placeholderScanArgs)
+		e.emitPolicies(ob, nil, n)
 
 	case valuesOp:
 		a := n.args.(*valuesArgs)

--- a/pkg/sql/opt/exec/explain/explain_factory.go
+++ b/pkg/sql/opt/exec/explain/explain_factory.go
@@ -34,6 +34,22 @@ func (f *Factory) Ctx() context.Context {
 	return f.wrappedFactory.Ctx()
 }
 
+// EnableCompilation implements the Factory interface.
+func (f *Factory) EnableCompilation() {}
+
+// DisableCompilation implements the Factory interface.
+func (f *Factory) DisableCompilation() {}
+
+// Compiled implements the Factory interface.
+func (f *Factory) Compiled() exec.CompiledPlan {
+	return nil
+}
+
+// CompiledPlan implements the Factory interface.
+func (f *Factory) CompiledPlan() exec.Node {
+	return nil
+}
+
 // Node in a plan tree; records the operation and arguments passed to the
 // factory method and provides access to the corresponding exec.Node (produced
 // by the wrapped factory).

--- a/pkg/sql/opt/exec/explain/plan_gist_factory.go
+++ b/pkg/sql/opt/exec/explain/plan_gist_factory.go
@@ -34,7 +34,8 @@ import (
 )
 
 func init() {
-	if numOperators != 65 {
+	// TODO
+	if numOperators != 66 {
 		// This error occurs when an operator has been added or removed in
 		// pkg/sql/opt/exec/explain/factory.opt. If an operator is added at the
 		// end of factory.opt, simply adjust the hardcoded value above. If an
@@ -105,6 +106,26 @@ var _ exec.Factory = &PlanGistFactory{}
 // Ctx implements the Factory interface.
 func (f *PlanGistFactory) Ctx() context.Context {
 	return f.wrappedFactory.Ctx()
+}
+
+// EnableCompilation implements the Factory interface.
+func (f *PlanGistFactory) EnableCompilation() {
+	f.wrappedFactory.EnableCompilation()
+}
+
+// DisableCompilation implements the Factory interface.
+func (f *PlanGistFactory) DisableCompilation() {
+	f.wrappedFactory.DisableCompilation()
+}
+
+// Compiled implements the Factory interface.
+func (f *PlanGistFactory) Compiled() exec.CompiledPlan {
+	return f.wrappedFactory.Compiled()
+}
+
+// CompiledPlan implements the Factory interface.
+func (f *PlanGistFactory) CompiledPlan() exec.Node {
+	return f.wrappedFactory.CompiledPlan()
 }
 
 // writeAndHash writes an arbitrary slice of bytes to the buffer and hashes each

--- a/pkg/sql/opt/exec/explain/result_columns.go
+++ b/pkg/sql/opt/exec/explain/result_columns.go
@@ -62,6 +62,10 @@ func getResultColumns(
 		a := args.(*scanArgs)
 		return tableColumns(a.Table, a.Params.NeededCols), nil
 
+	case placeholderScanOp:
+		a := args.(*placeholderScanArgs)
+		return tableColumns(a.Table, a.Params.NeededCols), nil
+
 	case indexJoinOp:
 		a := args.(*indexJoinArgs)
 		return tableColumns(a.Table, a.TableCols), nil

--- a/pkg/sql/opt/exec/factory.go
+++ b/pkg/sql/opt/exec/factory.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
+	"github.com/cockroachdb/cockroach/pkg/sql/idxusage"
 	"github.com/cockroachdb/cockroach/pkg/sql/inverted"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
@@ -20,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/intsets"
 	"github.com/cockroachdb/cockroach/pkg/util/optional"
+	"github.com/cockroachdb/errors"
 )
 
 // Node represents a node in the execution tree
@@ -107,6 +109,28 @@ func (pf *PlanFlags) Unset(flags PlanFlags) {
 	*pf &^= flags
 }
 
+type Factory interface {
+	factory
+
+	EnableCompilation()
+	DisableCompilation()
+
+	Compiled() CompiledPlan
+	CompiledPlan() Node
+}
+
+type CompiledPlan func(
+	context.Context,
+	*eval.Context,
+	*idxusage.LocalIndexUsageStats,
+) (Plan, error)
+
+var FailedCompiledPlan CompiledPlan = func(
+	context.Context, *eval.Context, *idxusage.LocalIndexUsageStats,
+) (Plan, error) {
+	return nil, nil
+}
+
 // ScanParams contains all the parameters for a table scan.
 type ScanParams struct {
 	// Only columns in this set are scanned and produced.
@@ -144,6 +168,69 @@ type ScanParams struct {
 	// to work correctly, the execution engine must create a local DistSQL plan
 	// for the main query (subqueries and postqueries need not be local).
 	LocalityOptimized bool
+}
+
+// PlaceholderScanParams contains all the parameters for a placeholder scan.
+type PlaceholderScanParams struct {
+	// Only columns in this set are scanned and produced.
+	NeededCols TableColumnOrdinalSet
+
+	// SpanValues TODO
+	SpanValues []tree.TypedExpr
+	// SpanColumns TODO
+	SpanColumns constraint.Columns
+
+	PKPointLookup bool
+
+	// If non-zero, the scan returns this many rows.
+	// HardLimit int64
+
+	// If non-zero, the scan may still be required to return up to all its rows
+	// (or up to the HardLimit if it is set, but can be optimized under the
+	// assumption that only SoftLimit rows will be needed.
+	// SoftLimit int64
+
+	// Row-level locking properties.
+	// TODO: Might need this...
+	// Locking opt.Locking
+
+	// EstimatedRowCount, if set, is the estimated number of rows that will be
+	// scanned, rounded up.
+	// TODO: Might need this.
+	// EstimatedRowCount uint64
+}
+
+// InitConstraint initializes a constraint based on the placeholder parameters.
+// Any placeholders in the Span are evaluated into datums.
+func (params *PlaceholderScanParams) InitConstraint(
+	ctx context.Context, evalCtx *eval.Context, c *constraint.Constraint,
+) error {
+	keyCtx := constraint.MakeKeyContext(ctx, &params.SpanColumns, evalCtx)
+
+	values := make([]tree.Datum, len(params.SpanValues))
+	for i, expr := range params.SpanValues {
+		// The expression is either a placeholder or a constant.
+		switch e := expr.(type) {
+		case *tree.Placeholder:
+			val, err := eval.Expr(ctx, evalCtx, e)
+			if err != nil {
+				return err
+			}
+			values[i] = val
+		case tree.Datum:
+			values[i] = e
+		default:
+			return errors.AssertionFailedf("invalid span value type: %T", e)
+		}
+	}
+
+	key := constraint.MakeCompositeKey(values...)
+	var sp constraint.Span
+	sp.Init(key, constraint.IncludeBoundary, key, constraint.IncludeBoundary)
+	var spans constraint.Spans
+	spans.InitSingleSpan(&sp)
+	c.Init(&keyCtx, &spans)
+	return nil
 }
 
 // OutputOrdering indicates the required output ordering on a Node that is being
@@ -615,3 +702,19 @@ const (
 	// NumScanCountTypes is the total number of types of counts of scans.
 	NumScanCountTypes
 )
+
+// EnableCompilation implements the Factory interface.
+func (f StubFactory) EnableCompilation() {}
+
+// DisableCompilation implements the Factory interface.
+func (f StubFactory) DisableCompilation() {}
+
+// Compiled implements the Factory interface.
+func (f StubFactory) Compiled() CompiledPlan {
+	return nil
+}
+
+// CompiledPlan implements the Factory interface.
+func (f StubFactory) CompiledPlan() Node {
+	return nil
+}

--- a/pkg/sql/opt/exec/factory.opt
+++ b/pkg/sql/opt/exec/factory.opt
@@ -7,6 +7,16 @@ define Scan {
     ReqOrdering exec.OutputOrdering
 }
 
+# PlaceholderScan runs a constrained scan of a specified index of a table with
+# some placeholders that are not known during optimization. Span contains a
+# constant datums and placeholders the correspond to a prefix of the index key
+# columns.
+define PlaceholderScan {
+    Table cat.Table
+    Index cat.Index
+    Params exec.PlaceholderScanParams
+}
+
 define Values {
     Rows [][]tree.TypedExpr
     Columns colinfo.ResultColumns

--- a/pkg/sql/opt/norm/factory.go
+++ b/pkg/sql/opt/norm/factory.go
@@ -131,7 +131,7 @@ func (f *Factory) Init(ctx context.Context, evalCtx *eval.Context, catalog cat.C
 		mem = &memo.Memo{}
 	}
 	mem.Init(ctx, evalCtx)
-	mem.SetReplacer(func(e opt.Expr, replace memo.ReplaceFunc) opt.Expr {
+	mem.SetReplacer(func(e opt.Expr, replace memo.ReplaceFunc) opt.Expr { // TODO: 1% of allocations. Do we need to do this for every query? Not for generic query plans.
 		return f.Replace(e, ReplaceFunc(replace))
 	})
 

--- a/pkg/sql/opt/optgen/cmd/optgen/exec_factory_gen.go
+++ b/pkg/sql/opt/optgen/cmd/optgen/exec_factory_gen.go
@@ -41,7 +41,7 @@ func (g *execFactoryGen) generate(compiled *lang.CompiledExpr, w io.Writer) {
 }
 
 func (g *execFactoryGen) genExecFactory() {
-	g.w.write("// Factory defines the interface for building an execution plan, which consists\n")
+	g.w.write("// factory defines the interface for building an execution plan, which consists\n")
 	g.w.write("// of a tree of execution nodes (currently a sql.planNode tree).\n")
 	g.w.write("//\n")
 	g.w.write("// The tree is always built bottom-up. The Construct methods either construct\n")
@@ -57,7 +57,7 @@ func (g *execFactoryGen) genExecFactory() {
 	g.w.write("//\n")
 	g.w.write("// The TypedExprs passed to these functions refer to columns of the input node\n")
 	g.w.write("// via IndexedVars.\n")
-	g.w.nest("type Factory interface {\n")
+	g.w.nest("type factory interface {\n")
 	g.w.writeIndent("// ConstructPlan creates a plan enclosing the given plan and (optionally)\n")
 	g.w.writeIndent("// subqueries, cascades, and checks.\n")
 	g.w.writeIndent("//\n")
@@ -109,7 +109,7 @@ func (g *execFactoryGen) genStubFactory() {
 	g.w.write("// StubFactory is a do-nothing implementation of Factory, used for testing.\n")
 	g.w.write("type StubFactory struct{}\n")
 	g.w.write("\n")
-	g.w.write("var _ Factory = StubFactory{}\n")
+	g.w.write("var _ factory = StubFactory{}\n")
 	g.w.write("\n")
 	g.w.nestIndent("func (StubFactory) ConstructPlan(\n")
 	g.w.writeIndent("root Node,\n")

--- a/pkg/sql/opt/xform/optimizer.go
+++ b/pkg/sql/opt/xform/optimizer.go
@@ -126,7 +126,7 @@ func (o *Optimizer) Init(ctx context.Context, evalCtx *eval.Context, catalog cat
 		evalCtx:  evalCtx,
 		catalog:  catalog,
 		f:        o.f,
-		stateMap: make(map[groupStateKey]*groupState),
+		stateMap: make(map[groupStateKey]*groupState), // TODO: 0.7% of allocations. We don't need to do this if we have a generic query plan.
 	}
 	o.cancelChecker.Reset(ctx)
 	o.f.Init(ctx, evalCtx, catalog)

--- a/pkg/sql/opt/xform/rules/generic.opt
+++ b/pkg/sql/opt/xform/rules/generic.opt
@@ -56,3 +56,28 @@
     []
     (OutputCols (Root))
 )
+
+# TODO: For the prototype:
+# 1. Move constraint building to the distsql/exec factory constructors.
+# 2. Build closures over immutable planning data in constructors and reuse them
+#    for PlaceholderScans, Updates, Deletes, maybe others?
+# 3. Benchmark the gains.
+#
+# TODO: For productions:
+# 1. We need to actually cost these PlaceholderScans now. Maybe they can have
+# the same cost as the lookup join, but like a little bit less?
+# TODO: Check for empty on filters here?
+[ConvertParameterizedJoinToPlaceholderScan, Explore]
+(LookupJoin
+    $values:(Values [ (Tuple $row:[ ... ]) ]) &
+        (Let
+            ($span $private $ok):(PlaceholderScanSpanAndPrivate
+                (Root)
+                $values
+                $row
+            )
+            $ok
+        )
+)
+=>
+(PlaceholderScan $span $private)

--- a/pkg/sql/opt/xform/rules/generic.opt
+++ b/pkg/sql/opt/xform/rules/generic.opt
@@ -68,16 +68,24 @@
 # the same cost as the lookup join, but like a little bit less?
 # TODO: Check for empty on filters here?
 [ConvertParameterizedJoinToPlaceholderScan, Explore]
-(LookupJoin
-    $values:(Values [ (Tuple $row:[ ... ]) ]) &
-        (Let
-            ($span $private $ok):(PlaceholderScanSpanAndPrivate
-                (Root)
-                $values
-                $row
+(Project
+    $lookup:(LookupJoin
+        $values:(Values [ (Tuple $row:[ ... ]) ]) &
+            (Let
+                (
+                    $span
+                    $private
+                    $ok
+                ):(PlaceholderScanSpanAndPrivate
+                    $lookup
+                    $values
+                    $row
+                )
+                $ok
             )
-            $ok
-        )
+    )
+    []
+    *
 )
 =>
 (PlaceholderScan $span $private)

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -521,7 +521,9 @@ func canRearrangeRenders(cols []exec.NodeColumnOrdinal, render tree.TypedExprs) 
 func (ef *execFactory) ConstructSerializingProject(
 	n exec.Node, cols []exec.NodeColumnOrdinal, colNames []string,
 ) (exec.Node, error) {
-	ef.compilationUnsupported()
+	// TODO(mgartner): This is a temporary workaround for now. We need to figure
+	// out how to support it in a compiled plan or something else...?
+	// ef.compilationUnsupported()
 
 	node := n.(planNode)
 	// If we are just renaming columns, we can do that in place.

--- a/pkg/sql/plan_columns.go
+++ b/pkg/sql/plan_columns.go
@@ -53,6 +53,8 @@ func getPlanColumns(plan planNode, mut bool) colinfo.ResultColumns {
 		return n.columns
 	case *scanNode:
 		return n.columns
+	case *pkLookup:
+		return n.columns
 	case *unionNode:
 		return n.columns
 	case *valuesNode:

--- a/pkg/sql/plan_opt.go
+++ b/pkg/sql/plan_opt.go
@@ -218,6 +218,8 @@ func (p *planner) prepareUsingOptimizer(
 		return 0, err
 	}
 
+	// a := opc.p.SessionData().ApplicationName == "marcus"
+	// _ = a
 	stmt.Prepared.Columns = resultCols
 	stmt.Prepared.Types = p.semaCtx.Placeholders.Types
 	if opc.allowMemoReuse {
@@ -914,8 +916,8 @@ func (opc *optPlanningCtx) runExecBuilder(
 	var bld *execbuilder.Builder
 	if !planTop.instrumentation.ShouldBuildExplainPlan() {
 		prep := opc.p.stmt.Prepared
-		a := opc.p.SessionData().ApplicationName == "marcus"
-		_ = a
+		// a := opc.p.SessionData().ApplicationName == "marcus"
+		// _ = a
 		isGeneric := prep != nil && prep.GenericMemo == mem
 		if isGeneric && prep.CompiledPlan != nil {
 			// plan, err := prep.CompiledPlan(
@@ -927,7 +929,7 @@ func (opc *optPlanningCtx) runExecBuilder(
 			// result = plan.(*planComponents)
 			opc.p.compiledPlan = prep.CompiledPlan.(planNode)
 		} else {
-			compile := isGeneric && !opc.p.SessionData().Internal
+			compile := isGeneric && !prep.FailedCompilation && !opc.p.SessionData().Internal
 			if compile {
 				f.EnableCompilation()
 			}
@@ -948,6 +950,8 @@ func (opc *optPlanningCtx) runExecBuilder(
 					p := plan.(planNode)
 					prep.CompiledPlan = p
 					opc.p.compiledPlan = p
+				} else {
+					prep.FailedCompilation = true
 				}
 				f.DisableCompilation()
 			}

--- a/pkg/sql/plan_opt.go
+++ b/pkg/sql/plan_opt.go
@@ -346,7 +346,7 @@ func (p *planner) runExecBuild(
 		ctx,
 		&p.curPlan,
 		&p.stmt,
-		newExecFactory(ctx, p),
+		newExecFactory(ctx, p), // TODO: 0.6% of allocations. We don't need to allocate this if we have a pre-compiled plan (see prototype in #143540).
 		execMemo,
 		p.SemaCtx(),
 		p.EvalContext(),
@@ -429,7 +429,7 @@ func (opc *optPlanningCtx) log(ctx context.Context, msg redact.SafeString) {
 	if log.VDepth(1, 1) {
 		log.InfofDepth(ctx, 1, "%s: %s", msg, opc.p.stmt)
 	} else {
-		log.Eventf(ctx, "%s", string(msg))
+		log.Eventf(ctx, "%s", string(msg)) // TODO: 0.7% allocations.
 	}
 }
 

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -258,7 +258,8 @@ type planner struct {
 	// curPlan collects the properties of the current plan being prepared. This state
 	// is undefined at the beginning of the planning of each new statement, and cannot
 	// be reused for an old prepared statement after a new statement has been prepared.
-	curPlan planTop
+	curPlan      planTop
+	compiledPlan planNode
 
 	// Avoid allocations by embedding commonly used objects and visitors.
 	txCtx     transform.ExprTransformContext

--- a/pkg/sql/prep/statement.go
+++ b/pkg/sql/prep/statement.go
@@ -45,7 +45,8 @@ type Statement struct {
 
 	// GenericMemo, if present, is a fully-optimized memo that can be executed
 	// as-is.
-	GenericMemo *memo.Memo
+	GenericMemo  *memo.Memo
+	CompiledPlan any
 
 	// IdealGenericPlan is true if GenericMemo is guaranteed to be optimal
 	// across all executions of the prepared statement. Ideal generic plans are

--- a/pkg/sql/prep/statement.go
+++ b/pkg/sql/prep/statement.go
@@ -45,8 +45,9 @@ type Statement struct {
 
 	// GenericMemo, if present, is a fully-optimized memo that can be executed
 	// as-is.
-	GenericMemo  *memo.Memo
-	CompiledPlan any
+	GenericMemo       *memo.Memo
+	CompiledPlan      any
+	FailedCompilation bool
 
 	// IdealGenericPlan is true if GenericMemo is guaranteed to be optimal
 	// across all executions of the prepared statement. Ideal generic plans are

--- a/pkg/sql/row/fetcher.go
+++ b/pkg/sql/row/fetcher.go
@@ -487,8 +487,8 @@ func (rf *Fetcher) Init(ctx context.Context, args FetcherInitArgs) error {
 		}
 		rf.kvFetcher = args.StreamingKVFetcher
 	} else if !args.WillUseKVProvider {
-		var kvPairsRead int64
-		var batchRequestsIssued int64
+		var kvPairsRead int64         // TODO: Can we eliminate this allocation? ~0.4% of allocations
+		var batchRequestsIssued int64 // TODO: Can we eliminate this allocation? ~0.4% of allocations
 		fetcherArgs := newTxnKVFetcherArgs{
 			reverse:                    args.Reverse,
 			lockStrength:               args.LockStrength,
@@ -509,7 +509,7 @@ func (rf *Fetcher) Init(ctx context.Context, args FetcherInitArgs) error {
 			fetcherArgs.admission.pacerFactory = args.Txn.DB().AdmissionPacerFactory
 			fetcherArgs.admission.settingsValues = args.Txn.DB().SettingsValues()
 		}
-		rf.kvFetcher = newKVFetcher(newTxnKVFetcherInternal(fetcherArgs))
+		rf.kvFetcher = newKVFetcher(newTxnKVFetcherInternal(fetcherArgs)) // TODO: ~1% of allocations. Can we reuse the kv fetcher?
 	}
 
 	return nil

--- a/pkg/sql/sem/tree/annotation.go
+++ b/pkg/sql/sem/tree/annotation.go
@@ -35,7 +35,7 @@ type Annotations []interface{}
 
 // MakeAnnotations allocates an annotations container of the given size.
 func MakeAnnotations(numAnnotations AnnotationIdx) Annotations {
-	return make(Annotations, numAnnotations)
+	return make(Annotations, numAnnotations) // TODO: 0.8% of allocations
 }
 
 // Set an annotation in the container.

--- a/pkg/sql/sessiondata/session_data.go
+++ b/pkg/sql/sessiondata/session_data.go
@@ -61,7 +61,7 @@ func (s *SessionData) Clone() *SessionData {
 	// as all the slices/maps does a copy if it mutates OR are operations that
 	// affect the whole SessionDataStack (e.g. setting SequenceState should be the
 	// setting the same value across all copied SessionData).
-	ret := *s
+	ret := *s // TODO: 2% of allocations
 	ret.CustomOptions = newCustomOptions
 	return &ret
 }
@@ -228,8 +228,8 @@ func NewStack(firstElem *SessionData) *Stack {
 
 // Clone clones the current stack.
 func (s *Stack) Clone() *Stack {
-	ret := &Stack{
-		stack: make([]*SessionData, len(s.stack)),
+	ret := &Stack{ // TODO: 2.5% of allocations
+		stack: make([]*SessionData, len(s.stack)), // TODO: 2.5% of allocations.
 	}
 	for i, st := range s.stack {
 		ret.stack[i] = st.Clone()

--- a/pkg/sql/txn_state.go
+++ b/pkg/sql/txn_state.go
@@ -259,7 +259,7 @@ func (ts *txnState) resetForNewSQLTxn(
 		}
 
 		txnID = ts.mu.txn.ID()
-		sp.SetTag("txn", attribute.StringValue(txnID.String()))
+		sp.SetTag("txn", attribute.StringValue(txnID.String())) // TODO: ~0.9% of allocations to turn txnID into a string.
 		ts.mu.txnStart = crtime.NowMono()
 		ts.mu.autoRetryCounter = 0
 		ts.mu.autoRetryReason = nil


### PR DESCRIPTION
This is a very crude prototype that builds on #143392 to explore the overhead of post-optimization planning and the distsql execution engine (even when disabled). The gist of it is constructing a reusable `planNode`, `pkLookup`, during `PREPARE` and stripping down the execution of it to the bare minimum during `EXECUTE`: building spans, starting a `row.Fetcher`, and adding the decoded row to the result.

There's a fair bit of logic that is avoided in the prototype that we probably can't avoid in order to productionize something like this. **TODO:** Enumerate those things and comment on how much overhead they might add and if they can be sped up.

It's too early to say whether this is a promising path forward. If nothing else, it may be able to help us understand what the speed-of-light is for a PK lookup.

#### TODO

- [ ] Enumerate the missing things (see above).
- [x] Run sysbench micro-benchmarks.
  - [x] oltp_point_select
  - [x] oltp_read_only
  - [x] oltp_read_write
- [x] Benchmark full sysbench.

### Benchmarks

##### BenchmarkEndToEnd/kv-read$/

```
name                                     old time/op    new time/op    delta
EndToEnd/kv-read/vectorize=on/Simple        165µs ± 2%     146µs ± 1%  -11.04%  (p=0.000 n=10+8)
EndToEnd/kv-read/vectorize=on/Prepared      111µs ± 2%      84µs ± 4%  -24.50%  (p=0.000 n=9+10)
EndToEnd/kv-read/vectorize=off/Simple       171µs ± 2%     159µs ± 3%   -6.88%  (p=0.000 n=8+10)
EndToEnd/kv-read/vectorize=off/Prepared     109µs ± 2%      87µs ± 2%  -19.76%  (p=0.000 n=10+10)

name                                     old alloc/op   new alloc/op   delta
EndToEnd/kv-read/vectorize=on/Simple       30.5kB ± 4%    26.9kB ± 4%  -11.75%  (p=0.000 n=9+9)
EndToEnd/kv-read/vectorize=on/Prepared     19.4kB ± 0%    13.1kB ± 8%  -32.19%  (p=0.000 n=8+10)
EndToEnd/kv-read/vectorize=off/Simple      31.8kB ± 8%    26.6kB ± 0%  -16.20%  (p=0.000 n=10+8)
EndToEnd/kv-read/vectorize=off/Prepared    21.1kB ±11%    12.6kB ± 0%  -40.28%  (p=0.000 n=10+8)

name                                     old allocs/op  new allocs/op  delta
EndToEnd/kv-read/vectorize=on/Simple          250 ± 3%       200 ± 3%  -19.87%  (p=0.000 n=9+9)
EndToEnd/kv-read/vectorize=on/Prepared        171 ± 0%        98 ± 4%  -42.40%  (p=0.000 n=9+8)
EndToEnd/kv-read/vectorize=off/Simple         242 ± 0%       199 ± 0%  -17.64%  (p=0.000 n=8+7)
EndToEnd/kv-read/vectorize=off/Prepared       164 ± 1%        98 ± 0%  -40.29%  (p=0.000 n=8+9)
```

#### BenchmarkSysbench/SQL/.*/oltp_point_select

```
name                                         old time/op    new time/op    delta
Sysbench/SQL/1node_local/oltp_point_select      153µs ± 3%     120µs ± 3%  -21.17%  (p=0.000 n=10+10)
Sysbench/SQL/1node_remote/oltp_point_select     175µs ± 1%     144µs ± 3%  -17.78%  (p=0.000 n=10+10)
Sysbench/SQL/3node/oltp_point_select            181µs ± 6%     150µs ± 2%  -17.09%  (p=0.000 n=10+9)

name                                         old alloc/op   new alloc/op   delta
Sysbench/SQL/1node_local/oltp_point_select     23.9kB ± 0%    15.6kB ± 0%  -34.54%  (p=0.000 n=10+10)
Sysbench/SQL/1node_remote/oltp_point_select    26.6kB ± 2%    19.0kB ± 1%  -28.43%  (p=0.000 n=10+9)
Sysbench/SQL/3node/oltp_point_select           26.4kB ± 0%    18.4kB ± 1%  -30.13%  (p=0.000 n=10+10)

name                                         old allocs/op  new allocs/op  delta
Sysbench/SQL/1node_local/oltp_point_select        195 ± 0%       118 ± 1%  -39.33%  (p=0.000 n=8+10)
Sysbench/SQL/1node_remote/oltp_point_select       226 ± 3%       157 ± 1%  -30.48%  (p=0.000 n=10+9)
Sysbench/SQL/3node/oltp_point_select              223 ± 1%       149 ± 1%  -33.26%  (p=0.000 n=10+10)
```

#### BenchmarkParallelSysbench/SQL/3node/oltp_read_only

```
name                                       old time/op    new time/op    delta
ParallelSysbench/SQL/3node/oltp_read_only    2.76ms ± 1%    2.45ms ± 1%  -11.13%  (p=0.008 n=5+5)

name                                       old errs/op    new errs/op    delta
ParallelSysbench/SQL/3node/oltp_read_only      0.00           0.00          ~     (all equal)

name                                       old alloc/op   new alloc/op   delta
ParallelSysbench/SQL/3node/oltp_read_only    1.12MB ± 0%    1.05MB ± 0%   -6.61%  (p=0.008 n=5+5)

name                                       old allocs/op  new allocs/op  delta
ParallelSysbench/SQL/3node/oltp_read_only     4.20k ± 0%     3.48k ± 0%  -16.99%  (p=0.016 n=4+5)
```