### PR TITLE
jsonpath: add support for `() is unknown`

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/jsonb_path_query
+++ b/pkg/sql/logictest/testdata/logic_test/jsonb_path_query
@@ -1074,3 +1074,18 @@ query T
 SELECT jsonb_path_query('[{"a": 1, "b": 2}, {"a": 1}, {"b": 2}, {}]', '$[*] ? (exists(@.a) && exists(@.b))');
 ----
 {"a": 1, "b": 2}
+
+query T
+SELECT jsonb_path_query('{}', '(1 + 2 == 3) is unknown');
+----
+false
+
+query T
+SELECT jsonb_path_query('{}', '($ < 1) is unknown');
+----
+true
+
+query T
+SELECT jsonb_path_query('{}', '(null like_regex "^he.*$") is unknown');
+----
+true

--- a/pkg/util/jsonpath/eval/operation.go
+++ b/pkg/util/jsonpath/eval/operation.go
@@ -46,35 +46,19 @@ func convertFromBool(b jsonpathBool) json.JSON {
 	}
 }
 
-func convertToBool(j json.JSON) jsonpathBool {
-	b, ok := j.AsBool()
-	if !ok {
-		return jsonpathBoolUnknown
-	}
-	if b {
-		return jsonpathBoolTrue
-	}
-	return jsonpathBoolFalse
-}
-
 func (ctx *jsonpathCtx) evalOperation(
 	op jsonpath.Operation, jsonValue json.JSON,
 ) ([]json.JSON, error) {
 	switch op.Type {
-	case jsonpath.OpLogicalAnd, jsonpath.OpLogicalOr, jsonpath.OpLogicalNot:
-		res, err := ctx.evalLogical(op, jsonValue)
+	case jsonpath.OpLogicalAnd, jsonpath.OpLogicalOr, jsonpath.OpLogicalNot,
+		jsonpath.OpCompEqual, jsonpath.OpCompNotEqual, jsonpath.OpCompLess,
+		jsonpath.OpCompLessEqual, jsonpath.OpCompGreater, jsonpath.OpCompGreaterEqual,
+		jsonpath.OpLikeRegex, jsonpath.OpExists:
+		b, err := ctx.evalBoolean(op, jsonValue)
 		if err != nil {
 			return []json.JSON{convertFromBool(jsonpathBoolUnknown)}, err
 		}
-		return []json.JSON{convertFromBool(res)}, nil
-	case jsonpath.OpCompEqual, jsonpath.OpCompNotEqual,
-		jsonpath.OpCompLess, jsonpath.OpCompLessEqual,
-		jsonpath.OpCompGreater, jsonpath.OpCompGreaterEqual:
-		res, err := ctx.evalComparison(op, jsonValue)
-		if err != nil {
-			return []json.JSON{convertFromBool(jsonpathBoolUnknown)}, err
-		}
-		return []json.JSON{convertFromBool(res)}, nil
+		return []json.JSON{convertFromBool(b)}, nil
 	case jsonpath.OpAdd, jsonpath.OpSub, jsonpath.OpMult,
 		jsonpath.OpDiv, jsonpath.OpMod:
 		results, err := ctx.evalArithmetic(op, jsonValue)
@@ -82,20 +66,27 @@ func (ctx *jsonpathCtx) evalOperation(
 			return nil, err
 		}
 		return []json.JSON{results}, nil
-	case jsonpath.OpLikeRegex:
-		res, err := ctx.evalRegex(op, jsonValue)
-		if err != nil {
-			return []json.JSON{convertFromBool(jsonpathBoolUnknown)}, err
-		}
-		return []json.JSON{convertFromBool(res)}, nil
 	case jsonpath.OpPlus, jsonpath.OpMinus:
 		return ctx.evalUnaryArithmetic(op, jsonValue)
+	default:
+		panic(errors.AssertionFailedf("unhandled operation type"))
+	}
+}
+
+func (ctx *jsonpathCtx) evalBoolean(
+	op jsonpath.Operation, jsonValue json.JSON,
+) (jsonpathBool, error) {
+	switch op.Type {
+	case jsonpath.OpLogicalAnd, jsonpath.OpLogicalOr, jsonpath.OpLogicalNot:
+		return ctx.evalLogical(op, jsonValue)
+	case jsonpath.OpCompEqual, jsonpath.OpCompNotEqual,
+		jsonpath.OpCompLess, jsonpath.OpCompLessEqual,
+		jsonpath.OpCompGreater, jsonpath.OpCompGreaterEqual:
+		return ctx.evalComparison(op, jsonValue)
+	case jsonpath.OpLikeRegex:
+		return ctx.evalRegex(op, jsonValue)
 	case jsonpath.OpExists:
-		res, err := ctx.evalExists(op, jsonValue)
-		if err != nil {
-			return []json.JSON{convertFromBool(jsonpathBoolUnknown)}, err
-		}
-		return []json.JSON{convertFromBool(res)}, nil
+		return ctx.evalExists(op, jsonValue)
 	default:
 		panic(errors.AssertionFailedf("unhandled operation type"))
 	}
@@ -158,16 +149,16 @@ func (ctx *jsonpathCtx) evalRegex(
 }
 
 func (ctx *jsonpathCtx) evalLogical(
-	op jsonpath.Operation, current json.JSON,
+	op jsonpath.Operation, jsonValue json.JSON,
 ) (jsonpathBool, error) {
-	left, err := ctx.eval(op.Left, current, !ctx.strict /* unwrap */)
-	if err != nil {
-		return jsonpathBoolUnknown, err
+	leftOp, ok := op.Left.(jsonpath.Operation)
+	if !ok {
+		return jsonpathBoolUnknown, errors.AssertionFailedf("left is not an operation")
 	}
-	if len(left) != 1 || !isBool(left[0]) {
+	leftBool, err := ctx.evalBoolean(leftOp, jsonValue)
+	if err != nil {
 		return jsonpathBoolUnknown, errors.AssertionFailedf("left is not a boolean")
 	}
-	leftBool := convertToBool(left[0])
 	switch op.Type {
 	case jsonpath.OpLogicalAnd:
 		if leftBool == jsonpathBoolFalse {
@@ -189,14 +180,14 @@ func (ctx *jsonpathCtx) evalLogical(
 		panic(errors.AssertionFailedf("unhandled logical operation type"))
 	}
 
-	right, err := ctx.eval(op.Right, current, !ctx.strict /* unwrap */)
-	if err != nil {
-		return jsonpathBoolUnknown, err
+	rightOp, ok := op.Right.(jsonpath.Operation)
+	if !ok {
+		return jsonpathBoolUnknown, errors.AssertionFailedf("right is not an operation")
 	}
-	if len(right) != 1 || !isBool(right[0]) {
+	rightBool, err := ctx.evalBoolean(rightOp, jsonValue)
+	if err != nil {
 		return jsonpathBoolUnknown, errors.AssertionFailedf("right is not a boolean")
 	}
-	rightBool := convertToBool(right[0])
 	switch op.Type {
 	case jsonpath.OpLogicalAnd:
 		if rightBool == jsonpathBoolTrue {

--- a/pkg/util/jsonpath/operation.go
+++ b/pkg/util/jsonpath/operation.go
@@ -28,6 +28,7 @@ const (
 	OpPlus
 	OpMinus
 	OpExists
+	OpIsUnknown
 )
 
 var OperationTypeStrings = map[OperationType]string{
@@ -49,6 +50,7 @@ var OperationTypeStrings = map[OperationType]string{
 	OpPlus:             "+",
 	OpMinus:            "-",
 	OpExists:           "exists",
+	OpIsUnknown:        "is unknown",
 }
 
 type Operation struct {
@@ -78,6 +80,9 @@ func (o Operation) String() string {
 	}
 	if o.Type == OpExists {
 		return fmt.Sprintf("%s (%s)", OperationTypeStrings[o.Type], o.Left)
+	}
+	if o.Type == OpIsUnknown {
+		return fmt.Sprintf("(%s) %s", o.Left, OperationTypeStrings[o.Type])
 	}
 	return fmt.Sprintf("(%s %s %s)", o.Left, OperationTypeStrings[o.Type], o.Right)
 }

--- a/pkg/util/jsonpath/parser/jsonpath.y
+++ b/pkg/util/jsonpath/parser/jsonpath.y
@@ -191,6 +191,8 @@ func regexBinaryOp(left jsonpath.Path, regex string) (jsonpath.Operation, error)
 
 %token <str> LAST
 %token <str> EXISTS
+%token <str> IS
+%token <str> UNKNOWN
 
 %type <jsonpath.Jsonpath> jsonpath
 %type <jsonpath.Path> expr_or_predicate
@@ -414,6 +416,10 @@ predicate:
   {
     $$.val = unaryOp(jsonpath.OpLogicalNot, $2.path())
   }
+| '(' predicate ')' IS UNKNOWN
+  {
+    $$.val = unaryOp(jsonpath.OpIsUnknown, $2.path())
+  }
 | expr LIKE_REGEX STRING
   {
     regex, err := regexBinaryOp($1.path(), $3)
@@ -520,6 +526,7 @@ unreserved_keyword:
   EXISTS
 | FALSE
 | FLAG
+| IS
 | LAST
 | LAX
 | LIKE_REGEX
@@ -527,6 +534,7 @@ unreserved_keyword:
 | STRICT
 | TO
 | TRUE
+| UNKNOWN
 ;
 
 %%

--- a/pkg/util/jsonpath/parser/testdata/jsonpath
+++ b/pkg/util/jsonpath/parser/testdata/jsonpath
@@ -529,6 +529,21 @@ $.a ? (exists(@.b) && !exists(@.c))
 ----
 $."a"?((exists (@."b") && !(exists (@."c")))) -- normalized!
 
+parse
+(1 + 2 == 3) is unknown
+----
+(((1 + 2) == 3)) is unknown -- normalized!
+
+parse
+($ < 1) is unknown
+----
+(($ < 1)) is unknown -- normalized!
+
+parse
+(null like_regex "^he.*$") is unknown
+----
+((null like_regex "^he.*$")) is unknown -- normalized!
+
 # postgres allows floats as array indexes
 # parse
 # $.abc[1.0]


### PR DESCRIPTION
#### jsonpath: extract boolean operations into `evalBoolean`

This commit moves the switch statement evaluation of boolean returning
operators into a separate `evalBoolean`. This allows for other operators
that expect to return a boolean (logical AND/OR/NOT, filters) to do so
without needing to do `isBool` checks after an `eval` call.

Epic: None
Release note: None

#### jsonpath: add support for `() is unknown`

This commit adds support for using `() is unknown` within jsonpath
queries. This returns a boolean - whether or not the enclosed predicate
returned unknown.

Epic: None
Release note (sql change): Add support for `() is unknown` in JSONPath
queries. For example, `SELECT jsonb_path_query('{}', '($ < 1) is unknown');`.
