### PR TITLE
jsonpath: add division by zero check for modulo operation

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/jsonb_path_query
+++ b/pkg/sql/logictest/testdata/logic_test/jsonb_path_query
@@ -729,6 +729,9 @@ SELECT jsonb_path_query('{}', '3 % 2');
 ----
 1
 
+statement error pgcode 22012 pq: division by zero
+SELECT jsonb_path_query('{}', '1 % 0');
+
 query T
 SELECT jsonb_path_query('{"a": 4, "b": 5}', '$.a + $.b');
 ----

--- a/pkg/util/jsonpath/eval/operation.go
+++ b/pkg/util/jsonpath/eval/operation.go
@@ -358,6 +358,16 @@ func (ctx *jsonpathCtx) evalArithmetic(
 			return nil, tree.ErrDivByZero
 		}
 	case jsonpath.OpMod:
+		// In other places where apd.Context.Rem() is called, we first check if
+		// the left value is NaN and the right value is 0, then return ErrDivByZero.
+		// In this case, NaN shouldn't happen because JSON numbers cannot be NaN.
+		// We assert this here, and then check if the right value is 0.
+		if leftNum.Form == apd.NaN || rightNum.Form == apd.NaN {
+			return nil, errors.AssertionFailedf("numbers in jsonpath queries cannot be NaN")
+		}
+		if rightNum.IsZero() {
+			return nil, tree.ErrDivByZero
+		}
 		_, err = tree.DecimalCtx.Rem(&res, leftNum, rightNum)
 	default:
 		panic(errors.AssertionFailedf("unhandled jsonpath arithmetic type"))


### PR DESCRIPTION
This commit adds a check for division by zero in the modulo operation to match Postgres' behaviour and maintain consistency with other modulo/division operations in the codebase.

Epic: None
Release note: None