### PR TITLE
sql: add support for prefix columns to vector search

### DIFF
--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -4569,7 +4569,7 @@ func (dsp *DistSQLPlanner) planVectorSearch(
 
 	colTypes := getTypesFromResultColumns(planInfo.columns)
 	spec := &execinfrapb.VectorSearchSpec{
-		PrefixKey:           planInfo.prefixKey,
+		PrefixKeys:          planInfo.prefixKeys,
 		QueryVector:         queryVector,
 		TargetNeighborCount: planInfo.targetNeighborCount,
 	}

--- a/pkg/sql/distsql_spec_exec_factory.go
+++ b/pkg/sql/distsql_spec_exec_factory.go
@@ -1452,7 +1452,7 @@ func (e *distSQLSpecExecFactory) ConstructVectorSearch(
 	table cat.Table,
 	index cat.Index,
 	outCols exec.TableColumnOrdinalSet,
-	prefixKey constraint.Key,
+	prefixConstraint *constraint.Constraint,
 	queryVector tree.TypedExpr,
 	targetNeighborCount uint64,
 ) (exec.Node, error) {
@@ -1461,17 +1461,17 @@ func (e *distSQLSpecExecFactory) ConstructVectorSearch(
 	cols := makeColList(table, outCols)
 	resultCols := colinfo.ResultColumnsFromColumns(tabDesc.GetID(), cols)
 
-	// Encode the prefix values as a roachpb.Key.
+	// Encode the prefix constraint as a list of roachpb.Keys.
 	var sb span.Builder
 	sb.Init(e.planner.EvalContext(), e.planner.ExecCfg().Codec, tabDesc, indexDesc)
-	encPrefixKey, _, err := sb.EncodeConstraintKey(prefixKey)
+	prefixKeys, err := sb.KeysFromVectorPrefixConstraint(e.ctx, prefixConstraint)
 	if err != nil {
 		return nil, err
 	}
 	planInfo := &vectorSearchPlanningInfo{
 		table:               tabDesc,
 		index:               indexDesc,
-		prefixKey:           encPrefixKey,
+		prefixKeys:          prefixKeys,
 		queryVector:         queryVector,
 		targetNeighborCount: targetNeighborCount,
 		cols:                cols,

--- a/pkg/sql/execinfrapb/flow_diagram.go
+++ b/pkg/sql/execinfrapb/flow_diagram.go
@@ -103,9 +103,15 @@ func (v *VectorSearchSpec) summary() (string, []string) {
 		fmt.Sprintf("Nearest Neighbor Target Count: %d", v.TargetNeighborCount),
 		fmt.Sprintf("Query Vector: %s", vector.T(v.QueryVector).String()),
 	}
-	if len(v.PrefixKey) > 0 {
-		vals, _ := encoding.PrettyPrintValuesWithTypes(nil /* valDirs */, v.PrefixKey)
-		details = append(details, fmt.Sprintf("Prefix Vals: %s", strings.Join(vals, "/")))
+	if len(v.PrefixKeys) > 0 {
+		// Only show the first prefix key.
+		var spanStr strings.Builder
+		vals, _ := encoding.PrettyPrintValuesWithTypes(nil /* valDirs */, v.PrefixKeys[0])
+		spanStr.WriteString(fmt.Sprintf("Prefix Vals: %s", strings.Join(vals, "/")))
+		if len(v.PrefixKeys) > 1 {
+			spanStr.WriteString(fmt.Sprintf(" and %d more", len(v.PrefixKeys)-1))
+		}
+		details = append(details, spanStr.String())
 	}
 	return "VectorSearch", details
 }

--- a/pkg/sql/execinfrapb/processors_sql.proto
+++ b/pkg/sql/execinfrapb/processors_sql.proto
@@ -1102,9 +1102,9 @@ message InsertSpec {
 message VectorSearchSpec {
   optional sqlbase.IndexFetchSpec fetch_spec = 1 [(gogoproto.nullable) = false];
 
-  // PrefixKey constrains the prefix index columns to a single value. It is
-  // empty for an index without prefix columns.
-  optional bytes prefix_key = 2 [(gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/roachpb.Key"];
+  // PrefixKeys, if set, contains keys that each constrain every index prefix
+  // column to a single value. It is set IFF the index has prefix columns.
+  repeated bytes prefix_keys = 2 [(gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/roachpb.Key"];
 
   // QueryVector is the vector to search for.
   repeated float query_vector = 3;

--- a/pkg/sql/opt/exec/execbuilder/testdata/not_visible_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/not_visible_index
@@ -576,8 +576,10 @@ vectorized: false
 │
 └── • render
     │
-    └── • index join
+    └── • lookup join
         │ table: t1@t1_pkey
+        │ equality: (rowid) = (rowid)
+        │ equality cols are key
         │
         └── • vector search
               table: t1@idx_vec_visible

--- a/pkg/sql/opt/exec/execbuilder/testdata/vector_search
+++ b/pkg/sql/opt/exec/execbuilder/testdata/vector_search
@@ -111,12 +111,11 @@ vectorized: false
                   target count: 5
                   query vector: '[1,2,3]'
 
-# NOTE: the vector-search rule doesn't yet handle prefix columns.
 query T
 EXPLAIN (VERBOSE) SELECT * FROM t_multi WHERE a = 1 AND b = 2 ORDER BY v <-> '[1, 2, 3]' LIMIT 1;
 ----
 distribution: local
-vectorized: true
+vectorized: false
 ·
 • project
 │ columns: (x, y, a, b, c, v)
@@ -137,16 +136,60 @@ vectorized: true
         │ render c: c
         │ render v: v
         │
-        └── • filter
+        └── • lookup join (inner)
             │ columns: (x, y, a, b, c, v)
-            │ estimated row count: 1 (missing stats)
-            │ filter: (a = 1) AND (b = 2)
+            │ estimated row count: 2 (missing stats)
+            │ table: t_multi@t_multi_pkey
+            │ equality: (x, y) = (x, y)
+            │ equality cols are key
             │
-            └── • scan
-                  columns: (x, y, a, b, c, v)
-                  estimated row count: 1,000 (missing stats)
-                  table: t_multi@t_multi_pkey
-                  spans: FULL SCAN
+            └── • vector search
+                  columns: (x, y)
+                  estimated row count: 2 (missing stats)
+                  table: t_multi@t_multi_a_b_v_idx
+                  target count: 1
+                  prefix spans: /1/2-/1/3
+                  query vector: '[1,2,3]'
+
+query T
+EXPLAIN (VERBOSE) SELECT * FROM t_multi WHERE (a, b) IN ((1, 2), (3, 4), (5, 6)) ORDER BY v <-> '[1, 2, 3]' LIMIT 1;
+----
+distribution: local
+vectorized: false
+·
+• project
+│ columns: (x, y, a, b, c, v)
+│
+└── • top-k
+    │ columns: (column11, x, y, a, b, c, v)
+    │ estimated row count: 1 (missing stats)
+    │ order: +column11
+    │ k: 1
+    │
+    └── • render
+        │ columns: (column11, x, y, a, b, c, v)
+        │ render column11: v <-> '[1,2,3]'
+        │ render x: x
+        │ render y: y
+        │ render a: a
+        │ render b: b
+        │ render c: c
+        │ render v: v
+        │
+        └── • lookup join (inner)
+            │ columns: (x, y, a, b, c, v)
+            │ estimated row count: 2 (missing stats)
+            │ table: t_multi@t_multi_pkey
+            │ equality: (x, y) = (x, y)
+            │ equality cols are key
+            │
+            └── • vector search
+                  columns: (x, y)
+                  estimated row count: 2 (missing stats)
+                  table: t_multi@t_multi_a_b_v_idx
+                  target count: 1
+                  prefix spans: /1/2-/1/3 /3/4-/3/5 /5/6-/5/7
+                  query vector: '[1,2,3]'
 
 # ==============================================================================
 # Vector Mutation Search Tests

--- a/pkg/sql/opt/exec/execbuilder/testdata/vector_search
+++ b/pkg/sql/opt/exec/execbuilder/testdata/vector_search
@@ -32,8 +32,10 @@ vectorized: false
 │
 └── • render
     │
-    └── • index join
+    └── • lookup join
         │ table: t@t_pkey
+        │ equality: (k) = (k)
+        │ equality cols are key
         │
         └── • vector search
               table: t@t_v_idx
@@ -60,11 +62,12 @@ vectorized: false
         │ render k: k
         │ render v: v
         │
-        └── • index join
+        └── • lookup join (inner)
             │ columns: (k, v)
             │ estimated row count: 2 (missing stats)
             │ table: t@t_pkey
-            │ key columns: k
+            │ equality: (k) = (k)
+            │ equality cols are key
             │
             └── • vector search
                   columns: (k)
@@ -94,11 +97,12 @@ vectorized: false
         │ render k: k
         │ render v: v
         │
-        └── • index join
+        └── • lookup join (inner)
             │ columns: (k, v)
             │ estimated row count: 10 (missing stats)
             │ table: t@t_pkey
-            │ key columns: k
+            │ equality: (k) = (k)
+            │ equality cols are key
             │
             └── • vector search
                   columns: (k)

--- a/pkg/sql/opt/exec/explain/emit.go
+++ b/pkg/sql/opt/exec/explain/emit.go
@@ -942,10 +942,15 @@ func (e *emitter) emitNodeAttributes(ctx context.Context, evalCtx *eval.Context,
 		a := n.args.(*vectorSearchArgs)
 		e.emitTableAndIndex("table", a.Table, a.Index, "" /* suffix */)
 		ob.Attr("target count", a.TargetNeighborCount)
-		if ob.flags.Verbose {
-			if !a.PrefixKey.IsEmpty() {
-				ob.Attr("prefix key", a.PrefixKey)
+		if a.PrefixConstraint != nil {
+			params := exec.ScanParams{
+				NeededCols:      a.OutCols,
+				IndexConstraint: a.PrefixConstraint,
 			}
+			e.emitSpans("prefix spans", a.Table, a.Index, params)
+		}
+		if ob.flags.Verbose {
+			// Vectors can have many dimensions, so don't print them unless verbose.
 			ob.Expr("query vector", a.QueryVector, nil /* varColumns */)
 		}
 

--- a/pkg/sql/opt/exec/factory.opt
+++ b/pkg/sql/opt/exec/factory.opt
@@ -860,7 +860,7 @@ define VectorSearch {
     Table cat.Table
     Index cat.Index
     OutCols exec.TableColumnOrdinalSet
-    PrefixKey constraint.Key
+    PrefixConstraint *constraint.Constraint
     QueryVector tree.TypedExpr
     TargetNeighborCount uint64
 }

--- a/pkg/sql/opt/idxconstraint/BUILD.bazel
+++ b/pkg/sql/opt/idxconstraint/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/sql/opt",
+        "//pkg/sql/opt/cat",
         "//pkg/sql/opt/constraint",
         "//pkg/sql/opt/memo",
         "//pkg/sql/opt/norm",

--- a/pkg/sql/opt/idxconstraint/index_constraints.go
+++ b/pkg/sql/opt/idxconstraint/index_constraints.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/constraint"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/norm"
@@ -1332,4 +1333,89 @@ func (c *indexConstraintCtx) computedColInSuffix(offset int) bool {
 		}
 	}
 	return false
+}
+
+// IndexPrefixCols returns a slice of ordering columns for each of the prefix
+// columns of the inverted or vector index. It also returns a set of those
+// columns that are NOT NULL. If the index is a single-column inverted index,
+// the function returns nil ordering columns.
+func IndexPrefixCols(
+	tabID opt.TableID, index cat.Index,
+) (_ []opt.OrderingColumn, notNullCols opt.ColSet) {
+	prefixColumnCount := index.PrefixColumnCount()
+
+	// If this is a single-column inverted/vector index, there are no prefix
+	// columns.
+	if prefixColumnCount == 0 {
+		return nil, opt.ColSet{}
+	}
+
+	prefixColumns := make([]opt.OrderingColumn, prefixColumnCount)
+	for i := range prefixColumns {
+		col := index.Column(i)
+		colID := tabID.ColumnID(col.Ordinal())
+		prefixColumns[i] = opt.MakeOrderingColumn(colID, col.Descending)
+		if !col.IsNullable() {
+			notNullCols.Add(colID)
+		}
+	}
+	return prefixColumns, notNullCols
+}
+
+// ConstrainIndexPrefixCols attempts to build a constraint for the prefix
+// columns of the given inverted or vector index. If a constraint is
+// successfully built, it is returned along with remaining filters and ok=true.
+// The function is only successful if it can generate a constraint where all
+// spans have the same start and end keys for all prefix columns. This is
+// required for building spans for scanning multi-column inverted/vector indexes
+// (see span.Builder.SpansFromInvertedSpans).
+func ConstrainIndexPrefixCols(
+	ctx context.Context,
+	evalCtx *eval.Context,
+	factory *norm.Factory,
+	columns []opt.OrderingColumn,
+	notNullCols opt.ColSet,
+	filters memo.FiltersExpr,
+	optionalFilters memo.FiltersExpr,
+	tabID opt.TableID,
+	index cat.Index,
+	checkCancellation func(),
+) (_ *constraint.Constraint, remainingFilters memo.FiltersExpr, ok bool) {
+	tabMeta := factory.Metadata().TableMeta(tabID)
+	prefixColumnCount := index.PrefixColumnCount()
+	ps := tabMeta.IndexPartitionLocality(index.Ordinal())
+
+	// Consolidation of a constraint converts contiguous spans into a single
+	// span. By definition, the consolidated span would have different start and
+	// end keys and could not be used for multi-column inverted index scans.
+	// Therefore, we only generate and check the unconsolidated constraint,
+	// allowing the optimizer to plan multi-column inverted/vector index scans in
+	// more cases.
+	//
+	// For example, the consolidated constraint for (x IN (1, 2, 3)) is:
+	//
+	//   /x: [/1 - /3]
+	//   Prefix: 0
+	//
+	// The unconsolidated constraint for the same expression is:
+	//
+	//   /x: [/1 - /1] [/2 - /2] [/3 - /3]
+	//   Prefix: 1
+	//
+	var ic Instance
+	ic.Init(
+		ctx, filters, optionalFilters,
+		columns, notNullCols, tabMeta.ComputedCols,
+		tabMeta.ColsInComputedColsExpressions,
+		false, /* consolidate */
+		evalCtx, factory, ps, checkCancellation,
+	)
+	var c constraint.Constraint
+	ic.UnconsolidatedConstraint(&c)
+	if c.Prefix(ctx, evalCtx) != prefixColumnCount {
+		// The prefix columns must be constrained to single values.
+		return nil, nil, false
+	}
+
+	return &c, ic.RemainingFilters(), true
 }

--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -747,6 +747,13 @@ func (f *ExprFmtCtx) formatRelational(e RelExpr, tp treeprinter.Node) {
 
 	case *VectorSearchExpr:
 		tp.Childf("target nearest neighbors: %d", t.TargetNeighborCount)
+		if t.PrefixConstraint != nil {
+			n := tp.Childf("prefix constraint: %s", t.PrefixConstraint.Columns.String())
+			for i := 0; i < t.PrefixConstraint.Spans.Count(); i++ {
+				spanString := t.PrefixConstraint.Spans.Get(i).String()
+				n.Child(cat.MaybeMarkRedactable(spanString, f.RedactableValues))
+			}
+		}
 
 	case *VectorMutationSearchExpr:
 		if t.IsIndexPut {

--- a/pkg/sql/opt/memo/testdata/stats/vector-search
+++ b/pkg/sql/opt/memo/testdata/stats/vector-search
@@ -107,17 +107,20 @@ top-k
       ├── stats: [rows=2]
       ├── key: (1)
       ├── fd: (1)-->(2), (2)-->(5)
-      ├── index-join t
+      ├── inner-join (lookup t)
       │    ├── columns: x:1(int!null) v:2(vector)
+      │    ├── key columns: [1] = [1]
+      │    ├── lookup columns are key
       │    ├── stats: [rows=2]
       │    ├── key: (1)
       │    ├── fd: (1)-->(2)
-      │    └── vector-search t@t_v_idx,vector
-      │         ├── columns: x:1(int!null)
-      │         ├── target nearest neighbors: 1
-      │         ├── stats: [rows=2]
-      │         ├── key: (1)
-      │         └── '[1,2,3]' [type=vector]
+      │    ├── vector-search t@t_v_idx,vector
+      │    │    ├── columns: x:1(int!null)
+      │    │    ├── target nearest neighbors: 1
+      │    │    ├── stats: [rows=2]
+      │    │    ├── key: (1)
+      │    │    └── '[1,2,3]' [type=vector]
+      │    └── filters (true)
       └── projections
            └── v:2 <-> '[1,2,3]' [as=column5:5, type=float, outer=(2), immutable]
 
@@ -140,17 +143,20 @@ top-k
       ├── stats: [rows=10]
       ├── key: (1)
       ├── fd: (1)-->(2), (2)-->(5)
-      ├── index-join t
+      ├── inner-join (lookup t)
       │    ├── columns: x:1(int!null) v:2(vector)
+      │    ├── key columns: [1] = [1]
+      │    ├── lookup columns are key
       │    ├── stats: [rows=10]
       │    ├── key: (1)
       │    ├── fd: (1)-->(2)
-      │    └── vector-search t@t_v_idx,vector
-      │         ├── columns: x:1(int!null)
-      │         ├── target nearest neighbors: 5
-      │         ├── stats: [rows=10]
-      │         ├── key: (1)
-      │         └── '[1,2,3]' [type=vector]
+      │    ├── vector-search t@t_v_idx,vector
+      │    │    ├── columns: x:1(int!null)
+      │    │    ├── target nearest neighbors: 5
+      │    │    ├── stats: [rows=10]
+      │    │    ├── key: (1)
+      │    │    └── '[1,2,3]' [type=vector]
+      │    └── filters (true)
       └── projections
            └── v:2 <-> '[1,2,3]' [as=column5:5, type=float, outer=(2), immutable]
 
@@ -174,16 +180,19 @@ top-k
       ├── stats: [rows=1000]
       ├── key: (1)
       ├── fd: (1)-->(2), (2)-->(5)
-      ├── index-join t
+      ├── inner-join (lookup t)
       │    ├── columns: x:1(int!null) v:2(vector)
+      │    ├── key columns: [1] = [1]
+      │    ├── lookup columns are key
       │    ├── stats: [rows=1000]
       │    ├── key: (1)
       │    ├── fd: (1)-->(2)
-      │    └── vector-search t@t_v_idx,vector
-      │         ├── columns: x:1(int!null)
-      │         ├── target nearest neighbors: 10000
-      │         ├── stats: [rows=1000]
-      │         ├── key: (1)
-      │         └── '[1,2,3]' [type=vector]
+      │    ├── vector-search t@t_v_idx,vector
+      │    │    ├── columns: x:1(int!null)
+      │    │    ├── target nearest neighbors: 10000
+      │    │    ├── stats: [rows=1000]
+      │    │    ├── key: (1)
+      │    │    └── '[1,2,3]' [type=vector]
+      │    └── filters (true)
       └── projections
            └── v:2 <-> '[1,2,3]' [as=column5:5, type=float, outer=(2), immutable]

--- a/pkg/sql/opt/ops/relational.opt
+++ b/pkg/sql/opt/ops/relational.opt
@@ -1439,11 +1439,6 @@ define RecursiveCTEPrivate {
 # distances to the query vector, and applies the NN limit.
 [Relational, Telemetry]
 define VectorSearch {
-    # PrefixVals is set iff the vector index has a prefix of non-vector columns.
-    # It contains a list of constant values or placeholders that map 1-1 to the
-    # prefix columns.
-    PrefixVals ScalarListExpr
-
     # QueryVector is the scalar query vector. It is either a constant or a
     # placeholder.
     QueryVector ScalarExpr
@@ -1459,6 +1454,10 @@ define VectorSearchPrivate {
     # Index identifies the vector index to search. It can be passed to the
     # cat.Table.Index() method in order to fetch the cat.Index metadata.
     Index IndexOrdinal
+
+    # PrefixConstraint, if set, contains a set of spans that each constrain
+    # every index prefix column to a single value.
+    PrefixConstraint Constraint
 
     # Cols is the set of columns produced by the vector search operator. This
     # is currently always the set of primary key columns.

--- a/pkg/sql/opt/xform/join_funcs.go
+++ b/pkg/sql/opt/xform/join_funcs.go
@@ -392,7 +392,7 @@ func (c *CustomFuncs) generateLookupJoinsImpl(
 	// deriving a `t1.crdb_region = t2.crdb_region` term based on foreign key
 	// constraints.
 	if !lookupIsKey {
-		if scanExpr, _, ok := c.getfilteredCanonicalScan(input); ok {
+		if scanExpr, _, ok := c.GetFilteredCanonicalScan(input); ok {
 			scanPrivate2 = &scanExpr.ScanPrivate
 			// The scan should already exist in the memo. We need to look it up so we
 			// have a `ScanExpr` with properties fully populated.
@@ -1547,12 +1547,12 @@ func (c *CustomFuncs) CanSplitJoinWithDisjuncts(
 		panic(errors.AssertionFailedf("expected joinRel to be inner, semi, or anti-join"))
 	}
 
-	origLeftScan, _, ok := c.getfilteredCanonicalScan(leftInput)
+	origLeftScan, _, ok := c.GetFilteredCanonicalScan(leftInput)
 	if !ok {
 		return nil, nil, nil, false
 	}
 
-	origRightScan, _, ok := c.getfilteredCanonicalScan(rightInput)
+	origRightScan, _, ok := c.GetFilteredCanonicalScan(rightInput)
 	if !ok {
 		return nil, nil, nil, false
 	}
@@ -1602,12 +1602,12 @@ func (c *CustomFuncs) SplitJoinWithDisjuncts(
 		panic(errors.AssertionFailedf("expected joinRel to be inner, semi, or anti-join"))
 	}
 
-	origLeftScan, leftFilters, ok := c.getfilteredCanonicalScan(leftInput)
+	origLeftScan, leftFilters, ok := c.GetFilteredCanonicalScan(leftInput)
 	if !ok {
 		panic(errors.AssertionFailedf("expected join left input to have canonical scan"))
 	}
 	origLeftScanPrivate := &origLeftScan.ScanPrivate
-	origRightScan, rightFilters, ok := c.getfilteredCanonicalScan(rightInput)
+	origRightScan, rightFilters, ok := c.GetFilteredCanonicalScan(rightInput)
 	if !ok {
 		panic(errors.AssertionFailedf("expected join right input to have canonical scan"))
 	}
@@ -1750,30 +1750,6 @@ func (c *CustomFuncs) SplitJoinWithDisjuncts(
 	return firstJoin, secondJoin, newRelationCols, aggCols, groupingCols
 }
 
-// getfilteredCanonicalScan looks at a *ScanExpr or *SelectExpr "relation" and
-// returns the input *ScanExpr and FiltersExpr, along with ok=true, if the Scan
-// is a canonical scan. If "relation" is a different type, or if it's a
-// *SelectExpr with an Input other than a *ScanExpr, ok=false is returned. Scans
-// or Selects with no filters may return filters as nil.
-func (c *CustomFuncs) getfilteredCanonicalScan(
-	relation memo.RelExpr,
-) (scanExpr *memo.ScanExpr, filters memo.FiltersExpr, ok bool) {
-	var selectExpr *memo.SelectExpr
-	if selectExpr, ok = relation.(*memo.SelectExpr); ok {
-		if scanExpr, ok = selectExpr.Input.(*memo.ScanExpr); !ok {
-			return nil, nil, false
-		}
-		filters = selectExpr.Filters
-	} else if scanExpr, ok = relation.(*memo.ScanExpr); !ok {
-		return nil, nil, false
-	}
-	scanPrivate := &scanExpr.ScanPrivate
-	if !c.IsCanonicalScan(scanPrivate) {
-		return nil, nil, false
-	}
-	return scanExpr, filters, true
-}
-
 // CanHoistProjectInput returns true if a projection of an expression on
 // `relation` is allowed to be hoisted above a parent Join. The preconditions
 // for this are if `relation` is a canonical scan or a select from a canonical
@@ -1783,7 +1759,7 @@ func (c *CustomFuncs) CanHoistProjectInput(relation memo.RelExpr) (ok bool) {
 	if c.e.evalCtx.SessionData().DisableHoistProjectionInJoinLimitation {
 		return true
 	}
-	_, _, ok = c.getfilteredCanonicalScan(relation)
+	_, _, ok = c.GetFilteredCanonicalScan(relation)
 	return ok
 }
 
@@ -1896,7 +1872,7 @@ func (c *CustomFuncs) CanMaybeGenerateLocalityOptimizedSearchOfLookupJoins(
 	}
 	// Only rewrite canonical scans or selects from canonical scans, which also
 	// means they are not locality-optimized.
-	inputScan, inputFilters, ok = c.getfilteredCanonicalScan(lookupJoinExpr.Input)
+	inputScan, inputFilters, ok = c.GetFilteredCanonicalScan(lookupJoinExpr.Input)
 	if !ok {
 		return nil, memo.FiltersExpr{}, false
 	}

--- a/pkg/sql/opt/xform/limit_funcs.go
+++ b/pkg/sql/opt/xform/limit_funcs.go
@@ -469,7 +469,6 @@ func (c *CustomFuncs) TryGenerateVectorSearch(
 			// This index is for a different vector column.
 			return
 		}
-		var prefixVals memo.ScalarListExpr
 		if index.PrefixColumnCount() > 0 {
 			// TODO(drewk, mw5h): support multi-column vector indexes.
 			return
@@ -479,7 +478,7 @@ func (c *CustomFuncs) TryGenerateVectorSearch(
 		limitInt := int64(*limit.(*tree.DInt))
 		indexCols := c.PrimaryKeyCols(sp.Table)
 		vectorSearch := c.e.f.ConstructVectorSearch(
-			prefixVals, queryVector,
+			queryVector,
 			&memo.VectorSearchPrivate{
 				Table:               sp.Table,
 				Index:               index.Ordinal(),

--- a/pkg/sql/opt/xform/limit_funcs.go
+++ b/pkg/sql/opt/xform/limit_funcs.go
@@ -503,6 +503,7 @@ func (c *CustomFuncs) TryGenerateVectorSearch(
 			KeyCols:               lookupCols,
 			Cols:                  sp.Cols,
 			LookupColsAreTableKey: true,
+			Locking:               sp.Locking,
 		}
 		vectorSearch = c.e.f.ConstructLookupJoin(vectorSearch, nil /* on */, lookupPrivate)
 

--- a/pkg/sql/opt/xform/rules/limit.opt
+++ b/pkg/sql/opt/xform/rules/limit.opt
@@ -295,14 +295,18 @@
 # GenerateVectorSearch generates VectorSearch expressions that implement
 # approximate KNN search using vector indexes. Currently, the comparison
 # must be with a constant or placeholder vector expression.
-#
-# TODO(drewk, mw5h): generate VectorSearch in more cases.
 [GenerateVectorSearch, Explore]
 (Limit
     $project:(Project
-            $scan:(Scan
-                $scanPrivate:* & (IsCanonicalScan $scanPrivate)
-            )
+            $input:* &
+                (Let
+                    (
+                        $scan
+                        $filters
+                        $ok
+                    ):(GetFilteredCanonicalScan $input)
+                    $ok
+                )
             $projections:[
                 (ProjectionsItem
                     $distanceExpr:(VectorDistance
@@ -321,7 +325,8 @@
 )
 =>
 (TryGenerateVectorSearch
-    $scanPrivate
+    $scan
+    $filters
     $passthrough
     $vectorCol
     $distanceCol

--- a/pkg/sql/opt/xform/scan_funcs.go
+++ b/pkg/sql/opt/xform/scan_funcs.go
@@ -514,7 +514,7 @@ func (c *CustomFuncs) IsRegionalByRowTableScanOrSelect(input memo.RelExpr) bool 
 // region without bounded staleness. Bounded staleness would allow local
 // replicas to be used for the scan.
 func (c *CustomFuncs) IsSelectFromRemoteTableRowsOnly(input memo.RelExpr) bool {
-	scanExpr, inputFilters, ok := c.getfilteredCanonicalScan(input)
+	scanExpr, inputFilters, ok := c.GetFilteredCanonicalScan(input)
 	if !ok {
 		return false
 	}

--- a/pkg/sql/opt/xform/testdata/rules/limit
+++ b/pkg/sql/opt/xform/testdata/rules/limit
@@ -3654,6 +3654,118 @@ top-k
       └── projections
            └── vec1:9 <-> $1 [as=column15:15, outer=(9), immutable]
 
+# Locking should transfer from the scan to the lookup-join.
+opt expect=GenerateVectorSearch
+SELECT * FROM index_tab ORDER BY vec1 <-> '[3,1,2]' LIMIT 5 FOR UPDATE;
+----
+top-k
+ ├── columns: id:1!null val:2 region:3 latitude:4 longitude:5 data1:6!null data2:7!null geom:8 vec1:9 vec2:10 vec3:11  [hidden: column15:15]
+ ├── internal-ordering: +15
+ ├── k: 5
+ ├── cardinality: [0 - 5]
+ ├── volatile
+ ├── key: (1)
+ ├── fd: (1)-->(2-11), (9)-->(15)
+ ├── ordering: +15
+ └── project
+      ├── columns: column15:15 id:1!null val:2 region:3 latitude:4 longitude:5 data1:6!null data2:7!null geom:8 vec1:9 vec2:10 vec3:11
+      ├── volatile
+      ├── key: (1)
+      ├── fd: (1)-->(2-11), (9)-->(15)
+      ├── inner-join (lookup index_tab)
+      │    ├── columns: id:1!null val:2 region:3 latitude:4 longitude:5 data1:6!null data2:7!null geom:8 vec1:9 vec2:10 vec3:11
+      │    ├── key columns: [1] = [1]
+      │    ├── lookup columns are key
+      │    ├── locking: for-update
+      │    ├── volatile
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(2-11)
+      │    ├── vector-search index_tab@index_tab_vec1_idx,vector
+      │    │    ├── columns: id:1!null
+      │    │    ├── target nearest neighbors: 5
+      │    │    ├── key: (1)
+      │    │    └── '[3,1,2]'
+      │    └── filters (true)
+      └── projections
+           └── vec1:9 <-> '[3,1,2]' [as=column15:15, outer=(9), immutable]
+
+opt expect=GenerateVectorSearch
+SELECT * FROM index_tab ORDER BY vec1 <-> '[3,1,2]' LIMIT 5 FOR SHARE SKIP LOCKED;
+----
+top-k
+ ├── columns: id:1!null val:2 region:3 latitude:4 longitude:5 data1:6!null data2:7!null geom:8 vec1:9 vec2:10 vec3:11  [hidden: column15:15]
+ ├── internal-ordering: +15
+ ├── k: 5
+ ├── cardinality: [0 - 5]
+ ├── volatile
+ ├── key: (1)
+ ├── fd: (1)-->(2-11), (9)-->(15)
+ ├── ordering: +15
+ └── project
+      ├── columns: column15:15 id:1!null val:2 region:3 latitude:4 longitude:5 data1:6!null data2:7!null geom:8 vec1:9 vec2:10 vec3:11
+      ├── volatile
+      ├── key: (1)
+      ├── fd: (1)-->(2-11), (9)-->(15)
+      ├── inner-join (lookup index_tab)
+      │    ├── columns: id:1!null val:2 region:3 latitude:4 longitude:5 data1:6!null data2:7!null geom:8 vec1:9 vec2:10 vec3:11
+      │    ├── key columns: [1] = [1]
+      │    ├── lookup columns are key
+      │    ├── locking: for-share,skip-locked
+      │    ├── volatile
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(2-11)
+      │    ├── vector-search index_tab@index_tab_vec1_idx,vector
+      │    │    ├── columns: id:1!null
+      │    │    ├── target nearest neighbors: 5
+      │    │    ├── key: (1)
+      │    │    └── '[3,1,2]'
+      │    └── filters (true)
+      └── projections
+           └── vec1:9 <-> '[3,1,2]' [as=column15:15, outer=(9), immutable]
+
+# The lock operator handles locking, so the lookup-join is non-locking.
+opt expect=GenerateVectorSearch set=optimizer_use_lock_op_for_serializable=true
+SELECT * FROM index_tab ORDER BY vec1 <-> '[3,1,2]' LIMIT 5 FOR SHARE;
+----
+lock index_tab
+ ├── columns: id:1!null val:2 region:3 latitude:4 longitude:5 data1:6!null data2:7!null geom:8 vec1:9 vec2:10 vec3:11  [hidden: column15:15]
+ ├── key columns: id:1
+ ├── lock columns: (16-26)
+ ├── locking: for-share
+ ├── cardinality: [0 - 5]
+ ├── volatile
+ ├── key: (1)
+ ├── fd: (1)-->(2-11), (9)-->(15)
+ ├── ordering: +15
+ └── top-k
+      ├── columns: id:1!null val:2 region:3 latitude:4 longitude:5 data1:6!null data2:7!null geom:8 vec1:9 vec2:10 vec3:11 column15:15
+      ├── internal-ordering: +15
+      ├── k: 5
+      ├── cardinality: [0 - 5]
+      ├── immutable
+      ├── key: (1)
+      ├── fd: (1)-->(2-11), (9)-->(15)
+      ├── ordering: +15
+      └── project
+           ├── columns: column15:15 id:1!null val:2 region:3 latitude:4 longitude:5 data1:6!null data2:7!null geom:8 vec1:9 vec2:10 vec3:11
+           ├── immutable
+           ├── key: (1)
+           ├── fd: (1)-->(2-11), (9)-->(15)
+           ├── inner-join (lookup index_tab)
+           │    ├── columns: id:1!null val:2 region:3 latitude:4 longitude:5 data1:6!null data2:7!null geom:8 vec1:9 vec2:10 vec3:11
+           │    ├── key columns: [1] = [1]
+           │    ├── lookup columns are key
+           │    ├── key: (1)
+           │    ├── fd: (1)-->(2-11)
+           │    ├── vector-search index_tab@index_tab_vec1_idx,vector
+           │    │    ├── columns: id:1!null
+           │    │    ├── target nearest neighbors: 5
+           │    │    ├── key: (1)
+           │    │    └── '[3,1,2]'
+           │    └── filters (true)
+           └── projections
+                └── vec1:9 <-> '[3,1,2]' [as=column15:15, outer=(9), immutable]
+
 # The index can be forced.
 opt expect=GenerateVectorSearch
 SELECT * FROM index_tab@index_tab_vec2_idx ORDER BY vec2 <-> '[3,1,2]' LIMIT 500;

--- a/pkg/sql/opt/xform/testdata/rules/limit
+++ b/pkg/sql/opt/xform/testdata/rules/limit
@@ -3505,15 +3505,18 @@ top-k
       ├── immutable
       ├── key: (1)
       ├── fd: (1)-->(2-11), (9)-->(15)
-      ├── index-join index_tab
+      ├── inner-join (lookup index_tab)
       │    ├── columns: id:1!null val:2 region:3 latitude:4 longitude:5 data1:6!null data2:7!null geom:8 vec1:9 vec2:10 vec3:11
+      │    ├── key columns: [1] = [1]
+      │    ├── lookup columns are key
       │    ├── key: (1)
       │    ├── fd: (1)-->(2-11)
-      │    └── vector-search index_tab@index_tab_vec1_idx,vector
-      │         ├── columns: id:1!null
-      │         ├── target nearest neighbors: 1
-      │         ├── key: (1)
-      │         └── '[3,1,2]'
+      │    ├── vector-search index_tab@index_tab_vec1_idx,vector
+      │    │    ├── columns: id:1!null
+      │    │    ├── target nearest neighbors: 1
+      │    │    ├── key: (1)
+      │    │    └── '[3,1,2]'
+      │    └── filters (true)
       └── projections
            └── vec1:9 <-> '[3,1,2]' [as=column15:15, outer=(9), immutable]
 
@@ -3535,15 +3538,18 @@ top-k
       ├── immutable
       ├── key: (1)
       ├── fd: (1)-->(2-11), (9)-->(15)
-      ├── index-join index_tab
+      ├── inner-join (lookup index_tab)
       │    ├── columns: id:1!null val:2 region:3 latitude:4 longitude:5 data1:6!null data2:7!null geom:8 vec1:9 vec2:10 vec3:11
+      │    ├── key columns: [1] = [1]
+      │    ├── lookup columns are key
       │    ├── key: (1)
       │    ├── fd: (1)-->(2-11)
-      │    └── vector-search index_tab@index_tab_vec1_idx,vector
-      │         ├── columns: id:1!null
-      │         ├── target nearest neighbors: 5
-      │         ├── key: (1)
-      │         └── '[3,1,2]'
+      │    ├── vector-search index_tab@index_tab_vec1_idx,vector
+      │    │    ├── columns: id:1!null
+      │    │    ├── target nearest neighbors: 5
+      │    │    ├── key: (1)
+      │    │    └── '[3,1,2]'
+      │    └── filters (true)
       └── projections
            └── vec1:9 <-> '[3,1,2]' [as=column15:15, outer=(9), immutable]
 
@@ -3565,15 +3571,18 @@ top-k
       ├── immutable
       ├── key: (1)
       ├── fd: (1)-->(2-11), (10)-->(15)
-      ├── index-join index_tab
+      ├── inner-join (lookup index_tab)
       │    ├── columns: id:1!null val:2 region:3 latitude:4 longitude:5 data1:6!null data2:7!null geom:8 vec1:9 vec2:10 vec3:11
+      │    ├── key columns: [1] = [1]
+      │    ├── lookup columns are key
       │    ├── key: (1)
       │    ├── fd: (1)-->(2-11)
-      │    └── vector-search index_tab@index_tab_vec2_idx,vector
-      │         ├── columns: id:1!null
-      │         ├── target nearest neighbors: 5
-      │         ├── key: (1)
-      │         └── '[3,1,2]'
+      │    ├── vector-search index_tab@index_tab_vec2_idx,vector
+      │    │    ├── columns: id:1!null
+      │    │    ├── target nearest neighbors: 5
+      │    │    ├── key: (1)
+      │    │    └── '[3,1,2]'
+      │    └── filters (true)
       └── projections
            └── vec2:10 <-> '[3,1,2]' [as=column15:15, outer=(10), immutable]
 
@@ -3595,15 +3604,18 @@ top-k
       ├── immutable
       ├── key: (1)
       ├── fd: (1)-->(9), (9)-->(15)
-      ├── index-join index_tab
+      ├── inner-join (lookup index_tab)
       │    ├── columns: id:1!null vec1:9
+      │    ├── key columns: [1] = [1]
+      │    ├── lookup columns are key
       │    ├── key: (1)
       │    ├── fd: (1)-->(9)
-      │    └── vector-search index_tab@index_tab_vec1_idx,vector
-      │         ├── columns: id:1!null
-      │         ├── target nearest neighbors: 5
-      │         ├── key: (1)
-      │         └── '[3,1,2]'
+      │    ├── vector-search index_tab@index_tab_vec1_idx,vector
+      │    │    ├── columns: id:1!null
+      │    │    ├── target nearest neighbors: 5
+      │    │    ├── key: (1)
+      │    │    └── '[3,1,2]'
+      │    └── filters (true)
       └── projections
            └── vec1:9 <-> '[3,1,2]' [as=column15:15, outer=(9), immutable]
 
@@ -3625,17 +3637,20 @@ top-k
       ├── immutable, has-placeholder
       ├── key: (1)
       ├── fd: (1)-->(2-11), (9)-->(15)
-      ├── index-join index_tab
+      ├── inner-join (lookup index_tab)
       │    ├── columns: id:1!null val:2 region:3 latitude:4 longitude:5 data1:6!null data2:7!null geom:8 vec1:9 vec2:10 vec3:11
+      │    ├── key columns: [1] = [1]
+      │    ├── lookup columns are key
       │    ├── has-placeholder
       │    ├── key: (1)
       │    ├── fd: (1)-->(2-11)
-      │    └── vector-search index_tab@index_tab_vec1_idx,vector
-      │         ├── columns: id:1!null
-      │         ├── target nearest neighbors: 5
-      │         ├── has-placeholder
-      │         ├── key: (1)
-      │         └── $1
+      │    ├── vector-search index_tab@index_tab_vec1_idx,vector
+      │    │    ├── columns: id:1!null
+      │    │    ├── target nearest neighbors: 5
+      │    │    ├── has-placeholder
+      │    │    ├── key: (1)
+      │    │    └── $1
+      │    └── filters (true)
       └── projections
            └── vec1:9 <-> $1 [as=column15:15, outer=(9), immutable]
 
@@ -3657,15 +3672,18 @@ top-k
       ├── immutable
       ├── key: (1)
       ├── fd: (1)-->(2-11), (10)-->(15)
-      ├── index-join index_tab
+      ├── inner-join (lookup index_tab)
       │    ├── columns: id:1!null val:2 region:3 latitude:4 longitude:5 data1:6!null data2:7!null geom:8 vec1:9 vec2:10 vec3:11
+      │    ├── key columns: [1] = [1]
+      │    ├── lookup columns are key
       │    ├── key: (1)
       │    ├── fd: (1)-->(2-11)
-      │    └── vector-search index_tab@index_tab_vec2_idx,vector
-      │         ├── columns: id:1!null
-      │         ├── target nearest neighbors: 500
-      │         ├── key: (1)
-      │         └── '[3,1,2]'
+      │    ├── vector-search index_tab@index_tab_vec2_idx,vector
+      │    │    ├── columns: id:1!null
+      │    │    ├── target nearest neighbors: 500
+      │    │    ├── key: (1)
+      │    │    └── '[3,1,2]'
+      │    └── filters (true)
       └── projections
            └── vec2:10 <-> '[3,1,2]' [as=column15:15, outer=(10), immutable]
 
@@ -3903,12 +3921,15 @@ top-k
  └── project
       ├── columns: column8:8 photo_id:2!null photo_url:3!null description:4
       ├── immutable
-      ├── index-join image_embeddings
+      ├── inner-join (lookup image_embeddings)
       │    ├── columns: photo_id:2!null photo_url:3!null description:4 embedding:5!null
-      │    └── vector-search image_embeddings@image_embeddings_embedding_idx,vector
-      │         ├── columns: id:1!null
-      │         ├── target nearest neighbors: 5
-      │         ├── key: (1)
-      │         └── '[0.016068,-0.033417,-0.020309,-0.031494,-0.014076,0.03653]'
+      │    ├── key columns: [1] = [1]
+      │    ├── lookup columns are key
+      │    ├── vector-search image_embeddings@image_embeddings_embedding_idx,vector
+      │    │    ├── columns: id:1!null
+      │    │    ├── target nearest neighbors: 5
+      │    │    ├── key: (1)
+      │    │    └── '[0.016068,-0.033417,-0.020309,-0.031494,-0.014076,0.03653]'
+      │    └── filters (true)
       └── projections
            └── embedding:5 <-> '[0.016068,-0.033417,-0.020309,-0.031494,-0.014076,0.03653]' [as=column8:8, outer=(5), immutable]

--- a/pkg/sql/opt/xform/testdata/rules/limit
+++ b/pkg/sql/opt/xform/testdata/rules/limit
@@ -57,7 +57,8 @@ CREATE TABLE index_tab
     INDEX d (latitude, longitude, data1, data2),
     INVERTED INDEX geomIdx(geom),
     VECTOR INDEX (vec1),
-    VECTOR INDEX (vec2)
+    VECTOR INDEX (vec2),
+    VECTOR INDEX (data1, data2, vec1)
 )
 ----
 
@@ -3619,6 +3620,266 @@ top-k
       └── projections
            └── vec1:9 <-> '[3,1,2]' [as=column15:15, outer=(9), immutable]
 
+# Case with prefix columns.
+opt expect=GenerateVectorSearch
+SELECT id, val, vec1 FROM index_tab WHERE data1 = 1 AND data2 = 2 ORDER BY vec1 <-> '[3,1,2]' LIMIT 5;
+----
+top-k
+ ├── columns: id:1!null val:2 vec1:9  [hidden: column15:15]
+ ├── internal-ordering: +15
+ ├── k: 5
+ ├── cardinality: [0 - 5]
+ ├── immutable
+ ├── key: (1)
+ ├── fd: (1)-->(2,9), (9)-->(15)
+ ├── ordering: +15
+ └── project
+      ├── columns: column15:15 id:1!null val:2 vec1:9
+      ├── immutable
+      ├── key: (1)
+      ├── fd: (1)-->(2,9,15), (9)-->(15)
+      ├── inner-join (lookup index_tab)
+      │    ├── columns: id:1!null val:2 data1:6!null data2:7!null vec1:9
+      │    ├── key columns: [1] = [1]
+      │    ├── lookup columns are key
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(2,6,7,9)
+      │    ├── vector-search index_tab@index_tab_data1_data2_vec1_idx,vector
+      │    │    ├── columns: id:1!null
+      │    │    ├── target nearest neighbors: 5
+      │    │    ├── prefix constraint: /6/7
+      │    │    │    └── [/1/2 - /1/2]
+      │    │    ├── key: (1)
+      │    │    └── '[3,1,2]'
+      │    └── filters (true)
+      └── projections
+           └── vec1:9 <-> '[3,1,2]' [as=column15:15, outer=(9), immutable]
+
+# Case with the index prefix constrained to multiple sets of values.
+opt expect=GenerateVectorSearch
+SELECT id, val, region, vec1 FROM index_tab
+WHERE (data1, data2) IN ((1, 2), (3, 4), (5, 6))
+ORDER BY vec1 <-> '[3,1,2]' LIMIT 5;
+----
+top-k
+ ├── columns: id:1!null val:2 region:3 vec1:9  [hidden: column15:15]
+ ├── internal-ordering: +15
+ ├── k: 5
+ ├── cardinality: [0 - 5]
+ ├── immutable
+ ├── key: (1)
+ ├── fd: (1)-->(2,3,9,15), (9)-->(15)
+ ├── ordering: +15
+ └── project
+      ├── columns: column15:15 id:1!null val:2 region:3 vec1:9
+      ├── immutable
+      ├── key: (1)
+      ├── fd: (1)-->(2,3,9,15), (9)-->(15)
+      ├── inner-join (lookup index_tab)
+      │    ├── columns: id:1!null val:2 region:3 data1:6!null data2:7!null vec1:9
+      │    ├── key columns: [1] = [1]
+      │    ├── lookup columns are key
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(2,3,6,7,9)
+      │    ├── vector-search index_tab@index_tab_data1_data2_vec1_idx,vector
+      │    │    ├── columns: id:1!null
+      │    │    ├── target nearest neighbors: 5
+      │    │    ├── prefix constraint: /6/7
+      │    │    │    ├── [/1/2 - /1/2]
+      │    │    │    ├── [/3/4 - /3/4]
+      │    │    │    └── [/5/6 - /5/6]
+      │    │    ├── key: (1)
+      │    │    └── '[3,1,2]'
+      │    └── filters (true)
+      └── projections
+           └── vec1:9 <-> '[3,1,2]' [as=column15:15, outer=(9), immutable]
+
+# Case with prefix columns constrained by a check constraint. Inapplicable check
+# constraints should not prevent the search.
+exec-ddl
+CREATE TABLE index_with_check_tab (
+  col1 INT NOT NULL,
+  col2 INT NOT NULL,
+  vec VECTOR(3),
+  CHECK (col1 IN (1, 2, 3, 5)),
+  CHECK (col2 IN (100, 200, 300)),
+  VECTOR INDEX (col1, vec)
+)
+----
+
+opt expect=GenerateVectorSearch
+SELECT * FROM index_with_check_tab ORDER BY vec <-> '[3,1,2]' LIMIT 5;
+----
+top-k
+ ├── columns: col1:1!null col2:2!null vec:3  [hidden: column7:7]
+ ├── internal-ordering: +7
+ ├── k: 5
+ ├── cardinality: [0 - 5]
+ ├── immutable
+ ├── fd: (3)-->(7)
+ ├── ordering: +7
+ └── project
+      ├── columns: column7:7 col1:1!null col2:2!null vec:3
+      ├── immutable
+      ├── fd: (3)-->(7)
+      ├── inner-join (lookup index_with_check_tab)
+      │    ├── columns: col1:1!null col2:2!null vec:3
+      │    ├── key columns: [4] = [4]
+      │    ├── lookup columns are key
+      │    ├── vector-search index_with_check_tab@index_with_check_tab_col1_vec_idx,vector
+      │    │    ├── columns: rowid:4!null
+      │    │    ├── target nearest neighbors: 5
+      │    │    ├── prefix constraint: /1
+      │    │    │    ├── [/1 - /1]
+      │    │    │    ├── [/2 - /2]
+      │    │    │    ├── [/3 - /3]
+      │    │    │    └── [/5 - /5]
+      │    │    ├── key: (4)
+      │    │    └── '[3,1,2]'
+      │    └── filters (true)
+      └── projections
+           └── vec:3 <-> '[3,1,2]' [as=column7:7, outer=(3), immutable]
+
+# Test computed prefix columns. TODO(drewk): support more of these cases.
+exec-ddl
+CREATE TABLE index_with_computed_tab (
+  col1 INT NOT NULL,
+  col2 INT NOT NULL,
+  col3 INT NOT NULL AS (col1 + col2) STORED,
+  col4 INT NOT NULL AS (col1 * col2) VIRTUAL,
+  vec VECTOR(3),
+  VECTOR INDEX (col3, vec),
+  VECTOR INDEX (col4, vec)
+)
+----
+
+opt expect=GenerateVectorSearch
+SELECT vec FROM index_with_computed_tab WHERE col3 = 5 ORDER BY vec <-> '[3,1,2]' LIMIT 5;
+----
+top-k
+ ├── columns: vec:5  [hidden: column9:9]
+ ├── internal-ordering: +9
+ ├── k: 5
+ ├── cardinality: [0 - 5]
+ ├── immutable
+ ├── fd: (5)-->(9)
+ ├── ordering: +9
+ └── project
+      ├── columns: column9:9 vec:5
+      ├── immutable
+      ├── fd: (5)-->(9)
+      ├── inner-join (lookup index_with_computed_tab)
+      │    ├── columns: col3:3!null vec:5
+      │    ├── key columns: [6] = [6]
+      │    ├── lookup columns are key
+      │    ├── vector-search index_with_computed_tab@index_with_computed_tab_col3_vec_idx,vector
+      │    │    ├── columns: rowid:6!null
+      │    │    ├── target nearest neighbors: 5
+      │    │    ├── prefix constraint: /3
+      │    │    │    └── [/5 - /5]
+      │    │    ├── key: (6)
+      │    │    └── '[3,1,2]'
+      │    └── filters (true)
+      └── projections
+           └── vec:5 <-> '[3,1,2]' [as=column9:9, outer=(5), immutable]
+
+# Currently, the extra projection for col4 prevents the vector search.
+opt expect-not=GenerateVectorSearch
+SELECT * FROM index_with_computed_tab WHERE col3 = 5 ORDER BY vec <-> '[3,1,2]' LIMIT 5;
+----
+top-k
+ ├── columns: col1:1!null col2:2!null col3:3!null col4:4!null vec:5  [hidden: column9:9]
+ ├── internal-ordering: +9 opt(3)
+ ├── k: 5
+ ├── cardinality: [0 - 5]
+ ├── immutable
+ ├── fd: ()-->(3), (5)-->(9), (1,2)-->(4)
+ ├── ordering: +9 opt(3) [actual: +9]
+ └── project
+      ├── columns: column9:9 col4:4!null col1:1!null col2:2!null col3:3!null vec:5
+      ├── immutable
+      ├── fd: ()-->(3), (5)-->(9), (1,2)-->(4)
+      ├── select
+      │    ├── columns: col1:1!null col2:2!null col3:3!null vec:5
+      │    ├── fd: ()-->(3)
+      │    ├── scan index_with_computed_tab
+      │    │    ├── columns: col1:1!null col2:2!null col3:3!null vec:5
+      │    │    ├── computed column expressions
+      │    │    │    ├── col3:3
+      │    │    │    │    └── col1:1 + col2:2
+      │    │    │    └── col4:4
+      │    │    │         └── col1:1 * col2:2
+      │    │    └── fd: (1,2)-->(3)
+      │    └── filters
+      │         └── col3:3 = 5 [outer=(3), constraints=(/3: [/5 - /5]; tight), fd=()-->(3)]
+      └── projections
+           ├── vec:5 <-> '[3,1,2]' [as=column9:9, outer=(5), immutable]
+           └── col1:1 * col2:2 [as=col4:4, outer=(1,2), immutable]
+
+# The optimizer is unable to prove that (col1*col2) is equivalent to col4.
+opt expect-not=GenerateVectorSearch
+SELECT vec FROM index_with_computed_tab WHERE col4 = 12 ORDER BY vec <-> '[3,1,2]' LIMIT 5;
+----
+top-k
+ ├── columns: vec:5  [hidden: column9:9]
+ ├── internal-ordering: +9
+ ├── k: 5
+ ├── cardinality: [0 - 5]
+ ├── immutable
+ ├── fd: (5)-->(9)
+ ├── ordering: +9
+ └── project
+      ├── columns: column9:9 vec:5
+      ├── immutable
+      ├── fd: (5)-->(9)
+      ├── select
+      │    ├── columns: col1:1!null col2:2!null vec:5
+      │    ├── immutable
+      │    ├── scan index_with_computed_tab
+      │    │    ├── columns: col1:1!null col2:2!null vec:5
+      │    │    └── computed column expressions
+      │    │         ├── col3:3
+      │    │         │    └── col1:1 + col2:2
+      │    │         └── col4:4
+      │    │              └── col1:1 * col2:2
+      │    └── filters
+      │         └── (col1:1 * col2:2) = 12 [outer=(1,2), immutable]
+      └── projections
+           └── vec:5 <-> '[3,1,2]' [as=column9:9, outer=(5), immutable]
+
+# The col1 and col2 filters imply filters on col3 and col4, but may filter
+# additional rows, so this case is not yet supported.
+opt expect-not=GenerateVectorSearch
+SELECT vec FROM index_with_computed_tab WHERE col1 = 2 AND col2 = 10 ORDER BY vec <-> '[3,1,2]' LIMIT 5;
+----
+top-k
+ ├── columns: vec:5  [hidden: column9:9]
+ ├── internal-ordering: +9
+ ├── k: 5
+ ├── cardinality: [0 - 5]
+ ├── immutable
+ ├── fd: (5)-->(9)
+ ├── ordering: +9
+ └── project
+      ├── columns: column9:9 vec:5
+      ├── immutable
+      ├── fd: (5)-->(9)
+      ├── select
+      │    ├── columns: col1:1!null col2:2!null vec:5
+      │    ├── fd: ()-->(1,2)
+      │    ├── scan index_with_computed_tab
+      │    │    ├── columns: col1:1!null col2:2!null vec:5
+      │    │    └── computed column expressions
+      │    │         ├── col3:3
+      │    │         │    └── col1:1 + col2:2
+      │    │         └── col4:4
+      │    │              └── col1:1 * col2:2
+      │    └── filters
+      │         ├── col1:1 = 2 [outer=(1), constraints=(/1: [/2 - /2]; tight), fd=()-->(1)]
+      │         └── col2:2 = 10 [outer=(2), constraints=(/2: [/10 - /10]; tight), fd=()-->(2)]
+      └── projections
+           └── vec:5 <-> '[3,1,2]' [as=column9:9, outer=(5), immutable]
+
 # Case with a placeholder vector.
 opt expect=GenerateVectorSearch
 SELECT * FROM index_tab ORDER BY vec1 <-> $1 LIMIT 5;
@@ -4005,6 +4266,119 @@ top-k
       │    └── fd: (1)-->(2-11)
       └── projections
            └── '[3,1,2]' <-> vec1:9 [as=column15:15, outer=(9), immutable]
+
+# Currently, there can be no extra filters beyond those used to constrain index
+# prefix columns, if any.
+opt expect-not=GenerateVectorSearch
+SELECT * FROM index_tab WHERE region = 'us-west' AND latitude > 0 ORDER BY vec1 <-> '[3,1,2]' LIMIT 5;
+----
+top-k
+ ├── columns: id:1!null val:2 region:3!null latitude:4!null longitude:5 data1:6!null data2:7!null geom:8 vec1:9 vec2:10 vec3:11  [hidden: column15:15]
+ ├── internal-ordering: +15 opt(3)
+ ├── k: 5
+ ├── cardinality: [0 - 5]
+ ├── immutable
+ ├── key: (1)
+ ├── fd: ()-->(3), (1)-->(2,4-11), (9)-->(15)
+ ├── ordering: +15 opt(3) [actual: +15]
+ └── project
+      ├── columns: column15:15 id:1!null val:2 region:3!null latitude:4!null longitude:5 data1:6!null data2:7!null geom:8 vec1:9 vec2:10 vec3:11
+      ├── immutable
+      ├── key: (1)
+      ├── fd: ()-->(3), (1)-->(2,4-11), (9)-->(15)
+      ├── select
+      │    ├── columns: id:1!null val:2 region:3!null latitude:4!null longitude:5 data1:6!null data2:7!null geom:8 vec1:9 vec2:10 vec3:11
+      │    ├── key: (1)
+      │    ├── fd: ()-->(3), (1)-->(2,4-11)
+      │    ├── index-join index_tab
+      │    │    ├── columns: id:1!null val:2 region:3 latitude:4 longitude:5 data1:6!null data2:7!null geom:8 vec1:9 vec2:10 vec3:11
+      │    │    ├── key: (1)
+      │    │    ├── fd: ()-->(3), (1)-->(2,4-11)
+      │    │    └── scan index_tab@c
+      │    │         ├── columns: id:1!null region:3!null data1:6!null data2:7!null
+      │    │         ├── constraint: /3/6/7/1: [/'us-west' - /'us-west']
+      │    │         ├── key: (1)
+      │    │         └── fd: ()-->(3), (1)-->(6,7)
+      │    └── filters
+      │         └── latitude:4 > 0 [outer=(4), constraints=(/4: [/1 - ]; tight)]
+      └── projections
+           └── vec1:9 <-> '[3,1,2]' [as=column15:15, outer=(9), immutable]
+
+# The full index prefix must be constrained in order to use the index.
+opt expect-not=GenerateVectorSearch
+SELECT id, val, vec1 FROM index_tab WHERE data1 = 1 ORDER BY vec1 <-> '[3,1,2]' LIMIT 5;
+----
+top-k
+ ├── columns: id:1!null val:2 vec1:9  [hidden: column15:15]
+ ├── internal-ordering: +15
+ ├── k: 5
+ ├── cardinality: [0 - 5]
+ ├── immutable
+ ├── key: (1)
+ ├── fd: (1)-->(2,9), (9)-->(15)
+ ├── ordering: +15
+ └── project
+      ├── columns: column15:15 id:1!null val:2 vec1:9
+      ├── immutable
+      ├── key: (1)
+      ├── fd: (1)-->(2,9), (9)-->(15)
+      ├── select
+      │    ├── columns: id:1!null val:2 data1:6!null vec1:9
+      │    ├── key: (1)
+      │    ├── fd: ()-->(6), (1)-->(2,9)
+      │    ├── scan index_tab
+      │    │    ├── columns: id:1!null val:2 data1:6!null vec1:9
+      │    │    ├── key: (1)
+      │    │    └── fd: (1)-->(2,6,9)
+      │    └── filters
+      │         └── data1:6 = 1 [outer=(6), constraints=(/6: [/1 - /1]; tight), fd=()-->(6)]
+      └── projections
+           └── vec1:9 <-> '[3,1,2]' [as=column15:15, outer=(9), immutable]
+
+# The filters cannot be used to constrain the index prefix because they are a
+# contradiction.
+opt expect-not=GenerateVectorSearch
+SELECT id, val, vec1 FROM index_tab WHERE data1 = 1 AND data1 = 2 AND data2 = 2
+ORDER BY vec1 <-> '[3,1,2]' LIMIT 5;
+----
+values
+ ├── columns: id:1!null val:2!null vec1:9!null
+ ├── cardinality: [0 - 0]
+ ├── key: ()
+ └── fd: ()-->(1,2,9)
+
+# Inequalities cannot be used to constrain the index prefix.
+opt expect-not=GenerateVectorSearch
+SELECT id, val, vec1 FROM index_tab WHERE data1 = 1 AND data2 >= 2 AND data2 <= 5
+ORDER BY vec1 <-> '[3,1,2]' LIMIT 5;
+----
+top-k
+ ├── columns: id:1!null val:2 vec1:9  [hidden: column15:15]
+ ├── internal-ordering: +15
+ ├── k: 5
+ ├── cardinality: [0 - 5]
+ ├── immutable
+ ├── key: (1)
+ ├── fd: (1)-->(2,9,15), (9)-->(15)
+ ├── ordering: +15
+ └── project
+      ├── columns: column15:15 id:1!null val:2 vec1:9
+      ├── immutable
+      ├── key: (1)
+      ├── fd: (1)-->(2,9,15), (9)-->(15)
+      ├── select
+      │    ├── columns: id:1!null val:2 data1:6!null data2:7!null vec1:9
+      │    ├── key: (1)
+      │    ├── fd: ()-->(6), (1)-->(2,7,9)
+      │    ├── scan index_tab
+      │    │    ├── columns: id:1!null val:2 data1:6!null data2:7!null vec1:9
+      │    │    ├── key: (1)
+      │    │    └── fd: (1)-->(2,6,7,9)
+      │    └── filters
+      │         ├── (data2:7 >= 2) AND (data2:7 <= 5) [outer=(7), constraints=(/7: [/2 - /5]; tight)]
+      │         └── data1:6 = 1 [outer=(6), constraints=(/6: [/1 - /1]; tight), fd=()-->(6)]
+      └── projections
+           └── vec1:9 <-> '[3,1,2]' [as=column15:15, outer=(9), immutable]
 
 # Regression test for failure to project the vector column from the index join.
 exec-ddl

--- a/pkg/sql/rowexec/BUILD.bazel
+++ b/pkg/sql/rowexec/BUILD.bazel
@@ -99,7 +99,6 @@ go_library(
         "//pkg/util/collatedstring",
         "//pkg/util/ctxgroup",
         "//pkg/util/encoding",
-        "//pkg/util/errorutil/unimplemented",
         "//pkg/util/hlc",
         "//pkg/util/intsets",
         "//pkg/util/log",

--- a/pkg/sql/span/span_builder_test.go
+++ b/pkg/sql/span/span_builder_test.go
@@ -75,7 +75,7 @@ func TestBuilder_EncodeConstraintKey(t *testing.T) {
 					valDirs[i] = encoding.Descending
 				}
 			}
-			outKey, _, err := b.EncodeConstraintKey(tc.in)
+			outKey, _, err := b.encodeConstraintKey(tc.in)
 			require.NoError(t, err)
 			vals, _ := encoding.PrettyPrintValuesWithTypes(valDirs, outKey)
 			require.Equal(t, tc.out, "/"+strings.Join(vals, "/"))

--- a/pkg/sql/vector_search.go
+++ b/pkg/sql/vector_search.go
@@ -24,7 +24,7 @@ type vectorSearchNode struct {
 type vectorSearchPlanningInfo struct {
 	table               catalog.TableDescriptor
 	index               catalog.Index
-	prefixKey           roachpb.Key
+	prefixKeys          []roachpb.Key
 	queryVector         tree.TypedExpr
 	targetNeighborCount uint64
 


### PR DESCRIPTION
#### opt: use lookup-join instead of index-join for vector search

Index joins expect all input rows to find a match in the primary index,
excluding locked rows when in skip locked mode. Vector indexes can have
"dangling" vectors after a delete operation fails to locate a vector in
the index. Accordingly, this commit changes the vector-search optimizer
rule to use a lookup-join instead of an index-join to avoid violating
assumptions made elsewhere in the optimizer.

Epic: CRDB-42943

Release note: None

#### opt: do not plan vector search for a locking scan

This commit disallows vector-search when the original scan is performing
locking. Even if we did support this, it is unclear which rows should be
locked, so it seems best to disallow it entirely.

Epic: CRDB-42943

Release note: None

#### sql: add execution support for vector search with multiple prefix keys

This commit changes the vector-search operator to propagate a constraint
set rather than a single list of values to be used in constraining index
prefix columns. Execution has been modified as well to handle multiple
prefixes. This change will allow the vector-search optimizer rule to
handle cases where prefix columns can take on multiple possible values.
Note that modifying the vector search rule to take advantage of this
change is left for a following commit.

Epic: CRDB-42943

Release note: None

#### opt: add support for prefix columns to vector search rule

This commit adds support for prefix columns to the `GenerateVectorSearch`
optimizer rule. Select filters over the matched scan as well as check
constraint filters can be used if they constrain every prefix column to
single-key spans, like the following examples:
```
prefix1 = 1 AND prefix2 = 2

(prefix1, prefix2) IN ((1, 2), (3, 4))
```
Currently, additional filters beyond those used to constrain the
prefix are not yet supported. This will have to wait until the vector
index is able to stream results in approximate order of distance.

Fixes #143206

Release note: None