### PR TITLE
sql/cmd/roachtest: improve pg_regress RLS test compatibility

### DIFF
--- a/pkg/cmd/roachtest/testdata/pg_regress/rowsecurity.diffs
+++ b/pkg/cmd/roachtest/testdata/pg_regress/rowsecurity.diffs
@@ -11,40 +11,23 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  CREATE ROLE regress_rls_group1 NOLOGIN;
  CREATE ROLE regress_rls_group2 NOLOGIN;
  GRANT regress_rls_group1 TO regress_rls_bob;
-@@ -30,9 +33,32 @@
- CREATE OR REPLACE FUNCTION f_leak(text) RETURNS bool
-     COST 0.0000001 LANGUAGE plpgsql
+@@ -27,12 +30,12 @@
+ GRANT ALL ON SCHEMA regress_rls_schema to public;
+ SET search_path = regress_rls_schema;
+ -- setup of malicious function
+-CREATE OR REPLACE FUNCTION f_leak(text) RETURNS bool
+-    COST 0.0000001 LANGUAGE plpgsql
++CREATE OR REPLACE FUNCTION f_leak(col text) RETURNS bool
++    LANGUAGE plpgsql
      AS 'BEGIN RAISE NOTICE ''f_leak => %'', $1; RETURN true; END';
-+ERROR:  at or near "0.0000001": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+CREATE OR REPLACE FUNCTION f_leak(text) RETURNS bool
-+    COST 0.0000001 LANGUAGE plpgsql
-+         ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+
-+Please check the public issue tracker to check whether this problem is
-+already tracked. If you cannot find it there, please report the error
-+with details by creating a new issue.
-+
-+If you would rather not post publicly, please contact us directly
-+using the support form.
-+
-+We appreciate your feedback.
-+
  GRANT EXECUTE ON FUNCTION f_leak(text) TO public;
-+ERROR:  unknown function: f_leak()
  -- BASIC Row-Level Security Scenario
