### PR TITLE
crosscluster/logical: fix ALTER .. SET REPLICATION READ VIRTUAL CLUSTER

### DIFF
--- a/pkg/crosscluster/physical/alter_replication_job.go
+++ b/pkg/crosscluster/physical/alter_replication_job.go
@@ -265,7 +265,7 @@ func alterReplicationJobHook(
 		if !alterTenantStmt.Options.IsDefault() {
 			// If the statement contains options, then the user provided the ALTER
 			// TENANT ... SET REPLICATION [options] form of the command.
-			return alterTenantSetReplication(ctx, p.InternalSQLTxn(), jobRegistry, options, tenInfo)
+			return alterTenantSetReplication(ctx, p, p.InternalSQLTxn(), jobRegistry, options, tenInfo)
 		}
 		if err := checkForActiveIngestionJob(tenInfo); err != nil {
 			return err
@@ -318,6 +318,7 @@ func alterTenantSetReplicationSource(
 
 func alterTenantSetReplication(
 	ctx context.Context,
+	p sql.PlanHookState,
 	txn isql.Txn,
 	jobRegistry *jobs.Registry,
 	options *resolvedTenantReplicationOptions,
@@ -326,7 +327,7 @@ func alterTenantSetReplication(
 	if err := checkForActiveIngestionJob(tenInfo); err != nil {
 		return err
 	}
-	if err := alterTenantConsumerOptions(ctx, txn, jobRegistry, options, tenInfo); err != nil {
+	if err := alterTenantConsumerOptions(ctx, p, txn, jobRegistry, options, tenInfo); err != nil {
 		return err
 	}
 	return nil
@@ -426,7 +427,7 @@ func alterTenantRestartReplication(
 		revertTo = tenInfo.PreviousSourceTenant.CutoverAsOf
 	}
 
-	readerID, err := createReaderTenant(ctx, p, tenInfo.Name, dstTenantID, options)
+	readerID, err := createReaderTenant(ctx, p, tenInfo.Name, dstTenantID, options, false)
 	if err != nil {
 		return err
 	}
@@ -672,16 +673,38 @@ func alterTenantExpirationWindow(
 
 func alterTenantConsumerOptions(
 	ctx context.Context,
+	p sql.PlanHookState,
 	txn isql.Txn,
 	jobRegistry *jobs.Registry,
 	options *resolvedTenantReplicationOptions,
 	tenInfo *mtinfopb.TenantInfo,
 ) error {
+
 	return jobRegistry.UpdateJobWithTxn(ctx, tenInfo.PhysicalReplicationConsumerJobID, txn,
 		func(txn isql.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater) error {
+			var readerID roachpb.TenantID
+			if options.enableReaderTenant {
+				// If the replicating tenant already has a resolved tiemstamp, we can
+				// create the reader tenant directly to its ready state rather than in
+				// the add state that replies on the replication job to activate it when
+				// its frontier advances for the first time. If we don't have a resolved
+				// timestamp, we'll fallback to creating it inactive and just let the
+				// job do it later, which it does since we record the reader's ID below.
+				ready := md.Progress.GetStreamIngest().ReplicatedTime.IsSet()
+				var err error
+				if readerID, err = createReaderTenant(ctx, p, tenInfo.Name, roachpb.MustMakeTenantID(tenInfo.ID), options, ready); err != nil {
+					return err
+				}
+			}
+
 			streamIngestionDetails := md.Payload.GetStreamIngestion()
 			if ret, ok := options.GetRetention(); ok {
 				streamIngestionDetails.ReplicationTTLSeconds = ret
+			}
+			// Record the reader ID; this is used in the job to start the reader if
+			// needed when the first frontier advance is recorded.
+			if readerID != (roachpb.TenantID{}) {
+				streamIngestionDetails.ReadTenantID = readerID
 			}
 			ju.UpdatePayload(md.Payload)
 			return nil

--- a/pkg/crosscluster/physical/stream_ingestion_planning.go
+++ b/pkg/crosscluster/physical/stream_ingestion_planning.go
@@ -181,7 +181,7 @@ func ingestionPlanHook(
 			return nil
 		}
 
-		readerID, err := createReaderTenant(ctx, p, tenantInfo.Name, destinationTenantID, options)
+		readerID, err := createReaderTenant(ctx, p, tenantInfo.Name, destinationTenantID, options, false)
 		if err != nil {
 			return err
 		}
@@ -300,11 +300,17 @@ func createReaderTenant(
 	tenantName roachpb.TenantName,
 	destinationTenantID roachpb.TenantID,
 	options *resolvedTenantReplicationOptions,
+	ready bool,
 ) (roachpb.TenantID, error) {
 	var readerID roachpb.TenantID
 	if options.ReaderTenantEnabled() {
 		var readerInfo mtinfopb.TenantInfoWithUsage
-		readerInfo.DataState = mtinfopb.DataStateAdd
+		if ready {
+			readerInfo.DataState = mtinfopb.DataStateReady
+			readerInfo.ServiceMode = mtinfopb.ServiceModeShared
+		} else {
+			readerInfo.DataState = mtinfopb.DataStateAdd
+		}
 		readerInfo.Name = tenantName + "-readonly"
 		readerInfo.ReadFromTenant = &destinationTenantID
 


### PR DESCRIPTION
This is in the syntax but the ALTER function was not handling this option if it was set -- the statement would silently succeed without even attempting to create a reader cluster.

This statement now attempts to create a readder cluster. If one already exists, or another virtual cluster has otherwise been created with the reader's default name, the statement will fail.

Release note (bug fix): The ALTER VIRTUAL CLUSTER SET REPLICATION READ VIRTUAL CLUSTER syntax is now supported for adding a reader virtual cluster for an existing PCR standby.
Epic: none.