### PR TITLE
raft: Pipeline hints into MsgVoteResp

### DIFF
--- a/pkg/raft/log.go
+++ b/pkg/raft/log.go
@@ -235,9 +235,13 @@ func (l *raftLog) match(s LeadSlice) (uint64, bool) {
 //
 // The second returned value is the term(guessIndex), or 0 if it is unknown.
 //
-// This function is used by a follower and leader to resolve log conflicts after
-// an unsuccessful append to a follower, and ultimately restore the steady flow
-// of appends.
+
+// This function is used by:
+//  1. a follower and leader to resolve log conflicts after an unsuccessful
+//     append to a follower, and ultimately restore the steady flow of appends.
+//  2. a voter and candidate, for the same purpose as above but during election.
+//     If the candidate wins election, it can enter the steady flow of appends
+//     faster (usually directly).
 func (l *raftLog) findConflictByTerm(index uint64, term uint64) (uint64, uint64) {
 	// Entry terms in a log are monotonic. A specific entry being (index, term)
 	// means term(i) <= term for all i <= index in that log. That is, we know the

--- a/pkg/raft/raft.go
+++ b/pkg/raft/raft.go
@@ -2201,22 +2201,7 @@ func stepCandidate(r *raft, m pb.Message) error {
 		r.becomeFollower(m.Term, None)
 		r.handleSnapshot(m)
 	case myVoteRespType:
-		gr, rj, res := r.poll(m.From, m.Type, !m.Reject)
-		r.logger.Infof("%x has received %d %s votes and %d vote rejections", r.id, gr, m.Type, rj)
-		switch res {
-		case quorum.VoteWon:
-			if r.state == pb.StatePreCandidate {
-				r.campaign(campaignElection)
-			} else {
-				r.becomeLeader()
-				r.bcastFortify()
-				r.bcastAppend()
-			}
-		case quorum.VoteLost:
-			// pb.MsgPreVoteResp contains future term of pre-candidate
-			// m.Term > r.Term; reuse r.Term
-			r.becomeFollower(r.Term, None)
-		}
+		r.handleVoteResp(m)
 	}
 	return nil
 }
@@ -2342,6 +2327,25 @@ func leadSliceFromMsgApp(m *pb.Message) LeadSlice {
 			prev:    entryID{term: m.LogTerm, index: m.Index},
 			entries: m.Entries,
 		},
+	}
+}
+
+func (r *raft) handleVoteResp(m pb.Message) {
+	gr, rj, res := r.poll(m.From, m.Type, !m.Reject)
+	r.logger.Infof("%x has received %d %s votes and %d vote rejections", r.id, gr, m.Type, rj)
+	switch res {
+	case quorum.VoteWon:
+		if r.state == pb.StatePreCandidate {
+			r.campaign(campaignElection)
+		} else {
+			r.becomeLeader()
+			r.bcastFortify()
+			r.bcastAppend()
+		}
+	case quorum.VoteLost:
+		// pb.MsgPreVoteResp contains future term of pre-candidate
+		// m.Term > r.Term; reuse r.Term
+		r.becomeFollower(r.Term, None)
 	}
 }
 

--- a/pkg/raft/raft.go
+++ b/pkg/raft/raft.go
@@ -1540,14 +1540,14 @@ func (r *raft) campaign(t CampaignType) {
 }
 
 func (r *raft) poll(
-	id pb.PeerID, t pb.MessageType, v bool,
+	id pb.PeerID, t pb.MessageType, v bool, matchGuess tracker.MatchGuess,
 ) (granted int, rejected int, result quorum.VoteResult) {
 	if v {
 		r.logger.Infof("%x received %s from %x at term %d", r.id, t, id, r.Term)
 	} else {
 		r.logger.Infof("%x received %s rejection from %x at term %d", r.id, t, id, r.Term)
 	}
-	r.electionTracker.RecordVote(id, v)
+	r.electionTracker.RecordVote(id, v, matchGuess)
 	return r.electionTracker.TallyVotes()
 }
 

--- a/pkg/raft/raft.go
+++ b/pkg/raft/raft.go
@@ -1342,7 +1342,43 @@ func (r *raft) becomeLeader() {
 		panic("invalid transition [follower -> leader]")
 	}
 	r.step = stepLeader
-	r.reset(r.Term, nil)
+
+	// A special visit function to use the recorded hints and optimize the first
+	// round of MsgApp after becoming leader.
+	r.reset(r.Term, func(id pb.PeerID, pr *tracker.Progress) {
+		// matchGuess would only be recorded if the voter voted for this candidate.
+		matchGuess, voted := r.electionTracker.MatchGuess(id)
+		if !voted {
+			matchGuess = tracker.MatchGuess{Index: r.raftLog.lastIndex()}
+		}
+
+		*pr = tracker.Progress{
+			Match:       0,
+			MatchCommit: 0,
+			Next:        matchGuess.Index + 1,
+			Inflights:   tracker.NewInflights(r.maxInflight, r.maxInflightBytes),
+			IsLearner:   pr.IsLearner,
+			// Since the voter voted for us(not during pre-election), we can set
+			// RecentActive to true.
+			// (We set RecentActive to true for every MsgAppResp, so we treat
+			// MsgVoteResp(non-reject) the same in this case)
+			// In the case that Progress.Next <= r.raftLog.storage.Compacted(),
+			// RecentActive needs to be true in order to send out a snapshot
+			// immediately after becoming leader.
+			RecentActive: voted,
+		}
+
+		if matchGuess.Match {
+			// Follower's log matches the leader's log at next-1.
+			// Set the follower's state to StateReplicate early.
+			r.becomeReplicate(pr)
+			// NB: this is a bit of a hack, but we need to set the Next again since
+			// r.becomeReplicate sets pr.Next to match + 1.
+			// Where match is 0 in this case.
+			pr.Next = matchGuess.Index + 1
+		}
+	})
+
 	// NB: The fortificationTracker holds state from a peer's leadership stint
 	// that's acted upon after it has stepped down. We reset it right before
 	// stepping up to become leader again, but not when stepping down as leader
@@ -1365,11 +1401,14 @@ func (r *raft) becomeLeader() {
 			return
 		}
 		// All peer flows, except the leader's own, are initially in StateProbe.
+		// However, if discovered during voting that the follower's log matches the
+		// leader's, the follower is set to StateReplicate.
 		// Account the probe state entering in metrics here. All subsequent flow
 		// state changes, while we are the leader, are counted in the corresponding
 		// methods: becomeProbe, becomeReplicate, becomeSnapshot.
-		assertTrue(pr.State == tracker.StateProbe, "peers must be in StateProbe on leader step up")
-		r.metrics.FlowsEnteredStateProbe.Inc(1)
+		if pr.State == tracker.StateProbe {
+			r.metrics.FlowsEnteredStateProbe.Inc(1)
+		}
 	})
 
 	// Conservatively set the pendingConfIndex to the last index in the
@@ -2228,7 +2267,7 @@ func stepCandidate(r *raft, m pb.Message) error {
 		r.becomeFollower(m.Term, None)
 		r.handleSnapshot(m)
 	case myVoteRespType:
-		r.handleVoteResp(m)
+		r.handleVoteResp(m, myVoteRespType)
 	}
 	return nil
 }
@@ -2357,8 +2396,44 @@ func leadSliceFromMsgApp(m *pb.Message) LeadSlice {
 	}
 }
 
-func (r *raft) handleVoteResp(m pb.Message) {
-	gr, rj, res := r.poll(m.From, m.Type, !m.Reject)
+func (r *raft) handleVoteResp(m pb.Message, myVoteRespType pb.MessageType) {
+	voterHint := entryID{index: m.RejectHint, term: m.LogTerm}
+	matchGuess := tracker.MatchGuess{Index: r.raftLog.lastIndex()}
+
+	// If the voter voted for us through MsgVoteResp, it will not vote again at
+	// terms <= r.Term, and can only accept MsgApp from terms >= term. Thus, if
+	// this candidate wins election, the voter's log will not change until the
+	// first MsgApp from this or later leader.
+	// (See section 5.2 & 5.4 of the Raft paper for more details.)
+	if myVoteRespType == pb.MsgVoteResp && !m.Reject &&
+		// Avoid scanning the whole leader log in findConflictByTerm if the voter
+		// did not attach a valid hint for any reason.
+		voterHint.term > 0 && voterHint.index > 0 &&
+		// Voter side logic should ensure this is true.
+		// Leaving this check here just to be safe.
+		voterHint.index <= r.raftLog.lastIndex() {
+		// index <= voterHint.index.
+		// Also, raftLog.term(index) <= voterHint.term, or the entry at index
+		// is missing.
+		index, term := r.raftLog.findConflictByTerm(voterHint.index, voterHint.term)
+		matchGuess = tracker.MatchGuess{
+			Index: index,
+			// If we found an entry at <= voterHint.index with a matching term then
+			// our log matches the voter's at matchGuess, by Log Matching Property.
+			// (See findConflictByTerm for proof.)
+			//
+			// If this candidate becomes the leader, it can directly set this
+			// follower to StateReplicate and begin sending MsgApp from matchGuess.
+			//
+			// The returned term can be 0 if the entry at the index is missing, in
+			// which case we don't consider it a match.
+			Match: term == voterHint.term,
+		}
+	}
+
+	// Record Vote and hint information. The collected matchGuess will be used
+	// for the first round of MsgApp if this candidate wins election.
+	gr, rj, res := r.poll(m.From, m.Type, !m.Reject, matchGuess)
 	r.logger.Infof("%x has received %d %s votes and %d vote rejections", r.id, gr, m.Type, rj)
 	switch res {
 	case quorum.VoteWon:

--- a/pkg/raft/raft_test.go
+++ b/pkg/raft/raft_test.go
@@ -5032,7 +5032,7 @@ func entsWithConfig(configFunc func(*Config), terms ...uint64) *raft {
 		configFunc(cfg)
 	}
 	sm := newRaft(cfg)
-	sm.reset(terms[len(terms)-1])
+	sm.reset(terms[len(terms)-1], nil)
 	return sm
 }
 
@@ -5047,7 +5047,7 @@ func votedWithConfig(configFunc func(*Config), vote pb.PeerID, term uint64) *raf
 		configFunc(cfg)
 	}
 	sm := newRaft(cfg)
-	sm.reset(term)
+	sm.reset(term, nil)
 	return sm
 }
 
@@ -5290,7 +5290,7 @@ func newNetworkWithConfigAndLivenessFabric(
 				}
 				v.trk.TestingSetProgress(peerAddrs[i], pr)
 			}
-			v.reset(v.Term)
+			v.reset(v.Term, nil)
 			npeers[id] = v
 		case *blackHole:
 			npeers[id] = v

--- a/pkg/raft/raft_test.go
+++ b/pkg/raft/raft_test.go
@@ -2685,6 +2685,159 @@ func TestLeaderAppResp(t *testing.T) {
 	}
 }
 
