### PR TITLE
roachprod: update gc job image

### DIFF
--- a/pkg/roachprod/k8s/roachprod-gc.yaml
+++ b/pkg/roachprod/k8s/roachprod-gc.yaml
@@ -31,7 +31,7 @@ spec:
         spec:
           containers:
             - name: roachprod-gc-cronjob
-              image: gcr.io/cockroach-dev-inf/cockroachlabs/roachprod:ea736e6ab07
+              image: gcr.io/cockroach-dev-inf/cockroachlabs/roachprod:13afd784242
               args:
                 - gc
                 - --gce-project=cockroach-ephemeral,cockroach-roachstress


### PR DESCRIPTION
This patch updates the GC job image to latest.

Epic: none
Release note: None