### PR TITLE
kvserver: move a couple of fields to shMu

### DIFF
--- a/pkg/kv/kvserver/replica_init.go
+++ b/pkg/kv/kvserver/replica_init.go
@@ -246,7 +246,7 @@ func newUninitializedReplicaWithoutRaftGroup(
 		store.cfg.Settings, store.stopper, r.AmbientContext, r, onTrip, onReset,
 	)
 	r.LeaderlessWatcher = NewLeaderlessWatcher(r)
-	r.mu.currentRACv2Mode = r.replicationAdmissionControlModeToUse(context.TODO())
+	r.shMu.currentRACv2Mode = r.replicationAdmissionControlModeToUse(context.TODO())
 	r.raftMu.flowControlLevel = kvflowcontrol.GetV2EnabledWhenLeaderLevel(
 		r.raftCtx, store.ClusterSettings(), store.TestingKnobs().FlowControlTestingKnobs)
 	if r.raftMu.flowControlLevel > kvflowcontrol.V2NotEnabledWhenLeader {
@@ -373,7 +373,7 @@ func (r *Replica) initRaftGroupRaftMuLockedReplicaMuLocked() error {
 		raftpb.PeerID(r.replicaID),
 		r.shMu.state.RaftAppliedIndex,
 		r.store.cfg,
-		r.mu.currentRACv2Mode == rac2.MsgAppPull,
+		r.shMu.currentRACv2Mode == rac2.MsgAppPull,
 		&raftLogger{ctx: ctx},
 		(*replicaRLockedStoreLiveness)(r),
 		r.store.raftMetrics,

--- a/pkg/kv/kvserver/replica_proposal_quota.go
+++ b/pkg/kv/kvserver/replica_proposal_quota.go
@@ -145,8 +145,8 @@ func (r *Replica) updateProposalQuotaRaftMuLocked(
 	// need for a setting change callback, as handleRaftReady (the caller), will
 	// be called at least at the tick interval for a non-quiescent range.
 	shouldInitQuotaPool := false
-	if r.mu.leaderID != lastLeaderID {
-		if r.replicaID == r.mu.leaderID {
+	if r.shMu.leaderID != lastLeaderID {
+		if r.replicaID == r.shMu.leaderID {
 			r.mu.lastUpdateTimes = make(map[roachpb.ReplicaID]time.Time)
 			r.mu.lastUpdateTimes.updateOnBecomeLeader(r.shMu.state.Desc.Replicas().Descriptors(), now)
 			r.mu.replicaFlowControlIntegration.onBecameLeader(ctx)
@@ -176,10 +176,10 @@ func (r *Replica) updateProposalQuotaRaftMuLocked(
 			}
 			return
 		}
-	} else if r.replicaID == r.mu.leaderID && r.mu.proposalQuota == nil && enabled {
+	} else if r.replicaID == r.shMu.leaderID && r.mu.proposalQuota == nil && enabled {
 		r.mu.lastProposalAtTicks = r.mu.ticks // delay imminent quiescence
 		shouldInitQuotaPool = true
-	} else if r.replicaID != r.mu.leaderID {
+	} else if r.replicaID != r.shMu.leaderID {
 		// We're a follower and have been since the last update. Nothing to do.
 		return
 	}

--- a/pkg/kv/kvserver/store_raft.go
+++ b/pkg/kv/kvserver/store_raft.go
@@ -852,7 +852,7 @@ func (s *Store) supportWithdrawnCallback(supportWithdrawnForStoreIDs map[roachpb
 			if !r.mu.asleep {
 				return false
 			}
-			leader, err := r.getReplicaDescriptorByIDRLocked(r.mu.leaderID, roachpb.ReplicaDescriptor{})
+			leader, err := r.getReplicaDescriptorByIDRLocked(r.shMu.leaderID, roachpb.ReplicaDescriptor{})
 			// If we found the replica's leader's store, and it doesn't match any of
 			// the stores in supportWithdrawnForStoreIDs, the replica shouldn't wake
 			// up. In all other cases, the replica should wake up.


### PR DESCRIPTION
This allows reading the fields outside `Replica.mu` sections.

Related to #140235