### PR TITLE
roachtest/tpce: add unit and is_higher_better labels for tpce benchmark metrics

### DIFF
--- a/pkg/cmd/roachtest/tests/tpce.go
+++ b/pkg/cmd/roachtest/tests/tpce.go
@@ -368,7 +368,7 @@ func exportTPCEResults(t test.Test, c cluster.Cluster, result string) error {
 				"workload": "tpce",
 			}
 			labelString := roachtestutil.GetOpenmetricsLabelString(t, c, labels)
-			metricBytes = getOpenMetrics(metrics, fields[5], labelString)
+			metricBytes = GetTpceOpenmetricsBytes(metrics, fields[5], labelString)
 		} else {
 			metricBytes, err = json.Marshal(metrics)
 		}
@@ -389,19 +389,29 @@ func exportTPCEResults(t test.Test, c cluster.Cluster, result string) error {
 	return errors.Errorf("exportTPCEResults: found no lines starting with TradeResult")
 }
 
-func getOpenMetrics(metrics tpceMetrics, countOfLatencies string, labelString string) []byte {
+func GetTpceOpenmetricsBytes(
+	metrics tpceMetrics, countOfLatencies string, labelString string,
+) []byte {
 
 	var buffer bytes.Buffer
 	now := timeutil.Now().Unix()
 
 	buffer.WriteString("# TYPE tpce_latency summary\n")
 	buffer.WriteString("# HELP tpce_latency Latency metrics for TPC-E transactions\n")
-	buffer.WriteString(fmt.Sprintf("tpce_latency{%s,quantile=\"0.5\"} %s %d\n", labelString, metrics.P50Latency, now))
-	buffer.WriteString(fmt.Sprintf("tpce_latency{%s,quantile=\"0.9\"} %s %d\n", labelString, metrics.P90Latency, now))
-	buffer.WriteString(fmt.Sprintf("tpce_latency{%s,quantile=\"0.99\"} %s %d\n", labelString, metrics.P99Latency, now))
-	buffer.WriteString(fmt.Sprintf("tpce_latency{%s,quantile=\"1.0\"} %s %d\n", labelString, metrics.PMaxLatency, now))
+
+	latencyString := func(quantile, latency string) string {
+		return fmt.Sprintf(`tpce_latency{%s,unit="ms",is_higher_better="false",quantile="%s"} %s %d\n`, labelString, quantile, latency, now)
+	}
+
+	buffer.WriteString(latencyString("0.5", metrics.P50Latency))
+	buffer.WriteString(latencyString("0.9", metrics.P90Latency))
+	buffer.WriteString(latencyString("0.99", metrics.P99Latency))
+	buffer.WriteString(latencyString("1.0", metrics.PMaxLatency))
+	// Sum is hardcoded is zero to denote null values, since we don't have exact values
 	buffer.WriteString(fmt.Sprintf("tpce_latency_sum{%s} %d %d\n", labelString, 0, now))
 	buffer.WriteString(fmt.Sprintf("tpce_latency_count{%s} %s %d\n", labelString, countOfLatencies, now))
+	buffer.WriteString("# TYPE tpce_avg_latency gauge\n")
+	buffer.WriteString(fmt.Sprintf(`tpce_avg_latency{%s,unit="ms",is_higher_better="false"} %s %d\n`, labelString, metrics.AvgLatency, now))
 	buffer.WriteString("# EOF")
 
 	metricsBytes := buffer.Bytes()


### PR DESCRIPTION


The golang perf dashboards require unit and is_higher_better labels for correctly plotting the comparison metrics. This relevant change awas added to the aggregated metrics change for histograms.

Since the tpce benchmark doesn't emit a histogram from the workload binary, this commit aims to manually add the labels while emitting the metrics.

Epic: CRDB-48908

Release note: None