### PR TITLE
release-24.3: explain: fix plan gist decoding with nil catalog

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/explain_gist
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain_gist
@@ -199,10 +199,13 @@ SELECT crdb_internal.decode_external_plan_gist('Ag8f')
 
 # Regression test for #130758. Gracefully handle unknown indexes.
 query T nosort
-SELECT crdb_internal.decode_external_plan_gist('AixE')
+SELECT crdb_internal.decode_external_plan_gist('AgICAgYCLNABAgYG')
 ----
 • split
-  index: ?@?
+│ index: ?@?
+│
+└── • values
+      size: 1 column, 1 row
 
 # Regression test for #133015. Gracefully handle decoding negative integers.
 query T
@@ -215,3 +218,61 @@ query T nosort
 SELECT crdb_internal.decode_external_plan_gist('Aj0=':::STRING)
 ----
 • call
+
+# Regression test for hitting an internal error with "external" variant because
+# we didn't consume the table ID.
+query T nosort
+SELECT crdb_internal.decode_external_plan_gist('AgH8/f//nxkAAN6DgICAgDQAAAADAZz9//+fGQAAzgIAAAADCQECAgAAEQUQCw4HEBEGDg==':::STRING);
+----
+• sort
+│ order
+│
+└── • render
+    │
+    └── • group (hash)
+        │ group by: unknownCol-1, unknownCol-1, unknownCol-1, unknownCol-1, unknownCol-1, unknownCol-1, unknownCol-1
+        │
+        └── • sort
+            │ order
+            │
+            └── • hash join (left outer)
+                │ equality: (unknownCol-1) = (unknownCol-1)
+                │
+                ├── • filter
+                │   │
+                │   └── • scan
+                │         table: ?@?
+                │         spans: FULL SCAN
+                │
+                └── • filter
+                    │
+                    └── • scan
+                          table: ?@?
+                          spans: FULL SCAN
+
+query T nosort
+SELECT crdb_internal.decode_plan_gist('AgH8/f//nxkAAN6DgICAgDQAAAADAZz9//+fGQAAzgIAAAADCQECAgAAEQUQCw4HEBEGDg==':::STRING);
+----
+• sort
+│ order
+│
+└── • render
+    │
+    └── • group (hash)
+        │ group by: table_catalog, table_catalog, table_catalog, table_catalog, table_catalog, table_catalog, table_catalog
+        │
+        └── • sort
+            │ order
+            │
+            └── • hash join (left outer)
+                │ equality: (table_catalog) = (constraint_catalog)
+                │
+                ├── • filter
+                │   │
+                │   └── • virtual table
+                │         table: @primary
+                │
+                └── • filter
+                    │
+                    └── • virtual table
+                          table: @primary

--- a/pkg/sql/opt/exec/explain/plan_gist_factory.go
+++ b/pkg/sql/opt/exec/explain/plan_gist_factory.go
@@ -296,10 +296,12 @@ func (f *PlanGistFactory) decodeID() cat.StableID {
 }
 
 func (f *PlanGistFactory) decodeTable() cat.Table {
+	// We need to consume the ID even if we don't have the catalog to actually
+	// decode the table.
+	id := f.decodeID()
 	if f.catalog == nil {
 		return &unknownTable{}
 	}
-	id := f.decodeID()
 	ds, _, err := f.catalog.ResolveDataSourceByID(f.Ctx(), cat.Flags{}, id)
 	if err == nil {
 		return ds.(cat.Table)


### PR DESCRIPTION
Backport 1/1 commits from #143506.

/cc @cockroachdb/release

---

Previously, when catalog wasn't specified during plan gist decoding, we forgot to decode the table ID. This would lead to unexpected remainder of the gist that could result in unexpected behavior, and this is now fixed. Only the "external" variant of decoding is affected, so I decided to not include the release note.

Epic: None
Release note: None

Release justification: low-risk bug fix.