### PR TITLE
sql: include current user in EXPLAIN bundle

### DIFF
--- a/pkg/acceptance/generated_cli_test.go
+++ b/pkg/acceptance/generated_cli_test.go
@@ -384,6 +384,13 @@ func TestDockerCLI_test_sb_recreate_mr(t *testing.T) {
 	runTestDockerCLI(t, "test_sb_recreate_mr", "../cli/interactive_tests/test_sb_recreate_mr.tcl")
 }
 
+func TestDockerCLI_test_sb_recreate_rls(t *testing.T) {
+	s := log.Scope(t)
+	defer s.Close(t)
+
+	runTestDockerCLI(t, "test_sb_recreate_rls", "../cli/interactive_tests/test_sb_recreate_rls.tcl")
+}
+
 func TestDockerCLI_test_secure(t *testing.T) {
 	s := log.Scope(t)
 	defer s.Close(t)

--- a/pkg/cli/interactive_tests/test_sb_recreate_rls.tcl
+++ b/pkg/cli/interactive_tests/test_sb_recreate_rls.tcl
@@ -1,0 +1,56 @@
+#! /usr/bin/env expect -f
+
+source [file join [file dirname $argv0] common.tcl]
+
+proc file_exists {filepath} {
+  if {! [ file exist $filepath]} {
+    report "MISSING EXPECTED FILE: $filepath"
+    exit 1
+  }
+}
+
+start_test "Ensure that 'debug sb recreate' works with row-level security"
+
+spawn $argv demo --no-line-editor --empty --log-dir=logs
+eexpect "defaultdb>"
+
+send "CREATE TABLE rls1 (pk INT PRIMARY KEY, comment TEXT);\r"
+send "ALTER TABLE rls1 ENABLE ROW LEVEL SECURITY, FORCE ROW LEVEL SECURITY;\r"
+send "CREATE POLICY pol1 ON rls1 USING (comment = 'visible');\r"
+send "CREATE USER rls_user;\r"
+send "ALTER TABLE rls1 OWNER TO rls_user;\r"
+send "GRANT SYSTEM VIEWCLUSTERSETTING TO rls_user;\r"
+send "GRANT SYSTEM VIEWACTIVITY to rls_user;\r"
+send "GRANT SYSTEM VIEWSYSTEMTABLE to rls_user;\r"
+send "SET ROLE rls_user;\r"
+eexpect "defaultdb>"
+
+send "EXPLAIN ANALYZE (DEBUG) SELECT * FROM rls1;\r"
+eexpect "Statement diagnostics bundle generated."
+expect -re "SQL shell: \\\\statement-diag download (\\d+)" {
+  set id1 $expect_out(1,string)
+}
+
+send "\\statement-diag download $id1\r"
+eexpect "Bundle saved to"
+eexpect root@
+
+file_exists "stmt-bundle-$id1.zip"
+
+send_eof
+eexpect eof
+
+set python "python2.7"
+set pyfile [file join [file dirname $argv0] unzip.py]
+system "mkdir bundle"
+system "$python $pyfile stmt-bundle-$id1.zip bundle"
+
+spawn $argv debug sb recreate bundle
+eexpect "Statement was:"
+eexpect "SELECT"
+eexpect "defaultdb>"
+
+send_eof
+eexpect eof
+
+end_test


### PR DESCRIPTION
Include the current user in the env.sql file of the EXPLAIN bundle. This information is useful for debugging issues related to row-level security (RLS), as the user determines which policies are applied to a query.

This change also verifies the presence of other relevant RLS metadata in the bundle, including:
- the list of existing policies,
- whether RLS is enabled on the target table,
- the policies enforced in the query plan (with EXPLAIN (VERBOSE)), and
- modifications to the plan such as injected filters that enforce RLS policies.

Includes a new test to validate these additions.

Informs #139329

Epic: CRDB-11724
Release note: none