### PR TITLE
explain: clarify "network usage" line of EXPLAIN ANALYZE

### DIFF
--- a/docs/generated/eventlog.md
+++ b/docs/generated/eventlog.md
@@ -3222,10 +3222,10 @@ Fields in this struct should be updated in sync with apps_stats.proto.
 
 | Field | Description | Sensitive |
 |--|--|--|
-| `NetworkBytes` | NetworkBytes collects the number of bytes sent over the network. | no |
+| `NetworkBytes` | NetworkBytes collects the number of bytes sent over the network by DistSQL components. | no |
 | `MaxMemUsage` | MaxMemUsage collects the maximum memory usage that occurred on a node. | no |
 | `ContentionTime` | ContentionTime collects the time in seconds statements in the transaction spent contending. | no |
-| `NetworkMessages` | NetworkMessages collects the number of messages that were sent over the network. | no |
+| `NetworkMessages` | NetworkMessages collects the number of messages that were sent over the network by DistSQL components. | no |
 | `MaxDiskUsage` | MaxDiskUsage collects the maximum temporary disk usage that occurred. This is set in cases where a query had to spill to disk, e.g. when performing a large sort where not all of the tuples fit in memory. | no |
 | `CPUSQLNanos` | CPUSQLNanos collects the CPU time spent executing SQL operations in nanoseconds. Currently, it is only collected for statements without mutations that have a vectorized plan. | no |
 | `MVCCIteratorStats` | Internal storage iteration statistics. | yes |
@@ -3273,13 +3273,13 @@ contains common SQL event/execution details.
 | `ZigZagJoinCount` | The number of zig zag joins in the query plan. | no |
 | `ContentionNanos` | The duration of time in nanoseconds that the query experienced contention. | no |
 | `Regions` | The regions of the nodes where SQL processors ran. | no |
-| `NetworkBytesSent` | The number of network bytes sent by nodes for this query. | no |
+| `NetworkBytesSent` | The number of network bytes by DistSQL components. | no |
 | `MaxMemUsage` | The maximum amount of memory usage by nodes for this query. | no |
 | `MaxDiskUsage` | The maximum amount of disk usage by nodes for this query. | no |
 | `KVBytesRead` | The number of bytes read at the KV layer for this query. | no |
 | `KVPairsRead` | The number of key-value pairs read at the KV layer for this query. | no |
 | `KVRowsRead` | The number of rows read at the KV layer for this query. | no |
-| `NetworkMessages` | The number of network messages sent by nodes for this query. | no |
+| `NetworkMessages` | The number of network messages sent by nodes for this query by DistSQL components. | no |
 | `IndexRecommendations` | Generated index recommendations for this query. | no |
 | `ScanCount` | The number of scans in the query plan. | no |
 | `ScanWithStatsCount` | The number of scans using statistics (including forecasted statistics) in the query plan. | no |

