### PR TITLE
schemachanger/scplan: add deprules to eval zone cfgs in seqNum order

### DIFF
--- a/pkg/sql/schemachanger/scplan/internal/rules/current/BUILD.bazel
+++ b/pkg/sql/schemachanger/scplan/internal/rules/current/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
         "dep_add_index_and_constraint.go",
         "dep_add_trigger.go",
         "dep_alter_column_type.go",
+        "dep_configure_zone.go",
         "dep_create.go",
         "dep_create_function.go",
         "dep_create_policy.go",

--- a/pkg/sql/schemachanger/scplan/internal/rules/current/dep_configure_zone.go
+++ b/pkg/sql/schemachanger/scplan/internal/rules/current/dep_configure_zone.go
@@ -1,0 +1,128 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package current
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/rel"
+	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scpb"
+	. "github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scplan/internal/rules"
+	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scplan/internal/scgraph"
+	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/screl"
+)
+
+// The following set of rules ensure that zone configs depend on each other in
+// increasing seqNum order.
+
+func init() {
+	// Table zone configs
+	registerDepRule(
+		"ensure table zone configs are in increasing seqNum order",
+		scgraph.Precedence,
+		"later-seqNum", "earlier-seqNum",
+		func(from, to NodeVars) rel.Clauses {
+			status := rel.Var("status")
+			return rel.Clauses{
+				from.Type((*scpb.TableZoneConfig)(nil)),
+				from.JoinTargetNode(),
+				to.Type((*scpb.TableZoneConfig)(nil)),
+				// Join on the target ID to ensure we're only comparing zone configs
+				// for the same object (database, table, index, etc.)
+				JoinOnDescID(from, to, "seqnum"),
+				ToPublicOrTransient(from, to),
+				status.Entities(screl.CurrentStatus, from.Node, to.Node),
+				FilterElements("SmallerSeqNumFirst", from, to, func(from, to *scpb.TableZoneConfig) bool {
+					return from.SeqNum < to.SeqNum
+				}),
+			}
+		})
+
+	// Database zone configs
+	registerDepRule(
+		"ensure database zone configs are in increasing seqNum order",
+		scgraph.Precedence,
+		"later-seqNum", "earlier-seqNum",
+		func(from, to NodeVars) rel.Clauses {
+			status := rel.Var("status")
+			return rel.Clauses{
+				from.Type((*scpb.DatabaseZoneConfig)(nil)),
+				from.JoinTargetNode(),
+				to.Type((*scpb.DatabaseZoneConfig)(nil)),
+				JoinOnDescID(from, to, "seqnum"),
+				ToPublicOrTransient(from, to),
+				status.Entities(screl.CurrentStatus, from.Node, to.Node),
+				FilterElements("SmallerSeqNumFirst", from, to, func(from, to *scpb.DatabaseZoneConfig) bool {
+					return from.SeqNum < to.SeqNum
+				}),
+			}
+		})
+
+	// Named range zone configs
+	registerDepRule(
+		"ensure named range zone configs are in increasing seqNum order",
+		scgraph.Precedence,
+		"later-seqNum", "earlier-seqNum",
+		func(from, to NodeVars) rel.Clauses {
+			status := rel.Var("status")
+			return rel.Clauses{
+				from.Type((*scpb.NamedRangeZoneConfig)(nil)),
+				from.JoinTargetNode(),
+				to.Type((*scpb.NamedRangeZoneConfig)(nil)),
+				JoinOnDescID(from, to, "seqnum"),
+				ToPublicOrTransient(from, to),
+				status.Entities(screl.CurrentStatus, from.Node, to.Node),
+				FilterElements("SmallerSeqNumFirst", from, to, func(from, to *scpb.NamedRangeZoneConfig) bool {
+					return from.SeqNum < to.SeqNum
+				}),
+			}
+		})
+
+	// Index zone configs
+	registerDepRule(
+		"ensure index zone configs are in increasing seqNum order",
+		scgraph.Precedence,
+		"later-seqNum", "earlier-seqNum",
+		func(from, to NodeVars) rel.Clauses {
+			status := rel.Var("status")
+			return rel.Clauses{
+				from.Type((*scpb.IndexZoneConfig)(nil)),
+				from.JoinTargetNode(),
+				to.Type((*scpb.IndexZoneConfig)(nil)),
+				JoinOnDescID(from, to, "seqnum"),
+				// Join on index ID to ensure we're only comparing zone configs
+				// for the same index
+				JoinOnIndexID(from, to, "table-id", "index-id"),
+				ToPublicOrTransient(from, to),
+				status.Entities(screl.CurrentStatus, from.Node, to.Node),
+				FilterElements("SmallerSeqNumFirst", from, to, func(from, to *scpb.IndexZoneConfig) bool {
+					return from.SeqNum < to.SeqNum
+				}),
+			}
+		})
+
+	// Partition zone configs
+	registerDepRule(
+		"ensure partition zone configs are in increasing seqNum order",
+		scgraph.Precedence,
+		"later-seqNum", "earlier-seqNum",
+		func(from, to NodeVars) rel.Clauses {
+			status := rel.Var("status")
+			return rel.Clauses{
+				from.Type((*scpb.PartitionZoneConfig)(nil)),
+				from.JoinTargetNode(),
+				to.Type((*scpb.PartitionZoneConfig)(nil)),
+				JoinOnDescID(from, to, "seqnum"),
+				// Join on index ID and partition name to ensure we're only comparing
+				// zone configs for the same partition
+				JoinOnIndexID(from, to, "table-id", "index-id"),
+				JoinOnPartitionName(from, to, "table-id", "index-id", "partition-name"),
+				ToPublicOrTransient(from, to),
+				status.Entities(screl.CurrentStatus, from.Node, to.Node),
+				FilterElements("SmallerSeqNumFirst", from, to, func(from, to *scpb.PartitionZoneConfig) bool {
+					return from.SeqNum < to.SeqNum
+				}),
+			}
+		})
+}