+// TestVoteHintPipelining tests that a candidate correctly processes
+// MsgVoteResp messages that include the voter's last entryID.
+// When the candidate wins the election and becomes leader, it should initialize
+// the follower's Progress.Next value using this best guess information.
+// This test checks various combinations of candidate logs and voter hints to
+// ensure proper initialization of the replication state after election.
+func TestVoteHintPipelining(t *testing.T) {
+	testCases := []struct {
+		candidateLog LeadSlice         // log entries in the candidate
+		voterLast    entryID           // last entryID in the voter's log
+		next         uint64            // expected Progress.Next after election
+		prState      tracker.StateType // expected Progress.State after election
+		compact      uint64            // compact the candidate log before campaigning if not 0
+	}{
+		// NB: All the test illustrations shows a possible/legal raft log of voter n2.
+		// However, the candidate n1 doesn't know what the log of n2 is like.
+		// Since the only information we have is the last entryID of the voter.
+		{
+			// NB: This test case is for showing if the voter did not attach a hint.
+			// For mixed version tests, the voter would not attach anything because it
+			// is still running on old code.
+			// The candidate will just ignore the hint because
+			// !(m.RejectHint != 0 && m.LogTerm != 0)
+			// And set next to be the dummy entry index at 11 after becoming leader.
+			// The follower Progress.State is in StateProbe same as before the change.
+			//      1  2  3  4  5  6  7  8  9  10 11 12
+			// n1: [1][1][1][4][4][5][5][6][6][6]
+			candidateLog: entryID{}.append(1, 1, 1, 4, 4, 5, 5, 6, 6, 6),
+			voterLast: entryID{
+				term:  0,
+				index: 0,
+			},
+			next:    11,
+			prState: tracker.StateProbe,
+		},
+		{
+			//       n1.compacted() = 3
+			//              |
+			//      1  2  3 | 4  5  6  7  8  9  10 11 12
+			// n1: [1][1][1]|[4][4][5][5][6][6][6]
+			// n2: [1][1]
+			candidateLog: entryID{}.append(1, 1, 1, 4, 4, 5, 5, 6, 6, 6),
+			voterLast: entryID{
+				term:  1,
+				index: 2,
+			},
+			// NB: next is 1 here because index is not set in MsgSnap.
+			next:    1,
+			prState: tracker.StateSnapshot,
+			compact: 3,
+		},
+		{
+			//      1  2  3  4  5  6  7  8  9  10 11 12
+			// n1: [1][1][1][4][4][5][5][6][6][6]
+			// n2: [1][1][1][4][4][5][5][6][6][6]
+			candidateLog: entryID{}.append(1, 1, 1, 4, 4, 5, 5, 6, 6, 6),
+			voterLast: entryID{
+				term:  6,
+				index: 10,
+			},
+			next:    11,
+			prState: tracker.StateReplicate,
+		},
+		{
+			//      1  2  3  4  5  6  7  8  9  10 11 12
+			// n1: [1][1][1][4][4][5][5][6][6][6]
+			// n2: [1][1][1][4][4][5][5][6][6]
+			candidateLog: entryID{}.append(1, 1, 1, 4, 4, 5, 5, 6, 6, 6),
+			voterLast: entryID{
+				term:  6,
+				index: 9,
+			},
+			next:    10,
+			prState: tracker.StateReplicate,
+		},
+		{
+			//      1  2  3  4  5  6  7  8  9  10 11 12
+			// n1: [1][1][1][4][4][5][5][6][6][6]
+			// n2: [1][1][1][4][4][5][5][6]
+			candidateLog: entryID{}.append(1, 1, 1, 4, 4, 5, 5, 6, 6, 6),
+			voterLast: entryID{
+				term:  6,
+				index: 8,
+			},
+			next:    9,
+			prState: tracker.StateReplicate,
+		},
+		{
+			//      1  2  3  4  5  6  7  8  9  10 11 12
+			// n1: [1][1][1][4][4][5][5][6][6][6]
+			// n2: [1][1][1][4][4][5][5]
+			candidateLog: entryID{}.append(1, 1, 1, 4, 4, 5, 5, 6, 6, 6),
+			voterLast: entryID{
+				term:  5,
+				index: 7,
+			},
+			next:    8,
+			prState: tracker.StateReplicate,
+		},
+		{
+			//      1  2  3  4  5  6  7  8  9  10 11 12
+			// n1: [1][1][1][4][4][5][5][6][6][6]
+			// n2: [1][1][1][4][4][4][4]
+			candidateLog: entryID{}.append(1, 1, 1, 4, 4, 5, 5, 6, 6, 6),
+			voterLast: entryID{
+				term:  4,
+				index: 7,
+			},
+			next:    6,
+			prState: tracker.StateReplicate,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run("", func(t *testing.T) {
+			// Create storage with the candidate's log
+			storage := newTestMemoryStorage(withPeers(1, 2, 3))
+			require.NoError(t, storage.Append(tc.candidateLog.entries))
+			if tc.compact != 0 {
+				storage.Compact(tc.compact)
+			}
+
+			// Create candidate node
+			r := newTestRaft(1, 5, 1, storage)
+			r.Term = tc.candidateLog.term
+			// pr.Next does not increment after the leader wins election since
+			// we don't immediately send out the first round of MsgApps.
+			r.lazyReplication = true
+			// n1 campaigns.
+			r.Step(pb.Message{From: 1, To: 1, Type: pb.MsgHup})
+			r.advanceMessagesAfterAppend()
+
+			// Simulate receiving vote response from node 2
+			r.Step(pb.Message{
+				From: 2,
+				To:   1,
+				Term: tc.candidateLog.term + 1,
+				// Node 2 includes its last entryID as hint.
+				RejectHint: tc.voterLast.index,
+				LogTerm:    tc.voterLast.term,
+				Type:       pb.MsgVoteResp,
+			})
+
+			// The candidate should now be leader after receiving vote from node 2.
+			assert.Equal(t, pb.StateLeader, r.state)
+
+			p := r.trk.Progress(2)
+			assert.Equal(t, tc.next, p.Next)
+			assert.Equal(t, tc.prState, p.State)
+		})
+	}
+}
+
 // TestBcastBeat is when the leader receives a heartbeat tick, it should
 // send a MsgHeartbeat with m.Index = 0, m.LogTerm=0 and empty entries if
 // store liveness is disabled. On the other hand, if store liveness is enabled,

--- a/pkg/raft/testdata/async_storage_writes.txt
+++ b/pkg/raft/testdata/async_storage_writes.txt
@@ -54,12 +54,12 @@ stabilize
   Ready:
   HardState Term:1 Vote:1 Commit:10 Lead:0 LeadEpoch:0
   OnSync:
-  2->1 MsgVoteResp Term:1 Log:0/0
+  2->1 MsgVoteResp Term:1 Log:1/0 Hint:1/10
 > 3 handling Ready
   Ready:
   HardState Term:1 Vote:1 Commit:10 Lead:0 LeadEpoch:0
   OnSync:
-  3->1 MsgVoteResp Term:1 Log:0/0
+  3->1 MsgVoteResp Term:1 Log:1/0 Hint:1/10
 > 1 receiving messages
   1->1 MsgVoteResp Term:1 Log:0/0
   1->1 StorageAppendAck Mark:{Term:0 Index:0}
@@ -68,17 +68,17 @@ stabilize
 > 2 processing append thread
   HardState {Term:1 Vote:1 Commit:10 Lead:0 LeadEpoch:0}
   OnSync:
-  2->1 MsgVoteResp Term:1 Log:0/0
+  2->1 MsgVoteResp Term:1 Log:1/0 Hint:1/10
 > 3 processing append thread
   HardState {Term:1 Vote:1 Commit:10 Lead:0 LeadEpoch:0}
   OnSync:
-  3->1 MsgVoteResp Term:1 Log:0/0
+  3->1 MsgVoteResp Term:1 Log:1/0 Hint:1/10
 > 1 receiving messages
-  2->1 MsgVoteResp Term:1 Log:0/0
+  2->1 MsgVoteResp Term:1 Log:1/0 Hint:1/10
   INFO 1 received MsgVoteResp from 2 at term 1
   INFO 1 has received 2 MsgVoteResp votes and 0 vote rejections
   INFO 1 became leader at term 1
-  3->1 MsgVoteResp Term:1 Log:0/0
+  3->1 MsgVoteResp Term:1 Log:1/0 Hint:1/10
 > 1 handling Ready
   Ready:
   State:StateLeader

--- a/pkg/raft/testdata/async_storage_writes_append_aba_race.txt
+++ b/pkg/raft/testdata/async_storage_writes_append_aba_race.txt
@@ -231,7 +231,7 @@ HardState Term:2 Commit:11 Lead:3 LeadEpoch:1
 Entries:
 2/12 EntryNormal ""
 OnSync:
-1->3 MsgVoteResp Term:2 Log:0/0 Rejected (Hint: 0)
+1->3 MsgVoteResp Term:2 Log:0/0 Rejected
 1->3 MsgFortifyLeaderResp Term:2 Log:0/0 LeadEpoch:1
 1->3 MsgAppResp Term:2 Log:0/12 Commit:11
 
@@ -445,7 +445,7 @@ stabilize 1
   HardState {Term:2 Commit:11 Lead:3 LeadEpoch:1}
   Entry: 2/12 EntryNormal ""
   OnSync:
-  1->3 MsgVoteResp Term:2 Log:0/0 Rejected (Hint: 0)
+  1->3 MsgVoteResp Term:2 Log:0/0 Rejected
   1->3 MsgFortifyLeaderResp Term:2 Log:0/0 LeadEpoch:1
   1->3 MsgAppResp Term:2 Log:0/12 Commit:11
   HardState {Term:3 Commit:11 Lead:4 LeadEpoch:1}

--- a/pkg/raft/testdata/async_storage_writes_append_aba_race.txt
+++ b/pkg/raft/testdata/async_storage_writes_append_aba_race.txt
@@ -385,9 +385,9 @@ Messages:
 4->1 MsgApp Term:3 Log:1/11 Commit:11 Entries:[3/12 EntryNormal ""]
 4->2 MsgApp Term:3 Log:1/11 Commit:11 Entries:[3/12 EntryNormal ""]
 4->3 MsgApp Term:3 Log:1/11 Commit:11 Entries:[3/12 EntryNormal ""]
-4->5 MsgApp Term:3 Log:1/11 Commit:11 Entries:[3/12 EntryNormal ""]
-4->6 MsgApp Term:3 Log:1/11 Commit:11 Entries:[3/12 EntryNormal ""]
-4->7 MsgApp Term:3 Log:1/11 Commit:11 Entries:[3/12 EntryNormal ""]
+4->5 MsgApp Term:3 Log:3/12 Commit:11
+4->6 MsgApp Term:3 Log:3/12 Commit:11
+4->7 MsgApp Term:3 Log:3/12 Commit:11
 OnSync:
 4->4 MsgFortifyLeaderResp Term:3 Log:0/0 LeadEpoch:1
 

--- a/pkg/raft/testdata/async_storage_writes_append_aba_race.txt
+++ b/pkg/raft/testdata/async_storage_writes_append_aba_race.txt
@@ -124,17 +124,17 @@ process-ready 4 5 6
   Ready:
   HardState Term:2 Vote:3 Commit:11 Lead:0 LeadEpoch:0
   OnSync:
-  4->3 MsgVoteResp Term:2 Log:0/0
+  4->3 MsgVoteResp Term:2 Log:1/0 Hint:1/11
 > 5 handling Ready
   Ready:
   HardState Term:2 Vote:3 Commit:11 Lead:0 LeadEpoch:0
   OnSync:
-  5->3 MsgVoteResp Term:2 Log:0/0
+  5->3 MsgVoteResp Term:2 Log:1/0 Hint:1/11
 > 6 handling Ready
   Ready:
   HardState Term:2 Vote:3 Commit:11 Lead:0 LeadEpoch:0
   OnSync:
-  6->3 MsgVoteResp Term:2 Log:0/0
+  6->3 MsgVoteResp Term:2 Log:1/0 Hint:1/11
 
 process-append-thread 3 4 5 6
 ----
@@ -145,15 +145,15 @@ process-append-thread 3 4 5 6
 > 4 processing append thread
   HardState {Term:2 Vote:3 Commit:11 Lead:0 LeadEpoch:0}
   OnSync:
-  4->3 MsgVoteResp Term:2 Log:0/0
+  4->3 MsgVoteResp Term:2 Log:1/0 Hint:1/11
 > 5 processing append thread
   HardState {Term:2 Vote:3 Commit:11 Lead:0 LeadEpoch:0}
   OnSync:
-  5->3 MsgVoteResp Term:2 Log:0/0
+  5->3 MsgVoteResp Term:2 Log:1/0 Hint:1/11
 > 6 processing append thread
   HardState {Term:2 Vote:3 Commit:11 Lead:0 LeadEpoch:0}
   OnSync:
-  6->3 MsgVoteResp Term:2 Log:0/0
+  6->3 MsgVoteResp Term:2 Log:1/0 Hint:1/11
 
 deliver-msgs 3
 ----
@@ -161,13 +161,13 @@ deliver-msgs 3
 3->3 StorageAppendAck Mark:{Term:0 Index:0}
 INFO 3 received MsgVoteResp from 3 at term 2
 INFO 3 has received 1 MsgVoteResp votes and 0 vote rejections
-4->3 MsgVoteResp Term:2 Log:0/0
+4->3 MsgVoteResp Term:2 Log:1/0 Hint:1/11
 INFO 3 received MsgVoteResp from 4 at term 2
 INFO 3 has received 2 MsgVoteResp votes and 0 vote rejections
-5->3 MsgVoteResp Term:2 Log:0/0
+5->3 MsgVoteResp Term:2 Log:1/0 Hint:1/11
 INFO 3 received MsgVoteResp from 5 at term 2
 INFO 3 has received 3 MsgVoteResp votes and 0 vote rejections
-6->3 MsgVoteResp Term:2 Log:0/0
+6->3 MsgVoteResp Term:2 Log:1/0 Hint:1/11
 INFO 3 received MsgVoteResp from 6 at term 2
 INFO 3 has received 4 MsgVoteResp votes and 0 vote rejections
 INFO 3 became leader at term 2
@@ -284,17 +284,17 @@ process-ready 5 6 7
   Ready:
   HardState Term:3 Vote:4 Commit:11 Lead:0 LeadEpoch:0
   OnSync:
-  5->4 MsgVoteResp Term:3 Log:0/0
+  5->4 MsgVoteResp Term:3 Log:1/0 Hint:1/11
 > 6 handling Ready
   Ready:
   HardState Term:3 Vote:4 Commit:11 Lead:0 LeadEpoch:0
   OnSync:
-  6->4 MsgVoteResp Term:3 Log:0/0
+  6->4 MsgVoteResp Term:3 Log:1/0 Hint:1/11
 > 7 handling Ready
   Ready:
   HardState Term:3 Vote:4 Commit:11 Lead:0 LeadEpoch:0
   OnSync:
-  7->4 MsgVoteResp Term:3 Log:0/0
+  7->4 MsgVoteResp Term:3 Log:1/0 Hint:1/11
 
 process-append-thread 4 5 6 7
 ----
@@ -305,15 +305,15 @@ process-append-thread 4 5 6 7
 > 5 processing append thread
   HardState {Term:3 Vote:4 Commit:11 Lead:0 LeadEpoch:0}
   OnSync:
-  5->4 MsgVoteResp Term:3 Log:0/0
+  5->4 MsgVoteResp Term:3 Log:1/0 Hint:1/11
 > 6 processing append thread
   HardState {Term:3 Vote:4 Commit:11 Lead:0 LeadEpoch:0}
   OnSync:
-  6->4 MsgVoteResp Term:3 Log:0/0
+  6->4 MsgVoteResp Term:3 Log:1/0 Hint:1/11
 > 7 processing append thread
   HardState {Term:3 Vote:4 Commit:11 Lead:0 LeadEpoch:0}
   OnSync:
-  7->4 MsgVoteResp Term:3 Log:0/0
+  7->4 MsgVoteResp Term:3 Log:1/0 Hint:1/11
 
 deliver-msgs 4
 ----
@@ -321,13 +321,13 @@ deliver-msgs 4
 4->4 StorageAppendAck Mark:{Term:0 Index:0}
 INFO 4 received MsgVoteResp from 4 at term 3
 INFO 4 has received 1 MsgVoteResp votes and 0 vote rejections
-5->4 MsgVoteResp Term:3 Log:0/0
+5->4 MsgVoteResp Term:3 Log:1/0 Hint:1/11
 INFO 4 received MsgVoteResp from 5 at term 3
 INFO 4 has received 2 MsgVoteResp votes and 0 vote rejections
-6->4 MsgVoteResp Term:3 Log:0/0
+6->4 MsgVoteResp Term:3 Log:1/0 Hint:1/11
 INFO 4 received MsgVoteResp from 6 at term 3
 INFO 4 has received 3 MsgVoteResp votes and 0 vote rejections
-7->4 MsgVoteResp Term:3 Log:0/0
+7->4 MsgVoteResp Term:3 Log:1/0 Hint:1/11
 INFO 4 received MsgVoteResp from 7 at term 3
 INFO 4 has received 4 MsgVoteResp votes and 0 vote rejections
 INFO 4 became leader at term 3

--- a/pkg/raft/testdata/campaign.txt
+++ b/pkg/raft/testdata/campaign.txt
@@ -48,18 +48,18 @@ stabilize
   Ready:
   HardState Term:1 Vote:1 Commit:2 Lead:0 LeadEpoch:0
   OnSync:
-  2->1 MsgVoteResp Term:1 Log:0/0
+  2->1 MsgVoteResp Term:1 Log:1/0 Hint:1/2
 > 3 handling Ready
   Ready:
   HardState Term:1 Vote:1 Commit:2 Lead:0 LeadEpoch:0
   OnSync:
-  3->1 MsgVoteResp Term:1 Log:0/0
+  3->1 MsgVoteResp Term:1 Log:1/0 Hint:1/2
 > 1 receiving messages
-  2->1 MsgVoteResp Term:1 Log:0/0
+  2->1 MsgVoteResp Term:1 Log:1/0 Hint:1/2
   INFO 1 received MsgVoteResp from 2 at term 1
   INFO 1 has received 2 MsgVoteResp votes and 0 vote rejections
   INFO 1 became leader at term 1
-  3->1 MsgVoteResp Term:1 Log:0/0
+  3->1 MsgVoteResp Term:1 Log:1/0 Hint:1/2
 > 1 handling Ready
   Ready:
   State:StateLeader

--- a/pkg/raft/testdata/campaign_learner_must_vote.txt
+++ b/pkg/raft/testdata/campaign_learner_must_vote.txt
@@ -111,33 +111,15 @@ stabilize 2 3
   2->1 MsgFortifyLeader Term:2 Log:0/0
   2->3 MsgFortifyLeader Term:2 Log:0/0
   2->1 MsgApp Term:2 Log:1/4 Commit:4 Entries:[2/5 EntryNormal ""]
-  2->3 MsgApp Term:2 Log:1/4 Commit:4 Entries:[2/5 EntryNormal ""]
+  2->3 MsgApp Term:2 Log:1/3 Commit:4 Entries:[
+    1/4 EntryConfChangeV2 v3
+    2/5 EntryNormal ""
+  ]
   OnSync:
   2->2 MsgAppResp Term:2 Log:0/5 Commit:4
   2->2 MsgFortifyLeaderResp Term:2 Log:0/0 LeadEpoch:1
 > 3 receiving messages
   2->3 MsgFortifyLeader Term:2 Log:0/0
-  2->3 MsgApp Term:2 Log:1/4 Commit:4 Entries:[2/5 EntryNormal ""]
-  DEBUG 3 [logterm: 0, index: 4] rejected MsgApp [logterm: 1, index: 4] from 2
-> 3 handling Ready
-  Ready:
-  HardState Term:2 Vote:2 Commit:3 Lead:2 LeadEpoch:1
-  OnSync:
-  3->2 MsgFortifyLeaderResp Term:2 Log:0/0 LeadEpoch:1
-  3->2 MsgAppResp Term:2 Log:1/4 Rejected Hint:1/3 Commit:3
-> 2 receiving messages
-  3->2 MsgFortifyLeaderResp Term:2 Log:0/0 LeadEpoch:1
-  3->2 MsgAppResp Term:2 Log:1/4 Rejected Hint:1/3 Commit:3
-  DEBUG 2 received MsgAppResp(rejected, hint: (index 3, term 1)) from 3 for index 4
-  DEBUG 2 decreased progress of 3 to [StateProbe match=0 next=4 sentCommit=3 matchCommit=3]
-> 2 handling Ready
-  Ready:
-  Messages:
-  2->3 MsgApp Term:2 Log:1/3 Commit:4 Entries:[
-    1/4 EntryConfChangeV2 v3
-    2/5 EntryNormal ""
-  ]
-> 3 receiving messages
   2->3 MsgApp Term:2 Log:1/3 Commit:4 Entries:[
     1/4 EntryConfChangeV2 v3
     2/5 EntryNormal ""
@@ -150,11 +132,13 @@ stabilize 2 3
   2/5 EntryNormal ""
   Committed: (3,4]
   OnSync:
+  3->2 MsgFortifyLeaderResp Term:2 Log:0/0 LeadEpoch:1
   3->2 MsgAppResp Term:2 Log:0/5 Commit:4
   Applying:
   1/4 EntryConfChangeV2 v3
   INFO 3 switched to configuration voters=(1 2 3)
 > 2 receiving messages
+  3->2 MsgFortifyLeaderResp Term:2 Log:0/0 LeadEpoch:1
   3->2 MsgAppResp Term:2 Log:0/5 Commit:4
 > 2 handling Ready
   Ready:

--- a/pkg/raft/testdata/campaign_learner_must_vote.txt
+++ b/pkg/raft/testdata/campaign_learner_must_vote.txt
@@ -124,10 +124,10 @@ stabilize 2 3
   HardState Term:2 Vote:2 Commit:3 Lead:2 LeadEpoch:1
   OnSync:
   3->2 MsgFortifyLeaderResp Term:2 Log:0/0 LeadEpoch:1
-  3->2 MsgAppResp Term:2 Log:1/4 Rejected (Hint: 3) Commit:3
+  3->2 MsgAppResp Term:2 Log:1/4 Rejected Hint:1/3 Commit:3
 > 2 receiving messages
   3->2 MsgFortifyLeaderResp Term:2 Log:0/0 LeadEpoch:1
-  3->2 MsgAppResp Term:2 Log:1/4 Rejected (Hint: 3) Commit:3
+  3->2 MsgAppResp Term:2 Log:1/4 Rejected Hint:1/3 Commit:3
   DEBUG 2 received MsgAppResp(rejected, hint: (index 3, term 1)) from 3 for index 4
   DEBUG 2 decreased progress of 3 to [StateProbe match=0 next=4 sentCommit=3 matchCommit=3]
 > 2 handling Ready

--- a/pkg/raft/testdata/campaign_learner_must_vote.txt
+++ b/pkg/raft/testdata/campaign_learner_must_vote.txt
@@ -92,12 +92,12 @@ stabilize 3
   Ready:
   HardState Term:2 Vote:2 Commit:3 Lead:0 LeadEpoch:0
   OnSync:
-  3->2 MsgVoteResp Term:2 Log:0/0
+  3->2 MsgVoteResp Term:2 Log:1/0 Hint:1/3
 
 stabilize 2 3
 ----
 > 2 receiving messages
-  3->2 MsgVoteResp Term:2 Log:0/0
+  3->2 MsgVoteResp Term:2 Log:1/0 Hint:1/3
   INFO 2 received MsgVoteResp from 3 at term 2
   INFO 2 has received 2 MsgVoteResp votes and 0 vote rejections
   INFO 2 became leader at term 2

--- a/pkg/raft/testdata/confchange_fortification_safety.txt
+++ b/pkg/raft/testdata/confchange_fortification_safety.txt
@@ -164,10 +164,10 @@ stabilize 1 4
   HardState Term:1 Commit:2 Lead:1 LeadEpoch:1
   OnSync:
   4->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:1
-  4->1 MsgAppResp Term:1 Log:1/3 Rejected (Hint: 2) Commit:2
+  4->1 MsgAppResp Term:1 Log:1/3 Rejected Hint:1/2 Commit:2
 > 1 receiving messages
   4->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:1
-  4->1 MsgAppResp Term:1 Log:1/3 Rejected (Hint: 2) Commit:2
+  4->1 MsgAppResp Term:1 Log:1/3 Rejected Hint:1/2 Commit:2
   DEBUG 1 received MsgAppResp(rejected, hint: (index 2, term 1)) from 4 for index 3
   DEBUG 1 decreased progress of 4 to [StateProbe match=0 next=3 sentCommit=2 matchCommit=2]
 > 1 handling Ready

--- a/pkg/raft/testdata/confchange_v1_add_single.txt
+++ b/pkg/raft/testdata/confchange_v1_add_single.txt
@@ -79,10 +79,10 @@ stabilize
   HardState Term:1 Commit:0 Lead:1 LeadEpoch:1
   OnSync:
   2->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:1
-  2->1 MsgAppResp Term:1 Log:0/3 Rejected (Hint: 0)
+  2->1 MsgAppResp Term:1 Log:0/3 Rejected
 > 1 receiving messages
   2->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:1
-  2->1 MsgAppResp Term:1 Log:0/3 Rejected (Hint: 0)
+  2->1 MsgAppResp Term:1 Log:0/3 Rejected
   DEBUG 1 received MsgAppResp(rejected, hint: (index 0, term 0)) from 2 for index 3
   DEBUG 1 decreased progress of 2 to [StateProbe match=0 next=1 sentCommit=0 matchCommit=0]
   DEBUG 1 [firstindex: 3, commit: 4] sent snapshot[index: 4, term: 1] to 2 [StateProbe match=0 next=1 sentCommit=0 matchCommit=0]

--- a/pkg/raft/testdata/confchange_v2_add_double_auto.txt
+++ b/pkg/raft/testdata/confchange_v2_add_double_auto.txt
@@ -107,10 +107,10 @@ stabilize 1 2
   HardState Term:1 Commit:0 Lead:1 LeadEpoch:1
   OnSync:
   2->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:1
-  2->1 MsgAppResp Term:1 Log:0/3 Rejected (Hint: 0)
+  2->1 MsgAppResp Term:1 Log:0/3 Rejected
 > 1 receiving messages
   2->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:1
-  2->1 MsgAppResp Term:1 Log:0/3 Rejected (Hint: 0)
+  2->1 MsgAppResp Term:1 Log:0/3 Rejected
   DEBUG 1 received MsgAppResp(rejected, hint: (index 0, term 0)) from 2 for index 3
   DEBUG 1 decreased progress of 2 to [StateProbe match=0 next=1 sentCommit=0 matchCommit=0]
   DEBUG 1 [firstindex: 3, commit: 4] sent snapshot[index: 4, term: 1] to 2 [StateProbe match=0 next=1 sentCommit=0 matchCommit=0]
@@ -232,11 +232,11 @@ stabilize 1 3
   HardState Term:1 Commit:0 Lead:1 LeadEpoch:1
   OnSync:
   3->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:1
-  3->1 MsgAppResp Term:1 Log:0/3 Rejected (Hint: 0)
+  3->1 MsgAppResp Term:1 Log:0/3 Rejected
   3->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:1
 > 1 receiving messages
   3->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:1
-  3->1 MsgAppResp Term:1 Log:0/3 Rejected (Hint: 0)
+  3->1 MsgAppResp Term:1 Log:0/3 Rejected
   DEBUG 1 received MsgAppResp(rejected, hint: (index 0, term 0)) from 3 for index 3
   DEBUG 1 decreased progress of 3 to [StateProbe match=0 next=1 sentCommit=0 matchCommit=0]
   DEBUG 1 [firstindex: 3, commit: 6] sent snapshot[index: 6, term: 1] to 3 [StateProbe match=0 next=1 sentCommit=0 matchCommit=0]

--- a/pkg/raft/testdata/confchange_v2_add_single_auto.txt
+++ b/pkg/raft/testdata/confchange_v2_add_single_auto.txt
@@ -80,10 +80,10 @@ stabilize
   HardState Term:1 Commit:0 Lead:1 LeadEpoch:1
   OnSync:
   2->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:1
-  2->1 MsgAppResp Term:1 Log:0/3 Rejected (Hint: 0)
+  2->1 MsgAppResp Term:1 Log:0/3 Rejected
 > 1 receiving messages
   2->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:1
-  2->1 MsgAppResp Term:1 Log:0/3 Rejected (Hint: 0)
+  2->1 MsgAppResp Term:1 Log:0/3 Rejected
   DEBUG 1 received MsgAppResp(rejected, hint: (index 0, term 0)) from 2 for index 3
   DEBUG 1 decreased progress of 2 to [StateProbe match=0 next=1 sentCommit=0 matchCommit=0]
   DEBUG 1 [firstindex: 3, commit: 4] sent snapshot[index: 4, term: 1] to 2 [StateProbe match=0 next=1 sentCommit=0 matchCommit=0]

--- a/pkg/raft/testdata/confchange_v2_add_single_explicit.txt
+++ b/pkg/raft/testdata/confchange_v2_add_single_explicit.txt
@@ -80,10 +80,10 @@ stabilize 1 2
   HardState Term:1 Commit:0 Lead:1 LeadEpoch:1
   OnSync:
   2->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:1
-  2->1 MsgAppResp Term:1 Log:0/3 Rejected (Hint: 0)
+  2->1 MsgAppResp Term:1 Log:0/3 Rejected
 > 1 receiving messages
   2->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:1
-  2->1 MsgAppResp Term:1 Log:0/3 Rejected (Hint: 0)
+  2->1 MsgAppResp Term:1 Log:0/3 Rejected
   DEBUG 1 received MsgAppResp(rejected, hint: (index 0, term 0)) from 2 for index 3
   DEBUG 1 decreased progress of 2 to [StateProbe match=0 next=1 sentCommit=0 matchCommit=0]
   DEBUG 1 [firstindex: 3, commit: 4] sent snapshot[index: 4, term: 1] to 2 [StateProbe match=0 next=1 sentCommit=0 matchCommit=0]

--- a/pkg/raft/testdata/confchange_v2_add_single_implicit.txt
+++ b/pkg/raft/testdata/confchange_v2_add_single_implicit.txt
@@ -118,11 +118,11 @@ stabilize
   HardState Term:1 Commit:0 Lead:1 LeadEpoch:1
   OnSync:
   3->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:1
-  3->1 MsgAppResp Term:1 Log:0/3 Rejected (Hint: 0)
+  3->1 MsgAppResp Term:1 Log:0/3 Rejected
 > 1 receiving messages
   2->1 MsgAppResp Term:1 Log:0/5 Commit:4
   3->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:1
-  3->1 MsgAppResp Term:1 Log:0/3 Rejected (Hint: 0)
+  3->1 MsgAppResp Term:1 Log:0/3 Rejected
   DEBUG 1 received MsgAppResp(rejected, hint: (index 0, term 0)) from 3 for index 3
   DEBUG 1 decreased progress of 3 to [StateProbe match=0 next=1 sentCommit=0 matchCommit=0]
   DEBUG 1 [firstindex: 3, commit: 5] sent snapshot[index: 4, term: 1] to 3 [StateProbe match=0 next=1 sentCommit=0 matchCommit=0]

--- a/pkg/raft/testdata/de_fortification_basic.txt
+++ b/pkg/raft/testdata/de_fortification_basic.txt
@@ -99,12 +99,12 @@ stabilize
   Ready:
   HardState Term:1 Vote:1 Commit:2 Lead:0 LeadEpoch:0
   OnSync:
-  2->1 MsgVoteResp Term:1 Log:0/0
+  2->1 MsgVoteResp Term:1 Log:1/0 Hint:1/2
 > 3 handling Ready
   Ready:
   HardState Term:1 Vote:1 Commit:2 Lead:0 LeadEpoch:0
   OnSync:
-  3->1 MsgVoteResp Term:1 Log:0/0
+  3->1 MsgVoteResp Term:1 Log:1/0 Hint:1/2
 > 1 receiving messages
   1->1 MsgVoteResp Term:1 Log:0/0
   1->1 StorageAppendAck Mark:{Term:0 Index:0}
@@ -113,17 +113,17 @@ stabilize
 > 2 processing append thread
   HardState {Term:1 Vote:1 Commit:2 Lead:0 LeadEpoch:0}
   OnSync:
-  2->1 MsgVoteResp Term:1 Log:0/0
+  2->1 MsgVoteResp Term:1 Log:1/0 Hint:1/2
 > 3 processing append thread
   HardState {Term:1 Vote:1 Commit:2 Lead:0 LeadEpoch:0}
   OnSync:
-  3->1 MsgVoteResp Term:1 Log:0/0
+  3->1 MsgVoteResp Term:1 Log:1/0 Hint:1/2
 > 1 receiving messages
-  2->1 MsgVoteResp Term:1 Log:0/0
+  2->1 MsgVoteResp Term:1 Log:1/0 Hint:1/2
   INFO 1 received MsgVoteResp from 2 at term 1
   INFO 1 has received 2 MsgVoteResp votes and 0 vote rejections
   INFO 1 became leader at term 1
-  3->1 MsgVoteResp Term:1 Log:0/0
+  3->1 MsgVoteResp Term:1 Log:1/0 Hint:1/2
 > 1 handling Ready
   Ready:
   State:StateLeader
@@ -367,12 +367,12 @@ stabilize
   Ready:
   HardState Term:2 Vote:2 Commit:3 Lead:0 LeadEpoch:0
   OnSync:
-  1->2 MsgVoteResp Term:2 Log:0/0
+  1->2 MsgVoteResp Term:2 Log:1/0 Hint:1/3
 > 3 handling Ready
   Ready:
   HardState Term:2 Vote:2 Commit:3 Lead:0 LeadEpoch:0
   OnSync:
-  3->2 MsgVoteResp Term:2 Log:0/0
+  3->2 MsgVoteResp Term:2 Log:1/0 Hint:1/3
 > 2 receiving messages
   2->2 MsgVoteResp Term:2 Log:0/0
   2->2 StorageAppendAck Mark:{Term:0 Index:0}
@@ -381,17 +381,17 @@ stabilize
 > 1 processing append thread
   HardState {Term:2 Vote:2 Commit:3 Lead:0 LeadEpoch:0}
   OnSync:
-  1->2 MsgVoteResp Term:2 Log:0/0
+  1->2 MsgVoteResp Term:2 Log:1/0 Hint:1/3
 > 3 processing append thread
   HardState {Term:2 Vote:2 Commit:3 Lead:0 LeadEpoch:0}
   OnSync:
-  3->2 MsgVoteResp Term:2 Log:0/0
+  3->2 MsgVoteResp Term:2 Log:1/0 Hint:1/3
 > 2 receiving messages
-  1->2 MsgVoteResp Term:2 Log:0/0
+  1->2 MsgVoteResp Term:2 Log:1/0 Hint:1/3
   INFO 2 received MsgVoteResp from 1 at term 2
   INFO 2 has received 2 MsgVoteResp votes and 0 vote rejections
   INFO 2 became leader at term 2
-  3->2 MsgVoteResp Term:2 Log:0/0
+  3->2 MsgVoteResp Term:2 Log:1/0 Hint:1/3
 > 2 handling Ready
   Ready:
   State:StateLeader
@@ -592,7 +592,7 @@ stabilize
   Ready:
   HardState Term:3 Vote:3 Commit:4 Lead:0 LeadEpoch:0
   OnSync:
-  2->3 MsgVoteResp Term:3 Log:0/0
+  2->3 MsgVoteResp Term:3 Log:2/0 Hint:2/4
 > 3 receiving messages
   3->3 MsgVoteResp Term:3 Log:0/0
   3->3 StorageAppendAck Mark:{Term:0 Index:0}
@@ -601,9 +601,9 @@ stabilize
 > 2 processing append thread
   HardState {Term:3 Vote:3 Commit:4 Lead:0 LeadEpoch:0}
   OnSync:
-  2->3 MsgVoteResp Term:3 Log:0/0
+  2->3 MsgVoteResp Term:3 Log:2/0 Hint:2/4
 > 3 receiving messages
-  2->3 MsgVoteResp Term:3 Log:0/0
+  2->3 MsgVoteResp Term:3 Log:2/0 Hint:2/4
   INFO 3 received MsgVoteResp from 2 at term 3
   INFO 3 has received 2 MsgVoteResp votes and 0 vote rejections
   INFO 3 became leader at term 3
@@ -812,13 +812,13 @@ stabilize
   Ready:
   HardState Term:4 Vote:2 Commit:5 Lead:0 LeadEpoch:0
   OnSync:
-  1->2 MsgVoteResp Term:4 Log:0/0
+  1->2 MsgVoteResp Term:4 Log:3/0 Hint:3/5
 > 3 handling Ready
   Ready:
   State:StateFollower
   HardState Term:4 Vote:2 Commit:5 Lead:0 LeadEpoch:0
   OnSync:
-  3->2 MsgVoteResp Term:4 Log:0/0
+  3->2 MsgVoteResp Term:4 Log:3/0 Hint:3/5
 > 2 receiving messages
   2->2 MsgVoteResp Term:4 Log:0/0
   2->2 StorageAppendAck Mark:{Term:0 Index:0}
@@ -827,17 +827,17 @@ stabilize
 > 1 processing append thread
   HardState {Term:4 Vote:2 Commit:5 Lead:0 LeadEpoch:0}
   OnSync:
-  1->2 MsgVoteResp Term:4 Log:0/0
+  1->2 MsgVoteResp Term:4 Log:3/0 Hint:3/5
 > 3 processing append thread
   HardState {Term:4 Vote:2 Commit:5 Lead:0 LeadEpoch:0}
   OnSync:
-  3->2 MsgVoteResp Term:4 Log:0/0
+  3->2 MsgVoteResp Term:4 Log:3/0 Hint:3/5
 > 2 receiving messages
-  1->2 MsgVoteResp Term:4 Log:0/0
+  1->2 MsgVoteResp Term:4 Log:3/0 Hint:3/5
   INFO 2 received MsgVoteResp from 1 at term 4
   INFO 2 has received 2 MsgVoteResp votes and 0 vote rejections
   INFO 2 became leader at term 4
-  3->2 MsgVoteResp Term:4 Log:0/0
+  3->2 MsgVoteResp Term:4 Log:3/0 Hint:3/5
 > 2 handling Ready
   Ready:
   State:StateLeader
@@ -1035,7 +1035,7 @@ stabilize
   Ready:
   HardState Term:5 Vote:1 Commit:6 Lead:0 LeadEpoch:0
   OnSync:
-  2->1 MsgVoteResp Term:5 Log:0/0
+  2->1 MsgVoteResp Term:5 Log:4/0 Hint:4/6
 > 1 receiving messages
   1->1 MsgVoteResp Term:5 Log:0/0
   1->1 StorageAppendAck Mark:{Term:0 Index:0}
@@ -1044,9 +1044,9 @@ stabilize
 > 2 processing append thread
   HardState {Term:5 Vote:1 Commit:6 Lead:0 LeadEpoch:0}
   OnSync:
-  2->1 MsgVoteResp Term:5 Log:0/0
+  2->1 MsgVoteResp Term:5 Log:4/0 Hint:4/6
 > 1 receiving messages
-  2->1 MsgVoteResp Term:5 Log:0/0
+  2->1 MsgVoteResp Term:5 Log:4/0 Hint:4/6
   INFO 1 received MsgVoteResp from 2 at term 5
   INFO 1 has received 2 MsgVoteResp votes and 0 vote rejections
   INFO 1 became leader at term 5

--- a/pkg/raft/testdata/de_fortification_checkquorum.txt
+++ b/pkg/raft/testdata/de_fortification_checkquorum.txt
@@ -311,9 +311,9 @@ stabilize 1 3
   Ready:
   HardState Term:3 Vote:3 Commit:12 Lead:0 LeadEpoch:0
   OnSync:
-  1->3 MsgVoteResp Term:3 Log:0/0
+  1->3 MsgVoteResp Term:3 Log:2/0 Hint:2/12
 > 3 receiving messages
-  1->3 MsgVoteResp Term:3 Log:0/0
+  1->3 MsgVoteResp Term:3 Log:2/0 Hint:2/12
   INFO 3 received MsgVoteResp from 1 at term 3
   INFO 3 has received 2 MsgVoteResp votes and 0 vote rejections
   INFO 3 became leader at term 3

--- a/pkg/raft/testdata/forget_leader_prevote_checkquorum.txt
+++ b/pkg/raft/testdata/forget_leader_prevote_checkquorum.txt
@@ -292,7 +292,7 @@ stabilize 2
 > 2 handling Ready
   Ready:
   OnSync:
-  2->1 MsgPreVoteResp Term:2 Log:0/0 Rejected (Hint: 0)
+  2->1 MsgPreVoteResp Term:2 Log:0/0 Rejected
 
 stabilize log-level=none
 ----

--- a/pkg/raft/testdata/fortification_basic.txt
+++ b/pkg/raft/testdata/fortification_basic.txt
@@ -98,31 +98,31 @@ stabilize 2 3 4
   Ready:
   HardState Term:1 Vote:1 Commit:2 Lead:0 LeadEpoch:0
   OnSync:
-  2->1 MsgVoteResp Term:1 Log:0/0
+  2->1 MsgVoteResp Term:1 Log:1/0 Hint:1/2
 > 3 handling Ready
   Ready:
   HardState Term:1 Vote:1 Commit:2 Lead:0 LeadEpoch:0
   OnSync:
-  3->1 MsgVoteResp Term:1 Log:0/0
+  3->1 MsgVoteResp Term:1 Log:1/0 Hint:1/2
 > 4 handling Ready
   Ready:
   HardState Term:1 Vote:1 Commit:2 Lead:0 LeadEpoch:0
   OnSync:
-  4->1 MsgVoteResp Term:1 Log:0/0
+  4->1 MsgVoteResp Term:1 Log:1/0 Hint:1/2
 
 # Since node 3 withdrew its support, node 1 will not send a MsgFortifyLeader to
 # it.
 stabilize 1
 ----
 > 1 receiving messages
-  2->1 MsgVoteResp Term:1 Log:0/0
+  2->1 MsgVoteResp Term:1 Log:1/0 Hint:1/2
   INFO 1 received MsgVoteResp from 2 at term 1
   INFO 1 has received 2 MsgVoteResp votes and 0 vote rejections
-  3->1 MsgVoteResp Term:1 Log:0/0
+  3->1 MsgVoteResp Term:1 Log:1/0 Hint:1/2
   INFO 1 received MsgVoteResp from 3 at term 1
   INFO 1 has received 3 MsgVoteResp votes and 0 vote rejections
   INFO 1 became leader at term 1
-  4->1 MsgVoteResp Term:1 Log:0/0
+  4->1 MsgVoteResp Term:1 Log:1/0 Hint:1/2
 > 1 handling Ready
   Ready:
   State:StateLeader

--- a/pkg/raft/testdata/fortification_basic.txt
+++ b/pkg/raft/testdata/fortification_basic.txt
@@ -180,13 +180,13 @@ stabilize
   Entries:
   1/3 EntryNormal ""
   OnSync:
-  4->1 MsgFortifyLeaderResp Term:1 Log:0/0 Rejected (Hint: 0)
+  4->1 MsgFortifyLeaderResp Term:1 Log:0/0 Rejected
   4->1 MsgAppResp Term:1 Log:0/3 Commit:2
 > 1 receiving messages
   2->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:2
   2->1 MsgAppResp Term:1 Log:0/3 Commit:2
   3->1 MsgAppResp Term:1 Log:0/3 Commit:2
-  4->1 MsgFortifyLeaderResp Term:1 Log:0/0 Rejected (Hint: 0)
+  4->1 MsgFortifyLeaderResp Term:1 Log:0/0 Rejected
   4->1 MsgAppResp Term:1 Log:0/3 Commit:2
 > 1 handling Ready
   Ready:

--- a/pkg/raft/testdata/fortification_followers_dont_call_election_prevote.txt
+++ b/pkg/raft/testdata/fortification_followers_dont_call_election_prevote.txt
@@ -88,18 +88,18 @@ stabilize
   Ready:
   HardState Term:1 Vote:1 Commit:10 Lead:0 LeadEpoch:0
   OnSync:
-  2->1 MsgVoteResp Term:1 Log:0/0
+  2->1 MsgVoteResp Term:1 Log:1/0 Hint:1/10
 > 3 handling Ready
   Ready:
   HardState Term:1 Vote:1 Commit:10 Lead:0 LeadEpoch:0
   OnSync:
-  3->1 MsgVoteResp Term:1 Log:0/0
+  3->1 MsgVoteResp Term:1 Log:1/0 Hint:1/10
 > 1 receiving messages
-  2->1 MsgVoteResp Term:1 Log:0/0
+  2->1 MsgVoteResp Term:1 Log:1/0 Hint:1/10
   INFO 1 received MsgVoteResp from 2 at term 1
   INFO 1 has received 2 MsgVoteResp votes and 0 vote rejections
   INFO 1 became leader at term 1
-  3->1 MsgVoteResp Term:1 Log:0/0
+  3->1 MsgVoteResp Term:1 Log:1/0 Hint:1/10
 > 1 handling Ready
   Ready:
   State:StateLeader

--- a/pkg/raft/testdata/fortification_followers_dont_prevote.txt
+++ b/pkg/raft/testdata/fortification_followers_dont_prevote.txt
@@ -88,18 +88,18 @@ stabilize
   Ready:
   HardState Term:1 Vote:1 Commit:10 Lead:0 LeadEpoch:0
   OnSync:
-  2->1 MsgVoteResp Term:1 Log:0/0
+  2->1 MsgVoteResp Term:1 Log:1/0 Hint:1/10
 > 3 handling Ready
   Ready:
   HardState Term:1 Vote:1 Commit:10 Lead:0 LeadEpoch:0
   OnSync:
-  3->1 MsgVoteResp Term:1 Log:0/0
+  3->1 MsgVoteResp Term:1 Log:1/0 Hint:1/10
 > 1 receiving messages
-  2->1 MsgVoteResp Term:1 Log:0/0
+  2->1 MsgVoteResp Term:1 Log:1/0 Hint:1/10
   INFO 1 received MsgVoteResp from 2 at term 1
   INFO 1 has received 2 MsgVoteResp votes and 0 vote rejections
   INFO 1 became leader at term 1
-  3->1 MsgVoteResp Term:1 Log:0/0
+  3->1 MsgVoteResp Term:1 Log:1/0 Hint:1/10
 > 1 handling Ready
   Ready:
   State:StateLeader
@@ -286,9 +286,9 @@ stabilize
   Ready:
   HardState Term:2 Vote:2 Commit:11 Lead:0 LeadEpoch:0
   OnSync:
-  3->2 MsgVoteResp Term:2 Log:0/0
+  3->2 MsgVoteResp Term:2 Log:1/0 Hint:1/11
 > 2 receiving messages
-  3->2 MsgVoteResp Term:2 Log:0/0
+  3->2 MsgVoteResp Term:2 Log:1/0 Hint:1/11
   INFO 2 received MsgVoteResp from 3 at term 2
   INFO 2 has received 2 MsgVoteResp votes and 0 vote rejections
   INFO 2 became leader at term 2
@@ -561,18 +561,18 @@ stabilize
   Ready:
   HardState Term:3 Vote:2 Commit:12 Lead:0 LeadEpoch:0
   OnSync:
-  1->2 MsgVoteResp Term:3 Log:0/0
+  1->2 MsgVoteResp Term:3 Log:2/0 Hint:2/12
 > 3 handling Ready
   Ready:
   HardState Term:3 Vote:2 Commit:12 Lead:0 LeadEpoch:0
   OnSync:
-  3->2 MsgVoteResp Term:3 Log:0/0
+  3->2 MsgVoteResp Term:3 Log:2/0 Hint:2/12
 > 2 receiving messages
-  1->2 MsgVoteResp Term:3 Log:0/0
+  1->2 MsgVoteResp Term:3 Log:2/0 Hint:2/12
   INFO 2 received MsgVoteResp from 1 at term 3
   INFO 2 has received 2 MsgVoteResp votes and 0 vote rejections
   INFO 2 became leader at term 3
-  3->2 MsgVoteResp Term:3 Log:0/0
+  3->2 MsgVoteResp Term:3 Log:2/0 Hint:2/12
 > 2 handling Ready
   Ready:
   State:StateLeader

--- a/pkg/raft/testdata/fortification_leader_does_not_support_itself.txt
+++ b/pkg/raft/testdata/fortification_leader_does_not_support_itself.txt
@@ -80,19 +80,19 @@ stabilize
   Ready:
   HardState Term:1 Vote:1 Commit:2 Lead:0 LeadEpoch:0
   OnSync:
-  2->1 MsgVoteResp Term:1 Log:0/0
+  2->1 MsgVoteResp Term:1 Log:1/0 Hint:1/2
 > 3 handling Ready
   Ready:
   HardState Term:1 Vote:1 Commit:2 Lead:0 LeadEpoch:0
   OnSync:
-  3->1 MsgVoteResp Term:1 Log:0/0
+  3->1 MsgVoteResp Term:1 Log:1/0 Hint:1/2
 > 1 receiving messages
-  2->1 MsgVoteResp Term:1 Log:0/0
+  2->1 MsgVoteResp Term:1 Log:1/0 Hint:1/2
   INFO 1 received MsgVoteResp from 2 at term 1
   INFO 1 has received 2 MsgVoteResp votes and 0 vote rejections
   INFO 1 became leader at term 1
   INFO 1 leader at term 1 does not support itself in the liveness fabric
-  3->1 MsgVoteResp Term:1 Log:0/0
+  3->1 MsgVoteResp Term:1 Log:1/0 Hint:1/2
 > 1 handling Ready
   Ready:
   State:StateLeader

--- a/pkg/raft/testdata/fortification_support_tracking.txt
+++ b/pkg/raft/testdata/fortification_support_tracking.txt
@@ -62,18 +62,18 @@ stabilize
   Ready:
   HardState Term:1 Vote:1 Commit:10 Lead:0 LeadEpoch:0
   OnSync:
-  2->1 MsgVoteResp Term:1 Log:0/0
+  2->1 MsgVoteResp Term:1 Log:1/0 Hint:1/10
 > 3 handling Ready
   Ready:
   HardState Term:1 Vote:1 Commit:10 Lead:0 LeadEpoch:0
   OnSync:
-  3->1 MsgVoteResp Term:1 Log:0/0
+  3->1 MsgVoteResp Term:1 Log:1/0 Hint:1/10
 > 1 receiving messages
-  2->1 MsgVoteResp Term:1 Log:0/0
+  2->1 MsgVoteResp Term:1 Log:1/0 Hint:1/10
   INFO 1 received MsgVoteResp from 2 at term 1
   INFO 1 has received 2 MsgVoteResp votes and 0 vote rejections
   INFO 1 became leader at term 1
-  3->1 MsgVoteResp Term:1 Log:0/0
+  3->1 MsgVoteResp Term:1 Log:1/0 Hint:1/10
 > 1 handling Ready
   Ready:
   State:StateLeader
@@ -211,9 +211,9 @@ stabilize
   Ready:
   HardState Term:2 Vote:2 Commit:11 Lead:0 LeadEpoch:0
   OnSync:
-  3->2 MsgVoteResp Term:2 Log:0/0
+  3->2 MsgVoteResp Term:2 Log:1/0 Hint:1/11
 > 2 receiving messages
-  3->2 MsgVoteResp Term:2 Log:0/0
+  3->2 MsgVoteResp Term:2 Log:1/0 Hint:1/11
   INFO 2 received MsgVoteResp from 3 at term 2
   INFO 2 has received 2 MsgVoteResp votes and 0 vote rejections
   INFO 2 became leader at term 2

--- a/pkg/raft/testdata/lazy_replication.txt
+++ b/pkg/raft/testdata/lazy_replication.txt
@@ -45,6 +45,12 @@ stabilize
   1->1 MsgAppResp Term:1 Log:0/12 Commit:11
   1->1 MsgAppResp Term:1 Log:0/13 Commit:11
 
+status 1
+----
+1: StateReplicate match=13 next=14 sentCommit=11 matchCommit=11
+2: StateReplicate match=11 next=12 sentCommit=11 matchCommit=11
+3: StateReplicate match=11 next=12 sentCommit=11 matchCommit=11
+
 # Attempt to send a misaligned MsgApp. No-op.
 send-msg-app 1 to=2 lo=10 hi=13
 ----

--- a/pkg/raft/testdata/lazy_replication.txt
+++ b/pkg/raft/testdata/lazy_replication.txt
@@ -48,18 +48,14 @@ stabilize
 status 1
 ----
 1: StateReplicate match=13 next=14 sentCommit=11 matchCommit=11
-2: StateReplicate match=11 next=12 sentCommit=11 matchCommit=11
+2: StateReplicate match=10 next=11 sentCommit=10 matchCommit=10
 3: StateReplicate match=11 next=12 sentCommit=11 matchCommit=11
 
-# Attempt to send a misaligned MsgApp. No-op.
+# Send a MsgApp to node 2, containing 3 entries.
 send-msg-app 1 to=2 lo=10 hi=13
 ----
-could not send MsgApp (10,13] to 2
-
-# Send a MsgApp to node 2, containing both entries.
-send-msg-app 1 to=2 lo=11 hi=13
-----
-1->2 MsgApp Term:1 Log:1/11 Commit:11 Entries:[
+1->2 MsgApp Term:1 Log:1/10 Commit:11 Entries:[
+  1/11 EntryNormal ""
   1/12 EntryNormal "data-1"
   1/13 EntryNormal "data-2"
 ]
@@ -74,7 +70,8 @@ send-msg-app 1 to=3 lo=11 hi=12
 stabilize
 ----
 > 2 receiving messages
-  1->2 MsgApp Term:1 Log:1/11 Commit:11 Entries:[
+  1->2 MsgApp Term:1 Log:1/10 Commit:11 Entries:[
+    1/11 EntryNormal ""
     1/12 EntryNormal "data-1"
     1/13 EntryNormal "data-2"
   ]
@@ -82,11 +79,16 @@ stabilize
   1->3 MsgApp Term:1 Log:1/11 Commit:11 Entries:[1/12 EntryNormal "data-1"]
 > 2 handling Ready
   Ready:
+  HardState Term:1 Vote:1 Commit:11 Lead:1 LeadEpoch:1
   Entries:
+  1/11 EntryNormal ""
   1/12 EntryNormal "data-1"
   1/13 EntryNormal "data-2"
+  Committed: (10,11]
   OnSync:
   2->1 MsgAppResp Term:1 Log:0/13 Commit:11
+  Applying:
+  1/11 EntryNormal ""
 > 3 handling Ready
   Ready:
   Entries:

--- a/pkg/raft/testdata/leader_step_down_stranded_peer.txt
+++ b/pkg/raft/testdata/leader_step_down_stranded_peer.txt
@@ -140,9 +140,9 @@ stabilize 1 2
   Ready:
   HardState Term:1 Vote:1 Commit:10 Lead:0 LeadEpoch:0
   OnSync:
-  2->1 MsgVoteResp Term:1 Log:0/0
+  2->1 MsgVoteResp Term:1 Log:1/0 Hint:1/10
 > 1 receiving messages
-  2->1 MsgVoteResp Term:1 Log:0/0
+  2->1 MsgVoteResp Term:1 Log:1/0 Hint:1/10
   INFO 1 received MsgVoteResp from 2 at term 1
   INFO 1 has received 2 MsgVoteResp votes and 0 vote rejections
   INFO 1 became leader at term 1
@@ -304,19 +304,19 @@ stabilize
   Ready:
   HardState Term:4 Vote:1 Commit:11 Lead:0 LeadEpoch:0
   OnSync:
-  2->1 MsgVoteResp Term:4 Log:0/0
+  2->1 MsgVoteResp Term:4 Log:1/0 Hint:1/11
 > 3 handling Ready
   Ready:
   State:StateFollower
   HardState Term:4 Vote:1 Commit:10 Lead:0 LeadEpoch:0
   OnSync:
-  3->1 MsgVoteResp Term:4 Log:0/0
+  3->1 MsgVoteResp Term:4 Log:1/0 Hint:1/10
 > 1 receiving messages
-  2->1 MsgVoteResp Term:4 Log:0/0
+  2->1 MsgVoteResp Term:4 Log:1/0 Hint:1/11
   INFO 1 received MsgVoteResp from 2 at term 4
   INFO 1 has received 2 MsgVoteResp votes and 0 vote rejections
   INFO 1 became leader at term 4
-  3->1 MsgVoteResp Term:4 Log:0/0
+  3->1 MsgVoteResp Term:4 Log:1/0 Hint:1/10
 > 1 handling Ready
   Ready:
   State:StateLeader

--- a/pkg/raft/testdata/leader_step_down_stranded_peer.txt
+++ b/pkg/raft/testdata/leader_step_down_stranded_peer.txt
@@ -351,12 +351,12 @@ stabilize
   HardState Term:4 Vote:1 Commit:10 Lead:1 LeadEpoch:1
   OnSync:
   3->1 MsgFortifyLeaderResp Term:4 Log:0/0 LeadEpoch:1
-  3->1 MsgAppResp Term:4 Log:1/11 Rejected (Hint: 10) Commit:10
+  3->1 MsgAppResp Term:4 Log:1/11 Rejected Hint:1/10 Commit:10
 > 1 receiving messages
   2->1 MsgFortifyLeaderResp Term:4 Log:0/0 LeadEpoch:1
   2->1 MsgAppResp Term:4 Log:0/12 Commit:11
   3->1 MsgFortifyLeaderResp Term:4 Log:0/0 LeadEpoch:1
-  3->1 MsgAppResp Term:4 Log:1/11 Rejected (Hint: 10) Commit:10
+  3->1 MsgAppResp Term:4 Log:1/11 Rejected Hint:1/10 Commit:10
   DEBUG 1 received MsgAppResp(rejected, hint: (index 10, term 1)) from 3 for index 11
   DEBUG 1 decreased progress of 3 to [StateProbe match=0 next=11 sentCommit=10 matchCommit=10]
 > 1 handling Ready

--- a/pkg/raft/testdata/leader_step_down_stranded_peer_prevote.txt
+++ b/pkg/raft/testdata/leader_step_down_stranded_peer_prevote.txt
@@ -505,12 +505,12 @@ stabilize
   HardState Term:4 Vote:1 Commit:10 Lead:1 LeadEpoch:1
   OnSync:
   3->1 MsgFortifyLeaderResp Term:4 Log:0/0 LeadEpoch:1
-  3->1 MsgAppResp Term:4 Log:1/11 Rejected (Hint: 10) Commit:10
+  3->1 MsgAppResp Term:4 Log:1/11 Rejected Hint:1/10 Commit:10
 > 1 receiving messages
   2->1 MsgFortifyLeaderResp Term:4 Log:0/0 LeadEpoch:1
   2->1 MsgAppResp Term:4 Log:0/12 Commit:11
   3->1 MsgFortifyLeaderResp Term:4 Log:0/0 LeadEpoch:1
-  3->1 MsgAppResp Term:4 Log:1/11 Rejected (Hint: 10) Commit:10
+  3->1 MsgAppResp Term:4 Log:1/11 Rejected Hint:1/10 Commit:10
   DEBUG 1 received MsgAppResp(rejected, hint: (index 10, term 1)) from 3 for index 11
   DEBUG 1 decreased progress of 3 to [StateProbe match=0 next=11 sentCommit=10 matchCommit=10]
 > 1 handling Ready

--- a/pkg/raft/testdata/leader_step_down_stranded_peer_prevote.txt
+++ b/pkg/raft/testdata/leader_step_down_stranded_peer_prevote.txt
@@ -266,9 +266,9 @@ stabilize 1 2
   Ready:
   HardState Term:1 Vote:1 Commit:10 Lead:0 LeadEpoch:0
   OnSync:
-  2->1 MsgVoteResp Term:1 Log:0/0
+  2->1 MsgVoteResp Term:1 Log:1/0 Hint:1/10
 > 1 receiving messages
-  2->1 MsgVoteResp Term:1 Log:0/0
+  2->1 MsgVoteResp Term:1 Log:1/0 Hint:1/10
   INFO 1 received MsgVoteResp from 2 at term 1
   INFO 1 has received 2 MsgVoteResp votes and 0 vote rejections
   INFO 1 became leader at term 1
@@ -458,19 +458,19 @@ stabilize
   Ready:
   HardState Term:4 Vote:1 Commit:11 Lead:0 LeadEpoch:0
   OnSync:
-  2->1 MsgVoteResp Term:4 Log:0/0
+  2->1 MsgVoteResp Term:4 Log:1/0 Hint:1/11
 > 3 handling Ready
   Ready:
   State:StateFollower
   HardState Term:4 Vote:1 Commit:10 Lead:0 LeadEpoch:0
   OnSync:
-  3->1 MsgVoteResp Term:4 Log:0/0
+  3->1 MsgVoteResp Term:4 Log:1/0 Hint:1/10
 > 1 receiving messages
-  2->1 MsgVoteResp Term:4 Log:0/0
+  2->1 MsgVoteResp Term:4 Log:1/0 Hint:1/11
   INFO 1 received MsgVoteResp from 2 at term 4
   INFO 1 has received 2 MsgVoteResp votes and 0 vote rejections
   INFO 1 became leader at term 4
-  3->1 MsgVoteResp Term:4 Log:0/0
+  3->1 MsgVoteResp Term:4 Log:1/0 Hint:1/10
 > 1 handling Ready
   Ready:
   State:StateLeader

--- a/pkg/raft/testdata/liveness_recovered_after_temporary_loss_of_quorum.txt
+++ b/pkg/raft/testdata/liveness_recovered_after_temporary_loss_of_quorum.txt
@@ -116,9 +116,9 @@ stabilize
 > 1 handling Ready
   Ready:
   OnSync:
-  1->2 MsgPreVoteResp Term:1 Log:0/0 Rejected (Hint: 0)
+  1->2 MsgPreVoteResp Term:1 Log:0/0 Rejected
 > 2 receiving messages
-  1->2 MsgPreVoteResp Term:1 Log:0/0 Rejected (Hint: 0)
+  1->2 MsgPreVoteResp Term:1 Log:0/0 Rejected
   INFO 2 received MsgPreVoteResp rejection from 1 at term 1
   INFO 2 has received 1 MsgPreVoteResp votes and 1 vote rejections
   INFO 2 became follower at term 1
@@ -227,10 +227,10 @@ stabilize
   HardState Term:2 Vote:1 Commit:11 Lead:1 LeadEpoch:1
   OnSync:
   2->1 MsgFortifyLeaderResp Term:2 Log:0/0 LeadEpoch:1
-  2->1 MsgAppResp Term:2 Log:1/12 Rejected (Hint: 11) Commit:11
+  2->1 MsgAppResp Term:2 Log:1/12 Rejected Hint:1/11 Commit:11
 > 1 receiving messages
   2->1 MsgFortifyLeaderResp Term:2 Log:0/0 LeadEpoch:1
-  2->1 MsgAppResp Term:2 Log:1/12 Rejected (Hint: 11) Commit:11
+  2->1 MsgAppResp Term:2 Log:1/12 Rejected Hint:1/11 Commit:11
 > 1 handling Ready
   Ready:
   Messages:

--- a/pkg/raft/testdata/liveness_recovered_after_temporary_loss_of_quorum.txt
+++ b/pkg/raft/testdata/liveness_recovered_after_temporary_loss_of_quorum.txt
@@ -215,42 +215,30 @@ stabilize
   2/13 EntryNormal ""
   Messages:
   1->2 MsgFortifyLeader Term:2 Log:0/0
-  1->2 MsgApp Term:2 Log:1/12 Commit:11 Entries:[2/13 EntryNormal ""]
+  1->2 MsgApp Term:2 Log:1/11 Commit:11 Entries:[
+    1/12 EntryNormal "data1"
+    2/13 EntryNormal ""
+  ]
   OnSync:
   1->1 MsgAppResp Term:2 Log:0/13 Commit:11
   1->1 MsgFortifyLeaderResp Term:2 Log:0/0 LeadEpoch:1
 > 2 receiving messages
   1->2 MsgFortifyLeader Term:2 Log:0/0
-  1->2 MsgApp Term:2 Log:1/12 Commit:11 Entries:[2/13 EntryNormal ""]
+  1->2 MsgApp Term:2 Log:1/11 Commit:11 Entries:[
+    1/12 EntryNormal "data1"
+    2/13 EntryNormal ""
+  ]
 > 2 handling Ready
   Ready:
   HardState Term:2 Vote:1 Commit:11 Lead:1 LeadEpoch:1
-  OnSync:
-  2->1 MsgFortifyLeaderResp Term:2 Log:0/0 LeadEpoch:1
-  2->1 MsgAppResp Term:2 Log:1/12 Rejected Hint:1/11 Commit:11
-> 1 receiving messages
-  2->1 MsgFortifyLeaderResp Term:2 Log:0/0 LeadEpoch:1
-  2->1 MsgAppResp Term:2 Log:1/12 Rejected Hint:1/11 Commit:11
-> 1 handling Ready
-  Ready:
-  Messages:
-  1->2 MsgApp Term:2 Log:1/11 Commit:11 Entries:[
-    1/12 EntryNormal "data1"
-    2/13 EntryNormal ""
-  ]
-> 2 receiving messages
-  1->2 MsgApp Term:2 Log:1/11 Commit:11 Entries:[
-    1/12 EntryNormal "data1"
-    2/13 EntryNormal ""
-  ]
-> 2 handling Ready
-  Ready:
   Entries:
   1/12 EntryNormal "data1"
   2/13 EntryNormal ""
   OnSync:
+  2->1 MsgFortifyLeaderResp Term:2 Log:0/0 LeadEpoch:1
   2->1 MsgAppResp Term:2 Log:0/13 Commit:11
 > 1 receiving messages
+  2->1 MsgFortifyLeaderResp Term:2 Log:0/0 LeadEpoch:1
   2->1 MsgAppResp Term:2 Log:0/13 Commit:11
 > 1 handling Ready
   Ready:

--- a/pkg/raft/testdata/liveness_recovered_after_temporary_loss_of_quorum.txt
+++ b/pkg/raft/testdata/liveness_recovered_after_temporary_loss_of_quorum.txt
@@ -201,9 +201,9 @@ stabilize
   Ready:
   HardState Term:2 Vote:1 Commit:11 Lead:0 LeadEpoch:0
   OnSync:
-  2->1 MsgVoteResp Term:2 Log:0/0
+  2->1 MsgVoteResp Term:2 Log:1/0 Hint:1/11
 > 1 receiving messages
-  2->1 MsgVoteResp Term:2 Log:0/0
+  2->1 MsgVoteResp Term:2 Log:1/0 Hint:1/11
   INFO 1 received MsgVoteResp from 2 at term 2
   INFO 1 has received 2 MsgVoteResp votes and 0 vote rejections
   INFO 1 became leader at term 2

--- a/pkg/raft/testdata/prevote.txt
+++ b/pkg/raft/testdata/prevote.txt
@@ -238,18 +238,18 @@ stabilize
   State:StateFollower
   HardState Term:2 Vote:2 Commit:12 Lead:0 LeadEpoch:0
   OnSync:
-  1->2 MsgVoteResp Term:2 Log:0/0
+  1->2 MsgVoteResp Term:2 Log:1/0 Hint:1/12
 > 3 handling Ready
   Ready:
   HardState Term:2 Vote:2 Commit:12 Lead:0 LeadEpoch:0
   OnSync:
-  3->2 MsgVoteResp Term:2 Log:0/0
+  3->2 MsgVoteResp Term:2 Log:1/0 Hint:1/12
 > 2 receiving messages
-  1->2 MsgVoteResp Term:2 Log:0/0
+  1->2 MsgVoteResp Term:2 Log:1/0 Hint:1/12
   INFO 2 received MsgVoteResp from 1 at term 2
   INFO 2 has received 2 MsgVoteResp votes and 0 vote rejections
   INFO 2 became leader at term 2
-  3->2 MsgVoteResp Term:2 Log:0/0
+  3->2 MsgVoteResp Term:2 Log:1/0 Hint:1/12
 > 2 handling Ready
   Ready:
   State:StateLeader

--- a/pkg/raft/testdata/prevote.txt
+++ b/pkg/raft/testdata/prevote.txt
@@ -124,14 +124,14 @@ stabilize
   1->2 MsgApp Term:1 Log:1/12 Commit:12
   1->3 MsgApp Term:1 Log:1/12 Commit:12
   OnSync:
-  1->3 MsgPreVoteResp Term:1 Log:0/0 Rejected (Hint: 0)
+  1->3 MsgPreVoteResp Term:1 Log:0/0 Rejected
   Applying:
   1/12 EntryNormal "prop_1"
 > 2 handling Ready
   Ready:
   HardState Term:1 Vote:1 Commit:11 Lead:1 LeadEpoch:0
   OnSync:
-  2->3 MsgPreVoteResp Term:1 Log:0/0 Rejected (Hint: 0)
+  2->3 MsgPreVoteResp Term:1 Log:0/0 Rejected
 > 2 receiving messages
   1->2 MsgApp Term:1 Log:1/12 Commit:12
 > 3 receiving messages
@@ -139,8 +139,8 @@ stabilize
   INFO 3 became follower at term 1
   DEBUG 3 reset election elapsed to 0
   1->3 MsgApp Term:1 Log:1/12 Commit:12
-  1->3 MsgPreVoteResp Term:1 Log:0/0 Rejected (Hint: 0)
-  2->3 MsgPreVoteResp Term:1 Log:0/0 Rejected (Hint: 0)
+  1->3 MsgPreVoteResp Term:1 Log:0/0 Rejected
+  2->3 MsgPreVoteResp Term:1 Log:0/0 Rejected
 > 2 handling Ready
   Ready:
   HardState Term:1 Vote:1 Commit:12 Lead:1 LeadEpoch:0

--- a/pkg/raft/testdata/prevote_checkquorum.txt
+++ b/pkg/raft/testdata/prevote_checkquorum.txt
@@ -143,9 +143,9 @@ stabilize
   State:StateFollower
   HardState Term:2 Vote:3 Commit:11 Lead:0 LeadEpoch:0
   OnSync:
-  2->3 MsgVoteResp Term:2 Log:0/0
+  2->3 MsgVoteResp Term:2 Log:1/0 Hint:1/11
 > 3 receiving messages
-  2->3 MsgVoteResp Term:2 Log:0/0
+  2->3 MsgVoteResp Term:2 Log:1/0 Hint:1/11
   INFO 3 received MsgVoteResp from 2 at term 2
   INFO 3 has received 2 MsgVoteResp votes and 0 vote rejections
   INFO 3 became leader at term 2
@@ -351,9 +351,9 @@ stabilize
   State:StateFollower
   HardState Term:3 Vote:2 Commit:12 Lead:0 LeadEpoch:0
   OnSync:
-  1->2 MsgVoteResp Term:3 Log:0/0
+  1->2 MsgVoteResp Term:3 Log:2/0 Hint:2/12
 > 2 receiving messages
-  1->2 MsgVoteResp Term:3 Log:0/0
+  1->2 MsgVoteResp Term:3 Log:2/0 Hint:2/12
   INFO 2 received MsgVoteResp from 1 at term 3
   INFO 2 has received 2 MsgVoteResp votes and 0 vote rejections
   INFO 2 became leader at term 3

--- a/pkg/raft/testdata/probe_and_replicate.txt
+++ b/pkg/raft/testdata/probe_and_replicate.txt
@@ -464,7 +464,7 @@ stabilize 2 3 4 5 6 7
   State:StateFollower
   HardState Term:8 Commit:18 Lead:0 LeadEpoch:0
   OnSync:
-  4->1 MsgVoteResp Term:8 Log:0/0 Rejected (Hint: 0)
+  4->1 MsgVoteResp Term:8 Log:0/0 Rejected
 > 5 handling Ready
   Ready:
   State:StateFollower
@@ -477,7 +477,7 @@ stabilize 2 3 4 5 6 7
   5->6 MsgDeFortifyLeader Term:7 Log:0/0
   5->7 MsgDeFortifyLeader Term:7 Log:0/0
   OnSync:
-  5->1 MsgVoteResp Term:8 Log:0/0 Rejected (Hint: 0)
+  5->1 MsgVoteResp Term:8 Log:0/0 Rejected
 > 6 handling Ready
   Ready:
   HardState Term:8 Vote:1 Commit:15 Lead:0 LeadEpoch:0
@@ -531,12 +531,12 @@ stabilize 1
   3->1 MsgVoteResp Term:8 Log:0/0
   INFO 1 received MsgVoteResp from 3 at term 8
   INFO 1 has received 3 MsgVoteResp votes and 0 vote rejections
-  4->1 MsgVoteResp Term:8 Log:0/0 Rejected (Hint: 0)
+  4->1 MsgVoteResp Term:8 Log:0/0 Rejected
   INFO 1 received MsgVoteResp rejection from 4 at term 8
   INFO 1 has received 3 MsgVoteResp votes and 1 vote rejections
   5->1 MsgDeFortifyLeader Term:7 Log:0/0
   INFO 1 [term: 8] ignored a MsgDeFortifyLeader message with lower term from 5 [term: 7]
-  5->1 MsgVoteResp Term:8 Log:0/0 Rejected (Hint: 0)
+  5->1 MsgVoteResp Term:8 Log:0/0 Rejected
   INFO 1 received MsgVoteResp rejection from 5 at term 8
   INFO 1 has received 3 MsgVoteResp votes and 2 vote rejections
   6->1 MsgVoteResp Term:8 Log:0/0
@@ -590,10 +590,10 @@ stabilize 1 2
   HardState Term:8 Vote:1 Commit:18 Lead:1 LeadEpoch:2
   OnSync:
   2->1 MsgFortifyLeaderResp Term:8 Log:0/0 LeadEpoch:2
-  2->1 MsgAppResp Term:8 Log:6/20 Rejected (Hint: 19) Commit:18
+  2->1 MsgAppResp Term:8 Log:6/20 Rejected Hint:6/19 Commit:18
 > 1 receiving messages
   2->1 MsgFortifyLeaderResp Term:8 Log:0/0 LeadEpoch:2
-  2->1 MsgAppResp Term:8 Log:6/20 Rejected (Hint: 19) Commit:18
+  2->1 MsgAppResp Term:8 Log:6/20 Rejected Hint:6/19 Commit:18
 > 1 handling Ready
   Ready:
   Messages:
@@ -626,10 +626,10 @@ stabilize 1 3
   HardState Term:8 Vote:1 Commit:14 Lead:1 LeadEpoch:2
   OnSync:
   3->1 MsgFortifyLeaderResp Term:8 Log:0/0 LeadEpoch:2
-  3->1 MsgAppResp Term:8 Log:4/20 Rejected (Hint: 14) Commit:14
+  3->1 MsgAppResp Term:8 Log:4/20 Rejected Hint:4/14 Commit:14
 > 1 receiving messages
   3->1 MsgFortifyLeaderResp Term:8 Log:0/0 LeadEpoch:2
-  3->1 MsgAppResp Term:8 Log:4/20 Rejected (Hint: 14) Commit:14
+  3->1 MsgAppResp Term:8 Log:4/20 Rejected Hint:4/14 Commit:14
 > 1 handling Ready
   Ready:
   Messages:
@@ -729,10 +729,10 @@ stabilize 1 5
   HardState Term:8 Commit:18 Lead:1 LeadEpoch:2
   OnSync:
   5->1 MsgFortifyLeaderResp Term:8 Log:0/0 LeadEpoch:2
-  5->1 MsgAppResp Term:8 Log:6/20 Rejected (Hint: 18) Commit:18
+  5->1 MsgAppResp Term:8 Log:6/20 Rejected Hint:6/18 Commit:18
 > 1 receiving messages
   5->1 MsgFortifyLeaderResp Term:8 Log:0/0 LeadEpoch:2
-  5->1 MsgAppResp Term:8 Log:6/20 Rejected (Hint: 18) Commit:18
+  5->1 MsgAppResp Term:8 Log:6/20 Rejected Hint:6/18 Commit:18
 > 1 handling Ready
   Ready:
   Messages:
@@ -776,10 +776,10 @@ stabilize 1 6
   HardState Term:8 Vote:1 Commit:15 Lead:1 LeadEpoch:2
   OnSync:
   6->1 MsgFortifyLeaderResp Term:8 Log:0/0 LeadEpoch:2
-  6->1 MsgAppResp Term:8 Log:4/20 Rejected (Hint: 17) Commit:15
+  6->1 MsgAppResp Term:8 Log:4/20 Rejected Hint:4/17 Commit:15
 > 1 receiving messages
   6->1 MsgFortifyLeaderResp Term:8 Log:0/0 LeadEpoch:2
-  6->1 MsgAppResp Term:8 Log:4/20 Rejected (Hint: 17) Commit:15
+  6->1 MsgAppResp Term:8 Log:4/20 Rejected Hint:4/17 Commit:15
 > 1 handling Ready
   Ready:
   Messages:

--- a/pkg/raft/testdata/probe_and_replicate.txt
+++ b/pkg/raft/testdata/probe_and_replicate.txt
@@ -453,12 +453,12 @@ stabilize 2 3 4 5 6 7
   Ready:
   HardState Term:8 Vote:1 Commit:18 Lead:0 LeadEpoch:0
   OnSync:
-  2->1 MsgVoteResp Term:8 Log:0/0
+  2->1 MsgVoteResp Term:8 Log:6/0 Hint:6/19
 > 3 handling Ready
   Ready:
   HardState Term:8 Vote:1 Commit:14 Lead:0 LeadEpoch:0
   OnSync:
-  3->1 MsgVoteResp Term:8 Log:0/0
+  3->1 MsgVoteResp Term:8 Log:4/0 Hint:4/14
 > 4 handling Ready
   Ready:
   State:StateFollower
@@ -482,7 +482,7 @@ stabilize 2 3 4 5 6 7
   Ready:
   HardState Term:8 Vote:1 Commit:15 Lead:0 LeadEpoch:0
   OnSync:
-  6->1 MsgVoteResp Term:8 Log:0/0
+  6->1 MsgVoteResp Term:8 Log:4/0 Hint:4/17
 > 7 handling Ready
   Ready:
   HardState Term:8 Vote:1 Commit:13 Lead:0 LeadEpoch:0
@@ -494,7 +494,7 @@ stabilize 2 3 4 5 6 7
   7->5 MsgDeFortifyLeader Term:3 Log:0/0
   7->6 MsgDeFortifyLeader Term:3 Log:0/0
   OnSync:
-  7->1 MsgVoteResp Term:8 Log:0/0
+  7->1 MsgVoteResp Term:8 Log:3/0 Hint:3/20
 > 2 receiving messages
   5->2 MsgDeFortifyLeader Term:7 Log:0/0
   INFO 2 [term: 8] ignored a MsgDeFortifyLeader message with lower term from 5 [term: 7]
@@ -525,10 +525,10 @@ stabilize 2 3 4 5 6 7
 stabilize 1
 ----
 > 1 receiving messages
-  2->1 MsgVoteResp Term:8 Log:0/0
+  2->1 MsgVoteResp Term:8 Log:6/0 Hint:6/19
   INFO 1 received MsgVoteResp from 2 at term 8
   INFO 1 has received 2 MsgVoteResp votes and 0 vote rejections
-  3->1 MsgVoteResp Term:8 Log:0/0
+  3->1 MsgVoteResp Term:8 Log:4/0 Hint:4/14
   INFO 1 received MsgVoteResp from 3 at term 8
   INFO 1 has received 3 MsgVoteResp votes and 0 vote rejections
   4->1 MsgVoteResp Term:8 Log:0/0 Rejected
@@ -539,13 +539,13 @@ stabilize 1
   5->1 MsgVoteResp Term:8 Log:0/0 Rejected
   INFO 1 received MsgVoteResp rejection from 5 at term 8
   INFO 1 has received 3 MsgVoteResp votes and 2 vote rejections
-  6->1 MsgVoteResp Term:8 Log:0/0
+  6->1 MsgVoteResp Term:8 Log:4/0 Hint:4/17
   INFO 1 received MsgVoteResp from 6 at term 8
   INFO 1 has received 4 MsgVoteResp votes and 2 vote rejections
   INFO 1 became leader at term 8
   7->1 MsgDeFortifyLeader Term:3 Log:0/0
   INFO 1 [term: 8] ignored a MsgDeFortifyLeader message with lower term from 7 [term: 3]
-  7->1 MsgVoteResp Term:8 Log:0/0
+  7->1 MsgVoteResp Term:8 Log:3/0 Hint:3/20
 > 1 handling Ready
   Ready:
   State:StateLeader

--- a/pkg/raft/testdata/probe_and_replicate.txt
+++ b/pkg/raft/testdata/probe_and_replicate.txt
@@ -569,6 +569,16 @@ stabilize 1
   1->1 MsgAppResp Term:8 Log:0/21 Commit:18
   1->1 MsgFortifyLeaderResp Term:8 Log:0/0 LeadEpoch:2
 
+status 1
+----
+1: StateReplicate match=21 next=22 sentCommit=18 matchCommit=18
+2: StateProbe match=0 next=21 sentCommit=18 matchCommit=0 paused inactive
+3: StateProbe match=0 next=21 sentCommit=18 matchCommit=0 paused inactive
+4: StateProbe match=0 next=21 sentCommit=18 matchCommit=0 paused inactive
+5: StateProbe match=0 next=21 sentCommit=18 matchCommit=0 paused inactive
+6: StateProbe match=0 next=21 sentCommit=18 matchCommit=0 paused inactive
+7: StateProbe match=0 next=21 sentCommit=18 matchCommit=0 paused inactive
+
 ## Recover each follower, one by one.
 stabilize 1 2
 ----
@@ -814,3 +824,70 @@ stabilize 1 6
   8/21 EntryNormal ""
 > 1 receiving messages
   6->1 MsgAppResp Term:8 Log:0/21 Commit:21
+
+stabilize 1 7
+----
+> 7 receiving messages
+  1->7 MsgFortifyLeader Term:8 Log:0/0
+  1->7 MsgApp Term:8 Log:6/20 Commit:18 Entries:[8/21 EntryNormal ""]
+> 7 handling Ready
+  Ready:
+  HardState Term:8 Vote:1 Commit:13 Lead:1 LeadEpoch:2
+  OnSync:
+  7->1 MsgFortifyLeaderResp Term:8 Log:0/0 LeadEpoch:2
+  7->1 MsgAppResp Term:8 Log:3/20 Rejected Hint:3/20 Commit:13
+> 1 receiving messages
+  7->1 MsgFortifyLeaderResp Term:8 Log:0/0 LeadEpoch:2
+  7->1 MsgAppResp Term:8 Log:3/20 Rejected Hint:3/20 Commit:13
+> 1 handling Ready
+  Ready:
+  Messages:
+  1->7 MsgApp Term:8 Log:1/13 Commit:21 Entries:[
+    4/14 EntryNormal ""
+    4/15 EntryNormal "prop_4_15"
+    5/16 EntryNormal ""
+    5/17 EntryNormal "prop_5_17"
+    6/18 EntryNormal ""
+    6/19 EntryNormal "prop_6_19"
+    6/20 EntryNormal "prop_6_20"
+    8/21 EntryNormal ""
+  ]
+> 7 receiving messages
+  1->7 MsgApp Term:8 Log:1/13 Commit:21 Entries:[
+    4/14 EntryNormal ""
+    4/15 EntryNormal "prop_4_15"
+    5/16 EntryNormal ""
+    5/17 EntryNormal "prop_5_17"
+    6/18 EntryNormal ""
+    6/19 EntryNormal "prop_6_19"
+    6/20 EntryNormal "prop_6_20"
+    8/21 EntryNormal ""
+  ]
+  INFO found conflict at index 14 [existing term: 2, conflicting term: 4]
+  INFO replace the unstable entries from index 14
+> 7 handling Ready
+  Ready:
+  HardState Term:8 Vote:1 Commit:21 Lead:1 LeadEpoch:2
+  Entries:
+  4/14 EntryNormal ""
+  4/15 EntryNormal "prop_4_15"
+  5/16 EntryNormal ""
+  5/17 EntryNormal "prop_5_17"
+  6/18 EntryNormal ""
+  6/19 EntryNormal "prop_6_19"
+  6/20 EntryNormal "prop_6_20"
+  8/21 EntryNormal ""
+  Committed: (13,21]
+  OnSync:
+  7->1 MsgAppResp Term:8 Log:0/21 Commit:21
+  Applying:
+  4/14 EntryNormal ""
+  4/15 EntryNormal "prop_4_15"
+  5/16 EntryNormal ""
+  5/17 EntryNormal "prop_5_17"
+  6/18 EntryNormal ""
+  6/19 EntryNormal "prop_6_19"
+  6/20 EntryNormal "prop_6_20"
+  8/21 EntryNormal ""
+> 1 receiving messages
+  7->1 MsgAppResp Term:8 Log:0/21 Commit:21

--- a/pkg/raft/testdata/probe_and_replicate.txt
+++ b/pkg/raft/testdata/probe_and_replicate.txt
@@ -559,80 +559,10 @@ stabilize 1
   1->5 MsgFortifyLeader Term:8 Log:0/0
   1->6 MsgFortifyLeader Term:8 Log:0/0
   1->7 MsgFortifyLeader Term:8 Log:0/0
-  1->2 MsgApp Term:8 Log:6/20 Commit:18 Entries:[8/21 EntryNormal ""]
-  1->3 MsgApp Term:8 Log:6/20 Commit:18 Entries:[8/21 EntryNormal ""]
-  1->4 MsgApp Term:8 Log:6/20 Commit:18 Entries:[8/21 EntryNormal ""]
-  1->5 MsgApp Term:8 Log:6/20 Commit:18 Entries:[8/21 EntryNormal ""]
-  1->6 MsgApp Term:8 Log:6/20 Commit:18 Entries:[8/21 EntryNormal ""]
-  1->7 MsgApp Term:8 Log:6/20 Commit:18 Entries:[8/21 EntryNormal ""]
-  OnSync:
-  1->1 MsgAppResp Term:8 Log:0/21 Commit:18
-  1->1 MsgFortifyLeaderResp Term:8 Log:0/0 LeadEpoch:2
-
-status 1
-----
-1: StateReplicate match=21 next=22 sentCommit=18 matchCommit=18
-2: StateProbe match=0 next=21 sentCommit=18 matchCommit=0 paused inactive
-3: StateProbe match=0 next=21 sentCommit=18 matchCommit=0 paused inactive
-4: StateProbe match=0 next=21 sentCommit=18 matchCommit=0 paused inactive
-5: StateProbe match=0 next=21 sentCommit=18 matchCommit=0 paused inactive
-6: StateProbe match=0 next=21 sentCommit=18 matchCommit=0 paused inactive
-7: StateProbe match=0 next=21 sentCommit=18 matchCommit=0 paused inactive
-
-## Recover each follower, one by one.
-stabilize 1 2
-----
-> 2 receiving messages
-  1->2 MsgFortifyLeader Term:8 Log:0/0
-  1->2 MsgApp Term:8 Log:6/20 Commit:18 Entries:[8/21 EntryNormal ""]
-> 2 handling Ready
-  Ready:
-  HardState Term:8 Vote:1 Commit:18 Lead:1 LeadEpoch:2
-  OnSync:
-  2->1 MsgFortifyLeaderResp Term:8 Log:0/0 LeadEpoch:2
-  2->1 MsgAppResp Term:8 Log:6/20 Rejected Hint:6/19 Commit:18
-> 1 receiving messages
-  2->1 MsgFortifyLeaderResp Term:8 Log:0/0 LeadEpoch:2
-  2->1 MsgAppResp Term:8 Log:6/20 Rejected Hint:6/19 Commit:18
-> 1 handling Ready
-  Ready:
-  Messages:
   1->2 MsgApp Term:8 Log:6/19 Commit:18 Entries:[
     6/20 EntryNormal "prop_6_20"
     8/21 EntryNormal ""
   ]
-> 2 receiving messages
-  1->2 MsgApp Term:8 Log:6/19 Commit:18 Entries:[
-    6/20 EntryNormal "prop_6_20"
-    8/21 EntryNormal ""
-  ]
-> 2 handling Ready
-  Ready:
-  Entries:
-  6/20 EntryNormal "prop_6_20"
-  8/21 EntryNormal ""
-  OnSync:
-  2->1 MsgAppResp Term:8 Log:0/21 Commit:18
-> 1 receiving messages
-  2->1 MsgAppResp Term:8 Log:0/21 Commit:18
-
-stabilize 1 3
-----
-> 3 receiving messages
-  1->3 MsgFortifyLeader Term:8 Log:0/0
-  1->3 MsgApp Term:8 Log:6/20 Commit:18 Entries:[8/21 EntryNormal ""]
-> 3 handling Ready
-  Ready:
-  HardState Term:8 Vote:1 Commit:14 Lead:1 LeadEpoch:2
-  OnSync:
-  3->1 MsgFortifyLeaderResp Term:8 Log:0/0 LeadEpoch:2
-  3->1 MsgAppResp Term:8 Log:4/20 Rejected Hint:4/14 Commit:14
-> 1 receiving messages
-  3->1 MsgFortifyLeaderResp Term:8 Log:0/0 LeadEpoch:2
-  3->1 MsgAppResp Term:8 Log:4/20 Rejected Hint:4/14 Commit:14
-> 1 handling Ready
-  Ready:
-  Messages:
   1->3 MsgApp Term:8 Log:4/14 Commit:18 Entries:[
     4/15 EntryNormal "prop_4_15"
     5/16 EntryNormal ""
@@ -642,7 +572,64 @@ stabilize 1 3
     6/20 EntryNormal "prop_6_20"
     8/21 EntryNormal ""
   ]
+  1->4 MsgApp Term:8 Log:6/20 Commit:18 Entries:[8/21 EntryNormal ""]
+  1->5 MsgApp Term:8 Log:6/20 Commit:18 Entries:[8/21 EntryNormal ""]
+  1->6 MsgApp Term:8 Log:4/15 Commit:18 Entries:[
+    5/16 EntryNormal ""
+    5/17 EntryNormal "prop_5_17"
+    6/18 EntryNormal ""
+    6/19 EntryNormal "prop_6_19"
+    6/20 EntryNormal "prop_6_20"
+    8/21 EntryNormal ""
+  ]
+  1->7 MsgApp Term:8 Log:6/20 Commit:18 Entries:[8/21 EntryNormal ""]
+  OnSync:
+  1->1 MsgAppResp Term:8 Log:0/21 Commit:18
+  1->1 MsgFortifyLeaderResp Term:8 Log:0/0 LeadEpoch:2
+
+# The new leader n1 used hints from n2, n3, and n6 (their last EntryID) in
+# MsgVoteResp to set them to StateReplicate, as their logs matched n1. For n6,
+# despite hint EntryID t7/14 not being in n1's log, n1 deduced a match point at
+# t4/14 and set n6 to StateReplicate. n7's hint was ignored since n1 already
+# had a quorum. Even if received earlier, hint t3/21 was insufficient as it
+# exceeded n1's log length and lacked term 3.
+# TODO(hakuuww): This motivates adding term cache EntryIDs to MsgVoteResp.
+status 1
+----
+1: StateReplicate match=21 next=22 sentCommit=18 matchCommit=18
+2: StateReplicate match=0 next=22 sentCommit=18 matchCommit=0 inflight=1
+3: StateReplicate match=0 next=22 sentCommit=18 matchCommit=0 inflight=1
+4: StateProbe match=0 next=21 sentCommit=18 matchCommit=0 paused
+5: StateProbe match=0 next=21 sentCommit=18 matchCommit=0 paused
+6: StateReplicate match=0 next=22 sentCommit=18 matchCommit=0 inflight=1
+7: StateProbe match=0 next=21 sentCommit=18 matchCommit=0 paused inactive
+
+## Recover each follower, one by one.
+stabilize 1 2
+----
+> 2 receiving messages
+  1->2 MsgFortifyLeader Term:8 Log:0/0
+  1->2 MsgApp Term:8 Log:6/19 Commit:18 Entries:[
+    6/20 EntryNormal "prop_6_20"
+    8/21 EntryNormal ""
+  ]
+> 2 handling Ready
+  Ready:
+  HardState Term:8 Vote:1 Commit:18 Lead:1 LeadEpoch:2
+  Entries:
+  6/20 EntryNormal "prop_6_20"
+  8/21 EntryNormal ""
+  OnSync:
+  2->1 MsgFortifyLeaderResp Term:8 Log:0/0 LeadEpoch:2
+  2->1 MsgAppResp Term:8 Log:0/21 Commit:18
+> 1 receiving messages
+  2->1 MsgFortifyLeaderResp Term:8 Log:0/0 LeadEpoch:2
+  2->1 MsgAppResp Term:8 Log:0/21 Commit:18
+
+stabilize 1 3
+----
 > 3 receiving messages
+  1->3 MsgFortifyLeader Term:8 Log:0/0
   1->3 MsgApp Term:8 Log:4/14 Commit:18 Entries:[
     4/15 EntryNormal "prop_4_15"
     5/16 EntryNormal ""
@@ -665,6 +652,7 @@ stabilize 1 3
   8/21 EntryNormal ""
   Committed: (14,18]
   OnSync:
+  3->1 MsgFortifyLeaderResp Term:8 Log:0/0 LeadEpoch:2
   3->1 MsgAppResp Term:8 Log:0/21 Commit:18
   Applying:
   4/15 EntryNormal "prop_4_15"
@@ -672,6 +660,7 @@ stabilize 1 3
   5/17 EntryNormal "prop_5_17"
   6/18 EntryNormal ""
 > 1 receiving messages
+  3->1 MsgFortifyLeaderResp Term:8 Log:0/0 LeadEpoch:2
   3->1 MsgAppResp Term:8 Log:0/21 Commit:18
 
 stabilize 1 4
@@ -700,6 +689,7 @@ stabilize 1 4
   1->2 MsgApp Term:8 Log:8/21 Commit:21
   1->3 MsgApp Term:8 Log:8/21 Commit:21
   1->4 MsgApp Term:8 Log:8/21 Commit:21
+  1->6 MsgApp Term:8 Log:8/21 Commit:21
   Applying:
   6/19 EntryNormal "prop_6_19"
   6/20 EntryNormal "prop_6_20"
@@ -770,29 +760,7 @@ stabilize 1 6
 ----
 > 6 receiving messages
   1->6 MsgFortifyLeader Term:8 Log:0/0
-  1->6 MsgApp Term:8 Log:6/20 Commit:18 Entries:[8/21 EntryNormal ""]
-> 6 handling Ready
-  Ready:
-  HardState Term:8 Vote:1 Commit:15 Lead:1 LeadEpoch:2
-  OnSync:
-  6->1 MsgFortifyLeaderResp Term:8 Log:0/0 LeadEpoch:2
-  6->1 MsgAppResp Term:8 Log:4/20 Rejected Hint:4/17 Commit:15
-> 1 receiving messages
-  6->1 MsgFortifyLeaderResp Term:8 Log:0/0 LeadEpoch:2
-  6->1 MsgAppResp Term:8 Log:4/20 Rejected Hint:4/17 Commit:15
-> 1 handling Ready
-  Ready:
-  Messages:
-  1->6 MsgApp Term:8 Log:4/15 Commit:21 Entries:[
-    5/16 EntryNormal ""
-    5/17 EntryNormal "prop_5_17"
-    6/18 EntryNormal ""
-    6/19 EntryNormal "prop_6_19"
-    6/20 EntryNormal "prop_6_20"
-    8/21 EntryNormal ""
-  ]
-> 6 receiving messages
-  1->6 MsgApp Term:8 Log:4/15 Commit:21 Entries:[
+  1->6 MsgApp Term:8 Log:4/15 Commit:18 Entries:[
     5/16 EntryNormal ""
     5/17 EntryNormal "prop_5_17"
     6/18 EntryNormal ""
@@ -802,6 +770,7 @@ stabilize 1 6
   ]
   INFO found conflict at index 16 [existing term: 4, conflicting term: 5]
   INFO replace the unstable entries from index 16
+  1->6 MsgApp Term:8 Log:8/21 Commit:21
 > 6 handling Ready
   Ready:
   HardState Term:8 Vote:1 Commit:21 Lead:1 LeadEpoch:2
@@ -814,6 +783,8 @@ stabilize 1 6
   8/21 EntryNormal ""
   Committed: (15,21]
   OnSync:
+  6->1 MsgFortifyLeaderResp Term:8 Log:0/0 LeadEpoch:2
+  6->1 MsgAppResp Term:8 Log:0/21 Commit:18
   6->1 MsgAppResp Term:8 Log:0/21 Commit:21
   Applying:
   5/16 EntryNormal ""
@@ -823,6 +794,8 @@ stabilize 1 6
   6/20 EntryNormal "prop_6_20"
   8/21 EntryNormal ""
 > 1 receiving messages
+  6->1 MsgFortifyLeaderResp Term:8 Log:0/0 LeadEpoch:2
+  6->1 MsgAppResp Term:8 Log:0/21 Commit:18
   6->1 MsgAppResp Term:8 Log:0/21 Commit:21
 
 stabilize 1 7

--- a/pkg/raft/testdata/refortification_basic.txt
+++ b/pkg/raft/testdata/refortification_basic.txt
@@ -75,18 +75,18 @@ stabilize
   Ready:
   HardState Term:1 Vote:1 Commit:2 Lead:0 LeadEpoch:0
   OnSync:
-  2->1 MsgVoteResp Term:1 Log:0/0
+  2->1 MsgVoteResp Term:1 Log:1/0 Hint:1/2
 > 3 handling Ready
   Ready:
   HardState Term:1 Vote:1 Commit:2 Lead:0 LeadEpoch:0
   OnSync:
-  3->1 MsgVoteResp Term:1 Log:0/0
+  3->1 MsgVoteResp Term:1 Log:1/0 Hint:1/2
 > 1 receiving messages
-  2->1 MsgVoteResp Term:1 Log:0/0
+  2->1 MsgVoteResp Term:1 Log:1/0 Hint:1/2
   INFO 1 received MsgVoteResp from 2 at term 1
   INFO 1 has received 2 MsgVoteResp votes and 0 vote rejections
   INFO 1 became leader at term 1
-  3->1 MsgVoteResp Term:1 Log:0/0
+  3->1 MsgVoteResp Term:1 Log:1/0 Hint:1/2
 > 1 handling Ready
   Ready:
   State:StateLeader

--- a/pkg/raft/testdata/replicate_pause.txt
+++ b/pkg/raft/testdata/replicate_pause.txt
@@ -144,13 +144,13 @@ stabilize 2 3
 > 3 handling Ready
   Ready:
   OnSync:
-  3->1 MsgAppResp Term:1 Log:1/14 Rejected (Hint: 11) Commit:11
+  3->1 MsgAppResp Term:1 Log:1/14 Rejected Hint:1/11 Commit:11
 
 # Node 1 receives the rejection and adjusts the MsgApp sent to node 3.
 stabilize 1
 ----
 > 1 receiving messages
-  3->1 MsgAppResp Term:1 Log:1/14 Rejected (Hint: 11) Commit:11
+  3->1 MsgAppResp Term:1 Log:1/14 Rejected Hint:1/11 Commit:11
   DEBUG 1 received MsgAppResp(rejected, hint: (index 11, term 1)) from 3 for index 14
   DEBUG 1 decreased progress of 3 to [StateReplicate match=11 next=12 sentCommit=11 matchCommit=11 paused inflight=3[full]]
 > 1 handling Ready

--- a/pkg/raft/testdata/snapshot_new_term.txt
+++ b/pkg/raft/testdata/snapshot_new_term.txt
@@ -73,9 +73,9 @@ stabilize 1 2
   Ready:
   HardState Term:2 Vote:2 Commit:11 Lead:0 LeadEpoch:0
   OnSync:
-  1->2 MsgVoteResp Term:2 Log:0/0
+  1->2 MsgVoteResp Term:2 Log:1/0 Hint:1/11
 > 2 receiving messages
-  1->2 MsgVoteResp Term:2 Log:0/0
+  1->2 MsgVoteResp Term:2 Log:1/0 Hint:1/11
   INFO 2 received MsgVoteResp from 1 at term 2
   INFO 2 has received 2 MsgVoteResp votes and 0 vote rejections
   INFO 2 became leader at term 2

--- a/pkg/raft/testdata/snapshot_sent_and_leadership_change.txt
+++ b/pkg/raft/testdata/snapshot_sent_and_leadership_change.txt
@@ -135,7 +135,7 @@ stabilize 3
   HardState Term:2 Commit:15 Lead:2 LeadEpoch:0
   Snapshot Index:15 Term:1 ConfState:Voters:[1 2 3] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
   OnSync:
-  3->2 MsgAppResp Term:2 Log:1/15 Rejected (Hint: 11) Commit:11
+  3->2 MsgAppResp Term:2 Log:1/15 Rejected Hint:1/11 Commit:11
   3->1 MsgAppResp Term:2 Log:0/15 Commit:15
   3->2 MsgAppResp Term:2 Log:0/15 Commit:15
 > 3 receiving messages
@@ -146,7 +146,7 @@ stabilize 3
   Ready:
   HardState Term:2 Commit:15 Lead:2 LeadEpoch:1
   OnSync:
-  3->2 MsgVoteResp Term:2 Log:0/0 Rejected (Hint: 0)
+  3->2 MsgVoteResp Term:2 Log:0/0 Rejected
   3->2 MsgFortifyLeaderResp Term:2 Log:0/0 LeadEpoch:1
 
 # 3 has applied the snapshot
@@ -172,14 +172,14 @@ compact 2 15
 stabilize 2
 ----
 > 2 receiving messages
-  3->2 MsgAppResp Term:2 Log:1/15 Rejected (Hint: 11) Commit:11
+  3->2 MsgAppResp Term:2 Log:1/15 Rejected Hint:1/11 Commit:11
   DEBUG 2 received MsgAppResp(rejected, hint: (index 11, term 1)) from 3 for index 15
   DEBUG 2 decreased progress of 3 to [StateProbe match=0 next=12 sentCommit=11 matchCommit=11]
   DEBUG 2 [firstindex: 16, commit: 16] sent snapshot[index: 16, term: 2] to 3 [StateProbe match=0 next=12 sentCommit=11 matchCommit=11]
   DEBUG 2 paused sending replication messages to 3 [StateSnapshot match=0 next=17 sentCommit=16 matchCommit=11 paused pendingSnap=16]
   3->2 MsgAppResp Term:2 Log:0/15 Commit:15
   DEBUG 2 recovered from needing snapshot, resumed sending replication messages to 3 [StateSnapshot match=15 next=17 sentCommit=16 matchCommit=15 paused pendingSnap=16]
-  3->2 MsgVoteResp Term:2 Log:0/0 Rejected (Hint: 0)
+  3->2 MsgVoteResp Term:2 Log:0/0 Rejected
   3->2 MsgFortifyLeaderResp Term:2 Log:0/0 LeadEpoch:1
 > 2 handling Ready
   Ready:

--- a/pkg/raft/testdata/snapshot_succeed_via_app_resp_behind.txt
+++ b/pkg/raft/testdata/snapshot_succeed_via_app_resp_behind.txt
@@ -50,7 +50,7 @@ status 1
 ----
 1: StateReplicate match=11 next=12 sentCommit=10 matchCommit=10
 2: StateReplicate match=11 next=12 sentCommit=11 matchCommit=11
-3: StateProbe match=0 next=11 sentCommit=10 matchCommit=0 paused inactive
+3: StateSnapshot match=0 next=11 sentCommit=10 matchCommit=0 paused pendingSnap=10
 
 raft-log 3
 ----
@@ -85,32 +85,34 @@ status 1
 ----
 1: StateReplicate match=12 next=13 sentCommit=11 matchCommit=11
 2: StateReplicate match=12 next=13 sentCommit=12 matchCommit=12
-3: StateProbe match=0 next=11 sentCommit=10 matchCommit=0 paused inactive
+3: StateSnapshot match=0 next=11 sentCommit=10 matchCommit=0 paused pendingSnap=10
 
 # 3 now gets the first MsgApp the leader originally sent, trying to append entry
 # 11 but this is rejected because the follower's log started at index 5.
 deliver-msgs 3 type=MsgApp
 ----
-1->3 MsgApp Term:1 Log:1/10 Commit:10 Entries:[1/11 EntryNormal ""]
-DEBUG 3 [logterm: 0, index: 10] rejected MsgApp [logterm: 1, index: 10] from 1
+no messages
 
 # Note below that the RejectionHint is 5, which is below the first index 10 of the
 # leader. Once the leader receives this, it will move 3 into StateSnapshot with
 # PendingSnapshot=lastIndex=12.
 process-ready 3
 ----
-Ready:
-HardState Term:1 Vote:1 Commit:5 Lead:1 LeadEpoch:0
-OnSync:
-3->1 MsgAppResp Term:1 Log:1/10 Rejected Hint:1/5 Commit:5
+<empty Ready>
 
 # 3 receives and applies the snapshot, but doesn't respond with MsgAppResp yet.
 deliver-msgs 3
 ----
 1->3 MsgFortifyLeader Term:1 Log:0/0
 1->3 MsgSnap Term:1 Log:0/0
+  Snapshot: Index:10 Term:1 ConfState:Voters:[1 2 3] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
+INFO log [committed=5, applied=5, applying=5, unstable.offset=6, unstable.offsetInProgress=6, len(unstable.Entries)=0] starts to restore snapshot [index: 10, term: 1]
+INFO 3 switched to configuration voters=(1 2 3)
+INFO 3 [commit: 10, lastindex: 10, lastterm: 1] restored snapshot [index: 10, term: 1]
+INFO 3 [commit: 10] restored snapshot [index: 10, term: 1]
+1->3 MsgSnap Term:1 Log:0/0
   Snapshot: Index:11 Term:1 ConfState:Voters:[1 2 3] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
-INFO log [committed=5, applied=5, applying=5, unstable.offset=6, unstable.offsetInProgress=6, len(unstable.Entries)=0] starts to restore snapshot [index: 11, term: 1]
+INFO log [committed=10, applied=5, applying=5, unstable.offset=11, unstable.offsetInProgress=11, len(unstable.Entries)=0] starts to restore snapshot [index: 11, term: 1]
 INFO 3 switched to configuration voters=(1 2 3)
 INFO 3 [commit: 11, lastindex: 11, lastterm: 1] restored snapshot [index: 11, term: 1]
 INFO 3 [commit: 11] restored snapshot [index: 11, term: 1]
@@ -120,23 +122,12 @@ INFO 3 [commit: 11] restored snapshot [index: 11, term: 1]
 # current last index).
 stabilize 1
 ----
-> 1 receiving messages
-  3->1 MsgAppResp Term:1 Log:1/10 Rejected Hint:1/5 Commit:5
-  DEBUG 1 received MsgAppResp(rejected, hint: (index 5, term 1)) from 3 for index 10
-  DEBUG 1 decreased progress of 3 to [StateProbe match=0 next=6 sentCommit=5 matchCommit=5]
-  DEBUG 1 [firstindex: 11, commit: 12] sent snapshot[index: 12, term: 1] to 3 [StateProbe match=0 next=6 sentCommit=5 matchCommit=5]
-  DEBUG 1 paused sending replication messages to 3 [StateSnapshot match=0 next=13 sentCommit=12 matchCommit=5 paused pendingSnap=12]
-> 1 handling Ready
-  Ready:
-  Messages:
-  1->3 MsgSnap Term:1 Log:0/0
-    Snapshot: Index:12 Term:1 ConfState:Voters:[1 2 3] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
+ok
 
 # Drop the extra MsgSnap(index=12) that 1 just sent, to keep the test tidy.
 deliver-msgs drop=(3)
 ----
-dropped: 1->3 MsgSnap Term:1 Log:0/0
-  Snapshot: Index:12 Term:1 ConfState:Voters:[1 2 3] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
+no messages
 
 # 3 sends the affirmative MsgAppResp that resulted from applying the snapshot
 # at index 11.
@@ -148,18 +139,23 @@ stabilize 3
   Snapshot Index:11 Term:1 ConfState:Voters:[1 2 3] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
   OnSync:
   3->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:1
+  3->1 MsgAppResp Term:1 Log:0/10 Commit:10
   3->1 MsgAppResp Term:1 Log:0/11 Commit:11
 
 stabilize 1
 ----
 > 1 receiving messages
   3->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:1
+  3->1 MsgAppResp Term:1 Log:0/10 Commit:10
+  DEBUG 1 recovered from needing snapshot, resumed sending replication messages to 3 [StateSnapshot match=10 next=11 sentCommit=10 matchCommit=10 paused pendingSnap=10]
   3->1 MsgAppResp Term:1 Log:0/11 Commit:11
-  DEBUG 1 recovered from needing snapshot, resumed sending replication messages to 3 [StateSnapshot match=11 next=13 sentCommit=12 matchCommit=11 paused pendingSnap=12]
 > 1 handling Ready
   Ready:
   Messages:
-  1->3 MsgApp Term:1 Log:1/11 Commit:12 Entries:[1/12 EntryNormal "\"foo\""]
+  1->3 MsgApp Term:1 Log:1/10 Commit:12 Entries:[
+    1/11 EntryNormal ""
+    1/12 EntryNormal "\"foo\""
+  ]
 
 # 3 is in StateReplicate thanks to receiving the snapshot at index 11.
 # This is despite its PendingSnapshot having been 12.

--- a/pkg/raft/testdata/snapshot_succeed_via_app_resp_behind.txt
+++ b/pkg/raft/testdata/snapshot_succeed_via_app_resp_behind.txt
@@ -30,6 +30,13 @@ stabilize 3
 ----
 ok
 
+# The leader has to rely on the n2's vote to become the leader. Otherwise it
+# will become leader when receiving n3's vote, which disables the purpose of
+# this test due to VoteHintPipelining.
+deliver-msgs drop=(1) type=MsgVoteResp
+----
+ok
+
 stabilize 1 2
 ----
 ok
@@ -37,6 +44,7 @@ ok
 log-level debug
 ----
 ok
+
 
 # We now have a leader at index 11 (it appended an empty entry when elected). 3
 # is still at index 5, and has not received any MsgApp from the leader yet.
@@ -50,7 +58,7 @@ status 1
 ----
 1: StateReplicate match=11 next=12 sentCommit=10 matchCommit=10
 2: StateReplicate match=11 next=12 sentCommit=11 matchCommit=11
-3: StateSnapshot match=0 next=11 sentCommit=10 matchCommit=0 paused pendingSnap=10
+3: StateProbe match=0 next=11 sentCommit=10 matchCommit=0 paused inactive
 
 raft-log 3
 ----
@@ -85,34 +93,32 @@ status 1
 ----
 1: StateReplicate match=12 next=13 sentCommit=11 matchCommit=11
 2: StateReplicate match=12 next=13 sentCommit=12 matchCommit=12
-3: StateSnapshot match=0 next=11 sentCommit=10 matchCommit=0 paused pendingSnap=10
+3: StateProbe match=0 next=11 sentCommit=10 matchCommit=0 paused inactive
 
 # 3 now gets the first MsgApp the leader originally sent, trying to append entry
 # 11 but this is rejected because the follower's log started at index 5.
 deliver-msgs 3 type=MsgApp
 ----
-no messages
+1->3 MsgApp Term:1 Log:1/10 Commit:10 Entries:[1/11 EntryNormal ""]
+DEBUG 3 [logterm: 0, index: 10] rejected MsgApp [logterm: 1, index: 10] from 1
 
 # Note below that the RejectionHint is 5, which is below the first index 10 of the
 # leader. Once the leader receives this, it will move 3 into StateSnapshot with
 # PendingSnapshot=lastIndex=12.
 process-ready 3
 ----
-<empty Ready>
+Ready:
+HardState Term:1 Vote:1 Commit:5 Lead:1 LeadEpoch:0
+OnSync:
+3->1 MsgAppResp Term:1 Log:1/10 Rejected Hint:1/5 Commit:5
 
 # 3 receives and applies the snapshot, but doesn't respond with MsgAppResp yet.
 deliver-msgs 3
 ----
 1->3 MsgFortifyLeader Term:1 Log:0/0
 1->3 MsgSnap Term:1 Log:0/0
-  Snapshot: Index:10 Term:1 ConfState:Voters:[1 2 3] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
-INFO log [committed=5, applied=5, applying=5, unstable.offset=6, unstable.offsetInProgress=6, len(unstable.Entries)=0] starts to restore snapshot [index: 10, term: 1]
-INFO 3 switched to configuration voters=(1 2 3)
-INFO 3 [commit: 10, lastindex: 10, lastterm: 1] restored snapshot [index: 10, term: 1]
-INFO 3 [commit: 10] restored snapshot [index: 10, term: 1]
-1->3 MsgSnap Term:1 Log:0/0
   Snapshot: Index:11 Term:1 ConfState:Voters:[1 2 3] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
-INFO log [committed=10, applied=5, applying=5, unstable.offset=11, unstable.offsetInProgress=11, len(unstable.Entries)=0] starts to restore snapshot [index: 11, term: 1]
+INFO log [committed=5, applied=5, applying=5, unstable.offset=6, unstable.offsetInProgress=6, len(unstable.Entries)=0] starts to restore snapshot [index: 11, term: 1]
 INFO 3 switched to configuration voters=(1 2 3)
 INFO 3 [commit: 11, lastindex: 11, lastterm: 1] restored snapshot [index: 11, term: 1]
 INFO 3 [commit: 11] restored snapshot [index: 11, term: 1]
@@ -122,12 +128,23 @@ INFO 3 [commit: 11] restored snapshot [index: 11, term: 1]
 # current last index).
 stabilize 1
 ----
-ok
+> 1 receiving messages
+  3->1 MsgAppResp Term:1 Log:1/10 Rejected Hint:1/5 Commit:5
+  DEBUG 1 received MsgAppResp(rejected, hint: (index 5, term 1)) from 3 for index 10
+  DEBUG 1 decreased progress of 3 to [StateProbe match=0 next=6 sentCommit=5 matchCommit=5]
+  DEBUG 1 [firstindex: 11, commit: 12] sent snapshot[index: 12, term: 1] to 3 [StateProbe match=0 next=6 sentCommit=5 matchCommit=5]
+  DEBUG 1 paused sending replication messages to 3 [StateSnapshot match=0 next=13 sentCommit=12 matchCommit=5 paused pendingSnap=12]
+> 1 handling Ready
+  Ready:
+  Messages:
+  1->3 MsgSnap Term:1 Log:0/0
+    Snapshot: Index:12 Term:1 ConfState:Voters:[1 2 3] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
 
 # Drop the extra MsgSnap(index=12) that 1 just sent, to keep the test tidy.
 deliver-msgs drop=(3)
 ----
-no messages
+dropped: 1->3 MsgSnap Term:1 Log:0/0
+  Snapshot: Index:12 Term:1 ConfState:Voters:[1 2 3] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
 
 # 3 sends the affirmative MsgAppResp that resulted from applying the snapshot
 # at index 11.
@@ -139,23 +156,18 @@ stabilize 3
   Snapshot Index:11 Term:1 ConfState:Voters:[1 2 3] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
   OnSync:
   3->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:1
-  3->1 MsgAppResp Term:1 Log:0/10 Commit:10
   3->1 MsgAppResp Term:1 Log:0/11 Commit:11
 
 stabilize 1
 ----
 > 1 receiving messages
   3->1 MsgFortifyLeaderResp Term:1 Log:0/0 LeadEpoch:1
-  3->1 MsgAppResp Term:1 Log:0/10 Commit:10
-  DEBUG 1 recovered from needing snapshot, resumed sending replication messages to 3 [StateSnapshot match=10 next=11 sentCommit=10 matchCommit=10 paused pendingSnap=10]
   3->1 MsgAppResp Term:1 Log:0/11 Commit:11
+  DEBUG 1 recovered from needing snapshot, resumed sending replication messages to 3 [StateSnapshot match=11 next=13 sentCommit=12 matchCommit=11 paused pendingSnap=12]
 > 1 handling Ready
   Ready:
   Messages:
-  1->3 MsgApp Term:1 Log:1/10 Commit:12 Entries:[
-    1/11 EntryNormal ""
-    1/12 EntryNormal "\"foo\""
-  ]
+  1->3 MsgApp Term:1 Log:1/11 Commit:12 Entries:[1/12 EntryNormal "\"foo\""]
 
 # 3 is in StateReplicate thanks to receiving the snapshot at index 11.
 # This is despite its PendingSnapshot having been 12.

--- a/pkg/raft/testdata/snapshot_succeed_via_app_resp_behind.txt
+++ b/pkg/raft/testdata/snapshot_succeed_via_app_resp_behind.txt
@@ -102,7 +102,7 @@ process-ready 3
 Ready:
 HardState Term:1 Vote:1 Commit:5 Lead:1 LeadEpoch:0
 OnSync:
-3->1 MsgAppResp Term:1 Log:1/10 Rejected (Hint: 5) Commit:5
+3->1 MsgAppResp Term:1 Log:1/10 Rejected Hint:1/5 Commit:5
 
 # 3 receives and applies the snapshot, but doesn't respond with MsgAppResp yet.
 deliver-msgs 3
@@ -121,7 +121,7 @@ INFO 3 [commit: 11] restored snapshot [index: 11, term: 1]
 stabilize 1
 ----
 > 1 receiving messages
-  3->1 MsgAppResp Term:1 Log:1/10 Rejected (Hint: 5) Commit:5
+  3->1 MsgAppResp Term:1 Log:1/10 Rejected Hint:1/5 Commit:5
   DEBUG 1 received MsgAppResp(rejected, hint: (index 5, term 1)) from 3 for index 10
   DEBUG 1 decreased progress of 3 to [StateProbe match=0 next=6 sentCommit=5 matchCommit=5]
   DEBUG 1 [firstindex: 11, commit: 12] sent snapshot[index: 12, term: 1] to 3 [StateProbe match=0 next=6 sentCommit=5 matchCommit=5]

--- a/pkg/raft/testdata/transfer-leadership.txt
+++ b/pkg/raft/testdata/transfer-leadership.txt
@@ -80,18 +80,18 @@ stabilize
   Ready:
   HardState Term:2 Vote:2 Commit:11 Lead:0 LeadEpoch:0
   OnSync:
-  1->2 MsgVoteResp Term:2 Log:0/0
+  1->2 MsgVoteResp Term:2 Log:1/0 Hint:1/11
 > 3 handling Ready
   Ready:
   HardState Term:2 Vote:2 Commit:11 Lead:0 LeadEpoch:0
   OnSync:
-  3->2 MsgVoteResp Term:2 Log:0/0
+  3->2 MsgVoteResp Term:2 Log:1/0 Hint:1/11
 > 2 receiving messages
-  1->2 MsgVoteResp Term:2 Log:0/0
+  1->2 MsgVoteResp Term:2 Log:1/0 Hint:1/11
   INFO 2 received MsgVoteResp from 1 at term 2
   INFO 2 has received 2 MsgVoteResp votes and 0 vote rejections
   INFO 2 became leader at term 2
-  3->2 MsgVoteResp Term:2 Log:0/0
+  3->2 MsgVoteResp Term:2 Log:1/0 Hint:1/11
 > 2 handling Ready
   Ready:
   State:StateLeader
@@ -241,18 +241,18 @@ stabilize
   Ready:
   HardState Term:3 Vote:3 Commit:12 Lead:0 LeadEpoch:0
   OnSync:
-  1->3 MsgVoteResp Term:3 Log:0/0
+  1->3 MsgVoteResp Term:3 Log:2/0 Hint:2/12
 > 2 handling Ready
   Ready:
   HardState Term:3 Vote:3 Commit:12 Lead:0 LeadEpoch:0
   OnSync:
-  2->3 MsgVoteResp Term:3 Log:0/0
+  2->3 MsgVoteResp Term:3 Log:2/0 Hint:2/12
 > 3 receiving messages
-  1->3 MsgVoteResp Term:3 Log:0/0
+  1->3 MsgVoteResp Term:3 Log:2/0 Hint:2/12
   INFO 3 received MsgVoteResp from 1 at term 3
   INFO 3 has received 2 MsgVoteResp votes and 0 vote rejections
   INFO 3 became leader at term 3
-  2->3 MsgVoteResp Term:3 Log:0/0
+  2->3 MsgVoteResp Term:3 Log:2/0 Hint:2/12
 > 3 handling Ready
   Ready:
   State:StateLeader

--- a/pkg/raft/util.go
+++ b/pkg/raft/util.go
@@ -197,7 +197,10 @@ func DescribeMessage(m pb.Message, f EntryFormatter) string {
 	fmt.Fprintf(&buf, "%s->%s %v Term:%d Log:%d/%d",
 		describeTarget(m.From), describeTarget(m.To), m.Type, m.Term, m.LogTerm, m.Index)
 	if m.Reject {
-		fmt.Fprintf(&buf, " Rejected (Hint: %d)", m.RejectHint)
+		fmt.Fprintf(&buf, " Rejected")
+	}
+	if m.RejectHint != 0 {
+		fmt.Fprintf(&buf, " Hint:%d/%d", m.LogTerm, m.RejectHint)
 	}
 	if m.Commit != 0 {
 		fmt.Fprintf(&buf, " Commit:%d", m.Commit)


### PR DESCRIPTION
This PR optimizes the first MsgApp/Replication flow after a raft candidate becomes the new leader. 

**Commit by commit review recommended.**

This is done by Pipelining/piggybacking a hint into `MsgVoteResp` and having the candidate use that hint:
1. The voter attaches a best guess hint `entryID` into `MsgVoteResp` when reacting to `MsgVote`. 
2. Upon receiving `MsgVoteResp`, the candidate computes a `matchGuess` index if `MsgVoteResp` is non-reject.
3. The candidate keeps those conflict `entryIDs` in memory, and send `MsgApp` starting from there after winning election. 
4. If the voter voted for this candidate, and the voter's `hint EntryID` "suggests a match" on a leader's log, the leader transfers `Progress.State` to `StateReplicate` for that follower when becoming the leader after winning election.

Subsequent `MsgApp` to the followers that are already in `StateReplicate` are "(almost) guaranteed" to succeed and carries more raft entries than in `StateProbe`. And so the leader can commit faster (assuming moderate incoming raft proposals).

Even for followers (voters) where the candidate received a vote with hint from, but could not set to `StateReplicate` (because the hint does not suggest a match), the first round of `MsgApp` is still very likely to succeed. This is because we computed a best guess `next Index` based on the original hint(which was also a best guess on where the two logs match).

Both the voter and candidate side computes a (regressed) best guess (index,term) using findConflictByTerm, this is very similar to how a leader and a follower resolve log conflicts. 

If the hint suggests that the voter would need a snapshot to be caught up, a snapshot would be sent by if the candidate wins election.

---
**Why this PR brings some performance improvements:** 

In the happy scenario, all the supporting voters attaches a `lastEntryID` hint, the candidate computes a `conclictIndex`, which is very likely to be a match. It would only not be a match if we have a long divergent tail with conflicting terms (possible, but very unlikely to happen).

So when the candidate wins election and becomes leader, it can set a quorum of followers to `StateReplicate`. 
This allows for faster replication and commit time. Essentially saving "1 RTT" in "almost all"(like 95%+?)  leader election scenarios. 

---

**Why we can do this with a high level informal proof:**
Due to the following guarantees by Raft: 
(deduced from Raft paper section 5.2 & 5.4)

  - When becoming leader from candidate state, the candidate/leader does not overwrite any of its own log, it simply appends a dummy entry with a new term number when becoming leader.

  - If a voter "`B`" voted for candidate `A`, then it means voter `B` won't vote for anybody else for the current election term(of candidate `A`). Also, voter `B` won't accept any `MsgApp` from nodes of lower or equal term than `A`.

NB: `B`'s log can be overwritten, by a different leader `C` with term higher than `A`, which is fine, since `A` will also get overwritten by that different leader `C`.

---

**Future optimizations 1:**
A candidate becomes the leader immediately when receiving enough votes(quorum), so the `MsgVoteResp` from the remaining replica(s) are ignored in this case. 

This is largely fine though, since we only need a quorum to make progress(commit new entries). The other replica can lag behind by a bit(behind by just 1rtt in most cases). 

But that hint would be useful, if it allows for catching up a candidate faster.
 
The change would involve letting the leader handle `MsgVoteResp` in a similar way as `MsgAppResp`.

---

**Further optimizations 2:**

In this issue, we are only attaching a single hint index which is the voter's last entryID in `MsgVoteResp`. 

In extreme log inconsistency scenarios, a single hint index would not satisfy as a solution. 

Example:
Imagine the following case, which is a somewhat extreme example, but is theoretically possible. 

```
#      1  2  3  4  5  6  7  8  9 10   index
# n1: [1][1][3][3][5][5][7]
# n2: [1][1][2][2][4][4]
```

n1 is the new leader of term 7 with dummy entry: t7/8 
n2 is a particular voter

1. n1 sends `MsgVote` to n2, with its `candLastID` = (index:8, term:7)
2. n2 votes for n1, computes a hint entryID =`(index:6, term:4)` based on `candLastID` = `(index:7, term:7)`, sends `MsgVoteResp` to n1
3. n1 receives `MsgVoteResp` from n2, compute a `matchGuess` index  based on the hint `(index:6, term:4)`
  the `matchGuess` is at (index: 4, term:3). This does not suggest a match with the voter's log.
4. n1 wins election after receiving a quorum of votes(including the vote from n2). Sends out the first round of MsgApp starting at (index: 5), which would not succeed. 

Overall, An extra round of probing must happen before n1 can replicate to n2 in steady flow.

However, in `MsgVoteResp`, we can actually attach the suffix entryIDs on the voter's raftLog which is the `termCache`. 
If we do that, then we have the guarantee(99.9% chance) that we can (almost) always transfer a quorum of followers into `stateReplicate` when becoming leader. This guarantee will be quite useful for upper layers that rely on Raft.

For this example, if n2 attaches the term cache into 'MsgVoteResp{reject = false}', then the leader can compute the correct match index t1/2 from the term cache, set n2's state to `stateReplicate`, and start replicating at t3/3 which will succeed. 

---


References: https://github.com/cockroachdb/cockroach/issues/142492
Epic: None
Release note: None