### PR TITLE
sql: Deflake TestTransactionDeadline

### DIFF
--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -891,6 +891,7 @@ go_test(
         "//pkg/sql/sqlerrors",
         "//pkg/sql/sqlinstance",
         "//pkg/sql/sqlliveness",
+        "//pkg/sql/sqlliveness/slbase",
         "//pkg/sql/sqlliveness/sqllivenesstestutils",
         "//pkg/sql/sqlstats",
         "//pkg/sql/sqlstats/persistedsqlstats",


### PR DESCRIPTION
Previously, TestTransactionDeadline could flake if the lease expiration occurred before our fake session expirations. This happened in session-based leasing when, on an overloaded system, we couldn't extend sqlliveness fast enough for the real session backing the descriptor leases. To address this, this patch intentionally increases the TTL for the actual session liveness, eliminating the risk of the actual liveness being older.

Fixes: #142837

Release note: None