### PR TITLE
kvpb: avoid potential race for Combine callers 

### DIFF
--- a/pkg/kv/kvnemesis/kvnemesis_test.go
+++ b/pkg/kv/kvnemesis/kvnemesis_test.go
@@ -45,6 +45,7 @@ func (cfg kvnemesisTestCfg) testClusterArgs(
 	ctx context.Context, tr *SeqTracker,
 ) base.TestClusterArgs {
 	storeKnobs := &kvserver.StoreTestingKnobs{
+		AllowUnsynchronizedReplicationChanges: true,
 		// Drop the clock MaxOffset to reduce commit-wait time for
 		// transactions that write to global_read ranges.
 		MaxOffset: 10 * time.Millisecond,

--- a/pkg/kv/kvpb/batch.go
+++ b/pkg/kv/kvpb/batch.go
@@ -714,7 +714,7 @@ func (br *BatchResponse) Combine(
 	for i := range otherBatch.Responses {
 		pos := positions[i]
 		if br.Responses[pos] == (ResponseUnion{}) {
-			br.Responses[pos] = otherBatch.Responses[i]
+			br.Responses[pos].MustSetInner(otherBatch.Responses[i].GetInner().ShallowCopy())
 			continue
 		}
 		valLeft := br.Responses[pos].GetInner()

--- a/pkg/kv/kvserver/batcheval/BUILD.bazel
+++ b/pkg/kv/kvserver/batcheval/BUILD.bazel
@@ -60,6 +60,7 @@ go_library(
         "//pkg/build",
         "//pkg/clusterversion",
         "//pkg/keys",
+        "//pkg/kv/kvnemesis/kvnemesisutil",
         "//pkg/kv/kvpb",
         "//pkg/kv/kvserver/abortspan",
         "//pkg/kv/kvserver/batcheval/result",

--- a/pkg/kv/kvserver/batcheval/cmd_add_sstable.go
+++ b/pkg/kv/kvserver/batcheval/cmd_add_sstable.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvnemesis/kvnemesisutil"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/batcheval/result"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
@@ -585,6 +586,11 @@ func assertSSTContents(sst []byte, sstTimestamp hlc.Timestamp, stats *enginepb.M
 			if !value.IsTombstone() {
 				return errors.AssertionFailedf("SST contains non-tombstone range key %s", rangeKey)
 			}
+
+			// Set the KVNemesisSeq to its zero value so that we can run KVNemesis
+			// under the race detector.
+			var emptyContainer kvnemesisutil.Container
+			value.MVCCValueHeader.KVNemesisSeq = emptyContainer
 			if value.MVCCValueHeader != (enginepb.MVCCValueHeader{}) {
 				return errors.AssertionFailedf("SST contains non-empty MVCC value header for range key %s",
 					rangeKey)


### PR DESCRIPTION
First commit is #143835

When the local fast path is in use and for requests that can be acked
before application, it is possible that the KVServer still has a
reference to the returned response that it is going to read.

As a result, the previous code had a potential race condition in which
the response the server-side was still reading was being written to by
a subsequent call to combine.

Here, we avoid that race by taking a shallow copy.

Fixes https://github.com/cockroachdb/cockroach/issues/143834

Release note: None