### PR TITLE
roachtest: increase admission control mixed version timeout

### DIFF
--- a/pkg/cmd/roachtest/tests/admission_control_elastic_mixed_version.go
+++ b/pkg/cmd/roachtest/tests/admission_control_elastic_mixed_version.go
@@ -37,7 +37,7 @@ func registerElasticWorkloadMixedVersion(r registry.Registry) {
 	r.Add(registry.TestSpec{
 		Name:             "admission-control/elastic-workload/mixed-version",
 		Owner:            registry.OwnerKV,
-		Timeout:          1 * time.Hour,
+		Timeout:          3 * time.Hour,
 		Benchmark:        true,
 		CompatibleClouds: registry.OnlyGCE,
 		Suites:           registry.Suites(registry.MixedVersion, registry.Nightly),


### PR DESCRIPTION
Recently, this test started running with more workload steps, each of which takes 5min, so it's been timing out consistently. This commit increases the test timeout to 3 hours.

Fixes: #143331

Release note: None