### PR TITLE
opt: add rule to eliminate nested subqueries

### DIFF
--- a/pkg/sql/opt/memo/testdata/logprops/tail-calls
+++ b/pkg/sql/opt/memo/testdata/logprops/tail-calls
@@ -747,22 +747,18 @@ values
                                                    │                        │                        └── const: 1
                                                    │                        └── subquery
                                                    │                             ├── tail-call
-                                                   │                             └── values
-                                                   │                                  └── tuple
-                                                   │                                       └── subquery
+                                                   │                             └── project
+                                                   │                                  ├── values
+                                                   │                                  │    └── tuple
+                                                   │                                  │         └── plus
+                                                   │                                  │              ├── variable: i
+                                                   │                                  │              └── const: 1
+                                                   │                                  └── projections
+                                                   │                                       └── udf: stmt_loop_5
                                                    │                                            ├── tail-call
-                                                   │                                            └── project
-                                                   │                                                 ├── values
-                                                   │                                                 │    └── tuple
-                                                   │                                                 │         └── plus
-                                                   │                                                 │              ├── variable: i
-                                                   │                                                 │              └── const: 1
-                                                   │                                                 └── projections
-                                                   │                                                      └── udf: stmt_loop_5
-                                                   │                                                           ├── tail-call
-                                                   │                                                           ├── args
-                                                   │                                                           │    └── variable: i
-                                                   │                                                           └── recursive-call
+                                                   │                                            ├── args
+                                                   │                                            │    └── variable: i
+                                                   │                                            └── recursive-call
                                                    └── udf: loop_exit_1
                                                         ├── tail-call
                                                         ├── args

--- a/pkg/sql/opt/norm/rules/scalar.opt
+++ b/pkg/sql/opt/norm/rules/scalar.opt
@@ -288,6 +288,14 @@ $value
 =>
 $udf
 
+# EliminateNestedSubquery removes redundant nesting of subqueries by replacing
+# a subquery whose input is a single-row, single-column Values expression 
+# containing another subquery with just the inner subquery.
+[EliminateNestedSubquery, Normalize]
+(Subquery (Values [ (Tuple [ $subquery:(Subquery) ]) ]))
+=>
+$subquery
+
 # SimplifyCaseWhenConstValue removes branches known to not match. Any
 # branch known to match is used as the ELSE and further WHEN conditions
 # are skipped. If all WHEN conditions have been removed, the ELSE


### PR DESCRIPTION
This commit adds a new normalization rule `EliminateNestedSubquery` that removes unnecessary subquery wrappers around subqueries when they appear in single row and single column Values expressions.

Epic: None
Release note: None