### PR TITLE
kvserver: tolerate missing store in raft transport

### DIFF
--- a/pkg/kv/kvserver/raft_transport.go
+++ b/pkg/kv/kvserver/raft_transport.go
@@ -428,6 +428,7 @@ func (t *RaftTransport) getOutgoingMessageHandler(
 func (t *RaftTransport) handleRaftRequest(
 	ctx context.Context, req *kvserverpb.RaftMessageRequest, respStream RaftMessageResponseStream,
 ) *kvpb.Error {
+	isV1 := log.V(1)
 	for i := range req.AdmittedRaftLogEntries {
 		// Process any flow tokens that were returned over the RaftTransport. Do
 		// this first thing, before these requests enter the receive queues
@@ -444,7 +445,7 @@ func (t *RaftTransport) handleRaftRequest(
 			)
 		}
 
-		if log.V(1) {
+		if isV1 {
 			log.Infof(ctx, "informed of below-raft %s", admittedEntries)
 		}
 	}
@@ -457,9 +458,16 @@ func (t *RaftTransport) handleRaftRequest(
 
 	incomingMessageHandler, ok := t.getIncomingRaftMessageHandler(req.ToReplica.StoreID)
 	if !ok {
-		log.Warningf(ctx, "unable to accept Raft message from %+v: no handler registered for %+v",
-			req.FromReplica, req.ToReplica)
-		return kvpb.NewError(kvpb.NewStoreNotFoundError(req.ToReplica.StoreID))
+		if isV1 {
+			log.Warningf(ctx, "unable to accept Raft message from %+v: no handler registered for %+v",
+				req.FromReplica, req.ToReplica)
+		}
+		// We don't return an error to the client. If this node restarted with fewer
+		// stores than it had before (think: hardware failure), then it is expected
+		// for remote ranges to think there should be a replica on this store. We
+		// could still send an error back here, but then it would have to be dropped
+		// at the other node - not a good use of bandwidth.
+		return nil
 	}
 
 	return incomingMessageHandler.HandleRaftRequest(ctx, req, respStream)


### PR DESCRIPTION
In a multi-store cluster, if a node (say n1) is restarted with fewer stores
than initially, it will take some time for replicas to be moved off of it.

Previously, while in this state, the raft transport from other nodes to n1
would frequently be reconnected. Concretely, this would happen every time a
leader on n2 would try to reach a follower on a now-missing store on n1.
n2 would respond with a StoreNotFoundError, and the original sender would
tear down the raft transport stream to n1 and reconnect, dropping messages
directed at other valid stores on n1 in the process.

We now no longer emit StoreNotFoundError from n1, and in mixed clusters such
messages are now handled as no-ops, leaving the raft transport intact and thus
preventing interruption to raft message flows to stores still present on n1.

Epic: CRDB-49133
Release note: None
