### PR TITLE
build/teamcity: add commit, os labels for nightlies

### DIFF
--- a/build/teamcity/cockroach/nightlies/roachtest_nightly_impl.sh
+++ b/build/teamcity/cockroach/nightlies/roachtest_nightly_impl.sh
@@ -100,6 +100,6 @@ build/teamcity-roachtest-invoke.sh \
   --selective-tests="${selective_tests:-false}" \
   --side-eye-token="${SIDE_EYE_API_TOKEN}" \
   --export-openmetrics="${EXPORT_OPENMETRICS:-false}" \
-  --openmetrics-labels="branch=$(tc_build_branch), cpu-arch=${arch}, suite=nightly" \
+  --openmetrics-labels="branch=$(tc_build_branch), goarch=${arch}, goos=linux, commit=${COMMIT_SHA}, suite=nightly" \
   ${EXTRA_ROACHTEST_ARGS:+$EXTRA_ROACHTEST_ARGS} \
   "${TESTS}"

--- a/build/teamcity/cockroach/nightlies/roachtest_weekly_impl.sh
+++ b/build/teamcity/cockroach/nightlies/roachtest_weekly_impl.sh
@@ -49,5 +49,5 @@ timeout -s INT $((7800*60)) build/teamcity-roachtest-invoke.sh \
   --slack-token="${SLACK_TOKEN}" \
   --side-eye-token="${SIDE_EYE_API_TOKEN}" \
   --export-openmetrics="${EXPORT_OPENMETRICS:-false}" \
-  --openmetrics-labels="branch=$(tc_build_branch), cpu-arch=${arch}, suite=weekly" \
+  --openmetrics-labels="branch=$(tc_build_branch), goarch=${arch}, goos=linux, commit=${COMMIT_SHA}, suite=weekly" \
   ${TESTS:-}

--- a/build/teamcity/util/roachtest_util.sh
+++ b/build/teamcity/util/roachtest_util.sh
@@ -35,6 +35,8 @@ if [[ "${EXPORT_OPENMETRICS}" == "true" ]]; then
   stats_file_name="stats.om"
 fi
 
+COMMIT_SHA=$(git rev-parse --short HEAD)
+
 # Set up a function we'll invoke at the end.
 function upload_stats {
   if tc_release_branch; then


### PR DESCRIPTION
This change aims to add commit label, goos label and also renames cpu_arch label to goarch label to be more consistent for comparisons.

Epic: none

Release note: None