### PR TITLE
roachtest: handle flaky node-postgres tests

### DIFF
--- a/pkg/cmd/roachtest/tests/nodejs_postgres.go
+++ b/pkg/cmd/roachtest/tests/nodejs_postgres.go
@@ -150,14 +150,22 @@ PGSSLCERT=$HOME/certs/client.%[1]s.crt PGSSLKEY=$HOME/certs/client.%[1]s.key PGS
 		rawResultsStr := result.Stdout + result.Stderr
 		t.L().Printf("Test Results: %s", rawResultsStr)
 		if err != nil {
-			// The one failing test is `pool size of 1` which
-			// fails because it does SELECT count(*) FROM pg_stat_activity which is
-			// not implemented in CRDB.
-			if strings.Contains(rawResultsStr, "1 failing") &&
-				// Failing tests are listed numerically, we only expect one.
-				// The one failing test should be "pool size of 1".
-				strings.Contains(rawResultsStr, "1) pool size of 1") {
-				err = nil
+			// Check for expected test failures. We allow:
+			// 1. One failing test that is "pool size of 1"
+			// 2. One failing test that is "events"
+			// 3. Two failing tests that are exactly "events" and "pool size of 1"
+			if strings.Contains(rawResultsStr, "1 failing") {
+				// Single test failure case
+				if strings.Contains(rawResultsStr, "1) pool size of 1") ||
+					strings.Contains(rawResultsStr, "1) events") {
+					err = nil
+				}
+			} else if strings.Contains(rawResultsStr, "2 failing") {
+				// Two test failures case - must be exactly events and pool size of 1
+				if strings.Contains(rawResultsStr, "1) events") &&
+					strings.Contains(rawResultsStr, "2) pool size of 1") {
+					err = nil
+				}
 			}
 			if err != nil {
 				t.Fatal(err)


### PR DESCRIPTION
Previously, we would only handle the "pool size of 1" flaky test in the node-postgres roachtest. However, there is another flaky test "events" which fails with "expected 0 to equal 20". This change updates the error handling to properly handle both known flaky tests while maintaining the existing behavior of failing on any other errors.

Fixes: #143047
Release note: none