--- a/pkg/sql/schemachanger/scplan/internal/rules/current/testdata/deprules
+++ b/pkg/sql/schemachanger/scplan/internal/rules/current/testdata/deprules
@@ -3479,6 +3479,84 @@ deprules
     - SmallerColumnIDFirst(*scpb.Column, *scpb.Column)($later-column, $earlier-column)
     - joinTargetNode($later-column, $later-column-Target, $later-column-Node)
     - joinTargetNode($earlier-column, $earlier-column-Target, $earlier-column-Node)
+- name: ensure database zone configs are in increasing seqNum order
+  from: later-seqNum-Node
+  kind: Precedence
+  to: earlier-seqNum-Node
+  query:
+    - $later-seqNum[Type] = '*scpb.DatabaseZoneConfig'
+    - joinTargetNode($later-seqNum, $later-seqNum-Target, $later-seqNum-Node)
+    - $earlier-seqNum[Type] = '*scpb.DatabaseZoneConfig'
+    - joinOnDescID($later-seqNum, $earlier-seqNum, $seqnum)
+    - ToPublicOrTransient($later-seqNum-Target, $earlier-seqNum-Target)
+    - $later-seqNum-Node[CurrentStatus] = $status
+    - $earlier-seqNum-Node[CurrentStatus] = $status
+    - SmallerSeqNumFirst(*scpb.DatabaseZoneConfig, *scpb.DatabaseZoneConfig)($later-seqNum, $earlier-seqNum)
+    - joinTargetNode($later-seqNum, $later-seqNum-Target, $later-seqNum-Node)
+    - joinTargetNode($earlier-seqNum, $earlier-seqNum-Target, $earlier-seqNum-Node)
+- name: ensure index zone configs are in increasing seqNum order
+  from: later-seqNum-Node
+  kind: Precedence
+  to: earlier-seqNum-Node
+  query:
+    - $later-seqNum[Type] = '*scpb.IndexZoneConfig'
+    - joinTargetNode($later-seqNum, $later-seqNum-Target, $later-seqNum-Node)
+    - $earlier-seqNum[Type] = '*scpb.IndexZoneConfig'
+    - joinOnDescID($later-seqNum, $earlier-seqNum, $seqnum)
+    - joinOnIndexID($later-seqNum, $earlier-seqNum, $table-id, $index-id)
+    - ToPublicOrTransient($later-seqNum-Target, $earlier-seqNum-Target)
+    - $later-seqNum-Node[CurrentStatus] = $status
+    - $earlier-seqNum-Node[CurrentStatus] = $status
+    - SmallerSeqNumFirst(*scpb.IndexZoneConfig, *scpb.IndexZoneConfig)($later-seqNum, $earlier-seqNum)
+    - joinTargetNode($later-seqNum, $later-seqNum-Target, $later-seqNum-Node)
+    - joinTargetNode($earlier-seqNum, $earlier-seqNum-Target, $earlier-seqNum-Node)
+- name: ensure named range zone configs are in increasing seqNum order
+  from: later-seqNum-Node
+  kind: Precedence
+  to: earlier-seqNum-Node
+  query:
+    - $later-seqNum[Type] = '*scpb.NamedRangeZoneConfig'
+    - joinTargetNode($later-seqNum, $later-seqNum-Target, $later-seqNum-Node)
+    - $earlier-seqNum[Type] = '*scpb.NamedRangeZoneConfig'
+    - joinOnDescID($later-seqNum, $earlier-seqNum, $seqnum)
+    - ToPublicOrTransient($later-seqNum-Target, $earlier-seqNum-Target)
+    - $later-seqNum-Node[CurrentStatus] = $status
+    - $earlier-seqNum-Node[CurrentStatus] = $status
+    - SmallerSeqNumFirst(*scpb.NamedRangeZoneConfig, *scpb.NamedRangeZoneConfig)($later-seqNum, $earlier-seqNum)
+    - joinTargetNode($later-seqNum, $later-seqNum-Target, $later-seqNum-Node)
+    - joinTargetNode($earlier-seqNum, $earlier-seqNum-Target, $earlier-seqNum-Node)
+- name: ensure partition zone configs are in increasing seqNum order
+  from: later-seqNum-Node
+  kind: Precedence
+  to: earlier-seqNum-Node
+  query:
+    - $later-seqNum[Type] = '*scpb.PartitionZoneConfig'
+    - joinTargetNode($later-seqNum, $later-seqNum-Target, $later-seqNum-Node)
+    - $earlier-seqNum[Type] = '*scpb.PartitionZoneConfig'
+    - joinOnDescID($later-seqNum, $earlier-seqNum, $seqnum)
+    - joinOnIndexID($later-seqNum, $earlier-seqNum, $table-id, $index-id)
+    - joinOnPartitionName($later-seqNum, $earlier-seqNum, $table-id, $index-id, $partition-name)
+    - ToPublicOrTransient($later-seqNum-Target, $earlier-seqNum-Target)
+    - $later-seqNum-Node[CurrentStatus] = $status
+    - $earlier-seqNum-Node[CurrentStatus] = $status
+    - SmallerSeqNumFirst(*scpb.PartitionZoneConfig, *scpb.PartitionZoneConfig)($later-seqNum, $earlier-seqNum)
+    - joinTargetNode($later-seqNum, $later-seqNum-Target, $later-seqNum-Node)
+    - joinTargetNode($earlier-seqNum, $earlier-seqNum-Target, $earlier-seqNum-Node)
+- name: ensure table zone configs are in increasing seqNum order
+  from: later-seqNum-Node
+  kind: Precedence
+  to: earlier-seqNum-Node
+  query:
+    - $later-seqNum[Type] = '*scpb.TableZoneConfig'
+    - joinTargetNode($later-seqNum, $later-seqNum-Target, $later-seqNum-Node)
+    - $earlier-seqNum[Type] = '*scpb.TableZoneConfig'
+    - joinOnDescID($later-seqNum, $earlier-seqNum, $seqnum)
+    - ToPublicOrTransient($later-seqNum-Target, $earlier-seqNum-Target)
+    - $later-seqNum-Node[CurrentStatus] = $status
+    - $earlier-seqNum-Node[CurrentStatus] = $status
+    - SmallerSeqNumFirst(*scpb.TableZoneConfig, *scpb.TableZoneConfig)($later-seqNum, $earlier-seqNum)
+    - joinTargetNode($later-seqNum, $later-seqNum-Target, $later-seqNum-Node)
+    - joinTargetNode($earlier-seqNum, $earlier-seqNum-Target, $earlier-seqNum-Node)
 - name: function name should be set before parent ids
   from: function-name-Node
   kind: Precedence
