### PR TITLE
release-24.3: colflow: fix flow-level stats for some dist plans in EXPLAIN ANALYZE

### DIFF
--- a/pkg/sql/colflow/vectorized_flow.go
+++ b/pkg/sql/colflow/vectorized_flow.go
@@ -484,6 +484,11 @@ func (s *vectorizedFlowCreator) makeGetStatsFnForOutbox(
 			// At the last outbox, we can accurately retrieve stats for the
 			// whole flow from parent monitors. These stats are added to a
 			// flow-level span.
+			// TODO(yuzefovich): in theory, we should be doing this in the very
+			// last goroutine that is part of the remote flow, which could be
+			// a goroutine corresponding to a remote router. It shouldn't matter
+			// as much in practice, so we approximate "the last goroutine of the
+			// flow" as "the last outbox goroutine of the flow".
 			result = append(result, &execinfrapb.ComponentStats{
 				Component: flowCtx.FlowComponentID(),
 				FlowStats: execinfrapb.FlowStats{
@@ -832,11 +837,14 @@ func (s *vectorizedFlowCreator) setupRouter(
 		case execinfrapb.StreamEndpointSpec_SYNC_RESPONSE:
 			return errors.Errorf("unexpected sync response output when setting up router")
 		case execinfrapb.StreamEndpointSpec_REMOTE:
+			// We pass nil statsCollectors here since the router is responsible
+			// for collecting stats from the input.
+			getStats := s.makeGetStatsFnForOutbox(flowCtx, nil /* statsCollectors */)
 			if _, err := s.setupRemoteOutputStream(
 				ctx, flowCtx, processorID, colexecargs.OpWithMetaInfo{
 					Root:            op,
 					MetadataSources: colexecop.MetadataSources{op},
-				}, outputTyps, stream, factory, nil, /* getStats */
+				}, outputTyps, stream, factory, getStats,
 			); err != nil {
 				return err
 			}

--- a/pkg/sql/opt/exec/explain/BUILD.bazel
+++ b/pkg/sql/opt/exec/explain/BUILD.bazel
@@ -87,6 +87,7 @@ go_test(
         "//pkg/util/log",
         "//pkg/util/treeprinter",
         "@com_github_cockroachdb_datadriven//:datadriven",
+        "@com_github_cockroachdb_errors//:errors",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
         "@in_gopkg_yaml_v2//:yaml_v2",

--- a/pkg/sql/opt/exec/explain/output_test.go
+++ b/pkg/sql/opt/exec/explain/output_test.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -29,6 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/datadriven"
+	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	yaml "gopkg.in/yaml.v2"
@@ -379,4 +381,68 @@ func TestRetryFields(t *testing.T) {
 	}
 	assert.Truef(t, foundCount, "expected to find transaction retries, full output:\n\n%s", output.String())
 	assert.Truef(t, foundTime, "expected to find time spent retrying, full output:\n\n%s", output.String())
+}
+
+// TestMaximumMemoryUsage verifies that "maximum memory usage" statistic is
+// reported correctly in distributed plans. It is a regression test for #143617.
+func TestMaximumMemoryUsage(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	skip.UnderStress(t, "multinode cluster setup times out under stress")
+	skip.UnderRace(t, "multinode cluster setup times out under race")
+
+	const numNodes = 3
+	tc := testcluster.StartTestCluster(t, numNodes, base.TestClusterArgs{})
+	ctx := context.Background()
+	defer tc.Stopper().Stop(ctx)
+
+	if srv := tc.Server(0); srv.TenantController().StartedDefaultTestTenant() {
+		systemSqlDB := srv.SystemLayer().SQLConn(t, serverutils.DBName("system"))
+		_, err := systemSqlDB.Exec(`ALTER TENANT [$1] GRANT CAPABILITY can_admin_relocate_range=true`, serverutils.TestTenantID().ToUint64())
+		require.NoError(t, err)
+		serverutils.WaitForTenantCapabilities(t, srv, serverutils.TestTenantID(), map[tenantcapabilities.ID]string{
+			tenantcapabilities.CanAdminRelocateRange: "true",
+		}, "")
+	}
+
+	// Set up such a distributed plan where memory-intensive aggregation occurs
+	// on the remote nodes whereas the gateway only merges streams of final
+	// results from remote nodes.
+	db := sqlutils.MakeSQLRunner(tc.Conns[0])
+	db.Query(t, "CREATE TABLE t (k INT PRIMARY KEY, bucket INT, v STRING);")
+	db.Query(t, "INSERT INTO t SELECT i, i % 4, repeat('a', 1000) FROM generate_series(1, 10000) AS g(i);")
+	db.Query(t, "ALTER TABLE t SPLIT AT VALUES (5001);")
+	testutils.SucceedsSoon(t, func() error {
+		// Wrap this query in a retry loop since it might hit expected errors
+		// for some time.
+		_, err := db.DB.ExecContext(ctx, "ALTER TABLE t EXPERIMENTAL_RELOCATE VALUES (ARRAY[2], 1), (ARRAY[3], 5001)")
+		return err
+	})
+
+	// In rare cases (due to metamorphic randomization) we might drop the
+	// ComponentStats proto that powers "maximum memory usage" stat from the
+	// trace, so we add a retry loop around this.
+	testutils.SucceedsSoon(t, func() error {
+		rows := db.QueryStr(t, "EXPLAIN ANALYZE SELECT max(v) FROM t GROUP BY bucket;")
+		var output strings.Builder
+		maxMemoryRE := regexp.MustCompile(`maximum memory usage: ([\d\.]+) MiB`)
+		var maxMemoryUsage float64
+		for _, row := range rows {
+			output.WriteString(row[0])
+			output.WriteString("\n")
+			s := strings.TrimSpace(row[0])
+			if matches := maxMemoryRE.FindStringSubmatch(s); len(matches) > 0 {
+				var err error
+				maxMemoryUsage, err = strconv.ParseFloat(matches[1], 64)
+				if err != nil {
+					return err
+				}
+			}
+		}
+		if maxMemoryUsage < 5.0 {
+			return errors.Newf("expected maximum memory usage to be at least 5 MiB, full output:\n\n%s", output.String())
+		}
+		return nil
+	})
 }


### PR DESCRIPTION
Backport 1/1 commits from #143777 on behalf of @yuzefovich.

/cc @cockroachdb/release

----

Previously, we could report an underestimate for "maximum memory usage" and "max sql temp disk usage" statistics in EXPLAIN ANALYZE for some distributed plans. This is the case since on the remote nodes the reporting of this information (as well as RU estimate in multi-tenant environments) is done by the last outbox exiting from the node. Outboxes can be created in two scenarios - when an operator needs to communicate its results to a remote component, and when an operator needs to communicate its results to _multiple_ components, some of which are remote. Previously, we would only instrument the former for statistics reporting, so if we created at least one router on a remote node, we would never report the flow-level stats (since we'd increment `numOutboxes` for each outbox, yet `getStats` callback that increments `numOutboxesDrained` would be incremented only for some). This is now fixed.

Fixes: #143617.

Release note (bug fix): Previously, the top-level fields "maximum memory usage" and "max sql temp disk usage" of EXPLAIN ANALYZE output could be under-reported for distributed plans when memory-intensive operations were fully performed on the remote nodes. The bug has been present since before 22.1 version and is now fixed.

----

Release justification: bug fix.