### PR TITLE
rafttrace,kvserver: remove dep from MsgStorageApply

### DIFF
--- a/pkg/kv/kvserver/client_raft_log_queue_test.go
+++ b/pkg/kv/kvserver/client_raft_log_queue_test.go
@@ -206,6 +206,7 @@ func TestRaftTracing(t *testing.T) {
 					// sufficient to just check one of them for tracing.
 					`replica_raft.* 1->2 MsgApp`,
 					`replica_raft.* AppendThread->1 MsgStorageAppendResp`,
+					`replica_raft.* applying entries`,
 					`ack-ing replication success to the client`,
 				}
 				require.NoError(t, testutils.MatchInOrder(output, expectedMessages...))


### PR DESCRIPTION
Replace the `rafttrace` API that expects `MsgStorageApply/Resp` messages with an equivalent strongly typed version with a couple of methods. This is in preparation for removing `MsgStorageApply`.

Epic: none
Release note: none