### PR TITLE
batcheval: catch pebble data corruption on split/merge commit triggers

### DIFF
--- a/pkg/kv/kvserver/batcheval/BUILD.bazel
+++ b/pkg/kv/kvserver/batcheval/BUILD.bazel
@@ -95,6 +95,7 @@ go_library(
         "//pkg/util/tracing",
         "//pkg/util/uuid",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_cockroachdb_pebble//:pebble",
         "@com_github_cockroachdb_redact//:redact",
         "@com_github_gogo_protobuf//types",
         "@com_github_kr_pretty//:pretty",

--- a/pkg/kv/kvserver/kvserverbase/knobs.go
+++ b/pkg/kv/kvserver/kvserverbase/knobs.go
@@ -62,6 +62,9 @@ type BatchEvalTestingKnobs struct {
 	// NOTE: This currently only applies to Migrate requests and only ignores the
 	// cluster version.
 	OverrideDoTimelyApplicationToAllReplicas bool
+
+	// CommitTriggerError is called at commit triggers to simulate errors.
+	CommitTriggerError func() error
 }
 
 // IntentResolverTestingKnobs contains testing helpers that are used during


### PR DESCRIPTION
This commit catches the pebble data corruption error on split and merge
commit triggers (instead of crashing the node). This is useful if a
file that an external SSTable is pointing to gets deleted, we don't want
to crash the process. Excise command could be used to recover from this
situation.

References: #143135

Release note: None