### PR TITLE
row, sql: add CPut of primary index to Updater and Deleter

### DIFF
--- a/pkg/crosscluster/logical/lww_kv_processor.go
+++ b/pkg/crosscluster/logical/lww_kv_processor.go
@@ -503,7 +503,10 @@ func (p *kvTableWriter) updateRow(
 		// and destination clusters.
 		// ShouldWinTie: true,
 	}
-	_, err := p.ru.UpdateRow(ctx, b, p.oldVals, p.newVals, ph, vh, oth, false)
+	_, err := p.ru.UpdateRow(
+		ctx, b, p.oldVals, p.newVals, ph, vh, oth, false, /* mustValidateOldPKValues */
+		false, /* traceKV */
+	)
 	return err
 }
 
@@ -526,7 +529,9 @@ func (p *kvTableWriter) deleteRow(
 		// ShouldWinTie: true,
 	}
 
-	return p.rd.DeleteRow(ctx, b, p.oldVals, ph, vh, oth, false)
+	return p.rd.DeleteRow(
+		ctx, b, p.oldVals, ph, vh, oth, false /* mustValidateOldPKValues */, false, /* traceKV */
+	)
 }
 
 func (p *kvTableWriter) fillOld(vals cdcevent.Row) error {

--- a/pkg/crosscluster/logical/tombstone_updater.go
+++ b/pkg/crosscluster/logical/tombstone_updater.go
@@ -155,6 +155,7 @@ func (tu *tombstoneUpdater) addToBatch(
 			OriginTimestamp:    afterRow.MvccTimestamp,
 			PreviousWasDeleted: true,
 		},
+		false, /* mustValidateOldPKValues */
 		false, /* traceKV */
 	)
 }

--- a/pkg/sql/backfill/backfill.go
+++ b/pkg/sql/backfill/backfill.go
@@ -402,7 +402,7 @@ func (cb *ColumnBackfiller) RunColumnBackfillChunk(
 		var pm row.PartialIndexUpdateHelper
 		var vh row.VectorIndexUpdateHelper
 		if _, err := ru.UpdateRow(
-			ctx, b, oldValues, updateValues, pm, vh, nil, traceKV,
+			ctx, b, oldValues, updateValues, pm, vh, nil, false /* mustValidateOldPKValues */, traceKV,
 		); err != nil {
 			return roachpb.Key{}, err
 		}

--- a/pkg/sql/delete.go
+++ b/pkg/sql/delete.go
@@ -171,7 +171,9 @@ func (d *deleteNode) processSourceRow(params runParams, sourceVals tree.Datums) 
 	}
 
 	// Queue the deletion in the KV batch.
-	if err := d.run.td.row(params.ctx, deleteVals, pm, vh, d.run.traceKV); err != nil {
+	if err := d.run.td.row(
+		params.ctx, deleteVals, pm, vh, false /* mustValidateOldPKValues */, d.run.traceKV,
+	); err != nil {
 		return err
 	}
 

--- a/pkg/sql/row/helper.go
+++ b/pkg/sql/row/helper.go
@@ -494,6 +494,24 @@ func delFn(
 	}
 }
 
