### PR TITLE
aggmetric: add clear method in ChildStorage

### DIFF
--- a/pkg/util/metric/aggmetric/BUILD.bazel
+++ b/pkg/util/metric/aggmetric/BUILD.bazel
@@ -46,6 +46,7 @@ go_test(
         "@com_github_cockroachdb_crlib//testutils/require",
         "@com_github_prometheus_client_model//go",
         "@com_github_prometheus_common//expfmt",
+        "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/util/metric/aggmetric/agg_metric_test.go
+++ b/pkg/util/metric/aggmetric/agg_metric_test.go
@@ -71,22 +71,7 @@ func TestAggMetric(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
 	r := metric.NewRegistry()
-	writePrometheusMetrics := func(t *testing.T) string {
-		var in bytes.Buffer
-		ex := metric.MakePrometheusExporter()
-		scrape := func(ex *metric.PrometheusExporter) {
-			ex.ScrapeRegistry(r, true /* includeChildMetrics */, true)
-		}
-		require.NoError(t, ex.ScrapeAndPrintAsText(&in, expfmt.FmtText, scrape))
-		var lines []string
-		for sc := bufio.NewScanner(&in); sc.Scan(); {
-			if !bytes.HasPrefix(sc.Bytes(), []byte{'#'}) {
-				lines = append(lines, sc.Text())
-			}
-		}
-		sort.Strings(lines)
-		return strings.Join(lines, "\n")
-	}
+	writePrometheusMetrics := WritePrometheusMetricsFunc(r)
 
 	c := NewCounter(metric.Metadata{
 		Name: "foo_counter",
@@ -295,4 +280,60 @@ func TestAggHistogramRotate(t *testing.T) {
 		now = now.Add(time.Duration(i+1) * 10 * time.Second)
 		// Go to beginning.
 	}
+}
+
+func TestAggMetricClear(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	r := metric.NewRegistry()
+	writePrometheusMetrics := WritePrometheusMetricsFunc(r)
+
+	c := NewCounter(metric.Metadata{
+		Name: "foo_counter",
+	}, "tenant_id")
+	r.AddMetric(c)
+
+	d := NewCounter(metric.Metadata{
+		Name: "bar_counter",
+	}, "tenant_id")
+	d.initWithCacheStorageType([]string{"tenant_id"})
+	r.AddMetric(d)
+
+	tenant2 := roachpb.MustMakeTenantID(2)
+	c1 := c.AddChild(tenant2.String())
+
+	t.Run("before clear", func(t *testing.T) {
+		c1.Inc(2)
+		d.Inc(2, "3")
+		testFile := "aggMetric_pre_clear.txt"
+		echotest.Require(t, writePrometheusMetrics(t), datapathutils.TestDataPath(t, testFile))
+	})
+
+	c.clear()
+	d.clear()
+
+	t.Run("post clear", func(t *testing.T) {
+		testFile := "aggMetric_post_clear.txt"
+		echotest.Require(t, writePrometheusMetrics(t), datapathutils.TestDataPath(t, testFile))
+	})
+}
+
+func WritePrometheusMetricsFunc(r *metric.Registry) func(t *testing.T) string {
+	writePrometheusMetrics := func(t *testing.T) string {
+		var in bytes.Buffer
+		ex := metric.MakePrometheusExporter()
+		scrape := func(ex *metric.PrometheusExporter) {
+			ex.ScrapeRegistry(r, true /* includeChildMetrics */, true)
+		}
+		require.NoError(t, ex.ScrapeAndPrintAsText(&in, expfmt.FmtText, scrape))
+		var lines []string
+		for sc := bufio.NewScanner(&in); sc.Scan(); {
+			if !bytes.HasPrefix(sc.Bytes(), []byte{'#'}) {
+				lines = append(lines, sc.Text())
+			}
+		}
+		sort.Strings(lines)
+		return strings.Join(lines, "\n")
+	}
+	return writePrometheusMetrics
 }

--- a/pkg/util/metric/aggmetric/gauge_test.go
+++ b/pkg/util/metric/aggmetric/gauge_test.go
@@ -20,13 +20,14 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/crlib/testutils/require"
 	"github.com/prometheus/common/expfmt"
+	"github.com/stretchr/testify/assert"
 )
 
 func TestAggGaugeEviction(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	const cacheSize = 10
 	r := metric.NewRegistry()
-	writePrometheusMetrics := writePrometheusMetricsFunc(r)
+	writePrometheusMetrics := WritePrometheusMetricsFunc(r)
 
 	g := NewGauge(metric.Metadata{
 		Name: "foo_gauge",
@@ -101,11 +102,30 @@ func TestAggGaugeMethods(t *testing.T) {
 	echotest.Require(t, writePrometheusMetrics(t), datapathutils.TestDataPath(t, testFile))
 }
 
+func TestPanicForAggGaugeWithBtreeStorage(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	g := NewGauge(metric.Metadata{
+		Name: "foo_gauge",
+	}, "tenant_id")
+
+	assert.Panics(t, func() {
+		g.Inc(1, "1", "1")
+	}, "expected panic when Inc is invoked on AggGauge with BTreeStorage")
+
+	assert.Panics(t, func() {
+		g.Dec(1, "1", "1")
+	}, "expected panic when Dec is invoked on AggGauge with BTreeStorage")
+
+	assert.Panics(t, func() {
+		g.Update(1, "1", "1")
+	}, "expected panic when Update is invoked on AggGauge with BTreeStorage")
+}
+
 func TestAggGaugeFloat64Eviction(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	const cacheSize = 10
 	r := metric.NewRegistry()
-	writePrometheusMetrics := writePrometheusMetricsFunc(r)
+	writePrometheusMetrics := WritePrometheusMetricsFunc(r)
 
 	g := NewGaugeFloat64(metric.Metadata{
 		Name: "foo_gauge_float64",
@@ -136,22 +156,13 @@ func TestAggGaugeFloat64Eviction(t *testing.T) {
 	echotest.Require(t, writePrometheusMetrics(t), datapathutils.TestDataPath(t, testFile))
 }
 
-func writePrometheusMetricsFunc(r *metric.Registry) func(t *testing.T) string {
-	writePrometheusMetrics := func(t *testing.T) string {
-		var in bytes.Buffer
-		ex := metric.MakePrometheusExporter()
-		scrape := func(ex *metric.PrometheusExporter) {
-			ex.ScrapeRegistry(r, true /* includeChildMetrics */, true)
-		}
-		require.NoError(t, ex.ScrapeAndPrintAsText(&in, expfmt.FmtText, scrape))
-		var lines []string
-		for sc := bufio.NewScanner(&in); sc.Scan(); {
-			if !bytes.HasPrefix(sc.Bytes(), []byte{'#'}) {
-				lines = append(lines, sc.Text())
-			}
-		}
-		sort.Strings(lines)
-		return strings.Join(lines, "\n")
-	}
-	return writePrometheusMetrics
+func TestPanicForAggGaugeFloat64WithBtreeStorage(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	g := NewGaugeFloat64(metric.Metadata{
+		Name: "foo_gauge",
+	}, "tenant_id")
+
+	assert.Panics(t, func() {
+		g.Update(1, "1", "1")
+	}, "expected panic when Update is invoked on AggGaugeFloat64 with BTreeStorage")
 }

--- a/pkg/util/metric/aggmetric/testdata/aggMetric_post_clear.txt
+++ b/pkg/util/metric/aggmetric/testdata/aggMetric_post_clear.txt
@@ -1,0 +1,4 @@
+echo
+----
+bar_counter 2
+foo_counter 2

--- a/pkg/util/metric/aggmetric/testdata/aggMetric_pre_clear.txt
+++ b/pkg/util/metric/aggmetric/testdata/aggMetric_pre_clear.txt
@@ -1,0 +1,6 @@
+echo
+----
+bar_counter 2
+bar_counter{tenant_id="3"} 2
+foo_counter 2
+foo_counter{tenant_id="2"} 2


### PR DESCRIPTION
This patch introduces `clear` method in ChildStorage. It will clear all children which are part of parent metric. This method will be used during reinitialisation of aggmetric on cluster setting changes.

Epic: CRDB-43153
Part of: CRDB-48253
Release note: None