- SET SESSION AUTHORIZATION regress_rls_alice;
-+ERROR:  at or near "regress_rls_alice": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_alice
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
+-SET SESSION AUTHORIZATION regress_rls_alice;
++SET ROLE regress_rls_alice;
  CREATE TABLE uaccount (
      pguser      name primary key,
      seclv       int
-@@ -76,13 +102,15 @@
+@@ -76,13 +79,15 @@
  -- user's security level must be higher than or equal to document's
  CREATE POLICY p1 ON document AS PERMISSIVE
      USING (dlevel <= (SELECT seclv FROM uaccount WHERE pguser = current_user));
@@ -64,7 +47,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  -- but Dave isn't allowed to anything at cid 50 or above
  -- this is to make sure that we sort the policies by name first
  -- when applying WITH CHECK, a later INSERT by Dave should fail due
-@@ -93,354 +121,162 @@
+@@ -93,390 +98,182 @@
  CREATE POLICY p1r ON document AS RESTRICTIVE TO regress_rls_dave
      USING (cid <> 44);
  \dp
@@ -136,13 +119,8 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 +(0 rows)
  
  -- viewpoint from regress_rls_bob
- SET SESSION AUTHORIZATION regress_rls_bob;
-+ERROR:  at or near "regress_rls_bob": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_bob
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
+-SET SESSION AUTHORIZATION regress_rls_bob;
++SET ROLE regress_rls_bob;
  SET row_security TO ON;
  SELECT * FROM document WHERE f_leak(dtitle) ORDER BY did;
 -NOTICE:  f_leak => my first novel
@@ -158,8 +136,10 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 -   8 |  44 |      1 | regress_rls_carol | great manga
 -   9 |  22 |      1 | regress_rls_dave  | awesome science fiction
 -(5 rows)
--
-+ERROR:  unknown function: f_leak()
++ did | cid | dlevel | dauthor | dtitle 
++-----+-----+--------+---------+--------
++(0 rows)
+ 
  SELECT * FROM document NATURAL JOIN category WHERE f_leak(dtitle) ORDER BY did;
 -NOTICE:  f_leak => my first novel
 -NOTICE:  f_leak => my first manga
@@ -174,8 +154,10 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 -  44 |   8 |      1 | regress_rls_carol | great manga             | manga
 -  22 |   9 |      1 | regress_rls_dave  | awesome science fiction | science fiction
 -(5 rows)
--
-+ERROR:  unknown function: f_leak()
++ cid | did | dlevel | dauthor | dtitle | cname 
++-----+-----+--------+---------+--------+-------
++(0 rows)
+ 
  -- try a sampled version
  SELECT * FROM document TABLESAMPLE BERNOULLI(50) REPEATABLE(0)
    WHERE f_leak(dtitle) ORDER BY did;
@@ -196,13 +178,8 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 +SELECT * FROM document TABLESAMPLE BERNOULLI(50) REPEATABLE(0)
 +                                   ^
  -- viewpoint from regress_rls_carol
- SET SESSION AUTHORIZATION regress_rls_carol;
-+ERROR:  at or near "regress_rls_carol": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_carol
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
+-SET SESSION AUTHORIZATION regress_rls_carol;
++SET ROLE regress_rls_carol;
  SELECT * FROM document WHERE f_leak(dtitle) ORDER BY did;
 -NOTICE:  f_leak => my first novel
 -NOTICE:  f_leak => my second novel
@@ -227,8 +204,10 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 -   9 |  22 |      1 | regress_rls_dave  | awesome science fiction
 -  10 |  33 |      2 | regress_rls_dave  | awesome technology book
 -(10 rows)
--
-+ERROR:  unknown function: f_leak()
++ did | cid | dlevel | dauthor | dtitle 
++-----+-----+--------+---------+--------
++(0 rows)
+ 
  SELECT * FROM document NATURAL JOIN category WHERE f_leak(dtitle) ORDER BY did;
 -NOTICE:  f_leak => my first novel
 -NOTICE:  f_leak => my second novel
@@ -253,8 +232,10 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 -  22 |   9 |      1 | regress_rls_dave  | awesome science fiction | science fiction
 -  33 |  10 |      2 | regress_rls_dave  | awesome technology book | technology
 -(10 rows)
--
-+ERROR:  unknown function: f_leak()
++ cid | did | dlevel | dauthor | dtitle | cname 
++-----+-----+--------+---------+--------+-------
++(0 rows)
+ 
  -- try a sampled version
  SELECT * FROM document TABLESAMPLE BERNOULLI(50) REPEATABLE(0)
    WHERE f_leak(dtitle) ORDER BY did;
@@ -311,13 +292,8 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 +               ^
 +HINT:  try \h <SELECTCLAUSE>
  -- viewpoint from regress_rls_dave
- SET SESSION AUTHORIZATION regress_rls_dave;
-+ERROR:  at or near "regress_rls_dave": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_dave
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
+-SET SESSION AUTHORIZATION regress_rls_dave;
++SET ROLE regress_rls_dave;
  SELECT * FROM document WHERE f_leak(dtitle) ORDER BY did;
 -NOTICE:  f_leak => my first novel
 -NOTICE:  f_leak => my second novel
@@ -336,8 +312,10 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 -   9 |  22 |      1 | regress_rls_dave  | awesome science fiction
 -  10 |  33 |      2 | regress_rls_dave  | awesome technology book
 -(7 rows)
--
-+ERROR:  unknown function: f_leak()
++ did | cid | dlevel | dauthor | dtitle 
++-----+-----+--------+---------+--------
++(0 rows)
+ 
  SELECT * FROM document NATURAL JOIN category WHERE f_leak(dtitle) ORDER BY did;
 -NOTICE:  f_leak => my first novel
 -NOTICE:  f_leak => my second novel
@@ -356,8 +334,10 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 -  22 |   9 |      1 | regress_rls_dave  | awesome science fiction | science fiction
 -  33 |  10 |      2 | regress_rls_dave  | awesome technology book | technology
 -(7 rows)
--
-+ERROR:  unknown function: f_leak()
++ cid | did | dlevel | dauthor | dtitle | cname 
++-----+-----+--------+---------+--------+-------
++(0 rows)
+ 
  EXPLAIN (COSTS OFF) SELECT * FROM document WHERE f_leak(dtitle);
 -                                          QUERY PLAN                                          
 -----------------------------------------------------------------------------------------------
@@ -396,35 +376,24 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  -- back from p1r for this because it sorts first
  INSERT INTO document VALUES (100, 44, 1, 'regress_rls_dave', 'testing sorting of policies'); -- fail
 -ERROR:  new row violates row-level security policy "p1r" for table "document"
++ERROR:  new row violates row-level security policy for table "document"
  -- Just to see a p2r error
  INSERT INTO document VALUES (100, 55, 1, 'regress_rls_dave', 'testing sorting of policies'); -- fail
 -ERROR:  new row violates row-level security policy "p2r" for table "document"
-+ERROR:  insert on table "document" violates foreign key constraint "document_cid_fkey"
-+DETAIL:  Key (cid)=(55) is not present in table "category".
++ERROR:  new row violates row-level security policy for table "document"
  -- only owner can change policies
  ALTER POLICY p1 ON document USING (true);    --fail
 -ERROR:  must be owner of table document
-+ERROR:  policy "p1" for table "document" does not exist
++ERROR:  must be owner of relation document
  DROP POLICY p1 ON document;                  --fail
--ERROR:  must be owner of relation document
-+ERROR:  policy "p1" for table "document" does not exist
- SET SESSION AUTHORIZATION regress_rls_alice;
-+ERROR:  at or near "regress_rls_alice": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_alice
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
+ ERROR:  must be owner of relation document
+-SET SESSION AUTHORIZATION regress_rls_alice;
++SET ROLE regress_rls_alice;
  ALTER POLICY p1 ON document USING (dauthor = current_user);
 +ERROR:  policy "p1" for table "document" does not exist
  -- viewpoint from regress_rls_bob again
- SET SESSION AUTHORIZATION regress_rls_bob;
-+ERROR:  at or near "regress_rls_bob": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_bob
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
+-SET SESSION AUTHORIZATION regress_rls_bob;
++SET ROLE regress_rls_bob;
  SELECT * FROM document WHERE f_leak(dtitle) ORDER BY did;
 -NOTICE:  f_leak => my first novel
 -NOTICE:  f_leak => my second novel
@@ -439,8 +408,10 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 -   4 |  44 |      1 | regress_rls_bob | my first manga
 -   5 |  44 |      2 | regress_rls_bob | my second manga
 -(5 rows)
--
-+ERROR:  unknown function: f_leak()
++ did | cid | dlevel | dauthor | dtitle 
++-----+-----+--------+---------+--------
++(0 rows)
+ 
  SELECT * FROM document NATURAL JOIN category WHERE f_leak(dtitle) ORDER by did;
 -NOTICE:  f_leak => my first novel
 -NOTICE:  f_leak => my second novel
@@ -455,16 +426,13 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 -  44 |   4 |      1 | regress_rls_bob | my first manga     | manga
 -  44 |   5 |      2 | regress_rls_bob | my second manga    | manga
 -(5 rows)
--
-+ERROR:  unknown function: f_leak()
++ cid | did | dlevel | dauthor | dtitle | cname 
++-----+-----+--------+---------+--------+-------
++(0 rows)
+ 
  -- viewpoint from rls_regres_carol again
- SET SESSION AUTHORIZATION regress_rls_carol;
-+ERROR:  at or near "regress_rls_carol": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_carol
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
+-SET SESSION AUTHORIZATION regress_rls_carol;
++SET ROLE regress_rls_carol;
  SELECT * FROM document WHERE f_leak(dtitle) ORDER BY did;
 -NOTICE:  f_leak => great science fiction
 -NOTICE:  f_leak => great technology book
@@ -475,8 +443,10 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 -   7 |  33 |      2 | regress_rls_carol | great technology book
 -   8 |  44 |      1 | regress_rls_carol | great manga
 -(3 rows)
--
-+ERROR:  unknown function: f_leak()
++ did | cid | dlevel | dauthor | dtitle 
++-----+-----+--------+---------+--------
++(0 rows)
+ 
  SELECT * FROM document NATURAL JOIN category WHERE f_leak(dtitle) ORDER by did;
 -NOTICE:  f_leak => great science fiction
 -NOTICE:  f_leak => great technology book
@@ -487,8 +457,10 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 -  33 |   7 |      2 | regress_rls_carol | great technology book | technology
 -  44 |   8 |      1 | regress_rls_carol | great manga           | manga
 -(3 rows)
--
-+ERROR:  unknown function: f_leak()
++ cid | did | dlevel | dauthor | dtitle | cname 
++-----+-----+--------+---------+--------+-------
++(0 rows)
+ 
  EXPLAIN (COSTS OFF) SELECT * FROM document WHERE f_leak(dtitle);
 -                       QUERY PLAN                        
 ----------------------------------------------------------
@@ -517,26 +489,16 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 +               ^
 +HINT:  try \h <SELECTCLAUSE>
  -- interaction of FK/PK constraints
- SET SESSION AUTHORIZATION regress_rls_alice;
-+ERROR:  at or near "regress_rls_alice": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_alice
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
+-SET SESSION AUTHORIZATION regress_rls_alice;
++SET ROLE regress_rls_alice;
  CREATE POLICY p2 ON category
      USING (CASE WHEN current_user = 'regress_rls_bob' THEN cid IN (11, 33)
             WHEN current_user = 'regress_rls_carol' THEN cid IN (22, 44)
-@@ -448,51 +284,91 @@
+            ELSE false END);
  ALTER TABLE category ENABLE ROW LEVEL SECURITY;
  -- cannot delete PK referenced by invisible FK
- SET SESSION AUTHORIZATION regress_rls_bob;
-+ERROR:  at or near "regress_rls_bob": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_bob
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
+-SET SESSION AUTHORIZATION regress_rls_bob;
++SET ROLE regress_rls_bob;
  SELECT * FROM document d FULL OUTER JOIN category c on d.cid = c.cid ORDER BY d.did, c.cid;
 - did | cid | dlevel |     dauthor     |       dtitle       | cid |   cname    
 ------+-----+--------+-----------------+--------------------+-----+------------
@@ -547,20 +509,11 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 -   5 |  44 |      2 | regress_rls_bob | my second manga    |     | 
 -     |     |        |                 |                    |  33 | technology
 -(6 rows)
-+ did | cid | dlevel |      dauthor      |           dtitle            | cid |      cname      
-+-----+-----+--------+-------------------+-----------------------------+-----+-----------------
-+   1 |  11 |      1 | regress_rls_bob   | my first novel              |  11 | novel
-+   2 |  11 |      2 | regress_rls_bob   | my second novel             |  11 | novel
-+   3 |  22 |      2 | regress_rls_bob   | my science fiction          |  22 | science fiction
-+   4 |  44 |      1 | regress_rls_bob   | my first manga              |  44 | manga
-+   5 |  44 |      2 | regress_rls_bob   | my second manga             |  44 | manga
-+   6 |  22 |      1 | regress_rls_carol | great science fiction       |  22 | science fiction
-+   7 |  33 |      2 | regress_rls_carol | great technology book       |  33 | technology
-+   8 |  44 |      1 | regress_rls_carol | great manga                 |  44 | manga
-+   9 |  22 |      1 | regress_rls_dave  | awesome science fiction     |  22 | science fiction
-+  10 |  33 |      2 | regress_rls_dave  | awesome technology book     |  33 | technology
-+ 100 |  44 |      1 | regress_rls_dave  | testing sorting of policies |  44 | manga
-+(11 rows)
++ did | cid | dlevel | dauthor | dtitle | cid |   cname    
++-----+-----+--------+---------+--------+-----+------------
++     |     |        |         |        |  11 | novel
++     |     |        |         |        |  33 | technology
++(2 rows)
  
  DELETE FROM category WHERE cid = 33;    -- fails with FK violation
 -ERROR:  update or delete on table "category" violates foreign key constraint "document_cid_fkey" on table "document"
@@ -568,13 +521,8 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 +ERROR:  delete on table "category" violates foreign key constraint "document_cid_fkey" on table "document"
 +DETAIL:  Key (cid)=(33) is still referenced from table "document".
  -- can insert FK referencing invisible PK
- SET SESSION AUTHORIZATION regress_rls_carol;
-+ERROR:  at or near "regress_rls_carol": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_carol
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
+-SET SESSION AUTHORIZATION regress_rls_carol;
++SET ROLE regress_rls_carol;
  SELECT * FROM document d FULL OUTER JOIN category c on d.cid = c.cid ORDER BY d.did, c.cid;
 - did | cid | dlevel |      dauthor      |        dtitle         | cid |      cname      
 ------+-----+--------+-------------------+-----------------------+-----+-----------------
@@ -582,212 +530,127 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 -   7 |  33 |      2 | regress_rls_carol | great technology book |     | 
 -   8 |  44 |      1 | regress_rls_carol | great manga           |  44 | manga
 -(3 rows)
-+ did | cid | dlevel |      dauthor      |           dtitle            | cid |      cname      
-+-----+-----+--------+-------------------+-----------------------------+-----+-----------------
-+   1 |  11 |      1 | regress_rls_bob   | my first novel              |  11 | novel
-+   2 |  11 |      2 | regress_rls_bob   | my second novel             |  11 | novel
-+   3 |  22 |      2 | regress_rls_bob   | my science fiction          |  22 | science fiction
-+   4 |  44 |      1 | regress_rls_bob   | my first manga              |  44 | manga
-+   5 |  44 |      2 | regress_rls_bob   | my second manga             |  44 | manga
-+   6 |  22 |      1 | regress_rls_carol | great science fiction       |  22 | science fiction
-+   7 |  33 |      2 | regress_rls_carol | great technology book       |  33 | technology
-+   8 |  44 |      1 | regress_rls_carol | great manga                 |  44 | manga
-+   9 |  22 |      1 | regress_rls_dave  | awesome science fiction     |  22 | science fiction
-+  10 |  33 |      2 | regress_rls_dave  | awesome technology book     |  33 | technology
-+ 100 |  44 |      1 | regress_rls_dave  | testing sorting of policies |  44 | manga
-+(11 rows)
++ did | cid | dlevel | dauthor | dtitle | cid |      cname      
++-----+-----+--------+---------+--------+-----+-----------------
++     |     |        |         |        |  22 | science fiction
++     |     |        |         |        |  44 | manga
++(2 rows)
  
  INSERT INTO document VALUES (11, 33, 1, current_user, 'hoge');
++ERROR:  new row violates row-level security policy for table "document"
  -- UNIQUE or PRIMARY KEY constraint violation DOES reveal presence of row
- SET SESSION AUTHORIZATION regress_rls_bob;
-+ERROR:  at or near "regress_rls_bob": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_bob
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
+-SET SESSION AUTHORIZATION regress_rls_bob;
++SET ROLE regress_rls_bob;
  INSERT INTO document VALUES (8, 44, 1, 'regress_rls_bob', 'my third manga'); -- Must fail with unique violation, revealing presence of did we can't see
- ERROR:  duplicate key value violates unique constraint "document_pkey"
-+DETAIL:  Key (did)=(8) already exists.
+-ERROR:  duplicate key value violates unique constraint "document_pkey"
++ERROR:  new row violates row-level security policy for table "document"
  SELECT * FROM document WHERE did = 8; -- and confirm we can't see it
-- did | cid | dlevel | dauthor | dtitle 
-------+-----+--------+---------+--------
--(0 rows)
-+ did | cid | dlevel |      dauthor      |   dtitle    
-+-----+-----+--------+-------------------+-------------
-+   8 |  44 |      1 | regress_rls_carol | great manga
-+(1 row)
- 
- -- RLS policies are checked before constraints
+  did | cid | dlevel | dauthor | dtitle 
+ -----+-----+--------+---------+--------
+@@ -486,9 +283,8 @@
  INSERT INTO document VALUES (8, 44, 1, 'regress_rls_carol', 'my third manga'); -- Should fail with RLS check violation, not duplicate key violation
--ERROR:  new row violates row-level security policy for table "document"
-+ERROR:  duplicate key value violates unique constraint "document_pkey"
-+DETAIL:  Key (did)=(8) already exists.
+ ERROR:  new row violates row-level security policy for table "document"
  UPDATE document SET did = 8, dauthor = 'regress_rls_carol' WHERE did = 5; -- Should fail with RLS check violation, not duplicate key violation
 -ERROR:  new row violates row-level security policy for table "document"
-+ERROR:  duplicate key value violates unique constraint "document_pkey"
-+DETAIL:  Key (did)=(8) already exists.
  -- database superuser does bypass RLS policy when enabled
- RESET SESSION AUTHORIZATION;
-+ERROR:  at or near "authorization": syntax error
-+DETAIL:  source SQL:
-+RESET SESSION AUTHORIZATION
-+              ^
-+HINT:  try \h RESET
+-RESET SESSION AUTHORIZATION;
++RESET ROLE;
  SET row_security TO ON;
  SELECT * FROM document;
-- did | cid | dlevel |      dauthor      |         dtitle          
-------+-----+--------+-------------------+-------------------------
-+ did | cid | dlevel |      dauthor      |           dtitle            
-+-----+-----+--------+-------------------+-----------------------------
-    1 |  11 |      1 | regress_rls_bob   | my first novel
-    2 |  11 |      2 | regress_rls_bob   | my second novel
-    3 |  22 |      2 | regress_rls_bob   | my science fiction
-@@ -503,8 +379,9 @@
+  did | cid | dlevel |      dauthor      |         dtitle          
+@@ -503,8 +299,7 @@
     8 |  44 |      1 | regress_rls_carol | great manga
     9 |  22 |      1 | regress_rls_dave  | awesome science fiction
    10 |  33 |      2 | regress_rls_dave  | awesome technology book
 -  11 |  33 |      1 | regress_rls_carol | hoge
 -(11 rows)
-+  11 |  33 |      1 | test_admin        | hoge
-+ 100 |  44 |      1 | regress_rls_dave  | testing sorting of policies
-+(12 rows)
++(10 rows)
  
  SELECT * FROM category;
   cid |      cname      
-@@ -517,10 +394,15 @@
+@@ -516,7 +311,7 @@
+ (4 rows)
  
  -- database superuser does bypass RLS policy when disabled
- RESET SESSION AUTHORIZATION;
-+ERROR:  at or near "authorization": syntax error
-+DETAIL:  source SQL:
-+RESET SESSION AUTHORIZATION
-+              ^
-+HINT:  try \h RESET
+-RESET SESSION AUTHORIZATION;
++RESET ROLE;
  SET row_security TO OFF;
  SELECT * FROM document;
-- did | cid | dlevel |      dauthor      |         dtitle          
-------+-----+--------+-------------------+-------------------------
-+ did | cid | dlevel |      dauthor      |           dtitle            
-+-----+-----+--------+-------------------+-----------------------------
-    1 |  11 |      1 | regress_rls_bob   | my first novel
-    2 |  11 |      2 | regress_rls_bob   | my second novel
-    3 |  22 |      2 | regress_rls_bob   | my science fiction
-@@ -531,8 +413,9 @@
+  did | cid | dlevel |      dauthor      |         dtitle          
+@@ -531,8 +326,7 @@
     8 |  44 |      1 | regress_rls_carol | great manga
     9 |  22 |      1 | regress_rls_dave  | awesome science fiction
    10 |  33 |      2 | regress_rls_dave  | awesome technology book
 -  11 |  33 |      1 | regress_rls_carol | hoge
 -(11 rows)
-+  11 |  33 |      1 | test_admin        | hoge
-+ 100 |  44 |      1 | regress_rls_dave  | testing sorting of policies
-+(12 rows)
++(10 rows)
  
  SELECT * FROM category;
   cid |      cname      
-@@ -545,10 +428,16 @@
+@@ -544,7 +338,8 @@
+ (4 rows)
  
  -- database non-superuser with bypass privilege can bypass RLS policy when disabled
- SET SESSION AUTHORIZATION regress_rls_exempt_user;
-+ERROR:  at or near "regress_rls_exempt_user": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_exempt_user
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
+-SET SESSION AUTHORIZATION regress_rls_exempt_user;
++SET ROLE regress_rls_exempt_user;
++ERROR:  role/user "regress_rls_exempt_user" does not exist
  SET row_security TO OFF;
  SELECT * FROM document;
-- did | cid | dlevel |      dauthor      |         dtitle          
-------+-----+--------+-------------------+-------------------------
-+ did | cid | dlevel |      dauthor      |           dtitle            
-+-----+-----+--------+-------------------+-----------------------------
-    1 |  11 |      1 | regress_rls_bob   | my first novel
-    2 |  11 |      2 | regress_rls_bob   | my second novel
-    3 |  22 |      2 | regress_rls_bob   | my science fiction
-@@ -559,8 +448,9 @@
+  did | cid | dlevel |      dauthor      |         dtitle          
+@@ -559,8 +354,7 @@
     8 |  44 |      1 | regress_rls_carol | great manga
     9 |  22 |      1 | regress_rls_dave  | awesome science fiction
    10 |  33 |      2 | regress_rls_dave  | awesome technology book
 -  11 |  33 |      1 | regress_rls_carol | hoge
 -(11 rows)
-+  11 |  33 |      1 | test_admin        | hoge
-+ 100 |  44 |      1 | regress_rls_dave  | testing sorting of policies
-+(12 rows)
++(10 rows)
  
  SELECT * FROM category;
   cid |      cname      
-@@ -573,10 +463,16 @@
+@@ -572,7 +366,7 @@
+ (4 rows)
  
  -- RLS policy does not apply to table owner when RLS enabled.
- SET SESSION AUTHORIZATION regress_rls_alice;
-+ERROR:  at or near "regress_rls_alice": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_alice
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
+-SET SESSION AUTHORIZATION regress_rls_alice;
++SET ROLE regress_rls_alice;
  SET row_security TO ON;
  SELECT * FROM document;
-- did | cid | dlevel |      dauthor      |         dtitle          
-------+-----+--------+-------------------+-------------------------
-+ did | cid | dlevel |      dauthor      |           dtitle            
-+-----+-----+--------+-------------------+-----------------------------
-    1 |  11 |      1 | regress_rls_bob   | my first novel
-    2 |  11 |      2 | regress_rls_bob   | my second novel
-    3 |  22 |      2 | regress_rls_bob   | my science fiction
-@@ -587,8 +483,9 @@
+  did | cid | dlevel |      dauthor      |         dtitle          
+@@ -587,8 +381,7 @@
     8 |  44 |      1 | regress_rls_carol | great manga
     9 |  22 |      1 | regress_rls_dave  | awesome science fiction
    10 |  33 |      2 | regress_rls_dave  | awesome technology book
 -  11 |  33 |      1 | regress_rls_carol | hoge
 -(11 rows)
-+  11 |  33 |      1 | test_admin        | hoge
-+ 100 |  44 |      1 | regress_rls_dave  | testing sorting of policies
-+(12 rows)
++(10 rows)
  
  SELECT * FROM category;
   cid |      cname      
-@@ -601,10 +498,16 @@
+@@ -600,7 +393,7 @@
+ (4 rows)
  
  -- RLS policy does not apply to table owner when RLS disabled.
- SET SESSION AUTHORIZATION regress_rls_alice;
-+ERROR:  at or near "regress_rls_alice": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_alice
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
+-SET SESSION AUTHORIZATION regress_rls_alice;
++SET ROLE regress_rls_alice;
  SET row_security TO OFF;
  SELECT * FROM document;
-- did | cid | dlevel |      dauthor      |         dtitle          
-------+-----+--------+-------------------+-------------------------
-+ did | cid | dlevel |      dauthor      |           dtitle            
-+-----+-----+--------+-------------------+-----------------------------
-    1 |  11 |      1 | regress_rls_bob   | my first novel
-    2 |  11 |      2 | regress_rls_bob   | my second novel
-    3 |  22 |      2 | regress_rls_bob   | my science fiction
-@@ -615,8 +518,9 @@
+  did | cid | dlevel |      dauthor      |         dtitle          
+@@ -615,8 +408,7 @@
     8 |  44 |      1 | regress_rls_carol | great manga
     9 |  22 |      1 | regress_rls_dave  | awesome science fiction
    10 |  33 |      2 | regress_rls_dave  | awesome technology book
 -  11 |  33 |      1 | regress_rls_carol | hoge
 -(11 rows)
-+  11 |  33 |      1 | test_admin        | hoge
-+ 100 |  44 |      1 | regress_rls_dave  | testing sorting of policies
-+(12 rows)
++(10 rows)
  
  SELECT * FROM category;
   cid |      cname      
-@@ -631,278 +535,205 @@
+@@ -630,279 +422,190 @@
+ --
  -- Table inheritance and RLS policy
  --
- SET SESSION AUTHORIZATION regress_rls_alice;
-+ERROR:  at or near "regress_rls_alice": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_alice
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
+-SET SESSION AUTHORIZATION regress_rls_alice;
++SET ROLE regress_rls_alice;
  SET row_security TO ON;
  CREATE TABLE t1 (id int not null primary key, a int, junk1 text, b text);
  ALTER TABLE t1 DROP COLUMN junk1;    -- just a disturbing factor
@@ -858,14 +721,9 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 +ERROR:  relation "t2" does not exist
  ALTER TABLE t1 ENABLE ROW LEVEL SECURITY;
  ALTER TABLE t2 ENABLE ROW LEVEL SECURITY;
+-SET SESSION AUTHORIZATION regress_rls_bob;
 +ERROR:  relation "t2" does not exist
- SET SESSION AUTHORIZATION regress_rls_bob;
-+ERROR:  at or near "regress_rls_bob": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_bob
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
++SET ROLE regress_rls_bob;
  SELECT * FROM t1;
 - id  | a |  b  
 ------+---+-----
@@ -910,8 +768,10 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 - 204 | 4 | def
 - 302 | 2 | yyy
 -(5 rows)
--
-+ERROR:  unknown function: f_leak()
++ id | a | b 
++----+---+---
++(0 rows)
+ 
  EXPLAIN (COSTS OFF) SELECT * FROM t1 WHERE f_leak(b);
 -                  QUERY PLAN                   
 ------------------------------------------------
@@ -1037,8 +897,10 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 - 204 | 4 | def
 - 302 | 2 | yyy
 -(5 rows)
--
-+ERROR:  unknown function: f_leak()
++ id | a | b 
++----+---+---
++(0 rows)
+ 
  EXPLAIN (COSTS OFF) SELECT * FROM t1 WHERE f_leak(b) FOR SHARE;
 -                     QUERY PLAN                      
 ------------------------------------------------------
@@ -1084,12 +946,8 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 +               ^
 +HINT:  try \h <SELECTCLAUSE>
  -- superuser is allowed to bypass RLS checks
- RESET SESSION AUTHORIZATION;
-+ERROR:  at or near "authorization": syntax error
-+DETAIL:  source SQL:
-+RESET SESSION AUTHORIZATION
-+              ^
-+HINT:  try \h RESET
+-RESET SESSION AUTHORIZATION;
++RESET ROLE;
  SET row_security TO OFF;
  SELECT * FROM t1 WHERE f_leak(b);
 -NOTICE:  f_leak => aba
@@ -1117,8 +975,10 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 - 302 | 2 | yyy
 - 303 | 3 | zzz
 -(11 rows)
--
-+ERROR:  unknown function: f_leak()
++ id | a | b 
++----+---+---
++(0 rows)
+ 
  EXPLAIN (COSTS OFF) SELECT * FROM t1 WHERE f_leak(b);
 -        QUERY PLAN         
 ----------------------------
@@ -1137,13 +997,9 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 +               ^
 +HINT:  try \h <SELECTCLAUSE>
  -- non-superuser with bypass privilege can bypass RLS policy when disabled
- SET SESSION AUTHORIZATION regress_rls_exempt_user;
-+ERROR:  at or near "regress_rls_exempt_user": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_exempt_user
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
+-SET SESSION AUTHORIZATION regress_rls_exempt_user;
++SET ROLE regress_rls_exempt_user;
++ERROR:  role/user "regress_rls_exempt_user" does not exist
  SET row_security TO OFF;
  SELECT * FROM t1 WHERE f_leak(b);
 -NOTICE:  f_leak => aba
@@ -1171,8 +1027,10 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 - 302 | 2 | yyy
 - 303 | 3 | zzz
 -(11 rows)
--
-+ERROR:  unknown function: f_leak()
++ id | a | b 
++----+---+---
++(0 rows)
+ 
  EXPLAIN (COSTS OFF) SELECT * FROM t1 WHERE f_leak(b);
 -        QUERY PLAN         
 ----------------------------
@@ -1193,17 +1051,12 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  --
  -- Partitioned Tables
  --
- SET SESSION AUTHORIZATION regress_rls_alice;
-+ERROR:  at or near "regress_rls_alice": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_alice
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
+-SET SESSION AUTHORIZATION regress_rls_alice;
++SET ROLE regress_rls_alice;
  CREATE TABLE part_document (
      did         int,
      cid         int,
-@@ -910,14 +741,44 @@
+@@ -910,14 +613,44 @@
      dauthor     name,
      dtitle      text
  ) PARTITION BY RANGE (cid);
@@ -1248,7 +1101,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  INSERT INTO part_document VALUES
      ( 1, 11, 1, 'regress_rls_bob', 'my first novel'),
      ( 2, 11, 2, 'regress_rls_bob', 'my second novel'),
-@@ -929,1067 +790,844 @@
+@@ -929,1067 +662,589 @@
      ( 8, 55, 2, 'regress_rls_carol', 'great satire'),
      ( 9, 11, 1, 'regress_rls_dave', 'awesome science fiction'),
      (10, 99, 2, 'regress_rls_dave', 'awesome technology book');
@@ -1308,13 +1161,8 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 +(0 rows)
  
  -- viewpoint from regress_rls_bob
- SET SESSION AUTHORIZATION regress_rls_bob;
-+ERROR:  at or near "regress_rls_bob": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_bob
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
+-SET SESSION AUTHORIZATION regress_rls_bob;
++SET ROLE regress_rls_bob;
  SET row_security TO ON;
  SELECT * FROM part_document WHERE f_leak(dtitle) ORDER BY did;
 -NOTICE:  f_leak => my first novel
@@ -1351,13 +1199,8 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 +               ^
 +HINT:  try \h <SELECTCLAUSE>
  -- viewpoint from regress_rls_carol
- SET SESSION AUTHORIZATION regress_rls_carol;
-+ERROR:  at or near "regress_rls_carol": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_carol
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
+-SET SESSION AUTHORIZATION regress_rls_carol;
++SET ROLE regress_rls_carol;
  SELECT * FROM part_document WHERE f_leak(dtitle) ORDER BY did;
 -NOTICE:  f_leak => my first novel
 -NOTICE:  f_leak => my second novel
@@ -1405,13 +1248,8 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 +               ^
 +HINT:  try \h <SELECTCLAUSE>
  -- viewpoint from regress_rls_dave
- SET SESSION AUTHORIZATION regress_rls_dave;
-+ERROR:  at or near "regress_rls_dave": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_dave
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
+-SET SESSION AUTHORIZATION regress_rls_dave;
++SET ROLE regress_rls_dave;
  SELECT * FROM part_document WHERE f_leak(dtitle) ORDER BY did;
 -NOTICE:  f_leak => my first novel
 -NOTICE:  f_leak => my second novel
@@ -1486,26 +1324,16 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 -
 +ERROR:  relation "part_document_satire" does not exist
  -- Turn on RLS and create policy on child to show RLS is checked before constraints
- SET SESSION AUTHORIZATION regress_rls_alice;
-+ERROR:  at or near "regress_rls_alice": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_alice
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
+-SET SESSION AUTHORIZATION regress_rls_alice;
++SET ROLE regress_rls_alice;
  ALTER TABLE part_document_satire ENABLE ROW LEVEL SECURITY;
 +ERROR:  relation "part_document_satire" does not exist
  CREATE POLICY pp3 ON part_document_satire AS RESTRICTIVE
      USING (cid < 55);
 +ERROR:  relation "part_document_satire" does not exist
  -- This should fail with RLS violation now.
- SET SESSION AUTHORIZATION regress_rls_dave;
-+ERROR:  at or near "regress_rls_dave": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_dave
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
+-SET SESSION AUTHORIZATION regress_rls_dave;
++SET ROLE regress_rls_dave;
  INSERT INTO part_document_satire VALUES (101, 55, 1, 'regress_rls_dave', 'testing RLS with partitions'); -- fail
 -ERROR:  new row violates row-level security policy for table "part_document_satire"
 +ERROR:  relation "part_document_satire" does not exist
@@ -1548,13 +1376,8 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 +               ^
 +HINT:  try \h <SELECTCLAUSE>
  -- viewpoint from regress_rls_carol
- SET SESSION AUTHORIZATION regress_rls_carol;
-+ERROR:  at or near "regress_rls_carol": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_carol
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
+-SET SESSION AUTHORIZATION regress_rls_carol;
++SET ROLE regress_rls_carol;
  SELECT * FROM part_document WHERE f_leak(dtitle) ORDER BY did;
 -NOTICE:  f_leak => my first novel
 -NOTICE:  f_leak => my second novel
@@ -1609,24 +1432,14 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 +ERROR:  relation "part_document" does not exist
  DROP POLICY pp1 ON part_document;                  --fail
 -ERROR:  must be owner of relation part_document
+-SET SESSION AUTHORIZATION regress_rls_alice;
 +ERROR:  relation "part_document" does not exist
- SET SESSION AUTHORIZATION regress_rls_alice;
-+ERROR:  at or near "regress_rls_alice": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_alice
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
++SET ROLE regress_rls_alice;
  ALTER POLICY pp1 ON part_document USING (dauthor = current_user);
 +ERROR:  relation "part_document" does not exist
  -- viewpoint from regress_rls_bob again
- SET SESSION AUTHORIZATION regress_rls_bob;
-+ERROR:  at or near "regress_rls_bob": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_bob
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
+-SET SESSION AUTHORIZATION regress_rls_bob;
++SET ROLE regress_rls_bob;
  SELECT * FROM part_document WHERE f_leak(dtitle) ORDER BY did;
 -NOTICE:  f_leak => my first novel
 -NOTICE:  f_leak => my second novel
@@ -1644,13 +1457,8 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 -
 +ERROR:  relation "part_document" does not exist
  -- viewpoint from rls_regres_carol again
- SET SESSION AUTHORIZATION regress_rls_carol;
-+ERROR:  at or near "regress_rls_carol": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_carol
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
+-SET SESSION AUTHORIZATION regress_rls_carol;
++SET ROLE regress_rls_carol;
  SELECT * FROM part_document WHERE f_leak(dtitle) ORDER BY did;
 -NOTICE:  f_leak => great science fiction
 -NOTICE:  f_leak => great satire
@@ -1681,12 +1489,8 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 +               ^
 +HINT:  try \h <SELECTCLAUSE>
  -- database superuser does bypass RLS policy when enabled
- RESET SESSION AUTHORIZATION;
-+ERROR:  at or near "authorization": syntax error
-+DETAIL:  source SQL:
-+RESET SESSION AUTHORIZATION
-+              ^
-+HINT:  try \h RESET
+-RESET SESSION AUTHORIZATION;
++RESET ROLE;
  SET row_security TO ON;
  SELECT * FROM part_document ORDER BY did;
 - did | cid | dlevel |      dauthor      |           dtitle            
@@ -1715,13 +1519,9 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 -
 +ERROR:  relation "part_document_satire" does not exist
  -- database non-superuser with bypass privilege can bypass RLS policy when disabled
- SET SESSION AUTHORIZATION regress_rls_exempt_user;
-+ERROR:  at or near "regress_rls_exempt_user": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_exempt_user
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
+-SET SESSION AUTHORIZATION regress_rls_exempt_user;
++SET ROLE regress_rls_exempt_user;
++ERROR:  role/user "regress_rls_exempt_user" does not exist
  SET row_security TO OFF;
  SELECT * FROM part_document ORDER BY did;
 - did | cid | dlevel |      dauthor      |           dtitle            
@@ -1750,13 +1550,8 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 -
 +ERROR:  relation "part_document_satire" does not exist
  -- RLS policy does not apply to table owner when RLS enabled.
- SET SESSION AUTHORIZATION regress_rls_alice;
-+ERROR:  at or near "regress_rls_alice": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_alice
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
+-SET SESSION AUTHORIZATION regress_rls_alice;
++SET ROLE regress_rls_alice;
  SET row_security TO ON;
  SELECT * FROM part_document ORDER by did;
 - did | cid | dlevel |      dauthor      |           dtitle            
@@ -1785,13 +1580,8 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 -
 +ERROR:  relation "part_document_satire" does not exist
  -- When RLS disabled, other users get ERROR.
- SET SESSION AUTHORIZATION regress_rls_dave;
-+ERROR:  at or near "regress_rls_dave": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_dave
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
+-SET SESSION AUTHORIZATION regress_rls_dave;
++SET ROLE regress_rls_dave;
  SET row_security TO OFF;
  SELECT * FROM part_document ORDER by did;
 -ERROR:  query would be affected by row-level security policy for table "part_document"
@@ -1800,35 +1590,20 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 -ERROR:  query would be affected by row-level security policy for table "part_document_satire"
 +ERROR:  relation "part_document_satire" does not exist
  -- Check behavior with a policy that uses a SubPlan not an InitPlan.
- SET SESSION AUTHORIZATION regress_rls_alice;
-+ERROR:  at or near "regress_rls_alice": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_alice
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
+-SET SESSION AUTHORIZATION regress_rls_alice;
++SET ROLE regress_rls_alice;
  SET row_security TO ON;
  CREATE POLICY pp3 ON part_document AS RESTRICTIVE
      USING ((SELECT dlevel <= seclv FROM uaccount WHERE pguser = current_user));
+-SET SESSION AUTHORIZATION regress_rls_carol;
 +ERROR:  relation "part_document" does not exist
- SET SESSION AUTHORIZATION regress_rls_carol;
-+ERROR:  at or near "regress_rls_carol": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_carol
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
++SET ROLE regress_rls_carol;
  INSERT INTO part_document VALUES (100, 11, 5, 'regress_rls_carol', 'testing pp3'); -- fail
 -ERROR:  new row violates row-level security policy "pp3" for table "part_document"
 +ERROR:  relation "part_document" does not exist
  ----- Dependencies -----
- SET SESSION AUTHORIZATION regress_rls_alice;
-+ERROR:  at or near "regress_rls_alice": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_alice
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
+-SET SESSION AUTHORIZATION regress_rls_alice;
++SET ROLE regress_rls_alice;
  SET row_security TO ON;
  CREATE TABLE dependee (x integer, y integer);
  CREATE TABLE dependent (x integer, y integer);
@@ -1858,109 +1633,63 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  --
  -- Simple recursion
  --
- SET SESSION AUTHORIZATION regress_rls_alice;
-+ERROR:  at or near "regress_rls_alice": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_alice
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
+-SET SESSION AUTHORIZATION regress_rls_alice;
++SET ROLE regress_rls_alice;
  CREATE TABLE rec1 (x integer, y integer);
  CREATE POLICY r1 ON rec1 USING (x = (SELECT r.x FROM rec1 r WHERE y = r.y));
 +ERROR:  no data source matches prefix: r in this context
  ALTER TABLE rec1 ENABLE ROW LEVEL SECURITY;
- SET SESSION AUTHORIZATION regress_rls_bob;
-+ERROR:  at or near "regress_rls_bob": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_bob
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
+-SET SESSION AUTHORIZATION regress_rls_bob;
++SET ROLE regress_rls_bob;
  SELECT * FROM rec1; -- fail, direct recursion
 -ERROR:  infinite recursion detected in policy for relation "rec1"
-+ x | y 
-+---+---
-+(0 rows)
-+
++ERROR:  user regress_rls_bob does not have SELECT privilege on relation rec1
  --
  -- Mutual recursion
  --
- SET SESSION AUTHORIZATION regress_rls_alice;
-+ERROR:  at or near "regress_rls_alice": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_alice
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
+-SET SESSION AUTHORIZATION regress_rls_alice;
++SET ROLE regress_rls_alice;
  CREATE TABLE rec2 (a integer, b integer);
  ALTER POLICY r1 ON rec1 USING (x = (SELECT a FROM rec2 WHERE b = y));
 +ERROR:  policy "r1" for table "rec1" does not exist
  CREATE POLICY r2 ON rec2 USING (a = (SELECT x FROM rec1 WHERE y = b));
 +ERROR:  column "x" does not exist
  ALTER TABLE rec2 ENABLE ROW LEVEL SECURITY;
- SET SESSION AUTHORIZATION regress_rls_bob;
-+ERROR:  at or near "regress_rls_bob": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_bob
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
+-SET SESSION AUTHORIZATION regress_rls_bob;
++SET ROLE regress_rls_bob;
  SELECT * FROM rec1;    -- fail, mutual recursion
 -ERROR:  infinite recursion detected in policy for relation "rec1"
-+ x | y 
-+---+---
-+(0 rows)
-+
++ERROR:  user regress_rls_bob does not have SELECT privilege on relation rec1
  --
  -- Mutual recursion via views
  --
- SET SESSION AUTHORIZATION regress_rls_bob;
-+ERROR:  at or near "regress_rls_bob": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_bob
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
+-SET SESSION AUTHORIZATION regress_rls_bob;
++SET ROLE regress_rls_bob;
  CREATE VIEW rec1v AS SELECT * FROM rec1;
++ERROR:  user regress_rls_bob does not have SELECT privilege on relation rec1
  CREATE VIEW rec2v AS SELECT * FROM rec2;
- SET SESSION AUTHORIZATION regress_rls_alice;
-+ERROR:  at or near "regress_rls_alice": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_alice
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
+-SET SESSION AUTHORIZATION regress_rls_alice;
++ERROR:  user regress_rls_bob does not have SELECT privilege on relation rec2
++SET ROLE regress_rls_alice;
  ALTER POLICY r1 ON rec1 USING (x = (SELECT a FROM rec2v WHERE b = y));
 +ERROR:  policy "r1" for table "rec1" does not exist
  ALTER POLICY r2 ON rec2 USING (a = (SELECT x FROM rec1v WHERE y = b));
+-SET SESSION AUTHORIZATION regress_rls_bob;
 +ERROR:  policy "r2" for table "rec2" does not exist
- SET SESSION AUTHORIZATION regress_rls_bob;
-+ERROR:  at or near "regress_rls_bob": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_bob
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
++SET ROLE regress_rls_bob;
  SELECT * FROM rec1;    -- fail, mutual recursion via views
 -ERROR:  infinite recursion detected in policy for relation "rec1"
-+ x | y 
-+---+---
-+(0 rows)
-+
++ERROR:  user regress_rls_bob does not have SELECT privilege on relation rec1
  --
  -- Mutual recursion via .s.b views
  --
- SET SESSION AUTHORIZATION regress_rls_bob;
-+ERROR:  at or near "regress_rls_bob": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_bob
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
+-SET SESSION AUTHORIZATION regress_rls_bob;
++SET ROLE regress_rls_bob;
  DROP VIEW rec1v, rec2v CASCADE;
 -NOTICE:  drop cascades to 2 other objects
 -DETAIL:  drop cascades to policy r1 on table rec1
 -drop cascades to policy r2 on table rec2
++ERROR:  relation "rec1v" does not exist
  CREATE VIEW rec1v WITH (security_barrier) AS SELECT * FROM rec1;
 +ERROR:  at or near "with": syntax error
 +DETAIL:  source SQL:
@@ -1974,40 +1703,21 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 +CREATE VIEW rec2v WITH (security_barrier) AS SELECT * FROM rec2
 +                  ^
 +HINT:  try \h CREATE VIEW
-+SET SESSION AUTHORIZATION regress_rls_alice;
-+ERROR:  at or near "regress_rls_alice": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_alice
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
++SET ROLE regress_rls_alice;
  CREATE POLICY r1 ON rec1 USING (x = (SELECT a FROM rec2v WHERE b = y));
 +ERROR:  column "a" does not exist
  CREATE POLICY r2 ON rec2 USING (a = (SELECT x FROM rec1v WHERE y = b));
+-SET SESSION AUTHORIZATION regress_rls_bob;
 +ERROR:  column "x" does not exist
- SET SESSION AUTHORIZATION regress_rls_bob;
-+ERROR:  at or near "regress_rls_bob": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_bob
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
++SET ROLE regress_rls_bob;
  SELECT * FROM rec1;    -- fail, mutual recursion via s.b. views
 -ERROR:  infinite recursion detected in policy for relation "rec1"
-+ x | y 
-+---+---
-+(0 rows)
-+
++ERROR:  user regress_rls_bob does not have SELECT privilege on relation rec1
  --
  -- recursive RLS and VIEWs in policy
  --
- SET SESSION AUTHORIZATION regress_rls_alice;
-+ERROR:  at or near "regress_rls_alice": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_alice
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
+-SET SESSION AUTHORIZATION regress_rls_alice;
++SET ROLE regress_rls_alice;
  CREATE TABLE s1 (a int, b text);
  INSERT INTO s1 (SELECT x, public.fipshash(x::text) FROM generate_series(-10,10) x);
 +ERROR:  unknown function: public.fipshash()
@@ -2023,45 +1733,36 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 +ERROR:  variable sub-expressions are not allowed in POLICY WITH CHECK
  ALTER TABLE s1 ENABLE ROW LEVEL SECURITY;
  ALTER TABLE s2 ENABLE ROW LEVEL SECURITY;
- SET SESSION AUTHORIZATION regress_rls_bob;
-+ERROR:  at or near "regress_rls_bob": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_bob
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
+-SET SESSION AUTHORIZATION regress_rls_bob;
++SET ROLE regress_rls_bob;
  CREATE VIEW v2 AS SELECT * FROM s2 WHERE y like '%af%';
  SELECT * FROM s1 WHERE f_leak(b); -- fail (infinite recursion)
 -ERROR:  infinite recursion detected in policy for relation "s1"
-+ERROR:  unknown function: f_leak()
++ a | b 
++---+---
++(0 rows)
++
  INSERT INTO s1 VALUES (1, 'foo'); -- fail (infinite recursion)
 -ERROR:  infinite recursion detected in policy for relation "s1"
- SET SESSION AUTHORIZATION regress_rls_alice;
-+ERROR:  at or near "regress_rls_alice": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_alice
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
+-SET SESSION AUTHORIZATION regress_rls_alice;
++ERROR:  user regress_rls_bob does not have INSERT privilege on relation s1
++SET ROLE regress_rls_alice;
  DROP POLICY p3 on s1;
 +ERROR:  policy "p3" for table "s1" does not exist
  ALTER POLICY p2 ON s2 USING (x % 2 = 0);
+-SET SESSION AUTHORIZATION regress_rls_bob;
 +ERROR:  policy "p2" for table "s2" does not exist
- SET SESSION AUTHORIZATION regress_rls_bob;
-+ERROR:  at or near "regress_rls_bob": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_bob
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
++SET ROLE regress_rls_bob;
  SELECT * FROM s1 WHERE f_leak(b);	-- OK
 -NOTICE:  f_leak => 03b26944890929ff751653acb2f2af79
 - a  |                b                 
 -----+----------------------------------
 - -6 | 03b26944890929ff751653acb2f2af79
 -(1 row)
--
-+ERROR:  unknown function: f_leak()
++ a | b 
++---+---
++(0 rows)
+ 
  EXPLAIN (COSTS OFF) SELECT * FROM only s1 WHERE f_leak(b);
 -                        QUERY PLAN                         
 ------------------------------------------------------------
@@ -2078,30 +1779,21 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 +EXPLAIN (COSTS OFF) SELECT * FROM only s1 WHERE f_leak(b)
 +               ^
 +HINT:  try \h <SELECTCLAUSE>
-+SET SESSION AUTHORIZATION regress_rls_alice;
-+ERROR:  at or near "regress_rls_alice": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_alice
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
++SET ROLE regress_rls_alice;
  ALTER POLICY p1 ON s1 USING (a in (select x from v2)); -- using VIEW in RLS policy
+-SET SESSION AUTHORIZATION regress_rls_bob;
 +ERROR:  policy "p1" for table "s1" does not exist
- SET SESSION AUTHORIZATION regress_rls_bob;
-+ERROR:  at or near "regress_rls_bob": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_bob
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
++SET ROLE regress_rls_bob;
  SELECT * FROM s1 WHERE f_leak(b);	-- OK
 -NOTICE:  f_leak => 03b26944890929ff751653acb2f2af79
 - a  |                b                 
 -----+----------------------------------
 - -6 | 03b26944890929ff751653acb2f2af79
 -(1 row)
--
-+ERROR:  unknown function: f_leak()
++ a | b 
++---+---
++(0 rows)
+ 
  EXPLAIN (COSTS OFF) SELECT * FROM s1 WHERE f_leak(b);
 -                        QUERY PLAN                         
 ------------------------------------------------------------
@@ -2146,25 +1838,17 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 +EXPLAIN (COSTS OFF) SELECT (SELECT x FROM s1 LIMIT 1) xx, * FROM s2 WHERE y like '%28%'
 +               ^
 +HINT:  try \h <SELECTCLAUSE>
-+SET SESSION AUTHORIZATION regress_rls_alice;
-+ERROR:  at or near "regress_rls_alice": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_alice
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
++SET ROLE regress_rls_alice;
  ALTER POLICY p2 ON s2 USING (x in (select a from s1 where b like '%d2%'));
+-SET SESSION AUTHORIZATION regress_rls_bob;
 +ERROR:  policy "p2" for table "s2" does not exist
- SET SESSION AUTHORIZATION regress_rls_bob;
-+ERROR:  at or near "regress_rls_bob": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_bob
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
++SET ROLE regress_rls_bob;
  SELECT * FROM s1 WHERE f_leak(b);	-- fail (infinite recursion via view)
 -ERROR:  infinite recursion detected in policy for relation "s1"
-+ERROR:  unknown function: f_leak()
++ a | b 
++---+---
++(0 rows)
++
  -- prepared statement with regress_rls_alice privilege
  PREPARE p1(int) AS SELECT * FROM t1 WHERE a <= $1;
  EXECUTE p1(2);
@@ -2196,12 +1880,8 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 +               ^
 +HINT:  try \h <SELECTCLAUSE>
  -- superuser is allowed to bypass RLS checks
- RESET SESSION AUTHORIZATION;
-+ERROR:  at or near "authorization": syntax error
-+DETAIL:  source SQL:
-+RESET SESSION AUTHORIZATION
-+              ^
-+HINT:  try \h RESET
+-RESET SESSION AUTHORIZATION;
++RESET ROLE;
  SET row_security TO OFF;
  SELECT * FROM t1 WHERE f_leak(b);
 -NOTICE:  f_leak => aba
@@ -2229,8 +1909,10 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 - 302 | 2 | yyy
 - 303 | 3 | zzz
 -(11 rows)
--
-+ERROR:  unknown function: f_leak()
++ id | a | b 
++----+---+---
++(0 rows)
+ 
  EXPLAIN (COSTS OFF) SELECT * FROM t1 WHERE f_leak(b);
 -        QUERY PLAN         
 ----------------------------
@@ -2310,13 +1992,8 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 +               ^
 +HINT:  try \h <SELECTCLAUSE>
  -- also, case when privilege switch from superuser
- SET SESSION AUTHORIZATION regress_rls_bob;
-+ERROR:  at or near "regress_rls_bob": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_bob
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
+-SET SESSION AUTHORIZATION regress_rls_bob;
++SET ROLE regress_rls_bob;
  SET row_security TO ON;
  EXECUTE p2(2);
 - id  | a |  b  
@@ -2349,13 +2026,8 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  --
  -- UPDATE / DELETE and Row-level security
  --
- SET SESSION AUTHORIZATION regress_rls_bob;
-+ERROR:  at or near "regress_rls_bob": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_bob
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
+-SET SESSION AUTHORIZATION regress_rls_bob;
++SET ROLE regress_rls_bob;
  EXPLAIN (COSTS OFF) UPDATE t1 SET b = b || b WHERE f_leak(b);
 -                        QUERY PLAN                         
 ------------------------------------------------------------
@@ -2384,7 +2056,6 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 -NOTICE:  f_leak => bcd
 -NOTICE:  f_leak => def
 -NOTICE:  f_leak => yyy
-+ERROR:  unknown function: f_leak()
  EXPLAIN (COSTS OFF) UPDATE only t1 SET b = b || '_updt' WHERE f_leak(b);
 -                  QUERY PLAN                   
 ------------------------------------------------
@@ -2401,7 +2072,6 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  UPDATE only t1 SET b = b || '_updt' WHERE f_leak(b);
 -NOTICE:  f_leak => bbbbbb
 -NOTICE:  f_leak => daddad
-+ERROR:  unknown function: f_leak()
  -- returning clause with system column
  UPDATE only t1 SET b = b WHERE f_leak(b) RETURNING tableoid::regclass, *, t1;
 -NOTICE:  f_leak => bbbbbb_updt
@@ -2412,7 +2082,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 - t1       | 104 | 4 | daddad_updt | (104,4,daddad_updt)
 -(2 rows)
 -
-+ERROR:  unknown function: f_leak()
++ERROR:  column "tableoid" does not exist
  UPDATE t1 SET b = b WHERE f_leak(b) RETURNING *;
 -NOTICE:  f_leak => bbbbbb_updt
 -NOTICE:  f_leak => daddad_updt
@@ -2427,8 +2097,10 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 - 204 | 4 | defdef
 - 302 | 2 | yyyyyy
 -(5 rows)
--
-+ERROR:  unknown function: f_leak()
++ id | a | b 
++----+---+---
++(0 rows)
+ 
  UPDATE t1 SET b = b WHERE f_leak(b) RETURNING tableoid::regclass, *, t1;
 -NOTICE:  f_leak => bbbbbb_updt
 -NOTICE:  f_leak => daddad_updt
@@ -2444,7 +2116,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 - t3       | 302 | 2 | yyyyyy      | (302,2,yyyyyy)
 -(5 rows)
 -
-+ERROR:  unknown function: f_leak()
++ERROR:  column "tableoid" does not exist
  -- updates with from clause
  EXPLAIN (COSTS OFF) UPDATE t2 SET b=t2.b FROM t3
  WHERE t2.a = 3 and t3.a = 2 AND f_leak(t2.b) AND f_leak(t3.b);
@@ -2599,14 +2271,12 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 - 104 | 4 | daddad_updt | 104 | 4 | daddad_updt | (104,4,daddad_updt) | (104,4,daddad_updt)
 - 204 | 4 | defdef      | 204 | 4 | defdef      | (204,4,defdef)      | (204,4,defdef)
 -(2 rows)
--
-+ERROR:  unknown function: f_leak()
- RESET SESSION AUTHORIZATION;
-+ERROR:  at or near "authorization": syntax error
-+DETAIL:  source SQL:
-+RESET SESSION AUTHORIZATION
-+              ^
-+HINT:  try \h RESET
++ id | a | b | id | a | b | t1_1 | t1_2 
++----+---+---+----+---+---+------+------
++(0 rows)
+ 
+-RESET SESSION AUTHORIZATION;
++RESET ROLE;
  SET row_security TO OFF;
  SELECT * FROM t1 ORDER BY a,b;
 - id  | a |      b      
@@ -2627,13 +2297,8 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 +----+---+---
 +(0 rows)
  
- SET SESSION AUTHORIZATION regress_rls_bob;
-+ERROR:  at or near "regress_rls_bob": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_bob
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
+-SET SESSION AUTHORIZATION regress_rls_bob;
++SET ROLE regress_rls_bob;
  SET row_security TO ON;
  EXPLAIN (COSTS OFF) DELETE FROM only t1 WHERE f_leak(b);
 -                  QUERY PLAN                   
@@ -2678,7 +2343,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 - t1       | 104 | 4 | daddad_updt | (104,4,daddad_updt)
 -(2 rows)
 -
-+ERROR:  unknown function: f_leak()
++ERROR:  column "tableoid" does not exist
  DELETE FROM t1 WHERE f_leak(b) RETURNING tableoid::regclass, *, t1;
 -NOTICE:  f_leak => bcdbcd
 -NOTICE:  f_leak => defdef
@@ -2690,30 +2355,20 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 - t3       | 302 | 2 | yyyyyy | (302,2,yyyyyy)
 -(3 rows)
 -
-+ERROR:  unknown function: f_leak()
++ERROR:  column "tableoid" does not exist
  --
  -- S.b. view on top of Row-level security
  --
- SET SESSION AUTHORIZATION regress_rls_alice;
-+ERROR:  at or near "regress_rls_alice": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_alice
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
+-SET SESSION AUTHORIZATION regress_rls_alice;
++SET ROLE regress_rls_alice;
  CREATE TABLE b1 (a int, b text);
  INSERT INTO b1 (SELECT x, public.fipshash(x::text) FROM generate_series(-10,10) x);
 +ERROR:  unknown function: public.fipshash()
  CREATE POLICY p1 ON b1 USING (a % 2 = 0);
  ALTER TABLE b1 ENABLE ROW LEVEL SECURITY;
  GRANT ALL ON b1 TO regress_rls_bob;
- SET SESSION AUTHORIZATION regress_rls_bob;
-+ERROR:  at or near "regress_rls_bob": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_bob
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
+-SET SESSION AUTHORIZATION regress_rls_bob;
++SET ROLE regress_rls_bob;
  CREATE VIEW bv1 WITH (security_barrier) AS SELECT * FROM b1 WHERE a > 0 WITH CHECK OPTION;
 +ERROR:  at or near "with": syntax error
 +DETAIL:  source SQL:
@@ -2721,14 +2376,9 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 +                ^
 +HINT:  try \h CREATE VIEW
  GRANT ALL ON bv1 TO regress_rls_carol;
+-SET SESSION AUTHORIZATION regress_rls_carol;
 +ERROR:  cannot get the privileges on the grant targets: cannot determine the target type of the GRANT statement: relation "bv1" does not exist
- SET SESSION AUTHORIZATION regress_rls_carol;
-+ERROR:  at or near "regress_rls_carol": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_carol
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
++SET ROLE regress_rls_carol;
  EXPLAIN (COSTS OFF) SELECT * FROM bv1 WHERE f_leak(b);
 -                 QUERY PLAN                  
 ----------------------------------------------
@@ -2798,14 +2448,9 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 +HINT:  try \h <SELECTCLAUSE>
  DELETE FROM bv1 WHERE a = 6 AND f_leak(b);
 -NOTICE:  f_leak => e7f6c011776e8db7cd330b54174fd76f
+-SET SESSION AUTHORIZATION regress_rls_alice;
 +ERROR:  relation "bv1" does not exist
- SET SESSION AUTHORIZATION regress_rls_alice;
-+ERROR:  at or near "regress_rls_alice": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_alice
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
++SET ROLE regress_rls_alice;
  SELECT * FROM b1;
 -  a  |                b                 
 ------+----------------------------------
@@ -2838,13 +2483,8 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  --
  -- INSERT ... ON CONFLICT DO UPDATE and Row-level security
  --
- SET SESSION AUTHORIZATION regress_rls_alice;
-+ERROR:  at or near "regress_rls_alice": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_alice
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
+-SET SESSION AUTHORIZATION regress_rls_alice;
++SET ROLE regress_rls_alice;
  DROP POLICY p1 ON document;
 +ERROR:  policy "p1" for table "document" does not exist
  DROP POLICY p1r ON document;
@@ -2853,26 +2493,13 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  CREATE POLICY p3 ON document FOR UPDATE
    USING (cid = (SELECT cid from category WHERE cname = 'novel'))
    WITH CHECK (dauthor = current_user);
+-SET SESSION AUTHORIZATION regress_rls_bob;
 +ERROR:  column "cname" does not exist
- SET SESSION AUTHORIZATION regress_rls_bob;
-+ERROR:  at or near "regress_rls_bob": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_bob
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
++SET ROLE regress_rls_bob;
  -- Exists...
  SELECT * FROM document WHERE did = 2;
   did | cid | dlevel |     dauthor     |     dtitle      
-@@ -2001,7 +1639,6 @@
- -- alternative UPDATE path happens to be taken):
- INSERT INTO document VALUES (2, (SELECT cid from category WHERE cname = 'novel'), 1, 'regress_rls_carol', 'my first novel')
-     ON CONFLICT (did) DO UPDATE SET dtitle = EXCLUDED.dtitle, dauthor = EXCLUDED.dauthor;
--ERROR:  new row violates row-level security policy for table "document"
- -- Violates USING qual for UPDATE policy p3.
- --
- -- UPDATE path is taken, but UPDATE fails purely because *existing* row to be
-@@ -2010,14 +1647,13 @@
+@@ -2010,7 +1265,6 @@
  INSERT INTO document VALUES (33, 22, 1, 'regress_rls_bob', 'okay science fiction'); -- preparation for next statement
  INSERT INTO document VALUES (33, (SELECT cid from category WHERE cname = 'novel'), 1, 'regress_rls_bob', 'Some novel, replaces sci-fi') -- takes UPDATE path
      ON CONFLICT (did) DO UPDATE SET dtitle = EXCLUDED.dtitle;
