### PR TITLE
concurrency: track explicit savepoints

### DIFF
--- a/pkg/kv/kvclient/kvcoord/txn_coord_sender_savepoints.go
+++ b/pkg/kv/kvclient/kvcoord/txn_coord_sender_savepoints.go
@@ -100,6 +100,7 @@ func (tc *TxnCoordSender) CreateSavepoint(ctx context.Context) (kv.SavepointToke
 		reqInt.createSavepointLocked(ctx, s)
 	}
 
+	tc.mu.txn.AddExplicitSavepointTarget(s.seqNum)
 	return s, nil
 }
 

--- a/pkg/kv/kvserver/batcheval/lock.go
+++ b/pkg/kv/kvserver/batcheval/lock.go
@@ -239,7 +239,7 @@ func acquireLockOnKey(
 	default:
 		panic("unexpected lock durability")
 	}
-	acq := roachpb.MakeLockAcquisition(txn.TxnMeta, key, dur, str, txn.IgnoredSeqNums)
+	acq := roachpb.MakeLockAcquisition(txn.TxnMeta, key, dur, str, txn.IgnoredSeqNums, txn.MaxExplicitRollbackTarget)
 	return acq, nil
 }
 

--- a/pkg/kv/kvserver/concurrency/concurrency_manager_test.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_manager_test.go
@@ -463,7 +463,7 @@ func TestConcurrencyManagerBasic(t *testing.T) {
 
 				mon.runSync("acquire lock", func(ctx context.Context) {
 					log.Eventf(ctx, "txn %s @ %s", txn.Short(), key)
-					acq := roachpb.MakeLockAcquisition(txnAcquire.TxnMeta, roachpb.Key(key), dur, str, nil)
+					acq := roachpb.MakeLockAcquisition(txnAcquire.TxnMeta, roachpb.Key(key), dur, str, nil, 0)
 					m.OnLockAcquired(ctx, &acq)
 				})
 				return c.waitAndCollect(t, mon)

--- a/pkg/kv/kvserver/testdata/lock_table/replicated_reacquistion
+++ b/pkg/kv/kvserver/testdata/lock_table/replicated_reacquistion
@@ -1,0 +1,92 @@
+new-txn txn=t1
+----
+
+put k=a v=v1 txn=t1
+----
+
+commit txn=t1
+----
+
+new-txn txn=t2
+----
+
+get txn=t2 k=a lock=Exclusive dur=Unreplicated
+----
+get: "\xfaa"="v1"
+
+print-in-memory-lock-table
+----
+num=1
+ lock: "\xfaa"
+  holder: txn: t2 epoch: 0, iso: Serializable, ts: <stripped>, info: unrepl [(str: Exclusive seq: 0)]
+
+savepoint txn=t2 name=s1
+----
+
+put k=a v=v2 txn=t2
+----
+
+print-in-memory-lock-table retry
+----
+num=1
+ lock: "\xfaa"
+  holder: txn: t2 epoch: 0, iso: Serializable, ts: <stripped>, info: repl [Intent], unrepl [(str: Exclusive seq: 0)]
+
+rollback-to txn=t2 name=s1
+----
+
+get k=a txn=t2
+----
+get: "\xfaa"="v1"
+
+commit txn=t2
+----
+
+# Without an explicit savepoint the unreplicated lock is replaced.
+new-txn txn=t3
+----
+
+get txn=t3 k=a lock=Exclusive dur=Unreplicated
+----
+get: "\xfaa"="v1"
+
+print-in-memory-lock-table
+----
+num=1
+ lock: "\xfaa"
+  holder: txn: t3 epoch: 0, iso: Serializable, ts: <stripped>, info: unrepl [(str: Exclusive seq: 0)]
+
+put k=a v=v2 txn=t3
+----
+
+print-in-memory-lock-table retry
+----
+num=0
+
+commit txn=t3
+----
+
+# If the unreplicated lock would also be rolled back with the replicated lock,
+# we go ahead and drop it.
+new-txn txn=t4
+----
+
+get txn=t4 k=a lock=Exclusive dur=Unreplicated
+----
+get: "\xfaa"="v2"
+
+print-in-memory-lock-table
+----
+num=1
+ lock: "\xfaa"
+  holder: txn: t4 epoch: 0, iso: Serializable, ts: <stripped>, info: unrepl [(str: Exclusive seq: 0)]
+
+put k=a v=v2 txn=t4
+----
+
+print-in-memory-lock-table retry
+----
+num=0
+
+commit txn=t4
+----

--- a/pkg/roachpb/data.proto
+++ b/pkg/roachpb/data.proto
@@ -133,7 +133,7 @@ message SplitTrigger {
   // UseEstimatesBecauseExternalBytesArePresent is true if we should consider estimating MVCC
   // stats when calculating them in the splitTrigger.
   bool use_estimates_because_external_bytes_are_present = 7;
-  
+
   // ManualSplit indicates that this split is manually triggered via an AdminSplitRequest by a sql client.
   bool manualSplit = 8;
 }
@@ -534,6 +534,11 @@ message Transaction {
   // choose which writes are exported on a per-transaction basis.
   bool omit_in_rangefeeds = 20;
 
+  // MaxExplicitRollbackTarget is the maximum sequence number of user-created
+  // savepoints for the transaction.
+  int32 max_explicit_rollback_target = 21 [
+    (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/storage/enginepb.TxnSeq"];
+
   reserved 3, 6, 9, 13, 14;
 }
 
@@ -594,6 +599,11 @@ message LockAcquisition {
   // IgnoredSeqNums is a list of sequence numbers that have been rolled back
   // by the transaction at the time of the lock acquisition.
   repeated storage.enginepb.IgnoredSeqNumRange ignored_seqnums = 5 [(gogoproto.nullable) = false, (gogoproto.customname) = "IgnoredSeqNums"];
+
+  // MaxExplicitRollbackTarget is the maximum sequence number of user-created
+  // savepoints for the acquiring transaction at the time of acquisition.
+  int32 max_explicit_rollback_target = 6 [
+    (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/storage/enginepb.TxnSeq"];
 }
 
 // A LockUpdate is a Span together with Transaction state. LockUpdate messages

--- a/pkg/roachpb/data_test.go
+++ b/pkg/roachpb/data_test.go
@@ -604,13 +604,14 @@ var nonZeroTxn = Transaction{
 			Logical:  2,
 		},
 	}},
-	WriteTooOld:        true,
-	LockSpans:          []Span{{Key: []byte("a"), EndKey: []byte("b")}},
-	InFlightWrites:     []SequencedWrite{{Key: []byte("c"), Sequence: 1}},
-	ReadTimestampFixed: true,
-	IgnoredSeqNums:     []enginepb.IgnoredSeqNumRange{{Start: 888, End: 999}},
-	AdmissionPriority:  1,
-	OmitInRangefeeds:   true,
+	WriteTooOld:               true,
+	LockSpans:                 []Span{{Key: []byte("a"), EndKey: []byte("b")}},
+	InFlightWrites:            []SequencedWrite{{Key: []byte("c"), Sequence: 1}},
+	ReadTimestampFixed:        true,
+	IgnoredSeqNums:            []enginepb.IgnoredSeqNumRange{{Start: 888, End: 999}},
+	MaxExplicitRollbackTarget: 1,
+	AdmissionPriority:         1,
+	OmitInRangefeeds:          true,
 }
 
 func TestTransactionUpdate(t *testing.T) {
@@ -699,6 +700,7 @@ func TestTransactionUpdate(t *testing.T) {
 	expTxn5.LockSpans = nil
 	expTxn5.InFlightWrites = nil
 	expTxn5.IgnoredSeqNums = nil
+	expTxn5.MaxExplicitRollbackTarget = 0
 	expTxn5.WriteTooOld = false
 	expTxn5.ReadTimestampFixed = false
 	require.Equal(t, expTxn5, txn5)
@@ -886,6 +888,7 @@ func TestTransactionRestart(t *testing.T) {
 	expTxn.LockSpans = nil
 	expTxn.InFlightWrites = nil
 	expTxn.IgnoredSeqNums = nil
+	expTxn.MaxExplicitRollbackTarget = 0
 	require.Equal(t, expTxn, txn)
 }
 

--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -2793,7 +2793,7 @@ func mvccPutInternal(
 			return false, roachpb.LockAcquisition{}, err
 		}
 		lockAcquisition = roachpb.MakeLockAcquisition(
-			*newMeta.Txn, metaKey.Key, lock.Replicated, lock.Intent, opts.Txn.IgnoredSeqNums,
+			*newMeta.Txn, metaKey.Key, lock.Replicated, lock.Intent, opts.Txn.IgnoredSeqNums, opts.Txn.MaxExplicitRollbackTarget,
 		)
 	} else {
 		// Per-key stats count the full-key once and MVCCVersionTimestampSize for


### PR DESCRIPTION
When a replicated locks are acquired, we want to clear out any unreplicated locks on the same key. Previously, we did this without regard to sequence numbers. Ideally, we don't want to drop an upreplicated lock with a sequence number that is less than the sequence number of the replicated lock. Unfortunately, that describes most replicated lock re-acquisitions.

The hazard is replacing an unreplicated lock with another lock that might be rolled back in the future. Here, we attempt to avoid this hazard while still allowing us to remove most unreplicated locks on replicated re-acquisition.

Most transactions don't create explicit savepoints. Here we track the maximum sequence number of explicit savepoints. If not savepoint has ever been created, then we can safely remove the unreplicated lock since it can't be rolled back.

We also remove the unreplicated lock if both the unreplicated lock and the replicated lock is above the maximum sequence number that can be rolled back.

Fixes #141360

Epic: none
Release note: None