### PR TITLE
kvserver: allow running KVNemesis under race-detector

### DIFF
--- a/pkg/kv/kvnemesis/kvnemesis_test.go
+++ b/pkg/kv/kvnemesis/kvnemesis_test.go
@@ -45,6 +45,7 @@ func (cfg kvnemesisTestCfg) testClusterArgs(
 	ctx context.Context, tr *SeqTracker,
 ) base.TestClusterArgs {
 	storeKnobs := &kvserver.StoreTestingKnobs{
+		AllowUnsynchronizedReplicationChanges: true,
 		// Drop the clock MaxOffset to reduce commit-wait time for
 		// transactions that write to global_read ranges.
 		MaxOffset: 10 * time.Millisecond,

--- a/pkg/kv/kvserver/batcheval/BUILD.bazel
+++ b/pkg/kv/kvserver/batcheval/BUILD.bazel
@@ -60,6 +60,7 @@ go_library(
         "//pkg/build",
         "//pkg/clusterversion",
         "//pkg/keys",
+        "//pkg/kv/kvnemesis/kvnemesisutil",
         "//pkg/kv/kvpb",
         "//pkg/kv/kvserver/abortspan",
         "//pkg/kv/kvserver/batcheval/result",

--- a/pkg/kv/kvserver/batcheval/cmd_add_sstable.go
+++ b/pkg/kv/kvserver/batcheval/cmd_add_sstable.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvnemesis/kvnemesisutil"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/batcheval/result"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
@@ -585,6 +586,11 @@ func assertSSTContents(sst []byte, sstTimestamp hlc.Timestamp, stats *enginepb.M
 			if !value.IsTombstone() {
 				return errors.AssertionFailedf("SST contains non-tombstone range key %s", rangeKey)
 			}
+
+			// Set the KVNemesisSeq to its zero value so that we can run KVNemesis
+			// under the race detector.
+			var emptyContainer kvnemesisutil.Container
+			value.MVCCValueHeader.KVNemesisSeq = emptyContainer
 			if value.MVCCValueHeader != (enginepb.MVCCValueHeader{}) {
 				return errors.AssertionFailedf("SST contains non-empty MVCC value header for range key %s",
 					rangeKey)


### PR DESCRIPTION
When race-detector builds are enabled, we run additional safety checks that are not compatible with KVNemesis. This PR addresses a few of those checks so that we can run KVNemesis under the race detector.

All KVNemesis tests are still skipped under the race detector, but can be run manually with something like:

    ./dev test ./pkg/kv/kvnemesis/ --filter \
    '^TestKVNemesisSingleNode$' --race --verbose -- --test_env \
    COCKROACH_FORCE_RUN_SKIPPED_TESTS=true --test_env \
    COCKROACH_KVNEMESIS_STEPS=1000

This immediately found #143834.

Epic: none

Release note: None