### PR TITLE
sql,plpgsql: fix case sensitivity in composite element assignment

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/plpgsql_assign
+++ b/pkg/ccl/logictestccl/testdata/logic_test/plpgsql_assign
@@ -121,6 +121,97 @@ CREATE FUNCTION f(val xy) RETURNS xy AS $$
   END
 $$ LANGUAGE PLpgSQL;
 
+subtest assign_elem_case_sensitivity
+
+# Composite type with unquoted (lowercase) fields.
+statement ok
+CREATE TYPE comp1 AS (foo INT, bar INT);
+
+statement ok
+CREATE FUNCTION f1(val comp1) RETURNS comp1 AS $$
+  BEGIN
+    val.foo := 10;
+    val.bar := 20;
+    RETURN val;
+  END
+$$ LANGUAGE PLpgSQL;
+
+query T
+SELECT f1(ROW(1, 2));
+----
+(10,20)
+
+statement ok
+DROP FUNCTION f1;
+
+# Composite type with quoted (uppercase) fields.
+statement ok
+CREATE TYPE comp2 AS ("FOO" INT, "BAR" INT);
+
+statement ok
+CREATE FUNCTION f2(val comp2) RETURNS comp2 AS $$
+  BEGIN
+    val."FOO" := 100;
+    val."BAR" := 200;
+    RETURN val;
+  END
+$$ LANGUAGE PLpgSQL;
+
+query T
+SELECT f2(ROW(1, 2)::comp2);
+----
+(100,200)
+
+statement ok
+DROP FUNCTION f2;
+
+# Attempt to assign using wrong case (should fail).
+statement error pgcode 42703 pq: record "val" has no field "FOO"
+CREATE FUNCTION f3(val comp1) RETURNS comp1 AS $$
+  BEGIN
+    val."FOO" := 1;
+    RETURN val;
+  END
+$$ LANGUAGE PLpgSQL;
+
+statement error pgcode 42703 pq: record "val" has no field "foo"
+CREATE FUNCTION f4(val comp2) RETURNS comp2 AS $$
+  BEGIN
+    val.foo := 1;
+    RETURN val;
+  END
+$$ LANGUAGE PLpgSQL;
+
+# Mixed quoted/unquoted field names in composite type.
+statement ok
+CREATE TYPE comp3 AS (foo INT, "BAR" INT);
+
+statement ok
+CREATE FUNCTION f5(val comp3) RETURNS comp3 AS $$
+  BEGIN
+    val.foo := 5;
+    val."BAR" := 6;
+    RETURN val;
+  END
+$$ LANGUAGE PLpgSQL;
+
+query T
+SELECT f5(ROW(0, 0)::comp3);
+----
+(5,6)
+
+statement ok
+DROP FUNCTION f5;
+
+statement ok
+DROP TYPE comp1;
+
+statement ok
+DROP TYPE comp2;
+
+statement ok
+DROP TYPE comp3;
+
 subtest end
 
 # Ordinal parameter references should reflect updates made by variable

--- a/pkg/ccl/logictestccl/testdata/logic_test/triggers
+++ b/pkg/ccl/logictestccl/testdata/logic_test/triggers
@@ -4247,6 +4247,125 @@ SELECT id, a, b FROM tab_141810 ORDER BY id
 3  1     2
 4  NULL  NULL
 
