### PR TITLE
raft: remove apply flow control

### DIFF
--- a/pkg/raft/node_test.go
+++ b/pkg/raft/node_test.go
@@ -735,23 +735,14 @@ func TestCommitPaginationWithAsyncStorageWrites(t *testing.T) {
 		}
 	}
 
-	// Third entry should not be returned to be applied until first entry's
-	// application is acknowledged.
-	for rn.HasReady() { // drain the Ready-s
-		rd := rn.Ready()
-		for _, m := range rd.Messages {
-			require.NotEqual(t, raftpb.MsgStorageApply, m.Type, "unexpected message: %v", m)
-		}
-	}
-
 	// Acknowledged first entry application.
 	require.NoError(t, rn.Step(applyResps[0]))
 	applyResps = applyResps[1:]
 
 	// Third entry now returned for application.
 	rd = rn.Ready()
-	require.Len(t, rd.Messages, 1)
-	m = rd.Messages[0]
+	require.Len(t, rd.Messages, 2)
+	m = rd.Messages[1]
 	require.Equal(t, raftpb.MsgStorageApply, m.Type)
 	require.Len(t, m.Entries, 1)
 	applyResps = append(applyResps, m.Responses[0])

--- a/pkg/raft/raft_paper_test.go
+++ b/pkg/raft/raft_paper_test.go
@@ -824,7 +824,7 @@ func commitNoopEntry(r *raft, s *MemoryStorage) {
 	// ignore further messages to refresh followers' commit index
 	r.readMessages()
 	s.Append(r.raftLog.nextUnstableEnts())
-	r.raftLog.appliedTo(r.raftLog.committed, 0 /* size */)
+	r.raftLog.appliedTo(r.raftLog.committed)
 	r.raftLog.stableTo(r.raftLog.unstable.mark())
 }
 

--- a/pkg/raft/raft_test.go
+++ b/pkg/raft/raft_test.go
@@ -46,7 +46,7 @@ func nextEnts(r *raft, s *MemoryStorage) (ents []pb.Entry) {
 
 	// Return committed entries.
 	ents = r.raftLog.nextCommittedEnts(true)
-	r.raftLog.appliedTo(r.raftLog.committed, 0 /* size */)
+	r.raftLog.appliedTo(r.raftLog.committed)
 	return ents
 }
 

--- a/pkg/raft/rawnode.go
+++ b/pkg/raft/rawnode.go
@@ -244,8 +244,7 @@ func (rn *RawNode) Ready() Ready {
 	allowUnstable := rn.applyUnstableEntries()
 	if r.raftLog.hasNextCommittedEnts(allowUnstable) {
 		entries := r.raftLog.nextCommittedEnts(allowUnstable)
-		index := entries[len(entries)-1].Index
-		r.raftLog.acceptApplying(index, entsSize(entries), allowUnstable)
+		r.raftLog.acceptApplying(entries[len(entries)-1].Index)
 		rd.CommittedEntries = entries
 	}
 


### PR DESCRIPTION
This is not used in CRDB. We always apply one batch of entries at a time, so we only need to keep the max size policy. Entry application flow control should be done outside `pkg/raft`, anyway. It will be achievable with the `LogSnapshot`-based API, since the latter allows setting the max total size of entries to read.

Epic: none
Release note: none