### PR TITLE
changefeedccl: accept "invalid escape string" as valid pg error

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -1355,6 +1355,7 @@ func TestChangefeedRandomExpressions(t *testing.T) {
 					"cannot subtract infinite dates",
 					"regexp compilation failed",
 					"invalid regular expression",
+					"invalid escape string",
 					"error parsing GeoJSON",
 					"error parsing EWKT",
 					"geometry type is unsupported",


### PR DESCRIPTION
The TestChangefeedRandomExpressions test could fail if sqlsmith
generated a query including not_similar_to_escape with certain
regexs. Treat this error the same as "invalid regular expression"
and add it to the list of valid errors.

Fixes: #143589

Release note: None