### PR TITLE
release-24.3: tree: include gist into enum comparison assertion

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -4729,4 +4729,5 @@ func init() {
 	logcrash.RegisterTagFn("gist", func(ctx context.Context) string {
 		return planGistFromCtx(ctx)
 	})
+	tree.PlanGistFromCtx = planGistFromCtx
 }

--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -5344,6 +5344,10 @@ func (d *DEnum) ResolvedType() *types.T {
 	return d.EnumTyp
 }
 
+// PlanCistFromCtx returns the plan gist if it is stored in the context. It is
+// injected from the sql package to avoid import cycle.
+var PlanGistFromCtx func(context.Context) string
+
 // Compare implements the Datum interface.
 func (d *DEnum) Compare(ctx context.Context, cmpCtx CompareContext, other Datum) (int, error) {
 	if other == DNull {
@@ -5361,10 +5365,16 @@ func (d *DEnum) Compare(ctx context.Context, cmpCtx CompareContext, other Datum)
 
 	// We should never be comparing two different versions of the same enum.
 	if v.EnumTyp.TypeMeta.Version != d.EnumTyp.TypeMeta.Version {
+		var gist redact.SafeString
+		if PlanGistFromCtx != nil {
+			// Plan gist, by construction, doesn't contain any PII, so it's a
+			// safe string.
+			gist = redact.SafeString(PlanGistFromCtx(ctx))
+		}
 		panic(errors.AssertionFailedf(
-			"comparison of two different versions of enum %s oid %d: versions %d and %d",
+			"comparison of two different versions of enum %s oid %d: versions %d and %d, gist %q",
 			d.EnumTyp.SQLStringForError(), errors.Safe(d.EnumTyp.Oid()), d.EnumTyp.TypeMeta.Version,
-			v.EnumTyp.TypeMeta.Version,
+			v.EnumTyp.TypeMeta.Version, gist,
 		))
 	}
 


### PR DESCRIPTION
Backport 1/1 commits from #143695 on behalf of @yuzefovich.

/cc @cockroachdb/release

----

In theory, the plan gist should already be included in all ~assertion failures~sentry reports, but it doesn't happen in practice. Let's include it explicitly (if it is present in the context) into the enum mismatched version comparison error to help with tracking it down.

Informs: #143571
Epic: None
Release note: None

----

Release justification: low-risk debugging improvement.