### PR TITLE
backup: add experimental copy option to restore

### DIFF
--- a/docs/generated/sql/bnf/restore_options.bnf
+++ b/docs/generated/sql/bnf/restore_options.bnf
@@ -18,4 +18,5 @@ restore_options ::=
 	| 'UNSAFE_RESTORE_INCOMPATIBLE_VERSION'
 	| 'EXECUTION' 'LOCALITY' '=' string_or_placeholder
 	| 'EXPERIMENTAL' 'DEFERRED' 'COPY'
+	| 'EXPERIMENTAL' 'COPY'
 	| 'REMOVE_REGIONS'

--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -2843,6 +2843,7 @@ restore_options ::=
 	| 'UNSAFE_RESTORE_INCOMPATIBLE_VERSION'
 	| 'EXECUTION' 'LOCALITY' '=' string_or_placeholder
 	| 'EXPERIMENTAL' 'DEFERRED' 'COPY'
+	| 'EXPERIMENTAL' 'COPY'
 	| 'REMOVE_REGIONS'
 
 scrub_option_list ::=

--- a/pkg/backup/backup_cloud_test.go
+++ b/pkg/backup/backup_cloud_test.go
@@ -139,7 +139,7 @@ func TestOnlineRestoreS3(t *testing.T) {
 	_, rSQLDB, cleanupFnRestored := backupRestoreTestSetupEmpty(t, 1, "", InitManualReplication, params)
 	defer cleanupFnRestored()
 
-	bankOnlineRestore(t, rSQLDB, numAccounts, externalStorage)
+	bankOnlineRestore(t, rSQLDB, numAccounts, externalStorage, false)
 }
 
 // TestBackupRestoreGoogleCloudStorage hits the real GCS and so could

