### PR TITLE
WIP raft: prototype for term cache in rejections

### DIFF
--- a/pkg/raft/log.go
+++ b/pkg/raft/log.go
@@ -667,3 +667,24 @@ func (l *raftLog) snap(storage LogStorage) LogSnapshot {
 		logger:    l.logger,
 	}
 }
+
+// findMatch finds the most up to date entryID in the remote log that matches
+// the local log.
+// remoteTermFlips is a list of entryIDs that are know to be in the remote log
+// which comes from the termCache of the remote log.
+func (l *raftLog) findMatch(remoteTermFlips []entryID, remoteLast entryID) (entryID, bool) {
+	tmp := remoteLast.index
+	for j := len(remoteTermFlips) - 1; j >= 0; j-- {
+		if tmp == 0 {
+			break
+		}
+		for i := int64(tmp); i >= int64(remoteTermFlips[j].index); i-- {
+			remoteEnt := entryID{term: remoteTermFlips[j].term, index: uint64(i)}
+			if l.matchTerm(remoteEnt) {
+				return remoteEnt, true
+			}
+		}
+		tmp = min(remoteTermFlips[j].index-1, tmp)
+	}
+	return entryID{remoteTermFlips[0].term, remoteTermFlips[0].index}, false
+}

--- a/pkg/raft/raft_test.go
+++ b/pkg/raft/raft_test.go
@@ -4855,20 +4855,20 @@ func TestConfChangeV2CheckBeforeCampaign(t *testing.T) {
 
 func TestFastLogRejection(t *testing.T) {
 	tests := []struct {
-		leaderLog       []pb.Entry // Logs on the leader
-		followerLog     []pb.Entry // Logs on the follower
-		followerCompact uint64     // Index at which the follower log is compacted.
-		rejectHintTerm  uint64     // Expected term included in rejected MsgAppResp.
-		rejectHintIndex uint64     // Expected index included in rejected MsgAppResp.
-		nextAppendTerm  uint64     // Expected term when leader appends after rejected.
-		nextAppendIndex uint64     // Expected index when leader appends after rejected.
+		leaderLog       LeadSlice // Logs on the leader
+		followerLog     LeadSlice // Logs on the follower
+		followerCompact uint64    // Index at which the follower log is compacted.
+		rejectHintTerm  uint64    // Expected term included in rejected MsgAppResp.
+		rejectHintIndex uint64    // Expected index included in rejected MsgAppResp.
+		nextAppendTerm  uint64    // Expected term when leader appends after rejected.
+		nextAppendIndex uint64    // Expected index when leader appends after rejected.
 	}{
 		// This case tests that leader can find the conflict index quickly.
 		// Firstly leader appends (type=MsgApp,index=7,logTerm=4, entries=...);
 		// After rejected leader appends (type=MsgApp,index=3,logTerm=2).
 		{
-			leaderLog:       index(1).terms(1, 2, 2, 4, 4, 4, 4),
-			followerLog:     index(1).terms(1, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3),
+			leaderLog:       entryID{index: 0, term: 1}.append(1, 2, 2, 4, 4, 4, 4),
+			followerLog:     entryID{index: 0, term: 0}.append(1, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3),
 			rejectHintTerm:  3,
 			rejectHintIndex: 7,
 			nextAppendTerm:  2,
@@ -4878,8 +4878,8 @@ func TestFastLogRejection(t *testing.T) {
 		// Firstly leader appends (type=MsgApp,index=8,logTerm=5, entries=...);
 		// After rejected leader appends (type=MsgApp,index=4,logTerm=3).
 		{
-			leaderLog:       index(1).terms(1, 2, 2, 3, 4, 4, 4, 5),
-			followerLog:     index(1).terms(1, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3),
+			leaderLog:       entryID{index: 0, term: 1}.append(1, 2, 2, 3, 4, 4, 4, 5),
+			followerLog:     entryID{index: 0, term: 0}.append(1, 2, 2, 3, 3, 3, 3, 3, 3, 3, 3),
 			rejectHintTerm:  3,
 			rejectHintIndex: 8,
 			nextAppendTerm:  3,
@@ -4889,8 +4889,8 @@ func TestFastLogRejection(t *testing.T) {
 		// Firstly leader appends (type=MsgApp,index=4,logTerm=1, entries=...);
 		// After rejected leader appends (type=MsgApp,index=1,logTerm=1).
 		{
-			leaderLog:       index(1).terms(1, 1, 1, 1),
-			followerLog:     index(1).terms(1, 2, 2, 4),
+			leaderLog:       entryID{index: 0, term: 1}.append(1, 1, 1, 1),
+			followerLog:     entryID{index: 0, term: 0}.append(1, 2, 2, 4),
 			rejectHintTerm:  1,
 			rejectHintIndex: 1,
 			nextAppendTerm:  1,
@@ -4901,8 +4901,8 @@ func TestFastLogRejection(t *testing.T) {
 		// Firstly leader appends (type=MsgApp,index=6,logTerm=1, entries=...);
 		// After rejected leader appends (type=MsgApp,index=1,logTerm=1).
 		{
-			leaderLog:       index(1).terms(1, 1, 1, 1, 1, 1),
-			followerLog:     index(1).terms(1, 2, 2, 4),
+			leaderLog:       entryID{index: 0, term: 1}.append(1, 1, 1, 1, 1, 1),
+			followerLog:     entryID{index: 0, term: 0}.append(1, 2, 2, 4),
 			rejectHintTerm:  1,
 			rejectHintIndex: 1,
 			nextAppendTerm:  1,
@@ -4913,8 +4913,8 @@ func TestFastLogRejection(t *testing.T) {
 		// Firstly leader appends (type=MsgApp,index=4,logTerm=1, entries=...);
 		// After rejected leader appends (type=MsgApp,index=1,logTerm=1).
 		{
-			leaderLog:       index(1).terms(1, 1, 1, 1),
-			followerLog:     index(1).terms(1, 2, 2, 4, 4, 4),
+			leaderLog:       entryID{index: 0, term: 1}.append(1, 1, 1, 1),
+			followerLog:     entryID{index: 0, term: 0}.append(1, 2, 2, 4, 4, 4),
 			rejectHintTerm:  1,
 			rejectHintIndex: 1,
 			nextAppendTerm:  1,
@@ -4924,8 +4924,8 @@ func TestFastLogRejection(t *testing.T) {
 		// Firstly leader appends (type=MsgApp,index=5,logTerm=5, entries=...);
 		// After rejected leader appends (type=MsgApp,index=4,logTerm=4).
 		{
-			leaderLog:       index(1).terms(1, 1, 1, 4, 5),
-			followerLog:     index(1).terms(1, 1, 1, 4),
+			leaderLog:       entryID{index: 0, term: 1}.append(1, 1, 1, 4, 5),
+			followerLog:     entryID{index: 0, term: 0}.append(1, 1, 1, 4),
 			rejectHintTerm:  4,
 			rejectHintIndex: 4,
 			nextAppendTerm:  4,
@@ -4933,8 +4933,8 @@ func TestFastLogRejection(t *testing.T) {
 		},
 		// Test case from example comment in stepLeader (on leader).
 		{
-			leaderLog:       index(1).terms(2, 5, 5, 5, 5, 5, 5, 5, 5),
-			followerLog:     index(1).terms(2, 4, 4, 4, 4, 4),
+			leaderLog:       entryID{index: 0, term: 1}.append(2, 5, 5, 5, 5, 5, 5, 5, 5),
+			followerLog:     entryID{index: 0, term: 0}.append(2, 4, 4, 4, 4, 4),
 			rejectHintTerm:  4,
 			rejectHintIndex: 6,
 			nextAppendTerm:  2,
@@ -4942,27 +4942,61 @@ func TestFastLogRejection(t *testing.T) {
 		},
 		// Test case from example comment in handleAppendEntries (on follower).
 		{
-			leaderLog:       index(1).terms(2, 2, 2, 2, 2),
-			followerLog:     index(1).terms(2, 4, 4, 4, 4, 4, 4, 4),
+			leaderLog:       entryID{index: 0, term: 1}.append(2, 2, 2, 2, 2),
+			followerLog:     entryID{index: 0, term: 0}.append(2, 4, 4, 4, 4, 4, 4, 4),
 			rejectHintTerm:  2,
 			rejectHintIndex: 1,
 			nextAppendTerm:  2,
 			nextAppendIndex: 1,
 		},
-		// A case when a stale MsgApp from leader arrives after the corresponding
-		// log index got compacted.
-		// A stale (type=MsgApp,index=3,logTerm=3,entries=[(term=3,index=4)]) is
-		// delivered to a follower who has already compacted beyond log index 3. The
-		// MsgAppResp rejection will return same index=3, with logTerm=0. The leader
-		// will rollback by one entry, and send MsgApp with index=2,logTerm=1.
+		// // A case when a stale MsgApp from leader arrives after the corresponding
+		// // log index got compacted.
+		// // A stale (type=MsgApp,index=3,logTerm=3,entries=[(term=3,index=4)]) is
+		// // delivered to a follower who has already compacted beyond log index 3. The
+		// // MsgAppResp rejection will return same index=3, with logTerm=0. The leader
+		// // will rollback by one entry, and send MsgApp with index=2,logTerm=1.
+		// {
+		// 	leaderLog:       entryID{index: 0, term: 1}.append(1, 1, 3),
+		// 	followerLog:     entryID{index: 0, term: 0}.append(1, 1, 3, 3, 3),
+		// 	followerCompact: 5, // entries <= index 5 are compacted
+		// 	rejectHintTerm:  0,
+		// 	rejectHintIndex: 3,
+		// 	nextAppendTerm:  1,
+		// 	nextAppendIndex: 2,
+		// },
+		// Test term cache in RPC instant probe
 		{
-			leaderLog:       index(1).terms(1, 1, 3),
-			followerLog:     index(1).terms(1, 1, 3, 3, 3),
-			followerCompact: 5, // entries <= index 5 are compacted
-			rejectHintTerm:  0,
-			rejectHintIndex: 3,
-			nextAppendTerm:  1,
+			leaderLog:       entryID{index: 0, term: 1}.append(2, 2, 4, 6, 8),
+			followerLog:     entryID{index: 0, term: 0}.append(2, 3, 5, 7, 9),
+			rejectHintTerm:  7,
+			rejectHintIndex: 4,
+			nextAppendTerm:  2,
+			nextAppendIndex: 1,
+		},
+		{
+			leaderLog:       entryID{index: 0, term: 1}.append(2, 2, 4, 6, 8),
+			followerLog:     entryID{index: 0, term: 0}.append(2, 2, 5, 7, 9),
+			rejectHintTerm:  7,
+			rejectHintIndex: 4,
+			nextAppendTerm:  2,
 			nextAppendIndex: 2,
+		},
+		{
+			leaderLog:       entryID{index: 0, term: 1}.append(2, 2, 3, 6, 8),
+			followerLog:     entryID{index: 0, term: 0}.append(2, 2, 3, 7, 9),
+			rejectHintTerm:  7,
+			rejectHintIndex: 4,
+			nextAppendTerm:  3,
+			nextAppendIndex: 3,
+		},
+		{
+			leaderLog:       entryID{index: 0, term: 1}.append(2, 2, 3, 6, 8),
+			followerLog:     entryID{index: 0, term: 0}.append(2, 2, 3, 7, 9),
+			followerCompact: 3,
+			rejectHintTerm:  7,
+			rejectHintIndex: 4,
+			nextAppendTerm:  3,
+			nextAppendIndex: 3,
 		},
 	}
 
@@ -4970,8 +5004,8 @@ func TestFastLogRejection(t *testing.T) {
 		t.Run("", func(t *testing.T) {
 			s1 := NewMemoryStorage()
 			s1.snapshot.Metadata.ConfState = pb.ConfState{Voters: []pb.PeerID{1, 2, 3}}
-			s1.Append(test.leaderLog)
-			last := test.leaderLog[len(test.leaderLog)-1]
+			require.NoError(t, s1.Append(test.leaderLog.entries))
+			last := test.leaderLog.entries[len(test.leaderLog.entries)-1]
 			s1.SetHardState(pb.HardState{
 				Term:   last.Term - 1,
 				Commit: last.Index,
@@ -4982,15 +5016,22 @@ func TestFastLogRejection(t *testing.T) {
 
 			s2 := NewMemoryStorage()
 			s2.snapshot.Metadata.ConfState = pb.ConfState{Voters: []pb.PeerID{1, 2, 3}}
-			s2.Append(test.followerLog)
+
 			s2.SetHardState(pb.HardState{
 				Term:   last.Term,
 				Vote:   1,
 				Commit: 0,
 			})
 			n2 := newTestRaft(2, 10, 1, s2)
+			require.True(t, n2.raftLog.maybeAppend(test.followerLog))
+
 			if test.followerCompact != 0 {
-				s2.Compact(test.followerCompact)
+				n2.raftLog.commitTo(LogMark{Term: 3, Index: 5})
+				n2.raftLog.appliedTo(5)
+				require.NoError(t, s2.Append(test.followerLog.entries))
+				n2.raftLog.stableTo(LogMark{Term: 3, Index: 5})
+				n2.appliedTo(test.followerCompact - 1)
+				require.NoError(t, s2.Compact(test.followerCompact))
 				// NB: the state of n2 after this compaction isn't realistic because the
 				// commit index is still at 0. We do this to exercise a "doesn't happen"
 				// edge case behaviour, in case it still does happen in some other way.

--- a/pkg/raft/raftpb/raft.proto
+++ b/pkg/raft/raftpb/raft.proto
@@ -26,6 +26,11 @@ message Entry {
   optional bytes      Data  = 4;
 }
 
+message EntryID {
+  optional uint64     Term = 1 [(gogoproto.nullable) = false];
+  optional uint64     Index = 2 [(gogoproto.nullable) = false];
+}
+
 message SnapshotMetadata {
   optional ConfState conf_state = 1 [(gogoproto.nullable) = false];
   optional uint64    index      = 2 [(gogoproto.nullable) = false];
@@ -94,6 +99,7 @@ message Message {
   optional Snapshot    snapshot    = 9  [(gogoproto.nullable) = true];
   optional bool        reject      = 10 [(gogoproto.nullable) = false];
   optional uint64      rejectHint  = 11 [(gogoproto.nullable) = false];
+  repeated EntryID     tcEntryIDs  = 18  [(gogoproto.nullable) = false];
   optional bytes       context     = 12 [(gogoproto.nullable) = true];
 
   // match is the log index up to which the follower's log must persistently

--- a/pkg/raft/raftpb/raft_test.go
+++ b/pkg/raft/raftpb/raft_test.go
@@ -48,7 +48,7 @@ func TestProtoMemorySizes(t *testing.T) {
 	assert(unsafe.Sizeof(s), if64Bit(144, 80), "Snapshot")
 
 	var m Message
-	assert(unsafe.Sizeof(m), if64Bit(144, 84), "Message")
+	assert(unsafe.Sizeof(m), if64Bit(168, 112), "Message")
 
 	var hs HardState
 	assert(unsafe.Sizeof(hs), 40, "HardState")

--- a/pkg/raft/testdata/campaign_learner_must_vote.txt
+++ b/pkg/raft/testdata/campaign_learner_must_vote.txt
@@ -124,10 +124,10 @@ stabilize 2 3
   HardState Term:2 Vote:2 Commit:3 Lead:2 LeadEpoch:1
   OnSync:
   3->2 MsgFortifyLeaderResp Term:2 Log:0/0 LeadEpoch:1
-  3->2 MsgAppResp Term:2 Log:1/4 Rejected (Hint: 3) Commit:3
+  3->2 MsgAppResp Term:2 Log:1/4 Rejected (Hint: 3) TermCache: [t1/3] Commit:3
 > 2 receiving messages
   3->2 MsgFortifyLeaderResp Term:2 Log:0/0 LeadEpoch:1
-  3->2 MsgAppResp Term:2 Log:1/4 Rejected (Hint: 3) Commit:3
+  3->2 MsgAppResp Term:2 Log:1/4 Rejected (Hint: 3) TermCache: [t1/3] Commit:3
   DEBUG 2 received MsgAppResp(rejected, hint: (index 3, term 1)) from 3 for index 4
   DEBUG 2 decreased progress of 3 to [StateProbe match=0 next=4 sentCommit=3 matchCommit=3]
 > 2 handling Ready

--- a/pkg/raft/testdata/liveness_recovered_after_temporary_loss_of_quorum.txt
+++ b/pkg/raft/testdata/liveness_recovered_after_temporary_loss_of_quorum.txt
@@ -227,10 +227,10 @@ stabilize
   HardState Term:2 Vote:1 Commit:11 Lead:1 LeadEpoch:1
   OnSync:
   2->1 MsgFortifyLeaderResp Term:2 Log:0/0 LeadEpoch:1
-  2->1 MsgAppResp Term:2 Log:1/12 Rejected (Hint: 11) Commit:11
+  2->1 MsgAppResp Term:2 Log:1/12 Rejected (Hint: 11) TermCache: [t1/11] Commit:11
 > 1 receiving messages
   2->1 MsgFortifyLeaderResp Term:2 Log:0/0 LeadEpoch:1
-  2->1 MsgAppResp Term:2 Log:1/12 Rejected (Hint: 11) Commit:11
+  2->1 MsgAppResp Term:2 Log:1/12 Rejected (Hint: 11) TermCache: [t1/11] Commit:11
 > 1 handling Ready
   Ready:
   Messages:

--- a/pkg/raft/testdata/probe_and_replicate.txt
+++ b/pkg/raft/testdata/probe_and_replicate.txt
@@ -580,10 +580,10 @@ stabilize 1 2
   HardState Term:8 Vote:1 Commit:18 Lead:1 LeadEpoch:2
   OnSync:
   2->1 MsgFortifyLeaderResp Term:8 Log:0/0 LeadEpoch:2
-  2->1 MsgAppResp Term:8 Log:6/20 Rejected (Hint: 19) Commit:18
+  2->1 MsgAppResp Term:8 Log:6/20 Rejected (Hint: 19) TermCache: [t1/11, t4/14, t5/16, t6/18] Commit:18
 > 1 receiving messages
   2->1 MsgFortifyLeaderResp Term:8 Log:0/0 LeadEpoch:2
-  2->1 MsgAppResp Term:8 Log:6/20 Rejected (Hint: 19) Commit:18
+  2->1 MsgAppResp Term:8 Log:6/20 Rejected (Hint: 19) TermCache: [t1/11, t4/14, t5/16, t6/18] Commit:18
 > 1 handling Ready
   Ready:
   Messages:
@@ -616,10 +616,10 @@ stabilize 1 3
   HardState Term:8 Vote:1 Commit:14 Lead:1 LeadEpoch:2
   OnSync:
   3->1 MsgFortifyLeaderResp Term:8 Log:0/0 LeadEpoch:2
-  3->1 MsgAppResp Term:8 Log:4/20 Rejected (Hint: 14) Commit:14
+  3->1 MsgAppResp Term:8 Log:4/20 Rejected (Hint: 14) TermCache: [t1/11, t4/14] Commit:14
 > 1 receiving messages
   3->1 MsgFortifyLeaderResp Term:8 Log:0/0 LeadEpoch:2
-  3->1 MsgAppResp Term:8 Log:4/20 Rejected (Hint: 14) Commit:14
+  3->1 MsgAppResp Term:8 Log:4/20 Rejected (Hint: 14) TermCache: [t1/11, t4/14] Commit:14
 > 1 handling Ready
   Ready:
   Messages:
@@ -719,10 +719,10 @@ stabilize 1 5
   HardState Term:8 Commit:18 Lead:1 LeadEpoch:2
   OnSync:
   5->1 MsgFortifyLeaderResp Term:8 Log:0/0 LeadEpoch:2
-  5->1 MsgAppResp Term:8 Log:6/20 Rejected (Hint: 18) Commit:18
+  5->1 MsgAppResp Term:8 Log:6/20 Rejected (Hint: 18) TermCache: [t4/14, t5/16, t6/18] Commit:18
 > 1 receiving messages
   5->1 MsgFortifyLeaderResp Term:8 Log:0/0 LeadEpoch:2
-  5->1 MsgAppResp Term:8 Log:6/20 Rejected (Hint: 18) Commit:18
+  5->1 MsgAppResp Term:8 Log:6/20 Rejected (Hint: 18) TermCache: [t4/14, t5/16, t6/18] Commit:18
 > 1 handling Ready
   Ready:
   Messages:
@@ -766,10 +766,10 @@ stabilize 1 6
   HardState Term:8 Vote:1 Commit:15 Lead:1 LeadEpoch:2
   OnSync:
   6->1 MsgFortifyLeaderResp Term:8 Log:0/0 LeadEpoch:2
-  6->1 MsgAppResp Term:8 Log:4/20 Rejected (Hint: 17) Commit:15
+  6->1 MsgAppResp Term:8 Log:4/20 Rejected (Hint: 17) TermCache: [t1/11, t4/14] Commit:15
 > 1 receiving messages
   6->1 MsgFortifyLeaderResp Term:8 Log:0/0 LeadEpoch:2
-  6->1 MsgAppResp Term:8 Log:4/20 Rejected (Hint: 17) Commit:15
+  6->1 MsgAppResp Term:8 Log:4/20 Rejected (Hint: 17) TermCache: [t1/11, t4/14] Commit:15
 > 1 handling Ready
   Ready:
   Messages:
@@ -825,10 +825,10 @@ stabilize 1 7
   HardState Term:8 Vote:1 Commit:13 Lead:1 LeadEpoch:2
   OnSync:
   7->1 MsgFortifyLeaderResp Term:8 Log:0/0 LeadEpoch:2
-  7->1 MsgAppResp Term:8 Log:3/20 Rejected (Hint: 20) Commit:13
+  7->1 MsgAppResp Term:8 Log:3/20 Rejected (Hint: 20) TermCache: [t1/11, t2/14, t3/17] Commit:13
 > 1 receiving messages
   7->1 MsgFortifyLeaderResp Term:8 Log:0/0 LeadEpoch:2
-  7->1 MsgAppResp Term:8 Log:3/20 Rejected (Hint: 20) Commit:13
+  7->1 MsgAppResp Term:8 Log:3/20 Rejected (Hint: 20) TermCache: [t1/11, t2/14, t3/17] Commit:13
 > 1 handling Ready
   Ready:
   Messages:

--- a/pkg/raft/testdata/probe_and_replicate.txt
+++ b/pkg/raft/testdata/probe_and_replicate.txt
@@ -814,3 +814,70 @@ stabilize 1 6
   8/21 EntryNormal ""
 > 1 receiving messages
   6->1 MsgAppResp Term:8 Log:0/21 Commit:21
+
+stabilize 1 7
+----
+> 7 receiving messages
+  1->7 MsgFortifyLeader Term:8 Log:0/0
+  1->7 MsgApp Term:8 Log:6/20 Commit:18 Entries:[8/21 EntryNormal ""]
+> 7 handling Ready
+  Ready:
+  HardState Term:8 Vote:1 Commit:13 Lead:1 LeadEpoch:2
+  OnSync:
+  7->1 MsgFortifyLeaderResp Term:8 Log:0/0 LeadEpoch:2
+  7->1 MsgAppResp Term:8 Log:3/20 Rejected (Hint: 20) Commit:13
+> 1 receiving messages
+  7->1 MsgFortifyLeaderResp Term:8 Log:0/0 LeadEpoch:2
+  7->1 MsgAppResp Term:8 Log:3/20 Rejected (Hint: 20) Commit:13
+> 1 handling Ready
+  Ready:
+  Messages:
+  1->7 MsgApp Term:8 Log:1/13 Commit:21 Entries:[
+    4/14 EntryNormal ""
+    4/15 EntryNormal "prop_4_15"
+    5/16 EntryNormal ""
+    5/17 EntryNormal "prop_5_17"
+    6/18 EntryNormal ""
+    6/19 EntryNormal "prop_6_19"
+    6/20 EntryNormal "prop_6_20"
+    8/21 EntryNormal ""
+  ]
+> 7 receiving messages
+  1->7 MsgApp Term:8 Log:1/13 Commit:21 Entries:[
+    4/14 EntryNormal ""
+    4/15 EntryNormal "prop_4_15"
+    5/16 EntryNormal ""
+    5/17 EntryNormal "prop_5_17"
+    6/18 EntryNormal ""
+    6/19 EntryNormal "prop_6_19"
+    6/20 EntryNormal "prop_6_20"
+    8/21 EntryNormal ""
+  ]
+  INFO found conflict at index 14 [existing term: 2, conflicting term: 4]
+  INFO replace the unstable entries from index 14
+> 7 handling Ready
+  Ready:
+  HardState Term:8 Vote:1 Commit:21 Lead:1 LeadEpoch:2
+  Entries:
+  4/14 EntryNormal ""
+  4/15 EntryNormal "prop_4_15"
+  5/16 EntryNormal ""
+  5/17 EntryNormal "prop_5_17"
+  6/18 EntryNormal ""
+  6/19 EntryNormal "prop_6_19"
+  6/20 EntryNormal "prop_6_20"
+  8/21 EntryNormal ""
+  Committed: (13,21]
+  OnSync:
+  7->1 MsgAppResp Term:8 Log:0/21 Commit:21
+  Applying:
+  4/14 EntryNormal ""
+  4/15 EntryNormal "prop_4_15"
+  5/16 EntryNormal ""
+  5/17 EntryNormal "prop_5_17"
+  6/18 EntryNormal ""
+  6/19 EntryNormal "prop_6_19"
+  6/20 EntryNormal "prop_6_20"
+  8/21 EntryNormal ""
+> 1 receiving messages
+  7->1 MsgAppResp Term:8 Log:0/21 Commit:21

--- a/pkg/raft/testdata/replicate_pause.txt
+++ b/pkg/raft/testdata/replicate_pause.txt
@@ -144,13 +144,13 @@ stabilize 2 3
 > 3 handling Ready
   Ready:
   OnSync:
-  3->1 MsgAppResp Term:1 Log:1/14 Rejected (Hint: 11) Commit:11
+  3->1 MsgAppResp Term:1 Log:1/14 Rejected (Hint: 11) TermCache: [t1/11] Commit:11
 
 # Node 1 receives the rejection and adjusts the MsgApp sent to node 3.
 stabilize 1
 ----
 > 1 receiving messages
-  3->1 MsgAppResp Term:1 Log:1/14 Rejected (Hint: 11) Commit:11
+  3->1 MsgAppResp Term:1 Log:1/14 Rejected (Hint: 11) TermCache: [t1/11] Commit:11
   DEBUG 1 received MsgAppResp(rejected, hint: (index 11, term 1)) from 3 for index 14
   DEBUG 1 decreased progress of 3 to [StateReplicate match=11 next=12 sentCommit=11 matchCommit=11 paused inflight=3[full]]
 > 1 handling Ready

--- a/pkg/raft/testdata/snapshot_sent_and_leadership_change.txt
+++ b/pkg/raft/testdata/snapshot_sent_and_leadership_change.txt
@@ -174,8 +174,8 @@ stabilize 2
 > 2 receiving messages
   3->2 MsgAppResp Term:2 Log:1/15 Rejected (Hint: 11) TermCache: [t1/11] Commit:11
   DEBUG 2 received MsgAppResp(rejected, hint: (index 11, term 1)) from 3 for index 15
-  DEBUG 2 decreased progress of 3 to [StateProbe match=0 next=12 sentCommit=11 matchCommit=11]
-  DEBUG 2 [firstindex: 16, commit: 16] sent snapshot[index: 16, term: 2] to 3 [StateProbe match=0 next=12 sentCommit=11 matchCommit=11]
+  DEBUG 2 decreased progress of 3 to [StateProbe match=0 next=11 sentCommit=10 matchCommit=11]
+  DEBUG 2 [firstindex: 16, commit: 16] sent snapshot[index: 16, term: 2] to 3 [StateProbe match=0 next=11 sentCommit=10 matchCommit=11]
   DEBUG 2 paused sending replication messages to 3 [StateSnapshot match=0 next=17 sentCommit=16 matchCommit=11 paused pendingSnap=16]
   3->2 MsgAppResp Term:2 Log:0/15 Commit:15
   DEBUG 2 recovered from needing snapshot, resumed sending replication messages to 3 [StateSnapshot match=15 next=17 sentCommit=16 matchCommit=15 paused pendingSnap=16]

--- a/pkg/raft/testdata/snapshot_sent_and_leadership_change.txt
+++ b/pkg/raft/testdata/snapshot_sent_and_leadership_change.txt
@@ -135,7 +135,7 @@ stabilize 3
   HardState Term:2 Commit:15 Lead:2 LeadEpoch:0
   Snapshot Index:15 Term:1 ConfState:Voters:[1 2 3] VotersOutgoing:[] Learners:[] LearnersNext:[] AutoLeave:false
   OnSync:
-  3->2 MsgAppResp Term:2 Log:1/15 Rejected (Hint: 11) Commit:11
+  3->2 MsgAppResp Term:2 Log:1/15 Rejected (Hint: 11) TermCache: [t1/11] Commit:11
   3->1 MsgAppResp Term:2 Log:0/15 Commit:15
   3->2 MsgAppResp Term:2 Log:0/15 Commit:15
 > 3 receiving messages
@@ -172,7 +172,7 @@ compact 2 15
 stabilize 2
 ----
 > 2 receiving messages
-  3->2 MsgAppResp Term:2 Log:1/15 Rejected (Hint: 11) Commit:11
+  3->2 MsgAppResp Term:2 Log:1/15 Rejected (Hint: 11) TermCache: [t1/11] Commit:11
   DEBUG 2 received MsgAppResp(rejected, hint: (index 11, term 1)) from 3 for index 15
   DEBUG 2 decreased progress of 3 to [StateProbe match=0 next=12 sentCommit=11 matchCommit=11]
   DEBUG 2 [firstindex: 16, commit: 16] sent snapshot[index: 16, term: 2] to 3 [StateProbe match=0 next=12 sentCommit=11 matchCommit=11]

--- a/pkg/raft/util.go
+++ b/pkg/raft/util.go
@@ -199,6 +199,9 @@ func DescribeMessage(m pb.Message, f EntryFormatter) string {
 	if m.Reject {
 		fmt.Fprintf(&buf, " Rejected (Hint: %d)", m.RejectHint)
 	}
+	if len(m.TcEntryIDs) != 0 {
+		fmt.Fprintf(&buf, " TermCache: %v", prettyPrintLogTermCacheContents(convertEntryIDs(m.TcEntryIDs)))
+	}
 	if m.Commit != 0 {
 		fmt.Fprintf(&buf, " Commit:%d", m.Commit)
 	}


### PR DESCRIPTION
Prototype. 

```
//   idx        1 2 3 4 5 6 7 8 9
//              -----------------
//   term (L)   1 3 3 3 3 3 3 3 7
//   term (F)   1 3 3 4 4 5 5 5 6
```

How to find the correct fork point? 
There are a few considerations and a few scenarios:
How many entries don't match each other in total?
a few?
10s?
1000s? (for our case this is quite likely, since we are specifically looking at long divergent tails. If during each leader change, a lot of commands are proposed)

If we are to compare fork points, 
- should we do a simple binary search? Seems to be the way to go if there are 1000s entries.
- For simplicity, just do a linear scan? Well from left(lower entryIDs) to right(higher entryIDs)? or from right to left?
So the problem is, we are doing point look-ups, if those entries are not in the term cache, and also not in the entry cache, doing it one way doesn't load the entries into the entry cache, it is quite complicated
- taking advantage of the properties of the term cache, since it only carries term flip entries:
this is going to be hard to think about, there can be many cases:
example:
term cache entries:
leader:
[t5/10, t6/15, t8/20, t9/25]
follower:
[t5/10, t6/15, t7/19]

Cool, t5/10 matches, t6/15 matches, but we see that t7/19 does not match t8/20, this must mean t6/18 is the fork point. this is super fast. 
But this requires the term cache to cover all of that. 

What do we do if the term cache doesn't cover anything? 








