### PR TITLE
jsonpath: add support for key access wildcards

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/jsonb_path_query
+++ b/pkg/sql/logictest/testdata/logic_test/jsonb_path_query
@@ -1,11 +1,6 @@
 # LogicTest: !local-mixed-24.3 !local-mixed-25.1
 
 query T
-SELECT jsonb_path_query('"\\"', '$ ? (@ like_regex "^\\\\$")');
-----
-"\\"
-
-query T
 SELECT jsonb_path_query('{}', '$')
 ----
 {}
@@ -914,12 +909,21 @@ SELECT jsonb_path_query('[null, 1, "abc", "abd", "aBdC", "abdacb", "babc", "adc\
 "abc"
 "abdacb"
 
-# TODO(normanchenn): support scanning identQuote within regex.
-# SELECT jsonb_path_query('"He said \"Hello\\World!\""', '$ ? (@ like_regex ".*\"H.*\\\\.*!.*\".*")');
+query T
+SELECT jsonb_path_query('"He said \"Hello\\World!\""', '$ ? (@ like_regex ".*\"H.*\\\\.*!.*\".*")');
+----
+"He said \"Hello\\World!\""
+
+query T rowsort
+SELECT jsonb_path_query('{"a": [1, 2], "b": "hello"}', '$.a ? ($.b == "hello") ');
+----
+1
+2
+
+query T
+SELECT jsonb_path_query('{"a": [1, 2], "b": "hello"}', 'strict $.a ? ($.b == "hello") ');
+----
+[1, 2]
 
 # select jsonb_path_query('[1, 2, 3, 4, 5]', '$[-1]');
 # select jsonb_path_query('[1, 2, 3, 4, 5]', 'strict $[-1]');
-
-# interesting functionality
-# select jsonb_path_query('{"a": [1, 2], "b": "hello"}', '$.a ? ($.b == "hello") ');
-# select jsonb_path_query('{"a": [1, 2], "b": "hello"}', '$.a');

--- a/pkg/sql/logictest/testdata/logic_test/jsonb_path_query
+++ b/pkg/sql/logictest/testdata/logic_test/jsonb_path_query
@@ -925,5 +925,36 @@ SELECT jsonb_path_query('{"a": [1, 2], "b": "hello"}', 'strict $.a ? ($.b == "he
 ----
 [1, 2]
 
+query T rowsort
+SELECT jsonb_path_query('{"a": "world", "b": 2, "c": true}', '$.*');
+----
+"world"
+2
+true
+
+query T rowsort
+SELECT jsonb_path_query('{"a": ["hello", "world"], "b": [2, 5], "c": [true, false], "d": "non-array"}', '$.*[1]');
+----
+"world"
+5
+false
+
+query T
+SELECT jsonb_path_query('{"a": {"ab": 1}, "b": {"bc": 2}, "c": {"cd": 3}}', '$.*.bc');
+----
+2
+
+query empty
+SELECT jsonb_path_query('{}', '$.*');
+
+query empty
+SELECT jsonb_path_query('[1, 2, 3, 4, 5]', '$.*');
+
+query T rowsort
+SELECT jsonb_path_query('{"a": {"x": {"y": 1}}, "b": {"x": {"z": 2}}}', '$.*.x.*');
+----
+1
+2
+
 # select jsonb_path_query('[1, 2, 3, 4, 5]', '$[-1]');
 # select jsonb_path_query('[1, 2, 3, 4, 5]', 'strict $[-1]');

--- a/pkg/sql/logictest/testdata/logic_test/jsonpath
+++ b/pkg/sql/logictest/testdata/logic_test/jsonpath
@@ -100,6 +100,56 @@ SELECT bpchar('$.   abc    [*]':::JSONPATH::JSONPATH)::BPCHAR FROM t ORDER BY 1 
 ----
 $."abc"[*]
 
+query T
+SELECT '$.a[*] ? (@.b == 1 && @.c != 1)'::JSONPATH
+----
+$."a"[*]?(((@."b" == 1) && (@."c" != 1)))
+
+query T
+SELECT '$.a[*] ? (@.b != 1)'::JSONPATH
+----
+$."a"[*]?((@."b" != 1))
+
+query T
+SELECT '$.a[*] ? (@.b < 1)'::JSONPATH
+----
+$."a"[*]?((@."b" < 1))
+
+query T
+SELECT '$.a[*] ? (@.b <= 1)'::JSONPATH
+----
+$."a"[*]?((@."b" <= 1))
+
+query T
+SELECT '$.a[*] ? (@.b > 1)'::JSONPATH
+----
+$."a"[*]?((@."b" > 1))
+
+query T
+SELECT '$.a[*] ? (@.b >= 1)'::JSONPATH
+----
+$."a"[*]?((@."b" >= 1))
+
+query T
+SELECT '$.a ? ($.b == 1)'::JSONPATH
+----
+$."a"?(($."b" == 1))
+
+query T
+SELECT '$.a ? (@.b == 1).c ? (@.d == 2)'::JSONPATH
+----
+$."a"?((@."b" == 1))."c"?((@."d" == 2))
+
+query T
+SELECT '$.a?(@.b==1).c?(@.d==2)'::JSONPATH
+----
+$."a"?((@."b" == 1))."c"?((@."d" == 2))
+
+query T
+SELECT '$  .  a  ?  (  @  .  b  ==  1  )  .  c  ?  (  @  .  d  ==  2  )  '::JSONPATH
+----
+$."a"?((@."b" == 1))."c"?((@."d" == 2))
+
 ## When we allow table creation
 
 # statement ok
@@ -133,56 +183,6 @@ $."abc"[*]
 # $.*
 
 # query T
-# SELECT '$.a[*] ? (@.b == 1 && @.c != 1)'::JSONPATH
-# ----
-# $.a[*] ? (@.b == 1 && @.c != 1)
-
-# query T
-# SELECT '$.a[*] ? (@.b != 1)'::JSONPATH
-# ----
-# $.a[*] ? (@.b != 1)
-
-# query T
-# SELECT '$.a[*] ? (@.b < 1)'::JSONPATH
-# ----
-# $.a[*] ? (@.b < 1)
-
-# query T
-# SELECT '$.a[*] ? (@.b <= 1)'::JSONPATH
-# ----
-# $.a[*] ? (@.b <= 1)
-
-# query T
-# SELECT '$.a[*] ? (@.b > 1)'::JSONPATH
-# ----
-# $.a[*] ? (@.b > 1)
-
-# query T
-# SELECT '$.a[*] ? (@.b >= 1)'::JSONPATH
-# ----
-# $.a[*] ? (@.b >= 1)
-
-# query T
-# SELECT '$.a ? (@.b == 1).c ? (@.d == 2)'::JSONPATH
-# ----
-# $.a ? (@.b == 1).c ? (@.d == 2)
-
-# query T
-# SELECT '$.a?(@.b==1).c?(@.d==2)'::JSONPATH
-# ----
-# $.a?(@.b==1).c?(@.d==2)
-
-# query T
-# SELECT '$  .  a  ?  (  @  .  b  ==  1  )  .  c  ?  (  @  .  d  ==  2  )  '::JSONPATH
-# ----
-# $  .  a  ?  (  @  .  b  ==  1  )  .  c  ?  (  @  .  d  ==  2  )
-
-# query T
 # SELECT '$.a.type()'::JSONPATH
 # ----
 # $.a.type()
-
-# query T
-# SELECT '$.a ? ($.b == 1)'::JSONPATH
-# ----
-# $.a ? ($.b == 1)

--- a/pkg/util/jsonpath/eval/key.go
+++ b/pkg/util/jsonpath/eval/key.go
@@ -33,3 +33,17 @@ func (ctx *jsonpathCtx) evalKey(
 	}
 	return []json.JSON{}, nil
 }
+
+func (ctx *jsonpathCtx) evalAnyKey(
+	anyKey jsonpath.AnyKey, jsonValue json.JSON, unwrap bool,
+) ([]json.JSON, error) {
+	if jsonValue.Type() == json.ObjectJSONType {
+		return ctx.executeAnyItem(nil /* jsonPath */, jsonValue, !ctx.strict /* unwrapNext */)
+	} else if unwrap && jsonValue.Type() == json.ArrayJSONType {
+		return ctx.unwrapCurrentTargetAndEval(anyKey, jsonValue, false /* unwrapNext */)
+	} else if ctx.strict {
+		return nil, pgerror.Newf(pgcode.SQLJSONObjectNotFound,
+			"jsonpath wildcard member accessor can only be applied to an object")
+	}
+	return []json.JSON{}, nil
+}

--- a/pkg/util/jsonpath/expr.go
+++ b/pkg/util/jsonpath/expr.go
@@ -129,3 +129,9 @@ var _ tree.RegexpCacheKey = Regex{}
 func (r Regex) Pattern() (string, error) {
 	return r.Regex, nil
 }
+
+type AnyKey struct{}
+
+var _ Path = AnyKey{}
+
+func (a AnyKey) String() string { return ".*" }

--- a/pkg/util/jsonpath/parser/jsonpath.y
+++ b/pkg/util/jsonpath/parser/jsonpath.y
@@ -311,6 +311,10 @@ accessor_op:
   {
     $$.val = jsonpath.Filter{Condition: $3.path()}
   }
+| '.' '*'
+  {
+    $$.val = jsonpath.AnyKey{}
+  }
 ;
 
 key:
@@ -430,6 +434,7 @@ comp_op:
   }
 ;
 
+// TODO(normanchenn): support negative numbers.
 scalar_value:
   VARIABLE
   {

--- a/pkg/util/jsonpath/parser/testdata/jsonpath
+++ b/pkg/util/jsonpath/parser/testdata/jsonpath
@@ -459,6 +459,17 @@ $.a ? (@.b like_regex "^[aeiou]")
 ----
 $."a"?((@."b" like_regex "^[aeiou]")) -- normalized!
 
+parse
+$.*
+----
+$.*
+
+parse
+$.abc.*.def.*
+----
+$."abc".*."def".* -- normalized!
+
+
 # postgres allows floats as array indexes
 # parse
 # $.abc[1.0]


### PR DESCRIPTION
#### logictest: clean up jsonpath logictests

This commit cleans up some jsonpath-related logictests. Some tests that
were commented out previously due to some functionality not being
supported yet within jsonpath have now been uncommented.

Epic: None
Release note: None

#### jsonpath: add support for key access wildcards

This commit adds support for wildcard key accessors within jsonpath
queries.

Epic: None
Release note (sql change): Add support for wildcard key accessors in
JSONPath queries. For example, `SELECT jsonb_path_query('{"a": 1, "b": true}', '$.*');`.