### PR TITLE
jsonpath: add support for `exists()`

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/jsonb_path_query
+++ b/pkg/sql/logictest/testdata/logic_test/jsonb_path_query
@@ -1054,3 +1054,23 @@ SELECT jsonb_path_query('[1, 2, 3, 4]', '$[1 to last, last to last]');
 3
 4
 4
+
+query T
+SELECT jsonb_path_query('[1, 2, 3]', 'exists($[*])');
+----
+true
+
+query T
+SELECT jsonb_path_query('[]', 'exists($[*])');
+----
+false
+
+query T
+SELECT jsonb_path_query('[{"items": [{"id": 1}, {"id": 2}]}, {"items": []}]', '$[*] ? (exists(@.items[*].id))');
+----
+{"items": [{"id": 1}, {"id": 2}]}
+
+query T
+SELECT jsonb_path_query('[{"a": 1, "b": 2}, {"a": 1}, {"b": 2}, {}]', '$[*] ? (exists(@.a) && exists(@.b))');
+----
+{"a": 1, "b": 2}

--- a/pkg/util/jsonpath/operation.go
+++ b/pkg/util/jsonpath/operation.go
@@ -27,6 +27,7 @@ const (
 	OpLikeRegex
 	OpPlus
 	OpMinus
+	OpExists
 )
 
 var OperationTypeStrings = map[OperationType]string{
@@ -47,6 +48,7 @@ var OperationTypeStrings = map[OperationType]string{
 	OpLikeRegex:        "like_regex",
 	OpPlus:             "+",
 	OpMinus:            "-",
+	OpExists:           "exists",
 }
 
 type Operation struct {
@@ -73,6 +75,9 @@ func (o Operation) String() string {
 	// can be done at parse time.
 	if o.Type == OpPlus || o.Type == OpMinus {
 		return fmt.Sprintf("(%s%s)", OperationTypeStrings[o.Type], o.Left)
+	}
+	if o.Type == OpExists {
+		return fmt.Sprintf("%s (%s)", OperationTypeStrings[o.Type], o.Left)
 	}
 	return fmt.Sprintf("(%s %s %s)", o.Left, OperationTypeStrings[o.Type], o.Right)
 }

--- a/pkg/util/jsonpath/parser/jsonpath.y
+++ b/pkg/util/jsonpath/parser/jsonpath.y
@@ -190,6 +190,7 @@ func regexBinaryOp(left jsonpath.Path, regex string) (jsonpath.Operation, error)
 %token <str> FLAG
 
 %token <str> LAST
+%token <str> EXISTS
 
 %type <jsonpath.Jsonpath> jsonpath
 %type <jsonpath.Path> expr_or_predicate
@@ -433,6 +434,10 @@ delimited_predicate:
   {
     $$.val = $2.path()
   }
+| EXISTS '(' expr ')'
+  {
+    $$.val = unaryOp(jsonpath.OpExists, $3.path())
+  }
 ;
 
 comp_op:
@@ -512,7 +517,8 @@ any_identifier:
 ;
 
 unreserved_keyword:
-  FALSE
+  EXISTS
+| FALSE
 | FLAG
 | LAST
 | LAX

--- a/pkg/util/jsonpath/parser/testdata/jsonpath
+++ b/pkg/util/jsonpath/parser/testdata/jsonpath
@@ -519,6 +519,16 @@ $[1 to last, last to last]
 ----
 $[1 to last,last to last] -- normalized!
 
+parse
+exists($.a)
+----
+exists ($."a") -- normalized!
+
+parse
+$.a ? (exists(@.b) && !exists(@.c))
+----
+$."a"?((exists (@."b") && !(exists (@."c")))) -- normalized!
+
 # postgres allows floats as array indexes
 # parse
 # $.abc[1.0]


### PR DESCRIPTION
This commit adds support for using `exists()` within jsonpath queries.
This returns a boolean - whether or not the enclosed expression returns
any results.

Epic: None
Release note (sql change): Add support for `exists()` in JSONPath
queries. For example, `SELECT jsonb_path_query('[1, 2, 3]', 'exists($[*])');`.
