### PR TITLE
release-24.1: tests: use livebytes metric for disagg-rebalance

### DIFF
--- a/pkg/cmd/roachtest/tests/disagg_rebalance.go
+++ b/pkg/cmd/roachtest/tests/disagg_rebalance.go
@@ -131,8 +131,7 @@ func registerDisaggRebalance(r registry.Registry) {
 			testutils.SucceedsWithin(t, func() error {
 				var bytesInRanges int64
 				if err := db.QueryRow(
-					"SELECT sum(used) "+
-						"FROM crdb_internal.kv_store_status WHERE node_id = $1 GROUP BY node_id LIMIT 1",
+					"SELECT metrics['livebytes']::INT FROM crdb_internal.kv_store_status WHERE node_id = $1 LIMIT 1",
 					4,
 				).Scan(&bytesInRanges); err != nil {
 					t.Fatal(err)


### PR DESCRIPTION
Manual backport of https://github.com/cockroachdb/cockroach/pull/122847.

Fixes #142317

Epic: none

Release note: None

Release justification: test only change.