@@ -8150,6 +8228,84 @@ deprules
     - SmallerColumnIDFirst(*scpb.Column, *scpb.Column)($later-column, $earlier-column)
     - joinTargetNode($later-column, $later-column-Target, $later-column-Node)
     - joinTargetNode($earlier-column, $earlier-column-Target, $earlier-column-Node)
+- name: ensure database zone configs are in increasing seqNum order
+  from: later-seqNum-Node
+  kind: Precedence
+  to: earlier-seqNum-Node
+  query:
+    - $later-seqNum[Type] = '*scpb.DatabaseZoneConfig'
+    - joinTargetNode($later-seqNum, $later-seqNum-Target, $later-seqNum-Node)
+    - $earlier-seqNum[Type] = '*scpb.DatabaseZoneConfig'
+    - joinOnDescID($later-seqNum, $earlier-seqNum, $seqnum)
+    - ToPublicOrTransient($later-seqNum-Target, $earlier-seqNum-Target)
+    - $later-seqNum-Node[CurrentStatus] = $status
+    - $earlier-seqNum-Node[CurrentStatus] = $status
+    - SmallerSeqNumFirst(*scpb.DatabaseZoneConfig, *scpb.DatabaseZoneConfig)($later-seqNum, $earlier-seqNum)
+    - joinTargetNode($later-seqNum, $later-seqNum-Target, $later-seqNum-Node)
+    - joinTargetNode($earlier-seqNum, $earlier-seqNum-Target, $earlier-seqNum-Node)
+- name: ensure index zone configs are in increasing seqNum order
+  from: later-seqNum-Node
+  kind: Precedence
+  to: earlier-seqNum-Node
+  query:
+    - $later-seqNum[Type] = '*scpb.IndexZoneConfig'
+    - joinTargetNode($later-seqNum, $later-seqNum-Target, $later-seqNum-Node)
+    - $earlier-seqNum[Type] = '*scpb.IndexZoneConfig'
+    - joinOnDescID($later-seqNum, $earlier-seqNum, $seqnum)
+    - joinOnIndexID($later-seqNum, $earlier-seqNum, $table-id, $index-id)
+    - ToPublicOrTransient($later-seqNum-Target, $earlier-seqNum-Target)
+    - $later-seqNum-Node[CurrentStatus] = $status
+    - $earlier-seqNum-Node[CurrentStatus] = $status
+    - SmallerSeqNumFirst(*scpb.IndexZoneConfig, *scpb.IndexZoneConfig)($later-seqNum, $earlier-seqNum)
+    - joinTargetNode($later-seqNum, $later-seqNum-Target, $later-seqNum-Node)
+    - joinTargetNode($earlier-seqNum, $earlier-seqNum-Target, $earlier-seqNum-Node)
+- name: ensure named range zone configs are in increasing seqNum order
+  from: later-seqNum-Node
+  kind: Precedence
+  to: earlier-seqNum-Node
+  query:
+    - $later-seqNum[Type] = '*scpb.NamedRangeZoneConfig'
+    - joinTargetNode($later-seqNum, $later-seqNum-Target, $later-seqNum-Node)
+    - $earlier-seqNum[Type] = '*scpb.NamedRangeZoneConfig'
+    - joinOnDescID($later-seqNum, $earlier-seqNum, $seqnum)
+    - ToPublicOrTransient($later-seqNum-Target, $earlier-seqNum-Target)
+    - $later-seqNum-Node[CurrentStatus] = $status
+    - $earlier-seqNum-Node[CurrentStatus] = $status
+    - SmallerSeqNumFirst(*scpb.NamedRangeZoneConfig, *scpb.NamedRangeZoneConfig)($later-seqNum, $earlier-seqNum)
+    - joinTargetNode($later-seqNum, $later-seqNum-Target, $later-seqNum-Node)
+    - joinTargetNode($earlier-seqNum, $earlier-seqNum-Target, $earlier-seqNum-Node)
+- name: ensure partition zone configs are in increasing seqNum order
+  from: later-seqNum-Node
+  kind: Precedence
+  to: earlier-seqNum-Node
+  query:
+    - $later-seqNum[Type] = '*scpb.PartitionZoneConfig'
+    - joinTargetNode($later-seqNum, $later-seqNum-Target, $later-seqNum-Node)
+    - $earlier-seqNum[Type] = '*scpb.PartitionZoneConfig'
+    - joinOnDescID($later-seqNum, $earlier-seqNum, $seqnum)
+    - joinOnIndexID($later-seqNum, $earlier-seqNum, $table-id, $index-id)
+    - joinOnPartitionName($later-seqNum, $earlier-seqNum, $table-id, $index-id, $partition-name)
+    - ToPublicOrTransient($later-seqNum-Target, $earlier-seqNum-Target)
+    - $later-seqNum-Node[CurrentStatus] = $status
+    - $earlier-seqNum-Node[CurrentStatus] = $status
+    - SmallerSeqNumFirst(*scpb.PartitionZoneConfig, *scpb.PartitionZoneConfig)($later-seqNum, $earlier-seqNum)
+    - joinTargetNode($later-seqNum, $later-seqNum-Target, $later-seqNum-Node)
+    - joinTargetNode($earlier-seqNum, $earlier-seqNum-Target, $earlier-seqNum-Node)
+- name: ensure table zone configs are in increasing seqNum order
+  from: later-seqNum-Node
+  kind: Precedence
+  to: earlier-seqNum-Node
+  query:
+    - $later-seqNum[Type] = '*scpb.TableZoneConfig'
+    - joinTargetNode($later-seqNum, $later-seqNum-Target, $later-seqNum-Node)
+    - $earlier-seqNum[Type] = '*scpb.TableZoneConfig'
+    - joinOnDescID($later-seqNum, $earlier-seqNum, $seqnum)
+    - ToPublicOrTransient($later-seqNum-Target, $earlier-seqNum-Target)
+    - $later-seqNum-Node[CurrentStatus] = $status
+    - $earlier-seqNum-Node[CurrentStatus] = $status
+    - SmallerSeqNumFirst(*scpb.TableZoneConfig, *scpb.TableZoneConfig)($later-seqNum, $earlier-seqNum)
+    - joinTargetNode($later-seqNum, $later-seqNum-Target, $later-seqNum-Node)
+    - joinTargetNode($earlier-seqNum, $earlier-seqNum-Target, $earlier-seqNum-Node)
 - name: function name should be set before parent ids
   from: function-name-Node
   kind: Precedence

