### PR TITLE
cspann: check level of root partition in delete vector fixup

### DIFF
--- a/pkg/sql/vecindex/cspann/testdata/delete.ddt
+++ b/pkg/sql/vecindex/cspann/testdata/delete.ddt
@@ -231,6 +231,55 @@ vec1: (1, 2)
     └───• vec2 (7, 4)
 
 # ----------------------------------------------------------------------
+# Delete vector from root partition just after a split.
+# ----------------------------------------------------------------------
+
+# Load root partition that exceeds the max partition size.
+load-index min-partition-size=1 max-partition-size=3 beam-size=2
+• 1 (0, 0)
+│
+├───• vec1 (1, 2)
+├───• vec2 (7, 4)
+├───• vec3 (4, 3)
+└───• vec4 (5, 5)
+----
+Loaded 4 vectors.
+
+# Delete vector from primary index, but not from secondary index.
+delete not-found
+vec3
+----
+• 1 (0, 0)
+│
+├───• vec1 (1, 2)
+├───• vec2 (7, 4)
+├───• vec3 (MISSING)
+└───• vec4 (5, 5)
+
+# Search triggers a split, followed by an attempt to delete the missing vector.
+# However, the split changes the root partition level, so the fixup should
+# abort.
+search max-results=1
+(4, 3)
+----
+vec4: 5 (centroid=7.07)
+4 leaf vectors, 4 vectors, 4 full vectors, 1 partitions
+
+# Split should detect missing vector and remove it.
+format-tree
+----
+• 1 (3.5, 3.25)
+│
+├───• 2 (6, 4.5)
+│   │
+│   ├───• vec4 (5, 5)
+│   └───• vec2 (7, 4)
+│
+└───• 3 (1, 2)
+    │
+    └───• vec1 (1, 2)
+
+# ----------------------------------------------------------------------
 # Search root partition with only missing vectors.
 # ----------------------------------------------------------------------
 new-index min-partition-size=1 max-partition-size=3 beam-size=2


### PR DESCRIPTION
Dangling vectors should only exist in leaf partitions. However, the root partition's level changes when it's split. If there is a pending delete vector fixup for a partition that gets split, this results in a RemoveFromPartition call with the wrong level (e.g. LeafLevel when the partition's level is now SecondLevel). This causes an assert in the memstore, which expects the correct level.

The fix is to get the root partition's level when performing a delete vector fixup.

Epic: CRDB-42943

Release note: None