### PR TITLE
sql: disallow creating triggers which use TG_ARGV

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/triggers
+++ b/pkg/ccl/logictestccl/testdata/logic_test/triggers
@@ -4086,6 +4086,10 @@ DROP FUNCTION update_listing_balance ;
 statement ok
 drop table listings_balance cascade;
 
+# ==============================================================================
+# Regression tests.
+# ==============================================================================
+
 # Test that CREATE and DROP TRIGGER work when sent in a statement batch.
 
 subtest create_drop_in_batch_statement
@@ -4148,5 +4152,55 @@ SELECT id, a, b FROM tab_141810 ORDER BY id
 2  NULL  NULL
 3  1     2
 4  NULL  NULL
+
+subtest end
+
+# Until #135311 can be fixed, disallow TG_ARGV references by default. There is
+# a setting to allow them if necessary.
+subtest regression_135311
+
+statement ok
+DROP FUNCTION IF EXISTS g;
+
+statement ok
+CREATE FUNCTION g() RETURNS TRIGGER LANGUAGE PLpgSQL AS $$
+  BEGIN
+    RAISE NOTICE 'g()';
+    RAISE NOTICE 'TG_ARGV[1]: %', TG_ARGV[1];
+    RETURN NEW;
+  END
+$$;
+
+statement error pgcode 0A000 pq: unimplemented: referencing the TG_ARGV trigger function parameter is not yet supported
+CREATE TRIGGER foo BEFORE INSERT ON xy FOR EACH ROW EXECUTE FUNCTION g('foo', 'bar');
+
+statement ok
+SET allow_create_trigger_function_with_argv_references = true;
+
+statement ok
+CREATE TRIGGER foo BEFORE INSERT ON xy FOR EACH ROW EXECUTE FUNCTION g('foo', 'bar');
+
+query T noticetrace
+INSERT INTO xy VALUES (1, 2);
+----
+NOTICE: g()
+NOTICE: TG_ARGV[1]: foo
+
+statement ok
+RESET allow_create_trigger_function_with_argv_references;
+
+# The setting only disallows creating the trigger - not executing it if it was
+# already created.
+query T noticetrace
+INSERT INTO xy VALUES (3, 4);
+----
+NOTICE: g()
+NOTICE: TG_ARGV[1]: foo
+
+statement ok
+DROP TRIGGER foo ON xy;
+
+statement ok
+DROP FUNCTION g;
 
 subtest end

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -4119,6 +4119,10 @@ func (m *sessionDataMutator) SetOptimizerUseDeleteRangeFastPath(val bool) {
 	m.data.OptimizerUseDeleteRangeFastPath = val
 }
 
+func (m *sessionDataMutator) SetAllowCreateTriggerFunctionWithArgvReferences(val bool) {
+	m.data.AllowCreateTriggerFunctionWithArgvReferences = val
+}
+
 // Utility functions related to scrubbing sensitive information on SQL Stats.
 
 // quantizeCounts ensures that the Count field in the

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -3902,6 +3902,7 @@ WHERE
 ORDER BY variable
 ----
 variable                                                   value
+allow_create_trigger_function_with_argv_references         off
 allow_ordinal_column_references                            off
 allow_role_memberships_to_change_during_transaction        off
 alter_primary_region_super_region_override                 off

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -2911,6 +2911,7 @@ WHERE
 ORDER BY name
 ----
 name                                                       setting             category  short_desc  extra_desc  vartype
+allow_create_trigger_function_with_argv_references         off                 NULL      NULL        NULL        string
 allow_ordinal_column_references                            off                 NULL      NULL        NULL        string
 allow_role_memberships_to_change_during_transaction        off                 NULL      NULL        NULL        string
 alter_primary_region_super_region_override                 off                 NULL      NULL        NULL        string
@@ -3127,6 +3128,7 @@ WHERE
 ORDER BY name
 ----
 name                                                       setting             unit  context  enumvals  boot_val            reset_val
+allow_create_trigger_function_with_argv_references         off                 NULL  user     NULL      off                 off
 allow_ordinal_column_references                            off                 NULL  user     NULL      off                 off
 allow_role_memberships_to_change_during_transaction        off                 NULL  user     NULL      off                 off
 alter_primary_region_super_region_override                 off                 NULL  user     NULL      off                 off
@@ -3336,6 +3338,7 @@ query TTTTTT colnames,rowsort
 SELECT name, source, min_val, max_val, sourcefile, sourceline FROM pg_catalog.pg_settings
 ----
 name                                                       source  min_val  max_val  sourcefile  sourceline