--- a/pkg/sql/schemachanger/scplan/internal/rules/helpers.go
+++ b/pkg/sql/schemachanger/scplan/internal/rules/helpers.go
@@ -134,6 +134,13 @@ func JoinOnPolicyID(a, b NodeVars, relationIDVar, policyID rel.Var) rel.Clause {
 	return joinOnPolicyIDUntyped(a.El, b.El, relationIDVar, policyID)
 }
 
+// JoinOnPartitionName joins elements on partition name.
+func JoinOnPartitionName(
+	a, b NodeVars, relationIDVar, indexIDVar, partitionNameVar rel.Var,
+) rel.Clause {
+	return joinOnPartitionNameUntyped(a.El, b.El, relationIDVar, indexIDVar, partitionNameVar)
+}
+
 // ColumnInIndex requires that a column exists within an index.
 func ColumnInIndex(
 	indexColumn, index NodeVars, relationIDVar, columnIDVar, indexIDVar rel.Var,
@@ -341,6 +348,17 @@ var (
 			return rel.Clauses{
 				JoinOnDescIDUntyped(a, b, descID),
 				policyID.Entities(screl.PolicyID, a, b),
+			}
+		},
+	)
+	joinOnPartitionNameUntyped = screl.Schema.Def5(
+		"joinOnPartitionName", "a", "b", "desc-id", "index-id", "partition-name", func(
+			a, b, descID, indexID, partitionName rel.Var,
+		) rel.Clauses {
+			return rel.Clauses{
+				JoinOnDescIDUntyped(a, b, descID),
+				indexID.Entities(screl.IndexID, a, b),
+				partitionName.Entities(screl.PartitionName, a, b),
 			}
 		},
 	)


### PR DESCRIPTION
This patch adds deprules to ensure that zone configs are depended by
each other in increasing`seqNum` order.

Epic: none
Fixes: https://github.com/cockroachdb/cockroach/issues/129482

Release note: None