--- a/pkg/sql/appstatspb/app_stats.proto
+++ b/pkg/sql/appstatspb/app_stats.proto
@@ -328,7 +328,9 @@ message ExecStats {
   // run.
   optional int64 count = 1 [(gogoproto.nullable) = false];
 
-  // NetworkBytes collects the number of bytes sent over the network.
+  // NetworkBytes collects the number of bytes sent over the network by DistSQL
+  // components.
+  // TODO(yuzefovich): rename this all the way up to the DB Console.
   optional NumericStat network_bytes = 2 [(gogoproto.nullable) = false];
 
   // MaxMemUsage collects the maximum memory usage that occurred on a node.
@@ -338,7 +340,8 @@ message ExecStats {
   optional NumericStat contention_time = 4 [(gogoproto.nullable) = false];
 
   // NetworkMessages collects the number of messages that were sent over the
-  // network.
+  // network by DistSQL components.
+  // TODO(yuzefovich): rename this all the way up to the DB Console.
   optional NumericStat network_messages = 5 [(gogoproto.nullable) = false];
 
   // MaxDiskUsage collects the maximum temporary disk usage that occurred. This

--- a/pkg/sql/exec_log.go
+++ b/pkg/sql/exec_log.go
@@ -396,7 +396,7 @@ func (p *planner) maybeLogStatementInternal(
 			SQLInstanceIDs:           queryLevelStats.SQLInstanceIDs,
 			KVNodeIDs:                queryLevelStats.KVNodeIDs,
 			UsedFollowerRead:         queryLevelStats.UsedFollowerRead,
-			NetworkBytesSent:         queryLevelStats.NetworkBytesSent,
+			NetworkBytesSent:         queryLevelStats.DistSQLNetworkBytesSent,
 			MaxMemUsage:              queryLevelStats.MaxMemUsage,
 			MaxDiskUsage:             queryLevelStats.MaxDiskUsage,
 			KVBytesRead:              queryLevelStats.KVBytesRead,
@@ -404,7 +404,7 @@ func (p *planner) maybeLogStatementInternal(
 			KVRowsRead:               queryLevelStats.KVRowsRead,
 			KvTimeNanos:              queryLevelStats.KVTime.Nanoseconds(),
 			KvGrpcCalls:              queryLevelStats.KVBatchRequestsIssued,
-			NetworkMessages:          queryLevelStats.NetworkMessages,
+			NetworkMessages:          queryLevelStats.DistSQLNetworkMessages,
 			CpuTimeNanos:             queryLevelStats.CPUTime.Nanoseconds(),
 			IndexRecommendations:     indexRecs,
 			// TODO(mgartner): Use a slice of struct{uint64, uint64} instead of
@@ -498,10 +498,10 @@ func (p *planner) logTransaction(
 
 	if txnStats.CollectedExecStats {
 		sampledTxn.SampledExecStats = &eventpb.SampledExecStats{
-			NetworkBytes:    txnStats.ExecStats.NetworkBytesSent,
+			NetworkBytes:    txnStats.ExecStats.DistSQLNetworkBytesSent,
 			MaxMemUsage:     txnStats.ExecStats.MaxMemUsage,
 			ContentionTime:  int64(txnStats.ExecStats.ContentionTime.Seconds()),
-			NetworkMessages: txnStats.ExecStats.NetworkMessages,
+			NetworkMessages: txnStats.ExecStats.DistSQLNetworkMessages,
 			MaxDiskUsage:    txnStats.ExecStats.MaxDiskUsage,
 			CPUSQLNanos:     txnStats.ExecStats.CPUTime.Nanoseconds(),
 			MVCCIteratorStats: eventpb.MVCCIteratorStats{

--- a/pkg/sql/execstats/traceanalyzer.go
+++ b/pkg/sql/execstats/traceanalyzer.go
@@ -95,7 +95,7 @@ func NewFlowsMetadata(flows map[base.SQLInstanceID]*execinfrapb.FlowSpec) *Flows
 // given traces and flow metadata.
 // NOTE: When adding fields to this struct, be sure to update Accumulate.
 type QueryLevelStats struct {
-	NetworkBytesSent                   int64
+	DistSQLNetworkBytesSent            int64
 	MaxMemUsage                        int64
 	MaxDiskUsage                       int64
 	KVBytesRead                        int64
@@ -116,7 +116,7 @@ type QueryLevelStats struct {
 	MvccRangeKeyCount                  int64
 	MvccRangeKeyContainedPoints        int64
 	MvccRangeKeySkippedPoints          int64
-	NetworkMessages                    int64
+	DistSQLNetworkMessages             int64
 	ContentionTime                     time.Duration
 	LockWaitTime                       time.Duration
 	LatchWaitTime                      time.Duration
@@ -156,7 +156,7 @@ func MakeQueryLevelStatsWithErr(stats QueryLevelStats, err error) QueryLevelStat
 
 // Accumulate accumulates other's stats into the receiver.
 func (s *QueryLevelStats) Accumulate(other QueryLevelStats) {
-	s.NetworkBytesSent += other.NetworkBytesSent
+	s.DistSQLNetworkBytesSent += other.DistSQLNetworkBytesSent
 	if other.MaxMemUsage > s.MaxMemUsage {
 		s.MaxMemUsage = other.MaxMemUsage
 	}
@@ -181,7 +181,7 @@ func (s *QueryLevelStats) Accumulate(other QueryLevelStats) {
 	s.MvccRangeKeyCount += other.MvccRangeKeyCount
 	s.MvccRangeKeyContainedPoints += other.MvccRangeKeyContainedPoints
 	s.MvccRangeKeySkippedPoints += other.MvccRangeKeySkippedPoints
-	s.NetworkMessages += other.NetworkMessages
+	s.DistSQLNetworkMessages += other.DistSQLNetworkMessages
 	s.ContentionTime += other.ContentionTime
 	s.LockWaitTime += other.LockWaitTime
 	s.LatchWaitTime += other.LatchWaitTime
@@ -295,8 +295,8 @@ func (a *TraceAnalyzer) ProcessStats() {
 		if stats.stats == nil {
 			continue
 		}
-		s.NetworkBytesSent += getNetworkBytesFromComponentStats(stats.stats)
-		s.NetworkMessages += getNumNetworkMessagesFromComponentsStats(stats.stats)
+		s.DistSQLNetworkBytesSent += getNetworkBytesFromComponentStats(stats.stats)
+		s.DistSQLNetworkMessages += getNumDistSQLNetworkMessagesFromComponentsStats(stats.stats)
 	}
 
 	// Process flowStats.
@@ -350,7 +350,7 @@ func getNetworkBytesFromComponentStats(v *execinfrapb.ComponentStats) int64 {
 	return 0
 }
 
-func getNumNetworkMessagesFromComponentsStats(v *execinfrapb.ComponentStats) int64 {
+func getNumDistSQLNetworkMessagesFromComponentsStats(v *execinfrapb.ComponentStats) int64 {
 	// We expect exactly one of MessagesReceived and MessagesSent to be set. It
 	// may seem like we are double-counting everything (from both the send and
 	// the receive side) but in practice only one side of each stream presents

--- a/pkg/sql/execstats/traceanalyzer_test.go
+++ b/pkg/sql/execstats/traceanalyzer_test.go
@@ -161,7 +161,7 @@ func TestTraceAnalyzer(t *testing.T) {
 			// The stats don't count the actual bytes, but they are a synthetic value
 			// based on the number of tuples. In this test 21 tuples flow over the
 			// network.
-			require.Equal(t, int64(21*8), queryLevelStats.NetworkBytesSent)
+			require.Equal(t, int64(21*8), queryLevelStats.DistSQLNetworkBytesSent)
 
 			// Soft check that MaxMemUsage is set to a non-zero value. The actual
 			// value differs between test runs due to metamorphic randomization.
@@ -176,7 +176,7 @@ func TestTraceAnalyzer(t *testing.T) {
 
 			// For tests, network messages is a synthetic value based on the number of
 			// network tuples. In this test 21 tuples flow over the network.
-			require.Equal(t, int64(21/2), queryLevelStats.NetworkMessages)
+			require.Equal(t, int64(21/2), queryLevelStats.DistSQLNetworkMessages)
 		})
 	}
 }
@@ -233,14 +233,14 @@ func TestTraceAnalyzerProcessStats(t *testing.T) {
 func TestQueryLevelStatsAccumulate(t *testing.T) {
 	aEvent := kvpb.ContentionEvent{Duration: 7 * time.Second}
 	a := execstats.QueryLevelStats{
-		NetworkBytesSent:                   1,
+		DistSQLNetworkBytesSent:            1,
 		MaxMemUsage:                        2,
 		KVBytesRead:                        3,
 		KVPairsRead:                        4,
 		KVRowsRead:                         4,
 		KVBatchRequestsIssued:              4,
 		KVTime:                             5 * time.Second,
-		NetworkMessages:                    6,
+		DistSQLNetworkMessages:             6,
 		ContentionTime:                     7 * time.Second,
 		LockWaitTime:                       4 * time.Second,
 		LatchWaitTime:                      3 * time.Second,
@@ -269,14 +269,14 @@ func TestQueryLevelStatsAccumulate(t *testing.T) {
 	}
 	bEvent := kvpb.ContentionEvent{Duration: 14 * time.Second}
 	b := execstats.QueryLevelStats{
-		NetworkBytesSent:                   8,
+		DistSQLNetworkBytesSent:            8,
 		MaxMemUsage:                        9,
 		KVBytesRead:                        10,
 		KVPairsRead:                        11,
 		KVRowsRead:                         11,
 		KVBatchRequestsIssued:              11,
 		KVTime:                             12 * time.Second,
-		NetworkMessages:                    13,
+		DistSQLNetworkMessages:             13,
 		ContentionTime:                     14 * time.Second,
 		LockWaitTime:                       10 * time.Second,
 		LatchWaitTime:                      4 * time.Second,
@@ -304,14 +304,14 @@ func TestQueryLevelStatsAccumulate(t *testing.T) {
 		ClientTime:                         2 * time.Second,
 	}
 	expected := execstats.QueryLevelStats{
-		NetworkBytesSent:                   9,
+		DistSQLNetworkBytesSent:            9,
 		MaxMemUsage:                        9,
 		KVBytesRead:                        13,
 		KVPairsRead:                        15,
 		KVRowsRead:                         15,
 		KVBatchRequestsIssued:              15,
 		KVTime:                             17 * time.Second,
-		NetworkMessages:                    19,
+		DistSQLNetworkMessages:             19,
 		ContentionTime:                     21 * time.Second,
 		LockWaitTime:                       14 * time.Second,
 		LatchWaitTime:                      7 * time.Second,

--- a/pkg/sql/instrumentation.go
+++ b/pkg/sql/instrumentation.go
@@ -839,7 +839,7 @@ func (ih *instrumentationHelper) emitExplainAnalyzePlanToOutputBuilder(
 		}
 
 		ob.AddMaxMemUsage(queryStats.MaxMemUsage)
-		ob.AddNetworkStats(queryStats.NetworkMessages, queryStats.NetworkBytesSent)
+		ob.AddDistSQLNetworkStats(queryStats.DistSQLNetworkMessages, queryStats.DistSQLNetworkBytesSent)
 		ob.AddMaxDiskUsage(queryStats.MaxDiskUsage)
 		if len(queryStats.Regions) > 0 {
 			ob.AddRegionsStats(queryStats.Regions)

--- a/pkg/sql/opt/exec/execbuilder/testdata/call
+++ b/pkg/sql/opt/exec/execbuilder/testdata/call
@@ -139,7 +139,7 @@ distribution: <hidden>
 vectorized: <hidden>
 plan type: custom
 maximum memory usage: <hidden>
-network usage: <hidden>
+DistSQL network usage: <hidden>
 regions: <hidden>
 isolation level: serializable
 priority: normal
@@ -161,7 +161,7 @@ distribution: <hidden>
 vectorized: <hidden>
 plan type: custom
 maximum memory usage: <hidden>
-network usage: <hidden>
+DistSQL network usage: <hidden>
 regions: <hidden>
 isolation level: serializable
 priority: normal

--- a/pkg/sql/opt/exec/execbuilder/testdata/call_plpgsql
+++ b/pkg/sql/opt/exec/execbuilder/testdata/call_plpgsql
@@ -145,7 +145,7 @@ distribution: <hidden>
 vectorized: <hidden>
 plan type: custom
 maximum memory usage: <hidden>
-network usage: <hidden>
+DistSQL network usage: <hidden>
 regions: <hidden>
 isolation level: serializable
 priority: normal
@@ -167,7 +167,7 @@ distribution: <hidden>
 vectorized: <hidden>
 plan type: custom
 maximum memory usage: <hidden>
-network usage: <hidden>
+DistSQL network usage: <hidden>
 regions: <hidden>
 isolation level: serializable
 priority: normal

--- a/pkg/sql/opt/exec/execbuilder/testdata/cascade
+++ b/pkg/sql/opt/exec/execbuilder/testdata/cascade
@@ -1072,7 +1072,7 @@ vectorized: <hidden>
 plan type: custom
 rows decoded from KV: 9 (72 B, 18 KVs, 9 gRPC calls)
 maximum memory usage: <hidden>
-network usage: <hidden>
+DistSQL network usage: <hidden>
 regions: <hidden>
 isolation level: serializable
 priority: normal
@@ -1473,7 +1473,7 @@ distribution: <hidden>
 vectorized: <hidden>
 plan type: custom
 maximum memory usage: <hidden>
-network usage: <hidden>
+DistSQL network usage: <hidden>
 regions: <hidden>
 isolation level: serializable
 priority: normal

--- a/pkg/sql/opt/exec/execbuilder/testdata/delete
+++ b/pkg/sql/opt/exec/execbuilder/testdata/delete
@@ -483,7 +483,7 @@ distribution: <hidden>
 vectorized: <hidden>
 plan type: generic, re-optimized
 maximum memory usage: <hidden>
-network usage: <hidden>
+DistSQL network usage: <hidden>
 regions: <hidden>
 isolation level: serializable
 priority: normal
@@ -543,7 +543,7 @@ distribution: <hidden>
 vectorized: <hidden>
 plan type: generic, re-optimized
 maximum memory usage: <hidden>
-network usage: <hidden>
+DistSQL network usage: <hidden>
 regions: <hidden>
 isolation level: serializable
 priority: normal

--- a/pkg/sql/opt/exec/execbuilder/testdata/dist_vectorize
+++ b/pkg/sql/opt/exec/execbuilder/testdata/dist_vectorize
@@ -59,7 +59,7 @@ vectorized: <hidden>
 plan type: custom
 rows decoded from KV: 5 (40 B, 10 KVs, 5 gRPC calls)
 maximum memory usage: <hidden>
-network usage: <hidden>
+DistSQL network usage: <hidden>
 regions: <hidden>
 isolation level: serializable
 priority: normal
@@ -97,7 +97,7 @@ vectorized: <hidden>
 plan type: custom
 rows decoded from KV: 10 (80 B, 20 KVs, 10 gRPC calls)
 maximum memory usage: <hidden>
-network usage: <hidden>
+DistSQL network usage: <hidden>
 regions: <hidden>
 isolation level: serializable
 priority: normal

--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_misc
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_misc
@@ -108,7 +108,7 @@ vectorized: <hidden>
 plan type: custom
 rows decoded from KV: 1,000 (7.8 KiB, 2,000 KVs, 1,000 gRPC calls)
 maximum memory usage: <hidden>
-network usage: <hidden>
+DistSQL network usage: <hidden>
 regions: <hidden>
 isolation level: serializable
 priority: normal
@@ -149,7 +149,7 @@ vectorized: <hidden>
 plan type: custom
 rows decoded from KV: 1,000 (7.8 KiB, 2,000 KVs, 1,000 gRPC calls)
 maximum memory usage: <hidden>
-network usage: <hidden>
+DistSQL network usage: <hidden>
 regions: <hidden>
 isolation level: serializable
 priority: normal
@@ -169,7 +169,7 @@ vectorized: <hidden>
 plan type: custom
 rows decoded from KV: 1,000 (7.8 KiB, 2,000 KVs, 1,000 gRPC calls)
 maximum memory usage: <hidden>
-network usage: <hidden>
+DistSQL network usage: <hidden>
 regions: <hidden>
 isolation level: serializable
 priority: normal
@@ -189,7 +189,7 @@ vectorized: <hidden>
 plan type: custom
 rows decoded from KV: 1,000 (7.8 KiB, 2,000 KVs, 1,000 gRPC calls)
 maximum memory usage: <hidden>
-network usage: <hidden>
+DistSQL network usage: <hidden>
 regions: <hidden>
 isolation level: serializable
 priority: normal
@@ -212,7 +212,7 @@ vectorized: <hidden>
 plan type: custom
 rows decoded from KV: 1,000 (7.8 KiB, 2,000 KVs, 1,000 gRPC calls)
 maximum memory usage: <hidden>
-network usage: <hidden>
+DistSQL network usage: <hidden>
 regions: <hidden>
 isolation level: serializable
 priority: normal
@@ -244,7 +244,7 @@ vectorized: <hidden>
 plan type: custom
 rows decoded from KV: 1,000 (7.8 KiB, 2,000 KVs, 1,000 gRPC calls)
 maximum memory usage: <hidden>
-network usage: <hidden>
+DistSQL network usage: <hidden>
 regions: <hidden>
 isolation level: serializable
 priority: normal
@@ -268,7 +268,7 @@ vectorized: <hidden>
 plan type: custom
 rows decoded from KV: 1,000 (7.8 KiB, 2,000 KVs, 1,000 gRPC calls)
 maximum memory usage: <hidden>
-network usage: <hidden>
+DistSQL network usage: <hidden>
 regions: <hidden>
 isolation level: serializable
 priority: normal
@@ -295,7 +295,7 @@ vectorized: <hidden>
 plan type: custom
 rows decoded from KV: 1,000 (7.8 KiB, 2,000 KVs, 1,000 gRPC calls)
 maximum memory usage: <hidden>
-network usage: <hidden>
+DistSQL network usage: <hidden>
 regions: <hidden>
 isolation level: serializable
 priority: normal
@@ -322,7 +322,7 @@ vectorized: <hidden>
 plan type: custom
 rows decoded from KV: 1,000 (7.8 KiB, 2,000 KVs, 1,000 gRPC calls)
 maximum memory usage: <hidden>
-network usage: <hidden>
+DistSQL network usage: <hidden>
 regions: <hidden>
 isolation level: serializable
 priority: normal

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -2253,7 +2253,7 @@ distribution: <hidden>
 vectorized: <hidden>
 plan type: custom
 maximum memory usage: <hidden>
-network usage: <hidden>
+DistSQL network usage: <hidden>
 regions: <hidden>
 isolation level: serializable
 priority: normal

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain_analyze
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain_analyze
@@ -12,7 +12,7 @@ distribution: <hidden>
 vectorized: <hidden>
 plan type: custom
 maximum memory usage: <hidden>
-network usage: <hidden>
+DistSQL network usage: <hidden>
 regions: <hidden>
 isolation level: serializable
 priority: normal
@@ -45,7 +45,7 @@ vectorized: <hidden>
 plan type: custom
 rows decoded from KV: 3 (24 B, 6 KVs, 3 gRPC calls)
 maximum memory usage: <hidden>
-network usage: <hidden>
+DistSQL network usage: <hidden>
 regions: <hidden>
 isolation level: serializable
 priority: normal
@@ -92,7 +92,7 @@ distribution: <hidden>
 vectorized: <hidden>
 plan type: custom
 maximum memory usage: <hidden>
-network usage: <hidden>
+DistSQL network usage: <hidden>
 regions: <hidden>
 isolation level: serializable
 priority: normal

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain_analyze_plans
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain_analyze_plans
@@ -68,7 +68,7 @@ vectorized: <hidden>
 plan type: custom
 rows decoded from KV: 10 (80 B, 20 KVs, 10 gRPC calls)
 maximum memory usage: <hidden>
-network usage: <hidden>
+DistSQL network usage: <hidden>
 regions: <hidden>
 isolation level: serializable
 priority: normal
@@ -134,7 +134,7 @@ vectorized: <hidden>
 plan type: custom
 rows decoded from KV: 10 (80 B, 20 KVs, 10 gRPC calls)
 maximum memory usage: <hidden>
-network usage: <hidden>
+DistSQL network usage: <hidden>
 regions: <hidden>
 isolation level: serializable
 priority: normal
@@ -205,7 +205,7 @@ vectorized: <hidden>
 plan type: custom
 rows decoded from KV: 10 (80 B, 20 KVs, 10 gRPC calls)
 maximum memory usage: <hidden>
-network usage: <hidden>
+DistSQL network usage: <hidden>
 regions: <hidden>
 isolation level: serializable
 priority: normal
@@ -292,7 +292,7 @@ vectorized: <hidden>
 plan type: custom
 rows decoded from KV: 5 (40 B, 10 KVs, 5 gRPC calls)
 maximum memory usage: <hidden>
-network usage: <hidden>
+DistSQL network usage: <hidden>
 regions: <hidden>
 isolation level: serializable
 priority: normal
@@ -333,7 +333,7 @@ distribution: <hidden>
 vectorized: <hidden>
 plan type: custom
 maximum memory usage: <hidden>
-network usage: <hidden>
+DistSQL network usage: <hidden>
 regions: <hidden>
 isolation level: serializable
 priority: normal
@@ -371,7 +371,7 @@ vectorized: <hidden>
 plan type: custom
 rows decoded from KV: 2 (16 B, 4 KVs, 2 gRPC calls)
 maximum memory usage: <hidden>
-network usage: <hidden>
+DistSQL network usage: <hidden>
 regions: <hidden>
 isolation level: serializable
 priority: normal

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain_analyze_read_committed
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain_analyze_read_committed
@@ -27,7 +27,7 @@ vectorized: <hidden>
 plan type: custom
 rows decoded from KV: 3 (24 B, 6 KVs, 3 gRPC calls)
 maximum memory usage: <hidden>
-network usage: <hidden>
+DistSQL network usage: <hidden>
 regions: <hidden>
 isolation level: read committed
 priority: low
@@ -68,7 +68,7 @@ vectorized: <hidden>
 plan type: custom
 rows decoded from KV: 7 (56 B, 14 KVs, 7 gRPC calls)
 maximum memory usage: <hidden>
-network usage: <hidden>
+DistSQL network usage: <hidden>
 regions: <hidden>
 isolation level: read committed
 priority: normal

--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_index_geospatial
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_index_geospatial
@@ -29,7 +29,7 @@ vectorized: <hidden>
 plan type: custom
 rows decoded from KV: 6 (48 B, 12 KVs, 6 gRPC calls)
 maximum memory usage: <hidden>
-network usage: <hidden>
+DistSQL network usage: <hidden>
 regions: <hidden>
 isolation level: serializable
 priority: normal
@@ -121,7 +121,7 @@ vectorized: <hidden>
 plan type: generic, re-optimized
 rows decoded from KV: 4 (32 B, 8 KVs, 4 gRPC calls)
 maximum memory usage: <hidden>
-network usage: <hidden>
+DistSQL network usage: <hidden>
 regions: <hidden>
 isolation level: serializable
 priority: normal
@@ -197,7 +197,7 @@ vectorized: <hidden>
 plan type: generic, re-optimized
 rows decoded from KV: 4 (32 B, 8 KVs, 4 gRPC calls)
 maximum memory usage: <hidden>
-network usage: <hidden>
+DistSQL network usage: <hidden>
 regions: <hidden>
 isolation level: serializable
 priority: normal

--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_join_geospatial
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_join_geospatial
@@ -312,7 +312,7 @@ distribution: <hidden>
 vectorized: <hidden>
 plan type: custom
 maximum memory usage: <hidden>
-network usage: <hidden>
+DistSQL network usage: <hidden>
 regions: <hidden>
 isolation level: serializable
 priority: normal

--- a/pkg/sql/opt/exec/execbuilder/testdata/lookup_join_limit
+++ b/pkg/sql/opt/exec/execbuilder/testdata/lookup_join_limit
@@ -83,7 +83,7 @@ vectorized: <hidden>
 plan type: custom
 rows decoded from KV: 2 (16 B, 4 KVs, 2 gRPC calls)
 maximum memory usage: <hidden>
-network usage: <hidden>
+DistSQL network usage: <hidden>
 regions: <hidden>
 isolation level: serializable
 priority: normal
@@ -166,7 +166,7 @@ vectorized: <hidden>
 plan type: generic, reused
 rows decoded from KV: 2 (16 B, 4 KVs, 2 gRPC calls)
 maximum memory usage: <hidden>
-network usage: <hidden>
+DistSQL network usage: <hidden>
 regions: <hidden>
 isolation level: serializable
 priority: normal
@@ -322,7 +322,7 @@ vectorized: <hidden>
 plan type: custom
 rows decoded from KV: 2 (16 B, 4 KVs, 2 gRPC calls)
 maximum memory usage: <hidden>
-network usage: <hidden>
+DistSQL network usage: <hidden>
 regions: <hidden>
 isolation level: serializable
 priority: normal
@@ -418,7 +418,7 @@ vectorized: <hidden>
 plan type: custom
 rows decoded from KV: 4 (32 B, 8 KVs, 4 gRPC calls)
 maximum memory usage: <hidden>
-network usage: <hidden>
+DistSQL network usage: <hidden>
 regions: <hidden>
 isolation level: serializable
 priority: normal

--- a/pkg/sql/opt/exec/execbuilder/testdata/prepare
+++ b/pkg/sql/opt/exec/execbuilder/testdata/prepare
@@ -118,7 +118,7 @@ vectorized: <hidden>
 plan type: generic, reused
 rows decoded from KV: 1 (8 B, 2 KVs, 1 gRPC calls)
 maximum memory usage: <hidden>
-network usage: <hidden>
+DistSQL network usage: <hidden>
 regions: <hidden>
 isolation level: serializable
 priority: normal
@@ -148,7 +148,7 @@ distribution: <hidden>
 vectorized: <hidden>
 plan type: generic, reused
 maximum memory usage: <hidden>
-network usage: <hidden>
+DistSQL network usage: <hidden>
 regions: <hidden>
 isolation level: serializable
 priority: normal

--- a/pkg/sql/opt/exec/execbuilder/testdata/triggers
+++ b/pkg/sql/opt/exec/execbuilder/testdata/triggers
@@ -112,7 +112,7 @@ distribution: <hidden>
 vectorized: <hidden>
 plan type: custom
 maximum memory usage: <hidden>
-network usage: <hidden>
+DistSQL network usage: <hidden>
 regions: <hidden>
 isolation level: serializable
 priority: normal
@@ -322,7 +322,7 @@ distribution: <hidden>
 vectorized: <hidden>
 plan type: custom
 maximum memory usage: <hidden>
-network usage: <hidden>
+DistSQL network usage: <hidden>
 regions: <hidden>
 isolation level: serializable
 priority: normal
@@ -395,7 +395,7 @@ vectorized: <hidden>
 plan type: generic, reused
 rows decoded from KV: 1 (8 B, 2 KVs, 1 gRPC calls)
 maximum memory usage: <hidden>
-network usage: <hidden>
+DistSQL network usage: <hidden>
 regions: <hidden>
 isolation level: serializable
 priority: normal
@@ -666,7 +666,7 @@ distribution: <hidden>
 vectorized: <hidden>
 plan type: custom
 maximum memory usage: <hidden>
-network usage: <hidden>
+DistSQL network usage: <hidden>
 regions: <hidden>
 isolation level: serializable
 priority: normal
@@ -738,7 +738,7 @@ vectorized: <hidden>
 plan type: generic, reused
 rows decoded from KV: 3 (24 B, 6 KVs, 3 gRPC calls)
 maximum memory usage: <hidden>
-network usage: <hidden>
+DistSQL network usage: <hidden>
 regions: <hidden>
 isolation level: serializable
 priority: normal
@@ -1003,7 +1003,7 @@ vectorized: <hidden>
 plan type: custom
 rows decoded from KV: 1 (8 B, 2 KVs, 1 gRPC calls)
 maximum memory usage: <hidden>
-network usage: <hidden>
+DistSQL network usage: <hidden>
 regions: <hidden>
 isolation level: serializable
 priority: normal

--- a/pkg/sql/opt/exec/execbuilder/testdata/unique
+++ b/pkg/sql/opt/exec/execbuilder/testdata/unique
@@ -608,7 +608,7 @@ vectorized: <hidden>
 plan type: custom
 rows decoded from KV: 4 (32 B, 8 KVs, 4 gRPC calls)
 maximum memory usage: <hidden>
-network usage: <hidden>
+DistSQL network usage: <hidden>
 regions: <hidden>
 isolation level: serializable
 priority: normal
@@ -724,7 +724,7 @@ vectorized: <hidden>
 plan type: custom
 rows decoded from KV: 6 (48 B, 12 KVs, 6 gRPC calls)
 maximum memory usage: <hidden>
-network usage: <hidden>
+DistSQL network usage: <hidden>
 regions: <hidden>
 isolation level: serializable
 priority: normal
@@ -2605,7 +2605,7 @@ vectorized: <hidden>
 plan type: custom
 rows decoded from KV: 10 (80 B, 20 KVs, 10 gRPC calls)
 maximum memory usage: <hidden>
-network usage: <hidden>
+DistSQL network usage: <hidden>
 regions: <hidden>
 isolation level: serializable
 priority: normal

--- a/pkg/sql/opt/exec/execbuilder/testdata/update
+++ b/pkg/sql/opt/exec/execbuilder/testdata/update
@@ -1004,7 +1004,7 @@ distribution: <hidden>
 vectorized: <hidden>
 plan type: generic, re-optimized
 maximum memory usage: <hidden>
-network usage: <hidden>
+DistSQL network usage: <hidden>
 regions: <hidden>
 isolation level: serializable
 priority: normal
@@ -1069,7 +1069,7 @@ distribution: <hidden>
 vectorized: <hidden>
 plan type: generic, re-optimized
 maximum memory usage: <hidden>
-network usage: <hidden>
+DistSQL network usage: <hidden>
 regions: <hidden>
 isolation level: serializable
 priority: normal
@@ -1151,7 +1151,7 @@ vectorized: <hidden>
 plan type: generic, re-optimized
 rows decoded from KV: 1 (8 B, 2 KVs, 1 gRPC calls)
 maximum memory usage: <hidden>
-network usage: <hidden>
+DistSQL network usage: <hidden>
 regions: <hidden>
 isolation level: serializable
 priority: normal
@@ -1232,7 +1232,7 @@ vectorized: <hidden>
 plan type: generic, re-optimized
 rows decoded from KV: 1 (8 B, 2 KVs, 1 gRPC calls)
 maximum memory usage: <hidden>
-network usage: <hidden>
+DistSQL network usage: <hidden>
 regions: <hidden>
 isolation level: serializable
 priority: normal

--- a/pkg/sql/opt/exec/execbuilder/testdata/upsert
+++ b/pkg/sql/opt/exec/execbuilder/testdata/upsert
@@ -1173,7 +1173,7 @@ distribution: <hidden>
 vectorized: <hidden>
 plan type: generic, re-optimized
 maximum memory usage: <hidden>
-network usage: <hidden>
+DistSQL network usage: <hidden>
 regions: <hidden>
 isolation level: serializable
 priority: normal
@@ -1242,7 +1242,7 @@ distribution: <hidden>
 vectorized: <hidden>
 plan type: generic, re-optimized
 maximum memory usage: <hidden>
-network usage: <hidden>
+DistSQL network usage: <hidden>
 regions: <hidden>
 isolation level: serializable
 priority: normal

--- a/pkg/sql/opt/exec/execbuilder/testdata/vectorize_local
+++ b/pkg/sql/opt/exec/execbuilder/testdata/vectorize_local
@@ -45,7 +45,7 @@ vectorized: <hidden>
 plan type: custom
 rows decoded from KV: 2,001 (16 KiB, 4,002 KVs, 2,001 gRPC calls)
 maximum memory usage: <hidden>
-network usage: <hidden>
+DistSQL network usage: <hidden>
 regions: <hidden>
 isolation level: serializable
 priority: normal
@@ -78,7 +78,7 @@ vectorized: <hidden>
 plan type: custom
 rows decoded from KV: 3 (24 B, 6 KVs, 3 gRPC calls)
 maximum memory usage: <hidden>
-network usage: <hidden>
+DistSQL network usage: <hidden>
 regions: <hidden>
 isolation level: serializable
 priority: normal
@@ -128,7 +128,7 @@ vectorized: <hidden>
 plan type: custom
 rows decoded from KV: 2 (16 B, 4 KVs, 2 gRPC calls)
 maximum memory usage: <hidden>
-network usage: <hidden>
+DistSQL network usage: <hidden>
 regions: <hidden>
 isolation level: serializable
 priority: normal
@@ -208,7 +208,7 @@ vectorized: <hidden>
 plan type: custom
 rows decoded from KV: 4 (32 B, 8 KVs, 4 gRPC calls)
 maximum memory usage: <hidden>
-network usage: <hidden>
+DistSQL network usage: <hidden>
 regions: <hidden>
 isolation level: serializable
 priority: normal

--- a/pkg/sql/opt/exec/explain/output.go
+++ b/pkg/sql/opt/exec/explain/output.go
@@ -416,11 +416,11 @@ func (ob *OutputBuilder) AddMaxMemUsage(bytes int64) {
 	)
 }
 
-// AddNetworkStats adds a top-level field for network statistics.
-func (ob *OutputBuilder) AddNetworkStats(messages, bytes int64) {
+// AddDistSQLNetworkStats adds a top-level field for DistSQL network statistics.
+func (ob *OutputBuilder) AddDistSQLNetworkStats(messages, bytes int64) {
 	ob.AddFlakyTopLevelField(
 		DeflakeVolatile,
-		"network usage",
+		"DistSQL network usage",
 		fmt.Sprintf("%s (%s messages)", humanizeutil.IBytes(bytes), humanizeutil.Count(uint64(messages))),
 	)
 }

--- a/pkg/sql/sqlstats/ssmemstorage/ss_mem_storage.go
+++ b/pkg/sql/sqlstats/ssmemstorage/ss_mem_storage.go
@@ -374,10 +374,10 @@ func (s *stmtStats) sizeUnsafeLocked() int64 {
 func (s *stmtStats) recordExecStatsLocked(stats execstats.QueryLevelStats) {
 	s.mu.data.ExecStats.Count++
 	count := s.mu.data.ExecStats.Count
-	s.mu.data.ExecStats.NetworkBytes.Record(count, float64(stats.NetworkBytesSent))
+	s.mu.data.ExecStats.NetworkBytes.Record(count, float64(stats.DistSQLNetworkBytesSent))
 	s.mu.data.ExecStats.MaxMemUsage.Record(count, float64(stats.MaxMemUsage))
 	s.mu.data.ExecStats.ContentionTime.Record(count, stats.ContentionTime.Seconds())
-	s.mu.data.ExecStats.NetworkMessages.Record(count, float64(stats.NetworkMessages))
+	s.mu.data.ExecStats.NetworkMessages.Record(count, float64(stats.DistSQLNetworkMessages))
 	s.mu.data.ExecStats.MaxDiskUsage.Record(count, float64(stats.MaxDiskUsage))
 	s.mu.data.ExecStats.CPUSQLNanos.Record(count, float64(stats.CPUTime.Nanoseconds()))
 

--- a/pkg/sql/sqlstats/ssmemstorage/ss_mem_writer.go
+++ b/pkg/sql/sqlstats/ssmemstorage/ss_mem_writer.go
@@ -236,10 +236,10 @@ func (s *Container) RecordTransaction(ctx context.Context, value *sqlstats.Recor
 
 	if value.CollectedExecStats {
 		stats.mu.data.ExecStats.Count++
-		stats.mu.data.ExecStats.NetworkBytes.Record(stats.mu.data.ExecStats.Count, float64(value.ExecStats.NetworkBytesSent))
+		stats.mu.data.ExecStats.NetworkBytes.Record(stats.mu.data.ExecStats.Count, float64(value.ExecStats.DistSQLNetworkBytesSent))
 		stats.mu.data.ExecStats.MaxMemUsage.Record(stats.mu.data.ExecStats.Count, float64(value.ExecStats.MaxMemUsage))
 		stats.mu.data.ExecStats.ContentionTime.Record(stats.mu.data.ExecStats.Count, value.ExecStats.ContentionTime.Seconds())
-		stats.mu.data.ExecStats.NetworkMessages.Record(stats.mu.data.ExecStats.Count, float64(value.ExecStats.NetworkMessages))
+		stats.mu.data.ExecStats.NetworkMessages.Record(stats.mu.data.ExecStats.Count, float64(value.ExecStats.DistSQLNetworkMessages))
 		stats.mu.data.ExecStats.MaxDiskUsage.Record(stats.mu.data.ExecStats.Count, float64(value.ExecStats.MaxDiskUsage))
 		stats.mu.data.ExecStats.CPUSQLNanos.Record(stats.mu.data.ExecStats.Count, float64(value.ExecStats.CPUTime.Nanoseconds()))
 

--- a/pkg/sql/telemetry_logging_test.go
+++ b/pkg/sql/telemetry_logging_test.go
@@ -134,12 +134,12 @@ func TestTelemetryLogging(t *testing.T) {
 			expectedIndexes:         false,
 			queryLevelStats: execstats.QueryLevelStats{
 				ContentionTime:                     0 * time.Nanosecond,
-				NetworkBytesSent:                   1,
+				DistSQLNetworkBytesSent:            1,
 				MaxMemUsage:                        2,
 				MaxDiskUsage:                       3,
 				KVBytesRead:                        4,
 				KVRowsRead:                         5,
-				NetworkMessages:                    6,
+				DistSQLNetworkMessages:             6,
 				MvccValueBytes:                     100,
 				MvccSteps:                          101,
 				MvccStepsInternal:                  102,
@@ -201,10 +201,10 @@ func TestTelemetryLogging(t *testing.T) {
 			expectedWrite:           false,
 			expectedIndexes:         true,
 			queryLevelStats: execstats.QueryLevelStats{
-				ContentionTime:   2 * time.Nanosecond,
-				NetworkBytesSent: 1,
-				MaxMemUsage:      2,
-				NetworkMessages:  6,
+				ContentionTime:          2 * time.Nanosecond,
+				DistSQLNetworkBytesSent: 1,
+				MaxMemUsage:             2,
+				DistSQLNetworkMessages:  6,
 			},
 			enableTracing: false,
 		},
@@ -226,13 +226,13 @@ func TestTelemetryLogging(t *testing.T) {
 			expectedWrite:           false,
 			expectedIndexes:         true,
 			queryLevelStats: execstats.QueryLevelStats{
-				ContentionTime:   3 * time.Nanosecond,
-				NetworkBytesSent: 1124,
-				MaxMemUsage:      132,
-				MaxDiskUsage:     3,
-				KVBytesRead:      4,
-				KVRowsRead:       2345,
-				NetworkMessages:  36,
+				ContentionTime:          3 * time.Nanosecond,
+				DistSQLNetworkBytesSent: 1124,
+				MaxMemUsage:             132,
+				MaxDiskUsage:            3,
+				KVBytesRead:             4,
+				KVRowsRead:              2345,
+				DistSQLNetworkMessages:  36,
 			},
 			enableTracing: false,
 		},
@@ -254,12 +254,12 @@ func TestTelemetryLogging(t *testing.T) {
 			expectedWrite:           false,
 			expectedIndexes:         true,
 			queryLevelStats: execstats.QueryLevelStats{
-				ContentionTime:   0 * time.Nanosecond,
-				NetworkBytesSent: 124235,
-				MaxMemUsage:      12412,
-				MaxDiskUsage:     3,
-				KVRowsRead:       5,
-				NetworkMessages:  6235,
+				ContentionTime:          0 * time.Nanosecond,
+				DistSQLNetworkBytesSent: 124235,
+				MaxMemUsage:             12412,
+				MaxDiskUsage:            3,
+				KVRowsRead:              5,
+				DistSQLNetworkMessages:  6235,
 			},
 			enableTracing: false,
 		},
@@ -281,11 +281,11 @@ func TestTelemetryLogging(t *testing.T) {
 			expectedWrite:           true,
 			expectedIndexes:         true,
 			queryLevelStats: execstats.QueryLevelStats{
-				ContentionTime:   0 * time.Nanosecond,
-				NetworkBytesSent: 1,
-				KVBytesRead:      4,
-				KVRowsRead:       5,
-				NetworkMessages:  6,
+				ContentionTime:          0 * time.Nanosecond,
+				DistSQLNetworkBytesSent: 1,
+				KVBytesRead:             4,
+				KVRowsRead:              5,
+				DistSQLNetworkMessages:  6,
 			},
 			enableTracing: false,
 		},
@@ -327,13 +327,13 @@ func TestTelemetryLogging(t *testing.T) {
 			expectedWrite:           false,
 			expectedIndexes:         true,
 			queryLevelStats: execstats.QueryLevelStats{
-				ContentionTime:   2 * time.Nanosecond,
-				NetworkBytesSent: 10,
-				MaxMemUsage:      20,
-				MaxDiskUsage:     33,
-				KVBytesRead:      24,
-				KVRowsRead:       55,
-				NetworkMessages:  66,
+				ContentionTime:          2 * time.Nanosecond,
+				DistSQLNetworkBytesSent: 10,
+				MaxMemUsage:             20,
+				MaxDiskUsage:            33,
+				KVBytesRead:             24,
+				KVRowsRead:              55,
+				DistSQLNetworkMessages:  66,
 			},
 			enableTracing: true,
 		},
@@ -374,13 +374,13 @@ func TestTelemetryLogging(t *testing.T) {
 			expectedIndexes:         true,
 			queryLevelStats: execstats.QueryLevelStats{
 				ContentionTime:                     9223372036854775807 * time.Nanosecond,
-				NetworkBytesSent:                   9223372036854775807,
+				DistSQLNetworkBytesSent:            9223372036854775807,
 				MaxMemUsage:                        9223372036854775807,
 				MaxDiskUsage:                       9223372036854775807,
 				KVBytesRead:                        9223372036854775807,
 				KVPairsRead:                        9223372036854775807,
 				KVRowsRead:                         9223372036854775807,
-				NetworkMessages:                    9223372036854775807,
+				DistSQLNetworkMessages:             9223372036854775807,
 				MvccValueBytes:                     9223372036854775807,
 				MvccSteps:                          9223372036854775807,
 				MvccStepsInternal:                  9223372036854775807,
@@ -631,10 +631,10 @@ func TestTelemetryLogging(t *testing.T) {
 						t.Errorf("expected no ContentionNanos field, but was found")
 					}
 					networkBytesSent := regexp.MustCompile("\"NetworkBytesSent\":[0-9]*")
-					if tc.queryLevelStats.NetworkBytesSent > 0 && !networkBytesSent.MatchString(e.Message) {
+					if tc.queryLevelStats.DistSQLNetworkBytesSent > 0 && !networkBytesSent.MatchString(e.Message) {
 						// If we have sent network bytes, we expect the NetworkBytesSent field to be populated.
 						t.Errorf("expected to find NetworkBytesSent but none was found")
-					} else if tc.queryLevelStats.NetworkBytesSent == 0 && networkBytesSent.MatchString(e.Message) {
+					} else if tc.queryLevelStats.DistSQLNetworkBytesSent == 0 && networkBytesSent.MatchString(e.Message) {
 						// If we have not sent network bytes, expect no NetworkBytesSent field.
 						t.Errorf("expected no NetworkBytesSent field, but was found")
 					}
@@ -671,10 +671,10 @@ func TestTelemetryLogging(t *testing.T) {
 						t.Errorf("expected no KVRowsRead field, but was found")
 					}
 					networkMessages := regexp.MustCompile("\"NetworkMessages\":[0-9]*")
-					if tc.queryLevelStats.NetworkMessages > 0 && !networkMessages.MatchString(e.Message) {
+					if tc.queryLevelStats.DistSQLNetworkMessages > 0 && !networkMessages.MatchString(e.Message) {
 						// If we have network messages, we expect the NetworkMessages field to be populated.
 						t.Errorf("expected to find NetworkMessages but none was found")
-					} else if tc.queryLevelStats.NetworkMessages == 0 && networkMessages.MatchString(e.Message) {
+					} else if tc.queryLevelStats.DistSQLNetworkMessages == 0 && networkMessages.MatchString(e.Message) {
 						// If we do not have network messages, expect no NetworkMessages field.
 						t.Errorf("expected no NetworkMessages field, but was found")
 					}

--- a/pkg/sql/testdata/explain_tree
+++ b/pkg/sql/testdata/explain_tree
@@ -13,7 +13,7 @@ distribution: local
 vectorized: false
 plan type: custom
 maximum memory usage: 0 B
-network usage: 0 B (0 messages)
+DistSQL network usage: 0 B (0 messages)
 isolation level: serializable
 priority: normal
 quality of service: regular
@@ -36,7 +36,7 @@ distribution: local
 vectorized: false
 plan type: custom
 maximum memory usage: 0 B
-network usage: 0 B (0 messages)
+DistSQL network usage: 0 B (0 messages)
 isolation level: serializable
 priority: normal
 quality of service: regular
@@ -59,7 +59,7 @@ distribution: local
 vectorized: false
 plan type: custom
 maximum memory usage: 0 B
-network usage: 0 B (0 messages)
+DistSQL network usage: 0 B (0 messages)
 isolation level: serializable
 priority: normal
 quality of service: regular
@@ -110,7 +110,7 @@ distribution: local
 vectorized: false
 plan type: custom
 maximum memory usage: 0 B
-network usage: 0 B (0 messages)
+DistSQL network usage: 0 B (0 messages)
 isolation level: serializable
 priority: normal
 quality of service: regular
@@ -133,7 +133,7 @@ distribution: local
 vectorized: false
 plan type: custom
 maximum memory usage: 0 B
-network usage: 0 B (0 messages)
+DistSQL network usage: 0 B (0 messages)
 isolation level: serializable
 priority: normal
 quality of service: regular
@@ -192,7 +192,7 @@ distribution: local
 vectorized: false
 plan type: custom
 maximum memory usage: 0 B
-network usage: 0 B (0 messages)
+DistSQL network usage: 0 B (0 messages)
 isolation level: serializable
 priority: normal
 quality of service: regular
@@ -233,4 +233,3 @@ quality of service: regular
                   spans: FULL SCAN
 ----
 ----
-

--- a/pkg/util/log/eventpb/telemetry.proto
+++ b/pkg/util/log/eventpb/telemetry.proto
@@ -136,7 +136,7 @@ message SampledQuery {
   // The regions of the nodes where SQL processors ran.
   repeated string regions = 38 [(gogoproto.jsontag) = ',omitempty', (gogoproto.moretags) = "redact:\"nonsensitive\""];
 
-  // The number of network bytes sent by nodes for this query.
+  // The number of network bytes by DistSQL components.
   int64 network_bytes_sent = 39 [(gogoproto.jsontag) = ',omitempty'];
 
   // The maximum amount of memory usage by nodes for this query.
@@ -154,7 +154,8 @@ message SampledQuery {
   // The number of rows read at the KV layer for this query.
   int64 kv_rows_read = 43 [(gogoproto.customname) = "KVRowsRead", (gogoproto.jsontag) = ',omitempty'];
 
-  // The number of network messages sent by nodes for this query.
+  // The number of network messages sent by nodes for this query by DistSQL
+  // components.
   int64 network_messages = 44 [(gogoproto.jsontag) = ',omitempty'];
 
   // Generated index recommendations for this query.
@@ -311,7 +312,8 @@ message SampledQuery {
 // Fields in this struct should be updated in sync with apps_stats.proto.
 message SampledExecStats {
 
-  // NetworkBytes collects the number of bytes sent over the network.
+  // NetworkBytes collects the number of bytes sent over the network by DistSQL
+  // components.
   int64 network_bytes = 1 [(gogoproto.jsontag) = ",includeempty"];
 
   // MaxMemUsage collects the maximum memory usage that occurred on a node.
@@ -321,7 +323,7 @@ message SampledExecStats {
   int64 contention_time = 3 [(gogoproto.jsontag) = ",omitempty"];
 
   // NetworkMessages collects the number of messages that were sent over the
-  // network.
+  // network by DistSQL components.
   int64 network_messages = 4 [(gogoproto.jsontag) = ",includeempty"];
 
   // MaxDiskUsage collects the maximum temporary disk usage that occurred. This


### PR DESCRIPTION
In "network statistics" (messages and bytes sent) we only include the network traffic between DistSQL components completely ignoring any traffic from KV layer to SQL layer. In order to clarify this a bit, this commit renames `network usage` top-level information to include "DistSQL" prefix.

Epic: None

Release note (sql change): `network usage` top-level statistic in EXPLAIN ANALYZE output has been renamed to `DistSQL network usage` to clarify that it only tracks network traffic between DistSQL components and completely ignores traffic from KV layer to DistSQL components.