### PR TITLE
testutilsccl: only test legacy in AlterPrimaryKeyCorrectZoneConfigTest

### DIFF
--- a/pkg/ccl/testutilsccl/BUILD.bazel
+++ b/pkg/ccl/testutilsccl/BUILD.bazel
@@ -17,7 +17,6 @@ go_library(
         "//pkg/sql",
         "//pkg/sql/execinfra",
         "//pkg/sql/sqltestutils",
-        "//pkg/testutils",
         "//pkg/testutils/serverutils",
         "//pkg/testutils/skip",
         "//pkg/util",

--- a/pkg/ccl/testutilsccl/alter_primary_key.go
+++ b/pkg/ccl/testutilsccl/alter_primary_key.go
@@ -18,9 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltestutils"
-	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
-	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/stretchr/testify/require"
 )
@@ -106,29 +104,20 @@ func AlterPrimaryKeyCorrectZoneConfigTest(
 			db = sqlDB
 			defer s.Stopper().Stop(ctx)
 
-			if _, err := sqlDB.Exec(fmt.Sprintf(`
-%s;
-USE t;
-%s
-`, createDBStatement, tc.SetupQuery)); err != nil {
-				t.Fatal(err)
-			}
+			_, err := sqlDB.Exec(fmt.Sprintf(`
+				%s;
+				USE t;
+				%s
+`, createDBStatement, tc.SetupQuery))
+			require.NoError(t, err)
+			_, err = sqlDB.Exec("SET CLUSTER SETTING sql.schema.force_declarative_statements = '!ALTER TABLE';")
+			require.NoError(t, err)
 
 			// Insert some rows so we can interrupt inspect state during backfill.
 			require.NoError(t, sqltestutils.BulkInsertIntoTable(sqlDB, maxValue))
-
-			testutils.RunTrueAndFalse(t, "uses-declarative-for-alter-table",
-				func(t *testing.T, useDeclarativeSchemaChangerForAlter bool) {
-					if useDeclarativeSchemaChangerForAlter {
-						skip.WithIssue(t, 136846)
-					} else {
-						_, err := sqlDB.Exec("SET CLUSTER SETTING sql.schema.force_declarative_statements = '!ALTER TABLE';")
-						require.NoError(t, err)
-					}
-					runCheck = true
-					_, err := sqlDB.Exec(tc.AlterQuery)
-					require.NoError(t, err)
-				})
+			runCheck = true
+			_, err = sqlDB.Exec(tc.AlterQuery)
+			require.NoError(t, err)
 		})
 	}
 


### PR DESCRIPTION
The end to end tests with DML injections we added
in #140617, #139622, #142921 are sufficient.

Epic: none
Fixes: #136846

Release note: None