### PR TITLE
cmd/dev: do not unconditionally regenerate logic tests under crdb_test

### DIFF
--- a/dev
+++ b/dev
@@ -8,7 +8,7 @@ fi
 set -euo pipefail
 
 # Bump this counter to force rebuilding `dev` on all machines.
-DEV_VERSION=110
+DEV_VERSION=111
 
 THIS_DIR=$(cd "$(dirname "$0")" && pwd)
 BINARY_DIR=$THIS_DIR/bin/dev-versions

--- a/pkg/cmd/dev/testdata/datadriven/testlogic
+++ b/pkg/cmd/dev/testdata/datadriven/testlogic
@@ -2,6 +2,7 @@ exec
 dev testlogic
 ----
 bazel info workspace --color=no
+git remote -v
 bazel info workspace --color=no
 bazel run pkg/cmd/generate-logictest -- -out-dir=crdb-checkout
 bazel run //pkg/gen:schemachanger
@@ -11,6 +12,7 @@ exec
 dev testlogic ccl
 ----
 bazel info workspace --color=no
+git remote -v
 bazel info workspace --color=no
 bazel run pkg/cmd/generate-logictest -- -out-dir=crdb-checkout
 bazel run //pkg/gen:schemachanger
@@ -20,6 +22,7 @@ exec
 dev testlogic ccl opt
 ----
 bazel info workspace --color=no
+git remote -v
 bazel info workspace --color=no
 bazel run pkg/cmd/generate-logictest -- -out-dir=crdb-checkout
 bazel run //pkg/gen:schemachanger
@@ -29,6 +32,7 @@ exec
 dev testlogic base --ignore-cache 
 ----
 bazel info workspace --color=no
+git remote -v
 bazel info workspace --color=no
 bazel run pkg/cmd/generate-logictest -- -out-dir=crdb-checkout
 bazel run //pkg/gen:schemachanger
@@ -38,6 +42,7 @@ exec
 dev testlogic base --show-sql
 ----
 bazel info workspace --color=no
+git remote -v
 bazel info workspace --color=no
 bazel run pkg/cmd/generate-logictest -- -out-dir=crdb-checkout
 bazel run //pkg/gen:schemachanger
@@ -47,6 +52,7 @@ exec
 dev testlogic base --files=auto_span_config_reconciliation --stress
 ----
 bazel info workspace --color=no
+git remote -v
 bazel info workspace --color=no
 bazel run pkg/cmd/generate-logictest -- -out-dir=crdb-checkout
 bazel run //pkg/gen:schemachanger
@@ -57,6 +63,7 @@ exec
 dev testlogic base --files=auto_span_config_reconciliation --stress --timeout 1m --cpus 8
 ----
 bazel info workspace --color=no
+git remote -v
 bazel info workspace --color=no
 bazel run pkg/cmd/generate-logictest -- -out-dir=crdb-checkout
 bazel run //pkg/gen:schemachanger
@@ -67,6 +74,7 @@ exec
 dev testlogic base --files=auto_span_config_reconciliation --stress
 ----
 bazel info workspace --color=no
+git remote -v
 bazel info workspace --color=no
 bazel run pkg/cmd/generate-logictest -- -out-dir=crdb-checkout
 bazel run //pkg/gen:schemachanger
@@ -77,6 +85,7 @@ exec
 dev testlogic base --files=auto_span_config_reconciliation --stress
 ----
 bazel info workspace --color=no
+git remote -v
 bazel info workspace --color=no
 bazel run pkg/cmd/generate-logictest -- -out-dir=crdb-checkout
 bazel run //pkg/gen:schemachanger
@@ -87,6 +96,7 @@ exec
 dev testlogic base --files=auto_span_config_reconciliation --stress
 ----
 bazel info workspace --color=no
+git remote -v
 bazel info workspace --color=no
 bazel run pkg/cmd/generate-logictest -- -out-dir=crdb-checkout
 bazel run //pkg/gen:schemachanger

--- a/pkg/cmd/dev/testlogic.go
+++ b/pkg/cmd/dev/testlogic.go
@@ -15,7 +15,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
 	"github.com/spf13/cobra"
 )
 
@@ -292,11 +291,9 @@ func (d *dev) testlogic(cmd *cobra.Command, commandLine []string) error {
 }
 
 // This function determines if any test_logic or execbuilder/testdata files were
-// modified in the current branch, and if so, determines if we should re-generate logic tests.
+// modified in the current branch, and if so, determines if we should
+// re-generate logic tests.
 func (d *dev) shouldGenerateLogicTests(ctx context.Context) bool {
-	if buildutil.CrdbTestBuild {
-		return true
-	}
 	base, _ := d.getMergeBaseHash(ctx)
 	// Generate logic tests if the merge base hash isn't found
 	if base == "" {


### PR DESCRIPTION
I'm not sure why but we used to always regenerate logic tests under `CrdbTestBuild` flag, and this is now removed.

Epic: None
Release note: None