### PR TITLE
microbench-ci: fix marker file name

### DIFF
--- a/pkg/cmd/microbench-ci/run.go
+++ b/pkg/cmd/microbench-ci/run.go
@@ -124,7 +124,7 @@ func (b *Benchmark) run() error {
 	// Write change marker file if the benchmark changed.
 	if status != NoChange {
 		marker := strings.ToUpper(status.String())
-		err := os.WriteFile(path.Join(suite.artifactsDir(New), "."+marker), nil, 0644)
+		err := os.WriteFile(path.Join(suite.artifactsDir(New), "_"+marker), nil, 0644)
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/microbench-ci/testdata/regression.txt
+++ b/pkg/cmd/microbench-ci/testdata/regression.txt
@@ -157,7 +157,7 @@ tree
 /github-summary.md
 /qwerty456
 /qwerty456/artifacts
-/qwerty456/artifacts/.REGRESSED
+/qwerty456/artifacts/_REGRESSED
 /qwerty456/artifacts/cleaned_Sysbench_SQL_3node_oltp_read_write.log
 /qwerty456/artifacts/cpu_Sysbench_SQL_3node_oltp_read_write_merged.prof
 /qwerty456/artifacts/memory_Sysbench_SQL_3node_oltp_read_write_merged.prof


### PR DESCRIPTION
Previously, the marker file started with a dot, which made it invisible in the directory listing and copy operation ran during the GitHub actions to copy to GCS. It's possible to update the copy operation to include the dot, but it's better to standardize the name to start with an underscore.

Epic: None
Release note: None