--- a/pkg/backup/restore_job.go
+++ b/pkg/backup/restore_job.go
@@ -334,11 +334,11 @@ func restore(
 	defer introducedSpanFrontier.Release()
 
 	targetSize := targetRestoreSpanSize.Get(&execCtx.ExecCfg().Settings.SV)
-	if details.ExperimentalOnline {
+	if details.OnlineImpl() {
 		targetSize = targetOnlineRestoreSpanSize.Get(&execCtx.ExecCfg().Settings.SV)
 	}
 	maxFileCount := maxFileCount.Get(&execCtx.ExecCfg().Settings.SV)
-	if details.ExperimentalOnline {
+	if details.OnlineImpl() {
 		// Online Restore does not need to limit the number of files per restore
 		// span entry as the files are never opened when processing the span. The
 		// span is only used to create split points.
@@ -433,7 +433,7 @@ func restore(
 	}
 
 	progCh := make(chan *execinfrapb.RemoteProducerMetadata_BulkProcessorProgress)
-	if !details.ExperimentalOnline {
+	if !details.OnlineImpl() {
 		// Online restore tracks progress by pinging requestFinishedCh instead
 		generativeCheckpointLoop := func(ctx context.Context) error {
 			defer close(requestFinishedCh)
@@ -479,7 +479,7 @@ func restore(
 	}
 
 	resumeClusterVersion := execCtx.ExecCfg().Settings.Version.ActiveVersion(restoreCtx).Version
-	if clusterversion.V24_3.Version().LessEq(resumeClusterVersion) && !details.ExperimentalOnline {
+	if clusterversion.V24_3.Version().LessEq(resumeClusterVersion) && !details.OnlineImpl() {
 		tasks = append(tasks, countCompletedProcLoop)
 	}
 
@@ -506,7 +506,7 @@ func restore(
 	tasks = append(tasks, tracingAggLoop)
 
 	runRestore := func(ctx context.Context) error {
-		if details.ExperimentalOnline {
+		if details.OnlineImpl() {
 			log.Warningf(ctx, "EXPERIMENTAL ONLINE RESTORE being used")
 			approxRows, approxDataSize, err := sendAddRemoteSSTs(
 				ctx,
@@ -997,7 +997,7 @@ func createImportingDescriptors(
 			}
 
 			if backedUpDescriptorWithInProgressImportInto(desc) {
-				if details.ExperimentalOnline && !epochBasedInProgressImport(desc) {
+				if details.OnlineImpl() && !epochBasedInProgressImport(desc) {
 					return nil, nil, nil, errors.Newf("table %s (id %d) in restoring backup has an in-progress import, but online restore cannot be run on a table with an in progress import", desc.GetName(), desc.GetID())
 				}
 			} else {
@@ -1048,11 +1048,11 @@ func createImportingDescriptors(
 
 	// We get the spans of the restoring tables _as they appear in the backup_,
 	// that is, in the 'old' keyspace, before we reassign the table IDs.
-	preRestoreSpans, err := spansForAllRestoreTableIndexes(backupCodec, preRestoreTables, nil, details.SchemaOnly, details.ExperimentalOnline)
+	preRestoreSpans, err := spansForAllRestoreTableIndexes(backupCodec, preRestoreTables, nil, details.SchemaOnly, details.OnlineImpl())
 	if err != nil {
 		return nil, nil, nil, err
 	}
-	postRestoreSpans, err := spansForAllRestoreTableIndexes(backupCodec, postRestoreTables, nil, details.SchemaOnly, details.ExperimentalOnline)
+	postRestoreSpans, err := spansForAllRestoreTableIndexes(backupCodec, postRestoreTables, nil, details.SchemaOnly, details.OnlineImpl())
 	if err != nil {
 		return nil, nil, nil, err
 	}
@@ -1060,7 +1060,7 @@ func createImportingDescriptors(
 	if details.VerifyData {
 		// verifySpans contains the spans that should be read and checksum'd during a
 		// verify_backup_table_data RESTORE
-		verifySpans, err = spansForAllRestoreTableIndexes(backupCodec, postRestoreTables, nil, false, details.ExperimentalOnline)
+		verifySpans, err = spansForAllRestoreTableIndexes(backupCodec, postRestoreTables, nil, false, details.OnlineImpl())
 		if err != nil {
 			return nil, nil, nil, err
 		}
@@ -1769,7 +1769,7 @@ func (r *restoreResumer) doResume(ctx context.Context, execCtx interface{}) erro
 		if err := p.ExecCfg().JobRegistry.CheckPausepoint("restore.before_do_download_files"); err != nil {
 			return err
 		}
-		return r.doDownloadFiles(ctx, p)
+		return r.doDownloadFiles(ctx, p, details.DownloadSpans)
 	}
 
 	if err := p.ExecCfg().JobRegistry.CheckPausepoint("restore.before_load_descriptors_from_backup"); err != nil {
@@ -1894,6 +1894,10 @@ func (r *restoreResumer) doResume(ctx context.Context, execCtx interface{}) erro
 
 	var resTotal roachpb.RowCount
 
+	// TODO(msbutler): add a progress field to skip running a restore flow if it
+	// has already complete. This ensures we skip the link phase if we resume an
+	// online restore job that blocks on the download job.
+
 	if !preData.isEmpty() {
 		res, err := restoreWithRetry(
 			ctx,
@@ -1978,6 +1982,15 @@ func (r *restoreResumer) doResume(ctx context.Context, execCtx interface{}) erro
 	if err := insertStats(ctx, r.job, p.ExecCfg(), remappedStats); err != nil {
 		return errors.Wrap(err, "inserting table statistics")
 	}
+	if details.ExperimentalCopy {
+		downloadSpans, err := getDownloadSpans(p.ExecCfg().Codec, preData, mainData)
+		if err != nil {
+			return err
+		}
+		if err := r.doDownloadFiles(ctx, p, downloadSpans); err != nil {
+			return err
+		}
+	}
 
 	publishDescriptors := func(ctx context.Context, txn descs.Txn) (err error) {
 		return r.publishDescriptors(
@@ -2055,7 +2068,7 @@ func (r *restoreResumer) doResume(ctx context.Context, execCtx interface{}) erro
 	if err := r.execCfg.ProtectedTimestampManager.Unprotect(ctx, r.job); err != nil {
 		log.Errorf(ctx, "failed to release protected timestamp: %v", err)
 	}
-	if !details.ExperimentalOnline {
+	if !details.OnlineImpl() {
 		r.notifyStatsRefresherOfNewTables()
 	}
 
@@ -2166,7 +2179,7 @@ func (r *restoreResumer) ReportResults(ctx context.Context, resultsCh chan<- tre
 		return ctx.Err()
 	case resultsCh <- func() tree.Datums {
 		details := r.job.Details().(jobspb.RestoreDetails)
-		if details.ExperimentalOnline {
+		if details.OnlineImpl() {
 			return tree.Datums{
 				tree.NewDInt(tree.DInt(r.job.ID())),
 				tree.NewDInt(tree.DInt(len(details.TableDescs))),
@@ -2437,7 +2450,7 @@ func (r *restoreResumer) publishDescriptors(
 			return err
 		}
 
-		if details.ExperimentalOnline && epochBasedInProgressImport(desc) {
+		if details.OnlineImpl() && epochBasedInProgressImport(desc) {
 			if err := createImportRollbackJob(ctx,
 				r.execCfg.JobRegistry, txn, r.job.Payload().UsernameProto.Decode(), mutTable,
 			); err != nil {
@@ -2478,7 +2491,7 @@ func (r *restoreResumer) publishDescriptors(
 	b := txn.KV().NewBatch()
 	if err := all.ForEachDescriptor(func(desc catalog.Descriptor) error {
 		d := desc.(catalog.MutableDescriptor)
-		if details.ExperimentalOnline && epochBasedInProgressImport(desc) {
+		if details.OnlineImpl() && epochBasedInProgressImport(desc) {
 			log.Infof(ctx, "table %q (%d) with in-progress IMPORT remaining offline", desc.GetName(), desc.GetID())
 		} else {
 			d.SetPublic()
@@ -2517,7 +2530,7 @@ func (r *restoreResumer) publishDescriptors(
 	details.SchemaDescs = newSchemas
 	details.DatabaseDescs = newDBs
 	details.FunctionDescs = newFunctions
-	if details.ExperimentalOnline {
+	if details.OnlineImpl() {
 		details.PostDownloadTableAutoStatsSettings = tableAutoStatsSettings
 	}
 	if err := r.job.WithTxn(txn).SetDetails(ctx, details); err != nil {

--- a/pkg/backup/restore_job.go
+++ b/pkg/backup/restore_job.go
@@ -1866,9 +1866,6 @@ func (r *restoreResumer) doResume(ctx context.Context, execCtx interface{}) erro
 				return err
 			}
 		}
-		if err := r.maybeWriteDownloadJob(ctx, p.ExecCfg(), preData, mainData); err != nil {
-			return err
-		}
 		emitRestoreJobEvent(ctx, p, jobs.StateSucceeded, r.job)
 		return nil
 	}

--- a/pkg/backup/restore_planning.go
+++ b/pkg/backup/restore_planning.go
@@ -1078,6 +1078,7 @@ func resolveOptionsForRestoreJobDescription(
 		UnsafeRestoreIncompatibleVersion: opts.UnsafeRestoreIncompatibleVersion,
 		ExecutionLocality:                opts.ExecutionLocality,
 		ExperimentalOnline:               opts.ExperimentalOnline,
+		ExperimentalCopy:                 opts.ExperimentalCopy,
 		RemoveRegions:                    opts.RemoveRegions,
 	}
 
@@ -1185,7 +1186,7 @@ func restoreTypeCheck(
 	}
 	if restoreStmt.Options.Detached {
 		header = jobs.DetachedJobExecutionResultHeader
-	} else if restoreStmt.Options.ExperimentalOnline {
+	} else if restoreStmt.Options.OnlineImpl() {
 		header = jobs.OnlineRestoreJobExecutionResultHeader
 	} else {
 		header = jobs.BackupRestoreJobResultHeader
@@ -1324,7 +1325,7 @@ func restorePlanHook(
 		}
 	}
 
-	if restoreStmt.Options.ExperimentalOnline && restoreStmt.Options.VerifyData {
+	if restoreStmt.Options.OnlineImpl() && restoreStmt.Options.VerifyData {
 		return nil, nil, false, errors.New("cannot run online restore with verify_backup_table_data")
 	}
 
@@ -1422,7 +1423,7 @@ func restorePlanHook(
 	var header colinfo.ResultColumns
 	if restoreStmt.Options.Detached {
 		header = jobs.DetachedJobExecutionResultHeader
-	} else if restoreStmt.Options.ExperimentalOnline {
+	} else if restoreStmt.Options.OnlineImpl() {
 		header = jobs.OnlineRestoreJobExecutionResultHeader
 	} else {
 		header = jobs.BackupRestoreJobResultHeader
@@ -1794,7 +1795,7 @@ func doRestorePlan(
 	if err != nil {
 		return err
 	}
-	if restoreStmt.Options.ExperimentalOnline {
+	if restoreStmt.Options.OnlineImpl() {
 		for _, uri := range defaultURIs {
 			if err := cloud.SchemeSupportsEarlyBoot(uri); err != nil {
 				return errors.Wrap(err, "backup URI not supported for online restore")
@@ -1812,7 +1813,7 @@ func doRestorePlan(
 		return err
 	}
 
-	if restoreStmt.Options.ExperimentalOnline {
+	if restoreStmt.Options.OnlineImpl() {
 		if err := checkManifestsForOnlineCompat(ctx, mainBackupManifests); err != nil {
 			return err
 		}
@@ -1995,7 +1996,7 @@ func doRestorePlan(
 		return err
 	}
 
-	if restoreStmt.Options.ExperimentalOnline {
+	if restoreStmt.Options.OnlineImpl() {
 		if err := checkBackupElidedPrefixForOnlineCompat(ctx, mainBackupManifests, descriptorRewrites); err != nil {
 			return err
 		}
@@ -2091,6 +2092,7 @@ func doRestorePlan(
 		SkipLocalitiesCheck:              restoreStmt.Options.SkipLocalitiesCheck,
 		ExecutionLocality:                execLocality,
 		ExperimentalOnline:               restoreStmt.Options.ExperimentalOnline,
+		ExperimentalCopy:                 restoreStmt.Options.ExperimentalCopy,
 		RemoveRegions:                    restoreStmt.Options.RemoveRegions,
 		UnsafeRestoreIncompatibleVersion: restoreStmt.Options.UnsafeRestoreIncompatibleVersion,
 	}

--- a/pkg/backup/restore_planning_test.go
+++ b/pkg/backup/restore_planning_test.go
@@ -59,6 +59,7 @@ func TestRestoreResolveOptionsForJobDescription(t *testing.T) {
 		UnsafeRestoreIncompatibleVersion: true,
 		ExecutionLocality:                tree.NewDString("test expr"),
 		ExperimentalOnline:               true,
+		ExperimentalCopy:                 true,
 		RemoveRegions:                    true,
 
 		IntoDB:               tree.NewDString("test expr"),

--- a/pkg/backup/testdata/backup-restore/online-restore-empty-database
+++ b/pkg/backup/testdata/backup-restore/online-restore-empty-database
@@ -22,4 +22,4 @@ RESTORE DATABASE d FROM LATEST IN 'nodelocal://1/cluster/' with EXPERIMENTAL DEF
 query-sql retry
 SELECT count(*) FROM [SHOW JOBS] WHERE job_type='RESTORE' and status='succeeded';
 ----
-2
+1

--- a/pkg/jobs/jobspb/jobs.go
+++ b/pkg/jobs/jobspb/jobs.go
@@ -134,3 +134,7 @@ func (tsm *TimestampSpansMap) IsEmpty() bool {
 func (m *ChangefeedProgress_Checkpoint) IsEmpty() bool {
 	return m == nil || (len(m.Spans) == 0 && m.Timestamp.IsEmpty())
 }
+
+func (r RestoreDetails) OnlineImpl() bool {
+	return r.ExperimentalCopy || r.ExperimentalOnline
+}

--- a/pkg/jobs/jobspb/jobs.proto
+++ b/pkg/jobs/jobspb/jobs.proto
@@ -637,7 +637,9 @@ message RestoreDetails {
 
   bool download_job = 36;
 
-  // NEXT ID: 37.
+  bool experimental_copy = 37;
+
+  // NEXT ID: 38.
 }
 
 

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -4099,6 +4099,10 @@ restore_options:
   {
     $$.val = &tree.RestoreOptions{ExperimentalOnline: true}
   }
+| EXPERIMENTAL COPY
+{
+  $$.val = &tree.RestoreOptions{ExperimentalCopy: true}
+}
 | REMOVE_REGIONS
   {
     $$.val = &tree.RestoreOptions{RemoveRegions: true, SkipLocalitiesCheck: true}

--- a/pkg/sql/parser/testdata/backup_restore
+++ b/pkg/sql/parser/testdata/backup_restore
@@ -520,6 +520,15 @@ RESTORE DATABASE _ FROM 'latest' IN '*****' WITH OPTIONS (schema_only) -- identi
 RESTORE DATABASE foo FROM 'latest' IN 'bar' WITH OPTIONS (schema_only) -- passwords exposed
 
 parse
+RESTORE DATABASE foo FROM LATEST IN 'bar' WITH experimental copy
+----
+RESTORE DATABASE foo FROM 'latest' IN '*****' WITH OPTIONS (experimental copy) -- normalized!
+RESTORE DATABASE foo FROM ('latest') IN ('*****') WITH OPTIONS (experimental copy) -- fully parenthesized
+RESTORE DATABASE foo FROM '_' IN '_' WITH OPTIONS (experimental copy) -- literals removed
+RESTORE DATABASE _ FROM 'latest' IN '*****' WITH OPTIONS (experimental copy) -- identifiers removed
+RESTORE DATABASE foo FROM 'latest' IN 'bar' WITH OPTIONS (experimental copy) -- passwords exposed
+
+parse
 RESTORE DATABASE foo FROM LATEST IN 'bar' WITH incremental_location = 'baz'
 ----
 RESTORE DATABASE foo FROM 'latest' IN '*****' WITH OPTIONS (incremental_location = '*****') -- normalized!

--- a/pkg/sql/sem/tree/backup.go
+++ b/pkg/sql/sem/tree/backup.go
@@ -127,7 +127,12 @@ type RestoreOptions struct {
 	UnsafeRestoreIncompatibleVersion bool
 	ExecutionLocality                Expr
 	ExperimentalOnline               bool
+	ExperimentalCopy                 bool
 	RemoveRegions                    bool
+}
+
+func (opts *RestoreOptions) OnlineImpl() bool {
+	return opts.ExperimentalCopy || opts.ExperimentalOnline
 }
 
 var _ NodeFormatter = &RestoreOptions{}
@@ -488,6 +493,11 @@ func (o *RestoreOptions) Format(ctx *FmtCtx) {
 		ctx.WriteString("experimental deferred copy")
 	}
 
+	if o.ExperimentalCopy {
+		maybeAddSep()
+		ctx.WriteString("experimental copy")
+	}
+
 	if o.RemoveRegions {
 		maybeAddSep()
 		ctx.WriteString("remove_regions")
@@ -633,6 +643,14 @@ func (o *RestoreOptions) CombineWith(other *RestoreOptions) error {
 		o.ExperimentalOnline = other.ExperimentalOnline
 	}
 
+	if o.ExperimentalCopy {
+		if other.ExperimentalCopy {
+			return errors.New("experimental copy specified multiple times")
+		}
+	} else {
+		o.ExperimentalCopy = other.ExperimentalCopy
+	}
+
 	if o.RemoveRegions {
 		if other.RemoveRegions {
 			return errors.New("remove_regions specified multiple times")
@@ -666,6 +684,7 @@ func (o RestoreOptions) IsDefault() bool {
 		o.UnsafeRestoreIncompatibleVersion == options.UnsafeRestoreIncompatibleVersion &&
 		o.ExecutionLocality == options.ExecutionLocality &&
 		o.ExperimentalOnline == options.ExperimentalOnline &&
+		o.ExperimentalCopy == options.ExperimentalCopy &&
 		o.RemoveRegions == options.RemoveRegions
 }
 


### PR DESCRIPTION
This patch adds the `experimental copy` option to restore to conduct an online
restore with a blocking download job-- i.e. the job will only complete once the
download completes. An async download job will not be spun up.

Epic: none

Release note: this patch adds the new `experimental copy` to restore which runs
online restore, but waits to publish the tables until all data is downloaded.