### PR TITLE
microbench-ci: named marker file name

### DIFF
--- a/pkg/cmd/microbench-ci/run.go
+++ b/pkg/cmd/microbench-ci/run.go
@@ -124,7 +124,7 @@ func (b *Benchmark) run() error {
 	// Write change marker file if the benchmark changed.
 	if status != NoChange {
 		marker := strings.ToUpper(status.String())
-		err := os.WriteFile(path.Join(suite.artifactsDir(New), "_"+marker), nil, 0644)
+		err := os.WriteFile(path.Join(suite.artifactsDir(New), b.sanitizedName()+"."+marker), nil, 0644)
 		if err != nil {
 			return err
 		}

--- a/pkg/cmd/microbench-ci/testdata/regression.txt
+++ b/pkg/cmd/microbench-ci/testdata/regression.txt
@@ -157,7 +157,7 @@ tree
 /github-summary.md
 /qwerty456
 /qwerty456/artifacts
-/qwerty456/artifacts/_REGRESSED
+/qwerty456/artifacts/Sysbench_SQL_3node_oltp_read_write.REGRESSED
 /qwerty456/artifacts/cleaned_Sysbench_SQL_3node_oltp_read_write.log
 /qwerty456/artifacts/cpu_Sysbench_SQL_3node_oltp_read_write_merged.prof
 /qwerty456/artifacts/memory_Sysbench_SQL_3node_oltp_read_write_merged.prof


### PR DESCRIPTION
Previously, if there is more than one runner that fails with a regression there is a race between which job copies the `_REGRESSED` marker file first. The "last" job fails when trying to overwrite the file, already copied by the other job (runner). Hence we should name the marker files with the benchmark name to avoid conflicts.

Epic: None
Release note: None