### PR TITLE
workload: tpcc fix alter partition query for partitioned replication

### DIFF
--- a/pkg/workload/tpcc/partition.go
+++ b/pkg/workload/tpcc/partition.go
@@ -395,10 +395,14 @@ func configureZone(
 	if len(cfg.zones) > 0 {
 		constraint = fmt.Sprintf("[+zone=%s]", cfg.zones[partIdx])
 	} else {
-		// Note that this only specifies 3 replica locations. If the number of
-		// replicas is >3 this will only specify the location for 3 of them.
-		constraint = fmt.Sprintf(`{+rack=%d: 1, +rack=%d: 1, +rack=%d: 1}`, partIdx, (partIdx+totalParts/3)%totalParts, (partIdx+2*totalParts/3)%totalParts)
-		lease = fmt.Sprintf("[[+rack=%d]]", partIdx)
+		if cfg.strategy == partitionedLeases {
+			// Note that this only specifies 3 replica locations. If the number of
+			// replicas is >3 this will only specify the location for 3 of them.
+			constraint = fmt.Sprintf(`{+rack=%d: 1, +rack=%d: 1, +rack=%d: 1}`, partIdx, (partIdx+totalParts/3)%totalParts, (partIdx+2*totalParts/3)%totalParts)
+			lease = fmt.Sprintf("[[+rack=%d]]", partIdx)
+		} else {
+			constraint = fmt.Sprintf("[+rack=%d]", partIdx)
+		}
 	}
 
 	var opts string


### PR DESCRIPTION
Fixes partitioning query generated with no zone config and partition strategy as replication. Earlier we were specifying per rack replica placement information which is not required in partitionedReplication which caused the error.
Example bad query
- `ALTER PARTITION p0_0 OF TABLE warehouse CONFIGURE ZONE USING constraints = '{+rack=0: 1, +rack=1: 1, +rack=2: 1}`
- error : `pq: could not validate zone config: when per-replica constraints are set, num_replicas must be set as well`

Fix is to not add this per replica constraint for replication, reverting to the old way of alter partition query generation.

Fixes: #143410
Epic: none