+allow_create_trigger_function_with_argv_references         NULL    NULL     NULL     NULL        NULL
 allow_ordinal_column_references                            NULL    NULL     NULL     NULL        NULL
 allow_role_memberships_to_change_during_transaction        NULL    NULL     NULL     NULL        NULL
 alter_primary_region_super_region_override                 NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -27,6 +27,7 @@ WHERE variable NOT IN ('optimizer', 'crdb_version', 'session_id', 'distsql_workm
 ORDER BY variable
 ----
 variable                                                   value
+allow_create_trigger_function_with_argv_references         off
 allow_ordinal_column_references                            off
 allow_role_memberships_to_change_during_transaction        off
 alter_primary_region_super_region_override                 off

--- a/pkg/sql/opt/optbuilder/create_function.go
+++ b/pkg/sql/opt/optbuilder/create_function.go
@@ -428,6 +428,7 @@ func (b *Builder) buildCreateFunction(cf *tree.CreateRoutine, inScope *scope) (o
 
 		// Special handling for trigger functions.
 		buildSQL := true
+		isTriggerFn := false
 		if funcReturnType.Identical(types.Trigger) {
 			// Trigger functions cannot have user-defined parameters. However, they do
 			// have a set of implicitly defined parameters.
@@ -449,6 +450,7 @@ func (b *Builder) buildCreateFunction(cf *tree.CreateRoutine, inScope *scope) (o
 			// Analysis of SQL expressions for trigger functions must be deferred
 			// until the function is bound to a trigger.
 			buildSQL = false
+			isTriggerFn = true
 		}
 
 		// We need to disable stable function folding because we want to catch the
@@ -456,8 +458,8 @@ func (b *Builder) buildCreateFunction(cf *tree.CreateRoutine, inScope *scope) (o
 		// the volatility.
 		b.factory.FoldingControl().TemporarilyDisallowStableFolds(func() {
 			plBuilder := newPLpgSQLBuilder(
-				b, cf.Name.Object(), stmt.AST.Label, nil /* colRefs */, routineParams,
-				funcReturnType, cf.IsProcedure, false /* isDoBlock */, buildSQL, nil, /* outScope */
+				b, cf.Name.Object(), stmt.AST.Label, nil /* colRefs */, routineParams, funcReturnType,
+				cf.IsProcedure, false /* isDoBlock */, isTriggerFn, buildSQL, nil, /* outScope */
 			)
 			stmtScope = plBuilder.buildRootBlock(stmt.AST, bodyScope, routineParams)
 		})

--- a/pkg/sql/opt/optbuilder/routine.go
+++ b/pkg/sql/opt/optbuilder/routine.go
@@ -447,7 +447,7 @@ func (b *Builder) buildRoutine(
 		var physProps *physical.Required
 		plBuilder := newPLpgSQLBuilder(
 			b, def.Name, stmt.AST.Label, colRefs, routineParams, f.ResolvedType(),
-			isProc, false /* isDoBlock */, true /* buildSQL */, outScope,
+			isProc, false /* isDoBlock */, false /* isTriggerFn */, true /* buildSQL */, outScope,
 		)
 		stmtScope := plBuilder.buildRootBlock(stmt.AST, bodyScope, routineParams)
 		rTyp := b.finalizeRoutineReturnType(f, stmtScope, inScope, oldInsideDataSource)
@@ -859,7 +859,8 @@ func (b *Builder) buildPLpgSQLDoBody(
 	// Build an expression for each statement in the function body.
 	plBuilder := newPLpgSQLBuilder(
 		b, doBlockRoutineName, do.Block.Label, nil /* colRefs */, nil /* routineParams */, types.Void,
-		true /* isProc */, true /* isDoBlock */, true /* buildSQL */, nil, /* outScope */
+		true /* isProc */, true, /* isDoBlock */
+		false /* isTriggerFn */, true /* buildSQL */, nil, /* outScope */
 	)
 	// Allocate a fresh scope, since DO blocks do not take parameters or reference
 	// variables or columns from the calling context.

--- a/pkg/sql/opt/optbuilder/scope.go
+++ b/pkg/sql/opt/optbuilder/scope.go
@@ -872,7 +872,7 @@ func (s *scope) FindSourceProvidingColumn(
 			if candidate.ambiguous {
 				return nil, nil, -1, s.newAmbiguousColumnError(colName, candidate.matchClass)
 			}
-			return &col.table, col, int(col.id), nil
+			return &col.table, col, int(col.id), col.resolveErr
 		}
 		// No matches in this scope; proceed to the parent scope.
 	}
@@ -1015,7 +1015,7 @@ func (s *scope) Resolve(
 		if col.visibility != inaccessible &&
 			col.name.MatchesReferenceName(colName) &&
 			sourceNameMatches(*prefix, col.table) {
-			return col, nil
+			return col, col.resolveErr
 		}
 	}
 

--- a/pkg/sql/opt/optbuilder/scope_column.go
+++ b/pkg/sql/opt/optbuilder/scope_column.go
@@ -70,6 +70,11 @@ type scopeColumn struct {
 	// exprStr contains a stringified representation of expr, or the original
 	// column name if expr is nil. It is populated lazily inside getExprStr().
 	exprStr string
+
+	// resolveErr, if non-nil, is the error to be returned when the column is
+	// successfully resolved. This is used to provide a helpful error message for
+	// a column that is not allowed to be referenced.
+	resolveErr error
 }
 
 // columnVisibility is an extension of cat.ColumnVisibility.

--- a/pkg/sql/opt/optbuilder/trigger.go
+++ b/pkg/sql/opt/optbuilder/trigger.go
@@ -839,7 +839,8 @@ func (b *Builder) buildTriggerFunction(
 	}
 	plBuilder := newPLpgSQLBuilder(
 		b, resolvedDef.Name, stmt.AST.Label, nil /* colRefs */, params, tableTyp,
-		false /* isProc */, false /* isDoBlock */, true /* buildSQL */, nil, /* outScope */
+		false /* isProc */, false, /* isDoBlock */
+		true /* isTriggerFn */, true /* buildSQL */, nil, /* outScope */
 	)
 	stmtScope := plBuilder.buildRootBlock(stmt.AST, triggerFuncScope, params)
 	udfDef.Body = []memo.RelExpr{stmtScope.expr}

--- a/pkg/sql/sessiondatapb/local_only_session_data.proto
+++ b/pkg/sql/sessiondatapb/local_only_session_data.proto
@@ -648,6 +648,11 @@ message LocalOnlySessionData {
   // OptimizerUseDeleteRangeFastPath, when true, indicates that the optimizer
   // should try to use the delete range fast-path when possible.
   bool optimizer_use_delete_range_fast_path = 164;
+  // AllowCreateTriggerFunctionWithArgvReferences, when true, allows triggers to
+  // be created with trigger functions that use the TG_ARGV parameter even
+  // though it currently doesn't have Postgres-compatible 0-based indexing
+  // behavior.
+  bool allow_create_trigger_function_with_argv_references = 165;
 
   ///////////////////////////////////////////////////////////////////////////
   // WARNING: consider whether a session parameter you're adding needs to  //

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -3924,6 +3924,23 @@ var varGen = map[string]sessionVar{
 		},
 		GlobalDefault: globalTrue,
 	},
+
+	// CockroachDB extension.
+	`allow_create_trigger_function_with_argv_references`: {
+		GetStringVal: makePostgresBoolGetStringValFn(`allow_create_trigger_function_with_argv_references`),
+		Set: func(_ context.Context, m sessionDataMutator, s string) error {
+			b, err := paramparse.ParseBoolVar("allow_create_trigger_function_with_argv_references", s)
+			if err != nil {
+				return err
+			}
+			m.SetAllowCreateTriggerFunctionWithArgvReferences(b)
+			return nil
+		},
+		Get: func(evalCtx *extendedEvalContext, _ *kv.Txn) (string, error) {
+			return formatBoolAsPostgresSetting(evalCtx.SessionData().AllowCreateTriggerFunctionWithArgvReferences), nil
+		},
+		GlobalDefault: globalFalse,
+	},
 }
 
 func ReplicationModeFromString(s string) (sessiondatapb.ReplicationMode, error) {


### PR DESCRIPTION
The `TG_ARGV` trigger function argument is 0-indexed in Postgres. Since we currently don't have a way to replicate this behvaior, this commit disallows usage of `TG_ARGV` for now. The session setting `allow_create_trigger_function_with_argv_references` can be set to true to allow usage (with 1-based indexing).

Informs #135311

Release note (sql change): Usage of `TG_ARGV` in trigger functions is now disallowed by default.