### PR TITLE
release-25.1: explain: fix recently added TestRetryFields

### DIFF
--- a/pkg/sql/opt/exec/explain/output_test.go
+++ b/pkg/sql/opt/exec/explain/output_test.go
@@ -358,22 +358,25 @@ func TestRetryFields(t *testing.T) {
 	sqlDB.Exec(t, "CREATE SEQUENCE s")
 
 	retryCountRE := regexp.MustCompile(`number of transaction retries: (\d+)`)
-	retryTimeRE := regexp.MustCompile(`time spent retrying the transaction: (\d+)[µsm]+`)
-	queryMatchRE := func(query string) bool {
-		rows, err := conn.QueryContext(ctx, query)
-		assert.NoError(t, err)
-		var foundCount, foundTime bool
-		for rows.Next() {
-			var res string
-			assert.NoError(t, rows.Scan(&res))
-			if matches := retryCountRE.FindStringSubmatch(res); len(matches) > 0 {
-				foundCount = true
-			}
-			if matches := retryTimeRE.FindStringSubmatch(res); len(matches) > 0 {
-				foundTime = true
-			}
+	retryTimeRE := regexp.MustCompile(`time spent retrying the transaction: ([\d\.]+)[µsm]+`)
+
+	const query = "EXPLAIN ANALYZE SELECT IF(nextval('s')<=3, crdb_internal.force_retry('1h'::INTERVAL), 0)"
+	rows, err := conn.QueryContext(ctx, query)
+	assert.NoError(t, err)
+	var output strings.Builder
+	var foundCount, foundTime bool
+	for rows.Next() {
+		var res string
+		assert.NoError(t, rows.Scan(&res))
+		output.WriteString(res)
+		output.WriteString("\n")
+		if matches := retryCountRE.FindStringSubmatch(res); len(matches) > 0 {
+			foundCount = true
 		}
-		return foundCount && foundTime
+		if matches := retryTimeRE.FindStringSubmatch(res); len(matches) > 0 {
+			foundTime = true
+		}
 	}
-	assert.True(t, queryMatchRE("EXPLAIN ANALYZE SELECT IF(nextval('s')<=3, crdb_internal.force_retry('1h'::INTERVAL), 0)"))
+	assert.Truef(t, foundCount, "expected to find transaction retries, full output:\n\n%s", output.String())
+	assert.Truef(t, foundTime, "expected to find time spent retrying, full output:\n\n%s", output.String())
 }


### PR DESCRIPTION
Backport 1/1 commits from #143755 on behalf of @yuzefovich.

/cc @cockroachdb/release

----

This test rarely flaked because we could see a decimal point in the time spent retrying which the regex didn't account for. This commit fixes the pattern as well as refactors the test to provide more context about the failure to make it easier to understand.

An example failure before this change would include the output line like
```
                                time spent retrying the transaction: 2.8s
```

Fixes: #143649.
Fixes: #143721.
Fixes: #143724.

Release note: None

----

Release justification: test-only change.