### PR TITLE
backup: skip flaky scheduled compaction test

### DIFF
--- a/pkg/backup/backup_compaction_test.go
+++ b/pkg/backup/backup_compaction_test.go
@@ -462,6 +462,8 @@ func TestScheduledBackupCompaction(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
+	skip.WithIssue(t, 143543, "flaky test")
+
 	ctx := context.Background()
 	th, cleanup := newTestHelper(t)
 	defer cleanup()


### PR DESCRIPTION
Skipping flaky test as per #143543.

Epic: None

Informs: #143543