### PR TITLE
tree: include gist into enum comparison assertion

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -4854,4 +4854,5 @@ func init() {
 	logcrash.RegisterTagFn("gist", func(ctx context.Context) string {
 		return planGistFromCtx(ctx)
 	})
+	tree.PlanGistFromCtx = planGistFromCtx
 }


### PR DESCRIPTION
In theory, the plan gist should already be included in all ~assertion failures~sentry reports, but it doesn't happen in practice. Let's include it explicitly (if it is present in the context) into the enum mismatched version comparison error to help with tracking it down.

Informs: #143571
Epic: None
Release note: None