### PR TITLE
sql: add RLS policy support for UPSERT

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/row_level_security
+++ b/pkg/sql/logictest/testdata/logic_test/row_level_security
@@ -698,6 +698,55 @@ drop table flying_roaches
 statement ok
 drop type roach_type
 
+subtest insert_returning
+
+statement ok
+CREATE TABLE ins (c1 INT);
+
+statement ok
+CREATE USER ins;
+
+statement ok
+ALTER TABLE ins OWNER TO ins;
+
+statement ok
+SET ROLE ins;
+
+statement ok
+CREATE POLICY p_ins ON ins FOR INSERT WITH CHECK (c1 > 0);
+
+statement ok
+CREATE POLICY p_sel ON ins FOR SELECT USING (c1 % 2 = 0);
+
+statement ok
+ALTER TABLE ins FORCE ROW LEVEL SECURITY, ENABLE ROW LEVEL SECURITY;
+
+# Verify that p_ins allows all positive rows to be inserted.
+statement ok
+INSERT INTO ins VALUES (1),(2),(3),(4);
+
+# Verify that the same statement with RETURNING will fail because it enforces
+# the SELECT policy.
+statement error pq: new row violates row-level security policy for table "ins"
+INSERT INTO ins VALUES (1),(2),(3),(4) RETURNING c1;
+
+# Verify that only rows that pass the USING expression are allowed (even numbers).
+statement ok
+INSERT INTO ins VALUES (2),(4) RETURNING c1;
+
+# Verify that insert policy violation applies when using RETURNING
+statement error pq: new row violates row-level security policy for table "ins"
+INSERT INTO ins VALUES (2),(4),(-2),(-4) RETURNING c1;
+
+statement ok
+SET ROLE root;
+
+statement ok
+DROP TABLE ins;
+
+statement ok
+DROP USER ins;
+
 subtest alter_table_rls_legacy_unimplemented
 
 statement ok
@@ -3462,6 +3511,743 @@ DROP TABLE bypassrls;
 
 statement ok
 DROP USER bypassrls_user;
