### PR TITLE
sql: Queries under the InternalAppNamePrefix attribute to internal metrics.

### DIFF
--- a/pkg/cli/sql_client.go
+++ b/pkg/cli/sql_client.go
@@ -136,8 +136,14 @@ func makeSQLClientForBaseURL(
 	// If there is no user in the URL already, fill in the default user.
 	sqlCtx.User = username.RootUser
 
-	// If there is no application name already, use the provided one.
-	sqlCtx.ApplicationName = catconstants.ReportableAppNamePrefix + appName
+	// Some cli utilities (ex/ debug zip) use an InternalAppNamePrefix so that
+	// they do not affect user facing SQL metrics (and as a result the SQL charts
+	// in the DB Console).
+	if strings.HasPrefix(appName, catconstants.InternalAppNamePrefix) {
+		sqlCtx.ApplicationName = appName
+	} else {
+		sqlCtx.ApplicationName = catconstants.ReportableAppNamePrefix + appName
+	}
 
 	// How we're going to authenticate.
 	usePw, _, _ := baseURL.GetAuthnPassword()

--- a/pkg/cli/zip.go
+++ b/pkg/cli/zip.go
@@ -291,7 +291,7 @@ func runDebugZip(cmd *cobra.Command, args []string) (retErr error) {
 
 			zr.sqlOutputFilenameExtension = computeSQLOutputFilenameExtension(sqlExecCtx.TableDisplayFormat)
 
-			sqlConn, err := makeTenantSQLClient(ctx, "cockroach zip", useSystemDb, tenant.TenantName)
+			sqlConn, err := makeTenantSQLClient(ctx, catconstants.InternalAppNamePrefix+" cockroach zip", useSystemDb, tenant.TenantName)
 			// The zip output is sent directly into a text file, so the results should
 			// be scanned into strings.
 			_ = sqlConn.SetAlwaysInferResultTypes(false)

--- a/pkg/sql/sem/catconstants/constants.go
+++ b/pkg/sql/sem/catconstants/constants.go
@@ -20,7 +20,7 @@ const InternalAppNamePrefix = ReportableAppNamePrefix + "internal"
 
 // AttributedToUserInternalAppNamePrefix indicates that the application name
 // identifies an internally-executed query that should be attributed to the
-// user.
+// user. Specifically, this means having the queries show up in SQL activity pages.
 const AttributedToUserInternalAppNamePrefix = ReportableAppNamePrefix + "public-internal"
 
 // DelegatedAppNamePrefix is added to a regular client application


### PR DESCRIPTION
Previously, there did not exist a way for external connections to have their
SQL metrics (ex/ `sql.insert.count`) be counted as internal queries
(ex/ `sql.insert.count.internal`).

This is specifically problematic for cli utilities like `cockroach debug zip`
which issue SQL queries that often take much longer than queries in a user's
workload. As a result, users see a spike in their p99.99 or p99.9 SQL service
latencies causing unnecessary concern.

This commit utilizes the existing constant InternalAppNamePrefix. Specifically,
it modifies the connExecutor to set the metrics struct to the server's internal
or user facing metrics according to the app name.

This commit also modifies the debug zip to use the InternalAppNamePrefix.

Fixes: https://github.com/cockroachdb/cockroach/issues/143224

Release note (ops change): debug zip queries are attributed towards internal
sql metrics. As a result user's won't see the debug zip impact on the SQL
charts in DB console.