### PR TITLE
storage: test that batch commit doesn't touch SSTs

### DIFF
--- a/pkg/storage/BUILD.bazel
+++ b/pkg/storage/BUILD.bazel
@@ -217,6 +217,7 @@ go_test(
         "@com_github_cockroachdb_pebble//sstable",
         "@com_github_cockroachdb_pebble//sstable/block",
         "@com_github_cockroachdb_pebble//vfs",
+        "@com_github_cockroachdb_pebble//vfs/errorfs",
         "@com_github_cockroachdb_redact//:redact",
         "@com_github_kr_pretty//:pretty",
         "@com_github_stretchr_testify//assert",


### PR DESCRIPTION
This commit adds simple test where it injects errors on any operation touching any SSTable file before attempting to commit a batch, and asserts that the batch can commit successfully without needing any SSTable.

References: #143135

Release note: None