### PR TITLE
jsonpath: add support for `last` array index

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/jsonb_path_query
+++ b/pkg/sql/logictest/testdata/logic_test/jsonb_path_query
@@ -1033,3 +1033,24 @@ SELECT jsonb_path_query('[1, 2, 3, 4]', '$[*] ? (@ > +2)');
 ----
 3
 4
+
+statement error pgcode 42601 pq: LAST is allowed only in array subscripts
+SELECT jsonb_path_query('{}', 'last');
+
+query T
+SELECT jsonb_path_query('[1, 2, 3, 4]', '$[last]');
+----
+4
+
+query T
+SELECT jsonb_path_query('"hello"', '$[last]');
+----
+"hello"
+
+query T rowsort
+SELECT jsonb_path_query('[1, 2, 3, 4]', '$[1 to last, last to last]');
+----
+2
+3
+4
+4

--- a/pkg/util/jsonpath/eval/eval.go
+++ b/pkg/util/jsonpath/eval/eval.go
@@ -25,6 +25,10 @@ type jsonpathCtx struct {
 	root   json.JSON
 	vars   json.JSON
 	strict bool
+
+	// innermostArrayLength stores the length of the innermost array. If the current
+	// evaluation context is not evaluating on an array, this value is -1.
+	innermostArrayLength int
 }
 
 func JsonpathQuery(
@@ -37,9 +41,10 @@ func JsonpathQuery(
 	expr := parsedPath.AST
 
 	ctx := &jsonpathCtx{
-		root:   target.JSON,
-		vars:   vars.JSON,
-		strict: expr.Strict,
+		root:                 target.JSON,
+		vars:                 vars.JSON,
+		strict:               expr.Strict,
+		innermostArrayLength: -1,
 	}
 	// When silent is true, overwrite the strict mode.
 	if bool(silent) {
@@ -103,6 +108,8 @@ func (ctx *jsonpathCtx) eval(
 		return ctx.evalOperation(path, jsonValue)
 	case jsonpath.Filter:
 		return ctx.evalFilter(path, jsonValue, unwrap)
+	case jsonpath.Last:
+		return ctx.evalLast()
 	default:
 		return nil, errUnimplemented
 	}

--- a/pkg/util/jsonpath/expr.go
+++ b/pkg/util/jsonpath/expr.go
@@ -93,6 +93,12 @@ func (a ArrayList) String() string {
 	return sb.String()
 }
 
+type Last struct{}
+
+var _ Path = Last{}
+
+func (l Last) String() string { return "last" }
+
 type Filter struct {
 	Condition Path
 }

--- a/pkg/util/jsonpath/parser/jsonpath.y
+++ b/pkg/util/jsonpath/parser/jsonpath.y
@@ -189,6 +189,8 @@ func regexBinaryOp(left jsonpath.Path, regex string) (jsonpath.Operation, error)
 %token <str> LIKE_REGEX
 %token <str> FLAG
 
+%token <str> LAST
+
 %type <jsonpath.Jsonpath> jsonpath
 %type <jsonpath.Path> expr_or_predicate
 %type <jsonpath.Path> expr
@@ -315,7 +317,10 @@ path_primary:
   {
     $$.val = $1.path()
   }
-// TODO(normanchenn): support LAST for array ranges.
+| LAST
+  {
+    $$.val = jsonpath.Last{}
+  }
 ;
 
 accessor_op:
@@ -509,6 +514,7 @@ any_identifier:
 unreserved_keyword:
   FALSE
 | FLAG
+| LAST
 | LAX
 | LIKE_REGEX
 | NULL

--- a/pkg/util/jsonpath/parser/testdata/jsonpath
+++ b/pkg/util/jsonpath/parser/testdata/jsonpath
@@ -502,6 +502,23 @@ DETAIL: source SQL:
 $ ? (@ like_regex "(invalid pattern")
                                     ^
 
+# TODO(normanchenn): This shouldn't be parsed, as the last keyword isn't within
+# array subscripts.
+parse
+last
+----
+last
+
+parse
+$[last]
+----
+$[last]
+
+parse
+$[1 to last, last to last]
+----
+$[1 to last,last to last] -- normalized!
+
 # postgres allows floats as array indexes
 # parse
 # $.abc[1.0]


### PR DESCRIPTION
This commit adds support for using `last` as an array index within jsonpath queries.

Epic: None
Release note (sql change): Add support for using `last` for arrays indexing in JSONPath queries. For example, `SELECT jsonb_path_query('[1, 2, 3, 4]', '$[1 to last]');`.
