### PR TITLE
release-23.2: kvfeed: fix writer being closed with wrong error when drain fails

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -431,8 +431,15 @@ func (ca *changeAggregator) startKVFeed(
 	cfg := ca.flowCtx.Cfg
 	kvFeedMemMon := mon.NewMonitorInheritWithLimit("kvFeed", memLimit, parentMemMon)
 	kvFeedMemMon.StartNoReserved(ctx, parentMemMon)
+
+	var options []kvevent.BlockingBufferOption
+	if ca.knobs.MakeKVFeedToAggregatorBufferKnobs != nil {
+		options = append(options,
+			kvevent.WithBlockingBufferTestingKnobs(ca.knobs.MakeKVFeedToAggregatorBufferKnobs()))
+	}
 	buf := kvevent.NewThrottlingBuffer(
-		kvevent.NewMemBuffer(kvFeedMemMon.MakeBoundAccount(), &cfg.Settings.SV, &ca.metrics.KVFeedMetrics.AggregatorBufferMetricsWithCompat),
+		kvevent.NewMemBuffer(kvFeedMemMon.MakeBoundAccount(), &cfg.Settings.SV,
+			&ca.metrics.KVFeedMetrics.AggregatorBufferMetricsWithCompat, options...),
 		cdcutils.NodeLevelThrottler(&cfg.Settings.SV, &ca.metrics.ThrottleMetrics))
 
 	// KVFeed takes ownership of the kvevent.Writer portion of the buffer, while

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -1658,7 +1658,9 @@ func TestNoStopAfterNonTargetColumnDrop(t *testing.T) {
 		}
 	}
 
-	cdcTest(t, testFn)
+	runWithAndWithoutRegression141453(t, testFn, func(t *testing.T, testFn cdcTestFn) {
+		cdcTest(t, testFn)
+	})
 }
 
 func TestChangefeedProjectionDelete(t *testing.T) {
@@ -1894,7 +1896,9 @@ func TestChangefeedColumnDropsOnTheSameTableWithMultipleFamilies(t *testing.T) {
 		})
 	}
 
-	cdcTest(t, testFn)
+	runWithAndWithoutRegression141453(t, testFn, func(t *testing.T, testFn cdcTestFn) {
+		cdcTest(t, testFn)
+	})
 }
 
 func TestNoStopAfterNonTargetAddColumnWithBackfill(t *testing.T) {
@@ -1938,7 +1942,9 @@ func TestNoStopAfterNonTargetAddColumnWithBackfill(t *testing.T) {
 		}
 	}
 
