### PR TITLE
plpgsql: add support for set-returning functions

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/plpgsql_srf
+++ b/pkg/ccl/logictestccl/testdata/logic_test/plpgsql_srf
@@ -1,0 +1,591 @@
+statement ok
+CREATE TABLE xy (x INT, y INT);
+INSERT INTO xy VALUES (1, 2), (3, 4), (5, 6);
+
+statement ok
+CREATE TYPE typ AS (a INT);
+
+statement ok
+CREATE FUNCTION f() RETURNS SETOF INT LANGUAGE PLpgSQL AS $$ BEGIN RETURN QUERY SELECT 1; END $$;
+
+query I nosort
+SELECT f();
+----
+1
+
+query I nosort
+SELECT * FROM f();
+----
+1
+
+statement ok
+CREATE OR REPLACE FUNCTION f() RETURNS SETOF INT LANGUAGE PLpgSQL AS $$
+  BEGIN RETURN QUERY SELECT * FROM generate_series(1, 3); END
+$$;
+
+query I nosort
+SELECT f();
+----
+1
+2
+3
+
+query I nosort
+SELECT * FROM f();
+----
+1
+2
+3
+
+query II nosort
+SELECT * FROM f(), f();
+----
+1  1
+1  2
+1  3
+2  1
+2  2
+2  3
+3  1
+3  2
+3  3
+
+# Case with multiple RETURN QUERY statements. Expect rows to be in order.
+statement ok
+CREATE OR REPLACE FUNCTION f() RETURNS SETOF INT LANGUAGE PLpgSQL AS $$
+  BEGIN
+    RETURN QUERY SELECT * FROM generate_series(1, 3);
+    RETURN QUERY SELECT * FROM generate_series(4, 6);
+    RETURN QUERY SELECT * FROM generate_series(7, 9);
+  END
+$$;
+
+query I nosort
+SELECT f();
+----
+1
+2
+3
+4
+5
+6
+7
+8
+9
+
+query I nosort
+SELECT * FROM f();
+----
+1
+2
+3
+4
+5
+6
+7
+8
+9
+
+# RETURN NEXT should work as well.
+statement ok
+CREATE OR REPLACE FUNCTION f() RETURNS SETOF INT LANGUAGE PLpgSQL AS $$
+  BEGIN
+    RETURN NEXT 1;
+    RETURN NEXT 2;
+    RETURN NEXT 3;
+  END
+$$;
+
+query I nosort
+SELECT f();
+----
+1
+2
+3
+
+query I nosort
+SELECT * FROM f();
+----
+1
+2
+3
+
+# RETURN NEXT with an expression.
+statement ok
+CREATE OR REPLACE FUNCTION f() RETURNS SETOF INT LANGUAGE PLpgSQL AS $$
+  BEGIN
+    RETURN NEXT 1 + 1;
+    RETURN NEXT 2 + 2;
+    RETURN NEXT 3 + 3;
+  END
+$$;
+
+query I nosort
+SELECT f();
+----
+2
+4
+6
+
+query I nosort
+SELECT * FROM f();
+----
+2
+4
+6
+
+# RETURN NEXT with a subquery reading from a table.
+statement ok
+CREATE OR REPLACE FUNCTION f() RETURNS SETOF INT LANGUAGE PLpgSQL AS $$
+  BEGIN
+    RETURN NEXT (SELECT x FROM xy WHERE y = 2);
+    RETURN NEXT (SELECT x FROM xy WHERE y = 4);
+    RETURN NEXT (SELECT x FROM xy WHERE y = 6);
+  END
+$$;
+
+query I nosort
+SELECT f();
+----
+1
+3
+5
+
+query I nosort
+SELECT * FROM f();
+----
+1
+3
+5
+
+statement ok
+DROP FUNCTION f;
+
+# RETURN QUERY with a union.
+statement ok
+CREATE FUNCTION f() RETURNS SETOF INT LANGUAGE PLpgSQL AS $$
+  BEGIN
+    RETURN QUERY SELECT 1 UNION ALL SELECT 2 UNION ALL SELECT 3;
+  END
+$$;
+
+query I nosort
+SELECT f();
+----
+1
+2
+3
+
+query I nosort
+SELECT * FROM f();
+----
+1
+2
+3
+
+statement ok
+DROP FUNCTION f;
+
+# RETURN QUERY with a join.
+statement ok
+CREATE FUNCTION f() RETURNS SETOF RECORD LANGUAGE PLpgSQL AS $$
+  BEGIN
+    RETURN QUERY SELECT x, y FROM xy JOIN (SELECT 1 AS z UNION ALL SELECT 2) AS t ON xy.x = t.z;
+  END
+$$;
+
+query II nosort,colnames
+SELECT * FROM f() AS t(a INT, b INT);
+----
+a  b
+1  2
+
+statement ok
+DROP FUNCTION f;
+
+# RETURN QUERY with a CTE.
+statement ok
+CREATE FUNCTION f() RETURNS SETOF INT LANGUAGE PLpgSQL AS $$
+  BEGIN
+    RETURN QUERY WITH cte AS (SELECT 1 AS x UNION ALL SELECT 2) SELECT x FROM cte;
+  END
+$$;
+
+query I nosort
+SELECT f();
+----
+1
+2
+
+query I nosort
+SELECT * FROM f();
+----
+1
+2
+
+statement ok
+DROP FUNCTION f;
+
+# Parameterless RETURN can terminate the function early.
+statement ok
+CREATE FUNCTION f(b BOOL) RETURNS SETOF INT LANGUAGE PLpgSQL AS $$
+  BEGIN
+    RETURN NEXT 1;
+    IF b THEN
+      RETURN;
+    END IF;
+    RETURN NEXT 2;
+  END
+$$;
+
+query I nosort
+SELECT f(true);
+----
+1
+
+query I nosort
+SELECT f(false);
+----
+1
+2
+
+statement ok
+DROP FUNCTION f;
+
+# Test RETURN NEXT with a loop.
+statement ok
+CREATE FUNCTION f() RETURNS SETOF INT LANGUAGE PLpgSQL AS $$
+  DECLARE
+    i INT := 1;
+  BEGIN
+    WHILE i <= 3 LOOP
+      RETURN NEXT i;
+      i := i + 1;
+    END LOOP;
+  END
+$$;
+
+query I nosort
+SELECT f();
+----
+1
+2
+3
+
+query I nosort
+SELECT * FROM f();
+----
+1
+2
+3
+
+statement ok
+DROP FUNCTION f;
+
+# Test RETURN NEXT and RETURN QUERY with a combination of IF statements a loops.
+statement ok
+CREATE FUNCTION f() RETURNS SETOF INT LANGUAGE PLpgSQL AS $$
+  DECLARE
+    i INT := 0;
+  BEGIN
+    WHILE i < 3 LOOP
+      IF i = 0 THEN
+        RETURN NEXT 1;
+      ELSIF i = 1 THEN
+        RETURN QUERY SELECT 2;
+      ELSE
+        RETURN NEXT 3;
+      END IF;
+      i := i + 1;
+    END LOOP;
+  END
+$$;
+
+query I nosort
+SELECT f();
+----
+1
+2
+3
+
+statement ok
+DROP FUNCTION f;
+
+# Nesting function calls should not interfere with RETURN NEXT/QUERY.
+statement ok
+CREATE FUNCTION f_nested() RETURNS INT LANGUAGE PLpgSQL AS $$ BEGIN RAISE NOTICE 'foo'; RETURN 2; END $$;
+
+statement ok
+CREATE FUNCTION f() RETURNS SETOF INT LANGUAGE PLpgSQL AS $$
+  BEGIN
+    RETURN NEXT 1;
+    SELECT f_nested();
+    RETURN NEXT f_nested();
+    RETURN NEXT 3;
+    RETURN QUERY SELECT * FROM f_nested();
+  END
+$$;
+
+query I nosort
+SELECT f();
+----
+1
+2
+3
+2
+
+statement ok
+CREATE FUNCTION g() RETURNS SETOF INT LANGUAGE PLpgSQL AS $$
+  BEGIN
+    RETURN QUERY SELECT * FROM f();
+  END
+$$;
+
+query I nosort
+SELECT g();
+----
+1
+2
+3
+2
+
+statement ok
+DROP FUNCTION g;
+DROP FUNCTION f;
+DROP FUNCTION f_nested;
+
+subtest composite
+
+statement ok
+CREATE FUNCTION f() RETURNS SETOF xy LANGUAGE PLpgSQL AS $$
+  BEGIN
+    RETURN NEXT (1, 2);
+    RETURN NEXT (3, 4);
+    RETURN NEXT (5, 6);
+  END
+$$;
+
+query T nosort
+SELECT f();
+----
+(1,2)
+(3,4)
+(5,6)
+
+query II nosort
+SELECT * FROM f();
+----
+1  2
+3  4
+5  6
+
+statement ok
+DROP FUNCTION f;
+
+statement ok
+CREATE FUNCTION f() RETURNS SETOF typ LANGUAGE PLpgSQL AS $$
+  BEGIN
+    RETURN NEXT ROW(1);
+    RETURN QUERY SELECT 2;
+  END
+$$;
+
+query T nosort
+SELECT f();
+----
+(1)
+(2)
+
+query I nosort
+SELECT * FROM f();
+----
+1
+2
+
+statement ok
+DROP FUNCTION f;
+
+# Return TABLE.
+statement ok
+CREATE FUNCTION f() RETURNS TABLE (x INT, y INT) LANGUAGE PLpgSQL AS $$
+  BEGIN
+    RETURN QUERY SELECT * FROM xy ORDER BY x;
+  END
+$$;
+
+# TODO(144013): we should be able to use nosort here, but the ordering is
+# dropped.
+query T rowsort
+SELECT f();
+----
+(1,2)
+(3,4)
+(5,6)
+
+query II nosort
+SELECT * FROM f();
+----
+1  2
+3  4
+5  6
+
+statement ok
+DROP FUNCTION f;
+
+subtest end
+
+subtest record
+
+statement ok
+CREATE FUNCTION f() RETURNS SETOF RECORD LANGUAGE PLpgSQL AS $$
+  BEGIN
+    RETURN NEXT (1, 2);
+    RETURN NEXT (3, 4);
+    RETURN NEXT (5, 6);
+  END
+$$;
+
+query II nosort,colnames
+SELECT * FROM f() AS t(x INT, y INT);
+----
+x  y
+1  2
+3  4
+5  6
+
+statement ok
+DROP FUNCTION f;
+
+statement ok
+CREATE FUNCTION f() RETURNS SETOF RECORD LANGUAGE PLpgSQL AS $$
+  BEGIN
+    RETURN QUERY SELECT * FROM xy ORDER BY x;
+  END
+$$;
+
+query II nosort,colnames
+SELECT * FROM f() AS t(a INT, b INT);
+----
+a  b
+1  2
+3  4
+5  6
+
+statement ok
+DROP FUNCTION f;
+
+statement ok
+CREATE FUNCTION f() RETURNS SETOF RECORD LANGUAGE PLpgSQL AS $$
+  BEGIN
+    RETURN QUERY SELECT row(x, y)::xy FROM xy ORDER BY x;
+  END
+$$;
+
+query T nosort,colnames
+SELECT * FROM f() AS t(foo xy);
+----
+foo
+(1,2)
+(3,4)
+(5,6)
+
+statement ok
+DROP FUNCTION f;
+
+# Case with OUT parameters - the function doesn't have to be used as a data
+# source with a column definition list.
+statement ok
+CREATE FUNCTION f(OUT x INT, OUT y INT) RETURNS SETOF RECORD LANGUAGE PLpgSQL AS $$
+  BEGIN
+    RETURN QUERY SELECT 1, 2;
+    RETURN NEXT;
+    x := 100;
+    y := 200;
+    RETURN NEXT;
+    RETURN;
+  END
+$$;
+
+query T nosort,colnames
+SELECT f();
+----
+f
+(1,2)
+(,)
+(100,200)
+
+query II nosort,colnames
+SELECT * FROM f();
+----
+x     y
+1     2
+NULL  NULL
+100   200
+
+statement ok
+DROP FUNCTION f;
+
+subtest end
+
+subtest errors
+
+statement error pgcode 42804 pq: RETURN cannot have a parameter in a function returning set
+CREATE FUNCTION f() RETURNS SETOF INT LANGUAGE PLpgSQL AS $$ BEGIN RETURN 1; END $$;
+
+statement error pgcode 42804 pq: cannot use RETURN NEXT in a non-SETOF function
+CREATE FUNCTION f() RETURNS INT LANGUAGE PLpgSQL AS $$ BEGIN RETURN NEXT 1; END $$;
+
+statement error pgcode 42804 pq: cannot use RETURN QUERY in a non-SETOF function
+CREATE FUNCTION f() RETURNS INT LANGUAGE PLpgSQL AS $$ BEGIN RETURN QUERY SELECT 1; END $$;
+
+statement error pgcode 42804 pq: structure of query does not match function result type
+CREATE FUNCTION f() RETURNS SETOF INT LANGUAGE PLpgSQL AS $$ BEGIN RETURN QUERY SELECT True; END $$;
+
+statement error pgcode 42804 pq: structure of query does not match function result type
+CREATE FUNCTION f() RETURNS SETOF INT LANGUAGE PLpgSQL AS $$ BEGIN RETURN QUERY SELECT 1, 100; END $$;
+
+statement error pgcode 42804 pq: structure of query does not match function result type
+CREATE FUNCTION f() RETURNS SETOF xy LANGUAGE PLpgSQL AS $$ BEGIN RETURN QUERY SELECT 1; END $$;
+
+statement error pgcode 42804 pq: structure of query does not match function result type
+CREATE FUNCTION f() RETURNS SETOF xy LANGUAGE PLpgSQL AS $$
+  BEGIN
+    RETURN QUERY SELECT row(x, y)::xy FROM xy ORDER BY x;
+  END
+$$;
+
+statement ok
+CREATE FUNCTION f() RETURNS SETOF typ LANGUAGE PLpgSQL AS $$ BEGIN RETURN NEXT 1; END $$;
+
+# TODO(drewk): this error differs from Postgres. There should be a check for
+# non-NULL non-composite expressions in RETURN and RETURN NEXT statements.
+statement error pgcode 22P02 pq: could not parse "1" as type tuple{int AS a}: record must be enclosed in \( and \)
+SELECT f();
+
+statement ok
+DROP FUNCTION f;
+
+statement ok
+CREATE FUNCTION f() RETURNS SETOF RECORD LANGUAGE PLpgSQL AS $$ BEGIN RETURN QUERY SELECT 1, 2; END $$;
+
+statement error pgcode 0A000 materialize mode required, but it is not allowed in this context
+SELECT f();
+
+statement error pgcode 42601 pq: a column definition list is required for functions returning "record"
+SELECT * FROM f();
+
+# If the column types aren't given, it's not a column definition list.
+statement error pgcode 42601 pq: a column definition list is required for functions returning "record"
+SELECT * FROM f() AS g(foo, bar);
+
+statement ok
+DROP FUNCTION f;
+
+statement error pgcode 42804 pq: RETURN NEXT cannot have a parameter in function with OUT parameters
+CREATE FUNCTION f(OUT x INT, OUT y INT) RETURNS SETOF RECORD LANGUAGE PLpgSQL AS $$
+  BEGIN
+    RETURN NEXT ROW(3, 4);
+  END
+$$;
+
+subtest end

