### PR TITLE
kvnemesis: add new KVNemesis test variant

### DIFF
--- a/pkg/kv/kvclient/kvcoord/testing_knobs.go
+++ b/pkg/kv/kvclient/kvcoord/testing_knobs.go
@@ -71,6 +71,11 @@ type ClientTestingKnobs struct {
 	// picking a transaction's anchor key; instead, the transaction is anchored at
 	// the first key it locks.
 	DisableTxnAnchorKeyRandomization bool
+
+	// Disable1PCForAllLockingRequests, if set, disables 1PC anytime a
+	// request is locking. In production, this is done automatically for
+	// replicated locks.
+	Disable1PCForAllLockingReadRequests bool
 }
 
 var _ base.ModuleTestingKnobs = &ClientTestingKnobs{}

--- a/pkg/kv/kvclient/kvcoord/txn_coord_sender.go
+++ b/pkg/kv/kvclient/kvcoord/txn_coord_sender.go
@@ -265,6 +265,7 @@ func newRootTxnCoordSender(
 		stopper: tcs.stopper,
 		metrics: &tcs.metrics,
 		mu:      &tcs.mu.Mutex,
+		knobs:   &tcs.testingKnobs,
 	}
 	tcs.interceptorAlloc.txnMetricRecorder = txnMetricRecorder{
 		metrics:    &tcs.metrics,

--- a/pkg/kv/kvnemesis/BUILD.bazel
+++ b/pkg/kv/kvnemesis/BUILD.bazel
@@ -82,6 +82,7 @@ go_test(
         "//pkg/kv/kvpb",
         "//pkg/kv/kvserver",
         "//pkg/kv/kvserver/apply",
+        "//pkg/kv/kvserver/concurrency",
         "//pkg/kv/kvserver/concurrency/isolation",
         "//pkg/kv/kvserver/kvserverbase",
         "//pkg/kv/kvserver/kvserverpb",

--- a/pkg/kv/kvpb/api.go
+++ b/pkg/kv/kvpb/api.go
@@ -1874,6 +1874,17 @@ func scanLockStrength(str KeyLockingStrengthType) lock.Strength {
 	}
 }
 
+var testingAlwaysUseUnreplicatedLocks bool
+
+// TestingAlwaysUseUnreplicatedLocks changes the behaviour of
+// GuaranteedDurability locks to use unreplicated instead of replicated locks.
+func TestingAlwaysUseUnreplicatedLocks() func() {
+	testingAlwaysUseUnreplicatedLocks = true
+	return func() {
+		testingAlwaysUseUnreplicatedLocks = false
+	}
+}
+
 func scanLockDurability(dur KeyLockingDurabilityType) lock.Durability {
 	switch dur {
 	case Invalid:
@@ -1881,6 +1892,9 @@ func scanLockDurability(dur KeyLockingDurabilityType) lock.Durability {
 	case BestEffort:
 		return lock.Unreplicated
 	case GuaranteedDurability:
+		if testingAlwaysUseUnreplicatedLocks {
+			return lock.Unreplicated
+		}
 		return lock.Replicated
 	default:
 		panic(fmt.Sprintf("unknown durability type: %d", dur))

--- a/pkg/kv/kvserver/batcheval/cmd_resolve_intent.go
+++ b/pkg/kv/kvserver/batcheval/cmd_resolve_intent.go
@@ -109,8 +109,11 @@ func ResolveIntent(
 	res.Local.ResolvedLocks = []roachpb.LockUpdate{update}
 	res.Local.Metrics = resolveToMetricType(args.Status, args.Poison)
 
+	shouldBumpTSCache := replLocksReleased
+	shouldBumpTSCache = shouldBumpTSCache || cArgs.EvalCtx.EvalKnobs().BumpTimestampCacheOnUnreplicatedLocks
+
 	// Handle replicated lock releases.
-	if replLocksReleased && update.Status == roachpb.COMMITTED {
+	if shouldBumpTSCache && update.Status == roachpb.COMMITTED {
 		// A replicated {shared, exclusive} lock was released for a committed
 		// transaction. Now that the lock is no longer there, we still need to make
 		// sure other transactions can't write underneath the transaction's commit

--- a/pkg/kv/kvserver/batcheval/cmd_resolve_intent_range.go
+++ b/pkg/kv/kvserver/batcheval/cmd_resolve_intent_range.go
@@ -74,8 +74,11 @@ func ResolveIntentRange(
 	res.Local.ResolvedLocks = []roachpb.LockUpdate{update}
 	res.Local.Metrics = resolveToMetricType(args.Status, args.Poison)
 
+	shouldBumpTSCache := replLocksReleased
+	shouldBumpTSCache = shouldBumpTSCache || cArgs.EvalCtx.EvalKnobs().BumpTimestampCacheOnUnreplicatedLocks
+
 	// Handle replicated lock releases.
-	if replLocksReleased && update.Status == roachpb.COMMITTED {
+	if shouldBumpTSCache && update.Status == roachpb.COMMITTED {
 		// A replicated {shared, exclusive} lock was released for a committed
 		// transaction. Now that the lock is no longer there, we still need to make
 		// sure other transactions can't write underneath the transaction's commit

--- a/pkg/kv/kvserver/kvserverbase/knobs.go
+++ b/pkg/kv/kvserver/kvserverbase/knobs.go
@@ -62,6 +62,10 @@ type BatchEvalTestingKnobs struct {
 	// NOTE: This currently only applies to Migrate requests and only ignores the
 	// cluster version.
 	OverrideDoTimelyApplicationToAllReplicas bool
+
+	// BumpTimestampCacheOnUnreplicatedLocks bumps the timestamp
+	// cache for all locks, not just replicated locks.
+	BumpTimestampCacheOnUnreplicatedLocks bool
 }
 
 // IntentResolverTestingKnobs contains testing helpers that are used during


### PR DESCRIPTION
This introduces a new KVNemesis test variant in which unreplicated locks are always used in place of replicated locks. To facilitate this it introduces 3 new test-only changes:

- A function that sets the durability of GuaranteedDurability locks to Unreplicated for the duration of a test.

- A testing knob that forces EndTxn, ResolveIntent, and ResolveIntentRange to bump the timestamp cache for all locks.

- A testing knob that forces the committer interceptor to disable 1PC for all batches including locking read requests.

Epic: CRDB-42764

Release note: None