+# ==============================================================================
+# Test case sensitivity of column names in triggers
+# ==============================================================================
+
+subtest case_sensitivity
+
+# Setup: clean up any existing tables and functions
+statement ok
+DROP TABLE IF EXISTS t1, t2, t3;
+
+statement ok
+DROP TRIGGER IF EXISTS tr1 ON t1;
+DROP TRIGGER IF EXISTS tr2 ON t1;
+DROP TRIGGER IF EXISTS tr3 ON t1;
+-- tr4 failed to create, so no need to drop
+
+statement ok
+DROP TRIGGER IF EXISTS tr5 ON t2;
+DROP TRIGGER IF EXISTS tr6 ON t2;
+DROP TRIGGER IF EXISTS tr7 ON t2;
+-- tr8 failed to create, so no need to drop
+
+statement ok
+DROP TRIGGER IF EXISTS tr12 ON t3;
+-- tr9, tr10, tr11 failed to create, so no need to drop
+
+# Setup: Create tables with different casing
+statement ok
+CREATE TABLE t1 (foo_bar INT);
+CREATE TABLE t2 ("foo_bar" INT);
+CREATE TABLE t3 ("FOO_BAR" INT);
+
+# Trigger functions with different quoting/casing styles
+statement ok
+CREATE FUNCTION f1() RETURNS TRIGGER LANGUAGE PLpgSQL AS $$
+  BEGIN
+    NEW.foo_bar := 1;
+    RETURN NEW;
+  END;
+$$;
+
+statement ok
+CREATE FUNCTION f2() RETURNS TRIGGER LANGUAGE PLpgSQL AS $$
+  BEGIN
+    NEW.FOO_BAR := 1;
+    RETURN NEW;
+  END;
+$$;
+
+statement ok
+CREATE FUNCTION f3() RETURNS TRIGGER LANGUAGE PLpgSQL AS $$
+  BEGIN
+    NEW."foo_bar" := 1;
+    RETURN NEW;
+  END;
+$$;
+
+statement ok
+CREATE FUNCTION f4() RETURNS TRIGGER LANGUAGE PLpgSQL AS $$
+  BEGIN
+    NEW."FOO_BAR" := 1;
+    RETURN NEW;
+  END;
+$$;
+
+# Attach each function to each table and check success/failure
+
+# Unquoted table
+statement ok
+CREATE TRIGGER tr1 BEFORE INSERT ON t1 FOR EACH ROW EXECUTE FUNCTION f1();
+
+statement ok
+CREATE TRIGGER tr2 BEFORE INSERT ON t1 FOR EACH ROW EXECUTE FUNCTION f2();
+
+statement ok
+CREATE TRIGGER tr3 BEFORE INSERT ON t1 FOR EACH ROW EXECUTE FUNCTION f3();
+
+statement error pgcode 42703 pq: record "new" has no field "FOO_BAR"
+CREATE TRIGGER tr4 BEFORE INSERT ON t1 FOR EACH ROW EXECUTE FUNCTION f4();
+
+# Quoted lowercase column
+statement ok
+CREATE TRIGGER tr5 BEFORE INSERT ON t2 FOR EACH ROW EXECUTE FUNCTION f1();
+
+statement ok
+CREATE TRIGGER tr6 BEFORE INSERT ON t2 FOR EACH ROW EXECUTE FUNCTION f2();
+
+statement ok
+CREATE TRIGGER tr7 BEFORE INSERT ON t2 FOR EACH ROW EXECUTE FUNCTION f3();
+
+statement error pgcode 42703 pq: record "new" has no field "FOO_BAR"
+CREATE TRIGGER tr8 BEFORE INSERT ON t2 FOR EACH ROW EXECUTE FUNCTION f4();
+
+# Quoted uppercase column
+statement error pgcode 42703 pq: record "new" has no field "foo_bar"
+CREATE TRIGGER tr9 BEFORE INSERT ON t3 FOR EACH ROW EXECUTE FUNCTION f1();
+
+statement error pgcode 42703 pq: record "new" has no field "foo_bar"
+CREATE TRIGGER tr10 BEFORE INSERT ON t3 FOR EACH ROW EXECUTE FUNCTION f2();
+
+statement error pgcode 42703 pq: record "new" has no field "foo_bar"
+CREATE TRIGGER tr11 BEFORE INSERT ON t3 FOR EACH ROW EXECUTE FUNCTION f3();
+
+statement ok
+CREATE TRIGGER tr12 BEFORE INSERT ON t3 FOR EACH ROW EXECUTE FUNCTION f4();
+
+# Drop all tables
+statement ok
+DROP TABLE t1;
+DROP TABLE t2;
+DROP TABLE t3;
+
+# Drop all functions
+statement ok
+DROP FUNCTION f1();
+DROP FUNCTION f2();
+DROP FUNCTION f3();
+DROP FUNCTION f4();
+
 subtest end
 
 # Until #135311 can be fixed, disallow TG_ARGV references by default. There is

--- a/pkg/sql/opt/optbuilder/plpgsql.go
+++ b/pkg/sql/opt/optbuilder/plpgsql.go
@@ -1608,7 +1608,7 @@ const noIndirection = ""
 func (b *plpgsqlBuilder) handleIndirectionForAssign(
 	inScope *scope, typ *types.T, ident ast.Variable, indirection tree.Name, val tree.Expr,
 ) opt.ScalarExpr {
-	elemName := indirection.Normalize()
+	elemName := string(indirection)
 
 	// We do not yet support qualifying a variable with a block label.
 	b.checkBlockLabelReference(elemName)


### PR DESCRIPTION
#### sql,plpgsql: fix case sensitivity in composite element assignment

Previously, the logic that resolved an element of a composite-typed PL/pgSQL
variable for assignment normalized the element name after it was already
normalized. This caused every field to be treated as lowercase, making it
impossible to perform an assignment like `NEW."FOO_Bar" = 100`. This commit
removes the extra normalization and replaces it with a conversion to string.

Fixes #142083

Release note (sql change): Assigning to an element of a composite-typed
variable in a PL/pgSQL routine now respects case-sensitivity rules. For
example, a field named `"FOO_Bar"` can be assigned like `NEW."FOO_Bar" = 100`.