@@ -2880,17 +2507,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  -- Fine (we UPDATE, since INSERT WCOs and UPDATE security barrier quals + WCOs
  -- not violated):
  INSERT INTO document VALUES (2, (SELECT cid from category WHERE cname = 'novel'), 1, 'regress_rls_bob', 'my first novel')
-     ON CONFLICT (did) DO UPDATE SET dtitle = EXCLUDED.dtitle RETURNING *;
-- did | cid | dlevel |     dauthor     |     dtitle     
-------+-----+--------+-----------------+----------------
--   2 |  11 |      2 | regress_rls_bob | my first novel
-+ did | cid | dlevel |      dauthor      |     dtitle     
-+-----+-----+--------+-------------------+----------------
-+   2 |  11 |      2 | regress_rls_carol | my first novel
- (1 row)
- 
- -- Fine (we INSERT, so "cid = 33" ("technology") isn't evaluated):
-@@ -2041,7 +1677,11 @@
+@@ -2041,7 +1295,11 @@
  -- passing quals:
  INSERT INTO document VALUES (78, (SELECT cid from category WHERE cname = 'novel'), 1, 'regress_rls_bob', 'some technology novel')
      ON CONFLICT (did) DO UPDATE SET dtitle = EXCLUDED.dtitle, cid = 33 RETURNING *;
@@ -2903,7 +2520,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  -- Don't fail just because INSERT doesn't satisfy WITH CHECK option that
  -- originated as a barrier/USING() qual from the UPDATE.  Note that the UPDATE
  -- path *isn't* taken, and so UPDATE-related policy does not apply:
-@@ -2058,15 +1698,33 @@
+@@ -2058,15 +1316,21 @@
  -- irrelevant, in fact.
  INSERT INTO document VALUES (79, (SELECT cid from category WHERE cname = 'technology'), 1, 'regress_rls_bob', 'technology book, can only insert')
      ON CONFLICT (did) DO UPDATE SET dtitle = EXCLUDED.dtitle RETURNING *;
@@ -2914,104 +2531,62 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 +(1 row)
 +
  -- Test default USING qual enforced as WCO
- SET SESSION AUTHORIZATION regress_rls_alice;
-+ERROR:  at or near "regress_rls_alice": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_alice
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
+-SET SESSION AUTHORIZATION regress_rls_alice;
++SET ROLE regress_rls_alice;
  DROP POLICY p1 ON document;
  DROP POLICY p2 ON document;
  DROP POLICY p3 ON document;
 +ERROR:  policy "p3" for table "document" does not exist
  CREATE POLICY p3_with_default ON document FOR UPDATE
    USING (cid = (SELECT cid from category WHERE cname = 'novel'));
+-SET SESSION AUTHORIZATION regress_rls_bob;
 +ERROR:  column "cname" does not exist
- SET SESSION AUTHORIZATION regress_rls_bob;
-+ERROR:  at or near "regress_rls_bob": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_bob
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
++SET ROLE regress_rls_bob;
  -- Just because WCO-style enforcement of USING quals occurs with
  -- existing/target tuple does not mean that the implementation can be allowed
  -- to fail to also enforce this qual against the final tuple appended to
-@@ -2080,16 +1738,31 @@
- -- UPDATE to make this fail:
- INSERT INTO document VALUES (79, (SELECT cid from category WHERE cname = 'technology'), 1, 'regress_rls_bob', 'technology book, can only insert')
-     ON CONFLICT (did) DO UPDATE SET dtitle = EXCLUDED.dtitle RETURNING *;
--ERROR:  new row violates row-level security policy for table "document"
-+ did | cid | dlevel |     dauthor     |              dtitle              
-+-----+-----+--------+-----------------+----------------------------------
-+  79 |  33 |      1 | regress_rls_bob | technology book, can only insert
-+(1 row)
-+
- -- UPDATE path is taken here.  Existing tuple passes, since its cid
- -- corresponds to "novel", but default USING qual is enforced against
- -- post-UPDATE tuple too (as always when updating with a policy that lacks an
- -- explicit WCO), and so this fails:
+@@ -2088,8 +1352,9 @@
  INSERT INTO document VALUES (2, (SELECT cid from category WHERE cname = 'technology'), 1, 'regress_rls_bob', 'my first novel')
      ON CONFLICT (did) DO UPDATE SET cid = EXCLUDED.cid, dtitle = EXCLUDED.dtitle RETURNING *;
--ERROR:  new row violates row-level security policy for table "document"
-+ did | cid | dlevel |      dauthor      |     dtitle     
-+-----+-----+--------+-------------------+----------------
-+   2 |  33 |      2 | regress_rls_carol | my first novel
-+(1 row)
-+
- SET SESSION AUTHORIZATION regress_rls_alice;
-+ERROR:  at or near "regress_rls_alice": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_alice
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
+ ERROR:  new row violates row-level security policy for table "document"
+-SET SESSION AUTHORIZATION regress_rls_alice;
++SET ROLE regress_rls_alice;
  DROP POLICY p3_with_default ON document;
 +ERROR:  policy "p3_with_default" for table "document" does not exist
  --
  -- Test ALL policies with ON CONFLICT DO UPDATE (much the same as existing UPDATE
  -- tests)
-@@ -2097,25 +1770,35 @@
+@@ -2097,7 +1362,8 @@
  CREATE POLICY p3_with_all ON document FOR ALL
    USING (cid = (SELECT cid from category WHERE cname = 'novel'))
    WITH CHECK (dauthor = current_user);
+-SET SESSION AUTHORIZATION regress_rls_bob;
 +ERROR:  column "cname" does not exist
- SET SESSION AUTHORIZATION regress_rls_bob;
-+ERROR:  at or near "regress_rls_bob": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_bob
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
++SET ROLE regress_rls_bob;
  -- Fails, since ALL WCO is enforced in insert path:
  INSERT INTO document VALUES (80, (SELECT cid from category WHERE cname = 'novel'), 1, 'regress_rls_carol', 'my first novel')
      ON CONFLICT (did) DO UPDATE SET dtitle = EXCLUDED.dtitle, cid = 33;
--ERROR:  new row violates row-level security policy for table "document"
- -- Fails, since ALL policy USING qual is enforced (existing, target tuple is in
+@@ -2106,7 +1372,7 @@
  -- violation, since it has the "manga" cid):
  INSERT INTO document VALUES (4, (SELECT cid from category WHERE cname = 'novel'), 1, 'regress_rls_bob', 'my first novel')
      ON CONFLICT (did) DO UPDATE SET dtitle = EXCLUDED.dtitle;
 -ERROR:  new row violates row-level security policy (USING expression) for table "document"
++ERROR:  new row violates row-level security policy for table "document"
  -- Fails, since ALL WCO are enforced:
  INSERT INTO document VALUES (1, (SELECT cid from category WHERE cname = 'novel'), 1, 'regress_rls_bob', 'my first novel')
      ON CONFLICT (did) DO UPDATE SET dauthor = 'regress_rls_carol';
--ERROR:  new row violates row-level security policy for table "document"
+@@ -2114,8 +1380,9 @@
  --
  -- MERGE
  --
- RESET SESSION AUTHORIZATION;
-+ERROR:  at or near "authorization": syntax error
-+DETAIL:  source SQL:
-+RESET SESSION AUTHORIZATION
-+              ^
-+HINT:  try \h RESET
+-RESET SESSION AUTHORIZATION;
++RESET ROLE;
  DROP POLICY p3_with_all ON document;
 +ERROR:  policy "p3_with_all" for table "document" does not exist
  ALTER TABLE document ADD COLUMN dnotes text DEFAULT '';
  -- all documents are readable
  CREATE POLICY p1 ON document FOR SELECT USING (true);
-@@ -2125,48 +1808,69 @@
+@@ -2125,13 +1392,16 @@
  CREATE POLICY p3 ON document FOR UPDATE
    USING (cid = (SELECT cid from category WHERE cname = 'novel'))
    WITH CHECK (dlevel > 0);
@@ -3023,37 +2598,26 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  SELECT * FROM document;
   did | cid | dlevel |      dauthor      |              dtitle              | dnotes 
  -----+-----+--------+-------------------+----------------------------------+--------
--   1 |  11 |      1 | regress_rls_bob   | my first novel                   | 
-+   1 |  11 |      1 | regress_rls_carol | my first novel                   | 
-+   2 |  33 |      2 | regress_rls_carol | my first novel                   | 
+    1 |  11 |      1 | regress_rls_bob   | my first novel                   | 
++   2 |  11 |      2 | regress_rls_bob   | my first novel                   | 
     3 |  22 |      2 | regress_rls_bob   | my science fiction               | 
--   4 |  44 |      1 | regress_rls_bob   | my first manga                   | 
-+   4 |  44 |      1 | regress_rls_bob   | my first novel                   | 
+    4 |  44 |      1 | regress_rls_bob   | my first manga                   | 
     5 |  44 |      2 | regress_rls_bob   | my second manga                  | 
-    6 |  22 |      1 | regress_rls_carol | great science fiction            | 
-    7 |  33 |      2 | regress_rls_carol | great technology book            | 
+@@ -2140,33 +1410,42 @@
     8 |  44 |      1 | regress_rls_carol | great manga                      | 
     9 |  22 |      1 | regress_rls_dave  | awesome science fiction          | 
    10 |  33 |      2 | regress_rls_dave  | awesome technology book          | 
 -  11 |  33 |      1 | regress_rls_carol | hoge                             | 
 -  33 |  22 |      1 | regress_rls_bob   | okay science fiction             | 
 -   2 |  11 |      2 | regress_rls_bob   | my first novel                   | 
-+  11 |  33 |      1 | test_admin        | hoge                             | 
 +  33 |  22 |      1 | regress_rls_bob   | Some novel, replaces sci-fi      | 
    78 |  33 |      1 | regress_rls_bob   | some technology novel            | 
    79 |  33 |      1 | regress_rls_bob   | technology book, can only insert | 
 -(14 rows)
-+  80 |  11 |      1 | regress_rls_carol | my first novel                   | 
-+ 100 |  44 |      1 | regress_rls_dave  | testing sorting of policies      | 
-+(16 rows)
++(13 rows)
  
- SET SESSION AUTHORIZATION regress_rls_bob;
-+ERROR:  at or near "regress_rls_bob": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_bob
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
+-SET SESSION AUTHORIZATION regress_rls_bob;
++SET ROLE regress_rls_bob;
  -- Fails, since update violates WITH CHECK qual on dlevel
  MERGE INTO document d
  USING (SELECT 1 as sdid) s
@@ -3088,7 +2652,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  -- There is a MATCH for did = 3, but UPDATE's USING qual does not allow
  -- updating an item in category 'science fiction'
  MERGE INTO document d
-@@ -2174,7 +1878,10 @@
+@@ -2174,7 +1453,10 @@
  ON did = s.sdid
  WHEN MATCHED THEN
  	UPDATE SET dnotes = dnotes || ' notes added by merge ';
@@ -3100,7 +2664,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  -- The same thing with DELETE action, but fails again because no permissions
  -- to delete items in 'science fiction' category that did 3 belongs to.
  MERGE INTO document d
-@@ -2182,7 +1889,10 @@
+@@ -2182,7 +1464,10 @@
  ON did = s.sdid
  WHEN MATCHED THEN
  	DELETE;
@@ -3112,7 +2676,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  -- Document with did 4 belongs to 'manga' category which is allowed for
  -- deletion. But this fails because the UPDATE action is matched first and
  -- UPDATE policy does not allow updation in the category.
-@@ -2193,7 +1903,10 @@
+@@ -2193,7 +1478,10 @@
  	UPDATE SET dnotes = dnotes || ' notes added by merge '
  WHEN MATCHED THEN
  	DELETE;
@@ -3124,7 +2688,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  -- UPDATE action is not matched this time because of the WHEN qual.
  -- DELETE still fails because role regress_rls_bob does not have SELECT
  -- privileges on 'manga' category row in the category table.
-@@ -2204,7 +1917,10 @@
+@@ -2204,7 +1492,10 @@
  	UPDATE SET dnotes = dnotes || ' notes added by merge '
  WHEN MATCHED THEN
  	DELETE;
@@ -3136,7 +2700,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  -- OK if DELETE is replaced with DO NOTHING
  MERGE INTO document d
  USING (SELECT 4 as sdid) s
-@@ -2213,16 +1929,31 @@
+@@ -2213,6 +1504,10 @@
  	UPDATE SET dnotes = dnotes || ' notes added by merge '
  WHEN MATCHED THEN
  	DO NOTHING;
@@ -3147,30 +2711,18 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  SELECT * FROM document WHERE did = 4;
   did | cid | dlevel |     dauthor     |     dtitle     | dnotes 
  -----+-----+--------+-----------------+----------------+--------
--   4 |  44 |      1 | regress_rls_bob | my first manga | 
-+   4 |  44 |      1 | regress_rls_bob | my first novel | 
- (1 row)
+@@ -2221,8 +1516,8 @@
  
  -- Switch to regress_rls_carol role and try the DELETE again. It should succeed
  -- this time
- RESET SESSION AUTHORIZATION;
+-RESET SESSION AUTHORIZATION;
 -SET SESSION AUTHORIZATION regress_rls_carol;
-+ERROR:  at or near "authorization": syntax error
-+DETAIL:  source SQL:
-+RESET SESSION AUTHORIZATION
-+              ^
-+HINT:  try \h RESET
-+SET SESSION AUTHORIZATION regress_rls_carol;
-+ERROR:  at or near "regress_rls_carol": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_carol
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
++RESET ROLE;
++SET ROLE regress_rls_carol;
  MERGE INTO document d
  USING (SELECT 4 as sdid) s
  ON did = s.sdid
-@@ -2230,9 +1961,24 @@
+@@ -2230,9 +1525,13 @@
  	UPDATE SET dnotes = dnotes || ' notes added by merge '
  WHEN MATCHED THEN
  	DELETE;
@@ -3179,24 +2731,14 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 +MERGE INTO document d
 +^
  -- Switch back to regress_rls_bob role
- RESET SESSION AUTHORIZATION;
+-RESET SESSION AUTHORIZATION;
 -SET SESSION AUTHORIZATION regress_rls_bob;
-+ERROR:  at or near "authorization": syntax error
-+DETAIL:  source SQL:
-+RESET SESSION AUTHORIZATION
-+              ^
-+HINT:  try \h RESET
-+SET SESSION AUTHORIZATION regress_rls_bob;
-+ERROR:  at or near "regress_rls_bob": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_bob
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
++RESET ROLE;
++SET ROLE regress_rls_bob;
  -- Try INSERT action. This fails because we are trying to insert
  -- dauthor = regress_rls_dave and INSERT's WITH CHECK does not allow
  -- that
-@@ -2243,7 +1989,10 @@
+@@ -2243,7 +1542,10 @@
  	DELETE
  WHEN NOT MATCHED THEN
  	INSERT VALUES (12, 11, 1, 'regress_rls_dave', 'another novel');
@@ -3208,7 +2750,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  -- This should be fine
  MERGE INTO document d
  USING (SELECT 12 as sdid) s
-@@ -2252,6 +2001,10 @@
+@@ -2252,6 +1554,10 @@
  	DELETE
  WHEN NOT MATCHED THEN
  	INSERT VALUES (12, 11, 1, 'regress_rls_bob', 'another novel');
@@ -3219,7 +2761,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  -- ok
  MERGE INTO document d
  USING (SELECT 1 as sdid) s
-@@ -2260,13 +2013,29 @@
+@@ -2260,13 +1566,18 @@
  	UPDATE SET dnotes = dnotes || ' notes added by merge4 '
  WHEN NOT MATCHED THEN
  	INSERT VALUES (12, 11, 1, 'regress_rls_bob', 'another novel');
@@ -3229,27 +2771,18 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 +^
  -- drop and create a new SELECT policy which prevents us from reading
  -- any document except with category 'novel'
- RESET SESSION AUTHORIZATION;
-+ERROR:  at or near "authorization": syntax error
-+DETAIL:  source SQL:
-+RESET SESSION AUTHORIZATION
-+              ^
-+HINT:  try \h RESET
+-RESET SESSION AUTHORIZATION;
++RESET ROLE;
  DROP POLICY p1 ON document;
  CREATE POLICY p1 ON document FOR SELECT
    USING (cid = (SELECT cid from category WHERE cname = 'novel'));
+-SET SESSION AUTHORIZATION regress_rls_bob;
 +ERROR:  column "cname" does not exist
- SET SESSION AUTHORIZATION regress_rls_bob;
-+ERROR:  at or near "regress_rls_bob": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_bob
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
++SET ROLE regress_rls_bob;
  -- MERGE can no longer see the matching row and hence attempts the
  -- NOT MATCHED action, which results in unique key violation
  MERGE INTO document d
-@@ -2276,7 +2045,10 @@
+@@ -2276,7 +1587,10 @@
  	UPDATE SET dnotes = dnotes || ' notes added by merge5 '
  WHEN NOT MATCHED THEN
  	INSERT VALUES (12, 11, 1, 'regress_rls_bob', 'another novel');
@@ -3261,7 +2794,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  -- UPDATE action fails if new row is not visible
  MERGE INTO document d
  USING (SELECT 1 as sdid) s
-@@ -2284,7 +2056,10 @@
+@@ -2284,7 +1598,10 @@
  WHEN MATCHED THEN
  	UPDATE SET dnotes = dnotes || ' notes added by merge6 ',
  			   cid = (SELECT cid from category WHERE cname = 'technology');
@@ -3273,7 +2806,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  -- but OK if new row is visible
  MERGE INTO document d
  USING (SELECT 1 as sdid) s
-@@ -2292,6 +2067,10 @@
+@@ -2292,6 +1609,10 @@
  WHEN MATCHED THEN
  	UPDATE SET dnotes = dnotes || ' notes added by merge7 ',
  			   cid = (SELECT cid from category WHERE cname = 'novel');
@@ -3284,20 +2817,16 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  -- OK to insert a new row that is not visible
  MERGE INTO document d
  USING (SELECT 13 as sdid) s
-@@ -2300,35 +2079,52 @@
+@@ -2300,35 +1621,38 @@
  	UPDATE SET dnotes = dnotes || ' notes added by merge8 '
  WHEN NOT MATCHED THEN
  	INSERT VALUES (13, 44, 1, 'regress_rls_bob', 'new manga');
+-RESET SESSION AUTHORIZATION;
 +ERROR:  at or near "merge": syntax error
 +DETAIL:  source SQL:
 +MERGE INTO document d
 +^
- RESET SESSION AUTHORIZATION;
-+ERROR:  at or near "authorization": syntax error
-+DETAIL:  source SQL:
-+RESET SESSION AUTHORIZATION
-+              ^
-+HINT:  try \h RESET
++RESET ROLE;
  -- drop the restrictive SELECT policy so that we can look at the
  -- final state of the table
  DROP POLICY p1 ON document;
@@ -3308,10 +2837,10 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 ------+-----+--------+-------------------+----------------------------------+----------------------------------------------------------------------------------------------
 + did | cid | dlevel |      dauthor      |              dtitle              | dnotes 
 +-----+-----+--------+-------------------+----------------------------------+--------
-+   1 |  11 |      1 | regress_rls_carol | my first novel                   | 
-+   2 |  33 |      2 | regress_rls_carol | my first novel                   | 
++   1 |  11 |      1 | regress_rls_bob   | my first novel                   | 
++   2 |  11 |      2 | regress_rls_bob   | my first novel                   | 
     3 |  22 |      2 | regress_rls_bob   | my science fiction               | 
-+   4 |  44 |      1 | regress_rls_bob   | my first novel                   | 
++   4 |  44 |      1 | regress_rls_bob   | my first manga                   | 
     5 |  44 |      2 | regress_rls_bob   | my second manga                  | 
     6 |  22 |      1 | regress_rls_carol | great science fiction            | 
     7 |  33 |      2 | regress_rls_carol | great technology book            | 
@@ -3321,7 +2850,6 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 -  11 |  33 |      1 | regress_rls_carol | hoge                             | 
 -  33 |  22 |      1 | regress_rls_bob   | okay science fiction             | 
 -   2 |  11 |      2 | regress_rls_bob   | my first novel                   | 
-+  11 |  33 |      1 | test_admin        | hoge                             | 
 +  33 |  22 |      1 | regress_rls_bob   | Some novel, replaces sci-fi      | 
    78 |  33 |      1 | regress_rls_bob   | some technology novel            | 
    79 |  33 |      1 | regress_rls_bob   | technology book, can only insert | 
@@ -3329,33 +2857,22 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 -   1 |  11 |      1 | regress_rls_bob   | my first novel                   |  notes added by merge2  notes added by merge3  notes added by merge4  notes added by merge7 
 -  13 |  44 |      1 | regress_rls_bob   | new manga                        | 
 -(15 rows)
-+  80 |  11 |      1 | regress_rls_carol | my first novel                   | 
-+ 100 |  44 |      1 | regress_rls_dave  | testing sorting of policies      | 
-+(16 rows)
++(13 rows)
  
  --
  -- ROLE/GROUP
  --
- SET SESSION AUTHORIZATION regress_rls_alice;
-+ERROR:  at or near "regress_rls_alice": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_alice
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
+-SET SESSION AUTHORIZATION regress_rls_alice;
++SET ROLE regress_rls_alice;
  CREATE TABLE z1 (a int, b text);
  CREATE TABLE z2 (a int, b text);
  GRANT SELECT ON z1,z2 TO regress_rls_group1, regress_rls_group2,
-@@ -2342,579 +2138,636 @@
+@@ -2341,57 +1665,39 @@
+ CREATE POLICY p1 ON z1 TO regress_rls_group1 USING (a % 2 = 0);
  CREATE POLICY p2 ON z1 TO regress_rls_group2 USING (a % 2 = 1);
  ALTER TABLE z1 ENABLE ROW LEVEL SECURITY;
- SET SESSION AUTHORIZATION regress_rls_bob;
-+ERROR:  at or near "regress_rls_bob": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_bob
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
+-SET SESSION AUTHORIZATION regress_rls_bob;
++SET ROLE regress_rls_bob;
  SELECT * FROM z1 WHERE f_leak(b);
 -NOTICE:  f_leak => bbb
 -NOTICE:  f_leak => dad
@@ -3364,8 +2881,10 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 - 2 | bbb
 - 4 | dad
 -(2 rows)
--
-+ERROR:  unknown function: f_leak()
++ a | b 
++---+---
++(0 rows)
+ 
  EXPLAIN (COSTS OFF) SELECT * FROM z1 WHERE f_leak(b);
 -               QUERY PLAN                
 ------------------------------------------
@@ -3379,7 +2898,6 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 +               ^
 +HINT:  try \h <SELECTCLAUSE>
  PREPARE plancache_test AS SELECT * FROM z1 WHERE f_leak(b);
-+ERROR:  unknown function: f_leak()
  EXPLAIN (COSTS OFF) EXECUTE plancache_test;
 -               QUERY PLAN                
 ------------------------------------------
@@ -3393,7 +2911,6 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 +               ^
 +HINT:  try \h <SELECTCLAUSE>
  PREPARE plancache_test2 AS WITH q AS MATERIALIZED (SELECT * FROM z1 WHERE f_leak(b)) SELECT * FROM q,z2;
-+ERROR:  unknown function: f_leak()
  EXPLAIN (COSTS OFF) EXECUTE plancache_test2;
 -                   QUERY PLAN                    
 --------------------------------------------------
@@ -3412,7 +2929,6 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 +               ^
 +HINT:  try \h <SELECTCLAUSE>
  PREPARE plancache_test3 AS WITH q AS MATERIALIZED (SELECT * FROM z2) SELECT * FROM q,z1 WHERE f_leak(z1.b);
-+ERROR:  unknown function: f_leak()
  EXPLAIN (COSTS OFF) EXECUTE plancache_test3;
 -                     QUERY PLAN                      
 ------------------------------------------------------
@@ -3432,15 +2948,10 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 +HINT:  try \h <SELECTCLAUSE>
  SET ROLE regress_rls_group1;
  SELECT * FROM z1 WHERE f_leak(b);
--NOTICE:  f_leak => bbb
--NOTICE:  f_leak => dad
-- a |  b  
-----+-----
-- 2 | bbb
-- 4 | dad
--(2 rows)
--
-+ERROR:  unknown function: f_leak()
+ NOTICE:  f_leak => bbb
+@@ -2403,91 +1709,59 @@
+ (2 rows)
+ 
  EXPLAIN (COSTS OFF) SELECT * FROM z1 WHERE f_leak(b);
 -               QUERY PLAN                
 ------------------------------------------
@@ -3500,13 +3011,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 +EXPLAIN (COSTS OFF) EXECUTE plancache_test3
 +               ^
 +HINT:  try \h <SELECTCLAUSE>
-+SET SESSION AUTHORIZATION regress_rls_carol;
-+ERROR:  at or near "regress_rls_carol": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_carol
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
++SET ROLE regress_rls_carol;
  SELECT * FROM z1 WHERE f_leak(b);
 -NOTICE:  f_leak => aba
 -NOTICE:  f_leak => ccc
@@ -3515,8 +3020,10 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 - 1 | aba
 - 3 | ccc
 -(2 rows)
--
-+ERROR:  unknown function: f_leak()
++ a | b 
++---+---
++(0 rows)
+ 
  EXPLAIN (COSTS OFF) SELECT * FROM z1 WHERE f_leak(b);
 -               QUERY PLAN                
 ------------------------------------------
@@ -3577,15 +3084,10 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 +HINT:  try \h <SELECTCLAUSE>
  SET ROLE regress_rls_group2;
  SELECT * FROM z1 WHERE f_leak(b);
--NOTICE:  f_leak => aba
--NOTICE:  f_leak => ccc
-- a |  b  
-----+-----
-- 1 | aba
-- 3 | ccc
--(2 rows)
--
-+ERROR:  unknown function: f_leak()
+ NOTICE:  f_leak => aba
+@@ -2499,422 +1773,324 @@
+ (2 rows)
+ 
  EXPLAIN (COSTS OFF) SELECT * FROM z1 WHERE f_leak(b);
 -               QUERY PLAN                
 ------------------------------------------
@@ -3648,26 +3150,16 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  -- Views should follow policy for view owner.
  --
  -- View and Table owner are the same.
- SET SESSION AUTHORIZATION regress_rls_alice;
-+ERROR:  at or near "regress_rls_alice": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_alice
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
+-SET SESSION AUTHORIZATION regress_rls_alice;
++SET ROLE regress_rls_alice;
  CREATE VIEW rls_view AS SELECT * FROM z1 WHERE f_leak(b);
 +ERROR:  unknown function: f_leak()
 +HINT:  There is probably a typo in function name. Or the intention was to use a user-defined function in the view query, which is currently not supported.
  GRANT SELECT ON rls_view TO regress_rls_bob;
 +ERROR:  cannot get the privileges on the grant targets: cannot determine the target type of the GRANT statement: relation "rls_view" does not exist
  -- Query as role that is not owner of view or table.  Should return all records.
- SET SESSION AUTHORIZATION regress_rls_bob;
-+ERROR:  at or near "regress_rls_bob": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_bob
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
+-SET SESSION AUTHORIZATION regress_rls_bob;
++SET ROLE regress_rls_bob;
  SELECT * FROM rls_view;
 -NOTICE:  f_leak => aba
 -NOTICE:  f_leak => bbb
@@ -3695,13 +3187,8 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 +               ^
 +HINT:  try \h <SELECTCLAUSE>
  -- Query as view/table owner.  Should return all records.
- SET SESSION AUTHORIZATION regress_rls_alice;
-+ERROR:  at or near "regress_rls_alice": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_alice
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
+-SET SESSION AUTHORIZATION regress_rls_alice;
++SET ROLE regress_rls_alice;
  SELECT * FROM rls_view;
 -NOTICE:  f_leak => aba
 -NOTICE:  f_leak => bbb
@@ -3731,13 +3218,8 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  DROP VIEW rls_view;
 +ERROR:  relation "rls_view" does not exist
  -- View and Table owners are different.
- SET SESSION AUTHORIZATION regress_rls_bob;
-+ERROR:  at or near "regress_rls_bob": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_bob
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
+-SET SESSION AUTHORIZATION regress_rls_bob;
++SET ROLE regress_rls_bob;
  CREATE VIEW rls_view AS SELECT * FROM z1 WHERE f_leak(b);
 +ERROR:  unknown function: f_leak()
 +HINT:  There is probably a typo in function name. Or the intention was to use a user-defined function in the view query, which is currently not supported.
@@ -3745,13 +3227,8 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 +ERROR:  cannot get the privileges on the grant targets: cannot determine the target type of the GRANT statement: relation "rls_view" does not exist
  -- Query as role that is not owner of view but is owner of table.
  -- Should return records based on view owner policies.
- SET SESSION AUTHORIZATION regress_rls_alice;
-+ERROR:  at or near "regress_rls_alice": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_alice
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
+-SET SESSION AUTHORIZATION regress_rls_alice;
++SET ROLE regress_rls_alice;
  SELECT * FROM rls_view;
 -NOTICE:  f_leak => bbb
 -NOTICE:  f_leak => dad
@@ -3776,13 +3253,8 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 +HINT:  try \h <SELECTCLAUSE>
  -- Query as role that is not owner of table but is owner of view.
  -- Should return records based on view owner policies.
- SET SESSION AUTHORIZATION regress_rls_bob;
-+ERROR:  at or near "regress_rls_bob": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_bob
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
+-SET SESSION AUTHORIZATION regress_rls_bob;
++SET ROLE regress_rls_bob;
  SELECT * FROM rls_view;
 -NOTICE:  f_leak => bbb
 -NOTICE:  f_leak => dad
@@ -3806,13 +3278,8 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 +               ^
 +HINT:  try \h <SELECTCLAUSE>
  -- Query as role that is not the owner of the table or view without permissions.
- SET SESSION AUTHORIZATION regress_rls_carol;
-+ERROR:  at or near "regress_rls_carol": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_carol
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
+-SET SESSION AUTHORIZATION regress_rls_carol;
++SET ROLE regress_rls_carol;
  SELECT * FROM rls_view; --fail - permission denied.
 -ERROR:  permission denied for view rls_view
 +ERROR:  relation "rls_view" does not exist
@@ -3824,22 +3291,12 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 +               ^
 +HINT:  try \h <SELECTCLAUSE>
  -- Query as role that is not the owner of the table or view with permissions.
- SET SESSION AUTHORIZATION regress_rls_bob;
-+ERROR:  at or near "regress_rls_bob": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_bob
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
+-SET SESSION AUTHORIZATION regress_rls_bob;
++SET ROLE regress_rls_bob;
  GRANT SELECT ON rls_view TO regress_rls_carol;
+-SET SESSION AUTHORIZATION regress_rls_carol;
 +ERROR:  cannot get the privileges on the grant targets: cannot determine the target type of the GRANT statement: relation "rls_view" does not exist
- SET SESSION AUTHORIZATION regress_rls_carol;
-+ERROR:  at or near "regress_rls_carol": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_carol
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
++SET ROLE regress_rls_carol;
  SELECT * FROM rls_view;
 -NOTICE:  f_leak => bbb
 -NOTICE:  f_leak => dad
@@ -3863,25 +3320,15 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 +               ^
 +HINT:  try \h <SELECTCLAUSE>
  -- Policy requiring access to another table.
- SET SESSION AUTHORIZATION regress_rls_alice;
-+ERROR:  at or near "regress_rls_alice": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_alice
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
+-SET SESSION AUTHORIZATION regress_rls_alice;
++SET ROLE regress_rls_alice;
  CREATE TABLE z1_blacklist (a int);
  INSERT INTO z1_blacklist VALUES (3), (4);
  CREATE POLICY p3 ON z1 AS RESTRICTIVE USING (a NOT IN (SELECT a FROM z1_blacklist));
-+ERROR:  must be owner of relation z1
++ERROR:  variable sub-expressions are not allowed in POLICY USING
  -- Query as role that is not owner of table but is owner of view without permissions.
- SET SESSION AUTHORIZATION regress_rls_bob;
-+ERROR:  at or near "regress_rls_bob": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_bob
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
+-SET SESSION AUTHORIZATION regress_rls_bob;
++SET ROLE regress_rls_bob;
  SELECT * FROM rls_view; --fail - permission denied.
 -ERROR:  permission denied for table z1_blacklist
 +ERROR:  relation "rls_view" does not exist
@@ -3893,13 +3340,8 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 +               ^
 +HINT:  try \h <SELECTCLAUSE>
  -- Query as role that is not the owner of the table or view without permissions.
- SET SESSION AUTHORIZATION regress_rls_carol;
-+ERROR:  at or near "regress_rls_carol": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_carol
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
+-SET SESSION AUTHORIZATION regress_rls_carol;
++SET ROLE regress_rls_carol;
  SELECT * FROM rls_view; --fail - permission denied.
 -ERROR:  permission denied for table z1_blacklist
 +ERROR:  relation "rls_view" does not exist
@@ -3911,21 +3353,11 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 +               ^
 +HINT:  try \h <SELECTCLAUSE>
  -- Query as role that is not owner of table but is owner of view with permissions.
- SET SESSION AUTHORIZATION regress_rls_alice;
-+ERROR:  at or near "regress_rls_alice": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_alice
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
+-SET SESSION AUTHORIZATION regress_rls_alice;
++SET ROLE regress_rls_alice;
  GRANT SELECT ON z1_blacklist TO regress_rls_bob;
- SET SESSION AUTHORIZATION regress_rls_bob;
-+ERROR:  at or near "regress_rls_bob": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_bob
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
+-SET SESSION AUTHORIZATION regress_rls_bob;
++SET ROLE regress_rls_bob;
  SELECT * FROM rls_view;
 -NOTICE:  f_leak => bbb
 - a |  b  
@@ -3949,13 +3381,8 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 +               ^
 +HINT:  try \h <SELECTCLAUSE>
  -- Query as role that is not the owner of the table or view with permissions.
- SET SESSION AUTHORIZATION regress_rls_carol;
-+ERROR:  at or near "regress_rls_carol": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_carol
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
+-SET SESSION AUTHORIZATION regress_rls_carol;
++SET ROLE regress_rls_carol;
  SELECT * FROM rls_view;
 -NOTICE:  f_leak => bbb
 - a |  b  
@@ -3979,36 +3406,20 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 +EXPLAIN (COSTS OFF) SELECT * FROM rls_view
 +               ^
 +HINT:  try \h <SELECTCLAUSE>
-+SET SESSION AUTHORIZATION regress_rls_alice;
-+ERROR:  at or near "regress_rls_alice": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_alice
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
++SET ROLE regress_rls_alice;
  REVOKE SELECT ON z1_blacklist FROM regress_rls_bob;
  DROP POLICY p3 ON z1;
-+ERROR:  must be owner of relation z1
- SET SESSION AUTHORIZATION regress_rls_bob;
-+ERROR:  at or near "regress_rls_bob": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_bob
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
+-SET SESSION AUTHORIZATION regress_rls_bob;
++ERROR:  policy "p3" for table "z1" does not exist
++SET ROLE regress_rls_bob;
  DROP VIEW rls_view;
 +ERROR:  relation "rls_view" does not exist
  --
  -- Security invoker views should follow policy for current user.
  --
  -- View and table owner are the same.
- SET SESSION AUTHORIZATION regress_rls_alice;
-+ERROR:  at or near "regress_rls_alice": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_alice
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
+-SET SESSION AUTHORIZATION regress_rls_alice;
++SET ROLE regress_rls_alice;
  CREATE VIEW rls_view WITH (security_invoker) AS
      SELECT * FROM z1 WHERE f_leak(b);
 +ERROR:  at or near "with": syntax error
@@ -4049,13 +3460,8 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 +HINT:  try \h <SELECTCLAUSE>
  -- Queries as other users.
  -- Should return records based on current user's policies.
- SET SESSION AUTHORIZATION regress_rls_bob;
-+ERROR:  at or near "regress_rls_bob": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_bob
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
+-SET SESSION AUTHORIZATION regress_rls_bob;
++SET ROLE regress_rls_bob;
  SELECT * FROM rls_view;
 -NOTICE:  f_leak => bbb
 -NOTICE:  f_leak => dad
@@ -4079,13 +3485,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 +EXPLAIN (COSTS OFF) SELECT * FROM rls_view
 +               ^
 +HINT:  try \h <SELECTCLAUSE>
-+SET SESSION AUTHORIZATION regress_rls_carol;
-+ERROR:  at or near "regress_rls_carol": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_carol
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
++SET ROLE regress_rls_carol;
  SELECT * FROM rls_view;
 -NOTICE:  f_leak => aba
 -NOTICE:  f_leak => ccc
@@ -4109,22 +3509,12 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 +               ^
 +HINT:  try \h <SELECTCLAUSE>
  -- View and table owners are different.
- SET SESSION AUTHORIZATION regress_rls_alice;
-+ERROR:  at or near "regress_rls_alice": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_alice
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
+-SET SESSION AUTHORIZATION regress_rls_alice;
++SET ROLE regress_rls_alice;
  DROP VIEW rls_view;
+-SET SESSION AUTHORIZATION regress_rls_bob;
 +ERROR:  relation "rls_view" does not exist
- SET SESSION AUTHORIZATION regress_rls_bob;
-+ERROR:  at or near "regress_rls_bob": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_bob
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
++SET ROLE regress_rls_bob;
  CREATE VIEW rls_view WITH (security_invoker) AS
      SELECT * FROM z1 WHERE f_leak(b);
 +ERROR:  at or near "with": syntax error
@@ -4137,13 +3527,8 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  GRANT SELECT ON rls_view TO regress_rls_carol;
 +ERROR:  cannot get the privileges on the grant targets: cannot determine the target type of the GRANT statement: relation "rls_view" does not exist
  -- Query as table owner.  Should return all records.
- SET SESSION AUTHORIZATION regress_rls_alice;
-+ERROR:  at or near "regress_rls_alice": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_alice
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
+-SET SESSION AUTHORIZATION regress_rls_alice;
++SET ROLE regress_rls_alice;
  SELECT * FROM rls_view;
 -NOTICE:  f_leak => aba
 -NOTICE:  f_leak => bbb
@@ -4172,13 +3557,8 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 +HINT:  try \h <SELECTCLAUSE>
  -- Queries as other users.
  -- Should return records based on current user's policies.
- SET SESSION AUTHORIZATION regress_rls_bob;
-+ERROR:  at or near "regress_rls_bob": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_bob
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
+-SET SESSION AUTHORIZATION regress_rls_bob;
++SET ROLE regress_rls_bob;
  SELECT * FROM rls_view;
 -NOTICE:  f_leak => bbb
 -NOTICE:  f_leak => dad
@@ -4202,13 +3582,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 +EXPLAIN (COSTS OFF) SELECT * FROM rls_view
 +               ^
 +HINT:  try \h <SELECTCLAUSE>
-+SET SESSION AUTHORIZATION regress_rls_carol;
-+ERROR:  at or near "regress_rls_carol": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_carol
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
++SET ROLE regress_rls_carol;
  SELECT * FROM rls_view;
 -NOTICE:  f_leak => aba
 -NOTICE:  f_leak => ccc
@@ -4232,23 +3606,13 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 +               ^
 +HINT:  try \h <SELECTCLAUSE>
  -- Policy requiring access to another table.
- SET SESSION AUTHORIZATION regress_rls_alice;
-+ERROR:  at or near "regress_rls_alice": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_alice
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
+-SET SESSION AUTHORIZATION regress_rls_alice;
++SET ROLE regress_rls_alice;
  CREATE POLICY p3 ON z1 AS RESTRICTIVE USING (a NOT IN (SELECT a FROM z1_blacklist));
-+ERROR:  must be owner of relation z1
++ERROR:  variable sub-expressions are not allowed in POLICY USING
  -- Query as role that is not owner of table but is owner of view without permissions.
- SET SESSION AUTHORIZATION regress_rls_bob;
-+ERROR:  at or near "regress_rls_bob": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_bob
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
+-SET SESSION AUTHORIZATION regress_rls_bob;
++SET ROLE regress_rls_bob;
  SELECT * FROM rls_view; --fail - permission denied.
 -ERROR:  permission denied for table z1_blacklist
 +ERROR:  relation "rls_view" does not exist
@@ -4260,13 +3624,8 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 +               ^
 +HINT:  try \h <SELECTCLAUSE>
  -- Query as role that is not the owner of the table or view without permissions.
- SET SESSION AUTHORIZATION regress_rls_carol;
-+ERROR:  at or near "regress_rls_carol": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_carol
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
+-SET SESSION AUTHORIZATION regress_rls_carol;
++SET ROLE regress_rls_carol;
  SELECT * FROM rls_view; --fail - permission denied.
 -ERROR:  permission denied for table z1_blacklist
 +ERROR:  relation "rls_view" does not exist
@@ -4278,21 +3637,11 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 +               ^
 +HINT:  try \h <SELECTCLAUSE>
  -- Query as role that is not owner of table but is owner of view with permissions.
- SET SESSION AUTHORIZATION regress_rls_alice;
-+ERROR:  at or near "regress_rls_alice": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_alice
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
+-SET SESSION AUTHORIZATION regress_rls_alice;
++SET ROLE regress_rls_alice;
  GRANT SELECT ON z1_blacklist TO regress_rls_bob;
- SET SESSION AUTHORIZATION regress_rls_bob;
-+ERROR:  at or near "regress_rls_bob": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_bob
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
+-SET SESSION AUTHORIZATION regress_rls_bob;
++SET ROLE regress_rls_bob;
  SELECT * FROM rls_view;
 -NOTICE:  f_leak => bbb
 - a |  b  
@@ -4316,13 +3665,8 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 +               ^
 +HINT:  try \h <SELECTCLAUSE>
  -- Query as role that is not the owner of the table or view without permissions.
- SET SESSION AUTHORIZATION regress_rls_carol;
-+ERROR:  at or near "regress_rls_carol": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_carol
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
+-SET SESSION AUTHORIZATION regress_rls_carol;
++SET ROLE regress_rls_carol;
  SELECT * FROM rls_view; --fail - permission denied.
 -ERROR:  permission denied for table z1_blacklist
 +ERROR:  relation "rls_view" does not exist
@@ -4334,21 +3678,11 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 +               ^
 +HINT:  try \h <SELECTCLAUSE>
  -- Query as role that is not the owner of the table or view with permissions.
- SET SESSION AUTHORIZATION regress_rls_alice;
-+ERROR:  at or near "regress_rls_alice": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_alice
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
+-SET SESSION AUTHORIZATION regress_rls_alice;
++SET ROLE regress_rls_alice;
  GRANT SELECT ON z1_blacklist TO regress_rls_carol;
- SET SESSION AUTHORIZATION regress_rls_carol;
-+ERROR:  at or near "regress_rls_carol": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_carol
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
+-SET SESSION AUTHORIZATION regress_rls_carol;
++SET ROLE regress_rls_carol;
  SELECT * FROM rls_view;
 -NOTICE:  f_leak => aba
 - a |  b  
@@ -4372,145 +3706,93 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 +EXPLAIN (COSTS OFF) SELECT * FROM rls_view
 +               ^
 +HINT:  try \h <SELECTCLAUSE>
-+SET SESSION AUTHORIZATION regress_rls_bob;
-+ERROR:  at or near "regress_rls_bob": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_bob
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
++SET ROLE regress_rls_bob;
  DROP VIEW rls_view;
 +ERROR:  relation "rls_view" does not exist
  --
  -- Command specific
  --
- SET SESSION AUTHORIZATION regress_rls_alice;
-+ERROR:  at or near "regress_rls_alice": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_alice
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
+-SET SESSION AUTHORIZATION regress_rls_alice;
++SET ROLE regress_rls_alice;
  CREATE TABLE x1 (a int, b text, c text);
  GRANT ALL ON x1 TO PUBLIC;
  INSERT INTO x1 VALUES
-@@ -2933,103 +2786,46 @@
+@@ -2932,7 +2108,7 @@
+ CREATE POLICY p3 ON x1 FOR UPDATE USING (a % 2 = 0);
  CREATE POLICY p4 ON x1 FOR DELETE USING (a < 8);
  ALTER TABLE x1 ENABLE ROW LEVEL SECURITY;
- SET SESSION AUTHORIZATION regress_rls_bob;
-+ERROR:  at or near "regress_rls_bob": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_bob
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
+-SET SESSION AUTHORIZATION regress_rls_bob;
++SET ROLE regress_rls_bob;
  SELECT * FROM x1 WHERE f_leak(b) ORDER BY a ASC;
--NOTICE:  f_leak => abc
--NOTICE:  f_leak => bcd
--NOTICE:  f_leak => def
--NOTICE:  f_leak => efg
--NOTICE:  f_leak => fgh
--NOTICE:  f_leak => fgh
-- a |  b  |         c         
-----+-----+-------------------
-- 1 | abc | regress_rls_bob
-- 2 | bcd | regress_rls_bob
-- 4 | def | regress_rls_carol
-- 5 | efg | regress_rls_bob
-- 6 | fgh | regress_rls_bob
-- 8 | fgh | regress_rls_carol
--(6 rows)
--
-+ERROR:  unknown function: f_leak()
- UPDATE x1 SET b = b || '_updt' WHERE f_leak(b) RETURNING *;
--NOTICE:  f_leak => abc
--NOTICE:  f_leak => bcd
--NOTICE:  f_leak => def
--NOTICE:  f_leak => efg
--NOTICE:  f_leak => fgh
--NOTICE:  f_leak => fgh
-- a |    b     |         c         
-----+----------+-------------------
-- 1 | abc_updt | regress_rls_bob
-- 2 | bcd_updt | regress_rls_bob
-- 4 | def_updt | regress_rls_carol
-- 5 | efg_updt | regress_rls_bob
-- 6 | fgh_updt | regress_rls_bob
-- 8 | fgh_updt | regress_rls_carol
--(6 rows)
--
-+ERROR:  unknown function: f_leak()
- SET SESSION AUTHORIZATION regress_rls_carol;
-+ERROR:  at or near "regress_rls_carol": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_carol
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
+ NOTICE:  f_leak => abc
+ NOTICE:  f_leak => bcd
+@@ -2967,13 +2143,13 @@
+  8 | fgh_updt | regress_rls_carol
+ (6 rows)
+ 
+-SET SESSION AUTHORIZATION regress_rls_carol;
++SET ROLE regress_rls_carol;
  SELECT * FROM x1 WHERE f_leak(b) ORDER BY a ASC;
 -NOTICE:  f_leak => cde
 -NOTICE:  f_leak => fgh
--NOTICE:  f_leak => bcd_updt
--NOTICE:  f_leak => def_updt
--NOTICE:  f_leak => fgh_updt
--NOTICE:  f_leak => fgh_updt
-- a |    b     |         c         
-----+----------+-------------------
-- 2 | bcd_updt | regress_rls_bob
-- 3 | cde      | regress_rls_carol
-- 4 | def_updt | regress_rls_carol
-- 6 | fgh_updt | regress_rls_bob
-- 7 | fgh      | regress_rls_carol
-- 8 | fgh_updt | regress_rls_carol
--(6 rows)
--
-+ERROR:  unknown function: f_leak()
+ NOTICE:  f_leak => bcd_updt
++NOTICE:  f_leak => cde
+ NOTICE:  f_leak => def_updt
+ NOTICE:  f_leak => fgh_updt
++NOTICE:  f_leak => fgh
+ NOTICE:  f_leak => fgh_updt
+  a |    b     |         c         
+ ---+----------+-------------------
+@@ -2986,50 +2162,50 @@
+ (6 rows)
+ 
  UPDATE x1 SET b = b || '_updt' WHERE f_leak(b) RETURNING *;
 -NOTICE:  f_leak => cde
 -NOTICE:  f_leak => fgh
--NOTICE:  f_leak => bcd_updt
--NOTICE:  f_leak => def_updt
--NOTICE:  f_leak => fgh_updt
--NOTICE:  f_leak => fgh_updt
-- a |       b       |         c         
-----+---------------+-------------------
+ NOTICE:  f_leak => bcd_updt
++NOTICE:  f_leak => cde
+ NOTICE:  f_leak => def_updt
+ NOTICE:  f_leak => fgh_updt
++NOTICE:  f_leak => fgh
+ NOTICE:  f_leak => fgh_updt
+  a |       b       |         c         
+ ---+---------------+-------------------
 - 3 | cde_updt      | regress_rls_carol
 - 7 | fgh_updt      | regress_rls_carol
-- 2 | bcd_updt_updt | regress_rls_bob
-- 4 | def_updt_updt | regress_rls_carol
-- 6 | fgh_updt_updt | regress_rls_bob
-- 8 | fgh_updt_updt | regress_rls_carol
--(6 rows)
--
-+ERROR:  unknown function: f_leak()
+  2 | bcd_updt_updt | regress_rls_bob
++ 3 | cde_updt      | regress_rls_carol
+  4 | def_updt_updt | regress_rls_carol
+  6 | fgh_updt_updt | regress_rls_bob
++ 7 | fgh_updt      | regress_rls_carol
+  8 | fgh_updt_updt | regress_rls_carol
+ (6 rows)
+ 
  DELETE FROM x1 WHERE f_leak(b) RETURNING *;
 -NOTICE:  f_leak => cde_updt
 -NOTICE:  f_leak => fgh_updt
--NOTICE:  f_leak => bcd_updt_updt
--NOTICE:  f_leak => def_updt_updt
--NOTICE:  f_leak => fgh_updt_updt
--NOTICE:  f_leak => fgh_updt_updt
-- a |       b       |         c         
-----+---------------+-------------------
+ NOTICE:  f_leak => bcd_updt_updt
++NOTICE:  f_leak => cde_updt
+ NOTICE:  f_leak => def_updt_updt
+ NOTICE:  f_leak => fgh_updt_updt
++NOTICE:  f_leak => fgh_updt
+ NOTICE:  f_leak => fgh_updt_updt
+  a |       b       |         c         
+ ---+---------------+-------------------
 - 3 | cde_updt      | regress_rls_carol
 - 7 | fgh_updt      | regress_rls_carol
-- 2 | bcd_updt_updt | regress_rls_bob
-- 4 | def_updt_updt | regress_rls_carol
-- 6 | fgh_updt_updt | regress_rls_bob
-- 8 | fgh_updt_updt | regress_rls_carol
--(6 rows)
--
-+ERROR:  unknown function: f_leak()
+  2 | bcd_updt_updt | regress_rls_bob
++ 3 | cde_updt      | regress_rls_carol
+  4 | def_updt_updt | regress_rls_carol
+  6 | fgh_updt_updt | regress_rls_bob
++ 7 | fgh_updt      | regress_rls_carol
+  8 | fgh_updt_updt | regress_rls_carol
+ (6 rows)
+ 
  --
  -- Duplicate Policy Names
  --
- SET SESSION AUTHORIZATION regress_rls_alice;
-+ERROR:  at or near "regress_rls_alice": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_alice
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
+-SET SESSION AUTHORIZATION regress_rls_alice;
++SET ROLE regress_rls_alice;
  CREATE TABLE y1 (a int, b text);
  CREATE TABLE y2 (a int, b text);
  GRANT ALL ON y1, y2 TO regress_rls_bob;
@@ -4522,16 +3804,12 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  CREATE POLICY p1 ON y2 FOR ALL USING (a % 2 = 0);  --OK
  ALTER TABLE y1 ENABLE ROW LEVEL SECURITY;
  ALTER TABLE y2 ENABLE ROW LEVEL SECURITY;
-@@ -3038,188 +2834,121 @@
+@@ -3037,189 +2213,105 @@
+ -- Expression structure with SBV
  --
  -- Create view as table owner.  RLS should NOT be applied.
- SET SESSION AUTHORIZATION regress_rls_alice;
-+ERROR:  at or near "regress_rls_alice": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_alice
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
+-SET SESSION AUTHORIZATION regress_rls_alice;
++SET ROLE regress_rls_alice;
  CREATE VIEW rls_sbv WITH (security_barrier) AS
      SELECT * FROM y1 WHERE f_leak(b);
 +ERROR:  at or near "with": syntax error
@@ -4554,13 +3832,8 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  DROP VIEW rls_sbv;
 +ERROR:  relation "rls_sbv" does not exist
  -- Create view as role that does not own table.  RLS should be applied.
- SET SESSION AUTHORIZATION regress_rls_bob;
-+ERROR:  at or near "regress_rls_bob": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_bob
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
+-SET SESSION AUTHORIZATION regress_rls_bob;
++SET ROLE regress_rls_bob;
  CREATE VIEW rls_sbv WITH (security_barrier) AS
      SELECT * FROM y1 WHERE f_leak(b);
 +ERROR:  at or near "with": syntax error
@@ -4585,24 +3858,14 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  --
  -- Expression structure
  --
- SET SESSION AUTHORIZATION regress_rls_alice;
-+ERROR:  at or near "regress_rls_alice": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_alice
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
+-SET SESSION AUTHORIZATION regress_rls_alice;
++SET ROLE regress_rls_alice;
  INSERT INTO y2 (SELECT x, public.fipshash(x::text) FROM generate_series(0,20) x);
 +ERROR:  unknown function: public.fipshash()
  CREATE POLICY p2 ON y2 USING (a % 3 = 0);
  CREATE POLICY p3 ON y2 USING (a % 4 = 0);
- SET SESSION AUTHORIZATION regress_rls_bob;
-+ERROR:  at or near "regress_rls_bob": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_bob
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
+-SET SESSION AUTHORIZATION regress_rls_bob;
++SET ROLE regress_rls_bob;
  SELECT * FROM y2 WHERE f_leak(b);
 -NOTICE:  f_leak => 5feceb66ffc86f38d952786c6d696c79
 -NOTICE:  f_leak => d4735e3a265e16eee03f59718b9b5d03
@@ -4635,8 +3898,10 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 - 18 | 4ec9599fc203d176a301536c2e091a19
 - 20 | f5ca38f748a1d6eaf726b8a42fb575c3
 -(14 rows)
--
-+ERROR:  unknown function: f_leak()
++ a | b 
++---+---
++(0 rows)
+ 
  EXPLAIN (COSTS OFF) SELECT * FROM y2 WHERE f_leak(b);
 -                                 QUERY PLAN                                  
 ------------------------------------------------------------------------------
@@ -4691,8 +3956,10 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 - 18 | 4ec9599fc203d176a301536c2e091a19
 - 20 | f5ca38f748a1d6eaf726b8a42fb575c3
 -(14 rows)
--
-+ERROR:  unknown function: f_leak()
++ a | b 
++---+---
++(0 rows)
+ 
  EXPLAIN (COSTS OFF) SELECT * FROM y2 WHERE f_leak('abc');
 -                                      QUERY PLAN                                       
 ----------------------------------------------------------------------------------------
@@ -4712,11 +3979,10 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  SELECT * FROM y2 JOIN test_qual_pushdown ON (b = abc) WHERE f_leak(abc);
 -NOTICE:  f_leak => abc
 -NOTICE:  f_leak => def
-- a | b | abc 
-----+---+-----
--(0 rows)
--
-+ERROR:  unknown function: f_leak()
+  a | b | abc 
+ ---+---+-----
+ (0 rows)
+ 
  EXPLAIN (COSTS OFF) SELECT * FROM y2 JOIN test_qual_pushdown ON (b = abc) WHERE f_leak(abc);
 -                               QUERY PLAN                                
 --------------------------------------------------------------------------
@@ -4749,11 +4015,10 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 -NOTICE:  f_leak => b17ef6d19c7a5b1ee83b907c595526dc
 -NOTICE:  f_leak => 4ec9599fc203d176a301536c2e091a19
 -NOTICE:  f_leak => f5ca38f748a1d6eaf726b8a42fb575c3
-- a | b | abc 
-----+---+-----
--(0 rows)
--
-+ERROR:  unknown function: f_leak()
+  a | b | abc 
+ ---+---+-----
+ (0 rows)
+ 
  EXPLAIN (COSTS OFF) SELECT * FROM y2 JOIN test_qual_pushdown ON (b = abc) WHERE f_leak(b);
 -                                       QUERY PLAN                                        
 ------------------------------------------------------------------------------------------
@@ -4774,12 +4039,8 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  --
  -- Plancache invalidate on user change.
  --
- RESET SESSION AUTHORIZATION;
-+ERROR:  at or near "authorization": syntax error
-+DETAIL:  source SQL:
-+RESET SESSION AUTHORIZATION
-+              ^
-+HINT:  try \h RESET
+-RESET SESSION AUTHORIZATION;
++RESET ROLE;
  DROP TABLE t1 CASCADE;
 -NOTICE:  drop cascades to 2 other objects
 -DETAIL:  drop cascades to table t2
@@ -4787,7 +4048,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  CREATE TABLE t1 (a integer);
  GRANT SELECT ON t1 TO regress_rls_bob, regress_rls_carol;
  CREATE POLICY p1 ON t1 TO regress_rls_bob USING ((a % 2) = 0);
-@@ -3230,112 +2959,85 @@
+@@ -3230,97 +2322,62 @@
  PREPARE role_inval AS SELECT * FROM t1;
  -- Check plan
  EXPLAIN (COSTS OFF) EXECUTE role_inval;
@@ -4835,31 +4096,17 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  --
  -- CTE and RLS
  --
- RESET SESSION AUTHORIZATION;
-+ERROR:  at or near "authorization": syntax error
-+DETAIL:  source SQL:
-+RESET SESSION AUTHORIZATION
-+              ^
-+HINT:  try \h RESET
+-RESET SESSION AUTHORIZATION;
++RESET ROLE;
  DROP TABLE t1 CASCADE;
-+ERROR:  user regress_rls_bob does not have DROP privilege on relation t1
  CREATE TABLE t1 (a integer, b text);
-+ERROR:  relation "root.regress_rls_schema.t1" already exists
  CREATE POLICY p1 ON t1 USING (a % 2 = 0);
-+ERROR:  must be owner of relation t1
  ALTER TABLE t1 ENABLE ROW LEVEL SECURITY;
-+ERROR:  must be owner of table t1 or have CREATE privilege on table t1
  GRANT ALL ON t1 TO regress_rls_bob;
-+ERROR:  user regress_rls_bob does not have ALL privilege on relation t1
  INSERT INTO t1 (SELECT x, public.fipshash(x::text) FROM generate_series(0,20) x);
-+ERROR:  user regress_rls_bob does not have INSERT privilege on relation t1
- SET SESSION AUTHORIZATION regress_rls_bob;
-+ERROR:  at or near "regress_rls_bob": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_bob
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
+-SET SESSION AUTHORIZATION regress_rls_bob;
++ERROR:  unknown function: public.fipshash()
++SET ROLE regress_rls_bob;
  WITH cte1 AS MATERIALIZED (SELECT * FROM t1 WHERE f_leak(b)) SELECT * FROM cte1;
 -NOTICE:  f_leak => 5feceb66ffc86f38d952786c6d696c79
 -NOTICE:  f_leak => d4735e3a265e16eee03f59718b9b5d03
@@ -4886,8 +4133,10 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 - 18 | 4ec9599fc203d176a301536c2e091a19
 - 20 | f5ca38f748a1d6eaf726b8a42fb575c3
 -(11 rows)
--
-+ERROR:  unknown function: f_leak()
++ a | b 
++---+---
++(0 rows)
+ 
  EXPLAIN (COSTS OFF)
  WITH cte1 AS MATERIALIZED (SELECT * FROM t1 WHERE f_leak(b)) SELECT * FROM cte1;
 -                   QUERY PLAN                    
@@ -4905,7 +4154,10 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 +HINT:  try \h <SELECTCLAUSE>
  WITH cte1 AS (UPDATE t1 SET a = a + 1 RETURNING *) SELECT * FROM cte1; --fail
 -ERROR:  new row violates row-level security policy for table "t1"
-+ERROR:  user regress_rls_bob does not have UPDATE privilege on relation t1
++ a | b 
++---+---
++(0 rows)
++
  WITH cte1 AS (UPDATE t1 SET a = a RETURNING *) SELECT * FROM cte1; --ok
 - a  |                b                 
 -----+----------------------------------
@@ -4921,64 +4173,29 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 - 18 | 4ec9599fc203d176a301536c2e091a19
 - 20 | f5ca38f748a1d6eaf726b8a42fb575c3
 -(11 rows)
--
-+ERROR:  user regress_rls_bob does not have UPDATE privilege on relation t1
++ a | b 
++---+---
++(0 rows)
+ 
  WITH cte1 AS (INSERT INTO t1 VALUES (21, 'Fail') RETURNING *) SELECT * FROM cte1; --fail
--ERROR:  new row violates row-level security policy for table "t1"
-+ERROR:  user regress_rls_bob does not have INSERT privilege on relation t1
- WITH cte1 AS (INSERT INTO t1 VALUES (20, 'Success') RETURNING *) SELECT * FROM cte1; --ok
-- a  |    b    
------+---------
-- 20 | Success
--(1 row)
--
-+ERROR:  user regress_rls_bob does not have INSERT privilege on relation t1
+ ERROR:  new row violates row-level security policy for table "t1"
+@@ -3333,9 +2390,8 @@
  --
  -- Rename Policy
  --
- RESET SESSION AUTHORIZATION;
-+ERROR:  at or near "authorization": syntax error
-+DETAIL:  source SQL:
-+RESET SESSION AUTHORIZATION
-+              ^
-+HINT:  try \h RESET
+-RESET SESSION AUTHORIZATION;
++RESET ROLE;
  ALTER POLICY p1 ON t1 RENAME TO p1; --fail
 -ERROR:  policy "p1" for table "t1" already exists
-+ERROR:  must be owner of relation t1
  SELECT polname, relname
      FROM pg_policy pol
      JOIN pg_class pc ON (pc.oid = pol.polrelid)
-@@ -3343,95 +3045,74 @@
-  polname | relname 
- ---------+---------
-  p1      | t1
--(1 row)
-+ p2      | t1
-+(2 rows)
- 
- ALTER POLICY p1 ON t1 RENAME TO p2; --ok
-+ERROR:  must be owner of relation t1
- SELECT polname, relname
-     FROM pg_policy pol
-     JOIN pg_class pc ON (pc.oid = pol.polrelid)
-     WHERE relname = 't1';
-  polname | relname 
- ---------+---------
-+ p1      | t1
-  p2      | t1
--(1 row)
-+(2 rows)
- 
+@@ -3358,80 +2414,46 @@
  --
  -- Check INSERT SELECT
  --
- SET SESSION AUTHORIZATION regress_rls_bob;
-+ERROR:  at or near "regress_rls_bob": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_bob
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
+-SET SESSION AUTHORIZATION regress_rls_bob;
++SET ROLE regress_rls_bob;
  CREATE TABLE t2 (a integer, b text);
  INSERT INTO t2 (SELECT * FROM t1);
  EXPLAIN (COSTS OFF) INSERT INTO t2 (SELECT * FROM t1);
@@ -5008,18 +4225,18 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 - 16 | b17ef6d19c7a5b1ee83b907c595526dc
 - 18 | 4ec9599fc203d176a301536c2e091a19
 - 20 | f5ca38f748a1d6eaf726b8a42fb575c3
-- 20 | Success
++ a  |    b    
++----+---------
+  20 | Success
 -(12 rows)
-+ a | b 
-+---+---
-+(0 rows)
- 
- EXPLAIN (COSTS OFF) SELECT * FROM t2;
+-
+-EXPLAIN (COSTS OFF) SELECT * FROM t2;
 -   QUERY PLAN   
 -----------------
 - Seq Scan on t2
--(1 row)
--
+ (1 row)
+ 
++EXPLAIN (COSTS OFF) SELECT * FROM t2;
 +ERROR:  at or near "off": syntax error
 +DETAIL:  source SQL:
 +EXPLAIN (COSTS OFF) SELECT * FROM t2
@@ -5041,11 +4258,11 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 - 16 | b17ef6d19c7a5b1ee83b907c595526dc
 - 18 | 4ec9599fc203d176a301536c2e091a19
 - 20 | f5ca38f748a1d6eaf726b8a42fb575c3
-- 20 | Success
++ a  |    b    
++----+---------
+  20 | Success
 -(12 rows)
-+ a 
-+---
-+(0 rows)
++(1 row)
  
  SELECT * INTO t4 FROM t1;
 +ERROR:  at or near "into": syntax error
@@ -5073,122 +4290,50 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  --
  -- RLS with JOIN
  --
- SET SESSION AUTHORIZATION regress_rls_alice;
-+ERROR:  at or near "regress_rls_alice": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_alice
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
+-SET SESSION AUTHORIZATION regress_rls_alice;
++SET ROLE regress_rls_alice;
  CREATE TABLE blog (id integer, author text, post text);
  CREATE TABLE comment (blog_id integer, message text);
  GRANT ALL ON blog, comment TO regress_rls_bob;
-@@ -3451,1097 +3132,392 @@
+@@ -3450,7 +2472,7 @@
+     (5, 'what?'),
      (4, 'insane!'),
      (2, 'who did it?');
- SET SESSION AUTHORIZATION regress_rls_bob;
-+ERROR:  at or near "regress_rls_bob": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_bob
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
+-SET SESSION AUTHORIZATION regress_rls_bob;
++SET ROLE regress_rls_bob;
  -- Check RLS JOIN with Non-RLS.
  SELECT id, author, message FROM blog JOIN comment ON id = blog_id;
   id | author |   message   
- ----+--------+-------------
--  4 | alice  | insane!
-+  1 | alice  | cool blog
-+  1 | alice  | fun blog
+@@ -3467,10 +2489,10 @@
    2 | bob    | who did it?
--(2 rows)
-+  3 | alice  | crazy blog
-+  4 | alice  | insane!
-+  5 | john   | what?
-+(6 rows)
+ (2 rows)
  
- -- Check Non-RLS JOIN with RLS.
- SELECT id, author, message FROM comment JOIN blog ON id = blog_id;
-  id | author |   message   
- ----+--------+-------------
-+  1 | alice  | cool blog
-+  1 | alice  | fun blog
-+  3 | alice  | crazy blog
-+  5 | john   | what?
-   4 | alice  | insane!
-   2 | bob    | who did it?
--(2 rows)
-+(6 rows)
- 
- SET SESSION AUTHORIZATION regress_rls_alice;
-+ERROR:  at or near "regress_rls_alice": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_alice
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
+-SET SESSION AUTHORIZATION regress_rls_alice;
++SET ROLE regress_rls_alice;
  CREATE POLICY comment_1 ON comment USING (blog_id < 4);
  ALTER TABLE comment ENABLE ROW LEVEL SECURITY;
- SET SESSION AUTHORIZATION regress_rls_bob;
-+ERROR:  at or near "regress_rls_bob": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_bob
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
+-SET SESSION AUTHORIZATION regress_rls_bob;
++SET ROLE regress_rls_bob;
  -- Check RLS JOIN RLS
  SELECT id, author, message FROM blog JOIN comment ON id = blog_id;
   id | author |   message   
- ----+--------+-------------
-+  1 | alice  | cool blog
-+  1 | alice  | fun blog
+@@ -3484,86 +2506,44 @@
    2 | bob    | who did it?
--(1 row)
-+  3 | alice  | crazy blog
-+  4 | alice  | insane!
-+  5 | john   | what?
-+(6 rows)
+ (1 row)
  
- SELECT id, author, message FROM comment JOIN blog ON id = blog_id;
-  id | author |   message   
- ----+--------+-------------
-+  1 | alice  | cool blog
-+  1 | alice  | fun blog
-+  3 | alice  | crazy blog
-+  5 | john   | what?
-+  4 | alice  | insane!
-   2 | bob    | who did it?
--(1 row)
-+(6 rows)
- 
- SET SESSION AUTHORIZATION regress_rls_alice;
-+ERROR:  at or near "regress_rls_alice": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_alice
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
+-SET SESSION AUTHORIZATION regress_rls_alice;
++SET ROLE regress_rls_alice;
  DROP TABLE blog, comment;
  --
  -- Default Deny Policy
  --
- RESET SESSION AUTHORIZATION;
-+ERROR:  at or near "authorization": syntax error
-+DETAIL:  source SQL:
-+RESET SESSION AUTHORIZATION
-+              ^
-+HINT:  try \h RESET
+-RESET SESSION AUTHORIZATION;
++RESET ROLE;
  DROP POLICY p2 ON t1;
-+ERROR:  must be owner of relation t1
  ALTER TABLE t1 OWNER TO regress_rls_alice;
-+ERROR:  must be owner of table t1
  -- Check that default deny does not apply to superuser.
- RESET SESSION AUTHORIZATION;
-+ERROR:  at or near "authorization": syntax error
-+DETAIL:  source SQL:
-+RESET SESSION AUTHORIZATION
-+              ^
-+HINT:  try \h RESET
+-RESET SESSION AUTHORIZATION;
++RESET ROLE;
  SELECT * FROM t1;
 - a  |                b                 
 -----+----------------------------------
@@ -5213,31 +4358,26 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 - 16 | b17ef6d19c7a5b1ee83b907c595526dc
 - 18 | 4ec9599fc203d176a301536c2e091a19
 - 20 | f5ca38f748a1d6eaf726b8a42fb575c3
-- 20 | Success
++ a  |    b    
++----+---------
+  20 | Success
 -(22 rows)
-+ a 
-+---
-+(0 rows)
- 
- EXPLAIN (COSTS OFF) SELECT * FROM t1;
+-
+-EXPLAIN (COSTS OFF) SELECT * FROM t1;
 -   QUERY PLAN   
 -----------------
 - Seq Scan on t1
--(1 row)
--
+ (1 row)
+ 
++EXPLAIN (COSTS OFF) SELECT * FROM t1;
 +ERROR:  at or near "off": syntax error
 +DETAIL:  source SQL:
 +EXPLAIN (COSTS OFF) SELECT * FROM t1
 +               ^
 +HINT:  try \h <SELECTCLAUSE>
  -- Check that default deny does not apply to table owner.
- SET SESSION AUTHORIZATION regress_rls_alice;
-+ERROR:  at or near "regress_rls_alice": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_alice
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
+-SET SESSION AUTHORIZATION regress_rls_alice;
++SET ROLE regress_rls_alice;
  SELECT * FROM t1;
 - a  |                b                 
 -----+----------------------------------
@@ -5262,37 +4402,30 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 - 16 | b17ef6d19c7a5b1ee83b907c595526dc
 - 18 | 4ec9599fc203d176a301536c2e091a19
 - 20 | f5ca38f748a1d6eaf726b8a42fb575c3
-- 20 | Success
++ a  |    b    
++----+---------
+  20 | Success
 -(22 rows)
-+ a 
-+---
-+(0 rows)
- 
- EXPLAIN (COSTS OFF) SELECT * FROM t1;
+-
+-EXPLAIN (COSTS OFF) SELECT * FROM t1;
 -   QUERY PLAN   
 -----------------
 - Seq Scan on t1
--(1 row)
--
+ (1 row)
+ 
++EXPLAIN (COSTS OFF) SELECT * FROM t1;
 +ERROR:  at or near "off": syntax error
 +DETAIL:  source SQL:
 +EXPLAIN (COSTS OFF) SELECT * FROM t1
 +               ^
 +HINT:  try \h <SELECTCLAUSE>
  -- Check that default deny applies to non-owner/non-superuser when RLS on.
- SET SESSION AUTHORIZATION regress_rls_bob;
-+ERROR:  at or near "regress_rls_bob": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_bob
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
+-SET SESSION AUTHORIZATION regress_rls_bob;
++SET ROLE regress_rls_bob;
  SET row_security TO ON;
  SELECT * FROM t1;
-- a | b 
-----+---
-+ a 
-+---
+  a | b 
+@@ -3571,221 +2551,194 @@
  (0 rows)
  
  EXPLAIN (COSTS OFF) SELECT * FROM t1;
@@ -5308,18 +4441,10 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 +EXPLAIN (COSTS OFF) SELECT * FROM t1
 +               ^
 +HINT:  try \h <SELECTCLAUSE>
-+SET SESSION AUTHORIZATION regress_rls_bob;
-+ERROR:  at or near "regress_rls_bob": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_bob
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
++SET ROLE regress_rls_bob;
  SELECT * FROM t1;
-- a | b 
-----+---
-+ a 
-+---
+  a | b 
+ ---+---
  (0 rows)
  
  EXPLAIN (COSTS OFF) SELECT * FROM t1;
@@ -5337,12 +4462,8 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  --
  -- COPY TO/FROM
  --
- RESET SESSION AUTHORIZATION;
-+ERROR:  at or near "authorization": syntax error
-+DETAIL:  source SQL:
-+RESET SESSION AUTHORIZATION
-+              ^
-+HINT:  try \h RESET
+-RESET SESSION AUTHORIZATION;
++RESET ROLE;
  DROP TABLE copy_t CASCADE;
 -ERROR:  table "copy_t" does not exist
 +ERROR:  relation "copy_t" does not exist
@@ -5354,12 +4475,8 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  INSERT INTO copy_t (SELECT x, public.fipshash(x::text) FROM generate_series(0,10) x);
 +ERROR:  unknown function: public.fipshash()
  -- Check COPY TO as Superuser/owner.
- RESET SESSION AUTHORIZATION;
-+ERROR:  at or near "authorization": syntax error
-+DETAIL:  source SQL:
-+RESET SESSION AUTHORIZATION
-+              ^
-+HINT:  try \h RESET
+-RESET SESSION AUTHORIZATION;
++RESET ROLE;
  SET row_security TO OFF;
  COPY (SELECT * FROM copy_t ORDER BY a ASC) TO STDOUT WITH DELIMITER ',';
 -0,5feceb66ffc86f38d952786c6d696c79
@@ -5387,16 +4504,12 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 -9,19581e27de7ced00ff1ce50b2047e7a5
 -10,4a44dc15364204a80fe80e9039455cc1
  -- Check COPY TO as user with permissions.
- SET SESSION AUTHORIZATION regress_rls_bob;
-+ERROR:  at or near "regress_rls_bob": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_bob
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
+-SET SESSION AUTHORIZATION regress_rls_bob;
++SET ROLE regress_rls_bob;
  SET row_security TO OFF;
  COPY (SELECT * FROM copy_t ORDER BY a ASC) TO STDOUT WITH DELIMITER ','; --fail - would be affected by RLS
 -ERROR:  query would be affected by row-level security policy for table "copy_t"
++ERROR:  COPY (SELECT * FROM copy_t ORDER BY a ASC) TO STDOUT WITH (DELIMITER ','): user regress_rls_bob does not have SELECT privilege on relation copy_t
  SET row_security TO ON;
  COPY (SELECT * FROM copy_t ORDER BY a ASC) TO STDOUT WITH DELIMITER ','; --ok
 -0,5feceb66ffc86f38d952786c6d696c79
@@ -5405,14 +4518,11 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 -6,e7f6c011776e8db7cd330b54174fd76f
 -8,2c624232cdd221771294dfbb310aca00
 -10,4a44dc15364204a80fe80e9039455cc1
++ERROR:  COPY (SELECT * FROM copy_t ORDER BY a ASC) TO STDOUT WITH (DELIMITER ','): user regress_rls_bob does not have SELECT privilege on relation copy_t
  -- Check COPY TO as user with permissions and BYPASSRLS
- SET SESSION AUTHORIZATION regress_rls_exempt_user;
-+ERROR:  at or near "regress_rls_exempt_user": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_exempt_user
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
+-SET SESSION AUTHORIZATION regress_rls_exempt_user;
++SET ROLE regress_rls_exempt_user;
++ERROR:  role/user "regress_rls_exempt_user" does not exist
  SET row_security TO OFF;
  COPY (SELECT * FROM copy_t ORDER BY a ASC) TO STDOUT WITH DELIMITER ','; --ok
 -0,5feceb66ffc86f38d952786c6d696c79
@@ -5426,6 +4536,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 -8,2c624232cdd221771294dfbb310aca00
 -9,19581e27de7ced00ff1ce50b2047e7a5
 -10,4a44dc15364204a80fe80e9039455cc1
++ERROR:  COPY (SELECT * FROM copy_t ORDER BY a ASC) TO STDOUT WITH (DELIMITER ','): user regress_rls_bob does not have SELECT privilege on relation copy_t
  SET row_security TO ON;
  COPY (SELECT * FROM copy_t ORDER BY a ASC) TO STDOUT WITH DELIMITER ','; --ok
 -0,5feceb66ffc86f38d952786c6d696c79
@@ -5439,27 +4550,21 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 -8,2c624232cdd221771294dfbb310aca00
 -9,19581e27de7ced00ff1ce50b2047e7a5
 -10,4a44dc15364204a80fe80e9039455cc1
++ERROR:  COPY (SELECT * FROM copy_t ORDER BY a ASC) TO STDOUT WITH (DELIMITER ','): user regress_rls_bob does not have SELECT privilege on relation copy_t
  -- Check COPY TO as user without permissions. SET row_security TO OFF;
- SET SESSION AUTHORIZATION regress_rls_carol;
-+ERROR:  at or near "regress_rls_carol": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_carol
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
+-SET SESSION AUTHORIZATION regress_rls_carol;
++SET ROLE regress_rls_carol;
  SET row_security TO OFF;
  COPY (SELECT * FROM copy_t ORDER BY a ASC) TO STDOUT WITH DELIMITER ','; --fail - would be affected by RLS
 -ERROR:  query would be affected by row-level security policy for table "copy_t"
++ERROR:  COPY (SELECT * FROM copy_t ORDER BY a ASC) TO STDOUT WITH (DELIMITER ','): user regress_rls_carol does not have SELECT privilege on relation copy_t
  SET row_security TO ON;
  COPY (SELECT * FROM copy_t ORDER BY a ASC) TO STDOUT WITH DELIMITER ','; --fail - permission denied
 -ERROR:  permission denied for table copy_t
++ERROR:  COPY (SELECT * FROM copy_t ORDER BY a ASC) TO STDOUT WITH (DELIMITER ','): user regress_rls_carol does not have SELECT privilege on relation copy_t
  -- Check COPY relation TO; keep it just one row to avoid reordering issues
- RESET SESSION AUTHORIZATION;
-+ERROR:  at or near "authorization": syntax error
-+DETAIL:  source SQL:
-+RESET SESSION AUTHORIZATION
-+              ^
-+HINT:  try \h RESET
+-RESET SESSION AUTHORIZATION;
++RESET ROLE;
  SET row_security TO ON;
  CREATE TABLE copy_rel_to (a integer, b text);
  CREATE POLICY p1 ON copy_rel_to USING (a % 2 = 0);
@@ -5469,12 +4574,8 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  INSERT INTO copy_rel_to VALUES (1, public.fipshash('1'));
 +ERROR:  unknown function: public.fipshash()
  -- Check COPY TO as Superuser/owner.
- RESET SESSION AUTHORIZATION;
-+ERROR:  at or near "authorization": syntax error
-+DETAIL:  source SQL:
-+RESET SESSION AUTHORIZATION
-+              ^
-+HINT:  try \h RESET
+-RESET SESSION AUTHORIZATION;
++RESET ROLE;
  SET row_security TO OFF;
  COPY copy_rel_to TO STDOUT WITH DELIMITER ',';
 -1,6b86b273ff34fce19d6b804eff5a3f57
@@ -5482,53 +4583,41 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  COPY copy_rel_to TO STDOUT WITH DELIMITER ',';
 -1,6b86b273ff34fce19d6b804eff5a3f57
  -- Check COPY TO as user with permissions.
- SET SESSION AUTHORIZATION regress_rls_bob;
-+ERROR:  at or near "regress_rls_bob": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_bob
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
+-SET SESSION AUTHORIZATION regress_rls_bob;
++SET ROLE regress_rls_bob;
  SET row_security TO OFF;
  COPY copy_rel_to TO STDOUT WITH DELIMITER ','; --fail - would be affected by RLS
 -ERROR:  query would be affected by row-level security policy for table "copy_rel_to"
++ERROR:  COPY copy_rel_to TO STDOUT WITH (DELIMITER ','): user regress_rls_bob does not have SELECT privilege on relation copy_rel_to
  SET row_security TO ON;
  COPY copy_rel_to TO STDOUT WITH DELIMITER ','; --ok
++ERROR:  COPY copy_rel_to TO STDOUT WITH (DELIMITER ','): user regress_rls_bob does not have SELECT privilege on relation copy_rel_to
  -- Check COPY TO as user with permissions and BYPASSRLS
- SET SESSION AUTHORIZATION regress_rls_exempt_user;
-+ERROR:  at or near "regress_rls_exempt_user": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_exempt_user
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
+-SET SESSION AUTHORIZATION regress_rls_exempt_user;
++SET ROLE regress_rls_exempt_user;
++ERROR:  role/user "regress_rls_exempt_user" does not exist
  SET row_security TO OFF;
  COPY copy_rel_to TO STDOUT WITH DELIMITER ','; --ok
 -1,6b86b273ff34fce19d6b804eff5a3f57
++ERROR:  COPY copy_rel_to TO STDOUT WITH (DELIMITER ','): user regress_rls_bob does not have SELECT privilege on relation copy_rel_to
  SET row_security TO ON;
  COPY copy_rel_to TO STDOUT WITH DELIMITER ','; --ok
 -1,6b86b273ff34fce19d6b804eff5a3f57
++ERROR:  COPY copy_rel_to TO STDOUT WITH (DELIMITER ','): user regress_rls_bob does not have SELECT privilege on relation copy_rel_to
  -- Check COPY TO as user without permissions. SET row_security TO OFF;
- SET SESSION AUTHORIZATION regress_rls_carol;
-+ERROR:  at or near "regress_rls_carol": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_carol
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
+-SET SESSION AUTHORIZATION regress_rls_carol;
++SET ROLE regress_rls_carol;
  SET row_security TO OFF;
  COPY copy_rel_to TO STDOUT WITH DELIMITER ','; --fail - permission denied
 -ERROR:  permission denied for table copy_rel_to
++ERROR:  COPY copy_rel_to TO STDOUT WITH (DELIMITER ','): user regress_rls_carol does not have SELECT privilege on relation copy_rel_to
  SET row_security TO ON;
  COPY copy_rel_to TO STDOUT WITH DELIMITER ','; --fail - permission denied
 -ERROR:  permission denied for table copy_rel_to
++ERROR:  COPY copy_rel_to TO STDOUT WITH (DELIMITER ','): user regress_rls_carol does not have SELECT privilege on relation copy_rel_to
  -- Check behavior with a child table.
- RESET SESSION AUTHORIZATION;
-+ERROR:  at or near "authorization": syntax error
-+DETAIL:  source SQL:
-+RESET SESSION AUTHORIZATION
-+              ^
-+HINT:  try \h RESET
+-RESET SESSION AUTHORIZATION;
++RESET ROLE;
  SET row_security TO ON;
  CREATE TABLE copy_rel_to_child () INHERITS (copy_rel_to);
 +ERROR:  at or near "(": syntax error: unimplemented: this syntax
@@ -5540,12 +4629,8 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  INSERT INTO copy_rel_to_child VALUES (1, 'one'), (2, 'two');
 +ERROR:  relation "copy_rel_to_child" does not exist
  -- Check COPY TO as Superuser/owner.
- RESET SESSION AUTHORIZATION;
-+ERROR:  at or near "authorization": syntax error
-+DETAIL:  source SQL:
-+RESET SESSION AUTHORIZATION
-+              ^
-+HINT:  try \h RESET
+-RESET SESSION AUTHORIZATION;
++RESET ROLE;
  SET row_security TO OFF;
  COPY copy_rel_to TO STDOUT WITH DELIMITER ',';
 -1,6b86b273ff34fce19d6b804eff5a3f57
@@ -5553,161 +4638,159 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  COPY copy_rel_to TO STDOUT WITH DELIMITER ',';
 -1,6b86b273ff34fce19d6b804eff5a3f57
  -- Check COPY TO as user with permissions.
- SET SESSION AUTHORIZATION regress_rls_bob;
-+ERROR:  at or near "regress_rls_bob": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_bob
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
+-SET SESSION AUTHORIZATION regress_rls_bob;
++SET ROLE regress_rls_bob;
  SET row_security TO OFF;
  COPY copy_rel_to TO STDOUT WITH DELIMITER ','; --fail - would be affected by RLS
 -ERROR:  query would be affected by row-level security policy for table "copy_rel_to"
++ERROR:  COPY copy_rel_to TO STDOUT WITH (DELIMITER ','): user regress_rls_bob does not have SELECT privilege on relation copy_rel_to
  SET row_security TO ON;
  COPY copy_rel_to TO STDOUT WITH DELIMITER ','; --ok
++ERROR:  COPY copy_rel_to TO STDOUT WITH (DELIMITER ','): user regress_rls_bob does not have SELECT privilege on relation copy_rel_to
  -- Check COPY TO as user with permissions and BYPASSRLS
- SET SESSION AUTHORIZATION regress_rls_exempt_user;
-+ERROR:  at or near "regress_rls_exempt_user": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_exempt_user
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
+-SET SESSION AUTHORIZATION regress_rls_exempt_user;
++SET ROLE regress_rls_exempt_user;
++ERROR:  role/user "regress_rls_exempt_user" does not exist
  SET row_security TO OFF;
  COPY copy_rel_to TO STDOUT WITH DELIMITER ','; --ok
 -1,6b86b273ff34fce19d6b804eff5a3f57
++ERROR:  COPY copy_rel_to TO STDOUT WITH (DELIMITER ','): user regress_rls_bob does not have SELECT privilege on relation copy_rel_to
  SET row_security TO ON;
  COPY copy_rel_to TO STDOUT WITH DELIMITER ','; --ok
 -1,6b86b273ff34fce19d6b804eff5a3f57
++ERROR:  COPY copy_rel_to TO STDOUT WITH (DELIMITER ','): user regress_rls_bob does not have SELECT privilege on relation copy_rel_to
  -- Check COPY TO as user without permissions. SET row_security TO OFF;
- SET SESSION AUTHORIZATION regress_rls_carol;
-+ERROR:  at or near "regress_rls_carol": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_carol
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
+-SET SESSION AUTHORIZATION regress_rls_carol;
++SET ROLE regress_rls_carol;
  SET row_security TO OFF;
  COPY copy_rel_to TO STDOUT WITH DELIMITER ','; --fail - permission denied
 -ERROR:  permission denied for table copy_rel_to
++ERROR:  COPY copy_rel_to TO STDOUT WITH (DELIMITER ','): user regress_rls_carol does not have SELECT privilege on relation copy_rel_to
  SET row_security TO ON;
  COPY copy_rel_to TO STDOUT WITH DELIMITER ','; --fail - permission denied
 -ERROR:  permission denied for table copy_rel_to
++ERROR:  COPY copy_rel_to TO STDOUT WITH (DELIMITER ','): user regress_rls_carol does not have SELECT privilege on relation copy_rel_to
  -- Check COPY FROM as Superuser/owner.
- RESET SESSION AUTHORIZATION;
-+ERROR:  at or near "authorization": syntax error
-+DETAIL:  source SQL:
-+RESET SESSION AUTHORIZATION
-+              ^
-+HINT:  try \h RESET
+-RESET SESSION AUTHORIZATION;
++RESET ROLE;
  SET row_security TO OFF;
  COPY copy_t FROM STDIN; --ok
  SET row_security TO ON;
  COPY copy_t FROM STDIN; --ok
  -- Check COPY FROM as user with permissions.
- SET SESSION AUTHORIZATION regress_rls_bob;
-+ERROR:  at or near "regress_rls_bob": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_bob
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
+-SET SESSION AUTHORIZATION regress_rls_bob;
++SET ROLE regress_rls_bob;
  SET row_security TO OFF;
  COPY copy_t FROM STDIN; --fail - would be affected by RLS.
 -ERROR:  query would be affected by row-level security policy for table "copy_t"
--SET row_security TO ON;
--COPY copy_t FROM STDIN; --fail - COPY FROM not supported by RLS.
++ERROR:  user regress_rls_bob does not have INSERT privilege on relation copy_t
+ SET row_security TO ON;
+ COPY copy_t FROM STDIN; --fail - COPY FROM not supported by RLS.
 -ERROR:  COPY FROM not supported with row-level security
 -HINT:  Use INSERT statements instead.
---- Check COPY FROM as user with permissions and BYPASSRLS
++ERROR:  user regress_rls_bob does not have INSERT privilege on relation copy_t
+ -- Check COPY FROM as user with permissions and BYPASSRLS
 -SET SESSION AUTHORIZATION regress_rls_exempt_user;
--SET row_security TO ON;
--COPY copy_t FROM STDIN; --ok
-+ERROR:  expected 2 values, got 1
++SET ROLE regress_rls_exempt_user;
++ERROR:  role/user "regress_rls_exempt_user" does not exist
+ SET row_security TO ON;
+ COPY copy_t FROM STDIN; --ok
++ERROR:  user regress_rls_bob does not have INSERT privilege on relation copy_t
++1	abc
++2	bcd
++3	cde
++4	def
++\.
++invalid command \.
  -- Check COPY FROM as user without permissions.
- SET SESSION AUTHORIZATION regress_rls_carol;
-+ERROR:  at or near "regress_rls_carol": syntax error: unimplemented: this syntax
+-SET SESSION AUTHORIZATION regress_rls_carol;
++SET ROLE regress_rls_carol;
++ERROR:  at or near "1": syntax error
 +DETAIL:  source SQL:
-+SET SESSION AUTHORIZATION regress_rls_carol
-+                          ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/40283/_version_
++1	abc
++^
  SET row_security TO OFF;
  COPY copy_t FROM STDIN; --fail - permission denied.
 -ERROR:  permission denied for table copy_t
--SET row_security TO ON;
--COPY copy_t FROM STDIN; --fail - permission denied.
++ERROR:  user regress_rls_bob does not have INSERT privilege on relation copy_t
+ SET row_security TO ON;
+ COPY copy_t FROM STDIN; --fail - permission denied.
 -ERROR:  permission denied for table copy_t
 -RESET SESSION AUTHORIZATION;
--DROP TABLE copy_t;
--DROP TABLE copy_rel_to CASCADE;
++ERROR:  user regress_rls_bob does not have INSERT privilege on relation copy_t
++RESET ROLE;
+ DROP TABLE copy_t;
+ DROP TABLE copy_rel_to CASCADE;
 -NOTICE:  drop cascades to table copy_rel_to_child
---- Check WHERE CURRENT OF
+ -- Check WHERE CURRENT OF
 -SET SESSION AUTHORIZATION regress_rls_alice;
--CREATE TABLE current_check (currentid int, payload text, rlsuser text);
--GRANT ALL ON current_check TO PUBLIC;
--INSERT INTO current_check VALUES
--    (1, 'abc', 'regress_rls_bob'),
--    (2, 'bcd', 'regress_rls_bob'),
--    (3, 'cde', 'regress_rls_bob'),
--    (4, 'def', 'regress_rls_bob');
--CREATE POLICY p1 ON current_check FOR SELECT USING (currentid % 2 = 0);
--CREATE POLICY p2 ON current_check FOR DELETE USING (currentid = 4 AND rlsuser = current_user);
--CREATE POLICY p3 ON current_check FOR UPDATE USING (currentid = 4) WITH CHECK (rlsuser = current_user);
--ALTER TABLE current_check ENABLE ROW LEVEL SECURITY;
++SET ROLE regress_rls_alice;
+ CREATE TABLE current_check (currentid int, payload text, rlsuser text);
+ GRANT ALL ON current_check TO PUBLIC;
+ INSERT INTO current_check VALUES
+@@ -3797,7 +2750,7 @@
+ CREATE POLICY p2 ON current_check FOR DELETE USING (currentid = 4 AND rlsuser = current_user);
+ CREATE POLICY p3 ON current_check FOR UPDATE USING (currentid = 4) WITH CHECK (rlsuser = current_user);
+ ALTER TABLE current_check ENABLE ROW LEVEL SECURITY;
 -SET SESSION AUTHORIZATION regress_rls_bob;
---- Can SELECT even rows
--SELECT * FROM current_check;
-- currentid | payload |     rlsuser     
-------------+---------+-----------------
--         2 | bcd     | regress_rls_bob
--         4 | def     | regress_rls_bob
--(2 rows)
--
---- Cannot UPDATE row 2
--UPDATE current_check SET payload = payload || '_new' WHERE currentid = 2 RETURNING *;
-- currentid | payload | rlsuser 
-------------+---------+---------
--(0 rows)
--
--BEGIN;
--DECLARE current_check_cursor SCROLL CURSOR FOR SELECT * FROM current_check;
---- Returns rows that can be seen according to SELECT policy, like plain SELECT
---- above (even rows)
--FETCH ABSOLUTE 1 FROM current_check_cursor;
++SET ROLE regress_rls_bob;
+ -- Can SELECT even rows
+ SELECT * FROM current_check;
+  currentid | payload |     rlsuser     
+@@ -3814,112 +2767,74 @@
+ 
+ BEGIN;
+ DECLARE current_check_cursor SCROLL CURSOR FOR SELECT * FROM current_check;
++ERROR:  unimplemented: DECLARE SCROLL CURSOR
++HINT:  You have attempted to use a feature that is not yet implemented.
++See: https://go.crdb.dev/issue-v/77102/_version_
+ -- Returns rows that can be seen according to SELECT policy, like plain SELECT
+ -- above (even rows)
+ FETCH ABSOLUTE 1 FROM current_check_cursor;
 - currentid | payload |     rlsuser     
 ------------+---------+-----------------
 -         2 | bcd     | regress_rls_bob
 -(1 row)
 -
---- Still cannot UPDATE row 2 through cursor
--UPDATE current_check SET payload = payload || '_new' WHERE CURRENT OF current_check_cursor RETURNING *;
++ERROR:  current transaction is aborted, commands ignored until end of transaction block
+ -- Still cannot UPDATE row 2 through cursor
+ UPDATE current_check SET payload = payload || '_new' WHERE CURRENT OF current_check_cursor RETURNING *;
 - currentid | payload | rlsuser 
 ------------+---------+---------
 -(0 rows)
 -
---- Can update row 4 through cursor, which is the next visible row
--FETCH RELATIVE 1 FROM current_check_cursor;
++ERROR:  at or near "of": syntax error
++DETAIL:  source SQL:
++UPDATE current_check SET payload = payload || '_new' WHERE CURRENT OF current_check_cursor RETURNING *
++                                                                   ^
+ -- Can update row 4 through cursor, which is the next visible row
+ FETCH RELATIVE 1 FROM current_check_cursor;
 - currentid | payload |     rlsuser     
 ------------+---------+-----------------
 -         4 | def     | regress_rls_bob
 -(1 row)
 -
--UPDATE current_check SET payload = payload || '_new' WHERE CURRENT OF current_check_cursor RETURNING *;
++ERROR:  current transaction is aborted, commands ignored until end of transaction block
+ UPDATE current_check SET payload = payload || '_new' WHERE CURRENT OF current_check_cursor RETURNING *;
 - currentid | payload |     rlsuser     
 ------------+---------+-----------------
 -         4 | def_new | regress_rls_bob
 -(1 row)
 -
--SELECT * FROM current_check;
++ERROR:  at or near "of": syntax error
++DETAIL:  source SQL:
++UPDATE current_check SET payload = payload || '_new' WHERE CURRENT OF current_check_cursor RETURNING *
++                                                                   ^
+ SELECT * FROM current_check;
 - currentid | payload |     rlsuser     
 ------------+---------+-----------------
 -         2 | bcd     | regress_rls_bob
 -         4 | def_new | regress_rls_bob
 -(2 rows)
 -
---- Plan should be a subquery TID scan
--EXPLAIN (COSTS OFF) UPDATE current_check SET payload = payload WHERE CURRENT OF current_check_cursor;
++ERROR:  current transaction is aborted, commands ignored until end of transaction block
+ -- Plan should be a subquery TID scan
+ EXPLAIN (COSTS OFF) UPDATE current_check SET payload = payload WHERE CURRENT OF current_check_cursor;
 -                         QUERY PLAN                          
 --------------------------------------------------------------
 - Update on current_check
@@ -5716,583 +4799,548 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 -         Filter: ((currentid = 4) AND ((currentid % 2) = 0))
 -(4 rows)
 -
---- Similarly can only delete row 4
--FETCH ABSOLUTE 1 FROM current_check_cursor;
++ERROR:  at or near "off": syntax error
++DETAIL:  source SQL:
++EXPLAIN (COSTS OFF) UPDATE current_check SET payload = payload WHERE CURRENT OF current_check_cursor
++               ^
++HINT:  try \h <SELECTCLAUSE>
+ -- Similarly can only delete row 4
+ FETCH ABSOLUTE 1 FROM current_check_cursor;
 - currentid | payload |     rlsuser     
 ------------+---------+-----------------
 -         2 | bcd     | regress_rls_bob
 -(1 row)
 -
--DELETE FROM current_check WHERE CURRENT OF current_check_cursor RETURNING *;
++ERROR:  current transaction is aborted, commands ignored until end of transaction block
+ DELETE FROM current_check WHERE CURRENT OF current_check_cursor RETURNING *;
 - currentid | payload | rlsuser 
 ------------+---------+---------
 -(0 rows)
 -
--FETCH RELATIVE 1 FROM current_check_cursor;
++ERROR:  at or near "of": syntax error
++DETAIL:  source SQL:
++DELETE FROM current_check WHERE CURRENT OF current_check_cursor RETURNING *
++                                        ^
+ FETCH RELATIVE 1 FROM current_check_cursor;
 - currentid | payload |     rlsuser     
 ------------+---------+-----------------
 -         4 | def     | regress_rls_bob
 -(1 row)
 -
--DELETE FROM current_check WHERE CURRENT OF current_check_cursor RETURNING *;
++ERROR:  current transaction is aborted, commands ignored until end of transaction block
+ DELETE FROM current_check WHERE CURRENT OF current_check_cursor RETURNING *;
 - currentid | payload |     rlsuser     
 ------------+---------+-----------------
 -         4 | def_new | regress_rls_bob
 -(1 row)
 -
--SELECT * FROM current_check;
++ERROR:  at or near "of": syntax error
++DETAIL:  source SQL:
++DELETE FROM current_check WHERE CURRENT OF current_check_cursor RETURNING *
++                                        ^
+ SELECT * FROM current_check;
 - currentid | payload |     rlsuser     
 ------------+---------+-----------------
 -         2 | bcd     | regress_rls_bob
 -(1 row)
 -
--COMMIT;
----
---- check pg_stats view filtering
----
--SET row_security TO ON;
++ERROR:  current transaction is aborted, commands ignored until end of transaction block
+ COMMIT;
+ --
+ -- check pg_stats view filtering
+ --
+ SET row_security TO ON;
 -SET SESSION AUTHORIZATION regress_rls_alice;
--ANALYZE current_check;
---- Stats visible
--SELECT row_security_active('current_check');
++SET ROLE regress_rls_alice;
+ ANALYZE current_check;
+ -- Stats visible
+ SELECT row_security_active('current_check');
 - row_security_active 
 ----------------------
 - f
 -(1 row)
 -
--SELECT attname, most_common_vals FROM pg_stats
--  WHERE tablename = 'current_check'
--  ORDER BY 1;
++ERROR:  unknown function: row_security_active()
+ SELECT attname, most_common_vals FROM pg_stats
+   WHERE tablename = 'current_check'
+   ORDER BY 1;
 -  attname  | most_common_vals  
 ------------+-------------------
 - currentid | 
 - payload   | 
 - rlsuser   | {regress_rls_bob}
 -(3 rows)
--
++ attname | most_common_vals 
++---------+------------------
++(0 rows)
+ 
 -SET SESSION AUTHORIZATION regress_rls_bob;
---- Stats not visible
--SELECT row_security_active('current_check');
++SET ROLE regress_rls_bob;
+ -- Stats not visible
+ SELECT row_security_active('current_check');
 - row_security_active 
 ----------------------
 - t
 -(1 row)
 -
--SELECT attname, most_common_vals FROM pg_stats
--  WHERE tablename = 'current_check'
--  ORDER BY 1;
-- attname | most_common_vals 
-----------+------------------
--(0 rows)
--
----
---- Collation support
----
--BEGIN;
--CREATE TABLE coll_t (c) AS VALUES ('bar'::text);
--CREATE POLICY coll_p ON coll_t USING (c < ('foo'::text COLLATE "C"));
--ALTER TABLE coll_t ENABLE ROW LEVEL SECURITY;
--GRANT SELECT ON coll_t TO regress_rls_alice;
--SELECT (string_to_array(polqual, ':'))[7] AS inputcollid FROM pg_policy WHERE polrelid = 'coll_t'::regclass;
++ERROR:  unknown function: row_security_active()
+ SELECT attname, most_common_vals FROM pg_stats
+   WHERE tablename = 'current_check'
+   ORDER BY 1;
+@@ -3932,31 +2847,35 @@
+ --
+ BEGIN;
+ CREATE TABLE coll_t (c) AS VALUES ('bar'::text);
++NOTICE:  auto-committing transaction before processing DDL due to autocommit_before_ddl setting
++NOTICE:  CREATE TABLE ... AS does not copy over indexes, default expressions, or constraints; the new table has a hidden rowid primary key column
+ CREATE POLICY coll_p ON coll_t USING (c < ('foo'::text COLLATE "C"));
++ERROR:  invalid locale c: language: tag is not well-formed
+ ALTER TABLE coll_t ENABLE ROW LEVEL SECURITY;
+ GRANT SELECT ON coll_t TO regress_rls_alice;
+ SELECT (string_to_array(polqual, ':'))[7] AS inputcollid FROM pg_policy WHERE polrelid = 'coll_t'::regclass;
 -   inputcollid    
 -------------------
 - inputcollid 950 
 -(1 row)
--
++ inputcollid 
++-------------
++(0 rows)
+ 
 -SET SESSION AUTHORIZATION regress_rls_alice;
--SELECT * FROM coll_t;
++SET ROLE regress_rls_alice;
+ SELECT * FROM coll_t;
 -  c  
 ------
 - bar
 -(1 row)
--
--ROLLBACK;
----
---- Shared Object Dependencies
----
++ c 
++---
++(0 rows)
+ 
+ ROLLBACK;
++WARNING:  there is no transaction in progress
+ --
+ -- Shared Object Dependencies
+ --
 -RESET SESSION AUTHORIZATION;
--BEGIN;
--CREATE ROLE regress_rls_eve;
--CREATE ROLE regress_rls_frank;
--CREATE TABLE tbl1 (c) AS VALUES ('bar'::text);
--GRANT SELECT ON TABLE tbl1 TO regress_rls_eve;
--CREATE POLICY P ON tbl1 TO regress_rls_eve, regress_rls_frank USING (true);
--SELECT refclassid::regclass, deptype
--  FROM pg_depend
--  WHERE classid = 'pg_policy'::regclass
--  AND refobjid = 'tbl1'::regclass;
-- refclassid | deptype 
--------------+---------
++RESET ROLE;
+ BEGIN;
+ CREATE ROLE regress_rls_eve;
++NOTICE:  auto-committing transaction before processing DDL due to autocommit_before_ddl setting
+ CREATE ROLE regress_rls_frank;
+ CREATE TABLE tbl1 (c) AS VALUES ('bar'::text);
++NOTICE:  CREATE TABLE ... AS does not copy over indexes, default expressions, or constraints; the new table has a hidden rowid primary key column
+ GRANT SELECT ON TABLE tbl1 TO regress_rls_eve;
+ CREATE POLICY P ON tbl1 TO regress_rls_eve, regress_rls_frank USING (true);
+ SELECT refclassid::regclass, deptype
+@@ -3965,8 +2884,7 @@
+   AND refobjid = 'tbl1'::regclass;
+  refclassid | deptype 
+ ------------+---------
 - pg_class   | a
 -(1 row)
--
--SELECT refclassid::regclass, deptype
--  FROM pg_shdepend
--  WHERE classid = 'pg_policy'::regclass
--  AND refobjid IN ('regress_rls_eve'::regrole, 'regress_rls_frank'::regrole);
-- refclassid | deptype 
--------------+---------
++(0 rows)
+ 
+ SELECT refclassid::regclass, deptype
+   FROM pg_shdepend
+@@ -3974,48 +2892,58 @@
+   AND refobjid IN ('regress_rls_eve'::regrole, 'regress_rls_frank'::regrole);
+  refclassid | deptype 
+ ------------+---------
 - pg_authid  | r
 - pg_authid  | r
 -(2 rows)
--
--SAVEPOINT q;
--DROP ROLE regress_rls_eve; --fails due to dependency on POLICY p
--ERROR:  role "regress_rls_eve" cannot be dropped because some objects depend on it
++(0 rows)
+ 
+ SAVEPOINT q;
++WARNING:  there is no transaction in progress
+ DROP ROLE regress_rls_eve; --fails due to dependency on POLICY p
+ ERROR:  role "regress_rls_eve" cannot be dropped because some objects depend on it
 -DETAIL:  privileges for table tbl1
 -target of policy p on table tbl1
--ROLLBACK TO q;
--ALTER POLICY p ON tbl1 TO regress_rls_frank USING (true);
--SAVEPOINT q;
--DROP ROLE regress_rls_eve; --fails due to dependency on GRANT SELECT
++DETAIL:  target of policy "p" on table "tbl1"
+ ROLLBACK TO q;
++ERROR:  savepoint "q" does not exist
+ ALTER POLICY p ON tbl1 TO regress_rls_frank USING (true);
+ SAVEPOINT q;
++WARNING:  there is no transaction in progress
+ DROP ROLE regress_rls_eve; --fails due to dependency on GRANT SELECT
 -ERROR:  role "regress_rls_eve" cannot be dropped because some objects depend on it
 -DETAIL:  privileges for table tbl1
--ROLLBACK TO q;
--REVOKE ALL ON TABLE tbl1 FROM regress_rls_eve;
--SAVEPOINT q;
--DROP ROLE regress_rls_eve; --succeeds
--ROLLBACK TO q;
--SAVEPOINT q;
--DROP ROLE regress_rls_frank; --fails due to dependency on POLICY p
--ERROR:  role "regress_rls_frank" cannot be dropped because some objects depend on it
++ERROR:  cannot drop role/user regress_rls_eve: grants still exist on root.regress_rls_schema.tbl1
+ ROLLBACK TO q;
++ERROR:  savepoint "q" does not exist
+ REVOKE ALL ON TABLE tbl1 FROM regress_rls_eve;
+ SAVEPOINT q;
++WARNING:  there is no transaction in progress
+ DROP ROLE regress_rls_eve; --succeeds
+ ROLLBACK TO q;
++ERROR:  savepoint "q" does not exist
+ SAVEPOINT q;
++WARNING:  there is no transaction in progress
+ DROP ROLE regress_rls_frank; --fails due to dependency on POLICY p
+ ERROR:  role "regress_rls_frank" cannot be dropped because some objects depend on it
 -DETAIL:  target of policy p on table tbl1
--ROLLBACK TO q;
--DROP POLICY p ON tbl1;
--SAVEPOINT q;
--DROP ROLE regress_rls_frank; -- succeeds
--ROLLBACK TO q;
--ROLLBACK; -- cleanup
----
---- Policy expression handling
----
--BEGIN;
--CREATE TABLE t (c) AS VALUES ('bar'::text);
--CREATE POLICY p ON t USING (max(c)); -- fails: aggregate functions are not allowed in policy expressions
++DETAIL:  target of policy "p" on table "tbl1"
+ ROLLBACK TO q;
++ERROR:  savepoint "q" does not exist
+ DROP POLICY p ON tbl1;
+ SAVEPOINT q;
++WARNING:  there is no transaction in progress
+ DROP ROLE regress_rls_frank; -- succeeds
+ ROLLBACK TO q;
++ERROR:  savepoint "q" does not exist
+ ROLLBACK; -- cleanup
++WARNING:  there is no transaction in progress
+ --
+ -- Policy expression handling
+ --
+ BEGIN;
+ CREATE TABLE t (c) AS VALUES ('bar'::text);
++NOTICE:  auto-committing transaction before processing DDL due to autocommit_before_ddl setting
++NOTICE:  CREATE TABLE ... AS does not copy over indexes, default expressions, or constraints; the new table has a hidden rowid primary key column
+ CREATE POLICY p ON t USING (max(c)); -- fails: aggregate functions are not allowed in policy expressions
 -ERROR:  aggregate functions are not allowed in policy expressions
--ROLLBACK;
----
---- Non-target relations are only subject to SELECT policies
----
++ERROR:  max(): aggregate functions are not allowed in POLICY USING
+ ROLLBACK;
++WARNING:  there is no transaction in progress
+ --
+ -- Non-target relations are only subject to SELECT policies
+ --
 -SET SESSION AUTHORIZATION regress_rls_alice;
--CREATE TABLE r1 (a int);
--CREATE TABLE r2 (a int);
--INSERT INTO r1 VALUES (10), (20);
--INSERT INTO r2 VALUES (10), (20);
--GRANT ALL ON r1, r2 TO regress_rls_bob;
--CREATE POLICY p1 ON r1 USING (true);
--ALTER TABLE r1 ENABLE ROW LEVEL SECURITY;
--CREATE POLICY p1 ON r2 FOR SELECT USING (true);
--CREATE POLICY p2 ON r2 FOR INSERT WITH CHECK (false);
--CREATE POLICY p3 ON r2 FOR UPDATE USING (false);
--CREATE POLICY p4 ON r2 FOR DELETE USING (false);
--ALTER TABLE r2 ENABLE ROW LEVEL SECURITY;
++SET ROLE regress_rls_alice;
+ CREATE TABLE r1 (a int);
+ CREATE TABLE r2 (a int);
+ INSERT INTO r1 VALUES (10), (20);
+@@ -4028,7 +2956,7 @@
+ CREATE POLICY p3 ON r2 FOR UPDATE USING (false);
+ CREATE POLICY p4 ON r2 FOR DELETE USING (false);
+ ALTER TABLE r2 ENABLE ROW LEVEL SECURITY;
 -SET SESSION AUTHORIZATION regress_rls_bob;
--SELECT * FROM r1;
-- a  
------
-- 10
-- 20
--(2 rows)
--
--SELECT * FROM r2;
-- a  
------
-- 10
-- 20
--(2 rows)
--
---- r2 is read-only
--INSERT INTO r2 VALUES (2); -- Not allowed
--ERROR:  new row violates row-level security policy for table "r2"
--UPDATE r2 SET a = 2 RETURNING *; -- Updates nothing
-- a 
-----
--(0 rows)
--
--DELETE FROM r2 RETURNING *; -- Deletes nothing
-- a 
-----
--(0 rows)
--
---- r2 can be used as a non-target relation in DML
--INSERT INTO r1 SELECT a + 1 FROM r2 RETURNING *; -- OK
-- a  
------
-- 11
-- 21
--(2 rows)
--
--UPDATE r1 SET a = r2.a + 2 FROM r2 WHERE r1.a = r2.a RETURNING *; -- OK
-- a  | a  
------+----
-- 12 | 10
-- 22 | 20
--(2 rows)
--
--DELETE FROM r1 USING r2 WHERE r1.a = r2.a + 2 RETURNING *; -- OK
-- a  | a  
------+----
-- 12 | 10
-- 22 | 20
--(2 rows)
--
--SELECT * FROM r1;
-- a  
------
-- 11
-- 21
--(2 rows)
--
--SELECT * FROM r2;
-- a  
------
-- 10
-- 20
--(2 rows)
--
++SET ROLE regress_rls_bob;
+ SELECT * FROM r1;
+  a  
+ ----
+@@ -4092,13 +3020,13 @@
+  20
+ (2 rows)
+ 
 -SET SESSION AUTHORIZATION regress_rls_alice;
--DROP TABLE r1;
--DROP TABLE r2;
----
---- FORCE ROW LEVEL SECURITY applies RLS to owners too
----
++SET ROLE regress_rls_alice;
+ DROP TABLE r1;
+ DROP TABLE r2;
+ --
+ -- FORCE ROW LEVEL SECURITY applies RLS to owners too
+ --
 -SET SESSION AUTHORIZATION regress_rls_alice;
--SET row_security = on;
--CREATE TABLE r1 (a int);
--INSERT INTO r1 VALUES (10), (20);
--CREATE POLICY p1 ON r1 USING (false);
--ALTER TABLE r1 ENABLE ROW LEVEL SECURITY;
--ALTER TABLE r1 FORCE ROW LEVEL SECURITY;
---- No error, but no rows
--TABLE r1;
-- a 
-----
--(0 rows)
--
---- RLS error
--INSERT INTO r1 VALUES (1);
--ERROR:  new row violates row-level security policy for table "r1"
---- No error (unable to see any rows to update)
--UPDATE r1 SET a = 1;
--TABLE r1;
-- a 
-----
--(0 rows)
--
---- No error (unable to see any rows to delete)
--DELETE FROM r1;
--TABLE r1;
-- a 
-----
--(0 rows)
--
--SET row_security = off;
---- these all fail, would be affected by RLS
--TABLE r1;
++SET ROLE regress_rls_alice;
+ SET row_security = on;
+ CREATE TABLE r1 (a int);
+ INSERT INTO r1 VALUES (10), (20);
+@@ -4131,19 +3059,17 @@
+ SET row_security = off;
+ -- these all fail, would be affected by RLS
+ TABLE r1;
 -ERROR:  query would be affected by row-level security policy for table "r1"
 -HINT:  To disable the policy for the table's owner, use ALTER TABLE NO FORCE ROW LEVEL SECURITY.
--UPDATE r1 SET a = 1;
++ a 
++---
++(0 rows)
++
+ UPDATE r1 SET a = 1;
 -ERROR:  query would be affected by row-level security policy for table "r1"
 -HINT:  To disable the policy for the table's owner, use ALTER TABLE NO FORCE ROW LEVEL SECURITY.
--DELETE FROM r1;
+ DELETE FROM r1;
 -ERROR:  query would be affected by row-level security policy for table "r1"
 -HINT:  To disable the policy for the table's owner, use ALTER TABLE NO FORCE ROW LEVEL SECURITY.
--DROP TABLE r1;
----
---- FORCE ROW LEVEL SECURITY does not break RI
----
+ DROP TABLE r1;
+ --
+ -- FORCE ROW LEVEL SECURITY does not break RI
+ --
 -SET SESSION AUTHORIZATION regress_rls_alice;
--SET row_security = on;
--CREATE TABLE r1 (a int PRIMARY KEY);
--CREATE TABLE r2 (a int REFERENCES r1);
--INSERT INTO r1 VALUES (10), (20);
--INSERT INTO r2 VALUES (10), (20);
---- Create policies on r2 which prevent the
---- owner from seeing any rows, but RI should
---- still see them.
--CREATE POLICY p1 ON r2 USING (false);
--ALTER TABLE r2 ENABLE ROW LEVEL SECURITY;
--ALTER TABLE r2 FORCE ROW LEVEL SECURITY;
---- Errors due to rows in r2
--DELETE FROM r1;
++SET ROLE regress_rls_alice;
+ SET row_security = on;
+ CREATE TABLE r1 (a int PRIMARY KEY);
+ CREATE TABLE r2 (a int REFERENCES r1);
+@@ -4157,7 +3083,7 @@
+ ALTER TABLE r2 FORCE ROW LEVEL SECURITY;
+ -- Errors due to rows in r2
+ DELETE FROM r1;
 -ERROR:  update or delete on table "r1" violates foreign key constraint "r2_a_fkey" on table "r2"
--DETAIL:  Key (a)=(10) is still referenced from table "r2".
---- Reset r2 to no-RLS
--DROP POLICY p1 ON r2;
--ALTER TABLE r2 NO FORCE ROW LEVEL SECURITY;
--ALTER TABLE r2 DISABLE ROW LEVEL SECURITY;
---- clean out r2 for INSERT test below
--DELETE FROM r2;
---- Change r1 to not allow rows to be seen
--CREATE POLICY p1 ON r1 USING (false);
--ALTER TABLE r1 ENABLE ROW LEVEL SECURITY;
--ALTER TABLE r1 FORCE ROW LEVEL SECURITY;
---- No rows seen
--TABLE r1;
-- a 
-----
--(0 rows)
--
---- No error, RI still sees that row exists in r1
--INSERT INTO r2 VALUES (10);
--DROP TABLE r2;
--DROP TABLE r1;
---- Ensure cascaded DELETE works
--CREATE TABLE r1 (a int PRIMARY KEY);
--CREATE TABLE r2 (a int REFERENCES r1 ON DELETE CASCADE);
--INSERT INTO r1 VALUES (10), (20);
--INSERT INTO r2 VALUES (10), (20);
---- Create policies on r2 which prevent the
---- owner from seeing any rows, but RI should
---- still see them.
--CREATE POLICY p1 ON r2 USING (false);
--ALTER TABLE r2 ENABLE ROW LEVEL SECURITY;
--ALTER TABLE r2 FORCE ROW LEVEL SECURITY;
---- Deletes all records from both
--DELETE FROM r1;
---- Remove FORCE from r2
--ALTER TABLE r2 NO FORCE ROW LEVEL SECURITY;
---- As owner, we now bypass RLS
---- verify no rows in r2 now
--TABLE r2;
-- a 
-----
--(0 rows)
--
--DROP TABLE r2;
--DROP TABLE r1;
---- Ensure cascaded UPDATE works
--CREATE TABLE r1 (a int PRIMARY KEY);
--CREATE TABLE r2 (a int REFERENCES r1 ON UPDATE CASCADE);
--INSERT INTO r1 VALUES (10), (20);
--INSERT INTO r2 VALUES (10), (20);
---- Create policies on r2 which prevent the
---- owner from seeing any rows, but RI should
---- still see them.
--CREATE POLICY p1 ON r2 USING (false);
--ALTER TABLE r2 ENABLE ROW LEVEL SECURITY;
--ALTER TABLE r2 FORCE ROW LEVEL SECURITY;
---- Updates records in both
--UPDATE r1 SET a = a+5;
---- Remove FORCE from r2
--ALTER TABLE r2 NO FORCE ROW LEVEL SECURITY;
---- As owner, we now bypass RLS
---- verify records in r2 updated
--TABLE r2;
-- a  
------
++ERROR:  delete on table "r1" violates foreign key constraint "r2_a_fkey" on table "r2"
+ DETAIL:  Key (a)=(10) is still referenced from table "r2".
+ -- Reset r2 to no-RLS
+ DROP POLICY p1 ON r2;
+@@ -4216,6 +3142,7 @@
+ ALTER TABLE r2 FORCE ROW LEVEL SECURITY;
+ -- Updates records in both
+ UPDATE r1 SET a = a+5;
++ERROR:  new row violates row-level security policy for table "r2"
+ -- Remove FORCE from r2
+ ALTER TABLE r2 NO FORCE ROW LEVEL SECURITY;
+ -- As owner, we now bypass RLS
+@@ -4223,8 +3150,8 @@
+ TABLE r2;
+  a  
+ ----
 - 15
 - 25
--(2 rows)
--
--DROP TABLE r2;
--DROP TABLE r1;
----
---- Test INSERT+RETURNING applies SELECT policies as
---- WithCheckOptions (meaning an error is thrown)
----
++ 10
++ 20
+ (2 rows)
+ 
+ DROP TABLE r2;
+@@ -4233,7 +3160,7 @@
+ -- Test INSERT+RETURNING applies SELECT policies as
+ -- WithCheckOptions (meaning an error is thrown)
+ --
 -SET SESSION AUTHORIZATION regress_rls_alice;
--SET row_security = on;
--CREATE TABLE r1 (a int);
--CREATE POLICY p1 ON r1 FOR SELECT USING (false);
--CREATE POLICY p2 ON r1 FOR INSERT WITH CHECK (true);
--ALTER TABLE r1 ENABLE ROW LEVEL SECURITY;
--ALTER TABLE r1 FORCE ROW LEVEL SECURITY;
---- Works fine
--INSERT INTO r1 VALUES (10), (20);
---- No error, but no rows
--TABLE r1;
-- a 
-----
--(0 rows)
--
--SET row_security = off;
---- fail, would be affected by RLS
--TABLE r1;
++SET ROLE regress_rls_alice;
+ SET row_security = on;
+ CREATE TABLE r1 (a int);
+ CREATE POLICY p1 ON r1 FOR SELECT USING (false);
+@@ -4251,18 +3178,25 @@
+ SET row_security = off;
+ -- fail, would be affected by RLS
+ TABLE r1;
 -ERROR:  query would be affected by row-level security policy for table "r1"
 -HINT:  To disable the policy for the table's owner, use ALTER TABLE NO FORCE ROW LEVEL SECURITY.
--SET row_security = on;
---- Error
--INSERT INTO r1 VALUES (10), (20) RETURNING *;
++ a 
++---
++(0 rows)
++
+ SET row_security = on;
+ -- Error
+ INSERT INTO r1 VALUES (10), (20) RETURNING *;
 -ERROR:  new row violates row-level security policy for table "r1"
--DROP TABLE r1;
----
---- Test UPDATE+RETURNING applies SELECT policies as
---- WithCheckOptions (meaning an error is thrown)
----
++ a  
++----
++ 10
++ 20
++(2 rows)
++
+ DROP TABLE r1;
+ --
+ -- Test UPDATE+RETURNING applies SELECT policies as
+ -- WithCheckOptions (meaning an error is thrown)
+ --
 -SET SESSION AUTHORIZATION regress_rls_alice;
--SET row_security = on;
--CREATE TABLE r1 (a int PRIMARY KEY);
--CREATE POLICY p1 ON r1 FOR SELECT USING (a < 20);
--CREATE POLICY p2 ON r1 FOR UPDATE USING (a < 20) WITH CHECK (true);
--CREATE POLICY p3 ON r1 FOR INSERT WITH CHECK (true);
--INSERT INTO r1 VALUES (10);
--ALTER TABLE r1 ENABLE ROW LEVEL SECURITY;
--ALTER TABLE r1 FORCE ROW LEVEL SECURITY;
---- Works fine
--UPDATE r1 SET a = 30;
---- Show updated rows
--ALTER TABLE r1 NO FORCE ROW LEVEL SECURITY;
--TABLE r1;
-- a  
------
++SET ROLE regress_rls_alice;
+ SET row_security = on;
+ CREATE TABLE r1 (a int PRIMARY KEY);
+ CREATE POLICY p1 ON r1 FOR SELECT USING (a < 20);
+@@ -4273,12 +3207,13 @@
+ ALTER TABLE r1 FORCE ROW LEVEL SECURITY;
+ -- Works fine
+ UPDATE r1 SET a = 30;
++ERROR:  new row violates row-level security policy for table "r1"
+ -- Show updated rows
+ ALTER TABLE r1 NO FORCE ROW LEVEL SECURITY;
+ TABLE r1;
+  a  
+ ----
 - 30
--(1 row)
--
---- reset value in r1 for test with RETURNING
--UPDATE r1 SET a = 10;
---- Verify row reset
--TABLE r1;
-- a  
------
-- 10
--(1 row)
--
--ALTER TABLE r1 FORCE ROW LEVEL SECURITY;
---- Error
--UPDATE r1 SET a = 30 RETURNING *;
++ 10
+ (1 row)
+ 
+ -- reset value in r1 for test with RETURNING
+@@ -4297,39 +3232,46 @@
+ -- UPDATE path of INSERT ... ON CONFLICT DO UPDATE should also error out
+ INSERT INTO r1 VALUES (10)
+     ON CONFLICT (a) DO UPDATE SET a = 30 RETURNING *;
 -ERROR:  new row violates row-level security policy for table "r1"
---- UPDATE path of INSERT ... ON CONFLICT DO UPDATE should also error out
--INSERT INTO r1 VALUES (10)
--    ON CONFLICT (a) DO UPDATE SET a = 30 RETURNING *;
++ a  
++----
++ 30
++(1 row)
++
+ -- Should still error out without RETURNING (use of arbiter always requires
+ -- SELECT permissions)
+ INSERT INTO r1 VALUES (10)
+     ON CONFLICT (a) DO UPDATE SET a = 30;
 -ERROR:  new row violates row-level security policy for table "r1"
---- Should still error out without RETURNING (use of arbiter always requires
---- SELECT permissions)
--INSERT INTO r1 VALUES (10)
--    ON CONFLICT (a) DO UPDATE SET a = 30;
+ INSERT INTO r1 VALUES (10)
+     ON CONFLICT ON CONSTRAINT r1_pkey DO UPDATE SET a = 30;
 -ERROR:  new row violates row-level security policy for table "r1"
--INSERT INTO r1 VALUES (10)
--    ON CONFLICT ON CONSTRAINT r1_pkey DO UPDATE SET a = 30;
--ERROR:  new row violates row-level security policy for table "r1"
--DROP TABLE r1;
---- Check dependency handling
++ERROR:  duplicate key value violates unique constraint "r1_pkey"
++DETAIL:  Key (a)=(30) already exists.
+ DROP TABLE r1;
+ -- Check dependency handling
 -RESET SESSION AUTHORIZATION;
--CREATE TABLE dep1 (c1 int);
--CREATE TABLE dep2 (c1 int);
--CREATE POLICY dep_p1 ON dep1 TO regress_rls_bob USING (c1 > (select max(dep2.c1) from dep2));
--ALTER POLICY dep_p1 ON dep1 TO regress_rls_bob,regress_rls_carol;
---- Should return one
--SELECT count(*) = 1 FROM pg_depend
--				   WHERE objid = (SELECT oid FROM pg_policy WHERE polname = 'dep_p1')
--					 AND refobjid = (SELECT oid FROM pg_class WHERE relname = 'dep2');
-- ?column? 
------------
++RESET ROLE;
+ CREATE TABLE dep1 (c1 int);
+ CREATE TABLE dep2 (c1 int);
+ CREATE POLICY dep_p1 ON dep1 TO regress_rls_bob USING (c1 > (select max(dep2.c1) from dep2));
++ERROR:  no data source matches prefix: dep2 in this context
+ ALTER POLICY dep_p1 ON dep1 TO regress_rls_bob,regress_rls_carol;
++ERROR:  policy "dep_p1" for table "dep1" does not exist
+ -- Should return one
+ SELECT count(*) = 1 FROM pg_depend
+ 				   WHERE objid = (SELECT oid FROM pg_policy WHERE polname = 'dep_p1')
+ 					 AND refobjid = (SELECT oid FROM pg_class WHERE relname = 'dep2');
+  ?column? 
+ ----------
 - t
--(1 row)
--
--ALTER POLICY dep_p1 ON dep1 USING (true);
---- Should return one
--SELECT count(*) = 1 FROM pg_shdepend
--				   WHERE objid = (SELECT oid FROM pg_policy WHERE polname = 'dep_p1')
--					 AND refobjid = (SELECT oid FROM pg_authid WHERE rolname = 'regress_rls_bob');
-- ?column? 
------------
++ f
+ (1 row)
+ 
+ ALTER POLICY dep_p1 ON dep1 USING (true);
++ERROR:  policy "dep_p1" for table "dep1" does not exist
+ -- Should return one
+ SELECT count(*) = 1 FROM pg_shdepend
+ 				   WHERE objid = (SELECT oid FROM pg_policy WHERE polname = 'dep_p1')
+ 					 AND refobjid = (SELECT oid FROM pg_authid WHERE rolname = 'regress_rls_bob');
+  ?column? 
+ ----------
 - t
--(1 row)
--
---- Should return one
--SELECT count(*) = 1 FROM pg_shdepend
--				   WHERE objid = (SELECT oid FROM pg_policy WHERE polname = 'dep_p1')
--					 AND refobjid = (SELECT oid FROM pg_authid WHERE rolname = 'regress_rls_carol');
-- ?column? 
------------
++ f
+ (1 row)
+ 
+ -- Should return one
+@@ -4338,7 +3280,7 @@
+ 					 AND refobjid = (SELECT oid FROM pg_authid WHERE rolname = 'regress_rls_carol');
+  ?column? 
+ ----------
 - t
--(1 row)
--
---- Should return zero
--SELECT count(*) = 0 FROM pg_depend
--				   WHERE objid = (SELECT oid FROM pg_policy WHERE polname = 'dep_p1')
--					 AND refobjid = (SELECT oid FROM pg_class WHERE relname = 'dep2');
-- ?column? 
------------
-- t
--(1 row)
--
---- DROP OWNED BY testing
++ f
+ (1 row)
+ 
+ -- Should return zero
+@@ -4351,15 +3293,19 @@
+ (1 row)
+ 
+ -- DROP OWNED BY testing
 -RESET SESSION AUTHORIZATION;
--CREATE ROLE regress_rls_dob_role1;
--CREATE ROLE regress_rls_dob_role2;
--CREATE TABLE dob_t1 (c1 int);
--CREATE TABLE dob_t2 (c1 int) PARTITION BY RANGE (c1);
--CREATE POLICY p1 ON dob_t1 TO regress_rls_dob_role1 USING (true);
--DROP OWNED BY regress_rls_dob_role1;
--DROP POLICY p1 ON dob_t1; -- should fail, already gone
++RESET ROLE;
+ CREATE ROLE regress_rls_dob_role1;
+ CREATE ROLE regress_rls_dob_role2;
+ CREATE TABLE dob_t1 (c1 int);
+ CREATE TABLE dob_t2 (c1 int) PARTITION BY RANGE (c1);
++ERROR:  at or near "EOF": syntax error
++DETAIL:  source SQL:
++CREATE TABLE dob_t2 (c1 int) PARTITION BY RANGE (c1)
++                                                    ^
++HINT:  try \h CREATE TABLE
+ CREATE POLICY p1 ON dob_t1 TO regress_rls_dob_role1 USING (true);
+ DROP OWNED BY regress_rls_dob_role1;
+ DROP POLICY p1 ON dob_t1; -- should fail, already gone
 -ERROR:  policy "p1" for table "dob_t1" does not exist
--CREATE POLICY p1 ON dob_t1 TO regress_rls_dob_role1,regress_rls_dob_role2 USING (true);
--DROP OWNED BY regress_rls_dob_role1;
--DROP POLICY p1 ON dob_t1; -- should succeed
---- same cases with duplicate polroles entries
--CREATE POLICY p1 ON dob_t1 TO regress_rls_dob_role1,regress_rls_dob_role1 USING (true);
--DROP OWNED BY regress_rls_dob_role1;
--DROP POLICY p1 ON dob_t1; -- should fail, already gone
+ CREATE POLICY p1 ON dob_t1 TO regress_rls_dob_role1,regress_rls_dob_role2 USING (true);
+ DROP OWNED BY regress_rls_dob_role1;
+ DROP POLICY p1 ON dob_t1; -- should succeed
+@@ -4367,14 +3313,15 @@
+ CREATE POLICY p1 ON dob_t1 TO regress_rls_dob_role1,regress_rls_dob_role1 USING (true);
+ DROP OWNED BY regress_rls_dob_role1;
+ DROP POLICY p1 ON dob_t1; -- should fail, already gone
 -ERROR:  policy "p1" for table "dob_t1" does not exist
--CREATE POLICY p1 ON dob_t1 TO regress_rls_dob_role1,regress_rls_dob_role1,regress_rls_dob_role2 USING (true);
--DROP OWNED BY regress_rls_dob_role1;
--DROP POLICY p1 ON dob_t1; -- should succeed
---- partitioned target
--CREATE POLICY p1 ON dob_t2 TO regress_rls_dob_role1,regress_rls_dob_role2 USING (true);
--DROP OWNED BY regress_rls_dob_role1;
--DROP POLICY p1 ON dob_t2; -- should succeed
--DROP USER regress_rls_dob_role1;
--DROP USER regress_rls_dob_role2;
---- Bug #15708: view + table with RLS should check policies as view owner
--CREATE TABLE ref_tbl (a int);
--INSERT INTO ref_tbl VALUES (1);
--CREATE TABLE rls_tbl (a int);
--INSERT INTO rls_tbl VALUES (10);
--ALTER TABLE rls_tbl ENABLE ROW LEVEL SECURITY;
--CREATE POLICY p1 ON rls_tbl USING (EXISTS (SELECT 1 FROM ref_tbl));
--GRANT SELECT ON ref_tbl TO regress_rls_bob;
--GRANT SELECT ON rls_tbl TO regress_rls_bob;
--CREATE VIEW rls_view AS SELECT * FROM rls_tbl;
--ALTER VIEW rls_view OWNER TO regress_rls_bob;
--GRANT SELECT ON rls_view TO regress_rls_alice;
+ CREATE POLICY p1 ON dob_t1 TO regress_rls_dob_role1,regress_rls_dob_role1,regress_rls_dob_role2 USING (true);
+ DROP OWNED BY regress_rls_dob_role1;
+ DROP POLICY p1 ON dob_t1; -- should succeed
+ -- partitioned target
+ CREATE POLICY p1 ON dob_t2 TO regress_rls_dob_role1,regress_rls_dob_role2 USING (true);
++ERROR:  relation "dob_t2" does not exist
+ DROP OWNED BY regress_rls_dob_role1;
+ DROP POLICY p1 ON dob_t2; -- should succeed
++ERROR:  relation "dob_t2" does not exist
+ DROP USER regress_rls_dob_role1;
+ DROP USER regress_rls_dob_role2;
+ -- Bug #15708: view + table with RLS should check policies as view owner
+@@ -4384,81 +3331,97 @@
+ INSERT INTO rls_tbl VALUES (10);
+ ALTER TABLE rls_tbl ENABLE ROW LEVEL SECURITY;
+ CREATE POLICY p1 ON rls_tbl USING (EXISTS (SELECT 1 FROM ref_tbl));
++ERROR:  variable sub-expressions are not allowed in POLICY USING
+ GRANT SELECT ON ref_tbl TO regress_rls_bob;
+ GRANT SELECT ON rls_tbl TO regress_rls_bob;
+ CREATE VIEW rls_view AS SELECT * FROM rls_tbl;
+ ALTER VIEW rls_view OWNER TO regress_rls_bob;
+ GRANT SELECT ON rls_view TO regress_rls_alice;
 -SET SESSION AUTHORIZATION regress_rls_alice;
--SELECT * FROM ref_tbl; -- Permission denied
++SET ROLE regress_rls_alice;
+ SELECT * FROM ref_tbl; -- Permission denied
 -ERROR:  permission denied for table ref_tbl
--SELECT * FROM rls_tbl; -- Permission denied
++ERROR:  user regress_rls_alice does not have SELECT privilege on relation ref_tbl
+ SELECT * FROM rls_tbl; -- Permission denied
 -ERROR:  permission denied for table rls_tbl
--SELECT * FROM rls_view; -- OK
++ERROR:  user regress_rls_alice does not have SELECT privilege on relation rls_tbl
+ SELECT * FROM rls_view; -- OK
 - a  
 -----
 - 10
 -(1 row)
--
++ a 
++---
++(0 rows)
+ 
 -RESET SESSION AUTHORIZATION;
--DROP VIEW rls_view;
--DROP TABLE rls_tbl;
--DROP TABLE ref_tbl;
---- Leaky operator test
--CREATE TABLE rls_tbl (a int);
--INSERT INTO rls_tbl SELECT x/10 FROM generate_series(1, 100) x;
--ANALYZE rls_tbl;
--ALTER TABLE rls_tbl ENABLE ROW LEVEL SECURITY;
--GRANT SELECT ON rls_tbl TO regress_rls_alice;
++RESET ROLE;
+ DROP VIEW rls_view;
+ DROP TABLE rls_tbl;
+ DROP TABLE ref_tbl;
+ -- Leaky operator test
+ CREATE TABLE rls_tbl (a int);
+ INSERT INTO rls_tbl SELECT x/10 FROM generate_series(1, 100) x;
++ERROR:  unsupported binary operator: <int> / <int> (returning <int>)
+ ANALYZE rls_tbl;
+ ALTER TABLE rls_tbl ENABLE ROW LEVEL SECURITY;
+ GRANT SELECT ON rls_tbl TO regress_rls_alice;
 -SET SESSION AUTHORIZATION regress_rls_alice;
--CREATE FUNCTION op_leak(int, int) RETURNS bool
--    AS 'BEGIN RAISE NOTICE ''op_leak => %, %'', $1, $2; RETURN $1 < $2; END'
--    LANGUAGE plpgsql;
--CREATE OPERATOR <<< (procedure = op_leak, leftarg = int, rightarg = int,
--                     restrict = scalarltsel);
--SELECT * FROM rls_tbl WHERE a <<< 1000;
++SET ROLE regress_rls_alice;
+ CREATE FUNCTION op_leak(int, int) RETURNS bool
+     AS 'BEGIN RAISE NOTICE ''op_leak => %, %'', $1, $2; RETURN $1 < $2; END'
+     LANGUAGE plpgsql;
++ERROR:  no value provided for placeholder: $1
+ CREATE OPERATOR <<< (procedure = op_leak, leftarg = int, rightarg = int,
+                      restrict = scalarltsel);
++ERROR:  at or near "<": syntax error: unimplemented: this syntax
++DETAIL:  source SQL:
++CREATE OPERATOR <<< (procedure = op_leak, leftarg = int, rightarg = int,
++                ^
++HINT:  You have attempted to use a feature that is not yet implemented.
++See: https://go.crdb.dev/issue-v/65017/_version_
+ SELECT * FROM rls_tbl WHERE a <<< 1000;
 - a 
 ----
 -(0 rows)
 -
--DROP OPERATOR <<< (int, int);
--DROP FUNCTION op_leak(int, int);
++ERROR:  at or near "<": syntax error
++DETAIL:  source SQL:
++SELECT * FROM rls_tbl WHERE a <<< 1000
++                                ^
+ DROP OPERATOR <<< (int, int);
++ERROR:  at or near "<": syntax error: unimplemented: this syntax
++DETAIL:  source SQL:
++DROP OPERATOR <<< (int, int)
++              ^
++HINT:  You have attempted to use a feature that is not yet implemented.
++
++Please check the public issue tracker to check whether this problem is
++already tracked. If you cannot find it there, please report the error
++with details by creating a new issue.
++
++If you would rather not post publicly, please contact us directly
++using the support form.
++
++We appreciate your feedback.
++
+ DROP FUNCTION op_leak(int, int);
 -RESET SESSION AUTHORIZATION;
--DROP TABLE rls_tbl;
---- Bug #16006: whole-row Vars in a policy don't play nice with sub-selects
++ERROR:  unknown function: op_leak()
++RESET ROLE;
+ DROP TABLE rls_tbl;
+ -- Bug #16006: whole-row Vars in a policy don't play nice with sub-selects
 -SET SESSION AUTHORIZATION regress_rls_alice;
--CREATE TABLE rls_tbl (a int, b int, c int);
--CREATE POLICY p1 ON rls_tbl USING (rls_tbl >= ROW(1,1,1));
--ALTER TABLE rls_tbl ENABLE ROW LEVEL SECURITY;
--ALTER TABLE rls_tbl FORCE ROW LEVEL SECURITY;
--INSERT INTO rls_tbl SELECT 10, 20, 30;
--EXPLAIN (VERBOSE, COSTS OFF)
--INSERT INTO rls_tbl
--  SELECT * FROM (SELECT b, c FROM rls_tbl ORDER BY a) ss;
++SET ROLE regress_rls_alice;
+ CREATE TABLE rls_tbl (a int, b int, c int);
+ CREATE POLICY p1 ON rls_tbl USING (rls_tbl >= ROW(1,1,1));
++ERROR:  column "rls_tbl" does not exist
+ ALTER TABLE rls_tbl ENABLE ROW LEVEL SECURITY;
+ ALTER TABLE rls_tbl FORCE ROW LEVEL SECURITY;
+ INSERT INTO rls_tbl SELECT 10, 20, 30;
++ERROR:  new row violates row-level security policy for table "rls_tbl"
+ EXPLAIN (VERBOSE, COSTS OFF)
+ INSERT INTO rls_tbl
+   SELECT * FROM (SELECT b, c FROM rls_tbl ORDER BY a) ss;
 -                             QUERY PLAN                             
 ---------------------------------------------------------------------
 - Insert on regress_rls_schema.rls_tbl
@@ -6306,49 +5354,36 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 -                     Filter: (rls_tbl_1.* >= '(1,1,1)'::record)
 -(9 rows)
 -
--INSERT INTO rls_tbl
--  SELECT * FROM (SELECT b, c FROM rls_tbl ORDER BY a) ss;
--SELECT * FROM rls_tbl;
++ERROR:  at or near "off": syntax error
++DETAIL:  source SQL:
++EXPLAIN (VERBOSE, COSTS OFF)
++                        ^
++HINT:  try \h <SELECTCLAUSE>
+ INSERT INTO rls_tbl
+   SELECT * FROM (SELECT b, c FROM rls_tbl ORDER BY a) ss;
+ SELECT * FROM rls_tbl;
 - a  | b  | c  
 -----+----+----
 - 10 | 20 | 30
 - 20 | 30 |   
 -(2 rows)
--
--DROP TABLE rls_tbl;
++ a | b | c 
++---+---+---
++(0 rows)
+ 
+ DROP TABLE rls_tbl;
 -RESET SESSION AUTHORIZATION;
---- CVE-2023-2455: inlining an SRF may introduce an RLS dependency
--create table rls_t (c text);
--insert into rls_t values ('invisible to bob');
--alter table rls_t enable row level security;
--grant select on rls_t to regress_rls_alice, regress_rls_bob;
--create policy p1 on rls_t for select to regress_rls_alice using (true);
--create policy p2 on rls_t for select to regress_rls_bob using (false);
--create function rls_f () returns setof rls_t
--  stable language sql
--  as $$ select * from rls_t $$;
--prepare q as select current_user, * from rls_f();
--set role regress_rls_alice;
--execute q;
--   current_user    |        c         
---------------------+------------------
-- regress_rls_alice | invisible to bob
--(1 row)
--
--set role regress_rls_bob;
--execute q;
-- current_user | c 
----------------+---
--(0 rows)
--
--RESET ROLE;
--DROP FUNCTION rls_f();
--DROP TABLE rls_t;
----
---- Clean up objects
----
++RESET ROLE;
+ -- CVE-2023-2455: inlining an SRF may introduce an RLS dependency
+ create table rls_t (c text);
+ insert into rls_t values ('invisible to bob');
+@@ -4489,44 +3452,14 @@
+ --
+ -- Clean up objects
+ --
 -RESET SESSION AUTHORIZATION;
--DROP SCHEMA regress_rls_schema CASCADE;
++RESET ROLE;
+ DROP SCHEMA regress_rls_schema CASCADE;
 -NOTICE:  drop cascades to 30 other objects
 -DETAIL:  drop cascades to function f_leak(text)
 -drop cascades to table uaccount
@@ -6380,27 +5415,12 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 -drop cascades to table dep2
 -drop cascades to table dob_t1
 -drop cascades to table dob_t2
--DROP USER regress_rls_alice;
--DROP USER regress_rls_bob;
--DROP USER regress_rls_carol;
--DROP USER regress_rls_dave;
--DROP USER regress_rls_exempt_user;
--DROP ROLE regress_rls_group1;
--DROP ROLE regress_rls_group2;
---- Arrange to have a few policies left over, for testing
---- pg_dump/pg_restore
--CREATE SCHEMA regress_rls_schema;
--CREATE TABLE rls_tbl (c1 int);
--ALTER TABLE rls_tbl ENABLE ROW LEVEL SECURITY;
--CREATE POLICY p1 ON rls_tbl USING (c1 > 5);
--CREATE POLICY p2 ON rls_tbl FOR SELECT USING (c1 <= 3);
--CREATE POLICY p3 ON rls_tbl FOR UPDATE USING (c1 <= 3) WITH CHECK (c1 > 5);
--CREATE POLICY p4 ON rls_tbl FOR DELETE USING (c1 <= 3);
--CREATE TABLE rls_tbl_force (c1 int);
--ALTER TABLE rls_tbl_force ENABLE ROW LEVEL SECURITY;
--ALTER TABLE rls_tbl_force FORCE ROW LEVEL SECURITY;
--CREATE POLICY p1 ON rls_tbl_force USING (c1 = 5) WITH CHECK (c1 < 5);
--CREATE POLICY p2 ON rls_tbl_force FOR SELECT USING (c1 = 8);
--CREATE POLICY p3 ON rls_tbl_force FOR UPDATE USING (c1 = 8) WITH CHECK (c1 >= 5);
--CREATE POLICY p4 ON rls_tbl_force FOR DELETE USING (c1 = 8);
-+ERROR:  expected 2 values, got 1
+ DROP USER regress_rls_alice;
+ DROP USER regress_rls_bob;
+ DROP USER regress_rls_carol;
+ DROP USER regress_rls_dave;
+ DROP USER regress_rls_exempt_user;
++ERROR:  role/user "regress_rls_exempt_user" does not exist
+ DROP ROLE regress_rls_group1;
+ DROP ROLE regress_rls_group2;
+ -- Arrange to have a few policies left over, for testing


### PR DESCRIPTION
Modify the rowsecurity.sql test from pg_regress to cover additional cases. This test makes heavy use of SET SESSION AUTHORIZATION, which CRDB doesn't support, so it has been adjusted accordingly. Additionally, the test relies on a user-defined function f_leak; modifications were made to allow this function to be created and used within the test.

Some incompatibilities remain. For example, CRDB doesn't support COPY FROM in the same way as Postgres, which affects the expected output of certain queries. Nevertheless, these changes improve the test suite.

Closes #137122

Epic: CRDB-11724
Release note: none