### PR TITLE
explain: show "execution time" on EXPLAIN ANALYZE output

### DIFF
--- a/pkg/sql/instrumentation.go
+++ b/pkg/sql/instrumentation.go
@@ -1060,6 +1060,10 @@ func (m execNodeTraceMetadata) annotateExplain(
 					nodeStats.InternalStepCount.MaybeAdd(stats.KV.NumInternalSteps)
 					nodeStats.SeekCount.MaybeAdd(stats.KV.NumInterfaceSeeks)
 					nodeStats.InternalSeekCount.MaybeAdd(stats.KV.NumInternalSeeks)
+					// If multiple physical plan stages correspond to a single
+					// operator, we want to aggregate the execution time across
+					// all of them.
+					nodeStats.ExecTime.MaybeAdd(stats.Exec.ExecTime)
 					nodeStats.MaxAllocatedMem.MaybeAdd(stats.Exec.MaxAllocatedMem)
 					nodeStats.MaxAllocatedDisk.MaybeAdd(stats.Exec.MaxAllocatedDisk)
 					if noMutations && !makeDeterministic {

--- a/pkg/sql/opt/exec/execbuilder/testdata/call
+++ b/pkg/sql/opt/exec/execbuilder/testdata/call
@@ -149,6 +149,7 @@ quality of service: regular
   sql nodes: <hidden>
   regions: <hidden>
   actual row count: 0
+  execution time: 0µs
   estimated row count: 0
   procedure: foo(3)
 
@@ -171,6 +172,7 @@ quality of service: regular
   sql nodes: <hidden>
   regions: <hidden>
   actual row count: 0
+  execution time: 0µs
   estimated row count: 0
   procedure: foo(3)
 ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/call_plpgsql
+++ b/pkg/sql/opt/exec/execbuilder/testdata/call_plpgsql
@@ -155,6 +155,7 @@ quality of service: regular
   sql nodes: <hidden>
   regions: <hidden>
   actual row count: 0
+  execution time: 0µs
   estimated row count: 0
   procedure: foo(3)
 
@@ -177,6 +178,7 @@ quality of service: regular
   sql nodes: <hidden>
   regions: <hidden>
   actual row count: 0
+  execution time: 0µs
   estimated row count: 0
   procedure: foo(3)
 ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/cascade
+++ b/pkg/sql/opt/exec/execbuilder/testdata/cascade
@@ -1084,12 +1084,14 @@ quality of service: regular
 │   │ sql nodes: <hidden>
 │   │ regions: <hidden>
 │   │ actual row count: 1
+│   │ execution time: 0µs
 │   │ from: loop_a
 │   │
 │   └── • buffer
 │       │ sql nodes: <hidden>
 │       │ regions: <hidden>
 │       │ actual row count: 1
+│       │ execution time: 0µs
 │       │ label: buffer 1
 │       │
 │       └── • scan
@@ -1117,18 +1119,21 @@ quality of service: regular
         │   │ sql nodes: <hidden>
         │   │ regions: <hidden>
         │   │ actual row count: 0
+        │   │ execution time: 0µs
         │   │ from: loop_b
         │   │
         │   └── • buffer
         │       │ sql nodes: <hidden>
         │       │ regions: <hidden>
         │       │ actual row count: 1
+        │       │ execution time: 0µs
         │       │ label: buffer 1
         │       │
         │       └── • hash join (semi)
         │           │ sql nodes: <hidden>
         │           │ regions: <hidden>
         │           │ actual row count: 1
+        │           │ execution time: 0µs
         │           │ estimated max memory allocated: 0 B
         │           │ equality: (cascade_delete) = (id)
         │           │
@@ -1151,6 +1156,7 @@ quality of service: regular
         │                 sql nodes: <hidden>
         │                 regions: <hidden>
         │                 actual row count: 1
+        │                 execution time: 0µs
         │                 estimated row count: 1
         │                 label: buffer 1000000
         │
@@ -1163,12 +1169,14 @@ quality of service: regular
                 │   │ sql nodes: <hidden>
                 │   │ regions: <hidden>
                 │   │ actual row count: 0
+                │   │ execution time: 0µs
                 │   │ from: loop_a
                 │   │
                 │   └── • buffer
                 │       │ sql nodes: <hidden>
                 │       │ regions: <hidden>
                 │       │ actual row count: 1
+                │       │ execution time: 0µs
                 │       │ label: buffer 1
                 │       │
                 │       └── • lookup join
@@ -1181,6 +1189,7 @@ quality of service: regular
                 │           │ KV pairs read: 2
                 │           │ KV bytes read: 8 B
                 │           │ KV gRPC calls: 1
+                │           │ execution time: 0µs
                 │           │ estimated max memory allocated: 0 B
                 │           │ table: loop_a@loop_a_cascade_delete_idx
                 │           │ equality: (id) = (cascade_delete)
@@ -1189,6 +1198,7 @@ quality of service: regular
                 │               │ sql nodes: <hidden>
                 │               │ regions: <hidden>
                 │               │ actual row count: 1
+                │               │ execution time: 0µs
                 │               │ estimated max memory allocated: 0 B
                 │               │ estimated row count: 1
                 │               │ distinct on: id
@@ -1197,6 +1207,7 @@ quality of service: regular
                 │                     sql nodes: <hidden>
                 │                     regions: <hidden>
                 │                     actual row count: 1
+                │                     execution time: 0µs
                 │                     estimated row count: 1
                 │                     label: buffer 1000000
                 │
@@ -1485,18 +1496,21 @@ quality of service: regular
 │   │ sql nodes: <hidden>
 │   │ regions: <hidden>
 │   │ actual row count: 0
+│   │ execution time: 0µs
 │   │ from: p138974
 │   │
 │   └── • buffer
 │       │ sql nodes: <hidden>
 │       │ regions: <hidden>
 │       │ actual row count: 0
+│       │ execution time: 0µs
 │       │ label: buffer 1
 │       │
 │       └── • filter
 │           │ sql nodes: <hidden>
 │           │ regions: <hidden>
 │           │ actual row count: 0
+│           │ execution time: 0µs
 │           │ filter: v = 1
 │           │
 │           └── • scan

--- a/pkg/sql/opt/exec/execbuilder/testdata/delete
+++ b/pkg/sql/opt/exec/execbuilder/testdata/delete
@@ -493,6 +493,7 @@ quality of service: regular
 │ sql nodes: <hidden>
 │ regions: <hidden>
 │ actual row count: 0
+│ execution time: 0µs
 │ from: t137352
 │ auto commit
 │
@@ -505,6 +506,7 @@ quality of service: regular
     │ KV rows decoded: 0
     │ KV bytes read: 0 B
     │ KV gRPC calls: 0
+    │ execution time: 0µs
     │ estimated max memory allocated: 0 B
     │ table: t137352@t137352_pkey
     │ equality: ($1) = (k)
@@ -515,6 +517,7 @@ quality of service: regular
           sql nodes: <hidden>
           regions: <hidden>
           actual row count: 1
+          execution time: 0µs
           size: 1 column, 1 row
 
 statement ok
@@ -553,6 +556,7 @@ quality of service: regular
 │ sql nodes: <hidden>
 │ regions: <hidden>
 │ actual row count: 0
+│ execution time: 0µs
 │ from: t137352
 │ auto commit
 │
@@ -564,6 +568,7 @@ quality of service: regular
     │ KV rows decoded: 0
     │ KV bytes read: 0 B
     │ KV gRPC calls: 0
+    │ execution time: 0µs
     │ estimated max memory allocated: 0 B
     │ table: t137352@t137352_pkey
     │ equality: (k) = (k)
@@ -579,6 +584,7 @@ quality of service: regular
         │ KV rows decoded: 0
         │ KV bytes read: 0 B
         │ KV gRPC calls: 0
+        │ execution time: 0µs
         │ estimated max memory allocated: 0 B
         │ table: t137352@t137352_a_idx
         │ equality: ($1) = (a)
@@ -588,6 +594,7 @@ quality of service: regular
               sql nodes: <hidden>
               regions: <hidden>
               actual row count: 1
+              execution time: 0µs
               size: 1 column, 1 row
 
 statement ok

--- a/pkg/sql/opt/exec/execbuilder/testdata/dist_vectorize
+++ b/pkg/sql/opt/exec/execbuilder/testdata/dist_vectorize
@@ -69,6 +69,7 @@ quality of service: regular
 │ sql nodes: <hidden>
 │ regions: <hidden>
 │ actual row count: 1
+│ execution time: 0µs
 │
 └── • scan
       sql nodes: <hidden>
@@ -107,6 +108,7 @@ quality of service: regular
 │ sql nodes: <hidden>
 │ regions: <hidden>
 │ actual row count: 5
+│ execution time: 0µs
 │ estimated max memory allocated: 0 B
 │ estimated max sql temp disk usage: 0 B
 │ equality: (k) = (k)

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -2263,6 +2263,7 @@ quality of service: regular
   sql nodes: <hidden>
   regions: <hidden>
   actual row count: 1
+  execution time: 0µs
   size: 1 column, 1 row
 
 # Tests for EXPLAIN (OPT, MEMO).

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain_analyze
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain_analyze
@@ -102,6 +102,7 @@ quality of service: regular
 │ sql nodes: <hidden>
 │ regions: <hidden>
 │ actual row count: 1
+│ execution time: 0µs
 │ estimated max memory allocated: 0 B
 │ order: +nspname,+relname
 │
@@ -111,6 +112,7 @@ quality of service: regular
         │ sql nodes: <hidden>
         │ regions: <hidden>
         │ actual row count: 1
+        │ execution time: 0µs
         │ estimated max memory allocated: 0 B
         │ equality: (column80) = (table_id)
         │
@@ -120,6 +122,7 @@ quality of service: regular
         │       │ sql nodes: <hidden>
         │       │ regions: <hidden>
         │       │ actual row count: 1
+        │       │ execution time: 0µs
         │       │ estimated max memory allocated: 0 B
         │       │ equality: (column62) = (table_id)
         │       │ right cols are key
@@ -130,6 +133,7 @@ quality of service: regular
         │       │       │ sql nodes: <hidden>
         │       │       │ regions: <hidden>
         │       │       │ actual row count: 1
+        │       │       │ execution time: 0µs
         │       │       │ estimated max memory allocated: 0 B
         │       │       │ equality: (oid) = (relowner)
         │       │       │
@@ -137,12 +141,14 @@ quality of service: regular
         │       │       │     sql nodes: <hidden>
         │       │       │     regions: <hidden>
         │       │       │     actual row count: 4
+        │       │       │     execution time: 0µs
         │       │       │     table: pg_roles@primary
         │       │       │
         │       │       └── • hash join
         │       │           │ sql nodes: <hidden>
         │       │           │ regions: <hidden>
         │       │           │ actual row count: 1
+        │       │           │ execution time: 0µs
         │       │           │ estimated max memory allocated: 0 B
         │       │           │ equality: (oid) = (relnamespace)
         │       │           │
@@ -150,30 +156,35 @@ quality of service: regular
         │       │           │   │ sql nodes: <hidden>
         │       │           │   │ regions: <hidden>
         │       │           │   │ actual row count: 1
+        │       │           │   │ execution time: 0µs
         │       │           │   │ filter: nspname NOT IN ('crdb_internal', 'information_schema', __more1_10__, 'pg_extension')
         │       │           │   │
         │       │           │   └── • virtual table
         │       │           │         sql nodes: <hidden>
         │       │           │         regions: <hidden>
         │       │           │         actual row count: 5
+        │       │           │         execution time: 0µs
         │       │           │         table: pg_namespace@primary
         │       │           │
         │       │           └── • filter
         │       │               │ sql nodes: <hidden>
         │       │               │ regions: <hidden>
         │       │               │ actual row count: 330
+        │       │               │ execution time: 0µs
         │       │               │ filter: relkind IN ('S', 'm', __more1_10__, 'v')
         │       │               │
         │       │               └── • virtual table
         │       │                     sql nodes: <hidden>
         │       │                     regions: <hidden>
         │       │                     actual row count: 362
+        │       │                     execution time: 0µs
         │       │                     table: pg_class@primary
         │       │
         │       └── • distinct
         │           │ sql nodes: <hidden>
         │           │ regions: <hidden>
         │           │ actual row count: 330
+        │           │ execution time: 0µs
         │           │ estimated max memory allocated: 0 B
         │           │ distinct on: table_id
         │           │
@@ -181,11 +192,13 @@ quality of service: regular
         │                 sql nodes: <hidden>
         │                 regions: <hidden>
         │                 actual row count: 330
+        │                 execution time: 0µs
         │                 table: table_row_statistics@primary
         │
         └── • virtual table
               sql nodes: <hidden>
               regions: <hidden>
               actual row count: 1
+              execution time: 0µs
               table: tables@tables_database_name_idx (partial index)
               spans: [/'test' - /'test']

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain_analyze_plans
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain_analyze_plans
@@ -78,6 +78,7 @@ quality of service: regular
 │ sql nodes: <hidden>
 │ regions: <hidden>
 │ actual row count: 5
+│ execution time: 0µs
 │ group by: k
 │ ordered: +k
 │
@@ -85,6 +86,7 @@ quality of service: regular
     │ sql nodes: <hidden>
     │ regions: <hidden>
     │ actual row count: 5
+    │ execution time: 0µs
     │ estimated max memory allocated: 0 B
     │ estimated max sql temp disk usage: 0 B
     │ equality: (k) = (k)
@@ -144,6 +146,7 @@ quality of service: regular
 │ sql nodes: <hidden>
 │ regions: <hidden>
 │ actual row count: 5
+│ execution time: 0µs
 │ estimated max memory allocated: 0 B
 │ order: +w
 │
@@ -151,6 +154,7 @@ quality of service: regular
     │ sql nodes: <hidden>
     │ regions: <hidden>
     │ actual row count: 5
+    │ execution time: 0µs
     │ estimated max memory allocated: 0 B
     │ distinct on: w
     │
@@ -158,6 +162,7 @@ quality of service: regular
         │ sql nodes: <hidden>
         │ regions: <hidden>
         │ actual row count: 5
+        │ execution time: 0µs
         │ estimated max memory allocated: 0 B
         │ equality: (k) = (w)
         │ left cols are key
@@ -215,6 +220,7 @@ quality of service: regular
 │ sql nodes: <hidden>
 │ regions: <hidden>
 │ actual row count: 25
+│ execution time: 0µs
 │ estimated max memory allocated: 0 B
 │ estimated max sql temp disk usage: 0 B
 │
@@ -222,6 +228,7 @@ quality of service: regular
 │   │ sql nodes: <hidden>
 │   │ regions: <hidden>
 │   │ actual row count: 5
+│   │ execution time: 0µs
 │   │
 │   └── • scan
 │         sql nodes: <hidden>
@@ -242,6 +249,7 @@ quality of service: regular
     │ sql nodes: <hidden>
     │ regions: <hidden>
     │ actual row count: 5
+    │ execution time: 0µs
     │
     └── • scan
           sql nodes: <hidden>
@@ -302,6 +310,7 @@ quality of service: regular
 │ sql nodes: <hidden>
 │ regions: <hidden>
 │ actual row count: 5
+│ execution time: 0µs
 │ estimated max memory allocated: 0 B
 │ estimated max sql temp disk usage: 0 B
 │
@@ -383,18 +392,21 @@ quality of service: regular
 │   │ sql nodes: <hidden>
 │   │ regions: <hidden>
 │   │ actual row count: 1
+│   │ execution time: 0µs
 │   │ into: child(c, p)
 │   │
 │   └── • buffer
 │       │ sql nodes: <hidden>
 │       │ regions: <hidden>
 │       │ actual row count: 1
+│       │ execution time: 0µs
 │       │ label: buffer 1
 │       │
 │       └── • values
 │             sql nodes: <hidden>
 │             regions: <hidden>
 │             actual row count: 1
+│             execution time: 0µs
 │             size: 2 columns, 1 row
 │
 ├── • subquery
@@ -406,6 +418,7 @@ quality of service: regular
 │       │ sql nodes: <hidden>
 │       │ regions: <hidden>
 │       │ actual row count: 1
+│       │ execution time: 0µs
 │       │
 │       └── • scan
 │             sql nodes: <hidden>
@@ -429,6 +442,7 @@ quality of service: regular
         │ sql nodes: <hidden>
         │ regions: <hidden>
         │ actual row count: 0
+        │ execution time: 0µs
         │
         └── • lookup join (anti)
             │ sql nodes: <hidden>
@@ -440,6 +454,7 @@ quality of service: regular
             │ KV pairs read: 2
             │ KV bytes read: 8 B
             │ KV gRPC calls: 1
+            │ execution time: 0µs
             │ estimated max memory allocated: 0 B
             │ table: parent@parent_pkey
             │ equality: (column2) = (p)
@@ -449,6 +464,7 @@ quality of service: regular
                 │ sql nodes: <hidden>
                 │ regions: <hidden>
                 │ actual row count: 1
+                │ execution time: 0µs
                 │ estimated row count: 1
                 │ filter: column2 IS NOT NULL
                 │
@@ -456,6 +472,7 @@ quality of service: regular
                       sql nodes: <hidden>
                       regions: <hidden>
                       actual row count: 1
+                      execution time: 0µs
                       estimated row count: 1
                       label: buffer 1
 ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain_analyze_read_committed
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain_analyze_read_committed
@@ -80,6 +80,7 @@ quality of service: regular
 │ regions: <hidden>
 │ actual row count: 2
 │ vectorized batch count: 0
+│ execution time: 0µs
 │ estimated max memory allocated: 0 B
 │ estimated row count: 990 (missing stats)
 │ equality: (v) = (a)

--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_index_geospatial
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_index_geospatial
@@ -39,6 +39,7 @@ quality of service: regular
 │ sql nodes: <hidden>
 │ regions: <hidden>
 │ actual row count: 2
+│ execution time: 0µs
 │ estimated max memory allocated: 0 B
 │ order: +k
 │
@@ -46,6 +47,7 @@ quality of service: regular
     │ sql nodes: <hidden>
     │ regions: <hidden>
     │ actual row count: 2
+    │ execution time: 0µs
     │ filter: st_intersects('010100002026690000000000000C6A18410000008081844E41', geom)
     │
     └── • index join (streamer)
@@ -66,6 +68,7 @@ quality of service: regular
             │ sql nodes: <hidden>
             │ regions: <hidden>
             │ actual row count: 2
+            │ execution time: 0µs
             │ estimated max memory allocated: 0 B
             │ estimated max sql temp disk usage: 0 B
             │ inverted column: geom_inverted_key
@@ -131,6 +134,7 @@ quality of service: regular
 │ sql nodes: <hidden>
 │ regions: <hidden>
 │ actual row count: 2
+│ execution time: 0µs
 │ estimated max memory allocated: 0 B
 │ order: +k
 │
@@ -138,6 +142,7 @@ quality of service: regular
     │ sql nodes: <hidden>
     │ regions: <hidden>
     │ actual row count: 2
+    │ execution time: 0µs
     │ filter: st_intersects('010100002026690000000000000C6A18410000008081844E41', geom)
     │
     └── • index join (streamer)
@@ -158,6 +163,7 @@ quality of service: regular
             │ sql nodes: <hidden>
             │ regions: <hidden>
             │ actual row count: 2
+            │ execution time: 0µs
             │ estimated max memory allocated: 0 B
             │ estimated max sql temp disk usage: 0 B
             │ inverted column: geom_inverted_key
@@ -207,6 +213,7 @@ quality of service: regular
 │ sql nodes: <hidden>
 │ regions: <hidden>
 │ actual row count: 2
+│ execution time: 0µs
 │ estimated max memory allocated: 0 B
 │ order: +k
 │
@@ -214,6 +221,7 @@ quality of service: regular
     │ sql nodes: <hidden>
     │ regions: <hidden>
     │ actual row count: 2
+    │ execution time: 0µs
     │ filter: st_intersects('010100002026690000000000000C6A18410000008081844E41', geom)
     │
     └── • index join (streamer)
@@ -234,6 +242,7 @@ quality of service: regular
             │ sql nodes: <hidden>
             │ regions: <hidden>
             │ actual row count: 2
+            │ execution time: 0µs
             │ estimated max memory allocated: 0 B
             │ estimated max sql temp disk usage: 0 B
             │ inverted column: geom_inverted_key

--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_join_geospatial
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_join_geospatial
@@ -326,6 +326,7 @@ quality of service: regular
 │       │ sql nodes: <hidden>
 │       │ regions: <hidden>
 │       │ actual row count: 0
+│       │ execution time: 0µs
 │       │ estimated max memory allocated: 0 B
 │       │ estimated max sql temp disk usage: 0 B
 │       │ group by: lk
@@ -338,6 +339,7 @@ quality of service: regular
 │           │ KV rows decoded: 0
 │           │ KV bytes read: 0 B
 │           │ KV gRPC calls: 0
+│           │ execution time: 0µs
 │           │ estimated max memory allocated: 0 B
 │           │ table: rtable@rtable_pkey
 │           │ equality: (rk1, rk2) = (rk1, rk2)
@@ -352,6 +354,7 @@ quality of service: regular
 │               │ KV rows decoded: 0
 │               │ KV bytes read: 0 B
 │               │ KV gRPC calls: 0
+│               │ execution time: 0µs
 │               │ estimated max memory allocated: 0 B
 │               │ estimated max sql temp disk usage: 0 B
 │               │ table: rtable@geom_index
@@ -360,6 +363,7 @@ quality of service: regular
 │                     sql nodes: <hidden>
 │                     regions: <hidden>
 │                     actual row count: 0
+│                     execution time: 0µs
 │                     label: buffer 1 (q)
 │
 ├── • subquery
@@ -371,6 +375,7 @@ quality of service: regular
 │       │ sql nodes: <hidden>
 │       │ regions: <hidden>
 │       │ actual row count: 0
+│       │ execution time: 0µs
 │       │ label: buffer 1 (q)
 │       │
 │       └── • scan
@@ -396,11 +401,13 @@ quality of service: regular
         │ sql nodes: <hidden>
         │ regions: <hidden>
         │ actual row count: 1
+        │ execution time: 0µs
         │
         └── • scan buffer
               sql nodes: <hidden>
               regions: <hidden>
               actual row count: 0
+              execution time: 0µs
               label: buffer 1 (q)
 
 # Anti joins are also converted to paired joins by the optimizer.

--- a/pkg/sql/opt/exec/execbuilder/testdata/lookup_join_limit
+++ b/pkg/sql/opt/exec/execbuilder/testdata/lookup_join_limit
@@ -96,6 +96,7 @@ quality of service: regular
     │ sql nodes: <hidden>
     │ regions: <hidden>
     │ actual row count: 1
+    │ execution time: 0µs
     │
     ├── • index join (streamer)
     │   │ sql nodes: <hidden>
@@ -341,6 +342,7 @@ quality of service: regular
     │ KV pairs read: 2
     │ KV bytes read: 8 B
     │ KV gRPC calls: 1
+    │ execution time: 0µs
     │ estimated max memory allocated: 0 B
     │ table: b@b_pkey
     │ equality: (x) = (x)
@@ -437,6 +439,7 @@ quality of service: regular
     │ KV pairs read: 4
     │ KV bytes read: 16 B
     │ KV gRPC calls: 2
+    │ execution time: 0µs
     │ estimated max memory allocated: 0 B
     │ estimated max sql temp disk usage: 0 B
     │ table: xy@xy_pkey

--- a/pkg/sql/opt/exec/execbuilder/testdata/triggers
+++ b/pkg/sql/opt/exec/execbuilder/testdata/triggers
@@ -124,6 +124,7 @@ quality of service: regular
 │ regions: <hidden>
 │ actual row count: 0
 │ vectorized batch count: 0
+│ execution time: 0µs
 │ estimated row count: 0 (missing stats)
 │ table: xy
 │ set: x, y
@@ -146,6 +147,7 @@ quality of service: regular
         │ regions: <hidden>
         │ actual row count: 0
         │ vectorized batch count: 0
+        │ execution time: 0µs
         │ estimated row count: 10 (missing stats)
         │ filter: f IS DISTINCT FROM NULL
         │
@@ -182,6 +184,7 @@ quality of service: regular
                     │ regions: <hidden>
                     │ actual row count: 0
                     │ vectorized batch count: 0
+                    │ execution time: 0µs
                     │ estimated row count: 10 (missing stats)
                     │ filter: y = 2
                     │
@@ -337,6 +340,7 @@ quality of service: regular
 │   │ regions: <hidden>
 │   │ actual row count: 0
 │   │ vectorized batch count: 0
+│   │ execution time: 0µs
 │   │ estimated row count: 0 (missing stats)
 │   │ from: xy
 │   │
@@ -346,6 +350,7 @@ quality of service: regular
 │       │ regions: <hidden>
 │       │ actual row count: 0
 │       │ vectorized batch count: 0
+│       │ execution time: 0µs
 │       │ label: buffer 1
 │       │
 │       └── • filter
@@ -354,6 +359,7 @@ quality of service: regular
 │           │ regions: <hidden>
 │           │ actual row count: 0
 │           │ vectorized batch count: 0
+│           │ execution time: 0µs
 │           │ estimated row count: 10 (missing stats)
 │           │ filter: y = 2
 │           │
@@ -410,6 +416,7 @@ quality of service: regular
 │   │ regions: <hidden>
 │   │ actual row count: 1
 │   │ vectorized batch count: 0
+│   │ execution time: 0µs
 │   │ estimated row count: 0 (missing stats)
 │   │ from: xy
 │   │
@@ -419,6 +426,7 @@ quality of service: regular
 │       │ regions: <hidden>
 │       │ actual row count: 1
 │       │ vectorized batch count: 0
+│       │ execution time: 0µs
 │       │ label: buffer 1
 │       │
 │       └── • filter
@@ -427,6 +435,7 @@ quality of service: regular
 │           │ regions: <hidden>
 │           │ actual row count: 1
 │           │ vectorized batch count: 0
+│           │ execution time: 0µs
 │           │ estimated row count: 10 (missing stats)
 │           │ filter: y = 2
 │           │
@@ -476,6 +485,7 @@ quality of service: regular
                       regions: <hidden>
                       actual row count: 1
                       vectorized batch count: 0
+                      execution time: 0µs
                       estimated row count: 1
                       label: buffer 1000000
 
@@ -681,6 +691,7 @@ quality of service: regular
 │   │ regions: <hidden>
 │   │ actual row count: 0
 │   │ vectorized batch count: 0
+│   │ execution time: 0µs
 │   │ estimated row count: 0 (missing stats)
 │   │ table: parent
 │   │ set: k
@@ -691,6 +702,7 @@ quality of service: regular
 │       │ regions: <hidden>
 │       │ actual row count: 0
 │       │ vectorized batch count: 0
+│       │ execution time: 0µs
 │       │ label: buffer 1
 │       │
 │       └── • render
@@ -753,6 +765,7 @@ quality of service: regular
 │   │ regions: <hidden>
 │   │ actual row count: 1
 │   │ vectorized batch count: 0
+│   │ execution time: 0µs
 │   │ estimated row count: 0 (missing stats)
 │   │ table: parent
 │   │ set: k
@@ -763,6 +776,7 @@ quality of service: regular
 │       │ regions: <hidden>
 │       │ actual row count: 1
 │       │ vectorized batch count: 0
+│       │ execution time: 0µs
 │       │ label: buffer 1
 │       │
 │       └── • render
@@ -802,6 +816,7 @@ quality of service: regular
         │   │ regions: <hidden>
         │   │ actual row count: 0
         │   │ vectorized batch count: 0
+        │   │ execution time: 0µs
         │   │ estimated row count: 0 (missing stats)
         │   │ table: child
         │   │ set: fk
@@ -815,6 +830,7 @@ quality of service: regular
         │       │ regions: <hidden>
         │       │ actual row count: 1
         │       │ vectorized batch count: 0
+        │       │ execution time: 0µs
         │       │ label: buffer 1
         │       │
         │       └── • filter
@@ -823,6 +839,7 @@ quality of service: regular
         │           │ regions: <hidden>
         │           │ actual row count: 1
         │           │ vectorized batch count: 0
+        │           │ execution time: 0µs
         │           │ estimated row count: 3 (missing stats)
         │           │ filter: f IS DISTINCT FROM NULL
         │           │
@@ -862,6 +879,7 @@ quality of service: regular
         │                           │ regions: <hidden>
         │                           │ actual row count: 1
         │                           │ vectorized batch count: 0
+        │                           │ execution time: 0µs
         │                           │ estimated max memory allocated: 0 B
         │                           │ estimated row count: 3 (missing stats)
         │                           │ equality: (fk) = (k)
@@ -891,6 +909,7 @@ quality of service: regular
         │                               │ regions: <hidden>
         │                               │ actual row count: 1
         │                               │ vectorized batch count: 0
+        │                               │ execution time: 0µs
         │                               │ estimated row count: 0
         │                               │ filter: k IS DISTINCT FROM k_new
         │                               │
@@ -900,6 +919,7 @@ quality of service: regular
         │                                     regions: <hidden>
         │                                     actual row count: 1
         │                                     vectorized batch count: 0
+        │                                     execution time: 0µs
         │                                     estimated row count: 1
         │                                     label: buffer 1000000
         │
@@ -911,6 +931,7 @@ quality of service: regular
         │       │ regions: <hidden>
         │       │ actual row count: 0
         │       │ vectorized batch count: 0
+        │       │ execution time: 0µs
         │       │
         │       └── • lookup join (anti)
         │           │ columns: (fk_new)
@@ -924,6 +945,7 @@ quality of service: regular
         │           │ KV pairs read: 2
         │           │ KV bytes read: 8 B
         │           │ KV gRPC calls: 1
+        │           │ execution time: 0µs
         │           │ estimated max memory allocated: 0 B
         │           │ MVCC step count (ext/int): 0/0
         │           │ MVCC seek count (ext/int): 0/0
@@ -938,6 +960,7 @@ quality of service: regular
         │               │ regions: <hidden>
         │               │ actual row count: 1
         │               │ vectorized batch count: 0
+        │               │ execution time: 0µs
         │               │ estimated row count: 3 (missing stats)
         │               │ filter: fk_new IS NOT NULL
         │               │
@@ -950,6 +973,7 @@ quality of service: regular
         │                         regions: <hidden>
         │                         actual row count: 1
         │                         vectorized batch count: 0
+        │                         execution time: 0µs
         │                         estimated row count: 3 (missing stats)
         │                         label: buffer 1
         │
@@ -984,6 +1008,7 @@ quality of service: regular
                               regions: <hidden>
                               actual row count: 1
                               vectorized batch count: 0
+                              execution time: 0µs
                               estimated row count: 1
                               label: buffer 1000000
 
@@ -1018,6 +1043,7 @@ quality of service: regular
 │     regions: <hidden>
 │     actual row count: 1
 │     vectorized batch count: 0
+│     execution time: 0µs
 │     estimated row count: 0 (missing stats)
 │     from: parent
 │     spans: /2/0
@@ -1034,6 +1060,7 @@ quality of service: regular
         │   │ regions: <hidden>
         │   │ actual row count: 0
         │   │ vectorized batch count: 0
+        │   │ execution time: 0µs
         │   │ estimated row count: 0 (missing stats)
         │   │ from: child
         │   │
@@ -1046,6 +1073,7 @@ quality of service: regular
         │       │ regions: <hidden>
         │       │ actual row count: 1
         │       │ vectorized batch count: 0
+        │       │ execution time: 0µs
         │       │ label: buffer 1
         │       │
         │       └── • filter
@@ -1054,6 +1082,7 @@ quality of service: regular
         │           │ regions: <hidden>
         │           │ actual row count: 1
         │           │ vectorized batch count: 0
+        │           │ execution time: 0µs
         │           │ estimated row count: 10 (missing stats)
         │           │ filter: f IS DISTINCT FROM NULL
         │           │
@@ -1084,6 +1113,7 @@ quality of service: regular
         │                           │ regions: <hidden>
         │                           │ actual row count: 1
         │                           │ vectorized batch count: 0
+        │                           │ execution time: 0µs
         │                           │ estimated row count: 10 (missing stats)
         │                           │ filter: fk = 2
         │                           │
@@ -1133,6 +1163,7 @@ quality of service: regular
                               regions: <hidden>
                               actual row count: 1
                               vectorized batch count: 0
+                              execution time: 0µs
                               estimated row count: 1
                               label: buffer 1000000
 

--- a/pkg/sql/opt/exec/execbuilder/testdata/unique
+++ b/pkg/sql/opt/exec/execbuilder/testdata/unique
@@ -620,12 +620,14 @@ quality of service: regular
 │   │ sql nodes: <hidden>
 │   │ regions: <hidden>
 │   │ actual row count: 2
+│   │ execution time: 0µs
 │   │ into: uniq_fk_parent(a, b, c, rowid)
 │   │
 │   └── • buffer
 │       │ sql nodes: <hidden>
 │       │ regions: <hidden>
 │       │ actual row count: 2
+│       │ execution time: 0µs
 │       │ label: buffer 1
 │       │
 │       └── • render
@@ -634,6 +636,7 @@ quality of service: regular
 │                 sql nodes: <hidden>
 │                 regions: <hidden>
 │                 actual row count: 2
+│                 execution time: 0µs
 │                 size: 3 columns, 2 rows
 │
 ├── • constraint-check
@@ -642,11 +645,13 @@ quality of service: regular
 │       │ sql nodes: <hidden>
 │       │ regions: <hidden>
 │       │ actual row count: 0
+│       │ execution time: 0µs
 │       │
 │       └── • hash join (right semi)
 │           │ sql nodes: <hidden>
 │           │ regions: <hidden>
 │           │ actual row count: 0
+│           │ execution time: 0µs
 │           │ estimated max memory allocated: 0 B
 │           │ estimated max sql temp disk usage: 0 B
 │           │ equality: (a) = (column1)
@@ -671,6 +676,7 @@ quality of service: regular
 │                 sql nodes: <hidden>
 │                 regions: <hidden>
 │                 actual row count: 2
+│                 execution time: 0µs
 │                 estimated row count: 2
 │                 label: buffer 1
 │
@@ -680,11 +686,13 @@ quality of service: regular
         │ sql nodes: <hidden>
         │ regions: <hidden>
         │ actual row count: 0
+        │ execution time: 0µs
         │
         └── • hash join (right semi)
             │ sql nodes: <hidden>
             │ regions: <hidden>
             │ actual row count: 0
+            │ execution time: 0µs
             │ estimated max memory allocated: 0 B
             │ estimated max sql temp disk usage: 0 B
             │ equality: (b, c) = (column2, column3)
@@ -709,6 +717,7 @@ quality of service: regular
                   sql nodes: <hidden>
                   regions: <hidden>
                   actual row count: 2
+                  execution time: 0µs
                   estimated row count: 2
                   label: buffer 1
 
@@ -736,12 +745,14 @@ quality of service: regular
 │   │ sql nodes: <hidden>
 │   │ regions: <hidden>
 │   │ actual row count: 2
+│   │ execution time: 0µs
 │   │ into: uniq_fk_child(a, b, c, rowid)
 │   │
 │   └── • buffer
 │       │ sql nodes: <hidden>
 │       │ regions: <hidden>
 │       │ actual row count: 2
+│       │ execution time: 0µs
 │       │ label: buffer 1
 │       │
 │       └── • render
@@ -750,6 +761,7 @@ quality of service: regular
 │                 sql nodes: <hidden>
 │                 regions: <hidden>
 │                 actual row count: 2
+│                 execution time: 0µs
 │                 size: 3 columns, 2 rows
 │
 ├── • constraint-check
@@ -758,11 +770,13 @@ quality of service: regular
 │       │ sql nodes: <hidden>
 │       │ regions: <hidden>
 │       │ actual row count: 0
+│       │ execution time: 0µs
 │       │
 │       └── • hash join (right semi)
 │           │ sql nodes: <hidden>
 │           │ regions: <hidden>
 │           │ actual row count: 0
+│           │ execution time: 0µs
 │           │ estimated max memory allocated: 0 B
 │           │ estimated max sql temp disk usage: 0 B
 │           │ equality: (c) = (column3)
@@ -787,6 +801,7 @@ quality of service: regular
 │                 sql nodes: <hidden>
 │                 regions: <hidden>
 │                 actual row count: 2
+│                 execution time: 0µs
 │                 estimated row count: 2
 │                 label: buffer 1
 │
@@ -796,11 +811,13 @@ quality of service: regular
 │       │ sql nodes: <hidden>
 │       │ regions: <hidden>
 │       │ actual row count: 0
+│       │ execution time: 0µs
 │       │
 │       └── • hash join (right anti)
 │           │ sql nodes: <hidden>
 │           │ regions: <hidden>
 │           │ actual row count: 0
+│           │ execution time: 0µs
 │           │ estimated max memory allocated: 0 B
 │           │ equality: (b, c) = (column2, column3)
 │           │
@@ -823,6 +840,7 @@ quality of service: regular
 │                 sql nodes: <hidden>
 │                 regions: <hidden>
 │                 actual row count: 2
+│                 execution time: 0µs
 │                 estimated row count: 2
 │                 label: buffer 1
 │
@@ -832,11 +850,13 @@ quality of service: regular
         │ sql nodes: <hidden>
         │ regions: <hidden>
         │ actual row count: 0
+        │ execution time: 0µs
         │
         └── • hash join (right anti)
             │ sql nodes: <hidden>
             │ regions: <hidden>
             │ actual row count: 0
+            │ execution time: 0µs
             │ estimated max memory allocated: 0 B
             │ equality: (a) = (column1)
             │
@@ -859,6 +879,7 @@ quality of service: regular
                   sql nodes: <hidden>
                   regions: <hidden>
                   actual row count: 2
+                  execution time: 0µs
                   estimated row count: 2
                   label: buffer 1
 
@@ -2617,6 +2638,7 @@ quality of service: regular
 │   │ sql nodes: <hidden>
 │   │ regions: <hidden>
 │   │ actual row count: 2
+│   │ execution time: 0µs
 │   │ table: uniq_fk_parent
 │   │ set: c
 │   │
@@ -2624,6 +2646,7 @@ quality of service: regular
 │       │ sql nodes: <hidden>
 │       │ regions: <hidden>
 │       │ actual row count: 2
+│       │ execution time: 0µs
 │       │ label: buffer 1
 │       │
 │       └── • render
@@ -2653,6 +2676,7 @@ quality of service: regular
 │       │   │ sql nodes: <hidden>
 │       │   │ regions: <hidden>
 │       │   │ actual row count: 0
+│       │   │ execution time: 0µs
 │       │   │ table: uniq_fk_child
 │       │   │ set: b, c
 │       │   │
@@ -2660,12 +2684,14 @@ quality of service: regular
 │       │       │ sql nodes: <hidden>
 │       │       │ regions: <hidden>
 │       │       │ actual row count: 2
+│       │       │ execution time: 0µs
 │       │       │ label: buffer 1
 │       │       │
 │       │       └── • hash join
 │       │           │ sql nodes: <hidden>
 │       │           │ regions: <hidden>
 │       │           │ actual row count: 2
+│       │           │ execution time: 0µs
 │       │           │ estimated max memory allocated: 0 B
 │       │           │ equality: (b, c) = (b, c)
 │       │           │
@@ -2688,6 +2714,7 @@ quality of service: regular
 │       │               │ sql nodes: <hidden>
 │       │               │ regions: <hidden>
 │       │               │ actual row count: 2
+│       │               │ execution time: 0µs
 │       │               │ estimated row count: 1
 │       │               │ filter: (b IS DISTINCT FROM b) OR (c IS DISTINCT FROM c_new)
 │       │               │
@@ -2695,6 +2722,7 @@ quality of service: regular
 │       │                     sql nodes: <hidden>
 │       │                     regions: <hidden>
 │       │                     actual row count: 2
+│       │                     execution time: 0µs
 │       │                     estimated row count: 2
 │       │                     label: buffer 1000000
 │       │
@@ -2704,11 +2732,13 @@ quality of service: regular
 │       │       │ sql nodes: <hidden>
 │       │       │ regions: <hidden>
 │       │       │ actual row count: 0
+│       │       │ execution time: 0µs
 │       │       │
 │       │       └── • hash join (right semi)
 │       │           │ sql nodes: <hidden>
 │       │           │ regions: <hidden>
 │       │           │ actual row count: 0
+│       │           │ execution time: 0µs
 │       │           │ estimated max memory allocated: 0 B
 │       │           │ estimated max sql temp disk usage: 0 B
 │       │           │ equality: (c) = (c_new)
@@ -2733,6 +2763,7 @@ quality of service: regular
 │       │                 sql nodes: <hidden>
 │       │                 regions: <hidden>
 │       │                 actual row count: 2
+│       │                 execution time: 0µs
 │       │                 label: buffer 1
 │       │
 │       └── • constraint-check
@@ -2741,11 +2772,13 @@ quality of service: regular
 │               │ sql nodes: <hidden>
 │               │ regions: <hidden>
 │               │ actual row count: 0
+│               │ execution time: 0µs
 │               │
 │               └── • hash join (right anti)
 │                   │ sql nodes: <hidden>
 │                   │ regions: <hidden>
 │                   │ actual row count: 0
+│                   │ execution time: 0µs
 │                   │ estimated max memory allocated: 0 B
 │                   │ equality: (b, c) = (b, c_new)
 │                   │
@@ -2768,12 +2801,14 @@ quality of service: regular
 │                       │ sql nodes: <hidden>
 │                       │ regions: <hidden>
 │                       │ actual row count: 2
+│                       │ execution time: 0µs
 │                       │ filter: (b IS NOT NULL) AND (c_new IS NOT NULL)
 │                       │
 │                       └── • scan buffer
 │                             sql nodes: <hidden>
 │                             regions: <hidden>
 │                             actual row count: 2
+│                             execution time: 0µs
 │                             label: buffer 1
 │
 └── • constraint-check
@@ -2782,11 +2817,13 @@ quality of service: regular
         │ sql nodes: <hidden>
         │ regions: <hidden>
         │ actual row count: 0
+        │ execution time: 0µs
         │
         └── • hash join (semi)
             │ sql nodes: <hidden>
             │ regions: <hidden>
             │ actual row count: 0
+            │ execution time: 0µs
             │ estimated max memory allocated: 0 B
             │ estimated max sql temp disk usage: 0 B
             │ equality: (b, c_new) = (b, c)
@@ -2796,6 +2833,7 @@ quality of service: regular
             │     sql nodes: <hidden>
             │     regions: <hidden>
             │     actual row count: 2
+            │     execution time: 0µs
             │     label: buffer 1
             │
             └── • scan

--- a/pkg/sql/opt/exec/execbuilder/testdata/update
+++ b/pkg/sql/opt/exec/execbuilder/testdata/update
@@ -1014,6 +1014,7 @@ quality of service: regular
 │ sql nodes: <hidden>
 │ regions: <hidden>
 │ actual row count: 0
+│ execution time: 0µs
 │ table: t137352
 │ set: a, b
 │ auto commit
@@ -1029,6 +1030,7 @@ quality of service: regular
         │ KV rows decoded: 0
         │ KV bytes read: 0 B
         │ KV gRPC calls: 0
+        │ execution time: 0µs
         │ estimated max memory allocated: 0 B
         │ table: t137352@t137352_pkey
         │ equality: ($1) = (k)
@@ -1039,6 +1041,7 @@ quality of service: regular
               sql nodes: <hidden>
               regions: <hidden>
               actual row count: 1
+              execution time: 0µs
               size: 1 column, 1 row
 
 statement ok
@@ -1079,6 +1082,7 @@ quality of service: regular
 │ sql nodes: <hidden>
 │ regions: <hidden>
 │ actual row count: 0
+│ execution time: 0µs
 │ table: t137352
 │ set: a, b
 │ auto commit
@@ -1093,6 +1097,7 @@ quality of service: regular
         │ KV rows decoded: 0
         │ KV bytes read: 0 B
         │ KV gRPC calls: 0
+        │ execution time: 0µs
         │ estimated max memory allocated: 0 B
         │ table: t137352@t137352_pkey
         │ equality: (k) = (k)
@@ -1108,6 +1113,7 @@ quality of service: regular
             │ KV rows decoded: 0
             │ KV bytes read: 0 B
             │ KV gRPC calls: 0
+            │ execution time: 0µs
             │ estimated max memory allocated: 0 B
             │ table: t137352@t137352_a_idx
             │ equality: ($1) = (a)
@@ -1117,6 +1123,7 @@ quality of service: regular
                   sql nodes: <hidden>
                   regions: <hidden>
                   actual row count: 1
+                  execution time: 0µs
                   size: 1 column, 1 row
 
 statement ok
@@ -1161,6 +1168,7 @@ quality of service: regular
 │ sql nodes: <hidden>
 │ regions: <hidden>
 │ actual row count: 1
+│ execution time: 0µs
 │ table: t137352
 │ set: a, b
 │ auto commit
@@ -1177,6 +1185,7 @@ quality of service: regular
         │ KV pairs read: 2
         │ KV bytes read: 8 B
         │ KV gRPC calls: 1
+        │ execution time: 0µs
         │ estimated max memory allocated: 0 B
         │ table: t137352@t137352_pkey
         │ equality: ($1) = (k)
@@ -1187,6 +1196,7 @@ quality of service: regular
               sql nodes: <hidden>
               regions: <hidden>
               actual row count: 1
+              execution time: 0µs
               size: 1 column, 1 row
 
 statement ok
@@ -1242,6 +1252,7 @@ quality of service: regular
 │ sql nodes: <hidden>
 │ regions: <hidden>
 │ actual row count: 0
+│ execution time: 0µs
 │ table: t137352
 │ set: a, b
 │ auto commit
@@ -1259,6 +1270,7 @@ quality of service: regular
             │ KV rows decoded: 0
             │ KV bytes read: 0 B
             │ KV gRPC calls: 0
+            │ execution time: 0µs
             │ estimated max memory allocated: 0 B
             │ estimated row count: 10
             │ table: t137352@t137352_pkey
@@ -1274,6 +1286,7 @@ quality of service: regular
                 │ KV rows decoded: 0
                 │ KV bytes read: 0 B
                 │ KV gRPC calls: 0
+                │ execution time: 0µs
                 │ estimated max memory allocated: 0 B
                 │ estimated row count: 10
                 │ table: t137352@t137352_a_idx
@@ -1290,6 +1303,7 @@ quality of service: regular
                     │ KV pairs read: 2
                     │ KV bytes read: 8 B
                     │ KV gRPC calls: 1
+                    │ execution time: 0µs
                     │ estimated max memory allocated: 0 B
                     │ estimated row count: 1
                     │ table: t137352@t137352_pkey
@@ -1300,6 +1314,7 @@ quality of service: regular
                           sql nodes: <hidden>
                           regions: <hidden>
                           actual row count: 1
+                          execution time: 0µs
                           size: 1 column, 1 row
 
 statement ok

--- a/pkg/sql/opt/exec/execbuilder/testdata/upsert
+++ b/pkg/sql/opt/exec/execbuilder/testdata/upsert
@@ -1183,6 +1183,7 @@ quality of service: regular
 │ sql nodes: <hidden>
 │ regions: <hidden>
 │ actual row count: 1
+│ execution time: 0µs
 │ into: t137352(k, a, b)
 │ auto commit
 │ arbiter indexes: t137352_pkey
@@ -1196,6 +1197,7 @@ quality of service: regular
     │ KV rows decoded: 0
     │ KV bytes read: 0 B
     │ KV gRPC calls: 0
+    │ execution time: 0µs
     │ estimated max memory allocated: 0 B
     │ table: t137352@t137352_pkey
     │ equality: (column1) = (k)
@@ -1206,6 +1208,7 @@ quality of service: regular
           sql nodes: <hidden>
           regions: <hidden>
           actual row count: 1
+          execution time: 0µs
           size: 3 columns, 1 row
 
 # Only need to update 'b' - no need to modify the secondary index.
@@ -1252,6 +1255,7 @@ quality of service: regular
 │ sql nodes: <hidden>
 │ regions: <hidden>
 │ actual row count: 1
+│ execution time: 0µs
 │ into: t137352(k, a, b)
 │ auto commit
 │ arbiter indexes: t137352_a_key
@@ -1266,6 +1270,7 @@ quality of service: regular
         │ KV rows decoded: 0
         │ KV bytes read: 0 B
         │ KV gRPC calls: 0
+        │ execution time: 0µs
         │ estimated max memory allocated: 0 B
         │ table: t137352@t137352_pkey
         │ equality: (k) = (k)
@@ -1281,6 +1286,7 @@ quality of service: regular
             │ KV rows decoded: 0
             │ KV bytes read: 0 B
             │ KV gRPC calls: 0
+            │ execution time: 0µs
             │ estimated max memory allocated: 0 B
             │ table: t137352@t137352_a_key
             │ equality: (column2) = (a)
@@ -1291,6 +1297,7 @@ quality of service: regular
                   sql nodes: <hidden>
                   regions: <hidden>
                   actual row count: 1
+                  execution time: 0µs
                   size: 3 columns, 1 row
 
 # Conflict on 'a', so we're only updating the value of 'b'.

--- a/pkg/sql/opt/exec/execbuilder/testdata/vectorize_local
+++ b/pkg/sql/opt/exec/execbuilder/testdata/vectorize_local
@@ -94,6 +94,7 @@ quality of service: regular
 │ KV pairs read: 2
 │ KV bytes read: 8 B
 │ KV gRPC calls: 1
+│ execution time: 0µs
 │ estimated max memory allocated: 0 B
 │ table: d@d_pkey
 │ equality: (b) = (b)
@@ -140,6 +141,7 @@ quality of service: regular
     │ sql nodes: <hidden>
     │ regions: <hidden>
     │ actual row count: 2
+    │ execution time: 0µs
     │ table: d@d_pkey
     │ equality: (b) = (b)
     │
@@ -218,6 +220,7 @@ quality of service: regular
 │ sql nodes: <hidden>
 │ regions: <hidden>
 │ actual row count: 2
+│ execution time: 0µs
 │ estimated max memory allocated: 0 B
 │ estimated max sql temp disk usage: 0 B
 │ equality: (a) = (b)

--- a/pkg/sql/opt/exec/explain/emit.go
+++ b/pkg/sql/opt/exec/explain/emit.go
@@ -549,6 +549,9 @@ func (e *emitter) emitNodeAttributes(ctx context.Context, evalCtx *eval.Context,
 		if s.KVBatchRequestsIssued.HasValue() {
 			e.ob.AddField("KV gRPC calls", string(humanizeutil.Count(s.KVBatchRequestsIssued.Value())))
 		}
+		if s.ExecTime.HasValue() {
+			e.ob.AddField("execution time", string(humanizeutil.Duration(s.ExecTime.Value())))
+		}
 		if s.MaxAllocatedMem.HasValue() {
 			e.ob.AddField("estimated max memory allocated", humanize.IBytes(s.MaxAllocatedMem.Value()))
 		}

--- a/pkg/sql/opt/exec/factory.go
+++ b/pkg/sql/opt/exec/factory.go
@@ -527,6 +527,7 @@ type ExecutionStats struct {
 	SeekCount         optional.Uint
 	InternalSeekCount optional.Uint
 
+	ExecTime         optional.Duration
 	MaxAllocatedMem  optional.Uint
 	MaxAllocatedDisk optional.Uint
 	SQLCPUTime       optional.Duration


### PR DESCRIPTION
We've been tracking "execution time" statistic for most operators (except for vectorized KV-reading ones which get separate "KV time" stat) for many years now, but for some reason we only reported it on the DistSQL diagram.  This commit fixes that oversight so that the stat is now included on `EXPLAIN ANALYZE` output when available.

Fixes: #143443.

Release note (sql change): New statistic `execution time` is now reported on EXPLAIN ANALYZE output for most operators. It was previously only available on the DistSQL diagrams (included in `EXPLAIN ANALYZE (DISTSQL)` output).