+
+subtest multi_col_family_policies
+
+statement ok
+CREATE TABLE mc (pk int not null primary key, f1 int, f2 int, family pk (pk), family f1 (f1), family f2 (f2));
+
+statement ok
+CREATE ROLE mc;
+
+statement ok
+ALTER TABLE mc OWNER TO mc;
+
+statement ok
+SET ROLE mc;
+
+statement ok
+ALTER TABLE mc ENABLE ROW LEVEL SECURITY, FORCE ROW LEVEL SECURITY;
+
+statement ok
+CREATE POLICY p1 ON mc USING (f1 > 0 and f2 > 0);
+
+statement ok
+INSERT INTO mc VALUES (1, 1, 1);
+
+# An UPDATE that writes to one column but reads from another—where the read column
+# belongs to a different column family—fails because we don't currently have locking
+# to enforce safe access across families.
+onlyif config weak-iso-level-configs
+statement error pq: unimplemented: multi-column-family check constraints are not yet supported under read committed isolation
+UPDATE mc SET f2 = 10 WHERE f1 = 1;
+
+skipif config weak-iso-level-configs
+statement ok
+UPDATE mc SET f2 = 11 WHERE f1 = 1;
+
+statement ok
+DROP POLICY p1 ON mc;
+
+statement ok
+CREATE POLICY sel ON mc FOR SELECT USING (f1 > 0);
+
+statement ok
+CREATE POLICY upd ON mc FOR UPDATE USING (true) WITH CHECK (f2 > 0);
+
+statement ok
+CREATE POLICY ins ON mc FOR INSERT WITH CHECK (true);
+
+onlyif config weak-iso-level-configs
+statement error pq: unimplemented: multi-column-family check constraints are not yet supported under read committed isolation
+INSERT INTO mc VALUES(1, 1, 1) ON CONFLICT (pk) DO UPDATE SET f2 = 12;
+
+skipif config weak-iso-level-configs
+statement ok
+INSERT INTO mc VALUES(1, 1, 1) ON CONFLICT (pk) DO UPDATE SET f2 = 12;
+
+# Switch up the expressions to ensure we look at the column from the merge of
+# all the policies.
+statement ok
+ALTER POLICY sel ON mc USING (f2 > 0);
+
+statement ok
+ALTER POLICY upd ON mc WITH CHECK (f1 > 0);
+
+onlyif config weak-iso-level-configs
+statement error pq: unimplemented: multi-column-family check constraints are not yet supported under read committed isolation
+INSERT INTO mc VALUES(1, 1, 1) ON CONFLICT (pk) DO UPDATE SET f2 = 13;
+
+skipif config weak-iso-level-configs
+statement ok
+INSERT INTO mc VALUES(1, 1, 1) ON CONFLICT (pk) DO UPDATE SET f2 = 13;
+
+statement ok
+SET ROLE root;
+
+statement ok
+DROP TABLE mc;
+
+statement ok
+DROP USER mc;
+
+subtest insert_on_conflict_update
+
+statement ok
+CREATE TABLE ups (pk INT NOT NULL PRIMARY KEY, comment TEXT);
+
+statement ok
+CREATE USER ups;
+
+statement ok
+ALTER TABLE ups OWNER TO ups;
+
+statement ok
+SET ROLE ups;
+
+statement ok
+ALTER TABLE ups ENABLE ROW LEVEL SECURITY, FORCE ROW LEVEL SECURITY;
+
+# pk=1: Trigger UPDATE policy violation during conflict resolution, caused by
+# the new row values for the updated row violating the policy's USING clause.
+statement ok
+CREATE POLICY p_sel ON ups FOR SELECT USING (true);
+
+statement ok
+CREATE POLICY p_ins ON ups FOR INSERT WITH CHECK (true);
+
+statement ok
+CREATE POLICY p_upd ON ups FOR UPDATE USING (comment = 'upsert') WITH CHECK (true);
+
+# Okay because there is no conflict
+statement ok
+INSERT INTO ups VALUES (1, 'original value') ON CONFLICT (pk) DO UPDATE SET comment = 'upsert';
+
+# Reject because we hit a conflict, and the old column of comment violates the UPDATE policy.
+statement error pq: new row violates row-level security policy for table "ups"
+INSERT INTO ups VALUES (1, 'original value') ON CONFLICT (pk) DO UPDATE SET comment = 'upsert';
+
+query T
+SELECT comment FROM ups WHERE pk = 1;
+----
+original value
+
+# pk=2: Ensure UPDATE policy USING expression doesn't apply to new version of
+# updated row.
+statement ok
+ALTER POLICY p_upd ON ups USING (comment = 'original value') WITH CHECK (true);
+
+# Okay because there is no conflict
+statement ok
+INSERT INTO ups VALUES (2, 'original value') ON CONFLICT (pk) DO UPDATE SET comment = 'upsert';
+
+# Drive a conflict and confirm that the USING expression isn't used against the
+# new version of the row. Otherwise, the policy would be violated.
+statement ok
+INSERT INTO ups VALUES (2, 'original value') ON CONFLICT (pk) DO UPDATE SET comment = 'upsert';
+
+query T
+SELECT comment FROM ups WHERE pk = 2;
+----
+upsert
+
+# pk=3: Confirm no policy violation during conflict resolution when the updated
+# row satisfies the WITH CHECK expression.
+statement ok
+ALTER POLICY p_upd ON ups USING (true) WITH CHECK (comment = 'upsert');
+
+statement ok
+INSERT INTO ups VALUES (3, 'original value') ON CONFLICT (pk) DO UPDATE SET comment = 'upsert';
+
+statement ok
+INSERT INTO ups VALUES (3, 'original value') ON CONFLICT (pk) DO UPDATE SET comment = 'upsert';
+
+query T
+SELECT comment FROM ups WHERE pk = 3;
+----
+upsert
+
+# pk=4: Trigger UPDATE policy violation during conflict resolution, caused by
+# failing the WITH CHECK expression for the updated column values.
+statement ok
+ALTER POLICY p_upd ON ups USING (true) WITH CHECK (comment = 'original value');
+
+statement ok
+INSERT INTO ups VALUES (4, 'original value') ON CONFLICT (pk) DO UPDATE SET comment = 'upsert';
+
+# This should be rejected because updated value violates the WITH CHECK expression in the update policy.
+statement error pq: new row violates row-level security policy for table "ups"
+INSERT INTO ups VALUES (4, 'original value') ON CONFLICT (pk) DO UPDATE SET comment = 'upsert';
+
+query T
+SELECT comment FROM ups WHERE pk = 4;
+----
+original value
+
+# pk=5: Trigger INSERT policy violation before conflict resolution.
+statement ok
+DROP POLICY p_upd ON ups;
+
+statement ok
+CREATE POLICY p_upd ON ups FOR UPDATE USING (true);
+
+statement ok
+ALTER POLICY p_ins ON ups WITH CHECK (comment = 'upsert');
+
+statement error pq: new row violates row-level security policy for table "ups"
+INSERT INTO ups VALUES (5, 'original value') ON CONFLICT (pk) DO UPDATE SET comment = 'upsert';
+
+statement ok
+ALTER POLICY p_ins ON ups WITH CHECK (comment = 'original value');
+
+statement ok
+INSERT INTO ups VALUES (5, 'original value') ON CONFLICT (pk) DO UPDATE SET comment = 'upsert';
+
+# Verify that the INSERT policies are skipped if we hit a conflict and end up
+# updating the existing row.
+statement ok
+INSERT INTO ups VALUES (5, 'original value') ON CONFLICT (pk) DO UPDATE SET comment = 'upsert';
+
+query T
+SELECT comment FROM ups WHERE pk = 5;
+----
+upsert
+
+# pk=6: Trigger SELECT policy violation on conflict resolution.
+statement ok
+ALTER POLICY p_ins ON ups WITH CHECK (true);
+
+statement ok
+ALTER POLICY p_sel ON ups USING (comment = 'original value');
+
+statement ok
+INSERT INTO ups VALUES (6, 'original value') ON CONFLICT (pk) DO UPDATE SET comment = 'upsert';
+
+# This should be rejected. The updated rows violate the USING clause expression
+# for the SELECT policy.
+statement error pq: new row violates row-level security policy for table "ups"
+INSERT INTO ups VALUES (6, 'original value') ON CONFLICT (pk) DO UPDATE SET comment = 'upsert';
+
+query T
+SELECT comment FROM ups WHERE pk = 6;
+----
+original value
+
+# pk=7: Trigger SELECT policy violation on new inserted row and updated row
+# during conflict resolution.
+statement ok
+ALTER POLICY p_sel ON ups USING (comment = 'upsert');
+
+# This should fail because the USING clause of the SELECT policy violates the
+# new rows being inserted.
+statement error pq: new row violates row-level security policy for table "ups"
+INSERT INTO ups VALUES (7, 'original value') ON CONFLICT (pk) DO UPDATE SET comment = 'upsert';
+
+# Setup so we can try on a conflict. Disable RLS to properly insert pk=7 in.
+statement ok
+ALTER TABLE ups NO FORCE ROW LEVEL SECURITY;
+
+statement ok
+INSERT INTO ups VALUES (7, 'original value');
+
+statement ok
+ALTER TABLE ups FORCE ROW LEVEL SECURITY;
+
+# This should be rejected. When reading the old row, it violates the USING
+# clause of the SELECT policy.
+statement error pq: new row violates row-level security policy for table "ups"
+INSERT INTO ups VALUES (7, 'original value') ON CONFLICT (pk) DO UPDATE SET comment = 'upsert';
+
+statement ok
+ALTER TABLE ups NO FORCE ROW LEVEL SECURITY;
+
+query T
+SELECT comment FROM ups WHERE pk = 7;
+----
+original value
+
+statement ok
+ALTER TABLE ups FORCE ROW LEVEL SECURITY;
+
+# pk=8: Have an ALL policy with a USING expression that violates the new row.
+statement ok
+DROP POLICY p_sel ON ups;
+
+statement ok
+DROP POLICY p_ins ON ups;
+
+statement ok
+DROP POLICY p_upd ON ups;
+
+statement ok
+CREATE POLICY p_all ON ups FOR ALL USING (comment = 'upsert') WITH CHECK (true);
+
+# This should fail with an RLS violation because the new row violates the USING expression.
+statement error pq: new row violates row-level security policy for table "ups"
+INSERT INTO ups VALUES (8, 'original value') ON CONFLICT (pk) DO UPDATE SET comment = 'upsert';
+
+# Setup so we can try on a conflict. Disable RLS to properly insert pk=8 in.
+statement ok
+ALTER TABLE ups NO FORCE ROW LEVEL SECURITY;
+
+statement ok
+INSERT INTO ups VALUES (8, 'original value');
+
+statement ok
+ALTER TABLE ups FORCE ROW LEVEL SECURITY;
+
+# This fails because the old row violates the USING expression of p_all.
+statement error pq: new row violates row-level security policy for table "ups"
+INSERT INTO ups VALUES (8, 'original value') ON CONFLICT (pk) DO UPDATE SET comment = 'upsert';
+
+statement ok
+ALTER TABLE ups NO FORCE ROW LEVEL SECURITY;
+
+query T
+SELECT comment FROM ups WHERE pk = 8;
+----
+original value
+
+statement ok
+ALTER TABLE ups FORCE ROW LEVEL SECURITY;
+
+# pk=9: Have an ALL policy with a USING expression that violates the updated row
+# during conflict resolution.
+statement ok
+ALTER POLICY p_all ON ups USING (comment = 'original value') WITH CHECK (true);
+
+statement ok
+INSERT INTO ups VALUES (9, 'original value') ON CONFLICT (pk) DO UPDATE SET comment = 'upsert';
+
+statement error pq: new row violates row-level security policy for table "ups"
+INSERT INTO ups VALUES (9, 'original value') ON CONFLICT (pk) DO UPDATE SET comment = 'upsert';
+
+query T
+SELECT comment FROM ups WHERE pk = 9;
+----
+original value
+
+# pk=10: Use an ALL policy with a WITH CHECK expression that applies to the
+# updated value during conflict resolution.
+statement ok
+ALTER POLICY p_all ON ups USING (true) WITH CHECK (comment = 'upsert')
+
+# This should fail with an RLS violation because the new row violates the WITH CHECK expression.
+statement error pq: new row violates row-level security policy for table "ups"
+INSERT INTO ups VALUES (10, 'original value') ON CONFLICT (pk) DO UPDATE SET comment = 'upsert';
+
+# Setup so we can try on a conflict. Disable RLS to properly insert pk=8 in.
+statement ok
+ALTER TABLE ups NO FORCE ROW LEVEL SECURITY;
+
+statement ok
+INSERT INTO ups VALUES (10, 'original value');
+
+statement ok
+ALTER TABLE ups FORCE ROW LEVEL SECURITY;
+
+# Insert a row that triggers a conflict and is handled via UPDATE.
+# The values provided for the initial INSERT would violate a WITH CHECK
+# constraint, but because the conflict resolution results in an UPDATE,
+# we allow the statement to succeed.
+#
+# Note: This behavior slightly deviates from PostgreSQL, which rejects
+# the statement.
+statement ok
+INSERT INTO ups VALUES (10, 'original value') ON CONFLICT (pk) DO UPDATE SET comment = 'upsert';
+
+# However, if you leave off the conflict, the insert will get rejected due to the policy.
+statement error pq: new row violates row-level security policy for table "ups"
+INSERT INTO ups VALUES (10, 'original value')
+
+query T
+SELECT comment FROM ups WHERE pk = 10;
+----
+upsert
+
+# pk=11: Use an ALL policy with a WITH CHECK expression that applies to the
+# inserted row value.
+statement ok
+ALTER POLICY p_all ON ups USING (true) WITH CHECK (comment = 'original value')
+
+statement ok
+INSERT INTO ups VALUES (11, 'original value') ON CONFLICT (pk) DO UPDATE SET comment = 'upsert';
+
+# This should fail because the updated row violates the INSERT policy.
+statement error pq: new row violates row-level security policy for table "ups"
+INSERT INTO ups VALUES (11, 'original value') ON CONFLICT (pk) DO UPDATE SET comment = 'upsert';
+
+query T
+SELECT comment FROM ups WHERE pk = 11;
+----
+original value
+
+# pk=12: Test an ALL policy that only includes a WITH CHECK expression.
+# Since there is no USING expression to evaluate during conflict checks,
+# the default behavior is deny-all, causing the statements to fail.
+statement ok
+DROP POLICY p_all ON ups;
+
+statement ok
+CREATE POLICY p_all ON ups FOR ALL WITH CHECK (true);
+
+statement error pq: new row violates row-level security policy for table "ups"
+INSERT INTO ups VALUES (12, 'original value') ON CONFLICT (pk) DO UPDATE SET comment = 'upsert';
+
+statement ok
+INSERT INTO ups VALUES (12, 'original value')
+
+statement error pq: new row violates row-level security policy for table "ups"
+INSERT INTO ups VALUES (12, 'original value') ON CONFLICT (pk) DO UPDATE SET comment = 'upsert';
+
+# Turn off force so we can query the row back
+statement ok
+ALTER TABLE ups NO FORCE ROW LEVEL SECURITY;
+
+query T
+SELECT comment FROM ups WHERE pk = 12;
+----
+original value
+
+statement ok
+SET ROLE root;
+
+statement ok
+DROP TABLE ups;
+
+statement ok
+DROP USER ups;
+
+subtest insert_on_conflict_do_nothing
+
+statement ok
+CREATE TABLE ups (pk INT NOT NULL PRIMARY KEY, comment TEXT, c SMALLINT);
+
+statement ok
+CREATE USER ups;
+
+statement ok
+ALTER TABLE ups OWNER TO ups;
+
+statement ok
+SET ROLE ups;
+
+statement ok
+ALTER TABLE ups ENABLE ROW LEVEL SECURITY, FORCE ROW LEVEL SECURITY;
+
+# pk=1: Verify the conflict scan is exempt from RLS policies USING expressions
+# and we don't insert a duplicate value.
+statement ok
+CREATE POLICY p_sel ON ups FOR SELECT USING (comment = 'original value');
+
+statement ok
+CREATE POLICY p_ins ON ups FOR INSERT WITH CHECK (true);
+
+statement ok
+INSERT INTO ups VALUES (1, 'original value', 1) ON CONFLICT (pk) DO NOTHING;
+
+statement ok
+INSERT INTO ups VALUES (1, 'original value', 2) ON CONFLICT (pk) DO NOTHING;
+
+# Verify that input VALUES are not checked against policies when a conflict
+# occurs. This behaviour differs from PostgreSQL, which evaluates VALUES even in
+# conflict cases. The discrepancy stems from a known difference in how CHECK
+# constraints are handled. See issue #35370 for more details.
+statement ok
+INSERT INTO ups VALUES (1, 'upsert', 3) ON CONFLICT (pk) DO NOTHING;
+
+query TI
+SELECT comment, c FROM ups WHERE pk = 1;
+----
+original value 1
+
+statement ok
+ALTER POLICY p_sel ON ups USING (comment = 'upsert');
+
+# PostgreSQL would block this, but since a conflict occurs and we do nothing,
+# the constraints are never evaluated.
+statement ok
+INSERT INTO ups VALUES (1, 'original value', 4) ON CONFLICT (pk) DO NOTHING;
+
+# pk=2: Ensure that the INSERT expression is only violated if there is no
+# conflict
+statement ok
+ALTER POLICY p_sel ON ups USING (true);
+
+statement ok
+ALTER POLICY p_ins ON ups WITH CHECK (comment = 'original value');
+
+statement error pq: new row violates row-level security policy for table "ups"
+INSERT INTO ups VALUES (2, 'first value', 1) ON CONFLICT (pk) DO NOTHING;
+
+statement ok
+INSERT INTO ups VALUES (2, 'original value', 2) ON CONFLICT (pk) DO NOTHING;
+
+statement ok
+INSERT INTO ups VALUES (2, 'original value', 3) ON CONFLICT (pk) DO NOTHING;
+
+# An INSERT that encounters a conflict will skip writing the row and skip the
+# RLS policy checks. Note: This differs from PostgreSQL, which raises a policy
+# violation error because it checks constraints/policies on the input values.
+statement ok
+INSERT INTO ups VALUES (2, 'upsert', 4) ON CONFLICT (pk) DO NOTHING;
+
+query TI
+SELECT comment, c FROM ups WHERE pk = 2;
+----
+original value 2
+
+# pk=3: Test an ALL policy with a USING expression that is intentionally violated
+statement ok
+DROP POLICY p_ins ON ups;
+
+statement ok
+DROP POLICY p_sel ON ups;
+
+statement ok
+CREATE POLICY p_all ON ups FOR ALL USING (comment = 'original value') WITH CHECK (true);
+
+statement error pq: new row violates row-level security policy for table "ups"
+INSERT INTO ups VALUES (3, 'first value', 1) ON CONFLICT (pk) DO NOTHING;
+
+statement ok
+INSERT INTO ups VALUES (3, 'original value', 2) ON CONFLICT (pk) DO NOTHING;
+
+statement ok
+INSERT INTO ups VALUES (3, 'original value', 3) ON CONFLICT (pk) DO NOTHING;
+
+# An INSERT that encounters a conflict will skip writing the row and skip the
+# RLS policy checks. Note: This differs from PostgreSQL, which raises a policy
+# violation error because it checks constraints/policies on the input values.
+statement ok
+INSERT INTO ups VALUES (3, 'upsert', 4) ON CONFLICT (pk) DO NOTHING;
+
+query TI
+SELECT comment, c FROM ups WHERE pk = 3;
+----
+original value 2
+
+statement ok
+DELETE FROM ups WHERE pk = 3;
+
+statement ok
+INSERT INTO ups VALUES (3, 'first value', 5);
+
+statement ok
+ALTER POLICY p_all ON ups USING (comment = 'upsert');
+
+statement ok
+INSERT INTO ups VALUES (3, 'upsert', 6) ON CONFLICT (pk) DO NOTHING;
+
+statement ok
+ALTER TABLE ups NO FORCE ROW LEVEL SECURITY;
+
+query TI
+SELECT comment, c FROM ups WHERE pk = 3;
+----
+first value 5
+
+statement ok
+ALTER TABLE ups FORCE ROW LEVEL SECURITY;
+
+# pk=4: ALL policy with a violated WITH CHECK expression
+statement ok
+ALTER POLICY p_all ON ups USING (true) WITH CHECK (comment = 'original value');
+
+statement ok
+INSERT INTO ups VALUES (4, 'original value', 1) ON CONFLICT (pk) DO NOTHING;
+
+statement ok
+INSERT INTO ups VALUES (4, 'original value', 2) ON CONFLICT (pk) DO NOTHING;
+
+# An INSERT that encounters a conflict will skip writing the row and skip the
+# RLS policy checks. Note: This differs from PostgreSQL, which raises a policy
+# violation error because it checks constraints/policies on the input values.
+statement ok
+INSERT INTO ups VALUES (4, 'upsert', 3) ON CONFLICT (pk) DO NOTHING;
+
+query TI
+SELECT comment, c FROM ups WHERE pk = 4;
+----
+original value 1
+
+statement ok
+ALTER POLICY p_all ON ups WITH CHECK (comment = 'upsert');
+
+statement ok
+INSERT INTO ups VALUES (4, 'upsert', 4) ON CONFLICT (pk) DO NOTHING;
+
+statement ok
+ALTER TABLE ups NO FORCE ROW LEVEL SECURITY;
+
+query TI
+SELECT comment, c FROM ups WHERE pk = 4;
+----
+original value 1
+
+statement ok
+SET ROLE root;
+
+statement ok
+DROP TABLE ups;
+
+statement ok
+DROP USER ups;
+
+subtest upsert
+
+statement ok
+CREATE TABLE ups (pk INT NOT NULL PRIMARY KEY, comment TEXT, c SMALLINT);
+
+statement ok
+CREATE USER ups;
+
+statement ok
+ALTER TABLE ups OWNER TO ups;
+
+statement ok
+SET ROLE ups;
+
+statement ok
+ALTER TABLE ups ENABLE ROW LEVEL SECURITY, FORCE ROW LEVEL SECURITY;
+
+# pk=1: Trigger an UPDATE policy violation during conflict resolution,
+# caused by the new row values violating the policy's USING expression.
+statement ok
+CREATE POLICY p_sel ON ups FOR SELECT USING (true);
+
+statement ok
+CREATE POLICY p_ins ON ups FOR INSERT WITH CHECK (true);
+
+statement ok
+CREATE POLICY p_upd ON ups FOR UPDATE USING (comment = 'original value') WITH CHECK (true);
+
+statement ok
+UPSERT INTO ups VALUES (1, 'original value', 1);
+
+# Succeeds because the policy evaluates to true when it reads the old row.
+statement ok
+UPSERT INTO ups VALUES (1, 'upsert', 2);
+
+query TI
+SELECT comment, c FROM ups WHERE pk = 1;
+----
+upsert 2
+
+# Fail because the old row violates the USING expression of the UPDATE policy
+statement error pq: new row violates row-level security policy for table "ups"
+UPSERT INTO ups VALUES (1, 'upsert', 3);
+
+# Fail because the old row violates the USING expression of the UPDATE policy
+statement error pq: new row violates row-level security policy for table "ups"
+UPSERT INTO ups VALUES (1, 'original value', 4);
+
+query TI
+SELECT comment, c FROM ups WHERE pk = 1;
+----
+upsert 2
+
+# pk=2: Trigger an UPDATE policy violation during conflict resolution because
+# WITH CHECK expression fails.
+statement ok
+ALTER POLICY p_upd ON ups USING (true) WITH CHECK (comment = 'original value');
+
+statement ok
+UPSERT INTO ups VALUES (2, 'original value', 1);
+
+# Drive a conflict and confirm that the WITH CHECK expression is violated.
+statement error pq: new row violates row-level security policy for table "ups"
+UPSERT INTO ups VALUES (2, 'upsert', 2);
+
+query TI
+SELECT comment, c FROM ups WHERE pk = 2;
+----
+original value 1
+
+# pk=3: Trigger a SELECT policy violation during conflict resolution.
+statement ok
+ALTER POLICY p_upd ON ups USING (true) WITH CHECK (true);
+
+statement ok
+ALTER POLICY p_sel ON ups USING (comment = 'original value')
+
+# Fails because new row doesn't pass SELECT policy expression
+statement error pq: new row violates row-level security policy for table "ups"
+UPSERT INTO ups VALUES (3, 'expect fail', 1);
+
+statement ok
+UPSERT INTO ups VALUES (3, 'original value', 2);
+
+statement ok
+UPSERT INTO ups VALUES (3, 'original value', 3);
+
+statement error pq: new row violates row-level security policy for table "ups"
+UPSERT INTO ups VALUES (3, 'upsert', 4);
+
+query TI
+SELECT comment, c FROM ups WHERE pk = 3;
+----
+original value 3
+
+statement ok
+ALTER TABLE ups NO FORCE ROW LEVEL SECURITY;
+
+statement ok
+UPSERT INTO ups VALUES (3, 'upsert', 5);
+
+statement ok
+ALTER TABLE ups FORCE ROW LEVEL SECURITY;
+
+statement error pq: new row violates row-level security policy for table "ups"
+UPSERT INTO ups VALUES (3, 'original value', 6);
+
+statement ok
+ALTER TABLE ups NO FORCE ROW LEVEL SECURITY;
+
+query TI
+SELECT comment, c FROM ups WHERE pk = 3;
+----
+upsert 5
+
+statement ok
+ALTER TABLE ups FORCE ROW LEVEL SECURITY;
+
+# pk=4: Trigger INSERT policy violation before conflict resolution.
+statement ok
+ALTER POLICY p_upd ON ups USING (true) WITH CHECK (true);
+
+statement ok
+ALTER POLICY p_ins ON ups WITH CHECK (comment = 'upsert');
+
+statement ok
+ALTER POLICY p_sel ON ups USING (true);
+
+statement error pq: new row violates row-level security policy for table "ups"
+UPSERT INTO ups VALUES (4, 'original value', 1);
+
+statement ok
+ALTER POLICY p_ins ON ups WITH CHECK (comment = 'original value');
+
+statement ok
+UPSERT INTO ups VALUES (4, 'original value', 2);
+
+# Confirm that the INSERT policy isn't used if there is a conflict.
+statement ok
+UPSERT INTO ups VALUES (4, 'upsert', 3);
+
+query TI
+SELECT comment, c FROM ups WHERE pk = 4;
+----
+upsert 3
+
+statement ok
+SET ROLE root
+
+statement ok
+DROP TABLE ups;
+
+statement ok
+DROP USER ups;
 
 subtest end
 

