### PR TITLE
release-25.1: crosscluster/logical: fix ALTER .. SET REPLICATION READ VIRTUAL CLUSTER

### DIFF
--- a/pkg/crosscluster/physical/alter_replication_job_test.go
+++ b/pkg/crosscluster/physical/alter_replication_job_test.go
@@ -111,6 +111,30 @@ func TestAlterTenantCompleteToLatest(t *testing.T) {
 	c.CompareResult(`SELECT * FROM d.t2`)
 }
 
+func TestAlterTenantAddReader(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	args := replicationtestutils.DefaultTenantStreamingClustersArgs
+
+	c, cleanup := replicationtestutils.CreateTenantStreamingClusters(ctx, t, args)
+	defer cleanup()
+	producerJobID, ingestionJobID := c.StartStreamReplication(ctx)
+
+	jobutils.WaitForJobToRun(t, c.SrcSysSQL, jobspb.JobID(producerJobID))
+	jobutils.WaitForJobToRun(t, c.DestSysSQL, jobspb.JobID(ingestionJobID))
+
+	c.WaitUntilReplicatedTime(c.SrcCluster.Server(0).Clock().Now(), jobspb.JobID(ingestionJobID))
+	c.DestSysSQL.CheckQueryResults(t, "SELECT name FROM [SHOW TENANTS] ORDER BY name",
+		[][]string{{"destination"}, {"system"}},
+	)
+	c.DestSysSQL.Exec(t, "ALTER TENANT $1 SET REPLICATION READ VIRTUAL CLUSTER", args.DestTenantName)
+	c.DestSysSQL.CheckQueryResults(t, "SELECT name, data_state FROM [SHOW TENANTS] ORDER BY name",
+		[][]string{{"destination", "replicating"}, {"destination-readonly", "ready"}, {"system", "ready"}},
+	)
+}
+
 func TestAlterTenantPauseResume(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)

--- a/pkg/crosscluster/physical/stream_ingestion_planning.go
+++ b/pkg/crosscluster/physical/stream_ingestion_planning.go
@@ -181,7 +181,7 @@ func ingestionPlanHook(
 			return nil
 		}
 
-		readerID, err := createReaderTenant(ctx, p, tenantInfo.Name, destinationTenantID, options)
+		readerID, err := createReaderTenant(ctx, p, tenantInfo.Name, destinationTenantID, options, false)
 		if err != nil {
 			return err
 		}
@@ -300,11 +300,17 @@ func createReaderTenant(
 	tenantName roachpb.TenantName,
 	destinationTenantID roachpb.TenantID,
 	options *resolvedTenantReplicationOptions,
+	ready bool,
 ) (roachpb.TenantID, error) {
 	var readerID roachpb.TenantID
 	if options.ReaderTenantEnabled() {
 		var readerInfo mtinfopb.TenantInfoWithUsage
-		readerInfo.DataState = mtinfopb.DataStateAdd
+		if ready {
+			readerInfo.DataState = mtinfopb.DataStateReady
+			readerInfo.ServiceMode = mtinfopb.ServiceModeShared
+		} else {
+			readerInfo.DataState = mtinfopb.DataStateAdd
+		}
 		readerInfo.Name = tenantName + "-readonly"
 		readerInfo.ReadFromTenant = &destinationTenantID
 


### PR DESCRIPTION
Backport 1/1 commits from #143752.

/cc @cockroachdb/release

---

This is in the syntax but the ALTER function was not handling this option if it was set -- the statement would silently succeed without even attempting to create a reader cluster.

This statement now attempts to create a readder cluster. If one already exists, or another virtual cluster has otherwise been created with the reader's default name, the statement will fail.

Release note (bug fix): The ALTER VIRTUAL CLUSTER SET REPLICATION READ VIRTUAL CLUSTER syntax is now supported for adding a reader virtual cluster for an existing PCR standby.
Epic: none.