--- a/pkg/ccl/logictestccl/testdata/logic_test/plpgsql_unsupported
+++ b/pkg/ccl/logictestccl/testdata/logic_test/plpgsql_unsupported
@@ -10,12 +10,6 @@ CREATE OR REPLACE PROCEDURE foo() AS $$
   END
 $$ LANGUAGE PLpgSQL;
 
-statement error pq: unimplemented: set-returning PL/pgSQL functions
-CREATE OR REPLACE FUNCTION bar() RETURNS SETOF INT LANGUAGE PLpgSQL AS $$ BEGIN RETURN NEXT 100; END $$;
-
-statement error pq: unimplemented: set-returning PL/pgSQL functions
-CREATE OR REPLACE FUNCTION bar() RETURNS TABLE (x INT) LANGUAGE PLpgSQL AS $$ BEGIN RETURN NEXT 100; END $$;
-
 subtest error_detail
 
 # Regression test for #123672 - annotate "unsupported" errors with the

--- a/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
@@ -2801,6 +2801,13 @@ func TestTenantLogicCCL_plpgsql_record(
 	runCCLLogicTest(t, "plpgsql_record")
 }
 
+func TestTenantLogicCCL_plpgsql_srf(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "plpgsql_srf")
+}
+
 func TestTenantLogicCCL_plpgsql_txn(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/fakedist-disk/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/fakedist-disk/BUILD.bazel
@@ -12,7 +12,7 @@ go_test(
         "//build/toolchains:is_heavy": {"test.Pool": "heavy"},
         "//conditions:default": {"test.Pool": "large"},
     }),
-    shard_count = 32,
+    shard_count = 33,
     tags = ["cpu:2"],
     deps = [
         "//pkg/base",

--- a/pkg/ccl/logictestccl/tests/fakedist-disk/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/fakedist-disk/generated_test.go
@@ -173,6 +173,13 @@ func TestCCLLogic_plpgsql_record(
 	runCCLLogicTest(t, "plpgsql_record")
 }
 
+func TestCCLLogic_plpgsql_srf(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "plpgsql_srf")
+}
+
 func TestCCLLogic_plpgsql_txn(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/fakedist-vec-off/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/fakedist-vec-off/BUILD.bazel
@@ -12,7 +12,7 @@ go_test(
         "//build/toolchains:is_heavy": {"test.Pool": "heavy"},
         "//conditions:default": {"test.Pool": "large"},
     }),
-    shard_count = 32,
+    shard_count = 33,
     tags = ["cpu:2"],
     deps = [
         "//pkg/base",

--- a/pkg/ccl/logictestccl/tests/fakedist-vec-off/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/fakedist-vec-off/generated_test.go
@@ -173,6 +173,13 @@ func TestCCLLogic_plpgsql_record(
 	runCCLLogicTest(t, "plpgsql_record")
 }
 
+func TestCCLLogic_plpgsql_srf(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "plpgsql_srf")
+}
+
 func TestCCLLogic_plpgsql_txn(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/fakedist/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/fakedist/BUILD.bazel
@@ -12,7 +12,7 @@ go_test(
         "//build/toolchains:is_heavy": {"test.Pool": "heavy"},
         "//conditions:default": {"test.Pool": "large"},
     }),
-    shard_count = 33,
+    shard_count = 34,
     tags = ["cpu:2"],
     deps = [
         "//pkg/base",

--- a/pkg/ccl/logictestccl/tests/fakedist/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/fakedist/generated_test.go
@@ -180,6 +180,13 @@ func TestCCLLogic_plpgsql_record(
 	runCCLLogicTest(t, "plpgsql_record")
 }
 
+func TestCCLLogic_plpgsql_srf(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "plpgsql_srf")
+}
+
 func TestCCLLogic_plpgsql_txn(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/local-legacy-schema-changer/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/local-legacy-schema-changer/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
         "//pkg/ccl/logictestccl:testdata",  # keep
     ],
     exec_properties = {"test.Pool": "large"},
-    shard_count = 31,
+    shard_count = 32,
     tags = ["cpu:1"],
     deps = [
         "//pkg/base",

--- a/pkg/ccl/logictestccl/tests/local-legacy-schema-changer/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/local-legacy-schema-changer/generated_test.go
@@ -173,6 +173,13 @@ func TestCCLLogic_plpgsql_record(
 	runCCLLogicTest(t, "plpgsql_record")
 }
 
+func TestCCLLogic_plpgsql_srf(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "plpgsql_srf")
+}
+
 func TestCCLLogic_plpgsql_txn(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/local-mixed-24.3/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/local-mixed-24.3/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
         "//pkg/ccl/logictestccl:testdata",  # keep
     ],
     exec_properties = {"test.Pool": "large"},
-    shard_count = 32,
+    shard_count = 33,
     tags = ["cpu:1"],
     deps = [
         "//pkg/base",

--- a/pkg/ccl/logictestccl/tests/local-mixed-24.3/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/local-mixed-24.3/generated_test.go
@@ -173,6 +173,13 @@ func TestCCLLogic_plpgsql_record(
 	runCCLLogicTest(t, "plpgsql_record")
 }
 
+func TestCCLLogic_plpgsql_srf(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "plpgsql_srf")
+}
+
 func TestCCLLogic_plpgsql_txn(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/local-mixed-25.1/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/local-mixed-25.1/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
         "//pkg/ccl/logictestccl:testdata",  # keep
     ],
     exec_properties = {"test.Pool": "large"},
-    shard_count = 32,
+    shard_count = 33,
     tags = ["cpu:1"],
     deps = [
         "//pkg/base",

--- a/pkg/ccl/logictestccl/tests/local-mixed-25.1/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/local-mixed-25.1/generated_test.go
@@ -173,6 +173,13 @@ func TestCCLLogic_plpgsql_record(
 	runCCLLogicTest(t, "plpgsql_record")
 }
 
+func TestCCLLogic_plpgsql_srf(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "plpgsql_srf")
+}
+
 func TestCCLLogic_plpgsql_txn(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/local-read-committed/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/local-read-committed/generated_test.go
@@ -2757,6 +2757,13 @@ func TestReadCommittedLogicCCL_plpgsql_record(
 	runCCLLogicTest(t, "plpgsql_record")
 }
 
+func TestReadCommittedLogicCCL_plpgsql_srf(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "plpgsql_srf")
+}
+
 func TestReadCommittedLogicCCL_plpgsql_txn(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/local-repeatable-read/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/local-repeatable-read/generated_test.go
@@ -2750,6 +2750,13 @@ func TestRepeatableReadLogicCCL_plpgsql_record(
 	runCCLLogicTest(t, "plpgsql_record")
 }
 
+func TestRepeatableReadLogicCCL_plpgsql_srf(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "plpgsql_srf")
+}
+
 func TestRepeatableReadLogicCCL_plpgsql_txn(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/local-vec-off/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/local-vec-off/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
         "//pkg/ccl/logictestccl:testdata",  # keep
     ],
     exec_properties = {"test.Pool": "large"},
