### PR TITLE
jsonpath: add support for `starts with`

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/jsonb_path_query
+++ b/pkg/sql/logictest/testdata/logic_test/jsonb_path_query
@@ -1099,3 +1099,58 @@ query T
 SELECT jsonb_path_query('{}', '(null like_regex "^he.*$") is unknown');
 ----
 true
+
+query T
+SELECT jsonb_path_query('"abcdef"', '$ starts with "abc"');
+----
+true
+
+query T
+SELECT jsonb_path_query('"abc"', '$ starts with "abc"');
+----
+true
+
+query T
+SELECT jsonb_path_query('"ab"', '$ starts with "abc"');
+----
+false
+
+query T
+SELECT jsonb_path_query('"abcdef"', '$ starts with $var', '{"var": "abc"}');
+----
+true
+
+query T
+SELECT jsonb_path_query('"abc"', '$ starts with $var', '{"var": "abc"}');
+----
+true
+
+query T
+SELECT jsonb_path_query('"ab"', '$ starts with $var', '{"var": "abc"}');
+----
+false
+
+query T
+SELECT jsonb_path_query('["ab", "abc"]', '$ starts with $var', '{"var": "abc"}');
+----
+true
+
+query T
+SELECT jsonb_path_query('["ab", "a"]', '$ starts with $var', '{"var": "abc"}');
+----
+false
+
+query T
+SELECT jsonb_path_query('["ab", "abc"]', 'strict $ starts with $var', '{"var": "abc"}');
+----
+null
+
+query T
+SELECT jsonb_path_query('["ab", "abc"]', 'strict $ starts with $var', '{"var": 1}');
+----
+null
+
+query T
+SELECT jsonb_path_query('["ab", 1]', 'strict $ starts with $var', '{"var": "abc"}');
+----
+null

--- a/pkg/sql/logictest/testdata/logic_test/jsonb_path_query
+++ b/pkg/sql/logictest/testdata/logic_test/jsonb_path_query
@@ -914,6 +914,16 @@ SELECT jsonb_path_query('"He said \"Hello\\World!\""', '$ ? (@ like_regex ".*\"H
 ----
 "He said \"Hello\\World!\""
 
+query T
+SELECT jsonb_path_query('["hello", "a"]', '$ like_regex "he"');
+----
+true
+
+query T
+SELECT jsonb_path_query('["hello", "a"]', 'strict $ like_regex "he"');
+----
+null
+
 query T rowsort
 SELECT jsonb_path_query('{"a": [1, 2], "b": "hello"}', '$.a ? ($.b == "hello") ');
 ----

--- a/pkg/util/jsonpath/eval/operation.go
+++ b/pkg/util/jsonpath/eval/operation.go
@@ -6,6 +6,8 @@
 package eval
 
 import (
+	"strings"
+
 	"github.com/cockroachdb/apd/v3"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
@@ -53,7 +55,8 @@ func (ctx *jsonpathCtx) evalOperation(
 	case jsonpath.OpLogicalAnd, jsonpath.OpLogicalOr, jsonpath.OpLogicalNot,
 		jsonpath.OpCompEqual, jsonpath.OpCompNotEqual, jsonpath.OpCompLess,
 		jsonpath.OpCompLessEqual, jsonpath.OpCompGreater, jsonpath.OpCompGreaterEqual,
-		jsonpath.OpLikeRegex, jsonpath.OpExists, jsonpath.OpIsUnknown:
+		jsonpath.OpLikeRegex, jsonpath.OpExists, jsonpath.OpIsUnknown,
+		jsonpath.OpStartsWith:
 		b, err := ctx.evalBoolean(op, jsonValue)
 		if err != nil {
 			return []json.JSON{convertFromBool(jsonpathBoolUnknown)}, err
@@ -89,9 +92,29 @@ func (ctx *jsonpathCtx) evalBoolean(
 		return ctx.evalExists(op, jsonValue)
 	case jsonpath.OpIsUnknown:
 		return ctx.evalIsUnknown(op, jsonValue)
+	case jsonpath.OpStartsWith:
+		return ctx.evalPredicate(op, jsonValue, evalStartsWithFunc, true /* evalRight */, false /* unwrapRight */)
 	default:
 		panic(errors.AssertionFailedf("unhandled operation type"))
 	}
+}
+
+func evalStartsWithFunc(_ jsonpath.Operation, l, r json.JSON) (jsonpathBool, error) {
+	if l.Type() != json.StringJSONType || r.Type() != json.StringJSONType {
+		return jsonpathBoolUnknown, nil
+	}
+	left, err := l.AsText()
+	if err != nil {
+		return jsonpathBoolUnknown, err
+	}
+	right, err := r.AsText()
+	if err != nil {
+		return jsonpathBoolUnknown, err
+	}
+	if strings.HasPrefix(*left, *right) {
+		return jsonpathBoolTrue, nil
+	}
+	return jsonpathBoolFalse, nil
 }
 
 func (ctx *jsonpathCtx) evalIsUnknown(

--- a/pkg/util/jsonpath/operation.go
+++ b/pkg/util/jsonpath/operation.go
@@ -29,6 +29,7 @@ const (
 	OpMinus
 	OpExists
 	OpIsUnknown
+	OpStartsWith
 )
 
 var OperationTypeStrings = map[OperationType]string{
@@ -51,6 +52,7 @@ var OperationTypeStrings = map[OperationType]string{
 	OpMinus:            "-",
 	OpExists:           "exists",
 	OpIsUnknown:        "is unknown",
+	OpStartsWith:       "starts with",
 }
 
 type Operation struct {

--- a/pkg/util/jsonpath/parser/testdata/jsonpath
+++ b/pkg/util/jsonpath/parser/testdata/jsonpath
@@ -544,6 +544,21 @@ parse
 ----
 ((null like_regex "^he.*$")) is unknown -- normalized!
 
+parse
+$ starts with "abc"
+----
+($ starts with "abc") -- normalized!
+
+parse
+$.a ? (@.b starts with "def")
+----
+$."a"?((@."b" starts with "def")) -- normalized!
+
+parse
+$.a starts with $var
+----
+($."a" starts with $"var") -- normalized!
+
 # postgres allows floats as array indexes
 # parse
 # $.abc[1.0]


### PR DESCRIPTION
#### jsonpath: reuse `evalComparison` logic for all predicate expressions

This commit refactors `evalComparison` to be used for `like_regex` logic
in addition to comparison operators. This allows for `like_regex` to
have existence semantics when being evaluated on arrays of strings, rather
than throwing an error.

Epic: None
Release note: None

#### jsonpath: add support for `starts with`

This commit adds support for using `starts with` within jsonpath
queries. This returns a boolean - whether or not the string or
variable following the `starts with` directive is the prefix of
the current json string.

Epic: None
Release note (sql change): Add support for `starts with ""` in JSONPath
queries. For example, `SELECT jsonb_path_query('"abcdef"', '$
starts with "abc"');`.
