### PR TITLE
jsonpath: add support for unary arithmetic operators

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/jsonb_path_query
+++ b/pkg/sql/logictest/testdata/logic_test/jsonb_path_query
@@ -956,5 +956,80 @@ SELECT jsonb_path_query('{"a": {"x": {"y": 1}}, "b": {"x": {"z": 2}}}', '$.*.x.*
 1
 2
 
-# select jsonb_path_query('[1, 2, 3, 4, 5]', '$[-1]');
-# select jsonb_path_query('[1, 2, 3, 4, 5]', 'strict $[-1]');
+query T
+SELECT jsonb_path_query('{}', '-1');
+----
+-1
+
+query T rowsort
+SELECT jsonb_path_query('[1, 2, 3]', '-$[*]');
+----
+-1
+-2
+-3
+
+query T rowsort
+SELECT jsonb_path_query('[1, 2, 3]', '-$');
+----
+-1
+-2
+-3
+
+query T
+SELECT jsonb_path_query('{}', '1 + 2 * -4');
+----
+-7
+
+query T
+SELECT jsonb_path_query('{"a": -10, "b": -5}', '$.a * -2 + $.b');
+----
+15
+
+query T rowsort
+SELECT jsonb_path_query('[1, -2, 3, -4]', '$[*] ? (@ < -1)');
+----
+-2
+-4
+
+query T
+SELECT jsonb_path_query('{"x": 5, "y": -3}', '(-$.x * 2 + $.y) / -1')
+----
+13.000000000000000000
+
+statement error pgcode 22012 pq: division by zero
+SELECT jsonb_path_query('{"x": 5, "y": -3}', '(-$.x * 2 + $.y) / -0')
+
+query empty
+SELECT jsonb_path_query('[1, 2, 3, 4, 5]', '$[-1]');
+
+statement error pgcode 22033 pq: jsonpath array subscript is out of bounds
+SELECT jsonb_path_query('[1, 2, 3, 4, 5]', 'strict $[-1]');
+
+statement error pgcode 22038 pq: operand of unary jsonpath operator - is not a numeric value
+SELECT jsonb_path_query('[1, 2, 3, 4, "hello"]', '-$[*]');
+
+statement error pgcode 22038 pq: operand of unary jsonpath operator \+ is not a numeric value
+SELECT jsonb_path_query('null', '+$');
+
+query T
+SELECT jsonb_path_query('{}', '+1');
+----
+1
+
+query T rowsort
+SELECT jsonb_path_query('[1, 2, 3]', '+$[*]');
+----
+1
+2
+3
+
+query T
+SELECT jsonb_path_query('{}', '+1 + 2 * +4');
+----
+9
+
+query T rowsort
+SELECT jsonb_path_query('[1, 2, 3, 4]', '$[*] ? (@ > +2)');
+----
+3
+4

--- a/pkg/util/jsonpath/eval/array.go
+++ b/pkg/util/jsonpath/eval/array.go
@@ -116,7 +116,7 @@ func jsonArrayValueAtIndex(ctx *jsonpathCtx, jsonValue json.JSON, index int) (js
 		return nil, pgerror.Newf(pgcode.InvalidSQLJSONSubscript, "jsonpath array subscript is out of bounds")
 	}
 	if index < 0 {
-		// Shouldn't happen, not supported in parser.
+		// Shouldn't happen, would have been caught above.
 		return nil, errors.AssertionFailedf("negative array index")
 	}
 	return jsonValue.FetchValIdx(index)

--- a/pkg/util/jsonpath/eval/eval.go
+++ b/pkg/util/jsonpath/eval/eval.go
@@ -104,11 +104,7 @@ func (ctx *jsonpathCtx) eval(
 		}
 		return []json.JSON{resolved}, nil
 	case jsonpath.Operation:
-		res, err := ctx.evalOperation(path, jsonValue)
-		if err != nil {
-			return nil, err
-		}
-		return []json.JSON{res}, nil
+		return ctx.evalOperation(path, jsonValue)
 	case jsonpath.Filter:
 		return ctx.evalFilter(path, jsonValue, unwrap)
 	default:

--- a/pkg/util/jsonpath/parser/jsonpath.y
+++ b/pkg/util/jsonpath/parser/jsonpath.y
@@ -202,6 +202,7 @@ func unaryOp(op jsonpath.OperationType, left jsonpath.Path) jsonpath.Operation {
 
 %left '+' '-'
 %left '*' '/' '%'
+%left UMINUS
 
 %%
 
@@ -248,6 +249,14 @@ expr:
   {
     $$.val = $2.path()
   }
+| '+' expr %prec UMINUS
+  {
+    $$.val = unaryOp(jsonpath.OpPlus, $2.path())
+  }
+| '-' expr %prec UMINUS
+  {
+    $$.val = unaryOp(jsonpath.OpMinus, $2.path())
+  }
 | expr '+' expr
   {
     $$.val = binaryOp(jsonpath.OpAdd, $1.path(), $3.path())
@@ -268,7 +277,6 @@ expr:
   {
     $$.val = binaryOp(jsonpath.OpMod, $1.path(), $3.path())
   }
-// TODO(normanchenn): add unary + and -.
 ;
 
 accessor_expr:
@@ -434,7 +442,6 @@ comp_op:
   }
 ;
 
-// TODO(normanchenn): support negative numbers.
 scalar_value:
   VARIABLE
   {

--- a/pkg/util/jsonpath/parser/testdata/jsonpath
+++ b/pkg/util/jsonpath/parser/testdata/jsonpath
@@ -469,6 +469,30 @@ $.abc.*.def.*
 ----
 $."abc".*."def".* -- normalized!
 
+parse
+-1
+----
+(-1) -- normalized!
+
+parse
+- "hello"
+----
+(-"hello") -- normalized!
+
+parse
++ "hello"
+----
+(+"hello") -- normalized!
+
+parse
+- - $.a[2]
+----
+(-(-$."a"[2])) -- normalized!
+
+parse
+1 + 2 * -4
+----
+(1 + (2 * (-4))) -- normalized!
 
 # postgres allows floats as array indexes
 # parse


### PR DESCRIPTION
This commit adds support for unary + and unary - operators within
jsonpath queries. This allows for the evaluation of negative numbers.

Epic: None
Release note (sql change): Add support for unary arithmetic operators in
JSONPath queries. For example, `SELECT jsonb_path_query('[1, 2, 3]', '-$');`.