--- a/pkg/sql/opt/cat/policy.go
+++ b/pkg/sql/opt/cat/policy.go
@@ -27,6 +27,9 @@ const (
 	PolicyScopeUpdate
 	// PolicyScopeDelete indicates that the policy applies to DELETE operations.
 	PolicyScopeDelete
+	// PolicyScopeUpsert is used to indicate it's an INSERT ... ON CONFLICT
+	// statement.
+	PolicyScopeUpsert
 	// PolicyScopeExempt indicates that the operation is exempt from row-level security policies.
 	PolicyScopeExempt
 )

--- a/pkg/sql/opt/exec/explain/testdata/row_level_security
+++ b/pkg/sql/opt/exec/explain/testdata/row_level_security
@@ -421,3 +421,94 @@ select count(*) from t1,t2 where t1.c1 = t2.c1;
           table: t2@t2_pkey
           spans: FULL SCAN
           policies: t2_pol_1
+
+# Show that policies are shown for UPSERT (and its variations).
+# ----------------------------------------------------------------------
+
+exec-ddl
+CREATE TABLE ups (pk int not null primary key, comment text);
+----
+
+exec-ddl
+ALTER TABLE ups OWNER TO rls_accessor
+----
+
+exec-ddl
+ALTER TABLE ups ENABLE ROW LEVEL SECURITY, FORCE ROW LEVEL SECURITY;
+----
+
+exec-ddl
+CREATE POLICY p_ins ON ups FOR INSERT USING (comment = 'insert');
+----
+
+exec-ddl
+CREATE POLICY p_sel ON ups FOR SELECT USING (comment = 'select');
+----
+
+exec-ddl
+CREATE POLICY p_upd ON ups FOR UPDATE USING (comment = 'update');
+----
+
+plan
+UPSERT INTO ups VALUES (1, 'first value');
+----
+• upsert
+│ into: ups(pk, comment)
+│ auto commit
+│ arbiter indexes: ups_pkey
+│ policies: p_ins, p_sel, p_upd
+│
+└── • render
+    │
+    └── • cross join (left outer)
+        │
+        ├── • values
+        │     size: 2 columns, 1 row
+        │
+        └── • scan
+              table: ups@ups_pkey
+              spans: 1+ spans
+              locking strength: for update
+
+plan
+INSERT INTO ups VALUES (1, 'first value') ON CONFLICT (pk) DO UPDATE SET comment = 'second value';
+----
+• upsert
+│ into: ups(pk, comment)
+│ auto commit
+│ arbiter indexes: ups_pkey
+│ policies: p_ins, p_sel, p_upd
+│
+└── • render
+    │
+    └── • render
+        │
+        └── • cross join (left outer)
+            │
+            ├── • values
+            │     size: 2 columns, 1 row
+            │
+            └── • scan
+                  table: ups@ups_pkey
+                  spans: 1+ spans
+                  locking strength: for update
+
+plan
+INSERT INTO ups VALUES (1, 'first value') ON CONFLICT (pk) DO NOTHING;
+----
+• insert
+│ into: ups(pk, comment)
+│ auto commit
+│ arbiter indexes: ups_pkey
+│ policies: p_ins, p_sel
+│
+└── • render
+    │
+    └── • cross join (anti)
+        │
+        ├── • values
+        │     size: 2 columns, 1 row
+        │
+        └── • scan
+              table: ups@ups_pkey
+              spans: 1+ spans

