### PR TITLE
changefeedccl: replan if details changed

### DIFF
--- a/pkg/jobs/jobspb/jobs.proto
+++ b/pkg/jobs/jobspb/jobs.proto
@@ -1100,10 +1100,13 @@ message SchemaChangeGCProgress {
 }
 
 message ChangefeedTargetTable {
+  option (gogoproto.equal) = true;
   string statement_time_name = 1;
 }
 
 message ChangefeedTargetSpecification {
+  option (gogoproto.equal) = true;
+
   enum TargetType {
     // The primary index of the table with table_id descriptor id.
     // Fail if there are ever multiple column families.
@@ -1129,6 +1132,7 @@ message ChangefeedTargetSpecification {
 }
 
 message ChangefeedDetails {
+  option (gogoproto.equal) = true;
   // Targets contains the user-specified tables to watch, mapping
   // the descriptor id to the name at the time of changefeed creation.
   // The names at resolution time are included so that table and database

--- a/pkg/sql/sessiondatapb/session_data.proto
+++ b/pkg/sql/sessiondatapb/session_data.proto
@@ -17,6 +17,8 @@ import "google/protobuf/duration.proto";
 // required to be propagated to the remote nodes for the correct execution of
 // DistSQL flows.
 message SessionData {
+    option (gogoproto.equal) = true;
+
   // Database indicates the "current" database for the purpose of resolving
   // names.
   string database = 1;
@@ -148,6 +150,8 @@ message SessionData {
 // DataConversionConfig contains the parameters that influence the output
 // of certain data types as strings or bytes.
 message DataConversionConfig {
+    option (gogoproto.equal) = true;
+
   // BytesEncodeFormat indicates how to encode byte arrays when converting to
   // string.
   BytesEncodeFormat bytes_encode_format = 1;
@@ -187,8 +191,11 @@ enum VectorizeExecMode {
 
 // SequenceState is used to marshall the sessiondata.SequenceState struct.
 message SequenceState {
+  option (gogoproto.equal) = true;
+
   // Seq represents the last value of one sequence modified by the session.
   message Seq {
+    option (gogoproto.equal) = true;
     uint32 seq_id = 1 [(gogoproto.customname) = "SeqID"];
     int64 latest_val = 2;
   }

--- a/pkg/util/timeutil/pgdate/BUILD.bazel
+++ b/pkg/util/timeutil/pgdate/BUILD.bazel
@@ -59,6 +59,7 @@ proto_library(
     srcs = ["pgdate.proto"],
     strip_import_prefix = "/pkg",
     visibility = ["//visibility:public"],
+    deps = ["@com_github_gogo_protobuf//gogoproto:gogo_proto"],
 )
 
 go_proto_library(
@@ -67,4 +68,5 @@ go_proto_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/util/timeutil/pgdate",
     proto = ":pgdate_proto",
     visibility = ["//visibility:public"],
+    deps = ["@com_github_gogo_protobuf//gogoproto"],
 )

--- a/pkg/util/timeutil/pgdate/pgdate.proto
+++ b/pkg/util/timeutil/pgdate/pgdate.proto
@@ -7,8 +7,12 @@ syntax = "proto3";
 package cockroach.util.timeutil.pgdate;
 option go_package = "github.com/cockroachdb/cockroach/pkg/util/timeutil/pgdate";
 
+import "gogoproto/gogo.proto";
+
 // DateStyle refers to the PostgreSQL DateStyle allowed variables.
 message DateStyle {
+  option (gogoproto.equal) = true;
+
   // Style refers to the style to print output dates.
   Style style = 1;
   // Order refers to the order of day, month and year components.


### PR DESCRIPTION
Currently this patch has no effect since ALTER still requires the job be paused so the running job would never observe the change checked for in this patch. However if/when ALTER were to start allowing some or alter alterations to be done even on non-paused jobs, these checks will ensure the job notices and replans.

Release note: none.
Epic: none.