-    shard_count = 32,
+    shard_count = 33,
     tags = ["cpu:1"],
     deps = [
         "//pkg/base",

--- a/pkg/ccl/logictestccl/tests/local-vec-off/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/local-vec-off/generated_test.go
@@ -173,6 +173,13 @@ func TestCCLLogic_plpgsql_record(
 	runCCLLogicTest(t, "plpgsql_record")
 }
 
+func TestCCLLogic_plpgsql_srf(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "plpgsql_srf")
+}
+
 func TestCCLLogic_plpgsql_txn(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/local/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/local/generated_test.go
@@ -264,6 +264,13 @@ func TestCCLLogic_plpgsql_record(
 	runCCLLogicTest(t, "plpgsql_record")
 }
 
+func TestCCLLogic_plpgsql_srf(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "plpgsql_srf")
+}
+
 func TestCCLLogic_plpgsql_txn(
 	t *testing.T,
 ) {

--- a/pkg/sql/opt/exec/execbuilder/builder.go
+++ b/pkg/sql/opt/exec/execbuilder/builder.go
@@ -94,6 +94,10 @@ type Builder struct {
 	// rather than scans.
 	withExprs []builtWithExpr
 
+	// routineResultBuffers allows expressions within the body of a set-returning
+	// PL/pgSQL function to add to the result set during execution.
+	routineResultBuffers map[memo.RoutineResultBufferID]tree.RoutineResultWriter
+
 	// allowAutoCommit is passed through to factory methods for mutation
 	// operators. It allows execution to commit the transaction as part of the
 	// mutation itself. See canAutoCommit().

--- a/pkg/sql/opt/memo/interner.go
+++ b/pkg/sql/opt/memo/interner.go
@@ -1343,16 +1343,21 @@ func (h *hasher) IsUDFDefinitionEqual(l, r *UDFDefinition) bool {
 	} else if r.ExceptionBlock != nil {
 		return false
 	}
-	if l.CursorDeclaration != nil {
-		if r.CursorDeclaration == nil {
+	leftCursDec := l.FirstStmtOutput.CursorDeclaration
+	rightCursDec := r.FirstStmtOutput.CursorDeclaration
+	if leftCursDec != nil {
+		if rightCursDec == nil {
 			return false
 		}
-		if l.CursorDeclaration.NameArgIdx != r.CursorDeclaration.NameArgIdx ||
-			l.CursorDeclaration.Scroll != r.CursorDeclaration.Scroll ||
-			l.CursorDeclaration.CursorSQL != r.CursorDeclaration.CursorSQL {
+		if leftCursDec.NameArgIdx != rightCursDec.NameArgIdx ||
+			leftCursDec.Scroll != rightCursDec.Scroll ||
+			leftCursDec.CursorSQL != rightCursDec.CursorSQL {
 			return false
 		}
-	} else if r.CursorDeclaration != nil {
+	} else if rightCursDec != nil {
+		return false
+	}
+	if l.FirstStmtOutput.TargetBufferID != r.FirstStmtOutput.TargetBufferID {
 		return false
 	}
 	return h.IsColListEqual(l.Params, r.Params) && l.IsRecursive == r.IsRecursive

--- a/pkg/sql/opt/memo/memo.go
+++ b/pkg/sql/opt/memo/memo.go
@@ -217,6 +217,10 @@ type Memo struct {
 	// curWithID is the highest currently in-use WITH ID.
 	curWithID opt.WithID
 
+	// curRoutineResultBufferID is the highest currently in-use routine result
+	// buffer ID. See the RoutineResultBufferID comment for more details.
+	curRoutineResultBufferID RoutineResultBufferID
+
 	newGroupFn func(opt.Expr)
 
 	// disableCheckExpr disables expression validation performed by CheckExpr,
@@ -563,14 +567,12 @@ func (m *Memo) NextRank() opt.ScalarRank {
 	return m.curRank
 }
 
-// CopyNextRankFrom copies the next ScalarRank from the other memo.
-func (m *Memo) CopyNextRankFrom(other *Memo) {
+// CopyRankAndIDsFrom copies the next ScalarRank, WithID, and
+// RoutineResultBufferID from the other memo.
+func (m *Memo) CopyRankAndIDsFrom(other *Memo) {
 	m.curRank = other.curRank
-}
-
-// CopyNextWithIDFrom copies the next WithID from the other memo.
-func (m *Memo) CopyNextWithIDFrom(other *Memo) {
 	m.curWithID = other.curWithID
+	m.curRoutineResultBufferID = other.curRoutineResultBufferID
 }
 
 // RequestColStat calculates and returns the column statistic calculated on the
@@ -612,6 +614,13 @@ func (m *Memo) RowsProcessed(expr RelExpr) (_ float64, ok bool) {
 func (m *Memo) NextWithID() opt.WithID {
 	m.curWithID++
 	return m.curWithID
+}
+
+// NextRoutineResultBufferID returns a not-yet-assigned identifier for the
+// result buffer of a PL/pgSQL set-returning function.
+func (m *Memo) NextRoutineResultBufferID() RoutineResultBufferID {
+	m.curRoutineResultBufferID++
+	return m.curRoutineResultBufferID
 }
 
 // Detach is used when we detach a memo that is to be reused later (either for

--- a/pkg/sql/opt/norm/factory.go
+++ b/pkg/sql/opt/norm/factory.go
@@ -317,14 +317,10 @@ func (f *Factory) CopyMetadataFrom(from *memo.Memo) {
 		panic(errors.AssertionFailedf("destination memo must be empty"))
 	}
 
-	// Copy the next scalar rank to the target memo so that new scalar
-	// expressions built with the new memo will not share scalar ranks with
-	// existing expressions.
-	f.mem.CopyNextRankFrom(from)
-
-	// Copy the next With ID to the target memo so that new CTE expressions built
-	// with the new memo will not share With IDs with existing expressions.
-	f.mem.CopyNextWithIDFrom(from)
+	// Copy the next scalar rank, With ID, and routine buffer ID to the target
+	// memo so that new expressions built with the new memo will not share scalar
+	// ranks, With IDs, or routine buffer IDs with existing expressions.
+	f.mem.CopyRankAndIDsFrom(from)
 
 	// Copy all metadata to the target memo so that referenced tables and
 	// columns can keep the same ids they had in the "from" memo. Scalar

--- a/pkg/sql/opt/optbuilder/create_function.go
+++ b/pkg/sql/opt/optbuilder/create_function.go
@@ -360,6 +360,7 @@ func (b *Builder) buildCreateFunction(cf *tree.CreateRoutine, inScope *scope) (o
 		typeDeps.Add(int(id))
 	})
 
+	isSetReturning := cf.ReturnType != nil && cf.ReturnType.SetOf
 	targetVolatility := tree.GetRoutineVolatility(cf.Options)
 	fmtCtx := tree.NewFmtCtx(tree.FmtSerializable)
 
@@ -401,13 +402,6 @@ func (b *Builder) buildCreateFunction(cf *tree.CreateRoutine, inScope *scope) (o
 			afterBuildStmt()
 		}
 	case tree.RoutineLangPLpgSQL:
-		if cf.ReturnType != nil && cf.ReturnType.SetOf {
-			panic(unimplemented.NewWithIssueDetail(105240,
-				"set-returning PL/pgSQL functions",
-				"set-returning PL/pgSQL functions are not yet supported",
-			))
-		}
-
 		// Parse the function body.
 		stmt, err := plpgsqlparser.Parse(funcBodyStr)
 		if err != nil {
@@ -456,13 +450,14 @@ func (b *Builder) buildCreateFunction(cf *tree.CreateRoutine, inScope *scope) (o
 		// volatility of stable functions. If folded, we only get a scalar and lose
 		// the volatility.
 		options := basePLOptions().
-      SetIsProcedure(cf.IsProcedure).
-      SetIsTriggerFn(isTriggerFn).
-      SetSkipSQL(skipSQL)
+			SetIsSetReturning(isSetReturning).
+			SetIsProcedure(cf.IsProcedure).
+			SetIsTriggerFn(isTriggerFn).
+			SetSkipSQL(skipSQL)
 		b.factory.FoldingControl().TemporarilyDisallowStableFolds(func() {
 			plBuilder := newPLpgSQLBuilder(
 				b, options, cf.Name.Object(), stmt.AST.Label, nil /* colRefs */, routineParams,
-				funcReturnType, nil, /* outScope */
+				funcReturnType, nil /* outScope */, 0, /* resultBufferID */
 			)
 			stmtScope = plBuilder.buildRootBlock(stmt.AST, bodyScope, routineParams)
 		})
@@ -475,9 +470,12 @@ func (b *Builder) buildCreateFunction(cf *tree.CreateRoutine, inScope *scope) (o
 		panic(errors.AssertionFailedf("unexpected language: %v", language))
 	}
 
-	if stmtScope != nil {
+	if stmtScope != nil && (language != tree.RoutineLangPLpgSQL || !isSetReturning) {
 		// Validate that the result type of the last statement matches the
-		// return type of the function.
+		// return type of the function. We skip this validation for PL/pgSQL SRFs
+		// because those handle their own validation, and do not return a result
+		// directly from their last body statement anyway.
+		//
 		// TODO(mgartner): stmtScope.cols does not describe the result
 		// columns of the statement. We should use physical.Presentation
 		// instead.

--- a/pkg/sql/opt/optbuilder/create_function.go
+++ b/pkg/sql/opt/optbuilder/create_function.go
@@ -427,8 +427,7 @@ func (b *Builder) buildCreateFunction(cf *tree.CreateRoutine, inScope *scope) (o
 		}
 
 		// Special handling for trigger functions.
-		buildSQL := true
-		isTriggerFn := false
+		var skipSQL, isTriggerFn bool
 		if funcReturnType.Identical(types.Trigger) {
 			// Trigger functions cannot have user-defined parameters. However, they do
 			// have a set of implicitly defined parameters.
@@ -449,17 +448,21 @@ func (b *Builder) buildCreateFunction(cf *tree.CreateRoutine, inScope *scope) (o
 
 			// Analysis of SQL expressions for trigger functions must be deferred
 			// until the function is bound to a trigger.
-			buildSQL = false
 			isTriggerFn = true
+			skipSQL = true
 		}
 
 		// We need to disable stable function folding because we want to catch the
 		// volatility of stable functions. If folded, we only get a scalar and lose
 		// the volatility.
+		options := basePLOptions().
+      SetIsProcedure(cf.IsProcedure).
+      SetIsTriggerFn(isTriggerFn).
+      SetSkipSQL(skipSQL)
 		b.factory.FoldingControl().TemporarilyDisallowStableFolds(func() {
 			plBuilder := newPLpgSQLBuilder(
-				b, cf.Name.Object(), stmt.AST.Label, nil /* colRefs */, routineParams, funcReturnType,
-				cf.IsProcedure, false /* isDoBlock */, isTriggerFn, buildSQL, nil, /* outScope */
+				b, options, cf.Name.Object(), stmt.AST.Label, nil /* colRefs */, routineParams,
+				funcReturnType, nil, /* outScope */
 			)
 			stmtScope = plBuilder.buildRootBlock(stmt.AST, bodyScope, routineParams)
 		})

--- a/pkg/sql/opt/optbuilder/create_trigger.go
+++ b/pkg/sql/opt/optbuilder/create_trigger.go
@@ -244,9 +244,8 @@ func (b *Builder) buildFunctionForTrigger(
 	}
 	b.factory.FoldingControl().TemporarilyDisallowStableFolds(func() {
 		plBuilder := newPLpgSQLBuilder(
-			b, ct.FuncName.String(), stmt.AST.Label, nil /* colRefs */, triggerFuncParams, tableTyp,
-			false /* isProcedure */, false, /* isDoBlock */
-			true /* isTriggerFn */, true /* buildSQL */, nil, /* outScope */
+			b, basePLOptions().WithIsTriggerFn(), ct.FuncName.String(), stmt.AST.Label,
+			nil /* colRefs */, triggerFuncParams, tableTyp, nil, /* outScope */
 		)
 		funcScope = plBuilder.buildRootBlock(stmt.AST, funcScope, triggerFuncParams)
 	})

--- a/pkg/sql/opt/optbuilder/create_trigger.go
+++ b/pkg/sql/opt/optbuilder/create_trigger.go
@@ -245,7 +245,7 @@ func (b *Builder) buildFunctionForTrigger(
 	b.factory.FoldingControl().TemporarilyDisallowStableFolds(func() {
 		plBuilder := newPLpgSQLBuilder(
 			b, basePLOptions().WithIsTriggerFn(), ct.FuncName.String(), stmt.AST.Label,
-			nil /* colRefs */, triggerFuncParams, tableTyp, nil, /* outScope */
+			nil /* colRefs */, triggerFuncParams, tableTyp, nil /* outScope */, 0, /* resultBufferID */
 		)
 		funcScope = plBuilder.buildRootBlock(stmt.AST, funcScope, triggerFuncParams)
 	})

--- a/pkg/sql/opt/optbuilder/plpgsql.go
+++ b/pkg/sql/opt/optbuilder/plpgsql.go
@@ -929,7 +929,7 @@ func (b *plpgsqlBuilder) buildPLpgSQLStatements(stmts []ast.Statement, s *scope)
 			query := b.resolveOpenQuery(t)
 			fmtCtx := b.ob.evalCtx.FmtCtx(tree.FmtSimple)
 			fmtCtx.FormatNode(query)
-			openCon.def.CursorDeclaration = &tree.RoutineOpenCursor{
+			openCon.def.FirstStmtOutput.CursorDeclaration = &tree.RoutineOpenCursor{
 				NameArgIdx: source.(*scopeColumn).getParamOrd(),
 				Scroll:     t.Scroll,
 				CursorSQL:  fmtCtx.CloseAndGetString(),

--- a/pkg/sql/opt/optbuilder/plpgsql.go
+++ b/pkg/sql/opt/optbuilder/plpgsql.go
@@ -1168,8 +1168,8 @@ func (b *plpgsqlBuilder) buildPLpgSQLStatements(stmts []ast.Statement, s *scope)
 			// statement, and then the following PL/pgSQL statements in the second.
 			doCon := b.makeContinuation("_stmt_do")
 			doCon.def.Volatility = volatility.Volatile
-			body, bodyProps := b.ob.buildPLpgSQLDoBody(t)
-			b.appendBodyStmt(&doCon, body, bodyProps)
+			bodyScope := b.ob.buildPLpgSQLDoBody(t)
+			b.appendBodyStmtFromScope(&doCon, bodyScope)
 			b.appendPlpgSQLStmts(&doCon, stmts[i+1:])
 			return b.callContinuation(&doCon, s)
 
@@ -2124,31 +2124,24 @@ func (b *plpgsqlBuilder) makeContinuationWithTyp(
 	return con
 }
 
-// appendBodyStmt adds the given body statement and its required properties to
-// the definition of a continuation function. Only the last body statement will
-// return results; all others will only be executed for their side effects
-// (e.g. RAISE statement).
+// appendBodyStmtFromScope adds the given body statement and its required
+// properties from the given scope to the definition of a continuation function.
+// Only the last body statement will return results; all others will only be
+// executed for their side effects (e.g. RAISE statement).
 //
-// appendBodyStmt is separate from makeContinuation to allow recursive routine
-// definitions, which need to push the continuation before it is finished. The
-// separation also allows for appending multiple body statements.
-func (b *plpgsqlBuilder) appendBodyStmt(
-	con *continuation, body memo.RelExpr, bodyProps *physical.Required,
-) {
+// appendBodyStmtFromScope is separate from makeContinuation to allow recursive
+// routine definitions, which need to push the continuation before it is
+// finished. The separation also allows for appending multiple body statements.
+func (b *plpgsqlBuilder) appendBodyStmtFromScope(con *continuation, bodyScope *scope) {
 	// Set the volatility of the continuation routine to the least restrictive
 	// volatility level in the Relational properties of the body statements.
-	vol := body.Relational().VolatilitySet.ToVolatility()
+	bodyExpr := bodyScope.expr
+	vol := bodyExpr.Relational().VolatilitySet.ToVolatility()
 	if con.def.Volatility < vol {
 		con.def.Volatility = vol
 	}
-	con.def.Body = append(con.def.Body, body)
-	con.def.BodyProps = append(con.def.BodyProps, bodyProps)
-}
-
-// appendBodyStmtFromScope is similar to appendBodyStmt, but retrieves the body
-// statement its required properties from the given scope for convenience.
-func (b *plpgsqlBuilder) appendBodyStmtFromScope(con *continuation, bodyScope *scope) {
-	b.appendBodyStmt(con, bodyScope.expr, bodyScope.makePhysicalProps())
+	con.def.Body = append(con.def.Body, bodyExpr)
+	con.def.BodyProps = append(con.def.BodyProps, bodyScope.makePhysicalProps())
 }
 
 // appendPlpgSQLStmts builds the given PLpgSQL statements into a relational

--- a/pkg/sql/opt/optbuilder/plpgsql.go
+++ b/pkg/sql/opt/optbuilder/plpgsql.go
@@ -163,8 +163,15 @@ type plpgsqlBuilder struct {
 	// expressions.
 	colRefs *opt.ColSet
 
-	// returnType is the return type of the PL/pgSQL routine.
+	// returnType is the return type of the sub-routines that implement the
+	// PL/pgSQL routine. This is normally the same as the return type of the
+	// routine, but can be different in the case of a set-returning function, in
+	// which case it is types.Void.
 	returnType *types.T
+
+	// setReturnType, if set, is the return type of the set-returning function.
+	// It identifies the type of RETURN NEXT and RETURN QUERY statements.
+	setReturnType *types.T
 
 	// continuations is a stack of sub-routines that are called to resume
 	// execution from a certain point within the PL/pgSQL routine. For example,
@@ -190,6 +197,12 @@ type plpgsqlBuilder struct {
 	// building their body statements.
 	outScope *scope
 
+	// resultBufferID, if nonzero, uniquely identifies the result buffer for the
+	// set-returning PL/pgSQL function that is being built. Sub-routines may use
+	// this ID to add to the result set at arbitrary points during execution. This
+	// is how RETURN NEXT and RETURN QUERY are implemented.
+	resultBufferID memo.RoutineResultBufferID
+
 	routineName  string
 	identCounter int
 }
@@ -197,9 +210,11 @@ type plpgsqlBuilder struct {
 // plOptions is a set of options that can be used to modify the behavior of the
 // PLpgSQL builder.
 type plOptions struct {
-	isProcedure bool
-	isDoBlock   bool
-	isTriggerFn bool
+	isSetReturning   bool
+	insideDataSource bool
+	isProcedure      bool
+	isTriggerFn      bool
+	isDoBlock        bool
 
 	// skipSQL is true if SQL statements and expressions should not be built.
 	// This is used during trigger function creation.
@@ -209,6 +224,20 @@ type plOptions struct {
 // basePLOptions returns a new plOptions struct with default values.
 func basePLOptions() plOptions {
 	return plOptions{}
+}
+
+// SetIsSetReturning returns a new plOptions struct with the isSetReturning flag
+// set to the given value.
+func (opts plOptions) SetIsSetReturning(isSetReturning bool) plOptions {
+	opts.isSetReturning = isSetReturning
+	return opts
+}
+
+// SetInsideDataSource returns a new plOptions struct with the insideDataSource
+// flag set to the given value.
+func (opts plOptions) SetInsideDataSource(insideDataSource bool) plOptions {
+	opts.insideDataSource = insideDataSource
+	return opts
 }
 
 // WithIsProcedure returns a new plOptions struct with the isProcedure flag set
@@ -268,16 +297,26 @@ func newPLpgSQLBuilder(
 	routineParams []routineParam,
 	returnType *types.T,
 	outScope *scope,
+	resultBufferID memo.RoutineResultBufferID,
 ) *plpgsqlBuilder {
 	const initialBlocksCap = 2
 	b := &plpgsqlBuilder{
-		ob:          ob,
-		options:     options,
-		colRefs:     colRefs,
-		returnType:  returnType,
-		blocks:      make([]plBlock, 0, initialBlocksCap),
-		routineName: routineName,
-		outScope:    outScope,
+		ob:             ob,
+		options:        options,
+		colRefs:        colRefs,
+		returnType:     returnType,
+		blocks:         make([]plBlock, 0, initialBlocksCap),
+		routineName:    routineName,
+		outScope:       outScope,
+		resultBufferID: resultBufferID,
+	}
+	if options.isSetReturning {
+		// The sub-routines for a set-returning PL/pgSQL function return VOID, since
+		// they don't return a value directly. Results are added to the result set
+		// by RETURN NEXT and RETURN QUERY statements instead; see their
+		// implementations in buildPLpgSQLStatements for details.
+		b.returnType = types.Void
+		b.setReturnType = returnType
 	}
 	// Build the initial block for the routine parameters, which are considered
 	// PL/pgSQL variables.
@@ -494,7 +533,15 @@ func (b *plpgsqlBuilder) buildBlock(astBlock *ast.Block, s *scope) *scope {
 	// For a RECORD-returning routine, infer the concrete type by examining the
 	// RETURN statements. This has to happen after building the declaration
 	// block because RETURN statements can reference declared variables.
-	if b.returnType.Identical(types.AnyTuple) {
+	returnType := b.returnType
+	if b.options.isSetReturning {
+		returnType = b.setReturnType
+		if !b.ob.insideFuncDef && returnType.Identical(types.AnyTuple) {
+			panic(errors.AssertionFailedf(
+				"set-returning PL/pgSQL function should have a concrete return type by now",
+			))
+		}
+	} else if returnType.Identical(types.AnyTuple) {
 		recordVisitor := newRecordTypeVisitor(b.ob.ctx, b.ob.semaCtx, s, astBlock)
 		ast.Walk(recordVisitor, astBlock)
 		if rtyp := recordVisitor.typ; rtyp == nil || rtyp.Identical(types.AnyTuple) {
@@ -563,16 +610,22 @@ func (b *plpgsqlBuilder) buildPLpgSQLStatements(stmts []ast.Statement, s *scope)
 			return scope
 
 		case *ast.Return:
-			// If the routine has OUT-parameters or a VOID return type, the RETURN
-			// statement must have no expression. Otherwise, the RETURN statement must
-			// have a non-empty expression.
+			// If the routine has OUT-parameters, a VOID return type, or returns a
+			// set, the RETURN statement must have no expression. Otherwise, the
+			// RETURN statement must have a non-empty expression.
 			expr := t.Expr
-			if b.hasOutParam() {
+			switch {
+			case b.options.isSetReturning:
+				if expr != nil {
+					panic(returnWithReturnsSetErr)
+				}
+				expr = tree.DNull
+			case b.hasOutParam():
 				if expr != nil {
 					panic(returnWithOUTParameterErr)
 				}
 				expr = b.makeReturnForOutParams()
-			} else if b.returnType.Family() == types.VoidFamily {
+			case b.returnType.Family() == types.VoidFamily:
 				if expr != nil {
 					if b.options.isProcedure {
 						panic(returnWithVoidParameterProcedureErr)
@@ -581,9 +634,10 @@ func (b *plpgsqlBuilder) buildPLpgSQLStatements(stmts []ast.Statement, s *scope)
 					}
 				}
 				expr = tree.DNull
-			}
-			if expr == nil {
-				panic(emptyReturnErr)
+			default:
+				if expr == nil {
+					panic(emptyReturnErr)
+				}
 			}
 			// RETURN is handled by projecting a single column with the expression
 			// that is being returned.
@@ -594,6 +648,78 @@ func (b *plpgsqlBuilder) buildPLpgSQLStatements(stmts []ast.Statement, s *scope)
 			b.ob.synthesizeColumn(returnScope, returnColName, b.returnType, nil /* expr */, returnScalar)
 			b.ob.constructProjectForScope(s, returnScope)
 			return returnScope
+
+		case *ast.ReturnNext:
+			if !b.options.isSetReturning {
+				panic(returnNextScalarErr)
+			}
+			expr := t.Expr
+			if b.hasOutParam() {
+				// A set-returning routine with OUT parameters returns those parameters
+				// instead of an expression in a RETURN NEXT statement.
+				if expr != nil {
+					panic(returnNextWithOUTParameterErr)
+				}
+				expr = b.makeReturnForOutParams()
+			}
+			// RETURN NEXT is handled by projecting a single column with the return
+			// expression. This becomes the first body statement of a new continuation
+			// with output redirected to the result buffer.
+			retCon := b.makeContinuation("return_next")
+			retCon.def.FirstStmtOutput.TargetBufferID = b.resultBufferID
+			returnScalar := b.buildSQLExpr(expr, b.setReturnType, retCon.s)
+			retColName := scopeColName("").WithMetadataName(b.makeIdentifier("stmt_return_next"))
+			retNextScope := retCon.s.push()
+			b.ob.synthesizeColumn(retNextScope, retColName, b.setReturnType, nil /* expr */, returnScalar)
+			b.ob.constructProjectForScope(retCon.s, retNextScope)
+			if b.options.insideDataSource && b.setReturnType.Family() == types.TupleFamily {
+				retNextScope = b.ob.expandRoutineTupleIntoCols(retNextScope)
+			}
+			b.appendBodyStmtFromScope(&retCon, retNextScope)
+			b.appendPlpgSQLStmts(&retCon, stmts[i+1:])
+			return b.callContinuation(&retCon, s)
+
+		case *ast.ReturnQuery:
+			if !b.options.isSetReturning {
+				panic(returnQueryScalarErr)
+			}
+			// RETURN QUERY is handled by building the query into the first body
+			// statement of a new continuation. The output of the query is redirected
+			// to the result buffer.
+			retCon := b.makeContinuation("return_next")
+			retCon.def.FirstStmtOutput.TargetBufferID = b.resultBufferID
+			retQueryScope := b.buildSQLStatement(t.SqlStmt, retCon.s)
+			if !b.setReturnType.Identical(types.AnyTuple) {
+				// The query must be validated against the expected return type. Do not
+				// validate during creation of a RECORD-returning function, since the
+				// return type is not known until the function is invoked.
+				var expectedTypes []*types.T
+				if b.setReturnType.Family() == types.TupleFamily {
+					expectedTypes = b.setReturnType.TupleContents()
+				} else {
+					expectedTypes = []*types.T{b.setReturnType}
+				}
+				if len(retQueryScope.cols) != len(expectedTypes) {
+					panic(errors.WithDetailf(returnQueryBaseErr,
+						"Number of returned columns (%d) does not match expected column count (%d).",
+						len(retQueryScope.cols), len(expectedTypes),
+					))
+				}
+				for colIdx := range retQueryScope.cols {
+					colTyp := retQueryScope.cols[colIdx].typ
+					if !colTyp.Identical(expectedTypes[colIdx]) {
+						panic(errors.WithDetailf(returnQueryBaseErr,
+							"Returned type %v does not match expected type %v in column %d.",
+							colTyp.SQLStringForError(), expectedTypes[colIdx].SQLStringForError(), colIdx+1))
+					}
+				}
+			}
+			if !b.options.insideDataSource && b.setReturnType.Family() == types.TupleFamily {
+				retQueryScope = b.ob.combineRoutineColsIntoTuple(retQueryScope)
+			}
+			b.appendBodyStmtFromScope(&retCon, retQueryScope)
+			b.appendPlpgSQLStmts(&retCon, stmts[i+1:])
+			return b.callContinuation(&retCon, s)
 
 		case *ast.Assignment:
 			// Assignment (:=) is handled by projecting a new column with the same
@@ -1843,11 +1969,11 @@ func (b *plpgsqlBuilder) buildExceptions(block *ast.Block) *memo.ExceptionBlock 
 // handleEndOfFunction handles the case when control flow reaches the end of a
 // PL/pgSQL routine without reaching a RETURN statement.
 func (b *plpgsqlBuilder) handleEndOfFunction(inScope *scope) *scope {
-	if b.hasOutParam() || b.returnType.Family() == types.VoidFamily {
-		// Routines with OUT-parameters and VOID return types need not explicitly
-		// specify a RETURN statement.
+	if b.options.isSetReturning || b.hasOutParam() || b.returnType.Family() == types.VoidFamily {
+		// Routines that return VOID, or have OUT parameters, or are set-returning
+		// functions need not explicitly specify a RETURN statement.
 		var returnExpr tree.Expr = tree.DNull
-		if b.hasOutParam() {
+		if b.hasOutParam() && !b.options.isSetReturning {
 			returnExpr = b.makeReturnForOutParams()
 		}
 		returnScope := inScope.push()
@@ -2780,6 +2906,21 @@ var (
 	)
 	returnWithVoidParameterProcedureErr = pgerror.New(pgcode.Syntax,
 		"RETURN cannot have a parameter in a procedure")
+	returnWithReturnsSetErr = pgerror.New(pgcode.DatatypeMismatch,
+		"RETURN cannot have a parameter in a function returning set",
+	)
+	returnQueryBaseErr = pgerror.New(pgcode.DatatypeMismatch,
+		"structure of query does not match function result type",
+	)
+	returnNextScalarErr = pgerror.New(pgcode.DatatypeMismatch,
+		"cannot use RETURN NEXT in a non-SETOF function",
+	)
+	returnQueryScalarErr = pgerror.New(pgcode.DatatypeMismatch,
+		"cannot use RETURN QUERY in a non-SETOF function",
+	)
+	returnNextWithOUTParameterErr = pgerror.New(pgcode.DatatypeMismatch,
+		"RETURN NEXT cannot have a parameter in function with OUT parameters",
+	)
 	emptyReturnErr = pgerror.New(pgcode.Syntax,
 		"missing expression at or near \"RETURN;\"",
 	)

--- a/pkg/sql/opt/optbuilder/routine.go
+++ b/pkg/sql/opt/optbuilder/routine.go
@@ -11,7 +11,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
-	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/props/physical"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser/statements"
@@ -23,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/volatility"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 	"github.com/cockroachdb/errors"
 )
@@ -405,17 +405,14 @@ func (b *Builder) buildRoutine(
 
 		for i := range stmts {
 			stmtScope := b.buildStmtAtRootWithScope(stmts[i].AST, nil /* desiredTypes */, bodyScope)
-			expr, physProps := stmtScope.expr, stmtScope.makePhysicalProps()
 
 			// The last statement produces the output of the UDF.
 			if i == len(stmts)-1 {
 				rTyp := b.finalizeRoutineReturnType(f, stmtScope, inScope, oldInsideDataSource)
-				expr, physProps = b.finishBuildLastStmt(
-					stmtScope, bodyScope, isSetReturning, oldInsideDataSource, rTyp,
-				)
+				stmtScope = b.finishRoutineReturnStmt(stmtScope, isSetReturning, oldInsideDataSource, rTyp)
 			}
-			body[i] = expr
-			bodyProps[i] = physProps
+			body[i] = stmtScope.expr
+			bodyProps[i] = stmtScope.makePhysicalProps()
 		}
 
 		if b.verboseTracing {
@@ -443,19 +440,15 @@ func (b *Builder) buildRoutine(
 				class: param.Class,
 			})
 		}
-		var expr memo.RelExpr
-		var physProps *physical.Required
 		options := basePLOptions().SetIsProcedure(isProc)
 		plBuilder := newPLpgSQLBuilder(
 			b, options, def.Name, stmt.AST.Label, colRefs, routineParams, f.ResolvedType(), outScope,
 		)
 		stmtScope := plBuilder.buildRootBlock(stmt.AST, bodyScope, routineParams)
 		rTyp := b.finalizeRoutineReturnType(f, stmtScope, inScope, oldInsideDataSource)
-		expr, physProps = b.finishBuildLastStmt(
-			stmtScope, bodyScope, isSetReturning, oldInsideDataSource, rTyp,
-		)
-		body = []memo.RelExpr{expr}
-		bodyProps = []*physical.Required{physProps}
+		stmtScope = b.finishRoutineReturnStmt(stmtScope, isSetReturning, oldInsideDataSource, rTyp)
+		body = []memo.RelExpr{stmtScope.expr}
+		bodyProps = []*physical.Required{stmtScope.makePhysicalProps()}
 		if b.verboseTracing {
 			bodyStmts = []string{stmt.String()}
 		}
@@ -486,44 +479,37 @@ func (b *Builder) buildRoutine(
 	return routine
 }
 
-// finishBuildLastStmt manages the columns returned by the last statement of a
-// routine. Depending on the context and return type of the routine, this may
-// mean expanding a tuple into multiple columns, or combining multiple columns
-// into a tuple.
-func (b *Builder) finishBuildLastStmt(
-	stmtScope, bodyScope *scope, isSetReturning, insideDataSource bool, rTyp *types.T,
-) (expr memo.RelExpr, physProps *physical.Required) {
+// finishRoutineReturnStmt manages the output columns for a statement that will
+// be added to the result set of a routine. Depending on the context and return
+// type of the routine, this may mean expanding a tuple into multiple columns,
+// or combining multiple columns into a tuple.
+func (b *Builder) finishRoutineReturnStmt(
+	stmtScope *scope, isSetReturning, insideDataSource bool, rTyp *types.T,
+) *scope {
 	// NOTE: the result columns of the last statement may not reflect the return
 	// type until after the call to maybeAddRoutineAssignmentCasts. Therefore, the
 	// logic below must take care in distinguishing the resolved return type from
 	// the result column type(s).
-	expr, physProps = stmtScope.expr, stmtScope.makePhysicalProps()
-
+	//
 	// Add a LIMIT 1 to the last statement if the UDF is not
 	// set-returning. This is valid because any other rows after the
 	// first can simply be ignored. The limit could be beneficial
 	// because it could allow additional optimization.
 	if !isSetReturning {
 		b.buildLimit(&tree.Limit{Count: tree.NewDInt(1)}, b.allocScope(), stmtScope)
-		expr = stmtScope.expr
-		// The limit expression will maintain the desired ordering, if any,
-		// so the physical props ordering can be cleared. The presentation
-		// must remain.
-		physProps.Ordering = props.OrderingChoice{}
 	}
 
 	// Depending on the context in which the UDF was called, it may be necessary
 	// to either combine multiple result columns into a tuple, or to expand a
 	// tuple result column into multiple columns.
-	cols := physProps.Presentation
-	scopeCols := stmtScope.cols
-	isSingleTupleResult := len(scopeCols) == 1 && scopeCols[0].typ.Family() == types.TupleFamily
+	isSingleTupleResult := len(stmtScope.cols) == 1 &&
+		stmtScope.cols[0].typ.Family() == types.TupleFamily
 	if insideDataSource {
 		// The UDF is a data source. If it returns a composite type and the last
 		// statement returns a single tuple column, the elements of the column
 		// should be expanded into individual columns.
 		if rTyp.Family() == types.TupleFamily && isSingleTupleResult {
-			expr, physProps = b.expandRoutineTupleIntoCols(cols[0].ID, bodyScope.push(), expr)
+			stmtScope = b.expandRoutineTupleIntoCols(stmtScope)
 		}
 	} else {
 		// Only a single column can be returned from a routine, unless it is a UDF
@@ -533,18 +519,16 @@ func (b *Builder) finishBuildLastStmt(
 		//   2. The routine returns RECORD, and the (single) result column cannot
 		//      be coerced to the return type. Note that a procedure with OUT-params
 		//      always wraps the OUT-param types in a record.
-		if len(cols) > 1 || (rTyp.Family() == types.TupleFamily && !scopeCols[0].typ.Equivalent(rTyp) &&
-			!cast.ValidCast(scopeCols[0].typ, rTyp, cast.ContextAssignment)) {
-			expr, physProps = b.combineRoutineColsIntoTuple(cols, bodyScope.push(), expr)
+		if len(stmtScope.cols) > 1 ||
+			(rTyp.Family() == types.TupleFamily && !stmtScope.cols[0].typ.Equivalent(rTyp) &&
+				!cast.ValidCast(stmtScope.cols[0].typ, rTyp, cast.ContextAssignment)) {
+			stmtScope = b.combineRoutineColsIntoTuple(stmtScope)
 		}
 	}
 
-	// We must preserve the presentation of columns as physical properties to
-	// prevent the optimizer from pruning the output column(s). If necessary, we
-	// add an assignment cast to the result column(s) so that its type matches the
-	// function return type.
-	cols = physProps.Presentation
-	return b.maybeAddRoutineAssignmentCasts(cols, bodyScope, rTyp, expr, physProps, insideDataSource)
+	// If necessary, we add an assignment cast to the result column(s) so that its
+	// type matches the function return type.
+	return b.maybeAddRoutineAssignmentCasts(stmtScope, rTyp, insideDataSource)
 }
 
 // finalizeRoutineReturnType updates the routine's return type, taking into
@@ -599,51 +583,51 @@ func (b *Builder) finalizeRoutineReturnType(
 
 // combineRoutineColsIntoTuple is a helper to combine individual result columns
 // into a single tuple column.
-func (b *Builder) combineRoutineColsIntoTuple(
-	cols physical.Presentation, stmtScope *scope, inputExpr memo.RelExpr,
-) (memo.RelExpr, *physical.Required) {
-	elems := make(memo.ScalarListExpr, len(cols))
-	typContents := make([]*types.T, len(cols))
-	for i := range cols {
-		elems[i] = b.factory.ConstructVariable(cols[i].ID)
-		typContents[i] = b.factory.Metadata().ColumnMeta(cols[i].ID).Type
+func (b *Builder) combineRoutineColsIntoTuple(stmtScope *scope) *scope {
+	outScope := stmtScope.push()
+	elems := make(memo.ScalarListExpr, len(stmtScope.cols))
+	typContents := make([]*types.T, len(stmtScope.cols))
+	for i := range stmtScope.cols {
+		elems[i] = b.factory.ConstructVariable(stmtScope.cols[i].id)
+		typContents[i] = stmtScope.cols[i].typ
 	}
 	colTyp := types.MakeTuple(typContents)
 	tup := b.factory.ConstructTuple(elems, colTyp)
-	col := b.synthesizeColumn(stmtScope, scopeColName(""), colTyp, nil /* expr */, tup)
-	return b.constructProject(inputExpr, []scopeColumn{*col}), stmtScope.makePhysicalProps()
+	b.synthesizeColumn(outScope, scopeColName(""), colTyp, nil /* expr */, tup)
+	b.constructProjectForScope(stmtScope, outScope)
+	return outScope
 }
 
 // expandRoutineTupleIntoCols is a helper to expand the elements of a single
 // tuple result column into individual result columns.
-func (b *Builder) expandRoutineTupleIntoCols(
-	tupleColID opt.ColumnID, stmtScope *scope, inputExpr memo.RelExpr,
-) (memo.RelExpr, *physical.Required) {
+func (b *Builder) expandRoutineTupleIntoCols(stmtScope *scope) *scope {
+	// Assume that the input scope has a single tuple column.
+	if buildutil.CrdbTestBuild {
+		if len(stmtScope.cols) != 1 {
+			panic(errors.AssertionFailedf("expected a single tuple column"))
+		}
+	}
+	tupleColID := stmtScope.cols[0].id
+	outScope := stmtScope.push()
 	colTyp := b.factory.Metadata().ColumnMeta(tupleColID).Type
-	elems := make([]scopeColumn, len(colTyp.TupleContents()))
 	for i := range colTyp.TupleContents() {
 		varExpr := b.factory.ConstructVariable(tupleColID)
 		e := b.factory.ConstructColumnAccess(varExpr, memo.TupleOrdinal(i))
-		col := b.synthesizeColumn(stmtScope, scopeColName(""), colTyp.TupleContents()[i], nil, e)
-		elems[i] = *col
+		b.synthesizeColumn(outScope, scopeColName(""), colTyp.TupleContents()[i], nil, e)
 	}
-	return b.constructProject(inputExpr, elems), stmtScope.makePhysicalProps()
+	b.constructProjectForScope(stmtScope, outScope)
+	return outScope
 }
 
 // maybeAddRoutineAssignmentCasts checks whether the result columns of the last
 // statement in a routine match up with the return type. If not, it attempts to
 // assignment-cast the columns to the correct type.
 func (b *Builder) maybeAddRoutineAssignmentCasts(
-	cols physical.Presentation,
-	bodyScope *scope,
-	rTyp *types.T,
-	expr memo.RelExpr,
-	physProps *physical.Required,
-	insideDataSource bool,
-) (memo.RelExpr, *physical.Required) {
+	stmtScope *scope, rTyp *types.T, insideDataSource bool,
+) *scope {
 	if rTyp.Family() == types.VoidFamily {
 		// Void routines don't return a result, so a cast is not necessary.
-		return expr, physProps
+		return stmtScope
 	}
 	var desiredTypes []*types.T
 	if insideDataSource && rTyp.Family() == types.TupleFamily {
@@ -655,37 +639,35 @@ func (b *Builder) maybeAddRoutineAssignmentCasts(
 		// type.
 		desiredTypes = []*types.T{rTyp}
 	}
-	if len(desiredTypes) != len(cols) {
+	if len(desiredTypes) != len(stmtScope.cols) {
 		panic(errors.AssertionFailedf("expected types and cols to be the same length"))
 	}
 	needCast := false
-	md := b.factory.Metadata()
-	for i, col := range cols {
-		colTyp, expectedTyp := md.ColumnMeta(col.ID).Type, desiredTypes[i]
-		if !colTyp.Identical(expectedTyp) {
+	for i, col := range stmtScope.cols {
+		if !col.typ.Identical(desiredTypes[i]) {
 			needCast = true
 			break
 		}
 	}
 	if !needCast {
-		return expr, physProps
+		return stmtScope
 	}
-	stmtScope := bodyScope.push()
-	for i, col := range cols {
-		colTyp, expectedTyp := md.ColumnMeta(col.ID).Type, desiredTypes[i]
-		scalar := b.factory.ConstructVariable(cols[i].ID)
-		if !colTyp.Identical(expectedTyp) {
-			if !cast.ValidCast(colTyp, expectedTyp, cast.ContextAssignment) {
+	outScope := stmtScope.push()
+	for i, col := range stmtScope.cols {
+		scalar := b.factory.ConstructVariable(col.id)
+		if !col.typ.Identical(desiredTypes[i]) {
+			if !cast.ValidCast(col.typ, desiredTypes[i], cast.ContextAssignment) {
 				panic(errors.AssertionFailedf(
 					"invalid cast from %s to %s should have been caught earlier",
-					colTyp.SQLStringForError(), expectedTyp.SQLStringForError(),
+					col.typ.SQLStringForError(), desiredTypes[i].SQLStringForError(),
 				))
 			}
-			scalar = b.factory.ConstructAssignmentCast(scalar, expectedTyp)
+			scalar = b.factory.ConstructAssignmentCast(scalar, desiredTypes[i])
 		}
-		b.synthesizeColumn(stmtScope, scopeColName(""), expectedTyp, nil /* expr */, scalar)
+		b.synthesizeColumn(outScope, scopeColName(""), desiredTypes[i], nil /* expr */, scalar)
 	}
-	return b.constructProject(expr, stmtScope.cols), stmtScope.makePhysicalProps()
+	b.constructProjectForScope(stmtScope, outScope)
+	return outScope
 }
 
 // addDefaultArgs adds DEFAULT arguments to the list of user-supplied arguments
@@ -826,7 +808,7 @@ func (b *Builder) buildDo(do *tree.DoBlock, inScope *scope) *scope {
 	if !ok {
 		panic(errors.AssertionFailedf("expected a plpgsql block"))
 	}
-	body, bodyProps := b.buildPLpgSQLDoBody(doBlockImpl)
+	bodyScope := b.buildPLpgSQLDoBody(doBlockImpl)
 
 	// Build a CALL expression that invokes the routine.
 	outScope := inScope.push()
@@ -839,8 +821,8 @@ func (b *Builder) buildDo(do *tree.DoBlock, inScope *scope) *scope {
 				Volatility:  volatility.Volatile,
 				RoutineType: tree.ProcedureRoutine,
 				RoutineLang: tree.RoutineLangPLpgSQL,
-				Body:        []memo.RelExpr{body},
-				BodyProps:   []*physical.Required{bodyProps},
+				Body:        []memo.RelExpr{bodyScope.expr},
+				BodyProps:   []*physical.Required{bodyScope.makePhysicalProps()},
 				BodyStmts:   bodyStmts,
 			},
 		},
@@ -853,9 +835,7 @@ func (b *Builder) buildDo(do *tree.DoBlock, inScope *scope) *scope {
 }
 
 // buildDoBody builds the body of the anonymous routine for a DO statement.
-func (b *Builder) buildPLpgSQLDoBody(
-	do *plpgsqltree.DoBlock,
-) (body memo.RelExpr, bodyProps *physical.Required) {
+func (b *Builder) buildPLpgSQLDoBody(do *plpgsqltree.DoBlock) *scope {
 	// Build an expression for each statement in the function body.
 	options := basePLOptions().WithIsProcedure().WithIsDoBlock()
 	plBuilder := newPLpgSQLBuilder(
@@ -866,7 +846,7 @@ func (b *Builder) buildPLpgSQLDoBody(
 	// variables or columns from the calling context.
 	bodyScope := b.allocScope()
 	stmtScope := plBuilder.buildRootBlock(do.Block, bodyScope, nil /* routineParams */)
-	return b.finishBuildLastStmt(
-		stmtScope, bodyScope, false /* isSetReturning */, false /* insideDataSource */, types.Void,
+	return b.finishRoutineReturnStmt(
+		stmtScope, false /* isSetReturning */, false /* insideDataSource */, types.Void,
 	)
 }

--- a/pkg/sql/opt/optbuilder/routine.go
+++ b/pkg/sql/opt/optbuilder/routine.go
@@ -445,9 +445,9 @@ func (b *Builder) buildRoutine(
 		}
 		var expr memo.RelExpr
 		var physProps *physical.Required
+		options := basePLOptions().SetIsProcedure(isProc)
 		plBuilder := newPLpgSQLBuilder(
-			b, def.Name, stmt.AST.Label, colRefs, routineParams, f.ResolvedType(),
-			isProc, false /* isDoBlock */, false /* isTriggerFn */, true /* buildSQL */, outScope,
+			b, options, def.Name, stmt.AST.Label, colRefs, routineParams, f.ResolvedType(), outScope,
 		)
 		stmtScope := plBuilder.buildRootBlock(stmt.AST, bodyScope, routineParams)
 		rTyp := b.finalizeRoutineReturnType(f, stmtScope, inScope, oldInsideDataSource)
@@ -857,10 +857,10 @@ func (b *Builder) buildPLpgSQLDoBody(
 	do *plpgsqltree.DoBlock,
 ) (body memo.RelExpr, bodyProps *physical.Required) {
 	// Build an expression for each statement in the function body.
+	options := basePLOptions().WithIsProcedure().WithIsDoBlock()
 	plBuilder := newPLpgSQLBuilder(
-		b, doBlockRoutineName, do.Block.Label, nil /* colRefs */, nil /* routineParams */, types.Void,
-		true /* isProc */, true, /* isDoBlock */
-		false /* isTriggerFn */, true /* buildSQL */, nil, /* outScope */
+		b, options, doBlockRoutineName, do.Block.Label, nil, /* colRefs */
+		nil /* routineParams */, types.Void, nil, /* outScope */
 	)
 	// Allocate a fresh scope, since DO blocks do not take parameters or reference
 	// variables or columns from the calling context.

--- a/pkg/sql/opt/optbuilder/routine.go
+++ b/pkg/sql/opt/optbuilder/routine.go
@@ -374,6 +374,41 @@ func (b *Builder) buildRoutine(
 		b.checkPrivilegeUser = checkPrivUser
 	}
 
+	// Special handling for set-returning PL/pgSQL functions.
+	//
+	// resultBufferID is used by set-returning PL/pgSQL functions to allow
+	// sub-routines to add to the result set at arbitrary points during execution.
+	var resultBufferID memo.RoutineResultBufferID
+	if isSetReturning && o.Language == tree.RoutineLangPLpgSQL {
+		// Allocate the result buffer ID so that sub-routines can add to the
+		// result set.
+		resultBufferID = b.factory.Memo().NextRoutineResultBufferID()
+		if o.ReturnsRecordType {
+			// A PL/pgSQL function that returns SETOF RECORD must be used as a data
+			// source and gets its concrete return type from the column definition
+			// list.
+			if !oldInsideDataSource {
+				// NOTE: This is the same error as returned by Postgres.
+				panic(
+					errors.WithHint(
+						pgerror.New(pgcode.FeatureNotSupported,
+							"materialize mode required, but it is not allowed in this context",
+						),
+						"PL/pgSQL functions that return SETOF RECORD are only allowed in data source "+
+							"context with a column definition list, "+
+							"e.g. SELECT * FROM my_func() AS (a INT, b STRING)",
+					),
+				)
+			}
+			rTyp := b.getColumnDefinitionListTypes(inScope)
+			if rTyp == nil {
+				panic(needColumnDefListForRecordErr)
+			}
+			f.SetTypeAnnotation(rTyp)
+		}
+		b.validateGeneratorFunctionReturnType(f.ResolvedOverload(), f.ResolvedType(), inScope)
+	}
+
 	// Build an expression for each statement in the function body.
 	var body []memo.RelExpr
 	var bodyProps []*physical.Required
@@ -440,13 +475,22 @@ func (b *Builder) buildRoutine(
 				class: param.Class,
 			})
 		}
-		options := basePLOptions().SetIsProcedure(isProc)
+		options := basePLOptions().
+			SetIsSetReturning(isSetReturning).
+			SetInsideDataSource(oldInsideDataSource).
+			SetIsProcedure(isProc)
 		plBuilder := newPLpgSQLBuilder(
-			b, options, def.Name, stmt.AST.Label, colRefs, routineParams, f.ResolvedType(), outScope,
+			b, options, def.Name, stmt.AST.Label, colRefs,
+			routineParams, f.ResolvedType(), outScope, resultBufferID,
 		)
 		stmtScope := plBuilder.buildRootBlock(stmt.AST, bodyScope, routineParams)
-		rTyp := b.finalizeRoutineReturnType(f, stmtScope, inScope, oldInsideDataSource)
-		stmtScope = b.finishRoutineReturnStmt(stmtScope, isSetReturning, oldInsideDataSource, rTyp)
+		if !isSetReturning {
+			// Set-returning functions add to the result set during execution rather
+			// than directly returning the result of the last statement. The PL/pgSQL
+			// statements used to add to the result set handle their own validation.
+			rTyp := b.finalizeRoutineReturnType(f, stmtScope, inScope, oldInsideDataSource)
+			stmtScope = b.finishRoutineReturnStmt(stmtScope, isSetReturning, oldInsideDataSource, rTyp)
+		}
 		body = []memo.RelExpr{stmtScope.expr}
 		bodyProps = []*physical.Required{stmtScope.makePhysicalProps()}
 		if b.verboseTracing {
@@ -473,6 +517,7 @@ func (b *Builder) buildRoutine(
 				BodyProps:          bodyProps,
 				BodyStmts:          bodyStmts,
 				Params:             params,
+				ResultBufferID:     resultBufferID,
 			},
 		},
 	)
@@ -840,7 +885,7 @@ func (b *Builder) buildPLpgSQLDoBody(do *plpgsqltree.DoBlock) *scope {
 	options := basePLOptions().WithIsProcedure().WithIsDoBlock()
 	plBuilder := newPLpgSQLBuilder(
 		b, options, doBlockRoutineName, do.Block.Label, nil, /* colRefs */
-		nil /* routineParams */, types.Void, nil, /* outScope */
+		nil /* routineParams */, types.Void, nil /* outScope */, 0, /* resultBufferID */
 	)
 	// Allocate a fresh scope, since DO blocks do not take parameters or reference
 	// variables or columns from the calling context.

--- a/pkg/sql/opt/optbuilder/srfs.go
+++ b/pkg/sql/opt/optbuilder/srfs.go
@@ -271,9 +271,7 @@ func (b *Builder) validateGeneratorFunctionReturnType(
 			}
 		}
 	} else if overload.ReturnsRecordType {
-		panic(pgerror.New(pgcode.Syntax,
-			"a column definition list is required for functions returning \"record\"",
-		))
+		panic(needColumnDefListForRecordErr)
 	}
 
 	// Verify that the function return type can be assignment-casted to the
@@ -322,3 +320,7 @@ func (b *Builder) buildProjectSet(inScope *scope) {
 
 	inScope.expr = b.factory.ConstructProjectSet(inScope.expr, zip)
 }
+
+var needColumnDefListForRecordErr = pgerror.New(pgcode.Syntax,
+	"a column definition list is required for functions returning \"record\"",
+)

--- a/pkg/sql/opt/optbuilder/testdata/udf_plpgsql
+++ b/pkg/sql/opt/optbuilder/testdata/udf_plpgsql
@@ -7751,3 +7751,155 @@ with &1 (foo)
                           │    └── projections
                           │         └── variable: x:7 [as=stmt_return_1:8]
                           └── const: 1
+
+# Set-returning function. Note the "add-to-srf-result" body statements.
+# Also note that the sub-routines are all tail-calls apart from the outermost,
+# since its result is not directly used by "f".
+exec-ddl
+CREATE OR REPLACE FUNCTION f(n INT) RETURNS SETOF INT LANGUAGE PLpgSQL AS $$
+  DECLARE
+    i INT := 0;
+  BEGIN
+    RETURN QUERY SELECT random()::INT * 100;
+    WHILE i <= n LOOP
+      RETURN NEXT i;
+      i := i + 1;
+    END LOOP;
+  END
+$$;
+----
+
+build format=show-scalars
+SELECT f(3);
+----
+project-set
+ ├── columns: f:24
+ ├── values
+ │    └── tuple
+ └── zip
+      └── udf: f
+           ├── args
+           │    └── const: 3
+           ├── params: n:1
+           └── body
+                └── project
+                     ├── columns: return_next_1:23
+                     ├── barrier
+                     │    ├── columns: i:2!null
+                     │    └── project
+                     │         ├── columns: i:2!null
+                     │         ├── values
+                     │         │    └── tuple
+                     │         └── projections
+                     │              └── const: 0 [as=i:2]
+                     └── projections
+                          └── udf: return_next_1 [as=return_next_1:23]
+                               ├── args
+                               │    ├── variable: n:1
+                               │    └── variable: i:2
+                               ├── params: n:3 i:4
+                               └── body
+                                    ├── add-to-srf-result
+                                    │    └── project
+                                    │         ├── columns: "?column?":5
+                                    │         ├── values
+                                    │         │    └── tuple
+                                    │         └── projections
+                                    │              └── mult [as="?column?":5]
+                                    │                   ├── cast: INT8
+                                    │                   │    └── function: random
+                                    │                   └── const: 100
+                                    └── project
+                                         ├── columns: stmt_loop_3:22
+                                         ├── values
+                                         │    └── tuple
+                                         └── projections
+                                              └── udf: stmt_loop_3 [as=stmt_loop_3:22]
+                                                   ├── tail-call
+                                                   ├── args
+                                                   │    ├── variable: n:3
+                                                   │    └── variable: i:4
+                                                   ├── params: n:9 i:10
+                                                   └── body
+                                                        └── project
+                                                             ├── columns: stmt_if_7:21
+                                                             ├── values
+                                                             │    └── tuple
+                                                             └── projections
+                                                                  └── case [as=stmt_if_7:21]
+                                                                       ├── true
+                                                                       ├── when
+                                                                       │    ├── le
+                                                                       │    │    ├── variable: i:10
+                                                                       │    │    └── variable: n:9
+                                                                       │    └── subquery
+                                                                       │         ├── tail-call
+                                                                       │         └── project
+                                                                       │              ├── columns: return_next_5:19
+                                                                       │              ├── values
+                                                                       │              │    └── tuple
+                                                                       │              └── projections
+                                                                       │                   └── udf: return_next_5 [as=return_next_5:19]
+                                                                       │                        ├── tail-call
+                                                                       │                        ├── args
+                                                                       │                        │    ├── variable: n:9
+                                                                       │                        │    └── variable: i:10
+                                                                       │                        ├── params: n:14 i:15
+                                                                       │                        └── body
+                                                                       │                             ├── add-to-srf-result
+                                                                       │                             │    └── project
+                                                                       │                             │         ├── columns: stmt_return_next_6:16
+                                                                       │                             │         ├── values
+                                                                       │                             │         │    └── tuple
+                                                                       │                             │         └── projections
+                                                                       │                             │              └── variable: i:15 [as=stmt_return_next_6:16]
+                                                                       │                             └── project
+                                                                       │                                  ├── columns: stmt_if_4:18
+                                                                       │                                  ├── project
+                                                                       │                                  │    ├── columns: i:17
+                                                                       │                                  │    ├── values
+                                                                       │                                  │    │    └── tuple
+                                                                       │                                  │    └── projections
+                                                                       │                                  │         └── plus [as=i:17]
+                                                                       │                                  │              ├── variable: i:15
+                                                                       │                                  │              └── const: 1
+                                                                       │                                  └── projections
+                                                                       │                                       └── udf: stmt_if_4 [as=stmt_if_4:18]
+                                                                       │                                            ├── tail-call
+                                                                       │                                            ├── args
+                                                                       │                                            │    ├── variable: n:14
+                                                                       │                                            │    └── variable: i:17
+                                                                       │                                            ├── params: n:11 i:12
+                                                                       │                                            └── body
+                                                                       │                                                 └── project
+                                                                       │                                                      ├── columns: stmt_loop_3:13
+                                                                       │                                                      ├── values
+                                                                       │                                                      │    └── tuple
+                                                                       │                                                      └── projections
+                                                                       │                                                           └── udf: stmt_loop_3 [as=stmt_loop_3:13]
+                                                                       │                                                                ├── tail-call
+                                                                       │                                                                ├── args
+                                                                       │                                                                │    ├── variable: n:11
+                                                                       │                                                                │    └── variable: i:12
+                                                                       │                                                                └── recursive-call
+                                                                       └── subquery
+                                                                            ├── tail-call
+                                                                            └── project
+                                                                                 ├── columns: loop_exit_2:20
+                                                                                 ├── values
+                                                                                 │    └── tuple
+                                                                                 └── projections
+                                                                                      └── udf: loop_exit_2 [as=loop_exit_2:20]
+                                                                                           ├── tail-call
+                                                                                           ├── args
+                                                                                           │    ├── variable: n:9
+                                                                                           │    └── variable: i:10
+                                                                                           ├── params: n:6 i:7
+                                                                                           └── body
+                                                                                                └── project
+                                                                                                     ├── columns: "_implicit_return":8
+                                                                                                     ├── values
+                                                                                                     │    └── tuple
+                                                                                                     └── projections
+                                                                                                          └── cast: VOID [as="_implicit_return":8]
+                                                                                                               └── null

--- a/pkg/sql/opt/optbuilder/trigger.go
+++ b/pkg/sql/opt/optbuilder/trigger.go
@@ -838,9 +838,8 @@ func (b *Builder) buildTriggerFunction(
 		panic(err)
 	}
 	plBuilder := newPLpgSQLBuilder(
-		b, resolvedDef.Name, stmt.AST.Label, nil /* colRefs */, params, tableTyp,
-		false /* isProc */, false, /* isDoBlock */
-		true /* isTriggerFn */, true /* buildSQL */, nil, /* outScope */
+		b, basePLOptions().WithIsTriggerFn(), resolvedDef.Name, stmt.AST.Label, nil, /* colRefs */
+		params, tableTyp, nil, /* outScope */
 	)
 	stmtScope := plBuilder.buildRootBlock(stmt.AST, triggerFuncScope, params)
 	udfDef.Body = []memo.RelExpr{stmtScope.expr}

--- a/pkg/sql/opt/optbuilder/trigger.go
+++ b/pkg/sql/opt/optbuilder/trigger.go
@@ -839,7 +839,7 @@ func (b *Builder) buildTriggerFunction(
 	}
 	plBuilder := newPLpgSQLBuilder(
 		b, basePLOptions().WithIsTriggerFn(), resolvedDef.Name, stmt.AST.Label, nil, /* colRefs */
-		params, tableTyp, nil, /* outScope */
+		params, tableTyp, nil /* outScope */, 0, /* resultBufferID */
 	)
 	stmtScope := plBuilder.buildRootBlock(stmt.AST, triggerFuncScope, params)
 	udfDef.Body = []memo.RelExpr{stmtScope.expr}

--- a/pkg/sql/plpgsql/parser/lexer.go
+++ b/pkg/sql/plpgsql/parser/lexer.go
@@ -373,6 +373,17 @@ func makeDoStmt(options tree.DoBlockOptions) (*plpgsqltree.DoBlock, error) {
 	return &plpgsqltree.DoBlock{Block: parsedStmt.AST}, nil
 }
 
+// ParseReturnExpr handles reading and parsing the expression for a RETURN or
+// RETURN NEXT statement, which can be nonexistent.
+func (l *lexer) ParseReturnExpr() (plpgsqltree.Expr, error) {
+	startPos, endPos, _, err := l.readSQLConstruct(true /* isExpr */, true /* allowEmpty */, ';')
+	if err != nil || startPos == endPos {
+		return nil, err
+	}
+	exprStr := l.getStr(startPos, endPos)
+	return l.ParseExpr(exprStr)
+}
+
 func (l *lexer) ReadSqlExpr(
 	terminator1 int, terminators ...int,
 ) (sqlStr string, terminatorMet int, err error) {
@@ -381,17 +392,6 @@ func (l *lexer) ReadSqlExpr(
 		true /* isExpr */, false /* allowEmpty */, terminator1, terminators...,
 	)
 	return l.getStr(startPos, endPos), terminatorMet, err
-}
-
-// ReadReturnExpr handles reading the expression for a RETURN statement, which
-// can be nonexistent.
-func (l *lexer) ReadReturnExpr() (sqlStr string, err error) {
-	var startPos, endPos int
-	startPos, endPos, _, err = l.readSQLConstruct(true /* isExpr */, true /* allowEmpty */, ';')
-	if err != nil || startPos == endPos {
-		return "", err
-	}
-	return l.getStr(startPos, endPos), err
 }
 
 func (l *lexer) ReadSqlStatement(

--- a/pkg/sql/plpgsql/parser/testdata/stmt_return
+++ b/pkg/sql/plpgsql/parser/testdata/stmt_return
@@ -193,32 +193,6 @@ We appreciate your feedback.
 error
 DECLARE
 BEGIN
-  RETURN NEXT 1 + 1;
-END
-----
-----
-at or near "next": syntax error: unimplemented: this syntax
-DETAIL: source SQL:
-DECLARE
-BEGIN
-  RETURN NEXT 1 + 1;
-         ^
-HINT: You have attempted to use a feature that is not yet implemented.
-
-Please check the public issue tracker to check whether this problem is
-already tracked. If you cannot find it there, please report the error
-with details by creating a new issue.
-
-If you would rather not post publicly, please contact us directly
-using the support form.
-
-We appreciate your feedback.
-----
-----
-
-error
-DECLARE
-BEGIN
   RETURN (NULL;
 END
 ----
@@ -263,12 +237,12 @@ BEGIN
   RETURN 1, 'string';
 END
 ----
-at or near ";": syntax error: query returned 2 columns
+at or near "string": syntax error: query returned 2 columns
 DETAIL: source SQL:
 DECLARE
 BEGIN
   RETURN 1, 'string';
-                    ^
+            ^
 
 error
 DECLARE
@@ -276,9 +250,9 @@ BEGIN
   RETURN 1, (2, 3, 4, 5);
 END
 ----
-at or near ";": syntax error: query returned 2 columns
+at or near ")": syntax error: query returned 2 columns
 DETAIL: source SQL:
 DECLARE
 BEGIN
   RETURN 1, (2, 3, 4, 5);
-                        ^
+                       ^

--- a/pkg/sql/plpgsql/parser/testdata/stmt_return
+++ b/pkg/sql/plpgsql/parser/testdata/stmt_return
@@ -141,58 +141,6 @@ END;
 error
 DECLARE
 BEGIN
-  RETURN QUERY SELECT 1 + 1;
-END
-----
-----
-at or near "query": syntax error: unimplemented: this syntax
-DETAIL: source SQL:
-DECLARE
-BEGIN
-  RETURN QUERY SELECT 1 + 1;
-         ^
-HINT: You have attempted to use a feature that is not yet implemented.
-
-Please check the public issue tracker to check whether this problem is
-already tracked. If you cannot find it there, please report the error
-with details by creating a new issue.
-
-If you would rather not post publicly, please contact us directly
-using the support form.
-
-We appreciate your feedback.
-----
-----
-
-error
-DECLARE
-BEGIN
-  RETURN QUERY EXECUTE a dynamic command;
-END
-----
-----
-at or near "query": syntax error: unimplemented: this syntax
-DETAIL: source SQL:
-DECLARE
-BEGIN
-  RETURN QUERY EXECUTE a dynamic command;
-         ^
-HINT: You have attempted to use a feature that is not yet implemented.
-
-Please check the public issue tracker to check whether this problem is
-already tracked. If you cannot find it there, please report the error
-with details by creating a new issue.
-
-If you would rather not post publicly, please contact us directly
-using the support form.
-
-We appreciate your feedback.
-----
-----
-
-error
-DECLARE
-BEGIN
   RETURN (NULL;
 END
 ----

--- a/pkg/sql/plpgsql/parser/testdata/stmt_return_next
+++ b/pkg/sql/plpgsql/parser/testdata/stmt_return_next
@@ -1,0 +1,137 @@
+parse
+BEGIN
+  RETURN NEXT foo;
+END
+----
+BEGIN
+RETURN NEXT foo;
+END;
+ -- normalized!
+BEGIN
+RETURN NEXT (foo);
+END;
+ -- fully parenthesized
+BEGIN
+RETURN NEXT foo;
+END;
+ -- literals removed
+BEGIN
+RETURN NEXT _;
+END;
+ -- identifiers removed
+
+parse
+BEGIN
+  RETURN NEXT 1 + foo + 3;
+END
+----
+BEGIN
+RETURN NEXT (1 + foo) + 3;
+END;
+ -- normalized!
+BEGIN
+RETURN NEXT ((((1) + (foo))) + (3));
+END;
+ -- fully parenthesized
+BEGIN
+RETURN NEXT (_ + foo) + _;
+END;
+ -- literals removed
+BEGIN
+RETURN NEXT (1 + _) + 3;
+END;
+ -- identifiers removed
+
+parse
+BEGIN
+  RETURN NEXT;
+END
+----
+BEGIN
+RETURN NEXT;
+END;
+ -- normalized!
+BEGIN
+RETURN NEXT;
+END;
+ -- fully parenthesized
+BEGIN
+RETURN NEXT;
+END;
+ -- literals removed
+BEGIN
+RETURN NEXT;
+END;
+ -- identifiers removed
+
+parse
+BEGIN
+  RETURN NEXT (1 + 2) + 3;
+END
+----
+BEGIN
+RETURN NEXT (1 + 2) + 3;
+END;
+ -- normalized!
+BEGIN
+RETURN NEXT (((((1) + (2)))) + (3));
+END;
+ -- fully parenthesized
+BEGIN
+RETURN NEXT (_ + _) + _;
+END;
+ -- literals removed
+BEGIN
+RETURN NEXT (1 + 2) + 3;
+END;
+ -- identifiers removed
+
+parse
+BEGIN
+  RETURN NEXT (SELECT * FROM xy);
+END
+----
+BEGIN
+RETURN NEXT (SELECT * FROM xy);
+END;
+ -- normalized!
+BEGIN
+RETURN NEXT ((SELECT (*) FROM xy));
+END;
+ -- fully parenthesized
+BEGIN
+RETURN NEXT (SELECT * FROM xy);
+END;
+ -- literals removed
+BEGIN
+RETURN NEXT (SELECT * FROM _);
+END;
+ -- identifiers removed
+
+error
+BEGIN
+  RETURN NEXT (foo;
+END
+----
+at or near "EOF": syntax error: mismatched parentheses
+DETAIL: source SQL:
+BEGIN
+  RETURN NEXT (foo;
+END
+   ^
+
+error
+BEGIN
+  RETURN NEXT SELECT * FROM xy;
+END
+----
+at or near "xy": at or near "select": syntax error
+DETAIL: source SQL:
+SET ROW (SELECT * FROM xy)
+         ^
+--
+source SQL:
+BEGIN
+  RETURN NEXT SELECT * FROM xy;
+                            ^
+HINT: try \h SET SESSION

--- a/pkg/sql/plpgsql/parser/testdata/stmt_return_query
+++ b/pkg/sql/plpgsql/parser/testdata/stmt_return_query
@@ -1,0 +1,153 @@
+parse
+DECLARE
+BEGIN
+  RETURN QUERY SELECT 1 + 1;
+END
+----
+DECLARE
+BEGIN
+RETURN QUERY SELECT 1 + 1;
+END;
+ -- normalized!
+DECLARE
+BEGIN
+RETURN QUERY SELECT ((1) + (1));
+END;
+ -- fully parenthesized
+DECLARE
+BEGIN
+RETURN QUERY SELECT _ + _;
+END;
+ -- literals removed
+DECLARE
+BEGIN
+RETURN QUERY SELECT 1 + 1;
+END;
+ -- identifiers removed
+
+parse
+DECLARE
+BEGIN
+  RETURN QUERY SELECT * FROM xy INNER JOIN ab ON x = a;
+END
+----
+DECLARE
+BEGIN
+RETURN QUERY SELECT * FROM xy INNER JOIN ab ON x = a;
+END;
+ -- normalized!
+DECLARE
+BEGIN
+RETURN QUERY SELECT (*) FROM xy INNER JOIN ab ON ((x) = (a));
+END;
+ -- fully parenthesized
+DECLARE
+BEGIN
+RETURN QUERY SELECT * FROM xy INNER JOIN ab ON x = a;
+END;
+ -- literals removed
+DECLARE
+BEGIN
+RETURN QUERY SELECT * FROM _ INNER JOIN _ ON _ = _;
+END;
+ -- identifiers removed
+
+parse
+DECLARE
+BEGIN
+  RETURN QUERY (SELECT * FROM xy INNER JOIN ab ON x = a);
+END
+----
+DECLARE
+BEGIN
+RETURN QUERY (SELECT * FROM xy INNER JOIN ab ON x = a);
+END;
+ -- normalized!
+DECLARE
+BEGIN
+RETURN QUERY (SELECT (*) FROM xy INNER JOIN ab ON ((x) = (a)));
+END;
+ -- fully parenthesized
+DECLARE
+BEGIN
+RETURN QUERY (SELECT * FROM xy INNER JOIN ab ON x = a);
+END;
+ -- literals removed
+DECLARE
+BEGIN
+RETURN QUERY (SELECT * FROM _ INNER JOIN _ ON _ = _);
+END;
+ -- identifiers removed
+
+error
+DECLARE
+BEGIN
+  RETURN QUERY;
+END
+----
+at or near "query": syntax error: missing SQL statement
+DETAIL: source SQL:
+DECLARE
+BEGIN
+  RETURN QUERY;
+         ^
+
+error
+DECLARE
+BEGIN
+  RETURN QUERY 100;
+END
+----
+at or near "100": at or near "100": syntax error
+DETAIL: source SQL:
+100
+^
+--
+source SQL:
+DECLARE
+BEGIN
+  RETURN QUERY 100;
+               ^
+
+error
+DECLARE
+BEGIN
+  RETURN QUERY * FROM xy INNER JOIN ab ON x = a;
+END
+----
+at or near "a": at or near "*": syntax error
+DETAIL: source SQL:
+* FROM xy INNER JOIN ab ON x = a
+^
+--
+source SQL:
+DECLARE
+BEGIN
+  RETURN QUERY * FROM xy INNER JOIN ab ON x = a;
+                                              ^
+
+error
+DECLARE
+BEGIN
+  RETURN QUERY EXECUTE a dynamic command;
+END
+----
+----
+at or near "execute": syntax error: unimplemented: this syntax
+DETAIL: source SQL:
+DECLARE
+BEGIN
+  RETURN QUERY EXECUTE a dynamic command;
+               ^
+HINT: You have attempted to use a feature that is not yet implemented.
+
+Please check the public issue tracker to check whether this problem is
+already tracked. If you cannot find it there, please report the error
+with details by creating a new issue.
+
+If you would rather not post publicly, please contact us directly
+using the support form.
+
+We appreciate your feedback.
+----
+----

--- a/pkg/sql/sem/plpgsqltree/statements.go
+++ b/pkg/sql/sem/plpgsqltree/statements.go
@@ -852,12 +852,21 @@ func (s *ReturnNext) WalkStmt(visitor StatementVisitor) Statement {
 
 type ReturnQuery struct {
 	StatementImpl
-	Query        Expr
-	DynamicQuery Expr
-	Params       []Expr
+	SqlStmt tree.Statement
+}
+
+func (s *ReturnQuery) CopyNode() *ReturnQuery {
+	copyNode := *s
+	return &copyNode
 }
 
 func (s *ReturnQuery) Format(ctx *tree.FmtCtx) {
+	ctx.WriteString("RETURN QUERY")
+	if s.SqlStmt != nil {
+		ctx.WriteByte(' ')
+		ctx.FormatNode(s.SqlStmt)
+	}
+	ctx.WriteString(";\n")
 }
 
 func (s *ReturnQuery) PlpgSQLStatementTag() string {
@@ -865,7 +874,8 @@ func (s *ReturnQuery) PlpgSQLStatementTag() string {
 }
 
 func (s *ReturnQuery) WalkStmt(visitor StatementVisitor) Statement {
-	panic(unimplemented.New("plpgsql visitor", "Unimplemented PLpgSQL visitor pattern"))
+	newStmt, _ := visitor.Visit(s)
+	return newStmt
 }
 
 // stmt_raise

--- a/pkg/sql/sem/plpgsqltree/statements.go
+++ b/pkg/sql/sem/plpgsqltree/statements.go
@@ -824,11 +824,21 @@ func (s *Return) WalkStmt(visitor StatementVisitor) Statement {
 
 type ReturnNext struct {
 	StatementImpl
-	Expr   Expr
-	RetVar Variable
+	Expr Expr
+}
+
+func (s *ReturnNext) CopyNode() *ReturnNext {
+	copyNode := *s
+	return &copyNode
 }
 
 func (s *ReturnNext) Format(ctx *tree.FmtCtx) {
+	ctx.WriteString("RETURN NEXT")
+	if s.Expr != nil {
+		ctx.WriteByte(' ')
+		ctx.FormatNode(s.Expr)
+	}
+	ctx.WriteString(";\n")
 }
 
 func (s *ReturnNext) PlpgSQLStatementTag() string {
@@ -836,7 +846,8 @@ func (s *ReturnNext) PlpgSQLStatementTag() string {
 }
 
 func (s *ReturnNext) WalkStmt(visitor StatementVisitor) Statement {
-	panic(unimplemented.New("plpgsql visitor", "Unimplemented PLpgSQL visitor pattern"))
+	newStmt, _ := visitor.Visit(s)
+	return newStmt
 }
 
 type ReturnQuery struct {

--- a/pkg/sql/sem/plpgsqltree/visitor.go
+++ b/pkg/sql/sem/plpgsqltree/visitor.go
@@ -200,6 +200,16 @@ func (v *SQLStmtVisitor) Visit(stmt Statement) (newStmt Statement, recurse bool)
 			cpy.Expr = e
 			newStmt = cpy
 		}
+	case *ReturnQuery:
+		s, v.Err = v.visitStmt(t.SqlStmt)
+		if v.Err != nil {
+			return stmt, false
+		}
+		if t.SqlStmt != s {
+			cpy := t.CopyNode()
+			cpy.SqlStmt = s
+			newStmt = cpy
+		}
 	case *Raise:
 		for i, p := range t.Params {
 			e, v.Err = v.visitExpr(p)
@@ -297,7 +307,7 @@ func (v *SQLStmtVisitor) Visit(stmt Statement) (newStmt Statement, recurse bool)
 			}
 		}
 
-	case *ForEachArray, *ReturnQuery, *Perform:
+	case *ForEachArray, *Perform:
 		panic(unimp.New("plpgsql visitor", "Unimplemented PLpgSQL visitor"))
 	}
 	if v.Err != nil {

--- a/pkg/sql/sem/plpgsqltree/visitor.go
+++ b/pkg/sql/sem/plpgsqltree/visitor.go
@@ -190,6 +190,16 @@ func (v *SQLStmtVisitor) Visit(stmt Statement) (newStmt Statement, recurse bool)
 			cpy.Expr = e
 			newStmt = cpy
 		}
+	case *ReturnNext:
+		e, v.Err = v.visitExpr(t.Expr)
+		if v.Err != nil {
+			return stmt, false
+		}
+		if t.Expr != e {
+			cpy := t.CopyNode()
+			cpy.Expr = e
+			newStmt = cpy
+		}
 	case *Raise:
 		for i, p := range t.Params {
 			e, v.Err = v.visitExpr(p)
@@ -287,8 +297,7 @@ func (v *SQLStmtVisitor) Visit(stmt Statement) (newStmt Statement, recurse bool)
 			}
 		}
 
-	case *ForEachArray, *ReturnNext,
-		*ReturnQuery, *Perform:
+	case *ForEachArray, *ReturnQuery, *Perform:
 		panic(unimp.New("plpgsql visitor", "Unimplemented PLpgSQL visitor"))
 	}
 	if v.Err != nil {


### PR DESCRIPTION
#### plpgsql/parser: add parser support for RETURN NEXT

This commit adds support for `RETURN NEXT` statements to the PL/pgSQL
parser. A following commit will add execution support.

Informs #105240

Release note: None

#### plpgsql/parser: add parser support for RETURN QUERY

This commit adds support for `RETURN QUERY` statements to the PL/pgSQL
parser. A following commit will add execution support.

Informs #105240

Release note: None

#### plpgsql: pass options struct to plpgsqlBuilder

This commit moves the bool arguments used when constructing a
`plpgsqlBuilder` instance to an options struct. This will simplify
adding new options in the future.

Informs #105240

Release note: None

#### optbuilder: refactor routine output stmt finalization

This commit is a mechanical refactor to the logic that finalizes a
routine's result type and last body statement. This change will make
it easier for PL/pgSQL `RETURN NEXT` and `RETURN QUERY` statements
to perform their own validation.

Informs #105240

Release note: None

#### sql: add ability to redirect first statement to srf result set

Similar to the existing method to direct the result of the first body
statement of a routine to a cursor, this commit adds the ability to
redirect to the result buffer of an SRF. This will be used in a later
commit to implement PL/pgSQL `RETURN NEXT` and `RETURN QUERY` statements.
This commit also adds an option to prevent a routine from adding the
result of its *last* body statement to its result set - this will
be used by set-returning PL/pgSQL functions that rely on sub-routines
to fill in the result set during execution.

Informs #105240

Release note: None

#### plpgsql: add support for set-returning functions

This commit adds support for set-returning PL/pgSQL functions. Unlike SQL
SRFs, PL/pgSQL SRFs add to the result set at arbitrary points during
execution using `RETURN NEXT` (scalar) and `RETURN QUERY` (relational)
statements. We support this feature by allocating a `RoutineResultBufferID`
that allows the sub-routines that implement the PL/pgSQL routine body to
access the SRF's result buffer directly during execution.

Fixes #105240

Release note (sql change): Set-returning PL/pgSQL functions are now
supported. A PL/pgSQL SRF can be created by declaring the return type
as `SETOF <type>` or `TABLE`.