### PR TITLE
security: fix possible deadlock in certificate caching code

### DIFF
--- a/pkg/security/clientcert/cert_expiry_cache_test.go
+++ b/pkg/security/clientcert/cert_expiry_cache_test.go
@@ -153,7 +153,7 @@ func TestCacheMetricsSync(t *testing.T) {
 	// insert.
 	cache.MaybeUpsert(ctx, fooUser, defaultSerial, laterExpiration)
 	// update.
-	cache.MaybeUpsert(ctx, fooUser, defaultSerial, closerExpiration)
+	cache.MaybeUpsert(ctx, fooUser, secondarySerial, closerExpiration)
 
 	expFloat := *(findChildMetric(expMetric, fooUser).Gauge.Value)
 	expiration := cache.GetExpiration(fooUser)

--- a/pkg/util/metric/aggmetric/BUILD.bazel
+++ b/pkg/util/metric/aggmetric/BUILD.bazel
@@ -46,7 +46,6 @@ go_test(
         "@com_github_cockroachdb_crlib//testutils/require",
         "@com_github_prometheus_client_model//go",
         "@com_github_prometheus_common//expfmt",
-        "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/util/metric/aggmetric/agg_metric.go
+++ b/pkg/util/metric/aggmetric/agg_metric.go
@@ -234,8 +234,12 @@ type BtreeWrapper struct {
 }
 
 func (b BtreeWrapper) Get(labelVals ...string) (ChildMetric, bool) {
-	panic(errors.AssertionFailedf("btree does not support get method. Invocation with label values: %s",
-		labelVals))
+	key := labelValuesSlice(labelVals)
+	cm := b.tree.Get(&key)
+	if cm == nil {
+		return nil, false
+	}
+	return cm.(ChildMetric), true
 }
 
 func (b BtreeWrapper) Add(metric ChildMetric) {

--- a/pkg/util/metric/aggmetric/counter_test.go
+++ b/pkg/util/metric/aggmetric/counter_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/crlib/testutils/require"
 	"github.com/prometheus/common/expfmt"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestAggCounter(t *testing.T) {
@@ -72,17 +71,4 @@ func TestAggCounter(t *testing.T) {
 
 	testFile = "aggCounter_post_eviction.txt"
 	echotest.Require(t, writePrometheusMetrics(t), datapathutils.TestDataPath(t, testFile))
-}
-
-func TestPanicForAggCounterWithBtreeStorage(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	r := metric.NewRegistry()
-	c := NewCounter(metric.Metadata{
-		Name: "foo_counter",
-	}, "tenant_id", "counter_label")
-	r.AddMetric(c)
-
-	assert.Panics(t, func() {
-		c.Inc(1, "1", "1")
-	}, "expected panic when Inc is invoked on AggCounter with BTreeStorage")
 }

--- a/pkg/util/metric/aggmetric/gauge.go
+++ b/pkg/util/metric/aggmetric/gauge.go
@@ -146,6 +146,15 @@ func (g *AggGauge) Update(val int64, labelVals ...string) {
 	child.Update(val)
 }
 
+// UpdateFn updates the Gauge value by val for the given label values. If a
+// Gauge with the given label values doesn't exist yet, it creates a new
+// Gauge and updates it. Panics if the number of label values doesn't
+// match the number of labels defined for this Gauge.
+func (g *AggGauge) UpdateFn(f func() int64, labelVals ...string) {
+	child := g.getOrCreateChild(labelVals...)
+	child.UpdateFn(f)
+}
+
 func (g *AggGauge) getOrCreateChild(labelVals ...string) *Gauge {
 	if len(g.labels) != len(labelVals) {
 		panic(errors.AssertionFailedf(

--- a/pkg/util/metric/aggmetric/gauge_test.go
+++ b/pkg/util/metric/aggmetric/gauge_test.go
@@ -20,7 +20,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/crlib/testutils/require"
 	"github.com/prometheus/common/expfmt"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestAggGaugeEviction(t *testing.T) {
@@ -102,25 +101,6 @@ func TestAggGaugeMethods(t *testing.T) {
 	echotest.Require(t, writePrometheusMetrics(t), datapathutils.TestDataPath(t, testFile))
 }
 
-func TestPanicForAggGaugeWithBtreeStorage(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	g := NewGauge(metric.Metadata{
-		Name: "foo_gauge",
-	}, "tenant_id")
-
-	assert.Panics(t, func() {
-		g.Inc(1, "1", "1")
-	}, "expected panic when Inc is invoked on AggGauge with BTreeStorage")
-
-	assert.Panics(t, func() {
-		g.Dec(1, "1", "1")
-	}, "expected panic when Dec is invoked on AggGauge with BTreeStorage")
-
-	assert.Panics(t, func() {
-		g.Update(1, "1", "1")
-	}, "expected panic when Update is invoked on AggGauge with BTreeStorage")
-}
-
 func TestAggGaugeFloat64Eviction(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	const cacheSize = 10
@@ -154,17 +134,6 @@ func TestAggGaugeFloat64Eviction(t *testing.T) {
 
 	testFile = "aggGaugeFloat64_post_eviction.txt"
 	echotest.Require(t, writePrometheusMetrics(t), datapathutils.TestDataPath(t, testFile))
-}
-
-func TestPanicForAggGaugeFloat64WithBtreeStorage(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	g := NewGaugeFloat64(metric.Metadata{
-		Name: "foo_gauge",
-	}, "tenant_id")
-
-	assert.Panics(t, func() {
-		g.Update(1, "1", "1")
-	}, "expected panic when Update is invoked on AggGaugeFloat64 with BTreeStorage")
 }
 
 func writePrometheusMetricsFunc(r *metric.Registry) func(t *testing.T) string {

--- a/pkg/util/metric/aggmetric/histogram_test.go
+++ b/pkg/util/metric/aggmetric/histogram_test.go
@@ -21,7 +21,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/crlib/testutils/require"
 	"github.com/prometheus/common/expfmt"
-	"github.com/stretchr/testify/assert"
 )
 
 func TestAggHistogram(t *testing.T) {
@@ -85,21 +84,4 @@ func TestAggHistogram(t *testing.T) {
 		testFile = "aggHistogram_post_eviction_hdr.txt"
 	}
 	echotest.Require(t, writePrometheusMetrics(t), datapathutils.TestDataPath(t, testFile))
-}
-
-func TestPanicForAggHistogramWithBtreeStorage(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	h := NewHistogram(metric.HistogramOptions{
-		Metadata: metric.Metadata{
-			Name: "histo_gram",
-		},
-		Duration:     base.DefaultHistogramWindowInterval(),
-		MaxVal:       100,
-		SigFigs:      1,
-		BucketConfig: metric.Percent100Buckets,
-	}, "tenant_id", "hist_label")
-
-	assert.Panics(t, func() {
-		h.RecordValue(1, "1", "1")
-	}, "expected panic when RecordValue is invoked on AggHistogram with BTreeStorage")
 }


### PR DESCRIPTION
security: fix possible deadlock in certificate caching code

The changes introduce in #143384 allowed for caching client certificates based on when they were last seen, expanding the functionality for reporting on upcoming expirations.

However this introduced a subtle possible deadlock as a result, for adding a new certificate would lock the cache, then the metric, while reading the metric (as the metrics scraper would do) would first lock the metric, then the cache.

Because these operations could happen independently, and locked in the inverse order, a scrape which occurred during an upsert could create a system deadlock.

To fix this, we aim to remove the requirement that the metrics scrape has on locking the cache.

Fixes: #143662
Epic: CRDB-40209

Release note (bug fix): Fixes possible deadlock in cert caching code.