+func delWithCPutFn(
+	ctx context.Context,
+	b Putter,
+	key *roachpb.Key,
+	expVal []byte,
+	traceKV bool,
+	keyEncodingDirs []encoding.Direction,
+) {
+	if traceKV {
+		if keyEncodingDirs != nil {
+			log.VEventf(ctx, 2, "CPut %s -> nil (delete)", keys.PrettyPrint(keyEncodingDirs, *key))
+		} else {
+			log.VEventf(ctx, 2, "CPut %s -> nil (delete)", *key)
+		}
+	}
+	b.CPut(key, nil, expVal)
+}
+
 func (rh *RowHelper) deleteIndexEntry(
 	ctx context.Context,
 	b Putter,
@@ -550,7 +568,10 @@ func (oh *OriginTimestampCPutHelper) CPutFn(
 	traceKV bool,
 ) {
 	if traceKV {
-		log.VEventfDepth(ctx, 1, 2, "CPutWithOriginTimestamp %s -> %s @ %s", *key, value.PrettyPrint(), oh.OriginTimestamp)
+		log.VEventfDepth(
+			ctx, 1, 2, "CPutWithOriginTimestamp %s -> %s (swap) @ %s", *key, value.PrettyPrint(),
+			oh.OriginTimestamp,
+		)
 	}
 	b.CPutWithOriginTimestamp(key, value, expVal, oh.OriginTimestamp)
 }
@@ -559,7 +580,9 @@ func (oh *OriginTimestampCPutHelper) DelWithCPut(
 	ctx context.Context, b Putter, key *roachpb.Key, expVal []byte, traceKV bool,
 ) {
 	if traceKV {
-		log.VEventfDepth(ctx, 1, 2, "CPutWithOriginTimestamp %s -> nil (delete) @ %s", key, oh.OriginTimestamp)
+		log.VEventfDepth(
+			ctx, 1, 2, "CPutWithOriginTimestamp %s -> nil (delete) @ %s", key, oh.OriginTimestamp,
+		)
 	}
 	b.CPutWithOriginTimestamp(key, nil, expVal, oh.OriginTimestamp)
 }

--- a/pkg/sql/row/inserter.go
+++ b/pkg/sql/row/inserter.go
@@ -199,7 +199,7 @@ func (ri *Inserter) InsertRow(
 	ri.valueBuf, err = prepareInsertOrUpdateBatch(
 		ctx, b, &ri.Helper, primaryIndexKey, ri.InsertCols, values, ri.InsertColIDtoRowIndex,
 		ri.InsertColIDtoRowIndex, &ri.key, &ri.value, ri.valueBuf, oth, nil, /* oldValues */
-		kvOp, traceKV,
+		kvOp, false /* mustValidateOldPKValues */, traceKV,
 	)
 	if err != nil {
 		return err

--- a/pkg/sql/tablewriter_delete.go
+++ b/pkg/sql/tablewriter_delete.go
@@ -43,6 +43,9 @@ func (td *tableDeleter) init(_ context.Context, txn *kv.Txn, evalCtx *eval.Conte
 // of the table, and are materialized only for the purpose of updating vector
 // indexes.
 //
+// The mustValidateOldPKValues parameter indicates whether the expected previous
+// row must be verified (using CPut).
+//
 // The traceKV parameter determines whether the individual K/V operations
 // should be logged to the context. We use a separate argument here instead
 // of a Value field on the context because Value access in context.Context
@@ -52,10 +55,11 @@ func (td *tableDeleter) row(
 	values tree.Datums,
 	pm row.PartialIndexUpdateHelper,
 	vh row.VectorIndexUpdateHelper,
+	mustValidateOldPKValues bool,
 	traceKV bool,
 ) error {
 	td.currentBatchSize++
-	return td.rd.DeleteRow(ctx, td.b, values, pm, vh, nil, traceKV)
+	return td.rd.DeleteRow(ctx, td.b, values, pm, vh, nil, mustValidateOldPKValues, traceKV)
 }
 
 // deleteIndex runs the kv operations necessary to delete all kv entries in the

--- a/pkg/sql/tablewriter_update.go
+++ b/pkg/sql/tablewriter_update.go
@@ -39,6 +39,9 @@ func (tu *tableUpdater) init(_ context.Context, txn *kv.Txn, evalCtx *eval.Conte
 // partitions. This is necessary because these values are not part of the table,
 // and are materialized only for the purpose of updating vector indexes.
 //
+// The mustValidateOldPKValues parameter indicates whether the expected previous
+// row must be verified (using CPut).
+//
 // The traceKV parameter determines whether the individual K/V operations
 // should be logged to the context. We use a separate argument here instead
 // of a Value field on the context because Value access in context.Context
@@ -48,10 +51,13 @@ func (tu *tableUpdater) rowForUpdate(
 	oldValues, updateValues tree.Datums,
 	pm row.PartialIndexUpdateHelper,
 	vh row.VectorIndexUpdateHelper,
+	mustValidateOldPKValues bool,
 	traceKV bool,
 ) (tree.Datums, error) {
 	tu.currentBatchSize++
-	return tu.ru.UpdateRow(ctx, tu.b, oldValues, updateValues, pm, vh, nil, traceKV)
+	return tu.ru.UpdateRow(
+		ctx, tu.b, oldValues, updateValues, pm, vh, nil, mustValidateOldPKValues, traceKV,
+	)
 }
 
 // tableDesc returns the TableDescriptor for the table that the tableUpdater

--- a/pkg/sql/tablewriter_upsert.go
+++ b/pkg/sql/tablewriter_upsert.go
@@ -285,7 +285,9 @@ func (tu *tableUpserter) updateConflictingRow(
 	// Queue the update in KV. This also returns an "update row"
 	// containing the updated values for every column in the
 	// table. This is useful for RETURNING, which we collect below.
-	_, err := tu.ru.UpdateRow(ctx, b, fetchRow, updateValues, pm, vh, nil, traceKV)
+	_, err := tu.ru.UpdateRow(
+		ctx, b, fetchRow, updateValues, pm, vh, nil, false /* mustValidateOldPKValues */, traceKV,
+	)
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/update.go
+++ b/pkg/sql/update.go
@@ -225,7 +225,9 @@ func (u *updateNode) processSourceRow(params runParams, sourceVals tree.Datums) 
 	}
 
 	// Queue the insert in the KV batch.
-	newValues, err := u.run.tu.rowForUpdate(params.ctx, oldValues, updateValues, pm, vh, u.run.traceKV)
+	newValues, err := u.run.tu.rowForUpdate(
+		params.ctx, oldValues, updateValues, pm, vh, false /* mustValidateOldPKValues */, u.run.traceKV,
+	)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The upcoming fast paths for UPDATE and DELETE will skip the initial scan
of the target row. Instead, they will rely on CPut(s) to the primary
index to confirm that the target row exists and matches the WHERE clause
of the statement.

This PR adds a new CPut path to the Updater and Deleter which uses
expValue to validate the old values. It closely mirrors the CPut paths
added for the OriginTimestampCPutHelper in #130512. The main difference
is that unlike the OriginTimestampCPutHelper, these paths do not need to
delete all-NULL non-0 column families when not overwriting.

Only writes to the primary index need validation using CPut with
expValue. Writes to secondary indexes should be unchanged. If the CPut
to the primary index fails, all writes for the statement will be rolled
back using a savepoint (next PR).

Informs: #71153

Release note: None