-	cdcTest(t, testFn)
+	runWithAndWithoutRegression141453(t, testFn, func(t *testing.T, testFn cdcTestFn) {
+		cdcTest(t, testFn)
+	})
 }
 
 func TestChangefeedExternalIODisabled(t *testing.T) {
@@ -2798,7 +2804,7 @@ func TestChangefeedSchemaChangeAllowBackfill(t *testing.T) {
 
 	require.NoError(t, log.SetVModule("kv_feed=2,changefeed_processors=2"))
 
-	testFn := func(t *testing.T, s TestServerWithSystem, f cdctest.TestFeedFactory) {
+	testFn := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
 		sqlDB := sqlutils.MakeSQLRunner(s.DB)
 
 		// Expected semantics:
@@ -2829,7 +2835,7 @@ func TestChangefeedSchemaChangeAllowBackfill(t *testing.T) {
 				`add_column_def: [2]->{"after": {"a": 2}}`,
 			})
 			sqlDB.Exec(t, `ALTER TABLE add_column_def ADD COLUMN b STRING DEFAULT 'd'`)
-			ts := schematestutils.FetchDescVersionModificationTime(t, s.TestServer.Server, `d`, `public`, `add_column_def`, 7)
+			ts := schematestutils.FetchDescVersionModificationTime(t, s.Server, `d`, `public`, `add_column_def`, 7)
 			assertPayloads(t, addColumnDef, []string{
 				fmt.Sprintf(`add_column_def: [1]->{"after": {"a": 1, "b": "d"}, "updated": "%s"}`,
 					ts.AsOfSystemTime()),
@@ -2849,7 +2855,7 @@ func TestChangefeedSchemaChangeAllowBackfill(t *testing.T) {
 				`add_col_comp: [2]->{"after": {"a": 2, "b": 7}}`,
 			})
 			sqlDB.Exec(t, `ALTER TABLE add_col_comp ADD COLUMN c INT AS (a + 10) STORED`)
-			ts := schematestutils.FetchDescVersionModificationTime(t, s.TestServer.Server, `d`, `public`, `add_col_comp`, 7)
+			ts := schematestutils.FetchDescVersionModificationTime(t, s.Server, `d`, `public`, `add_col_comp`, 7)
 			assertPayloads(t, addColComp, []string{
 				fmt.Sprintf(`add_col_comp: [1]->{"after": {"a": 1, "b": 6, "c": 11}, "updated": "%s"}`,
 					ts.AsOfSystemTime()),
@@ -2870,7 +2876,7 @@ func TestChangefeedSchemaChangeAllowBackfill(t *testing.T) {
 			})
 			sqlDB.Exec(t, `ALTER TABLE drop_column DROP COLUMN b`)
 			sqlDB.Exec(t, `INSERT INTO drop_column VALUES (3)`)
-			ts := schematestutils.FetchDescVersionModificationTime(t, s.TestServer.Server, `d`, `public`, `drop_column`, 2)
+			ts := schematestutils.FetchDescVersionModificationTime(t, s.Server, `d`, `public`, `drop_column`, 2)
 
 			// Backfill for DROP COLUMN b.
 			assertPayloads(t, dropColumn, []string{
@@ -2921,9 +2927,9 @@ func TestChangefeedSchemaChangeAllowBackfill(t *testing.T) {
 			// version 2. Then, when adding column c, it goes from 9->17, with the schema change being visible at
 			// the 7th step (version 15). Finally, when adding column d, it goes from 17->25 ith the schema change
 			// being visible at the 7th step (version 23).
-			dropTS := schematestutils.FetchDescVersionModificationTime(t, s.TestServer.Server, `d`, `public`, `multiple_alters`, 2)
-			addTS := schematestutils.FetchDescVersionModificationTime(t, s.TestServer.Server, `d`, `public`, `multiple_alters`, 15)
-			addTS2 := schematestutils.FetchDescVersionModificationTime(t, s.TestServer.Server, `d`, `public`, `multiple_alters`, 23)
+			dropTS := schematestutils.FetchDescVersionModificationTime(t, s.Server, `d`, `public`, `multiple_alters`, 2)
+			addTS := schematestutils.FetchDescVersionModificationTime(t, s.Server, `d`, `public`, `multiple_alters`, 15)
+			addTS2 := schematestutils.FetchDescVersionModificationTime(t, s.Server, `d`, `public`, `multiple_alters`, 23)
 
 			assertPayloads(t, multipleAlters, []string{
 				fmt.Sprintf(`multiple_alters: [1]->{"after": {"a": 1}, "updated": "%s"}`, dropTS.AsOfSystemTime()),
@@ -2936,7 +2942,9 @@ func TestChangefeedSchemaChangeAllowBackfill(t *testing.T) {
 		})
 	}
 
-	cdcTestWithSystem(t, testFn)
+	runWithAndWithoutRegression141453(t, testFn, func(t *testing.T, testFn cdcTestFn) {
+		cdcTest(t, testFn)
+	})
 
 	log.FlushFiles()
 	entries, err := log.FetchEntriesFromFiles(0, math.MaxInt64, 1,
@@ -3180,8 +3188,6 @@ func TestChangefeedSingleColumnFamilySchemaChanges(t *testing.T) {
 	testFn := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
 		sqlDB := sqlutils.MakeSQLRunner(s.DB)
 
-		_ = maybeDisableDeclarativeSchemaChangesForTest(t, sqlDB)
-
 		// Table with 2 column families.
 		sqlDB.Exec(t, `CREATE TABLE foo (a INT PRIMARY KEY, b STRING, c STRING, FAMILY most (a,b), FAMILY rest (c))`)
 		sqlDB.Exec(t, `INSERT INTO foo values (0, 'dog', 'cat')`)
@@ -3208,9 +3214,11 @@ func TestChangefeedSingleColumnFamilySchemaChanges(t *testing.T) {
 		waitForSchemaChange(t, sqlDB, `ALTER TABLE foo DROP column c`)
 		requireErrorSoon(context.Background(), t, fooRest,
 			regexp.MustCompile(`CHANGEFEED targeting nonexistent or removed column family rest of table foo`))
-
 	}
-	cdcTest(t, testFn)
+
+	runWithAndWithoutRegression141453(t, testFn, func(t *testing.T, testFn cdcTestFn) {
+		cdcTest(t, testFn)
+	}, withMaybeUseLegacySchemaChanger())
 }
 
 func TestChangefeedEachColumnFamilySchemaChanges(t *testing.T) {
@@ -3221,8 +3229,6 @@ func TestChangefeedEachColumnFamilySchemaChanges(t *testing.T) {
 
 	testFn := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
 		sqlDB := sqlutils.MakeSQLRunner(s.DB)
-
-		_ = maybeDisableDeclarativeSchemaChangesForTest(t, sqlDB)
 
 		// Table with 2 column families.
 		sqlDB.Exec(t, `CREATE TABLE foo (a INT PRIMARY KEY, b STRING, c STRING, FAMILY f1 (a,b), FAMILY f2 (c))`)
@@ -3250,7 +3256,10 @@ func TestChangefeedEachColumnFamilySchemaChanges(t *testing.T) {
 			`foo.f3: [0]->{"after": {"e": "hello"}}`,
 		})
 	}
-	cdcTest(t, testFn)
+
+	runWithAndWithoutRegression141453(t, testFn, func(t *testing.T, testFn cdcTestFn) {
+		cdcTest(t, testFn)
+	}, withMaybeUseLegacySchemaChanger())
 }
 
 func TestCoreChangefeedRequiresSelectPrivilege(t *testing.T) {
@@ -8712,7 +8721,9 @@ func TestSchemachangeDoesNotBreakSinklessFeed(t *testing.T) {
 		})
 	}
 
-	cdcTest(t, testFn, feedTestForceSink("sinkless"))
+	runWithAndWithoutRegression141453(t, testFn, func(t *testing.T, testFn cdcTestFn) {
+		cdcTest(t, testFn, feedTestForceSink("sinkless"))
+	})
 }
 
 func TestChangefeedKafkaMessageTooLarge(t *testing.T) {

--- a/pkg/ccl/changefeedccl/helpers_test.go
+++ b/pkg/ccl/changefeedccl/helpers_test.go
@@ -19,6 +19,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -26,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/cdctest"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeedbase"
+	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/kvevent"
 	_ "github.com/cockroachdb/cockroach/pkg/ccl/multiregionccl" // allow locality-related mutations
 	"github.com/cockroachdb/cockroach/pkg/ccl/multiregionccl/multiregionccltestutils"
 	_ "github.com/cockroachdb/cockroach/pkg/ccl/partitionccl"
@@ -64,7 +66,7 @@ func maybeDisableDeclarativeSchemaChangesForTest(t testing.TB, sqlDB *sqlutils.S
 	if disable {
 		t.Log("using legacy schema changer")
 		sqlDB.Exec(t, "SET use_declarative_schema_changer='off'")
-		sqlDB.Exec(t, "SET CLUSTER SETTING  sql.defaults.use_declarative_schema_changer='off'")
+		sqlDB.Exec(t, "SET CLUSTER SETTING sql.defaults.use_declarative_schema_changer='off'")
 	}
 	return disable
 }
@@ -1382,4 +1384,111 @@ func ChangefeedJobPermissionsTestSetup(t *testing.T, s TestServer) {
 
 		`CREATE USER regularUser`,
 	)
+}
+
+type regression141453Options struct {
+	maybeUseLegacySchemaChanger bool
+}
+
+type regression141453Option func(*regression141453Options)
+
+func withMaybeUseLegacySchemaChanger() regression141453Option {
+	return func(opts *regression141453Options) {
+		opts.maybeUseLegacySchemaChanger = true
+	}
+}
+
+// runWithAndWithoutRegression141453 runs the test both with and without testing
+// knobs that simulate the scenario where a change aggregator encounters a schema
+// change restart but draining the buffer fails so the resolved spans message
+// signaling the restart doesn't get sent to the change frontier.
+func runWithAndWithoutRegression141453(
+	t *testing.T,
+	testFn cdcTestFn,
+	runTestFn func(t *testing.T, testFn cdcTestFn),
+	opts ...regression141453Option,
+) {
+	testutils.RunTrueAndFalse(t, "regression 141453",
+		func(t *testing.T, regression141453 bool) {
+			testFn := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
+				var options regression141453Options
+				for _, opt := range opts {
+					opt(&options)
+				}
+
+				var useLegacySchemaChanger bool
+				if options.maybeUseLegacySchemaChanger {
+					sqlDB := sqlutils.MakeSQLRunner(s.DB)
+					useLegacySchemaChanger = maybeDisableDeclarativeSchemaChangesForTest(t, sqlDB)
+				}
+
+				// This regression scenario doesn't always happen with the legacy schema changer
+				// because altering the table sometimes results in backfills instead of restarts.
+				if useLegacySchemaChanger || !regression141453 {
+					testFn(t, s, f)
+					return
+				}
+
+				knobs := s.TestingKnobs.
+					DistSQL.(*execinfra.TestingKnobs).
+					Changefeed.(*TestingKnobs)
+
+				// We force the regression scenario to happen by:
+				// 1. Blocking popping from the kv feed to change aggregator buffer
+				//    before we add the restart resolved span boundary message.
+				// 2. Canceling the context that Drain uses so that it fails.
+				// 3. Re-allowing popping after the buffer is closed.
+				//
+				// This will ensure that the change aggregator will not be able
+				// to pop (and send) the restart resolved span boundary message
+				// and thus the changefeed should restart due to transient error
+				// (before the expected restart for the schema change).
+				//
+				// Previously, this scenario would incorrectly cause the changefeed
+				// to shut down as if it had completed successfully.
+				//
+				// Note that we only want to make Drain fail once, otherwise the test
+				// will never be able to proceed.
+				var drainFailedOnce atomic.Bool
+				knobs.MakeKVFeedToAggregatorBufferKnobs = func() kvevent.BlockingBufferTestingKnobs {
+					if drainFailedOnce.Load() {
+						return kvevent.BlockingBufferTestingKnobs{}
+					}
+					var blockPop atomic.Bool
+					popCh := make(chan struct{})
+					return kvevent.BlockingBufferTestingKnobs{
+						BeforeAdd: func(ctx context.Context, e kvevent.Event) (context.Context, kvevent.Event) {
+							if e.Type() == kvevent.TypeResolved &&
+								e.Resolved().BoundaryType == jobspb.ResolvedSpan_RESTART {
+								blockPop.Store(true)
+							}
+							return ctx, e
+						},
+						BeforePop: func() {
+							if blockPop.Load() {
+								<-popCh
+							}
+						},
+						BeforeDrain: func(ctx context.Context) context.Context {
+							ctx, cancel := context.WithCancel(ctx)
+							cancel()
+							return ctx
+						},
+						AfterDrain: func(err error) {
+							require.Error(t, err)
+							drainFailedOnce.Store(true)
+						},
+						AfterCloseWithReason: func(err error) {
+							require.NoError(t, err)
+							close(popCh)
+							blockPop.Store(false)
+						},
+					}
+				}
+				testFn(t, s, f)
+				require.True(t, drainFailedOnce.Load())
+			}
+
+			runTestFn(t, testFn)
+		})
 }

--- a/pkg/ccl/changefeedccl/kvevent/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/kvevent/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
         "chunked_event_queue.go",
         "event.go",
         "metrics.go",
+        "testing_knobs.go",
         "throttling_buffer.go",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/kvevent",

--- a/pkg/ccl/changefeedccl/kvevent/testing_knobs.go
+++ b/pkg/ccl/changefeedccl/kvevent/testing_knobs.go
@@ -1,0 +1,17 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package kvevent
+
+import "context"
+
+// BlockingBufferTestingKnobs are testing knobs for blocking buffers.
+type BlockingBufferTestingKnobs struct {
+	BeforeAdd            func(ctx context.Context, e Event) (context.Context, Event)
+	BeforePop            func()
+	BeforeDrain          func(ctx context.Context) context.Context
+	AfterDrain           func(err error)
+	AfterCloseWithReason func(err error)
+}

--- a/pkg/ccl/changefeedccl/kvfeed/kv_feed.go
+++ b/pkg/ccl/changefeedccl/kvfeed/kv_feed.go
@@ -167,18 +167,18 @@ func Run(ctx context.Context, cfg Config) error {
 	// Regardless of whether drain succeeds, we must also close the buffer to release
 	// any resources, and to let the consumer (changeAggregator) know that no more writes
 	// are expected so that it can transition to a draining state.
-	err = errors.CombineErrors(
-		f.writer.Drain(ctx),
-		f.writer.CloseWithReason(ctx, kvevent.ErrNormalRestartReason),
-	)
-
-	if err == nil {
-		// This context is canceled by the change aggregator when it receives
-		// an error reading from the Writer that was closed above.
-		<-ctx.Done()
+	if err := f.writer.Drain(ctx); err != nil {
+		err := errors.Wrap(err, "failed to drain kv feed writer")
+		return errors.CombineErrors(err, f.writer.CloseWithReason(ctx, err))
+	}
+	if err := f.writer.CloseWithReason(ctx, kvevent.ErrNormalRestartReason); err != nil {
+		return err
 	}
 
-	return err
+	// This context is canceled by the change aggregator when it receives
+	// an error reading from the Writer that was closed above.
+	<-ctx.Done()
+	return ctx.Err()
 }
 
 func startLaggingRangesObserver(

--- a/pkg/ccl/changefeedccl/testing_knobs.go
+++ b/pkg/ccl/changefeedccl/testing_knobs.go
@@ -8,6 +8,7 @@ package changefeedccl
 import (
 	"context"
 
+	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/kvevent"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/kvfeed"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -91,6 +92,10 @@ type TestingKnobs struct {
 
 	// WrapTelemetryLogger is used to wrap the periodic telemetry logger in tests.
 	WrapTelemetryLogger func(logger telemetryLogger) telemetryLogger
+
+	// MakeKVFeedToAggregatorBufferKnobs is used to make a fresh set of testing knobs
+	// to pass to the constructor of the kv feed to change aggregator buffer.
+	MakeKVFeedToAggregatorBufferKnobs func() kvevent.BlockingBufferTestingKnobs
 }
 
 // ModuleTestingKnobs is part of the base.ModuleTestingKnobs interface.


### PR DESCRIPTION
Backport 1/1 commits from #143706.

/cc @cockroachdb/release

---

This patch fixes an issue where the kv feed's writer could be closed
with ErrNormalRestartReason even though draining failed, which could
lead to boundary resolved span messages quietly not being delivered.

Fixes #141453

Test failures on master:
Fixes #139805
Fixes #140669
Fixes #142181
Fixes #142326
Fixes #142719
Fixes #142811
Fixes #143782

Test failures on release branches (won't be fixed until PR is backported):
Informs #139825
Informs #140796
Informs #141128
Informs #141412
Informs #141355
Informs #141891
Informs #142028
Informs #142032
Informs #142118

Release note: None

---

Release justification: low-risk, high-priority bug fix
