### PR TITLE
vecindex: add non-transactional split of root partitions

### DIFF
--- a/pkg/sql/vecindex/cspann/fixup_split.go
+++ b/pkg/sql/vecindex/cspann/fixup_split.go
@@ -48,8 +48,22 @@ import (
 //     longer visible to searches.
 //  12. Delete the splitting partition from the index.
 //
-// TODO(andyk): Describe the flow for splitting a root partition once it's
-// implemented.
+// Splitting a root partition changes the above flow in the following ways:
+//
+//	a. The root partition does not have a parent, so step #3 is skipped.
+//	b. Similarly, step #5 is skipped.
+//	c. The root partition cannot be removed from its parent and is not deleted,
+//	   so steps #11 and #12 are skipped.
+//	d. Instead, all vectors in the root partition are cleared so that it is
+//	   temporarily empty. Searches can still find these vectors because they
+//	   were copied to the left and right sub-partitions in steps #7 and #9.
+//	   Searches can find the keys of the sub-partitions in the Target fields of
+//	   the root partition metadata.
+//	e. Update the root partition's state to AddingLevel and increase its level
+//	   by one.
+//	f. Add the left sub-partition as a child of the root partition.
+//	g. Add the right sub-partition as a child of the root partition.
+//	h. Update the root partition's state to Ready.
 //
 // The following diagrams show the partition state machines for the split
 // operation:
@@ -106,13 +120,15 @@ func (fw *fixupWorker) splitPartition(
 	}
 
 	if metadata.Level != LeafLevel && partition.Count() == 0 {
-		// Something's terribly wrong, abort and hope that merge can clean this up.
-		return errors.AssertionFailedf(
-			"non-leaf partition %d should not have 0 vectors", partitionKey)
+		if partitionKey != RootKey || metadata.StateDetails.State == ReadyState {
+			// Something's terribly wrong, abort and hope that merge can clean this up.
+			return errors.AssertionFailedf("non-leaf partition %d (state=%s) should not have 0 vectors",
+				partitionKey, metadata.StateDetails.State.String())
+		}
 	}
 
 	log.VEventf(ctx, 2, "splitting partition %d with %d vectors (parent=%d, state=%s)",
-		partitionKey, partition.Count(), parentPartitionKey, metadata.StateDetails.String())
+		partitionKey, parentPartitionKey, partition.Count(), metadata.StateDetails.String())
 
 	// Update partition's state to Splitting.
 	if metadata.StateDetails.State == ReadyState {
@@ -206,9 +222,55 @@ func (fw *fixupWorker) splitPartition(
 			return err
 		}
 
-		// The source partition has been drained, so remove it from its parent
-		// and delete it.
-		err = fw.deletePartition(ctx, parentPartitionKey, partitionKey)
+		// Check whether the splitting partition is the root.
+		if parentPartitionKey != InvalidKey {
+			// The source partition has been drained, so remove it from its parent
+			// and delete it.
+			err = fw.deletePartition(ctx, parentPartitionKey, partitionKey)
+			if err != nil {
+				return err
+			}
+		} else {
+			// This is the root partition, so remove all of its vectors rather than
+			// delete the root partition itself. Note that the vectors have already
+			// been copied to the two target partitions.
+			err = fw.clearPartition(ctx, partitionKey, partition)
+			if err != nil {
+				return err
+			}
+
+			// Increase level by one and move to the AddingLevel state.
+			expected := metadata
+			metadata.Level++
+			metadata.StateDetails = MakeAddingLevelDetails(leftPartitionKey, rightPartitionKey)
+			err = fw.updateMetadata(ctx, partitionKey, metadata, expected)
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	if metadata.StateDetails.State == AddingLevelState {
+		fw.tempChildKey[0] = ChildKey{PartitionKey: leftPartitionKey}
+		fw.tempValueBytes[0] = nil
+		err = fw.addToPartition(ctx, partitionKey,
+			leftMetadata.Centroid.AsSet(), fw.tempChildKey[:1], fw.tempValueBytes[:1], metadata)
+		if err != nil {
+			return err
+		}
+
+		fw.tempChildKey[0] = ChildKey{PartitionKey: rightPartitionKey}
+		fw.tempValueBytes[0] = nil
+		err = fw.addToPartition(ctx, partitionKey,
+			rightMetadata.Centroid.AsSet(), fw.tempChildKey[:1], fw.tempValueBytes[:1], metadata)
+		if err != nil {
+			return err
+		}
+
+		// Move to the Ready state.
+		expected := metadata
+		metadata.StateDetails = MakeReadyDetails()
+		err = fw.updateMetadata(ctx, partitionKey, metadata, expected)
 		if err != nil {
 			return err
 		}
@@ -280,19 +342,53 @@ func (fw *fixupWorker) addToPartition(
 	valueBytes []ValueBytes,
 	expected PartitionMetadata,
 ) error {
+	if !expected.StateDetails.State.AllowAddOrRemove() {
+		return errors.AssertionFailedf("cannot add to partition in state that disallows adds/removes")
+	}
+
 	added, err := fw.index.store.TryAddToPartition(ctx, fw.treeKey, partitionKey,
 		vectors, childKeys, valueBytes, expected)
 	if err != nil {
 		metadata, err := suppressRaceErrors(err)
 		if err == nil {
 			// Another worker raced to update the metadata, so abort.
-			return errors.Wrapf(errFixupAborted, "adding % vectors to partition %d expected %s, found %s",
-				vectors.Count, partitionKey, expected.StateDetails.String(), metadata.StateDetails.String())
+			return errors.Wrapf(errFixupAborted,
+				"adding %d vectors to partition %d expected %s, found %s", vectors.Count, partitionKey,
+				expected.StateDetails.String(), metadata.StateDetails.String())
 		}
 		return errors.Wrap(err, "adding to partition")
 	} else if fw.singleStep && added {
 		return errFixupAborted
 	}
+	return nil
+}
+
+// clearPartition removes all vectors and associated data from the given
+// partition, leaving it empty, on the condition that the partition's state has
+// not changed unexpectedly. If that's the case, it returns errFixupAborted.
+func (fw *fixupWorker) clearPartition(
+	ctx context.Context, partitionKey PartitionKey, partition *Partition,
+) (err error) {
+	if partition.Metadata().StateDetails.State.AllowAddOrRemove() {
+		return errors.AssertionFailedf("cannot clear partition in state that allows adds/removes")
+	}
+
+	// Remove all children in the partition.
+	removed, err := fw.index.store.TryRemoveFromPartition(ctx, fw.treeKey,
+		partitionKey, partition.ChildKeys(), *partition.Metadata())
+	if err != nil {
+		metadata, err := suppressRaceErrors(err)
+		if err == nil {
+			// Another worker raced to update the metadata, so abort.
+			return errors.Wrapf(errFixupAborted,
+				"clearing % vectors from partition, %d expected %s, found %s", partition.Count(),
+				partitionKey, metadata.StateDetails.String(), metadata.StateDetails.String())
+		}
+		return errors.Wrap(err, "clearing vectors")
+	} else if fw.singleStep && removed {
+		return errFixupAborted
+	}
+
 	return nil
 }
 

--- a/pkg/sql/vecindex/cspann/fixup_worker.go
+++ b/pkg/sql/vecindex/cspann/fixup_worker.go
@@ -799,7 +799,7 @@ func (fw *fixupWorker) deleteVector(
 		return nil
 	}
 
-	// If removing from a root partition, check that it's level is LeafLevel. It
+	// If removing from a root partition, check that its level is LeafLevel. It
 	// might not be if it was recently split.
 	if partitionKey == RootKey {
 		metadata, err := fw.txn.GetPartitionMetadata(

--- a/pkg/sql/vecindex/cspann/partition_metadata.go
+++ b/pkg/sql/vecindex/cspann/partition_metadata.go
@@ -190,6 +190,18 @@ func MakeUpdatingDetails(source PartitionKey) PartitionStateDetails {
 	}
 }
 
+// MakeAddingLevelDetails constructs state for an AddingLevel partition,
+// including the target partitions which will become the new children of the
+// root partition.
+func MakeAddingLevelDetails(target1, target2 PartitionKey) PartitionStateDetails {
+	return PartitionStateDetails{
+		State:     AddingLevelState,
+		Target1:   target1,
+		Target2:   target2,
+		Timestamp: timeutil.Now(),
+	}
+}
+
 // stalledOpTimeout specifies how long a partition can remain in a non-ready
 // state before other fixup workers conclude a fixup has stalled (e.g. because
 // the original worker crashed) and attempt to assist. If this is set too high,

--- a/pkg/sql/vecindex/cspann/store_errors.go
+++ b/pkg/sql/vecindex/cspann/store_errors.go
@@ -19,11 +19,6 @@ var ErrPartitionNotFound = errors.New("partition not found")
 // been refreshed.
 var ErrRestartOperation = errors.New("conflict detected, restart operation")
 
-// ErrRemoveNotAllowed is returned by the store when an attempt is made to
-// remove all vectors from a non-leaf partition. This would result in an
-// unbalanced K-means tree, which is not allowed.
-var ErrRemoveNotAllowed = errors.New("cannot remove last remaining vector from non-leaf partition")
-
 // ConditionFailedError is returned by an operation that fails because a
 // partition's metadata does not match some expected value. This is used to
 // detect races between multiple agents operating on a partition.

--- a/pkg/sql/vecindex/cspann/testdata/split-root-step.ddt
+++ b/pkg/sql/vecindex/cspann/testdata/split-root-step.ddt
@@ -1,0 +1,181 @@
+# ----------------------------------------------------------------------
+# Step through typical split of a root partition.
+# ----------------------------------------------------------------------
+
+load-index min-partition-size=1 max-partition-size=3 beam-size=2 new-fixups
+• 1 (6.8, 4.2)
+│
+├───• vec1 (1, 2)
+├───• vec2 (7, 4)
+├───• vec3 (4, 3)
+└───• vec5 (14, 1)
+----
+Loaded 4 vectors.
+
+# Update splitting root partition to Splitting state.
+force-split partition-key=1 steps=1
+----
+• 1 (6.8, 4.2) [Splitting:2,3]
+│
+├───• vec1 (1, 2)
+├───• vec2 (7, 4)
+├───• vec3 (4, 3)
+└───• vec5 (14, 1)
+
+# Create empty left sub-partition #2.
+force-split partition-key=1 root=2 steps=1
+----
+• 2 (10.5, 2.5) [Updating:1]
+
+# Create empty right sub-partition #3.
+force-split partition-key=1 root=3 steps=1
+----
+• 3 (2.5, 2.5) [Updating:1]
+
+# Update splitting root partition to DrainingForSplit state.
+force-split partition-key=1 steps=1
+----
+• 1 (6.8, 4.2) [DrainingForSplit:2,3]
+│
+├───• vec1 (1, 2)
+├───• vec2 (7, 4)
+├───• vec3 (4, 3)
+└───• vec5 (14, 1)
+
+# Add ~1/2 vectors to left sub-partition #2.
+force-split partition-key=1 root=2 steps=1
+----
+• 2 (10.5, 2.5) [Updating:1]
+│
+├───• vec2 (7, 4)
+└───• vec5 (14, 1)
+
+# Update left sub-partition #2 to Ready state.
+force-split partition-key=1 root=2 steps=1
+----
+• 2 (10.5, 2.5)
+│
+├───• vec2 (7, 4)
+└───• vec5 (14, 1)
+
+# Add ~1/2 vectors to right sub-partition #3.
+force-split partition-key=1 root=3 steps=1
+----
+• 3 (2.5, 2.5) [Updating:1]
+│
+├───• vec1 (1, 2)
+└───• vec3 (4, 3)
+
+# Update right sub-partition #3 to Ready state.
+force-split partition-key=1 root=3 steps=1
+----
+• 3 (2.5, 2.5)
+│
+├───• vec1 (1, 2)
+└───• vec3 (4, 3)
+
+# Remove children from root partition.
+force-split partition-key=1 steps=1
+----
+• 1 (6.8, 4.2) [DrainingForSplit:2,3]
+
+# Update splitting root partition to AddingLevel state.
+force-split partition-key=1 steps=1
+----
+• 1 (6.8, 4.2) [AddingLevel:2,3]
+
+# Add left sub-partition #2 to root partition.
+force-split partition-key=1 steps=1
+----
+• 1 (6.8, 4.2) [AddingLevel:2,3]
+│
+└───• 2 (10.5, 2.5)
+    │
+    ├───• vec2 (7, 4)
+    └───• vec5 (14, 1)
+
+# Add right sub-partition #3 to root partition.
+force-split partition-key=1 steps=1
+----
+• 1 (6.8, 4.2) [AddingLevel:2,3]
+│
+├───• 2 (10.5, 2.5)
+│   │
+│   ├───• vec2 (7, 4)
+│   └───• vec5 (14, 1)
+│
+└───• 3 (2.5, 2.5)
+    │
+    ├───• vec1 (1, 2)
+    └───• vec3 (4, 3)
+
+# Update splitting root partition to Ready state.
+force-split partition-key=1 steps=1
+----
+• 1 (6.8, 4.2)
+│
+├───• 2 (10.5, 2.5)
+│   │
+│   ├───• vec2 (7, 4)
+│   └───• vec5 (14, 1)
+│
+└───• 3 (2.5, 2.5)
+    │
+    ├───• vec1 (1, 2)
+    └───• vec3 (4, 3)
+
+# ----------------------------------------------------------------------
+# Try to split a root partition with only 1 vector.
+# ----------------------------------------------------------------------
+
+load-index min-partition-size=1 max-partition-size=2 beam-size=2 new-fixups
+• 1 (6.8, 4.2)
+│
+└───• 2 (2.5, 2.5)
+    │
+    ├───• vec1 (1, 2)
+    └───• vec2 (4, 3)
+
+----
+Loaded 2 vectors.
+
+# Step to point where partition #2 is copied to target sub-partition #3.
+force-split partition-key=1 root=3 steps=6
+----
+• 3 (2.5, 2.5)
+│
+└───• 2 (2.5, 2.5)
+    │
+    ├───• vec1 (1, 2)
+    └───• vec2 (4, 3)
+
+# Next steps should duplicate the last remaining vector in partition #1 and also
+# add it to partition #4. This will prevent partition #4 from being empty, which
+# would be a violation of the constraint that the K-means tree must be balanced.
+force-split partition-key=1 root=4 steps=2
+----
+• 4 (2.5, 2.5)
+│
+└───• 2 (2.5, 2.5)
+    │
+    ├───• vec1 (1, 2)
+    └───• vec2 (4, 3)
+
+# Finish the split, with partition #2 a child of both sub-partitions.
+force-split partition-key=1 steps=5
+----
+• 1 (6.8, 4.2)
+│
+├───• 3 (2.5, 2.5)
+│   │
+│   └───• 2 (2.5, 2.5)
+│       │
+│       ├───• vec1 (1, 2)
+│       └───• vec2 (4, 3)
+│
+└───• 4 (2.5, 2.5)
+    │
+    └───• 2 (2.5, 2.5)
+        │
+        ├───• vec1 (1, 2)
+        └───• vec2 (4, 3)


### PR DESCRIPTION
The background split operation currently only works for non-root partitions. This commit extends that to also work for root partitions. It does this by extending the state machine with a new AddingLevel state and updating the flow to remove from steps and add others.

Epic: CRDB-42943

Release note: None