--- a/pkg/sql/opt/optbuilder/mutation_builder.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder.go
@@ -864,7 +864,9 @@ func (mb *mutationBuilder) addSynthesizedComputedCols(colIDs opt.OptionalColList
 // is true, check columns that do not reference mutation columns are not added
 // to checkColIDs, which allows pruning normalization rules to remove the
 // unnecessary projected column.
-func (mb *mutationBuilder) addCheckConstraintCols(isUpdate bool) {
+func (mb *mutationBuilder) addCheckConstraintCols(
+	isUpdate bool, policyCmdScope cat.PolicyCommandScope, includeSelectOnInsert bool,
+) {
 	if mb.tab.CheckCount() != 0 {
 		projectionsScope := mb.outScope.replace()
 		projectionsScope.appendColumnsFromScope(mb.outScope)
@@ -873,6 +875,9 @@ func (mb *mutationBuilder) addCheckConstraintCols(isUpdate bool) {
 
 		for i, n := 0, mb.tab.CheckCount(); i < n; i++ {
 			check := mb.tab.Check(i)
+
+			referencedCols := &opt.ColSet{}
+			var scopeCol *scopeColumn
 
 			// For tables with RLS enabled, we create a synthetic check constraint
 			// to enforce the policies. Since this check varies based on the role
@@ -883,38 +888,28 @@ func (mb *mutationBuilder) addCheckConstraintCols(isUpdate bool) {
 					panic(errors.AssertionFailedf("a table should only have one RLS constraint"))
 				}
 				seenRLSConstraint = true
-				chkBuilder := optRLSConstraintBuilder{
-					tab:      mb.tab,
-					md:       mb.md,
-					tabMeta:  mb.md.TableMeta(mb.tabID),
-					oc:       mb.b.catalog,
-					user:     mb.b.checkPrivilegeUser,
-					isUpdate: isUpdate,
-				}
-				check = chkBuilder.Build(mb.b.ctx)
-			}
 
-			expr, err := parser.ParseExpr(check.Constraint())
-			if err != nil {
-				panic(err)
-			}
-
-			texpr := mb.outScope.resolveAndRequireType(expr, types.Bool)
-
-			// Use an anonymous name because the column cannot be referenced
-			// in other expressions.
-			colName := scopeColName("")
-			if check.IsRLSConstraint() {
-				colName = colName.WithMetadataName("rls")
+				var rlsScalar opt.ScalarExpr
+				rlsScalar, check = mb.buildRLSCheckConstraint(policyCmdScope, includeSelectOnInsert, referencedCols)
+				colName := scopeColName("").WithMetadataName("rls")
+				scopeCol = mb.b.synthesizeColumn(projectionsScope, colName, rlsScalar.DataType(), nil /* expr */, rlsScalar)
 			} else {
-				colName = colName.WithMetadataName(fmt.Sprintf("check%d", i+1))
-			}
-			scopeCol := projectionsScope.addColumn(colName, texpr)
+				expr, err := parser.ParseExpr(check.Constraint())
+				if err != nil {
+					panic(err)
+				}
 
-			// TODO(ridwanmsharif): Maybe we can avoid building constraints here
-			// and instead use the constraints stored in the table metadata.
-			referencedCols := &opt.ColSet{}
-			mb.b.buildScalar(texpr, mb.outScope, projectionsScope, scopeCol, referencedCols)
+				texpr := mb.outScope.resolveAndRequireType(expr, types.Bool)
+
+				// Use an anonymous name because the column cannot be referenced
+				// in other expressions.
+				colName := scopeColName("").WithMetadataName(fmt.Sprintf("check%d", i+1))
+				scopeCol = projectionsScope.addColumn(colName, texpr)
+
+				// TODO(ridwanmsharif): Maybe we can avoid building constraints here
+				// and instead use the constraints stored in the table metadata.
+				mb.b.buildScalar(texpr, mb.outScope, projectionsScope, scopeCol, referencedCols)
+			}
 
 			// For non-UPDATE mutations, track the synthesized check columns in
 			// checkColIDs. For UPDATE mutations, track the check columns in two
@@ -970,6 +965,241 @@ func (mb *mutationBuilder) addCheckConstraintCols(isUpdate bool) {
 		mb.b.constructProjectForScope(mb.outScope, projectionsScope)
 		mb.outScope = projectionsScope
 	}
+}
+
+// buildRLSCheckConstraint returns a RLS specific check constraint that is used
+// to enforce the policies on write.
+func (mb *mutationBuilder) buildRLSCheckConstraint(
+	cmdScope cat.PolicyCommandScope, includeSelectOnInsert bool, referencedCols *opt.ColSet,
+) (opt.ScalarExpr, *rlsCheckConstraint) {
+	tabMeta := mb.md.TableMeta(mb.tabID)
+	scalar := mb.buildRLSCheckExpr(tabMeta, cmdScope, includeSelectOnInsert, referencedCols)
+
+	// Build a CheckConstraint so the caller knows what columns were referenced.
+	check := rlsCheckConstraint{
+		colIDs: mb.b.getColIDsFromPoliciesUsed(tabMeta),
+		tab:    mb.tab,
+	}
+	return scalar, &check
+}
+
+// buildRLSCheckExpr constructs the scalar expression that enforces row-level
+// security (RLS) policies via a synthetic check constraint. The resulting
+// expression is used during data mutation operations (e.g., INSERT, UPDATE, UPSERT).
+//
+// The includeSelectOnInsert flag indicates whether SELECT policies should also be
+// included in the constraint. This is necessary for certain INSERT scenarios
+// (e.g., INSERT ... RETURNING, INSERT ... ON CONFLICT DO NOTHING), where rows
+// may need to be read during execution, even if no updates occur. This behavior
+// aligns with postgres, which also enforces SELECT policies in these cases.
+func (mb *mutationBuilder) buildRLSCheckExpr(
+	tabMeta *opt.TableMeta,
+	cmdScope cat.PolicyCommandScope,
+	includeSelectOnInsert bool,
+	referencedCols *opt.ColSet,
+) opt.ScalarExpr {
+	if mb.b.isExemptFromRLSPolicies(tabMeta, cmdScope) {
+		return memo.TrueSingleton
+	}
+
+	var scalar opt.ScalarExpr
+	switch cmdScope {
+	case cat.PolicyScopeInsert:
+		// Only apply select policies if requested.
+		var selectPolicyExpr opt.ScalarExpr = memo.TrueSingleton
+		if includeSelectOnInsert {
+			// Note: we use mb.outScope because we want the policies applied to the newly
+			// inserted rows. For example, INSERT ... RETURNING must ensure the returned
+			// rows are visible.
+			selectPolicyExpr = mb.genPolicyUsingExpr(tabMeta, cat.PolicyScopeSelect, mb.outScope, referencedCols)
+		}
+		scalar = mb.b.factory.ConstructAnd(
+			selectPolicyExpr,
+			mb.genPolicyWithCheckExpr(tabMeta, cat.PolicyScopeInsert, referencedCols),
+		)
+	case cat.PolicyScopeUpdate:
+		scalar = mb.b.factory.ConstructAnd(
+			mb.genPolicyUsingExpr(tabMeta, cat.PolicyScopeSelect, mb.outScope, referencedCols),
+			mb.genPolicyWithCheckExpr(tabMeta, cat.PolicyScopeUpdate, referencedCols),
+		)
+	case cat.PolicyScopeUpsert:
+		// For UPSERT, the applied RLS policies depend on whether the operation results in
+		// an INSERT or an UPDATE. We determine this by checking if the canary column is NULL:
+		//   - If it IS NULL → no conflict occurred → this is an INSERT
+		//   - If it is NOT NULL → conflict occurred → this is an UPDATE
+		//
+		// The expression below enforces:
+		//   - On conflict (UPDATE):
+		//       * SELECT + UPDATE policies on the existing row (fetchScope)
+		//       * SELECT + UPDATE policies on the updated row (outScope)
+		//   - On no conflict (INSERT):
+		//       * SELECT + INSERT policies on the inserted row (outScope)
+		//
+		// This is expressed as:
+		//   (isConflict AND all UPDATE-related policies)
+		//   OR
+		//   (isNotConflict AND all INSERT-related policies)
+		isNotConflict := mb.b.factory.ConstructIs(
+			mb.b.factory.ConstructVariable(mb.canaryColID),
+			memo.NullSingleton,
+		)
+		isConflict := mb.b.factory.ConstructNot(isNotConflict)
+		scalar = mb.b.factory.ConstructOr(
+			// CASE 1: apply all UPDATE-related policies. Note: we use mb.fetchScope
+			// to apply policies against columns fetched during conflict detection.
+			// We don't filter out rows that violate SELECT policies (as we would in
+			// a normal query), because we want the UPSERT to fail if a conflict occurs
+			// but the user does not have visibility into the conflicting row.
+			mb.b.factory.ConstructAnd(
+				isConflict,
+				mb.b.factory.ConstructAnd(
+					mb.genPolicyUsingExpr(tabMeta, cat.PolicyScopeSelect, mb.fetchScope, referencedCols),
+					mb.b.factory.ConstructAnd(
+						mb.genPolicyUsingExpr(tabMeta, cat.PolicyScopeUpdate, mb.fetchScope, referencedCols),
+						mb.b.factory.ConstructAnd(
+							mb.genPolicyUsingExpr(tabMeta, cat.PolicyScopeSelect, mb.outScope, referencedCols),
+							mb.genPolicyWithCheckExpr(tabMeta, cat.PolicyScopeUpdate, referencedCols),
+						),
+					),
+				),
+			),
+			// CASE 2: apply all INSERT-related policies
+			mb.b.factory.ConstructAnd(
+				isNotConflict,
+				mb.b.factory.ConstructAnd(
+					mb.genPolicyUsingExpr(tabMeta, cat.PolicyScopeSelect, mb.outScope, referencedCols),
+					mb.genPolicyWithCheckExpr(tabMeta, cat.PolicyScopeInsert, referencedCols),
+				),
+			),
+		)
+	default:
+		panic(errors.AssertionFailedf("unsupported policy command scope for check expr: %v", cmdScope))
+	}
+
+	mb.b.factory.Metadata().GetRLSMeta().RefreshNoPoliciesAppliedForTable(tabMeta.MetaID)
+	return scalar
+}
+
+// genPolicyWithCheckExpr will build a WITH CHECK expression for the
+// given policy command. If no policy applies, then the 'false' expression is
+// returned.
+func (mb *mutationBuilder) genPolicyWithCheckExpr(
+	tabMeta *opt.TableMeta, cmdScope cat.PolicyCommandScope, referencedCols *opt.ColSet,
+) opt.ScalarExpr {
+	scalar := mb.genPolicyExpr(tabMeta, cmdScope, mb.outScope, referencedCols, false /* forceUsingExpr */)
+	if scalar == nil {
+		return memo.FalseSingleton
+	}
+	return scalar
+}
+
+// genPolicyUsingExpr generates a USING expression for the given policy command.
+// If no applicable policies are found, it returns 'false'. Otherwise, it returns
+// the generated scalar expression.
+func (mb *mutationBuilder) genPolicyUsingExpr(
+	tabMeta *opt.TableMeta,
+	cmdScope cat.PolicyCommandScope,
+	exprScope *scope,
+	referencedCols *opt.ColSet,
+) opt.ScalarExpr {
+	scalar := mb.genPolicyExpr(tabMeta, cmdScope, exprScope, referencedCols, true /* forceUsingExpr */)
+	if scalar == nil {
+		return memo.FalseSingleton
+	}
+	return scalar
+}
+
+// genPolicyExpr constructs a scalar expression representing the RLS (row-level
+// security) policy checks to enforce for a given command scope (INSERT, UPDATE,
+// etc.).
+//
+// Typically, RLS policies are enforced using the WITH CHECK expression, which
+// ensures that written rows comply with the defined policies. However, in
+// certain scenarios, the USING expression is used instead—most notably during
+// conflict resolution in UPSERTs. In those cases, we don't filter out invisible
+// rows during scans; instead, we enforce visibility by requiring the row to
+// satisfy the USING expression. If it doesn't, the statement fails via a
+// constraint violation.
+//
+// The `forceUsingExpr` flag controls this behaviour:
+//   - If false: the WITH CHECK expression is used (if present).
+//   - If true: the USING expression is used instead, even if a WITH CHECK
+//     expression is defined.
+//
+// This function returns a scalar expression composed of all applicable policies
+// (both permissive and restrictive), and records which policies were applied in
+// the RLS metadata.
+//
+// The final expression has the form:
+//
+//	(permissive1 OR permissive2 OR ...) AND restrictive1 AND restrictive2 AND ...
+//
+// This structure allows permissive policies to grant access if *any* are
+// satisfied, while all restrictive policies must be satisfied to allow the
+// operation.
+func (mb *mutationBuilder) genPolicyExpr(
+	tabMeta *opt.TableMeta,
+	cmdScope cat.PolicyCommandScope,
+	exprScope *scope,
+	referencedCols *opt.ColSet,
+	forceUsingExpr bool,
+) opt.ScalarExpr {
+	var scalar opt.ScalarExpr
+	var policiesUsed opt.PolicyIDSet
+	policies := tabMeta.Table.Policies()
+
+	// Create a closure to handle building the expression for one policy.
+	buildForPolicy := func(p cat.Policy, combineScalars func(opt.ScalarExpr, opt.ScalarExpr) opt.ScalarExpr) {
+		if !p.AppliesToRole(mb.b.checkPrivilegeUser) || !policyAppliesToCommandScope(p, cmdScope) {
+			return
+		}
+		policiesUsed.Add(p.ID)
+
+		expr := p.WithCheckExpr
+		if expr == "" || forceUsingExpr {
+			// The USING expression is used in two scenarios:
+			// - When the WITH CHECK expression is not defined
+			// - When the caller explicitly requests only the USING expression (e.g.,
+			// during UPSERT)
+			expr = p.UsingExpr
+		}
+		if expr == "" {
+			// If both expressions are missing, the policy does not apply and can
+			// be skipped.
+			return
+		}
+		pexpr, err := parser.ParseExpr(expr)
+		if err != nil {
+			panic(err)
+		}
+		texpr := exprScope.resolveAndRequireType(pexpr, types.Bool)
+		singleExprScalar := mb.b.buildScalar(texpr, mb.outScope, nil, nil, referencedCols)
+
+		// Build up a scalar expression of all singleExprScalar's combined.
+		if scalar != nil {
+			scalar = combineScalars(scalar, singleExprScalar)
+		} else {
+			scalar = singleExprScalar
+		}
+	}
+
+	for _, policy := range policies.Permissive {
+		buildForPolicy(policy, mb.b.factory.ConstructOr)
+	}
+	// If no permissive policies apply, then we will add a false check as
+	// nothing is allowed to be written.
+	if scalar == nil {
+		return memo.FalseSingleton
+	}
+	for _, policy := range policies.Restrictive {
+		buildForPolicy(policy, mb.b.factory.ConstructAnd)
+	}
+
+	if scalar == nil {
+		panic(errors.AssertionFailedf("at least one applicable policy should have been included"))
+	}
+	mb.b.factory.Metadata().GetRLSMeta().AddPoliciesUsed(tabMeta.MetaID, policiesUsed, false /* applyFilterExpr */)
+	return scalar
 }
 
 // getColumnFamilySet gets the set of column families represented in colOrdinals.

--- a/pkg/sql/opt/optbuilder/mutation_builder_arbiter.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder_arbiter.go
@@ -335,8 +335,6 @@ func (mb *mutationBuilder) buildAntiJoinForDoNothingArbiter(
 		locking,
 		inScope,
 		true, /* disableNotVisibleIndex */
-		// TODO(136704): Review and adjust the scope used here after implementing
-		// WITH CHECK to ensure correct filtering behavior for UPSERT operations.
 		cat.PolicyScopeExempt,
 	)
 
@@ -477,8 +475,6 @@ func (mb *mutationBuilder) buildLeftJoinForUpsertArbiter(
 		locking,
 		inScope,
 		true, /* disableNotVisibleIndex */
-		// TODO(136704): Review and adjust the scope used here after implementing
-		// WITH CHECK to ensure correct filtering behavior for UPSERT operations.
 		cat.PolicyScopeExempt,
 	)
 	// Set fetchColIDs to reference the columns created for the fetch values.
@@ -697,8 +693,6 @@ func (h *arbiterPredicateHelper) tableScope() *scope {
 			noRowLocking,
 			h.mb.b.allocScope(),
 			false, /* disableNotVisibleIndex */
-			// TODO(136704): Review and adjust the scope used here after implementing
-			// WITH CHECK to ensure correct filtering behavior for UPSERT operations.
 			cat.PolicyScopeExempt,
 		)
 	}

--- a/pkg/sql/opt/optbuilder/row_level_security.go
+++ b/pkg/sql/opt/optbuilder/row_level_security.go
@@ -6,11 +6,6 @@
 package optbuilder
 
 import (
-	"context"
-	"fmt"
-	"strings"
-
-	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
@@ -30,8 +25,22 @@ import (
 func (b *Builder) addRowLevelSecurityFilter(
 	tabMeta *opt.TableMeta, tableScope *scope, cmdScope cat.PolicyCommandScope,
 ) {
-	if !tabMeta.Table.IsRowLevelSecurityEnabled() || cmdScope == cat.PolicyScopeExempt {
+	if b.isExemptFromRLSPolicies(tabMeta, cmdScope) {
 		return
+	}
+	scalar := b.buildRowLevelSecurityUsingExpression(tabMeta, tableScope, cmdScope)
+	if scalar != nil {
+		tableScope.expr = b.factory.ConstructSelect(tableScope.expr,
+			memo.FiltersExpr{b.factory.ConstructFiltersItem(scalar)})
+	}
+}
+
+// isExemptFromRLSPolicies will check if the given user is exempt from RLS policies.
+func (b *Builder) isExemptFromRLSPolicies(
+	tabMeta *opt.TableMeta, cmdScope cat.PolicyCommandScope,
+) bool {
+	if !tabMeta.Table.IsRowLevelSecurityEnabled() || cmdScope == cat.PolicyScopeExempt {
+		return true
 	}
 
 	// Check for cases where users are exempt from policies.
@@ -51,12 +60,9 @@ func (b *Builder) addRowLevelSecurityFilter(
 		isOwnerAndNotForced, bypassRLS)
 	// Check if RLS filtering is exempt.
 	if isAdmin || isOwnerAndNotForced || bypassRLS {
-		return
+		return true
 	}
-
-	scalar := b.buildRowLevelSecurityUsingExpression(tabMeta, tableScope, cmdScope)
-	tableScope.expr = b.factory.ConstructSelect(tableScope.expr,
-		memo.FiltersExpr{b.factory.ConstructFiltersItem(scalar)})
+	return false
 }
 
 // buildRowLevelSecurityUsingExpression generates a scalar expression for read
@@ -189,163 +195,31 @@ func (b *Builder) isTableOwnerAndRLSNotForced(tabMeta *opt.TableMeta) (bool, err
 	return b.catalog.IsOwner(b.ctx, tabMeta.Table, b.checkPrivilegeUser)
 }
 
-// optRLSConstraintBuilder is used synthesize a check constraint to enforce the
-// RLS policies for new rows.
-type optRLSConstraintBuilder struct {
-	tab      cat.Table
-	md       *opt.Metadata
-	tabMeta  *opt.TableMeta
-	oc       cat.Catalog
-	user     username.SQLUsername
-	isUpdate bool
-}
-
-// Build will construct a CheckConstraint to enforce the policies for the
-// current user and command.
-func (r *optRLSConstraintBuilder) Build(ctx context.Context) cat.CheckConstraint {
-	expr, colIDs := r.genExpression(ctx)
-	if expr == "" {
-		panic(fmt.Sprintf("must return some expression but empty string returned for user: %v", r.user))
-	}
-	return &rlsCheckConstraint{
-		constraint: expr,
-		colIDs:     colIDs,
-		tab:        r.tab,
-	}
-}
-
-// genExpression builds the expression that will be used within the check
-// constraint built for RLS.
-func (r *optRLSConstraintBuilder) genExpression(ctx context.Context) (string, []int) {
-	// colIDs tracks the column IDs referenced in all the policy expressions
-	// that are applied. We use a set as we need to combine the columns used
-	// for multiple policies.
+// getColIDsFromPoliciesUsed returns the column ordinals referenced by all
+// policies used in the RLS meta cache.
+func (b *Builder) getColIDsFromPoliciesUsed(tabMeta *opt.TableMeta) []int {
+	filters, checks := b.factory.Metadata().GetRLSMeta().GetPoliciesUsed(tabMeta.MetaID)
 	var colIDs intsets.Fast
-
-	// Check for cases where users are exempt from policies.
-	isAdmin, err := r.oc.UserHasAdminRole(ctx, r.user)
-	if err != nil {
-		panic(err)
-	}
-	isOwnerAndNotForced, err := r.isTableOwnerAndRLSNotForced(ctx)
-	if err != nil {
-		panic(err)
-	}
-	bypassRLS, err := r.oc.UserHasGlobalPrivilegeOrRoleOption(ctx, privilege.BYPASSRLS, r.user)
-	if err != nil {
-		panic(err)
-	}
-	r.md.SetRLSEnabled(r.user, isAdmin, r.tabMeta.MetaID, isOwnerAndNotForced, bypassRLS)
-	if isAdmin || isOwnerAndNotForced || bypassRLS {
-		// Return a constraint check that always passes.
-		return "true", nil
-	}
-
-	combinedExpr := r.combinePolicyWithCheckExpr(&colIDs)
-	// If no policies apply, then we will add a false check as nothing is allowed
-	// to be written.
-	if combinedExpr == "" {
-		r.md.GetRLSMeta().NoPoliciesApplied = true
-		return "false", nil
-	}
-	return combinedExpr, colIDs.Ordered()
-}
-
-// combinePolicyWithCheckExpr will build a combined expression depending if this
-// is INSERT or UPDATE.
-func (r *optRLSConstraintBuilder) combinePolicyWithCheckExpr(colIDs *intsets.Fast) string {
-	// When handling UPDATE, we need to add the SELECT/ALL using expressions
-	// first, then apply any UPDATE policy.
-	if r.isUpdate {
-		selExpr := r.genPolicyWithCheckExprForCommand(colIDs, cat.PolicyScopeSelect)
-		if selExpr == "" {
-			return ""
-		}
-		updExpr := r.genPolicyWithCheckExprForCommand(colIDs, cat.PolicyScopeUpdate)
-		if updExpr == "" {
-			return ""
-		}
-		return fmt.Sprintf("(%s) and (%s)", selExpr, updExpr)
-	}
-	return r.genPolicyWithCheckExprForCommand(colIDs, cat.PolicyScopeInsert)
-}
-
-// genPolicyWithCheckExprForCommand will build a WITH CHECK expression for the
-// given policy command.
-func (r *optRLSConstraintBuilder) genPolicyWithCheckExprForCommand(
-	colIDs *intsets.Fast, cmdScope cat.PolicyCommandScope,
-) string {
-	var sb strings.Builder
-	var policiesUsed opt.PolicyIDSet
-	policies := r.tabMeta.Table.Policies()
-
-	// Create a closure to handle building the expression for one policy.
-	buildForPolicy := func(p cat.Policy, restrictive bool) {
-		if !p.AppliesToRole(r.user) || !policyAppliesToCommandScope(p, cmdScope) {
-			return
-		}
-		policiesUsed.Add(p.ID)
-
-		var expr string
-		// If the WITH CHECK expression is missing, we default to the USING
-		// expression. If both are missing, then this policy doesn't apply and can
-		// be skipped.
-		if p.WithCheckExpr == "" {
-			if p.UsingExpr == "" {
-				return
+	extractColIDsForPolicies := func(policies []cat.Policy) {
+		for _, policy := range policies {
+			if checks.Contains(policy.ID) && policy.WithCheckExpr != "" {
+				for _, id := range policy.WithCheckColumnIDs {
+					colIDs.Add(int(id))
+				}
 			}
-			expr = p.UsingExpr
-			for _, id := range p.UsingColumnIDs {
-				colIDs.Add(int(id))
-			}
-		} else {
-			expr = p.WithCheckExpr
-			for _, id := range p.WithCheckColumnIDs {
-				colIDs.Add(int(id))
+			// Include columns from the USING expression. Note: if a WITH CHECK expression
+			// is present but empty, the USING expression will be applied instead.
+			if filters.Contains(policy.ID) || (checks.Contains(policy.ID) && policy.WithCheckExpr == "") {
+				for _, id := range policy.UsingColumnIDs {
+					colIDs.Add(int(id))
+				}
 			}
 		}
-		if sb.Len() != 0 {
-			if restrictive {
-				sb.WriteString(" AND ")
-			} else {
-				sb.WriteString(" OR ")
-			}
-		} else {
-			sb.WriteString("(") // Add the outer parenthesis that surrounds all permissive policies
-		}
-		sb.WriteString("(")
-		sb.WriteString(expr)
-		sb.WriteString(")")
 	}
-
-	for _, policy := range policies.Permissive {
-		buildForPolicy(policy, false /* restrictive */)
-	}
-	// If no permissive policies apply, then we will add a false check as
-	// nothing is allowed to be written.
-	if sb.Len() == 0 {
-		r.md.GetRLSMeta().NoPoliciesApplied = true
-		return "false"
-	}
-	sb.WriteString(")") // Close the outer parenthesis that surrounds all permissive policies
-	for _, policy := range policies.Restrictive {
-		buildForPolicy(policy, true /* restrictive */)
-	}
-
-	if sb.Len() == 0 {
-		panic(errors.AssertionFailedf("at least one applicable policy should have been included"))
-	}
-	r.md.GetRLSMeta().AddPoliciesUsed(r.tabMeta.MetaID, policiesUsed, false /* applyFilterExpr */)
-	return sb.String()
-}
-
-// isTableOwnerAndRLSNotForced returns true iff the user is the table owner and
-// the NO FORCE option is set.
-func (r *optRLSConstraintBuilder) isTableOwnerAndRLSNotForced(ctx context.Context) (bool, error) {
-	if r.tabMeta.Table.IsRowLevelSecurityForced() {
-		return false, nil
-	}
-	return r.oc.IsOwner(ctx, r.tabMeta.Table, r.user)
+	policies := tabMeta.Table.Policies()
+	extractColIDsForPolicies(policies.Permissive)
+	extractColIDsForPolicies(policies.Restrictive)
+	return colIDs.Ordered()
 }
 
 // rlsCheckConstraint is an implementation of cat.CheckConstraint for the

--- a/pkg/sql/opt/optbuilder/testdata/row_level_security
+++ b/pkg/sql/opt/optbuilder/testdata/row_level_security
@@ -259,7 +259,7 @@ insert t1
       │         ├── NULL::DATE [as=c3_default:9]
       │         └── unique_rowid() [as=rowid_default:10]
       └── projections
-           └── column1:7 > 0 [as=rls:11]
+           └── true AND (column1:7 > 0) [as=rls:11]
 
 # Verify policies apply to table with an existing check constraint.
 
@@ -297,7 +297,7 @@ insert t1_with_check
       │         └── unique_rowid() [as=rowid_default:8]
       └── projections
            ├── column1:6 > 0 [as=check1:9]
-           └── c2_default:7 > 2 [as=rls:10]
+           └── true AND (c2_default:7 > 2) [as=rls:10]
 
 # Verify a policy that has no WITH CHECK will use the USING expression for new rows.
 
@@ -336,7 +336,7 @@ insert t1
       │         ├── NULL::DATE [as=c3_default:9]
       │         └── unique_rowid() [as=rowid_default:10]
       └── projections
-           └── (c2_default:8 = 'Hello, World') OR (c3_default:9 = '2024-12-24') [as=rls:11]
+           └── true AND ((c2_default:8 = 'Hello, World') OR (c3_default:9 = '2024-12-24')) [as=rls:11]
 
 build
 UPDATE t1 SET c2 = 'new val';
@@ -392,7 +392,7 @@ insert t1
       │         ├── NULL::DATE [as=c3_default:9]
       │         └── unique_rowid() [as=rowid_default:10]
       └── projections
-           └── false [as=rls:11]
+           └── true AND false [as=rls:11]
 
 build
 UPDATE t1 SET c2 = 'new val';
@@ -460,7 +460,68 @@ insert t1
       │    └── projections
       │         └── unique_rowid() [as=rowid_default:13]
       └── projections
-           └── char_length(c2:8) < 10 [as=rls:14]
+           └── true AND (char_length(c2:8) < 10) [as=rls:14]
+
+# Apply SELECT policies on inserted rows if a RETURNING clause is present.
+# The first case handles inserts without RETURNING; the second handles inserts
+# with RETURNING.
+
+build
+INSERT INTO t1(c1) VALUES (10);
+----
+insert t1
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├── column1:7 => c1:1
+ │    ├── c2_default:8 => c2:2
+ │    ├── c3_default:9 => c3:3
+ │    └── rowid_default:10 => rowid:4
+ ├── check columns: rls:11
+ └── project
+      ├── columns: rls:11 column1:7!null c2_default:8 c3_default:9 rowid_default:10
+      ├── project
+      │    ├── columns: c2_default:8 c3_default:9 rowid_default:10 column1:7!null
+      │    ├── values
+      │    │    ├── columns: column1:7!null
+      │    │    └── (10,)
+      │    └── projections
+      │         ├── NULL::STRING [as=c2_default:8]
+      │         ├── NULL::DATE [as=c3_default:9]
+      │         └── unique_rowid() [as=rowid_default:10]
+      └── projections
+           └── true AND (char_length(c2_default:8) < 10) [as=rls:11]
+
+build
+INSERT INTO t1(c1) VALUES (10) RETURNING c1, c2;
+----
+project
+ ├── columns: c1:1!null c2:2
+ └── insert t1
+      ├── columns: c1:1!null c2:2 c3:3 rowid:4!null
+      ├── insert-mapping:
+      │    ├── column1:7 => c1:1
+      │    ├── c2_default:8 => c2:2
+      │    ├── c3_default:9 => c3:3
+      │    └── rowid_default:10 => rowid:4
+      ├── return-mapping:
+      │    ├── column1:7 => c1:1
+      │    ├── c2_default:8 => c2:2
+      │    ├── c3_default:9 => c3:3
+      │    └── rowid_default:10 => rowid:4
+      ├── check columns: rls:11
+      └── project
+           ├── columns: rls:11 column1:7!null c2_default:8 c3_default:9 rowid_default:10
+           ├── project
+           │    ├── columns: c2_default:8 c3_default:9 rowid_default:10 column1:7!null
+           │    ├── values
+           │    │    ├── columns: column1:7!null
+           │    │    └── (10,)
+           │    └── projections
+           │         ├── NULL::STRING [as=c2_default:8]
+           │         ├── NULL::DATE [as=c3_default:9]
+           │         └── unique_rowid() [as=rowid_default:10]
+           └── projections
+                └── (c3_default:9 IN ('2013-06-02', '1988-07-01')) AND (char_length(c2_default:8) < 10) [as=rls:11]
 
 exec-ddl
 DROP POLICY p_select on t1;
@@ -538,10 +599,9 @@ DROP POLICY p_update on t1;
 ----
 
 # Verify an upsert operation.
-# TODO(141998): There is more work needed to enforce the proper policies for upsert.
 
 exec-ddl
-CREATE TABLE t1_explicit_pk (C1 INT NOT NULL PRIMARY KEY, C2 TEXT, C3 DATE);
+CREATE TABLE t1_explicit_pk (C1 INT NOT NULL PRIMARY KEY, C2 TEXT, C3 TEXT);
 ----
 
 exec-ddl
@@ -549,30 +609,59 @@ ALTER TABLE t1_explicit_pk ENABLE ROW LEVEL SECURITY;
 ----
 
 exec-ddl
-CREATE POLICY p_insert ON t1_explicit_pk FOR INSERT WITH CHECK (c3 != '2023-05-02');
+CREATE POLICY p_select ON t1_explicit_pk FOR SELECT USING (c2 = '(c2) p_select policy')
 ----
 
 exec-ddl
-CREATE POLICY p_update ON t1_explicit_pk FOR UPDATE WITH CHECK (c3 >= '2000-01-01');
+CREATE POLICY p_insert ON t1_explicit_pk FOR INSERT WITH CHECK (c3 = '(c3) p_insert policy')
+----
+
+exec-ddl
+CREATE POLICY p_update ON t1_explicit_pk FOR UPDATE USING (c3 = '(c3) USING p_update policy') WITH CHECK (c3 != '(c3) WITH CHECK p_update policy');
 ----
 
 build
 UPSERT INTO t1_explicit_pk VALUES (1, 'first', '2010-08-08');
 ----
 upsert t1_explicit_pk
+ ├── arbiter indexes: t1_explicit_pk_pkey
  ├── columns: <none>
- ├── upsert-mapping:
+ ├── canary column: c1:9
+ ├── fetch columns: c1:9 c2:10 c3:11
+ ├── insert-mapping:
  │    ├── column1:6 => c1:1
  │    ├── column2:7 => c2:2
  │    └── column3:8 => c3:3
- ├── check columns: rls:9
+ ├── update-mapping:
+ │    ├── column2:7 => c2:2
+ │    └── column3:8 => c3:3
+ ├── check columns: rls:15
  └── project
-      ├── columns: rls:9!null column1:6!null column2:7!null column3:8!null
-      ├── values
-      │    ├── columns: column1:6!null column2:7!null column3:8!null
-      │    └── (1, 'first', '2010-08-08')
+      ├── columns: rls:15 column1:6!null column2:7!null column3:8!null c1:9 c2:10 c3:11 crdb_internal_mvcc_timestamp:12 tableoid:13 upsert_c1:14
+      ├── project
+      │    ├── columns: upsert_c1:14 column1:6!null column2:7!null column3:8!null c1:9 c2:10 c3:11 crdb_internal_mvcc_timestamp:12 tableoid:13
+      │    ├── left-join (hash)
+      │    │    ├── columns: column1:6!null column2:7!null column3:8!null c1:9 c2:10 c3:11 crdb_internal_mvcc_timestamp:12 tableoid:13
+      │    │    ├── ensure-upsert-distinct-on
+      │    │    │    ├── columns: column1:6!null column2:7!null column3:8!null
+      │    │    │    ├── grouping columns: column1:6!null
+      │    │    │    ├── values
+      │    │    │    │    ├── columns: column1:6!null column2:7!null column3:8!null
+      │    │    │    │    └── (1, 'first', '2010-08-08')
+      │    │    │    └── aggregations
+      │    │    │         ├── first-agg [as=column2:7]
+      │    │    │         │    └── column2:7
+      │    │    │         └── first-agg [as=column3:8]
+      │    │    │              └── column3:8
+      │    │    ├── scan t1_explicit_pk
+      │    │    │    ├── columns: c1:9!null c2:10 c3:11 crdb_internal_mvcc_timestamp:12 tableoid:13
+      │    │    │    └── flags: avoid-full-scan disabled not visible index feature
+      │    │    └── filters
+      │    │         └── column1:6 = c1:9
+      │    └── projections
+      │         └── CASE WHEN c1:9 IS NULL THEN column1:6 ELSE c1:9 END [as=upsert_c1:14]
       └── projections
-           └── column3:8 != '2023-05-02' [as=rls:9]
+           └── ((NOT (c1:9 IS NULL)) AND ((c2:10 = '(c2) p_select policy') AND ((c3:11 = '(c3) USING p_update policy') AND ((column2:7 = '(c2) p_select policy') AND (column3:8 != '(c3) WITH CHECK p_update policy'))))) OR ((c1:9 IS NULL) AND ((column2:7 = '(c2) p_select policy') AND (column3:8 = '(c3) p_insert policy'))) [as=rls:15]
 
 build
 INSERT INTO t1_explicit_pk VALUES (2, 'second', '2008-11-19') ON CONFLICT DO NOTHING;
@@ -606,7 +695,7 @@ insert t1_explicit_pk
       │         └── first-agg [as=column3:8]
       │              └── column3:8
       └── projections
-           └── column3:8 != '2023-05-02' [as=rls:14]
+           └── (column2:7 = '(c2) p_select policy') AND (column3:8 = '(c3) p_insert policy') [as=rls:14]
 
 build
 INSERT INTO t1_explicit_pk VALUES (2, 'second', '2008-11-19') ON CONFLICT (c1) DO UPDATE SET c2 = 'updated';
@@ -654,7 +743,66 @@ upsert t1_explicit_pk
       │         ├── CASE WHEN c1:9 IS NULL THEN column2:7 ELSE c2_new:14 END [as=upsert_c2:16]
       │         └── CASE WHEN c1:9 IS NULL THEN column3:8 ELSE c3:11 END [as=upsert_c3:17]
       └── projections
-           └── upsert_c3:17 != '2023-05-02' [as=rls:18]
+           └── ((NOT (c1:9 IS NULL)) AND ((c2:10 = '(c2) p_select policy') AND ((c3:11 = '(c3) USING p_update policy') AND ((upsert_c2:16 = '(c2) p_select policy') AND (upsert_c3:17 != '(c3) WITH CHECK p_update policy'))))) OR ((c1:9 IS NULL) AND ((upsert_c2:16 = '(c2) p_select policy') AND (upsert_c3:17 = '(c3) p_insert policy'))) [as=rls:18]
+
+# Recreate the update policy so that the USING expression is false and only the
+# WITH CHECK expression is set. This should cause the rls check to always be
+# false for conflicts.
+exec-ddl
+DROP POLICY p_update ON t1_explicit_pk;
+----
+
+exec-ddl
+CREATE POLICY p_update ON t1_explicit_pk FOR UPDATE WITH CHECK (c3 != '(c3) WITH CHECK p_update policy');
+----
+
+build
+INSERT INTO t1_explicit_pk VALUES (2, 'second', '2008-11-19') ON CONFLICT (c1) DO UPDATE SET c2 = 'updated';
+----
+upsert t1_explicit_pk
+ ├── arbiter indexes: t1_explicit_pk_pkey
+ ├── columns: <none>
+ ├── canary column: c1:9
+ ├── fetch columns: c1:9 c2:10 c3:11
+ ├── insert-mapping:
+ │    ├── column1:6 => c1:1
+ │    ├── column2:7 => c2:2
+ │    └── column3:8 => c3:3
+ ├── update-mapping:
+ │    └── upsert_c2:16 => c2:2
+ ├── check columns: rls:18
+ └── project
+      ├── columns: rls:18 column1:6!null column2:7!null column3:8!null c1:9 c2:10 c3:11 crdb_internal_mvcc_timestamp:12 tableoid:13 c2_new:14!null upsert_c1:15 upsert_c2:16!null upsert_c3:17
+      ├── project
+      │    ├── columns: upsert_c1:15 upsert_c2:16!null upsert_c3:17 column1:6!null column2:7!null column3:8!null c1:9 c2:10 c3:11 crdb_internal_mvcc_timestamp:12 tableoid:13 c2_new:14!null
+      │    ├── project
+      │    │    ├── columns: c2_new:14!null column1:6!null column2:7!null column3:8!null c1:9 c2:10 c3:11 crdb_internal_mvcc_timestamp:12 tableoid:13
+      │    │    ├── left-join (hash)
+      │    │    │    ├── columns: column1:6!null column2:7!null column3:8!null c1:9 c2:10 c3:11 crdb_internal_mvcc_timestamp:12 tableoid:13
+      │    │    │    ├── ensure-upsert-distinct-on
+      │    │    │    │    ├── columns: column1:6!null column2:7!null column3:8!null
+      │    │    │    │    ├── grouping columns: column1:6!null
+      │    │    │    │    ├── values
+      │    │    │    │    │    ├── columns: column1:6!null column2:7!null column3:8!null
+      │    │    │    │    │    └── (2, 'second', '2008-11-19')
+      │    │    │    │    └── aggregations
+      │    │    │    │         ├── first-agg [as=column2:7]
+      │    │    │    │         │    └── column2:7
+      │    │    │    │         └── first-agg [as=column3:8]
+      │    │    │    │              └── column3:8
+      │    │    │    ├── scan t1_explicit_pk
+      │    │    │    │    ├── columns: c1:9!null c2:10 c3:11 crdb_internal_mvcc_timestamp:12 tableoid:13
+      │    │    │    │    └── flags: avoid-full-scan disabled not visible index feature
+      │    │    │    └── filters
+      │    │    │         └── column1:6 = c1:9
+      │    │    └── projections
+      │    │         └── 'updated' [as=c2_new:14]
+      │    └── projections
+      │         ├── CASE WHEN c1:9 IS NULL THEN column1:6 ELSE c1:9 END [as=upsert_c1:15]
+      │         ├── CASE WHEN c1:9 IS NULL THEN column2:7 ELSE c2_new:14 END [as=upsert_c2:16]
+      │         └── CASE WHEN c1:9 IS NULL THEN column3:8 ELSE c3:11 END [as=upsert_c3:17]
+      └── projections
+           └── ((NOT (c1:9 IS NULL)) AND ((c2:10 = '(c2) p_select policy') AND (false AND ((upsert_c2:16 = '(c2) p_select policy') AND (upsert_c3:17 != '(c3) WITH CHECK p_update policy'))))) OR ((c1:9 IS NULL) AND ((upsert_c2:16 = '(c2) p_select policy') AND (upsert_c3:17 = '(c3) p_insert policy'))) [as=rls:18]
 
 exec-ddl
 DROP POLICY p_insert ON t1_explicit_pk;
@@ -702,7 +850,7 @@ project
       │    ├── scan t1_explicit_pk
       │    │    └── columns: c1:1!null c2:2 c3:3 crdb_internal_mvcc_timestamp:4 tableoid:5
       │    └── filters
-      │         └── (((((c1:1 = 1) OR (c1:1 = 2)) OR (c1:1 = 3)) OR (c1:1 = 4)) AND ((c1:1 % 2) = 0)) AND ((c1:1 % 3) = 0)
+      │         └── ((((((c2:2 = '(c2) p_select policy') OR (c1:1 = 1)) OR (c1:1 = 2)) OR (c1:1 = 3)) OR (c1:1 = 4)) AND ((c1:1 % 2) = 0)) AND ((c1:1 % 3) = 0)
       └── filters
            └── c3:3 >= '2025-01-01'
 
@@ -722,10 +870,10 @@ insert t1_explicit_pk
       │    ├── columns: column1:6!null column2:7!null column3:8!null
       │    └── (8, 'eight', '2002-05-04')
       └── projections
-           └── (((((column1:6 = 1) OR (column1:6 = 2)) OR (column1:6 = 3)) OR (column1:6 = 4)) AND ((column1:6 % 2) = 0)) AND ((column1:6 % 3) = 0) [as=rls:9]
+           └── true AND ((((((column1:6 = 1) OR (column1:6 = 2)) OR (column1:6 = 3)) OR (column1:6 = 4)) AND ((column1:6 % 2) = 0)) AND ((column1:6 % 3) = 0)) [as=rls:9]
 
 build
-UPDATE t1_explicit_pk SET c3 = now() WHERE c1 = 18;
+UPDATE t1_explicit_pk SET c3 = 'updated value' WHERE c1 = 18;
 ----
 update t1_explicit_pk
  ├── columns: <none>
@@ -734,9 +882,9 @@ update t1_explicit_pk
  │    └── c3_new:11 => c3:3
  ├── check columns: rls:12
  └── project
-      ├── columns: rls:12!null c1:6!null c2:7 c3:8 crdb_internal_mvcc_timestamp:9 tableoid:10 c3_new:11
+      ├── columns: rls:12 c1:6!null c2:7 c3:8 crdb_internal_mvcc_timestamp:9 tableoid:10 c3_new:11!null
       ├── project
-      │    ├── columns: c3_new:11 c1:6!null c2:7 c3:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+      │    ├── columns: c3_new:11!null c1:6!null c2:7 c3:8 crdb_internal_mvcc_timestamp:9 tableoid:10
       │    ├── select
       │    │    ├── columns: c1:6!null c2:7 c3:8 crdb_internal_mvcc_timestamp:9 tableoid:10
       │    │    ├── select
@@ -745,13 +893,13 @@ update t1_explicit_pk
       │    │    │    │    ├── columns: c1:6!null c2:7 c3:8 crdb_internal_mvcc_timestamp:9 tableoid:10
       │    │    │    │    └── flags: avoid-full-scan
       │    │    │    └── filters
-      │    │    │         └── ((((((c1:6 = 1) OR (c1:6 = 2)) OR (c1:6 = 3)) OR (c1:6 = 4)) AND ((c1:6 % 2) = 0)) AND ((c1:6 % 3) = 0)) AND ((((((c1:6 = 1) OR (c1:6 = 2)) OR (c1:6 = 3)) OR (c1:6 = 4)) AND ((c1:6 % 2) = 0)) AND ((c1:6 % 3) = 0))
+      │    │    │         └── (((((((c2:7 = '(c2) p_select policy') OR (c1:6 = 1)) OR (c1:6 = 2)) OR (c1:6 = 3)) OR (c1:6 = 4)) AND ((c1:6 % 2) = 0)) AND ((c1:6 % 3) = 0)) AND ((((((c1:6 = 1) OR (c1:6 = 2)) OR (c1:6 = 3)) OR (c1:6 = 4)) AND ((c1:6 % 2) = 0)) AND ((c1:6 % 3) = 0))
       │    │    └── filters
       │    │         └── c1:6 = 18
       │    └── projections
-      │         └── now() [as=c3_new:11]
+      │         └── 'updated value' [as=c3_new:11]
       └── projections
-           └── ((((((c1:6 = 1) OR (c1:6 = 2)) OR (c1:6 = 3)) OR (c1:6 = 4)) AND ((c1:6 % 2) = 0)) AND ((c1:6 % 3) = 0)) AND ((((((c1:6 = 1) OR (c1:6 = 2)) OR (c1:6 = 3)) OR (c1:6 = 4)) AND ((c1:6 % 2) = 0)) AND ((c1:6 % 3) = 0)) [as=rls:12]
+           └── (((((((c2:7 = '(c2) p_select policy') OR (c1:6 = 1)) OR (c1:6 = 2)) OR (c1:6 = 3)) OR (c1:6 = 4)) AND ((c1:6 % 2) = 0)) AND ((c1:6 % 3) = 0)) AND ((((((c1:6 = 1) OR (c1:6 = 2)) OR (c1:6 = 3)) OR (c1:6 = 4)) AND ((c1:6 % 2) = 0)) AND ((c1:6 % 3) = 0)) [as=rls:12]
 
 # Show that the owner, who is not admin, is exempt from policies unless FORCE
 # option is set.
@@ -850,7 +998,7 @@ insert t1
       │         ├── NULL::DATE [as=c3_default:9]
       │         └── unique_rowid() [as=rowid_default:10]
       └── projections
-           └── c3_default:9 >= '2025-01-01' [as=rls:11]
+           └── true AND (c3_default:9 >= '2025-01-01') [as=rls:11]
 
 # Tests for when stored virtual column is used in an RLS expression
 
@@ -957,7 +1105,7 @@ insert t
       │    └── projections
       │         └── column4:11 + 1 [as=v_comp:12]
       └── projections
-           └── v_comp:12 > 1 [as=rls:13]
+           └── true AND (v_comp:12 > 1) [as=rls:13]
 
 build
 UPDATE t SET c = -10 WHERE k = 1;
@@ -1101,7 +1249,7 @@ insert t
       │    └── projections
       │         └── column4:11 + 1 [as=v_comp:12]
       └── projections
-           └── v_comp:12 > 1 [as=rls:13]
+           └── true AND (v_comp:12 > 1) [as=rls:13]
 
 build
 UPDATE t SET c = -10 WHERE k = 1;

--- a/pkg/sql/opt/optbuilder/update.go
+++ b/pkg/sql/opt/optbuilder/update.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
@@ -336,7 +337,8 @@ func (mb *mutationBuilder) buildUpdate(returning *tree.ReturningExprs) {
 	mb.disambiguateColumns()
 
 	// Add any check constraint boolean columns to the input.
-	mb.addCheckConstraintCols(true /* isUpdate */)
+	mb.addCheckConstraintCols(true, /* isUpdate */
+		cat.PolicyScopeUpdate, false /* includeSelectOnInsert */)
 
 	// Add the partial index predicate expressions to the table metadata.
 	// These expressions are used to prune fetch columns during

--- a/pkg/sql/opt/row_level_security.go
+++ b/pkg/sql/opt/row_level_security.go
@@ -85,6 +85,25 @@ func (r *RowLevelSecurityMeta) AddPoliciesUsed(
 	r.PoliciesApplied[tableID] = a
 }
 
+// GetPoliciesUsed returns the policies that are in use for a particular table.
+func (r *RowLevelSecurityMeta) GetPoliciesUsed(
+	tableID TableID,
+) (filters PolicyIDSet, checks PolicyIDSet) {
+	if a, ok := r.PoliciesApplied[tableID]; ok {
+		return a.Filter, a.Check
+	}
+	return PolicyIDSet{}, PolicyIDSet{}
+}
+
+// RefreshNoPoliciesAppliedForTable should be called after policy application
+// is complete for a given table. If no policies were recorded for the table,
+// it updates the 'NoPoliciesApplied' flag to indicate this.
+func (r *RowLevelSecurityMeta) RefreshNoPoliciesAppliedForTable(tableID TableID) {
+	if _, ok := r.PoliciesApplied[tableID]; !ok {
+		r.NoPoliciesApplied = true
+	}
+}
+
 // PoliciesApplied stores the set of policies that were applied to a table.
 type PoliciesApplied struct {
 	// NoForceExempt is true if the policies were exempt because they were the


### PR DESCRIPTION
Previously, row-level security (RLS) was not enforced for UPSERT statements. This change introduces full RLS support for the following UPSERT variants:
- UPSERT
- INSERT … ON CONFLICT DO UPDATE
- INSERT … ON CONFLICT DO NOTHING

The specific RLS policies enforced during an UPSERT depend on whether a row conflict occurs:
- No Conflict (row is inserted):
  - SELECT/ALL: used to scan for potential conflicts.
  - INSERT/ALL: enforced on the newly inserted row.
- Conflict (row is updated):
  - SELECT/ALL: enforced to verify access to the conflicting row.
  - UPDATE/ALL: enforced on the row being updated.

Importantly, SELECT/ALL policies used in conflict detection are not applied as filters. Filtering out unauthorized rows would permit inserting duplicates. Instead, we enforce these policies via explicit checks: if the user is not authorized to see the conflicting row, the UPSERT fails.

To support this behaviour, we reused the single synthetic check constraint per table. It now has a combined expression that captures all relevant RLS checks for UPSERTs:
1. Enforce SELECT/ALL on existing rows during conflict detection.
2. Enforce UPDATE/ALL on conflicting rows that are updated.
3. Enforce INSERT/ALL on new rows that are inserted.

This implementation differs from PostgreSQL in one key way. In Postgres, the VALUES clause is always subject to constraint and policy checks—even if the row is not written due to a conflict. This is a known limitation discussed in #35370.

As a result, we allow statements like the following to succeed if a conflict occurs, even when the VALUES clause violates RLS:
```
INSERT INTO t VALUES (...violates RLS...) ON CONFLICT DO UPDATE SET ...complies with RLS...;
INSERT INTO t VALUES (...violates RLS...) ON CONFLICT DO NOTHING;
```

Closes #141998
Closes #144802 

Epic: CRDB-11724
Release note: none