### PR TITLE
kvfeed: fix race when draining and closing buffer

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -3411,6 +3411,7 @@ func TestChangefeedSingleColumnFamilySchemaChanges(t *testing.T) {
 	cdcTest(t, testFn)
 }
 
+// TODO update this test
 func TestChangefeedEachColumnFamilySchemaChanges(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)

--- a/pkg/ccl/changefeedccl/kvevent/event.go
+++ b/pkg/ccl/changefeedccl/kvevent/event.go
@@ -57,6 +57,7 @@ type Writer interface {
 	// Add adds event to this writer.
 	Add(ctx context.Context, event Event) error
 	// Drain waits until all events buffered by this writer has been consumed.
+	// It then closes the writer with reason ErrNormalRestartReason.
 	Drain(ctx context.Context) error
 	// CloseWithReason closes this writer. reason may be added as a detail to ErrBufferClosed.
 	CloseWithReason(ctx context.Context, reason error) error

--- a/pkg/ccl/changefeedccl/kvfeed/kv_feed.go
+++ b/pkg/ccl/changefeedccl/kvfeed/kv_feed.go
@@ -172,10 +172,7 @@ func Run(ctx context.Context, cfg Config) error {
 	// Regardless of whether drain succeeds, we must also close the buffer to release
 	// any resources, and to let the consumer (changeAggregator) know that no more writes
 	// are expected so that it can transition to a draining state.
-	err = errors.CombineErrors(
-		f.writer.Drain(ctx),
-		f.writer.CloseWithReason(ctx, kvevent.ErrNormalRestartReason),
-	)
+	err = f.writer.Drain(ctx)
 
 	if err == nil {
 		// This context is canceled by the change aggregator when it receives


### PR DESCRIPTION
This patch fixes a race condition in the kv feed that exists because
a mutex is left unlocked between draining and closing the blocking
buffer, potentially leading to events being added to the buffer after
it's drained but before it's closed.

Release note (bug fix): TODO